### PR TITLE
Adding no-unused-vars to TSLint

### DIFF
--- a/packages/firestore/package.json
+++ b/packages/firestore/package.json
@@ -5,8 +5,8 @@
   "author": "Firebase <firebase-support@google.com> (https://firebase.google.com/)",
   "scripts": {
     "dev": "gulp dev",
-    "lint": "tslint -p tsconfig.json -c tslint.json firestore src/**/*.ts test/**/*.ts",
-    "lint:fix": "tslint -p tsconfig.json -c tslint.json --fix firestore src/**/*.ts test/**/*.ts",
+    "lint": "tslint -p tsconfig.json -c tslint.json src/**/*.ts test/**/*.ts",
+    "lint:fix": "tslint --fix -p tsconfig.json -c tslint.json  src/**/*.ts test/**/*.ts",
     "test": "run-s lint test:all",
     "test:all": "run-p test:browser test:node",
     "test:browser": "karma start --single-run",

--- a/packages/firestore/package.json
+++ b/packages/firestore/package.json
@@ -5,7 +5,8 @@
   "author": "Firebase <firebase-support@google.com> (https://firebase.google.com/)",
   "scripts": {
     "dev": "gulp dev",
-    "lint": "tslint -c tslint.json src/**/*.ts test/**/*.ts",
+    "lint": "tslint -p tsconfig.json -c tslint.json firestore src/**/*.ts test/**/*.ts",
+    "lint:fix": "tslint -p tsconfig.json -c tslint.json --fix firestore src/**/*.ts test/**/*.ts",
     "test": "run-s lint test:all",
     "test:all": "run-p test:browser test:node",
     "test:browser": "karma start --single-run",

--- a/packages/firestore/src/api/credentials.ts
+++ b/packages/firestore/src/api/credentials.ts
@@ -17,7 +17,6 @@
 import { User } from '../auth/user';
 import { assert, fail } from '../util/assert';
 import { Code, FirestoreError } from '../util/error';
-import { AnyJs } from '../util/misc';
 import { FirebaseApp } from '@firebase/app-types';
 import { _FirebaseApp } from '@firebase/app-types/private';
 

--- a/packages/firestore/src/api/database.ts
+++ b/packages/firestore/src/api/database.ts
@@ -33,10 +33,7 @@ import {
   RelationOp
 } from '../core/query';
 import { Transaction as InternalTransaction } from '../core/transaction';
-import {
-  ChangeType,
-  ViewSnapshot
-} from '../core/view_snapshot';
+import { ChangeType, ViewSnapshot } from '../core/view_snapshot';
 import { Document, MaybeDocument, NoDocument } from '../model/document';
 import { DocumentKey } from '../model/document_key';
 import {

--- a/packages/firestore/src/api/database.ts
+++ b/packages/firestore/src/api/database.ts
@@ -35,7 +35,6 @@ import {
 import { Transaction as InternalTransaction } from '../core/transaction';
 import {
   ChangeType,
-  DocumentViewChange,
   ViewSnapshot
 } from '../core/view_snapshot';
 import { Document, MaybeDocument, NoDocument } from '../model/document';

--- a/packages/firestore/src/api/user_data_converter.ts
+++ b/packages/firestore/src/api/user_data_converter.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-
 import { DatabaseId } from '../core/database_info';
 import { Timestamp } from '../core/timestamp';
 import { DocumentKey } from '../model/document_key';

--- a/packages/firestore/src/api/user_data_converter.ts
+++ b/packages/firestore/src/api/user_data_converter.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import * as firestore from '@firebase/firestore-types';
 
 import { DatabaseId } from '../core/database_info';
 import { Timestamp } from '../core/timestamp';
@@ -247,13 +246,6 @@ class ParseContext {
     if (isWrite(this.dataSource) && RESERVED_FIELD_REGEX.test(segment)) {
       throw this.createError('Document fields cannot begin and end with __');
     }
-  }
-
-  private isWrite(): boolean {
-    return (
-      this.dataSource === UserDataSource.Set ||
-      this.dataSource === UserDataSource.Update
-    );
   }
 }
 /**

--- a/packages/firestore/src/core/event_manager.ts
+++ b/packages/firestore/src/core/event_manager.ts
@@ -22,7 +22,6 @@ import { ChangeType, ViewSnapshot } from './view_snapshot';
 import { DocumentSet } from '../model/document_set';
 import { assert } from '../util/assert';
 import { EventHandler } from '../util/misc';
-import * as obj from '../util/obj';
 import { ObjectMap } from '../util/obj_map';
 
 /**

--- a/packages/firestore/src/core/firestore_client.ts
+++ b/packages/firestore/src/core/firestore_client.ts
@@ -273,7 +273,12 @@ export class FirestoreClient {
         const serializer = this.platform.newSerializer(
           this.databaseInfo.databaseId
         );
-        const datastore = new Datastore(this.asyncQueue, connection, this.credentials, serializer);
+        const datastore = new Datastore(
+          this.asyncQueue,
+          connection,
+          this.credentials,
+          serializer
+        );
 
         const onlineStateChangedHandler = (onlineState: OnlineState) => {
           this.syncEngine.applyOnlineStateChange(onlineState);

--- a/packages/firestore/src/core/firestore_client.ts
+++ b/packages/firestore/src/core/firestore_client.ts
@@ -273,13 +273,7 @@ export class FirestoreClient {
         const serializer = this.platform.newSerializer(
           this.databaseInfo.databaseId
         );
-        const datastore = new Datastore(
-          this.databaseInfo,
-          this.asyncQueue,
-          connection,
-          this.credentials,
-          serializer
-        );
+        const datastore = new Datastore(this.asyncQueue, connection, this.credentials, serializer);
 
         const onlineStateChangedHandler = (onlineState: OnlineState) => {
           this.syncEngine.applyOnlineStateChange(onlineState);

--- a/packages/firestore/src/local/indexeddb_mutation_queue.ts
+++ b/packages/firestore/src/local/indexeddb_mutation_queue.ts
@@ -514,8 +514,8 @@ export class IndexedDbMutationQueue implements MutationQueue {
     const startRange = IDBKeyRange.lowerBound(indexKey);
     let containsKey = false;
     return documentMutationsStore(txn)
-      .iterate({ range: startRange, keysOnly: true }, (key, _, control) => {
-        const [userID, keyPath] = key;
+      .iterate({ range: startRange, keysOnly: true }, (key, value, control) => {
+        const [userID, keyPath, /*batchID*/ _] = key;
         if (userID === this.userId && keyPath === encodedPath) {
           containsKey = true;
         }

--- a/packages/firestore/src/local/indexeddb_mutation_queue.ts
+++ b/packages/firestore/src/local/indexeddb_mutation_queue.ts
@@ -222,7 +222,6 @@ export class IndexedDbMutationQueue implements MutationQueue {
       .next(() => {
         const promises: Array<PersistencePromise<void>> = [];
         for (const mutation of mutations) {
-          const encodedPath = EncodedResourcePath.encode(mutation.key.path);
           const indexKey = DbDocumentMutation.key(
             this.userId,
             mutation.key.path,
@@ -379,7 +378,6 @@ export class IndexedDbMutationQueue implements MutationQueue {
       this.userId,
       queryPath
     );
-    const encodedQueryPath = indexPrefix[1];
     const indexStart = IDBKeyRange.lowerBound(indexPrefix);
 
     // Collect up unique batchIDs encountered during a scan of the index. Use a
@@ -517,7 +515,7 @@ export class IndexedDbMutationQueue implements MutationQueue {
     let containsKey = false;
     return documentMutationsStore(txn)
       .iterate({ range: startRange, keysOnly: true }, (key, _, control) => {
-        const [userID, keyPath, batchID] = key;
+        const [userID, keyPath] = key;
         if (userID === this.userId && keyPath === encodedPath) {
           containsKey = true;
         }

--- a/packages/firestore/src/local/indexeddb_query_cache.ts
+++ b/packages/firestore/src/local/indexeddb_query_cache.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import * as api from '../protos/firestore_proto_api';
 import { Query } from '../core/query';
 import { SnapshotVersion } from '../core/snapshot_version';
 import { Timestamp } from '../core/timestamp';
@@ -27,7 +26,6 @@ import { immediateSuccessor } from '../util/misc';
 import * as EncodedResourcePath from './encoded_resource_path';
 import { GarbageCollector } from './garbage_collector';
 import {
-  DbQuery,
   DbTarget,
   DbTargetDocument,
   DbTargetDocumentKey,
@@ -237,7 +235,6 @@ export class IndexedDbQueryCache implements QueryCache {
     txn: PersistenceTransaction,
     targetId: TargetId
   ): PersistencePromise<DocumentKeySet> {
-    const promises: Array<PersistencePromise<void>> = [];
     const range = IDBKeyRange.bound(
       [targetId],
       [targetId + 1],

--- a/packages/firestore/src/local/memory_query_cache.ts
+++ b/packages/firestore/src/local/memory_query_cache.ts
@@ -20,7 +20,6 @@ import { TargetId } from '../core/types';
 import { DocumentKeySet } from '../model/collections';
 import { DocumentKey } from '../model/document_key';
 import { ObjectMap } from '../util/obj_map';
-import { SortedSet } from '../util/sorted_set';
 
 import { GarbageCollector } from './garbage_collector';
 import { PersistenceTransaction } from './persistence';

--- a/packages/firestore/src/local/memory_remote_document_cache.ts
+++ b/packages/firestore/src/local/memory_remote_document_cache.ts
@@ -22,7 +22,6 @@ import {
 } from '../model/collections';
 import { Document, MaybeDocument } from '../model/document';
 import { DocumentKey } from '../model/document_key';
-import { DocumentSet } from '../model/document_set';
 
 import { PersistenceTransaction } from './persistence';
 import { PersistencePromise } from './persistence_promise';

--- a/packages/firestore/src/local/reference_set.ts
+++ b/packages/firestore/src/local/reference_set.ts
@@ -17,7 +17,6 @@
 import { BatchId, TargetId } from '../core/types';
 import { documentKeySet, DocumentKeySet } from '../model/collections';
 import { DocumentKey } from '../model/document_key';
-import { assert } from '../util/assert';
 import { primitiveComparator } from '../util/misc';
 import { SortedSet } from '../util/sorted_set';
 

--- a/packages/firestore/src/model/document_set.ts
+++ b/packages/firestore/src/model/document_set.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import { assert } from '../util/assert';
 import { SortedMap } from '../util/sorted_map';
 
 import { documentMap } from './collections';

--- a/packages/firestore/src/model/field_value.ts
+++ b/packages/firestore/src/model/field_value.ts
@@ -20,10 +20,8 @@ import { SnapshotOptions } from '../api/database';
 import { DatabaseId } from '../core/database_info';
 import { Timestamp } from '../core/timestamp';
 import { assert, fail } from '../util/assert';
-import { AnyJs, primitiveComparator } from '../util/misc';
-import * as objUtils from '../util/obj';
+import { primitiveComparator } from '../util/misc';
 import { SortedMap } from '../util/sorted_map';
-import * as typeUtils from '../util/types';
 
 import { DocumentKey } from './document_key';
 import { FieldPath } from './path';

--- a/packages/firestore/src/platform/config.ts
+++ b/packages/firestore/src/platform/config.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import * as firestore from '@firebase/firestore-types';
 import { FirebaseApp, FirebaseNamespace } from '@firebase/app-types';
 import { _FirebaseNamespace } from '@firebase/app-types/private';
 import { PublicBlob } from '../api/blob';

--- a/packages/firestore/src/platform_node/grpc_connection.ts
+++ b/packages/firestore/src/platform_node/grpc_connection.ts
@@ -29,7 +29,6 @@ import { mapCodeFromRpcCode } from '../remote/rpc_error';
 import { assert } from '../util/assert';
 import { FirestoreError } from '../util/error';
 import * as log from '../util/log';
-import { AnyJs } from '../util/misc';
 import { NodeCallback, nodePromise } from '../util/node_api';
 import { Deferred } from '../util/promise';
 
@@ -45,7 +44,7 @@ const X_GOOG_API_CLIENT_VALUE = `gl-node/${process.versions.node} fire/${
 type DuplexRpc = () => grpc.ClientDuplexStream;
 type ReadableRpc<Req> = (req: Req) => grpc.ClientReadableStream;
 type UnaryRpc<Req, Resp> = (
-  req,
+  req:Req,
   callback: (err?: grpc.ServiceError, resp?: Resp) => void
 ) => grpc.ClientUnaryCall;
 

--- a/packages/firestore/src/platform_node/grpc_connection.ts
+++ b/packages/firestore/src/platform_node/grpc_connection.ts
@@ -44,7 +44,7 @@ const X_GOOG_API_CLIENT_VALUE = `gl-node/${process.versions.node} fire/${
 type DuplexRpc = () => grpc.ClientDuplexStream;
 type ReadableRpc<Req> = (req: Req) => grpc.ClientReadableStream;
 type UnaryRpc<Req, Resp> = (
-  req:Req,
+  req: Req,
   callback: (err?: grpc.ServiceError, resp?: Resp) => void
 ) => grpc.ClientUnaryCall;
 

--- a/packages/firestore/src/remote/datastore.ts
+++ b/packages/firestore/src/remote/datastore.ts
@@ -46,18 +46,32 @@ interface CommitRequest extends api.CommitRequest {
  * client SDK architecture to consume.
  */
 export class Datastore {
-  constructor(private queue: AsyncQueue,
-              private connection: Connection,
-              private credentials: CredentialsProvider,
-              private serializer: JsonProtoSerializer,
-              private initialBackoffDelay?: number) {}
+  constructor(
+    private queue: AsyncQueue,
+    private connection: Connection,
+    private credentials: CredentialsProvider,
+    private serializer: JsonProtoSerializer,
+    private initialBackoffDelay?: number
+  ) {}
 
   newPersistentWriteStream(): PersistentWriteStream {
-    return new PersistentWriteStream(this.queue, this.connection, this.credentials, this.serializer, this.initialBackoffDelay);
+    return new PersistentWriteStream(
+      this.queue,
+      this.connection,
+      this.credentials,
+      this.serializer,
+      this.initialBackoffDelay
+    );
   }
 
   newPersistentWatchStream(): PersistentListenStream {
-    return new PersistentListenStream(this.queue, this.connection, this.credentials, this.serializer, this.initialBackoffDelay);
+    return new PersistentListenStream(
+      this.queue,
+      this.connection,
+      this.credentials,
+      this.serializer,
+      this.initialBackoffDelay
+    );
   }
 
   commit(mutations: Mutation[]): Promise<MutationResult[]> {

--- a/packages/firestore/src/remote/datastore.ts
+++ b/packages/firestore/src/remote/datastore.ts
@@ -16,7 +16,6 @@
 
 import * as api from '../protos/firestore_proto_api';
 import { CredentialsProvider } from '../api/credentials';
-import { DatabaseInfo } from '../core/database_info';
 import { maybeDocumentMap } from '../model/collections';
 import { MaybeDocument } from '../model/document';
 import { DocumentKey } from '../model/document_key';
@@ -27,9 +26,7 @@ import { AsyncQueue } from '../util/async_queue';
 import { Connection } from './connection';
 import {
   PersistentListenStream,
-  PersistentWriteStream,
-  WatchStreamListener,
-  WriteStreamListener
+  PersistentWriteStream
 } from './persistent_stream';
 import { JsonProtoSerializer } from './serializer';
 
@@ -49,35 +46,18 @@ interface CommitRequest extends api.CommitRequest {
  * client SDK architecture to consume.
  */
 export class Datastore {
-  constructor(
-    private databaseInfo: DatabaseInfo,
-    private queue: AsyncQueue,
-    private connection: Connection,
-    private credentials: CredentialsProvider,
-    private serializer: JsonProtoSerializer,
-    private initialBackoffDelay?: number
-  ) {}
+  constructor(private queue: AsyncQueue,
+              private connection: Connection,
+              private credentials: CredentialsProvider,
+              private serializer: JsonProtoSerializer,
+              private initialBackoffDelay?: number) {}
 
   newPersistentWriteStream(): PersistentWriteStream {
-    return new PersistentWriteStream(
-      this.databaseInfo,
-      this.queue,
-      this.connection,
-      this.credentials,
-      this.serializer,
-      this.initialBackoffDelay
-    );
+    return new PersistentWriteStream(this.queue, this.connection, this.credentials, this.serializer, this.initialBackoffDelay);
   }
 
   newPersistentWatchStream(): PersistentListenStream {
-    return new PersistentListenStream(
-      this.databaseInfo,
-      this.queue,
-      this.connection,
-      this.credentials,
-      this.serializer,
-      this.initialBackoffDelay
-    );
+    return new PersistentListenStream(this.queue, this.connection, this.credentials, this.serializer, this.initialBackoffDelay);
   }
 
   commit(mutations: Mutation[]): Promise<MutationResult[]> {

--- a/packages/firestore/src/remote/persistent_stream.ts
+++ b/packages/firestore/src/remote/persistent_stream.ts
@@ -532,11 +532,13 @@ export class PersistentListenStream extends PersistentStream<
   api.ListenResponse,
   WatchStreamListener
 > {
-  constructor(queue: AsyncQueue,
-              connection: Connection,
-              credentials: CredentialsProvider,
-              private serializer: JsonProtoSerializer,
-              initialBackoffDelay?: number) {
+  constructor(
+    queue: AsyncQueue,
+    connection: Connection,
+    credentials: CredentialsProvider,
+    private serializer: JsonProtoSerializer,
+    initialBackoffDelay?: number
+  ) {
     super(queue, connection, credentials, initialBackoffDelay);
   }
 
@@ -633,11 +635,13 @@ export class PersistentWriteStream extends PersistentStream<
 > {
   private handshakeComplete_ = false;
 
-  constructor(queue: AsyncQueue,
-              connection: Connection,
-              credentials: CredentialsProvider,
-              private serializer: JsonProtoSerializer,
-              initialBackoffDelay?: number) {
+  constructor(
+    queue: AsyncQueue,
+    connection: Connection,
+    credentials: CredentialsProvider,
+    private serializer: JsonProtoSerializer,
+    initialBackoffDelay?: number
+  ) {
     super(queue, connection, credentials, initialBackoffDelay);
   }
 

--- a/packages/firestore/src/remote/persistent_stream.ts
+++ b/packages/firestore/src/remote/persistent_stream.ts
@@ -16,7 +16,6 @@
 
 import * as api from '../protos/firestore_proto_api';
 import { CredentialsProvider, Token } from '../api/credentials';
-import { DatabaseInfo } from '../core/database_info';
 import { SnapshotVersion } from '../core/snapshot_version';
 import { ProtoByteString, TargetId } from '../core/types';
 import { QueryData } from '../local/query_data';
@@ -533,14 +532,11 @@ export class PersistentListenStream extends PersistentStream<
   api.ListenResponse,
   WatchStreamListener
 > {
-  constructor(
-    private databaseInfo: DatabaseInfo,
-    queue: AsyncQueue,
-    connection: Connection,
-    credentials: CredentialsProvider,
-    private serializer: JsonProtoSerializer,
-    initialBackoffDelay?: number
-  ) {
+  constructor(queue: AsyncQueue,
+              connection: Connection,
+              credentials: CredentialsProvider,
+              private serializer: JsonProtoSerializer,
+              initialBackoffDelay?: number) {
     super(queue, connection, credentials, initialBackoffDelay);
   }
 
@@ -637,14 +633,11 @@ export class PersistentWriteStream extends PersistentStream<
 > {
   private handshakeComplete_ = false;
 
-  constructor(
-    private databaseInfo: DatabaseInfo,
-    queue: AsyncQueue,
-    connection: Connection,
-    credentials: CredentialsProvider,
-    private serializer: JsonProtoSerializer,
-    initialBackoffDelay?: number
-  ) {
+  constructor(queue: AsyncQueue,
+              connection: Connection,
+              credentials: CredentialsProvider,
+              private serializer: JsonProtoSerializer,
+              initialBackoffDelay?: number) {
     super(queue, connection, credentials, initialBackoffDelay);
   }
 

--- a/packages/firestore/src/remote/remote_store.ts
+++ b/packages/firestore/src/remote/remote_store.ts
@@ -15,7 +15,6 @@
  */
 
 import { User } from '../auth/user';
-import { DatabaseInfo } from '../core/database_info';
 import { SnapshotVersion } from '../core/snapshot_version';
 import { Transaction } from '../core/transaction';
 import { BatchId, OnlineState, TargetId } from '../core/types';
@@ -31,7 +30,6 @@ import {
 } from '../model/mutation_batch';
 import { emptyByteString } from '../platform/platform';
 import { assert } from '../util/assert';
-import { AsyncQueue } from '../util/async_queue';
 import { Code, FirestoreError } from '../util/error';
 import * as log from '../util/log';
 import * as objUtils from '../util/obj';
@@ -291,7 +289,6 @@ export class RemoteStore {
       objUtils.contains(this.listenTargets, targetId),
       'unlisten called without assigned target ID!'
     );
-    const queryData = this.listenTargets[targetId];
     delete this.listenTargets[targetId];
     if (this.isNetworkEnabled() && this.watchStream.isOpen()) {
       this.sendUnwatchRequest(targetId);

--- a/packages/firestore/src/remote/stream_bridge.ts
+++ b/packages/firestore/src/remote/stream_bridge.ts
@@ -16,7 +16,6 @@
 
 import { assert } from '../util/assert';
 import { FirestoreError } from '../util/error';
-import { AnyJs } from '../util/misc';
 
 import { Stream } from './connection';
 

--- a/packages/firestore/src/util/async_queue.ts
+++ b/packages/firestore/src/util/async_queue.ts
@@ -16,7 +16,7 @@
 
 import { assert, fail } from './assert';
 import * as log from './log';
-import { AnyDuringMigration, AnyJs } from './misc';
+import { AnyJs } from './misc';
 import { Deferred, CancelablePromise } from './promise';
 import { Code, FirestoreError } from './error';
 

--- a/packages/firestore/src/util/sorted_map.ts
+++ b/packages/firestore/src/util/sorted_map.ts
@@ -485,7 +485,7 @@ export class LLRBNode<K, V> {
 
   // In a balanced RB tree, the black-depth (number of black nodes) from root to
   // leaves is equal on both sides.  This function verifies that or asserts.
-  private check(): number {
+  protected check(): number {
     if (this.isRed() && this.left.isRed()) {
       throw fail('Red node has red child(' + this.key + ',' + this.value + ')');
     }
@@ -562,7 +562,7 @@ export class LLRBEmptyNode<K, V> {
     return true;
   }
 
-  private check() {
+  protected check() {
     return 0;
   }
 } // end LLRBEmptyNode

--- a/packages/firestore/test/integration/api/type.test.ts
+++ b/packages/firestore/test/integration/api/type.test.ts
@@ -18,8 +18,11 @@ import { expect } from 'chai';
 import * as firestore from '@firebase/firestore-types';
 import firebase from '../util/firebase_export';
 import { apiDescribe, withTestDb, withTestDoc } from '../util/helpers';
+import { addEqualityMatcher } from '../../util/equality_matcher';
 
 apiDescribe('Firestore', persistence => {
+  addEqualityMatcher();
+
   function expectRoundtrip(
     db: firestore.FirebaseFirestore,
     data: {}

--- a/packages/firestore/test/integration/util/internal_helpers.ts
+++ b/packages/firestore/test/integration/util/internal_helpers.ts
@@ -52,13 +52,7 @@ export function withTestDatastore(
       const serializer = PlatformSupport.getPlatform().newSerializer(
         databaseInfo.databaseId
       );
-      const datastore = new Datastore(
-        databaseInfo,
-        queue || new AsyncQueue(),
-        conn,
-        new EmptyCredentialsProvider(),
-        serializer
-      );
+      const datastore = new Datastore(queue || new AsyncQueue(), conn, new EmptyCredentialsProvider(), serializer);
 
       return fn(datastore);
     });

--- a/packages/firestore/test/integration/util/internal_helpers.ts
+++ b/packages/firestore/test/integration/util/internal_helpers.ts
@@ -52,7 +52,12 @@ export function withTestDatastore(
       const serializer = PlatformSupport.getPlatform().newSerializer(
         databaseInfo.databaseId
       );
-      const datastore = new Datastore(queue || new AsyncQueue(), conn, new EmptyCredentialsProvider(), serializer);
+      const datastore = new Datastore(
+        queue || new AsyncQueue(),
+        conn,
+        new EmptyCredentialsProvider(),
+        serializer
+      );
 
       return fn(datastore);
     });

--- a/packages/firestore/test/unit/model/mutation.test.ts
+++ b/packages/firestore/test/unit/model/mutation.test.ts
@@ -40,8 +40,11 @@ import {
   version,
   wrapObject
 } from '../../util/helpers';
+import { addEqualityMatcher } from '../../util/equality_matcher';
 
 describe('Mutation', () => {
+  addEqualityMatcher();
+
   const timestamp = Timestamp.now();
 
   it('can apply sets to documents', () => {

--- a/packages/firestore/test/unit/specs/spec_test_runner.ts
+++ b/packages/firestore/test/unit/specs/spec_test_runner.ts
@@ -375,7 +375,13 @@ abstract class TestRunner {
     this.connection = new MockConnection(this.queue);
     // Set backoff delay to 1ms so simulated disconnects don't delay the tests.
     const initialBackoffDelay = 1;
-    this.datastore = new Datastore(this.queue, this.connection, new EmptyCredentialsProvider(), this.serializer, initialBackoffDelay);
+    this.datastore = new Datastore(
+      this.queue,
+      this.connection,
+      new EmptyCredentialsProvider(),
+      this.serializer,
+      initialBackoffDelay
+    );
     const onlineStateChangedHandler = (onlineState: OnlineState) => {
       this.syncEngine.applyOnlineStateChange(onlineState);
       this.eventManager.applyOnlineStateChange(onlineState);

--- a/packages/firestore/test/unit/specs/spec_test_runner.ts
+++ b/packages/firestore/test/unit/specs/spec_test_runner.ts
@@ -375,14 +375,7 @@ abstract class TestRunner {
     this.connection = new MockConnection(this.queue);
     // Set backoff delay to 1ms so simulated disconnects don't delay the tests.
     const initialBackoffDelay = 1;
-    this.datastore = new Datastore(
-      this.databaseInfo,
-      this.queue,
-      this.connection,
-      new EmptyCredentialsProvider(),
-      this.serializer,
-      initialBackoffDelay
-    );
+    this.datastore = new Datastore(this.queue, this.connection, new EmptyCredentialsProvider(), this.serializer, initialBackoffDelay);
     const onlineStateChangedHandler = (onlineState: OnlineState) => {
       this.syncEngine.applyOnlineStateChange(onlineState);
       this.eventManager.applyOnlineStateChange(onlineState);

--- a/packages/firestore/test/util/equality_matcher.ts
+++ b/packages/firestore/test/util/equality_matcher.ts
@@ -53,6 +53,9 @@ function customDeepEqual(left, right) {
   return true;
 }
 
+/** The original equality function passed in by chai(). */
+let originalFunction = null;
+
 export function addEqualityMatcher() {
   let isActive = true;
 
@@ -61,13 +64,14 @@ export function addEqualityMatcher() {
       const Assertion = chai.Assertion;
 
       const assertEql = _super => {
+        originalFunction = originalFunction || _super;
         return function(...args) {
           if (isActive) {
             const [right, msg] = args;
             utils.flag(this, 'message', msg);
             const left = utils.flag(this, 'object');
 
-            this.assert(
+            chai.assert(
               customDeepEqual(left, right),
               'expected #{act} to roughly deeply equal #{exp}',
               'expected #{act} to not roughly deeply equal #{exp}',
@@ -76,7 +80,7 @@ export function addEqualityMatcher() {
               true
             );
           } else {
-            _super.apply(this, args);
+            originalFunction.apply(this, args);
           }
         };
       };

--- a/packages/firestore/test/util/equality_matcher.ts
+++ b/packages/firestore/test/util/equality_matcher.ts
@@ -54,26 +54,30 @@ function customDeepEqual(left, right) {
 }
 
 export function addEqualityMatcher() {
-  let originalFunction;
-  beforeEach(() => {
+  let isActive = true;
+
+  before(() => {
     use((chai, utils) => {
       const Assertion = chai.Assertion;
 
       const assertEql = _super => {
-        originalFunction = originalFunction || _super;
         return function(...args) {
-          const [right, msg] = args;
-          utils.flag(this, 'message', msg);
-          const left = utils.flag(this, 'object');
+          if (isActive) {
+            const [right, msg] = args;
+            utils.flag(this, 'message', msg);
+            const left = utils.flag(this, 'object');
 
-          this.assert(
-            customDeepEqual(left, right),
-            'expected #{act} to roughly deeply equal #{exp}',
-            'expected #{act} to not roughly deeply equal #{exp}',
-            left,
-            right,
-            true
-          );
+            this.assert(
+                customDeepEqual(left, right),
+                'expected #{act} to roughly deeply equal #{exp}',
+                'expected #{act} to not roughly deeply equal #{exp}',
+                left,
+                right,
+                true
+            );
+          } else {
+            _super.apply(this, args);
+          }
         };
       };
 
@@ -82,15 +86,7 @@ export function addEqualityMatcher() {
     });
   });
 
-  afterEach(() => {
-    if (originalFunction) {
-      use(chai => {
-        return _super => {
-          return function(...args) {
-            originalFunction.apply(this, args);
-          };
-        };
-      });
-    }
+  after(() => {
+    isActive = false;
   });
 }

--- a/packages/firestore/test/util/equality_matcher.ts
+++ b/packages/firestore/test/util/equality_matcher.ts
@@ -85,7 +85,7 @@ export function addEqualityMatcher() {
   afterEach(() => {
     if (originalFunction) {
       use(chai => {
-        const wrappedDefault = _super => {
+        return _super => {
           return function(...args) {
             originalFunction.apply(this, args);
           };

--- a/packages/firestore/test/util/equality_matcher.ts
+++ b/packages/firestore/test/util/equality_matcher.ts
@@ -68,12 +68,12 @@ export function addEqualityMatcher() {
             const left = utils.flag(this, 'object');
 
             this.assert(
-                customDeepEqual(left, right),
-                'expected #{act} to roughly deeply equal #{exp}',
-                'expected #{act} to not roughly deeply equal #{exp}',
-                left,
-                right,
-                true
+              customDeepEqual(left, right),
+              'expected #{act} to roughly deeply equal #{exp}',
+              'expected #{act} to not roughly deeply equal #{exp}',
+              left,
+              right,
+              true
             );
           } else {
             _super.apply(this, args);

--- a/packages/firestore/test/util/helpers.ts
+++ b/packages/firestore/test/util/helpers.ts
@@ -90,7 +90,6 @@ import {
 import { assert, fail } from '../../src/util/assert';
 import { AnyJs, primitiveComparator } from '../../src/util/misc';
 import { forEach } from '../../src/util/obj';
-import { Deferred } from '../../src/util/promise';
 import { SortedMap } from '../../src/util/sorted_map';
 import { SortedSet } from '../../src/util/sorted_set';
 
@@ -233,7 +232,7 @@ export function bound(
 ): Bound {
   const components: FieldValue[] = [];
   for (const value of values) {
-    const [field, dataValue] = value;
+    const dataValue = value[1];
     components.push(wrap(dataValue));
   }
   return new Bound(components, before);
@@ -460,16 +459,12 @@ export class DocComparator {
     return Document.compareByField.bind(this, path);
   }
 }
-type MochaTestRunner = (
-  expectation: string,
-  callback?: (this: Mocha.ITestCallbackContext, done: MochaDone) => AnyJs
-) => Mocha.ITest;
 
 /**
  * Two helper functions to simplify testing isEqual() method.
  */
 // tslint:disable-next-line:no-any so we can dynamically call .isEqual().
-export function expectEqual<T>(left: any, right: any, message?: string): void {
+export function expectEqual(left: any, right: any, message?: string): void {
   message = message || '';
   if (typeof left.isEqual !== 'function') {
     return fail(

--- a/packages/firestore/test/util/helpers.ts
+++ b/packages/firestore/test/util/helpers.ts
@@ -232,7 +232,7 @@ export function bound(
 ): Bound {
   const components: FieldValue[] = [];
   for (const value of values) {
-    const dataValue = value[1];
+    const [_, dataValue] = value;
     components.push(wrap(dataValue));
   }
   return new Bound(components, before);

--- a/packages/firestore/tslint.json
+++ b/packages/firestore/tslint.json
@@ -38,7 +38,7 @@
     "no-reference": true,
     "no-string-throw": true,
     "no-unused-expression": true,
-	"no-unused-variable": true,
+    "no-unused-variable": true,
     "no-var-keyword": true,
     "object-literal-shorthand": true,
     "only-arrow-functions": [true, "allow-declarations", "allow-named-functions"],

--- a/packages/firestore/tslint.json
+++ b/packages/firestore/tslint.json
@@ -38,7 +38,7 @@
     "no-reference": true,
     "no-string-throw": true,
     "no-unused-expression": true,
-    "no-unused-variable": true,
+    "no-unused-variable": [true, {"ignore-pattern": "^_$"}],
     "no-var-keyword": true,
     "object-literal-shorthand": true,
     "only-arrow-functions": [true, "allow-declarations", "allow-named-functions"],

--- a/packages/firestore/tslint.json
+++ b/packages/firestore/tslint.json
@@ -38,6 +38,7 @@
     "no-reference": true,
     "no-string-throw": true,
     "no-unused-expression": true,
+	"no-unused-variable": true,
     "no-var-keyword": true,
     "object-literal-shorthand": true,
     "only-arrow-functions": [true, "allow-declarations", "allow-named-functions"],


### PR DESCRIPTION
This PR adds type checking to tslint and enables "no-unused-vars".

I also added a new auto-fix option to the default scripts (`yarn lint:fix`), which is responsible for some of the changes in here.

Tests are all passing locally for me and `yarn prepare` works in the repo root as well as in packages/firestore