### PR TITLE
Fix broken firestore test.

### DIFF
--- a/packages/firestore/test/integration/api/database.test.ts
+++ b/packages/firestore/test/integration/api/database.test.ts
@@ -612,17 +612,18 @@ apiDescribe('Database', persistence => {
       return firestoreInternal.disableNetwork().then(() => {
         const writePromise = docRef.set({ foo: 'bar' });
 
-        return docRef.get().then(snapshot => {
-          expect(snapshot.metadata.fromCache).to.be.true;
-          return firestoreInternal.enableNetwork().then(() => {
-            return writePromise.then(() => {
-              docRef.get().then(doc => {
-                expect(snapshot.metadata.fromCache).to.be.false;
-                expect(doc.data()).to.deep.equal({ foo: 'bar' });
-              });
-            });
+        return docRef
+          .get()
+          .then(doc => {
+            expect(doc.metadata.fromCache).to.be.true;
+            return firestoreInternal.enableNetwork();
+          })
+          .then(() => writePromise)
+          .then(() => docRef.get())
+          .then(doc => {
+            expect(doc.metadata.fromCache).to.be.false;
+            expect(doc.data()).to.deep.equal({ foo: 'bar' });
           });
-        });
       });
     });
   });


### PR DESCRIPTION
This test had two problems:

1. After reading the document a second time (as `doc`) it was validating fromCache on the old version (`snapshot`).
2. It wasn't returning the Promise, causing the failure to happen asynchronously and not be noticed by mocha.

This in turn seems to have (sometimes?) caused errors about offline persistence being enabled in a different tab.  I fixed the test and implemented it with more chaining instead of nesting. :-)