### PR TITLE
Adding Spec Test for Target Removal

### DIFF
--- a/packages/firestore/src/remote/remote_store.ts
+++ b/packages/firestore/src/remote/remote_store.ts
@@ -455,11 +455,15 @@ export class RemoteStore implements TargetMetadataProvider {
     let promiseChain = Promise.resolve();
     watchChange.targetIds.forEach(targetId => {
       promiseChain = promiseChain.then(async () => {
+        this.watchChangeAggregator.handleTargetChange(watchChange);
         // A watched target might have been removed already.
-        if (objUtils.contains(this.listenTargets, targetId)) {
+        if (
+          objUtils.contains(this.listenTargets, targetId) &&
+          !this.watchChangeAggregator.isPending(targetId) // handle target change before
+          // asert we dont go below zero
+        ) {
           delete this.listenTargets[targetId];
-          this.watchChangeAggregator.removeTarget(targetId);
-          return this.syncEngine.rejectListen(targetId, error);
+          await this.syncEngine.rejectListen(targetId, error);
         }
       });
     });

--- a/packages/firestore/src/remote/watch_change.ts
+++ b/packages/firestore/src/remote/watch_change.ts
@@ -226,6 +226,7 @@ class TargetState {
 
   recordTargetResponse(): void {
     this.pendingResponses -= 1;
+    assert(this.pendingResponses >= 0, 'This assert should not fire');
   }
 
   markCurrent(): void {
@@ -326,10 +327,6 @@ export class WatchChangeAggregator {
           if (!targetState.isPending) {
             this.removeTarget(targetId);
           }
-          assert(
-            !targetChange.cause,
-            'WatchChangeAggregator does not handle errored targets'
-          );
           break;
         case WatchTargetChangeState.Current:
           if (this.isActiveTarget(targetId)) {
@@ -644,6 +641,10 @@ export class WatchChangeAggregator {
   ): boolean {
     const existingKeys = this.metadataProvider.getRemoteKeysForTarget(targetId);
     return existingKeys.has(key);
+  }
+
+  isPending(targetId: TargetId) {
+    return this.targetStates[targetId] && this.targetStates[targetId].isPending;
   }
 }
 

--- a/packages/firestore/test/unit/specs/listen_spec.test.ts
+++ b/packages/firestore/test/unit/specs/listen_spec.test.ts
@@ -141,6 +141,19 @@ describeSpec('Listens:', [], () => {
     }
   );
 
+  specTest("Doesn't raise events for non-active target", [], () => {
+    const query = Query.atPath(path('collection'));
+
+    return spec()
+      .withGCEnabled(false)
+      .userListens(query)
+      .userUnlistens(query)
+      .watchRemoves(
+        query,
+        new RpcError(Code.PERMISSION_DENIED, 'Permission denied')
+      );
+  });
+
   // It can happen that we need to process watch messages for previously failed
   // targets, because target failures are handled out of band.
   // This test verifies that the code does not crash in this case.

--- a/packages/firestore/test/unit/specs/spec_test_runner.ts
+++ b/packages/firestore/test/unit/specs/spec_test_runner.ts
@@ -601,10 +601,12 @@ abstract class TestRunner {
       // with a server-side removal), but we want to pay extra careful
       // attention in tests that we only remove targets we listened too.
       removed.targetIds.forEach(targetId => {
-        expect(
-          this.connection.activeTargets[targetId],
-          'Removing a non-active target'
-        ).to.exist;
+        if (this.expectedActiveTargets[targetId]) {
+          expect(
+            this.connection.activeTargets[targetId],
+            'Removing a non-active target'
+          ).to.exist;
+        }
         delete this.connection.activeTargets[targetId];
       });
     }


### PR DESCRIPTION
Spec test for:

  * Client adds a target
  * Client removes a target (without waiting for the response)
  * Watch fails the add target (perhaps with permission denied)
  * Watch now sees a remove target for a target not currently being listened to