### PR TITLE
Fetch API missing support handling

### DIFF
--- a/packages/auth/demo/public/script.js
+++ b/packages/auth/demo/public/script.js
@@ -1146,9 +1146,11 @@ function populateActionCodes() {
 /**
  * Provides basic Database checks for authenticated and unauthenticated access.
  * The Database node being tested has the following rule:
- * "$user_id": {
- *   ".read": "$user_id === auth.uid",
- *   ".write": "$user_id === auth.uid"
+ * "users": {
+ *   "$user_id": {
+ *     ".read": "$user_id === auth.uid",
+ *     ".write": "$user_id === auth.uid"
+ *   }
  * }
  * This applies when Real-time database service is available.
  */
@@ -1226,7 +1228,7 @@ function onRunWebWorkTests() {
     return;
   }
   var onError = function(error) {
-    alertError('Error: ' + error.code);
+    alertError('Error code: ' + error.code + ' message: ' + error.message);
   };
   auth.signInWithPopup(new firebase.auth.GoogleAuthProvider())
       .then(function(result) {

--- a/packages/auth/demo/public/web-worker.js
+++ b/packages/auth/demo/public/web-worker.js
@@ -23,6 +23,11 @@ importScripts('/dist/firebase-app.js');
 importScripts('/dist/firebase-auth.js');
 importScripts('config.js');
 
+// Polyfill Promise in case it is not supported.
+if (typeof Promise === 'undefined') {
+  var Promise = firebase.Promise;
+}
+
 // Initialize the Firebase app in the web worker.
 firebase.initializeApp(config);
 
@@ -179,7 +184,8 @@ self.onmessage = function(e) {
           self.postMessage(result);
         }).catch(function(error) {
           result.status = 'failure';
-          result.error = error;
+          // DataCloneError when postMessaging in IE11 and 10.
+          result.error = error.code ? error : error.message;
           self.postMessage(result);
         });
         break;

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -28,6 +28,7 @@
     "del": "^3.0.0",
     "express": "^4.16.2",
     "firebase-tools": "^3.17.4",
+    "firebase-functions": "^0.9.0",
     "google-closure-compiler": "^20180204.0.0",
     "google-closure-library": "^20180204.0.0",
     "gulp": "^3.9.1",

--- a/packages/auth/src/rpchandler.js
+++ b/packages/auth/src/rpchandler.js
@@ -462,6 +462,13 @@ fireauth.RpcHandler.prototype.sendXhrUsingXhrIo_ = function(
     opt_data,
     opt_headers,
     opt_timeout) {
+  if (fireauth.util.isWorker() && !fireauth.util.isFetchSupported()) {
+    throw new fireauth.AuthError(
+        fireauth.authenum.Error.OPERATION_NOT_SUPPORTED,
+        'fetch, Headers and Request native APIs or equivalent Polyfills ' +
+        'must be available to support HTTP requests from a Worker ' +
+        'environment.');
+  }
   var xhrIo = new goog.net.XhrIo(this.rpcHandlerXhrFactory_);
 
   // xhrIo.setTimeoutInterval not working in IE10 and IE11, handle manually.

--- a/packages/auth/src/utils.js
+++ b/packages/auth/src/utils.js
@@ -630,6 +630,20 @@ fireauth.util.isWorker = function(opt_global) {
 
 
 /**
+ * @param {?Object=} opt_global The optional global scope.
+ * @return {boolean} Whether current environment supports fetch API and other
+ *     APIs it depends on.
+ */
+fireauth.util.isFetchSupported = function(opt_global) {
+  // Required by fetch API calls.
+  var scope = opt_global || goog.global;
+  return typeof scope['fetch'] !== 'undefined' &&
+         typeof scope['Headers'] !== 'undefined' &&
+         typeof scope['Request'] !== 'undefined';
+};
+
+
+/**
  * Enum for the runtime environment.
  * @enum {string}
  */

--- a/packages/auth/test/utils_test.js
+++ b/packages/auth/test/utils_test.js
@@ -520,6 +520,31 @@ function testIsWorker() {
 }
 
 
+function testIsFetchSupported() {
+  // All fetch related APIs supported.
+  assertTrue(fireauth.util.isFetchSupported({
+    'fetch': function() {},
+    'Request': function() {},
+    'Headers': function() {}
+  }));
+  // Headers missing.
+  assertFalse(fireauth.util.isFetchSupported({
+    'fetch': function() {},
+    'Request': function() {},
+  }));
+  // Request missing.
+  assertFalse(fireauth.util.isFetchSupported({
+    'fetch': function() {},
+    'Headers': function() {}
+  }));
+  // fetch missing.
+  assertFalse(fireauth.util.isFetchSupported({
+    'Request': function() {},
+    'Headers': function() {}
+  }));
+}
+
+
 function testGetBrowserName_opera() {
   assertEquals('Opera', fireauth.util.getBrowserName(operaUA));
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -258,6 +258,13 @@
   dependencies:
     samsam "1.3.0"
 
+"@types/body-parser@*":
+  version "1.16.8"
+  resolved "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.16.8.tgz#687ec34140624a3bec2b1a8ea9268478ae8f3be3"
+  dependencies:
+    "@types/express" "*"
+    "@types/node" "*"
+
 "@types/chai-as-promised@^7.1.0":
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/@types/chai-as-promised/-/chai-as-promised-7.1.0.tgz#010b04cde78eacfb6e72bfddb3e58fe23c2e78b9"
@@ -268,15 +275,54 @@
   version "4.1.2"
   resolved "https://registry.npmjs.org/@types/chai/-/chai-4.1.2.tgz#f1af664769cfb50af805431c407425ed619daa21"
 
+"@types/cors@^2.8.1":
+  version "2.8.3"
+  resolved "https://registry.npmjs.org/@types/cors/-/cors-2.8.3.tgz#eaf6e476da0d36bee6b061a24d57e343ddce86d6"
+  dependencies:
+    "@types/express" "*"
+
+"@types/events@*":
+  version "1.2.0"
+  resolved "https://registry.npmjs.org/@types/events/-/events-1.2.0.tgz#81a6731ce4df43619e5c8c945383b3e62a89ea86"
+
+"@types/express-serve-static-core@*":
+  version "4.11.1"
+  resolved "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.11.1.tgz#f6f7212382d59b19d696677bcaa48a37280f5d45"
+  dependencies:
+    "@types/events" "*"
+    "@types/node" "*"
+
+"@types/express@*", "@types/express@^4.0.33":
+  version "4.11.1"
+  resolved "https://registry.npmjs.org/@types/express/-/express-4.11.1.tgz#f99663b3ab32d04cb11db612ef5dd7933f75465b"
+  dependencies:
+    "@types/body-parser" "*"
+    "@types/express-serve-static-core" "*"
+    "@types/serve-static" "*"
+
 "@types/google-cloud__storage@^1.1.1":
   version "1.1.7"
   resolved "https://registry.npmjs.org/@types/google-cloud__storage/-/google-cloud__storage-1.1.7.tgz#f4b568b163cce16314f32f954f5b7d5c9001fa86"
   dependencies:
     "@types/node" "*"
 
+"@types/jsonwebtoken@^7.1.32":
+  version "7.2.6"
+  resolved "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-7.2.6.tgz#8d018c21ca5910b5eb3ebcb385656606a215032f"
+  dependencies:
+    "@types/node" "*"
+
+"@types/lodash@^4.14.34":
+  version "4.14.105"
+  resolved "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.105.tgz#9fcc4627a1f98f8f8fce79ddb2bff4afd97e959b"
+
 "@types/long@^3.0.32":
   version "3.0.32"
   resolved "https://registry.npmjs.org/@types/long/-/long-3.0.32.tgz#f4e5af31e9e9b196d8e5fca8a5e2e20aa3d60b69"
+
+"@types/mime@*":
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/@types/mime/-/mime-2.0.0.tgz#5a7306e367c539b9f6543499de8dd519fac37a8b"
 
 "@types/mocha@^2.2.48":
   version "2.2.48"
@@ -301,6 +347,19 @@
 "@types/selenium-webdriver@^2.53.35", "@types/selenium-webdriver@~2.53.39":
   version "2.53.43"
   resolved "https://registry.npmjs.org/@types/selenium-webdriver/-/selenium-webdriver-2.53.43.tgz#2de3d718819bc20165754c4a59afb7e9833f6707"
+
+"@types/serve-static@*":
+  version "1.13.1"
+  resolved "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.1.tgz#1d2801fa635d274cd97d4ec07e26b21b44127492"
+  dependencies:
+    "@types/express-serve-static-core" "*"
+    "@types/mime" "*"
+
+"@types/sha1@^1.1.0":
+  version "1.1.1"
+  resolved "https://registry.npmjs.org/@types/sha1/-/sha1-1.1.1.tgz#ab34efa782ff948d402d896afc9f10f41e94dd44"
+  dependencies:
+    "@types/node" "*"
 
 "@types/sinon@^2.3.3":
   version "2.3.7"
@@ -330,6 +389,13 @@ accepts@~1.3.3, accepts@~1.3.4:
   resolved "https://registry.npmjs.org/accepts/-/accepts-1.3.4.tgz#86246758c7dd6d21a6474ff084a4740ec05eb21f"
   dependencies:
     mime-types "~2.1.16"
+    negotiator "0.6.1"
+
+accepts@~1.3.5:
+  version "1.3.5"
+  resolved "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz#eb777df6011723a3b14e8a72c0805c8e86746bd2"
+  dependencies:
+    mime-types "~2.1.18"
     negotiator "0.6.1"
 
 acorn-dynamic-import@^2.0.0:
@@ -1666,6 +1732,10 @@ chardet@^0.4.0:
   version "0.4.2"
   resolved "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz#b5473b33dc97c424e5d98dc87d55d4d8a29c8bf2"
 
+"charenc@>= 0.0.1":
+  version "0.0.2"
+  resolved "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz#c0a1d2f3a7092e03774bfa83f14c0fc5790a8667"
+
 check-error@^1.0.1:
   version "1.0.2"
   resolved "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz#574d312edd88bb5dd8912e9286dd6c0aed4aac82"
@@ -2381,6 +2451,13 @@ core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
 
+cors@^2.8.4:
+  version "2.8.4"
+  resolved "https://registry.npmjs.org/cors/-/cors-2.8.4.tgz#2bd381f2eb201020105cd50ea59da63090694686"
+  dependencies:
+    object-assign "^4"
+    vary "^1"
+
 coveralls@^3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/coveralls/-/coveralls-3.0.0.tgz#22ef730330538080d29b8c151dc9146afde88a99"
@@ -2449,6 +2526,10 @@ cross-spawn@^5.0.1, cross-spawn@^5.1.0:
     lru-cache "^4.0.1"
     shebang-command "^1.2.0"
     which "^1.2.9"
+
+"crypt@>= 0.0.1":
+  version "0.0.2"
+  resolved "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz#88d7ff7ec0dfb86f713dc87bbb42d044d3e6c41b"
 
 cryptiles@2.x.x:
   version "2.0.5"
@@ -2793,7 +2874,7 @@ depd@1.1.1:
   version "1.1.1"
   resolved "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz#5783b4e1c459f06fa5ca27f991f3d06e7a310359"
 
-depd@~1.1.0, depd@~1.1.1:
+depd@~1.1.0, depd@~1.1.1, depd@~1.1.2:
   version "1.1.2"
   resolved "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz#9bcd52e14c097763e749b274c4346ed2e560b5a9"
 
@@ -3063,7 +3144,7 @@ empower@^1.2.3:
     core-js "^2.0.0"
     empower-core "^0.6.2"
 
-encodeurl@~1.0.1:
+encodeurl@~1.0.1, encodeurl@~1.0.2:
   version "1.0.2"
   resolved "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz#ad3ff4c86ec2d029322f5a02c3a9a606c95b3f59"
 
@@ -3533,6 +3614,41 @@ express@4.15.4:
     utils-merge "1.0.0"
     vary "~1.1.1"
 
+express@^4.0.33:
+  version "4.16.3"
+  resolved "https://registry.npmjs.org/express/-/express-4.16.3.tgz#6af8a502350db3246ecc4becf6b5a34d22f7ed53"
+  dependencies:
+    accepts "~1.3.5"
+    array-flatten "1.1.1"
+    body-parser "1.18.2"
+    content-disposition "0.5.2"
+    content-type "~1.0.4"
+    cookie "0.3.1"
+    cookie-signature "1.0.6"
+    debug "2.6.9"
+    depd "~1.1.2"
+    encodeurl "~1.0.2"
+    escape-html "~1.0.3"
+    etag "~1.8.1"
+    finalhandler "1.1.1"
+    fresh "0.5.2"
+    merge-descriptors "1.0.1"
+    methods "~1.1.2"
+    on-finished "~2.3.0"
+    parseurl "~1.3.2"
+    path-to-regexp "0.1.7"
+    proxy-addr "~2.0.3"
+    qs "6.5.1"
+    range-parser "~1.2.0"
+    safe-buffer "5.1.1"
+    send "0.16.2"
+    serve-static "1.13.2"
+    setprototypeof "1.1.0"
+    statuses "~1.4.0"
+    type-is "~1.6.16"
+    utils-merge "1.0.1"
+    vary "~1.1.2"
+
 express@^4.15.4, express@^4.16.2:
   version "4.16.2"
   resolved "https://registry.npmjs.org/express/-/express-4.16.2.tgz#e35c6dfe2d64b7dca0a5cd4f21781be3299e076c"
@@ -3775,6 +3891,18 @@ finalhandler@1.1.0:
     statuses "~1.3.1"
     unpipe "~1.0.0"
 
+finalhandler@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz#eebf4ed840079c83f4249038c9d703008301b105"
+  dependencies:
+    debug "2.6.9"
+    encodeurl "~1.0.2"
+    escape-html "~1.0.3"
+    on-finished "~2.3.0"
+    parseurl "~1.3.2"
+    statuses "~1.4.0"
+    unpipe "~1.0.0"
+
 finalhandler@~1.0.4:
   version "1.0.6"
   resolved "https://registry.npmjs.org/finalhandler/-/finalhandler-1.0.6.tgz#007aea33d1a4d3e42017f624848ad58d212f814f"
@@ -3852,6 +3980,21 @@ firebase-admin@5.9.0:
     faye-websocket "0.9.3"
     jsonwebtoken "8.1.0"
     node-forge "0.7.1"
+
+firebase-functions@^0.9.0:
+  version "0.9.0"
+  resolved "https://registry.npmjs.org/firebase-functions/-/firebase-functions-0.9.0.tgz#5fa15725bdb9cfc51ba716e9a57a554753d0c073"
+  dependencies:
+    "@types/cors" "^2.8.1"
+    "@types/express" "^4.0.33"
+    "@types/jsonwebtoken" "^7.1.32"
+    "@types/lodash" "^4.14.34"
+    "@types/sha1" "^1.1.0"
+    cors "^2.8.4"
+    express "^4.0.33"
+    jsonwebtoken "^7.1.9"
+    lodash "^4.6.1"
+    sha1 "^1.1.1"
 
 firebase-tools@^3.17.4:
   version "3.17.4"
@@ -6099,7 +6242,7 @@ jsonwebtoken@8.1.0:
     ms "^2.0.0"
     xtend "^4.0.1"
 
-jsonwebtoken@^7.4.1:
+jsonwebtoken@^7.1.9, jsonwebtoken@^7.4.1:
   version "7.4.3"
   resolved "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-7.4.3.tgz#77f5021de058b605a1783fa1283e99812e645638"
   dependencies:
@@ -7744,7 +7887,7 @@ oauth-sign@~0.8.1, oauth-sign@~0.8.2:
   version "0.8.2"
   resolved "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz#46a6ab7f0aead8deae9ec0565780b7d4efeb9d43"
 
-object-assign@4.X, object-assign@^4.0.0, object-assign@^4.0.1, object-assign@^4.1.0:
+object-assign@4.X, object-assign@^4, object-assign@^4.0.0, object-assign@^4.0.1, object-assign@^4.1.0:
   version "4.1.1"
   resolved "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
 
@@ -8551,7 +8694,7 @@ proxy-addr@~1.1.5:
     forwarded "~0.1.0"
     ipaddr.js "1.4.0"
 
-proxy-addr@~2.0.2:
+proxy-addr@~2.0.2, proxy-addr@~2.0.3:
   version "2.0.3"
   resolved "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.3.tgz#355f262505a621646b3130a728eb647e22055341"
   dependencies:
@@ -9448,6 +9591,24 @@ send@0.16.1:
     range-parser "~1.2.0"
     statuses "~1.3.1"
 
+send@0.16.2:
+  version "0.16.2"
+  resolved "https://registry.npmjs.org/send/-/send-0.16.2.tgz#6ecca1e0f8c156d141597559848df64730a6bbc1"
+  dependencies:
+    debug "2.6.9"
+    depd "~1.1.2"
+    destroy "~1.0.4"
+    encodeurl "~1.0.2"
+    escape-html "~1.0.3"
+    etag "~1.8.1"
+    fresh "0.5.2"
+    http-errors "~1.6.2"
+    mime "1.4.1"
+    ms "2.0.0"
+    on-finished "~2.3.0"
+    range-parser "~1.2.0"
+    statuses "~1.4.0"
+
 sequencify@~0.0.7:
   version "0.0.7"
   resolved "https://registry.npmjs.org/sequencify/-/sequencify-0.0.7.tgz#90cff19d02e07027fd767f5ead3e7b95d1e7380c"
@@ -9491,6 +9652,15 @@ serve-static@1.13.1:
     escape-html "~1.0.3"
     parseurl "~1.3.2"
     send "0.16.1"
+
+serve-static@1.13.2:
+  version "1.13.2"
+  resolved "https://registry.npmjs.org/serve-static/-/serve-static-1.13.2.tgz#095e8472fd5b46237db50ce486a43f4b86c6cec1"
+  dependencies:
+    encodeurl "~1.0.2"
+    escape-html "~1.0.3"
+    parseurl "~1.3.2"
+    send "0.16.2"
 
 set-blocking@^2.0.0, set-blocking@~2.0.0:
   version "2.0.0"
@@ -9542,6 +9712,13 @@ sha.js@^2.4.0, sha.js@^2.4.8, sha.js@~2.4.4:
   dependencies:
     inherits "^2.0.1"
     safe-buffer "^5.0.1"
+
+sha1@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.npmjs.org/sha1/-/sha1-1.1.1.tgz#addaa7a93168f393f19eb2b15091618e2700f848"
+  dependencies:
+    charenc ">= 0.0.1"
+    crypt ">= 0.0.1"
 
 shasum@^1.0.0:
   version "1.0.2"
@@ -9975,7 +10152,7 @@ static-extend@^0.1.1:
     define-property "^0.2.5"
     object-copy "^0.1.0"
 
-"statuses@>= 1.3.1 < 2":
+"statuses@>= 1.3.1 < 2", statuses@~1.4.0:
   version "1.4.0"
   resolved "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz#bb73d446da2796106efcc1b601a253d6c46bd087"
 
@@ -10739,7 +10916,7 @@ type-detect@^4.0.0, type-detect@^4.0.5:
   version "4.0.8"
   resolved "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
 
-type-is@~1.6.15:
+type-is@~1.6.15, type-is@~1.6.16:
   version "1.6.16"
   resolved "https://registry.npmjs.org/type-is/-/type-is-1.6.16.tgz#f89ce341541c672b25ee7ae3c73dee3b2be50194"
   dependencies:
@@ -11099,7 +11276,7 @@ vargs@0.1.0:
   version "0.1.0"
   resolved "https://registry.npmjs.org/vargs/-/vargs-0.1.0.tgz#6b6184da6520cc3204ce1b407cac26d92609ebff"
 
-vary@~1.1.1, vary@~1.1.2:
+vary@^1, vary@~1.1.1, vary@~1.1.2:
   version "1.1.2"
   resolved "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
 


### PR DESCRIPTION
Fixes vague errors thrown in older browsers such as IE10/11 and iOS mobile Safari related to worker support.

Most of these are attributed to lack of support for fetch related APIs even when web workers are still supported.
In that case we throw an operation not supported in environment error on operations that require http requests.

Also adds missing dependency on firebase-functions required for demo app.