### PR TITLE
Ensure persistence started

### DIFF
--- a/packages/firestore/src/local/indexeddb_persistence.ts
+++ b/packages/firestore/src/local/indexeddb_persistence.ts
@@ -96,10 +96,7 @@ export class IndexedDbPersistence implements Persistence {
   static MAIN_DATABASE = 'main';
 
   private simpleDb: SimpleDb;
-  private hasStarted: boolean;
-  get started(): boolean {
-    return this.hasStarted;
-  }
+  private _started = false;
   private dbName: string;
   private localStoragePrefix: string;
   private ownerId: string = this.generateOwnerId();
@@ -144,13 +141,13 @@ export class IndexedDbPersistence implements Persistence {
         this.attachWindowUnloadHook();
       })
       .then(() => {
-        this.hasStarted = true;
+        this._started = true;
       });
   }
 
   shutdown(deleteData?: boolean): Promise<void> {
     assert(this.started, 'IndexedDbPersistence shutdown without start!');
-    this.hasStarted = false;
+    this._started = false;
     this.detachWindowUnloadHook();
     this.stopOwnerLeaseRefreshes();
     return this.releaseOwnerLease().then(() => {
@@ -159,6 +156,10 @@ export class IndexedDbPersistence implements Persistence {
         return SimpleDb.delete(this.dbName);
       }
     });
+  }
+
+  get started(): boolean {
+    return this._started;
   }
 
   getMutationQueue(user: User): MutationQueue {

--- a/packages/firestore/src/local/indexeddb_persistence.ts
+++ b/packages/firestore/src/local/indexeddb_persistence.ts
@@ -142,7 +142,8 @@ export class IndexedDbPersistence implements Persistence {
       .then(() => {
         this.scheduleOwnerLeaseRefreshes();
         this.attachWindowUnloadHook();
-      }).then(() => {
+      })
+      .then(() => {
         this.hasStarted = true;
       });
   }

--- a/packages/firestore/src/local/local_store.ts
+++ b/packages/firestore/src/local/local_store.ts
@@ -163,6 +163,10 @@ export class LocalStore {
      */
     private garbageCollector: GarbageCollector
   ) {
+    assert(
+      persistence.started,
+      'Local Store passed an unstarted persistence implementation'
+    );
     this.mutationQueue = persistence.getMutationQueue(initialUser);
     this.remoteDocuments = persistence.getRemoteDocumentCache();
     this.queryCache = persistence.getQueryCache();

--- a/packages/firestore/src/local/local_store.ts
+++ b/packages/firestore/src/local/local_store.ts
@@ -165,7 +165,7 @@ export class LocalStore {
   ) {
     assert(
       persistence.started,
-      'Local Store passed an unstarted persistence implementation'
+      'LocalStore was passed an unstarted persistence implementation'
     );
     this.mutationQueue = persistence.getMutationQueue(initialUser);
     this.remoteDocuments = persistence.getRemoteDocumentCache();

--- a/packages/firestore/src/local/memory_persistence.ts
+++ b/packages/firestore/src/local/memory_persistence.ts
@@ -45,21 +45,22 @@ export class MemoryPersistence implements Persistence {
   private remoteDocumentCache = new MemoryRemoteDocumentCache();
   private queryCache = new MemoryQueryCache();
 
-  private hasStarted = false;
-  get started(): boolean {
-    return this.hasStarted;
-  }
+  private _started = false;
 
   async start(): Promise<void> {
     // No durable state to read on startup.
-    assert(!this.hasStarted, 'MemoryPersistence double-started!');
-    this.hasStarted = true;
+    assert(!this._started, 'MemoryPersistence double-started!');
+    this._started = true;
   }
 
   async shutdown(deleteData?: boolean): Promise<void> {
     // No durable state to ensure is closed on shutdown.
-    assert(this.hasStarted, 'MemoryPersistence shutdown without start!');
-    this.hasStarted = false;
+    assert(this._started, 'MemoryPersistence shutdown without start!');
+    this._started = false;
+  }
+
+  get started(): boolean {
+    return this._started;
   }
 
   getMutationQueue(user: User): MutationQueue {

--- a/packages/firestore/src/local/memory_persistence.ts
+++ b/packages/firestore/src/local/memory_persistence.ts
@@ -45,18 +45,21 @@ export class MemoryPersistence implements Persistence {
   private remoteDocumentCache = new MemoryRemoteDocumentCache();
   private queryCache = new MemoryQueryCache();
 
-  private started = false;
+  private hasStarted = false;
+  get started(): boolean {
+    return this.hasStarted;
+  }
 
   async start(): Promise<void> {
     // No durable state to read on startup.
-    assert(!this.started, 'MemoryPersistence double-started!');
-    this.started = true;
+    assert(!this.hasStarted, 'MemoryPersistence double-started!');
+    this.hasStarted = true;
   }
 
   async shutdown(deleteData?: boolean): Promise<void> {
     // No durable state to ensure is closed on shutdown.
-    assert(this.started, 'MemoryPersistence shutdown without start!');
-    this.started = false;
+    assert(this.hasStarted, 'MemoryPersistence shutdown without start!');
+    this.hasStarted = false;
   }
 
   getMutationQueue(user: User): MutationQueue {

--- a/packages/firestore/src/local/persistence.ts
+++ b/packages/firestore/src/local/persistence.ts
@@ -69,16 +69,16 @@ export interface PersistenceTransaction {}
  */
 export interface Persistence {
   /**
+   * Whether or not this persistence instance has been started.
+   */
+  readonly started: boolean;
+
+  /**
    * Starts persistent storage, opening the database or similar.
    *
    * Throws an exception if the database could not be opened.
    */
   start(): Promise<void>;
-
-  /**
-   * Whether or not this persistence instance has been started.
-   */
-  readonly started: boolean;
 
   /**
    * Releases any resources held during eager shutdown.

--- a/packages/firestore/src/local/persistence.ts
+++ b/packages/firestore/src/local/persistence.ts
@@ -76,6 +76,11 @@ export interface Persistence {
   start(): Promise<void>;
 
   /**
+   * Whether or not this persistence instance has been started.
+   */
+  readonly started: boolean;
+
+  /**
    * Releases any resources held during eager shutdown.
    *
    * @param deleteData Whether to delete the persisted data. This causes


### PR DESCRIPTION
This mostly fixes up the spec tests so that we can assert that `LocalStore` always gets an already-started `Persistence` instance. 