### PR TITLE
Add flag to setBackgroundMessageHandler for allowing all notifications to be handled

### DIFF
--- a/packages/messaging-types/index.d.ts
+++ b/packages/messaging-types/index.d.ts
@@ -32,7 +32,7 @@ export class FirebaseMessaging {
     completed?: () => void
   ): Unsubscribe;
   requestPermission(): Promise<void>;
-  setBackgroundMessageHandler(callback: (a: object) => Promise<void>): void;
+  setBackgroundMessageHandler(callback: (a: object) => Promise<void>, handlerMode: boolean): void;
   useServiceWorker(registration: ServiceWorkerRegistration): void;
   usePublicVapidKey(b64PublicKey: string): void;
 }

--- a/packages/messaging-types/index.d.ts
+++ b/packages/messaging-types/index.d.ts
@@ -32,7 +32,10 @@ export class FirebaseMessaging {
     completed?: () => void
   ): Unsubscribe;
   requestPermission(): Promise<void>;
-  setBackgroundMessageHandler(callback: (a: object) => Promise<void>, handlerMode: boolean): void;
+  setBackgroundMessageHandler(
+    callback: (a: object) => Promise<void>,
+    handlerMode: boolean
+  ): void;
   useServiceWorker(registration: ServiceWorkerRegistration): void;
   usePublicVapidKey(b64PublicKey: string): void;
 }

--- a/packages/messaging/src/controllers/sw-controller.ts
+++ b/packages/messaging/src/controllers/sw-controller.ts
@@ -38,6 +38,7 @@ const FCM_MSG = 'FCM_MSG';
 
 export class SWController extends ControllerInterface {
   private bgMessageHandler: BgMessageHandler | null = null;
+  private bgMessageHandlerMode: boolean = false;
 
   constructor(app: FirebaseApp) {
     super(app);
@@ -103,7 +104,7 @@ export class SWController extends ControllerInterface {
     }
 
     const notificationDetails = this.getNotificationData_(msgPayload);
-    if (notificationDetails) {
+    if (notificationDetails && !this.bgMessageHandlerMode) {
       const notificationTitle = notificationDetails.title || '';
       const reg = await this.getSWRegistration_();
 
@@ -262,12 +263,13 @@ export class SWController extends ControllerInterface {
    * and a notification must be shown. The callback will be given the data from
    * the push message.
    */
-  setBackgroundMessageHandler(callback: BgMessageHandler): void {
+  setBackgroundMessageHandler(callback: BgMessageHandler, handlerMode?: boolean): void {
     if (!callback || typeof callback !== 'function') {
       throw errorFactory.create(ERROR_CODES.BG_HANDLER_FUNCTION_EXPECTED);
     }
 
     this.bgMessageHandler = callback;
+    this.bgMessageHandlerMode = handlerMode || false;
   }
 
   /**

--- a/packages/messaging/src/controllers/sw-controller.ts
+++ b/packages/messaging/src/controllers/sw-controller.ts
@@ -263,7 +263,10 @@ export class SWController extends ControllerInterface {
    * and a notification must be shown. The callback will be given the data from
    * the push message.
    */
-  setBackgroundMessageHandler(callback: BgMessageHandler, handlerMode?: boolean): void {
+  setBackgroundMessageHandler(
+    callback: BgMessageHandler,
+    handlerMode?: boolean
+  ): void {
     if (!callback || typeof callback !== 'function') {
       throw errorFactory.create(ERROR_CODES.BG_HANDLER_FUNCTION_EXPECTED);
     }


### PR DESCRIPTION
This fixes #777 

A small API change has been introduced to `setBackgroundMessageHandler`

```ts
setBackgroundMessageHandler(
    callback: (a: object) => Promise<void>,
    handlerMode: boolean
  ): void;
```

`handlerMode` when true, will disable the default handling, where notification is automatically sent. this fixes a lot of gotchas and will make the DX for some users better without finding a hacky workaround. I especially need this for work, we store extra data that isn't in the notification object, and we don't want to break our other services as a result of adding it.