### PR TITLE
Generate smaller bundles (take 2)

### DIFF
--- a/packages/firebase/rollup.config.js
+++ b/packages/firebase/rollup.config.js
@@ -49,6 +49,20 @@ const plugins = [
 
 const external = Object.keys(pkg.dependencies || {});
 
+const uglifyOptions = {
+  mangle: {
+    properties: {
+      keep_quoted: true,
+      regex: /_$|^_/
+    }
+  },
+  compress: {
+    passes: 3,
+    unsafe: true,
+    warnings: false,
+  }
+};
+
 /**
  * Global UMD Build
  */
@@ -81,7 +95,7 @@ const appBuilds = [
       format: 'umd',
       name: GLOBAL_NAME
     },
-    plugins: [...plugins, uglify()]
+    plugins: [...plugins, uglify(uglifyOptions)]
   }
 ];
 
@@ -138,7 +152,7 @@ const componentBuilds = components
               );
             }`
         },
-        plugins: [...plugins, uglify()],
+        plugins: [...plugins, uglify(component !== 'auth' ? uglifyOptions : {})],
         external: ['@firebase/app']
       }
     ];
@@ -168,7 +182,7 @@ const completeBuilds = [
       format: 'umd',
       name: GLOBAL_NAME
     },
-    plugins: [...plugins, uglify()]
+    plugins: [...plugins, uglify(uglifyOptions)]
   },
   /**
    * App Node.js Builds

--- a/packages/firebase/rollup.config.js
+++ b/packages/firebase/rollup.config.js
@@ -53,7 +53,7 @@ const uglifyOptions = {
   mangle: {
     properties: {
       keep_quoted: true,
-      regex: /_$|^_/
+      regex: /(^_[^_])|([^_]_$)/
     }
   },
   compress: {

--- a/packages/firebase/rollup.config.js
+++ b/packages/firebase/rollup.config.js
@@ -57,9 +57,7 @@ const uglifyOptions = {
     }
   },
   compress: {
-    passes: 3,
-    unsafe: true,
-    warnings: false,
+    passes: 3
   }
 };
 
@@ -152,7 +150,10 @@ const componentBuilds = components
               );
             }`
         },
-        plugins: [...plugins, uglify(component !== 'auth' ? uglifyOptions : {})],
+        plugins: [
+          ...plugins,
+          uglify(component !== 'auth' ? uglifyOptions : {})
+        ],
         external: ['@firebase/app']
       }
     ];


### PR DESCRIPTION
This reapplies the *uglify* optimizations from #94, which were lost after the build process was switched to rollup a while ago.

Here's the size diff compared with the current master:

| File | Before | After | % diff |
|----------|-------------|------|------|
| firebase-app.js | 34.03 KiB | 32.63 KiB | **-4.12%** |
| firebase-database.js | 178.22 KiB | 158.28 KiB | **-11.19%** |
| firebase-firestore.js | 354.32 KiB | 350.68 KiB | **-1.03%** |
| firebase-functions.js | 7.30 KiB | 7.26 KiB | **-0.51%** |
| firebase-messaging.js | 35.01 KiB | 34.11 KiB | **-2.55%** |
| firebase-storage.js | 35.57 KiB | 32.05 KiB | **-9.90%** |
| firebase.js | 779.88 KiB | 751.72 KiB | **-3.61%** |

This change doesn't affect `firebase-auth.js`, since applying these uglify options actually generated a slightly larger bundle for auth. It does apply to the global `firebase.js`, though, which includes auth.

All tests pass.