### PR TITLE
Allow schema downgrades

### DIFF
--- a/packages/firestore/src/local/indexeddb_persistence.ts
+++ b/packages/firestore/src/local/indexeddb_persistence.ts
@@ -45,7 +45,8 @@ import {
   DbPrimaryClient,
   DbPrimaryClientKey,
   DbTargetDocument,
-  DbTargetGlobal, FIRST_MANUAL_SCHEMA_VERSION,
+  DbTargetGlobal,
+  FIRST_MANUAL_SCHEMA_VERSION,
   SCHEMA_VERSION,
   SchemaConverter
 } from './indexeddb_schema';

--- a/packages/firestore/src/local/indexeddb_persistence.ts
+++ b/packages/firestore/src/local/indexeddb_persistence.ts
@@ -45,7 +45,7 @@ import {
   DbPrimaryClient,
   DbPrimaryClientKey,
   DbTargetDocument,
-  DbTargetGlobal,
+  DbTargetGlobal, FIRST_MANUAL_SCHEMA_VERSION,
   SCHEMA_VERSION,
   SchemaConverter
 } from './indexeddb_schema';
@@ -321,7 +321,8 @@ export class IndexedDbPersistence implements Persistence {
     return SimpleDb.openOrCreate(
       this.dbName,
       SCHEMA_VERSION,
-      new SchemaConverter(this.serializer)
+      new SchemaConverter(this.serializer),
+      FIRST_MANUAL_SCHEMA_VERSION
     )
       .then(db => {
         this.simpleDb = db;

--- a/packages/firestore/src/local/indexeddb_schema.ts
+++ b/packages/firestore/src/local/indexeddb_schema.ts
@@ -318,7 +318,9 @@ function addManualSchemaVersion(
   return writeManualSchemaVersion(txn, FIRST_MANUAL_SCHEMA_VERSION);
 }
 
-function readManualSchemaVersion(txn: SimpleDbTransaction): PersistencePromise<number> {
+function readManualSchemaVersion(
+  txn: SimpleDbTransaction
+): PersistencePromise<number> {
   const store = txn.store<DbVersionGlobalKeyType, DbVersionGlobal>(
     DB_VERSION_GLOBAL_STORE
   );

--- a/packages/firestore/src/local/indexeddb_schema.ts
+++ b/packages/firestore/src/local/indexeddb_schema.ts
@@ -157,7 +157,10 @@ export class SchemaConverter implements SimpleDbSchemaConverter {
     return p;
   }
 
-  doManualMigrations(db: IDBDatabase, toVersion: number): PersistencePromise<void> {
+  doManualMigrations(
+    db: IDBDatabase,
+    toVersion: number
+  ): PersistencePromise<void> {
     return readManualSchemaVersion(db).next(fromVersion => {
       // We don't yet know what migrations will run, and we don't know which ones might be skipped
       // that added object stores that we will need to access. Rather than attempt to pick the exact
@@ -168,7 +171,9 @@ export class SchemaConverter implements SimpleDbSchemaConverter {
       for (let i = 0; i < objectStoreNames.length; i++) {
         objectStores.push(objectStoreNames[i]);
       }
-      const txn = new SimpleDbTransaction(db.transaction(objectStores, 'readwrite'));
+      const txn = new SimpleDbTransaction(
+        db.transaction(objectStores, 'readwrite')
+      );
       return this.upgradeFromManualVersion(txn, fromVersion, toVersion);
     });
   }
@@ -308,7 +313,6 @@ export class SchemaConverter implements SimpleDbSchemaConverter {
   }
 }
 
-
 function addManualSchemaVersion(
   txn: SimpleDbTransaction,
   db: IDBDatabase
@@ -323,10 +327,10 @@ function addManualSchemaVersion(
   return writeManualSchemaVersion(txn, FIRST_MANUAL_SCHEMA_VERSION);
 }
 
-function readManualSchemaVersion(
-  db: IDBDatabase
-): PersistencePromise<number> {
-  const txn = new SimpleDbTransaction(db.transaction(DB_VERSION_GLOBAL_STORE, 'readonly'));
+function readManualSchemaVersion(db: IDBDatabase): PersistencePromise<number> {
+  const txn = new SimpleDbTransaction(
+    db.transaction(DB_VERSION_GLOBAL_STORE, 'readonly')
+  );
   const store = txn.store<DbVersionGlobalKeyType, DbVersionGlobal>(
     DB_VERSION_GLOBAL_STORE
   );

--- a/packages/firestore/src/local/indexeddb_schema.ts
+++ b/packages/firestore/src/local/indexeddb_schema.ts
@@ -685,6 +685,12 @@ export class DbRemoteDocument {
   ) {}
 }
 
+/**
+ * These constants define an object store with a single entry, our current
+ * schema version. We use this, rather than IndexedDB's version so that we can
+ * allow downgrades. The constants are not exported because this should be
+ * internal to the schema migration code.
+ */
 const DB_VERSION_GLOBAL_STORE = 'versionGlobal';
 const DB_VERSION_GLOBAL_KEY = 'versionGlobalKey';
 type DbVersionGlobalKeyType = typeof DB_VERSION_GLOBAL_KEY;

--- a/packages/firestore/src/local/indexeddb_schema.ts
+++ b/packages/firestore/src/local/indexeddb_schema.ts
@@ -324,6 +324,10 @@ export class SchemaConverter implements SimpleDbSchemaConverter {
   }
 }
 
+/**
+ * If the array of stores don't exist, runs the provided function. Throws an error
+ * if only some, but not all, of  the provided stores exist.
+ */
 function ifStoresDontExist(
   db: IDBDatabase,
   stores: string[],

--- a/packages/firestore/src/local/simple_db.ts
+++ b/packages/firestore/src/local/simple_db.ts
@@ -129,9 +129,12 @@ export class SimpleDb {
     schemaConverter: SimpleDbSchemaConverter,
     firstManualVersion = Infinity
   ): Promise<SimpleDb> {
-    return openIndexedDb(name, version, schemaConverter, firstManualVersion).then(
-      db => new SimpleDb(db)
-    );
+    return openIndexedDb(
+      name,
+      version,
+      schemaConverter,
+      firstManualVersion
+    ).then(db => new SimpleDb(db));
   }
 
   /** Deletes the specified database. */

--- a/packages/firestore/src/local/simple_db.ts
+++ b/packages/firestore/src/local/simple_db.ts
@@ -19,7 +19,10 @@ import { Code, FirestoreError } from '../util/error';
 import { debug } from '../util/log';
 import { AnyJs } from '../util/misc';
 import { Deferred } from '../util/promise';
-import { FIRST_MANUAL_SCHEMA_VERSION, SCHEMA_VERSION } from './indexeddb_schema';
+import {
+  FIRST_MANUAL_SCHEMA_VERSION,
+  SCHEMA_VERSION
+} from './indexeddb_schema';
 import { PersistencePromise } from './persistence_promise';
 
 const LOG_TAG = 'SimpleDb';
@@ -32,10 +35,17 @@ export interface SimpleDbSchemaConverter {
     toVersion: number
   ): PersistencePromise<void>;
 
-  doManualMigrations(db: IDBDatabase, toVersion: number): PersistencePromise<void>;
+  doManualMigrations(
+    db: IDBDatabase,
+    toVersion: number
+  ): PersistencePromise<void>;
 }
 
-export function openIndexedDb(name: string, version: number, schemaConverter: SimpleDbSchemaConverter): Promise<IDBDatabase> {
+export function openIndexedDb(
+  name: string,
+  version: number,
+  schemaConverter: SimpleDbSchemaConverter
+): Promise<IDBDatabase> {
   assert(
     SimpleDb.isAvailable(),
     'IndexedDB not supported in current environment.'
@@ -64,7 +74,7 @@ export function openIndexedDb(name: string, version: number, schemaConverter: Si
         new FirestoreError(
           Code.FAILED_PRECONDITION,
           'Cannot upgrade IndexedDB schema while another tab is open. ' +
-          'Close all tabs that access Firestore and reload this page to proceed.'
+            'Close all tabs that access Firestore and reload this page to proceed.'
         )
       );
     };
@@ -85,13 +95,13 @@ export function openIndexedDb(name: string, version: number, schemaConverter: Si
       // API for schema migration operations.
       const txn = new SimpleDbTransaction(request.transaction);
       schemaConverter
-         .createOrUpgrade(db, txn, event.oldVersion, event.newVersion!)
-         .next(() => {
-           debug(
-             LOG_TAG,
-           'Database upgrade to version ' + SCHEMA_VERSION + ' complete'
-           );
-         });
+        .createOrUpgrade(db, txn, event.oldVersion, event.newVersion!)
+        .next(() => {
+          debug(
+            LOG_TAG,
+            'Database upgrade to version ' + SCHEMA_VERSION + ' complete'
+          );
+        });
     };
   });
 }
@@ -110,7 +120,9 @@ export class SimpleDb {
     version: number,
     schemaConverter: SimpleDbSchemaConverter
   ): Promise<SimpleDb> {
-    return openIndexedDb(name, version, schemaConverter).then(db => new SimpleDb(db));
+    return openIndexedDb(name, version, schemaConverter).then(
+      db => new SimpleDb(db)
+    );
   }
 
   /** Deletes the specified database. */

--- a/packages/firestore/test/unit/local/encoded_resource_path.test.ts
+++ b/packages/firestore/test/unit/local/encoded_resource_path.test.ts
@@ -39,6 +39,10 @@ class EncodedResourcePathSchemaConverter implements SimpleDbSchemaConverter {
     db.createObjectStore('test');
     return PersistencePromise.resolve();
   }
+
+  doManualMigrations(db: IDBDatabase, toVersion: number): PersistencePromise<void> {
+    throw new Error('Not yet implemented');
+  }
 }
 
 describe('EncodedResourcePath', () => {

--- a/packages/firestore/test/unit/local/encoded_resource_path.test.ts
+++ b/packages/firestore/test/unit/local/encoded_resource_path.test.ts
@@ -41,7 +41,7 @@ class EncodedResourcePathSchemaConverter implements SimpleDbSchemaConverter {
   }
 
   doManualMigrations(db: IDBDatabase, toVersion: number): PersistencePromise<void> {
-    throw new Error('Not yet implemented');
+    throw new Error('Not implemented');
   }
 }
 

--- a/packages/firestore/test/unit/local/encoded_resource_path.test.ts
+++ b/packages/firestore/test/unit/local/encoded_resource_path.test.ts
@@ -40,7 +40,10 @@ class EncodedResourcePathSchemaConverter implements SimpleDbSchemaConverter {
     return PersistencePromise.resolve();
   }
 
-  doManualMigrations(db: IDBDatabase, toVersion: number): PersistencePromise<void> {
+  doManualMigrations(
+    db: IDBDatabase,
+    toVersion: number
+  ): PersistencePromise<void> {
     throw new Error('Not implemented');
   }
 }

--- a/packages/firestore/test/unit/local/indexeddb_persistence.test.ts
+++ b/packages/firestore/test/unit/local/indexeddb_persistence.test.ts
@@ -49,10 +49,7 @@ import {
 import { LruParams } from '../../../src/local/lru_garbage_collector';
 import { PersistencePromise } from '../../../src/local/persistence_promise';
 import { ClientId } from '../../../src/local/shared_client_state';
-import {
-  openIndexedDb,
-  SimpleDb
-} from '../../../src/local/simple_db';
+import { openIndexedDb, SimpleDb } from '../../../src/local/simple_db';
 import { PlatformSupport } from '../../../src/platform/platform';
 import { JsonProtoSerializer } from '../../../src/remote/serializer';
 import { AsyncQueue } from '../../../src/util/async_queue';

--- a/packages/firestore/test/unit/local/indexeddb_persistence.test.ts
+++ b/packages/firestore/test/unit/local/indexeddb_persistence.test.ts
@@ -37,7 +37,8 @@ import {
   DbTargetGlobal,
   DbTargetGlobalKey,
   DbTargetKey,
-  DbTimestamp, FIRST_MANUAL_SCHEMA_VERSION,
+  DbTimestamp,
+  FIRST_MANUAL_SCHEMA_VERSION,
   SCHEMA_VERSION,
   SchemaConverter,
   V1_STORES,
@@ -48,7 +49,11 @@ import {
 import { LruParams } from '../../../src/local/lru_garbage_collector';
 import { PersistencePromise } from '../../../src/local/persistence_promise';
 import { ClientId } from '../../../src/local/shared_client_state';
-import {openIndexedDb, SimpleDb, SimpleDbTransaction} from '../../../src/local/simple_db';
+import {
+  openIndexedDb,
+  SimpleDb,
+  SimpleDbTransaction
+} from '../../../src/local/simple_db';
 import { PlatformSupport } from '../../../src/platform/platform';
 import { JsonProtoSerializer } from '../../../src/remote/serializer';
 import { AsyncQueue } from '../../../src/util/async_queue';
@@ -67,7 +72,11 @@ function withDb(
   fn: (db: IDBDatabase) => Promise<void>
 ): Promise<void> {
   const schemaConverter = new SchemaConverter(TEST_SERIALIZER);
-  return openIndexedDb(INDEXEDDB_TEST_DATABASE_NAME, schemaVersion, schemaConverter)
+  return openIndexedDb(
+    INDEXEDDB_TEST_DATABASE_NAME,
+    schemaVersion,
+    schemaConverter
+  )
     .then(db => fn(db).then(() => db))
     .then(db => {
       db.close();

--- a/packages/firestore/test/unit/local/indexeddb_persistence.test.ts
+++ b/packages/firestore/test/unit/local/indexeddb_persistence.test.ts
@@ -656,7 +656,8 @@ describe('IndexedDb: canActAsPrimary', () => {
     const simpleDb = await SimpleDb.openOrCreate(
       INDEXEDDB_TEST_DATABASE_NAME,
       SCHEMA_VERSION,
-      new SchemaConverter(TEST_SERIALIZER)
+      new SchemaConverter(TEST_SERIALIZER),
+      FIRST_MANUAL_SCHEMA_VERSION
     );
     await simpleDb.runTransaction('readwrite', [DbPrimaryClient.store], txn => {
       const primaryStore = txn.store<DbPrimaryClientKey, DbPrimaryClient>(
@@ -667,9 +668,7 @@ describe('IndexedDb: canActAsPrimary', () => {
     simpleDb.close();
   }
 
-  beforeEach(() => {
-    return SimpleDb.delete(INDEXEDDB_TEST_DATABASE_NAME);
-  });
+  beforeEach(() => SimpleDb.delete(INDEXEDDB_TEST_DATABASE_NAME));
 
   after(() => SimpleDb.delete(INDEXEDDB_TEST_DATABASE_NAME));
 
@@ -734,7 +733,6 @@ describe('IndexedDb: canActAsPrimary', () => {
           // Clear the current primary holder, since our logic will not revoke
           // the lease until it expires.
           await clearPrimaryLease();
-
           await withPersistence(
             'thisClient',
             async (thisPersistence, thisPlatform, thisQueue) => {

--- a/packages/firestore/test/unit/local/indexeddb_persistence.test.ts
+++ b/packages/firestore/test/unit/local/indexeddb_persistence.test.ts
@@ -51,8 +51,7 @@ import { PersistencePromise } from '../../../src/local/persistence_promise';
 import { ClientId } from '../../../src/local/shared_client_state';
 import {
   openIndexedDb,
-  SimpleDb,
-  SimpleDbTransaction
+  SimpleDb
 } from '../../../src/local/simple_db';
 import { PlatformSupport } from '../../../src/platform/platform';
 import { JsonProtoSerializer } from '../../../src/remote/serializer';

--- a/packages/firestore/test/unit/local/indexeddb_persistence.test.ts
+++ b/packages/firestore/test/unit/local/indexeddb_persistence.test.ts
@@ -71,7 +71,8 @@ function withDb(
   return openIndexedDb(
     INDEXEDDB_TEST_DATABASE_NAME,
     schemaVersion,
-    schemaConverter
+    schemaConverter,
+    FIRST_MANUAL_SCHEMA_VERSION
   )
     .then(db => fn(db).then(() => db))
     .then(db => {
@@ -618,10 +619,7 @@ describe('IndexedDbSchema: createOrUpgradeDb', () => {
           expect(thisVersionStores.contains(store)).to.be.true;
         }
         // Reload the existing stores to check the next version.
-        stores = [];
-        for (let i = 0; i < thisVersionStores.length; i++) {
-          stores.push(thisVersionStores[i]);
-        }
+        stores = Array.from(thisVersionStores);
       });
     }
   });

--- a/packages/firestore/test/unit/local/simple_db.test.ts
+++ b/packages/firestore/test/unit/local/simple_db.test.ts
@@ -77,7 +77,10 @@ class TestSchemaConverter implements SimpleDbSchemaConverter {
     return PersistencePromise.resolve();
   }
 
-  doManualMigrations(db: IDBDatabase, toVersion: number): PersistencePromise<void> {
+  doManualMigrations(
+    db: IDBDatabase,
+    toVersion: number
+  ): PersistencePromise<void> {
     throw new Error('Not implemented');
   }
 }

--- a/packages/firestore/test/unit/local/simple_db.test.ts
+++ b/packages/firestore/test/unit/local/simple_db.test.ts
@@ -76,6 +76,10 @@ class TestSchemaConverter implements SimpleDbSchemaConverter {
     db.createObjectStore('docs');
     return PersistencePromise.resolve();
   }
+
+  doManualMigrations(db: IDBDatabase, toVersion: number): PersistencePromise<void> {
+    throw new Error('Not yet implemented');
+  }
 }
 
 describe('SimpleDb', () => {

--- a/packages/firestore/test/unit/local/simple_db.test.ts
+++ b/packages/firestore/test/unit/local/simple_db.test.ts
@@ -548,7 +548,12 @@ describe('SimpleDb', () => {
     const expectedManualVersion = 20;
     const firstManualVersion = expectedIndexedDbVersion;
     const converter = new TestSchemaConverter();
-    db = await SimpleDb.openOrCreate(dbName, expectedManualVersion, converter, firstManualVersion);
+    db = await SimpleDb.openOrCreate(
+      dbName,
+      expectedManualVersion,
+      converter,
+      firstManualVersion
+    );
     expect(converter.indexedDbVersion).to.equal(expectedIndexedDbVersion);
     expect(converter.manualVersion).to.equal(expectedManualVersion);
   });

--- a/packages/firestore/test/unit/local/simple_db.test.ts
+++ b/packages/firestore/test/unit/local/simple_db.test.ts
@@ -78,7 +78,7 @@ class TestSchemaConverter implements SimpleDbSchemaConverter {
   }
 
   doManualMigrations(db: IDBDatabase, toVersion: number): PersistencePromise<void> {
-    throw new Error('Not yet implemented');
+    throw new Error('Not implemented');
   }
 }
 

--- a/packages/firestore/test/unit/specs/spec_test_runner.ts
+++ b/packages/firestore/test/unit/specs/spec_test_runner.ts
@@ -40,7 +40,7 @@ import {
 import { IndexedDbPersistence } from '../../../src/local/indexeddb_persistence';
 import {
   DbPrimaryClient,
-  DbPrimaryClientKey,
+  DbPrimaryClientKey, FIRST_MANUAL_SCHEMA_VERSION,
   SCHEMA_VERSION,
   SchemaConverter
 } from '../../../src/local/indexeddb_schema';
@@ -1550,7 +1550,8 @@ async function clearCurrentPrimaryLease(): Promise<void> {
   const db = await SimpleDb.openOrCreate(
     INDEXEDDB_TEST_DATABASE_NAME,
     SCHEMA_VERSION,
-    new SchemaConverter(TEST_SERIALIZER)
+    new SchemaConverter(TEST_SERIALIZER),
+    FIRST_MANUAL_SCHEMA_VERSION
   );
   await db.runTransaction('readwrite', [DbPrimaryClient.store], txn => {
     const primaryClientStore = txn.store<DbPrimaryClientKey, DbPrimaryClient>(

--- a/packages/firestore/test/unit/specs/spec_test_runner.ts
+++ b/packages/firestore/test/unit/specs/spec_test_runner.ts
@@ -40,7 +40,8 @@ import {
 import { IndexedDbPersistence } from '../../../src/local/indexeddb_persistence';
 import {
   DbPrimaryClient,
-  DbPrimaryClientKey, FIRST_MANUAL_SCHEMA_VERSION,
+  DbPrimaryClientKey,
+  FIRST_MANUAL_SCHEMA_VERSION,
   SCHEMA_VERSION,
   SchemaConverter
 } from '../../../src/local/indexeddb_schema';


### PR DESCRIPTION
Adds a schema migration that switches to our own schema version number. In the future, we will be able to downgrade as far as this migration. 

Adds a test that we don't delete object stores.

Switches existing migrations to use guards as an example. In practice we can't safely downgrade far enough that they would be necessary.