### PR TITLE
Replace all instances of 'intialize' with 'initialize'.

### DIFF
--- a/packages/app-types/index.d.ts
+++ b/packages/app-types/index.d.ts
@@ -44,7 +44,7 @@ export class FirebaseApp {
 
 export interface FirebaseNamespace {
   /**
-   * Create (and intialize) a FirebaseApp.
+   * Create (and initialize) a FirebaseApp.
    *
    * @param options Options to configure the services used in the App.
    * @param name The optional name of the app to initialize ('[DEFAULT]' if

--- a/packages/app-types/private.d.ts
+++ b/packages/app-types/private.d.ts
@@ -98,7 +98,7 @@ export interface _FirebaseNamespace extends FirebaseNamespace {
      * @param name The Firebase Service being registered.
      * @param createService Factory function to create a service instance.
      * @param serviceProperties Properties to copy to the service's namespace.
-     * @param appHook All appHooks called before intializeApp returns to caller.
+     * @param appHook All appHooks called before initializeApp returns to caller.
      * @param allowMultipleInstances Whether the registered service supports
      *   multiple instances per app. If not specified, the default is false.
      */

--- a/packages/app/test/firebaseApp.test.ts
+++ b/packages/app/test/firebaseApp.test.ts
@@ -34,7 +34,7 @@ describe('Firebase App Class', () => {
     assert.equal(firebase.apps.length, 0);
   });
 
-  it('Can intialize DEFAULT App.', () => {
+  it('Can initialize DEFAULT App.', () => {
     let app = firebase.initializeApp({});
     assert.equal(firebase.apps.length, 1);
     assert.strictEqual(app, firebase.apps[0]);

--- a/packages/auth/src/storage/indexeddb.js
+++ b/packages/auth/src/storage/indexeddb.js
@@ -201,7 +201,7 @@ fireauth.storage.IndexedDB.prototype.initializeDb_ = function() {
 
 
 /**
- * Checks if indexedDB is intialized, if so, the callback is run, otherwise,
+ * Checks if indexedDB is initialized, if so, the callback is run, otherwise,
  * it waits for the db to initialize and then runs the callback function.
  * @return {!goog.Promise<!IDBDatabase>} A promise for the initialized indexedDB
  *     database.

--- a/packages/auth/test/autheventmanager_test.js
+++ b/packages/auth/test/autheventmanager_test.js
@@ -1347,7 +1347,7 @@ function testProcessPopup_alreadyRedirected() {
   // Fake popup window.
   var popupWin = {};
   // OAuth handler should be initialized automatically if not already
-  // intialized.
+  // initialized.
   stubs.replace(
       OAuthSignInHandler.prototype,
       'addAuthEventListener',

--- a/packages/database/src/core/RepoManager.ts
+++ b/packages/database/src/core/RepoManager.ts
@@ -84,7 +84,7 @@ export class RepoManager {
       fatal(
         "Can't determine Firebase Database URL.  Be sure to include " +
           DATABASE_URL_OPTION +
-          ' option when calling firebase.intializeApp().'
+          ' option when calling firebase.initializeApp().'
       );
     }
 


### PR DESCRIPTION
I noticed that the word "initialize" is misspelled in multiple places across the product and documentation, and wanted to fix that.