### PR TITLE
Remove computeInitialDocChanges

### DIFF
--- a/packages/firestore/src/core/sync_engine.ts
+++ b/packages/firestore/src/core/sync_engine.ts
@@ -246,7 +246,7 @@ export class SyncEngine implements RemoteSyncer, SharedClientStateSyncer {
         .remoteDocumentKeys(queryData.targetId)
         .then(remoteKeys => {
           const view = new View(query, remoteKeys);
-          const viewDocChanges = view.computeInitialChanges(docs);
+          const viewDocChanges = view.computeDocChanges(docs);
           // tslint:disable-next-line:max-line-length Prettier formats this exceed 100 characters.
           const synthesizedTargetChange = TargetChange.createSynthesizedTargetChangeForCurrentChange(
             queryData.targetId,

--- a/packages/firestore/src/core/view.ts
+++ b/packages/firestore/src/core/view.ts
@@ -100,56 +100,6 @@ export class View {
   }
 
   /**
-   * Computes the initial set of document changes based on the provided
-   * documents.
-   *
-   * Unlike `computeDocChanges`, documents with committed mutations don't raise
-   * `hasPendingWrites`. This distinction allows us to only raise
-   * `hasPendingWrite` events for documents that changed during the lifetime of
-   * the View.
-   *
-   * @param docs The docs to apply to this view.
-   * @return A new set of docs, changes, and refill flag.
-   */
-  computeInitialChanges(docs: MaybeDocumentMap): ViewDocumentChanges {
-    assert(
-      this.documentSet.size === 0,
-      'computeInitialChanges called when docs are aleady present'
-    );
-
-    const changeSet = new DocumentChangeSet();
-    let newMutatedKeys = this.mutatedKeys;
-    let newDocumentSet = this.documentSet;
-
-    docs.inorderTraversal((key: DocumentKey, maybeDoc: MaybeDocument) => {
-      if (maybeDoc instanceof Document) {
-        if (this.query.matches(maybeDoc)) {
-          changeSet.track({ type: ChangeType.Added, doc: maybeDoc });
-          newDocumentSet = newDocumentSet.add(maybeDoc);
-          if (maybeDoc.hasLocalMutations) {
-            newMutatedKeys = newMutatedKeys.add(key);
-          }
-        }
-      }
-    });
-
-    if (this.query.hasLimit()) {
-      while (newDocumentSet.size > this.query.limit!) {
-        const oldDoc = newDocumentSet.last();
-        newDocumentSet = newDocumentSet.delete(oldDoc!.key);
-        newMutatedKeys = newMutatedKeys.delete(oldDoc!.key);
-        changeSet.track({ type: ChangeType.Removed, doc: oldDoc! });
-      }
-    }
-    return {
-      documentSet: newDocumentSet,
-      changeSet,
-      needsRefill: false,
-      mutatedKeys: newMutatedKeys
-    };
-  }
-
-  /**
    * Iterates over a set of doc changes, applies the query limit, and computes
    * what the new results should be, what the changes were, and whether we may
    * need to go back to the local cache for more results. Does not make any

--- a/packages/firestore/test/unit/core/event_manager.test.ts
+++ b/packages/firestore/test/unit/core/event_manager.test.ts
@@ -255,7 +255,7 @@ describe('QueryListener', () => {
     const eventListenable = queryListener(query, events);
 
     const view = new View(query, documentKeySet());
-    const changes = view.computeInitialChanges(documentUpdates(doc1));
+    const changes = view.computeDocChanges(documentUpdates(doc1));
     const snap1 = view.applyChanges(changes, true, ackTarget()).snapshot!;
 
     eventListenable.onViewSnapshot(snap1);
@@ -276,7 +276,7 @@ describe('QueryListener', () => {
     const eventListenable = queryListener(query, events);
 
     const view = new View(query, documentKeySet());
-    const changes = view.computeInitialChanges(documentUpdates(doc1));
+    const changes = view.computeDocChanges(documentUpdates(doc1));
     const snap1 = view.applyChanges(changes, true, ackTarget()).snapshot!;
 
     eventListenable.onViewSnapshot(snap1);


### PR DESCRIPTION
During the Android port I noticed that all the special handling of View.computeInitialDocChanges was also done by View.computeDocChanges.

This code snippet:
```
const newDocHasPendingMutations = newDoc
          ? newDoc.hasLocalMutations ||
            // We only consider committed mutations for documents that were
            // mutated during the lifetime of the view.
            (this.mutatedKeys.has(newDoc.key) && newDoc.hasCommittedMutations)
          : false;
```

simplifies to: `newDoc.hasLocalMutations` since `mutatedKeys` is empty to start with. `newDoc.hasLocalMutations` happens to be the line we rely on in `computeInitialDocChanges`.