### PR TITLE
Adding mergeFields support to the Web SDK

### DIFF
--- a/packages/firebase/index.d.ts
+++ b/packages/firebase/index.d.ts
@@ -1,3 +1,5 @@
+import { FieldPath } from '../firestore-types/index';
+
 /**
  * Copyright 2017 Google Inc.
  *
@@ -1115,7 +1117,7 @@ declare namespace firebase.firestore {
    * An options object that configures the behavior of `set()` calls in
    * `DocumentReference`, `WriteBatch` and `Transaction`. These calls can be
    * configured to perform granular merges instead of overwriting the target
-   * documents in their entirety by providing a `SetOptions` with `merge: true`.
+   * documents in their entirety.
    */
   export interface SetOptions {
     /**
@@ -1124,6 +1126,16 @@ declare namespace firebase.firestore {
      * untouched.
      */
     readonly merge?: boolean;
+
+    /**
+     * Changes the behavior of set() calls to only replace the specified field
+     * paths. Any field path that is not specified is ignored and remains
+     * untouched.
+     *
+     * <p>It is an error to pass a SetOptions object to a set() call that is
+     * missing a value for any of the fields specified here.
+     */
+    readonly mergeFields?: (string | FieldPath)[];
   }
 
   /**

--- a/packages/firebase/index.d.ts
+++ b/packages/firebase/index.d.ts
@@ -1,5 +1,3 @@
-import { FieldPath } from '../firestore-types/index';
-
 /**
  * Copyright 2017 Google Inc.
  *

--- a/packages/firestore-types/index.d.ts
+++ b/packages/firestore-types/index.d.ts
@@ -483,7 +483,7 @@ export interface DocumentListenOptions {
  * An options object that configures the behavior of `set()` calls in
  * `DocumentReference`, `WriteBatch` and `Transaction`. These calls can be
  * configured to perform granular merges instead of overwriting the target
- * documents in their entirety by providing a `SetOptions` with `merge: true`.
+ * documents in their entirety.
  */
 export interface SetOptions {
   /**
@@ -492,6 +492,16 @@ export interface SetOptions {
    * untouched.
    */
   readonly merge?: boolean;
+
+  /**
+   * Changes the behavior of set() calls to only replace the specified field
+   * paths. Any field path that is not specified is ignored and remains
+   * untouched.
+   *
+   * <p>It is an error to pass a SetOptions object to a set() call that is
+   * missing a value for any of the fields specified here.
+   */
+  readonly mergeFields?: (string | FieldPath)[];
 }
 
 /**

--- a/packages/firestore/CHANGELOG.md
+++ b/packages/firestore/CHANGELOG.md
@@ -14,6 +14,8 @@
   Query.get() should fetch from server only, (by passing { source: 'server' }),
   cache only (by passing { source: 'cache' }), or attempt server and fall back
   to the cache (which was the only option previously, and is now the default).
+- [feature] Added new `{ mergeFields: (string|FieldPath)[] }` option to `set()` 
+  which allows merging of a reduced subset of fields.
 
 # 0.3.6
 - [fixed] Fixed a regression in the Firebase JS release 4.11.0 that could

--- a/packages/firestore/src/api/database.ts
+++ b/packages/firestore/src/api/database.ts
@@ -63,7 +63,8 @@ import {
   validateNamedType,
   validateOptionalArgType,
   validateOptionNames,
-  valueDescription
+  valueDescription,
+  validateOptionalArrayElements
 } from '../util/input_validation';
 import * as log from '../util/log';
 import { LogLevel } from '../util/log';
@@ -566,9 +567,14 @@ export class Transaction implements firestore.Transaction {
       this._firestore
     );
     options = validateSetOptions('Transaction.set', options);
-    const parsed = options.merge
-      ? this._firestore._dataConverter.parseMergeData('Transaction.set', value)
-      : this._firestore._dataConverter.parseSetData('Transaction.set', value);
+    const parsed =
+      options.merge || options.mergeFields
+        ? this._firestore._dataConverter.parseMergeData(
+            'Transaction.set',
+            value,
+            options.mergeFields
+          )
+        : this._firestore._dataConverter.parseSetData('Transaction.set', value);
     this._transaction.set(ref._key, parsed);
     return this;
   }
@@ -656,9 +662,14 @@ export class WriteBatch implements firestore.WriteBatch {
       this._firestore
     );
     options = validateSetOptions('WriteBatch.set', options);
-    const parsed = options.merge
-      ? this._firestore._dataConverter.parseMergeData('WriteBatch.set', value)
-      : this._firestore._dataConverter.parseSetData('WriteBatch.set', value);
+    const parsed =
+      options.merge || options.mergeFields
+        ? this._firestore._dataConverter.parseMergeData(
+            'WriteBatch.set',
+            value,
+            options.mergeFields
+          )
+        : this._firestore._dataConverter.parseSetData('WriteBatch.set', value);
     this._mutations = this._mutations.concat(
       parsed.toMutations(ref._key, Precondition.NONE)
     );
@@ -815,15 +826,17 @@ export class DocumentReference implements firestore.DocumentReference {
     validateBetweenNumberOfArgs('DocumentReference.set', arguments, 1, 2);
     options = validateSetOptions('DocumentReference.set', options);
 
-    const parsed = options.merge
-      ? this.firestore._dataConverter.parseMergeData(
-          'DocumentReference.set',
-          value
-        )
-      : this.firestore._dataConverter.parseSetData(
-          'DocumentReference.set',
-          value
-        );
+    const parsed =
+      options.merge || options.mergeFields
+        ? this.firestore._dataConverter.parseMergeData(
+            'DocumentReference.set',
+            value,
+            options.mergeFields
+          )
+        : this.firestore._dataConverter.parseSetData(
+            'DocumentReference.set',
+            value
+          );
     return this._firestoreClient.write(
       parsed.toMutations(this._key, Precondition.NONE)
     );
@@ -1920,8 +1933,24 @@ function validateSetOptions(
     };
   }
 
-  validateOptionNames(methodName, options, ['merge']);
+  validateOptionNames(methodName, options, ['merge', 'mergeFields']);
   validateNamedOptionalType(methodName, 'boolean', 'merge', options.merge);
+  validateOptionalArrayElements(
+    methodName,
+    'mergeFields',
+    'a string or a FieldPath',
+    options.mergeFields,
+    element =>
+      typeof element === 'string' || element instanceof ExternalFieldPath
+  );
+
+  if (options.mergeFields !== undefined && options.merge !== undefined) {
+    throw new FirestoreError(
+      Code.INVALID_ARGUMENT,
+      `Invalid options passed to function ${methodName}(): You cannot specify both "merge" and "mergeFields".`
+    );
+  }
+
   return options;
 }
 

--- a/packages/firestore/src/api/user_data_converter.ts
+++ b/packages/firestore/src/api/user_data_converter.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import * as firestore from '@firebase/firestore-types';
+
 import { Timestamp } from '../api/timestamp';
 import { DatabaseId } from '../core/database_info';
 import { DocumentKey } from '../model/document_key';
@@ -297,7 +299,11 @@ export class UserDataConverter {
   }
 
   /** Parse document data from a set() call with '{merge:true}'. */
-  parseMergeData(methodName: string, input: AnyJs): ParsedSetData {
+  parseMergeData(
+    methodName: string,
+    input: AnyJs,
+    fieldPaths?: Array<string | firestore.FieldPath>
+  ): ParsedSetData {
     const context = new ParseContext(
       UserDataSource.MergeSet,
       methodName,
@@ -305,11 +311,42 @@ export class UserDataConverter {
     );
     validatePlainObject('Data must be an object, but it was:', context, input);
 
-    const updateData = this.parseData(input, context);
-    const fieldMask = new FieldMask(context.fieldMask);
+    const updateData = this.parseData(input, context) as ObjectValue;
+    let fieldMask: FieldMask | null = null;
+
+    if (!fieldPaths) {
+      fieldMask = new FieldMask(context.fieldMask);
+    } else {
+      const validatedFieldPaths = [];
+
+      for (const stringOrFieldPath of fieldPaths) {
+        let fieldPath;
+
+        if (stringOrFieldPath instanceof ExternalFieldPath) {
+          fieldPath = stringOrFieldPath as ExternalFieldPath;
+        } else if (typeof stringOrFieldPath === 'string') {
+          fieldPath = fieldPathFromDotSeparatedString(
+            methodName,
+            stringOrFieldPath
+          );
+        } else {
+          fail('Expected stringOrFieldPath to be a string or a FieldPath');
+        }
+
+        if (!updateData.contains(fieldPath)) {
+          throw new FirestoreError(
+            Code.INVALID_ARGUMENT,
+            `Field '${fieldPath}' is specified in your field mask but missing from your input data.`
+          );
+        }
+        validatedFieldPaths.push(fieldPath);
+
+        fieldMask = new FieldMask(validatedFieldPaths);
+      }
+    }
     return new ParsedSetData(
       updateData as ObjectValue,
-      fieldMask,
+      fieldMask || new FieldMask(context.fieldMask),
       context.fieldTransforms
     );
   }

--- a/packages/firestore/src/api/user_data_converter.ts
+++ b/packages/firestore/src/api/user_data_converter.ts
@@ -350,7 +350,9 @@ export class UserDataConverter {
       );
     }
     return new ParsedSetData(
-      updateData as ObjectValue, fieldMask, fieldTransforms
+      updateData as ObjectValue,
+      fieldMask,
+      fieldTransforms
     );
   }
 

--- a/packages/firestore/src/api/user_data_converter.ts
+++ b/packages/firestore/src/api/user_data_converter.ts
@@ -312,10 +312,12 @@ export class UserDataConverter {
     validatePlainObject('Data must be an object, but it was:', context, input);
 
     const updateData = this.parseData(input, context) as ObjectValue;
-    let fieldMask: FieldMask | null = null;
+    let fieldMask: FieldMask;
+    let fieldTransforms: FieldTransform[];
 
     if (!fieldPaths) {
       fieldMask = new FieldMask(context.fieldMask);
+      fieldTransforms = context.fieldTransforms;
     } else {
       const validatedFieldPaths = [];
 
@@ -340,14 +342,15 @@ export class UserDataConverter {
           );
         }
         validatedFieldPaths.push(fieldPath);
-
-        fieldMask = new FieldMask(validatedFieldPaths);
       }
+
+      fieldMask = new FieldMask(validatedFieldPaths);
+      fieldTransforms = context.fieldTransforms.filter(transform =>
+        fieldMask.covers(transform.field)
+      );
     }
     return new ParsedSetData(
-      updateData as ObjectValue,
-      fieldMask || new FieldMask(context.fieldMask),
-      context.fieldTransforms
+      updateData as ObjectValue, fieldMask, fieldTransforms
     );
   }
 

--- a/packages/firestore/src/model/mutation.ts
+++ b/packages/firestore/src/model/mutation.ts
@@ -39,6 +39,22 @@ export class FieldMask {
     // TODO(dimond): validation of FieldMask
   }
 
+  /**
+   * Verifies that `fieldPath` is included by at least one field in this field
+   * mask.
+   *
+   * This is an O(n) operation, where `n` is the size of the field mask.
+   */
+  covers(fieldPath: FieldPath): boolean {
+    for (const fieldMaskPath of this.fields) {
+      if (fieldMaskPath.isPrefixOf(fieldPath)) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
   isEqual(other: FieldMask): boolean {
     return misc.arrayEquals(this.fields, other.fields);
   }

--- a/packages/firestore/src/util/input_validation.ts
+++ b/packages/firestore/src/util/input_validation.ts
@@ -175,7 +175,7 @@ export function validateArrayElements<T>(
   typeDescription: string,
   argument: T[],
   validator: (T) => boolean
-) : void {
+): void {
   if (!(argument instanceof Array)) {
     throw new FirestoreError(
       Code.INVALID_ARGUMENT,
@@ -202,7 +202,7 @@ export function validateOptionalArrayElements<T>(
   typeDescription: string,
   argument: T[] | undefined,
   validator: (T) => boolean
-) : void {
+): void {
   if (argument !== undefined) {
     validateArrayElements(
       functionName,

--- a/packages/firestore/src/util/input_validation.ts
+++ b/packages/firestore/src/util/input_validation.ts
@@ -169,6 +169,51 @@ export function validateNamedOptionalType(
   }
 }
 
+export function validateArrayElements<T>(
+  functionName: string,
+  optionName: string,
+  typeDescription: string,
+  argument: T[],
+  validator: (T) => boolean
+) : void {
+  if (!(argument instanceof Array)) {
+    throw new FirestoreError(
+      Code.INVALID_ARGUMENT,
+      `Function ${functionName}() requires its ${optionName} ` +
+        `option to be an array, but it was: ${valueDescription(argument)}`
+    );
+  }
+
+  for (let i = 0; i < argument.length; ++i) {
+    if (!validator(argument[i])) {
+      throw new FirestoreError(
+        Code.INVALID_ARGUMENT,
+        `Function ${functionName}() requires all ${optionName} ` +
+          `elements to be ${typeDescription}, but the value at index ${i} ` +
+          `was: ${valueDescription(argument[i])}`
+      );
+    }
+  }
+}
+
+export function validateOptionalArrayElements<T>(
+  functionName: string,
+  optionName: string,
+  typeDescription: string,
+  argument: T[] | undefined,
+  validator: (T) => boolean
+) : void {
+  if (argument !== undefined) {
+    validateArrayElements(
+      functionName,
+      optionName,
+      typeDescription,
+      argument,
+      validator
+    );
+  }
+}
+
 /**
  * Validates that the provided named option equals one of the expected values.
  */

--- a/packages/firestore/test/integration/api/database.test.ts
+++ b/packages/firestore/test/integration/api/database.test.ts
@@ -288,7 +288,7 @@ apiDescribe('Database', persistence => {
     });
   });
 
-  it('can specify fields multiple time in a field mask', () => {
+  it('can specify fields multiple times in a field mask', () => {
     const initialData = {
       desc: 'Description',
       owner: { name: 'Jonny', email: 'abc@xyz.com' }

--- a/packages/firestore/test/integration/api/validation.test.ts
+++ b/packages/firestore/test/integration/api/validation.test.ts
@@ -304,6 +304,28 @@ apiDescribe('Validation:', persistence => {
       });
   });
 
+  validationIt(persistence, 'Merge options are validated', db => {
+    const docRef = db.collection('test').doc();
+
+    expect(() => docRef.set({}, { merge: true, mergeFields: [] })).to.throw(
+      'Invalid options passed to function DocumentReference.set(): You cannot specify both "merge" and "mergeFields".'
+    );
+    expect(() => docRef.set({}, { merge: false, mergeFields: [] })).to.throw(
+      'Invalid options passed to function DocumentReference.set(): You cannot specify both "merge" and "mergeFields".'
+    );
+    expect(() => docRef.set({}, { merge: 'foo' as any })).to.throw(
+      'Function DocumentReference.set() requires its merge option to be of type boolean, but it was: "foo"'
+    );
+    expect(() => docRef.set({}, { mergeFields: 'foo' as any })).to.throw(
+      'Function DocumentReference.set() requires its mergeFields option to be an array, but it was: "foo"'
+    );
+    expect(() =>
+      docRef.set({}, { mergeFields: ['foo', false as any] })
+    ).to.throw(
+      'Function DocumentReference.set() requires all mergeFields elements to be a string or a FieldPath, but the value at index 1 was: false'
+    );
+  });
+
   describe('Writes', () => {
     /** Class used to verify custom classes can't be used in writes. */
     class TestClass {


### PR DESCRIPTION
This PR adds field mask support to `.set(, {..})`. It's mostly a port of the missing features from https://critique.corp.google.com/#review/167190604 (internal)