### PR TITLE
Fix Typings Path

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -45,5 +45,5 @@
   "bugs": {
     "url": "https://github.com/firebase/firebase-js-sdk/issues"
   },
-  "typings": "dist/index.d.ts"
+  "typings": "dist/esm/index.d.ts"
 }

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -51,5 +51,5 @@
   "bugs": {
     "url": "https://github.com/firebase/firebase-js-sdk/issues"
   },
-  "typings": "dist/index.d.ts"
+  "typings": "dist/esm/index.d.ts"
 }

--- a/packages/firestore/package.json
+++ b/packages/firestore/package.json
@@ -54,5 +54,6 @@
   },
   "bugs": {
     "url": "https://github.com/firebase/firebase-js-sdk/issues"
-  }
+  },
+  "typings": "dist/esm/index.d.ts"
 }

--- a/packages/messaging/package.json
+++ b/packages/messaging/package.json
@@ -44,5 +44,5 @@
   "bugs": {
     "url": "https://github.com/firebase/firebase-js-sdk/issues"
   },
-  "typings": "dist/index.d.ts"
+  "typings": "dist/esm/index.d.ts"
 }

--- a/packages/polyfill/package.json
+++ b/packages/polyfill/package.json
@@ -24,5 +24,5 @@
   "bugs": {
     "url": "https://github.com/firebase/firebase-js-sdk/issues"
   },
-  "typings": "dist/index.d.ts"
+  "typings": "dist/esm/index.d.ts"
 }

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -42,5 +42,5 @@
   "bugs": {
     "url": "https://github.com/firebase/firebase-js-sdk/issues"
   },
-  "typings": "dist/index.d.ts"
+  "typings": "dist/esm/index.d.ts"
 }

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -39,5 +39,6 @@
   },
   "bugs": {
     "url": "https://github.com/firebase/firebase-js-sdk/issues"
-  }
+  },
+  "typings": "dist/esm/index.d.ts"
 }


### PR DESCRIPTION
The typings path in the `package.json` of these packages was referencing a file that is not generated in the specified location (any longer).

This updates the typings to properly reference the `.d.ts` files.