### PR TITLE
Draining on client switches

### DIFF
--- a/packages/firestore/test/unit/specs/spec_builder.ts
+++ b/packages/firestore/test/unit/specs/spec_builder.ts
@@ -810,8 +810,8 @@ export class MultiClientSpecBuilder extends SpecBuilder {
 
     this.activeClientIndex = clientIndex;
     this.config.numClients = Math.max(
-        this.config.numClients,
-        this.activeClientIndex + 1
+      this.config.numClients,
+      this.activeClientIndex + 1
     );
 
     return this;

--- a/packages/firestore/test/unit/specs/spec_builder.ts
+++ b/packages/firestore/test/unit/specs/spec_builder.ts
@@ -271,14 +271,6 @@ export class SpecBuilder {
     return this;
   }
 
-  drainQueue(): this {
-    this.nextStep();
-    this.currentStep = {
-      drainQueue: true
-    };
-    return this;
-  }
-
   changeUser(uid: string | null): this {
     this.nextStep();
     this.currentStep = { changeUser: uid };
@@ -812,11 +804,16 @@ export class MultiClientSpecBuilder extends SpecBuilder {
     // state, we don't need to use a different SpecBuilder instance for each
     // client.
     this.nextStep();
+    this.currentStep = {
+      drainQueue: true
+    };
+
     this.activeClientIndex = clientIndex;
     this.config.numClients = Math.max(
-      this.config.numClients,
-      this.activeClientIndex + 1
+        this.config.numClients,
+        this.activeClientIndex + 1
     );
+
     return this;
   }
 

--- a/packages/firestore/test/unit/specs/write_spec.test.ts
+++ b/packages/firestore/test/unit/specs/write_spec.test.ts
@@ -696,7 +696,6 @@ describeSpec('Writes:', [], () => {
           modified: [docV2]
         })
         .client(1)
-        .drainQueue() // Process all local storage events.
         .expectEvents(query, {
           hasPendingWrites: true,
           fromCache: true,
@@ -709,7 +708,6 @@ describeSpec('Writes:', [], () => {
           modified: [docV3]
         })
         .client(0)
-        .drainQueue() // Process all local storage events.
         .expectEvents(query, {
           hasPendingWrites: true,
           modified: [docV3]
@@ -745,7 +743,6 @@ describeSpec('Writes:', [], () => {
         added: [localDoc]
       })
       .client(0)
-      .drainQueue()
       .expectEvents(query, {
         hasPendingWrites: true,
         added: [localDoc]
@@ -757,7 +754,6 @@ describeSpec('Writes:', [], () => {
         metadata: [remoteDoc]
       })
       .client(1)
-      .drainQueue()
       .expectUserCallbacks({
         acknowledged: ['collection/a']
       });
@@ -794,7 +790,6 @@ describeSpec('Writes:', [], () => {
         added: [localDoc]
       })
       .client(0)
-      .drainQueue()
       .expectEvents(query, {
         hasPendingWrites: true,
         added: [localDoc]
@@ -810,7 +805,6 @@ describeSpec('Writes:', [], () => {
         removed: [localDoc]
       })
       .client(1)
-      .drainQueue()
       .expectUserCallbacks({
         rejected: ['collection/a']
       })


### PR DESCRIPTION
I am getting kind of annoyed at writing `drainQueue()` after every client switch in the SpecTests. This should solve that.