### PR TITLE
Stop iterating when we encounter an error

### DIFF
--- a/packages/firestore/src/local/simple_db.ts
+++ b/packages/firestore/src/local/simple_db.ts
@@ -516,7 +516,13 @@ export class SimpleDbStore<
         const controller = new IterationController(cursor);
         const userResult = fn(cursor.primaryKey, cursor.value, controller);
         if (userResult instanceof PersistencePromise) {
-          results.push(userResult);
+          const userPromise: PersistencePromise<void> = userResult.catch(
+            err => {
+              controller.done();
+              return PersistencePromise.reject(err);
+            }
+          );
+          results.push(userPromise);
         }
         if (controller.isDone) {
           resolve();

--- a/packages/firestore/test/unit/local/simple_db.test.ts
+++ b/packages/firestore/test/unit/local/simple_db.test.ts
@@ -28,6 +28,7 @@ import {
   SimpleDbStore,
   SimpleDbTransaction
 } from '../../../src/local/simple_db';
+import { fail } from '../../../src/util/assert';
 
 chai.use(chaiAsPromised);
 
@@ -313,6 +314,22 @@ describe('SimpleDb', () => {
         })
         .next(() => {
           expect(iterated).to.deep.equal(testData.filter(v => v.id % 2 === 0));
+        });
+    });
+  });
+
+  it('stops iteration after rejected promise', async () => {
+    return runTransaction(store => {
+      const iterated: User[] = [];
+      return store
+        .iterate((key, value) => {
+          iterated.push(value);
+          return PersistencePromise.reject(new Error('Expected error'));
+        })
+        .next(() => fail('Promise not rejected'))
+        .catch(err => {
+          expect(err.message).to.eq('Expected error');
+          expect(iterated).to.deep.equal([testData[0]]);
         });
     });
   });


### PR DESCRIPTION
Maybe we should stop iterating in SimpleDb after we encountered an error. Maybe.