### PR TITLE
Generating target IDs from persistence

### DIFF
--- a/packages/firestore/src/core/target_id_generator.ts
+++ b/packages/firestore/src/core/target_id_generator.ts
@@ -20,7 +20,7 @@ import { assert } from '../util/assert';
 const RESERVED_BITS = 1;
 
 enum GeneratorIds {
-  LocalStore = 0, // The target IDs for user queries are even (end in 0).
+  QueryCache = 0, // The target IDs for user-issued queries are even (end in 0).
   SyncEngine = 1 // The target IDs for limbo detection are odd (end in 1).
 }
 
@@ -31,6 +31,8 @@ enum GeneratorIds {
  * will ever produce the same ID. This is useful, because sometimes the backend
  * may group IDs from separate parts of the client into the same ID space.
  */
+// TODO(mrschmidt): Explore removing this class in favor of generating these IDs
+// directly in SyncEngine and LocalStore.
 export class TargetIdGenerator {
   private nextId: TargetId;
 
@@ -69,12 +71,12 @@ export class TargetIdGenerator {
     this.nextId = targetId;
   }
 
-  static forLocalStore(): TargetIdGenerator {
+  static forQueryCache(): TargetIdGenerator {
     // We seed the local store generator to return '2' as its first ID, as there
     // is no differentiation in the protocol layer between an unset number and
     // the number '0'. If we were to sent a target with target ID '0', the
     // backend would consider it unset and replace it with its own ID.
-    const targetIdGenerator = new TargetIdGenerator(GeneratorIds.LocalStore, 2);
+    const targetIdGenerator = new TargetIdGenerator(GeneratorIds.QueryCache, 2);
     return targetIdGenerator;
   }
 

--- a/packages/firestore/src/core/target_id_generator.ts
+++ b/packages/firestore/src/core/target_id_generator.ts
@@ -25,11 +25,18 @@ enum GeneratorIds {
 }
 
 /**
- * TargetIdGenerator generates monotonically increasing integer IDs. There are
- * separate generators for different scopes. While these generators will operate
- * independently of each other, they are scoped, such that no two generators
- * will ever produce the same ID. This is useful, because sometimes the backend
- * may group IDs from separate parts of the client into the same ID space.
+ * Generates monotonically increasing target IDs for sending targets to the
+ * watch stream.
+ *
+ * The client constructs two generators, one for the query cache (via
+ * forQueryCache()), and one for limbo documents (via forSyncEngine()). These
+ * two generators produce non-overlapping IDs (by using even and odd IDs
+ * respectively).
+ *
+ * By separating the target ID space, the query cache can generate target IDs
+ * that persist across client restarts, while sync engine can independently
+ * generate in-memory target IDs that are transient and can be reused after a
+ * restart.
  */
 // TODO(mrschmidt): Explore removing this class in favor of generating these IDs
 // directly in SyncEngine and LocalStore.
@@ -72,7 +79,7 @@ export class TargetIdGenerator {
   }
 
   static forQueryCache(): TargetIdGenerator {
-    // We seed the local store generator to return '2' as its first ID, as there
+    // We seed the query cache generator to return '2' as its first ID, as there
     // is no differentiation in the protocol layer between an unset number and
     // the number '0'. If we were to sent a target with target ID '0', the
     // backend would consider it unset and replace it with its own ID.

--- a/packages/firestore/src/core/target_id_generator.ts
+++ b/packages/firestore/src/core/target_id_generator.ts
@@ -15,12 +15,13 @@
  */
 
 import { TargetId } from './types';
+import { assert } from '../util/assert';
 
 const RESERVED_BITS = 1;
 
 enum GeneratorIds {
-  LocalStore = 0,
-  SyncEngine = 1
+  LocalStore = 0, // The target IDs for user queries are even (end in 0).
+  SyncEngine = 1 // The target IDs for limbo detection are odd (end in 1).
 }
 
 /**
@@ -31,44 +32,54 @@ enum GeneratorIds {
  * may group IDs from separate parts of the client into the same ID space.
  */
 export class TargetIdGenerator {
-  private previousId: TargetId;
+  private nextId: TargetId;
 
-  constructor(private generatorId: number, initAfter: TargetId = 0) {
-    // Replace the generator part of initAfter with this generator's ID.
-    const afterWithoutGenerator = (initAfter >> RESERVED_BITS) << RESERVED_BITS;
-    const afterGenerator = initAfter - afterWithoutGenerator;
-    if (afterGenerator >= generatorId) {
-      // For example, if:
-      //   this.generatorId = 0b0000
-      //   after = 0b1011
-      //   afterGenerator = 0b0001
-      // Then:
-      //   previous = 0b1010
-      //   next = 0b1100
-      this.previousId = afterWithoutGenerator | this.generatorId;
-    } else {
-      // For example, if:
-      //   this.generatorId = 0b0001
-      //   after = 0b1010
-      //   afterGenerator = 0b0000
-      // Then:
-      //   previous = 0b1001
-      //   next = 0b1011
-      this.previousId =
-        (afterWithoutGenerator | this.generatorId) - (1 << RESERVED_BITS);
-    }
+  /**
+   * Instantiates a new TargetIdGenerator. If a seed is provided, the generator
+   * will use the seed value as the next target ID.
+   */
+  constructor(private generatorId: number, seed?: number) {
+    assert(
+      (generatorId & RESERVED_BITS) === generatorId,
+      `Generator ID ${generatorId} contains more than ${RESERVED_BITS} reserved bits`
+    );
+    this.seek(seed !== undefined ? seed : this.generatorId);
   }
 
   next(): TargetId {
-    this.previousId += 1 << RESERVED_BITS;
-    return this.previousId;
+    const nextId = this.nextId;
+    this.nextId += 1 << RESERVED_BITS;
+    return nextId;
   }
 
-  static forLocalStore(initAfter: TargetId = 0): TargetIdGenerator {
-    return new TargetIdGenerator(GeneratorIds.LocalStore, initAfter);
+  /**
+   * Returns the ID that follows the given ID. Subsequent calls to `next()`
+   * use the newly returned target ID as their base.
+   */
+  after(targetId: TargetId): TargetId {
+    this.seek(targetId + (1 << RESERVED_BITS));
+    return this.next();
+  }
+
+  private seek(targetId: TargetId): void {
+    assert(
+      (targetId & RESERVED_BITS) === this.generatorId,
+      'Cannot supply target ID from different generator ID'
+    );
+    this.nextId = targetId;
+  }
+
+  static forLocalStore(): TargetIdGenerator {
+    // We seed the local store generator to return '2' as its first ID, as there
+    // is no differentiation in the protocol layer between an unset number and
+    // the number '0'. If we were to sent a target with target ID '0', the
+    // backend would consider it unset and replace it with its own ID.
+    const targetIdGenerator = new TargetIdGenerator(GeneratorIds.LocalStore, 2);
+    return targetIdGenerator;
   }
 
   static forSyncEngine(): TargetIdGenerator {
+    // Sync engine assigns target IDs for limbo document detection.
     return new TargetIdGenerator(GeneratorIds.SyncEngine);
   }
 }

--- a/packages/firestore/src/local/indexeddb_query_cache.ts
+++ b/packages/firestore/src/local/indexeddb_query_cache.ts
@@ -39,59 +39,54 @@ import { PersistencePromise } from './persistence_promise';
 import { QueryCache } from './query_cache';
 import { QueryData } from './query_data';
 import { SimpleDbStore, SimpleDbTransaction } from './simple_db';
+import { TargetIdGenerator } from '../core/target_id_generator';
 
 export class IndexedDbQueryCache implements QueryCache {
   constructor(private serializer: LocalSerializer) {}
-
-  /**
-   * The last received snapshot version. We store this seperately from the
-   * metadata to avoid the extra conversion to/from DbTimestamp.
-   */
-  private lastRemoteSnapshotVersion = SnapshotVersion.MIN;
-
-  /**
-   * A cached copy of the metadata for the query cache.
-   */
-  private metadata = null;
 
   /** The garbage collector to notify about potential garbage keys. */
   private garbageCollector: GarbageCollector | null = null;
 
   start(transaction: PersistenceTransaction): PersistencePromise<void> {
-    return globalTargetStore(transaction)
-      .get(DbTargetGlobal.key)
-      .next(metadata => {
-        assert(
-          metadata !== null,
-          'Missing metadata row that should be added by schema migration.'
-        );
-        this.metadata = metadata;
-        const lastSavedVersion = metadata.lastRemoteSnapshotVersion;
-        this.lastRemoteSnapshotVersion = SnapshotVersion.fromTimestamp(
-          new Timestamp(lastSavedVersion.seconds, lastSavedVersion.nanoseconds)
-        );
-        return PersistencePromise.resolve();
-      });
+    // Nothing to do.
+    return PersistencePromise.resolve();
   }
 
-  getHighestTargetId(): TargetId {
-    return this.metadata.highestTargetId;
+  allocateTargetId(
+    transaction: PersistenceTransaction,
+    targetIdGenerator: TargetIdGenerator
+  ): PersistencePromise<TargetId> {
+    return this.retrieveMetadata(transaction).next(metadata => {
+      metadata.highestTargetId = targetIdGenerator.after(
+        metadata.highestTargetId
+      );
+      return this.saveMetadata(transaction, metadata).next(
+        () => metadata.highestTargetId
+      );
+    });
   }
 
-  getLastRemoteSnapshotVersion(): SnapshotVersion {
-    return this.lastRemoteSnapshotVersion;
+  getLastRemoteSnapshotVersion(
+    transaction: PersistenceTransaction
+  ): PersistencePromise<SnapshotVersion> {
+    return this.retrieveMetadata(transaction).next(metadata => {
+      return SnapshotVersion.fromTimestamp(
+        new Timestamp(
+          metadata.lastRemoteSnapshotVersion.seconds,
+          metadata.lastRemoteSnapshotVersion.nanoseconds
+        )
+      );
+    });
   }
 
   setLastRemoteSnapshotVersion(
     transaction: PersistenceTransaction,
     snapshotVersion: SnapshotVersion
   ): PersistencePromise<void> {
-    this.lastRemoteSnapshotVersion = snapshotVersion;
-    this.metadata.lastRemoteSnapshotVersion = snapshotVersion.toTimestamp();
-    return globalTargetStore(transaction).put(
-      DbTargetGlobal.key,
-      this.metadata
-    );
+    return this.retrieveMetadata(transaction).next(metadata => {
+      metadata.lastRemoteSnapshotVersion = snapshotVersion.toTimestamp();
+      return this.saveMetadata(transaction, metadata);
+    });
   }
 
   addQueryData(
@@ -99,9 +94,11 @@ export class IndexedDbQueryCache implements QueryCache {
     queryData: QueryData
   ): PersistencePromise<void> {
     return this.saveQueryData(transaction, queryData).next(() => {
-      this.metadata.targetCount += 1;
-      this.updateMetadataFromQueryData(queryData);
-      return this.saveMetadata(transaction);
+      return this.retrieveMetadata(transaction).next(metadata => {
+        metadata.targetCount += 1;
+        this.updateMetadataFromQueryData(queryData, metadata);
+        return this.saveMetadata(transaction, metadata);
+      });
     });
   }
 
@@ -110,11 +107,13 @@ export class IndexedDbQueryCache implements QueryCache {
     queryData: QueryData
   ): PersistencePromise<void> {
     return this.saveQueryData(transaction, queryData).next(() => {
-      if (this.updateMetadataFromQueryData(queryData)) {
-        return this.saveMetadata(transaction);
-      } else {
-        return PersistencePromise.resolve();
-      }
+      return this.retrieveMetadata(transaction).next(metadata => {
+        if (this.updateMetadataFromQueryData(queryData, metadata)) {
+          return this.saveMetadata(transaction, metadata);
+        } else {
+          return PersistencePromise.resolve();
+        }
+      });
     });
   }
 
@@ -122,22 +121,32 @@ export class IndexedDbQueryCache implements QueryCache {
     transaction: PersistenceTransaction,
     queryData: QueryData
   ): PersistencePromise<void> {
-    assert(this.metadata.targetCount > 0, 'Removing from an empty query cache');
     return this.removeMatchingKeysForTargetId(transaction, queryData.targetId)
       .next(() => targetsStore(transaction).delete(queryData.targetId))
-      .next(() => {
-        this.metadata.targetCount -= 1;
-        return this.saveMetadata(transaction);
+      .next(() => this.retrieveMetadata(transaction))
+      .next(metadata => {
+        assert(metadata.targetCount > 0, 'Removing from an empty query cache');
+        metadata.targetCount -= 1;
+        return this.saveMetadata(transaction, metadata);
+      });
+  }
+
+  private retrieveMetadata(
+    transaction: PersistenceTransaction
+  ): PersistencePromise<DbTargetGlobal> {
+    return globalTargetStore(transaction)
+      .get(DbTargetGlobal.key)
+      .next(metadata => {
+        assert(metadata !== null, 'Missing metadata row.');
+        return metadata;
       });
   }
 
   private saveMetadata(
-    transaction: PersistenceTransaction
+    transaction: PersistenceTransaction,
+    metadata: DbTargetGlobal
   ): PersistencePromise<void> {
-    return globalTargetStore(transaction).put(
-      DbTargetGlobal.key,
-      this.metadata
-    );
+    return globalTargetStore(transaction).put(DbTargetGlobal.key, metadata);
   }
 
   private saveQueryData(
@@ -148,23 +157,29 @@ export class IndexedDbQueryCache implements QueryCache {
   }
 
   /**
-   * Updates the in-memory version of the metadata to account for values in the
-   * given QueryData. Saving is done separately. Returns true if there were any
+   * In-place updates the provided metadata to account for values in the given
+   * QueryData. Saving is done separately. Returns true if there were any
    * changes to the metadata.
    */
-  private updateMetadataFromQueryData(queryData: QueryData): boolean {
-    let needsUpdate = false;
-    if (queryData.targetId > this.metadata.highestTargetId) {
-      this.metadata.highestTargetId = queryData.targetId;
-      needsUpdate = true;
+  private updateMetadataFromQueryData(
+    queryData: QueryData,
+    metadata: DbTargetGlobal
+  ): boolean {
+    if (queryData.targetId > metadata.highestTargetId) {
+      metadata.highestTargetId = queryData.targetId;
+      return true;
     }
 
     // TODO(GC): add sequence number check
-    return needsUpdate;
+    return false;
   }
 
-  get count(): number {
-    return this.metadata.targetCount;
+  getQueryCount(
+    transaction: PersistenceTransaction
+  ): PersistencePromise<number> {
+    return this.retrieveMetadata(transaction).next(
+      metadata => metadata.targetCount
+    );
   }
 
   getQueryData(

--- a/packages/firestore/src/local/local_store.ts
+++ b/packages/firestore/src/local/local_store.ts
@@ -18,7 +18,6 @@ import { Timestamp } from '../api/timestamp';
 import { User } from '../auth/user';
 import { Query } from '../core/query';
 import { SnapshotVersion } from '../core/snapshot_version';
-import { TargetIdGenerator } from '../core/target_id_generator';
 import { BatchId, ProtoByteString, TargetId } from '../core/types';
 import {
   DocumentKeySet,

--- a/packages/firestore/src/local/local_store.ts
+++ b/packages/firestore/src/local/local_store.ts
@@ -266,8 +266,7 @@ export class LocalStore {
     txn: PersistenceTransaction
   ): PersistencePromise<void> {
     return this.queryCache.start(txn).next(() => {
-      const targetId = this.queryCache.getHighestTargetId();
-      this.targetIdGenerator = TargetIdGenerator.forLocalStore(targetId);
+      this.targetIdGenerator = TargetIdGenerator.forLocalStore();
     });
   }
 
@@ -373,8 +372,9 @@ export class LocalStore {
       let affected: DocumentKeySet;
       return this.mutationQueue
         .acknowledgeBatch(txn, batchResult.batch, batchResult.streamToken)
-        .next(() => {
-          if (this.shouldHoldBatchResult(batchResult.commitVersion)) {
+        .next(() => this.shouldHoldBatchResult(txn, batchResult.commitVersion))
+        .next(shouldHoldBatchResult => {
+          if (shouldHoldBatchResult) {
             this.heldBatchResults.push(batchResult);
             affected = documentKeySet();
             return PersistencePromise.resolve();
@@ -473,8 +473,12 @@ export class LocalStore {
    * Returns the last consistent snapshot processed (used by the RemoteStore to
    * determine whether to buffer incoming snapshots from the backend).
    */
-  getLastRemoteSnapshotVersion(): SnapshotVersion {
-    return this.queryCache.getLastRemoteSnapshotVersion();
+  getLastRemoteSnapshotVersion(): Promise<SnapshotVersion> {
+    return this.persistence.runTransaction(
+      'Get last remote snapshot version',
+      false,
+      txn => this.queryCache.getLastRemoteSnapshotVersion(txn)
+    );
   }
 
   /**
@@ -580,19 +584,24 @@ export class LocalStore {
       // can synthesize remote events when we get permission denied errors while
       // trying to resolve the state of a locally cached document that is in
       // limbo.
-      const lastRemoteVersion = this.queryCache.getLastRemoteSnapshotVersion();
       const remoteVersion = remoteEvent.snapshotVersion;
       if (!remoteVersion.isEqual(SnapshotVersion.MIN)) {
-        assert(
-          remoteVersion.compareTo(lastRemoteVersion) >= 0,
-          'Watch stream reverted to previous snapshot?? ' +
-            remoteVersion +
-            ' < ' +
-            lastRemoteVersion
-        );
-        promises.push(
-          this.queryCache.setLastRemoteSnapshotVersion(txn, remoteVersion)
-        );
+        const updateRemoteVersion = this.queryCache
+          .getLastRemoteSnapshotVersion(txn)
+          .next(lastRemoteVersion => {
+            assert(
+              remoteVersion.compareTo(lastRemoteVersion) >= 0,
+              'Watch stream reverted to previous snapshot?? ' +
+                remoteVersion +
+                ' < ' +
+                lastRemoteVersion
+            );
+            return this.queryCache.setLastRemoteSnapshotVersion(
+              txn,
+              remoteVersion
+            );
+          });
+        promises.push(updateRemoteVersion);
       }
 
       let releasedWriteKeys: DocumentKeySet;
@@ -697,10 +706,12 @@ export class LocalStore {
             queryData = cached;
             return PersistencePromise.resolve();
           } else {
-            // TODO(multitab): targetIdGenerator is not multi-tab safe
-            const targetId = this.targetIdGenerator.next();
-            queryData = new QueryData(query, targetId, QueryPurpose.Listen);
-            return this.queryCache.addQueryData(txn, queryData);
+            return this.queryCache
+              .allocateTargetId(txn, this.targetIdGenerator)
+              .next(targetId => {
+                queryData = new QueryData(query, targetId, QueryPurpose.Listen);
+                return this.queryCache.addQueryData(txn, queryData);
+              });
           }
         })
         .next(() => {
@@ -809,36 +820,63 @@ export class LocalStore {
     txn: PersistenceTransaction,
     documentBuffer: RemoteDocumentChangeBuffer
   ): PersistencePromise<DocumentKeySet> {
-    const toRelease: MutationBatchResult[] = [];
-    for (const batchResult of this.heldBatchResults) {
-      if (!this.isRemoteUpToVersion(batchResult.commitVersion)) {
-        break;
-      }
-      toRelease.push(batchResult);
-    }
+    let writesToRelease: PersistencePromise<MutationBatchResult[]>;
 
-    if (toRelease.length === 0) {
-      return PersistencePromise.resolve(documentKeySet());
+    if (objUtils.isEmpty(this.targetIds)) {
+      // We always release all writes when there are no active watch targets.
+      writesToRelease = PersistencePromise.resolve(
+        this.heldBatchResults.slice()
+      );
     } else {
-      this.heldBatchResults.splice(0, toRelease.length);
-      return this.releaseBatchResults(txn, toRelease, documentBuffer);
+      writesToRelease = this.queryCache
+        .getLastRemoteSnapshotVersion(txn)
+        .next(lastRemoteVersion => {
+          const toRelease = [];
+          for (const batchResult of this.heldBatchResults) {
+            if (batchResult.commitVersion.compareTo(lastRemoteVersion) > 0) {
+              break;
+            }
+            toRelease.push(batchResult);
+          }
+          return toRelease;
+        });
     }
+
+    return writesToRelease.next(toRelease => {
+      if (toRelease.length === 0) {
+        return PersistencePromise.resolve(documentKeySet());
+      } else {
+        this.heldBatchResults.splice(0, toRelease.length);
+        return this.releaseBatchResults(txn, toRelease, documentBuffer);
+      }
+    });
   }
 
-  private isRemoteUpToVersion(version: SnapshotVersion): boolean {
-    // If there are no watch targets, then we won't get remote snapshots, and
-    // we are always "up-to-date."
-    const lastRemoteVersion = this.queryCache.getLastRemoteSnapshotVersion();
-    return (
-      version.compareTo(lastRemoteVersion) <= 0 ||
-      objUtils.isEmpty(this.targetIds)
-    );
+  private isRemoteUpToVersion(
+    txn: PersistenceTransaction,
+    version: SnapshotVersion
+  ): PersistencePromise<boolean> {
+    return this.queryCache
+      .getLastRemoteSnapshotVersion(txn)
+      .next(lastRemoteVersion => {
+        return (
+          version.compareTo(lastRemoteVersion) <= 0 ||
+          objUtils.isEmpty(this.targetIds)
+        );
+      });
   }
 
-  private shouldHoldBatchResult(version: SnapshotVersion): boolean {
+  private shouldHoldBatchResult(
+    txn: PersistenceTransaction,
+    batchVersion: SnapshotVersion
+  ): PersistencePromise<boolean> {
     // Check if watcher isn't up to date or prior results are already held.
-    return (
-      !this.isRemoteUpToVersion(version) || this.heldBatchResults.length > 0
+    if (this.heldBatchResults.length > 0) {
+      return PersistencePromise.resolve(true);
+    }
+
+    return this.isRemoteUpToVersion(txn, batchVersion).next(
+      remoteSynced => !remoteSynced
     );
   }
 

--- a/packages/firestore/src/local/memory_query_cache.ts
+++ b/packages/firestore/src/local/memory_query_cache.ts
@@ -48,6 +48,8 @@ export class MemoryQueryCache implements QueryCache {
 
   private targetCount = 0;
 
+  private targetIdGenerator = TargetIdGenerator.forQueryCache();
+
   start(transaction: PersistenceTransaction): PersistencePromise<void> {
     // Nothing to do.
     return PersistencePromise.resolve();
@@ -60,10 +62,9 @@ export class MemoryQueryCache implements QueryCache {
   }
 
   allocateTargetId(
-    transaction: PersistenceTransaction,
-    targetIdGenerator: TargetIdGenerator
+    transaction: PersistenceTransaction
   ): PersistencePromise<TargetId> {
-    const nextTargetId = targetIdGenerator.after(this.highestTargetId);
+    const nextTargetId = this.targetIdGenerator.after(this.highestTargetId);
     this.highestTargetId = nextTargetId;
     return PersistencePromise.resolve(nextTargetId);
   }

--- a/packages/firestore/src/local/memory_query_cache.ts
+++ b/packages/firestore/src/local/memory_query_cache.ts
@@ -28,6 +28,7 @@ import { QueryCache } from './query_cache';
 import { QueryData } from './query_data';
 import { ReferenceSet } from './reference_set';
 import { assert } from '../util/assert';
+import { TargetIdGenerator } from '../core/target_id_generator';
 
 export class MemoryQueryCache implements QueryCache {
   /**
@@ -52,12 +53,19 @@ export class MemoryQueryCache implements QueryCache {
     return PersistencePromise.resolve();
   }
 
-  getLastRemoteSnapshotVersion(): SnapshotVersion {
-    return this.lastRemoteSnapshotVersion;
+  getLastRemoteSnapshotVersion(
+    transaction: PersistenceTransaction
+  ): PersistencePromise<SnapshotVersion> {
+    return PersistencePromise.resolve(this.lastRemoteSnapshotVersion);
   }
 
-  getHighestTargetId(): TargetId {
-    return this.highestTargetId;
+  allocateTargetId(
+    transaction: PersistenceTransaction,
+    targetIdGenerator: TargetIdGenerator
+  ): PersistencePromise<TargetId> {
+    const nextTargetId = targetIdGenerator.after(this.highestTargetId);
+    this.highestTargetId = nextTargetId;
+    return PersistencePromise.resolve(nextTargetId);
   }
 
   setLastRemoteSnapshotVersion(
@@ -114,8 +122,10 @@ export class MemoryQueryCache implements QueryCache {
     return PersistencePromise.resolve();
   }
 
-  get count(): number {
-    return this.targetCount;
+  getQueryCount(
+    transaction: PersistenceTransaction
+  ): PersistencePromise<number> {
+    return PersistencePromise.resolve(this.targetCount);
   }
 
   getQueryData(

--- a/packages/firestore/src/local/query_cache.ts
+++ b/packages/firestore/src/local/query_cache.ts
@@ -23,7 +23,6 @@ import { GarbageSource } from './garbage_source';
 import { PersistenceTransaction } from './persistence';
 import { PersistencePromise } from './persistence_promise';
 import { QueryData } from './query_data';
-import { TargetIdGenerator } from '../core/target_id_generator';
 
 /**
  * Represents cached queries received from the remote backend.

--- a/packages/firestore/src/local/query_cache.ts
+++ b/packages/firestore/src/local/query_cache.ts
@@ -163,7 +163,6 @@ export interface QueryCache extends GarbageSource {
    * return the same ID twice.
    */
   allocateTargetId(
-    transaction: PersistenceTransaction,
-    targetIdGenerator: TargetIdGenerator
+    transaction: PersistenceTransaction
   ): PersistencePromise<TargetId>;
 }

--- a/packages/firestore/src/remote/remote_store.ts
+++ b/packages/firestore/src/remote/remote_store.ts
@@ -364,7 +364,7 @@ export class RemoteStore {
     if (
       !snapshotVersion.isEqual(SnapshotVersion.MIN) &&
       snapshotVersion.compareTo(
-        this.localStore.getLastRemoteSnapshotVersion()
+        await this.localStore.getLastRemoteSnapshotVersion()
       ) >= 0
     ) {
       const changes = this.accumulatedWatchChanges;

--- a/packages/firestore/src/remote/remote_store.ts
+++ b/packages/firestore/src/remote/remote_store.ts
@@ -361,15 +361,14 @@ export class RemoteStore {
     // snapshotVersion or it's older than a previous snapshot we've processed
     // (can happen after we resume a target using a resume token).
     this.accumulatedWatchChanges.push(watchChange);
-    if (
-      !snapshotVersion.isEqual(SnapshotVersion.MIN) &&
-      snapshotVersion.compareTo(
-        await this.localStore.getLastRemoteSnapshotVersion()
-      ) >= 0
-    ) {
-      const changes = this.accumulatedWatchChanges;
-      this.accumulatedWatchChanges = [];
-      return this.handleWatchChangeBatch(snapshotVersion, changes);
+
+    if (!snapshotVersion.isEqual(SnapshotVersion.MIN)) {
+      const lastRemoteSnapshotVersion = await this.localStore.getLastRemoteSnapshotVersion();
+      if (snapshotVersion.compareTo(lastRemoteSnapshotVersion) >= 0) {
+        const changes = this.accumulatedWatchChanges;
+        this.accumulatedWatchChanges = [];
+        return this.handleWatchChangeBatch(snapshotVersion, changes);
+      }
     }
   }
 

--- a/packages/firestore/test/unit/core/target_id_generator.test.ts
+++ b/packages/firestore/test/unit/core/target_id_generator.test.ts
@@ -46,8 +46,8 @@ describe('TargetIdGenerator', () => {
     expect(generator.next()).to.equal(53);
   });
 
-  it('can return correct generator for local store and sync engine', () => {
-    expect(TargetIdGenerator.forLocalStore().next()).to.equal(2);
+  it('can return correct generator for query cache and sync engine', () => {
+    expect(TargetIdGenerator.forQueryCache().next()).to.equal(2);
     expect(TargetIdGenerator.forSyncEngine().next()).to.equal(1);
   });
 

--- a/packages/firestore/test/unit/core/target_id_generator.test.ts
+++ b/packages/firestore/test/unit/core/target_id_generator.test.ts
@@ -18,19 +18,29 @@ import { expect } from 'chai';
 import { TargetIdGenerator } from '../../../src/core/target_id_generator';
 
 describe('TargetIdGenerator', () => {
-  it('can initialize with increment and "after value"', () => {
-    expect(new TargetIdGenerator(0).next()).to.equal(2);
+  it('can initialize with generator and seed', () => {
+    expect(new TargetIdGenerator(0, 2).next()).to.equal(2);
     expect(new TargetIdGenerator(1).next()).to.equal(1);
+  });
 
-    expect(new TargetIdGenerator(1, -1).next()).to.equal(1);
-    expect(new TargetIdGenerator(1, 2).next()).to.equal(3);
-    expect(new TargetIdGenerator(1, 4).next()).to.equal(5);
-    expect(new TargetIdGenerator(1, 23).next()).to.equal(25);
+  it('rejects invalid seeds', () => {
+    expect(() => new TargetIdGenerator(0, 1)).to.throw(
+      'Cannot supply target ID from different generator ID'
+    );
+    expect(() => new TargetIdGenerator(1).after(2)).to.throw(
+      'Cannot supply target ID from different generator ID'
+    );
+  });
+
+  it('rejects invalid generator IDs', () => {
+    expect(() => new TargetIdGenerator(3)).to.throw(
+      ' Generator ID 3 contains more than 1 reserved bits'
+    );
   });
 
   it('can increments ids', () => {
-    const generator = new TargetIdGenerator(1, 46);
-    expect(generator.next()).to.equal(47);
+    const generator = new TargetIdGenerator(1);
+    expect(generator.after(45)).to.equal(47);
     expect(generator.next()).to.equal(49);
     expect(generator.next()).to.equal(51);
     expect(generator.next()).to.equal(53);
@@ -39,5 +49,13 @@ describe('TargetIdGenerator', () => {
   it('can return correct generator for local store and sync engine', () => {
     expect(TargetIdGenerator.forLocalStore().next()).to.equal(2);
     expect(TargetIdGenerator.forSyncEngine().next()).to.equal(1);
+  });
+
+  it('can return next ids', () => {
+    expect(new TargetIdGenerator(1).next()).to.equal(1);
+    expect(new TargetIdGenerator(1).after(-1)).to.equal(1);
+    expect(new TargetIdGenerator(1).after(1)).to.equal(3);
+    expect(new TargetIdGenerator(1).after(3)).to.equal(5);
+    expect(new TargetIdGenerator(1).after(23)).to.equal(25);
   });
 });

--- a/packages/firestore/test/unit/local/query_cache.test.ts
+++ b/packages/firestore/test/unit/local/query_cache.test.ts
@@ -130,11 +130,11 @@ function genericQueryCacheTests(): void {
     // equal canonicalIDs.
     expect(await cache.getQueryData(q2)).to.equal(null);
     expect(await cache.getQueryData(q1)).to.deep.equal(data1);
-    expect(cache.count()).to.equal(1);
+    expect(await cache.getQueryCount()).to.equal(1);
 
     const data2 = testQueryData(q2, 2, 1);
     await cache.addQueryData(data2);
-    expect(cache.count()).to.equal(2);
+    expect(await cache.getQueryCount()).to.equal(2);
 
     expect(await cache.getQueryData(q1)).to.deep.equal(data1);
     expect(await cache.getQueryData(q2)).to.deep.equal(data2);
@@ -142,12 +142,12 @@ function genericQueryCacheTests(): void {
     await cache.removeQueryData(data1);
     expect(await cache.getQueryData(q1)).to.equal(null);
     expect(await cache.getQueryData(q2)).to.deep.equal(data2);
-    expect(cache.count()).to.equal(1);
+    expect(await cache.getQueryCount()).to.equal(1);
 
     await cache.removeQueryData(data2);
     expect(await cache.getQueryData(q1)).to.equal(null);
     expect(await cache.getQueryData(q2)).to.equal(null);
-    expect(cache.count()).to.equal(0);
+    expect(await cache.getQueryCount()).to.equal(0);
   });
 
   it('can set query to new value', async () => {
@@ -282,36 +282,39 @@ function genericQueryCacheTests(): void {
     ]);
   });
 
-  it('can get / set highestTargetId', async () => {
-    expect(cache.getHighestTargetId()).to.deep.equal(0);
-    const queryData1 = testQueryData(QUERY_ROOMS, 1);
+  it('can allocate target ID', async () => {
+    expect(await cache.allocateTargetId()).to.deep.equal(2);
+    const queryData1 = testQueryData(QUERY_ROOMS, 2);
 
     await cache.addQueryData(queryData1);
     const key1 = key('rooms/bar');
     const key2 = key('rooms/foo');
-    await cache.addMatchingKeys([key1, key2], 1);
+    await cache.addMatchingKeys([key1, key2], 2);
 
-    const queryData2 = testQueryData(QUERY_HALLS, 2);
+    expect(await cache.allocateTargetId()).to.deep.equal(4);
+
+    const queryData2 = testQueryData(QUERY_HALLS, 4);
     await cache.addQueryData(queryData2);
     const key3 = key('halls/foo');
-    await cache.addMatchingKeys([key3], 2);
-    expect(cache.getHighestTargetId()).to.deep.equal(2);
+    await cache.addMatchingKeys([key3], 4);
+
+    expect(await cache.allocateTargetId()).to.deep.equal(6);
 
     await cache.removeQueryData(queryData2);
 
     // Target IDs never come down.
-    expect(cache.getHighestTargetId()).to.deep.equal(2);
+    expect(await cache.allocateTargetId()).to.deep.equal(8);
 
     // A query with an empty result set still counts.
     const queryData3 = testQueryData(QUERY_GARAGES, 42);
     await cache.addQueryData(queryData3);
-    expect(cache.getHighestTargetId()).to.deep.equal(42);
+    expect(await cache.allocateTargetId()).to.deep.equal(44);
 
     await cache.removeQueryData(queryData1);
-    expect(cache.getHighestTargetId()).to.deep.equal(42);
+    expect(await cache.allocateTargetId()).to.deep.equal(46);
 
     await cache.removeQueryData(queryData3);
-    expect(cache.getHighestTargetId()).to.deep.equal(42);
+    expect(await cache.allocateTargetId()).to.deep.equal(48);
 
     // Verify that the highestTargetId persists restarts.
     const otherCache = new TestQueryCache(
@@ -319,19 +322,21 @@ function genericQueryCacheTests(): void {
       persistence.getQueryCache()
     );
     await otherCache.start();
-    expect(otherCache.getHighestTargetId()).to.deep.equal(42);
+    expect(await otherCache.allocateTargetId()).to.deep.equal(50);
   });
 
-  it('can get / set lastRemoteSnapshotVersion', () => {
-    expect(cache.getLastRemoteSnapshotVersion()).to.deep.equal(
+  it('can get / set lastRemoteSnapshotVersion', async () => {
+    expect(await cache.getLastRemoteSnapshotVersion()).to.deep.equal(
       SnapshotVersion.MIN
     );
 
     // Can set the snapshot version.
     return cache
       .setLastRemoteSnapshotVersion(version(42))
-      .then(() => {
-        expect(cache.getLastRemoteSnapshotVersion()).to.deep.equal(version(42));
+      .then(async () => {
+        expect(await cache.getLastRemoteSnapshotVersion()).to.deep.equal(
+          version(42)
+        );
       })
       .then(() => {
         // Verify snapshot version persists restarts.
@@ -339,8 +344,8 @@ function genericQueryCacheTests(): void {
           persistence,
           persistence.getQueryCache()
         );
-        return otherCache.start().then(() => {
-          expect(otherCache.getLastRemoteSnapshotVersion()).to.deep.equal(
+        return otherCache.start().then(async () => {
+          expect(await otherCache.getLastRemoteSnapshotVersion()).to.deep.equal(
             version(42)
           );
         });

--- a/packages/firestore/test/unit/local/test_query_cache.ts
+++ b/packages/firestore/test/unit/local/test_query_cache.ts
@@ -22,7 +22,6 @@ import { QueryCache } from '../../../src/local/query_cache';
 import { QueryData } from '../../../src/local/query_data';
 import { documentKeySet } from '../../../src/model/collections';
 import { DocumentKey } from '../../../src/model/document_key';
-import { TargetIdGenerator } from '../../../src/core/target_id_generator';
 
 /**
  * A wrapper around a QueryCache that automatically creates a

--- a/packages/firestore/test/unit/local/test_query_cache.ts
+++ b/packages/firestore/test/unit/local/test_query_cache.ts
@@ -28,9 +28,9 @@ import { TargetIdGenerator } from '../../../src/core/target_id_generator';
  * A wrapper around a QueryCache that automatically creates a
  * transaction around every operation to reduce test boilerplate.
  */
+// TODO(multitab): Adjust the `requirePrimaryLease` argument to match the usage
+// in the client.
 export class TestQueryCache {
-  private targetIdGenerator = TargetIdGenerator.forLocalStore();
-
   constructor(public persistence: Persistence, public cache: QueryCache) {}
 
   start(): Promise<void> {
@@ -80,8 +80,8 @@ export class TestQueryCache {
   }
 
   allocateTargetId(): Promise<TargetId> {
-    return this.persistence.runTransaction('allocateTargetId', true, txn => {
-      return this.cache.allocateTargetId(txn, this.targetIdGenerator);
+    return this.persistence.runTransaction('allocateTargetId', false, txn => {
+      return this.cache.allocateTargetId(txn);
     });
   }
 

--- a/packages/firestore/test/unit/specs/spec_builder.ts
+++ b/packages/firestore/test/unit/specs/spec_builder.ts
@@ -81,7 +81,7 @@ export class ClientMemoryState {
     this.queryMapping = {};
     this.limboMapping = {};
     this.activeTargets = {};
-    this.queryIdGenerator = TargetIdGenerator.forLocalStore();
+    this.queryIdGenerator = TargetIdGenerator.forQueryCache();
     this.limboIdGenerator = TargetIdGenerator.forSyncEngine();
   }
 }


### PR DESCRIPTION
This PR removes the in-memory state from the query cache. All tabs will generate target IDs based on the current state in IndexedDb.

I'm still using the TargetIdGenerator, but it now takes the value read from IndexedDb to generate the next Target ID.