### PR TITLE
Don't update query target metadata for updates

### DIFF
--- a/packages/firestore/src/local/indexeddb_query_cache.ts
+++ b/packages/firestore/src/local/indexeddb_query_cache.ts
@@ -87,12 +87,16 @@ export class IndexedDbQueryCache implements QueryCache {
     });
   }
 
-  setLastRemoteSnapshotVersion(
-    transaction: PersistenceTransaction,
-    snapshotVersion: SnapshotVersion
+  setTargetsMetadata(
+      transaction: PersistenceTransaction,
+      highestListenSequenceNumber: number,
+      lastRemoteSnapshotVersion?: SnapshotVersion
   ): PersistencePromise<void> {
     return this.retrieveMetadata(transaction).next(metadata => {
-      metadata.lastRemoteSnapshotVersion = snapshotVersion.toTimestamp();
+      metadata.highestListenSequenceNumber = highestListenSequenceNumber;
+      if (lastRemoteSnapshotVersion) {
+        metadata.lastRemoteSnapshotVersion = lastRemoteSnapshotVersion.toTimestamp();
+      }
       return this.saveMetadata(transaction, metadata);
     });
   }

--- a/packages/firestore/src/local/indexeddb_query_cache.ts
+++ b/packages/firestore/src/local/indexeddb_query_cache.ts
@@ -114,15 +114,7 @@ export class IndexedDbQueryCache implements QueryCache {
     transaction: PersistenceTransaction,
     queryData: QueryData
   ): PersistencePromise<void> {
-    return this.saveQueryData(transaction, queryData).next(() => {
-      return this.retrieveMetadata(transaction).next(metadata => {
-        if (this.updateMetadataFromQueryData(queryData, metadata)) {
-          return this.saveMetadata(transaction, metadata);
-        } else {
-          return PersistencePromise.resolve();
-        }
-      });
-    });
+    return this.saveQueryData(transaction, queryData);
   }
 
   removeQueryData(

--- a/packages/firestore/src/local/indexeddb_query_cache.ts
+++ b/packages/firestore/src/local/indexeddb_query_cache.ts
@@ -88,9 +88,9 @@ export class IndexedDbQueryCache implements QueryCache {
   }
 
   setTargetsMetadata(
-      transaction: PersistenceTransaction,
-      highestListenSequenceNumber: number,
-      lastRemoteSnapshotVersion?: SnapshotVersion
+    transaction: PersistenceTransaction,
+    highestListenSequenceNumber: number,
+    lastRemoteSnapshotVersion?: SnapshotVersion
   ): PersistencePromise<void> {
     return this.retrieveMetadata(transaction).next(metadata => {
       metadata.highestListenSequenceNumber = highestListenSequenceNumber;

--- a/packages/firestore/src/local/local_store.ts
+++ b/packages/firestore/src/local/local_store.ts
@@ -605,10 +605,7 @@ export class LocalStore {
                 ' < ' +
                 lastRemoteVersion
             );
-            return this.queryCache.setLastRemoteSnapshotVersion(
-              txn,
-              remoteVersion
-            );
+            return this.queryCache.setTargetsMetadata(txn, /*highestSequenceNumber=*/0, remoteVersion);
           });
         promises.push(updateRemoteVersion);
       }

--- a/packages/firestore/src/local/local_store.ts
+++ b/packages/firestore/src/local/local_store.ts
@@ -605,7 +605,11 @@ export class LocalStore {
                 ' < ' +
                 lastRemoteVersion
             );
-            return this.queryCache.setTargetsMetadata(txn, /*highestSequenceNumber=*/0, remoteVersion);
+            return this.queryCache.setTargetsMetadata(
+              txn,
+              /*highestSequenceNumber=*/ 0,
+              remoteVersion
+            );
           });
         promises.push(updateRemoteVersion);
       }

--- a/packages/firestore/src/local/memory_query_cache.ts
+++ b/packages/firestore/src/local/memory_query_cache.ts
@@ -70,9 +70,9 @@ export class MemoryQueryCache implements QueryCache {
   }
 
   setTargetsMetadata(
-      transaction: PersistenceTransaction,
-      highestListenSequenceNumber: number,
-      lastRemoteSnapshotVersion?: SnapshotVersion
+    transaction: PersistenceTransaction,
+    highestListenSequenceNumber: number,
+    lastRemoteSnapshotVersion?: SnapshotVersion
   ): PersistencePromise<void> {
     if (lastRemoteSnapshotVersion) {
       this.lastRemoteSnapshotVersion = lastRemoteSnapshotVersion;

--- a/packages/firestore/src/local/memory_query_cache.ts
+++ b/packages/firestore/src/local/memory_query_cache.ts
@@ -69,11 +69,14 @@ export class MemoryQueryCache implements QueryCache {
     return PersistencePromise.resolve(nextTargetId);
   }
 
-  setLastRemoteSnapshotVersion(
-    transaction: PersistenceTransaction,
-    snapshotVersion: SnapshotVersion
+  setTargetsMetadata(
+      transaction: PersistenceTransaction,
+      highestListenSequenceNumber: number,
+      lastRemoteSnapshotVersion?: SnapshotVersion
   ): PersistencePromise<void> {
-    this.lastRemoteSnapshotVersion = snapshotVersion;
+    if (lastRemoteSnapshotVersion) {
+      this.lastRemoteSnapshotVersion = lastRemoteSnapshotVersion;
+    }
     return PersistencePromise.resolve();
   }
 

--- a/packages/firestore/src/local/query_cache.ts
+++ b/packages/firestore/src/local/query_cache.ts
@@ -51,14 +51,17 @@ export interface QueryCache extends GarbageSource {
   ): PersistencePromise<SnapshotVersion>;
 
   /**
-   * Set the snapshot version representing the last consistent snapshot received
-   * from the backend. (see getLastRemoteSnapshotVersion() for more details).
+   * Set the highest listen sequence number and optionally updates the
+   * snapshot version of the last consistent snapshot received from the backend
+   * (see getLastRemoteSnapshotVersion() for more details).
    *
-   * @param snapshotVersion The new snapshot version.
+   * @param highestListenSequenceNumber The new maximum listen sequence number.
+   * @param lastRemoteSnapshotVersion The new snapshot version. Optional.
    */
-  setLastRemoteSnapshotVersion(
-    transaction: PersistenceTransaction,
-    snapshotVersion: SnapshotVersion
+  setTargetsMetadata(
+      transaction: PersistenceTransaction,
+      highestListenSequenceNumber: number,
+      lastRemoteSnapshotVersion?: SnapshotVersion
   ): PersistencePromise<void>;
 
   /**

--- a/packages/firestore/src/local/query_cache.ts
+++ b/packages/firestore/src/local/query_cache.ts
@@ -59,9 +59,9 @@ export interface QueryCache extends GarbageSource {
    * @param lastRemoteSnapshotVersion The new snapshot version. Optional.
    */
   setTargetsMetadata(
-      transaction: PersistenceTransaction,
-      highestListenSequenceNumber: number,
-      lastRemoteSnapshotVersion?: SnapshotVersion
+    transaction: PersistenceTransaction,
+    highestListenSequenceNumber: number,
+    lastRemoteSnapshotVersion?: SnapshotVersion
   ): PersistencePromise<void>;
 
   /**

--- a/packages/firestore/test/unit/local/query_cache.test.ts
+++ b/packages/firestore/test/unit/local/query_cache.test.ts
@@ -325,14 +325,14 @@ function genericQueryCacheTests(): void {
     expect(await otherCache.allocateTargetId()).to.deep.equal(50);
   });
 
-  it('can get / set lastRemoteSnapshotVersion', async () => {
+  it('can get / set targets metadata', async () => {
     expect(await cache.getLastRemoteSnapshotVersion()).to.deep.equal(
       SnapshotVersion.MIN
     );
 
     // Can set the snapshot version.
     return cache
-      .setLastRemoteSnapshotVersion(version(42))
+      .setTargetsMetadata(/* highestListenSequenceNumber= */0, version(42))
       .then(async () => {
         expect(await cache.getLastRemoteSnapshotVersion()).to.deep.equal(
           version(42)

--- a/packages/firestore/test/unit/local/query_cache.test.ts
+++ b/packages/firestore/test/unit/local/query_cache.test.ts
@@ -332,7 +332,7 @@ function genericQueryCacheTests(): void {
 
     // Can set the snapshot version.
     return cache
-      .setTargetsMetadata(/* highestListenSequenceNumber= */0, version(42))
+      .setTargetsMetadata(/* highestListenSequenceNumber= */ 0, version(42))
       .then(async () => {
         expect(await cache.getLastRemoteSnapshotVersion()).to.deep.equal(
           version(42)

--- a/packages/firestore/test/unit/local/test_query_cache.ts
+++ b/packages/firestore/test/unit/local/test_query_cache.ts
@@ -132,11 +132,11 @@ export class TestQueryCache {
     });
   }
 
-  setLastRemoteSnapshotVersion(version: SnapshotVersion): Promise<void> {
+  setTargetsMetadata(highestListenSequenceNumber:number, lastRemoteSnapshotVersion?: SnapshotVersion): Promise<void> {
     return this.persistence.runTransaction(
-      'setLastRemoteSnapshotVersion',
+      'setTargetsMetadata',
       true,
-      txn => this.cache.setLastRemoteSnapshotVersion(txn, version)
+      txn => this.cache.setTargetsMetadata(txn, highestListenSequenceNumber, lastRemoteSnapshotVersion)
     );
   }
 }

--- a/packages/firestore/test/unit/local/test_query_cache.ts
+++ b/packages/firestore/test/unit/local/test_query_cache.ts
@@ -132,11 +132,16 @@ export class TestQueryCache {
     });
   }
 
-  setTargetsMetadata(highestListenSequenceNumber:number, lastRemoteSnapshotVersion?: SnapshotVersion): Promise<void> {
-    return this.persistence.runTransaction(
-      'setTargetsMetadata',
-      true,
-      txn => this.cache.setTargetsMetadata(txn, highestListenSequenceNumber, lastRemoteSnapshotVersion)
+  setTargetsMetadata(
+    highestListenSequenceNumber: number,
+    lastRemoteSnapshotVersion?: SnapshotVersion
+  ): Promise<void> {
+    return this.persistence.runTransaction('setTargetsMetadata', true, txn =>
+      this.cache.setTargetsMetadata(
+        txn,
+        highestListenSequenceNumber,
+        lastRemoteSnapshotVersion
+      )
     );
   }
 }


### PR DESCRIPTION
This PR ports some of what I think I learned by reviewing Greg's latest Android PR to the Web. This save an additional read on every query update in Multi-Tab.

Greg - is this correct?