### PR TITLE
Rejecting 'null' and 'undefined' as arguments for CollectionReference.doc()

### DIFF
--- a/src/firestore/api/database.ts
+++ b/src/firestore/api/database.ts
@@ -1639,11 +1639,13 @@ export class CollectionReference extends Query
 
   doc(pathString?: string): firestore.DocumentReference {
     validateBetweenNumberOfArgs('CollectionReference.doc', arguments, 0, 1);
-    validateOptionalArgType('CollectionReference.doc', 'string', 1, pathString);
-    if (pathString === undefined) {
+    // We allow omission of 'pathString' but explicitly prohibit passing in both
+    // 'undefined' and 'null'.
+    if (arguments.length === 0) {
       pathString = AutoId.newId();
     }
-    if (typeof pathString !== 'string' || pathString === '') {
+    validateArgType('CollectionReference.doc', 'string', 1, pathString);
+    if (pathString === '') {
       throw new FirestoreError(
         Code.INVALID_ARGUMENT,
         'Document path must be a non-empty string'

--- a/tests/firestore/integration/api/validation.test.ts
+++ b/tests/firestore/integration/api/validation.test.ts
@@ -194,6 +194,10 @@ apiDescribe('Validation:', persistence => {
         'Function CollectionReference.doc() requires its first ' +
           'argument to be of type string, but it was: null'
       );
+      expect(() => baseCollectionRef.doc(undefined as any)).to.throw(
+        'Function CollectionReference.doc() requires its first ' +
+          'argument to be of type string, but it was: undefined'
+      );
       expect(() => (baseCollectionRef.doc as any)('foo', 'bar')).to.throw(
         'Function CollectionReference.doc() requires between 0 and ' +
           '1 arguments, but was called with 2 arguments.'


### PR DESCRIPTION
This is for Google-internal bug b/67419579