### PR TITLE
Messaging - IDB Cleanup

### DIFF
--- a/packages/messaging/src/models/clean-v1-undefined.ts
+++ b/packages/messaging/src/models/clean-v1-undefined.ts
@@ -1,0 +1,87 @@
+/**
+ * Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * There seems to have been a bug in the messaging SDK versions <= 4.9.x
+ * where the IndexedDB model was using a database name of 'undefined'.
+ *
+ * In 4.10.x we changed the model implementation, but kept the database
+ * name as it should have been. This however introduced an issue where
+ * two tokens were pointing to the same underlying PushSubscription.
+ *
+ * This code will look for the undefined database and delete any of the
+ * underlying tokens.
+ */
+
+import IIDModel from '../models/iid-model';
+
+const OLD_DB_NAME = 'undefined';
+const OLD_OBJECT_STORE_NAME = 'fcm_token_object_Store';
+
+function handleDb(db: IDBDatabase) {
+  if (!db.objectStoreNames.contains(OLD_OBJECT_STORE_NAME)) {
+    // We found a database with the right name, but our expected object
+    // store isn't defined.
+    return;
+  }
+
+  const transaction = db.transaction([OLD_OBJECT_STORE_NAME]);
+  const objectStore = transaction.objectStore(OLD_OBJECT_STORE_NAME);
+
+  const iidModel = new IIDModel();
+
+  const openCursorRequest = objectStore.openCursor();
+  openCursorRequest.onerror = event => {
+    // NOOP - Nothing we can do.
+  };
+
+  openCursorRequest.onsuccess = event => {
+    var cursor = event.target.result;
+    if (cursor) {
+      // cursor.value contains the current record being iterated through
+      // this is where you'd do something with the result
+      const tokenDetails = cursor.value;
+
+      iidModel.deleteToken(
+        tokenDetails.fcmSenderId,
+        tokenDetails.fcmToken,
+        tokenDetails.fcmPushSet
+      );
+
+      cursor.continue();
+    } else {
+      // No more results - delete database if we are the only
+      // SDK using it
+      if (db.objectStoreNames.length === 1) {
+        indexedDB.deleteDatabase(OLD_DB_NAME);
+      }
+      db.close();
+    }
+  };
+}
+
+function cleanV1() {
+  const request: IDBOpenDBRequest = indexedDB.open(OLD_DB_NAME);
+  request.onerror = function(event) {
+    // NOOP - Nothing we can do.
+  };
+  request.onsuccess = function(event) {
+    const db = request.result;
+    handleDb(db);
+  };
+}
+
+export {cleanV1};

--- a/packages/messaging/src/models/clean-v1-undefined.ts
+++ b/packages/messaging/src/models/clean-v1-undefined.ts
@@ -43,13 +43,13 @@ function handleDb(db: IDBDatabase) {
 
   const iidModel = new IIDModel();
 
-  const openCursorRequest = objectStore.openCursor();
+  const openCursorRequest: IDBRequest = objectStore.openCursor();
   openCursorRequest.onerror = event => {
     // NOOP - Nothing we can do.
   };
 
-  openCursorRequest.onsuccess = event => {
-    var cursor = event.target.result;
+  openCursorRequest.onsuccess = () => {
+    const cursor = openCursorRequest.result;
     if (cursor) {
       // cursor.value contains the current record being iterated through
       // this is where you'd do something with the result

--- a/packages/messaging/src/models/clean-v1-undefined.ts
+++ b/packages/messaging/src/models/clean-v1-undefined.ts
@@ -84,4 +84,4 @@ function cleanV1() {
   };
 }
 
-export {cleanV1};
+export { cleanV1 };

--- a/packages/messaging/src/models/clean-v1-undefined.ts
+++ b/packages/messaging/src/models/clean-v1-undefined.ts
@@ -33,12 +33,12 @@ const OLD_OBJECT_STORE_NAME = 'fcm_token_object_Store';
 
 function handleDb(db: IDBDatabase) {
   if (!db.objectStoreNames.contains(OLD_OBJECT_STORE_NAME)) {
-    // We found a database with the right name, but our expected object
+    // We found a database with the name 'undefined', but our expected object
     // store isn't defined.
     return;
   }
 
-  const transaction = db.transaction([OLD_OBJECT_STORE_NAME]);
+  const transaction = db.transaction(OLD_OBJECT_STORE_NAME);
   const objectStore = transaction.objectStore(OLD_OBJECT_STORE_NAME);
 
   const iidModel = new IIDModel();
@@ -46,6 +46,7 @@ function handleDb(db: IDBDatabase) {
   const openCursorRequest: IDBRequest = objectStore.openCursor();
   openCursorRequest.onerror = event => {
     // NOOP - Nothing we can do.
+    console.warn('Unable to cleanup old IDB.', event);
   };
 
   openCursorRequest.onsuccess = () => {
@@ -63,12 +64,8 @@ function handleDb(db: IDBDatabase) {
 
       cursor.continue();
     } else {
-      // No more results - delete database if we are the only
-      // SDK using it
-      if (db.objectStoreNames.length === 1) {
-        indexedDB.deleteDatabase(OLD_DB_NAME);
-      }
       db.close();
+      indexedDB.deleteDatabase(OLD_DB_NAME);
     }
   };
 }

--- a/packages/messaging/src/models/db-interface.ts
+++ b/packages/messaging/src/models/db-interface.ts
@@ -59,7 +59,7 @@ export default class DBInterface {
       request.onupgradeneeded = event => {
         try {
           var db = (<IDBRequest>event.target).result;
-          this.onDBUpgrade(db);
+          this.onDBUpgrade(db, event);
         } catch (err) {
           // close the database as it can't be used.
           db.close();
@@ -90,7 +90,7 @@ export default class DBInterface {
    * @protected
    * @param {!IDBDatabase} db
    */
-  onDBUpgrade(db) {
+  onDBUpgrade(db: IDBDatabase, event: IDBVersionChangeEvent) {
     throw this.errorFactory_.create(Errors.codes.SHOULD_BE_INHERITED);
   }
 }

--- a/packages/messaging/src/models/token-details-model.ts
+++ b/packages/messaging/src/models/token-details-model.ts
@@ -18,9 +18,11 @@
 import DBInterface from './db-interface';
 import Errors from './errors';
 import arrayBufferToBase64 from '../helpers/array-buffer-to-base64';
+import {cleanV1} from './clean-v1-undefined';
 
 const FCM_TOKEN_OBJ_STORE = 'fcm_token_object_Store';
-const DB_VERSION = 1;
+const DB_NAME = 'fcm_token_details_db';
+const DB_VERSION = 2;
 
 /** @record */
 function ValidateInput() {}
@@ -39,29 +41,31 @@ ValidateInput.prototype.fcmPushSet;
 
 export default class TokenDetailsModel extends DBInterface {
   constructor() {
-    super(TokenDetailsModel.DB_NAME, DB_VERSION);
+    super(DB_NAME, DB_VERSION);
   }
 
-  static get DB_NAME() {
-    return 'fcm_token_details_db';
-  }
+  onDBUpgrade(db: IDBDatabase, evt: IDBVersionChangeEvent) {
+    if (evt.oldVersion < 1) {
+      var objectStore = db.createObjectStore(FCM_TOKEN_OBJ_STORE, {
+        keyPath: 'swScope'
+      });
 
-  /**
-   * @override
-   */
-  onDBUpgrade(db) {
-    var objectStore = db.createObjectStore(FCM_TOKEN_OBJ_STORE, {
-      keyPath: 'swScope'
-    });
+      // Make sure the sender ID can be searched
+      objectStore.createIndex('fcmSenderId', 'fcmSenderId', {
+        unique: false
+      });
 
-    // Make sure the sender ID can be searched
-    objectStore.createIndex('fcmSenderId', 'fcmSenderId', {
-      unique: false
-    });
+      objectStore.createIndex('fcmToken', 'fcmToken', {
+        unique: true
+      });
+    }
 
-    objectStore.createIndex('fcmToken', 'fcmToken', {
-      unique: true
-    });
+    if (evt.oldVersion < 2) {
+      // Prior to version 2, we were using either 'fcm_token_details_db'
+      // or 'undefined' as the database name due to bug in the SDK
+      // So remove the old tokens and databases.
+      cleanV1();
+    }
   }
 
   /**

--- a/packages/messaging/src/models/token-details-model.ts
+++ b/packages/messaging/src/models/token-details-model.ts
@@ -46,6 +46,7 @@ export default class TokenDetailsModel extends DBInterface {
 
   onDBUpgrade(db: IDBDatabase, evt: IDBVersionChangeEvent) {
     if (evt.oldVersion < 1) {
+      // New IDB instance
       var objectStore = db.createObjectStore(FCM_TOKEN_OBJ_STORE, {
         keyPath: 'swScope'
       });

--- a/packages/messaging/src/models/token-details-model.ts
+++ b/packages/messaging/src/models/token-details-model.ts
@@ -18,7 +18,7 @@
 import DBInterface from './db-interface';
 import Errors from './errors';
 import arrayBufferToBase64 from '../helpers/array-buffer-to-base64';
-import {cleanV1} from './clean-v1-undefined';
+import { cleanV1 } from './clean-v1-undefined';
 
 const FCM_TOKEN_OBJ_STORE = 'fcm_token_object_Store';
 const DB_NAME = 'fcm_token_details_db';

--- a/packages/messaging/src/models/vapid-details-model.ts
+++ b/packages/messaging/src/models/vapid-details-model.ts
@@ -19,16 +19,13 @@ import DBInterface from './db-interface';
 import Errors from './errors';
 
 const FCM_VAPID_OBJ_STORE = 'fcm_vapid_object_Store';
+const DB_NAME = 'fcm_vapid_details_db';
 const DB_VERSION = 1;
 const UNCOMPRESSED_PUBLIC_KEY_SIZE = 65;
 
 export default class VapidDetailsModel extends DBInterface {
   constructor() {
-    super(VapidDetailsModel.DB_NAME, DB_VERSION);
-  }
-
-  static get DB_NAME() {
-    return 'fcm_vapid_details_db';
+    super(DB_NAME, DB_VERSION);
   }
 
   /**

--- a/packages/messaging/test/controller-delete-token.test.ts
+++ b/packages/messaging/test/controller-delete-token.test.ts
@@ -71,7 +71,7 @@ describe('Firebase Messaging > *Controller.deleteToken()', function() {
       deletePromises.push(globalMessagingService.delete());
     }
     return Promise.all(deletePromises)
-      .then(() => deleteDatabase(TokenDetailsModel.DB_NAME))
+      .then(() => deleteDatabase('fcm_token_details_db'))
       .then(() => (globalMessagingService = null));
   };
 

--- a/packages/messaging/test/tokenDetailsModel-deleteToken.test.ts
+++ b/packages/messaging/test/tokenDetailsModel-deleteToken.test.ts
@@ -46,7 +46,7 @@ describe('Firebase Messaging > TokenDetailsModel.deleteToken()', function() {
     }
 
     return Promise.all(promises)
-      .then(() => deleteDatabase(TokenDetailsModel.DB_NAME))
+      .then(() => deleteDatabase('fcm_token_details_db'))
       .then(() => (globalTokenModel = null));
   };
 

--- a/packages/messaging/test/tokenDetailsModel-getToken.test.ts
+++ b/packages/messaging/test/tokenDetailsModel-getToken.test.ts
@@ -45,7 +45,7 @@ describe('Firebase Messaging > TokenDetailsModel.getTokenDetailsFromToken()', fu
     }
 
     return Promise.all(promises)
-      .then(() => deleteDatabase(TokenDetailsModel.DB_NAME))
+      .then(() => deleteDatabase('fcm_token_details_db'))
       .then(() => (globalTokenModel = null));
   };
 

--- a/packages/messaging/test/tokenDetailsModel-saveToken.test.ts
+++ b/packages/messaging/test/tokenDetailsModel-saveToken.test.ts
@@ -42,7 +42,7 @@ describe('Firebase Messaging > TokenDetailsModel.saveToken()', function() {
     }
 
     return Promise.all(promises)
-      .then(() => deleteDatabase(TokenDetailsModel.DB_NAME))
+      .then(() => deleteDatabase('fcm_token_details_db'))
       .then(() => (globalTokenModel = null));
   };
 

--- a/packages/messaging/test/vapid-details-model-delete.test.ts
+++ b/packages/messaging/test/vapid-details-model-delete.test.ts
@@ -35,7 +35,7 @@ describe('Firebase Messaging > VapidDetailsModel.deleteToken()', function() {
     }
 
     return promiseChain
-      .then(() => deleteDatabase(VapidDetailsModel.DB_NAME))
+      .then(() => deleteDatabase('fcm_vapid_details_db'))
       .then(() => (vapidModel = null));
   };
 

--- a/packages/messaging/test/vapid-details-model-get.test.ts
+++ b/packages/messaging/test/vapid-details-model-get.test.ts
@@ -35,7 +35,7 @@ describe('Firebase Messaging > VapidDetailsModel.getVapidFromSWScope()', functio
     }
 
     return promiseChain
-      .then(() => deleteDatabase(VapidDetailsModel.DB_NAME))
+      .then(() => deleteDatabase('fcm_vapid_details_db'))
       .then(() => (vapidModel = null));
   };
 

--- a/packages/messaging/test/vapid-details-model-save.test.ts
+++ b/packages/messaging/test/vapid-details-model-save.test.ts
@@ -35,7 +35,7 @@ describe('Firebase Messaging > VapidDetailsModel.saveVapidDetails()', function()
     }
 
     return promiseChain
-      .then(() => deleteDatabase(VapidDetailsModel.DB_NAME))
+      .then(() => deleteDatabase('fcm_vapid_details_db'))
       .then(() => (vapidModel = null));
   };
 


### PR DESCRIPTION
A few bugs have been highlighted from 4.9x => 4.10.0:

- There was a bug in <= 4.9.X builds of the messaging SDK that meant the SDK was using an IDB name of 'undefined'. My hunch is something went wonky in closure -> typescript.
- If the name wasn't `undefined` the changes in 4.10 should have been fine, but because there is now a difference IDB name, the SDK is creating a new token, meaning end users can get two notifications - one for the old token and one for the new token.

This PR will bump the version of the IDB database in the next release, and clean up any old IDB instances if they exist in the version upgrade step.
