### PR TITLE
Make ReferenceSet.containsKey synchronous

### DIFF
--- a/packages/firestore/src/local/indexeddb_persistence.ts
+++ b/packages/firestore/src/local/indexeddb_persistence.ts
@@ -1141,13 +1141,11 @@ export class IndexedDbLruDelegate implements ReferenceDelegate, LruDelegate {
     txn: PersistenceTransaction,
     docKey: DocumentKey
   ): PersistencePromise<boolean> {
-    return this.inMemoryPins!.containsKey(txn, docKey).next(isPinned => {
-      if (isPinned) {
-        return PersistencePromise.resolve(true);
-      } else {
-        return mutationQueuesContainKey(txn, docKey);
-      }
-    });
+    if (this.inMemoryPins!.containsKey(docKey)) {
+      return PersistencePromise.resolve(true);
+    } else {
+      return mutationQueuesContainKey(txn, docKey);
+    }
   }
 
   removeOrphanedDocuments(

--- a/packages/firestore/src/local/memory_persistence.ts
+++ b/packages/firestore/src/local/memory_persistence.ts
@@ -249,7 +249,7 @@ export class MemoryEagerDelegate implements ReferenceDelegate {
     return PersistencePromise.or([
       () => this.persistence.getQueryCache().containsKey(txn, key),
       () => this.persistence.mutationQueuesContainKey(txn, key),
-      () => this.inMemoryPins!.containsKey(txn, key)
+      () => PersistencePromise.resolve(this.inMemoryPins!.containsKey(key))
     ]);
   }
 }
@@ -390,7 +390,7 @@ export class MemoryLruDelegate implements ReferenceDelegate, LruDelegate {
   ): PersistencePromise<boolean> {
     return PersistencePromise.or([
       () => this.persistence.mutationQueuesContainKey(txn, key),
-      () => this.inMemoryPins!.containsKey(txn, key),
+      () => PersistencePromise.resolve(this.inMemoryPins!.containsKey(key)),
       () => this.persistence.getQueryCache().containsKey(txn, key),
       () => {
         const orphanedAt = this.orphanedSequenceNumbers.get(key);

--- a/packages/firestore/src/local/memory_query_cache.ts
+++ b/packages/firestore/src/local/memory_query_cache.ts
@@ -246,6 +246,6 @@ export class MemoryQueryCache implements QueryCache {
     txn: PersistenceTransaction,
     key: DocumentKey
   ): PersistencePromise<boolean> {
-    return this.references.containsKey(txn, key);
+    return PersistencePromise.resolve(this.references.containsKey(key));
   }
 }

--- a/packages/firestore/src/local/reference_set.ts
+++ b/packages/firestore/src/local/reference_set.ts
@@ -20,9 +20,6 @@ import { DocumentKey } from '../model/document_key';
 import { primitiveComparator } from '../util/misc';
 import { SortedSet } from '../util/sorted_set';
 
-import { PersistenceTransaction } from './persistence';
-import { PersistencePromise } from './persistence_promise';
-
 /**
  * A collection of references to a document from some kind of numbered entity
  * (either a target ID or batch ID). As references are added to or removed from
@@ -110,15 +107,10 @@ export class ReferenceSet {
     return keys;
   }
 
-  containsKey(
-    txn: PersistenceTransaction | null,
-    key: DocumentKey
-  ): PersistencePromise<boolean> {
+  containsKey(key: DocumentKey): boolean {
     const ref = new DocReference(key, 0);
     const firstRef = this.refsByKey.firstAfterOrEqual(ref);
-    return PersistencePromise.resolve(
-      firstRef !== null && key.isEqual(firstRef.key)
-    );
+    return firstRef !== null && key.isEqual(firstRef.key);
   }
 }
 

--- a/packages/firestore/test/unit/local/reference_set.test.ts
+++ b/packages/firestore/test/unit/local/reference_set.test.ts
@@ -19,39 +19,27 @@ import { ReferenceSet } from '../../../src/local/reference_set';
 import { key } from '../../util/helpers';
 
 describe('ReferenceSet', () => {
-  it('can add/remove references', async () => {
+  it('can add/remove references', () => {
     const documentKey = key('foo/bar');
 
     const refSet = new ReferenceSet();
-    expect(refSet.isEmpty()).to.equal(true);
-    expect(await refSet.containsKey(null, documentKey).toPromise()).to.equal(
-      false
-    );
+    expect(refSet.isEmpty()).to.be.true;
+    expect(refSet.containsKey(documentKey)).to.be.false;
     refSet.addReference(documentKey, 1);
-    expect(refSet.isEmpty()).to.equal(false);
-    expect(await refSet.containsKey(null, documentKey).toPromise()).to.equal(
-      true
-    );
+    expect(refSet.isEmpty()).to.be.false;
+    expect(refSet.containsKey(documentKey)).to.be.true;
     refSet.addReference(documentKey, 2);
-    expect(await refSet.containsKey(null, documentKey).toPromise()).to.equal(
-      true
-    );
+    expect(refSet.containsKey(documentKey)).to.be.true;
     refSet.removeReference(documentKey, 1);
-    expect(await refSet.containsKey(null, documentKey).toPromise()).to.equal(
-      true
-    );
+    expect(refSet.containsKey(documentKey)).to.be.true;
     refSet.removeReference(documentKey, 3);
-    expect(await refSet.containsKey(null, documentKey).toPromise()).to.equal(
-      true
-    );
+    expect(refSet.containsKey(documentKey)).to.be.true;
     refSet.removeReference(documentKey, 2);
-    expect(await refSet.containsKey(null, documentKey).toPromise()).to.equal(
-      false
-    );
-    expect(refSet.isEmpty()).to.equal(true);
+    expect(refSet.containsKey(documentKey)).to.be.false;
+    expect(refSet.isEmpty()).to.be.true;
   });
 
-  it('can remove all references for a target ID', async () => {
+  it('can remove all references for a target ID', () => {
     const key1 = key('foo/bar');
     const key2 = key('foo/baz');
     const key3 = key('foo/blah');
@@ -60,19 +48,19 @@ describe('ReferenceSet', () => {
     refSet.addReference(key1, 1);
     refSet.addReference(key2, 1);
     refSet.addReference(key3, 2);
-    expect(refSet.isEmpty()).to.equal(false);
-    expect(await refSet.containsKey(null, key1).toPromise()).to.equal(true);
-    expect(await refSet.containsKey(null, key2).toPromise()).to.equal(true);
-    expect(await refSet.containsKey(null, key3).toPromise()).to.equal(true);
+    expect(refSet.isEmpty()).to.be.false;
+    expect(refSet.containsKey(key1)).to.be.true;
+    expect(refSet.containsKey(key2)).to.be.true;
+    expect(refSet.containsKey(key3)).to.be.true;
     refSet.removeReferencesForId(1);
-    expect(refSet.isEmpty()).to.equal(false);
-    expect(await refSet.containsKey(null, key1).toPromise()).to.equal(false);
-    expect(await refSet.containsKey(null, key2).toPromise()).to.equal(false);
-    expect(await refSet.containsKey(null, key3).toPromise()).to.equal(true);
+    expect(refSet.isEmpty()).to.be.false;
+    expect(refSet.containsKey(key1)).to.be.false;
+    expect(refSet.containsKey(key2)).to.be.false;
+    expect(refSet.containsKey(key3)).to.be.true;
     refSet.removeReferencesForId(2);
-    expect(refSet.isEmpty()).to.equal(true);
-    expect(await refSet.containsKey(null, key1).toPromise()).to.equal(false);
-    expect(await refSet.containsKey(null, key2).toPromise()).to.equal(false);
-    expect(await refSet.containsKey(null, key3).toPromise()).to.equal(false);
+    expect(refSet.isEmpty()).to.be.true;
+    expect(refSet.containsKey(key1)).to.be.false;
+    expect(refSet.containsKey(key2)).to.be.false;
+    expect(refSet.containsKey(key3)).to.be.false;
   });
 });


### PR DESCRIPTION
`ReferenceSet` used to have an async method for this so it could conform to the `GarbageSource` interface, but that no longer exists. So, we can have a synchronous `containsKey` implementation.