### PR TITLE
Firestore Node.js External Fix

### DIFF
--- a/packages/firestore/rollup.config.js
+++ b/packages/firestore/rollup.config.js
@@ -51,6 +51,9 @@ export default [
     input: 'index.node.ts',
     output: [{ file: pkg.main, format: 'cjs' }],
     plugins,
-    external
+    external: [
+      ...external,
+      'util'
+    ]
   }
 ];

--- a/packages/firestore/rollup.config.js
+++ b/packages/firestore/rollup.config.js
@@ -51,9 +51,6 @@ export default [
     input: 'index.node.ts',
     output: [{ file: pkg.main, format: 'cjs' }],
     plugins,
-    external: [
-      ...external,
-      'util'
-    ]
+    external: [...external, 'util']
   }
 ];


### PR DESCRIPTION
With the build refactor the vast majority of imports worked seamlessly. However Firestore's import of the `util` lib here (which translates to a `require('util')` was not properly externally referenced resulting in errors.

This correctly marks the lib as external for the Node.js build.