### PR TITLE
fix(app): Allow Object.prototype member names as app names

### DIFF
--- a/src/app/firebase_app.ts
+++ b/src/app/firebase_app.ts
@@ -217,6 +217,10 @@ export interface FirebaseNamespace {
   }
 }
 
+const contains = function(obj, key) {
+  return Object.prototype.hasOwnProperty.call(obj, key);
+};
+
 let LocalPromise = local.Promise as typeof Promise;
 
 const DEFAULT_ENTRY_NAME = '[DEFAULT]';
@@ -438,11 +442,10 @@ export function createFirebaseNamespace(): FirebaseNamespace {
    */
   function app(name?: string): FirebaseApp {
     name = name || DEFAULT_ENTRY_NAME;
-    let result = apps_[name];
-    if (result === undefined) {
+    if (!contains(apps_, name)) {
       error('no-app', {'name': name});
     }
-    return result;
+    return apps_[name];
   }
 
   patchProperty(app, 'App', FirebaseAppImpl);
@@ -458,7 +461,7 @@ export function createFirebaseNamespace(): FirebaseNamespace {
         error('bad-app-name', {'name': name + ''});
       }
     }
-    if (apps_[name!] !== undefined) {
+    if (contains(apps_, name) ) {
       error('duplicate-app', {'name': name});
     }
 

--- a/tests/app/unit/firebase_app.test.ts
+++ b/tests/app/unit/firebase_app.test.ts
@@ -143,6 +143,19 @@ describe("Firebase App Class", () => {
       });
   });
 
+  it("OK to use Object.prototype member names as app name.", () => {
+    let app = firebase.initializeApp({}, 'toString');
+    assert.equal(firebase.apps.length, 1);
+    assert.equal(app.name, 'toString');
+    assert.strictEqual(firebase.app('toString'), app);
+  });
+
+  it("Error to get uninitialized app using Object.prototype member name.", () => {
+    assert.throws(() => {
+      firebase.app('toString');
+    }, /'toString'.*created/i);
+  });
+
   it("Only calls createService on first use (per app).", () => {
     let registrations = 0;
     firebase.INTERNAL.registerService('test', (app: FirebaseApp) => {


### PR DESCRIPTION
### Discussion
Fix for issue #69 

This implements the option 1 approach mentioned in the linked issue.

Note: Once the `ts-database/add-new-impl` branch has been merged into `master`, the `contains` function definition should be replaced with an import from [`src/utils/obj.ts`](https://github.com/firebase/firebase-js-sdk/blob/7efa1b0d40d8e20bf85042cb12c650333d540880/src/utils/obj.ts#L3-L5)

### Testing
Added 2 tests

### API Changes
None.