### PR TITLE
Ensure that we create an empty TargetGlobal row.

### DIFF
--- a/packages/firestore/test/unit/local/indexeddb_schema.test.ts
+++ b/packages/firestore/test/unit/local/indexeddb_schema.test.ts
@@ -98,16 +98,16 @@ describe('IndexedDbSchema: createOrUpgradeDb', () => {
 
     const expectedMutation = new DbMutationBatch(userId, batchId, 1000, []);
     const dummyTargetGlobal = new DbTargetGlobal(
-      1,
-      1,
-      new DbTimestamp(1, 1),
-      1
+      /*highestTargetId=*/ 1,
+      /*highestListenSequencNumber=*/ 1,
+      /*lastRemoteSnapshotVersion=*/ new DbTimestamp(1, 1),
+      /*targetCount=*/ 1
     );
     const resetTargetGlobal = new DbTargetGlobal(
-      0,
-      0,
-      SnapshotVersion.MIN.toTimestamp(),
-      0
+      /*highestTargetId=*/ 0,
+      /*highestListenSequencNumber=*/ 0,
+      /*lastRemoteSnapshotVersion=*/ SnapshotVersion.MIN.toTimestamp(),
+      /*targetCount=*/ 0
     );
 
     return withDb(2, db => {

--- a/packages/firestore/test/unit/local/indexeddb_schema.test.ts
+++ b/packages/firestore/test/unit/local/indexeddb_schema.test.ts
@@ -24,10 +24,11 @@ import {
   DbTarget,
   DbTargetGlobal,
   DbTargetGlobalKey,
-  DbTargetKey
+  DbTargetKey,
+  DbTimestamp
 } from '../../../src/local/indexeddb_schema';
 import { SimpleDb, SimpleDbTransaction } from '../../../src/local/simple_db';
-import { PersistencePromise } from '../../../src/local/persistence_promise';
+import { SnapshotVersion } from '../../../src/core/snapshot_version';
 
 const INDEXEDDB_TEST_DATABASE = 'schemaTest';
 
@@ -71,17 +72,6 @@ function getAllObjectStores(db: IDBDatabase): string[] {
   return objectStores;
 }
 
-function getTargetCount(db: IDBDatabase): Promise<number> {
-  const sdb = new SimpleDb(db);
-  return sdb
-    .runTransaction('readonly', [DbTargetGlobal.store], txn =>
-      txn
-        .store<DbTargetGlobalKey, DbTargetGlobal>(DbTargetGlobal.store)
-        .get(DbTargetGlobal.key)
-    )
-    .then(metadata => metadata.targetCount);
-}
-
 describe('IndexedDbSchema: createOrUpgradeDb', () => {
   if (!IndexedDbPersistence.isAvailable()) {
     console.warn('No IndexedDB. Skipping createOrUpgradeDb() tests.');
@@ -101,58 +91,35 @@ describe('IndexedDbSchema: createOrUpgradeDb', () => {
     });
   });
 
-  it('can install schema version 2', () => {
-    return withDb(2, db => {
-      expect(db.version).to.equal(2);
-      // We should have all of the stores, we should have the target global row
-      // and we should not have any targets counted, because there are none.
-      expect(getAllObjectStores(db)).to.have.members(ALL_STORES);
-      // Check the target count. We haven't added any targets, so we expect 0.
-      return getTargetCount(db).then(targetCount => {
-        expect(targetCount).to.equal(0);
-      });
-    });
-  });
-
-  it('can upgrade from schema version 1 to 2', () => {
-    const expectedTargetCount = 5;
-    return withDb(1, db => {
-      const sdb = new SimpleDb(db);
-      // Now that we have all of the stores, add some targets so the next
-      // migration can count them.
-      return sdb.runTransaction('readwrite', [DbTarget.store], txn => {
-        const store = txn.store(DbTarget.store);
-        let p = PersistencePromise.resolve();
-        for (let i = 0; i < expectedTargetCount; i++) {
-          p = p.next(() => store.put({ targetId: i }));
-        }
-        return p;
-      });
-    }).then(() =>
-      withDb(2, db => {
-        expect(db.version).to.equal(2);
-        expect(getAllObjectStores(db)).to.have.members(ALL_STORES);
-        return getTargetCount(db).then(targetCount => {
-          expect(targetCount).to.equal(expectedTargetCount);
-        });
-      })
-    );
-  });
-
   it('drops the query cache from 2 to 3', () => {
     const userId = 'user';
     const batchId = 1;
     const targetId = 2;
 
     const expectedMutation = new DbMutationBatch(userId, batchId, 1000, []);
+    const dummyTargetGlobal = new DbTargetGlobal(
+      1,
+      1,
+      new DbTimestamp(1, 1),
+      1
+    );
+    const resetTargetGlobal = new DbTargetGlobal(
+      0,
+      0,
+      SnapshotVersion.MIN.toTimestamp(),
+      0
+    );
 
     return withDb(2, db => {
       const sdb = new SimpleDb(db);
       return sdb.runTransaction(
         'readwrite',
-        [DbTarget.store, DbMutationBatch.store],
+        [DbTarget.store, DbTargetGlobal.store, DbMutationBatch.store],
         txn => {
           const targets = txn.store<DbTargetKey, DbTarget>(DbTarget.store);
+          const targetGlobal = txn.store<DbTargetGlobalKey, DbTargetGlobal>(
+            DbTargetGlobal.store
+          );
           const mutations = txn.store<DbMutationBatchKey, DbMutationBatch>(
             DbMutationBatch.store
           );
@@ -161,6 +128,9 @@ describe('IndexedDbSchema: createOrUpgradeDb', () => {
             targets
               // tslint:disable-next-line:no-any
               .put({ targetId, canonicalId: 'foo' } as any)
+              .next(() =>
+                targetGlobal.put(DbTargetGlobal.key, dummyTargetGlobal)
+              )
               .next(() => mutations.put(expectedMutation))
           );
         }
@@ -173,9 +143,12 @@ describe('IndexedDbSchema: createOrUpgradeDb', () => {
         const sdb = new SimpleDb(db);
         return sdb.runTransaction(
           'readwrite',
-          [DbTarget.store, DbMutationBatch.store],
+          [DbTarget.store, DbTargetGlobal.store, DbMutationBatch.store],
           txn => {
             const targets = txn.store<DbTargetKey, DbTarget>(DbTarget.store);
+            const targetGlobal = txn.store<DbTargetGlobalKey, DbTargetGlobal>(
+              DbTargetGlobal.store
+            );
             const mutations = txn.store<DbMutationBatchKey, DbMutationBatch>(
               DbMutationBatch.store
             );
@@ -185,6 +158,14 @@ describe('IndexedDbSchema: createOrUpgradeDb', () => {
               .next(target => {
                 // The target should have been dropped
                 expect(target).to.be.null;
+              })
+              .next(() => targetGlobal.get(DbTargetGlobal.key))
+              .next(targetGlobalEntry => {
+                // Target Global should exist but be cleared.
+                // HACK: round-trip through JSON to clear types, like IndexedDb
+                // does.
+                const expected = JSON.parse(JSON.stringify(resetTargetGlobal));
+                expect(targetGlobalEntry).to.deep.equal(expected);
               })
               .next(() => mutations.get([userId, batchId]))
               .next(mutation => {


### PR DESCRIPTION
Ensure the v3 migration unconditionally creates the TargetGlobal row.  Remove the no-longer-necessary v2 schema migration.