### PR TITLE
Adding Numeric Add

### DIFF
--- a/packages/firebase/index.d.ts
+++ b/packages/firebase/index.d.ts
@@ -1978,6 +1978,25 @@ declare namespace firebase.firestore {
     static arrayRemove(...elements: any[]): FieldValue;
 
     /**
+     * Returns a special value that can be used with set() or update() that tells
+     * the server to add the given value to the field's current value.
+     *
+     * If either the operand or the current field value is of type double, both
+     * values will be interpreted as doubles and all arithmetic will follow IEEE
+     * 754 semantics. If both values are integers, values outside of JavaScript's
+     * safe number range (`Number.MIN_SAFE_INTEGER` to `Number.MAX_SAFE_INTEGER`)
+     * are subject to precision loss. Furthermore, once processed by the Firestore
+     * backend, all integer operations are capped between -2^63 and 2^63-1.
+     *
+     * If field is not an integer or double, or if the field does not yet exist,
+     * the transformation will set the field to the given value.
+     *
+     * @param n The value to add.
+     * @return The FieldValue sentinel for use in a call to set() or update().
+     */
+    static numericAdd(n: number): FieldValue;
+
+    /**
      * Returns true if this `FieldValue` is equal to the provided one.
      *
      * @param other The `FieldValue` to compare against.

--- a/packages/firestore-types/index.d.ts
+++ b/packages/firestore-types/index.d.ts
@@ -1261,6 +1261,25 @@ export class FieldValue {
   static arrayRemove(...elements: any[]): FieldValue;
 
   /**
+   * Returns a special value that can be used with set() or update() that tells
+   * the server to add the given value to the field's current value.
+   *
+   * If either the operand or the current field value is of type double, both
+   * values will be interpreted as doubles and all arithmetic will follow IEEE
+   * 754 semantics. If both values are integers, values outside of JavaScript's
+   * safe number range (`Number.MIN_SAFE_INTEGER` to `Number.MAX_SAFE_INTEGER`)
+   * are subject to precision loss. Furthermore, once processed by the Firestore
+   * backend, all integer operations are capped between -2^63 and 2^63-1.
+   *
+   * If field is not an integer or double, or if the field does not yet exist,
+   * the transformation will set the field to the given value.
+   *
+   * @param n The value to add.
+   * @return The FieldValue sentinel for use in a call to set() or update().
+   */
+  static numericAdd(n: number): FieldValue;
+
+  /**
    * Returns true if this `FieldValue` is equal to the provided one.
    *
    * @param other The `FieldValue` to compare against.

--- a/packages/firestore/src/api/field_value.ts
+++ b/packages/firestore/src/api/field_value.ts
@@ -17,7 +17,10 @@
 import * as firestore from '@firebase/firestore-types';
 
 import { makeConstructorPrivate } from '../util/api';
-import { validateAtLeastNumberOfArgs } from '../util/input_validation';
+import {
+  validateArgType,
+  validateAtLeastNumberOfArgs
+} from '../util/input_validation';
 import { AnyJs } from '../util/misc';
 
 /**
@@ -50,6 +53,11 @@ export abstract class FieldValueImpl implements firestore.FieldValue {
     return new ArrayRemoveFieldValueImpl(elements);
   }
 
+  static numericAdd(n: number): FieldValueImpl {
+    validateArgType('FieldValue.numericAdd', 'number', 1, n);
+    return new NumericAddFieldValueImpl(n);
+  }
+
   isEqual(other: FieldValueImpl): boolean {
     return this === other;
   }
@@ -80,6 +88,12 @@ export class ArrayUnionFieldValueImpl extends FieldValueImpl {
 export class ArrayRemoveFieldValueImpl extends FieldValueImpl {
   constructor(readonly _elements: AnyJs[]) {
     super('FieldValue.arrayRemove');
+  }
+}
+
+export class NumericAddFieldValueImpl extends FieldValueImpl {
+  constructor(readonly _operand: number) {
+    super('FieldValue.numericAdd');
   }
 }
 

--- a/packages/firestore/src/api/user_data_converter.ts
+++ b/packages/firestore/src/api/user_data_converter.ts
@@ -19,7 +19,7 @@ import * as firestore from '@firebase/firestore-types';
 import { Timestamp } from '../api/timestamp';
 import { DatabaseId } from '../core/database_info';
 import { DocumentKey } from '../model/document_key';
-import { FieldValue, ObjectValue } from '../model/field_value';
+import { FieldValue, NumberValue, ObjectValue } from '../model/field_value';
 import {
   ArrayValue,
   BlobValue,
@@ -54,6 +54,7 @@ import * as typeUtils from '../util/types';
 import {
   ArrayRemoveTransformOperation,
   ArrayUnionTransformOperation,
+  NumericAddTransformOperation,
   ServerTimestampTransform
 } from '../model/transform_operation';
 import { Blob } from './blob';
@@ -66,6 +67,7 @@ import {
   ArrayUnionFieldValueImpl,
   DeleteFieldValueImpl,
   FieldValueImpl,
+  NumericAddFieldValueImpl,
   ServerTimestampFieldValueImpl
 } from './field_value';
 import { GeoPoint } from './geo_point';
@@ -643,6 +645,15 @@ export class UserDataConverter {
       const arrayRemove = new ArrayRemoveTransformOperation(parsedElements);
       context.fieldTransforms.push(
         new FieldTransform(context.path, arrayRemove)
+      );
+    } else if (value instanceof NumericAddFieldValueImpl) {
+      const operand = this.parseQueryValue(
+        'FieldValue.numericAdd',
+        value._operand
+      ) as NumberValue;
+      const numericAdd = new NumericAddTransformOperation(operand);
+      context.fieldTransforms.push(
+        new FieldTransform(context.path, numericAdd)
       );
     } else {
       fail('Unknown FieldValue type: ' + value);

--- a/packages/firestore/src/local/indexeddb_mutation_queue.ts
+++ b/packages/firestore/src/local/indexeddb_mutation_queue.ts
@@ -148,6 +148,7 @@ export class IndexedDbMutationQueue implements MutationQueue {
   addMutationBatch(
     transaction: PersistenceTransaction,
     localWriteTime: Timestamp,
+    baseMutations: Mutation[],
     mutations: Mutation[]
   ): PersistencePromise<MutationBatch> {
     const documentStore = documentMutationsStore(transaction);
@@ -165,7 +166,12 @@ export class IndexedDbMutationQueue implements MutationQueue {
     return mutationStore.add({} as any).next(batchId => {
       assert(typeof batchId === 'number', 'Auto-generated key is not a number');
 
-      const batch = new MutationBatch(batchId, localWriteTime, mutations);
+      const batch = new MutationBatch(
+        batchId,
+        localWriteTime,
+        baseMutations,
+        mutations
+      );
       const dbBatch = this.serializer.toDbMutationBatch(this.userId, batch);
 
       this.documentKeysByBatchId[batchId] = batch.keys();

--- a/packages/firestore/src/local/indexeddb_schema.ts
+++ b/packages/firestore/src/local/indexeddb_schema.ts
@@ -304,6 +304,20 @@ export class DbMutationBatch {
      */
     public localWriteTimeMs: number,
     /**
+     * A list of "mutations" that represent a partial base state from when this
+     * write batch was initially created. During local application of the write
+     * batch, these baseMutations are applied prior to the real writes in order
+     * to override certain document fields from the remote document cache. This
+     * is necessary in the case of non-idempotent writes (e.g. `numericAdd()`
+     * transforms) to make sure that the local view of the modified documents
+     * doesn't flicker if the remote document cache receives the result of the
+     * non-idempotent write before the write is removed from the queue.
+     *
+     * These mutations are never sent to the backend and serialized via
+     * JsonProtoSerializer.toMutation().
+     */
+    public baseMutations: api.Write[] | undefined,
+    /**
      * A list of mutations to apply. All mutations will be applied atomically.
      *
      * Mutations are serialized via JsonProtoSerializer.toMutation().

--- a/packages/firestore/src/local/memory_mutation_queue.ts
+++ b/packages/firestore/src/local/memory_mutation_queue.ts
@@ -108,6 +108,7 @@ export class MemoryMutationQueue implements MutationQueue {
   addMutationBatch(
     transaction: PersistenceTransaction,
     localWriteTime: Timestamp,
+    baseMutations: Mutation[],
     mutations: Mutation[]
   ): PersistencePromise<MutationBatch> {
     assert(mutations.length !== 0, 'Mutation batches should not be empty');
@@ -123,7 +124,12 @@ export class MemoryMutationQueue implements MutationQueue {
       );
     }
 
-    const batch = new MutationBatch(batchId, localWriteTime, mutations);
+    const batch = new MutationBatch(
+      batchId,
+      localWriteTime,
+      baseMutations,
+      mutations
+    );
     this.mutationQueue.push(batch);
 
     // Track references by document key.

--- a/packages/firestore/src/local/mutation_queue.ts
+++ b/packages/firestore/src/local/mutation_queue.ts
@@ -52,10 +52,18 @@ export interface MutationQueue {
 
   /**
    * Creates a new mutation batch and adds it to this mutation queue.
+   *
+   * @param transaction The transaction this operation is scoped to.
+   * @param localWriteTime The original write time of this mutation.
+   * @param baseMutations Base mutations that are used to populate the base
+   * values when this mutation is applied locally. These mutations are used to
+   * locally overwrite values that are persisted in the remote document cache.
+   * @param mutations The user-provided mutations in this mutation batch.
    */
   addMutationBatch(
     transaction: PersistenceTransaction,
     localWriteTime: Timestamp,
+    baseMutations: Mutation[],
     mutations: Mutation[]
   ): PersistencePromise<MutationBatch>;
 

--- a/packages/firestore/src/model/document.ts
+++ b/packages/firestore/src/model/document.ts
@@ -45,6 +45,8 @@ export abstract class MaybeDocument {
   abstract get hasPendingWrites(): boolean;
 
   abstract isEqual(other: MaybeDocument | null | undefined): boolean;
+
+  abstract toString(): string;
 }
 
 /**

--- a/packages/firestore/src/model/mutation_batch.ts
+++ b/packages/firestore/src/model/mutation_batch.ts
@@ -23,7 +23,8 @@ import {
   documentKeySet,
   DocumentKeySet,
   DocumentVersionMap,
-  documentVersionMap
+  documentVersionMap,
+  MaybeDocumentMap
 } from './collections';
 import { MaybeDocument } from './document';
 import { DocumentKey } from './document_key';
@@ -35,9 +36,21 @@ export const BATCHID_UNKNOWN = -1;
  * A batch of mutations that will be sent as one unit to the backend.
  */
 export class MutationBatch {
+  /**
+   * @param batchId The unique ID of this mutation batch.
+   * @param localWriteTime The original write time of this mutation.
+   * @param baseMutations Mutations that are used to populate the base
+   * values when this mutation is applied locally. This can be used to locally
+   * overwrite values that are persisted in the remote document cache. Base
+   * mutations are never sent to the backend.
+   * @param mutations The user-provided mutations in this mutation batch.
+   * User-provided mutations are applied both locally and remotely on the
+   * backend.
+   */
   constructor(
     public batchId: BatchId,
     public localWriteTime: Timestamp,
+    public baseMutations: Mutation[],
     public mutations: Mutation[]
   ) {
     assert(mutations.length > 0, 'Cannot create an empty mutation batch');
@@ -101,10 +114,23 @@ export class MutationBatch {
         ${maybeDoc.key}`
       );
     }
+
+    // First, apply the base state. This allows us to apply non-idempotent
+    // transform against a consistent set of values.
+    for (const mutation of this.baseMutations) {
+      if (mutation.key.isEqual(docKey)) {
+        maybeDoc = mutation.applyToLocalView(
+          maybeDoc,
+          maybeDoc,
+          this.localWriteTime
+        );
+      }
+    }
+
     const baseDoc = maybeDoc;
 
-    for (let i = 0; i < this.mutations.length; i++) {
-      const mutation = this.mutations[i];
+    // Second, apply all user-provided mutations.
+    for (const mutation of this.mutations) {
       if (mutation.key.isEqual(docKey)) {
         maybeDoc = mutation.applyToLocalView(
           maybeDoc,
@@ -116,19 +142,39 @@ export class MutationBatch {
     return maybeDoc;
   }
 
-  keys(): DocumentKeySet {
-    let keySet = documentKeySet();
+  /**
+   * Computes the local view for all provided documents given the mutations in
+   * this batch.
+   */
+  applyToLocalDocumentSet(maybeDocs: MaybeDocumentMap): MaybeDocumentMap {
+    // TODO(mrschmidt): This implementation is O(n^2). If we iterate through the
+    // mutations first (as done in `applyToLocalView()`), we can reduce the
+    // complexity to O(n).
+    let mutatedDocuments = maybeDocs;
+    this.mutations.forEach(m => {
+      const mutatedDocument = this.applyToLocalView(
+        m.key,
+        maybeDocs.get(m.key)
+      );
+      if (mutatedDocument) {
+        mutatedDocuments = mutatedDocuments.insert(m.key, mutatedDocument);
+      }
+    });
+    return mutatedDocuments;
+  }
 
-    for (const mutation of this.mutations) {
-      keySet = keySet.add(mutation.key);
-    }
-    return keySet;
+  keys(): DocumentKeySet {
+    return this.mutations.reduce(
+      (keys, m) => keys.add(m.key),
+      documentKeySet()
+    );
   }
 
   isEqual(other: MutationBatch): boolean {
     return (
       this.batchId === other.batchId &&
-      misc.arrayEquals(this.mutations, other.mutations)
+      misc.arrayEquals(this.mutations, other.mutations) &&
+      misc.arrayEquals(this.baseMutations, other.baseMutations)
     );
   }
 }

--- a/packages/firestore/src/model/transform_operation.ts
+++ b/packages/firestore/src/model/transform_operation.ts
@@ -15,11 +15,22 @@
  */
 
 import { Timestamp } from '../api/timestamp';
+import { assert } from '../util/assert';
 import * as misc from '../util/misc';
-import { ArrayValue, FieldValue, ServerTimestampValue } from './field_value';
+import {
+  ArrayValue,
+  DoubleValue,
+  FieldValue,
+  IntegerValue,
+  NumberValue,
+  ServerTimestampValue
+} from './field_value';
 
 /** Represents a transform within a TransformMutation. */
 export interface TransformOperation {
+  /** Whether this field transform is idempotent. */
+  readonly isIdempotent: boolean;
+
   /**
    * Computes the local transform result against the provided `previousValue`,
    * optionally using the provided localWriteTime.
@@ -43,6 +54,8 @@ export interface TransformOperation {
 
 /** Transforms a value into a server-generated timestamp. */
 export class ServerTimestampTransform implements TransformOperation {
+  readonly isIdempotent = true;
+
   private constructor() {}
   static instance = new ServerTimestampTransform();
 
@@ -67,6 +80,8 @@ export class ServerTimestampTransform implements TransformOperation {
 
 /** Transforms an array value via a union operation. */
 export class ArrayUnionTransformOperation implements TransformOperation {
+  readonly isIdempotent = true;
+
   constructor(readonly elements: FieldValue[]) {}
 
   applyToLocalView(
@@ -106,6 +121,8 @@ export class ArrayUnionTransformOperation implements TransformOperation {
 
 /** Transforms an array value via a remove operation. */
 export class ArrayRemoveTransformOperation implements TransformOperation {
+  readonly isIdempotent = true;
+
   constructor(readonly elements: FieldValue[]) {}
 
   applyToLocalView(
@@ -137,6 +154,62 @@ export class ArrayRemoveTransformOperation implements TransformOperation {
     return (
       other instanceof ArrayRemoveTransformOperation &&
       misc.arrayEquals(other.elements, this.elements)
+    );
+  }
+}
+
+/**
+ * Implements the backend semantics for locally computed NUMERIC_ADD transforms.
+ * Converts all field values to integers or doubles, but unlike the backend does
+ * not cap integer values at 2^63. Instead, JavaScript number arithmetic is used
+ * and precision loss can occur for values greater than 2^53.
+ */
+export class NumericAddTransformOperation implements TransformOperation {
+  readonly isIdempotent = false;
+
+  // PORTING NOTE: Since JavaScript's integer arithmetic is limited to 53 bit
+  // precision and resolves overflows by reducing precision, we do not manually
+  // cap overflows at 2^63.
+
+  constructor(readonly operand: NumberValue) {}
+
+  applyToLocalView(
+    previousValue: FieldValue | null,
+    localWriteTime: Timestamp
+  ): FieldValue {
+    // Return an integer value iff the previous value and the operand is an
+    // integer.
+    if (
+      previousValue instanceof IntegerValue &&
+      this.operand instanceof IntegerValue
+    ) {
+      const sum = previousValue.internalValue + this.operand.internalValue;
+      return new IntegerValue(sum);
+    } else if (previousValue instanceof NumberValue) {
+      const sum = previousValue.internalValue + this.operand.internalValue;
+      return new DoubleValue(sum);
+    }
+
+    // If the existing value is not a number, use the value of the transform as
+    // the new base value.
+    return this.operand;
+  }
+
+  applyToRemoteDocument(
+    previousValue: FieldValue | null,
+    transformResult: FieldValue | null
+  ): FieldValue {
+    assert(
+      transformResult !== null,
+      "Didn't receive transformResult for NUMERIC_ADD transform"
+    );
+    return transformResult!;
+  }
+
+  isEqual(other: TransformOperation): boolean {
+    return (
+      other instanceof NumericAddTransformOperation &&
+      this.operand.isEqual(other.operand)
     );
   }
 }

--- a/packages/firestore/src/protos/firestore_proto_api.d.ts
+++ b/packages/firestore/src/protos/firestore_proto_api.d.ts
@@ -214,6 +214,7 @@ export declare namespace firestoreV1beta1ApiClientInterfaces {
     setToServerValue?: FieldTransformSetToServerValue;
     appendMissingElements?: ArrayValue;
     removeAllFromArray?: ArrayValue;
+    numericAdd?: Value;
   }
   interface Filter {
     compositeFilter?: CompositeFilter;

--- a/packages/firestore/src/protos/google/firestore/v1beta1/write.proto
+++ b/packages/firestore/src/protos/google/firestore/v1beta1/write.proto
@@ -89,6 +89,18 @@ message DocumentTransform {
       // Sets the field to the given server value.
       ServerValue set_to_server_value = 2;
 
+      // Adds the given value to the field's current value.
+      //
+      // This must be an integer or a double value.
+      // If the field is not an integer or double, or if the field does not yet
+      // exist, the transformation will set the field to the given value.
+      // If either of the given value or the current field value are doubles,
+      // both values will be interpreted as doubles. Double arithmetic and
+      // representation of double values follow IEEE 754 semantics.
+      // If there is positive/negative integer overflow, the field is resolved
+      // to the largest magnitude positive/negative integer.
+      Value numeric_add = 3;
+
       // Append the given elements in order if they are not already present in
       // the current field value.
       // If the field is not an array, or if the field does not yet exist, it is

--- a/packages/firestore/src/remote/serializer.ts
+++ b/packages/firestore/src/remote/serializer.ts
@@ -54,9 +54,11 @@ import { AnyJs } from '../util/misc';
 import * as obj from '../util/obj';
 import * as typeUtils from '../util/types';
 
+import { NumberValue } from '../model/field_value';
 import {
   ArrayRemoveTransformOperation,
   ArrayUnionTransformOperation,
+  NumericAddTransformOperation,
   ServerTimestampTransform,
   TransformOperation
 } from '../model/transform_operation';
@@ -947,6 +949,11 @@ export class JsonProtoSerializer {
           values: transform.elements.map(v => this.toValue(v))
         }
       };
+    } else if (transform instanceof NumericAddTransformOperation) {
+      return {
+        fieldPath: fieldTransform.field.canonicalString(),
+        numericAdd: this.toValue(transform.operand)
+      };
     } else {
       throw fail('Unknown transform: ' + fieldTransform.transform);
     }
@@ -972,6 +979,13 @@ export class JsonProtoSerializer {
       transform = new ArrayRemoveTransformOperation(
         values.map(v => this.fromValue(v))
       );
+    } else if (hasTag(proto, type, 'numericAdd')) {
+      const operand = this.fromValue(proto.numericAdd!);
+      assert(
+        operand instanceof NumberValue,
+        'NUMERIC_ADD transform requires a NumberValue'
+      );
+      transform = new NumericAddTransformOperation(operand as NumberValue);
     } else {
       fail('Unknown transform proto: ' + JSON.stringify(proto));
     }

--- a/packages/firestore/test/integration/api/numeric_transforms.test.ts
+++ b/packages/firestore/test/integration/api/numeric_transforms.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Copyright 2018 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as firestore from '@firebase/firestore-types';
+import { expect } from 'chai';
+
+import { EventsAccumulator } from '../util/events_accumulator';
+import firebase from '../util/firebase_export';
+import { apiDescribe, withTestDoc } from '../util/helpers';
+
+// tslint:disable-next-line:variable-name Type alias can be capitalized.
+const FieldValue = firebase.firestore!.FieldValue;
+
+const DOUBLE_EPSILON = 0.000001;
+
+apiDescribe('Numeric Transforms:', persistence => {
+  // A document reference to read and write to.
+  let docRef: firestore.DocumentReference;
+
+  // Accumulator used to capture events during the test.
+  let accumulator: EventsAccumulator<firestore.DocumentSnapshot>;
+
+  // Listener registration for a listener maintained during the course of the
+  // test.
+  let unsubscribe: () => void;
+
+  /** Writes some initialData and consumes the events generated. */
+  async function writeInitialData(
+    initialData: firestore.DocumentData
+  ): Promise<void> {
+    await docRef.set(initialData);
+    await accumulator.awaitLocalEvent();
+    const snapshot = await accumulator.awaitRemoteEvent();
+    expect(snapshot.data()).to.deep.equal(initialData);
+  }
+
+  async function expectLocalAndRemoteValue(expectedSum: number): Promise<void> {
+    const localSnap = await accumulator.awaitLocalEvent();
+    expect(localSnap.get('sum')).to.be.closeTo(expectedSum, DOUBLE_EPSILON);
+    const remoteSnap = await accumulator.awaitRemoteEvent();
+    expect(remoteSnap.get('sum')).to.be.closeTo(expectedSum, DOUBLE_EPSILON);
+  }
+
+  /**
+   * Wraps a test, getting a docRef and event accumulator, and cleaning them
+   * up when done.
+   */
+  async function withTestSetup<T>(test: () => Promise<T>): Promise<void> {
+    await withTestDoc(persistence, async doc => {
+      docRef = doc;
+      accumulator = new EventsAccumulator<firestore.DocumentSnapshot>();
+      unsubscribe = docRef.onSnapshot(
+        { includeMetadataChanges: true },
+        accumulator.storeEvent
+      );
+
+      // wait for initial null snapshot to avoid potential races.
+      const snapshot = await accumulator.awaitRemoteEvent();
+      expect(snapshot.exists).to.be.false;
+      await test();
+      unsubscribe();
+    });
+  }
+
+  it('create document with increment', async () => {
+    await withTestSetup(async () => {
+      await docRef.set({ sum: FieldValue.numericAdd(1337) });
+      await expectLocalAndRemoteValue(1337);
+    });
+  });
+
+  it('merge on non-existing document with increment', async () => {
+    await withTestSetup(async () => {
+      await docRef.set({ sum: FieldValue.numericAdd(1337) }, { merge: true });
+      await expectLocalAndRemoteValue(1337);
+    });
+  });
+
+  it('increment existing integer with integer', async () => {
+    await withTestSetup(async () => {
+      await writeInitialData({ sum: 1337 });
+      await docRef.update('sum', FieldValue.numericAdd(1));
+      await expectLocalAndRemoteValue(1338);
+    });
+  });
+
+  it('increment existing double with double', async () => {
+    await withTestSetup(async () => {
+      await writeInitialData({ sum: 13.37 });
+      await docRef.update('sum', FieldValue.numericAdd(0.1));
+      await expectLocalAndRemoteValue(13.47);
+    });
+  });
+
+  it('increment existing double with integer', async () => {
+    await withTestSetup(async () => {
+      await writeInitialData({ sum: 13.37 });
+      await docRef.update('sum', FieldValue.numericAdd(1));
+      await expectLocalAndRemoteValue(14.37);
+    });
+  });
+
+  it('increment existing integer with double', async () => {
+    await withTestSetup(async () => {
+      await writeInitialData({ sum: 1337 });
+      await docRef.update('sum', FieldValue.numericAdd(0.1));
+      await expectLocalAndRemoteValue(1337.1);
+    });
+  });
+
+  it('increment existing string with integer', async () => {
+    await withTestSetup(async () => {
+      await writeInitialData({ sum: 'overwrite' });
+      await docRef.update('sum', FieldValue.numericAdd(1337));
+      await expectLocalAndRemoteValue(1337);
+    });
+  });
+
+  it('increment existing string with double', async () => {
+    await withTestSetup(async () => {
+      await writeInitialData({ sum: 'overwrite' });
+      await docRef.update('sum', FieldValue.numericAdd(13.37));
+      await expectLocalAndRemoteValue(13.37);
+    });
+  });
+
+  it('multiple double increments', async () => {
+    await withTestSetup(async () => {
+      await writeInitialData({ sum: 0.0 });
+
+      await docRef.firestore.disableNetwork();
+
+      docRef.update('sum', FieldValue.numericAdd(0.1));
+      docRef.update('sum', FieldValue.numericAdd(0.01));
+      docRef.update('sum', FieldValue.numericAdd(0.001));
+
+      let snap = await accumulator.awaitLocalEvent();
+      expect(snap.get('sum')).to.be.closeTo(0.1, DOUBLE_EPSILON);
+      snap = await accumulator.awaitLocalEvent();
+      expect(snap.get('sum')).to.be.closeTo(0.11, DOUBLE_EPSILON);
+      snap = await accumulator.awaitLocalEvent();
+      expect(snap.get('sum')).to.be.closeTo(0.111, DOUBLE_EPSILON);
+
+      await docRef.firestore.enableNetwork();
+
+      snap = await accumulator.awaitRemoteEvent();
+      expect(snap.get('sum')).to.be.closeTo(0.111, DOUBLE_EPSILON);
+    });
+  });
+});

--- a/packages/firestore/test/integration/api/validation.test.ts
+++ b/packages/firestore/test/integration/api/validation.test.ts
@@ -713,6 +713,29 @@ apiDescribe('Validation:', persistence => {
     });
   });
 
+  describe('Numeric transforms', () => {
+    validationIt(persistence, 'fail in queries', db => {
+      const collection = db.collection('test');
+      expect(() =>
+        collection.where('test', '==', { test: FieldValue.numericAdd(1) })
+      ).to.throw(
+        'Function Query.where() called with invalid data. ' +
+          'FieldValue.numericAdd() can only be used with update() and set() ' +
+          '(found in field test)'
+      );
+    });
+
+    validationIt(persistence, 'reject invalid operands', db => {
+      const doc = db.collection('test').doc();
+      expect(() =>
+        doc.set({ x: FieldValue.numericAdd('foo' as any) })
+      ).to.throw(
+        'Function FieldValue.numericAdd() requires its first argument to ' +
+          'be of type number, but it was: "foo"'
+      );
+    });
+  });
+
   describe('Queries', () => {
     validationIt(persistence, 'with non-positive limit fail', db => {
       const collection = db.collection('test');

--- a/packages/firestore/test/unit/local/indexeddb_persistence.test.ts
+++ b/packages/firestore/test/unit/local/indexeddb_persistence.test.ts
@@ -197,7 +197,7 @@ describe('IndexedDbSchema: createOrUpgradeDb', () => {
     const batchId = 1;
     const targetId = 2;
 
-    const expectedMutation = new DbMutationBatch(userId, batchId, 1000, []);
+    const expectedMutation = new DbMutationBatch(userId, batchId, 1000, [], []);
     const dummyTargetGlobal = new DbTargetGlobal(
       /*highestTargetId=*/ 1,
       /*highestListenSequencNumber=*/ 1,
@@ -287,18 +287,21 @@ describe('IndexedDbSchema: createOrUpgradeDb', () => {
         userId: 'foo',
         batchId: 0,
         localWriteTimeMs: 1337,
+        baseMutations: undefined,
         mutations: []
       },
       {
         userId: 'foo',
         batchId: 1,
         localWriteTimeMs: 1337,
+        baseMutations: undefined,
         mutations: [testWrite]
       },
       {
         userId: 'foo',
         batchId: 42,
         localWriteTimeMs: 1337,
+        baseMutations: undefined,
         mutations: [testWrite, testWrite]
       }
     ];
@@ -370,12 +373,14 @@ describe('IndexedDbSchema: createOrUpgradeDb', () => {
         userId: 'foo',
         batchId: 1,
         localWriteTimeMs: 1337,
+        baseMutations: undefined,
         mutations: [testWriteFoo]
       },
       {
         userId: 'foo',
         batchId: 2,
         localWriteTimeMs: 1337,
+        baseMutations: undefined,
         mutations: [testWriteFoo]
       },
       // User 'bar' has one acknowledged mutation and one that is pending.
@@ -383,18 +388,21 @@ describe('IndexedDbSchema: createOrUpgradeDb', () => {
         userId: 'bar',
         batchId: 3,
         localWriteTimeMs: 1337,
+        baseMutations: undefined,
         mutations: [testWriteBar, testWriteBaz]
       },
       {
         userId: 'bar',
         batchId: 4,
         localWriteTimeMs: 1337,
+        baseMutations: undefined,
         mutations: [testWritePending]
       },
       {
         userId: 'foo',
         batchId: 5,
         localWriteTimeMs: 1337,
+        baseMutations: undefined,
         mutations: [testWritePending]
       }
     ];

--- a/packages/firestore/test/unit/local/local_store.test.ts
+++ b/packages/firestore/test/unit/local/local_store.test.ts
@@ -15,6 +15,7 @@
  */
 
 import { expect } from 'chai';
+import { PublicFieldValue } from '../../../src/api/field_value';
 import { Timestamp } from '../../../src/api/timestamp';
 import { User } from '../../../src/auth/user';
 import { Query } from '../../../src/core/query';
@@ -29,7 +30,11 @@ import {
   MaybeDocumentMap
 } from '../../../src/model/collections';
 import { MaybeDocument, NoDocument } from '../../../src/model/document';
-import { Mutation, MutationResult } from '../../../src/model/mutation';
+import {
+  Mutation,
+  MutationResult,
+  Precondition
+} from '../../../src/model/mutation';
 import {
   MutationBatch,
   MutationBatchResult
@@ -57,10 +62,12 @@ import {
   path,
   setMutation,
   TestSnapshotVersion,
+  transformMutation,
   unknownDoc,
   version
 } from '../../util/helpers';
 
+import { FieldValue, IntegerValue } from '../../../src/model/field_value';
 import * as persistenceHelpers from './persistence_test_helpers';
 
 class LocalStoreTester {
@@ -91,7 +98,7 @@ class LocalStoreTester {
       })
       .then((result: LocalWriteResult) => {
         this.batches.push(
-          new MutationBatch(result.batchId, Timestamp.now(), mutations)
+          new MutationBatch(result.batchId, Timestamp.now(), [], mutations)
         );
         this.lastChanges = result.changes;
       });
@@ -118,6 +125,7 @@ class LocalStoreTester {
 
   afterAcknowledgingMutation(options: {
     documentVersion: TestSnapshotVersion;
+    transformResult?: FieldValue;
   }): LocalStoreTester {
     this.promiseChain = this.promiseChain
       .then(() => {
@@ -128,7 +136,10 @@ class LocalStoreTester {
         );
         const ver = version(options.documentVersion);
         const mutationResults = [
-          new MutationResult(ver, /*transformResults=*/ null)
+          new MutationResult(
+            ver,
+            options.transformResult ? [options.transformResult] : null
+          )
         ];
         const write = MutationBatchResult.from(
           batch,
@@ -191,7 +202,13 @@ class LocalStoreTester {
       expect(this.lastChanges!.size).to.equal(docs.length, 'number of changes');
       for (const doc of docs) {
         const returned = this.lastChanges!.get(doc.key);
-        expectEqual(doc, returned);
+        expectEqual(
+          doc,
+          returned,
+          `Expected '${
+            returned ? returned.toString() : null
+          }' to equal '${doc.toString()}'.`
+        );
       }
       this.lastChanges = null;
     });
@@ -966,5 +983,250 @@ function genericLocalStoreTests(
     // Should come back with the same resume token
     const queryData2 = await localStore.allocateQuery(query);
     expect(queryData2.resumeToken).to.deep.equal(resumeToken);
+  });
+
+  // TODO(mrschmidt): The FieldValue.numericAdd() field transform tests below would probably be
+  // better implemented as spec tests but currently they don't support transforms.
+
+  it('handles SetMutation -> TransformMutation -> TransformMutation', () => {
+    return expectLocalStore()
+      .after(setMutation('foo/bar', { sum: 0 }))
+      .toReturnChanged(
+        doc('foo/bar', 0, { sum: 0 }, { hasLocalMutations: true })
+      )
+      .toContain(doc('foo/bar', 0, { sum: 0 }, { hasLocalMutations: true }))
+      .after(
+        transformMutation('foo/bar', { sum: PublicFieldValue.numericAdd(1) })
+      )
+      .toReturnChanged(
+        doc('foo/bar', 0, { sum: 1 }, { hasLocalMutations: true })
+      )
+      .toContain(doc('foo/bar', 0, { sum: 1 }, { hasLocalMutations: true }))
+      .after(
+        transformMutation('foo/bar', { sum: PublicFieldValue.numericAdd(2) })
+      )
+      .toReturnChanged(
+        doc('foo/bar', 0, { sum: 3 }, { hasLocalMutations: true })
+      )
+      .toContain(doc('foo/bar', 0, { sum: 3 }, { hasLocalMutations: true }))
+      .finish();
+  });
+
+  it('handles SetMutation -> Ack -> TransformMutation -> Ack -> TransformMutation', () => {
+    if (gcIsEager) {
+      // Since this test doesn't start a listen, Eager GC removes the documents from the cache as
+      // soon as the mutation is applied. This creates a lot of special casing in this unit test but
+      // does not expand its test coverage.
+      return;
+    }
+
+    return expectLocalStore()
+      .after(setMutation('foo/bar', { sum: 0 }))
+      .toReturnChanged(
+        doc('foo/bar', 0, { sum: 0 }, { hasLocalMutations: true })
+      )
+      .toContain(doc('foo/bar', 0, { sum: 0 }, { hasLocalMutations: true }))
+      .afterAcknowledgingMutation({ documentVersion: 1 })
+      .toReturnChanged(
+        doc('foo/bar', 1, { sum: 0 }, { hasCommittedMutations: true })
+      )
+      .toContain(doc('foo/bar', 1, { sum: 0 }, { hasCommittedMutations: true }))
+      .after(
+        transformMutation('foo/bar', { sum: PublicFieldValue.numericAdd(1) })
+      )
+      .toReturnChanged(
+        doc('foo/bar', 1, { sum: 1 }, { hasLocalMutations: true })
+      )
+      .toContain(doc('foo/bar', 1, { sum: 1 }, { hasLocalMutations: true }))
+      .afterAcknowledgingMutation({
+        documentVersion: 2,
+        transformResult: new IntegerValue(1)
+      })
+      .toReturnChanged(
+        doc('foo/bar', 2, { sum: 1 }, { hasCommittedMutations: true })
+      )
+      .toContain(doc('foo/bar', 2, { sum: 1 }, { hasCommittedMutations: true }))
+      .after(
+        transformMutation('foo/bar', { sum: PublicFieldValue.numericAdd(2) })
+      )
+      .toReturnChanged(
+        doc('foo/bar', 2, { sum: 3 }, { hasLocalMutations: true })
+      )
+      .toContain(doc('foo/bar', 2, { sum: 3 }, { hasLocalMutations: true }))
+      .finish();
+  });
+
+  it('handles SetMutation -> TransformMutation -> RemoteEvent -> TransformMutation', () => {
+    const query = Query.atPath(path('foo'));
+    return (
+      expectLocalStore()
+        .afterAllocatingQuery(query)
+        .toReturnTargetId(2)
+        .after(setMutation('foo/bar', { sum: 0 }))
+        .toReturnChanged(
+          doc('foo/bar', 0, { sum: 0 }, { hasLocalMutations: true })
+        )
+        .toContain(doc('foo/bar', 0, { sum: 0 }, { hasLocalMutations: true }))
+        .afterRemoteEvent(
+          docAddedRemoteEvent(doc('foo/bar', 1, { sum: 0 }), [2])
+        )
+        .afterAcknowledgingMutation({ documentVersion: 1 })
+        .toReturnChanged(doc('foo/bar', 1, { sum: 0 }))
+        .toContain(doc('foo/bar', 1, { sum: 0 }))
+        .after(
+          transformMutation('foo/bar', { sum: PublicFieldValue.numericAdd(1) })
+        )
+        .toReturnChanged(
+          doc('foo/bar', 1, { sum: 1 }, { hasLocalMutations: true })
+        )
+        .toContain(doc('foo/bar', 1, { sum: 1 }, { hasLocalMutations: true }))
+        // The value in this remote event gets ignored since we still have a pending transform
+        // mutation.
+        .afterRemoteEvent(
+          docUpdateRemoteEvent(doc('foo/bar', 2, { sum: 1337 }), [2])
+        )
+        .toReturnChanged(
+          doc('foo/bar', 2, { sum: 1 }, { hasLocalMutations: true })
+        )
+        .toContain(doc('foo/bar', 2, { sum: 1 }, { hasLocalMutations: true }))
+        // Add another increment. Note that we still compute the increment based on the local value.
+        .after(
+          transformMutation('foo/bar', { sum: PublicFieldValue.numericAdd(2) })
+        )
+        .toReturnChanged(
+          doc('foo/bar', 2, { sum: 3 }, { hasLocalMutations: true })
+        )
+        .toContain(doc('foo/bar', 2, { sum: 3 }, { hasLocalMutations: true }))
+        .afterAcknowledgingMutation({
+          documentVersion: 3,
+          transformResult: new IntegerValue(1)
+        })
+        .toReturnChanged(
+          doc('foo/bar', 3, { sum: 3 }, { hasLocalMutations: true })
+        )
+        .toContain(doc('foo/bar', 3, { sum: 3 }, { hasLocalMutations: true }))
+        .afterAcknowledgingMutation({
+          documentVersion: 4,
+          transformResult: new IntegerValue(1339)
+        })
+        .toReturnChanged(
+          doc('foo/bar', 4, { sum: 1339 }, { hasCommittedMutations: true })
+        )
+        .toContain(
+          doc('foo/bar', 4, { sum: 1339 }, { hasCommittedMutations: true })
+        )
+        .finish()
+    );
+  });
+
+  it('holds back only non-idempotent transforms', () => {
+    const query = Query.atPath(path('foo'));
+    return (
+      expectLocalStore()
+        .afterAllocatingQuery(query)
+        .toReturnTargetId(2)
+        .after(setMutation('foo/bar', { sum: 0, array_union: [] }))
+        .toReturnChanged(
+          doc(
+            'foo/bar',
+            0,
+            { sum: 0, array_union: [] },
+            { hasLocalMutations: true }
+          )
+        )
+        .afterAcknowledgingMutation({ documentVersion: 1 })
+        .toReturnChanged(
+          doc(
+            'foo/bar',
+            1,
+            { sum: 0, array_union: [] },
+            { hasCommittedMutations: true }
+          )
+        )
+        .afterRemoteEvent(
+          docAddedRemoteEvent(doc('foo/bar', 1, { sum: 0, array_union: [] }), [
+            2
+          ])
+        )
+        .toReturnChanged(doc('foo/bar', 1, { sum: 0, array_union: [] }))
+        .afterMutations([
+          transformMutation('foo/bar', { sum: PublicFieldValue.numericAdd(1) }),
+          transformMutation('foo/bar', {
+            array_union: PublicFieldValue.arrayUnion('foo')
+          })
+        ])
+        .toReturnChanged(
+          doc(
+            'foo/bar',
+            1,
+            { sum: 1, array_union: ['foo'] },
+            { hasLocalMutations: true }
+          )
+        )
+        // The sum transform is not idempotent and the backend's updated value is ignored. The
+        // ArrayUnion transform is recomputed and includes the backend value.
+        .afterRemoteEvent(
+          docUpdateRemoteEvent(
+            doc('foo/bar', 2, { sum: 1337, array_union: ['bar'] }),
+            [2]
+          )
+        )
+        .toReturnChanged(
+          doc(
+            'foo/bar',
+            2,
+            { sum: 1, array_union: ['bar', 'foo'] },
+            { hasLocalMutations: true }
+          )
+        )
+        .finish()
+    );
+  });
+
+  it('handles MergeMutation with Transform -> RemoteEvent', () => {
+    const query = Query.atPath(path('foo'));
+    return expectLocalStore()
+      .afterAllocatingQuery(query)
+      .toReturnTargetId(2)
+      .afterMutations([
+        patchMutation('foo/bar', {}, Precondition.NONE),
+        transformMutation('foo/bar', { sum: PublicFieldValue.numericAdd(1) })
+      ])
+      .toReturnChanged(
+        doc('foo/bar', 0, { sum: 1 }, { hasLocalMutations: true })
+      )
+      .toContain(doc('foo/bar', 0, { sum: 1 }, { hasLocalMutations: true }))
+      .afterRemoteEvent(
+        docAddedRemoteEvent(doc('foo/bar', 1, { sum: 1337 }), [2])
+      )
+      .toReturnChanged(
+        doc('foo/bar', 1, { sum: 1 }, { hasLocalMutations: true })
+      )
+      .toContain(doc('foo/bar', 1, { sum: 1 }, { hasLocalMutations: true }))
+      .finish();
+  });
+
+  it('handles PatchMutation with Transform -> RemoteEvent', () => {
+    // Note: This test reflects the current behavior, but it may be preferable
+    // to replay the mutation once we receive the first value from the backend.
+
+    const query = Query.atPath(path('foo'));
+    return expectLocalStore()
+      .afterAllocatingQuery(query)
+      .toReturnTargetId(2)
+      .afterMutations([
+        patchMutation('foo/bar', {}),
+        transformMutation('foo/bar', { sum: PublicFieldValue.numericAdd(1) })
+      ])
+      .toReturnChanged(deletedDoc('foo/bar', 0))
+      .toNotContain('foo/bar')
+      .afterRemoteEvent(
+        docAddedRemoteEvent(doc('foo/bar', 1, { sum: 1337 }), [2])
+      )
+      .toReturnChanged(
+        doc('foo/bar', 1, { sum: 1 }, { hasLocalMutations: true })
+      )
+      .toContain(doc('foo/bar', 1, { sum: 1 }, { hasLocalMutations: true }))
+      .finish();
   });
 }

--- a/packages/firestore/test/unit/local/lru_garbage_collector.test.ts
+++ b/packages/firestore/test/unit/local/lru_garbage_collector.test.ts
@@ -470,6 +470,7 @@ function genericLruGarbageCollectorTests(
         return mutationQueue.addMutationBatch(
           txn,
           Timestamp.fromMillis(2000),
+          /* baseMutations= */ [],
           mutations
         );
       }

--- a/packages/firestore/test/unit/local/test_mutation_queue.ts
+++ b/packages/firestore/test/unit/local/test_mutation_queue.ts
@@ -84,7 +84,12 @@ export class TestMutationQueue {
       'addMutationBatch',
       'readwrite',
       txn => {
-        return this.queue.addMutationBatch(txn, Timestamp.now(), mutations);
+        return this.queue.addMutationBatch(
+          txn,
+          Timestamp.now(),
+          /* baseMutations= */ [],
+          mutations
+        );
       }
     );
   }

--- a/packages/firestore/test/unit/model/mutation.test.ts
+++ b/packages/firestore/test/unit/model/mutation.test.ts
@@ -19,6 +19,7 @@ import { PublicFieldValue as FieldValue } from '../../../src/api/field_value';
 import { Timestamp } from '../../../src/api/timestamp';
 import { Document, MaybeDocument } from '../../../src/model/document';
 import {
+  IntegerValue,
   ServerTimestampValue,
   TimestampValue
 } from '../../../src/model/field_value';
@@ -347,16 +348,22 @@ describe('Mutation', () => {
 
   function verifyTransform(
     baseData: Dict<AnyJs>,
-    transformData: Dict<AnyJs>,
+    transforms: Dict<AnyJs> | Array<Dict<AnyJs>>,
     expectedData: Dict<AnyJs>
   ): void {
     const baseDoc = doc('collection/key', 0, baseData);
-    const transform = transformMutation('collection/key', transformData);
-    const transformedDoc = transform.applyToLocalView(
-      baseDoc,
-      baseDoc,
-      timestamp
-    );
+    let transformedDoc: MaybeDocument | null = baseDoc;
+
+    transforms = Array.isArray(transforms) ? transforms : [transforms];
+
+    for (const transformData of transforms) {
+      const transform = transformMutation('collection/key', transformData);
+      transformedDoc = transform.applyToLocalView(
+        transformedDoc,
+        transformedDoc,
+        timestamp
+      );
+    }
 
     const expectedDoc = doc('collection/key', 0, expectedData, {
       hasLocalMutations: true
@@ -390,7 +397,7 @@ describe('Mutation', () => {
     );
   });
 
-  it('can apply server-acked array transforms to documents', () => {
+  it('can apply server-acked array transforms to document', () => {
     const docData = { array1: [1, 2], array2: ['a', 'b'] };
     const baseDoc = doc('collection/key', 0, docData);
     const transform = transformMutation('collection/key', {
@@ -412,6 +419,89 @@ describe('Mutation', () => {
         { array1: [1, 2, 3], array2: ['b'] },
         { hasCommittedMutations: true }
       )
+    );
+  });
+
+  it('can apply numeric add transform to document', () => {
+    const baseDoc = {
+      longPlusLong: 1,
+      longPlusDouble: 2,
+      doublePlusLong: 3.3,
+      doublePlusDouble: 4.0,
+      longPlusNan: 5,
+      doublePlusNan: 6.6,
+      longPlusInfinity: 7,
+      doublePlusInfinity: 8.8
+    };
+    const transform = {
+      longPlusLong: FieldValue.numericAdd(1),
+      longPlusDouble: FieldValue.numericAdd(2.2),
+      doublePlusLong: FieldValue.numericAdd(3),
+      doublePlusDouble: FieldValue.numericAdd(4.4),
+      longPlusNan: FieldValue.numericAdd(Number.NaN),
+      doublePlusNan: FieldValue.numericAdd(Number.NaN),
+      longPlusInfinity: FieldValue.numericAdd(Number.POSITIVE_INFINITY),
+      doublePlusInfinity: FieldValue.numericAdd(Number.POSITIVE_INFINITY)
+    };
+
+    const expected = {
+      longPlusLong: 2,
+      longPlusDouble: 4.2,
+      doublePlusLong: 6.3,
+      doublePlusDouble: 8.4,
+      longPlusNan: Number.NaN,
+      doublePlusNan: Number.NaN,
+      longPlusInfinity: Number.POSITIVE_INFINITY,
+      doublePlusInfinity: Number.POSITIVE_INFINITY
+    };
+
+    verifyTransform(baseDoc, transform, expected);
+  });
+
+  it('can apply numeric add transform to unexpected type', () => {
+    const baseDoc = { string: 'zero' };
+    const transform = { string: FieldValue.numericAdd(1) };
+    const expected = { string: 1 };
+    verifyTransform(baseDoc, transform, expected);
+  });
+
+  it('can apply numeric add transform to missing field', () => {
+    const baseDoc = {};
+    const transform = { missing: FieldValue.numericAdd(1) };
+    const expected = { missing: 1 };
+    verifyTransform(baseDoc, transform, expected);
+  });
+
+  it('can apply numeric add transforms consecutively', () => {
+    const baseDoc = { number: 1 };
+    const transform1 = { number: FieldValue.numericAdd(2) };
+    const transform2 = { number: FieldValue.numericAdd(3) };
+    const transform3 = { number: FieldValue.numericAdd(4) };
+    const expected = { number: 10 };
+    verifyTransform(baseDoc, [transform1, transform2, transform3], expected);
+  });
+
+  // PORTING NOTE: The `numericAdd()` overflow/underflow tests from Android/iOS
+  // are not applicable to Web since we expose JavaScript's number arithmetic
+  // directly.
+
+  it('can apply server-acked numeric add transform to document', () => {
+    const docData = { sum: 1 };
+    const baseDoc = doc('collection/key', 0, docData);
+    const transform = transformMutation('collection/key', {
+      sum: FieldValue.numericAdd(2)
+    });
+
+    const mutationResult = new MutationResult(version(1), [
+      new IntegerValue(3)
+    ]);
+    const transformedDoc = transform.applyToRemoteDocument(
+      baseDoc,
+      mutationResult
+    );
+
+    expect(transformedDoc).to.deep.equal(
+      doc('collection/key', 1, { sum: 3 }, { hasCommittedMutations: true })
     );
   });
 

--- a/packages/firestore/test/unit/remote/node/serializer.test.ts
+++ b/packages/firestore/test/unit/remote/node/serializer.test.ts
@@ -705,6 +705,24 @@ describe('Serializer', () => {
       verifyMutation(mutation, proto);
     });
 
+    it('TransformMutation (Numeric Add transform)', () => {
+      const mutation = transformMutation('baz/quux', {
+        integer: FieldValue.numericAdd(42),
+        double: FieldValue.numericAdd(13.37)
+      });
+      const proto = {
+        transform: {
+          document: s.toName(mutation.key),
+          fieldTransforms: [
+            { fieldPath: 'integer', numericAdd: { integerValue: '42' } },
+            { fieldPath: 'double', numericAdd: { doubleValue: 13.37 } }
+          ]
+        },
+        currentDocument: { exists: true }
+      };
+      verifyMutation(mutation, proto);
+    });
+
     it('TransformMutation (Array transforms)', () => {
       const mutation = transformMutation('docs/1', {
         a: FieldValue.arrayUnion('a', 2),


### PR DESCRIPTION
Port of https://github.com/firebase/firebase-android-sdk/pull/105

Unlike Android, this PR doesn't treat INT64 overflows, as JavaScript's precision is limited to 53 bit. We likely can't properly expose the full backend semantics our customers, since we eventually surface the results as a `number`. 

This limitation is currently - along with the rest of the API - going through API review. 