### PR TITLE
Adding readwrite-primary mode

### DIFF
--- a/packages/firestore/src/local/indexeddb_persistence.ts
+++ b/packages/firestore/src/local/indexeddb_persistence.ts
@@ -436,51 +436,55 @@ export class IndexedDbPersistence implements Persistence {
       let activeClients: DbClientMetadata[];
       let inactiveClients: DbClientMetadata[] = [];
 
-      await this.runTransaction('readwrite', true, txn => {
-        const metadataStore = IndexedDbPersistence.getStore<
-          DbClientMetadataKey,
-          DbClientMetadata
-        >(txn, DbClientMetadata.store);
+      await this.runTransaction(
+        'maybeGarbageCollectMultiClientState',
+        'readwrite-primary',
+        txn => {
+          const metadataStore = IndexedDbPersistence.getStore<
+            DbClientMetadataKey,
+            DbClientMetadata
+          >(txn, DbClientMetadata.store);
 
-        return metadataStore
-          .loadAll()
-          .next(existingClients => {
-            activeClients = this.filterActiveClients(
-              existingClients,
-              CLIENT_STATE_GARBAGE_COLLECTION_THRESHOLD_MS
-            );
-            inactiveClients = existingClients.filter(
-              client => activeClients.indexOf(client) === -1
-            );
-          })
-          .next(() =>
-            // Delete metadata for clients that are no longer considered active.
-            PersistencePromise.forEach(inactiveClients, inactiveClient =>
-              metadataStore.delete(inactiveClient.clientId)
+          return metadataStore
+            .loadAll()
+            .next(existingClients => {
+              activeClients = this.filterActiveClients(
+                existingClients,
+                CLIENT_STATE_GARBAGE_COLLECTION_THRESHOLD_MS
+              );
+              inactiveClients = existingClients.filter(
+                client => activeClients.indexOf(client) === -1
+              );
+            })
+            .next(() =>
+              // Delete metadata for clients that are no longer considered active.
+              PersistencePromise.forEach(inactiveClients, inactiveClient =>
+                metadataStore.delete(inactiveClient.clientId)
+              )
             )
-          )
-          .next(() => {
-            // Retrieve the minimum change ID from the set of active clients.
+            .next(() => {
+              // Retrieve the minimum change ID from the set of active clients.
 
-            // The primary client doesn't read from the document change log,
-            // and hence we exclude it when we determine the minimum
-            // `lastProcessedDocumentChangeId`.
-            activeClients = activeClients.filter(
-              client => client.clientId !== this.clientId
-            );
+              // The primary client doesn't read from the document change log,
+              // and hence we exclude it when we determine the minimum
+              // `lastProcessedDocumentChangeId`.
+              activeClients = activeClients.filter(
+                client => client.clientId !== this.clientId
+              );
 
-            if (activeClients.length > 0) {
-              const processedChangeIds = activeClients.map(
-                client => client.lastProcessedDocumentChangeId || 0
-              );
-              const oldestChangeId = Math.min(...processedChangeIds);
-              return this.remoteDocumentCache.removeDocumentChangesThroughChangeId(
-                txn,
-                oldestChangeId
-              );
-            }
-          });
-      });
+              if (activeClients.length > 0) {
+                const processedChangeIds = activeClients.map(
+                  client => client.lastProcessedDocumentChangeId || 0
+                );
+                const oldestChangeId = Math.min(...processedChangeIds);
+                return this.remoteDocumentCache.removeDocumentChangesThroughChangeId(
+                  txn,
+                  oldestChangeId
+                );
+              }
+            });
+        }
+      );
 
       // Delete potential leftover entries that may continue to mark the
       // inactive clients as zombied in LocalStorage.
@@ -712,7 +716,7 @@ export class IndexedDbPersistence implements Persistence {
 
   runTransaction<T>(
     action: string,
-    requirePrimaryLease: boolean,
+    mode: 'readonly' | 'readwrite' | 'readwrite-primary',
     transactionOperation: (
       transaction: PersistenceTransaction
     ) => PersistencePromise<T>
@@ -724,10 +728,10 @@ export class IndexedDbPersistence implements Persistence {
     // Do all transactions as readwrite against all object stores, since we
     // are the only reader/writer.
     return this.simpleDb.runTransaction(
-      'readwrite',
+      mode == 'readonly' ? 'readonly' : 'readwrite',
       ALL_STORES,
       simpleDbTxn => {
-        if (requirePrimaryLease) {
+        if (mode === 'readwrite-primary') {
           // While we merely verify that we have (or can acquire) the lease
           // immediately, we wait to extend the primary lease until after
           // executing transactionOperation(). This ensures that even if the

--- a/packages/firestore/src/local/local_store.ts
+++ b/packages/firestore/src/local/local_store.ts
@@ -664,7 +664,7 @@ export class LocalStore {
   allocateQuery(query: Query): Promise<QueryData> {
     return this.persistence.runTransaction(
       'Allocate query',
-      'readonly',
+      'readwrite',
       txn => {
         let queryData: QueryData;
         return this.queryCache

--- a/packages/firestore/src/local/local_store.ts
+++ b/packages/firestore/src/local/local_store.ts
@@ -183,8 +183,10 @@ export class LocalStore {
   /** Performs any initial startup actions required by the local store. */
   start(): Promise<void> {
     // TODO(multitab): Ensure that we in fact don't need the primary lease.
-    return this.persistence.runTransaction('Start LocalStore', false, txn =>
-      this.startMutationQueue(txn)
+    return this.persistence.runTransaction(
+      'Start LocalStore',
+      'readonly',
+      txn => this.startMutationQueue(txn)
     );
   }
 
@@ -195,63 +197,67 @@ export class LocalStore {
    * returns any resulting document changes.
    */
   handleUserChange(user: User): Promise<UserChangeResult> {
-    return this.persistence.runTransaction('Handle user change', false, txn => {
-      // Swap out the mutation queue, grabbing the pending mutation batches
-      // before and after.
-      let oldBatches: MutationBatch[];
-      return this.mutationQueue
-        .getAllMutationBatches(txn)
-        .next(promisedOldBatches => {
-          oldBatches = promisedOldBatches;
+    return this.persistence.runTransaction(
+      'Handle user change',
+      'readonly',
+      txn => {
+        // Swap out the mutation queue, grabbing the pending mutation batches
+        // before and after.
+        let oldBatches: MutationBatch[];
+        return this.mutationQueue
+          .getAllMutationBatches(txn)
+          .next(promisedOldBatches => {
+            oldBatches = promisedOldBatches;
 
-          this.garbageCollector.removeGarbageSource(this.mutationQueue);
-          this.mutationQueue = this.persistence.getMutationQueue(user);
-          this.garbageCollector.addGarbageSource(this.mutationQueue);
-          return this.startMutationQueue(txn);
-        })
-        .next(() => {
-          // Recreate our LocalDocumentsView using the new
-          // MutationQueue.
-          this.localDocuments = new LocalDocumentsView(
-            this.remoteDocuments,
-            this.mutationQueue
-          );
-          return this.mutationQueue.getAllMutationBatches(txn);
-        })
-        .next(newBatches => {
-          const removedBatchIds: BatchId[] = [];
-          const addedBatchIds: BatchId[] = [];
+            this.garbageCollector.removeGarbageSource(this.mutationQueue);
+            this.mutationQueue = this.persistence.getMutationQueue(user);
+            this.garbageCollector.addGarbageSource(this.mutationQueue);
+            return this.startMutationQueue(txn);
+          })
+          .next(() => {
+            // Recreate our LocalDocumentsView using the new
+            // MutationQueue.
+            this.localDocuments = new LocalDocumentsView(
+              this.remoteDocuments,
+              this.mutationQueue
+            );
+            return this.mutationQueue.getAllMutationBatches(txn);
+          })
+          .next(newBatches => {
+            const removedBatchIds: BatchId[] = [];
+            const addedBatchIds: BatchId[] = [];
 
-          // Union the old/new changed keys.
-          let changedKeys = documentKeySet();
+            // Union the old/new changed keys.
+            let changedKeys = documentKeySet();
 
-          for (const batch of oldBatches) {
-            removedBatchIds.push(batch.batchId);
-            for (const mutation of batch.mutations) {
-              changedKeys = changedKeys.add(mutation.key);
+            for (const batch of oldBatches) {
+              removedBatchIds.push(batch.batchId);
+              for (const mutation of batch.mutations) {
+                changedKeys = changedKeys.add(mutation.key);
+              }
             }
-          }
 
-          for (const batch of newBatches) {
-            addedBatchIds.push(batch.batchId);
-            for (const mutation of batch.mutations) {
-              changedKeys = changedKeys.add(mutation.key);
+            for (const batch of newBatches) {
+              addedBatchIds.push(batch.batchId);
+              for (const mutation of batch.mutations) {
+                changedKeys = changedKeys.add(mutation.key);
+              }
             }
-          }
 
-          // Return the set of all (potentially) changed documents and the list
-          // of mutation batch IDs that were affected by change.
-          return this.localDocuments
-            .getDocuments(txn, changedKeys)
-            .next(affectedDocuments => {
-              return {
-                affectedDocuments,
-                removedBatchIds,
-                addedBatchIds
-              };
-            });
-        });
-    });
+            // Return the set of all (potentially) changed documents and the list
+            // of mutation batch IDs that were affected by change.
+            return this.localDocuments
+              .getDocuments(txn, changedKeys)
+              .next(affectedDocuments => {
+                return {
+                  affectedDocuments,
+                  removedBatchIds,
+                  addedBatchIds
+                };
+              });
+          });
+      }
+    );
   }
 
   private startMutationQueue(
@@ -264,7 +270,7 @@ export class LocalStore {
   localWrite(mutations: Mutation[]): Promise<LocalWriteResult> {
     return this.persistence.runTransaction(
       'Locally write mutations',
-      false,
+      'readwrite',
       txn => {
         let batch: MutationBatch;
         const localWriteTime = Timestamp.now();
@@ -290,7 +296,7 @@ export class LocalStore {
   lookupMutationDocuments(batchId: BatchId): Promise<MaybeDocumentMap | null> {
     return this.persistence.runTransaction(
       'Lookup mutation documents',
-      false,
+      'readonly',
       txn => {
         return this.mutationQueue
           .lookupMutationKeys(txn, batchId)
@@ -325,20 +331,24 @@ export class LocalStore {
   acknowledgeBatch(
     batchResult: MutationBatchResult
   ): Promise<MaybeDocumentMap> {
-    return this.persistence.runTransaction('Acknowledge batch', true, txn => {
-      const affected = batchResult.batch.keys();
-      const documentBuffer = new RemoteDocumentChangeBuffer(
-        this.remoteDocuments
-      );
-      return this.mutationQueue
-        .acknowledgeBatch(txn, batchResult.batch, batchResult.streamToken)
-        .next(() =>
-          this.applyWriteToRemoteDocuments(txn, batchResult, documentBuffer)
-        )
-        .next(() => documentBuffer.apply(txn))
-        .next(() => this.mutationQueue.performConsistencyCheck(txn))
-        .next(() => this.localDocuments.getDocuments(txn, affected));
-    });
+    return this.persistence.runTransaction(
+      'Acknowledge batch',
+      'readwrite-primary',
+      txn => {
+        const affected = batchResult.batch.keys();
+        const documentBuffer = new RemoteDocumentChangeBuffer(
+          this.remoteDocuments
+        );
+        return this.mutationQueue
+          .acknowledgeBatch(txn, batchResult.batch, batchResult.streamToken)
+          .next(() =>
+            this.applyWriteToRemoteDocuments(txn, batchResult, documentBuffer)
+          )
+          .next(() => documentBuffer.apply(txn))
+          .next(() => this.mutationQueue.performConsistencyCheck(txn))
+          .next(() => this.localDocuments.getDocuments(txn, affected));
+      }
+    );
   }
 
   /**
@@ -348,29 +358,33 @@ export class LocalStore {
    * @returns The resulting modified documents.
    */
   rejectBatch(batchId: BatchId): Promise<MaybeDocumentMap> {
-    return this.persistence.runTransaction('Reject batch', true, txn => {
-      let affectedKeys: DocumentKeySet;
-      return this.mutationQueue
-        .lookupMutationBatch(txn, batchId)
-        .next((batch: MutationBatch | null) => {
-          assert(batch !== null, 'Attempt to reject nonexistent batch!');
-          affectedKeys = batch!.keys();
-          return this.mutationQueue.removeMutationBatch(txn, batch!);
-        })
-        .next(() => {
-          return this.mutationQueue.performConsistencyCheck(txn);
-        })
-        .next(() => {
-          return this.localDocuments.getDocuments(txn, affectedKeys);
-        });
-    });
+    return this.persistence.runTransaction(
+      'Reject batch',
+      'readwrite-primary',
+      txn => {
+        let affectedKeys: DocumentKeySet;
+        return this.mutationQueue
+          .lookupMutationBatch(txn, batchId)
+          .next((batch: MutationBatch | null) => {
+            assert(batch !== null, 'Attempt to reject nonexistent batch!');
+            affectedKeys = batch!.keys();
+            return this.mutationQueue.removeMutationBatch(txn, batch!);
+          })
+          .next(() => {
+            return this.mutationQueue.performConsistencyCheck(txn);
+          })
+          .next(() => {
+            return this.localDocuments.getDocuments(txn, affectedKeys);
+          });
+      }
+    );
   }
 
   /** Returns the last recorded stream token for the current user. */
   getLastStreamToken(): Promise<ProtoByteString> {
     return this.persistence.runTransaction(
       'Get last stream token',
-      false,
+      'readonly',
       txn => {
         return this.mutationQueue.getLastStreamToken(txn);
       }
@@ -385,7 +399,7 @@ export class LocalStore {
   setLastStreamToken(streamToken: ProtoByteString): Promise<void> {
     return this.persistence.runTransaction(
       'Set last stream token',
-      true,
+      'readwrite-primary',
       txn => {
         return this.mutationQueue.setLastStreamToken(txn, streamToken);
       }
@@ -399,7 +413,7 @@ export class LocalStore {
   getLastRemoteSnapshotVersion(): Promise<SnapshotVersion> {
     return this.persistence.runTransaction(
       'Get last remote snapshot version',
-      false,
+      'readonly',
       txn => this.queryCache.getLastRemoteSnapshotVersion(txn)
     );
   }
@@ -414,132 +428,140 @@ export class LocalStore {
    */
   applyRemoteEvent(remoteEvent: RemoteEvent): Promise<MaybeDocumentMap> {
     const documentBuffer = new RemoteDocumentChangeBuffer(this.remoteDocuments);
-    return this.persistence.runTransaction('Apply remote event', true, txn => {
-      const promises = [] as Array<PersistencePromise<void>>;
-      let authoritativeUpdates = documentKeySet();
-      objUtils.forEachNumber(
-        remoteEvent.targetChanges,
-        (targetId: TargetId, change: TargetChange) => {
-          // Do not ref/unref unassigned targetIds - it may lead to leaks.
-          let queryData = this.queryDataByTarget[targetId];
-          if (!queryData) return;
+    return this.persistence.runTransaction(
+      'Apply remote event',
+      'readwrite-primary',
+      txn => {
+        const promises = [] as Array<PersistencePromise<void>>;
+        let authoritativeUpdates = documentKeySet();
+        objUtils.forEachNumber(
+          remoteEvent.targetChanges,
+          (targetId: TargetId, change: TargetChange) => {
+            // Do not ref/unref unassigned targetIds - it may lead to leaks.
+            let queryData = this.queryDataByTarget[targetId];
+            if (!queryData) return;
 
-          // When a global snapshot contains updates (either add or modify) we
-          // can completely trust these updates as authoritative and blindly
-          // apply them to our cache (as a defensive measure to promote
-          // self-healing in the unfortunate case that our cache is ever somehow
-          // corrupted / out-of-sync).
-          //
-          // If the document is only updated while removing it from a target
-          // then watch isn't obligated to send the absolute latest version: it
-          // can send the first version that caused the document not to match.
-          change.addedDocuments.forEach(key => {
-            authoritativeUpdates = authoritativeUpdates.add(key);
-          });
-          change.modifiedDocuments.forEach(key => {
-            authoritativeUpdates = authoritativeUpdates.add(key);
-          });
-
-          promises.push(
-            this.queryCache
-              .removeMatchingKeys(txn, change.removedDocuments, targetId)
-              .next(() => {
-                return this.queryCache.addMatchingKeys(
-                  txn,
-                  change.addedDocuments,
-                  targetId
-                );
-              })
-          );
-
-          // Update the resume token if the change includes one. Don't clear
-          // any preexisting value.
-          const resumeToken = change.resumeToken;
-          if (resumeToken.length > 0) {
-            const oldQueryData = queryData;
-            queryData = queryData.copy({
-              resumeToken,
-              snapshotVersion: remoteEvent.snapshotVersion
+            // When a global snapshot contains updates (either add or modify) we
+            // can completely trust these updates as authoritative and blindly
+            // apply them to our cache (as a defensive measure to promote
+            // self-healing in the unfortunate case that our cache is ever somehow
+            // corrupted / out-of-sync).
+            //
+            // If the document is only updated while removing it from a target
+            // then watch isn't obligated to send the absolute latest version: it
+            // can send the first version that caused the document not to match.
+            change.addedDocuments.forEach(key => {
+              authoritativeUpdates = authoritativeUpdates.add(key);
             });
-            this.queryDataByTarget[targetId] = queryData;
+            change.modifiedDocuments.forEach(key => {
+              authoritativeUpdates = authoritativeUpdates.add(key);
+            });
 
-            if (
-              LocalStore.shouldPersistQueryData(oldQueryData, queryData, change)
-            ) {
-              promises.push(this.queryCache.updateQueryData(txn, queryData));
+            promises.push(
+              this.queryCache
+                .removeMatchingKeys(txn, change.removedDocuments, targetId)
+                .next(() => {
+                  return this.queryCache.addMatchingKeys(
+                    txn,
+                    change.addedDocuments,
+                    targetId
+                  );
+                })
+            );
+
+            // Update the resume token if the change includes one. Don't clear
+            // any preexisting value.
+            const resumeToken = change.resumeToken;
+            if (resumeToken.length > 0) {
+              const oldQueryData = queryData;
+              queryData = queryData.copy({
+                resumeToken,
+                snapshotVersion: remoteEvent.snapshotVersion
+              });
+              this.queryDataByTarget[targetId] = queryData;
+
+              if (
+                LocalStore.shouldPersistQueryData(
+                  oldQueryData,
+                  queryData,
+                  change
+                )
+              ) {
+                promises.push(this.queryCache.updateQueryData(txn, queryData));
+              }
             }
           }
-        }
-      );
-
-      let changedDocKeys = documentKeySet();
-      remoteEvent.documentUpdates.forEach((key, doc) => {
-        changedDocKeys = changedDocKeys.add(key);
-        promises.push(
-          documentBuffer.getEntry(txn, key).next(existingDoc => {
-            // If a document update isn't authoritative, make sure we don't
-            // apply an old document version to the remote cache. We make an
-            // exception for SnapshotVersion.MIN which can happen for
-            // manufactured events (e.g. in the case of a limbo document
-            // resolution failing).
-            if (
-              existingDoc == null ||
-              doc.version.isEqual(SnapshotVersion.MIN) ||
-              (authoritativeUpdates.has(doc.key) &&
-                !existingDoc.hasPendingWrites) ||
-              doc.version.compareTo(existingDoc.version) >= 0
-            ) {
-              documentBuffer.addEntry(doc);
-            } else {
-              log.debug(
-                LOG_TAG,
-                'Ignoring outdated watch update for ',
-                key,
-                '. Current version:',
-                existingDoc.version,
-                ' Watch version:',
-                doc.version
-              );
-            }
-
-            // The document might be garbage because it was unreferenced by
-            // everything. Make sure to mark it as garbage if it is...
-            this.garbageCollector.addPotentialGarbageKey(key);
-          })
         );
-      });
 
-      // HACK: The only reason we allow a null snapshot version is so that we
-      // can synthesize remote events when we get permission denied errors while
-      // trying to resolve the state of a locally cached document that is in
-      // limbo.
-      const remoteVersion = remoteEvent.snapshotVersion;
-      if (!remoteVersion.isEqual(SnapshotVersion.MIN)) {
-        const updateRemoteVersion = this.queryCache
-          .getLastRemoteSnapshotVersion(txn)
-          .next(lastRemoteVersion => {
-            assert(
-              remoteVersion.compareTo(lastRemoteVersion) >= 0,
-              'Watch stream reverted to previous snapshot?? ' +
-                remoteVersion +
-                ' < ' +
-                lastRemoteVersion
-            );
-            return this.queryCache.setTargetsMetadata(
-              txn,
-              /*highestSequenceNumber=*/ 0,
-              remoteVersion
-            );
-          });
-        promises.push(updateRemoteVersion);
-      }
+        let changedDocKeys = documentKeySet();
+        remoteEvent.documentUpdates.forEach((key, doc) => {
+          changedDocKeys = changedDocKeys.add(key);
+          promises.push(
+            documentBuffer.getEntry(txn, key).next(existingDoc => {
+              // If a document update isn't authoritative, make sure we don't
+              // apply an old document version to the remote cache. We make an
+              // exception for SnapshotVersion.MIN which can happen for
+              // manufactured events (e.g. in the case of a limbo document
+              // resolution failing).
+              if (
+                existingDoc == null ||
+                doc.version.isEqual(SnapshotVersion.MIN) ||
+                (authoritativeUpdates.has(doc.key) &&
+                  !existingDoc.hasPendingWrites) ||
+                doc.version.compareTo(existingDoc.version) >= 0
+              ) {
+                documentBuffer.addEntry(doc);
+              } else {
+                log.debug(
+                  LOG_TAG,
+                  'Ignoring outdated watch update for ',
+                  key,
+                  '. Current version:',
+                  existingDoc.version,
+                  ' Watch version:',
+                  doc.version
+                );
+              }
 
-      return PersistencePromise.waitFor(promises)
-        .next(() => documentBuffer.apply(txn))
-        .next(() => {
-          return this.localDocuments.getDocuments(txn, changedDocKeys);
+              // The document might be garbage because it was unreferenced by
+              // everything. Make sure to mark it as garbage if it is...
+              this.garbageCollector.addPotentialGarbageKey(key);
+            })
+          );
         });
-    });
+
+        // HACK: The only reason we allow a null snapshot version is so that we
+        // can synthesize remote events when we get permission denied errors while
+        // trying to resolve the state of a locally cached document that is in
+        // limbo.
+        const remoteVersion = remoteEvent.snapshotVersion;
+        if (!remoteVersion.isEqual(SnapshotVersion.MIN)) {
+          const updateRemoteVersion = this.queryCache
+            .getLastRemoteSnapshotVersion(txn)
+            .next(lastRemoteVersion => {
+              assert(
+                remoteVersion.compareTo(lastRemoteVersion) >= 0,
+                'Watch stream reverted to previous snapshot?? ' +
+                  remoteVersion +
+                  ' < ' +
+                  lastRemoteVersion
+              );
+              return this.queryCache.setTargetsMetadata(
+                txn,
+                /*highestSequenceNumber=*/ 0,
+                remoteVersion
+              );
+            });
+          promises.push(updateRemoteVersion);
+        }
+
+        return PersistencePromise.waitFor(promises)
+          .next(() => documentBuffer.apply(txn))
+          .next(() => {
+            return this.localDocuments.getDocuments(txn, changedDocKeys);
+          });
+      }
+    );
   }
 
   /**
@@ -611,7 +633,7 @@ export class LocalStore {
   nextMutationBatch(afterBatchId?: BatchId): Promise<MutationBatch | null> {
     return this.persistence.runTransaction(
       'Get next mutation batch',
-      false,
+      'readonly',
       txn => {
         if (afterBatchId === undefined) {
           afterBatchId = BATCHID_UNKNOWN;
@@ -629,7 +651,7 @@ export class LocalStore {
    * found - used for testing.
    */
   readDocument(key: DocumentKey): Promise<MaybeDocument | null> {
-    return this.persistence.runTransaction('read document', false, txn => {
+    return this.persistence.runTransaction('read document', 'readonly', txn => {
       return this.localDocuments.getDocument(txn, key);
     });
   }
@@ -640,33 +662,37 @@ export class LocalStore {
    * the store can be used to manage its view.
    */
   allocateQuery(query: Query): Promise<QueryData> {
-    return this.persistence.runTransaction('Allocate query', false, txn => {
-      let queryData: QueryData;
-      return this.queryCache
-        .getQueryData(txn, query)
-        .next((cached: QueryData | null) => {
-          if (cached) {
-            // This query has been listened to previously, so reuse the
-            // previous targetID.
-            // TODO(mcg): freshen last accessed date?
-            queryData = cached;
-            return PersistencePromise.resolve();
-          } else {
-            return this.queryCache.allocateTargetId(txn).next(targetId => {
-              queryData = new QueryData(query, targetId, QueryPurpose.Listen);
-              return this.queryCache.addQueryData(txn, queryData);
-            });
-          }
-        })
-        .next(() => {
-          assert(
-            !this.queryDataByTarget[queryData.targetId],
-            'Tried to allocate an already allocated query: ' + query
-          );
-          this.queryDataByTarget[queryData.targetId] = queryData;
-          return queryData;
-        });
-    });
+    return this.persistence.runTransaction(
+      'Allocate query',
+      'readwrite',
+      txn => {
+        let queryData: QueryData;
+        return this.queryCache
+          .getQueryData(txn, query)
+          .next((cached: QueryData | null) => {
+            if (cached) {
+              // This query has been listened to previously, so reuse the
+              // previous targetID.
+              // TODO(mcg): freshen last accessed date?
+              queryData = cached;
+              return PersistencePromise.resolve();
+            } else {
+              return this.queryCache.allocateTargetId(txn).next(targetId => {
+                queryData = new QueryData(query, targetId, QueryPurpose.Listen);
+                return this.queryCache.addQueryData(txn, queryData);
+              });
+            }
+          })
+          .next(() => {
+            assert(
+              !this.queryDataByTarget[queryData.targetId],
+              'Tried to allocate an already allocated query: ' + query
+            );
+            this.queryDataByTarget[queryData.targetId] = queryData;
+            return queryData;
+          });
+      }
+    );
   }
 
   /**
@@ -676,39 +702,35 @@ export class LocalStore {
    */
   // PORTING NOTE: `keepPersistedQueryData` is multi-tab only.
   releaseQuery(query: Query, keepPersistedQueryData: boolean): Promise<void> {
-    const requirePrimaryLease = keepPersistedQueryData === false;
-    return this.persistence.runTransaction(
-      'Release query',
-      requirePrimaryLease,
-      txn => {
-        return this.queryCache
-          .getQueryData(txn, query)
-          .next((queryData: QueryData | null) => {
-            assert(
-              queryData != null,
-              'Tried to release nonexistent query: ' + query
-            );
-            const targetId = queryData!.targetId;
-            const cachedQueryData = this.queryDataByTarget[targetId];
+    const mode = keepPersistedQueryData ? 'readonly' : 'readwrite-primary';
+    return this.persistence.runTransaction('Release query', mode, txn => {
+      return this.queryCache
+        .getQueryData(txn, query)
+        .next((queryData: QueryData | null) => {
+          assert(
+            queryData != null,
+            'Tried to release nonexistent query: ' + query
+          );
+          const targetId = queryData!.targetId;
+          const cachedQueryData = this.queryDataByTarget[targetId];
 
-            this.localViewReferences.removeReferencesForId(targetId);
-            delete this.queryDataByTarget[targetId];
-            if (!keepPersistedQueryData && this.garbageCollector.isEager) {
-              return this.queryCache.removeQueryData(txn, queryData!);
-            } else if (
-              cachedQueryData.snapshotVersion > queryData!.snapshotVersion
-            ) {
-              // If we've been avoiding persisting the resumeToken (see
-              // shouldPersistQueryData for conditions and rationale) we need to
-              // persist the token now because there will no longer be an
-              // in-memory version to fall back on.
-              return this.queryCache.updateQueryData(txn, cachedQueryData);
-            } else {
-              return PersistencePromise.resolve();
-            }
-          });
-      }
-    );
+          this.localViewReferences.removeReferencesForId(targetId);
+          delete this.queryDataByTarget[targetId];
+          if (!keepPersistedQueryData && this.garbageCollector.isEager) {
+            return this.queryCache.removeQueryData(txn, queryData!);
+          } else if (
+            cachedQueryData.snapshotVersion > queryData!.snapshotVersion
+          ) {
+            // If we've been avoiding persisting the resumeToken (see
+            // shouldPersistQueryData for conditions and rationale) we need to
+            // persist the token now because there will no longer be an
+            // in-memory version to fall back on.
+            return this.queryCache.updateQueryData(txn, cachedQueryData);
+          } else {
+            return PersistencePromise.resolve();
+          }
+        });
+    });
   }
 
   /**
@@ -716,7 +738,7 @@ export class LocalStore {
    * returns the results.
    */
   executeQuery(query: Query): Promise<DocumentMap> {
-    return this.persistence.runTransaction('Execute query', false, txn => {
+    return this.persistence.runTransaction('Execute query', 'readonly', txn => {
       return this.localDocuments.getDocumentsMatchingQuery(txn, query);
     });
   }
@@ -728,7 +750,7 @@ export class LocalStore {
   remoteDocumentKeys(targetId: TargetId): Promise<DocumentKeySet> {
     return this.persistence.runTransaction(
       'Remote document keys',
-      false,
+      'readonly',
       txn => {
         return this.queryCache.getMatchingKeysForTargetId(txn, targetId);
       }
@@ -744,15 +766,19 @@ export class LocalStore {
   collectGarbage(): Promise<void> {
     // Call collectGarbage regardless of whether isGCEnabled so the referenceSet
     // doesn't continue to accumulate the garbage keys.
-    return this.persistence.runTransaction('Garbage collection', true, txn => {
-      return this.garbageCollector.collectGarbage(txn).next(garbage => {
-        const promises = [] as Array<PersistencePromise<void>>;
-        garbage.forEach(key => {
-          promises.push(this.remoteDocuments.removeEntry(txn, key));
+    return this.persistence.runTransaction(
+      'Garbage collection',
+      'readwrite-primary',
+      txn => {
+        return this.garbageCollector.collectGarbage(txn).next(garbage => {
+          const promises = [] as Array<PersistencePromise<void>>;
+          garbage.forEach(key => {
+            promises.push(this.remoteDocuments.removeEntry(txn, key));
+          });
+          return PersistencePromise.waitFor(promises);
         });
-        return PersistencePromise.waitFor(promises);
-      });
-    });
+      }
+    );
   }
 
   // PORTING NOTE: Multi-tab only.
@@ -817,11 +843,15 @@ export class LocalStore {
     if (this.queryDataByTarget[targetId]) {
       return Promise.resolve(this.queryDataByTarget[targetId].query);
     } else {
-      return this.persistence.runTransaction('Get query data', false, txn => {
-        return this.queryCache
-          .getQueryDataForTarget(txn, targetId)
-          .next(queryData => (queryData ? queryData.query : null));
-      });
+      return this.persistence.runTransaction(
+        'Get query data',
+        'readonly',
+        txn => {
+          return this.queryCache
+            .getQueryDataForTarget(txn, targetId)
+            .next(queryData => (queryData ? queryData.query : null));
+        }
+      );
     }
   }
 
@@ -829,7 +859,7 @@ export class LocalStore {
   getNewDocumentChanges(): Promise<MaybeDocumentMap> {
     return this.persistence.runTransaction(
       'Get new document changes',
-      false,
+      'readonly',
       txn => {
         return this.remoteDocuments.getNewDocumentChanges(txn);
       }

--- a/packages/firestore/src/local/memory_persistence.ts
+++ b/packages/firestore/src/local/memory_persistence.ts
@@ -100,7 +100,7 @@ export class MemoryPersistence implements Persistence {
 
   runTransaction<T>(
     action: string,
-    requirePrimaryLease: boolean,
+    mode: 'readonly' | 'readwrite' | 'readwrite-primary',
     transactionOperation: (
       transaction: PersistenceTransaction
     ) => PersistencePromise<T>

--- a/packages/firestore/src/local/persistence.ts
+++ b/packages/firestore/src/local/persistence.ts
@@ -167,16 +167,18 @@ export interface Persistence {
    *
    * @param action A description of the action performed by this transaction,
    * used for logging.
-   * @param requirePrimaryLease Whether this transaction can only be executed
-   * by the primary client. If the primary lease cannot be acquired, the
-   * transactionOperation will not be run, and the returned promise will be
-   * rejected with a FAILED_PRECONDITION error.
+   * @param mode The underlying mode of the IndexedDb transaction. Can be
+   * 'readonly`, 'readwrite' or 'readwrite-primary'. Transactions marked
+   * 'readwrite-primary' can only be executed by the primary client. In this
+   * mode, the transactionOperation will not be run if the primary lease cannot
+   * be acquired and the returned promise will be rejected with a
+   * FAILED_PRECONDITION error.
    * @param transactionOperation The operation to run inside a transaction.
    * @return A promise that is resolved once the transaction completes.
    */
   runTransaction<T>(
     action: string,
-    requirePrimaryLease: boolean,
+    mode: 'readonly' | 'readwrite' | 'readwrite-primary',
     transactionOperation: (
       transaction: PersistenceTransaction
     ) => PersistencePromise<T>

--- a/packages/firestore/test/unit/local/remote_document_cache.test.ts
+++ b/packages/firestore/test/unit/local/remote_document_cache.test.ts
@@ -73,7 +73,7 @@ describe('IndexedDbRemoteDocumentCache', () => {
     // Add two change batches and remove the first one.
     await persistence.runTransaction(
       'removeDocumentChangesThroughChangeId',
-      true,
+      'readwrite',
       txn => {
         const cache = persistence.getRemoteDocumentCache() as IndexedDbRemoteDocumentCache;
         return cache
@@ -85,7 +85,7 @@ describe('IndexedDbRemoteDocumentCache', () => {
     // We removed the first batch, there should be a single batch remaining.
     const remainingChangeCount = await persistence.runTransaction(
       'verify',
-      true,
+      'readonly',
       txn => {
         const store = IndexedDbPersistence.getStore<
           DbRemoteDocumentChangesKey,

--- a/packages/firestore/test/unit/local/test_garbage_collector.ts
+++ b/packages/firestore/test/unit/local/test_garbage_collector.ts
@@ -27,7 +27,7 @@ export class TestGarbageCollector {
 
   collectGarbage(): Promise<DocumentKey[]> {
     return this.persistence
-      .runTransaction('garbageCollect', true, txn => {
+      .runTransaction('garbageCollect', 'readwrite-primary', txn => {
         return this.gc.collectGarbage(txn);
       })
       .then(garbage => {

--- a/packages/firestore/test/unit/local/test_mutation_queue.ts
+++ b/packages/firestore/test/unit/local/test_mutation_queue.ts
@@ -34,20 +34,20 @@ export class TestMutationQueue {
   constructor(public persistence: Persistence, public queue: MutationQueue) {}
 
   start(): Promise<void> {
-    return this.persistence.runTransaction('start', false, txn => {
+    return this.persistence.runTransaction('start', 'readonly', txn => {
       return this.queue.start(txn);
     });
   }
 
   checkEmpty(): Promise<boolean> {
-    return this.persistence.runTransaction('checkEmpty', false, txn => {
+    return this.persistence.runTransaction('checkEmpty', 'readonly', txn => {
       return this.queue.checkEmpty(txn);
     });
   }
 
   countBatches(): Promise<number> {
     return this.persistence
-      .runTransaction('countBatches', false, txn => {
+      .runTransaction('countBatches', 'readonly', txn => {
         return this.queue.getAllMutationBatches(txn);
       })
       .then(batches => batches.length);
@@ -59,7 +59,7 @@ export class TestMutationQueue {
   ): Promise<void> {
     return this.persistence.runTransaction(
       'acknowledgeThroughBatchId',
-      true,
+      'readwrite-primary',
       txn => {
         return this.queue.acknowledgeBatch(txn, batch, streamToken);
       }
@@ -67,27 +67,39 @@ export class TestMutationQueue {
   }
 
   getLastStreamToken(): Promise<string> {
-    return this.persistence.runTransaction('getLastStreamToken', false, txn => {
-      return this.queue.getLastStreamToken(txn);
-    }) as AnyDuringMigration;
+    return this.persistence.runTransaction(
+      'getLastStreamToken',
+      'readonly',
+      txn => {
+        return this.queue.getLastStreamToken(txn);
+      }
+    ) as AnyDuringMigration;
   }
 
   setLastStreamToken(streamToken: string): Promise<void> {
-    return this.persistence.runTransaction('setLastStreamToken', true, txn => {
-      return this.queue.setLastStreamToken(txn, streamToken);
-    });
+    return this.persistence.runTransaction(
+      'setLastStreamToken',
+      'readwrite-primary',
+      txn => {
+        return this.queue.setLastStreamToken(txn, streamToken);
+      }
+    );
   }
 
   addMutationBatch(mutations: Mutation[]): Promise<MutationBatch> {
-    return this.persistence.runTransaction('addMutationBatch', false, txn => {
-      return this.queue.addMutationBatch(txn, Timestamp.now(), mutations);
-    });
+    return this.persistence.runTransaction(
+      'addMutationBatch',
+      'readwrite',
+      txn => {
+        return this.queue.addMutationBatch(txn, Timestamp.now(), mutations);
+      }
+    );
   }
 
   lookupMutationBatch(batchId: BatchId): Promise<MutationBatch | null> {
     return this.persistence.runTransaction(
       'lookupMutationBatch',
-      false,
+      'readonly',
       txn => {
         return this.queue.lookupMutationBatch(txn, batchId);
       }
@@ -99,7 +111,7 @@ export class TestMutationQueue {
   ): Promise<MutationBatch | null> {
     return this.persistence.runTransaction(
       'getNextMutationBatchAfterBatchId',
-      false,
+      'readonly',
       txn => {
         return this.queue.getNextMutationBatchAfterBatchId(txn, batchId);
       }
@@ -109,7 +121,7 @@ export class TestMutationQueue {
   getAllMutationBatches(): Promise<MutationBatch[]> {
     return this.persistence.runTransaction(
       'getAllMutationBatches',
-      false,
+      'readonly',
       txn => {
         return this.queue.getAllMutationBatches(txn);
       }
@@ -121,7 +133,7 @@ export class TestMutationQueue {
   ): Promise<MutationBatch[]> {
     return this.persistence.runTransaction(
       'getAllMutationBatchesAffectingDocumentKey',
-      false,
+      'readonly',
       txn => {
         return this.queue.getAllMutationBatchesAffectingDocumentKey(
           txn,
@@ -136,7 +148,7 @@ export class TestMutationQueue {
   ): Promise<MutationBatch[]> {
     return this.persistence.runTransaction(
       'getAllMutationBatchesAffectingDocumentKeys',
-      false,
+      'readonly',
       txn => {
         return this.queue.getAllMutationBatchesAffectingDocumentKeys(
           txn,
@@ -149,7 +161,7 @@ export class TestMutationQueue {
   getAllMutationBatchesAffectingQuery(query: Query): Promise<MutationBatch[]> {
     return this.persistence.runTransaction(
       'getAllMutationBatchesAffectingQuery',
-      false,
+      'readonly',
       txn => {
         return this.queue.getAllMutationBatchesAffectingQuery(txn, query);
       }
@@ -157,14 +169,22 @@ export class TestMutationQueue {
   }
 
   removeMutationBatch(batch: MutationBatch): Promise<void> {
-    return this.persistence.runTransaction('removeMutationBatch', true, txn => {
-      return this.queue.removeMutationBatch(txn, batch);
-    });
+    return this.persistence.runTransaction(
+      'removeMutationBatch',
+      'readwrite-primary',
+      txn => {
+        return this.queue.removeMutationBatch(txn, batch);
+      }
+    );
   }
 
   collectGarbage(gc: GarbageCollector): Promise<DocumentKeySet> {
-    return this.persistence.runTransaction('garbageCollection', true, txn => {
-      return gc.collectGarbage(txn);
-    });
+    return this.persistence.runTransaction(
+      'garbageCollection',
+      'readwrite-primary',
+      txn => {
+        return gc.collectGarbage(txn);
+      }
+    );
   }
 }

--- a/packages/firestore/test/unit/local/test_query_cache.ts
+++ b/packages/firestore/test/unit/local/test_query_cache.ts
@@ -31,31 +31,39 @@ export class TestQueryCache {
   constructor(public persistence: Persistence, public cache: QueryCache) {}
 
   addQueryData(queryData: QueryData): Promise<void> {
-    return this.persistence.runTransaction('addQueryData', false, txn => {
+    return this.persistence.runTransaction('addQueryData', 'readwrite', txn => {
       return this.cache.addQueryData(txn, queryData);
     });
   }
 
   updateQueryData(queryData: QueryData): Promise<void> {
-    return this.persistence.runTransaction('updateQueryData', true, txn => {
-      return this.cache.updateQueryData(txn, queryData);
-    });
+    return this.persistence.runTransaction(
+      'updateQueryData',
+      'readwrite-primary',
+      txn => {
+        return this.cache.updateQueryData(txn, queryData);
+      }
+    );
   }
 
   getQueryCount(): Promise<number> {
-    return this.persistence.runTransaction('getQueryCount', false, txn => {
+    return this.persistence.runTransaction('getQueryCount', 'readonly', txn => {
       return this.cache.getQueryCount(txn);
     });
   }
 
   removeQueryData(queryData: QueryData): Promise<void> {
-    return this.persistence.runTransaction('addQueryData', true, txn => {
-      return this.cache.removeQueryData(txn, queryData);
-    });
+    return this.persistence.runTransaction(
+      'addQueryData',
+      'readwrite-primary',
+      txn => {
+        return this.cache.removeQueryData(txn, queryData);
+      }
+    );
   }
 
   getQueryData(query: Query): Promise<QueryData | null> {
-    return this.persistence.runTransaction('getQueryData', false, txn => {
+    return this.persistence.runTransaction('getQueryData', 'readonly', txn => {
       return this.cache.getQueryData(txn, query);
     });
   }
@@ -63,7 +71,7 @@ export class TestQueryCache {
   getLastRemoteSnapshotVersion(): Promise<SnapshotVersion> {
     return this.persistence.runTransaction(
       'getLastRemoteSnapshotVersion',
-      false,
+      'readonly',
       txn => {
         return this.cache.getLastRemoteSnapshotVersion(txn);
       }
@@ -71,34 +79,46 @@ export class TestQueryCache {
   }
 
   allocateTargetId(): Promise<TargetId> {
-    return this.persistence.runTransaction('allocateTargetId', false, txn => {
-      return this.cache.allocateTargetId(txn);
-    });
+    return this.persistence.runTransaction(
+      'allocateTargetId',
+      'readwrite',
+      txn => {
+        return this.cache.allocateTargetId(txn);
+      }
+    );
   }
 
   addMatchingKeys(keys: DocumentKey[], targetId: TargetId): Promise<void> {
-    return this.persistence.runTransaction('addMatchingKeys', true, txn => {
-      let set = documentKeySet();
-      for (const key of keys) {
-        set = set.add(key);
+    return this.persistence.runTransaction(
+      'addMatchingKeys',
+      'readwrite-primary',
+      txn => {
+        let set = documentKeySet();
+        for (const key of keys) {
+          set = set.add(key);
+        }
+        return this.cache.addMatchingKeys(txn, set, targetId);
       }
-      return this.cache.addMatchingKeys(txn, set, targetId);
-    });
+    );
   }
 
   removeMatchingKeys(keys: DocumentKey[], targetId: TargetId): Promise<void> {
-    return this.persistence.runTransaction('removeMatchingKeys', true, txn => {
-      let set = documentKeySet();
-      for (const key of keys) {
-        set = set.add(key);
+    return this.persistence.runTransaction(
+      'removeMatchingKeys',
+      'readwrite-primary',
+      txn => {
+        let set = documentKeySet();
+        for (const key of keys) {
+          set = set.add(key);
+        }
+        return this.cache.removeMatchingKeys(txn, set, targetId);
       }
-      return this.cache.removeMatchingKeys(txn, set, targetId);
-    });
+    );
   }
 
   getMatchingKeysForTargetId(targetId: TargetId): Promise<DocumentKey[]> {
     return this.persistence
-      .runTransaction('getMatchingKeysForTargetId', false, txn => {
+      .runTransaction('getMatchingKeysForTargetId', 'readonly', txn => {
         return this.cache.getMatchingKeysForTargetId(txn, targetId);
       })
       .then(keySet => {
@@ -111,7 +131,7 @@ export class TestQueryCache {
   removeMatchingKeysForTargetId(targetId: TargetId): Promise<void> {
     return this.persistence.runTransaction(
       'removeMatchingKeysForTargetId',
-      true,
+      'readwrite-primary',
       txn => {
         return this.cache.removeMatchingKeysForTargetId(txn, targetId);
       }
@@ -119,7 +139,7 @@ export class TestQueryCache {
   }
 
   containsKey(key: DocumentKey): Promise<boolean> {
-    return this.persistence.runTransaction('containsKey', false, txn => {
+    return this.persistence.runTransaction('containsKey', 'readonly', txn => {
       return this.cache.containsKey(txn, key);
     });
   }
@@ -128,12 +148,15 @@ export class TestQueryCache {
     highestListenSequenceNumber: number,
     lastRemoteSnapshotVersion?: SnapshotVersion
   ): Promise<void> {
-    return this.persistence.runTransaction('setTargetsMetadata', true, txn =>
-      this.cache.setTargetsMetadata(
-        txn,
-        highestListenSequenceNumber,
-        lastRemoteSnapshotVersion
-      )
+    return this.persistence.runTransaction(
+      'setTargetsMetadata',
+      'readwrite-primary',
+      txn =>
+        this.cache.setTargetsMetadata(
+          txn,
+          highestListenSequenceNumber,
+          lastRemoteSnapshotVersion
+        )
     );
   }
 }

--- a/packages/firestore/test/unit/local/test_query_cache.ts
+++ b/packages/firestore/test/unit/local/test_query_cache.ts
@@ -81,7 +81,7 @@ export class TestQueryCache {
   getHighestSequenceNumber(): Promise<ListenSequenceNumber> {
     return this.persistence.runTransaction(
       'getHighestSequenceNumber',
-      false,
+      'readonly',
       txn => {
         return this.cache.getHighestSequenceNumber(txn);
       }

--- a/packages/firestore/test/unit/local/test_remote_document_cache.ts
+++ b/packages/firestore/test/unit/local/test_remote_document_cache.ts
@@ -32,19 +32,27 @@ export class TestRemoteDocumentCache {
   ) {}
 
   addEntries(maybeDocuments: MaybeDocument[]): Promise<void> {
-    return this.persistence.runTransaction('addEntry', true, txn => {
-      return this.cache.addEntries(txn, maybeDocuments);
-    });
+    return this.persistence.runTransaction(
+      'addEntry',
+      'readwrite-primary',
+      txn => {
+        return this.cache.addEntries(txn, maybeDocuments);
+      }
+    );
   }
 
   removeEntry(documentKey: DocumentKey): Promise<void> {
-    return this.persistence.runTransaction('removeEntry', true, txn => {
-      return this.cache.removeEntry(txn, documentKey);
-    });
+    return this.persistence.runTransaction(
+      'removeEntry',
+      'readwrite-primary',
+      txn => {
+        return this.cache.removeEntry(txn, documentKey);
+      }
+    );
   }
 
   getEntry(documentKey: DocumentKey): Promise<MaybeDocument | null> {
-    return this.persistence.runTransaction('getEntry', false, txn => {
+    return this.persistence.runTransaction('getEntry', 'readonly', txn => {
       return this.cache.getEntry(txn, documentKey);
     });
   }
@@ -52,7 +60,7 @@ export class TestRemoteDocumentCache {
   getDocumentsMatchingQuery(query: Query): Promise<DocumentMap> {
     return this.persistence.runTransaction(
       'getDocumentsMatchingQuery',
-      false,
+      'readonly',
       txn => {
         return this.cache.getDocumentsMatchingQuery(txn, query);
       }
@@ -62,7 +70,7 @@ export class TestRemoteDocumentCache {
   getNextDocumentChanges(): Promise<MaybeDocumentMap> {
     return this.persistence.runTransaction(
       'getNextDocumentChanges',
-      false,
+      'readonly',
       txn => {
         return this.cache.getNewDocumentChanges(txn);
       }

--- a/packages/firestore/test/unit/local/test_remote_document_change_buffer.ts
+++ b/packages/firestore/test/unit/local/test_remote_document_change_buffer.ts
@@ -35,14 +35,18 @@ export class TestRemoteDocumentChangeBuffer {
   }
 
   getEntry(documentKey: DocumentKey): Promise<MaybeDocument | null> {
-    return this.persistence.runTransaction('getEntry', false, txn => {
+    return this.persistence.runTransaction('getEntry', 'readonly', txn => {
       return this.buffer.getEntry(txn, documentKey);
     });
   }
 
   apply(): Promise<void> {
-    return this.persistence.runTransaction('apply', true, txn => {
-      return this.buffer.apply(txn);
-    });
+    return this.persistence.runTransaction(
+      'apply',
+      'readwrite-primary',
+      txn => {
+        return this.buffer.apply(txn);
+      }
+    );
   }
 }


### PR DESCRIPTION
This exposes three modes for an IndexedDbTransaction (readonly, readwrite, readwrite-primary) and removes the `requiresPrimaryLease` flag.