### PR TITLE
Manual merge of Persistence Mock

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -32,7 +32,7 @@
       "args": [
         "--require", "ts-node/register/type-check",
         "--require", "index.node.ts",
-        "--require", "test/util/mock_persistence.ts",
+        "--require", "test/util/node_persistence.ts",
         "--timeout", "5000",
         "test/{,!(browser|integration)/**/}*.test.ts",
         "--exit"
@@ -72,7 +72,7 @@
       "args": [
         "--require", "ts-node/register/type-check",
         "--require", "index.node.ts",
-        "--require", "test/util/mock_persistence.ts",
+        "--require", "test/util/node_persistence.ts",
         "--timeout", "5000",
         "test/{,!(browser|unit)/**/}*.test.ts",
         "--exit"

--- a/packages/firestore/.idea/runConfigurations/All_Tests.xml
+++ b/packages/firestore/.idea/runConfigurations/All_Tests.xml
@@ -4,9 +4,7 @@
     <node-options />
     <working-directory>$PROJECT_DIR$</working-directory>
     <pass-parent-env>true</pass-parent-env>
-    <envs>
-      <env name="USE_MOCK_PERSISTENCE" value="YES" />
-    </envs>
+    <envs />
     <ui>bdd</ui>
     <extra-mocha-options>--require ts-node/register/type-check --require index.node.ts --timeout 5000</extra-mocha-options>
     <test-kind>PATTERN</test-kind>

--- a/packages/firestore/.idea/runConfigurations/All_Tests__w__Mock_Persistence_.xml
+++ b/packages/firestore/.idea/runConfigurations/All_Tests__w__Mock_Persistence_.xml
@@ -8,7 +8,7 @@
       <env name="USE_MOCK_PERSISTENCE" value="YES" />
     </envs>
     <ui>bdd</ui>
-    <extra-mocha-options>--require ts-node/register/type-check --require index.node.ts --require test/util/mock_persistence.ts --timeout 5000</extra-mocha-options>
+    <extra-mocha-options>--require ts-node/register/type-check --require index.node.ts --require test/util/node_persistence.ts --timeout 5000</extra-mocha-options>
     <test-kind>PATTERN</test-kind>
     <test-pattern>test/{,!(browser)/**/}*.test.ts</test-pattern>
     <method />

--- a/packages/firestore/.idea/runConfigurations/Integration_Tests.xml
+++ b/packages/firestore/.idea/runConfigurations/Integration_Tests.xml
@@ -4,9 +4,7 @@
     <node-options />
     <working-directory>$PROJECT_DIR$</working-directory>
     <pass-parent-env>true</pass-parent-env>
-    <envs>
-      <env name="USE_MOCK_PERSISTENCE" value="YES" />
-    </envs>
+    <envs />
     <ui>bdd</ui>
     <extra-mocha-options>--require ts-node/register/type-check --require index.node.ts --timeout 5000</extra-mocha-options>
     <test-kind>PATTERN</test-kind>

--- a/packages/firestore/.idea/runConfigurations/Integration_Tests__w__Mock_Persistence_.xml
+++ b/packages/firestore/.idea/runConfigurations/Integration_Tests__w__Mock_Persistence_.xml
@@ -8,7 +8,7 @@
       <env name="USE_MOCK_PERSISTENCE" value="YES" />
     </envs>
     <ui>bdd</ui>
-    <extra-mocha-options>--require ts-node/register/type-check --require index.node.ts --require test/util/mock_persistence.ts --timeout 5000</extra-mocha-options>
+    <extra-mocha-options>--require ts-node/register/type-check --require index.node.ts --require test/util/node_persistence.ts --timeout 5000</extra-mocha-options>
     <test-kind>PATTERN</test-kind>
     <test-pattern>test/integration/{,!(browser)/**/}*.test.ts</test-pattern>
     <method />

--- a/packages/firestore/.idea/runConfigurations/Unit_Tests.xml
+++ b/packages/firestore/.idea/runConfigurations/Unit_Tests.xml
@@ -4,9 +4,7 @@
     <node-options />
     <working-directory>$PROJECT_DIR$</working-directory>
     <pass-parent-env>true</pass-parent-env>
-    <envs>
-      <env name="USE_MOCK_PERSISTENCE" value="YES" />
-    </envs>
+    <envs />
     <ui>bdd</ui>
     <extra-mocha-options>--require ts-node/register/type-check --require index.node.ts</extra-mocha-options>
     <test-kind>PATTERN</test-kind>

--- a/packages/firestore/.idea/runConfigurations/Unit_Tests__w__Mock_Persistence_.xml
+++ b/packages/firestore/.idea/runConfigurations/Unit_Tests__w__Mock_Persistence_.xml
@@ -8,7 +8,7 @@
       <env name="USE_MOCK_PERSISTENCE" value="YES" />
     </envs>
     <ui>bdd</ui>
-    <extra-mocha-options>--require ts-node/register/type-check --require index.node.ts --require test/util/mock_persistence.ts</extra-mocha-options>
+    <extra-mocha-options>--require ts-node/register/type-check --require index.node.ts --require test/util/node_persistence.ts</extra-mocha-options>
     <test-kind>PATTERN</test-kind>
     <test-pattern>test/unit/{,!(browser)/**/}*.test.ts</test-pattern>
     <method />

--- a/packages/firestore/src/core/firestore_client.ts
+++ b/packages/firestore/src/core/firestore_client.ts
@@ -282,8 +282,8 @@ export class FirestoreClient {
       } else {
         if (process.env.USE_MOCK_PERSISTENCE !== 'YES') {
           throw new FirestoreError(
-              Code.UNIMPLEMENTED,
-              'IndexedDB persistence is only available on platforms that support LocalStorage.'
+            Code.UNIMPLEMENTED,
+            'IndexedDB persistence is only available on platforms that support LocalStorage.'
           );
         }
         debug(LOG_TAG, 'Starting Persistence in test-only non multi-tab mode');

--- a/packages/firestore/src/core/firestore_client.ts
+++ b/packages/firestore/src/core/firestore_client.ts
@@ -270,13 +270,18 @@ export class FirestoreClient {
         this.asyncQueue,
         serializer
       );
-      this.sharedClientState = new WebStorageSharedClientState(
-        this.asyncQueue,
-        this.platform,
-        storagePrefix,
-        this.clientId,
-        user
-      );
+      if (WebStorageSharedClientState.isAvailable(this.platform)) {
+        this.sharedClientState = new WebStorageSharedClientState(
+          this.asyncQueue,
+          this.platform,
+          storagePrefix,
+          this.clientId,
+          user
+        );
+      } else {
+        debug(LOG_TAG, 'Starting Persistence in non multi-tab mode');
+        this.sharedClientState = new MemorySharedClientState();
+      }
       return this.persistence.start();
     });
   }
@@ -372,36 +377,23 @@ export class FirestoreClient {
     });
   }
 
-<<<<<<< HEAD
-  shutdown(): Promise<void> {
+  shutdown(options?: {
+    purgePersistenceWithDataLoss?: boolean;
+  }): Promise<void> {
     return this.asyncQueue.enqueue(async () => {
       // PORTING NOTE: LocalStore does not need an explicit shutdown on web.
       await this.syncEngine.shutdown();
       await this.remoteStore.shutdown();
       await this.sharedClientState.shutdown();
-      await this.persistence.shutdown();
+      await this.persistence.shutdown(
+        options && options.purgePersistenceWithDataLoss
+      );
 
       // `removeUserChangeListener` must be called after shutting down the
       // RemoteStore as it will prevent the RemoteStore from retrieving
       // auth tokens.
       this.credentials.removeUserChangeListener();
     });
-=======
-  shutdown(options?: {
-    purgePersistenceWithDataLoss?: boolean;
-  }): Promise<void> {
-    return this.asyncQueue
-      .enqueue(() => {
-        this.credentials.removeUserChangeListener();
-        return this.remoteStore.shutdown();
-      })
-      .then(() => {
-        // PORTING NOTE: LocalStore does not need an explicit shutdown on web.
-        return this.persistence.shutdown(
-          options && options.purgePersistenceWithDataLoss
-        );
-      });
->>>>>>> master
   }
 
   listen(

--- a/packages/firestore/src/core/firestore_client.ts
+++ b/packages/firestore/src/core/firestore_client.ts
@@ -59,6 +59,7 @@ import {
   WebStorageSharedClientState
 } from '../local/shared_client_state';
 import { AutoId } from '../util/misc';
+import {assert} from '../util/assert';
 
 const LOG_TAG = 'FirestoreClient';
 
@@ -279,7 +280,11 @@ export class FirestoreClient {
           user
         );
       } else {
-        debug(LOG_TAG, 'Starting Persistence in non multi-tab mode');
+        assert(
+            process.env.USE_MOCK_PERSISTENCE === 'YES',
+            'IndexedDB persistence is only available in browsers that support WebStorage.'
+        );
+        debug(LOG_TAG, 'Starting Persistence in test-only non multi-tab mode');
         this.sharedClientState = new MemorySharedClientState();
       }
       return this.persistence.start();

--- a/packages/firestore/src/core/firestore_client.ts
+++ b/packages/firestore/src/core/firestore_client.ts
@@ -59,7 +59,7 @@ import {
   WebStorageSharedClientState
 } from '../local/shared_client_state';
 import { AutoId } from '../util/misc';
-import {assert} from '../util/assert';
+import { assert } from '../util/assert';
 
 const LOG_TAG = 'FirestoreClient';
 
@@ -281,8 +281,8 @@ export class FirestoreClient {
         );
       } else {
         assert(
-            process.env.USE_MOCK_PERSISTENCE === 'YES',
-            'IndexedDB persistence is only available in browsers that support WebStorage.'
+          process.env.USE_MOCK_PERSISTENCE === 'YES',
+          'IndexedDB persistence is only available in browsers that support LocalStorage.'
         );
         debug(LOG_TAG, 'Starting Persistence in test-only non multi-tab mode');
         this.sharedClientState = new MemorySharedClientState();

--- a/packages/firestore/src/core/firestore_client.ts
+++ b/packages/firestore/src/core/firestore_client.ts
@@ -280,10 +280,12 @@ export class FirestoreClient {
           user
         );
       } else {
-        assert(
-          process.env.USE_MOCK_PERSISTENCE === 'YES',
-          'IndexedDB persistence is only available in browsers that support LocalStorage.'
-        );
+        if (process.env.USE_MOCK_PERSISTENCE !== 'YES') {
+          throw new FirestoreError(
+              Code.UNIMPLEMENTED,
+              'IndexedDB persistence is only available on platforms that support LocalStorage.'
+          );
+        }
         debug(LOG_TAG, 'Starting Persistence in test-only non multi-tab mode');
         this.sharedClientState = new MemorySharedClientState();
       }

--- a/packages/firestore/src/local/indexeddb_mutation_queue.ts
+++ b/packages/firestore/src/local/indexeddb_mutation_queue.ts
@@ -589,7 +589,7 @@ function convertStreamToken(token: ProtoByteString): string {
     // TODO(b/78771403): Convert tokens to strings during deserialization
     assert(
       process.env.USE_MOCK_PERSISTENCE === 'YES',
-      'Persisting non-string stream tokens is only supported with mock persistence .'
+      'Persisting non-string stream tokens is only supported with mock persistence.'
     );
     return token.toString();
   } else {

--- a/packages/firestore/src/local/indexeddb_persistence.ts
+++ b/packages/firestore/src/local/indexeddb_persistence.ts
@@ -532,21 +532,26 @@ export class IndexedDbPersistence implements Persistence {
    * record exists.
    */
   private getZombiedClientId(): ClientId | null {
-    if (this.window.localStorage) {
-      const zombiedClientId = this.window.localStorage.getItem(
-        this.zombiedClientLocalStorageKey()
-      );
-      log.debug(
-        LOG_TAG,
-        'Zombied clientId from LocalStorage:',
-        zombiedClientId
-      );
-      return zombiedClientId;
-    } else {
-      // Gracefully handle if LocalStorage isn't available / working.
-      log.debug(LOG_TAG, 'Failed to get zombied client id.');
-      return null;
+    try {
+      if (this.window.localStorage) {
+        const zombiedClientId = this.window.localStorage.getItem(
+            this.zombiedClientLocalStorageKey()
+        );
+        log.debug(
+            LOG_TAG,
+            'Zombied clientId from LocalStorage:',
+            zombiedClientId
+        );
+        return zombiedClientId;
+      } else {
+        log.debug(LOG_TAG, 'Failed to get zombied client id. LocalStorage is not available.');
+      }
+    } catch (e) {
+        // Gracefully handle if LocalStorage isn't available / working.
+        log.debug(LOG_TAG, 'Failed to get zombied client id.', e);
     }
+
+    return null;
   }
 
   /**

--- a/packages/firestore/src/local/indexeddb_persistence.ts
+++ b/packages/firestore/src/local/indexeddb_persistence.ts
@@ -533,28 +533,20 @@ export class IndexedDbPersistence implements Persistence {
    */
   private getZombiedClientId(): ClientId | null {
     try {
-      if (this.window.localStorage) {
-        const zombiedClientId = this.window.localStorage.getItem(
-          this.zombiedClientLocalStorageKey()
-        );
-        log.debug(
-          LOG_TAG,
-          'Zombied clientId from LocalStorage:',
-          zombiedClientId
-        );
-        return zombiedClientId;
-      } else {
-        log.debug(
-          LOG_TAG,
-          'Failed to get zombied client id. LocalStorage is not available.'
-        );
-      }
+      const zombiedClientId = this.window.localStorage.getItem(
+        this.zombiedClientLocalStorageKey()
+      );
+      log.debug(
+        LOG_TAG,
+        'Zombied clientId from LocalStorage:',
+        zombiedClientId
+      );
+      return zombiedClientId;
     } catch (e) {
       // Gracefully handle if LocalStorage isn't available / working.
       log.debug(LOG_TAG, 'Failed to get zombied client id.', e);
+      return null;
     }
-
-    return null;
   }
 
   /**

--- a/packages/firestore/src/local/indexeddb_persistence.ts
+++ b/packages/firestore/src/local/indexeddb_persistence.ts
@@ -544,7 +544,7 @@ export class IndexedDbPersistence implements Persistence {
       return zombiedClientId;
     } catch (e) {
       // Gracefully handle if LocalStorage isn't available / working.
-      log.debug(LOG_TAG, 'Failed to get zombied client id.', e);
+      log.error(LOG_TAG, 'Failed to get zombied client id.', e);
       return null;
     }
   }

--- a/packages/firestore/src/local/indexeddb_persistence.ts
+++ b/packages/firestore/src/local/indexeddb_persistence.ts
@@ -535,20 +535,23 @@ export class IndexedDbPersistence implements Persistence {
     try {
       if (this.window.localStorage) {
         const zombiedClientId = this.window.localStorage.getItem(
-            this.zombiedClientLocalStorageKey()
+          this.zombiedClientLocalStorageKey()
         );
         log.debug(
-            LOG_TAG,
-            'Zombied clientId from LocalStorage:',
-            zombiedClientId
+          LOG_TAG,
+          'Zombied clientId from LocalStorage:',
+          zombiedClientId
         );
         return zombiedClientId;
       } else {
-        log.debug(LOG_TAG, 'Failed to get zombied client id. LocalStorage is not available.');
+        log.debug(
+          LOG_TAG,
+          'Failed to get zombied client id. LocalStorage is not available.'
+        );
       }
     } catch (e) {
-        // Gracefully handle if LocalStorage isn't available / working.
-        log.debug(LOG_TAG, 'Failed to get zombied client id.', e);
+      // Gracefully handle if LocalStorage isn't available / working.
+      log.debug(LOG_TAG, 'Failed to get zombied client id.', e);
     }
 
     return null;

--- a/packages/firestore/src/local/shared_client_state.ts
+++ b/packages/firestore/src/local/shared_client_state.ts
@@ -428,7 +428,7 @@ export class WebStorageSharedClientState implements SharedClientState {
     private readonly localClientId: ClientId,
     initialUser: User
   ) {
-    if (!WebStorageSharedClientState.isAvailable()) {
+    if (!WebStorageSharedClientState.isAvailable(this.platform)) {
       throw new FirestoreError(
         Code.UNIMPLEMENTED,
         'LocalStorage is not available on this platform.'
@@ -457,8 +457,8 @@ export class WebStorageSharedClientState implements SharedClientState {
   }
 
   /** Returns 'true' if LocalStorage is available in the current environment. */
-  static isAvailable(): boolean {
-    return typeof window !== 'undefined' && window.localStorage != null;
+  static isAvailable(platform: Platform): boolean {
+    return platform.window && platform.window.localStorage != null;
   }
 
   // TOOD(multitab): Register the mutations that are already pending at client

--- a/packages/firestore/src/platform_node/node_platform.ts
+++ b/packages/firestore/src/platform_node/node_platform.ts
@@ -33,7 +33,13 @@ export class NodePlatform implements Platform {
 
   readonly document = null;
 
-  readonly window = null;
+  get window(): Window | null {
+    if (process.env.USE_MOCK_PERSISTENCE === 'YES') {
+      return window;
+    }
+
+    return null;
+  }
 
   loadConnection(databaseInfo: DatabaseInfo): Promise<Connection> {
     const protos = loadProtos();

--- a/packages/firestore/src/remote/remote_store.ts
+++ b/packages/firestore/src/remote/remote_store.ts
@@ -538,13 +538,17 @@ export class RemoteStore {
       return this.localStore
         .nextMutationBatch(this.lastBatchSeen)
         .then(batch => {
-          if (batch === null) {
-            if (this.pendingWrites.length === 0) {
-              this.writeStream.markIdle();
+          // Verify that we are still connected, since we might have gotten
+          // shutdown while reading new mutation batches.
+          if (this.canWriteMutations()) {
+            if (batch === null) {
+              if (this.pendingWrites.length === 0) {
+                this.writeStream.markIdle();
+              }
+            } else {
+              this.commit(batch);
+              return this.fillWritePipeline();
             }
-          } else {
-            this.commit(batch);
-            return this.fillWritePipeline();
           }
         });
     }

--- a/packages/firestore/src/remote/remote_store.ts
+++ b/packages/firestore/src/remote/remote_store.ts
@@ -546,7 +546,6 @@ export class RemoteStore {
             this.commit(batch);
             return this.fillWritePipeline();
           }
-
         });
     }
   }

--- a/packages/firestore/src/remote/remote_store.ts
+++ b/packages/firestore/src/remote/remote_store.ts
@@ -538,18 +538,15 @@ export class RemoteStore {
       return this.localStore
         .nextMutationBatch(this.lastBatchSeen)
         .then(batch => {
-          // Verify that we are still connected, since we might have gotten
-          // shutdown while reading new mutation batches.
-          if (this.canWriteMutations()) {
-            if (batch === null) {
-              if (this.pendingWrites.length === 0) {
-                this.writeStream.markIdle();
-              }
-            } else {
-              this.commit(batch);
-              return this.fillWritePipeline();
+          if (batch === null) {
+            if (this.pendingWrites.length === 0) {
+              this.writeStream.markIdle();
             }
+          } else {
+            this.commit(batch);
+            return this.fillWritePipeline();
           }
+
         });
     }
   }

--- a/packages/firestore/test/unit/local/local_store.test.ts
+++ b/packages/firestore/test/unit/local/local_store.test.ts
@@ -293,13 +293,7 @@ function genericLocalStoreTests(
     return localStore.start();
   });
 
-<<<<<<< HEAD
-  afterEach(async () => {
-    await persistence.shutdown();
-  });
-=======
   afterEach(() => persistence.shutdown(/* deleteData= */ true));
->>>>>>> master
 
   /**
    * Restarts the local store using the NoOpGarbageCollector instead of the

--- a/packages/firestore/test/unit/local/persistence_test_helpers.ts
+++ b/packages/firestore/test/unit/local/persistence_test_helpers.ts
@@ -30,6 +30,7 @@ import { User } from '../../../src/auth/user';
 import { SharedClientStateSyncer } from '../../../src/local/shared_client_state_syncer';
 import { FirestoreError } from '../../../src/util/error';
 import { AutoId } from '../../../src/util/misc';
+import { PlatformSupport } from '../../../src/platform/platform';
 
 /** The persistence prefix used for testing in IndexedBD and LocalStorage. */
 export const TEST_PERSISTENCE_PREFIX = 'PersistenceTestHelpers';
@@ -54,7 +55,7 @@ export async function testIndexedDbPersistence(
   const serializer = new JsonProtoSerializer(partition, {
     useProto3Json: true
   });
-  const platform = new BrowserPlatform();
+  const platform = PlatformSupport.getPlatform();
   const persistence = new IndexedDbPersistence(
     prefix,
     clientId,

--- a/packages/firestore/test/unit/local/web_storage_shared_client_state.test.ts
+++ b/packages/firestore/test/unit/local/web_storage_shared_client_state.test.ts
@@ -35,6 +35,7 @@ import {
 } from './persistence_test_helpers';
 import { BrowserPlatform } from '../../../src/platform_browser/browser_platform';
 import { fail } from '../../../src/util/assert';
+import { PlatformSupport } from '../../../src/platform/platform';
 
 /**
  * The tests assert that the lastUpdateTime of each row in LocalStorage gets
@@ -110,7 +111,7 @@ class TestSharedClientSyncer implements SharedClientStateSyncer {
 }
 
 describe('WebStorageSharedClientState', () => {
-  if (!WebStorageSharedClientState.isAvailable()) {
+  if (!WebStorageSharedClientState.isAvailable(PlatformSupport.getPlatform())) {
     console.warn(
       'No LocalStorage. Skipping WebStorageSharedClientState tests.'
     );

--- a/packages/firestore/test/unit/specs/spec_test_runner.ts
+++ b/packages/firestore/test/unit/specs/spec_test_runner.ts
@@ -483,7 +483,6 @@ abstract class TestRunner {
   }
 
   async shutdown(): Promise<void> {
-<<<<<<< HEAD
     if (this.started) {
       await this.doShutdown();
     }
@@ -498,23 +497,6 @@ abstract class TestRunner {
     this.eventList = [];
     this.rejectedDocs = [];
     this.acknowledgedDocs = [];
-=======
-    await this.remoteStore.shutdown();
-    await this.persistence.shutdown(/* deleteData= */ true);
-    await this.destroyPersistence();
-  }
-
-  run(steps: SpecStep[]): Promise<void> {
-    // tslint:disable-next-line:no-console
-    console.log('Running spec: ' + this.name);
-    return sequence(steps, async step => {
-      await this.doStep(step);
-      await this.queue.drain();
-      this.validateStepExpectations(step.expect!);
-      this.validateStateExpectations(step.stateExpect!);
-      this.eventList = [];
-    });
->>>>>>> master
   }
 
   private doStep(step: SpecStep): Promise<void> {
@@ -875,7 +857,10 @@ abstract class TestRunner {
     await this.syncEngine.shutdown();
     await this.remoteStore.shutdown();
     await this.sharedClientState.shutdown();
-    await this.persistence.shutdown();
+    // We don't delete the persisted data here since multi-clients may still
+    // be accessing it. Instead, we manually remove it at the end of the
+    // test run.
+    await this.persistence.shutdown(/* deleteData= */ false);
     this.started = false;
   }
 
@@ -1280,6 +1265,10 @@ class MockWindow {
     return this.storageArea;
   }
 
+  get indexedDB(): IDBFactory {
+    return window.indexedDB;
+  }
+
   addEventListener(type: string, listener: EventListener): void {
     switch (type) {
       case 'storage':
@@ -1315,12 +1304,8 @@ class TestPlatform implements Platform {
     private readonly basePlatform: Platform,
     private readonly mockStorage: SharedMockStorage
   ) {
-    if (this.basePlatform.document) {
-      this.mockDocument = new MockDocument();
-    }
-    if (this.basePlatform.window) {
-      this.mockWindow = new MockWindow(this.mockStorage);
-    }
+    this.mockDocument = new MockDocument();
+    this.mockWindow = new MockWindow(this.mockStorage);
   }
 
   get document(): Document | null {

--- a/packages/firestore/test/util/node_persistence.ts
+++ b/packages/firestore/test/util/node_persistence.ts
@@ -36,6 +36,14 @@ if (process.env.USE_MOCK_PERSISTENCE === 'YES') {
   globalAny.window = Object.assign(globalAny.window || {}, {
     indexedDB: globalAny.indexedDB
   });
+
+  // We need to define the `Event` type as it is used in Node to send events to
+  // WebStorage when using both the IndexedDB mock and the WebStorage mock.
+  class Event {
+    constructor(typeArg: string, eventInitDict?: EventInit) {}
+  }
+
+  globalAny.Event = Event;
 }
 
 // `deleteDatabaseFiles` does not reliable delete all SQLite files. Before


### PR DESCRIPTION
So I have created two branches 'multitab-dirty-merge' that has the result of the automatic merge with all merge markers.

This PR is set up against this branch to make it easier to show the manual changes.

The merge was kind of complicated since Multi-Tab also introduces LocalStorage. So now there are tests that use IndexedDb that don't have access to Local Storage (I was debating using a Mock for this as well, but decided that we could clean this up later if deemed necessary).

I also renamed the "mock_persistence" file to "node_persistence" so that bootstrap.ts doesn't pick it up.