### PR TITLE
Upgrade GRPC to 1.16.0

### DIFF
--- a/packages/firestore/package.json
+++ b/packages/firestore/package.json
@@ -28,7 +28,7 @@
     "@firebase/firestore-types": "0.7.0",
     "@firebase/logger": "0.1.1",
     "@firebase/webchannel-wrapper": "0.2.11",
-    "grpc": "1.13.1",
+    "grpc": "1.16.0",
     "tslib": "1.9.0"
   },
   "peerDependencies": {

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -19,7 +19,7 @@
     "@firebase/logger": "0.1.1",
     "@firebase/util": "0.2.2",
     "@types/request": "2.47.1",
-    "grpc": "1.13.1",
+    "grpc": "1.16.0",
     "request": "2.88.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6060,16 +6060,6 @@ growl@1.10.3:
   resolved "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz#1926ba90cf3edfe2adb4927f5880bc22c66c790f"
   integrity sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q==
 
-grpc@1.13.1:
-  version "1.13.1"
-  resolved "https://registry.npmjs.org/grpc/-/grpc-1.13.1.tgz#9b5c49d4e56309b6e3bd631f8948b7b298d88790"
-  integrity sha512-yl0xChnlUISTefOPU2NQ1cYPh5m/DTatEUV6jdRyQPE9NCrtPq7Gn6J2alMTglN7ufYbJapOd00dvhGurHH6HQ==
-  dependencies:
-    lodash "^4.17.5"
-    nan "^2.0.0"
-    node-pre-gyp "^0.10.0"
-    protobufjs "^5.0.3"
-
 grpc@1.16.0:
   version "1.16.0"
   resolved "https://registry.npmjs.org/grpc/-/grpc-1.16.0.tgz#cdf56d6ede2f1b6ab5224ad467cb22e1b3ec36fc"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6070,6 +6070,16 @@ grpc@1.13.1:
     node-pre-gyp "^0.10.0"
     protobufjs "^5.0.3"
 
+grpc@1.16.0:
+  version "1.16.0"
+  resolved "https://registry.npmjs.org/grpc/-/grpc-1.16.0.tgz#cdf56d6ede2f1b6ab5224ad467cb22e1b3ec36fc"
+  integrity sha512-+p8YRIng7Gihkn2jycAXwXdA9aQ10SikRrcHY+/r3W1Z1Pr9NFIbLcmBZPoaTbzzLDv/ysqwqFEZriAdd8tveQ==
+  dependencies:
+    lodash "^4.17.5"
+    nan "^2.0.0"
+    node-pre-gyp "^0.10.0"
+    protobufjs "^5.0.3"
+
 gtoken@^1.2.1, gtoken@^1.2.3:
   version "1.2.3"
   resolved "https://registry.npmjs.org/gtoken/-/gtoken-1.2.3.tgz#5509571b8afd4322e124cf66cf68115284c476d8"


### PR DESCRIPTION
This removes a deprecated call used internally by GRPC, fixing the deprecation warning.

Fixes https://github.com/firebase/firebase-js-sdk/issues/1113