### PR TITLE
Making sure we don't export 'experimental'

### DIFF
--- a/packages/firestore/test/unit/specs/describe_spec.ts
+++ b/packages/firestore/test/unit/specs/describe_spec.ts
@@ -139,26 +139,29 @@ export function specTest(
         return spec.runAsTest(fullName, usePersistence);
       });
     }
-    return;
+  } else {
+    assert(
+      tags.indexOf(EXCLUSIVE_TAG) === -1,
+      "The 'exclusive' tag is only supported for development and should not be exported to other platforms."
+    );
+    const spec = builder();
+
+    const specJSON = spec.toJSON();
+
+    const json = {
+      describeName,
+      itName: name,
+      tags,
+      comment,
+      config: specJSON.config,
+      steps: specJSON.steps
+    };
+
+    if (name in specsInThisTest) {
+      throw new Error('duplicate spec test: "' + name + '"');
+    }
+    specsInThisTest[name] = json;
   }
-
-  const spec = builder();
-
-  const specJSON = spec.toJSON();
-
-  const json = {
-    describeName,
-    itName: name,
-    tags,
-    comment,
-    config: specJSON.config,
-    steps: specJSON.steps
-  };
-
-  if (name in specsInThisTest) {
-    throw new Error('duplicate spec test: "' + name + '"');
-  }
-  specsInThisTest[name] = json;
 }
 
 /**


### PR DESCRIPTION
I spent the last hour or so trying to make "specTest.only" work (https://gist.github.com/schmidt-sebastian/2259e4a62b3bc96e2d09ac27ba4e14ee), and gave up when the JSON generator tripped over it. This PR is the not-so-nice-version of that change.