### PR TITLE
Add listen spec tests

### DIFF
--- a/packages/firestore/test/unit/specs/limit_spec.test.ts
+++ b/packages/firestore/test/unit/specs/limit_spec.test.ts
@@ -55,6 +55,7 @@ describeSpec('Limits:', [], () => {
         })
         .watchResets(query)
         .watchSends({ affects: [query] }, doc2, doc3)
+        .watchCurrents(query, 'resume-token-' + 2000)
         .watchSnapshots(2000)
         .expectLimboDocs(doc1.key)
         // Limbo document causes query to be "inconsistent"
@@ -161,6 +162,7 @@ describeSpec('Limits:', [], () => {
          * D, since they are results for query2. query2 is just a hack to make
          * sure that C and D are in the local cache.
          */
+        .watchCurrents(query1, 'resume-token-' + 2000)
         .watchSnapshots(2000)
         .expectLimboDocs(docA.key, docB.key)
         // Limbo document causes query to be "inconsistent"

--- a/packages/firestore/test/unit/specs/listen_spec.test.ts
+++ b/packages/firestore/test/unit/specs/listen_spec.test.ts
@@ -16,7 +16,7 @@
 
 import { Query } from '../../../src/core/query';
 import { Code } from '../../../src/util/error';
-import { doc, filter, path } from '../../util/helpers';
+import { deletedDoc, doc, filter, path } from '../../util/helpers';
 
 import { describeSpec, specTest } from './describe_spec';
 import { spec } from './spec_builder';
@@ -77,6 +77,19 @@ describeSpec('Listens:', [], () => {
       );
     }
   );
+
+  specTest('Does not raise event for initial document delete', [], () => {
+    const query = Query.atPath(path('collection'));
+    const missingDoc = deletedDoc('collection/a', 1000);
+    return spec()
+      .userListens(query)
+      .watchAcks(query)
+      .watchSends({ removed: [query] }, missingDoc)
+      .watchSnapshots(1000)
+      .watchCurrents(query, 'resume-token-2000')
+      .watchSnapshots(2000)
+      .expectEvents(query, { fromCache: false });
+  });
 
   specTest(
     'Will process removals without waiting for a consistent snapshot',
@@ -261,4 +274,47 @@ describeSpec('Listens:', [], () => {
       .watchAcksFull(query, 2000, docB)
       .expectEvents(query, { added: [docB] });
   });
+
+  specTest('Ignores update from inactive target', [], () => {
+    const query = Query.atPath(path('collection'));
+    const docA = doc('collection/a', 1000, { key: 'a' });
+    const docB = doc('collection/b', 2000, { key: 'b' });
+    return spec()
+      .withGCEnabled(false)
+      .userListens(query)
+      .watchAcksFull(query, 1000, docA)
+      .expectEvents(query, { added: [docA] })
+      .userUnlistens(query)
+      .watchSends({ affects: [query] }, docB)
+      .watchSnapshots(2000)
+      .watchRemoves(query)
+      .userListens(query, 'resume-token-1000')
+      .expectEvents(query, { added: [docA], fromCache: true });
+  });
+
+  specTest(
+    'Does not synthesize deletes for previously acked documents',
+    [],
+    () => {
+      const query = Query.atPath(path('collection/a'));
+      const docA = doc('collection/a', 1000, { key: 'a' });
+      return (
+        spec()
+          .withGCEnabled(false)
+          .userListens(query)
+          .watchAcks(query)
+          .watchSends({ affects: [query] }, docA)
+          .watchSnapshots(1000)
+          .expectEvents(query, { added: [docA], fromCache: true })
+          .watchCurrents(query, 'resume-token-2000')
+          .watchSnapshots(2000)
+          // The snapshot is empty, but we have received 'docA' in a previous
+          // snapshot and don't synthesize a document delete.
+          .expectEvents(query, { fromCache: false })
+          .userUnlistens(query)
+          .userListens(query, 'resume-token-2000')
+          .expectEvents(query, { added: [docA], fromCache: true })
+      );
+    }
+  );
 });

--- a/packages/firestore/test/unit/specs/spec_builder.ts
+++ b/packages/firestore/test/unit/specs/spec_builder.ts
@@ -17,7 +17,11 @@
 import { Filter, Query, RelationFilter } from '../../../src/core/query';
 import { TargetIdGenerator } from '../../../src/core/target_id_generator';
 import { TargetId } from '../../../src/core/types';
-import { Document, NoDocument } from '../../../src/model/document';
+import {
+  Document,
+  MaybeDocument,
+  NoDocument
+} from '../../../src/model/document';
 import { DocumentKey } from '../../../src/model/document_key';
 import { JsonObject } from '../../../src/model/field_value';
 import { mapRpcCodeFromCode } from '../../../src/remote/rpc_error';
@@ -412,7 +416,7 @@ export class SpecBuilder {
 
   watchSends(
     targets: { affects?: Query[]; removed?: Query[] },
-    ...docs: Document[]
+    ...docs: MaybeDocument[]
   ): SpecBuilder {
     this.nextStep();
     const affects =
@@ -614,15 +618,21 @@ export class SpecBuilder {
     return spec;
   }
 
-  private static docToSpec(doc: Document): SpecDocument {
+  private static docToSpec(doc: MaybeDocument): SpecDocument {
+    const data = doc instanceof Document ? doc.data.value() : null;
+    const localMutations =
+      doc instanceof Document ? doc.hasLocalMutations : false;
+
     const spec: SpecDocument = [
       SpecBuilder.keyToSpec(doc.key),
       doc.version.toMicroseconds(),
-      doc.data.value()
+      data
     ];
-    if (doc.hasLocalMutations) {
+
+    if (localMutations) {
       spec.push('local');
     }
+
     return spec;
   }
 

--- a/packages/firestore/test/unit/specs/spec_test_runner.ts
+++ b/packages/firestore/test/unit/specs/spec_test_runner.ts
@@ -77,6 +77,7 @@ import * as obj from '../../../src/util/obj';
 import { ObjectMap } from '../../../src/util/obj_map';
 import { Deferred, sequence } from '../../../src/util/promise';
 import {
+  deletedDoc,
   deleteMutation,
   doc,
   filter,
@@ -644,7 +645,13 @@ abstract class TestRunner {
         );
       });
     } else if (watchEntity.doc) {
-      const d = doc(watchEntity.doc[0], watchEntity.doc[1], watchEntity.doc[2]);
+      let d;
+      if (watchEntity.doc[2]) {
+        d = doc(watchEntity.doc[0], watchEntity.doc[1], watchEntity.doc[2]);
+      } else {
+        d = deletedDoc(watchEntity.doc[0], watchEntity.doc[1]);
+      }
+
       const change = new DocumentWatchChange(
         watchEntity.targets || [],
         watchEntity.removedTargets || [],
@@ -1247,15 +1254,18 @@ export interface SpecQuery {
 
 /**
  * [<key>, <version>, <value>, <doc-options> (optional), ...]
- * Represents a document.
+ * Represents a document. <value> is null for deleted documents.
  * Doc options are:
  *   'local': document has local modifications
  */
-export type SpecDocument = [string, SpecSnapshotVersion, JsonObject<AnyJs>];
+export type SpecDocument = [
+  string,
+  SpecSnapshotVersion,
+  JsonObject<AnyJs> | null
+];
 
 export interface SpecExpectation {
-  /** If a query is a string, that's treated as a query for a path. */
-  query: string | SpecQuery;
+  query: SpecQuery;
   errorCode?: number;
   fromCache?: boolean;
   hasPendingWrites?: boolean;

--- a/scripts/release/cli.js
+++ b/scripts/release/cli.js
@@ -207,7 +207,11 @@ const { argv } = require('yargs');
     /**
      * Release new versions to NPM
      */
-    await publishToNpm(updates, releaseType, argv.canary ? 'canary': 'default');
+    await publishToNpm(
+      updates,
+      releaseType,
+      argv.canary ? 'canary' : 'default'
+    );
 
     /**
      * If this wasn't a production release there


### PR DESCRIPTION
This add some spec tests that tests behavior that I rely on in the RemoteEvent refactor. It also fixes existing test to send CURRENT after each RESET.

This PR also makes sending a `documentDelete` (rather than a `documentRemove`) message possible via the spec tests.