### PR TITLE
Removing last lint errors

### DIFF
--- a/packages/firestore/src/local/indexeddb_schema.ts
+++ b/packages/firestore/src/local/indexeddb_schema.ts
@@ -35,14 +35,14 @@ export function createOrUpgradeDb(db: IDBDatabase, oldVersion: number): void {
   // TODO(mikelehen): Get rid of "as any" if/when TypeScript fixes their
   // types. https://github.com/Microsoft/TypeScript/issues/14322
   db.createObjectStore(
-    // tslint:disable-next-line:no-any
     DbMutationBatch.store,
+    // tslint:disable-next-line:no-any
     { keyPath: DbMutationBatch.keyPath as any }
   );
 
   const targetDocumentsStore = db.createObjectStore(
-    // tslint:disable-next-line:no-any
     DbTargetDocument.store,
+    // tslint:disable-next-line:no-any
     { keyPath: DbTargetDocument.keyPath as any }
   );
   targetDocumentsStore.createIndex(

--- a/packages/firestore/src/remote/serializer.ts
+++ b/packages/firestore/src/remote/serializer.ts
@@ -160,6 +160,7 @@ export class JsonProtoSerializer {
    */
   private toInt32Value(val: number | null): number | undefined {
     if (!typeUtils.isNullOrUndefined(val)) {
+      // tslint:disable-next-line:no-any We need to match generated Proto types.
       return { value: val } as any;
     } else {
       return undefined;
@@ -176,6 +177,7 @@ export class JsonProtoSerializer {
   private fromInt32Value(val: number | undefined): number | null {
     let result;
     if (typeof val === 'object') {
+      // tslint:disable-next-line:no-any We need to match generated Proto types.
       result = (val as any).value;
     } else {
       // We accept raw numbers (without the {value: ... } wrapper) for

--- a/packages/firestore/src/util/sorted_map.ts
+++ b/packages/firestore/src/util/sorted_map.ts
@@ -253,7 +253,7 @@ export class SortedMapIterator<K, V> {
     );
 
     let node = this.nodeStack.pop()!;
-    let result = { key: node.key, value: node.value };
+    const result = { key: node.key, value: node.value };
 
     if (this.isReverse) {
       node = node.left;

--- a/packages/firestore/test/integration/bootstrap.ts
+++ b/packages/firestore/test/integration/bootstrap.ts
@@ -22,6 +22,9 @@ import '../../index';
  * Taken from karma-webpack source:
  * https://github.com/webpack-contrib/karma-webpack#alternative-usage
  */
+
+// 'context()' definition requires additional dependency on webpack-env package.
+// tslint:disable-next-line:no-any
 const testsContext = (require as any).context('.', true, /.test$/);
 const browserTests = testsContext
   .keys()

--- a/packages/firestore/test/unit/bootstrap.ts
+++ b/packages/firestore/test/unit/bootstrap.ts
@@ -22,6 +22,9 @@ import '../../src/platform_browser/browser_init';
  * Taken from karma-webpack source:
  * https://github.com/webpack-contrib/karma-webpack#alternative-usage
  */
+
+// 'context()' definition requires additional dependency on webpack-env package.
+// tslint:disable-next-line:no-any
 const testsContext = (require as any).context('.', true, /.test$/);
 const browserTests = testsContext
   .keys()


### PR DESCRIPTION
This silences the remaining uses of `any` (and fixes a lint error I just introduced!)

- In serializer, we are deliberately using the wrong type, but unless we fix the generated typings, this is here to stay.
- We could fix the `any` use in both bootstrap.js files, but this would require a type dependency on `webpack-env`. To me, adding a new dependency just to address this warning isn't quite justified, especially since this affects only the setup code for our tests.