### PR TITLE
Small cleanup to FieldValue sentinel code to make it easier to add more sentinels in the future.

### DIFF
--- a/packages/firestore/src/api/field_value.ts
+++ b/packages/firestore/src/api/field_value.ts
@@ -24,12 +24,16 @@ import { makeConstructorPrivate } from '../util/api';
  */
 // tslint:disable-next-line:class-as-namespace  We use this as a base class.
 export abstract class FieldValueImpl implements firestore.FieldValue {
+  protected constructor(readonly methodName: string) {}
+
   static delete(): FieldValueImpl {
     return DeleteFieldValueImpl.instance;
   }
+
   static serverTimestamp(): FieldValueImpl {
     return ServerTimestampFieldValueImpl.instance;
   }
+
   isEqual(other: FieldValueImpl): boolean {
     return this === other;
   }
@@ -37,7 +41,7 @@ export abstract class FieldValueImpl implements firestore.FieldValue {
 
 export class DeleteFieldValueImpl extends FieldValueImpl {
   private constructor() {
-    super();
+    super('FieldValue.delete()');
   }
   /** Singleton instance. */
   static instance = new DeleteFieldValueImpl();
@@ -45,7 +49,7 @@ export class DeleteFieldValueImpl extends FieldValueImpl {
 
 export class ServerTimestampFieldValueImpl extends FieldValueImpl {
   private constructor() {
-    super();
+    super('FieldValue.serverTimestamp()');
   }
   /** Singleton instance. */
   static instance = new ServerTimestampFieldValueImpl();

--- a/packages/firestore/src/api/user_data_converter.ts
+++ b/packages/firestore/src/api/user_data_converter.ts
@@ -584,7 +584,7 @@ export class UserDataConverter {
         new FieldTransform(context.path, ServerTimestampTransform.instance)
       );
     } else {
-      return fail('Unknown FieldValue type: ' + value);
+      fail('Unknown FieldValue type: ' + value);
     }
   }
 }

--- a/packages/firestore/test/integration/api/validation.test.ts
+++ b/packages/firestore/test/integration/api/validation.test.ts
@@ -437,7 +437,8 @@ apiDescribe('Validation:', persistence => {
         return expectSetToFail(
           db,
           { foo: firebase.firestore.FieldValue.delete() },
-          'FieldValue.delete() cannot be used with set() unless you pass {merge:true}'
+          'FieldValue.delete() cannot be used with set() unless you pass ' +
+            '{merge:true} (found in field foo)'
         );
       }
     );

--- a/packages/firestore/test/integration/api/validation.test.ts
+++ b/packages/firestore/test/integration/api/validation.test.ts
@@ -437,7 +437,7 @@ apiDescribe('Validation:', persistence => {
         return expectSetToFail(
           db,
           { foo: firebase.firestore.FieldValue.delete() },
-          'FieldValue.delete() can only be used with update() and set() with {merge:true} (found in field foo)'
+          'FieldValue.delete() cannot be used with set() unless you pass {merge:true}'
         );
       }
     );


### PR DESCRIPTION
This technically includes a small breaking change. Before we would allow you to do:

`doc.set({a: [0, FieldValue.delete(), 2] }, {merge: true})`

Which ended up equivalent to:

`doc.set({a: [0, null, 2] }, {merge: true})`

But with my change it will now result in an error:

`FieldValue.delete() is not currently supported inside arrays.`

Let me know if you think that's an issue. I can rework it but I don't think the existing behavior was particularly useful or intentional.