### PR TITLE
added return type definition to useFunctionsEmulator

### DIFF
--- a/packages/functions-types/index.d.ts
+++ b/packages/functions-types/index.d.ts
@@ -52,7 +52,7 @@ export class FirebaseFunctions {
    * @param origin The origin of the local emulator, such as
    * "http://localhost:5005".
    */
-  useFunctionsEmulator(origin: string);
+  useFunctionsEmulator(origin: string): void;
 }
 
 /**


### PR DESCRIPTION
There is a return type missing for useFunctionsEmulator() and typescript complains about that.  

I added an Issue already here: #1360