### PR TITLE
use apply instead of call to invoke iife

### DIFF
--- a/packages/auth/gulpfile.js
+++ b/packages/auth/gulpfile.js
@@ -32,7 +32,7 @@ const CJS_WRAPPER_PREFIX =
     `(function() {var firebase = require('@firebase/app').default;`;
 const EMS_WRAPPER_PREFIX = `import firebase from '@firebase/app';(function() {`;
 const WRAPPER_SUFFIX =
-    `}).call(typeof global !== 'undefined' ? ` +
+    `}).apply(typeof global !== 'undefined' ? ` +
     `global : typeof self !== 'undefined' ? ` +
     `self : typeof window !== 'undefined' ? window : {});`;
 


### PR DESCRIPTION
The old babel preset env doesn't recognize iife invoked by call, and map this to undefined incorrectly. https://github.com/firebase/firebase-js-sdk/issues/1165

Though it is a babel issue, we have a quick easy fix to be tolerant with the issue by using apply instead.  