### PR TITLE
 Falling back on ABORTED_ERROR

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ applications using Firebase services. This SDK is distributed via:
 To get started using Firebase, see
 [Add Firebase to your JavaScript Project](https://firebase.google.com/docs/web/setup).
 
+Current [Release Notes](https://firebase.google.com/support/release-notes/js)
+
 ## SDK Dev Workflow
 
 ### Prerequisites

--- a/packages/database-types/index.d.ts
+++ b/packages/database-types/index.d.ts
@@ -53,7 +53,12 @@ export interface OnDisconnect {
   update(values: Object, onComplete?: (a: Error | null) => any): Promise<any>;
 }
 
-type EventType = 'value' | 'child_added' | 'child_changed' | 'child_moved' | 'child_removed';
+type EventType =
+  | 'value'
+  | 'child_added'
+  | 'child_changed'
+  | 'child_moved'
+  | 'child_removed';
 
 export interface Query {
   endAt(value: number | string | boolean | null, key?: string): Query;

--- a/packages/firestore/src/core/firestore_client.ts
+++ b/packages/firestore/src/core/firestore_client.ts
@@ -57,7 +57,7 @@ import { ViewSnapshot } from './view_snapshot';
 const LOG_TAG = 'FirestoreClient';
 
 /** The DOMException code for an aborted operation. */
-const DOM_EXCEPTION_ABORTED = 22;
+const DOM_EXCEPTION_ABORTED = 20;
 
 /** The DOMException code for quota exceeded. */
 const DOM_EXCEPTION_QUOTA_EXCEEDED = 22;

--- a/packages/firestore/src/core/firestore_client.ts
+++ b/packages/firestore/src/core/firestore_client.ts
@@ -56,10 +56,13 @@ import { ViewSnapshot } from './view_snapshot';
 
 const LOG_TAG = 'FirestoreClient';
 
+/** The DOMException code for an aborted operation. */
+const DOM_EXCEPTION_ABORTED = 22;
+
 /** The DOMException code for quota exceeded. */
 const DOM_EXCEPTION_QUOTA_EXCEEDED = 22;
 
-/**
+    /**
  * FirestoreClient is a top-level class that constructs and owns all of the
  * pieces of the client SDK architecture. It is responsible for creating the
  * async queue that is shared by all of the other components in the system.
@@ -243,7 +246,10 @@ export class FirestoreClient {
       typeof DOMException !== 'undefined' &&
       error instanceof DOMException
     ) {
-      return error.code === DOM_EXCEPTION_QUOTA_EXCEEDED;
+      return (
+          error.code === DOM_EXCEPTION_QUOTA_EXCEEDED ||
+          error.code === DOM_EXCEPTION_ABORTED
+      );
     }
 
     return true;

--- a/packages/firestore/src/core/firestore_client.ts
+++ b/packages/firestore/src/core/firestore_client.ts
@@ -62,7 +62,7 @@ const DOM_EXCEPTION_ABORTED = 22;
 /** The DOMException code for quota exceeded. */
 const DOM_EXCEPTION_QUOTA_EXCEEDED = 22;
 
-    /**
+/**
  * FirestoreClient is a top-level class that constructs and owns all of the
  * pieces of the client SDK architecture. It is responsible for creating the
  * async queue that is shared by all of the other components in the system.
@@ -247,8 +247,8 @@ export class FirestoreClient {
       error instanceof DOMException
     ) {
       return (
-          error.code === DOM_EXCEPTION_QUOTA_EXCEEDED ||
-          error.code === DOM_EXCEPTION_ABORTED
+        error.code === DOM_EXCEPTION_QUOTA_EXCEEDED ||
+        error.code === DOM_EXCEPTION_ABORTED
       );
     }
 

--- a/packages/firestore/src/core/firestore_client.ts
+++ b/packages/firestore/src/core/firestore_client.ts
@@ -246,6 +246,12 @@ export class FirestoreClient {
       typeof DOMException !== 'undefined' &&
       error instanceof DOMException
     ) {
+      // We fall back to memory persistence if we cannot acquire an owner lease.
+      // This can happen can during a schema migration, or during the initial
+      // write of the `owner` lease.
+      // For both the `QuotaExceededError` and the  `AbortError`, it is safe to
+      // fall back to memory persistence since all modifications to IndexedDb
+      // failed to commit.
       return (
         error.code === DOM_EXCEPTION_QUOTA_EXCEEDED ||
         error.code === DOM_EXCEPTION_ABORTED


### PR DESCRIPTION
This allows us to fall back to memory persistence when we get ABORTED_ERR 20.

Reference: https://developer.mozilla.org/en-US/docs/Web/API/DOMException#Error_names

Fixes: https://github.com/firebase/firebase-js-sdk/issues/720