### PR TITLE
Finish type migration and get rid of AnyDuringMigration

### DIFF
--- a/packages/firestore/src/local/simple_db.ts
+++ b/packages/firestore/src/local/simple_db.ts
@@ -17,7 +17,6 @@
 import { assert } from '../util/assert';
 import { Code, FirestoreError } from '../util/error';
 import { debug } from '../util/log';
-import { AnyDuringMigration } from '../util/misc';
 import { AnyJs } from '../util/misc';
 import { Deferred } from '../util/promise';
 import { SCHEMA_VERSION } from './indexeddb_schema';
@@ -173,6 +172,7 @@ export class SimpleDb {
       .catch(error => {
         // Abort the transaction if there was an error.
         transaction.abort(error);
+        return PersistencePromise.reject<T>(error);
       })
       .toPromise();
 
@@ -181,7 +181,7 @@ export class SimpleDb {
     // caller.
     return transaction.completionPromise.then(
       () => transactionFnResult
-    ) as AnyDuringMigration;
+    );
   }
 
   close(): void {

--- a/packages/firestore/src/local/simple_db.ts
+++ b/packages/firestore/src/local/simple_db.ts
@@ -172,6 +172,10 @@ export class SimpleDb {
       .catch(error => {
         // Abort the transaction if there was an error.
         transaction.abort(error);
+        // We cannot actually recover, and calling `abort()` will cause the transaction's
+        // completion promise to be rejected. This in turn means that we won't use
+        // `transactionFnResult` below. We return a rejection here so that we don't add the
+        // possibility of returning `void` to the type of `transactionFnResult`.
         return PersistencePromise.reject<T>(error);
       })
       .toPromise();

--- a/packages/firestore/src/local/simple_db.ts
+++ b/packages/firestore/src/local/simple_db.ts
@@ -179,9 +179,7 @@ export class SimpleDb {
     // Wait for the transaction to complete (i.e. IndexedDb's onsuccess event to
     // fire), but still return the original transactionFnResult back to the
     // caller.
-    return transaction.completionPromise.then(
-      () => transactionFnResult
-    );
+    return transaction.completionPromise.then(() => transactionFnResult);
   }
 
   close(): void {

--- a/packages/firestore/src/util/misc.ts
+++ b/packages/firestore/src/util/misc.ts
@@ -32,12 +32,6 @@ export type AnyJs = null | undefined | boolean | number | string | object;
  */
 export type Unknown = null | undefined | {} | void;
 
-// TODO(b/66916745): AnyDuringMigration was used to suppress type check failures
-// that were found during the upgrade to TypeScript 2.4. They need to be audited
-// and fixed.
-// tslint:disable-next-line:no-any
-export type AnyDuringMigration = any;
-
 // tslint:disable-next-line:class-as-namespace
 export class AutoId {
   static newId(): string {

--- a/packages/firestore/src/util/promise.ts
+++ b/packages/firestore/src/util/promise.ts
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import { AnyDuringMigration } from './misc';
-
 export interface Resolver<R> {
   (value?: R | Promise<R>): void;
 }
@@ -42,20 +40,17 @@ export class Deferred<R> {
 }
 
 /**
- * Takes an array of values and sequences them using the promise (or value)
- * returned by the supplied callback. The callback for each item is called
- * after the promise is resolved for the previous item.
- * The function returns a promise which is resolved after the promise for
- * the last item is resolved.
+ * Takes an array of values and a function from a value to a Promise. The function is run on each
+ * value sequentially, waiting for the previous promise to resolve before starting the next one.
+ * The returned promise resolves once the function has been run on all values.
  */
-export function sequence<T, R>(
+export function sequence<T>(
   values: T[],
-  fn: (value: T, result?: R) => R | Promise<R>,
-  initialValue?: R
-): Promise<R> {
-  let result = Promise.resolve(initialValue);
-  values.forEach(value => {
-    result = result.then(lastResult => fn(value, lastResult));
-  });
-  return result as AnyDuringMigration;
+  fn: (value: T) => Promise<void>
+): Promise<void> {
+  let p = Promise.resolve();
+  for (const value of values) {
+    p = p.then(() => fn(value));
+  }
+  return p;
 }

--- a/packages/firestore/test/unit/local/test_mutation_queue.ts
+++ b/packages/firestore/test/unit/local/test_mutation_queue.ts
@@ -23,7 +23,6 @@ import { DocumentKeySet } from '../../../src/model/collections';
 import { DocumentKey } from '../../../src/model/document_key';
 import { Mutation } from '../../../src/model/mutation';
 import { MutationBatch } from '../../../src/model/mutation_batch';
-import { AnyDuringMigration } from '../../../src/util/misc';
 
 /**
  * A wrapper around a MutationQueue that automatically creates a
@@ -64,9 +63,15 @@ export class TestMutationQueue {
       'getLastStreamToken',
       'readonly',
       txn => {
-        return this.queue.getLastStreamToken(txn);
+        return this.queue.getLastStreamToken(txn).next(token => {
+          if (typeof token === 'string') {
+            return token;
+          } else {
+            throw new Error('Test mutation queue cannot handle Uint8Arrays');
+          }
+        });
       }
-    ) as AnyDuringMigration;
+    );
   }
 
   setLastStreamToken(streamToken: string): Promise<void> {

--- a/packages/firestore/test/unit/specs/spec_test_runner.ts
+++ b/packages/firestore/test/unit/specs/spec_test_runner.ts
@@ -83,10 +83,7 @@ import {
 import { assert, fail } from '../../../src/util/assert';
 import { AsyncQueue, TimerId } from '../../../src/util/async_queue';
 import { FirestoreError } from '../../../src/util/error';
-import {
-  AnyJs,
-  primitiveComparator
-} from '../../../src/util/misc';
+import { AnyJs, primitiveComparator } from '../../../src/util/misc';
 import * as obj from '../../../src/util/obj';
 import { ObjectMap } from '../../../src/util/obj_map';
 import { Deferred, sequence } from '../../../src/util/promise';

--- a/packages/firestore/test/unit/specs/spec_test_runner.ts
+++ b/packages/firestore/test/unit/specs/spec_test_runner.ts
@@ -156,8 +156,9 @@ class MockConnection implements Connection {
   }
 
   waitForWriteRequest(): Promise<api.WriteRequest> {
-    if (this.earlyWrites.length > 0) {
-      return Promise.resolve(this.earlyWrites.shift()!);
+    const earlyWrite = this.earlyWrites.shift();
+    if (earlyWrite) {
+      return Promise.resolve(earlyWrite);
     }
     const barrier = new Deferred<WriteRequest>();
     this.writeSendBarriers.push(barrier);

--- a/packages/firestore/test/unit/specs/spec_test_runner.ts
+++ b/packages/firestore/test/unit/specs/spec_test_runner.ts
@@ -84,7 +84,6 @@ import { assert, fail } from '../../../src/util/assert';
 import { AsyncQueue, TimerId } from '../../../src/util/async_queue';
 import { FirestoreError } from '../../../src/util/error';
 import {
-  AnyDuringMigration,
   AnyJs,
   primitiveComparator
 } from '../../../src/util/misc';
@@ -161,7 +160,7 @@ class MockConnection implements Connection {
 
   waitForWriteRequest(): Promise<api.WriteRequest> {
     if (this.earlyWrites.length > 0) {
-      return Promise.resolve(this.earlyWrites.shift()) as AnyDuringMigration;
+      return Promise.resolve(this.earlyWrites.shift()!);
     }
     const barrier = new Deferred<WriteRequest>();
     this.writeSendBarriers.push(barrier);


### PR DESCRIPTION
Fixes b/66916745

Of note: `sequence()` was barely being used, so rather than port the declared functionality, I removed what wasn't being used.

