### PR TITLE
Add arrayUnion() and arrayRemove() Transforms (not publicly exposed yet)

### DIFF
--- a/packages/firebase/index.d.ts
+++ b/packages/firebase/index.d.ts
@@ -1896,6 +1896,33 @@ declare namespace firebase.firestore {
     static delete(): FieldValue;
 
     /**
+     * Returns a special value that can be used with set() or update() that tells
+     * the server to union the given elements with any array value that already
+     * exists on the server. Each specified element that doesn't already exist in
+     * the array will be added to the end. If the field being modified is not
+     * already an array it will be overwritten with an array containing exactly
+     * the specified elements.
+     *
+     * @param elements The elements to union into the array.
+     * @return The FieldValue sentinel for use in a call to set() or update().
+     */
+    // TODO(array-features): Expose this once backend support lands.
+    //static arrayUnion(...elements: any[]): FieldValue;
+
+    /**
+     * Returns a special value that can be used with set() or update() that tells
+     * the server to remove the given elements from any array value that already
+     * exists on the server. All instances of each element specified will be
+     * removed from the array. If the field being modified is not already an
+     * array it will be overwritten with an empty array.
+     *
+     * @param elements The elements to remove from the array.
+     * @return The FieldValue sentinel for use in a call to set() or update().
+     */
+    // TODO(array-features): Expose this once backend support lands.
+    //static arrayRemove(...elements: any[]): FieldValue;
+
+    /**
      * Returns true if this `FieldValue` is equal to the provided one.
      *
      * @param other The `FieldValue` to compare against.

--- a/packages/firestore-types/index.d.ts
+++ b/packages/firestore-types/index.d.ts
@@ -1218,6 +1218,33 @@ export class FieldValue {
   static delete(): FieldValue;
 
   /**
+   * Returns a special value that can be used with set() or update() that tells
+   * the server to union the given elements with any array value that already
+   * exists on the server. Each specified element that doesn't already exist in
+   * the array will be added to the end. If the field being modified is not
+   * already an array it will be overwritten with an array containing exactly
+   * the specified elements.
+   *
+   * @param elements The elements to union into the array.
+   * @return The FieldValue sentinel for use in a call to set() or update().
+   */
+  // TODO(array-features): Expose this once backend support lands.
+  //static arrayUnion(...elements: any[]): FieldValue;
+
+  /**
+   * Returns a special value that can be used with set() or update() that tells
+   * the server to remove the given elements from any array value that already
+   * exists on the server. All instances of each element specified will be
+   * removed from the array. If the field being modified is not already an
+   * array it will be overwritten with an empty array.
+   *
+   * @param elements The elements to remove from the array.
+   * @return The FieldValue sentinel for use in a call to set() or update().
+   */
+  // TODO(array-features): Expose this once backend support lands.
+  //static arrayRemove(...elements: any[]): FieldValue;
+
+  /**
    * Returns true if this `FieldValue` is equal to the provided one.
    *
    * @param other The `FieldValue` to compare against.

--- a/packages/firestore/src/api/user_data_converter.ts
+++ b/packages/firestore/src/api/user_data_converter.ts
@@ -40,7 +40,9 @@ import {
   Precondition,
   ServerTimestampTransform,
   SetMutation,
-  TransformMutation
+  TransformMutation,
+  ArrayUnionTransformOperation,
+  ArrayRemoveTransformOperation
 } from '../model/mutation';
 import { FieldPath } from '../model/path';
 import { assert, fail } from '../util/assert';
@@ -60,7 +62,9 @@ import {
 import {
   DeleteFieldValueImpl,
   FieldValueImpl,
-  ServerTimestampFieldValueImpl
+  ServerTimestampFieldValueImpl,
+  ArrayUnionFieldValueImpl,
+  ArrayRemoveFieldValueImpl
 } from './field_value';
 import { GeoPoint } from './geo_point';
 
@@ -118,7 +122,11 @@ enum UserDataSource {
   Set,
   Update,
   MergeSet,
-  QueryValue // from a where clause or cursor bound
+  /**
+   * Indicates the source is a where clause, cursor bound, arrayUnion()
+   * element, etc. Of note, isWrite(source) will return false.
+   */
+  Argument
 }
 
 function isWrite(dataSource: UserDataSource): boolean {
@@ -127,7 +135,7 @@ function isWrite(dataSource: UserDataSource): boolean {
     case UserDataSource.MergeSet: // fall through
     case UserDataSource.Update:
       return true;
-    case UserDataSource.QueryValue:
+    case UserDataSource.Argument:
       return false;
     default:
       throw fail(`Unexpected case for UserDataSource: ${dataSource}`);
@@ -449,7 +457,7 @@ export class UserDataConverter {
    */
   parseQueryValue(methodName: string, input: AnyJs): FieldValue {
     const context = new ParseContext(
-      UserDataSource.QueryValue,
+      UserDataSource.Argument,
       methodName,
       FieldPath.EMPTY_PATH
     );
@@ -486,6 +494,14 @@ export class UserDataConverter {
     if (looksLikeJsonObject(input)) {
       validatePlainObject('Unsupported field value:', context, input);
       return this.parseObject(input as Dict<AnyJs>, context);
+    } else if (input instanceof FieldValueImpl) {
+      // FieldValues usually parse into transforms (except FieldValue.delete())
+      // in which case we do not want to include this field in our parsed data
+      // (as doing so will overwrite the field directly prior to the transform
+      // trying to transform it). So we don't add this location to
+      // context.fieldMask and we return null as our parsing result.
+      this.parseSentinelFieldValue(input, context);
+      return null;
     } else {
       // If context.path is null we are inside an array and we don't support
       // field mask paths more granular than the top-level array.
@@ -500,11 +516,6 @@ export class UserDataConverter {
           throw context.createError('Nested arrays are not supported');
         }
         return this.parseArray(input as AnyJs[], context);
-      } else if (input instanceof FieldValueImpl) {
-        // parseSentinelFieldValue() may add a FieldTransform, but we return
-        // null since nothing should be included in the actual parsed data.
-        this.parseSentinelFieldValue(input, context);
-        return null;
       } else {
         return this.parseScalarValue(input, context);
       }
@@ -555,18 +566,20 @@ export class UserDataConverter {
     // Sentinels are only supported with writes, and not within arrays.
     if (!isWrite(context.dataSource)) {
       throw context.createError(
-        `${value.methodName} can only be used with update() and set()`
+        `${value.methodName}() can only be used with update() and set()`
       );
     }
     if (context.path === null) {
       throw context.createError(
-        `${value.methodName} is not currently supported inside arrays`
+        `${value.methodName}() is not currently supported inside arrays`
       );
     }
 
     if (value instanceof DeleteFieldValueImpl) {
       if (context.dataSource === UserDataSource.MergeSet) {
-        // No transform to add for a delete, so we do nothing.
+        // No transform to add for a delete, but we need to add it to our
+        // fieldMask so it gets deleted.
+        context.fieldMask.push(context.path);
       } else if (context.dataSource === UserDataSource.Update) {
         assert(
           context.path.length > 0,
@@ -587,6 +600,24 @@ export class UserDataConverter {
     } else if (value instanceof ServerTimestampFieldValueImpl) {
       context.fieldTransforms.push(
         new FieldTransform(context.path, ServerTimestampTransform.instance)
+      );
+    } else if (value instanceof ArrayUnionFieldValueImpl) {
+      const parsedElements = this.parseArrayTransformElements(
+        value.methodName,
+        value._elements
+      );
+      const arrayUnion = new ArrayUnionTransformOperation(parsedElements);
+      context.fieldTransforms.push(
+        new FieldTransform(context.path, arrayUnion)
+      );
+    } else if (value instanceof ArrayRemoveFieldValueImpl) {
+      const parsedElements = this.parseArrayTransformElements(
+        value.methodName,
+        value._elements
+      );
+      const arrayRemove = new ArrayRemoveTransformOperation(parsedElements);
+      context.fieldTransforms.push(
+        new FieldTransform(context.path, arrayRemove)
       );
     } else {
       fail('Unknown FieldValue type: ' + value);
@@ -634,6 +665,30 @@ export class UserDataConverter {
         `Unsupported field value: ${valueDescription(value)}`
       );
     }
+  }
+
+  private parseArrayTransformElements(
+    methodName: string,
+    elements: AnyJs[]
+  ): FieldValue[] {
+    const parsedElements = [] as FieldValue[];
+    for (let i = 0; i < elements.length; i++) {
+      const element = elements[i];
+      // Although array transforms are used with writes, the actual elements
+      // being unioned or removed are not considered writes since they cannot
+      // contain any FieldValue sentinels, etc.
+      const context = new ParseContext(
+        UserDataSource.Argument,
+        methodName,
+        FieldPath.EMPTY_PATH
+      );
+      const parsedElement = this.parseData(
+        element,
+        context.childContextForArray(i)
+      );
+      parsedElements.push(parsedElement);
+    }
+    return parsedElements;
   }
 }
 

--- a/packages/firestore/src/api/user_data_converter.ts
+++ b/packages/firestore/src/api/user_data_converter.ts
@@ -38,11 +38,8 @@ import {
   Mutation,
   PatchMutation,
   Precondition,
-  ServerTimestampTransform,
   SetMutation,
-  TransformMutation,
-  ArrayUnionTransformOperation,
-  ArrayRemoveTransformOperation
+  TransformMutation
 } from '../model/mutation';
 import { FieldPath } from '../model/path';
 import { assert, fail } from '../util/assert';
@@ -67,6 +64,11 @@ import {
   ArrayRemoveFieldValueImpl
 } from './field_value';
 import { GeoPoint } from './geo_point';
+import {
+  ServerTimestampTransform,
+  ArrayUnionTransformOperation,
+  ArrayRemoveTransformOperation
+} from '../model/transform_operation';
 
 const RESERVED_FIELD_REGEX = /^__.*__$/;
 

--- a/packages/firestore/src/api/user_data_converter.ts
+++ b/packages/firestore/src/api/user_data_converter.ts
@@ -671,9 +671,7 @@ export class UserDataConverter {
     methodName: string,
     elements: AnyJs[]
   ): FieldValue[] {
-    const parsedElements = [] as FieldValue[];
-    for (let i = 0; i < elements.length; i++) {
-      const element = elements[i];
+    return elements.map((element, i) => {
       // Although array transforms are used with writes, the actual elements
       // being unioned or removed are not considered writes since they cannot
       // contain any FieldValue sentinels, etc.
@@ -682,13 +680,8 @@ export class UserDataConverter {
         methodName,
         FieldPath.EMPTY_PATH
       );
-      const parsedElement = this.parseData(
-        element,
-        context.childContextForArray(i)
-      );
-      parsedElements.push(parsedElement);
-    }
-    return parsedElements;
+      return this.parseData(element, context.childContextForArray(i));
+    });
   }
 }
 

--- a/packages/firestore/src/model/mutation.ts
+++ b/packages/firestore/src/model/mutation.ts
@@ -75,6 +75,30 @@ export class ServerTimestampTransform implements TransformOperation {
   }
 }
 
+/** Transforms an array value via a union operation. */
+export class ArrayUnionTransformOperation {
+  constructor(readonly elements: FieldValue[]) {}
+
+  isEqual(other: TransformOperation): boolean {
+    return (
+      other instanceof ArrayUnionTransformOperation &&
+      misc.arrayEquals(other.elements, this.elements)
+    );
+  }
+}
+
+/** Transforms an array value via a remove operation. */
+export class ArrayRemoveTransformOperation {
+  constructor(readonly elements: FieldValue[]) {}
+
+  isEqual(other: TransformOperation): boolean {
+    return (
+      other instanceof ArrayRemoveTransformOperation &&
+      misc.arrayEquals(other.elements, this.elements)
+    );
+  }
+}
+
 /** A field path and the TransformOperation to perform upon it. */
 export class FieldTransform {
   constructor(
@@ -604,7 +628,6 @@ export class TransformMutation extends Mutation {
 
     for (let i = 0; i < this.fieldTransforms.length; i++) {
       const fieldTransform = this.fieldTransforms[i];
-      const transform = fieldTransform.transform;
       const fieldPath = fieldTransform.field;
       if (transform instanceof ServerTimestampTransform) {
         data = data.set(fieldPath, transformResults[i]);

--- a/packages/firestore/src/model/transform_operation.ts
+++ b/packages/firestore/src/model/transform_operation.ts
@@ -1,0 +1,97 @@
+/**
+ * Copyright 2018 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { FieldValue, ServerTimestampValue, ArrayValue } from './field_value';
+import { Timestamp } from '../api/timestamp';
+import * as misc from '../util/misc';
+import { assert } from '../util/assert';
+
+/** Represents a transform within a TransformMutation. */
+export interface TransformOperation {
+  /** Transforms the provided `previousValue`. */
+  transform(previousValue: FieldValue, localWriteTime?: Timestamp): FieldValue;
+
+  isEqual(other: TransformOperation): boolean;
+}
+
+/** Transforms a value into a server-generated timestamp. */
+export class ServerTimestampTransform implements TransformOperation {
+  private constructor() {}
+  static instance = new ServerTimestampTransform();
+
+  transform(previousValue: FieldValue, localWriteTime?: Timestamp): FieldValue {
+    assert(
+      localWriteTime !== undefined,
+      'ServerTimestampTransform.transform() requires localWriteTime.'
+    );
+    return new ServerTimestampValue(localWriteTime!, previousValue);
+  }
+
+  isEqual(other: TransformOperation): boolean {
+    return other instanceof ServerTimestampTransform;
+  }
+}
+
+/** Transforms an array value via a union operation. */
+export class ArrayUnionTransformOperation implements TransformOperation {
+  constructor(readonly elements: FieldValue[]) {}
+
+  transform(previousValue: FieldValue, localWriteTime?: Timestamp): FieldValue {
+    const result = coercedFieldValuesArray(previousValue);
+    for (const toUnion of this.elements) {
+      if (!result.find(element => element.isEqual(toUnion))) {
+        result.push(toUnion);
+      }
+    }
+    return new ArrayValue(result);
+  }
+
+  isEqual(other: TransformOperation): boolean {
+    return (
+      other instanceof ArrayUnionTransformOperation &&
+      misc.arrayEquals(other.elements, this.elements)
+    );
+  }
+}
+
+/** Transforms an array value via a remove operation. */
+export class ArrayRemoveTransformOperation implements TransformOperation {
+  constructor(readonly elements: FieldValue[]) {}
+
+  transform(previousValue: FieldValue, localWriteTime?: Timestamp): FieldValue {
+    let result = coercedFieldValuesArray(previousValue);
+    for (const toRemove of this.elements) {
+      result = result.filter(element => !element.isEqual(toRemove));
+    }
+    return new ArrayValue(result);
+  }
+
+  isEqual(other: TransformOperation): boolean {
+    return (
+      other instanceof ArrayRemoveTransformOperation &&
+      misc.arrayEquals(other.elements, this.elements)
+    );
+  }
+}
+
+function coercedFieldValuesArray(value: FieldValue | null): FieldValue[] {
+  if (value instanceof ArrayValue) {
+    return value.internalValue.slice();
+  } else {
+    // coerce to empty array.
+    return [];
+  }
+}

--- a/packages/firestore/src/remote/serializer.ts
+++ b/packages/firestore/src/remote/serializer.ts
@@ -46,7 +46,10 @@ import {
   Precondition,
   ServerTimestampTransform,
   SetMutation,
-  TransformMutation
+  TransformMutation,
+  ArrayUnionTransformOperation,
+  ArrayRemoveTransformOperation,
+  TransformOperation
 } from '../model/mutation';
 import { FieldPath, ResourcePath } from '../model/path';
 import { assert, fail } from '../util/assert';
@@ -906,23 +909,56 @@ export class JsonProtoSerializer {
   }
 
   private toFieldTransform(fieldTransform: FieldTransform): api.FieldTransform {
-    assert(
-      fieldTransform.transform instanceof ServerTimestampTransform,
-      'Unknown transform: ' + fieldTransform.transform
-    );
-    return {
-      fieldPath: fieldTransform.field.canonicalString(),
-      setToServerValue: 'REQUEST_TIME'
-    };
+    const transform = fieldTransform.transform;
+    if (transform instanceof ServerTimestampTransform) {
+      return {
+        fieldPath: fieldTransform.field.canonicalString(),
+        setToServerValue: 'REQUEST_TIME'
+      };
+    } else if (transform instanceof ArrayUnionTransformOperation) {
+      return {
+        fieldPath: fieldTransform.field.canonicalString(),
+        appendMissingElements: {
+          values: transform.elements.map(v => this.toValue(v))
+        }
+      };
+    } else if (transform instanceof ArrayRemoveTransformOperation) {
+      return {
+        fieldPath: fieldTransform.field.canonicalString(),
+        removeAllFromArray: {
+          values: transform.elements.map(v => this.toValue(v))
+        }
+      };
+    } else {
+      fail('Unknown transform: ' + fieldTransform.transform);
+    }
   }
 
   private fromFieldTransform(proto: api.FieldTransform): FieldTransform {
-    assert(
-      proto.setToServerValue! === 'REQUEST_TIME',
-      'Unknown transform proto: ' + JSON.stringify(proto)
-    );
+    // tslint:disable-next-line:no-any We need to match generated Proto types.
+    const type = (proto as any)['transform_type'];
+    let transform: TransformOperation | null = null;
+    if (hasTag(proto, type, 'setToServerValue')) {
+      assert(
+        proto.setToServerValue === 'REQUEST_TIME',
+        'Unknown server value transform proto: ' + JSON.stringify(proto)
+      );
+      transform = ServerTimestampTransform.instance;
+    } else if (hasTag(proto, type, 'appendMissingElements')) {
+      const values = proto.appendMissingElements!.values || [];
+      transform = new ArrayUnionTransformOperation(
+        values.map(v => this.fromValue(v))
+      );
+    } else if (hasTag(proto, type, 'removeAllFromArray')) {
+      const values = proto.removeAllFromArray!.values || [];
+      transform = new ArrayRemoveTransformOperation(
+        values.map(v => this.fromValue(v))
+      );
+    } else {
+      fail('Unknown transform proto: ' + JSON.stringify(proto));
+    }
     const fieldPath = FieldPath.fromServerFormat(proto.fieldPath!);
-    return new FieldTransform(fieldPath, ServerTimestampTransform.instance);
+    return new FieldTransform(fieldPath, transform);
   }
 
   toDocumentsTarget(query: Query): api.DocumentsTarget {

--- a/packages/firestore/src/remote/serializer.ts
+++ b/packages/firestore/src/remote/serializer.ts
@@ -44,12 +44,8 @@ import {
   MutationResult,
   PatchMutation,
   Precondition,
-  ServerTimestampTransform,
   SetMutation,
-  TransformMutation,
-  ArrayUnionTransformOperation,
-  ArrayRemoveTransformOperation,
-  TransformOperation
+  TransformMutation
 } from '../model/mutation';
 import { FieldPath, ResourcePath } from '../model/path';
 import { assert, fail } from '../util/assert';
@@ -68,6 +64,12 @@ import {
   WatchTargetChangeState
 } from './watch_change';
 import { ApiClientObjectMap } from '../protos/firestore_proto_api';
+import {
+  TransformOperation,
+  ServerTimestampTransform,
+  ArrayUnionTransformOperation,
+  ArrayRemoveTransformOperation
+} from '../model/transform_operation';
 
 const DIRECTIONS = (() => {
   const dirs: { [dir: string]: api.OrderDirection } = {};

--- a/packages/firestore/src/util/array.ts
+++ b/packages/firestore/src/util/array.ts
@@ -1,3 +1,5 @@
+import { Equatable } from './misc';
+
 /**
  * Copyright 2017 Google Inc.
  *
@@ -22,6 +24,31 @@ export function includes<T>(array: T[], value: T): boolean {
     if (array[i] === value) return true;
   }
   return false;
+}
+
+export function includesEqualElement<T extends Equatable<T>>(
+  array: T[],
+  value: T
+): boolean {
+  for (const element of array) {
+    if (element.isEqual(value)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+export function removeEqualElements<T extends Equatable<T>>(
+  array: T[],
+  value: T
+): T[] {
+  const result = [] as T[];
+  for (const element of array) {
+    if (!element.isEqual(value)) {
+      result.push(element);
+    }
+  }
+  return result;
 }
 
 /**

--- a/packages/firestore/src/util/array.ts
+++ b/packages/firestore/src/util/array.ts
@@ -1,5 +1,3 @@
-import { Equatable } from './misc';
-
 /**
  * Copyright 2017 Google Inc.
  *
@@ -24,31 +22,6 @@ export function includes<T>(array: T[], value: T): boolean {
     if (array[i] === value) return true;
   }
   return false;
-}
-
-export function includesEqualElement<T extends Equatable<T>>(
-  array: T[],
-  value: T
-): boolean {
-  for (const element of array) {
-    if (element.isEqual(value)) {
-      return true;
-    }
-  }
-  return false;
-}
-
-export function removeEqualElements<T extends Equatable<T>>(
-  array: T[],
-  value: T
-): T[] {
-  const result = [] as T[];
-  for (const element of array) {
-    if (!element.isEqual(value)) {
-      result.push(element);
-    }
-  }
-  return result;
 }
 
 /**

--- a/packages/firestore/test/integration/api/array_transforms.test.ts
+++ b/packages/firestore/test/integration/api/array_transforms.test.ts
@@ -1,0 +1,253 @@
+/**
+ * Copyright 2018 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { expect } from 'chai';
+import * as firestore from '@firebase/firestore-types';
+
+import firebase from '../util/firebase_export';
+import { apiDescribe, withTestDoc, withTestDb } from '../util/helpers';
+import { EventsAccumulator } from '../util/events_accumulator';
+
+// TODO(array-features): Remove "as any"
+// tslint:disable-next-line:no-any variable-name Type alias can be capitalized.
+const FieldValue = firebase.firestore.FieldValue as any;
+
+/**
+ * Note: Transforms are tested pretty thoroughly in server_timestamp.test.ts
+ * (via set, update, transactions, nested in documents, multiple transforms
+ * together, etc.) and so these tests mostly focus on the array transform
+ * semantics.
+ */
+// TODO(array-features): Enable these tests once the feature is available in
+// prod. For now you can run these tests using:
+// yarn test:browser --integration --local
+apiDescribe.skip('Array Transforms:', persistence => {
+  // A document reference to read and write to.
+  let docRef: firestore.DocumentReference;
+
+  // Accumulator used to capture events during the test.
+  let accumulator: EventsAccumulator<firestore.DocumentSnapshot>;
+
+  // Listener registration for a listener maintained during the course of the
+  // test.
+  let listenerRegistration: () => void;
+
+  /** Waits for a latency compensated local snapshot. */
+  async function waitForLocalEvent(): Promise<firestore.DocumentSnapshot> {
+    const snapshot = await accumulator.awaitEvent();
+    if (snapshot.metadata.hasPendingWrites) {
+      return snapshot;
+    } else {
+      return waitForLocalEvent();
+    }
+  }
+
+  /** Waits for a snapshot that has no pending writes */
+  async function waitForRemoteEvent(): Promise<firestore.DocumentSnapshot> {
+    const snapshot = await accumulator.awaitEvent();
+    if (!snapshot.metadata.hasPendingWrites) {
+      return snapshot;
+    } else {
+      return waitForRemoteEvent();
+    }
+  }
+
+  /** Writes some initialData and consumes the events generated. */
+  async function writeInitialData(
+    initialData: firestore.DocumentData
+  ): Promise<void> {
+    await docRef.set(initialData);
+    await waitForLocalEvent();
+    const snapshot = await waitForRemoteEvent();
+    expect(snapshot.data()).to.deep.equal(initialData);
+  }
+
+  async function expectLocalAndRemoteEvent(
+    expected: firestore.DocumentData
+  ): Promise<void> {
+    const localSnap = await waitForLocalEvent();
+    expect(localSnap.data()).to.deep.equal(expected);
+    const remoteSnap = await waitForRemoteEvent();
+    expect(remoteSnap.data()).to.deep.equal(expected);
+  }
+
+  /**
+   * Wraps a test, getting a docRef and event accumulator, and cleaning them
+   * up when done.
+   */
+  async function withTestSetup<T>(test: () => Promise<T>): Promise<void> {
+    await withTestDoc(persistence, async doc => {
+      docRef = doc;
+      accumulator = new EventsAccumulator<firestore.DocumentSnapshot>();
+      listenerRegistration = docRef.onSnapshot(
+        { includeMetadataChanges: true },
+        accumulator.storeEvent
+      );
+
+      // wait for initial null snapshot to avoid potential races.
+      const snapshot = await waitForRemoteEvent();
+      expect(snapshot.exists).to.be.false;
+      await test();
+      listenerRegistration();
+    });
+  }
+
+  it('create document with arrayUnion()', async () => {
+    await withTestSetup(async () => {
+      await docRef.set({ array: FieldValue._arrayUnion(1, 2) });
+      expectLocalAndRemoteEvent({ array: [1, 2] });
+    });
+  });
+
+  it('append to array via update()', async () => {
+    await withTestSetup(async () => {
+      await writeInitialData({ array: [1, 3] });
+      await docRef.update({ array: FieldValue._arrayUnion(2, 1, 4) });
+      await expectLocalAndRemoteEvent({ array: [1, 3, 2, 4] });
+    });
+  });
+
+  it('append to array via set(..., {merge: true})', async () => {
+    await withTestSetup(async () => {
+      await writeInitialData({ array: [1, 3] });
+      await docRef.set(
+        { array: FieldValue._arrayUnion(2, 1, 4) },
+        { merge: true }
+      );
+      await expectLocalAndRemoteEvent({ array: [1, 3, 2, 4] });
+    });
+  });
+
+  it('append object to array via update()', async () => {
+    await withTestSetup(async () => {
+      await writeInitialData({ array: [{ a: 'hi' }] });
+      await docRef.update({
+        array: FieldValue._arrayUnion({ a: 'hi' }, { a: 'bye' })
+      });
+      await expectLocalAndRemoteEvent({ array: [{ a: 'hi' }, { a: 'bye' }] });
+    });
+  });
+
+  it('remove from array via update()', async () => {
+    await withTestSetup(async () => {
+      await writeInitialData({ array: [1, 3, 1, 3] });
+      await docRef.update({ array: FieldValue._arrayRemove(1, 4) });
+      await expectLocalAndRemoteEvent({ array: [3, 3] });
+    });
+  });
+
+  it('remove from array via set(..., {merge: true})', async () => {
+    await withTestSetup(async () => {
+      await writeInitialData({ array: [1, 3, 1, 3] });
+      await docRef.set(
+        { array: FieldValue._arrayRemove(1, 4) },
+        { merge: true }
+      );
+      await expectLocalAndRemoteEvent({ array: [3, 3] });
+    });
+  });
+
+  it('remove object from array via update()', async () => {
+    await withTestSetup(async () => {
+      await writeInitialData({ array: [{ a: 'hi' }, { a: 'bye' }] });
+      await docRef.update({ array: FieldValue._arrayRemove({ a: 'hi' }) });
+      await expectLocalAndRemoteEvent({ array: [{ a: 'bye' }] });
+    });
+  });
+
+  /**
+   * Unlike the withTestSetup() tests above, these tests intentionally avoid
+   * having any ongoing listeners so that we can test what gets stored in the
+   * offline cache based purely on the write acknowledgement (without receiving
+   * an updated document via watch). As such they also rely on persistence
+   * being enabled so documents remain in the cache after the write.
+   */
+  (persistence ? describe : describe.skip)('Server Application: ', () => {
+    it('set() with no cached base doc', async () => {
+      await withTestDoc(persistence, async docRef => {
+        await docRef.set({ array: FieldValue._arrayUnion(1, 2) });
+        const snapshot = await docRef.get({ source: 'cache' });
+        expect(snapshot.data()).to.deep.equal({ array: [1, 2] });
+      });
+    });
+
+    it('update() with no cached base doc', async () => {
+      let path: string | null = null;
+      // Write an initial document in an isolated Firestore instance so it's not
+      // stored in our cache
+      await withTestDoc(persistence, async docRef => {
+        path = docRef.path;
+        await docRef.set({ array: [42] });
+      });
+
+      await withTestDb(persistence, async db => {
+        const docRef = db.doc(path);
+        await docRef.update({ array: FieldValue._arrayUnion(1, 2) });
+
+        // Nothing should be cached since it was an update and we had no base
+        // doc.
+        let errCaught = false;
+        try {
+          await docRef.get({ source: 'cache' });
+        } catch (err) {
+          expect(err.code).to.equal('unavailable');
+          errCaught = true;
+        }
+        expect(errCaught).to.be.true;
+      });
+    });
+
+    it('set(..., {merge}) with no cached based doc', async () => {
+      let path: string | null = null;
+      // Write an initial document in an isolated Firestore instance so it's not
+      // stored in our cache
+      await withTestDoc(persistence, async docRef => {
+        path = docRef.path;
+        await docRef.set({ array: [42] });
+      });
+
+      await withTestDb(persistence, async db => {
+        const docRef = db.doc(path);
+        await docRef.set(
+          { array: FieldValue._arrayUnion(1, 2) },
+          { merge: true }
+        );
+
+        // Document will be cached but we'll be missing 42.
+        const snapshot = await docRef.get({ source: 'cache' });
+        expect(snapshot.data()).to.deep.equal({ array: [1, 2] });
+      });
+    });
+
+    it('update() with cached base doc using arrayUnion()', async () => {
+      await withTestDoc(persistence, async docRef => {
+        await docRef.set({ array: [42] });
+        await docRef.update({ array: FieldValue._arrayUnion(1, 2) });
+        const snapshot = await docRef.get({ source: 'cache' });
+        expect(snapshot.data()).to.deep.equal({ array: [42, 1, 2] });
+      });
+    });
+
+    it('update() with cached base doc using arrayRemove()', async () => {
+      await withTestDoc(persistence, async docRef => {
+        await docRef.set({ array: [42, 1, 2] });
+        await docRef.update({ array: FieldValue._arrayRemove(1, 2) });
+        const snapshot = await docRef.get({ source: 'cache' });
+        expect(snapshot.data()).to.deep.equal({ array: [42] });
+      });
+    });
+  });
+});

--- a/packages/firestore/test/integration/api/server_timestamp.test.ts
+++ b/packages/firestore/test/integration/api/server_timestamp.test.ts
@@ -68,9 +68,9 @@ apiDescribe('Server Timestamps', persistence => {
 
   /** Waits for a latency compensated local snapshot. */
   function waitForLocalEvent(): Promise<firestore.DocumentSnapshot> {
-    return accumulator.awaitEvent().then(remoteSnap => {
-      if (remoteSnap.metadata.hasPendingWrites) {
-        return remoteSnap;
+    return accumulator.awaitEvent().then(snapshot => {
+      if (snapshot.metadata.hasPendingWrites) {
+        return snapshot;
       } else {
         return waitForLocalEvent();
       }
@@ -96,9 +96,9 @@ apiDescribe('Server Timestamps', persistence => {
 
   /** Waits for a snapshot that has no pending writes */
   function waitForRemoteEvent(): Promise<firestore.DocumentSnapshot> {
-    return accumulator.awaitEvent().then(remoteSnap => {
-      if (!remoteSnap.metadata.hasPendingWrites) {
-        return remoteSnap;
+    return accumulator.awaitEvent().then(snapshot => {
+      if (!snapshot.metadata.hasPendingWrites) {
+        return snapshot;
       } else {
         return waitForRemoteEvent();
       }

--- a/packages/firestore/test/integration/api/server_timestamp.test.ts
+++ b/packages/firestore/test/integration/api/server_timestamp.test.ts
@@ -49,7 +49,7 @@ apiDescribe('Server Timestamps', persistence => {
 
   // Listener registration for a listener maintained during the course of the
   // test.
-  let listenerRegistration: () => void;
+  let unsubscribe: () => void;
 
   // Returns the expected data, with an arbitrary timestamp substituted in.
   function expectedDataWithTimestamp(timestamp: object | null): AnyTestData {
@@ -64,45 +64,6 @@ apiDescribe('Server Timestamps', persistence => {
       .then(initialDataSnap => {
         expect(initialDataSnap.data()).to.deep.equal(initialData);
       });
-  }
-
-  /** Waits for a latency compensated local snapshot. */
-  function waitForLocalEvent(): Promise<firestore.DocumentSnapshot> {
-    return accumulator.awaitEvent().then(snapshot => {
-      if (snapshot.metadata.hasPendingWrites) {
-        return snapshot;
-      } else {
-        return waitForLocalEvent();
-      }
-    });
-  }
-
-  /** Waits for `count` latency compensated local snapshots. */
-  function waitForLocalEvents(
-    count: number
-  ): Promise<firestore.DocumentSnapshot[]> {
-    const snapshots: firestore.DocumentSnapshot[] = [];
-    let promise = Promise.resolve(snapshots);
-
-    while (count--) {
-      promise = promise.then(() => waitForLocalEvent()).then(localSnap => {
-        snapshots.push(localSnap);
-        return snapshots;
-      });
-    }
-
-    return promise;
-  }
-
-  /** Waits for a snapshot that has no pending writes */
-  function waitForRemoteEvent(): Promise<firestore.DocumentSnapshot> {
-    return accumulator.awaitEvent().then(snapshot => {
-      if (!snapshot.metadata.hasPendingWrites) {
-        return snapshot;
-      } else {
-        return waitForRemoteEvent();
-      }
-    });
   }
 
   /** Verifies a snapshot containing setData but with resolved server timestamps. */
@@ -169,7 +130,7 @@ apiDescribe('Server Timestamps', persistence => {
       docRef = doc;
 
       accumulator = new EventsAccumulator<firestore.DocumentSnapshot>();
-      listenerRegistration = docRef.onSnapshot(accumulator.storeEvent);
+      unsubscribe = docRef.onSnapshot(accumulator.storeEvent);
 
       // wait for initial null snapshot to avoid potential races.
       return accumulator
@@ -179,7 +140,7 @@ apiDescribe('Server Timestamps', persistence => {
         })
         .then(() => test())
         .then(() => {
-          listenerRegistration();
+          unsubscribe();
         });
     });
   }
@@ -188,9 +149,9 @@ apiDescribe('Server Timestamps', persistence => {
     return withTestSetup(() => {
       return docRef
         .set(setData)
-        .then(waitForLocalEvent)
+        .then(() => accumulator.awaitLocalEvent())
         .then(snapshot => verifyTimestampsAreNull(snapshot))
-        .then(waitForRemoteEvent)
+        .then(() => accumulator.awaitRemoteEvent())
         .then(snapshot => verifyTimestampsAreResolved(snapshot));
     });
   });
@@ -199,9 +160,9 @@ apiDescribe('Server Timestamps', persistence => {
     return withTestSetup(() => {
       return writeInitialData()
         .then(() => docRef.update(updateData))
-        .then(waitForLocalEvent)
+        .then(() => accumulator.awaitLocalEvent())
         .then(snapshot => verifyTimestampsAreNull(snapshot))
-        .then(waitForRemoteEvent)
+        .then(() => accumulator.awaitRemoteEvent())
         .then(snapshot => verifyTimestampsAreResolved(snapshot));
     });
   });
@@ -212,7 +173,7 @@ apiDescribe('Server Timestamps', persistence => {
         .runTransaction(async txn => {
           txn.set(docRef, setData);
         })
-        .then(waitForRemoteEvent)
+        .then(() => accumulator.awaitRemoteEvent())
         .then(snapshot => verifyTimestampsAreResolved(snapshot));
     });
   });
@@ -225,7 +186,7 @@ apiDescribe('Server Timestamps', persistence => {
             txn.update(docRef, updateData);
           })
         )
-        .then(waitForRemoteEvent)
+        .then(() => accumulator.awaitRemoteEvent())
         .then(snapshot => verifyTimestampsAreResolved(snapshot));
     });
   });
@@ -234,7 +195,7 @@ apiDescribe('Server Timestamps', persistence => {
     return withTestSetup(() => {
       return writeInitialData()
         .then(() => docRef.update(updateData))
-        .then(waitForLocalEvent)
+        .then(() => accumulator.awaitLocalEvent())
         .then(snapshot => verifyTimestampsAreEstimates(snapshot));
     });
   });
@@ -245,14 +206,14 @@ apiDescribe('Server Timestamps', persistence => {
     return withTestSetup(() => {
       return writeInitialData()
         .then(() => docRef.update(updateData))
-        .then(waitForLocalEvent)
+        .then(() => accumulator.awaitLocalEvent())
         .then(snapshot => verifyTimestampsUsePreviousValue(snapshot, null))
-        .then(waitForRemoteEvent)
+        .then(() => accumulator.awaitRemoteEvent())
         .then(snapshot => {
           previousSnapshot = snapshot;
         })
         .then(() => docRef.update(updateData))
-        .then(waitForLocalEvent)
+        .then(() => accumulator.awaitLocalEvent())
         .then(snapshot =>
           verifyTimestampsUsePreviousValue(snapshot, previousSnapshot)
         );
@@ -266,7 +227,7 @@ apiDescribe('Server Timestamps', persistence => {
           // Change field 'a' from a number type to a server timestamp.
           docRef.update('a', firebase.firestore.FieldValue.serverTimestamp())
         )
-        .then(waitForLocalEvent)
+        .then(() => accumulator.awaitLocalEvent())
         .then(snapshot => {
           // Verify that we can still obtain the number.
           expect(snapshot.get('a', { serverTimestamps: 'previous' })).to.equal(
@@ -284,7 +245,7 @@ apiDescribe('Server Timestamps', persistence => {
           // We set up two consecutive writes with server timestamps.
           docRef.update('a', firebase.firestore.FieldValue.serverTimestamp());
           docRef.update('a', firebase.firestore.FieldValue.serverTimestamp());
-          return waitForLocalEvents(2);
+          return accumulator.awaitLocalEvents(2);
         })
         .then(snapshots => {
           // Both snapshot use the initial value (42) as the previous value.
@@ -307,7 +268,7 @@ apiDescribe('Server Timestamps', persistence => {
           docRef.update('a', firebase.firestore.FieldValue.serverTimestamp());
           docRef.update('a', 1337);
           docRef.update('a', firebase.firestore.FieldValue.serverTimestamp());
-          return waitForLocalEvents(3);
+          return accumulator.awaitLocalEvents(3);
         })
         .then(snapshots => {
           // The first snapshot uses the initial value (42) as the previous value.

--- a/packages/firestore/test/integration/api/validation.test.ts
+++ b/packages/firestore/test/integration/api/validation.test.ts
@@ -620,12 +620,16 @@ apiDescribe('Validation:', persistence => {
 
     validationIt(persistence, 'reject invalid elements', db => {
       const doc = db.collection('test').doc();
-      expect(() => doc.set({x: FieldValue._arrayUnion(1, new TestClass('foo'))})).to.throw(
+      expect(() =>
+        doc.set({ x: FieldValue._arrayUnion(1, new TestClass('foo')) })
+      ).to.throw(
         'Function FieldValue.arrayUnion() called with invalid data. ' +
           'Unsupported field value: a custom TestClass object'
       );
 
-      expect(() => doc.set({x: FieldValue._arrayRemove(1, new TestClass('foo'))})).to.throw(
+      expect(() =>
+        doc.set({ x: FieldValue._arrayRemove(1, new TestClass('foo')) })
+      ).to.throw(
         'Function FieldValue.arrayRemove() called with invalid data. ' +
           'Unsupported field value: a custom TestClass object'
       );
@@ -634,12 +638,16 @@ apiDescribe('Validation:', persistence => {
     validationIt(persistence, 'reject arrays', db => {
       const doc = db.collection('test').doc();
       // This would result in a directly nested array which is not supported.
-      expect(() => doc.set({x: FieldValue._arrayUnion(1, ['nested'])})).to.throw(
+      expect(() =>
+        doc.set({ x: FieldValue._arrayUnion(1, ['nested']) })
+      ).to.throw(
         'Function FieldValue.arrayUnion() called with invalid data. ' +
           'Nested arrays are not supported'
       );
 
-      expect(() => doc.set({x: FieldValue._arrayRemove(1, ['nested'])})).to.throw(
+      expect(() =>
+        doc.set({ x: FieldValue._arrayRemove(1, ['nested']) })
+      ).to.throw(
         'Function FieldValue.arrayRemove() called with invalid data. ' +
           'Nested arrays are not supported'
       );

--- a/packages/firestore/test/integration/api/validation.test.ts
+++ b/packages/firestore/test/integration/api/validation.test.ts
@@ -92,6 +92,11 @@ const validationIt: ValidationIt = Object.assign(
   }
 );
 
+/** Class used to verify custom classes can't be used in writes. */
+class TestClass {
+  constructor(readonly property: string) {}
+}
+
 // NOTE: The JS SDK does extensive validation of argument counts, types, etc.
 // since it is an untyped language. These tests are not exhaustive as that would
 // be extremely tedious, but we do try to hit every error template at least
@@ -326,11 +331,6 @@ apiDescribe('Validation:', persistence => {
   });
 
   describe('Writes', () => {
-    /** Class used to verify custom classes can't be used in writes. */
-    class TestClass {
-      constructor(readonly property: string) {}
-    }
-
     validationIt(persistence, 'must be objects.', db => {
       // PORTING NOTE: The error for firebase.firestore.FieldValue.delete()
       // is different for minified builds, so omit testing it specifically.
@@ -593,6 +593,58 @@ apiDescribe('Validation:', persistence => {
       return Promise.all(promises);
     }
   );
+
+  describe('Array transforms', () => {
+    // TODO(array-features): Remove "as any"
+    // tslint:disable-next-line:variable-name Type alias can be capitalized.
+    const FieldValue = firebase.firestore.FieldValue as any;
+
+    validationIt(persistence, 'fail in queries', db => {
+      const collection = db.collection('test');
+      expect(() =>
+        collection.where('test', '==', { test: FieldValue._arrayUnion(1) })
+      ).to.throw(
+        'Function Query.where() called with invalid data. ' +
+          'FieldValue.arrayUnion() can only be used with update() and set() ' +
+          '(found in field test)'
+      );
+
+      expect(() =>
+        collection.where('test', '==', { test: FieldValue._arrayRemove(1) })
+      ).to.throw(
+        'Function Query.where() called with invalid data. ' +
+          'FieldValue.arrayRemove() can only be used with update() and set() ' +
+          '(found in field test)'
+      );
+    });
+
+    validationIt(persistence, 'reject invalid elements', db => {
+      const doc = db.collection('test').doc();
+      expect(() => doc.set({x: FieldValue._arrayUnion(1, new TestClass('foo'))})).to.throw(
+        'Function FieldValue.arrayUnion() called with invalid data. ' +
+          'Unsupported field value: a custom TestClass object'
+      );
+
+      expect(() => doc.set({x: FieldValue._arrayRemove(1, new TestClass('foo'))})).to.throw(
+        'Function FieldValue.arrayRemove() called with invalid data. ' +
+          'Unsupported field value: a custom TestClass object'
+      );
+    });
+
+    validationIt(persistence, 'reject arrays', db => {
+      const doc = db.collection('test').doc();
+      // This would result in a directly nested array which is not supported.
+      expect(() => doc.set({x: FieldValue._arrayUnion(1, ['nested'])})).to.throw(
+        'Function FieldValue.arrayUnion() called with invalid data. ' +
+          'Nested arrays are not supported'
+      );
+
+      expect(() => doc.set({x: FieldValue._arrayRemove(1, ['nested'])})).to.throw(
+        'Function FieldValue.arrayRemove() called with invalid data. ' +
+          'Nested arrays are not supported'
+      );
+    });
+  });
 
   describe('Queries', () => {
     validationIt(persistence, 'with non-positive limit fail', db => {

--- a/packages/firestore/test/integration/util/helpers.ts
+++ b/packages/firestore/test/integration/util/helpers.ts
@@ -70,7 +70,15 @@ export function isPersistenceAvailable(): boolean {
  * A wrapper around Jasmine's describe method that allows for it to be run with
  * persistence both disabled and enabled (if the browser is supported).
  */
-export function apiDescribe(
+export const apiDescribe = apiDescribeInternal.bind(
+  null,
+  describe
+) as Mocha.IContextDefinition;
+apiDescribe.skip = apiDescribeInternal.bind(null, describe.skip);
+apiDescribe.only = apiDescribeInternal.bind(null, describe.only);
+
+function apiDescribeInternal(
+  describeFn: Mocha.IContextDefinition,
   message: string,
   testSuite: (persistence: boolean) => void
 ): void {
@@ -80,7 +88,7 @@ export function apiDescribe(
   }
 
   for (const enabled of persistenceModes) {
-    describe(`(Persistence=${enabled}) ${message}`, () => testSuite(enabled));
+    describeFn(`(Persistence=${enabled}) ${message}`, () => testSuite(enabled));
   }
 }
 

--- a/packages/firestore/test/integration/util/helpers.ts
+++ b/packages/firestore/test/integration/util/helpers.ts
@@ -70,10 +70,7 @@ export function isPersistenceAvailable(): boolean {
  * A wrapper around Jasmine's describe method that allows for it to be run with
  * persistence both disabled and enabled (if the browser is supported).
  */
-export const apiDescribe = apiDescribeInternal.bind(
-  null,
-  describe
-) as Mocha.IContextDefinition;
+export const apiDescribe = apiDescribeInternal.bind(null, describe);
 apiDescribe.skip = apiDescribeInternal.bind(null, describe.skip);
 apiDescribe.only = apiDescribeInternal.bind(null, describe.only);
 

--- a/packages/firestore/test/unit/model/mutation.test.ts
+++ b/packages/firestore/test/unit/model/mutation.test.ts
@@ -16,6 +16,7 @@
 
 import { expect } from 'chai';
 import { Timestamp } from '../../../src/api/timestamp';
+import { PublicFieldValue as FieldValue } from '../../../src/api/field_value';
 import { Document, MaybeDocument } from '../../../src/model/document';
 import {
   ServerTimestampValue,
@@ -24,7 +25,9 @@ import {
 import {
   Mutation,
   MutationResult,
-  Precondition
+  Precondition,
+  ArrayUnionTransformOperation,
+  ArrayRemoveTransformOperation
 } from '../../../src/model/mutation';
 import {
   DELETE_SENTINEL,
@@ -38,9 +41,12 @@ import {
   setMutation,
   transformMutation,
   version,
+  wrap,
   wrapObject
 } from '../../util/helpers';
 import { addEqualityMatcher } from '../../util/equality_matcher';
+import { Dict } from '../../../src/util/obj';
+import { AnyJs } from '../../../src/util/misc';
 
 describe('Mutation', () => {
   addEqualityMatcher();
@@ -170,11 +176,13 @@ describe('Mutation', () => {
     expect(patchedDoc).to.deep.equal(baseDoc);
   });
 
-  it('can apply local transforms to documents', () => {
+  it('can apply local serverTimestamp transforms to documents', () => {
     const docData = { foo: { bar: 'bar-value' }, baz: 'baz-value' };
 
     const baseDoc = doc('collection/key', 0, docData);
-    const transform = transformMutation('collection/key', ['foo.bar']);
+    const transform = transformMutation('collection/key', {
+      'foo.bar': FieldValue.serverTimestamp()
+    });
 
     const transformedDoc = transform.applyToLocalView(
       baseDoc,
@@ -194,11 +202,172 @@ describe('Mutation', () => {
     expect(transformedDoc).to.deep.equal(expectedDoc);
   });
 
-  it('can apply server-acked transforms to documents', () => {
+  // NOTE: This is more a test of UserDataConverter code than Mutation code but
+  // we don't have unit tests for it currently. We could consider removing this
+  // test once we have integration tests.
+  it('can create arrayUnion() transform.', () => {
+    const transform = transformMutation('collection/key', {
+      foo: FieldValue._arrayUnion('tag'),
+      'bar.baz': FieldValue._arrayUnion(true, { nested: { a: [1, 2] } })
+    });
+    expect(transform.fieldTransforms.length).to.equal(2);
+
+    const first = transform.fieldTransforms[0];
+    expect(first.field).to.deep.equal(field('foo'));
+    expect(first.transform).to.deep.equal(
+      new ArrayUnionTransformOperation([wrap('tag')])
+    );
+
+    const second = transform.fieldTransforms[1];
+    expect(second.field).to.deep.equal(field('bar.baz'));
+    expect(second.transform).to.deep.equal(
+      new ArrayUnionTransformOperation([
+        wrap(true),
+        wrap({ nested: { a: [1, 2] } })
+      ])
+    );
+  });
+
+  // NOTE: This is more a test of UserDataConverter code than Mutation code but
+  // we don't have unit tests for it currently. We could consider removing this
+  // test once we have integration tests.
+  it('can create arrayRemove() transform.', () => {
+    const transform = transformMutation('collection/key', {
+      foo: FieldValue._arrayRemove('tag')
+    });
+    expect(transform.fieldTransforms.length).to.equal(1);
+
+    const first = transform.fieldTransforms[0];
+    expect(first.field).to.deep.equal(field('foo'));
+    expect(first.transform).to.deep.equal(
+      new ArrayRemoveTransformOperation([wrap('tag')])
+    );
+  });
+
+  it('can apply local arrayUnion transform to missing field', () => {
+    const baseDoc = {};
+    const transform = { missing: FieldValue._arrayUnion(1, 2) };
+    const expected = { missing: [1, 2] };
+    verifyTransform(baseDoc, transform, expected);
+  });
+
+  it('can apply local arrayUnion transform to non-array field', () => {
+    const baseDoc = { 'non-array': 42 };
+    const transform = { 'non-array': FieldValue._arrayUnion(1, 2) };
+    const expected = { 'non-array': [1, 2] };
+    verifyTransform(baseDoc, transform, expected);
+  });
+
+  it('can apply local arrayUnion transform with non-existing elements', () => {
+    const baseDoc = { array: [1, 3] };
+    const transform = { array: FieldValue._arrayUnion(2, 4) };
+    const expected = { array: [1, 3, 2, 4] };
+    verifyTransform(baseDoc, transform, expected);
+  });
+
+  it('can apply local arrayUnion transform with existing elements', () => {
+    const baseDoc = { array: [1, 3] };
+    const transform = { array: FieldValue._arrayUnion(1, 3) };
+    const expected = { array: [1, 3] };
+    verifyTransform(baseDoc, transform, expected);
+  });
+
+  it('can apply local arrayUnion transform with duplicate existing elements', () => {
+    // Duplicate entries in your existing array should be preserved.
+    const baseDoc = { array: [1, 2, 2, 3] };
+    const transform = { array: FieldValue._arrayUnion(2) };
+    const expected = { array: [1, 2, 2, 3] };
+    verifyTransform(baseDoc, transform, expected);
+  });
+
+  it('can apply local arrayUnion transform with duplicate union elements', () => {
+    // Duplicate entries in your union array should only be added once.
+    const baseDoc = { array: [1, 3] };
+    const transform = { array: FieldValue._arrayUnion(2, 2) };
+    const expected = { array: [1, 3, 2] };
+    verifyTransform(baseDoc, transform, expected);
+  });
+
+  it('can apply local arrayUnion transform with non-primitive elements', () => {
+    // Union nested object values (one existing, one not).
+    const baseDoc = { array: [1, { a: 'b' }] };
+    const transform = { array: FieldValue._arrayUnion({ a: 'b' }, { c: 'd' }) };
+    const expected = { array: [1, { a: 'b' }, { c: 'd' }] };
+    verifyTransform(baseDoc, transform, expected);
+  });
+
+  it('can apply local arrayUnion transform with partially-overlapping elements', () => {
+    // Union objects that partially overlap an existing object.
+    const baseDoc = { array: [1, { a: 'b', c: 'd' }] };
+    const transform = { array: FieldValue._arrayUnion({ a: 'b' }, { c: 'd' }) };
+    const expected = { array: [1, { a: 'b', c: 'd' }, { a: 'b' }, { c: 'd' }] };
+    verifyTransform(baseDoc, transform, expected);
+  });
+
+  it('can apply local arrayRemove transform to missing field', () => {
+    const baseDoc = {};
+    const transform = { missing: FieldValue._arrayRemove(1, 2) };
+    const expected = { missing: [] };
+    verifyTransform(baseDoc, transform, expected);
+  });
+
+  it('can apply local arrayRemove transform to non-array field', () => {
+    const baseDoc = { 'non-array': 42 };
+    const transform = { 'non-array': FieldValue._arrayRemove(1, 2) };
+    const expected = { 'non-array': [] };
+    verifyTransform(baseDoc, transform, expected);
+  });
+
+  it('can apply local arrayRemove transform with non-existing elements', () => {
+    const baseDoc = { array: [1, 3] };
+    const transform = { array: FieldValue._arrayRemove(2, 4) };
+    const expected = { array: [1, 3] };
+    verifyTransform(baseDoc, transform, expected);
+  });
+
+  it('can apply local arrayRemove transform with existing elements', () => {
+    const baseDoc = { array: [1, 2, 3, 4] };
+    const transform = { array: FieldValue._arrayRemove(1, 3) };
+    const expected = { array: [2, 4] };
+    verifyTransform(baseDoc, transform, expected);
+  });
+
+  it('can apply local arrayRemove transform with non-primitive elements', () => {
+    // Remove nested object values (one existing, one not).
+    const baseDoc = { array: [1, { a: 'b' }] };
+    const transform = {
+      array: FieldValue._arrayRemove({ a: 'b' }, { c: 'd' })
+    };
+    const expected = { array: [1] };
+    verifyTransform(baseDoc, transform, expected);
+  });
+
+  function verifyTransform(
+    baseData: Dict<AnyJs>,
+    transformData: Dict<AnyJs>,
+    expectedData: Dict<AnyJs>
+  ): void {
+    const baseDoc = doc('collection/key', 0, baseData);
+    const transform = transformMutation('collection/key', transformData);
+    const transformedDoc = transform.applyToLocalView(
+      baseDoc,
+      baseDoc,
+      timestamp
+    );
+
+    const expectedDoc = doc('collection/key', 0, expectedData, {
+      hasLocalMutations: true
+    });
+    expect(transformedDoc).to.deep.equal(expectedDoc);
+  }
+
+  it('can apply server-acked serverTimestamp transform to documents', () => {
     const docData = { foo: { bar: 'bar-value' }, baz: 'baz-value' };
 
     const baseDoc = doc('collection/key', 0, docData);
-    const transform = transformMutation('collection/key', ['foo.bar']);
+    const transform = transformMutation('collection/key', {
+      'foo.bar': FieldValue.serverTimestamp()
+    });
 
     const mutationResult = new MutationResult(version(1), [
       new TimestampValue(timestamp)
@@ -213,6 +382,31 @@ describe('Mutation', () => {
         'collection/key',
         0,
         { foo: { bar: timestamp.toDate() }, baz: 'baz-value' },
+        { hasLocalMutations: false }
+      )
+    );
+  });
+
+  it('can apply server-acked array transforms to documents', () => {
+    const docData = { array1: [1, 2], array2: ['a', 'b'] };
+    const baseDoc = doc('collection/key', 0, docData);
+    const transform = transformMutation('collection/key', {
+      array1: FieldValue._arrayUnion(2, 3),
+      array2: FieldValue._arrayRemove('a', 'c')
+    });
+
+    // Server just sends null transform results for array operations.
+    const mutationResult = new MutationResult(version(1), [null, null]);
+    const transformedDoc = transform.applyToRemoteDocument(
+      baseDoc,
+      mutationResult
+    );
+
+    expect(transformedDoc).to.deep.equal(
+      doc(
+        'collection/key',
+        0,
+        { array1: [1, 2, 3], array2: ['b'] },
         { hasLocalMutations: false }
       )
     );
@@ -274,7 +468,7 @@ describe('Mutation', () => {
 
     const set = setMutation('collection/key', {});
     const patch = patchMutation('collection/key', {});
-    const transform = transformMutation('collection/key', []);
+    const transform = transformMutation('collection/key', {});
     const deleter = deleteMutation('collection/key');
 
     const mutationResult = new MutationResult(

--- a/packages/firestore/test/unit/model/mutation.test.ts
+++ b/packages/firestore/test/unit/model/mutation.test.ts
@@ -25,9 +25,7 @@ import {
 import {
   Mutation,
   MutationResult,
-  Precondition,
-  ArrayUnionTransformOperation,
-  ArrayRemoveTransformOperation
+  Precondition
 } from '../../../src/model/mutation';
 import {
   DELETE_SENTINEL,
@@ -47,6 +45,10 @@ import {
 import { addEqualityMatcher } from '../../util/equality_matcher';
 import { Dict } from '../../../src/util/obj';
 import { AnyJs } from '../../../src/util/misc';
+import {
+  ArrayRemoveTransformOperation,
+  ArrayUnionTransformOperation
+} from '../../../src/model/transform_operation';
 
 describe('Mutation', () => {
   addEqualityMatcher();

--- a/packages/firestore/test/unit/remote/node/serializer.test.ts
+++ b/packages/firestore/test/unit/remote/node/serializer.test.ts
@@ -686,7 +686,7 @@ describe('Serializer', () => {
       verifyMutation(mutation, proto);
     });
 
-    it('TransformMutation', () => {
+    it('TransformMutation (ServerTimestamp transform)', () => {
       const mutation = transformMutation('baz/quux', {
         a: FieldValue.serverTimestamp(),
         'bar.baz': FieldValue.serverTimestamp()
@@ -697,6 +697,32 @@ describe('Serializer', () => {
           fieldTransforms: [
             { fieldPath: 'a', setToServerValue: 'REQUEST_TIME' },
             { fieldPath: 'bar.baz', setToServerValue: 'REQUEST_TIME' }
+          ]
+        },
+        currentDocument: { exists: true }
+      };
+      verifyMutation(mutation, proto);
+    });
+
+    it('TransformMutation (Array transforms)', () => {
+      const mutation = transformMutation('docs/1', {
+        a: FieldValue._arrayUnion('a', 2),
+        'bar.baz': FieldValue._arrayRemove({ x: 1 })
+      });
+      const proto: api.Write = {
+        transform: {
+          document: s.toName(mutation.key),
+          fieldTransforms: [
+            {
+              fieldPath: 'a',
+              appendMissingElements: {
+                values: [s.toValue(wrap('a')), s.toValue(wrap(2))]
+              }
+            },
+            {
+              fieldPath: 'bar.baz',
+              removeAllFromArray: { values: [s.toValue(wrap({ x: 1 }))] }
+            }
           ]
         },
         currentDocument: { exists: true }

--- a/packages/firestore/test/unit/remote/node/serializer.test.ts
+++ b/packages/firestore/test/unit/remote/node/serializer.test.ts
@@ -20,6 +20,7 @@ import * as Long from 'long';
 import * as api from '../../../../src/protos/firestore_proto_api';
 import { Blob } from '../../../../src/api/blob';
 import { GeoPoint } from '../../../../src/api/geo_point';
+import { PublicFieldValue as FieldValue } from '../../../../src/api/field_value';
 import { Timestamp } from '../../../../src/api/timestamp';
 import { DatabaseId } from '../../../../src/core/database_info';
 import {
@@ -686,7 +687,10 @@ describe('Serializer', () => {
     });
 
     it('TransformMutation', () => {
-      const mutation = transformMutation('baz/quux', ['a', 'bar.baz']);
+      const mutation = transformMutation('baz/quux', {
+        a: FieldValue.serverTimestamp(),
+        'bar.baz': FieldValue.serverTimestamp()
+      });
       const proto = {
         transform: {
           document: s.toName(mutation.key),


### PR DESCRIPTION
[This review is not super urgent if you're busy this week]

This is a port of The following iOS commits:
https://github.com/firebase/firebase-ios-sdk/commit/60d43d7b0980719beac21811da712f1cb4881308
https://github.com/firebase/firebase-ios-sdk/commit/360e58901c359d7d21da4fff8043894c843427b7
https://github.com/firebase/firebase-ios-sdk/commit/f2ec9e11fba82d4a76d989293d270a37ad1373a2
https://github.com/firebase/firebase-ios-sdk/commit/e36cc9610b11dfd2581ba5e3fda1917e0d5e697a
https://github.com/firebase/firebase-ios-sdk/commit/7dca635039efb00082624552c223ac7f47ea0cad

While I split this PR into separate commits, they don't match 1:1 with the iOS commits (some of the commits iterated on bits from previous ones) so it may be a little difficult to compare. So I'd probably just compare to iOS HEAD if in doubt.