### PR TITLE
fixed wrong return type in auth-extern

### DIFF
--- a/packages/firebase/externs/firebase-auth-externs.js
+++ b/packages/firebase/externs/firebase-auth-externs.js
@@ -1917,7 +1917,7 @@ firebase.auth.Auth.prototype.signInAnonymouslyAndRetrieveData = function() {};
  *   }
  * });
  *
- * @return {!firebase.Promise<!firebase.Promise<!firebase.auth.UserCredential>}
+ * @return {!firebase.Promise<!firebase.auth.UserCredential>}
  */
 firebase.auth.Auth.prototype.signInAnonymously = function() {};
 


### PR DESCRIPTION
Fixed wrong return type of signInAnonymously in auth-externs 
