### PR TITLE
Add @license annotation to externs

### DIFF
--- a/packages/firebase/externs/firebase-app-externs.js
+++ b/packages/firebase/externs/firebase-app-externs.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 Google Inc.
+ * @license Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/firebase/externs/firebase-app-internal-externs.js
+++ b/packages/firebase/externs/firebase-app-internal-externs.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 Google Inc.
+ * @license Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/firebase/externs/firebase-auth-externs.js
+++ b/packages/firebase/externs/firebase-auth-externs.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 Google Inc.
+ * @license Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/firebase/externs/firebase-client-auth-externs.js
+++ b/packages/firebase/externs/firebase-client-auth-externs.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 Google Inc.
+ * @license Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/firebase/externs/firebase-database-externs.js
+++ b/packages/firebase/externs/firebase-database-externs.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 Google Inc.
+ * @license Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/firebase/externs/firebase-database-internal-externs.js
+++ b/packages/firebase/externs/firebase-database-internal-externs.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 Google Inc.
+ * @license Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/firebase/externs/firebase-error-externs.js
+++ b/packages/firebase/externs/firebase-error-externs.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 Google Inc.
+ * @license Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/firebase/externs/firebase-externs.js
+++ b/packages/firebase/externs/firebase-externs.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 Google Inc.
+ * @license Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/firebase/externs/firebase-messaging-externs.js
+++ b/packages/firebase/externs/firebase-messaging-externs.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 Google Inc.
+ * @license Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/firebase/externs/firebase-storage-externs.js
+++ b/packages/firebase/externs/firebase-storage-externs.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 Google Inc.
+ * @license Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Adding some `@license` annotations to ensure the externs are properly handled by Closure Compiler.