### PR TITLE
Remove mutation data from client state

### DIFF
--- a/packages/firestore/src/core/sync_engine.ts
+++ b/packages/firestore/src/core/sync_engine.ts
@@ -349,7 +349,7 @@ export class SyncEngine implements RemoteSyncer, SharedClientStateSyncer {
     return this.localStore
       .localWrite(batch)
       .then(result => {
-        this.sharedClientState.addLocalPendingMutation(result.batchId);
+        this.sharedClientState.addPendingMutation(result.batchId);
         this.addMutationCallback(result.batchId, userCallback);
         return this.emitNewSnapsAndNotifyLocalStore(result.changes);
       })
@@ -580,7 +580,6 @@ export class SyncEngine implements RemoteSyncer, SharedClientStateSyncer {
     } else if (batchState === 'acknowledged' || batchState === 'rejected') {
       // NOTE: Both these methods are no-ops for batches that originated from
       // other clients.
-      this.sharedClientState.removeLocalPendingMutation(batchId);
       this.processUserCallback(batchId, error ? error : null);
 
       this.localStore.removeCachedMutationBatchMetadata(batchId);
@@ -607,7 +606,6 @@ export class SyncEngine implements RemoteSyncer, SharedClientStateSyncer {
     return this.localStore
       .acknowledgeBatch(mutationBatchResult)
       .then(changes => {
-        this.sharedClientState.removeLocalPendingMutation(batchId);
         return this.emitNewSnapsAndNotifyLocalStore(changes);
       })
       .catch(err => this.ignoreIfPrimaryLeaseLoss(err));
@@ -626,7 +624,6 @@ export class SyncEngine implements RemoteSyncer, SharedClientStateSyncer {
       .rejectBatch(batchId)
       .then(changes => {
         this.sharedClientState.trackMutationResult(batchId, 'rejected', error);
-        this.sharedClientState.removeLocalPendingMutation(batchId);
         return this.emitNewSnapsAndNotifyLocalStore(changes);
       })
       .catch(err => this.ignoreIfPrimaryLeaseLoss(err));

--- a/packages/firestore/src/model/collections.ts
+++ b/packages/firestore/src/model/collections.ts
@@ -21,7 +21,7 @@ import { SortedSet } from '../util/sorted_set';
 import { Document, MaybeDocument } from './document';
 import { DocumentKey } from './document_key';
 import { primitiveComparator } from '../util/misc';
-import { BatchId, TargetId } from '../core/types';
+import { TargetId } from '../core/types';
 
 /** Miscellaneous collection types / constants. */
 
@@ -59,10 +59,4 @@ export type TargetIdSet = SortedSet<TargetId>;
 const EMPTY_TARGET_ID_SET = new SortedSet<TargetId>(primitiveComparator);
 export function targetIdSet(): SortedSet<TargetId> {
   return EMPTY_TARGET_ID_SET;
-}
-
-export type BatchIdSet = SortedSet<BatchId>;
-const EMPTY_BATCH_ID_SET = new SortedSet<BatchId>(primitiveComparator);
-export function batchIdSet(): SortedSet<BatchId> {
-  return EMPTY_BATCH_ID_SET;
 }

--- a/packages/firestore/test/integration/api/get_options.test.ts
+++ b/packages/firestore/test/integration/api/get_options.test.ts
@@ -566,16 +566,18 @@ apiDescribe('GetOptions', persistence => {
 
   it('get non existing doc while offline with source=server', () => {
     return withTestDocAndInitialData(persistence, null, docRef => {
-      return docRef.firestore
-        .disableNetwork()
-        // Attempt to get doc.  This will fail since there's nothing in cache.
-        .then(() => docRef.get({ source: 'server' }))
-        .then(
-          doc => {
-            expect.fail();
-          },
-          expected => {}
-        );
+      return (
+        docRef.firestore
+          .disableNetwork()
+          // Attempt to get doc.  This will fail since there's nothing in cache.
+          .then(() => docRef.get({ source: 'server' }))
+          .then(
+            doc => {
+              expect.fail();
+            },
+            expected => {}
+          )
+      );
     });
   });
 

--- a/packages/firestore/test/unit/local/persistence_test_helpers.ts
+++ b/packages/firestore/test/unit/local/persistence_test_helpers.ts
@@ -132,7 +132,7 @@ export async function populateWebStorage(
   await secondaryClientState.start();
 
   for (const batchId of existingMutationBatchIds) {
-    secondaryClientState.addLocalPendingMutation(batchId);
+    secondaryClientState.addPendingMutation(batchId);
   }
 
   for (const targetId of existingQueryTargetIds) {


### PR DESCRIPTION
This PR removes a bunch of code that was only ever used to save us from persisting a mutation state if no client is interested in it anymore. 