### PR TITLE
Remove startsWith because it's not supported in IE11

### DIFF
--- a/packages/database/src/core/util/libs/parser.ts
+++ b/packages/database/src/core/util/libs/parser.ts
@@ -43,7 +43,7 @@ function decodePath(pathString: string): string {
  */
 function decodeQuery(queryString: string): { [key: string]: string } {
   let results = {};
-  if (queryString.startsWith('?')) {
+  if (queryString.charAt(0) === '?') {
     queryString = queryString.substring(1);
   }
   for (const segment of queryString.split('&')) {


### PR DESCRIPTION
Make IE great again. Fixes #958 

I tried adding the tslint [rule](https://github.com/Microsoft/tslint-microsoft-contrib) `"no-unsupported-browser-code": [true, ["IE 11"]],` but as it turns out the package `database` doesn't lint the code.
Linting is only enabled in `firestore` and `messaging`

I went a bit deeper trying to copy the config from `firestore` but as it turns out, there are loads of lint errors and I don't feel like touching more code than necessary.

For the moment simply remote the unsupported method in IE11, if anyone cares please add linting and configure it so that these errors won't show up again in the future
