### PR TITLE
rxfire: added functions to map RTDB changes to values

### DIFF
--- a/packages/rxfire/database/list/index.ts
+++ b/packages/rxfire/database/list/index.ts
@@ -20,6 +20,7 @@ import { Observable, of, merge, from } from 'rxjs';
 import { validateEventsArray, isNil } from '../utils';
 import { fromRef } from '../fromRef';
 import { switchMap, scan, distinctUntilChanged, map } from 'rxjs/operators';
+import { changeToData } from '../object';
 
 export function stateChanges(query: database.Query, events?: ListenEvent[]) {
   events = validateEventsArray(events);
@@ -48,6 +49,20 @@ export function list(
       return merge(...childEvent$).pipe(scan(buildView, []));
     }),
     distinctUntilChanged()
+  );
+}
+
+/**
+ * Get an object mapped to its value, and optionally its key
+ * @param query object ref or query
+ * @param keyField map the object key to a specific field
+ */
+export function listVal<T>(
+  query: database.Query,
+  keyField?: string
+): Observable<T[]> {
+  return list(query).pipe(
+    map(arr => arr.map(change => changeToData(change, keyField) as T))
   );
 }
 

--- a/packages/rxfire/database/object/index.ts
+++ b/packages/rxfire/database/object/index.ts
@@ -18,6 +18,7 @@ import { database } from 'firebase';
 import { QueryChange, ListenEvent } from '../interfaces';
 import { fromRef } from '../fromRef';
 import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
 
 /**
  * Get the snapshot changes of an object
@@ -25,4 +26,25 @@ import { Observable } from 'rxjs';
  */
 export function object(query: database.Query): Observable<QueryChange> {
   return fromRef(query, ListenEvent.value);
+}
+
+/**
+ * Get an array of object values, optionally with a mapped key
+ * @param query object ref or query
+ * @param keyField map the object key to a specific field
+ */
+export function objectVal<T>(
+  query: database.Query,
+  keyField?: string
+): Observable<T> {
+  return fromRef(query, ListenEvent.value).pipe(
+    map(change => changeToData(change, keyField) as T)
+  );
+}
+
+export function changeToData(change: QueryChange, keyField?: string) {
+  return {
+    ...change.snapshot.val(),
+    ...(keyField ? { [keyField]: change.snapshot.key } : null)
+  };
 }


### PR DESCRIPTION
### Discussion

CC @davideast 

### Testing

Added two new specs to test API changes below

### API Changes

`listVal(query, keyField?)` Maps a query to an array of objects

`objectVal(query, keyField?)` Maps a query to an object
