### PR TITLE
Initializing WatchStreamAggregator before starting stream

### DIFF
--- a/packages/firestore/src/remote/remote_store.ts
+++ b/packages/firestore/src/remote/remote_store.ts
@@ -259,13 +259,13 @@ export class RemoteStore implements TargetMetadataProvider {
       this.shouldStartWatchStream(),
       'startWriteStream() called when shouldStartWatchStream() is false.'
     );
+                   
+    this.watchChangeAggregator = new WatchChangeAggregator(this);
     this.watchStream.start({
       onOpen: this.onWatchStreamOpen.bind(this),
       onClose: this.onWatchStreamClose.bind(this),
       onWatchChange: this.onWatchStreamChange.bind(this)
     });
-
-    this.watchChangeAggregator = new WatchChangeAggregator(this);
     this.onlineStateTracker.handleWatchStreamStart();
   }
 


### PR DESCRIPTION
The WatchStreamAggregator has to be started before the stream, as at least on iOS we can receive message during stream start.
