### PR TITLE
b/68251551: Send headers via URL Param to avoid CORS preflight round-trip.

### DIFF
--- a/packages/firestore/CHANGELOG.md
+++ b/packages/firestore/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Unreleased
 
+# v0.1.4
+- [changed] Network streams are automatically closed after 60 seconds of
+  idleness.
+- [changed] We no longer log 'RPC failed' messages for expected failures.
+
 # v0.1.2
+- [changed] We now support `FieldValue.delete()` sentinels in `set()` calls
+  with `{merge:true}`.
 - [fixed] Fixed validation of nested arrays to allow indirect nesting
 
 # v0.1.1

--- a/packages/firestore/src/platform_browser/webchannel_connection.ts
+++ b/packages/firestore/src/platform_browser/webchannel_connection.ts
@@ -204,7 +204,8 @@ export class WebChannelConnection implements Connection {
       httpSessionIdParam: 'gsessionid',
       initMessageHeaders: {},
       // Send our custom headers as a '$httpHeaders=' url param to avoid CORS
-      // preflight round-trip.
+      // preflight round-trip. This is formally defined here:
+      // https://github.com/google/closure-library/blob/b0e1815b13fb92a46d7c9b3c30de5d6a396a3245/closure/goog/net/rpc/httpcors.js#L40
       httpHeadersOverwriteParam: '$httpHeaders',
       sendRawJson: true,
       supportsCrossDomainXhr: true

--- a/packages/firestore/src/platform_browser/webchannel_connection.ts
+++ b/packages/firestore/src/platform_browser/webchannel_connection.ts
@@ -203,6 +203,9 @@ export class WebChannelConnection implements Connection {
       // parameter.
       httpSessionIdParam: 'gsessionid',
       initMessageHeaders: {},
+      // Send our custom headers as a '$httpHeaders=' url param to avoid CORS
+      // preflight round-trip.
+      httpHeadersOverwriteParam: '$httpHeaders',
       sendRawJson: true,
       supportsCrossDomainXhr: true
     };


### PR DESCRIPTION
I verified that our Authorization header is sent via the the '$httpHeaders' URL parameter now, the OPTIONS network round-trip no longer occurs, and our authentication token is still correctly respected by the backend.