### PR TITLE
Consider JWTs with empty signatures to be valid

### DIFF
--- a/packages/util/src/jwt.ts
+++ b/packages/util/src/jwt.ts
@@ -119,11 +119,7 @@ export const isValidFormat = function(token) {
   var decoded = decode(token),
     claims = decoded.claims;
 
-  return (
-    !!claims &&
-    typeof claims === 'object' &&
-    claims.hasOwnProperty('iat')
-  );
+  return !!claims && typeof claims === 'object' && claims.hasOwnProperty('iat');
 };
 
 /**

--- a/packages/util/src/jwt.ts
+++ b/packages/util/src/jwt.ts
@@ -106,8 +106,7 @@ export const issuedAtTime = function(token) {
 };
 
 /**
- * Decodes a Firebase auth. token and checks the validity of its format. Expects a valid issued-at time and non-empty
- * signature.
+ * Decodes a Firebase auth. token and checks the validity of its format. Expects a valid issued-at time.
  *
  * Notes:
  * - May return a false negative if there's no native base64 decoding support.
@@ -121,7 +120,6 @@ export const isValidFormat = function(token) {
     claims = decoded.claims;
 
   return (
-    !!decoded.signature &&
     !!claims &&
     typeof claims === 'object' &&
     claims.hasOwnProperty('iat')


### PR DESCRIPTION
We use unsecured JWTs for authenticate against the database emulator. I do not think this check is necessary, and it breaks the unsecured JWT auth behavior for the database SDK.