### PR TITLE
Fix generate_spec_json script.

### DIFF
--- a/packages/firestore/package.json
+++ b/packages/firestore/package.json
@@ -38,6 +38,7 @@
     "karma-sourcemap-loader": "^0.3.7",
     "karma-spec-reporter": "^0.0.31",
     "karma-webpack": "^2.0.4",
+    "mkdirp": "^0.5.1",
     "mocha": "^3.5.0",
     "npm-run-all": "^4.1.1",
     "sinon": "^3.2.1",

--- a/packages/firestore/test/unit/generate_spec_json.js
+++ b/packages/firestore/test/unit/generate_spec_json.js
@@ -25,6 +25,7 @@
  */
 var glob = require('glob');
 var fs = require('fs');
+var mkdirp = require('mkdirp');
 
 const describeSpec = require('./specs/describe_spec');
 
@@ -52,17 +53,20 @@ function main(args) {
     return;
   }
   outputPath = args[2];
+  mkdirp.sync(outputPath);
 
   const testFiles = glob.sync('**/specs/*_spec.test.ts', { cwd: __dirname });
   if (testFiles.length === 0) {
     throw new Error('No test files found');
   }
   for (var i = 0; i < testFiles.length; ++i) {
-    var specName = testFiles[i].replace(/\.js$/, '');
+    var specName = testFiles[i].replace(/\.ts$/, '');
     var testName = specName.replace(/^specs\//, '');
     var filename = testName.replace(/[^A-Za-z\d]/g, '_') + '.json';
     writeToJSON(testFiles[i], outputPath + '/' + filename);
   }
+
+  console.log('JSON spec files successfully generated to:', outputPath);
 }
 
 main(process.argv);

--- a/packages/firestore/test/unit/generate_spec_json.sh
+++ b/packages/firestore/test/unit/generate_spec_json.sh
@@ -24,4 +24,4 @@ NPM_BIN_DIR="$(npm bin)"
 TSNODE="$NPM_BIN_DIR/ts-node"
 GENERATE_SPEC_JS="$DIR/generate_spec_json.js"
 
-TS_NODE_PROJECT="$DIR/../../../tsconfig.test.json" $TSNODE $GENERATE_SPEC_JS "$@"
+TS_NODE_PROJECT="$DIR/../../tsconfig.json" $TSNODE $GENERATE_SPEC_JS "$@"


### PR DESCRIPTION
* The tsconfig path was broken after the recent repo refactor.
* We were accidentally leaving a .ts in the destination json file names.
* I made it so the destination directory doesn't need to exist in advance.