### PR TITLE
fix(database): Adding toJSON() method to TransactionResult

### DIFF
--- a/src/database/api/Reference.ts
+++ b/src/database/api/Reference.ts
@@ -206,7 +206,7 @@ export class Reference extends Query {
    */
   transaction(transactionUpdate: (a: any) => any,
               onComplete?: (a: Error | null, b: boolean, c: DataSnapshot | null) => void,
-              applyLocally?: boolean): Promise<any> {
+              applyLocally?: boolean): Promise<TransactionResult> {
     validateArgCount('Reference.transaction', 1, 3, arguments.length);
     validateWritablePath('Reference.transaction', this.path);
     validateCallback('Reference.transaction', 1, transactionUpdate, false);

--- a/src/database/api/TransactionResult.ts
+++ b/src/database/api/TransactionResult.ts
@@ -31,7 +31,7 @@ export class TransactionResult {
 
   // Do not create public documentation. This is intended to make JSON serialization work but is otherwise unnecessary
   // for end-users
-  toJSON(): any {
+  toJSON(): object {
     validateArgCount('TransactionResult.toJSON', 0, 1, arguments.length);
     return { committed: this.committed, snapshot: this.snapshot.toJSON() };
   }

--- a/src/database/api/TransactionResult.ts
+++ b/src/database/api/TransactionResult.ts
@@ -15,6 +15,7 @@
 */
 
 import { DataSnapshot } from './DataSnapshot';
+import { validateArgCount } from '../../utils/validation';
 
 export class TransactionResult {
   /**
@@ -27,4 +28,12 @@ export class TransactionResult {
   constructor(public committed: boolean, public snapshot: DataSnapshot) {
 
   }
+
+  // Do not create public documentation. This is intended to make JSON serialization work but is otherwise unnecessary
+  // for end-users
+  toJSON(): any {
+    validateArgCount('TransactionResult.toJSON', 0, 1, arguments.length);
+    return { committed: this.committed, snapshot: this.snapshot.toJSON() };
+  }
+
 }

--- a/tests/database/transaction.test.ts
+++ b/tests/database/transaction.test.ts
@@ -56,6 +56,16 @@ describe('Transaction Tests', function() {
     expect(eventHelper.waiter()).to.equal(true);
   });
 
+  it('Transaction result can be converted to JSON.', function() {
+    const node = (getRandomNode() as Reference);
+
+    return node.transaction(() => {
+      return 42;
+    }).then(transactionResult => {
+      expect(transactionResult.toJSON()).to.deep.equal({ committed: true, snapshot: 42 });
+    });
+  });
+
   it('Non-aborted transaction sets committed to true in callback.', function(done) {
     const node = (getRandomNode() as Reference);
 


### PR DESCRIPTION
To address https://stackoverflow.com/questions/43151022/cloud-functions-for-firebase-onwrite-timeout, this adds a toJSON method() in TransactionResult.

This also addresses Google-internal bug https://b.corp.google.com/issues/62262817 and allows transaction objects to be returned from GCF.