### PR TITLE
Treat ABORTED writes as retryable

### DIFF
--- a/packages/firestore/src/remote/remote_store.ts
+++ b/packages/firestore/src/remote/remote_store.ts
@@ -27,7 +27,7 @@ import {
 } from '../model/mutation_batch';
 import { emptyByteString } from '../platform/platform';
 import { assert } from '../util/assert';
-import { Code, FirestoreError } from '../util/error';
+import { FirestoreError } from '../util/error';
 import * as log from '../util/log';
 import * as objUtils from '../util/obj';
 

--- a/packages/firestore/src/remote/rpc_error.ts
+++ b/packages/firestore/src/remote/rpc_error.ts
@@ -48,6 +48,12 @@ enum RpcCode {
   DATA_LOSS = 15
 }
 
+/**
+ * Determines whether an error code represents a permanent error when received
+ * in response to a non-write operation.
+ *
+ * See isPermanentWriteError for classifying write errors.
+ */
 export function isPermanentError(code: Code): boolean {
   switch (code) {
     case Code.OK:
@@ -78,6 +84,22 @@ export function isPermanentError(code: Code): boolean {
     default:
       return fail('Unknown status code: ' + code);
   }
+}
+
+/**
+ * Determines whether an error code represents a permanent error when received
+ * in response to a write operation.
+ *
+ * Write operations must be handled specially because as of b/119437764, ABORTED
+ * errors on the write stream should be retried too (even though ABORTED errors
+ * are not generally retryable).
+ *
+ * Note that during the initial handshake on the write stream an ABORTED error
+ * signals that we should discard our stream token (i.e. it is permanent). This
+ * means a handshake error should be classified with isPermanentError, above.
+ */
+export function isPermanentWriteError(code: Code): boolean {
+  return isPermanentError(code) && code !== Code.ABORTED;
 }
 
 /**

--- a/packages/firestore/test/unit/specs/spec_builder.ts
+++ b/packages/firestore/test/unit/specs/spec_builder.ts
@@ -25,7 +25,7 @@ import {
 import { DocumentKey } from '../../../src/model/document_key';
 import { JsonObject } from '../../../src/model/field_value';
 import {
-  isPermanentError,
+  isPermanentWriteError,
   mapCodeFromRpcCode,
   mapRpcCodeFromCode
 } from '../../../src/remote/rpc_error';
@@ -504,7 +504,8 @@ export class SpecBuilder {
 
     // If this is a permanent error, the write is not expected to be sent
     // again.
-    const isPermanentFailure = isPermanentError(mapCodeFromRpcCode(error.code));
+    const code = mapCodeFromRpcCode(error.code);
+    const isPermanentFailure = isPermanentWriteError(code);
     const keepInQueue =
       options.keepInQueue !== undefined
         ? options.keepInQueue

--- a/packages/firestore/test/unit/specs/write_spec.test.ts
+++ b/packages/firestore/test/unit/specs/write_spec.test.ts
@@ -633,7 +633,6 @@ describeSpec('Writes:', [], () => {
     Code.ALREADY_EXISTS,
     Code.PERMISSION_DENIED,
     Code.FAILED_PRECONDITION,
-    Code.ABORTED,
     Code.OUT_OF_RANGE,
     Code.UNIMPLEMENTED,
     Code.DATA_LOSS
@@ -697,6 +696,7 @@ describeSpec('Writes:', [], () => {
   );
 
   for (const code of [
+    Code.ABORTED,
     Code.CANCELLED,
     Code.UNKNOWN,
     Code.DEADLINE_EXCEEDED,


### PR DESCRIPTION
This corresponds to a server-side change that will be released for the v1 protocol only.