### PR TITLE
Enable Messaging tests on Sauce Labs

### DIFF
--- a/config/karma.saucelabs.js
+++ b/config/karma.saucelabs.js
@@ -23,7 +23,6 @@ const karmaBase = require('./karma.base');
 const excluded = [
   'packages/database/*',
   'packages/firestore/*',
-  'packages/messaging/*',
   'integration/firestore/*',
   'integration/messaging/*'
 ];

--- a/packages/messaging/index.ts
+++ b/packages/messaging/index.ts
@@ -77,7 +77,7 @@ declare module '@firebase/app-types' {
   }
 }
 
-function isSupported(): boolean {
+export function isSupported(): boolean {
   if (self && 'ServiceWorkerGlobalScope' in self) {
     // Running in ServiceWorker context
     return isSWControllerSupported();

--- a/packages/messaging/package.json
+++ b/packages/messaging/package.json
@@ -39,6 +39,7 @@
     "karma-cli": "1.0.1",
     "karma-firefox-launcher": "1.1.0",
     "karma-mocha": "1.3.0",
+    "karma-safari-launcher": "1.0.0",
     "karma-sauce-launcher": "1.2.0",
     "karma-sourcemap-loader": "0.3.7",
     "karma-spec-reporter": "0.0.32",

--- a/packages/messaging/test/constructor.test.ts
+++ b/packages/messaging/test/constructor.test.ts
@@ -21,6 +21,7 @@ import { WindowController } from '../src/controllers/window-controller';
 import { ERROR_CODES } from '../src/models/errors';
 
 import { makeFakeApp } from './testing-utils/make-fake-app';
+import { describe } from './testing-utils/messaging-test-runner';
 
 describe('Firebase Messaging > new *Controller()', () => {
   it('should handle bad input', () => {

--- a/packages/messaging/test/controller-delete-token.test.ts
+++ b/packages/messaging/test/controller-delete-token.test.ts
@@ -29,21 +29,10 @@ import { makeFakeApp } from './testing-utils/make-fake-app';
 import { makeFakeSubscription } from './testing-utils/make-fake-subscription';
 import { makeFakeSWReg } from './testing-utils/make-fake-sw-reg';
 
-const FAKE_SUBSCRIPTION = makeFakeSubscription();
-const EXAMPLE_TOKEN_SAVE = {
-  swScope: '/example-scope',
-  vapidKey: base64ToArrayBuffer(
-    'BNJxw7sCGkGLOUP2cawBaBXRuWZ3lw_PmQMgreLVVvX_b' +
-      '4emEWVURkCF8fUTHEFe2xrEgTt5ilh5xD94v0pFe_I'
-  ),
-  fcmSenderId: '1234567',
-  fcmToken: 'qwerty',
-  fcmPushSet: '7654321',
-  endpoint: FAKE_SUBSCRIPTION.endpoint,
-  auth: FAKE_SUBSCRIPTION.getKey('auth')!,
-  p256dh: FAKE_SUBSCRIPTION.getKey('p256dh')!,
-  createTime: Date.now()
-};
+import { describe } from './testing-utils/messaging-test-runner';
+
+let FAKE_SUBSCRIPTION: PushSubscription;
+let EXAMPLE_TOKEN_SAVE: any;
 
 describe('Firebase Messaging > *Controller.deleteToken()', () => {
   let sandbox: sinon.SinonSandbox;
@@ -70,6 +59,24 @@ describe('Firebase Messaging > *Controller.deleteToken()', () => {
 
     return registration;
   }
+
+  before(() => {
+    FAKE_SUBSCRIPTION = makeFakeSubscription();
+    EXAMPLE_TOKEN_SAVE = {
+      swScope: '/example-scope',
+      vapidKey: base64ToArrayBuffer(
+        'BNJxw7sCGkGLOUP2cawBaBXRuWZ3lw_PmQMgreLVVvX_b' +
+          '4emEWVURkCF8fUTHEFe2xrEgTt5ilh5xD94v0pFe_I'
+      ),
+      fcmSenderId: '1234567',
+      fcmToken: 'qwerty',
+      fcmPushSet: '7654321',
+      endpoint: FAKE_SUBSCRIPTION.endpoint,
+      auth: FAKE_SUBSCRIPTION.getKey('auth')!,
+      p256dh: FAKE_SUBSCRIPTION.getKey('p256dh')!,
+      createTime: Date.now()
+    };
+  });
 
   beforeEach(() => {
     sandbox = sinon.sandbox.create();

--- a/packages/messaging/test/controller-interface.test.ts
+++ b/packages/messaging/test/controller-interface.test.ts
@@ -29,6 +29,8 @@ import { VapidDetailsModel } from '../src/models/vapid-details-model';
 import { makeFakeApp } from './testing-utils/make-fake-app';
 import { makeFakeSWReg } from './testing-utils/make-fake-sw-reg';
 
+import { describe } from './testing-utils/messaging-test-runner';
+
 const controllersToTest = [WindowController, SWController];
 
 /**

--- a/packages/messaging/test/db-interface.test.ts
+++ b/packages/messaging/test/db-interface.test.ts
@@ -15,8 +15,11 @@
  */
 
 import { expect } from 'chai';
+
 import { DBInterface } from '../src/models/db-interface';
+
 import { deleteDatabase } from './testing-utils/db-helper';
+import { describe } from './testing-utils/messaging-test-runner';
 
 const VALUE = {
   key: 'key-value',

--- a/packages/messaging/test/get-sw-reg.test.ts
+++ b/packages/messaging/test/get-sw-reg.test.ts
@@ -23,6 +23,8 @@ import { ERROR_CODES } from '../src/models/errors';
 import { makeFakeApp } from './testing-utils/make-fake-app';
 import { makeFakeSWReg } from './testing-utils/make-fake-sw-reg';
 
+import { describe } from './testing-utils/messaging-test-runner';
+
 const EXAMPLE_SENDER_ID = '1234567890';
 
 const app = makeFakeApp({

--- a/packages/messaging/test/helpers.test.ts
+++ b/packages/messaging/test/helpers.test.ts
@@ -15,9 +15,12 @@
  */
 
 import { expect } from 'chai';
+
 import { arrayBufferToBase64 } from '../src/helpers/array-buffer-to-base64';
 import { base64ToArrayBuffer } from '../src/helpers/base64-to-array-buffer';
 import { isArrayBufferEqual } from '../src/helpers/is-array-buffer-equal';
+
+import { describe } from './testing-utils/messaging-test-runner';
 
 describe('Firebase Messaging > Helpers', () => {
   describe('Array Buffer - Base64 conversion', () => {

--- a/packages/messaging/test/iid-model.test.ts
+++ b/packages/messaging/test/iid-model.test.ts
@@ -23,10 +23,12 @@ import { IIDModel } from '../src/models/iid-model';
 import { makeFakeSubscription } from './testing-utils/make-fake-subscription';
 import { fetchMock } from './testing-utils/mock-fetch';
 
+import { describe } from './testing-utils/messaging-test-runner';
+
 const fcmSenderId = '1234567';
 const fcmToken = 'qwerty';
 const fcmPushSet = '7654321';
-const subscription = makeFakeSubscription();
+let subscription: PushSubscription;
 // prettier-ignore
 const appPubKey = new Uint8Array([
   255, 237, 107, 177, 171, 78, 84, 131, 221, 231, 87, 188, 22, 232, 71, 15
@@ -35,6 +37,11 @@ const appPubKey = new Uint8Array([
 describe('Firebase Messaging > IIDModel', () => {
   let sandbox: sinon.SinonSandbox;
   let globalIIDModel: IIDModel;
+
+  before(() => {
+    subscription = makeFakeSubscription();
+  });
+
   beforeEach(() => {
     sandbox = sinon.sandbox.create();
     globalIIDModel = new IIDModel();

--- a/packages/messaging/test/index.test.ts
+++ b/packages/messaging/test/index.test.ts
@@ -26,6 +26,7 @@ import { ERROR_CODES } from '../src/models/errors';
 import { SWController } from '../src/controllers/sw-controller';
 import { WindowController } from '../src/controllers/window-controller';
 import { makeFakeApp } from './testing-utils/make-fake-app';
+import { describe } from './testing-utils/messaging-test-runner';
 
 describe('Firebase Messaging > registerMessaging', () => {
   let sinonSandbox: SinonSandbox;

--- a/packages/messaging/test/sw-controller.test.ts
+++ b/packages/messaging/test/sw-controller.test.ts
@@ -33,6 +33,8 @@ import { base64ToArrayBuffer } from '../src/helpers/base64-to-array-buffer';
 import { DEFAULT_PUBLIC_VAPID_KEY } from '../src/models/fcm-details';
 import { VapidDetailsModel } from '../src/models/vapid-details-model';
 
+import { describe } from './testing-utils/messaging-test-runner';
+
 const VALID_VAPID_KEY =
   'BJzVfWqLoALJdgV20MYy6lrj0OfhmE16PI1qLIIYx2ZZL3FoQWJJL8L0rf7rS7tqd92j_3xN3fmejKK5Eb7yMYw';
 

--- a/packages/messaging/test/sw-controller.test.ts
+++ b/packages/messaging/test/sw-controller.test.ts
@@ -241,6 +241,11 @@ describe('Firebase Messaging > *SWController', () => {
     });
 
     it('displays a warning if there are too many actions in the message', async () => {
+      if (!('maxActions' in Notification)) {
+        // Browser does not support maxActions, skip test
+        return;
+      }
+
       const registration = makeFakeSWReg();
       sandbox.stub(self, 'registration').value(registration);
 

--- a/packages/messaging/test/testing-utils/make-fake-subscription.ts
+++ b/packages/messaging/test/testing-utils/make-fake-subscription.ts
@@ -14,14 +14,6 @@
  * limitations under the License.
  */
 
-/**
- * FakeSubscription Constructor.
- */
-const fakeSubscription = ((() => {}) as any) as {
-  new (): PushSubscription;
-};
-fakeSubscription.prototype = PushSubscription.prototype;
-
 function stringToArrayBuffer(str: string): ArrayBuffer {
   // String char codes are 16 bits (See MDN).
   const arrayBuffer = new ArrayBuffer(str.length * 2);
@@ -38,6 +30,11 @@ function stringToArrayBuffer(str: string): ArrayBuffer {
  * @return Returns a fake subscription.
  */
 export function makeFakeSubscription(options: any = {}): PushSubscription {
+  const fakeSubscription = ((() => {}) as any) as {
+    new (): PushSubscription;
+  };
+  fakeSubscription.prototype = PushSubscription.prototype;
+
   const fakeSub = new fakeSubscription();
 
   // Set endpoint

--- a/packages/messaging/test/testing-utils/make-fake-sw-reg.ts
+++ b/packages/messaging/test/testing-utils/make-fake-sw-reg.ts
@@ -16,15 +16,15 @@
 
 import * as sinon from 'sinon';
 
-const fakeRegistration = ((() => {}) as any) as {
-  new (): ServiceWorkerRegistration;
-};
-fakeRegistration.prototype = ServiceWorkerRegistration.prototype;
-
 export function makeFakeSWReg(
   selectedState?: string,
   desiredValue?: object
 ): ServiceWorkerRegistration {
+  const fakeRegistration = ((() => {}) as any) as {
+    new (): ServiceWorkerRegistration;
+  };
+  fakeRegistration.prototype = ServiceWorkerRegistration.prototype;
+
   const fakeReg: ServiceWorkerRegistration = new fakeRegistration();
   // No need to use a sandbox to stub this object as it should be a used
   // once per test.

--- a/packages/messaging/test/testing-utils/messaging-test-runner.ts
+++ b/packages/messaging/test/testing-utils/messaging-test-runner.ts
@@ -1,0 +1,21 @@
+/**
+ * Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { WindowController } from '../../src/controllers/window-controller';
+
+/** Runner for tests that require service worker functionality. */
+const runner = WindowController.isSupported_() ? describe : describe.skip;
+export { runner as describe };

--- a/packages/messaging/test/testing-utils/messaging-test-runner.ts
+++ b/packages/messaging/test/testing-utils/messaging-test-runner.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import { WindowController } from '../../src/controllers/window-controller';
+import { isSupported } from '../../index';
 
 /** Runner for tests that require service worker functionality. */
-const runner = WindowController.isSupported_() ? describe : describe.skip;
+const runner = isSupported() ? describe : describe.skip;
 export { runner as describe };

--- a/packages/messaging/test/token-details-model.test.ts
+++ b/packages/messaging/test/token-details-model.test.ts
@@ -27,6 +27,8 @@ import { deleteDatabase } from './testing-utils/db-helper';
 import { compareDetails } from './testing-utils/detail-comparator';
 import { makeFakeSubscription } from './testing-utils/make-fake-subscription';
 
+import { describe } from './testing-utils/messaging-test-runner';
+
 const BAD_INPUTS: any[] = ['', [], {}, true, null, 123];
 
 describe('Firebase Messaging > TokenDetailsModel', () => {

--- a/packages/messaging/test/vapid-details-model.test.ts
+++ b/packages/messaging/test/vapid-details-model.test.ts
@@ -21,6 +21,7 @@ import { ERROR_CODES } from '../src/models/errors';
 import { VapidDetailsModel } from '../src/models/vapid-details-model';
 
 import { deleteDatabase } from './testing-utils/db-helper';
+import { describe } from './testing-utils/messaging-test-runner';
 
 const EXAMPLE_SCOPE = '/example-scope';
 const EXAMPLE_VAPID_STRING =

--- a/packages/messaging/test/window-controller.test.ts
+++ b/packages/messaging/test/window-controller.test.ts
@@ -23,6 +23,8 @@ import { WindowController } from '../src/controllers/window-controller';
 import { base64ToArrayBuffer } from '../src/helpers/base64-to-array-buffer';
 import { DEFAULT_PUBLIC_VAPID_KEY } from '../src/models/fcm-details';
 
+import { describe } from './testing-utils/messaging-test-runner';
+
 const VALID_VAPID_KEY =
   'BJzVfWqLoALJdgV20MYy6lrj0OfhmE16PI1qLIIYx2ZZL3FoQWJJL8L0rf7rS7tqd92j_3xN3fmejKK5Eb7yMYw';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5906,6 +5906,10 @@ karma-mocha@1.3.0:
   dependencies:
     minimist "1.2.0"
 
+karma-safari-launcher@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/karma-safari-launcher/-/karma-safari-launcher-1.0.0.tgz#96982a2cc47d066aae71c553babb28319115a2ce"
+
 karma-sauce-launcher@1.2.0:
   version "1.2.0"
   resolved "https://registry.npmjs.org/karma-sauce-launcher/-/karma-sauce-launcher-1.2.0.tgz#6f2558ddef3cf56879fa27540c8ae9f8bfd16bca"


### PR DESCRIPTION
Enables tests on all desktop browsers that currently support Push API and Notifications API (Chrome, Edge 17 and Firefox). Skips tests on Safari.

Thanks @yifanyang!