### PR TITLE
Fix Issue 474

### DIFF
--- a/packages/firebase/index.d.ts
+++ b/packages/firebase/index.d.ts
@@ -1799,6 +1799,4 @@ declare namespace firebase.firestore {
   }
 }
 
-declare module 'firebase' {
-  export = firebase;
-}
+export = firebase;


### PR DESCRIPTION
Removes the following unneeded block:

```typescript
declare module `firebase` {}
```

This file is referenced from the package.json and is automatically assigned to the `firebase` name.

Fixes #474