### PR TITLE
Always log resource exhausted errors to console ...

### DIFF
--- a/packages/firestore/src/platform_browser/webchannel_connection.ts
+++ b/packages/firestore/src/platform_browser/webchannel_connection.ts
@@ -301,19 +301,10 @@ export class WebChannelConnection implements Connection {
         // can be removed once the fix has been rolled out.
         const error = msgData.error || (msgData[0] && msgData[0].error);
         if (error) {
+          log.debug(LOG_TAG, 'WebChannel received error:', error);
           // error.status will be a string like 'OK' or 'NOT_FOUND'.
           const status: string = error.status;
           let code = mapCodeFromRpcStatus(status);
-          if (code === Code.RESOURCE_EXHAUSTED) {
-            log.error(
-              LOG_TAG,
-              'WebChannel received resource exhausted error:',
-              error
-            );
-          } else {
-            log.debug(LOG_TAG, 'WebChannel received error:', error);
-          }
-
           let message = error.message;
           if (code === undefined) {
             code = Code.INTERNAL;

--- a/packages/firestore/src/platform_browser/webchannel_connection.ts
+++ b/packages/firestore/src/platform_browser/webchannel_connection.ts
@@ -301,10 +301,15 @@ export class WebChannelConnection implements Connection {
         // can be removed once the fix has been rolled out.
         const error = msgData.error || (msgData[0] && msgData[0].error);
         if (error) {
-          log.debug(LOG_TAG, 'WebChannel received error:', error);
           // error.status will be a string like 'OK' or 'NOT_FOUND'.
           const status: string = error.status;
           let code = mapCodeFromRpcStatus(status);
+          if (code === Code.RESOURCE_EXHAUSTED) {
+            log.error(LOG_TAG, 'WebChannel received resource exhausted error:', error);
+          } else {
+            log.debug(LOG_TAG, 'WebChannel received error:', error);
+          }
+
           let message = error.message;
           if (code === undefined) {
             code = Code.INTERNAL;

--- a/packages/firestore/src/platform_browser/webchannel_connection.ts
+++ b/packages/firestore/src/platform_browser/webchannel_connection.ts
@@ -305,7 +305,11 @@ export class WebChannelConnection implements Connection {
           const status: string = error.status;
           let code = mapCodeFromRpcStatus(status);
           if (code === Code.RESOURCE_EXHAUSTED) {
-            log.error(LOG_TAG, 'WebChannel received resource exhausted error:', error);
+            log.error(
+              LOG_TAG,
+              'WebChannel received resource exhausted error:',
+              error
+            );
           } else {
             log.debug(LOG_TAG, 'WebChannel received error:', error);
           }

--- a/packages/firestore/src/remote/persistent_stream.ts
+++ b/packages/firestore/src/remote/persistent_stream.ts
@@ -319,7 +319,7 @@ export abstract class PersistentStream<
       this.backoff.reset();
     } else if (error && error.code === Code.RESOURCE_EXHAUSTED) {
       // Log the error. (Probably either 'quota exceeded' or 'max queue length reached'.)
-      log.error(error);
+      log.error(error.toString());
       log.error(
         'Using maximum backoff delay to prevent overloading the backend.'
       );

--- a/packages/firestore/src/remote/persistent_stream.ts
+++ b/packages/firestore/src/remote/persistent_stream.ts
@@ -318,8 +318,9 @@ export abstract class PersistentStream<
       // If this is an intentional close ensure we don't delay our next connection attempt.
       this.backoff.reset();
     } else if (error && error.code === Code.RESOURCE_EXHAUSTED) {
-      log.debug(
-        LOG_TAG,
+      // Log the error. (Probably either 'quota exceeded' or 'max queue length reached'.)
+      log.error(error);
+      log.error(
         'Using maximum backoff delay to prevent overloading the backend.'
       );
       this.backoff.resetToMax();

--- a/packages/util/test/base64.test.ts
+++ b/packages/util/test/base64.test.ts
@@ -18,7 +18,7 @@ import { base64Encode, base64Decode } from '../src/crypt';
 
 describe('base64', () => {
   it('bijective', () => {
-    let cases = [ '$', '¢', '€', '𐍈' ]; // 1, 2, 3, and 4 byte characters
+    let cases = ['$', '¢', '€', '𐍈']; // 1, 2, 3, and 4 byte characters
     cases.forEach(str => {
       assert.strictEqual(base64Decode(base64Encode(str)), str);
     });


### PR DESCRIPTION
... when receiving webchannel messages. Even without debug mode one
(i.e. even when the caller hasn't called
firebase.firestore.setLogLevel('debug')).

Without this, the developer would have no idea why firestore was not
returning any data, as it would just silently not work.

b/69638501