### PR TITLE
 Throw a more helpful error if there isn't a 'sub' field

### DIFF
--- a/packages/testing/src/api/index.ts
+++ b/packages/testing/src/api/index.ts
@@ -63,6 +63,9 @@ function createUnsecuredJwt(auth: object): string {
   (auth as any).iat = (auth as any).iat || 0;
   // Use `uid` field as a backup when `sub` is missing.
   (auth as any).sub = (auth as any).sub || (auth as any).uid;
+  if (!(auth as any).sub) {
+    throw new Error("auth must be an object with a 'sub' or 'uid' field");
+  }
   // Unsecured JWTs use the empty string as a signature.
   const signature = '';
   return [

--- a/packages/testing/test/database.test.ts
+++ b/packages/testing/test/database.test.ts
@@ -117,9 +117,9 @@ describe('Testing Module Tests', function() {
 
   it('apps() returns apps created with initializeTestApp', async function() {
     const numApps = firebase.apps().length;
-    await firebase.initializeTestApp({ databaseName: 'foo', auth: {} });
+    await firebase.initializeTestApp({ databaseName: 'foo', auth: null });
     expect(firebase.apps().length).to.equal(numApps + 1);
-    await firebase.initializeTestApp({ databaseName: 'bar', auth: {} });
+    await firebase.initializeTestApp({ databaseName: 'bar', auth: null });
     expect(firebase.apps().length).to.equal(numApps + 2);
   });
 


### PR DESCRIPTION
Right now if you try `firebase.initializeTestApp({ ..., auth: { "email": "ryan@google.com" })` it will be rejected in the emulator because we require a `sub` field. This happens silently and is pretty confusing. I think we should blow up immediately in the client, so developers can figure out what they're doing wrong.