### PR TITLE
[Multi-Tab] Recomputing views after failover

### DIFF
--- a/packages/firestore/src/core/sync_engine.ts
+++ b/packages/firestore/src/core/sync_engine.ts
@@ -66,7 +66,6 @@ import {
 } from '../local/shared_client_state_syncer';
 import { ClientId, SharedClientState } from '../local/shared_client_state';
 import { SortedSet } from '../util/sorted_set';
-import * as objUtils from '../util/obj';
 
 const LOG_TAG = 'SyncEngine';
 
@@ -139,6 +138,10 @@ export class SyncEngine implements RemoteSyncer, SharedClientStateSyncer {
     [uidKey: string]: SortedMap<BatchId, Deferred<void>>;
   };
   private limboTargetIdGenerator = TargetIdGenerator.forSyncEngine();
+
+  // The primary state is set to `true` or `false` immediately after Firestore
+  // startup. In the interim, a client should only be considered primary if `
+  // isPrimary` is true.
   private isPrimary: undefined | boolean = undefined;
 
   constructor(
@@ -185,19 +188,23 @@ export class SyncEngine implements RemoteSyncer, SharedClientStateSyncer {
       const status = this.sharedClientState.addLocalQueryTarget(
         queryData.targetId
       );
-      return this.initializeListenAndNotifyViews(
+      return this.initializeViewAndComputeInitialSnapshot(
         queryData,
         status === 'current'
-      ).then(() => {
+      ).then(viewSnapshot => {
+        if (this.isPrimary) {
+          this.remoteStore.listen(queryData);
+        }
+        this.viewHandler!([viewSnapshot]);
         return queryData.targetId;
       });
     });
   }
 
-  private initializeListenAndNotifyViews(
+  private initializeViewAndComputeInitialSnapshot(
     queryData: QueryData,
     current: boolean
-  ): Promise<void> {
+  ): Promise<ViewSnapshot> {
     const query = queryData.query;
 
     return this.localStore.executeQuery(query).then(docs => {
@@ -232,25 +239,24 @@ export class SyncEngine implements RemoteSyncer, SharedClientStateSyncer {
           );
           this.queryViewsByQuery.set(query, data);
           this.queryViewsByTarget[queryData.targetId] = data;
-          this.viewHandler!([viewChange.snapshot!]);
-          if (this.isPrimary) {
-            this.remoteStore.listen(queryData);
-          }
+          return viewChange.snapshot!;
         });
     });
   }
 
-  private synchronizeLocalView(queryData: QueryData): Promise<void> {
-    const query = queryData.query;
-
-    return this.localStore.executeQuery(query).then(docs => {
-      return this.localStore
-        .remoteDocumentKeys(queryData.targetId)
-        .then(async remoteKeys => {
-          const queryView = this.queryViewsByTarget[queryData.targetId];
-          queryView.view.synchronizeWithRemoteKeys(remoteKeys);
-        });
-    });
+  /**
+   * Reconcile the list of synced documents in the local views with those from
+   * persistence.
+   */
+  // PORTING NOTE: Multi-tab only.
+  private async synchronizeLocalView(queryData: QueryData): Promise<void> {
+    return this.localStore
+      .remoteDocumentKeys(queryData.targetId)
+      .then(async remoteKeys => {
+        const queryView = this.queryViewsByTarget[queryData.targetId];
+        assert(!!queryView, 'Expected queryView to be defined');
+        queryView.view.synchronizeWithRemoteKeys(remoteKeys);
+      });
   }
 
   /** Stops listening to the query. */
@@ -736,44 +742,50 @@ export class SyncEngine implements RemoteSyncer, SharedClientStateSyncer {
 
   // PORTING NOTE: Multi-tab only
   async applyPrimaryState(isPrimary: boolean): Promise<void> {
-    const stateUpgraded = this.isPrimary === false && isPrimary;
+    if (isPrimary === true && this.isPrimary !== true) {
+      this.isPrimary = true;
 
-    this.isPrimary = isPrimary;
-    if (this.isPrimary) {
+      // Secondary tabs only maintain Views for their local listeners and the
+      // Views internal state may not be 100% populated (in particular
+      // secondary tabs don't track syncedDocuments, the set of documents the
+      // server considers to be in the target). So when a secondary becomes
+      // primary, we need to need to make sure that all views for all targets
+      // match the state on disk.
+      let p = Promise.resolve();
+      const activeTargets = this.sharedClientState.getAllActiveQueryTargets();
+      activeTargets.forEach(targetId => {
+        p = p.then(async () => {
+          let queryData;
+          const query = await this.localStore.getQueryForTarget(targetId);
+          if (this.queryViewsByTarget[targetId] === undefined) {
+            // For queries that never executed on this client, we need to
+            // allocate the query in LocalStore and initialize a new View.
+            queryData = await this.localStore.allocateQuery(query);
+            await this.initializeViewAndComputeInitialSnapshot(
+              queryData,
+              false
+            );
+          } else {
+            // For queries that have a local View, we need to update their state
+            // in LocalStore (as the resume token and the snapshot version
+            // might have changed) and reconcile their views with the persisted
+            // state (the list of syncedDocuments may have gotten out of sync).
+            await this.localStore.releaseQuery(query, true);
+            queryData = await this.localStore.allocateQuery(query);
+            await this.synchronizeLocalView(queryData);
+          }
+          this.remoteStore.listen(queryData);
+        });
+      });
+      await p;
+
       if (this.networkAllowed) {
         await this.remoteStore.enableNetwork();
       }
+    } else if (isPrimary === false && this.isPrimary !== false) {
+      this.isPrimary = false;
 
-      if (stateUpgraded) {
-        // Secondary tabs do not update their set of synced keys. When a
-        // secondary tab acquires a primary lease, we need to reconcile our
-        // state with the state in persistence. To do this, we release and
-        // re-allocate all active queries and update all views accordingly.
-        objUtils.forEachNumber(
-          this.queryViewsByTarget,
-          async (targetId, queryView) => {
-            await this.localStore.releaseQuery(
-              queryView.query,
-              /*keepPersistedQueryData=*/ true
-            );
-          }
-        );
-
-        let p = Promise.resolve();
-        const activeTargets = this.sharedClientState.getAllActiveQueryTargets();
-        activeTargets.forEach(targetId => {
-          p = p.then(async () => {
-            const queryData = await this.localStore.getQueryDataForTarget(
-              targetId
-            );
-            this.remoteStore.listen(queryData);
-            await this.localStore.allocateQuery(queryData.query);
-            await this.synchronizeLocalView(queryData);
-          });
-        });
-        await p;
-      }
-    } else {
+      // TODO: Unlisten from all active targets
       await this.remoteStore.disableNetwork();
     }
   }
@@ -833,10 +845,14 @@ export class SyncEngine implements RemoteSyncer, SharedClientStateSyncer {
         !this.queryViewsByTarget[targetId],
         'Trying to add an already active target'
       );
-      const queryData = await this.localStore.getQueryDataForTarget(targetId);
-      assert(!!queryData, `Query data for active target ${targetId} not found`);
-      await this.localStore.allocateQuery(queryData.query);
-      await this.initializeListenAndNotifyViews(queryData, /*current=*/ false);
+      const query = await this.localStore.getQueryForTarget(targetId);
+      assert(!!query, `Query data for active target ${targetId} not found`);
+      const queryData = await this.localStore.allocateQuery(query);
+      await this.initializeViewAndComputeInitialSnapshot(
+        queryData,
+        /*current=*/ false
+      );
+      this.remoteStore.listen(queryData);
     }
 
     for (const targetId of removed) {

--- a/packages/firestore/src/core/sync_engine.ts
+++ b/packages/firestore/src/core/sync_engine.ts
@@ -240,9 +240,7 @@ export class SyncEngine implements RemoteSyncer, SharedClientStateSyncer {
     });
   }
 
-  private synchronizeLocalView(
-    queryData: QueryData
-  ): Promise<void> {
+  private synchronizeLocalView(queryData: QueryData): Promise<void> {
     const query = queryData.query;
 
     return this.localStore.executeQuery(query).then(docs => {

--- a/packages/firestore/src/core/sync_engine.ts
+++ b/packages/firestore/src/core/sync_engine.ts
@@ -140,8 +140,8 @@ export class SyncEngine implements RemoteSyncer, SharedClientStateSyncer {
   private limboTargetIdGenerator = TargetIdGenerator.forSyncEngine();
 
   // The primary state is set to `true` or `false` immediately after Firestore
-  // startup. In the interim, a client should only be considered primary if `
-  // isPrimary` is true.
+  // startup. In the interim, a client should only be considered primary if
+  // `isPrimary` is true.
   private isPrimary: undefined | boolean = undefined;
 
   constructor(
@@ -249,11 +249,11 @@ export class SyncEngine implements RemoteSyncer, SharedClientStateSyncer {
    * persistence.
    */
   // PORTING NOTE: Multi-tab only.
-  private async synchronizeLocalView(queryData: QueryData): Promise<void> {
+  private async synchronizeLocalView(targetId: TargetId): Promise<void> {
     return this.localStore
-      .remoteDocumentKeys(queryData.targetId)
+      .remoteDocumentKeys(targetId)
       .then(async remoteKeys => {
-        const queryView = this.queryViewsByTarget[queryData.targetId];
+        const queryView = this.queryViewsByTarget[targetId];
         assert(!!queryView, 'Expected queryView to be defined');
         queryView.view.synchronizeWithRemoteKeys(remoteKeys);
       });
@@ -772,7 +772,7 @@ export class SyncEngine implements RemoteSyncer, SharedClientStateSyncer {
             // state (the list of syncedDocuments may have gotten out of sync).
             await this.localStore.releaseQuery(query, true);
             queryData = await this.localStore.allocateQuery(query);
-            await this.synchronizeLocalView(queryData);
+            await this.synchronizeLocalView(targetId);
           }
           this.remoteStore.listen(queryData);
         });

--- a/packages/firestore/src/core/view.ts
+++ b/packages/firestore/src/core/view.ts
@@ -382,6 +382,10 @@ export class View {
     });
     return changes;
   }
+
+  synchronizeWithRemoteKeys(remoteKeys: DocumentKeySet): void {
+    this._syncedDocuments = remoteKeys;
+  }
 }
 
 function compareChangeType(c1: ChangeType, c2: ChangeType): number {

--- a/packages/firestore/src/local/local_store.ts
+++ b/packages/firestore/src/local/local_store.ts
@@ -142,6 +142,7 @@ export class LocalStore {
   private queryCache: QueryCache;
 
   /** Maps a targetID to data about its query. */
+  // TODO(multitab): Rename to `queryDataByTarget` to match SyncEngine's naming.
   private targetIds = {} as { [targetId: number]: QueryData };
 
   /**

--- a/packages/firestore/src/local/local_store.ts
+++ b/packages/firestore/src/local/local_store.ts
@@ -971,10 +971,16 @@ export class LocalStore {
   }
 
   // PORTING NOTE: Multi-tab only.
-  getQueryDataForTarget(targetId: TargetId): Promise<QueryData | null> {
-    return this.persistence.runTransaction('Get query data', false, txn => {
-      return this.queryCache.getQueryDataForTarget(txn, targetId);
-    });
+  getQueryForTarget(targetId: TargetId): Promise<Query | null> {
+    if (this.targetIds[targetId]) {
+      return Promise.resolve(this.targetIds[targetId].query);
+    } else {
+      return this.persistence.runTransaction('Get query data', false, txn => {
+        return this.queryCache
+          .getQueryDataForTarget(txn, targetId)
+          .next(queryData => queryData.query);
+      });
+    }
   }
 
   // PORTING NOTE: Multi-tab only.

--- a/packages/firestore/test/unit/specs/limbo_spec.test.ts
+++ b/packages/firestore/test/unit/specs/limbo_spec.test.ts
@@ -261,31 +261,31 @@ describeSpec('Limbo Documents:', [], () => {
     ['multi-client'],
     () => {
       const query = Query.atPath(path('collection'));
-      const doc1 = doc('collection/a', 1000, { key: 'a' });
-      const doc2 = doc('collection/b', 1001, { key: 'b' });
-      const deletedDoc2 = deletedDoc('collection/b', 1004);
+      const docA = doc('collection/a', 1000, { key: 'a' });
+      const docB = doc('collection/b', 1001, { key: 'b' });
+      const deletedDocB = deletedDoc('collection/b', 1004);
 
       return client(0)
-        .becomeVisible()
+        .expectPrimaryState(true)
         .client(1)
         .userListens(query)
         .expectEvents(query, { fromCache: true })
         .client(0)
         .expectListen(query)
-        .watchAcksFull(query, 1002, doc1, doc2)
+        .watchAcksFull(query, 1002, docA, docB)
         .client(1)
-        .expectEvents(query, { added: [doc1, doc2] })
+        .expectEvents(query, { added: [docA, docB] })
         .client(0)
-        .watchRemovesDoc(doc2.key, query)
+        .watchRemovesDoc(docB.key, query)
         .watchSnapshots(1003)
-        .expectLimboDocs(doc2.key)
+        .expectLimboDocs(docB.key)
         .client(1)
         .expectEvents(query, { fromCache: true })
         .client(0)
-        .ackLimbo(1004, deletedDoc2)
+        .ackLimbo(1004, deletedDocB)
         .expectLimboDocs()
         .client(1)
-        .expectEvents(query, { removed: [doc2] });
+        .expectEvents(query, { removed: [docB] });
     }
   );
 
@@ -294,25 +294,25 @@ describeSpec('Limbo Documents:', [], () => {
     ['multi-client'],
     () => {
       const query = Query.atPath(path('collection'));
-      const doc1 = doc('collection/a', 1000, { key: 'a' });
-      const doc2 = doc('collection/b', 1001, { key: 'b' });
-      const deletedDoc2 = deletedDoc('collection/b', 1005);
+      const docA = doc('collection/a', 1000, { key: 'a' });
+      const docB = doc('collection/b', 1001, { key: 'b' });
+      const deletedDocB = deletedDoc('collection/b', 1005);
 
       return (
         client(0, false)
-          .becomeVisible()
+          .expectPrimaryState(true)
           .client(1)
           .userListens(query)
           .expectEvents(query, { fromCache: true })
           .client(0)
           .expectListen(query)
-          .watchAcksFull(query, 1002, doc1, doc2)
+          .watchAcksFull(query, 1002, docA, docB)
           .client(1)
-          .expectEvents(query, { added: [doc1, doc2] })
+          .expectEvents(query, { added: [docA, docB] })
           .client(0)
-          .watchRemovesDoc(doc2.key, query)
+          .watchRemovesDoc(docB.key, query)
           .watchSnapshots(1003)
-          .expectLimboDocs(doc2.key)
+          .expectLimboDocs(docB.key)
           .shutdown()
           .client(1)
           .expectEvents(query, { fromCache: true })
@@ -322,10 +322,10 @@ describeSpec('Limbo Documents:', [], () => {
           // global snapshot.
           .expectListen(query, 'resume-token-1002')
           .watchAcksFull(query, 1004)
-          .expectLimboDocs(doc2.key)
-          .ackLimbo(1005, deletedDoc2)
+          .expectLimboDocs(docB.key)
+          .ackLimbo(1005, deletedDocB)
           .expectLimboDocs()
-          .expectEvents(query, { removed: [doc2] })
+          .expectEvents(query, { removed: [docB] })
       );
     }
   );

--- a/packages/firestore/test/unit/specs/listen_spec.test.ts
+++ b/packages/firestore/test/unit/specs/listen_spec.test.ts
@@ -751,7 +751,7 @@ describeSpec('Listens:', [], () => {
       .userListens(query)
       .watchAcksFull(query, 1000, docA)
       .expectEvents(query, { added: [docA] })
-      .client(1)
+      .client(1) // Start up and initialize the second client.
       .client(2)
       .userListens(query)
       .expectEvents(query, { added: [docA] })

--- a/packages/firestore/test/unit/specs/spec_builder.ts
+++ b/packages/firestore/test/unit/specs/spec_builder.ts
@@ -345,7 +345,6 @@ export class SpecBuilder {
     // Reset our mappings / target ids since all existing listens will be
     // forgotten.
     this.clientState.reset();
-    this.queryIdGenerator = new CachedTargetIdGenerator();
     return this;
   }
 
@@ -361,7 +360,6 @@ export class SpecBuilder {
     // Reset our mappings / target ids since all existing listens will be
     // forgotten.
     this.clientState.reset();
-    this.queryIdGenerator = new CachedTargetIdGenerator();
     return this;
   }
 

--- a/packages/firestore/test/unit/specs/spec_test_runner.ts
+++ b/packages/firestore/test/unit/specs/spec_test_runner.ts
@@ -980,18 +980,19 @@ abstract class TestRunner {
       }
     }
 
-    // Always validate that the expected limbo docs match the actual limbo docs
-    this.validateLimboDocs();
-    // Always validate that the expected active targets match the actual active
-    // targets
-    await this.validateActiveTargets();
+    // Clients don't reset their limbo docs on shutdown, so any validation will
+    // likely fail.
+    if (this.started) {
+      // Always validate that the expected limbo docs match the actual limbo
+      // docs
+      this.validateLimboDocs();
+      // Always validate that the expected active targets match the actual
+      // active targets
+      await this.validateActiveTargets();
+    }
   }
 
   private validateLimboDocs(): void {
-    if (!this.started) {
-      return;
-    }
-
     let actualLimboDocs = this.syncEngine.currentLimboDocs();
     // Validate that each limbo doc has an expected active target
     actualLimboDocs.forEach((key, targetId) => {
@@ -1023,6 +1024,8 @@ abstract class TestRunner {
     // In multi-tab mode, we cannot rely on the `waitForWatchOpen` call in
     // `doUserListen` since primary tabs may execute queries from other tabs
     // without any direct user interaction.
+    // TODO(multitab): Refactor so this is only executed after primary tab
+    // change
     if (!obj.isEmpty(this.expectedActiveTargets)) {
       await this.connection.waitForWatchOpen();
       await this.queue.drain();


### PR DESCRIPTION
This PR adds the functionality to reconcile views with the truth from persistence as tabs gain the primary lease. To do this, it updates state internal to the view, so we might want to wait with merging this until after the View refactor.

This also fixed an issue in the Spec test that cleared the target IDs on client shutdown. They should be cleared on global shutdown (or just re-recreated at test startup like we already do).

