### PR TITLE
Refresh token instead of breaking if VAPID key doesn't exist

### DIFF
--- a/packages/messaging/src/controllers/controller-interface.ts
+++ b/packages/messaging/src/controllers/controller-interface.ts
@@ -371,6 +371,7 @@ function isTokenStillValid(
   tokenDetails: TokenDetails
 ): boolean {
   if (
+    !tokenDetails.vapidKey ||
     !isArrayBufferEqual(publicVapidKey.buffer, tokenDetails.vapidKey.buffer)
   ) {
     return false;


### PR DESCRIPTION
#482 added VAPID keys, and started storing `vapidKey` as part of `TokenDetails` (code [here](https://github.com/firebase/firebase-js-sdk/blob/7a611b645fbedcd6c732853ed19e3f6a1a2638d5/packages/messaging/src/controllers/controller-interface.ts#L209)).

Since we were storing a stringified `vapidKey` at that point, if there was no `vapidKey` in an older `tokenDetails` object, [this check](https://github.com/firebase/firebase-js-sdk/blob/7a611b645fbedcd6c732853ed19e3f6a1a2638d5/packages/messaging/src/controllers/controller-interface.ts#L131) (comparing a `string` to `undefined`) would simply return `false`, and get a new token.

After #649, we started to store `vapidKey` as `Uint8Array` instead of the stringified version. This also changed the check [here](https://github.com/firebase/firebase-js-sdk/blob/452a4be0de4a8f9f5c9163ffb0600d2c741787b7/packages/messaging/src/controllers/controller-interface.ts#L367), which meant that if `vapidKey` was still undefined, the check would refer to `undefined.buffer`, which throws a `TypeError`.

Because of this, if a user updates from a version of the SDK before #482 directly to a version that includes #649 (4.13 or higher), messaging doesn't work. This PR fixes that by checking the existence of `tokenDetails.vapidKey`.