### PR TITLE
Update Chrome and Safari version in cross-browser test.

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,6 +1,5 @@
-chrome 66
-firefox 60
-safari 11
-edge 17
-ie 11
-
+last 2 chrome version
+last 2 firefox version
+last 2 safari version
+last 2 edge version
+last 2 ie version

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,7 @@ matrix:
 
 jobs:
   allow_failures:
+    - script: yarn test:saucelabs
     - script: yarn test:saucelabs --database-firestore-only
   include:
     - stage: test

--- a/config/karma.saucelabs.js
+++ b/config/karma.saucelabs.js
@@ -85,11 +85,11 @@ function appiumLauncher(
  */
 const sauceLabsBrowsers = {
   // Desktop
-  Chrome_Windows: seleniumLauncher('chrome', 'Windows 10', '66.0'),
-  Firefox_Windows: seleniumLauncher('firefox', 'Windows 10', '60.0'),
-  Safari_macOS: seleniumLauncher('safari', 'macOS 10.13', '11.0'),
-  Edge_Windows: seleniumLauncher('MicrosoftEdge', 'Windows 10', '17.17134'),
-  IE_Windows: seleniumLauncher('internet explorer', 'Windows 10', '11.103')
+  Chrome_Windows: seleniumLauncher('chrome', 'Windows 10', 'latest'),
+  Firefox_Windows: seleniumLauncher('firefox', 'Windows 10', 'latest'),
+  Safari_macOS: seleniumLauncher('safari', 'macOS 10.13', 'latest'),
+  Edge_Windows: seleniumLauncher('MicrosoftEdge', 'Windows 10', 'latest'),
+  IE_Windows: seleniumLauncher('internet explorer', 'Windows 10', 'latest')
 
   // Mobile
   // Safari_iOS: appiumLauncher('Safari', 'iPhone Simulator', 'iOS', '11.2'),


### PR DESCRIPTION

The root cause of recent cannot start browser failure (https://travis-ci.org/firebase/firebase-js-sdk/jobs/386792434) is that Safari 11.0 used for our browser test is no longer supported by SauceLabs. This commit sets browsers to be always the lasted version available on SauceLabs.