### PR TITLE
Lockdown the version of yarn to 1.10.1 in our Travis environment.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ env:
 before_install:
   # Yarn defaults to an old version, make sure we
   # get an up to date version
-  - npm install -g yarn
+  - npm install -g yarn@1.10.1
   - '[ "${NPM_TOKEN+x}" ] && echo "//registry.npmjs.org/:_authToken=\${NPM_TOKEN}" > $HOME/.npmrc || echo "Skipping .npmrc creation";'
 before_script:
   - cp config/ci.config.json config/project.json


### PR DESCRIPTION
The latest yarn (1.12.1 as of Nov 1st) appears to hang the CI build.