### PR TITLE
Fix MutationQueue issue resulting in re-sending acknowledged writes.

### DIFF
--- a/packages/firestore/src/local/memory_mutation_queue.ts
+++ b/packages/firestore/src/local/memory_mutation_queue.ts
@@ -182,11 +182,11 @@ export class MemoryMutationQueue implements MutationQueue {
     // All batches with batchId <= this.highestAcknowledgedBatchId have been
     // acknowledged so the first unacknowledged batch after batchID will have a
     // batchID larger than both of these values.
-    batchId = Math.max(batchId + 1, this.highestAcknowledgedBatchId);
+    const nextBatchId = Math.max(batchId, this.highestAcknowledgedBatchId) + 1;
 
     // The requested batchId may still be out of range so normalize it to the
     // start of the queue.
-    const rawIndex = this.indexOfBatchId(batchId);
+    const rawIndex = this.indexOfBatchId(nextBatchId);
     let index = rawIndex < 0 ? 0 : rawIndex;
 
     // Finally return the first non-tombstone batch.

--- a/packages/firestore/test/unit/specs/spec_test_runner.ts
+++ b/packages/firestore/test/unit/specs/spec_test_runner.ts
@@ -825,17 +825,17 @@ abstract class TestRunner {
   private validateStateExpectations(expectation: StateExpectation): void {
     if (expectation) {
       if ('numOutstandingWrites' in expectation) {
-        expect(this.remoteStore.outstandingWrites()).to.deep.equal(
+        expect(this.remoteStore.outstandingWrites()).to.equal(
           expectation.numOutstandingWrites
         );
       }
       if ('writeStreamRequestCount' in expectation) {
-        expect(this.connection.writeStreamRequestCount).to.deep.equal(
+        expect(this.connection.writeStreamRequestCount).to.equal(
           expectation.writeStreamRequestCount
         );
       }
       if ('watchStreamRequestCount' in expectation) {
-        expect(this.connection.watchStreamRequestCount).to.deep.equal(
+        expect(this.connection.watchStreamRequestCount).to.equal(
           expectation.watchStreamRequestCount
         );
       }

--- a/packages/firestore/test/unit/specs/write_spec.test.ts
+++ b/packages/firestore/test/unit/specs/write_spec.test.ts
@@ -395,6 +395,56 @@ describeSpec('Writes:', [], () => {
   });
 
   specTest(
+    'Held writes are not re-sent after disable/enable network.',
+    [],
+    () => {
+      const query = Query.atPath(path('collection'));
+      const docALocal = doc(
+        'collection/a',
+        0,
+        { v: 1 },
+        { hasLocalMutations: true }
+      );
+      const docA = doc('collection/a', 1000, { v: 1 });
+
+      return (
+        spec()
+          .userListens(query)
+          .watchAcksFull(query, 500)
+          .expectEvents(query, {})
+          .userSets('collection/a', { v: 1 })
+          .expectEvents(query, {
+            hasPendingWrites: true,
+            added: [docALocal]
+          })
+          // ack write but without a watch event.
+          .writeAcks(1000)
+
+          .disableNetwork()
+          .expectEvents(query, {
+            hasPendingWrites: true,
+            fromCache: true
+          })
+
+          // handshake + write + close = 3 requests
+          .expectWriteStreamRequestCount(3)
+
+          .enableNetwork()
+          .expectActiveTargets({ query, resumeToken: 'resume-token-500' })
+
+          // acked write should /not/ have been resent, so count should still be 3
+          .expectWriteStreamRequestCount(3)
+
+          // Finally watch catches up.
+          .watchAcksFull(query, 2000, docA)
+          .expectEvents(query, {
+            metadata: [docA]
+          })
+      );
+    }
+  );
+
+  specTest(
     'Held writes are released when there are no queries left.',
     [],
     () => {


### PR DESCRIPTION
getNextMutationBatchAfterBatchId() was not respecting highestAcknowledgedBatchId and therefore we were resending writes if they had been acknowledged but not removed (aka the held write acks case). This showed up when a user enabled / disabled the network as reported here and I've included a spec test to emulate that case: https://github.com/firebase/firebase-ios-sdk/issues/772  (cc/ @gsoltis FYI).

This is the JS port which I'll port to iOS (where the issue was reported) once we're happy with the fix here.