### PR TITLE
Remove Multi-Tab TODOs

### DIFF
--- a/packages/firestore/src/core/sync_engine.ts
+++ b/packages/firestore/src/core/sync_engine.ts
@@ -811,7 +811,6 @@ export class SyncEngine implements RemoteSyncer, SharedClientStateSyncer {
     await Promise.all(queriesProcessed);
     this.syncEngineListener.onWatchChange(newSnaps);
     this.localStore.notifyLocalViewChanges(docChangesInAllViews);
-    // TODO(multitab): Multitab garbage collection
     if (this.isPrimary) {
       await this.localStore
         .collectGarbage()

--- a/packages/firestore/src/local/indexeddb_persistence.ts
+++ b/packages/firestore/src/local/indexeddb_persistence.ts
@@ -905,7 +905,6 @@ export class IndexedDbPersistence implements Persistence {
    */
   private markClientZombied(): void {
     try {
-      // TODO(multitab): Garbage Collect Local Storage
       this.window.localStorage.setItem(
         this.zombiedClientLocalStorageKey(this.clientId),
         String(Date.now())

--- a/packages/firestore/src/local/indexeddb_remote_document_cache.ts
+++ b/packages/firestore/src/local/indexeddb_remote_document_cache.ts
@@ -106,7 +106,6 @@ export class IndexedDbRemoteDocumentCache implements RemoteDocumentCache {
       }
 
       if (this.keepDocumentChangeLog) {
-        // TODO(multitab): GC the documentChanges store.
         promises.push(
           documentChangesStore(transaction).put({
             changes: this.serializer.toDbResourcePaths(changedKeys)

--- a/packages/firestore/src/local/persistence.ts
+++ b/packages/firestore/src/local/persistence.ts
@@ -79,9 +79,6 @@ export type PrimaryStateListener = (isPrimary: boolean) => Promise<void>;
  * writes in order to avoid relying on being able to read back uncommitted
  * writes.
  */
-// TODO(multitab): Instead of marking methods as multi-tab safe, we should
-// point out (and maybe enforce) when methods cannot safely be used from
-// secondary tabs.
 export interface Persistence {
   /**
    * Whether or not this persistence instance has been started.

--- a/packages/firestore/src/local/shared_client_state.ts
+++ b/packages/firestore/src/local/shared_client_state.ts
@@ -758,12 +758,12 @@ export class WebStorageSharedClientState implements SharedClientState {
     if (event.storageArea === this.storage) {
       debug(LOG_TAG, 'EVENT', event.key, event.newValue);
 
-      if (
-          event.key === this.localClientStorageKey) {
-      error('Received LocalStorage notification for local change. Another client might have garbage-collected our state'
-      );
-      return;
-    }
+      if (event.key === this.localClientStorageKey) {
+        error(
+          'Received LocalStorage notification for local change. Another client might have garbage-collected our state'
+        );
+        return;
+      }
 
       this.queue.enqueueAndForget(async () => {
         if (!this.started) {

--- a/packages/firestore/src/local/shared_client_state.ts
+++ b/packages/firestore/src/local/shared_client_state.ts
@@ -571,8 +571,6 @@ export class WebStorageSharedClientState implements SharedClientState {
     return platform.window && platform.window.localStorage != null;
   }
 
-  // TOOD(multitab): Register the mutations that are already pending at client
-  // startup.
   async start(): Promise<void> {
     assert(!this.started, 'WebStorageSharedClientState already started');
     assert(
@@ -758,14 +756,14 @@ export class WebStorageSharedClientState implements SharedClientState {
 
   private handleLocalStorageEvent(event: StorageEvent): void {
     if (event.storageArea === this.storage) {
-      // TODO(multitab): This assert will likely become invalid as we add garbage
-      // collection.
-      assert(
-        event.key !== this.localClientStorageKey,
-        'Received LocalStorage notification for local change.'
-      );
-
       debug(LOG_TAG, 'EVENT', event.key, event.newValue);
+
+      if (
+          event.key === this.localClientStorageKey) {
+      error('Received LocalStorage notification for local change. Another client might have garbage-collected our state'
+      );
+      return;
+    }
 
       this.queue.enqueueAndForget(async () => {
         if (!this.started) {

--- a/packages/firestore/test/unit/specs/describe_spec.ts
+++ b/packages/firestore/test/unit/specs/describe_spec.ts
@@ -45,7 +45,7 @@ const KNOWN_TAGS = [
   DURABLE_PERSISTENCE_TAG
 ];
 
-// TOOD(mrschmidt): Make this configurable with mocha options.
+// TODO(mrschmidt): Make this configurable with mocha options.
 const RUN_BENCHMARK_TESTS = false;
 
 // The format of one describeSpec written to a JSON file.


### PR DESCRIPTION
This PR removes Multi-Tab TODOs that are no longer applicable. The GC work is mostly done (with the exception of b/112717384), and we don't need to register pending mutations at startup in LocalStorage since we won't raise callbacks for these and will instead keep track of the changes in the remote document change log.