### PR TITLE
Disabling travis branch restriction

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,3 @@ addons:
     packages:
       - google-chrome-stable
       - g++-4.8
-
-branches:
-  only:
-    - master


### PR DESCRIPTION
We are getting some issues where tests will fail on push but not on PR.

This disables the branch whitelist to ensure we are running push build tests in Travis as well.