### PR TITLE
Added firestoreClearData() testing sdk method

### DIFF
--- a/packages/testing/index.ts
+++ b/packages/testing/index.ts
@@ -24,11 +24,11 @@ export {
   apps,
   assertFails,
   assertSucceeds,
+  clearFirestoreData,
   database,
   firestore,
   initializeAdminApp,
   initializeTestApp,
   loadDatabaseRules,
-  loadFirestoreRules,
-  clearFirestoreData
+  loadFirestoreRules
 } from './src/api';

--- a/packages/testing/index.ts
+++ b/packages/testing/index.ts
@@ -29,5 +29,6 @@ export {
   initializeAdminApp,
   initializeTestApp,
   loadDatabaseRules,
-  loadFirestoreRules
+  loadFirestoreRules,
+  clearFirestoreData
 } from './src/api';

--- a/packages/testing/src/api/index.ts
+++ b/packages/testing/src/api/index.ts
@@ -220,6 +220,44 @@ export function loadFirestoreRules(
   });
 }
 
+export type clearFirestoreDataOptions = {
+  projectId: string;
+  databaseId?: string;
+};
+export function clearFirestoreData(
+  options: clearFirestoreDataOptions
+): Promise<void> {
+  if (!options.projectId) {
+    throw new Error('projectId not specified');
+  }
+
+  const optionsWithDefaults = Object.assign({}, options, {databaseId: '(default)'})
+
+  let client = new EMULATOR.FirestoreEmulator(
+    FIRESTORE_ADDRESS,
+    grpc.credentials.createInsecure(),
+    {
+      // As with 'loadFirestoreRules', cap how much backoff gRPC will perform.
+      'grpc.initial_reconnect_backoff_ms': 100,
+      'grpc.max_reconnect_backoff_ms': 100
+    }
+  );
+  return new Promise((resolve, reject) => {
+    client.clearData(
+      {
+        database: `projects/${optionsWithDefaults.projectId}/databases/${optionsWithDefaults.databaseId}`,
+      },
+      (err, resp) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve(resp);
+        }
+      }
+    );
+  });
+}
+
 export function assertFails(pr: Promise<any>): any {
   return pr.then(
     v =>

--- a/packages/testing/src/api/index.ts
+++ b/packages/testing/src/api/index.ts
@@ -109,10 +109,10 @@ function initializeApp(
 ): firebase.app.App {
   let appOptions = {};
   if (databaseName) {
-    appOptions["databaseURL"] = `http://${DATABASE_ADDRESS}?ns=${databaseName}`;
+    appOptions['databaseURL'] = `http://${DATABASE_ADDRESS}?ns=${databaseName}`;
   }
   if (projectId) {
-    appOptions["projectId"] = projectId;
+    appOptions['projectId'] = projectId;
   }
   const appName = 'app-' + new Date().getTime() + '-' + Math.random();
   let app = firebase.initializeApp(appOptions, appName);
@@ -231,7 +231,9 @@ export function clearFirestoreData(
     throw new Error('projectId not specified');
   }
 
-  const optionsWithDefaults = Object.assign({}, options, {databaseId: '(default)'})
+  const optionsWithDefaults = Object.assign({}, options, {
+    databaseId: '(default)'
+  });
 
   let client = new EMULATOR.FirestoreEmulator(
     FIRESTORE_ADDRESS,
@@ -245,7 +247,9 @@ export function clearFirestoreData(
   return new Promise((resolve, reject) => {
     client.clearData(
       {
-        database: `projects/${optionsWithDefaults.projectId}/databases/${optionsWithDefaults.databaseId}`,
+        database: `projects/${optionsWithDefaults.projectId}/databases/${
+          optionsWithDefaults.databaseId
+        }`
       },
       (err, resp) => {
         if (err) {

--- a/packages/testing/src/api/index.ts
+++ b/packages/testing/src/api/index.ts
@@ -220,11 +220,11 @@ export function loadFirestoreRules(
   });
 }
 
-export type clearFirestoreDataOptions = {
+export type ClearFirestoreDataOptions = {
   projectId: string;
 };
 export function clearFirestoreData(
-  options: clearFirestoreDataOptions
+  options: ClearFirestoreDataOptions
 ): Promise<void> {
   if (!options.projectId) {
     throw new Error('projectId not specified');

--- a/packages/testing/src/api/index.ts
+++ b/packages/testing/src/api/index.ts
@@ -222,7 +222,6 @@ export function loadFirestoreRules(
 
 export type clearFirestoreDataOptions = {
   projectId: string;
-  databaseId?: string;
 };
 export function clearFirestoreData(
   options: clearFirestoreDataOptions
@@ -230,10 +229,6 @@ export function clearFirestoreData(
   if (!options.projectId) {
     throw new Error('projectId not specified');
   }
-
-  const optionsWithDefaults = Object.assign({}, options, {
-    databaseId: '(default)'
-  });
 
   let client = new EMULATOR.FirestoreEmulator(
     FIRESTORE_ADDRESS,
@@ -247,9 +242,7 @@ export function clearFirestoreData(
   return new Promise((resolve, reject) => {
     client.clearData(
       {
-        database: `projects/${optionsWithDefaults.projectId}/databases/${
-          optionsWithDefaults.databaseId
-        }`
+        database: `projects/${options.projectId}/databases/(default)`
       },
       (err, resp) => {
         if (err) {

--- a/packages/testing/test/database.test.ts
+++ b/packages/testing/test/database.test.ts
@@ -115,6 +115,13 @@ describe('Testing Module Tests', function() {
     await expect(promise).to.be.rejectedWith(/UNAVAILABLE/);
   });
 
+  it('clearFirestoreData() succeeds on valid input', async function() {
+    let promise = firebase.clearFirestoreData({
+      projectId: 'foo'
+    });
+    await expect(promise).to.be.rejectedWith(/UNAVAILABLE/);
+  });
+
   it('apps() returns apps created with initializeTestApp', async function() {
     const numApps = firebase.apps().length;
     await firebase.initializeTestApp({ databaseName: 'foo', auth: null });


### PR DESCRIPTION
This PR exposes a new method for the @firebase/testing package to give users the ability to delete their entire database with one call. This is particularly useful in testing frameworks during the before/beforeEach lifecycle phases to isolate each test from one another. This only works with a properly updated Firestore Emulator (>v1.2.4)