### PR TITLE
wrap component with try catch outside of iife for old browser compati…

### DIFF
--- a/packages/firebase/rollup.config.js
+++ b/packages/firebase/rollup.config.js
@@ -117,8 +117,8 @@ const componentBuilds = components
           globals: {
             '@firebase/app': GLOBAL_NAME
           },
-          intro: `try  {`,
-          outro: `} catch(err) {
+          banner: `try  {`,
+          footer: `} catch(err) {
               console.error(err);
               throw new Error(
                 'Cannot instantiate firebase-${component} - ' +


### PR DESCRIPTION
This change is to make firebase bundles compatible with old safari browser implementation([Issue #931](https://github.com/firebase/firebase-js-sdk/issues/931)), where function declaration in the nested scope is not allowed. All major browsers has decided to not implement this feature nowadays.