### PR TITLE
Specify types of observer and next function for UploadTask.on

### DIFF
--- a/packages/storage-types/index.d.ts
+++ b/packages/storage-types/index.d.ts
@@ -77,7 +77,10 @@ export interface UploadTask {
   catch(onRejected: (a: Error) => any): Promise<any>;
   on(
     event: TaskEvent,
-    nextOrObserver?: Observer<any, any> | null | ((a: Object) => any),
+    nextOrObserver?:
+      | Observer<UploadTaskSnapshot, Error>
+      | null
+      | ((a: UploadTaskSnapshot) => any),
     error?: ((a: Error) => any) | null,
     complete?: (Unsubscribe) | null
   ): Function;


### PR DESCRIPTION
Fix for Storage types described in #620.