### PR TITLE
Tracking query state in local storage

### DIFF
--- a/packages/firestore/src/core/sync_engine.ts
+++ b/packages/firestore/src/core/sync_engine.ts
@@ -60,7 +60,10 @@ import {
   ViewDocumentChanges
 } from './view';
 import { ViewSnapshot } from './view_snapshot';
-import { SharedClientStateSyncer } from '../local/shared_client_state_syncer';
+import {
+  SharedClientStateSyncer,
+  QueryTargetState
+} from '../local/shared_client_state_syncer';
 import { ClientId, SharedClientState } from '../local/shared_client_state';
 import { SortedSet } from '../util/sorted_set';
 
@@ -665,6 +668,16 @@ export class SyncEngine implements RemoteSyncer, SharedClientStateSyncer {
   // PORTING NOTE: Multi-tab only
   getActiveClients(): Promise<ClientId[]> {
     return this.localStore.getActiveClients();
+  }
+
+  // PORTING NOTE: Multi-tab only
+  applyTargetState(
+    targetId: TargetId,
+    state: QueryTargetState,
+    error?: FirestoreError
+  ): Promise<void> {
+    // TODO(multitab): Implement this
+    return Promise.resolve();
   }
 
   async enableNetwork(): Promise<void> {

--- a/packages/firestore/src/core/sync_engine.ts
+++ b/packages/firestore/src/core/sync_engine.ts
@@ -680,6 +680,15 @@ export class SyncEngine implements RemoteSyncer, SharedClientStateSyncer {
     return Promise.resolve();
   }
 
+  // PORTING NOTE: Multi-tab only
+  applyActiveTargetsChange(
+    added: TargetId[],
+    removed: TargetId[]
+  ): Promise<void> {
+    // TODO(multitab): Implement this
+    return Promise.resolve();
+  }
+
   async enableNetwork(): Promise<void> {
     this.networkAllowed = true;
     if (this.isPrimary) {

--- a/packages/firestore/src/local/shared_client_state.ts
+++ b/packages/firestore/src/local/shared_client_state.ts
@@ -118,12 +118,12 @@ export interface SharedClientState {
   /**
    * Records that a query target has been updated.
    *
-   * Called by the primary client to notify secondary clients of updates to
-   * existing watch targets.
+   * Called by the primary client to notify secondary clients of document
+   * changes or state transitions for the provided query target.
    */
   trackQueryUpdate(
     targetId: TargetId,
-    state: 'active' | 'inactive' | 'rejected',
+    state: 'active' | 'current' | 'rejected',
     error?: FirestoreError
   ): void;
 
@@ -289,7 +289,7 @@ export class QueryTargetMetadata {
     let validData =
       typeof targetState === 'object' &&
       isSafeInteger(targetState.lastUpdateTime) &&
-      ['pending', 'active', 'inactive', 'rejected'].indexOf(
+      ['pending', 'active', 'current', 'rejected'].indexOf(
         targetState.state
       ) !== -1 &&
       (targetState.error === undefined ||
@@ -678,7 +678,7 @@ export class WebStorageSharedClientState implements SharedClientState {
 
   trackQueryUpdate(
     targetId: BatchId,
-    state: 'active' | 'inactive' | 'rejected',
+    state: 'active' | 'current' | 'rejected',
     error?: FirestoreError
   ): void {
     this.persistQueryTargetState(targetId, state, error);
@@ -954,7 +954,7 @@ export class MemorySharedClientState implements SharedClientState {
 
   trackQueryUpdate(
     targetId: BatchId,
-    state: 'active' | 'inactive' | 'rejected',
+    state: 'active' | 'current' | 'rejected',
     error?: FirestoreError
   ): void {
     // No op.

--- a/packages/firestore/src/local/shared_client_state_syncer.ts
+++ b/packages/firestore/src/local/shared_client_state_syncer.ts
@@ -18,8 +18,17 @@ import { BatchId, MutationBatchState, TargetId } from '../core/types';
 import { FirestoreError } from '../util/error';
 import { ClientId } from './shared_client_state';
 
-/** The different states of a watch target. */
-export type QueryTargetState = 'pending' | 'active' | 'inactive' | 'rejected';
+/**
+ * The different states of a watch target.
+ *
+ * When a secondary tab inserts a new target, it is marked 'pending'. The
+ * primary tab then transitions the target to 'active' once Watch has
+ * delivered the first snapshot. Once a Watch target is current, it transitions
+ * to 'current' from 'active'.
+ *
+ * Targets that get rejected from the backend are marked 'rejected'.
+ */
+export type QueryTargetState = 'pending' | 'active' | 'current' | 'rejected';
 
 /**
  * An interface that describes the actions the SharedClientState class needs to

--- a/packages/firestore/src/local/shared_client_state_syncer.ts
+++ b/packages/firestore/src/local/shared_client_state_syncer.ts
@@ -18,21 +18,8 @@ import { BatchId, MutationBatchState, TargetId } from '../core/types';
 import { FirestoreError } from '../util/error';
 import { ClientId } from './shared_client_state';
 
-/**
- * The different states of a watch target.
- *
- * When a secondary tab inserts a new target, it is marked 'pending'. The
- * primary tab then transitions the target to 'incomplete' once Watch has
- * delivered the first snapshot. Once a Watch target is current, it transitions
- * to 'current'.
- *
- * Targets that get rejected from the backend are marked 'rejected'.
- */
-export type QueryTargetState =
-  | 'pending'
-  | 'incomplete'
-  | 'current'
-  | 'rejected';
+/** The different states of a watch target. */
+export type QueryTargetState = 'not-current' | 'current' | 'rejected';
 
 /**
  * An interface that describes the actions the SharedClientState class needs to
@@ -56,6 +43,12 @@ export interface SharedClientStateSyncer {
     targetId: TargetId,
     state: QueryTargetState,
     error?: FirestoreError
+  ): Promise<void>;
+
+  /** Adds or removes Watch targets for queries from different tabs. */
+  applyActiveTargetsChange(
+    added: TargetId[],
+    removed: TargetId[]
   ): Promise<void>;
 
   /** Returns the IDs of the clients that are currently active. */

--- a/packages/firestore/src/local/shared_client_state_syncer.ts
+++ b/packages/firestore/src/local/shared_client_state_syncer.ts
@@ -14,9 +14,12 @@
  * limitations under the License.
  */
 
-import { BatchId, MutationBatchState } from '../core/types';
+import { BatchId, MutationBatchState, TargetId } from '../core/types';
 import { FirestoreError } from '../util/error';
 import { ClientId } from './shared_client_state';
+
+/** The different states of a watch target. */
+export type QueryTargetState = 'pending' | 'active' | 'inactive' | 'rejected';
 
 /**
  * An interface that describes the actions the SharedClientState class needs to
@@ -32,6 +35,13 @@ export interface SharedClientStateSyncer {
   applyBatchState(
     batchId: BatchId,
     state: MutationBatchState,
+    error?: FirestoreError
+  ): Promise<void>;
+
+  /** Applies a query target change from a different tab. */
+  applyTargetState(
+    targetId: TargetId,
+    state: QueryTargetState,
     error?: FirestoreError
   ): Promise<void>;
 

--- a/packages/firestore/src/local/shared_client_state_syncer.ts
+++ b/packages/firestore/src/local/shared_client_state_syncer.ts
@@ -22,13 +22,17 @@ import { ClientId } from './shared_client_state';
  * The different states of a watch target.
  *
  * When a secondary tab inserts a new target, it is marked 'pending'. The
- * primary tab then transitions the target to 'active' once Watch has
+ * primary tab then transitions the target to 'incomplete' once Watch has
  * delivered the first snapshot. Once a Watch target is current, it transitions
- * to 'current' from 'active'.
+ * to 'current'.
  *
  * Targets that get rejected from the backend are marked 'rejected'.
  */
-export type QueryTargetState = 'pending' | 'active' | 'current' | 'rejected';
+export type QueryTargetState =
+  | 'pending'
+  | 'incomplete'
+  | 'current'
+  | 'rejected';
 
 /**
  * An interface that describes the actions the SharedClientState class needs to

--- a/packages/firestore/src/model/collections.ts
+++ b/packages/firestore/src/model/collections.ts
@@ -20,6 +20,8 @@ import { SortedSet } from '../util/sorted_set';
 
 import { Document, MaybeDocument } from './document';
 import { DocumentKey } from './document_key';
+import { primitiveComparator } from '../util/misc';
+import { BatchId, TargetId } from '../core/types';
 
 /** Miscellaneous collection types / constants. */
 
@@ -51,4 +53,16 @@ export type DocumentKeySet = SortedSet<DocumentKey>;
 const EMPTY_DOCUMENT_KEY_SET = new SortedSet(DocumentKey.comparator);
 export function documentKeySet(): DocumentKeySet {
   return EMPTY_DOCUMENT_KEY_SET;
+}
+
+export type TargetIdSet = SortedSet<TargetId>;
+const EMPTY_TARGET_ID_SET = new SortedSet<number>(primitiveComparator);
+export function targetIdSet(): SortedSet<TargetId> {
+  return EMPTY_TARGET_ID_SET;
+}
+
+export type BatchIdSet = SortedSet<BatchId>;
+const EMPTY_BATCH_ID_SET = new SortedSet<number>(primitiveComparator);
+export function batchIdSet(): SortedSet<BatchId> {
+  return EMPTY_BATCH_ID_SET;
 }

--- a/packages/firestore/src/model/collections.ts
+++ b/packages/firestore/src/model/collections.ts
@@ -56,13 +56,13 @@ export function documentKeySet(): DocumentKeySet {
 }
 
 export type TargetIdSet = SortedSet<TargetId>;
-const EMPTY_TARGET_ID_SET = new SortedSet<number>(primitiveComparator);
+const EMPTY_TARGET_ID_SET = new SortedSet<TargetId>(primitiveComparator);
 export function targetIdSet(): SortedSet<TargetId> {
   return EMPTY_TARGET_ID_SET;
 }
 
 export type BatchIdSet = SortedSet<BatchId>;
-const EMPTY_BATCH_ID_SET = new SortedSet<number>(primitiveComparator);
+const EMPTY_BATCH_ID_SET = new SortedSet<BatchId>(primitiveComparator);
 export function batchIdSet(): SortedSet<BatchId> {
   return EMPTY_BATCH_ID_SET;
 }

--- a/packages/firestore/test/unit/local/persistence_test_helpers.ts
+++ b/packages/firestore/test/unit/local/persistence_test_helpers.ts
@@ -97,6 +97,10 @@ class NoOpSharedClientStateSyncer implements SharedClientStateSyncer {
     state: QueryTargetState,
     error?: FirestoreError
   ): Promise<void> {}
+  async applyActiveTargetsChange(
+    added: TargetId[],
+    removed: TargetId[]
+  ): Promise<void> {}
 }
 /**
  * Populates Web Storage with instance data from a pre-existing client.

--- a/packages/firestore/test/unit/local/persistence_test_helpers.ts
+++ b/packages/firestore/test/unit/local/persistence_test_helpers.ts
@@ -27,7 +27,10 @@ import { BatchId, MutationBatchState, TargetId } from '../../../src/core/types';
 import { BrowserPlatform } from '../../../src/platform_browser/browser_platform';
 import { AsyncQueue } from '../../../src/util/async_queue';
 import { User } from '../../../src/auth/user';
-import { SharedClientStateSyncer } from '../../../src/local/shared_client_state_syncer';
+import {
+  QueryTargetState,
+  SharedClientStateSyncer
+} from '../../../src/local/shared_client_state_syncer';
 import { FirestoreError } from '../../../src/util/error';
 import { AutoId } from '../../../src/util/misc';
 import { PlatformSupport } from '../../../src/platform/platform';
@@ -89,6 +92,11 @@ class NoOpSharedClientStateSyncer implements SharedClientStateSyncer {
   async getActiveClients(): Promise<ClientId[]> {
     return this.activeClients;
   }
+  async applyTargetState(
+    targetId: TargetId,
+    state: QueryTargetState,
+    error?: FirestoreError
+  ): Promise<void> {}
 }
 /**
  * Populates Web Storage with instance data from a pre-existing client.


### PR DESCRIPTION
This PR adds local storage notifications for query updates.

There are two kinds of updates that we track:

- Query changes from `inactive` to `pending` or `rejected`.
- A `pending` query receives an update (by setting a new lastUpdateTime).

