### PR TITLE
Stop starting the remote document cache

### DIFF
--- a/packages/firestore/src/core/firestore_client.ts
+++ b/packages/firestore/src/core/firestore_client.ts
@@ -307,7 +307,8 @@ export class FirestoreClient {
         this.clientId,
         this.platform,
         this.asyncQueue,
-        serializer
+        serializer,
+        settings.experimentalTabSynchronization
       );
       this.persistence = persistence;
 
@@ -330,7 +331,7 @@ export class FirestoreClient {
             user
           )
         : new MemorySharedClientState();
-      return persistence.start(settings.experimentalTabSynchronization);
+      return persistence.start();
     });
   }
 

--- a/packages/firestore/src/local/indexeddb_persistence.ts
+++ b/packages/firestore/src/local/indexeddb_persistence.ts
@@ -210,13 +210,13 @@ export class IndexedDbPersistence implements Persistence {
     platform: Platform,
     private readonly queue: AsyncQueue,
     serializer: JsonProtoSerializer,
-    synchronizeTabs?: boolean
+    synchronizeTabs: boolean
   ) {
     this.dbName = persistenceKey + IndexedDbPersistence.MAIN_DATABASE;
     this.serializer = new LocalSerializer(serializer);
     this.document = platform.document;
     this.window = platform.window;
-    this.allowTabSynchronization = !!synchronizeTabs;
+    this.allowTabSynchronization = synchronizeTabs;
     this.queryCache = new IndexedDbQueryCache(this.serializer);
     this.remoteDocumentCache = new IndexedDbRemoteDocumentCache(
       this.serializer,
@@ -245,6 +245,7 @@ export class IndexedDbPersistence implements Persistence {
       .then(db => {
         this.simpleDb = db;
       })
+      .then(() => this.startRemoteDocumentCache())
       .then(() => {
         this.attachVisibilityHandler();
         this.attachWindowUnloadHook();
@@ -252,7 +253,6 @@ export class IndexedDbPersistence implements Persistence {
           this.scheduleClientMetadataAndPrimaryLeaseRefreshes()
         );
       })
-      .then(() => this.startRemoteDocumentCache())
       .then(() => {
         this._started = true;
       });

--- a/packages/firestore/src/local/indexeddb_persistence.ts
+++ b/packages/firestore/src/local/indexeddb_persistence.ts
@@ -209,22 +209,27 @@ export class IndexedDbPersistence implements Persistence {
     private readonly clientId: ClientId,
     platform: Platform,
     private readonly queue: AsyncQueue,
-    serializer: JsonProtoSerializer
+    serializer: JsonProtoSerializer,
+    synchronizeTabs?: boolean
   ) {
     this.dbName = persistenceKey + IndexedDbPersistence.MAIN_DATABASE;
     this.serializer = new LocalSerializer(serializer);
     this.document = platform.document;
     this.window = platform.window;
+    this.allowTabSynchronization = !!synchronizeTabs;
+    this.queryCache = new IndexedDbQueryCache(this.serializer);
+    this.remoteDocumentCache = new IndexedDbRemoteDocumentCache(
+      this.serializer,
+      /*keepDocumentChangeLog=*/ this.allowTabSynchronization
+    );
   }
 
   /**
    * Attempt to start IndexedDb persistence.
    *
-   * @param {boolean} synchronizeTabs Whether to enable shared persistence
-   *     across multiple tabs.
    * @return {Promise<void>} Whether persistence was enabled.
    */
-  start(synchronizeTabs?: boolean): Promise<void> {
+  start(): Promise<void> {
     if (!IndexedDbPersistence.isAvailable()) {
       this.persistenceError = new FirestoreError(
         Code.UNIMPLEMENTED,
@@ -234,18 +239,11 @@ export class IndexedDbPersistence implements Persistence {
     }
 
     assert(!this.started, 'IndexedDbPersistence double-started!');
-    this.allowTabSynchronization = !!synchronizeTabs;
-
     assert(this.window !== null, "Expected 'window' to be defined");
 
     return SimpleDb.openOrCreate(this.dbName, SCHEMA_VERSION, createOrUpgradeDb)
       .then(db => {
         this.simpleDb = db;
-        this.queryCache = new IndexedDbQueryCache(this.serializer);
-        this.remoteDocumentCache = new IndexedDbRemoteDocumentCache(
-          this.serializer,
-          /*keepDocumentChangeLog=*/ this.allowTabSynchronization
-        );
       })
       .then(() => {
         this.attachVisibilityHandler();
@@ -254,9 +252,16 @@ export class IndexedDbPersistence implements Persistence {
           this.scheduleClientMetadataAndPrimaryLeaseRefreshes()
         );
       })
+      .then(() => this.startRemoteDocumentCache())
       .then(() => {
         this._started = true;
       });
+  }
+
+  private startRemoteDocumentCache(): Promise<void> {
+    return this.simpleDb.runTransaction('readonly', ALL_STORES, txn =>
+      this.remoteDocumentCache.start(txn)
+    );
   }
 
   setPrimaryStateListener(

--- a/packages/firestore/src/local/local_store.ts
+++ b/packages/firestore/src/local/local_store.ts
@@ -203,11 +203,9 @@ export class LocalStore {
   /** Performs any initial startup actions required by the local store. */
   start(): Promise<void> {
     // TODO(multitab): Ensure that we in fact don't need the primary lease.
-    return this.persistence.runTransaction('Start LocalStore', false, txn => {
-      return this.startMutationQueue(txn).next(() =>
-        this.startRemoteDocumentCache(txn)
-      );
-    });
+    return this.persistence.runTransaction('Start LocalStore', false, txn =>
+      this.startMutationQueue(txn)
+    );
   }
 
   /**
@@ -310,12 +308,6 @@ export class LocalStore {
           return PersistencePromise.resolve();
         }
       });
-  }
-
-  private startRemoteDocumentCache(
-    txn: PersistenceTransaction
-  ): PersistencePromise<void> {
-    return this.remoteDocuments.start(txn);
   }
 
   /* Accept locally generated Mutations and commit them to storage. */

--- a/packages/firestore/src/local/remote_document_cache.ts
+++ b/packages/firestore/src/local/remote_document_cache.ts
@@ -32,16 +32,6 @@ import { PersistencePromise } from './persistence_promise';
  */
 export interface RemoteDocumentCache {
   /**
-   * Starts up the remote document cache.
-   *
-   * Reads the ID of the last  document change from the documentChanges store.
-   * Existing changes will not be returned as part of
-   * `getNewDocumentChanges()`.
-   */
-  // PORTING NOTE: This is only used for multi-tab synchronization.
-  start(transaction: PersistenceTransaction): PersistencePromise<void>;
-
-  /**
    * Adds or replaces document entries in the cache.
    *
    * The cache key is extracted from `maybeDocument.key`. If there is already a

--- a/packages/firestore/test/unit/local/indexeddb_persistence.test.ts
+++ b/packages/firestore/test/unit/local/indexeddb_persistence.test.ts
@@ -125,7 +125,7 @@ async function withPersistence(
   );
 }
 
-async function withMultiTabPersistence(
+async function withMultiClientPersistence(
   clientId: ClientId,
   fn: (
     persistence: IndexedDbPersistence,
@@ -472,9 +472,9 @@ describe('IndexedDb: allowTabSynchronization', () => {
   });
 
   it('grants access when synchronization is enabled', async () => {
-    return withMultiTabPersistence('clientA', async db1 => {
+    return withMultiClientPersistence('clientA', async db1 => {
       await db1.start();
-      await withMultiTabPersistence('clientB', async db2 => {
+      await withMultiClientPersistence('clientB', async db2 => {
         await db2.start();
       });
     });

--- a/packages/firestore/test/unit/local/indexeddb_persistence.test.ts
+++ b/packages/firestore/test/unit/local/indexeddb_persistence.test.ts
@@ -41,6 +41,7 @@ import { PlatformSupport } from '../../../src/platform/platform';
 import { AsyncQueue } from '../../../src/util/async_queue';
 import { SharedFakeWebStorage, TestPlatform } from '../../util/test_platform';
 import { SnapshotVersion } from '../../../src/core/snapshot_version';
+import { PersistenceSettings } from '../../../src/api/database';
 
 const INDEXEDDB_TEST_DATABASE_PREFIX = 'schemaTest/';
 const INDEXEDDB_TEST_DATABASE =
@@ -77,8 +78,9 @@ function withDb(
     });
 }
 
-async function withPersistence(
+async function withConfiguredPersistence(
   clientId: ClientId,
+  settings: PersistenceSettings,
   fn: (
     persistence: IndexedDbPersistence,
     platform: TestPlatform,
@@ -100,11 +102,38 @@ async function withPersistence(
     clientId,
     platform,
     queue,
-    serializer
+    serializer,
+    settings.experimentalTabSynchronization
   );
 
   await fn(persistence, platform, queue);
   await persistence.shutdown();
+}
+
+async function withPersistence(
+  clientId: ClientId,
+  fn: (
+    persistence: IndexedDbPersistence,
+    platform: TestPlatform,
+    queue: AsyncQueue
+  ) => Promise<void>
+): Promise<void> {
+  return withConfiguredPersistence(clientId, new PersistenceSettings(true), fn);
+}
+
+async function withMultiTabPersistence(
+  clientId: ClientId,
+  fn: (
+    persistence: IndexedDbPersistence,
+    platform: TestPlatform,
+    queue: AsyncQueue
+  ) => Promise<void>
+): Promise<void> {
+  return withConfiguredPersistence(
+    clientId,
+    new PersistenceSettings(true, { experimentalTabSynchronization: true }),
+    fn
+  );
 }
 
 function getAllObjectStores(db: IDBDatabase): string[] {
@@ -427,11 +456,9 @@ describe('IndexedDb: allowTabSynchronization', () => {
 
   it('rejects access when synchronization is disabled', () => {
     return withPersistence('clientA', async db1 => {
-      await db1.start(/*synchronizeTabs=*/ false);
+      await db1.start();
       await withPersistence('clientB', async db2 => {
-        await expect(
-          db2.start(/*synchronizeTabs=*/ false)
-        ).to.eventually.be.rejectedWith(
+        await expect(db2.start()).to.eventually.be.rejectedWith(
           'There is another tab open with offline persistence enabled.'
         );
       });
@@ -439,10 +466,10 @@ describe('IndexedDb: allowTabSynchronization', () => {
   });
 
   it('grants access when synchronization is enabled', async () => {
-    return withPersistence('clientA', async db1 => {
-      await db1.start(/*synchronizeTabs=*/ true);
-      await withPersistence('clientB', async db2 => {
-        await db2.start(/*synchronizeTabs=*/ true);
+    return withMultiTabPersistence('clientA', async db1 => {
+      await db1.start();
+      await withMultiTabPersistence('clientB', async db2 => {
+        await db2.start();
       });
     });
   });

--- a/packages/firestore/test/unit/local/indexeddb_persistence.test.ts
+++ b/packages/firestore/test/unit/local/indexeddb_persistence.test.ts
@@ -78,7 +78,7 @@ function withDb(
     });
 }
 
-async function withConfiguredPersistence(
+async function withCustomPersistence(
   clientId: ClientId,
   settings: PersistenceSettings,
   fn: (
@@ -118,7 +118,11 @@ async function withPersistence(
     queue: AsyncQueue
   ) => Promise<void>
 ): Promise<void> {
-  return withConfiguredPersistence(clientId, new PersistenceSettings(true), fn);
+  return withCustomPersistence(
+    clientId,
+    new PersistenceSettings(/* enabled */ true),
+    fn
+  );
 }
 
 async function withMultiTabPersistence(
@@ -129,9 +133,11 @@ async function withMultiTabPersistence(
     queue: AsyncQueue
   ) => Promise<void>
 ): Promise<void> {
-  return withConfiguredPersistence(
+  return withCustomPersistence(
     clientId,
-    new PersistenceSettings(true, { experimentalTabSynchronization: true }),
+    new PersistenceSettings(/* enabled */ true, {
+      experimentalTabSynchronization: true
+    }),
     fn
   );
 }

--- a/packages/firestore/test/unit/local/persistence_test_helpers.ts
+++ b/packages/firestore/test/unit/local/persistence_test_helpers.ts
@@ -72,9 +72,10 @@ export async function testIndexedDbPersistence(
     clientId,
     platform,
     queue,
-    serializer
+    serializer,
+    options.synchronizeTabs
   );
-  await persistence.start(options.synchronizeTabs);
+  await persistence.start();
   return persistence;
 }
 

--- a/packages/firestore/test/unit/local/test_remote_document_cache.ts
+++ b/packages/firestore/test/unit/local/test_remote_document_cache.ts
@@ -31,12 +31,6 @@ export class TestRemoteDocumentCache {
     public cache: RemoteDocumentCache
   ) {}
 
-  start(): Promise<void> {
-    return this.persistence.runTransaction('start', false, txn => {
-      return this.cache.start(txn);
-    });
-  }
-
   addEntries(maybeDocuments: MaybeDocument[]): Promise<void> {
     return this.persistence.runTransaction('addEntry', true, txn => {
       return this.cache.addEntries(txn, maybeDocuments);

--- a/packages/firestore/test/unit/specs/spec_test_runner.ts
+++ b/packages/firestore/test/unit/specs/spec_test_runner.ts
@@ -1184,9 +1184,10 @@ class IndexedDbTestRunner extends TestRunner {
       this.clientId,
       this.platform,
       this.queue,
-      serializer
+      serializer,
+      /*synchronizeTabs=*/ true
     );
-    await persistence.start(/*synchronizeTabs=*/ true);
+    await persistence.start();
     return persistence;
   }
 


### PR DESCRIPTION
Remove `start()` from the `RemoteDocumentCache` interface. The memory implementation was a no-op, and `IndexedDbPersistence` can guarantee an already-started `IndexedDbRemoteDocumentCache` instance after it has been started itself.

Additionally, move the specification of multi-tab support to the `IndexedDbPersistence` constructor.