### PR TITLE
Refine onSnapshot tests to ensure correct number of events emitted

### DIFF
--- a/packages/firestore/test/integration/api/database.test.ts
+++ b/packages/firestore/test/integration/api/database.test.ts
@@ -17,6 +17,7 @@
 import { expect } from 'chai';
 import * as firestore from '@firebase/firestore-types';
 
+import { EventsAccumulator } from '../util/events_accumulator';
 import { Deferred } from '../../util/promise';
 import firebase from '../util/firebase_export';
 import {
@@ -540,54 +541,35 @@ apiDescribe('Database', persistence => {
   it('DocumentSnapshot events for non existent document', () => {
     return withTestCollection(persistence, {}, col => {
       const doc = col.doc();
-      const deferred = new Deferred<void>();
-      let callbacks = 0;
-      doc.onSnapshot(snap => {
-        callbacks++;
-
-        if (callbacks === 1) {
-          expect(snap.exists).to.be.false;
-          expect(snap.data()).to.equal(undefined);
-          deferred.resolve();
-        } else if (callbacks === 2) {
-          throw new Error('Should not have received this callback');
-        }
+      const storeEvent = new EventsAccumulator<firestore.DocumentSnapshot>();
+      doc.onSnapshot(storeEvent.storeEvent);
+      return storeEvent.awaitEvent().then(snap => {
+        expect(snap.exists).to.be.false;
+        expect(snap.data()).to.equal(undefined);
+        return storeEvent.assertNoAdditionalEvents();
       });
-
-      return deferred.promise;
     });
   });
 
   it('DocumentSnapshot events for add data to document', () => {
     return withTestCollection(persistence, {}, col => {
       const doc = col.doc();
-      const emptyDeferred = new Deferred<void>();
-      const dataDeferred = new Deferred<void>();
-      let callbacks = 0;
-      doc.onSnapshot({ includeMetadataChanges: true }, snap => {
-        callbacks++;
-
-        if (callbacks === 1) {
+      const storeEvent = new EventsAccumulator<firestore.DocumentSnapshot>();
+      doc.onSnapshot({ includeMetadataChanges: true }, storeEvent.storeEvent);
+      return storeEvent.awaitEvent().then(snap => {
           expect(snap.exists).to.be.false;
           expect(snap.data()).to.equal(undefined);
-          emptyDeferred.resolve();
-        } else if (callbacks === 2) {
-          expect(snap.exists).to.be.true;
-          expect(snap.data()).to.deep.equal({ a: 1 });
-          expect(snap.metadata.hasPendingWrites).to.be.true;
-        } else if (callbacks === 3) {
-          expect(snap.exists).to.be.true;
-          expect(snap.data()).to.deep.equal({ a: 1 });
-          expect(snap.metadata.hasPendingWrites).to.be.false;
-          dataDeferred.resolve();
-        } else {
-          throw new Error('Should not have received this callback');
-        }
-      });
-
-      return emptyDeferred.promise
-        .then(() => doc.set({ a: 1 }))
-        .then(() => dataDeferred.promise);
+        })
+      .then(() => doc.set({ a: 1 }))
+      .then(() => storeEvent.awaitEvent()).then(snap => {
+        expect(snap.exists).to.be.true;
+        expect(snap.data()).to.deep.equal({ a: 1 });
+        expect(snap.metadata.hasPendingWrites).to.be.true;
+      }).then(() => storeEvent.awaitEvent()).then(snap => {
+        expect(snap.exists).to.be.true;
+        expect(snap.data()).to.deep.equal({ a: 1 });
+        expect(snap.metadata.hasPendingWrites).to.be.false;
+      }).then(() => storeEvent.assertNoAdditionalEvents());
     });
   });
 
@@ -597,31 +579,20 @@ apiDescribe('Database', persistence => {
 
     return withTestCollection(persistence, { key1: initialData }, col => {
       const doc = col.doc('key1');
-      const initialDeferred = new Deferred<void>();
-      const changedDeferred = new Deferred<void>();
-      let callbacks = 0;
-      doc.onSnapshot({ includeMetadataChanges: true }, snap => {
-        callbacks++;
-
-        if (callbacks === 1) {
+      const storeEvent = new EventsAccumulator<firestore.DocumentSnapshot>();
+      doc.onSnapshot({ includeMetadataChanges: true }, storeEvent.storeEvent);
+      return storeEvent.awaitEvent().then(snap => {
           expect(snap.data()).to.deep.equal(initialData);
           expect(snap.metadata.hasPendingWrites).to.be.false;
-          initialDeferred.resolve();
-        } else if (callbacks === 2) {
+      })
+      .then(() => doc.set(changedData))
+      .then(() => storeEvent.awaitEvent()).then(snap => {
           expect(snap.data()).to.deep.equal(changedData);
           expect(snap.metadata.hasPendingWrites).to.be.true;
-        } else if (callbacks === 3) {
+      }).then(() => storeEvent.awaitEvent()).then(snap => {
           expect(snap.data()).to.deep.equal(changedData);
           expect(snap.metadata.hasPendingWrites).to.be.false;
-          changedDeferred.resolve();
-        } else {
-          throw new Error('Should not have received this callback');
-        }
-      });
-
-      return initialDeferred.promise
-        .then(() => doc.set(changedData))
-        .then(() => changedDeferred.promise);
+      }).then(() => storeEvent.assertNoAdditionalEvents());
     });
   });
 
@@ -630,30 +601,19 @@ apiDescribe('Database', persistence => {
 
     return withTestCollection(persistence, { key1: initialData }, col => {
       const doc = col.doc('key1');
-      const initialDeferred = new Deferred<void>();
-      const deletedDeferred = new Deferred<void>();
-      let callbacks = 0;
-      doc.onSnapshot({ includeMetadataChanges: true }, snap => {
-        callbacks++;
-
-        if (callbacks === 1) {
+      const storeEvent = new EventsAccumulator<firestore.DocumentSnapshot>();
+      doc.onSnapshot({ includeMetadataChanges: true }, storeEvent.storeEvent);
+      return storeEvent.awaitEvent().then(snap => {
           expect(snap.exists).to.be.true;
           expect(snap.data()).to.deep.equal(initialData);
           expect(snap.metadata.hasPendingWrites).to.be.false;
-          initialDeferred.resolve();
-        } else if (callbacks === 2) {
+      })
+      .then(() => doc.delete())
+      .then(() => storeEvent.awaitEvent()).then(snap => {
           expect(snap.exists).to.be.false;
           expect(snap.data()).to.equal(undefined);
           expect(snap.metadata.hasPendingWrites).to.be.false;
-          deletedDeferred.resolve();
-        } else {
-          throw new Error('Should not have received this callback');
-        }
-      });
-
-      return initialDeferred.promise
-        .then(() => doc.delete())
-        .then(() => deletedDeferred.promise);
+      }).then(() => storeEvent.assertNoAdditionalEvents());
     });
   });
 

--- a/packages/firestore/test/integration/api/database.test.ts
+++ b/packages/firestore/test/integration/api/database.test.ts
@@ -545,11 +545,11 @@ apiDescribe('Database', persistence => {
       doc.onSnapshot(snap => {
         callbacks++;
 
-        if (callbacks == 1) {
+        if (callbacks === 1) {
           expect(snap.exists).to.be.false;
           expect(snap.data()).to.equal(undefined);
           deferred.resolve();
-        } else if (callbacks == 2) {
+        } else if (callbacks === 2) {
           throw new Error('Should not have received this callback');
         }
       });
@@ -567,15 +567,15 @@ apiDescribe('Database', persistence => {
       doc.onSnapshot({ includeMetadataChanges: true }, snap => {
         callbacks++;
 
-        if (callbacks == 1) {
+        if (callbacks === 1) {
           expect(snap.exists).to.be.false;
           expect(snap.data()).to.equal(undefined);
           emptyDeferred.resolve();
-        } else if (callbacks == 2) {
+        } else if (callbacks === 2) {
           expect(snap.exists).to.be.true;
           expect(snap.data()).to.deep.equal({ a: 1 });
           expect(snap.metadata.hasPendingWrites).to.be.true;
-        } else if (callbacks == 3) {
+        } else if (callbacks === 3) {
           expect(snap.exists).to.be.true;
           expect(snap.data()).to.deep.equal({ a: 1 });
           expect(snap.metadata.hasPendingWrites).to.be.false;
@@ -603,14 +603,14 @@ apiDescribe('Database', persistence => {
       doc.onSnapshot({ includeMetadataChanges: true }, snap => {
         callbacks++;
 
-        if (callbacks == 1) {
+        if (callbacks === 1) {
           expect(snap.data()).to.deep.equal(initialData);
           expect(snap.metadata.hasPendingWrites).to.be.false;
           initialDeferred.resolve();
-        } else if (callbacks == 2) {
+        } else if (callbacks === 2) {
           expect(snap.data()).to.deep.equal(changedData);
           expect(snap.metadata.hasPendingWrites).to.be.true;
-        } else if (callbacks == 3) {
+        } else if (callbacks === 3) {
           expect(snap.data()).to.deep.equal(changedData);
           expect(snap.metadata.hasPendingWrites).to.be.false;
           changedDeferred.resolve();
@@ -636,12 +636,12 @@ apiDescribe('Database', persistence => {
       doc.onSnapshot({ includeMetadataChanges: true }, snap => {
         callbacks++;
 
-        if (callbacks == 1) {
+        if (callbacks === 1) {
           expect(snap.exists).to.be.true;
           expect(snap.data()).to.deep.equal(initialData);
           expect(snap.metadata.hasPendingWrites).to.be.false;
           initialDeferred.resolve();
-        } else if (callbacks == 2) {
+        } else if (callbacks === 2) {
           expect(snap.exists).to.be.false;
           expect(snap.data()).to.equal(undefined);
           expect(snap.metadata.hasPendingWrites).to.be.false;

--- a/packages/firestore/test/integration/api/database.test.ts
+++ b/packages/firestore/test/integration/api/database.test.ts
@@ -564,105 +564,96 @@ apiDescribe('Database', persistence => {
       const emptyDeferred = new Deferred<void>();
       const dataDeferred = new Deferred<void>();
       let callbacks = 0;
-      doc.onSnapshot(
-        { includeMetadataChanges: true },
-        snap => {
-          callbacks++;
+      doc.onSnapshot({ includeMetadataChanges: true }, snap => {
+        callbacks++;
 
-          if (callbacks == 1) {
-            expect(snap.exists).to.be.false;
-            expect(snap.data()).to.equal(undefined);
-            emptyDeferred.resolve();
-          } else if (callbacks == 2) {
-            expect(snap.exists).to.be.true;
-            expect(snap.data()).to.deep.equal({"a": 1});
-            expect(snap.metadata.hasPendingWrites).to.be.true;
-          } else if (callbacks == 3) {
-            expect(snap.exists).to.be.true;
-            expect(snap.data()).to.deep.equal({"a": 1});
-            expect(snap.metadata.hasPendingWrites).to.be.false;
-            dataDeferred.resolve();
-          } else {
-            throw new Error('Should not have received this callback');
-          }
+        if (callbacks == 1) {
+          expect(snap.exists).to.be.false;
+          expect(snap.data()).to.equal(undefined);
+          emptyDeferred.resolve();
+        } else if (callbacks == 2) {
+          expect(snap.exists).to.be.true;
+          expect(snap.data()).to.deep.equal({ a: 1 });
+          expect(snap.metadata.hasPendingWrites).to.be.true;
+        } else if (callbacks == 3) {
+          expect(snap.exists).to.be.true;
+          expect(snap.data()).to.deep.equal({ a: 1 });
+          expect(snap.metadata.hasPendingWrites).to.be.false;
+          dataDeferred.resolve();
+        } else {
+          throw new Error('Should not have received this callback');
         }
-      );
+      });
 
       return emptyDeferred.promise
-          .then(() => doc.set({"a": 1}))
-          .then(() => dataDeferred.promise);
+        .then(() => doc.set({ a: 1 }))
+        .then(() => dataDeferred.promise);
     });
   });
 
   it('DocumentSnapshot events for change data in document', () => {
-    const initialData = {"a": 1};
-    const changedData = {"b": 2};
+    const initialData = { a: 1 };
+    const changedData = { b: 2 };
 
-    return withTestCollection(persistence, {key1: initialData}, col => {
-      const doc = col.doc("key1");
+    return withTestCollection(persistence, { key1: initialData }, col => {
+      const doc = col.doc('key1');
       const initialDeferred = new Deferred<void>();
       const changedDeferred = new Deferred<void>();
       let callbacks = 0;
-      doc.onSnapshot(
-        { includeMetadataChanges: true },
-        snap => {
-          callbacks++;
+      doc.onSnapshot({ includeMetadataChanges: true }, snap => {
+        callbacks++;
 
-          if (callbacks == 1) {
-            expect(snap.data()).to.deep.equal(initialData);
-            expect(snap.metadata.hasPendingWrites).to.be.false;
-            initialDeferred.resolve();
-          } else if (callbacks == 2) {
-            expect(snap.data()).to.deep.equal(changedData);
-            expect(snap.metadata.hasPendingWrites).to.be.true;
-          } else if (callbacks == 3) {
-            expect(snap.data()).to.deep.equal(changedData);
-            expect(snap.metadata.hasPendingWrites).to.be.false;
-            changedDeferred.resolve();
-          } else {
-            throw new Error('Should not have received this callback');
-          }
+        if (callbacks == 1) {
+          expect(snap.data()).to.deep.equal(initialData);
+          expect(snap.metadata.hasPendingWrites).to.be.false;
+          initialDeferred.resolve();
+        } else if (callbacks == 2) {
+          expect(snap.data()).to.deep.equal(changedData);
+          expect(snap.metadata.hasPendingWrites).to.be.true;
+        } else if (callbacks == 3) {
+          expect(snap.data()).to.deep.equal(changedData);
+          expect(snap.metadata.hasPendingWrites).to.be.false;
+          changedDeferred.resolve();
+        } else {
+          throw new Error('Should not have received this callback');
         }
-      );
+      });
 
       return initialDeferred.promise
-          .then(() => doc.set(changedData))
-          .then(() => changedDeferred.promise);
+        .then(() => doc.set(changedData))
+        .then(() => changedDeferred.promise);
     });
   });
 
-  it('DocumentSnapshot TODO events for delete data in document', () => {
-    const initialData = {"a": 1};
+  it('DocumentSnapshot events for delete data in document', () => {
+    const initialData = { a: 1 };
 
-    return withTestCollection(persistence, {key1: initialData}, col => {
-      const doc = col.doc("key1");
+    return withTestCollection(persistence, { key1: initialData }, col => {
+      const doc = col.doc('key1');
       const initialDeferred = new Deferred<void>();
       const deletedDeferred = new Deferred<void>();
       let callbacks = 0;
-      doc.onSnapshot(
-        { includeMetadataChanges: true },
-        snap => {
-          callbacks++;
+      doc.onSnapshot({ includeMetadataChanges: true }, snap => {
+        callbacks++;
 
-          if (callbacks == 1) {
-            expect(snap.exists).to.be.true;
-            expect(snap.data()).to.deep.equal(initialData);
-            expect(snap.metadata.hasPendingWrites).to.be.false;
-            initialDeferred.resolve();
-          } else if (callbacks == 2) {
-            expect(snap.exists).to.be.false;
-            expect(snap.data()).to.equal(undefined);
-            expect(snap.metadata.hasPendingWrites).to.be.false;
-            deletedDeferred.resolve();
-          } else {
-            throw new Error('Should not have received this callback');
-          }
+        if (callbacks == 1) {
+          expect(snap.exists).to.be.true;
+          expect(snap.data()).to.deep.equal(initialData);
+          expect(snap.metadata.hasPendingWrites).to.be.false;
+          initialDeferred.resolve();
+        } else if (callbacks == 2) {
+          expect(snap.exists).to.be.false;
+          expect(snap.data()).to.equal(undefined);
+          expect(snap.metadata.hasPendingWrites).to.be.false;
+          deletedDeferred.resolve();
+        } else {
+          throw new Error('Should not have received this callback');
         }
-      );
+      });
 
       return initialDeferred.promise
-          .then(() => doc.delete())
-          .then(() => deletedDeferred.promise);
+        .then(() => doc.delete())
+        .then(() => deletedDeferred.promise);
     });
   });
 

--- a/packages/firestore/test/integration/api/database.test.ts
+++ b/packages/firestore/test/integration/api/database.test.ts
@@ -556,20 +556,26 @@ apiDescribe('Database', persistence => {
       const doc = col.doc();
       const storeEvent = new EventsAccumulator<firestore.DocumentSnapshot>();
       doc.onSnapshot({ includeMetadataChanges: true }, storeEvent.storeEvent);
-      return storeEvent.awaitEvent().then(snap => {
+      return storeEvent
+        .awaitEvent()
+        .then(snap => {
           expect(snap.exists).to.be.false;
           expect(snap.data()).to.equal(undefined);
         })
-      .then(() => doc.set({ a: 1 }))
-      .then(() => storeEvent.awaitEvent()).then(snap => {
-        expect(snap.exists).to.be.true;
-        expect(snap.data()).to.deep.equal({ a: 1 });
-        expect(snap.metadata.hasPendingWrites).to.be.true;
-      }).then(() => storeEvent.awaitEvent()).then(snap => {
-        expect(snap.exists).to.be.true;
-        expect(snap.data()).to.deep.equal({ a: 1 });
-        expect(snap.metadata.hasPendingWrites).to.be.false;
-      }).then(() => storeEvent.assertNoAdditionalEvents());
+        .then(() => doc.set({ a: 1 }))
+        .then(() => storeEvent.awaitEvent())
+        .then(snap => {
+          expect(snap.exists).to.be.true;
+          expect(snap.data()).to.deep.equal({ a: 1 });
+          expect(snap.metadata.hasPendingWrites).to.be.true;
+        })
+        .then(() => storeEvent.awaitEvent())
+        .then(snap => {
+          expect(snap.exists).to.be.true;
+          expect(snap.data()).to.deep.equal({ a: 1 });
+          expect(snap.metadata.hasPendingWrites).to.be.false;
+        })
+        .then(() => storeEvent.assertNoAdditionalEvents());
     });
   });
 
@@ -581,18 +587,24 @@ apiDescribe('Database', persistence => {
       const doc = col.doc('key1');
       const storeEvent = new EventsAccumulator<firestore.DocumentSnapshot>();
       doc.onSnapshot({ includeMetadataChanges: true }, storeEvent.storeEvent);
-      return storeEvent.awaitEvent().then(snap => {
+      return storeEvent
+        .awaitEvent()
+        .then(snap => {
           expect(snap.data()).to.deep.equal(initialData);
           expect(snap.metadata.hasPendingWrites).to.be.false;
-      })
-      .then(() => doc.set(changedData))
-      .then(() => storeEvent.awaitEvent()).then(snap => {
+        })
+        .then(() => doc.set(changedData))
+        .then(() => storeEvent.awaitEvent())
+        .then(snap => {
           expect(snap.data()).to.deep.equal(changedData);
           expect(snap.metadata.hasPendingWrites).to.be.true;
-      }).then(() => storeEvent.awaitEvent()).then(snap => {
+        })
+        .then(() => storeEvent.awaitEvent())
+        .then(snap => {
           expect(snap.data()).to.deep.equal(changedData);
           expect(snap.metadata.hasPendingWrites).to.be.false;
-      }).then(() => storeEvent.assertNoAdditionalEvents());
+        })
+        .then(() => storeEvent.assertNoAdditionalEvents());
     });
   });
 
@@ -603,17 +615,21 @@ apiDescribe('Database', persistence => {
       const doc = col.doc('key1');
       const storeEvent = new EventsAccumulator<firestore.DocumentSnapshot>();
       doc.onSnapshot({ includeMetadataChanges: true }, storeEvent.storeEvent);
-      return storeEvent.awaitEvent().then(snap => {
+      return storeEvent
+        .awaitEvent()
+        .then(snap => {
           expect(snap.exists).to.be.true;
           expect(snap.data()).to.deep.equal(initialData);
           expect(snap.metadata.hasPendingWrites).to.be.false;
-      })
-      .then(() => doc.delete())
-      .then(() => storeEvent.awaitEvent()).then(snap => {
+        })
+        .then(() => doc.delete())
+        .then(() => storeEvent.awaitEvent())
+        .then(snap => {
           expect(snap.exists).to.be.false;
           expect(snap.data()).to.equal(undefined);
           expect(snap.metadata.hasPendingWrites).to.be.false;
-      }).then(() => storeEvent.assertNoAdditionalEvents());
+        })
+        .then(() => storeEvent.assertNoAdditionalEvents());
     });
   });
 

--- a/packages/firestore/test/integration/api/query.test.ts
+++ b/packages/firestore/test/integration/api/query.test.ts
@@ -243,6 +243,7 @@ apiDescribe('Queries', persistence => {
           return storeEvent.assertNoAdditionalEvents();
         })
         .then(() => {
+          storeEvent.allowAdditionalEvents();
           return coll.doc('b').set({ v: 'b1' });
         })
         .then(() => {

--- a/packages/firestore/test/integration/util/events_accumulator.ts
+++ b/packages/firestore/test/integration/util/events_accumulator.ts
@@ -32,7 +32,9 @@ export class EventsAccumulator<
 
   storeEvent: (evt: T) => void = (evt: T) => {
     if (this.rejectAdditionalEvents) {
-      throw new Error("Additional event detected after assertNoAdditionalEvents called");
+      throw new Error(
+        'Additional event detected after assertNoAdditionalEvents called'
+      );
     }
     this.events.push(evt);
     this.checkFulfilled();

--- a/packages/firestore/test/integration/util/events_accumulator.ts
+++ b/packages/firestore/test/integration/util/events_accumulator.ts
@@ -34,6 +34,7 @@ export class EventsAccumulator<
     if (this.rejectAdditionalEvents) {
       throw new Error(
         'Additional event detected after assertNoAdditionalEvents called'
+        + JSON.stringify(evt)
       );
     }
     this.events.push(evt);

--- a/packages/firestore/test/integration/util/events_accumulator.ts
+++ b/packages/firestore/test/integration/util/events_accumulator.ts
@@ -100,6 +100,10 @@ export class EventsAccumulator<
     });
   }
 
+  allowAdditionalEvents() : void {
+    this.rejectAdditionalEvents = false;
+  }
+
   private checkFulfilled(): void {
     if (this.deferred !== null && this.events.length >= this.waitingFor) {
       const events = this.events.splice(0, this.waitingFor);

--- a/packages/firestore/test/integration/util/events_accumulator.ts
+++ b/packages/firestore/test/integration/util/events_accumulator.ts
@@ -100,7 +100,7 @@ export class EventsAccumulator<
     });
   }
 
-  allowAdditionalEvents() : void {
+  allowAdditionalEvents(): void {
     this.rejectAdditionalEvents = false;
   }
 

--- a/packages/firestore/test/integration/util/events_accumulator.ts
+++ b/packages/firestore/test/integration/util/events_accumulator.ts
@@ -28,8 +28,12 @@ export class EventsAccumulator<
   private events: T[] = [];
   private waitingFor: number;
   private deferred: Deferred<T[]> | null = null;
+  private rejectAdditionalEvents = false;
 
   storeEvent: (evt: T) => void = (evt: T) => {
+    if (this.rejectAdditionalEvents) {
+      throw new Error("Additional event detected after assertNoAdditionalEvents called");
+    }
     this.events.push(evt);
     this.checkFulfilled();
   };
@@ -77,6 +81,7 @@ export class EventsAccumulator<
   }
 
   assertNoAdditionalEvents(): Promise<void> {
+    this.rejectAdditionalEvents = true;
     return new Promise((resolve: (val: void) => void, reject) => {
       setTimeout(() => {
         if (this.events.length > 0) {


### PR DESCRIPTION
Behaviour was already correct. This PR is effectively just porting the
existing iOS tests to typescript.

http://b/32764756