### PR TITLE
[Multi-Tab] Don't disable network on shutdown

### DIFF
--- a/packages/firestore/src/core/sync_engine.ts
+++ b/packages/firestore/src/core/sync_engine.ts
@@ -707,8 +707,8 @@ export class SyncEngine implements RemoteSyncer, SharedClientStateSyncer {
     return this.enableNetwork();
   }
 
-  shutdown(): Promise<void> {
-    return this.disableNetwork();
+  async shutdown(): Promise<void> {
+    this.networkAllowed = false;
   }
 
   getRemoteKeysForTarget(targetId: TargetId): DocumentKeySet {


### PR DESCRIPTION
This should bring make the multitab branch green again.

The additional asserts of https://github.com/firebase/firebase-js-sdk/pull/903 uncovered a problem in the Multi-Tab branch since the explicit call to `remoteStore.disableNetwork()` raised `isFromCache:true` events.