### PR TITLE
Change downloaded emulator file mode to 'rwxr-xr-x'.

### DIFF
--- a/scripts/emulator-testing/emulators/emulator.ts
+++ b/scripts/emulator-testing/emulators/emulator.ts
@@ -51,8 +51,12 @@ export abstract class Emulator {
           .pipe(writeStream)
           .on('finish', () => {
             console.log(`Saved emulator binary file to [${filepath}].`);
-            this.binaryPath = filepath;
-            resolve();
+            fs.chmod(filepath, 0o755, err => {
+              if (err) reject(err);
+              console.log(`Changed emulator file permissions to 'rwxr-xr-x'.`);
+              this.binaryPath = filepath;
+              resolve();
+            });
           })
           .on('error', reject);
       });

--- a/scripts/emulator-testing/emulators/emulator.ts
+++ b/scripts/emulator-testing/emulators/emulator.ts
@@ -51,6 +51,9 @@ export abstract class Emulator {
           .pipe(writeStream)
           .on('finish', () => {
             console.log(`Saved emulator binary file to [${filepath}].`);
+            // Change emulator binary file permission to 'rwxr-xr-x'.
+            // The execute permission is required for it to be able to start
+            // with 'java -jar'.
             fs.chmod(filepath, 0o755, err => {
               if (err) reject(err);
               console.log(`Changed emulator file permissions to 'rwxr-xr-x'.`);


### PR DESCRIPTION
The firestore emulator binary file cannot be started by 'java -jar' with
permission 'rw-r--r--' on Google corp workstation (Debian). The reason
why we didn't notice this before is that the emulator can run on macbook
(macOS Mojave) and Travis VM (Ubuntu Trusty) perfectly without this
change though.