### PR TITLE
Add firebase-functions to README.

### DIFF
--- a/packages/firebase/README.md
+++ b/packages/firebase/README.md
@@ -102,6 +102,7 @@ you need. The individually installable services are:
 - `firebase-firestore` - Cloud Firestore (optional).
 - `firebase-storage` - Firebase Storage (optional).
 - `firebase-messaging` - Firebase Cloud Messaging (optional).
+- `firebase-functions` - Firebase Cloud Functions (optional).
 
 From the CDN, include the individual services you use (include `firebase-app`
 first):
@@ -113,6 +114,7 @@ first):
 <script src="https://www.gstatic.com/firebasejs/${FIREBASE_VERSION}/firebase-firestore.js"></script>
 <script src="https://www.gstatic.com/firebasejs/${FIREBASE_VERSION}/firebase-storage.js"></script>
 <script src="https://www.gstatic.com/firebasejs/${FIREBASE_VERSION}/firebase-messaging.js"></script>
+<script src="https://www.gstatic.com/firebasejs/${FIREBASE_VERSION}/firebase-functions.js"></script>
 
 <script>
   var app = firebase.initializeApp({ ... });


### PR DESCRIPTION
When I looked at package documentation for [firebase](https://www.npmjs.com/package/firebase) package, I didn’t see `firebase-functions` listed. I assumed that it came built-in to `firebase-app`, which [turns out to be wrong](https://firebase.google.com/docs/functions/callable#set_up_your_client_development_environment).

This PR adds `firebase-functions` to the list of modules in `firebase` package’s README.
