### PR TITLE
Refactoring Messaging

### DIFF
--- a/packages/messaging/src/controllers/controller-interface.ts
+++ b/packages/messaging/src/controllers/controller-interface.ts
@@ -77,15 +77,11 @@ export abstract class ControllerInterface implements FirebaseMessaging {
   async getToken(): Promise<string | null> {
     // Check with permissions
     const currentPermission = this.getNotificationPermission_();
-    if (currentPermission !== 'granted') {
-      if (currentPermission === 'denied') {
-        return Promise.reject(
-          errorFactory.create(ERROR_CODES.NOTIFICATIONS_BLOCKED)
-        );
-      }
-
+    if (currentPermission === 'denied') {
+      throw errorFactory.create(ERROR_CODES.NOTIFICATIONS_BLOCKED);
+    } else if (currentPermission !== 'granted') {
       // We must wait for permission to be granted
-      return Promise.resolve(null);
+      return null;
     }
 
     const swReg = await this.getSWRegistration_();
@@ -223,7 +219,6 @@ export abstract class ControllerInterface implements FirebaseMessaging {
    * unsubscribes the token from FCM  and then unregisters the push
    * subscription if it exists. It returns a promise that indicates
    * whether or not the unsubscribe request was processed successfully.
-   * @export
    */
   async deleteToken(token: string): Promise<boolean> {
     // Delete the token details from the database.

--- a/packages/messaging/src/controllers/window-controller.ts
+++ b/packages/messaging/src/controllers/window-controller.ts
@@ -81,46 +81,10 @@ export class WindowController extends ControllerInterface {
    */
   async getToken(): Promise<string | null> {
     if (!this.manifestCheckPromise) {
-      this.manifestCheckPromise = this.manifestCheck_();
+      this.manifestCheckPromise = manifestCheck();
     }
     await this.manifestCheckPromise;
     return super.getToken();
-  }
-
-  /**
-   * The method checks that a manifest is defined and has the correct GCM
-   * sender ID.
-   * @return Returns a promise that resolves if the manifest matches
-   * our required sender ID
-   */
-  // Visible for testing
-  // TODO: make private
-  async manifestCheck_(): Promise<void> {
-    const manifestTag = document.querySelector<HTMLAnchorElement>(
-      'link[rel="manifest"]'
-    );
-
-    if (!manifestTag) {
-      return;
-    }
-
-    let manifestContent: ManifestContent;
-    try {
-      const response = await fetch(manifestTag.href);
-      manifestContent = await response.json();
-    } catch (e) {
-      // If the download or parsing fails allow check.
-      // We only want to error if we KNOW that the gcm_sender_id is incorrect.
-      return;
-    }
-
-    if (!manifestContent || !manifestContent.gcm_sender_id) {
-      return;
-    }
-
-    if (manifestContent.gcm_sender_id !== '103953800507') {
-      throw errorFactory.create(ERROR_CODES.INCORRECT_GCM_SENDER_ID);
-    }
   }
 
   /**
@@ -352,5 +316,40 @@ export class WindowController extends ControllerInterface {
       },
       false
     );
+  }
+}
+
+/**
+ * The method checks that a manifest is defined and has the correct GCM
+ * sender ID.
+ * @return Returns a promise that resolves if the manifest matches
+ * our required sender ID
+ */
+// Exported for testing
+export async function manifestCheck(): Promise<void> {
+  const manifestTag = document.querySelector<HTMLAnchorElement>(
+    'link[rel="manifest"]'
+  );
+
+  if (!manifestTag) {
+    return;
+  }
+
+  let manifestContent: ManifestContent;
+  try {
+    const response = await fetch(manifestTag.href);
+    manifestContent = await response.json();
+  } catch (e) {
+    // If the download or parsing fails allow check.
+    // We only want to error if we KNOW that the gcm_sender_id is incorrect.
+    return;
+  }
+
+  if (!manifestContent || !manifestContent.gcm_sender_id) {
+    return;
+  }
+
+  if (manifestContent.gcm_sender_id !== '103953800507') {
+    throw errorFactory.create(ERROR_CODES.INCORRECT_GCM_SENDER_ID);
   }
 }

--- a/packages/messaging/test/window-controller.test.ts
+++ b/packages/messaging/test/window-controller.test.ts
@@ -19,7 +19,10 @@ import * as sinon from 'sinon';
 import { makeFakeApp } from './testing-utils/make-fake-app';
 import { makeFakeSWReg } from './testing-utils/make-fake-sw-reg';
 
-import { WindowController } from '../src/controllers/window-controller';
+import {
+  manifestCheck,
+  WindowController
+} from '../src/controllers/window-controller';
 import { base64ToArrayBuffer } from '../src/helpers/base64-to-array-buffer';
 import { DEFAULT_PUBLIC_VAPID_KEY } from '../src/models/fcm-details';
 
@@ -46,15 +49,14 @@ describe('Firebase Messaging > *WindowController', () => {
     return cleanup();
   });
 
-  describe('manifestCheck_()', () => {
+  describe('manifestCheck()', () => {
     it("should resolve when the tag isn't defined", () => {
       sandbox
         .stub(document, 'querySelector')
         .withArgs('link[rel="manifest"]')
         .returns(null);
 
-      const controller = new WindowController(app);
-      return controller.manifestCheck_();
+      return manifestCheck();
     });
 
     it('should fetch the manifest if defined and resolve when no gcm_sender_id', () => {
@@ -76,8 +78,7 @@ describe('Firebase Messaging > *WindowController', () => {
           })
         );
 
-      const controller = new WindowController(app);
-      return controller.manifestCheck_();
+      return manifestCheck();
     });
 
     it('should fetch the manifest if defined and resolve with expected gcm_sender_id', () => {
@@ -101,8 +102,7 @@ describe('Firebase Messaging > *WindowController', () => {
           })
         );
 
-      const controller = new WindowController(app);
-      return controller.manifestCheck_();
+      return manifestCheck();
     });
 
     it('should fetch the manifest if defined and reject when using wrong gcm_sender_id', () => {
@@ -126,8 +126,7 @@ describe('Firebase Messaging > *WindowController', () => {
           })
         );
 
-      const controller = new WindowController(app);
-      return controller.manifestCheck_().then(
+      return manifestCheck().then(
         () => {
           throw new Error('Expected error to be thrown.');
         },
@@ -150,8 +149,7 @@ describe('Firebase Messaging > *WindowController', () => {
         .withArgs('https://firebase.io/messaging/example')
         .returns(Promise.reject(new Error('Injected Failure.')));
 
-      const controller = new WindowController(app);
-      return controller.manifestCheck_();
+      return manifestCheck();
     });
   });
 

--- a/packages/messaging/test/window-controller.test.ts
+++ b/packages/messaging/test/window-controller.test.ts
@@ -206,16 +206,6 @@ describe('Firebase Messaging > *WindowController', () => {
       const controller = new WindowController(app);
       return controller.requestPermission();
     });
-
-    it('should resolve if the requestPermission() is granted using old callback API', () => {
-      sandbox.stub(Notification as any, 'permission').value('default');
-      sandbox.stub(Notification, 'requestPermission').callsFake(cb => {
-        cb('granted');
-      });
-
-      const controller = new WindowController(app);
-      return controller.requestPermission();
-    });
   });
 
   describe('useServiceWorker()', () => {


### PR DESCRIPTION
Simplified the code by replacing some more promises with async/await and removing deprecated callback API of `Notification.requestPermission()`.

Promise based `requestPermission` API is supported by Chrome since version 46 (2015-10-13) and Firefox since version 47 (2016-06-07). [Source](https://developer.mozilla.org/en-US/docs/Web/API/Notification/requestPermission).