### PR TITLE
Fix map()

### DIFF
--- a/packages/firestore/src/local/persistence_promise.ts
+++ b/packages/firestore/src/local/persistence_promise.ts
@@ -224,7 +224,7 @@ export class PersistencePromise<T> {
 
   static forEach<T>(
     all: Iterable<T>,
-    callback: (elem:T) => PersistencePromise<void>
+    callback: (elem: T) => PersistencePromise<void>
   ): PersistencePromise<void> {
     const it = all[Symbol.iterator]();
 

--- a/packages/firestore/src/local/persistence_promise.ts
+++ b/packages/firestore/src/local/persistence_promise.ts
@@ -224,7 +224,7 @@ export class PersistencePromise<T> {
 
   static forEach<T>(
     all: Iterable<T>,
-    callback: (T) => PersistencePromise<void>
+    callback: (elem:T) => PersistencePromise<void>
   ): PersistencePromise<void> {
     const it = all[Symbol.iterator]();
 

--- a/packages/firestore/test/unit/local/indexeddb_persistence.test.ts
+++ b/packages/firestore/test/unit/local/indexeddb_persistence.test.ts
@@ -416,7 +416,7 @@ describe('IndexedDbSchema: createOrUpgradeDb', () => {
             return PersistencePromise.forEach(testMutation.mutations, write => {
               const indexKey = DbDocumentMutation.key(
                 testMutation.userId,
-                path(write.update.name, 5),
+                path(write.update!.name!, 5),
                 testMutation.batchId
               );
               return documentMutationStore.put(

--- a/packages/firestore/test/unit/local/persistence_promise.test.ts
+++ b/packages/firestore/test/unit/local/persistence_promise.test.ts
@@ -16,6 +16,12 @@
 
 import { expect } from 'chai';
 import { PersistencePromise } from '../../../src/local/persistence_promise';
+import { Deferred } from '../../../src/util/promise';
+
+import * as chai from 'chai';
+import * as chaiAsPromised from 'chai-as-promised';
+
+chai.use(chaiAsPromised);
 
 describe('PersistencePromise', () => {
   function async<R>(value: R): PersistencePromise<R> {
@@ -214,6 +220,17 @@ describe('PersistencePromise', () => {
       .toPromise();
   });
 
+  it('propagates error for waitFor()', () => {
+    const resolved = PersistencePromise.resolve('resolved');
+    const rejected: PersistencePromise<string> = PersistencePromise.reject(
+      new Error('rejected')
+    );
+
+    const p = PersistencePromise.waitFor([resolved, rejected]).toPromise();
+
+    return expect(p).to.be.eventually.rejectedWith('rejected');
+  });
+
   it('executes forEach in order', async () => {
     let result = '';
     await PersistencePromise.forEach(['a', 'b', 'c'], el => {
@@ -221,5 +238,48 @@ describe('PersistencePromise', () => {
       return PersistencePromise.resolve();
     }).toPromise();
     expect(result).to.equal('abc');
+  });
+
+  it('propagates error for forEach()', () => {
+    const p = PersistencePromise.forEach([true, false], success => {
+      if (success) {
+        return PersistencePromise.resolve();
+      } else {
+        return PersistencePromise.reject(new Error('rejected'));
+      }
+    }).toPromise();
+
+    return expect(p).to.be.eventually.rejectedWith('rejected');
+  });
+
+  it('maintains order for map()', async () => {
+    const deferred = new Deferred<void>();
+
+    const pending = new PersistencePromise<string>(resolve => {
+      return deferred.promise.then(() => resolve('first'));
+    });
+    const resolved = PersistencePromise.resolve('second');
+
+    const p = PersistencePromise.map([pending, resolved]).next(results => {
+      expect(results).to.deep.eq(['first', 'second']);
+      return PersistencePromise.resolve();
+    });
+
+    setImmediate(() => {
+      deferred.resolve();
+    });
+
+    await p.toPromise();
+  });
+
+  it('propagates error for map()', () => {
+    const resolved = PersistencePromise.resolve('resolved');
+    const rejected: PersistencePromise<string> = PersistencePromise.reject(
+      new Error('rejected')
+    );
+
+    const p = PersistencePromise.map([resolved, rejected]).toPromise();
+
+    return expect(p).to.be.eventually.rejectedWith('rejected');
   });
 });

--- a/packages/firestore/test/unit/local/persistence_promise.test.ts
+++ b/packages/firestore/test/unit/local/persistence_promise.test.ts
@@ -279,7 +279,6 @@ describe('PersistencePromise', () => {
     );
 
     const p = PersistencePromise.map([resolved, rejected]).toPromise();
-
     return expect(p).to.be.eventually.rejectedWith('rejected');
   });
 });

--- a/packages/firestore/test/unit/local/simple_db.test.ts
+++ b/packages/firestore/test/unit/local/simple_db.test.ts
@@ -488,7 +488,7 @@ describe('SimpleDb', () => {
         for (let i = 0; i < 1000; ++i) {
           promises.push(store.get(i));
         }
-        return PersistencePromise.map(promises).next(() => {
+        return PersistencePromise.waitFor(promises).next(() => {
           const end = new Date().getTime();
           // tslint:disable-next-line:no-console
           console.log(`Reading: ${end - start} ms`);


### PR DESCRIPTION
Turns out that using foreach() for map() doesn't quite work. These two functions do very different things:

- Map takes the result of persistence promises and converts them to an array.
- forEach takes a list of values and "converts" them to a PersistencePromise by passing them through a callback.

`map` is so far only used in a single test that doesn't look at the return values, and hence nothing broke. I changed that test to use `waitFor`.

Alternatively, we could also remove `map`, but it might come in handy and is not all that trivial to implement (as I have just shown).