### PR TITLE
Stop saving persistence layer across spec tests

### DIFF
--- a/packages/firestore/test/unit/specs/describe_spec.ts
+++ b/packages/firestore/test/unit/specs/describe_spec.ts
@@ -80,7 +80,10 @@ export function setSpecJSONHandler(writer: (json: string) => void): void {
 function getTestRunner(tags, persistenceEnabled): Function {
   if (tags.indexOf(NO_WEB_TAG) >= 0) {
     return it.skip;
-  } else if (!persistenceEnabled && tags.indexOf(NO_MEMORY_PERSISTENCE) !== -1) {
+  } else if (
+    !persistenceEnabled &&
+    tags.indexOf(NO_MEMORY_PERSISTENCE) !== -1
+  ) {
     // Test requires actual persistence, but it's not enabled. Skip it.
     return it.skip;
   } else if (persistenceEnabled && tags.indexOf(NO_LRU_TAG) !== -1) {

--- a/packages/firestore/test/unit/specs/describe_spec.ts
+++ b/packages/firestore/test/unit/specs/describe_spec.ts
@@ -24,20 +24,25 @@ import { SpecStep } from './spec_test_runner';
 // Disables all other tests; useful for debugging. Multiple tests can have
 // this tag and they'll all be run (but all others won't).
 const EXCLUSIVE_TAG = 'exclusive';
+// Explicit per-platform disable flags.
+const NO_WEB_TAG = 'no-web';
+const NO_ANDROID_TAG = 'no-android';
+const NO_IOS_TAG = 'no-ios';
 // The remaining tags specify features that must be present to run a given test
 // Multi-client related tests (which imply persistence).
 const MULTI_CLIENT_TAG = 'multi-client';
 const EAGER_GC_TAG = 'eager-gc';
 const DURABLE_PERSISTENCE_TAG = 'durable-persistence';
 const BENCHMARK_TAG = 'benchmark';
-const JAVASCRIPT_TAG = 'javascript';
 const KNOWN_TAGS = [
   BENCHMARK_TAG,
   EXCLUSIVE_TAG,
   MULTI_CLIENT_TAG,
+  NO_WEB_TAG,
+  NO_ANDROID_TAG,
+  NO_IOS_TAG,
   EAGER_GC_TAG,
-  DURABLE_PERSISTENCE_TAG,
-  JAVASCRIPT_TAG
+  DURABLE_PERSISTENCE_TAG
 ];
 
 // TOOD(mrschmidt): Make this configurable with mocha options.
@@ -74,7 +79,9 @@ export function setSpecJSONHandler(writer: (json: string) => void): void {
 
 /** Gets the test runner based on the specified tags. */
 function getTestRunner(tags, persistenceEnabled): Function {
-  if (!persistenceEnabled && tags.indexOf(DURABLE_PERSISTENCE_TAG) !== -1) {
+  if (tags.indexOf(NO_WEB_TAG) >= 0) {
+    return it.skip;
+  } else if (!persistenceEnabled && tags.indexOf(DURABLE_PERSISTENCE_TAG) !== -1) {
     // Test requires actual persistence, but it's not enabled. Skip it.
     return it.skip;
   } else if (persistenceEnabled && tags.indexOf(EAGER_GC_TAG) !== -1) {

--- a/packages/firestore/test/unit/specs/describe_spec.ts
+++ b/packages/firestore/test/unit/specs/describe_spec.ts
@@ -37,7 +37,7 @@ const KNOWN_TAGS = [
   MULTI_CLIENT_TAG,
   EAGER_GC_TAG,
   DURABLE_PERSISTENCE_TAG,
-  JAVASCRIPT_TAG,
+  JAVASCRIPT_TAG
 ];
 
 // TOOD(mrschmidt): Make this configurable with mocha options.
@@ -74,10 +74,7 @@ export function setSpecJSONHandler(writer: (json: string) => void): void {
 
 /** Gets the test runner based on the specified tags. */
 function getTestRunner(tags, persistenceEnabled): Function {
-  if (
-    !persistenceEnabled &&
-    tags.indexOf(DURABLE_PERSISTENCE_TAG) !== -1
-  ) {
+  if (!persistenceEnabled && tags.indexOf(DURABLE_PERSISTENCE_TAG) !== -1) {
     // Test requires actual persistence, but it's not enabled. Skip it.
     return it.skip;
   } else if (persistenceEnabled && tags.indexOf(EAGER_GC_TAG) !== -1) {

--- a/packages/firestore/test/unit/specs/describe_spec.ts
+++ b/packages/firestore/test/unit/specs/describe_spec.ts
@@ -31,6 +31,7 @@ const NO_WEB_TAG = 'no-web';
 const NO_ANDROID_TAG = 'no-android';
 const NO_IOS_TAG = 'no-ios';
 const NO_LRU_TAG = 'no-lru';
+const NO_MEMORY_PERSISTENCE = 'no-memory-persistence';
 const BENCHMARK_TAG = 'benchmark';
 const KNOWN_TAGS = [
   BENCHMARK_TAG,
@@ -39,7 +40,8 @@ const KNOWN_TAGS = [
   NO_WEB_TAG,
   NO_ANDROID_TAG,
   NO_IOS_TAG,
-  NO_LRU_TAG
+  NO_LRU_TAG,
+  NO_MEMORY_PERSISTENCE
 ];
 
 // TOOD(mrschmidt): Make this configurable with mocha options.
@@ -77,6 +79,9 @@ export function setSpecJSONHandler(writer: (json: string) => void): void {
 /** Gets the test runner based on the specified tags. */
 function getTestRunner(tags, persistenceEnabled): Function {
   if (tags.indexOf(NO_WEB_TAG) >= 0) {
+    return it.skip;
+  } else if (!persistenceEnabled && tags.indexOf(NO_MEMORY_PERSISTENCE) !== -1) {
+    // Test requires actual persistence, but it's not enabled. Skip it.
     return it.skip;
   } else if (persistenceEnabled && tags.indexOf(NO_LRU_TAG) !== -1) {
     // spec should have a comment explaining why it is being skipped.

--- a/packages/firestore/test/unit/specs/describe_spec.ts
+++ b/packages/firestore/test/unit/specs/describe_spec.ts
@@ -81,7 +81,10 @@ export function setSpecJSONHandler(writer: (json: string) => void): void {
 function getTestRunner(tags, persistenceEnabled): Function {
   if (tags.indexOf(NO_WEB_TAG) >= 0) {
     return it.skip;
-  } else if (!persistenceEnabled && tags.indexOf(DURABLE_PERSISTENCE_TAG) !== -1) {
+  } else if (
+    !persistenceEnabled &&
+    tags.indexOf(DURABLE_PERSISTENCE_TAG) !== -1
+  ) {
     // Test requires actual persistence, but it's not enabled. Skip it.
     return it.skip;
   } else if (persistenceEnabled && tags.indexOf(EAGER_GC_TAG) !== -1) {

--- a/packages/firestore/test/unit/specs/describe_spec.ts
+++ b/packages/firestore/test/unit/specs/describe_spec.ts
@@ -24,24 +24,20 @@ import { SpecStep } from './spec_test_runner';
 // Disables all other tests; useful for debugging. Multiple tests can have
 // this tag and they'll all be run (but all others won't).
 const EXCLUSIVE_TAG = 'exclusive';
+// The remaining tags specify features that must be present to run a given test
 // Multi-client related tests (which imply persistence).
 const MULTI_CLIENT_TAG = 'multi-client';
-// Explicit per-platform disable flags.
-const NO_WEB_TAG = 'no-web';
-const NO_ANDROID_TAG = 'no-android';
-const NO_IOS_TAG = 'no-ios';
-const NO_LRU_TAG = 'no-lru';
-const NO_MEMORY_PERSISTENCE = 'no-memory-persistence';
+const EAGER_GC_TAG = 'eager-gc';
+const DURABLE_PERSISTENCE_TAG = 'durable-persistence';
 const BENCHMARK_TAG = 'benchmark';
+const JAVASCRIPT_TAG = 'javascript';
 const KNOWN_TAGS = [
   BENCHMARK_TAG,
   EXCLUSIVE_TAG,
   MULTI_CLIENT_TAG,
-  NO_WEB_TAG,
-  NO_ANDROID_TAG,
-  NO_IOS_TAG,
-  NO_LRU_TAG,
-  NO_MEMORY_PERSISTENCE
+  EAGER_GC_TAG,
+  DURABLE_PERSISTENCE_TAG,
+  JAVASCRIPT_TAG,
 ];
 
 // TOOD(mrschmidt): Make this configurable with mocha options.
@@ -78,15 +74,13 @@ export function setSpecJSONHandler(writer: (json: string) => void): void {
 
 /** Gets the test runner based on the specified tags. */
 function getTestRunner(tags, persistenceEnabled): Function {
-  if (tags.indexOf(NO_WEB_TAG) >= 0) {
-    return it.skip;
-  } else if (
+  if (
     !persistenceEnabled &&
-    tags.indexOf(NO_MEMORY_PERSISTENCE) !== -1
+    tags.indexOf(DURABLE_PERSISTENCE_TAG) !== -1
   ) {
     // Test requires actual persistence, but it's not enabled. Skip it.
     return it.skip;
-  } else if (persistenceEnabled && tags.indexOf(NO_LRU_TAG) !== -1) {
+  } else if (persistenceEnabled && tags.indexOf(EAGER_GC_TAG) !== -1) {
     // spec should have a comment explaining why it is being skipped.
     return it.skip;
   } else if (!persistenceEnabled && tags.indexOf(MULTI_CLIENT_TAG) !== -1) {

--- a/packages/firestore/test/unit/specs/listen_spec.test.ts
+++ b/packages/firestore/test/unit/specs/listen_spec.test.ts
@@ -228,7 +228,7 @@ describeSpec('Listens:', [], () => {
   // This would only happen when we use a resume token, but omitted for brevity.
   specTest(
     'Will gracefully handle watch stream reverting snapshots (with restart)',
-    [],
+    ['no-memory-persistence'],
     () => {
       const query = Query.atPath(path('collection'));
       const docAv1 = doc('collection/a', 1000, { v: 'v1000' });
@@ -570,7 +570,7 @@ describeSpec('Listens:', [], () => {
     );
   });
 
-  specTest('Omits global resume tokens for a short while', [], () => {
+  specTest('Omits global resume tokens for a short while', ['no-memory-persistence'], () => {
     const query = Query.atPath(path('collection'));
     const docA = doc('collection/a', 1000, { key: 'a' });
 
@@ -597,7 +597,7 @@ describeSpec('Listens:', [], () => {
 
   specTest(
     'Persists global resume tokens if the snapshot is old enough',
-    [],
+    ['no-memory-persistence'],
     () => {
       const initialVersion = 1000;
       const minutesLater = 5 * 60 * 1e6 + initialVersion;

--- a/packages/firestore/test/unit/specs/listen_spec.test.ts
+++ b/packages/firestore/test/unit/specs/listen_spec.test.ts
@@ -27,7 +27,7 @@ describeSpec('Listens:', [], () => {
   // Obviously this test won't hold with offline persistence enabled.
   specTest(
     'Contents of query are cleared when listen is removed.',
-    ['no-lru'],
+    ['eager-gc'],
     'Explicitly tests eager GC behavior',
     () => {
       const query = Query.atPath(path('collection'));
@@ -228,7 +228,7 @@ describeSpec('Listens:', [], () => {
   // This would only happen when we use a resume token, but omitted for brevity.
   specTest(
     'Will gracefully handle watch stream reverting snapshots (with restart)',
-    ['no-memory-persistence'],
+    ['durable-persistence'],
     () => {
       const query = Query.atPath(path('collection'));
       const docAv1 = doc('collection/a', 1000, { v: 'v1000' });
@@ -572,7 +572,7 @@ describeSpec('Listens:', [], () => {
 
   specTest(
     'Omits global resume tokens for a short while',
-    ['no-memory-persistence'],
+    ['durable-persistence'],
     () => {
       const query = Query.atPath(path('collection'));
       const docA = doc('collection/a', 1000, { key: 'a' });
@@ -601,7 +601,7 @@ describeSpec('Listens:', [], () => {
 
   specTest(
     'Persists global resume tokens if the snapshot is old enough',
-    ['no-memory-persistence'],
+    ['durable-persistence'],
     () => {
       const initialVersion = 1000;
       const minutesLater = 5 * 60 * 1e6 + initialVersion;

--- a/packages/firestore/test/unit/specs/listen_spec.test.ts
+++ b/packages/firestore/test/unit/specs/listen_spec.test.ts
@@ -570,30 +570,34 @@ describeSpec('Listens:', [], () => {
     );
   });
 
-  specTest('Omits global resume tokens for a short while', ['no-memory-persistence'], () => {
-    const query = Query.atPath(path('collection'));
-    const docA = doc('collection/a', 1000, { key: 'a' });
+  specTest(
+    'Omits global resume tokens for a short while',
+    ['no-memory-persistence'],
+    () => {
+      const query = Query.atPath(path('collection'));
+      const docA = doc('collection/a', 1000, { key: 'a' });
 
-    return (
-      spec()
-        .withGCEnabled(false)
-        .userListens(query)
-        .watchAcksFull(query, 1000, docA)
-        .expectEvents(query, { added: [docA] })
+      return (
+        spec()
+          .withGCEnabled(false)
+          .userListens(query)
+          .watchAcksFull(query, 1000, docA)
+          .expectEvents(query, { added: [docA] })
 
-        // One millisecond later, watch sends an updated resume token but the
-        // user doesn't manage to unlisten before restart.
-        .watchSnapshots(2000, [], 'resume-token-2000')
-        .restart()
+          // One millisecond later, watch sends an updated resume token but the
+          // user doesn't manage to unlisten before restart.
+          .watchSnapshots(2000, [], 'resume-token-2000')
+          .restart()
 
-        .userListens(query, 'resume-token-1000')
-        .expectEvents(query, { added: [docA], fromCache: true })
-        .watchAcks(query)
-        .watchCurrents(query, 'resume-token-3000')
-        .watchSnapshots(3000)
-        .expectEvents(query, { fromCache: false })
-    );
-  });
+          .userListens(query, 'resume-token-1000')
+          .expectEvents(query, { added: [docA], fromCache: true })
+          .watchAcks(query)
+          .watchCurrents(query, 'resume-token-3000')
+          .watchSnapshots(3000)
+          .expectEvents(query, { fromCache: false })
+      );
+    }
+  );
 
   specTest(
     'Persists global resume tokens if the snapshot is old enough',

--- a/packages/firestore/test/unit/specs/offline_spec.test.ts
+++ b/packages/firestore/test/unit/specs/offline_spec.test.ts
@@ -64,7 +64,7 @@ describeSpec('Offline:', [], () => {
 
   specTest(
     'Removing all listeners delays "Offline" status on next listen',
-    ['no-lru'],
+    ['eager-gc'],
     'Marked as no-lru because when a listen is re-added, it gets a new target id rather than reusing one',
     () => {
       const query = Query.atPath(path('collection'));

--- a/packages/firestore/test/unit/specs/persistence_spec.test.ts
+++ b/packages/firestore/test/unit/specs/persistence_spec.test.ts
@@ -22,46 +22,54 @@ import { client, spec } from './spec_builder';
 import { TimerId } from '../../../src/util/async_queue';
 
 describeSpec('Persistence:', [], () => {
-  specTest('Local mutations are persisted and re-sent', ['no-memory-persistence'], () => {
-    return spec()
-      .userSets('collection/key1', { foo: 'bar' })
-      .userSets('collection/key2', { baz: 'quu' })
-      .restart()
-      .expectNumOutstandingWrites(2)
-      .writeAcks('collection/key1', 1, { expectUserCallback: false })
-      .writeAcks('collection/key2', 2, { expectUserCallback: false })
-      .expectNumOutstandingWrites(0);
-  });
-
-  specTest('Persisted local mutations are visible to listeners', ['no-memory-persistence'], () => {
-    const query = Query.atPath(path('collection'));
-    return (
-      spec()
+  specTest(
+    'Local mutations are persisted and re-sent',
+    ['no-memory-persistence'],
+    () => {
+      return spec()
         .userSets('collection/key1', { foo: 'bar' })
         .userSets('collection/key2', { baz: 'quu' })
         .restart()
-        // It should be visible to listens.
-        .userListens(query)
-        .expectEvents(query, {
-          added: [
-            doc(
-              'collection/key1',
-              0,
-              { foo: 'bar' },
-              { hasLocalMutations: true }
-            ),
-            doc(
-              'collection/key2',
-              0,
-              { baz: 'quu' },
-              { hasLocalMutations: true }
-            )
-          ],
-          fromCache: true,
-          hasPendingWrites: true
-        })
-    );
-  });
+        .expectNumOutstandingWrites(2)
+        .writeAcks('collection/key1', 1, { expectUserCallback: false })
+        .writeAcks('collection/key2', 2, { expectUserCallback: false })
+        .expectNumOutstandingWrites(0);
+    }
+  );
+
+  specTest(
+    'Persisted local mutations are visible to listeners',
+    ['no-memory-persistence'],
+    () => {
+      const query = Query.atPath(path('collection'));
+      return (
+        spec()
+          .userSets('collection/key1', { foo: 'bar' })
+          .userSets('collection/key2', { baz: 'quu' })
+          .restart()
+          // It should be visible to listens.
+          .userListens(query)
+          .expectEvents(query, {
+            added: [
+              doc(
+                'collection/key1',
+                0,
+                { foo: 'bar' },
+                { hasLocalMutations: true }
+              ),
+              doc(
+                'collection/key2',
+                0,
+                { baz: 'quu' },
+                { hasLocalMutations: true }
+              )
+            ],
+            fromCache: true,
+            hasPendingWrites: true
+          })
+      );
+    }
+  );
 
   specTest('Remote documents are persisted', ['no-memory-persistence'], () => {
     const query = Query.atPath(path('collection'));

--- a/packages/firestore/test/unit/specs/persistence_spec.test.ts
+++ b/packages/firestore/test/unit/specs/persistence_spec.test.ts
@@ -24,7 +24,7 @@ import { TimerId } from '../../../src/util/async_queue';
 describeSpec('Persistence:', [], () => {
   specTest(
     'Local mutations are persisted and re-sent',
-    ['no-memory-persistence'],
+    ['durable-persistence'],
     () => {
       return spec()
         .userSets('collection/key1', { foo: 'bar' })
@@ -39,7 +39,7 @@ describeSpec('Persistence:', [], () => {
 
   specTest(
     'Persisted local mutations are visible to listeners',
-    ['no-memory-persistence'],
+    ['durable-persistence'],
     () => {
       const query = Query.atPath(path('collection'));
       return (
@@ -71,7 +71,7 @@ describeSpec('Persistence:', [], () => {
     }
   );
 
-  specTest('Remote documents are persisted', ['no-memory-persistence'], () => {
+  specTest('Remote documents are persisted', ['durable-persistence'], () => {
     const query = Query.atPath(path('collection'));
     const doc1 = doc('collection/key', 1000, { foo: 'bar' });
     return spec()
@@ -134,7 +134,7 @@ describeSpec('Persistence:', [], () => {
 
   specTest(
     'Mutation Queue is persisted across uid switches (with restarts)',
-    ['no-memory-persistence'],
+    ['durable-persistence'],
     () => {
       return spec()
         .userSets('users/anon', { uid: 'anon' })

--- a/packages/firestore/test/unit/specs/persistence_spec.test.ts
+++ b/packages/firestore/test/unit/specs/persistence_spec.test.ts
@@ -22,7 +22,7 @@ import { client, spec } from './spec_builder';
 import { TimerId } from '../../../src/util/async_queue';
 
 describeSpec('Persistence:', [], () => {
-  specTest('Local mutations are persisted and re-sent', [], () => {
+  specTest('Local mutations are persisted and re-sent', ['no-memory-persistence'], () => {
     return spec()
       .userSets('collection/key1', { foo: 'bar' })
       .userSets('collection/key2', { baz: 'quu' })
@@ -33,7 +33,7 @@ describeSpec('Persistence:', [], () => {
       .expectNumOutstandingWrites(0);
   });
 
-  specTest('Persisted local mutations are visible to listeners', [], () => {
+  specTest('Persisted local mutations are visible to listeners', ['no-memory-persistence'], () => {
     const query = Query.atPath(path('collection'));
     return (
       spec()
@@ -63,7 +63,7 @@ describeSpec('Persistence:', [], () => {
     );
   });
 
-  specTest('Remote documents are persisted', [], () => {
+  specTest('Remote documents are persisted', ['no-memory-persistence'], () => {
     const query = Query.atPath(path('collection'));
     const doc1 = doc('collection/key', 1000, { foo: 'bar' });
     return spec()
@@ -126,7 +126,7 @@ describeSpec('Persistence:', [], () => {
 
   specTest(
     'Mutation Queue is persisted across uid switches (with restarts)',
-    [],
+    ['no-memory-persistence'],
     () => {
       return spec()
         .userSets('users/anon', { uid: 'anon' })

--- a/packages/firestore/test/unit/specs/remote_store_spec.test.ts
+++ b/packages/firestore/test/unit/specs/remote_store_spec.test.ts
@@ -87,7 +87,7 @@ describeSpec('Remote store:', [], () => {
   // tests exclude backoff entirely.
   specTest(
     'Handles user changes while offline (b/74749605).',
-    ['no-android', 'no-ios'],
+    ['javascript'],
     () => {
       const query = Query.atPath(path('collection'));
       return (

--- a/packages/firestore/test/unit/specs/remote_store_spec.test.ts
+++ b/packages/firestore/test/unit/specs/remote_store_spec.test.ts
@@ -87,7 +87,7 @@ describeSpec('Remote store:', [], () => {
   // tests exclude backoff entirely.
   specTest(
     'Handles user changes while offline (b/74749605).',
-    ['javascript'],
+    ['no-android', 'no-ios'],
     () => {
       const query = Query.atPath(path('collection'));
       return (

--- a/packages/firestore/test/unit/specs/spec_test_runner.ts
+++ b/packages/firestore/test/unit/specs/spec_test_runner.ts
@@ -872,6 +872,7 @@ abstract class TestRunner {
   }
 
   private async doRestart(): Promise<void> {
+    expect(this.persistence instanceof MemoryPersistence).to.be.false;
     // Reinitialize everything, except the persistence.
     // No local store to shutdown.
     await this.remoteStore.shutdown();

--- a/packages/firestore/test/unit/specs/spec_test_runner.ts
+++ b/packages/firestore/test/unit/specs/spec_test_runner.ts
@@ -418,10 +418,6 @@ abstract class TestRunner {
 
   async start(): Promise<void> {
     this.persistence = await this.initPersistence(this.serializer);
-    await this.init();
-  }
-
-  private async init(): Promise<void> {
     const garbageCollector = this.getGarbageCollector();
 
     this.sharedClientState = this.getSharedClientState();
@@ -872,14 +868,14 @@ abstract class TestRunner {
   }
 
   private async doRestart(): Promise<void> {
-    expect(this.persistence instanceof MemoryPersistence).to.be.false;
-    // Reinitialize everything, except the persistence.
+    // Reinitialize everything.
     // No local store to shutdown.
     await this.remoteStore.shutdown();
+    await this.persistence.shutdown(/* deleteData= */ false);
 
     // We have to schedule the starts, otherwise we could end up with
     // interleaved events.
-    await this.queue.enqueue(() => this.init());
+    await this.queue.enqueue(() => this.start());
   }
 
   private async doApplyClientState(state: SpecClientState): Promise<void> {

--- a/packages/firestore/test/unit/specs/write_spec.test.ts
+++ b/packages/firestore/test/unit/specs/write_spec.test.ts
@@ -455,7 +455,7 @@ describeSpec('Writes:', [], () => {
 
   specTest(
     'Held writes are released when there are no queries left.',
-    ['no-lru'],
+    ['eager-gc'],
     'This test expects a new target id for a new listen, but without eager gc, the same target id is reused',
     () => {
       const query = Query.atPath(path('collection'));


### PR DESCRIPTION
Verified we don't lose any code coverage in tests.

Exempt a few spec tests from running with memory persistence. Restart the persistence layer along with everything else in spec tests.