### PR TITLE
Refactor AsyncQueue's "delayed scheduling" support and add cancellation.

### DIFF
--- a/packages/firestore/src/remote/persistent_stream.ts
+++ b/packages/firestore/src/remote/persistent_stream.ts
@@ -256,6 +256,8 @@ export abstract class PersistentStream<
    * states imply pending network operations.
    */
   markIdle(): void {
+    // Starts the idle time if we are in state 'Open' and are not yet already
+    // running a timer (in which case the previous idle timeout still applies).
     if (this.isOpen() && this.inactivityTimerPromise === null) {
       this.inactivityTimerPromise = this.queue.scheduleWithDelay(
         () => this.handleIdleCloseTimer(),

--- a/packages/firestore/src/remote/persistent_stream.ts
+++ b/packages/firestore/src/remote/persistent_stream.ts
@@ -31,6 +31,7 @@ import { Connection, Stream } from './connection';
 import { JsonProtoSerializer } from './serializer';
 import { WatchChange } from './watch_change';
 import { isNullOrUndefined } from '../util/types';
+import { CancelablePromise } from '../util/promise';
 
 const LOG_TAG = 'PersistentStream';
 
@@ -154,7 +155,7 @@ export abstract class PersistentStream<
   ListenerType extends PersistentStreamListener
 > {
   private state: PersistentStreamState;
-  private idle = false;
+  private inactivityTimerPromise: CancelablePromise<void> | null = null;
   private stream: Stream<SendType, ReceiveType> | null = null;
 
   protected backoff: ExponentialBackoff;
@@ -245,16 +246,23 @@ export abstract class PersistentStream<
   }
 
   /**
-   * Initializes the idle timer. If no write takes place within one minute, the
-   * WebChannel stream will be closed.
+   * Marks this stream as idle. If no further actions are performed on the
+   * stream for one minute, the stream will automatically close itself and
+   * notify the stream's onClose() handler with Status.OK. The stream will then
+   * be in a !isStarted() state, requiring the caller to start the stream again
+   * before further use.
+   *
+   * Only streams that are in state 'Open' can be marked idle, as all other
+   * states imply pending network operations.
    */
   markIdle(): void {
-    this.idle = true;
-    this.queue
-      .scheduleWithDelay(() => {
-        return this.handleIdleCloseTimer();
-      }, IDLE_TIMEOUT_MS)
-      .promise.catch((err: FirestoreError) => {
+    if (this.isOpen() && this.inactivityTimerPromise === null) {
+      this.inactivityTimerPromise = this.queue.scheduleWithDelay(
+        () => this.handleIdleCloseTimer(),
+        IDLE_TIMEOUT_MS
+      );
+
+      this.inactivityTimerPromise.catch((err: FirestoreError) => {
         // When the AsyncQueue gets drained during testing, pending Promises
         // (including these idle checks) will get rejected. We special-case
         // these cancelled idle checks to make sure that these specific Promise
@@ -266,6 +274,7 @@ export abstract class PersistentStream<
           }`
         );
       });
+    }
   }
 
   /** Sends a message to the underlying stream. */
@@ -276,7 +285,7 @@ export abstract class PersistentStream<
 
   /** Called by the idle timer when the stream should close due to inactivity. */
   private handleIdleCloseTimer(): Promise<void> {
-    if (this.isOpen() && this.idle) {
+    if (this.isOpen()) {
       // When timing out an idle stream there's no reason to force the stream into backoff when
       // it restarts so set the stream state to Initial instead of Error.
       return this.close(PersistentStreamState.Initial);
@@ -286,7 +295,10 @@ export abstract class PersistentStream<
 
   /** Marks the stream as active again. */
   private cancelIdleCheck() {
-    this.idle = false;
+    if (this.inactivityTimerPromise) {
+      this.inactivityTimerPromise.cancel();
+      this.inactivityTimerPromise = null;
+    }
   }
 
   /**

--- a/packages/firestore/src/remote/persistent_stream.ts
+++ b/packages/firestore/src/remote/persistent_stream.ts
@@ -251,10 +251,10 @@ export abstract class PersistentStream<
   markIdle(): void {
     this.idle = true;
     this.queue
-      .schedule(() => {
+      .scheduleWithDelay(() => {
         return this.handleIdleCloseTimer();
       }, IDLE_TIMEOUT_MS)
-      .catch((err: FirestoreError) => {
+      .promise.catch((err: FirestoreError) => {
         // When the AsyncQueue gets drained during testing, pending Promises
         // (including these idle checks) will get rejected. We special-case
         // these cancelled idle checks to make sure that these specific Promise

--- a/packages/firestore/src/util/async_queue.ts
+++ b/packages/firestore/src/util/async_queue.ts
@@ -50,13 +50,18 @@ class DelayedOperation<T> implements CancelablePromise<T> {
     asyncQueue: AsyncQueue,
     op: () => Promise<T>,
     delayMs: number
-  ) {
+  ): DelayedOperation<T> {
     const delayedOp = new DelayedOperation(asyncQueue, op);
-    delayedOp.timerHandle = setTimeout(
-      () => delayedOp.handleDelayElapsed(),
-      delayMs
-    );
+    delayedOp.start(delayMs);
     return delayedOp;
+  }
+
+  /**
+   * Starts the timer. This is called immediately after construction by
+   * createAndSchedule().
+   */
+  private start(delayMs: number): void {
+    this.timerHandle = setTimeout(() => this.handleDelayElapsed(), delayMs);
   }
 
   /**
@@ -70,6 +75,9 @@ class DelayedOperation<T> implements CancelablePromise<T> {
   /**
    * Cancels the operation if it hasn't already been executed or canceled. The
    * promise will be rejected.
+   *
+   * As long as the operation has not yet been run, calling cancel() provides a
+   * guarantee that the operation will not be run.
    */
   cancel(reason?: string): void {
     if (this.timerHandle !== null) {

--- a/packages/firestore/src/util/promise.ts
+++ b/packages/firestore/src/util/promise.ts
@@ -24,6 +24,10 @@ export interface Rejecter {
   (reason?: Error): void;
 }
 
+export interface CancelablePromise<T> extends Promise<T> {
+  cancel(): void;
+}
+
 export class Deferred<R> {
   promise: Promise<R>;
   resolve: Resolver<R>;


### PR DESCRIPTION
* Introduces a DelayedOperation helper class in AsyncQueue to encapsulate
  delayed op logic.
* Adds cancellation support which I want to use in
  https://github.com/firebase/firebase-js-sdk/pull/412
* Remove delayedOperationsCount in favor of keeping delayedOperations populated
  correctly at all times.
* Fixes a preexisting issue in AsyncQueue.schedule() where the returned promise
  would always be resolved with undefined, instead of the result of your op.
  Also remove an AnyDuringMigration usage.
