### PR TITLE
Adding .skip and .only for validation tests

### DIFF
--- a/packages/firestore/test/integration/api/validation.test.ts
+++ b/packages/firestore/test/integration/api/validation.test.ts
@@ -30,45 +30,52 @@ import {
 // We're using 'as any' to pass invalid values to APIs for testing purposes.
 // tslint:disable:no-any
 
+interface ValidationIt  {
+  (persistence: boolean, message: string, testFunction: (db: firestore.FirebaseFirestore) => void | Promise<any>) : void,
+  skip:  (persistence: boolean,
+          message: string,
+          testFunction: (db: firestore.FirebaseFirestore) => void | Promise<any>) => void,
+  only:  (persistence: boolean,
+          message: string,
+          testFunction: (db: firestore.FirebaseFirestore) => void | Promise<any>) => void
+}
+
 // Since most of our tests are "synchronous" but require a Firestore instance,
 // we have a helper wrapper around it() and withTestDb() to optimize for that.
-const validationIt: any = function(
-  persistence: boolean,
-  message: string,
-  testFunction: (db: firestore.FirebaseFirestore) => void | Promise<any>
-) {
-  it(message, () => {
-    return withTestDb(persistence, async db => {
-      const maybePromise = testFunction(db);
-      if (maybePromise) {
-        return maybePromise;
+const validationIt: ValidationIt = Object.assign(
+ (persistence: boolean,
+      message: string,
+      testFunction: (db: firestore.FirebaseFirestore) => void | Promise<any>) => {
+   it(message, () => {
+     return withTestDb(persistence, async db => {
+       const maybePromise = testFunction(db);
+       if (maybePromise) {
+         return maybePromise;
+       }
+     });
+   });
+ },
+    {
+      skip: function (persistence: boolean,
+                      message: string,
+                      _: (db: firestore.FirebaseFirestore) => void | Promise<any>) {
+        it.skip(message, () => {
+        });
+      },
+      only: function (persistence: boolean,
+                      message: string,
+                      testFunction: (db: firestore.FirebaseFirestore) => void | Promise<any>) {
+        it.only(message, () => {
+          return withTestDb(persistence, async db => {
+            const maybePromise = testFunction(db);
+            if (maybePromise) {
+              return maybePromise;
+            }
+          });
+        });
       }
-    });
-  });
-};
-
-validationIt.skip = function(
-  persistence: boolean,
-  message: string,
-  _: (db: firestore.FirebaseFirestore) => void | Promise<any>
-) {
-  it.skip(message, () => {});
-};
-
-validationIt.only = function(
-  persistence: boolean,
-  message: string,
-  testFunction: (db: firestore.FirebaseFirestore) => void | Promise<any>
-) {
-  it.only(message, () => {
-    return withTestDb(persistence, async db => {
-      const maybePromise = testFunction(db);
-      if (maybePromise) {
-        return maybePromise;
-      }
-    });
-  });
-};
+    }
+ );
 
 // NOTE: The JS SDK does extensive validation of argument counts, types, etc.
 // since it is an untyped language. These tests are not exhaustive as that would

--- a/packages/firestore/test/integration/api/validation.test.ts
+++ b/packages/firestore/test/integration/api/validation.test.ts
@@ -32,7 +32,7 @@ import {
 
 // Since most of our tests are "synchronous" but require a Firestore instance,
 // we have a helper wrapper around it() and withTestDb() to optimize for that.
-const validationIt : any = function(
+const validationIt: any = function(
   persistence: boolean,
   message: string,
   testFunction: (db: firestore.FirebaseFirestore) => void | Promise<any>
@@ -48,17 +48,17 @@ const validationIt : any = function(
 };
 
 validationIt.skip = function(
-    persistence: boolean,
-    message: string,
-    _: (db: firestore.FirebaseFirestore) => void | Promise<any>
+  persistence: boolean,
+  message: string,
+  _: (db: firestore.FirebaseFirestore) => void | Promise<any>
 ) {
   it.skip(message, () => {});
 };
 
-validationIt.only =  function(
-    persistence: boolean,
-    message: string,
-    testFunction: (db: firestore.FirebaseFirestore) => void | Promise<any>
+validationIt.only = function(
+  persistence: boolean,
+  message: string,
+  testFunction: (db: firestore.FirebaseFirestore) => void | Promise<any>
 ) {
   it.only(message, () => {
     return withTestDb(persistence, async db => {

--- a/packages/firestore/test/integration/api/validation.test.ts
+++ b/packages/firestore/test/integration/api/validation.test.ts
@@ -32,7 +32,7 @@ import {
 
 // Since most of our tests are "synchronous" but require a Firestore instance,
 // we have a helper wrapper around it() and withTestDb() to optimize for that.
-function validationIt(
+const validationIt : any = function(
   persistence: boolean,
   message: string,
   testFunction: (db: firestore.FirebaseFirestore) => void | Promise<any>
@@ -45,7 +45,30 @@ function validationIt(
       }
     });
   });
-}
+};
+
+validationIt.skip = function(
+    persistence: boolean,
+    message: string,
+    _: (db: firestore.FirebaseFirestore) => void | Promise<any>
+) {
+  it.skip(message, () => {});
+};
+
+validationIt.only =  function(
+    persistence: boolean,
+    message: string,
+    testFunction: (db: firestore.FirebaseFirestore) => void | Promise<any>
+) {
+  it.only(message, () => {
+    return withTestDb(persistence, async db => {
+      const maybePromise = testFunction(db);
+      if (maybePromise) {
+        return maybePromise;
+      }
+    });
+  });
+};
 
 // NOTE: The JS SDK does extensive validation of argument counts, types, etc.
 // since it is an untyped language. These tests are not exhaustive as that would

--- a/packages/polyfill/src/polyfills/promise.ts
+++ b/packages/polyfill/src/polyfills/promise.ts
@@ -30,7 +30,5 @@ const __global = (() => {
 // Polyfill Promise
 if (typeof Promise === 'undefined') {
   // HACK: TS throws an error if I attempt to use 'dot-notation'
-  __global[
-    'Promise'
-  ] = require('promise-polyfill') as PromiseConstructor;
+  __global['Promise'] = require('promise-polyfill') as PromiseConstructor;
 }


### PR DESCRIPTION
This add mocha-like .skip and .only functions to validationIt. I am not sure if this can be done without the 'any' keyword, as validationIt is now both a function and an object.

As always, this also contains unrelated prettier changes :)