### PR TITLE
[Multi-Tab] Using fixed client IDs in spec tests

### DIFF
--- a/packages/firestore/test/unit/specs/spec_test_runner.ts
+++ b/packages/firestore/test/unit/specs/spec_test_runner.ts
@@ -76,7 +76,7 @@ import {
 import { assert, fail } from '../../../src/util/assert';
 import { AsyncQueue, TimerId } from '../../../src/util/async_queue';
 import { FirestoreError } from '../../../src/util/error';
-import { AnyDuringMigration, AnyJs, AutoId } from '../../../src/util/misc';
+import { AnyDuringMigration, AnyJs } from '../../../src/util/misc';
 import * as obj from '../../../src/util/obj';
 import { ObjectMap } from '../../../src/util/obj_map';
 import { Deferred, sequence } from '../../../src/util/promise';
@@ -385,9 +385,10 @@ abstract class TestRunner {
   constructor(
     protected readonly platform: TestPlatform,
     private sharedWrites: SharedWriteTracker,
+    clientIndex: number,
     config: SpecConfig
   ) {
-    this.clientId = AutoId.newId();
+    this.clientId = `client${clientIndex}`;
     this.databaseInfo = new DatabaseInfo(
       new DatabaseId('project'),
       'persistenceKey',
@@ -1424,12 +1425,14 @@ export async function runSpec(
         runners[clientIndex] = new IndexedDbTestRunner(
           platform,
           outstandingMutations,
+          clientIndex,
           config
         );
       } else {
         runners[clientIndex] = new MemoryTestRunner(
           platform,
           outstandingMutations,
+          clientIndex,
           config
         );
       }


### PR DESCRIPTION
Making Multi-Tab easier to debug by using predicable client IDs in the multi-tab spec tests.