### PR TITLE
Update base64-to-array-buffer.ts

### DIFF
--- a/packages/messaging/src/helpers/base64-to-array-buffer.ts
+++ b/packages/messaging/src/helpers/base64-to-array-buffer.ts
@@ -20,7 +20,7 @@ export function base64ToArrayBuffer(base64String: string): Uint8Array {
     .replace(/\-/g, '+')
     .replace(/_/g, '/');
 
-  const rawData = window.atob(base64);
+  const rawData = atob(base64);
   const outputArray = new Uint8Array(rawData.length);
 
   for (let i = 0; i < rawData.length; ++i) {


### PR DESCRIPTION
Fixes https://github.com/firebase/quickstart-js/issues/199

A similar issue was fixed in a separate helper but this one wasn't fixed as well.