### PR TITLE
Support BrowserPlatforms with no window or document

### DIFF
--- a/packages/firestore/src/platform_browser/browser_platform.ts
+++ b/packages/firestore/src/platform_browser/browser_platform.ts
@@ -27,12 +27,16 @@ export class BrowserPlatform implements Platform {
 
   readonly emptyByteString = '';
 
-  readonly document = document;
-
-  readonly window = window;
-
   constructor() {
     this.base64Available = typeof atob !== 'undefined';
+  }
+
+  get document(): Document | null {
+    return typeof document !== 'undefined' ? document : null;
+  }
+
+  get window(): Window | null {
+    return typeof window !== 'undefined' ? window : null;
   }
 
   loadConnection(databaseInfo: DatabaseInfo): Promise<Connection> {


### PR DESCRIPTION
This expand the checks of #1139 to support platforms where merely accessing "document" or "window" is an error condition (as is the case in Node for example).

Fixes #1138 which uses ReactNative.