### PR TITLE
Dev-X improvements for running Firestore tests.

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -29,7 +29,7 @@
       "args": [
         "start",
         "--auto-watch",
-        "--testFiles", "test/unit/bootstrap.ts",
+        "--unit",
         "--browsers", "Chrome"
       ]
     },
@@ -42,7 +42,7 @@
       "args": [
         "start",
         "--auto-watch",
-        "--testFiles", "test/integration/bootstrap.ts",
+        "--integration",
         "--browsers", "Chrome"
       ]
     }

--- a/config/karma.base.js
+++ b/config/karma.base.js
@@ -17,6 +17,7 @@
 const karma = require('karma');
 const path = require('path');
 const webpackTestConfig = require('./webpack.test');
+const { argv } = require('yargs');
 
 /**
  * Custom SauceLabs Launchers
@@ -68,7 +69,7 @@ const config = {
   reporters: ['spec' /*, 'saucelabs' */],
 
   // web server port
-  port: 8080,
+  port: 8089,
 
   // enable / disable colors in the output (reporters and logs)
   colors: true,
@@ -108,7 +109,10 @@ const config = {
     mocha: {
       timeout: 20000,
       retries: 3
-    }
+    },
+
+    // Pass through --grep option to filter the tests that run.
+    args: argv.grep ? ['--grep', argv.grep] : []
   }
 };
 

--- a/packages/firestore/CONTRIBUTING.md
+++ b/packages/firestore/CONTRIBUTING.md
@@ -1,9 +1,9 @@
-# Contributing to the Firebase JavaScript SDK
+# Contributing to the Cloud Firestore Component
 
 See [Contributing](../../CONTRIBUTING.md) for general information on
 contributing to the Firebase JavaScript SDK (including Cloud Firestore).
 
-# Running Firestore Tests
+## Running Firestore Tests
 All commands must be run from this `packages/firestore/` directory.
 ```
 # Run all tests once (browser and node)

--- a/packages/firestore/CONTRIBUTING.md
+++ b/packages/firestore/CONTRIBUTING.md
@@ -1,0 +1,30 @@
+# Contributing to the Firebase JavaScript SDK
+
+See [Contributing](../../CONTRIBUTING.md) for general information on
+contributing to the Firebase JavaScript SDK (including Cloud Firestore).
+
+# Running Firestore Tests
+All commands must be run from this packages/firestore/ directory.
+```
+# Run all tests once (browser and node)
+yarn test
+
+# Run all browser tests once (unit and integration)
+yarn test:browser
+
+# Debug browser tests in Chrome and keep the browser open (and watch for file
+# changes).
+yarn test:browser:debug
+
+# Run only the browser unit or integration tests
+yarn test:browser --unit
+yarn test:browser --integration
+
+# Run browser integration tests against a Firestore server running on
+# localhost:8080.
+yarn test:browser --integration --local
+
+# Run a subset of tests whose names match a filter.
+yarn test:browser --grep 'SortedSet keeps elements in the right order'
+yarn test:node --grep 'SortedSet keeps elements in the right order'
+```

--- a/packages/firestore/CONTRIBUTING.md
+++ b/packages/firestore/CONTRIBUTING.md
@@ -4,7 +4,7 @@ See [Contributing](../../CONTRIBUTING.md) for general information on
 contributing to the Firebase JavaScript SDK (including Cloud Firestore).
 
 # Running Firestore Tests
-All commands must be run from this packages/firestore/ directory.
+All commands must be run from this `packages/firestore/` directory.
 ```
 # Run all tests once (browser and node)
 yarn test

--- a/packages/firestore/README.md
+++ b/packages/firestore/README.md
@@ -44,5 +44,7 @@ Docs][reference-docs].
 [reference-docs]: https://firebase.google.com/docs/reference/js/
 
 ## Contributing
-See [Contributing](./CONTRIBUTING.md) for more information on contributing to
-the Cloud Firestore component of the Firebase JavaScript SDK.
+See [Contributing to the Firebase SDK](../../CONTRIBUTING.md) for general
+information about contributing to the firebase-js-sdk repo and
+[Contributing to the Cloud Firestore Component](./CONTRIBUTING.md) for
+details specific to the Cloud Firestore code and tests.

--- a/packages/firestore/README.md
+++ b/packages/firestore/README.md
@@ -1,6 +1,6 @@
 # @firebase/firestore
 
-This is the Firestore component for the Firebase JS SDK. It has a peer
+This is the Cloud Firestore component for the Firebase JS SDK. It has a peer
 dependency on the [`@firebase/app`](https://npm.im/@firebase/app) package on NPM. This package
 **is not** included by default in the [`firebase`](https://npm.im/firebase)
 wrapper package.
@@ -42,3 +42,7 @@ For comprehensive documentation please see the [Firebase Reference
 Docs][reference-docs].
 
 [reference-docs]: https://firebase.google.com/docs/reference/js/
+
+## Contributing
+See [Contributing](./CONTRIBUTING.md) for more information on contributing to
+the Cloud Firestore component of the Firebase JavaScript SDK.

--- a/packages/firestore/test/integration/util/helpers.ts
+++ b/packages/firestore/test/integration/util/helpers.ts
@@ -20,16 +20,27 @@ import { DatabaseId, DatabaseInfo } from '../../../src/core/database_info';
 
 import firebase from './firebase_export';
 
+// tslint:disable-next-line:no-any __karma__ is an untyped global
+declare let __karma__: any;
+
 const PROJECT_CONFIG = require('../../../../../config/project.json');
 
 export const DEFAULT_PROJECT_ID = PROJECT_CONFIG.projectId;
 export const ALT_PROJECT_ID = 'test-db2';
 
-// TODO(b/66917388): Reintroduce way to test against localhost.
-const DEFAULT_SETTINGS = {
-  host: 'firestore.googleapis.com',
-  ssl: true
-};
+const DEFAULT_SETTINGS = getDefaultSettings();
+
+function getDefaultSettings(): firestore.Settings {
+  let karma = typeof __karma__ !== 'undefined' ? __karma__ : undefined;
+  if (karma && karma.config.firestoreSettings) {
+    return karma.config.firestoreSettings;
+  } else {
+    return {
+      host: 'firestore.googleapis.com',
+      ssl: true
+    };
+  }
+}
 
 function isIeOrEdge(): boolean {
   const ua = window.navigator.userAgent;

--- a/packages/firestore/test/integration/util/helpers.ts
+++ b/packages/firestore/test/integration/util/helpers.ts
@@ -21,7 +21,7 @@ import { DatabaseId, DatabaseInfo } from '../../../src/core/database_info';
 import firebase from './firebase_export';
 
 // tslint:disable-next-line:no-any __karma__ is an untyped global
-declare let __karma__: any;
+declare const __karma__: any;
 
 const PROJECT_CONFIG = require('../../../../../config/project.json');
 
@@ -31,7 +31,7 @@ export const ALT_PROJECT_ID = 'test-db2';
 const DEFAULT_SETTINGS = getDefaultSettings();
 
 function getDefaultSettings(): firestore.Settings {
-  let karma = typeof __karma__ !== 'undefined' ? __karma__ : undefined;
+  const karma = __karma__; //typeof __karma__ !== 'undefined' ? __karma__ : undefined;
   if (karma && karma.config.firestoreSettings) {
     return karma.config.firestoreSettings;
   } else {


### PR DESCRIPTION
See new packages/firestore CONTRIBUTING.md doc for new abilities.

Changes:
* Add --local flag to run against a localhost Firestore server.
* Add --unit and --integration flags to limit to unit or integration tests.
* Make --grep work with karma / mocha to limit the tests that run.
* Change default karma port to 8089 to avoid conflicting with localhost
  Firestore server on 8080 (and other common web servers that default
  to 8080).