### PR TITLE
Fixes #1450: ThenableReference should extend Promise, not PromiseLike.

### DIFF
--- a/packages/database-types/index.d.ts
+++ b/packages/database-types/index.d.ts
@@ -125,7 +125,7 @@ export interface ServerValue {
   };
 }
 
-export interface ThenableReference extends Reference, PromiseLike<Reference> {}
+export interface ThenableReference extends Reference, Promise<Reference> {}
 
 export function enableLogging(
   logger?: boolean | ((a: string) => any),

--- a/packages/firebase/index.d.ts
+++ b/packages/firebase/index.d.ts
@@ -585,7 +585,7 @@ declare namespace firebase.database {
 
   interface ThenableReference
     extends firebase.database.Reference,
-      PromiseLike<any> {}
+      Promise<Reference> {}
 
   function enableLogging(
     logger?: boolean | ((a: string) => any),


### PR DESCRIPTION
Since we implement .catch(), we should extend Promise.