### PR TITLE
 Fix variable and class names

### DIFF
--- a/packages/messaging/index.ts
+++ b/packages/messaging/index.ts
@@ -20,7 +20,7 @@ import {
   FirebaseServiceFactory
 } from '@firebase/app-types/private';
 
-import { SWController } from './src/controllers/sw-controller';
+import { SwController } from './src/controllers/sw-controller';
 import { WindowController } from './src/controllers/window-controller';
 import { ERROR_CODES, errorFactory } from './src/models/errors';
 
@@ -40,7 +40,7 @@ export function registerMessaging(instance: _FirebaseNamespace): void {
 
     if (self && 'ServiceWorkerGlobalScope' in self) {
       // Running in ServiceWorker context
-      return new SWController(app);
+      return new SwController(app);
     } else {
       // Assume we are in the window context.
       return new WindowController(app);

--- a/packages/messaging/src/controllers/controller-interface.ts
+++ b/packages/messaging/src/controllers/controller-interface.ts
@@ -29,7 +29,7 @@ import { isArrayBufferEqual } from '../helpers/is-array-buffer-equal';
 import { MessagePayload } from '../interfaces/message-payload';
 import { TokenDetails } from '../interfaces/token-details';
 import { ERROR_CODES, errorFactory } from '../models/errors';
-import { IIDModel } from '../models/iid-model';
+import { IidModel } from '../models/iid-model';
 import { TokenDetailsModel } from '../models/token-details-model';
 import { VapidDetailsModel } from '../models/vapid-details-model';
 
@@ -46,7 +46,7 @@ export abstract class ControllerInterface implements FirebaseMessaging {
   private readonly messagingSenderId: string;
   private readonly tokenDetailsModel: TokenDetailsModel;
   private readonly vapidDetailsModel: VapidDetailsModel;
-  private readonly iidModel: IIDModel;
+  private readonly iidModel: IidModel;
 
   /**
    * An interface of the Messaging Service API
@@ -63,7 +63,7 @@ export abstract class ControllerInterface implements FirebaseMessaging {
 
     this.tokenDetailsModel = new TokenDetailsModel();
     this.vapidDetailsModel = new VapidDetailsModel();
-    this.iidModel = new IIDModel();
+    this.iidModel = new IidModel();
 
     this.app = app;
     this.INTERNAL = {
@@ -352,7 +352,7 @@ export abstract class ControllerInterface implements FirebaseMessaging {
 
   // Visible for testing
   // TODO: make protected
-  getIIDModel(): IIDModel {
+  getIidModel(): IidModel {
     return this.iidModel;
   }
 }

--- a/packages/messaging/src/controllers/sw-controller.ts
+++ b/packages/messaging/src/controllers/sw-controller.ts
@@ -36,7 +36,7 @@ declare const self: ServiceWorkerGlobalScope;
 
 const FCM_MSG = 'FCM_MSG';
 
-export class SWController extends ControllerInterface {
+export class SwController extends ControllerInterface {
   private bgMessageHandler: BgMessageHandler | null = null;
 
   constructor(app: FirebaseApp) {

--- a/packages/messaging/src/models/clean-v1-undefined.ts
+++ b/packages/messaging/src/models/clean-v1-undefined.ts
@@ -26,7 +26,7 @@
  * underlying tokens.
  */
 
-import { IIDModel } from '../models/iid-model';
+import { IidModel } from '../models/iid-model';
 
 const OLD_DB_NAME = 'undefined';
 const OLD_OBJECT_STORE_NAME = 'fcm_token_object_Store';
@@ -41,7 +41,7 @@ function handleDb(db: IDBDatabase): void {
   const transaction = db.transaction(OLD_OBJECT_STORE_NAME);
   const objectStore = transaction.objectStore(OLD_OBJECT_STORE_NAME);
 
-  const iidModel = new IIDModel();
+  const iidModel = new IidModel();
 
   const openCursorRequest: IDBRequest = objectStore.openCursor();
   openCursorRequest.onerror = event => {

--- a/packages/messaging/src/models/db-interface.ts
+++ b/packages/messaging/src/models/db-interface.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-export abstract class DBInterface {
+export abstract class DbInterface {
   private dbPromise: Promise<IDBDatabase> | null = null;
 
   protected abstract readonly dbName: string;

--- a/packages/messaging/src/models/iid-model.ts
+++ b/packages/messaging/src/models/iid-model.ts
@@ -18,29 +18,21 @@ import { arrayBufferToBase64 } from '../helpers/array-buffer-to-base64';
 import { ERROR_CODES, errorFactory } from './errors';
 import { DEFAULT_PUBLIC_VAPID_KEY, ENDPOINT } from './fcm-details';
 
-// tslint:disable interface-name TSLint thinks I in IID is an interface prefix.
-//
-// TODO: Fix abbreviations in variable and class names to match Google
-// TypeScript style guide, which follows the Java style guide:
-// https://google.github.io/styleguide/javaguide.html#s5.3-camel-case
-//
-// In this case, IIDDetails should be IidDetails.
-export interface IIDDetails {
+export interface IidDetails {
   token: string;
   pushSet: string;
 }
-// tslint:enable interface-name
 
-interface ApiResponse extends Partial<IIDDetails> {
+interface ApiResponse extends Partial<IidDetails> {
   error?: { message: string };
 }
 
-export class IIDModel {
+export class IidModel {
   async getToken(
     senderId: string,
     subscription: PushSubscription,
     publicVapidKey: Uint8Array
-  ): Promise<IIDDetails> {
+  ): Promise<IidDetails> {
     const p256dh = arrayBufferToBase64(subscription.getKey('p256dh')!);
     const auth = arrayBufferToBase64(subscription.getKey('auth')!);
 

--- a/packages/messaging/src/models/token-details-model.ts
+++ b/packages/messaging/src/models/token-details-model.ts
@@ -17,10 +17,10 @@
 import { base64ToArrayBuffer } from '../helpers/base64-to-array-buffer';
 import { TokenDetails } from '../interfaces/token-details';
 import { cleanV1 } from './clean-v1-undefined';
-import { DBInterface } from './db-interface';
+import { DbInterface } from './db-interface';
 import { ERROR_CODES, errorFactory } from './errors';
 
-export class TokenDetailsModel extends DBInterface {
+export class TokenDetailsModel extends DbInterface {
   protected readonly dbName: string = 'fcm_token_details_db';
   protected readonly dbVersion: number = 3;
   protected readonly objectStoreName: string = 'fcm_token_object_Store';

--- a/packages/messaging/src/models/vapid-details-model.ts
+++ b/packages/messaging/src/models/vapid-details-model.ts
@@ -15,12 +15,12 @@
  */
 
 import { VapidDetails } from '../interfaces/vapid-details';
-import { DBInterface } from './db-interface';
+import { DbInterface } from './db-interface';
 import { ERROR_CODES, errorFactory } from './errors';
 
 const UNCOMPRESSED_PUBLIC_KEY_SIZE = 65;
 
-export class VapidDetailsModel extends DBInterface {
+export class VapidDetailsModel extends DbInterface {
   protected readonly dbName: string = 'fcm_vapid_details_db';
   protected readonly dbVersion: number = 1;
   protected readonly objectStoreName: string = 'fcm_vapid_object_Store';

--- a/packages/messaging/test/constructor.test.ts
+++ b/packages/messaging/test/constructor.test.ts
@@ -16,7 +16,7 @@
 
 import { assert } from 'chai';
 
-import { SWController } from '../src/controllers/sw-controller';
+import { SwController } from '../src/controllers/sw-controller';
 import { WindowController } from '../src/controllers/window-controller';
 import { ERROR_CODES } from '../src/models/errors';
 
@@ -44,7 +44,7 @@ describe('Firebase Messaging > new *Controller()', () => {
       let caughtError;
       try {
         new WindowController(badInput);
-        new SWController(badInput);
+        new SwController(badInput);
 
         console.warn(
           'Bad Input should have thrown: ',
@@ -62,6 +62,6 @@ describe('Firebase Messaging > new *Controller()', () => {
       messagingSenderId: '1234567890'
     });
     new WindowController(app);
-    new SWController(app);
+    new SwController(app);
   });
 });

--- a/packages/messaging/test/controller-delete-token.test.ts
+++ b/packages/messaging/test/controller-delete-token.test.ts
@@ -195,16 +195,14 @@ describe('Firebase Messaging > *Controller.deleteToken()', () => {
       sandbox.stub(IidModel.prototype, 'deleteToken').callsFake(async () => {});
 
       messagingService = new serviceClass(app);
-      return messagingService
-        .deleteToken(EXAMPLE_TOKEN_SAVE.fcmToken)
-        .then(
-          () => {
-            throw new Error('Expected this to reject');
-          },
-          err => {
-            assert.equal(errorMsg, err.message);
-          }
-        );
+      return messagingService.deleteToken(EXAMPLE_TOKEN_SAVE.fcmToken).then(
+        () => {
+          throw new Error('Expected this to reject');
+        },
+        err => {
+          assert.equal(errorMsg, err.message);
+        }
+      );
     });
 
     it(`should handle error on deleteToken ${serviceClass.name}`, () => {
@@ -231,16 +229,14 @@ describe('Firebase Messaging > *Controller.deleteToken()', () => {
       });
 
       messagingService = new serviceClass(app);
-      return messagingService
-        .deleteToken(EXAMPLE_TOKEN_SAVE.fcmToken)
-        .then(
-          () => {
-            throw new Error('Expected this to reject');
-          },
-          err => {
-            assert.equal(errorMsg, err.message);
-          }
-        );
+      return messagingService.deleteToken(EXAMPLE_TOKEN_SAVE.fcmToken).then(
+        () => {
+          throw new Error('Expected this to reject');
+        },
+        err => {
+          assert.equal(errorMsg, err.message);
+        }
+      );
     });
 
     it(`should delete with valid unsubscribe ${serviceClass.name}`, () => {

--- a/packages/messaging/test/controller-delete-token.test.ts
+++ b/packages/messaging/test/controller-delete-token.test.ts
@@ -17,11 +17,11 @@ import { FirebaseApp } from '@firebase/app-types';
 import { assert } from 'chai';
 import * as sinon from 'sinon';
 
-import { SWController } from '../src/controllers/sw-controller';
+import { SwController } from '../src/controllers/sw-controller';
 import { WindowController } from '../src/controllers/window-controller';
 import { base64ToArrayBuffer } from '../src/helpers/base64-to-array-buffer';
 import { ERROR_CODES } from '../src/models/errors';
-import { IIDModel } from '../src/models/iid-model';
+import { IidModel } from '../src/models/iid-model';
 import { TokenDetailsModel } from '../src/models/token-details-model';
 
 import { deleteDatabase } from './testing-utils/db-helper';
@@ -37,10 +37,10 @@ let EXAMPLE_TOKEN_SAVE: any;
 describe('Firebase Messaging > *Controller.deleteToken()', () => {
   let sandbox: sinon.SinonSandbox;
   let app: FirebaseApp;
-  let globalMessagingService: WindowController | SWController;
+  let messagingService: WindowController | SwController;
 
   function configureRegistrationMocks(
-    serviceClass: typeof WindowController | typeof SWController,
+    serviceClass: typeof WindowController | typeof SwController,
     fakeReg: ServiceWorkerRegistration | null
   ): void {
     sandbox.stub(serviceClass.prototype, 'getSWRegistration_').callsFake(() => {
@@ -88,16 +88,16 @@ describe('Firebase Messaging > *Controller.deleteToken()', () => {
   afterEach(async () => {
     sandbox.restore();
 
-    if (globalMessagingService) {
-      await globalMessagingService.delete();
+    if (messagingService) {
+      await messagingService.delete();
     }
 
     await deleteDatabase('fcm_token_details_db');
   });
 
   it('should handle no token to delete', () => {
-    globalMessagingService = new WindowController(app);
-    return globalMessagingService.deleteToken(undefined as any).then(
+    messagingService = new WindowController(app);
+    return messagingService.deleteToken(undefined as any).then(
       () => {
         throw new Error('Expected error to be thrown.');
       },
@@ -117,10 +117,10 @@ describe('Firebase Messaging > *Controller.deleteToken()', () => {
         return EXAMPLE_TOKEN_SAVE;
       });
 
-    sandbox.stub(IIDModel.prototype, 'deleteToken').callsFake(async () => {});
+    sandbox.stub(IidModel.prototype, 'deleteToken').callsFake(async () => {});
 
-    globalMessagingService = new WindowController(app);
-    return globalMessagingService.deleteToken(EXAMPLE_TOKEN_SAVE.fcmToken);
+    messagingService = new WindowController(app);
+    return messagingService.deleteToken(EXAMPLE_TOKEN_SAVE.fcmToken);
   });
 
   it('should handle get subscription error', () => {
@@ -138,10 +138,10 @@ describe('Firebase Messaging > *Controller.deleteToken()', () => {
         return EXAMPLE_TOKEN_SAVE;
       });
 
-    sandbox.stub(IIDModel.prototype, 'deleteToken').callsFake(async () => {});
+    sandbox.stub(IidModel.prototype, 'deleteToken').callsFake(async () => {});
 
-    globalMessagingService = new WindowController(app);
-    return globalMessagingService.deleteToken(EXAMPLE_TOKEN_SAVE.fcmToken).then(
+    messagingService = new WindowController(app);
+    return messagingService.deleteToken(EXAMPLE_TOKEN_SAVE.fcmToken).then(
       () => {
         throw new Error('Expected this to reject');
       },
@@ -151,7 +151,7 @@ describe('Firebase Messaging > *Controller.deleteToken()', () => {
     );
   });
 
-  [WindowController, SWController].forEach(serviceClass => {
+  [WindowController, SwController].forEach(serviceClass => {
     it(`should handle null getSubscription() ${serviceClass.name}`, () => {
       configureRegistrationMocks(
         serviceClass,
@@ -165,10 +165,10 @@ describe('Firebase Messaging > *Controller.deleteToken()', () => {
           return EXAMPLE_TOKEN_SAVE;
         });
 
-      sandbox.stub(IIDModel.prototype, 'deleteToken').callsFake(async () => {});
+      sandbox.stub(IidModel.prototype, 'deleteToken').callsFake(async () => {});
 
-      globalMessagingService = new serviceClass(app);
-      return globalMessagingService.deleteToken(EXAMPLE_TOKEN_SAVE.fcmToken);
+      messagingService = new serviceClass(app);
+      return messagingService.deleteToken(EXAMPLE_TOKEN_SAVE.fcmToken);
     });
 
     it(`should handle error on unsubscribe ${serviceClass.name}`, () => {
@@ -192,10 +192,10 @@ describe('Firebase Messaging > *Controller.deleteToken()', () => {
           return EXAMPLE_TOKEN_SAVE;
         });
 
-      sandbox.stub(IIDModel.prototype, 'deleteToken').callsFake(async () => {});
+      sandbox.stub(IidModel.prototype, 'deleteToken').callsFake(async () => {});
 
-      globalMessagingService = new serviceClass(app);
-      return globalMessagingService
+      messagingService = new serviceClass(app);
+      return messagingService
         .deleteToken(EXAMPLE_TOKEN_SAVE.fcmToken)
         .then(
           () => {
@@ -226,12 +226,12 @@ describe('Firebase Messaging > *Controller.deleteToken()', () => {
         });
 
       const errorMsg = 'messaging/' + ERROR_CODES.TOKEN_UNSUBSCRIBE_FAILED;
-      sandbox.stub(IIDModel.prototype, 'deleteToken').callsFake(async () => {
+      sandbox.stub(IidModel.prototype, 'deleteToken').callsFake(async () => {
         throw new Error(errorMsg);
       });
 
-      globalMessagingService = new serviceClass(app);
-      return globalMessagingService
+      messagingService = new serviceClass(app);
+      return messagingService
         .deleteToken(EXAMPLE_TOKEN_SAVE.fcmToken)
         .then(
           () => {
@@ -261,10 +261,10 @@ describe('Firebase Messaging > *Controller.deleteToken()', () => {
           return EXAMPLE_TOKEN_SAVE;
         });
 
-      sandbox.stub(IIDModel.prototype, 'deleteToken').callsFake(async () => {});
+      sandbox.stub(IidModel.prototype, 'deleteToken').callsFake(async () => {});
 
-      globalMessagingService = new serviceClass(app);
-      return globalMessagingService.deleteToken(EXAMPLE_TOKEN_SAVE.fcmToken);
+      messagingService = new serviceClass(app);
+      return messagingService.deleteToken(EXAMPLE_TOKEN_SAVE.fcmToken);
     });
   });
 });

--- a/packages/messaging/test/controller-get-token.test.ts
+++ b/packages/messaging/test/controller-get-token.test.ts
@@ -19,14 +19,14 @@ import * as sinon from 'sinon';
 import { FirebaseApp } from '@firebase/app-types';
 
 import { ControllerInterface } from '../src/controllers/controller-interface';
-import { SWController } from '../src/controllers/sw-controller';
+import { SwController } from '../src/controllers/sw-controller';
 import { WindowController } from '../src/controllers/window-controller';
 import { base64ToArrayBuffer } from '../src/helpers/base64-to-array-buffer';
 import { isArrayBufferEqual } from '../src/helpers/is-array-buffer-equal';
 import { TokenDetails } from '../src/interfaces/token-details';
 import { ERROR_CODES } from '../src/models/errors';
 import { DEFAULT_PUBLIC_VAPID_KEY } from '../src/models/fcm-details';
-import { IIDModel } from '../src/models/iid-model';
+import { IidModel } from '../src/models/iid-model';
 import { TokenDetailsModel } from '../src/models/token-details-model';
 import { VapidDetailsModel } from '../src/models/vapid-details-model';
 
@@ -38,7 +38,7 @@ import { describe } from './testing-utils/messaging-test-runner';
 const ONE_DAY = 24 * 60 * 60 * 1000;
 
 describe('Firebase Messaging > *Controller.getToken()', () => {
-  const servicesToTest = [WindowController, SWController];
+  const servicesToTest = [WindowController, SwController];
   const vapidSetupToTest = ['default', 'custom'];
 
   function mockGetReg(fakeReg: Promise<ServiceWorkerRegistration>): void {
@@ -297,7 +297,7 @@ describe('Firebase Messaging > *Controller.getToken()', () => {
         .callsFake(() => Promise.resolve(subscription));
 
       sandbox
-        .stub(IIDModel.prototype, 'updateToken')
+        .stub(IidModel.prototype, 'updateToken')
         .callsFake(() => Promise.resolve(EXAMPLE_FCM_TOKEN));
 
       sandbox
@@ -353,7 +353,7 @@ describe('Firebase Messaging > *Controller.getToken()', () => {
           .callsFake(async () => {});
 
         sandbox
-          .stub(IIDModel.prototype, 'getToken')
+          .stub(IidModel.prototype, 'getToken')
           .callsFake(() => Promise.resolve(TOKEN_DETAILS));
 
         sandbox
@@ -431,10 +431,10 @@ describe('Firebase Messaging > *Controller.getToken()', () => {
           pushSet: 'new-pushSet'
         };
         sandbox
-          .stub(IIDModel.prototype, 'getToken')
+          .stub(IidModel.prototype, 'getToken')
           .callsFake(() => Promise.resolve(GET_TOKEN_RESPONSE));
         sandbox
-          .stub(IIDModel.prototype, 'deleteToken')
+          .stub(IidModel.prototype, 'deleteToken')
           .callsFake(async () => {});
 
         const registration = generateFakeReg();
@@ -541,10 +541,10 @@ describe('Firebase Messaging > *Controller.getToken()', () => {
         return Promise.resolve(EXAMPLE_TOKEN_DETAILS_DEFAULT_VAPID);
       });
 
-      sandbox.stub(IIDModel.prototype, 'deleteToken').callsFake(async () => {});
+      sandbox.stub(IidModel.prototype, 'deleteToken').callsFake(async () => {});
 
       sandbox
-        .stub(IIDModel.prototype, 'getToken')
+        .stub(IidModel.prototype, 'getToken')
         .callsFake(() => Promise.resolve(TOKEN_DETAILS));
 
       const customVAPIDToken = await serviceInstance.getToken();
@@ -591,7 +591,7 @@ describe('Firebase Messaging > *Controller.getToken()', () => {
         .callsFake(async () => {});
 
       sandbox
-        .stub(IIDModel.prototype, 'updateToken')
+        .stub(IidModel.prototype, 'updateToken')
         .callsFake(() => Promise.reject(new Error(errorMsg)));
 
       const deleteTokenStub = sandbox.stub(
@@ -603,7 +603,7 @@ describe('Firebase Messaging > *Controller.getToken()', () => {
         return Promise.resolve(EXAMPLE_EXPIRED_TOKEN_DETAILS);
       });
 
-      sandbox.stub(IIDModel.prototype, 'deleteToken').callsFake(async () => {});
+      sandbox.stub(IidModel.prototype, 'deleteToken').callsFake(async () => {});
 
       const serviceInstance = new serviceClass(app);
       try {

--- a/packages/messaging/test/controller-interface.test.ts
+++ b/packages/messaging/test/controller-interface.test.ts
@@ -19,10 +19,10 @@ import { expect } from 'chai';
 import * as sinon from 'sinon';
 
 import { ControllerInterface } from '../src/controllers/controller-interface';
-import { SWController } from '../src/controllers/sw-controller';
+import { SwController } from '../src/controllers/sw-controller';
 import { WindowController } from '../src/controllers/window-controller';
 import { DEFAULT_PUBLIC_VAPID_KEY } from '../src/models/fcm-details';
-import { IIDModel } from '../src/models/iid-model';
+import { IidModel } from '../src/models/iid-model';
 import { TokenDetailsModel } from '../src/models/token-details-model';
 import { VapidDetailsModel } from '../src/models/vapid-details-model';
 
@@ -31,7 +31,7 @@ import { makeFakeSWReg } from './testing-utils/make-fake-sw-reg';
 
 import { describe } from './testing-utils/messaging-test-runner';
 
-const controllersToTest = [WindowController, SWController];
+const controllersToTest = [WindowController, SwController];
 
 /**
  * As ControllerInterface is an abstract class, we need a concrete
@@ -244,11 +244,11 @@ describe('Firebase Messaging > *ControllerInterface', () => {
     });
   });
 
-  describe('getIIDModel', () => {
-    it('should return an instance of IIDModel', () => {
+  describe('getIidModel', () => {
+    it('should return an instance of IidModel', () => {
       const controller = new MockControllerInterface(app);
-      const result = controller.getIIDModel();
-      expect(result).to.be.instanceof(IIDModel);
+      const result = controller.getIidModel();
+      expect(result).to.be.instanceof(IidModel);
     });
   });
 });

--- a/packages/messaging/test/db-interface.test.ts
+++ b/packages/messaging/test/db-interface.test.ts
@@ -16,7 +16,7 @@
 
 import { expect } from 'chai';
 
-import { DBInterface } from '../src/models/db-interface';
+import { DbInterface } from '../src/models/db-interface';
 
 import { deleteDatabase } from './testing-utils/db-helper';
 import { describe } from './testing-utils/messaging-test-runner';
@@ -32,7 +32,7 @@ const DIFFERENT_VALUE = {
   otherValue: 'different-other-value'
 };
 
-class MockDbInterface extends DBInterface {
+class MockDbInterface extends DbInterface {
   readonly dbName: string = 'test-db';
   readonly dbVersion: number = 1;
   readonly objectStoreName: string = 'test-obj-store';
@@ -51,7 +51,7 @@ class MockDbInterface extends DBInterface {
   }
 }
 
-describe('DBInterface', () => {
+describe('DbInterface', () => {
   let dbInterface: MockDbInterface;
 
   beforeEach(() => {

--- a/packages/messaging/test/get-sw-reg.test.ts
+++ b/packages/messaging/test/get-sw-reg.test.ts
@@ -16,7 +16,7 @@
 import { assert } from 'chai';
 import * as sinon from 'sinon';
 
-import { SWController } from '../src/controllers/sw-controller';
+import { SwController } from '../src/controllers/sw-controller';
 import { WindowController } from '../src/controllers/window-controller';
 import { ERROR_CODES } from '../src/models/errors';
 
@@ -98,7 +98,7 @@ describe('Firebase Messaging > *Controller.getSWReg_()', () => {
     const fakeReg = makeFakeSWReg();
     (self as any).registration = fakeReg;
 
-    const messagingService = new SWController(app);
+    const messagingService = new SwController(app);
     return messagingService
       .getSWRegistration_()
       .then(registration => {

--- a/packages/messaging/test/iid-model.test.ts
+++ b/packages/messaging/test/iid-model.test.ts
@@ -18,7 +18,7 @@ import * as sinon from 'sinon';
 
 import { ERROR_CODES, ERROR_MAP } from '../src/models/errors';
 import { DEFAULT_PUBLIC_VAPID_KEY } from '../src/models/fcm-details';
-import { IIDModel } from '../src/models/iid-model';
+import { IidModel } from '../src/models/iid-model';
 
 import { makeFakeSubscription } from './testing-utils/make-fake-subscription';
 import { fetchMock } from './testing-utils/mock-fetch';
@@ -34,9 +34,9 @@ const appPubKey = new Uint8Array([
   255, 237, 107, 177, 171, 78, 84, 131, 221, 231, 87, 188, 22, 232, 71, 15
 ]);
 
-describe('Firebase Messaging > IIDModel', () => {
+describe('Firebase Messaging > IidModel', () => {
   let sandbox: sinon.SinonSandbox;
-  let globalIIDModel: IIDModel;
+  let iidModel: IidModel;
 
   before(() => {
     subscription = makeFakeSubscription();
@@ -44,7 +44,7 @@ describe('Firebase Messaging > IIDModel', () => {
 
   beforeEach(() => {
     sandbox = sinon.sandbox.create();
-    globalIIDModel = new IIDModel();
+    iidModel = new IidModel();
   });
 
   afterEach(() => {
@@ -60,7 +60,7 @@ describe('Firebase Messaging > IIDModel', () => {
       sandbox
         .stub(window, 'fetch')
         .returns(fetchMock.jsonOk(JSON.stringify(mockResponse)));
-      await globalIIDModel.getToken(fcmSenderId, subscription, appPubKey);
+      await iidModel.getToken(fcmSenderId, subscription, appPubKey);
     });
 
     it('gets token on valid request with default VAPID key', async () => {
@@ -71,7 +71,7 @@ describe('Firebase Messaging > IIDModel', () => {
       sandbox
         .stub(window, 'fetch')
         .returns(fetchMock.jsonOk(JSON.stringify(mockResponse)));
-      await globalIIDModel.getToken(
+      await iidModel.getToken(
         fcmSenderId,
         subscription,
         DEFAULT_PUBLIC_VAPID_KEY
@@ -82,7 +82,7 @@ describe('Firebase Messaging > IIDModel', () => {
       const errorMsg = 'invalid token';
       sandbox.stub(window, 'fetch').returns(fetchMock.jsonError(400, errorMsg));
       try {
-        await globalIIDModel.getToken(fcmSenderId, subscription, appPubKey);
+        await iidModel.getToken(fcmSenderId, subscription, appPubKey);
         throw new Error('Expected error to be thrown.');
       } catch (e) {
         expect(e.message).to.equal(errorMsg);
@@ -94,7 +94,7 @@ describe('Firebase Messaging > IIDModel', () => {
         .stub(window, 'fetch')
         .returns(fetchMock.htmlError(400, 'html-response'));
       try {
-        await globalIIDModel.getToken(fcmSenderId, subscription, appPubKey);
+        await iidModel.getToken(fcmSenderId, subscription, appPubKey);
         throw new Error('Expected error to be thrown.');
       } catch (e) {
         expect(e.code).to.include(ERROR_CODES.TOKEN_SUBSCRIBE_FAILED);
@@ -109,7 +109,7 @@ describe('Firebase Messaging > IIDModel', () => {
         .stub(window, 'fetch')
         .returns(fetchMock.jsonOk(JSON.stringify(mockInvalidResponse)));
       try {
-        await globalIIDModel.getToken(fcmSenderId, subscription, appPubKey);
+        await iidModel.getToken(fcmSenderId, subscription, appPubKey);
         throw new Error('Expected error to be thrown.');
       } catch (e) {
         expect(e.message).to.include(
@@ -126,7 +126,7 @@ describe('Firebase Messaging > IIDModel', () => {
         .stub(window, 'fetch')
         .returns(fetchMock.jsonOk(JSON.stringify(mockInvalidResponse)));
       try {
-        await globalIIDModel.getToken(fcmSenderId, subscription, appPubKey);
+        await iidModel.getToken(fcmSenderId, subscription, appPubKey);
         throw new Error('Expected error to be thrown.');
       } catch (e) {
         expect(e.code).to.include(ERROR_CODES.TOKEN_SUBSCRIBE_NO_PUSH_SET);
@@ -140,7 +140,7 @@ describe('Firebase Messaging > IIDModel', () => {
       sandbox
         .stub(window, 'fetch')
         .returns(fetchMock.jsonOk(JSON.stringify(mockResponse)));
-      const res = await globalIIDModel.updateToken(
+      const res = await iidModel.updateToken(
         fcmSenderId,
         fcmToken,
         fcmPushSet,
@@ -155,7 +155,7 @@ describe('Firebase Messaging > IIDModel', () => {
       sandbox
         .stub(window, 'fetch')
         .returns(fetchMock.jsonOk(JSON.stringify(mockResponse)));
-      const res = await globalIIDModel.updateToken(
+      const res = await iidModel.updateToken(
         fcmSenderId,
         fcmToken,
         fcmPushSet,
@@ -173,7 +173,7 @@ describe('Firebase Messaging > IIDModel', () => {
         .stub(window, 'fetch')
         .returns(fetchMock.jsonOk(JSON.stringify(mockInvalidResponse)));
       try {
-        await globalIIDModel.updateToken(
+        await iidModel.updateToken(
           fcmSenderId,
           fcmToken,
           fcmPushSet,
@@ -191,7 +191,7 @@ describe('Firebase Messaging > IIDModel', () => {
         .stub(window, 'fetch')
         .returns(fetchMock.htmlError(404, 'html-response'));
       try {
-        await globalIIDModel.updateToken(
+        await iidModel.updateToken(
           fcmSenderId,
           fcmToken,
           fcmPushSet,
@@ -208,7 +208,7 @@ describe('Firebase Messaging > IIDModel', () => {
       const errorMsg = 'invalid token';
       sandbox.stub(window, 'fetch').returns(fetchMock.jsonError(400, errorMsg));
       try {
-        await globalIIDModel.updateToken(
+        await iidModel.updateToken(
           fcmSenderId,
           fcmToken,
           fcmPushSet,
@@ -225,7 +225,7 @@ describe('Firebase Messaging > IIDModel', () => {
   describe('deleteToken', () => {
     it('deletes on valid request', async () => {
       sandbox.stub(window, 'fetch').returns(fetchMock.jsonOk('{}'));
-      await globalIIDModel.deleteToken(fcmSenderId, fcmToken, fcmPushSet);
+      await iidModel.deleteToken(fcmSenderId, fcmToken, fcmPushSet);
     });
 
     it('handles fetch errors', async () => {
@@ -234,7 +234,7 @@ describe('Firebase Messaging > IIDModel', () => {
       sandbox.stub(window, 'fetch').returns(fetchMock.jsonError(400, errorMsg));
 
       try {
-        await globalIIDModel.deleteToken(fcmSenderId, fcmToken, fcmPushSet);
+        await iidModel.deleteToken(fcmSenderId, fcmToken, fcmPushSet);
         throw new Error('Expected error to be thrown.');
       } catch (e) {
         expect(e.code).to.include(ERROR_CODES.TOKEN_UNSUBSCRIBE_FAILED);
@@ -245,7 +245,7 @@ describe('Firebase Messaging > IIDModel', () => {
       const stubbedFetch = sandbox.stub(window, 'fetch');
       stubbedFetch.returns(fetchMock.htmlError(404, 'html-response'));
       try {
-        await globalIIDModel.deleteToken(fcmSenderId, fcmToken, fcmPushSet);
+        await iidModel.deleteToken(fcmSenderId, fcmToken, fcmPushSet);
         throw new Error('Expected error to be thrown.');
       } catch (e) {
         expect(e.code).to.include(ERROR_CODES.TOKEN_UNSUBSCRIBE_FAILED);

--- a/packages/messaging/test/index.test.ts
+++ b/packages/messaging/test/index.test.ts
@@ -23,7 +23,7 @@ import { _FirebaseNamespace } from '@firebase/app-types/private';
 import { MessagingServiceFactory, registerMessaging } from '../index';
 import { ERROR_CODES } from '../src/models/errors';
 
-import { SWController } from '../src/controllers/sw-controller';
+import { SwController } from '../src/controllers/sw-controller';
 import { WindowController } from '../src/controllers/window-controller';
 import { makeFakeApp } from './testing-utils/make-fake-app';
 import { describe } from './testing-utils/messaging-test-runner';
@@ -81,9 +81,9 @@ describe('Firebase Messaging > registerMessaging', () => {
         delete (self as any).ServiceWorkerGlobalScope;
       });
 
-      it('returns a SWController', () => {
+      it('returns a SwController', () => {
         const firebaseService = factoryMethod(fakeApp);
-        expect(firebaseService).to.be.instanceOf(SWController);
+        expect(firebaseService).to.be.instanceOf(SwController);
       });
     });
 

--- a/packages/messaging/test/sw-controller.test.ts
+++ b/packages/messaging/test/sw-controller.test.ts
@@ -28,7 +28,7 @@ import { FirebaseError } from '@firebase/util';
 import { makeFakeApp } from './testing-utils/make-fake-app';
 import { makeFakeSWReg } from './testing-utils/make-fake-sw-reg';
 
-import { SWController } from '../src/controllers/sw-controller';
+import { SwController } from '../src/controllers/sw-controller';
 import { base64ToArrayBuffer } from '../src/helpers/base64-to-array-buffer';
 import { DEFAULT_PUBLIC_VAPID_KEY } from '../src/models/fcm-details';
 import { VapidDetailsModel } from '../src/models/vapid-details-model';
@@ -38,7 +38,7 @@ import { describe } from './testing-utils/messaging-test-runner';
 const VALID_VAPID_KEY =
   'BJzVfWqLoALJdgV20MYy6lrj0OfhmE16PI1qLIIYx2ZZL3FoQWJJL8L0rf7rS7tqd92j_3xN3fmejKK5Eb7yMYw';
 
-describe('Firebase Messaging > *SWController', () => {
+describe('Firebase Messaging > *SwController', () => {
   let sandbox: sinon.SinonSandbox;
   let app: FirebaseApp;
 
@@ -72,7 +72,7 @@ describe('Firebase Messaging > *SWController', () => {
 
   describe('onPush', () => {
     it('should handle a push event with no data', async () => {
-      const swController = new SWController(app);
+      const swController = new SwController(app);
       const waitUntilSpy = sandbox.spy();
       swController.onPush({
         waitUntil: waitUntilSpy,
@@ -83,7 +83,7 @@ describe('Firebase Messaging > *SWController', () => {
     });
 
     it('should handle a push event where .json() throws', async () => {
-      const swController = new SWController(app);
+      const swController = new SwController(app);
       const waitUntilSpy = sandbox.spy();
       swController.onPush({
         waitUntil: waitUntilSpy,
@@ -98,14 +98,14 @@ describe('Firebase Messaging > *SWController', () => {
     it('should send data payload to window if window is in focus', async () => {
       const waitUntilSpy = sandbox.spy();
       const stub = sandbox.stub(
-        SWController.prototype,
+        SwController.prototype,
         'sendMessageToWindowClients_'
       );
       sandbox
-        .stub(SWController.prototype, 'hasVisibleClients_')
+        .stub(SwController.prototype, 'hasVisibleClients_')
         .callsFake(async () => true);
 
-      const swController = new SWController(app);
+      const swController = new SwController(app);
       swController.onPush({
         waitUntil: waitUntilSpy,
         data: {
@@ -120,14 +120,14 @@ describe('Firebase Messaging > *SWController', () => {
     it('should send notification payload to window if window is in focus', async () => {
       const waitUntilSpy = sandbox.spy();
       const stub = sandbox.stub(
-        SWController.prototype,
+        SwController.prototype,
         'sendMessageToWindowClients_'
       );
       sandbox
-        .stub(SWController.prototype, 'hasVisibleClients_')
+        .stub(SwController.prototype, 'hasVisibleClients_')
         .callsFake(async () => true);
 
-      const swController = new SWController(app);
+      const swController = new SwController(app);
       swController.onPush({
         waitUntil: waitUntilSpy,
         data: {
@@ -144,14 +144,14 @@ describe('Firebase Messaging > *SWController', () => {
     it('should send to window if a bgMessageHandler is defined', async () => {
       const waitUntilSpy = sandbox.spy();
       const stub = sandbox.stub(
-        SWController.prototype,
+        SwController.prototype,
         'sendMessageToWindowClients_'
       );
       sandbox
-        .stub(SWController.prototype, 'hasVisibleClients_')
+        .stub(SwController.prototype, 'hasVisibleClients_')
         .callsFake(async () => true);
 
-      const swController = new SWController(app);
+      const swController = new SwController(app);
       swController.setBackgroundMessageHandler((() => {}) as any);
       swController.onPush({
         waitUntil: waitUntilSpy,
@@ -170,14 +170,14 @@ describe('Firebase Messaging > *SWController', () => {
 
       const waitUntilSpy = sandbox.spy();
       sandbox
-        .stub(SWController.prototype, 'hasVisibleClients_')
+        .stub(SwController.prototype, 'hasVisibleClients_')
         .callsFake(async () => false);
       const showNotificationStub = sandbox.spy(
         registration,
         'showNotification'
       );
 
-      const swController = new SWController(app);
+      const swController = new SwController(app);
       swController.onPush({
         waitUntil: waitUntilSpy,
         data: {
@@ -205,7 +205,7 @@ describe('Firebase Messaging > *SWController', () => {
 
       const waitUntilSpy = sandbox.spy();
       sandbox
-        .stub(SWController.prototype, 'hasVisibleClients_')
+        .stub(SwController.prototype, 'hasVisibleClients_')
         .callsFake(async () => false);
       const showNotificationSpy = sandbox.spy(registration, 'showNotification');
 
@@ -215,7 +215,7 @@ describe('Firebase Messaging > *SWController', () => {
         icon: '/images/test-icon.png'
       };
 
-      const swController = new SWController(app);
+      const swController = new SwController(app);
       swController.onPush({
         waitUntil: waitUntilSpy,
         data: {
@@ -251,7 +251,7 @@ describe('Firebase Messaging > *SWController', () => {
 
       const waitUntilSpy = sandbox.spy();
       sandbox
-        .stub(SWController.prototype, 'hasVisibleClients_')
+        .stub(SwController.prototype, 'hasVisibleClients_')
         .callsFake(async () => false);
       sandbox.spy(registration, 'showNotification');
 
@@ -283,7 +283,7 @@ describe('Firebase Messaging > *SWController', () => {
         ]
       };
 
-      const swController = new SWController(app);
+      const swController = new SwController(app);
       swController.onPush({
         waitUntil: waitUntilSpy,
         data: {
@@ -311,13 +311,13 @@ describe('Firebase Messaging > *SWController', () => {
       const bgMessageHandlerSpy = sandbox.spy();
       const waitUntilSpy = sandbox.spy();
       sandbox
-        .stub(SWController.prototype, 'hasVisibleClients_')
+        .stub(SwController.prototype, 'hasVisibleClients_')
         .callsFake(async () => false);
       sandbox.spy(registration, 'showNotification');
 
       const payloadData = {};
 
-      const swController = new SWController(app);
+      const swController = new SwController(app);
       swController.setBackgroundMessageHandler(bgMessageHandlerSpy);
       swController.onPush({
         waitUntil: waitUntilSpy,
@@ -336,10 +336,10 @@ describe('Firebase Messaging > *SWController', () => {
     it('should do nothing if no background message handler and no notification', async () => {
       const waitUntilSpy = sandbox.spy();
       sandbox
-        .stub(SWController.prototype, 'hasVisibleClients_')
+        .stub(SwController.prototype, 'hasVisibleClients_')
         .callsFake(async () => false);
 
-      const swController = new SWController(app);
+      const swController = new SwController(app);
       swController.onPush({
         waitUntil: waitUntilSpy,
         data: {
@@ -355,7 +355,7 @@ describe('Firebase Messaging > *SWController', () => {
 
   describe('setBackgroundMessageHandler', () => {
     it('should throw on a non-function input', () => {
-      const swController = new SWController(app);
+      const swController = new SwController(app);
       let thrownError: FirebaseError | undefined;
       try {
         swController.setBackgroundMessageHandler('' as any);
@@ -384,7 +384,7 @@ describe('Firebase Messaging > *SWController', () => {
       };
       sandbox.stub(self, 'clients').value(clients);
 
-      const swController = new SWController(app);
+      const swController = new SwController(app);
       const result = await swController.hasVisibleClients_();
       expect(result).to.equal(false);
     });
@@ -412,7 +412,7 @@ describe('Firebase Messaging > *SWController', () => {
       };
       sandbox.stub(self, 'clients').value(clients);
 
-      const swController = new SWController(app);
+      const swController = new SwController(app);
       const result = await swController.hasVisibleClients_();
       expect(result).to.equal(false);
     });
@@ -443,7 +443,7 @@ describe('Firebase Messaging > *SWController', () => {
       };
       sandbox.stub(self, 'clients').value(clients);
 
-      const swController = new SWController(app);
+      const swController = new SwController(app);
       const result = await swController.hasVisibleClients_();
       expect(result).to.equal(true);
     });
@@ -463,7 +463,7 @@ describe('Firebase Messaging > *SWController', () => {
       };
       sandbox.stub(self, 'clients').value(clients);
 
-      const swController = new SWController(app);
+      const swController = new SwController(app);
       const result = await swController.getWindowClient_('/test-url');
       expect(result).to.equal(null);
     });
@@ -491,7 +491,7 @@ describe('Firebase Messaging > *SWController', () => {
       };
       sandbox.stub(self, 'clients').value(clients);
 
-      const swController = new SWController(app);
+      const swController = new SwController(app);
       const result = await swController.getWindowClient_('/test-url');
       expect(result).to.equal(null);
     });
@@ -523,7 +523,7 @@ describe('Firebase Messaging > *SWController', () => {
       };
       sandbox.stub(self, 'clients').value(clients);
 
-      const swController = new SWController(app);
+      const swController = new SwController(app);
       const result = await swController.getWindowClient_(matchingClient.url);
       expect(result).to.equal(matchingClient);
     });
@@ -536,7 +536,7 @@ describe('Firebase Messaging > *SWController', () => {
         waitUntil: waitUntilSpy,
         stopImmediatePropagation: sandbox.spy()
       };
-      const swController = new SWController(app);
+      const swController = new SwController(app);
 
       swController.onNotificationClick(event);
 
@@ -550,7 +550,7 @@ describe('Firebase Messaging > *SWController', () => {
         waitUntil: waitUntilSpy,
         stopImmediatePropagation: sandbox.spy()
       };
-      const swController = new SWController(app);
+      const swController = new SwController(app);
 
       swController.onNotificationClick(event);
 
@@ -566,7 +566,7 @@ describe('Firebase Messaging > *SWController', () => {
         waitUntil: waitUntilSpy,
         stopImmediatePropagation: sandbox.spy()
       };
-      const swController = new SWController(app);
+      const swController = new SwController(app);
 
       swController.onNotificationClick(event);
 
@@ -588,7 +588,7 @@ describe('Firebase Messaging > *SWController', () => {
         stopImmediatePropagation: sandbox.spy(),
         action: 'action1'
       };
-      const swController = new SWController(app);
+      const swController = new SwController(app);
 
       swController.onNotificationClick(event);
 
@@ -607,7 +607,7 @@ describe('Firebase Messaging > *SWController', () => {
         waitUntil: waitUntilSpy,
         stopImmediatePropagation: sandbox.spy()
       };
-      const swController = new SWController(app);
+      const swController = new SwController(app);
 
       swController.onNotificationClick(event);
 
@@ -629,7 +629,7 @@ describe('Firebase Messaging > *SWController', () => {
         waitUntil: waitUntilSpy,
         stopImmediatePropagation: sandbox.spy()
       };
-      const swController = new SWController(app);
+      const swController = new SwController(app);
 
       swController.onNotificationClick(event);
       await event.waitUntil.getCall(0).args[0];
@@ -666,7 +666,7 @@ describe('Firebase Messaging > *SWController', () => {
       };
       sandbox.stub(self, 'clients').value(clients);
 
-      const swController = new SWController(app);
+      const swController = new SwController(app);
 
       sandbox
         .stub(swController, 'getWindowClient_')
@@ -711,7 +711,7 @@ describe('Firebase Messaging > *SWController', () => {
       };
       sandbox.stub(self, 'clients').value(clients);
 
-      const swController = new SWController(app);
+      const swController = new SwController(app);
 
       sandbox
         .stub(swController, 'getWindowClient_')
@@ -769,7 +769,7 @@ describe('Firebase Messaging > *SWController', () => {
       };
       sandbox.stub(self, 'clients').value(clients);
 
-      const swController = new SWController(app);
+      const swController = new SwController(app);
 
       sandbox
         .stub(swController, 'getWindowClient_')
@@ -800,14 +800,14 @@ describe('Firebase Messaging > *SWController', () => {
 
   describe('getNotificationData_', () => {
     it('should return nothing for no payload', () => {
-      const swController = new SWController(app);
+      const swController = new SwController(app);
       expect(swController.getNotificationData_(undefined as any)).to.equal(
         undefined
       );
     });
 
     it('adds message payload to data.FCM_MSG without replacing user defined data', () => {
-      const swController = new SWController(app);
+      const swController = new SwController(app);
       const msgPayload = {
         notification: {
           title: 'Hello World',
@@ -834,7 +834,7 @@ describe('Firebase Messaging > *SWController', () => {
 
   describe('attemptToMessageClient_', () => {
     it('should reject when no window client provided', () => {
-      const swController = new SWController(app);
+      const swController = new SwController(app);
       return swController.attemptToMessageClient_(null as any, {} as any).then(
         () => {
           throw new Error('Expected error to be thrown');
@@ -851,7 +851,7 @@ describe('Firebase Messaging > *SWController', () => {
       const client: any = {
         postMessage: sandbox.spy()
       };
-      const swController = new SWController(app);
+      const swController = new SwController(app);
       await swController.attemptToMessageClient_(client, msg);
       expect(client.postMessage.callCount).to.equal(1);
       expect(client.postMessage.getCall(0).args[0]).to.equal(msg);
@@ -866,7 +866,7 @@ describe('Firebase Messaging > *SWController', () => {
       };
       sandbox.stub(self, 'clients').value(clients);
 
-      const swController = new SWController(app);
+      const swController = new SwController(app);
 
       const payload = {};
 
@@ -886,7 +886,7 @@ describe('Firebase Messaging > *SWController', () => {
       };
       sandbox.stub(self, 'clients').value(clients);
 
-      const swController = new SWController(app);
+      const swController = new SwController(app);
       const attemptToMessageClientStub = sandbox
         .stub(swController, 'attemptToMessageClient_')
         .callsFake(async () => {});
@@ -921,10 +921,10 @@ describe('Firebase Messaging > *SWController', () => {
       sandbox.stub(self, 'addEventListener').callsFake((eventName, eventCb) => {
         listeners[eventName] = eventCb;
       });
-      const onPushStub = sandbox.stub(SWController.prototype, 'onPush');
+      const onPushStub = sandbox.stub(SwController.prototype, 'onPush');
       const pushEvent = new Event('push');
 
-      new SWController(app);
+      new SwController(app);
       expect(listeners['push']).to.exist;
 
       listeners['push'](pushEvent);
@@ -939,12 +939,12 @@ describe('Firebase Messaging > *SWController', () => {
         listeners[eventName] = eventCb;
       });
       const onSubChangeStub = sandbox.stub(
-        SWController.prototype,
+        SwController.prototype,
         'onSubChange'
       );
       const pushEvent = new Event('pushsubscriptionchange');
 
-      new SWController(app);
+      new SwController(app);
       expect(listeners['pushsubscriptionchange']).to.exist;
 
       listeners['pushsubscriptionchange'](pushEvent);
@@ -965,12 +965,12 @@ describe('Firebase Messaging > *SWController', () => {
         listeners[eventName] = eventCb;
       });
       const onNotificationClickStub = sandbox.stub(
-        SWController.prototype,
+        SwController.prototype,
         'onNotificationClick'
       );
       const pushEvent = new Event('notificationclick');
 
-      new SWController(app);
+      new SwController(app);
       expect(listeners['notificationclick']).to.exist;
 
       listeners['notificationclick'](pushEvent);
@@ -990,7 +990,7 @@ describe('Firebase Messaging > *SWController', () => {
       sandbox.stub(self, 'registration').value(registration);
 
       sandbox
-        .stub(SWController.prototype, 'getSWRegistration_')
+        .stub(SwController.prototype, 'getSWRegistration_')
         .callsFake(async () => {
           throw new Error('Injected Error');
         });
@@ -999,7 +999,7 @@ describe('Firebase Messaging > *SWController', () => {
         waitUntil: waitUntilSpy
       };
 
-      const swController = new SWController(app);
+      const swController = new SwController(app);
       swController.onSubChange(event);
 
       let error: FirebaseError | undefined;
@@ -1018,7 +1018,7 @@ describe('Firebase Messaging > *SWController', () => {
     it('should return the default key by default', async () => {
       const registration = makeFakeSWReg();
       sandbox.stub(self, 'registration').value(registration);
-      const controller = new SWController(app);
+      const controller = new SwController(app);
       sandbox
         .stub(VapidDetailsModel.prototype, 'getVapidFromSWScope')
         .callsFake(async () => null);
@@ -1029,7 +1029,7 @@ describe('Firebase Messaging > *SWController', () => {
     it('should return the default key', async () => {
       const registration = makeFakeSWReg();
       sandbox.stub(self, 'registration').value(registration);
-      const controller = new SWController(app);
+      const controller = new SwController(app);
       sandbox
         .stub(VapidDetailsModel.prototype, 'getVapidFromSWScope')
         .callsFake(async () => DEFAULT_PUBLIC_VAPID_KEY);
@@ -1040,7 +1040,7 @@ describe('Firebase Messaging > *SWController', () => {
     it('should return the custom key if set', async () => {
       const registration = makeFakeSWReg();
       sandbox.stub(self, 'registration').value(registration);
-      const controller = new SWController(app);
+      const controller = new SwController(app);
       const vapidKeyInUse = base64ToArrayBuffer(VALID_VAPID_KEY);
       sandbox
         .stub(VapidDetailsModel.prototype, 'getVapidFromSWScope')

--- a/packages/messaging/test/token-details-model.test.ts
+++ b/packages/messaging/test/token-details-model.test.ts
@@ -33,14 +33,14 @@ const BAD_INPUTS: any[] = ['', [], {}, true, null, 123];
 
 describe('Firebase Messaging > TokenDetailsModel', () => {
   let clock: sinon.SinonFakeTimers;
-  let globalTokenModel: TokenDetailsModel;
+  let tokenDetailsModel: TokenDetailsModel;
   let exampleInput: TokenDetails;
   let fakeSubscription: PushSubscription;
 
   beforeEach(() => {
     clock = sinon.useFakeTimers();
 
-    globalTokenModel = new TokenDetailsModel();
+    tokenDetailsModel = new TokenDetailsModel();
 
     fakeSubscription = makeFakeSubscription();
     exampleInput = {
@@ -60,7 +60,7 @@ describe('Firebase Messaging > TokenDetailsModel', () => {
   });
 
   afterEach(async () => {
-    await globalTokenModel.closeDatabase();
+    await tokenDetailsModel.closeDatabase();
     await deleteDatabase('fcm_token_details_db');
 
     clock.restore();
@@ -91,7 +91,7 @@ describe('Firebase Messaging > TokenDetailsModel', () => {
       await oldDBTokenDetailsModel.closeDatabase();
 
       // Get the same token using DB v3
-      const tokenDetails = await globalTokenModel.get<TokenDetails>(
+      const tokenDetails = await tokenDetailsModel.get<TokenDetails>(
         exampleInput.swScope
       );
 
@@ -103,9 +103,9 @@ describe('Firebase Messaging > TokenDetailsModel', () => {
   describe('saveToken', () => {
     it('should throw on bad input', () => {
       const promises = BAD_INPUTS.map(badInput => {
-        globalTokenModel = new TokenDetailsModel();
+        tokenDetailsModel = new TokenDetailsModel();
         exampleInput.swScope = badInput;
-        return globalTokenModel.saveTokenDetails(exampleInput).then(
+        return tokenDetailsModel.saveTokenDetails(exampleInput).then(
           () => {
             throw new Error('Expected promise to reject');
           },
@@ -120,9 +120,9 @@ describe('Firebase Messaging > TokenDetailsModel', () => {
 
     it('should throw on bad vapid key input', () => {
       const promises = BAD_INPUTS.map(badInput => {
-        globalTokenModel = new TokenDetailsModel();
+        tokenDetailsModel = new TokenDetailsModel();
         exampleInput.vapidKey = badInput;
-        return globalTokenModel.saveTokenDetails(exampleInput).then(
+        return tokenDetailsModel.saveTokenDetails(exampleInput).then(
           () => {
             throw new Error('Expected promise to reject');
           },
@@ -137,9 +137,9 @@ describe('Firebase Messaging > TokenDetailsModel', () => {
 
     it('should throw on bad endpoint input', () => {
       const promises = BAD_INPUTS.map(badInput => {
-        globalTokenModel = new TokenDetailsModel();
+        tokenDetailsModel = new TokenDetailsModel();
         exampleInput.endpoint = badInput;
-        return globalTokenModel.saveTokenDetails(exampleInput).then(
+        return tokenDetailsModel.saveTokenDetails(exampleInput).then(
           () => {
             throw new Error('Expected promise to reject');
           },
@@ -154,9 +154,9 @@ describe('Firebase Messaging > TokenDetailsModel', () => {
 
     it('should throw on bad auth input', () => {
       const promises = BAD_INPUTS.map(badInput => {
-        globalTokenModel = new TokenDetailsModel();
+        tokenDetailsModel = new TokenDetailsModel();
         exampleInput.auth = badInput;
-        return globalTokenModel.saveTokenDetails(exampleInput).then(
+        return tokenDetailsModel.saveTokenDetails(exampleInput).then(
           () => {
             throw new Error('Expected promise to reject');
           },
@@ -171,9 +171,9 @@ describe('Firebase Messaging > TokenDetailsModel', () => {
 
     it('should throw on bad p256dh input', () => {
       const promises = BAD_INPUTS.map(badInput => {
-        globalTokenModel = new TokenDetailsModel();
+        tokenDetailsModel = new TokenDetailsModel();
         exampleInput.p256dh = badInput;
-        return globalTokenModel.saveTokenDetails(exampleInput).then(
+        return tokenDetailsModel.saveTokenDetails(exampleInput).then(
           () => {
             throw new Error('Expected promise to reject');
           },
@@ -188,9 +188,9 @@ describe('Firebase Messaging > TokenDetailsModel', () => {
 
     it('should throw on bad send id input', () => {
       const promises = BAD_INPUTS.map(badInput => {
-        globalTokenModel = new TokenDetailsModel();
+        tokenDetailsModel = new TokenDetailsModel();
         exampleInput.fcmSenderId = badInput;
-        return globalTokenModel.saveTokenDetails(exampleInput).then(
+        return tokenDetailsModel.saveTokenDetails(exampleInput).then(
           () => {
             throw new Error('Expected promise to reject');
           },
@@ -205,9 +205,9 @@ describe('Firebase Messaging > TokenDetailsModel', () => {
 
     it('should throw on bad token input', () => {
       const promises = BAD_INPUTS.map(badInput => {
-        globalTokenModel = new TokenDetailsModel();
+        tokenDetailsModel = new TokenDetailsModel();
         exampleInput.fcmToken = badInput;
-        return globalTokenModel.saveTokenDetails(exampleInput).then(
+        return tokenDetailsModel.saveTokenDetails(exampleInput).then(
           () => {
             throw new Error('Expected promise to reject');
           },
@@ -222,9 +222,9 @@ describe('Firebase Messaging > TokenDetailsModel', () => {
 
     it('should throw on bad pushSet input', () => {
       const promises = BAD_INPUTS.map(badInput => {
-        globalTokenModel = new TokenDetailsModel();
+        tokenDetailsModel = new TokenDetailsModel();
         exampleInput.fcmPushSet = badInput;
-        return globalTokenModel.saveTokenDetails(exampleInput).then(
+        return tokenDetailsModel.saveTokenDetails(exampleInput).then(
           () => {
             throw new Error('Expected promise to reject');
           },
@@ -238,15 +238,15 @@ describe('Firebase Messaging > TokenDetailsModel', () => {
     });
 
     it('should save valid details', () => {
-      globalTokenModel = new TokenDetailsModel();
-      return globalTokenModel.saveTokenDetails(exampleInput);
+      tokenDetailsModel = new TokenDetailsModel();
+      return tokenDetailsModel.saveTokenDetails(exampleInput);
     });
   });
 
   describe('getTokenDetailsFromToken', () => {
     for (const badInput of BAD_INPUTS) {
       it(`should throw on bad scope input ${JSON.stringify(badInput)}`, () => {
-        return globalTokenModel.getTokenDetailsFromSWScope(badInput).then(
+        return tokenDetailsModel.getTokenDetailsFromSWScope(badInput).then(
           () => {
             throw new Error('Expected promise to reject');
           },
@@ -259,7 +259,7 @@ describe('Firebase Messaging > TokenDetailsModel', () => {
 
     for (const badInput of BAD_INPUTS) {
       it(`should throw on bad FCM Token input: '${badInput}'`, () => {
-        return globalTokenModel.getTokenDetailsFromToken(badInput).then(
+        return tokenDetailsModel.getTokenDetailsFromToken(badInput).then(
           () => {
             throw new Error('Expected promise to reject');
           },
@@ -271,14 +271,14 @@ describe('Firebase Messaging > TokenDetailsModel', () => {
     }
 
     it('should get from scope', () => {
-      return globalTokenModel
+      return tokenDetailsModel
         .getTokenDetailsFromSWScope(exampleInput.swScope)
         .then(details => {
           assert.notExists(details);
-          return globalTokenModel.saveTokenDetails(exampleInput);
+          return tokenDetailsModel.saveTokenDetails(exampleInput);
         })
         .then(() => {
-          return globalTokenModel.getTokenDetailsFromSWScope(
+          return tokenDetailsModel.getTokenDetailsFromSWScope(
             exampleInput.swScope
           );
         })
@@ -289,14 +289,14 @@ describe('Firebase Messaging > TokenDetailsModel', () => {
     });
 
     it('should get from token', () => {
-      return globalTokenModel
+      return tokenDetailsModel
         .getTokenDetailsFromToken(exampleInput.fcmToken)
         .then(details => {
           assert.notExists(details);
-          return globalTokenModel.saveTokenDetails(exampleInput);
+          return tokenDetailsModel.saveTokenDetails(exampleInput);
         })
         .then(() => {
-          return globalTokenModel.getTokenDetailsFromToken(
+          return tokenDetailsModel.getTokenDetailsFromToken(
             exampleInput.fcmToken
           );
         })
@@ -309,8 +309,8 @@ describe('Firebase Messaging > TokenDetailsModel', () => {
 
   describe('deleteToken', () => {
     it('should handle no input', () => {
-      globalTokenModel = new TokenDetailsModel();
-      return globalTokenModel.deleteToken(undefined as any).then(
+      tokenDetailsModel = new TokenDetailsModel();
+      return tokenDetailsModel.deleteToken(undefined as any).then(
         () => {
           throw new Error('Expected this to throw an error due to no token');
         },
@@ -324,8 +324,8 @@ describe('Firebase Messaging > TokenDetailsModel', () => {
     });
 
     it('should handle empty string', () => {
-      globalTokenModel = new TokenDetailsModel();
-      return globalTokenModel.deleteToken('').then(
+      tokenDetailsModel = new TokenDetailsModel();
+      return tokenDetailsModel.deleteToken('').then(
         () => {
           throw new Error('Expected this to throw an error due to no token');
         },
@@ -339,15 +339,15 @@ describe('Firebase Messaging > TokenDetailsModel', () => {
     });
 
     it('should delete current token', () => {
-      globalTokenModel = new TokenDetailsModel();
-      return globalTokenModel
+      tokenDetailsModel = new TokenDetailsModel();
+      return tokenDetailsModel
         .saveTokenDetails(exampleInput)
         .then(() => {
-          return globalTokenModel.deleteToken(exampleInput.fcmToken);
+          return tokenDetailsModel.deleteToken(exampleInput.fcmToken);
         })
         .then(details => {
           compareDetails(exampleInput, details);
-          return globalTokenModel.getTokenDetailsFromToken(
+          return tokenDetailsModel.getTokenDetailsFromToken(
             exampleInput.fcmToken
           );
         })
@@ -357,8 +357,8 @@ describe('Firebase Messaging > TokenDetailsModel', () => {
     });
 
     it('should handle deleting a non-existant token', () => {
-      globalTokenModel = new TokenDetailsModel();
-      return globalTokenModel.deleteToken('bad-token').then(
+      tokenDetailsModel = new TokenDetailsModel();
+      return tokenDetailsModel.deleteToken('bad-token').then(
         () => {
           throw new Error('Expected this delete to throw and error.');
         },


### PR DESCRIPTION
Fixes abbreviations in variable and class names to match Google TypeScript style guide, which follows the [Java style guide](https://google.github.io/styleguide/javaguide.html#s5.3-camel-case).

Also changes some variable names in tests.