### PR TITLE
[Multi-Tab]  Supporting non-initial initial queries

### DIFF
--- a/packages/firestore/src/core/event_manager.ts
+++ b/packages/firestore/src/core/event_manager.ts
@@ -19,7 +19,6 @@ import { SyncEngine } from './sync_engine';
 import { OnlineState, TargetId } from './types';
 import { DocumentViewChange } from './view_snapshot';
 import { ChangeType, ViewSnapshot } from './view_snapshot';
-import { DocumentSet } from '../model/document_set';
 import { assert } from '../util/assert';
 import { EventHandler } from '../util/misc';
 import { ObjectMap } from '../util/obj_map';
@@ -289,28 +288,13 @@ export class QueryListener {
       !this.raisedInitialEvent,
       'Trying to raise initial events for second time'
     );
-    snap = new ViewSnapshot(
+    snap = ViewSnapshot.fromSyncedDocuments(
       snap.query,
       snap.docs,
-      DocumentSet.emptySet(snap.docs),
-      QueryListener.getInitialViewChanges(snap),
       snap.fromCache,
-      snap.hasPendingWrites,
-      /* syncChangesState= */ true,
-      /* excludesMetadataChanges= */ false
+      snap.hasPendingWrites
     );
     this.raisedInitialEvent = true;
     this.queryObserver.next(snap);
-  }
-
-  /** Returns changes as if all documents in the snap were added. */
-  private static getInitialViewChanges(
-    snap: ViewSnapshot
-  ): DocumentViewChange[] {
-    const result: DocumentViewChange[] = [];
-    snap.docs.forEach(doc => {
-      result.push({ type: ChangeType.Added, doc });
-    });
-    return result;
   }
 }

--- a/packages/firestore/src/core/event_manager.ts
+++ b/packages/firestore/src/core/event_manager.ts
@@ -288,7 +288,7 @@ export class QueryListener {
       !this.raisedInitialEvent,
       'Trying to raise initial events for second time'
     );
-    snap = ViewSnapshot.fromSyncedDocuments(
+    snap = ViewSnapshot.fromInitialDocuments(
       snap.query,
       snap.docs,
       snap.fromCache,

--- a/packages/firestore/src/core/sync_engine.ts
+++ b/packages/firestore/src/core/sync_engine.ts
@@ -212,6 +212,7 @@ export class SyncEngine implements RemoteSyncer, SharedClientStateSyncer {
     this.viewHandler!([viewSnapshot]);
     return targetId;
   }
+
   private initializeViewAndComputeInitialSnapshot(
     queryData: QueryData,
     current: boolean

--- a/packages/firestore/src/core/sync_engine.ts
+++ b/packages/firestore/src/core/sync_engine.ts
@@ -177,30 +177,41 @@ export class SyncEngine implements RemoteSyncer, SharedClientStateSyncer {
    * server. All the subsequent view snapshots or errors are sent to the
    * subscribed handlers. Returns the targetId of the query.
    */
-  listen(query: Query): Promise<TargetId> {
+  async listen(query: Query): Promise<TargetId> {
     this.assertSubscribed('listen()');
-    assert(
-      !this.queryViewsByQuery.has(query),
-      'We already listen to the query: ' + query
-    );
 
-    return this.localStore.allocateQuery(query).then(queryData => {
+    let targetId;
+    let viewSnapshot;
+
+    const queryView = this.queryViewsByQuery.get(query);
+    if (queryView) {
+      // PORTING NOTE: With Mult-Tab Web, it is possible that a query view
+      // already exists when EventManager calls us for the first time. This
+      // happens when the primary tab is already listening to this query on
+      // behalf of another tab and the user of the primary also starts listening
+      // to the query. EventManager will not have an assigned target ID in this
+      // case and calls `listen` to obtain this ID.
+      targetId = queryView.targetId;
+      this.sharedClientState.addLocalQueryTarget(targetId);
+      viewSnapshot = queryView.view.computeInitialSnapshot();
+    } else {
+      const queryData = await this.localStore.allocateQuery(query);
       const status = this.sharedClientState.addLocalQueryTarget(
         queryData.targetId
       );
-      return this.initializeViewAndComputeInitialSnapshot(
+      targetId = queryData.targetId;
+      viewSnapshot = await this.initializeViewAndComputeInitialSnapshot(
         queryData,
         status === 'current'
-      ).then(viewSnapshot => {
-        if (this.isPrimary) {
-          this.remoteStore.listen(queryData);
-        }
-        this.viewHandler!([viewSnapshot]);
-        return queryData.targetId;
-      });
-    });
-  }
+      );
+      if (this.isPrimary) {
+        this.remoteStore.listen(queryData);
+      }
+    }
 
+    this.viewHandler!([viewSnapshot]);
+    return targetId;
+  }
   private initializeViewAndComputeInitialSnapshot(
     queryData: QueryData,
     current: boolean

--- a/packages/firestore/src/core/view.ts
+++ b/packages/firestore/src/core/view.ts
@@ -395,7 +395,7 @@ export class View {
    */
   // PORTING NOTE: Multi-tab only.
   computeInitialSnapshot(): ViewSnapshot {
-    return ViewSnapshot.fromSyncedDocuments(
+    return ViewSnapshot.fromInitialDocuments(
       this.query,
       this.documentSet,
       this.syncState === SyncState.Local,

--- a/packages/firestore/src/core/view.ts
+++ b/packages/firestore/src/core/view.ts
@@ -383,8 +383,24 @@ export class View {
     return changes;
   }
 
+  // PORTING NOTE: Multi-tab only.
   synchronizeWithRemoteKeys(remoteKeys: DocumentKeySet): void {
     this._syncedDocuments = remoteKeys;
+  }
+
+  /**
+   * Returns a view snapshot as if this query was just listened to. Contains
+   * a document add for every existing document and the `fromCache` and
+   * `hasPendingWrites` status of the already established view.
+   */
+  // PORTING NOTE: Multi-tab only.
+  computeInitialSnapshot(): ViewSnapshot {
+    return ViewSnapshot.fromSyncedDocuments(
+      this.query,
+      this.documentSet,
+      this.syncState === SyncState.Local,
+      !this.mutatedKeys.isEmpty()
+    );
   }
 }
 

--- a/packages/firestore/src/core/view_snapshot.ts
+++ b/packages/firestore/src/core/view_snapshot.ts
@@ -150,7 +150,7 @@ export class ViewSnapshot {
   ) {}
 
   /** Returns a view snapshot as if all documents in the snapshot were added. */
-  static fromSyncedDocuments(
+  static fromInitialDocuments(
     query: Query,
     documents: DocumentSet,
     fromCache: boolean,

--- a/packages/firestore/src/core/view_snapshot.ts
+++ b/packages/firestore/src/core/view_snapshot.ts
@@ -155,7 +155,7 @@ export class ViewSnapshot {
     documents: DocumentSet,
     fromCache: boolean,
     hasPendingWrites: boolean
-  ) : ViewSnapshot {
+  ): ViewSnapshot {
     const changeSet = new DocumentChangeSet();
     documents.forEach(doc => {
       changeSet.track({ type: ChangeType.Added, doc });

--- a/packages/firestore/src/core/view_snapshot.ts
+++ b/packages/firestore/src/core/view_snapshot.ts
@@ -149,6 +149,30 @@ export class ViewSnapshot {
     readonly excludesMetadataChanges: boolean
   ) {}
 
+  /** Returns a view snapshot as if all documents in the snapshot were added. */
+  static fromSyncedDocuments(
+    query: Query,
+    documents: DocumentSet,
+    fromCache: boolean,
+    hasPendingWrites: boolean
+  ) : ViewSnapshot {
+    const changeSet = new DocumentChangeSet();
+    documents.forEach(doc => {
+      changeSet.track({ type: ChangeType.Added, doc });
+    });
+
+    return new ViewSnapshot(
+      query,
+      documents,
+      DocumentSet.emptySet(documents),
+      changeSet.getChanges(),
+      fromCache,
+      hasPendingWrites,
+      /* syncStateChanged */ true,
+      /* excludesMetadataChanges= */ false
+    );
+  }
+
   isEqual(other: ViewSnapshot): boolean {
     if (
       this.fromCache !== other.fromCache ||


### PR DESCRIPTION
This PR adds support for queries that SyncEngine knows about but EventManager doesn't.