### PR TITLE
 Implement timeouts in HttpsCallables.

### DIFF
--- a/config/functions/index.js
+++ b/config/functions/index.js
@@ -134,3 +134,10 @@ exports.httpErrorTest = functions.https.onRequest((request, response) => {
     response.status(400).send();
   });
 });
+
+exports.timeoutTest = functions.https.onRequest((request, response) => {
+  cors(request, response, () => {
+    // Wait for longer than 500ms.
+    setTimeout(() => response.send({data: true}), 500);
+  });
+});

--- a/config/functions/index.js
+++ b/config/functions/index.js
@@ -138,6 +138,6 @@ exports.httpErrorTest = functions.https.onRequest((request, response) => {
 exports.timeoutTest = functions.https.onRequest((request, response) => {
   cors(request, response, () => {
     // Wait for longer than 500ms.
-    setTimeout(() => response.send({data: true}), 500);
+    setTimeout(() => response.send({ data: true }), 500);
   });
 });

--- a/packages/firebase/index.d.ts
+++ b/packages/firebase/index.d.ts
@@ -144,10 +144,13 @@ declare namespace firebase.functions {
   export interface HttpsCallable {
     (data?: any): Promise<HttpsCallableResult>;
   }
+  export interface HttpsCallableOptions {
+    timeout?: number;
+  }
   export class Functions {
     private constructor();
     useFunctionsEmulator(url: string): void;
-    httpsCallable(name: string): HttpsCallable;
+    httpsCallable(name: string, options?: HttpsCallableOptions): HttpsCallable;
   }
   export type ErrorStatus =
     | 'ok'

--- a/packages/functions-types/index.d.ts
+++ b/packages/functions-types/index.d.ts
@@ -34,7 +34,7 @@ export interface HttpsCallable {
  * HttpsCallableOptions specify metadata about how calls should be executed.
  */
 export interface HttpsCallableOptions {
-  timeout?: number;  // in millis
+  timeout?: number; // in millis
 }
 
 /**

--- a/packages/functions-types/index.d.ts
+++ b/packages/functions-types/index.d.ts
@@ -31,6 +31,13 @@ export interface HttpsCallable {
 }
 
 /**
+ * HttpsCallableOptions specify metadata about how calls should be executed.
+ */
+export interface HttpsCallableOptions {
+  timeout?: number;  // in millis
+}
+
+/**
  * `FirebaseFunctions` represents a Functions app, and is the entry point for
  * all Functions operations.
  */
@@ -44,7 +51,7 @@ export class FirebaseFunctions {
    * @param name The name of the https callable function.
    * @return The `HttpsCallable` instance.
    */
-  httpsCallable(name: string): HttpsCallable;
+  httpsCallable(name: string, options?: HttpsCallableOptions): HttpsCallable;
 
   /**
    * Changes this instance to point to a Cloud Functions emulator running

--- a/packages/functions/src/api/service.ts
+++ b/packages/functions/src/api/service.ts
@@ -21,7 +21,8 @@ import {
   FirebaseFunctions,
   FunctionsErrorCode,
   HttpsCallable,
-  HttpsCallableResult
+  HttpsCallableResult,
+  HttpsCallableOptions
 } from '@firebase/functions-types';
 import { _errorForResponse, HttpsErrorImpl } from './error';
 import { ContextProvider } from '../context';
@@ -33,6 +34,19 @@ import { Serializer } from '../serializer';
 interface HttpResponse {
   status: number;
   json: any;
+}
+
+/**
+ * Returns a Promise that will be rejected after the given duration.
+ * The error will be of type HttpsErrorImpl.
+ *
+ * @param millis Number of milliseconds to wait before rejecting.
+ */
+function delay(millis): Promise<Response> {
+  return new Promise((_, reject) => {
+    const error = new HttpsErrorImpl('deadline-exceeded', 'deadline-exceeded');
+    setTimeout(() => reject(error), millis);
+  });
 }
 
 /**
@@ -88,9 +102,9 @@ export class Service implements FirebaseFunctions {
    * Returns a reference to the callable https trigger with the given name.
    * @param name The name of the trigger.
    */
-  httpsCallable(name: string): HttpsCallable {
+  httpsCallable(name: string, options?: HttpsCallableOptions): HttpsCallable {
     let callable = <HttpsCallable>(data?: any) => {
-      return this.call(name, data);
+      return this.call(name, data, options || {});
     };
     return callable;
   }
@@ -118,7 +132,7 @@ export class Service implements FirebaseFunctions {
       });
     } catch (e) {
       // This could be an unhandled error on the backend, or it could be a
-      // network error. There's no way to no, since an unhandled error on the
+      // network error. There's no way to know, since an unhandled error on the
       // backend will fail to set the proper CORS header, and thus will be
       // treated as a network error by fetch.
       return {
@@ -143,7 +157,7 @@ export class Service implements FirebaseFunctions {
    * @param name The name of the callable trigger.
    * @param data The data to pass as params to the function.s
    */
-  private async call(name: string, data: any): Promise<HttpsCallableResult> {
+  private async call(name: string, data: any, options: HttpsCallableOptions): Promise<HttpsCallableResult> {
     const url = this._url(name);
 
     // Encode any special types, such as dates, in the input data.
@@ -160,7 +174,13 @@ export class Service implements FirebaseFunctions {
       headers.append('Firebase-Instance-ID-Token', context.instanceIdToken);
     }
 
-    const response = await this.postJSON(url, body, headers);
+    // Default timeout to 60s, but let the options override it.
+    const timeout = options.timeout || 60000;
+
+    const response = await Promise.race([
+      this.postJSON(url, body, headers),
+      delay(timeout)
+    ]);
 
     // Check for an error status, regardless of http status.
     const error = _errorForResponse(

--- a/packages/functions/src/api/service.ts
+++ b/packages/functions/src/api/service.ts
@@ -157,7 +157,11 @@ export class Service implements FirebaseFunctions {
    * @param name The name of the callable trigger.
    * @param data The data to pass as params to the function.s
    */
-  private async call(name: string, data: any, options: HttpsCallableOptions): Promise<HttpsCallableResult> {
+  private async call(
+    name: string,
+    data: any,
+    options: HttpsCallableOptions
+  ): Promise<HttpsCallableResult> {
     const url = this._url(name);
 
     // Encode any special types, such as dates, in the input data.

--- a/packages/functions/src/api/service.ts
+++ b/packages/functions/src/api/service.ts
@@ -179,8 +179,8 @@ export class Service implements FirebaseFunctions {
       headers.append('Firebase-Instance-ID-Token', context.instanceIdToken);
     }
 
-    // Default timeout to 60s, but let the options override it.
-    const timeout = options.timeout || 60000;
+    // Default timeout to 70s, but let the options override it.
+    const timeout = options.timeout || 70000;
 
     const response = await Promise.race([
       this.postJSON(url, body, headers),

--- a/packages/functions/src/api/service.ts
+++ b/packages/functions/src/api/service.ts
@@ -42,7 +42,7 @@ interface HttpResponse {
  *
  * @param millis Number of milliseconds to wait before rejecting.
  */
-function delay(millis): Promise<Response> {
+function failAfter(millis): Promise<HttpResponse> {
   return new Promise((_, reject) => {
     const error = new HttpsErrorImpl('deadline-exceeded', 'deadline-exceeded');
     setTimeout(() => reject(error), millis);
@@ -183,7 +183,7 @@ export class Service implements FirebaseFunctions {
 
     const response = await Promise.race([
       this.postJSON(url, body, headers),
-      delay(timeout)
+      failAfter(timeout)
     ]);
 
     // Check for an error status, regardless of http status.

--- a/packages/functions/src/api/service.ts
+++ b/packages/functions/src/api/service.ts
@@ -42,10 +42,11 @@ interface HttpResponse {
  *
  * @param millis Number of milliseconds to wait before rejecting.
  */
-function failAfter(millis): Promise<HttpResponse> {
+function failAfter(millis: number): Promise<HttpResponse> {
   return new Promise((_, reject) => {
-    const error = new HttpsErrorImpl('deadline-exceeded', 'deadline-exceeded');
-    setTimeout(() => reject(error), millis);
+    setTimeout(() => {
+      reject(new HttpsErrorImpl('deadline-exceeded', 'deadline-exceeded'));
+    }, millis);
   });
 }
 

--- a/packages/functions/test/callable.test.ts
+++ b/packages/functions/test/callable.test.ts
@@ -43,7 +43,7 @@ async function expectError(
     expect(e.details).to.deep.equal(details);
   }
   if (!failed) {
-    expect(false, 'Promise should have failed.');
+    expect(false, 'Promise should have failed.').to.be.true;
   }
 }
 
@@ -168,5 +168,10 @@ describe('Firebase Functions > Call', () => {
   it('http error', async () => {
     const func = functions.httpsCallable('httpErrorTest');
     await expectError(func(), 'invalid-argument', 'invalid-argument');
+  });
+
+  it('timeout', async () => {
+    const func = functions.httpsCallable('timeoutTest', {timeout: 10});
+    await expectError(func(), 'deadline-exceeded', 'deadline-exceeded');
   });
 });

--- a/packages/functions/test/callable.test.ts
+++ b/packages/functions/test/callable.test.ts
@@ -171,7 +171,7 @@ describe('Firebase Functions > Call', () => {
   });
 
   it('timeout', async () => {
-    const func = functions.httpsCallable('timeoutTest', {timeout: 10});
+    const func = functions.httpsCallable('timeoutTest', { timeout: 10 });
     await expectError(func(), 'deadline-exceeded', 'deadline-exceeded');
   });
 });


### PR DESCRIPTION
`fetch` doesn't support timeouts directly, so this uses `Promise.race` instead.

This also fixes a small problem with the functions test runner that would ignore some errors.