### PR TITLE
Multi-Tab Renames

### DIFF
--- a/packages/firestore/src/core/firestore_client.ts
+++ b/packages/firestore/src/core/firestore_client.ts
@@ -261,9 +261,9 @@ export class FirestoreClient {
       typeof DOMException !== 'undefined' &&
       error instanceof DOMException
     ) {
-      // We fall back to memory persistence if we cannot acquire an owner lease.
-      // This can happen can during a schema migration, or during the initial
-      // write of the `owner` lease.
+      // We fall back to memory persistence if we cannot write the primary
+      // lease. This can happen can during a schema migration, or if we run out
+      // of quota when we try to write the primary lease.
       // For both the `QuotaExceededError` and the  `AbortError`, it is safe to
       // fall back to memory persistence since all modifications to IndexedDb
       // failed to commit.

--- a/packages/firestore/src/local/indexeddb_persistence.ts
+++ b/packages/firestore/src/local/indexeddb_persistence.ts
@@ -29,8 +29,8 @@ import {
   createOrUpgradeDb,
   DbClientMetadataKey,
   DbClientMetadata,
-  DbOwner,
-  DbOwnerKey,
+  DbPrimaryClient,
+  DbPrimaryClientKey,
   SCHEMA_VERSION
 } from './indexeddb_schema';
 import { LocalSerializer } from './local_serializer';
@@ -306,7 +306,7 @@ export class IndexedDbPersistence implements Persistence {
   }
 
   /** Checks whether `client` is the local client. */
-  private isLocalClient(client: DbOwner | null): boolean {
+  private isLocalClient(client: DbPrimaryClient | null): boolean {
     return client ? client.ownerId === this.clientId : false;
   }
 
@@ -320,7 +320,7 @@ export class IndexedDbPersistence implements Persistence {
   private canActAsPrimary(
     txn: SimpleDbTransaction
   ): PersistencePromise<boolean> {
-    const store = ownerStore(txn);
+    const store = primaryClientStore(txn);
     return store
       .get('owner')
       .next(currentPrimary => {
@@ -422,7 +422,7 @@ export class IndexedDbPersistence implements Persistence {
     this.detachWindowUnloadHook();
     await this.simpleDb.runTransaction(
       'readwrite',
-      [DbOwner.store, DbClientMetadata.store],
+      [DbPrimaryClient.store, DbClientMetadata.store],
       txn => {
         return this.releasePrimaryLeaseIfHeld(txn).next(() =>
           this.removeClientMetadata(txn)
@@ -513,8 +513,6 @@ export class IndexedDbPersistence implements Persistence {
           return this.canActAsPrimary(simpleDbTxn)
             .next(canActAsPrimary => {
               if (!canActAsPrimary) {
-                // TODO(multitab): Handle this gracefully and transition back to
-                // secondary state.
                 log.error(
                   `Failed to obtain primary lease for action '${action}'.`
                 );
@@ -554,7 +552,7 @@ export class IndexedDbPersistence implements Persistence {
   private verifyAllowTabSynchronization(
     txn: SimpleDbTransaction
   ): PersistencePromise<void> {
-    const store = ownerStore(txn);
+    const store = primaryClientStore(txn);
     return store.get('owner').next(currentPrimary => {
       const currentLeaseIsValid =
         currentPrimary !== null &&
@@ -577,12 +575,12 @@ export class IndexedDbPersistence implements Persistence {
    * method does not verify that the client is eligible for this lease.
    */
   private acquireOrExtendPrimaryLease(txn): PersistencePromise<void> {
-    const newPrimary = new DbOwner(
+    const newPrimary = new DbPrimaryClient(
       this.clientId,
       this.allowTabSynchronization,
       Date.now()
     );
-    return ownerStore(txn).put('owner', newPrimary);
+    return primaryClientStore(txn).put('owner', newPrimary);
   }
 
   static isAvailable(): boolean {
@@ -615,7 +613,7 @@ export class IndexedDbPersistence implements Persistence {
   ): PersistencePromise<void> {
     this.isPrimary = false;
 
-    const store = ownerStore(txn);
+    const store = primaryClientStore(txn);
     return store.get('owner').next(primaryClient => {
       if (this.isLocalClient(primaryClient)) {
         log.debug(LOG_TAG, 'Releasing primary lease.');
@@ -649,7 +647,7 @@ export class IndexedDbPersistence implements Persistence {
       typeof this.document.addEventListener === 'function'
     ) {
       this.documentVisibilityHandler = () => {
-        this.queue.enqueueAndForget<DbOwner | void>(() => {
+        this.queue.enqueueAndForget(() => {
           this.inForeground = this.document.visibilityState === 'visible';
           return this.updateClientMetadataAndTryBecomePrimary();
         });
@@ -681,12 +679,13 @@ export class IndexedDbPersistence implements Persistence {
 
   /**
    * Attaches a window.unload handler that will synchronously write our
-   * ownerId to a "zombie owner id" location in localstorage. This can be used
-   * by tabs trying to acquire the lease to determine that the lease should be
-   * acquired immediately even if the timestamp is recent. This is particularly
-   * important for the refresh case (so the tab correctly re-acquires the owner
-   * lease). LocalStorage is used for this rather than IndexedDb because it is
-   * a synchronous API and so can be used reliably from an unload handler.
+   * clientId to a "zombie client id" location in LocalStorage. This can be used
+   * by tabs trying to acquire the primary lease to determine that the lease
+   * is no longer valid even if the timestamp is recent. This is particularly
+   * important for the refresh case (so the tab correctly re-acquires the
+   * primary lease). LocalStorage is used for this rather than IndexedDb because
+   * it is a synchronous API and so can be used reliably from  an unload
+   * handler.
    */
   private attachWindowUnloadHook(): void {
     if (typeof this.window.addEventListener === 'function') {
@@ -697,8 +696,8 @@ export class IndexedDbPersistence implements Persistence {
         this.markClientZombied();
 
         this.queue.enqueueAndForget(() => {
-          // Attempt graceful shutdown (including releasing our owner lease), but
-          // there's no guarantee it will complete.
+          // Attempt graceful shutdown (including releasing our primary lease),
+          // but there's no guarantee it will complete.
           return this.shutdown();
         });
       };
@@ -718,9 +717,9 @@ export class IndexedDbPersistence implements Persistence {
   }
 
   /**
-   * Returns any recorded "zombied owner" (i.e. a previous owner that became
-   * zombied due to their tab closing) from LocalStorage, or null if no such
-   * record exists.
+   * Returns whether a client is "zombied" based on its LocalStorage entry.
+   * Clients become zombied when their tab closes without running all of the
+   * cleanup logic in `shutdown()`.
    */
   private isClientZombied(clientId: ClientId): boolean {
     if (this.window.localStorage === undefined) {
@@ -763,7 +762,7 @@ export class IndexedDbPersistence implements Persistence {
       );
     } catch (e) {
       // Gracefully handle if LocalStorage isn't available / working.
-      log.error('Failed to set zombie owner id.', e);
+      log.error('Failed to set zombie client id.', e);
     }
   }
 
@@ -790,12 +789,12 @@ export function isPrimaryLeaseLostError(err: FirestoreError): boolean {
   );
 }
 /**
- * Helper to get a typed SimpleDbStore for the owner object store.
+ * Helper to get a typed SimpleDbStore for the primary client object store.
  */
-function ownerStore(
+function primaryClientStore(
   txn: SimpleDbTransaction
-): SimpleDbStore<DbOwnerKey, DbOwner> {
-  return txn.store<DbOwnerKey, DbOwner>(DbOwner.store);
+): SimpleDbStore<DbPrimaryClientKey, DbPrimaryClient> {
+  return txn.store<DbPrimaryClientKey, DbPrimaryClient>(DbPrimaryClient.store);
 }
 
 /**

--- a/packages/firestore/src/local/indexeddb_persistence.ts
+++ b/packages/firestore/src/local/indexeddb_persistence.ts
@@ -322,7 +322,7 @@ export class IndexedDbPersistence implements Persistence {
   ): PersistencePromise<boolean> {
     const store = primaryClientStore(txn);
     return store
-      .get('owner')
+      .get(DbPrimaryClient.key)
       .next(currentPrimary => {
         const currentLeaseIsValid =
           currentPrimary !== null &&
@@ -553,7 +553,7 @@ export class IndexedDbPersistence implements Persistence {
     txn: SimpleDbTransaction
   ): PersistencePromise<void> {
     const store = primaryClientStore(txn);
-    return store.get('owner').next(currentPrimary => {
+    return store.get(DbPrimaryClient.key).next(currentPrimary => {
       const currentLeaseIsValid =
         currentPrimary !== null &&
         this.isWithinMaxAge(currentPrimary.leaseTimestampMs) &&
@@ -580,7 +580,7 @@ export class IndexedDbPersistence implements Persistence {
       this.allowTabSynchronization,
       Date.now()
     );
-    return primaryClientStore(txn).put('owner', newPrimary);
+    return primaryClientStore(txn).put(DbPrimaryClient.key, newPrimary);
   }
 
   static isAvailable(): boolean {
@@ -614,10 +614,10 @@ export class IndexedDbPersistence implements Persistence {
     this.isPrimary = false;
 
     const store = primaryClientStore(txn);
-    return store.get('owner').next(primaryClient => {
+    return store.get(DbPrimaryClient.key).next(primaryClient => {
       if (this.isLocalClient(primaryClient)) {
         log.debug(LOG_TAG, 'Releasing primary lease.');
-        return store.delete('owner');
+        return store.delete(DbPrimaryClient.key);
       } else {
         return PersistencePromise.resolve();
       }

--- a/packages/firestore/src/local/indexeddb_schema.ts
+++ b/packages/firestore/src/local/indexeddb_schema.ts
@@ -108,8 +108,8 @@ export class DbTimestamp {
   constructor(public seconds: number, public nanoseconds: number) {}
 }
 
-// The key for the singleton object in the DbPrimaryClient store is 'owner'.
-export type DbPrimaryClientKey = 'owner';
+// The key for the singleton object in the DbPrimaryClient is a single string.
+export type DbPrimaryClientKey = typeof DbPrimaryClient.key;
 
 /**
  * A singleton object to be stored in the 'owner' store in IndexedDb.
@@ -129,6 +129,12 @@ export class DbPrimaryClient {
    * layer.
    */
   static store = 'owner';
+
+  /**
+   * The key string used for the single object that exists in the
+   * DbPrimaryClient store.
+   */
+  static key = 'owner';
 
   constructor(
     public ownerId: string,

--- a/packages/firestore/src/local/indexeddb_schema.ts
+++ b/packages/firestore/src/local/indexeddb_schema.ts
@@ -57,7 +57,7 @@ export function createOrUpgradeDb(
   );
 
   if (fromVersion < 1 && toVersion >= 1) {
-    createOwnerStore(db);
+    createPrimaryClientStore(db);
     createMutationQueue(db);
     createQueryCache(db);
     createRemoteDocumentCache(db);
@@ -108,21 +108,26 @@ export class DbTimestamp {
   constructor(public seconds: number, public nanoseconds: number) {}
 }
 
-// The key for the singleton object in the 'owner' store is 'owner'.
-export type DbOwnerKey = 'owner';
+// The key for the singleton object in the DbPrimaryClient store is 'owner'.
+export type DbPrimaryClientKey = 'owner';
 
 /**
  * A singleton object to be stored in the 'owner' store in IndexedDb.
  *
- * A given database can be owned by a single tab at a given time. That tab
- * must validate that it is still the owner before every write operation and
- * should regularly write an updated timestamp to prevent other tabs from
- * "stealing" ownership of the db.
+ * A given database can have a single primary tab assigned at a given time. That
+ * tab must validate that it is still holding the primary lease before every
+ * operation that requires locked access. The primary tab should regularly
+ * write an updated timestamp to this lease to prevent other tabs from
+ * "stealing" the primary lease
  */
-// TODO(multitab): Rename this class to reflect the primary/secondary naming
-// in the rest of the client.
-export class DbOwner {
-  /** Name of the IndexedDb object store. */
+export class DbPrimaryClient {
+  /**
+   * Name of the IndexedDb object store.
+   *
+   * Note that the name 'owner' is chosen to ensure backwards compatibility with
+   * older clients that only supported single locked access to the persistence
+   * layer.
+   */
   static store = 'owner';
 
   constructor(
@@ -133,8 +138,8 @@ export class DbOwner {
   ) {}
 }
 
-function createOwnerStore(db: IDBDatabase): void {
-  db.createObjectStore(DbOwner.store);
+function createPrimaryClientStore(db: IDBDatabase): void {
+  db.createObjectStore(DbPrimaryClient.store);
 }
 
 /** Object keys in the 'mutationQueues' store are userId strings. */
@@ -690,7 +695,7 @@ export const V1_STORES = [
   DbDocumentMutation.store,
   DbRemoteDocument.store,
   DbTarget.store,
-  DbOwner.store,
+  DbPrimaryClient.store,
   DbTargetGlobal.store,
   DbTargetDocument.store
 ];

--- a/packages/firestore/test/unit/local/indexeddb_persistence.test.ts
+++ b/packages/firestore/test/unit/local/indexeddb_persistence.test.ts
@@ -300,10 +300,10 @@ describe('IndexedDb: canActAsPrimary', () => {
       createOrUpgradeDb
     );
     await simpleDb.runTransaction('readwrite', [DbPrimaryClient.store], txn => {
-      const ownerStore = txn.store<DbPrimaryClientKey, DbPrimaryClient>(
+      const primaryStore = txn.store<DbPrimaryClientKey, DbPrimaryClient>(
         DbPrimaryClient.store
       );
-      return ownerStore.delete('owner');
+      return primaryStore.delete(DbPrimaryClient.key);
     });
     simpleDb.close();
   }

--- a/packages/firestore/test/unit/local/indexeddb_persistence.test.ts
+++ b/packages/firestore/test/unit/local/indexeddb_persistence.test.ts
@@ -14,16 +14,14 @@
  * limitations under the License.
  */
 
-// TODO(multitab): Rename this file to `indexeddb_persistence.test.ts`.
-
 import { expect } from 'chai';
 import { IndexedDbPersistence } from '../../../src/local/indexeddb_persistence';
 import {
   createOrUpgradeDb,
   DbMutationBatch,
   DbMutationBatchKey,
-  DbOwner,
-  DbOwnerKey,
+  DbPrimaryClient,
+  DbPrimaryClientKey,
   DbTarget,
   DbTargetGlobal,
   DbTargetGlobalKey,
@@ -295,14 +293,16 @@ describe('IndexedDb: canActAsPrimary', () => {
     return;
   }
 
-  async function clearOwner(): Promise<void> {
+  async function clearPrimaryLease(): Promise<void> {
     const simpleDb = await SimpleDb.openOrCreate(
       INDEXEDDB_TEST_DATABASE,
       SCHEMA_VERSION,
       createOrUpgradeDb
     );
-    await simpleDb.runTransaction('readwrite', [DbOwner.store], txn => {
-      const ownerStore = txn.store<DbOwnerKey, DbOwner>(DbOwner.store);
+    await simpleDb.runTransaction('readwrite', [DbPrimaryClient.store], txn => {
+      const ownerStore = txn.store<DbPrimaryClientKey, DbPrimaryClient>(
+        DbPrimaryClient.store
+      );
       return ownerStore.delete('owner');
     });
     simpleDb.close();
@@ -375,7 +375,7 @@ describe('IndexedDb: canActAsPrimary', () => {
 
           // Clear the current primary holder, since our logic will not revoke
           // the lease until it expires.
-          await clearOwner();
+          await clearPrimaryLease();
 
           await withPersistence(
             'thisClient',

--- a/packages/firestore/test/unit/specs/spec_test_runner.ts
+++ b/packages/firestore/test/unit/specs/spec_test_runner.ts
@@ -1523,7 +1523,9 @@ export interface StateExpectation {
   };
 }
 
-async function writePrimaryClientToIndexedDb(clientId: ClientId): Promise<void> {
+async function writePrimaryClientToIndexedDb(
+  clientId: ClientId
+): Promise<void> {
   const db = await SimpleDb.openOrCreate(
     IndexedDbTestRunner.TEST_DB_NAME + IndexedDbPersistence.MAIN_DATABASE,
     SCHEMA_VERSION,
@@ -1534,7 +1536,7 @@ async function writePrimaryClientToIndexedDb(clientId: ClientId): Promise<void> 
       DbPrimaryClient.store
     );
     return primaryClientStore.put(
-        DbPrimaryClient.key,
+      DbPrimaryClient.key,
       new DbPrimaryClient(
         clientId,
         /* allowTabSynchronization=*/ true,

--- a/packages/firestore/test/unit/specs/spec_test_runner.ts
+++ b/packages/firestore/test/unit/specs/spec_test_runner.ts
@@ -883,7 +883,7 @@ abstract class TestRunner {
     }
 
     if (state.primary) {
-      await writeOwnerToIndexedDb(this.clientId);
+      await writePrimaryClientToIndexedDb(this.clientId);
       await this.queue.runDelayedOperationsEarly(TimerId.ClientMetadataRefresh);
     }
 
@@ -1523,18 +1523,18 @@ export interface StateExpectation {
   };
 }
 
-async function writeOwnerToIndexedDb(clientId: ClientId): Promise<void> {
+async function writePrimaryClientToIndexedDb(clientId: ClientId): Promise<void> {
   const db = await SimpleDb.openOrCreate(
     IndexedDbTestRunner.TEST_DB_NAME + IndexedDbPersistence.MAIN_DATABASE,
     SCHEMA_VERSION,
     createOrUpgradeDb
   );
-  await db.runTransaction('readwrite', ['owner'], txn => {
-    const owner = txn.store<DbPrimaryClientKey, DbPrimaryClient>(
+  await db.runTransaction('readwrite', [DbPrimaryClient.store], txn => {
+    const primaryClientStore = txn.store<DbPrimaryClientKey, DbPrimaryClient>(
       DbPrimaryClient.store
     );
-    return owner.put(
-      'owner',
+    return primaryClientStore.put(
+        DbPrimaryClient.key,
       new DbPrimaryClient(
         clientId,
         /* allowTabSynchronization=*/ true,

--- a/packages/firestore/test/unit/specs/spec_test_runner.ts
+++ b/packages/firestore/test/unit/specs/spec_test_runner.ts
@@ -99,8 +99,8 @@ import {
 } from '../../../src/local/shared_client_state';
 import {
   createOrUpgradeDb,
-  DbOwner,
-  DbOwnerKey,
+  DbPrimaryClient,
+  DbPrimaryClientKey,
   SCHEMA_VERSION
 } from '../../../src/local/indexeddb_schema';
 import { TestPlatform, SharedFakeWebStorage } from '../../util/test_platform';
@@ -1530,10 +1530,16 @@ async function writeOwnerToIndexedDb(clientId: ClientId): Promise<void> {
     createOrUpgradeDb
   );
   await db.runTransaction('readwrite', ['owner'], txn => {
-    const owner = txn.store<DbOwnerKey, DbOwner>(DbOwner.store);
+    const owner = txn.store<DbPrimaryClientKey, DbPrimaryClient>(
+      DbPrimaryClient.store
+    );
     return owner.put(
       'owner',
-      new DbOwner(clientId, /* allowTabSynchronization=*/ true, Date.now())
+      new DbPrimaryClient(
+        clientId,
+        /* allowTabSynchronization=*/ true,
+        Date.now()
+      )
     );
   });
   db.close();


### PR DESCRIPTION
This PR:
- Renames the DbOwner store to DbPrimaryClient store (without renaming the IndexedDb location).
- Renames `targetIds` to `queryDataByTarget`
- Renames `indexeddb_schema.test.ts` to `indexeddb_persistence.test.ts`