### PR TITLE
Fix data message not being handled on foreground when backgroundMessageHandler isn't set

### DIFF
--- a/packages/messaging/src/controllers/sw-controller.ts
+++ b/packages/messaging/src/controllers/sw-controller.ts
@@ -98,12 +98,8 @@ export class SWController extends ControllerInterface {
 
     const hasVisibleClients = await this.hasVisibleClients_();
     if (hasVisibleClients) {
-      // Do not need to show a notification.
-      if (msgPayload.notification || this.bgMessageHandler) {
-        // Send to page
-        return this.sendMessageToWindowClients_(msgPayload);
-      }
-      return;
+      // App in foreground. Send to page.
+      return this.sendMessageToWindowClients_(msgPayload);
     }
 
     const notificationDetails = this.getNotificationData_(msgPayload);

--- a/packages/messaging/test/sw-controller.test.ts
+++ b/packages/messaging/test/sw-controller.test.ts
@@ -93,7 +93,7 @@ describe('Firebase Messaging > *SWController', () => {
       } as any);
     });
 
-    it('should not do anything if window is in focus', async () => {
+    it('should send data payload to window if window is in focus', async () => {
       const waitUntilSpy = sandbox.spy();
       const stub = sandbox.stub(
         SWController.prototype,
@@ -114,10 +114,10 @@ describe('Firebase Messaging > *SWController', () => {
       } as any);
 
       await waitUntilSpy.getCall(0).args[0];
-      expect(stub.callCount).to.equal(0);
+      expect(stub.callCount).to.equal(1);
     });
 
-    it('should send to window if a notification payload', async () => {
+    it('should send notification payload to window if window is in focus', async () => {
       const waitUntilSpy = sandbox.spy();
       const stub = sandbox.stub(
         SWController.prototype,
@@ -135,31 +135,6 @@ describe('Firebase Messaging > *SWController', () => {
             return {
               notification: {}
             };
-          }
-        }
-      } as any);
-
-      await waitUntilSpy.getCall(0).args[0];
-      expect(stub.callCount).to.equal(1);
-    });
-
-    it('should send to window if a bgMessageHandler is defined', async () => {
-      const waitUntilSpy = sandbox.spy();
-      const stub = sandbox.stub(
-        SWController.prototype,
-        'sendMessageToWindowClients_'
-      );
-      sandbox
-        .stub(SWController.prototype, 'hasVisibleClients_')
-        .callsFake(async () => true);
-
-      const swController = new SWController(app);
-      swController.setBackgroundMessageHandler((() => {}) as any);
-      swController.onPush({
-        waitUntil: waitUntilSpy,
-        data: {
-          json: () => {
-            return {};
           }
         }
       } as any);


### PR DESCRIPTION
According to https://firebase.google.com/docs/cloud-messaging/js/receive, a message should always be sent to the window client if it is in focus.

This change removes the checks that prevent the message from being sent if it is a data message and if bgMessageHandler isn't set.

Fixes #381.