### PR TITLE
[Multi-Tab] Making Multi-Tab optional

### DIFF
--- a/packages/firestore-types/index.d.ts
+++ b/packages/firestore-types/index.d.ts
@@ -57,6 +57,22 @@ export interface Settings {
   timestampsInSnapshots?: boolean;
 }
 
+/** Settings used to configure Firestore persistence. */
+export interface PersistenceSettings {
+  /**
+   * Whether to synchronize the in-memory state of multiple tabs. Setting this
+   * to 'true' in all open tabs enables shared access to local persistence,
+   * shared execution of queries and latency-compensated local document updates
+   * across all connected instances.
+   *
+   * To enable this mode, `synchronizeTabs:true` needs to be set globally in
+   * all active tabs.
+   *
+   * NOTE: This mode is experimental.
+   */
+  synchronizeTabs?: boolean;
+}
+
 export type LogLevel = 'debug' | 'error' | 'silent';
 
 export function setLogLevel(logLevel: LogLevel): void;
@@ -91,10 +107,11 @@ export class FirebaseFirestore {
    *   * unimplemented: The browser is incompatible with the offline
    *     persistence implementation.
    *
+   * @param settings Optional settings object to configure persistence.
    * @return A promise that represents successfully enabling persistent
    * storage.
    */
-  enablePersistence(): Promise<void>;
+  enablePersistence(settings?: PersistenceSettings): Promise<void>;
 
   /**
    * Gets a `CollectionReference` instance that refers to the collection at

--- a/packages/firestore-types/index.d.ts
+++ b/packages/firestore-types/index.d.ts
@@ -57,7 +57,10 @@ export interface Settings {
   timestampsInSnapshots?: boolean;
 }
 
-/** Settings used to configure Firestore persistence. */
+/**
+ * Settings that can be passed to Firestore.enablePersistence() to configure
+ * Firestore persistence.
+ */
 export interface PersistenceSettings {
   /**
    * Whether to synchronize the in-memory state of multiple tabs. Setting this
@@ -66,9 +69,10 @@ export interface PersistenceSettings {
    * across all connected instances.
    *
    * To enable this mode, `synchronizeTabs:true` needs to be set globally in
-   * all active tabs.
+   * all active tabs. If omitted or set to 'false', `enablePersistence()` will
+   * will fail in all but the first tab.
    *
-   * NOTE: This mode is experimental.
+   * NOTE: This mode is experimental and not yet recommended for production use.
    */
   synchronizeTabs?: boolean;
 }

--- a/packages/firestore-types/index.d.ts
+++ b/packages/firestore-types/index.d.ts
@@ -70,7 +70,7 @@ export interface PersistenceSettings {
    *
    * To enable this mode, `synchronizeTabs:true` needs to be set globally in
    * all active tabs. If omitted or set to 'false', `enablePersistence()` will
-   * will fail in all but the first tab.
+   * fail in all but the first tab.
    *
    * NOTE: This mode is experimental and not yet recommended for production use.
    */

--- a/packages/firestore/src/api/database.ts
+++ b/packages/firestore/src/api/database.ts
@@ -98,9 +98,12 @@ import {
 // underscore to discourage their use.
 // tslint:disable:strip-private-property-underscore
 
+// settings() defaults:
 const DEFAULT_HOST = 'firestore.googleapis.com';
 const DEFAULT_SSL = true;
 const DEFAULT_TIMESTAMPS_IN_SNAPSHOTS = false;
+
+// enablePersistence() defaults:
 const DEFAULT_SYNCHRONIZE_TABS = false;
 
 /** Undocumented, private additional settings not exposed in our public API. */

--- a/packages/firestore/src/api/database.ts
+++ b/packages/firestore/src/api/database.ts
@@ -101,6 +101,7 @@ import {
 const DEFAULT_HOST = 'firestore.googleapis.com';
 const DEFAULT_SSL = true;
 const DEFAULT_TIMESTAMPS_IN_SNAPSHOTS = false;
+const DEFAULT_SYNCHRONIZE_TABS = false;
 
 /** Undocumented, private additional settings not exposed in our public API. */
 interface PrivateSettings extends firestore.Settings {
@@ -199,6 +200,37 @@ class FirestoreConfig {
 }
 
 /**
+ * Encapsulates the settings that can be used to configure Firestore
+ * persistence.
+ */
+export class PersistenceSettings {
+  /** Whether to enable multi-tab synchronization. */
+  synchronizeTabs: boolean;
+
+  constructor(
+    readonly enabled: boolean,
+    settings?: firestore.PersistenceSettings
+  ) {
+    assert(
+      enabled || !settings,
+      'Can only provide PersistenceSettings with persistence enabled'
+    );
+    settings = settings || {};
+    this.synchronizeTabs = objUtils.defaulted(
+      settings.synchronizeTabs,
+      DEFAULT_SYNCHRONIZE_TABS
+    );
+  }
+
+  isEqual(other: PersistenceSettings): boolean {
+    return (
+      this.enabled === other.enabled &&
+      this.synchronizeTabs === other.synchronizeTabs
+    );
+  }
+}
+
+/**
  * The root reference to the database.
  */
 export class Firestore implements firestore.FirebaseFirestore, FirebaseService {
@@ -291,7 +323,7 @@ export class Firestore implements firestore.FirebaseFirestore, FirebaseService {
     return this._firestoreClient.disableNetwork();
   }
 
-  enablePersistence(): Promise<void> {
+  enablePersistence(settings?: firestore.PersistenceSettings): Promise<void> {
     if (this._firestoreClient) {
       throw new FirestoreError(
         Code.FAILED_PRECONDITION,
@@ -301,17 +333,21 @@ export class Firestore implements firestore.FirebaseFirestore, FirebaseService {
       );
     }
 
-    return this.configureClient(/* persistence= */ true);
+    return this.configureClient(
+      new PersistenceSettings(/* enabled= */ true, settings)
+    );
   }
 
   ensureClientConfigured(): FirestoreClient {
     if (!this._firestoreClient) {
-      this.configureClient(/* persistence= */ false);
+      this.configureClient(new PersistenceSettings(/* enabled= */ false));
     }
     return this._firestoreClient as FirestoreClient;
   }
 
-  private configureClient(persistence: boolean): Promise<void> {
+  private configureClient(
+    persistenceSettings: PersistenceSettings
+  ): Promise<void> {
     assert(
       !!this._config.settings.host,
       'FirestoreSettings.host cannot be falsey'
@@ -377,7 +413,7 @@ follow these steps, YOUR APP MAY BREAK.`);
       this._config.credentials,
       this._queue
     );
-    return this._firestoreClient.start(persistence);
+    return this._firestoreClient.start(persistenceSettings);
   }
 
   private static databaseIdFromApp(app: FirebaseApp): DatabaseId {

--- a/packages/firestore/src/core/firestore_client.ts
+++ b/packages/firestore/src/core/firestore_client.ts
@@ -137,8 +137,8 @@ export class FirestoreClient {
    * fallback succeeds we signal success to the async queue even though the
    * start() itself signals failure.
    *
-   * @param persistenceSettings Settings object for the suggested persistence
-   *     mode.
+   * @param persistenceSettings Settings object to configure offline
+   *     persistence.
    * @returns A deferred result indicating the user-visible result of enabling
    *     offline persistence. This method will reject this if IndexedDB fails to
    *     start for any reason. If usePersistence is false this is
@@ -302,7 +302,7 @@ export class FirestoreClient {
     });
 
     return Promise.resolve().then(() => {
-      const persistence = new IndexedDbPersistence(
+      const persistence: IndexedDbPersistence = new IndexedDbPersistence(
         storagePrefix,
         this.clientId,
         this.platform,
@@ -315,12 +315,10 @@ export class FirestoreClient {
         settings.synchronizeTabs &&
         !WebStorageSharedClientState.isAvailable(this.platform)
       ) {
-        if (process.env.USE_MOCK_PERSISTENCE !== 'YES') {
-          throw new FirestoreError(
-            Code.UNIMPLEMENTED,
-            'IndexedDB persistence is only available on platforms that support LocalStorage.'
-          );
-        }
+        throw new FirestoreError(
+          Code.UNIMPLEMENTED,
+          'IndexedDB persistence is only available on platforms that support LocalStorage.'
+        );
       }
 
       this.sharedClientState = settings.synchronizeTabs

--- a/packages/firestore/src/core/firestore_client.ts
+++ b/packages/firestore/src/core/firestore_client.ts
@@ -59,6 +59,8 @@ import {
   WebStorageSharedClientState
 } from '../local/shared_client_state';
 import { AutoId } from '../util/misc';
+import { PersistenceSettings } from '../api/database';
+import { assert } from '../util/assert';
 
 const LOG_TAG = 'FirestoreClient';
 
@@ -135,13 +137,14 @@ export class FirestoreClient {
    * fallback succeeds we signal success to the async queue even though the
    * start() itself signals failure.
    *
-   * @param usePersistence Whether or not to attempt to enable persistence.
+   * @param persistenceSettings Settings object for the suggested persistence
+   *     mode.
    * @returns A deferred result indicating the user-visible result of enabling
    *     offline persistence. This method will reject this if IndexedDB fails to
    *     start for any reason. If usePersistence is false this is
    *     unconditionally resolved.
    */
-  start(usePersistence: boolean): Promise<void> {
+  start(persistenceSettings: PersistenceSettings): Promise<void> {
     // We defer our initialization until we get the current user from
     // setUserChangeListener(). We block the async queue until we got the
     // initial user and the initialization is completed. This will prevent
@@ -164,7 +167,7 @@ export class FirestoreClient {
       if (!initialized) {
         initialized = true;
 
-        this.initializePersistence(usePersistence, persistenceResult, user)
+        this.initializePersistence(persistenceSettings, persistenceResult, user)
           .then(() => this.initializeRest(user))
           .then(initializationDone.resolve, initializationDone.reject);
       } else {
@@ -200,7 +203,7 @@ export class FirestoreClient {
    * platform can't possibly support our implementation then this method rejects
    * the persistenceResult and falls back on memory-only persistence.
    *
-   * @param usePersistence indicates whether or not to use offline persistence
+   * @param persistenceSettings Settings object to configure offline persistence
    * @param persistenceResult A deferred result indicating the user-visible
    *     result of enabling offline persistence. This method will reject this if
    *     IndexedDB fails to start for any reason. If usePersistence is false
@@ -210,12 +213,12 @@ export class FirestoreClient {
    *     succeeded.
    */
   private initializePersistence(
-    usePersistence: boolean,
+    persistenceSettings: PersistenceSettings,
     persistenceResult: Deferred<void>,
     user: User
   ): Promise<void> {
-    if (usePersistence) {
-      return this.startIndexedDbPersistence(user)
+    if (persistenceSettings.enabled) {
+      return this.startIndexedDbPersistence(user, persistenceSettings)
         .then(persistenceResult.resolve)
         .catch(error => {
           // Regardless of whether or not the retry succeeds, from an user
@@ -278,7 +281,15 @@ export class FirestoreClient {
    *
    * @returns A promise indicating success or failure.
    */
-  private startIndexedDbPersistence(user: User): Promise<void> {
+  private startIndexedDbPersistence(
+    user: User,
+    settings: PersistenceSettings
+  ): Promise<void> {
+    assert(
+      settings.enabled,
+      'Should only start IndexedDb persitence with offline persistence enabled.'
+    );
+
     // TODO(http://b/33384523): For now we just disable garbage collection
     // when persistence is enabled.
     this.garbageCollector = new NoOpGarbageCollector();
@@ -291,32 +302,37 @@ export class FirestoreClient {
     });
 
     return Promise.resolve().then(() => {
-      this.persistence = new IndexedDbPersistence(
+      const persistence = new IndexedDbPersistence(
         storagePrefix,
         this.clientId,
         this.platform,
         this.asyncQueue,
         serializer
       );
-      if (WebStorageSharedClientState.isAvailable(this.platform)) {
-        this.sharedClientState = new WebStorageSharedClientState(
-          this.asyncQueue,
-          this.platform,
-          storagePrefix,
-          this.clientId,
-          user
-        );
-      } else {
+      this.persistence = persistence;
+
+      if (
+        settings.synchronizeTabs &&
+        !WebStorageSharedClientState.isAvailable(this.platform)
+      ) {
         if (process.env.USE_MOCK_PERSISTENCE !== 'YES') {
           throw new FirestoreError(
             Code.UNIMPLEMENTED,
             'IndexedDB persistence is only available on platforms that support LocalStorage.'
           );
         }
-        debug(LOG_TAG, 'Starting Persistence in test-only non multi-tab mode');
-        this.sharedClientState = new MemorySharedClientState();
       }
-      return this.persistence.start();
+
+      this.sharedClientState = settings.synchronizeTabs
+        ? new WebStorageSharedClientState(
+            this.asyncQueue,
+            this.platform,
+            storagePrefix,
+            this.clientId,
+            user
+          )
+        : new MemorySharedClientState();
+      return persistence.start(settings.synchronizeTabs);
     });
   }
 
@@ -420,11 +436,11 @@ export class FirestoreClient {
     return this.asyncQueue.enqueue(async () => {
       // PORTING NOTE: LocalStore does not need an explicit shutdown on web.
       await this.syncEngine.shutdown();
-      await this.remoteStore.shutdown();
       await this.sharedClientState.shutdown();
       await this.persistence.shutdown(
         options && options.purgePersistenceWithDataLoss
       );
+      await this.remoteStore.shutdown();
 
       // `removeUserChangeListener` must be called after shutting down the
       // RemoteStore as it will prevent the RemoteStore from retrieving

--- a/packages/firestore/src/local/indexeddb_persistence.ts
+++ b/packages/firestore/src/local/indexeddb_persistence.ts
@@ -72,6 +72,10 @@ const ZOMBIED_PRIMARY_LOCALSTORAGE_SUFFIX = 'zombiedClientId';
 const PRIMARY_LEASE_LOST_ERROR_MSG =
   'The current tab is not in the required state to perform this operation. ' +
   'It might be necessary to refresh the browser tab.';
+const PRIMARY_LEASE_EXCLUSIVE_ERROR_MSG =
+  'Another tab has exclusive access to the persistence layer. ' +
+  'To allow shared access, make sure to invoke ' +
+  '`enablePersistence()` with `synchronizeTabs:true` in all tabs.';
 const UNSUPPORTED_PLATFORM_ERROR_MSG =
   'This platform is either missing' +
   ' IndexedDB or is known to have an incomplete implementation. Offline' +
@@ -141,6 +145,9 @@ export class IndexedDbPersistence implements Persistence {
   /** The client metadata refresh task. */
   private clientMetadataRefresher: CancelablePromise<void>;
 
+  /** Whether to allow shared multi-tab access to the persistence layer. */
+  private allowTabSynchronization: boolean;
+
   /** A listener to notify on primary state changes. */
   private primaryStateListener: PrimaryStateListener = _ => Promise.resolve();
 
@@ -158,7 +165,14 @@ export class IndexedDbPersistence implements Persistence {
     this.window = platform.window;
   }
 
-  start(): Promise<void> {
+  /**
+   * Attempt to start IndexedDb persistence.
+   *
+   * @param {boolean} synchronizeTabs Whether to enable shared persistence
+   *     across multiple tabs.
+   * @return {Promise<void>} Whether persistence was enabled.
+   */
+  start(synchronizeTabs?: boolean): Promise<void> {
     if (!IndexedDbPersistence.isAvailable()) {
       this.persistenceError = new FirestoreError(
         Code.UNIMPLEMENTED,
@@ -168,6 +182,7 @@ export class IndexedDbPersistence implements Persistence {
     }
 
     assert(!this.started, 'IndexedDbPersistence double-started!');
+    this.allowTabSynchronization = !!synchronizeTabs;
     this.started = true;
 
     assert(this.window !== null, "Expected 'window' to be defined");
@@ -205,7 +220,11 @@ export class IndexedDbPersistence implements Persistence {
         .next(canActAsPrimary => {
           if (canActAsPrimary !== this.isPrimary) {
             this.isPrimary = canActAsPrimary;
-            this.queue.enqueue(() => this.primaryStateListener(this.isPrimary));
+            this.queue.enqueue(async () => {
+              if (this.started) {
+                return this.primaryStateListener(this.isPrimary);
+              }
+            });
           }
 
           if (this.isPrimary) {
@@ -263,7 +282,18 @@ export class IndexedDbPersistence implements Persistence {
           currentPrimary.ownerId !== this.getZombiedClientId();
 
         if (currentLeaseIsValid) {
-          return this.isLocalClient(currentPrimary);
+          if (this.isLocalClient(currentPrimary)) {
+            return true;
+          }
+
+          if (!currentPrimary.allowTabSynchronization) {
+            throw new FirestoreError(
+              Code.FAILED_PRECONDITION,
+              PRIMARY_LEASE_EXCLUSIVE_ERROR_MSG
+            );
+          }
+
+          return false;
         }
 
         // Check if this client is eligible for a primary lease based on its
@@ -310,7 +340,9 @@ export class IndexedDbPersistence implements Persistence {
     // entry to Local Storage first to indicate that we are no longer alive.
     // This will help us when the shutdown handler doesn't run to completion.
     this.started = false;
-    this.clientMetadataRefresher.cancel();
+    if (this.clientMetadataRefresher) {
+      this.clientMetadataRefresher.cancel();
+    }
     this.detachVisibilityHandler();
     this.detachWindowUnloadHook();
     await this.releasePrimaryLeaseIfHeld();
@@ -399,7 +431,11 @@ export class IndexedDbPersistence implements Persistence {
    * method does not verify that the client is eligible for this lease.
    */
   private acquireOrExtendPrimaryLease(txn): PersistencePromise<void> {
-    const newPrimary = new DbOwner(this.clientId, Date.now());
+    const newPrimary = new DbOwner(
+      this.clientId,
+      this.allowTabSynchronization,
+      Date.now()
+    );
     return ownerStore(txn).put('owner', newPrimary);
   }
 

--- a/packages/firestore/src/local/indexeddb_persistence.ts
+++ b/packages/firestore/src/local/indexeddb_persistence.ts
@@ -295,9 +295,9 @@ export class IndexedDbPersistence implements Persistence {
             // `enablePersistence()` and the user can continue to use Firestore
             // with in-memory persistence.
             // If this fails during a lease refresh, we will instead block the
-            // AsyncQueue from execution further operations. Note that this is
+            // AsyncQueue from executing further operations. Note that this is
             // acceptable since mixing & matching different `synchronizeTabs`
-            // settings is not officially supported.
+            // settings is not supported.
             //
             // TODO(multitab): Remove this check when `synchronizeTabs` can no
             // longer be turned off.

--- a/packages/firestore/src/local/indexeddb_schema.ts
+++ b/packages/firestore/src/local/indexeddb_schema.ts
@@ -113,7 +113,12 @@ export class DbOwner {
   /** Name of the IndexedDb object store. */
   static store = 'owner';
 
-  constructor(public ownerId: string, public leaseTimestampMs: number) {}
+  constructor(
+    public ownerId: string,
+    /** Whether to allow shared access from multiple tabs. */
+    public allowTabSynchronization: boolean,
+    public leaseTimestampMs: number
+  ) {}
 }
 
 function createOwnerStore(db: IDBDatabase): void {

--- a/packages/firestore/src/local/simple_db.ts
+++ b/packages/firestore/src/local/simple_db.ts
@@ -310,7 +310,7 @@ export class SimpleDbTransaction {
     if (!this.aborted) {
       debug(
         LOG_TAG,
-        'Aborting transaction: %s',
+        'Aborting transaction:',
         error ? error.message : 'Client-initiated abort'
       );
       this.aborted = true;

--- a/packages/firestore/test/unit/local/indexeddb_schema.test.ts
+++ b/packages/firestore/test/unit/local/indexeddb_schema.test.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+// TODO(multitab): Rename this file to `indexeddb_persistence.test.ts`.
+
 import { expect } from 'chai';
 import { IndexedDbPersistence } from '../../../src/local/indexeddb_persistence';
 import {
@@ -250,8 +252,7 @@ describe('IndexedDb: allowTabSynchronization', () => {
 
   it('rejects access when synchronization is disabled', () => {
     return withPersistence('clientA', async db1 => {
-      await expect(db1.start(/*synchronizeTabs=*/ false)).to.eventually.be
-        .fulfilled;
+      await db1.start(/*synchronizeTabs=*/ false);
       await withPersistence('clientB', async db2 => {
         await expect(
           db2.start(/*synchronizeTabs=*/ false)
@@ -264,11 +265,9 @@ describe('IndexedDb: allowTabSynchronization', () => {
 
   it('grants access when synchronization is enabled', async () => {
     return withPersistence('clientA', async db1 => {
-      await expect(db1.start(/*synchronizeTabs=*/ true)).to.eventually.be
-        .fulfilled;
+      await db1.start(/*synchronizeTabs=*/ true);
       await withPersistence('clientB', async db2 => {
-        await expect(db2.start(/*synchronizeTabs=*/ true)).to.eventually.be
-          .fulfilled;
+        await db2.start(/*synchronizeTabs=*/ true);
       });
     });
   });

--- a/packages/firestore/test/unit/local/persistence_test_helpers.ts
+++ b/packages/firestore/test/unit/local/persistence_test_helpers.ts
@@ -58,7 +58,7 @@ export async function testIndexedDbPersistence(
   queue = queue || new AsyncQueue();
   clientId = clientId || AutoId.newId();
 
-  const prefix = '${TEST_PERSISTENCE_PREFIX}/';
+  const prefix = `${TEST_PERSISTENCE_PREFIX}/`;
   await SimpleDb.delete(prefix + IndexedDbPersistence.MAIN_DATABASE);
   const partition = new DatabaseId('project');
   const serializer = new JsonProtoSerializer(partition, {

--- a/packages/firestore/test/unit/specs/spec_test_runner.ts
+++ b/packages/firestore/test/unit/specs/spec_test_runner.ts
@@ -463,6 +463,8 @@ abstract class TestRunner {
     serializer: JsonProtoSerializer
   ): Persistence;
 
+  protected abstract startPersistence(persistence: Persistence): Promise<void>;
+
   protected abstract getSharedClientState(): SharedClientState;
 
   get isPrimaryClient(): boolean {
@@ -471,7 +473,7 @@ abstract class TestRunner {
 
   async start(): Promise<void> {
     this.connection.reset();
-    await this.persistence.start();
+    await this.startPersistence(this.persistence);
     await this.localStore.start();
     await this.sharedClientState.start();
     await this.remoteStore.start();
@@ -1134,6 +1136,10 @@ class MemoryTestRunner extends TestRunner {
   protected getSharedClientState(): SharedClientState {
     return new MemorySharedClientState();
   }
+
+  protected startPersistence(persistence: Persistence): Promise<void> {
+    return persistence.start();
+  }
 }
 
 /**
@@ -1384,6 +1390,12 @@ class IndexedDbTestRunner extends TestRunner {
       IndexedDbTestRunner.TEST_DB_NAME,
       this.clientId,
       this.user
+    );
+  }
+
+  protected startPersistence(persistence: Persistence): Promise<void> {
+    return (persistence as IndexedDbPersistence).start(
+      /*synchronizeTabs=*/ true
     );
   }
 


### PR DESCRIPTION
This PR adds the yet-to-be approved API to make multi-tab optional.

It also fixes a race during the shutdown: We need to shut down the persistence layer before we shut down the remote store, as the persistence layer could end up calling the remote store even when it is already destroyed.

TODO: Rename `indexeddb_schema.test.ts` to something more applicable once Multi-Tab is merged.