### PR TITLE
Email alerts after SauceLabs browser test failures.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,9 @@ env:
   global:
     - CXX=g++-4.8
 before_install:
+  - sudo apt-get -qq update
+  - sudo apt-get install aha bsd-mailx jq ssmtp
+  - echo -e $SSMTP_CONFIG | sudo tee /etc/ssmtp/ssmtp.conf
   # Yarn defaults to an old version, make sure we
   # get an up to date version
   - npm install -g yarn
@@ -27,26 +30,34 @@ addons:
       - google-chrome-stable
       - g++-4.8
 
+# Defaults to cloning only the current branch with depth 50.
+# This allows all branches to be cloned, so that we can obtain a list of commits
+# as well as committers' name and email. This increases git cloning time by ~1s.
+git:
+  depth: false
+
 matrix:
   fast_finish: true
 
 jobs:
   allow_failures:
+    - script: ./scripts/saucelabs/run_test_for_push_build.sh
     - script: yarn test:saucelabs
-    - script: yarn test:saucelabs --database-firestore-only
   include:
     - stage: test
       script: xvfb-run yarn test
       after_success: yarn test:coverage
       env: '#= chrome headless test'
     - stage: test
-      script: yarn test:saucelabs
-      env: '#= cross browser test: all packages except database and firestore'
+      script: ./scripts/saucelabs/run_test_for_push_build.sh
+      after_failure: ./scripts/saucelabs/report_test_results.sh
+      env: '#= saucelabs browser test --- push build'
       if: type = push
     - stage: test
-      script: yarn test:saucelabs --database-firestore-only
-      env: '#= cross browser test: database and firestore (allow_failures)'
-      if: type = push
+      script: yarn test:saucelabs
+      after_failure: ./scripts/saucelabs/report_test_results.sh
+      env: '#= saucelabs browser test --- cron job'
+      if: type = cron
     - stage: deploy
       script: skip
       # NPM Canary Build Config

--- a/config/karma.saucelabs.js
+++ b/config/karma.saucelabs.js
@@ -27,7 +27,6 @@ const karmaBase = require('./karma.base');
  */
 function getTestFiles() {
   const root = path.resolve(__dirname, '..');
-  console.log('argv:', argv);
   const packages = argv['packages'] || ['{packages,integration}/*'];
   // Firestore integration test excluded from automated test.
   // See integration/firestore/package.json.
@@ -35,13 +34,11 @@ function getTestFiles() {
     packages.map(x => path.join(x, 'karma.conf.js')),
     { ignore: 'integration/firestore/*' }
   );
-  console.log('configs:', configs);
   let files = configs.map(x => {
     let patterns = require(path.resolve(root, x)).files;
     let dirname = path.dirname(x);
     return patterns.map(p => path.resolve(dirname, p));
   });
-  console.log('files:', files);
   return [].concat(...files);
 }
 

--- a/scripts/saucelabs/report_test_results.sh
+++ b/scripts/saucelabs/report_test_results.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+# Copyright 2018 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS-IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Sends out an email in case of browser test failures, with summary of
+# the test result.
+
+sleep 10 # Wait for log file to be accessible via below url.
+
+TRAVIS_LOG_URL=https://api.travis-ci.org/v3/job/$TRAVIS_JOB_ID/log.txt
+TRAVIS_BUILD_URL=https://travis-ci.org/$TRAVIS_REPO_SLUG/builds/$TRAVIS_BUILD_ID
+
+BASE_BRANCH=origin/master
+
+JS_CORE_EMAIL="jscore-team@google.com"
+
+LAST_COMMITTER_NAME=$(git log -1 $TRAVIS_COMMIT --pretty="%cN")
+LAST_COMMITTER_EMAIL=$(git log -1 $TRAVIS_COMMIT --pretty="%cE")
+ALL_AUTHORS_EMAIL_IN_BRANCH=($(git log $BASE_BRANCH..$TRAVIS_BRANCH --pretty="%aE" | sort -u))
+
+SUBJECT="[firebase/firebase-js-sdk] SauceLabs Browsers Test Failed"
+HEADER="Content-Type: text/html"
+
+function greetings_for_cron_job() {
+cat << EOF
+Hello team,
+
+Continuous SauceLabs browsers test failed at [$(date)].
+Testing on branch [$TRAVIS_BRANCH] at:
+
+$(git log -1 --color=always $TRAVIS_COMMIT)
+EOF
+}
+
+function greetings_for_push_build() {
+cat << EOF
+Hello $LAST_COMMITTER_NAME,
+
+SauceLabs browsers test failed in push build for branch [$TRAVIS_BRANCH]:
+
+$(git log --color=always $BASE_BRANCH..$TRAVIS_BRANCH)
+EOF
+}
+
+email_body=$(mktemp)
+if [[ "$TRAVIS_EVENT_TYPE" == "cron" ]]; then
+  greetings_for_cron_job > ${email_body}
+else
+  greetings_for_push_build > ${email_body}
+fi
+
+echo -e "\n\n========== See full build logs at: $TRAVIS_BUILD_URL. ==========\n\n" >> ${email_body}
+
+curl $TRAVIS_LOG_URL \
+  | sed -nE '/Executed [[:digit:]]+ of [[:digit:]]+.*(SUCCESS|FAILED)/,/The command "[^"]*" exited with 1\./ p' >> ${email_body}
+
+# Convert from ANSI color to HTML.
+email_body_html=$(mktemp)
+aha < ${email_body} > ${email_body_html}
+
+if [[ "$TRAVIS_EVENT_TYPE" == "cron" ]]; then
+  to="$JS_CORE_EMAIL"
+else
+  to="$LAST_COMMITTER_EMAIL"
+  cc="$(printf -- " -c %s" "${ALL_AUTHORS_EMAIL_IN_BRANCH[@]}")"
+fi
+cc="${cc} -c yifany@google.com"
+
+mail -a "$HEADER" -s "$SUBJECT" ${cc} -- ${to} < ${email_body_html}
+

--- a/scripts/saucelabs/run_test_for_push_build.sh
+++ b/scripts/saucelabs/run_test_for_push_build.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# Copyright 2018 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS-IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Run SauceLabs browsers tests for directly affected packages in the current
+# git branch.
+
+BASE_BRANCH=origin/master
+
+cat << EOL
+Diffstat of branch [$TRAVIS_BRANCH] compared to [$BASE_BRANCH]:
+$(git diff $BASE_BRANCH...$TRAVIS_BRANCH --stat --color=always)
+EOL
+
+changed_files=$(git diff $BASE_BRANCH...$TRAVIS_BRANCH --name-only)
+packages=($(echo -e "${changed_files}" \
+  | sed -nE 's%(^(packages|integration)/[^/]*)/.*%\1%p' \
+  | sort -u))
+
+if [[ ${#packages[@]} -ne 0 ]]; then
+  echo "Affected packages in branch [$TRAVIS_BRANCH]: ${packages[@]}."
+  echo "Starting SauceLabs test ..."
+  yarn test:saucelabs --packages ${packages[@]}
+else
+  echo "No package affected. Skipped SauceLabs test."
+fi


### PR DESCRIPTION
- Run browser test:
  - for only affected packages in presubmit (push builds);
  - for all packages in continuous builds (cron build, triggered daily (or weekly?) on master branch).
- Browser test will be allowed to fail on Travis, not blocking code submission. 
- In case of failures, an email notification containing summary of test results will be send out to inform the author of the commits.

A sample email would look like [this](https://screenshot.googleplex.com/pYE638FuZH8.png).