### PR TITLE
Mikelehen/doc changes for each

### DIFF
--- a/packages/firestore/src/api/database.ts
+++ b/packages/firestore/src/api/database.ts
@@ -1914,10 +1914,11 @@ const docChangesPropertiesToOverride = [
 ];
 docChangesPropertiesToOverride.forEach(property => {
   /**
-   * This will technically overwrite the `Function.prototype.length` property of
-   * `docChanges`. On IE11, the property is improperly defined with
-   * `{ configurable: false }` which causes this line to throw. Wrap in a
-   * try-catch to ensure that we still have a functional SDK.
+   * We are (re-)defining properties on QuerySnapshot.prototype.docChanges which
+   * is a Function. This could fail, in particular in the case of 'length' which
+   * already exists on Function.prototype and on IE11 is improperly defined with
+   * `{ configurable: false }`. So we wrap this in a try/catch to ensure that we
+   * still have a functional SDK.
    */
   try {
     Object.defineProperty(QuerySnapshot.prototype.docChanges, property, {

--- a/packages/firestore/src/api/database.ts
+++ b/packages/firestore/src/api/database.ts
@@ -1907,8 +1907,10 @@ function throwDocChangesMethodError(): never {
 }
 
 const docChangesPropertiesToOverride = [
-  'length', 'forEach', 'map',
-  ...(typeof Symbol !== 'undefined' ? [Symbol.iterator] : []),
+  'length',
+  'forEach',
+  'map',
+  ...(typeof Symbol !== 'undefined' ? [Symbol.iterator] : [])
 ];
 docChangesPropertiesToOverride.forEach(property => {
   /**

--- a/packages/firestore/src/api/database.ts
+++ b/packages/firestore/src/api/database.ts
@@ -1893,9 +1893,10 @@ export class QuerySnapshot implements firestore.QuerySnapshot {
 
 // TODO(2018/11/01): As of 2018/04/17 we're changing docChanges from an array
 // into a method. Because this is a runtime breaking change and somewhat subtle
-// (both Array and Function have a .length, etc.), we'll replace the .length and
-// @@iterator properties to throw a custom error message. In ~6 months we can
-// delete the custom error as most folks will have hopefully migrated.
+// (both Array and Function have a .length, etc.), we'll replace commonly-used
+// properties (including Symbol.iterator) to throw a custom error message. In
+// ~6 months we can delete the custom error as most folks will have hopefully
+// migrated.
 function throwDocChangesMethodError(): never {
   throw new FirestoreError(
     Code.INVALID_ARGUMENT,
@@ -1905,23 +1906,23 @@ function throwDocChangesMethodError(): never {
   );
 }
 
-/**
- * This is technically overwriting the `Function.prototype.length` property of
- * `docChanges`. On IE11, the property is improperly defined with
- * `{ configurable: false }` which causes this line to throw. Wrap in a
- * try-catch to ensure that we still have a functional SDK.
- */
-try {
-  Object.defineProperty(QuerySnapshot.prototype.docChanges, 'length', {
-    get: () => throwDocChangesMethodError()
-  });
-} catch (err) {} // Ignore this failure intentionally
-
-if (typeof Symbol !== 'undefined') {
-  Object.defineProperty(QuerySnapshot.prototype.docChanges, Symbol.iterator, {
-    get: () => throwDocChangesMethodError()
-  });
-}
+const docChangesPropertiesToOverride = [
+  'length', 'forEach', 'map',
+  ...(typeof Symbol !== 'undefined' ? [Symbol.iterator] : []),
+];
+docChangesPropertiesToOverride.forEach(property => {
+  /**
+   * This will technically overwrite the `Function.prototype.length` property of
+   * `docChanges`. On IE11, the property is improperly defined with
+   * `{ configurable: false }` which causes this line to throw. Wrap in a
+   * try-catch to ensure that we still have a functional SDK.
+   */
+  try {
+    Object.defineProperty(QuerySnapshot.prototype.docChanges, property, {
+      get: () => throwDocChangesMethodError()
+    });
+  } catch (err) {} // Ignore this failure intentionally
+});
 
 export class CollectionReference extends Query
   implements firestore.CollectionReference {

--- a/scripts/release/cli.js
+++ b/scripts/release/cli.js
@@ -207,7 +207,11 @@ const { argv } = require('yargs');
     /**
      * Release new versions to NPM
      */
-    await publishToNpm(updates, releaseType, argv.canary ? 'canary': 'default');
+    await publishToNpm(
+      updates,
+      releaseType,
+      argv.canary ? 'canary' : 'default'
+    );
 
     /**
      * If this wasn't a production release there


### PR DESCRIPTION
Add 'forEach' (and 'map' for good measure) to Array methods we intercept on QuerySnapshot.docChanges.

Would have prevented https://github.com/firebase/firebase-js-sdk/issues/824.