### PR TITLE
Fixing Storage Types

### DIFF
--- a/packages/firebase/app/index.d.ts
+++ b/packages/firebase/app/index.d.ts
@@ -154,10 +154,10 @@ declare namespace firebase.auth {
     applyActionCode(code: string): Promise<any>;
     checkActionCode(code: string): Promise<any>;
     confirmPasswordReset(code: string, newPassword: string): Promise<any>;
-    createUserAndRetrieveDataWithEmailAndPassword( 
-      email: string, 
-      password: string 
-    ): Promise<any>; 
+    createUserAndRetrieveDataWithEmailAndPassword(
+      email: string,
+      password: string
+    ): Promise<any>;
     createUserWithEmailAndPassword(
       email: string,
       password: string
@@ -202,7 +202,10 @@ declare namespace firebase.auth {
     signInWithCustomToken(token: string): Promise<any>;
     signInAndRetrieveDataWithCustomToken(token: string): Promise<any>;
     signInWithEmailAndPassword(email: string, password: string): Promise<any>;
-    signInAndRetrieveDataWithEmailAndPassword(email: string, password: string): Promise<any>;
+    signInAndRetrieveDataWithEmailAndPassword(
+      email: string,
+      password: string
+    ): Promise<any>;
     signInWithPhoneNumber(
       phoneNumber: string,
       applicationVerifier: firebase.auth.ApplicationVerifier

--- a/packages/storage-types/index.d.ts
+++ b/packages/storage-types/index.d.ts
@@ -38,7 +38,10 @@ export interface Reference {
   getMetadata(): Promise<FullMetadata>;
   name: string;
   parent: Reference | null;
-  put(data: Blob|Uint8Array|ArrayBuffer, metadata?: UploadMetadata): UploadTask;
+  put(
+    data: Blob | Uint8Array | ArrayBuffer,
+    metadata?: UploadMetadata
+  ): UploadTask;
   putString(
     data: string,
     format?: StringFormat,

--- a/packages/storage-types/index.d.ts
+++ b/packages/storage-types/index.d.ts
@@ -32,13 +32,13 @@ export interface FullMetadata extends UploadMetadata {
 export interface Reference {
   bucket: string;
   child(path: string): Reference;
-  delete(): Promise<any>;
+  delete(): Promise<void>;
   fullPath: string;
-  getDownloadURL(): Promise<any>;
-  getMetadata(): Promise<any>;
+  getDownloadURL(): Promise<string>;
+  getMetadata(): Promise<FullMetadata>;
   name: string;
   parent: Reference | null;
-  put(data: any | any | any, metadata?: UploadMetadata): UploadTask;
+  put(data: Blob|Uint8Array|ArrayBuffer, metadata?: UploadMetadata): UploadTask;
   putString(
     data: string,
     format?: StringFormat,
@@ -47,7 +47,7 @@ export interface Reference {
   root: Reference;
   storage: Storage;
   toString(): string;
-  updateMetadata(metadata: SettableMetadata): Promise<any>;
+  updateMetadata(metadata: SettableMetadata): Promise<FullMetadata>;
 }
 
 export interface SettableMetadata {
@@ -105,6 +105,6 @@ export class FirebaseStorage {
   maxUploadRetryTime: number;
   ref(path?: string): Reference;
   refFromURL(url: string): Reference;
-  setMaxOperationRetryTime(time: number): any;
-  setMaxUploadRetryTime(time: number): any;
+  setMaxOperationRetryTime(time: number): void;
+  setMaxUploadRetryTime(time: number): void;
 }


### PR DESCRIPTION
Removing 'any' from some of the Storage APIs. I copied this from the Storage externs definition in Google3.