### PR TITLE
PushSubscription validation

### DIFF
--- a/packages/firebase/app/index.d.ts
+++ b/packages/firebase/app/index.d.ts
@@ -154,10 +154,10 @@ declare namespace firebase.auth {
     applyActionCode(code: string): Promise<any>;
     checkActionCode(code: string): Promise<any>;
     confirmPasswordReset(code: string, newPassword: string): Promise<any>;
-    createUserAndRetrieveDataWithEmailAndPassword( 
-      email: string, 
-      password: string 
-    ): Promise<any>; 
+    createUserAndRetrieveDataWithEmailAndPassword(
+      email: string,
+      password: string
+    ): Promise<any>;
     createUserWithEmailAndPassword(
       email: string,
       password: string
@@ -202,7 +202,10 @@ declare namespace firebase.auth {
     signInWithCustomToken(token: string): Promise<any>;
     signInAndRetrieveDataWithCustomToken(token: string): Promise<any>;
     signInWithEmailAndPassword(email: string, password: string): Promise<any>;
-    signInAndRetrieveDataWithEmailAndPassword(email: string, password: string): Promise<any>;
+    signInAndRetrieveDataWithEmailAndPassword(
+      email: string,
+      password: string
+    ): Promise<any>;
     signInWithPhoneNumber(
       phoneNumber: string,
       applicationVerifier: firebase.auth.ApplicationVerifier

--- a/packages/messaging/src/controllers/controller-interface.ts
+++ b/packages/messaging/src/controllers/controller-interface.ts
@@ -114,7 +114,7 @@ export default class ControllerInterface {
     publicVapidKey: Uint8Array,
     tokenDetails: Object
   ): Promise<string> {
-    const isTokenValid = await this.isTokenStillValid(tokenDetails);
+    const isTokenValid = this.isTokenStillValid(pushSubscription, publicVapidKey, tokenDetails);
     if (isTokenValid) {
       const now = Date.now();
       if (now < tokenDetails['createTime'] + TOKEN_EXPIRATION_MILLIS) {
@@ -138,14 +138,20 @@ export default class ControllerInterface {
   /*
    * Checks if the tokenDetails match the details provided in the clients.
    */
-  private isTokenStillValid(tokenDetails: Object): Promise<Boolean> {
-    // TODO Validate rest of the details.
-    return this.getPublicVapidKey_().then(publicKey => {
-      if (arrayBufferToBase64(publicKey) !== tokenDetails['vapidKey']) {
-        return false;
-      }
-      return true;
-    });
+  private isTokenStillValid(pushSubscription: PushSubscription, publicVapidKey: Uint8Array, tokenDetails: Object): Boolean {
+    if (arrayBufferToBase64(publicVapidKey) !== tokenDetails['vapidKey']) {
+      return false;
+    }
+
+    // getKey() isn't defined in the PushSubscription externs file, hence
+    // subscription['getKey']('<key name>').
+    return (
+      pushSubscription.endpoint === tokenDetails['endpoint'] &&
+      arrayBufferToBase64(pushSubscription['getKey']('auth')) ===
+        tokenDetails['auth'] &&
+      arrayBufferToBase64(pushSubscription['getKey']('p256dh')) ===
+        tokenDetails['p256dh']
+    );
   }
 
   private async updateToken(

--- a/packages/messaging/src/controllers/controller-interface.ts
+++ b/packages/messaging/src/controllers/controller-interface.ts
@@ -114,7 +114,11 @@ export default class ControllerInterface {
     publicVapidKey: Uint8Array,
     tokenDetails: Object
   ): Promise<string> {
-    const isTokenValid = this.isTokenStillValid(pushSubscription, publicVapidKey, tokenDetails);
+    const isTokenValid = this.isTokenStillValid(
+      pushSubscription,
+      publicVapidKey,
+      tokenDetails
+    );
     if (isTokenValid) {
       const now = Date.now();
       if (now < tokenDetails['createTime'] + TOKEN_EXPIRATION_MILLIS) {
@@ -138,7 +142,11 @@ export default class ControllerInterface {
   /*
    * Checks if the tokenDetails match the details provided in the clients.
    */
-  private isTokenStillValid(pushSubscription: PushSubscription, publicVapidKey: Uint8Array, tokenDetails: Object): Boolean {
+  private isTokenStillValid(
+    pushSubscription: PushSubscription,
+    publicVapidKey: Uint8Array,
+    tokenDetails: Object
+  ): Boolean {
     if (arrayBufferToBase64(publicVapidKey) !== tokenDetails['vapidKey']) {
       return false;
     }

--- a/packages/messaging/test/controller-get-token.test.ts
+++ b/packages/messaging/test/controller-get-token.test.ts
@@ -39,6 +39,7 @@ describe('Firebase Messaging > *Controller.getToken()', function() {
   const sandbox = sinon.sandbox.create();
   const now = Date.now();
   const expiredDate = new Date(now - ONE_DAY);
+  const FAKE_SUBSCRIPTION = makeFakeSubscription();
 
   const EXAMPLE_FCM_TOKEN = 'ExampleFCMToken1337';
   const EXAMPLE_SENDER_ID = '1234567890';
@@ -52,7 +53,9 @@ describe('Firebase Messaging > *Controller.getToken()', function() {
   const EXAMPLE_TOKEN_DETAILS_DEFAULT_VAPID = {
     swScope: '/example-scope',
     vapidKey: DEFAULT_VAPID_KEY,
-    subscription: makeFakeSubscription(),
+    endpoint: FAKE_SUBSCRIPTION.endpoint,
+    auth: arrayBufferToBase64(FAKE_SUBSCRIPTION['getKey']('auth')),
+    p256dh: arrayBufferToBase64(FAKE_SUBSCRIPTION['getKey']('p256dh')),
     fcmSenderId: EXAMPLE_SENDER_ID,
     fcmToken: 'qwerty1',
     fcmPushSet: '87654321',
@@ -61,7 +64,9 @@ describe('Firebase Messaging > *Controller.getToken()', function() {
   const EXAMPLE_TOKEN_DETAILS_CUSTOM_VAPID = {
     swScope: '/example-scope',
     vapidKey: CUSTOM_VAPID_KEY,
-    subscription: makeFakeSubscription(),
+    endpoint: FAKE_SUBSCRIPTION.endpoint,
+    auth: arrayBufferToBase64(FAKE_SUBSCRIPTION['getKey']('auth')),
+    p256dh: arrayBufferToBase64(FAKE_SUBSCRIPTION['getKey']('p256dh')),
     fcmSenderId: EXAMPLE_SENDER_ID,
     fcmToken: 'qwerty2',
     fcmPushSet: '7654321',
@@ -70,7 +75,9 @@ describe('Firebase Messaging > *Controller.getToken()', function() {
   const EXAMPLE_EXPIRED_TOKEN_DETAILS = {
     swScope: '/example-scope',
     vapidKey: DEFAULT_VAPID_KEY,
-    subscription: makeFakeSubscription(),
+    endpoint: FAKE_SUBSCRIPTION.endpoint,
+    auth: arrayBufferToBase64(FAKE_SUBSCRIPTION['getKey']('auth')),
+    p256dh: arrayBufferToBase64(FAKE_SUBSCRIPTION['getKey']('p256dh')),
     fcmSenderId: EXAMPLE_SENDER_ID,
     fcmToken: 'qwerty3',
     fcmPushSet: '654321',
@@ -397,6 +404,81 @@ describe('Firebase Messaging > *Controller.getToken()', function() {
           assert.equal(tokenModelArgs.fcmSenderId, EXAMPLE_SENDER_ID);
           assert.equal(tokenModelArgs.fcmToken, TOKEN_DETAILS['token']);
           assert.equal(tokenModelArgs.fcmPushSet, TOKEN_DETAILS['pushSet']);
+        });
+      });
+
+      it('should get a new token in ${ServiceClass.name} if PushSubscription details have changed', function() {
+        // Stubs
+        const deleteTokenStub = sandbox.stub(
+          TokenDetailsModel.prototype,
+          'deleteToken'
+        );
+        const saveTokenDetailsStub = sandbox.stub(
+          TokenDetailsModel.prototype,
+          'saveTokenDetails'
+        );
+        saveTokenDetailsStub.callsFake(async () => {});
+
+        sandbox
+          .stub(ControllerInterface.prototype, 'getNotificationPermission_')
+          .callsFake(() => NotificationPermission.granted);
+
+        const existingTokenDetails = VapidSetup['details'];
+        let vapidKeyToUse = FCMDetails.DEFAULT_PUBLIC_VAPID_KEY;
+        if (VapidSetup['name'] === 'custom') {
+          vapidKeyToUse = base64ToArrayBuffer(CUSTOM_VAPID_KEY);
+        }
+        sandbox
+          .stub(ServiceClass.prototype, 'getPublicVapidKey_')
+          .callsFake(() => Promise.resolve(vapidKeyToUse));
+
+        sandbox
+          .stub(VapidDetailsModel.prototype, 'saveVapidDetails')
+          .callsFake(async () => {});
+
+        const GET_TOKEN_RESPONSE = {
+          token: 'new-token',
+          pushSet: 'new-pushSet'
+        };
+        sandbox
+          .stub(IIDModel.prototype, 'getToken')
+          .callsFake(() => Promise.resolve(GET_TOKEN_RESPONSE));
+        sandbox.stub(IIDModel.prototype, 'deleteToken').callsFake(async () => {});
+
+        const registration = generateFakeReg(Promise.resolve(null));
+        mockGetReg(Promise.resolve(registration));
+
+        const options = {
+          endpoint: "https://different-push-endpoint.com/",
+          auth: "another-auth-secret",
+          p256dh: "another-user-public-key"
+        }
+        const newPS = makeFakeSubscription(options);
+
+        deleteTokenStub.callsFake(token => {
+          assert.equal(token, existingTokenDetails.fcmToken);
+          return Promise.resolve(existingTokenDetails);
+        });
+        // The push subscription has changed since we saved the token.
+        sandbox
+          .stub(ServiceClass.prototype, 'getPushSubscription')
+          .callsFake(() => Promise.resolve(newPS));
+        sandbox
+          .stub(TokenDetailsModel.prototype, 'getTokenDetailsFromSWScope')
+          .callsFake(() => Promise.resolve(existingTokenDetails));
+
+        const serviceInstance = new ServiceClass(app);
+        return serviceInstance.getToken().then(token => {
+          // make sure we call getToken and retrieve the new token.
+          assert.equal('new-token', token);
+          // make sure the existing token is deleted.
+          assert.equal(deleteTokenStub.callCount, 1);
+          // make sure the new details are saved.
+          assert.equal(saveTokenDetailsStub.callCount, 1);
+          assert.equal(
+            VapidDetailsModel.prototype.saveVapidDetails['callCount'],
+            1
+          );
         });
       });
     });

--- a/packages/messaging/test/controller-get-token.test.ts
+++ b/packages/messaging/test/controller-get-token.test.ts
@@ -443,16 +443,18 @@ describe('Firebase Messaging > *Controller.getToken()', function() {
         sandbox
           .stub(IIDModel.prototype, 'getToken')
           .callsFake(() => Promise.resolve(GET_TOKEN_RESPONSE));
-        sandbox.stub(IIDModel.prototype, 'deleteToken').callsFake(async () => {});
+        sandbox
+          .stub(IIDModel.prototype, 'deleteToken')
+          .callsFake(async () => {});
 
         const registration = generateFakeReg(Promise.resolve(null));
         mockGetReg(Promise.resolve(registration));
 
         const options = {
-          endpoint: "https://different-push-endpoint.com/",
-          auth: "another-auth-secret",
-          p256dh: "another-user-public-key"
-        }
+          endpoint: 'https://different-push-endpoint.com/',
+          auth: 'another-auth-secret',
+          p256dh: 'another-user-public-key'
+        };
         const newPS = makeFakeSubscription(options);
 
         deleteTokenStub.callsFake(token => {


### PR DESCRIPTION
Check if pushSubscription details have changed before returning an existing token.

This should enable us to deal with permission changes where new push subscriptions are generated but we're returning old token: https://stackoverflow.com/questions/49393052/chrome-firebase-cloud-message-notregistered

cc: @gauntface 