### PR TITLE
 Renaming ClientKey to ClientId

### DIFF
--- a/packages/firestore/src/local/indexeddb_schema.ts
+++ b/packages/firestore/src/local/indexeddb_schema.ts
@@ -611,11 +611,11 @@ export class DbClientMetadata {
   static store = 'clientMetadata';
 
   /** Keys are automatically assigned via the clientId properties. */
-  static keyPath = ['clientKey'];
+  static keyPath = ['clientId'];
 
   constructor(
     /** The auto-generated client id assigned at client startup. */
-    public clientKey: string,
+    public clientId: string,
     /** The last time this state was updated. */
     public updateTimeMs: number,
     /** Whether this client is running in a foreground tab. */

--- a/packages/firestore/src/local/memory_persistence.ts
+++ b/packages/firestore/src/local/memory_persistence.ts
@@ -30,7 +30,7 @@ import {
 import { PersistencePromise } from './persistence_promise';
 import { QueryCache } from './query_cache';
 import { RemoteDocumentCache } from './remote_document_cache';
-import { ClientKey } from './shared_client_state';
+import { ClientId } from './shared_client_state';
 import { AsyncQueue } from '../util/async_queue';
 import { AutoId } from '../util/misc';
 
@@ -51,7 +51,7 @@ export class MemoryPersistence implements Persistence {
   private mutationQueues: { [user: string]: MutationQueue } = {};
   private remoteDocumentCache = new MemoryRemoteDocumentCache();
   private queryCache = new MemoryQueryCache();
-  private readonly clientId: ClientKey = AutoId.newId();
+  private readonly clientId: ClientId = AutoId.newId();
 
   private started = false;
 
@@ -69,7 +69,7 @@ export class MemoryPersistence implements Persistence {
     this.started = false;
   }
 
-  async getActiveClients(): Promise<ClientKey[]> {
+  async getActiveClients(): Promise<ClientId[]> {
     return [this.clientId];
   }
 

--- a/packages/firestore/src/local/persistence.ts
+++ b/packages/firestore/src/local/persistence.ts
@@ -21,7 +21,7 @@ import { PersistenceTransaction } from './persistence';
 import { PersistencePromise } from './persistence_promise';
 import { QueryCache } from './query_cache';
 import { RemoteDocumentCache } from './remote_document_cache';
-import { ClientKey } from './shared_client_state';
+import { ClientId } from './shared_client_state';
 
 /**
  * Opaque interface representing a persistence transaction.
@@ -107,7 +107,7 @@ export interface Persistence {
    *
    * PORTING NOTE: This is only used for Web multi-tab.
    */
-  getActiveClients(): Promise<ClientKey[]>;
+  getActiveClients(): Promise<ClientId[]>;
 
   /**
    * Returns a MutationQueue representing the persisted mutations for the

--- a/packages/firestore/src/local/shared_client_state.ts
+++ b/packages/firestore/src/local/shared_client_state.ts
@@ -588,7 +588,7 @@ export class WebStorageSharedClientState implements SharedClientState {
   /** Assembles the key for a client state in LocalStorage */
   private toLocalStorageClientStateKey(clientId: ClientId): string {
     assert(
-        clientId.indexOf('_') === -1,
+      clientId.indexOf('_') === -1,
       `Client key cannot contain '_', but was '${clientId}'`
     );
 

--- a/packages/firestore/src/local/shared_client_state.ts
+++ b/packages/firestore/src/local/shared_client_state.ts
@@ -45,8 +45,7 @@ const MUTATION_BATCH_KEY_PREFIX = 'fs_mutations';
 /**
  * A randomly-generated key assigned to each Firestore instance at startup.
  */
-// TODO(multitab): Rename to ClientId.
-export type ClientKey = string;
+export type ClientId = string;
 
 /**
  * A `SharedClientState` keeps track of the global state of the mutations
@@ -203,7 +202,7 @@ export class MutationMetadata {
 
 /**
  * The JSON representation of a clients's metadata as used during LocalStorage
- * serialization. The ClientKey is omitted here as it is encoded as part of the
+ * serialization. The ClientId is omitted here as it is encoded as part of the
  * key.
  */
 interface ClientStateSchema {
@@ -233,7 +232,7 @@ export interface ClientState {
  */
 class RemoteClientState implements ClientState {
   private constructor(
-    readonly clientId: ClientKey,
+    readonly clientId: ClientId,
     readonly lastUpdateTime: Date,
     readonly activeTargetIds: SortedSet<TargetId>,
     readonly minMutationBatchId: BatchId | null,
@@ -245,7 +244,7 @@ class RemoteClientState implements ClientState {
    * Logs a warning and returns null if the format of the data is not valid.
    */
   static fromLocalStorageEntry(
-    clientKey: string,
+    clientId: ClientId,
     value: string
   ): RemoteClientState | null {
     const clientState = JSON.parse(value) as ClientStateSchema;
@@ -270,7 +269,7 @@ class RemoteClientState implements ClientState {
 
     if (validData) {
       return new RemoteClientState(
-        clientKey,
+        clientId,
         new Date(clientState.lastUpdateTime),
         activeTargetIdsSet,
         clientState.minMutationBatchId,
@@ -279,7 +278,7 @@ class RemoteClientState implements ClientState {
     } else {
       error(
         LOG_TAG,
-        `Failed to parse client data for instance '${clientKey}': ${value}`
+        `Failed to parse client data for instance '${clientId}': ${value}`
       );
       return null;
     }
@@ -389,7 +388,7 @@ export class WebStorageSharedClientState implements SharedClientState {
   constructor(
     private readonly queue: AsyncQueue,
     private readonly persistenceKey: string,
-    private readonly localClientKey: ClientKey
+    private readonly localClientId: ClientId
   ) {
     if (!WebStorageSharedClientState.isAvailable()) {
       throw new FirestoreError(
@@ -399,9 +398,9 @@ export class WebStorageSharedClientState implements SharedClientState {
     }
     this.storage = window.localStorage;
     this.localClientStorageKey = this.toLocalStorageClientStateKey(
-      this.localClientKey
+      this.localClientId
     );
-    this.activeClients[this.localClientKey] = new LocalClientState();
+    this.activeClients[this.localClientId] = new LocalClientState();
     this.clientStateKeyRe = new RegExp(
       `^${CLIENT_STATE_KEY_PREFIX}_${persistenceKey}_([^_]*)$`
     );
@@ -427,17 +426,17 @@ export class WebStorageSharedClientState implements SharedClientState {
     // SharedClientState.
     const existingClients = await this.syncEngine.getActiveClients();
 
-    for (const clientKey of existingClients) {
-      if (clientKey === this.localClientKey) {
+    for (const clientId of existingClients) {
+      if (clientId === this.localClientId) {
         continue;
       }
 
       const storageItem = this.storage.getItem(
-        this.toLocalStorageClientStateKey(clientKey)
+        this.toLocalStorageClientStateKey(clientId)
       );
       if (storageItem) {
         const clientState = RemoteClientState.fromLocalStorageEntry(
-          clientKey,
+          clientId,
           storageItem
         );
         if (clientState) {
@@ -549,7 +548,7 @@ export class WebStorageSharedClientState implements SharedClientState {
   }
 
   private get localClientState(): LocalClientState {
-    return this.activeClients[this.localClientKey] as LocalClientState;
+    return this.activeClients[this.localClientId] as LocalClientState;
   }
 
   private persistClientState(): void {
@@ -587,20 +586,20 @@ export class WebStorageSharedClientState implements SharedClientState {
   }
 
   /** Assembles the key for a client state in LocalStorage */
-  private toLocalStorageClientStateKey(clientKey: string): string {
+  private toLocalStorageClientStateKey(clientId: ClientId): string {
     assert(
-      clientKey.indexOf('_') === -1,
-      `Client key cannot contain '_', but was '${clientKey}'`
+        clientId.indexOf('_') === -1,
+      `Client key cannot contain '_', but was '${clientId}'`
     );
 
-    return `${CLIENT_STATE_KEY_PREFIX}_${this.persistenceKey}_${clientKey}`;
+    return `${CLIENT_STATE_KEY_PREFIX}_${this.persistenceKey}_${clientId}`;
   }
 
   /**
    * Parses a client state key in LocalStorage. Returns null if the key does not
    * match the expected key format.
    */
-  private fromLocalStorageClientStateKey(key: string): ClientKey | null {
+  private fromLocalStorageClientStateKey(key: string): ClientId | null {
     const match = this.clientStateKeyRe.exec(key);
     return match ? match[1] : null;
   }

--- a/packages/firestore/src/local/shared_client_state_syncer.ts
+++ b/packages/firestore/src/local/shared_client_state_syncer.ts
@@ -16,7 +16,7 @@
 
 import { BatchId } from '../core/types';
 import { FirestoreError } from '../util/error';
-import { ClientKey } from './shared_client_state';
+import { ClientId } from './shared_client_state';
 
 /**
  * An interface that describes the actions the SharedClientState class needs to
@@ -33,5 +33,5 @@ export interface SharedClientStateSyncer {
   rejectFailedWrite(batchId: BatchId, err: FirestoreError): Promise<void>;
 
   /** Returns the IDs of the clients that are currently active. */
-  getActiveClients(): Promise<ClientKey[]>;
+  getActiveClients(): Promise<ClientId[]>;
 }

--- a/packages/firestore/test/unit/local/persistence_test_helpers.ts
+++ b/packages/firestore/test/unit/local/persistence_test_helpers.ts
@@ -22,7 +22,7 @@ import { JsonProtoSerializer } from '../../../src/remote/serializer';
 import {
   WebStorageSharedClientState,
   SharedClientState,
-  ClientKey
+  ClientId
 } from '../../../src/local/shared_client_state';
 import { BatchId, TargetId } from '../../../src/core/types';
 import { BrowserPlatform } from '../../../src/platform_browser/browser_platform';
@@ -71,14 +71,14 @@ export async function testMemoryPersistence(): Promise<MemoryPersistence> {
 }
 
 class NoOpSharedClientStateSyncer implements SharedClientStateSyncer {
-  constructor(private readonly activeClients: ClientKey[]) {}
+  constructor(private readonly activeClients: ClientId[]) {}
   async applyPendingBatch(batchId: BatchId): Promise<void> {}
   async applySuccessfulWrite(batchId: BatchId): Promise<void> {}
   async rejectFailedWrite(
     batchId: BatchId,
     err: FirestoreError
   ): Promise<void> {}
-  async getActiveClients(): Promise<ClientKey[]> {
+  async getActiveClients(): Promise<ClientId[]> {
     return this.activeClients;
   }
 }
@@ -88,7 +88,7 @@ class NoOpSharedClientStateSyncer implements SharedClientStateSyncer {
  */
 export async function populateWebStorage(
   user: User,
-  existingClientId: ClientKey,
+  existingClientId: ClientId,
   existingMutationBatchIds: BatchId[],
   existingQueryTargetIds: TargetId[]
 ): Promise<void> {

--- a/packages/firestore/test/unit/local/web_storage_shared_client_state.test.ts
+++ b/packages/firestore/test/unit/local/web_storage_shared_client_state.test.ts
@@ -314,7 +314,10 @@ describe('WebStorageSharedClientState', () => {
       const oldState = new LocalClientState();
       oldState.addQueryTarget(5);
 
-      writeToLocalStorage(secondaryClientStateKey, oldState.toLocalStorageJSON());
+      writeToLocalStorage(
+        secondaryClientStateKey,
+        oldState.toLocalStorageJSON()
+      );
       verifyState(1, [3, 4, 5]);
 
       const updatedState = new LocalClientState();
@@ -346,7 +349,10 @@ describe('WebStorageSharedClientState', () => {
       verifyState(1, [3, 4]);
 
       // We ignore the newly added target.
-      writeToLocalStorage(secondaryClientStateKey, JSON.stringify(invalidState));
+      writeToLocalStorage(
+        secondaryClientStateKey,
+        JSON.stringify(invalidState)
+      );
       verifyState(1, [3, 4]);
     });
   });

--- a/packages/firestore/test/unit/local/web_storage_shared_client_state.test.ts
+++ b/packages/firestore/test/unit/local/web_storage_shared_client_state.test.ts
@@ -19,7 +19,7 @@ import {
   WebStorageSharedClientState,
   LocalClientState,
   MutationMetadata,
-  ClientKey,
+  ClientId,
   SharedClientState
 } from '../../../src/local/shared_client_state';
 import { BatchId, TargetId } from '../../../src/core/types';
@@ -64,7 +64,7 @@ class TestClientSyncer implements SharedClientStateSyncer {
   readonly acknowledgedBatches: BatchId[] = [];
   readonly rejectedBatches: { [batchId: number]: FirestoreError } = {};
 
-  constructor(public activeClients: ClientKey[]) {}
+  constructor(public activeClients: ClientId[]) {}
 
   async applyPendingBatch(batchId: BatchId): Promise<void> {
     this.pendingBatches.push(batchId);
@@ -81,7 +81,7 @@ class TestClientSyncer implements SharedClientStateSyncer {
     this.rejectedBatches[batchId] = err;
   }
 
-  async getActiveClients(): Promise<ClientKey[]> {
+  async getActiveClients(): Promise<ClientId[]> {
     return this.activeClients;
   }
 }
@@ -304,7 +304,7 @@ describe('WebStorageSharedClientState', () => {
     });
 
     it('with data from new clients', () => {
-      const secondaryClientKey = `fs_clients_${
+      const secondaryClientStateKey = `fs_clients_${
         persistenceHelpers.TEST_PERSISTENCE_PREFIX
       }_${AutoId.newId()}`;
 
@@ -314,7 +314,7 @@ describe('WebStorageSharedClientState', () => {
       const oldState = new LocalClientState();
       oldState.addQueryTarget(5);
 
-      writeToLocalStorage(secondaryClientKey, oldState.toLocalStorageJSON());
+      writeToLocalStorage(secondaryClientStateKey, oldState.toLocalStorageJSON());
       verifyState(1, [3, 4, 5]);
 
       const updatedState = new LocalClientState();
@@ -323,17 +323,17 @@ describe('WebStorageSharedClientState', () => {
       updatedState.addPendingMutation(0);
 
       writeToLocalStorage(
-        secondaryClientKey,
+        secondaryClientStateKey,
         updatedState.toLocalStorageJSON()
       );
       verifyState(0, [3, 4, 5, 6]);
 
-      writeToLocalStorage(secondaryClientKey, null);
+      writeToLocalStorage(secondaryClientStateKey, null);
       verifyState(1, [3, 4]);
     });
 
     it('ignores invalid data', () => {
-      const secondaryClientKey = `fs_clients_${
+      const secondaryClientStateKey = `fs_clients_${
         persistenceHelpers.TEST_PERSISTENCE_PREFIX
       }_${AutoId.newId()}`;
 
@@ -346,7 +346,7 @@ describe('WebStorageSharedClientState', () => {
       verifyState(1, [3, 4]);
 
       // We ignore the newly added target.
-      writeToLocalStorage(secondaryClientKey, JSON.stringify(invalidState));
+      writeToLocalStorage(secondaryClientStateKey, JSON.stringify(invalidState));
       verifyState(1, [3, 4]);
     });
   });


### PR DESCRIPTION
This renames ClientKey to ClientId.

```
mrschmidt@mrschmidt-macbookpro3 src (multitab-clientidrename) $ grep -r -i "clientkey" .
mrschmidt@mrschmidt-macbookpro3 src (multitab-clientidrename) $ 
```