### PR TITLE
Database API: Ref from Ref

### DIFF
--- a/packages/database-types/index.d.ts
+++ b/packages/database-types/index.d.ts
@@ -37,7 +37,7 @@ export class FirebaseDatabase {
   app: FirebaseApp;
   goOffline(): void;
   goOnline(): void;
-  ref(path?: string|Reference): Reference;
+  ref(path?: string | Reference): Reference;
   refFromURL(url: string): Reference;
 }
 

--- a/packages/database-types/index.d.ts
+++ b/packages/database-types/index.d.ts
@@ -37,7 +37,7 @@ export class FirebaseDatabase {
   app: FirebaseApp;
   goOffline(): void;
   goOnline(): void;
-  ref(path?: string): Reference;
+  ref(path?: string|Reference): Reference;
   refFromURL(url: string): Reference;
 }
 

--- a/packages/database/src/api/Database.ts
+++ b/packages/database/src/api/Database.ts
@@ -62,15 +62,26 @@ export class Database implements FirebaseService {
   }
 
   /**
-   * Returns a reference to the root or the path specified in opt_pathString.
-   * @param {string=} pathString
+   * Returns a reference to the root or to the path specified in the provided
+   * argument.
+
+   * @param {string|Reference=} path The relative string path or an existing
+   * Reference to a database location.
+   * @throws If a Reference is provided, throws if it does not belong to the
+   * same project.
    * @return {!Reference} Firebase reference.
-   */
-  ref(pathString?: string): Reference {
+   **/
+  ref(path?: string): Reference;
+  ref(path?: Reference): Reference;
+  ref(path?: string|Reference): Reference {
     this.checkDeleted_('ref');
     validateArgCount('database.ref', 0, 1, arguments.length);
 
-    return pathString !== undefined ? this.root_.child(pathString) : this.root_;
+    if (path instanceof Reference) {
+      return this.refFromURL(path.toString());
+    }
+
+    return path !== undefined ? this.root_.child(path) : this.root_;
   }
 
   /**

--- a/packages/database/src/api/Database.ts
+++ b/packages/database/src/api/Database.ts
@@ -73,7 +73,7 @@ export class Database implements FirebaseService {
    **/
   ref(path?: string): Reference;
   ref(path?: Reference): Reference;
-  ref(path?: string|Reference): Reference {
+  ref(path?: string | Reference): Reference {
     this.checkDeleted_('ref');
     validateArgCount('database.ref', 0, 1, arguments.length);
 

--- a/packages/database/test/database.test.ts
+++ b/packages/database/test/database.test.ts
@@ -149,11 +149,33 @@ describe('Database Tests', function() {
     expect(ref.key).to.equal('grand-child');
   });
 
+  it('Can get ref from ref', function() {
+    const db1 = (firebase as any).database();
+    const db2 = (firebase as any).database();
+
+    const ref1 = db1.ref('child');
+    const ref2 = db2.ref(ref1);
+
+    expect(ref1.key).to.equal('child');
+    expect(ref2.key).to.equal('child');
+  });
+
   it('ref() validates arguments', function() {
     const db = (firebase as any).database();
     expect(function() {
       const ref = (db as any).ref('path', 'extra');
     }).to.throw(/Expects no more than 1/);
+  });
+
+  it('ref() validates project', function() {
+    const db1 = defaultApp.database('http://bar.foo.com');
+    const db2 = defaultApp.database('http://foo.bar.com');
+
+    const ref1 = db1.ref('child');
+
+    expect(function() {
+      db2.ref(ref1);
+    }).to.throw(/does not match.*database/i);
   });
 
   it('Can get refFromURL()', function() {


### PR DESCRIPTION
This implements go/firebase-ref-from-ref:

// Before:
// The developer must know of the little-used refFromUrl and must also know that a 
// ref's toString is the full URL of the ref
let ref2 = admin.database().refFromURL(ref1.toString());

// After:
// more intuitive
let ref2 = admin.database().ref(ref1);