### PR TITLE
Don't use the escaped persistence keys when we write to Local Storage

### DIFF
--- a/packages/firestore/test/unit/local/persistence_test_helpers.ts
+++ b/packages/firestore/test/unit/local/persistence_test_helpers.ts
@@ -56,7 +56,7 @@ export const INDEXEDDB_TEST_DATABASE_ID = new DatabaseId('test-project');
 /** The DatabaseInfo used by most tests that access IndexedDb. */
 const INDEXEDDB_TEST_DATABASE_INFO = new DatabaseInfo(
   INDEXEDDB_TEST_DATABASE_ID,
-  'PersistenceTestHelpers',
+  '[PersistenceTestHelpers]',
   'host',
   /*ssl=*/ false
 );


### PR DESCRIPTION
I think this is the last regression that prevents multi-tab from working...  Broke with ac7f9ced0fd18088c17ed76470095f0dcde7a15d

When we write to LS, we should use the unescaped key. Only when we use the key in a RegExp does it need to be escaped. To catch this failure, I changed the test persistence key to include brackets.