### PR TITLE
Enable no-floating-promises lint check and fix / suppress violations.

### DIFF
--- a/packages/firestore/src/api/database.ts
+++ b/packages/firestore/src/api/database.ts
@@ -305,6 +305,8 @@ export class Firestore implements firestore.FirebaseFirestore, FirebaseService {
 
   ensureClientConfigured(): FirestoreClient {
     if (!this._firestoreClient) {
+      // Kick off starting the client but don't actually wait for it.
+      // tslint:disable-next-line:no-floating-promises
       this.configureClient(/* persistence= */ false);
     }
     return this._firestoreClient as FirestoreClient;

--- a/packages/firestore/src/core/firestore_client.ts
+++ b/packages/firestore/src/core/firestore_client.ts
@@ -157,14 +157,14 @@ export class FirestoreClient {
           .then(() => this.initializeRest(user))
           .then(initializationDone.resolve, initializationDone.reject);
       } else {
-        this.asyncQueue.enqueue(() => {
+        this.asyncQueue.enqueueAndForget(() => {
           return this.handleUserChange(user);
         });
       }
     });
 
     // Block the async queue until initialization is done
-    this.asyncQueue.enqueue(() => {
+    this.asyncQueue.enqueueAndForget(() => {
       return initializationDone.promise;
     });
 
@@ -176,7 +176,7 @@ export class FirestoreClient {
 
   /** Enables the network connection and requeues all pending operations. */
   enableNetwork(): Promise<void> {
-    return this.asyncQueue.enqueueAndWait(() => {
+    return this.asyncQueue.enqueue(() => {
       return this.remoteStore.enableNetwork();
     });
   }
@@ -358,7 +358,7 @@ export class FirestoreClient {
 
   /** Disables the network connection. Pending operations will not complete. */
   disableNetwork(): Promise<void> {
-    return this.asyncQueue.enqueueAndWait(() => {
+    return this.asyncQueue.enqueue(() => {
       return this.remoteStore.disableNetwork();
     });
   }
@@ -367,7 +367,7 @@ export class FirestoreClient {
     purgePersistenceWithDataLoss?: boolean;
   }): Promise<void> {
     return this.asyncQueue
-      .enqueueAndWait(() => {
+      .enqueue(() => {
         this.credentials.removeUserChangeListener();
         return this.remoteStore.shutdown();
       })
@@ -385,21 +385,21 @@ export class FirestoreClient {
     options: ListenOptions
   ): QueryListener {
     const listener = new QueryListener(query, observer, options);
-    this.asyncQueue.enqueue(() => {
+    this.asyncQueue.enqueueAndForget(() => {
       return this.eventMgr.listen(listener);
     });
     return listener;
   }
 
   unlisten(listener: QueryListener): void {
-    this.asyncQueue.enqueue(() => {
+    this.asyncQueue.enqueueAndForget(() => {
       return this.eventMgr.unlisten(listener);
     });
   }
 
   getDocumentFromLocalCache(docKey: DocumentKey): Promise<Document> {
     return this.asyncQueue
-      .enqueueAndWait(() => {
+      .enqueue(() => {
         return this.localStore.readDocument(docKey);
       })
       .then((maybeDoc: MaybeDocument | null) => {
@@ -419,7 +419,7 @@ export class FirestoreClient {
 
   getDocumentsFromLocalCache(query: Query): Promise<ViewSnapshot> {
     return this.asyncQueue
-      .enqueueAndWait(() => {
+      .enqueue(() => {
         return this.localStore.executeQuery(query);
       })
       .then((docs: DocumentMap) => {
@@ -435,7 +435,9 @@ export class FirestoreClient {
 
   write(mutations: Mutation[]): Promise<void> {
     const deferred = new Deferred<void>();
-    this.asyncQueue.enqueue(() => this.syncEngine.write(mutations, deferred));
+    this.asyncQueue.enqueueAndForget(() =>
+      this.syncEngine.write(mutations, deferred)
+    );
     return deferred.promise;
   }
 
@@ -448,7 +450,7 @@ export class FirestoreClient {
   ): Promise<T> {
     // We have to wait for the async queue to be sure syncEngine is initialized.
     return this.asyncQueue
-      .enqueueAndWait(async () => {})
+      .enqueue(async () => {})
       .then(() => this.syncEngine.runTransaction(updateFunction));
   }
 }

--- a/packages/firestore/src/core/firestore_client.ts
+++ b/packages/firestore/src/core/firestore_client.ts
@@ -176,7 +176,7 @@ export class FirestoreClient {
 
   /** Enables the network connection and requeues all pending operations. */
   enableNetwork(): Promise<void> {
-    return this.asyncQueue.enqueue(() => {
+    return this.asyncQueue.enqueueAndWait(() => {
       return this.remoteStore.enableNetwork();
     });
   }
@@ -358,7 +358,7 @@ export class FirestoreClient {
 
   /** Disables the network connection. Pending operations will not complete. */
   disableNetwork(): Promise<void> {
-    return this.asyncQueue.enqueue(() => {
+    return this.asyncQueue.enqueueAndWait(() => {
       return this.remoteStore.disableNetwork();
     });
   }
@@ -367,7 +367,7 @@ export class FirestoreClient {
     purgePersistenceWithDataLoss?: boolean;
   }): Promise<void> {
     return this.asyncQueue
-      .enqueue(() => {
+      .enqueueAndWait(() => {
         this.credentials.removeUserChangeListener();
         return this.remoteStore.shutdown();
       })
@@ -399,7 +399,7 @@ export class FirestoreClient {
 
   getDocumentFromLocalCache(docKey: DocumentKey): Promise<Document> {
     return this.asyncQueue
-      .enqueue(() => {
+      .enqueueAndWait(() => {
         return this.localStore.readDocument(docKey);
       })
       .then((maybeDoc: MaybeDocument | null) => {
@@ -419,7 +419,7 @@ export class FirestoreClient {
 
   getDocumentsFromLocalCache(query: Query): Promise<ViewSnapshot> {
     return this.asyncQueue
-      .enqueue(() => {
+      .enqueueAndWait(() => {
         return this.localStore.executeQuery(query);
       })
       .then((docs: DocumentMap) => {
@@ -448,7 +448,7 @@ export class FirestoreClient {
   ): Promise<T> {
     // We have to wait for the async queue to be sure syncEngine is initialized.
     return this.asyncQueue
-      .enqueue(async () => {})
+      .enqueueAndWait(async () => {})
       .then(() => this.syncEngine.runTransaction(updateFunction));
   }
 }

--- a/packages/firestore/src/local/indexeddb_persistence.ts
+++ b/packages/firestore/src/local/indexeddb_persistence.ts
@@ -396,6 +396,7 @@ export class IndexedDbPersistence implements Persistence {
 
         // Attempt graceful shutdown (including releasing our owner lease), but
         // there's no guarantee it will complete.
+        // tslint:disable-next-line:no-floating-promises
         this.shutdown();
       };
       window.addEventListener('unload', this.windowUnloadHandler);

--- a/packages/firestore/src/remote/persistent_stream.ts
+++ b/packages/firestore/src/remote/persistent_stream.ts
@@ -502,7 +502,7 @@ export abstract class PersistentStream<
     startCloseCount: number
   ): (fn: () => Promise<void>) => void {
     return (fn: () => Promise<void>): void => {
-      this.queue.enqueue(() => {
+      this.queue.enqueueAndForget(() => {
         if (this.closeCount === startCloseCount) {
           return fn();
         } else {

--- a/packages/firestore/src/remote/persistent_stream.ts
+++ b/packages/firestore/src/remote/persistent_stream.ts
@@ -241,9 +241,9 @@ export abstract class PersistentStream<
    *
    * When stop returns, isStarted() and isOpen() will both return false.
    */
-  stop(): void {
+  async stop(): Promise<void> {
     if (this.isStarted()) {
-      this.close(PersistentStreamState.Initial);
+      await this.close(PersistentStreamState.Initial);
     }
   }
 

--- a/packages/firestore/src/remote/remote_store.ts
+++ b/packages/firestore/src/remote/remote_store.ts
@@ -188,8 +188,8 @@ export class RemoteStore implements TargetMetadataProvider {
     if (this.networkEnabled) {
       this.networkEnabled = false;
 
-      this.writeStream.stop();
-      this.watchStream.stop();
+      await this.writeStream.stop();
+      await this.watchStream.stop();
 
       if (this.writePipeline.length > 0) {
         log.debug(
@@ -205,14 +205,13 @@ export class RemoteStore implements TargetMetadataProvider {
     }
   }
 
-  shutdown(): Promise<void> {
+  async shutdown(): Promise<void> {
     log.debug(LOG_TAG, 'RemoteStore shutting down.');
-    this.disableNetworkInternal();
+    await this.disableNetworkInternal();
 
     // Set the OnlineState to Unknown (rather than Offline) to avoid potentially
     // triggering spurious listener events with cached data, etc.
     this.onlineStateTracker.set(OnlineState.Unknown);
-    return Promise.resolve();
   }
 
   /** Starts new listen for the given query. Uses resume token if provided */
@@ -671,7 +670,7 @@ export class RemoteStore implements TargetMetadataProvider {
       // Tear down and re-create our network streams. This will ensure we get a fresh auth token
       // for the new user and re-fill the write pipeline with new mutations from the LocalStore
       // (since mutations are per-user).
-      this.disableNetworkInternal();
+      await this.disableNetworkInternal();
       this.onlineStateTracker.set(OnlineState.Unknown);
       await this.enableNetwork();
     }

--- a/packages/firestore/src/util/async_queue.ts
+++ b/packages/firestore/src/util/async_queue.ts
@@ -154,7 +154,7 @@ class DelayedOperation<T extends Unknown> implements CancelablePromise<T> {
   catch = this.deferred.promise.catch.bind(this.deferred.promise);
 
   private handleDelayElapsed(): void {
-    this.asyncQueue.enqueue(() => {
+    this.asyncQueue.enqueueAndForget(() => {
       if (this.timerHandle !== null) {
         this.clearTimeout();
         return this.op().then(result => {
@@ -194,16 +194,16 @@ export class AsyncQueue {
    * Adds a new operation to the queue without waiting for it to complete (i.e.
    * we ignore the Promise result).
    */
-  enqueue<T extends Unknown>(op: () => Promise<T>): void {
+  enqueueAndForget<T extends Unknown>(op: () => Promise<T>): void {
     // tslint:disable-next-line:no-floating-promises
-    this.enqueueAndWait(op);
+    this.enqueue(op);
   }
 
   /**
    * Adds a new operation to the queue. Returns a promise that will be resolved
    * when the promise returned by the new operation is (with its value).
    */
-  enqueueAndWait<T extends Unknown>(op: () => Promise<T>): Promise<T> {
+  enqueue<T extends Unknown>(op: () => Promise<T>): Promise<T> {
     this.verifyNotFailed();
     const newTail = this.tail.then(() => {
       this.operationInProgress = true;
@@ -295,7 +295,7 @@ export class AsyncQueue {
    * operations are not run.
    */
   drain(): Promise<void> {
-    return this.enqueueAndWait(() => Promise.resolve());
+    return this.enqueue(() => Promise.resolve());
   }
 
   /**

--- a/packages/firestore/src/util/async_queue.ts
+++ b/packages/firestore/src/util/async_queue.ts
@@ -191,10 +191,19 @@ export class AsyncQueue {
   private operationInProgress = false;
 
   /**
+   * Adds a new operation to the queue without waiting for it to complete (i.e.
+   * we ignore the Promise result).
+   */
+  enqueue<T extends Unknown>(op: () => Promise<T>): void {
+    // tslint:disable-next-line:no-floating-promises
+    this.enqueueAndWait(op);
+  }
+
+  /**
    * Adds a new operation to the queue. Returns a promise that will be resolved
    * when the promise returned by the new operation is (with its value).
    */
-  enqueue<T extends Unknown>(op: () => Promise<T>): Promise<T> {
+  enqueueAndWait<T extends Unknown>(op: () => Promise<T>): Promise<T> {
     this.verifyNotFailed();
     const newTail = this.tail.then(() => {
       this.operationInProgress = true;
@@ -286,7 +295,7 @@ export class AsyncQueue {
    * operations are not run.
    */
   drain(): Promise<void> {
-    return this.enqueue(() => Promise.resolve());
+    return this.enqueueAndWait(() => Promise.resolve());
   }
 
   /**

--- a/packages/firestore/test/integration/api/array_transforms.test.ts
+++ b/packages/firestore/test/integration/api/array_transforms.test.ts
@@ -84,7 +84,7 @@ apiDescribe('Array Transforms:', persistence => {
   it('create document with arrayUnion()', async () => {
     await withTestSetup(async () => {
       await docRef.set({ array: FieldValue.arrayUnion(1, 2) });
-      expectLocalAndRemoteEvent({ array: [1, 2] });
+      await expectLocalAndRemoteEvent({ array: [1, 2] });
     });
   });
 

--- a/packages/firestore/test/integration/remote/stream.test.ts
+++ b/packages/firestore/test/integration/remote/stream.test.ts
@@ -144,10 +144,10 @@ describe('Watch Stream', () => {
       watchStream = ds.newPersistentWatchStream(streamListener);
       watchStream.start();
 
-      return streamListener.awaitCallback('open').then(() => {
-        watchStream.stop();
+      return streamListener.awaitCallback('open').then(async () => {
+        await watchStream.stop();
 
-        return streamListener.awaitCallback('close');
+        await streamListener.awaitCallback('close');
       });
     });
   });
@@ -193,10 +193,10 @@ describe('Write Stream', () => {
       writeStream = ds.newPersistentWriteStream(streamListener);
       writeStream.start();
       return streamListener.awaitCallback('open');
-    }).then(() => {
-      writeStream.stop();
+    }).then(async () => {
+      await writeStream.stop();
 
-      return streamListener.awaitCallback('close');
+      await streamListener.awaitCallback('close');
     });
   });
 
@@ -221,10 +221,10 @@ describe('Write Stream', () => {
         writeStream.writeMutations(SINGLE_MUTATION);
         return streamListener.awaitCallback('mutationResult');
       })
-      .then(() => {
-        writeStream.stop();
+      .then(async () => {
+        await writeStream.stop();
 
-        return streamListener.awaitCallback('close');
+        await streamListener.awaitCallback('close');
       });
   });
 
@@ -295,9 +295,11 @@ describe('Write Stream', () => {
           .then(() => {
             // Simulate callback from GRPC with an unauthenticated error -- this should invalidate
             // the token.
-            writeStream.handleStreamClose(
+            return writeStream.handleStreamClose(
               new FirestoreError(Code.UNAUTHENTICATED, '')
             );
+          })
+          .then(() => {
             return streamListener.awaitCallback('close');
           })
           .then(() => {
@@ -306,9 +308,11 @@ describe('Write Stream', () => {
           })
           .then(() => {
             // Simulate a different error -- token should not be invalidated this time.
-            writeStream.handleStreamClose(
+            return writeStream.handleStreamClose(
               new FirestoreError(Code.UNAVAILABLE, '')
             );
+          })
+          .then(() => {
             return streamListener.awaitCallback('close');
           })
           .then(() => {

--- a/packages/firestore/test/unit/core/event_manager.test.ts
+++ b/packages/firestore/test/unit/core/event_manager.test.ts
@@ -57,7 +57,7 @@ describe('EventManager', () => {
     return stub;
   }
 
-  it('handles many listenables per query', () => {
+  it('handles many listenables per query', async () => {
     const query = Query.atPath(path('foo/bar'));
     const fakeListener1 = fakeQueryListener(query);
     const fakeListener2 = fakeQueryListener(query);
@@ -65,29 +65,29 @@ describe('EventManager', () => {
     const syncEngineSpy = makeSyncEngineSpy();
     const eventManager = new EventManager(syncEngineSpy);
 
-    eventManager.listen(fakeListener1);
+    await eventManager.listen(fakeListener1);
     expect(syncEngineSpy.listen.calledWith(query)).to.be.true;
 
-    eventManager.listen(fakeListener2);
+    await eventManager.listen(fakeListener2);
     expect(syncEngineSpy.listen.callCount).to.equal(1);
 
-    eventManager.unlisten(fakeListener2);
+    await eventManager.unlisten(fakeListener2);
     expect(syncEngineSpy.unlisten.callCount).to.equal(0);
 
-    eventManager.unlisten(fakeListener1);
+    await eventManager.unlisten(fakeListener1);
     expect(syncEngineSpy.unlisten.calledWith(query)).to.be.true;
   });
 
-  it('handles unlisten on unknown listenable gracefully', () => {
+  it('handles unlisten on unknown listenable gracefully', async () => {
     const syncEngineSpy = makeSyncEngineSpy();
     const query = Query.atPath(path('foo/bar'));
     const fakeListener1 = fakeQueryListener(query);
     const eventManager = new EventManager(syncEngineSpy);
-    eventManager.unlisten(fakeListener1);
+    await eventManager.unlisten(fakeListener1);
     expect(syncEngineSpy.unlisten.callCount).to.equal(0);
   });
 
-  it('notifies listenables in the right order', () => {
+  it('notifies listenables in the right order', async () => {
     const query1 = Query.atPath(path('foo/bar'));
     const query2 = Query.atPath(path('bar/baz'));
     const eventOrder: string[] = [];
@@ -108,9 +108,9 @@ describe('EventManager', () => {
     const syncEngineSpy = makeSyncEngineSpy();
     const eventManager = new EventManager(syncEngineSpy);
 
-    eventManager.listen(fakeListener1);
-    eventManager.listen(fakeListener2);
-    eventManager.listen(fakeListener3);
+    await eventManager.listen(fakeListener1);
+    await eventManager.listen(fakeListener2);
+    await eventManager.listen(fakeListener3);
     expect(syncEngineSpy.listen.callCount).to.equal(2);
 
     // tslint:disable-next-line:no-any mock ViewSnapshot.
@@ -126,7 +126,7 @@ describe('EventManager', () => {
     ]);
   });
 
-  it('will forward applyOnlineStateChange calls', () => {
+  it('will forward applyOnlineStateChange calls', async () => {
     const query = Query.atPath(path('foo/bar'));
     const fakeListener1 = fakeQueryListener(query);
     const events: OnlineState[] = [];
@@ -137,7 +137,7 @@ describe('EventManager', () => {
     const syncEngineSpy = makeSyncEngineSpy();
     const eventManager = new EventManager(syncEngineSpy);
 
-    eventManager.listen(fakeListener1);
+    await eventManager.listen(fakeListener1);
     expect(events).to.deep.equal([OnlineState.Unknown]);
     eventManager.applyOnlineStateChange(OnlineState.Online);
     expect(events).to.deep.equal([OnlineState.Unknown, OnlineState.Online]);

--- a/packages/firestore/test/unit/local/mutation_queue.test.ts
+++ b/packages/firestore/test/unit/local/mutation_queue.test.ts
@@ -220,12 +220,12 @@ function genericMutationQueueTests(): void {
       BATCHID_UNKNOWN
     );
 
-    mutationQueue.acknowledgeBatch(batch1, emptyByteString());
+    await mutationQueue.acknowledgeBatch(batch1, emptyByteString());
     expect(await mutationQueue.getHighestAcknowledgedBatchId()).to.equal(
       batch1.batchId
     );
 
-    mutationQueue.acknowledgeBatch(batch2, emptyByteString());
+    await mutationQueue.acknowledgeBatch(batch2, emptyByteString());
     expect(await mutationQueue.getHighestAcknowledgedBatchId()).to.equal(
       batch2.batchId
     );

--- a/packages/firestore/test/unit/local/query_cache.test.ts
+++ b/packages/firestore/test/unit/local/query_cache.test.ts
@@ -97,7 +97,7 @@ function genericQueryCacheTests(
   });
 
   afterEach(async () => {
-    persistence.shutdown(/* deleteData= */ true);
+    await persistence.shutdown(/* deleteData= */ true);
   });
 
   it('returns null for query not in cache', () => {
@@ -205,18 +205,18 @@ function genericQueryCacheTests(
     const key2 = key('foo/baz');
     const key3 = key('foo/blah');
 
-    cache.addMatchingKeys([key1, key2], 1);
-    cache.addMatchingKeys([key3], 2);
+    await cache.addMatchingKeys([key1, key2], 1);
+    await cache.addMatchingKeys([key3], 2);
     expect(await cache.containsKey(key1)).to.equal(true);
     expect(await cache.containsKey(key2)).to.equal(true);
     expect(await cache.containsKey(key3)).to.equal(true);
 
-    cache.removeMatchingKeysForTargetId(1);
+    await cache.removeMatchingKeysForTargetId(1);
     expect(await cache.containsKey(key1)).to.equal(false);
     expect(await cache.containsKey(key2)).to.equal(false);
     expect(await cache.containsKey(key3)).to.equal(true);
 
-    cache.removeMatchingKeysForTargetId(2);
+    await cache.removeMatchingKeysForTargetId(2);
     expect(await cache.containsKey(key1)).to.equal(false);
     expect(await cache.containsKey(key2)).to.equal(false);
     expect(await cache.containsKey(key3)).to.equal(false);
@@ -244,13 +244,13 @@ function genericQueryCacheTests(
 
     expect(await testGc.collectGarbage()).to.deep.equal([]);
 
-    cache.removeMatchingKeys([room1], rooms.targetId);
+    await cache.removeMatchingKeys([room1], rooms.targetId);
     expect(await testGc.collectGarbage()).to.deep.equal([room1]);
 
-    cache.removeQueryData(rooms);
+    await cache.removeQueryData(rooms);
     expect(await testGc.collectGarbage()).to.deep.equal([room2]);
 
-    cache.removeMatchingKeysForTargetId(halls.targetId);
+    await cache.removeMatchingKeysForTargetId(halls.targetId);
     expect(await testGc.collectGarbage()).to.deep.equal([hall1, hall2]);
   });
 
@@ -268,7 +268,7 @@ function genericQueryCacheTests(
     ]);
     expect(await cache.getMatchingKeysForTargetId(2)).to.deep.equal([key3]);
 
-    cache.addMatchingKeys([key1], 2);
+    await cache.addMatchingKeys([key1], 2);
     expect(await cache.getMatchingKeysForTargetId(1)).to.deep.equal([
       key1,
       key2

--- a/packages/firestore/test/unit/specs/spec_test_runner.ts
+++ b/packages/firestore/test/unit/specs/spec_test_runner.ts
@@ -237,7 +237,7 @@ class MockConnection implements Connection {
           this.resetAndCloseWriteStream();
         }
       });
-      this.queue.enqueue(async () => {
+      this.queue.enqueueAndForget(async () => {
         if (this.writeStream === writeStream) {
           writeStream.callOnOpen();
         }
@@ -270,7 +270,7 @@ class MockConnection implements Connection {
         }
       });
       // Call on open immediately after returning
-      this.queue.enqueue(async () => {
+      this.queue.enqueueAndForget(async () => {
         if (this.watchStream === watchStream) {
           watchStream.callOnOpen();
           this.watchOpen.resolve();
@@ -425,7 +425,7 @@ abstract class TestRunner {
   protected abstract destroyPersistence(): Promise<void>;
 
   async shutdown(): Promise<void> {
-    await this.queue.enqueueAndWait(async () => {
+    await this.queue.enqueue(async () => {
       await this.remoteStore.shutdown();
       await this.persistence.shutdown(/* deleteData= */ true);
       await this.destroyPersistence();
@@ -504,7 +504,7 @@ abstract class TestRunner {
     const queryListener = new QueryListener(query, aggregator, options);
     this.queryListeners.set(query, queryListener);
 
-    await this.queue.enqueueAndWait(async () => {
+    await this.queue.enqueue(async () => {
       const targetId = await this.eventManager.listen(queryListener);
       expect(targetId).to.equal(
         expectedTargetId,
@@ -534,9 +534,7 @@ abstract class TestRunner {
     const eventEmitter = this.queryListeners.get(query);
     assert(!!eventEmitter, 'There must be a query to unlisten too!');
     this.queryListeners.delete(query);
-    await this.queue.enqueueAndWait(() =>
-      this.eventManager.unlisten(eventEmitter!)
-    );
+    await this.queue.enqueue(() => this.eventManager.unlisten(eventEmitter!));
   }
 
   private doSet(setSpec: SpecUserSet): Promise<void> {
@@ -555,7 +553,7 @@ abstract class TestRunner {
   private async doMutations(mutations: Mutation[]): Promise<void> {
     const userCallback = new Deferred<void>();
     this.outstandingWrites.push({ mutations, userCallback });
-    return this.queue.enqueueAndWait(() => {
+    return this.queue.enqueue(() => {
       return this.syncEngine.write(mutations, userCallback);
     });
   }
@@ -682,7 +680,7 @@ abstract class TestRunner {
 
     // Put a no-op in the queue so that we know when any outstanding RemoteStore
     // writes on the network are complete.
-    return this.queue.enqueueAndWait(async () => {});
+    return this.queue.enqueue(async () => {});
   }
 
   private async doWatchEvent(watchChange: WatchChange): Promise<void> {
@@ -691,7 +689,7 @@ abstract class TestRunner {
 
     // Put a no-op in the queue so that we know when any outstanding RemoteStore
     // writes on the network are complete.
-    return this.queue.enqueueAndWait(async () => {});
+    return this.queue.enqueue(async () => {});
   }
 
   private async doWatchStreamClose(spec: SpecWatchStreamClose): Promise<void> {
@@ -790,14 +788,14 @@ abstract class TestRunner {
 
     // We have to schedule the starts, otherwise we could end up with
     // interleaved events.
-    await this.queue.enqueueAndWait(async () => {
+    await this.queue.enqueue(async () => {
       await this.init();
     });
   }
 
   private doChangeUser(user: string | null): Promise<void> {
     this.user = new User(user);
-    return this.queue.enqueueAndWait(() =>
+    return this.queue.enqueue(() =>
       this.syncEngine.handleUserChange(this.user)
     );
   }

--- a/packages/firestore/test/unit/util/async_queue.test.ts
+++ b/packages/firestore/test/unit/util/async_queue.test.ts
@@ -35,7 +35,7 @@ describe('AsyncQueue', () => {
       results.push(result);
     }
 
-    const op1 = queue.enqueueAndWait(() => {
+    const op1 = queue.enqueue(() => {
       return defer(() => 'Hello')
         .then((result: string) => {
           return defer(() => result + ' world!');
@@ -43,13 +43,13 @@ describe('AsyncQueue', () => {
         .then(pushResult);
     });
 
-    const op2 = queue.enqueueAndWait(() => {
+    const op2 = queue.enqueue(() => {
       return defer(() => 'Bye bye.').then(pushResult);
     });
 
     const op4 = new Deferred<void>();
-    const op3 = queue.enqueueAndWait(() => {
-      queue.enqueue(() => {
+    const op3 = queue.enqueue(() => {
+      queue.enqueueAndForget(() => {
         return Promise.resolve('Bye for good.')
           .then(pushResult)
           .then(op4.resolve);
@@ -80,7 +80,7 @@ describe('AsyncQueue', () => {
 
     // Schedule a failing operation and make sure it's handled correctly.
     const op1Promise = queue
-      .enqueueAndWait(() => {
+      .enqueue(() => {
         // This promise represents something that is rejected
         return defer(() => {
           throw expected;
@@ -101,7 +101,7 @@ describe('AsyncQueue', () => {
     // Schedule a second failing operation (before the first one has actually
     // executed and failed). It should not be run.
     const op2Promise = queue
-      .enqueueAndWait(() => {
+      .enqueue(() => {
         return defer(() => {
           expect.fail('op2 should not be executed.');
         });
@@ -122,7 +122,7 @@ describe('AsyncQueue', () => {
       // synchronously throw with "already failed" error.
       const dummyOp = () => Promise.reject('dummyOp should not be run');
       expect(() => {
-        queue.enqueue(dummyOp);
+        queue.enqueueAndForget(dummyOp);
       }).to.throw(/already failed:.*Simulated Error/);
 
       // Finally, restore log level.
@@ -134,10 +134,10 @@ describe('AsyncQueue', () => {
     const queue = new AsyncQueue();
     const completedSteps = [];
     const doStep = (n: number) => defer(() => completedSteps.push(n));
-    queue.enqueue(() => doStep(1));
+    queue.enqueueAndForget(() => doStep(1));
     const last = queue.enqueueAfterDelay(timerId1, 5, () => doStep(4));
     queue.enqueueAfterDelay(timerId2, 1, () => doStep(3));
-    queue.enqueue(() => doStep(2));
+    queue.enqueueAndForget(() => doStep(2));
 
     await last;
     expect(completedSteps).to.deep.equal([1, 2, 3, 4]);
@@ -147,7 +147,7 @@ describe('AsyncQueue', () => {
     const queue = new AsyncQueue();
     const completedSteps = [];
     const doStep = (n: number) => defer(() => completedSteps.push(n));
-    queue.enqueue(() => doStep(1));
+    queue.enqueueAndForget(() => doStep(1));
     const delayedPromise = queue.enqueueAfterDelay(timerId1, 1, () =>
       doStep(2)
     );
@@ -169,10 +169,10 @@ describe('AsyncQueue', () => {
     const queue = new AsyncQueue();
     const completedSteps = [];
     const doStep = (n: number) => defer(() => completedSteps.push(n));
-    queue.enqueue(() => doStep(1));
+    queue.enqueueAndForget(() => doStep(1));
     queue.enqueueAfterDelay(timerId1, 20000, () => doStep(4));
     queue.enqueueAfterDelay(timerId2, 10000, () => doStep(3));
-    queue.enqueue(() => doStep(2));
+    queue.enqueueAndForget(() => doStep(2));
 
     await queue.runDelayedOperationsEarly(TimerId.All);
     expect(completedSteps).to.deep.equal([1, 2, 3, 4]);
@@ -182,11 +182,11 @@ describe('AsyncQueue', () => {
     const queue = new AsyncQueue();
     const completedSteps = [];
     const doStep = (n: number) => defer(() => completedSteps.push(n));
-    queue.enqueue(() => doStep(1));
+    queue.enqueueAndForget(() => doStep(1));
     queue.enqueueAfterDelay(timerId1, 20000, () => doStep(5));
     queue.enqueueAfterDelay(timerId2, 10000, () => doStep(3));
     queue.enqueueAfterDelay(timerId3, 15000, () => doStep(4));
-    queue.enqueue(() => doStep(2));
+    queue.enqueueAndForget(() => doStep(2));
 
     await queue.runDelayedOperationsEarly(timerId3);
     expect(completedSteps).to.deep.equal([1, 2, 3, 4]);
@@ -196,9 +196,9 @@ describe('AsyncQueue', () => {
     const queue = new AsyncQueue();
     const completedSteps = [];
     const doStep = (n: number) => defer(() => completedSteps.push(n));
-    queue.enqueue(() => doStep(1));
+    queue.enqueueAndForget(() => doStep(1));
     queue.enqueueAfterDelay(timerId1, 10000, () => doStep(5));
-    queue.enqueue(() => doStep(2));
+    queue.enqueueAndForget(() => doStep(2));
 
     await queue.drain();
     expect(completedSteps).to.deep.equal([1, 2]);

--- a/packages/firestore/test/unit/util/async_queue.test.ts
+++ b/packages/firestore/test/unit/util/async_queue.test.ts
@@ -35,7 +35,7 @@ describe('AsyncQueue', () => {
       results.push(result);
     }
 
-    const op1 = queue.enqueue(() => {
+    const op1 = queue.enqueueAndWait(() => {
       return defer(() => 'Hello')
         .then((result: string) => {
           return defer(() => result + ' world!');
@@ -43,12 +43,12 @@ describe('AsyncQueue', () => {
         .then(pushResult);
     });
 
-    const op2 = queue.enqueue(() => {
+    const op2 = queue.enqueueAndWait(() => {
       return defer(() => 'Bye bye.').then(pushResult);
     });
 
     const op4 = new Deferred<void>();
-    const op3 = queue.enqueue(() => {
+    const op3 = queue.enqueueAndWait(() => {
       queue.enqueue(() => {
         return Promise.resolve('Bye for good.')
           .then(pushResult)
@@ -80,7 +80,7 @@ describe('AsyncQueue', () => {
 
     // Schedule a failing operation and make sure it's handled correctly.
     const op1Promise = queue
-      .enqueue(() => {
+      .enqueueAndWait(() => {
         // This promise represents something that is rejected
         return defer(() => {
           throw expected;
@@ -101,7 +101,7 @@ describe('AsyncQueue', () => {
     // Schedule a second failing operation (before the first one has actually
     // executed and failed). It should not be run.
     const op2Promise = queue
-      .enqueue(() => {
+      .enqueueAndWait(() => {
         return defer(() => {
           expect.fail('op2 should not be executed.');
         });

--- a/packages/firestore/tslint.json
+++ b/packages/firestore/tslint.json
@@ -36,6 +36,7 @@
     "no-debugger": true,
     "no-default-export": true,
     "no-duplicate-variable": true,
+    "no-floating-promises": true,
     "no-inferrable-types": true,
     "no-namespace": [true, "allow-declarations"],
     "no-reference": true,


### PR DESCRIPTION
I noticed that we were failing to wait for promises in a couple places so I enabled no-floating-promises lint check and cleaned up all the violations.  To make this a bit easier I introduced enqueue() vs enqueueAndWait() on the AsyncQueue, with the former returning void instead of a Promise.