### PR TITLE
Remove some Array to SortedSet<FieldPath> conversion

### DIFF
--- a/packages/firestore/src/api/user_data_converter.ts
+++ b/packages/firestore/src/api/user_data_converter.ts
@@ -56,6 +56,7 @@ import {
   ArrayUnionTransformOperation,
   ServerTimestampTransform
 } from '../model/transform_operation';
+import { SortedSet } from '../util/sorted_set';
 import { Blob } from './blob';
 import {
   FieldPath as ExternalFieldPath,
@@ -339,7 +340,7 @@ export class UserDataConverter {
       fieldMask = FieldMask.fromArray(context.fieldMask);
       fieldTransforms = context.fieldTransforms;
     } else {
-      const validatedFieldPaths: FieldPath[] = [];
+      let validatedFieldPaths = new SortedSet<FieldPath>(FieldPath.comparator);
 
       for (const stringOrFieldPath of fieldPaths) {
         let fieldPath: FieldPath;
@@ -364,10 +365,10 @@ export class UserDataConverter {
           );
         }
 
-        validatedFieldPaths.push(fieldPath);
+        validatedFieldPaths = validatedFieldPaths.add(fieldPath);
       }
 
-      fieldMask = FieldMask.fromArray(validatedFieldPaths);
+      fieldMask = new FieldMask(validatedFieldPaths);
       fieldTransforms = context.fieldTransforms.filter(transform =>
         fieldMask.covers(transform.field)
       );
@@ -388,7 +389,7 @@ export class UserDataConverter {
     );
     validatePlainObject('Data must be an object, but it was:', context, input);
 
-    const fieldMaskPaths = [] as FieldPath[];
+    let fieldMaskPaths = new SortedSet<FieldPath>(FieldPath.comparator);
     let updateData = ObjectValue.EMPTY;
     objUtils.forEach(input as Dict<AnyJs>, (key, value) => {
       const path = fieldPathFromDotSeparatedString(methodName, key);
@@ -397,17 +398,17 @@ export class UserDataConverter {
       value = this.runPreConverter(value, childContext);
       if (value instanceof DeleteFieldValueImpl) {
         // Add it to the field mask, but don't add anything to updateData.
-        fieldMaskPaths.push(path);
+        fieldMaskPaths = fieldMaskPaths.add(path);
       } else {
         const parsedValue = this.parseData(value, childContext);
         if (parsedValue != null) {
-          fieldMaskPaths.push(path);
+          fieldMaskPaths = fieldMaskPaths.add(path);
           updateData = updateData.set(path, parsedValue);
         }
       }
     });
 
-    const mask = FieldMask.fromArray(fieldMaskPaths);
+    const mask = new FieldMask(fieldMaskPaths);
     return new ParsedUpdateData(updateData, mask, context.fieldTransforms);
   }
 
@@ -443,7 +444,7 @@ export class UserDataConverter {
       values.push(moreFieldsAndValues[i + 1]);
     }
 
-    const fieldMaskPaths = [] as FieldPath[];
+    let fieldMaskPaths = new SortedSet<FieldPath>(FieldPath.comparator);
     let updateData = ObjectValue.EMPTY;
 
     for (let i = 0; i < keys.length; ++i) {
@@ -452,17 +453,17 @@ export class UserDataConverter {
       const value = this.runPreConverter(values[i], childContext);
       if (value instanceof DeleteFieldValueImpl) {
         // Add it to the field mask, but don't add anything to updateData.
-        fieldMaskPaths.push(path);
+        fieldMaskPaths = fieldMaskPaths.add(path);
       } else {
         const parsedValue = this.parseData(value, childContext);
         if (parsedValue != null) {
-          fieldMaskPaths.push(path);
+          fieldMaskPaths = fieldMaskPaths.add(path);
           updateData = updateData.set(path, parsedValue);
         }
       }
     }
 
-    const mask = FieldMask.fromArray(fieldMaskPaths);
+    const mask = new FieldMask(fieldMaskPaths);
     return new ParsedUpdateData(updateData, mask, context.fieldTransforms);
   }
 

--- a/packages/firestore/src/api/user_data_converter.ts
+++ b/packages/firestore/src/api/user_data_converter.ts
@@ -368,7 +368,7 @@ export class UserDataConverter {
         validatedFieldPaths = validatedFieldPaths.add(fieldPath);
       }
 
-      fieldMask = new FieldMask(validatedFieldPaths);
+      fieldMask = FieldMask.fromSet(validatedFieldPaths);
       fieldTransforms = context.fieldTransforms.filter(transform =>
         fieldMask.covers(transform.field)
       );
@@ -408,7 +408,7 @@ export class UserDataConverter {
       }
     });
 
-    const mask = new FieldMask(fieldMaskPaths);
+    const mask = FieldMask.fromSet(fieldMaskPaths);
     return new ParsedUpdateData(updateData, mask, context.fieldTransforms);
   }
 
@@ -463,7 +463,7 @@ export class UserDataConverter {
       }
     }
 
-    const mask = new FieldMask(fieldMaskPaths);
+    const mask = FieldMask.fromSet(fieldMaskPaths);
     return new ParsedUpdateData(updateData, mask, context.fieldTransforms);
   }
 

--- a/packages/firestore/src/model/mutation.ts
+++ b/packages/firestore/src/model/mutation.ts
@@ -42,8 +42,12 @@ import { TransformOperation } from './transform_operation';
  *             containing foo
  */
 export class FieldMask {
-  constructor(readonly fields: SortedSet<FieldPath>) {
+  private constructor(readonly fields: SortedSet<FieldPath>) {
     // TODO(dimond): validation of FieldMask
+  }
+
+  static fromSet(fields: SortedSet<FieldPath>): FieldMask {
+    return new FieldMask(fields);
   }
 
   static fromArray(fields: FieldPath[]): FieldMask {

--- a/packages/firestore/src/model/mutation.ts
+++ b/packages/firestore/src/model/mutation.ts
@@ -42,7 +42,7 @@ import { TransformOperation } from './transform_operation';
  *             containing foo
  */
 export class FieldMask {
-  private constructor(readonly fields: SortedSet<FieldPath>) {
+  constructor(readonly fields: SortedSet<FieldPath>) {
     // TODO(dimond): validation of FieldMask
   }
 


### PR DESCRIPTION
There are a couple of places in UserDataConverter that construct an array of FieldPaths, which is then  immediately converted to a SortedSet. This PR directly constructs the SortedSet.

Note that I did not touch the remaining FieldPath array in ParseContext, as it is modified in place and requires a mutable data structure.

See commit https://github.com/firebase/firebase-js-sdk/pull/1368/commits/e62de99269434c4c55389dbb10b87fd645d02d4c#diff-af007bc1ca0cf1509f29df38bed7d308L609 for the rationale. 