### PR TITLE
Remove start() from Persistence interface

### DIFF
--- a/packages/firestore/src/local/indexeddb_persistence.ts
+++ b/packages/firestore/src/local/indexeddb_persistence.ts
@@ -299,7 +299,7 @@ export class IndexedDbPersistence implements Persistence {
    *
    * @return {Promise<void>} Whether persistence was enabled.
    */
-  start(): Promise<void> {
+  private start(): Promise<void> {
     assert(!this.started, 'IndexedDbPersistence double-started!');
     assert(this.window !== null, "Expected 'window' to be defined");
 

--- a/packages/firestore/src/local/indexeddb_persistence.ts
+++ b/packages/firestore/src/local/indexeddb_persistence.ts
@@ -156,6 +156,9 @@ export class IndexedDbTransaction extends PersistenceTransaction {
  * TODO(multitab): Remove `experimentalTabSynchronization` section when
  * multi-tab is no longer optional.
  */
+type MultiClientParams = {
+  sequenceNumberSyncer: SequenceNumberSyncer;
+};
 export class IndexedDbPersistence implements Persistence {
   static getStore<Key extends IDBValidKey, Value>(
     txn: PersistenceTransaction,
@@ -200,9 +203,7 @@ export class IndexedDbPersistence implements Persistence {
     platform: Platform,
     queue: AsyncQueue,
     serializer: JsonProtoSerializer,
-    multiClientParams: {
-      sequenceNumberSyncer: SequenceNumberSyncer;
-    }
+    multiClientParams: MultiClientParams
   ): Promise<IndexedDbPersistence> {
     const persistence = new IndexedDbPersistence(
       persistenceKey,
@@ -260,9 +261,7 @@ export class IndexedDbPersistence implements Persistence {
     platform: Platform,
     private readonly queue: AsyncQueue,
     serializer: JsonProtoSerializer,
-    private readonly multiClientParams?: {
-      sequenceNumberSyncer: SequenceNumberSyncer;
-    }
+    private readonly multiClientParams?: MultiClientParams
   ) {
     if (!IndexedDbPersistence.isAvailable()) {
       throw new FirestoreError(

--- a/packages/firestore/src/local/indexeddb_persistence.ts
+++ b/packages/firestore/src/local/indexeddb_persistence.ts
@@ -156,7 +156,7 @@ export class IndexedDbTransaction extends PersistenceTransaction {
  * TODO(multitab): Remove `experimentalTabSynchronization` section when
  * multi-tab is no longer optional.
  */
-type MultiClientParams = {
+export type MultiClientParams = {
   sequenceNumberSyncer: SequenceNumberSyncer;
 };
 export class IndexedDbPersistence implements Persistence {

--- a/packages/firestore/src/local/indexeddb_persistence.ts
+++ b/packages/firestore/src/local/indexeddb_persistence.ts
@@ -183,7 +183,13 @@ export class IndexedDbPersistence implements Persistence {
     queue: AsyncQueue,
     serializer: JsonProtoSerializer
   ): Promise<IndexedDbPersistence> {
-    const persistence = new IndexedDbPersistence(persistenceKey, clientId, platform, queue, serializer);
+    const persistence = new IndexedDbPersistence(
+      persistenceKey,
+      clientId,
+      platform,
+      queue,
+      serializer
+    );
     await persistence.start();
     return persistence;
   }
@@ -198,7 +204,14 @@ export class IndexedDbPersistence implements Persistence {
       sequenceNumberSyncer: SequenceNumberSyncer;
     }
   ): Promise<IndexedDbPersistence> {
-    const persistence = new IndexedDbPersistence(persistenceKey, clientId, platform, queue, serializer, multiClientParams);
+    const persistence = new IndexedDbPersistence(
+      persistenceKey,
+      clientId,
+      platform,
+      queue,
+      serializer,
+      multiClientParams
+    );
     await persistence.start();
     return persistence;
   }

--- a/packages/firestore/src/local/indexeddb_persistence.ts
+++ b/packages/firestore/src/local/indexeddb_persistence.ts
@@ -176,6 +176,33 @@ export class IndexedDbPersistence implements Persistence {
    */
   static MAIN_DATABASE = 'main';
 
+  static async createIndexedDbPersistence(
+    persistenceKey: string,
+    clientId: ClientId,
+    platform: Platform,
+    queue: AsyncQueue,
+    serializer: JsonProtoSerializer
+  ): Promise<IndexedDbPersistence> {
+    const persistence = new IndexedDbPersistence(persistenceKey, clientId, platform, queue, serializer);
+    await persistence.start();
+    return persistence;
+  }
+
+  static async createMultiClientIndexedDbPersistence(
+    persistenceKey: string,
+    clientId: ClientId,
+    platform: Platform,
+    queue: AsyncQueue,
+    serializer: JsonProtoSerializer,
+    multiClientParams: {
+      sequenceNumberSyncer: SequenceNumberSyncer;
+    }
+  ): Promise<IndexedDbPersistence> {
+    const persistence = new IndexedDbPersistence(persistenceKey, clientId, platform, queue, serializer, multiClientParams);
+    await persistence.start();
+    return persistence;
+  }
+
   private readonly document: Document | null;
   private readonly window: Window;
 
@@ -214,7 +241,7 @@ export class IndexedDbPersistence implements Persistence {
   // Note that `multiClientParams` must be present to enable multi-client support while multi-tab
   // is still experimental. When multi-client is switched to always on, `multiClientParams` will
   // no longer be optional.
-  constructor(
+  private constructor(
     private readonly persistenceKey: string,
     private readonly clientId: ClientId,
     platform: Platform,

--- a/packages/firestore/src/local/indexeddb_persistence.ts
+++ b/packages/firestore/src/local/indexeddb_persistence.ts
@@ -327,6 +327,10 @@ export class IndexedDbPersistence implements Persistence {
       })
       .then(() => {
         this._started = true;
+      })
+      .catch(reason => {
+        this.simpleDb && this.simpleDb.close();
+        return Promise.reject(reason);
       });
   }
 

--- a/packages/firestore/src/local/memory_persistence.ts
+++ b/packages/firestore/src/local/memory_persistence.ts
@@ -54,11 +54,7 @@ export class MemoryPersistence implements Persistence {
 
   private _started = false;
 
-  constructor(private readonly clientId: ClientId) {}
-
-  async start(): Promise<void> {
-    // No durable state to read on startup.
-    assert(!this._started, 'MemoryPersistence double-started!');
+  constructor(private readonly clientId: ClientId) {
     this._started = true;
   }
 

--- a/packages/firestore/src/local/memory_persistence.ts
+++ b/packages/firestore/src/local/memory_persistence.ts
@@ -15,7 +15,6 @@
  */
 
 import { User } from '../auth/user';
-import { assert } from '../util/assert';
 import { debug } from '../util/log';
 
 import { MemoryMutationQueue } from './memory_mutation_queue';

--- a/packages/firestore/src/local/persistence.ts
+++ b/packages/firestore/src/local/persistence.ts
@@ -89,13 +89,6 @@ export interface Persistence {
   readonly started: boolean;
 
   /**
-   * Starts persistent storage, opening the database or similar.
-   *
-   * Throws an exception if the database could not be opened.
-   */
-  start(): Promise<void>;
-
-  /**
    * Releases any resources held during eager shutdown.
    *
    * @param deleteData Whether to delete the persisted data. This causes

--- a/packages/firestore/test/unit/local/indexeddb_persistence.test.ts
+++ b/packages/firestore/test/unit/local/indexeddb_persistence.test.ts
@@ -106,9 +106,6 @@ async function withCustomPersistence(
     PlatformSupport.getPlatform(),
     new SharedFakeWebStorage()
   );
-  if (settings.experimentalTabSynchronization) {
-  } else {
-  }
   const persistence = await (settings.experimentalTabSynchronization
     ? IndexedDbPersistence.createMultiClientIndexedDbPersistence(
         TEST_PERSISTENCE_PREFIX,

--- a/packages/firestore/test/unit/local/indexeddb_persistence.test.ts
+++ b/packages/firestore/test/unit/local/indexeddb_persistence.test.ts
@@ -107,29 +107,26 @@ async function withCustomPersistence(
     new SharedFakeWebStorage()
   );
   if (settings.experimentalTabSynchronization) {
-
   } else {
-
   }
-  const persistence = await (
-    settings.experimentalTabSynchronization
-      ? IndexedDbPersistence.createMultiClientIndexedDbPersistence(
-          TEST_PERSISTENCE_PREFIX,
-          clientId,
-          platform,
-          queue,
-          serializer,{
-            sequenceNumberSyncer: MOCK_SEQUENCE_NUMBER_SYNCER
-          }
-        )
-      : IndexedDbPersistence.createIndexedDbPersistence(
-          TEST_PERSISTENCE_PREFIX,
-          clientId,
-          platform,
-          queue,
-          serializer
-        )
-  );
+  const persistence = await (settings.experimentalTabSynchronization
+    ? IndexedDbPersistence.createMultiClientIndexedDbPersistence(
+        TEST_PERSISTENCE_PREFIX,
+        clientId,
+        platform,
+        queue,
+        serializer,
+        {
+          sequenceNumberSyncer: MOCK_SEQUENCE_NUMBER_SYNCER
+        }
+      )
+    : IndexedDbPersistence.createIndexedDbPersistence(
+        TEST_PERSISTENCE_PREFIX,
+        clientId,
+        platform,
+        queue,
+        serializer
+      ));
 
   await fn(persistence, platform, queue);
   await persistence.shutdown();
@@ -621,7 +618,9 @@ describe('IndexedDb: allowTabSynchronization', () => {
 
   it('rejects access when synchronization is disabled', async () => {
     await withPersistence('clientA', async db1 => {
-      await expect(withPersistence('clientB', db2 => Promise.resolve())).to.eventually.be.rejectedWith(
+      await expect(
+        withPersistence('clientB', db2 => Promise.resolve())
+      ).to.eventually.be.rejectedWith(
         'There is another tab open with offline persistence enabled.'
       );
     });
@@ -629,8 +628,7 @@ describe('IndexedDb: allowTabSynchronization', () => {
 
   it('grants access when synchronization is enabled', async () => {
     return withMultiClientPersistence('clientA', async db1 => {
-      await withMultiClientPersistence('clientB', async db2 => {
-      });
+      await withMultiClientPersistence('clientB', async db2 => {});
     });
   });
 });

--- a/packages/firestore/test/unit/local/persistence_test_helpers.ts
+++ b/packages/firestore/test/unit/local/persistence_test_helpers.ts
@@ -105,24 +105,27 @@ export async function testIndexedDbPersistence(
     useProto3Json: true
   });
   const platform = PlatformSupport.getPlatform();
-  const persistence = new IndexedDbPersistence(
-    TEST_PERSISTENCE_PREFIX,
-    clientId,
-    platform,
-    queue,
-    serializer,
-    options.synchronizeTabs
-      ? { sequenceNumberSyncer: MOCK_SEQUENCE_NUMBER_SYNCER }
-      : undefined
-  );
-  await persistence.start();
-  return persistence;
+  return options.synchronizeTabs
+    ? IndexedDbPersistence.createMultiClientIndexedDbPersistence(
+        TEST_PERSISTENCE_PREFIX,
+        clientId,
+        platform,
+        queue,
+        serializer,
+      { sequenceNumberSyncer: MOCK_SEQUENCE_NUMBER_SYNCER }
+      )
+    : IndexedDbPersistence.createIndexedDbPersistence(
+        TEST_PERSISTENCE_PREFIX,
+        clientId,
+        platform,
+        queue,
+        serializer
+      );
 }
 
 /** Creates and starts a MemoryPersistence instance for testing. */
 export async function testMemoryPersistence(): Promise<MemoryPersistence> {
   const persistence = new MemoryPersistence(AutoId.newId());
-  await persistence.start();
   return persistence;
 }
 

--- a/packages/firestore/test/unit/local/persistence_test_helpers.ts
+++ b/packages/firestore/test/unit/local/persistence_test_helpers.ts
@@ -112,7 +112,7 @@ export async function testIndexedDbPersistence(
         platform,
         queue,
         serializer,
-      { sequenceNumberSyncer: MOCK_SEQUENCE_NUMBER_SYNCER }
+        { sequenceNumberSyncer: MOCK_SEQUENCE_NUMBER_SYNCER }
       )
     : IndexedDbPersistence.createIndexedDbPersistence(
         TEST_PERSISTENCE_PREFIX,

--- a/packages/firestore/test/unit/specs/spec_test_runner.ts
+++ b/packages/firestore/test/unit/specs/spec_test_runner.ts
@@ -1156,9 +1156,7 @@ class MemoryTestRunner extends TestRunner {
   protected async initPersistence(
     serializer: JsonProtoSerializer
   ): Promise<Persistence> {
-    const persistence = new MemoryPersistence(this.clientId);
-    await persistence.start();
-    return persistence;
+    return new MemoryPersistence(this.clientId);
   }
 }
 
@@ -1177,10 +1175,10 @@ class IndexedDbTestRunner extends TestRunner {
     );
   }
 
-  protected async initPersistence(
+  protected initPersistence(
     serializer: JsonProtoSerializer
   ): Promise<Persistence> {
-    const persistence = new IndexedDbPersistence(
+    return IndexedDbPersistence.createMultiClientIndexedDbPersistence(
       TEST_PERSISTENCE_PREFIX,
       this.clientId,
       this.platform,
@@ -1188,8 +1186,6 @@ class IndexedDbTestRunner extends TestRunner {
       serializer,
       { sequenceNumberSyncer: this.sharedClientState }
     );
-    await persistence.start();
-    return persistence;
   }
 
   static destroyPersistence(): Promise<void> {

--- a/packages/firestore/test/unit/specs/spec_test_runner.ts
+++ b/packages/firestore/test/unit/specs/spec_test_runner.ts
@@ -1153,10 +1153,10 @@ class MemoryTestRunner extends TestRunner {
     return new MemorySharedClientState();
   }
 
-  protected async initPersistence(
+  protected initPersistence(
     serializer: JsonProtoSerializer
   ): Promise<Persistence> {
-    return new MemoryPersistence(this.clientId);
+    return Promise.resolve(new MemoryPersistence(this.clientId));
   }
 }
 


### PR DESCRIPTION
This PR:
 * removes `start()` from the `Persistence` interface. We always immediately called it after instantiating the persistence layer.
 * Makes the constructor for `IndexedDbPersistence` private.
 * Provides static factory methods on `IndexedDbPersistence`. They return a `Promise` of a fully started instance. The two methods also differentiate between multi-client and not. They can be consolidated when multi-client becomes required for disk persistence.
 * Switch instantiations to use static helpers.

The intention is that if you are able to obtain an instance of `Persistence`, then it is useable. Callers should not have access to unstarted instances.

Note that this PR merges into the `sequence_number` branch to resolve some issues that came up in that PR.