### PR TITLE
Version Patch for Firebase Admin

### DIFF
--- a/packages/database/index.node.ts
+++ b/packages/database/index.node.ts
@@ -15,6 +15,7 @@
  */
 
 import firebase from '@firebase/app';
+import { CONSTANTS, isNodeSdk } from "@firebase/util";
 import { FirebaseApp, FirebaseNamespace } from '@firebase/app-types';
 import { _FirebaseNamespace } from '@firebase/app-types/private';
 import { Database } from './src/api/Database';
@@ -24,7 +25,6 @@ import { enableLogging } from './src/core/util/util';
 import { RepoManager } from './src/core/RepoManager';
 import * as INTERNAL from './src/api/internal';
 import * as TEST_ACCESS from './src/api/test_access';
-import { isNodeSdk } from '@firebase/util';
 import './src/nodePatches';
 import * as types from '@firebase/database-types';
 
@@ -38,7 +38,17 @@ import * as types from '@firebase/database-types';
 
 const ServerValue = Database.ServerValue;
 
-export function initStandalone(app, url) {
+export function initStandalone(app, url, version?: string) {
+
+  /**
+   * This should allow the firebase-admin package to provide a custom version
+   * to the backend
+   */
+  CONSTANTS.NODE_ADMIN = true;
+  if (version) {
+    firebase.SDK_VERSION = version;
+  }
+
   return {
     instance: RepoManager.getInstance().databaseFromApp(app, url),
     namespace: {

--- a/packages/database/index.node.ts
+++ b/packages/database/index.node.ts
@@ -15,7 +15,7 @@
  */
 
 import firebase from '@firebase/app';
-import { CONSTANTS, isNodeSdk } from "@firebase/util";
+import { CONSTANTS, isNodeSdk } from '@firebase/util';
 import { FirebaseApp, FirebaseNamespace } from '@firebase/app-types';
 import { _FirebaseNamespace } from '@firebase/app-types/private';
 import { Database } from './src/api/Database';
@@ -39,7 +39,6 @@ import * as types from '@firebase/database-types';
 const ServerValue = Database.ServerValue;
 
 export function initStandalone(app, url, version?: string) {
-
   /**
    * This should allow the firebase-admin package to provide a custom version
    * to the backend


### PR DESCRIPTION
Refactor the `initStandalone` function to optionally patch the firebase version.
Also sets the `NODE_ADMIN` constant to `true`