### PR TITLE
Remove the "private" flag from the @firebase/logger package

### DIFF
--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@firebase/logger",
   "version": "0.1.0",
-  "private": true,
   "description": "A logger package for use in the Firebase JS SDK",
   "author": "Firebase <firebase-support@google.com> (https://firebase.google.com/)",
   "main": "dist/cjs/index.js",


### PR DESCRIPTION
This will ensure the `@firebase/logger` package is picked up for the next release.