### PR TITLE
 Limit gRPC's built-in exponential backoff

### DIFF
--- a/packages/firestore/src/platform_node/grpc_connection.ts
+++ b/packages/firestore/src/platform_node/grpc_connection.ts
@@ -117,10 +117,9 @@ export class GrpcConnection implements Connection {
           this.databaseInfo.host,
           credentials,
           {
-            // gRPC will automatically perform exponential backoff if there is already a connection
-            // to this host. In production this is not an issue because "firestore.googleapis.com"
-            // resolves to many different IPs, so we almost always get a fresh connection. For the
-            // Firestore emulator, which often runs on localhost, this backoff is undesireable.
+            // We do our own connection backoff (that for example is aware of whether or
+            // not a write stream error is permanent or not) so we don't want gRPC to do
+            // backoff on top of that. 100ms is the minimum value that gRPC allows.
             'grpc.max_reconnect_backoff_ms': 100
           }
         ),

--- a/packages/firestore/src/platform_node/grpc_connection.ts
+++ b/packages/firestore/src/platform_node/grpc_connection.ts
@@ -113,7 +113,9 @@ export class GrpcConnection implements Connection {
         ? grpc.credentials.createSsl()
         : grpc.credentials.createInsecure();
       this.cachedStub = {
-        stub: new this.firestore.Firestore(this.databaseInfo.host, credentials),
+        stub: new this.firestore.Firestore(this.databaseInfo.host, credentials, {
+          "grpc.max_reconnect_backoff_ms": 100
+        }),
         token
       };
     }

--- a/packages/firestore/src/platform_node/grpc_connection.ts
+++ b/packages/firestore/src/platform_node/grpc_connection.ts
@@ -120,6 +120,7 @@ export class GrpcConnection implements Connection {
             // We do our own connection backoff (that for example is aware of whether or
             // not a write stream error is permanent or not) so we don't want gRPC to do
             // backoff on top of that. 100ms is the minimum value that gRPC allows.
+            'grpc.initial_reconnect_backoff_ms': 100,
             'grpc.max_reconnect_backoff_ms': 100
           }
         ),

--- a/packages/firestore/src/platform_node/grpc_connection.ts
+++ b/packages/firestore/src/platform_node/grpc_connection.ts
@@ -113,9 +113,17 @@ export class GrpcConnection implements Connection {
         ? grpc.credentials.createSsl()
         : grpc.credentials.createInsecure();
       this.cachedStub = {
-        stub: new this.firestore.Firestore(this.databaseInfo.host, credentials, {
-          "grpc.max_reconnect_backoff_ms": 100
-        }),
+        stub: new this.firestore.Firestore(
+          this.databaseInfo.host,
+          credentials,
+          {
+            // gRPC will automatically perform exponential backoff if there is already a connection
+            // to this host. In production this is not an issue because "firestore.googleapis.com"
+            // resolves to many different IPs, so we almost always get a fresh connection. For the
+            // Firestore emulator, which often runs on localhost, this backoff is undesireable.
+            'grpc.max_reconnect_backoff_ms': 100
+          }
+        ),
         token
       };
     }

--- a/packages/testing/index.ts
+++ b/packages/testing/index.ts
@@ -29,5 +29,5 @@ export {
   initializeAdminApp,
   initializeTestApp,
   loadDatabaseRules,
-  loadFirestoreRules,
+  loadFirestoreRules
 } from './src/api';

--- a/packages/testing/index.ts
+++ b/packages/testing/index.ts
@@ -29,5 +29,5 @@ export {
   initializeAdminApp,
   initializeTestApp,
   loadDatabaseRules,
-  loadFirestoreRules
+  loadFirestoreRules,
 } from './src/api';


### PR DESCRIPTION
When we upgraded to gRPC 1.16.0 (https://github.com/firebase/firebase-js-sdk/pull/1353) we accidentally introduced a performance issue in the Firestore emulator. Somewhere between 1.13.1 and 1.16.0, gRPC implemented exponential backoff on a per-connection basis.

We already implement "smart" backoffs that have knowledge of which error codes are safe to retry immediately and which are not, and the gRPC backoffs are happening underneath them. In production use-cases we're dodging this behavior because we're hitting multiple machines. For the emulator, this is introducing exponential delay for every failed write.