### PR TITLE
Run prettier on the whole codebase

### DIFF
--- a/packages/firestore/karma.conf.js
+++ b/packages/firestore/karma.conf.js
@@ -60,12 +60,12 @@ function getFirestoreSettings(argv) {
   if (argv.local) {
     return {
       host: 'localhost:8080',
-      ssl: false,
+      ssl: false
     };
   } else {
     return {
       host: 'firestore.googleapis.com',
-      ssl: true,
+      ssl: true
     };
   }
 }

--- a/packages/firestore/test/integration/util/helpers.ts
+++ b/packages/firestore/test/integration/util/helpers.ts
@@ -33,12 +33,12 @@ export const USE_EMULATOR = !!EMULATOR_PORT;
 
 const EMULATOR_FIRESTORE_SETTING = {
   host: `localhost:${EMULATOR_PORT}`,
-  ssl: false,
+  ssl: false
 };
 
 const PROD_FIRESTORE_SETTING = {
   host: 'firestore.googleapis.com',
-  ssl: true,
+  ssl: true
 };
 
 export const DEFAULT_SETTINGS = getDefaultSettings();

--- a/packages/testing/src/api/index.ts
+++ b/packages/testing/src/api/index.ts
@@ -131,7 +131,7 @@ function initializeApp(
   if (projectId) {
     app.firestore().settings({
       host: FIRESTORE_ADDRESS,
-      ssl: false,
+      ssl: false
     });
   }
   /**


### PR DESCRIPTION
prettier runs on the entire codebase (until https://github.com/firebase/firebase-js-sdk/pull/1480 is merged) which can result in spurious diffs (example: https://github.com/firebase/firebase-js-sdk/pull/1479)

this is just bringing the codebase up to spec