### PR TITLE
Hot fix: small quick update types for Server Side Rendering ( Angular Universal)

### DIFF
--- a/packages/auth-types/index.d.ts
+++ b/packages/auth-types/index.d.ts
@@ -279,12 +279,12 @@ export class FirebaseAuth {
   languageCode: string | null;
   settings: AuthSettings;
   onAuthStateChanged(
-    nextOrObserver: Observer<any> | ((a: User | null) => any),
+    nextOrObserver: Observer<any,any> | ((a: User | null) => any),
     error?: (a: Error) => any,
     completed?: Unsubscribe
   ): Unsubscribe;
   onIdTokenChanged(
-    nextOrObserver: Observer<any> | ((a: User | null) => any),
+    nextOrObserver: Observer<any,any> | ((a: User | null) => any),
     error?: (a: Error) => any,
     completed?: Unsubscribe
   ): Unsubscribe;

--- a/packages/auth-types/index.d.ts
+++ b/packages/auth-types/index.d.ts
@@ -279,12 +279,12 @@ export class FirebaseAuth {
   languageCode: string | null;
   settings: AuthSettings;
   onAuthStateChanged(
-    nextOrObserver: Observer<any,any> | ((a: User | null) => any),
+    nextOrObserver: Observer<any,Error> | ((a: User | null) => any),
     error?: (a: Error) => any,
     completed?: Unsubscribe
   ): Unsubscribe;
   onIdTokenChanged(
-    nextOrObserver: Observer<any,any> | ((a: User | null) => any),
+    nextOrObserver: Observer<any,Error> | ((a: User | null) => any),
     error?: (a: Error) => any,
     completed?: Unsubscribe
   ): Unsubscribe;

--- a/packages/auth-types/index.d.ts
+++ b/packages/auth-types/index.d.ts
@@ -279,12 +279,12 @@ export class FirebaseAuth {
   languageCode: string | null;
   settings: AuthSettings;
   onAuthStateChanged(
-    nextOrObserver: Observer<any,Error> | ((a: User | null) => any),
+    nextOrObserver: Observer<any, Error> | ((a: User | null) => any),
     error?: (a: Error) => any,
     completed?: Unsubscribe
   ): Unsubscribe;
   onIdTokenChanged(
-    nextOrObserver: Observer<any,Error> | ((a: User | null) => any),
+    nextOrObserver: Observer<any, Error> | ((a: User | null) => any),
     error?: (a: Error) => any,
     completed?: Unsubscribe
   ): Unsubscribe;

--- a/packages/storage-types/index.d.ts
+++ b/packages/storage-types/index.d.ts
@@ -77,7 +77,7 @@ export interface UploadTask {
   on(
     event: TaskEvent,
     nextOrObserver?:
-      | Observer<UploadTaskSnapshot,Error>
+      | Observer<UploadTaskSnapshot, Error>
       | null
       | ((a: UploadTaskSnapshot) => any),
     error?: ((a: Error) => any) | null,

--- a/packages/storage-types/index.d.ts
+++ b/packages/storage-types/index.d.ts
@@ -77,7 +77,7 @@ export interface UploadTask {
   on(
     event: TaskEvent,
     nextOrObserver?:
-      | Observer<UploadTaskSnapshot>
+      | Observer<UploadTaskSnapshot,Error>
       | null
       | ((a: UploadTaskSnapshot) => any),
     error?: ((a: Error) => any) | null,


### PR DESCRIPTION
Hello, I'm fixing types error when compiling AOT with angular universal

### Discussion
  fixing this issue [Generic type 'Observer<V, E>' requires 2 type argument(s)](https://github.com/firebase/firebase-js-sdk/issues/900)

### Testing

tested

### API Changes

nope
