### PR TITLE
Enable firestore sdk to talk to emulator

### DIFF
--- a/packages/firestore/src/api/credentials.ts
+++ b/packages/firestore/src/api/credentials.ts
@@ -148,8 +148,6 @@ export class FirebaseCredentialsProvider implements CredentialsProvider {
 
   private forceRefresh = false;
 
-  private tokenOverride: string = null;
-
   constructor(private readonly app: FirebaseApp) {
     // We listen for token changes but all we really care about is knowing when
     // the uid may have changed.
@@ -165,7 +163,6 @@ export class FirebaseCredentialsProvider implements CredentialsProvider {
     };
 
     this.userCounter = 0;
-    this.tokenOverride = app.options.tokenOverride;
 
     // Will fire at least once where we set this.currentUser
     (this.app as _FirebaseApp).INTERNAL.addAuthTokenListener(
@@ -185,13 +182,7 @@ export class FirebaseCredentialsProvider implements CredentialsProvider {
     const initialUserCounter = this.userCounter;
     const forceRefresh = this.forceRefresh;
     this.forceRefresh = false;
-    var token: Promise<FirebaseAuthTokenData>;
-    if (this.tokenOverride != null) {
-      token = Promise.resolve({ accessToken: this.tokenOverride });
-    } else {
-      token = (this.app as _FirebaseApp).INTERNAL.getToken(forceRefresh);
-    }
-    return token.then(tokenData => {
+    return (this.app as _FirebaseApp).INTERNAL.getToken(forceRefresh).then(tokenData => {
       // Cancel the request since the user changed while the request was
       // outstanding so the response is likely for a previous user (which
       // user, we can't be sure).

--- a/packages/firestore/src/api/credentials.ts
+++ b/packages/firestore/src/api/credentials.ts
@@ -18,10 +18,7 @@ import { User } from '../auth/user';
 import { assert, fail } from '../util/assert';
 import { Code, FirestoreError } from '../util/error';
 import { FirebaseApp } from '@firebase/app-types';
-import {
-  _FirebaseApp,
-  FirebaseAuthTokenData
-} from '@firebase/app-types/private';
+import { _FirebaseApp } from '@firebase/app-types/private';
 
 // TODO(mikelehen): This should be split into multiple files and probably
 // moved to an auth/ folder to match other platforms.

--- a/packages/firestore/src/api/credentials.ts
+++ b/packages/firestore/src/api/credentials.ts
@@ -18,7 +18,7 @@ import { User } from '../auth/user';
 import { assert, fail } from '../util/assert';
 import { Code, FirestoreError } from '../util/error';
 import { FirebaseApp } from '@firebase/app-types';
-import { _FirebaseApp } from '@firebase/app-types/private';
+import { _FirebaseApp, FirebaseAuthTokenData } from '@firebase/app-types/private';
 
 // TODO(mikelehen): This should be split into multiple files and probably
 // moved to an auth/ folder to match other platforms.
@@ -145,6 +145,8 @@ export class FirebaseCredentialsProvider implements CredentialsProvider {
 
   private forceRefresh = false;
 
+  private tokenOverride: string = null;
+
   constructor(private readonly app: FirebaseApp) {
     // We listen for token changes but all we really care about is knowing when
     // the uid may have changed.
@@ -160,6 +162,7 @@ export class FirebaseCredentialsProvider implements CredentialsProvider {
     };
 
     this.userCounter = 0;
+    this.tokenOverride = app.options.tokenOverride;
 
     // Will fire at least once where we set this.currentUser
     (this.app as _FirebaseApp).INTERNAL.addAuthTokenListener(
@@ -179,7 +182,13 @@ export class FirebaseCredentialsProvider implements CredentialsProvider {
     const initialUserCounter = this.userCounter;
     const forceRefresh = this.forceRefresh;
     this.forceRefresh = false;
-    return (this.app as _FirebaseApp).INTERNAL.getToken(forceRefresh).then(
+    var token: Promise<FirebaseAuthTokenData>;
+    if (this.tokenOverride != null) {
+      token = Promise.resolve({ accessToken: this.tokenOverride });
+    } else {
+      token = (this.app as _FirebaseApp).INTERNAL.getToken(forceRefresh);
+    }
+    return token.then(
       tokenData => {
         // Cancel the request since the user changed while the request was
         // outstanding so the response is likely for a previous user (which

--- a/packages/firestore/src/api/credentials.ts
+++ b/packages/firestore/src/api/credentials.ts
@@ -182,27 +182,29 @@ export class FirebaseCredentialsProvider implements CredentialsProvider {
     const initialUserCounter = this.userCounter;
     const forceRefresh = this.forceRefresh;
     this.forceRefresh = false;
-    return (this.app as _FirebaseApp).INTERNAL.getToken(forceRefresh).then(tokenData => {
-      // Cancel the request since the user changed while the request was
-      // outstanding so the response is likely for a previous user (which
-      // user, we can't be sure).
-      if (this.userCounter !== initialUserCounter) {
-        throw new FirestoreError(
-          Code.ABORTED,
-          'getToken aborted due to uid change.'
-        );
-      } else {
-        if (tokenData) {
-          assert(
-            typeof tokenData.accessToken === 'string',
-            'Invalid tokenData returned from getToken():' + tokenData
+    return (this.app as _FirebaseApp).INTERNAL.getToken(forceRefresh).then(
+      tokenData => {
+        // Cancel the request since the user changed while the request was
+        // outstanding so the response is likely for a previous user (which
+        // user, we can't be sure).
+        if (this.userCounter !== initialUserCounter) {
+          throw new FirestoreError(
+            Code.ABORTED,
+            'getToken aborted due to uid change.'
           );
-          return new OAuthToken(tokenData.accessToken, this.currentUser);
         } else {
-          return null;
+          if (tokenData) {
+            assert(
+              typeof tokenData.accessToken === 'string',
+              'Invalid tokenData returned from getToken():' + tokenData
+            );
+            return new OAuthToken(tokenData.accessToken, this.currentUser);
+          } else {
+            return null;
+          }
         }
       }
-    });
+    );
   }
 
   invalidateToken(): void {

--- a/packages/testing/index.ts
+++ b/packages/testing/index.ts
@@ -24,7 +24,6 @@ export {
   apps,
   assertFails,
   assertSucceeds,
-  initializeAdminApp,
   initializeTestApp,
   loadDatabaseRules
 } from './src/api';

--- a/packages/testing/index.ts
+++ b/packages/testing/index.ts
@@ -26,5 +26,6 @@ export {
   assertSucceeds,
   initializeAdminApp,
   initializeTestApp,
+  initializeFirestoreTestApp,
   loadDatabaseRules
 } from './src/api';

--- a/packages/testing/index.ts
+++ b/packages/testing/index.ts
@@ -26,6 +26,5 @@ export {
   assertSucceeds,
   initializeAdminApp,
   initializeTestApp,
-  initializeFirestoreTestApp,
   loadDatabaseRules
 } from './src/api';

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -16,7 +16,6 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "firebase-admin": "5.12.0",
     "request-promise": "4.2.2"
   },
   "devDependencies": {

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@firebase/testing",
-  "version": "1.0.0",
+  "version": "0.1.0",
   "private": true,
   "description": "",
   "author": "Firebase <firebase-support@google.com> (https://firebase.google.com/)",

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@firebase/testing",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "private": true,
   "description": "",
   "author": "Firebase <firebase-support@google.com> (https://firebase.google.com/)",

--- a/packages/testing/src/api/index.ts
+++ b/packages/testing/src/api/index.ts
@@ -75,19 +75,20 @@ export function initializeFirestoreTestApp(options: any): FirebaseApp {
     throw new Error('auth must be an object');
   }
   var header = {
-    alg: "RS256",
-    kid: "fakekid"
+    alg: 'RS256',
+    kid: 'fakekid'
   };
   var fakeToken = [
-    util.base64.encodeString(JSON.stringify(header),/*webSafe=*/true),
-    util.base64.encodeString(JSON.stringify(options.auth),/*webSafe=*/true),
-    "fakesignature"
-  ].join(".");
-  return firebase.initializeApp({
+    util.base64.encodeString(JSON.stringify(header), /*webSafe=*/ true),
+    util.base64.encodeString(JSON.stringify(options.auth), /*webSafe=*/ true),
+    'fakesignature'
+  ].join('.');
+  return firebase.initializeApp(
+    {
       projectId: options.projectId,
       tokenOverride: fakeToken
     },
-    'app-' + new Date().getTime() + "-" + Math.random()
+    'app-' + new Date().getTime() + '-' + Math.random()
   );
 }
 

--- a/packages/testing/src/api/index.ts
+++ b/packages/testing/src/api/index.ts
@@ -84,8 +84,8 @@ export function initializeFirestoreTestApp(
     kid: 'fakekid'
   };
   const fakeToken = [
-    base64.encodeString(JSON.stringify(header), /*webSafe=*/ true),
-    base64.encodeString(JSON.stringify(options.auth), /*webSafe=*/ true),
+    base64.encodeString(JSON.stringify(header), /*webSafe=*/ false),
+    base64.encodeString(JSON.stringify(options.auth), /*webSafe=*/ false),
     'fakesignature'
   ].join('.');
   const app = firebase.initializeApp(

--- a/packages/testing/src/api/index.ts
+++ b/packages/testing/src/api/index.ts
@@ -19,7 +19,7 @@ import * as admin from 'firebase-admin';
 import request from 'request-promise';
 import * as fs from 'fs';
 import { FirebaseApp } from '@firebase/app-types';
-import * as util from '@firebase/util';
+import { base64 } from '@firebase/util';
 
 const DBURL = 'http://localhost:9000';
 
@@ -79,17 +79,19 @@ export function initializeFirestoreTestApp(options: any): FirebaseApp {
     kid: 'fakekid'
   };
   var fakeToken = [
-    util.base64.encodeString(JSON.stringify(header), /*webSafe=*/ true),
-    util.base64.encodeString(JSON.stringify(options.auth), /*webSafe=*/ true),
+    base64.encodeString(JSON.stringify(header), /*webSafe=*/ true),
+    base64.encodeString(JSON.stringify(options.auth), /*webSafe=*/ true),
     'fakesignature'
   ].join('.');
-  return firebase.initializeApp(
+  let app = firebase.initializeApp(
     {
       projectId: options.projectId,
       tokenOverride: fakeToken
     },
     'app-' + new Date().getTime() + '-' + Math.random()
   );
+  (app as any).INTERNAL.getToken = () => Promise.resolve({ accessToken: fakeToken });
+  return app;
 }
 
 export type LoadDatabaseRulesOptions = {

--- a/packages/testing/src/api/index.ts
+++ b/packages/testing/src/api/index.ts
@@ -62,7 +62,7 @@ export type AppOptions = {
   databaseName?: string;
   projectId?: string;
   auth: object;
-}
+};
 export function initializeTestApp(options: AppOptions): FirebaseApp {
   let appOptions: FirebaseOptions;
   if ('databaseName' in options) {
@@ -74,7 +74,7 @@ export function initializeTestApp(options: AppOptions): FirebaseApp {
       projectId: options.projectId
     };
   } else {
-    throw new Error("neither databaseName or projectId were specified");
+    throw new Error('neither databaseName or projectId were specified');
   }
   const header = {
     alg: 'RS256',

--- a/packages/testing/src/api/index.ts
+++ b/packages/testing/src/api/index.ts
@@ -15,7 +15,6 @@
  */
 
 import { firebase } from '@firebase/app';
-import * as admin from 'firebase-admin';
 import request from 'request-promise';
 import * as fs from 'fs';
 import { FirebaseApp, FirebaseOptions } from '@firebase/app-types';
@@ -35,27 +34,8 @@ class FakeCredentials {
   }
 }
 
-export function adminApps(): (admin.app.App | null)[] {
-  return admin.apps;
-}
-
 export function apps(): (FirebaseApp | null)[] {
   return firebase.apps;
-}
-
-type AdminAppOptions = {
-  databaseName: string;
-};
-
-export function initializeAdminApp(options: AdminAppOptions): admin.app.App {
-  const appName = 'app-' + new Date().getTime() + '-' + Math.random();
-  return admin.initializeApp(
-    {
-      credential: new FakeCredentials(),
-      databaseURL: DBURL + '?ns=' + options.databaseName
-    },
-    appName
-  );
 }
 
 export type AppOptions = {

--- a/packages/testing/src/api/index.ts
+++ b/packages/testing/src/api/index.ts
@@ -58,17 +58,12 @@ export function initializeAdminApp(options: AdminAppOptions): admin.app.App {
   );
 }
 
-export type DatabaseAppOptions = {
-  databaseName: string;
+export type AppOptions = {
+  databaseName?: string;
+  projectId?: string;
   auth: object;
-};
-export type FirestoreAppOptions = {
-  projectId: string;
-  auth: object;
-};
-export function initializeTestApp(
-  options: DatabaseAppOptions | FirestoreAppOptions
-): FirebaseApp {
+}
+export function initializeTestApp(options: AppOptions): FirebaseApp {
   let appOptions: FirebaseOptions;
   if ('databaseName' in options) {
     appOptions = {
@@ -78,6 +73,8 @@ export function initializeTestApp(
     appOptions = {
       projectId: options.projectId
     };
+  } else {
+    throw new Error("neither databaseName or projectId were specified");
   }
   const header = {
     alg: 'RS256',

--- a/packages/testing/src/api/index.ts
+++ b/packages/testing/src/api/index.ts
@@ -90,7 +90,8 @@ export function initializeFirestoreTestApp(options: any): FirebaseApp {
     },
     'app-' + new Date().getTime() + '-' + Math.random()
   );
-  (app as any).INTERNAL.getToken = () => Promise.resolve({ accessToken: fakeToken });
+  (app as any).INTERNAL.getToken = () =>
+    Promise.resolve({ accessToken: fakeToken });
   return app;
 }
 

--- a/packages/testing/src/api/index.ts
+++ b/packages/testing/src/api/index.ts
@@ -14,9 +14,12 @@
  * limitations under the License.
  */
 
+import { firebase } from '@firebase/app';
 import * as admin from 'firebase-admin';
 import request from 'request-promise';
 import * as fs from 'fs';
+import { FirebaseApp } from '@firebase/app-types';
+import * as util from '@firebase/util';
 
 const DBURL = 'http://localhost:9000';
 
@@ -61,6 +64,30 @@ export function initializeTestApp(options: any): admin.app.App {
       databaseAuthVariableOverride: options.auth || null
     },
     'app-' + (new Date().getTime() + Math.random())
+  );
+}
+
+export function initializeFirestoreTestApp(options: any): FirebaseApp {
+  if (!('projectId' in options)) {
+    throw new Error('projectId not specified');
+  }
+  if (typeof options.auth != 'object') {
+    throw new Error('auth must be an object');
+  }
+  var header = {
+    alg: "RS256",
+    kid: "fakekid"
+  };
+  var fakeToken = [
+    util.base64.encodeString(JSON.stringify(header),/*webSafe=*/true),
+    util.base64.encodeString(JSON.stringify(options.auth),/*webSafe=*/true),
+    "fakesignature"
+  ].join(".");
+  return firebase.initializeApp({
+      projectId: options.projectId,
+      tokenOverride: fakeToken
+    },
+    'app-' + new Date().getTime() + "-" + Math.random()
   );
 }
 

--- a/packages/testing/src/api/index.ts
+++ b/packages/testing/src/api/index.ts
@@ -76,7 +76,9 @@ export type FirestoreTestAppOptions = {
   projectId: string;
   auth: Object;
 };
-export function initializeFirestoreTestApp(options: FirestoreTestAppOptions): FirebaseApp {
+export function initializeFirestoreTestApp(
+  options: FirestoreTestAppOptions
+): FirebaseApp {
   const header = {
     alg: 'RS256',
     kid: 'fakekid'

--- a/packages/testing/src/api/index.ts
+++ b/packages/testing/src/api/index.ts
@@ -45,7 +45,7 @@ export function apps(): (FirebaseApp | null)[] {
 
 type AdminAppOptions = {
   databaseName: string;
-}
+};
 
 export function initializeAdminApp(options: AdminAppOptions): admin.app.App {
   const appName = 'app-' + new Date().getTime() + '-' + Math.random();
@@ -61,12 +61,14 @@ export function initializeAdminApp(options: AdminAppOptions): admin.app.App {
 export type DatabaseAppOptions = {
   databaseName: string;
   auth: object;
-}
+};
 export type FirestoreAppOptions = {
   projectId: string;
   auth: object;
-}
-export function initializeTestApp(options: DatabaseAppOptions | FirestoreAppOptions): FirebaseApp {
+};
+export function initializeTestApp(
+  options: DatabaseAppOptions | FirestoreAppOptions
+): FirebaseApp {
   let appOptions: FirebaseOptions;
   if ('databaseName' in options) {
     appOptions = {

--- a/packages/testing/test/database.test.ts
+++ b/packages/testing/test/database.test.ts
@@ -47,11 +47,6 @@ describe('Testing Module Tests', function() {
     });
   });
 
-  it('initializeAdminApp() provides admin', function() {
-    const app = firebase.initializeAdminApp({ databaseName: 'foo' });
-    expect(app.options).to.not.have.any.keys('databaseAuthVariableOverride');
-  });
-
   it('initializeTestApp() with DatabaseAppOptions uses specified auth.', async function() {
     let app = firebase.initializeTestApp({
       projectId: 'foo',
@@ -128,23 +123,11 @@ describe('Testing Module Tests', function() {
     ).to.throw(/Could not find file/);
   });
 
-  it('adminApps() returns only apps created with initializeAdminApp', async function() {
+  it('apps() returns apps created with initializeTestApp', async function() {
     const numApps = firebase.apps().length;
-    await firebase.initializeAdminApp({ databaseName: 'foo' });
-    expect(firebase.adminApps().length).to.equal(numApps + 1);
-    await firebase.initializeAdminApp({ databaseName: 'foo' });
-    expect(firebase.adminApps().length).to.equal(numApps + 2);
-    await firebase.initializeTestApp({ databaseName: 'foo', auth: {} });
-    expect(firebase.adminApps().length).to.equal(numApps + 2);
-  });
-
-  it('apps() returns only apps created with initializeTestApp', async function() {
-    const numApps = firebase.apps().length;
-    await firebase.initializeAdminApp({ databaseName: 'foo' });
-    expect(firebase.apps().length).to.equal(numApps + 0);
-    await firebase.initializeAdminApp({ databaseName: 'foo' });
-    expect(firebase.apps().length).to.equal(numApps + 0);
     await firebase.initializeTestApp({ databaseName: 'foo', auth: {} });
     expect(firebase.apps().length).to.equal(numApps + 1);
+    await firebase.initializeTestApp({ databaseName: 'bar', auth: {} });
+    expect(firebase.apps().length).to.equal(numApps + 2);
   });
 });

--- a/packages/testing/test/database.test.ts
+++ b/packages/testing/test/database.test.ts
@@ -84,8 +84,8 @@ describe('Testing Module Tests', function() {
     let token = await (app as any).INTERNAL.getToken();
     expect(token).to.have.any.keys('accessToken');
     let claims = base64.decodeString(
-      token.accessToken.split('.')[3],
-      /*webSafe=*/ true
+      token.accessToken.split('.')[1],
+      /*webSafe=*/ false
     );
     expect(claims).to.equal('{}');
 
@@ -96,8 +96,8 @@ describe('Testing Module Tests', function() {
     token = await (app as any).INTERNAL.getToken();
     expect(token).to.have.any.keys('accessToken');
     claims = base64.decodeString(
-      token.accessToken.split('.')[3],
-      /*webSafe=*/ true
+      token.accessToken.split('.')[1],
+      /*webSafe=*/ false
     );
     expect(claims).to.equal('{"uid":"alice"}');
   });

--- a/packages/testing/test/database.test.ts
+++ b/packages/testing/test/database.test.ts
@@ -84,6 +84,32 @@ describe('Testing Module Tests', function() {
     );
   });
 
+  it('initializeFirestoreTestApp() throws if no projectId', function() {
+    expect(firebase.initializeFirestoreTestApp.bind(null, { auth: {} })).to.throw(
+      /projectId not specified/
+    );
+    expect(
+      firebase.initializeFirestoreTestApp.bind(null, { projectId: 'foo', auth: {} })
+    ).to.not.throw();
+  });
+
+  it('initializeFirestoreTestApp() throws if auth is not an object', function() {
+    expect(firebase.initializeFirestoreTestApp.bind(null, { projectId: 'a', auth: 'b' })).to.throw(
+      /auth must be an object/
+    );
+    expect(
+      firebase.initializeFirestoreTestApp.bind(null, { projectId: 'a', auth: {} })
+    ).to.not.throw();
+  });
+
+  it('initializeFirestoreTestApp() uses specified auth.', function() {
+    let app = firebase.initializeFirestoreTestApp({ projectId: 'foo', auth: {} });
+    expect(app.options).to.have.any.keys('tokenOverride');
+
+    app = firebase.initializeFirestoreTestApp({ projectId: 'foo', auth: { uid: 'alice' }});
+    expect(app.options).to.have.any.keys('tokenOverride');
+  });
+
   it('loadDatabaseRules() throws if no databaseName or rulesPath', async function() {
     expect(firebase.loadDatabaseRules.bind(null, {})).to.throw(
       /databaseName not specified/

--- a/packages/testing/test/database.test.ts
+++ b/packages/testing/test/database.test.ts
@@ -83,16 +83,22 @@ describe('Testing Module Tests', function() {
     });
     let token = await (app as any).INTERNAL.getToken();
     expect(token).to.have.any.keys('accessToken');
-    let claims = base64.decodeString(token.accessToken.split('.')[3],/*webSafe=*/true);
+    let claims = base64.decodeString(
+      token.accessToken.split('.')[3],
+      /*webSafe=*/ true
+    );
     expect(claims).to.equal('{}');
 
     app = firebase.initializeFirestoreTestApp({
       projectId: 'foo',
       auth: { uid: 'alice' }
     });
-    token = await (app as any).INTERNAL.getToken()
+    token = await (app as any).INTERNAL.getToken();
     expect(token).to.have.any.keys('accessToken');
-    claims = base64.decodeString(token.accessToken.split('.')[3],/*webSafe=*/true);
+    claims = base64.decodeString(
+      token.accessToken.split('.')[3],
+      /*webSafe=*/ true
+    );
     expect(claims).to.equal('{"uid":"alice"}');
   });
 

--- a/packages/testing/test/database.test.ts
+++ b/packages/testing/test/database.test.ts
@@ -85,28 +85,43 @@ describe('Testing Module Tests', function() {
   });
 
   it('initializeFirestoreTestApp() throws if no projectId', function() {
-    expect(firebase.initializeFirestoreTestApp.bind(null, { auth: {} })).to.throw(
-      /projectId not specified/
-    );
     expect(
-      firebase.initializeFirestoreTestApp.bind(null, { projectId: 'foo', auth: {} })
+      firebase.initializeFirestoreTestApp.bind(null, { auth: {} })
+    ).to.throw(/projectId not specified/);
+    expect(
+      firebase.initializeFirestoreTestApp.bind(null, {
+        projectId: 'foo',
+        auth: {}
+      })
     ).to.not.throw();
   });
 
   it('initializeFirestoreTestApp() throws if auth is not an object', function() {
-    expect(firebase.initializeFirestoreTestApp.bind(null, { projectId: 'a', auth: 'b' })).to.throw(
-      /auth must be an object/
-    );
     expect(
-      firebase.initializeFirestoreTestApp.bind(null, { projectId: 'a', auth: {} })
+      firebase.initializeFirestoreTestApp.bind(null, {
+        projectId: 'a',
+        auth: 'b'
+      })
+    ).to.throw(/auth must be an object/);
+    expect(
+      firebase.initializeFirestoreTestApp.bind(null, {
+        projectId: 'a',
+        auth: {}
+      })
     ).to.not.throw();
   });
 
   it('initializeFirestoreTestApp() uses specified auth.', function() {
-    let app = firebase.initializeFirestoreTestApp({ projectId: 'foo', auth: {} });
+    let app = firebase.initializeFirestoreTestApp({
+      projectId: 'foo',
+      auth: {}
+    });
     expect(app.options).to.have.any.keys('tokenOverride');
 
-    app = firebase.initializeFirestoreTestApp({ projectId: 'foo', auth: { uid: 'alice' }});
+    app = firebase.initializeFirestoreTestApp({
+      projectId: 'foo',
+      auth: { uid: 'alice' }
+    });
     expect(app.options).to.have.any.keys('tokenOverride');
   });
 


### PR DESCRIPTION
This change enables the testing sdk to talk to the firestore emulator. This is based off of https://docs.google.com/document/d/1dWAVm8-jK_JLsCOx4uZBj2MN_6auc7ood-0llWoojs8/edit?ts=5b47bec0#heading=h.sm63cr1eg2l2