### PR TITLE
b/68276665: Raise isFromCache=true events when offline

### DIFF
--- a/packages/firestore/CHANGELOG.md
+++ b/packages/firestore/CHANGELOG.md
@@ -1,4 +1,11 @@
 # Unreleased
+- [changed] Snapshot listeners (with the `includeMetadataChanges` option
+  enabled) now receive an event with `snapshot.metadata.fromCache` set to
+  `true` if the SDK loses its connection to the backend. A new event with
+  `snapshot.metadata.fromCache` set to false will be raised once the
+  connection is restored and the query is in sync with the backend again.
+
+# v0.2.0
 - [feature] Added Node.js support for Cloud Firestore (with the exception of
   the offline persistence feature).
 - [changed] Webchannel requests use $httpHeaders URL parameter rather than

--- a/packages/firestore/CHANGELOG.md
+++ b/packages/firestore/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# Unreleased (firestore-api-changes)
 - [changed] Snapshot listeners (with the `includeMetadataChanges` option
   enabled) now receive an event with `snapshot.metadata.fromCache` set to
   `true` if the SDK loses its connection to the backend. A new event with

--- a/packages/firestore/src/core/firestore_client.ts
+++ b/packages/firestore/src/core/firestore_client.ts
@@ -282,6 +282,7 @@ export class FirestoreClient {
         );
 
         const onlineStateChangedHandler = (onlineState: OnlineState) => {
+          this.syncEngine.applyOnlineStateChange(onlineState);
           this.eventMgr.onOnlineStateChanged(onlineState);
         };
 

--- a/packages/firestore/src/core/sync_engine.ts
+++ b/packages/firestore/src/core/sync_engine.ts
@@ -350,13 +350,13 @@ export class SyncEngine implements RemoteSyncer {
   applyOnlineStateChange(onlineState: OnlineState) {
     const newViewSnapshots = [] as ViewSnapshot[];
     this.queryViewsByQuery.forEach((_, queryView) => {
-      const viewSnap = queryView.view.applyOnlineStateChange(onlineState);
+      const viewChange = queryView.view.applyOnlineStateChange(onlineState);
       assert(
-        viewSnap.limboChanges.length === 0,
+        viewChange.limboChanges.length === 0,
         'OnlineState should not affect limbo documents.'
       );
-      if (viewSnap.snapshot) {
-        newViewSnapshots.push(viewSnap.snapshot);
+      if (viewChange.snapshot) {
+        newViewSnapshots.push(viewChange.snapshot);
       }
     });
     this.viewHandler(newViewSnapshots);

--- a/packages/firestore/src/core/sync_engine.ts
+++ b/packages/firestore/src/core/sync_engine.ts
@@ -42,7 +42,7 @@ import { Query } from './query';
 import { SnapshotVersion } from './snapshot_version';
 import { TargetIdGenerator } from './target_id_generator';
 import { Transaction } from './transaction';
-import { BatchId, ProtoByteString, TargetId, OnlineState } from './types';
+import { BatchId, OnlineState, ProtoByteString, TargetId } from './types';
 import {
   AddedLimboDocument,
   LimboDocumentChange,
@@ -349,7 +349,7 @@ export class SyncEngine implements RemoteSyncer {
    */
   applyOnlineStateChange(onlineState: OnlineState) {
     const newViewSnapshots = [] as ViewSnapshot[];
-    this.queryViewsByQuery.forEach((_, queryView) => {
+    this.queryViewsByQuery.forEach((query, queryView) => {
       const viewChange = queryView.view.applyOnlineStateChange(onlineState);
       assert(
         viewChange.limboChanges.length === 0,

--- a/packages/firestore/src/core/types.ts
+++ b/packages/firestore/src/core/types.ts
@@ -34,22 +34,22 @@ export type ProtoByteString = Uint8Array | string;
 export enum OnlineState {
   /**
    * The Firestore client is in an unknown online state. This means the client
-   * is either not actively trying to establish a connection or it was
-   * previously in an unknown state and is trying to establish a connection.
+   * is either not actively trying to establish a connection or it is currently
+   * trying to establish a connection, but it has not succeeded or failed yet.
    */
   Unknown,
 
   /**
    * The client is connected and the connections are healthy. This state is
    * reached after a successful connection and there has been at least one
-   * succesful message received from the backends.
+   * successful message received from the backends.
    */
   Healthy,
 
   /**
-   * The client has tried to establish a connection but has failed.
-   * This state is reached after either a connection attempt failed or a
-   * healthy stream was closed for unexpected reasons.
+   * The client considers itself offline. It is either trying to establish a
+   * connection but failing, or it has been explicitly marked offline via a call
+   * to disableNetwork().
    */
   Failed
 }

--- a/packages/firestore/src/core/view.ts
+++ b/packages/firestore/src/core/view.ts
@@ -31,13 +31,13 @@ import {
 import { assert, fail } from '../util/assert';
 
 import { Query } from './query';
+import { OnlineState } from './types';
 import {
   ChangeType,
   DocumentChangeSet,
   SyncState,
   ViewSnapshot
 } from './view_snapshot';
-import { OnlineState } from './types';
 
 export type LimboDocumentChange = AddedLimboDocument | RemovedLimboDocument;
 export class AddedLimboDocument {

--- a/packages/firestore/src/core/view.ts
+++ b/packages/firestore/src/core/view.ts
@@ -37,6 +37,7 @@ import {
   SyncState,
   ViewSnapshot
 } from './view_snapshot';
+import { OnlineState } from './types';
 
 export type LimboDocumentChange = AddedLimboDocument | RemovedLimboDocument;
 export class AddedLimboDocument {
@@ -50,7 +51,7 @@ export class RemovedLimboDocument {
 export interface ViewDocumentChanges {
   /** The new set of docs that should be in the view. */
   documentSet: DocumentSet;
-  /** The diff of this these docs with the previous set of docs. */
+  /** The diff of these docs with the previous set of docs. */
   changeSet: DocumentChangeSet;
   /**
    * Whether the set of documents passed in was not sufficient to calculate the
@@ -265,6 +266,29 @@ export class View {
         },
         limboChanges
       };
+    }
+  }
+
+  /**
+   * Applies an OnlineState change to the view, potentially generating a
+   * ViewChange if the view's syncState changes as a result.
+   */
+  applyOnlineStateChange(onlineState: OnlineState): ViewChange {
+    if (this.current && onlineState === OnlineState.Failed) {
+      // If we're offline, set `current` to false and then call applyChanges()
+      // to refresh our syncState and generate a ViewChange as appropriate. We
+      // are guaranteed to get a new TargetChange that sets `current` back to
+      // true once the client is back online.
+      this.current = false;
+      return this.applyChanges({
+        documentSet: this.documentSet,
+        changeSet: new DocumentChangeSet(),
+        mutatedKeys: this.mutatedKeys,
+        needsRefill: false
+      });
+    } else {
+      // No effect, just return a no-op ViewChange.
+      return { limboChanges: [] };
     }
   }
 

--- a/packages/firestore/src/remote/remote_store.ts
+++ b/packages/firestore/src/remote/remote_store.ts
@@ -255,8 +255,6 @@ export class RemoteStore {
   private disableNetworkInternal(
     targetOnlineState: OnlineState
   ): Promise<void> {
-    this.updateOnlineState(targetOnlineState);
-
     // NOTE: We're guaranteed not to get any further events from these streams (not even a close
     // event).
     this.watchStream.stop();
@@ -267,6 +265,8 @@ export class RemoteStore {
 
     this.writeStream = null;
     this.watchStream = null;
+
+    this.updateOnlineState(targetOnlineState);
 
     return Promise.resolve();
   }

--- a/packages/firestore/src/remote/remote_store.ts
+++ b/packages/firestore/src/remote/remote_store.ts
@@ -155,28 +155,41 @@ export class RemoteStore {
     return this.enableNetwork();
   }
 
-  private setOnlineStateToHealthy(): void {
-    this.shouldWarnOffline = false;
-    this.updateAndBroadcastOnlineState(OnlineState.Healthy);
+  /**
+   * Updates our OnlineState to the new state, updating local state
+   * and notifying the onlineStateHandler as appropriate.
+   */
+  private updateOnlineState(newState: OnlineState) {
+    if (newState === OnlineState.Healthy) {
+      // We've connected to watch at least once. Don't warn the developer about
+      // being offline going forward.
+      this.shouldWarnOffline = false;
+    } else if (newState === OnlineState.Unknown) {
+      // The state is set to unknown when a healthy stream is closed (e.g. due to
+      // a token timeout) or when we have no active listens and therefore there's
+      // no need to start the stream. Assuming there is (possibly in the future)
+      // an active listen, then we will eventually move to state Online or Failed,
+      // but we always want to make at least ONLINE_ATTEMPTS_BEFORE_FAILURE
+      // attempts before failing, so we reset the count here.
+      this.watchStreamFailures = 0;
+    }
+
+    // Update and broadcast the new state.
+    if (newState !== this.watchStreamOnlineState) {
+      this.watchStreamOnlineState = newState;
+      this.onlineStateHandler(newState);
+    }
   }
 
-  private setOnlineStateToUnknown(): void {
-    // The state is set to unknown when a healthy stream is closed (e.g. due to
-    // a token timeout) or when we have no active listens and therefore there's
-    // no need to start the stream. Assuming there is (possibly in the future)
-    // an active listen, then we will eventually move to state Online or Failed,
-    // but we always want to make at least ONLINE_ATTEMPTS_BEFORE_FAILURE
-    // attempts before failing, so we reset the count here.
-    this.watchStreamFailures = 0;
-    this.updateAndBroadcastOnlineState(OnlineState.Unknown);
-  }
-
+  /**
+   * Updates our OnlineState as appropriate after the watch stream reports a
+   * failure. The first failure moves us to the 'Unknown' state. We then may
+   * allow multiple failures (based on ONLINE_ATTEMPTS_BEFORE_FAILURE) before we
+   * actually transition to OnlineState.Failed.
+   */
   private updateOnlineStateAfterFailure(): void {
-    // The first failure after we are successfully connected moves us to the
-    // 'Unknown' state. We then may make multiple attempts (based on
-    // ONLINE_ATTEMPTS_BEFORE_FAILURE) before we actually report failure.
     if (this.watchStreamOnlineState === OnlineState.Healthy) {
-      this.setOnlineStateToUnknown();
+      this.updateOnlineState(OnlineState.Unknown);
     } else {
       this.watchStreamFailures++;
       if (this.watchStreamFailures >= ONLINE_ATTEMPTS_BEFORE_FAILURE) {
@@ -184,16 +197,8 @@ export class RemoteStore {
           log.debug(LOG_TAG, 'Could not reach Firestore backend.');
           this.shouldWarnOffline = false;
         }
-        this.updateAndBroadcastOnlineState(OnlineState.Failed);
+        this.updateOnlineState(OnlineState.Failed);
       }
-    }
-  }
-
-  private updateAndBroadcastOnlineState(onlineState: OnlineState): void {
-    const didChange = this.watchStreamOnlineState !== onlineState;
-    this.watchStreamOnlineState = onlineState;
-    if (didChange) {
-      this.onlineStateHandler(onlineState);
     }
   }
 
@@ -228,7 +233,7 @@ export class RemoteStore {
         this.startWatchStream();
       }
 
-      this.setOnlineStateToUnknown();
+      this.updateOnlineState(OnlineState.Unknown);
 
       return this.fillWritePipeline(); // This may start the writeStream.
     });
@@ -236,18 +241,21 @@ export class RemoteStore {
 
   /**
    * Temporarily disables the network. The network can be re-enabled using
-   * enableNetwork(). By default this will also update (and broadcast) our
-   * onlineState to OnlineState.Failed. If this should not happen (e.g. because
-   * this is being called as part of shutdown logic or because we're going to
-   * immediately re-enable the network), pass `true` for
-   * suppressOnlineStateFailure.
+   * enableNetwork().
    */
-  disableNetwork(suppressOnlineStateFailure?: boolean): Promise<void> {
-    if (suppressOnlineStateFailure) {
-      this.setOnlineStateToUnknown();
-    } else {
-      this.updateAndBroadcastOnlineState(OnlineState.Failed);
-    }
+  disableNetwork(): Promise<void> {
+    // Set the OnlineState to failed so get()'s return from cache, etc.
+    return this.disableNetworkInternal(OnlineState.Failed);
+  }
+
+  /**
+   * Disables the network, setting the OnlineState to the specified
+   * targetOnlineState.
+   */
+  private disableNetworkInternal(
+    targetOnlineState: OnlineState
+  ): Promise<void> {
+    this.updateOnlineState(targetOnlineState);
 
     // NOTE: We're guaranteed not to get any further events from these streams (not even a close
     // event).
@@ -265,7 +273,9 @@ export class RemoteStore {
 
   shutdown(): Promise<void> {
     log.debug(LOG_TAG, 'RemoteStore shutting down.');
-    this.disableNetwork(/*suppressOnlineStateFailure=*/ true);
+    // Set the OnlineState to Unknown (rather than Failed) to avoid potentially
+    // triggering spurious listener events with cached data, etc.
+    this.disableNetworkInternal(OnlineState.Unknown);
     return Promise.resolve(undefined);
   }
 
@@ -389,7 +399,7 @@ export class RemoteStore {
       // No need to restart watch stream because there are no active targets.
       // The online state is set to unknown because there is no active attempt
       // at establishing a connection
-      this.setOnlineStateToUnknown();
+      this.updateOnlineState(OnlineState.Unknown);
     }
     return Promise.resolve();
   }
@@ -399,7 +409,7 @@ export class RemoteStore {
     snapshotVersion: SnapshotVersion
   ): Promise<void> {
     // Mark the connection as healthy because we got a message from the server
-    this.setOnlineStateToHealthy();
+    this.updateOnlineState(OnlineState.Healthy);
 
     if (
       watchChange instanceof WatchTargetChange &&
@@ -812,7 +822,7 @@ export class RemoteStore {
     // Tear down and re-create our network streams. This will ensure we get a fresh auth token
     // for the new user and re-fill the write pipeline with new mutations from the LocalStore
     // (since mutations are per-user).
-    this.disableNetwork(/*suppressOnlineStateFailure=*/ true);
+    this.disableNetworkInternal(OnlineState.Unknown);
     return this.enableNetwork();
   }
 }

--- a/packages/firestore/test/unit/specs/listen_spec.test.ts
+++ b/packages/firestore/test/unit/specs/listen_spec.test.ts
@@ -253,6 +253,7 @@ describeSpec('Listens:', [], () => {
       .watchAcksFull(query, 1000, docA)
       .expectEvents(query, { added: [docA] })
       .disableNetwork()
+      .expectEvents(query, { fromCache: true })
       .enableNetwork()
       .restoreListen(query, 'resume-token-1000')
       .expectWatchStreamRequestCount(

--- a/packages/firestore/test/unit/specs/offline_spec.test.ts
+++ b/packages/firestore/test/unit/specs/offline_spec.test.ts
@@ -17,7 +17,7 @@
 import { expect } from 'chai';
 import { Query } from '../../../src/core/query';
 import { Code } from '../../../src/util/error';
-import { path, doc } from '../../util/helpers';
+import { doc, path } from '../../util/helpers';
 
 import { describeSpec, specTest } from './describe_spec';
 import { spec } from './spec_builder';

--- a/packages/firestore/test/unit/specs/offline_spec.test.ts
+++ b/packages/firestore/test/unit/specs/offline_spec.test.ts
@@ -17,7 +17,7 @@
 import { expect } from 'chai';
 import { Query } from '../../../src/core/query';
 import { Code } from '../../../src/util/error';
-import { path } from '../../util/helpers';
+import { path, doc } from '../../util/helpers';
 
 import { describeSpec, specTest } from './describe_spec';
 import { spec } from './spec_builder';
@@ -94,4 +94,25 @@ describeSpec('Offline:', [], () => {
       );
     }
   );
+
+  specTest('Queries revert to fromCache=true when offline.', [], () => {
+    const query = Query.atPath(path('collection'));
+    const docA = doc('collection/a', 1000, { key: 'a' });
+    return (
+      spec()
+        .userListens(query)
+        .watchAcksFull(query, 1000, docA)
+        .expectEvents(query, { added: [docA] })
+        // first error triggers unknown state
+        .watchStreamCloses(Code.UNAVAILABLE)
+        .restoreListen(query, 'resume-token-1000')
+        // getting two more errors triggers offline state and fromCache: true
+        .watchStreamCloses(Code.UNAVAILABLE)
+        .watchStreamCloses(Code.UNAVAILABLE)
+        .expectEvents(query, { fromCache: true })
+        // Going online and getting a CURRENT message triggers fromCache: false
+        .watchAcksFull(query, 1000)
+        .expectEvents(query, { fromCache: false })
+    );
+  });
 });

--- a/packages/firestore/test/unit/specs/spec_test_runner.ts
+++ b/packages/firestore/test/unit/specs/spec_test_runner.ts
@@ -384,6 +384,7 @@ abstract class TestRunner {
       initialBackoffDelay
     );
     const onlineStateChangedHandler = (onlineState: OnlineState) => {
+      this.syncEngine.applyOnlineStateChange(onlineState);
       this.eventManager.onOnlineStateChanged(onlineState);
     };
     this.remoteStore = new RemoteStore(
@@ -500,7 +501,10 @@ abstract class TestRunner {
 
     await this.queue.schedule(async () => {
       const targetId = await this.eventManager.listen(queryListener);
-      expect(targetId).to.equal(expectedTargetId);
+      expect(targetId).to.equal(
+        expectedTargetId,
+        'targetId assigned to listen'
+      );
     });
     // Open should always have happened after a listen
     await this.connection.waitForWatchOpen();


### PR DESCRIPTION
* Plumbs OnlineState changes through to views.
* View sets this.current to false on OnlineState.Failed, triggering
  isFromCache=true events. this.current will automatically be returned to true
  once the listen is reestablished and we get a new CURRENT message.
* Updated tests (and added new ones) to verify behavior.