### PR TITLE
Include empty import types file for NPM installation

### DIFF
--- a/packages/firebase/package.json
+++ b/packages/firebase/package.json
@@ -19,6 +19,7 @@
     "/firebase*.js",
     "/firebase*.map",
     "/index.d.ts",
+    "/empty-import.d.ts",
     "/externs"
   ],
   "repository": {


### PR DESCRIPTION
Adds the file `empty-import.d.ts` to the npm installation and fixes missing line from #1347.
