### PR TITLE
Fix issues with enablePersistence() in second tab.

### DIFF
--- a/packages/firestore/CHANGELOG.md
+++ b/packages/firestore/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Unreleased
+- [fixed] Fixed an uncaught promise error occurring when `enablePersistence()`
+  was called in a second tab (#1531).
+
+# 1.0.0
 - [changed] The `timestampsInSnapshots` setting is now enabled by default.
   Timestamp fields that read from a `DocumentSnapshot` are now returned as
   `Timestamp` objects instead of `Date` objects. This is a breaking change;

--- a/packages/firestore/src/local/indexeddb_persistence.ts
+++ b/packages/firestore/src/local/indexeddb_persistence.ts
@@ -326,14 +326,17 @@ export class IndexedDbPersistence implements Persistence {
     )
       .then(db => {
         this.simpleDb = db;
+        // NOTE: This is expected to fail sometimes (in the case of another tab already
+        // having the persistence lock), so it's the first thing we should do.
+        return this.updateClientMetadataAndTryBecomePrimary();
       })
-      .then(() => this.startRemoteDocumentCache())
       .then(() => {
         this.attachVisibilityHandler();
         this.attachWindowUnloadHook();
-        return this.updateClientMetadataAndTryBecomePrimary().then(() =>
-          this.scheduleClientMetadataAndPrimaryLeaseRefreshes()
-        );
+
+        this.scheduleClientMetadataAndPrimaryLeaseRefreshes();
+
+        return this.startRemoteDocumentCache();
       })
       .then(() => {
         return this.simpleDb.runTransaction(

--- a/packages/firestore/src/local/simple_db.ts
+++ b/packages/firestore/src/local/simple_db.ts
@@ -202,6 +202,10 @@ export class SimpleDb {
       })
       .toPromise();
 
+    // As noted above, errors are propagated by aborting the transaction. So
+    // we swallow any error here to avoid the browser logging it as unhandled.
+    transactionFnResult.catch(() => {});
+
     // Wait for the transaction to complete (i.e. IndexedDb's onsuccess event to
     // fire), but still return the original transactionFnResult back to the
     // caller.


### PR DESCRIPTION
1. Fixes #1531 (Firestore error uncaught in promise when primary lease check fails).
2. Ensures IndexedDbPersistence doesn't set up its visibility handler, etc. if
   it fails to initialize.

The first one was caused by https://github.com/firebase/firebase-js-sdk/commit/f970f9cd51c17897e397d5b0e30dc5abc3c4999d#diff-db492a8b6a1f21cd1cf9bb73da289281R175