### PR TITLE
print debug info in release cli

### DIFF
--- a/scripts/release/utils/git.js
+++ b/scripts/release/utils/git.js
@@ -75,5 +75,7 @@ exports.getCurrentSha = async () => {
 };
 
 exports.hasDiff = async () => {
-  return !!await git.diff();
+  const diff = await git.diff();
+  console.log(diff);
+  return !!diff;
 };


### PR DESCRIPTION
I have seen build issues in travis, which I can't reproduce locally. Adding more debug information, so it's easier to figure out why a build failed.