### PR TITLE
Using readWrite query mode for releaseQuery

### DIFF
--- a/packages/firestore/src/local/local_store.ts
+++ b/packages/firestore/src/local/local_store.ts
@@ -706,7 +706,7 @@ export class LocalStore {
    */
   // PORTING NOTE: `keepPersistedQueryData` is multi-tab only.
   releaseQuery(query: Query, keepPersistedQueryData: boolean): Promise<void> {
-    const mode = keepPersistedQueryData ? 'readonly' : 'readwrite-primary';
+    const mode = keepPersistedQueryData ? 'readwrite' : 'readwrite-primary';
     return this.persistence.runTransaction('Release query', mode, txn => {
       return this.queryCache
         .getQueryData(txn, query)


### PR DESCRIPTION
`releaseQuery` can end up calling `updateQueryData`, which writes to IndexedDb.

This is a stracktrace from a local test:

index.esm.js:145 Uncaught Error: FIRESTORE (5.5.2) INTERNAL ASSERTION FAILED: AsyncQueue is already failed: Error: Failed to execute 'put' on 'IDBObjectStore': The transaction is read-only.
    at e.put (index.esm.js:9779)
    at e.saveQueryData (index.esm.js:10034)
    at e.updateQueryData (index.esm.js:10014)
    at index.esm.js:12150
    at index.esm.js:7582
    at e.wrapUserFunction (index.esm.js:7568)
    at e.wrapSuccess (index.esm.js:7582)
    at e.r.nextCallback (index.esm.js:7552)