### PR TITLE
allow storing Object.create(null) in documents

### DIFF
--- a/packages/firestore/src/util/input_validation.ts
+++ b/packages/firestore/src/util/input_validation.ts
@@ -282,14 +282,14 @@ function validateType(
 }
 
 /**
- * Returns true iff it's a non-null object without a custom prototype
+ * Returns true if it's a non-null object without a custom prototype
  * (i.e. excludes Array, Date, etc.).
  */
 export function isPlainObject(input: AnyJs): boolean {
   return (
     typeof input === 'object' &&
     input !== null &&
-    Object.getPrototypeOf(input) === Object.prototype
+    (Object.getPrototypeOf(input) === Object.prototype || Object.getPrototypeOf(input) === null)
   );
 }
 


### PR DESCRIPTION
Fixes issue #811, where objects created with `Object.create(null)` would fail input validation.