### PR TITLE
[Multi-Tab] Making Platform, Window and Document Mock available in all tests

### DIFF
--- a/packages/firestore/test/unit/specs/spec_test_runner.ts
+++ b/packages/firestore/test/unit/specs/spec_test_runner.ts
@@ -52,7 +52,6 @@ import { JsonObject } from '../../../src/model/field_value';
 import { Mutation } from '../../../src/model/mutation';
 import {
   emptyByteString,
-  Platform,
   PlatformSupport
 } from '../../../src/platform/platform';
 import { Connection, Stream } from '../../../src/remote/connection';
@@ -99,6 +98,7 @@ import {
   SharedClientState,
   WebStorageSharedClientState
 } from '../../../src/local/shared_client_state';
+import { MockPlatform, SharedMockStorage } from '../../util/mock_platform';
 
 class MockConnection implements Connection {
   watchStream: StreamBridge<
@@ -383,7 +383,7 @@ abstract class TestRunner {
   private serializer: JsonProtoSerializer;
 
   constructor(
-    protected readonly platform: TestPlatform,
+    protected readonly platform: MockPlatform,
     private sharedWrites: SharedWriteTracker,
     config: SpecConfig
   ) {
@@ -1137,230 +1137,6 @@ class MemoryTestRunner extends TestRunner {
 }
 
 /**
- * `Document` mock that implements the `visibilitychange` API used by Firestore.
- */
-class MockDocument {
-  private _visibilityState: VisibilityState = 'unloaded';
-  private visibilityListener: EventListener | null;
-
-  get visibilityState(): VisibilityState {
-    return this._visibilityState;
-  }
-
-  addEventListener(type: string, listener: EventListener): void {
-    assert(
-      type === 'visibilitychange',
-      "MockDocument only supports events of type 'visibilitychange'"
-    );
-    this.visibilityListener = listener;
-  }
-
-  removeEventListener(type: string, listener: EventListener): void {
-    if (listener === this.visibilityListener) {
-      this.visibilityListener = null;
-    }
-  }
-
-  raiseVisibilityEvent(visibility: VisibilityState): void {
-    this._visibilityState = visibility;
-    if (this.visibilityListener) {
-      this.visibilityListener(new Event('visibilitychange'));
-    }
-  }
-}
-
-/**
- * `WebStorage` mock that implements the WebStorage behavior for multiple
- * clients. To get a client-specific storage area that implements the WebStorage
- * API, invoke `getStorageArea(storageListener)`.
- */
-class SharedMockStorage {
-  private readonly data = new Map<string, string>();
-  private readonly activeClients: Array<{
-    storageListener: EventListener;
-    storageArea: Storage;
-  }> = [];
-
-  getStorageArea(storageListener: EventListener): Storage {
-    const clientIndex = this.activeClients.length;
-    const self = this;
-
-    const storageArea: Storage = {
-      get length(): number {
-        return self.length;
-      },
-      getItem: (key: string) => this.getItem(key),
-      key: (index: number) => this.key(index),
-      clear: () => this.clear(),
-      removeItem: (key: string) => {
-        const oldValue = this.getItem(key);
-        this.removeItem(key);
-        this.raiseStorageEvent(clientIndex, key, oldValue, null);
-      },
-      setItem: (key: string, value: string) => {
-        const oldValue = this.getItem(key);
-        this.setItem(key, value);
-        this.raiseStorageEvent(clientIndex, key, oldValue, value);
-      }
-    };
-
-    this.activeClients[clientIndex] = { storageListener, storageArea };
-
-    return storageArea;
-  }
-
-  private clear(): void {
-    this.data.clear();
-  }
-
-  private getItem(key: string): string | null {
-    return this.data.get(key);
-  }
-
-  private key(index: number): string | null {
-    return Array.from(this.data.keys())[index];
-  }
-
-  private removeItem(key: string): void {
-    this.data.delete(key);
-  }
-
-  private setItem(key: string, data: string): void {
-    this.data.set(key, data);
-  }
-
-  private get length(): number {
-    return this.data.size;
-  }
-
-  private raiseStorageEvent(
-    sourceClientIndex: number,
-    key: string,
-    oldValue: string | null,
-    newValue: string | null
-  ): void {
-    this.activeClients.forEach((client, index) => {
-      // WebStorage doesn't raise events for writes from the originating client.
-      if (sourceClientIndex === index) {
-        return;
-      }
-
-      client.storageListener({
-        key,
-        oldValue,
-        newValue,
-        storageArea: client.storageArea
-      } as any); // tslint:disable-line:no-any Not mocking entire Event type.
-    });
-  }
-}
-
-/**
- * `Window` mock that implements the event and storage API that is used by
- * Firestore.
- */
-class MockWindow {
-  private readonly storageArea: Storage;
-  private storageListener: EventListener = () => {};
-
-  constructor(sharedMockStorage: SharedMockStorage) {
-    this.storageArea = sharedMockStorage.getStorageArea(event =>
-      this.storageListener(event)
-    );
-  }
-
-  get localStorage(): Storage {
-    return this.storageArea;
-  }
-
-  get indexedDB(): IDBFactory {
-    return window.indexedDB;
-  }
-
-  addEventListener(type: string, listener: EventListener): void {
-    switch (type) {
-      case 'storage':
-        this.storageListener = listener;
-        break;
-      case 'unload':
-        // The spec tests currently do not rely on 'unload' listeners.
-        break;
-      default:
-        fail(`MockWindow doesn't support events of type '${type}'`);
-    }
-  }
-
-  removeEventListener(type: string, listener: EventListener): void {
-    if (type === 'storage') {
-      assert(
-        this.storageListener === listener,
-        "Listener passed to 'removeEventListener' doesn't match the current listener."
-      );
-      this.storageListener = () => {};
-    }
-  }
-}
-
-/**
- * Implementation of `Platform` that allows mocking of `document` and `window`.
- */
-class TestPlatform implements Platform {
-  readonly mockDocument: MockDocument | null = null;
-  readonly mockWindow: MockWindow | null = null;
-
-  constructor(
-    private readonly basePlatform: Platform,
-    private readonly mockStorage: SharedMockStorage
-  ) {
-    this.mockDocument = new MockDocument();
-    this.mockWindow = new MockWindow(this.mockStorage);
-  }
-
-  get document(): Document | null {
-    // tslint:disable-next-line:no-any MockWindow doesn't support full Document interface.
-    return this.mockDocument as any;
-  }
-
-  get window(): Window | null {
-    // tslint:disable-next-line:no-any MockWindow doesn't support full Window interface.
-    return this.mockWindow as any;
-  }
-
-  get base64Available(): boolean {
-    return this.basePlatform.base64Available;
-  }
-
-  get emptyByteString(): ProtoByteString {
-    return this.basePlatform.emptyByteString;
-  }
-
-  raiseVisibilityEvent(visibility: VisibilityState): void {
-    if (this.mockDocument) {
-      this.mockDocument.raiseVisibilityEvent(visibility);
-    }
-  }
-
-  loadConnection(databaseInfo: DatabaseInfo): Promise<Connection> {
-    return this.basePlatform.loadConnection(databaseInfo);
-  }
-
-  newSerializer(databaseId: DatabaseId): JsonProtoSerializer {
-    return this.basePlatform.newSerializer(databaseId);
-  }
-
-  formatJSON(value: AnyJs): string {
-    return this.basePlatform.formatJSON(value);
-  }
-
-  atob(encoded: string): string {
-    return this.basePlatform.atob(encoded);
-  }
-
-  btoa(raw: string): string {
-    return this.basePlatform.btoa(raw);
-  }
-}
-/**
  * Runs the specs using IndexedDbPersistence, the creator must ensure that it is
  * enabled for the platform.
  */
@@ -1416,7 +1192,7 @@ export async function runSpec(
 
   const ensureRunner = async clientIndex => {
     if (!runners[clientIndex]) {
-      const platform = new TestPlatform(
+      const platform = new MockPlatform(
         PlatformSupport.getPlatform(),
         sharedMockStorage
       );

--- a/packages/firestore/test/unit/specs/spec_test_runner.ts
+++ b/packages/firestore/test/unit/specs/spec_test_runner.ts
@@ -98,7 +98,7 @@ import {
   SharedClientState,
   WebStorageSharedClientState
 } from '../../../src/local/shared_client_state';
-import { MockPlatform, SharedMockStorage } from '../../util/mock_platform';
+import { TestPlatform, SharedFakeWebStorage } from '../../util/test_platform';
 
 class MockConnection implements Connection {
   watchStream: StreamBridge<
@@ -383,7 +383,7 @@ abstract class TestRunner {
   private serializer: JsonProtoSerializer;
 
   constructor(
-    protected readonly platform: MockPlatform,
+    protected readonly platform: TestPlatform,
     private sharedWrites: SharedWriteTracker,
     config: SpecConfig
   ) {
@@ -1184,7 +1184,7 @@ export async function runSpec(
   // tslint:disable-next-line:no-console
   console.log('Running spec: ' + name);
 
-  const sharedMockStorage = new SharedMockStorage();
+  const sharedMockStorage = new SharedFakeWebStorage();
 
   // PORTING NOTE: Non multi-client SDKs only support a single test runner.
   const runners: TestRunner[] = [];
@@ -1192,7 +1192,7 @@ export async function runSpec(
 
   const ensureRunner = async clientIndex => {
     if (!runners[clientIndex]) {
-      const platform = new MockPlatform(
+      const platform = new TestPlatform(
         PlatformSupport.getPlatform(),
         sharedMockStorage
       );

--- a/packages/firestore/test/util/mock_platform.ts
+++ b/packages/firestore/test/util/mock_platform.ts
@@ -1,0 +1,248 @@
+/**
+ * Copyright 2018 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { DatabaseId, DatabaseInfo } from '../../src/core/database_info';
+import { AnyJs } from '../../src/util/misc';
+import { Platform } from '../../src/platform/platform';
+import { JsonProtoSerializer } from '../../src/remote/serializer';
+import { ProtoByteString } from '../../src/core/types';
+import { Connection } from '../../src/remote/connection';
+import { assert, fail } from '../../src/util/assert';
+
+/**
+ * `Window` mock that implements the event and storage API that is used by
+ * Firestore.
+ */
+export class MockWindow {
+  private readonly storageArea: Storage;
+  private storageListener: EventListener = () => {};
+
+  constructor(sharedMockStorage: SharedMockStorage) {
+    this.storageArea = sharedMockStorage.getStorageArea(event =>
+      this.storageListener(event)
+    );
+  }
+
+  get localStorage(): Storage {
+    return this.storageArea;
+  }
+
+  get indexedDB(): IDBFactory {
+    return window.indexedDB;
+  }
+
+  addEventListener(type: string, listener: EventListener): void {
+    switch (type) {
+      case 'storage':
+        this.storageListener = listener;
+        break;
+      case 'unload':
+        // The spec tests currently do not rely on 'unload' listeners.
+        break;
+      default:
+        fail(`MockWindow doesn't support events of type '${type}'`);
+    }
+  }
+
+  removeEventListener(type: string, listener: EventListener): void {
+    if (type === 'storage') {
+      assert(
+        this.storageListener === listener,
+        "Listener passed to 'removeEventListener' doesn't match the current listener."
+      );
+      this.storageListener = () => {};
+    }
+  }
+}
+
+/**
+ * `Document` mock that implements the `visibilitychange` API used by Firestore.
+ */
+export class MockDocument {
+  private _visibilityState: VisibilityState = 'unloaded';
+  private visibilityListener: EventListener | null;
+
+  get visibilityState(): VisibilityState {
+    return this._visibilityState;
+  }
+
+  addEventListener(type: string, listener: EventListener): void {
+    assert(
+      type === 'visibilitychange',
+      "MockDocument only supports events of type 'visibilitychange'"
+    );
+    this.visibilityListener = listener;
+  }
+
+  removeEventListener(type: string, listener: EventListener): void {
+    if (listener === this.visibilityListener) {
+      this.visibilityListener = null;
+    }
+  }
+
+  raiseVisibilityEvent(visibility: VisibilityState): void {
+    this._visibilityState = visibility;
+    if (this.visibilityListener) {
+      this.visibilityListener(new Event('visibilitychange'));
+    }
+  }
+}
+
+/**
+ * `WebStorage` mock that implements the WebStorage behavior for multiple
+ * clients. To get a client-specific storage area that implements the WebStorage
+ * API, invoke `getStorageArea(storageListener)`.
+ */
+export class SharedMockStorage {
+  private readonly data = new Map<string, string>();
+  private readonly activeClients: Array<{
+    storageListener: EventListener;
+    storageArea: Storage;
+  }> = [];
+
+  getStorageArea(storageListener: EventListener): Storage {
+    const clientIndex = this.activeClients.length;
+    const self = this;
+
+    const storageArea: Storage = {
+      get length(): number {
+        return self.length;
+      },
+      getItem: (key: string) => this.getItem(key),
+      key: (index: number) => this.key(index),
+      clear: () => this.clear(),
+      removeItem: (key: string) => {
+        const oldValue = this.getItem(key);
+        this.removeItem(key);
+        this.raiseStorageEvent(clientIndex, key, oldValue, null);
+      },
+      setItem: (key: string, value: string) => {
+        const oldValue = this.getItem(key);
+        this.setItem(key, value);
+        this.raiseStorageEvent(clientIndex, key, oldValue, value);
+      }
+    };
+
+    this.activeClients[clientIndex] = { storageListener, storageArea };
+
+    return storageArea;
+  }
+
+  private clear(): void {
+    this.data.clear();
+  }
+
+  private getItem(key: string): string | null {
+    return this.data.get(key);
+  }
+
+  private key(index: number): string | null {
+    return Array.from(this.data.keys())[index];
+  }
+
+  private removeItem(key: string): void {
+    this.data.delete(key);
+  }
+
+  private setItem(key: string, data: string): void {
+    this.data.set(key, data);
+  }
+
+  private get length(): number {
+    return this.data.size;
+  }
+
+  private raiseStorageEvent(
+    sourceClientIndex: number,
+    key: string,
+    oldValue: string | null,
+    newValue: string | null
+  ): void {
+    this.activeClients.forEach((client, index) => {
+      // WebStorage doesn't raise events for writes from the originating client.
+      if (sourceClientIndex === index) {
+        return;
+      }
+
+      client.storageListener({
+        key,
+        oldValue,
+        newValue,
+        storageArea: client.storageArea
+      } as any); // tslint:disable-line:no-any Not mocking entire Event type.
+    });
+  }
+}
+
+/**
+ * Implementation of `Platform` that allows mocking of `document` and `window`.
+ */
+export class MockPlatform implements Platform {
+  readonly mockDocument: MockDocument | null = null;
+  readonly mockWindow: MockWindow | null = null;
+
+  constructor(
+    private readonly basePlatform: Platform,
+    private readonly mockStorage: SharedMockStorage
+  ) {
+    this.mockDocument = new MockDocument();
+    this.mockWindow = new MockWindow(this.mockStorage);
+  }
+
+  get document(): Document | null {
+    // tslint:disable-next-line:no-any MockWindow doesn't support full Document interface.
+    return this.mockDocument as any;
+  }
+
+  get window(): Window | null {
+    // tslint:disable-next-line:no-any MockWindow doesn't support full Window interface.
+    return this.mockWindow as any;
+  }
+
+  get base64Available(): boolean {
+    return this.basePlatform.base64Available;
+  }
+
+  get emptyByteString(): ProtoByteString {
+    return this.basePlatform.emptyByteString;
+  }
+
+  raiseVisibilityEvent(visibility: VisibilityState): void {
+    if (this.mockDocument) {
+      this.mockDocument.raiseVisibilityEvent(visibility);
+    }
+  }
+
+  loadConnection(databaseInfo: DatabaseInfo): Promise<Connection> {
+    return this.basePlatform.loadConnection(databaseInfo);
+  }
+
+  newSerializer(databaseId: DatabaseId): JsonProtoSerializer {
+    return this.basePlatform.newSerializer(databaseId);
+  }
+
+  formatJSON(value: AnyJs): string {
+    return this.basePlatform.formatJSON(value);
+  }
+
+  atob(encoded: string): string {
+    return this.basePlatform.atob(encoded);
+  }
+
+  btoa(raw: string): string {
+    return this.basePlatform.btoa(raw);
+  }
+}

--- a/packages/firestore/test/util/test_platform.ts
+++ b/packages/firestore/test/util/test_platform.ts
@@ -23,14 +23,14 @@ import { Connection } from '../../src/remote/connection';
 import { assert, fail } from '../../src/util/assert';
 
 /**
- * `Window` mock that implements the event and storage API that is used by
+ * `Window` fake that implements the event and storage API that is used by
  * Firestore.
  */
-export class MockWindow {
+export class FakeWindow {
   private readonly storageArea: Storage;
   private storageListener: EventListener = () => {};
 
-  constructor(sharedMockStorage: SharedMockStorage) {
+  constructor(sharedMockStorage: SharedFakeWebStorage) {
     this.storageArea = sharedMockStorage.getStorageArea(event =>
       this.storageListener(event)
     );
@@ -69,9 +69,9 @@ export class MockWindow {
 }
 
 /**
- * `Document` mock that implements the `visibilitychange` API used by Firestore.
+ * `Document` fake that implements the `visibilitychange` API used by Firestore.
  */
-export class MockDocument {
+export class FakeDocument {
   private _visibilityState: VisibilityState = 'unloaded';
   private visibilityListener: EventListener | null;
 
@@ -82,7 +82,7 @@ export class MockDocument {
   addEventListener(type: string, listener: EventListener): void {
     assert(
       type === 'visibilitychange',
-      "MockDocument only supports events of type 'visibilitychange'"
+      "FakeDocument only supports events of type 'visibilitychange'"
     );
     this.visibilityListener = listener;
   }
@@ -106,7 +106,7 @@ export class MockDocument {
  * clients. To get a client-specific storage area that implements the WebStorage
  * API, invoke `getStorageArea(storageListener)`.
  */
-export class SharedMockStorage {
+export class SharedFakeWebStorage {
   private readonly data = new Map<string, string>();
   private readonly activeClients: Array<{
     storageListener: EventListener;
@@ -188,27 +188,27 @@ export class SharedMockStorage {
 }
 
 /**
- * Implementation of `Platform` that allows mocking of `document` and `window`.
+ * Implementation of `Platform` that allows faking of `document` and `window`.
  */
-export class MockPlatform implements Platform {
-  readonly mockDocument: MockDocument | null = null;
-  readonly mockWindow: MockWindow | null = null;
+export class TestPlatform implements Platform {
+  readonly mockDocument: FakeDocument | null = null;
+  readonly mockWindow: FakeWindow | null = null;
 
   constructor(
     private readonly basePlatform: Platform,
-    private readonly mockStorage: SharedMockStorage
+    private readonly mockStorage: SharedFakeWebStorage
   ) {
-    this.mockDocument = new MockDocument();
-    this.mockWindow = new MockWindow(this.mockStorage);
+    this.mockDocument = new FakeDocument();
+    this.mockWindow = new FakeWindow(this.mockStorage);
   }
 
   get document(): Document | null {
-    // tslint:disable-next-line:no-any MockWindow doesn't support full Document interface.
+    // tslint:disable-next-line:no-any FakeWindow doesn't support full Document interface.
     return this.mockDocument as any;
   }
 
   get window(): Window | null {
-    // tslint:disable-next-line:no-any MockWindow doesn't support full Window interface.
+    // tslint:disable-next-line:no-any FakeWindow doesn't support full Window interface.
     return this.mockWindow as any;
   }
 


### PR DESCRIPTION
In order to raise visibility events in non-spec unit tests, this PR moves the Platform mocks out of the spec tests file and makes them public in `mock_platform.ts`. There is also a name change from `TestPlatform` to `MockPlatform`.

This is the base PR for what I assume will be #994.