### PR TITLE
Add @license tags

### DIFF
--- a/integration/browserify/karma.conf.js
+++ b/integration/browserify/karma.conf.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/integration/browserify/karma.conf.js
+++ b/integration/browserify/karma.conf.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/integration/browserify/src/namespace.test.js
+++ b/integration/browserify/src/namespace.test.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/integration/browserify/src/namespace.test.js
+++ b/integration/browserify/src/namespace.test.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/integration/firebase-typings/index.submodules.ts
+++ b/integration/firebase-typings/index.submodules.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/integration/firebase-typings/index.submodules.ts
+++ b/integration/firebase-typings/index.submodules.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/integration/firebase-typings/index.ts
+++ b/integration/firebase-typings/index.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/integration/firebase-typings/index.ts
+++ b/integration/firebase-typings/index.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/integration/firestore/gulpfile.js
+++ b/integration/firestore/gulpfile.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/integration/firestore/gulpfile.js
+++ b/integration/firestore/gulpfile.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/integration/firestore/karma.conf.js
+++ b/integration/firestore/karma.conf.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/integration/firestore/karma.conf.js
+++ b/integration/firestore/karma.conf.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/integration/messaging/download-browsers.js
+++ b/integration/messaging/download-browsers.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/integration/messaging/download-browsers.js
+++ b/integration/messaging/download-browsers.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/integration/messaging/manual-test-server.js
+++ b/integration/messaging/manual-test-server.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/integration/messaging/manual-test-server.js
+++ b/integration/messaging/manual-test-server.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/integration/messaging/test/static/app.js
+++ b/integration/messaging/test/static/app.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/integration/messaging/test/static/app.js
+++ b/integration/messaging/test/static/app.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/integration/messaging/test/static/firebase-messaging-sw.js
+++ b/integration/messaging/test/static/firebase-messaging-sw.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/integration/messaging/test/static/firebase-messaging-sw.js
+++ b/integration/messaging/test/static/firebase-messaging-sw.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/integration/messaging/test/static/sw-shared.js
+++ b/integration/messaging/test/static/sw-shared.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/integration/messaging/test/static/sw-shared.js
+++ b/integration/messaging/test/static/sw-shared.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/integration/messaging/test/static/valid-no-vapid-key/firebaseConfig.js
+++ b/integration/messaging/test/static/valid-no-vapid-key/firebaseConfig.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/integration/messaging/test/static/valid-no-vapid-key/firebaseConfig.js
+++ b/integration/messaging/test/static/valid-no-vapid-key/firebaseConfig.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/integration/messaging/test/static/valid-no-vapid-key/sw.js
+++ b/integration/messaging/test/static/valid-no-vapid-key/sw.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/integration/messaging/test/static/valid-no-vapid-key/sw.js
+++ b/integration/messaging/test/static/valid-no-vapid-key/sw.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/integration/messaging/test/static/valid-vapid-key/firebaseConfig.js
+++ b/integration/messaging/test/static/valid-vapid-key/firebaseConfig.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/integration/messaging/test/static/valid-vapid-key/firebaseConfig.js
+++ b/integration/messaging/test/static/valid-vapid-key/firebaseConfig.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/integration/messaging/test/static/valid-vapid-key/sw.js
+++ b/integration/messaging/test/static/valid-vapid-key/sw.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/integration/messaging/test/static/valid-vapid-key/sw.js
+++ b/integration/messaging/test/static/valid-vapid-key/sw.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/integration/messaging/test/test-default-sw.js
+++ b/integration/messaging/test/test-default-sw.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/integration/messaging/test/test-default-sw.js
+++ b/integration/messaging/test/test-default-sw.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/integration/messaging/test/test-deleteToken.js
+++ b/integration/messaging/test/test-deleteToken.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/integration/messaging/test/test-deleteToken.js
+++ b/integration/messaging/test/test-deleteToken.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/integration/messaging/test/test-send.js
+++ b/integration/messaging/test/test-send.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/integration/messaging/test/test-send.js
+++ b/integration/messaging/test/test-send.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/integration/messaging/test/test-updateToken.js
+++ b/integration/messaging/test/test-updateToken.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/integration/messaging/test/test-updateToken.js
+++ b/integration/messaging/test/test-updateToken.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/integration/messaging/test/test-valid-manifest.js
+++ b/integration/messaging/test/test-valid-manifest.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/integration/messaging/test/test-valid-manifest.js
+++ b/integration/messaging/test/test-valid-manifest.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/integration/messaging/test/utils/deleteFCMToken.js
+++ b/integration/messaging/test/utils/deleteFCMToken.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/integration/messaging/test/utils/deleteFCMToken.js
+++ b/integration/messaging/test/utils/deleteFCMToken.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/integration/messaging/test/utils/getDemoSetup.js
+++ b/integration/messaging/test/utils/getDemoSetup.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/integration/messaging/test/utils/getDemoSetup.js
+++ b/integration/messaging/test/utils/getDemoSetup.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/integration/messaging/test/utils/getErrors.js
+++ b/integration/messaging/test/utils/getErrors.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/integration/messaging/test/utils/getErrors.js
+++ b/integration/messaging/test/utils/getErrors.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/integration/messaging/test/utils/getFCMToken.js
+++ b/integration/messaging/test/utils/getFCMToken.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/integration/messaging/test/utils/getFCMToken.js
+++ b/integration/messaging/test/utils/getFCMToken.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/integration/messaging/test/utils/getReceivedMessages.js
+++ b/integration/messaging/test/utils/getReceivedMessages.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/integration/messaging/test/utils/getReceivedMessages.js
+++ b/integration/messaging/test/utils/getReceivedMessages.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/integration/messaging/test/utils/makeFCMAPICall.js
+++ b/integration/messaging/test/utils/makeFCMAPICall.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/integration/messaging/test/utils/makeFCMAPICall.js
+++ b/integration/messaging/test/utils/makeFCMAPICall.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/integration/messaging/test/utils/retrieveFCMToken.js
+++ b/integration/messaging/test/utils/retrieveFCMToken.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/integration/messaging/test/utils/retrieveFCMToken.js
+++ b/integration/messaging/test/utils/retrieveFCMToken.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/integration/messaging/test/utils/setupNotificationPermission.js
+++ b/integration/messaging/test/utils/setupNotificationPermission.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/integration/messaging/test/utils/setupNotificationPermission.js
+++ b/integration/messaging/test/utils/setupNotificationPermission.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/integration/messaging/test/utils/test-server.js
+++ b/integration/messaging/test/utils/test-server.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/integration/messaging/test/utils/test-server.js
+++ b/integration/messaging/test/utils/test-server.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/integration/messaging/test/utils/timeForward.js
+++ b/integration/messaging/test/utils/timeForward.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/integration/messaging/test/utils/timeForward.js
+++ b/integration/messaging/test/utils/timeForward.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/integration/shared/validator.js
+++ b/integration/shared/validator.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/integration/shared/validator.js
+++ b/integration/shared/validator.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/integration/typescript/karma.conf.js
+++ b/integration/typescript/karma.conf.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/integration/typescript/karma.conf.js
+++ b/integration/typescript/karma.conf.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/integration/typescript/test/namespace.test.ts
+++ b/integration/typescript/test/namespace.test.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/integration/typescript/test/namespace.test.ts
+++ b/integration/typescript/test/namespace.test.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/integration/typescript/test/typings.d.ts
+++ b/integration/typescript/test/typings.d.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/integration/typescript/test/typings.d.ts
+++ b/integration/typescript/test/typings.d.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/integration/webpack/karma.conf.js
+++ b/integration/webpack/karma.conf.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/integration/webpack/karma.conf.js
+++ b/integration/webpack/karma.conf.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/integration/webpack/src/namespace.test.js
+++ b/integration/webpack/src/namespace.test.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/integration/webpack/src/namespace.test.js
+++ b/integration/webpack/src/namespace.test.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/integration/webpack/webpack.config.js
+++ b/integration/webpack/webpack.config.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/integration/webpack/webpack.config.js
+++ b/integration/webpack/webpack.config.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/app-types/index.d.ts
+++ b/packages/app-types/index.d.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/app-types/index.d.ts
+++ b/packages/app-types/index.d.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/app-types/private.d.ts
+++ b/packages/app-types/private.d.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/app-types/private.d.ts
+++ b/packages/app-types/private.d.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/app/index.node.ts
+++ b/packages/app/index.node.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/app/index.node.ts
+++ b/packages/app/index.node.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/app/index.rn.ts
+++ b/packages/app/index.rn.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/app/index.rn.ts
+++ b/packages/app/index.rn.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/app/index.ts
+++ b/packages/app/index.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/app/index.ts
+++ b/packages/app/index.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/app/karma.conf.js
+++ b/packages/app/karma.conf.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/app/karma.conf.js
+++ b/packages/app/karma.conf.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/app/rollup.config.js
+++ b/packages/app/rollup.config.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/app/rollup.config.js
+++ b/packages/app/rollup.config.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/app/src/firebaseApp.ts
+++ b/packages/app/src/firebaseApp.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/app/src/firebaseApp.ts
+++ b/packages/app/src/firebaseApp.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/app/test/firebaseApp.test.ts
+++ b/packages/app/test/firebaseApp.test.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/app/test/firebaseApp.test.ts
+++ b/packages/app/test/firebaseApp.test.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth-types/index.d.ts
+++ b/packages/auth-types/index.d.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth-types/index.d.ts
+++ b/packages/auth-types/index.d.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/demo/functions/index.js
+++ b/packages/auth/demo/functions/index.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/demo/functions/index.js
+++ b/packages/auth/demo/functions/index.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/demo/public/common.js
+++ b/packages/auth/demo/public/common.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/demo/public/common.js
+++ b/packages/auth/demo/public/common.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/demo/public/script.js
+++ b/packages/auth/demo/public/script.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/demo/public/script.js
+++ b/packages/auth/demo/public/script.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/demo/public/service-worker.js
+++ b/packages/auth/demo/public/service-worker.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/demo/public/service-worker.js
+++ b/packages/auth/demo/public/service-worker.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/demo/public/web-worker.js
+++ b/packages/auth/demo/public/web-worker.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/demo/public/web-worker.js
+++ b/packages/auth/demo/public/web-worker.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/externs/externs.js
+++ b/packages/auth/externs/externs.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/externs/externs.js
+++ b/packages/auth/externs/externs.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/externs/gapi.iframes.js
+++ b/packages/auth/externs/gapi.iframes.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/externs/gapi.iframes.js
+++ b/packages/auth/externs/gapi.iframes.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/externs/grecaptcha.js
+++ b/packages/auth/externs/grecaptcha.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/externs/grecaptcha.js
+++ b/packages/auth/externs/grecaptcha.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/gulpfile.js
+++ b/packages/auth/gulpfile.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/gulpfile.js
+++ b/packages/auth/gulpfile.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/index.d.ts
+++ b/packages/auth/index.d.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/index.d.ts
+++ b/packages/auth/index.d.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/protractor.conf.js
+++ b/packages/auth/protractor.conf.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/protractor.conf.js
+++ b/packages/auth/protractor.conf.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/protractor_spec.js
+++ b/packages/auth/protractor_spec.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/protractor_spec.js
+++ b/packages/auth/protractor_spec.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/src/actioncodeinfo.js
+++ b/packages/auth/src/actioncodeinfo.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/src/actioncodeinfo.js
+++ b/packages/auth/src/actioncodeinfo.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/src/actioncodesettings.js
+++ b/packages/auth/src/actioncodesettings.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/src/actioncodesettings.js
+++ b/packages/auth/src/actioncodesettings.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/src/actioncodeurl.js
+++ b/packages/auth/src/actioncodeurl.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/src/actioncodeurl.js
+++ b/packages/auth/src/actioncodeurl.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/src/additionaluserinfo.js
+++ b/packages/auth/src/additionaluserinfo.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/src/additionaluserinfo.js
+++ b/packages/auth/src/additionaluserinfo.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/src/args.js
+++ b/packages/auth/src/args.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/src/args.js
+++ b/packages/auth/src/args.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/src/auth.js
+++ b/packages/auth/src/auth.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/src/auth.js
+++ b/packages/auth/src/auth.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/src/authcredential.js
+++ b/packages/auth/src/authcredential.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/src/authcredential.js
+++ b/packages/auth/src/authcredential.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/src/authevent.js
+++ b/packages/auth/src/authevent.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/src/authevent.js
+++ b/packages/auth/src/authevent.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/src/autheventmanager.js
+++ b/packages/auth/src/autheventmanager.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/src/autheventmanager.js
+++ b/packages/auth/src/autheventmanager.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/src/authsettings.js
+++ b/packages/auth/src/authsettings.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/src/authsettings.js
+++ b/packages/auth/src/authsettings.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/src/authstorage.js
+++ b/packages/auth/src/authstorage.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/src/authstorage.js
+++ b/packages/auth/src/authstorage.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/src/authuser.js
+++ b/packages/auth/src/authuser.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/src/authuser.js
+++ b/packages/auth/src/authuser.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/src/cacherequest.js
+++ b/packages/auth/src/cacherequest.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/src/cacherequest.js
+++ b/packages/auth/src/cacherequest.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/src/confirmationresult.js
+++ b/packages/auth/src/confirmationresult.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/src/confirmationresult.js
+++ b/packages/auth/src/confirmationresult.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/src/cordovahandler.js
+++ b/packages/auth/src/cordovahandler.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/src/cordovahandler.js
+++ b/packages/auth/src/cordovahandler.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/src/debug.js
+++ b/packages/auth/src/debug.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/src/debug.js
+++ b/packages/auth/src/debug.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/src/defines.js
+++ b/packages/auth/src/defines.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/src/defines.js
+++ b/packages/auth/src/defines.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/src/deprecation.js
+++ b/packages/auth/src/deprecation.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/src/deprecation.js
+++ b/packages/auth/src/deprecation.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/src/dynamiclink.js
+++ b/packages/auth/src/dynamiclink.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/src/dynamiclink.js
+++ b/packages/auth/src/dynamiclink.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/src/error_auth.js
+++ b/packages/auth/src/error_auth.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/src/error_auth.js
+++ b/packages/auth/src/error_auth.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/src/error_invalidorigin.js
+++ b/packages/auth/src/error_invalidorigin.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/src/error_invalidorigin.js
+++ b/packages/auth/src/error_invalidorigin.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/src/error_withcredential.js
+++ b/packages/auth/src/error_withcredential.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/src/error_withcredential.js
+++ b/packages/auth/src/error_withcredential.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/src/exports_auth.js
+++ b/packages/auth/src/exports_auth.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/src/exports_auth.js
+++ b/packages/auth/src/exports_auth.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/src/exports_lib.js
+++ b/packages/auth/src/exports_lib.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/src/exports_lib.js
+++ b/packages/auth/src/exports_lib.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/src/exports_unreleased.js
+++ b/packages/auth/src/exports_unreleased.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/src/exports_unreleased.js
+++ b/packages/auth/src/exports_unreleased.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/src/externs.js
+++ b/packages/auth/src/externs.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/src/externs.js
+++ b/packages/auth/src/externs.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/src/idp.js
+++ b/packages/auth/src/idp.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/src/idp.js
+++ b/packages/auth/src/idp.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/src/idtoken.js
+++ b/packages/auth/src/idtoken.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/src/idtoken.js
+++ b/packages/auth/src/idtoken.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/src/idtokenresult.js
+++ b/packages/auth/src/idtokenresult.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/src/idtokenresult.js
+++ b/packages/auth/src/idtokenresult.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/src/iframeclient/ifchandler.js
+++ b/packages/auth/src/iframeclient/ifchandler.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/src/iframeclient/ifchandler.js
+++ b/packages/auth/src/iframeclient/ifchandler.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/src/iframeclient/iframewrapper.js
+++ b/packages/auth/src/iframeclient/iframewrapper.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/src/iframeclient/iframewrapper.js
+++ b/packages/auth/src/iframeclient/iframewrapper.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/src/messagechannel/defines.js
+++ b/packages/auth/src/messagechannel/defines.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/src/messagechannel/defines.js
+++ b/packages/auth/src/messagechannel/defines.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/src/messagechannel/postmessager.js
+++ b/packages/auth/src/messagechannel/postmessager.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/src/messagechannel/postmessager.js
+++ b/packages/auth/src/messagechannel/postmessager.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/src/messagechannel/receiver.js
+++ b/packages/auth/src/messagechannel/receiver.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/src/messagechannel/receiver.js
+++ b/packages/auth/src/messagechannel/receiver.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/src/messagechannel/sender.js
+++ b/packages/auth/src/messagechannel/sender.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/src/messagechannel/sender.js
+++ b/packages/auth/src/messagechannel/sender.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/src/oauthhelperstate.js
+++ b/packages/auth/src/oauthhelperstate.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/src/oauthhelperstate.js
+++ b/packages/auth/src/oauthhelperstate.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/src/oauthsigninhandler.js
+++ b/packages/auth/src/oauthsigninhandler.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/src/oauthsigninhandler.js
+++ b/packages/auth/src/oauthsigninhandler.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/src/object.js
+++ b/packages/auth/src/object.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/src/object.js
+++ b/packages/auth/src/object.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/src/proactiverefresh.js
+++ b/packages/auth/src/proactiverefresh.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/src/proactiverefresh.js
+++ b/packages/auth/src/proactiverefresh.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/src/recaptchaverifier/grecaptcha.js
+++ b/packages/auth/src/recaptchaverifier/grecaptcha.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/src/recaptchaverifier/grecaptcha.js
+++ b/packages/auth/src/recaptchaverifier/grecaptcha.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/src/recaptchaverifier/grecaptchamock.js
+++ b/packages/auth/src/recaptchaverifier/grecaptchamock.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/src/recaptchaverifier/grecaptchamock.js
+++ b/packages/auth/src/recaptchaverifier/grecaptchamock.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/src/recaptchaverifier/loader.js
+++ b/packages/auth/src/recaptchaverifier/loader.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/src/recaptchaverifier/loader.js
+++ b/packages/auth/src/recaptchaverifier/loader.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/src/recaptchaverifier/mockloader.js
+++ b/packages/auth/src/recaptchaverifier/mockloader.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/src/recaptchaverifier/mockloader.js
+++ b/packages/auth/src/recaptchaverifier/mockloader.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/src/recaptchaverifier/realloader.js
+++ b/packages/auth/src/recaptchaverifier/realloader.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/src/recaptchaverifier/realloader.js
+++ b/packages/auth/src/recaptchaverifier/realloader.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/src/recaptchaverifier/recaptchaverifier.js
+++ b/packages/auth/src/recaptchaverifier/recaptchaverifier.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/src/recaptchaverifier/recaptchaverifier.js
+++ b/packages/auth/src/recaptchaverifier/recaptchaverifier.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/src/rpchandler.js
+++ b/packages/auth/src/rpchandler.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/src/rpchandler.js
+++ b/packages/auth/src/rpchandler.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/src/storage/asyncstorage.js
+++ b/packages/auth/src/storage/asyncstorage.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/src/storage/asyncstorage.js
+++ b/packages/auth/src/storage/asyncstorage.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/src/storage/factory.js
+++ b/packages/auth/src/storage/factory.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/src/storage/factory.js
+++ b/packages/auth/src/storage/factory.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/src/storage/hybridindexeddb.js
+++ b/packages/auth/src/storage/hybridindexeddb.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/src/storage/hybridindexeddb.js
+++ b/packages/auth/src/storage/hybridindexeddb.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/src/storage/indexeddb.js
+++ b/packages/auth/src/storage/indexeddb.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/src/storage/indexeddb.js
+++ b/packages/auth/src/storage/indexeddb.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/src/storage/inmemorystorage.js
+++ b/packages/auth/src/storage/inmemorystorage.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/src/storage/inmemorystorage.js
+++ b/packages/auth/src/storage/inmemorystorage.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/src/storage/localstorage.js
+++ b/packages/auth/src/storage/localstorage.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/src/storage/localstorage.js
+++ b/packages/auth/src/storage/localstorage.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/src/storage/mockstorage.js
+++ b/packages/auth/src/storage/mockstorage.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/src/storage/mockstorage.js
+++ b/packages/auth/src/storage/mockstorage.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/src/storage/nullstorage.js
+++ b/packages/auth/src/storage/nullstorage.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/src/storage/nullstorage.js
+++ b/packages/auth/src/storage/nullstorage.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/src/storage/sessionstorage.js
+++ b/packages/auth/src/storage/sessionstorage.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/src/storage/sessionstorage.js
+++ b/packages/auth/src/storage/sessionstorage.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/src/storage/storage.js
+++ b/packages/auth/src/storage/storage.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/src/storage/storage.js
+++ b/packages/auth/src/storage/storage.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/src/storageautheventmanager.js
+++ b/packages/auth/src/storageautheventmanager.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/src/storageautheventmanager.js
+++ b/packages/auth/src/storageautheventmanager.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/src/storageoauthhandlermanager.js
+++ b/packages/auth/src/storageoauthhandlermanager.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/src/storageoauthhandlermanager.js
+++ b/packages/auth/src/storageoauthhandlermanager.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/src/storagependingredirectmanager.js
+++ b/packages/auth/src/storagependingredirectmanager.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/src/storagependingredirectmanager.js
+++ b/packages/auth/src/storagependingredirectmanager.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/src/storageredirectusermanager.js
+++ b/packages/auth/src/storageredirectusermanager.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/src/storageredirectusermanager.js
+++ b/packages/auth/src/storageredirectusermanager.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/src/storageusermanager.js
+++ b/packages/auth/src/storageusermanager.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/src/storageusermanager.js
+++ b/packages/auth/src/storageusermanager.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/src/token.js
+++ b/packages/auth/src/token.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/src/token.js
+++ b/packages/auth/src/token.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/src/universallinksubscriber.js
+++ b/packages/auth/src/universallinksubscriber.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/src/universallinksubscriber.js
+++ b/packages/auth/src/universallinksubscriber.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/src/utils.js
+++ b/packages/auth/src/utils.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/src/utils.js
+++ b/packages/auth/src/utils.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/test/actioncodeinfo_test.js
+++ b/packages/auth/test/actioncodeinfo_test.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/test/actioncodeinfo_test.js
+++ b/packages/auth/test/actioncodeinfo_test.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/test/actioncodesettings_test.js
+++ b/packages/auth/test/actioncodesettings_test.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/test/actioncodesettings_test.js
+++ b/packages/auth/test/actioncodesettings_test.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/test/actioncodeurl_test.js
+++ b/packages/auth/test/actioncodeurl_test.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/test/actioncodeurl_test.js
+++ b/packages/auth/test/actioncodeurl_test.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/test/additionaluserinfo_test.js
+++ b/packages/auth/test/additionaluserinfo_test.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/test/additionaluserinfo_test.js
+++ b/packages/auth/test/additionaluserinfo_test.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/test/args_test.js
+++ b/packages/auth/test/args_test.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/test/args_test.js
+++ b/packages/auth/test/args_test.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/test/auth_test.js
+++ b/packages/auth/test/auth_test.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/test/auth_test.js
+++ b/packages/auth/test/auth_test.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/test/authcredential_test.js
+++ b/packages/auth/test/authcredential_test.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/test/authcredential_test.js
+++ b/packages/auth/test/authcredential_test.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/test/authevent_test.js
+++ b/packages/auth/test/authevent_test.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/test/authevent_test.js
+++ b/packages/auth/test/authevent_test.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/test/autheventmanager_test.js
+++ b/packages/auth/test/autheventmanager_test.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/test/autheventmanager_test.js
+++ b/packages/auth/test/autheventmanager_test.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/test/authsettings_test.js
+++ b/packages/auth/test/authsettings_test.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/test/authsettings_test.js
+++ b/packages/auth/test/authsettings_test.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/test/authstorage_test.js
+++ b/packages/auth/test/authstorage_test.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/test/authstorage_test.js
+++ b/packages/auth/test/authstorage_test.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/test/authuser_test.js
+++ b/packages/auth/test/authuser_test.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/test/authuser_test.js
+++ b/packages/auth/test/authuser_test.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/test/cacherequest_test.js
+++ b/packages/auth/test/cacherequest_test.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/test/cacherequest_test.js
+++ b/packages/auth/test/cacherequest_test.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/test/confirmationresult_test.js
+++ b/packages/auth/test/confirmationresult_test.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/test/confirmationresult_test.js
+++ b/packages/auth/test/confirmationresult_test.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/test/cordovahandler_test.js
+++ b/packages/auth/test/cordovahandler_test.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/test/cordovahandler_test.js
+++ b/packages/auth/test/cordovahandler_test.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/test/defines_test.js
+++ b/packages/auth/test/defines_test.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/test/defines_test.js
+++ b/packages/auth/test/defines_test.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/test/deprecation_test.js
+++ b/packages/auth/test/deprecation_test.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/test/deprecation_test.js
+++ b/packages/auth/test/deprecation_test.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/test/dynamiclink_test.js
+++ b/packages/auth/test/dynamiclink_test.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/test/dynamiclink_test.js
+++ b/packages/auth/test/dynamiclink_test.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/test/error_test.js
+++ b/packages/auth/test/error_test.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/test/error_test.js
+++ b/packages/auth/test/error_test.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/test/exports_lib_test.js
+++ b/packages/auth/test/exports_lib_test.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/test/exports_lib_test.js
+++ b/packages/auth/test/exports_lib_test.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/test/idp_test.js
+++ b/packages/auth/test/idp_test.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/test/idp_test.js
+++ b/packages/auth/test/idp_test.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/test/idtoken_test.js
+++ b/packages/auth/test/idtoken_test.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/test/idtoken_test.js
+++ b/packages/auth/test/idtoken_test.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/test/idtokenresult_test.js
+++ b/packages/auth/test/idtokenresult_test.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/test/idtokenresult_test.js
+++ b/packages/auth/test/idtokenresult_test.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/test/iframeclient/ifchandler_test.js
+++ b/packages/auth/test/iframeclient/ifchandler_test.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/test/iframeclient/ifchandler_test.js
+++ b/packages/auth/test/iframeclient/ifchandler_test.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/test/iframeclient/iframewrapper_test.js
+++ b/packages/auth/test/iframeclient/iframewrapper_test.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/test/iframeclient/iframewrapper_test.js
+++ b/packages/auth/test/iframeclient/iframewrapper_test.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/test/messagechannel/postmessager_test.js
+++ b/packages/auth/test/messagechannel/postmessager_test.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/test/messagechannel/postmessager_test.js
+++ b/packages/auth/test/messagechannel/postmessager_test.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/test/messagechannel/receiver_test.js
+++ b/packages/auth/test/messagechannel/receiver_test.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/test/messagechannel/receiver_test.js
+++ b/packages/auth/test/messagechannel/receiver_test.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/test/messagechannel/sender_test.js
+++ b/packages/auth/test/messagechannel/sender_test.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/test/messagechannel/sender_test.js
+++ b/packages/auth/test/messagechannel/sender_test.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/test/oauthhelperstate_test.js
+++ b/packages/auth/test/oauthhelperstate_test.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/test/oauthhelperstate_test.js
+++ b/packages/auth/test/oauthhelperstate_test.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/test/object_test.js
+++ b/packages/auth/test/object_test.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/test/object_test.js
+++ b/packages/auth/test/object_test.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/test/proactiverefresh_test.js
+++ b/packages/auth/test/proactiverefresh_test.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/test/proactiverefresh_test.js
+++ b/packages/auth/test/proactiverefresh_test.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/test/recaptchaverifier/grecaptchamock_test.js
+++ b/packages/auth/test/recaptchaverifier/grecaptchamock_test.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/test/recaptchaverifier/grecaptchamock_test.js
+++ b/packages/auth/test/recaptchaverifier/grecaptchamock_test.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/test/recaptchaverifier/mockloader_test.js
+++ b/packages/auth/test/recaptchaverifier/mockloader_test.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/test/recaptchaverifier/mockloader_test.js
+++ b/packages/auth/test/recaptchaverifier/mockloader_test.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/test/recaptchaverifier/realloader_test.js
+++ b/packages/auth/test/recaptchaverifier/realloader_test.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/test/recaptchaverifier/realloader_test.js
+++ b/packages/auth/test/recaptchaverifier/realloader_test.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/test/recaptchaverifier/recaptchaverifier_test.js
+++ b/packages/auth/test/recaptchaverifier/recaptchaverifier_test.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/test/recaptchaverifier/recaptchaverifier_test.js
+++ b/packages/auth/test/recaptchaverifier/recaptchaverifier_test.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/test/rpchandler_test.js
+++ b/packages/auth/test/rpchandler_test.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/test/rpchandler_test.js
+++ b/packages/auth/test/rpchandler_test.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/test/storage/asyncstorage_test.js
+++ b/packages/auth/test/storage/asyncstorage_test.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/test/storage/asyncstorage_test.js
+++ b/packages/auth/test/storage/asyncstorage_test.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/test/storage/factory_test.js
+++ b/packages/auth/test/storage/factory_test.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/test/storage/factory_test.js
+++ b/packages/auth/test/storage/factory_test.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/test/storage/hybridindexeddb_test.js
+++ b/packages/auth/test/storage/hybridindexeddb_test.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/test/storage/hybridindexeddb_test.js
+++ b/packages/auth/test/storage/hybridindexeddb_test.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/test/storage/indexeddb_test.js
+++ b/packages/auth/test/storage/indexeddb_test.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/test/storage/indexeddb_test.js
+++ b/packages/auth/test/storage/indexeddb_test.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/test/storage/inmemorystorage_test.js
+++ b/packages/auth/test/storage/inmemorystorage_test.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/test/storage/inmemorystorage_test.js
+++ b/packages/auth/test/storage/inmemorystorage_test.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/test/storage/localstorage_test.js
+++ b/packages/auth/test/storage/localstorage_test.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/test/storage/localstorage_test.js
+++ b/packages/auth/test/storage/localstorage_test.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/test/storage/mockstorage_test.js
+++ b/packages/auth/test/storage/mockstorage_test.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/test/storage/mockstorage_test.js
+++ b/packages/auth/test/storage/mockstorage_test.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/test/storage/nullstorage_test.js
+++ b/packages/auth/test/storage/nullstorage_test.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/test/storage/nullstorage_test.js
+++ b/packages/auth/test/storage/nullstorage_test.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/test/storage/sessionstorage_test.js
+++ b/packages/auth/test/storage/sessionstorage_test.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/test/storage/sessionstorage_test.js
+++ b/packages/auth/test/storage/sessionstorage_test.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/test/storage/testhelper.js
+++ b/packages/auth/test/storage/testhelper.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/test/storage/testhelper.js
+++ b/packages/auth/test/storage/testhelper.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/test/storageautheventmanager_test.js
+++ b/packages/auth/test/storageautheventmanager_test.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/test/storageautheventmanager_test.js
+++ b/packages/auth/test/storageautheventmanager_test.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/test/storageoauthhandlermanager_test.js
+++ b/packages/auth/test/storageoauthhandlermanager_test.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/test/storageoauthhandlermanager_test.js
+++ b/packages/auth/test/storageoauthhandlermanager_test.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/test/storagependingredirectmanager_test.js
+++ b/packages/auth/test/storagependingredirectmanager_test.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/test/storagependingredirectmanager_test.js
+++ b/packages/auth/test/storagependingredirectmanager_test.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/test/storageredirectusermanager_test.js
+++ b/packages/auth/test/storageredirectusermanager_test.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/test/storageredirectusermanager_test.js
+++ b/packages/auth/test/storageredirectusermanager_test.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/test/storageusermanager_test.js
+++ b/packages/auth/test/storageusermanager_test.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/test/storageusermanager_test.js
+++ b/packages/auth/test/storageusermanager_test.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/test/testhelper.js
+++ b/packages/auth/test/testhelper.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/test/testhelper.js
+++ b/packages/auth/test/testhelper.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/test/token_test.js
+++ b/packages/auth/test/token_test.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/test/token_test.js
+++ b/packages/auth/test/token_test.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/test/universallinksubscriber_test.js
+++ b/packages/auth/test/universallinksubscriber_test.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/test/universallinksubscriber_test.js
+++ b/packages/auth/test/universallinksubscriber_test.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/test/utils_test.js
+++ b/packages/auth/test/utils_test.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/auth/test/utils_test.js
+++ b/packages/auth/test/utils_test.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database-types/index.d.ts
+++ b/packages/database-types/index.d.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database-types/index.d.ts
+++ b/packages/database-types/index.d.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/index.node.ts
+++ b/packages/database/index.node.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/index.node.ts
+++ b/packages/database/index.node.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/index.ts
+++ b/packages/database/index.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/index.ts
+++ b/packages/database/index.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/karma.conf.js
+++ b/packages/database/karma.conf.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/karma.conf.js
+++ b/packages/database/karma.conf.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/rollup.config.js
+++ b/packages/database/rollup.config.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/rollup.config.js
+++ b/packages/database/rollup.config.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/api/DataSnapshot.ts
+++ b/packages/database/src/api/DataSnapshot.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/api/DataSnapshot.ts
+++ b/packages/database/src/api/DataSnapshot.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/api/Database.ts
+++ b/packages/database/src/api/Database.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/api/Database.ts
+++ b/packages/database/src/api/Database.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/api/Query.ts
+++ b/packages/database/src/api/Query.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/api/Query.ts
+++ b/packages/database/src/api/Query.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/api/Reference.ts
+++ b/packages/database/src/api/Reference.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/api/Reference.ts
+++ b/packages/database/src/api/Reference.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/api/TransactionResult.ts
+++ b/packages/database/src/api/TransactionResult.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/api/TransactionResult.ts
+++ b/packages/database/src/api/TransactionResult.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/api/internal.ts
+++ b/packages/database/src/api/internal.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/api/internal.ts
+++ b/packages/database/src/api/internal.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/api/onDisconnect.ts
+++ b/packages/database/src/api/onDisconnect.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/api/onDisconnect.ts
+++ b/packages/database/src/api/onDisconnect.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/api/test_access.ts
+++ b/packages/database/src/api/test_access.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/api/test_access.ts
+++ b/packages/database/src/api/test_access.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/core/AuthTokenProvider.ts
+++ b/packages/database/src/core/AuthTokenProvider.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/core/AuthTokenProvider.ts
+++ b/packages/database/src/core/AuthTokenProvider.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/core/CompoundWrite.ts
+++ b/packages/database/src/core/CompoundWrite.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/core/CompoundWrite.ts
+++ b/packages/database/src/core/CompoundWrite.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/core/PersistentConnection.ts
+++ b/packages/database/src/core/PersistentConnection.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/core/PersistentConnection.ts
+++ b/packages/database/src/core/PersistentConnection.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/core/ReadonlyRestClient.ts
+++ b/packages/database/src/core/ReadonlyRestClient.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/core/ReadonlyRestClient.ts
+++ b/packages/database/src/core/ReadonlyRestClient.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/core/Repo.ts
+++ b/packages/database/src/core/Repo.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/core/Repo.ts
+++ b/packages/database/src/core/Repo.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/core/RepoInfo.ts
+++ b/packages/database/src/core/RepoInfo.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/core/RepoInfo.ts
+++ b/packages/database/src/core/RepoInfo.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/core/RepoManager.ts
+++ b/packages/database/src/core/RepoManager.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/core/RepoManager.ts
+++ b/packages/database/src/core/RepoManager.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/core/Repo_transaction.ts
+++ b/packages/database/src/core/Repo_transaction.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/core/Repo_transaction.ts
+++ b/packages/database/src/core/Repo_transaction.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/core/ServerActions.ts
+++ b/packages/database/src/core/ServerActions.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/core/ServerActions.ts
+++ b/packages/database/src/core/ServerActions.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/core/SnapshotHolder.ts
+++ b/packages/database/src/core/SnapshotHolder.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/core/SnapshotHolder.ts
+++ b/packages/database/src/core/SnapshotHolder.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/core/SparseSnapshotTree.ts
+++ b/packages/database/src/core/SparseSnapshotTree.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/core/SparseSnapshotTree.ts
+++ b/packages/database/src/core/SparseSnapshotTree.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/core/SyncPoint.ts
+++ b/packages/database/src/core/SyncPoint.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/core/SyncPoint.ts
+++ b/packages/database/src/core/SyncPoint.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/core/SyncTree.ts
+++ b/packages/database/src/core/SyncTree.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/core/SyncTree.ts
+++ b/packages/database/src/core/SyncTree.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/core/WriteTree.ts
+++ b/packages/database/src/core/WriteTree.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/core/WriteTree.ts
+++ b/packages/database/src/core/WriteTree.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/core/operation/AckUserWrite.ts
+++ b/packages/database/src/core/operation/AckUserWrite.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/core/operation/AckUserWrite.ts
+++ b/packages/database/src/core/operation/AckUserWrite.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/core/operation/ListenComplete.ts
+++ b/packages/database/src/core/operation/ListenComplete.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/core/operation/ListenComplete.ts
+++ b/packages/database/src/core/operation/ListenComplete.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/core/operation/Merge.ts
+++ b/packages/database/src/core/operation/Merge.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/core/operation/Merge.ts
+++ b/packages/database/src/core/operation/Merge.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/core/operation/Operation.ts
+++ b/packages/database/src/core/operation/Operation.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/core/operation/Operation.ts
+++ b/packages/database/src/core/operation/Operation.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/core/operation/Overwrite.ts
+++ b/packages/database/src/core/operation/Overwrite.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/core/operation/Overwrite.ts
+++ b/packages/database/src/core/operation/Overwrite.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/core/snap/ChildrenNode.ts
+++ b/packages/database/src/core/snap/ChildrenNode.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/core/snap/ChildrenNode.ts
+++ b/packages/database/src/core/snap/ChildrenNode.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/core/snap/IndexMap.ts
+++ b/packages/database/src/core/snap/IndexMap.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/core/snap/IndexMap.ts
+++ b/packages/database/src/core/snap/IndexMap.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/core/snap/LeafNode.ts
+++ b/packages/database/src/core/snap/LeafNode.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/core/snap/LeafNode.ts
+++ b/packages/database/src/core/snap/LeafNode.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/core/snap/Node.ts
+++ b/packages/database/src/core/snap/Node.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/core/snap/Node.ts
+++ b/packages/database/src/core/snap/Node.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/core/snap/childSet.ts
+++ b/packages/database/src/core/snap/childSet.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/core/snap/childSet.ts
+++ b/packages/database/src/core/snap/childSet.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/core/snap/comparators.ts
+++ b/packages/database/src/core/snap/comparators.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/core/snap/comparators.ts
+++ b/packages/database/src/core/snap/comparators.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/core/snap/indexes/Index.ts
+++ b/packages/database/src/core/snap/indexes/Index.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/core/snap/indexes/Index.ts
+++ b/packages/database/src/core/snap/indexes/Index.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/core/snap/indexes/KeyIndex.ts
+++ b/packages/database/src/core/snap/indexes/KeyIndex.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/core/snap/indexes/KeyIndex.ts
+++ b/packages/database/src/core/snap/indexes/KeyIndex.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/core/snap/indexes/PathIndex.ts
+++ b/packages/database/src/core/snap/indexes/PathIndex.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/core/snap/indexes/PathIndex.ts
+++ b/packages/database/src/core/snap/indexes/PathIndex.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/core/snap/indexes/PriorityIndex.ts
+++ b/packages/database/src/core/snap/indexes/PriorityIndex.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/core/snap/indexes/PriorityIndex.ts
+++ b/packages/database/src/core/snap/indexes/PriorityIndex.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/core/snap/indexes/ValueIndex.ts
+++ b/packages/database/src/core/snap/indexes/ValueIndex.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/core/snap/indexes/ValueIndex.ts
+++ b/packages/database/src/core/snap/indexes/ValueIndex.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/core/snap/nodeFromJSON.ts
+++ b/packages/database/src/core/snap/nodeFromJSON.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/core/snap/nodeFromJSON.ts
+++ b/packages/database/src/core/snap/nodeFromJSON.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/core/snap/snap.ts
+++ b/packages/database/src/core/snap/snap.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/core/snap/snap.ts
+++ b/packages/database/src/core/snap/snap.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/core/stats/StatsCollection.ts
+++ b/packages/database/src/core/stats/StatsCollection.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/core/stats/StatsCollection.ts
+++ b/packages/database/src/core/stats/StatsCollection.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/core/stats/StatsListener.ts
+++ b/packages/database/src/core/stats/StatsListener.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/core/stats/StatsListener.ts
+++ b/packages/database/src/core/stats/StatsListener.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/core/stats/StatsManager.ts
+++ b/packages/database/src/core/stats/StatsManager.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/core/stats/StatsManager.ts
+++ b/packages/database/src/core/stats/StatsManager.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/core/stats/StatsReporter.ts
+++ b/packages/database/src/core/stats/StatsReporter.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/core/stats/StatsReporter.ts
+++ b/packages/database/src/core/stats/StatsReporter.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/core/storage/DOMStorageWrapper.ts
+++ b/packages/database/src/core/storage/DOMStorageWrapper.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/core/storage/DOMStorageWrapper.ts
+++ b/packages/database/src/core/storage/DOMStorageWrapper.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/core/storage/MemoryStorage.ts
+++ b/packages/database/src/core/storage/MemoryStorage.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/core/storage/MemoryStorage.ts
+++ b/packages/database/src/core/storage/MemoryStorage.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/core/storage/storage.ts
+++ b/packages/database/src/core/storage/storage.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/core/storage/storage.ts
+++ b/packages/database/src/core/storage/storage.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/core/util/CountedSet.ts
+++ b/packages/database/src/core/util/CountedSet.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/core/util/CountedSet.ts
+++ b/packages/database/src/core/util/CountedSet.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/core/util/EventEmitter.ts
+++ b/packages/database/src/core/util/EventEmitter.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/core/util/EventEmitter.ts
+++ b/packages/database/src/core/util/EventEmitter.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/core/util/ImmutableTree.ts
+++ b/packages/database/src/core/util/ImmutableTree.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/core/util/ImmutableTree.ts
+++ b/packages/database/src/core/util/ImmutableTree.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/core/util/NextPushId.ts
+++ b/packages/database/src/core/util/NextPushId.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/core/util/NextPushId.ts
+++ b/packages/database/src/core/util/NextPushId.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/core/util/OnlineMonitor.ts
+++ b/packages/database/src/core/util/OnlineMonitor.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/core/util/OnlineMonitor.ts
+++ b/packages/database/src/core/util/OnlineMonitor.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/core/util/Path.ts
+++ b/packages/database/src/core/util/Path.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/core/util/Path.ts
+++ b/packages/database/src/core/util/Path.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/core/util/ServerValues.ts
+++ b/packages/database/src/core/util/ServerValues.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/core/util/ServerValues.ts
+++ b/packages/database/src/core/util/ServerValues.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/core/util/SortedMap.ts
+++ b/packages/database/src/core/util/SortedMap.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/core/util/SortedMap.ts
+++ b/packages/database/src/core/util/SortedMap.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/core/util/Tree.ts
+++ b/packages/database/src/core/util/Tree.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/core/util/Tree.ts
+++ b/packages/database/src/core/util/Tree.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/core/util/VisibilityMonitor.ts
+++ b/packages/database/src/core/util/VisibilityMonitor.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/core/util/VisibilityMonitor.ts
+++ b/packages/database/src/core/util/VisibilityMonitor.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/core/util/libs/parser.ts
+++ b/packages/database/src/core/util/libs/parser.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/core/util/libs/parser.ts
+++ b/packages/database/src/core/util/libs/parser.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/core/util/util.ts
+++ b/packages/database/src/core/util/util.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/core/util/util.ts
+++ b/packages/database/src/core/util/util.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/core/util/validation.ts
+++ b/packages/database/src/core/util/validation.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/core/util/validation.ts
+++ b/packages/database/src/core/util/validation.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/core/view/CacheNode.ts
+++ b/packages/database/src/core/view/CacheNode.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/core/view/CacheNode.ts
+++ b/packages/database/src/core/view/CacheNode.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/core/view/Change.ts
+++ b/packages/database/src/core/view/Change.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/core/view/Change.ts
+++ b/packages/database/src/core/view/Change.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/core/view/ChildChangeAccumulator.ts
+++ b/packages/database/src/core/view/ChildChangeAccumulator.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/core/view/ChildChangeAccumulator.ts
+++ b/packages/database/src/core/view/ChildChangeAccumulator.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/core/view/CompleteChildSource.ts
+++ b/packages/database/src/core/view/CompleteChildSource.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/core/view/CompleteChildSource.ts
+++ b/packages/database/src/core/view/CompleteChildSource.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/core/view/Event.ts
+++ b/packages/database/src/core/view/Event.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/core/view/Event.ts
+++ b/packages/database/src/core/view/Event.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/core/view/EventGenerator.ts
+++ b/packages/database/src/core/view/EventGenerator.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/core/view/EventGenerator.ts
+++ b/packages/database/src/core/view/EventGenerator.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/core/view/EventQueue.ts
+++ b/packages/database/src/core/view/EventQueue.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/core/view/EventQueue.ts
+++ b/packages/database/src/core/view/EventQueue.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/core/view/EventRegistration.ts
+++ b/packages/database/src/core/view/EventRegistration.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/core/view/EventRegistration.ts
+++ b/packages/database/src/core/view/EventRegistration.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/core/view/QueryParams.ts
+++ b/packages/database/src/core/view/QueryParams.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/core/view/QueryParams.ts
+++ b/packages/database/src/core/view/QueryParams.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/core/view/View.ts
+++ b/packages/database/src/core/view/View.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/core/view/View.ts
+++ b/packages/database/src/core/view/View.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/core/view/ViewCache.ts
+++ b/packages/database/src/core/view/ViewCache.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/core/view/ViewCache.ts
+++ b/packages/database/src/core/view/ViewCache.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/core/view/ViewProcessor.ts
+++ b/packages/database/src/core/view/ViewProcessor.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/core/view/ViewProcessor.ts
+++ b/packages/database/src/core/view/ViewProcessor.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/core/view/filter/IndexedFilter.ts
+++ b/packages/database/src/core/view/filter/IndexedFilter.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/core/view/filter/IndexedFilter.ts
+++ b/packages/database/src/core/view/filter/IndexedFilter.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/core/view/filter/LimitedFilter.ts
+++ b/packages/database/src/core/view/filter/LimitedFilter.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/core/view/filter/LimitedFilter.ts
+++ b/packages/database/src/core/view/filter/LimitedFilter.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/core/view/filter/NodeFilter.ts
+++ b/packages/database/src/core/view/filter/NodeFilter.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/core/view/filter/NodeFilter.ts
+++ b/packages/database/src/core/view/filter/NodeFilter.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/core/view/filter/RangedFilter.ts
+++ b/packages/database/src/core/view/filter/RangedFilter.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/core/view/filter/RangedFilter.ts
+++ b/packages/database/src/core/view/filter/RangedFilter.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/nodePatches.ts
+++ b/packages/database/src/nodePatches.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/nodePatches.ts
+++ b/packages/database/src/nodePatches.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/realtime/BrowserPollConnection.ts
+++ b/packages/database/src/realtime/BrowserPollConnection.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/realtime/BrowserPollConnection.ts
+++ b/packages/database/src/realtime/BrowserPollConnection.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/realtime/Connection.ts
+++ b/packages/database/src/realtime/Connection.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/realtime/Connection.ts
+++ b/packages/database/src/realtime/Connection.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/realtime/Constants.ts
+++ b/packages/database/src/realtime/Constants.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/realtime/Constants.ts
+++ b/packages/database/src/realtime/Constants.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/realtime/Transport.ts
+++ b/packages/database/src/realtime/Transport.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/realtime/Transport.ts
+++ b/packages/database/src/realtime/Transport.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/realtime/TransportManager.ts
+++ b/packages/database/src/realtime/TransportManager.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/realtime/TransportManager.ts
+++ b/packages/database/src/realtime/TransportManager.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/realtime/WebSocketConnection.ts
+++ b/packages/database/src/realtime/WebSocketConnection.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/realtime/WebSocketConnection.ts
+++ b/packages/database/src/realtime/WebSocketConnection.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/realtime/polling/PacketReceiver.ts
+++ b/packages/database/src/realtime/polling/PacketReceiver.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/src/realtime/polling/PacketReceiver.ts
+++ b/packages/database/src/realtime/polling/PacketReceiver.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/test/browser/crawler_support.test.ts
+++ b/packages/database/test/browser/crawler_support.test.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/test/browser/crawler_support.test.ts
+++ b/packages/database/test/browser/crawler_support.test.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/test/compound_write.test.ts
+++ b/packages/database/test/compound_write.test.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/test/compound_write.test.ts
+++ b/packages/database/test/compound_write.test.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/test/connection.test.ts
+++ b/packages/database/test/connection.test.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/test/connection.test.ts
+++ b/packages/database/test/connection.test.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/test/database.test.ts
+++ b/packages/database/test/database.test.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/test/database.test.ts
+++ b/packages/database/test/database.test.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/test/datasnapshot.test.ts
+++ b/packages/database/test/datasnapshot.test.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/test/datasnapshot.test.ts
+++ b/packages/database/test/datasnapshot.test.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/test/helpers/EventAccumulator.ts
+++ b/packages/database/test/helpers/EventAccumulator.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/test/helpers/EventAccumulator.ts
+++ b/packages/database/test/helpers/EventAccumulator.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/test/helpers/events.ts
+++ b/packages/database/test/helpers/events.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/test/helpers/events.ts
+++ b/packages/database/test/helpers/events.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/test/helpers/util.ts
+++ b/packages/database/test/helpers/util.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/test/helpers/util.ts
+++ b/packages/database/test/helpers/util.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/test/info.test.ts
+++ b/packages/database/test/info.test.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/test/info.test.ts
+++ b/packages/database/test/info.test.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/test/node.test.ts
+++ b/packages/database/test/node.test.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/test/node.test.ts
+++ b/packages/database/test/node.test.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/test/order.test.ts
+++ b/packages/database/test/order.test.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/test/order.test.ts
+++ b/packages/database/test/order.test.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/test/order_by.test.ts
+++ b/packages/database/test/order_by.test.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/test/order_by.test.ts
+++ b/packages/database/test/order_by.test.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/test/path.test.ts
+++ b/packages/database/test/path.test.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/test/path.test.ts
+++ b/packages/database/test/path.test.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/test/promise.test.ts
+++ b/packages/database/test/promise.test.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/test/promise.test.ts
+++ b/packages/database/test/promise.test.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/test/query.test.ts
+++ b/packages/database/test/query.test.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/test/query.test.ts
+++ b/packages/database/test/query.test.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/test/repoinfo.test.ts
+++ b/packages/database/test/repoinfo.test.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/test/repoinfo.test.ts
+++ b/packages/database/test/repoinfo.test.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/test/sortedmap.test.ts
+++ b/packages/database/test/sortedmap.test.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/test/sortedmap.test.ts
+++ b/packages/database/test/sortedmap.test.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/test/sparsesnapshottree.test.ts
+++ b/packages/database/test/sparsesnapshottree.test.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/test/sparsesnapshottree.test.ts
+++ b/packages/database/test/sparsesnapshottree.test.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/test/transaction.test.ts
+++ b/packages/database/test/transaction.test.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/database/test/transaction.test.ts
+++ b/packages/database/test/transaction.test.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firebase/app/index.ts
+++ b/packages/firebase/app/index.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firebase/app/index.ts
+++ b/packages/firebase/app/index.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firebase/auth/index.ts
+++ b/packages/firebase/auth/index.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firebase/auth/index.ts
+++ b/packages/firebase/auth/index.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firebase/database/index.ts
+++ b/packages/firebase/database/index.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firebase/database/index.ts
+++ b/packages/firebase/database/index.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firebase/empty-import.d.ts
+++ b/packages/firebase/empty-import.d.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firebase/empty-import.d.ts
+++ b/packages/firebase/empty-import.d.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firebase/firestore/index.ts
+++ b/packages/firebase/firestore/index.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firebase/firestore/index.ts
+++ b/packages/firebase/firestore/index.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firebase/functions/index.ts
+++ b/packages/firebase/functions/index.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firebase/functions/index.ts
+++ b/packages/firebase/functions/index.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firebase/index.d.ts
+++ b/packages/firebase/index.d.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firebase/index.d.ts
+++ b/packages/firebase/index.d.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firebase/messaging/index.ts
+++ b/packages/firebase/messaging/index.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firebase/messaging/index.ts
+++ b/packages/firebase/messaging/index.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firebase/package.json
+++ b/packages/firebase/package.json
@@ -46,8 +46,10 @@
     "@firebase/storage": "0.2.7"
   },
   "devDependencies": {
+    "git-rev-sync": "1.12.0",
     "rollup": "0.57.1",
     "rollup-plugin-commonjs": "9.1.0",
+    "rollup-plugin-license": "0.8.1",
     "rollup-plugin-node-resolve": "3.3.0",
     "rollup-plugin-typescript2": "0.12.0",
     "rollup-plugin-uglify": "3.0.0",

--- a/packages/firebase/package.json
+++ b/packages/firebase/package.json
@@ -46,10 +46,8 @@
     "@firebase/storage": "0.2.7"
   },
   "devDependencies": {
-    "git-rev-sync": "1.12.0",
     "rollup": "0.57.1",
     "rollup-plugin-commonjs": "9.1.0",
-    "rollup-plugin-license": "0.8.1",
     "rollup-plugin-node-resolve": "3.3.0",
     "rollup-plugin-typescript2": "0.12.0",
     "rollup-plugin-uglify": "3.0.0",

--- a/packages/firebase/rollup-internal.config.js
+++ b/packages/firebase/rollup-internal.config.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2019 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firebase/rollup-internal.config.js
+++ b/packages/firebase/rollup-internal.config.js
@@ -15,9 +15,9 @@
  * limitations under the License.
  */
 
- /**
-  * Config for internal deployment, adds required license header to generated code.
-  */
+/**
+ * Config for internal deployment, adds required license header to generated code.
+ */
 
 import baseBuilds from './rollup.config.js';
 import license from 'rollup-plugin-license';
@@ -30,7 +30,7 @@ const license = license({
 });
 
 const buildsWithLicense = baseBuilds.map(build => {
-    return Object.assign({}, build, { plugins: build.plugins.concat(license) });
+  return Object.assign({}, build, { plugins: build.plugins.concat(license) });
 });
 
 export default buildsWithLicense;

--- a/packages/firebase/rollup-internal.config.js
+++ b/packages/firebase/rollup-internal.config.js
@@ -1,0 +1,35 @@
+/**
+ * Copyright 2019 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+ /**
+  * Config for internal deployment, adds required license header to generated code.
+  */
+
+import baseBuilds from './rollup.config.js';
+import license from 'rollup-plugin-license';
+import gitRev from 'git-rev-sync';
+
+const license = license({
+  banner: `@license Firebase v${pkg.version}
+    Build: rev-${gitRev.short()}
+    Terms: https://firebase.google.com/terms/`
+});
+
+const buildsWithLicense = baseBuilds.map(build => {
+    return Object.assign({}, build, { plugins: build.plugins.concat(license) });
+});
+
+export default buildsWithLicense;

--- a/packages/firebase/rollup.config.js
+++ b/packages/firebase/rollup.config.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firebase/rollup.config.js
+++ b/packages/firebase/rollup.config.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,6 +20,8 @@ import resolveModule from 'rollup-plugin-node-resolve';
 import commonjs from 'rollup-plugin-commonjs';
 import typescript from 'rollup-plugin-typescript2';
 import uglify from 'rollup-plugin-uglify';
+import license from 'rollup-plugin-license';
+import gitRev from 'git-rev-sync';
 import pkg from './package.json';
 
 import appPkg from './app/package.json';
@@ -46,6 +49,12 @@ const plugins = [
   }),
   commonjs()
 ];
+
+const licenseOptions = {
+  banner: `@license Firebase v${pkg.version}
+    Build: rev-${gitRev.short()}
+    Terms: https://firebase.google.com/terms/`
+};
 
 const external = Object.keys(pkg.dependencies || {});
 
@@ -81,7 +90,7 @@ const appBuilds = [
       format: 'umd',
       name: GLOBAL_NAME
     },
-    plugins: [...plugins, uglify()]
+    plugins: [...plugins, uglify(), license(licenseOptions)]
   }
 ];
 
@@ -138,7 +147,7 @@ const componentBuilds = components
               );
             }`
         },
-        plugins: [...plugins, uglify()],
+        plugins: [...plugins, uglify(), license(licenseOptions)],
         external: ['@firebase/app']
       }
     ];
@@ -168,7 +177,7 @@ const completeBuilds = [
       format: 'umd',
       name: GLOBAL_NAME
     },
-    plugins: [...plugins, uglify()]
+    plugins: [...plugins, uglify(), license(licenseOptions)]
   },
   /**
    * App Node.js Builds

--- a/packages/firebase/rollup.config.js
+++ b/packages/firebase/rollup.config.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -20,8 +19,6 @@ import resolveModule from 'rollup-plugin-node-resolve';
 import commonjs from 'rollup-plugin-commonjs';
 import typescript from 'rollup-plugin-typescript2';
 import uglify from 'rollup-plugin-uglify';
-import license from 'rollup-plugin-license';
-import gitRev from 'git-rev-sync';
 import pkg from './package.json';
 
 import appPkg from './app/package.json';
@@ -49,12 +46,6 @@ const plugins = [
   }),
   commonjs()
 ];
-
-const licenseOptions = {
-  banner: `@license Firebase v${pkg.version}
-    Build: rev-${gitRev.short()}
-    Terms: https://firebase.google.com/terms/`
-};
 
 const external = Object.keys(pkg.dependencies || {});
 
@@ -90,7 +81,7 @@ const appBuilds = [
       format: 'umd',
       name: GLOBAL_NAME
     },
-    plugins: [...plugins, uglify(), license(licenseOptions)]
+    plugins: [...plugins, uglify()]
   }
 ];
 
@@ -147,7 +138,7 @@ const componentBuilds = components
               );
             }`
         },
-        plugins: [...plugins, uglify(), license(licenseOptions)],
+        plugins: [...plugins, uglify()],
         external: ['@firebase/app']
       }
     ];
@@ -177,7 +168,7 @@ const completeBuilds = [
       format: 'umd',
       name: GLOBAL_NAME
     },
-    plugins: [...plugins, uglify(), license(licenseOptions)]
+    plugins: [...plugins, uglify()]
   },
   /**
    * App Node.js Builds

--- a/packages/firebase/src/index.cdn.ts
+++ b/packages/firebase/src/index.cdn.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firebase/src/index.cdn.ts
+++ b/packages/firebase/src/index.cdn.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firebase/src/index.node.ts
+++ b/packages/firebase/src/index.node.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firebase/src/index.node.ts
+++ b/packages/firebase/src/index.node.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firebase/src/index.rn.ts
+++ b/packages/firebase/src/index.rn.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firebase/src/index.rn.ts
+++ b/packages/firebase/src/index.rn.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firebase/src/index.ts
+++ b/packages/firebase/src/index.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firebase/src/index.ts
+++ b/packages/firebase/src/index.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firebase/storage/index.ts
+++ b/packages/firebase/storage/index.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firebase/storage/index.ts
+++ b/packages/firebase/storage/index.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore-types/index.d.ts
+++ b/packages/firestore-types/index.d.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore-types/index.d.ts
+++ b/packages/firestore-types/index.d.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/index.node.ts
+++ b/packages/firestore/index.node.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/index.node.ts
+++ b/packages/firestore/index.node.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/index.ts
+++ b/packages/firestore/index.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/index.ts
+++ b/packages/firestore/index.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/karma.conf.js
+++ b/packages/firestore/karma.conf.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/karma.conf.js
+++ b/packages/firestore/karma.conf.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/rollup.config.js
+++ b/packages/firestore/rollup.config.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/rollup.config.js
+++ b/packages/firestore/rollup.config.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/api/blob.ts
+++ b/packages/firestore/src/api/blob.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/api/blob.ts
+++ b/packages/firestore/src/api/blob.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/api/credentials.ts
+++ b/packages/firestore/src/api/credentials.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/api/credentials.ts
+++ b/packages/firestore/src/api/credentials.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/api/database.ts
+++ b/packages/firestore/src/api/database.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/api/database.ts
+++ b/packages/firestore/src/api/database.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/api/field_path.ts
+++ b/packages/firestore/src/api/field_path.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/api/field_path.ts
+++ b/packages/firestore/src/api/field_path.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/api/field_value.ts
+++ b/packages/firestore/src/api/field_value.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/api/field_value.ts
+++ b/packages/firestore/src/api/field_value.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/api/geo_point.ts
+++ b/packages/firestore/src/api/geo_point.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/api/geo_point.ts
+++ b/packages/firestore/src/api/geo_point.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/api/observer.ts
+++ b/packages/firestore/src/api/observer.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/api/observer.ts
+++ b/packages/firestore/src/api/observer.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/api/timestamp.ts
+++ b/packages/firestore/src/api/timestamp.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/api/timestamp.ts
+++ b/packages/firestore/src/api/timestamp.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/api/user_data_converter.ts
+++ b/packages/firestore/src/api/user_data_converter.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/api/user_data_converter.ts
+++ b/packages/firestore/src/api/user_data_converter.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/auth/user.ts
+++ b/packages/firestore/src/auth/user.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/auth/user.ts
+++ b/packages/firestore/src/auth/user.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/core/database_info.ts
+++ b/packages/firestore/src/core/database_info.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/core/database_info.ts
+++ b/packages/firestore/src/core/database_info.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/core/event_manager.ts
+++ b/packages/firestore/src/core/event_manager.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/core/event_manager.ts
+++ b/packages/firestore/src/core/event_manager.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/core/firestore_client.ts
+++ b/packages/firestore/src/core/firestore_client.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/core/firestore_client.ts
+++ b/packages/firestore/src/core/firestore_client.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/core/listen_sequence.ts
+++ b/packages/firestore/src/core/listen_sequence.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/core/listen_sequence.ts
+++ b/packages/firestore/src/core/listen_sequence.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/core/query.ts
+++ b/packages/firestore/src/core/query.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/core/query.ts
+++ b/packages/firestore/src/core/query.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/core/snapshot_version.ts
+++ b/packages/firestore/src/core/snapshot_version.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/core/snapshot_version.ts
+++ b/packages/firestore/src/core/snapshot_version.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/core/sync_engine.ts
+++ b/packages/firestore/src/core/sync_engine.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/core/sync_engine.ts
+++ b/packages/firestore/src/core/sync_engine.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/core/target_id_generator.ts
+++ b/packages/firestore/src/core/target_id_generator.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/core/target_id_generator.ts
+++ b/packages/firestore/src/core/target_id_generator.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/core/transaction.ts
+++ b/packages/firestore/src/core/transaction.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/core/transaction.ts
+++ b/packages/firestore/src/core/transaction.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/core/types.ts
+++ b/packages/firestore/src/core/types.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/core/types.ts
+++ b/packages/firestore/src/core/types.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/core/version.ts
+++ b/packages/firestore/src/core/version.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/core/version.ts
+++ b/packages/firestore/src/core/version.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/core/view.ts
+++ b/packages/firestore/src/core/view.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/core/view.ts
+++ b/packages/firestore/src/core/view.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/core/view_snapshot.ts
+++ b/packages/firestore/src/core/view_snapshot.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/core/view_snapshot.ts
+++ b/packages/firestore/src/core/view_snapshot.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/local/encoded_resource_path.ts
+++ b/packages/firestore/src/local/encoded_resource_path.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/local/encoded_resource_path.ts
+++ b/packages/firestore/src/local/encoded_resource_path.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/local/indexeddb_mutation_queue.ts
+++ b/packages/firestore/src/local/indexeddb_mutation_queue.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/local/indexeddb_mutation_queue.ts
+++ b/packages/firestore/src/local/indexeddb_mutation_queue.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/local/indexeddb_persistence.ts
+++ b/packages/firestore/src/local/indexeddb_persistence.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/local/indexeddb_persistence.ts
+++ b/packages/firestore/src/local/indexeddb_persistence.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/local/indexeddb_query_cache.ts
+++ b/packages/firestore/src/local/indexeddb_query_cache.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/local/indexeddb_query_cache.ts
+++ b/packages/firestore/src/local/indexeddb_query_cache.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/local/indexeddb_remote_document_cache.ts
+++ b/packages/firestore/src/local/indexeddb_remote_document_cache.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/local/indexeddb_remote_document_cache.ts
+++ b/packages/firestore/src/local/indexeddb_remote_document_cache.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/local/indexeddb_schema.ts
+++ b/packages/firestore/src/local/indexeddb_schema.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/local/indexeddb_schema.ts
+++ b/packages/firestore/src/local/indexeddb_schema.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/local/local_documents_view.ts
+++ b/packages/firestore/src/local/local_documents_view.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/local/local_documents_view.ts
+++ b/packages/firestore/src/local/local_documents_view.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/local/local_serializer.ts
+++ b/packages/firestore/src/local/local_serializer.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/local/local_serializer.ts
+++ b/packages/firestore/src/local/local_serializer.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/local/local_store.ts
+++ b/packages/firestore/src/local/local_store.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/local/local_store.ts
+++ b/packages/firestore/src/local/local_store.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/local/local_view_changes.ts
+++ b/packages/firestore/src/local/local_view_changes.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/local/local_view_changes.ts
+++ b/packages/firestore/src/local/local_view_changes.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/local/lru_garbage_collector.ts
+++ b/packages/firestore/src/local/lru_garbage_collector.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/local/lru_garbage_collector.ts
+++ b/packages/firestore/src/local/lru_garbage_collector.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/local/memory_mutation_queue.ts
+++ b/packages/firestore/src/local/memory_mutation_queue.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/local/memory_mutation_queue.ts
+++ b/packages/firestore/src/local/memory_mutation_queue.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/local/memory_persistence.ts
+++ b/packages/firestore/src/local/memory_persistence.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/local/memory_persistence.ts
+++ b/packages/firestore/src/local/memory_persistence.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/local/memory_query_cache.ts
+++ b/packages/firestore/src/local/memory_query_cache.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/local/memory_query_cache.ts
+++ b/packages/firestore/src/local/memory_query_cache.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/local/memory_remote_document_cache.ts
+++ b/packages/firestore/src/local/memory_remote_document_cache.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/local/memory_remote_document_cache.ts
+++ b/packages/firestore/src/local/memory_remote_document_cache.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/local/mutation_queue.ts
+++ b/packages/firestore/src/local/mutation_queue.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/local/mutation_queue.ts
+++ b/packages/firestore/src/local/mutation_queue.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/local/persistence.ts
+++ b/packages/firestore/src/local/persistence.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/local/persistence.ts
+++ b/packages/firestore/src/local/persistence.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/local/persistence_promise.ts
+++ b/packages/firestore/src/local/persistence_promise.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/local/persistence_promise.ts
+++ b/packages/firestore/src/local/persistence_promise.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/local/query_cache.ts
+++ b/packages/firestore/src/local/query_cache.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/local/query_cache.ts
+++ b/packages/firestore/src/local/query_cache.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/local/query_data.ts
+++ b/packages/firestore/src/local/query_data.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/local/query_data.ts
+++ b/packages/firestore/src/local/query_data.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/local/reference_set.ts
+++ b/packages/firestore/src/local/reference_set.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/local/reference_set.ts
+++ b/packages/firestore/src/local/reference_set.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/local/remote_document_cache.ts
+++ b/packages/firestore/src/local/remote_document_cache.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/local/remote_document_cache.ts
+++ b/packages/firestore/src/local/remote_document_cache.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/local/remote_document_change_buffer.ts
+++ b/packages/firestore/src/local/remote_document_change_buffer.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/local/remote_document_change_buffer.ts
+++ b/packages/firestore/src/local/remote_document_change_buffer.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/local/shared_client_state.ts
+++ b/packages/firestore/src/local/shared_client_state.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/local/shared_client_state.ts
+++ b/packages/firestore/src/local/shared_client_state.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/local/shared_client_state_syncer.ts
+++ b/packages/firestore/src/local/shared_client_state_syncer.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/local/shared_client_state_syncer.ts
+++ b/packages/firestore/src/local/shared_client_state_syncer.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/local/simple_db.ts
+++ b/packages/firestore/src/local/simple_db.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/local/simple_db.ts
+++ b/packages/firestore/src/local/simple_db.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/model/collections.ts
+++ b/packages/firestore/src/model/collections.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/model/collections.ts
+++ b/packages/firestore/src/model/collections.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/model/document.ts
+++ b/packages/firestore/src/model/document.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/model/document.ts
+++ b/packages/firestore/src/model/document.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/model/document_comparator.ts
+++ b/packages/firestore/src/model/document_comparator.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/model/document_comparator.ts
+++ b/packages/firestore/src/model/document_comparator.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/model/document_key.ts
+++ b/packages/firestore/src/model/document_key.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/model/document_key.ts
+++ b/packages/firestore/src/model/document_key.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/model/document_set.ts
+++ b/packages/firestore/src/model/document_set.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/model/document_set.ts
+++ b/packages/firestore/src/model/document_set.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/model/field_value.ts
+++ b/packages/firestore/src/model/field_value.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/model/field_value.ts
+++ b/packages/firestore/src/model/field_value.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/model/mutation.ts
+++ b/packages/firestore/src/model/mutation.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/model/mutation.ts
+++ b/packages/firestore/src/model/mutation.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/model/mutation_batch.ts
+++ b/packages/firestore/src/model/mutation_batch.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/model/mutation_batch.ts
+++ b/packages/firestore/src/model/mutation_batch.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/model/path.ts
+++ b/packages/firestore/src/model/path.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/model/path.ts
+++ b/packages/firestore/src/model/path.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/model/transform_operation.ts
+++ b/packages/firestore/src/model/transform_operation.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/model/transform_operation.ts
+++ b/packages/firestore/src/model/transform_operation.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/platform/config.ts
+++ b/packages/firestore/src/platform/config.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/platform/config.ts
+++ b/packages/firestore/src/platform/config.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/platform/config/goog_module_config.ts
+++ b/packages/firestore/src/platform/config/goog_module_config.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/platform/config/goog_module_config.ts
+++ b/packages/firestore/src/platform/config/goog_module_config.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/platform/platform.ts
+++ b/packages/firestore/src/platform/platform.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/platform/platform.ts
+++ b/packages/firestore/src/platform/platform.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/platform_browser/browser_init.ts
+++ b/packages/firestore/src/platform_browser/browser_init.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/platform_browser/browser_init.ts
+++ b/packages/firestore/src/platform_browser/browser_init.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/platform_browser/browser_platform.ts
+++ b/packages/firestore/src/platform_browser/browser_platform.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/platform_browser/browser_platform.ts
+++ b/packages/firestore/src/platform_browser/browser_platform.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/platform_browser/webchannel_connection.ts
+++ b/packages/firestore/src/platform_browser/webchannel_connection.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/platform_browser/webchannel_connection.ts
+++ b/packages/firestore/src/platform_browser/webchannel_connection.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/platform_node/grpc_connection.ts
+++ b/packages/firestore/src/platform_node/grpc_connection.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/platform_node/grpc_connection.ts
+++ b/packages/firestore/src/platform_node/grpc_connection.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/platform_node/load_protos.ts
+++ b/packages/firestore/src/platform_node/load_protos.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/platform_node/load_protos.ts
+++ b/packages/firestore/src/platform_node/load_protos.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/platform_node/node_init.ts
+++ b/packages/firestore/src/platform_node/node_init.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/platform_node/node_init.ts
+++ b/packages/firestore/src/platform_node/node_init.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/platform_node/node_platform.ts
+++ b/packages/firestore/src/platform_node/node_platform.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/platform_node/node_platform.ts
+++ b/packages/firestore/src/platform_node/node_platform.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/protos/firestore_proto_api.d.ts
+++ b/packages/firestore/src/protos/firestore_proto_api.d.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/protos/firestore_proto_api.d.ts
+++ b/packages/firestore/src/protos/firestore_proto_api.d.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/remote/backoff.ts
+++ b/packages/firestore/src/remote/backoff.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/remote/backoff.ts
+++ b/packages/firestore/src/remote/backoff.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/remote/connection.ts
+++ b/packages/firestore/src/remote/connection.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/remote/connection.ts
+++ b/packages/firestore/src/remote/connection.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/remote/datastore.ts
+++ b/packages/firestore/src/remote/datastore.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/remote/datastore.ts
+++ b/packages/firestore/src/remote/datastore.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/remote/existence_filter.ts
+++ b/packages/firestore/src/remote/existence_filter.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/remote/existence_filter.ts
+++ b/packages/firestore/src/remote/existence_filter.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/remote/online_state_tracker.ts
+++ b/packages/firestore/src/remote/online_state_tracker.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/remote/online_state_tracker.ts
+++ b/packages/firestore/src/remote/online_state_tracker.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/remote/persistent_stream.ts
+++ b/packages/firestore/src/remote/persistent_stream.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/remote/persistent_stream.ts
+++ b/packages/firestore/src/remote/persistent_stream.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/remote/remote_event.ts
+++ b/packages/firestore/src/remote/remote_event.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/remote/remote_event.ts
+++ b/packages/firestore/src/remote/remote_event.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/remote/remote_store.ts
+++ b/packages/firestore/src/remote/remote_store.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/remote/remote_store.ts
+++ b/packages/firestore/src/remote/remote_store.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/remote/remote_syncer.ts
+++ b/packages/firestore/src/remote/remote_syncer.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/remote/remote_syncer.ts
+++ b/packages/firestore/src/remote/remote_syncer.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/remote/rpc_error.ts
+++ b/packages/firestore/src/remote/rpc_error.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/remote/rpc_error.ts
+++ b/packages/firestore/src/remote/rpc_error.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/remote/serializer.ts
+++ b/packages/firestore/src/remote/serializer.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/remote/serializer.ts
+++ b/packages/firestore/src/remote/serializer.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/remote/stream_bridge.ts
+++ b/packages/firestore/src/remote/stream_bridge.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/remote/stream_bridge.ts
+++ b/packages/firestore/src/remote/stream_bridge.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/remote/watch_change.ts
+++ b/packages/firestore/src/remote/watch_change.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/remote/watch_change.ts
+++ b/packages/firestore/src/remote/watch_change.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/util/api.ts
+++ b/packages/firestore/src/util/api.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/util/api.ts
+++ b/packages/firestore/src/util/api.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/util/array.ts
+++ b/packages/firestore/src/util/array.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/util/array.ts
+++ b/packages/firestore/src/util/array.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/util/assert.ts
+++ b/packages/firestore/src/util/assert.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/util/assert.ts
+++ b/packages/firestore/src/util/assert.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/util/async_observer.ts
+++ b/packages/firestore/src/util/async_observer.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/util/async_observer.ts
+++ b/packages/firestore/src/util/async_observer.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/util/async_queue.ts
+++ b/packages/firestore/src/util/async_queue.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/util/async_queue.ts
+++ b/packages/firestore/src/util/async_queue.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/util/error.ts
+++ b/packages/firestore/src/util/error.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/util/error.ts
+++ b/packages/firestore/src/util/error.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/util/input_validation.ts
+++ b/packages/firestore/src/util/input_validation.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/util/input_validation.ts
+++ b/packages/firestore/src/util/input_validation.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/util/log.ts
+++ b/packages/firestore/src/util/log.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/util/log.ts
+++ b/packages/firestore/src/util/log.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/util/misc.ts
+++ b/packages/firestore/src/util/misc.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/util/misc.ts
+++ b/packages/firestore/src/util/misc.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/util/node_api.ts
+++ b/packages/firestore/src/util/node_api.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/util/node_api.ts
+++ b/packages/firestore/src/util/node_api.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/util/obj.ts
+++ b/packages/firestore/src/util/obj.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/util/obj.ts
+++ b/packages/firestore/src/util/obj.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/util/obj_map.ts
+++ b/packages/firestore/src/util/obj_map.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/util/obj_map.ts
+++ b/packages/firestore/src/util/obj_map.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/util/promise.ts
+++ b/packages/firestore/src/util/promise.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/util/promise.ts
+++ b/packages/firestore/src/util/promise.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/util/sorted_map.ts
+++ b/packages/firestore/src/util/sorted_map.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/util/sorted_map.ts
+++ b/packages/firestore/src/util/sorted_map.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/util/sorted_set.ts
+++ b/packages/firestore/src/util/sorted_set.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/util/sorted_set.ts
+++ b/packages/firestore/src/util/sorted_set.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/util/types.ts
+++ b/packages/firestore/src/util/types.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/util/types.ts
+++ b/packages/firestore/src/util/types.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/integration/api/array_transforms.test.ts
+++ b/packages/firestore/test/integration/api/array_transforms.test.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/integration/api/array_transforms.test.ts
+++ b/packages/firestore/test/integration/api/array_transforms.test.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/integration/api/batch_writes.test.ts
+++ b/packages/firestore/test/integration/api/batch_writes.test.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/integration/api/batch_writes.test.ts
+++ b/packages/firestore/test/integration/api/batch_writes.test.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/integration/api/cursor.test.ts
+++ b/packages/firestore/test/integration/api/cursor.test.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/integration/api/cursor.test.ts
+++ b/packages/firestore/test/integration/api/cursor.test.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/integration/api/database.test.ts
+++ b/packages/firestore/test/integration/api/database.test.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/integration/api/database.test.ts
+++ b/packages/firestore/test/integration/api/database.test.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/integration/api/fields.test.ts
+++ b/packages/firestore/test/integration/api/fields.test.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/integration/api/fields.test.ts
+++ b/packages/firestore/test/integration/api/fields.test.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/integration/api/get_options.test.ts
+++ b/packages/firestore/test/integration/api/get_options.test.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/integration/api/get_options.test.ts
+++ b/packages/firestore/test/integration/api/get_options.test.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/integration/api/query.test.ts
+++ b/packages/firestore/test/integration/api/query.test.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/integration/api/query.test.ts
+++ b/packages/firestore/test/integration/api/query.test.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/integration/api/server_timestamp.test.ts
+++ b/packages/firestore/test/integration/api/server_timestamp.test.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/integration/api/server_timestamp.test.ts
+++ b/packages/firestore/test/integration/api/server_timestamp.test.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/integration/api/smoke.test.ts
+++ b/packages/firestore/test/integration/api/smoke.test.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/integration/api/smoke.test.ts
+++ b/packages/firestore/test/integration/api/smoke.test.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/integration/api/transactions.test.ts
+++ b/packages/firestore/test/integration/api/transactions.test.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/integration/api/transactions.test.ts
+++ b/packages/firestore/test/integration/api/transactions.test.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/integration/api/type.test.ts
+++ b/packages/firestore/test/integration/api/type.test.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/integration/api/type.test.ts
+++ b/packages/firestore/test/integration/api/type.test.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/integration/api/validation.test.ts
+++ b/packages/firestore/test/integration/api/validation.test.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/integration/api/validation.test.ts
+++ b/packages/firestore/test/integration/api/validation.test.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/integration/api_internal/idle_timeout.test.ts
+++ b/packages/firestore/test/integration/api_internal/idle_timeout.test.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/integration/api_internal/idle_timeout.test.ts
+++ b/packages/firestore/test/integration/api_internal/idle_timeout.test.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/integration/bootstrap.ts
+++ b/packages/firestore/test/integration/bootstrap.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/integration/bootstrap.ts
+++ b/packages/firestore/test/integration/bootstrap.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/integration/browser/indexeddb.test.ts
+++ b/packages/firestore/test/integration/browser/indexeddb.test.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/integration/browser/indexeddb.test.ts
+++ b/packages/firestore/test/integration/browser/indexeddb.test.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/integration/browser/webchannel.test.ts
+++ b/packages/firestore/test/integration/browser/webchannel.test.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/integration/browser/webchannel.test.ts
+++ b/packages/firestore/test/integration/browser/webchannel.test.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/integration/prime_backend.test.ts
+++ b/packages/firestore/test/integration/prime_backend.test.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/integration/prime_backend.test.ts
+++ b/packages/firestore/test/integration/prime_backend.test.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/integration/remote/remote.test.ts
+++ b/packages/firestore/test/integration/remote/remote.test.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/integration/remote/remote.test.ts
+++ b/packages/firestore/test/integration/remote/remote.test.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/integration/remote/stream.test.ts
+++ b/packages/firestore/test/integration/remote/stream.test.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/integration/remote/stream.test.ts
+++ b/packages/firestore/test/integration/remote/stream.test.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/integration/util/events_accumulator.ts
+++ b/packages/firestore/test/integration/util/events_accumulator.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/integration/util/events_accumulator.ts
+++ b/packages/firestore/test/integration/util/events_accumulator.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/integration/util/firebase_export.ts
+++ b/packages/firestore/test/integration/util/firebase_export.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/integration/util/firebase_export.ts
+++ b/packages/firestore/test/integration/util/firebase_export.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/integration/util/helpers.ts
+++ b/packages/firestore/test/integration/util/helpers.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/integration/util/helpers.ts
+++ b/packages/firestore/test/integration/util/helpers.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/integration/util/internal_helpers.ts
+++ b/packages/firestore/test/integration/util/internal_helpers.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/integration/util/internal_helpers.ts
+++ b/packages/firestore/test/integration/util/internal_helpers.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/unit/api/blob.test.ts
+++ b/packages/firestore/test/unit/api/blob.test.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/unit/api/blob.test.ts
+++ b/packages/firestore/test/unit/api/blob.test.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/unit/api/database.test.ts
+++ b/packages/firestore/test/unit/api/database.test.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/unit/api/database.test.ts
+++ b/packages/firestore/test/unit/api/database.test.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/unit/api/document_change.test.ts
+++ b/packages/firestore/test/unit/api/document_change.test.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/unit/api/document_change.test.ts
+++ b/packages/firestore/test/unit/api/document_change.test.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/unit/api/field_path.test.ts
+++ b/packages/firestore/test/unit/api/field_path.test.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/unit/api/field_path.test.ts
+++ b/packages/firestore/test/unit/api/field_path.test.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/unit/api/field_value.test.ts
+++ b/packages/firestore/test/unit/api/field_value.test.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/unit/api/field_value.test.ts
+++ b/packages/firestore/test/unit/api/field_value.test.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/unit/api/geo_point.test.ts
+++ b/packages/firestore/test/unit/api/geo_point.test.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/unit/api/geo_point.test.ts
+++ b/packages/firestore/test/unit/api/geo_point.test.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/unit/api/timestamp.test.ts
+++ b/packages/firestore/test/unit/api/timestamp.test.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/unit/api/timestamp.test.ts
+++ b/packages/firestore/test/unit/api/timestamp.test.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/unit/bootstrap.ts
+++ b/packages/firestore/test/unit/bootstrap.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/unit/bootstrap.ts
+++ b/packages/firestore/test/unit/bootstrap.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/unit/core/event_manager.test.ts
+++ b/packages/firestore/test/unit/core/event_manager.test.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/unit/core/event_manager.test.ts
+++ b/packages/firestore/test/unit/core/event_manager.test.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/unit/core/listen_sequence.test.ts
+++ b/packages/firestore/test/unit/core/listen_sequence.test.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/unit/core/listen_sequence.test.ts
+++ b/packages/firestore/test/unit/core/listen_sequence.test.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/unit/core/query.test.ts
+++ b/packages/firestore/test/unit/core/query.test.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/unit/core/query.test.ts
+++ b/packages/firestore/test/unit/core/query.test.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/unit/core/target_id_generator.test.ts
+++ b/packages/firestore/test/unit/core/target_id_generator.test.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/unit/core/target_id_generator.test.ts
+++ b/packages/firestore/test/unit/core/target_id_generator.test.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/unit/core/view.test.ts
+++ b/packages/firestore/test/unit/core/view.test.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/unit/core/view.test.ts
+++ b/packages/firestore/test/unit/core/view.test.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/unit/generate_spec_json.js
+++ b/packages/firestore/test/unit/generate_spec_json.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/unit/generate_spec_json.js
+++ b/packages/firestore/test/unit/generate_spec_json.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/unit/local/encoded_resource_path.test.ts
+++ b/packages/firestore/test/unit/local/encoded_resource_path.test.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/unit/local/encoded_resource_path.test.ts
+++ b/packages/firestore/test/unit/local/encoded_resource_path.test.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/unit/local/indexeddb_persistence.test.ts
+++ b/packages/firestore/test/unit/local/indexeddb_persistence.test.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/unit/local/indexeddb_persistence.test.ts
+++ b/packages/firestore/test/unit/local/indexeddb_persistence.test.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/unit/local/local_store.test.ts
+++ b/packages/firestore/test/unit/local/local_store.test.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/unit/local/local_store.test.ts
+++ b/packages/firestore/test/unit/local/local_store.test.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/unit/local/lru_garbage_collector.test.ts
+++ b/packages/firestore/test/unit/local/lru_garbage_collector.test.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/unit/local/lru_garbage_collector.test.ts
+++ b/packages/firestore/test/unit/local/lru_garbage_collector.test.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/unit/local/mutation_queue.test.ts
+++ b/packages/firestore/test/unit/local/mutation_queue.test.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/unit/local/mutation_queue.test.ts
+++ b/packages/firestore/test/unit/local/mutation_queue.test.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/unit/local/persistence_promise.test.ts
+++ b/packages/firestore/test/unit/local/persistence_promise.test.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/unit/local/persistence_promise.test.ts
+++ b/packages/firestore/test/unit/local/persistence_promise.test.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/unit/local/persistence_test_helpers.ts
+++ b/packages/firestore/test/unit/local/persistence_test_helpers.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/unit/local/persistence_test_helpers.ts
+++ b/packages/firestore/test/unit/local/persistence_test_helpers.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/unit/local/query_cache.test.ts
+++ b/packages/firestore/test/unit/local/query_cache.test.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/unit/local/query_cache.test.ts
+++ b/packages/firestore/test/unit/local/query_cache.test.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/unit/local/reference_set.test.ts
+++ b/packages/firestore/test/unit/local/reference_set.test.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/unit/local/reference_set.test.ts
+++ b/packages/firestore/test/unit/local/reference_set.test.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/unit/local/remote_document_cache.test.ts
+++ b/packages/firestore/test/unit/local/remote_document_cache.test.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/unit/local/remote_document_cache.test.ts
+++ b/packages/firestore/test/unit/local/remote_document_cache.test.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/unit/local/remote_document_change_buffer.test.ts
+++ b/packages/firestore/test/unit/local/remote_document_change_buffer.test.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/unit/local/remote_document_change_buffer.test.ts
+++ b/packages/firestore/test/unit/local/remote_document_change_buffer.test.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/unit/local/simple_db.test.ts
+++ b/packages/firestore/test/unit/local/simple_db.test.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/unit/local/simple_db.test.ts
+++ b/packages/firestore/test/unit/local/simple_db.test.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/unit/local/test_mutation_queue.ts
+++ b/packages/firestore/test/unit/local/test_mutation_queue.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/unit/local/test_mutation_queue.ts
+++ b/packages/firestore/test/unit/local/test_mutation_queue.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/unit/local/test_query_cache.ts
+++ b/packages/firestore/test/unit/local/test_query_cache.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/unit/local/test_query_cache.ts
+++ b/packages/firestore/test/unit/local/test_query_cache.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/unit/local/test_remote_document_cache.ts
+++ b/packages/firestore/test/unit/local/test_remote_document_cache.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/unit/local/test_remote_document_cache.ts
+++ b/packages/firestore/test/unit/local/test_remote_document_cache.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/unit/local/test_remote_document_change_buffer.ts
+++ b/packages/firestore/test/unit/local/test_remote_document_change_buffer.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/unit/local/test_remote_document_change_buffer.ts
+++ b/packages/firestore/test/unit/local/test_remote_document_change_buffer.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/unit/local/web_storage_shared_client_state.test.ts
+++ b/packages/firestore/test/unit/local/web_storage_shared_client_state.test.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/unit/local/web_storage_shared_client_state.test.ts
+++ b/packages/firestore/test/unit/local/web_storage_shared_client_state.test.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/unit/model/document.test.ts
+++ b/packages/firestore/test/unit/model/document.test.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/unit/model/document.test.ts
+++ b/packages/firestore/test/unit/model/document.test.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/unit/model/document_set.test.ts
+++ b/packages/firestore/test/unit/model/document_set.test.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/unit/model/document_set.test.ts
+++ b/packages/firestore/test/unit/model/document_set.test.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/unit/model/field_value.test.ts
+++ b/packages/firestore/test/unit/model/field_value.test.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/unit/model/field_value.test.ts
+++ b/packages/firestore/test/unit/model/field_value.test.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/unit/model/mutation.test.ts
+++ b/packages/firestore/test/unit/model/mutation.test.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/unit/model/mutation.test.ts
+++ b/packages/firestore/test/unit/model/mutation.test.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/unit/model/path.test.ts
+++ b/packages/firestore/test/unit/model/path.test.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/unit/model/path.test.ts
+++ b/packages/firestore/test/unit/model/path.test.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/unit/platform/platform.test.ts
+++ b/packages/firestore/test/unit/platform/platform.test.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/unit/platform/platform.test.ts
+++ b/packages/firestore/test/unit/platform/platform.test.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/unit/remote/node/serializer.test.ts
+++ b/packages/firestore/test/unit/remote/node/serializer.test.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/unit/remote/node/serializer.test.ts
+++ b/packages/firestore/test/unit/remote/node/serializer.test.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/unit/remote/remote_event.test.ts
+++ b/packages/firestore/test/unit/remote/remote_event.test.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/unit/remote/remote_event.test.ts
+++ b/packages/firestore/test/unit/remote/remote_event.test.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/unit/specs/collection_spec.test.ts
+++ b/packages/firestore/test/unit/specs/collection_spec.test.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/unit/specs/collection_spec.test.ts
+++ b/packages/firestore/test/unit/specs/collection_spec.test.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/unit/specs/describe_spec.ts
+++ b/packages/firestore/test/unit/specs/describe_spec.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/unit/specs/describe_spec.ts
+++ b/packages/firestore/test/unit/specs/describe_spec.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/unit/specs/existence_filter_spec.test.ts
+++ b/packages/firestore/test/unit/specs/existence_filter_spec.test.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/unit/specs/existence_filter_spec.test.ts
+++ b/packages/firestore/test/unit/specs/existence_filter_spec.test.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/unit/specs/limbo_spec.test.ts
+++ b/packages/firestore/test/unit/specs/limbo_spec.test.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/unit/specs/limbo_spec.test.ts
+++ b/packages/firestore/test/unit/specs/limbo_spec.test.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/unit/specs/limit_spec.test.ts
+++ b/packages/firestore/test/unit/specs/limit_spec.test.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/unit/specs/limit_spec.test.ts
+++ b/packages/firestore/test/unit/specs/limit_spec.test.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/unit/specs/listen_spec.test.ts
+++ b/packages/firestore/test/unit/specs/listen_spec.test.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/unit/specs/listen_spec.test.ts
+++ b/packages/firestore/test/unit/specs/listen_spec.test.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/unit/specs/offline_spec.test.ts
+++ b/packages/firestore/test/unit/specs/offline_spec.test.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/unit/specs/offline_spec.test.ts
+++ b/packages/firestore/test/unit/specs/offline_spec.test.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/unit/specs/orderby_spec.test.ts
+++ b/packages/firestore/test/unit/specs/orderby_spec.test.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/unit/specs/orderby_spec.test.ts
+++ b/packages/firestore/test/unit/specs/orderby_spec.test.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/unit/specs/perf_spec.test.ts
+++ b/packages/firestore/test/unit/specs/perf_spec.test.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/unit/specs/perf_spec.test.ts
+++ b/packages/firestore/test/unit/specs/perf_spec.test.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/unit/specs/persistence_spec.test.ts
+++ b/packages/firestore/test/unit/specs/persistence_spec.test.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/unit/specs/persistence_spec.test.ts
+++ b/packages/firestore/test/unit/specs/persistence_spec.test.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/unit/specs/remote_store_spec.test.ts
+++ b/packages/firestore/test/unit/specs/remote_store_spec.test.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/unit/specs/remote_store_spec.test.ts
+++ b/packages/firestore/test/unit/specs/remote_store_spec.test.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/unit/specs/resume_token_spec.test.ts
+++ b/packages/firestore/test/unit/specs/resume_token_spec.test.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/unit/specs/resume_token_spec.test.ts
+++ b/packages/firestore/test/unit/specs/resume_token_spec.test.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/unit/specs/spec_builder.ts
+++ b/packages/firestore/test/unit/specs/spec_builder.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/unit/specs/spec_builder.ts
+++ b/packages/firestore/test/unit/specs/spec_builder.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/unit/specs/spec_rpc_error.ts
+++ b/packages/firestore/test/unit/specs/spec_rpc_error.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/unit/specs/spec_rpc_error.ts
+++ b/packages/firestore/test/unit/specs/spec_rpc_error.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/unit/specs/spec_test_runner.ts
+++ b/packages/firestore/test/unit/specs/spec_test_runner.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/unit/specs/spec_test_runner.ts
+++ b/packages/firestore/test/unit/specs/spec_test_runner.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/unit/specs/write_spec.test.ts
+++ b/packages/firestore/test/unit/specs/write_spec.test.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/unit/specs/write_spec.test.ts
+++ b/packages/firestore/test/unit/specs/write_spec.test.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/unit/util/api.test.ts
+++ b/packages/firestore/test/unit/util/api.test.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/unit/util/api.test.ts
+++ b/packages/firestore/test/unit/util/api.test.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/unit/util/async_queue.test.ts
+++ b/packages/firestore/test/unit/util/async_queue.test.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/unit/util/async_queue.test.ts
+++ b/packages/firestore/test/unit/util/async_queue.test.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/unit/util/misc.test.ts
+++ b/packages/firestore/test/unit/util/misc.test.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/unit/util/misc.test.ts
+++ b/packages/firestore/test/unit/util/misc.test.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/unit/util/node_api.test.ts
+++ b/packages/firestore/test/unit/util/node_api.test.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/unit/util/node_api.test.ts
+++ b/packages/firestore/test/unit/util/node_api.test.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/unit/util/obj_map.test.ts
+++ b/packages/firestore/test/unit/util/obj_map.test.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/unit/util/obj_map.test.ts
+++ b/packages/firestore/test/unit/util/obj_map.test.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/unit/util/sorted_map.test.ts
+++ b/packages/firestore/test/unit/util/sorted_map.test.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/unit/util/sorted_map.test.ts
+++ b/packages/firestore/test/unit/util/sorted_map.test.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/unit/util/sorted_set.test.ts
+++ b/packages/firestore/test/unit/util/sorted_set.test.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/unit/util/sorted_set.test.ts
+++ b/packages/firestore/test/unit/util/sorted_set.test.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/util/api_helpers.ts
+++ b/packages/firestore/test/util/api_helpers.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/util/api_helpers.ts
+++ b/packages/firestore/test/util/api_helpers.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/util/equality_matcher.ts
+++ b/packages/firestore/test/util/equality_matcher.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/util/equality_matcher.ts
+++ b/packages/firestore/test/util/equality_matcher.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/util/helpers.ts
+++ b/packages/firestore/test/util/helpers.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/util/helpers.ts
+++ b/packages/firestore/test/util/helpers.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/util/node_persistence.ts
+++ b/packages/firestore/test/util/node_persistence.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/util/node_persistence.ts
+++ b/packages/firestore/test/util/node_persistence.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/util/promise.ts
+++ b/packages/firestore/test/util/promise.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/util/promise.ts
+++ b/packages/firestore/test/util/promise.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/util/test_platform.ts
+++ b/packages/firestore/test/util/test_platform.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/util/test_platform.ts
+++ b/packages/firestore/test/util/test_platform.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/functions-types/index.d.ts
+++ b/packages/functions-types/index.d.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/functions-types/index.d.ts
+++ b/packages/functions-types/index.d.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/functions/index.node.ts
+++ b/packages/functions/index.node.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/functions/index.node.ts
+++ b/packages/functions/index.node.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/functions/index.ts
+++ b/packages/functions/index.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/functions/index.ts
+++ b/packages/functions/index.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/functions/karma.conf.js
+++ b/packages/functions/karma.conf.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/functions/karma.conf.js
+++ b/packages/functions/karma.conf.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/functions/rollup.config.js
+++ b/packages/functions/rollup.config.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/functions/rollup.config.js
+++ b/packages/functions/rollup.config.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/functions/src/api/error.ts
+++ b/packages/functions/src/api/error.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/functions/src/api/error.ts
+++ b/packages/functions/src/api/error.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/functions/src/api/service.ts
+++ b/packages/functions/src/api/service.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/functions/src/api/service.ts
+++ b/packages/functions/src/api/service.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/functions/src/context.ts
+++ b/packages/functions/src/context.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/functions/src/context.ts
+++ b/packages/functions/src/context.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/functions/src/serializer.ts
+++ b/packages/functions/src/serializer.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/functions/src/serializer.ts
+++ b/packages/functions/src/serializer.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/functions/test/browser/callable.test.ts
+++ b/packages/functions/test/browser/callable.test.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/functions/test/browser/callable.test.ts
+++ b/packages/functions/test/browser/callable.test.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/functions/test/callable.test.ts
+++ b/packages/functions/test/callable.test.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/functions/test/callable.test.ts
+++ b/packages/functions/test/callable.test.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/functions/test/serializer.test.ts
+++ b/packages/functions/test/serializer.test.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/functions/test/serializer.test.ts
+++ b/packages/functions/test/serializer.test.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/functions/test/service.test.ts
+++ b/packages/functions/test/service.test.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/functions/test/service.test.ts
+++ b/packages/functions/test/service.test.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/logger/index.ts
+++ b/packages/logger/index.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/logger/index.ts
+++ b/packages/logger/index.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/logger/karma.conf.js
+++ b/packages/logger/karma.conf.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/logger/karma.conf.js
+++ b/packages/logger/karma.conf.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/logger/rollup.config.js
+++ b/packages/logger/rollup.config.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/logger/rollup.config.js
+++ b/packages/logger/rollup.config.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/logger/src/logger.ts
+++ b/packages/logger/src/logger.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/logger/src/logger.ts
+++ b/packages/logger/src/logger.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/logger/test/logger.test.ts
+++ b/packages/logger/test/logger.test.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/logger/test/logger.test.ts
+++ b/packages/logger/test/logger.test.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/messaging-types/index.d.ts
+++ b/packages/messaging-types/index.d.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/messaging-types/index.d.ts
+++ b/packages/messaging-types/index.d.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/messaging/index.ts
+++ b/packages/messaging/index.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/messaging/index.ts
+++ b/packages/messaging/index.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/messaging/karma.conf.js
+++ b/packages/messaging/karma.conf.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/messaging/karma.conf.js
+++ b/packages/messaging/karma.conf.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/messaging/rollup.config.js
+++ b/packages/messaging/rollup.config.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/messaging/rollup.config.js
+++ b/packages/messaging/rollup.config.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/messaging/src/controllers/base-controller.ts
+++ b/packages/messaging/src/controllers/base-controller.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/messaging/src/controllers/base-controller.ts
+++ b/packages/messaging/src/controllers/base-controller.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/messaging/src/controllers/sw-controller.ts
+++ b/packages/messaging/src/controllers/sw-controller.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/messaging/src/controllers/sw-controller.ts
+++ b/packages/messaging/src/controllers/sw-controller.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/messaging/src/controllers/sw-types.ts
+++ b/packages/messaging/src/controllers/sw-types.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/messaging/src/controllers/sw-types.ts
+++ b/packages/messaging/src/controllers/sw-types.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/messaging/src/controllers/window-controller.ts
+++ b/packages/messaging/src/controllers/window-controller.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/messaging/src/controllers/window-controller.ts
+++ b/packages/messaging/src/controllers/window-controller.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/messaging/src/helpers/array-buffer-to-base64.ts
+++ b/packages/messaging/src/helpers/array-buffer-to-base64.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/messaging/src/helpers/array-buffer-to-base64.ts
+++ b/packages/messaging/src/helpers/array-buffer-to-base64.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/messaging/src/helpers/base64-to-array-buffer.ts
+++ b/packages/messaging/src/helpers/base64-to-array-buffer.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/messaging/src/helpers/base64-to-array-buffer.ts
+++ b/packages/messaging/src/helpers/base64-to-array-buffer.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/messaging/src/helpers/is-array-buffer-equal.ts
+++ b/packages/messaging/src/helpers/is-array-buffer-equal.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/messaging/src/helpers/is-array-buffer-equal.ts
+++ b/packages/messaging/src/helpers/is-array-buffer-equal.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/messaging/src/interfaces/message-payload.ts
+++ b/packages/messaging/src/interfaces/message-payload.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/messaging/src/interfaces/message-payload.ts
+++ b/packages/messaging/src/interfaces/message-payload.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/messaging/src/interfaces/token-details.ts
+++ b/packages/messaging/src/interfaces/token-details.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/messaging/src/interfaces/token-details.ts
+++ b/packages/messaging/src/interfaces/token-details.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/messaging/src/interfaces/vapid-details.ts
+++ b/packages/messaging/src/interfaces/vapid-details.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/messaging/src/interfaces/vapid-details.ts
+++ b/packages/messaging/src/interfaces/vapid-details.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/messaging/src/models/clean-v1-undefined.ts
+++ b/packages/messaging/src/models/clean-v1-undefined.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/messaging/src/models/clean-v1-undefined.ts
+++ b/packages/messaging/src/models/clean-v1-undefined.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/messaging/src/models/db-interface.ts
+++ b/packages/messaging/src/models/db-interface.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/messaging/src/models/db-interface.ts
+++ b/packages/messaging/src/models/db-interface.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/messaging/src/models/default-sw.ts
+++ b/packages/messaging/src/models/default-sw.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/messaging/src/models/default-sw.ts
+++ b/packages/messaging/src/models/default-sw.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/messaging/src/models/errors.ts
+++ b/packages/messaging/src/models/errors.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/messaging/src/models/errors.ts
+++ b/packages/messaging/src/models/errors.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/messaging/src/models/fcm-details.ts
+++ b/packages/messaging/src/models/fcm-details.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/messaging/src/models/fcm-details.ts
+++ b/packages/messaging/src/models/fcm-details.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/messaging/src/models/iid-model.ts
+++ b/packages/messaging/src/models/iid-model.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/messaging/src/models/iid-model.ts
+++ b/packages/messaging/src/models/iid-model.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/messaging/src/models/token-details-model.ts
+++ b/packages/messaging/src/models/token-details-model.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/messaging/src/models/token-details-model.ts
+++ b/packages/messaging/src/models/token-details-model.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/messaging/src/models/vapid-details-model.ts
+++ b/packages/messaging/src/models/vapid-details-model.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/messaging/src/models/vapid-details-model.ts
+++ b/packages/messaging/src/models/vapid-details-model.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/messaging/src/models/worker-page-message.ts
+++ b/packages/messaging/src/models/worker-page-message.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/messaging/src/models/worker-page-message.ts
+++ b/packages/messaging/src/models/worker-page-message.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/messaging/test/constructor.test.ts
+++ b/packages/messaging/test/constructor.test.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/messaging/test/constructor.test.ts
+++ b/packages/messaging/test/constructor.test.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/messaging/test/controller-delete-token.test.ts
+++ b/packages/messaging/test/controller-delete-token.test.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/messaging/test/controller-delete-token.test.ts
+++ b/packages/messaging/test/controller-delete-token.test.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/messaging/test/controller-get-token.test.ts
+++ b/packages/messaging/test/controller-get-token.test.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/messaging/test/controller-get-token.test.ts
+++ b/packages/messaging/test/controller-get-token.test.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/messaging/test/controller-interface.test.ts
+++ b/packages/messaging/test/controller-interface.test.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/messaging/test/controller-interface.test.ts
+++ b/packages/messaging/test/controller-interface.test.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/messaging/test/db-interface.test.ts
+++ b/packages/messaging/test/db-interface.test.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/messaging/test/db-interface.test.ts
+++ b/packages/messaging/test/db-interface.test.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/messaging/test/get-sw-reg.test.ts
+++ b/packages/messaging/test/get-sw-reg.test.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/messaging/test/get-sw-reg.test.ts
+++ b/packages/messaging/test/get-sw-reg.test.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/messaging/test/helpers.test.ts
+++ b/packages/messaging/test/helpers.test.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/messaging/test/helpers.test.ts
+++ b/packages/messaging/test/helpers.test.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/messaging/test/iid-model.test.ts
+++ b/packages/messaging/test/iid-model.test.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/messaging/test/iid-model.test.ts
+++ b/packages/messaging/test/iid-model.test.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/messaging/test/index.test.ts
+++ b/packages/messaging/test/index.test.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/messaging/test/index.test.ts
+++ b/packages/messaging/test/index.test.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/messaging/test/sw-controller.test.ts
+++ b/packages/messaging/test/sw-controller.test.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/messaging/test/sw-controller.test.ts
+++ b/packages/messaging/test/sw-controller.test.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/messaging/test/testing-utils/db-helper.ts
+++ b/packages/messaging/test/testing-utils/db-helper.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/messaging/test/testing-utils/db-helper.ts
+++ b/packages/messaging/test/testing-utils/db-helper.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/messaging/test/testing-utils/detail-comparator.ts
+++ b/packages/messaging/test/testing-utils/detail-comparator.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/messaging/test/testing-utils/detail-comparator.ts
+++ b/packages/messaging/test/testing-utils/detail-comparator.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/messaging/test/testing-utils/make-fake-app.ts
+++ b/packages/messaging/test/testing-utils/make-fake-app.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/messaging/test/testing-utils/make-fake-app.ts
+++ b/packages/messaging/test/testing-utils/make-fake-app.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/messaging/test/testing-utils/make-fake-subscription.ts
+++ b/packages/messaging/test/testing-utils/make-fake-subscription.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/messaging/test/testing-utils/make-fake-subscription.ts
+++ b/packages/messaging/test/testing-utils/make-fake-subscription.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/messaging/test/testing-utils/make-fake-sw-reg.ts
+++ b/packages/messaging/test/testing-utils/make-fake-sw-reg.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/messaging/test/testing-utils/make-fake-sw-reg.ts
+++ b/packages/messaging/test/testing-utils/make-fake-sw-reg.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/messaging/test/testing-utils/messaging-test-runner.ts
+++ b/packages/messaging/test/testing-utils/messaging-test-runner.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/messaging/test/testing-utils/messaging-test-runner.ts
+++ b/packages/messaging/test/testing-utils/messaging-test-runner.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/messaging/test/testing-utils/mock-fetch.ts
+++ b/packages/messaging/test/testing-utils/mock-fetch.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/messaging/test/testing-utils/mock-fetch.ts
+++ b/packages/messaging/test/testing-utils/mock-fetch.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/messaging/test/token-details-model.test.ts
+++ b/packages/messaging/test/token-details-model.test.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/messaging/test/token-details-model.test.ts
+++ b/packages/messaging/test/token-details-model.test.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/messaging/test/vapid-details-model.test.ts
+++ b/packages/messaging/test/vapid-details-model.test.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/messaging/test/vapid-details-model.test.ts
+++ b/packages/messaging/test/vapid-details-model.test.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/messaging/test/window-controller.test.ts
+++ b/packages/messaging/test/window-controller.test.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/messaging/test/window-controller.test.ts
+++ b/packages/messaging/test/window-controller.test.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/polyfill/index.ts
+++ b/packages/polyfill/index.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/polyfill/index.ts
+++ b/packages/polyfill/index.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/polyfill/rollup.config.js
+++ b/packages/polyfill/rollup.config.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/polyfill/rollup.config.js
+++ b/packages/polyfill/rollup.config.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/rxfire/auth/index.ts
+++ b/packages/rxfire/auth/index.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/rxfire/auth/index.ts
+++ b/packages/rxfire/auth/index.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/rxfire/database/fromRef.d.ts
+++ b/packages/rxfire/database/fromRef.d.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/rxfire/database/fromRef.d.ts
+++ b/packages/rxfire/database/fromRef.d.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/rxfire/database/fromRef.ts
+++ b/packages/rxfire/database/fromRef.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/rxfire/database/fromRef.ts
+++ b/packages/rxfire/database/fromRef.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/rxfire/database/index.ts
+++ b/packages/rxfire/database/index.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/rxfire/database/index.ts
+++ b/packages/rxfire/database/index.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/rxfire/database/interfaces.d.ts
+++ b/packages/rxfire/database/interfaces.d.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/rxfire/database/interfaces.d.ts
+++ b/packages/rxfire/database/interfaces.d.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/rxfire/database/interfaces.ts
+++ b/packages/rxfire/database/interfaces.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/rxfire/database/interfaces.ts
+++ b/packages/rxfire/database/interfaces.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/rxfire/database/list/audit-trail.d.ts
+++ b/packages/rxfire/database/list/audit-trail.d.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/rxfire/database/list/audit-trail.d.ts
+++ b/packages/rxfire/database/list/audit-trail.d.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/rxfire/database/list/audit-trail.ts
+++ b/packages/rxfire/database/list/audit-trail.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/rxfire/database/list/audit-trail.ts
+++ b/packages/rxfire/database/list/audit-trail.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/rxfire/database/list/index.ts
+++ b/packages/rxfire/database/list/index.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/rxfire/database/list/index.ts
+++ b/packages/rxfire/database/list/index.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/rxfire/database/object/index.ts
+++ b/packages/rxfire/database/object/index.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/rxfire/database/object/index.ts
+++ b/packages/rxfire/database/object/index.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/rxfire/database/utils.d.ts
+++ b/packages/rxfire/database/utils.d.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/rxfire/database/utils.d.ts
+++ b/packages/rxfire/database/utils.d.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/rxfire/database/utils.ts
+++ b/packages/rxfire/database/utils.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/rxfire/database/utils.ts
+++ b/packages/rxfire/database/utils.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/rxfire/firestore/collection/index.ts
+++ b/packages/rxfire/firestore/collection/index.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/rxfire/firestore/collection/index.ts
+++ b/packages/rxfire/firestore/collection/index.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/rxfire/firestore/document/index.ts
+++ b/packages/rxfire/firestore/document/index.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/rxfire/firestore/document/index.ts
+++ b/packages/rxfire/firestore/document/index.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/rxfire/firestore/fromRef.ts
+++ b/packages/rxfire/firestore/fromRef.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/rxfire/firestore/fromRef.ts
+++ b/packages/rxfire/firestore/fromRef.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/rxfire/firestore/index.ts
+++ b/packages/rxfire/firestore/index.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/rxfire/firestore/index.ts
+++ b/packages/rxfire/firestore/index.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/rxfire/functions/index.ts
+++ b/packages/rxfire/functions/index.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/rxfire/functions/index.ts
+++ b/packages/rxfire/functions/index.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/rxfire/karma.conf.js
+++ b/packages/rxfire/karma.conf.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/rxfire/karma.conf.js
+++ b/packages/rxfire/karma.conf.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/rxfire/rollup.config.js
+++ b/packages/rxfire/rollup.config.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/rxfire/rollup.config.js
+++ b/packages/rxfire/rollup.config.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/rxfire/storage/index.ts
+++ b/packages/rxfire/storage/index.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/rxfire/storage/index.ts
+++ b/packages/rxfire/storage/index.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/rxfire/test/database.test.ts
+++ b/packages/rxfire/test/database.test.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/rxfire/test/database.test.ts
+++ b/packages/rxfire/test/database.test.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/rxfire/test/firestore.test.ts
+++ b/packages/rxfire/test/firestore.test.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/rxfire/test/firestore.test.ts
+++ b/packages/rxfire/test/firestore.test.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/storage-types/index.d.ts
+++ b/packages/storage-types/index.d.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/storage-types/index.d.ts
+++ b/packages/storage-types/index.d.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/storage/index.ts
+++ b/packages/storage/index.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/storage/index.ts
+++ b/packages/storage/index.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/storage/karma.conf.js
+++ b/packages/storage/karma.conf.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/storage/karma.conf.js
+++ b/packages/storage/karma.conf.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/storage/rollup.config.js
+++ b/packages/storage/rollup.config.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/storage/rollup.config.js
+++ b/packages/storage/rollup.config.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/storage/src/implementation/args.ts
+++ b/packages/storage/src/implementation/args.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/storage/src/implementation/args.ts
+++ b/packages/storage/src/implementation/args.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/storage/src/implementation/array.ts
+++ b/packages/storage/src/implementation/array.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/storage/src/implementation/array.ts
+++ b/packages/storage/src/implementation/array.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/storage/src/implementation/async.ts
+++ b/packages/storage/src/implementation/async.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/storage/src/implementation/async.ts
+++ b/packages/storage/src/implementation/async.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/storage/src/implementation/authwrapper.ts
+++ b/packages/storage/src/implementation/authwrapper.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/storage/src/implementation/authwrapper.ts
+++ b/packages/storage/src/implementation/authwrapper.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/storage/src/implementation/backoff.ts
+++ b/packages/storage/src/implementation/backoff.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/storage/src/implementation/backoff.ts
+++ b/packages/storage/src/implementation/backoff.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/storage/src/implementation/blob.ts
+++ b/packages/storage/src/implementation/blob.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/storage/src/implementation/blob.ts
+++ b/packages/storage/src/implementation/blob.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/storage/src/implementation/blobbuilder.d.ts
+++ b/packages/storage/src/implementation/blobbuilder.d.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/storage/src/implementation/blobbuilder.d.ts
+++ b/packages/storage/src/implementation/blobbuilder.d.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/storage/src/implementation/constants.ts
+++ b/packages/storage/src/implementation/constants.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/storage/src/implementation/constants.ts
+++ b/packages/storage/src/implementation/constants.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/storage/src/implementation/error.ts
+++ b/packages/storage/src/implementation/error.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/storage/src/implementation/error.ts
+++ b/packages/storage/src/implementation/error.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/storage/src/implementation/failrequest.ts
+++ b/packages/storage/src/implementation/failrequest.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/storage/src/implementation/failrequest.ts
+++ b/packages/storage/src/implementation/failrequest.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/storage/src/implementation/fs.ts
+++ b/packages/storage/src/implementation/fs.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/storage/src/implementation/fs.ts
+++ b/packages/storage/src/implementation/fs.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/storage/src/implementation/json.ts
+++ b/packages/storage/src/implementation/json.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/storage/src/implementation/json.ts
+++ b/packages/storage/src/implementation/json.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/storage/src/implementation/location.ts
+++ b/packages/storage/src/implementation/location.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/storage/src/implementation/location.ts
+++ b/packages/storage/src/implementation/location.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/storage/src/implementation/metadata.ts
+++ b/packages/storage/src/implementation/metadata.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/storage/src/implementation/metadata.ts
+++ b/packages/storage/src/implementation/metadata.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/storage/src/implementation/object.ts
+++ b/packages/storage/src/implementation/object.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/storage/src/implementation/object.ts
+++ b/packages/storage/src/implementation/object.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/storage/src/implementation/observer.ts
+++ b/packages/storage/src/implementation/observer.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/storage/src/implementation/observer.ts
+++ b/packages/storage/src/implementation/observer.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/storage/src/implementation/path.ts
+++ b/packages/storage/src/implementation/path.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/storage/src/implementation/path.ts
+++ b/packages/storage/src/implementation/path.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/storage/src/implementation/promise_external.ts
+++ b/packages/storage/src/implementation/promise_external.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/storage/src/implementation/promise_external.ts
+++ b/packages/storage/src/implementation/promise_external.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/storage/src/implementation/request.ts
+++ b/packages/storage/src/implementation/request.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/storage/src/implementation/request.ts
+++ b/packages/storage/src/implementation/request.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/storage/src/implementation/requestinfo.ts
+++ b/packages/storage/src/implementation/requestinfo.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/storage/src/implementation/requestinfo.ts
+++ b/packages/storage/src/implementation/requestinfo.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/storage/src/implementation/requestmaker.ts
+++ b/packages/storage/src/implementation/requestmaker.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/storage/src/implementation/requestmaker.ts
+++ b/packages/storage/src/implementation/requestmaker.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/storage/src/implementation/requestmap.ts
+++ b/packages/storage/src/implementation/requestmap.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/storage/src/implementation/requestmap.ts
+++ b/packages/storage/src/implementation/requestmap.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/storage/src/implementation/requests.ts
+++ b/packages/storage/src/implementation/requests.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/storage/src/implementation/requests.ts
+++ b/packages/storage/src/implementation/requests.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/storage/src/implementation/string.ts
+++ b/packages/storage/src/implementation/string.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/storage/src/implementation/string.ts
+++ b/packages/storage/src/implementation/string.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/storage/src/implementation/taskenums.ts
+++ b/packages/storage/src/implementation/taskenums.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/storage/src/implementation/taskenums.ts
+++ b/packages/storage/src/implementation/taskenums.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/storage/src/implementation/type.ts
+++ b/packages/storage/src/implementation/type.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/storage/src/implementation/type.ts
+++ b/packages/storage/src/implementation/type.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/storage/src/implementation/url.ts
+++ b/packages/storage/src/implementation/url.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/storage/src/implementation/url.ts
+++ b/packages/storage/src/implementation/url.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/storage/src/implementation/xhrio.ts
+++ b/packages/storage/src/implementation/xhrio.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/storage/src/implementation/xhrio.ts
+++ b/packages/storage/src/implementation/xhrio.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/storage/src/implementation/xhrio_network.ts
+++ b/packages/storage/src/implementation/xhrio_network.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/storage/src/implementation/xhrio_network.ts
+++ b/packages/storage/src/implementation/xhrio_network.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/storage/src/implementation/xhriopool.ts
+++ b/packages/storage/src/implementation/xhriopool.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/storage/src/implementation/xhriopool.ts
+++ b/packages/storage/src/implementation/xhriopool.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/storage/src/metadata.ts
+++ b/packages/storage/src/metadata.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/storage/src/metadata.ts
+++ b/packages/storage/src/metadata.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/storage/src/reference.ts
+++ b/packages/storage/src/reference.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/storage/src/reference.ts
+++ b/packages/storage/src/reference.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/storage/src/service.ts
+++ b/packages/storage/src/service.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/storage/src/service.ts
+++ b/packages/storage/src/service.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/storage/src/task.ts
+++ b/packages/storage/src/task.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/storage/src/task.ts
+++ b/packages/storage/src/task.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/storage/src/tasksnapshot.ts
+++ b/packages/storage/src/tasksnapshot.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/storage/src/tasksnapshot.ts
+++ b/packages/storage/src/tasksnapshot.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/storage/test/blob.test.ts
+++ b/packages/storage/test/blob.test.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/storage/test/blob.test.ts
+++ b/packages/storage/test/blob.test.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/storage/test/reference.test.ts
+++ b/packages/storage/test/reference.test.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/storage/test/reference.test.ts
+++ b/packages/storage/test/reference.test.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/storage/test/request.test.ts
+++ b/packages/storage/test/request.test.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/storage/test/request.test.ts
+++ b/packages/storage/test/request.test.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/storage/test/requests.test.ts
+++ b/packages/storage/test/requests.test.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/storage/test/requests.test.ts
+++ b/packages/storage/test/requests.test.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/storage/test/service.test.ts
+++ b/packages/storage/test/service.test.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/storage/test/service.test.ts
+++ b/packages/storage/test/service.test.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/storage/test/string.test.ts
+++ b/packages/storage/test/string.test.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/storage/test/string.test.ts
+++ b/packages/storage/test/string.test.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/storage/test/task.test.ts
+++ b/packages/storage/test/task.test.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/storage/test/task.test.ts
+++ b/packages/storage/test/task.test.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/storage/test/testshared.ts
+++ b/packages/storage/test/testshared.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/storage/test/testshared.ts
+++ b/packages/storage/test/testshared.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/storage/test/xhrio.ts
+++ b/packages/storage/test/xhrio.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/storage/test/xhrio.ts
+++ b/packages/storage/test/xhrio.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/template-types/index.d.ts
+++ b/packages/template-types/index.d.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/template-types/index.d.ts
+++ b/packages/template-types/index.d.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/template/index.node.ts
+++ b/packages/template/index.node.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/template/index.node.ts
+++ b/packages/template/index.node.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/template/index.ts
+++ b/packages/template/index.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/template/index.ts
+++ b/packages/template/index.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/template/karma.conf.js
+++ b/packages/template/karma.conf.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/template/karma.conf.js
+++ b/packages/template/karma.conf.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/template/rollup.config.js
+++ b/packages/template/rollup.config.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/template/rollup.config.js
+++ b/packages/template/rollup.config.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/template/src/index.ts
+++ b/packages/template/src/index.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/template/src/index.ts
+++ b/packages/template/src/index.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/template/test/index.test.ts
+++ b/packages/template/test/index.test.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/template/test/index.test.ts
+++ b/packages/template/test/index.test.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/testing/index.ts
+++ b/packages/testing/index.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/testing/index.ts
+++ b/packages/testing/index.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/testing/rollup.config.js
+++ b/packages/testing/rollup.config.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/testing/rollup.config.js
+++ b/packages/testing/rollup.config.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/testing/src/api/index.ts
+++ b/packages/testing/src/api/index.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/testing/src/api/index.ts
+++ b/packages/testing/src/api/index.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/testing/test/database.test.ts
+++ b/packages/testing/test/database.test.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/testing/test/database.test.ts
+++ b/packages/testing/test/database.test.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/util/index.node.ts
+++ b/packages/util/index.node.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/util/index.node.ts
+++ b/packages/util/index.node.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/util/index.ts
+++ b/packages/util/index.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/util/index.ts
+++ b/packages/util/index.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/util/karma.conf.js
+++ b/packages/util/karma.conf.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/util/karma.conf.js
+++ b/packages/util/karma.conf.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/util/rollup.config.js
+++ b/packages/util/rollup.config.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/util/rollup.config.js
+++ b/packages/util/rollup.config.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/util/src/assert.ts
+++ b/packages/util/src/assert.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/util/src/assert.ts
+++ b/packages/util/src/assert.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/util/src/constants.ts
+++ b/packages/util/src/constants.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/util/src/constants.ts
+++ b/packages/util/src/constants.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/util/src/crypt.ts
+++ b/packages/util/src/crypt.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/util/src/crypt.ts
+++ b/packages/util/src/crypt.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/util/src/deepCopy.ts
+++ b/packages/util/src/deepCopy.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/util/src/deepCopy.ts
+++ b/packages/util/src/deepCopy.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/util/src/deferred.ts
+++ b/packages/util/src/deferred.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/util/src/deferred.ts
+++ b/packages/util/src/deferred.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/util/src/environment.ts
+++ b/packages/util/src/environment.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/util/src/environment.ts
+++ b/packages/util/src/environment.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/util/src/errors.ts
+++ b/packages/util/src/errors.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/util/src/errors.ts
+++ b/packages/util/src/errors.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/util/src/hash.ts
+++ b/packages/util/src/hash.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/util/src/hash.ts
+++ b/packages/util/src/hash.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/util/src/json.ts
+++ b/packages/util/src/json.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/util/src/json.ts
+++ b/packages/util/src/json.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/util/src/jwt.ts
+++ b/packages/util/src/jwt.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/util/src/jwt.ts
+++ b/packages/util/src/jwt.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/util/src/obj.ts
+++ b/packages/util/src/obj.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/util/src/obj.ts
+++ b/packages/util/src/obj.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/util/src/query.ts
+++ b/packages/util/src/query.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/util/src/query.ts
+++ b/packages/util/src/query.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/util/src/sha1.ts
+++ b/packages/util/src/sha1.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/util/src/sha1.ts
+++ b/packages/util/src/sha1.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/util/src/subscribe.ts
+++ b/packages/util/src/subscribe.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/util/src/subscribe.ts
+++ b/packages/util/src/subscribe.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/util/src/utf8.ts
+++ b/packages/util/src/utf8.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/util/src/utf8.ts
+++ b/packages/util/src/utf8.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/util/src/validation.ts
+++ b/packages/util/src/validation.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/util/src/validation.ts
+++ b/packages/util/src/validation.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/util/test/base64.test.ts
+++ b/packages/util/test/base64.test.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/util/test/base64.test.ts
+++ b/packages/util/test/base64.test.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/util/test/deepCopy.test.ts
+++ b/packages/util/test/deepCopy.test.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/util/test/deepCopy.test.ts
+++ b/packages/util/test/deepCopy.test.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/util/test/errors.test.ts
+++ b/packages/util/test/errors.test.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/util/test/errors.test.ts
+++ b/packages/util/test/errors.test.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/util/test/subscribe.test.ts
+++ b/packages/util/test/subscribe.test.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/util/test/subscribe.test.ts
+++ b/packages/util/test/subscribe.test.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/webchannel-wrapper/externs/overrides.js
+++ b/packages/webchannel-wrapper/externs/overrides.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/webchannel-wrapper/externs/overrides.js
+++ b/packages/webchannel-wrapper/externs/overrides.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/webchannel-wrapper/src/index.js
+++ b/packages/webchannel-wrapper/src/index.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/webchannel-wrapper/src/index.js
+++ b/packages/webchannel-wrapper/src/index.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/webchannel-wrapper/tools/build.js
+++ b/packages/webchannel-wrapper/tools/build.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/webchannel-wrapper/tools/build.js
+++ b/packages/webchannel-wrapper/tools/build.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/tools/gitHooks/license.js
+++ b/tools/gitHooks/license.js
@@ -10,6 +10,7 @@ const glob = promisify(globRaw);
 const root = resolve(__dirname, '../..');
 const git = simpleGit(root);
 const licenseHeader = `/**
+ * @license
  * Copyright 2019 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/yarn.lock
+++ b/yarn.lock
@@ -3770,6 +3770,11 @@ commander@~2.8.1:
   dependencies:
     graceful-readlink ">= 1.0.0"
 
+commenting@1.0.5:
+  version "1.0.5"
+  resolved "https://registry.npmjs.org/commenting/-/commenting-1.0.5.tgz#3104d542cac8a4f27b3d51438f4b80431fe4526b"
+  integrity sha512-U7qGbcDLSNpOcV3RQRKHp7hFpy9WUmfawbkPdS4R2RhrSu4dOF85QQpx/Zjcv7uLF6tWSUKEKUIkxknPCrVjwg==
+
 commondir@^1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz#ddd800da0c66127393cca5950ea968a3aaf1253b"
@@ -6396,6 +6401,15 @@ git-remote-origin-url@^2.0.0:
     gitconfiglocal "^1.0.0"
     pify "^2.3.0"
 
+git-rev-sync@1.12.0:
+  version "1.12.0"
+  resolved "https://registry.npmjs.org/git-rev-sync/-/git-rev-sync-1.12.0.tgz#4468406c7e6c3ba4cf4587999e1adb28d9d1af55"
+  integrity sha1-RGhAbH5sO6TPRYeZnhrbKNnRr1U=
+  dependencies:
+    escape-string-regexp "1.0.5"
+    graceful-fs "4.1.11"
+    shelljs "0.7.7"
+
 git-semver-tags@^2.0.2:
   version "2.0.2"
   resolved "https://registry.npmjs.org/git-semver-tags/-/git-semver-tags-2.0.2.tgz#f506ec07caade191ac0c8d5a21bdb8131b4934e3"
@@ -6864,15 +6878,15 @@ got@^8.3.2:
     url-parse-lax "^3.0.0"
     url-to-options "^1.0.1"
 
+graceful-fs@4.1.11, graceful-fs@^4.0.0, graceful-fs@^4.1.0, graceful-fs@^4.1.10, graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.1.9:
+  version "4.1.11"
+  resolved "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
+  integrity sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=
+
 graceful-fs@4.X, graceful-fs@^4.1.15:
   version "4.1.15"
   resolved "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz#ffb703e1066e8a0eeaa4c8b80ba9253eeefbfb00"
   integrity sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==
-
-graceful-fs@^4.0.0, graceful-fs@^4.1.0, graceful-fs@^4.1.10, graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.1.9:
-  version "4.1.11"
-  resolved "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
-  integrity sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=
 
 "graceful-readlink@>= 1.0.0":
   version "1.0.1"
@@ -9460,6 +9474,11 @@ lodash@4.16.2:
   resolved "https://registry.npmjs.org/lodash/-/lodash-4.16.2.tgz#3e626db827048a699281a8a125226326cfc0e652"
   integrity sha1-PmJtuCcEimmSgaihJSJjJs/A5lI=
 
+lodash@4.17.11, lodash@^4.17.10:
+  version "4.17.11"
+  resolved "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
+  integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
+
 lodash@4.17.5, lodash@^4.0.0, lodash@^4.14.0, lodash@^4.15.0, lodash@^4.16.6, lodash@^4.17.4, lodash@^4.2.1, lodash@^4.3.0, lodash@^4.5.0, lodash@^4.6.1, lodash@^4.8.0:
   version "4.17.5"
   resolved "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz#99a92d65c0272debe8c96b6057bc8fbfa3bed511"
@@ -9474,11 +9493,6 @@ lodash@^3.10.0, lodash@^3.10.1, lodash@^3.8.0:
   version "3.10.1"
   resolved "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
   integrity sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=
-
-lodash@^4.17.10:
-  version "4.17.11"
-  resolved "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
-  integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
 
 lodash@^4.17.5:
   version "4.17.10"
@@ -9629,6 +9643,13 @@ lru-queue@0.1:
   integrity sha1-Jzi9nw089PhEkMVzbEhpmsYyzaM=
   dependencies:
     es5-ext "~0.10.2"
+
+magic-string@0.25.1:
+  version "0.25.1"
+  resolved "https://registry.npmjs.org/magic-string/-/magic-string-0.25.1.tgz#b1c248b399cd7485da0fe7385c2fc7011843266e"
+  integrity sha512-sCuTz6pYom8Rlt4ISPFn6wuFodbKMIHUMv4Qko9P17dpxb7s52KJTmRuZZqHdGmLCK9AOcDare039nRIcfdkEg==
+  dependencies:
+    sourcemap-codec "^1.4.1"
 
 magic-string@^0.22.4:
   version "0.22.5"
@@ -10168,6 +10189,11 @@ module-deps@^6.0.0:
     subarg "^1.0.0"
     through2 "^2.0.0"
     xtend "^4.0.0"
+
+moment@2.23.0:
+  version "2.23.0"
+  resolved "https://registry.npmjs.org/moment/-/moment-2.23.0.tgz#759ea491ac97d54bac5ad776996e2a58cc1bc225"
+  integrity sha512-3IE39bHVqFbWWaPOMHZF98Q9c3LDKGTmypMiTM2QygGXXElkFWIH7GxfmlwmY2vwa+wmNsoYZmG2iusf1ZjJoA==
 
 moment@2.x.x:
   version "2.22.0"
@@ -12703,6 +12729,17 @@ rollup-plugin-hypothetical@2.1.0:
   resolved "https://registry.npmjs.org/rollup-plugin-hypothetical/-/rollup-plugin-hypothetical-2.1.0.tgz#7fec9a865ed7d0eac14ca6ee2b2c4088acdb1955"
   integrity sha512-MlxPQTkMtiRUtyhIJ7FpBvTzWtar8eFBA+V7/J6Deg9fSgIIHwL6bJKK1Wl1uWSWtOrWhOmtsMwb9F6aagP/Pg==
 
+rollup-plugin-license@0.8.1:
+  version "0.8.1"
+  resolved "https://registry.npmjs.org/rollup-plugin-license/-/rollup-plugin-license-0.8.1.tgz#cdcfee2a32f27790e5019a2a7abd9234476ac589"
+  integrity sha512-UeDVawklIv/rb4/M8AqHHtt03L+gDNfCVjQJqgUaQKiNTmUk+peAzkaLYeC6kfQm7i77kGYEzkbPZ0Dd9NEbCQ==
+  dependencies:
+    commenting "1.0.5"
+    lodash "4.17.11"
+    magic-string "0.25.1"
+    mkdirp "0.5.1"
+    moment "2.23.0"
+
 rollup-plugin-node-resolve@3.3.0:
   version "3.3.0"
   resolved "https://registry.npmjs.org/rollup-plugin-node-resolve/-/rollup-plugin-node-resolve-3.3.0.tgz#c26d110a36812cbefa7ce117cadcd3439aa1c713"
@@ -13138,6 +13175,15 @@ shell-quote@^1.6.1:
     array-map "~0.0.0"
     array-reduce "~0.0.0"
     jsonify "~0.0.0"
+
+shelljs@0.7.7:
+  version "0.7.7"
+  resolved "https://registry.npmjs.org/shelljs/-/shelljs-0.7.7.tgz#b2f5c77ef97148f4b4f6e22682e10bba8667cff1"
+  integrity sha1-svXHfvlxSPS09uImguELuoZnz/E=
+  dependencies:
+    glob "^7.0.0"
+    interpret "^1.0.0"
+    rechoir "^0.6.2"
 
 shelljs@~0.5:
   version "0.5.3"


### PR DESCRIPTION
Adding @license tags to all existing license comments and configuring rollup to add license comments to generated code in the same format as Webpack was previously doing.  This is to conform to google3 third_party rules about licenses in code.