### PR TITLE
Add onBlocked handler for schema upgrade

### DIFF
--- a/packages/firestore/src/local/simple_db.ts
+++ b/packages/firestore/src/local/simple_db.ts
@@ -68,7 +68,7 @@ export class SimpleDb {
           new FirestoreError(
             Code.FAILED_PRECONDITION,
             'Cannot upgrade IndexedDB schema while another tab is open. ' +
-             'Close all tabs that access Firestore and reload this page to proceed.'
+              'Close all tabs that access Firestore and reload this page to proceed.'
           )
         );
       };

--- a/packages/firestore/src/local/simple_db.ts
+++ b/packages/firestore/src/local/simple_db.ts
@@ -22,6 +22,7 @@ import { PersistencePromise } from './persistence_promise';
 import { SCHEMA_VERSION } from './indexeddb_schema';
 import { Deferred } from '../util/promise';
 import { PersistenceTransaction } from './persistence';
+import { Code, FirestoreError } from '../util/error';
 
 const LOG_TAG = 'SimpleDb';
 
@@ -60,6 +61,16 @@ export class SimpleDb {
       request.onsuccess = (event: Event) => {
         const db = (event.target as IDBOpenDBRequest).result;
         resolve(new SimpleDb(db));
+      };
+
+      request.onblocked = () => {
+        reject(
+          new FirestoreError(
+            Code.FAILED_PRECONDITION,
+            'Cannot upgrade IndexedDB schema while another tab is open. ' +
+             'Close all tabs that access Firestore and reload this page to proceed.'
+          )
+        );
       };
 
       request.onerror = (event: ErrorEvent) => {


### PR DESCRIPTION
We need to add an `onblocked` handler to our schema uprgade code. This handler gets called when another tab already has an open database connection. These connections prevent schema upgrades, but without this PR, we currently don't fail "enablePersistence()" and instead never resolve the Promise.

Let me know if you think we should include the origin/host name in the error message.

FYI: There is no code that tests this codepath as our schema upgrade tests set up their own onsuccess/onfailure handlers.