### PR TITLE
Use correct assert() method so we get good error messages.

### DIFF
--- a/packages/firestore/test/util/equality_matcher.ts
+++ b/packages/firestore/test/util/equality_matcher.ts
@@ -71,13 +71,13 @@ export function addEqualityMatcher(): void {
             utils.flag(this, 'message', msg);
             const left = utils.flag(this, 'object');
 
-            chai.assert(
+            new chai.Assertion(left).assert(
               customDeepEqual(left, right),
               'expected #{act} to roughly deeply equal #{exp}',
               'expected #{act} to not roughly deeply equal #{exp}',
               left,
               right,
-              true
+              /*showDiff=*/ true
             );
           } else {
             originalFunction.apply(this, args);


### PR DESCRIPTION
BEFORE:
```
     AssertionError: expected null to roughly deeply equal undefined
```

AFTER:
```
      AssertionError: expected { Object (elements) } to roughly deeply equal { Object (elements) }
      + expected - actual
       {
         "elements": [
           {
      -      "internalValue": "foo"
      +      "internalValue": "tag"
             "typeOrder": 4
           }
         ]
       }
```