### PR TITLE
Remove no-longer-necessary asyncIt wrappers.

### DIFF
--- a/packages/firestore/test/integration/api/batch_writes.test.ts
+++ b/packages/firestore/test/integration/api/batch_writes.test.ts
@@ -21,17 +21,16 @@ import * as testHelpers from '../../util/helpers';
 import firebase from '../util/firebase_export';
 import * as integrationHelpers from '../util/helpers';
 
-const asyncIt = testHelpers.asyncIt;
 const apiDescribe = integrationHelpers.apiDescribe;
 
 apiDescribe('Database batch writes', persistence => {
-  asyncIt('support empty batches', () => {
+  it('support empty batches', () => {
     return integrationHelpers.withTestDb(persistence, db => {
       return db.batch().commit();
     });
   });
 
-  asyncIt('can set documents', () => {
+  it('can set documents', () => {
     return integrationHelpers.withTestDoc(persistence, doc => {
       return doc.firestore
         .batch()
@@ -45,7 +44,7 @@ apiDescribe('Database batch writes', persistence => {
     });
   });
 
-  asyncIt('can set documents with merge', () => {
+  it('can set documents with merge', () => {
     return integrationHelpers.withTestDoc(persistence, doc => {
       return doc.firestore
         .batch()
@@ -69,7 +68,7 @@ apiDescribe('Database batch writes', persistence => {
     });
   });
 
-  asyncIt('can update documents', () => {
+  it('can update documents', () => {
     return integrationHelpers.withTestDoc(persistence, doc => {
       return doc
         .set({ foo: 'bar' })
@@ -87,7 +86,7 @@ apiDescribe('Database batch writes', persistence => {
     });
   });
 
-  asyncIt('can delete documents', () => {
+  it('can delete documents', () => {
     return integrationHelpers.withTestDoc(persistence, doc => {
       return doc
         .set({ foo: 'bar' })
@@ -108,7 +107,7 @@ apiDescribe('Database batch writes', persistence => {
     });
   });
 
-  asyncIt('commit atomically, raising correct events', () => {
+  it('commit atomically, raising correct events', () => {
     return integrationHelpers.withTestCollection(
       persistence,
       {},
@@ -156,7 +155,7 @@ apiDescribe('Database batch writes', persistence => {
     );
   });
 
-  asyncIt('fail atomically, raising correct events', () => {
+  it('fail atomically, raising correct events', () => {
     return integrationHelpers.withTestCollection(
       persistence,
       {},
@@ -217,7 +216,7 @@ apiDescribe('Database batch writes', persistence => {
     );
   });
 
-  asyncIt('write the same server timestamp across writes', () => {
+  it('write the same server timestamp across writes', () => {
     return integrationHelpers.withTestCollection(
       persistence,
       {},
@@ -271,7 +270,7 @@ apiDescribe('Database batch writes', persistence => {
     );
   });
 
-  asyncIt('can write the same document multiple times', () => {
+  it('can write the same document multiple times', () => {
     return integrationHelpers.withTestDoc(persistence, doc => {
       const accumulator = new testHelpers.EventsAccumulator<
         firestore.DocumentSnapshot
@@ -313,7 +312,7 @@ apiDescribe('Database batch writes', persistence => {
     });
   });
 
-  asyncIt('can update nested fields', () => {
+  it('can update nested fields', () => {
     const initialData = {
       desc: 'Description',
       owner: { name: 'Jonny' },

--- a/packages/firestore/test/integration/api/cursor.test.ts
+++ b/packages/firestore/test/integration/api/cursor.test.ts
@@ -15,7 +15,7 @@
  */
 
 import { expect } from 'chai';
-import { asyncIt, toDataArray } from '../../util/helpers';
+import { toDataArray } from '../../util/helpers';
 import firebase from '../util/firebase_export';
 import {
   apiDescribe,
@@ -25,7 +25,7 @@ import {
 } from '../util/helpers';
 
 apiDescribe('Cursors', persistence => {
-  asyncIt('can page through items', () => {
+  it('can page through items', () => {
     const testDocs = {
       a: { v: 'a' },
       b: { v: 'b' },
@@ -72,7 +72,7 @@ apiDescribe('Cursors', persistence => {
     });
   });
 
-  asyncIt('can be created from documents', () => {
+  it('can be created from documents', () => {
     const testDocs = {
       a: { k: 'a', sort: 1 },
       b: { k: 'b', sort: 2 },
@@ -109,7 +109,7 @@ apiDescribe('Cursors', persistence => {
     });
   });
 
-  asyncIt('can be created from values', () => {
+  it('can be created from values', () => {
     const testDocs = {
       a: { k: 'a', sort: 1 },
       b: { k: 'b', sort: 2 },
@@ -140,7 +140,7 @@ apiDescribe('Cursors', persistence => {
     });
   });
 
-  asyncIt('can be created using document id', () => {
+  it('can be created using document id', () => {
     const testDocs: { [key: string]: {} } = {
       a: { k: 'a' },
       b: { k: 'b' },
@@ -175,7 +175,7 @@ apiDescribe('Cursors', persistence => {
     });
   });
 
-  asyncIt('can be used with reference values', () => {
+  it('can be used with reference values', () => {
     // We require a db to create reference values
     return withTestDb(persistence, db => {
       const testDocs = {
@@ -202,7 +202,7 @@ apiDescribe('Cursors', persistence => {
     });
   });
 
-  asyncIt('can be used in descending queries', () => {
+  it('can be used in descending queries', () => {
     const testDocs = {
       a: { k: 'a', sort: 1 },
       b: { k: 'b', sort: 2 },

--- a/packages/firestore/test/integration/api/database.test.ts
+++ b/packages/firestore/test/integration/api/database.test.ts
@@ -18,7 +18,6 @@ import { expect } from 'chai';
 import * as firestore from 'firestore';
 
 import { Deferred } from '../../../src/util/promise';
-import { asyncIt } from '../../util/helpers';
 import firebase from '../util/firebase_export';
 import {
   apiDescribe,
@@ -29,7 +28,7 @@ import {
 } from '../util/helpers';
 
 apiDescribe('Database', persistence => {
-  asyncIt('can set a document', () => {
+  it('can set a document', () => {
     return withTestDoc(persistence, docRef => {
       return docRef.set({
         desc: 'Stuff related to Firestore project...',
@@ -41,7 +40,7 @@ apiDescribe('Database', persistence => {
     });
   });
 
-  asyncIt('doc() will auto generate an ID', () => {
+  it('doc() will auto generate an ID', () => {
     return withTestDb(persistence, db => {
       const ref = db.collection('foo').doc();
       // Auto IDs are 20 characters long
@@ -50,7 +49,7 @@ apiDescribe('Database', persistence => {
     });
   });
 
-  asyncIt('can delete a document', () => {
+  it('can delete a document', () => {
     return withTestDoc(persistence, docRef => {
       return docRef
         .set({ foo: 'bar' })
@@ -70,7 +69,7 @@ apiDescribe('Database', persistence => {
     });
   });
 
-  asyncIt('can update existing document', () => {
+  it('can update existing document', () => {
     return withTestDoc(persistence, doc => {
       const initialData = {
         desc: 'Description',
@@ -95,7 +94,7 @@ apiDescribe('Database', persistence => {
     });
   });
 
-  asyncIt('can merge data with an existing document using set', () => {
+  it('can merge data with an existing document using set', () => {
     return withTestDoc(persistence, doc => {
       const initialData = {
         desc: 'description',
@@ -121,7 +120,7 @@ apiDescribe('Database', persistence => {
     });
   });
 
-  asyncIt('can merge server timestamps', () => {
+  it('can merge server timestamps', () => {
     return withTestDoc(persistence, doc => {
       const initialData = {
         updated: false
@@ -141,7 +140,7 @@ apiDescribe('Database', persistence => {
     });
   });
 
-  asyncIt('can delete field using merge', () => {
+  it('can delete field using merge', () => {
     return withTestDoc(persistence, doc => {
       const initialData = {
         untouched: true,
@@ -167,7 +166,7 @@ apiDescribe('Database', persistence => {
     });
   });
 
-  asyncIt('can replace an array by merging using set', () => {
+  it('can replace an array by merging using set', () => {
     return withTestDoc(persistence, doc => {
       const initialData = {
         untouched: true,
@@ -197,7 +196,7 @@ apiDescribe('Database', persistence => {
     });
   });
 
-  asyncIt('cannot update nonexistent document', () => {
+  it('cannot update nonexistent document', () => {
     return withTestDoc(persistence, doc => {
       return doc
         .update({ owner: 'abc' })
@@ -216,7 +215,7 @@ apiDescribe('Database', persistence => {
     });
   });
 
-  asyncIt('can delete a field with an update', () => {
+  it('can delete a field with an update', () => {
     return withTestDoc(persistence, doc => {
       const initialData = {
         desc: 'Description',
@@ -240,7 +239,7 @@ apiDescribe('Database', persistence => {
     });
   });
 
-  asyncIt('can update nested fields', () => {
+  it('can update nested fields', () => {
     const FieldPath = firebase.firestore.FieldPath;
 
     return withTestDoc(persistence, doc => {
@@ -270,7 +269,7 @@ apiDescribe('Database', persistence => {
   describe('documents: ', () => {
     const invalidDocValues = [undefined, null, 0, 'foo', ['a'], new Date()];
     for (const val of invalidDocValues) {
-      asyncIt('set/update should reject: ' + val, () => {
+      it('set/update should reject: ' + val, () => {
         return withTestDoc(persistence, doc => {
           // tslint:disable-next-line:no-any Intentionally passing bad types.
           expect(() => doc.set(val as any)).to.throw();
@@ -282,7 +281,7 @@ apiDescribe('Database', persistence => {
     }
   });
 
-  asyncIt('CollectionRef.add() resolves with resulting DocumentRef.', () => {
+  it('CollectionRef.add() resolves with resulting DocumentRef.', () => {
     return withTestCollection(persistence, {}, coll => {
       return coll
         .add({ foo: 1 })
@@ -296,7 +295,7 @@ apiDescribe('Database', persistence => {
   apiDescribe('Queries are validated client-side', persistence => {
     // NOTE: Failure cases are validated in validation_test.ts
 
-    asyncIt('same inequality fields works', () => {
+    it('same inequality fields works', () => {
       return withTestCollection(persistence, {}, coll => {
         expect(() =>
           coll.where('x', '>=', 32).where('x', '<=', 'cat')
@@ -305,7 +304,7 @@ apiDescribe('Database', persistence => {
       });
     });
 
-    asyncIt('inequality and equality on different fields works', () => {
+    it('inequality and equality on different fields works', () => {
       return withTestCollection(persistence, {}, coll => {
         expect(() =>
           coll.where('x', '>=', 32).where('y', '==', 'cat')
@@ -314,7 +313,7 @@ apiDescribe('Database', persistence => {
       });
     });
 
-    asyncIt('inequality same as orderBy works.', () => {
+    it('inequality same as orderBy works.', () => {
       return withTestCollection(persistence, {}, coll => {
         expect(() => coll.where('x', '>', 32).orderBy('x')).not.to.throw();
         expect(() => coll.orderBy('x').where('x', '>', 32)).not.to.throw();
@@ -322,7 +321,7 @@ apiDescribe('Database', persistence => {
       });
     });
 
-    asyncIt('inequality same as first orderBy works.', () => {
+    it('inequality same as first orderBy works.', () => {
       return withTestCollection(persistence, {}, coll => {
         expect(() =>
           coll
@@ -341,7 +340,7 @@ apiDescribe('Database', persistence => {
     });
   });
 
-  asyncIt('Listen can be called multiple times', () => {
+  it('Listen can be called multiple times', () => {
     return withTestCollection(persistence, {}, coll => {
       const doc = coll.doc();
       const deferred1 = new Deferred<void>();
@@ -358,7 +357,7 @@ apiDescribe('Database', persistence => {
     });
   });
 
-  asyncIt('Local document events are fired with hasLocalChanges=true.', () => {
+  it('Local document events are fired with hasLocalChanges=true.', () => {
     return withTestDoc(persistence, docRef => {
       let gotLocalDocEvent = false;
       const remoteDocEventDeferred = new Deferred();
@@ -384,7 +383,7 @@ apiDescribe('Database', persistence => {
     });
   });
 
-  asyncIt(
+  it(
     'Metadata only changes are not fired when no options provided',
     () => {
       return withTestDoc(persistence, docRef => {
@@ -418,7 +417,7 @@ apiDescribe('Database', persistence => {
   xdescribe('Listens are rejected remotely:', () => {
     let queryForRejection: firestore.Query;
 
-    asyncIt('will reject listens', () => {
+    it('will reject listens', () => {
       const deferred = new Deferred();
       queryForRejection.onSnapshot(
         () => {},
@@ -431,7 +430,7 @@ apiDescribe('Database', persistence => {
       return deferred.promise;
     });
 
-    asyncIt('will reject same listens twice in a row', () => {
+    it('will reject same listens twice in a row', () => {
       const deferred = new Deferred();
       queryForRejection.onSnapshot(
         () => {},
@@ -451,7 +450,7 @@ apiDescribe('Database', persistence => {
       return deferred.promise;
     });
 
-    asyncIt('will reject gets', () => {
+    it('will reject gets', () => {
       return queryForRejection.get().then(
         () => {
           throw new Error('Promise resolved even though error was expected.');
@@ -463,7 +462,7 @@ apiDescribe('Database', persistence => {
       );
     });
 
-    asyncIt('will reject gets twice in a row', () => {
+    it('will reject gets twice in a row', () => {
       return queryForRejection
         .get()
         .then(
@@ -488,21 +487,21 @@ apiDescribe('Database', persistence => {
     });
   });
 
-  asyncIt('exposes "firestore" on document references.', () => {
+  it('exposes "firestore" on document references.', () => {
     return withTestDb(persistence, db => {
       expect(db.doc('foo/bar').firestore).to.equal(db);
       return Promise.resolve();
     });
   });
 
-  asyncIt('exposes "firestore" on query references.', () => {
+  it('exposes "firestore" on query references.', () => {
     return withTestDb(persistence, db => {
       expect(db.collection('foo').limit(5).firestore).to.equal(db);
       return Promise.resolve();
     });
   });
 
-  asyncIt('can compare DocumentReference instances with isEqual().', () => {
+  it('can compare DocumentReference instances with isEqual().', () => {
     return withTestDb(persistence, firestore => {
       return withTestDb(persistence, otherFirestore => {
         const docRef = firestore.doc('foo/bar');
@@ -518,7 +517,7 @@ apiDescribe('Database', persistence => {
     });
   });
 
-  asyncIt('can compare Query instances with isEqual().', () => {
+  it('can compare Query instances with isEqual().', () => {
     return withTestDb(persistence, firestore => {
       return withTestDb(persistence, otherFirestore => {
         const query = firestore
@@ -548,7 +547,7 @@ apiDescribe('Database', persistence => {
     });
   });
 
-  asyncIt('can traverse collections and documents.', () => {
+  it('can traverse collections and documents.', () => {
     return withTestDb(persistence, db => {
       const expected = 'a/b/c/d';
       // doc path from root Firestore.
@@ -565,7 +564,7 @@ apiDescribe('Database', persistence => {
     });
   });
 
-  asyncIt('can traverse collection and document parents.', () => {
+  it('can traverse collection and document parents.', () => {
     return withTestDb(persistence, db => {
       let collection = db.collection('a/b/c');
       expect(collection.path).to.deep.equal('a/b/c');
@@ -582,7 +581,7 @@ apiDescribe('Database', persistence => {
     });
   });
 
-  asyncIt('can queue writes while offline', () => {
+  it('can queue writes while offline', () => {
     return withTestDoc(persistence, docRef => {
       // TODO(mikelehen): Find better way to expose this to tests.
       // tslint:disable-next-line:no-any enableNetwork isn't exposed via d.ts
@@ -603,7 +602,7 @@ apiDescribe('Database', persistence => {
     });
   });
 
-  asyncIt('can get documents while offline', () => {
+  it('can get documents while offline', () => {
     return withTestDoc(persistence, docRef => {
       // TODO(mikelehen): Find better way to expose this to tests.
       // tslint:disable-next-line:no-any enableNetwork isn't exposed via d.ts
@@ -628,7 +627,7 @@ apiDescribe('Database', persistence => {
     });
   });
 
-  asyncIt('can write document after idle timeout', () => {
+  it('can write document after idle timeout', () => {
     return withTestDb(persistence, db => {
       const docRef = db.collection('test-collection').doc();
       return docRef
@@ -640,7 +639,7 @@ apiDescribe('Database', persistence => {
     });
   });
 
-  asyncIt('can watch documents after idle timeout', () => {
+  it('can watch documents after idle timeout', () => {
     return withTestDb(persistence, db => {
       const awaitOnlineSnapshot = () => {
         const docRef = db.collection('test-collection').doc();

--- a/packages/firestore/test/integration/api/database.test.ts
+++ b/packages/firestore/test/integration/api/database.test.ts
@@ -383,33 +383,30 @@ apiDescribe('Database', persistence => {
     });
   });
 
-  it(
-    'Metadata only changes are not fired when no options provided',
-    () => {
-      return withTestDoc(persistence, docRef => {
-        const secondUpdateFound = new Deferred();
-        let count = 0;
-        const unlisten = docRef.onSnapshot(doc => {
-          if (doc) {
-            count++;
-            if (count === 1) {
-              expect(doc.data()).to.deep.equal({ a: 1 });
-            } else {
-              expect(doc.data()).to.deep.equal({ b: 1 });
-              secondUpdateFound.resolve();
-            }
+  it('Metadata only changes are not fired when no options provided', () => {
+    return withTestDoc(persistence, docRef => {
+      const secondUpdateFound = new Deferred();
+      let count = 0;
+      const unlisten = docRef.onSnapshot(doc => {
+        if (doc) {
+          count++;
+          if (count === 1) {
+            expect(doc.data()).to.deep.equal({ a: 1 });
+          } else {
+            expect(doc.data()).to.deep.equal({ b: 1 });
+            secondUpdateFound.resolve();
           }
-        });
-
-        docRef.set({ a: 1 }).then(() => {
-          docRef.set({ b: 1 });
-        });
-        return secondUpdateFound.promise.then(() => {
-          unlisten();
-        });
+        }
       });
-    }
-  );
+
+      docRef.set({ a: 1 }).then(() => {
+        docRef.set({ b: 1 });
+      });
+      return secondUpdateFound.promise.then(() => {
+        unlisten();
+      });
+    });
+  });
 
   // TODO(mikelehen): We need a way to create a query that will pass
   // client-side validation but fail remotely.  May need to wait until we

--- a/packages/firestore/test/integration/api/fields.test.ts
+++ b/packages/firestore/test/integration/api/fields.test.ts
@@ -15,7 +15,7 @@
  */
 
 import { expect } from 'chai';
-import { asyncIt, toDataArray } from '../../util/helpers';
+import { toDataArray } from '../../util/helpers';
 import firebase from '../util/firebase_export';
 import { apiDescribe, withTestCollection, withTestDoc } from '../util/helpers';
 
@@ -35,7 +35,7 @@ apiDescribe('Nested Fields', persistence => {
     };
   };
 
-  asyncIt('can be written with set()', () => {
+  it('can be written with set()', () => {
     return withTestDoc(persistence, doc => {
       return doc
         .set(testData())
@@ -46,7 +46,7 @@ apiDescribe('Nested Fields', persistence => {
     });
   });
 
-  asyncIt('can be read directly with .get(<string>)', () => {
+  it('can be read directly with .get(<string>)', () => {
     return withTestDoc(persistence, doc => {
       const obj = testData();
       return doc
@@ -65,7 +65,7 @@ apiDescribe('Nested Fields', persistence => {
     });
   });
 
-  asyncIt('can be read directly with .get(<FieldPath>)', () => {
+  it('can be read directly with .get(<FieldPath>)', () => {
     return withTestDoc(persistence, doc => {
       const obj = testData();
       return doc
@@ -88,7 +88,7 @@ apiDescribe('Nested Fields', persistence => {
     });
   });
 
-  asyncIt('can be updated with update(<string>)', () => {
+  it('can be updated with update(<string>)', () => {
     return withTestDoc(persistence, doc => {
       return doc
         .set(testData())
@@ -114,7 +114,7 @@ apiDescribe('Nested Fields', persistence => {
     });
   });
 
-  asyncIt('can be updated with update(<FieldPath>)', () => {
+  it('can be updated with update(<FieldPath>)', () => {
     return withTestDoc(persistence, doc => {
       return doc
         .set(testData())
@@ -142,7 +142,7 @@ apiDescribe('Nested Fields', persistence => {
     });
   });
 
-  asyncIt('can be used with query.where(<string>).', () => {
+  it('can be used with query.where(<string>).', () => {
     const testDocs = {
       '1': testData(300),
       '2': testData(100),
@@ -162,7 +162,7 @@ apiDescribe('Nested Fields', persistence => {
     });
   });
 
-  asyncIt('can be used with query.where(<FieldPath>).', () => {
+  it('can be used with query.where(<FieldPath>).', () => {
     const testDocs = {
       '1': testData(300),
       '2': testData(100),
@@ -182,7 +182,7 @@ apiDescribe('Nested Fields', persistence => {
     });
   });
 
-  asyncIt('can be used with query.orderBy(<string>).', () => {
+  it('can be used with query.orderBy(<string>).', () => {
     const testDocs = {
       '1': testData(300),
       '2': testData(100),
@@ -202,7 +202,7 @@ apiDescribe('Nested Fields', persistence => {
     });
   });
 
-  asyncIt('can be used with query.orderBy(<FieldPath>).', () => {
+  it('can be used with query.orderBy(<FieldPath>).', () => {
     const testDocs = {
       '1': testData(300),
       '2': testData(100),
@@ -236,7 +236,7 @@ apiDescribe('Fields with special characters', persistence => {
     };
   };
 
-  asyncIt('can be written with set()', () => {
+  it('can be written with set()', () => {
     return withTestDoc(persistence, doc => {
       return doc
         .set(testData())
@@ -247,7 +247,7 @@ apiDescribe('Fields with special characters', persistence => {
     });
   });
 
-  asyncIt('can be read directly with .data(<field>)', () => {
+  it('can be read directly with .data(<field>)', () => {
     return withTestDoc(persistence, doc => {
       const obj = testData();
       return doc
@@ -265,7 +265,7 @@ apiDescribe('Fields with special characters', persistence => {
     });
   });
 
-  asyncIt('can be updated with update()', () => {
+  it('can be updated with update()', () => {
     return withTestDoc(persistence, doc => {
       return doc
         .set(testData())
@@ -288,7 +288,7 @@ apiDescribe('Fields with special characters', persistence => {
     });
   });
 
-  asyncIt('can be used in query filters.', () => {
+  it('can be used in query filters.', () => {
     const testDocs = {
       '1': testData(300),
       '2': testData(100),
@@ -310,7 +310,7 @@ apiDescribe('Fields with special characters', persistence => {
     });
   });
 
-  asyncIt('can be used in a query orderBy.', () => {
+  it('can be used in a query orderBy.', () => {
     const testDocs = {
       '1': testData(300),
       '2': testData(100),

--- a/packages/firestore/test/integration/api/query.test.ts
+++ b/packages/firestore/test/integration/api/query.test.ts
@@ -18,7 +18,7 @@ import { expect } from 'chai';
 import * as firestore from 'firestore';
 
 import { addEqualityMatcher } from '../../util/equality_matcher';
-import { asyncIt, EventsAccumulator, toDataArray } from '../../util/helpers';
+import { EventsAccumulator, toDataArray } from '../../util/helpers';
 import firebase from '../util/firebase_export';
 import { apiDescribe, withTestCollection, withTestDbs } from '../util/helpers';
 import { Firestore } from '../../../src/api/database';
@@ -27,7 +27,7 @@ import { Deferred } from '../../../src/util/promise';
 apiDescribe('Queries', persistence => {
   addEqualityMatcher();
 
-  asyncIt('can issue limit queries', () => {
+  it('can issue limit queries', () => {
     const testDocs = {
       a: { k: 'a' },
       b: { k: 'b' },
@@ -43,7 +43,7 @@ apiDescribe('Queries', persistence => {
     });
   });
 
-  asyncIt('can issue limit queries using descending sort order', () => {
+  it('can issue limit queries using descending sort order', () => {
     const testDocs = {
       a: { k: 'a', sort: 0 },
       b: { k: 'b', sort: 1 },
@@ -64,7 +64,7 @@ apiDescribe('Queries', persistence => {
     });
   });
 
-  asyncIt('key order is descending for descending inequality', () => {
+  it('key order is descending for descending inequality', () => {
     const testDocs = {
       a: {
         foo: 42
@@ -105,7 +105,7 @@ apiDescribe('Queries', persistence => {
     });
   });
 
-  asyncIt('can use unary filters', () => {
+  it('can use unary filters', () => {
     const testDocs = {
       a: { null: null, nan: NaN },
       b: { null: null, nan: 0 },
@@ -122,7 +122,7 @@ apiDescribe('Queries', persistence => {
     });
   });
 
-  asyncIt('can filter on infinity', () => {
+  it('can filter on infinity', () => {
     const testDocs = {
       a: { inf: Infinity },
       b: { inf: -Infinity }
@@ -137,7 +137,7 @@ apiDescribe('Queries', persistence => {
     });
   });
 
-  asyncIt('will not get metadata only updates', () => {
+  it('will not get metadata only updates', () => {
     const testDocs = { a: { v: 'a' }, b: { v: 'b' } };
     return withTestCollection(persistence, testDocs, coll => {
       const storeEvent = new EventsAccumulator<firestore.QuerySnapshot>();
@@ -173,7 +173,7 @@ apiDescribe('Queries', persistence => {
     });
   });
 
-  asyncIt('can listen for the same query with different options', () => {
+  it('can listen for the same query with different options', () => {
     const testDocs = { a: { v: 'a' }, b: { v: 'b' } };
     return withTestCollection(persistence, testDocs, coll => {
       const storeEvent = new EventsAccumulator<firestore.QuerySnapshot>();
@@ -275,7 +275,7 @@ apiDescribe('Queries', persistence => {
     });
   });
 
-  asyncIt('can issue queries with Dates differing in milliseconds', () => {
+  it('can issue queries with Dates differing in milliseconds', () => {
     const date1 = new Date();
     date1.setMilliseconds(0);
     const date2 = new Date(date1.getTime());
@@ -306,7 +306,7 @@ apiDescribe('Queries', persistence => {
     });
   });
 
-  asyncIt('can listen for QueryMetadata changes', () => {
+  it('can listen for QueryMetadata changes', () => {
     const testDocs = {
       '1': { sort: 1, filter: true, key: '1' },
       '2': { sort: 2, filter: true, key: '2' },
@@ -349,7 +349,7 @@ apiDescribe('Queries', persistence => {
     });
   });
 
-  asyncIt('can explicitly sort by document ID', () => {
+  it('can explicitly sort by document ID', () => {
     const testDocs = {
       a: { key: 'a' },
       b: { key: 'b' },
@@ -371,7 +371,7 @@ apiDescribe('Queries', persistence => {
     });
   });
 
-  asyncIt('can query by document ID', () => {
+  it('can query by document ID', () => {
     const testDocs = {
       aa: { key: 'aa' },
       ab: { key: 'ab' },
@@ -398,7 +398,7 @@ apiDescribe('Queries', persistence => {
     });
   });
 
-  asyncIt('can query by document ID using refs', () => {
+  it('can query by document ID using refs', () => {
     const testDocs = {
       aa: { key: 'aa' },
       ab: { key: 'ab' },
@@ -433,7 +433,7 @@ apiDescribe('Queries', persistence => {
     });
   });
 
-  asyncIt('can query while reconnecting to network', () => {
+  it('can query while reconnecting to network', () => {
     return withTestCollection(persistence, /* docs= */ {}, coll => {
       // TODO(mikelehen): Find better way to expose this to tests.
       // tslint:disable-next-line:no-any enableNetwork isn't exposed via d.ts

--- a/packages/firestore/test/integration/api/server_timestamp.test.ts
+++ b/packages/firestore/test/integration/api/server_timestamp.test.ts
@@ -21,8 +21,6 @@ import * as testHelpers from '../../util/helpers';
 import firebase from '../util/firebase_export';
 import { apiDescribe, withTestDoc } from '../util/helpers';
 
-const asyncIt = testHelpers.asyncIt;
-
 apiDescribe('Server Timestamps', persistence => {
   // Data written in tests via set().
   const setData = {
@@ -122,7 +120,7 @@ apiDescribe('Server Timestamps', persistence => {
     });
   }
 
-  asyncIt('work via set()', () => {
+  it('work via set()', () => {
     return withTestSetup(() => {
       return docRef
         .set(setData)
@@ -131,7 +129,7 @@ apiDescribe('Server Timestamps', persistence => {
     });
   });
 
-  asyncIt('work via update()', () => {
+  it('work via update()', () => {
     return withTestSetup(() => {
       return writeInitialData()
         .then(() => docRef.update(updateData))
@@ -140,7 +138,7 @@ apiDescribe('Server Timestamps', persistence => {
     });
   });
 
-  asyncIt('work via transaction set()', () => {
+  it('work via transaction set()', () => {
     return withTestSetup(() => {
       return docRef.firestore
         .runTransaction(txn => {
@@ -151,7 +149,7 @@ apiDescribe('Server Timestamps', persistence => {
     });
   });
 
-  asyncIt('work via transaction update()', () => {
+  it('work via transaction update()', () => {
     return withTestSetup(() => {
       return writeInitialData()
         .then(() =>
@@ -164,7 +162,7 @@ apiDescribe('Server Timestamps', persistence => {
     });
   });
 
-  asyncIt('fail via update() on nonexistent document.', () => {
+  it('fail via update() on nonexistent document.', () => {
     return withTestSetup(() => {
       return docRef.update(updateData).then(
         () => {
@@ -177,7 +175,7 @@ apiDescribe('Server Timestamps', persistence => {
     });
   });
 
-  asyncIt('fail via transaction update() on nonexistent document.', () => {
+  it('fail via transaction update() on nonexistent document.', () => {
     return withTestSetup(() => {
       return docRef.firestore
         .runTransaction(txn => {

--- a/packages/firestore/test/integration/api/smoke.test.ts
+++ b/packages/firestore/test/integration/api/smoke.test.ts
@@ -20,11 +20,10 @@ import * as testHelpers from '../../util/helpers';
 import { EventsAccumulator } from '../../util/helpers';
 import * as integrationHelpers from '../util/helpers';
 
-const asyncIt = testHelpers.asyncIt;
 const apiDescribe = integrationHelpers.apiDescribe;
 
 apiDescribe('Smoke Test', persistence => {
-  asyncIt('can write a single document', () => {
+  it('can write a single document', () => {
     return integrationHelpers.withTestDoc(persistence, ref => {
       return ref.set({
         name: 'Patryk',
@@ -33,7 +32,7 @@ apiDescribe('Smoke Test', persistence => {
     });
   });
 
-  asyncIt('can read a written document', () => {
+  it('can read a written document', () => {
     return integrationHelpers.withTestDoc(persistence, ref => {
       const data = {
         name: 'Patryk',
@@ -50,7 +49,7 @@ apiDescribe('Smoke Test', persistence => {
     });
   });
 
-  asyncIt('can read a written document with DocumentKey', () => {
+  it('can read a written document with DocumentKey', () => {
     return integrationHelpers.withTestDoc(persistence, ref1 => {
       const ref2 = ref1.firestore.collection('users').doc();
       const data = { user: ref2, message: 'We are writing data' };
@@ -73,7 +72,7 @@ apiDescribe('Smoke Test', persistence => {
     });
   });
 
-  asyncIt('will fire local and remote events', () => {
+  it('will fire local and remote events', () => {
     return integrationHelpers.withTestDbs(
       persistence,
       2,
@@ -100,7 +99,7 @@ apiDescribe('Smoke Test', persistence => {
     );
   });
 
-  asyncIt('will fire value events for empty collections', () => {
+  it('will fire value events for empty collections', () => {
     return integrationHelpers.withTestCollection(
       persistence,
       {},
@@ -119,7 +118,7 @@ apiDescribe('Smoke Test', persistence => {
     );
   });
 
-  asyncIt('can get collection query', () => {
+  it('can get collection query', () => {
     const testDocs = {
       '1': {
         name: 'Patryk',

--- a/packages/firestore/test/integration/api/transactions.test.ts
+++ b/packages/firestore/test/integration/api/transactions.test.ts
@@ -21,14 +21,13 @@ import * as testHelpers from '../../util/helpers';
 import firebase from '../util/firebase_export';
 import * as integrationHelpers from '../util/helpers';
 
-const asyncIt = testHelpers.asyncIt;
 const apiDescribe = integrationHelpers.apiDescribe;
 
 apiDescribe('Database transactions', persistence => {
   // TODO(klimt): Test that transactions don't see latency compensation
   // changes, using the other kind of integration test.
   // We currently require every document read to also be written.
-  asyncIt('get documents', () => {
+  it('get documents', () => {
     return integrationHelpers.withTestDb(persistence, db => {
       const doc = db.collection('spaces').doc();
       return doc
@@ -63,7 +62,7 @@ apiDescribe('Database transactions', persistence => {
     });
   });
 
-  asyncIt('delete documents', () => {
+  it('delete documents', () => {
     return integrationHelpers.withTestDb(persistence, db => {
       const doc = db.collection('towns').doc();
       return doc
@@ -89,7 +88,7 @@ apiDescribe('Database transactions', persistence => {
     });
   });
 
-  asyncIt('get nonexistent document then create', () => {
+  it('get nonexistent document then create', () => {
     return integrationHelpers.withTestDb(persistence, db => {
       const docRef = db.collection('towns').doc();
       return db
@@ -109,7 +108,7 @@ apiDescribe('Database transactions', persistence => {
     });
   });
 
-  asyncIt('get nonexistent document then fail patch', () => {
+  it('get nonexistent document then fail patch', () => {
     return integrationHelpers.withTestDb(persistence, db => {
       const docRef = db.collection('towns').doc();
       return db
@@ -129,7 +128,7 @@ apiDescribe('Database transactions', persistence => {
     });
   });
 
-  asyncIt("can't delete document then patch", () => {
+  it("can't delete document then patch", () => {
     return integrationHelpers.withTestDb(persistence, db => {
       const docRef = db.collection('towns').doc();
       return docRef.set({ foo: 'bar' }).then(() => {
@@ -157,7 +156,7 @@ apiDescribe('Database transactions', persistence => {
     });
   });
 
-  asyncIt("can't delete document then set", () => {
+  it("can't delete document then set", () => {
     return integrationHelpers.withTestDb(persistence, db => {
       const docRef = db.collection('towns').doc();
       return docRef.set({ foo: 'bar' }).then(() => {
@@ -184,7 +183,7 @@ apiDescribe('Database transactions', persistence => {
     });
   });
 
-  asyncIt('write document twice', () => {
+  it('write document twice', () => {
     return integrationHelpers.withTestDb(persistence, db => {
       const doc = db.collection('towns').doc();
       return db
@@ -202,7 +201,7 @@ apiDescribe('Database transactions', persistence => {
     });
   });
 
-  asyncIt('set document with merge', () => {
+  it('set document with merge', () => {
     return integrationHelpers.withTestDb(persistence, db => {
       const doc = db.collection('towns').doc();
       return db
@@ -230,7 +229,7 @@ apiDescribe('Database transactions', persistence => {
     });
   });
 
-  asyncIt('increment transactionally', () => {
+  it('increment transactionally', () => {
     // A set of concurrent transactions.
     const transactionPromises: Array<Promise<void>> = [];
     const readPromises: Array<Promise<void>> = [];
@@ -286,7 +285,7 @@ apiDescribe('Database transactions', persistence => {
     });
   });
 
-  asyncIt('update transactionally', () => {
+  it('update transactionally', () => {
     // A set of concurrent transactions.
     const transactionPromises: Array<Promise<void>> = [];
     const readPromises: Array<Promise<void>> = [];
@@ -344,7 +343,7 @@ apiDescribe('Database transactions', persistence => {
     });
   });
 
-  asyncIt('can update nested fields transactionally', () => {
+  it('can update nested fields transactionally', () => {
     const initialData = {
       desc: 'Description',
       owner: { name: 'Jonny' },
@@ -378,7 +377,7 @@ apiDescribe('Database transactions', persistence => {
     });
   });
 
-  asyncIt('handle reading one doc and writing another', () => {
+  it('handle reading one doc and writing another', () => {
     return integrationHelpers.withTestDb(persistence, db => {
       const doc1 = db.collection('counters').doc();
       const doc2 = db.collection('counters').doc();
@@ -427,7 +426,7 @@ apiDescribe('Database transactions', persistence => {
     });
   });
 
-  asyncIt('handle reading a doc twice with different versions', () => {
+  it('handle reading a doc twice with different versions', () => {
     return integrationHelpers.withTestDb(persistence, db => {
       const doc = db.collection('counters').doc();
       return doc
@@ -460,7 +459,7 @@ apiDescribe('Database transactions', persistence => {
     });
   });
 
-  asyncIt('cannot read after writing', () => {
+  it('cannot read after writing', () => {
     return integrationHelpers.withTestDb(persistence, db => {
       return db
         .runTransaction(transaction => {
@@ -491,7 +490,7 @@ apiDescribe('Database transactions', persistence => {
     ];
 
     for (const badReturn of badReturns) {
-      asyncIt(badReturn + ' is rejected', () => {
+      it(badReturn + ' is rejected', () => {
         // tslint:disable-next-line:no-any Intentionally returning bad type.
         const fn = ((txn: firestore.Transaction) => badReturn) as any;
         return integrationHelpers.withTestDb(persistence, db => {
@@ -509,7 +508,7 @@ apiDescribe('Database transactions', persistence => {
     }
   });
 
-  asyncIt('cannot have a get without mutations', () => {
+  it('cannot have a get without mutations', () => {
     return integrationHelpers.withTestDb(persistence, db => {
       const docRef = db.collection('foo').doc();
       return (
@@ -537,7 +536,7 @@ apiDescribe('Database transactions', persistence => {
     });
   });
 
-  asyncIt('are successful with no transaction operations', () => {
+  it('are successful with no transaction operations', () => {
     return integrationHelpers.withTestDb(persistence, db => {
       return db.runTransaction(txn => {
         return Promise.resolve();
@@ -545,7 +544,7 @@ apiDescribe('Database transactions', persistence => {
     });
   });
 
-  asyncIt('are cancelled on rejected promise', () => {
+  it('are cancelled on rejected promise', () => {
     return integrationHelpers.withTestDb(persistence, db => {
       const doc = db.collection('towns').doc();
       let count = 0;
@@ -570,7 +569,7 @@ apiDescribe('Database transactions', persistence => {
     });
   });
 
-  asyncIt('are cancelled on throw', () => {
+  it('are cancelled on throw', () => {
     return integrationHelpers.withTestDb(persistence, db => {
       const doc = db.collection('towns').doc();
       const failure = new Error('no');

--- a/packages/firestore/test/integration/api/type.test.ts
+++ b/packages/firestore/test/integration/api/type.test.ts
@@ -21,8 +21,6 @@ import { apiDescribe, withTestDb, withTestDoc } from '../util/helpers';
 
 import * as testHelpers from '../../util/helpers';
 
-const asyncIt = testHelpers.asyncIt;
-
 apiDescribe('Firestore', persistence => {
   function expectRoundtrip(db: firestore.Firestore, data: {}): Promise<void> {
     const doc = db.collection('rooms').doc();
@@ -34,19 +32,19 @@ apiDescribe('Firestore', persistence => {
       });
   }
 
-  asyncIt('can read and write null fields', () => {
+  it('can read and write null fields', () => {
     return withTestDb(persistence, db => {
       return expectRoundtrip(db, { a: 1, b: null });
     });
   });
 
-  asyncIt('can read and write array fields', () => {
+  it('can read and write array fields', () => {
     return withTestDb(persistence, db => {
       return expectRoundtrip(db, { array: [1, 'foo', { deep: true }, null] });
     });
   });
 
-  asyncIt('can read and write geo point fields', () => {
+  it('can read and write geo point fields', () => {
     return withTestDoc(persistence, doc => {
       return doc
         .set({ geopoint: new firebase.firestore.GeoPoint(1.23, 4.56) })
@@ -62,7 +60,7 @@ apiDescribe('Firestore', persistence => {
     });
   });
 
-  asyncIt('can read and write bytes fields', () => {
+  it('can read and write bytes fields', () => {
     return withTestDoc(persistence, doc => {
       return doc
         .set({
@@ -83,20 +81,20 @@ apiDescribe('Firestore', persistence => {
     });
   });
 
-  asyncIt('can read and write timestamp fields', () => {
+  it('can read and write timestamp fields', () => {
     return withTestDb(persistence, db => {
       const dateValue = new Date('2017-04-10T09:10:11.123Z');
       return expectRoundtrip(db, { timestamp: dateValue });
     });
   });
 
-  asyncIt('can read and write document references', () => {
+  it('can read and write document references', () => {
     return withTestDoc(persistence, doc => {
       return expectRoundtrip(doc.firestore, { a: 42, ref: doc });
     });
   });
 
-  asyncIt('can read and write document references in an array', () => {
+  it('can read and write document references in an array', () => {
     return withTestDoc(persistence, doc => {
       return expectRoundtrip(doc.firestore, { a: 42, refs: [doc] });
     });

--- a/packages/firestore/test/integration/api/validation.test.ts
+++ b/packages/firestore/test/integration/api/validation.test.ts
@@ -17,7 +17,6 @@
 import { expect } from 'chai';
 import * as firestore from 'firestore';
 
-import { asyncIt } from '../../util/helpers';
 import firebase from '../util/firebase_export';
 import {
   DEFAULT_PROJECT_ID,
@@ -32,13 +31,13 @@ import {
 // tslint:disable:no-any
 
 // Since most of our tests are "synchronous" but require a Firestore instance,
-// we have a helper wrapper around asyncIt and withTestDb to optimize for that.
+// we have a helper wrapper around it() and withTestDb() to optimize for that.
 function validationIt(
   persistence: boolean,
   message: string,
   testFunction: (db: firestore.Firestore) => void | Promise<any>
 ) {
-  asyncIt(message, () => {
+  it(message, () => {
     return withTestDb(persistence, db => {
       const maybePromise = testFunction(db);
       if (maybePromise) {
@@ -114,7 +113,7 @@ apiDescribe('Validation:', persistence => {
       }
     );
 
-    asyncIt("fails transaction if function doesn't return a Promise.", () => {
+    it("fails transaction if function doesn't return a Promise.", () => {
       return withTestDb(persistence, db => {
         return db.runTransaction(() => 5 as any).then(
           x => expect.fail('Transaction should fail'),
@@ -534,7 +533,7 @@ apiDescribe('Validation:', persistence => {
       );
     });
 
-    asyncIt('cannot be created from documents missing sort values', () => {
+    it('cannot be created from documents missing sort values', () => {
       const testDocs = {
         f: { k: 'f', nosort: 1 } // should not show up
       };

--- a/packages/firestore/test/integration/browser/indexeddb.test.ts
+++ b/packages/firestore/test/integration/browser/indexeddb.test.ts
@@ -17,7 +17,6 @@
 import { expect } from 'chai';
 import * as firestore from 'firestore';
 
-import { asyncIt } from '../../util/helpers';
 import { isPersistenceAvailable, withTestDb } from '../util/helpers';
 
 describe('where persistence is unsupported, enablePersistence', () => {
@@ -26,7 +25,7 @@ describe('where persistence is unsupported, enablePersistence', () => {
     return;
   }
 
-  asyncIt('fails with code unimplemented', () => {
+  it('fails with code unimplemented', () => {
     // withTestDb will fail the test if persistence is requested but it fails
     // so we'll enable persistence here instead.
     return withTestDb(/* persistence= */ false, db => {
@@ -41,7 +40,7 @@ describe('where persistence is unsupported, enablePersistence', () => {
     });
   });
 
-  asyncIt('falls back without requiring a wait for the promise', () => {
+  it('falls back without requiring a wait for the promise', () => {
     return withTestDb(/* persistence= */ false, db => {
       // Disregard the promise here intentionally.
       db.enablePersistence();

--- a/packages/firestore/test/integration/remote/remote.test.ts
+++ b/packages/firestore/test/integration/remote/remote.test.ts
@@ -23,13 +23,13 @@ import {
 } from '../../../src/model/document';
 import { MutationResult } from '../../../src/model/mutation';
 import { addEqualityMatcher } from '../../util/equality_matcher';
-import { asyncIt, key, setMutation } from '../../util/helpers';
+import { key, setMutation } from '../../util/helpers';
 import { withTestDatastore } from '../util/helpers';
 
 describe('Remote Storage', () => {
   addEqualityMatcher();
 
-  asyncIt('can write', () => {
+  it('can write', () => {
     return withTestDatastore(ds => {
       const mutation = setMutation('docs/1', { sort: 1 });
 
@@ -42,7 +42,7 @@ describe('Remote Storage', () => {
     });
   });
 
-  asyncIt('can read', () => {
+  it('can read', () => {
     return withTestDatastore(ds => {
       const k = key('docs/1');
       const mutation = setMutation('docs/1', { sort: 10 });
@@ -68,7 +68,7 @@ describe('Remote Storage', () => {
     });
   });
 
-  asyncIt('can read deleted documents', () => {
+  it('can read deleted documents', () => {
     return withTestDatastore(ds => {
       const k = key('docs/2');
       return ds.lookup([k]).then((docs: MaybeDocument[]) => {

--- a/packages/firestore/test/integration/remote/stream.test.ts
+++ b/packages/firestore/test/integration/remote/stream.test.ts
@@ -31,7 +31,7 @@ import {
 import { AsyncQueue } from '../../../src/util/async_queue';
 import { Deferred } from '../../../src/util/promise';
 import { Datastore } from '../../../src/remote/datastore';
-import { asyncIt, setMutation } from '../../util/helpers';
+import { setMutation } from '../../util/helpers';
 import { drainAsyncQueue, withTestDatastore } from '../util/helpers';
 
 /**
@@ -137,7 +137,7 @@ describe('Watch Stream', () => {
    * Verifies that the watch stream does not issue an onClose callback after a
    * call to stop().
    */
-  asyncIt('can be stopped before handshake', () => {
+  it('can be stopped before handshake', () => {
     let watchStream: PersistentListenStream;
 
     return withTestDatastore(ds => {
@@ -170,7 +170,7 @@ describe('Write Stream', () => {
    * Verifies that the write stream does not issue an onClose callback after a
    * call to stop().
    */
-  asyncIt('can be stopped before handshake', () => {
+  it('can be stopped before handshake', () => {
     let writeStream: PersistentWriteStream;
 
     return withTestDatastore(ds => {
@@ -186,7 +186,7 @@ describe('Write Stream', () => {
     });
   });
 
-  asyncIt('can be stopped after handshake', () => {
+  it('can be stopped after handshake', () => {
     let writeStream: PersistentWriteStream;
 
     return withTestDatastore(ds => {
@@ -212,7 +212,7 @@ describe('Write Stream', () => {
       });
   });
 
-  asyncIt('closes when idle', () => {
+  it('closes when idle', () => {
     let queue = new AsyncQueue();
 
     return withTestDatastore(ds => {
@@ -238,7 +238,7 @@ describe('Write Stream', () => {
     }, queue);
   });
 
-  asyncIt('cancels idle on write', () => {
+  it('cancels idle on write', () => {
     let queue = new AsyncQueue();
 
     return withTestDatastore(ds => {

--- a/packages/firestore/test/unit/local/eager_garbage_collector.test.ts
+++ b/packages/firestore/test/unit/local/eager_garbage_collector.test.ts
@@ -18,10 +18,9 @@ import { expect } from 'chai';
 import { EagerGarbageCollector } from '../../../src/local/eager_garbage_collector';
 import { ReferenceSet } from '../../../src/local/reference_set';
 import { expectSetToEqual, key } from '../../util/helpers';
-import { asyncIt } from '../../util/helpers';
 
 describe('EagerGarbageCollector', () => {
-  asyncIt('can add or remove references', () => {
+  it('can add or remove references', () => {
     const gc = new EagerGarbageCollector();
     const referenceSet = new ReferenceSet();
     gc.addGarbageSource(referenceSet);
@@ -44,7 +43,7 @@ describe('EagerGarbageCollector', () => {
       });
   });
 
-  asyncIt('can remove all references for ID', () => {
+  it('can remove all references for ID', () => {
     const gc = new EagerGarbageCollector();
     const referenceSet = new ReferenceSet();
     gc.addGarbageSource(referenceSet);
@@ -74,7 +73,7 @@ describe('EagerGarbageCollector', () => {
       });
   });
 
-  asyncIt('can handle two reference sets at the same time', () => {
+  it('can handle two reference sets at the same time', () => {
     const remoteTargets = new ReferenceSet();
     const localViews = new ReferenceSet();
     const mutations = new ReferenceSet();

--- a/packages/firestore/test/unit/local/encoded_resource_path.test.ts
+++ b/packages/firestore/test/unit/local/encoded_resource_path.test.ts
@@ -27,7 +27,6 @@ import {
 import { ResourcePath } from '../../../src/model/path';
 import { fail } from '../../../src/util/assert';
 import { path } from '../../util/helpers';
-import { asyncIt } from '../../util/helpers';
 
 import * as persistenceHelpers from './persistence_test_helpers';
 
@@ -57,7 +56,7 @@ describe('EncodedResourcePath', () => {
     db.close();
   });
 
-  asyncIt('encodes resource paths', async () => {
+  it('encodes resource paths', async () => {
     await assertEncoded(sep, ResourcePath.EMPTY_PATH);
     await assertEncoded('\u0001\u0010' + sep, path('\0'));
     await assertEncoded('\u0002' + sep, path('\u0002'));
@@ -84,7 +83,7 @@ describe('EncodedResourcePath', () => {
     );
   });
 
-  asyncIt('orders resource paths', async () => {
+  it('orders resource paths', async () => {
     await assertOrdered([
       ResourcePath.EMPTY_PATH,
       path('\0'),

--- a/packages/firestore/test/unit/local/local_store.test.ts
+++ b/packages/firestore/test/unit/local/local_store.test.ts
@@ -52,7 +52,6 @@ import {
 import { assert, fail } from '../../../src/util/assert';
 import { addEqualityMatcher } from '../../util/equality_matcher';
 import {
-  asyncIt,
   deletedDoc,
   deleteMutation,
   doc,
@@ -733,7 +732,7 @@ function genericLocalStoreTests(getPersistence: () => Promise<Persistence>) {
       .finish();
   });
 
-  asyncIt('can execute document queries', () => {
+  it('can execute document queries', () => {
     const localStore = expectLocalStore().localStore;
     return localStore
       .localWrite([
@@ -750,7 +749,7 @@ function genericLocalStoreTests(getPersistence: () => Promise<Persistence>) {
       });
   });
 
-  asyncIt('can execute collection queries', () => {
+  it('can execute collection queries', () => {
     const localStore = expectLocalStore().localStore;
     return localStore
       .localWrite([
@@ -770,7 +769,7 @@ function genericLocalStoreTests(getPersistence: () => Promise<Persistence>) {
       });
   });
 
-  asyncIt('can execute mixed collection queries', async () => {
+  it('can execute mixed collection queries', async () => {
     const query = Query.atPath(path('foo'));
     const queryData = await localStore.allocateQuery(query);
     expect(queryData.targetId).to.equal(2);
@@ -792,7 +791,7 @@ function genericLocalStoreTests(getPersistence: () => Promise<Persistence>) {
     ]);
   });
 
-  asyncIt('persists resume tokens', async () => {
+  it('persists resume tokens', async () => {
     await restartWithNoOpGarbageCollector();
     const query = Query.atPath(path('foo/bar'));
     const queryData = await localStore.allocateQuery(query);
@@ -820,7 +819,7 @@ function genericLocalStoreTests(getPersistence: () => Promise<Persistence>) {
     expect(queryData2.resumeToken).to.deep.equal(resumeToken);
   });
 
-  asyncIt('does not replace resume token with empty resume token', async () => {
+  it('does not replace resume token with empty resume token', async () => {
     await restartWithNoOpGarbageCollector();
     const query = Query.atPath(path('foo/bar'));
     const queryData = await localStore.allocateQuery(query);

--- a/packages/firestore/test/unit/local/mutation_queue.test.ts
+++ b/packages/firestore/test/unit/local/mutation_queue.test.ts
@@ -30,7 +30,6 @@ import {
 } from '../../../src/model/mutation_batch';
 import { emptyByteString } from '../../../src/platform/platform';
 import {
-  asyncIt,
   expectEqualArrays,
   expectSetToEqual,
   key,
@@ -93,17 +92,17 @@ describe('IndexedDbMutationQueue', () => {
       });
     }
 
-    asyncIt('returns zero when no mutations.', async () => {
+    it('returns zero when no mutations.', async () => {
       const batchId = await loadNextBatchId();
       expect(batchId).to.equal(0);
     });
 
-    asyncIt('finds next id after single mutation batch', async () => {
+    it('finds next id after single mutation batch', async () => {
       await addDummyBatch('foo', 6);
       expect(await loadNextBatchId()).to.equal(7);
     });
 
-    asyncIt('finds max across users', async () => {
+    it('finds max across users', async () => {
       await addDummyBatch('fo', 5);
       await addDummyBatch('food', 3);
 
@@ -133,7 +132,7 @@ function genericMutationQueueTests() {
     return persistence.shutdown();
   });
 
-  asyncIt('can count batches', async () => {
+  it('can count batches', async () => {
     expect(await mutationQueue.countBatches()).to.equal(0);
     expect(await mutationQueue.checkEmpty()).to.equal(true);
 
@@ -151,7 +150,7 @@ function genericMutationQueueTests() {
     expect(await mutationQueue.countBatches()).to.equal(0);
   });
 
-  asyncIt('can acknowledge batches through batchId', async () => {
+  it('can acknowledge batches through batchId', async () => {
     // Initial state of an empty queue
     expect(await mutationQueue.getHighestAcknowledgedBatchId()).to.equal(
       BATCHID_UNKNOWN
@@ -196,7 +195,7 @@ function genericMutationQueueTests() {
     );
   });
 
-  asyncIt('can acknowledge then remove', async () => {
+  it('can acknowledge then remove', async () => {
     const batch1 = await addMutationBatch();
     expect(await mutationQueue.countBatches()).to.equal(1);
     expect(await mutationQueue.getHighestAcknowledgedBatchId()).to.equal(
@@ -212,7 +211,7 @@ function genericMutationQueueTests() {
     );
   });
 
-  asyncIt(
+  it(
     'getHighestAcknowledgedBatchId() never exceeds getNextBatchId()',
     async () => {
       const batch1 = await addMutationBatch();
@@ -269,7 +268,7 @@ function genericMutationQueueTests() {
     }
   );
 
-  asyncIt('can lookup mutation batch', async () => {
+  it('can lookup mutation batch', async () => {
     // Searching on an empty queue should not find a non-existent batch
     let notFound = await mutationQueue.lookupMutationBatch(42);
     expect(notFound).to.be.null;
@@ -294,7 +293,7 @@ function genericMutationQueueTests() {
     expect(notFound).to.be.null;
   });
 
-  asyncIt('can getNextMutationBatchAfterBatchId()', async () => {
+  it('can getNextMutationBatchAfterBatchId()', async () => {
     const batches = await createBatches(10);
 
     // This is an array of successors assuming the removals below will happen:
@@ -332,7 +331,7 @@ function genericMutationQueueTests() {
     expect(notFound).to.be.null;
   });
 
-  asyncIt('can getAllMutationBatchesThroughBatchId()', async () => {
+  it('can getAllMutationBatchesThroughBatchId()', async () => {
     const batches = await createBatches(10);
     await makeHolesInBatches([2, 6, 7], batches);
 
@@ -353,7 +352,7 @@ function genericMutationQueueTests() {
     }
   });
 
-  asyncIt('can getAllMutationBatchesAffectingDocumentKey()', async () => {
+  it('can getAllMutationBatchesAffectingDocumentKey()', async () => {
     const mutations = [
       setMutation('fob/bar', { a: 1 }),
       setMutation('foo/bar', { a: 1 }),
@@ -376,7 +375,7 @@ function genericMutationQueueTests() {
     expectEqualArrays(matches, expected);
   });
 
-  asyncIt('can getAllMutationBatchesAffectingQuery()', async () => {
+  it('can getAllMutationBatchesAffectingQuery()', async () => {
     const mutations = [
       setMutation('fob/bar', { a: 1 }),
       setMutation('foo/bar', { a: 1 }),
@@ -399,7 +398,7 @@ function genericMutationQueueTests() {
     expectEqualArrays(matches, expected);
   });
 
-  asyncIt(
+  it(
     'can getAllMutationBatchesAffectingQuery() with compound batches',
     async () => {
       const value = { a: 1 };
@@ -420,7 +419,7 @@ function genericMutationQueueTests() {
     }
   );
 
-  asyncIt(
+  it(
     'can emits garbage events while removing mutation batches',
     async () => {
       const gc = new EagerGarbageCollector();
@@ -463,7 +462,7 @@ function genericMutationQueueTests() {
     }
   );
 
-  asyncIt('can save the last stream token', async () => {
+  it('can save the last stream token', async () => {
     const streamToken1 = 'token1';
     const streamToken2 = 'token2';
 
@@ -485,7 +484,7 @@ function genericMutationQueueTests() {
     );
   });
 
-  asyncIt('can removeMutationBatches()', async () => {
+  it('can removeMutationBatches()', async () => {
     const batches = await createBatches(10);
     const last = batches[batches.length - 1];
 

--- a/packages/firestore/test/unit/local/query_cache.test.ts
+++ b/packages/firestore/test/unit/local/query_cache.test.ts
@@ -25,7 +25,6 @@ import { Persistence } from '../../../src/local/persistence';
 import { QueryData, QueryPurpose } from '../../../src/local/query_data';
 import { addEqualityMatcher } from '../../util/equality_matcher';
 import {
-  asyncIt,
   filter,
   key,
   path,
@@ -108,17 +107,17 @@ function genericQueryCacheTests() {
     cache = new TestQueryCache(persistence, persistence.getQueryCache());
   });
 
-  asyncIt('returns null for query not in cache', () => {
+  it('returns null for query not in cache', () => {
     return cache.getQueryData(QUERY_ROOMS).then(queryData => {
       expect(queryData).to.equal(null);
     });
   });
 
-  asyncIt('can set and read a query', () => {
+  it('can set and read a query', () => {
     return setAndReadQuery(testQueryData(QUERY_ROOMS, 1, 1));
   });
 
-  asyncIt('handles canonical ID collisions', async () => {
+  it('handles canonical ID collisions', async () => {
     // Type information is currently lost in our canonicalID implementations so
     // this currently an easy way to force colliding canonicalIDs
     const q1 = Query.atPath(path('a')).addFilter(filter('foo', '==', 1));
@@ -148,12 +147,12 @@ function genericQueryCacheTests() {
     expect(await cache.getQueryData(q2)).to.equal(null);
   });
 
-  asyncIt('can set query to new value', async () => {
+  it('can set query to new value', async () => {
     await cache.addQueryData(testQueryData(QUERY_ROOMS, 1, 1));
     await setAndReadQuery(testQueryData(QUERY_ROOMS, 1, 2));
   });
 
-  asyncIt('can remove a query', async () => {
+  it('can remove a query', async () => {
     const queryData = testQueryData(QUERY_ROOMS, 1, 1);
     await cache.addQueryData(queryData);
     await cache.removeQueryData(queryData);
@@ -161,12 +160,12 @@ function genericQueryCacheTests() {
     expect(read).to.equal(null);
   });
 
-  asyncIt('can remove nonexistent query', () => {
+  it('can remove nonexistent query', () => {
     // no-op, but make sure it doesn't fail.
     return cache.removeQueryData(testQueryData(QUERY_ROOMS, 1, 1));
   });
 
-  asyncIt('can remove matching keys when a query is removed', async () => {
+  it('can remove matching keys when a query is removed', async () => {
     const rooms = testQueryData(QUERY_ROOMS, 1, 1);
     await cache.addQueryData(rooms);
 
@@ -186,7 +185,7 @@ function genericQueryCacheTests() {
     expect(await cache.containsKey(key2)).to.equal(false);
   });
 
-  asyncIt('adds or removes matching keys', async () => {
+  it('adds or removes matching keys', async () => {
     const k = key('foo/bar');
     expect(await cache.containsKey(k)).to.equal(false);
 
@@ -203,7 +202,7 @@ function genericQueryCacheTests() {
     expect(await cache.containsKey(k)).to.equal(false);
   });
 
-  asyncIt('can remove matching keys for a targetId', async () => {
+  it('can remove matching keys for a targetId', async () => {
     const key1 = key('foo/bar');
     const key2 = key('foo/baz');
     const key3 = key('foo/blah');
@@ -225,7 +224,7 @@ function genericQueryCacheTests() {
     expect(await cache.containsKey(key3)).to.equal(false);
   });
 
-  asyncIt('emits garbage collection events for removes', async () => {
+  it('emits garbage collection events for removes', async () => {
     const eagerGc = new EagerGarbageCollector();
     const testGc = new TestGarbageCollector(persistence, eagerGc);
     eagerGc.addGarbageSource(cache.cache);
@@ -257,7 +256,7 @@ function genericQueryCacheTests() {
     expect(await testGc.collectGarbage()).to.deep.equal([hall1, hall2]);
   });
 
-  asyncIt('can get matching keys for targetId', async () => {
+  it('can get matching keys for targetId', async () => {
     const key1 = key('foo/bar');
     const key2 = key('foo/baz');
     const key3 = key('foo/blah');
@@ -282,7 +281,7 @@ function genericQueryCacheTests() {
     ]);
   });
 
-  asyncIt('can get / set highestTargetId', async () => {
+  it('can get / set highestTargetId', async () => {
     expect(cache.getHighestTargetId()).to.deep.equal(0);
     const queryData1 = testQueryData(QUERY_ROOMS, 1);
 
@@ -322,7 +321,7 @@ function genericQueryCacheTests() {
     expect(otherCache.getHighestTargetId()).to.deep.equal(42);
   });
 
-  asyncIt('can get / set lastRemoteSnapshotVersion', () => {
+  it('can get / set lastRemoteSnapshotVersion', () => {
     expect(cache.getLastRemoteSnapshotVersion()).to.deep.equal(
       SnapshotVersion.MIN
     );

--- a/packages/firestore/test/unit/local/reference_set.test.ts
+++ b/packages/firestore/test/unit/local/reference_set.test.ts
@@ -16,10 +16,10 @@
 
 import { expect } from 'chai';
 import { ReferenceSet } from '../../../src/local/reference_set';
-import { asyncIt, expectSetToEqual, key } from '../../util/helpers';
+import { expectSetToEqual, key } from '../../util/helpers';
 
 describe('ReferenceSet', () => {
-  asyncIt('can add/remove references', async () => {
+  it('can add/remove references', async () => {
     const documentKey = key('foo/bar');
 
     const refSet = new ReferenceSet();
@@ -51,7 +51,7 @@ describe('ReferenceSet', () => {
     expect(refSet.isEmpty()).to.equal(true);
   });
 
-  asyncIt('can remove all references for a target ID', async () => {
+  it('can remove all references for a target ID', async () => {
     const key1 = key('foo/bar');
     const key2 = key('foo/baz');
     const key3 = key('foo/blah');

--- a/packages/firestore/test/unit/local/remote_document_cache.test.ts
+++ b/packages/firestore/test/unit/local/remote_document_cache.test.ts
@@ -20,7 +20,6 @@ import { IndexedDbPersistence } from '../../../src/local/indexeddb_persistence';
 import { Persistence } from '../../../src/local/persistence';
 import { MaybeDocument } from '../../../src/model/document';
 import {
-  asyncIt,
   deletedDoc,
   doc,
   expectEqual,
@@ -92,31 +91,31 @@ function genericRemoteDocumentCacheTests() {
     );
   });
 
-  asyncIt('returns null for document not in cache', () => {
+  it('returns null for document not in cache', () => {
     return cache.getEntry(key(DOC_PATH)).then(doc => {
       expect(doc).to.equal(null);
     });
   });
 
-  asyncIt('can set and read a document', () => {
+  it('can set and read a document', () => {
     return setAndReadDocument(doc(DOC_PATH, VERSION, DOC_DATA));
   });
 
-  asyncIt('can set and read a document at a long path', () => {
+  it('can set and read a document at a long path', () => {
     return setAndReadDocument(doc(LONG_DOC_PATH, VERSION, DOC_DATA));
   });
 
-  asyncIt('can set and read a NoDocument', () => {
+  it('can set and read a NoDocument', () => {
     return setAndReadDocument(deletedDoc(DOC_PATH, VERSION));
   });
 
-  asyncIt('can set document to new value', () => {
+  it('can set document to new value', () => {
     return cache.addEntry(doc(DOC_PATH, VERSION, DOC_DATA)).then(() => {
       return setAndReadDocument(doc(DOC_PATH, VERSION + 1, { data: 2 }));
     });
   });
 
-  asyncIt('can remove document', () => {
+  it('can remove document', () => {
     return cache
       .addEntry(doc(DOC_PATH, VERSION, DOC_DATA))
       .then(() => {
@@ -130,12 +129,12 @@ function genericRemoteDocumentCacheTests() {
       });
   });
 
-  asyncIt('can remove nonexistent document', () => {
+  it('can remove nonexistent document', () => {
     // no-op, but make sure it doesn't fail.
     return cache.removeEntry(key(DOC_PATH));
   });
 
-  asyncIt('can get documents matching query', () => {
+  it('can get documents matching query', () => {
     // TODO(mikelehen): This just verifies that we do a prefix scan against the
     // query path. We'll need more tests once we add index support.
     return cache

--- a/packages/firestore/test/unit/local/remote_document_cache.test.ts
+++ b/packages/firestore/test/unit/local/remote_document_cache.test.ts
@@ -19,13 +19,7 @@ import { Query } from '../../../src/core/query';
 import { IndexedDbPersistence } from '../../../src/local/indexeddb_persistence';
 import { Persistence } from '../../../src/local/persistence';
 import { MaybeDocument } from '../../../src/model/document';
-import {
-  deletedDoc,
-  doc,
-  expectEqual,
-  key,
-  path
-} from '../../util/helpers';
+import { deletedDoc, doc, expectEqual, key, path } from '../../util/helpers';
 
 import * as persistenceHelpers from './persistence_test_helpers';
 import { TestRemoteDocumentCache } from './test_remote_document_cache';

--- a/packages/firestore/test/unit/local/remote_document_change_buffer.test.ts
+++ b/packages/firestore/test/unit/local/remote_document_change_buffer.test.ts
@@ -18,7 +18,7 @@ import { expect } from 'chai';
 import { IndexedDbPersistence } from '../../../src/local/indexeddb_persistence';
 import { Persistence } from '../../../src/local/persistence';
 import { RemoteDocumentChangeBuffer } from '../../../src/local/remote_document_change_buffer';
-import { asyncIt, deletedDoc, doc, expectEqual, key } from '../../util/helpers';
+import { deletedDoc, doc, expectEqual, key } from '../../util/helpers';
 
 import { testIndexedDbPersistence } from './persistence_test_helpers';
 import { TestRemoteDocumentCache } from './test_remote_document_cache';
@@ -58,18 +58,18 @@ describe('RemoteDocumentChangeBuffer', () => {
     return persistence.shutdown();
   });
 
-  asyncIt('can read unchanged entry', async () => {
+  it('can read unchanged entry', async () => {
     const maybeDoc = await buffer.getEntry(key('coll/a'));
     expectEqual(maybeDoc, INITIAL_DOC);
   });
 
-  asyncIt('can add entry and read it back', async () => {
+  it('can add entry and read it back', async () => {
     const newADoc = doc('coll/a', 43, { new: 'data' });
     buffer.addEntry(newADoc);
     expectEqual(await buffer.getEntry(key('coll/a')), newADoc);
   });
 
-  asyncIt('can apply changes', async () => {
+  it('can apply changes', async () => {
     const newADoc = doc('coll/a', 43, { new: 'data' });
     buffer.addEntry(newADoc);
     expectEqual(await buffer.getEntry(key('coll/a')), newADoc);
@@ -82,7 +82,7 @@ describe('RemoteDocumentChangeBuffer', () => {
     expectEqual(await cache.getEntry(key('coll/a')), newADoc);
   });
 
-  asyncIt('methods fail after apply.', async () => {
+  it('methods fail after apply.', async () => {
     await buffer.apply();
 
     expect(() => buffer.addEntry(INITIAL_DOC)).to.throw();

--- a/packages/firestore/test/unit/local/simple_db.test.ts
+++ b/packages/firestore/test/unit/local/simple_db.test.ts
@@ -16,7 +16,6 @@
 
 import { expect } from 'chai';
 import { SimpleDb } from '../../../src/local/simple_db';
-import { asyncIt } from '../../util/helpers';
 
 import { PersistencePromise } from '../../../src/local/persistence_promise';
 import {
@@ -97,7 +96,7 @@ describe('SimpleDb', () => {
     db.close();
   });
 
-  asyncIt('can get', async () => {
+  it('can get', async () => {
     await runTransaction(store => {
       return store
         .get(42)
@@ -111,7 +110,7 @@ describe('SimpleDb', () => {
     });
   });
 
-  asyncIt('can put', async () => {
+  it('can put', async () => {
     await runTransaction(store => {
       return store.put(dummyUser);
     });
@@ -122,7 +121,7 @@ describe('SimpleDb', () => {
     });
   });
 
-  asyncIt('lets you explicitly abort transactions', async () => {
+  it('lets you explicitly abort transactions', async () => {
     await runTransaction((store, txn) => {
       return store.put(dummyUser).next(() => {
         txn.abort(); // JUST KIDDING!
@@ -136,7 +135,7 @@ describe('SimpleDb', () => {
     });
   });
 
-  asyncIt('aborts transactions when an error happens', async () => {
+  it('aborts transactions when an error happens', async () => {
     let gotError = false;
     try {
       await runTransaction(store => {
@@ -157,7 +156,7 @@ describe('SimpleDb', () => {
     });
   });
 
-  asyncIt(
+  it(
     'still propagates error if you throw after aborting an exception.',
     async () => {
       let gotError = false;
@@ -182,7 +181,7 @@ describe('SimpleDb', () => {
     }
   );
 
-  asyncIt('can delete', async () => {
+  it('can delete', async () => {
     await runTransaction(store => {
       return store.delete(3);
     });
@@ -194,7 +193,7 @@ describe('SimpleDb', () => {
     });
   });
 
-  asyncIt('loadAll', async () => {
+  it('loadAll', async () => {
     const range = IDBKeyRange.bound(3, 5);
     await runTransaction(store => {
       return store.loadAll(range).next(users => {
@@ -220,7 +219,7 @@ describe('SimpleDb', () => {
     });
   });
 
-  asyncIt('deleteAll', async () => {
+  it('deleteAll', async () => {
     await runTransaction(store => {
       return store
         .deleteAll()
@@ -233,7 +232,7 @@ describe('SimpleDb', () => {
     });
   });
 
-  asyncIt('deleteAll in key range', async () => {
+  it('deleteAll in key range', async () => {
     const range = IDBKeyRange.bound(3, 5);
     await runTransaction(store => {
       return store
@@ -249,7 +248,7 @@ describe('SimpleDb', () => {
     });
   });
 
-  asyncIt('deleteAll in index range', async () => {
+  it('deleteAll in index range', async () => {
     const indexRange = IDBKeyRange.bound([8], [10, 're']);
     await runTransaction(store => {
       return store
@@ -265,7 +264,7 @@ describe('SimpleDb', () => {
     });
   });
 
-  asyncIt('can iterate', async () => {
+  it('can iterate', async () => {
     return runTransaction(store => {
       const iterated: User[] = [];
       return store
@@ -278,7 +277,7 @@ describe('SimpleDb', () => {
     });
   });
 
-  asyncIt('can iterate and skip keys', async () => {
+  it('can iterate and skip keys', async () => {
     return runTransaction(store => {
       const iterated: User[] = [];
       // Just pull out all the even keys
@@ -293,7 +292,7 @@ describe('SimpleDb', () => {
     });
   });
 
-  asyncIt('can iterate in reverse', async () => {
+  it('can iterate in reverse', async () => {
     return runTransaction(store => {
       const iterated: User[] = [];
       return store
@@ -308,7 +307,7 @@ describe('SimpleDb', () => {
     });
   });
 
-  asyncIt('can iterate and skip keys in reverse', async () => {
+  it('can iterate and skip keys in reverse', async () => {
     return runTransaction(store => {
       const iterated: User[] = [];
       // Only get the odd keys
@@ -325,7 +324,7 @@ describe('SimpleDb', () => {
     });
   });
 
-  asyncIt('can iterate and skip over the index', async () => {
+  it('can iterate and skip over the index', async () => {
     return runTransaction(store => {
       const range = IDBKeyRange.lowerBound([10, 'greg']);
       const iterated: User[] = [];
@@ -348,7 +347,7 @@ describe('SimpleDb', () => {
     });
   });
 
-  asyncIt('can iterate using index and range and stop before end', async () => {
+  it('can iterate using index and range and stop before end', async () => {
     return runTransaction(store => {
       const range = IDBKeyRange.lowerBound([10, 'greg']);
       const iterated: User[] = [];
@@ -368,7 +367,7 @@ describe('SimpleDb', () => {
     });
   });
 
-  asyncIt('can iterate over index as keys-only', () => {
+  it('can iterate over index as keys-only', () => {
     return runTransaction(store => {
       const iterated: number[] = [];
       return store
@@ -391,7 +390,7 @@ describe('SimpleDb', () => {
     });
   });
 
-  asyncIt('can iterate over index using a partial bound', () => {
+  it('can iterate over index using a partial bound', () => {
     return runTransaction(store => {
       // All the users at least 10 but less than 11.
       const range = IDBKeyRange.bound([10], [11], false, true);
@@ -413,7 +412,7 @@ describe('SimpleDb', () => {
     });
   });
 
-  asyncIt('can use arrays as keys and do partial bounds ranges', async () => {
+  it('can use arrays as keys and do partial bounds ranges', async () => {
     const keys = [
       ['fo'],
       ['foo'],

--- a/packages/firestore/test/unit/local/simple_db.test.ts
+++ b/packages/firestore/test/unit/local/simple_db.test.ts
@@ -156,30 +156,27 @@ describe('SimpleDb', () => {
     });
   });
 
-  it(
-    'still propagates error if you throw after aborting an exception.',
-    async () => {
-      let gotError = false;
-      try {
-        await runTransaction((store, txn) => {
-          return store.put(dummyUser).next(() => {
-            txn.abort();
-            throw new Error('error');
-          });
-        });
-      } catch (error) {
-        expect(error.message).to.equal('error');
-        gotError = true;
-      }
-      expect(gotError).to.equal(true);
-
-      await runTransaction(store => {
-        return store.get(dummyUser.id).next(user => {
-          expect(user).to.deep.equal(null);
+  it('still propagates error if you throw after aborting an exception.', async () => {
+    let gotError = false;
+    try {
+      await runTransaction((store, txn) => {
+        return store.put(dummyUser).next(() => {
+          txn.abort();
+          throw new Error('error');
         });
       });
+    } catch (error) {
+      expect(error.message).to.equal('error');
+      gotError = true;
     }
-  );
+    expect(gotError).to.equal(true);
+
+    await runTransaction(store => {
+      return store.get(dummyUser.id).next(user => {
+        expect(user).to.deep.equal(null);
+      });
+    });
+  });
 
   it('can delete', async () => {
     await runTransaction(store => {

--- a/packages/firestore/test/unit/specs/describe_spec.ts
+++ b/packages/firestore/test/unit/specs/describe_spec.ts
@@ -17,7 +17,6 @@
 import { IndexedDbPersistence } from '../../../src/local/indexeddb_persistence';
 import { assert } from '../../../src/util/assert';
 import { addEqualityMatcher } from '../../util/equality_matcher';
-import { asyncIt, fasyncIt, xasyncIt } from '../../util/helpers';
 
 import { SpecBuilder } from './spec_builder';
 import { SpecStep } from './spec_test_runner';
@@ -71,13 +70,13 @@ export function setSpecJSONHandler(writer: (json: string) => void) {
 }
 
 /**
- * Like asyncIt, but for spec tests.
+ * Like it(), but for spec tests.
  * @param name A name to give the test.
  * @param tags Tags to apply to the test (e.g. 'exclusive' to only run
  *             individual tests)
  * @param builder A function that returns a spec.
  * If writeToJSONFile has been called, the spec will be stored in
- * `specsInThisTest`. Otherwise, it will be run, just as asyncIt would run it.
+ * `specsInThisTest`. Otherwise, it will be run, just as it() would run it.
  */
 export function specTest(
   name: string,
@@ -101,11 +100,11 @@ export function specTest(
       const spec = builder();
       let runner: Function;
       if (tags.indexOf(EXCLUSIVE_TAG) >= 0) {
-        runner = fasyncIt;
+        runner = it.only;
       } else if (!WEB_SPEC_TEST_FILTER(tags)) {
-        runner = xasyncIt;
+        runner = it.skip;
       } else {
-        runner = asyncIt;
+        runner = it;
       }
       const mode = usePersistence ? '(Persistence)' : '(Memory)';
       const fullName = `${mode} ${name}`;
@@ -139,7 +138,7 @@ export function specTest(
  * @param name A name to give the test.
  * @param tags Tags to apply to all tests in the spec (e.g. 'exclusive' to
  *             only run individual tests)
- * @param builder A function that calls specAsyncIt for each test case.
+ * @param builder A function that calls specTest for each test case.
  * If writeToJSONFile has been called, the specs will be stored in
  * that file. Otherwise, they will be run, just as describe would run.
  */

--- a/packages/firestore/test/util/helpers.ts
+++ b/packages/firestore/test/util/helpers.ts
@@ -473,69 +473,6 @@ type MochaTestRunner = (
 ) => Mocha.ITest;
 
 /**
- * Wrapper for Async (Promise-returning) tests.
- * TODO(b/66916896): This was necessary when we used Jasmine but should now be
- * removed since Mocha supports Promises directly.
- *
- * @example
- *
- *   asyncIt('can do anything', () => {
- *     ...
- *   });
- *
- *   You can optionally specify a timeout as the 3rd argument to override
- *   the default timeout.
- */
-export function asyncIt(
-  message: string,
-  testFunction: () => Promise<AnyJs | void>,
-  timeout?: number
-): void {
-  asyncItHelper(it, message, testFunction, timeout);
-}
-
-/**
- * Same as asyncIt() except it uses it.only() instead of it(), which runs only
- * this test and no others (useful when debugging a test failure).
- */
-export function fasyncIt(
-  message: string,
-  testFunction: () => Promise<AnyJs | void>,
-  timeout?: number
-): void {
-  asyncItHelper(it.only, message, testFunction, timeout);
-}
-
-/**
- * Same as asyncIt() except it uses xit() instead of it(), which disables this
- * test.
- */
-export function xasyncIt(
-  message: string,
-  testFunction: () => Promise<AnyJs | void>,
-  timeout?: number
-): void {
-  asyncItHelper(xit, message, testFunction, timeout);
-}
-
-function asyncItHelper(
-  testRunner: MochaTestRunner,
-  message: string,
-  testFunction: () => Promise<AnyJs | void>,
-  timeout?: number
-): void {
-  testRunner(message, () => {
-    if (timeout) {
-      this.timeout(timeout);
-    }
-    const result = testFunction();
-    // Should return a Thenable
-    expect(typeof result.then).to.equal('function');
-    return result;
-  });
-}
-
-/**
  * Two helper functions to simplify testing equals() method.
  */
 // tslint:disable-next-line:no-any so we can dynamically call .equals().


### PR DESCRIPTION
A few tests got re-indented by the code formatter. You can just look at the first commit to exclude those if you want.