### PR TITLE
Escape the persistence key everywhere & scope online state by project

### DIFF
--- a/packages/firestore/test/unit/local/web_storage_shared_client_state.test.ts
+++ b/packages/firestore/test/unit/local/web_storage_shared_client_state.test.ts
@@ -70,7 +70,7 @@ function targetKey(targetId: TargetId): string {
 }
 
 function onlineStateKey(): string {
-  return 'firestore_online_state';
+  return `firestore_online_state_${persistenceHelpers.TEST_PERSISTENCE_PREFIX}`;
 }
 
 interface TestSharedClientState {


### PR DESCRIPTION
This PR fixes some issues in SharedClientState:

- It used the escapedPersistenceKey everywhere instead of the unescaped version.
- It scopes online state by Firebase App (persistence key). This is needed since only tabs that share the same persistence key communicate through multi-tab.