### PR TITLE
Firestore log offline warning

### DIFF
--- a/packages/firestore/src/remote/remote_store.ts
+++ b/packages/firestore/src/remote/remote_store.ts
@@ -185,6 +185,9 @@ export class RemoteStore {
     const didChange = this.watchStreamOnlineState !== onlineState;
     this.watchStreamOnlineState = onlineState;
     if (didChange) {
+      if (onlineState == OnlineState.Failed) {
+        log.debug(LOG_TAG, 'Could not reach Firestore backend');
+      }
       this.onlineStateHandler(onlineState);
     }
   }

--- a/packages/firestore/src/remote/remote_store.ts
+++ b/packages/firestore/src/remote/remote_store.ts
@@ -128,6 +128,9 @@ export class RemoteStore {
   /** A count of consecutive failures to open the stream. */
   private watchStreamFailures = 0;
 
+  /** Whether the client should fire offline warning. */
+  private boolean shouldWarnOffline = true;
+
   constructor(
     private databaseInfo: DatabaseInfo,
     private asyncQueue: AsyncQueue,
@@ -153,6 +156,7 @@ export class RemoteStore {
   }
 
   private setOnlineStateToHealthy(): void {
+    this.shouldWarnOffline = false;
     this.updateAndBroadcastOnlineState(OnlineState.Healthy);
   }
 
@@ -176,6 +180,10 @@ export class RemoteStore {
     } else {
       this.watchStreamFailures++;
       if (this.watchStreamFailures >= ONLINE_ATTEMPTS_BEFORE_FAILURE) {
+        if (this.shouldWarnOffline) {
+          log.debug(LOG_TAG, 'Could not reach Firestore backend.');
+          this.shouldWarnOffline = false;
+        }
         this.updateAndBroadcastOnlineState(OnlineState.Failed);
       }
     }
@@ -185,9 +193,6 @@ export class RemoteStore {
     const didChange = this.watchStreamOnlineState !== onlineState;
     this.watchStreamOnlineState = onlineState;
     if (didChange) {
-      if (onlineState == OnlineState.Failed) {
-        log.debug(LOG_TAG, 'Could not reach Firestore backend');
-      }
       this.onlineStateHandler(onlineState);
     }
   }

--- a/packages/firestore/src/remote/remote_store.ts
+++ b/packages/firestore/src/remote/remote_store.ts
@@ -129,7 +129,7 @@ export class RemoteStore {
   private watchStreamFailures = 0;
 
   /** Whether the client should fire offline warning. */
-  private boolean shouldWarnOffline = true;
+  private shouldWarnOffline = true;
 
   constructor(
     private databaseInfo: DatabaseInfo,

--- a/packages/firestore/src/remote/remote_store.ts
+++ b/packages/firestore/src/remote/remote_store.ts
@@ -128,9 +128,6 @@ export class RemoteStore {
   /** A count of consecutive failures to open the stream. */
   private watchStreamFailures = 0;
 
-  /** Whether the client should fire offline warning. */
-  private boolean shouldWarnOffline = true;
-
   constructor(
     private databaseInfo: DatabaseInfo,
     private asyncQueue: AsyncQueue,
@@ -156,7 +153,6 @@ export class RemoteStore {
   }
 
   private setOnlineStateToHealthy(): void {
-    this.shouldWarnOffline = false;
     this.updateAndBroadcastOnlineState(OnlineState.Healthy);
   }
 
@@ -180,10 +176,6 @@ export class RemoteStore {
     } else {
       this.watchStreamFailures++;
       if (this.watchStreamFailures >= ONLINE_ATTEMPTS_BEFORE_FAILURE) {
-        if (this.shouldWarnOffline) {
-          log.debug(LOG_TAG, 'Could not reach Firestore backend.');
-          this.shouldWarnOffline = false;
-        }
         this.updateAndBroadcastOnlineState(OnlineState.Failed);
       }
     }
@@ -193,6 +185,9 @@ export class RemoteStore {
     const didChange = this.watchStreamOnlineState !== onlineState;
     this.watchStreamOnlineState = onlineState;
     if (didChange) {
+      if (onlineState == OnlineState.Failed) {
+        log.debug(LOG_TAG, 'Could not reach Firestore backend');
+      }
       this.onlineStateHandler(onlineState);
     }
   }


### PR DESCRIPTION
Firestore log offline warning

### Discussion
To avoid surprise by adding a warning. Right now, when offline, empty result is returned with no log nor error, see https://groups.google.com/forum/#!topic/google-cloud-firestore-discuss/puFl9HVU57I/discussion

### Testing
Tests pass. No new test required.

### API Changes
API review approved by all platform owners.