### PR TITLE
fix(travis.yml): pin Node.js version to 6 [triage-skip]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: required
 dist: trusty
 language: node_js
-node_js: stable
+node_js: "6"
 env:
   - CXX=g++-4.8
 cache: yarn


### PR DESCRIPTION
With the release of Node.js 8.0, our travis builds are failing.

Pinning Travis to version 6 of Node.