### PR TITLE
feat: Add offset to query

### DIFF
--- a/packages/firestore/src/api/database.ts
+++ b/packages/firestore/src/api/database.ts
@@ -1319,6 +1319,19 @@ export class Query implements firestore.Query {
     return new Query(this._query.withEndAt(bound), this.firestore);
   }
 
+  offset(n: number): firestore.Query {
+    validateExactNumberOfArgs('Query.offset', arguments, 1);
+    validateArgType('Query.offset', 'number', 1, n);
+    if (n < 0) {
+      throw new FirestoreError(
+        Code.INVALID_ARGUMENT,
+        `Invalid Query. Query offset (${n}) is invalid. Offset must be ` +
+          'positive.'
+      );
+    }
+    return new Query(this._query.withOffset(n), this.firestore);
+  }
+
   isEqual(other: firestore.Query): boolean {
     if (!(other instanceof Query)) {
       throw invalidClassError('isEqual', 'Query', 1, other);

--- a/packages/firestore/src/core/query.ts
+++ b/packages/firestore/src/core/query.ts
@@ -41,7 +41,8 @@ export class Query {
     readonly filters: Filter[] = [],
     readonly limit: number | null = null,
     readonly startAt: Bound | null = null,
-    readonly endAt: Bound | null = null
+    readonly endAt: Bound | null = null,
+    readonly offset: number | null = null
   ) {
     if (this.startAt) {
       this.assertValidBound(this.startAt);
@@ -120,7 +121,8 @@ export class Query {
       newFilters,
       this.limit,
       this.startAt,
-      this.endAt
+      this.endAt,
+      this.offset
     );
   }
 
@@ -138,7 +140,8 @@ export class Query {
       this.filters.slice(),
       this.limit,
       this.startAt,
-      this.endAt
+      this.endAt,
+      this.offset
     );
   }
 
@@ -149,7 +152,8 @@ export class Query {
       this.filters.slice(),
       limit,
       this.startAt,
-      this.endAt
+      this.endAt,
+      this.offset
     );
   }
 
@@ -160,7 +164,8 @@ export class Query {
       this.filters.slice(),
       this.limit,
       bound,
-      this.endAt
+      this.endAt,
+      this.offset
     );
   }
 
@@ -171,7 +176,20 @@ export class Query {
       this.filters.slice(),
       this.limit,
       this.startAt,
-      bound
+      bound,
+      this.offset
+    );
+  }
+
+  withOffset(offset: number | null): Query {
+    return new Query(
+      this.path,
+      this.explicitOrderBy.slice(),
+      this.filters.slice(),
+      this.limit,
+      this.startAt,
+      this.endAt,
+      offset
     );
   }
 
@@ -191,6 +209,10 @@ export class Query {
       for (const orderBy of this.orderBy) {
         canonicalId += orderBy.canonicalId();
         canonicalId += ',';
+      }
+      if (!isNullOrUndefined(this.offset)) {
+        canonicalId += '|o:';
+        canonicalId += this.offset!;
       }
       if (!isNullOrUndefined(this.limit)) {
         canonicalId += '|l:';
@@ -214,6 +236,9 @@ export class Query {
     if (this.filters.length > 0) {
       str += `, filters: [${this.filters.join(', ')}]`;
     }
+    if (!isNullOrUndefined(this.offset)) {
+      str += ', offset: ' + this.offset;
+    }
     if (!isNullOrUndefined(this.limit)) {
       str += ', limit: ' + this.limit;
     }
@@ -231,6 +256,10 @@ export class Query {
   }
 
   isEqual(other: Query): boolean {
+    if (this.offset !== other.offset) {
+      return false;
+    }
+
     if (this.limit !== other.limit) {
       return false;
     }
@@ -298,6 +327,10 @@ export class Query {
 
   hasLimit(): boolean {
     return !isNullOrUndefined(this.limit);
+  }
+
+  hasOffset(): boolean {
+    return !isNullOrUndefined(this.offset);
   }
 
   getFirstOrderByField(): FieldPath | null {

--- a/packages/firestore/src/remote/serializer.ts
+++ b/packages/firestore/src/remote/serializer.ts
@@ -951,6 +951,11 @@ export class JsonProtoSerializer {
       result.structuredQuery!.endAt = this.toCursor(query.endAt);
     }
 
+    const offset: number | null | undefined = query.offset;
+    if (!typeUtils.isNullOrUndefined(offset)) {
+      result.structuredQuery!.offset = offset;
+    }
+
     return result;
   }
 
@@ -993,7 +998,12 @@ export class JsonProtoSerializer {
       endAt = this.fromCursor(query.endAt);
     }
 
-    return new Query(path, orderBy, filterBy, limit, startAt, endAt);
+    let offset: number | null = null;
+    if (query.offset) {
+      offset = this.fromInt32Value(query.offset);
+    }
+
+    return new Query(path, orderBy, filterBy, limit, startAt, endAt, offset);
   }
 
   toListenRequestLabels(

--- a/packages/firestore/test/unit/core/query.test.ts
+++ b/packages/firestore/test/unit/core/query.test.ts
@@ -338,6 +338,8 @@ describe('Query', () => {
     // .addOrderBy(orderBy(DOCUMENT_KEY_NAME, 'desc'))
     // .withUpperBound(lip3, 'exclusive');
 
+    const q16a = Query.atPath(path('foo')).withOffset(10);
+
     const queries = [
       [q1a, q1b],
       [q2a, q2b],
@@ -351,9 +353,10 @@ describe('Query', () => {
       [q10a],
       [q11a],
       [q12a],
-      [q13a]
+      [q13a],
       //[q14a],
       //[q15a],
+      [q16a]
     ];
 
     expectEqualitySets(queries, (q1, q2) => {

--- a/packages/firestore/test/unit/remote/node/serializer.test.ts
+++ b/packages/firestore/test/unit/remote/node/serializer.test.ts
@@ -1111,6 +1111,29 @@ describe('Serializer', () => {
       expect(s.fromQueryTarget(s.toQueryTarget(q))).to.deep.equal(q);
     });
 
+    it('converts offsets', () => {
+      const q = Query.atPath(path('docs')).withOffset(26);
+      const result = s.toTarget(wrapQueryData(q));
+      const expected = {
+        query: {
+          parent: 'projects/p/databases/d',
+          structuredQuery: {
+            from: [{ collectionId: 'docs' }],
+            orderBy: [
+              {
+                field: { fieldPath: DOCUMENT_KEY_NAME },
+                direction: 'ASCENDING'
+              }
+            ],
+            offset: 26
+          }
+        },
+        targetId: 1
+      };
+      expect(result).to.deep.equal(expected);
+      expect(s.fromQueryTarget(s.toQueryTarget(q))).to.deep.equal(q);
+    });
+
     it('converts resume tokens', () => {
       const q = Query.atPath(path('docs'));
       const result = s.toTarget(


### PR DESCRIPTION
Hi there,

Firestore 's StructuredQuery has `offset`, but this package has no method, so I added it.

[StructuredQuery  |  Cloud Firestore  |  Google Cloud Platform](https://cloud.google.com/firestore/docs/reference/rest/v1beta1/StructuredQuery)

Many thanks,
atomita