### PR TITLE
Allow field deletes for SetOptions.mergeFields

### DIFF
--- a/packages/firestore/src/api/user_data_converter.ts
+++ b/packages/firestore/src/api/user_data_converter.ts
@@ -242,6 +242,16 @@ class ParseContext {
     );
   }
 
+  /** Returns 'true' if 'fieldPath' was traversed when creating this context. */
+  contains(fieldPath: FieldPath): boolean {
+    return (
+      this.fieldMask.find(field => fieldPath.isPrefixOf(field)) !== undefined ||
+      this.fieldTransforms.find(transform =>
+        fieldPath.isPrefixOf(transform.field)
+      ) !== undefined
+    );
+  }
+
   private validatePath(): void {
     // TODO(b/34871131): Remove null check once we have proper paths for fields
     // within arrays.
@@ -345,12 +355,13 @@ export class UserDataConverter {
           fail('Expected stringOrFieldPath to be a string or a FieldPath');
         }
 
-        if (!updateData.contains(fieldPath)) {
+        if (!context.contains(fieldPath)) {
           throw new FirestoreError(
             Code.INVALID_ARGUMENT,
             `Field '${fieldPath}' is specified in your field mask but missing from your input data.`
           );
         }
+
         validatedFieldPaths.push(fieldPath);
       }
 

--- a/packages/firestore/test/integration/api/database.test.ts
+++ b/packages/firestore/test/integration/api/database.test.ts
@@ -139,7 +139,8 @@ apiDescribe('Database', persistence => {
         updated: false
       };
       const mergeData = {
-        time: firebase.firestore.FieldValue.serverTimestamp()
+        time: firebase.firestore.FieldValue.serverTimestamp(),
+        nested: { time: firebase.firestore.FieldValue.serverTimestamp() }
       };
       return doc
         .set(initialData)
@@ -149,6 +150,7 @@ apiDescribe('Database', persistence => {
           expect(docSnapshot.exists).to.be.ok;
           expect(docSnapshot.get('updated')).to.be.false;
           expect(docSnapshot.get('time')).to.be.an.instanceof(Timestamp);
+          expect(docSnapshot.get('nested.time')).to.be.an.instanceof(Timestamp);
         });
     });
   });
@@ -158,14 +160,17 @@ apiDescribe('Database', persistence => {
       const initialData = {
         untouched: true,
         foo: 'bar',
+        inner: { untouched: true, foo: 'bar' },
         nested: { untouched: true, foo: 'bar' }
       };
       const mergeData = {
         foo: firebase.firestore.FieldValue.delete(),
+        inner: { foo: firebase.firestore.FieldValue.delete() },
         nested: { foo: firebase.firestore.FieldValue.delete() }
       };
       const finalData = {
         untouched: true,
+        inner: { untouched: true },
         nested: { untouched: true }
       };
       return doc
@@ -175,6 +180,64 @@ apiDescribe('Database', persistence => {
         .then(docSnapshot => {
           expect(docSnapshot.exists).to.be.ok;
           expect(docSnapshot.data()).to.deep.equal(finalData);
+        });
+    });
+  });
+
+  it('can delete field using mergeFields', () => {
+    return withTestDoc(persistence, doc => {
+      const initialData = {
+        untouched: true,
+        foo: 'bar',
+        inner: { removed: true, foo: 'bar' },
+        nested: { untouched: true, foo: 'bar' }
+      };
+      const mergeData = {
+        foo: firebase.firestore.FieldValue.delete(),
+        inner: { foo: firebase.firestore.FieldValue.delete() },
+        nested: { untouched: firebase.firestore.FieldValue.delete(), foo: firebase.firestore.FieldValue.delete() }
+      };
+      const finalData = {
+        untouched: true,
+        inner: {},
+        nested: { untouched: true }
+      };
+      return doc
+        .set(initialData)
+        .then(() =>
+          doc.set(mergeData, { mergeFields: ['foo', 'inner', 'nested.foo'] })
+        )
+        .then(() => doc.get())
+        .then(docSnapshot => {
+          expect(docSnapshot.exists).to.be.ok;
+          expect(docSnapshot.data()).to.deep.equal(finalData);
+        });
+    });
+  });
+
+  it('can set server timestamps using mergeFields', () => {
+    return withTestDoc(persistence, doc => {
+      const initialData = {
+        untouched: true,
+        foo: 'bar',
+        nested: { untouched: true, foo: 'bar' }
+      };
+      const mergeData = {
+        foo: firebase.firestore.FieldValue.serverTimestamp(),
+        inner: { foo: firebase.firestore.FieldValue.serverTimestamp() },
+        nested: { foo: firebase.firestore.FieldValue.serverTimestamp() }
+      };
+      return doc
+        .set(initialData)
+        .then(() =>
+          doc.set(mergeData, { mergeFields: ['foo', 'inner', 'nested.foo'] })
+        )
+        .then(() => doc.get())
+        .then(docSnapshot => {
+          expect(docSnapshot.exists).to.be.ok;
+          expect(docSnapshot.get('foo')).to.be.instanceof(Timestamp);
+          expect(docSnapshot.get('inner.foo')).to.be.instanceof(Timestamp);
+          expect(docSnapshot.get('nested.foo')).to.be.instanceof(Timestamp);
         });
     });
   });

--- a/packages/firestore/test/integration/api/database.test.ts
+++ b/packages/firestore/test/integration/api/database.test.ts
@@ -195,7 +195,10 @@ apiDescribe('Database', persistence => {
       const mergeData = {
         foo: firebase.firestore.FieldValue.delete(),
         inner: { foo: firebase.firestore.FieldValue.delete() },
-        nested: { untouched: firebase.firestore.FieldValue.delete(), foo: firebase.firestore.FieldValue.delete() }
+        nested: {
+          untouched: firebase.firestore.FieldValue.delete(),
+          foo: firebase.firestore.FieldValue.delete()
+        }
       };
       const finalData = {
         untouched: true,


### PR DESCRIPTION
The validation for `set(data, mergeFields:...`) rejected field paths that pointed to field deletes/transforms since these are stripped from the update data.  This PR checks the field mask (for field deletes) and the list of field transforms (for server timestamps) to validate mergeFields.

Note that I could re-use the existing FieldMask.covers() function if I turned the array of field paths into a FieldMask.