### PR TITLE
Add a debug script to integration/firestore

### DIFF
--- a/integration/firestore/package.json
+++ b/integration/firestore/package.json
@@ -3,8 +3,11 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
-    "pretest": "gulp compile-tests",
-    "test": "karma start --single-run"
+    "build": "gulp compile-tests",
+    "pretest": "npm run build",
+    "pretest:debug": "npm run build",
+    "test": "karma start --single-run",
+    "test:debug": "karma start --auto-watch --browsers Chrome"
   },
   "devDependencies": {
     "@types/mocha": "^2.2.44",


### PR DESCRIPTION
Adds a script to the integration/firestore package in the workspace to allow for debugging the int tests.