### PR TITLE
Upgrade mocha version to 5.2.0 in all packages.

### DIFF
--- a/integration/browserify/package.json
+++ b/integration/browserify/package.json
@@ -22,6 +22,6 @@
     "karma-sauce-launcher": "1.2.0",
     "karma-spec-reporter": "0.0.32",
     "mkdirp": "0.5.1",
-    "mocha": "5.0.5"
+    "mocha": "5.2.0"
   }
 }

--- a/integration/firestore/package.json
+++ b/integration/firestore/package.json
@@ -21,7 +21,7 @@
     "karma-firefox-launcher": "1.1.0",
     "karma-mocha": "1.3.0",
     "karma-spec-reporter": "0.0.32",
-    "mocha": "5.0.5",
+    "mocha": "5.2.0",
     "ts-loader": "3.5.0",
     "typescript": "2.8.1",
     "webpack": "3.11.0",

--- a/integration/messaging/package.json
+++ b/integration/messaging/package.json
@@ -15,7 +15,7 @@
     "chromedriver": "2.37.0",
     "express": "4.16.3",
     "geckodriver": "1.11.0",
-    "mocha": "5.0.5",
+    "mocha": "5.2.0",
     "node-fetch": "2.1.2",
     "selenium-assistant": "5.3.0",
     "sinon": "4.5.0"

--- a/integration/typescript/package.json
+++ b/integration/typescript/package.json
@@ -23,7 +23,7 @@
     "karma-sauce-launcher": "1.2.0",
     "karma-spec-reporter": "0.0.32",
     "karma-typescript": "3.0.12",
-    "mocha": "5.0.5",
+    "mocha": "5.2.0",
     "npm-run-all": "4.1.2",
     "typescript": "2.8.1"
   }

--- a/integration/webpack/package.json
+++ b/integration/webpack/package.json
@@ -20,7 +20,7 @@
     "karma-mocha": "1.3.0",
     "karma-sauce-launcher": "1.2.0",
     "karma-spec-reporter": "0.0.32",
-    "mocha": "5.0.5",
+    "mocha": "5.2.0",
     "webpack": "3.11.0"
   }
 }

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -42,7 +42,7 @@
     "karma-sourcemap-loader": "0.3.7",
     "karma-spec-reporter": "0.0.32",
     "karma-webpack": "2.0.9",
-    "mocha": "5.0.5",
+    "mocha": "5.2.0",
     "npm-run-all": "4.1.2",
     "nyc": "11.6.0",
     "rollup": "0.57.1",

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -44,7 +44,7 @@
     "karma-sourcemap-loader": "0.3.7",
     "karma-spec-reporter": "0.0.32",
     "karma-webpack": "2.0.9",
-    "mocha": "5.0.5",
+    "mocha": "5.2.0",
     "npm-run-all": "4.1.2",
     "nyc": "11.6.0",
     "rollup": "0.57.1",

--- a/packages/firestore/package.json
+++ b/packages/firestore/package.json
@@ -55,7 +55,7 @@
     "karma-webpack": "2.0.9",
     "long": "3.2.0",
     "mkdirp": "0.5.1",
-    "mocha": "5.0.5",
+    "mocha": "5.2.0",
     "npm-run-all": "4.1.2",
     "nyc": "11.6.0",
     "prettier": "1.12.0",

--- a/packages/functions/package.json
+++ b/packages/functions/package.json
@@ -39,7 +39,7 @@
     "karma-sourcemap-loader": "0.3.7",
     "karma-spec-reporter": "0.0.32",
     "karma-webpack": "2.0.9",
-    "mocha": "5.0.5",
+    "mocha": "5.2.0",
     "npm-run-all": "4.1.2",
     "nyc": "11.6.0",
     "rollup": "0.57.1",

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -31,7 +31,7 @@
     "karma-sauce-launcher": "1.2.0",
     "karma-spec-reporter": "0.0.32",
     "karma-webpack": "2.0.9",
-    "mocha": "5.0.5",
+    "mocha": "5.2.0",
     "npm-run-all": "4.1.2",
     "nyc": "11.6.0",
     "rollup": "0.57.1",

--- a/packages/messaging/package.json
+++ b/packages/messaging/package.json
@@ -43,7 +43,7 @@
     "karma-sauce-launcher": "1.2.0",
     "karma-sourcemap-loader": "0.3.7",
     "karma-spec-reporter": "0.0.32",
-    "mocha": "5.0.5",
+    "mocha": "5.2.0",
     "npm-run-all": "4.1.2",
     "rollup": "0.57.1",
     "rollup-plugin-commonjs": "9.1.0",

--- a/packages/rxfire/package.json
+++ b/packages/rxfire/package.json
@@ -57,7 +57,7 @@
     "karma-sourcemap-loader": "0.3.7",
     "karma-spec-reporter": "0.0.32",
     "karma-webpack": "2.0.9",
-    "mocha": "5.0.5",
+    "mocha": "5.2.0",
     "npm-run-all": "4.1.2",
     "nyc": "11.6.0",
     "sinon": "4.5.0",

--- a/packages/template/package.json
+++ b/packages/template/package.json
@@ -40,7 +40,7 @@
     "karma-sauce-launcher": "1.2.0",
     "karma-spec-reporter": "0.0.32",
     "karma-webpack": "2.0.9",
-    "mocha": "5.0.5",
+    "mocha": "5.2.0",
     "npm-run-all": "4.1.2",
     "nyc": "11.6.0",
     "rollup": "0.57.1",

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "chai": "4.1.2",
     "chai-as-promised": "7.1.1",
-    "mocha": "5.0.5",
+    "mocha": "5.2.0",
     "nyc": "13.1.0",
     "rollup": "0.57.1",
     "rollup-plugin-commonjs": "9.1.0",

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -34,7 +34,7 @@
     "karma-sauce-launcher": "1.2.0",
     "karma-spec-reporter": "0.0.32",
     "karma-webpack": "2.0.9",
-    "mocha": "5.0.5",
+    "mocha": "5.2.0",
     "npm-run-all": "4.1.2",
     "nyc": "11.6.0",
     "rollup": "0.57.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3031,12 +3031,7 @@ command-join@^2.0.0:
   resolved "https://registry.npmjs.org/command-join/-/command-join-2.0.0.tgz#52e8b984f4872d952ff1bdc8b98397d27c7144cf"
   integrity sha1-Uui5hPSHLZUv8b3IuYOX0nxxRM8=
 
-commander@2.11.0:
-  version "2.11.0"
-  resolved "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz#157152fd1e7a6c8d98a5b715cf376df928004563"
-  integrity sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==
-
-commander@^2.12.1, commander@^2.8.1, commander@^2.9.0:
+commander@2.15.1, commander@^2.12.1, commander@^2.8.1, commander@^2.9.0:
   version "2.15.1"
   resolved "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz#df46e867d0fc2aec66a34662b406a9ccafff5b0f"
   integrity sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==
@@ -6086,10 +6081,10 @@ graceful-fs@^4.0.0, graceful-fs@^4.1.0, graceful-fs@^4.1.10, graceful-fs@^4.1.11
   resolved "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz#4cafad76bc62f02fa039b2f94e9a3dd3a391a725"
   integrity sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=
 
-growl@1.10.3:
-  version "1.10.3"
-  resolved "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz#1926ba90cf3edfe2adb4927f5880bc22c66c790f"
-  integrity sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q==
+growl@1.10.5:
+  version "1.10.5"
+  resolved "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz#f2735dc2283674fa67478b10181059355c369e5e"
+  integrity sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==
 
 grpc@1.16.0:
   version "1.16.0"
@@ -8966,7 +8961,7 @@ minimalistic-crypto-utils@^1.0.0, minimalistic-crypto-utils@^1.0.1:
   resolved "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz#f6c00c1c0b082246e5c4d99dfb8c7c083b2b582a"
   integrity sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=
 
-"minimatch@2 || 3", minimatch@^3.0.0, minimatch@^3.0.2, minimatch@^3.0.3, minimatch@^3.0.4:
+"minimatch@2 || 3", minimatch@3.0.4, minimatch@^3.0.0, minimatch@^3.0.2, minimatch@^3.0.3, minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   integrity sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==
@@ -9038,21 +9033,22 @@ mkdirp@0.5.1, mkdirp@0.5.x, mkdirp@0.x.x, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdir
   dependencies:
     minimist "0.0.8"
 
-mocha@5.0.5:
-  version "5.0.5"
-  resolved "https://registry.npmjs.org/mocha/-/mocha-5.0.5.tgz#e228e3386b9387a4710007a641f127b00be44b52"
-  integrity sha512-3MM3UjZ5p8EJrYpG7s+29HAI9G7sTzKEe4+w37Dg0QP7qL4XGsV+Q2xet2cE37AqdgN1OtYQB6Vl98YiPV3PgA==
+mocha@5.2.0:
+  version "5.2.0"
+  resolved "https://registry.npmjs.org/mocha/-/mocha-5.2.0.tgz#6d8ae508f59167f940f2b5b3c4a612ae50c90ae6"
+  integrity sha512-2IUgKDhc3J7Uug+FxMXuqIyYzH7gJjXECKe/w43IGgQHTSj3InJi+yAA7T24L9bQMRKiUEHxEX37G5JpVUGLcQ==
   dependencies:
     browser-stdout "1.3.1"
-    commander "2.11.0"
+    commander "2.15.1"
     debug "3.1.0"
     diff "3.5.0"
     escape-string-regexp "1.0.5"
     glob "7.1.2"
-    growl "1.10.3"
+    growl "1.10.5"
     he "1.1.1"
+    minimatch "3.0.4"
     mkdirp "0.5.1"
-    supports-color "4.4.0"
+    supports-color "5.4.0"
 
 modelo@^4.2.0:
   version "4.2.3"
@@ -12525,12 +12521,12 @@ superstatic@^6.0.1:
     try-require "^1.0.0"
     update-notifier "^2.5.0"
 
-supports-color@4.4.0:
-  version "4.4.0"
-  resolved "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz#883f7ddabc165142b2a61427f3352ded195d1a3e"
-  integrity sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==
+supports-color@5.4.0:
+  version "5.4.0"
+  resolved "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz#1c6b337402c2137605efe19f10fec390f6faab54"
+  integrity sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==
   dependencies:
-    has-flag "^2.0.0"
+    has-flag "^3.0.0"
 
 supports-color@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
We are trying to consolidate flags passed to mocha test into [mocha.opts](https://mochajs.org/#mochaopts). In order to support comments in this file, mocha needs to be upgraded to its latest version (5.2.0 as of 11/09/2018).

See discussion in #1373 for more context.