### PR TITLE
NPM Publish Access

### DIFF
--- a/scripts/release/utils/npm.js
+++ b/scripts/release/utils/npm.js
@@ -39,7 +39,7 @@ async function publishPackage(pkg, releaseType) {
      * Default publish args
      */
 
-    let args = ['publish'];
+    let args = ['publish', '--access', 'public'];
 
     /**
      * Ensure prereleases are tagged with the `next` tag


### PR DESCRIPTION
As part of publishing scoped packages, we have to pass set the default access of our scoped packages. If we don't do this, the `npm publish` command will fail to publish new packages.