### PR TITLE
Expose database and firestore namespaces in the @firebase/testing module

### DIFF
--- a/packages/testing/index.ts
+++ b/packages/testing/index.ts
@@ -24,6 +24,8 @@ export {
   apps,
   assertFails,
   assertSucceeds,
+  database,
+  firestore,
   initializeAdminApp,
   initializeTestApp,
   loadDatabaseRules,

--- a/packages/testing/index.ts
+++ b/packages/testing/index.ts
@@ -29,5 +29,5 @@ export {
   initializeAdminApp,
   initializeTestApp,
   loadDatabaseRules,
-  loadFirestoreRules
+  loadFirestoreRules,
 } from './src/api';


### PR DESCRIPTION
We attempted to expose these in https://github.com/firebase/firebase-js-sdk/pull/1332 but neglected to expose them in the package-level API.