### PR TITLE
[Multi-Tab] Solving startup race

### DIFF
--- a/packages/firestore/src/core/firestore_client.ts
+++ b/packages/firestore/src/core/firestore_client.ts
@@ -394,7 +394,7 @@ export class FirestoreClient {
 
         // NOTE: This will immediately call the listener, so we make sure to
         // set it after localStore / remoteStore are started.
-        this.persistence.setPrimaryStateListener(isPrimary =>
+        await this.persistence.setPrimaryStateListener(isPrimary =>
           this.syncEngine.applyPrimaryState(isPrimary)
         );
       });

--- a/packages/firestore/src/local/indexeddb_persistence.ts
+++ b/packages/firestore/src/local/indexeddb_persistence.ts
@@ -185,9 +185,11 @@ export class IndexedDbPersistence implements Persistence {
       });
   }
 
-  setPrimaryStateListener(primaryStateListener: PrimaryStateListener): void {
+  setPrimaryStateListener(
+    primaryStateListener: PrimaryStateListener
+  ): Promise<void> {
     this.primaryStateListener = primaryStateListener;
-    primaryStateListener(this.isPrimary);
+    return primaryStateListener(this.isPrimary);
   }
 
   /**

--- a/packages/firestore/src/local/memory_persistence.ts
+++ b/packages/firestore/src/local/memory_persistence.ts
@@ -70,9 +70,11 @@ export class MemoryPersistence implements Persistence {
     return [this.clientId];
   }
 
-  setPrimaryStateListener(primaryStateListener: PrimaryStateListener): void {
+  setPrimaryStateListener(
+    primaryStateListener: PrimaryStateListener
+  ): Promise<void> {
     // All clients using memory persistence act as primary.
-    primaryStateListener(true);
+    return primaryStateListener(true);
   }
 
   getMutationQueue(user: User): MutationQueue {

--- a/packages/firestore/src/local/persistence.ts
+++ b/packages/firestore/src/local/persistence.ts
@@ -106,7 +106,9 @@ export interface Persistence {
    *
    * PORTING NOTE: This is only used for Web multi-tab.
    */
-  setPrimaryStateListener(primaryStateListener: PrimaryStateListener): void;
+  setPrimaryStateListener(
+    primaryStateListener: PrimaryStateListener
+  ): Promise<void>;
 
   /**
    * Returns the IDs of the clients that are currently active. If multi-tab

--- a/packages/firestore/test/unit/specs/spec_test_runner.ts
+++ b/packages/firestore/test/unit/specs/spec_test_runner.ts
@@ -478,7 +478,7 @@ abstract class TestRunner {
     await this.remoteStore.start();
     await this.syncEngine.start();
 
-    this.persistence.setPrimaryStateListener(isPrimary =>
+    await this.persistence.setPrimaryStateListener(isPrimary =>
       this.syncEngine.applyPrimaryState(isPrimary)
     );
 
@@ -872,15 +872,9 @@ abstract class TestRunner {
       await this.syncEngine.start();
       await this.sharedClientState.start();
 
-      const deferred = new Deferred<void>();
-      // We need to wait for the processing in `applyPrimaryState` to complete,
-      // but `setPrimaryStateListener` doesn't return a promise.
-      this.persistence.setPrimaryStateListener(isPrimary => {
-        return this.syncEngine
-          .applyPrimaryState(isPrimary)
-          .then(deferred.resolve);
-      });
-      await deferred.promise;
+      await this.persistence.setPrimaryStateListener(isPrimary =>
+        this.syncEngine.applyPrimaryState(isPrimary)
+      );
     });
   }
 


### PR DESCRIPTION
The latest round of CI failures seem to be due to the fact that we don't wait for `applyPrimaryState` to finish before we consider a client healthy. In the spec tests, I already worked around this by using a deferred Promise, but it probably makes sense to just make `setPrimaryStateListener()` a Promise and let it wait on the call to sync engine.

I'm open to renaming the method to something less setter-like - maybe "registerPrimaryStateListener()"?