### PR TITLE
Adding an entrypoint for firebase-admin-node

### DIFF
--- a/packages/database/index.node.ts
+++ b/packages/database/index.node.ts
@@ -50,3 +50,25 @@ export function registerDatabase(instance: FirebaseNamespace) {
 }
 
 registerDatabase(firebase);
+
+/**
+ * A one off register function which returns a database based on the app and
+ * passed database URL.
+ * 
+ * @param app A valid FirebaseApp-like object
+ * @param url A valid Firebase databaseURL 
+ */
+export function initStandalone(app, url) {
+  return {
+    instance: RepoManager.getInstance().databaseFromApp(app, url),
+    namespaces: {
+      Reference,
+      Query,
+      Database,
+      enableLogging,
+      INTERNAL,
+      ServerValue: Database.ServerValue,
+      TEST_ACCESS
+    }
+  }
+}

--- a/packages/database/index.node.ts
+++ b/packages/database/index.node.ts
@@ -35,7 +35,7 @@ import './src/nodePatches';
 export function initStandalone(app, url) {
   return {
     instance: RepoManager.getInstance().databaseFromApp(app, url),
-    namespaces: {
+    namespace: {
       Reference,
       Query,
       Database,

--- a/packages/database/index.node.ts
+++ b/packages/database/index.node.ts
@@ -25,32 +25,6 @@ import * as TEST_ACCESS from './src/api/test_access';
 import { isNodeSdk } from '@firebase/util';
 import './src/nodePatches';
 
-export function registerDatabase(instance: FirebaseNamespace) {
-  // Register the Database Service with the 'firebase' namespace.
-  const namespace = instance.INTERNAL.registerService(
-    'database',
-    (app, unused, url) => RepoManager.getInstance().databaseFromApp(app, url),
-    // firebase.database namespace properties
-    {
-      Reference,
-      Query,
-      Database,
-      enableLogging,
-      INTERNAL,
-      ServerValue: Database.ServerValue,
-      TEST_ACCESS
-    },
-    null,
-    true
-  );
-
-  if (isNodeSdk()) {
-    module.exports = namespace;
-  }
-}
-
-registerDatabase(firebase);
-
 /**
  * A one off register function which returns a database based on the app and
  * passed database URL.
@@ -72,3 +46,29 @@ export function initStandalone(app, url) {
     }
   }
 }
+
+export function registerDatabase(instance: FirebaseNamespace) {
+  // Register the Database Service with the 'firebase' namespace.
+  const namespace = instance.INTERNAL.registerService(
+    'database',
+    (app, unused, url) => RepoManager.getInstance().databaseFromApp(app, url),
+    // firebase.database namespace properties
+    {
+      Reference,
+      Query,
+      Database,
+      enableLogging,
+      INTERNAL,
+      ServerValue: Database.ServerValue,
+      TEST_ACCESS
+    },
+    null,
+    true
+  );
+
+  if (isNodeSdk()) {
+    module.exports = Object.assign({}, namespace, { initStandalone });
+  }
+}
+
+registerDatabase(firebase);

--- a/packages/database/index.node.ts
+++ b/packages/database/index.node.ts
@@ -44,7 +44,7 @@ export function initStandalone(app, url) {
       ServerValue: Database.ServerValue,
       TEST_ACCESS
     }
-  }
+  };
 }
 
 export function registerDatabase(instance: FirebaseNamespace) {


### PR DESCRIPTION
Creating a standalone entrypoint for the `firebase-admin-node` package to better consolidate the codebases.