### PR TITLE
TypeScript support for useFunctionsEmulator

### DIFF
--- a/packages/firebase/index.d.ts
+++ b/packages/firebase/index.d.ts
@@ -145,6 +145,7 @@ declare namespace firebase.functions {
   }
   export class Functions {
     private constructor();
+    useFunctionsEmulator(url: string): void;
     httpsCallable(name: string): HttpsCallable;
   }
   export type ErrorStatus =


### PR DESCRIPTION
According to this [comment](https://github.com/firebase/firebase-js-sdk/issues/941#issuecomment-401432710) this is now supported in the library. 

This tiny PR makes it available for TypeScript users without `d.ts` hacks.