### PR TITLE
Gracefully handle duplication modified/removed events in rxfire

### DIFF
--- a/packages/rxfire/firestore/collection/index.ts
+++ b/packages/rxfire/firestore/collection/index.ts
@@ -75,17 +75,21 @@ function processIndividualChange(
       }
       break;
     case 'modified':
-      // When an item changes position we first remove it
-      // and then add it's new position
-      if (change.oldIndex !== change.newIndex) {
-        combined.splice(change.oldIndex, 1);
-        combined.splice(change.newIndex, 0, change);
-      } else {
-        combined[change.newIndex] = change;
+      if (combined[change.oldIndex] == null || combined[change.oldIndex].doc.id == change.doc.id) {
+        // When an item changes position we first remove it
+        // and then add it's new position
+        if (change.oldIndex !== change.newIndex) {
+          combined.splice(change.oldIndex, 1);
+          combined.splice(change.newIndex, 0, change);
+        } else {
+          combined[change.newIndex] = change;
+        }
       }
       break;
     case 'removed':
-      combined.splice(change.oldIndex, 1);
+      if (combined[change.oldIndex] && combined[change.oldIndex].doc.id == change.doc.id) {
+        combined.splice(change.oldIndex, 1);
+      }
       break;
   }
   return combined;


### PR DESCRIPTION
Duplicate emissions affect modified and removes as will as insertion. This is a a port of [angularfire#1825](https://github.com/angular/angularfire2/pull/1825).