### PR TITLE
Allow skipping packages in a release

### DIFF
--- a/scripts/release/cli.js
+++ b/scripts/release/cli.js
@@ -138,6 +138,15 @@ const { argv } = require('yargs');
       versions = await prompt(versionUpdates);
 
       /**
+       * Remove the skipped packages
+       */
+      Object.keys(versions).forEach(name => {
+        if (versions[name] === 'skip') {
+          delete versions[name];
+        }
+      });
+      
+      /**
        * Verify that the versions selected are correct
        */
       const { versionCheck } = await prompt(validateVersions(versions));

--- a/scripts/release/cli.js
+++ b/scripts/release/cli.js
@@ -145,7 +145,7 @@ const { argv } = require('yargs');
           delete versions[name];
         }
       });
-      
+
       /**
        * Verify that the versions selected are correct
        */

--- a/scripts/release/utils/inquirer.js
+++ b/scripts/release/utils/inquirer.js
@@ -112,7 +112,7 @@ exports.packageVersionUpdate = async (package, releaseType) => {
    * Lerna doesn't work well with merge commits and may mark a package as changed
    * even though it's not changed except for the version bump from the last release.
    * https://github.com/lerna/lerna/issues/1377
-   * 
+   *
    * Background:
    * We introduced a release branch as a staging area for the next release
    * while development continues in the master branch. Eventually we publish the packages from

--- a/scripts/release/utils/inquirer.js
+++ b/scripts/release/utils/inquirer.js
@@ -111,7 +111,8 @@ exports.packageVersionUpdate = async (package, releaseType) => {
    * Reason:
    * Lerna doesn't work well with merge commits and may mark a package as changed
    * even though it's not changed except for the version bump from the last release.
-   *
+   * https://github.com/lerna/lerna/issues/1377
+   * 
    * Background:
    * We introduced a release branch as a staging area for the next release
    * while development continues in the master branch. Eventually we publish the packages from

--- a/scripts/release/utils/inquirer.js
+++ b/scripts/release/utils/inquirer.js
@@ -106,6 +106,29 @@ exports.packageVersionUpdate = async (package, releaseType) => {
   }
 
   /**
+   * Skip a pacakage
+   *
+   * Reason:
+   * Lerna doesn't work well with merge commits and may mark a package as changed
+   * even though it's not changed except for the version bump from the last release.
+   *
+   * Background:
+   * We introduced a release branch as a staging area for the next release
+   * while development continues in the master branch. Eventually we publish the packages from
+   * the release branch and make the version bumps in package.json and tags. It creats a merge
+   * commit in the master branch when we merge the release branch back.
+   *
+   * Only skip a package if you are sure Lerna listed the package in mistake.
+   * If you skipped a package, it won't show up in the candidate list going forward
+   * unless additional changes are made in this package.
+   *
+   */
+  choices.push({
+    name: chalk`Skip`,
+    value: 'skip'
+  });
+
+  /**
    * Create prompts
    */
   return {


### PR DESCRIPTION
Reason:
   Lerna doesn't work well with merge commits and may mark a package as changed even though it's not changed except for the version bump from the last release.

Background:
   We introduced a release branch as a staging area for the next release while development continues in the master branch. Eventually we publish the packages from the release branch and make the version bumps in package.json and tags. It creates a merge commit in the master branch when we merge the release branch back.
