### PR TITLE
Rename EventManager.onOnlineStateChanged => applyOnlineStateChange

### DIFF
--- a/packages/firestore/src/core/event_manager.ts
+++ b/packages/firestore/src/core/event_manager.ts
@@ -74,7 +74,7 @@ export class EventManager {
     }
     queryInfo.listeners.push(listener);
 
-    listener.onOnlineStateChanged(this.onlineState);
+    listener.applyOnlineStateChange(this.onlineState);
 
     if (queryInfo.viewSnap) listener.onViewSnapshot(queryInfo.viewSnap);
 
@@ -135,11 +135,11 @@ export class EventManager {
     this.queries.delete(query);
   }
 
-  onOnlineStateChanged(onlineState: OnlineState): void {
+  applyOnlineStateChange(onlineState: OnlineState): void {
     this.onlineState = onlineState;
     this.queries.forEach((_, queryInfo) => {
       for (const listener of queryInfo.listeners) {
-        listener.onOnlineStateChanged(onlineState);
+        listener.applyOnlineStateChange(onlineState);
       }
     });
   }
@@ -226,7 +226,7 @@ export class QueryListener {
     this.queryObserver.error(error);
   }
 
-  onOnlineStateChanged(onlineState: OnlineState): void {
+  applyOnlineStateChange(onlineState: OnlineState): void {
     this.onlineState = onlineState;
     if (
       this.snap &&

--- a/packages/firestore/src/core/firestore_client.ts
+++ b/packages/firestore/src/core/firestore_client.ts
@@ -283,7 +283,7 @@ export class FirestoreClient {
 
         const onlineStateChangedHandler = (onlineState: OnlineState) => {
           this.syncEngine.applyOnlineStateChange(onlineState);
-          this.eventMgr.onOnlineStateChanged(onlineState);
+          this.eventMgr.applyOnlineStateChange(onlineState);
         };
 
         this.remoteStore = new RemoteStore(

--- a/packages/firestore/test/unit/core/event_manager.test.ts
+++ b/packages/firestore/test/unit/core/event_manager.test.ts
@@ -43,7 +43,7 @@ describe('EventManager', () => {
       query,
       onViewSnapshot: () => {},
       onError: () => {},
-      onOnlineStateChanged: () => {}
+      applyOnlineStateChange: () => {}
     };
   }
 
@@ -126,11 +126,11 @@ describe('EventManager', () => {
     ]);
   });
 
-  it('will forward onOnlineStateChanged calls', () => {
+  it('will forward applyOnlineStateChange calls', () => {
     const query = Query.atPath(path('foo/bar'));
     const fakeListener1 = fakeQueryListener(query);
     const events: OnlineState[] = [];
-    fakeListener1.onOnlineStateChanged = (onlineState: OnlineState) => {
+    fakeListener1.applyOnlineStateChange = (onlineState: OnlineState) => {
       events.push(onlineState);
     };
 

--- a/packages/firestore/test/unit/core/event_manager.test.ts
+++ b/packages/firestore/test/unit/core/event_manager.test.ts
@@ -139,7 +139,7 @@ describe('EventManager', () => {
 
     eventManager.listen(fakeListener1);
     expect(events).to.deep.equal([OnlineState.Unknown]);
-    eventManager.onOnlineStateChanged(OnlineState.Healthy);
+    eventManager.applyOnlineStateChange(OnlineState.Healthy);
     expect(events).to.deep.equal([OnlineState.Unknown, OnlineState.Healthy]);
   });
 });
@@ -423,10 +423,10 @@ describe('QueryListener', () => {
     const changes3 = view.computeDocChanges(documentUpdates());
     const snap3 = view.applyChanges(changes3, ackTarget(doc1, doc2)).snapshot!;
 
-    listener.onOnlineStateChanged(OnlineState.Healthy); // no event
+    listener.applyOnlineStateChange(OnlineState.Healthy); // no event
     listener.onViewSnapshot(snap1); // no event
-    listener.onOnlineStateChanged(OnlineState.Unknown); // no event
-    listener.onOnlineStateChanged(OnlineState.Healthy); // no event
+    listener.applyOnlineStateChange(OnlineState.Unknown); // no event
+    listener.applyOnlineStateChange(OnlineState.Healthy); // no event
     listener.onViewSnapshot(snap2); // no event
     listener.onViewSnapshot(snap3); // event because synced
 
@@ -461,11 +461,11 @@ describe('QueryListener', () => {
     const changes2 = view.computeDocChanges(documentUpdates(doc2));
     const snap2 = view.applyChanges(changes2).snapshot!;
 
-    listener.onOnlineStateChanged(OnlineState.Healthy); // no event
+    listener.applyOnlineStateChange(OnlineState.Healthy); // no event
     listener.onViewSnapshot(snap1); // no event
-    listener.onOnlineStateChanged(OnlineState.Failed); // event
-    listener.onOnlineStateChanged(OnlineState.Healthy); // no event
-    listener.onOnlineStateChanged(OnlineState.Failed); // no event
+    listener.applyOnlineStateChange(OnlineState.Failed); // event
+    listener.applyOnlineStateChange(OnlineState.Healthy); // no event
+    listener.applyOnlineStateChange(OnlineState.Failed); // no event
     listener.onViewSnapshot(snap2); // another event
 
     const expectedSnap1 = {
@@ -499,9 +499,9 @@ describe('QueryListener', () => {
     const changes1 = view.computeDocChanges(documentUpdates());
     const snap1 = view.applyChanges(changes1).snapshot!;
 
-    listener.onOnlineStateChanged(OnlineState.Healthy); // no event
+    listener.applyOnlineStateChange(OnlineState.Healthy); // no event
     listener.onViewSnapshot(snap1); // no event
-    listener.onOnlineStateChanged(OnlineState.Failed); // event
+    listener.applyOnlineStateChange(OnlineState.Failed); // event
 
     const expectedSnap = {
       query,
@@ -525,7 +525,7 @@ describe('QueryListener', () => {
     const changes1 = view.computeDocChanges(documentUpdates());
     const snap1 = view.applyChanges(changes1).snapshot!;
 
-    listener.onOnlineStateChanged(OnlineState.Failed);
+    listener.applyOnlineStateChange(OnlineState.Failed);
     listener.onViewSnapshot(snap1);
 
     const expectedSnap = {

--- a/packages/firestore/test/unit/specs/spec_test_runner.ts
+++ b/packages/firestore/test/unit/specs/spec_test_runner.ts
@@ -385,7 +385,7 @@ abstract class TestRunner {
     );
     const onlineStateChangedHandler = (onlineState: OnlineState) => {
       this.syncEngine.applyOnlineStateChange(onlineState);
-      this.eventManager.onOnlineStateChanged(onlineState);
+      this.eventManager.applyOnlineStateChange(onlineState);
     };
     this.remoteStore = new RemoteStore(
       this.localStore,


### PR DESCRIPTION
FYI- I've gone with applyOnlineStateChange on iOS / Web (to be consistent with applyRemoteEvent, etc.) but handleOnlineStateChange on Android (to be consistent with handleListenEvent, etc.).  I'm not sure why the platforms diverged in naming but I don't want to try to clean it up in this PR.