### PR TITLE
Fix error catching for IDBRequest.error.

### DIFF
--- a/packages/auth/src/storage/indexeddb.js
+++ b/packages/auth/src/storage/indexeddb.js
@@ -399,7 +399,7 @@ fireauth.storage.IndexedDB.prototype.onIDBRequest_ =
       }
     };
     request.onerror = function(event) {
-      reject(new Error(event.target.errorCode));
+      reject(event.target.error);
     };
   });
 };
@@ -566,7 +566,7 @@ fireauth.storage.IndexedDB.prototype.sync_ = function() {
               }
             };
             request.onerror = function(event) {
-              reject(new Error(event.target.errorCode));
+              reject(event.target.error);
             };
           });
         }


### PR DESCRIPTION
`event.target.errorCode` is undefined, use event.target.error instead.