### PR TITLE
Fix #798: Avoid eval() in webchannel-wrapper.

### DIFF
--- a/packages/firestore/CHANGELOG.md
+++ b/packages/firestore/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Unreleased
+- [changed] Removed eval()-based fallback for JSON parsing, allowing SDK to
+  be used in environments that prohibit eval().
 
 # 0.8.3
 - [fixed] Fixed an issue that prevented query synchronization between multiple

--- a/packages/webchannel-wrapper/tools/build.js
+++ b/packages/webchannel-wrapper/tools/build.js
@@ -33,7 +33,9 @@ closureBuilder.build({
       output_wrapper:
         "(function() {%output%}).call(typeof global !== 'undefined' ? global : typeof self !== 'undefined' ? self : typeof window !== 'undefined' ? window : {})",
       language_out: 'ECMASCRIPT5',
-      compilation_level: 'ADVANCED'
+      compilation_level: 'ADVANCED',
+      // Avoid unsafe eval() calls (https://github.com/firebase/firebase-js-sdk/issues/798)
+      define: 'goog.json.USE_NATIVE_JSON=true'
     }
   }
 });
@@ -47,7 +49,9 @@ closureBuilder.build(
     options: {
       closure: {
         language_out: 'ECMASCRIPT5',
-        compilation_level: 'ADVANCED'
+        compilation_level: 'ADVANCED',
+        // Avoid unsafe eval() calls (https://github.com/firebase/firebase-js-sdk/issues/798)
+        define: 'goog.json.USE_NATIVE_JSON=true'
       }
     }
   },


### PR DESCRIPTION
Set goog.json.USE_NATIVE_JSON to true in our webchannel-wrapper build to avoid
fallback to eval() which isn't necessary, since we already rely on JSON.parse()
throughout the codebase.