### PR TITLE
Fixing the types for firebase/app

### DIFF
--- a/packages/firebase/app/index.d.ts
+++ b/packages/firebase/app/index.d.ts
@@ -1,2 +1,18 @@
-import firebase from '@firebase/app';
+/**
+ * Copyright 2018 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as firebase from '..';
 export default firebase;

--- a/packages/firebase/app/index.d.ts
+++ b/packages/firebase/app/index.d.ts
@@ -1,0 +1,2 @@
+import firebase from '@firebase/app';
+export default firebase;

--- a/packages/firebase/app/package.json
+++ b/packages/firebase/app/package.json
@@ -3,5 +3,5 @@
   "main": "dist/index.cjs.js",
   "browser": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
-  "typings": "../index.d.ts"
+  "typings": "index.d.ts"
 }


### PR DESCRIPTION
```ts
import firebase from 'firebase/app'; // Does not work (it should however)
``` 

```ts
import * as firebase from 'firebase/app'; // Compiles but fails w/runtime errors
```

Closing #1184 in favor of this... While my heart was in the right place (in terms of `firebase/app`) I was modifying the types for `firebase` and introducing breaking changes.

Let's start fresh shall we, the root cause is that the typings for `firebase/app` are pointing to that of `firebase`. Which is not correct. 

`firebase/app` is an ESM+CJS with a default export, the types as defined in the root use `export = ...` which suggests AMD and does not play nice with ESM.

This fix simply reexports  `firebase` from `..` in a new `index.d.ts`.