### PR TITLE
automaticDataCollectionEnabled Flag

### DIFF
--- a/packages/app-types/index.d.ts
+++ b/packages/app-types/index.d.ts
@@ -57,6 +57,16 @@ export interface FirebaseNamespace {
    * Create (and initialize) a FirebaseApp.
    *
    * @param options Options to configure the services used in the App.
+   * @param config The optional config for your firebase app
+   */
+  initializeApp(
+    options: FirebaseOptions,
+    config?: FirebaseAppConfig
+  ): FirebaseApp;
+  /**
+   * Create (and initialize) a FirebaseApp.
+   *
+   * @param options Options to configure the services used in the App.
    * @param name The optional name of the app to initialize ('[DEFAULT]' if
    * omitted)
    */

--- a/packages/app-types/index.d.ts
+++ b/packages/app-types/index.d.ts
@@ -24,6 +24,11 @@ export type FirebaseOptions = {
   [name: string]: any;
 };
 
+export interface FirebaseAppConfig {
+  name?: string;
+  automaticDataCollectionEnabled?: boolean;
+}
+
 export class FirebaseApp {
   /**
    * The (read-only) name (identifier) for this App. '[DEFAULT]' is the default
@@ -35,6 +40,11 @@ export class FirebaseApp {
    * The (read-only) configuration options from the app initialization.
    */
   options: FirebaseOptions;
+
+  /**
+   * The settable config flag for GDPR opt-in/opt-out
+   */
+  automaticDataCollectionEnabled: boolean;
 
   /**
    * Make the given App unusable and free resources.

--- a/packages/app/src/firebaseApp.ts
+++ b/packages/app/src/firebaseApp.ts
@@ -72,7 +72,8 @@ class FirebaseAppImpl implements FirebaseApp {
     private firebase_: FirebaseNamespace
   ) {
     this.name_ = config.name;
-    this._automaticDataCollectionEnabled = config.automaticDataCollectionEnabled || false;
+    this._automaticDataCollectionEnabled =
+      config.automaticDataCollectionEnabled || false;
     this.options_ = deepCopy<FirebaseOptions>(options);
     this.INTERNAL = {
       getUid: () => null,
@@ -298,7 +299,10 @@ export function createFirebaseNamespace(): FirebaseNamespace {
   /**
    * Create a new App instance (name must be unique).
    */
-  function initializeApp(options: FirebaseOptions, config?: FirebaseAppConfig): FirebaseApp;
+  function initializeApp(
+    options: FirebaseOptions,
+    config?: FirebaseAppConfig
+  ): FirebaseApp;
   function initializeApp(options: FirebaseOptions, name?: string): FirebaseApp;
   function initializeApp(options: FirebaseOptions, rawConfig = {}) {
     if (typeof rawConfig !== 'object' || rawConfig === null) {

--- a/packages/app/src/firebaseApp.ts
+++ b/packages/app/src/firebaseApp.ts
@@ -17,7 +17,8 @@
 import {
   FirebaseApp,
   FirebaseOptions,
-  FirebaseNamespace
+  FirebaseNamespace,
+  FirebaseAppConfig
 } from '@firebase/app-types';
 import {
   _FirebaseApp,
@@ -61,15 +62,17 @@ class FirebaseAppImpl implements FirebaseApp {
       [serviceName: string]: FirebaseService;
     };
   } = {};
+  private _automaticDataCollectionEnabled: boolean;
 
   public INTERNAL;
 
   constructor(
     options: FirebaseOptions,
-    name: string,
+    config: FirebaseAppConfig,
     private firebase_: FirebaseNamespace
   ) {
-    this.name_ = name;
+    this.name_ = config.name;
+    this._automaticDataCollectionEnabled = config.automaticDataCollectionEnabled || false;
     this.options_ = deepCopy<FirebaseOptions>(options);
     this.INTERNAL = {
       getUid: () => null,
@@ -85,6 +88,16 @@ class FirebaseAppImpl implements FirebaseApp {
         );
       }
     };
+  }
+
+  get automaticDataCollectionEnabled(): boolean {
+    this.checkDestroyed_();
+    return this._automaticDataCollectionEnabled;
+  }
+
+  set automaticDataCollectionEnabled(val) {
+    this.checkDestroyed_();
+    this._automaticDataCollectionEnabled = val;
   }
 
   get name(): string {
@@ -285,21 +298,33 @@ export function createFirebaseNamespace(): FirebaseNamespace {
   /**
    * Create a new App instance (name must be unique).
    */
-  function initializeApp(options: FirebaseOptions, name?: string): FirebaseApp {
-    if (name === undefined) {
-      name = DEFAULT_ENTRY_NAME;
-    } else {
-      if (typeof name !== 'string' || name === '') {
-        error('bad-app-name', { name: name + '' });
-      }
+  function initializeApp(options: FirebaseOptions, config?: FirebaseAppConfig): FirebaseApp;
+  function initializeApp(options: FirebaseOptions, name?: string): FirebaseApp;
+  function initializeApp(options: FirebaseOptions, rawConfig = {}) {
+    if (typeof rawConfig !== 'object' || rawConfig === null) {
+      const name = rawConfig;
+      rawConfig = { name };
     }
+
+    const config = rawConfig as FirebaseAppConfig;
+
+    if (config.name === undefined) {
+      config.name = DEFAULT_ENTRY_NAME;
+    }
+
+    const { name } = config;
+
+    if (typeof name !== 'string' || !name) {
+      error('bad-app-name', { name: name + '' });
+    }
+
     if (contains(apps_, name)) {
       error('duplicate-app', { name: name });
     }
 
     let app = new FirebaseAppImpl(
       options,
-      name!,
+      config!,
       namespace as FirebaseNamespace
     );
 

--- a/packages/app/test/firebaseApp.test.ts
+++ b/packages/app/test/firebaseApp.test.ts
@@ -113,6 +113,16 @@ describe('Firebase App Class', () => {
     }, /'abc'.*exists/i);
   });
 
+  it('automaticDataCollectionEnabled is `false` by default', () => {
+    let app = firebase.initializeApp({}, 'my-app');
+    assert.equal(app.automaticDataCollectionEnabled, false);
+  });
+
+  it('automaticDataCollectionEnabled can be set via the config object', () => {
+    let app = firebase.initializeApp({}, { automaticDataCollectionEnabled: true });
+    assert.equal(app.automaticDataCollectionEnabled, true);
+  });
+
   it('Modifying options object does not change options.', () => {
     let options = { opt: 'original', nested: { opt: 123 } };
     firebase.initializeApp(options);
@@ -378,6 +388,16 @@ describe('Firebase App Class', () => {
       it("where name == '" + data + "'", () => {
         assert.throws(() => {
           firebase.initializeApp({}, data as string);
+        }, /Illegal app name/i);
+      });
+    }
+  });
+  describe('Check for bad app names, passed as an object', () => {
+    let tests = ['', 123, false, null];
+    for (const name of tests) {
+      it("where name == '" + name + "'", () => {
+        assert.throws(() => {
+          firebase.initializeApp({}, { name: name as string });
         }, /Illegal app name/i);
       });
     }

--- a/packages/app/test/firebaseApp.test.ts
+++ b/packages/app/test/firebaseApp.test.ts
@@ -119,7 +119,10 @@ describe('Firebase App Class', () => {
   });
 
   it('automaticDataCollectionEnabled can be set via the config object', () => {
-    let app = firebase.initializeApp({}, { automaticDataCollectionEnabled: true });
+    let app = firebase.initializeApp(
+      {},
+      { automaticDataCollectionEnabled: true }
+    );
     assert.equal(app.automaticDataCollectionEnabled, true);
   });
 


### PR DESCRIPTION
This PR changes `initializeApp` to support an options object as the second argument. It propagates the `name` and `automaticDataCollectionEnabled` flags to the `FirebaseAppImpl`.