### PR TITLE
Workaround for IndexedDb bug

### DIFF
--- a/packages/firestore/src/local/indexeddb_mutation_queue.ts
+++ b/packages/firestore/src/local/indexeddb_mutation_queue.ts
@@ -165,7 +165,7 @@ export class IndexedDbMutationQueue implements MutationQueue {
     const mutationStore = mutationsStore(transaction);
 
     // The IndexedDb implementation in Chrome (and Firefox) does not handle
-    // compound indices with include auto-generated keys correctly. To ensure
+    // compound indices that include auto-generated keys correctly. To ensure
     // that the index entry is added correctly in all browsers, we perform two
     // writes: The first write is used to retrieve the next auto-generated Batch
     // ID, and the second write populates the index and stores the actual

--- a/packages/firestore/src/local/indexeddb_query_cache.ts
+++ b/packages/firestore/src/local/indexeddb_query_cache.ts
@@ -196,7 +196,7 @@ export class IndexedDbQueryCache implements QueryCache {
   ): PersistencePromise<QueryData | null> {
     // Iterating by the canonicalId may yield more than one result because
     // canonicalId values are not required to be unique per target. This query
-    // depends on the queryTargets index to be efficent.
+    // depends on the queryTargets index to be efficient.
     const canonicalId = query.canonicalId();
     const range = IDBKeyRange.bound(
       [canonicalId, Number.NEGATIVE_INFINITY],

--- a/packages/firestore/src/local/indexeddb_schema.ts
+++ b/packages/firestore/src/local/indexeddb_schema.ts
@@ -184,17 +184,15 @@ export class DbMutationBatch {
   /** The user mutations index is keyed by [userId, batchId] pairs. */
   static userMutationsKeyPath = ['userId', 'batchId'];
 
-  /**
-   * The auto-generated identifier for this batch, allocated in a monotonically
-   * increasing manner.
-   */
-  batchId?: BatchId;
-
   constructor(
     /**
      * The normalized user ID to which this batch belongs.
      */
     public userId: string,
+    /**
+     * An identifier for this batch, allocated using an auto-generated key.
+     */
+    public batchId: BatchId,
     /**
      * The local write time of the batch, stored as milliseconds since the
      * epoch.

--- a/packages/firestore/src/local/local_serializer.ts
+++ b/packages/firestore/src/local/local_serializer.ts
@@ -20,7 +20,7 @@ import { Query } from '../core/query';
 import { SnapshotVersion } from '../core/snapshot_version';
 import { Document, MaybeDocument, NoDocument } from '../model/document';
 import { DocumentKey } from '../model/document_key';
-import { BATCHID_UNKNOWN, MutationBatch } from '../model/mutation_batch';
+import { MutationBatch } from '../model/mutation_batch';
 import { JsonProtoSerializer } from '../remote/serializer';
 import { assert, fail } from '../util/assert';
 
@@ -72,16 +72,12 @@ export class LocalSerializer {
 
   /** Encodes a batch of mutations into a DbMutationBatch for local storage. */
   toDbMutationBatch(userId: string, batch: MutationBatch): DbMutationBatch {
-    assert(
-      batch.batchId === BATCHID_UNKNOWN,
-      'Can only persist mutation batches with unassigned IDs.'
-    );
-
     const serializedMutations = batch.mutations.map(m =>
       this.remoteSerializer.toMutation(m)
     );
     return new DbMutationBatch(
       userId,
+      batch.batchId,
       batch.localWriteTime.toMillis(),
       serializedMutations
     );

--- a/packages/firestore/test/unit/local/indexeddb_schema.test.ts
+++ b/packages/firestore/test/unit/local/indexeddb_schema.test.ts
@@ -199,7 +199,7 @@ describe('IndexedDbSchema: createOrUpgradeDb', () => {
           }
           p = p.next(() => {
             store
-              .add({ userId: 'foo', localWriteTimeMs: 1000, mutations: [] })
+              .add({} as any) // tslint:disable-line:no-any
               .next(batchId => {
                 expect(batchId).to.equal(43);
               });


### PR DESCRIPTION
This works around an IndexedDb bug in Chrome and Firefox that omits index entires for auto-generated keys.

https://bugs.chromium.org/p/chromium/issues/detail?id=701972
