### PR TITLE
Deprecate downloadURL property in Storage metadata types.

### DIFF
--- a/packages/firebase/app/index.d.ts
+++ b/packages/firebase/app/index.d.ts
@@ -508,6 +508,11 @@ declare namespace firebase.messaging {
 declare namespace firebase.storage {
   interface FullMetadata extends firebase.storage.UploadMetadata {
     bucket: string;
+    /**
+     * @deprecated
+     * Use Reference.getDownloadURL instead. This property will be removed in a
+     * future release.
+     */
     downloadURLs: string[];
     fullPath: string;
     generation: string;
@@ -612,6 +617,11 @@ declare namespace firebase.storage {
 
   interface UploadTaskSnapshot {
     bytesTransferred: number;
+    /**
+     * @deprecated
+     * Use Reference.getDownloadURL instead. This property will be removed in a
+     * future release.
+     */
     downloadURL: string | null;
     metadata: firebase.storage.FullMetadata;
     ref: firebase.storage.Reference;

--- a/packages/firebase/index.d.ts
+++ b/packages/firebase/index.d.ts
@@ -510,6 +510,11 @@ declare namespace firebase.messaging {
 declare namespace firebase.storage {
   interface FullMetadata extends firebase.storage.UploadMetadata {
     bucket: string;
+    /**
+     * @deprecated
+     * Use Reference.getDownloadURL instead. This property will be removed in a
+     * future release.
+     */
     downloadURLs: string[];
     fullPath: string;
     generation: string;
@@ -614,6 +619,11 @@ declare namespace firebase.storage {
 
   interface UploadTaskSnapshot {
     bytesTransferred: number;
+    /**
+     * @deprecated
+     * Use Reference.getDownloadURL instead. This property will be removed in a
+     * future release.
+     */
     downloadURL: string | null;
     metadata: firebase.storage.FullMetadata;
     ref: firebase.storage.Reference;

--- a/packages/storage-types/index.d.ts
+++ b/packages/storage-types/index.d.ts
@@ -19,6 +19,11 @@ import { Observer, Unsubscribe } from '@firebase/util';
 
 export interface FullMetadata extends UploadMetadata {
   bucket: string;
+  /**
+   * @deprecated
+   * Use Reference.getDownloadURL instead. This property will be removed in a
+   * future release.
+   */
   downloadURLs: string[];
   fullPath: string;
   generation: string;
@@ -95,6 +100,11 @@ export interface UploadTask {
 
 export interface UploadTaskSnapshot {
   bytesTransferred: number;
+  /**
+   * @deprecated
+   * Use Reference.getDownloadURL instead. This property will be removed in a
+   * future release.
+   */
   downloadURL: string | null;
   metadata: FullMetadata;
   ref: Reference;


### PR DESCRIPTION
In the future, Storage backend changes will make it infeasible to automatically provide these properties. These properties will eventually be removed, but it will still be possible to generate download URLs with the Reference.getDownloadURL method.

The `@deprecated` property will show up in TSLint. I'll also update our [documentation](https://firebase.google.com/docs/) before the next release.

