### PR TITLE
IE11 "Can't redefine non-configurable property 'length'" Error

### DIFF
--- a/packages/firestore/src/api/database.ts
+++ b/packages/firestore/src/api/database.ts
@@ -1903,15 +1903,15 @@ function throwDocChangesMethodError(): never {
 
 /**
  * This is technically overwriting the `Function.prototype.length` property of
- * `docChanges`. On IE11, the property is improperly defined with 
- * `{ configurable: false }` which causes this line to throw. Wrap in a 
+ * `docChanges`. On IE11, the property is improperly defined with
+ * `{ configurable: false }` which causes this line to throw. Wrap in a
  * try-catch to ensure that we still have a functional SDK.
  */
 try {
   Object.defineProperty(QuerySnapshot.prototype.docChanges, 'length', {
     get: () => throwDocChangesMethodError()
   });
-} catch (err) { } // Ignore this failure intentionally
+} catch (err) {} // Ignore this failure intentionally
 
 if (typeof Symbol !== 'undefined') {
   Object.defineProperty(QuerySnapshot.prototype.docChanges, Symbol.iterator, {

--- a/packages/firestore/src/api/database.ts
+++ b/packages/firestore/src/api/database.ts
@@ -1901,9 +1901,17 @@ function throwDocChangesMethodError(): never {
   );
 }
 
-Object.defineProperty(QuerySnapshot.prototype.docChanges, 'length', {
-  get: () => throwDocChangesMethodError()
-});
+/**
+ * This is technically overwriting the `Function.prototype.length` property of
+ * `docChanges`. On IE11, the property is improperly defined with 
+ * `{ configurable: false }` which causes this line to throw. Wrap in a 
+ * try-catch to ensure that we still have a functional SDK.
+ */
+try {
+  Object.defineProperty(QuerySnapshot.prototype.docChanges, 'length', {
+    get: () => throwDocChangesMethodError()
+  });
+} catch (err) { } // Ignore this failure intentionally
 
 if (typeof Symbol !== 'undefined') {
   Object.defineProperty(QuerySnapshot.prototype.docChanges, Symbol.iterator, {


### PR DESCRIPTION
This is a workaround for the error thrown trying to override the `length` property of a function.