### PR TITLE
Add --strict flag to TSConfig and fix errors

### DIFF
--- a/integration/messaging/test/static/app.js
+++ b/integration/messaging/test/static/app.js
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-'use strict';
-
 const EIGHT_DAYS_IN_MS = 8 * 86400000;
 
 /**

--- a/packages/messaging/index.ts
+++ b/packages/messaging/index.ts
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-'use strict';
 
 import { WindowController } from './src/controllers/window-controller';
 import { SWController } from './src/controllers/sw-controller';

--- a/packages/messaging/package.json
+++ b/packages/messaging/package.json
@@ -7,9 +7,10 @@
   "module": "dist/esm/index.js",
   "scripts": {
     "dev": "gulp dev",
-    "test": "karma start --single-run",
+    "test": "karma start --single-run && yarn type-check",
     "test:debug": "karma start --browsers=Chrome --auto-watch",
-    "prepare": "gulp build"
+    "prepare": "gulp build",
+    "type-check": "tsc --noEmit"
   },
   "license": "Apache-2.0",
   "peerDependencies": {

--- a/packages/messaging/src/controllers/controller-interface.ts
+++ b/packages/messaging/src/controllers/controller-interface.ts
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-'use strict';
 
 import { ErrorFactory } from '@firebase/util';
 import { ERROR_CODES, ERROR_MAP } from '../models/errors';

--- a/packages/messaging/src/controllers/sw-controller.ts
+++ b/packages/messaging/src/controllers/sw-controller.ts
@@ -23,7 +23,7 @@ import WorkerPageMessage from '../models/worker-page-message';
 const FCM_MSG = 'FCM_MSG';
 
 export class SWController extends ControllerInterface {
-  private bgMessageHandler_: (input: Object) => Promise<any>;
+  private bgMessageHandler_: ((input: Object) => Promise<any>)|null = null;
 
   constructor(app) {
     super(app);
@@ -39,12 +39,6 @@ export class SWController extends ControllerInterface {
       e => this.onNotificationClick_(e),
       false
     );
-
-    /**
-     * @private
-     * @type {function(Object)|null}
-     */
-    this.bgMessageHandler_ = null;
   }
 
   /**

--- a/packages/messaging/src/controllers/sw-controller.ts
+++ b/packages/messaging/src/controllers/sw-controller.ts
@@ -22,7 +22,7 @@ import WorkerPageMessage from '../models/worker-page-message';
 const FCM_MSG = 'FCM_MSG';
 
 export class SWController extends ControllerInterface {
-  private bgMessageHandler_: ((input: Object) => Promise<any>)|null = null;
+  private bgMessageHandler_: ((input: Object) => Promise<any>) | null = null;
 
   constructor(app) {
     super(app);

--- a/packages/messaging/src/controllers/sw-controller.ts
+++ b/packages/messaging/src/controllers/sw-controller.ts
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-'use strict';
 
 import { ControllerInterface } from './controller-interface';
 import { ERROR_CODES } from '../models/errors';

--- a/packages/messaging/src/controllers/window-controller.ts
+++ b/packages/messaging/src/controllers/window-controller.ts
@@ -32,11 +32,11 @@ export class WindowController extends ControllerInterface
   private registrationToUse_;
   private publicVapidKeyToUse_;
   private manifestCheckPromise_;
-  private messageObserver_ = null;
+  private messageObserver_: any = null;
   private onMessage_ = createSubscribe(observer => {
     this.messageObserver_ = observer;
   });
-  private tokenRefreshObserver_ = null;
+  private tokenRefreshObserver_: any = null;
   private onTokenRefresh_ = createSubscribe(observer => {
     this.tokenRefreshObserver_ = observer;
   });

--- a/packages/messaging/src/controllers/window-controller.ts
+++ b/packages/messaging/src/controllers/window-controller.ts
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-'use strict';
 
 import { FirebaseMessaging } from '@firebase/messaging-types';
 import { ControllerInterface } from './controller-interface';

--- a/packages/messaging/src/models/db-interface.ts
+++ b/packages/messaging/src/models/db-interface.ts
@@ -21,7 +21,7 @@ import { ERROR_CODES, ERROR_MAP } from './errors';
 export class DBInterface {
   private DB_NAME_: string;
   private dbVersion_: number;
-  private openDbPromise_: Promise<IDBDatabase>|null;
+  private openDbPromise_: Promise<IDBDatabase> | null;
   protected errorFactory_: ErrorFactory<string>;
   protected TRANSACTION_READ_WRITE: IDBTransactionMode;
 

--- a/packages/messaging/src/models/db-interface.ts
+++ b/packages/messaging/src/models/db-interface.ts
@@ -22,7 +22,7 @@ import { ERROR_CODES, ERROR_MAP } from './errors';
 export class DBInterface {
   private DB_NAME_: string;
   private dbVersion_: number;
-  private openDbPromise_: Promise<IDBDatabase>;
+  private openDbPromise_: Promise<IDBDatabase>|null;
   protected errorFactory_: ErrorFactory<string>;
   protected TRANSACTION_READ_WRITE: IDBTransactionMode;
 

--- a/packages/messaging/src/models/db-interface.ts
+++ b/packages/messaging/src/models/db-interface.ts
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-'use strict';
 
 import { ErrorFactory } from '@firebase/util';
 

--- a/packages/messaging/src/models/default-sw.ts
+++ b/packages/messaging/src/models/default-sw.ts
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-'use strict';
 
 export const DEFAULT_SW_PATH = '/firebase-messaging-sw.js';
 export const DEFAULT_SW_SCOPE = '/firebase-cloud-messaging-push-scope';

--- a/packages/messaging/src/models/errors.ts
+++ b/packages/messaging/src/models/errors.ts
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-'use strict';
 
 export const ERROR_CODES = {
   AVAILABLE_IN_WINDOW: 'only-available-in-window',

--- a/packages/messaging/src/models/fcm-details.ts
+++ b/packages/messaging/src/models/fcm-details.ts
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-'use strict';
 
 export const DEFAULT_PUBLIC_VAPID_KEY = new Uint8Array([
   0x04,

--- a/packages/messaging/src/models/iid-model.ts
+++ b/packages/messaging/src/models/iid-model.ts
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-'use strict';
-
 import { ErrorFactory, base64 } from '@firebase/util';
 
 import { ERROR_CODES, ERROR_MAP } from './errors';

--- a/packages/messaging/src/models/notification-permission.ts
+++ b/packages/messaging/src/models/notification-permission.ts
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-'use strict';
 
 export enum NotificationPermission {
   DEFAULT = 'default',

--- a/packages/messaging/src/models/token-details-model.ts
+++ b/packages/messaging/src/models/token-details-model.ts
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-'use strict';
 
 import { DBInterface } from './db-interface';
 import { ERROR_CODES } from './errors';

--- a/packages/messaging/src/models/vapid-details-model.ts
+++ b/packages/messaging/src/models/vapid-details-model.ts
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-'use strict';
 
 import { DBInterface } from './db-interface';
 import { ERROR_CODES } from './errors';

--- a/packages/messaging/src/models/vapid-details-model.ts
+++ b/packages/messaging/src/models/vapid-details-model.ts
@@ -58,7 +58,7 @@ export class VapidDetailsModel extends DBInterface {
 
         scopeRequest.onsuccess = () => {
           let result = scopeRequest.result;
-          let vapidKey = null;
+          let vapidKey: any = null;
           if (result) {
             vapidKey = result.vapidKey;
           }

--- a/packages/messaging/src/models/worker-page-message.ts
+++ b/packages/messaging/src/models/worker-page-message.ts
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-'use strict';
 
 // These fields are strings to prevent closure from thinking goog.getMsg
 // should be used to initialise the values

--- a/packages/messaging/test/controller-delete-token.test.ts
+++ b/packages/messaging/test/controller-delete-token.test.ts
@@ -66,7 +66,7 @@ describe('Firebase Messaging > *Controller.deleteToken()', function() {
   const cleanUp = () => {
     sandbox.restore();
 
-    const deletePromises = [];
+    const deletePromises: any[] = [];
     if (globalMessagingService) {
       deletePromises.push(globalMessagingService.delete());
     }

--- a/packages/messaging/test/tokenDetailsModel-deleteToken.test.ts
+++ b/packages/messaging/test/tokenDetailsModel-deleteToken.test.ts
@@ -39,7 +39,7 @@ describe('Firebase Messaging > TokenDetailsModel.deleteToken()', function() {
   let globalTokenModel;
 
   const cleanUp = () => {
-    let promises = [];
+    let promises: any = [];
 
     if (globalTokenModel) {
       promises.push(globalTokenModel.closeDatabase());

--- a/packages/messaging/test/tokenDetailsModel-getToken.test.ts
+++ b/packages/messaging/test/tokenDetailsModel-getToken.test.ts
@@ -39,7 +39,7 @@ describe('Firebase Messaging > TokenDetailsModel.getTokenDetailsFromToken()', fu
   let globalTokenModel;
 
   const cleanUp = () => {
-    let promises = [];
+    let promises: any[] = [];
     if (globalTokenModel) {
       promises.push(globalTokenModel.closeDatabase());
     }

--- a/packages/messaging/test/tokenDetailsModel-saveToken.test.ts
+++ b/packages/messaging/test/tokenDetailsModel-saveToken.test.ts
@@ -36,7 +36,7 @@ describe('Firebase Messaging > TokenDetailsModel.saveToken()', function() {
   let globalTokenModel;
 
   const cleanUp = () => {
-    const promises = [];
+    const promises: any = [];
     if (globalTokenModel) {
       promises.push(globalTokenModel.closeDatabase());
     }

--- a/packages/messaging/tsconfig.json
+++ b/packages/messaging/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../config/tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "dist"
+    "outDir": "dist",
+    "strict": true
   },
   "exclude": [
     "dist/**/*"


### PR DESCRIPTION
This doesn't really "fix" anything, but explicit "any"s are still better than implicit "any"s. I'll fix the types properly after this.

Adds TypeScript compilation as part of tests, which means tests & CI will now fail if you don't make the compiler happy.

I also removed "use strict"s, which are emitted automatically by --alwaysStrict, which is part of --strict.

FYI: --noImplicitAny, which is part of --strict, is still off. This is because it's set to false explicitly in the base TSConfig. I'm working on fixing the types so I can enable that as well.
