### PR TITLE
Remove meaningless return statement

### DIFF
--- a/packages/firestore/test/integration/api/database.test.ts
+++ b/packages/firestore/test/integration/api/database.test.ts
@@ -675,7 +675,6 @@ apiDescribe('Database', persistence => {
       await db.disableNetwork();
       await db.disableNetwork();
       await db.enableNetwork();
-      return Promise.resolve();
     });
   });
 });


### PR DESCRIPTION
Simplifies one of the integrations tests in a firestore module.

See https://github.com/firebase/firebase-js-sdk/issues/408