### PR TITLE
support es6 module in webchannel-wrapper

### DIFF
--- a/packages/webchannel-wrapper/package.json
+++ b/packages/webchannel-wrapper/package.json
@@ -4,6 +4,7 @@
   "description": "A wrapper of the webchannel packages from closure-library for use outside of a closure compiled application",
   "author": "Firebase <firebase-support@google.com> (https://firebase.google.com/)",
   "main": "dist/index.js",
+  "module": "dist/index.esm.js",
   "files": [
     "dist"
   ],
@@ -15,6 +16,9 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "closure-builder": "2.3.0",
+    "rollup": "0.57.1",
+    "rollup-plugin-commonjs": "9.1.0",
+    "rollup-plugin-hypothetical": "2.1.0",
     "watch": "1.0.2"
   },
   "repository": {

--- a/packages/webchannel-wrapper/tools/build.js
+++ b/packages/webchannel-wrapper/tools/build.js
@@ -50,7 +50,8 @@ closureBuilder.build(
         compilation_level: 'ADVANCED'
       }
     }
-  }, async function (errors, warnings, files, results) {
+  },
+  async function(errors, warnings, files, results) {
     const filePath = resolve(__dirname, '../src/index.js');
     const inputOptions = {
       input: filePath,

--- a/packages/webchannel-wrapper/tools/build.js
+++ b/packages/webchannel-wrapper/tools/build.js
@@ -15,9 +15,14 @@
  */
 
 const closureBuilder = require('closure-builder');
+const rollup = require('rollup');
+const commonjs = require('rollup-plugin-commonjs');
+const hypothetical = require('rollup-plugin-hypothetical');
+
 const glob = closureBuilder.globSupport();
 const { resolve } = require('path');
 
+// commonjs build
 closureBuilder.build({
   name: 'firebase.webchannel.wrapper',
   srcs: glob([resolve(__dirname, '../src/**/*.js')]),
@@ -28,7 +33,43 @@ closureBuilder.build({
       output_wrapper:
         "(function() {%output%}).call(typeof global !== 'undefined' ? global : typeof self !== 'undefined' ? self : typeof window !== 'undefined' ? window : {})",
       language_out: 'ECMASCRIPT5',
-      compilation_level: 'ADVANCED_OPTIMIZATIONS'
+      compilation_level: 'ADVANCED'
     }
   }
 });
+
+// esm build
+closureBuilder.build(
+  {
+    name: 'firebase.webchannel.wrapper',
+    srcs: glob([resolve(__dirname, '../src/**/*.js')]),
+    externs: [resolve(__dirname, '../externs/overrides.js')],
+    options: {
+      closure: {
+        language_out: 'ECMASCRIPT5',
+        compilation_level: 'ADVANCED'
+      }
+    }
+  }, async function (errors, warnings, files, results) {
+    const filePath = resolve(__dirname, '../src/index.js');
+    const inputOptions = {
+      input: filePath,
+      plugins: [
+        commonjs(),
+        hypothetical({
+          files: {
+            [filePath]: results // use the compiled code from memory
+          }
+        })
+      ]
+    };
+
+    const outputOptions = {
+      file: 'dist/index.esm.js',
+      format: 'es'
+    };
+
+    const bundle = await rollup.rollup(inputOptions);
+    return bundle.write(outputOptions);
+  }
+);

--- a/yarn.lock
+++ b/yarn.lock
@@ -9131,6 +9131,10 @@ rollup-plugin-copy-assets@1.0.0:
   dependencies:
     fs-extra "^5.0.0"
 
+rollup-plugin-hypothetical@2.1.0:
+  version "2.1.0"
+  resolved "https://registry.npmjs.org/rollup-plugin-hypothetical/-/rollup-plugin-hypothetical-2.1.0.tgz#7fec9a865ed7d0eac14ca6ee2b2c4088acdb1955"
+
 rollup-plugin-node-resolve@3.3.0:
   version "3.3.0"
   resolved "https://registry.npmjs.org/rollup-plugin-node-resolve/-/rollup-plugin-node-resolve-3.3.0.tgz#c26d110a36812cbefa7ce117cadcd3439aa1c713"


### PR DESCRIPTION
Added a build step to produce bundle in es6 module format.
@mikelehen the output file looks fine to me (it has all the expected exports in es6 format) and I tested it against the repo mentioned in https://github.com/firebase/firebase-js-sdk/issues/1031 and it works fine (just did firebase.firestore()). I don't know if the test is sufficient. If not, can you please let me know what else I should do? thanks!