### PR TITLE
Forbid queries endAt an uncommitted server timestamp.

### DIFF
--- a/packages/firestore/test/integration/api/validation.test.ts
+++ b/packages/firestore/test/integration/api/validation.test.ts
@@ -19,7 +19,6 @@ import * as firestore from '@firebase/firestore-types';
 import { expect } from 'chai';
 
 import { CACHE_SIZE_UNLIMITED } from '../../../src/api/database';
-import { EventsAccumulator } from '../util/events_accumulator';
 import firebase from '../util/firebase_export';
 import {
   ALT_PROJECT_ID,

--- a/packages/firestore/test/integration/api/validation.test.ts
+++ b/packages/firestore/test/integration/api/validation.test.ts
@@ -847,6 +847,8 @@ apiDescribe('Validation:', persistence => {
 
             await db.enableNetwork();
             await onlineAccumulator.awaitEvent();
+
+            unsubscribe();
           }
         );
       }

--- a/packages/firestore/test/integration/api/validation.test.ts
+++ b/packages/firestore/test/integration/api/validation.test.ts
@@ -19,6 +19,7 @@ import * as firestore from '@firebase/firestore-types';
 import { expect } from 'chai';
 
 import { CACHE_SIZE_UNLIMITED } from '../../../src/api/database';
+import { Deferred } from '../../util/promise';
 import firebase from '../util/firebase_export';
 import {
   ALT_PROJECT_ID,
@@ -28,7 +29,6 @@ import {
   withTestCollection,
   withTestDb
 } from '../util/helpers';
-import { Deferred } from '../../util/promise';
 
 const FieldPath = firebase.firestore!.FieldPath;
 const FieldValue = firebase.firestore!.FieldValue;

--- a/packages/firestore/test/integration/api/validation.test.ts
+++ b/packages/firestore/test/integration/api/validation.test.ts
@@ -806,8 +806,12 @@ apiDescribe('Validation:', persistence => {
           async (collection: firestore.CollectionReference) => {
             await db.disableNetwork();
 
-            const offlineAccumulator = new EventsAccumulator<firestore.QuerySnapshot>();
-            const onlineAccumulator = new EventsAccumulator<firestore.QuerySnapshot>();
+            const offlineAccumulator = new EventsAccumulator<
+              firestore.QuerySnapshot
+            >();
+            const onlineAccumulator = new EventsAccumulator<
+              firestore.QuerySnapshot
+            >();
 
             const unsubscribe = collection.onSnapshot(snapshot => {
               // Skip the initial empty snapshot.


### PR DESCRIPTION
Without this, it still fails, but:
a) not until serializing the query, and
b) the error is an internal error, and
c) the error message is quite cryptic and has nothing to do with the problem.

Port of https://github.com/firebase/firebase-android-sdk/pull/138