### PR TITLE
Custom auth endpoints config

### DIFF
--- a/packages/app-types/index.d.ts
+++ b/packages/app-types/index.d.ts
@@ -21,7 +21,7 @@ export type FirebaseOptions = {
   projectId?: string;
   storageBucket?: string;
   messagingSenderId?: string;
-  authUrl?: string;
+  authUrl?: Object;
   [name: string]: any;
 };
 

--- a/packages/app-types/index.d.ts
+++ b/packages/app-types/index.d.ts
@@ -21,6 +21,7 @@ export type FirebaseOptions = {
   projectId?: string;
   storageBucket?: string;
   messagingSenderId?: string;
+  authUrl?: string;
   [name: string]: any;
 };
 

--- a/packages/auth/src/auth.js
+++ b/packages/auth/src/auth.js
@@ -70,6 +70,11 @@ fireauth.Auth = function(app) {
       this, 'settings', new fireauth.AuthSettings());
   /** Auth's corresponding App. */
   fireauth.object.setReadonlyProperty(this, 'app', app);
+  // If auth URL is provided, 
+  // set constant 'Endpoint.TEST.firebaseAuthEndpoint' variable to option value
+  if(this.app_().options && this.app_().options['authUrl']) {
+    fireauth.constants.Endpoint.TEST.firebaseAuthEndpoint = this.app_().options['authUrl'];
+  }
   // Initialize RPC handler.
   // API key is required for web client RPC calls.
   if (this.app_().options && this.app_().options['apiKey']) {

--- a/packages/auth/src/autheventmanager.js
+++ b/packages/auth/src/autheventmanager.js
@@ -46,15 +46,18 @@ goog.require('goog.array');
  * @param {string} apiKey The API key for sending backend Auth requests.
  * @param {string} appName The App ID for the Auth instance that triggered this
  *     request.
+ * @param {?Object=} opt_authConfig The Auth Config, used in custom auth server
  * @constructor
  */
-fireauth.AuthEventManager = function(authDomain, apiKey, appName) {
+fireauth.AuthEventManager = function(authDomain, apiKey, appName, opt_authConfig) {
   /** @private {string} The Auth domain. */
   this.authDomain_ = authDomain;
   /** @private {string} The browser API key. */
   this.apiKey_ = apiKey;
   /** @private {string} The App name. */
   this.appName_ = appName;
+  /** @private {?Object} The Auth Config, used in custom auth server */
+  this.authConfig_ = opt_authConfig || null;
   /**
    * @private {!Array<!fireauth.AuthEventHandler>} List of subscribed handlers.
    */
@@ -106,7 +109,8 @@ fireauth.AuthEventManager = function(authDomain, apiKey, appName) {
       fireauth.AuthEventManager.instantiateOAuthSignInHandler(
           this.authDomain_, this.apiKey_, this.appName_,
           firebase.SDK_VERSION || null,
-          fireauth.constants.clientEndpoint);
+          fireauth.constants.clientEndpoint,
+          this.authConfig_);
 };
 
 
@@ -134,11 +138,12 @@ fireauth.AuthEventManager.prototype.getPopupAuthEventProcessor = function() {
  *     request.
  * @param {?string} version The SDK client version.
  * @param {?string=} opt_endpointId The endpoint ID (staging, test Gaia, etc).
+ * @param {?Object=} opt_authConfig The Auth Config, used in custom auth server
  * @return {!fireauth.OAuthSignInHandler} The OAuth sign in handler depending
  *     on the current environment.
  */
 fireauth.AuthEventManager.instantiateOAuthSignInHandler =
-    function(authDomain, apiKey, appName, version, opt_endpointId) {
+    function(authDomain, apiKey, appName, version, opt_endpointId, opt_authConfig) {
   // This assumes that android/iOS file environment must be a Cordova
   // environment which is not true. This is the best way currently available
   // to instantiate this synchronously without waiting for checkIfCordova to
@@ -149,7 +154,7 @@ fireauth.AuthEventManager.instantiateOAuthSignInHandler =
           authDomain, apiKey, appName, version, undefined, undefined,
           opt_endpointId) :
       new fireauth.iframeclient.IfcHandler(
-          authDomain, apiKey, appName, version, opt_endpointId);
+          authDomain, apiKey, appName, version, opt_endpointId, opt_authConfig);
 };
 
 
@@ -593,14 +598,15 @@ fireauth.AuthEventManager.getKey_ = function(apiKey, appName) {
  * @param {string} apiKey The API key for sending backend Auth requests.
  * @param {string} appName The Auth instance that initiated the Auth event
  *     manager.
+ * @param {?Object=} opt_authConfig The Auth Config, used in custom auth server
  * @return {!fireauth.AuthEventManager} the requested manager instance.
  */
-fireauth.AuthEventManager.getManager = function(authDomain, apiKey, appName) {
+fireauth.AuthEventManager.getManager = function(authDomain, apiKey, appName, opt_authConfig) {
   // Construct storage key.
   var key = fireauth.AuthEventManager.getKey_(apiKey, appName);
   if (!fireauth.AuthEventManager.manager_[key]) {
     fireauth.AuthEventManager.manager_[key] =
-        new fireauth.AuthEventManager(authDomain, apiKey, appName);
+        new fireauth.AuthEventManager(authDomain, apiKey, appName, opt_authConfig);
   }
   return fireauth.AuthEventManager.manager_[key];
 };

--- a/packages/auth/src/authuser.js
+++ b/packages/auth/src/authuser.js
@@ -209,6 +209,8 @@ fireauth.AuthUser =
   this.appName_ = /** @type {string} */ (appOptions['appName']);
   /** @private {?string} The Auth domain. */
   this.authDomain_ = appOptions['authDomain'] || null;
+  /** @private {?Object} The Auth Config, used in custom auth server */
+  this.authConfig_ = appOptions['authConfig'] || null;
   var clientFullVersion = firebase.SDK_VERSION ?
       fireauth.util.getClientVersion(
           fireauth.util.ClientImplementation.JSCORE, firebase.SDK_VERSION) :
@@ -217,7 +219,7 @@ fireauth.AuthUser =
   this.rpcHandler_ = new fireauth.RpcHandler(
       this.apiKey_,
       // Get the client Auth endpoint used.
-      fireauth.constants.getEndpointConfig(fireauth.constants.clientEndpoint),
+      (this.authConfig_ || fireauth.constants.getEndpointConfig(fireauth.constants.clientEndpoint)),
       clientFullVersion);
   // TODO: Consider having AuthUser take a fireauth.StsTokenManager
   // instance instead of a token response but make sure lastAccessToken_ also
@@ -245,7 +247,7 @@ fireauth.AuthUser =
       fireauth.util.isPopupRedirectSupported()) {
     // Get the Auth event manager associated with this user.
     this.authEventManager_ = fireauth.AuthEventManager.getManager(
-        this.authDomain_, this.apiKey_, this.appName_);
+        this.authDomain_, this.apiKey_, this.appName_, this.authConfig_);
   }
   /** @private {!Array<!function(!fireauth.AuthUser):!goog.Promise>} The list of
    *      state change listeners. This is needed to make sure state changes are
@@ -2252,7 +2254,8 @@ fireauth.AuthUser.fromPlainObject = function(user) {
   var options = {
     'apiKey': user['apiKey'],
     'authDomain': user['authDomain'],
-    'appName': user['appName']
+    'appName': user['appName'],
+    'authConfig': user['authConfig']
   };
   // Convert to server response format. Constructor does not take
   // stsTokenManager toPlainObject as that format is different than the return

--- a/packages/auth/src/iframeclient/ifchandler.js
+++ b/packages/auth/src/iframeclient/ifchandler.js
@@ -404,11 +404,12 @@ fireauth.iframeclient.OAuthUrlBuilder.getAuthFrameworksForApp_ =
  *     request.
  * @param {?string=} opt_clientVersion The optional client version string.
  * @param {?string=} opt_endpointId The endpoint ID (staging, test Gaia, etc).
+ * @param {?Object=} opt_AuthConfig The Auth Config, used in custom auth server
  * @constructor
  * @implements {fireauth.OAuthSignInHandler}
  */
 fireauth.iframeclient.IfcHandler = function(authDomain, apiKey, appName,
-    opt_clientVersion, opt_endpointId) {
+    opt_clientVersion, opt_endpointId, opt_AuthConfig) {
   /** @private {string} The Auth domain. */
   this.authDomain_ = authDomain;
   /** @private {string} The API key. */
@@ -419,6 +420,8 @@ fireauth.iframeclient.IfcHandler = function(authDomain, apiKey, appName,
   this.clientVersion_ = opt_clientVersion || null;
   /** @private {?string} The Auth endpoint ID. */
   this.endpointId_ = opt_endpointId || null;
+  /** @private {?Object} The Auth Config, used in custom auth server */
+  this.authConfig_ = opt_AuthConfig || null;
   // Delay RPC handler and iframe URL initialization until needed to ensure
   // logged frameworks are propagated to the iframe.
   /** @private {?string} The full client version string. */
@@ -698,7 +701,7 @@ fireauth.iframeclient.IfcHandler.prototype.getRpcHandler_ = function() {
     this.rpcHandler_ = new fireauth.RpcHandler(
         this.apiKey_,
         // Get the client Auth endpoint used.
-        fireauth.constants.getEndpointConfig(this.endpointId_),
+        (this.authConfig_ || fireauth.constants.getEndpointConfig(this.endpointId_)),
         this.fullClientVersion_);
   }
   return this.rpcHandler_;


### PR DESCRIPTION
Hey,
As I described in issue #975, I added not required option passing in initializeApp options, which provide custom auth servers endpoints. Option named "authConfig" is optional, and, if is passed, it must be an object. All tests in my private Travis CI account passed, coveralls reported +0.03 coverage increment ;) ,  all sdk features works fine in my local environment regardless of passing parameter or not. 

At the beginning I want to change constant variables in defines.js, but I in my opinion better solution is to pass authConfig via methods, someone may take advantage of this choice. It was hard, but finally it works :)

I hope, you will accept this pull request, but if not, please suggest me what is need to do, to accept next pull request with changes

Bye,
with Best Regards,
Mateusz Wozniak