### PR TITLE
WIP: Moving RemoteStore to SyncEngine

### DIFF
--- a/packages/firestore/src/core/event_manager.ts
+++ b/packages/firestore/src/core/event_manager.ts
@@ -57,7 +57,8 @@ export class EventManager {
   constructor(private syncEngine: SyncEngine) {
     this.syncEngine.subscribe(
       this.onChange.bind(this),
-      this.onError.bind(this)
+      this.onError.bind(this),
+        this.applyOnlineStateChange
     );
   }
 

--- a/packages/firestore/src/core/event_manager.ts
+++ b/packages/firestore/src/core/event_manager.ts
@@ -58,7 +58,7 @@ export class EventManager {
     this.syncEngine.subscribe(
       this.onChange.bind(this),
       this.onError.bind(this),
-        this.applyOnlineStateChange
+      this.applyOnlineStateChange
     );
   }
 

--- a/packages/firestore/src/core/firestore_client.ts
+++ b/packages/firestore/src/core/firestore_client.ts
@@ -260,7 +260,7 @@ export class FirestoreClient {
    * has been obtained from the credential provider and some persistence
    * implementation is available in this.persistence.
    */
-   private initializeRest(user: User): Promise<void> {
+  private initializeRest(user: User): Promise<void> {
     return this.platform
       .loadConnection(this.databaseInfo)
       .then(async connection => {
@@ -279,11 +279,7 @@ export class FirestoreClient {
           serializer
         );
 
-        this.syncEngine = new SyncEngine(
-          this.localStore,
-          datastore,
-          user
-        );
+        this.syncEngine = new SyncEngine(this.localStore, datastore, user);
 
         this.eventMgr = new EventManager(this.syncEngine);
 
@@ -309,13 +305,12 @@ export class FirestoreClient {
   }
 
   shutdown(): Promise<void> {
-    return this.asyncQueue
-      .enqueue(async () => {
-        this.credentials.removeUserChangeListener();
-        // PORTING NOTE: LocalStore does not need an explicit shutdown on web.
-        await this.syncEngine.shutdown();
-        await this.persistence.shutdown();
-      });
+    return this.asyncQueue.enqueue(async () => {
+      this.credentials.removeUserChangeListener();
+      // PORTING NOTE: LocalStore does not need an explicit shutdown on web.
+      await this.syncEngine.shutdown();
+      await this.persistence.shutdown();
+    });
   }
 
   listen(

--- a/packages/firestore/src/core/firestore_client.ts
+++ b/packages/firestore/src/core/firestore_client.ts
@@ -64,7 +64,6 @@ export class FirestoreClient {
   private garbageCollector: GarbageCollector;
   private persistence: Persistence;
   private localStore: LocalStore;
-  private remoteStore: RemoteStore;
   private syncEngine: SyncEngine;
 
   constructor(
@@ -163,7 +162,7 @@ export class FirestoreClient {
   /** Enables the network connection and requeues all pending operations. */
   enableNetwork(): Promise<void> {
     return this.asyncQueue.enqueue(() => {
-      return this.remoteStore.enableNetwork();
+      return this.syncEngine.enableNetwork();
     });
   }
 
@@ -261,10 +260,10 @@ export class FirestoreClient {
    * has been obtained from the credential provider and some persistence
    * implementation is available in this.persistence.
    */
-  private initializeRest(user: User): Promise<void> {
+   private initializeRest(user: User): Promise<void> {
     return this.platform
       .loadConnection(this.databaseInfo)
-      .then(connection => {
+      .then(async connection => {
         this.localStore = new LocalStore(
           this.persistence,
           user,
@@ -280,36 +279,18 @@ export class FirestoreClient {
           serializer
         );
 
-        const onlineStateChangedHandler = (onlineState: OnlineState) => {
-          this.syncEngine.applyOnlineStateChange(onlineState);
-          this.eventMgr.applyOnlineStateChange(onlineState);
-        };
-
-        this.remoteStore = new RemoteStore(
-          this.localStore,
-          datastore,
-          this.asyncQueue,
-          onlineStateChangedHandler
-        );
-
         this.syncEngine = new SyncEngine(
           this.localStore,
-          this.remoteStore,
+          datastore,
           user
         );
 
-        // Setup wiring between sync engine and remote store
-        this.remoteStore.syncEngine = this.syncEngine;
-
         this.eventMgr = new EventManager(this.syncEngine);
 
-        // NOTE: RemoteStore depends on LocalStore (for persisting stream
-        // tokens, refilling mutation queue, etc.) so must be started after
-        // LocalStore.
-        return this.localStore.start();
-      })
-      .then(() => {
-        return this.remoteStore.start();
+        // NOTE: SyncEngine depends on LocalStore (through its dependency on
+        // RemoteStore) so must be started after LocalStore.
+        await this.localStore.start();
+        await this.syncEngine.start();
       });
   }
 
@@ -323,19 +304,17 @@ export class FirestoreClient {
   /** Disables the network connection. Pending operations will not complete. */
   disableNetwork(): Promise<void> {
     return this.asyncQueue.enqueue(() => {
-      return this.remoteStore.disableNetwork();
+      return this.syncEngine.disableNetwork();
     });
   }
 
   shutdown(): Promise<void> {
     return this.asyncQueue
-      .enqueue(() => {
+      .enqueue(async () => {
         this.credentials.removeUserChangeListener();
-        return this.remoteStore.shutdown();
-      })
-      .then(() => {
         // PORTING NOTE: LocalStore does not need an explicit shutdown on web.
-        return this.persistence.shutdown();
+        await this.syncEngine.shutdown();
+        await this.persistence.shutdown();
       });
   }
 

--- a/packages/firestore/src/core/sync_engine.ts
+++ b/packages/firestore/src/core/sync_engine.ts
@@ -51,14 +51,14 @@ import {
   ViewDocumentChanges
 } from './view';
 import { ViewSnapshot } from './view_snapshot';
-import {Datastore} from '../remote/datastore';
-import {EventManager} from './event_manager';
+import { Datastore } from '../remote/datastore';
+import { EventManager } from './event_manager';
 
 const LOG_TAG = 'SyncEngine';
 
 export type ViewHandler = (viewSnaps: ViewSnapshot[]) => void;
 export type ErrorHandler = (query: Query, error: Error) => void;
-export type OnlineStateHandler = (onlineState:OnlineState) => void;
+export type OnlineStateHandler = (onlineState: OnlineState) => void;
 
 /**
  * QueryView contains all of the data that SyncEngine needs to keep track of for
@@ -73,22 +73,21 @@ class QueryView {
      * and applies the query filters and limits to determine the most correct
      * possible results.
      */
-    public readonly  view: View
+    public readonly view: View
   ) {}
 
   /**
    * The query itself.
    */
-  get query() : Query {
+  get query(): Query {
     return this.queryData.query;
   }
-
 
   /**
    * The target number created by the client that is used in the watch
    * stream to identify this query.
    */
-  get targetId() : TargetId {
+  get targetId(): TargetId {
     return this.queryData.targetId;
   }
 
@@ -97,7 +96,7 @@ class QueryView {
    * of the results that was received. This can be used to indicate where
    * to continue receiving new doc changes for the query.
    */
-  get resumeToken() : ProtoByteString {
+  get resumeToken(): ProtoByteString {
     return this.queryData.resumeToken;
   }
 }
@@ -147,7 +146,11 @@ export class SyncEngine implements RemoteSyncer {
   ) {}
 
   /** Subscribes view and error handler. Can be called only once. */
-  subscribe(viewHandler: ViewHandler, errorHandler: ErrorHandler, onlineStateHandler: OnlineStateHandler): void {
+  subscribe(
+    viewHandler: ViewHandler,
+    errorHandler: ErrorHandler,
+    onlineStateHandler: OnlineStateHandler
+  ): void {
     assert(
       viewHandler !== null && errorHandler !== null,
       'View and error handlers cannot be null'
@@ -193,10 +196,7 @@ export class SyncEngine implements RemoteSyncer {
                 'applyChanges for new view should always return a snapshot'
               );
 
-              const data = new QueryView(
-                queryData,
-                view
-              );
+              const data = new QueryView(queryData, view);
               this.queryViewsByQuery.set(query, data);
               this.queryViewsByTarget[queryData.targetId] = data;
               this.viewHandler!([viewChange.snapshot!]);
@@ -535,7 +535,7 @@ export class SyncEngine implements RemoteSyncer {
       this.limboKeysByTarget[limboTargetId] = key;
       if (this.remoteStore) {
         this.remoteStore.listen(
-            new QueryData(query, limboTargetId, QueryPurpose.Listen)
+          new QueryData(query, limboTargetId, QueryPurpose.Listen)
         );
       }
       this.limboTargetsByKey = this.limboTargetsByKey.insert(
@@ -648,11 +648,14 @@ export class SyncEngine implements RemoteSyncer {
   }
 
   private initRemoteStore() {
-    this.remoteStore = this.datastore.newRemoteStore(this.localStore, this.applyOnlineStateChange);
+    this.remoteStore = this.datastore.newRemoteStore(
+      this.localStore,
+      this.applyOnlineStateChange
+    );
     this.remoteStore.syncEngine = this;
     this.remoteStore.start(this.networkEnabled);
 
-    objUtils.forEach(this.queryViewsByTarget , (key, queryView) => {
+    objUtils.forEach(this.queryViewsByTarget, (key, queryView) => {
       this.remoteStore.listen(queryView.queryData);
     });
   }
@@ -667,20 +670,20 @@ export class SyncEngine implements RemoteSyncer {
     }
   }
 
-  async enableNetwork() : Promise<void> {
+  async enableNetwork(): Promise<void> {
     if (this.remoteStore) {
       return this.remoteStore.enableNetwork();
     }
   }
 
-  async disableNetwork(): Promise<void>  {
+  async disableNetwork(): Promise<void> {
     if (this.remoteStore) {
       return this.remoteStore.disableNetwork();
     }
   }
 
   // TEST ONLY
-  numOutstandingWrites() :number {
+  numOutstandingWrites(): number {
     // TODO: UPDATE COMMENT
     //
     // Make sure to execute all writes that are currently queued. This allows us

--- a/packages/firestore/src/core/sync_engine.ts
+++ b/packages/firestore/src/core/sync_engine.ts
@@ -51,11 +51,14 @@ import {
   ViewDocumentChanges
 } from './view';
 import { ViewSnapshot } from './view_snapshot';
+import {Datastore} from '../remote/datastore';
+import {EventManager} from './event_manager';
 
 const LOG_TAG = 'SyncEngine';
 
 export type ViewHandler = (viewSnaps: ViewSnapshot[]) => void;
 export type ErrorHandler = (query: Query, error: Error) => void;
+export type OnlineStateHandler = (onlineState:OnlineState) => void;
 
 /**
  * QueryView contains all of the data that SyncEngine needs to keep track of for
@@ -63,29 +66,40 @@ export type ErrorHandler = (query: Query, error: Error) => void;
  */
 class QueryView {
   constructor(
-    /**
-     * The query itself.
-     */
-    public query: Query,
-    /**
-     * The target number created by the client that is used in the watch
-     * stream to identify this query.
-     */
-    public targetId: TargetId,
-    /**
-     * An identifier from the datastore backend that indicates the last state
-     * of the results that was received. This can be used to indicate where
-     * to continue receiving new doc changes for the query.
-     */
-    public resumeToken: ProtoByteString,
+    public readonly queryData: QueryData,
     /**
      * The view is responsible for computing the final merged truth of what
      * docs are in the query. It gets notified of local and remote changes,
      * and applies the query filters and limits to determine the most correct
      * possible results.
      */
-    public view: View
+    public readonly  view: View
   ) {}
+
+  /**
+   * The query itself.
+   */
+  get query() : Query {
+    return this.queryData.query;
+  }
+
+
+  /**
+   * The target number created by the client that is used in the watch
+   * stream to identify this query.
+   */
+  get targetId() : TargetId {
+    return this.queryData.targetId;
+  }
+
+  /**
+   * An identifier from the datastore backend that indicates the last state
+   * of the results that was received. This can be used to indicate where
+   * to continue receiving new doc changes for the query.
+   */
+  get resumeToken() : ProtoByteString {
+    return this.queryData.resumeToken;
+  }
 }
 
 /**
@@ -103,8 +117,12 @@ class QueryView {
  * global async queue.
  */
 export class SyncEngine implements RemoteSyncer {
+  private remoteStore: RemoteStore | null = null;
   private viewHandler: ViewHandler | null = null;
   private errorHandler: ErrorHandler | null = null;
+  private onlineStateHandler: OnlineStateHandler | null = null;
+
+  private networkEnabled = false;
 
   private queryViewsByQuery = new ObjectMap<Query, QueryView>(q =>
     q.canonicalId()
@@ -124,12 +142,12 @@ export class SyncEngine implements RemoteSyncer {
 
   constructor(
     private localStore: LocalStore,
-    private remoteStore: RemoteStore,
+    private datastore: Datastore,
     private currentUser: User
   ) {}
 
   /** Subscribes view and error handler. Can be called only once. */
-  subscribe(viewHandler: ViewHandler, errorHandler: ErrorHandler): void {
+  subscribe(viewHandler: ViewHandler, errorHandler: ErrorHandler, onlineStateHandler: OnlineStateHandler): void {
     assert(
       viewHandler !== null && errorHandler !== null,
       'View and error handlers cannot be null'
@@ -140,6 +158,7 @@ export class SyncEngine implements RemoteSyncer {
     );
     this.viewHandler = viewHandler;
     this.errorHandler = errorHandler;
+    this.onlineStateHandler = onlineStateHandler;
     this.limboCollector.addGarbageSource(this.limboDocumentRefs);
   }
 
@@ -175,15 +194,16 @@ export class SyncEngine implements RemoteSyncer {
               );
 
               const data = new QueryView(
-                query,
-                queryData.targetId,
-                queryData.resumeToken,
+                queryData,
                 view
               );
               this.queryViewsByQuery.set(query, data);
               this.queryViewsByTarget[queryData.targetId] = data;
               this.viewHandler!([viewChange.snapshot!]);
-              this.remoteStore.listen(queryData);
+
+              if (this.remoteStore) {
+                this.remoteStore.listen(queryData);
+              }
             });
         })
         .then(() => {
@@ -200,7 +220,9 @@ export class SyncEngine implements RemoteSyncer {
     assert(!!queryView, 'Trying to unlisten on query not found:' + query);
 
     return this.localStore.releaseQuery(query).then(() => {
-      this.remoteStore.unlisten(queryView.targetId);
+      if (this.remoteStore) {
+        this.remoteStore.unlisten(queryView.targetId);
+      }
       return this.removeAndCleanupQuery(queryView).then(() => {
         return this.localStore.collectGarbage();
       });
@@ -226,7 +248,9 @@ export class SyncEngine implements RemoteSyncer {
         return this.emitNewSnapsAndNotifyLocalStore(result.changes);
       })
       .then(() => {
-        return this.remoteStore.fillWritePipeline();
+        if (this.remoteStore) {
+          return this.remoteStore.fillWritePipeline();
+        }
       });
   }
 
@@ -257,7 +281,7 @@ export class SyncEngine implements RemoteSyncer {
     retries = 5
   ): Promise<T> {
     assert(retries >= 0, 'Got negative number of retries for transaction.');
-    const transaction = this.remoteStore.createTransaction();
+    const transaction = new Transaction(this.datastore);
     const wrappedUpdateFunction = () => {
       try {
         const userPromise = updateFunction(transaction);
@@ -348,6 +372,7 @@ export class SyncEngine implements RemoteSyncer {
    * the change.
    */
   applyOnlineStateChange(onlineState: OnlineState) {
+    this.assertSubscribed('applyOnlineStateChange()');
     const newViewSnapshots = [] as ViewSnapshot[];
     this.queryViewsByQuery.forEach((query, queryView) => {
       const viewChange = queryView.view.applyOnlineStateChange(onlineState);
@@ -360,6 +385,7 @@ export class SyncEngine implements RemoteSyncer {
       }
     });
     this.viewHandler(newViewSnapshots);
+    this.onlineStateHandler!(onlineState);
   }
 
   rejectListen(targetId: TargetId, err: FirestoreError): Promise<void> {
@@ -507,9 +533,11 @@ export class SyncEngine implements RemoteSyncer {
       const limboTargetId = this.targetIdGenerator.next();
       const query = Query.atPath(key.path);
       this.limboKeysByTarget[limboTargetId] = key;
-      this.remoteStore.listen(
-        new QueryData(query, limboTargetId, QueryPurpose.Listen)
-      );
+      if (this.remoteStore) {
+        this.remoteStore.listen(
+            new QueryData(query, limboTargetId, QueryPurpose.Listen)
+        );
+      }
       this.limboTargetsByKey = this.limboTargetsByKey.insert(
         key,
         limboTargetId
@@ -529,7 +557,9 @@ export class SyncEngine implements RemoteSyncer {
             // This target already got removed, because the query failed.
             return;
           }
-          this.remoteStore.unlisten(limboTargetId);
+          if (this.remoteStore) {
+            this.remoteStore.unlisten(limboTargetId);
+          }
           this.limboTargetsByKey = this.limboTargetsByKey.remove(key);
           delete this.limboKeysByTarget[limboTargetId];
         });
@@ -615,5 +645,47 @@ export class SyncEngine implements RemoteSyncer {
       .then(() => {
         return this.remoteStore.handleUserChange(user);
       });
+  }
+
+  private initRemoteStore() {
+    this.remoteStore = this.datastore.newRemoteStore(this.localStore, this.applyOnlineStateChange);
+    this.remoteStore.syncEngine = this;
+    this.remoteStore.start(this.networkEnabled);
+
+    objUtils.forEach(this.queryViewsByTarget , (key, queryView) => {
+      this.remoteStore.listen(queryView.queryData);
+    });
+  }
+
+  start() {
+    this.initRemoteStore();
+  }
+
+  shutdown() {
+    if (this.remoteStore) {
+      this.remoteStore.shutdown();
+    }
+  }
+
+  async enableNetwork() : Promise<void> {
+    if (this.remoteStore) {
+      return this.remoteStore.enableNetwork();
+    }
+  }
+
+  async disableNetwork(): Promise<void>  {
+    if (this.remoteStore) {
+      return this.remoteStore.disableNetwork();
+    }
+  }
+
+  // TEST ONLY
+  numOutstandingWrites() :number {
+    // TODO: UPDATE COMMENT
+    //
+    // Make sure to execute all writes that are currently queued. This allows us
+    // to assert on the total number of requests sent before shutdown.
+    this.remoteStore.fillWritePipeline();
+    return this.remoteStore.outstandingWrites();
   }
 }

--- a/packages/firestore/src/core/sync_engine.ts
+++ b/packages/firestore/src/core/sync_engine.ts
@@ -117,11 +117,12 @@ class QueryView {
  */
 export class SyncEngine implements RemoteSyncer {
   private remoteStore: RemoteStore | null = null;
+
   private viewHandler: ViewHandler | null = null;
   private errorHandler: ErrorHandler | null = null;
   private onlineStateHandler: OnlineStateHandler | null = null;
 
-  private networkEnabled = false;
+  private networkEnabled = true;
 
   private queryViewsByQuery = new ObjectMap<Query, QueryView>(q =>
     q.canonicalId()
@@ -671,24 +672,31 @@ export class SyncEngine implements RemoteSyncer {
   }
 
   async enableNetwork(): Promise<void> {
+    this.networkEnabled = true;
     if (this.remoteStore) {
-      return this.remoteStore.enableNetwork();
+      return this.remoteStore!.enableNetwork();
     }
   }
 
   async disableNetwork(): Promise<void> {
+    this.networkEnabled = false;
     if (this.remoteStore) {
-      return this.remoteStore.disableNetwork();
+      return this.remoteStore!.disableNetwork();
     }
   }
 
   // TEST ONLY
   numOutstandingWrites(): number {
-    // TODO: UPDATE COMMENT
-    //
-    // Make sure to execute all writes that are currently queued. This allows us
-    // to assert on the total number of requests sent before shutdown.
-    this.remoteStore.fillWritePipeline();
-    return this.remoteStore.outstandingWrites();
+    if (this.remoteStore) {
+      // TODO: UPDATE COMMENT
+      //
+      // Make sure to execute all writes that are currently queued. This allows us
+      // to assert on the total number of requests sent before shutdown.
+      this.remoteStore.fillWritePipeline();
+      return this.remoteStore.outstandingWrites();
+    } else {
+      // or throw?
+      return 0;
+    }
   }
 }

--- a/packages/firestore/src/remote/datastore.ts
+++ b/packages/firestore/src/remote/datastore.ts
@@ -29,10 +29,10 @@ import {
   PersistentWriteStream
 } from './persistent_stream';
 import { JsonProtoSerializer } from './serializer';
-import {RemoteStore} from './remote_store';
-import {LocalStore} from '../local/local_store';
-import {OnlineStateTracker} from './online_state_tracker';
-import {OnlineState} from '../core/types';
+import { RemoteStore } from './remote_store';
+import { LocalStore } from '../local/local_store';
+import { OnlineStateTracker } from './online_state_tracker';
+import { OnlineState } from '../core/types';
 
 // The generated proto interfaces for these class are missing the database
 // field. So we add it here.
@@ -75,7 +75,10 @@ export class Datastore {
     );
   }
 
-  newRemoteStore(localStore:LocalStore, onlineStateHandler: (onlineState: OnlineState) => void):RemoteStore {
+  newRemoteStore(
+    localStore: LocalStore,
+    onlineStateHandler: (onlineState: OnlineState) => void
+  ): RemoteStore {
     return new RemoteStore(localStore, this, this.queue, onlineStateHandler);
   }
 

--- a/packages/firestore/src/remote/datastore.ts
+++ b/packages/firestore/src/remote/datastore.ts
@@ -29,6 +29,10 @@ import {
   PersistentWriteStream
 } from './persistent_stream';
 import { JsonProtoSerializer } from './serializer';
+import {RemoteStore} from './remote_store';
+import {LocalStore} from '../local/local_store';
+import {OnlineStateTracker} from './online_state_tracker';
+import {OnlineState} from '../core/types';
 
 // The generated proto interfaces for these class are missing the database
 // field. So we add it here.
@@ -69,6 +73,10 @@ export class Datastore {
       this.credentials,
       this.serializer
     );
+  }
+
+  newRemoteStore(localStore:LocalStore, onlineStateHandler: (onlineState: OnlineState) => void):RemoteStore {
+    return new RemoteStore(localStore, this, this.queue, onlineStateHandler);
   }
 
   commit(mutations: Mutation[]): Promise<MutationResult[]> {

--- a/packages/firestore/src/remote/remote_store.ts
+++ b/packages/firestore/src/remote/remote_store.ts
@@ -138,8 +138,10 @@ export class RemoteStore {
    * Starts up the remote store, creating streams, restoring state from
    * LocalStore, etc.
    */
-  start(): Promise<void> {
-    return this.enableNetwork();
+  async start(networkEnabled): Promise<void> {
+    if (networkEnabled) {
+      return this.enableNetwork();
+    }
   }
 
   private isNetworkEnabled(): boolean {
@@ -736,10 +738,6 @@ export class RemoteStore {
     } else {
       // Transient error, just let the retry logic kick in.
     }
-  }
-
-  createTransaction(): Transaction {
-    return new Transaction(this.datastore);
   }
 
   handleUserChange(user: User): Promise<void> {


### PR DESCRIPTION
This moves the ownership of RemoteStore to SyncEngine and makes SyncEngine keep track of all active QueryData.