### PR TITLE
Firestore: in tests, silence the verbose warning about old timestamp behavior

### DIFF
--- a/packages/firestore/test/integration/api/fields.test.ts
+++ b/packages/firestore/test/integration/api/fields.test.ts
@@ -24,6 +24,8 @@ import {
   withTestCollectionSettings,
   withTestDoc
 } from '../util/helpers';
+import * as log from '../../../src/util/log';
+import { LogLevel } from '../../../src/util/log';
 
 const FieldPath = firebase.firestore.FieldPath;
 const Timestamp = firebase.firestore.Timestamp;
@@ -349,12 +351,18 @@ apiDescribe('Timestamp Fields in snapshots', persistence => {
   };
 
   it('are returned as native dates if timestampsInSnapshots is not set', () => {
+    // Avoid the verbose log message triggered by timestampsInSnapshots ==
+    // false.
+    const logLevel = log.getLogLevel();
+    log.setLogLevel(LogLevel.SILENT);
+
     const settings = { ...DEFAULT_SETTINGS };
     settings['timestampsInSnapshots'] = false;
 
     const timestamp = new Timestamp(100, 123456789);
     const testDocs = { a: testDataWithTimestamps(timestamp) };
     return withTestCollectionSettings(persistence, settings, testDocs, coll => {
+      log.setLogLevel(logLevel);
       return coll
         .doc('a')
         .get()
@@ -374,6 +382,7 @@ apiDescribe('Timestamp Fields in snapshots', persistence => {
             .that.deep.equals(timestamp.toDate());
         });
     });
+
   });
 
   it('are returned as Timestamps', () => {
@@ -411,6 +420,9 @@ apiDescribe('Timestamp Fields in snapshots', persistence => {
   });
 
   it('timestampsInSnapshots affects server timestamps', () => {
+    const logLevel = log.getLogLevel();
+    log.setLogLevel(LogLevel.SILENT);
+
     const settings = { ...DEFAULT_SETTINGS };
     settings['timestampsInSnapshots'] = false;
     const testDocs = {
@@ -418,6 +430,7 @@ apiDescribe('Timestamp Fields in snapshots', persistence => {
     };
 
     return withTestCollectionSettings(persistence, settings, testDocs, coll => {
+      log.setLogLevel(logLevel);
       return coll
         .doc('a')
         .get()

--- a/packages/firestore/test/integration/api/fields.test.ts
+++ b/packages/firestore/test/integration/api/fields.test.ts
@@ -382,7 +382,6 @@ apiDescribe('Timestamp Fields in snapshots', persistence => {
             .that.deep.equals(timestamp.toDate());
         });
     });
-
   });
 
   it('are returned as Timestamps', () => {

--- a/packages/firestore/test/util/api_helpers.ts
+++ b/packages/firestore/test/util/api_helpers.ts
@@ -46,15 +46,16 @@ export const FIRESTORE = new Firestore({
 });
 
 export function firestore(): Firestore {
+  FIRESTORE.settings({timestampsInSnapshots: true});
   return FIRESTORE;
 }
 
 export function collectionReference(path: string): CollectionReference {
-  return new CollectionReference(pathFrom(path), FIRESTORE);
+  return new CollectionReference(pathFrom(path), firestore());
 }
 
 export function documentReference(path: string): DocumentReference {
-  return new DocumentReference(key(path), FIRESTORE);
+  return new DocumentReference(key(path), firestore());
 }
 
 export function documentSnapshot(
@@ -64,18 +65,18 @@ export function documentSnapshot(
 ): DocumentSnapshot {
   if (data) {
     return new DocumentSnapshot(
-      FIRESTORE,
+      firestore(),
       key(path),
       doc(path, 1, data),
       fromCache
     );
   } else {
-    return new DocumentSnapshot(FIRESTORE, key(path), null, fromCache);
+    return new DocumentSnapshot(firestore(), key(path), null, fromCache);
   }
 }
 
 export function query(path: string): Query {
-  return new Query(InternalQuery.atPath(pathFrom(path)), FIRESTORE);
+  return new Query(InternalQuery.atPath(pathFrom(path)), firestore());
 }
 
 /**
@@ -121,5 +122,5 @@ export function querySnapshot(
     syncStateChanged,
     /* excludesMetadataChanges= */ false
   );
-  return new QuerySnapshot(FIRESTORE, query, viewSnapshot);
+  return new QuerySnapshot(firestore(), query, viewSnapshot);
 }

--- a/packages/firestore/test/util/api_helpers.ts
+++ b/packages/firestore/test/util/api_helpers.ts
@@ -46,7 +46,7 @@ export const FIRESTORE = new Firestore({
 });
 
 export function firestore(): Firestore {
-  FIRESTORE.settings({timestampsInSnapshots: true});
+  FIRESTORE.settings({ timestampsInSnapshots: true });
   return FIRESTORE;
 }
 


### PR DESCRIPTION
This cleans up the few leftover places where the warning was still being outputted in tests. Running locally, I get a clean log.