### PR TITLE
Fixes #562, Adds usePublicVapidKey to firebase/index.d.ts

### DIFF
--- a/packages/firebase/index.d.ts
+++ b/packages/firebase/index.d.ts
@@ -474,6 +474,7 @@ declare namespace firebase.messaging {
     requestPermission(): Promise<any> | null;
     setBackgroundMessageHandler(callback: (a: Object) => any): any;
     useServiceWorker(registration: any): any;
+    usePublicVapidKey(b64PublicKey: string): void;
   }
 }
 


### PR DESCRIPTION
Pulls [firebase/index.d.ts](https://github.com/firebase/firebase-js-sdk/blob/master/packages/firebase/index.d.ts#L464) into alignment with [@firebase/messaging-types/index.d.ts](https://github.com/firebase/firebase-js-sdk/blob/master/packages/messaging-types/index.d.ts#L37) by adding `usePublicVapidKey` definition.