### PR TITLE
Prettier prepush improvements

### DIFF
--- a/tools/gitHooks/prettier.js
+++ b/tools/gitHooks/prettier.js
@@ -64,9 +64,7 @@ async function doPrettierCommit() {
   }
   const diff = await git.diff(['--name-only', 'origin/master...HEAD']);
   // Only run on .js or .ts files.
-  const targetFiles = diff
-    .split('\n')
-    .filter(line => line.match(/(js|ts)$/));
+  const targetFiles = diff.split('\n').filter(line => line.match(/(js|ts)$/));
   if (targetFiles.length === 0) return;
 
   const stylingSpinner = ora(

--- a/tools/gitHooks/prettier.js
+++ b/tools/gitHooks/prettier.js
@@ -20,6 +20,7 @@ const fs = require('mz/fs');
 const glob = require('glob');
 const simpleGit = require('simple-git/promise');
 const ora = require('ora');
+const chalk = require('chalk');
 
 // Computed Deps
 const root = resolve(__dirname, '../..');
@@ -39,11 +40,13 @@ function checkVersion() {
       const runtimeVersion = data.toString().trim();
       const packageVersion = packageJson.devDependencies.prettier;
       if (packageVersion !== runtimeVersion) {
-        reject(
-          `Installed version of prettier (${runtimeVersion}) ` +
-            `does not match required version (${packageVersion}). Please upgrade ` +
-            `and try running again.`
-        );
+        const versionMismatchMessage = chalk`
+          {red Installed version of prettier (${
+            runtimeVersion}) does not match required version (${packageVersion}).}
+          
+          {yellow Please re-run {reset 'yarn'} from the root of the repo and try again.}
+          `;
+        reject(versionMismatchMessage);
       }
       resolvePromise();
     });
@@ -55,7 +58,7 @@ async function doPrettierCommit() {
     await checkVersion();
   } catch (e) {
     console.error(e);
-    return;
+    return process.exit(1);
   }
   const diff = await git.diff(['--name-only', 'origin/master']);
   const targetFiles = diff.split('\n').filter(line => line);

--- a/tools/gitHooks/prettier.js
+++ b/tools/gitHooks/prettier.js
@@ -24,12 +24,49 @@ const ora = require('ora');
 // Computed Deps
 const root = resolve(__dirname, '../..');
 const git = simpleGit(root);
+const packageJson = require(root + '/package.json');
+
+function checkVersion() {
+  return new Promise((resolvePromise, reject) => {
+    const versionCheckCommand = spawn('prettier', ['--version'], {
+      stdio: ['ignore', 'pipe', process.stderr],
+      cwd: root,
+      env: {
+        PATH: `${resolve(root, 'node_modules/.bin')}:${process.env.PATH}`
+      }
+    }).catch(e => reject(e));
+    versionCheckCommand.childProcess.stdout.on('data', data => {
+      const runtimeVersion = data.toString().trim();
+      const packageVersion = packageJson.devDependencies.prettier;
+      if (packageVersion !== runtimeVersion) {
+        reject(
+          `Installed version of prettier (${runtimeVersion}) ` +
+            `does not match required version (${packageVersion}). Please upgrade ` +
+            `and try running again.`
+        );
+      }
+      resolvePromise();
+    });
+  });
+}
 
 async function doPrettierCommit() {
-  const stylingSpinner = ora(' Formatting code with prettier').start();
+  try {
+    await checkVersion();
+  } catch (e) {
+    console.error(e);
+    return;
+  }
+  const diff = await git.diff(['--name-only', 'origin/master']);
+  const targetFiles = diff.split('\n').filter(line => line);
+  if (targetFiles.length === 0) return;
+
+  const stylingSpinner = ora(
+    ` Formatting ${targetFiles.length} files with prettier`
+  ).start();
   await spawn(
     'prettier',
-    ['--config', `${resolve(root, '.prettierrc')}`, '--write', '**/*.{ts,js}'],
+    ['--config', `${resolve(root, '.prettierrc')}`, '--write', ...targetFiles],
     {
       stdio: ['ignore', 'ignore', process.stderr],
       cwd: root,
@@ -41,10 +78,6 @@ async function doPrettierCommit() {
   stylingSpinner.stopAndPersist({
     symbol: '✅'
   });
-
-  const hasDiff = await git.diff();
-
-  if (!hasDiff) return;
 
   const gitSpinner = ora(' Creating automated style commit').start();
   await git.add('.');

--- a/tools/gitHooks/prettier.js
+++ b/tools/gitHooks/prettier.js
@@ -79,6 +79,10 @@ async function doPrettierCommit() {
     symbol: '✅'
   });
 
+  const hasDiff = await git.diff();
+
+  if (!hasDiff) return;
+
   const gitSpinner = ora(' Creating automated style commit').start();
   await git.add('.');
 

--- a/tools/gitHooks/prettier.js
+++ b/tools/gitHooks/prettier.js
@@ -41,8 +41,7 @@ function checkVersion() {
       const packageVersion = packageJson.devDependencies.prettier;
       if (packageVersion !== runtimeVersion) {
         const versionMismatchMessage = chalk`
-          {red Installed version of prettier (${
-            runtimeVersion}) does not match required version (${packageVersion}).}
+          {red Installed version of prettier (${runtimeVersion}) does not match required version (${packageVersion}).}
           
           {yellow Please re-run {reset 'yarn'} from the root of the repo and try again.}
           `;

--- a/tools/gitHooks/prettier.js
+++ b/tools/gitHooks/prettier.js
@@ -40,8 +40,11 @@ function checkVersion() {
       const runtimeVersion = data.toString().trim();
       const packageVersion = packageJson.devDependencies.prettier;
       if (packageVersion !== runtimeVersion) {
+        const mismatchText =
+          `Installed version of prettier (${runtimeVersion}) does not match ` +
+          `required version (${packageVersion}).`;
         const versionMismatchMessage = chalk`
-          {red Installed version of prettier (${runtimeVersion}) does not match required version (${packageVersion}).}
+          {red ${mismatchText}}
           
           {yellow Please re-run {reset 'yarn'} from the root of the repo and try again.}
           `;
@@ -60,7 +63,10 @@ async function doPrettierCommit() {
     return process.exit(1);
   }
   const diff = await git.diff(['--name-only', 'origin/master']);
-  const targetFiles = diff.split('\n').filter(line => line);
+  // Only run on .js or .ts files.
+  const targetFiles = diff
+    .split('\n')
+    .filter(line => line.match(/^.+\.(js|ts)$/));
   if (targetFiles.length === 0) return;
 
   const stylingSpinner = ora(

--- a/tools/gitHooks/prettier.js
+++ b/tools/gitHooks/prettier.js
@@ -62,7 +62,7 @@ async function doPrettierCommit() {
     console.error(e);
     return process.exit(1);
   }
-  const diff = await git.diff(['--name-only', 'origin/master']);
+  const diff = await git.diff(['--name-only', 'origin/master...HEAD']);
   // Only run on .js or .ts files.
   const targetFiles = diff
     .split('\n')

--- a/tools/gitHooks/prettier.js
+++ b/tools/gitHooks/prettier.js
@@ -66,7 +66,7 @@ async function doPrettierCommit() {
   // Only run on .js or .ts files.
   const targetFiles = diff
     .split('\n')
-    .filter(line => line.match(/^.+\.(js|ts)$/));
+    .filter(line => line.match(/(js|ts)$/));
   if (targetFiles.length === 0) return;
 
   const stylingSpinner = ora(


### PR DESCRIPTION
Making some suggested changes to prettier prepush per #531.

- Check that user's version of prettier matches that specified in project package.json and if not, bail out with message to upgrade.
- Run only on changed files using `git diff --name-only origin/master`.