### PR TITLE
Speed up spec tests with connection backoffs

### DIFF
--- a/packages/firestore/test/unit/specs/offline_spec.test.ts
+++ b/packages/firestore/test/unit/specs/offline_spec.test.ts
@@ -84,7 +84,7 @@ describeSpec('Offline:', [], () => {
           .watchStreamCloses(Code.UNAVAILABLE)
           // Suppose sometime later we listen again, it should take two failures
           // before we get cached data.
-         .userListens(query)
+          .userListens(query)
           .watchStreamCloses(Code.UNAVAILABLE)
           .watchStreamCloses(Code.UNAVAILABLE)
           .expectEvents(query, {

--- a/packages/firestore/test/unit/specs/offline_spec.test.ts
+++ b/packages/firestore/test/unit/specs/offline_spec.test.ts
@@ -84,7 +84,7 @@ describeSpec('Offline:', [], () => {
           .watchStreamCloses(Code.UNAVAILABLE)
           // Suppose sometime later we listen again, it should take two failures
           // before we get cached data.
-          .userListens(query)
+         .userListens(query)
           .watchStreamCloses(Code.UNAVAILABLE)
           .watchStreamCloses(Code.UNAVAILABLE)
           .expectEvents(query, {

--- a/packages/firestore/test/unit/specs/spec_test_runner.ts
+++ b/packages/firestore/test/unit/specs/spec_test_runner.ts
@@ -509,8 +509,12 @@ abstract class TestRunner {
 
     // Skip the backoff that may have been triggered by a previous call to
     // `watchStreamCloses()`.
-    if (this.queue.containsDelayedOperation(TimerId.ListenStreamConnectionBackoff)) {
-      await this.queue.runDelayedOperationsEarly(TimerId.ListenStreamConnectionBackoff);
+    if (
+      this.queue.containsDelayedOperation(TimerId.ListenStreamConnectionBackoff)
+    ) {
+      await this.queue.runDelayedOperationsEarly(
+        TimerId.ListenStreamConnectionBackoff
+      );
     }
 
     // Open should always have happened after a listen

--- a/packages/firestore/test/unit/specs/spec_test_runner.ts
+++ b/packages/firestore/test/unit/specs/spec_test_runner.ts
@@ -506,6 +506,13 @@ abstract class TestRunner {
         'targetId assigned to listen'
       );
     });
+
+    // Skip the backoff that may have been triggered by a previous call to
+    // `watchStreamCloses()`.
+    if (this.queue.containsDelayedOperation(TimerId.ListenStreamConnectionBackoff)) {
+      await this.queue.runDelayedOperationsEarly(TimerId.ListenStreamConnectionBackoff);
+    }
+
     // Open should always have happened after a listen
     await this.connection.waitForWatchOpen();
   }
@@ -534,7 +541,7 @@ abstract class TestRunner {
     return this.doMutations([deleteMutation(key)]);
   }
 
-  private doMutations(mutations: Mutation[]): Promise<void> {
+  private async doMutations(mutations: Mutation[]): Promise<void> {
     const userCallback = new Deferred<void>();
     this.outstandingWrites.push({ mutations, userCallback });
     return this.queue.enqueue(() => {


### PR DESCRIPTION
The delays in `Removing all listeners delays "Offline" status on next listen` are due to the listen stream backoffs triggered by closing the stream with Code.UNAVAILABLE. 