### PR TITLE
Verifying callbacks in the spec tests

### DIFF
--- a/packages/firestore/test/unit/specs/persistence_spec.test.ts
+++ b/packages/firestore/test/unit/specs/persistence_spec.test.ts
@@ -28,8 +28,8 @@ describeSpec('Persistence:', [], () => {
       .userSets('collection/key2', { baz: 'quu' })
       .restart()
       .expectNumOutstandingWrites(2)
-      .writeAcks(1, { expectUserCallback: false })
-      .writeAcks(2, { expectUserCallback: false })
+      .writeAcks(['collection/key1'], 1, { expectUserCallback: false })
+      .writeAcks(['collection/key2'], 2, { expectUserCallback: false })
       .expectNumOutstandingWrites(0);
   });
 
@@ -98,7 +98,7 @@ describeSpec('Persistence:', [], () => {
         .withGCEnabled(false)
         .userSets('collection/key', { foo: 'bar' })
         // Normally the write would get GC'd from remote documents here.
-        .writeAcks(1000)
+        .writeAcks(['collection/key'], 1000)
         .userListens(query)
         // Version is 0 since we never received a server version via watch.
         .expectEvents(query, {
@@ -117,11 +117,11 @@ describeSpec('Persistence:', [], () => {
       .userSets('users/user1', { uid: 'user1', extra: true })
       .changeUser(null)
       .expectNumOutstandingWrites(1)
-      .writeAcks(1000)
+      .writeAcks(['users/anon'], 1000)
       .changeUser('user1')
       .expectNumOutstandingWrites(2)
-      .writeAcks(2000)
-      .writeAcks(3000);
+      .writeAcks(['users/user1'], 2000)
+      .writeAcks(['users/user1'], 3000);
   });
 
   specTest(
@@ -137,12 +137,12 @@ describeSpec('Persistence:', [], () => {
         .changeUser(null)
         .restart()
         .expectNumOutstandingWrites(1)
-        .writeAcks(1000, { expectUserCallback: false })
+        .writeAcks(['users/anon'], 1000, { expectUserCallback: false })
         .changeUser('user1')
         .restart()
         .expectNumOutstandingWrites(2)
-        .writeAcks(2000, { expectUserCallback: false })
-        .writeAcks(3000, { expectUserCallback: false });
+        .writeAcks(['users/user1'], 2000, { expectUserCallback: false })
+        .writeAcks(['users/user2'], 3000, { expectUserCallback: false });
     }
   );
 

--- a/packages/firestore/test/unit/specs/spec_test_runner.ts
+++ b/packages/firestore/test/unit/specs/spec_test_runner.ts
@@ -355,6 +355,9 @@ abstract class TestRunner {
   private syncEngine: SyncEngine;
 
   private eventList: QueryEvent[] = [];
+  private acknowledgedDocs: string[];
+  private rejectedDocs: string[];
+
   private outstandingCallbacks: Array<Deferred<void>> = [];
   private queryListeners = new ObjectMap<Query, QueryListener>(q =>
     q.canonicalId()
@@ -404,6 +407,8 @@ abstract class TestRunner {
 
     this.expectedLimboDocs = [];
     this.expectedActiveTargets = {};
+    this.acknowledgedDocs = [];
+    this.rejectedDocs = [];
   }
 
   private init(): void {
@@ -491,6 +496,8 @@ abstract class TestRunner {
     this.validateStepExpectations(step.expect!);
     await this.validateStateExpectations(step.stateExpect!);
     this.eventList = [];
+    this.rejectedDocs = [];
+    this.acknowledgedDocs = [];
   }
 
   private doStep(step: SpecStep): Promise<void> {
@@ -525,7 +532,7 @@ abstract class TestRunner {
     } else if ('runTimer' in step) {
       return this.doRunTimer(step.runTimer!);
     } else if ('drainQueue' in step) {
-      return this.doDrainQueue(step.drainQueue);
+      return this.doDrainQueue();
     } else if ('enableNetwork' in step) {
       return step.enableNetwork!
         ? this.doEnableNetwork()
@@ -597,11 +604,26 @@ abstract class TestRunner {
   }
 
   private doMutations(mutations: Mutation[]): Promise<void> {
+    const documentKeys = mutations.map(val => val.key.path.toString());
     const userCallback = new Deferred<void>();
+    const syncEngineCallback = new Deferred<void>();
+
+    syncEngineCallback.promise.then(
+      () => {
+        this.acknowledgedDocs.push(...documentKeys);
+        userCallback.resolve();
+      },
+      () => {
+        this.rejectedDocs.push(...documentKeys);
+        userCallback.resolve();
+      }
+    );
+
     this.outstandingMutations.push(mutations);
     this.outstandingCallbacks.push(userCallback);
+
     return this.queue.enqueue(() => {
-      return this.syncEngine.write(mutations, userCallback);
+      return this.syncEngine.write(mutations, syncEngineCallback);
     });
   }
 
@@ -794,12 +816,9 @@ abstract class TestRunner {
   private doWriteAck(writeAck: SpecWriteAck): Promise<void> {
     const updateTime = this.serializer.toVersion(version(writeAck.version));
     const nextMutation = this.outstandingMutations.poll();
+
     return this.validateNextWriteRequest(nextMutation).then(() => {
       this.connection.ackWrite(updateTime, [{ updateTime }]);
-      if (writeAck.expectUserCallback) {
-        const nextCallback = this.outstandingCallbacks.shift();
-        return nextCallback.promise;
-      }
     });
   }
 
@@ -818,17 +837,6 @@ abstract class TestRunner {
       }
 
       this.connection.failWrite(error);
-      if (writeFailure.expectUserCallback) {
-        const nextCallback = this.outstandingCallbacks.shift();
-        return nextCallback.promise.then(
-          () => {
-            fail('write should have failed');
-          },
-          err => {
-            expect(err).not.to.be.null;
-          }
-        );
-      }
     });
   }
 
@@ -847,12 +855,8 @@ abstract class TestRunner {
     await this.syncEngine.disableNetwork();
   }
 
-  private async doDrainQueue(drainQueue: SpecDrainQueue): Promise<void> {
+  private async doDrainQueue(): Promise<void> {
     await this.queue.drain();
-    if (drainQueue.expectUserCallback) {
-      const nextCallback = this.outstandingCallbacks.shift();
-      return nextCallback.promise;
-    }
   }
 
   private async doEnableNetwork(): Promise<void> {
@@ -957,6 +961,14 @@ abstract class TestRunner {
       }
       if ('isPrimary' in expectation) {
         expect(this.syncEngine.isPrimaryClient).to.eq(expectation.isPrimary!);
+      }
+      if ('userCallbacks' in expectation) {
+        expect(this.acknowledgedDocs).to.have.members(
+          expectation.userCallbacks.acknowledgedDocs
+        );
+        expect(this.rejectedDocs).to.have.members(
+          expectation.userCallbacks.rejectedDocs
+        );
       }
     }
 
@@ -1511,7 +1523,7 @@ export interface SpecStep {
   /**
    * Process all events currently enqueued in the AsyncQueue.
    */
-  drainQueue?: SpecDrainQueue;
+  drainQueue?: true;
 
   /** Enable or disable RemoteStore's network connection. */
   enableNetwork?: boolean;
@@ -1587,20 +1599,11 @@ export type SpecWatchStreamClose = {
 export type SpecWriteAck = {
   /** The version the backend uses to ack the write. */
   version: SpecSnapshotVersion;
-  /** Whether the ack is expected to generate a user callback. */
-  expectUserCallback: boolean;
 };
 
 export type SpecWriteFailure = {
   /** The error the backend uses to fail the write. */
   error: SpecError;
-  /** Whether the failure is expected to generate a user callback. */
-  expectUserCallback: boolean;
-};
-
-export type SpecDrainQueue = {
-  /** Whether the drain is expected to generate a user callback. */
-  expectUserCallback: boolean;
 };
 
 export interface SpecWatchEntity {
@@ -1694,5 +1697,12 @@ export interface StateExpectation {
    */
   activeTargets?: {
     [targetId: number]: { query: SpecQuery; resumeToken: string };
+  };
+  /**
+   * Expected set of callbacks for previously written docs.
+   */
+  userCallbacks?: {
+    acknowledgedDocs: string[];
+    rejectedDocs: string[];
   };
 }

--- a/packages/firestore/test/unit/specs/write_spec.test.ts
+++ b/packages/firestore/test/unit/specs/write_spec.test.ts
@@ -57,7 +57,7 @@ describeSpec('Writes:', [], () => {
         })
         .watchSends({ affects: [query] }, docAv2)
         .watchSnapshots(2000)
-        .writeAcks(2000)
+        .writeAcks(['collection/a'], 2000)
         .expectEvents(query, {
           metadata: [docAv2]
         })
@@ -68,7 +68,7 @@ describeSpec('Writes:', [], () => {
         })
         .watchSends({ affects: [query] }, docBv2)
         .watchSnapshots(3000)
-        .writeAcks(3000)
+        .writeAcks(['collection/b'], 3000)
         .expectEvents(query, {
           metadata: [docBv2]
         });
@@ -101,7 +101,7 @@ describeSpec('Writes:', [], () => {
         })
         .watchSends({ affects: [query1] }, doc1c)
         .watchSnapshots(2000)
-        .writeAcks(2000)
+        .writeAcks(['collection/key'], 2000)
         .expectEvents(query1, {
           metadata: [doc1c]
         });
@@ -136,7 +136,7 @@ describeSpec('Writes:', [], () => {
       })
       .watchSends({ affects: [query1] }, doc1c)
       .watchSnapshots(watchVersion)
-      .writeAcks(ackedVersion) // The ack is already outdated by the newer doc1c
+      .writeAcks(['collection/key'], ackedVersion) // The ack is already outdated by the newer doc1c
       .expectEvents(query1, {
         modified: [doc1c]
       });
@@ -167,7 +167,7 @@ describeSpec('Writes:', [], () => {
             modified: [docV2Local]
           })
           // The ack arrives before the watch snapshot; no events yet
-          .writeAcks(2000)
+          .writeAcks(['collection/key'], 2000)
           .watchSends({ affects: [query] }, docV2)
           .watchSnapshots(2000)
           .expectEvents(query, {
@@ -200,7 +200,7 @@ describeSpec('Writes:', [], () => {
           modified: [docV3Local]
         })
         // The ack arrives before the watch snapshot; no events yet
-        .writeAcks(3000)
+        .writeAcks(['collection/key'], 3000)
         // watch sends some stale data; no events
         .watchSends({ affects: [query] }, docV2)
         .watchSnapshots(2000)
@@ -251,7 +251,7 @@ describeSpec('Writes:', [], () => {
     specification.expectNumOutstandingWrites(10);
     for (let i = 0; i < numWrites; i++) {
       specification
-        .writeAcks((i + 1) * 1000)
+        .writeAcks(['collection/a' + i], (i + 1) * 1000)
         .watchSends({ affects: [query] }, docs[i])
         .watchSnapshots((i + 1) * 1000)
         .expectEvents(query, {
@@ -290,7 +290,10 @@ describeSpec('Writes:', [], () => {
     specification.expectNumOutstandingWrites(10);
     for (let i = 0; i < numWrites; i++) {
       specification
-        .failWrite(new RpcError(Code.PERMISSION_DENIED, 'permission denied'))
+        .failWrite(
+          ['collection/a' + i],
+          new RpcError(Code.PERMISSION_DENIED, 'permission denied')
+        )
         .expectEvents(query, {
           fromCache: true,
           hasPendingWrites: i < numWrites - 1,
@@ -330,14 +333,17 @@ describeSpec('Writes:', [], () => {
         .userSets('collection/b', { v: 1 })
         .expectEvents(query, { hasPendingWrites: true, added: [docBLocal] })
         // ack write but no watch snapshot so it'll be held.
-        .writeAcks(2000)
+        .writeAcks(['collection/b'], 2000)
         .userSets('collection/a', { v: 2 })
         .expectEvents(query, {
           hasPendingWrites: true,
           modified: [docAv2Local]
         })
         // reject write, should be released immediately.
-        .failWrite(new RpcError(Code.PERMISSION_DENIED, 'failure'))
+        .failWrite(
+          ['collection/a'],
+          new RpcError(Code.PERMISSION_DENIED, 'failure')
+        )
         .expectEvents(query, { hasPendingWrites: true, modified: [docAv1] })
         // watch updates, B should be visible
         .watchSends({ affects: [query] }, docB)
@@ -375,7 +381,7 @@ describeSpec('Writes:', [], () => {
           added: [docALocal]
         })
         // ack write but without a watch event.
-        .writeAcks(1000)
+        .writeAcks(['collection/a'], 1000)
         // Do another write.
         .userSets('collection/b', { v: 1 })
         .expectEvents(query, {
@@ -383,7 +389,7 @@ describeSpec('Writes:', [], () => {
           added: [docBLocal]
         })
         // ack second write
-        .writeAcks(2000)
+        .writeAcks(['collection/b'], 2000)
         // Finally watcher catches up.
         .watchSends({ affects: [query] }, docA, docB)
         .watchSnapshots(2000)
@@ -417,7 +423,7 @@ describeSpec('Writes:', [], () => {
             added: [docALocal]
           })
           // ack write but without a watch event.
-          .writeAcks(1000)
+          .writeAcks(['collection/a'], 1000)
 
           // handshake + write = 2 requests
           .expectWriteStreamRequestCount(2)
@@ -469,7 +475,7 @@ describeSpec('Writes:', [], () => {
             added: [docALocal]
           })
           // ack write but without a watch event.
-          .writeAcks(1000)
+          .writeAcks(['collection/a'], 1000)
           // Unlisten before the write is released.
           .userUnlistens(query)
           // Re-add listen and make sure we don't get any events.
@@ -506,7 +512,7 @@ describeSpec('Writes:', [], () => {
           hasPendingWrites: true,
           added: [doc1a]
         })
-        .failWrite(new RpcError(code, 'failure'))
+        .failWrite(['collection/key'], new RpcError(code, 'failure'))
         .expectEvents(query1, {
           fromCache: true,
           removed: [doc1a]
@@ -537,9 +543,13 @@ describeSpec('Writes:', [], () => {
           hasPendingWrites: true,
           added: [doc1a]
         })
-        .failWrite(new RpcError(Code.RESOURCE_EXHAUSTED, 'transient error'), {
-          expectUserCallback: false
-        });
+        .failWrite(
+          ['collection/key'],
+          new RpcError(Code.RESOURCE_EXHAUSTED, 'transient error'),
+          {
+            expectUserCallback: false
+          }
+        );
     }
   );
 
@@ -569,10 +579,10 @@ describeSpec('Writes:', [], () => {
           hasPendingWrites: true,
           added: [doc1a]
         })
-        .failWrite(new RpcError(code, 'transient error'), {
+        .failWrite(['collection/key'], new RpcError(code, 'transient error'), {
           expectUserCallback: false
         })
-        .writeAcks(1000)
+        .writeAcks(['collection/key'], 1000)
         .watchAcks(query1)
         .watchSends({ affects: [query1] }, doc1b)
         .watchCurrents(query1, 'resume-token-1000')
@@ -611,7 +621,7 @@ describeSpec('Writes:', [], () => {
           })
           .watchSends({ affects: [query] }, docV2)
           .watchSnapshots(2000)
-          .writeAcks(2000)
+          .writeAcks(['collection/doc'], 2000)
           .expectEvents(query, { metadata: [docV2] })
       );
     }
@@ -633,7 +643,7 @@ describeSpec('Writes:', [], () => {
         expectRequestCount({ handshakes: 2, writes: 2, closes: 1 })
       )
       .expectNumOutstandingWrites(1)
-      .writeAcks(1, { expectUserCallback: false })
+      .writeAcks(['collection/key'], 1, { expectUserCallback: false })
       .expectNumOutstandingWrites(0);
   });
 
@@ -740,14 +750,17 @@ describeSpec('Writes:', [], () => {
         hasPendingWrites: true,
         added: [localDoc]
       })
-      .writeAcks(1000, { expectUserCallback: false })
+      .writeAcks(['collection/a'], 1000, { expectUserCallback: false })
       .watchSends({ affects: [query] }, remoteDoc)
       .watchSnapshots(1000)
       .expectEvents(query, {
         metadata: [remoteDoc]
       })
       .client(1)
-      .drainQueue({ expectUserCallback: true });
+      .drainQueue()
+      .expectUserCallbacks({
+        acknowledged: ['collection/a']
+      });
     // TODO(heldacks): This event doesn't fire since we are holding the write
     // acknowledgment.
     // .expectEvents(query, {


### PR DESCRIPTION
This PR rewrites the spec tests to verify that the correct callbacks fire for writeAcks and failed writes.