### PR TITLE
fix(externs): fix window var provided extern

### DIFF
--- a/externs/firebase-externs.js
+++ b/externs/firebase-externs.js
@@ -29,11 +29,6 @@ Buffer.prototype.toString = function(encoding) { return 'dummy'; };
 
 // Browser externs
 var MozWebSocket;
-/**
- * @param {!string} input
- * @return {!string}
- */
-var atob = function(input) { return ''; };
 
 // WinRT
 var Windows;


### PR DESCRIPTION
Removes the window.atob function extern provided by the browser natively.