### PR TITLE
Adding SnapshotVersion to SharedClientState

### DIFF
--- a/packages/firestore/src/local/local_store.ts
+++ b/packages/firestore/src/local/local_store.ts
@@ -954,6 +954,7 @@ export class LocalStore {
           // is committed. b/33446471 will remove this reliance.
           this.sharedClientState.updateMutationState(
             batchResult.batch.batchId,
+            SnapshotVersion.MIN, // TODO: Replace with batch version from commit
             'acknowledged'
           );
         });

--- a/packages/firestore/src/local/shared_client_state_syncer.ts
+++ b/packages/firestore/src/local/shared_client_state_syncer.ts
@@ -17,6 +17,7 @@
 import { BatchId, MutationBatchState, TargetId } from '../core/types';
 import { FirestoreError } from '../util/error';
 import { ClientId } from './shared_client_state';
+import { SnapshotVersion } from '../core/snapshot_version';
 
 /** The different states of a watch target. */
 export type QueryTargetState = 'not-current' | 'current' | 'rejected';
@@ -34,6 +35,7 @@ export interface SharedClientStateSyncer {
   /** Applies a mutation state to an existing batch.  */
   applyBatchState(
     batchId: BatchId,
+    snapshotVersion: SnapshotVersion,
     state: MutationBatchState,
     error?: FirestoreError
   ): Promise<void>;
@@ -41,6 +43,7 @@ export interface SharedClientStateSyncer {
   /** Applies a query target change from a different tab. */
   applyTargetState(
     targetId: TargetId,
+    snapshotVersion: SnapshotVersion,
     state: QueryTargetState,
     error?: FirestoreError
   ): Promise<void>;

--- a/packages/firestore/src/remote/remote_event.ts
+++ b/packages/firestore/src/remote/remote_event.ts
@@ -65,6 +65,7 @@ export class RemoteEvent {
    */
   // PORTING NOTE: Multi-tab only
   static createSynthesizedRemoteEventForCurrentChange(
+    snapshotVersion: SnapshotVersion,
     targetId: TargetId,
     current: boolean
   ): RemoteEvent {
@@ -75,8 +76,24 @@ export class RemoteEvent {
       )
     };
     return new RemoteEvent(
-      SnapshotVersion.MIN,
+      snapshotVersion,
       targetChanges,
+      targetIdSet(),
+      maybeDocumentMap(),
+      documentKeySet()
+    );
+  }
+
+  /**
+   * Create a synthesized remote event that is used to apply the commit version
+   * of a successful write to a View.
+   */
+  static createSynthesizedRemoteEventForSuccessfulWrite(
+    snapshotVersion: SnapshotVersion
+  ): RemoteEvent {
+    return new RemoteEvent(
+      snapshotVersion,
+      [],
       targetIdSet(),
       maybeDocumentMap(),
       documentKeySet()

--- a/packages/firestore/test/unit/local/persistence_test_helpers.ts
+++ b/packages/firestore/test/unit/local/persistence_test_helpers.ts
@@ -38,7 +38,7 @@ import {
 import { FirestoreError } from '../../../src/util/error';
 import { AutoId } from '../../../src/util/misc';
 import { PlatformSupport } from '../../../src/platform/platform';
-import {SnapshotVersion} from '../../../src/core/snapshot_version';
+import { SnapshotVersion } from '../../../src/core/snapshot_version';
 
 /** The persistence prefix used for testing in IndexedBD and LocalStorage. */
 export const TEST_PERSISTENCE_PREFIX =
@@ -91,7 +91,7 @@ class NoOpSharedClientStateSyncer implements SharedClientStateSyncer {
   constructor(private readonly activeClients: ClientId[]) {}
   async applyBatchState(
     batchId: BatchId,
-    snapshotVersion:SnapshotVersion,
+    snapshotVersion: SnapshotVersion,
     state: MutationBatchState,
     error?: FirestoreError
   ): Promise<void> {}
@@ -105,7 +105,7 @@ class NoOpSharedClientStateSyncer implements SharedClientStateSyncer {
   }
   async applyTargetState(
     targetId: TargetId,
-    snapshotVersion:SnapshotVersion,
+    snapshotVersion: SnapshotVersion,
     state: QueryTargetState,
     error?: FirestoreError
   ): Promise<void> {}

--- a/packages/firestore/test/unit/local/persistence_test_helpers.ts
+++ b/packages/firestore/test/unit/local/persistence_test_helpers.ts
@@ -38,6 +38,7 @@ import {
 import { FirestoreError } from '../../../src/util/error';
 import { AutoId } from '../../../src/util/misc';
 import { PlatformSupport } from '../../../src/platform/platform';
+import {SnapshotVersion} from '../../../src/core/snapshot_version';
 
 /** The persistence prefix used for testing in IndexedBD and LocalStorage. */
 export const TEST_PERSISTENCE_PREFIX =
@@ -90,6 +91,7 @@ class NoOpSharedClientStateSyncer implements SharedClientStateSyncer {
   constructor(private readonly activeClients: ClientId[]) {}
   async applyBatchState(
     batchId: BatchId,
+    snapshotVersion:SnapshotVersion,
     state: MutationBatchState,
     error?: FirestoreError
   ): Promise<void> {}
@@ -103,6 +105,7 @@ class NoOpSharedClientStateSyncer implements SharedClientStateSyncer {
   }
   async applyTargetState(
     targetId: TargetId,
+    snapshotVersion:SnapshotVersion,
     state: QueryTargetState,
     error?: FirestoreError
   ): Promise<void> {}

--- a/packages/firestore/test/unit/local/web_storage_shared_client_state.test.ts
+++ b/packages/firestore/test/unit/local/web_storage_shared_client_state.test.ts
@@ -46,10 +46,13 @@ import { PlatformSupport } from '../../../src/platform/platform';
 import * as objUtils from '../../../src/util/obj';
 import { targetIdSet } from '../../../src/model/collections';
 import { SortedSet } from '../../../src/util/sorted_set';
+import { SnapshotVersion } from '../../../src/core/snapshot_version';
+import { version } from '../../util/helpers';
 
 const AUTHENTICATED_USER = new User('test');
 const UNAUTHENTICATED_USER = User.UNAUTHENTICATED;
 const TEST_ERROR = new FirestoreError('internal', 'Test Error');
+const TEST_SNAPSHOT_VERSION = version(42);
 
 function mutationKey(user: User, batchId: BatchId): string {
   if (user.isAuthenticated()) {
@@ -91,10 +94,18 @@ interface TestSharedClientState {
  */
 class TestSharedClientSyncer implements SharedClientStateSyncer {
   private mutationState: {
-    [batchId: number]: { state: MutationBatchState; error?: FirestoreError };
+    [batchId: number]: {
+      snapshotVersion: SnapshotVersion;
+      state: MutationBatchState;
+      error?: FirestoreError;
+    };
   } = {};
   private queryState: {
-    [targetId: number]: { state: QueryTargetState; error?: FirestoreError };
+    [targetId: number]: {
+      snapshotVersion: SnapshotVersion;
+      state: QueryTargetState;
+      error?: FirestoreError;
+    };
   } = {};
   private activeTargets = targetIdSet();
   private onlineState = OnlineState.Unknown;
@@ -113,18 +124,20 @@ class TestSharedClientSyncer implements SharedClientStateSyncer {
 
   async applyBatchState(
     batchId: BatchId,
+    snapshotVersion: SnapshotVersion,
     state: MutationBatchState,
     error?: FirestoreError
   ): Promise<void> {
-    this.mutationState[batchId] = { state, error };
+    this.mutationState[batchId] = { snapshotVersion, state, error };
   }
 
   async applyTargetState(
     targetId: TargetId,
+    snapshotVersion: SnapshotVersion,
     state: QueryTargetState,
     error?: FirestoreError
   ): Promise<void> {
-    this.queryState[targetId] = { state, error };
+    this.queryState[targetId] = { snapshotVersion, state, error };
   }
 
   async getActiveClients(): Promise<ClientId[]> {
@@ -148,6 +161,14 @@ class TestSharedClientSyncer implements SharedClientStateSyncer {
   applyOnlineStateChange(onlineState: OnlineState): void {
     this.onlineState = onlineState;
   }
+}
+
+function verifySnapshotVersion(
+  actual: { seconds: number; nanos: number },
+  expected: SnapshotVersion
+): void {
+  expect(actual.seconds).to.equal(expected.toTimestamp().seconds);
+  expect(actual.nanos).to.equal(expected.toTimestamp().nanoseconds);
 }
 
 describe('WebStorageSharedClientState', () => {
@@ -246,9 +267,15 @@ describe('WebStorageSharedClientState', () => {
 
       expect(actual.state).to.equal(mutationBatchState);
 
-      const expectedMembers = ['state'];
+      const expectedMembers = ['state', 'snapshotVersion'];
 
-      if (mutationBatchState === 'rejected') {
+      if (mutationBatchState === 'pending') {
+        verifySnapshotVersion(actual.snapshotVersion, SnapshotVersion.MIN);
+      } else if (mutationBatchState === 'acknowledged') {
+        verifySnapshotVersion(actual.snapshotVersion, TEST_SNAPSHOT_VERSION);
+      } else if (mutationBatchState === 'rejected') {
+        verifySnapshotVersion(actual.snapshotVersion, SnapshotVersion.MIN);
+
         expectedMembers.push('error');
         expect(actual.error.code).to.equal(err.code);
         expect(actual.error.message).to.equal(err.message);
@@ -274,7 +301,11 @@ describe('WebStorageSharedClientState', () => {
     it('with an acknowledged batch', () => {
       sharedClientState.addPendingMutation(0);
       assertBatchState(0, 'pending');
-      sharedClientState.updateMutationState(0, 'acknowledged');
+      sharedClientState.updateMutationState(
+        0,
+        TEST_SNAPSHOT_VERSION,
+        'acknowledged'
+      );
       // The entry is garbage collected immediately.
       assertNoBatchState(0);
     });
@@ -282,7 +313,12 @@ describe('WebStorageSharedClientState', () => {
     it('with a rejected batch', () => {
       sharedClientState.addPendingMutation(0);
       assertBatchState(0, 'pending');
-      sharedClientState.updateMutationState(0, 'rejected', TEST_ERROR);
+      sharedClientState.updateMutationState(
+        0,
+        TEST_SNAPSHOT_VERSION,
+        'rejected',
+        TEST_ERROR
+      );
       // The entry is garbage collected immediately.
       assertNoBatchState(0);
     });
@@ -300,8 +336,15 @@ describe('WebStorageSharedClientState', () => {
         const actual = JSON.parse(localStorage.getItem(targetKey(targetId)));
         expect(actual.state).to.equal(queryTargetState);
 
-        const expectedMembers = ['state'];
-        if (queryTargetState === 'rejected') {
+        const expectedMembers = ['state', 'snapshotVersion'];
+
+        if (queryTargetState === 'pending') {
+          verifySnapshotVersion(actual.snapshotVersion, SnapshotVersion.MIN);
+        } else if (queryTargetState === 'acknowledged') {
+          verifySnapshotVersion(actual.snapshotVersion, TEST_SNAPSHOT_VERSION);
+        } else if (queryTargetState === 'rejected') {
+          verifySnapshotVersion(actual.snapshotVersion, SnapshotVersion.MIN);
+
           expectedMembers.push('error');
           expect(actual.error.code).to.equal(err.code);
           expect(actual.error.message).to.equal(err.message);
@@ -337,7 +380,11 @@ describe('WebStorageSharedClientState', () => {
       sharedClientState.addLocalQueryTarget(0);
       assertClientState([0]);
       assertTargetState(0, 'pending');
-      sharedClientState.updateQueryState(0, 'not-current');
+      sharedClientState.updateQueryState(
+        0,
+        TEST_SNAPSHOT_VERSION,
+        'not-current'
+      );
       assertTargetState(0, 'not-current');
     });
 
@@ -345,9 +392,13 @@ describe('WebStorageSharedClientState', () => {
       sharedClientState.addLocalQueryTarget(0);
       assertClientState([0]);
       assertTargetState(0, 'pending');
-      sharedClientState.updateQueryState(0, 'not-current');
+      sharedClientState.updateQueryState(
+        0,
+        TEST_SNAPSHOT_VERSION,
+        'not-current'
+      );
       assertTargetState(0, 'not-current');
-      sharedClientState.updateQueryState(0, 'current');
+      sharedClientState.updateQueryState(0, TEST_SNAPSHOT_VERSION, 'current');
       assertTargetState(0, 'current');
     });
 
@@ -355,13 +406,18 @@ describe('WebStorageSharedClientState', () => {
       sharedClientState.addLocalQueryTarget(0);
       assertClientState([0]);
       assertTargetState(0, 'pending');
-      sharedClientState.updateQueryState(0, 'rejected', TEST_ERROR);
+      sharedClientState.updateQueryState(
+        0,
+        SnapshotVersion.MIN,
+        'rejected',
+        TEST_ERROR
+      );
       assertTargetState(0, 'rejected', TEST_ERROR);
     });
 
     it('garbage collects entry', () => {
       sharedClientState.addLocalQueryTarget(0);
-      sharedClientState.updateQueryState(0, 'current');
+      sharedClientState.updateQueryState(0, TEST_SNAPSHOT_VERSION, 'current');
       assertTargetState(0, 'current');
       sharedClientState.removeLocalQueryTarget(0);
       assertTargetState(0, 'current');
@@ -560,6 +616,7 @@ describe('WebStorageSharedClientState', () => {
           new MutationMetadata(
             AUTHENTICATED_USER,
             1,
+            SnapshotVersion.MIN,
             'pending'
           ).toLocalStorageJSON()
         );
@@ -576,6 +633,7 @@ describe('WebStorageSharedClientState', () => {
           new MutationMetadata(
             AUTHENTICATED_USER,
             1,
+            TEST_SNAPSHOT_VERSION,
             'acknowledged'
           ).toLocalStorageJSON()
         );
@@ -592,6 +650,7 @@ describe('WebStorageSharedClientState', () => {
           new MutationMetadata(
             AUTHENTICATED_USER,
             1,
+            TEST_SNAPSHOT_VERSION,
             'rejected',
             TEST_ERROR
           ).toLocalStorageJSON()
@@ -613,6 +672,7 @@ describe('WebStorageSharedClientState', () => {
           new MutationMetadata(
             UNAUTHENTICATED_USER,
             1,
+            SnapshotVersion.MIN,
             'pending'
           ).toLocalStorageJSON()
         );
@@ -631,12 +691,18 @@ describe('WebStorageSharedClientState', () => {
           new MutationMetadata(
             AUTHENTICATED_USER,
             1,
+            SnapshotVersion.MIN,
             'pending'
           ).toLocalStorageJSON()
         );
         writeToLocalStorage(
           mutationKey(otherUser, 1),
-          new MutationMetadata(otherUser, 2, 'pending').toLocalStorageJSON()
+          new MutationMetadata(
+            otherUser,
+            2,
+            SnapshotVersion.MIN,
+            'pending'
+          ).toLocalStorageJSON()
         );
       }).then(clientState => {
         expect(clientState.mutationCount).to.equal(1);
@@ -651,6 +717,7 @@ describe('WebStorageSharedClientState', () => {
           new MutationMetadata(
             AUTHENTICATED_USER,
             1,
+            TEST_SNAPSHOT_VERSION,
             'invalid' as any // tslint:disable-line:no-any
           ).toLocalStorageJSON()
         );
@@ -758,6 +825,7 @@ describe('WebStorageSharedClientState', () => {
           targetKey(firstClientTargetId),
           new QueryTargetMetadata(
             firstClientTargetId,
+            TEST_SNAPSHOT_VERSION,
             'not-current'
           ).toLocalStorageJSON()
         );
@@ -775,6 +843,7 @@ describe('WebStorageSharedClientState', () => {
           targetKey(firstClientTargetId),
           new QueryTargetMetadata(
             firstClientTargetId,
+            TEST_SNAPSHOT_VERSION,
             'current'
           ).toLocalStorageJSON()
         );
@@ -792,6 +861,7 @@ describe('WebStorageSharedClientState', () => {
           targetKey(1),
           new QueryTargetMetadata(
             firstClientTargetId,
+            SnapshotVersion.MIN,
             'rejected',
             TEST_ERROR
           ).toLocalStorageJSON()
@@ -815,6 +885,7 @@ describe('WebStorageSharedClientState', () => {
           targetKey(firstClientTargetId),
           new QueryTargetMetadata(
             firstClientTargetId,
+            TEST_SNAPSHOT_VERSION,
             'invalid' as any // tslint:disable-line:no-any
           ).toLocalStorageJSON()
         );


### PR DESCRIPTION
This PR is a part of #1135 and adds the SnapshotVersion to the state that is tracked in LocalStorage. This allows us to use this snapshot version in secondary clients during multi-tab to update their views.

A change from #1135 is that I updated the code to store the timestamps as an object of { seconds, nanos} instead of plain microseconds.