### PR TITLE
Accepting new backend error message for missing docs

### DIFF
--- a/packages/firestore/test/integration/api/batch_writes.test.ts
+++ b/packages/firestore/test/integration/api/batch_writes.test.ts
@@ -212,7 +212,7 @@ apiDescribe('Database batch writes', persistence => {
             },
             err => {
               expect(err.message).to.exist;
-              // TODO: Change this to just match "no Document to update" once
+              // TODO: Change this to just match "no document to update" once
               // the backend response is consistent.
               expect(err.message).to.match(/no (document|entity) to update/);
               expect(err.code).to.equal('not-found');

--- a/packages/firestore/test/integration/api/batch_writes.test.ts
+++ b/packages/firestore/test/integration/api/batch_writes.test.ts
@@ -212,7 +212,9 @@ apiDescribe('Database batch writes', persistence => {
             },
             err => {
               expect(err.message).to.exist;
-              expect(err.message).to.contain('no entity to update');
+              // TODO: Change this to just match "no Document to update" once
+              // the backend response is consistent.
+              expect(err.message).to.match(/no (document|entity) to update/);
               expect(err.code).to.equal('not-found');
               unsubscribe();
             }

--- a/packages/firestore/test/integration/api/database.test.ts
+++ b/packages/firestore/test/integration/api/database.test.ts
@@ -204,7 +204,7 @@ apiDescribe('Database', persistence => {
           () => Promise.reject('update should have failed.'),
           (err: firestore.FirestoreError) => {
             expect(err.message).to.exist;
-            // TODO: Change this to just match "no Document to update" once the
+            // TODO: Change this to just match "no document to update" once the
             // backend response is consistent.
             expect(err.message).to.match(/no (document|entity) to update/);
             expect(err.code).to.equal('not-found');

--- a/packages/firestore/test/integration/api/database.test.ts
+++ b/packages/firestore/test/integration/api/database.test.ts
@@ -204,7 +204,9 @@ apiDescribe('Database', persistence => {
           () => Promise.reject('update should have failed.'),
           (err: firestore.FirestoreError) => {
             expect(err.message).to.exist;
-            expect(err.message).to.contain('no entity to update');
+            // TODO: Change this to just match "no Document to update" once the
+            // backend response is consistent.
+            expect(err.message).to.match(/no (document|entity) to update/);
             expect(err.code).to.equal('not-found');
           }
         )


### PR DESCRIPTION
This should fix my Travis run: https://travis-ci.org/firebase/firebase-js-sdk/builds/327950507?utm_source=github_status&utm_medium=notification

Note that is seems that the backend still returns the old error message from time to time.