### PR TITLE
Sending an empty write request before tearing down the WriteStream.

### DIFF
--- a/packages/firestore/src/remote/persistent_stream.ts
+++ b/packages/firestore/src/remote/persistent_stream.ts
@@ -323,16 +323,16 @@ export abstract class PersistentStream<
       this.backoff.resetToMax();
     }
 
-    // This state must be assigned before calling onClose() to allow the callback to
-    // inhibit backoff or otherwise manipulate the state in its non-started state.
-    this.state = finalState;
-
     // Clean up the underlying stream because we are no longer interested in events.
     if (this.stream !== null) {
+      this.tearDown();
       this.stream.close();
       this.stream = null;
     }
 
+    // This state must be assigned before calling onClose() to allow the callback to
+    // inhibit backoff or otherwise manipulate the state in its non-started state.
+    this.state = finalState;
     const listener = this.listener!;
 
     // Clear the listener to avoid bleeding of events from the underlying streams.
@@ -346,6 +346,12 @@ export abstract class PersistentStream<
       return Promise.resolve();
     }
   }
+
+  /**
+   * Can be overridden to perform additional cleanup before the stream is closed.
+   * Calling super.tearDowm() is not required.
+   */
+  protected tearDown(): void {}
 
   /**
    * Used by subclasses to start the concrete RPC and return the underlying
@@ -644,6 +650,12 @@ export class PersistentWriteStream extends PersistentStream<
   start(listener: WriteStreamListener): void {
     this.handshakeComplete_ = false;
     super.start(listener);
+  }
+
+  protected tearDown() {
+    if (this.handshakeComplete_) {
+      this.writeMutations([]);
+    }
   }
 
   protected startRpc(

--- a/packages/firestore/src/remote/persistent_stream.ts
+++ b/packages/firestore/src/remote/persistent_stream.ts
@@ -349,7 +349,7 @@ export abstract class PersistentStream<
 
   /**
    * Can be overridden to perform additional cleanup before the stream is closed.
-   * Calling super.tearDowm() is not required.
+   * Calling super.tearDown() is not required.
    */
   protected tearDown(): void {}
 

--- a/packages/firestore/test/unit/specs/listen_spec.test.ts
+++ b/packages/firestore/test/unit/specs/listen_spec.test.ts
@@ -237,4 +237,21 @@ describeSpec('Listens:', [], () => {
         .expectEvents(allQuery, { fromCache: false })
     );
   });
+
+  specTest('Listens are reestablished after network disconnect', [], () => {
+    const query = Query.atPath(path('collection'));
+    const docA = doc('collection/a', 1000, { key: 'a' });
+    const docB = doc('collection/b', 2000, { key: 'b' });
+    return spec()
+      .userListens(query)
+      .expectNumWatchStreamRequests(1)
+      .watchAcksFull(query, 1000, docA)
+      .expectEvents(query, { added: [docA] })
+      .disableNetwork()
+      .enableNetwork()
+      .restoreListen(query, 'resume-token-1000')
+      .expectNumWatchStreamRequests(2)
+      .watchAcksFull(query, 2000, docB)
+      .expectEvents(query, { added: [docB] });
+  });
 });

--- a/packages/firestore/test/unit/specs/listen_spec.test.ts
+++ b/packages/firestore/test/unit/specs/listen_spec.test.ts
@@ -239,18 +239,21 @@ describeSpec('Listens:', [], () => {
   });
 
   specTest('Listens are reestablished after network disconnect', [], () => {
+    const expectRequestCount = (requestCounts) =>
+        requestCounts.addTarget + requestCounts.removeTarget;
+
     const query = Query.atPath(path('collection'));
     const docA = doc('collection/a', 1000, { key: 'a' });
     const docB = doc('collection/b', 2000, { key: 'b' });
     return spec()
       .userListens(query)
-      .expectNumWatchStreamRequests(1)
+      .expectWatchStreamRequestCount(expectRequestCount( { addTarget: 1, removeTarget: 0 }))
       .watchAcksFull(query, 1000, docA)
       .expectEvents(query, { added: [docA] })
       .disableNetwork()
       .enableNetwork()
       .restoreListen(query, 'resume-token-1000')
-      .expectNumWatchStreamRequests(2)
+      .expectWatchStreamRequestCount(expectRequestCount( { addTarget: 2, removeTarget: 0 }))
       .watchAcksFull(query, 2000, docB)
       .expectEvents(query, { added: [docB] });
   });

--- a/packages/firestore/test/unit/specs/listen_spec.test.ts
+++ b/packages/firestore/test/unit/specs/listen_spec.test.ts
@@ -239,21 +239,25 @@ describeSpec('Listens:', [], () => {
   });
 
   specTest('Listens are reestablished after network disconnect', [], () => {
-    const expectRequestCount = (requestCounts) =>
-        requestCounts.addTarget + requestCounts.removeTarget;
+    const expectRequestCount = requestCounts =>
+      requestCounts.addTarget + requestCounts.removeTarget;
 
     const query = Query.atPath(path('collection'));
     const docA = doc('collection/a', 1000, { key: 'a' });
     const docB = doc('collection/b', 2000, { key: 'b' });
     return spec()
       .userListens(query)
-      .expectWatchStreamRequestCount(expectRequestCount( { addTarget: 1, removeTarget: 0 }))
+      .expectWatchStreamRequestCount(
+        expectRequestCount({ addTarget: 1, removeTarget: 0 })
+      )
       .watchAcksFull(query, 1000, docA)
       .expectEvents(query, { added: [docA] })
       .disableNetwork()
       .enableNetwork()
       .restoreListen(query, 'resume-token-1000')
-      .expectWatchStreamRequestCount(expectRequestCount( { addTarget: 2, removeTarget: 0 }))
+      .expectWatchStreamRequestCount(
+        expectRequestCount({ addTarget: 2, removeTarget: 0 })
+      )
       .watchAcksFull(query, 2000, docB)
       .expectEvents(query, { added: [docB] });
   });

--- a/packages/firestore/test/unit/specs/spec_builder.ts
+++ b/packages/firestore/test/unit/specs/spec_builder.ts
@@ -142,7 +142,7 @@ export class SpecBuilder {
 
     this.activeTargets[targetId] = {
       query: SpecBuilder.queryToSpec(query),
-      resumeToken: resumeToken || ''
+      resumeToken: resumeToken
     };
 
     const currentStep = this.currentStep!;

--- a/packages/firestore/test/unit/specs/spec_builder.ts
+++ b/packages/firestore/test/unit/specs/spec_builder.ts
@@ -134,7 +134,7 @@ export class SpecBuilder {
     let targetId = this.queryMapping[query.canonicalId()];
 
     if (isNullOrUndefined(targetId)) {
-      throw new Error("Can't restore an unkonown query: " + query);
+      throw new Error("Can't restore an unknown query: " + query);
     }
 
     this.activeTargets[targetId] = {

--- a/packages/firestore/test/unit/specs/spec_builder.ts
+++ b/packages/firestore/test/unit/specs/spec_builder.ts
@@ -129,6 +129,27 @@ export class SpecBuilder {
     return this;
   }
 
+  /** Registers a previously active target after a stream disconnect. */
+  restoreListen(query: Query, resumeToken: string): SpecBuilder {
+    let targetId = this.queryMapping[query.canonicalId()];
+
+    if (isNullOrUndefined(targetId)) {
+      throw new Error("Can't restore an unkonown query: " + query);
+    }
+
+    this.activeTargets[targetId] = {
+      query: SpecBuilder.queryToSpec(query),
+      resumeToken: resumeToken || ''
+    };
+
+    const currentStep = this.currentStep!;
+    currentStep.stateExpect = currentStep.stateExpect || {};
+    currentStep.stateExpect.activeTargets = objUtils.shallowCopy(
+      this.activeTargets
+    );
+    return this;
+  }
+
   userUnlistens(query: Query): SpecBuilder {
     this.nextStep();
     if (!objUtils.contains(this.queryMapping, query.canonicalId())) {
@@ -173,6 +194,26 @@ export class SpecBuilder {
   changeUser(uid: string | null): SpecBuilder {
     this.nextStep();
     this.currentStep = { changeUser: uid };
+    return this;
+  }
+
+  disableNetwork(): SpecBuilder {
+    this.nextStep();
+    this.currentStep = {
+      enableNetwork: false,
+      stateExpect: {
+        activeTargets: {},
+        limboDocs: []
+      }
+    };
+    return this;
+  }
+
+  enableNetwork(): SpecBuilder {
+    this.nextStep();
+    this.currentStep = {
+      enableNetwork: true
+    };
     return this;
   }
 
@@ -490,6 +531,22 @@ export class SpecBuilder {
       fromCache: events.fromCache || false,
       hasPendingWrites: events.hasPendingWrites || false
     });
+    return this;
+  }
+
+  expectNumWriteStreamRequests(num: number): SpecBuilder {
+    this.assertStep('Expectations require previous step');
+    const currentStep = this.currentStep!;
+    currentStep.stateExpect = currentStep.stateExpect || {};
+    currentStep.stateExpect.numWriteStreamRequests = num;
+    return this;
+  }
+
+  expectNumWatchStreamRequests(num: number): SpecBuilder {
+    this.assertStep('Expectations require previous step');
+    const currentStep = this.currentStep!;
+    currentStep.stateExpect = currentStep.stateExpect || {};
+    currentStep.stateExpect.numWatchStreamRequests = num;
     return this;
   }
 

--- a/packages/firestore/test/unit/specs/spec_builder.ts
+++ b/packages/firestore/test/unit/specs/spec_builder.ts
@@ -538,7 +538,7 @@ export class SpecBuilder {
   }
 
   /**
-   * Verifies fhe total number of requests sent to the write backend since test
+   * Verifies the total number of requests sent to the write backend since test
    * initialization.
    */
   expectWriteStreamRequestCount(num: number): SpecBuilder {
@@ -548,8 +548,9 @@ export class SpecBuilder {
     currentStep.stateExpect.writeStreamRequestCount = num;
     return this;
   }
+
   /**
-   * Verifies fhe total number of requests sent to the watch backend since test
+   * Verifies the total number of requests sent to the watch backend since test
    * initialization.
    */
   expectWatchStreamRequestCount(num: number): SpecBuilder {

--- a/packages/firestore/test/unit/specs/spec_builder.ts
+++ b/packages/firestore/test/unit/specs/spec_builder.ts
@@ -129,7 +129,10 @@ export class SpecBuilder {
     return this;
   }
 
-  /** Registers a previously active target after a stream disconnect. */
+  /**
+   * Registers a previously active target with the test expectations after a
+   * stream disconnect.
+   */
   restoreListen(query: Query, resumeToken: string): SpecBuilder {
     let targetId = this.queryMapping[query.canonicalId()];
 
@@ -534,19 +537,26 @@ export class SpecBuilder {
     return this;
   }
 
-  expectNumWriteStreamRequests(num: number): SpecBuilder {
+  /**
+   * Verifies fhe total number of requests sent to the write backend since test
+   * initialization.
+   */
+  expectWriteStreamRequestCount(num: number): SpecBuilder {
     this.assertStep('Expectations require previous step');
     const currentStep = this.currentStep!;
     currentStep.stateExpect = currentStep.stateExpect || {};
-    currentStep.stateExpect.numWriteStreamRequests = num;
+    currentStep.stateExpect.writeStreamRequestCount = num;
     return this;
   }
-
-  expectNumWatchStreamRequests(num: number): SpecBuilder {
+  /**
+   * Verifies fhe total number of requests sent to the watch backend since test
+   * initialization.
+   */
+  expectWatchStreamRequestCount(num: number): SpecBuilder {
     this.assertStep('Expectations require previous step');
     const currentStep = this.currentStep!;
     currentStep.stateExpect = currentStep.stateExpect || {};
-    currentStep.stateExpect.numWatchStreamRequests = num;
+    currentStep.stateExpect.watchStreamRequestCount = num;
     return this;
   }
 

--- a/packages/firestore/test/unit/specs/spec_test_runner.ts
+++ b/packages/firestore/test/unit/specs/spec_test_runner.ts
@@ -765,8 +765,7 @@ abstract class TestRunner {
 
   private async doDisableNetwork(): Promise<void> {
     // Make sure to execute all writes that are currently queued. This allows us
-    // to assert on the total number of write requests sent to a stream before
-    // shutdown.
+    // to assert on the total number of requests sent before shutdown.
     await this.remoteStore.fillWritePipeline();
     await this.remoteStore.disableNetwork();
   }

--- a/packages/firestore/test/unit/specs/write_spec.test.ts
+++ b/packages/firestore/test/unit/specs/write_spec.test.ts
@@ -566,15 +566,20 @@ describeSpec('Writes:', [], () => {
   );
 
   specTest('Writes are resent after network disconnect', [], () => {
-    const expectRequestCount = requestCounts => requestCounts.handshakes + requestCounts.writes + requestCounts.closes;
+    const expectRequestCount = requestCounts =>
+      requestCounts.handshakes + requestCounts.writes + requestCounts.closes;
 
     return spec()
       .userSets('collection/key', { foo: 'bar' })
       .expectNumOutstandingWrites(1)
       .disableNetwork()
-      .expectWriteStreamRequestCount(expectRequestCount({ handshakes : 1, writes:  1, closes: 1 }))
+      .expectWriteStreamRequestCount(
+        expectRequestCount({ handshakes: 1, writes: 1, closes: 1 })
+      )
       .enableNetwork()
-      .expectWriteStreamRequestCount(expectRequestCount({ handshakes : 2, writes:  2, closes: 1 }))
+      .expectWriteStreamRequestCount(
+        expectRequestCount({ handshakes: 2, writes: 2, closes: 1 })
+      )
       .expectNumOutstandingWrites(1)
       .writeAcks(1, { expectUserCallback: false })
       .expectNumOutstandingWrites(0);

--- a/packages/firestore/test/unit/specs/write_spec.test.ts
+++ b/packages/firestore/test/unit/specs/write_spec.test.ts
@@ -566,16 +566,15 @@ describeSpec('Writes:', [], () => {
   );
 
   specTest('Writes are resent after network disconnect', [], () => {
-    const expectRequests = (handshakes, writes, closes) =>
-      handshakes + writes + closes;
+    const expectRequestCount = requestCounts => requestCounts.handshakes + requestCounts.writes + requestCounts.closes;
 
     return spec()
       .userSets('collection/key', { foo: 'bar' })
       .expectNumOutstandingWrites(1)
       .disableNetwork()
-      .expectNumWriteStreamRequests(expectRequests(1, 1, 1))
+      .expectWriteStreamRequestCount(expectRequestCount({ handshakes : 1, writes:  1, closes: 1 }))
       .enableNetwork()
-      .expectNumWriteStreamRequests(expectRequests(2, 2, 1))
+      .expectWriteStreamRequestCount(expectRequestCount({ handshakes : 2, writes:  2, closes: 1 }))
       .expectNumOutstandingWrites(1)
       .writeAcks(1, { expectUserCallback: false })
       .expectNumOutstandingWrites(0);

--- a/packages/firestore/test/unit/specs/write_spec.test.ts
+++ b/packages/firestore/test/unit/specs/write_spec.test.ts
@@ -564,4 +564,20 @@ describeSpec('Writes:', [], () => {
       );
     }
   );
+
+  specTest('Writes are resent after network disconnect', [], () => {
+    const expectRequests = (handshakes, writes, closes) =>
+      handshakes + writes + closes;
+
+    return spec()
+      .userSets('collection/key', { foo: 'bar' })
+      .expectNumOutstandingWrites(1)
+      .disableNetwork()
+      .expectNumWriteStreamRequests(expectRequests(1, 1, 1))
+      .enableNetwork()
+      .expectNumWriteStreamRequests(expectRequests(2, 2, 1))
+      .expectNumOutstandingWrites(1)
+      .writeAcks(1, { expectUserCallback: false })
+      .expectNumOutstandingWrites(0);
+  });
 });

--- a/packages/firestore/test/util/equality_matcher.ts
+++ b/packages/firestore/test/util/equality_matcher.ts
@@ -71,8 +71,8 @@ export function addEqualityMatcher() {
 
           this.assert(
             customDeepEqual(left, right),
-            'expected #{this} to roughly deeply equal #{exp}',
-            'expected #{this} to not roughly deeply equal #{exp}',
+            'expected #{act} to roughly deeply equal #{exp}',
+            'expected #{act} to not roughly deeply equal #{exp}',
             left,
             right,
             true


### PR DESCRIPTION
This PR makes sure that we sent an empty write request before the write steam closes. Most of the changes in this PR are geared towards making this testable via the Spec tests (which includes adding support for enable/disableNetwork and request counting).