### PR TITLE
Unify local.QueryData with the other platforms

### DIFF
--- a/packages/firestore/src/local/local_store.ts
+++ b/packages/firestore/src/local/local_store.ts
@@ -465,7 +465,7 @@ export class LocalStore {
           // any preexisting value.
           const resumeToken = change.resumeToken;
           if (resumeToken.length > 0) {
-            queryData = queryData.update({
+            queryData = queryData.copy({
               resumeToken,
               snapshotVersion: remoteEvent.snapshotVersion
             });

--- a/packages/firestore/src/local/query_data.ts
+++ b/packages/firestore/src/local/query_data.ts
@@ -62,7 +62,7 @@ export class QueryData {
    * Creates a new query data instance with an updated snapshot version and
    * resume token.
    */
-  update(updated: {
+  copy(updated: {
     resumeToken: ProtoByteString;
     snapshotVersion: SnapshotVersion;
   }): QueryData {

--- a/packages/firestore/src/local/query_data.ts
+++ b/packages/firestore/src/local/query_data.ts
@@ -39,23 +39,23 @@ export enum QueryPurpose {
 export class QueryData {
   constructor(
     /** The query being listened to. */
-    public query: Query,
+    readonly query: Query,
     /**
      * The target ID to which the query corresponds; Assigned by the
      * LocalStore for user listens and by the SyncEngine for limbo watches.
      */
-    public targetId: TargetId,
+    readonly targetId: TargetId,
     /** The purpose of the query. */
-    public purpose: QueryPurpose,
+    readonly purpose: QueryPurpose,
     /** The latest snapshot version seen for this target. */
-    public snapshotVersion: SnapshotVersion = SnapshotVersion.MIN,
+    readonly snapshotVersion: SnapshotVersion = SnapshotVersion.MIN,
     /**
      * An opaque, server-assigned token that allows watching a query to be
      * resumed after disconnecting without retransmitting all the data that
      * matches the query. The resume token essentially identifies a point in
      * time from which the server should resume sending results.
      */
-    public resumeToken: ProtoByteString = emptyByteString()
+    readonly resumeToken: ProtoByteString = emptyByteString()
   ) {}
 
   /**

--- a/packages/firestore/src/local/query_data.ts
+++ b/packages/firestore/src/local/query_data.ts
@@ -62,16 +62,16 @@ export class QueryData {
    * Creates a new query data instance with an updated snapshot version and
    * resume token.
    */
-  copy(updated: {
-    resumeToken: ProtoByteString;
-    snapshotVersion: SnapshotVersion;
+  copy(overwrite: {
+    resumeToken?: ProtoByteString;
+    snapshotVersion?: SnapshotVersion;
   }): QueryData {
     return new QueryData(
       this.query,
       this.targetId,
       this.purpose,
-      updated.snapshotVersion,
-      updated.resumeToken
+      overwrite.snapshotVersion || this.snapshotVersion,
+      overwrite.resumeToken || this.resumeToken
     );
   }
 

--- a/packages/firestore/src/remote/remote_store.ts
+++ b/packages/firestore/src/remote/remote_store.ts
@@ -424,7 +424,10 @@ export class RemoteStore implements TargetMetadataProvider {
 
       // Clear the resume token for the query, since we're in a known mismatch
       // state.
-      this.listenTargets[targetId] = queryData.copy({snapshotVersion: queryData.snapshotVersion, resumeToken: emptyByteString()});
+      this.listenTargets[targetId] = queryData.copy({
+        snapshotVersion: queryData.snapshotVersion,
+        resumeToken: emptyByteString()
+      });
 
       // Cause a hard reset by unwatching and rewatching immediately, but
       // deliberately don't send a resume token so that we get a full update.

--- a/packages/firestore/src/remote/remote_store.ts
+++ b/packages/firestore/src/remote/remote_store.ts
@@ -405,7 +405,7 @@ export class RemoteStore implements TargetMetadataProvider {
         const queryData = this.listenTargets[targetId];
         // A watched target might have been removed already.
         if (queryData) {
-          this.listenTargets[targetId] = queryData.update({
+          this.listenTargets[targetId] = queryData.copy({
             resumeToken: change.resumeToken,
             snapshotVersion
           });
@@ -424,7 +424,7 @@ export class RemoteStore implements TargetMetadataProvider {
 
       // Clear the resume token for the query, since we're in a known mismatch
       // state.
-      this.listenTargets[targetId] = queryData.update({snapshotVersion: queryData.snapshotVersion, resumeToken: emptyByteString()});
+      this.listenTargets[targetId] = queryData.copy({snapshotVersion: queryData.snapshotVersion, resumeToken: emptyByteString()});
 
       // Cause a hard reset by unwatching and rewatching immediately, but
       // deliberately don't send a resume token so that we get a full update.

--- a/packages/firestore/src/remote/remote_store.ts
+++ b/packages/firestore/src/remote/remote_store.ts
@@ -424,7 +424,7 @@ export class RemoteStore implements TargetMetadataProvider {
 
       // Clear the resume token for the query, since we're in a known mismatch
       // state.
-      queryData.resumeToken = emptyByteString();
+      this.listenTargets[targetId] = queryData.update({snapshotVersion: queryData.snapshotVersion, resumeToken: emptyByteString()});
 
       // Cause a hard reset by unwatching and rewatching immediately, but
       // deliberately don't send a resume token so that we get a full update.

--- a/packages/firestore/src/remote/remote_store.ts
+++ b/packages/firestore/src/remote/remote_store.ts
@@ -425,7 +425,6 @@ export class RemoteStore implements TargetMetadataProvider {
       // Clear the resume token for the query, since we're in a known mismatch
       // state.
       this.listenTargets[targetId] = queryData.copy({
-        snapshotVersion: queryData.snapshotVersion,
         resumeToken: emptyByteString()
       });
 

--- a/packages/firestore/test/unit/remote/remote_event.test.ts
+++ b/packages/firestore/test/unit/remote/remote_event.test.ts
@@ -668,8 +668,7 @@ describe('RemoteEvent', () => {
       WatchTargetChangeState.Current,
       [1, 2]
     );
-    const targets = listens(1, 2);
-    targets[2].purpose = QueryPurpose.LimboResolution;
+    const targets = {...listens(1), ...limboListens(2)};
 
     const event = createRemoteEvent({
       snapshotVersion: 1,

--- a/packages/firestore/test/unit/remote/remote_event.test.ts
+++ b/packages/firestore/test/unit/remote/remote_event.test.ts
@@ -668,7 +668,7 @@ describe('RemoteEvent', () => {
       WatchTargetChangeState.Current,
       [1, 2]
     );
-    const targets = {...listens(1), ...limboListens(2)};
+    const targets = { ...listens(1), ...limboListens(2) };
 
     const event = createRemoteEvent({
       snapshotVersion: 1,


### PR DESCRIPTION
This involves:
1) Making QueryData immutable
2) Renaming QueryData.update to QueryData.copy