### PR TITLE
[Multi-Tab] Separate GC threshold from Primary Election threshold

### DIFF
--- a/packages/firestore/src/local/indexeddb_persistence.ts
+++ b/packages/firestore/src/local/indexeddb_persistence.ts
@@ -83,7 +83,7 @@ const MAX_CLIENT_AGE_MS = 30 * 60 * 1000; // 30 minutes
  * primary lease election. Clients that have not updated their client metadata
  * within 5 seconds are not eligible to receive a primary lease.
  */
-const PRIMARY_ELECTION_MAX_CLIENT_AGE_MS = 5000;
+const MAX_PRIMARY_ELIGIBLE_AGE_MS = 5000;
 
 /**
  * The interval at which clients will update their metadata, including
@@ -571,7 +571,7 @@ export class IndexedDbPersistence implements Persistence {
           currentPrimary !== null &&
           this.isWithinAge(
             currentPrimary.leaseTimestampMs,
-            PRIMARY_ELECTION_MAX_CLIENT_AGE_MS
+            MAX_PRIMARY_ELIGIBLE_AGE_MS
           ) &&
           !this.isClientZombied(currentPrimary.ownerId);
 
@@ -623,7 +623,7 @@ export class IndexedDbPersistence implements Persistence {
             // them is better suited to obtain the primary lease.
             const preferredCandidate = this.filterActiveClients(
               existingClients,
-              PRIMARY_ELECTION_MAX_CLIENT_AGE_MS
+              MAX_PRIMARY_ELIGIBLE_AGE_MS
             ).find(otherClient => {
               if (this.clientId !== otherClient.clientId) {
                 const otherClientHasBetterNetworkState =
@@ -825,7 +825,7 @@ export class IndexedDbPersistence implements Persistence {
         currentPrimary !== null &&
         this.isWithinAge(
           currentPrimary.leaseTimestampMs,
-          PRIMARY_ELECTION_MAX_CLIENT_AGE_MS
+          MAX_PRIMARY_ELIGIBLE_AGE_MS
         ) &&
         !this.isClientZombied(currentPrimary.ownerId);
 

--- a/packages/firestore/src/local/indexeddb_persistence.ts
+++ b/packages/firestore/src/local/indexeddb_persistence.ts
@@ -72,19 +72,19 @@ import { SimpleDb, SimpleDbStore, SimpleDbTransaction } from './simple_db';
 const LOG_TAG = 'IndexedDbPersistence';
 
 /**
- * Oldest acceptable age in milliseconds for client metadata read from
- * IndexedDB. Client metadata and primary leases that are older than 5 seconds
- * are ignored.
+ * Oldest acceptable age in milliseconds for client metadata before the client
+ * is considered inactive and its associated data (such as the remote document
+ * cache changelog) is garbage collected.
  */
-const CLIENT_METADATA_MAX_AGE_MS = 5000;
+const MAX_CLIENT_AGE_MS = 30 * 60 * 1000; // 30 minutes
 
 /**
- * Oldest acceptable age in milliseconds for client metadata before it and its
- * associated data (such as the remote document cache changelog) can be
- * garbage collected. Clients that exceed this threshold will not be able to
- * replay Watch events that occurred before this threshold.
+ * Oldest acceptable metadata age for clients that may participate in the
+ * primary lease election. Clients that have not updated their client metadata
+ * within 5 seconds are not eligible to receive a primary lease.
  */
-const CLIENT_STATE_GARBAGE_COLLECTION_THRESHOLD_MS = 30 * 60 * 1000; // 30 Minutes
+const PRIMARY_ELECTION_MAX_CLIENT_AGE_MS = 5000;
+
 
 /**
  * The interval at which clients will update their metadata, including
@@ -465,7 +465,7 @@ export class IndexedDbPersistence implements Persistence {
       this.isPrimary &&
       !this.isWithinAge(
         this.lastGarbageCollectionTime,
-        CLIENT_STATE_GARBAGE_COLLECTION_THRESHOLD_MS
+        MAX_CLIENT_AGE_MS
       )
     ) {
       this.lastGarbageCollectionTime = Date.now();
@@ -487,7 +487,7 @@ export class IndexedDbPersistence implements Persistence {
             .next(existingClients => {
               activeClients = this.filterActiveClients(
                 existingClients,
-                CLIENT_STATE_GARBAGE_COLLECTION_THRESHOLD_MS
+                MAX_CLIENT_AGE_MS
               );
               inactiveClients = existingClients.filter(
                 client => activeClients.indexOf(client) === -1
@@ -575,7 +575,7 @@ export class IndexedDbPersistence implements Persistence {
           currentPrimary !== null &&
           this.isWithinAge(
             currentPrimary.leaseTimestampMs,
-            CLIENT_METADATA_MAX_AGE_MS
+            PRIMARY_ELECTION_MAX_CLIENT_AGE_MS
           ) &&
           !this.isClientZombied(currentPrimary.ownerId);
 
@@ -627,7 +627,7 @@ export class IndexedDbPersistence implements Persistence {
             // them is better suited to obtain the primary lease.
             const preferredCandidate = this.filterActiveClients(
               existingClients,
-              CLIENT_METADATA_MAX_AGE_MS
+              PRIMARY_ELECTION_MAX_CLIENT_AGE_MS
             ).find(otherClient => {
               if (this.clientId !== otherClient.clientId) {
                 const otherClientHasBetterNetworkState =
@@ -715,7 +715,7 @@ export class IndexedDbPersistence implements Persistence {
         return clientMetadataStore(txn)
           .loadAll()
           .next(clients =>
-            this.filterActiveClients(clients, CLIENT_METADATA_MAX_AGE_MS).map(
+            this.filterActiveClients(clients, MAX_CLIENT_AGE_MS).map(
               clientMetadata => clientMetadata.clientId
             )
           );
@@ -829,7 +829,7 @@ export class IndexedDbPersistence implements Persistence {
         currentPrimary !== null &&
         this.isWithinAge(
           currentPrimary.leaseTimestampMs,
-          CLIENT_METADATA_MAX_AGE_MS
+          PRIMARY_ELECTION_MAX_CLIENT_AGE_MS
         ) &&
         !this.isClientZombied(currentPrimary.ownerId);
 

--- a/packages/firestore/src/local/indexeddb_persistence.ts
+++ b/packages/firestore/src/local/indexeddb_persistence.ts
@@ -85,7 +85,6 @@ const MAX_CLIENT_AGE_MS = 30 * 60 * 1000; // 30 minutes
  */
 const PRIMARY_ELECTION_MAX_CLIENT_AGE_MS = 5000;
 
-
 /**
  * The interval at which clients will update their metadata, including
  * refreshing their primary lease if held or potentially trying to acquire it if
@@ -463,10 +462,7 @@ export class IndexedDbPersistence implements Persistence {
   private async maybeGarbageCollectMultiClientState(): Promise<void> {
     if (
       this.isPrimary &&
-      !this.isWithinAge(
-        this.lastGarbageCollectionTime,
-        MAX_CLIENT_AGE_MS
-      )
+      !this.isWithinAge(this.lastGarbageCollectionTime, MAX_CLIENT_AGE_MS)
     ) {
       this.lastGarbageCollectionTime = Date.now();
 


### PR DESCRIPTION
This addresses https://www.google.com/url?q=https://github.com/firebase/firebase-js-sdk/pull/1108/files/34e6eecf092bf1f684c290c3accec3b9981c2f17..1ab51cbe48f4c5b3a9c1d36d51435f1487bbee7c%23diff-cf8f425b1bd34112162e05d44fc3a464&sa=D&usg=AFQjCNG-YmGkXVPvM2p5ywOjaZ09G6OEnw

- The 5 second threshold is only used during primary tab selection.
- The 30 minute threshold is used everywhere else. This means that the entire system tracks all states for clients that managed to rewrite their state within the last 30 minutes.  This may lead to additional query load for clients that went away without writing their zombied client ID.

I'm also debating if 30 minutes is maybe a bit too long, since the clients are supposed to update their state every 4 seconds.