### PR TITLE
Introduce protos to communicate with the Firestore Emulator

### DIFF
--- a/packages/testing/README.md
+++ b/packages/testing/README.md
@@ -1,3 +1,14 @@
 # @firebase/testing
 
 This is the testing component for the Firebase JS SDK.
+
+
+## Protocol buffers
+
+There are some protocol buffers (the `.proto` files in `src/protos/`) that
+are included in this package but should not be modified. They're copied from
+Google production and emulator APIs, and are immutable specifically to maintain
+compatibility with those services.
+
+When those services update their APIs, the new versions should be mirrored into
+this package.

--- a/packages/testing/index.ts
+++ b/packages/testing/index.ts
@@ -26,5 +26,6 @@ export {
   assertSucceeds,
   initializeAdminApp,
   initializeTestApp,
-  loadDatabaseRules
+  loadDatabaseRules,
+  loadFirestoreRules
 } from './src/api';

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -11,18 +11,20 @@
   "scripts": {
     "build": "rollup -c",
     "dev": "rollup -c -w",
-    "test": "TS_NODE_CACHE=NO nyc --reporter lcovonly -- mocha 'test/{,!(browser)/**/}*.test.ts' --compilers ts:ts-node/register/type-check --retries 5 --timeout 5000 --exit",
+    "test": "TS_NODE_CACHE=NO nyc --reporter lcovonly -- mocha 'test/{,!(browser)/**/}*.test.ts' --require ts-node/register/type-check --retries 5 --timeout 5000 --exit",
     "prepare": "npm run build"
   },
   "license": "Apache-2.0",
   "dependencies": {
     "@firebase/logger": "0.1.1",
     "@firebase/util": "0.2.2",
-    "request": "2.88.0",
-    "request-promise": "4.2.2"
+    "@types/request": "^2.47.1",
+    "grpc": "1.13.1",
+    "request": "2.88.0"
   },
   "devDependencies": {
     "chai": "4.1.2",
+    "chai-as-promised": "^7.1.1",
     "mocha": "5.0.5",
     "nyc": "11.6.0",
     "rollup": "0.57.1",

--- a/packages/testing/src/api/index.ts
+++ b/packages/testing/src/api/index.ts
@@ -15,10 +15,15 @@
  */
 
 import { firebase } from '@firebase/app';
-import request from 'request-promise';
+import * as request from 'request';
 import { FirebaseApp, FirebaseOptions } from '@firebase/app-types';
 import { base64 } from '@firebase/util';
 import { setLogLevel, LogLevel } from '@firebase/logger';
+import * as grpc from 'grpc';
+import * as fs from 'fs';
+
+const PROTOS = grpc.load({ root: __dirname + "/../protos", file: "google/firestore/emulator/v1/firestore_emulator.proto" });
+const EMULATOR = PROTOS["google"]["firestore"]["emulator"]["v1"];
 
 /** If this environment variable is set, use it for the database emulator's address. */
 const DATABASE_ADDRESS_ENV: string = 'FIREBASE_DATABASE_EMULATOR_ADDRESS';
@@ -128,24 +133,57 @@ export type LoadDatabaseRulesOptions = {
   databaseName: string;
   rules: string;
 };
-export function loadDatabaseRules(options: LoadDatabaseRulesOptions): void {
+export function loadDatabaseRules(options: LoadDatabaseRulesOptions): Promise<void> {
   if (!options.databaseName) {
-    throw new Error('databaseName not specified');
+    throw Error('databaseName not specified');
   }
 
   if (!options.rules) {
-    throw new Error('must provide rules to loadDatabaseRules');
+    throw Error('must provide rules to loadDatabaseRules');
   }
 
-  request({
-    uri: `http://${DATABASE_ADDRESS}/.settings/rules.json?ns=${
-      options.databaseName
-    }`,
-    method: 'PUT',
-    headers: { Authorization: 'Bearer owner' },
-    body: options.rules
-  }).catch(function(err) {
-    throw new Error('could not load rules: ' + err);
+  return new Promise((resolve, reject) => {
+    request.put({
+      uri: `http://${DATABASE_ADDRESS}/.settings/rules.json?ns=${
+        options.databaseName
+      }`,
+      headers: { Authorization: 'Bearer owner' },
+      body: options.rules
+    }, (err, resp, body) => {
+      if (err) {
+        reject(err);
+      } else {
+        resolve();
+      }
+    });
+  });
+}
+
+export type LoadFirestoreRulesOptions = {
+  projectId: string;
+  rules: string;
+};
+export function loadFirestoreRules(options: LoadFirestoreRulesOptions): Promise<void> {
+  if (!options.projectId) {
+    throw new Error('projectId not specified');
+  }
+
+  if (!options.rules) {
+    throw new Error('must provide rules to loadFirestoreRules');
+  }
+
+  let client = new EMULATOR.FirestoreEmulator("localhost:8080", grpc.credentials.createInsecure());
+  return new Promise((resolve, reject) => {
+    client.setSecurityRules({
+      project: "projects/bar",
+      rules: { files: [{ content: options.rules }] }
+    }, (err, resp) => {
+      if (err) {
+        reject(err);
+      } else {
+        resolve(resp);
+      }
+    });
   });
 }
 

--- a/packages/testing/src/api/index.ts
+++ b/packages/testing/src/api/index.ts
@@ -183,13 +183,13 @@ export function loadFirestoreRules(
   }
 
   let client = new EMULATOR.FirestoreEmulator(
-    'localhost:8080',
+    FIRESTORE_ADDRESS,
     grpc.credentials.createInsecure()
   );
   return new Promise((resolve, reject) => {
     client.setSecurityRules(
       {
-        project: 'projects/bar',
+        project: `projects/${options.projectId}`,
         rules: { files: [{ content: options.rules }] }
       },
       (err, resp) => {

--- a/packages/testing/src/api/index.ts
+++ b/packages/testing/src/api/index.ts
@@ -22,8 +22,11 @@ import { setLogLevel, LogLevel } from '@firebase/logger';
 import * as grpc from 'grpc';
 import * as fs from 'fs';
 
-const PROTOS = grpc.load({ root: __dirname + "/../protos", file: "google/firestore/emulator/v1/firestore_emulator.proto" });
-const EMULATOR = PROTOS["google"]["firestore"]["emulator"]["v1"];
+const PROTOS = grpc.load({
+  root: __dirname + '/../protos',
+  file: 'google/firestore/emulator/v1/firestore_emulator.proto'
+});
+const EMULATOR = PROTOS['google']['firestore']['emulator']['v1'];
 
 /** If this environment variable is set, use it for the database emulator's address. */
 const DATABASE_ADDRESS_ENV: string = 'FIREBASE_DATABASE_EMULATOR_ADDRESS';
@@ -133,7 +136,9 @@ export type LoadDatabaseRulesOptions = {
   databaseName: string;
   rules: string;
 };
-export function loadDatabaseRules(options: LoadDatabaseRulesOptions): Promise<void> {
+export function loadDatabaseRules(
+  options: LoadDatabaseRulesOptions
+): Promise<void> {
   if (!options.databaseName) {
     throw Error('databaseName not specified');
   }
@@ -143,19 +148,22 @@ export function loadDatabaseRules(options: LoadDatabaseRulesOptions): Promise<vo
   }
 
   return new Promise((resolve, reject) => {
-    request.put({
-      uri: `http://${DATABASE_ADDRESS}/.settings/rules.json?ns=${
-        options.databaseName
-      }`,
-      headers: { Authorization: 'Bearer owner' },
-      body: options.rules
-    }, (err, resp, body) => {
-      if (err) {
-        reject(err);
-      } else {
-        resolve();
+    request.put(
+      {
+        uri: `http://${DATABASE_ADDRESS}/.settings/rules.json?ns=${
+          options.databaseName
+        }`,
+        headers: { Authorization: 'Bearer owner' },
+        body: options.rules
+      },
+      (err, resp, body) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve();
+        }
       }
-    });
+    );
   });
 }
 
@@ -163,7 +171,9 @@ export type LoadFirestoreRulesOptions = {
   projectId: string;
   rules: string;
 };
-export function loadFirestoreRules(options: LoadFirestoreRulesOptions): Promise<void> {
+export function loadFirestoreRules(
+  options: LoadFirestoreRulesOptions
+): Promise<void> {
   if (!options.projectId) {
     throw new Error('projectId not specified');
   }
@@ -172,18 +182,24 @@ export function loadFirestoreRules(options: LoadFirestoreRulesOptions): Promise<
     throw new Error('must provide rules to loadFirestoreRules');
   }
 
-  let client = new EMULATOR.FirestoreEmulator("localhost:8080", grpc.credentials.createInsecure());
+  let client = new EMULATOR.FirestoreEmulator(
+    'localhost:8080',
+    grpc.credentials.createInsecure()
+  );
   return new Promise((resolve, reject) => {
-    client.setSecurityRules({
-      project: "projects/bar",
-      rules: { files: [{ content: options.rules }] }
-    }, (err, resp) => {
-      if (err) {
-        reject(err);
-      } else {
-        resolve(resp);
+    client.setSecurityRules(
+      {
+        project: 'projects/bar',
+        rules: { files: [{ content: options.rules }] }
+      },
+      (err, resp) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve(resp);
+        }
       }
-    });
+    );
   });
 }
 

--- a/packages/testing/src/protos/google/firebase/rules/v1/source.proto
+++ b/packages/testing/src/protos/google/firebase/rules/v1/source.proto
@@ -1,0 +1,60 @@
+syntax = "proto3";
+
+package google.firebase.rules.v1;
+
+option java_package = "com.google.firebase.rules.v1";
+option java_multiple_files = true;
+option java_outer_classname = "SourceProto";
+
+// `Source` is one or more `File` messages comprising a logical set of rules.
+message Source {
+  // `File` set constituting the `Source` bundle.
+  repeated File files = 1;
+
+  // `Language` of the `Source` bundle. If unspecified, the language will
+  // default to `FIREBASE_RULES`.
+  Language language = 2;
+}
+
+// `File` containing source content.
+message File {
+  // Textual Content.
+  string content = 1;
+
+  // File name.
+  string name = 2;
+
+  // Fingerprint (e.g. github sha) associated with the `File`.
+  bytes fingerprint = 3;
+}
+
+// Position in the `Source` content including its line, column number, and an
+// index of the `File` in the `Source` message. Used for debug purposes.
+message SourcePosition {
+  // Name of the `File`.
+  string file_name = 1;
+
+  // Index of the `File` in the `Source` message where the content appears.
+  // Output only.
+  int32 file_index = 2;
+
+  // Line number of the source fragment. 1-based.
+  int32 line = 3;
+
+  // First column on the source line associated with the source fragment.
+  int32 column = 4;
+
+  // Position relative to the beginning of the file. This is used by the IDEA
+  // plugin, while the line and column are used by the compiler.
+  int32 current_offset = 5;
+}
+
+// `Language` set supported within `Source`.
+enum Language {
+  // Language unspecified. Defaults to FIREBASE_RULES.
+  LANGUAGE_UNSPECIFIED = 0;
+  // Firebase Rules language.
+  FIREBASE_RULES = 1;
+  // Event Flow triggers.
+  EVENT_FLOW_TRIGGERS = 2;
+}

--- a/packages/testing/src/protos/google/firebase/rules/v1/source.proto
+++ b/packages/testing/src/protos/google/firebase/rules/v1/source.proto
@@ -1,3 +1,17 @@
+// Copyright 2018 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 syntax = "proto3";
 
 package google.firebase.rules.v1;

--- a/packages/testing/src/protos/google/firestore/emulator/v1/firestore_emulator.proto
+++ b/packages/testing/src/protos/google/firestore/emulator/v1/firestore_emulator.proto
@@ -1,0 +1,42 @@
+// Specification of the Firestore Emulator API.
+syntax = "proto3";
+
+package google.firestore.emulator.v1;
+
+option java_multiple_files = true;
+option java_package = "com.google.firestore.emulator.v1";
+
+import "google/protobuf/empty.proto";
+import "google/firebase/rules/v1/source.proto";
+
+// The Cloud Firestore Emulator service.
+//
+// A collection of auxiliary functionality present in the Cloud Firestore
+// emulator but not the production Cloud Firestore service.
+service FirestoreEmulator {
+  // Set the Firebase Rules used to validate requests against a given project.
+  // Note: In production this behavior is handled by the Firebase Rules service.
+  // The Firestore Emulator does not interact with the Firebase Rules service,
+  // so it needs to have some way of uploading new rulesets.
+  rpc SetSecurityRules(SetSecurityRulesRequest)
+      returns (google.protobuf.Empty) {
+  }
+
+  // Delete all data in a given database. Useful for clearing a database
+  // between tests to prevent cross-test data contamination.
+  rpc ClearData(ClearDataRequest) returns (google.protobuf.Empty) {
+  }
+}
+
+message SetSecurityRulesRequest {
+  // Format: `projects/{project_id}
+  string project = 1;
+
+  // The ruleset to use for the project
+  google.firebase.rules.v1.Source rules = 2;
+}
+
+message ClearDataRequest {
+  // Format: `projects/{project_id}/databases/(default)`
+  string database = 1;
+}

--- a/packages/testing/src/protos/google/firestore/emulator/v1/firestore_emulator.proto
+++ b/packages/testing/src/protos/google/firestore/emulator/v1/firestore_emulator.proto
@@ -1,3 +1,17 @@
+// Copyright 2018 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // Specification of the Firestore Emulator API.
 syntax = "proto3";
 

--- a/packages/testing/src/protos/google/protobuf/empty.proto
+++ b/packages/testing/src/protos/google/protobuf/empty.proto
@@ -1,0 +1,52 @@
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+syntax = "proto3";
+
+package google.protobuf;
+
+option csharp_namespace = "Google.Protobuf.WellKnownTypes";
+option go_package = "github.com/golang/protobuf/ptypes/empty";
+option java_package = "com.google.protobuf";
+option java_outer_classname = "EmptyProto";
+option java_multiple_files = true;
+option objc_class_prefix = "GPB";
+option cc_enable_arenas = true;
+
+// A generic empty message that you can re-use to avoid defining duplicated
+// empty messages in your APIs. A typical example is to use it as the request
+// or the response type of an API method. For instance:
+//
+//     service Foo {
+//       rpc Bar(google.protobuf.Empty) returns (google.protobuf.Empty);
+//     }
+//
+// The JSON representation for `Empty` is empty JSON object `{}`.
+message Empty {}

--- a/packages/testing/test/database.test.ts
+++ b/packages/testing/test/database.test.ts
@@ -14,10 +14,17 @@
  * limitations under the License.
  */
 
-import { expect } from 'chai';
+import * as chai from 'chai';
+import * as chaiAsPromised from 'chai-as-promised';
 import * as firebase from '../src/api';
 import { base64 } from '@firebase/util';
 import '@firebase/firestore';
+
+const expect = chai.expect;
+
+before(() => {
+  chai.use(chaiAsPromised);
+});
 
 describe('Testing Module Tests', function() {
   it('assertSucceeds() iff success', async function() {
@@ -80,17 +87,34 @@ describe('Testing Module Tests', function() {
   });
 
   it('loadDatabaseRules() throws if no databaseName or rules', async function() {
-    expect(firebase.loadDatabaseRules.bind(null, {})).to.throw(
-      /databaseName not specified/
-    );
-    expect(
-      firebase.loadDatabaseRules.bind(null, { databaseName: 'foo' })
-    ).to.throw(/must provide rules/);
-    expect(
-      firebase.loadDatabaseRules.bind(null, {
-        rules: '{}'
-      })
+    await expect(
+      firebase.loadDatabaseRules.bind(null, { })
     ).to.throw(/databaseName not specified/);
+    console.log("b");
+    await expect(
+      firebase.loadDatabaseRules.bind(null, { databaseName: 'foo' }) as Promise<void>
+    ).to.throw(/must provide rules/);
+    await expect(
+      firebase.loadDatabaseRules.bind(null, { rules: '{}' })
+    ).to.throw(/databaseName not specified/);
+  });
+
+  it('loadDatabaseRules() tries to make a network request', async function() {
+    await expect(firebase.loadDatabaseRules({ databaseName: "foo", rules: "{}"})).to.be.rejectedWith(
+      /ECONNREFUSED/
+    );
+  });
+
+  it('loadFirestoreRules() succeeds on valid input', async function() {
+    let promise = firebase.loadFirestoreRules({
+      projectId: "foo",
+      rules: `service cloud.firestore {
+        match /databases/{db}/documents/{doc=**} {
+          allow read, write;
+        }
+      }`
+    });
+    await expect(promise).to.be.rejectedWith(/UNAVAILABLE/);
   });
 
   it('apps() returns apps created with initializeTestApp', async function() {

--- a/packages/testing/test/database.test.ts
+++ b/packages/testing/test/database.test.ts
@@ -87,27 +87,27 @@ describe('Testing Module Tests', function() {
   });
 
   it('loadDatabaseRules() throws if no databaseName or rules', async function() {
-    await expect(
-      firebase.loadDatabaseRules.bind(null, { })
-    ).to.throw(/databaseName not specified/);
-    console.log("b");
-    await expect(
-      firebase.loadDatabaseRules.bind(null, { databaseName: 'foo' }) as Promise<void>
-    ).to.throw(/must provide rules/);
+    await expect(firebase.loadDatabaseRules.bind(null, {})).to.throw(
+      /databaseName not specified/
+    );
+    console.log('b');
+    await expect(firebase.loadDatabaseRules.bind(null, {
+      databaseName: 'foo'
+    }) as Promise<void>).to.throw(/must provide rules/);
     await expect(
       firebase.loadDatabaseRules.bind(null, { rules: '{}' })
     ).to.throw(/databaseName not specified/);
   });
 
   it('loadDatabaseRules() tries to make a network request', async function() {
-    await expect(firebase.loadDatabaseRules({ databaseName: "foo", rules: "{}"})).to.be.rejectedWith(
-      /ECONNREFUSED/
-    );
+    await expect(
+      firebase.loadDatabaseRules({ databaseName: 'foo', rules: '{}' })
+    ).to.be.rejectedWith(/ECONNREFUSED/);
   });
 
   it('loadFirestoreRules() succeeds on valid input', async function() {
     let promise = firebase.loadFirestoreRules({
-      projectId: "foo",
+      projectId: 'foo',
       rules: `service cloud.firestore {
         match /databases/{db}/documents/{doc=**} {
           allow read, write;


### PR DESCRIPTION
This does two things:

In the short-term, this gives us the ability to set Firestore rules from the SDK, mirroring the database functionality

In the long-term, this proto API will give us the ability to expose interesting non-production functionality from the emulators.