### PR TITLE
Post-indexeddbshim test fixes

### DIFF
--- a/packages/firestore/package.json
+++ b/packages/firestore/package.json
@@ -13,7 +13,7 @@
     "test:browser": "karma start --single-run",
     "test:browser:debug": "karma start --browsers=Chrome --auto-watch",
     "test:node": "TS_NODE_CACHE=NO nyc --reporter lcovonly -- mocha 'test/{,!(browser)/**/}*.test.ts' --require ts-node/register/type-check --require index.node.ts --retries 5 --timeout 5000 --exit",
-    "test:node:persistence": "USE_MOCK_PERSISTENCE=YES TS_NODE_CACHE=NO nyc --reporter lcovonly -- mocha 'test/{,!(browser)/**/}*.test.ts' --require ts-node/register/type-check --require index.node.ts --require test/util/mock_persistence.ts --retries 5 --timeout 5000 --exit",
+    "test:node:persistence": "USE_MOCK_PERSISTENCE=YES TS_NODE_CACHE=NO nyc --reporter lcovonly -- mocha 'test/{,!(browser)/**/}*.test.ts' --require ts-node/register/type-check --require index.node.ts --require test/util/node_persistence.ts --retries 5 --timeout 5000 --exit",
     "prepare": "npm run build"
   },
   "main": "dist/index.node.cjs.js",

--- a/packages/firestore/test/integration/util/helpers.ts
+++ b/packages/firestore/test/integration/util/helpers.ts
@@ -184,7 +184,7 @@ export function withTestDbsSettings(
       return wipeDb(dbs[0]).then(() =>
         dbs.reduce(
           (chain, db) =>
-            chain.then(() =>
+            chain.then(
               db.INTERNAL.delete.bind(this, {
                 purgePersistenceWithDataLoss: true
               })


### PR DESCRIPTION
1. We weren't actually calling db.INTERNAL.delete(), leading to lingering webchannel connections in tests.
2. Fixed a missed reference to mock_persistence.ts.