### PR TITLE
Fixed Generic type Observer

### DIFF
--- a/packages/auth-types/index.d.ts
+++ b/packages/auth-types/index.d.ts
@@ -268,12 +268,12 @@ export class FirebaseAuth {
   languageCode: string | null;
   settings: AuthSettings;
   onAuthStateChanged(
-    nextOrObserver: Observer<any, any> | ((a: User | null) => any),
+    nextOrObserver: Observer<any> | ((a: User | null) => any),
     error?: (a: Error) => any,
     completed?: Unsubscribe
   ): Unsubscribe;
   onIdTokenChanged(
-    nextOrObserver: Observer<any, any> | ((a: User | null) => any),
+    nextOrObserver: Observer<any> | ((a: User | null) => any),
     error?: (a: Error) => any,
     completed?: Unsubscribe
   ): Unsubscribe;

--- a/packages/storage-types/index.d.ts
+++ b/packages/storage-types/index.d.ts
@@ -77,7 +77,7 @@ export interface UploadTask {
   on(
     event: TaskEvent,
     nextOrObserver?:
-      | Observer<UploadTaskSnapshot, Error>
+      | Observer<UploadTaskSnapshot>
       | null
       | ((a: UploadTaskSnapshot) => any),
     error?: ((a: Error) => any) | null,


### PR DESCRIPTION
Generic type 'Observer' requires 1 type argument(s). Fix #787 
