### PR TITLE
Firestore: in tests, fix SpecWatchFilter type to work on upcoming Typescript 2.7

### DIFF
--- a/packages/firestore/test/unit/specs/spec_test_runner.ts
+++ b/packages/firestore/test/unit/specs/spec_test_runner.ts
@@ -1190,7 +1190,10 @@ export interface SpecWatchEntity {
  * Note that the last parameter is really of type ...string (spread operator)
  * The filter is based of a list of keys to match in the existence filter
  */
-export type SpecWatchFilter = [TargetId[], string];
+export interface SpecWatchFilter extends Array<TargetId[] | string> {
+    '0': TargetId[];
+    '1'?: string;
+}
 
 /**
  * [field, op, value]

--- a/packages/firestore/test/unit/specs/spec_test_runner.ts
+++ b/packages/firestore/test/unit/specs/spec_test_runner.ts
@@ -1191,8 +1191,8 @@ export interface SpecWatchEntity {
  * The filter is based of a list of keys to match in the existence filter
  */
 export interface SpecWatchFilter extends Array<TargetId[] | string> {
-    '0': TargetId[];
-    '1'?: string;
+  '0': TargetId[];
+  '1'?: string;
 }
 
 /**


### PR DESCRIPTION
Fixes #309

Previously, the type SpecWatchFilter in spec_test_runner was specified as a tuple, but it was later used with `push` and is actually an array with a first element that is guaranteed to be present, and of type TargetId[].

In Typescript 2.7, tuples will be fixed-length and this usage will fail.  This changes the definition of SpecWatchFilter to an interface that extends Array<TargetId[] | string> and whose required '0' property is a TargetId[].