### PR TITLE
Add missing tslib dependency

### DIFF
--- a/packages/functions/package.json
+++ b/packages/functions/package.json
@@ -65,7 +65,8 @@
   "dependencies": {
     "@firebase/functions-types": "0.1.2",
     "@firebase/messaging-types": "0.2.2",
-    "isomorphic-fetch": "2.2.1"
+    "isomorphic-fetch": "2.2.1",
+    "tslib": "1.9.0"
   },
   "nyc": {
     "extension": [


### PR DESCRIPTION
`tslib` was missing from the `package.json`, so the helpers ended up being inlined. This PR fixes this. :)