### PR TITLE
 Don't drop empty objects during merge

### DIFF
--- a/packages/firestore/CHANGELOG.md
+++ b/packages/firestore/CHANGELOG.md
@@ -1,9 +1,11 @@
-# 0.7.3 (Unreleased)
+# 0.7.4 (Unreleased)
 - [fixed] Fixed an issue where the first `get()` call made after being offline
   could incorrectly return cached data without attempting to reach the backend.
 - [changed] Changed `get()` to only make 1 attempt to reach the backend before
   returning cached data, potentially reducing delays while offline. Previously
   it would make 2 attempts, to work around a backend bug.
+- [fixed] Fixed an issue that caused us to drop empty objects from a call to
+  `set(..., { merge: true })`.
 
 # 0.7.2
 - [fixed] Fixed a regression that prevented use of Firestore on ReactNative's

--- a/packages/firestore/CHANGELOG.md
+++ b/packages/firestore/CHANGELOG.md
@@ -4,7 +4,7 @@
 - [changed] Changed `get()` to only make 1 attempt to reach the backend before
   returning cached data, potentially reducing delays while offline. Previously
   it would make 2 attempts, to work around a backend bug.
-- [fixed] Fixed an issue that caused us to drop empty objects from a call to
+- [fixed] Fixed an issue that caused us to drop empty objects from calls to
   `set(..., { merge: true })`.
 
 # 0.7.2

--- a/packages/firestore/src/api/user_data_converter.ts
+++ b/packages/firestore/src/api/user_data_converter.ts
@@ -539,15 +539,25 @@ export class UserDataConverter {
 
   private parseObject(obj: Dict<AnyJs>, context: ParseContext): FieldValue {
     let result = new SortedMap<string, FieldValue>(primitiveComparator);
-    objUtils.forEach(obj, (key: string, val: AnyJs) => {
-      const parsedValue = this.parseData(
-        val,
-        context.childContextForField(key)
-      );
-      if (parsedValue != null) {
-        result = result.insert(key, parsedValue);
+
+    if (objUtils.isEmpty(obj)) {
+      // If we encounter an empty object, we explicitly add it to the update
+      // mask to ensure that the server creates a map entry.
+      if (context.path && context.path.length > 0) {
+        context.fieldMask.push(context.path);
       }
-    });
+    } else {
+      objUtils.forEach(obj, (key: string, val: AnyJs) => {
+        const parsedValue = this.parseData(
+          val,
+          context.childContextForField(key)
+        );
+        if (parsedValue != null) {
+          result = result.insert(key, parsedValue);
+        }
+      });
+    }
+
     return new ObjectValue(result);
   }
 

--- a/packages/firestore/src/model/mutation.ts
+++ b/packages/firestore/src/model/mutation.ts
@@ -449,11 +449,13 @@ export class PatchMutation extends Mutation {
 
   private patchObject(data: ObjectValue): ObjectValue {
     for (const fieldPath of this.fieldMask.fields) {
-      const newValue = this.data.field(fieldPath);
-      if (newValue !== undefined) {
-        data = data.set(fieldPath, newValue);
-      } else {
-        data = data.delete(fieldPath);
+      if (!fieldPath.isEmpty()) {
+        const newValue = this.data.field(fieldPath);
+        if (newValue !== undefined) {
+          data = data.set(fieldPath, newValue);
+        } else {
+          data = data.delete(fieldPath);
+        }
       }
     }
     return data;


### PR DESCRIPTION
We currently drop empty objects when during set({merge: true}) since we only add leaf nodes to the field mask. We need to consider an empty object a leaf node.

Fixes: https://github.com/firebase/firebase-js-sdk/issues/1168