### PR TITLE
Clears getRedirectResult() in AuthEventManager for a deleted Auth instance

### DIFF
--- a/packages/auth/src/auth.js
+++ b/packages/auth/src/auth.js
@@ -1830,6 +1830,7 @@ fireauth.Auth.prototype.delete = function() {
   // Unsubscribe from Auth event handling.
   if (this.authEventManager_) {
     this.authEventManager_.unsubscribe(this);
+    this.authEventManager_.clearRedirectResult();
   }
   return firebase.Promise.resolve();
 };

--- a/packages/auth/test/auth_test.js
+++ b/packages/auth/test/auth_test.js
@@ -1988,7 +1988,8 @@ function testAuth_authEventManager() {
   initializeMockStorage();
   var expectedManager = {
     'subscribe': goog.testing.recordFunction(),
-    'unsubscribe': goog.testing.recordFunction()
+    'unsubscribe': goog.testing.recordFunction(),
+    'clearRedirectResult': goog.testing.recordFunction()
   };
   // Return stub manager.
   stubs.replace(
@@ -2012,10 +2013,14 @@ function testAuth_authEventManager() {
     assertEquals(1, expectedManager.subscribe.getCallCount());
     assertEquals(
         auth1, expectedManager.subscribe.getLastCall().getArgument(0));
+    assertEquals(0, expectedManager.clearRedirectResult.getCallCount());
+    // Delete should trigger unsubscribe and redirect result clearing.
     auth1.delete();
     // After destroy, Auth should be unsubscribed.
     assertEquals(1, expectedManager.subscribe.getCallCount());
     assertEquals(1, expectedManager.unsubscribe.getCallCount());
+    // Redirect result should also be cleared.
+    assertEquals(1, expectedManager.clearRedirectResult.getCallCount());
     assertEquals(
         auth1, expectedManager.unsubscribe.getLastCall().getArgument(0));
     asyncTestCase.signal();


### PR DESCRIPTION
Clears getRedirectResult() in AuthEventManager for a specified Auth instance when it is deleted.
```
app.auth().getRedirectResult() => resolves with redirect result provided previous page called a redirect operation.
app.delete(); // deletes auth instance corresponding to app and clears redirect result.
// re-initialize app with same parameters.
app = firebase.initializeApp(config);
app.auth().getRedirectResult() should resolve with null.
```
This is needed for firebaseui-web react wrapper which on component unmount will delete the firebaseui instance (which deletes the internal auth instance). When the component is mounted again, the previously temp auth instance was still caching the redirect result.
https://github.com/firebase/firebaseui-web/issues/440

Cleans up private property access in AuthEventManager tests.

