### PR TITLE
WIP changes to keep mutations around

### DIFF
--- a/packages/firestore/src/local/indexeddb_schema.ts
+++ b/packages/firestore/src/local/indexeddb_schema.ts
@@ -132,9 +132,9 @@ export class DbMutationQueue {
      */
     public userId: string,
     /**
-     * An identifier for the highest numbered batch that has been acknowledged
+     * An identifier for the highest numbered batch that has been processed
      * by the server. All MutationBatches in this queue with batchIds less
-     * than or equal to this value are considered to have been acknowledged by
+     * than or equal to this value are considered to have been responded to by
      * the server.
      */
     public lastAcknowledgedBatchId: number,

--- a/packages/firestore/src/local/local_documents_view.ts
+++ b/packages/firestore/src/local/local_documents_view.ts
@@ -128,7 +128,7 @@ export class LocalDocumentsView {
     // Query the remote documents and overlay mutations.
     // TODO(mikelehen): There may be significant overlap between the mutations
     // affecting these remote documents and the
-    // getAllMutationBatchesAffectingQuery() mutations. Consider optimizing.
+    // getPendingMutationBatchesAffectingQuery() mutations. Consider optimizing.
     let results: DocumentMap;
     return this.remoteDocumentCache
       .getDocumentsMatchingQuery(transaction, query)
@@ -139,7 +139,7 @@ export class LocalDocumentsView {
         results = promisedResults;
         // Now use the mutation queue to discover any other documents that may
         // match the query after applying mutations.
-        return this.mutationQueue.getAllMutationBatchesAffectingQuery(
+        return this.mutationQueue.getPendingMutationBatchesAffectingQuery(
           transaction,
           query
         );
@@ -197,7 +197,7 @@ export class LocalDocumentsView {
     document: MaybeDocument | null
   ): PersistencePromise<MaybeDocument | null> {
     return this.mutationQueue
-      .getAllMutationBatchesAffectingDocumentKey(transaction, documentKey)
+      .getPendingMutationBatchesAffectingDocumentKey(transaction, documentKey)
       .next(batches => {
         for (const batch of batches) {
           document = batch.applyToLocalView(documentKey, document);

--- a/packages/firestore/src/remote/remote_store.ts
+++ b/packages/firestore/src/remote/remote_store.ts
@@ -731,7 +731,11 @@ export class RemoteStore {
       this.writeStream.inhibitBackoff();
 
       return this.syncEngine
-        .rejectFailedWrite(batch.batchId, error)
+        .rejectFailedWrite(
+          batch.batchId,
+          this.writeStream.lastStreamToken,
+          error
+        )
         .then(() => {
           // It's possible that with the completion of this mutation
           // another slot has freed up.

--- a/packages/firestore/src/remote/remote_syncer.ts
+++ b/packages/firestore/src/remote/remote_syncer.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { BatchId, TargetId } from '../core/types';
+import { BatchId, ProtoByteString, TargetId } from '../core/types';
 import { MutationBatchResult } from '../model/mutation_batch';
 import { FirestoreError } from '../util/error';
 
@@ -56,5 +56,9 @@ export interface RemoteSyncer {
    * the local view of any documents affected by the batch and then, emitting
    * snapshots with the reverted value.
    */
-  rejectFailedWrite(batchId: BatchId, error: FirestoreError): Promise<void>;
+  rejectFailedWrite(
+    batchId: BatchId,
+    streamToken: ProtoByteString,
+    error: FirestoreError
+  ): Promise<void>;
 }

--- a/packages/firestore/test/unit/local/local_store.test.ts
+++ b/packages/firestore/test/unit/local/local_store.test.ts
@@ -160,7 +160,10 @@ class LocalStoreTester {
   afterRejectingMutation(): LocalStoreTester {
     this.promiseChain = this.promiseChain
       .then(() => {
-        return this.localStore.rejectBatch(this.batches.shift()!.batchId);
+        return this.localStore.rejectBatch(
+          this.batches.shift()!.batchId,
+          emptyByteString()
+        );
       })
       .then((changes: MaybeDocumentMap) => {
         this.lastChanges = changes;
@@ -231,6 +234,12 @@ class LocalStoreTester {
       return this.localStore
         .readDocument(doc.key)
         .then((result: MaybeDocument) => {
+          console.log(
+            'document exists: ' +
+              result.key +
+              ' : ' +
+              (result instanceof Document)
+          );
           expectEqual(result, doc);
         });
     });

--- a/packages/firestore/test/unit/local/test_mutation_queue.ts
+++ b/packages/firestore/test/unit/local/test_mutation_queue.ts
@@ -48,7 +48,7 @@ export class TestMutationQueue {
   countBatches(): Promise<number> {
     return this.persistence
       .runTransaction('countBatches', true, txn => {
-        return this.queue.getAllMutationBatches(txn);
+        return this.queue.getPendingMutationBatches(txn);
       })
       .then(batches => batches.length);
   }
@@ -69,15 +69,15 @@ export class TestMutationQueue {
     );
   }
 
-  acknowledgeBatch(
-    batch: MutationBatch,
+  setLastProcessedBatch(
+    batchId: BatchId,
     streamToken: ProtoByteString
   ): Promise<void> {
     return this.persistence.runTransaction(
       'acknowledgeThroughBatchId',
       true,
       txn => {
-        return this.queue.acknowledgeBatch(txn, batch, streamToken);
+        return this.queue.setLastProcessedBatch(txn, batchId, streamToken);
       }
     );
   }
@@ -118,17 +118,17 @@ export class TestMutationQueue {
     );
   }
 
-  getAllMutationBatches(): Promise<MutationBatch[]> {
+  getAllPendingBatches(): Promise<MutationBatch[]> {
     return this.persistence.runTransaction(
       'getAllMutationBatches',
       true,
       txn => {
-        return this.queue.getAllMutationBatches(txn);
+        return this.queue.getPendingMutationBatches(txn);
       }
     );
   }
 
-  getAllMutationBatchesThroughBatchId(
+  getAllPendingBatchesThroughBatchId(
     batchId: BatchId
   ): Promise<MutationBatch[]> {
     return this.persistence.runTransaction(
@@ -147,7 +147,7 @@ export class TestMutationQueue {
       'getAllMutationBatchesAffectingDocumentKey',
       true,
       txn => {
-        return this.queue.getAllMutationBatchesAffectingDocumentKey(
+        return this.queue.getPendingMutationBatchesAffectingDocumentKey(
           txn,
           documentKey
         );
@@ -160,7 +160,7 @@ export class TestMutationQueue {
       'getAllMutationBatchesAffectingQuery',
       true,
       txn => {
-        return this.queue.getAllMutationBatchesAffectingQuery(txn, query);
+        return this.queue.getPendingMutationBatchesAffectingQuery(txn, query);
       }
     );
   }


### PR DESCRIPTION
This changes the mutation queue to no longer remove acknowledged/rejected mutations.

This is not ready for review and doesn't yet deal with heldWriteAcks properly. All naming tbd.