### PR TITLE
Remove TODO about making SortedSet.size O(1)

### DIFF
--- a/packages/firestore/src/core/view.ts
+++ b/packages/firestore/src/core/view.ts
@@ -272,7 +272,6 @@ export class View {
       }
     );
     if (this.query.hasLimit()) {
-      // TODO(klimt): Make DocumentSet size be constant time.
       while (newDocumentSet.size > this.query.limit!) {
         const oldDoc = newDocumentSet.last();
         newDocumentSet = newDocumentSet.delete(oldDoc!.key);


### PR DESCRIPTION
I wanted to change this while loop into a for-loop and only check `.size` once. It turns out that `.size` is O(1) though as it is set in the constructor.