### PR TITLE
Always update LocalStorage state

### DIFF
--- a/packages/firestore/src/local/shared_client_state.ts
+++ b/packages/firestore/src/local/shared_client_state.ts
@@ -262,7 +262,7 @@ export class MutationMetadata {
   toWebStorageJSON(): string {
     const batchMetadata: MutationMetadataSchema = {
       state: this.state,
-      updateTimeMs: Date.now()
+      updateTimeMs: Date.now() // Modify the existing value to trigger update.
     };
 
     if (this.error) {
@@ -352,7 +352,7 @@ export class QueryTargetMetadata {
   toWebStorageJSON(): string {
     const targetState: QueryTargetStateSchema = {
       state: this.state,
-      updateTimeMs: Date.now()
+      updateTimeMs: Date.now() // Modify the existing value to trigger update.
     };
 
     if (this.error) {
@@ -509,7 +509,7 @@ export class LocalClientState implements ClientState {
   toWebStorageJSON(): string {
     const data: ClientStateSchema = {
       activeTargetIds: this.activeTargetIds.toArray(),
-      updateTimeMs: Date.now()
+      updateTimeMs: Date.now() // Modify the existing value to trigger update.
     };
     return JSON.stringify(data);
   }

--- a/packages/firestore/src/local/shared_client_state.ts
+++ b/packages/firestore/src/local/shared_client_state.ts
@@ -190,6 +190,7 @@ export interface SharedClientState {
 interface MutationMetadataSchema {
   state: MutationBatchState;
   error?: { code: string; message: string }; // Only set when state === 'rejected'
+  updateTimeMs: number;
 }
 
 /**
@@ -260,7 +261,8 @@ export class MutationMetadata {
 
   toWebStorageJSON(): string {
     const batchMetadata: MutationMetadataSchema = {
-      state: this.state
+      state: this.state,
+      updateTimeMs: Date.now()
     };
 
     if (this.error) {
@@ -281,6 +283,7 @@ export class MutationMetadata {
 interface QueryTargetStateSchema {
   state: QueryTargetState;
   error?: { code: string; message: string }; // Only set when state === 'rejected'
+  updateTimeMs: number;
 }
 
 /**
@@ -348,7 +351,8 @@ export class QueryTargetMetadata {
 
   toWebStorageJSON(): string {
     const targetState: QueryTargetStateSchema = {
-      state: this.state
+      state: this.state,
+      updateTimeMs: Date.now()
     };
 
     if (this.error) {
@@ -369,6 +373,7 @@ export class QueryTargetMetadata {
  */
 interface ClientStateSchema {
   activeTargetIds: number[];
+  updateTimeMs: number;
 }
 
 /**
@@ -503,7 +508,8 @@ export class LocalClientState implements ClientState {
    */
   toWebStorageJSON(): string {
     const data: ClientStateSchema = {
-      activeTargetIds: this.activeTargetIds.toArray()
+      activeTargetIds: this.activeTargetIds.toArray(),
+      updateTimeMs: Date.now()
     };
     return JSON.stringify(data);
   }

--- a/packages/firestore/test/unit/local/web_storage_shared_client_state.test.ts
+++ b/packages/firestore/test/unit/local/web_storage_shared_client_state.test.ts
@@ -232,7 +232,10 @@ describe('WebStorageSharedClientState', () => {
       )!
     );
 
-    expect(Object.keys(actual)).to.have.members(['activeTargetIds']);
+    expect(Object.keys(actual)).to.have.members([
+      'activeTargetIds',
+      'updateTimeMs'
+    ]);
     expect(actual.activeTargetIds)
       .to.be.an('array')
       .and.have.members(activeTargetIds);
@@ -250,7 +253,7 @@ describe('WebStorageSharedClientState', () => {
 
       expect(actual.state).to.equal(mutationBatchState);
 
-      const expectedMembers = ['state'];
+      const expectedMembers = ['state', 'updateTimeMs'];
 
       if (mutationBatchState === 'rejected') {
         expectedMembers.push('error');
@@ -304,7 +307,7 @@ describe('WebStorageSharedClientState', () => {
         const actual = JSON.parse(webStorage.getItem(targetKey(targetId))!);
         expect(actual.state).to.equal(queryTargetState);
 
-        const expectedMembers = ['state'];
+        const expectedMembers = ['state', 'updateTimeMs'];
         if (queryTargetState === 'rejected') {
           expectedMembers.push('error');
           expect(actual.error.code).to.equal(err!.code);


### PR DESCRIPTION
During today's QA run, I wasn't able to reliably get LocalStorage updates when the entry we wrote didn't change. I would like to add back the `updateTimeMs`.