### PR TITLE
Garbage Collect the Remote Document Changelog

### DIFF
--- a/packages/firestore/src/local/indexeddb_persistence.ts
+++ b/packages/firestore/src/local/indexeddb_persistence.ts
@@ -57,6 +57,15 @@ const LOG_TAG = 'IndexedDbPersistence';
  * are ignored.
  */
 const CLIENT_METADATA_MAX_AGE_MS = 5000;
+
+/**
+ * Oldest acceptable age in milliseconds for client metadata before it and its
+ * associated data (such as the remote document cache changelog) can be
+ * garbage collected. Clients that exceed this threshold will not be able to
+ * replay Watch events that occurred before this threshold.
+ */
+const CLIENT_METADATA_GARBAGE_COLLECTION_THRESHOLD_MS = 30 * 60 * 1000; // 30 Minutes
+
 /**
  * The interval at which clients will update their metadata, including
  * refreshing their primary lease if held or potentially trying to acquire it if
@@ -183,11 +192,17 @@ export class IndexedDbPersistence implements Persistence {
   /** The client metadata refresh task. */
   private clientMetadataRefresher: CancelablePromise<void>;
 
+  /** The last time we garbage collected the Remote Document Changelog. */
+  private lastGarbageCollectionTime = Number.NEGATIVE_INFINITY;
+
   /** Whether to allow shared multi-tab access to the persistence layer. */
   private allowTabSynchronization: boolean;
 
   /** A listener to notify on primary state changes. */
   private primaryStateListener: PrimaryStateListener = _ => Promise.resolve();
+
+  private queryCache: IndexedDbQueryCache;
+  private remoteDocumentCache: IndexedDbRemoteDocumentCache;
 
   constructor(
     private readonly persistenceKey: string,
@@ -226,6 +241,11 @@ export class IndexedDbPersistence implements Persistence {
     return SimpleDb.openOrCreate(this.dbName, SCHEMA_VERSION, createOrUpgradeDb)
       .then(db => {
         this.simpleDb = db;
+        this.queryCache = new IndexedDbQueryCache(this.serializer);
+        this.remoteDocumentCache = new IndexedDbRemoteDocumentCache(
+          this.serializer,
+          /*keepDocumentChangeLog=*/ this.allowTabSynchronization
+        );
       })
       .then(() => {
         this.attachVisibilityHandler();
@@ -274,7 +294,8 @@ export class IndexedDbPersistence implements Persistence {
             this.clientId,
             Date.now(),
             this.networkEnabled,
-            this.inForeground
+            this.inForeground,
+            this.remoteDocumentCache.lastProcessedDocumentChangesId
           )
         )
         .next(() => this.canActAsPrimary(txn))
@@ -295,7 +316,9 @@ export class IndexedDbPersistence implements Persistence {
           if (wasPrimary && !this.isPrimary) {
             return this.releasePrimaryLeaseIfHeld(txn);
           } else if (this.isPrimary) {
-            return this.acquireOrExtendPrimaryLease(txn);
+            return this.acquireOrExtendPrimaryLease(txn).next(() =>
+              this.maybeGarbageCollectRemoteDocumentChangelog(txn)
+            );
           }
         });
     });
@@ -306,6 +329,59 @@ export class IndexedDbPersistence implements Persistence {
   ): PersistencePromise<void> {
     const metadataStore = clientMetadataStore(txn);
     return metadataStore.delete(this.clientId);
+  }
+
+  /**
+   * If the garbage collection threshold has passed, prunes the
+   * RemoteDocumentChanges store based on the metadata state of all existing
+   * clients.
+   */
+  // TODO(gsoltis): Execute this as part of LRU GC
+  private maybeGarbageCollectRemoteDocumentChangelog(
+    txn: SimpleDbTransaction
+  ): PersistencePromise<void> {
+    assert(this.isPrimary, 'GC should only run in the primary client');
+
+    if (
+      !this.isWithinAge(
+        this.lastGarbageCollectionTime,
+        CLIENT_METADATA_GARBAGE_COLLECTION_THRESHOLD_MS
+      )
+    ) {
+      this.lastGarbageCollectionTime = Date.now();
+
+      return clientMetadataStore(txn)
+        .loadAll()
+        .next(existingClients => {
+          let activeClients = this.filterActiveClients(
+            existingClients,
+            CLIENT_METADATA_GARBAGE_COLLECTION_THRESHOLD_MS
+          );
+
+          // The primary client doesn't read from the document change log,
+          // and hence we exclude it when we determine the minimum
+          // `lastProcessedDocumentChangesId`.
+          activeClients = activeClients.filter(
+            client => client.clientId !== this.clientId
+          );
+
+          if (activeClients.length) {
+            const mostOutdatedClient = activeClients.reduce(
+              (previousValue, currentValue) =>
+                (currentValue.lastProcessedDocumentChangesId || 0) <
+                (previousValue.lastProcessedDocumentChangesId || 0)
+                  ? currentValue
+                  : previousValue
+            );
+            return this.remoteDocumentCache.removeDocumentChangesThroughChangeId(
+              new IndexedDbTransaction(txn),
+              mostOutdatedClient.lastProcessedDocumentChangesId
+            );
+          }
+        });
+    } else {
+      return PersistencePromise.resolve();
+    }
   }
 
   /**
@@ -345,7 +421,10 @@ export class IndexedDbPersistence implements Persistence {
       .next(currentPrimary => {
         const currentLeaseIsValid =
           currentPrimary !== null &&
-          this.isWithinMaxAge(currentPrimary.leaseTimestampMs) &&
+          this.isWithinAge(
+            currentPrimary.leaseTimestampMs,
+            CLIENT_METADATA_MAX_AGE_MS
+          ) &&
           !this.isClientZombied(currentPrimary.ownerId);
 
         // A client is eligible for the primary lease if:
@@ -389,31 +468,34 @@ export class IndexedDbPersistence implements Persistence {
           return true;
         }
 
-        let canActAsPrimary = true;
         return clientMetadataStore(txn)
-          .iterate((key, otherClient, control) => {
-            if (
-              this.clientId !== otherClient.clientId &&
-              this.isWithinMaxAge(otherClient.updateTimeMs) &&
-              !this.isClientZombied(otherClient.clientId)
-            ) {
-              const otherClientHasBetterNetworkState =
-                !this.networkEnabled && otherClient.networkEnabled;
-              const otherClientHasBetterVisibility =
-                !this.inForeground && otherClient.inForeground;
-              const otherClientHasSameNetworkState =
-                this.networkEnabled === otherClient.networkEnabled;
-              if (
-                otherClientHasBetterNetworkState ||
-                (otherClientHasBetterVisibility &&
-                  otherClientHasSameNetworkState)
-              ) {
-                canActAsPrimary = false;
-                control.done();
+          .loadAll()
+          .next(existingClients => {
+            // Process all existing clients and determine whether at least one of
+            // them is better suited to obtain the primary lease.
+            const preferredCandidate = this.filterActiveClients(
+              existingClients,
+              CLIENT_METADATA_MAX_AGE_MS
+            ).find(otherClient => {
+              if (this.clientId !== otherClient.clientId) {
+                const otherClientHasBetterNetworkState =
+                  !this.networkEnabled && otherClient.networkEnabled;
+                const otherClientHasBetterVisibility =
+                  !this.inForeground && otherClient.inForeground;
+                const otherClientHasSameNetworkState =
+                  this.networkEnabled === otherClient.networkEnabled;
+                if (
+                  otherClientHasBetterNetworkState ||
+                  (otherClientHasBetterVisibility &&
+                    otherClientHasSameNetworkState)
+                ) {
+                  return true;
+                }
               }
-            }
-          })
-          .next(() => canActAsPrimary);
+              return false;
+            });
+            return preferredCandidate === undefined;
+          });
       })
       .next(canActAsPrimary => {
         if (this.isPrimary !== canActAsPrimary) {
@@ -458,17 +540,35 @@ export class IndexedDbPersistence implements Persistence {
     }
   }
 
+  /**
+   * Returns clients that are not zombied and have an updateTime within the
+   * provided threshold.
+   */
+  private filterActiveClients(
+    clients: DbClientMetadata[],
+    activityThresholdMs: number
+  ): DbClientMetadata[] {
+    return clients.filter(
+      client =>
+        this.isWithinAge(client.updateTimeMs, activityThresholdMs) &&
+        !this.isClientZombied(client.clientId)
+    );
+  }
+
   getActiveClients(): Promise<ClientId[]> {
-    const clientIds: ClientId[] = [];
-    return this.simpleDb
-      .runTransaction('readonly', [DbClientMetadata.store], txn => {
-        return clientMetadataStore(txn).iterate((key, value) => {
-          if (this.isWithinMaxAge(value.updateTimeMs)) {
-            clientIds.push(value.clientId);
-          }
-        });
-      })
-      .then(() => clientIds);
+    return this.simpleDb.runTransaction(
+      'readonly',
+      [DbClientMetadata.store],
+      txn => {
+        return clientMetadataStore(txn)
+          .loadAll()
+          .next(clients =>
+            this.filterActiveClients(clients, CLIENT_METADATA_MAX_AGE_MS).map(
+              clientMetadata => clientMetadata.clientId
+            )
+          );
+      }
+    );
   }
 
   get started(): boolean {
@@ -488,7 +588,7 @@ export class IndexedDbPersistence implements Persistence {
       this.started,
       'Cannot initialize QueryCache before persistence is started.'
     );
-    return new IndexedDbQueryCache(this.serializer);
+    return this.queryCache;
   }
 
   getRemoteDocumentCache(): RemoteDocumentCache {
@@ -496,10 +596,7 @@ export class IndexedDbPersistence implements Persistence {
       this.started,
       'Cannot initialize RemoteDocumentCache before persistence is started.'
     );
-    return new IndexedDbRemoteDocumentCache(
-      this.serializer,
-      /*keepDocumentChangeLog=*/ this.allowTabSynchronization
-    );
+    return this.remoteDocumentCache;
   }
 
   runTransaction<T>(
@@ -575,7 +672,10 @@ export class IndexedDbPersistence implements Persistence {
     return store.get(DbPrimaryClient.key).next(currentPrimary => {
       const currentLeaseIsValid =
         currentPrimary !== null &&
-        this.isWithinMaxAge(currentPrimary.leaseTimestampMs) &&
+        this.isWithinAge(
+          currentPrimary.leaseTimestampMs,
+          CLIENT_METADATA_MAX_AGE_MS
+        ) &&
         !this.isClientZombied(currentPrimary.ownerId);
 
       if (currentLeaseIsValid && !this.isLocalClient(currentPrimary)) {
@@ -643,10 +743,10 @@ export class IndexedDbPersistence implements Persistence {
     });
   }
 
-  /** Verifies that `updateTimeMs` is within CLIENT_STATE_MAX_AGE_MS. */
-  private isWithinMaxAge(updateTimeMs: number): boolean {
+  /** Verifies that `updateTimeMs` is within `maxAgeMs`. */
+  private isWithinAge(updateTimeMs: number, maxAgeMs: number): boolean {
     const now = Date.now();
-    const minAcceptable = now - CLIENT_METADATA_MAX_AGE_MS;
+    const minAcceptable = now - maxAgeMs;
     const maxAcceptable = now;
     if (updateTimeMs < minAcceptable) {
       return false;

--- a/packages/firestore/src/local/indexeddb_schema.ts
+++ b/packages/firestore/src/local/indexeddb_schema.ts
@@ -681,7 +681,12 @@ export class DbClientMetadata {
     /** Whether the client's network connection is enabled. */
     public networkEnabled: boolean,
     /** Whether this client is running in a foreground tab. */
-    public inForeground: boolean
+    public inForeground: boolean,
+    /**
+     * The last change read from the DbRemoteDocumentChanges store.
+     * Can be undefined for backwards compatibility.
+     */
+    public lastProcessedDocumentChangesId: number | undefined
   ) {}
 }
 

--- a/packages/firestore/src/local/indexeddb_schema.ts
+++ b/packages/firestore/src/local/indexeddb_schema.ts
@@ -686,7 +686,7 @@ export class DbClientMetadata {
      * The last change read from the DbRemoteDocumentChanges store.
      * Can be undefined for backwards compatibility.
      */
-    public lastProcessedDocumentChangesId: number | undefined
+    public lastProcessedDocumentChangeId: number | undefined
   ) {}
 }
 

--- a/packages/firestore/test/unit/local/persistence_test_helpers.ts
+++ b/packages/firestore/test/unit/local/persistence_test_helpers.ts
@@ -51,12 +51,17 @@ const LOCAL_STORAGE_PREFIX = 'firestore_';
  * any previous contents if they existed.
  */
 export async function testIndexedDbPersistence(
-  synchronizeTabs?: boolean
+  options: {
+    dontPurgeData?: boolean;
+    synchronizeTabs?: boolean;
+  } = {}
 ): Promise<IndexedDbPersistence> {
   const queue = new AsyncQueue();
   const clientId = AutoId.newId();
   const prefix = `${TEST_PERSISTENCE_PREFIX}/`;
-  await SimpleDb.delete(prefix + IndexedDbPersistence.MAIN_DATABASE);
+  if (!options.dontPurgeData) {
+    await SimpleDb.delete(prefix + IndexedDbPersistence.MAIN_DATABASE);
+  }
   const partition = new DatabaseId('project');
   const serializer = new JsonProtoSerializer(partition, {
     useProto3Json: true
@@ -69,7 +74,7 @@ export async function testIndexedDbPersistence(
     queue,
     serializer
   );
-  await persistence.start(synchronizeTabs);
+  await persistence.start(options.synchronizeTabs);
   return persistence;
 }
 

--- a/packages/firestore/test/unit/local/remote_document_cache.test.ts
+++ b/packages/firestore/test/unit/local/remote_document_cache.test.ts
@@ -31,9 +31,24 @@ import {
 import * as persistenceHelpers from './persistence_test_helpers';
 import { TestRemoteDocumentCache } from './test_remote_document_cache';
 import { MaybeDocumentMap } from '../../../src/model/collections';
+import { IndexedDbRemoteDocumentCache } from '../../../src/local/indexeddb_remote_document_cache';
+
+// Helpers for use throughout tests.
+const DOC_PATH = 'a/b';
+const LONG_DOC_PATH = 'a/b/c/d/e/f';
+const DOC_DATA = { a: 1, b: 2 };
+const VERSION = 42;
+
+let persistence: Persistence;
 
 describe('MemoryRemoteDocumentCache', () => {
-  genericRemoteDocumentCacheTests(persistenceHelpers.testMemoryPersistence);
+  beforeEach(async () => {
+    persistence = await persistenceHelpers.testMemoryPersistence();
+  });
+
+  afterEach(() => persistence.shutdown(/* deleteData= */ true));
+
+  genericRemoteDocumentCacheTests();
 });
 
 describe('IndexedDbRemoteDocumentCache', () => {
@@ -42,25 +57,55 @@ describe('IndexedDbRemoteDocumentCache', () => {
     return;
   }
 
-  genericRemoteDocumentCacheTests(() =>
-    persistenceHelpers.testIndexedDbPersistence(/* synchronizeTabs= */ true)
-  );
+  beforeEach(async () => {
+    persistence = await persistenceHelpers.testIndexedDbPersistence({
+      synchronizeTabs: true
+    });
+  });
+
+  afterEach(() => persistence.shutdown(/* deleteData= */ true));
+
+  it('can prune change log', async () => {
+    // Add two change batches and remove the first one.
+    await persistence.runTransaction(
+      'removeDocumentChangesThroughChangeId',
+      true,
+      txn => {
+        const cache = persistence.getRemoteDocumentCache() as IndexedDbRemoteDocumentCache;
+        return cache
+          .addEntries(txn, [doc('a/1', 1, DOC_DATA), doc('b/1', 2, DOC_DATA)])
+          .next(() => cache.getNewDocumentChanges(txn))
+          .next(() => cache.addEntries(txn, [doc('c/1', 3, DOC_DATA)]))
+          .next(() => cache.removeDocumentChangesThroughChangeId(txn, 1));
+      }
+    );
+    await persistence.shutdown(/* deleteData= */ false);
+
+    // Now make sure that we can only read back the second batch.
+    persistence = await persistenceHelpers.testIndexedDbPersistence({
+      synchronizeTabs: true,
+      dontPurgeData: true
+    });
+    const changedDocs = await persistence.runTransaction(
+      'getNewDocumentChanges',
+      false,
+      txn => {
+        const cache = persistence.getRemoteDocumentCache();
+        return cache.getNewDocumentChanges(txn);
+      }
+    );
+
+    assertMatches([doc('c/1', 3, DOC_DATA)], changedDocs);
+  });
+
+  genericRemoteDocumentCacheTests();
 });
 
 /**
  * Defines the set of tests to run against both remote document cache
  * implementations.
  */
-function genericRemoteDocumentCacheTests(
-  persistencePromise: () => Promise<Persistence>
-): void {
-  // Helpers for use throughout tests.
-  const DOC_PATH = 'a/b';
-  const LONG_DOC_PATH = 'a/b/c/d/e/f';
-  const DOC_DATA = { a: 1, b: 2 };
-  const VERSION = 42;
-
-  let persistence: Persistence;
+function genericRemoteDocumentCacheTests(): void {
   let cache: TestRemoteDocumentCache;
 
   function setAndReadDocument(doc: MaybeDocument): Promise<void> {
@@ -74,33 +119,12 @@ function genericRemoteDocumentCacheTests(
       });
   }
 
-  function assertMatches(
-    expected: MaybeDocument[],
-    actual: MaybeDocumentMap
-  ): void {
-    expect(actual.size).to.equal(expected.length);
-    actual.forEach((actualKey, actualDoc) => {
-      const found = expected.find(expectedDoc => {
-        if (actualKey.isEqual(expectedDoc.key)) {
-          expectEqual(actualDoc, expectedDoc);
-          return true;
-        }
-        return false;
-      });
-
-      expect(found).to.not.be.undefined;
-    });
-  }
-
-  beforeEach(async () => {
-    persistence = await persistencePromise();
+  beforeEach(() => {
     cache = new TestRemoteDocumentCache(
       persistence,
       persistence.getRemoteDocumentCache()
     );
   });
-
-  afterEach(() => persistence.shutdown(/* deleteData= */ true));
 
   it('returns null for document not in cache', () => {
     return cache.getEntry(key(DOC_PATH)).then(doc => {
@@ -214,5 +238,23 @@ function genericRemoteDocumentCacheTests(
 
     const changedDocs = await cache.getNextDocumentChanges();
     assertMatches([], changedDocs);
+  });
+}
+
+function assertMatches(
+  expected: MaybeDocument[],
+  actual: MaybeDocumentMap
+): void {
+  expect(actual.size).to.equal(expected.length);
+  actual.forEach((actualKey, actualDoc) => {
+    const found = expected.find(expectedDoc => {
+      if (actualKey.isEqual(expectedDoc.key)) {
+        expectEqual(actualDoc, expectedDoc);
+        return true;
+      }
+      return false;
+    });
+
+    expect(found).to.not.be.undefined;
   });
 }

--- a/packages/firestore/test/unit/local/remote_document_cache.test.ts
+++ b/packages/firestore/test/unit/local/remote_document_cache.test.ts
@@ -74,7 +74,6 @@ describe('IndexedDbRemoteDocumentCache', () => {
         const cache = persistence.getRemoteDocumentCache() as IndexedDbRemoteDocumentCache;
         return cache
           .addEntries(txn, [doc('a/1', 1, DOC_DATA), doc('b/1', 2, DOC_DATA)])
-          .next(() => cache.getNewDocumentChanges(txn))
           .next(() => cache.addEntries(txn, [doc('c/1', 3, DOC_DATA)]))
           .next(() => cache.removeDocumentChangesThroughChangeId(txn, 1));
       }
@@ -86,6 +85,10 @@ describe('IndexedDbRemoteDocumentCache', () => {
       synchronizeTabs: true,
       dontPurgeData: true
     });
+
+    // Note that we don't call `start()` on the RemoteDocumentCache. If we did,
+    // the cache would only replay changes that were added after invoking
+    // start().
     const changedDocs = await persistence.runTransaction(
       'getNewDocumentChanges',
       false,
@@ -255,6 +258,6 @@ function assertMatches(
       return false;
     });
 
-    expect(found).to.not.be.undefined;
+    expect(found).to.exist;
   });
 }


### PR DESCRIPTION
This PR adds garbage collection of the Remote Document Change Log. Right now, this runs as part of the client metadata refresh, but I added a TODO for Greg to move it to the LRU callsite once it exists.

I only run the GC code every 30 minutes since it requires a read of all client metadata. 

I tried to unify some code which made `canActAsPrimary` slightly less efficient and this can be reverted.

This code is not well tested (and could potentially be better tested if I added a TimerId for it and scheduled it separately), but I did confirm that Chrome runs this code after 30 minutes (and at startup).