### PR TITLE
Break import cycle

### DIFF
--- a/packages/firestore/src/local/lru_garbage_collector.ts
+++ b/packages/firestore/src/local/lru_garbage_collector.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import { CACHE_SIZE_UNLIMITED } from '../api/database';
 import { ListenSequence } from '../core/listen_sequence';
 import { ListenSequenceNumber } from '../core/types';
 import { assert } from '../util/assert';
@@ -235,7 +234,7 @@ export class LruScheduler {
     );
     if (
       this.garbageCollector.params.cacheSizeCollectionThreshold !==
-      CACHE_SIZE_UNLIMITED
+      LruParams.COLLECTION_DISABLED
     ) {
       this.scheduleGC();
     }


### PR DESCRIPTION
LruParams.COLLECTION_DISABLED <=> CACHE_SIZE_UNLIMITED

This allows `packages/firestore/test/unit/generate_spec_json.sh` to work without failure.