### PR TITLE
Removing some of the 'any' usage in our Promise implementation

### DIFF
--- a/packages/firestore/src/util/promise.ts
+++ b/packages/firestore/src/util/promise.ts
@@ -20,9 +20,8 @@ export interface Resolver<R> {
   (value?: R | Promise<R>): void;
 }
 
-// tslint:disable-next-line:no-any
 export interface Rejecter {
-  (value?: any): void;
+  (reason?: Error): void;
 }
 
 export class Deferred<R> {

--- a/packages/firestore/test/integration/api/batch_writes.test.ts
+++ b/packages/firestore/test/integration/api/batch_writes.test.ts
@@ -214,7 +214,7 @@ apiDescribe('Database batch writes', persistence => {
               expect(err.message).to.exist;
               // TODO: Change this to just match "no document to update" once
               // the backend response is consistent.
-              expect(err.message).to.match(/no (document|entity) to update/);
+              expect(err.message).to.match(/no (document|entity) to update/i);
               expect(err.code).to.equal('not-found');
               unsubscribe();
             }

--- a/packages/firestore/test/integration/api/database.test.ts
+++ b/packages/firestore/test/integration/api/database.test.ts
@@ -216,7 +216,7 @@ apiDescribe('Database', persistence => {
             expect(err.message).to.exist;
             // TODO: Change this to just match "no document to update" once the
             // backend response is consistent.
-            expect(err.message).to.match(/no (document|entity) to update/);
+            expect(err.message).to.match(/no (document|entity) to update/i);
             expect(err.code).to.equal('not-found');
           }
         )

--- a/packages/firestore/test/unit/local/persistence_promise.test.ts
+++ b/packages/firestore/test/unit/local/persistence_promise.test.ts
@@ -81,7 +81,7 @@ describe('PersistencePromise', () => {
   });
 
   it('ignores catches without errors', () => {
-    let catchClause = 'unset';
+    let catchClause: Error | undefined = undefined;
     return sync(1)
       .next(x => x + 1)
       .catch(x => {
@@ -89,13 +89,13 @@ describe('PersistencePromise', () => {
       })
       .next(x => {
         expect(x).to.equal(2);
-        expect(catchClause).to.equal('unset');
+        expect(catchClause).to.be.undefined;
       })
       .toPromise();
   });
 
   it('ignores catches without errors async', () => {
-    let catchClause = 'unset';
+    let catchClause: Error | undefined = undefined;
     return async(1)
       .next(x => x + 1)
       .catch(x => {
@@ -103,7 +103,7 @@ describe('PersistencePromise', () => {
       })
       .next(x => {
         expect(x).to.equal(2);
-        expect(catchClause).to.equal('unset');
+        expect(catchClause).to.be.undefined;
       })
       .toPromise();
   });


### PR DESCRIPTION
This PR:
- Disables lint warnings for the type of the next Promise in the Promise chain
- Restricts the error-type to adhere to `Error`