### PR TITLE
Persisting mutation batch state in LocalStorage

### DIFF
--- a/packages/firestore/src/local/shared_client_delegate.ts
+++ b/packages/firestore/src/local/shared_client_delegate.ts
@@ -1,0 +1,41 @@
+/**
+ * Copyright 2018 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { BatchId } from '../core/types';
+import { FirestoreError } from '../util/error';
+
+/**
+ * Callback methods invoked by SharedClientState for notifications received
+ * from Local Storage.
+ */
+export interface SharedClientDelegate {
+  /**
+   * Loads a pending batch from the persistence layer and updates all views.
+   */
+  loadPendingBatch(batchId: BatchId): Promise<void>;
+
+  /**
+   * Applies the result of a successful write of a mutation batch, updating all
+   * views and notifying all subscribers.
+   */
+  applySuccessfulWrite(batchId: BatchId): Promise<void>;
+
+  /**
+   * Rejects a failed mutation batch, updating all views and notifying all
+   * subscribers.
+   */
+  rejectFailedWrite(batchId: BatchId, err: FirestoreError): Promise<void>;
+}

--- a/packages/firestore/src/local/shared_client_state.ts
+++ b/packages/firestore/src/local/shared_client_state.ts
@@ -23,7 +23,7 @@ import { SortedSet } from '../util/sorted_set';
 import { isSafeInteger } from '../util/types';
 import * as objUtils from '../util/obj';
 import { User } from '../auth/user';
-import { SharedClientDelegate } from './shared_client_delegate';
+import { SharedClientStateSyncer } from './shared_client_state_syncer';
 
 const LOG_TAG = 'SharedClientState';
 
@@ -34,7 +34,8 @@ const LOG_TAG = 'SharedClientState';
 const CLIENT_STATE_KEY_PREFIX = 'fs_clients';
 
 // The format of the LocalStorage key that stores the mutation state is:
-//     fs_mutations_<persistence_prefix>_<instance_key>
+//     fs_mutations_<persistence_prefix>_<batch_id> (for unauthenticated users)
+// or: fs_mutations_<persistence_prefix>_<batch_id>_<user_uid>
 const MUTATION_BATCH_KEY_PREFIX = 'fs_mutations';
 
 /**
@@ -108,79 +109,79 @@ export type MutationBatchState = 'pending' | 'acknowledged' | 'rejected';
  * LocalStorage serialization. The UserId and BatchId is omitted as it is
  * encoded as part of the key.
  */
-interface MutationBatchSchema {
-  lastUpdateTime: number;
+interface MutationMetadataSchema {
   state: MutationBatchState;
-  error?: { code: string; message: string };
+  error?: { code: string; message: string }; // Only set when state === 'rejected'
 }
 
+/**
+ * Holds the state of a mutation batch, including its user ID, batch ID annd
+ * whether the batch is 'pending', 'acknowledged' or 'rejected'.
+ */
 // Visible for testing
-export class RemoteMutationBatch {
-  private lastUpdateTime: Date;
-
+export class MutationMetadata {
   constructor(
     readonly user: User,
     readonly batchId: BatchId,
     readonly state: MutationBatchState,
     readonly error?: FirestoreError
   ) {
-    this.lastUpdateTime = new Date();
+    assert(
+      (error !== undefined) === (state === 'rejected'),
+      `MutationMetadata must contain an error iff state is 'rejected'`
+    );
   }
 
   /**
-   * Parses a RemoteMutationBatch from its JSON representation in LocalStorage.
+   * Parses a MutationMetadata from its JSON representation in LocalStorage.
    * Logs a warning and returns null if the format of the data is not valid.
    */
   static fromLocalStorageEntry(
     user: User,
     batchId: BatchId,
-    value: string | null
-  ): RemoteMutationBatch | null {
-    if (value !== null) {
-      const mutationBatch = JSON.parse(value) as MutationBatchSchema;
+    value: string
+  ): MutationMetadata | null {
+    const mutationBatch = JSON.parse(value) as MutationMetadataSchema;
 
-      let validData =
-        typeof mutationBatch === 'object' &&
-        ['pending', 'acknowledged', 'rejected'].indexOf(mutationBatch.state) !==
-          -1 &&
-        (mutationBatch.error === undefined ||
-          typeof mutationBatch.error === 'object');
+    let validData =
+      typeof mutationBatch === 'object' &&
+      ['pending', 'acknowledged', 'rejected'].indexOf(mutationBatch.state) !==
+        -1 &&
+      (mutationBatch.error === undefined ||
+        typeof mutationBatch.error === 'object');
 
-      let firestoreError = undefined;
+    let firestoreError = undefined;
 
-      if (validData && mutationBatch.error) {
-        validData =
-          typeof mutationBatch.error.message === 'string' &&
-          typeof mutationBatch.error.code === 'string';
-        if (validData) {
-          firestoreError = new FirestoreError(
-            mutationBatch.error.code as Code,
-            mutationBatch.error.message
-          );
-        }
-      }
-
+    if (validData && mutationBatch.error) {
+      validData =
+        typeof mutationBatch.error.message === 'string' &&
+        typeof mutationBatch.error.code === 'string';
       if (validData) {
-        return new RemoteMutationBatch(
-          user,
-          batchId,
-          mutationBatch.state,
-          firestoreError
+        firestoreError = new FirestoreError(
+          mutationBatch.error.code as Code,
+          mutationBatch.error.message
         );
-      } else {
-        error(
-          LOG_TAG,
-          `Failed to parse mutation state for ID '${batchId}': ${value}`
-        );
-        return null;
       }
     }
-    return null;
+
+    if (validData) {
+      return new MutationMetadata(
+        user,
+        batchId,
+        mutationBatch.state,
+        firestoreError
+      );
+    } else {
+      error(
+        LOG_TAG,
+        `Failed to parse mutation state for ID '${batchId}': ${value}`
+      );
+      return null;
+    }
   }
 
   toLocalStorageJSON(): string {
-    const batchState: MutationBatchSchema = {
-      lastUpdateTime: this.lastUpdateTime.getTime(),
+    const batchState: MutationMetadataSchema = {
       state: this.state
     };
 
@@ -237,49 +238,43 @@ class RemoteClientState implements ClientState {
    */
   static fromLocalStorageEntry(
     clientKey: string,
-    value: string | null
+    value: string
   ): RemoteClientState | null {
-    if (value !== null) {
-      const clientState = JSON.parse(value) as ClientStateSchema;
+    const clientState = JSON.parse(value) as ClientStateSchema;
 
-      let validData =
-        typeof clientState === 'object' &&
-        isSafeInteger(clientState.lastUpdateTime) &&
-        clientState.activeTargetIds instanceof Array &&
-        (clientState.minMutationBatchId === null ||
-          isSafeInteger(clientState.minMutationBatchId)) &&
-        (clientState.maxMutationBatchId === null ||
-          isSafeInteger(clientState.maxMutationBatchId));
+    let validData =
+      typeof clientState === 'object' &&
+      isSafeInteger(clientState.lastUpdateTime) &&
+      clientState.activeTargetIds instanceof Array &&
+      (clientState.minMutationBatchId === null ||
+        isSafeInteger(clientState.minMutationBatchId)) &&
+      (clientState.maxMutationBatchId === null ||
+        isSafeInteger(clientState.maxMutationBatchId));
 
-      let activeTargetIdsSet = new SortedSet<TargetId>(primitiveComparator);
+    let activeTargetIdsSet = new SortedSet<TargetId>(primitiveComparator);
 
-      for (
-        let i = 0;
-        validData && i < clientState.activeTargetIds.length;
-        ++i
-      ) {
-        validData = isSafeInteger(clientState.activeTargetIds[i]);
-        activeTargetIdsSet = activeTargetIdsSet.add(
-          clientState.activeTargetIds[i]
-        );
-      }
-
-      if (validData) {
-        return new RemoteClientState(
-          clientKey,
-          new Date(clientState.lastUpdateTime),
-          activeTargetIdsSet,
-          clientState.minMutationBatchId,
-          clientState.maxMutationBatchId
-        );
-      } else {
-        error(
-          LOG_TAG,
-          `Failed to parse client data for instance '${clientKey}': ${value}`
-        );
-      }
+    for (let i = 0; validData && i < clientState.activeTargetIds.length; ++i) {
+      validData = isSafeInteger(clientState.activeTargetIds[i]);
+      activeTargetIdsSet = activeTargetIdsSet.add(
+        clientState.activeTargetIds[i]
+      );
     }
-    return null;
+
+    if (validData) {
+      return new RemoteClientState(
+        clientKey,
+        new Date(clientState.lastUpdateTime),
+        activeTargetIdsSet,
+        clientState.minMutationBatchId,
+        clientState.maxMutationBatchId
+      );
+    } else {
+      error(
+        LOG_TAG,
+        `Failed to parse client data for instance '${clientKey}': ${value}`
+      );
+      return null;
+    }
   }
 }
 
@@ -369,6 +364,7 @@ export class LocalClientState implements ClientState {
  * backing store for the SharedClientState. It keeps track of all active
  * clients and supports modifications of the current client's data.
  */
+// TODO(multitab): Rename all usages of LocalStorage to WebStorage to better differentiate from LocalClient.
 export class WebStorageSharedClientState implements SharedClientState {
   private readonly storage: Storage;
   private readonly localClientStorageKey: string;
@@ -376,7 +372,7 @@ export class WebStorageSharedClientState implements SharedClientState {
   private readonly storageListener = this.handleLocalStorageEvent.bind(this);
   private readonly clientStateKeyRe: RegExp;
   private readonly mutationBatchKeyRe: RegExp;
-  private sharedClientDelegate: SharedClientDelegate | null;
+  private syncEngine: SharedClientStateSyncer | null;
   private user: User;
   private started = false;
 
@@ -399,7 +395,7 @@ export class WebStorageSharedClientState implements SharedClientState {
       `^${CLIENT_STATE_KEY_PREFIX}_${persistenceKey}_([^_]*)$`
     );
     this.mutationBatchKeyRe = new RegExp(
-      `^${MUTATION_BATCH_KEY_PREFIX}_${persistenceKey}_([^_]*)_(\\d*)$`
+      `^${MUTATION_BATCH_KEY_PREFIX}_${persistenceKey}_(\\d*)(?:_(.*))$`
     );
   }
 
@@ -408,37 +404,42 @@ export class WebStorageSharedClientState implements SharedClientState {
     return typeof window !== 'undefined' && window.localStorage != null;
   }
 
-  subscribe(sharedClientDelegate: SharedClientDelegate) {
-    this.sharedClientDelegate = sharedClientDelegate;
+  subscribe(syncEngine: SharedClientStateSyncer) {
+    this.syncEngine = syncEngine;
   }
 
+  // TODO(multitab): Handle user changes.
   start(initialUser: User, knownClients: ClientKey[]): void {
     assert(!this.started, 'WebStorageSharedClientState already started');
     assert(
-      this.sharedClientDelegate !== null,
+      this.syncEngine !== null,
       'Start() called before subscribing to events'
     );
     window.addEventListener('storage', this.storageListener);
 
     for (const clientKey of knownClients) {
-      const storageKey = this.toLocalStorageClientStateKey(clientKey);
-      const clientState = RemoteClientState.fromLocalStorageEntry(
-        clientKey,
-        this.storage.getItem(storageKey)
+      const storageItem = this.storage.getItem(
+        this.toLocalStorageClientStateKey(clientKey)
       );
-      if (clientState) {
-        this.activeClients[clientState.clientId] = clientState;
+      if (storageItem) {
+        const clientState = RemoteClientState.fromLocalStorageEntry(
+          clientKey,
+          storageItem
+        );
+        if (clientState) {
+          this.activeClients[clientState.clientId] = clientState;
+        }
       }
     }
 
-    this.activeClients[this.localClientKey] = new LocalClientState();
     this.user = initialUser;
     this.started = true;
     this.persistClientState();
   }
 
+  // TODO(multitab): Return BATCHID_UNKNOWN instead of null
   getMinimumGlobalPendingMutation(): BatchId | null {
-    let minMutationBatch = null;
+    let minMutationBatch: number | null = null;
     objUtils.forEach(this.activeClients, (key, value) => {
       minMutationBatch = min(minMutationBatch, value.minMutationBatchId);
     });
@@ -497,26 +498,27 @@ export class WebStorageSharedClientState implements SharedClientState {
       );
 
       if (event.newValue == null) {
-        const clientId = this.fromLocalStorageClientStateKey(event.key);
-        if (clientId != null) {
+        if (this.clientStateKeyRe.test(event.key)) {
+          const clientId = this.fromLocalStorageClientStateKey(event.key);
           delete this.activeClients[clientId];
         }
       } else {
-        const clientState = this.fromLocalStorageClientState(
-          event.key,
-          event.newValue
-        );
-        if (clientState) {
-          this.activeClients[clientState.clientId] = clientState;
-          return;
-        }
-        const mutationBatch = this.fromLocalStorageMutation(
-          event.key,
-          event.newValue
-        );
-        if (mutationBatch) {
-          this.handleMutationBatchEvent(mutationBatch);
-          return;
+        if (this.clientStateKeyRe.test(event.key)) {
+          const clientState = this.fromLocalStorageClientState(
+            event.key,
+            event.newValue
+          );
+          if (clientState) {
+            this.activeClients[clientState.clientId] = clientState;
+          }
+        } else if (this.mutationBatchKeyRe.test(event.key)) {
+          const mutationMetadata = this.fromLocalStorageMutationMetadata(
+            event.key,
+            event.newValue
+          );
+          if (mutationMetadata) {
+            this.handleMutationBatchEvent(mutationMetadata);
+          }
         }
       }
     }
@@ -543,16 +545,20 @@ export class WebStorageSharedClientState implements SharedClientState {
     state: MutationBatchState,
     error?: FirestoreError
   ) {
-    const mutationState = new RemoteMutationBatch(
+    const mutationState = new MutationMetadata(
       this.user,
       batchId,
       state,
       error
     );
 
-    const mutationKey = `${MUTATION_BATCH_KEY_PREFIX}_${this.persistenceKey}_${
-      this.user.uid
+    let mutationKey = `${MUTATION_BATCH_KEY_PREFIX}_${
+      this.persistenceKey
     }_${batchId}`;
+
+    if (this.user.isAuthenticated()) {
+      mutationKey += `_${this.user.uid}`;
+    }
 
     this.storage.setItem(mutationKey, mutationState.toLocalStorageJSON());
   }
@@ -577,50 +583,40 @@ export class WebStorageSharedClientState implements SharedClientState {
   }
 
   /**
-   * Parses a client state in LocalStorage. Returns null if the key does not
-   * match the expected key format.
+   * Parses a client state in LocalStorage. Returns 'null' if the value could
+   * not be parsed.
    */
   private fromLocalStorageClientState(
     key: string,
     value: string
   ): RemoteClientState | null {
     const clientId = this.fromLocalStorageClientStateKey(key);
-    return clientId != null
-      ? RemoteClientState.fromLocalStorageEntry(clientId, value)
-      : null;
+    assert(clientId !== null, `Cannot parse client state key '${key}'`);
+    return RemoteClientState.fromLocalStorageEntry(clientId, value);
   }
 
   /**
-   * Parses a mutation batch state in LocalStorage. Returns null if the key does
-   * not match the expected key format.
+   * Parses a mutation batch state in LocalStorage. Returns 'null' if the value
+   * could not be parsed.
    */
-  private fromLocalStorageMutation(
+  private fromLocalStorageMutationMetadata(
     key: string,
-    value: string | null
-  ): RemoteMutationBatch | null {
+    value: string
+  ): MutationMetadata | null {
     const match = this.mutationBatchKeyRe.exec(key);
+    assert(match !== null, `Cannot parse mutation batch key '${key}'`);
 
-    if (match) {
-      const isCurrentUser =
-        match[1] === 'null'
-          ? this.user.uid === null
-          : match[1] === this.user.uid;
-
-      if (isCurrentUser) {
-        const batchId = Number(match[2]);
-        return RemoteMutationBatch.fromLocalStorageEntry(
-          this.user,
-          batchId,
-          value
-        );
-      }
-    }
-
-    return null;
+    const batchId = Number(match[1]);
+    const userId = match[2] !== undefined ? match[2] : null;
+    return MutationMetadata.fromLocalStorageEntry(
+      new User(userId),
+      batchId,
+      value
+    );
   }
 
   private async handleMutationBatchEvent(
-    mutationBatch: RemoteMutationBatch
+    mutationBatch: MutationMetadata
   ): Promise<void> {
     if (mutationBatch.user.uid !== this.user.uid) {
       debug(
@@ -632,15 +628,11 @@ export class WebStorageSharedClientState implements SharedClientState {
 
     switch (mutationBatch.state) {
       case 'pending':
-        return this.sharedClientDelegate.loadPendingBatch(
-          mutationBatch.batchId
-        );
+        return this.syncEngine.applyPendingBatch(mutationBatch.batchId);
       case 'acknowledged':
-        return this.sharedClientDelegate.applySuccessfulWrite(
-          mutationBatch.batchId
-        );
+        return this.syncEngine.applySuccessfulWrite(mutationBatch.batchId);
       case 'rejected':
-        return this.sharedClientDelegate.rejectFailedWrite(
+        return this.syncEngine.rejectFailedWrite(
           mutationBatch.batchId,
           mutationBatch.error
         );

--- a/packages/firestore/src/local/shared_client_state_syncer.ts
+++ b/packages/firestore/src/local/shared_client_state_syncer.ts
@@ -18,7 +18,7 @@ import { BatchId } from '../core/types';
 import { FirestoreError } from '../util/error';
 
 /**
- * A interface that describes the actions the SharedClientState class needs to
+ * An interface that describes the actions the SharedClientState class needs to
  * perform on a cooperating synchronization engine.
  */
 export interface SharedClientStateSyncer {

--- a/packages/firestore/src/local/shared_client_state_syncer.ts
+++ b/packages/firestore/src/local/shared_client_state_syncer.ts
@@ -18,24 +18,22 @@ import { BatchId } from '../core/types';
 import { FirestoreError } from '../util/error';
 
 /**
- * Callback methods invoked by SharedClientState for notifications received
- * from Local Storage.
+ * A interface that describes the actions the SharedClientState class needs to
+ * perform on a cooperating synchronization engine.
  */
-export interface SharedClientDelegate {
+export interface SharedClientStateSyncer {
   /**
-   * Loads a pending batch from the persistence layer and updates all views.
+   * Registers a new pending mutation batch.
    */
-  loadPendingBatch(batchId: BatchId): Promise<void>;
+  applyPendingBatch(batchId: BatchId): Promise<void>;
 
   /**
-   * Applies the result of a successful write of a mutation batch, updating all
-   * views and notifying all subscribers.
+   * Applies the result of a successful write of a mutation batch.
    */
   applySuccessfulWrite(batchId: BatchId): Promise<void>;
 
   /**
-   * Rejects a failed mutation batch, updating all views and notifying all
-   * subscribers.
+   * Rejects a failed mutation batch.
    */
   rejectFailedWrite(batchId: BatchId, err: FirestoreError): Promise<void>;
 }

--- a/packages/firestore/src/remote/remote_syncer.ts
+++ b/packages/firestore/src/remote/remote_syncer.ts
@@ -21,7 +21,7 @@ import { FirestoreError } from '../util/error';
 import { RemoteEvent } from './remote_event';
 
 /**
- * A interface that describes the actions the RemoteStore needs to perform on
+ * An interface that describes the actions the RemoteStore needs to perform on
  * a cooperating synchronization engine.
  */
 export interface RemoteSyncer {

--- a/packages/firestore/src/util/misc.ts
+++ b/packages/firestore/src/util/misc.ts
@@ -52,6 +52,22 @@ export function primitiveComparator<T>(left: T, right: T): number {
   return 0;
 }
 
+/** Implementation of min() that ignores null values. */
+export function min(...values: Array<number | null>): number | null {
+  let min = null;
+
+  for (const value of values) {
+    if (value !== null) {
+      if (min == null) {
+        min = value;
+      } else if (value < min) {
+        min = value;
+      }
+    }
+  }
+
+  return min;
+}
 /** Duck-typed interface for objects that have an isEqual() method. */
 export interface Equatable<T> {
   isEqual(other: T): boolean;

--- a/packages/firestore/test/unit/local/persistence_test_helpers.ts
+++ b/packages/firestore/test/unit/local/persistence_test_helpers.ts
@@ -118,7 +118,7 @@ export async function testWebStorageSharedClientState(
 
     knownInstances.push(SECONDARY_INSTANCE_KEY);
 
-    secondaryClientState.subscribe(new NoOpSharedClientStateSyncer());
+    secondaryClientState.syncEngine = new NoOpSharedClientStateSyncer();
     await secondaryClientState.start(user, [SECONDARY_INSTANCE_KEY]);
 
     for (const batchId of existingMutationBatchIds) {
@@ -136,7 +136,7 @@ export async function testWebStorageSharedClientState(
     TEST_PERSISTENCE_PREFIX,
     instanceKey
   );
-  sharedClientState.subscribe(sharedClientSyncer);
+  sharedClientState.syncEngine = sharedClientSyncer;
   await sharedClientState.start(user, knownInstances);
   return sharedClientState;
 }

--- a/packages/firestore/test/unit/local/persistence_test_helpers.ts
+++ b/packages/firestore/test/unit/local/persistence_test_helpers.ts
@@ -89,7 +89,7 @@ class NoOpSharedClientStateSyncer implements SharedClientStateSyncer {
 export async function testWebStorageSharedClientState(
   user: User,
   instanceKey: string,
-  sharedClientDelegate?: SharedClientStateSyncer,
+  sharedClientSyncer?: SharedClientStateSyncer,
   existingMutationBatchIds?: BatchId[],
   existingQueryTargetIds?: TargetId[]
 ): Promise<SharedClientState> {
@@ -130,14 +130,14 @@ export async function testWebStorageSharedClientState(
     }
   }
 
-  sharedClientDelegate =
-    sharedClientDelegate || new NoOpSharedClientStateSyncer();
+  sharedClientSyncer =
+    sharedClientSyncer || new NoOpSharedClientStateSyncer();
 
   const sharedClientState = new WebStorageSharedClientState(
     TEST_PERSISTENCE_PREFIX,
     instanceKey
   );
-  sharedClientState.subscribe(sharedClientDelegate);
+  sharedClientState.subscribe(sharedClientSyncer);
   await sharedClientState.start(user, knownInstances);
   return sharedClientState;
 }

--- a/packages/firestore/test/unit/local/persistence_test_helpers.ts
+++ b/packages/firestore/test/unit/local/persistence_test_helpers.ts
@@ -130,8 +130,7 @@ export async function testWebStorageSharedClientState(
     }
   }
 
-  sharedClientSyncer =
-    sharedClientSyncer || new NoOpSharedClientStateSyncer();
+  sharedClientSyncer = sharedClientSyncer || new NoOpSharedClientStateSyncer();
 
   const sharedClientState = new WebStorageSharedClientState(
     TEST_PERSISTENCE_PREFIX,

--- a/packages/firestore/test/unit/local/web_storage_shared_client_state.test.ts
+++ b/packages/firestore/test/unit/local/web_storage_shared_client_state.test.ts
@@ -46,7 +46,7 @@ function mutationKey(batchId: BatchId) {
 /**
  * Implementation of `SharedClientStateSyncer` that aggregates its callback data.
  */
-class TestClientDelegate implements SharedClientStateSyncer {
+class TestClientSyncer implements SharedClientStateSyncer {
   readonly pendingBatches: BatchId[] = [];
   readonly acknowledgedBatches: BatchId[] = [];
   readonly rejectedBatches: { [batchId: number]: FirestoreError } = {};
@@ -333,13 +333,13 @@ describe('WebStorageSharedClientState', () => {
   });
 
   describe('processes mutation updates', () => {
-    let clientDelegate;
+    let clientSyncer;
 
     beforeEach(() => {
-      clientDelegate = new TestClientDelegate();
+      clientSyncer = new TestClientSyncer();
 
       return persistenceHelpers
-        .testWebStorageSharedClientState(TEST_USER, ownerId, clientDelegate)
+        .testWebStorageSharedClientState(TEST_USER, ownerId, clientSyncer)
         .then(clientState => {
           sharedClientState = clientState;
           expect(writeToLocalStorage).to.exist;
@@ -356,9 +356,9 @@ describe('WebStorageSharedClientState', () => {
         new MutationMetadata(TEST_USER, 1, 'pending').toLocalStorageJSON()
       );
 
-      expect(clientDelegate.pendingBatches).to.have.members([1]);
-      expect(clientDelegate.acknowledgedBatches).to.be.empty;
-      expect(clientDelegate.rejectedBatches).to.be.empty;
+      expect(clientSyncer.pendingBatches).to.have.members([1]);
+      expect(clientSyncer.acknowledgedBatches).to.be.empty;
+      expect(clientSyncer.rejectedBatches).to.be.empty;
     });
 
     it('for acknowledged mutation', () => {
@@ -367,9 +367,9 @@ describe('WebStorageSharedClientState', () => {
         new MutationMetadata(TEST_USER, 1, 'acknowledged').toLocalStorageJSON()
       );
 
-      expect(clientDelegate.pendingBatches).to.be.empty;
-      expect(clientDelegate.acknowledgedBatches).to.have.members([1]);
-      expect(clientDelegate.rejectedBatches).to.be.empty;
+      expect(clientSyncer.pendingBatches).to.be.empty;
+      expect(clientSyncer.acknowledgedBatches).to.have.members([1]);
+      expect(clientSyncer.rejectedBatches).to.be.empty;
     });
 
     it('for rejected mutation', () => {
@@ -383,10 +383,10 @@ describe('WebStorageSharedClientState', () => {
         ).toLocalStorageJSON()
       );
 
-      expect(clientDelegate.pendingBatches).to.be.empty;
-      expect(clientDelegate.acknowledgedBatches).to.be.empty;
-      expect(clientDelegate.rejectedBatches[1].code).to.equal('internal');
-      expect(clientDelegate.rejectedBatches[1].message).to.equal('Test Error');
+      expect(clientSyncer.pendingBatches).to.be.empty;
+      expect(clientSyncer.acknowledgedBatches).to.be.empty;
+      expect(clientSyncer.rejectedBatches[1].code).to.equal('internal');
+      expect(clientSyncer.rejectedBatches[1].message).to.equal('Test Error');
     });
 
     it('ignores invalid data', () => {
@@ -399,9 +399,9 @@ describe('WebStorageSharedClientState', () => {
         ).toLocalStorageJSON()
       );
 
-      expect(clientDelegate.pendingBatches).to.be.empty;
-      expect(clientDelegate.acknowledgedBatches).to.be.empty;
-      expect(clientDelegate.rejectedBatches).to.be.empty;
+      expect(clientSyncer.pendingBatches).to.be.empty;
+      expect(clientSyncer.acknowledgedBatches).to.be.empty;
+      expect(clientSyncer.rejectedBatches).to.be.empty;
     });
   });
 });


### PR DESCRIPTION
This PR allows pending mutation batches to be persisted in LocalStorage. In order to keep things focussed, this only adds the serialization and deserialization in SharedClientState. The next PR will add the calls from LocalStorage that invoke SharedClientState, and in a further follow up I will add the wiring between SyncEngine and SharedClientState.

This PR also paves the way for SyncEngine to gain two pieces of functionality:
- Apply pending batches by Batch ID to all Local Views 
- Apply successful mutations by Batch ID

Note: The changes in `fromLocalStorageEntry` are formatting only  as I wrapped the logic in a `if (value !== null)` block.
