### PR TITLE
Fixed `get({source: 'cache'})` to return nonexistent documents from cache.

### DIFF
--- a/packages/firestore/CHANGELOG.md
+++ b/packages/firestore/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Unreleased
+- [fixed] Fixed `get({source: 'cache'})` to be able to return nonexistent
+  documents from cache.
+
+# 0.6.1
 - [changed] Improved how Firestore handles idle queries to reduce the cost of
   re-listening within 30 minutes.
 - [changed] Improved offline performance with many outstanding writes.

--- a/packages/firestore/src/api/database.ts
+++ b/packages/firestore/src/api/database.ts
@@ -1073,7 +1073,7 @@ export class DocumentReference implements firestore.DocumentReference {
           this.firestore
             .ensureClientConfigured()
             .getDocumentFromLocalCache(this._key)
-            .then((doc: Document) => {
+            .then(doc => {
               resolve(
                 new DocumentSnapshot(
                   this.firestore,

--- a/packages/firestore/src/core/firestore_client.ts
+++ b/packages/firestore/src/core/firestore_client.ts
@@ -36,7 +36,7 @@ import {
   documentKeySet,
   DocumentMap
 } from '../model/collections';
-import { Document, MaybeDocument } from '../model/document';
+import { Document, MaybeDocument, NoDocument } from '../model/document';
 import { DocumentKey } from '../model/document_key';
 import { Mutation } from '../model/mutation';
 import { Platform } from '../platform/platform';
@@ -469,7 +469,7 @@ export class FirestoreClient {
     });
   }
 
-  getDocumentFromLocalCache(docKey: DocumentKey): Promise<Document> {
+  getDocumentFromLocalCache(docKey: DocumentKey): Promise<Document | null> {
     return this.asyncQueue
       .enqueue(() => {
         return this.localStore.readDocument(docKey);
@@ -477,6 +477,8 @@ export class FirestoreClient {
       .then((maybeDoc: MaybeDocument | null) => {
         if (maybeDoc instanceof Document) {
           return maybeDoc;
+        } else if (maybeDoc instanceof NoDocument) {
+          return null;
         } else {
           throw new FirestoreError(
             Code.UNAVAILABLE,

--- a/packages/firestore/test/integration/api/get_options.test.ts
+++ b/packages/firestore/test/integration/api/get_options.test.ts
@@ -436,6 +436,7 @@ apiDescribe('GetOptions', persistence => {
   // TODO(b/112267729): We should raise a fromCache=true event with a
   // nonexistent snapshot, but because the default source goes through a normal
   // listener, we do not.
+  // tslint:disable-next-line:ban skipping test on purpose.
   it.skip('get deleted doc while offline with default get options', () => {
     return withTestDocAndInitialData(persistence, null, docRef => {
       return docRef
@@ -506,6 +507,7 @@ apiDescribe('GetOptions', persistence => {
   });
 
   // We need the deleted doc to stay in cache, so only run this with persistence.
+  // tslint:disable-next-line:ban skipping test on purpose.
   (persistence ? it : it.skip)(
     'get deleted doc while offline with source=cache',
     () => {

--- a/packages/firestore/test/integration/api/get_options.test.ts
+++ b/packages/firestore/test/integration/api/get_options.test.ts
@@ -436,7 +436,7 @@ apiDescribe('GetOptions', persistence => {
   // TODO(b/112267729): We should raise a fromCache=true event with a
   // nonexistent snapshot, but because the default source goes through a normal
   // listener, we do not.
-  // tslint:disable-next-line:ban skipping test on purpose.
+  // tslint:disable-next-line:ban
   it.skip('get deleted doc while offline with default get options', () => {
     return withTestDocAndInitialData(persistence, null, docRef => {
       return docRef
@@ -445,7 +445,7 @@ apiDescribe('GetOptions', persistence => {
         .then(() => docRef.get())
         .then(doc => {
           expect(doc.exists).to.be.false;
-          expect(doc.data).to.be.null;
+          expect(doc.data()).to.be.undefined;
           expect(doc.metadata.fromCache).to.be.true;
           expect(doc.metadata.hasPendingWrites).to.be.false;
         });
@@ -507,7 +507,7 @@ apiDescribe('GetOptions', persistence => {
   });
 
   // We need the deleted doc to stay in cache, so only run this with persistence.
-  // tslint:disable-next-line:ban skipping test on purpose.
+  // tslint:disable-next-line:ban
   (persistence ? it : it.skip)(
     'get deleted doc while offline with source=cache',
     () => {
@@ -568,6 +568,7 @@ apiDescribe('GetOptions', persistence => {
     return withTestDocAndInitialData(persistence, null, docRef => {
       return docRef.firestore
         .disableNetwork()
+        // Attempt to get doc.  This will fail since there's nothing in cache.
         .then(() => docRef.get({ source: 'server' }))
         .then(
           doc => {

--- a/packages/firestore/test/integration/api/get_options.test.ts
+++ b/packages/firestore/test/integration/api/get_options.test.ts
@@ -418,15 +418,36 @@ apiDescribe('GetOptions', persistence => {
 
   it('get non existing doc while offline with default get options', () => {
     return withTestDocAndInitialData(persistence, null, docRef => {
-      return docRef.firestore
-        .disableNetwork()
+      return (
+        docRef.firestore
+          .disableNetwork()
+          // Attempt to get doc. This will fail since there's nothing in cache.
+          .then(() => docRef.get())
+          .then(
+            doc => {
+              expect.fail();
+            },
+            expected => {}
+          )
+      );
+    });
+  });
+
+  // TODO(b/112267729): We should raise a fromCache=true event with a
+  // nonexistent snapshot, but because the default source goes through a normal
+  // listener, we do not.
+  it.skip('get deleted doc while offline with default get options', () => {
+    return withTestDocAndInitialData(persistence, null, docRef => {
+      return docRef
+        .delete()
+        .then(() => docRef.firestore.disableNetwork())
         .then(() => docRef.get())
-        .then(
-          doc => {
-            expect.fail();
-          },
-          expected => {}
-        );
+        .then(doc => {
+          expect(doc.exists).to.be.false;
+          expect(doc.data).to.be.null;
+          expect(doc.metadata.fromCache).to.be.true;
+          expect(doc.metadata.hasPendingWrites).to.be.false;
+        });
     });
   });
 
@@ -446,9 +467,7 @@ apiDescribe('GetOptions', persistence => {
 
   it('get non existing doc while online with source=cache', () => {
     return withTestDocAndInitialData(persistence, null, docRef => {
-      // attempt to get doc. Currently, this is expected to fail. In the
-      // future, we might consider adding support for negative cache hits so
-      // that we know certain documents *don't* exist.
+      // Attempt to get doc.  This will fail since there's nothing in cache.
       return docRef.get({ source: 'cache' }).then(
         doc => {
           expect.fail();
@@ -474,9 +493,7 @@ apiDescribe('GetOptions', persistence => {
       return (
         docRef.firestore
           .disableNetwork()
-          // attempt to get doc. Currently, this is expected to fail. In the
-          // future, we might consider adding support for negative cache hits so
-          // that we know certain documents *don't* exist.
+          // Attempt to get doc.  This will fail since there's nothing in cache.
           .then(() => docRef.get({ source: 'cache' }))
           .then(
             doc => {
@@ -487,6 +504,28 @@ apiDescribe('GetOptions', persistence => {
       );
     });
   });
+
+  // We need the deleted doc to stay in cache, so only run this with persistence.
+  (persistence ? it : it.skip)(
+    'get deleted doc while offline with source=cache',
+    () => {
+      return withTestDocAndInitialData(persistence, null, docRef => {
+        return (
+          docRef
+            .delete()
+            .then(() => docRef.firestore.disableNetwork())
+            // Should get a document with exists=false, fromCache=true
+            .then(() => docRef.get({ source: 'cache' }))
+            .then(doc => {
+              expect(doc.exists).to.be.false;
+              expect(doc.data()).to.be.undefined;
+              expect(doc.metadata.fromCache).to.be.true;
+              expect(doc.metadata.hasPendingWrites).to.be.false;
+            })
+        );
+      });
+    }
+  );
 
   it('get non existing collection while offline with source=cache', () => {
     return withTestCollection(persistence, {}, colRef => {
@@ -525,20 +564,15 @@ apiDescribe('GetOptions', persistence => {
 
   it('get non existing doc while offline with source=server', () => {
     return withTestDocAndInitialData(persistence, null, docRef => {
-      return (
-        docRef.firestore
-          .disableNetwork()
-          // attempt to get doc. Currently, this is expected to fail. In the
-          // future, we might consider adding support for negative cache hits so
-          // that we know certain documents *don't* exist.
-          .then(() => docRef.get({ source: 'server' }))
-          .then(
-            doc => {
-              expect.fail();
-            },
-            expected => {}
-          )
-      );
+      return docRef.firestore
+        .disableNetwork()
+        .then(() => docRef.get({ source: 'server' }))
+        .then(
+          doc => {
+            expect.fail();
+          },
+          expected => {}
+        );
     });
   });
 


### PR DESCRIPTION
Port of https://github.com/firebase/firebase-ios-sdk/pull/1642 (although there was no crash on web; it just unnecessarily returned an error instead of the cached nonexistent document)
