### PR TITLE
Revert "Prep rxfire release"

### DIFF
--- a/packages/rxfire/package.json
+++ b/packages/rxfire/package.json
@@ -1,7 +1,7 @@
 {
   "name": "rxfire",
-  "version": "2.0.0",
-  "private": false,
+  "version": "0.0.0",
+  "private": true,
   "description": "Firebase JavaScript library RxJS",
   "author": "Firebase <firebase-support@google.com> (https://firebase.google.com/)",
   "license": "Apache-2.0",


### PR DESCRIPTION
Reverts firebase/firebase-js-sdk#1079

Temporarily reverting this, as this seems to be what's causing CI deploy errors.