### PR TITLE
Add typedef TSLint rule

### DIFF
--- a/packages/messaging/src/controllers/controller-interface.ts
+++ b/packages/messaging/src/controllers/controller-interface.ts
@@ -274,15 +274,15 @@ export abstract class ControllerInterface {
   // The following methods should only be available in the window.
   //
 
-  requestPermission() {
+  requestPermission(): void {
     throw this.errorFactory_.create(ERROR_CODES.AVAILABLE_IN_WINDOW);
   }
 
-  useServiceWorker(registration: ServiceWorkerRegistration) {
+  useServiceWorker(registration: ServiceWorkerRegistration): void {
     throw this.errorFactory_.create(ERROR_CODES.AVAILABLE_IN_WINDOW);
   }
 
-  usePublicVapidKey(b64PublicKey: string) {
+  usePublicVapidKey(b64PublicKey: string): void {
     throw this.errorFactory_.create(ERROR_CODES.AVAILABLE_IN_WINDOW);
   }
 
@@ -290,7 +290,7 @@ export abstract class ControllerInterface {
     nextOrObserver: NextFn<{}> | PartialObserver<{}>,
     error?: (e: Error) => void,
     completed?: () => void
-  ) {
+  ): void {
     throw this.errorFactory_.create(ERROR_CODES.AVAILABLE_IN_WINDOW);
   }
 
@@ -298,7 +298,7 @@ export abstract class ControllerInterface {
     nextOrObserver: NextFn<{}> | PartialObserver<{}>,
     error?: (e: Error) => void,
     completed?: () => void
-  ) {
+  ): void {
     throw this.errorFactory_.create(ERROR_CODES.AVAILABLE_IN_WINDOW);
   }
 
@@ -306,7 +306,7 @@ export abstract class ControllerInterface {
   // The following methods are used by the service worker only.
   //
 
-  setBackgroundMessageHandler(callback: (a: any) => any) {
+  setBackgroundMessageHandler(callback: (a: any) => any): void {
     throw this.errorFactory_.create(ERROR_CODES.AVAILABLE_IN_SW);
   }
 
@@ -319,7 +319,7 @@ export abstract class ControllerInterface {
    * This method is required to adhere to the Firebase interface.
    * It closes any currently open indexdb database connections.
    */
-  delete() {
+  delete(): Promise<[void, void]> {
     return Promise.all([
       this.tokenDetailsModel_.closeDatabase(),
       this.vapidDetailsModel_.closeDatabase()
@@ -345,9 +345,8 @@ export abstract class ControllerInterface {
 
   /**
    * @protected
-   * @returns {IIDModel}
    */
-  getIIDModel() {
+  getIIDModel(): IIDModel {
     return this.iidModel_;
   }
 }

--- a/packages/messaging/src/controllers/sw-controller.ts
+++ b/packages/messaging/src/controllers/sw-controller.ts
@@ -67,7 +67,7 @@ export class SWController extends ControllerInterface {
    */
   // Visible for testing
   // TODO: Make private
-  onPush_(event: any) {
+  onPush_(event: any): void {
     let msgPayload: any;
     try {
       msgPayload = event.data.json();
@@ -104,7 +104,7 @@ export class SWController extends ControllerInterface {
 
   // Visible for testing
   // TODO: Make private
-  onSubChange_(event: any) {
+  onSubChange_(event: any): void {
     const promiseChain = this.getSWRegistration_()
       .then(registration => {
         return registration.pushManager
@@ -144,7 +144,7 @@ export class SWController extends ControllerInterface {
 
   // Visible for testing
   // TODO: Make private
-  onNotificationClick_(event: any) {
+  onNotificationClick_(event: any): void {
     if (
       !(
         event.notification &&
@@ -242,7 +242,7 @@ export class SWController extends ControllerInterface {
    * and a notification must be shown. The callback will be given the data from
    * the push message.
    */
-  setBackgroundMessageHandler(callback: BgMessageHandler) {
+  setBackgroundMessageHandler(callback: BgMessageHandler): void {
     if (!callback || typeof callback !== 'function') {
       throw this.errorFactory_.create(ERROR_CODES.BG_HANDLER_FUNCTION_EXPECTED);
     }

--- a/packages/messaging/src/helpers/array-buffer-to-base64.ts
+++ b/packages/messaging/src/helpers/array-buffer-to-base64.ts
@@ -14,12 +14,14 @@
  * limitations under the License.
  */
 
-function toBase64(arrayBuffer: ArrayBuffer | Uint8Array) {
+function toBase64(arrayBuffer: ArrayBuffer | Uint8Array): string {
   const uint8Version = new Uint8Array(arrayBuffer);
   return btoa(String.fromCharCode.apply(null, uint8Version));
 }
 
-export function arrayBufferToBase64(arrayBuffer: ArrayBuffer | Uint8Array) {
+export function arrayBufferToBase64(
+  arrayBuffer: ArrayBuffer | Uint8Array
+): string {
   const base64String = toBase64(arrayBuffer);
   return base64String
     .replace(/=/g, '')

--- a/packages/messaging/src/helpers/base64-to-array-buffer.ts
+++ b/packages/messaging/src/helpers/base64-to-array-buffer.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-export function base64ToArrayBuffer(base64String: string) {
+export function base64ToArrayBuffer(base64String: string): Uint8Array {
   const padding = '='.repeat((4 - base64String.length % 4) % 4);
   const base64 = (base64String + padding)
     .replace(/\-/g, '+')

--- a/packages/messaging/src/models/clean-v1-undefined.ts
+++ b/packages/messaging/src/models/clean-v1-undefined.ts
@@ -31,7 +31,7 @@ import { IIDModel } from '../models/iid-model';
 const OLD_DB_NAME = 'undefined';
 const OLD_OBJECT_STORE_NAME = 'fcm_token_object_Store';
 
-function handleDb(db: IDBDatabase) {
+function handleDb(db: IDBDatabase): void {
   if (!db.objectStoreNames.contains(OLD_OBJECT_STORE_NAME)) {
     // We found a database with the name 'undefined', but our expected object
     // store isn't defined.
@@ -70,7 +70,7 @@ function handleDb(db: IDBDatabase) {
   };
 }
 
-function cleanV1() {
+export function cleanV1(): void {
   const request: IDBOpenDBRequest = indexedDB.open(OLD_DB_NAME);
   request.onerror = event => {
     // NOOP - Nothing we can do.
@@ -80,5 +80,3 @@ function cleanV1() {
     handleDb(db);
   };
 }
-
-export { cleanV1 };

--- a/packages/messaging/src/models/db-interface.ts
+++ b/packages/messaging/src/models/db-interface.ts
@@ -69,9 +69,8 @@ export class DBInterface {
 
   /**
    * Close the currently open database.
-   * @return {!Promise} Returns the result of the promise chain.
    */
-  closeDatabase() {
+  closeDatabase(): Promise<void> {
     return Promise.resolve().then(() => {
       if (this.openDbPromise_) {
         return this.openDbPromise_.then(db => {
@@ -84,9 +83,8 @@ export class DBInterface {
 
   /**
    * @protected
-   * @param {!IDBDatabase} db
    */
-  onDBUpgrade(db: IDBDatabase, event: IDBVersionChangeEvent) {
+  onDBUpgrade(db: IDBDatabase, event: IDBVersionChangeEvent): void {
     throw this.errorFactory_.create(ERROR_CODES.SHOULD_BE_INHERITED);
   }
 }

--- a/packages/messaging/src/models/token-details-model.ts
+++ b/packages/messaging/src/models/token-details-model.ts
@@ -29,7 +29,7 @@ export class TokenDetailsModel extends DBInterface {
     super(DB_NAME, DB_VERSION);
   }
 
-  onDBUpgrade(db: IDBDatabase, evt: IDBVersionChangeEvent) {
+  onDBUpgrade(db: IDBDatabase, evt: IDBVersionChangeEvent): void {
     if (evt.oldVersion < 1) {
       // New IDB instance
       const objectStore = db.createObjectStore(FCM_TOKEN_OBJ_STORE, {

--- a/packages/messaging/src/models/vapid-details-model.ts
+++ b/packages/messaging/src/models/vapid-details-model.ts
@@ -27,7 +27,7 @@ export class VapidDetailsModel extends DBInterface {
     super(DB_NAME, DB_VERSION);
   }
 
-  onDBUpgrade(db: IDBDatabase) {
+  onDBUpgrade(db: IDBDatabase): void {
     db.createObjectStore(FCM_VAPID_OBJ_STORE, {
       keyPath: 'swScope'
     });

--- a/packages/messaging/src/models/worker-page-message.ts
+++ b/packages/messaging/src/models/worker-page-message.ts
@@ -28,10 +28,12 @@ export const TYPES_OF_MSG = {
   NOTIFICATION_CLICKED: 'notification-clicked'
 };
 
-export function createNewMsg(msgType: any, msgData: any) {
-  const message = {
+export function createNewMsg(
+  msgType: any,
+  msgData: any
+): { [key: string]: any } {
+  return {
     [PARAMS.TYPE_OF_MSG]: msgType,
     [PARAMS.DATA]: msgData
   };
-  return message;
 }

--- a/packages/messaging/test/testing-utils/db-helper.ts
+++ b/packages/messaging/test/testing-utils/db-helper.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-export function deleteDatabase(dbName) {
+export function deleteDatabase(dbName: string): Promise<void> {
   return new Promise((resolve, reject) => {
     const request = indexedDB.deleteDatabase(dbName);
     request.onerror = event => {

--- a/packages/messaging/tslint.json
+++ b/packages/messaging/tslint.json
@@ -46,6 +46,7 @@
     "prefer-readonly": true,
     "radix": true,
     "triple-equals": [true, "allow-null-check"],
+    "typedef": [true, "call-signature", "parameter", "member-variable-declaration"],
     "use-isnan": true
   }
 }


### PR DESCRIPTION
Makes type definitions mandatory for function parameters and signatures, and class/interface member variables.

I didn't put this in my previous TSLint PR as this one is a bit more controversial. There's some redundant information there as TS can already infer most of the types, but I still think this rule adds value, because adding types explicitly means TS will check if the inferred types are what you claim they are, and will warn you if they are not.

Please let me know what you think.