### PR TITLE
Exporting firebase as namespace

### DIFF
--- a/packages/firebase/index.d.ts
+++ b/packages/firebase/index.d.ts
@@ -2042,3 +2042,4 @@ declare namespace firebase.firestore {
 }
 
 export = firebase;
+export as namespace firebase;


### PR DESCRIPTION
You can't use firebase in a TypeScript project that loads firebase via a CDN. If you use a CDN then firebase should be available as a global variable because you don't import firebase in your codebase and just use the global variable.
Therefore (because it's a UMD library) I added a `export as namespace`