### PR TITLE
 Attempt to delete client metadata row

### DIFF
--- a/packages/firestore/src/local/shared_client_state.ts
+++ b/packages/firestore/src/local/shared_client_state.ts
@@ -651,9 +651,7 @@ export class WebStorageSharedClientState implements SharedClientState {
 
     // Register a window unload hook to remove the client metadata entry from
     // LocalStorage even if `shutdown()` was not called.
-    this.platform.window.addEventListener("unload", () =>
-      this.shutdown()
-    );
+    this.platform.window.addEventListener('unload', () => this.shutdown());
 
     this.started = true;
   }

--- a/packages/firestore/src/local/shared_client_state.ts
+++ b/packages/firestore/src/local/shared_client_state.ts
@@ -648,6 +648,13 @@ export class WebStorageSharedClientState implements SharedClientState {
     }
 
     this.earlyEvents = [];
+
+    // Register a window unload hook to remove the client metadata entry from
+    // LocalStorage even if `shutdown()` was not called.
+    this.platform.window.addEventListener("unload", () =>
+      this.shutdown()
+    );
+
     this.started = true;
   }
 
@@ -752,13 +759,11 @@ export class WebStorageSharedClientState implements SharedClientState {
   }
 
   shutdown(): void {
-    assert(
-      this.started,
-      'WebStorageSharedClientState.shutdown() called when not started'
-    );
-    this.platform.window.removeEventListener('storage', this.storageListener);
-    this.removeItem(this.localClientStorageKey);
-    this.started = false;
+    if (this.started) {
+      this.platform.window.removeEventListener('storage', this.storageListener);
+      this.removeItem(this.localClientStorageKey);
+      this.started = false;
+    }
   }
 
   private getItem(key: string): string | null {

--- a/packages/firestore/test/unit/local/web_storage_shared_client_state.test.ts
+++ b/packages/firestore/test/unit/local/web_storage_shared_client_state.test.ts
@@ -198,8 +198,9 @@ describe('WebStorageSharedClientState', () => {
     // client. If we directly relied on LocalStorage listeners, we would not
     // receive events for local writes.
     window.addEventListener = (type, callback) => {
-      expect(type).to.equal('storage');
-      localStorageCallbacks.push(callback);
+      if (type === 'storage') {
+        localStorageCallbacks.push(callback);
+      }
     };
     window.removeEventListener = () => {};
 


### PR DESCRIPTION
We should try to delete the client metadata row from LocalStorage even if `.shutdown()` wasn't called. Because it won't be.