### PR TITLE
Remove unnecessary lcov-result-merger dep from @firebase/messaging

### DIFF
--- a/packages/messaging/package.json
+++ b/packages/messaging/package.json
@@ -18,7 +18,6 @@
   "dependencies": {
     "@firebase/messaging-types": "0.1.2",
     "@firebase/util": "0.1.10",
-    "lcov-result-merger": "^2.0.0",
     "tslib": "^1.9.0"
   },
   "devDependencies": {


### PR DESCRIPTION
tentatively fixes #546 

I'm not sure that making grpc an optional dependency is the best way to fix this, but I figured I'd create this PR as a starting point.