### PR TITLE
Fix Edge not setting default transaction mode

### DIFF
--- a/packages/messaging/src/models/db-interface.ts
+++ b/packages/messaging/src/models/db-interface.ts
@@ -82,7 +82,7 @@ export abstract class DBInterface {
    */
   private async createTransaction<T>(
     runRequest: (objectStore: IDBObjectStore) => IDBRequest,
-    mode?: 'readonly' | 'readwrite'
+    mode: 'readonly' | 'readwrite' = 'readonly'
   ): Promise<T> {
     const db = await this.getDb();
     const transaction = db.transaction(this.objectStoreName, mode);


### PR DESCRIPTION
According to [the IndexedDB spec](https://www.w3.org/TR/IndexedDB-2/#database-interface), `db.transaction()` method's `mode` parameter is optional, and the default value is `"readonly"`.

However, MS Edge fails a transaction if mode is undefined, so we need to call it explicitly with `"readonly"`.

Fixes #757.