### PR TITLE
Update Firestore changelog for token change fix (4ec654d).

### DIFF
--- a/packages/firestore/CHANGELOG.md
+++ b/packages/firestore/CHANGELOG.md
@@ -1,8 +1,3 @@
-# Unreleased
-- [fixed] Fixed an issue where changes to custom authentication claims did not
-  take effect until you did a full sign-out and sign-in.
-  (firebase/firebase-ios-sdk#1499)
-
 # 0.7.0 (Unreleased)
 - [fixed] Fixed `get({source: 'cache'})` to be able to return nonexistent
   documents from cache.
@@ -10,6 +5,9 @@
   tabs. While this feature is not yet available, all schema changes are included
   in this release. Once you upgrade, you will not be able to use an older version
   of the Firestore SDK with persistence enabled.
+- [fixed] Fixed an issue where changes to custom authentication claims did not
+  take effect until you did a full sign-out and sign-in.
+  (firebase/firebase-ios-sdk#1499)
 
 # 0.6.1
 - [changed] Improved how Firestore handles idle queries to reduce the cost of

--- a/packages/firestore/CHANGELOG.md
+++ b/packages/firestore/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Unreleased
+- [fixed] Fixed an issue where changes to custom authentication claims did not
+  take effect until you did a full sign-out and sign-in.
+  (firebase/firebase-ios-sdk#1499)
+
 # 0.7.0 (Unreleased)
 - [fixed] Fixed `get({source: 'cache'})` to be able to return nonexistent
   documents from cache.


### PR DESCRIPTION
Hey Josh, can you confirm that this change I checked in earlier today (4ec654d) will _not_ be included in this week's release?  (if it will be I'll move it to the "0.7.0" section)