### PR TITLE
Allow iterables in PersistencePromise.map/forEach/waitFor

### DIFF
--- a/packages/firestore/src/core/sync_engine.ts
+++ b/packages/firestore/src/core/sync_engine.ts
@@ -684,7 +684,7 @@ export class SyncEngine implements RemoteSyncer, SharedClientStateSyncer {
         queryView.targetId
       );
       this.limboDocumentRefs.removeReferencesForId(queryView.targetId);
-      await PersistencePromise.forEach(limboKeys.toArray(), limboKey => {
+      await PersistencePromise.forEach(limboKeys, limboKey => {
         return this.limboDocumentRefs
           .containsKey(null, limboKey)
           .next(isReferenced => {

--- a/packages/firestore/src/util/sorted_map.ts
+++ b/packages/firestore/src/util/sorted_map.ts
@@ -168,6 +168,21 @@ export class SortedMap<K, V> {
   getReverseIteratorFrom(key: K): SortedMapIterator<K, V> {
     return new SortedMapIterator<K, V>(this.root, key, this.comparator, true);
   }
+
+  [Symbol.iterator](): Iterator<Entry<K, V>> {
+    const it = this.getIterator();
+    return {
+      next(): IteratorResult<Entry<K, V>> {
+        if (it.hasNext()) {
+          return { done: false, value: it.getNext() };
+        } else {
+          // The TypeScript typings don't allow `undefined` for Iterator<T>,
+          // so we return an empty object instead.
+          return { done: true, value: {} as Entry<K, V> };
+        }
+      }
+    };
+  }
 } // end SortedMap
 
 // An iterator over an LLRBNode.

--- a/packages/firestore/src/util/sorted_set.ts
+++ b/packages/firestore/src/util/sorted_set.ts
@@ -154,6 +154,21 @@ export class SortedSet<T> {
     return 'SortedSet(' + result.toString() + ')';
   }
 
+  [Symbol.iterator](): Iterator<T> {
+    const it = this.data.getIterator();
+    return {
+      next(): IteratorResult<T> {
+        if (it.hasNext()) {
+          return { done: false, value: it.getNext().key };
+        } else {
+          // The TypeScript typings don't allow `undefined` for Iterator<T>,
+          // so we return an empty object instead.
+          return { done: true, value: {} as T };
+        }
+      }
+    };
+  }
+
   private copy(data: SortedMap<T, boolean>): SortedSet<T> {
     const result = new SortedSet(this.comparator);
     result.data = data;


### PR DESCRIPTION
Revived this PR since https://github.com/firebase/firebase-js-sdk/pull/1256 could benefit from it.

This allows us to use SortedSet and SortedMap in the PersistencePromise utilities.