### PR TITLE
Fixing Typings for RTDB

### DIFF
--- a/packages/database/index.node.ts
+++ b/packages/database/index.node.ts
@@ -80,4 +80,4 @@ registerDatabase(firebase);
 export { Database, Query, Reference, enableLogging, ServerValue };
 
 export { DataSnapshot } from './src/api/DataSnapshot';
-export { OnDisconnect } from './src/api/OnDisconnect';
+export { OnDisconnect } from './src/api/onDisconnect';

--- a/packages/database/index.node.ts
+++ b/packages/database/index.node.ts
@@ -32,6 +32,9 @@ import './src/nodePatches';
  * @param app A valid FirebaseApp-like object
  * @param url A valid Firebase databaseURL 
  */
+
+const ServerValue = Database.ServerValue;
+
 export function initStandalone(app, url) {
   return {
     instance: RepoManager.getInstance().databaseFromApp(app, url),
@@ -41,7 +44,7 @@ export function initStandalone(app, url) {
       Database,
       enableLogging,
       INTERNAL,
-      ServerValue: Database.ServerValue,
+      ServerValue,
       TEST_ACCESS
     }
   };
@@ -59,7 +62,7 @@ export function registerDatabase(instance: FirebaseNamespace) {
       Database,
       enableLogging,
       INTERNAL,
-      ServerValue: Database.ServerValue,
+      ServerValue,
       TEST_ACCESS
     },
     null,
@@ -72,3 +75,15 @@ export function registerDatabase(instance: FirebaseNamespace) {
 }
 
 registerDatabase(firebase);
+
+// Types to export for the admin SDK
+export { 
+  Database, 
+  Query, 
+  Reference,
+  enableLogging,
+  ServerValue
+};
+
+export { DataSnapshot } from './src/api/DataSnapshot';
+export { OnDisconnect } from './src/api/OnDisconnect';

--- a/packages/database/index.node.ts
+++ b/packages/database/index.node.ts
@@ -77,13 +77,7 @@ export function registerDatabase(instance: FirebaseNamespace) {
 registerDatabase(firebase);
 
 // Types to export for the admin SDK
-export { 
-  Database, 
-  Query, 
-  Reference,
-  enableLogging,
-  ServerValue
-};
+export { Database, Query, Reference, enableLogging, ServerValue };
 
 export { DataSnapshot } from './src/api/DataSnapshot';
 export { OnDisconnect } from './src/api/OnDisconnect';

--- a/packages/database/index.ts
+++ b/packages/database/index.ts
@@ -53,13 +53,7 @@ export function registerDatabase(instance: FirebaseNamespace) {
 registerDatabase(firebase);
 
 // Types to export for the admin SDK
-export { 
-  Database, 
-  Query, 
-  Reference,
-  enableLogging,
-  ServerValue
-};
+export { Database, Query, Reference, enableLogging, ServerValue };
 
 export { DataSnapshot } from './src/api/DataSnapshot';
 export { OnDisconnect } from './src/api/OnDisconnect';

--- a/packages/database/index.ts
+++ b/packages/database/index.ts
@@ -56,4 +56,4 @@ registerDatabase(firebase);
 export { Database, Query, Reference, enableLogging, ServerValue };
 
 export { DataSnapshot } from './src/api/DataSnapshot';
-export { OnDisconnect } from './src/api/OnDisconnect';
+export { OnDisconnect } from './src/api/onDisconnect';

--- a/packages/database/index.ts
+++ b/packages/database/index.ts
@@ -24,6 +24,8 @@ import * as INTERNAL from './src/api/internal';
 import * as TEST_ACCESS from './src/api/test_access';
 import { isNodeSdk } from '@firebase/util';
 
+const ServerValue = Database.ServerValue;
+
 export function registerDatabase(instance: FirebaseNamespace) {
   // Register the Database Service with the 'firebase' namespace.
   const namespace = instance.INTERNAL.registerService(
@@ -36,7 +38,7 @@ export function registerDatabase(instance: FirebaseNamespace) {
       Database,
       enableLogging,
       INTERNAL,
-      ServerValue: Database.ServerValue,
+      ServerValue,
       TEST_ACCESS
     },
     null,
@@ -49,3 +51,15 @@ export function registerDatabase(instance: FirebaseNamespace) {
 }
 
 registerDatabase(firebase);
+
+// Types to export for the admin SDK
+export { 
+  Database, 
+  Query, 
+  Reference,
+  enableLogging,
+  ServerValue
+};
+
+export { DataSnapshot } from './src/api/DataSnapshot';
+export { OnDisconnect } from './src/api/OnDisconnect';

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -51,5 +51,5 @@
   "bugs": {
     "url": "https://github.com/firebase/firebase-js-sdk/issues"
   },
-  "typings": "dist/index.d.ts"
+  "typings": "dist/cjs/index.d.ts"
 }


### PR DESCRIPTION
The Admin SDK is trying to consume the `@firebase/database` package as a standalone. This fixes some of the typings to better support that.