### PR TITLE
Remove test-only error logs

### DIFF
--- a/packages/firestore/src/local/indexeddb_persistence.ts
+++ b/packages/firestore/src/local/indexeddb_persistence.ts
@@ -533,12 +533,12 @@ export class IndexedDbPersistence implements Persistence {
    */
   private getZombiedClientId(): ClientId | null {
     if (this.window.localStorage === undefined) {
-            assert(
-                 process.env.USE_MOCK_PERSISTENCE === 'YES',
-                  'Operating without LocalStorage is only supported with IndexedDbShim.'
-                );
-            return null;
-         }
+      assert(
+        process.env.USE_MOCK_PERSISTENCE === 'YES',
+        'Operating without LocalStorage is only supported with IndexedDbShim.'
+      );
+      return null;
+    }
 
     try {
       const zombiedClientId = this.window.localStorage.getItem(

--- a/packages/firestore/src/local/indexeddb_persistence.ts
+++ b/packages/firestore/src/local/indexeddb_persistence.ts
@@ -532,6 +532,14 @@ export class IndexedDbPersistence implements Persistence {
    * record exists.
    */
   private getZombiedClientId(): ClientId | null {
+    if (this.window.localStorage === undefined) {
+            assert(
+                 process.env.USE_MOCK_PERSISTENCE === 'YES',
+                  'Operating without LocalStorage is only supported with IndexedDbShim.'
+                );
+            return null;
+         }
+
     try {
       const zombiedClientId = this.window.localStorage.getItem(
         this.zombiedClientLocalStorageKey()


### PR DESCRIPTION
The error message that the try/catch is printing is getting a little annoying as I am trying to debug test runs. That's why it is now its own PR!