### PR TITLE
Add a method to allow using Functions with the local emulator.

### DIFF
--- a/packages/functions-types/index.d.ts
+++ b/packages/functions-types/index.d.ts
@@ -44,6 +44,15 @@ export class FirebaseFunctions {
    * @return The `HttpsCallable` instance.
    */
   httpsCallable(name: string): HttpsCallable;
+
+  /**
+   * Changes this instance to point to a Cloud Functions emulator running
+   * locally. See https://firebase.google.com/docs/functions/local-emulator
+   *
+   * @param origin The origin of the local emulator, such as
+   * "http://localhost:5005".
+   */
+  useFunctionsEmulator(origin: string);
 }
 
 /**

--- a/packages/functions/package.json
+++ b/packages/functions/package.json
@@ -16,6 +16,7 @@
     "test:browser": "karma start --single-run",
     "test:browser:debug": "karma start --browsers=Chrome --auto-watch",
     "test:node": "nyc --reporter lcovonly -- mocha 'test/{,!(browser)/**/}*.test.ts' --require ts-node/register --require index.node.ts --retries 5 --timeout 5000 --exit",
+    "test:emulator": "env FIREBASE_FUNCTIONS_EMULATOR_ORIGIN=http://localhost:5005 run-p test:node",
     "prepare": "npm run build"
   },
   "license": "Apache-2.0",

--- a/packages/functions/src/api/service.ts
+++ b/packages/functions/src/api/service.ts
@@ -40,7 +40,7 @@ interface HttpResponse {
 export class Service implements FirebaseFunctions {
   private readonly contextProvider: ContextProvider;
   private readonly serializer = new Serializer();
-  private emulatorOrigin: string|null = null;
+  private emulatorOrigin: string | null = null;
 
   /**
    * Creates a new Functions service for the given app and (optional) region.

--- a/packages/functions/src/api/service.ts
+++ b/packages/functions/src/api/service.ts
@@ -40,6 +40,7 @@ interface HttpResponse {
 export class Service implements FirebaseFunctions {
   private readonly contextProvider: ContextProvider;
   private readonly serializer = new Serializer();
+  private emulatorOrigin: string|null = null;
 
   /**
    * Creates a new Functions service for the given app and (optional) region.
@@ -64,7 +65,20 @@ export class Service implements FirebaseFunctions {
   _url(name: string): string {
     const projectId = this.app_.options.projectId;
     const region = this.region_;
+    if (this.emulatorOrigin !== null) {
+      const origin = this.emulatorOrigin;
+      return `${origin}/${projectId}/${region}/${name}`;
+    }
     return `https://${region}-${projectId}.cloudfunctions.net/${name}`;
+  }
+
+  /**
+   * Changes this instance to point to a Cloud Functions emulator running locally.
+   * See https://firebase.google.com/docs/functions/local-emulator
+   * @param origin The origin of the local emulator, such as "http://localhost:5005".
+   */
+  useFunctionsEmulator(origin: string) {
+    this.emulatorOrigin = origin;
   }
 
   /**

--- a/packages/functions/src/api/service.ts
+++ b/packages/functions/src/api/service.ts
@@ -73,9 +73,11 @@ export class Service implements FirebaseFunctions {
   }
 
   /**
-   * Changes this instance to point to a Cloud Functions emulator running locally.
-   * See https://firebase.google.com/docs/functions/local-emulator
-   * @param origin The origin of the local emulator, such as "http://localhost:5005".
+   * Changes this instance to point to a Cloud Functions emulator running
+   * locally. See https://firebase.google.com/docs/functions/local-emulator
+   *
+   * @param origin The origin of the local emulator, such as
+   * "http://localhost:5005".
    */
   useFunctionsEmulator(origin: string) {
     this.emulatorOrigin = origin;

--- a/packages/functions/test/callable.test.ts
+++ b/packages/functions/test/callable.test.ts
@@ -51,7 +51,8 @@ describe('Firebase Functions > Call', () => {
   let functions: Service;
 
   before(() => {
-    const projectId = TEST_PROJECT.projectId;
+    const useEmulator = !!process.env.FIREBASE_FUNCTIONS_EMULATOR_ORIGIN;
+    const projectId = useEmulator ? 'functions-integration-test' : TEST_PROJECT.projectId;
     const messagingSenderId = 'messaging-sender-id';
     const region = 'us-central1';
     try {
@@ -63,6 +64,9 @@ describe('Firebase Functions > Call', () => {
       );
     }
     functions = new Service(app, region);
+    if (useEmulator) {
+      functions.useFunctionsEmulator(process.env.FIREBASE_FUNCTIONS_EMULATOR_ORIGIN);
+    }
   });
 
   it('simple data', async () => {

--- a/packages/functions/test/callable.test.ts
+++ b/packages/functions/test/callable.test.ts
@@ -52,7 +52,9 @@ describe('Firebase Functions > Call', () => {
 
   before(() => {
     const useEmulator = !!process.env.FIREBASE_FUNCTIONS_EMULATOR_ORIGIN;
-    const projectId = useEmulator ? 'functions-integration-test' : TEST_PROJECT.projectId;
+    const projectId = useEmulator
+      ? 'functions-integration-test'
+      : TEST_PROJECT.projectId;
     const messagingSenderId = 'messaging-sender-id';
     const region = 'us-central1';
     try {
@@ -65,7 +67,9 @@ describe('Firebase Functions > Call', () => {
     }
     functions = new Service(app, region);
     if (useEmulator) {
-      functions.useFunctionsEmulator(process.env.FIREBASE_FUNCTIONS_EMULATOR_ORIGIN);
+      functions.useFunctionsEmulator(
+        process.env.FIREBASE_FUNCTIONS_EMULATOR_ORIGIN
+      );
     }
   });
 

--- a/packages/functions/test/service.test.ts
+++ b/packages/functions/test/service.test.ts
@@ -31,6 +31,15 @@ describe('Firebase Functions > Service', () => {
         'https://us-central1-my-project.cloudfunctions.net/foo'
       );
     });
+
+    it('can use emulator', () => {
+      service.useFunctionsEmulator('http://localhost:5005');
+      assert.equal(
+        service._url('foo'),
+        'http://localhost:5005/my-project/us-central1/foo'
+      );
+      service.useFunctionsEmulator(null);
+    });
   });
 
   describe('custom region constructor', () => {


### PR DESCRIPTION
Testing with the functions emulator is manual only for now, because we shouldn't require people to set it up just to run tests. But I ran it to verify that this works.