### PR TITLE
Fix deployment procedures.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,6 @@ jobs:
       env: '#comment = yarn test:saucelabs'
       if: type = push
     - stage: deploy
-      install: skip
       script: skip
       # NPM Canary Build Config
       deploy:


### PR DESCRIPTION
Install stage was mistakenly set to be skipped by PR #674.

This is to fix build failure: https://travis-ci.org/firebase/firebase-js-sdk/builds/365852699.