### PR TITLE
Clear reference set when we lose our primary lease

### DIFF
--- a/packages/firestore/src/core/sync_engine.ts
+++ b/packages/firestore/src/core/sync_engine.ts
@@ -911,6 +911,7 @@ export class SyncEngine implements RemoteSyncer, SharedClientStateSyncer {
     objUtils.forEachNumber(this.limboResolutionsByTarget, targetId => {
       this.remoteStore.unlisten(targetId);
     });
+    this.limboDocumentRefs.removeAllReferences();
     this.limboResolutionsByTarget = [];
     this.limboTargetsByKey = new SortedMap<DocumentKey, TargetId>(
       DocumentKey.comparator


### PR DESCRIPTION
I believe that we handle the ReferenceSet correctly when we transition between Primary and Secondary in 99% of all cases. `synchronizeQueryViewsAndRaiseSnapshots` calls `releaseQuery` and `allocateQuery` for every active query, and as such, the reference set in LocalStore gets synced with disk.

We do however not clear the reference set for Limbo Documents. This PR changes this.

