### PR TITLE
[rxfire] Reference realtime database typings

### DIFF
--- a/packages/rxfire/database/package.json
+++ b/packages/rxfire/database/package.json
@@ -1,5 +1,6 @@
 {
   "name": "rxfire/database",
   "main": "dist/index.cjs.js",
-  "module": "dist/index.esm.js"
+  "module": "dist/index.esm.js",
+  "typings": "dist/database/index.d.ts"
 }


### PR DESCRIPTION
Realtime database typings exist for rxfire but the package.json file does not reference them and vscode can't find them. This change adds the missing reference, matching auth/, firestore/, and storage/.

Hey there! So you want to contribute to a Firebase SDK? 
Before you file this pull request, please read these guidelines:

### Discussion

  * Read the contribution guidelines (CONTRIBUTING.md).
  * If this has been discussed in an issue, make sure to link to the issue here. 
    If not, go file an issue about this **before creating a pull request** to discuss.

### Testing

  * Make sure all existing tests in the repository pass after your change.
  * If you fixed a bug or added a feature, add a new test to cover your code.

### API Changes

  * At this time we cannot accept changes that affect the public API.  If you'd like to help 
    us make Firebase APIs better, please propose your change in an issue so that we 
    can discuss it together.
