### PR TITLE
Fix method name in comment.

### DIFF
--- a/packages/firestore/src/core/sync_engine.ts
+++ b/packages/firestore/src/core/sync_engine.ts
@@ -99,7 +99,7 @@ class LimboResolution {
 
   /**
    * Set to true once we've received a document. This is used in
-   * targetContainsDocument() and ultimately used by WatchChangeAggregator to
+   * getRemoteKeysForTarget() and ultimately used by WatchChangeAggregator to
    * decide whether it needs to manufacture a delete event for the target once
    * the target is CURRENT.
    */


### PR DESCRIPTION
While porting I noticed this was slightly wrong.  targetContainsDocument() is the method in WatchChangeAggregator.  The SyncEngine method I meant to reference is getRemoteKeysForTarget().