### PR TITLE
 Adding getActiveClients()

### DIFF
--- a/packages/firestore/src/local/indexeddb_persistence.ts
+++ b/packages/firestore/src/local/indexeddb_persistence.ts
@@ -308,6 +308,19 @@ export class IndexedDbPersistence implements Persistence {
     });
   }
 
+  getActiveClients(): Promise<ClientKey[]> {
+    const clientKeys: ClientKey[] = [];
+    return this.simpleDb
+      .runTransaction('readonly', [DbClientMetadata.store], txn => {
+        return clientMetadataStore(txn).iterate((key, value) => {
+          if (this.isWithinMaxAge(value.updateTimeMs)) {
+            clientKeys.push(value.clientKey);
+          }
+        });
+      })
+      .then(() => clientKeys);
+  }
+
   getMutationQueue(user: User): MutationQueue {
     return IndexedDbMutationQueue.forUser(user, this.serializer);
   }

--- a/packages/firestore/src/local/memory_persistence.ts
+++ b/packages/firestore/src/local/memory_persistence.ts
@@ -30,7 +30,9 @@ import {
 import { PersistencePromise } from './persistence_promise';
 import { QueryCache } from './query_cache';
 import { RemoteDocumentCache } from './remote_document_cache';
+import { ClientKey } from './shared_client_state';
 import { AsyncQueue } from '../util/async_queue';
+import { AutoId } from '../util/misc';
 
 const LOG_TAG = 'MemoryPersistence';
 
@@ -49,6 +51,7 @@ export class MemoryPersistence implements Persistence {
   private mutationQueues: { [user: string]: MutationQueue } = {};
   private remoteDocumentCache = new MemoryRemoteDocumentCache();
   private queryCache = new MemoryQueryCache();
+  private readonly clientId: ClientKey = AutoId.newId();
 
   private started = false;
 
@@ -64,6 +67,10 @@ export class MemoryPersistence implements Persistence {
     // No durable state to ensure is closed on shutdown.
     assert(this.started, 'MemoryPersistence shutdown without start!');
     this.started = false;
+  }
+
+  async getActiveClients(): Promise<ClientKey[]> {
+    return [this.clientId];
   }
 
   setPrimaryStateListener(primaryStateListener: PrimaryStateListener) {

--- a/packages/firestore/src/local/persistence.ts
+++ b/packages/firestore/src/local/persistence.ts
@@ -21,6 +21,7 @@ import { PersistenceTransaction } from './persistence';
 import { PersistencePromise } from './persistence_promise';
 import { QueryCache } from './query_cache';
 import { RemoteDocumentCache } from './remote_document_cache';
+import { ClientKey } from './shared_client_state';
 
 /**
  * Opaque interface representing a persistence transaction.
@@ -94,8 +95,19 @@ export interface Persistence {
    * Registers a listener that gets called when the primary state of the
    * instance changes. Upon registering, this listener is invoked immediately
    * with the current primary state.
+   *
+   * PORTING NOTE: This is only used for Web multi-tab.
    */
   setPrimaryStateListener(primaryStateListener: PrimaryStateListener);
+
+  /**
+   * Returns the IDs of the clients that are currently active. If multi-tab
+   * is not supported, returns an array that only contains the local client's
+   * ID.
+   *
+   * PORTING NOTE: This is only used for Web multi-tab.
+   */
+  getActiveClients(): Promise<ClientKey[]>;
 
   /**
    * Returns a MutationQueue representing the persisted mutations for the

--- a/packages/firestore/test/unit/specs/persistence_spec.test.ts
+++ b/packages/firestore/test/unit/specs/persistence_spec.test.ts
@@ -198,55 +198,47 @@ describeSpec('Persistence:', [], () => {
     );
   });
 
-  specTest(
-    'Single tab acquires primary lease',
-    ['multi-client'],
-    () => {
-      // This test simulates primary state handoff between two background tabs.
-      // With all instances in the background, the first active tab acquires
-      // ownership.
-      return client(0)
+  specTest('Single tab acquires primary lease', ['multi-client'], () => {
+    // This test simulates primary state handoff between two background tabs.
+    // With all instances in the background, the first active tab acquires
+    // ownership.
+    return client(0)
+      .becomeHidden()
+      .expectPrimaryState(true)
+      .client(1)
+      .becomeHidden()
+      .expectPrimaryState(false)
+      .client(0)
+      .shutdown()
+      .client(1)
+      .runTimer(TimerId.ClientMetadataRefresh)
+      .expectPrimaryState(true);
+  });
+
+  specTest('Foreground tab acquires primary lease', ['multi-client'], () => {
+    // This test verifies that in a multi-client scenario, a foreground tab
+    // takes precedence when a new primary client is elected.
+    return (
+      client(0)
         .becomeHidden()
         .expectPrimaryState(true)
         .client(1)
         .becomeHidden()
         .expectPrimaryState(false)
+        .client(2)
+        .becomeVisible()
+        .expectPrimaryState(false)
         .client(0)
+        // Shutdown the client that is currently holding the primary lease.
         .shutdown()
         .client(1)
+        // Client 1 is in the background and doesn't grab the primary lease as
+        // client 2 is in the foreground.
         .runTimer(TimerId.ClientMetadataRefresh)
-        .expectPrimaryState(true);
-    }
-  );
-
-  specTest(
-    'Foreground tab acquires primary lease',
-     ['multi-client'],
-    () => {
-      // This test verifies that in a multi-client scenario, a foreground tab
-      // takes precedence when a new primary client is elected.
-      return (
-        client(0)
-          .becomeHidden()
-          .expectPrimaryState(true)
-          .client(1)
-          .becomeHidden()
-          .expectPrimaryState(false)
-          .client(2)
-          .becomeVisible()
-          .expectPrimaryState(false)
-          .client(0)
-          // Shutdown the client that is currently holding the primary lease.
-          .shutdown()
-          .client(1)
-          // Client 1 is in the background and doesn't grab the primary lease as
-          // client 2 is in the foreground.
-          .runTimer(TimerId.ClientMetadataRefresh)
-          .expectPrimaryState(false)
-          .client(2)
-          .runTimer(TimerId.ClientMetadataRefresh)
-          .expectPrimaryState(true)
-      );
-    }
-  );
+        .expectPrimaryState(false)
+        .client(2)
+        .runTimer(TimerId.ClientMetadataRefresh)
+        .expectPrimaryState(true)
+    );
+  });
 });

--- a/packages/firestore/test/unit/specs/spec_builder.ts
+++ b/packages/firestore/test/unit/specs/spec_builder.ts
@@ -621,6 +621,14 @@ export class SpecBuilder {
     return this;
   }
 
+  expectNumActiveClients(num: number): SpecBuilder {
+    this.assertStep('Expectations require previous step');
+    const currentStep = this.currentStep!;
+    currentStep.stateExpect = currentStep.stateExpect || {};
+    currentStep.stateExpect.numActiveClients = num;
+    return this;
+  }
+
   expectPrimaryState(isPrimary: boolean): SpecBuilder {
     this.assertStep('Expectations requires previous step');
     const currentStep = this.currentStep!;
@@ -925,6 +933,11 @@ export class MultiClientSpecBuilder extends SpecBuilder {
 
   expectNumOutstandingWrites(num: number): MultiClientSpecBuilder {
     super.expectNumOutstandingWrites(num);
+    return this;
+  }
+
+  expectNumActiveClients(num: number): MultiClientSpecBuilder {
+    super.expectNumActiveClients(num);
     return this;
   }
 

--- a/packages/firestore/test/unit/specs/spec_test_runner.ts
+++ b/packages/firestore/test/unit/specs/spec_test_runner.ts
@@ -1175,7 +1175,9 @@ export async function runSpec(
     await sequence(steps, async step => {
       ++count;
       lastStep = step;
-      return ensureRunner(step.clientIndex || 0).then(runner => runner.run(step));
+      return ensureRunner(step.clientIndex || 0).then(runner =>
+        runner.run(step)
+      );
     });
   } catch (err) {
     console.warn(


### PR DESCRIPTION
This will be used by SharedClientState to retrieve the list of active clients during its startup. Using this list, the SharedClientState can then read all relevant rows in LocalStorage.