### PR TITLE
Removing no longer applicable comment

### DIFF
--- a/packages/firestore/src/local/local_store.ts
+++ b/packages/firestore/src/local/local_store.ts
@@ -648,7 +648,6 @@ export class LocalStore {
    * @returns The next mutation or null if there wasn't one.
    */
   nextMutationBatch(afterBatchId?: BatchId): Promise<MutationBatch | null> {
-    // TODO(multitab): This needs to run in O(1).
     return this.persistence.runTransaction(
       'Get next mutation batch',
       false,


### PR DESCRIPTION
This TODO seems no longer applicable - the current code in master and the new code has essentially the same performance characteristics. It's O(1) in IndexedDb and O(n) in the memory queue (the memory queue scans tombstones).

The code is also not called more often than before (just in `fillWritePipeline`).