### PR TITLE
Create empty-import.d.ts and reference it in submodule imports

### DIFF
--- a/packages/firebase/auth/package.json
+++ b/packages/firebase/auth/package.json
@@ -1,5 +1,6 @@
 {
   "name": "firebase/auth",
   "main": "dist/index.cjs.js",
-  "module": "dist/index.esm.js"
+  "module": "dist/index.esm.js",
+  "typings": "../empty-import.d.ts"
 }

--- a/packages/firebase/database/package.json
+++ b/packages/firebase/database/package.json
@@ -1,5 +1,6 @@
 {
   "name": "firebase/database",
   "main": "dist/index.cjs.js",
-  "module": "dist/index.esm.js"
+  "module": "dist/index.esm.js",
+  "typings": "../empty-import.d.ts"
 }

--- a/packages/firebase/empty-import.d.ts
+++ b/packages/firebase/empty-import.d.ts
@@ -1,0 +1,1 @@
+export = undefined;

--- a/packages/firebase/firestore/package.json
+++ b/packages/firebase/firestore/package.json
@@ -1,5 +1,6 @@
 {
   "name": "firebase/firestore",
   "main": "dist/index.cjs.js",
-  "module": "dist/index.esm.js"
+  "module": "dist/index.esm.js",
+  "typings": "../empty-import.d.ts"
 }

--- a/packages/firebase/functions/package.json
+++ b/packages/firebase/functions/package.json
@@ -1,5 +1,6 @@
 {
   "name": "firebase/functions",
   "main": "dist/index.cjs.js",
-  "module": "dist/index.esm.js"
+  "module": "dist/index.esm.js",
+  "typings": "../empty-import.d.ts"
 }

--- a/packages/firebase/messaging/package.json
+++ b/packages/firebase/messaging/package.json
@@ -1,5 +1,6 @@
 {
   "name": "firebase/messaging",
   "main": "dist/index.cjs.js",
-  "module": "dist/index.esm.js"
+  "module": "dist/index.esm.js",
+  "typings": "../empty-import.d.ts"
 }

--- a/packages/rxfire/database/package.json
+++ b/packages/rxfire/database/package.json
@@ -1,5 +1,6 @@
 {
   "name": "rxfire/database",
   "main": "dist/index.cjs.js",
-  "module": "dist/index.esm.js"
+  "module": "dist/index.esm.js",
+  "typings": "dist/database/index.d.ts"
 }


### PR DESCRIPTION
* Fixes https://github.com/firebase/firebase-js-sdk/issues/1111 

A full reproduction of the error is available below 

https://github.com/davideast/rxfire-samples/blob/f4b0b6b7959b7fb52b04fb7a8041edb17b92a872/src/preact/index.tsx#L20-L23

```typescript
// NOTE: The lazy load for Firestore does not work with TypeScipt
// w/out hacking the node_modules/firebase/firestore/package.json file
// to use "typings": "../index.d.ts".
const firestore$ = from(import('firebase/firestore'));
```

