### PR TITLE
fix(@firebase/auth): export types from auth-types

### DIFF
--- a/packages/auth/index.d.ts
+++ b/packages/auth/index.d.ts
@@ -14,4 +14,4 @@
  * limitations under the License.
  */
 
-import "@firebase/auth-types";
+export * from "@firebase/auth-types";


### PR DESCRIPTION
Exports the types from `@firebase/auth-types` in `@firebase/auth`

This allows to import types from `@firebase/auth` when using typescript.