### PR TITLE
Move getPushSubscription method to ControllerInterface. 

### DIFF
--- a/packages/firebase/index.d.ts
+++ b/packages/firebase/index.d.ts
@@ -154,10 +154,10 @@ declare namespace firebase.auth {
     applyActionCode(code: string): Promise<any>;
     checkActionCode(code: string): Promise<any>;
     confirmPasswordReset(code: string, newPassword: string): Promise<any>;
-    createUserAndRetrieveDataWithEmailAndPassword( 
-      email: string, 
-      password: string 
-    ): Promise<any>;      
+    createUserAndRetrieveDataWithEmailAndPassword(
+      email: string,
+      password: string
+    ): Promise<any>;
     createUserWithEmailAndPassword(
       email: string,
       password: string
@@ -202,7 +202,10 @@ declare namespace firebase.auth {
     signInWithCustomToken(token: string): Promise<any>;
     signInAndRetrieveDataWithCustomToken(token: string): Promise<any>;
     signInWithEmailAndPassword(email: string, password: string): Promise<any>;
-    signInAndRetrieveDataWithEmailAndPassword(email: string, password: string): Promise<any>;
+    signInAndRetrieveDataWithEmailAndPassword(
+      email: string,
+      password: string
+    ): Promise<any>;
     signInWithPhoneNumber(
       phoneNumber: string,
       applicationVerifier: firebase.auth.ApplicationVerifier

--- a/packages/messaging/src/controllers/controller-interface.ts
+++ b/packages/messaging/src/controllers/controller-interface.ts
@@ -273,11 +273,23 @@ export default class ControllerInterface {
     throw this.errorFactory_.create(Errors.codes.AVAILABLE_IN_WINDOW);
   }
 
-  private getPushSubscription(
+  /**
+   * Gets a PushSubscription for the current user.
+   */
+  getPushSubscription(
     swRegistration: ServiceWorkerRegistration,
     publicVapidKey: Uint8Array
   ): Promise<PushSubscription> {
-    throw this.errorFactory_.create(Errors.codes.SHOULD_BE_INHERITED);
+    return swRegistration.pushManager.getSubscription().then(subscription => {
+      if (subscription) {
+        return subscription;
+      }
+
+      return swRegistration.pushManager.subscribe({
+        userVisibleOnly: true,
+        applicationServerKey: publicVapidKey
+      });
+    });
   }
 
   /**

--- a/packages/messaging/src/controllers/controller-interface.ts
+++ b/packages/messaging/src/controllers/controller-interface.ts
@@ -273,11 +273,8 @@ export default class ControllerInterface {
     throw this.errorFactory_.create(Errors.codes.AVAILABLE_IN_WINDOW);
   }
 
-  getPushSubscription_(
-    registration,
-    publicVapidKey
-  ): Promise<PushSubscription> {
-    throw this.errorFactory_.create(Errors.codes.AVAILABLE_IN_WINDOW);
+  private getPushSubscription(swRegistration: ServiceWorkerRegistration, publicVapidKey: Uint8Array): Promise<PushSubscription> {
+    throw this.errorFactory_.create(Errors.codes.SHOULD_BE_INHERITED);
   }
 
   /**

--- a/packages/messaging/src/controllers/controller-interface.ts
+++ b/packages/messaging/src/controllers/controller-interface.ts
@@ -273,7 +273,10 @@ export default class ControllerInterface {
     throw this.errorFactory_.create(Errors.codes.AVAILABLE_IN_WINDOW);
   }
 
-  private getPushSubscription(swRegistration: ServiceWorkerRegistration, publicVapidKey: Uint8Array): Promise<PushSubscription> {
+  private getPushSubscription(
+    swRegistration: ServiceWorkerRegistration,
+    publicVapidKey: Uint8Array
+  ): Promise<PushSubscription> {
     throw this.errorFactory_.create(Errors.codes.SHOULD_BE_INHERITED);
   }
 

--- a/packages/messaging/src/controllers/controller-interface.ts
+++ b/packages/messaging/src/controllers/controller-interface.ts
@@ -145,7 +145,7 @@ export default class ControllerInterface {
     return this.getPublicVapidKey_()
       .then(publicKey => {
         publicVapidKey = publicKey;
-        return this.getPushSubscription_(swReg, publicVapidKey);
+        return this.getPushSubscription(swReg, publicVapidKey);
       })
       .then(pushSubscription => {
         subscription = pushSubscription;
@@ -192,7 +192,7 @@ export default class ControllerInterface {
     return this.getPublicVapidKey_()
       .then(publicKey => {
         publicVapidKey = publicKey;
-        return this.getPushSubscription_(swReg, publicVapidKey);
+        return this.getPushSubscription(swReg, publicVapidKey);
       })
       .then(pushSubscription => {
         subscription = pushSubscription;

--- a/packages/messaging/src/controllers/sw-controller.ts
+++ b/packages/messaging/src/controllers/sw-controller.ts
@@ -377,4 +377,8 @@ export default class SWController extends ControllerInterface {
         return vapidKeyFromDatabase;
       });
   }
+
+  getPushSubscription(swRegistration: ServiceWorkerRegistration, publicVapidKey: Uint8Array): Promise<PushSubscription> {
+    return Promise.resolve(null);
+  }
 }

--- a/packages/messaging/src/controllers/sw-controller.ts
+++ b/packages/messaging/src/controllers/sw-controller.ts
@@ -377,11 +377,4 @@ export default class SWController extends ControllerInterface {
         return vapidKeyFromDatabase;
       });
   }
-
-  getPushSubscription(
-    swRegistration: ServiceWorkerRegistration,
-    publicVapidKey: Uint8Array
-  ): Promise<PushSubscription> {
-    return Promise.resolve(null);
-  }
 }

--- a/packages/messaging/src/controllers/sw-controller.ts
+++ b/packages/messaging/src/controllers/sw-controller.ts
@@ -378,7 +378,10 @@ export default class SWController extends ControllerInterface {
       });
   }
 
-  getPushSubscription(swRegistration: ServiceWorkerRegistration, publicVapidKey: Uint8Array): Promise<PushSubscription> {
+  getPushSubscription(
+    swRegistration: ServiceWorkerRegistration,
+    publicVapidKey: Uint8Array
+  ): Promise<PushSubscription> {
     return Promise.resolve(null);
   }
 }

--- a/packages/messaging/src/controllers/window-controller.ts
+++ b/packages/messaging/src/controllers/window-controller.ts
@@ -369,28 +369,6 @@ export default class WindowController extends ControllerInterface
   }
 
   /**
-   * Gets a PushSubscription for the current user.
-   */
-  getPushSubscription(
-    swRegistration: ServiceWorkerRegistration,
-    publicVapidKey: Uint8Array
-  ): Promise<PushSubscription> {
-    // Check for existing subscription first
-    let subscription;
-    let fcmTokenDetails;
-    return swRegistration.pushManager.getSubscription().then(subscription => {
-      if (subscription) {
-        return subscription;
-      }
-
-      return swRegistration.pushManager.subscribe({
-        userVisibleOnly: true,
-        applicationServerKey: publicVapidKey
-      });
-    });
-  }
-
-  /**
    * This method will set up a message listener to handle
    * events from the service worker that should trigger
    * events in the page.

--- a/packages/messaging/src/controllers/window-controller.ts
+++ b/packages/messaging/src/controllers/window-controller.ts
@@ -370,11 +370,8 @@ export default class WindowController extends ControllerInterface
 
   /**
    * Gets a PushSubscription for the current user.
-   * @private
-   * @param {ServiceWorkerRegistration} registration
-   * @return {Promise<PushSubscription>}
    */
-  getPushSubscription_(swRegistration, publicVapidKey) {
+  getPushSubscription(swRegistration: ServiceWorkerRegistration, publicVapidKey: Uint8Array): Promise<PushSubscription> {
     // Check for existing subscription first
     let subscription;
     let fcmTokenDetails;

--- a/packages/messaging/src/controllers/window-controller.ts
+++ b/packages/messaging/src/controllers/window-controller.ts
@@ -371,7 +371,10 @@ export default class WindowController extends ControllerInterface
   /**
    * Gets a PushSubscription for the current user.
    */
-  getPushSubscription(swRegistration: ServiceWorkerRegistration, publicVapidKey: Uint8Array): Promise<PushSubscription> {
+  getPushSubscription(
+    swRegistration: ServiceWorkerRegistration,
+    publicVapidKey: Uint8Array
+  ): Promise<PushSubscription> {
     // Check for existing subscription first
     let subscription;
     let fcmTokenDetails;

--- a/packages/messaging/test/controller-get-token.test.ts
+++ b/packages/messaging/test/controller-get-token.test.ts
@@ -222,7 +222,7 @@ describe('Firebase Messaging > *Controller.getToken()', function() {
         mockGetReg(Promise.resolve(registration));
 
         sandbox
-          .stub(ServiceClass.prototype, 'getPushSubscription_')
+          .stub(ServiceClass.prototype, 'getPushSubscription')
           .callsFake(() => Promise.resolve(subscription));
 
         let vapidKeyToUse = FCMDetails.DEFAULT_PUBLIC_VAPID_KEY;
@@ -256,7 +256,7 @@ describe('Firebase Messaging > *Controller.getToken()', function() {
       mockGetReg(Promise.resolve(registration));
 
       sandbox
-        .stub(ServiceClass.prototype, 'getPushSubscription_')
+        .stub(ServiceClass.prototype, 'getPushSubscription')
         .callsFake(() => Promise.resolve(subscription));
       sandbox
         .stub(ServiceClass.prototype, 'getPublicVapidKey_')
@@ -298,7 +298,7 @@ describe('Firebase Messaging > *Controller.getToken()', function() {
         .callsFake(() => Promise.resolve(FCMDetails.DEFAULT_PUBLIC_VAPID_KEY));
 
       sandbox
-        .stub(ServiceClass.prototype, 'getPushSubscription_')
+        .stub(ServiceClass.prototype, 'getPushSubscription')
         .callsFake(() => Promise.resolve(subscription));
 
       sandbox
@@ -337,7 +337,7 @@ describe('Firebase Messaging > *Controller.getToken()', function() {
           .callsFake(() => NotificationPermission.granted);
 
         sandbox
-          .stub(ServiceClass.prototype, 'getPushSubscription_')
+          .stub(ServiceClass.prototype, 'getPushSubscription')
           .callsFake(() => Promise.resolve(subscription));
 
         let vapidKeyToUse = FCMDetails.DEFAULT_PUBLIC_VAPID_KEY;
@@ -437,7 +437,7 @@ describe('Firebase Messaging > *Controller.getToken()', function() {
         .callsFake(() => Promise.resolve(EXAMPLE_TOKEN_DETAILS_DEFAULT_VAPID));
 
       sandbox
-        .stub(ServiceClass.prototype, 'getPushSubscription_')
+        .stub(ServiceClass.prototype, 'getPushSubscription')
         .callsFake(() => Promise.resolve(subscription));
 
       const serviceInstance = new ServiceClass(app);
@@ -506,7 +506,7 @@ describe('Firebase Messaging > *Controller.getToken()', function() {
         .callsFake(() => Promise.resolve(EXAMPLE_EXPIRED_TOKEN_DETAILS));
 
       sandbox
-        .stub(ServiceClass.prototype, 'getPushSubscription_')
+        .stub(ServiceClass.prototype, 'getPushSubscription')
         .callsFake(() => Promise.resolve(subscription));
 
       sandbox

--- a/packages/messaging/test/controller-interface.test.ts
+++ b/packages/messaging/test/controller-interface.test.ts
@@ -16,11 +16,17 @@
 import { expect } from 'chai';
 import * as sinon from 'sinon';
 import makeFakeApp from './make-fake-app';
+import makeFakeSWReg from './make-fake-sw-reg';
 
+import FCMDetails from '../src/models/fcm-details';
+import WindowController from '../src/controllers/window-controller';
+import SWController from '../src/controllers/sw-controller';
 import ControllerInterface from '../src/controllers/controller-interface';
 import TokenDetailsModel from '../src/models/token-details-model';
 import VapidDetailsModel from '../src/models/vapid-details-model';
 import IIDModel from '../src/models/iid-model';
+
+const controllersToTest = [WindowController, SWController];
 
 describe('Firebase Messaging > *ControllerInterface', function() {
   const sandbox = sinon.sandbox.create();
@@ -91,17 +97,65 @@ describe('Firebase Messaging > *ControllerInterface', function() {
     });
   });
 
-  describe('getPushSubscription_()', function() {
-    it(`should throw`, function() {
-      const controller = new ControllerInterface(app);
-      let thrownError;
-      try {
-        controller.getPushSubscription_(null, null);
-      } catch (err) {
-        thrownError = err;
-      }
-      expect(thrownError).to.exist;
-      expect(thrownError.code).to.equal('messaging/only-available-in-window');
+  describe('getPushSubscription()', function() {
+    controllersToTest.forEach(ControllerInTest => {
+      it(`should return rejection error in ${ControllerInTest.name}`, function() {
+        const injectedError = new Error('Inject error.');
+        const reg = makeFakeSWReg();
+        sandbox.stub(reg, 'pushManager').value({
+          getSubscription: () => Promise.reject(injectedError)
+        });
+
+        const controller = new ControllerInTest(app);
+        return controller
+          .getPushSubscription(reg, FCMDetails.DEFAULT_PUBLIC_VAPID_KEY)
+          .then(
+            () => {
+              throw new Error('Expected an error.');
+            },
+            err => {
+              expect(err).to.equal(injectedError);
+            }
+          );
+      });
+
+      it(`should return PushSubscription if returned`, function() {
+        const exampleSubscription = {};
+        const reg = makeFakeSWReg();
+        sandbox.stub(reg, 'pushManager').value({
+          getSubscription: () => Promise.resolve(exampleSubscription)
+        });
+
+        const controller = new ControllerInTest(app);
+        return controller
+          .getPushSubscription(reg, FCMDetails.DEFAULT_PUBLIC_VAPID_KEY)
+          .then(subscription => {
+            expect(subscription).to.equal(exampleSubscription);
+          });
+      });
+
+      it('should call subscribe() if no subscription', function() {
+        const exampleSubscription = {};
+        const reg = makeFakeSWReg();
+        sandbox.stub(reg, 'pushManager').value({
+          getSubscription: async () => {},
+          subscribe: options => {
+            expect(options).to.deep.equal({
+              userVisibleOnly: true,
+              applicationServerKey: FCMDetails.DEFAULT_PUBLIC_VAPID_KEY
+            });
+
+            return Promise.resolve(exampleSubscription);
+          }
+        });
+
+        const controller = new ControllerInTest(app);
+        return controller
+          .getPushSubscription(reg, FCMDetails.DEFAULT_PUBLIC_VAPID_KEY)
+          .then(subscription => {
+            expect(subscription).to.equal(exampleSubscription);
+          });
+      });
     });
   });
 

--- a/packages/messaging/test/controller-interface.test.ts
+++ b/packages/messaging/test/controller-interface.test.ts
@@ -99,7 +99,9 @@ describe('Firebase Messaging > *ControllerInterface', function() {
 
   describe('getPushSubscription()', function() {
     controllersToTest.forEach(ControllerInTest => {
-      it(`should return rejection error in ${ControllerInTest.name}`, function() {
+      it(`should return rejection error in ${
+        ControllerInTest.name
+      }`, function() {
         const injectedError = new Error('Inject error.');
         const reg = makeFakeSWReg();
         sandbox.stub(reg, 'pushManager').value({

--- a/packages/messaging/test/window-controller.test.ts
+++ b/packages/messaging/test/window-controller.test.ts
@@ -346,66 +346,6 @@ describe('Firebase Messaging > *WindowController', function() {
     });
   });
 
-  describe('getPushSubscription_()', function() {
-    it(`should return rejection error`, function() {
-      const injectedError = new Error('Inject error.');
-      const reg = makeFakeSWReg();
-      sandbox.stub(reg, 'pushManager').value({
-        getSubscription: () => Promise.reject(injectedError)
-      });
-
-      const controller = new WindowController(app);
-      return controller
-        .getPushSubscription_(reg, FCMDetails.DEFAULT_PUBLIC_VAPID_KEY)
-        .then(
-          () => {
-            throw new Error('Expected an error.');
-          },
-          err => {
-            expect(err).to.equal(injectedError);
-          }
-        );
-    });
-
-    it(`should return PushSubscription if returned`, function() {
-      const exampleSubscription = {};
-      const reg = makeFakeSWReg();
-      sandbox.stub(reg, 'pushManager').value({
-        getSubscription: () => Promise.resolve(exampleSubscription)
-      });
-
-      const controller = new WindowController(app);
-      return controller
-        .getPushSubscription_(reg, FCMDetails.DEFAULT_PUBLIC_VAPID_KEY)
-        .then(subscription => {
-          expect(subscription).to.equal(exampleSubscription);
-        });
-    });
-
-    it('should call subscribe() if no subscription', function() {
-      const exampleSubscription = {};
-      const reg = makeFakeSWReg();
-      sandbox.stub(reg, 'pushManager').value({
-        getSubscription: async () => {},
-        subscribe: options => {
-          expect(options).to.deep.equal({
-            userVisibleOnly: true,
-            applicationServerKey: FCMDetails.DEFAULT_PUBLIC_VAPID_KEY
-          });
-
-          return Promise.resolve(exampleSubscription);
-        }
-      });
-
-      const controller = new WindowController(app);
-      return controller
-        .getPushSubscription_(reg, FCMDetails.DEFAULT_PUBLIC_VAPID_KEY)
-        .then(subscription => {
-          expect(subscription).to.equal(exampleSubscription);
-        });
-    });
-  });
-
   describe('setupSWMessageListener_()', function() {
     it('should not do anything is no service worker support', function() {
       sandbox.stub(window, 'navigator').value({});


### PR DESCRIPTION
Both SWController and WindowController need to implement getPushSubscription method to use in the getToken flow. For SwController, the parameters of the method is a bit redundant: we pass a swRegistration in the method, even though SWController has internal access to it.