### PR TITLE
fix(core): utilize "webpackJsonpFirebase" for Webpack JSONP output func

### DIFF
--- a/gulp/tasks/build.js
+++ b/gulp/tasks/build.js
@@ -138,7 +138,8 @@ function compileIndvES2015ModulesToBrowser() {
     },
     output: {
       path: path.resolve(__dirname, './dist/browser'),
-      filename: '[name].js'
+      filename: '[name].js',
+      jsonpFunction: 'webpackJsonpFirebase'
     },
     module: {
       rules: [{


### PR DESCRIPTION
Creates a custom `webpackJsonpFirebase` function for webpack chunk output.

ISSUES CLOSED: #42 
