### PR TITLE
 Fix a bug that was introduced in PR: #591

### DIFF
--- a/packages/messaging/src/controllers/controller-interface.ts
+++ b/packages/messaging/src/controllers/controller-interface.ts
@@ -80,6 +80,8 @@ export default class ControllerInterface {
 
     const swReg = await this.getSWRegistration_();
     const publicVapidKey = await this.getPublicVapidKey_();
+    // If there didn't exist one, this call will subscribe a new
+    // push subscription.
     const pushSubscription = await this.getPushSubscription(
       swReg,
       publicVapidKey
@@ -134,8 +136,10 @@ export default class ControllerInterface {
     }
 
     // If the token is no longer valid (for example if the VAPID details
-    // have changed), delete the existing token, and create a new one.
-    await this.deleteToken(tokenDetails['fcmToken']);
+    // have changed), delete the existing token from the FCM client and server
+    // database. No need to unsubscribe from the Service Worker as we have a
+    // good push subscription that we'd like to use in getNewToken.
+    await this.deleteTokenFromDB(tokenDetails['fcmToken']);
     return this.getNewToken(swReg, pushSubscription, publicVapidKey);
   }
 
@@ -228,29 +232,33 @@ export default class ControllerInterface {
    * whether or not the unsubscribe request was processed successfully.
    * @export
    */
-  deleteToken(token: string): Promise<Boolean> {
-    return this.tokenDetailsModel_
-      .deleteToken(token)
-      .then(details => {
-        return this.iidModel_.deleteToken(
-          details['fcmSenderId'],
-          details['fcmToken'],
-          details['fcmPushSet']
-        );
-      })
-      .then(() => {
-        return this.getSWRegistration_()
-          .then(registration => {
-            if (registration) {
-              return registration.pushManager.getSubscription();
-            }
-          })
-          .then(subscription => {
-            if (subscription) {
-              return subscription.unsubscribe();
-            }
-          });
-      });
+  async deleteToken(token: string): Promise<Boolean> {
+    // Delete the token details from the database.
+    await this.deleteTokenFromDB(token);
+    // Unsubscribe from the SW.
+    const registration = await this.getSWRegistration_();
+    if (registration) {
+      const pushSubscription = await registration.pushManager.getSubscription();
+      if (pushSubscription) {
+        return pushSubscription.unsubscribe();
+      }
+    }
+    // If there's no SW, consider it a success.
+    return true;
+  }
+
+  /**
+   * This method will delete the token from the client database, and make a
+   * call to FCM to remove it from the server DB. Does not temper with the
+   * push subscription.
+   */
+  private async deleteTokenFromDB(token: string): Promise<void> {
+    const details = await this.tokenDetailsModel_.deleteToken(token);
+    await this.iidModel_.deleteToken(
+      details['fcmSenderId'],
+      details['fcmToken'],
+      details['fcmPushSet']
+    );
   }
 
   getSWRegistration_(): Promise<ServiceWorkerRegistration> {

--- a/packages/messaging/src/controllers/controller-interface.ts
+++ b/packages/messaging/src/controllers/controller-interface.ts
@@ -80,8 +80,8 @@ export default class ControllerInterface {
 
     const swReg = await this.getSWRegistration_();
     const publicVapidKey = await this.getPublicVapidKey_();
-    // If there didn't exist one, this call will subscribe a new
-    // push subscription.
+    // If a PushSubscription exists it's returned, otherwise a new subscription
+    // is generated and returned.
     const pushSubscription = await this.getPushSubscription(
       swReg,
       publicVapidKey
@@ -269,14 +269,6 @@ export default class ControllerInterface {
     throw this.errorFactory_.create(Errors.codes.SHOULD_BE_INHERITED);
   }
 
-  //
-  // The following methods should only be available in the window.
-  //
-
-  requestPermission() {
-    throw this.errorFactory_.create(Errors.codes.AVAILABLE_IN_WINDOW);
-  }
-
   /**
    * Gets a PushSubscription for the current user.
    */
@@ -294,6 +286,14 @@ export default class ControllerInterface {
         applicationServerKey: publicVapidKey
       });
     });
+  }
+
+  //
+  // The following methods should only be available in the window.
+  //
+
+  requestPermission() {
+    throw this.errorFactory_.create(Errors.codes.AVAILABLE_IN_WINDOW);
   }
 
   /**

--- a/packages/polyfill/src/polyfills/promise.ts
+++ b/packages/polyfill/src/polyfills/promise.ts
@@ -30,7 +30,5 @@ const __global = (() => {
 // Polyfill Promise
 if (typeof Promise === 'undefined') {
   // HACK: TS throws an error if I attempt to use 'dot-notation'
-  __global[
-    'Promise'
-  ] = require('promise-polyfill') as PromiseConstructor;
+  __global['Promise'] = require('promise-polyfill') as PromiseConstructor;
 }


### PR DESCRIPTION
Basically when the permissions are revoked and restored, do not unsubscribe from the PushSubscription, as we're using a brand new one.

Just remove the token from DB and from FCM server DB.