### PR TITLE
Remove Mutation tombstones

### DIFF
--- a/packages/firestore/src/model/mutation_batch.ts
+++ b/packages/firestore/src/model/mutation_batch.ts
@@ -39,7 +39,9 @@ export class MutationBatch {
     public batchId: BatchId,
     public localWriteTime: Timestamp,
     public mutations: Mutation[]
-  ) {}
+  ) {
+    assert(mutations.length > 0, 'Cannot create an empty mutation batch');
+  }
 
   /**
    * Applies all the mutations in this MutationBatch to the specified document

--- a/packages/firestore/src/model/mutation_batch.ts
+++ b/packages/firestore/src/model/mutation_batch.ts
@@ -129,23 +129,6 @@ export class MutationBatch {
       misc.arrayEquals(this.mutations, other.mutations)
     );
   }
-
-  /**
-   * Returns true if this mutation batch has already been removed from the
-   * mutation queue.
-   *
-   * Note that not all implementations of the MutationQueue necessarily use
-   * tombstones as part of their implementation and generally speaking no code
-   * outside the mutation queues should really care about this.
-   */
-  isTombstone(): boolean {
-    return this.mutations.length === 0;
-  }
-
-  /** Converts this batch into a tombstone */
-  toTombstone(): MutationBatch {
-    return new MutationBatch(this.batchId, this.localWriteTime, []);
-  }
 }
 
 /** The result of applying a mutation batch to the backend. */


### PR DESCRIPTION
If my understanding is correct, we no longer remove mutation batches from any place but the front of the queue. This PR removes the code that handles this removal.