### PR TITLE
v5 Change: Removing .path from Database Typings

### DIFF
--- a/packages/database-types/index.d.ts
+++ b/packages/database-types/index.d.ts
@@ -91,7 +91,6 @@ export interface Reference extends Query {
   key: string | null;
   onDisconnect(): OnDisconnect;
   parent: Reference | null;
-  path: string;
   push(value?: any, onComplete?: (a: Error | null) => any): ThenableReference;
   remove(onComplete?: (a: Error | null) => any): Promise<any>;
   root: Reference;

--- a/packages/firebase/app/index.d.ts
+++ b/packages/firebase/app/index.d.ts
@@ -447,7 +447,6 @@ declare namespace firebase.database {
     key: string | null;
     onDisconnect(): firebase.database.OnDisconnect;
     parent: firebase.database.Reference | null;
-    path: string;
     push(
       value?: any,
       onComplete?: (a: Error | null) => any


### PR DESCRIPTION
This is the "Removing .path from Database Typings" PR (https://github.com/firebase/firebase-js-sdk/pull/613) against the v5-master branch.
