### PR TITLE
Port feedback on event filtering

### DIFF
--- a/packages/firestore/src/core/sync_engine.ts
+++ b/packages/firestore/src/core/sync_engine.ts
@@ -305,10 +305,7 @@ export class SyncEngine implements RemoteSyncer {
         if (!limboKey) {
           const qv = this.queryViewsByTarget[targetId];
           assert(!!qv, 'Missing QueryView for non-limbo query: ' + targetId);
-          remoteEvent.filterUpdatesFromTargetChange(
-            targetId,
-            qv.view.syncedDocuments
-          );
+          targetChange.mapping.filterUpdates(qv.view.syncedDocuments);
         } else {
           remoteEvent.synthesizeDeleteForLimboTargetChange(
             targetChange,

--- a/packages/firestore/src/remote/remote_event.ts
+++ b/packages/firestore/src/remote/remote_event.ts
@@ -101,7 +101,7 @@ export class RemoteEvent {
       // arrives, the document is not present in the snapshot and our
       // normal view handling would consider the document to remain in
       // limbo indefinitely because there are no updates to the document.
-      // To avoid this, we specially handle this just this case here:
+      // To avoid this, we specially handle this case here:
       // synthesizing a delete.
       //
       // TODO(dimond): Ideally we would have an explicit lookup query

--- a/packages/firestore/src/remote/remote_event.ts
+++ b/packages/firestore/src/remote/remote_event.ts
@@ -73,33 +73,6 @@ export class RemoteEvent {
   }
 
   /**
-   * Strips out mapping changes that aren't actually changes. That is, if the document already
-   * existed in the target, and is being added in the target, and this is not a reset, we can
-   * skip doing the work to associate the document with the target because it has already been done.
-   */
-  filterUpdatesFromTargetChange(
-    targetId: TargetId,
-    existingDocuments: DocumentKeySet
-  ): void {
-    const targetChange = this.targetChanges[targetId];
-    assert(
-      !!targetChange,
-      'Trying to filter updates from unknown target: ' + targetId
-    );
-    if (targetChange.mapping instanceof UpdateMapping) {
-      const update = targetChange.mapping;
-      const added = update.addedDocuments;
-      let result = added;
-      added.forEach(key => {
-        if (existingDocuments.has(key)) {
-          result = result.delete(key);
-        }
-      });
-      update.addedDocuments = result;
-    }
-  }
-
-  /**
    * Synthesize a delete change if necessary for the given limbo target.
    */
   synthesizeDeleteForLimboTargetChange(
@@ -212,6 +185,10 @@ export class ResetMapping {
   isEqual(other: ResetMapping): boolean {
     return other !== null && this.docs.isEqual(other.docs);
   }
+
+  filterUpdates(existingKeys: DocumentKeySet): void {
+    // No-op. Resets don't get filtered.
+  }
 }
 
 export class UpdateMapping {
@@ -241,5 +218,20 @@ export class UpdateMapping {
       this.addedDocuments.isEqual(other.addedDocuments) &&
       this.removedDocuments.isEqual(other.removedDocuments)
     );
+  }
+
+  /**
+   * Strips out mapping changes that aren't actually changes. That is, if the document already
+   * existed in the target, and is being added in the target, and this is not a reset, we can
+   * skip doing the work to associate the document with the target because it has already been done.
+   */
+  filterUpdates(existingKeys: DocumentKeySet): void {
+    let results = this.addedDocuments;
+    this.addedDocuments.forEach(docKey => {
+      if (existingKeys.has(docKey)) {
+        results = results.delete(docKey);
+      }
+    });
+    this.addedDocuments = results;
   }
 }

--- a/packages/firestore/src/remote/remote_event.ts
+++ b/packages/firestore/src/remote/remote_event.ts
@@ -24,7 +24,6 @@ import {
 import { MaybeDocument, NoDocument } from '../model/document';
 import { DocumentKey } from '../model/document_key';
 import { emptyByteString } from '../platform/platform';
-import { assert } from '../util/assert';
 
 /**
  * An event from the RemoteStore. It is split into targetChanges (changes to the

--- a/packages/firestore/test/unit/remote/remote_event.test.ts
+++ b/packages/firestore/test/unit/remote/remote_event.test.ts
@@ -466,28 +466,17 @@ describe('RemoteEvent', () => {
   });
 
   it('synthesizes deletes', () => {
-    const targets = listens(1, 2, 3);
+    const targets = listens(1);
     const shouldSynthesize = new WatchTargetChange(
       WatchTargetChangeState.Current,
       [1]
     );
-    const wrongState = new WatchTargetChange(WatchTargetChangeState.NoChange, [
-      2
-    ]);
-    const hasDocument = new WatchTargetChange(WatchTargetChangeState.Current, [
-      3
-    ]);
-    const doc1 = doc('docs/1', 1, { value: 1 });
-    const docChange = new DocumentWatchChange([3], [], doc1.key, doc1);
 
     const event = remoteEvent(
       1,
       targets,
       noPendingResponses,
-      shouldSynthesize,
-      wrongState,
-      hasDocument,
-      docChange
+      shouldSynthesize
     );
 
     const synthesized = DocumentKey.fromPathString('docs/2');
@@ -500,6 +489,14 @@ describe('RemoteEvent', () => {
       event.snapshotVersion.toMicroseconds()
     );
     expectEqual(event.documentUpdates.get(synthesized), expected);
+  });
+
+  it('doesn\'t synthesize deletes in the wrong state', () => {
+    const wrongState = new WatchTargetChange(WatchTargetChangeState.NoChange, [
+      2
+    ]);
+    const targets = listens(2);
+    const event = remoteEvent(1, targets, noPendingResponses, wrongState);
 
     const notSynthesized = DocumentKey.fromPathString('docs/no1');
     const wrongStateChange = event.targetChanges[2];
@@ -508,6 +505,16 @@ describe('RemoteEvent', () => {
       notSynthesized
     );
     expect(event.documentUpdates.get(notSynthesized)).to.not.exist;
+  });
+
+  it('doesn\'t synthesize deletes with existing document', () => {
+    const hasDocument = new WatchTargetChange(WatchTargetChangeState.Current, [
+      3
+    ]);
+    const doc1 = doc('docs/1', 1, { value: 1 });
+    const docChange = new DocumentWatchChange([3], [], doc1.key, doc1);
+    const targets = listens(3);
+    const event = remoteEvent(1, targets, noPendingResponses, hasDocument, docChange);
 
     const hasDocumentChange = event.targetChanges[3];
     event.synthesizeDeleteForLimboTargetChange(hasDocumentChange, doc1.key);
@@ -517,49 +524,62 @@ describe('RemoteEvent', () => {
   });
 
   it('filters updates', () => {
+    const updateTargetId = 1;
     const newDoc = doc('docs/new', 1, { key: 'value' });
     const existingDoc = doc('docs/existing', 1, { some: 'data' });
-    const newDocChange = new DocumentWatchChange([1], [], newDoc.key, newDoc);
+    const newDocChange = new DocumentWatchChange([updateTargetId], [], newDoc.key, newDoc);
 
-    const resetTargetChange = new WatchTargetChange(
-      WatchTargetChangeState.Reset,
-      [2]
-    );
     const existingDocChange = new DocumentWatchChange(
-      [1, 2],
+      [updateTargetId],
       [],
       existingDoc.key,
       existingDoc
     );
 
-    const updateChangeId = 1;
-    const resetChangeId = 2;
-    const targets = listens(updateChangeId, resetChangeId);
+    const targets = listens(updateTargetId);
     const event = remoteEvent(
       1,
       targets,
       noPendingResponses,
       newDocChange,
-      resetTargetChange,
       existingDocChange
     );
 
-    const updateChange = event.targetChanges[updateChangeId];
+    const updateChange = event.targetChanges[updateTargetId];
     expect(updateChange.mapping).to.be.instanceof(UpdateMapping);
     const update = updateChange.mapping as UpdateMapping;
     expect(update.addedDocuments.has(existingDoc.key)).to.be.true;
 
     const existingKeys = documentKeySet().add(existingDoc.key);
-    event.filterUpdatesFromTargetChange(updateChangeId, existingKeys);
+    update.filterUpdates(existingKeys);
     expect(update.addedDocuments.has(existingDoc.key)).to.be.false;
     expect(update.addedDocuments.has(newDoc.key)).to.be.true;
+  });
 
-    const resetChange = event.targetChanges[resetChangeId];
+  it('doesn\'t filter resets', () => {
+    const resetTargetId = 2;
+    const resetTargetChange = new WatchTargetChange(
+      WatchTargetChangeState.Reset,
+      [resetTargetId]
+    );
+    const existingDoc = doc('docs/existing', 1, { some: 'data' });
+    const existingDocChange = new DocumentWatchChange(
+      [resetTargetId],
+      [],
+      existingDoc.key,
+      existingDoc
+    );
+
+    const targets = listens(resetTargetId);
+    const event = remoteEvent(1, targets, noPendingResponses, resetTargetChange, existingDocChange);
+
+    const resetChange = event.targetChanges[resetTargetId];
     expect(resetChange.mapping).to.be.instanceof(ResetMapping);
     const reset = resetChange.mapping as ResetMapping;
     expect(reset.documents.has(existingDoc.key)).to.be.true;
 
-    event.filterUpdatesFromTargetChange(resetChangeId, existingKeys);
+    const existingKeys = documentKeySet().add(existingDoc.key);
+    reset.filterUpdates(existingKeys);
     // document is still there, as reset mappings don't get filtered
     expect(reset.documents.has(existingDoc.key)).to.be.true;
   });

--- a/packages/firestore/test/unit/remote/remote_event.test.ts
+++ b/packages/firestore/test/unit/remote/remote_event.test.ts
@@ -472,12 +472,7 @@ describe('RemoteEvent', () => {
       [1]
     );
 
-    const event = remoteEvent(
-      1,
-      targets,
-      noPendingResponses,
-      shouldSynthesize
-    );
+    const event = remoteEvent(1, targets, noPendingResponses, shouldSynthesize);
 
     const synthesized = DocumentKey.fromPathString('docs/2');
     expect(event.documentUpdates.get(synthesized)).to.be.null;
@@ -491,7 +486,7 @@ describe('RemoteEvent', () => {
     expectEqual(event.documentUpdates.get(synthesized), expected);
   });
 
-  it('doesn\'t synthesize deletes in the wrong state', () => {
+  it("doesn't synthesize deletes in the wrong state", () => {
     const wrongState = new WatchTargetChange(WatchTargetChangeState.NoChange, [
       2
     ]);
@@ -507,14 +502,20 @@ describe('RemoteEvent', () => {
     expect(event.documentUpdates.get(notSynthesized)).to.not.exist;
   });
 
-  it('doesn\'t synthesize deletes with existing document', () => {
+  it("doesn't synthesize deletes with existing document", () => {
     const hasDocument = new WatchTargetChange(WatchTargetChangeState.Current, [
       3
     ]);
     const doc1 = doc('docs/1', 1, { value: 1 });
     const docChange = new DocumentWatchChange([3], [], doc1.key, doc1);
     const targets = listens(3);
-    const event = remoteEvent(1, targets, noPendingResponses, hasDocument, docChange);
+    const event = remoteEvent(
+      1,
+      targets,
+      noPendingResponses,
+      hasDocument,
+      docChange
+    );
 
     const hasDocumentChange = event.targetChanges[3];
     event.synthesizeDeleteForLimboTargetChange(hasDocumentChange, doc1.key);
@@ -527,7 +528,12 @@ describe('RemoteEvent', () => {
     const updateTargetId = 1;
     const newDoc = doc('docs/new', 1, { key: 'value' });
     const existingDoc = doc('docs/existing', 1, { some: 'data' });
-    const newDocChange = new DocumentWatchChange([updateTargetId], [], newDoc.key, newDoc);
+    const newDocChange = new DocumentWatchChange(
+      [updateTargetId],
+      [],
+      newDoc.key,
+      newDoc
+    );
 
     const existingDocChange = new DocumentWatchChange(
       [updateTargetId],
@@ -556,7 +562,7 @@ describe('RemoteEvent', () => {
     expect(update.addedDocuments.has(newDoc.key)).to.be.true;
   });
 
-  it('doesn\'t filter resets', () => {
+  it("doesn't filter resets", () => {
     const resetTargetId = 2;
     const resetTargetChange = new WatchTargetChange(
       WatchTargetChangeState.Reset,
@@ -571,7 +577,13 @@ describe('RemoteEvent', () => {
     );
 
     const targets = listens(resetTargetId);
-    const event = remoteEvent(1, targets, noPendingResponses, resetTargetChange, existingDocChange);
+    const event = remoteEvent(
+      1,
+      targets,
+      noPendingResponses,
+      resetTargetChange,
+      existingDocChange
+    );
 
     const resetChange = event.targetChanges[resetTargetId];
     expect(resetChange.mapping).to.be.instanceof(ResetMapping);


### PR DESCRIPTION
I got some good feedback on the java port internally, so I am porting that to typescript.

Filtering is moved onto the mapping subtypes, and some tests are split into distinct cases.