### PR TITLE
Refactor integration/api/ tests to have no src/ dependencies.

### DIFF
--- a/packages/firestore/src/api/database.ts
+++ b/packages/firestore/src/api/database.ts
@@ -195,7 +195,11 @@ export class Firestore implements firestore.FirebaseFirestore, FirebaseService {
   // Operations on the _firestoreClient don't block on _firestoreReady. Those
   // are already set to synchronize on the async queue.
   private _firestoreClient: FirestoreClient | undefined;
-  private _queue = new AsyncQueue();
+
+  // Public for use in tests.
+  // TODO(mikelehen): Use modularized initialization instead.
+  readonly _queue = new AsyncQueue();
+
   _dataConverter: UserDataConverter;
 
   constructor(databaseIdOrApp: FirestoreDatabase | FirebaseApp) {
@@ -389,10 +393,7 @@ export class Firestore implements firestore.FirebaseFirestore, FirebaseService {
       } else {
         return Promise.resolve();
       }
-    },
-    // Exposed via INTERNAL for use in tests.
-    drainAsyncQueue: (executeDelayedTasks: boolean) =>
-      this._queue.drain(executeDelayedTasks)
+    }
   };
 
   collection(pathString: string): firestore.CollectionReference {

--- a/packages/firestore/test/integration/api/README.md
+++ b/packages/firestore/test/integration/api/README.md
@@ -1,0 +1,4 @@
+All tests in this directory are also run against our (minified)
+firebase-firestore.js build (via 'yarn test:manual' under
+firebase-js-sdk/integration/firestore/) and therefore must not have any
+dependencies on src/ files.

--- a/packages/firestore/test/integration/api/README.md
+++ b/packages/firestore/test/integration/api/README.md
@@ -2,3 +2,6 @@ All tests in this directory are also run against our (minified)
 firebase-firestore.js build (via 'yarn test:manual' under
 firebase-js-sdk/integration/firestore/) and therefore must not have any
 dependencies on src/ files.
+
+API tests that need to use internal hooks (via src/ dependencies) should be
+put in test/integration/api_internal instead.

--- a/packages/firestore/test/integration/api/batch_writes.test.ts
+++ b/packages/firestore/test/integration/api/batch_writes.test.ts
@@ -17,9 +17,9 @@
 import { expect } from 'chai';
 import * as firestore from '@firebase/firestore-types';
 
-import * as testHelpers from '../../util/helpers';
-import firebase from '../util/firebase_export';
+import { EventsAccumulator } from '../util/events_accumulator';
 import * as integrationHelpers from '../util/helpers';
+import firebase from '../util/firebase_export';
 
 const apiDescribe = integrationHelpers.apiDescribe;
 
@@ -114,9 +114,7 @@ apiDescribe('Database batch writes', persistence => {
       collection => {
         const docA = collection.doc('a');
         const docB = collection.doc('b');
-        const accumulator = new testHelpers.EventsAccumulator<
-          firestore.QuerySnapshot
-        >();
+        const accumulator = new EventsAccumulator<firestore.QuerySnapshot>();
         const unsubscribe = collection.onSnapshot(
           { includeQueryMetadataChanges: true },
           accumulator.storeEvent
@@ -137,7 +135,7 @@ apiDescribe('Database batch writes', persistence => {
           })
           .then(localSnap => {
             expect(localSnap.metadata.hasPendingWrites).to.equal(true);
-            expect(testHelpers.toDataArray(localSnap)).to.deep.equal([
+            expect(integrationHelpers.toDataArray(localSnap)).to.deep.equal([
               { a: 1 },
               { b: 2 }
             ]);
@@ -145,7 +143,7 @@ apiDescribe('Database batch writes', persistence => {
           })
           .then(serverSnap => {
             expect(serverSnap.metadata.hasPendingWrites).to.equal(false);
-            expect(testHelpers.toDataArray(serverSnap)).to.deep.equal([
+            expect(integrationHelpers.toDataArray(serverSnap)).to.deep.equal([
               { a: 1 },
               { b: 2 }
             ]);
@@ -162,9 +160,7 @@ apiDescribe('Database batch writes', persistence => {
       collection => {
         const docA = collection.doc('a');
         const docB = collection.doc('b');
-        const accumulator = new testHelpers.EventsAccumulator<
-          firestore.QuerySnapshot
-        >();
+        const accumulator = new EventsAccumulator<firestore.QuerySnapshot>();
         const unsubscribe = collection.onSnapshot(
           { includeQueryMetadataChanges: true },
           accumulator.storeEvent
@@ -193,7 +189,7 @@ apiDescribe('Database batch writes', persistence => {
           .then(localSnap => {
             // Local event with the set document.
             expect(localSnap.metadata.hasPendingWrites).to.equal(true);
-            expect(testHelpers.toDataArray(localSnap)).to.deep.equal([
+            expect(integrationHelpers.toDataArray(localSnap)).to.deep.equal([
               { a: 1 }
             ]);
 
@@ -230,9 +226,7 @@ apiDescribe('Database batch writes', persistence => {
       collection => {
         const docA = collection.doc('a');
         const docB = collection.doc('b');
-        const accumulator = new testHelpers.EventsAccumulator<
-          firestore.QuerySnapshot
-        >();
+        const accumulator = new EventsAccumulator<firestore.QuerySnapshot>();
         const unsubscribe = collection.onSnapshot(
           { includeQueryMetadataChanges: true },
           accumulator.storeEvent
@@ -258,7 +252,7 @@ apiDescribe('Database batch writes', persistence => {
           .then(localSnap => {
             expect(localSnap.metadata.hasPendingWrites).to.equal(true);
             expect(localSnap.docs.length).to.equal(2);
-            expect(testHelpers.toDataArray(localSnap)).to.deep.equal([
+            expect(integrationHelpers.toDataArray(localSnap)).to.deep.equal([
               { when: null },
               { when: null }
             ]);
@@ -279,9 +273,7 @@ apiDescribe('Database batch writes', persistence => {
 
   it('can write the same document multiple times', () => {
     return integrationHelpers.withTestDoc(persistence, doc => {
-      const accumulator = new testHelpers.EventsAccumulator<
-        firestore.DocumentSnapshot
-      >();
+      const accumulator = new EventsAccumulator<firestore.DocumentSnapshot>();
       const unsubscribe = doc.onSnapshot(
         { includeMetadataChanges: true },
         accumulator.storeEvent

--- a/packages/firestore/test/integration/api/cursor.test.ts
+++ b/packages/firestore/test/integration/api/cursor.test.ts
@@ -15,10 +15,10 @@
  */
 
 import { expect } from 'chai';
-import { toDataArray } from '../../util/helpers';
 import firebase from '../util/firebase_export';
 import {
   apiDescribe,
+  toDataArray,
   withTestCollection,
   withTestDb,
   withTestDbs

--- a/packages/firestore/test/integration/api/database.test.ts
+++ b/packages/firestore/test/integration/api/database.test.ts
@@ -17,11 +17,10 @@
 import { expect } from 'chai';
 import * as firestore from '@firebase/firestore-types';
 
-import { Deferred } from '../../../src/util/promise';
+import { Deferred } from '../../util/promise';
 import firebase from '../util/firebase_export';
 import {
   apiDescribe,
-  drainAsyncQueue,
   withTestCollection,
   withTestDb,
   withTestDoc
@@ -629,42 +628,6 @@ apiDescribe('Database', persistence => {
             expect(doc.data()).to.deep.equal({ foo: 'bar' });
           });
       });
-    });
-  });
-
-  it('can write document after idle timeout', () => {
-    return withTestDb(persistence, db => {
-      const docRef = db.collection('test-collection').doc();
-      return docRef
-        .set({ foo: 'bar' })
-        .then(() => {
-          return drainAsyncQueue(db);
-        })
-        .then(() => docRef.set({ foo: 'bar' }));
-    });
-  });
-
-  it('can watch documents after idle timeout', () => {
-    return withTestDb(persistence, db => {
-      const awaitOnlineSnapshot = () => {
-        const docRef = db.collection('test-collection').doc();
-        const deferred = new Deferred<void>();
-        const unregister = docRef.onSnapshot(
-          { includeMetadataChanges: true },
-          snapshot => {
-            if (!snapshot.metadata.fromCache) {
-              deferred.resolve();
-            }
-          }
-        );
-        return deferred.promise.then(unregister);
-      };
-
-      return awaitOnlineSnapshot()
-        .then(() => {
-          return drainAsyncQueue(db);
-        })
-        .then(() => awaitOnlineSnapshot());
     });
   });
 

--- a/packages/firestore/test/integration/api/fields.test.ts
+++ b/packages/firestore/test/integration/api/fields.test.ts
@@ -15,9 +15,13 @@
  */
 
 import { expect } from 'chai';
-import { toDataArray } from '../../util/helpers';
 import firebase from '../util/firebase_export';
-import { apiDescribe, withTestCollection, withTestDoc } from '../util/helpers';
+import {
+  apiDescribe,
+  toDataArray,
+  withTestCollection,
+  withTestDoc
+} from '../util/helpers';
 
 const FieldPath = firebase.firestore.FieldPath;
 

--- a/packages/firestore/test/integration/api/query.test.ts
+++ b/packages/firestore/test/integration/api/query.test.ts
@@ -18,11 +18,15 @@ import { expect } from 'chai';
 import * as firestore from '@firebase/firestore-types';
 
 import { addEqualityMatcher } from '../../util/equality_matcher';
-import { EventsAccumulator, toDataArray } from '../../util/helpers';
+import { EventsAccumulator } from '../util/events_accumulator';
 import firebase from '../util/firebase_export';
-import { apiDescribe, withTestCollection, withTestDbs } from '../util/helpers';
-import { Firestore } from '../../../src/api/database';
-import { Deferred } from '../../../src/util/promise';
+import {
+  apiDescribe,
+  toDataArray,
+  withTestCollection,
+  withTestDbs
+} from '../util/helpers';
+import { Deferred } from '../../util/promise';
 
 apiDescribe('Queries', persistence => {
   addEqualityMatcher();

--- a/packages/firestore/test/integration/api/server_timestamp.test.ts
+++ b/packages/firestore/test/integration/api/server_timestamp.test.ts
@@ -17,9 +17,9 @@
 import { expect } from 'chai';
 import * as firestore from '@firebase/firestore-types';
 
-import * as testHelpers from '../../util/helpers';
 import firebase from '../util/firebase_export';
 import { apiDescribe, withTestDoc } from '../util/helpers';
+import { EventsAccumulator } from '../util/events_accumulator';
 
 apiDescribe('Server Timestamps', persistence => {
   // Data written in tests via set().
@@ -40,7 +40,7 @@ apiDescribe('Server Timestamps', persistence => {
   let docRef: firestore.DocumentReference;
 
   // Accumulator used to capture events during the test.
-  let accumulator: testHelpers.EventsAccumulator<firestore.DocumentSnapshot>;
+  let accumulator: EventsAccumulator<firestore.DocumentSnapshot>;
 
   // Listener registration for a listener maintained during the course of the
   // test.
@@ -161,9 +161,7 @@ apiDescribe('Server Timestamps', persistence => {
       // Set variables for use during test.
       docRef = doc;
 
-      accumulator = new testHelpers.EventsAccumulator<
-        firestore.DocumentSnapshot
-      >();
+      accumulator = new EventsAccumulator<firestore.DocumentSnapshot>();
       listenerRegistration = docRef.onSnapshot(accumulator.storeEvent);
 
       // wait for initial null snapshot to avoid potential races.

--- a/packages/firestore/test/integration/api/smoke.test.ts
+++ b/packages/firestore/test/integration/api/smoke.test.ts
@@ -16,8 +16,7 @@
 
 import { expect } from 'chai';
 import * as firestore from '@firebase/firestore-types';
-import * as testHelpers from '../../util/helpers';
-import { EventsAccumulator } from '../../util/helpers';
+import { EventsAccumulator } from '../util/events_accumulator';
 import * as integrationHelpers from '../util/helpers';
 
 const apiDescribe = integrationHelpers.apiDescribe;
@@ -131,7 +130,7 @@ apiDescribe('Smoke Test', persistence => {
       return ref.get().then(result => {
         expect(result.empty).to.equal(false);
         expect(result.size).to.equal(3);
-        expect(testHelpers.toDataArray(result)).to.deep.equal([
+        expect(integrationHelpers.toDataArray(result)).to.deep.equal([
           testDocs[1],
           testDocs[2],
           testDocs[3]
@@ -155,7 +154,7 @@ apiDescribe('Smoke Test', persistence => {
       coll => {
         const query = coll.where('filter', '==', true).orderBy('sort', 'desc');
         return query.get().then(result => {
-          expect(testHelpers.toDataArray(result)).to.deep.equal([
+          expect(integrationHelpers.toDataArray(result)).to.deep.equal([
             testDocs[2],
             testDocs[3],
             testDocs[1]

--- a/packages/firestore/test/integration/api/transactions.test.ts
+++ b/packages/firestore/test/integration/api/transactions.test.ts
@@ -16,8 +16,7 @@
 
 import { expect } from 'chai';
 import * as firestore from '@firebase/firestore-types';
-import { Deferred } from '../../../src/util/promise';
-import * as testHelpers from '../../util/helpers';
+import { Deferred } from '../../util/promise';
 import firebase from '../util/firebase_export';
 import * as integrationHelpers from '../util/helpers';
 

--- a/packages/firestore/test/integration/api/type.test.ts
+++ b/packages/firestore/test/integration/api/type.test.ts
@@ -19,8 +19,6 @@ import * as firestore from '@firebase/firestore-types';
 import firebase from '../util/firebase_export';
 import { apiDescribe, withTestDb, withTestDoc } from '../util/helpers';
 
-import * as testHelpers from '../../util/helpers';
-
 apiDescribe('Firestore', persistence => {
   function expectRoundtrip(
     db: firestore.FirebaseFirestore,

--- a/packages/firestore/test/integration/api_internal/idle_timeout.test.ts
+++ b/packages/firestore/test/integration/api_internal/idle_timeout.test.ts
@@ -16,6 +16,7 @@
 
 import { apiDescribe, withTestDb } from '../util/helpers';
 import { drainAsyncQueue } from '../util/internal_helpers';
+import { Deferred } from '../../util/promise';
 
 apiDescribe('Idle Timeout', persistence => {
   it('can write document after idle timeout', () => {

--- a/packages/firestore/test/integration/api_internal/idle_timeout.ts
+++ b/packages/firestore/test/integration/api_internal/idle_timeout.ts
@@ -1,0 +1,56 @@
+/**
+ * Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { apiDescribe, withTestDb } from '../util/helpers';
+import { drainAsyncQueue } from '../util/internal_helpers';
+
+apiDescribe('Idle Timeout', persistence => {
+  it('can write document after idle timeout', () => {
+    return withTestDb(persistence, db => {
+      const docRef = db.collection('test-collection').doc();
+      return docRef
+        .set({ foo: 'bar' })
+        .then(() => {
+          return drainAsyncQueue(db);
+        })
+        .then(() => docRef.set({ foo: 'bar' }));
+    });
+  });
+
+  it('can watch documents after idle timeout', () => {
+    return withTestDb(persistence, db => {
+      const awaitOnlineSnapshot = () => {
+        const docRef = db.collection('test-collection').doc();
+        const deferred = new Deferred<void>();
+        const unregister = docRef.onSnapshot(
+          { includeMetadataChanges: true },
+          snapshot => {
+            if (!snapshot.metadata.fromCache) {
+              deferred.resolve();
+            }
+          }
+        );
+        return deferred.promise.then(unregister);
+      };
+
+      return awaitOnlineSnapshot()
+        .then(() => {
+          return drainAsyncQueue(db);
+        })
+        .then(() => awaitOnlineSnapshot());
+    });
+  });
+});

--- a/packages/firestore/test/integration/browser/webchannel.test.ts
+++ b/packages/firestore/test/integration/browser/webchannel.test.ts
@@ -18,7 +18,8 @@ import * as api from '../../../src/protos/firestore_proto_api';
 import { expect } from 'chai';
 import { WebChannelConnection } from '../../../src/platform_browser/webchannel_connection';
 import { DatabaseId, DatabaseInfo } from '../../../src/core/database_info';
-import * as utilHelpers from '../util/helpers';
+import {DEFAULT_PROJECT_ID} from '../util/helpers';
+import {getDefaultDatabaseInfo} from '../util/internal_helpers';
 
 const describeFn = typeof window !== 'undefined' ? describe : xdescribe;
 describeFn('WebChannel', () => {
@@ -42,8 +43,8 @@ describeFn('WebChannel', () => {
   });
 
   it('receives error messages', done => {
-    const projectId = utilHelpers.DEFAULT_PROJECT_ID;
-    const info = utilHelpers.getDefaultDatabaseInfo();
+    const projectId = DEFAULT_PROJECT_ID;
+    const info = getDefaultDatabaseInfo();
     const conn = new WebChannelConnection(info);
     const stream = conn.openStream<api.ListenRequest, api.ListenResponse>(
       'Listen',

--- a/packages/firestore/test/integration/browser/webchannel.test.ts
+++ b/packages/firestore/test/integration/browser/webchannel.test.ts
@@ -18,8 +18,8 @@ import * as api from '../../../src/protos/firestore_proto_api';
 import { expect } from 'chai';
 import { WebChannelConnection } from '../../../src/platform_browser/webchannel_connection';
 import { DatabaseId, DatabaseInfo } from '../../../src/core/database_info';
-import {DEFAULT_PROJECT_ID} from '../util/helpers';
-import {getDefaultDatabaseInfo} from '../util/internal_helpers';
+import { DEFAULT_PROJECT_ID } from '../util/helpers';
+import { getDefaultDatabaseInfo } from '../util/internal_helpers';
 
 const describeFn = typeof window !== 'undefined' ? describe : xdescribe;
 describeFn('WebChannel', () => {

--- a/packages/firestore/test/integration/remote/remote.test.ts
+++ b/packages/firestore/test/integration/remote/remote.test.ts
@@ -24,7 +24,7 @@ import {
 import { MutationResult } from '../../../src/model/mutation';
 import { addEqualityMatcher } from '../../util/equality_matcher';
 import { key, setMutation } from '../../util/helpers';
-import { withTestDatastore } from '../util/helpers';
+import { withTestDatastore } from '../util/internal_helpers';
 
 describe('Remote Storage', () => {
   addEqualityMatcher();

--- a/packages/firestore/test/integration/remote/stream.test.ts
+++ b/packages/firestore/test/integration/remote/stream.test.ts
@@ -32,7 +32,7 @@ import { AsyncQueue } from '../../../src/util/async_queue';
 import { Deferred } from '../../../src/util/promise';
 import { Datastore } from '../../../src/remote/datastore';
 import { setMutation } from '../../util/helpers';
-import { drainAsyncQueue, withTestDatastore } from '../util/helpers';
+import { drainAsyncQueue, withTestDatastore } from '../util/internal_helpers';
 import { FirestoreError } from '@firebase/firestore-types';
 
 /**

--- a/packages/firestore/test/integration/util/events_accumulator.ts
+++ b/packages/firestore/test/integration/util/events_accumulator.ts
@@ -1,0 +1,71 @@
+/**
+ * Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Deferred } from '@firebase/util';
+import { expect } from 'chai';
+
+/**
+ * A helper object that can accumulate an arbitrary amount of events and resolve
+ * a promise when expected number has been emitted.
+ */
+export class EventsAccumulator<T> {
+  private events: T[] = [];
+  private waitingFor: number;
+  private deferred: Deferred<T[]> | null = null;
+
+  storeEvent: (evt: T) => void = (evt: T) => {
+    this.events.push(evt);
+    this.checkFulfilled();
+  };
+
+  awaitEvents(length: number): Promise<T[]> {
+    expect(this.deferred).to.equal(null, 'Already waiting for events.');
+    this.waitingFor = length;
+    this.deferred = new Deferred<T[]>();
+    const promise = this.deferred.promise;
+    this.checkFulfilled();
+    return promise;
+  }
+
+  awaitEvent(): Promise<T> {
+    return this.awaitEvents(1).then(events => events[0]);
+  }
+
+  assertNoAdditionalEvents(): Promise<void> {
+    return new Promise((resolve: (val: void) => void, reject) => {
+      setTimeout(() => {
+        if (this.events.length > 0) {
+          reject(
+            'Received ' +
+              this.events.length +
+              ' events: ' +
+              JSON.stringify(this.events)
+          );
+        } else {
+          resolve(undefined);
+        }
+      }, 0);
+    });
+  }
+
+  private checkFulfilled() {
+    if (this.deferred !== null && this.events.length >= this.waitingFor) {
+      const events = this.events.splice(0, this.waitingFor);
+      this.deferred.resolve(events);
+      this.deferred = null;
+    }
+  }
+}

--- a/packages/firestore/test/integration/util/internal_helpers.ts
+++ b/packages/firestore/test/integration/util/internal_helpers.ts
@@ -1,0 +1,65 @@
+/**
+ * Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as firestore from '@firebase/firestore-types';
+
+import { DatabaseId, DatabaseInfo } from '../../../src/core/database_info';
+import { Datastore } from '../../../src/remote/datastore';
+
+import { EmptyCredentialsProvider } from '../../../src/api/credentials';
+import { PlatformSupport } from '../../../src/platform/platform';
+import { AsyncQueue } from '../../../src/util/async_queue';
+import { DEFAULT_SETTINGS, DEFAULT_PROJECT_ID } from './helpers';
+import { Firestore } from '../../../src/api/database';
+
+/** Drains the AsyncQueue. Delayed tasks are executed immediately. */
+export function drainAsyncQueue(
+  db: firestore.FirebaseFirestore
+): Promise<void> {
+  return (db as Firestore)._queue.drain(/* executeDelayedTasks= */ true);
+}
+
+export function getDefaultDatabaseInfo(): DatabaseInfo {
+  return new DatabaseInfo(
+    new DatabaseId(DEFAULT_PROJECT_ID),
+    'persistenceKey',
+    DEFAULT_SETTINGS.host,
+    DEFAULT_SETTINGS.ssl
+  );
+}
+
+export function withTestDatastore(
+  fn: (datastore: Datastore) => Promise<void>,
+  queue?: AsyncQueue
+): Promise<void> {
+  const databaseInfo = getDefaultDatabaseInfo();
+  return PlatformSupport.getPlatform()
+    .loadConnection(databaseInfo)
+    .then(conn => {
+      const serializer = PlatformSupport.getPlatform().newSerializer(
+        databaseInfo.databaseId
+      );
+      const datastore = new Datastore(
+        databaseInfo,
+        queue || new AsyncQueue(),
+        conn,
+        new EmptyCredentialsProvider(),
+        serializer
+      );
+
+      return fn(datastore);
+    });
+}

--- a/packages/firestore/test/util/promise.ts
+++ b/packages/firestore/test/util/promise.ts
@@ -1,0 +1,36 @@
+/**
+ * Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export interface Resolver<R> {
+  (value?: R | Promise<R>): void;
+}
+
+export interface Rejecter {
+  (reason?: Error): void;
+}
+
+export class Deferred<R> {
+  promise: Promise<R>;
+  resolve: Resolver<R>;
+  reject: Rejecter;
+
+  constructor() {
+    this.promise = new Promise((resolve: Resolver<R>, reject: Rejecter) => {
+      this.resolve = resolve;
+      this.reject = reject;
+    });
+  }
+}


### PR DESCRIPTION
This lets us run these tests (via firebase-js-sdk/integration/firestore/)
against the minified build without risk of accidentally mixing in non-minified
classes (leading to tests misbehaving or skipping testing the minified code
that we were intending to test).

Fixes b/71721842 and b/66946692.

Changes include:
* Split integration/api into api/ and api_internal/
  * Move Idle Timeout tests (that drain the async queue) to api_internal/ and
    remove semi-public db.INTERNAL.drainAsyncQueue() method.
* Remove src/ dependencies from integration/api tests:
  * Split integration/util/helpers.ts into helpers.ts (with no src/
    dependencies) and internal_helpers.ts (with src/ dependencies).
  * Create test/util/promise.ts with Deferred<> implementation to avoid depending
    on src/util/promise.ts.
  * Move EventsAccumulator into its own
    test/integration/util/events_accumulator.ts file.
* Change minified test build (/integration/firestore/) to only include the
  desired test/ code without pulling over any src/ code (protect us from 
  accidental src/ dependencies).