### PR TITLE
Added missing types for optional database instance.

### DIFF
--- a/packages/firebase/index.d.ts
+++ b/packages/firebase/index.d.ts
@@ -125,7 +125,7 @@ declare namespace firebase {
 declare namespace firebase.app {
   interface App {
     auth(): firebase.auth.Auth;
-    database(): firebase.database.Database;
+    database(instance?: string): firebase.database.Database;
     delete(): Promise<any>;
     messaging(): firebase.messaging.Messaging;
     name: string;

--- a/packages/firebase/index.d.ts
+++ b/packages/firebase/index.d.ts
@@ -125,7 +125,7 @@ declare namespace firebase {
 declare namespace firebase.app {
   interface App {
     auth(): firebase.auth.Auth;
-    database(instance?: string): firebase.database.Database;
+    database(url?: string): firebase.database.Database;
     delete(): Promise<any>;
     messaging(): firebase.messaging.Messaging;
     name: string;


### PR DESCRIPTION
Creating a reference to another DB instance (Database Sharding https://firebase.google.com/docs/database/usage/sharding) throws typing error: `[ts] Expected 0 arguments, but got 1.`

i.e.

```
app.database(`https://xxx.firebaseio.com/`);
```

I was able to find testing for these cases https://github.com/firebase/firebase-js-sdk/blob/81cd260aeb729c5003952988b19d5b32788510d4/packages/database/test/database.test.ts#L73 but the optional type is missing from https://github.com/firebase/firebase-js-sdk/blob/81cd260aeb729c5003952988b19d5b32788510d4/packages/firebase/index.d.ts#L128