### PR TITLE
Remove non-test only invocation of findIndex

### DIFF
--- a/packages/firestore/src/util/async_queue.ts
+++ b/packages/firestore/src/util/async_queue.ts
@@ -260,6 +260,13 @@ export class AsyncQueue {
       `Attempted to schedule an operation with a negative delay of ${delayMs}`
     );
 
+    // While not necessarily harmful, we currently don't expect to have multiple
+    // ops with the same timer id in the queue, so defensively reject them.
+    assert(
+      !this.containsDelayedOperation(timerId),
+      `Attempted to schedule multiple operations with timer id ${timerId}.`
+    );
+
     const delayedOp = DelayedOperation.createAndSchedule<Unknown>(
       this,
       timerId,
@@ -305,17 +312,18 @@ export class AsyncQueue {
   /**
    * For Tests: Determine if a delayed operation with a particular TimerId
    * exists.
-   *
-   * Note: This method is not supported on IE 11.
    */
   containsDelayedOperation(timerId: TimerId): boolean {
-    return this.delayedOperations.findIndex(op => op.timerId === timerId) >= 0;
+    for (const op of this.delayedOperations) {
+      if (op.timerId === timerId) {
+        return true;
+      }
+    }
+    return false;
   }
 
   /**
    * For Tests: Runs some or all delayed operations early.
-   *
-   * Note: This method is not supported on IE 11.
    *
    * @param lastTimerId Delayed operations up to and including this TimerId will
    *  be drained. Throws if no such operation exists. Pass TimerId.All to run

--- a/packages/firestore/src/util/async_queue.ts
+++ b/packages/firestore/src/util/async_queue.ts
@@ -260,13 +260,6 @@ export class AsyncQueue {
       `Attempted to schedule an operation with a negative delay of ${delayMs}`
     );
 
-    // While not necessarily harmful, we currently don't expect to have multiple
-    // ops with the same timer id in the queue, so defensively reject them.
-    assert(
-      !this.containsDelayedOperation(timerId),
-      `Attempted to schedule multiple operations with timer id ${timerId}.`
-    );
-
     const delayedOp = DelayedOperation.createAndSchedule<Unknown>(
       this,
       timerId,
@@ -312,6 +305,8 @@ export class AsyncQueue {
   /**
    * For Tests: Determine if a delayed operation with a particular TimerId
    * exists.
+   *
+   * Note: This method is not supported on IE 11.
    */
   containsDelayedOperation(timerId: TimerId): boolean {
     return this.delayedOperations.findIndex(op => op.timerId === timerId) >= 0;
@@ -319,6 +314,8 @@ export class AsyncQueue {
 
   /**
    * For Tests: Runs some or all delayed operations early.
+   *
+   * Note: This method is not supported on IE 11.
    *
    * @param lastTimerId Delayed operations up to and including this TimerId will
    *  be drained. Throws if no such operation exists. Pass TimerId.All to run


### PR DESCRIPTION
This is the only invocation of `findIndex` in a non test-only path. Alternatively, we could also rewrite this functionality.

Fixes https://github.com/firebase/firebase-js-sdk/issues/1319