### PR TITLE
Values of updateProfile method can be not passed (optional)

### DIFF
--- a/packages/auth-types/index.d.ts
+++ b/packages/auth-types/index.d.ts
@@ -58,8 +58,8 @@ export interface User extends UserInfo {
   updatePassword(newPassword: string): Promise<void>;
   updatePhoneNumber(phoneCredential: AuthCredential): Promise<void>;
   updateProfile(profile: {
-    displayName: string | null;
-    photoURL: string | null;
+    displayName?: string | null;
+    photoURL?: string | null;
   }): Promise<void>;
 }
 

--- a/packages/firebase/index.d.ts
+++ b/packages/firebase/index.d.ts
@@ -90,8 +90,8 @@ declare namespace firebase {
       phoneCredential: firebase.auth.AuthCredential
     ): Promise<void>;
     updateProfile(profile: {
-      displayName: string | null;
-      photoURL: string | null;
+      displayName?: string | null;
+      photoURL?: string | null;
     }): Promise<void>;
   }
 


### PR DESCRIPTION
Fix Types

According the Firebase Documentation of updateProfile() method, you won't change the current attribute's value if you're not passing a property.

https://firebase.google.com/docs/reference/js/firebase.User.html#updateProfile
```
// Passing a null value will delete the current attribute's value, but not
// passing a property won't change the current attribute's value:
// Let's say we're using the same user than before, after the update.
user.updateProfile({photoURL: null}).then(function() {
  // Profile updated successfully!
  // "Jane Q. User", hasn't changed.
  var displayName = user.displayName;
  // Now, this is null.
  var photoURL = user.photoURL;
}, function(error) {
  // An error happened.
});
```