### PR TITLE
Implement IndexedDB LRU Reference Delegate, add LRU tests

### DIFF
--- a/packages/firestore/src/local/indexeddb_mutation_queue.ts
+++ b/packages/firestore/src/local/indexeddb_mutation_queue.ts
@@ -525,19 +525,7 @@ export class IndexedDbMutationQueue implements MutationQueue {
     txn: PersistenceTransaction,
     key: DocumentKey
   ): PersistencePromise<boolean> {
-    const indexKey = DbDocumentMutation.prefixForPath(this.userId, key.path);
-    const encodedPath = indexKey[1];
-    const startRange = IDBKeyRange.lowerBound(indexKey);
-    let containsKey = false;
-    return documentMutationsStore(txn)
-      .iterate({ range: startRange, keysOnly: true }, (key, value, control) => {
-        const [userID, keyPath, /*batchID*/ _] = key;
-        if (userID === this.userId && keyPath === encodedPath) {
-          containsKey = true;
-        }
-        control.done();
-      })
-      .next(() => containsKey);
+    return mutationQueueContainsKey(txn, this.userId, key);
   }
 
   // PORTING NOTE: Multi-tab only (state is held in memory in other clients).
@@ -558,6 +546,29 @@ export class IndexedDbMutationQueue implements MutationQueue {
         );
       });
   }
+}
+
+/**
+ * @return true if the mutation queue for the given user contains a pending mutation for the given key.
+ */
+export function mutationQueueContainsKey(
+  txn: PersistenceTransaction,
+  userId: string,
+  key: DocumentKey
+): PersistencePromise<boolean> {
+  const indexKey = DbDocumentMutation.prefixForPath(userId, key.path);
+  const encodedPath = indexKey[1];
+  const startRange = IDBKeyRange.lowerBound(indexKey);
+  let containsKey = false;
+  return documentMutationsStore(txn)
+    .iterate({ range: startRange, keysOnly: true }, (key, value, control) => {
+      const [userID, keyPath, /*batchID*/ _] = key;
+      if (userID === userId && keyPath === encodedPath) {
+        containsKey = true;
+      }
+      control.done();
+    })
+    .next(() => containsKey);
 }
 
 /**

--- a/packages/firestore/src/local/indexeddb_mutation_queue.ts
+++ b/packages/firestore/src/local/indexeddb_mutation_queue.ts
@@ -578,7 +578,7 @@ export function mutationQueuesContainKey(
 ): PersistencePromise<boolean> {
   let found = false;
   return mutationQueuesStore(txn)
-    .iterateAsync(userId => {
+    .iterateSerial(userId => {
       return mutationQueueContainsKey(txn, userId, docKey).next(containsKey => {
         if (containsKey) {
           found = true;

--- a/packages/firestore/src/local/indexeddb_mutation_queue.ts
+++ b/packages/firestore/src/local/indexeddb_mutation_queue.ts
@@ -551,7 +551,7 @@ export class IndexedDbMutationQueue implements MutationQueue {
 /**
  * @return true if the mutation queue for the given user contains a pending mutation for the given key.
  */
-export function mutationQueueContainsKey(
+function mutationQueueContainsKey(
   txn: PersistenceTransaction,
   userId: string,
   key: DocumentKey
@@ -569,6 +569,25 @@ export function mutationQueueContainsKey(
       control.done();
     })
     .next(() => containsKey);
+}
+
+/** Returns true if any mutation queue contains the given document. */
+export function mutationQueuesContainKey(
+  txn: PersistenceTransaction,
+  docKey: DocumentKey
+): PersistencePromise<boolean> {
+  let found = false;
+  return mutationQueuesStore(txn).iterateAsync(userId => {
+    return mutationQueueContainsKey(txn, userId, docKey).next(
+      containsKey => {
+        if (containsKey) {
+          found = true;
+        }
+        return PersistencePromise.resolve(!containsKey);
+      }
+    );
+  })
+  .next(() => found);
 }
 
 /**

--- a/packages/firestore/src/local/indexeddb_mutation_queue.ts
+++ b/packages/firestore/src/local/indexeddb_mutation_queue.ts
@@ -577,17 +577,16 @@ export function mutationQueuesContainKey(
   docKey: DocumentKey
 ): PersistencePromise<boolean> {
   let found = false;
-  return mutationQueuesStore(txn).iterateAsync(userId => {
-    return mutationQueueContainsKey(txn, userId, docKey).next(
-      containsKey => {
+  return mutationQueuesStore(txn)
+    .iterateAsync(userId => {
+      return mutationQueueContainsKey(txn, userId, docKey).next(containsKey => {
         if (containsKey) {
           found = true;
         }
         return PersistencePromise.resolve(!containsKey);
-      }
-    );
-  })
-  .next(() => found);
+      });
+    })
+    .next(() => found);
 }
 
 /**

--- a/packages/firestore/src/local/indexeddb_persistence.ts
+++ b/packages/firestore/src/local/indexeddb_persistence.ts
@@ -1125,7 +1125,9 @@ class IndexedDbLruDelegate implements ReferenceDelegate, LruDelegate {
     upperBound: ListenSequenceNumber,
     activeTargetIds: ActiveTargets
   ): PersistencePromise<number> {
-    return this.db.getQueryCache().removeTargets(txn, upperBound, activeTargetIds);
+    return this.db
+      .getQueryCache()
+      .removeTargets(txn, upperBound, activeTargetIds);
   }
 
   removeOrphanedDocuments(

--- a/packages/firestore/src/local/indexeddb_persistence.ts
+++ b/packages/firestore/src/local/indexeddb_persistence.ts
@@ -1185,7 +1185,7 @@ export class IndexedDbLruDelegate implements ReferenceDelegate, LruDelegate {
     return this.db.getQueryCache().updateQueryData(txn, updated);
   }
 
-  onLimboDocumentUpdated(
+  updateLimboDocument(
     txn: PersistenceTransaction,
     key: DocumentKey
   ): PersistencePromise<void> {

--- a/packages/firestore/src/local/indexeddb_persistence.ts
+++ b/packages/firestore/src/local/indexeddb_persistence.ts
@@ -65,7 +65,7 @@ import { QueryData } from './query_data';
 import { DocumentKey } from '../model/document_key';
 import { encode, EncodedResourcePath } from './encoded_resource_path';
 import {
-  LiveTargets,
+  ActiveTargets,
   LruDelegate,
   LruGarbageCollector
 } from './lru_garbage_collector';
@@ -1123,9 +1123,9 @@ class IndexedDbLruDelegate implements ReferenceDelegate, LruDelegate {
   removeTargets(
     txn: PersistenceTransaction,
     upperBound: ListenSequenceNumber,
-    liveTargets: LiveTargets
+    activeTargetIds: ActiveTargets
   ): PersistencePromise<number> {
-    return this.db.getQueryCache().removeTargets(txn, upperBound, liveTargets);
+    return this.db.getQueryCache().removeTargets(txn, upperBound, activeTargetIds);
   }
 
   removeOrphanedDocuments(

--- a/packages/firestore/src/local/indexeddb_persistence.ts
+++ b/packages/firestore/src/local/indexeddb_persistence.ts
@@ -40,8 +40,7 @@ import {
   SCHEMA_VERSION,
   DbTargetGlobal,
   SchemaConverter,
-  DbTargetDocument,
-  DbTargetDocumentKey
+  DbTargetDocument
 } from './indexeddb_schema';
 import { LocalSerializer } from './local_serializer';
 import { MutationQueue } from './mutation_queue';

--- a/packages/firestore/src/local/indexeddb_persistence.ts
+++ b/packages/firestore/src/local/indexeddb_persistence.ts
@@ -42,9 +42,7 @@ import {
   DbTargetDocument,
   DbTargetDocumentKey,
   DbMutationQueueKey,
-  DbMutationQueue,
-  DbDocumentMutationKey,
-  DbDocumentMutation
+  DbMutationQueue
 } from './indexeddb_schema';
 import { LocalSerializer } from './local_serializer';
 import { MutationQueue } from './mutation_queue';
@@ -55,7 +53,6 @@ import {
   ReferenceDelegate
 } from './persistence';
 import { PersistencePromise } from './persistence_promise';
-import { QueryCache } from './query_cache';
 import { RemoteDocumentCache } from './remote_document_cache';
 import { SimpleDb, SimpleDbStore, SimpleDbTransaction } from './simple_db';
 import { Platform } from '../platform/platform';

--- a/packages/firestore/src/local/indexeddb_persistence.ts
+++ b/packages/firestore/src/local/indexeddb_persistence.ts
@@ -286,7 +286,7 @@ export class IndexedDbPersistence implements Persistence {
     this.serializer = new LocalSerializer(serializer);
     this.document = platform.document;
     this.allowTabSynchronization = multiClientParams !== undefined;
-    this.queryCache = new IndexedDbQueryCache(this, this.serializer);
+    this.queryCache = new IndexedDbQueryCache(this.referenceDelegate, this.serializer);
     this.remoteDocumentCache = new IndexedDbRemoteDocumentCache(
       this.serializer,
       /*keepDocumentChangeLog=*/ this.allowTabSynchronization
@@ -1045,7 +1045,7 @@ function clientMetadataStore(
 }
 
 /** Provides LRU functionality for IndexedDB persistence. */
-class IndexedDbLruDelegate implements ReferenceDelegate, LruDelegate {
+export class IndexedDbLruDelegate implements ReferenceDelegate, LruDelegate {
   private additionalReferences: ReferenceSet | null;
 
   readonly garbageCollector: LruGarbageCollector;

--- a/packages/firestore/src/local/indexeddb_persistence.ts
+++ b/packages/firestore/src/local/indexeddb_persistence.ts
@@ -1070,8 +1070,8 @@ class IndexedDbLruDelegate implements ReferenceDelegate, LruDelegate {
     f: (sequenceNumber: ListenSequenceNumber) => void
   ): PersistencePromise<void> {
     return this.forEachOrphanedDocument(txn, (docKey, sequenceNumber) =>
-        f(sequenceNumber)
-      );
+      f(sequenceNumber)
+    );
   }
 
   setInMemoryPins(inMemoryPins: ReferenceSet): void {
@@ -1136,7 +1136,9 @@ class IndexedDbLruDelegate implements ReferenceDelegate, LruDelegate {
   ): PersistencePromise<number> {
     let count = 0;
     const promises: Array<PersistencePromise<void>> = [];
-    const iteration = this.forEachOrphanedDocument(txn, (docKey, sequenceNumber) => {
+    const iteration = this.forEachOrphanedDocument(
+      txn,
+      (docKey, sequenceNumber) => {
         if (sequenceNumber <= upperBound) {
           const p = this.isPinned(txn, docKey).next(isPinned => {
             if (!isPinned) {
@@ -1146,10 +1148,13 @@ class IndexedDbLruDelegate implements ReferenceDelegate, LruDelegate {
           });
           promises.push(p);
         }
-      });
+      }
+    );
     // Wait for iteration first to make sure we have a chance to add all of the
     // removal promises to the array.
-    return iteration.next(() => PersistencePromise.waitFor(promises)).next(() => count);
+    return iteration
+      .next(() => PersistencePromise.waitFor(promises))
+      .next(() => count);
   }
 
   /**
@@ -1207,10 +1212,7 @@ class IndexedDbLruDelegate implements ReferenceDelegate, LruDelegate {
             // if nextToReport is valid, report it, this is a new key so the
             // last one must not be a member of any targets.
             if (nextToReport !== ListenSequence.INVALID) {
-              f(
-                new DocumentKey(decode(nextPath)),
-                nextToReport
-              );
+              f(new DocumentKey(decode(nextPath)), nextToReport);
             }
             // set nextToReport to be this sequence number. It's the next one we
             // might report, if we don't find any targets for this document.
@@ -1228,10 +1230,7 @@ class IndexedDbLruDelegate implements ReferenceDelegate, LruDelegate {
         // need to check if the last key we iterated over was an orphaned
         // document and report it.
         if (nextToReport !== ListenSequence.INVALID) {
-          f(
-            new DocumentKey(decode(nextPath)),
-            nextToReport
-          );
+          f(new DocumentKey(decode(nextPath)), nextToReport);
         }
       });
   }
@@ -1283,7 +1282,5 @@ function writeSentinelKey(
   txn: PersistenceTransaction,
   key: DocumentKey
 ): PersistencePromise<void> {
-  return sentinelKeyStore(txn).put(
-    sentinelRow(key, txn.currentSequenceNumber)
-  );
+  return sentinelKeyStore(txn).put(sentinelRow(key, txn.currentSequenceNumber));
 }

--- a/packages/firestore/src/local/indexeddb_persistence.ts
+++ b/packages/firestore/src/local/indexeddb_persistence.ts
@@ -286,7 +286,10 @@ export class IndexedDbPersistence implements Persistence {
     this.serializer = new LocalSerializer(serializer);
     this.document = platform.document;
     this.allowTabSynchronization = multiClientParams !== undefined;
-    this.queryCache = new IndexedDbQueryCache(this.referenceDelegate, this.serializer);
+    this.queryCache = new IndexedDbQueryCache(
+      this.referenceDelegate,
+      this.serializer
+    );
     this.remoteDocumentCache = new IndexedDbRemoteDocumentCache(
       this.serializer,
       /*keepDocumentChangeLog=*/ this.allowTabSynchronization

--- a/packages/firestore/src/local/indexeddb_persistence.ts
+++ b/packages/firestore/src/local/indexeddb_persistence.ts
@@ -1049,7 +1049,7 @@ function clientMetadataStore(
 
 /** Provides LRU functionality for IndexedDB persistence. */
 export class IndexedDbLruDelegate implements ReferenceDelegate, LruDelegate {
-  private additionalReferences: ReferenceSet | null;
+  private inMemoryPins: ReferenceSet | null;
 
   readonly garbageCollector: LruGarbageCollector;
 
@@ -1078,7 +1078,7 @@ export class IndexedDbLruDelegate implements ReferenceDelegate, LruDelegate {
   }
 
   setInMemoryPins(inMemoryPins: ReferenceSet): void {
-    this.additionalReferences = inMemoryPins;
+    this.inMemoryPins = inMemoryPins;
   }
 
   addReference(
@@ -1122,7 +1122,7 @@ export class IndexedDbLruDelegate implements ReferenceDelegate, LruDelegate {
     txn: PersistenceTransaction,
     docKey: DocumentKey
   ): PersistencePromise<boolean> {
-    return this.additionalReferences!.containsKey(txn, docKey).next(
+    return this.inMemoryPins!.containsKey(txn, docKey).next(
       isPinned => {
         if (isPinned) {
           return PersistencePromise.resolve(true);

--- a/packages/firestore/src/local/indexeddb_query_cache.ts
+++ b/packages/firestore/src/local/indexeddb_query_cache.ts
@@ -46,7 +46,7 @@ import {
   SentinelRow
 } from './indexeddb_persistence';
 import { ListenSequence } from '../core/listen_sequence';
-import { LiveTargets } from './lru_garbage_collector';
+import { ActiveTargets } from './lru_garbage_collector';
 
 export class IndexedDbQueryCache implements QueryCache {
   constructor(
@@ -159,7 +159,7 @@ export class IndexedDbQueryCache implements QueryCache {
   removeTargets(
     txn: PersistenceTransaction,
     upperBound: ListenSequenceNumber,
-    activeTargetIds: LiveTargets
+    activeTargetIds: ActiveTargets
   ): PersistencePromise<number> {
     let count = 0;
     const promises: Array<PersistencePromise<void>> = [];

--- a/packages/firestore/src/local/indexeddb_query_cache.ts
+++ b/packages/firestore/src/local/indexeddb_query_cache.ts
@@ -50,8 +50,8 @@ import { LiveTargets } from './lru_garbage_collector';
 
 export class IndexedDbQueryCache implements QueryCache {
   constructor(
-    private serializer: LocalSerializer,
-    private readonly db: IndexedDbPersistence
+    private readonly db: IndexedDbPersistence,
+    private serializer: LocalSerializer
   ) {}
 
   /** The garbage collector to notify about potential garbage keys. */

--- a/packages/firestore/src/local/indexeddb_query_cache.ts
+++ b/packages/firestore/src/local/indexeddb_query_cache.ts
@@ -476,7 +476,7 @@ export function getHighestListenSequenceNumber(
 /**
  * Helper to get a typed SimpleDbStore for the document target object store.
  */
-function documentTargetStore(
+export function documentTargetStore(
   txn: PersistenceTransaction
 ): SimpleDbStore<DbTargetDocumentKey, DbTargetDocument> {
   return IndexedDbPersistence.getStore<DbTargetDocumentKey, DbTargetDocument>(

--- a/packages/firestore/src/local/indexeddb_query_cache.ts
+++ b/packages/firestore/src/local/indexeddb_query_cache.ts
@@ -39,11 +39,7 @@ import { PersistencePromise } from './persistence_promise';
 import { QueryCache } from './query_cache';
 import { QueryData } from './query_data';
 import { TargetIdGenerator } from '../core/target_id_generator';
-import {
-  SimpleDbStore,
-  SimpleDbTransaction,
-  SimpleDb
-} from './simple_db';
+import { SimpleDbStore, SimpleDbTransaction, SimpleDb } from './simple_db';
 import {
   IndexedDbPersistence,
   IndexedDbTransaction,

--- a/packages/firestore/src/local/indexeddb_query_cache.ts
+++ b/packages/firestore/src/local/indexeddb_query_cache.ts
@@ -42,8 +42,7 @@ import { TargetIdGenerator } from '../core/target_id_generator';
 import {
   SimpleDbStore,
   SimpleDbTransaction,
-  SimpleDb,
-  IterationController
+  SimpleDb
 } from './simple_db';
 import {
   IndexedDbPersistence,

--- a/packages/firestore/src/local/indexeddb_schema.ts
+++ b/packages/firestore/src/local/indexeddb_schema.ts
@@ -15,7 +15,7 @@
  */
 
 import * as api from '../protos/firestore_proto_api';
-import { BatchId } from '../core/types';
+import { BatchId, ListenSequenceNumber } from '../core/types';
 import { TargetId } from '../core/types';
 import { ResourcePath } from '../model/path';
 import { assert } from '../util/assert';
@@ -573,9 +573,14 @@ export class DbTarget {
 export type DbTargetDocumentKey = [TargetId, EncodedResourcePath];
 
 /**
- * An object representing an association between a target and a document.
- * Stored in the targetDocument object store to store the documents tracked by a
- * particular target.
+ * An object representing an association between a target and a document, or a
+ * sentinel row marking the last sequence number at which a document was used.
+ * Each document cached must have a corresponding sentinel row before lru
+ * garbage collection is enabled.
+ *
+ * The target associations and sentinel rows are co-located so that orphaned
+ * documents and their sequence numbers can be identified efficiently via a scan
+ * of this store.
  */
 export class DbTargetDocument {
   /** Name of the IndexedDb object store.  */
@@ -592,14 +597,23 @@ export class DbTargetDocument {
 
   constructor(
     /**
-     * The targetId identifying a target.
+     * The targetId identifying a target or 0 for a sentinel row.
      */
     public targetId: TargetId,
     /**
      * The path to the document, as encoded in the key.
      */
-    public path: EncodedResourcePath
-  ) {}
+    public path: EncodedResourcePath,
+    /**
+     *
+     */
+    public sequenceNumber?: ListenSequenceNumber
+  ) {
+    assert(
+      (targetId !== 0) !== (typeof sequenceNumber !== 'undefined'),
+      'A target-document row must either have targetId == 0 and a defined sequence number, or a non-zero targetId and no sequence number'
+    );
+  }
 }
 
 /**

--- a/packages/firestore/src/local/indexeddb_schema.ts
+++ b/packages/firestore/src/local/indexeddb_schema.ts
@@ -612,7 +612,7 @@ export class DbTargetDocument {
     public sequenceNumber?: ListenSequenceNumber
   ) {
     assert(
-      (targetId === 0) === (typeof sequenceNumber !== undefined),
+      (targetId === 0) === (sequenceNumber !== undefined),
       'A target-document row must either have targetId == 0 and a defined sequence number, or a non-zero targetId and no sequence number'
     );
   }

--- a/packages/firestore/src/local/indexeddb_schema.ts
+++ b/packages/firestore/src/local/indexeddb_schema.ts
@@ -605,12 +605,14 @@ export class DbTargetDocument {
      */
     public path: EncodedResourcePath,
     /**
-     *
+     * If this is a sentinel row, this should be the sequence number of the last
+     * time the document specified by `path` was used. Otherwise, it should be
+     * `undefined`.
      */
     public sequenceNumber?: ListenSequenceNumber
   ) {
     assert(
-      (targetId !== 0) !== (typeof sequenceNumber !== 'undefined'),
+      (targetId === 0) === (typeof sequenceNumber !== undefined),
       'A target-document row must either have targetId == 0 and a defined sequence number, or a non-zero targetId and no sequence number'
     );
   }

--- a/packages/firestore/src/local/lru_garbage_collector.ts
+++ b/packages/firestore/src/local/lru_garbage_collector.ts
@@ -52,7 +52,7 @@ export interface LruDelegate {
   removeTargets(
     txn: PersistenceTransaction,
     upperBound: ListenSequenceNumber,
-    activeTargetIds: LiveTargets
+    activeTargetIds: ActiveTargets
   ): PersistencePromise<number>;
 
   /**
@@ -70,7 +70,7 @@ export interface LruDelegate {
 /**
  * Describes an object whose keys are active target ids. We do not care about the type of the values.
  */
-export type LiveTargets = {
+export type ActiveTargets = {
   [id: number]: AnyJs;
 };
 
@@ -252,9 +252,9 @@ export class LruGarbageCollector {
   removeTargets(
     txn: PersistenceTransaction,
     upperBound: ListenSequenceNumber,
-    liveTargets: LiveTargets
+    activeTargetIds: ActiveTargets
   ): PersistencePromise<number> {
-    return this.delegate.removeTargets(txn, upperBound, liveTargets);
+    return this.delegate.removeTargets(txn, upperBound, activeTargetIds);
   }
 
   /**

--- a/packages/firestore/src/local/lru_garbage_collector.ts
+++ b/packages/firestore/src/local/lru_garbage_collector.ts
@@ -27,6 +27,8 @@ import { AnyJs } from '../util/misc';
  * needs from the persistence layer.
  */
 export interface LruDelegate {
+  readonly garbageCollector: LruGarbageCollector;
+
   getTargetCount(txn: PersistenceTransaction): PersistencePromise<number>;
 
   /** Enumerates all the targets in the QueryCache. */

--- a/packages/firestore/src/local/lru_garbage_collector.ts
+++ b/packages/firestore/src/local/lru_garbage_collector.ts
@@ -29,13 +29,13 @@ import { AnyJs } from '../util/misc';
 export interface LruDelegate {
   readonly garbageCollector: LruGarbageCollector;
 
-  getTargetCount(txn: PersistenceTransaction): PersistencePromise<number>;
-
   /** Enumerates all the targets in the QueryCache. */
   forEachTarget(
     txn: PersistenceTransaction,
     f: (target: QueryData) => void
   ): PersistencePromise<void>;
+
+  getTargetCount(txn: PersistenceTransaction): PersistencePromise<number>;
 
   /**
    * Enumerates sequence numbers for documents not associated with a target.

--- a/packages/firestore/src/local/lru_garbage_collector.ts
+++ b/packages/firestore/src/local/lru_garbage_collector.ts
@@ -1,0 +1,268 @@
+/**
+ * Copyright 2018 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { QueryData } from './query_data';
+import { PersistenceTransaction } from './persistence';
+import { PersistencePromise } from './persistence_promise';
+import { ListenSequenceNumber } from '../core/types';
+import { ListenSequence } from '../core/listen_sequence';
+import { assert } from '../util/assert';
+import { AnyJs } from '../util/misc';
+
+/**
+ * Persistence layers intending to use LRU Garbage collection should have reference delegates that
+ * implement this interface. This interface defines the operations that the LRU garbage collector
+ * needs from the persistence layer.
+ */
+export interface LruDelegate {
+  getTargetCount(txn: PersistenceTransaction): PersistencePromise<number>;
+
+  /** Enumerates all the targets in the QueryCache. */
+  forEachTarget(
+    txn: PersistenceTransaction,
+    f: (target: QueryData) => void
+  ): PersistencePromise<void>;
+
+  /** Enumerates sequence numbers for documents not associated with a target. */
+  forEachOrphanedDocumentSequenceNumber(
+    txn: PersistenceTransaction,
+    f: (sequenceNumber: ListenSequenceNumber) => void
+  ): PersistencePromise<void>;
+
+  /**
+   * Removes all targets that have a sequence number less than or equal to `upperBound`, and are not
+   * present in the `activeTargetIds` set.
+   *
+   * @return the number of targets removed.
+   */
+  removeTargets(
+    txn: PersistenceTransaction,
+    upperBound: ListenSequenceNumber,
+    activeTargetIds: LiveTargets
+  ): PersistencePromise<number>;
+
+  /**
+   * Removes all unreferenced documents from the cache that have a sequence number less than or
+   * equal to the given `upperBound`.
+   *
+   * @return the number of documents removed.
+   */
+  removeOrphanedDocuments(
+    txn: PersistenceTransaction,
+    upperBound: ListenSequenceNumber
+  ): PersistencePromise<number>;
+}
+
+/**
+ * Describes an object whose keys are active target ids. We do not care about the type of the values.
+ */
+export type LiveTargets = {
+  [id: number]: AnyJs;
+};
+
+/**
+ * A selective port of `java.util.PriorityQueue`
+ * {@see <a href="https://github.com/openjdk-mirror/jdk7u-jdk/blob/master/src/share/classes/java/util/PriorityQueue.java">PriorityQueue.java</a>}
+ * The queue does not grow and must have an initial capacity when it is constructed. Additionally, elements may only be
+ * `poll()`'d and cannot be removed from any other position in the queue.
+ */
+class PriorityQueue<T> {
+  private _size = 0;
+  get size(): number {
+    return this._size;
+  }
+  private readonly queue: T[];
+  constructor(
+    private readonly capacity: number,
+    private readonly comparator: (a: T, b: T) => number
+  ) {
+    assert(capacity > 0, 'Capacity must be greater than 0');
+    this.queue = new Array<T>(capacity);
+  }
+
+  add(elem: T): void {
+    assert(this._size + 1 <= this.capacity, 'Queue is over capacity');
+    if (this._size === 0) {
+      this.queue[0] = elem;
+      this._size = 1;
+    } else {
+      this.siftUp(elem);
+    }
+  }
+
+  poll(): T | null {
+    if (this._size === 0) {
+      return null;
+    }
+    const result = this.queue[0];
+    const newSize = --this._size;
+    const last = this.queue[newSize];
+    delete this.queue[newSize];
+    if (newSize !== 0) {
+      this.siftDown(last);
+    }
+    return result;
+  }
+
+  peek(): T | null {
+    if (this._size > 0) {
+      return this.queue[0];
+    }
+    return null;
+  }
+
+  private siftUp(elem: T): void {
+    let k = this._size;
+    while (k > 0) {
+      const parent = (k - 1) >>> 1;
+      const toCheck = this.queue[parent];
+      const comp = this.comparator(elem, toCheck);
+      if (comp >= 0) {
+        break;
+      }
+      this.queue[k] = toCheck;
+      k = parent;
+    }
+    this.queue[k] = elem;
+    this._size++;
+  }
+
+  private siftDown(lastElem: T): void {
+    let k = 0;
+    const half = this._size >>> 1;
+    while (k < half) {
+      let child = (k << 1) + 1;
+      let toCheck = this.queue[child];
+      const right = child + 1;
+      if (
+        right < this._size &&
+        this.comparator(toCheck, this.queue[right]) > 0
+      ) {
+        toCheck = this.queue[right];
+        child = right;
+      }
+      if (this.comparator(lastElem, toCheck) <= 0) {
+        break;
+      }
+      this.queue[k] = toCheck;
+      k = child;
+    }
+    this.queue[k] = lastElem;
+  }
+}
+
+/**
+ * Used to calculate the nth sequence number. Keeps a rolling buffer of the lowest n values passed
+ * to `addElement`, and finally reports the largest of them in `maxValue`.
+ */
+class RollingSequenceNumberBuffer {
+  private queue: PriorityQueue<ListenSequenceNumber>;
+
+  // Invert the comparison because we want to keep the smallest values.
+  private static COMPARATOR: (
+    a: ListenSequenceNumber,
+    b: ListenSequenceNumber
+  ) => number = (a, b) => {
+    if (b < a) {
+      return -1;
+    } else if (b === a) {
+      return 0;
+    }
+    return 1;
+  };
+
+  constructor(private readonly maxElements: number) {
+    this.queue = new PriorityQueue(
+      maxElements,
+      RollingSequenceNumberBuffer.COMPARATOR
+    );
+  }
+
+  addElement(sequenceNumber: ListenSequenceNumber): void {
+    if (this.queue.size < this.maxElements) {
+      this.queue.add(sequenceNumber);
+    } else {
+      // Note: use first because we have inverted the comparison
+      const highestValue = this.queue.peek()!;
+      if (sequenceNumber < highestValue) {
+        this.queue.poll();
+        this.queue.add(sequenceNumber);
+      }
+    }
+  }
+
+  get maxValue(): ListenSequenceNumber {
+    return this.queue.peek()!;
+  }
+}
+
+/** Implements the steps for LRU garbage collection. */
+export class LruGarbageCollector {
+  constructor(private readonly delegate: LruDelegate) {}
+
+  /** Given a percentile of target to collect, returns the number of targets to collect. */
+  calculateTargetCount(
+    txn: PersistenceTransaction,
+    percentile: number
+  ): PersistencePromise<number> {
+    return this.delegate.getTargetCount(txn).next(targetCount => {
+      return Math.floor(percentile / 100.0 * targetCount);
+    });
+  }
+
+  /** Returns the nth sequence number, counting in order from the smallest. */
+  nthSequenceNumber(
+    txn: PersistenceTransaction,
+    n: number
+  ): PersistencePromise<ListenSequenceNumber> {
+    if (n === 0) {
+      return PersistencePromise.resolve(ListenSequence.INVALID);
+    }
+
+    const buffer = new RollingSequenceNumberBuffer(n);
+    return this.delegate
+      .forEachTarget(txn, target => buffer.addElement(target.sequenceNumber))
+      .next(() => {
+        return this.delegate.forEachOrphanedDocumentSequenceNumber(
+          txn,
+          sequenceNumber => buffer.addElement(sequenceNumber)
+        );
+      })
+      .next(() => buffer.maxValue);
+  }
+
+  /**
+   * Removes targets with a sequence number equal to or less than the given upper bound, and removes
+   * document associations with those targets.
+   */
+  removeTargets(
+    txn: PersistenceTransaction,
+    upperBound: ListenSequenceNumber,
+    liveTargets: LiveTargets
+  ): PersistencePromise<number> {
+    return this.delegate.removeTargets(txn, upperBound, liveTargets);
+  }
+
+  /**
+   * Removes documents that have a sequence number equal to or less than the upper bound and are not
+   * otherwise pinned.
+   */
+  removeOrphanedDocuments(
+    txn: PersistenceTransaction,
+    upperBound: ListenSequenceNumber
+  ): PersistencePromise<number> {
+    return this.delegate.removeOrphanedDocuments(txn, upperBound);
+  }
+}

--- a/packages/firestore/src/local/lru_garbage_collector.ts
+++ b/packages/firestore/src/local/lru_garbage_collector.ts
@@ -37,7 +37,10 @@ export interface LruDelegate {
     f: (target: QueryData) => void
   ): PersistencePromise<void>;
 
-  /** Enumerates sequence numbers for documents not associated with a target. */
+  /**
+   * Enumerates sequence numbers for documents not associated with a target.
+   * Note that this may include duplicate sequence numbers.
+   */
   forEachOrphanedDocumentSequenceNumber(
     txn: PersistenceTransaction,
     f: (sequenceNumber: ListenSequenceNumber) => void

--- a/packages/firestore/src/local/persistence.ts
+++ b/packages/firestore/src/local/persistence.ts
@@ -97,7 +97,7 @@ export interface ReferenceDelegate {
   ): PersistencePromise<void>;
 
   /** Notify the delegate that a limbo document was updated. */
-  onLimboDocumentUpdated(
+  updateLimboDocument(
     txn: PersistenceTransaction,
     doc: DocumentKey
   ): PersistencePromise<void>;

--- a/packages/firestore/src/local/persistence.ts
+++ b/packages/firestore/src/local/persistence.ts
@@ -22,6 +22,9 @@ import { QueryCache } from './query_cache';
 import { RemoteDocumentCache } from './remote_document_cache';
 import { ClientId } from './shared_client_state';
 import { ListenSequenceNumber } from '../core/types';
+import { ReferenceSet } from './reference_set';
+import { QueryData } from './query_data';
+import { DocumentKey } from '../model/document_key';
 
 /**
  * Opaque interface representing a persistence transaction.
@@ -45,6 +48,59 @@ export abstract class PersistenceTransaction {
  * exactly once marking the current instance as Primary.
  */
 export type PrimaryStateListener = (isPrimary: boolean) => Promise<void>;
+
+/**
+ * A ReferenceDelegate instance handles all of the hooks into the document-reference lifecycle. This
+ * includes being added to a target, being removed from a target, being subject to mutation, and
+ * being mutated by the user.
+ *
+ * <p>Different implementations may do different things with each of these events. Not every
+ * implementation needs to do something with every lifecycle hook.
+ *
+ * Porting note: since sequence numbers are attached to transactions in this client, the
+ * ReferenceDelegate does not need to deal in transactional semantics, nor does it need to
+ * track and generate sequence numbers.
+ */
+export interface ReferenceDelegate {
+  /**
+   * Registers a ReferenceSet of documents that should be considered 'referenced' and not eligible
+   * for removal during garbage collection.
+   */
+  setInMemoryPins(pins: ReferenceSet): void;
+
+  /** Notify the delegate that the given document was added to a target. */
+  addReference(
+    txn: PersistenceTransaction,
+    doc: DocumentKey
+  ): PersistencePromise<void>;
+
+  /** Notify the delegate that the given document was removed from a target. */
+  removeReference(
+    txn: PersistenceTransaction,
+    doc: DocumentKey
+  ): PersistencePromise<void>;
+
+  /**
+   * Notify the delegate that a target was removed. The delegate may, but is not obligated to,
+   * actually delete the target and associated data.
+   */
+  removeTarget(
+    txn: PersistenceTransaction,
+    queryData: QueryData
+  ): PersistencePromise<void>;
+
+  /** Notify the delegate that a document is no longer being mutated by the user. */
+  removeMutationReference(
+    txn: PersistenceTransaction,
+    doc: DocumentKey
+  ): PersistencePromise<void>;
+
+  /** Notify the delegate that a limbo document was updated. */
+  onLimboDocumentUpdated(
+    txn: PersistenceTransaction,
+    doc: DocumentKey
+  ): PersistencePromise<void>;
+}
 
 /**
  * Persistence is the lowest-level shared interface to persistent storage in

--- a/packages/firestore/src/local/persistence.ts
+++ b/packages/firestore/src/local/persistence.ts
@@ -54,12 +54,13 @@ export type PrimaryStateListener = (isPrimary: boolean) => Promise<void>;
  * includes being added to a target, being removed from a target, being subject to mutation, and
  * being mutated by the user.
  *
- * <p>Different implementations may do different things with each of these events. Not every
+ * Different implementations may do different things with each of these events. Not every
  * implementation needs to do something with every lifecycle hook.
  *
- * Porting note: since sequence numbers are attached to transactions in this client, the
- * ReferenceDelegate does not need to deal in transactional semantics, nor does it need to
- * track and generate sequence numbers.
+ * PORTING NOTE: since sequence numbers are attached to transactions in this
+ * client, the ReferenceDelegate does not need to deal in transactional
+ * semantics (onTransactionStarted/Committed()), nor does it need to track and
+ * generate sequence numbers (getCurrentSequenceNumber()).
  */
 export interface ReferenceDelegate {
   /**

--- a/packages/firestore/src/local/simple_db.ts
+++ b/packages/firestore/src/local/simple_db.ts
@@ -498,6 +498,39 @@ export class SimpleDbStore<
     return this.iterateCursor(cursor, callback);
   }
 
+  /**
+   * Iterates over a store, but waits for the given callback to complete for each entry
+   * before iterating the next entry. This allows the callback to do asynchronous work
+   * to determine if this iteration should continue.
+   *
+   * The provided callback should return `true` to continue iteration, and `false` otherwise.
+   */
+  iterateAsync(
+    callback: (k: KeyType, v: ValueType) => PersistencePromise<boolean>
+  ): PersistencePromise<void> {
+    const cursorRequest = this.cursor({});
+    return new PersistencePromise((resolve, reject) => {
+      cursorRequest.onerror = (event: Event) => {
+        reject((event.target as IDBRequest).error);
+      };
+      cursorRequest.onsuccess = (event: Event) => {
+        const cursor: IDBCursorWithValue = (event.target as IDBRequest).result;
+        if (!cursor) {
+          resolve();
+          return;
+        }
+
+        callback(cursor.primaryKey, cursor.value).next(shouldContinue => {
+          if (shouldContinue) {
+            cursor.continue();
+          } else {
+            resolve();
+          }
+        });
+      };
+    });
+  }
+
   private iterateCursor(
     cursorRequest: IDBRequest,
     fn: IterateCallback<KeyType, ValueType>

--- a/packages/firestore/src/local/simple_db.ts
+++ b/packages/firestore/src/local/simple_db.ts
@@ -499,13 +499,14 @@ export class SimpleDbStore<
   }
 
   /**
-   * Iterates over a store, but waits for the given callback to complete for each entry
-   * before iterating the next entry. This allows the callback to do asynchronous work
-   * to determine if this iteration should continue.
+   * Iterates over a store, but waits for the given callback to complete for
+   * each entry before iterating the next entry. This allows the callback to do
+   * asynchronous work to determine if this iteration should continue.
    *
-   * The provided callback should return `true` to continue iteration, and `false` otherwise.
+   * The provided callback should return `true` to continue iteration, and
+   * `false` otherwise.
    */
-  iterateAsync(
+  iterateSerial(
     callback: (k: KeyType, v: ValueType) => PersistencePromise<boolean>
   ): PersistencePromise<void> {
     const cursorRequest = this.cursor({});

--- a/packages/firestore/test/unit/local/lru_garbage_collector.test.ts
+++ b/packages/firestore/test/unit/local/lru_garbage_collector.test.ts
@@ -179,15 +179,23 @@ function genericLruGarbageCollectorTests(
   }
 
   function calculateTargetCount(percentile: number): Promise<number> {
-    return persistence.runTransaction('calculate target count', 'readwrite', txn => {
-      return garbageCollector.calculateTargetCount(txn, percentile);
-    });
+    return persistence.runTransaction(
+      'calculate target count',
+      'readwrite',
+      txn => {
+        return garbageCollector.calculateTargetCount(txn, percentile);
+      }
+    );
   }
 
   function nthSequenceNumber(n: number): Promise<ListenSequenceNumber> {
-    return persistence.runTransaction('nth sequence number', 'readwrite', txn => {
-      return garbageCollector.nthSequenceNumber(txn, n);
-    });
+    return persistence.runTransaction(
+      'nth sequence number',
+      'readwrite',
+      txn => {
+        return garbageCollector.nthSequenceNumber(txn, n);
+      }
+    );
   }
 
   function removeTargets(
@@ -275,13 +283,17 @@ function genericLruGarbageCollectorTests(
   it('sequence number for multiple targets in a transaction', async () => {
     // 50 queries, 9 with one transaction, incrementing from there. Should get second sequence
     // number.
-    await persistence.runTransaction('9 targets in a batch', 'readwrite', txn => {
-      let p = PersistencePromise.resolve();
-      for (let i = 0; i < 9; i++) {
-        p = p.next(() => addNextTargetInTransaction(txn)).next();
+    await persistence.runTransaction(
+      '9 targets in a batch',
+      'readwrite',
+      txn => {
+        let p = PersistencePromise.resolve();
+        for (let i = 0; i < 9; i++) {
+          p = p.next(() => addNextTargetInTransaction(txn)).next();
+        }
+        return p;
       }
-      return p;
-    });
+    );
     for (let i = 9; i < 50; i++) {
       await addNextTarget();
     }
@@ -290,13 +302,17 @@ function genericLruGarbageCollectorTests(
   });
 
   it('all collected targets in a single transaction', async () => {
-    await persistence.runTransaction('11 targets in a batch', 'readwrite', txn => {
-      let p = PersistencePromise.resolve();
-      for (let i = 0; i < 11; i++) {
-        p = p.next(() => addNextTargetInTransaction(txn)).next();
+    await persistence.runTransaction(
+      '11 targets in a batch',
+      'readwrite',
+      txn => {
+        let p = PersistencePromise.resolve();
+        for (let i = 0; i < 11; i++) {
+          p = p.next(() => addNextTargetInTransaction(txn)).next();
+        }
+        return p;
       }
-      return p;
-    });
+    );
     for (let i = 11; i < 50; i++) {
       await addNextTarget();
     }
@@ -333,12 +349,16 @@ function genericLruGarbageCollectorTests(
     for (let i = 0; i < 49; i++) {
       await addNextTarget();
     }
-    await persistence.runTransaction('target with a mutation', 'readwrite', txn => {
-      return addNextTargetInTransaction(txn).next(queryData => {
-        const keySet = documentKeySet().add(docInTarget);
-        return queryCache.addMatchingKeys(txn, keySet, queryData.targetId);
-      });
-    });
+    await persistence.runTransaction(
+      'target with a mutation',
+      'readwrite',
+      txn => {
+        return addNextTargetInTransaction(txn).next(queryData => {
+          const keySet = documentKeySet().add(docInTarget);
+          return queryCache.addMatchingKeys(txn, keySet, queryData.targetId);
+        });
+      }
+    );
     const expected = initialSequenceNumber + 3;
     expect(await nthSequenceNumber(10)).to.equal(expected);
   });
@@ -722,13 +742,17 @@ function genericLruGarbageCollectorTests(
     );
 
     // Remove the middle target
-    await persistence.runTransaction('remove middle target', 'readwrite', txn => {
-      // TODO(gsoltis): fix this cast
-      return (persistence as IndexedDbPersistence).referenceDelegate.removeTarget(
-        txn,
-        middleTarget
-      );
-    });
+    await persistence.runTransaction(
+      'remove middle target',
+      'readwrite',
+      txn => {
+        // TODO(gsoltis): fix this cast
+        return (persistence as IndexedDbPersistence).referenceDelegate.removeTarget(
+          txn,
+          middleTarget
+        );
+      }
+    );
 
     // Write a doc and get an ack, not part of a target
     await persistence.runTransaction(

--- a/packages/firestore/test/unit/local/lru_garbage_collector.test.ts
+++ b/packages/firestore/test/unit/local/lru_garbage_collector.test.ts
@@ -1,0 +1,770 @@
+/**
+ * Copyright 2018 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { expect } from 'chai';
+import { IndexedDbPersistence } from '../../../src/local/indexeddb_persistence';
+import {
+  Persistence,
+  PersistenceTransaction
+} from '../../../src/local/persistence';
+import * as PersistenceTestHelpers from './persistence_test_helpers';
+import { QueryData, QueryPurpose } from '../../../src/local/query_data';
+import { PersistencePromise } from '../../../src/local/persistence_promise';
+import { ListenSequenceNumber, TargetId } from '../../../src/core/types';
+import { Query } from '../../../src/core/query';
+import { doc, path, queryData, wrapObject } from '../../util/helpers';
+import { QueryCache } from '../../../src/local/query_cache';
+import {
+  LiveTargets,
+  LruDelegate,
+  LruGarbageCollector
+} from '../../../src/local/lru_garbage_collector';
+import { ListenSequence } from '../../../src/core/listen_sequence';
+import { DocumentKey } from '../../../src/model/document_key';
+import { documentKeySet } from '../../../src/model/collections';
+import {
+  Mutation,
+  Precondition,
+  SetMutation
+} from '../../../src/model/mutation';
+import { Document } from '../../../src/model/document';
+import { SnapshotVersion } from '../../../src/core/snapshot_version';
+import { MutationQueue } from '../../../src/local/mutation_queue';
+import { User } from '../../../src/auth/user';
+import { Timestamp } from '../../../src/api/timestamp';
+import { RemoteDocumentCache } from '../../../src/local/remote_document_cache';
+import { ReferenceSet } from '../../../src/local/reference_set';
+import { IndexedDbQueryCache } from '../../../src/local/indexeddb_query_cache';
+
+describe('IndexedDbLruReferenceDelegate', () => {
+  if (!IndexedDbPersistence.isAvailable()) {
+    console.warn('No IndexedDB. Skipping IndexedDbLruReferenceDelegate tests.');
+    return;
+  }
+
+  genericLruGarbageCollectorTests(() =>
+    PersistenceTestHelpers.testIndexedDbPersistence()
+  );
+});
+
+function genericLruGarbageCollectorTests(
+  newPersistence: () => Promise<Persistence>
+): void {
+  let previousTargetId: TargetId;
+  let previousDocNum: number;
+  beforeEach(async () => {
+    previousTargetId = 500;
+    previousDocNum = 10;
+    await newTestResources();
+  });
+
+  afterEach(async () => {
+    await persistence.shutdown(/* deleteData= */ true);
+  });
+
+  let persistence: Persistence;
+  let queryCache: QueryCache;
+  let garbageCollector: LruGarbageCollector;
+  let initialSequenceNumber: ListenSequenceNumber;
+  let mutationQueue: MutationQueue;
+  let documentCache: RemoteDocumentCache;
+  async function newTestResources(): Promise<void> {
+    if (persistence && persistence.started) {
+      await persistence.shutdown(/* deleteData= */ true);
+    }
+    persistence = await newPersistence();
+    queryCache = persistence.getQueryCache();
+    mutationQueue = persistence.getMutationQueue(new User('user'));
+    documentCache = persistence.getRemoteDocumentCache();
+    initialSequenceNumber = await persistence.runTransaction(
+      'highest sequence number',
+      false,
+      txn => PersistencePromise.resolve(txn.currentSequenceNumber)
+    );
+    // TODO(gsoltis): remove cast
+    const referenceDelegate = (persistence as IndexedDbPersistence)
+      .referenceDelegate;
+    referenceDelegate.setInMemoryPins(new ReferenceSet());
+    garbageCollector = new LruGarbageCollector(
+      (referenceDelegate as any) as LruDelegate
+    );
+  }
+
+  function nextQueryData(sequenceNumber: ListenSequenceNumber): QueryData {
+    const targetId = ++previousTargetId;
+    return new QueryData(
+      Query.atPath(path('path' + targetId)),
+      targetId,
+      QueryPurpose.Listen,
+      sequenceNumber
+    );
+  }
+
+  function nextTestDocumentKey(): DocumentKey {
+    return DocumentKey.fromPathString('docs/doc_' + ++previousDocNum);
+  }
+
+  function addNextTargetInTransaction(
+    txn: PersistenceTransaction
+  ): PersistencePromise<QueryData> {
+    const queryData = nextQueryData(txn.currentSequenceNumber);
+    return queryCache.addQueryData(txn, queryData).next(() => queryData);
+  }
+
+  function addNextTarget(): Promise<QueryData> {
+    return persistence.runTransaction('add query', false, txn => {
+      return addNextTargetInTransaction(txn);
+    });
+  }
+
+  function updateTargetInTransaction(
+    txn: PersistenceTransaction,
+    queryData: QueryData
+  ): PersistencePromise<void> {
+    const updated = queryData.copy({
+      sequenceNumber: txn.currentSequenceNumber
+    });
+    return queryCache
+      .updateQueryData(txn, updated)
+      .next(() =>
+        queryCache.setTargetsMetadata(txn, txn.currentSequenceNumber)
+      );
+  }
+
+  function markDocumentEligibleForGCInTransaction(
+    txn: PersistenceTransaction,
+    key: DocumentKey
+  ): PersistencePromise<void> {
+    // TODO: change this once reference delegate is added to the persistence interface
+    return (persistence as IndexedDbPersistence).referenceDelegate.removeMutationReference(
+      txn,
+      key
+    );
+  }
+
+  function markDocumentEligibleForGC(key: DocumentKey): Promise<void> {
+    return persistence.runTransaction(
+      'mark document eligible for GC',
+      false,
+      txn => {
+        return markDocumentEligibleForGCInTransaction(txn, key);
+      }
+    );
+  }
+
+  function markADocumentEligibleForGCInTransaction(
+    txn: PersistenceTransaction
+  ): PersistencePromise<void> {
+    const key = nextTestDocumentKey();
+    return markDocumentEligibleForGCInTransaction(txn, key);
+  }
+
+  function markADocumentEligibleForGC(): Promise<void> {
+    const key = nextTestDocumentKey();
+    return markDocumentEligibleForGC(key);
+  }
+
+  function calculateTargetCount(percentile: number): Promise<number> {
+    return persistence.runTransaction('calculate target count', false, txn => {
+      return garbageCollector.calculateTargetCount(txn, percentile);
+    });
+  }
+
+  function nthSequenceNumber(n: number): Promise<ListenSequenceNumber> {
+    return persistence.runTransaction('nth sequence number', false, txn => {
+      return garbageCollector.nthSequenceNumber(txn, n);
+    });
+  }
+
+  function removeTargets(
+    upperBound: ListenSequenceNumber,
+    liveTargets: LiveTargets
+  ): Promise<number> {
+    return persistence.runTransaction('remove targets', false, txn => {
+      return garbageCollector.removeTargets(txn, upperBound, liveTargets);
+    });
+  }
+
+  function removeOrphanedDocuments(
+    upperBound: ListenSequenceNumber
+  ): Promise<number> {
+    return persistence.runTransaction(
+      'remove orphaned documents',
+      false,
+      txn => {
+        return garbageCollector.removeOrphanedDocuments(txn, upperBound);
+      }
+    );
+  }
+
+  function nextTestDocument(): Document {
+    const key = nextTestDocumentKey();
+    return new Document(
+      key,
+      SnapshotVersion.fromMicroseconds(1000),
+      wrapObject({ foo: 3, bar: false }),
+      {}
+    );
+  }
+
+  function cacheADocumentInTransaction(
+    txn: PersistenceTransaction
+  ): PersistencePromise<DocumentKey> {
+    const doc = nextTestDocument();
+    return documentCache.addEntries(txn, [doc]).next(() => doc.key);
+  }
+
+  function mutation(key: DocumentKey): Mutation {
+    return new SetMutation(
+      key,
+      wrapObject({ baz: 'hello', world: 2 }),
+      Precondition.NONE
+    );
+  }
+
+  it('pick sequence number percentile', async () => {
+    const testCases: Array<{ targets: number; expected: number }> = [
+      //{ targets: 0, expected: 0 },
+      { targets: 10, expected: 1 },
+      { targets: 9, expected: 0 },
+      { targets: 50, expected: 5 },
+      { targets: 49, expected: 4 }
+    ];
+
+    for (const { targets, expected } of testCases) {
+      await newTestResources();
+      for (let i = 0; i < targets; i++) {
+        await addNextTarget();
+      }
+      const tenth = await calculateTargetCount(10);
+      expect(tenth).to.equal(
+        expected,
+        'Expected 10% of ' + targets + ' to be ' + expected
+      );
+    }
+  });
+
+  it('sequence number for no targets', async () => {
+    expect(await nthSequenceNumber(0)).to.equal(ListenSequence.INVALID);
+  });
+
+  it('sequence number for 50 targets', async () => {
+    // Add 50 queries sequentially, aim to collect 10 of them.
+    // The sequence number to collect should be 10 past the initial sequence number.
+    for (let i = 0; i < 50; i++) {
+      await addNextTarget();
+    }
+    const expected = initialSequenceNumber + 10;
+    expect(await nthSequenceNumber(10)).to.equal(expected);
+  });
+
+  it('sequence number for multiple targets in a transaction', async () => {
+    // 50 queries, 9 with one transaction, incrementing from there. Should get second sequence
+    // number.
+    await persistence.runTransaction('9 targets in a batch', false, txn => {
+      let p = PersistencePromise.resolve();
+      for (let i = 0; i < 9; i++) {
+        p = p.next(() => addNextTargetInTransaction(txn)).next();
+      }
+      return p;
+    });
+    for (let i = 9; i < 50; i++) {
+      await addNextTarget();
+    }
+    const expected = initialSequenceNumber + 2;
+    expect(await nthSequenceNumber(10)).to.equal(expected);
+  });
+
+  it('all collected targets in a single transaction', async () => {
+    await persistence.runTransaction('11 targets in a batch', false, txn => {
+      let p = PersistencePromise.resolve();
+      for (let i = 0; i < 11; i++) {
+        p = p.next(() => addNextTargetInTransaction(txn)).next();
+      }
+      return p;
+    });
+    for (let i = 11; i < 50; i++) {
+      await addNextTarget();
+    }
+    const expected = initialSequenceNumber + 1;
+    expect(await nthSequenceNumber(10)).to.equal(expected);
+  });
+
+  it('sequence number with mutation and sequential targets', async () => {
+    // Remove a mutated doc reference, marking it as eligible for GC.
+    // Then add 50 queries. Should get 10 past initial (9 queries).
+    await markADocumentEligibleForGC();
+    for (let i = 0; i < 50; i++) {
+      await addNextTarget();
+    }
+
+    const expected = initialSequenceNumber + 10;
+    expect(await nthSequenceNumber(10)).to.equal(expected);
+  });
+
+  it('sequence numbers with mutations in targets', async () => {
+    // Add mutated docs, then add one of them to a query target so it doesn't get GC'd.
+    // Expect 3 past the initial value: the mutations not part of a query, and two queries
+    const docInTarget = nextTestDocumentKey();
+    await persistence.runTransaction('mark mutations', false, txn => {
+      // Adding 9 doc keys in a transaction. If we remove one of them, we'll have room for two
+      // actual targets.
+      let p = markDocumentEligibleForGCInTransaction(txn, docInTarget);
+      for (let i = 0; i < 8; i++) {
+        p = p.next(() => markADocumentEligibleForGCInTransaction(txn));
+      }
+      return p;
+    });
+
+    for (let i = 0; i < 49; i++) {
+      await addNextTarget();
+    }
+    await persistence.runTransaction('target with a mutation', false, txn => {
+      return addNextTargetInTransaction(txn).next(queryData => {
+        const keySet = documentKeySet().add(docInTarget);
+        return queryCache.addMatchingKeys(txn, keySet, queryData.targetId);
+      });
+    });
+    const expected = initialSequenceNumber + 3;
+    expect(await nthSequenceNumber(10)).to.equal(expected);
+  });
+
+  it('remove targets up through sequence number', async () => {
+    const liveTargets: LiveTargets = {};
+    for (let i = 0; i < 100; i++) {
+      const queryData = await addNextTarget();
+      // Mark odd queries as live so we can test filtering out live queries.
+      const targetId = queryData.targetId;
+      if (targetId % 2 === 1) {
+        liveTargets[targetId] = queryData;
+      }
+    }
+
+    // GC up through 20th query, which is 20%.
+    // Expect to have GC'd 10 targets, since every other target is live
+    const upperBound = 20 + initialSequenceNumber;
+    const removed = await removeTargets(upperBound, liveTargets);
+    expect(removed).to.equal(10);
+    // Make sure we removed the even targets with targetID <= 20.
+    await persistence.runTransaction(
+      'verify remaining targets > 20 or odd',
+      false,
+      txn => {
+        // TODO: change this once forEachTarget is added to QueryCache interface
+        return (queryCache as IndexedDbQueryCache).forEachTarget(
+          txn,
+          queryData => {
+            const targetId = queryData.targetId;
+            expect(targetId > 20 || targetId % 2 === 1).to.be.true;
+          }
+        );
+      }
+    );
+  });
+
+  it('remove orphaned documents', async () => {
+    // Track documents we expect to be retained so we can verify post-GC.
+    // This will contain documents associated with targets that survive GC, as well
+    // as any documents with pending mutations.
+    const expectedRetained = new Set<DocumentKey>();
+    // we add two mutations later, for now track them in an array.
+    const mutations: Mutation[] = [];
+
+    // Add two documents to first target, queue a mutation on the second document
+    await persistence.runTransaction(
+      'add a target and add two documents to it',
+      false,
+      txn => {
+        return addNextTargetInTransaction(txn).next(queryData => {
+          let keySet = documentKeySet();
+          return cacheADocumentInTransaction(txn)
+            .next(docKey1 => {
+              expectedRetained.add(docKey1);
+              keySet = keySet.add(docKey1);
+            })
+            .next(() => cacheADocumentInTransaction(txn))
+            .next(docKey2 => {
+              expectedRetained.add(docKey2);
+              keySet = keySet.add(docKey2);
+              mutations.push(mutation(docKey2));
+            })
+            .next(() =>
+              queryCache.addMatchingKeys(txn, keySet, queryData.targetId)
+            );
+        });
+      }
+    );
+
+    // Add a second query and register a third document on it
+    await persistence.runTransaction('second target', false, txn => {
+      return addNextTargetInTransaction(txn).next(queryData => {
+        return cacheADocumentInTransaction(txn).next(docKey3 => {
+          expectedRetained.add(docKey3);
+          const keySet = documentKeySet().add(docKey3);
+          return queryCache.addMatchingKeys(txn, keySet, queryData.targetId);
+        });
+      });
+    });
+
+    // cache another document and prepare a mutation on it.
+    await persistence.runTransaction('queue a mutation', false, txn => {
+      return cacheADocumentInTransaction(txn).next(docKey4 => {
+        mutations.push(mutation(docKey4));
+        expectedRetained.add(docKey4);
+      });
+    });
+
+    // Insert the mutations. These operations don't have a sequence number, they just
+    // serve to keep the mutated documents from being GC'd while the mutations are outstanding.
+    await persistence.runTransaction(
+      'actually register the mutations',
+      false,
+      txn => {
+        return mutationQueue.addMutationBatch(
+          txn,
+          Timestamp.fromMillis(2000),
+          mutations
+        );
+      }
+    );
+
+    // Mark 5 documents eligible for GC. This simulates documents that were mutated then ack'd.
+    // Since they were ack'd, they are no longer in a mutation queue, and there is nothing keeping
+    // them alive.
+    const toBeRemoved = new Set<DocumentKey>();
+    await persistence.runTransaction(
+      "add orphaned docs (previously mutated, then ack'd",
+      false,
+      txn => {
+        let p = PersistencePromise.resolve();
+        for (let i = 0; i < 5; i++) {
+          p = p.next(() => {
+            return cacheADocumentInTransaction(txn).next(docKey => {
+              toBeRemoved.add(docKey);
+              return markDocumentEligibleForGCInTransaction(txn, docKey);
+            });
+          });
+        }
+        return p;
+      }
+    );
+
+    // We expect only the orphaned documents, those not in a mutation or a target, to be removed.
+    // use a large sequence number to remove as much as possible
+    const removed = await removeOrphanedDocuments(1000);
+    expect(removed).to.equal(toBeRemoved.size);
+    await persistence.runTransaction('verify', false, txn => {
+      let p = PersistencePromise.resolve();
+      toBeRemoved.forEach(docKey => {
+        p = p.next(() => {
+          return documentCache.getEntry(txn, docKey).next(maybeDoc => {
+            expect(maybeDoc).to.be.null;
+          });
+        });
+      });
+      expectedRetained.forEach(docKey => {
+        p = p.next(() => {
+          return documentCache.getEntry(txn, docKey).next(maybeDoc => {
+            expect(maybeDoc).to.not.be.null;
+          });
+        });
+      });
+      return p;
+    });
+  });
+
+  it('remove targets then GC', async () => {
+    // Create 3 targets, add docs to all of them
+    // Leave oldest target alone, it is still live
+    // Remove newest target
+    // Blind write 2 documents
+    // Add one of the blind write docs to oldest target (preserves it)
+    // Remove some documents from middle target (bumps sequence number)
+    // Add some documents from newest target to oldest target (preserves them)
+    // Update a doc from middle target
+    // Remove middle target
+    // Do a blind write
+    // GC up to but not including the removal of the middle target
+    //
+    // Expect:
+    // All docs in oldest target are still around
+    // One blind write is gone, the first one not added to oldest target
+    // Documents removed from middle target are gone, except ones added to oldest target
+    // Documents from newest target are gone, except
+
+    // Through the various steps, track which documents we expect to be removed vs
+    // documents we expect to be retained.
+    const expectedRetained = new Set<DocumentKey>();
+    const expectedRemoved = new Set<DocumentKey>();
+
+    // Add oldest target, 5 documents, and add those documents to the target.
+    // This target will not be removed, so all documents that are part of it will
+    // be retained.
+    const oldestTarget = await persistence.runTransaction(
+      'Add oldest target and docs',
+      false,
+      txn => {
+        return addNextTargetInTransaction(txn).next(queryData => {
+          let p = PersistencePromise.resolve();
+          let keySet = documentKeySet();
+          for (let i = 0; i < 5; i++) {
+            p = p.next(() => {
+              return cacheADocumentInTransaction(txn).next(docKey => {
+                expectedRetained.add(docKey);
+                keySet = keySet.add(docKey);
+              });
+            });
+          }
+          return p
+            .next(() =>
+              queryCache.addMatchingKeys(txn, keySet, queryData.targetId)
+            )
+            .next(() => queryData);
+        });
+      }
+    );
+
+    // Add middle target and docs. Some docs will be removed from this target later,
+    // which we track here.
+    let middleDocsToRemove = documentKeySet();
+    let middleDocToUpdate: DocumentKey;
+    // This will be the document in this target that gets an update later.
+    const middleTarget = await persistence.runTransaction(
+      'Add middle target and docs',
+      false,
+      txn => {
+        return addNextTargetInTransaction(txn).next(queryData => {
+          let p = PersistencePromise.resolve();
+          let keySet = documentKeySet();
+
+          // these docs will be removed from this target later, triggering a bump
+          // to their sequence numbers. Since they will not be a part of the target, we
+          // expect them to be removed.
+          for (let i = 0; i < 2; i++) {
+            p = p.next(() => {
+              return cacheADocumentInTransaction(txn).next(docKey => {
+                expectedRemoved.add(docKey);
+                keySet = keySet.add(docKey);
+                middleDocsToRemove = middleDocsToRemove.add(docKey);
+              });
+            });
+          }
+
+          // these docs stay in this target and only this target. There presence in this
+          // target prevents them from being GC'd, so they are also expected to be retained.
+          for (let i = 2; i < 4; i++) {
+            p = p.next(() => {
+              return cacheADocumentInTransaction(txn).next(docKey => {
+                expectedRetained.add(docKey);
+                keySet = keySet.add(docKey);
+              });
+            });
+          }
+
+          // This doc stays in this target, but gets updated.
+          {
+            p = p.next(() => {
+              return cacheADocumentInTransaction(txn).next(docKey => {
+                expectedRetained.add(docKey);
+                keySet = keySet.add(docKey);
+                middleDocToUpdate = docKey;
+              });
+            });
+          }
+
+          return p
+            .next(() =>
+              queryCache.addMatchingKeys(txn, keySet, queryData.targetId)
+            )
+            .next(() => queryData);
+        });
+      }
+    );
+
+    // Add the newest target and add 5 documents to it. Some of those documents will
+    // additionally be added to the oldest target, which will cause those documents to
+    // be retained. The remaining documents are expected to be removed, since this target
+    // will be removed.
+    let newestDocsToAddToOldest = documentKeySet();
+    await persistence.runTransaction(
+      'Add newest target and docs',
+      false,
+      txn => {
+        return addNextTargetInTransaction(txn).next(queryData => {
+          let p = PersistencePromise.resolve();
+          let keySet = documentKeySet();
+          // These documents are only in this target. They are expected to be removed
+          // because this target will also be removed.
+          for (let i = 0; i < 3; i++) {
+            p = p.next(() => {
+              return cacheADocumentInTransaction(txn).next(docKey => {
+                expectedRemoved.add(docKey);
+                keySet = keySet.add(docKey);
+              });
+            });
+          }
+
+          // docs to add to the oldest target in addition to this target. They will be retained
+          for (let i = 3; i < 5; i++) {
+            p = p.next(() => {
+              return cacheADocumentInTransaction(txn).next(docKey => {
+                expectedRetained.add(docKey);
+                keySet = keySet.add(docKey);
+                newestDocsToAddToOldest = newestDocsToAddToOldest.add(docKey);
+              });
+            });
+          }
+
+          return p
+            .next(() =>
+              queryCache.addMatchingKeys(txn, keySet, queryData.targetId)
+            )
+            .next(() => queryData);
+        });
+      }
+    );
+
+    // 2 doc writes, add one of them to the oldest target.
+    await persistence.runTransaction(
+      '2 doc writes, add one of them to the oldest target',
+      false,
+      txn => {
+        let keySet = documentKeySet();
+        return cacheADocumentInTransaction(txn)
+          .next(docKey1 => {
+            keySet = keySet.add(docKey1);
+            expectedRetained.add(docKey1);
+            return markDocumentEligibleForGCInTransaction(txn, docKey1);
+          })
+          .next(() => {
+            return queryCache.addMatchingKeys(
+              txn,
+              keySet,
+              oldestTarget.targetId
+            );
+          })
+          .next(() => {
+            return updateTargetInTransaction(txn, oldestTarget);
+          })
+          .next(() => {
+            return cacheADocumentInTransaction(txn);
+          })
+          .next(docKey2 => {
+            expectedRemoved.add(docKey2);
+            return markDocumentEligibleForGCInTransaction(txn, docKey2);
+          });
+      }
+    );
+
+    // Remove some documents from the middle target.
+    await persistence.runTransaction(
+      'Remove some documents from the middle target',
+      false,
+      txn => {
+        return updateTargetInTransaction(txn, middleTarget).next(() =>
+          queryCache.removeMatchingKeys(
+            txn,
+            middleDocsToRemove,
+            middleTarget.targetId
+          )
+        );
+      }
+    );
+
+    // Add a couple docs from the newest target to the oldest (preserves them past the point where
+    // newest was removed)
+    // upperBound is the sequence number right before middleTarget is updated, then removed.
+    const upperBound = await persistence.runTransaction(
+      'Add a couple docs from the newest target to the oldest',
+      false,
+      txn => {
+        return updateTargetInTransaction(txn, oldestTarget)
+          .next(() => {
+            return queryCache.addMatchingKeys(
+              txn,
+              newestDocsToAddToOldest,
+              oldestTarget.targetId
+            );
+          })
+          .next(() => txn.currentSequenceNumber);
+      }
+    );
+
+    // Update a doc in the middle target
+    await persistence.runTransaction(
+      'Update a doc in the middle target',
+      false,
+      txn => {
+        const doc = new Document(
+          middleDocToUpdate,
+          SnapshotVersion.fromMicroseconds(2000),
+          wrapObject({ foo: 4, bar: true }),
+          {}
+        );
+        return documentCache.addEntries(txn, [doc]).next(() => {
+          return updateTargetInTransaction(txn, middleTarget);
+        });
+      }
+    );
+
+    // Remove the middle target
+    await persistence.runTransaction('remove middle target', false, txn => {
+      // TODO(gsoltis): fix this cast
+      return (persistence as IndexedDbPersistence).referenceDelegate.removeTarget(
+        txn,
+        middleTarget
+      );
+    });
+
+    // Write a doc and get an ack, not part of a target
+    await persistence.runTransaction(
+      'Write a doc and get an ack, not part of a target',
+      false,
+      txn => {
+        return cacheADocumentInTransaction(txn).next(docKey => {
+          // This should be retained, it's too new to get removed.
+          expectedRetained.add(docKey);
+          // Mark it as eligible for GC, but this is after our upper bound for what we will collect.
+          return markDocumentEligibleForGCInTransaction(txn, docKey);
+        });
+      }
+    );
+
+    // Finally, do the garbage collection, up to but not including the removal of middleTarget
+    const liveTargets: LiveTargets = {};
+    liveTargets[oldestTarget.targetId] = {};
+
+    // Expect to remove newest target
+    const removed = await removeTargets(upperBound, liveTargets);
+    expect(removed).to.equal(1);
+    const docsRemoved = await removeOrphanedDocuments(upperBound);
+    expect(docsRemoved).to.equal(expectedRemoved.size);
+    await persistence.runTransaction('verify results', false, txn => {
+      let p = PersistencePromise.resolve();
+      expectedRemoved.forEach(key => {
+        p = p.next(() => documentCache.getEntry(txn, key)).next(maybeDoc => {
+          expect(maybeDoc).to.be.null;
+        });
+      });
+      expectedRetained.forEach(key => {
+        p = p.next(() => documentCache.getEntry(txn, key)).next(maybeDoc => {
+          expect(maybeDoc).to.not.be.null;
+        });
+      });
+      return p;
+    });
+  });
+}

--- a/packages/firestore/test/unit/local/lru_garbage_collector.test.ts
+++ b/packages/firestore/test/unit/local/lru_garbage_collector.test.ts
@@ -62,12 +62,16 @@ describe('IndexedDbLruReferenceDelegate', () => {
 function genericLruGarbageCollectorTests(
   newPersistence: () => Promise<Persistence>
 ): void {
+  // We need to initialize a few counters so that we can use them when we
+  // auto-generate things like targets and documents. Pick arbitrary values
+  // such that sequences are unlikely to overlap as we increment them.
   let previousTargetId: TargetId;
   let previousDocNum: number;
+
   beforeEach(async () => {
     previousTargetId = 500;
     previousDocNum = 10;
-    await newTestResources();
+    await initializeTestResources();
   });
 
   afterEach(async () => {
@@ -80,7 +84,8 @@ function genericLruGarbageCollectorTests(
   let initialSequenceNumber: ListenSequenceNumber;
   let mutationQueue: MutationQueue;
   let documentCache: RemoteDocumentCache;
-  async function newTestResources(): Promise<void> {
+
+  async function initializeTestResources(): Promise<void> {
     if (persistence && persistence.started) {
       await persistence.shutdown(/* deleteData= */ true);
     }
@@ -145,7 +150,7 @@ function genericLruGarbageCollectorTests(
     txn: PersistenceTransaction,
     key: DocumentKey
   ): PersistencePromise<void> {
-    // TODO: change this once reference delegate is added to the persistence interface
+    // TODO(gsoltis): change this once reference delegate is added to the persistence interface
     return (persistence as IndexedDbPersistence).referenceDelegate.removeMutationReference(
       txn,
       key
@@ -250,7 +255,7 @@ function genericLruGarbageCollectorTests(
     ];
 
     for (const { targets, expected } of testCases) {
-      await newTestResources();
+      await initializeTestResources();
       for (let i = 0; i < targets; i++) {
         await addNextTarget();
       }

--- a/packages/firestore/test/unit/local/lru_garbage_collector.test.ts
+++ b/packages/firestore/test/unit/local/lru_garbage_collector.test.ts
@@ -98,10 +98,7 @@ function genericLruGarbageCollectorTests(
     const referenceDelegate = (persistence as IndexedDbPersistence)
       .referenceDelegate;
     referenceDelegate.setInMemoryPins(new ReferenceSet());
-    garbageCollector = new LruGarbageCollector(
-      // tslint:disable-next-line:no-any
-      (referenceDelegate as any) as LruDelegate
-    );
+    garbageCollector = referenceDelegate.garbageCollector;
   }
 
   function nextQueryData(sequenceNumber: ListenSequenceNumber): QueryData {

--- a/packages/util/src/jwt.ts
+++ b/packages/util/src/jwt.ts
@@ -106,8 +106,7 @@ export const issuedAtTime = function(token) {
 };
 
 /**
- * Decodes a Firebase auth. token and checks the validity of its format. Expects a valid issued-at time and non-empty
- * signature.
+ * Decodes a Firebase auth. token and checks the validity of its format. Expects a valid issued-at time.
  *
  * Notes:
  * - May return a false negative if there's no native base64 decoding support.
@@ -120,12 +119,7 @@ export const isValidFormat = function(token) {
   var decoded = decode(token),
     claims = decoded.claims;
 
-  return (
-    !!decoded.signature &&
-    !!claims &&
-    typeof claims === 'object' &&
-    claims.hasOwnProperty('iat')
-  );
+  return !!claims && typeof claims === 'object' && claims.hasOwnProperty('iat');
 };
 
 /**


### PR DESCRIPTION
Adds:
 * `LruGarbageCollector` which implements the steps for LRU garbage collection
   * Includes a selective port of `java.util.PriorityQueue`
 * `LruDelegate` interface, which specifies what is needed for a persistence layer for LRU GC
 * `ReferenceDelegate` interface, which handles lifecycle hooks for document references and unreferences
   * Note that this is not yet wired up in most production code, as there is currently only a single implementation
 * `IndexedDbLruDelegate`, implements `ReferenceDelegate` and `LruDelegate` for `IndexedDbPersistence`
 * The LRU test suite
   * This currently only runs against `IndexedDbPersistence`, and as such contains a few casts that will be removed once the generic interfaces support the needed methods.

Android Port: https://github.com/FirebasePrivate/firebase-android-sdk/pull/190
iOS Port: https://github.com/firebase/firebase-ios-sdk/pull/1600