### PR TITLE
Fix flaky database transaction test.

### DIFF
--- a/packages/database/test/transaction.test.ts
+++ b/packages/database/test/transaction.test.ts
@@ -878,8 +878,10 @@ describe('Transaction Tests', function() {
   it('Transaction from value callback.', function(done) {
     const ref = getRandomNode() as Reference;
     const COUNT = 1;
+    let transactionsOutstanding = 0;
     ref.on('value', function(snap) {
       let shouldCommit = true;
+      transactionsOutstanding++;
       ref.transaction(
         function(current) {
           if (current == null) {
@@ -889,13 +891,13 @@ describe('Transaction Tests', function() {
           } else {
             shouldCommit = false;
           }
-
-          if (snap.val() === COUNT) {
-            done();
-          }
         },
         function(error, committed, snap) {
           expect(committed).to.equal(shouldCommit);
+          transactionsOutstanding--;
+          if (transactionsOutstanding === 0) {
+            done();
+          }
         }
       );
     });


### PR DESCRIPTION
The test was calling done() while there were still outstanding transactions,
and a subsequent test was calling goOffline(), which then caused the
outstanding transactions to be aborted, leading to the assertion in the
completion callback to fail. This probably only reproduced with the emulator
because it has much less latency than prod.
