### PR TITLE
Release CLI Fixes

### DIFF
--- a/.yarnrc
+++ b/.yarnrc
@@ -1,1 +1,1 @@
-registry "http://localhost:4873"
+registry "https://registry.npmjs.org/"

--- a/.yarnrc
+++ b/.yarnrc
@@ -1,1 +1,1 @@
-registry "https://registry.npmjs.org/"
+registry "http://localhost:4873"

--- a/scripts/release/cli.js
+++ b/scripts/release/cli.js
@@ -195,12 +195,12 @@ const { argv } = require('yargs');
         /**
          * Commit the version changes and tag the associated versions
          */
-        await commitAndTag(versions, releaseType);
+        const tags = await commitAndTag(versions, releaseType);
 
         /**
          * Push new version to Github
          */
-        await pushUpdatesToGithub();
+        await pushUpdatesToGithub(tags);
       }
     }
 

--- a/scripts/release/cli.js
+++ b/scripts/release/cli.js
@@ -154,11 +154,16 @@ const { argv } = require('yargs');
     await updateWorkspaceVersions(versions, argv.canary);
 
     /**
-     * Clean install dependencies
+     * Users can pass --skipRebuild to skip the rebuild step
      */
-    console.log('\r\nVerifying Build');
-    await cleanTree();
-    await reinstallDeps();
+    if (!argv.skipRebuild) {
+      /**
+       * Clean install dependencies
+       */
+      console.log('\r\nVerifying Build');
+      await cleanTree();
+      await reinstallDeps();
+    }
 
     /**
      * Don't do the following for canary releases:
@@ -171,8 +176,14 @@ const { argv } = require('yargs');
       /**
        * Ensure all tests are passing
        */
-      await setupTestDeps();
-      await runTests();
+
+      /**
+       * Users can pass --skipTests to skip the testing step
+       */
+      if (!argv.skipTests) {
+        await setupTestDeps();
+        await runTests();
+      }
 
       const { readyToPush } = await prompt(validateReadyToPush);
       if (!readyToPush) throw new Error('Push Check Failed');

--- a/scripts/release/utils/git.js
+++ b/scripts/release/utils/git.js
@@ -43,10 +43,7 @@ exports.commitAndTag = async (updatedVersions, releaseType) => {
 };
 
 exports.pushUpdatesToGithub = async () => {
-  await git.push('origin', 'master', {
-    '--follow-tags': null,
-    '--no-verify': null
-  });
+  await exec(`git push origin --follow-tags --no-verify -u`, { cwd: root });
 };
 
 exports.resetWorkingTree = async () => {

--- a/scripts/release/utils/git.js
+++ b/scripts/release/utils/git.js
@@ -32,16 +32,23 @@ exports.cleanTree = async () => {
 
 exports.commitAndTag = async (updatedVersions, releaseType) => {
   await exec('git add */package.json');
-  await exec(`git commit -m "Publish firebase@${updatedVersions.firebase}"`);
+
+  let result = await exec(`git commit -m "Publish firebase@${updatedVersions.firebase}"`);
+
+  console.log(result);
+
   await Promise.all(
     Object.keys(updatedVersions)
       .map(name => ({ name, version: updatedVersions[name] }))
-      .map(({name, version}) => exec(`git tag ${name}@${version}`))
+      .map(async ({name, version}) => {
+        const result = await exec(`git tag ${name}@${version}`);
+        console.log(result);
+      })
   );
 };
 
 exports.pushUpdatesToGithub = async () => {
-  let { stdout:currentBranch } = await exec(`git rev-parse --abbrev-ref HEAD`);
+  let { stdout:currentBranch, stderr } = await exec(`git rev-parse --abbrev-ref HEAD`);
   currentBranch = currentBranch.trim();
   
   await exec(`git push origin ${currentBranch} --follow-tags --no-verify -u`, { cwd: root });

--- a/scripts/release/utils/git.js
+++ b/scripts/release/utils/git.js
@@ -43,7 +43,10 @@ exports.commitAndTag = async (updatedVersions, releaseType) => {
 };
 
 exports.pushUpdatesToGithub = async () => {
-  await exec(`git push origin --follow-tags --no-verify -u`, { cwd: root });
+  let { stdout:currentBranch } = await exec(`git rev-parse --abbrev-ref HEAD`);
+  currentBranch = currentBranch.trim();
+  
+  await exec(`git push origin ${currentBranch} --follow-tags --no-verify -u`, { cwd: root });
 };
 
 exports.resetWorkingTree = async () => {

--- a/scripts/release/utils/git.js
+++ b/scripts/release/utils/git.js
@@ -33,19 +33,21 @@ exports.cleanTree = async () => {
 /**
  * Commits the current state of the repository and tags it with the appropriate
  * version changes.
- * 
+ *
  * Returns the tagged commits
  */
 exports.commitAndTag = async (updatedVersions, releaseType) => {
   await exec('git add */package.json');
 
-  let result = await exec(`git commit -m "Publish firebase@${updatedVersions.firebase}"`);
+  let result = await exec(
+    `git commit -m "Publish firebase@${updatedVersions.firebase}"`
+  );
 
   const tags = [];
   await Promise.all(
     Object.keys(updatedVersions)
       .map(name => ({ name, version: updatedVersions[name] }))
-      .map(async ({name, version}) => {
+      .map(async ({ name, version }) => {
         const tag = `${name}@${version}`;
         const result = await exec(`git tag ${tag}`);
         tags.push(tag);
@@ -55,9 +57,11 @@ exports.commitAndTag = async (updatedVersions, releaseType) => {
 };
 
 exports.pushUpdatesToGithub = async tags => {
-  let { stdout:currentBranch, stderr } = await exec(`git rev-parse --abbrev-ref HEAD`);
+  let { stdout: currentBranch, stderr } = await exec(
+    `git rev-parse --abbrev-ref HEAD`
+  );
   currentBranch = currentBranch.trim();
-  
+
   await exec(`git push origin ${currentBranch} --no-verify -u`, { cwd: root });
   await exec(`git push origin ${tags.join(' ')}`);
 };

--- a/scripts/release/utils/git.js
+++ b/scripts/release/utils/git.js
@@ -36,7 +36,7 @@ exports.cleanTree = async () => {
  *
  * Returns the tagged commits
  */
-exports.commitAndTag = async (updatedVersions, releaseType) => {
+exports.commitAndTag = async updatedVersions => {
   await exec('git add */package.json');
 
   let result = await exec(

--- a/scripts/release/utils/git.js
+++ b/scripts/release/utils/git.js
@@ -31,15 +31,13 @@ exports.cleanTree = async () => {
 };
 
 exports.commitAndTag = async (updatedVersions, releaseType) => {
-  await git.add('*/package.json');
-  await git.commit(
-    releaseType === 'Staging' ? 'Publish Prerelease' : 'Publish'
+  await exec('git add */package.json');
+  await exec(`git commit -m "Publish firebase@${updatedVersions.firebase}"`);
+  await Promise.all(
+    Object.keys(updatedVersions)
+      .map(name => ({ name, version: updatedVersions[name] }))
+      .map(({name, version}) => exec(`git tag ${name}@${version}`))
   );
-  Object.keys(updatedVersions)
-    .map(name => ({ name, version: updatedVersions[name] }))
-    .forEach(async ({ name, version }) => {
-      await git.addTag(`${name}@${version}`);
-    });
 };
 
 exports.pushUpdatesToGithub = async () => {


### PR DESCRIPTION
Fixes some issues/deficiencies in the release CLI

1. Fixes an issue where `--follow-tags` wasn't functioning as expected
1. Added some flags to skip various parts of the build process