### PR TITLE
Expose enable/DisableNetwork() via INTERNAL so it can be used in tests (but don't add to our .d.ts at least for now).

### DIFF
--- a/packages/firestore/src/api/database.ts
+++ b/packages/firestore/src/api/database.ts
@@ -187,9 +187,7 @@ export class Firestore implements firestore.Firestore, FirebaseService {
   //
   // Operations on the _firestoreClient don't block on _firestoreReady. Those
   // are already set to synchronize on the async queue.
-  //
-  // This is public for testing.
-  public _firestoreClient: FirestoreClient | undefined;
+  private _firestoreClient: FirestoreClient | undefined;
   public _dataConverter: UserDataConverter;
 
   constructor(databaseIdOrApp: FirestoreDatabase | FirebaseApp) {
@@ -373,7 +371,10 @@ export class Firestore implements firestore.Firestore, FirebaseService {
       } else {
         return Promise.resolve();
       }
-    }
+    },
+    // Exposed via INTERNAL for use in tests.
+    disableNetwork: () => this._firestoreClient.disableNetwork(),
+    enableNetwork: () => this._firestoreClient.enableNetwork()
   };
 
   collection(pathString: string): firestore.CollectionReference {

--- a/packages/firestore/test/integration/api/database.test.ts
+++ b/packages/firestore/test/integration/api/database.test.ts
@@ -519,14 +519,16 @@ apiDescribe('Database', persistence => {
   asyncIt('can queue writes while offline', () => {
     return withTestDb(persistence, db => {
       const docRef = db.collection('rooms').doc();
-      const firestoreClient = (docRef.firestore as Firestore)._firestoreClient;
+      // TODO(mikelehen): Find better way to expose this to tests.
+      // tslint:disable-next-line:no-any enableNetwork isn't exposed via d.ts
+      const firestoreInternal = docRef.firestore.INTERNAL as any;
 
-      return firestoreClient
+      return firestoreInternal
         .disableNetwork()
         .then(() => {
           return Promise.all([
             docRef.set({ foo: 'bar' }),
-            firestoreClient.enableNetwork()
+            firestoreInternal.enableNetwork()
           ]);
         })
         .then(() => docRef.get())
@@ -539,14 +541,16 @@ apiDescribe('Database', persistence => {
   asyncIt('can get documents while offline', () => {
     return withTestDb(persistence, db => {
       const docRef = db.collection('rooms').doc();
-      const firestoreClient = (docRef.firestore as Firestore)._firestoreClient;
+      // TODO(mikelehen): Find better way to expose this to tests.
+      // tslint:disable-next-line:no-any enableNetwork isn't exposed via d.ts
+      const firestoreInternal = docRef.firestore.INTERNAL as any;
 
-      return firestoreClient.disableNetwork().then(() => {
+      return firestoreInternal.disableNetwork().then(() => {
         const writePromise = docRef.set({ foo: 'bar' });
 
         return docRef.get().then(snapshot => {
           expect(snapshot.metadata.fromCache).to.be.true;
-          return firestoreClient.enableNetwork().then(() => {
+          return firestoreInternal.enableNetwork().then(() => {
             return writePromise.then(() => {
               docRef.get().then(doc => {
                 expect(snapshot.metadata.fromCache).to.be.false;

--- a/packages/firestore/test/integration/api/query.test.ts
+++ b/packages/firestore/test/integration/api/query.test.ts
@@ -456,7 +456,9 @@ apiDescribe('Queries', persistence => {
 
   asyncIt('can query while reconnecting to network', () => {
     return withTestCollection(persistence, /* docs= */ {}, coll => {
-      const firestoreClient = (coll.firestore as Firestore)._firestoreClient;
+      // TODO(mikelehen): Find better way to expose this to tests.
+      // tslint:disable-next-line:no-any enableNetwork isn't exposed via d.ts
+      const firestoreInternal = coll.firestore.INTERNAL as any;
 
       const deferred = new Deferred<void>();
 
@@ -469,9 +471,9 @@ apiDescribe('Queries', persistence => {
         }
       );
 
-      firestoreClient.disableNetwork().then(() => {
+      firestoreInternal.disableNetwork().then(() => {
         coll.doc().set({ a: 1 });
-        firestoreClient.enableNetwork();
+        firestoreInternal.enableNetwork();
       });
 
       return deferred.promise.then(unregister);


### PR DESCRIPTION
@jshcrowthe I thought this would fix the issue with the integration tests, but there are still some failing for a different reason.  I'm not sure what's going on, and unfortunately I have to run.  I can't take a look until later tonight.  If this is blocking you, feel free to disable the minified integration tests for the moment. I'll figure it out tonight or tomorrow. :-/
