### PR TITLE
Using an IndexedDB mock for Node testing

### DIFF
--- a/packages/firestore/.idea/runConfigurations/All_Tests.xml
+++ b/packages/firestore/.idea/runConfigurations/All_Tests.xml
@@ -1,0 +1,16 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="All Tests" type="mocha-javascript-test-runner" factoryName="Mocha">
+    <node-interpreter>project</node-interpreter>
+    <node-options />
+    <working-directory>$PROJECT_DIR$</working-directory>
+    <pass-parent-env>true</pass-parent-env>
+    <envs>
+      <env name="USE_MOCK_PERSISTENCE" value="YES" />
+    </envs>
+    <ui>bdd</ui>
+    <extra-mocha-options>--require ts-node/register/type-check --require index.node.ts --timeout 5000</extra-mocha-options>
+    <test-kind>PATTERN</test-kind>
+    <test-pattern>test/{,!(browser)/**/}*.test.ts</test-pattern>
+    <method />
+  </configuration>
+</component>

--- a/packages/firestore/.idea/runConfigurations/All_Tests__w__Mock_Persistence_.xml
+++ b/packages/firestore/.idea/runConfigurations/All_Tests__w__Mock_Persistence_.xml
@@ -1,0 +1,16 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="All Tests (w/ Mock Persistence)" type="mocha-javascript-test-runner" factoryName="Mocha">
+    <node-interpreter>project</node-interpreter>
+    <node-options />
+    <working-directory>$PROJECT_DIR$</working-directory>
+    <pass-parent-env>true</pass-parent-env>
+    <envs>
+      <env name="USE_MOCK_PERSISTENCE" value="YES" />
+    </envs>
+    <ui>bdd</ui>
+    <extra-mocha-options>--require ts-node/register/type-check --require index.node.ts --require test/util/mock_persistence.ts --timeout 5000</extra-mocha-options>
+    <test-kind>PATTERN</test-kind>
+    <test-pattern>test/{,!(browser)/**/}*.test.ts</test-pattern>
+    <method />
+  </configuration>
+</component>

--- a/packages/firestore/.idea/runConfigurations/Integration_Tests.xml
+++ b/packages/firestore/.idea/runConfigurations/Integration_Tests.xml
@@ -1,0 +1,16 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Integration Tests" type="mocha-javascript-test-runner" factoryName="Mocha">
+    <node-interpreter>project</node-interpreter>
+    <node-options />
+    <working-directory>$PROJECT_DIR$</working-directory>
+    <pass-parent-env>true</pass-parent-env>
+    <envs>
+      <env name="USE_MOCK_PERSISTENCE" value="YES" />
+    </envs>
+    <ui>bdd</ui>
+    <extra-mocha-options>--require ts-node/register/type-check --require index.node.ts --timeout 5000</extra-mocha-options>
+    <test-kind>PATTERN</test-kind>
+    <test-pattern>test/integration/{,!(browser)/**/}*.test.ts</test-pattern>
+    <method />
+  </configuration>
+</component>

--- a/packages/firestore/.idea/runConfigurations/Integration_Tests__w__Mock_Persistence_.xml
+++ b/packages/firestore/.idea/runConfigurations/Integration_Tests__w__Mock_Persistence_.xml
@@ -1,0 +1,16 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Integration Tests (w/ Mock Persistence)" type="mocha-javascript-test-runner" factoryName="Mocha">
+    <node-interpreter>project</node-interpreter>
+    <node-options />
+    <working-directory>$PROJECT_DIR$</working-directory>
+    <pass-parent-env>true</pass-parent-env>
+    <envs>
+      <env name="USE_MOCK_PERSISTENCE" value="YES" />
+    </envs>
+    <ui>bdd</ui>
+    <extra-mocha-options>--require ts-node/register/type-check --require index.node.ts --require test/util/mock_persistence.ts --timeout 5000</extra-mocha-options>
+    <test-kind>PATTERN</test-kind>
+    <test-pattern>test/integration/{,!(browser)/**/}*.test.ts</test-pattern>
+    <method />
+  </configuration>
+</component>

--- a/packages/firestore/.idea/runConfigurations/Unit_Tests.xml
+++ b/packages/firestore/.idea/runConfigurations/Unit_Tests.xml
@@ -1,0 +1,16 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Unit Tests" type="mocha-javascript-test-runner" factoryName="Mocha">
+    <node-interpreter>project</node-interpreter>
+    <node-options />
+    <working-directory>$PROJECT_DIR$</working-directory>
+    <pass-parent-env>true</pass-parent-env>
+    <envs>
+      <env name="USE_MOCK_PERSISTENCE" value="YES" />
+    </envs>
+    <ui>bdd</ui>
+    <extra-mocha-options>--require ts-node/register/type-check --require index.node.ts</extra-mocha-options>
+    <test-kind>PATTERN</test-kind>
+    <test-pattern>test/unit/{,!(browser)/**/}*.test.ts</test-pattern>
+    <method />
+  </configuration>
+</component>

--- a/packages/firestore/.idea/runConfigurations/Unit_Tests__w__Mock_Persistence_.xml
+++ b/packages/firestore/.idea/runConfigurations/Unit_Tests__w__Mock_Persistence_.xml
@@ -1,0 +1,16 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Unit Tests (w/ Mock Persistence)" type="mocha-javascript-test-runner" factoryName="Mocha">
+    <node-interpreter>project</node-interpreter>
+    <node-options />
+    <working-directory>$PROJECT_DIR$</working-directory>
+    <pass-parent-env>true</pass-parent-env>
+    <envs>
+      <env name="USE_MOCK_PERSISTENCE" value="YES" />
+    </envs>
+    <ui>bdd</ui>
+    <extra-mocha-options>--require ts-node/register/type-check --require index.node.ts --require test/util/mock_persistence.ts</extra-mocha-options>
+    <test-kind>PATTERN</test-kind>
+    <test-pattern>test/unit/{,!(browser)/**/}*.test.ts</test-pattern>
+    <method />
+  </configuration>
+</component>

--- a/packages/firestore/.npmignore
+++ b/packages/firestore/.npmignore
@@ -1,6 +1,7 @@
 # Directories not needed by end users
 /src
 test
+.idea
 
 # Files not needed by end users
 gulpfile.js

--- a/packages/firestore/package.json
+++ b/packages/firestore/package.json
@@ -13,6 +13,7 @@
     "test:browser": "karma start --single-run",
     "test:browser:debug": "karma start --browsers=Chrome --auto-watch",
     "test:node": "TS_NODE_CACHE=NO nyc --reporter lcovonly -- mocha 'test/{,!(browser)/**/}*.test.ts' --require ts-node/register/type-check --require index.node.ts --retries 5 --timeout 5000 --exit",
+    "test:node:persistence": "USE_MOCK_PERSISTENCE=YES TS_NODE_CACHE=NO nyc --reporter lcovonly -- mocha 'test/{,!(browser)/**/}*.test.ts' --require ts-node/register/type-check --require index.node.ts --require test/util/mock_persistence.ts --retries 5 --timeout 5000 --exit",
     "prepare": "npm run build"
   },
   "main": "dist/index.node.cjs.js",
@@ -39,6 +40,7 @@
     "@types/mocha": "5.0.0",
     "@types/sinon": "4.3.1",
     "chai": "4.1.2",
+    "indexeddbshim":"^3.6.1",
     "karma": "2.0.0",
     "karma-chrome-launcher": "2.2.0",
     "karma-cli": "1.0.1",

--- a/packages/firestore/package.json
+++ b/packages/firestore/package.json
@@ -40,7 +40,7 @@
     "@types/mocha": "5.0.0",
     "@types/sinon": "4.3.1",
     "chai": "4.1.2",
-    "indexeddbshim":"^3.6.1",
+    "indexeddbshim":"3.6.1",
     "karma": "2.0.0",
     "karma-chrome-launcher": "2.2.0",
     "karma-cli": "1.0.1",

--- a/packages/firestore/src/api/database.ts
+++ b/packages/firestore/src/api/database.ts
@@ -429,9 +429,11 @@ follow these steps, YOUR APP MAY BREAK.`);
   }
 
   INTERNAL = {
-    delete: async (): Promise<void> => {
+    delete: async (options?: {
+      purgePersistenceWithDataLoss?: boolean;
+    }): Promise<void> => {
       if (this._firestoreClient) {
-        return this._firestoreClient.shutdown();
+        return this._firestoreClient.shutdown(options);
       }
     }
   };

--- a/packages/firestore/src/core/firestore_client.ts
+++ b/packages/firestore/src/core/firestore_client.ts
@@ -335,7 +335,7 @@ export class FirestoreClient {
     });
   }
 
-  shutdown(): Promise<void> {
+  shutdown(options?: { purgePersistenceWithDataLoss?: boolean }): Promise<void> {
     return this.asyncQueue
       .enqueue(() => {
         this.credentials.removeUserChangeListener();
@@ -343,7 +343,9 @@ export class FirestoreClient {
       })
       .then(() => {
         // PORTING NOTE: LocalStore does not need an explicit shutdown on web.
-        return this.persistence.shutdown();
+        return this.persistence.shutdown(
+          options && options.purgePersistenceWithDataLoss
+        );
       });
   }
 

--- a/packages/firestore/src/core/firestore_client.ts
+++ b/packages/firestore/src/core/firestore_client.ts
@@ -335,7 +335,9 @@ export class FirestoreClient {
     });
   }
 
-  shutdown(options?: { purgePersistenceWithDataLoss?: boolean }): Promise<void> {
+  shutdown(options?: {
+    purgePersistenceWithDataLoss?: boolean;
+  }): Promise<void> {
     return this.asyncQueue
       .enqueue(() => {
         this.credentials.removeUserChangeListener();

--- a/packages/firestore/src/local/indexeddb_mutation_queue.ts
+++ b/packages/firestore/src/local/indexeddb_mutation_queue.ts
@@ -546,6 +546,7 @@ export class IndexedDbMutationQueue implements MutationQueue {
 
 function convertStreamToken(token: ProtoByteString): string {
   if (token instanceof Uint8Array) {
+    // TODO(b/78771403): Convert tokens to strings during deserialization
     assert(
       process.env.USE_MOCK_PERSISTENCE === 'YES',
       'Persisting non-string stream tokens is only supported with mock persistence .'

--- a/packages/firestore/src/local/indexeddb_mutation_queue.ts
+++ b/packages/firestore/src/local/indexeddb_mutation_queue.ts
@@ -190,7 +190,7 @@ export class IndexedDbMutationQueue implements MutationQueue {
     );
 
     this.metadata.lastAcknowledgedBatchId = batchId;
-    this.metadata.lastStreamToken = validateStreamToken(streamToken);
+    this.metadata.lastStreamToken = convertStreamToken(streamToken);
 
     return mutationQueuesStore(transaction).put(this.metadata);
   }
@@ -205,7 +205,7 @@ export class IndexedDbMutationQueue implements MutationQueue {
     transaction: PersistenceTransaction,
     streamToken: ProtoByteString
   ): PersistencePromise<void> {
-    this.metadata.lastStreamToken = validateStreamToken(streamToken);
+    this.metadata.lastStreamToken = convertStreamToken(streamToken);
     return mutationQueuesStore(transaction).put(this.metadata);
   }
 
@@ -544,12 +544,16 @@ export class IndexedDbMutationQueue implements MutationQueue {
   }
 }
 
-function validateStreamToken(token: ProtoByteString): string {
-  assert(
-    typeof token === 'string',
-    'Persisting non-string stream token not supported.'
-  );
-  return token as string;
+function convertStreamToken(token: ProtoByteString): string {
+  if (token instanceof Uint8Array) {
+    assert(
+      process.env.USE_MOCK_PERSISTENCE === 'YES',
+      'Persisting non-string stream tokens is only supported with mock persistence .'
+    );
+    return token.toString();
+  } else {
+    return token;
+  }
 }
 
 /**

--- a/packages/firestore/src/local/indexeddb_persistence.ts
+++ b/packages/firestore/src/local/indexeddb_persistence.ts
@@ -143,13 +143,16 @@ export class IndexedDbPersistence implements Persistence {
       });
   }
 
-  shutdown(): Promise<void> {
+  shutdown(deleteData?: boolean): Promise<void> {
     assert(this.started, 'IndexedDbPersistence shutdown without start!');
     this.started = false;
     this.detachWindowUnloadHook();
     this.stopOwnerLeaseRefreshes();
     return this.releaseOwnerLease().then(() => {
       this.simpleDb.close();
+      if (deleteData) {
+        return SimpleDb.delete(this.dbName);
+      }
     });
   }
 
@@ -350,19 +353,29 @@ export class IndexedDbPersistence implements Persistence {
    * a synchronous API and so can be used reliably from an unload handler.
    */
   private attachWindowUnloadHook(): void {
-    this.windowUnloadHandler = () => {
-      // Record that we're zombied.
-      this.setZombiedOwnerId(this.ownerId);
+    if (
+      typeof window === 'object' &&
+      typeof window.addEventListener === 'function'
+    ) {
+      this.windowUnloadHandler = () => {
+        // Record that we're zombied.
+        this.setZombiedOwnerId(this.ownerId);
 
-      // Attempt graceful shutdown (including releasing our owner lease), but
-      // there's no guarantee it will complete.
-      this.shutdown();
-    };
-    window.addEventListener('unload', this.windowUnloadHandler);
+        // Attempt graceful shutdown (including releasing our owner lease), but
+        // there's no guarantee it will complete.
+        this.shutdown();
+      };
+      window.addEventListener('unload', this.windowUnloadHandler);
+    }
   }
 
   private detachWindowUnloadHook(): void {
     if (this.windowUnloadHandler) {
+      assert(
+        typeof window === 'object' &&
+          typeof window.removeEventListener === 'function',
+        "Expected 'window.removeEventListener' to be a function"
+      );
       window.removeEventListener('unload', this.windowUnloadHandler);
       this.windowUnloadHandler = null;
     }

--- a/packages/firestore/src/local/local_serializer.ts
+++ b/packages/firestore/src/local/local_serializer.ts
@@ -132,11 +132,18 @@ export class LocalSerializer {
     } else {
       queryProto = this.remoteSerializer.toQueryTarget(queryData.query);
     }
-    assert(
-      typeof queryData.resumeToken === 'string',
-      'Persisting non-string resume token not supported.'
-    );
-    const resumeToken = queryData.resumeToken as string;
+
+    let resumeToken: string;
+
+    if (queryData.resumeToken instanceof Uint8Array) {
+      assert(
+        process.env.USE_MOCK_PERSISTENCE === 'YES',
+        'Persisting non-string stream tokens is only supported with mock persistence .'
+      );
+      resumeToken = queryData.resumeToken.toString();
+    } else {
+      resumeToken = queryData.resumeToken;
+    }
 
     // lastListenSequenceNumber is always 0 until we do real GC.
     return new DbTarget(

--- a/packages/firestore/src/local/local_serializer.ts
+++ b/packages/firestore/src/local/local_serializer.ts
@@ -136,6 +136,7 @@ export class LocalSerializer {
     let resumeToken: string;
 
     if (queryData.resumeToken instanceof Uint8Array) {
+      // TODO(b/78771403): Convert tokens to strings during deserialization
       assert(
         process.env.USE_MOCK_PERSISTENCE === 'YES',
         'Persisting non-string stream tokens is only supported with mock persistence .'

--- a/packages/firestore/src/local/memory_persistence.ts
+++ b/packages/firestore/src/local/memory_persistence.ts
@@ -53,7 +53,7 @@ export class MemoryPersistence implements Persistence {
     this.started = true;
   }
 
-  async shutdown(): Promise<void> {
+  async shutdown(deleteData?: boolean): Promise<void> {
     // No durable state to ensure is closed on shutdown.
     assert(this.started, 'MemoryPersistence shutdown without start!');
     this.started = false;

--- a/packages/firestore/src/local/persistence.ts
+++ b/packages/firestore/src/local/persistence.ts
@@ -75,8 +75,13 @@ export interface Persistence {
    */
   start(): Promise<void>;
 
-  /** Releases any resources held during eager shutdown. */
-  shutdown(): Promise<void>;
+  /**
+   * Releases any resources held during eager shutdown.
+   *
+   * @param deleteData Whether to delete the persisted data. This causes
+   * irrecoverable data loss and should only be used to delete test data.
+   */
+  shutdown(deleteData?: boolean): Promise<void>;
 
   /**
    * Returns a MutationQueue representing the persisted mutations for the

--- a/packages/firestore/src/local/simple_db.ts
+++ b/packages/firestore/src/local/simple_db.ts
@@ -102,29 +102,31 @@ export class SimpleDb {
     // to return that persistence is not enabled for those browsers.
     // For tracking support of this feature, see here:
     // https://developer.microsoft.com/en-us/microsoft-edge/platform/status/indexeddbarraysandmultientrysupport/
+    if (window.navigator) {
+      // Check the UA string to find out the browser.
+      const ua = window.navigator.userAgent;
 
-    // Check the UA string to find out the browser.
-    const ua = window.navigator.userAgent;
+      // IE 10
+      // ua = 'Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; Trident/6.0)';
 
-    // IE 10
-    // ua = 'Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; Trident/6.0)';
+      // IE 11
+      // ua = 'Mozilla/5.0 (Windows NT 6.3; Trident/7.0; rv:11.0) like Gecko';
 
-    // IE 11
-    // ua = 'Mozilla/5.0 (Windows NT 6.3; Trident/7.0; rv:11.0) like Gecko';
+      // Edge
+      // ua = 'Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML,
+      // like Gecko) Chrome/39.0.2171.71 Safari/537.36 Edge/12.0';
 
-    // Edge
-    // ua = 'Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML,
-    // like Gecko) Chrome/39.0.2171.71 Safari/537.36 Edge/12.0';
-
-    if (
-      ua.indexOf('MSIE ') > 0 ||
-      ua.indexOf('Trident/') > 0 ||
-      ua.indexOf('Edge/') > 0
-    ) {
-      return false;
-    } else {
-      return true;
+      if (
+          ua.indexOf('MSIE ') > 0 ||
+          ua.indexOf('Trident/') > 0 ||
+          ua.indexOf('Edge/') > 0
+      ) {
+        return false;
+      }
     }
+
+    return true;
+
   }
 
   constructor(private db: IDBDatabase) {}

--- a/packages/firestore/src/local/simple_db.ts
+++ b/packages/firestore/src/local/simple_db.ts
@@ -117,16 +117,15 @@ export class SimpleDb {
       // like Gecko) Chrome/39.0.2171.71 Safari/537.36 Edge/12.0';
 
       if (
-          ua.indexOf('MSIE ') > 0 ||
-          ua.indexOf('Trident/') > 0 ||
-          ua.indexOf('Edge/') > 0
+        ua.indexOf('MSIE ') > 0 ||
+        ua.indexOf('Trident/') > 0 ||
+        ua.indexOf('Edge/') > 0
       ) {
         return false;
       }
     }
 
     return true;
-
   }
 
   constructor(private db: IDBDatabase) {}

--- a/packages/firestore/src/local/simple_db.ts
+++ b/packages/firestore/src/local/simple_db.ts
@@ -102,30 +102,36 @@ export class SimpleDb {
     // to return that persistence is not enabled for those browsers.
     // For tracking support of this feature, see here:
     // https://developer.microsoft.com/en-us/microsoft-edge/platform/status/indexeddbarraysandmultientrysupport/
-    if (window.navigator) {
-      // Check the UA string to find out the browser.
-      const ua = window.navigator.userAgent;
 
-      // IE 10
-      // ua = 'Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; Trident/6.0)';
-
-      // IE 11
-      // ua = 'Mozilla/5.0 (Windows NT 6.3; Trident/7.0; rv:11.0) like Gecko';
-
-      // Edge
-      // ua = 'Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML,
-      // like Gecko) Chrome/39.0.2171.71 Safari/537.36 Edge/12.0';
-
-      if (
-        ua.indexOf('MSIE ') > 0 ||
-        ua.indexOf('Trident/') > 0 ||
-        ua.indexOf('Edge/') > 0
-      ) {
-        return false;
-      }
+    // If we are running in Node using the IndexedDBShim, `window` is defined,
+    // but `window.navigator` is not. In this case, we support IndexedDB and
+    // return `true`.
+    if (window.navigator === undefined) {
+      return process.env.USE_MOCK_PERSISTENCE === 'YES';
     }
 
-    return true;
+    // Check the UA string to find out the browser.
+    const ua = window.navigator.userAgent;
+
+    // IE 10
+    // ua = 'Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; Trident/6.0)';
+
+    // IE 11
+    // ua = 'Mozilla/5.0 (Windows NT 6.3; Trident/7.0; rv:11.0) like Gecko';
+
+    // Edge
+    // ua = 'Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML,
+    // like Gecko) Chrome/39.0.2171.71 Safari/537.36 Edge/12.0';
+
+    if (
+      ua.indexOf('MSIE ') > 0 ||
+      ua.indexOf('Trident/') > 0 ||
+      ua.indexOf('Edge/') > 0
+    ) {
+      return false;
+    } else {
+      return true;
+    }
   }
 
   constructor(private db: IDBDatabase) {}

--- a/packages/firestore/test/integration/browser/webchannel.test.ts
+++ b/packages/firestore/test/integration/browser/webchannel.test.ts
@@ -23,7 +23,10 @@ import { getDefaultDatabaseInfo } from '../util/internal_helpers';
 
 // We need to check both `window` and `window.navigator` to make sure we are
 // not running in Node with IndexedDBShim.
-const describeFn = typeof window === 'object' && typeof window.navigator === 'object' ? describe : xdescribe;
+const describeFn =
+  typeof window === 'object' && typeof window.navigator === 'object'
+    ? describe
+    : xdescribe;
 
 describeFn('WebChannel', () => {
   describe('makeUrl', () => {

--- a/packages/firestore/test/integration/browser/webchannel.test.ts
+++ b/packages/firestore/test/integration/browser/webchannel.test.ts
@@ -21,7 +21,10 @@ import { DatabaseId, DatabaseInfo } from '../../../src/core/database_info';
 import { DEFAULT_PROJECT_ID } from '../util/helpers';
 import { getDefaultDatabaseInfo } from '../util/internal_helpers';
 
-const describeFn = typeof window !== 'undefined' ? describe : xdescribe;
+// We need to check both `window` and `window.navigator` to make sure we are
+// not running in Node with IndexedDBShim.
+const describeFn = typeof window === 'object' && typeof window.navigator === 'object' ? describe : xdescribe;
+
 describeFn('WebChannel', () => {
   describe('makeUrl', () => {
     const info = new DatabaseInfo(

--- a/packages/firestore/test/integration/util/helpers.ts
+++ b/packages/firestore/test/integration/util/helpers.ts
@@ -185,7 +185,9 @@ export function withTestDbsSettings(
         dbs.reduce(
           (chain, db) =>
             chain.then(() =>
-              db.INTERNAL.delete.bind(this, { purgePersistenceWithDataLoss: true })
+              db.INTERNAL.delete.bind(this, {
+                purgePersistenceWithDataLoss: true
+              })
             ),
           Promise.resolve()
         )

--- a/packages/firestore/test/integration/util/helpers.ts
+++ b/packages/firestore/test/integration/util/helpers.ts
@@ -45,11 +45,11 @@ function getDefaultSettings(): firestore.Settings {
 export const DEFAULT_PROJECT_ID = PROJECT_CONFIG.projectId;
 export const ALT_PROJECT_ID = 'test-db2';
 
-function isBrowser(): boolean {
-  return typeof window !== 'undefined';
-}
-
 function isIeOrEdge(): boolean {
+  if (!window.navigator) {
+    return false;
+  }
+
   const ua = window.navigator.userAgent;
   return (
     ua.indexOf('MSIE ') > 0 ||
@@ -59,7 +59,11 @@ function isIeOrEdge(): boolean {
 }
 
 export function isPersistenceAvailable(): boolean {
-  return isBrowser() && !isIeOrEdge();
+  return (
+    typeof window === 'object' &&
+    typeof window.indexedDB === 'object' &&
+    !isIeOrEdge()
+  );
 }
 
 /**
@@ -179,7 +183,10 @@ export function withTestDbsSettings(
     const cleanup = () => {
       return wipeDb(dbs[0]).then(() =>
         dbs.reduce(
-          (chain, db) => chain.then(() => db.INTERNAL.delete()),
+          (chain, db) =>
+            chain.then(() =>
+              db.INTERNAL.delete.bind(this, { purgePersistenceWithDataLoss: true })
+            ),
           Promise.resolve()
         )
       );

--- a/packages/firestore/test/unit/local/encoded_resource_path.test.ts
+++ b/packages/firestore/test/unit/local/encoded_resource_path.test.ts
@@ -34,8 +34,9 @@ describe('EncodedResourcePath', () => {
     return;
   }
 
+  const dbName = 'resource-path-tests';
+
   beforeEach(() => {
-    const dbName = 'resource-path-tests';
     return SimpleDb.delete(dbName)
       .then(() => {
         return SimpleDb.openOrCreate(dbName, 1, db => {
@@ -51,6 +52,8 @@ describe('EncodedResourcePath', () => {
   afterEach(() => {
     db.close();
   });
+
+  after(() => SimpleDb.delete(dbName));
 
   it('encodes resource paths', async () => {
     await assertEncoded(sep, ResourcePath.EMPTY_PATH);

--- a/packages/firestore/test/unit/local/indexeddb_schema.test.ts
+++ b/packages/firestore/test/unit/local/indexeddb_schema.test.ts
@@ -87,6 +87,8 @@ describe('IndexedDbSchema: createOrUpgradeDb', () => {
 
   beforeEach(() => SimpleDb.delete(INDEXEDDB_TEST_DATABASE));
 
+  after(() => SimpleDb.delete(INDEXEDDB_TEST_DATABASE));
+
   it('can install schema version 1', () => {
     return withDb(1, db => {
       expect(db.version).to.equal(1);

--- a/packages/firestore/test/unit/local/local_store.test.ts
+++ b/packages/firestore/test/unit/local/local_store.test.ts
@@ -295,9 +295,7 @@ function genericLocalStoreTests(
     });
   });
 
-  afterEach(() => {
-    return persistence.shutdown();
-  });
+  afterEach(() => persistence.shutdown(true));
 
   /**
    * Restarts the local store using the NoOpGarbageCollector instead of the

--- a/packages/firestore/test/unit/local/local_store.test.ts
+++ b/packages/firestore/test/unit/local/local_store.test.ts
@@ -295,7 +295,7 @@ function genericLocalStoreTests(
     });
   });
 
-  afterEach(() => persistence.shutdown(true));
+  afterEach(() => persistence.shutdown(/* deleteData= */true));
 
   /**
    * Restarts the local store using the NoOpGarbageCollector instead of the

--- a/packages/firestore/test/unit/local/local_store.test.ts
+++ b/packages/firestore/test/unit/local/local_store.test.ts
@@ -295,7 +295,7 @@ function genericLocalStoreTests(
     });
   });
 
-  afterEach(() => persistence.shutdown(/* deleteData= */true));
+  afterEach(() => persistence.shutdown(/* deleteData= */ true));
 
   /**
    * Restarts the local store using the NoOpGarbageCollector instead of the

--- a/packages/firestore/test/unit/local/mutation_queue.test.ts
+++ b/packages/firestore/test/unit/local/mutation_queue.test.ts
@@ -131,7 +131,7 @@ function genericMutationQueueTests(): void {
     return mutationQueue.start();
   });
 
-  afterEach(() => persistence.shutdown(true));
+  afterEach(() => persistence.shutdown(/* deleteData= */true));
 
   it('can count batches', async () => {
     expect(await mutationQueue.countBatches()).to.equal(0);

--- a/packages/firestore/test/unit/local/mutation_queue.test.ts
+++ b/packages/firestore/test/unit/local/mutation_queue.test.ts
@@ -131,7 +131,7 @@ function genericMutationQueueTests(): void {
     return mutationQueue.start();
   });
 
-  afterEach(() => persistence.shutdown(/* deleteData= */true));
+  afterEach(() => persistence.shutdown(/* deleteData= */ true));
 
   it('can count batches', async () => {
     expect(await mutationQueue.countBatches()).to.equal(0);

--- a/packages/firestore/test/unit/local/mutation_queue.test.ts
+++ b/packages/firestore/test/unit/local/mutation_queue.test.ts
@@ -131,9 +131,7 @@ function genericMutationQueueTests(): void {
     return mutationQueue.start();
   });
 
-  afterEach(() => {
-    return persistence.shutdown();
-  });
+  afterEach(() => persistence.shutdown(true));
 
   it('can count batches', async () => {
     expect(await mutationQueue.countBatches()).to.equal(0);

--- a/packages/firestore/test/unit/local/query_cache.test.ts
+++ b/packages/firestore/test/unit/local/query_cache.test.ts
@@ -60,9 +60,7 @@ describe('IndexedDbQueryCache', () => {
     });
   });
 
-  afterEach(() => {
-    return persistence.shutdown();
-  });
+  afterEach(() => persistence.shutdown(true));
 
   genericQueryCacheTests();
 });

--- a/packages/firestore/test/unit/local/query_cache.test.ts
+++ b/packages/firestore/test/unit/local/query_cache.test.ts
@@ -60,7 +60,7 @@ describe('IndexedDbQueryCache', () => {
     });
   });
 
-  afterEach(() => persistence.shutdown(/* deleteData= */true));
+  afterEach(() => persistence.shutdown(/* deleteData= */ true));
 
   genericQueryCacheTests();
 });

--- a/packages/firestore/test/unit/local/query_cache.test.ts
+++ b/packages/firestore/test/unit/local/query_cache.test.ts
@@ -60,7 +60,7 @@ describe('IndexedDbQueryCache', () => {
     });
   });
 
-  afterEach(() => persistence.shutdown(true));
+  afterEach(() => persistence.shutdown(/* deleteData= */true));
 
   genericQueryCacheTests();
 });

--- a/packages/firestore/test/unit/local/remote_document_cache.test.ts
+++ b/packages/firestore/test/unit/local/remote_document_cache.test.ts
@@ -49,7 +49,7 @@ describe('IndexedDbRemoteDocumentCache', () => {
     });
   });
 
-  afterEach(() => persistence.shutdown(true));
+  afterEach(() => persistence.shutdown(/* deleteData= */true));
 
   genericRemoteDocumentCacheTests();
 });

--- a/packages/firestore/test/unit/local/remote_document_cache.test.ts
+++ b/packages/firestore/test/unit/local/remote_document_cache.test.ts
@@ -49,7 +49,7 @@ describe('IndexedDbRemoteDocumentCache', () => {
     });
   });
 
-  afterEach(() => persistence.shutdown(/* deleteData= */true));
+  afterEach(() => persistence.shutdown(/* deleteData= */ true));
 
   genericRemoteDocumentCacheTests();
 });

--- a/packages/firestore/test/unit/local/remote_document_cache.test.ts
+++ b/packages/firestore/test/unit/local/remote_document_cache.test.ts
@@ -49,9 +49,7 @@ describe('IndexedDbRemoteDocumentCache', () => {
     });
   });
 
-  afterEach(() => {
-    return persistence.shutdown();
-  });
+  afterEach(() => persistence.shutdown(true));
 
   genericRemoteDocumentCacheTests();
 });

--- a/packages/firestore/test/unit/local/remote_document_change_buffer.test.ts
+++ b/packages/firestore/test/unit/local/remote_document_change_buffer.test.ts
@@ -54,9 +54,7 @@ describe('RemoteDocumentChangeBuffer', () => {
     });
   });
 
-  afterEach(() => {
-    return persistence.shutdown();
-  });
+  afterEach(() => persistence.shutdown(true));
 
   it('can read unchanged entry', async () => {
     const maybeDoc = await buffer.getEntry(key('coll/a'));

--- a/packages/firestore/test/unit/local/remote_document_change_buffer.test.ts
+++ b/packages/firestore/test/unit/local/remote_document_change_buffer.test.ts
@@ -54,7 +54,7 @@ describe('RemoteDocumentChangeBuffer', () => {
     });
   });
 
-  afterEach(() => persistence.shutdown(true));
+  afterEach(() => persistence.shutdown(/* deleteData= */true));
 
   it('can read unchanged entry', async () => {
     const maybeDoc = await buffer.getEntry(key('coll/a'));

--- a/packages/firestore/test/unit/local/remote_document_change_buffer.test.ts
+++ b/packages/firestore/test/unit/local/remote_document_change_buffer.test.ts
@@ -54,7 +54,7 @@ describe('RemoteDocumentChangeBuffer', () => {
     });
   });
 
-  afterEach(() => persistence.shutdown(/* deleteData= */true));
+  afterEach(() => persistence.shutdown(/* deleteData= */ true));
 
   it('can read unchanged entry', async () => {
     const maybeDoc = await buffer.getEntry(key('coll/a'));

--- a/packages/firestore/test/unit/specs/spec_test_runner.ts
+++ b/packages/firestore/test/unit/specs/spec_test_runner.ts
@@ -425,7 +425,7 @@ abstract class TestRunner {
 
   async shutdown(): Promise<void> {
     await this.remoteStore.shutdown();
-    await this.persistence.shutdown(true);
+    await this.persistence.shutdown(/* deleteData= */true);
     await this.destroyPersistence();
   }
 

--- a/packages/firestore/test/unit/specs/spec_test_runner.ts
+++ b/packages/firestore/test/unit/specs/spec_test_runner.ts
@@ -425,7 +425,7 @@ abstract class TestRunner {
 
   async shutdown(): Promise<void> {
     await this.remoteStore.shutdown();
-    await this.persistence.shutdown();
+    await this.persistence.shutdown(true);
     await this.destroyPersistence();
   }
 

--- a/packages/firestore/test/unit/specs/spec_test_runner.ts
+++ b/packages/firestore/test/unit/specs/spec_test_runner.ts
@@ -425,7 +425,7 @@ abstract class TestRunner {
 
   async shutdown(): Promise<void> {
     await this.remoteStore.shutdown();
-    await this.persistence.shutdown(/* deleteData= */true);
+    await this.persistence.shutdown(/* deleteData= */ true);
     await this.destroyPersistence();
   }
 

--- a/packages/firestore/test/util/mock_persistence.ts
+++ b/packages/firestore/test/util/mock_persistence.ts
@@ -31,9 +31,11 @@ const globalAny = global as any; // tslint:disable-line:no-any
 if (process.env.USE_MOCK_PERSISTENCE === 'YES') {
   registerIndexedDBShim(null, {
     checkOrigin: false,
-    deleteDatabaseFiles: true,
+    deleteDatabaseFiles: true
   });
-  globalAny.window = Object.assign(globalAny.window || {}, { indexedDB: globalAny.indexedDB });
+  globalAny.window = Object.assign(globalAny.window || {}, {
+    indexedDB: globalAny.indexedDB
+  });
 }
 
 // `deleteDatabaseFiles` does not reliable delete all SQLite files. Before

--- a/packages/firestore/test/util/mock_persistence.ts
+++ b/packages/firestore/test/util/mock_persistence.ts
@@ -1,0 +1,53 @@
+/**
+ * Copyright 2018 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as registerIndexedDBShim from 'indexeddbshim';
+import * as fs from 'fs';
+
+// WARNING: The `indexeddbshim` installed via this module should only ever be
+// used during initial development. Do not use this code in your production apps
+// and always validate your changes via `yarn test:browser` (which uses a
+// browser-based IndexedDB implementation) before integrating with Firestore.
+//
+// To use this code to run persistence-based tests in Node, include this module
+// and set the environment variable `USE_MOCK_PERSISTENCE` to `YES`.
+
+const globalAny = global as any; // tslint:disable-line:no-any
+
+if (process.env.USE_MOCK_PERSISTENCE === 'YES') {
+  registerIndexedDBShim(null, {
+    checkOrigin: false,
+    deleteDatabaseFiles: true
+  });
+  globalAny.window = { indexedDB: globalAny.indexedDB };
+}
+
+// `deleteDatabaseFiles` does not reliable delete all SQLite files. Before
+// we exit the Node process, we attempt to delete all lingering "*.sqllite"
+// files.
+const existingFiles = new Set<string>();
+
+fs.readdirSync('.').forEach(file => {
+  existingFiles.add(file);
+});
+
+process.on('exit', () => {
+  fs.readdirSync('.').forEach(file => {
+    if (file.endsWith('.sqlite') && !existingFiles.has(file)) {
+      fs.unlinkSync(file);
+    }
+  });
+});

--- a/packages/firestore/test/util/mock_persistence.ts
+++ b/packages/firestore/test/util/mock_persistence.ts
@@ -16,7 +16,6 @@
 
 import * as registerIndexedDBShim from 'indexeddbshim';
 import * as fs from 'fs';
-import * as os from 'os';
 
 // WARNING: The `indexeddbshim` installed via this module should only ever be
 // used during initial development. Always validate your changes via

--- a/packages/firestore/test/util/mock_persistence.ts
+++ b/packages/firestore/test/util/mock_persistence.ts
@@ -16,11 +16,12 @@
 
 import * as registerIndexedDBShim from 'indexeddbshim';
 import * as fs from 'fs';
+import * as os from 'os';
 
 // WARNING: The `indexeddbshim` installed via this module should only ever be
-// used during initial development. Do not use this code in your production apps
-// and always validate your changes via `yarn test:browser` (which uses a
-// browser-based IndexedDB implementation) before integrating with Firestore.
+// used during initial development. Always validate your changes via
+// `yarn test:browser` (which uses a browser-based IndexedDB implementation)
+// before integrating with Firestore.
 //
 // To use this code to run persistence-based tests in Node, include this module
 // and set the environment variable `USE_MOCK_PERSISTENCE` to `YES`.
@@ -30,9 +31,9 @@ const globalAny = global as any; // tslint:disable-line:no-any
 if (process.env.USE_MOCK_PERSISTENCE === 'YES') {
   registerIndexedDBShim(null, {
     checkOrigin: false,
-    deleteDatabaseFiles: true
+    deleteDatabaseFiles: true,
   });
-  globalAny.window = { indexedDB: globalAny.indexedDB };
+  globalAny.window = Object.assign(globalAny.window || {}, { indexedDB: globalAny.indexedDB });
 }
 
 // `deleteDatabaseFiles` does not reliable delete all SQLite files. Before

--- a/yarn.lock
+++ b/yarn.lock
@@ -4991,7 +4991,7 @@ indent-string@^3.0.0:
   version "3.2.0"
   resolved "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz#4a5fd6d27cc332f37e5419a504dbb837105c9289"
 
-indexeddbshim@^3.6.1:
+indexeddbshim@3.6.1:
   version "3.6.1"
   resolved "https://registry.npmjs.org/indexeddbshim/-/indexeddbshim-3.6.1.tgz#a0eff29ebfd4b46b5c914dd32e2306d8bc7dd8fe"
   dependencies:
@@ -9891,9 +9891,9 @@ symbol-observable@^0.2.2:
   version "0.2.4"
   resolved "https://registry.npmjs.org/symbol-observable/-/symbol-observable-0.2.4.tgz#95a83db26186d6af7e7a18dbd9760a2f86d08f40"
 
-"sync-promise@https://github.com/brettz9/sync-promise#full-sync-missing-promise-features":
+"sync-promise@git+https://github.com/brettz9/sync-promise.git#full-sync-missing-promise-features":
   version "1.0.1"
-  resolved "https://github.com/brettz9/sync-promise#25845a49a00aa2d2c985a5149b97c86a1fcdc75a"
+  resolved "git+https://github.com/brettz9/sync-promise.git#25845a49a00aa2d2c985a5149b97c86a1fcdc75a"
 
 syntax-error@^1.1.1:
   version "1.4.0"
@@ -10920,9 +10920,9 @@ websocket-extensions@>=0.1.1:
   version "0.1.3"
   resolved "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.3.tgz#5d2ff22977003ec687a4b87073dfbbac146ccf29"
 
-"websql@https://github.com/brettz9/node-websql#configurable":
+"websql@git+https://github.com/brettz9/node-websql.git#configurable":
   version "0.4.4"
-  resolved "https://github.com/brettz9/node-websql#c9828a34c92eced64858fc19151ec099fd60e8dd"
+  resolved "git+https://github.com/brettz9/node-websql.git#c9828a34c92eced64858fc19151ec099fd60e8dd"
   dependencies:
     argsarray "^0.0.1"
     immediate "^3.2.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -609,6 +609,10 @@ argparse@^1.0.7:
   dependencies:
     sprintf-js "~1.0.2"
 
+argsarray@^0.0.1:
+  version "0.0.1"
+  resolved "https://registry.npmjs.org/argsarray/-/argsarray-0.0.1.tgz#6e7207b4ecdb39b0af88303fa5ae22bda8df61cb"
+
 arr-diff@^1.0.1:
   version "1.1.0"
   resolved "https://registry.npmjs.org/arr-diff/-/arr-diff-1.1.0.tgz#687c32758163588fef7de7b36fabe495eb1a399a"
@@ -929,6 +933,14 @@ babel-messages@^6.23.0:
   dependencies:
     babel-runtime "^6.22.0"
 
+babel-polyfill@6.26.0:
+  version "6.26.0"
+  resolved "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz#379937abc67d7895970adc621f284cd966cf2153"
+  dependencies:
+    babel-runtime "^6.26.0"
+    core-js "^2.5.0"
+    regenerator-runtime "^0.10.5"
+
 babel-runtime@^6.22.0, babel-runtime@^6.26.0:
   version "6.26.0"
   resolved "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"
@@ -994,6 +1006,10 @@ backo2@1.0.2:
 balanced-match@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
+
+base64-arraybuffer-es6@0.3.1:
+  version "0.3.1"
+  resolved "https://registry.npmjs.org/base64-arraybuffer-es6/-/base64-arraybuffer-es6-0.3.1.tgz#fdf0e382f4e2f56caf881f48ee0ce01ae79afe48"
 
 base64-arraybuffer@0.1.5:
   version "0.1.5"
@@ -2304,7 +2320,7 @@ copy-props@^2.0.1:
     each-props "^1.3.0"
     is-plain-object "^2.0.1"
 
-core-js@2.5.5, core-js@^2.0.0, core-js@^2.2.0, core-js@^2.4.0:
+core-js@2.5.5, core-js@^2.0.0, core-js@^2.2.0, core-js@^2.4.0, core-js@^2.5.0:
   version "2.5.5"
   resolved "https://registry.npmjs.org/core-js/-/core-js-2.5.5.tgz#b14dde936c640c0579a6b50cabcc132dd6127e3b"
 
@@ -3230,6 +3246,10 @@ events@^1.0.0, events@^1.1.1, events@~1.1.0:
 events@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/events/-/events-2.0.0.tgz#cbbb56bf3ab1ac18d71c43bb32c86255062769f2"
+
+eventtargeter@0.4.0:
+  version "0.4.0"
+  resolved "https://registry.npmjs.org/eventtargeter/-/eventtargeter-0.4.0.tgz#1a79967df9730b4f3c84a2f256b0e6ad4446fe07"
 
 evp_bytestokey@^1.0.0, evp_bytestokey@^1.0.3:
   version "1.0.3"
@@ -4949,6 +4969,10 @@ ignore@^3.3.5:
   version "3.3.7"
   resolved "https://registry.npmjs.org/ignore/-/ignore-3.3.7.tgz#612289bfb3c220e186a58118618d5be8c1bab021"
 
+immediate@^3.2.2:
+  version "3.2.3"
+  resolved "https://registry.npmjs.org/immediate/-/immediate-3.2.3.tgz#d140fa8f614659bd6541233097ddaac25cdd991c"
+
 immediate@~3.0.5:
   version "3.0.6"
   resolved "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz#9db1dbd0faf8de6fbe0f5dd5e56bb606280de69b"
@@ -4966,6 +4990,18 @@ indent-string@^2.1.0:
 indent-string@^3.0.0:
   version "3.2.0"
   resolved "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz#4a5fd6d27cc332f37e5419a504dbb837105c9289"
+
+indexeddbshim@^3.6.1:
+  version "3.6.1"
+  resolved "https://registry.npmjs.org/indexeddbshim/-/indexeddbshim-3.6.1.tgz#a0eff29ebfd4b46b5c914dd32e2306d8bc7dd8fe"
+  dependencies:
+    babel-polyfill "6.26.0"
+    eventtargeter "0.4.0"
+    sync-promise "https://github.com/brettz9/sync-promise#full-sync-missing-promise-features"
+    typeson "5.8.2"
+    typeson-registry "1.0.0-alpha.20"
+    unicode-10.0.0 "0.7.5"
+    websql "https://github.com/brettz9/node-websql#configurable"
 
 indexof@0.0.1:
   version "0.0.1"
@@ -6437,6 +6473,10 @@ lodash.some@^4.2.2:
   version "4.6.0"
   resolved "https://registry.npmjs.org/lodash.some/-/lodash.some-4.6.0.tgz#1bb9f314ef6b8baded13b549169b2a945eb68e4d"
 
+lodash.sortby@^4.7.0:
+  version "4.7.0"
+  resolved "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
+
 lodash.template@^3.0.0:
   version "3.6.2"
   resolved "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz#f8cdecc6169a255be9098ae8b0c53d378931d14f"
@@ -7050,6 +7090,10 @@ nan@^2.10.0, nan@^2.3.0:
   version "2.10.0"
   resolved "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz#96d0cd610ebd58d4b4de9cc0c6828cda99c7548f"
 
+nan@~2.7.0:
+  version "2.7.0"
+  resolved "https://registry.npmjs.org/nan/-/nan-2.7.0.tgz#d95bf721ec877e08db276ed3fc6eb78f9083ad46"
+
 nanomatch@^1.2.9:
   version "1.2.9"
   resolved "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.9.tgz#879f7150cb2dab7a471259066c104eee6e0fa7c2"
@@ -7180,7 +7224,7 @@ node-pre-gyp@0.7.0:
     tar "^2.2.1"
     tar-pack "^3.4.0"
 
-node-pre-gyp@^0.6.39:
+node-pre-gyp@^0.6.39, node-pre-gyp@~0.6.38:
   version "0.6.39"
   resolved "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.39.tgz#c00e96860b23c0e1420ac7befc5044e1d78d8649"
   dependencies:
@@ -7256,6 +7300,10 @@ nodemailer@^2.5.0:
     nodemailer-smtp-pool "2.8.2"
     nodemailer-smtp-transport "2.7.2"
     socks "1.1.9"
+
+noop-fn@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/noop-fn/-/noop-fn-1.0.0.tgz#5f33d47f13d2150df93e0cb036699e982f78ffbf"
 
 nopt@3.x:
   version "3.0.6"
@@ -7938,6 +7986,10 @@ posix-character-classes@^0.1.0:
   version "0.1.1"
   resolved "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz#01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab"
 
+pouchdb-collections@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.npmjs.org/pouchdb-collections/-/pouchdb-collections-1.0.1.tgz#fe63a17da977611abef7cb8026cb1a9553fd8359"
+
 power-assert-context-formatter@^1.0.7:
   version "1.1.1"
   resolved "https://registry.npmjs.org/power-assert-context-formatter/-/power-assert-context-formatter-1.1.1.tgz#edba352d3ed8a603114d667265acce60d689ccdf"
@@ -8463,6 +8515,10 @@ redis@^2.7.1:
     double-ended-queue "^2.1.0-0"
     redis-commands "^1.2.0"
     redis-parser "^2.6.0"
+
+regenerator-runtime@^0.10.5:
+  version "0.10.5"
+  resolved "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz#336c3efc1220adcedda2c9fab67b5a7955a33658"
 
 regenerator-runtime@^0.11.0:
   version "0.11.1"
@@ -9486,6 +9542,13 @@ sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
 
+sqlite3@^3.1.3:
+  version "3.1.13"
+  resolved "https://registry.npmjs.org/sqlite3/-/sqlite3-3.1.13.tgz#d990a05627392768de6278bafd1a31fdfe907dd9"
+  dependencies:
+    nan "~2.7.0"
+    node-pre-gyp "~0.6.38"
+
 sshpk@^1.7.0:
   version "1.14.1"
   resolved "https://registry.npmjs.org/sshpk/-/sshpk-1.14.1.tgz#130f5975eddad963f1d56f92b9ac6c51fa9f83eb"
@@ -9828,6 +9891,10 @@ symbol-observable@^0.2.2:
   version "0.2.4"
   resolved "https://registry.npmjs.org/symbol-observable/-/symbol-observable-0.2.4.tgz#95a83db26186d6af7e7a18dbd9760a2f86d08f40"
 
+"sync-promise@https://github.com/brettz9/sync-promise#full-sync-missing-promise-features":
+  version "1.0.1"
+  resolved "https://github.com/brettz9/sync-promise#25845a49a00aa2d2c985a5149b97c86a1fcdc75a"
+
 syntax-error@^1.1.1:
   version "1.4.0"
   resolved "https://registry.npmjs.org/syntax-error/-/syntax-error-1.4.0.tgz#2d9d4ff5c064acb711594a3e3b95054ad51d907c"
@@ -10031,6 +10098,10 @@ timespan@2.3.x:
   version "2.3.0"
   resolved "https://registry.npmjs.org/timespan/-/timespan-2.3.0.tgz#4902ce040bd13d845c8f59b27e9d59bad6f39929"
 
+tiny-queue@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.npmjs.org/tiny-queue/-/tiny-queue-0.2.1.tgz#25a67f2c6e253b2ca941977b5ef7442ef97a6046"
+
 tmp@0.0.24:
   version "0.0.24"
   resolved "https://registry.npmjs.org/tmp/-/tmp-0.0.24.tgz#d6a5e198d14a9835cc6f2d7c3d9e302428c8cf12"
@@ -10129,6 +10200,12 @@ toxic@^1.0.0:
   resolved "https://registry.npmjs.org/toxic/-/toxic-1.0.0.tgz#f1154d8b6ac21875ac943a9f7408df2dfe164ea2"
   dependencies:
     lodash "^2.4.1"
+
+tr46@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz#a8b13fd6bfd2489519674ccde55ba3693b706d09"
+  dependencies:
+    punycode "^2.1.0"
 
 traverse@^0.6.6:
   version "0.6.6"
@@ -10259,6 +10336,19 @@ typescript@2.8.1:
   version "2.8.1"
   resolved "https://registry.npmjs.org/typescript/-/typescript-2.8.1.tgz#6160e4f8f195d5ba81d4876f9c0cc1fbc0820624"
 
+typeson-registry@1.0.0-alpha.20:
+  version "1.0.0-alpha.20"
+  resolved "https://registry.npmjs.org/typeson-registry/-/typeson-registry-1.0.0-alpha.20.tgz#71e673490c2b0467a30d15693bcbbab421b8f635"
+  dependencies:
+    base64-arraybuffer-es6 "0.3.1"
+    typeson "5.8.2"
+    uuid "3.2.1"
+    whatwg-url "6.4.0"
+
+typeson@5.8.2:
+  version "5.8.2"
+  resolved "https://registry.npmjs.org/typeson/-/typeson-5.8.2.tgz#cc26f45b705760a8777fba5d3c910cc3f0e8d7dd"
+
 uglify-es@^3.3.7:
   version "3.3.9"
   resolved "https://registry.npmjs.org/uglify-es/-/uglify-es-3.3.9.tgz#0c1c4f0700bed8dbc124cdb304d2592ca203e677"
@@ -10346,6 +10436,10 @@ undertaker@^1.0.0:
     object.defaults "^1.0.0"
     object.reduce "^1.0.0"
     undertaker-registry "^1.0.0"
+
+unicode-10.0.0@0.7.5:
+  version "0.7.5"
+  resolved "https://registry.npmjs.org/unicode-10.0.0/-/unicode-10.0.0-0.7.5.tgz#7f67a1fb5cb295db843e91180fe63aa6241b312c"
 
 union-value@^1.0.0:
   version "1.0.0"
@@ -10746,6 +10840,10 @@ webdriver-manager@^12.0.6:
     semver "^5.3.0"
     xml2js "^0.4.17"
 
+webidl-conversions@^4.0.1:
+  version "4.0.2"
+  resolved "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz#a855980b1f0b6b359ba1d5d9fb39ae941faa63ad"
+
 webpack-core@^0.6.8:
   version "0.6.9"
   resolved "https://registry.npmjs.org/webpack-core/-/webpack-core-0.6.9.tgz#fc571588c8558da77be9efb6debdc5a3b172bdc2"
@@ -10822,9 +10920,28 @@ websocket-extensions@>=0.1.1:
   version "0.1.3"
   resolved "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.3.tgz#5d2ff22977003ec687a4b87073dfbbac146ccf29"
 
+"websql@https://github.com/brettz9/node-websql#configurable":
+  version "0.4.4"
+  resolved "https://github.com/brettz9/node-websql#c9828a34c92eced64858fc19151ec099fd60e8dd"
+  dependencies:
+    argsarray "^0.0.1"
+    immediate "^3.2.2"
+    noop-fn "^1.0.0"
+    pouchdb-collections "^1.0.1"
+    sqlite3 "^3.1.3"
+    tiny-queue "^0.2.1"
+
 whatwg-fetch@2.0.4, whatwg-fetch@>=0.10.0:
   version "2.0.4"
   resolved "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz#dde6a5df315f9d39991aa17621853d720b85566f"
+
+whatwg-url@6.4.0:
+  version "6.4.0"
+  resolved "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.4.0.tgz#08fdf2b9e872783a7a1f6216260a1d66cc722e08"
+  dependencies:
+    lodash.sortby "^4.7.0"
+    tr46 "^1.0.0"
+    webidl-conversions "^4.0.1"
 
 when@^3.7.7:
   version "3.7.8"


### PR DESCRIPTION
This likely falls in the category of "hack" but it is going to make my life much more pleasant.

This PR allows running the Persistence-based tests on Node using https://github.com/axemclion/IndexedDBShim. There are some glitches that I worked around (like lingering files) but overall, I am very pleased to report that I can now debug tests using IntelliJ.

I also included default test configurations for IntelliJ users.

Note that while I am able to run the tests via IntelliJ, `test:node:persistence` still has some occasional failures that I punted on for now (about 3-10 tests fail for with persistence related errors, and 1 fails because XMLHTTPRequest can't be resolved).