### PR TITLE
(Temporary) Disable Firestore Int Tests

### DIFF
--- a/integration/firestore/package.json
+++ b/integration/firestore/package.json
@@ -4,9 +4,10 @@
   "private": true,
   "scripts": {
     "build": "gulp compile-tests",
-    "pretest": "npm run build",
+    "pretest:manual": "npm run build",
     "pretest:debug": "npm run build",
-    "test": "karma start --single-run",
+    "test": "echo 'Automated tests temporarily disabled, run `npm run test:manual` to execute these tests'",
+    "test:manual": "karma start --single-run",
     "test:debug": "karma start --auto-watch --browsers Chrome"
   },
   "devDependencies": {


### PR DESCRIPTION
Due to some flakeyness issues we are disabling these tests until the server environment here, stabilizes.