### PR TITLE
Implement global resume token

### DIFF
--- a/packages/firestore/src/core/sync_engine.ts
+++ b/packages/firestore/src/core/sync_engine.ts
@@ -78,12 +78,6 @@ class QueryView {
      */
     public targetId: TargetId,
     /**
-     * An identifier from the datastore backend that indicates the last state
-     * of the results that was received. This can be used to indicate where
-     * to continue receiving new doc changes for the query.
-     */
-    public resumeToken: ProtoByteString,
-    /**
      * The view is responsible for computing the final merged truth of what
      * docs are in the query. It gets notified of local and remote changes,
      * and applies the query filters and limits to determine the most correct
@@ -195,12 +189,7 @@ export class SyncEngine implements RemoteSyncer {
                 'applyChanges for new view should always return a snapshot'
               );
 
-              const data = new QueryView(
-                query,
-                queryData.targetId,
-                queryData.resumeToken,
-                view
-              );
+              const data = new QueryView(query, queryData.targetId, view);
               this.queryViewsByQuery.set(query, data);
               this.queryViewsByTarget[queryData.targetId] = data;
               this.viewHandler!([viewChange.snapshot!]);

--- a/packages/firestore/src/core/sync_engine.ts
+++ b/packages/firestore/src/core/sync_engine.ts
@@ -46,7 +46,7 @@ import { Query } from './query';
 import { SnapshotVersion } from './snapshot_version';
 import { TargetIdGenerator } from './target_id_generator';
 import { Transaction } from './transaction';
-import { BatchId, OnlineState, ProtoByteString, TargetId } from './types';
+import { BatchId, OnlineState, TargetId } from './types';
 import {
   AddedLimboDocument,
   LimboDocumentChange,

--- a/packages/firestore/src/local/indexeddb_query_cache.ts
+++ b/packages/firestore/src/local/indexeddb_query_cache.ts
@@ -44,7 +44,7 @@ export class IndexedDbQueryCache implements QueryCache {
   constructor(private serializer: LocalSerializer) {}
 
   /**
-   * The last received snapshot version. We store this seperately from the
+   * The last received snapshot version. We store this separately from the
    * metadata to avoid the extra conversion to/from DbTimestamp.
    */
   private lastRemoteSnapshotVersion = SnapshotVersion.MIN;
@@ -173,7 +173,7 @@ export class IndexedDbQueryCache implements QueryCache {
   ): PersistencePromise<QueryData | null> {
     // Iterating by the canonicalId may yield more than one result because
     // canonicalId values are not required to be unique per target. This query
-    // depends on the queryTargets index to be efficent.
+    // depends on the queryTargets index to be efficient.
     const canonicalId = query.canonicalId();
     const range = IDBKeyRange.bound(
       [canonicalId, Number.NEGATIVE_INFINITY],
@@ -202,7 +202,7 @@ export class IndexedDbQueryCache implements QueryCache {
     targetId: TargetId
   ): PersistencePromise<void> {
     // PORTING NOTE: The reverse index (documentsTargets) is maintained by
-    // Indexeddb.
+    // IndexedDb.
     const promises: Array<PersistencePromise<void>> = [];
     const store = documentTargetStore(txn);
     keys.forEach(key => {

--- a/packages/firestore/src/remote/watch_change.ts
+++ b/packages/firestore/src/remote/watch_change.ts
@@ -297,7 +297,7 @@ export class WatchChangeAggregator {
 
   /** Processes and adds the WatchTargetChange to the current set of changes. */
   handleTargetChange(targetChange: WatchTargetChange): void {
-    targetChange.targetIds.forEach(targetId => {
+    this.forEachTargetId(targetChange, targetId => {
       const targetState = this.ensureTargetState(targetId);
       switch (targetChange.state) {
         case WatchTargetChangeState.NoChange:
@@ -350,6 +350,24 @@ export class WatchChangeAggregator {
           fail('Unknown target watch change state: ' + targetChange.state);
       }
     });
+  }
+
+  /**
+   * Iterates over all targetIds that the watch change applies to: either the
+   * targetIds explicitly listed in the change or the targetIds of all currently
+   * active targets.
+   */
+  forEachTargetId(
+    targetChange: WatchTargetChange,
+    fn: (targetId: TargetId) => void
+  ): void {
+    if (targetChange.targetIds.length > 0) {
+      targetChange.targetIds.forEach(fn);
+    } else {
+      objUtils.forEachNumber(this.targetStates, (targetId, _) => {
+        fn(targetId);
+      });
+    }
   }
 
   /**

--- a/packages/firestore/src/remote/watch_change.ts
+++ b/packages/firestore/src/remote/watch_change.ts
@@ -297,7 +297,7 @@ export class WatchChangeAggregator {
 
   /** Processes and adds the WatchTargetChange to the current set of changes. */
   handleTargetChange(targetChange: WatchTargetChange): void {
-    this.forEachTargetId(targetChange, targetId => {
+    this.forEachTarget(targetChange, targetId => {
       const targetState = this.ensureTargetState(targetId);
       switch (targetChange.state) {
         case WatchTargetChangeState.NoChange:
@@ -357,16 +357,14 @@ export class WatchChangeAggregator {
    * targetIds explicitly listed in the change or the targetIds of all currently
    * active targets.
    */
-  forEachTargetId(
+  forEachTarget(
     targetChange: WatchTargetChange,
     fn: (targetId: TargetId) => void
   ): void {
     if (targetChange.targetIds.length > 0) {
       targetChange.targetIds.forEach(fn);
     } else {
-      objUtils.forEachNumber(this.targetStates, (targetId, _) => {
-        fn(targetId);
-      });
+      objUtils.forEachNumber(this.targetStates, fn);
     }
   }
 

--- a/packages/firestore/test/unit/specs/listen_spec.test.ts
+++ b/packages/firestore/test/unit/specs/listen_spec.test.ts
@@ -510,7 +510,7 @@ describeSpec('Listens:', [], () => {
       .expectEvents(query, {});
   });
 
-  specTest('Persists global resume tokens', [], () => {
+  specTest('Persists global resume tokens on unlisten', [], () => {
     const query = Query.atPath(path('collection'));
     const docA = doc('collection/a', 1000, { key: 'a' });
 
@@ -535,4 +535,62 @@ describeSpec('Listens:', [], () => {
         .expectEvents(query, { fromCache: false })
     );
   });
+
+  specTest('Omits global resume tokens for a short while', [], () => {
+    const query = Query.atPath(path('collection'));
+    const docA = doc('collection/a', 1000, { key: 'a' });
+
+    return (
+      spec()
+        .withGCEnabled(false)
+        .userListens(query)
+        .watchAcksFull(query, 1000, docA)
+        .expectEvents(query, { added: [docA] })
+
+        // One millisecond later, watch sends an updated resume token but the
+        // user doesn't manage to unlisten before restart.
+        .watchSnapshots(2000, [], 'resume-token-2000')
+        .restart()
+
+        .userListens(query, 'resume-token-1000')
+        .expectEvents(query, { added: [docA], fromCache: true })
+        .watchAcks(query)
+        .watchCurrents(query, 'resume-token-3000')
+        .watchSnapshots(3000)
+        .expectEvents(query, { fromCache: false })
+    );
+  });
+
+  specTest(
+    'Persists global resume tokens if the snapshot is old enough',
+    [],
+    () => {
+      const initialVersion = 1000;
+      const minutesLater = 5 * 60 * 1e6 + initialVersion;
+      const evenLater = 1000 + minutesLater;
+
+      const query = Query.atPath(path('collection'));
+      const docA = doc('collection/a', initialVersion, { key: 'a' });
+
+      return (
+        spec()
+          .withGCEnabled(false)
+          .userListens(query)
+          .watchAcksFull(query, initialVersion, docA)
+          .expectEvents(query, { added: [docA] })
+
+          // 5 minutes later, watch sends an updated resume token but the user
+          // doesn't manage to unlisten before restart.
+          .watchSnapshots(minutesLater, [], 'resume-token-minutes-later')
+          .restart()
+
+          .userListens(query, 'resume-token-minutes-later')
+          .expectEvents(query, { added: [docA], fromCache: true })
+          .watchAcks(query)
+          .watchCurrents(query, 'resume-token-even-later')
+          .watchSnapshots(evenLater)
+          .expectEvents(query, { fromCache: false })
+      );
+    }
+  );
 });


### PR DESCRIPTION
Watch sends us a periodic heartbeat with an updated resume token that applies to [all active targets](https://github.com/googleapis/googleapis/blob/201d7be7f9da925df93bc52f8108963284f61aed/google/firestore/v1beta1/firestore.proto#L672) by sending us an empty list of target ids.

Our current implementation in the `WatchChangeAggregator` loops over the target ids in the change so in this case we fail to take any action. If a client has been listening to a query that sees no changes for more than thirty minutes we'll fail to persist any resume token updates during that period.

This change:
  * Implements special handling in the WatchChangeAggregator for the empty target IDs list
  * Adds a filter in the local store to prevent heartbeat resume token updates from being written out more than once every five minutes
  * Adds logic on unlisten to ensure that we don't lose a token.

Note that while a query is active, the in-memory state is updated, so any incidental re-listens that happen as a result of stream loss or re-auth will always use an up-to-date token.