### PR TITLE
b/112778345: Improve argument validation for get().

### DIFF
--- a/packages/firestore/CHANGELOG.md
+++ b/packages/firestore/CHANGELOG.md
@@ -6,6 +6,8 @@
   it would make 2 attempts, to work around a backend bug.
 - [fixed] Fixed an issue that caused us to drop empty objects from calls to
   `set(..., { merge: true })`.
+- [changed] Improved argument validation for DocumentReference.get() and
+  Query.get().
 
 # 0.7.3
 - [changed] Changed the internal handling for locally updated documents that

--- a/packages/firestore/src/api/database.ts
+++ b/packages/firestore/src/api/database.ts
@@ -1077,16 +1077,8 @@ export class DocumentReference implements firestore.DocumentReference {
   }
 
   get(options?: firestore.GetOptions): Promise<firestore.DocumentSnapshot> {
-    if (options) {
-      validateOptionNames('DocumentReference.get', options, ['source']);
-      validateNamedOptionalPropertyEquals(
-        'DocumentReference.get',
-        'options',
-        'source',
-        options.source,
-        ['default', 'server', 'cache']
-      );
-    }
+    validateBetweenNumberOfArgs('DocumentReference.get', arguments, 0, 1);
+    validateGetOptions('DocumentReference.get', options);
     return new Promise(
       (resolve: Resolver<firestore.DocumentSnapshot>, reject: Rejecter) => {
         if (options && options.source === 'cache') {
@@ -1741,6 +1733,7 @@ export class Query implements firestore.Query {
 
   get(options?: firestore.GetOptions): Promise<firestore.QuerySnapshot> {
     validateBetweenNumberOfArgs('Query.get', arguments, 0, 1);
+    validateGetOptions('Query.get', options);
     return new Promise(
       (resolve: Resolver<firestore.QuerySnapshot>, reject: Rejecter) => {
         if (options && options.source === 'cache') {
@@ -2112,6 +2105,23 @@ function validateSnapshotOptions(
     ['estimate', 'previous', 'none']
   );
   return options;
+}
+
+function validateGetOptions(
+  methodName: string,
+  options: firestore.GetOptions | undefined
+): void {
+  validateOptionalArgType(methodName, 'object', 1, options);
+  if (options) {
+    validateOptionNames(methodName, options, ['source']);
+    validateNamedOptionalPropertyEquals(
+      methodName,
+      'options',
+      'source',
+      options.source,
+      ['default', 'server', 'cache']
+    );
+  }
 }
 
 function validateReference(

--- a/packages/firestore/test/integration/api/validation.test.ts
+++ b/packages/firestore/test/integration/api/validation.test.ts
@@ -289,6 +289,26 @@ apiDescribe('Validation:', persistence => {
     );
   });
 
+  validationIt(persistence, 'get options are validated', db => {
+    const collection = db.collection('test');
+    const doc = collection.doc();
+    const fn = () => {};
+
+    expect(() => doc.get(fn as any)).to.throw(
+      'Function DocumentReference.get() requires its first argument to be of type object, but it was: a function'
+    );
+    expect(() => doc.get({ abc: 'cache' } as any)).to.throw(
+      `Unknown option 'abc' passed to function DocumentReference.get(). Available options: source`
+    );
+
+    expect(() => collection.get(fn as any)).to.throw(
+      'Function Query.get() requires its first argument to be of type object, but it was: a function'
+    );
+    expect(() => collection.get({ abc: 'cache' } as any)).to.throw(
+      `Unknown option 'abc' passed to function Query.get(). Available options: source`
+    );
+  });
+
   validationIt(persistence, 'Snapshot options are validated', db => {
     const docRef = db.collection('test').doc();
 


### PR DESCRIPTION
In particular, we'll throw a decent error if you accidentally pass a callback
function to get().
