### PR TITLE
Fix waitsForCount in EventAccumulator (tests)

### DIFF
--- a/packages/database/test/helpers/EventAccumulator.ts
+++ b/packages/database/test/helpers/EventAccumulator.ts
@@ -17,7 +17,7 @@
 export const EventAccumulatorFactory = {
   waitsForCount: maxCount => {
     let count = 0;
-    const condition = () => ea.eventData.length >= count;
+    const condition = () => count >= maxCount;
     const ea = new EventAccumulator(condition);
     ea.onReset(() => {
       count = 0;


### PR DESCRIPTION
The `waitsForCount(count)` helper function for the tests of the realtime database returns an `EventAccumulator` that is supposed to wait for `count` events to happen before resolving its Promise.

The current implementation, though, always resolves its Promise after the very first event no matter how many were specified. This could lead to tests behaving erroneously.

A quick demo to verify this incorrect behavior:
```ts
const ea = EventAccumulatorFactory.waitsForCount(3);

setTimeout(() => {
  console.log('1');
  ea.addEvent();
}, 100);

setTimeout(() => {
  console.log('2');
  ea.addEvent();
}, 200);

setTimeout(() => {
  console.log('3');
  ea.addEvent();
}, 300);

ea.promise.then(() => console.log('done'));
```

This outputs the following:
```
1
done
2
3
```

When it should output this:
```
1
2
3
done
```

This PR fixes this. I've rerun all the tests in the database package after the change and they all keep passing, so I guess we got lucky ¯\\\_(ツ)\_/¯