### PR TITLE
Add missing function in Auth interface

### DIFF
--- a/packages/firebase/index.d.ts
+++ b/packages/firebase/index.d.ts
@@ -154,6 +154,10 @@ declare namespace firebase.auth {
     applyActionCode(code: string): Promise<any>;
     checkActionCode(code: string): Promise<any>;
     confirmPasswordReset(code: string, newPassword: string): Promise<any>;
+    createUserAndRetrieveDataWithEmailAndPassword( 
+      email: string, 
+      password: string 
+    ): Promise<any>;      
     createUserWithEmailAndPassword(
       email: string,
       password: string


### PR DESCRIPTION
Related to issue #573.

Added the TypeScript definition for the `createUserAndRetrieveDataWithEmailAndPassword` function in Auth interface.