### PR TITLE
[Multi-Tab] Don't add change log entry when there are no changes

### DIFF
--- a/packages/firestore/src/local/indexeddb_remote_document_cache.ts
+++ b/packages/firestore/src/local/indexeddb_remote_document_cache.ts
@@ -69,18 +69,18 @@ export class IndexedDbRemoteDocumentCache implements RemoteDocumentCache {
       let changedKeys = documentKeySet();
       for (const maybeDocument of maybeDocuments) {
         promises.push(
-            documentStore.put(
-                dbKey(maybeDocument.key),
-                this.serializer.toDbRemoteDocument(maybeDocument)
-            )
+          documentStore.put(
+            dbKey(maybeDocument.key),
+            this.serializer.toDbRemoteDocument(maybeDocument)
+          )
         );
         changedKeys = changedKeys.add(maybeDocument.key);
       }
 
       promises.push(
-          documentChangesStore(transaction).put({
-            changes: this.serializer.toDbResourcePaths(changedKeys)
-          })
+        documentChangesStore(transaction).put({
+          changes: this.serializer.toDbResourcePaths(changedKeys)
+        })
       );
     }
 

--- a/packages/firestore/src/local/indexeddb_remote_document_cache.ts
+++ b/packages/firestore/src/local/indexeddb_remote_document_cache.ts
@@ -63,24 +63,27 @@ export class IndexedDbRemoteDocumentCache implements RemoteDocumentCache {
     maybeDocuments: MaybeDocument[]
   ): PersistencePromise<void> {
     const promises: Array<PersistencePromise<void>> = [];
-    const documentStore = remoteDocumentsStore(transaction);
 
-    let changedKeys = documentKeySet();
-    for (const maybeDocument of maybeDocuments) {
+    if (maybeDocuments.length > 0) {
+      const documentStore = remoteDocumentsStore(transaction);
+      let changedKeys = documentKeySet();
+      for (const maybeDocument of maybeDocuments) {
+        promises.push(
+            documentStore.put(
+                dbKey(maybeDocument.key),
+                this.serializer.toDbRemoteDocument(maybeDocument)
+            )
+        );
+        changedKeys = changedKeys.add(maybeDocument.key);
+      }
+
       promises.push(
-        documentStore.put(
-          dbKey(maybeDocument.key),
-          this.serializer.toDbRemoteDocument(maybeDocument)
-        )
+          documentChangesStore(transaction).put({
+            changes: this.serializer.toDbResourcePaths(changedKeys)
+          })
       );
-      changedKeys = changedKeys.add(maybeDocument.key);
     }
 
-    promises.push(
-      documentChangesStore(transaction).put({
-        changes: this.serializer.toDbResourcePaths(changedKeys)
-      })
-    );
     return PersistencePromise.waitFor(promises);
   }
 


### PR DESCRIPTION
FriendlyEats writes a bunch of empty change events to the document change log. Let's not do that.