### PR TITLE
Remove SortedMap.getPredecessorKey

### DIFF
--- a/packages/firestore/src/model/document_set.ts
+++ b/packages/firestore/src/model/document_set.ts
@@ -79,20 +79,6 @@ export class DocumentSet {
   }
 
   /**
-   * Returns previous document or null if it's a first doc.
-   *
-   * @param key A key that MUST be present in the DocumentSet.
-   */
-  prevDoc(key: DocumentKey): Document | null {
-    assert(
-      this.has(key),
-      'Trying to get a previous document to non-existing key: ' + key
-    );
-    const doc = this.keyedMap.get(key);
-    return this.sortedSet.getPredecessorKey(doc!);
-  }
-
-  /**
    * Returns the index of the provided key in the document set, or -1 if the
    * document key is not present in the set;
    */

--- a/packages/firestore/src/util/sorted_map.ts
+++ b/packages/firestore/src/util/sorted_map.ts
@@ -87,37 +87,6 @@ export class SortedMap<K, V> {
     return null;
   }
 
-  // Returns the key of the item *before* the specified key, or null if key is
-  // the first item.
-  getPredecessorKey(key: K): K | null {
-    let node = this.root;
-    let rightParent: LLRBNode<K, V> | LLRBEmptyNode<K, V> | null = null;
-    while (!node.isEmpty()) {
-      const cmp = this.comparator(key, node.key);
-      if (cmp === 0) {
-        if (!node.left.isEmpty()) {
-          node = node.left;
-          while (!node.right.isEmpty()) node = node.right;
-          return node.key;
-        } else if (rightParent) {
-          return rightParent.key;
-        } else {
-          return null; // first item.
-        }
-      } else if (cmp < 0) {
-        node = node.left;
-      } else if (cmp > 0) {
-        rightParent = node;
-        node = node.right;
-      }
-    }
-
-    throw fail(
-      'Attempted to find predecessor key for a nonexistent key.' +
-        '  What gives?'
-    );
-  }
-
   // Returns the index of the element in this sorted map, or -1 if it doesn't
   // exist.
   indexOf(key: K): number {

--- a/packages/firestore/test/unit/model/document_set.test.ts
+++ b/packages/firestore/test/unit/model/document_set.test.ts
@@ -50,10 +50,6 @@ describe('DocumentSet', () => {
     const results: Document[] = [];
     set.forEach((d: Document) => results.push(d));
     expect(results).to.deep.equal([d3, d1, d2]);
-
-    expect(set.prevDoc(d3.key)).to.deep.equal(null);
-    expect(set.prevDoc(d1.key)).to.deep.equal(d3);
-    expect(set.prevDoc(d2.key)).to.deep.equal(d1);
   });
 
   it('adds and deletes elements', () => {
@@ -90,7 +86,6 @@ describe('DocumentSet', () => {
     const set = documentSet(comp, doc1, doc2);
     expect(set.has(doc1.key)).to.equal(true);
     expect(set.has(doc2.key)).to.equal(true);
-    expect(set.prevDoc(doc2.key)).to.equal(doc1);
   });
 
   it('equals to other document set with the same elements and order', () => {

--- a/packages/firestore/test/unit/util/sorted_map.test.ts
+++ b/packages/firestore/test/unit/util/sorted_map.test.ts
@@ -412,23 +412,6 @@ describe('SortedMap Tests', () => {
     expect(expected).to.equal(10);
   });
 
-  it('SortedMap.getPredecessorKey works.', () => {
-    const map = new SortedMap(primitiveComparator)
-      .insert(1, 1)
-      .insert(50, 50)
-      .insert(3, 3)
-      .insert(4, 4)
-      .insert(7, 7)
-      .insert(9, 9);
-
-    expect(map.getPredecessorKey(1)).to.equal(null);
-    expect(map.getPredecessorKey(3)).to.equal(1);
-    expect(map.getPredecessorKey(4)).to.equal(3);
-    expect(map.getPredecessorKey(7)).to.equal(4);
-    expect(map.getPredecessorKey(9)).to.equal(7);
-    expect(map.getPredecessorKey(50)).to.equal(9);
-  });
-
   it('SortedMap.indexOf returns index.', () => {
     const map = new SortedMap(primitiveComparator)
       .insert(1, 1)


### PR DESCRIPTION
This is dead code.

I think it was probably useful in the RTDB because of the way it
notified of changes, but we give changes with indexes in Firestore so I
think we don't need it.

This parallels https://github.com/firebase/firebase-ios-sdk/pull/735