### PR TITLE
Removing/Addressing TODOs

### DIFF
--- a/packages/firestore/src/local/local_documents_view.ts
+++ b/packages/firestore/src/local/local_documents_view.ts
@@ -110,11 +110,7 @@ export class LocalDocumentsView {
       });
   }
 
-  /**
-   * Performs a query against the local view of all documents.
-   *
-   * Multi-Tab Note: This operation is safe to use from secondary clients.
-   */
+  /** Performs a query against the local view of all documents. */
   getDocumentsMatchingQuery(
     transaction: PersistenceTransaction,
     query: Query

--- a/packages/firestore/src/local/local_store.ts
+++ b/packages/firestore/src/local/local_store.ts
@@ -465,7 +465,7 @@ export class LocalStore {
   getLastStreamToken(): Promise<ProtoByteString> {
     return this.persistence.runTransaction(
       'Get last stream token',
-      false, // TODO(multitab): This requires the owner lease
+      false,
       txn => {
         return this.mutationQueue.getLastStreamToken(txn);
       }

--- a/packages/firestore/src/local/mutation_queue.ts
+++ b/packages/firestore/src/local/mutation_queue.ts
@@ -73,8 +73,6 @@ export interface MutationQueue extends GarbageSource {
 
   /**
    * Creates a new mutation batch and adds it to this mutation queue.
-   *
-   * TODO(multitab): Make this operation safe to use from secondary clients.
    */
   addMutationBatch(
     transaction: PersistenceTransaction,

--- a/packages/firestore/src/local/mutation_queue.ts
+++ b/packages/firestore/src/local/mutation_queue.ts
@@ -82,8 +82,6 @@ export interface MutationQueue extends GarbageSource {
 
   /**
    * Loads the mutation batch with the given batchId.
-   *
-   * Multi-Tab Note: This operation is safe to use from secondary clients.
    */
   lookupMutationBatch(
     transaction: PersistenceTransaction,
@@ -95,8 +93,6 @@ export interface MutationQueue extends GarbageSource {
    * For primary clients, this method returns `null` after
    * `removeMutationBatches()` has been called. Secondary clients return a
    * cached result until `removeCachedMutationKeys()` is invoked.
-   *
-   * Multi-Tab Note: This operation is safe to use from secondary clients.
    */
   lookupMutationKeys(
     transaction: PersistenceTransaction,
@@ -210,6 +206,8 @@ export interface MutationQueue extends GarbageSource {
    * In both cases, the array of mutations to remove must be a contiguous range
    * of batchIds. This is most easily accomplished by loading mutations with
    * getAllMutationBatchesThroughBatchId()
+   *
+   * Multi-Tab Note: This operation should only be called by the primary client.
    */
   removeMutationBatches(
     transaction: PersistenceTransaction,

--- a/packages/firestore/src/local/query_cache.ts
+++ b/packages/firestore/src/local/query_cache.ts
@@ -92,6 +92,8 @@ export interface QueryCache extends GarbageSource {
   /**
    * Removes the cached entry for the given query data. It is an error to remove
    * a query data that does not exist.
+   *
+   * Multi-Tab Note: This operation should only be called by the primary client.
    */
   removeQueryData(
     transaction: PersistenceTransaction,
@@ -109,8 +111,6 @@ export interface QueryCache extends GarbageSource {
   /**
    * Looks up a QueryData entry by query.
    *
-   * Multi-Tab Note: This operation is safe to use from secondary clients.
-   *
    * @param query The query corresponding to the entry to look up.
    * @return The cached QueryData entry, or null if the cache has no entry for
    * the query.
@@ -122,8 +122,6 @@ export interface QueryCache extends GarbageSource {
 
   /**
    * Looks up a QueryData entry by target ID.
-   *
-   * Multi-Tab Note: This operation is safe to use from secondary clients.
    *
    * @param targetId The target ID of the QueryData entry to look up.
    * @return The cached QueryData entry, or null if the cache has no entry for
@@ -138,6 +136,8 @@ export interface QueryCache extends GarbageSource {
   /**
    * Adds the given document keys to cached query results of the given target
    * ID.
+   *
+   * Multi-Tab Note: This operation should only be called by the primary client.
    */
   addMatchingKeys(
     transaction: PersistenceTransaction,
@@ -148,6 +148,8 @@ export interface QueryCache extends GarbageSource {
   /**
    * Removes the given document keys from the cached query results of the
    * given target ID.
+   *
+   * Multi-Tab Note: This operation should only be called by the primary client.
    */
   removeMatchingKeys(
     transaction: PersistenceTransaction,
@@ -157,6 +159,8 @@ export interface QueryCache extends GarbageSource {
 
   /**
    * Removes all the keys in the query results of the given target ID.
+   *
+   * Multi-Tab Note: This operation should only be called by the primary client.
    */
   removeMatchingKeysForTargetId(
     transaction: PersistenceTransaction,
@@ -165,8 +169,6 @@ export interface QueryCache extends GarbageSource {
 
   /**
    * Returns the document keys that match the provided target ID.
-   *
-   * Multi-Tab Note: This operation is safe to use from secondary clients.
    */
   getMatchingKeysForTargetId(
     transaction: PersistenceTransaction,

--- a/packages/firestore/src/local/remote_document_cache.ts
+++ b/packages/firestore/src/local/remote_document_cache.ts
@@ -49,13 +49,19 @@ export interface RemoteDocumentCache {
    *
    * @param maybeDocuments A set of Documents or NoDocuments to put in the
    * cache.
+   *
+   * Multi-Tab Note: This operation should only be called by the primary client.
    */
   addEntries(
     transaction: PersistenceTransaction,
     maybeDocuments: MaybeDocument[]
   ): PersistencePromise<void>;
 
-  /** Removes the cached entry for the given key (no-op if no entry exists). */
+  /**
+   * Removes the cached entry for the given key (no-op if no entry exists).
+   *
+   * Multi-Tab Note: This operation should only be called by the primary client.
+   */
   removeEntry(
     transaction: PersistenceTransaction,
     documentKey: DocumentKey
@@ -63,8 +69,6 @@ export interface RemoteDocumentCache {
 
   /**
    * Looks up an entry in the cache.
-   *
-   * Multi-Tab Note: This operation is safe to use from secondary clients.
    *
    * @param documentKey The key of the entry to look up.
    * @return The cached Document or NoDocument entry, or null if we have nothing
@@ -82,8 +86,6 @@ export interface RemoteDocumentCache {
    * should be re-filtered by the consumer before presenting them to the user.
    *
    * Cached NoDocument entries have no bearing on query results.
-   *
-   * Multi-Tab Note: This operation is safe to use from secondary clients.
    *
    * @param query The query to match documents against.
    * @return The set of matching documents.

--- a/packages/firestore/test/unit/local/test_mutation_queue.ts
+++ b/packages/firestore/test/unit/local/test_mutation_queue.ts
@@ -34,20 +34,20 @@ export class TestMutationQueue {
   constructor(public persistence: Persistence, public queue: MutationQueue) {}
 
   start(): Promise<void> {
-    return this.persistence.runTransaction('start', true, txn => {
+    return this.persistence.runTransaction('start', false, txn => {
       return this.queue.start(txn);
     });
   }
 
   checkEmpty(): Promise<boolean> {
-    return this.persistence.runTransaction('checkEmpty', true, txn => {
+    return this.persistence.runTransaction('checkEmpty', false, txn => {
       return this.queue.checkEmpty(txn);
     });
   }
 
   countBatches(): Promise<number> {
     return this.persistence
-      .runTransaction('countBatches', true, txn => {
+      .runTransaction('countBatches', false, txn => {
         return this.queue.getAllMutationBatches(txn);
       })
       .then(batches => batches.length);
@@ -56,7 +56,7 @@ export class TestMutationQueue {
   getHighestAcknowledgedBatchId(): Promise<BatchId> {
     return this.persistence.runTransaction(
       'getHighestAcknowledgedBatchId',
-      true,
+      false,
       txn => {
         return this.queue.getHighestAcknowledgedBatchId(txn);
       }
@@ -77,7 +77,7 @@ export class TestMutationQueue {
   }
 
   getLastStreamToken(): Promise<string> {
-    return this.persistence.runTransaction('getLastStreamToken', true, txn => {
+    return this.persistence.runTransaction('getLastStreamToken', false, txn => {
       return this.queue.getLastStreamToken(txn);
     }) as AnyDuringMigration;
   }
@@ -89,15 +89,19 @@ export class TestMutationQueue {
   }
 
   addMutationBatch(mutations: Mutation[]): Promise<MutationBatch> {
-    return this.persistence.runTransaction('addMutationBatch', true, txn => {
+    return this.persistence.runTransaction('addMutationBatch', false, txn => {
       return this.queue.addMutationBatch(txn, Timestamp.now(), mutations);
     });
   }
 
   lookupMutationBatch(batchId: BatchId): Promise<MutationBatch | null> {
-    return this.persistence.runTransaction('lookupMutationBatch', true, txn => {
-      return this.queue.lookupMutationBatch(txn, batchId);
-    });
+    return this.persistence.runTransaction(
+      'lookupMutationBatch',
+      false,
+      txn => {
+        return this.queue.lookupMutationBatch(txn, batchId);
+      }
+    );
   }
 
   getNextMutationBatchAfterBatchId(
@@ -105,7 +109,7 @@ export class TestMutationQueue {
   ): Promise<MutationBatch | null> {
     return this.persistence.runTransaction(
       'getNextMutationBatchAfterBatchId',
-      true,
+      false,
       txn => {
         return this.queue.getNextMutationBatchAfterBatchId(txn, batchId);
       }
@@ -115,7 +119,7 @@ export class TestMutationQueue {
   getAllMutationBatches(): Promise<MutationBatch[]> {
     return this.persistence.runTransaction(
       'getAllMutationBatches',
-      true,
+      false,
       txn => {
         return this.queue.getAllMutationBatches(txn);
       }
@@ -127,7 +131,7 @@ export class TestMutationQueue {
   ): Promise<MutationBatch[]> {
     return this.persistence.runTransaction(
       'getAllMutationBatchesThroughBatchId',
-      true,
+      false,
       txn => {
         return this.queue.getAllMutationBatchesThroughBatchId(txn, batchId);
       }
@@ -139,7 +143,7 @@ export class TestMutationQueue {
   ): Promise<MutationBatch[]> {
     return this.persistence.runTransaction(
       'getAllMutationBatchesAffectingDocumentKey',
-      true,
+      false,
       txn => {
         return this.queue.getAllMutationBatchesAffectingDocumentKey(
           txn,
@@ -154,7 +158,7 @@ export class TestMutationQueue {
   ): Promise<MutationBatch[]> {
     return this.persistence.runTransaction(
       'getAllMutationBatchesAffectingDocumentKeys',
-      true,
+      false,
       txn => {
         return this.queue.getAllMutationBatchesAffectingDocumentKeys(
           txn,
@@ -167,7 +171,7 @@ export class TestMutationQueue {
   getAllMutationBatchesAffectingQuery(query: Query): Promise<MutationBatch[]> {
     return this.persistence.runTransaction(
       'getAllMutationBatchesAffectingQuery',
-      true,
+      false,
       txn => {
         return this.queue.getAllMutationBatchesAffectingQuery(txn, query);
       }

--- a/packages/firestore/test/unit/local/test_query_cache.ts
+++ b/packages/firestore/test/unit/local/test_query_cache.ts
@@ -27,19 +27,17 @@ import { DocumentKey } from '../../../src/model/document_key';
  * A wrapper around a QueryCache that automatically creates a
  * transaction around every operation to reduce test boilerplate.
  */
-// TODO(multitab): Adjust the `requirePrimaryLease` argument to match the usage
-// in the client.
 export class TestQueryCache {
   constructor(public persistence: Persistence, public cache: QueryCache) {}
 
   start(): Promise<void> {
-    return this.persistence.runTransaction('start', true, txn =>
+    return this.persistence.runTransaction('start', false, txn =>
       this.cache.start(txn)
     );
   }
 
   addQueryData(queryData: QueryData): Promise<void> {
-    return this.persistence.runTransaction('addQueryData', true, txn => {
+    return this.persistence.runTransaction('addQueryData', false, txn => {
       return this.cache.addQueryData(txn, queryData);
     });
   }
@@ -51,7 +49,7 @@ export class TestQueryCache {
   }
 
   getQueryCount(): Promise<number> {
-    return this.persistence.runTransaction('getQueryCount', true, txn => {
+    return this.persistence.runTransaction('getQueryCount', false, txn => {
       return this.cache.getQueryCount(txn);
     });
   }
@@ -63,7 +61,7 @@ export class TestQueryCache {
   }
 
   getQueryData(query: Query): Promise<QueryData | null> {
-    return this.persistence.runTransaction('getQueryData', true, txn => {
+    return this.persistence.runTransaction('getQueryData', false, txn => {
       return this.cache.getQueryData(txn, query);
     });
   }
@@ -71,7 +69,7 @@ export class TestQueryCache {
   getLastRemoteSnapshotVersion(): Promise<SnapshotVersion> {
     return this.persistence.runTransaction(
       'getLastRemoteSnapshotVersion',
-      true,
+      false,
       txn => {
         return this.cache.getLastRemoteSnapshotVersion(txn);
       }
@@ -106,7 +104,7 @@ export class TestQueryCache {
 
   getMatchingKeysForTargetId(targetId: TargetId): Promise<DocumentKey[]> {
     return this.persistence
-      .runTransaction('getMatchingKeysForTargetId', true, txn => {
+      .runTransaction('getMatchingKeysForTargetId', false, txn => {
         return this.cache.getMatchingKeysForTargetId(txn, targetId);
       })
       .then(keySet => {
@@ -127,7 +125,7 @@ export class TestQueryCache {
   }
 
   containsKey(key: DocumentKey): Promise<boolean> {
-    return this.persistence.runTransaction('containsKey', true, txn => {
+    return this.persistence.runTransaction('containsKey', false, txn => {
       return this.cache.containsKey(txn, key);
     });
   }

--- a/packages/firestore/test/unit/local/test_remote_document_cache.ts
+++ b/packages/firestore/test/unit/local/test_remote_document_cache.ts
@@ -32,7 +32,7 @@ export class TestRemoteDocumentCache {
   ) {}
 
   start(): Promise<void> {
-    return this.persistence.runTransaction('start', true, txn => {
+    return this.persistence.runTransaction('start', false, txn => {
       return this.cache.start(txn);
     });
   }
@@ -50,7 +50,7 @@ export class TestRemoteDocumentCache {
   }
 
   getEntry(documentKey: DocumentKey): Promise<MaybeDocument | null> {
-    return this.persistence.runTransaction('getEntry', true, txn => {
+    return this.persistence.runTransaction('getEntry', false, txn => {
       return this.cache.getEntry(txn, documentKey);
     });
   }
@@ -58,7 +58,7 @@ export class TestRemoteDocumentCache {
   getDocumentsMatchingQuery(query: Query): Promise<DocumentMap> {
     return this.persistence.runTransaction(
       'getDocumentsMatchingQuery',
-      true,
+      false,
       txn => {
         return this.cache.getDocumentsMatchingQuery(txn, query);
       }
@@ -68,7 +68,7 @@ export class TestRemoteDocumentCache {
   getNextDocumentChanges(): Promise<MaybeDocumentMap> {
     return this.persistence.runTransaction(
       'getNextDocumentChanges',
-      true,
+      false,
       txn => {
         return this.cache.getNewDocumentChanges(txn);
       }

--- a/packages/firestore/test/unit/local/test_remote_document_change_buffer.ts
+++ b/packages/firestore/test/unit/local/test_remote_document_change_buffer.ts
@@ -35,7 +35,7 @@ export class TestRemoteDocumentChangeBuffer {
   }
 
   getEntry(documentKey: DocumentKey): Promise<MaybeDocument | null> {
-    return this.persistence.runTransaction('getEntry', true, txn => {
+    return this.persistence.runTransaction('getEntry', false, txn => {
       return this.buffer.getEntry(txn, documentKey);
     });
   }


### PR DESCRIPTION
This a) removes two TODOs that are no longer applicable/valid and b) addresses one by changing the test files that wrap the cache to use the primaryLease mode that is used in the rest of the client. 
Note that I did the latter from memory, and if we want to make 100% certain that this is correct, I can go back and verify the callers manually. 