### PR TITLE
Fix flaky test.

### DIFF
--- a/packages/firestore/test/integration/api/server_timestamp.test.ts
+++ b/packages/firestore/test/integration/api/server_timestamp.test.ts
@@ -245,11 +245,12 @@ apiDescribe('Server Timestamps', persistence => {
   it('can return previous value through consecutive updates', () => {
     return withTestSetup(() => {
       return writeInitialData()
-        .then(() => docRef.firestore.disableNetwork)
+        .then(() => docRef.firestore.disableNetwork())
         .then(() => {
           // We set up two consecutive writes with server timestamps.
           docRef.update('a', FieldValue.serverTimestamp());
-          docRef.update('a', FieldValue.serverTimestamp());
+          // include b=1 to ensure there's a change resulting in a new snapshot.
+          docRef.update('a', FieldValue.serverTimestamp(), 'b', 1);
           return accumulator.awaitLocalEvents(2);
         })
         .then(snapshots => {
@@ -260,6 +261,11 @@ apiDescribe('Server Timestamps', persistence => {
           expect(
             snapshots[1].get('a', { serverTimestamps: 'previous' })
           ).to.equal(42);
+          return docRef.firestore.enableNetwork();
+        })
+        .then(() => accumulator.awaitRemoteEvent())
+        .then(remoteSnapshot => {
+          expect(remoteSnapshot.get('a')).to.be.an.instanceof(Timestamp);
         });
     });
   });
@@ -267,7 +273,7 @@ apiDescribe('Server Timestamps', persistence => {
   it('uses previous value from local mutation', () => {
     return withTestSetup(() => {
       return writeInitialData()
-        .then(() => docRef.firestore.disableNetwork)
+        .then(() => docRef.firestore.disableNetwork())
         .then(() => {
           // We set up three consecutive writes.
           docRef.update('a', FieldValue.serverTimestamp());
@@ -284,6 +290,11 @@ apiDescribe('Server Timestamps', persistence => {
           expect(
             snapshots[2].get('a', { serverTimestamps: 'previous' })
           ).to.equal(1337);
+          return docRef.firestore.enableNetwork();
+        })
+        .then(() => accumulator.awaitRemoteEvent())
+        .then(remoteSnapshot => {
+          expect(remoteSnapshot.get('a')).to.be.an.instanceof(Timestamp);
         });
     });
   });


### PR DESCRIPTION
The "can return previous value through consecutive updates" test was flaky
because it did two consecutive server timestamp writes to the same field and
expected 2 local events. But if you do both writes within 1ms then the
snapshots will be indistinguishable (the estimated value for the server
timestamps will be the same) and so only 1 event will be raised. I added an
additional change to the second write to guarantee it triggers an event.

While looking at the test, I also noticed it was slightly broken / incomplete.
There was an incorrect line attempting to disable the network and the test was
missing the remaining code to re-enable the network and verify the behavior.  I
fixed that as well.
