### PR TITLE
GRPC Tweaks.

### DIFF
--- a/packages/firestore/src/platform_node/grpc_connection.ts
+++ b/packages/firestore/src/platform_node/grpc_connection.ts
@@ -265,18 +265,12 @@ export class GrpcConnection implements Connection {
     });
 
     log.debug(LOG_TAG, 'Opening GRPC stream');
-
-    // TODO(mikelehen): We will call waitForReady() on each stream attempt,
-    // but waitForReady() won't call our callback until the channel is
-    // successfully established (note that the callback is not called for most
-    // stream errors). So we'll accumulate more and more outstanding wait calls
-    // over time while the network is down, manifesting as a minor memory leak.
-    const client: grpc.Client = this.ensureActiveStub(token);
-    client.waitForReady(/*deadline=*/ Number.POSITIVE_INFINITY, error => {
-      if (!error && !closed) {
-        stream.callOnOpen();
-      }
-    });
+    // TODO(dimond): Since grpc has no explicit open status (or does it?) we
+    // simulate an onOpen in the next loop after the stream had it's listeners
+    // registered
+    setTimeout(() => {
+      stream.callOnOpen();
+    }, 0);
 
     return stream;
   }


### PR DESCRIPTION
* Use Client.waitForReady() to determine when the stream is actually open,
  rather than just considering it open right away.
* Don't lowercase RPC names because the gRPC stub supports both now.
* Remove event handlers / asserts that have been proven safe / unnecessary.
