### PR TITLE
Add tests for *-types packages

### DIFF
--- a/packages/app-types/package.json
+++ b/packages/app-types/package.json
@@ -5,7 +5,7 @@
   "author": "Firebase <firebase-support@google.com> (https://firebase.google.com/)",
   "license": "Apache-2.0",
   "scripts": {
-    "test": "echo 'Types package, skipping tests'"
+    "test": "tsc"
   },
   "files": [
     "index.d.ts",
@@ -17,5 +17,8 @@
   },
   "bugs": {
     "url": "https://github.com/firebase/firebase-js-sdk/issues"
+  },
+  "devDependencies": {
+    "typescript": "2.8.1"
   }
 }

--- a/packages/app-types/tsconfig.json
+++ b/packages/app-types/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../config/tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "exclude": [
+    "dist/**/*"
+  ]
+}

--- a/packages/auth-types/package.json
+++ b/packages/auth-types/package.json
@@ -5,7 +5,7 @@
   "author": "Firebase <firebase-support@google.com> (https://firebase.google.com/)",
   "license": "Apache-2.0",
   "scripts": {
-    "test": "echo 'Types package, skipping tests'"
+    "test": "tsc"
   },
   "files": [
     "index.d.ts"
@@ -19,5 +19,8 @@
   },
   "bugs": {
     "url": "https://github.com/firebase/firebase-js-sdk/issues"
+  },
+  "devDependencies": {
+    "typescript": "2.8.1"
   }
 }

--- a/packages/auth-types/tsconfig.json
+++ b/packages/auth-types/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../config/tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "exclude": [
+    "dist/**/*"
+  ]
+}

--- a/packages/database-types/package.json
+++ b/packages/database-types/package.json
@@ -5,7 +5,7 @@
   "author": "Firebase <firebase-support@google.com> (https://firebase.google.com/)",
   "license": "Apache-2.0",
   "scripts": {
-    "test": "echo 'Types package, skipping tests'"
+    "test": "tsc"
   },
   "files": [
     "index.d.ts"
@@ -19,5 +19,8 @@
   },
   "bugs": {
     "url": "https://github.com/firebase/firebase-js-sdk/issues"
+  },
+  "devDependencies": {
+    "typescript": "2.8.1"
   }
 }

--- a/packages/database-types/tsconfig.json
+++ b/packages/database-types/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../config/tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "exclude": [
+    "dist/**/*"
+  ]
+}

--- a/packages/firestore-types/package.json
+++ b/packages/firestore-types/package.json
@@ -5,7 +5,7 @@
   "author": "Firebase <firebase-support@google.com> (https://firebase.google.com/)",
   "license": "Apache-2.0",
   "scripts": {
-    "test": "echo 'Types package, skipping tests'"
+    "test": "tsc"
   },
   "files": [
     "index.d.ts"
@@ -19,5 +19,8 @@
   },
   "bugs": {
     "url": "https://github.com/firebase/firebase-js-sdk/issues"
+  },
+  "devDependencies": {
+    "typescript": "2.8.1"
   }
 }

--- a/packages/firestore-types/tsconfig.json
+++ b/packages/firestore-types/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../config/tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "exclude": [
+    "dist/**/*"
+  ]
+}

--- a/packages/functions-types/package.json
+++ b/packages/functions-types/package.json
@@ -5,7 +5,7 @@
   "author": "Firebase <firebase-support@google.com> (https://firebase.google.com/)",
   "license": "Apache-2.0",
   "scripts": {
-    "test": "echo 'Types package, skipping tests'"
+    "test": "tsc"
   },
   "files": [
     "index.d.ts"
@@ -16,5 +16,8 @@
   },
   "bugs": {
     "url": "https://github.com/firebase/firebase-js-sdk/issues"
+  },
+  "devDependencies": {
+    "typescript": "2.8.1"
   }
 }

--- a/packages/functions-types/tsconfig.json
+++ b/packages/functions-types/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../config/tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "exclude": [
+    "dist/**/*"
+  ]
+}

--- a/packages/messaging-types/package.json
+++ b/packages/messaging-types/package.json
@@ -5,7 +5,7 @@
   "author": "Firebase <firebase-support@google.com> (https://firebase.google.com/)",
   "license": "Apache-2.0",
   "scripts": {
-    "test": "echo 'Types package, skipping tests'"
+    "test": "tsc"
   },
   "files": [
     "index.d.ts"
@@ -19,5 +19,8 @@
   },
   "bugs": {
     "url": "https://github.com/firebase/firebase-js-sdk/issues"
+  },
+  "devDependencies": {
+    "typescript": "2.8.1"
   }
 }

--- a/packages/messaging-types/tsconfig.json
+++ b/packages/messaging-types/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../config/tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "exclude": [
+    "dist/**/*"
+  ]
+}

--- a/packages/storage-types/package.json
+++ b/packages/storage-types/package.json
@@ -5,7 +5,7 @@
   "author": "Firebase <firebase-support@google.com> (https://firebase.google.com/)",
   "license": "Apache-2.0",
   "scripts": {
-    "test": "echo 'Types package, skipping tests'"
+    "test": "tsc"
   },
   "files": [
     "index.d.ts"
@@ -19,5 +19,8 @@
   },
   "bugs": {
     "url": "https://github.com/firebase/firebase-js-sdk/issues"
+  },
+  "devDependencies": {
+    "typescript": "2.8.1"
   }
 }

--- a/packages/storage-types/tsconfig.json
+++ b/packages/storage-types/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../config/tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "exclude": [
+    "dist/**/*"
+  ]
+}

--- a/packages/template-types/package.json
+++ b/packages/template-types/package.json
@@ -6,7 +6,7 @@
   "author": "Firebase <firebase-support@google.com> (https://firebase.google.com/)",
   "license": "Apache-2.0",
   "scripts": {
-    "test": "echo 'Types package, skipping tests'"
+    "test": "tsc"
   },
   "files": [
     "index.d.ts"
@@ -17,5 +17,8 @@
   },
   "bugs": {
     "url": "https://github.com/firebase/firebase-js-sdk/issues"
+  },
+  "devDependencies": {
+    "typescript": "2.8.1"
   }
 }

--- a/packages/template-types/tsconfig.json
+++ b/packages/template-types/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../config/tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "exclude": [
+    "dist/**/*"
+  ]
+}


### PR DESCRIPTION
Tests are the same as [Messaging's type-check test](https://github.com/firebase/firebase-js-sdk/blob/9c953fa337f4e6e4cbcdf67e32888bea349be377/packages/messaging/package.json#L18).

This should prevent issues like #787.