### PR TITLE
fix(app): fix issue with default instanceIdentifier [triage-skip]

### DIFF
--- a/src/app/firebase_app.ts
+++ b/src/app/firebase_app.ts
@@ -303,7 +303,12 @@ class FirebaseAppImpl implements FirebaseApp {
     }
 
     if (!this.services_[name][instanceIdentifier]) {
-      let service = this.firebase_.INTERNAL.factories[name](this, this.extendApp.bind(this), instanceIdentifier);
+      /**
+       * If a custom instance has been defined (i.e. not '[DEFAULT]')
+       * then we will pass that instance on, otherwise we pass `null`
+       */
+      const instanceSpecifier = instanceIdentifier !== DEFAULT_ENTRY_NAME ? instanceIdentifier : undefined;
+      const service = this.firebase_.INTERNAL.factories[name](this, this.extendApp.bind(this), instanceSpecifier);
       this.services_[name][instanceIdentifier] = service;
     }
 

--- a/tests/app/unit/firebase_app.test.ts
+++ b/tests/app/unit/firebase_app.test.ts
@@ -280,6 +280,19 @@ describe("Firebase App Class", () => {
     assert.strictEqual(service.instanceIdentifier, service2.instanceIdentifier, '`instanceIdentifier` is not being set correctly');
     assert.strictEqual(service, service2);
   });
+  it(`Should pass null to the factory method if using default instance`, () => {
+    // Register Multi Instance Service
+    firebase.INTERNAL.registerService('testService', (...args) => {
+      const [app,,instanceIdentifier] = args;
+      assert.isUndefined(instanceIdentifier, '`instanceIdentifier` is not `undefined`');
+      return new TestService(app, instanceIdentifier);
+    });
+    firebase.initializeApp({});
+
+    // Capture a given service ref
+    const serviceIdentifier = 'custom instance identifier';
+    const service = (firebase.app() as any).testService();
+  });
 
   describe("Check for bad app names", () => {
     let tests = ["", 123, false, null];


### PR DESCRIPTION
FirebaseApp's contract with the components is that the instanceIdentifier will be `undefined` in the
default case (not the string `[DEFAULT]`). This was not tested by any existing tests and was broken in the async refactor. This fixes that issue and adds a test.