### PR TITLE
 Plumbing through SharedStorageState

### DIFF
--- a/packages/firestore/src/core/firestore_client.ts
+++ b/packages/firestore/src/core/firestore_client.ts
@@ -250,19 +250,22 @@ export class FirestoreClient {
     const serializer = new JsonProtoSerializer(this.databaseInfo.databaseId, {
       useProto3Json: true
     });
-    this.persistence = new IndexedDbPersistence(
-      storagePrefix,
-      this.clientId,
-      this.platform,
-      this.asyncQueue,
-      serializer
-    );
-    this.sharedClientState = new WebStorageSharedClientState(
-      this.asyncQueue,
-      storagePrefix,
-      this.clientId
-    );
-    return this.persistence.start();
+
+    return Promise.resolve().then(() => {
+      this.persistence = new IndexedDbPersistence(
+          storagePrefix,
+          this.clientId,
+          this.platform,
+          this.asyncQueue,
+          serializer
+      );
+      this.sharedClientState = new WebStorageSharedClientState(
+        this.asyncQueue,
+        storagePrefix,
+        this.clientId
+      );
+      return this.persistence.start();
+    });
   }
 
   /**

--- a/packages/firestore/src/core/firestore_client.ts
+++ b/packages/firestore/src/core/firestore_client.ts
@@ -253,11 +253,11 @@ export class FirestoreClient {
 
     return Promise.resolve().then(() => {
       this.persistence = new IndexedDbPersistence(
-          storagePrefix,
-          this.clientId,
-          this.platform,
-          this.asyncQueue,
-          serializer
+        storagePrefix,
+        this.clientId,
+        this.platform,
+        this.asyncQueue,
+        serializer
       );
       this.sharedClientState = new WebStorageSharedClientState(
         this.asyncQueue,

--- a/packages/firestore/src/core/firestore_client.ts
+++ b/packages/firestore/src/core/firestore_client.ts
@@ -73,10 +73,10 @@ export class FirestoreClient {
   private remoteStore: RemoteStore;
   private syncEngine: SyncEngine;
 
+  private readonly clientId = AutoId.newId();
+
   // PORTING NOTE: SharedClientState is only used in for multi-tab web.
   private sharedClientState: SharedClientState;
-
-  private readonly clientId = AutoId.newId();
 
   constructor(
     private platform: Platform,

--- a/packages/firestore/src/core/firestore_client.ts
+++ b/packages/firestore/src/core/firestore_client.ts
@@ -75,7 +75,7 @@ export class FirestoreClient {
 
   private readonly clientId = AutoId.newId();
 
-  // PORTING NOTE: SharedClientState is only used in for multi-tab web.
+  // PORTING NOTE: SharedClientState is only used for multi-tab web.
   private sharedClientState: SharedClientState;
 
   constructor(

--- a/packages/firestore/src/local/local_store.ts
+++ b/packages/firestore/src/local/local_store.ts
@@ -55,7 +55,7 @@ import { QueryData, QueryPurpose } from './query_data';
 import { ReferenceSet } from './reference_set';
 import { RemoteDocumentCache } from './remote_document_cache';
 import { RemoteDocumentChangeBuffer } from './remote_document_change_buffer';
-import { ClientId, SharedClientState } from './shared_client_state';
+import { ClientId } from './shared_client_state';
 
 const LOG_TAG = 'LocalStore';
 

--- a/packages/firestore/src/local/memory_persistence.ts
+++ b/packages/firestore/src/local/memory_persistence.ts
@@ -32,7 +32,6 @@ import { QueryCache } from './query_cache';
 import { RemoteDocumentCache } from './remote_document_cache';
 import { ClientId } from './shared_client_state';
 import { AsyncQueue } from '../util/async_queue';
-import { AutoId } from '../util/misc';
 
 const LOG_TAG = 'MemoryPersistence';
 
@@ -51,11 +50,13 @@ export class MemoryPersistence implements Persistence {
   private mutationQueues: { [user: string]: MutationQueue } = {};
   private remoteDocumentCache = new MemoryRemoteDocumentCache();
   private queryCache = new MemoryQueryCache();
-  private readonly clientId: ClientId = AutoId.newId();
 
   private started = false;
 
-  constructor(private readonly queue: AsyncQueue) {}
+  constructor(
+    private readonly queue: AsyncQueue,
+    private readonly clientId: ClientId
+  ) {}
 
   async start(): Promise<void> {
     // No durable state to read on startup.

--- a/packages/firestore/src/local/shared_client_state.ts
+++ b/packages/firestore/src/local/shared_client_state.ts
@@ -99,7 +99,7 @@ export interface SharedClientState {
    * Starts the SharedClientState, reads existing client data and registers
    * listeners for updates to new and existing clients.
    */
-  start(initialUser: User): Promise<void>;
+  start(): Promise<void>;
 
   /** Shuts down the `SharedClientState` and its listeners. */
   shutdown(): void;
@@ -372,7 +372,7 @@ export class LocalClientState implements ClientState {
     return JSON.stringify(data);
   }
 
-  handleUserChange() {
+  clearPendingMutations() {
     this.pendingBatchIds = new SortedSet<BatchId>(primitiveComparator);
   }
 }
@@ -393,7 +393,7 @@ export class WebStorageSharedClientState implements SharedClientState {
   private readonly clientStateKeyRe: RegExp;
   private readonly mutationBatchKeyRe: RegExp;
   private started = false;
-  private user: User;
+  private currentUser: User;
 
   /**
    * Captures WebStorage events that occur before `start()` is called. These
@@ -404,7 +404,8 @@ export class WebStorageSharedClientState implements SharedClientState {
   constructor(
     private readonly queue: AsyncQueue,
     private readonly persistenceKey: string,
-    private readonly localClientId: ClientId
+    private readonly localClientId: ClientId,
+    initialUser: User
   ) {
     if (!WebStorageSharedClientState.isAvailable()) {
       throw new FirestoreError(
@@ -413,6 +414,7 @@ export class WebStorageSharedClientState implements SharedClientState {
       );
     }
     this.storage = window.localStorage;
+    this.currentUser = initialUser;
     this.localClientStorageKey = this.toLocalStorageClientStateKey(
       this.localClientId
     );
@@ -438,7 +440,7 @@ export class WebStorageSharedClientState implements SharedClientState {
     return typeof window !== 'undefined' && window.localStorage != null;
   }
 
-  async start(initialUser: User): Promise<void> {
+  async start(): Promise<void> {
     assert(!this.started, 'WebStorageSharedClientState already started');
     assert(
       this.syncEngine !== null,
@@ -468,7 +470,6 @@ export class WebStorageSharedClientState implements SharedClientState {
       }
     }
 
-    this.user = initialUser;
     this.persistClientState();
 
     for (const event of this.earlyEvents) {
@@ -519,6 +520,7 @@ export class WebStorageSharedClientState implements SharedClientState {
 
   handleUserChange(user: User): void {
     // TODO(multitab): Handle user changes.
+    this.currentUser = user;
   }
 
   shutdown(): void {
@@ -595,7 +597,7 @@ export class WebStorageSharedClientState implements SharedClientState {
     error?: FirestoreError
   ) {
     const mutationState = new MutationMetadata(
-      this.user,
+      this.currentUser,
       batchId,
       state,
       error
@@ -605,8 +607,8 @@ export class WebStorageSharedClientState implements SharedClientState {
       this.persistenceKey
     }_${batchId}`;
 
-    if (this.user.isAuthenticated()) {
-      mutationKey += `_${this.user.uid}`;
+    if (this.currentUser.isAuthenticated()) {
+      mutationKey += `_${this.currentUser.uid}`;
     }
 
     this.storage.setItem(mutationKey, mutationState.toLocalStorageJSON());
@@ -667,7 +669,7 @@ export class WebStorageSharedClientState implements SharedClientState {
   private async handleMutationBatchEvent(
     mutationBatch: MutationMetadata
   ): Promise<void> {
-    if (mutationBatch.user.uid !== this.user.uid) {
+    if (mutationBatch.user.uid !== this.currentUser.uid) {
       debug(
         LOG_TAG,
         `Ignoring mutation for non-active user ${mutationBatch.user.uid}`
@@ -725,13 +727,13 @@ export class MemorySharedClientState implements SharedClientState {
     return this.localState.activeTargetIds;
   }
 
-  start(initialUser: User): Promise<void> {
+  start(): Promise<void> {
     this.localState = new LocalClientState();
     return Promise.resolve();
   }
 
   handleUserChange(user: User): void {
-    this.localState.handleUserChange();
+    this.localState.clearPendingMutations();
   }
 
   shutdown(): void {}

--- a/packages/firestore/src/local/shared_client_state.ts
+++ b/packages/firestore/src/local/shared_client_state.ts
@@ -103,6 +103,13 @@ export interface SharedClientState {
 
   /** Shuts down the `SharedClientState` and its listeners. */
   shutdown(): void;
+
+  /**
+   * Changes the active user and removes all existing user-specific data. The
+   * user change does not call back into SyncEngine (for example, no mutations
+   * will be marked as removed).
+   */
+  handleUserChange(user: User): void;
 }
 
 // Visible for testing
@@ -364,6 +371,10 @@ export class LocalClientState implements ClientState {
     };
     return JSON.stringify(data);
   }
+
+  handleUserChange() {
+    this.pendingBatchIds = new SortedSet<BatchId>(primitiveComparator);
+  }
 }
 
 /**
@@ -427,9 +438,12 @@ export class WebStorageSharedClientState implements SharedClientState {
     return typeof window !== 'undefined' && window.localStorage != null;
   }
 
-  // TODO(multitab): Handle user changes.
   async start(initialUser: User): Promise<void> {
     assert(!this.started, 'WebStorageSharedClientState already started');
+    assert(
+      this.syncEngine !== null,
+      'syncEngine property must be set before calling start()'
+    );
 
     // Retrieve the list of existing clients to backfill the data in
     // SharedClientState.
@@ -501,6 +515,10 @@ export class WebStorageSharedClientState implements SharedClientState {
   removeLocalQueryTarget(targetId: TargetId): void {
     this.localClientState.removeQueryTarget(targetId);
     this.persistClientState();
+  }
+
+  handleUserChange(user: User): void {
+    // TODO(multitab): Handle user changes.
   }
 
   shutdown(): void {
@@ -649,11 +667,6 @@ export class WebStorageSharedClientState implements SharedClientState {
   private async handleMutationBatchEvent(
     mutationBatch: MutationMetadata
   ): Promise<void> {
-    assert(
-      this.syncEngine !== null,
-      'syncEngine property must be set in order to handle events'
-    );
-
     if (mutationBatch.user.uid !== this.user.uid) {
       debug(
         LOG_TAG,
@@ -676,4 +689,50 @@ export class WebStorageSharedClientState implements SharedClientState {
         throw new Error('Not implemented');
     }
   }
+}
+
+/**
+ * `MemorySharedClientState` is a simple implementation of SharedClientState for
+ * clients using memory persistence. The state in this class remains fully
+ * isolated and no synchronization is performed.
+ */
+export class MemorySharedClientState implements SharedClientState {
+  private localState = new LocalClientState();
+
+  syncEngine: SharedClientStateSyncer | null;
+
+  addLocalPendingMutation(batchId: BatchId): void {
+    this.localState.addPendingMutation(batchId);
+  }
+
+  removeLocalPendingMutation(batchId: BatchId): void {
+    this.localState.removePendingMutation(batchId);
+  }
+
+  getMinimumGlobalPendingMutation(): BatchId | null {
+    return this.localState.minMutationBatchId;
+  }
+
+  addLocalQueryTarget(targetId: TargetId): void {
+    this.localState.addQueryTarget(targetId);
+  }
+
+  removeLocalQueryTarget(targetId: TargetId): void {
+    this.localState.removeQueryTarget(targetId);
+  }
+
+  getAllActiveQueryTargets(): SortedSet<TargetId> {
+    return this.localState.activeTargetIds;
+  }
+
+  start(initialUser: User): Promise<void> {
+    this.localState = new LocalClientState();
+    return Promise.resolve();
+  }
+
+  handleUserChange(user: User): void {
+    this.localState.handleUserChange();
+  }
+
+  shutdown(): void {}
 }

--- a/packages/firestore/src/local/shared_client_state_syncer.ts
+++ b/packages/firestore/src/local/shared_client_state_syncer.ts
@@ -26,9 +26,11 @@ export interface SharedClientStateSyncer {
   /** Registers a new pending mutation batch. */
   applyPendingBatch(batchId: BatchId): Promise<void>;
 
+  // TODO(multitab): Rename this method to not clash with RemoteSyncer
   /** Applies the result of a successful write of a mutation batch. */
   applySuccessfulWrite(batchId: BatchId): Promise<void>;
 
+  // TODO(multitab): Rename this method to not clash with RemoteSyncer
   /** Rejects a failed mutation batch. */
   rejectFailedWrite(batchId: BatchId, err: FirestoreError): Promise<void>;
 

--- a/packages/firestore/test/unit/local/local_store.test.ts
+++ b/packages/firestore/test/unit/local/local_store.test.ts
@@ -258,15 +258,7 @@ class LocalStoreTester {
 
 describe('LocalStore w/ Memory Persistence', () => {
   addEqualityMatcher();
-  const queue = new AsyncQueue();
-  const clientId = AutoId.newId();
-  genericLocalStoreTests(
-    persistenceHelpers.testMemoryPersistence.bind(this, queue, clientId),
-    persistenceHelpers.testMemorySharedClientState.bind(
-      this,
-      User.UNAUTHENTICATED
-    )
-  );
+  genericLocalStoreTests(persistenceHelpers.testMemoryPersistence);
 });
 
 describe('LocalStore w/ IndexedDB Persistence', () => {
@@ -278,33 +270,17 @@ describe('LocalStore w/ IndexedDB Persistence', () => {
   }
 
   addEqualityMatcher();
-  const queue = new AsyncQueue();
-  const clientId = AutoId.newId();
-  genericLocalStoreTests(
-    persistenceHelpers.testIndexedDbPersistence.bind(this, queue, clientId),
-    persistenceHelpers.testWebStorageSharedClientState.bind(
-      this,
-      queue,
-      clientId,
-      User.UNAUTHENTICATED
-    )
-  );
+  genericLocalStoreTests(persistenceHelpers.testIndexedDbPersistence);
 });
 
-function genericLocalStoreTests(
-  getPersistence: () => Promise<Persistence>,
-  getSharedClientState: () => Promise<SharedClientState>
-) {
+function genericLocalStoreTests(getPersistence: () => Promise<Persistence>) {
   let persistence: Persistence;
-  let sharedClientState: SharedClientState;
   let localStore: LocalStore;
 
   beforeEach(async () => {
     persistence = await getPersistence();
-    sharedClientState = await getSharedClientState();
     localStore = new LocalStore(
       persistence,
-      sharedClientState,
       User.UNAUTHENTICATED,
       new EagerGarbageCollector()
     );
@@ -312,7 +288,6 @@ function genericLocalStoreTests(
   });
 
   afterEach(async () => {
-    await sharedClientState.shutdown();
     await persistence.shutdown();
   });
 
@@ -323,7 +298,6 @@ function genericLocalStoreTests(
   function restartWithNoOpGarbageCollector(): Promise<void> {
     localStore = new LocalStore(
       persistence,
-      sharedClientState,
       User.UNAUTHENTICATED,
       new NoOpGarbageCollector()
     );

--- a/packages/firestore/test/unit/local/persistence_test_helpers.ts
+++ b/packages/firestore/test/unit/local/persistence_test_helpers.ts
@@ -68,14 +68,8 @@ export async function testIndexedDbPersistence(
 }
 
 /** Creates and starts a MemoryPersistence instance for testing. */
-export async function testMemoryPersistence(
-  queue?: AsyncQueue,
-  clientId?: ClientId
-): Promise<MemoryPersistence> {
-  queue = queue || new AsyncQueue();
-  clientId = clientId || AutoId.newId();
-
-  const persistence = new MemoryPersistence(queue, clientId);
+export async function testMemoryPersistence(): Promise<MemoryPersistence> {
+  const persistence = new MemoryPersistence(new AsyncQueue(), AutoId.newId());
   await persistence.start();
   return persistence;
 }
@@ -92,33 +86,6 @@ class NoOpSharedClientStateSyncer implements SharedClientStateSyncer {
     return this.activeClients;
   }
 }
-
-/** Creates and starts a WebStorageSharedClientState instance for testing. */
-export async function testWebStorageSharedClientState(
-  queue: AsyncQueue,
-  clientId: ClientId,
-  user: User
-): Promise<WebStorageSharedClientState> {
-  const sharedClientState = new WebStorageSharedClientState(
-    queue,
-    TEST_PERSISTENCE_PREFIX,
-    clientId
-  );
-  sharedClientState.syncEngine = new NoOpSharedClientStateSyncer([clientId]);
-  await sharedClientState.start(user);
-  return sharedClientState;
-}
-
-/** Creates and starts a MemorySharedClientState instance for testing. */
-export async function testMemorySharedClientState(
-  clientId: ClientId,
-  user: User
-): Promise<MemorySharedClientState> {
-  const sharedClientState = new MemorySharedClientState();
-  sharedClientState.syncEngine = new NoOpSharedClientStateSyncer([clientId]);
-  await sharedClientState.start(user);
-  return sharedClientState;
-}
 /**
  * Populates Web Storage with instance data from a pre-existing client.
  */
@@ -133,13 +100,14 @@ export async function populateWebStorage(
   const secondaryClientState = new WebStorageSharedClientState(
     new AsyncQueue(),
     TEST_PERSISTENCE_PREFIX,
-    existingClientId
+    existingClientId,
+    user
   );
 
   secondaryClientState.syncEngine = new NoOpSharedClientStateSyncer([
     existingClientId
   ]);
-  await secondaryClientState.start(user);
+  await secondaryClientState.start();
 
   for (const batchId of existingMutationBatchIds) {
     secondaryClientState.addLocalPendingMutation(batchId);

--- a/packages/firestore/test/unit/local/web_storage_shared_client_state.test.ts
+++ b/packages/firestore/test/unit/local/web_storage_shared_client_state.test.ts
@@ -146,7 +146,8 @@ describe('WebStorageSharedClientState', () => {
     sharedClientState = new WebStorageSharedClientState(
       queue,
       TEST_PERSISTENCE_PREFIX,
-      primaryClientId
+      primaryClientId,
+      AUTHENTICATED_USER
     );
     clientSyncer = new TestSharedClientSyncer([primaryClientId]);
     sharedClientState.syncEngine = clientSyncer;
@@ -213,7 +214,7 @@ describe('WebStorageSharedClientState', () => {
     }
 
     beforeEach(() => {
-      return sharedClientState.start(AUTHENTICATED_USER);
+      return sharedClientState.start();
     });
 
     it('when empty', () => {
@@ -248,7 +249,7 @@ describe('WebStorageSharedClientState', () => {
 
   describe('persists query targets', () => {
     beforeEach(() => {
-      return sharedClientState.start(AUTHENTICATED_USER);
+      return sharedClientState.start();
     });
 
     it('when empty', () => {
@@ -281,7 +282,7 @@ describe('WebStorageSharedClientState', () => {
         )
         .then(() => {
           clientSyncer.activeClients = [primaryClientId, existingClientId];
-          return sharedClientState.start(AUTHENTICATED_USER);
+          return sharedClientState.start();
         });
     });
 
@@ -373,11 +374,15 @@ describe('WebStorageSharedClientState', () => {
   });
 
   describe('processes mutation updates', () => {
+    beforeEach(() => {
+      return sharedClientState.start();
+    });
+
     async function withUser(
       user: User,
       fn: () => Promise<void>
     ): Promise<TestSharedClientState> {
-      await sharedClientState.start(user);
+      await sharedClientState.handleUserChange(user);
       await fn();
       await queue.drain();
       return clientSyncer.sharedClientState;


### PR DESCRIPTION
This PR adds the SharedClientState to FirestoreClient and plumbs it through to LocalStore (where it is currently only used to add new mutation batches to WebStorage). (Spec-)Tests for this will come in the next PR when I start reading these mutations back.

There are two changes in here to make sure the existing tests still work:

- The first part of `handleUserChange` is implemented in the memory-only SharedClientState implementation. This is needed since the Memory Persistence re-uses mutation batch IDs after a user change, which `LocalClientState` doesn't handle.

- IndexedDbPersistence cancels the client metadata refresh, since the LocalStore tests re-use the AysncQueue and fail when multiple clients metadata refreshes are active at the same time.
