### PR TITLE
Unify pushSubscription/publicVapidKey retrievals

### DIFF
--- a/packages/firebase/index.d.ts
+++ b/packages/firebase/index.d.ts
@@ -154,10 +154,10 @@ declare namespace firebase.auth {
     applyActionCode(code: string): Promise<any>;
     checkActionCode(code: string): Promise<any>;
     confirmPasswordReset(code: string, newPassword: string): Promise<any>;
-    createUserAndRetrieveDataWithEmailAndPassword( 
-      email: string, 
-      password: string 
-    ): Promise<any>;      
+    createUserAndRetrieveDataWithEmailAndPassword(
+      email: string,
+      password: string
+    ): Promise<any>;
     createUserWithEmailAndPassword(
       email: string,
       password: string
@@ -202,7 +202,10 @@ declare namespace firebase.auth {
     signInWithCustomToken(token: string): Promise<any>;
     signInAndRetrieveDataWithCustomToken(token: string): Promise<any>;
     signInWithEmailAndPassword(email: string, password: string): Promise<any>;
-    signInAndRetrieveDataWithEmailAndPassword(email: string, password: string): Promise<any>;
+    signInAndRetrieveDataWithEmailAndPassword(
+      email: string,
+      password: string
+    ): Promise<any>;
     signInWithPhoneNumber(
       phoneNumber: string,
       applicationVerifier: firebase.auth.ApplicationVerifier

--- a/packages/messaging/src/controllers/controller-interface.ts
+++ b/packages/messaging/src/controllers/controller-interface.ts
@@ -64,7 +64,7 @@ export default class ControllerInterface {
   /**
    * @export
    */
-  getToken(): Promise<string | null> {
+  async getToken(): Promise<string | null> {
     // Check with permissions
     const currentPermission = this.getNotificationPermission_();
     if (currentPermission !== NOTIFICATION_PERMISSION.granted) {
@@ -77,18 +77,16 @@ export default class ControllerInterface {
       // We must wait for permission to be granted
       return Promise.resolve(null);
     }
-    let swReg: ServiceWorkerRegistration;
-    return this.getSWRegistration_()
-      .then(reg => {
-        swReg = reg;
-        return this.tokenDetailsModel_.getTokenDetailsFromSWScope(swReg.scope);
-      })
-      .then(tokenDetails => {
-        if (tokenDetails) {
-          return this.manageExistingToken(tokenDetails, swReg);
-        }
-        return this.getNewToken(swReg);
-      });
+
+    const swReg = await this.getSWRegistration_();
+    const publicVapidKey = await this.getPublicVapidKey_();
+    const pushSubscription =  await this.getPushSubscription(swReg, publicVapidKey);
+    const tokenDetails = await this.tokenDetailsModel_.getTokenDetailsFromSWScope(swReg.scope);
+
+    if (tokenDetails) {
+      return this.manageExistingToken(swReg, pushSubscription, publicVapidKey, tokenDetails);
+    }
+    return this.getNewToken(swReg, pushSubscription, publicVapidKey);
   }
 
   /**
@@ -100,26 +98,26 @@ export default class ControllerInterface {
    * 3) If the database cache is invalidated: Send a request to FCM to update
    * the token, and to check if the token is still valid on FCM-side.
    */
-  private manageExistingToken(
+  private async manageExistingToken(
+    swReg: ServiceWorkerRegistration,
+    pushSubscription: PushSubscription,
+    publicVapidKey: Uint8Array,
     tokenDetails: Object,
-    swReg: ServiceWorkerRegistration
   ): Promise<string> {
-    return this.isTokenStillValid(tokenDetails).then(isValid => {
-      if (isValid) {
-        const now = Date.now();
-        if (now < tokenDetails['createTime'] + TOKEN_EXPIRATION_MILLIS) {
-          return tokenDetails['fcmToken'];
-        } else {
-          return this.updateToken(tokenDetails, swReg);
-        }
+    const isTokenValid = await this.isTokenStillValid(tokenDetails);
+    if (isTokenValid) {
+      const now = Date.now();
+      if (now < tokenDetails['createTime'] + TOKEN_EXPIRATION_MILLIS) {
+        return tokenDetails['fcmToken'];
       } else {
-        // If the VAPID details are updated, delete the existing token,
-        // and create a new one.
-        return this.deleteToken(tokenDetails['fcmToken']).then(() => {
-          return this.getNewToken(swReg);
-        });
+        return this.updateToken(swReg, pushSubscription, publicVapidKey, tokenDetails);
       }
-    });
+    }
+
+    // If the VAPID details are updated, delete the existing token,
+    // and create a new one.
+    await this.deleteToken(tokenDetails['fcmToken']);
+    return this.getNewToken(swReg, pushSubscription, publicVapidKey);
   }
 
   /*
@@ -135,94 +133,64 @@ export default class ControllerInterface {
     });
   }
 
-  private updateToken(
+  private async updateToken(
+    swReg: ServiceWorkerRegistration,
+    pushSubscription: PushSubscription,
+    publicVapidKey: Uint8Array,
     tokenDetails: Object,
-    swReg: ServiceWorkerRegistration
   ): Promise<string> {
-    let publicVapidKey: Uint8Array;
-    let updatedToken: string;
-    let subscription: PushSubscription;
-    return this.getPublicVapidKey_()
-      .then(publicKey => {
-        publicVapidKey = publicKey;
-        return this.getPushSubscription_(swReg, publicVapidKey);
-      })
-      .then(pushSubscription => {
-        subscription = pushSubscription;
-        return this.iidModel_.updateToken(
-          this.messagingSenderId_,
-          tokenDetails['fcmToken'],
-          tokenDetails['fcmPushSet'],
-          subscription,
-          publicVapidKey
-        );
-      })
-      .catch(err => {
-        return this.deleteToken(tokenDetails['fcmToken']).then(() => {
-          throw err;
-        });
-      })
-      .then(token => {
-        updatedToken = token;
-        const allDetails = {
-          swScope: swReg.scope,
-          vapidKey: publicVapidKey,
-          subscription: subscription,
-          fcmSenderId: this.messagingSenderId_,
-          fcmToken: updatedToken,
-          fcmPushSet: tokenDetails['fcmPushSet']
-        };
-        return this.tokenDetailsModel_.saveTokenDetails(allDetails);
-      })
-      .then(() => {
-        return this.vapidDetailsModel_.saveVapidDetails(
-          swReg.scope,
-          publicVapidKey
-        );
-      })
-      .then(() => {
-        return updatedToken;
-      });
+    try {
+      const updatedToken = await this.iidModel_.updateToken(
+        this.messagingSenderId_,
+        tokenDetails['fcmToken'],
+        tokenDetails['fcmPushSet'],
+        pushSubscription,
+        publicVapidKey
+      );
+
+      const allDetails = {
+        swScope: swReg.scope,
+        vapidKey: publicVapidKey,
+        subscription: pushSubscription,
+        fcmSenderId: this.messagingSenderId_,
+        fcmToken: updatedToken,
+        fcmPushSet: tokenDetails['fcmPushSet']
+      };
+
+      await this.tokenDetailsModel_.saveTokenDetails(allDetails);
+      await this.vapidDetailsModel_.saveVapidDetails(
+        swReg.scope,
+        publicVapidKey
+      );
+      return updatedToken;
+    } catch (e) {
+      await this.deleteToken(tokenDetails['fcmToken']);
+      throw e;
+    }
   }
 
-  private getNewToken(swReg: ServiceWorkerRegistration): Promise<string> {
-    let publicVapidKey: Uint8Array;
-    let subscription: PushSubscription;
-    let tokenDetails: Object;
-    return this.getPublicVapidKey_()
-      .then(publicKey => {
-        publicVapidKey = publicKey;
-        return this.getPushSubscription_(swReg, publicVapidKey);
-      })
-      .then(pushSubscription => {
-        subscription = pushSubscription;
-        return this.iidModel_.getToken(
-          this.messagingSenderId_,
-          subscription,
-          publicVapidKey
-        );
-      })
-      .then(iidTokenDetails => {
-        tokenDetails = iidTokenDetails;
-        const allDetails = {
-          swScope: swReg.scope,
-          vapidKey: publicVapidKey,
-          subscription: subscription,
-          fcmSenderId: this.messagingSenderId_,
-          fcmToken: tokenDetails['token'],
-          fcmPushSet: tokenDetails['pushSet']
-        };
-        return this.tokenDetailsModel_.saveTokenDetails(allDetails);
-      })
-      .then(() => {
-        return this.vapidDetailsModel_.saveVapidDetails(
-          swReg.scope,
-          publicVapidKey
-        );
-      })
-      .then(() => {
-        return tokenDetails['token'];
-      });
+  private async getNewToken(swReg: ServiceWorkerRegistration,
+    pushSubscription: PushSubscription,
+    publicVapidKey: Uint8Array): Promise<string> {
+    const tokenDetails = await this.iidModel_.getToken(
+      this.messagingSenderId_,
+      pushSubscription,
+      publicVapidKey
+    );
+    const allDetails = {
+      swScope: swReg.scope,
+      vapidKey: publicVapidKey,
+      subscription: pushSubscription,
+      fcmSenderId: this.messagingSenderId_,
+      fcmToken: tokenDetails['token'],
+      fcmPushSet: tokenDetails['pushSet']
+    };
+    await this.tokenDetailsModel_.saveTokenDetails(allDetails);
+    await this.vapidDetailsModel_.saveVapidDetails(
+      swReg.scope,
+      publicVapidKey
+    );
+    return tokenDetails['token'];
   }
 
   /**

--- a/packages/messaging/src/controllers/controller-interface.ts
+++ b/packages/messaging/src/controllers/controller-interface.ts
@@ -80,11 +80,21 @@ export default class ControllerInterface {
 
     const swReg = await this.getSWRegistration_();
     const publicVapidKey = await this.getPublicVapidKey_();
-    const pushSubscription =  await this.getPushSubscription(swReg, publicVapidKey);
-    const tokenDetails = await this.tokenDetailsModel_.getTokenDetailsFromSWScope(swReg.scope);
+    const pushSubscription = await this.getPushSubscription(
+      swReg,
+      publicVapidKey
+    );
+    const tokenDetails = await this.tokenDetailsModel_.getTokenDetailsFromSWScope(
+      swReg.scope
+    );
 
     if (tokenDetails) {
-      return this.manageExistingToken(swReg, pushSubscription, publicVapidKey, tokenDetails);
+      return this.manageExistingToken(
+        swReg,
+        pushSubscription,
+        publicVapidKey,
+        tokenDetails
+      );
     }
     return this.getNewToken(swReg, pushSubscription, publicVapidKey);
   }
@@ -102,7 +112,7 @@ export default class ControllerInterface {
     swReg: ServiceWorkerRegistration,
     pushSubscription: PushSubscription,
     publicVapidKey: Uint8Array,
-    tokenDetails: Object,
+    tokenDetails: Object
   ): Promise<string> {
     const isTokenValid = await this.isTokenStillValid(tokenDetails);
     if (isTokenValid) {
@@ -110,7 +120,12 @@ export default class ControllerInterface {
       if (now < tokenDetails['createTime'] + TOKEN_EXPIRATION_MILLIS) {
         return tokenDetails['fcmToken'];
       } else {
-        return this.updateToken(swReg, pushSubscription, publicVapidKey, tokenDetails);
+        return this.updateToken(
+          swReg,
+          pushSubscription,
+          publicVapidKey,
+          tokenDetails
+        );
       }
     }
 
@@ -137,7 +152,7 @@ export default class ControllerInterface {
     swReg: ServiceWorkerRegistration,
     pushSubscription: PushSubscription,
     publicVapidKey: Uint8Array,
-    tokenDetails: Object,
+    tokenDetails: Object
   ): Promise<string> {
     try {
       const updatedToken = await this.iidModel_.updateToken(
@@ -169,9 +184,11 @@ export default class ControllerInterface {
     }
   }
 
-  private async getNewToken(swReg: ServiceWorkerRegistration,
+  private async getNewToken(
+    swReg: ServiceWorkerRegistration,
     pushSubscription: PushSubscription,
-    publicVapidKey: Uint8Array): Promise<string> {
+    publicVapidKey: Uint8Array
+  ): Promise<string> {
     const tokenDetails = await this.iidModel_.getToken(
       this.messagingSenderId_,
       pushSubscription,
@@ -186,10 +203,7 @@ export default class ControllerInterface {
       fcmPushSet: tokenDetails['pushSet']
     };
     await this.tokenDetailsModel_.saveTokenDetails(allDetails);
-    await this.vapidDetailsModel_.saveVapidDetails(
-      swReg.scope,
-      publicVapidKey
-    );
+    await this.vapidDetailsModel_.saveVapidDetails(swReg.scope, publicVapidKey);
     return tokenDetails['token'];
   }
 

--- a/packages/messaging/src/controllers/controller-interface.ts
+++ b/packages/messaging/src/controllers/controller-interface.ts
@@ -129,8 +129,8 @@ export default class ControllerInterface {
       }
     }
 
-    // If the VAPID details are updated, delete the existing token,
-    // and create a new one.
+    // If the token is no longer valid (for example if the VAPID details
+    // have changed), delete the existing token, and create a new one.
     await this.deleteToken(tokenDetails['fcmToken']);
     return this.getNewToken(swReg, pushSubscription, publicVapidKey);
   }


### PR DESCRIPTION
cc @gauntface

Should be a no-op in terms of functionality:
1) Use async/await in the ControllerInterface.
2) Merge the retrieval of pushSubscription and publicVapidKey, so we don't call getPushSubscription and getPublicVapidKey multiple times in the flow.