### PR TITLE
Updating API surface

### DIFF
--- a/packages/messaging-types/index.d.ts
+++ b/packages/messaging-types/index.d.ts
@@ -34,4 +34,5 @@ export class FirebaseMessaging {
   requestPermission(): Promise<any> | null;
   setBackgroundMessageHandler(callback: (a: Object) => any): any;
   useServiceWorker(registration: any): any;
+  usePublicVapidKey(b64PublicKey: string): void;
 }


### PR DESCRIPTION
@pinarx pointed out that the types file was out of sync with the API surface.

@jshcrowthe we can do away with the types files if we get the "typescript-y-ness" of the source inline and up-to-date right, or is there something I'm missing? I.e. move away from closure and opt for typescript typing