### PR TITLE
Fix wrong import in TypeScript example

### DIFF
--- a/packages/firebase/README.md
+++ b/packages/firebase/README.md
@@ -130,7 +130,7 @@ services you use:
 
 ```
 // This import loads the firebase namespace along with all its type information.
-import * as firebase from 'firebase/app';
+import * as firebase from 'firebase';
 
 // These imports load individual services into the firebase namespace.
 import 'firebase/auth';


### PR DESCRIPTION
This PR fixes a wrong import statement in the TypeScript example.

While using this method, I got a console warning:
```
It looks like you're using the development build of the Firebase JS SDK.
When deploying Firebase apps to production, it is advisable to only import
the individual SDK components you intend to use.

For the module builds, these are available in the following manner
(replace <PACKAGE> with the name of a component - i.e. auth, database, etc):

CommonJS Modules:
const firebase = require('firebase/app');
require('firebase/<PACKAGE>');

ES Modules:
import firebase from 'firebase/app';
import 'firebase/<PACKAGE>';
```

But it appears this is the only way to be able to work with the full typing definitions of the SDK.
Therefore I was wondering: Is there a way to suppress this?