### PR TITLE
Make offline warning an `error` instead of `debug`.

### DIFF
--- a/packages/firestore/src/remote/remote_store.ts
+++ b/packages/firestore/src/remote/remote_store.ts
@@ -192,7 +192,7 @@ export class RemoteStore {
       this.watchStreamFailures++;
       if (this.watchStreamFailures >= ONLINE_ATTEMPTS_BEFORE_FAILURE) {
         if (this.shouldWarnOffline) {
-          log.error(LOG_TAG, 'Could not reach Firestore backend.');
+          log.error('Could not reach Firestore backend.');
           this.shouldWarnOffline = false;
         }
         this.updateOnlineState(OnlineState.Failed);

--- a/packages/firestore/src/remote/remote_store.ts
+++ b/packages/firestore/src/remote/remote_store.ts
@@ -192,7 +192,7 @@ export class RemoteStore {
       this.watchStreamFailures++;
       if (this.watchStreamFailures >= ONLINE_ATTEMPTS_BEFORE_FAILURE) {
         if (this.shouldWarnOffline) {
-          log.debug(LOG_TAG, 'Could not reach Firestore backend.');
+          log.error(LOG_TAG, 'Could not reach Firestore backend.');
           this.shouldWarnOffline = false;
         }
         this.updateOnlineState(OnlineState.Failed);


### PR DESCRIPTION
Make offline warning an `error` instead of `debug`. JS client SDK does not have `warning`. To make warning default behavior, we actually want `error` here instead of `debug`.