### PR TITLE
fix(app): fix issue with FirebaseApp extending INTERNAL

### DIFF
--- a/src/app/firebase_app.ts
+++ b/src/app/firebase_app.ts
@@ -246,6 +246,18 @@ class FirebaseAppImpl implements FirebaseApp {
               private firebase_: FirebaseNamespace) {
     this.name_ = name;
     this.options_ = deepCopy<FirebaseOptions>(options);
+    this.INTERNAL = {
+      'getUid': () => null,
+      'getToken': () => LocalPromise.resolve(null),
+      'addAuthTokenListener': (callback: (token: string|null) => void) => {
+        tokenListeners.push(callback);
+        // Make sure callback is called, asynchronously, in the absence of the auth module
+        setTimeout(() => callback(null), 0);
+      },
+      'removeAuthTokenListener': (callback) => {
+        tokenListeners = tokenListeners.filter(listener => listener !== callback);
+      },
+    };
   }
 
   get name(): string {
@@ -321,8 +333,8 @@ class FirebaseAppImpl implements FirebaseApp {
    */
   private extendApp(props: {[name: string]: any}): void {
     // Copy the object onto the FirebaseAppImpl prototype
-    deepExtend(FirebaseAppImpl.prototype, props);
-
+    deepExtend(this, props);
+    
     /**
      * If the app has overwritten the addAuthTokenListener stub, forward
      * the active token listeners on to the true fxn.
@@ -350,7 +362,7 @@ class FirebaseAppImpl implements FirebaseApp {
     }
   }
 };
-
+/*
 FirebaseAppImpl.prototype.INTERNAL = {
   'getUid': () => null,
   'getToken': () => LocalPromise.resolve(null),
@@ -363,7 +375,7 @@ FirebaseAppImpl.prototype.INTERNAL = {
     tokenListeners = tokenListeners.filter(listener => listener !== callback);
   },
 }
-
+*/
 // Prevent dead-code elimination of these methods w/o invalid property
 // copying.
 FirebaseAppImpl.prototype.name &&

--- a/src/app/firebase_app.ts
+++ b/src/app/firebase_app.ts
@@ -334,7 +334,7 @@ class FirebaseAppImpl implements FirebaseApp {
   private extendApp(props: {[name: string]: any}): void {
     // Copy the object onto the FirebaseAppImpl prototype
     deepExtend(this, props);
-    
+
     /**
      * If the app has overwritten the addAuthTokenListener stub, forward
      * the active token listeners on to the true fxn.
@@ -362,20 +362,7 @@ class FirebaseAppImpl implements FirebaseApp {
     }
   }
 };
-/*
-FirebaseAppImpl.prototype.INTERNAL = {
-  'getUid': () => null,
-  'getToken': () => LocalPromise.resolve(null),
-  'addAuthTokenListener': (callback: (token: string|null) => void) => {
-    tokenListeners.push(callback);
-    // Make sure callback is called, asynchronously, in the absence of the auth module
-    setTimeout(() => callback(null), 0);
-  },
-  'removeAuthTokenListener': (callback) => {
-    tokenListeners = tokenListeners.filter(listener => listener !== callback);
-  },
-}
-*/
+
 // Prevent dead-code elimination of these methods w/o invalid property
 // copying.
 FirebaseAppImpl.prototype.name &&


### PR DESCRIPTION
FirebaseAppImpl should not extend prototype.INTERNAL as this will apply to
all Firebase app instances.
To reproduce, do the following:
var app1 = firebase.initializeApp(config);
var app2 = firebase.initializeApp(config, 'app2');
console.log(app1.INTERNAL === app2.internal);
The above incorrectly resolves to true.
This means that if I sign in with app1.auth() and then call app1.INTERNAL.getToken(),
it will resolve with null as it is getting app2.INTERNAL.getToken.
The last initialized instance will basically overwrite all existing ones.

This is currently breaking all FirebaseUI-web single page applications
using Firebase real-time database with JS version >= 4.1.0:
https://github.com/firebase/firebaseui-web/issues/47#issuecomment-306648715
This should also be breaking any application using Auth and Database with
multiple app instances.

Hey there! So you want to contribute to a Firebase SDK? 
Before you file this pull request, please read these guidelines:
