### PR TITLE
Fix unsound type signature

### DIFF
--- a/packages/firestore/src/local/indexeddb_persistence.ts
+++ b/packages/firestore/src/local/indexeddb_persistence.ts
@@ -193,7 +193,7 @@ export class IndexedDbPersistence implements Persistence {
 
   runTransaction<T>(
     action: string,
-    operation: (transaction: IndexedDbTransaction) => PersistencePromise<T>
+    operation: (transaction: PersistenceTransaction) => PersistencePromise<T>
   ): Promise<T> {
     if (this.persistenceError) {
       return Promise.reject(this.persistenceError);


### PR DESCRIPTION
The passed transaction function must accept any `PersistenceTransaction`, even though it totally doesn't and we do a cast later under the hood.