### PR TITLE
Exclude node tests in the browser.

### DIFF
--- a/packages/firestore/test/integration/bootstrap.ts
+++ b/packages/firestore/test/integration/bootstrap.ts
@@ -23,4 +23,7 @@ import '../../src/platform_browser/browser_init';
  * https://github.com/webpack-contrib/karma-webpack#alternative-usage
  */
 var testsContext = (require as any).context('.', true, /.test$/);
-testsContext.keys().forEach(testsContext);
+var browserTests = testsContext
+  .keys()
+  .filter(file => file.indexOf('/node/') < 0);
+browserTests.forEach(testsContext);

--- a/packages/firestore/test/unit/bootstrap.ts
+++ b/packages/firestore/test/unit/bootstrap.ts
@@ -23,4 +23,7 @@ import '../../src/platform_browser/browser_init';
  * https://github.com/webpack-contrib/karma-webpack#alternative-usage
  */
 var testsContext = (require as any).context('.', true, /.test$/);
-testsContext.keys().forEach(testsContext);
+var browserTests = testsContext
+  .keys()
+  .filter(file => file.indexOf('/node/') < 0);
+browserTests.forEach(testsContext);


### PR DESCRIPTION
I'm about to send a subsequent PR that reenables our serializer tests (under a /node/ directory).