### PR TITLE
Set up separate esm build for polyfill

### DIFF
--- a/packages/polyfill/package.json
+++ b/packages/polyfill/package.json
@@ -22,6 +22,8 @@
   },
   "devDependencies": {
     "rollup": "0.57.1",
+    "rollup-plugin-commonjs": "9.1.0",	
+    "rollup-plugin-node-resolve": "3.3.0",
     "rollup-plugin-typescript2": "0.12.0"
   },
   "repository": {

--- a/packages/polyfill/rollup.config.js
+++ b/packages/polyfill/rollup.config.js
@@ -33,17 +33,13 @@ const deps = Object.keys(
 export default [
   {
     input: 'index.ts',
-    output: [
-      { file: pkg.main, format: 'cjs' }
-    ],
+    output: [{ file: pkg.main, format: 'cjs' }],
     plugins,
     external: id => deps.some(dep => id === dep || id.startsWith(`${dep}/`))
   },
   {
     input: 'index.ts',
-    output: [
-      { file: pkg.module, format: 'es' }
-    ],
+    output: [{ file: pkg.module, format: 'es' }],
     plugins: [...plugins, resolve(), commonjs()],
     external: deps
   }

--- a/packages/polyfill/rollup.config.js
+++ b/packages/polyfill/rollup.config.js
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+import commonjs from 'rollup-plugin-commonjs';
+import resolve from 'rollup-plugin-node-resolve';
 import typescript from 'rollup-plugin-typescript2';
 import pkg from './package.json';
 
@@ -28,12 +30,21 @@ const deps = Object.keys(
   Object.assign({}, pkg.peerDependencies, pkg.dependencies)
 );
 
-export default {
-  input: 'index.ts',
-  output: [
-    { file: pkg.main, format: 'cjs' },
-    { file: pkg.module, format: 'es' }
-  ],
-  plugins,
-  external: id => deps.some(dep => id === dep || id.startsWith(`${dep}/`))
-};
+export default [
+  {
+    input: 'index.ts',
+    output: [
+      { file: pkg.main, format: 'cjs' }
+    ],
+    plugins,
+    external: id => deps.some(dep => id === dep || id.startsWith(`${dep}/`))
+  },
+  {
+    input: 'index.ts',
+    output: [
+      { file: pkg.module, format: 'es' }
+    ],
+    plugins: [...plugins, resolve(), commonjs()],
+    external: deps
+  }
+];


### PR DESCRIPTION
The `polyfill` package has a dependency on the `core-js` library, which is not an es module.  To create a build consumable as esm, we need to bundle the `core-js` code converted to esm format.  This seems to be the cause of issue https://github.com/firebase/firebase-js-sdk/issues/1516 and was caused during the removal of (mostly) unnecessary dependencies in PR https://github.com/firebase/firebase-js-sdk/pull/699.