### PR TITLE
Ensure that we set the subject for unsecured JWTs

### DIFF
--- a/packages/testing/index.ts
+++ b/packages/testing/index.ts
@@ -24,6 +24,7 @@ export {
   apps,
   assertFails,
   assertSucceeds,
+  initializeAdminApp,
   initializeTestApp,
   loadDatabaseRules
 } from './src/api';

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@firebase/testing",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "description": "",
   "author": "Firebase <firebase-support@google.com> (https://firebase.google.com/)",

--- a/packages/testing/src/api/index.ts
+++ b/packages/testing/src/api/index.ts
@@ -33,6 +33,7 @@ function createUnsecuredJwt(auth: object): string {
   };
   // Ensure that the auth payload has a value for 'iat'.
   (auth as any).iat = (auth as any).iat || 0;
+  (auth as any).sub = (auth as any).sub || (auth as any).uid;
   // Unsecured JWTs use the empty string as a signature.
   const signature = '';
   return [

--- a/packages/testing/test/database.test.ts
+++ b/packages/testing/test/database.test.ts
@@ -68,7 +68,7 @@ describe('Testing Module Tests', function() {
       base64.decodeString(token.accessToken.split('.')[1], /*webSafe=*/ false)
     );
     // We add an 'iat' field.
-    expect(claims).to.deep.equal({ uid: auth.uid, iat: 0 });
+    expect(claims).to.deep.equal({ uid: auth.uid, iat: 0, sub: auth.uid });
   });
 
   it('initializeAdminApp() sets the access token to "owner"', async function() {


### PR DESCRIPTION
A JWT is supposed to set a valid subject. This is what actually pipes through to `request.uid` in Firebase Rules.