### PR TITLE
Support ns queryparam

### DIFF
--- a/packages/database/src/core/RepoInfo.ts
+++ b/packages/database/src/core/RepoInfo.ts
@@ -49,7 +49,7 @@ export class RepoInfo {
   }
 
   needsQueryParam(): boolean {
-    return this.host !== this.internalHost;
+    return this.host !== this.internalHost || this.isCustomHost();
   }
 
   isCacheableHost(): boolean {

--- a/packages/database/src/core/util/libs/parser.ts
+++ b/packages/database/src/core/util/libs/parser.ts
@@ -153,8 +153,8 @@ export const parseURL = function(
         const queryString = host.substring(queryStartIndex, host.length);
         const match = queryString.match(/ns=([a-zA-Z0-9-]+)/);
         if (match.length > 0) {
-            subdomain = match[1];
-            host = host.substring(0, queryStartIndex);
+          subdomain = match[1];
+          host = host.substring(0, queryStartIndex);
         }
       }
     }

--- a/packages/database/src/core/util/libs/parser.ts
+++ b/packages/database/src/core/util/libs/parser.ts
@@ -146,6 +146,18 @@ export const parseURL = function(
     } else if (parts[0].slice(0, colonInd).toLowerCase() === 'localhost') {
       domain = 'localhost';
     }
+    // Support `ns` query param if subdomain not already set
+    if (subdomain === '') {
+      const queryStartIndex = host.indexOf('?');
+      if (queryStartIndex != -1) {
+        const queryString = host.substring(queryStartIndex, host.length);
+        const match = queryString.match(/ns=([a-zA-Z0-9-]+)/);
+        if (match.length > 0) {
+            subdomain = match[1];
+            host = host.substring(0, queryStartIndex);
+        }
+      }
+    }
   }
 
   return {

--- a/packages/database/src/core/util/libs/parser.ts
+++ b/packages/database/src/core/util/libs/parser.ts
@@ -147,16 +147,17 @@ export const parseURL = function(
       domain = 'localhost';
     }
     // Support `ns` query param if subdomain not already set
-    if (subdomain === '') {
-      const queryStartIndex = host.indexOf('?');
-      if (queryStartIndex != -1) {
+    const queryStartIndex = host.indexOf('?');
+    if (queryStartIndex > 0) {
+      if (subdomain === '') {
         const queryString = host.substring(queryStartIndex, host.length);
         const match = queryString.match(/ns=([a-zA-Z0-9-]+)/);
         if (match.length > 0) {
           subdomain = match[1];
-          host = host.substring(0, queryStartIndex);
         }
       }
+      // Always remove all query params from the host
+      host = host.substring(0, queryStartIndex);
     }
   }
 

--- a/packages/database/src/core/util/libs/parser.ts
+++ b/packages/database/src/core/util/libs/parser.ts
@@ -152,7 +152,9 @@ export const parseURL = function(
       // For pathString, questionInd will always come after slashInd
       pathString = decodePath(dataURL.substring(slashInd, questionInd));
     }
-    let queryParams = decodeQuery(dataURL.substring(Math.min(dataURL.length, questionInd + 1)));
+    let queryParams = decodeQuery(
+      dataURL.substring(Math.min(dataURL.length, questionInd + 1))
+    );
 
     // If we have a port, use scheme for determining if it's secure.
     colonInd = host.indexOf(':');
@@ -176,7 +178,7 @@ export const parseURL = function(
     // Support `ns` query param if subdomain not already set
     if (subdomain === '' && queryParams.has('ns')) {
       subdomain = queryParams.get('ns');
-      console.log("here", queryParams, subdomain);
+      console.log('here', queryParams, subdomain);
     }
   }
 

--- a/packages/database/test/database.test.ts
+++ b/packages/database/test/database.test.ts
@@ -76,6 +76,20 @@ describe('Database Tests', function() {
     expect(db.ref().toString()).to.equal('https://localhost/');
   });
 
+  it('Can read ns query param', function() {
+    var db = defaultApp.database('http://localhost:80?ns=foo');
+    expect(db).to.be.ok;
+    expect(db.repo_.repoInfo_.namespace).to.equal('foo');
+    expect(db.ref().toString()).to.equal('http://localhost:80/');
+  });
+
+  it('Only reads ns query param when subdomain not set', function() {
+    var db = defaultApp.database('http://bar.firebaseio.com?ns=foo');
+    expect(db).to.be.ok;
+    expect(db.repo_.repoInfo_.namespace).to.equal('bar');
+    expect(db.ref().toString()).to.equal('https://bar.firebaseio.com?ns=foo/');
+  });
+
   it('Different instances for different URLs', function() {
     var db1 = defaultApp.database('http://foo1.bar.com');
     var db2 = defaultApp.database('http://foo2.bar.com');

--- a/packages/database/test/database.test.ts
+++ b/packages/database/test/database.test.ts
@@ -87,7 +87,7 @@ describe('Database Tests', function() {
     var db = defaultApp.database('http://bar.firebaseio.com?ns=foo');
     expect(db).to.be.ok;
     expect(db.repo_.repoInfo_.namespace).to.equal('bar');
-    expect(db.ref().toString()).to.equal('https://bar.firebaseio.com?ns=foo/');
+    expect(db.ref().toString()).to.equal('https://bar.firebaseio.com/');
   });
 
   it('Different instances for different URLs', function() {

--- a/packages/database/test/database.test.ts
+++ b/packages/database/test/database.test.ts
@@ -77,7 +77,7 @@ describe('Database Tests', function() {
   });
 
   it('Can read ns query param', function() {
-    var db = defaultApp.database('http://localhost:80?ns=foo');
+    var db = defaultApp.database('http://localhost:80/?ns=foo');
     expect(db).to.be.ok;
     expect(db.repo_.repoInfo_.namespace).to.equal('foo');
     expect(db.ref().toString()).to.equal('http://localhost:80/');

--- a/packages/database/test/database.test.ts
+++ b/packages/database/test/database.test.ts
@@ -77,7 +77,7 @@ describe('Database Tests', function() {
   });
 
   it('Can read ns query param', function() {
-    var db = defaultApp.database('http://localhost:80/?ns=foo');
+    var db = defaultApp.database('http://localhost:80/?ns=foo&unused=true');
     expect(db).to.be.ok;
     expect(db.repo_.repoInfo_.namespace).to.equal('foo');
     expect(db.ref().toString()).to.equal('http://localhost:80/');


### PR DESCRIPTION
This PR adds support for the `?ns=` query param. This will be used for testing against non-production endpoints.