### PR TITLE
fix(gulp): fix the gulp task "test:unit:node"

### DIFF
--- a/gulp/config.js
+++ b/gulp/config.js
@@ -29,6 +29,7 @@ module.exports = {
       unit: [
         'tests/**/*.test.ts',
         '!tests/**/browser/**/*.test.ts',
+        '!tests/**/binary/**/*.test.ts',
       ],
       binary: [
         'tests/**/binary/**/*.test.ts',


### PR DESCRIPTION
There was an issue where the task "test:unit:node" was running tests that dependend on the
build artifact. This change ignores those tests as they are run in a different suite.