### PR TITLE
Improves "Could not reach Firestore backend." log message.

### DIFF
--- a/packages/firestore/src/remote/online_state_tracker.ts
+++ b/packages/firestore/src/remote/online_state_tracker.ts
@@ -18,6 +18,7 @@ import { OnlineState } from '../core/types';
 import * as log from '../util/log';
 import { assert } from '../util/assert';
 import { AsyncQueue, TimerId } from '../util/async_queue';
+import { FirestoreError } from '../util/error';
 import { CancelablePromise } from '../util/promise';
 
 const LOG_TAG = 'OnlineStateTracker';
@@ -97,12 +98,10 @@ export class OnlineStateTracker {
             this.state === OnlineState.Unknown,
             'Timer should be canceled if we transitioned to a different state.'
           );
-          log.debug(
-            LOG_TAG,
-            `Watch stream didn't reach online or offline within ` +
-              `${ONLINE_STATE_TIMEOUT_MS}ms. Considering client offline.`
+          this.logClientOfflineWarningIfNecessary(
+            `Backend didn't respond within ${ONLINE_STATE_TIMEOUT_MS / 1000} ` +
+              `seconds.`
           );
-          this.logClientOfflineWarningIfNecessary();
           this.setAndBroadcast(OnlineState.Offline);
 
           // NOTE: handleWatchStreamFailure() will continue to increment
@@ -121,7 +120,7 @@ export class OnlineStateTracker {
    * allow multiple failures (based on MAX_WATCH_STREAM_FAILURES) before we
    * actually transition to the 'Offline' state.
    */
-  handleWatchStreamFailure(): void {
+  handleWatchStreamFailure(error: FirestoreError): void {
     if (this.state === OnlineState.Online) {
       this.setAndBroadcast(OnlineState.Unknown);
 
@@ -133,7 +132,12 @@ export class OnlineStateTracker {
       this.watchStreamFailures++;
       if (this.watchStreamFailures >= MAX_WATCH_STREAM_FAILURES) {
         this.clearOnlineStateTimer();
-        this.logClientOfflineWarningIfNecessary();
+
+        this.logClientOfflineWarningIfNecessary(
+          `Connection failed ${MAX_WATCH_STREAM_FAILURES} ` +
+            `times. Most recent error: ${error.toString()}`
+        );
+
         this.setAndBroadcast(OnlineState.Offline);
       }
     }
@@ -166,10 +170,18 @@ export class OnlineStateTracker {
     }
   }
 
-  private logClientOfflineWarningIfNecessary(): void {
+  private logClientOfflineWarningIfNecessary(details: string): void {
+    const message =
+      `Could not reach Cloud Firestore backend. ${details}\n` +
+      `This is purely an informational message and typically indicates ` +
+      `that your device does not have a healthy Internet connection at ` +
+      `the moment. The client will operate in offline mode until it is ` +
+      `able to successfully connect to the backend.`;
     if (this.shouldWarnClientIsOffline) {
-      log.error('Could not reach Firestore backend.');
+      log.error(message);
       this.shouldWarnClientIsOffline = false;
+    } else {
+      log.debug(LOG_TAG, message);
     }
   }
 

--- a/packages/firestore/src/remote/online_state_tracker.ts
+++ b/packages/firestore/src/remote/online_state_tracker.ts
@@ -173,10 +173,9 @@ export class OnlineStateTracker {
   private logClientOfflineWarningIfNecessary(details: string): void {
     const message =
       `Could not reach Cloud Firestore backend. ${details}\n` +
-      `This is purely an informational message and typically indicates ` +
-      `that your device does not have a healthy Internet connection at ` +
-      `the moment. The client will operate in offline mode until it is ` +
-      `able to successfully connect to the backend.`;
+      `This typically indicates that your device does not have a healthy ` +
+      `Internet connection at the moment. The client will operate in offline ` +
+      `mode until it is able to successfully connect to the backend.`;
     if (this.shouldWarnClientIsOffline) {
       log.error(message);
       this.shouldWarnClientIsOffline = false;

--- a/packages/firestore/src/remote/remote_store.ts
+++ b/packages/firestore/src/remote/remote_store.ts
@@ -323,12 +323,14 @@ export class RemoteStore {
 
     this.cleanUpWatchStreamState();
 
-    if (error) {
-      this.onlineStateTracker.handleWatchStreamFailure(error);
-    }
-
-    // If there was an error, retry the connection.
+    // If we still need the watch stream, retry the connection.
     if (this.shouldStartWatchStream()) {
+      // There should generally be an error if the watch stream was closed when
+      // it's still needed, but it's not quite worth asserting.
+      if (error) {
+        this.onlineStateTracker.handleWatchStreamFailure(error);
+      }
+
       this.startWatchStream();
     } else {
       // No need to restart watch stream because there are no active targets.

--- a/packages/firestore/src/remote/remote_store.ts
+++ b/packages/firestore/src/remote/remote_store.ts
@@ -315,16 +315,17 @@ export class RemoteStore {
     });
   }
 
-  private async onWatchStreamClose(
-    error: FirestoreError | null
-  ): Promise<void> {
+  private async onWatchStreamClose(error?: FirestoreError): Promise<void> {
     assert(
       this.isNetworkEnabled(),
       'onWatchStreamClose() should only be called when the network is enabled'
     );
 
     this.cleanUpWatchStreamState();
-    this.onlineStateTracker.handleWatchStreamFailure();
+
+    if (error) {
+      this.onlineStateTracker.handleWatchStreamFailure(error);
+    }
 
     // If there was an error, retry the connection.
     if (this.shouldStartWatchStream()) {


### PR DESCRIPTION
Improved message:

> Could not reach Cloud Firestore backend. Connection failed 2 times. Most recent error: FirebaseError: [code=unavailable]: 14 UNAVAILABLE: Connect Failed
> This is purely an informational message and typically indicates that your device does not have a healthy Internet connection at the moment. The client will operate in offline mode until it is able to successfully connect to the backend.
> 

Or:

> Could not reach Cloud Firestore backend. Backend didn't respond within 10 seconds.
> This is purely an informational message and typically indicates that your device does not have a healthy Internet connection at the moment. The client will operate in offline mode until it is able to successfully connect to the backend.