### PR TITLE
fix(gulp): fix path to unit tests for "gulp test" task [triage-skip]

### DIFF
--- a/gulp/tasks/dev.js
+++ b/gulp/tasks/dev.js
@@ -22,7 +22,7 @@ require('./test');
 function watchDevFiles() {
   const stream = gulp.watch([
     `${config.root}/src/**/*.ts`,
-    `${config.root}/tests/unit/**/*`,
+    config.paths.test.unit
   ], gulp.parallel('test:unit'));
 
   stream.on('error', () => {});


### PR DESCRIPTION
Fixes an issue where the `gulp dev` task was watching the wrong group of test files.