### PR TITLE
Upgrade firestore emulator version to v1.2.3.

### DIFF
--- a/scripts/emulator-testing/emulators/firestore-emulator.ts
+++ b/scripts/emulator-testing/emulators/firestore-emulator.ts
@@ -27,6 +27,6 @@ export class FirestoreEmulator extends Emulator {
     // The latest version can be found from firestore emulator doc:
     // https://firebase.google.com/docs/firestore/security/test-rules-emulator
     this.binaryUrl =
-      'https://storage.googleapis.com/firebase-preview-drop/emulator/cloud-firestore-emulator-v1.2.1.jar';
+      'https://storage.googleapis.com/firebase-preview-drop/emulator/cloud-firestore-emulator-v1.2.3.jar';
   }
 }


### PR DESCRIPTION
v1.2.3 helps resolve several kinds of errors in firestore sdk emulator test. See updates in this [doc](https://docs.google.com/document/d/1NF9DGH1bL9OIxQk207aMkA1MOC_zJWOO7uHcizao41U/edit).