### PR TITLE
Adding multi-client support for rejected mutations

### DIFF
--- a/packages/firestore/src/remote/remote_store.ts
+++ b/packages/firestore/src/remote/remote_store.ts
@@ -534,6 +534,7 @@ export class RemoteStore {
    * typically called by SyncEngine after it has sent mutations to LocalStore.
    */
   async fillWritePipeline(): Promise<void> {
+    console.log('---- fillWritePipeline ----' );
     if (this.canWriteMutations()) {
       return this.localStore
         .nextMutationBatch(this.lastBatchSeen)

--- a/packages/firestore/src/remote/remote_store.ts
+++ b/packages/firestore/src/remote/remote_store.ts
@@ -534,7 +534,7 @@ export class RemoteStore {
    * typically called by SyncEngine after it has sent mutations to LocalStore.
    */
   async fillWritePipeline(): Promise<void> {
-    console.log('---- fillWritePipeline ----' );
+    console.log('---- fillWritePipeline ----');
     if (this.canWriteMutations()) {
       return this.localStore
         .nextMutationBatch(this.lastBatchSeen)

--- a/packages/firestore/test/unit/specs/write_spec.test.ts
+++ b/packages/firestore/test/unit/specs/write_spec.test.ts
@@ -769,16 +769,19 @@ describeSpec('Writes:', [], () => {
     // });
   });
 
-  specTest('Write is rejected by primary client', ['exclusive', 'multi-client'], () => {
-    const query = Query.atPath(path('collection'));
-    const localDoc = doc(
+  specTest(
+    'Write is rejected by primary client',
+    ['exclusive', 'multi-client'],
+    () => {
+      const query = Query.atPath(path('collection'));
+      const localDoc = doc(
         'collection/a',
         0,
         { v: 1 },
         { hasLocalMutations: true }
-    );
+      );
 
-    return client(0)
+      return client(0)
         .userListens(query)
         .watchAcksFull(query, 500)
         .expectEvents(query, {})
@@ -799,9 +802,13 @@ describeSpec('Writes:', [], () => {
           hasPendingWrites: true,
           added: [localDoc]
         })
-        .failWrite('collection/a', new RpcError(Code.FAILED_PRECONDITION, 'failure'), {
-          expectUserCallback: false
-        })
+        .failWrite(
+          'collection/a',
+          new RpcError(Code.FAILED_PRECONDITION, 'failure'),
+          {
+            expectUserCallback: false
+          }
+        )
         .expectEvents(query, {
           removed: [localDoc]
         })
@@ -815,5 +822,6 @@ describeSpec('Writes:', [], () => {
           removed: [localDoc]
         })
         .drainQueue();
-  });
+    }
+  );
 });

--- a/packages/firestore/test/unit/specs/write_spec.test.ts
+++ b/packages/firestore/test/unit/specs/write_spec.test.ts
@@ -768,4 +768,52 @@ describeSpec('Writes:', [], () => {
     //   metadata: [remoteDoc]
     // });
   });
+
+  specTest(
+    'Write is rejected by primary client',
+    ['exclusive', 'multi-client'],
+    () => {
+      const query = Query.atPath(path('collection'));
+      const localDoc = doc(
+        'collection/a',
+        0,
+        { v: 1 },
+        { hasLocalMutations: true }
+      );
+
+      return client(0)
+        .userListens(query)
+        .watchAcksFull(query, 500)
+        .expectEvents(query, {})
+        .client(1)
+        .userListens(query)
+        .expectEvents(query, {
+          fromCache: true
+        })
+        .userSets('collection/a', { v: 1 })
+        .expectEvents(query, {
+          hasPendingWrites: true,
+          fromCache: true,
+          added: [localDoc]
+        })
+        .client(0)
+        .drainQueue()
+        .expectEvents(query, {
+          hasPendingWrites: true,
+          added: [localDoc]
+        })
+        .failWrite(new RpcError(Code.FAILED_PRECONDITION, 'failure'), {
+          expectUserCallback: false
+        })
+        .expectEvents(query, {
+          removed: [localDoc]
+        })
+        .client(1)
+        .drainQueue({ expectUserCallback: 'failure' })
+        .expectEvents(query, {
+          fromCache: true,
+          removed: [localDoc]
+        });
+    }
+  );
 });


### PR DESCRIPTION
This PR adds the missing elements to reject mutations for multi-client writes.