### PR TITLE
Fix defect with checking for BufferImpl by calling it.

### DIFF
--- a/src/database/core/util/util.ts
+++ b/src/database/core/util/util.ts
@@ -66,7 +66,7 @@ export function setBufferImpl(impl) {
  */
 export const base64Decode = function (str: string): string | null {
   try {
-    if (BufferImpl()) {
+    if (BufferImpl) {
       return new BufferImpl(str, 'base64').toString('utf8');
     } else {
       return base64.decodeString(str, /*useWebSafe=*/true);


### PR DESCRIPTION
Hey there! So you want to contribute to a Firebase SDK? 
Before you file this pull request, please read these guidelines:

### Discussion
The new firebase 4.1.4 api has problems in the browser since the check for BufferImpl is wrong. Instead of checking for BufferImpl being set it calls BufferImpl which causes and exception and makes authentication fail because the token cannot be validate.

  * Read the contribution guidelines (CONTRIBUTING.md).
  * If this has been discussed in an issue, make sure to link to the issue here. 
    If not, go file an issue about this **before creating a pull request** to discuss.

### Testing

  * Make sure all existing tests in the repository pass after your change.
  * If you fixed a bug or added a feature, add a new test to cover your code.
I tested this by patching 4.1.4 and it works.

### API Changes

  * At this time we cannot accept changes that affect the public API.  If you'd like to help 
    us make Firebase APIs better, please propose your change in an issue so that we 
    can discuss it together.
No API change required.