### PR TITLE
Check browser support before instantiating controllers

### DIFF
--- a/integration/shared/validator.js
+++ b/integration/shared/validator.js
@@ -88,9 +88,16 @@ function validateNamespace(definition, candidate) {
       if (
         definitionChunk.__type === 'function' &&
         definitionChunk.__return &&
-        typeof candidateChunk === 'function' &&
-        candidateChunk()
+        typeof candidateChunk === 'function'
       ) {
+        try {
+          candidateChunk();
+        } catch (e) {
+          it(`Throws because current browser is unsupported`, () => {
+            __expect(e.code).to.have.string('unsupported-browser');
+          });
+          return;
+        }
         validateNamespace(definitionChunk.__return, candidateChunk());
       }
     });

--- a/packages/functions/test/browser/callable.test.ts
+++ b/packages/functions/test/browser/callable.test.ts
@@ -68,10 +68,16 @@ describe('Firebase Functions > Call', () => {
   // TODO(klimt): Move this to the cross-platform tests and delete this file,
   // once instance id works there.
   it('instance id', async () => {
+    if (!('serviceWorker' in navigator)) {
+      // Current platform does not support messaging, skip test.
+      return;
+    }
+
     // Stub out the messaging method get an instance id token.
-    const messaging = (firebase as any).messaging(app);
-    const stub = sinon.stub(messaging, 'getToken');
-    stub.returns(Promise.resolve('iid'));
+    const messaging = firebase.messaging(app);
+    const stub = sinon
+      .stub(messaging, 'getToken')
+      .returns(Promise.resolve('iid'));
 
     const func = functions.httpsCallable('instanceIdTest');
     const result = await func({});

--- a/packages/messaging/src/controllers/window-controller.ts
+++ b/packages/messaging/src/controllers/window-controller.ts
@@ -74,13 +74,6 @@ export class WindowController extends ControllerInterface {
    * permission isn't granted.
    */
   getToken(): Promise<string | null> {
-    // Check that the required API's are available
-    if (!this.isSupported_()) {
-      return Promise.reject(
-        errorFactory.create(ERROR_CODES.UNSUPPORTED_BROWSER)
-      );
-    }
-
     return this.manifestCheck_().then(() => {
       return super.getToken();
     });
@@ -355,10 +348,6 @@ export class WindowController extends ControllerInterface {
   // Visible for testing
   // TODO: Make private
   setupSWMessageListener_(): void {
-    if (!('serviceWorker' in navigator)) {
-      return;
-    }
-
     navigator.serviceWorker.addEventListener(
       'message',
       event => {
@@ -382,23 +371,6 @@ export class WindowController extends ControllerInterface {
         }
       },
       false
-    );
-  }
-
-  /**
-   * Checks to see if the required API's are valid or not.
-   * @return Returns true if the desired APIs are available.
-   */
-  // Visible for testing
-  // TODO: Make private
-  isSupported_(): boolean {
-    return (
-      'serviceWorker' in navigator &&
-      'PushManager' in window &&
-      'Notification' in window &&
-      'fetch' in window &&
-      ServiceWorkerRegistration.prototype.hasOwnProperty('showNotification') &&
-      PushSubscription.prototype.hasOwnProperty('getKey')
     );
   }
 }

--- a/packages/messaging/test/controller-get-token.test.ts
+++ b/packages/messaging/test/controller-get-token.test.ts
@@ -130,22 +130,6 @@ describe('Firebase Messaging > *Controller.getToken()', () => {
     return cleanUp();
   });
 
-  it('should throw on unsupported browsers', () => {
-    sandbox
-      .stub(WindowController.prototype, 'isSupported_')
-      .callsFake(() => false);
-
-    const messagingService = new WindowController(app);
-    return messagingService.getToken().then(
-      () => {
-        throw new Error('Expected getToken to throw ');
-      },
-      err => {
-        assert.equal('messaging/' + ERROR_CODES.UNSUPPORTED_BROWSER, err.code);
-      }
-    );
-  });
-
   it('should handle a failure to get registration', () => {
     sandbox
       .stub(ControllerInterface.prototype, 'getNotificationPermission_')

--- a/packages/messaging/test/index.test.ts
+++ b/packages/messaging/test/index.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Copyright 2018 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { expect } from 'chai';
+import { sandbox, SinonSandbox, SinonStub } from 'sinon';
+
+import { FirebaseApp } from '@firebase/app-types';
+import {
+  _FirebaseNamespace,
+  FirebaseServiceFactory
+} from '@firebase/app-types/private';
+
+import { registerMessaging } from '../index';
+import { ERROR_CODES } from '../src/models/errors';
+
+import { SWController } from '../src/controllers/sw-controller';
+import { WindowController } from '../src/controllers/window-controller';
+import { makeFakeApp } from './testing-utils/make-fake-app';
+
+describe('Firebase Messaging > registerMessaging', () => {
+  let sinonSandbox: SinonSandbox;
+  let registerService: SinonStub;
+  let fakeFirebase: _FirebaseNamespace;
+
+  beforeEach(() => {
+    sinonSandbox = sandbox.create();
+    registerService = sinonSandbox.stub();
+
+    fakeFirebase = {
+      INTERNAL: { registerService }
+    } as any;
+  });
+
+  afterEach(() => {
+    sinonSandbox.restore();
+  });
+
+  it('calls registerService', () => {
+    registerMessaging(fakeFirebase);
+    expect(registerService.callCount).to.equal(1);
+  });
+
+  describe('factoryMethod', () => {
+    let factoryMethod: FirebaseServiceFactory;
+    let fakeApp: FirebaseApp;
+
+    beforeEach(() => {
+      registerMessaging(fakeFirebase);
+      factoryMethod = registerService.getCall(0).args[1];
+
+      fakeApp = makeFakeApp({
+        messagingSenderId: '1234567890'
+      });
+    });
+
+    describe('in Service Worker context', () => {
+      beforeEach(() => {
+        // self.ServiceWorkerGlobalScope exists
+        // can't stub a non-existing property, so no sinon.stub().
+        (self as any).ServiceWorkerGlobalScope = {};
+      });
+
+      afterEach(() => {
+        delete (self as any).ServiceWorkerGlobalScope;
+      });
+
+      it('returns a SWController', () => {
+        const firebaseService = factoryMethod(fakeApp);
+        expect(firebaseService).to.be.instanceOf(SWController);
+      });
+    });
+
+    describe('in Window context', () => {
+      it('throws if required globals do not exist', () => {
+        // Empty navigator, no navigator.serviceWorker ¯\_(ツ)_/¯
+        sinonSandbox.stub(window, 'navigator').value({});
+
+        try {
+          factoryMethod(fakeApp);
+        } catch (e) {
+          expect(e.code).to.equal(
+            'messaging/' + ERROR_CODES.UNSUPPORTED_BROWSER
+          );
+          return;
+        }
+        throw new Error('Expected getToken to throw ');
+      });
+
+      it('returns a WindowController', () => {
+        const firebaseService = factoryMethod(fakeApp);
+        expect(firebaseService).to.be.instanceOf(WindowController);
+      });
+    });
+  });
+});

--- a/packages/messaging/test/index.test.ts
+++ b/packages/messaging/test/index.test.ts
@@ -18,9 +18,7 @@ import { expect } from 'chai';
 import { sandbox, SinonSandbox, SinonStub } from 'sinon';
 
 import { FirebaseApp } from '@firebase/app-types';
-import {
-  _FirebaseNamespace,
-} from '@firebase/app-types/private';
+import { _FirebaseNamespace } from '@firebase/app-types/private';
 
 import { MessagingServiceFactory, registerMessaging } from '../index';
 import { ERROR_CODES } from '../src/models/errors';

--- a/packages/messaging/test/index.test.ts
+++ b/packages/messaging/test/index.test.ts
@@ -20,10 +20,9 @@ import { sandbox, SinonSandbox, SinonStub } from 'sinon';
 import { FirebaseApp } from '@firebase/app-types';
 import {
   _FirebaseNamespace,
-  FirebaseServiceFactory
 } from '@firebase/app-types/private';
 
-import { registerMessaging } from '../index';
+import { MessagingServiceFactory, registerMessaging } from '../index';
 import { ERROR_CODES } from '../src/models/errors';
 
 import { SWController } from '../src/controllers/sw-controller';
@@ -54,7 +53,7 @@ describe('Firebase Messaging > registerMessaging', () => {
   });
 
   describe('factoryMethod', () => {
-    let factoryMethod: FirebaseServiceFactory;
+    let factoryMethod: MessagingServiceFactory;
     let fakeApp: FirebaseApp;
 
     beforeEach(() => {
@@ -63,6 +62,12 @@ describe('Firebase Messaging > registerMessaging', () => {
 
       fakeApp = makeFakeApp({
         messagingSenderId: '1234567890'
+      });
+    });
+
+    describe('isSupported', () => {
+      it('is a static method on factoryMethod', () => {
+        expect(factoryMethod.isSupported).to.be.a('function');
       });
     });
 

--- a/packages/messaging/test/window-controller.test.ts
+++ b/packages/messaging/test/window-controller.test.ts
@@ -349,13 +349,6 @@ describe('Firebase Messaging > *WindowController', () => {
   });
 
   describe('setupSWMessageListener_()', () => {
-    it('should not do anything is no service worker support', () => {
-      sandbox.stub(window, 'navigator').value({});
-
-      const controller = new WindowController(app);
-      controller.setupSWMessageListener_();
-    });
-
     it('should add listener when supported', () => {
       const spy = sandbox.spy();
       sandbox.stub(navigator, 'serviceWorker').value({


### PR DESCRIPTION
Checks browser support before instantiating messaging service controllers and fixes some tests.

I think it's better to let the developer know that Messaging will not work as soon as possible, instead of instantiating a controller without an issue and then throwing an error as soon as they try to use it.

This also prevents issues such as #658 by making sure we don't call any unsupported methods by accident.

This can break users who were not checking browser support before calling `firebase.messaging()`, so it should go to the v5 branch.