### PR TITLE
Using BATCHID_UNKNOWN instead of null

### DIFF
--- a/packages/firestore/src/local/shared_client_state.ts
+++ b/packages/firestore/src/local/shared_client_state.ts
@@ -22,8 +22,8 @@ import {
   TargetId
 } from '../core/types';
 import { assert } from '../util/assert';
+import { BATCHID_UNKNOWN } from '../model/mutation_batch';
 import { debug, error } from '../util/log';
-import { min } from '../util/misc';
 import { SortedSet } from '../util/sorted_set';
 import { isSafeInteger } from '../util/types';
 import * as objUtils from '../util/obj';
@@ -111,7 +111,8 @@ export interface SharedClientState {
   ): void;
 
   /**
-   * Gets the minimum mutation batch for all active clients.
+   * Gets the minimum mutation batch for all active clients. Returns
+   * BATCHID_UNKNOWN if there are no mutation batches.
    *
    * The implementation for this may require O(n) runtime, where 'n' is the
    * number of clients.
@@ -375,8 +376,8 @@ export class QueryTargetMetadata {
 interface ClientStateSchema {
   lastUpdateTime: number;
   activeTargetIds: number[];
-  minMutationBatchId: number | null;
-  maxMutationBatchId: number | null;
+  minMutationBatchId: number;
+  maxMutationBatchId: number;
 }
 
 /**
@@ -388,8 +389,8 @@ interface ClientStateSchema {
 export interface ClientState {
   readonly activeTargetIds: TargetIdSet;
   readonly lastUpdateTime: Date;
-  readonly maxMutationBatchId: BatchId | null;
-  readonly minMutationBatchId: BatchId | null;
+  readonly maxMutationBatchId: BatchId;
+  readonly minMutationBatchId: BatchId;
 }
 
 /**
@@ -402,8 +403,8 @@ class RemoteClientState implements ClientState {
     readonly clientId: ClientId,
     readonly lastUpdateTime: Date,
     readonly activeTargetIds: TargetIdSet,
-    readonly minMutationBatchId: BatchId | null,
-    readonly maxMutationBatchId: BatchId | null
+    readonly minMutationBatchId: BatchId,
+    readonly maxMutationBatchId: BatchId
   ) {}
 
   /**
@@ -420,10 +421,8 @@ class RemoteClientState implements ClientState {
       typeof clientState === 'object' &&
       isSafeInteger(clientState.lastUpdateTime) &&
       clientState.activeTargetIds instanceof Array &&
-      (clientState.minMutationBatchId === null ||
-        isSafeInteger(clientState.minMutationBatchId)) &&
-      (clientState.maxMutationBatchId === null ||
-        isSafeInteger(clientState.maxMutationBatchId));
+      isSafeInteger(clientState.minMutationBatchId) &&
+      isSafeInteger(clientState.maxMutationBatchId);
 
     let activeTargetIdsSet = targetIdSet();
 
@@ -519,12 +518,16 @@ export class LocalClientState implements ClientState {
     this.lastUpdateTime = new Date();
   }
 
-  get minMutationBatchId(): BatchId | null {
-    return this.pendingBatchIds.first();
+  get minMutationBatchId(): BatchId {
+    return this.pendingBatchIds.isEmpty()
+      ? BATCHID_UNKNOWN
+      : this.pendingBatchIds.first();
   }
 
   get maxMutationBatchId(): BatchId | null {
-    return this.pendingBatchIds.last();
+    return this.pendingBatchIds.isEmpty()
+      ? BATCHID_UNKNOWN
+      : this.pendingBatchIds.last();
   }
 
   addPendingMutation(batchId: BatchId): void {
@@ -708,11 +711,17 @@ export class WebStorageSharedClientState implements SharedClientState {
     this.started = true;
   }
 
-  // TODO(multitab): Return BATCHID_UNKNOWN instead of null
-  getMinimumGlobalPendingMutation(): BatchId | null {
-    let minMutationBatch: number | null = null;
+  getMinimumGlobalPendingMutation(): BatchId {
+    let minMutationBatch = BATCHID_UNKNOWN;
     objUtils.forEach(this.activeClients, (key, value) => {
-      minMutationBatch = min(minMutationBatch, value.minMutationBatchId);
+      if (minMutationBatch === BATCHID_UNKNOWN) {
+        minMutationBatch = value.minMutationBatchId;
+      } else if (
+        value.minMutationBatchId !== BATCHID_UNKNOWN &&
+        value.minMutationBatchId < minMutationBatch
+      ) {
+        minMutationBatch = value.minMutationBatchId;
+      }
     });
     return minMutationBatch;
   }

--- a/packages/firestore/src/local/shared_client_state.ts
+++ b/packages/firestore/src/local/shared_client_state.ts
@@ -524,7 +524,7 @@ export class LocalClientState implements ClientState {
       : this.pendingBatchIds.first();
   }
 
-  get maxMutationBatchId(): BatchId | null {
+  get maxMutationBatchId(): BatchId {
     return this.pendingBatchIds.isEmpty()
       ? BATCHID_UNKNOWN
       : this.pendingBatchIds.last();

--- a/packages/firestore/src/util/misc.ts
+++ b/packages/firestore/src/util/misc.ts
@@ -59,22 +59,6 @@ export function primitiveComparator<T>(left: T, right: T): number {
   return 0;
 }
 
-/** Implementation of min() that ignores null values. */
-export function min(...values: Array<number | null>): number | null {
-  let min = null;
-
-  for (const value of values) {
-    if (value !== null) {
-      if (min == null) {
-        min = value;
-      } else if (value < min) {
-        min = value;
-      }
-    }
-  }
-
-  return min;
-}
 /** Duck-typed interface for objects that have an isEqual() method. */
 export interface Equatable<T> {
   isEqual(other: T): boolean;

--- a/packages/firestore/test/unit/local/web_storage_shared_client_state.test.ts
+++ b/packages/firestore/test/unit/local/web_storage_shared_client_state.test.ts
@@ -30,6 +30,7 @@ import {
   TargetId
 } from '../../../src/core/types';
 import { AutoId } from '../../../src/util/misc';
+import { BATCHID_UNKNOWN } from '../../../src/model/mutation_batch';
 import { expect } from 'chai';
 import { User } from '../../../src/auth/user';
 import { FirestoreError } from '../../../src/util/error';
@@ -226,9 +227,9 @@ describe('WebStorageSharedClientState', () => {
   });
 
   function assertClientState(
-    activeTargetIds: number[],
-    minMutationBatchId: number | null,
-    maxMutationBatchId: number | null
+    activeTargetIds: TargetId[],
+    minMutationBatchId: BatchId,
+    maxMutationBatchId: BatchId
   ): void {
     const actual = JSON.parse(
       localStorage.getItem(
@@ -283,12 +284,12 @@ describe('WebStorageSharedClientState', () => {
     });
 
     it('when empty', () => {
-      assertClientState([], null, null);
+      assertClientState([], BATCHID_UNKNOWN, BATCHID_UNKNOWN);
     });
 
     it('with one pending batch', () => {
       expect(sharedClientState.hasLocalPendingMutation(0)).to.be.false;
-      assertClientState([], null, null);
+      assertClientState([], BATCHID_UNKNOWN, BATCHID_UNKNOWN);
 
       sharedClientState.addLocalPendingMutation(0);
       expect(sharedClientState.hasLocalPendingMutation(0)).to.be.true;
@@ -297,7 +298,7 @@ describe('WebStorageSharedClientState', () => {
 
       sharedClientState.removeLocalPendingMutation(0);
       expect(sharedClientState.hasLocalPendingMutation(0)).to.be.false;
-      assertClientState([], null, null);
+      assertClientState([], BATCHID_UNKNOWN, BATCHID_UNKNOWN);
     });
 
     it('with multiple pending batches', () => {
@@ -363,27 +364,27 @@ describe('WebStorageSharedClientState', () => {
     });
 
     it('when empty', () => {
-      assertClientState([], null, null);
+      assertClientState([], BATCHID_UNKNOWN, BATCHID_UNKNOWN);
     });
 
     it('with multiple targets', () => {
       sharedClientState.addLocalQueryTarget(0);
-      assertClientState([0], null, null);
+      assertClientState([0], BATCHID_UNKNOWN, BATCHID_UNKNOWN);
       assertTargetState(0, 'pending');
 
       sharedClientState.addLocalQueryTarget(1);
       sharedClientState.addLocalQueryTarget(2);
-      assertClientState([0, 1, 2], null, null);
+      assertClientState([0, 1, 2], BATCHID_UNKNOWN, BATCHID_UNKNOWN);
       assertTargetState(1, 'pending');
       assertTargetState(2, 'pending');
 
       sharedClientState.removeLocalQueryTarget(1);
-      assertClientState([0, 2], null, null);
+      assertClientState([0, 2], BATCHID_UNKNOWN, BATCHID_UNKNOWN);
     });
 
     it('with a not-current target', () => {
       sharedClientState.addLocalQueryTarget(0);
-      assertClientState([0], null, null);
+      assertClientState([0], BATCHID_UNKNOWN, BATCHID_UNKNOWN);
       assertTargetState(0, 'pending');
       sharedClientState.trackQueryUpdate(0, 'not-current');
       assertTargetState(0, 'not-current');
@@ -391,7 +392,7 @@ describe('WebStorageSharedClientState', () => {
 
     it('with a current target', () => {
       sharedClientState.addLocalQueryTarget(0);
-      assertClientState([0], null, null);
+      assertClientState([0], BATCHID_UNKNOWN, BATCHID_UNKNOWN);
       assertTargetState(0, 'pending');
       sharedClientState.trackQueryUpdate(0, 'not-current');
       assertTargetState(0, 'not-current');
@@ -401,7 +402,7 @@ describe('WebStorageSharedClientState', () => {
 
     it('with an errored target', () => {
       sharedClientState.addLocalQueryTarget(0);
-      assertClientState([0], null, null);
+      assertClientState([0], BATCHID_UNKNOWN, BATCHID_UNKNOWN);
       assertTargetState(0, 'pending');
       sharedClientState.trackQueryUpdate(0, 'rejected', TEST_ERROR);
       assertTargetState(0, 'rejected', TEST_ERROR);


### PR DESCRIPTION
Not sure if this is an actual improvement, but this addressed the following TODO

// TODO(multitab): Return BATCHID_UNKNOWN instead of null