### PR TITLE
rxfire does not have side-effects, indicate this in the package.json

### DIFF
--- a/packages/rxfire/auth/package.json
+++ b/packages/rxfire/auth/package.json
@@ -2,5 +2,6 @@
   "name": "rxfire/auth",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
-  "typings": "dist/auth/index.d.ts"
+  "typings": "dist/auth/index.d.ts",
+  "sideEffects": false
 }

--- a/packages/rxfire/database/package.json
+++ b/packages/rxfire/database/package.json
@@ -1,5 +1,6 @@
 {
   "name": "rxfire/database",
   "main": "dist/index.cjs.js",
-  "module": "dist/index.esm.js"
+  "module": "dist/index.esm.js",
+  "sideEffects": false
 }

--- a/packages/rxfire/firestore/package.json
+++ b/packages/rxfire/firestore/package.json
@@ -2,5 +2,6 @@
   "name": "rxfire/firestore",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
-  "typings": "dist/firestore/index.d.ts"
+  "typings": "dist/firestore/index.d.ts",
+  "sideEffects": false
 }

--- a/packages/rxfire/functions/package.json
+++ b/packages/rxfire/functions/package.json
@@ -2,5 +2,6 @@
   "name": "rxfire/functions",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
-  "typings": "dist/functions/index.d.ts"
+  "typings": "dist/functions/index.d.ts",
+  "sideEffects": false
 }

--- a/packages/rxfire/package.json
+++ b/packages/rxfire/package.json
@@ -90,5 +90,6 @@
     "/rxfire-storage.js.map",
     "/rxfire-database.js",
     "/rxfire-database.js.map"
-  ]
+  ],
+  "sideEffects": false
 }

--- a/packages/rxfire/storage/package.json
+++ b/packages/rxfire/storage/package.json
@@ -2,5 +2,6 @@
   "name": "rxfire/storage",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
-  "typings": "dist/storage/index.d.ts"
+  "typings": "dist/storage/index.d.ts",
+  "sideEffects": false
 }


### PR DESCRIPTION
Indicate to Webpack that rxfire only consists of pure functions with `"sideEffects": false` in the `package.json`. This allows further optimization, [see Tree Shaking in the Webpack docs](https://webpack.js.org/guides/tree-shaking/#mark-the-file-as-side-effect-free).