### PR TITLE
[README] Supported Node.js versions for SDK development

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ Current [Release Notes](https://firebase.google.com/support/release-notes/js)
 #### Node.js
 
 Before you can start working on the Firebase JS SDK, you need to have Node.js
-`8.0.0` or greater installed on your machine. 
+installed on your machine. The currently supported versions are `8.0.0` or greater,
+but smaller than `10.0.0`.
 
 To download Node.js visit https://nodejs.org/en/download/.
 


### PR DESCRIPTION
Several dependencies currently have a `<=9` requirement on the Node.js engine version. The way the README is written, it may give people the impression that any version above 8 is also supported, but that's not the case for Node.js 10 and 11.