### PR TITLE
Refactor PersistentStream.

### DIFF
--- a/packages/firestore/src/remote/datastore.ts
+++ b/packages/firestore/src/remote/datastore.ts
@@ -1,3 +1,4 @@
+import { WatchStreamListener, WriteStreamListener } from './persistent_stream';
 /**
  * Copyright 2017 Google Inc.
  *
@@ -54,21 +55,27 @@ export class Datastore {
     private serializer: JsonProtoSerializer
   ) {}
 
-  newPersistentWriteStream(): PersistentWriteStream {
+  newPersistentWriteStream(
+    listener: WriteStreamListener
+  ): PersistentWriteStream {
     return new PersistentWriteStream(
       this.queue,
       this.connection,
       this.credentials,
-      this.serializer
+      this.serializer,
+      listener
     );
   }
 
-  newPersistentWatchStream(): PersistentListenStream {
+  newPersistentWatchStream(
+    listener: WatchStreamListener
+  ): PersistentListenStream {
     return new PersistentListenStream(
       this.queue,
       this.connection,
       this.credentials,
-      this.serializer
+      this.serializer,
+      listener
     );
   }
 

--- a/packages/firestore/src/remote/persistent_stream.ts
+++ b/packages/firestore/src/remote/persistent_stream.ts
@@ -168,7 +168,8 @@ export abstract class PersistentStream<
   private state = PersistentStreamState.Initial;
   /**
    * A close count that's incremented every time the stream is closed; used by
-   * closeGuardedDispatcher() to invalidate callbacks that happen after close.
+   * getCloseGuardedDispatcher() to invalidate callbacks that happen after
+   * close.
    */
   private closeCount = 0;
 
@@ -397,7 +398,7 @@ export abstract class PersistentStream<
 
     this.state = PersistentStreamState.Starting;
 
-    const dispatchIfNotClosed = this.closeGuardedDispatcher(this.closeCount);
+    const dispatchIfNotClosed = this.getCloseGuardedDispatcher(this.closeCount);
 
     // TODO(mikelehen): Just use dispatchIfNotClosed, but see TODO below.
     const closeCount = this.closeCount;
@@ -433,7 +434,7 @@ export abstract class PersistentStream<
       'Trying to start stream in a non-starting state'
     );
 
-    const dispatchIfNotClosed = this.closeGuardedDispatcher(this.closeCount);
+    const dispatchIfNotClosed = this.getCloseGuardedDispatcher(this.closeCount);
 
     this.stream = this.startRpc(token);
     this.stream.onOpen(() => {
@@ -497,7 +498,7 @@ export abstract class PersistentStream<
    * us to turn auth / stream callbacks into no-ops if the stream is closed /
    * re-opened, etc.
    */
-  private closeGuardedDispatcher(
+  private getCloseGuardedDispatcher(
     startCloseCount: number
   ): (fn: () => Promise<void>) => void {
     return (fn: () => Promise<void>): void => {
@@ -507,7 +508,7 @@ export abstract class PersistentStream<
         } else {
           log.debug(
             LOG_TAG,
-            'stream callback skipped by closeGuardedDispatcher.'
+            'stream callback skipped by getCloseGuardedDispatcher.'
           );
           return Promise.resolve();
         }

--- a/packages/firestore/src/remote/remote_store.ts
+++ b/packages/firestore/src/remote/remote_store.ts
@@ -318,11 +318,14 @@ export class RemoteStore implements TargetMetadataProvider {
   }
 
   private async onWatchStreamClose(error?: FirestoreError): Promise<void> {
-    assert(
-      error !== undefined || !this.shouldStartWatchStream(),
-      'onWatchStreamClose() should be called with an error if the watch ' +
-        'stream is still needed.'
-    );
+    if (error === undefined) {
+      // Graceful stop (due to stop() or idle timeout). Make sure that's
+      // desirable.
+      assert(
+        !this.shouldStartWatchStream(),
+        'Watch stream was stopped gracefully while still needed.'
+      );
+    }
 
     this.cleanUpWatchStreamState();
 
@@ -580,11 +583,14 @@ export class RemoteStore implements TargetMetadataProvider {
   }
 
   private async onWriteStreamClose(error?: FirestoreError): Promise<void> {
-    assert(
-      error !== undefined || !this.shouldStartWriteStream(),
-      'onWriteStreamClose() should be called with an error if the write ' +
-        'stream is still needed.'
-    );
+    if (error === undefined) {
+      // Graceful stop (due to stop() or idle timeout). Make sure that's
+      // desirable.
+      assert(
+        !this.shouldStartWriteStream(),
+        'Write stream was stopped gracefully while still needed.'
+      );
+    }
 
     // If the write stream closed due to an error, invoke the error callbacks if
     // there are pending writes.

--- a/packages/firestore/src/remote/remote_store.ts
+++ b/packages/firestore/src/remote/remote_store.ts
@@ -153,9 +153,6 @@ export class RemoteStore implements TargetMetadataProvider {
    * LocalStore, etc.
    */
   async start(): Promise<void> {
-    // Load any saved stream token from persistent storage
-    this.writeStream.lastStreamToken = await this.localStore.getLastStreamToken();
-
     await this.enableNetwork();
   }
 
@@ -197,9 +194,9 @@ export class RemoteStore implements TargetMetadataProvider {
       if (this.writePipeline.length > 0) {
         log.debug(
           LOG_TAG,
-          'Stopping write stream with ' +
-            this.writePipeline.length +
-            ' pending writes'
+          `Stopping write stream with ${
+            this.writePipeline.length
+          } pending writes`
         );
         this.writePipeline = [];
       }

--- a/packages/firestore/test/integration/remote/stream.test.ts
+++ b/packages/firestore/test/integration/remote/stream.test.ts
@@ -134,20 +134,20 @@ describe('Watch Stream', () => {
   });
 
   /**
-   * Verifies that the watch stream does not issue an onClose callback after a
+   * Verifies that the watch stream issues an onClose callback after a
    * call to stop().
    */
   it('can be stopped before handshake', () => {
     let watchStream: PersistentListenStream;
 
     return withTestDatastore(ds => {
-      watchStream = ds.newPersistentWatchStream();
-      watchStream.start(streamListener);
+      watchStream = ds.newPersistentWatchStream(streamListener);
+      watchStream.start();
 
       return streamListener.awaitCallback('open').then(() => {
-        // Stop must not call onClose because the full implementation of the callback could
-        // attempt to restart the stream in the event it had pending watches.
         watchStream.stop();
+
+        return streamListener.awaitCallback('close');
       });
     });
   });
@@ -183,22 +183,20 @@ describe('Write Stream', () => {
   });
 
   /**
-   * Verifies that the write stream does not issue an onClose callback after a
-   * call to stop().
+   * Verifies that the write stream issues an onClose callback after a call to
+   * stop().
    */
   it('can be stopped before handshake', () => {
     let writeStream: PersistentWriteStream;
 
     return withTestDatastore(ds => {
-      writeStream = ds.newPersistentWriteStream();
-      writeStream.start(streamListener);
+      writeStream = ds.newPersistentWriteStream(streamListener);
+      writeStream.start();
       return streamListener.awaitCallback('open');
     }).then(() => {
-      // Don't start the handshake.
-
-      // Stop must not call onClose because the full implementation of the callback could
-      // attempt to restart the stream in the event it had pending writes.
       writeStream.stop();
+
+      return streamListener.awaitCallback('close');
     });
   });
 
@@ -206,8 +204,8 @@ describe('Write Stream', () => {
     let writeStream: PersistentWriteStream;
 
     return withTestDatastore(ds => {
-      writeStream = ds.newPersistentWriteStream();
-      writeStream.start(streamListener);
+      writeStream = ds.newPersistentWriteStream(streamListener);
+      writeStream.start();
       return streamListener.awaitCallback('open');
     })
       .then(() => {
@@ -225,6 +223,8 @@ describe('Write Stream', () => {
       })
       .then(() => {
         writeStream.stop();
+
+        return streamListener.awaitCallback('close');
       });
   });
 
@@ -232,8 +232,8 @@ describe('Write Stream', () => {
     const queue = new AsyncQueue();
 
     return withTestDatastore(ds => {
-      const writeStream = ds.newPersistentWriteStream();
-      writeStream.start(streamListener);
+      const writeStream = ds.newPersistentWriteStream(streamListener);
+      writeStream.start();
       return streamListener
         .awaitCallback('open')
         .then(() => {
@@ -259,8 +259,8 @@ describe('Write Stream', () => {
     const queue = new AsyncQueue();
 
     return withTestDatastore(ds => {
-      const writeStream = ds.newPersistentWriteStream();
-      writeStream.start(streamListener);
+      const writeStream = ds.newPersistentWriteStream(streamListener);
+      writeStream.start();
       return streamListener
         .awaitCallback('open')
         .then(() => {
@@ -288,8 +288,8 @@ describe('Write Stream', () => {
 
     return withTestDatastore(
       ds => {
-        const writeStream = ds.newPersistentWriteStream();
-        writeStream.start(streamListener);
+        const writeStream = ds.newPersistentWriteStream(streamListener);
+        writeStream.start();
         return streamListener
           .awaitCallback('open')
           .then(() => {
@@ -301,7 +301,7 @@ describe('Write Stream', () => {
             return streamListener.awaitCallback('close');
           })
           .then(() => {
-            writeStream.start(streamListener);
+            writeStream.start();
             return streamListener.awaitCallback('open');
           })
           .then(() => {
@@ -312,7 +312,7 @@ describe('Write Stream', () => {
             return streamListener.awaitCallback('close');
           })
           .then(() => {
-            writeStream.start(streamListener);
+            writeStream.start();
             return streamListener.awaitCallback('open');
           })
           .then(() => {

--- a/packages/firestore/test/unit/specs/spec_test_runner.ts
+++ b/packages/firestore/test/unit/specs/spec_test_runner.ts
@@ -425,9 +425,11 @@ abstract class TestRunner {
   }
 
   async shutdown(): Promise<void> {
-    await this.remoteStore.shutdown();
-    await this.persistence.shutdown(/* deleteData= */ true);
-    await this.destroyPersistence();
+    await this.queue.enqueue(async () => {
+      await this.remoteStore.shutdown();
+      await this.persistence.shutdown(/* deleteData= */ true);
+      await this.destroyPersistence();
+    });
   }
 
   run(steps: SpecStep[]): Promise<void> {


### PR DESCRIPTION
[FYI- I'll probably have @wilhuff take a look at this too since he had opinions about the stream listener stuff, but in the interest of saving him time, can you do the first pass?]

This breaks out a number of changes I made as prep for b/80402781 (Continue
retrying streams for 1 minute (idle delay)).

PersistentStream changes:
* Rather than providing a stream event listener to every call of start(),
  the stream listener is now provided once to the constructor and cannot
  be changed.
* Streams can now be restarted indefinitely, even after a call to stop().
  * PersistentStreamState.Stopped was removed and we just return to
    'Initial' after a stop() call.
  * Added `currentAuthAttempt` member to PersistentStream in order to avoid
    bleedthrough issues if stop() / start() are called while an auth attempt
    is in progress (i.e. so we correctly abandon the old auth attempt).
  * Calling stop() now triggers the onClose() event listener, which
    simplifies stream cleanup.
* PersistentStreamState.Auth renamed to 'Starting' to better reflect that
  it encompasses both authentication and opening the stream.

RemoteStore changes:
* Creates streams once and just stop() / start()s them as necessary,
  never recreating them completely.
  * Added networkEnabled flag to track whether the network is
    enabled or not, since we no longer null out the streams.
  * Refactored disableNetwork() / enableNetwork() to remove stream
    re-creation. They're now simple enough that I stopped re-using
    them from shutdown() and handleUserChange().

Misc:
* Comment improvements including a state diagram on PersistentStream.
* Fixed spec test shutdown to schedule via the AsyncQueue to fix
  sequencing order I ran into.