### PR TITLE
Fix error in Memory LRU implementation

### DIFF
--- a/packages/firestore/src/local/memory_persistence.ts
+++ b/packages/firestore/src/local/memory_persistence.ts
@@ -295,8 +295,8 @@ export class MemoryLruDelegate implements ReferenceDelegate, LruDelegate {
     return PersistencePromise.forEach(
       this.orphanedSequenceNumbers,
       ({ key, value: sequenceNumber }) => {
-        // Pass in the exact sequence number as the upper bound so we know it won't be pinned by being
-        // too recent.
+        // Pass in the exact sequence number as the upper bound so we know it won't be pinned by
+        // being too recent.
         return this.isPinned(txn, key, sequenceNumber).next(isPinned => {
           if (!isPinned) {
             return f(sequenceNumber);

--- a/packages/firestore/src/local/memory_persistence.ts
+++ b/packages/firestore/src/local/memory_persistence.ts
@@ -292,17 +292,20 @@ export class MemoryLruDelegate implements ReferenceDelegate, LruDelegate {
     txn: PersistenceTransaction,
     f: (sequenceNumber: ListenSequenceNumber) => void
   ): PersistencePromise<void> {
-    return PersistencePromise.forEach(this.orphanedSequenceNumbers, ({ key, value: sequenceNumber }) => {
-      // Pass in the exact sequence number as the upper bound so we know it won't be pinned by being
-      // too recent.
-      return this.isPinned(txn, key, sequenceNumber).next(isPinned => {
-        if (!isPinned) {
-          return f(sequenceNumber);
-        } else {
-          return PersistencePromise.resolve();
-        }
-      });
-    });
+    return PersistencePromise.forEach(
+      this.orphanedSequenceNumbers,
+      ({ key, value: sequenceNumber }) => {
+        // Pass in the exact sequence number as the upper bound so we know it won't be pinned by being
+        // too recent.
+        return this.isPinned(txn, key, sequenceNumber).next(isPinned => {
+          if (!isPinned) {
+            return f(sequenceNumber);
+          } else {
+            return PersistencePromise.resolve();
+          }
+        });
+      }
+    );
   }
 
   setInMemoryPins(inMemoryPins: ReferenceSet): void {

--- a/packages/firestore/src/local/memory_persistence.ts
+++ b/packages/firestore/src/local/memory_persistence.ts
@@ -292,10 +292,17 @@ export class MemoryLruDelegate implements ReferenceDelegate, LruDelegate {
     txn: PersistenceTransaction,
     f: (sequenceNumber: ListenSequenceNumber) => void
   ): PersistencePromise<void> {
-    this.orphanedSequenceNumbers.forEach((_, sequenceNumber) =>
-      f(sequenceNumber)
-    );
-    return PersistencePromise.resolve();
+    return PersistencePromise.forEach(this.orphanedSequenceNumbers, ({ key, value: sequenceNumber }) => {
+      // Pass in the exact sequence number as the upper bound so we know it won't be pinned by being
+      // too recent.
+      return this.isPinned(txn, key, sequenceNumber).next(isPinned => {
+        if (!isPinned) {
+          return f(sequenceNumber);
+        } else {
+          return PersistencePromise.resolve();
+        }
+      });
+    });
   }
 
   setInMemoryPins(inMemoryPins: ReferenceSet): void {

--- a/packages/firestore/src/util/obj_map.ts
+++ b/packages/firestore/src/util/obj_map.ts
@@ -17,7 +17,7 @@
 import { Equatable } from './misc';
 import * as objUtil from './obj';
 
-export type Entry<K, V> = [K, V];
+type Entry<K, V> = [K, V];
 
 /**
  * A map implementation that uses objects as keys. Objects must implement the
@@ -111,60 +111,8 @@ export class ObjectMap<KeyType extends Equatable<KeyType>, ValueType> {
   [Symbol.iterator](): Iterator<{ key: KeyType; value: ValueType }> {
     // We don't care about the keys, all of the actual keys are in the
     // arrays that are the values of the inner object.
-    const it = objUtil.values(this.inner)[Symbol.iterator]();
-    return new ObjectMapIterator<KeyType, ValueType>(it);
-  }
-}
-
-/**
- * Implements an Iterator over ObjectMap.
- */
-export type IteratorEntry<KeyType, ValueType> = {
-  key: KeyType;
-  value: ValueType;
-};
-export class ObjectMapIterator<KeyType extends Equatable<KeyType>, ValueType>
-  implements Iterator<IteratorEntry<KeyType, ValueType>> {
-  private inner: Iterator<Entry<KeyType, ValueType>> | undefined;
-  private done: boolean;
-  private nextEntry: { key: KeyType; value: ValueType } | undefined;
-
-  constructor(
-    private readonly outer: Iterator<Array<Entry<KeyType, ValueType>>>
-  ) {
-    this.done = false;
-  }
-
-  private fillNextEntry(): void {
-    if (this.done) return;
-
-    if (!this.inner) {
-      const { done, value: innerArray } = this.outer.next();
-      if (done) {
-        this.done = true;
-        return;
-      } else {
-        this.inner = innerArray[Symbol.iterator]();
-      }
-    }
-
-    const { done: innerDone, value: entry } = this.inner!.next();
-    if (innerDone) {
-      // Start over with the next inner array.
-      this.inner = undefined;
-      this.fillNextEntry();
-      return;
-    } else {
-      this.nextEntry = { key: entry[0], value: entry[1] };
-    }
-  }
-
-  next(): IteratorResult<IteratorEntry<KeyType, ValueType>> {
-    this.fillNextEntry();
-    if (this.done) {
-      return { done: true, value: {} as { key: KeyType; value: ValueType } };
-    } else {
-      return { done: false, value: this.nextEntry! };
-    }
+    const entries: Array<{key: KeyType, value: ValueType}> = [];
+    this.forEach((key, value) => entries.push({key, value}));
+    return entries[Symbol.iterator]();
   }
 }

--- a/packages/firestore/src/util/obj_map.ts
+++ b/packages/firestore/src/util/obj_map.ts
@@ -17,7 +17,7 @@
 import { Equatable } from './misc';
 import * as objUtil from './obj';
 
-type Entry<K, V> = [K, V];
+export type Entry<K, V> = [K, V];
 
 /**
  * A map implementation that uses objects as keys. Objects must implement the
@@ -106,5 +106,59 @@ export class ObjectMap<KeyType extends Equatable<KeyType>, ValueType> {
 
   isEmpty(): boolean {
     return objUtil.isEmpty(this.inner);
+  }
+
+  [Symbol.iterator](): Iterator<{key: KeyType, value: ValueType}> {
+    // We don't care about the keys, all of the actual keys are in the
+    // arrays that are the values of the inner object.
+    const it = objUtil.values(this.inner)[Symbol.iterator]();
+    return new ObjectMapIterator<KeyType, ValueType>(it);
+  }
+}
+
+/**
+ * Implements an Iterator over ObjectMap.
+ */
+export type IteratorEntry<KeyType, ValueType> = { key: KeyType, value: ValueType };
+export class ObjectMapIterator<KeyType extends Equatable<KeyType>, ValueType> implements Iterator<IteratorEntry<KeyType, ValueType>> {
+  private inner: Iterator<Entry<KeyType, ValueType>> | undefined;
+  private done: boolean;
+  private nextEntry: { key: KeyType, value: ValueType } | undefined;
+
+  constructor(private readonly outer: Iterator<Array<Entry<KeyType, ValueType>>>) {
+    this.done = false;
+  }
+
+  private fillNextEntry(): void {
+    if (this.done) return;
+
+    if (!this.inner) {
+      const { done, value: innerArray } = this.outer.next();
+      if (done) {
+        this.done = true;
+        return;
+      } else {
+        this.inner = innerArray[Symbol.iterator]();
+      }
+    }
+
+    const { done: innerDone, value: entry } = this.inner!.next();
+    if (innerDone) {
+      // Start over with the next inner array.
+      this.inner = undefined;
+      this.fillNextEntry();
+      return;
+    } else {
+      this.nextEntry = { key: entry[0], value: entry[1] };
+    }
+  }
+
+  next(): IteratorResult<IteratorEntry<KeyType, ValueType>> {
+    this.fillNextEntry();
+    if (this.done) {
+      return { done: true, value: {} as { key: KeyType, value: ValueType } };
+    } else {
+      return { done: false, value: this.nextEntry! };
+    }
   }
 }

--- a/packages/firestore/src/util/obj_map.ts
+++ b/packages/firestore/src/util/obj_map.ts
@@ -108,7 +108,7 @@ export class ObjectMap<KeyType extends Equatable<KeyType>, ValueType> {
     return objUtil.isEmpty(this.inner);
   }
 
-  [Symbol.iterator](): Iterator<{key: KeyType, value: ValueType}> {
+  [Symbol.iterator](): Iterator<{ key: KeyType; value: ValueType }> {
     // We don't care about the keys, all of the actual keys are in the
     // arrays that are the values of the inner object.
     const it = objUtil.values(this.inner)[Symbol.iterator]();
@@ -119,13 +119,19 @@ export class ObjectMap<KeyType extends Equatable<KeyType>, ValueType> {
 /**
  * Implements an Iterator over ObjectMap.
  */
-export type IteratorEntry<KeyType, ValueType> = { key: KeyType, value: ValueType };
-export class ObjectMapIterator<KeyType extends Equatable<KeyType>, ValueType> implements Iterator<IteratorEntry<KeyType, ValueType>> {
+export type IteratorEntry<KeyType, ValueType> = {
+  key: KeyType;
+  value: ValueType;
+};
+export class ObjectMapIterator<KeyType extends Equatable<KeyType>, ValueType>
+  implements Iterator<IteratorEntry<KeyType, ValueType>> {
   private inner: Iterator<Entry<KeyType, ValueType>> | undefined;
   private done: boolean;
-  private nextEntry: { key: KeyType, value: ValueType } | undefined;
+  private nextEntry: { key: KeyType; value: ValueType } | undefined;
 
-  constructor(private readonly outer: Iterator<Array<Entry<KeyType, ValueType>>>) {
+  constructor(
+    private readonly outer: Iterator<Array<Entry<KeyType, ValueType>>>
+  ) {
     this.done = false;
   }
 
@@ -156,7 +162,7 @@ export class ObjectMapIterator<KeyType extends Equatable<KeyType>, ValueType> im
   next(): IteratorResult<IteratorEntry<KeyType, ValueType>> {
     this.fillNextEntry();
     if (this.done) {
-      return { done: true, value: {} as { key: KeyType, value: ValueType } };
+      return { done: true, value: {} as { key: KeyType; value: ValueType } };
     } else {
       return { done: false, value: this.nextEntry! };
     }

--- a/packages/firestore/src/util/obj_map.ts
+++ b/packages/firestore/src/util/obj_map.ts
@@ -111,8 +111,8 @@ export class ObjectMap<KeyType extends Equatable<KeyType>, ValueType> {
   [Symbol.iterator](): Iterator<{ key: KeyType; value: ValueType }> {
     // We don't care about the keys, all of the actual keys are in the
     // arrays that are the values of the inner object.
-    const entries: Array<{key: KeyType, value: ValueType}> = [];
-    this.forEach((key, value) => entries.push({key, value}));
+    const entries: Array<{ key: KeyType; value: ValueType }> = [];
+    this.forEach((key, value) => entries.push({ key, value }));
     return entries[Symbol.iterator]();
   }
 }

--- a/packages/firestore/test/unit/util/obj_map.test.ts
+++ b/packages/firestore/test/unit/util/obj_map.test.ts
@@ -127,11 +127,11 @@ describe('ObjectMap', () => {
     map.set(k5, 'boo');
 
     const expectedKeys: TestKey[] = [];
-    map.forEach((key) => {
+    map.forEach(key => {
       expectedKeys.push(key);
     });
 
-    const iterated: Array<{key: TestKey, value: string}> = [];
+    const iterated: Array<{ key: TestKey; value: string }> = [];
     const it = map[Symbol.iterator]();
     let result = it.next();
     while (!result.done) {

--- a/packages/firestore/test/unit/util/obj_map.test.ts
+++ b/packages/firestore/test/unit/util/obj_map.test.ts
@@ -110,4 +110,39 @@ describe('ObjectMap', () => {
     expect(map.get(k2)).to.equal(undefined);
     expect(map.get(k3)).to.equal(undefined);
   });
+
+  it('can iterate', () => {
+    const map = new ObjectMap<TestKey, string>(o => o.mapKey);
+    const k1 = new TestKey(4, 4);
+    const k2 = new TestKey(5, 5);
+    // Test a collision
+    const k3 = new TestKey(5, 6);
+    // Test an overwrite
+    const k4 = new TestKey(-12354, -12354);
+    const k5 = new TestKey(-12354, -12354);
+    map.set(k1, 'foo');
+    map.set(k2, 'bar');
+    map.set(k3, 'blah');
+    map.set(k4, 'baz');
+    map.set(k5, 'boo');
+
+    const expectedKeys: TestKey[] = [];
+    map.forEach((key) => {
+      expectedKeys.push(key);
+    });
+
+    const iterated: Array<{key: TestKey, value: string}> = [];
+    const it = map[Symbol.iterator]();
+    let result = it.next();
+    while (!result.done) {
+      iterated.push(result.value);
+      result = it.next();
+    }
+
+    for (const entry of iterated) {
+      expect(expectedKeys.indexOf(entry.key)).to.not.equal(-1);
+      expect(map.get(entry.key)).to.equal(entry.value);
+    }
+    expect(iterated.length).to.equal(expectedKeys.length);
+  });
 });


### PR DESCRIPTION
Iterating orphaned documents was returning all documents, not just orphaned ones. They weren't being incorrectly GC'd, but they were incorrectly counting towards sequence numbers to GC. 

The test that caught this is coming in the port of https://github.com/firebase/firebase-ios-sdk/pull/1905

Additionally, I implemented `Symbol.iterator` for `ObjectMap` so that I could use `PersistencePromise.forEach()`.