### PR TITLE
Remove TODOs

### DIFF
--- a/packages/firestore/src/local/indexeddb_persistence.ts
+++ b/packages/firestore/src/local/indexeddb_persistence.ts
@@ -717,8 +717,6 @@ export class IndexedDbPersistence implements Persistence {
       transaction: PersistenceTransaction
     ) => PersistencePromise<T>
   ): Promise<T> {
-    // TODO(multitab): Consider removing `requirePrimaryLease` and exposing
-    // three different write modes (readonly, readwrite, readwrite_primary).
     log.debug(LOG_TAG, 'Starting transaction:', action);
 
     // Do all transactions as readwrite against all object stores, since we

--- a/packages/firestore/src/local/shared_client_state_syncer.ts
+++ b/packages/firestore/src/local/shared_client_state_syncer.ts
@@ -26,11 +26,6 @@ export type QueryTargetState = 'not-current' | 'current' | 'rejected';
  * perform on a cooperating synchronization engine.
  */
 export interface SharedClientStateSyncer {
-  // TODO(multitab): Consider different names for these methods that convey
-  // that these method are used in multi-tab to load existing batches from
-  // persistence (a possible name for `applyBatchState` could be
-  // `applyBatchFromPersistence`).
-
   /** Applies a mutation state to an existing batch.  */
   applyBatchState(
     batchId: BatchId,

--- a/packages/rxfire/firestore/collection/index.ts
+++ b/packages/rxfire/firestore/collection/index.ts
@@ -75,7 +75,10 @@ function processIndividualChange(
       }
       break;
     case 'modified':
-      if (combined[change.oldIndex] == null || combined[change.oldIndex].doc.id == change.doc.id) {
+      if (
+        combined[change.oldIndex] == null ||
+        combined[change.oldIndex].doc.id == change.doc.id
+      ) {
         // When an item changes position we first remove it
         // and then add it's new position
         if (change.oldIndex !== change.newIndex) {
@@ -87,7 +90,10 @@ function processIndividualChange(
       }
       break;
     case 'removed':
-      if (combined[change.oldIndex] && combined[change.oldIndex].doc.id == change.doc.id) {
+      if (
+        combined[change.oldIndex] &&
+        combined[change.oldIndex].doc.id == change.doc.id
+      ) {
         combined.splice(change.oldIndex, 1);
       }
       break;


### PR DESCRIPTION
This PR removes two TODOs for things that I'd rather keep as is:

-  Consider removing `requirePrimaryLease` and exposing three different write modes (readonly, readwrite, readwrite_primary).

While that is a good idea per se, we don't expose the write mode in `IndexedDbPersistence.runTransaction`.

- SharedClientStateSyncer method renames.

I can't think of a better name that isn't super awkward. `applyBatchFromPersistence`/`synchronizeBatchWithPersistence` all imply things that are only 90% true, since these methods combine state from WebStorage and Persistence.