### PR TITLE
Allowing localhost URL with port

### DIFF
--- a/packages/database/src/core/util/libs/parser.ts
+++ b/packages/database/src/core/util/libs/parser.ts
@@ -127,7 +127,14 @@ export const parseURL = function(
     host = dataURL.substring(0, slashInd);
     pathString = decodePath(dataURL.substring(slashInd));
 
+    // If we have a port, use scheme for determining if it's secure.
     colonInd = host.indexOf(':');
+    if (colonInd >= 0) {
+      secure = scheme === 'https' || scheme === 'wss';
+      port = parseInt(host.substring(colonInd + 1), 10);
+    } else {
+      colonInd = dataURL.length;
+    }
 
     const parts = host.split('.');
     if (parts.length === 3) {
@@ -138,12 +145,6 @@ export const parseURL = function(
       domain = parts[0];
     } else if (parts[0].slice(0, colonInd).toLowerCase() === 'localhost') {
       domain = 'localhost';
-    }
-
-    // If we have a port, use scheme for determining if it's secure.
-    if (colonInd >= 0) {
-      secure = scheme === 'https' || scheme === 'wss';
-      port = parseInt(host.substring(colonInd + 1), 10);
     }
   }
 

--- a/packages/database/test/database.test.ts
+++ b/packages/database/test/database.test.ts
@@ -64,10 +64,16 @@ describe('Database Tests', function() {
     expect(db.ref().toString()).to.equal('https://foo.bar.com/');
   });
 
-  it('Can get database with localhost URL', function() {
+  it('Can get database with localhost URL and port', function() {
     var db = defaultApp.database('http://localhost:80');
     expect(db).to.be.ok;
     expect(db.ref().toString()).to.equal('http://localhost:80/');
+  });
+
+  it('Can get database with localhost URL', function() {
+    var db = defaultApp.database('http://localhost');
+    expect(db).to.be.ok;
+    expect(db.ref().toString()).to.equal('https://localhost/');
   });
 
   it('Different instances for different URLs', function() {


### PR DESCRIPTION
The builds on top of: https://github.com/firebase/firebase-js-sdk/pull/426 (@rynobax)

#426 added support for `localhost:<port>`, and this PR allows `localhost` without the `<port>`.

