### PR TITLE
Use orphaned docs as part of GC calculation

### DIFF
--- a/packages/firestore/src/local/indexeddb_persistence.ts
+++ b/packages/firestore/src/local/indexeddb_persistence.ts
@@ -1075,8 +1075,19 @@ export class IndexedDbLruDelegate implements ReferenceDelegate, LruDelegate {
     this.garbageCollector = new LruGarbageCollector(this);
   }
 
-  getTargetCount(txn: PersistenceTransaction): PersistencePromise<number> {
-    return this.db.getQueryCache().getQueryCount(txn);
+  getSequenceNumberCount(txn: PersistenceTransaction): PersistencePromise<number> {
+    const docCountPromise = this.orphanedDocmentCount(txn);
+    const targetCountPromise = this.db.getQueryCache().getQueryCount(txn);
+    return targetCountPromise.next(targetCount => 
+      docCountPromise.next(docCount => targetCount + docCount)
+    );
+  }
+
+  private orphanedDocmentCount(txn: PersistenceTransaction): PersistencePromise<number> {
+    let orphanedCount = 0;
+    return this.forEachOrphanedDocumentSequenceNumber(txn, _ => {
+      orphanedCount++;
+    }).next(() => orphanedCount);
   }
 
   forEachTarget(

--- a/packages/firestore/src/local/indexeddb_persistence.ts
+++ b/packages/firestore/src/local/indexeddb_persistence.ts
@@ -1075,15 +1075,19 @@ export class IndexedDbLruDelegate implements ReferenceDelegate, LruDelegate {
     this.garbageCollector = new LruGarbageCollector(this);
   }
 
-  getSequenceNumberCount(txn: PersistenceTransaction): PersistencePromise<number> {
+  getSequenceNumberCount(
+    txn: PersistenceTransaction
+  ): PersistencePromise<number> {
     const docCountPromise = this.orphanedDocmentCount(txn);
     const targetCountPromise = this.db.getQueryCache().getQueryCount(txn);
-    return targetCountPromise.next(targetCount => 
+    return targetCountPromise.next(targetCount =>
       docCountPromise.next(docCount => targetCount + docCount)
     );
   }
 
-  private orphanedDocmentCount(txn: PersistenceTransaction): PersistencePromise<number> {
+  private orphanedDocmentCount(
+    txn: PersistenceTransaction
+  ): PersistencePromise<number> {
     let orphanedCount = 0;
     return this.forEachOrphanedDocumentSequenceNumber(txn, _ => {
       orphanedCount++;

--- a/packages/firestore/src/local/lru_garbage_collector.ts
+++ b/packages/firestore/src/local/lru_garbage_collector.ts
@@ -36,7 +36,9 @@ export interface LruDelegate {
     f: (target: QueryData) => void
   ): PersistencePromise<void>;
 
-  getSequenceNumberCount(txn: PersistenceTransaction): PersistencePromise<number>;
+  getSequenceNumberCount(
+    txn: PersistenceTransaction
+  ): PersistencePromise<number>;
 
   /**
    * Enumerates sequence numbers for documents not associated with a target.

--- a/packages/firestore/src/local/lru_garbage_collector.ts
+++ b/packages/firestore/src/local/lru_garbage_collector.ts
@@ -36,7 +36,7 @@ export interface LruDelegate {
     f: (target: QueryData) => void
   ): PersistencePromise<void>;
 
-  getTargetCount(txn: PersistenceTransaction): PersistencePromise<number>;
+  getSequenceNumberCount(txn: PersistenceTransaction): PersistencePromise<number>;
 
   /**
    * Enumerates sequence numbers for documents not associated with a target.
@@ -146,7 +146,7 @@ export class LruGarbageCollector {
     txn: PersistenceTransaction,
     percentile: number
   ): PersistencePromise<number> {
-    return this.delegate.getTargetCount(txn).next(targetCount => {
+    return this.delegate.getSequenceNumberCount(txn).next(targetCount => {
       return Math.floor(percentile / 100.0 * targetCount);
     });
   }

--- a/packages/firestore/src/local/memory_persistence.ts
+++ b/packages/firestore/src/local/memory_persistence.ts
@@ -317,15 +317,21 @@ export class MemoryLruDelegate implements ReferenceDelegate, LruDelegate {
     return this.persistence.getQueryCache().forEachTarget(txn, f);
   }
 
-  getSequenceNumberCount(txn: PersistenceTransaction): PersistencePromise<number> {
+  getSequenceNumberCount(
+    txn: PersistenceTransaction
+  ): PersistencePromise<number> {
     const docCountPromise = this.orphanedDocumentCount(txn);
-    const targetCountPromise = this.persistence.getQueryCache().getTargetCount(txn);
-    return targetCountPromise.next(targetCount => 
+    const targetCountPromise = this.persistence
+      .getQueryCache()
+      .getTargetCount(txn);
+    return targetCountPromise.next(targetCount =>
       docCountPromise.next(docCount => targetCount + docCount)
     );
   }
 
-  private orphanedDocumentCount(txn: PersistenceTransaction): PersistencePromise<number> {
+  private orphanedDocumentCount(
+    txn: PersistenceTransaction
+  ): PersistencePromise<number> {
     let orphanedCount = 0;
     return this.forEachOrphanedDocumentSequenceNumber(txn, _ => {
       orphanedCount++;

--- a/packages/firestore/src/local/memory_persistence.ts
+++ b/packages/firestore/src/local/memory_persistence.ts
@@ -317,8 +317,19 @@ export class MemoryLruDelegate implements ReferenceDelegate, LruDelegate {
     return this.persistence.getQueryCache().forEachTarget(txn, f);
   }
 
-  getTargetCount(txn: PersistenceTransaction): PersistencePromise<number> {
-    return this.persistence.getQueryCache().getTargetCount(txn);
+  getSequenceNumberCount(txn: PersistenceTransaction): PersistencePromise<number> {
+    const docCountPromise = this.orphanedDocumentCount(txn);
+    const targetCountPromise = this.persistence.getQueryCache().getTargetCount(txn);
+    return targetCountPromise.next(targetCount => 
+      docCountPromise.next(docCount => targetCount + docCount)
+    );
+  }
+
+  private orphanedDocumentCount(txn: PersistenceTransaction): PersistencePromise<number> {
+    let orphanedCount = 0;
+    return this.forEachOrphanedDocumentSequenceNumber(txn, _ => {
+      orphanedCount++;
+    }).next(() => orphanedCount);
   }
 
   forEachOrphanedDocumentSequenceNumber(


### PR DESCRIPTION
Port of https://github.com/firebase/firebase-android-sdk/pull/80

We had originally decided to only look at targets when assessing how much to run GC. However, based on running a write-heavy workload test, we need to include documents that ended up cached without being part of a target.