### PR TITLE
[Multi-Tab] Sort the initial set of changes

### DIFF
--- a/packages/firestore/src/core/view_snapshot.ts
+++ b/packages/firestore/src/core/view_snapshot.ts
@@ -156,16 +156,16 @@ export class ViewSnapshot {
     fromCache: boolean,
     hasPendingWrites: boolean
   ): ViewSnapshot {
-    const changeSet = new DocumentChangeSet();
+    const changes: DocumentViewChange[] = [];
     documents.forEach(doc => {
-      changeSet.track({ type: ChangeType.Added, doc });
+      changes.push({ type: ChangeType.Added, doc });
     });
 
     return new ViewSnapshot(
       query,
       documents,
       DocumentSet.emptySet(documents),
-      changeSet.getChanges(),
+      changes,
       fromCache,
       hasPendingWrites,
       /* syncStateChanged */ true,


### PR DESCRIPTION
The new `fromInitialDocuments` didn't respect the query order as it went through DocumentChangeSet.  I changed this back to what event manager was doing and added a spec test that verified query result order.