### PR TITLE
Make npm happier about security vulnerabilities

### DIFF
--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -24,9 +24,9 @@
   },
   "devDependencies": {
     "chai": "4.1.2",
-    "chai-as-promised": "^7.1.1",
+    "chai-as-promised": "7.1.1",
     "mocha": "5.0.5",
-    "nyc": "^13.1.0",
+    "nyc": "13.1.0",
     "rollup": "0.57.1",
     "rollup-plugin-commonjs": "9.1.0",
     "rollup-plugin-copy-assets": "1.0.0",

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -26,7 +26,7 @@
     "chai": "4.1.2",
     "chai-as-promised": "^7.1.1",
     "mocha": "5.0.5",
-    "nyc": "11.6.0",
+    "nyc": "^13.1.0",
     "rollup": "0.57.1",
     "rollup-plugin-commonjs": "9.1.0",
     "rollup-plugin-copy-assets": "1.0.0",

--- a/packages/testing/test/database.test.ts
+++ b/packages/testing/test/database.test.ts
@@ -128,6 +128,7 @@ describe('Testing Module Tests', function() {
       '.sv': 'timestamp'
     });
   });
+
   it('there is a way to get firestore timestamps', function() {
     expect(firebase.firestore.FieldValue.serverTimestamp()).not.to.be.null;
   });


### PR DESCRIPTION
Before:
```
found 6 vulnerabilities (1 low, 5 moderate) in 2069 scanned packages
  6 vulnerabilities require semver-major dependency updates.
```

After:
```
found 0 vulnerabilities
 in 1083 scanned packages
```