### PR TITLE
b/111221684: Improve error message when passing empty strings to API methods.

### DIFF
--- a/packages/firestore/CHANGELOG.md
+++ b/packages/firestore/CHANGELOG.md
@@ -6,8 +6,7 @@
   it would make 2 attempts, to work around a backend bug.
 - [fixed] Fixed an issue that caused us to drop empty objects from calls to
   `set(..., { merge: true })`.
-- [changed] Improved argument validation for DocumentReference.get() and
-  Query.get().
+- [changed] Improved argument validation for several API methods.
 
 # 0.7.3
 - [changed] Changed the internal handling for locally updated documents that

--- a/packages/firestore/src/api/database.ts
+++ b/packages/firestore/src/api/database.ts
@@ -149,7 +149,7 @@ class FirestoreSettings {
       this.host = DEFAULT_HOST;
       this.ssl = DEFAULT_SSL;
     } else {
-      validateNamedType('settings', 'string', 'host', settings.host);
+      validateNamedType('settings', 'non-empty string', 'host', settings.host);
       this.host = settings.host;
 
       validateNamedOptionalType('settings', 'boolean', 'ssl', settings.ssl);
@@ -425,28 +425,9 @@ follow these steps, YOUR APP MAY BREAK.`);
   private static databaseIdFromApp(app: FirebaseApp): DatabaseId {
     const options = app.options as objUtils.Dict<{}>;
     if (!objUtils.contains(options, 'projectId')) {
-      // TODO(b/62673263): We can safely remove the special handling of
-      // 'firestoreId' once alpha testers have upgraded.
-      if (objUtils.contains(options, 'firestoreId')) {
-        throw new FirestoreError(
-          Code.INVALID_ARGUMENT,
-          '"firestoreId" is now specified as "projectId" in ' +
-            'firebase.initializeApp.'
-        );
-      }
       throw new FirestoreError(
         Code.INVALID_ARGUMENT,
         '"projectId" not provided in firebase.initializeApp.'
-      );
-    }
-
-    if (objUtils.contains(options, 'firestoreOptions')) {
-      // TODO(b/62673263): We can safely remove the special handling of
-      // 'firestoreOptions' once alpha testers have upgraded.
-      throw new FirestoreError(
-        Code.INVALID_ARGUMENT,
-        '"firestoreOptions" values are now specified with ' +
-          'Firestore.settings()'
       );
     }
 
@@ -483,7 +464,7 @@ follow these steps, YOUR APP MAY BREAK.`);
 
   collection(pathString: string): firestore.CollectionReference {
     validateExactNumberOfArgs('Firestore.collection', arguments, 1);
-    validateArgType('Firestore.collection', 'string', 1, pathString);
+    validateArgType('Firestore.collection', 'non-empty string', 1, pathString);
     if (!pathString) {
       throw new FirestoreError(
         Code.INVALID_ARGUMENT,
@@ -497,7 +478,7 @@ follow these steps, YOUR APP MAY BREAK.`);
 
   doc(pathString: string): firestore.DocumentReference {
     validateExactNumberOfArgs('Firestore.doc', arguments, 1);
-    validateArgType('Firestore.doc', 'string', 1, pathString);
+    validateArgType('Firestore.doc', 'non-empty string', 1, pathString);
     if (!pathString) {
       throw new FirestoreError(
         Code.INVALID_ARGUMENT,
@@ -541,7 +522,7 @@ follow these steps, YOUR APP MAY BREAK.`);
 
   static setLogLevel(level: firestore.LogLevel): void {
     validateExactNumberOfArgs('Firestore.setLogLevel', arguments, 1);
-    validateArgType('Firestore.setLogLevel', 'string', 1, level);
+    validateArgType('Firestore.setLogLevel', 'non-empty string', 1, level);
     switch (level) {
       case 'debug':
         log.setLogLevel(log.LogLevel.DEBUG);
@@ -864,7 +845,12 @@ export class DocumentReference implements firestore.DocumentReference {
 
   collection(pathString: string): firestore.CollectionReference {
     validateExactNumberOfArgs('DocumentReference.collection', arguments, 1);
-    validateArgType('DocumentReference.collection', 'string', 1, pathString);
+    validateArgType(
+      'DocumentReference.collection',
+      'non-empty string',
+      1,
+      pathString
+    );
     if (!pathString) {
       throw new FirestoreError(
         Code.INVALID_ARGUMENT,
@@ -1332,7 +1318,7 @@ export class Query implements firestore.Query {
     value: AnyJs
   ): firestore.Query {
     validateExactNumberOfArgs('Query.where', arguments, 3);
-    validateArgType('Query.where', 'string', 2, opStr);
+    validateArgType('Query.where', 'non-empty string', 2, opStr);
     validateDefined('Query.where', 3, value);
     let fieldValue;
     const fieldPath = fieldPathFromArgument('Query.where', field);
@@ -1397,7 +1383,12 @@ export class Query implements firestore.Query {
     directionStr?: firestore.OrderByDirection
   ): firestore.Query {
     validateBetweenNumberOfArgs('Query.orderBy', arguments, 1, 2);
-    validateOptionalArgType('Query.orderBy', 'string', 2, directionStr);
+    validateOptionalArgType(
+      'Query.orderBy',
+      'non-empty string',
+      2,
+      directionStr
+    );
     let direction: Direction;
     if (directionStr === undefined || directionStr === 'asc') {
       direction = Direction.ASCENDING;
@@ -2035,7 +2026,12 @@ export class CollectionReference extends Query
     if (arguments.length === 0) {
       pathString = AutoId.newId();
     }
-    validateArgType('CollectionReference.doc', 'string', 1, pathString);
+    validateArgType(
+      'CollectionReference.doc',
+      'non-empty string',
+      1,
+      pathString
+    );
     if (pathString === '') {
       throw new FirestoreError(
         Code.INVALID_ARGUMENT,

--- a/packages/firestore/src/util/input_validation.ts
+++ b/packages/firestore/src/util/input_validation.ts
@@ -19,6 +19,16 @@ import { Code, FirestoreError } from './error';
 import { AnyJs } from './misc';
 import * as obj from './obj';
 
+/** Types accepted by validateType() and related methods for validation. */
+export type ValidationType =
+  | 'undefined'
+  | 'object'
+  | 'function'
+  | 'boolean'
+  | 'number'
+  | 'string'
+  | 'non-empty string';
+
 /**
  * Validates the invocation of functionName has the exact number of arguments.
  *
@@ -119,7 +129,7 @@ export function validateNamedArrayAtLeastNumberOfElements<T>(
  */
 export function validateArgType(
   functionName: string,
-  type: string,
+  type: ValidationType,
   position: number,
   argument: AnyJs
 ): void {
@@ -132,7 +142,7 @@ export function validateArgType(
  */
 export function validateOptionalArgType(
   functionName: string,
-  type: string,
+  type: ValidationType,
   position: number,
   argument: AnyJs
 ): void {
@@ -147,7 +157,7 @@ export function validateOptionalArgType(
  */
 export function validateNamedType(
   functionName: string,
-  type: string,
+  type: ValidationType,
   optionName: string,
   argument: AnyJs
 ): void {
@@ -160,7 +170,7 @@ export function validateNamedType(
  */
 export function validateNamedOptionalType(
   functionName: string,
-  type: string,
+  type: ValidationType,
   optionName: string,
   argument: AnyJs
 ): void {
@@ -267,11 +277,20 @@ export function validateNamedOptionalPropertyEquals<T>(
 /** Helper to validate the type of a provided input. */
 function validateType(
   functionName: string,
-  type: string,
+  type: ValidationType,
   inputName: string,
   input: AnyJs
 ): void {
-  if (typeof input !== type || (type === 'object' && !isPlainObject(input))) {
+  let valid = false;
+  if (type === 'object') {
+    valid = isPlainObject(input);
+  } else if (type === 'non-empty string') {
+    valid = typeof input === 'string' && input !== '';
+  } else {
+    valid = typeof input === type;
+  }
+
+  if (!valid) {
     const description = valueDescription(input);
     throw new FirestoreError(
       Code.INVALID_ARGUMENT,

--- a/packages/firestore/test/integration/api/validation.test.ts
+++ b/packages/firestore/test/integration/api/validation.test.ts
@@ -123,7 +123,7 @@ apiDescribe('Validation:', persistence => {
 
       expect(() => db.settings({ host: null as any })).to.throw(
         'Function settings() requires its host option to be of type ' +
-          'string, but it was: null'
+          'non-empty string, but it was: null'
       );
     });
 
@@ -179,15 +179,23 @@ apiDescribe('Validation:', persistence => {
   });
 
   describe('Collection paths', () => {
-    validationIt(persistence, 'must be strings', db => {
+    validationIt(persistence, 'must be non-empty strings', db => {
       const baseDocRef = db.doc('foo/bar');
       expect(() => db.collection(null as any)).to.throw(
         'Function Firestore.collection() requires its first argument ' +
-          'to be of type string, but it was: null'
+          'to be of type non-empty string, but it was: null'
+      );
+      expect(() => db.collection('')).to.throw(
+        'Function Firestore.collection() requires its first argument ' +
+          'to be of type non-empty string, but it was: ""'
       );
       expect(() => baseDocRef.collection(null as any)).to.throw(
         'Function DocumentReference.collection() requires its first ' +
-          'argument to be of type string, but it was: null'
+          'argument to be of type non-empty string, but it was: null'
+      );
+      expect(() => baseDocRef.collection('')).to.throw(
+        'Function DocumentReference.collection() requires its first ' +
+          'argument to be of type non-empty string, but it was: ""'
       );
       expect(() => (baseDocRef.collection as any)('foo', 'bar')).to.throw(
         'Function DocumentReference.collection() requires 1 argument, ' +
@@ -237,15 +245,23 @@ apiDescribe('Validation:', persistence => {
       const baseCollectionRef = db.collection('foo');
       expect(() => db.doc(null as any)).to.throw(
         'Function Firestore.doc() requires its first argument to be ' +
-          'of type string, but it was: null'
+          'of type non-empty string, but it was: null'
+      );
+      expect(() => db.doc('')).to.throw(
+        'Function Firestore.doc() requires its first argument to be ' +
+          'of type non-empty string, but it was: ""'
       );
       expect(() => baseCollectionRef.doc(null as any)).to.throw(
         'Function CollectionReference.doc() requires its first ' +
-          'argument to be of type string, but it was: null'
+          'argument to be of type non-empty string, but it was: null'
+      );
+      expect(() => baseCollectionRef.doc('')).to.throw(
+        'Function CollectionReference.doc() requires its first ' +
+          'argument to be of type non-empty string, but it was: ""'
       );
       expect(() => baseCollectionRef.doc(undefined as any)).to.throw(
         'Function CollectionReference.doc() requires its first ' +
-          'argument to be of type string, but it was: undefined'
+          'argument to be of type non-empty string, but it was: undefined'
       );
       expect(() => (baseCollectionRef.doc as any)('foo', 'bar')).to.throw(
         'Function CollectionReference.doc() requires between 0 and ' +


### PR DESCRIPTION
In particular, doc("") and collection("") give better messages than saying
the path must be even or odd-length.

Also fixed b/62673263 by removing really stale validation code.