### PR TITLE
Don't overwrite user defined data

### DIFF
--- a/packages/messaging/src/controllers/sw-controller.ts
+++ b/packages/messaging/src/controllers/sw-controller.ts
@@ -240,6 +240,7 @@ export class SWController extends ControllerInterface {
     // somewhere else (i.e. normal web push or developer generated
     // notification).
     notificationInformation.data = {
+      ...msgPayload.notification.data,
       [FCM_MSG]: msgPayload
     };
 

--- a/packages/messaging/test/sw-controller.test.ts
+++ b/packages/messaging/test/sw-controller.test.ts
@@ -798,6 +798,31 @@ describe('Firebase Messaging > *SWController', () => {
         undefined
       );
     });
+
+    it('adds message payload to data.FCM_MSG without replacing user defined data', () => {
+      const swController = new SWController(app);
+      const msgPayload = {
+        notification: {
+          title: 'Hello World',
+          body: 'Notification Body',
+          data: {
+            userDefinedData: 'canBeAnything'
+          }
+        },
+        data: {
+          randomData: 'randomString'
+        }
+      };
+
+      expect(swController.getNotificationData_(msgPayload)).to.deep.equal({
+        title: 'Hello World',
+        body: 'Notification Body',
+        data: {
+          userDefinedData: 'canBeAnything',
+          FCM_MSG: msgPayload
+        }
+      });
+    });
   });
 
   describe('attemptToMessageClient_', () => {


### PR DESCRIPTION
This operation was safe when we didn't allow users to define "data" on their notification. Not anymore.