### PR TITLE
Firestore typings fix: Add firestore() to firebase.app.App.

### DIFF
--- a/packages/firebase/app/index.d.ts
+++ b/packages/firebase/app/index.d.ts
@@ -119,6 +119,7 @@ declare namespace firebase.app {
     name: string;
     options: Object;
     storage(url?: string): firebase.storage.Storage;
+    firestore(): firebase.firestore.Firestore;
   }
 }
 

--- a/packages/firebase/index.d.ts
+++ b/packages/firebase/index.d.ts
@@ -119,6 +119,7 @@ declare namespace firebase.app {
     name: string;
     options: Object;
     storage(url?: string): firebase.storage.Storage;
+    firestore(): firebase.firestore.Firestore;
   }
 }
 


### PR DESCRIPTION
@tstirrat noticed this was missing.