### PR TITLE
Schema migration that drops held write acks

### DIFF
--- a/packages/firestore/src/core/firestore_client.ts
+++ b/packages/firestore/src/core/firestore_client.ts
@@ -293,9 +293,7 @@ export class FirestoreClient {
     // TODO(http://b/33384523): For now we just disable garbage collection
     // when persistence is enabled.
     this.garbageCollector = new NoOpGarbageCollector();
-    const storagePrefix = IndexedDbPersistence.buildStoragePrefix(
-      this.databaseInfo
-    );
+
     // Opt to use proto3 JSON in case the platform doesn't support Uint8Array.
     const serializer = new JsonProtoSerializer(this.databaseInfo.databaseId, {
       useProto3Json: true
@@ -303,7 +301,7 @@ export class FirestoreClient {
 
     return Promise.resolve().then(() => {
       const persistence: IndexedDbPersistence = new IndexedDbPersistence(
-        storagePrefix,
+        this.databaseInfo,
         this.clientId,
         this.platform,
         this.asyncQueue,
@@ -322,6 +320,9 @@ export class FirestoreClient {
         );
       }
 
+      const storagePrefix = IndexedDbPersistence.buildStoragePrefix(
+        this.databaseInfo
+      );
       this.sharedClientState = settings.experimentalTabSynchronization
         ? new WebStorageSharedClientState(
             this.asyncQueue,

--- a/packages/firestore/src/core/firestore_client.ts
+++ b/packages/firestore/src/core/firestore_client.ts
@@ -293,7 +293,9 @@ export class FirestoreClient {
     // TODO(http://b/33384523): For now we just disable garbage collection
     // when persistence is enabled.
     this.garbageCollector = new NoOpGarbageCollector();
-
+    const storagePrefix = IndexedDbPersistence.buildStoragePrefix(
+      this.databaseInfo
+    );
     // Opt to use proto3 JSON in case the platform doesn't support Uint8Array.
     const serializer = new JsonProtoSerializer(this.databaseInfo.databaseId, {
       useProto3Json: true
@@ -301,7 +303,7 @@ export class FirestoreClient {
 
     return Promise.resolve().then(() => {
       const persistence: IndexedDbPersistence = new IndexedDbPersistence(
-        this.databaseInfo,
+        storagePrefix,
         this.clientId,
         this.platform,
         this.asyncQueue,
@@ -320,9 +322,6 @@ export class FirestoreClient {
         );
       }
 
-      const storagePrefix = IndexedDbPersistence.buildStoragePrefix(
-        this.databaseInfo
-      );
       this.sharedClientState = settings.experimentalTabSynchronization
         ? new WebStorageSharedClientState(
             this.asyncQueue,

--- a/packages/firestore/src/local/indexeddb_persistence.ts
+++ b/packages/firestore/src/local/indexeddb_persistence.ts
@@ -204,18 +204,15 @@ export class IndexedDbPersistence implements Persistence {
   private queryCache: IndexedDbQueryCache;
   private remoteDocumentCache: IndexedDbRemoteDocumentCache;
 
-  private readonly persistenceKey: string;
-
   constructor(
-    private readonly databaseInfo: DatabaseInfo,
+    private readonly persistenceKey: string,
     private readonly clientId: ClientId,
     platform: Platform,
     private readonly queue: AsyncQueue,
     serializer: JsonProtoSerializer,
     synchronizeTabs: boolean
   ) {
-    this.persistenceKey = IndexedDbPersistence.buildStoragePrefix(databaseInfo);
-    this.dbName = this.persistenceKey + IndexedDbPersistence.MAIN_DATABASE;
+    this.dbName = persistenceKey + IndexedDbPersistence.MAIN_DATABASE;
     this.serializer = new LocalSerializer(serializer);
     this.document = platform.document;
     this.window = platform.window;
@@ -247,7 +244,7 @@ export class IndexedDbPersistence implements Persistence {
     return SimpleDb.openOrCreate(
       this.dbName,
       SCHEMA_VERSION,
-      new SchemaConverter(this.databaseInfo.databaseId)
+      new SchemaConverter(this.serializer)
     )
       .then(db => {
         this.simpleDb = db;

--- a/packages/firestore/src/local/indexeddb_persistence.ts
+++ b/packages/firestore/src/local/indexeddb_persistence.ts
@@ -26,12 +26,12 @@ import { IndexedDbQueryCache } from './indexeddb_query_cache';
 import { IndexedDbRemoteDocumentCache } from './indexeddb_remote_document_cache';
 import {
   ALL_STORES,
-  createOrUpgradeDb,
   DbClientMetadataKey,
   DbClientMetadata,
   DbPrimaryClient,
   DbPrimaryClientKey,
-  SCHEMA_VERSION
+  SCHEMA_VERSION,
+  SchemaConverter
 } from './indexeddb_schema';
 import { LocalSerializer } from './local_serializer';
 import { MutationQueue } from './mutation_queue';
@@ -245,10 +245,9 @@ export class IndexedDbPersistence implements Persistence {
     assert(this.window !== null, "Expected 'window' to be defined");
 
     return SimpleDb.openOrCreate(
-      this.databaseInfo.databaseId,
       this.dbName,
       SCHEMA_VERSION,
-      createOrUpgradeDb
+      new SchemaConverter(this.databaseInfo.databaseId)
     )
       .then(db => {
         this.simpleDb = db;

--- a/packages/firestore/src/local/indexeddb_schema.ts
+++ b/packages/firestore/src/local/indexeddb_schema.ts
@@ -24,6 +24,12 @@ import { encode, EncodedResourcePath } from './encoded_resource_path';
 import { SimpleDbTransaction } from './simple_db';
 import { PersistencePromise } from './persistence_promise';
 import { SnapshotVersion } from '../core/snapshot_version';
+import { BATCHID_UNKNOWN } from '../model/mutation_batch';
+import { IndexedDbMutationQueue } from './indexeddb_mutation_queue';
+import { LocalSerializer } from './local_serializer';
+import { JsonProtoSerializer } from '../remote/serializer';
+import { IndexedDbTransaction } from './indexeddb_persistence';
+import { DatabaseId } from '../core/database_info';
 
 /**
  * Schema Version for the Web client:
@@ -35,8 +41,11 @@ import { SnapshotVersion } from '../core/snapshot_version';
  *    to limbo resolution. Addresses
  *    https://github.com/firebase/firebase-ios-sdk/issues/1548
  * 4. Multi-Tab Support.
+ * 5. Removal of held write acks (not yet active).
  */
 export const SCHEMA_VERSION = 4;
+// TODO(mrschmidt): As SCHEMA_VERSION becomes 5, uncomment the assert in
+// `createOrUpgradeDb`.
 
 /**
  * Performs database creation and schema upgrades.
@@ -47,14 +56,15 @@ export const SCHEMA_VERSION = 4;
  */
 export function createOrUpgradeDb(
   db: IDBDatabase,
+  databaseId: DatabaseId,
   txn: SimpleDbTransaction,
   fromVersion: number,
   toVersion: number
 ): PersistencePromise<void> {
-  assert(
-    fromVersion < toVersion && fromVersion >= 0 && toVersion <= SCHEMA_VERSION,
-    'Unexpected schema upgrade from v${fromVersion} to v{toVersion}.'
-  );
+  // assert(
+  //   fromVersion < toVersion && fromVersion >= 0 && toVersion <= SCHEMA_VERSION,
+  //   `Unexpected schema upgrade from v${fromVersion} to v{toVersion}.`
+  // );
 
   if (fromVersion < 1 && toVersion >= 1) {
     createPrimaryClientStore(db);
@@ -92,6 +102,10 @@ export function createOrUpgradeDb(
       createClientMetadataStore(db);
       createRemoteDocumentChangesStore(db);
     });
+  }
+
+  if (fromVersion < 5 && toVersion >= 5) {
+    p = p.next(() => removeAcknowledgedMutations(db, databaseId, txn));
   }
 
   return p;
@@ -292,6 +306,62 @@ function upgradeMutationBatchSchemaAndMigrateData(
     );
 
     return PersistencePromise.waitFor(writeAll);
+  });
+}
+
+function removeAcknowledgedMutations(
+  db: IDBDatabase,
+  databaseId: DatabaseId,
+  txn: SimpleDbTransaction
+): PersistencePromise<void> {
+  const queuesStore = txn.store<DbMutationQueueKey, DbMutationQueue>(
+    DbMutationQueue.store
+  );
+  const mutationsStore = txn.store<DbMutationBatchKey, DbMutationBatch>(
+    DbMutationBatch.store
+  );
+  const serializer = new LocalSerializer(
+    new JsonProtoSerializer(databaseId, {
+      useProto3Json: true
+    })
+  );
+
+  const indexedDbTransaction = new IndexedDbTransaction(txn);
+  return queuesStore.loadAll().next(queues => {
+    let p = PersistencePromise.resolve();
+    for (const queue of queues) {
+      p = p.next(() => {
+        const mutationQueue = new IndexedDbMutationQueue(
+          queue.userId,
+          serializer
+        );
+        const range = IDBKeyRange.bound(
+          [queue.userId, BATCHID_UNKNOWN],
+          [queue.userId, queue.lastAcknowledgedBatchId]
+        );
+
+        return mutationsStore
+          .loadAll(DbMutationBatch.userMutationsIndex, range)
+          .next(dbBatches => {
+            let removeP = PersistencePromise.resolve();
+            for (const dbBatch of dbBatches) {
+              assert(
+                dbBatch.userId === queue.userId,
+                `Cannot process batch ${dbBatch.batchId} from unexpected user`
+              );
+              const batch = serializer.fromDbMutationBatch(dbBatch);
+              removeP = removeP.next(() =>
+                mutationQueue.removeMutationBatch(indexedDbTransaction, batch)
+              );
+            }
+            return removeP;
+          })
+          .next(() =>
+            mutationQueue.performConsistencyCheck(indexedDbTransaction)
+          );
+      });
+    }
+    return p;
   });
 }
 

--- a/packages/firestore/src/local/indexeddb_schema.ts
+++ b/packages/firestore/src/local/indexeddb_schema.ts
@@ -27,9 +27,7 @@ import { SnapshotVersion } from '../core/snapshot_version';
 import { BATCHID_UNKNOWN } from '../model/mutation_batch';
 import { IndexedDbMutationQueue } from './indexeddb_mutation_queue';
 import { LocalSerializer } from './local_serializer';
-import { JsonProtoSerializer } from '../remote/serializer';
 import { IndexedDbTransaction } from './indexeddb_persistence';
-import { DatabaseId } from '../core/database_info';
 
 /**
  * Schema Version for the Web client:
@@ -49,15 +47,7 @@ export const SCHEMA_VERSION = 4;
 
 /** Performs database creation and schema upgrades. */
 export class SchemaConverter implements SimpleDbSchemaConverter {
-  private readonly serializer: LocalSerializer;
-
-  constructor(private databaseId: DatabaseId) {
-    this.serializer = new LocalSerializer(
-      new JsonProtoSerializer(this.databaseId, {
-        useProto3Json: true
-      })
-    );
-  }
+  constructor(private readonly serializer: LocalSerializer) {}
 
   /**
    * Performs database creation and schema upgrades.

--- a/packages/firestore/src/local/indexeddb_schema.ts
+++ b/packages/firestore/src/local/indexeddb_schema.ts
@@ -21,7 +21,7 @@ import { ResourcePath } from '../model/path';
 import { assert } from '../util/assert';
 
 import { encode, EncodedResourcePath } from './encoded_resource_path';
-import { SimpleDbTransaction } from './simple_db';
+import { SimpleDbSchemaConverter, SimpleDbTransaction } from './simple_db';
 import { PersistencePromise } from './persistence_promise';
 import { SnapshotVersion } from '../core/snapshot_version';
 import { BATCHID_UNKNOWN } from '../model/mutation_batch';
@@ -45,70 +45,131 @@ import { DatabaseId } from '../core/database_info';
  */
 export const SCHEMA_VERSION = 4;
 // TODO(mrschmidt): As SCHEMA_VERSION becomes 5, uncomment the assert in
-// `createOrUpgradeDb`.
+// `createOrUpgrade`.
 
-/**
- * Performs database creation and schema upgrades.
- *
- * Note that in production, this method is only ever used to upgrade the schema
- * to SCHEMA_VERSION. Different values of toVersion are only used for testing
- * and local feature development.
- */
-export function createOrUpgradeDb(
-  db: IDBDatabase,
-  databaseId: DatabaseId,
-  txn: SimpleDbTransaction,
-  fromVersion: number,
-  toVersion: number
-): PersistencePromise<void> {
-  // assert(
-  //   fromVersion < toVersion && fromVersion >= 0 && toVersion <= SCHEMA_VERSION,
-  //   `Unexpected schema upgrade from v${fromVersion} to v{toVersion}.`
-  // );
+/** Performs database creation and schema upgrades. */
+export class SchemaConverter implements SimpleDbSchemaConverter {
+  private readonly serializer: LocalSerializer;
 
-  if (fromVersion < 1 && toVersion >= 1) {
-    createPrimaryClientStore(db);
-    createMutationQueue(db);
-    createQueryCache(db);
-    createRemoteDocumentCache(db);
+  constructor(private databaseId: DatabaseId) {
+    this.serializer = new LocalSerializer(
+      new JsonProtoSerializer(this.databaseId, {
+        useProto3Json: true
+      })
+    );
   }
 
-  // Migration 2 to populate the targetGlobal object no longer needed since
-  // migration 3 unconditionally clears it.
+  /**
+   * Performs database creation and schema upgrades.
+   *
+   * Note that in production, this method is only ever used to upgrade the schema
+   * to SCHEMA_VERSION. Different values of toVersion are only used for testing
+   * and local feature development.
+   */
+  createOrUpgrade(
+    db: IDBDatabase,
+    txn: SimpleDbTransaction,
+    fromVersion: number,
+    toVersion: number
+  ): PersistencePromise<void> {
+    // assert(
+    //   fromVersion < toVersion && fromVersion >= 0 && toVersion <= SCHEMA_VERSION,
+    //   `Unexpected schema upgrade from v${fromVersion} to v{toVersion}.`
+    // );
 
-  let p = PersistencePromise.resolve();
-  if (fromVersion < 3 && toVersion >= 3) {
-    // Brand new clients don't need to drop and recreate--only clients that
-    // potentially have corrupt data.
-    if (fromVersion !== 0) {
-      dropQueryCache(db);
+    if (fromVersion < 1 && toVersion >= 1) {
+      createPrimaryClientStore(db);
+      createMutationQueue(db);
       createQueryCache(db);
+      createRemoteDocumentCache(db);
     }
-    p = p.next(() => writeEmptyTargetGlobalEntry(txn));
+
+    // Migration 2 to populate the targetGlobal object no longer needed since
+    // migration 3 unconditionally clears it.
+
+    let p = PersistencePromise.resolve();
+    if (fromVersion < 3 && toVersion >= 3) {
+      // Brand new clients don't need to drop and recreate--only clients that
+      // potentially have corrupt data.
+      if (fromVersion !== 0) {
+        dropQueryCache(db);
+        createQueryCache(db);
+      }
+      p = p.next(() => writeEmptyTargetGlobalEntry(txn));
+    }
+
+    if (fromVersion < 4 && toVersion >= 4) {
+      if (fromVersion !== 0) {
+        // Schema version 3 uses auto-generated keys to generate globally unique
+        // mutation batch IDs (this was previously ensured internally by the
+        // client). To migrate to the new schema, we have to read all mutations
+        // and write them back out. We preserve the existing batch IDs to guarantee
+        // consistency with other object stores. Any further mutation batch IDs will
+        // be auto-generated.
+        p = p.next(() => upgradeMutationBatchSchemaAndMigrateData(db, txn));
+      }
+
+      p = p.next(() => {
+        createClientMetadataStore(db);
+        createRemoteDocumentChangesStore(db);
+      });
+    }
+
+    if (fromVersion < 5 && toVersion >= 5) {
+      p = p.next(() => this.removeAcknowledgedMutations(txn));
+    }
+
+    return p;
   }
 
-  if (fromVersion < 4 && toVersion >= 4) {
-    if (fromVersion !== 0) {
-      // Schema version 3 uses auto-generated keys to generate globally unique
-      // mutation batch IDs (this was previously ensured internally by the
-      // client). To migrate to the new schema, we have to read all mutations
-      // and write them back out. We preserve the existing batch IDs to guarantee
-      // consistency with other object stores. Any further mutation batch IDs will
-      // be auto-generated.
-      p = p.next(() => upgradeMutationBatchSchemaAndMigrateData(db, txn));
-    }
+  private removeAcknowledgedMutations(
+    txn: SimpleDbTransaction
+  ): PersistencePromise<void> {
+    const queuesStore = txn.store<DbMutationQueueKey, DbMutationQueue>(
+      DbMutationQueue.store
+    );
+    const mutationsStore = txn.store<DbMutationBatchKey, DbMutationBatch>(
+      DbMutationBatch.store
+    );
 
-    p = p.next(() => {
-      createClientMetadataStore(db);
-      createRemoteDocumentChangesStore(db);
+    const indexedDbTransaction = new IndexedDbTransaction(txn);
+    return queuesStore.loadAll().next(queues => {
+      let p = PersistencePromise.resolve();
+      for (const queue of queues) {
+        p = p.next(() => {
+          const mutationQueue = new IndexedDbMutationQueue(
+            queue.userId,
+            this.serializer
+          );
+          const range = IDBKeyRange.bound(
+            [queue.userId, BATCHID_UNKNOWN],
+            [queue.userId, queue.lastAcknowledgedBatchId]
+          );
+
+          return mutationsStore
+            .loadAll(DbMutationBatch.userMutationsIndex, range)
+            .next(dbBatches => {
+              let removeP = PersistencePromise.resolve();
+              for (const dbBatch of dbBatches) {
+                assert(
+                  dbBatch.userId === queue.userId,
+                  `Cannot process batch ${dbBatch.batchId} from unexpected user`
+                );
+                const batch = this.serializer.fromDbMutationBatch(dbBatch);
+                removeP = removeP.next(() =>
+                  mutationQueue.removeMutationBatch(indexedDbTransaction, batch)
+                );
+              }
+              return removeP;
+            })
+            .next(() =>
+              mutationQueue.performConsistencyCheck(indexedDbTransaction)
+            );
+        });
+      }
+      return p;
     });
   }
-
-  if (fromVersion < 5 && toVersion >= 5) {
-    p = p.next(() => removeAcknowledgedMutations(db, databaseId, txn));
-  }
-
-  return p;
 }
 
 // TODO(mikelehen): Get rid of "as any" if/when TypeScript fixes their types.
@@ -306,62 +367,6 @@ function upgradeMutationBatchSchemaAndMigrateData(
     );
 
     return PersistencePromise.waitFor(writeAll);
-  });
-}
-
-function removeAcknowledgedMutations(
-  db: IDBDatabase,
-  databaseId: DatabaseId,
-  txn: SimpleDbTransaction
-): PersistencePromise<void> {
-  const queuesStore = txn.store<DbMutationQueueKey, DbMutationQueue>(
-    DbMutationQueue.store
-  );
-  const mutationsStore = txn.store<DbMutationBatchKey, DbMutationBatch>(
-    DbMutationBatch.store
-  );
-  const serializer = new LocalSerializer(
-    new JsonProtoSerializer(databaseId, {
-      useProto3Json: true
-    })
-  );
-
-  const indexedDbTransaction = new IndexedDbTransaction(txn);
-  return queuesStore.loadAll().next(queues => {
-    let p = PersistencePromise.resolve();
-    for (const queue of queues) {
-      p = p.next(() => {
-        const mutationQueue = new IndexedDbMutationQueue(
-          queue.userId,
-          serializer
-        );
-        const range = IDBKeyRange.bound(
-          [queue.userId, BATCHID_UNKNOWN],
-          [queue.userId, queue.lastAcknowledgedBatchId]
-        );
-
-        return mutationsStore
-          .loadAll(DbMutationBatch.userMutationsIndex, range)
-          .next(dbBatches => {
-            let removeP = PersistencePromise.resolve();
-            for (const dbBatch of dbBatches) {
-              assert(
-                dbBatch.userId === queue.userId,
-                `Cannot process batch ${dbBatch.batchId} from unexpected user`
-              );
-              const batch = serializer.fromDbMutationBatch(dbBatch);
-              removeP = removeP.next(() =>
-                mutationQueue.removeMutationBatch(indexedDbTransaction, batch)
-              );
-            }
-            return removeP;
-          })
-          .next(() =>
-            mutationQueue.performConsistencyCheck(indexedDbTransaction)
-          );
-      });
-    }
-    return p;
   });
 }
 

--- a/packages/firestore/src/local/simple_db.ts
+++ b/packages/firestore/src/local/simple_db.ts
@@ -22,6 +22,7 @@ import { SCHEMA_VERSION } from './indexeddb_schema';
 import { AnyJs } from '../util/misc';
 import { Deferred } from '../util/promise';
 import { Code, FirestoreError } from '../util/error';
+import { DatabaseId } from '../core/database_info';
 
 const LOG_TAG = 'SimpleDb';
 
@@ -35,10 +36,12 @@ const LOG_TAG = 'SimpleDb';
 export class SimpleDb {
   /** Opens the specified database, creating or upgrading it if necessary. */
   static openOrCreate(
+    databaseId: DatabaseId,
     name: string,
     version: number,
     runUpgrade: (
       db: IDBDatabase,
+      databaseId: DatabaseId,
       txn: SimpleDbTransaction,
       fromVersion: number,
       toVersion: number
@@ -87,12 +90,14 @@ export class SimpleDb {
         // we wrap that in a SimpleDbTransaction to allow use of our friendlier
         // API for schema migration operations.
         const txn = new SimpleDbTransaction(request.transaction);
-        runUpgrade(db, txn, event.oldVersion, SCHEMA_VERSION).next(() => {
-          debug(
-            LOG_TAG,
-            'Database upgrade to version ' + SCHEMA_VERSION + ' complete'
-          );
-        });
+        runUpgrade(db, databaseId, txn, event.oldVersion, SCHEMA_VERSION).next(
+          () => {
+            debug(
+              LOG_TAG,
+              'Database upgrade to version ' + SCHEMA_VERSION + ' complete'
+            );
+          }
+        );
       };
     }).toPromise();
   }

--- a/packages/firestore/src/local/simple_db.ts
+++ b/packages/firestore/src/local/simple_db.ts
@@ -26,6 +26,15 @@ import { DatabaseId } from '../core/database_info';
 
 const LOG_TAG = 'SimpleDb';
 
+export interface SimpleDbSchemaConverter {
+  createOrUpgrade(
+    db: IDBDatabase,
+    txn: SimpleDbTransaction,
+    fromVersion: number,
+    toVersion: number
+  ): PersistencePromise<void>;
+}
+
 /**
  * Provides a wrapper around IndexedDb with a simplified interface that uses
  * Promise-like return values to chain operations. Real promises cannot be used
@@ -36,16 +45,9 @@ const LOG_TAG = 'SimpleDb';
 export class SimpleDb {
   /** Opens the specified database, creating or upgrading it if necessary. */
   static openOrCreate(
-    databaseId: DatabaseId,
     name: string,
     version: number,
-    runUpgrade: (
-      db: IDBDatabase,
-      databaseId: DatabaseId,
-      txn: SimpleDbTransaction,
-      fromVersion: number,
-      toVersion: number
-    ) => PersistencePromise<void>
+    schemaConverter: SimpleDbSchemaConverter
   ): Promise<SimpleDb> {
     assert(
       SimpleDb.isAvailable(),
@@ -90,14 +92,14 @@ export class SimpleDb {
         // we wrap that in a SimpleDbTransaction to allow use of our friendlier
         // API for schema migration operations.
         const txn = new SimpleDbTransaction(request.transaction);
-        runUpgrade(db, databaseId, txn, event.oldVersion, SCHEMA_VERSION).next(
-          () => {
+        schemaConverter
+          .createOrUpgrade(db, txn, event.oldVersion, SCHEMA_VERSION)
+          .next(() => {
             debug(
               LOG_TAG,
               'Database upgrade to version ' + SCHEMA_VERSION + ' complete'
             );
-          }
-        );
+          });
       };
     }).toPromise();
   }

--- a/packages/firestore/src/local/simple_db.ts
+++ b/packages/firestore/src/local/simple_db.ts
@@ -22,7 +22,6 @@ import { SCHEMA_VERSION } from './indexeddb_schema';
 import { AnyJs } from '../util/misc';
 import { Deferred } from '../util/promise';
 import { Code, FirestoreError } from '../util/error';
-import { DatabaseId } from '../core/database_info';
 
 const LOG_TAG = 'SimpleDb';
 

--- a/packages/firestore/test/unit/local/encoded_resource_path.test.ts
+++ b/packages/firestore/test/unit/local/encoded_resource_path.test.ts
@@ -24,6 +24,7 @@ import {
 } from '../../../src/local/simple_db';
 import { ResourcePath } from '../../../src/model/path';
 import { path } from '../../util/helpers';
+import { INDEXEDDB_TEST_DATABASE_ID } from './persistence_test_helpers';
 
 let db: SimpleDb;
 const sep = '\u0001\u0001';
@@ -39,10 +40,15 @@ describe('EncodedResourcePath', () => {
   beforeEach(() => {
     return SimpleDb.delete(dbName)
       .then(() => {
-        return SimpleDb.openOrCreate(dbName, 1, db => {
-          db.createObjectStore('test');
-          return PersistencePromise.resolve();
-        });
+        return SimpleDb.openOrCreate(
+          INDEXEDDB_TEST_DATABASE_ID,
+          dbName,
+          1,
+          db => {
+            db.createObjectStore('test');
+            return PersistencePromise.resolve();
+          }
+        );
       })
       .then(simpleDb => {
         db = simpleDb;

--- a/packages/firestore/test/unit/local/encoded_resource_path.test.ts
+++ b/packages/firestore/test/unit/local/encoded_resource_path.test.ts
@@ -19,6 +19,7 @@ import * as EncodedResourcePath from '../../../src/local/encoded_resource_path';
 import { PersistencePromise } from '../../../src/local/persistence_promise';
 import {
   SimpleDb,
+  SimpleDbSchemaConverter,
   SimpleDbStore,
   SimpleDbTransaction
 } from '../../../src/local/simple_db';
@@ -28,6 +29,18 @@ import { INDEXEDDB_TEST_DATABASE_ID } from './persistence_test_helpers';
 
 let db: SimpleDb;
 const sep = '\u0001\u0001';
+
+class EncodedResourcePathSchemaConverter implements SimpleDbSchemaConverter {
+  createOrUpgrade(
+    db: IDBDatabase,
+    txn: SimpleDbTransaction,
+    fromVersion: number,
+    toVersion: number
+  ): PersistencePromise<void> {
+    db.createObjectStore('test');
+    return PersistencePromise.resolve();
+  }
+}
 
 describe('EncodedResourcePath', () => {
   if (!SimpleDb.isAvailable()) {
@@ -41,13 +54,9 @@ describe('EncodedResourcePath', () => {
     return SimpleDb.delete(dbName)
       .then(() => {
         return SimpleDb.openOrCreate(
-          INDEXEDDB_TEST_DATABASE_ID,
           dbName,
           1,
-          db => {
-            db.createObjectStore('test');
-            return PersistencePromise.resolve();
-          }
+          new EncodedResourcePathSchemaConverter()
         );
       })
       .then(simpleDb => {

--- a/packages/firestore/test/unit/local/encoded_resource_path.test.ts
+++ b/packages/firestore/test/unit/local/encoded_resource_path.test.ts
@@ -25,7 +25,6 @@ import {
 } from '../../../src/local/simple_db';
 import { ResourcePath } from '../../../src/model/path';
 import { path } from '../../util/helpers';
-import { INDEXEDDB_TEST_DATABASE_ID } from './persistence_test_helpers';
 
 let db: SimpleDb;
 const sep = '\u0001\u0001';

--- a/packages/firestore/test/unit/local/indexeddb_persistence.test.ts
+++ b/packages/firestore/test/unit/local/indexeddb_persistence.test.ts
@@ -17,9 +17,14 @@
 import { expect } from 'chai';
 import { IndexedDbPersistence } from '../../../src/local/indexeddb_persistence';
 import {
+  ALL_STORES,
   createOrUpgradeDb,
+  DbDocumentMutation,
+  DbDocumentMutationKey,
   DbMutationBatch,
   DbMutationBatchKey,
+  DbMutationQueue,
+  DbMutationQueueKey,
   DbPrimaryClient,
   DbPrimaryClientKey,
   DbTarget,
@@ -35,17 +40,18 @@ import {
 import { SimpleDb, SimpleDbTransaction } from '../../../src/local/simple_db';
 import { PersistencePromise } from '../../../src/local/persistence_promise';
 import { ClientId } from '../../../src/local/shared_client_state';
-import { DatabaseId } from '../../../src/core/database_info';
 import { JsonProtoSerializer } from '../../../src/remote/serializer';
 import { PlatformSupport } from '../../../src/platform/platform';
 import { AsyncQueue } from '../../../src/util/async_queue';
 import { SharedFakeWebStorage, TestPlatform } from '../../util/test_platform';
 import { SnapshotVersion } from '../../../src/core/snapshot_version';
 import { PersistenceSettings } from '../../../src/api/database';
-
-const INDEXEDDB_TEST_DATABASE_PREFIX = 'schemaTest/';
-const INDEXEDDB_TEST_DATABASE =
-  INDEXEDDB_TEST_DATABASE_PREFIX + IndexedDbPersistence.MAIN_DATABASE;
+import { path } from '../../util/helpers';
+import {
+  INDEXEDDB_TEST_DATABASE_ID,
+  INDEXEDDB_TEST_DATABASE_INFO,
+  INDEXEDDB_TEST_DATABASE_NAME
+} from './persistence_test_helpers';
 
 function withDb(
   schemaVersion,
@@ -53,13 +59,14 @@ function withDb(
 ): Promise<void> {
   return new Promise<IDBDatabase>((resolve, reject) => {
     const request = window.indexedDB.open(
-      INDEXEDDB_TEST_DATABASE,
+      INDEXEDDB_TEST_DATABASE_NAME,
       schemaVersion
     );
     request.onupgradeneeded = (event: IDBVersionChangeEvent) => {
       const db = (event.target as IDBOpenDBRequest).result;
       createOrUpgradeDb(
         db,
+        INDEXEDDB_TEST_DATABASE_ID,
         new SimpleDbTransaction(request.transaction),
         event.oldVersion,
         schemaVersion
@@ -87,18 +94,16 @@ async function withCustomPersistence(
     queue: AsyncQueue
   ) => Promise<void>
 ): Promise<void> {
-  const partition = new DatabaseId('project');
-  const serializer = new JsonProtoSerializer(partition, {
+  const serializer = new JsonProtoSerializer(INDEXEDDB_TEST_DATABASE_ID, {
     useProto3Json: true
   });
-
   const queue = new AsyncQueue();
   const platform = new TestPlatform(
     PlatformSupport.getPlatform(),
     new SharedFakeWebStorage()
   );
   const persistence = new IndexedDbPersistence(
-    INDEXEDDB_TEST_DATABASE_PREFIX,
+    INDEXEDDB_TEST_DATABASE_INFO,
     clientId,
     platform,
     queue,
@@ -157,9 +162,9 @@ describe('IndexedDbSchema: createOrUpgradeDb', () => {
     return;
   }
 
-  beforeEach(() => SimpleDb.delete(INDEXEDDB_TEST_DATABASE));
+  beforeEach(() => SimpleDb.delete(INDEXEDDB_TEST_DATABASE_NAME));
 
-  after(() => SimpleDb.delete(INDEXEDDB_TEST_DATABASE));
+  after(() => SimpleDb.delete(INDEXEDDB_TEST_DATABASE_NAME));
 
   it('can install schema version 1', () => {
     return withDb(1, async db => {
@@ -259,23 +264,23 @@ describe('IndexedDbSchema: createOrUpgradeDb', () => {
 
   it('can upgrade from schema version 3 to 4', () => {
     const testWrite = { delete: 'foo' };
-    const testMutations = [
+    const testMutations: DbMutationBatch[] = [
       {
         userId: 'foo',
         batchId: 0,
-        localWriteTime: 1337,
+        localWriteTimeMs: 1337,
         mutations: []
       },
       {
         userId: 'foo',
         batchId: 1,
-        localWriteTime: 1337,
+        localWriteTimeMs: 1337,
         mutations: [testWrite]
       },
       {
         userId: 'foo',
         batchId: 42,
-        localWriteTime: 1337,
+        localWriteTimeMs: 1337,
         mutations: [testWrite, testWrite]
       }
     ];
@@ -320,6 +325,152 @@ describe('IndexedDbSchema: createOrUpgradeDb', () => {
       })
     );
   });
+
+  it('can upgrade from schema version 4 to 5', () => {
+    // This test creates a database with schema version 4 that has two users,
+    // both of which have acknowledged mutations that haven't yet been removed
+    // from IndexedDb ("heldWriteAcks"). Schema version 5 removes heldWriteAcks,
+    // and as such these mutations are deleted.
+    const testWriteFoo = {
+      update: {
+        name: 'projects/test-project/databases/(default)/documents/docs/foo'
+      }
+    };
+    const testWriteBar = {
+      update: {
+        name: 'projects/test-project/databases/(default)/documents/docs/bar'
+      }
+    };
+    const testWriteBaz = {
+      update: {
+        name: 'projects/test-project/databases/(default)/documents/docs/baz'
+      }
+    };
+    const testWritePending = {
+      update: {
+        name: 'projects/test-project/databases/(default)/documents/docs/pending'
+      }
+    };
+    const testMutations: DbMutationBatch[] = [
+      // User 'foo' has two acknowledged mutations and one that is pending.
+      {
+        userId: 'foo',
+        batchId: 1,
+        localWriteTimeMs: 1337,
+        mutations: [testWriteFoo]
+      },
+      {
+        userId: 'foo',
+        batchId: 2,
+        localWriteTimeMs: 1337,
+        mutations: [testWriteFoo]
+      },
+      // User 'bar' has one acknowledged mutation and one that is pending.
+      {
+        userId: 'bar',
+        batchId: 3,
+        localWriteTimeMs: 1337,
+        mutations: [testWriteBar, testWriteBaz]
+      },
+      {
+        userId: 'bar',
+        batchId: 4,
+        localWriteTimeMs: 1337,
+        mutations: [testWritePending]
+      },
+      {
+        userId: 'foo',
+        batchId: 5,
+        localWriteTimeMs: 1337,
+        mutations: [testWritePending]
+      }
+    ];
+
+    return withDb(4, db => {
+      const sdb = new SimpleDb(db);
+      return sdb.runTransaction('readwrite', ALL_STORES, txn => {
+        const mutationBatchStore = txn.store<
+          DbMutationBatchKey,
+          DbMutationBatch
+        >(DbMutationBatch.store);
+        const documentMutationStore = txn.store<
+          DbDocumentMutationKey,
+          DbDocumentMutation
+        >(DbDocumentMutation.store);
+        const mutationQueuesStore = txn.store<
+          DbMutationQueueKey,
+          DbMutationQueue
+        >(DbMutationQueue.store);
+        // Manually populate the mutation queue and create all indicies.
+        let p = PersistencePromise.resolve();
+        for (const testMutation of testMutations) {
+          p = p.next(() => mutationBatchStore.put(testMutation));
+          for (const write of testMutation.mutations) {
+            p = p.next(() => {
+              const indexKey = DbDocumentMutation.key(
+                testMutation.userId,
+                path(write.update.name, 5),
+                testMutation.batchId
+              );
+              return documentMutationStore.put(
+                indexKey,
+                DbDocumentMutation.PLACEHOLDER
+              );
+            });
+          }
+        }
+        p = p.next(() =>
+          // Populate the mutation queues' metadata
+          PersistencePromise.waitFor([
+            mutationQueuesStore.put(new DbMutationQueue('foo', 2, '')),
+            mutationQueuesStore.put(new DbMutationQueue('bar', 3, '')),
+            mutationQueuesStore.put(new DbMutationQueue('empty', -1, ''))
+          ])
+        );
+        return p;
+      });
+    }).then(() =>
+      withDb(5, db => {
+        expect(db.version).to.be.equal(5);
+
+        const sdb = new SimpleDb(db);
+        return sdb.runTransaction('readwrite', ALL_STORES, txn => {
+          const mutationBatchStore = txn.store<
+            DbMutationBatchKey,
+            DbMutationBatch
+          >(DbMutationBatch.store);
+          const documentMutationStore = txn.store<
+            DbDocumentMutationKey,
+            DbDocumentMutation
+          >(DbDocumentMutation.store);
+          const mutationQueuesStore = txn.store<
+            DbMutationQueueKey,
+            DbMutationQueue
+          >(DbMutationQueue.store);
+
+          // Verify that all but the two pending mutations have been cleared
+          // by the migration.
+          let p = mutationBatchStore.count().next(count => {
+            expect(count).to.deep.equal(2);
+          });
+          p = p.next(() =>
+            documentMutationStore.count().next(count => {
+              expect(count).to.equal(2);
+            })
+          );
+
+          // Verify that we still have one metadata entry for each existing
+          // queue
+          p = p.next(() =>
+            mutationQueuesStore.count().next(count => {
+              expect(count).to.equal(3);
+            })
+          );
+          return p;
+        });
+      })
+    );
+  });
 });
 
 describe('IndexedDb: canActAsPrimary', () => {
@@ -330,7 +481,8 @@ describe('IndexedDb: canActAsPrimary', () => {
 
   async function clearPrimaryLease(): Promise<void> {
     const simpleDb = await SimpleDb.openOrCreate(
-      INDEXEDDB_TEST_DATABASE,
+      INDEXEDDB_TEST_DATABASE_ID,
+      INDEXEDDB_TEST_DATABASE_NAME,
       SCHEMA_VERSION,
       createOrUpgradeDb
     );
@@ -344,10 +496,10 @@ describe('IndexedDb: canActAsPrimary', () => {
   }
 
   beforeEach(() => {
-    return SimpleDb.delete(INDEXEDDB_TEST_DATABASE);
+    return SimpleDb.delete(INDEXEDDB_TEST_DATABASE_NAME);
   });
 
-  after(() => SimpleDb.delete(INDEXEDDB_TEST_DATABASE));
+  after(() => SimpleDb.delete(INDEXEDDB_TEST_DATABASE_NAME));
 
   const visible: VisibilityState = 'visible';
   const hidden: VisibilityState = 'hidden';
@@ -456,9 +608,9 @@ describe('IndexedDb: allowTabSynchronization', () => {
     return;
   }
 
-  beforeEach(() => SimpleDb.delete(INDEXEDDB_TEST_DATABASE));
+  beforeEach(() => SimpleDb.delete(INDEXEDDB_TEST_DATABASE_NAME));
 
-  after(() => SimpleDb.delete(INDEXEDDB_TEST_DATABASE));
+  after(() => SimpleDb.delete(INDEXEDDB_TEST_DATABASE_NAME));
 
   it('rejects access when synchronization is disabled', () => {
     return withPersistence('clientA', async db1 => {

--- a/packages/firestore/test/unit/local/persistence_test_helpers.ts
+++ b/packages/firestore/test/unit/local/persistence_test_helpers.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { DatabaseId } from '../../../src/core/database_info';
+import { DatabaseId, DatabaseInfo } from '../../../src/core/database_info';
 import { IndexedDbPersistence } from '../../../src/local/indexeddb_persistence';
 import { MemoryPersistence } from '../../../src/local/memory_persistence';
 import { SimpleDb } from '../../../src/local/simple_db';
@@ -46,6 +46,26 @@ export const TEST_PERSISTENCE_PREFIX =
 /** The prefix used by the keys that Firestore writes to Local Storage. */
 const LOCAL_STORAGE_PREFIX = 'firestore_';
 
+/** The Database ID used by most tests that access IndexedDb. */
+export const INDEXEDDB_TEST_DATABASE_ID = new DatabaseId('test-project');
+
+/** The DatabaseInfo used by most tests that access IndexedDb. */
+export const INDEXEDDB_TEST_DATABASE_INFO = new DatabaseInfo(
+  INDEXEDDB_TEST_DATABASE_ID,
+  'PersistenceTestHelpers',
+  'host',
+  /*ssl=*/ false
+);
+
+/**
+ * The database name used by tests that access IndexedDb. To be used in
+ * conjunction with `INDEXEDDB_TEST_DATABASE_INFO` and
+ * `INDEXEDDB_TEST_DATABASE_ID`.
+ */
+export const INDEXEDDB_TEST_DATABASE_NAME =
+  IndexedDbPersistence.buildStoragePrefix(INDEXEDDB_TEST_DATABASE_INFO) +
+  IndexedDbPersistence.MAIN_DATABASE;
+
 /**
  * Creates and starts an IndexedDbPersistence instance for testing, destroying
  * any previous contents if they existed.
@@ -62,13 +82,12 @@ export async function testIndexedDbPersistence(
   if (!options.dontPurgeData) {
     await SimpleDb.delete(prefix + IndexedDbPersistence.MAIN_DATABASE);
   }
-  const partition = new DatabaseId('project');
-  const serializer = new JsonProtoSerializer(partition, {
+  const serializer = new JsonProtoSerializer(INDEXEDDB_TEST_DATABASE_ID, {
     useProto3Json: true
   });
   const platform = PlatformSupport.getPlatform();
   const persistence = new IndexedDbPersistence(
-    prefix,
+    INDEXEDDB_TEST_DATABASE_INFO,
     clientId,
     platform,
     queue,

--- a/packages/firestore/test/unit/local/persistence_test_helpers.ts
+++ b/packages/firestore/test/unit/local/persistence_test_helpers.ts
@@ -38,10 +38,7 @@ import {
 import { FirestoreError } from '../../../src/util/error';
 import { AutoId } from '../../../src/util/misc';
 import { PlatformSupport } from '../../../src/platform/platform';
-
-/** The persistence prefix used for testing in IndexedBD and LocalStorage. */
-export const TEST_PERSISTENCE_PREFIX =
-  'firestore/[DEFAULT]/PersistenceTestHelpers';
+import { LocalSerializer } from '../../../src/local/local_serializer';
 
 /** The prefix used by the keys that Firestore writes to Local Storage. */
 const LOCAL_STORAGE_PREFIX = 'firestore_';
@@ -50,11 +47,16 @@ const LOCAL_STORAGE_PREFIX = 'firestore_';
 export const INDEXEDDB_TEST_DATABASE_ID = new DatabaseId('test-project');
 
 /** The DatabaseInfo used by most tests that access IndexedDb. */
-export const INDEXEDDB_TEST_DATABASE_INFO = new DatabaseInfo(
+const INDEXEDDB_TEST_DATABASE_INFO = new DatabaseInfo(
   INDEXEDDB_TEST_DATABASE_ID,
   'PersistenceTestHelpers',
   'host',
   /*ssl=*/ false
+);
+
+/** The persistence prefix used for testing in IndexedBD and LocalStorage. */
+export const TEST_PERSISTENCE_PREFIX = IndexedDbPersistence.buildStoragePrefix(
+  INDEXEDDB_TEST_DATABASE_INFO
 );
 
 /**
@@ -65,6 +67,16 @@ export const INDEXEDDB_TEST_DATABASE_INFO = new DatabaseInfo(
 export const INDEXEDDB_TEST_DATABASE_NAME =
   IndexedDbPersistence.buildStoragePrefix(INDEXEDDB_TEST_DATABASE_INFO) +
   IndexedDbPersistence.MAIN_DATABASE;
+
+/**
+ * IndexedDb serializer that uses `INDEXEDDB_TEST_DATABASE_ID` as its database
+ * id.
+ */
+export const INDEXEDDB_TEST_SERIALIZER = new LocalSerializer(
+  new JsonProtoSerializer(INDEXEDDB_TEST_DATABASE_ID, {
+    useProto3Json: true
+  })
+);
 
 /**
  * Creates and starts an IndexedDbPersistence instance for testing, destroying
@@ -87,7 +99,7 @@ export async function testIndexedDbPersistence(
   });
   const platform = PlatformSupport.getPlatform();
   const persistence = new IndexedDbPersistence(
-    INDEXEDDB_TEST_DATABASE_INFO,
+    TEST_PERSISTENCE_PREFIX,
     clientId,
     platform,
     queue,

--- a/packages/firestore/test/unit/local/simple_db.test.ts
+++ b/packages/firestore/test/unit/local/simple_db.test.ts
@@ -25,6 +25,7 @@ import {
   SimpleDbStore,
   SimpleDbTransaction
 } from '../../../src/local/simple_db';
+import { DatabaseId } from '../../../src/core/database_info';
 
 chai.use(chaiAsPromised);
 
@@ -86,7 +87,7 @@ describe('SimpleDb', () => {
   beforeEach(() => {
     return SimpleDb.delete(dbName)
       .then(() => {
-        return SimpleDb.openOrCreate(dbName, 1, db => {
+        return SimpleDb.openOrCreate(new DatabaseId(dbName), dbName, 1, db => {
           const objectStore = db.createObjectStore('users', { keyPath: 'id' });
           objectStore.createIndex('age-name', ['age', 'name'], {
             unique: false

--- a/packages/firestore/test/unit/local/simple_db.test.ts
+++ b/packages/firestore/test/unit/local/simple_db.test.ts
@@ -28,7 +28,6 @@ import {
   SimpleDbStore,
   SimpleDbTransaction
 } from '../../../src/local/simple_db';
-import { DatabaseId } from '../../../src/core/database_info';
 
 chai.use(chaiAsPromised);
 

--- a/packages/firestore/test/unit/local/simple_db.test.ts
+++ b/packages/firestore/test/unit/local/simple_db.test.ts
@@ -18,7 +18,10 @@ import * as chai from 'chai';
 import * as chaiAsPromised from 'chai-as-promised';
 
 import { expect } from 'chai';
-import { SimpleDb } from '../../../src/local/simple_db';
+import {
+  SimpleDb,
+  SimpleDbSchemaConverter
+} from '../../../src/local/simple_db';
 
 import { PersistencePromise } from '../../../src/local/persistence_promise';
 import {
@@ -57,6 +60,24 @@ function isIndexedDbMock(): boolean {
   return process.env.USE_MOCK_PERSISTENCE === 'YES';
 }
 
+class TestSchemaConverter implements SimpleDbSchemaConverter {
+  createOrUpgrade(
+    db: IDBDatabase,
+    txn: SimpleDbTransaction,
+    fromVersion: number,
+    toVersion: number
+  ): PersistencePromise<void> {
+    const objectStore = db.createObjectStore('users', { keyPath: 'id' });
+    objectStore.createIndex('age-name', ['age', 'name'], {
+      unique: false
+    });
+
+    // A store that uses arrays as keys.
+    db.createObjectStore('docs');
+    return PersistencePromise.resolve();
+  }
+}
+
 describe('SimpleDb', () => {
   if (!SimpleDb.isAvailable()) {
     console.warn('Skipping SimpleDb tests due to lack of indexedDB support.');
@@ -87,16 +108,7 @@ describe('SimpleDb', () => {
   beforeEach(() => {
     return SimpleDb.delete(dbName)
       .then(() => {
-        return SimpleDb.openOrCreate(new DatabaseId(dbName), dbName, 1, db => {
-          const objectStore = db.createObjectStore('users', { keyPath: 'id' });
-          objectStore.createIndex('age-name', ['age', 'name'], {
-            unique: false
-          });
-
-          // A store that uses arrays as keys.
-          db.createObjectStore('docs');
-          return PersistencePromise.resolve();
-        });
+        return SimpleDb.openOrCreate(dbName, 1, new TestSchemaConverter());
       })
       .then(simpleDb => {
         db = simpleDb;

--- a/packages/firestore/test/unit/specs/spec_test_runner.ts
+++ b/packages/firestore/test/unit/specs/spec_test_runner.ts
@@ -108,6 +108,11 @@ import {
   SCHEMA_VERSION
 } from '../../../src/local/indexeddb_schema';
 import { TestPlatform, SharedFakeWebStorage } from '../../util/test_platform';
+import {
+  INDEXEDDB_TEST_DATABASE_ID,
+  INDEXEDDB_TEST_DATABASE_INFO,
+  INDEXEDDB_TEST_DATABASE_NAME
+} from '../local/persistence_test_helpers';
 
 class MockConnection implements Connection {
   watchStream: StreamBridge<
@@ -1162,12 +1167,11 @@ class MemoryTestRunner extends TestRunner {
  * enabled for the platform.
  */
 class IndexedDbTestRunner extends TestRunner {
-  static TEST_DB_NAME = 'firestore/[DEFAULT]/specs';
   protected getSharedClientState(): SharedClientState {
     return new WebStorageSharedClientState(
       this.queue,
       this.platform,
-      IndexedDbTestRunner.TEST_DB_NAME,
+      INDEXEDDB_TEST_DATABASE_NAME,
       this.clientId,
       this.user
     );
@@ -1177,7 +1181,7 @@ class IndexedDbTestRunner extends TestRunner {
     serializer: JsonProtoSerializer
   ): Promise<Persistence> {
     const persistence = new IndexedDbPersistence(
-      IndexedDbTestRunner.TEST_DB_NAME,
+      INDEXEDDB_TEST_DATABASE_INFO,
       this.clientId,
       this.platform,
       this.queue,
@@ -1189,9 +1193,7 @@ class IndexedDbTestRunner extends TestRunner {
   }
 
   static destroyPersistence(): Promise<void> {
-    return SimpleDb.delete(
-      IndexedDbTestRunner.TEST_DB_NAME + IndexedDbPersistence.MAIN_DATABASE
-    );
+    return SimpleDb.delete(INDEXEDDB_TEST_DATABASE_NAME);
   }
 }
 
@@ -1538,7 +1540,8 @@ async function writePrimaryClientToIndexedDb(
   clientId: ClientId
 ): Promise<void> {
   const db = await SimpleDb.openOrCreate(
-    IndexedDbTestRunner.TEST_DB_NAME + IndexedDbPersistence.MAIN_DATABASE,
+    INDEXEDDB_TEST_DATABASE_ID,
+    INDEXEDDB_TEST_DATABASE_NAME,
     SCHEMA_VERSION,
     createOrUpgradeDb
   );

--- a/packages/firestore/test/unit/specs/spec_test_runner.ts
+++ b/packages/firestore/test/unit/specs/spec_test_runner.ts
@@ -109,9 +109,9 @@ import {
 } from '../../../src/local/indexeddb_schema';
 import { TestPlatform, SharedFakeWebStorage } from '../../util/test_platform';
 import {
-  INDEXEDDB_TEST_DATABASE_ID,
-  INDEXEDDB_TEST_DATABASE_INFO,
-  INDEXEDDB_TEST_DATABASE_NAME
+  INDEXEDDB_TEST_DATABASE_NAME,
+  INDEXEDDB_TEST_SERIALIZER,
+  TEST_PERSISTENCE_PREFIX
 } from '../local/persistence_test_helpers';
 
 class MockConnection implements Connection {
@@ -1171,7 +1171,7 @@ class IndexedDbTestRunner extends TestRunner {
     return new WebStorageSharedClientState(
       this.queue,
       this.platform,
-      INDEXEDDB_TEST_DATABASE_NAME,
+      TEST_PERSISTENCE_PREFIX,
       this.clientId,
       this.user
     );
@@ -1181,7 +1181,7 @@ class IndexedDbTestRunner extends TestRunner {
     serializer: JsonProtoSerializer
   ): Promise<Persistence> {
     const persistence = new IndexedDbPersistence(
-      INDEXEDDB_TEST_DATABASE_INFO,
+      TEST_PERSISTENCE_PREFIX,
       this.clientId,
       this.platform,
       this.queue,
@@ -1542,7 +1542,7 @@ async function writePrimaryClientToIndexedDb(
   const db = await SimpleDb.openOrCreate(
     INDEXEDDB_TEST_DATABASE_NAME,
     SCHEMA_VERSION,
-    new SchemaConverter(INDEXEDDB_TEST_DATABASE_ID)
+    new SchemaConverter(INDEXEDDB_TEST_SERIALIZER)
   );
   await db.runTransaction('readwrite', [DbPrimaryClient.store], txn => {
     const primaryClientStore = txn.store<DbPrimaryClientKey, DbPrimaryClient>(

--- a/packages/firestore/test/unit/specs/spec_test_runner.ts
+++ b/packages/firestore/test/unit/specs/spec_test_runner.ts
@@ -102,10 +102,10 @@ import {
   WebStorageSharedClientState
 } from '../../../src/local/shared_client_state';
 import {
-  createOrUpgradeDb,
   DbPrimaryClient,
   DbPrimaryClientKey,
-  SCHEMA_VERSION
+  SCHEMA_VERSION,
+  SchemaConverter
 } from '../../../src/local/indexeddb_schema';
 import { TestPlatform, SharedFakeWebStorage } from '../../util/test_platform';
 import {
@@ -1540,10 +1540,9 @@ async function writePrimaryClientToIndexedDb(
   clientId: ClientId
 ): Promise<void> {
   const db = await SimpleDb.openOrCreate(
-    INDEXEDDB_TEST_DATABASE_ID,
     INDEXEDDB_TEST_DATABASE_NAME,
     SCHEMA_VERSION,
-    createOrUpgradeDb
+    new SchemaConverter(INDEXEDDB_TEST_DATABASE_ID)
   );
   await db.runTransaction('readwrite', [DbPrimaryClient.store], txn => {
     const primaryClientStore = txn.store<DbPrimaryClientKey, DbPrimaryClient>(

--- a/packages/firestore/test/util/helpers.ts
+++ b/packages/firestore/test/util/helpers.ts
@@ -161,8 +161,8 @@ export function keys(
   return keys;
 }
 
-export function path(path: string): ResourcePath {
-  return new ResourcePath(splitPath(path, '/'));
+export function path(path: string, offset?: number): ResourcePath {
+  return new ResourcePath(splitPath(path, '/'), offset);
 }
 
 export function field(path: string): FieldPath {


### PR DESCRIPTION
This PR adds the schema migration that drops existing held write acks one last time. This is part of https://github.com/firebase/firebase-js-sdk/pull/1135

The migration itself is not running yet since the SchemaVersion is still set to 4.

As part of this, I have to plumb through DatabaseId to the migration code. I also started using the same Database names in all tests.