### PR TITLE
Refactor firestore int tests to be a private package

### DIFF
--- a/integration/firestore/package.json
+++ b/integration/firestore/package.json
@@ -1,6 +1,7 @@
 {
   "name": "firebase-firestore-integration-test",
   "version": "1.0.0",
+  "private": true,
   "scripts": {
     "pretest": "gulp compile-tests",
     "test": "karma start --single-run"


### PR DESCRIPTION
This will just help to prevent from accidentally publishing this as an npm package.