### PR TITLE
Change timestampsInSnapshots default to true.

### DIFF
--- a/packages/firebase/index.d.ts
+++ b/packages/firebase/index.d.ts
@@ -774,22 +774,24 @@ declare namespace firebase.firestore {
     ssl?: boolean;
 
     /**
-     * Enables the use of `Timestamp`s for timestamp fields in
-     * `DocumentSnapshot`s.
+     * Specifies whether to use `Timestamp` objects for timestamp fields in
+     * `DocumentSnapshot`s. This is enabled by default and should not be
+     * disabled.
      *
-     * Currently, Firestore returns timestamp fields as `Date` but `Date` only
-     * supports millisecond precision, which leads to truncation and causes
-     * unexpected behavior when using a timestamp from a snapshot as a part
-     * of a subsequent query.
+     * Previously, Firestore returned timestamp fields as `Date` but `Date`
+     * only supports millisecond precision, which leads to truncation and
+     * causes unexpected behavior when using a timestamp from a snapshot as a
+     * part of a subsequent query.
      *
-     * Setting `timestampsInSnapshots` to true will cause Firestore to return
-     * `Timestamp` values instead of `Date` avoiding this kind of problem. To make
-     * this work you must also change any code that uses `Date` to use `Timestamp`
-     * instead.
+     * So now Firestore returns `Timestamp` values instead of `Date`, avoiding
+     * this kind of problem.
      *
-     * NOTE: in the future `timestampsInSnapshots: true` will become the
-     * default and this option will be removed so you should change your code to
-     * use Timestamp now and opt-in to this new behavior as soon as you can.
+     * To opt into the old behavior of returning `Date` objects, you can
+     * temporarily set `timestampsInSnapshots` to false.
+     *
+     * WARNING: This setting will be removed in a future release. You should
+     * update your code to expect `Timestamp` objects and stop using the
+     * `timestampsInSnapshots` setting.
      */
     timestampsInSnapshots?: boolean;
 

--- a/packages/firebase/index.d.ts
+++ b/packages/firebase/index.d.ts
@@ -789,7 +789,7 @@ declare namespace firebase.firestore {
      * To opt into the old behavior of returning `Date` objects, you can
      * temporarily set `timestampsInSnapshots` to false.
      *
-     * WARNING: This setting will be removed in a future release. You should
+     * @deprecated This setting will be removed in a future release. You should
      * update your code to expect `Timestamp` objects and stop using the
      * `timestampsInSnapshots` setting.
      */

--- a/packages/firestore-types/index.d.ts
+++ b/packages/firestore-types/index.d.ts
@@ -59,7 +59,7 @@ export interface Settings {
    * To opt into the old behavior of returning `Date` objects, you can
    * temporarily set `timestampsInSnapshots` to false.
    *
-   * WARNING: This setting will be removed in a future release. You should
+   * @deprecated This setting will be removed in a future release. You should
    * update your code to expect `Timestamp` objects and stop using the
    * `timestampsInSnapshots` setting.
    */

--- a/packages/firestore-types/index.d.ts
+++ b/packages/firestore-types/index.d.ts
@@ -44,22 +44,24 @@ export interface Settings {
   ssl?: boolean;
 
   /**
-   * Enables the use of `Timestamp`s for timestamp fields in
-   * `DocumentSnapshot`s.
+   * Specifies whether to use `Timestamp` objects for timestamp fields in
+   * `DocumentSnapshot`s. This is enabled by default and should not be
+   * disabled.
    *
-   * Currently, Firestore returns timestamp fields as `Date` but `Date` only
+   * Previously, Firestore returned timestamp fields as `Date` but `Date` only
    * supports millisecond precision, which leads to truncation and causes
-   * unexpected behavior when using a timestamp from a snapshot as a part
-   * of a subsequent query.
+   * unexpected behavior when using a timestamp from a snapshot as a part of a
+   * subsequent query.
    *
-   * Setting `timestampsInSnapshots` to true will cause Firestore to return
-   * `Timestamp` values instead of `Date` avoiding this kind of problem. To make
-   * this work you must also change any code that uses `Date` to use `Timestamp`
-   * instead.
+   * So now Firestore returns `Timestamp` values instead of `Date`, avoiding
+   * this kind of problem.
    *
-   * NOTE: in the future `timestampsInSnapshots: true` will become the
-   * default and this option will be removed so you should change your code to
-   * use Timestamp now and opt-in to this new behavior as soon as you can.
+   * To opt into the old behavior of returning `Date` objects, you can
+   * temporarily set `timestampsInSnapshots` to false.
+   *
+   * WARNING: This setting will be removed in a future release. You should
+   * update your code to expect `Timestamp` objects and stop using the
+   * `timestampsInSnapshots` setting.
    */
   timestampsInSnapshots?: boolean;
 

--- a/packages/firestore/CHANGELOG.md
+++ b/packages/firestore/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Unreleased
 - [changed] The `timestampsInSnapshots` setting is now enabled by default
   so timestamp fields read from a `DocumentSnapshot` will be returned as
-  `Timestamp` objects instead of `Date`. Any cexpecting to receive a
+  `Timestamp` objects instead of `Date`. Any code expecting to receive a
   `Date` object must be updated.
 
 # 0.9.2

--- a/packages/firestore/CHANGELOG.md
+++ b/packages/firestore/CHANGELOG.md
@@ -1,4 +1,10 @@
 # Unreleased
+- [changed] The `timestampsInSnapshots` setting is now enabled by default
+  so timestamp fields read from a `DocumentSnapshot` will be returned as
+  `Timestamp` objects instead of `Date`. Any cexpecting to receive a
+  `Date` object must be updated.
+
+# 0.9.2
 - [fixed] Fixed a regression introduced in 5.7.0 that caused apps using
   experimentalTabSynchronization to hit an exception for "Failed to obtain
   primary lease for action 'Collect garbage'".
@@ -48,7 +54,7 @@
 - [changed] Eliminated superfluous update events for locally cached documents
   that are known to lag behind the server version. Instead, we buffer these
   events until the client has caught up with the server.
-  
+
 # 0.7.2
 - [fixed] Fixed a regression that prevented use of Firestore on ReactNative's
   Expo platform (#1138).

--- a/packages/firestore/karma.conf.js
+++ b/packages/firestore/karma.conf.js
@@ -61,13 +61,11 @@ function getFirestoreSettings(argv) {
     return {
       host: 'localhost:8080',
       ssl: false,
-      timestampsInSnapshots: true
     };
   } else {
     return {
       host: 'firestore.googleapis.com',
       ssl: true,
-      timestampsInSnapshots: true
     };
   }
 }

--- a/packages/firestore/src/model/field_value.ts
+++ b/packages/firestore/src/model/field_value.ts
@@ -329,7 +329,7 @@ export class TimestampValue extends FieldValue {
   }
 
   value(options?: FieldValueOptions): Date | Timestamp {
-    if (options && options.timestampsInSnapshots) {
+    if (!options || options.timestampsInSnapshots) {
       return this.internalValue;
     } else {
       return this.internalValue.toDate();

--- a/packages/firestore/test/integration/api/fields.test.ts
+++ b/packages/firestore/test/integration/api/fields.test.ts
@@ -351,7 +351,7 @@ apiDescribe('Timestamp Fields in snapshots', persistence => {
     return { timestamp: ts, nested: { timestamp2: ts } };
   };
 
-  it('are returned as native dates if timestampsInSnapshots is not set', () => {
+  it('are returned as native dates if timestampsInSnapshots set to false', () => {
     // Avoid the verbose log message triggered by timestampsInSnapshots ==
     // false.
     const logLevel = log.getLogLevel();
@@ -386,8 +386,6 @@ apiDescribe('Timestamp Fields in snapshots', persistence => {
   });
 
   it('are returned as Timestamps', () => {
-    expect(DEFAULT_SETTINGS['timestampsInSnapshots']).to.equal(true);
-
     const timestamp = new Timestamp(100, 123456000);
     // Timestamps are currently truncated to microseconds after being written to
     // the database, so a truncated version of the timestamp is needed for

--- a/packages/firestore/test/integration/util/helpers.ts
+++ b/packages/firestore/test/integration/util/helpers.ts
@@ -34,13 +34,11 @@ export const USE_EMULATOR = !!EMULATOR_PORT;
 const EMULATOR_FIRESTORE_SETTING = {
   host: `localhost:${EMULATOR_PORT}`,
   ssl: false,
-  timestampsInSnapshots: true
 };
 
 const PROD_FIRESTORE_SETTING = {
   host: 'firestore.googleapis.com',
   ssl: true,
-  timestampsInSnapshots: true
 };
 
 export const DEFAULT_SETTINGS = getDefaultSettings();

--- a/packages/firestore/test/unit/model/field_value.test.ts
+++ b/packages/firestore/test/unit/model/field_value.test.ts
@@ -118,8 +118,8 @@ describe('FieldValue', () => {
     expect(dateValue1).to.be.an.instanceof(fieldValue.TimestampValue);
     expect(dateValue2).to.be.an.instanceof(fieldValue.TimestampValue);
 
-    expect(dateValue1.value()).to.deep.equal(date1);
-    expect(dateValue2.value()).to.deep.equal(date2);
+    expect(dateValue1.value()).to.deep.equal(Timestamp.fromDate(date1));
+    expect(dateValue2.value()).to.deep.equal(Timestamp.fromDate(date2));
   });
 
   it('can parse geo points', () => {

--- a/packages/firestore/test/util/api_helpers.ts
+++ b/packages/firestore/test/util/api_helpers.ts
@@ -47,7 +47,6 @@ export const FIRESTORE = new Firestore({
 });
 
 export function firestore(): Firestore {
-  FIRESTORE.settings({ timestampsInSnapshots: true });
   return FIRESTORE;
 }
 

--- a/packages/rxfire/test/firestore.test.ts
+++ b/packages/rxfire/test/firestore.test.ts
@@ -83,7 +83,6 @@ describe('RxFire Firestore', () => {
   beforeEach(() => {
     app = initializeApp({ projectId: TEST_PROJECT.projectId });
     firestore = app.firestore();
-    firestore.settings({ timestampsInSnapshots: true });
     firestore.disableNetwork();
   });
 

--- a/packages/testing/src/api/index.ts
+++ b/packages/testing/src/api/index.ts
@@ -132,7 +132,6 @@ function initializeApp(
     app.firestore().settings({
       host: FIRESTORE_ADDRESS,
       ssl: false,
-      timestampsInSnapshots: true
     });
   }
   /**


### PR DESCRIPTION
Also update log messages instructing folks what to do if they're using the
soon-to-be-removed timestampsInSnapshots setting.