### PR TITLE
Remove 'tags' from log.error() statements.

### DIFF
--- a/packages/firestore/src/local/indexeddb_persistence.ts
+++ b/packages/firestore/src/local/indexeddb_persistence.ts
@@ -377,7 +377,7 @@ export class IndexedDbPersistence implements Persistence {
       return zombiedOwnerId;
     } catch (e) {
       // Gracefully handle if LocalStorage isn't available / working.
-      log.error(LOG_TAG, 'Failed to get zombie owner id.', e);
+      log.error('Failed to get zombie owner id.', e);
       return null;
     }
   }
@@ -398,7 +398,7 @@ export class IndexedDbPersistence implements Persistence {
       }
     } catch (e) {
       // Gracefully handle if LocalStorage isn't available / working.
-      log.error(LOG_TAG, 'Failed to set zombie owner id.', e);
+      log.error('Failed to set zombie owner id.', e);
     }
   }
 

--- a/packages/firestore/src/platform_node/grpc_connection.ts
+++ b/packages/firestore/src/platform_node/grpc_connection.ts
@@ -225,8 +225,8 @@ export class GrpcConnection implements Connection {
           } catch (e) {
             // This probably means we didn't conform to the proto.  Make sure to
             // log the message we sent.
-            log.error(LOG_TAG, 'Failure sending:', msg);
-            log.error(LOG_TAG, 'Error:', e);
+            log.error('Failure sending:', msg);
+            log.error('Error:', e);
             throw e;
           }
         } else {

--- a/packages/util/test/base64.test.ts
+++ b/packages/util/test/base64.test.ts
@@ -18,7 +18,7 @@ import { base64Encode, base64Decode } from '../src/crypt';
 
 describe('base64', () => {
   it('bijective', () => {
-    let cases = [ '$', '¢', '€', '𐍈' ]; // 1, 2, 3, and 4 byte characters
+    let cases = ['$', '¢', '€', '𐍈']; // 1, 2, 3, and 4 byte characters
     cases.forEach(str => {
       assert.strictEqual(base64Decode(base64Encode(str)), str);
     });


### PR DESCRIPTION
While log.debug() statements take a tag parameter, log.error()
statements do not. (Note that they still work even with a tag parameter
since log.error() takes in a va_list.)