### PR TITLE
Package.json has bad types reference

### DIFF
--- a/packages/firebase/package.json
+++ b/packages/firebase/package.json
@@ -52,5 +52,5 @@
     "rollup-plugin-uglify": "3.0.0",
     "typescript": "2.8.1"
   },
-  "typings": "dist/index.d.ts"
+  "typings": "index.d.ts"
 }


### PR DESCRIPTION
The reference to the `index.d.ts` file is incorrect in `firebase`.