### PR TITLE
Add pkg.files entry to each package.json

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -6,7 +6,7 @@
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
   "files": [
-    "dist/"
+    "dist"
   ],
   "scripts": {
     "build": "rollup -c",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -5,6 +5,9 @@
   "author": "Firebase <firebase-support@google.com> (https://firebase.google.com/)",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
+  "files": [
+    "dist/"
+  ],
   "scripts": {
     "build": "rollup -c",
     "dev": "rollup -c -w",

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -5,10 +5,7 @@
   "description": "Javascript library for Firebase Auth SDK",
   "author": "Firebase <firebase-support@google.com> (https://firebase.google.com/)",
   "files": [
-    "dist/**",
-    "LICENSE",
-    "README.md",
-    "package.json",
+    "dist",
     "index.d.ts"
   ],
   "scripts": {

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -6,6 +6,9 @@
   "main": "dist/index.node.cjs.js",
   "browser": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "rollup -c",
     "dev": "rollup -c -w",

--- a/packages/firestore/package.json
+++ b/packages/firestore/package.json
@@ -19,6 +19,9 @@
   "browser": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
   "license": "Apache-2.0",
+  "files": [
+    "dist"
+  ],
   "dependencies": {
     "@firebase/firestore-types": "0.2.2",
     "@firebase/logger": "0.1.0",

--- a/packages/functions/package.json
+++ b/packages/functions/package.json
@@ -6,6 +6,9 @@
   "main": "dist/index.node.cjs.js",
   "browser": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "rollup -c",
     "dev": "rollup -c -w",

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -5,6 +5,9 @@
   "author": "Firebase <firebase-support@google.com> (https://firebase.google.com/)",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "rollup -c",
     "dev": "rollup -c -w",

--- a/packages/messaging/package.json
+++ b/packages/messaging/package.json
@@ -5,6 +5,9 @@
   "author": "Firebase <firebase-support@google.com> (https://firebase.google.com/)",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "rollup -c",
     "dev": "rollup -c -w",

--- a/packages/polyfill/package.json
+++ b/packages/polyfill/package.json
@@ -5,6 +5,9 @@
   "author": "Firebase <firebase-support@google.com> (https://firebase.google.com/)",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "rollup -c",
     "dev": "rollup -c -w",

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -5,6 +5,9 @@
   "author": "Firebase <firebase-support@google.com> (https://firebase.google.com/)",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "rollup -c",
     "dev": "rollup -c -w",

--- a/packages/template/package.json
+++ b/packages/template/package.json
@@ -7,6 +7,9 @@
   "main": "dist/index.node.cjs.js",
   "browser": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "rollup -c",
     "dev": "rollup -c -w",

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -5,6 +5,9 @@
   "description": "",
   "author": "Firebase <firebase-support@google.com> (https://firebase.google.com/)",
   "main": "dist/index.cjs.js",
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "rollup -c",
     "dev": "rollup -c -w",

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -6,6 +6,9 @@
   "main": "dist/index.node.cjs.js",
   "browser": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "rollup -c",
     "dev": "rollup -c -w",

--- a/packages/webchannel-wrapper/package.json
+++ b/packages/webchannel-wrapper/package.json
@@ -4,6 +4,9 @@
   "description": "A wrapper of the webchannel packages from closure-library for use outside of a closure compiled application",
   "author": "Firebase <firebase-support@google.com> (https://firebase.google.com/)",
   "main": "dist/index.js",
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "dev": "watch 'npm run build' src",
     "build": "node tools/build.js",


### PR DESCRIPTION
We are accidentally including some of the coverage and cache directories in our NPM builds.

This scopes it to only the built artifacts in the `dist` directory of each component.

_NOTE: I removed some of the entries from `auth/package.json` because they are included by default (per https://docs.npmjs.com/files/package.json#files)_