### PR TITLE
Made rulesets that don't compile throw errors in testing sdk

### DIFF
--- a/packages/testing/src/api/index.ts
+++ b/packages/testing/src/api/index.ts
@@ -147,6 +147,9 @@ export type LoadDatabaseRulesOptions = {
   databaseName: string;
   rules: string;
 };
+type LoadDatabaseRulesErrorBody = {
+    error?: string;
+}
 export function loadDatabaseRules(
   options: LoadDatabaseRulesOptions
 ): Promise<void> {
@@ -168,8 +171,16 @@ export function loadDatabaseRules(
         body: options.rules
       },
       (err, resp, body) => {
+        let parsedBody: LoadDatabaseRulesErrorBody
+        try {
+          parsedBody = JSON.parse(body)
+        } catch(e) {
+          parsedBody = {}
+        }
         if (err) {
           reject(err);
+        } else if (parsedBody.error) {
+          reject(parsedBody.error)
         } else {
           resolve();
         }

--- a/packages/testing/src/api/index.ts
+++ b/packages/testing/src/api/index.ts
@@ -171,15 +171,11 @@ export function loadDatabaseRules(
         body: options.rules
       },
       (err, resp, body) => {
-        let parsedBody: LoadDatabaseRulesErrorBody;
-        try {
-          parsedBody = JSON.parse(body);
-        } catch (e) {
-          parsedBody = {};
-        }
+        // This should always parse (so don't purposefully catch errors).
+        let parsedBody: LoadDatabaseRulesErrorBody = JSON.parse(body);
         if (err) {
           reject(err);
-        } else if (parsedBody.error) {
+        } else if (resp.statusCode !== 200) {
           reject(parsedBody.error);
         } else {
           resolve();

--- a/packages/testing/src/api/index.ts
+++ b/packages/testing/src/api/index.ts
@@ -148,8 +148,8 @@ export type LoadDatabaseRulesOptions = {
   rules: string;
 };
 type LoadDatabaseRulesErrorBody = {
-    error?: string;
-}
+  error?: string;
+};
 export function loadDatabaseRules(
   options: LoadDatabaseRulesOptions
 ): Promise<void> {
@@ -171,16 +171,16 @@ export function loadDatabaseRules(
         body: options.rules
       },
       (err, resp, body) => {
-        let parsedBody: LoadDatabaseRulesErrorBody
+        let parsedBody: LoadDatabaseRulesErrorBody;
         try {
-          parsedBody = JSON.parse(body)
-        } catch(e) {
-          parsedBody = {}
+          parsedBody = JSON.parse(body);
+        } catch (e) {
+          parsedBody = {};
         }
         if (err) {
           reject(err);
         } else if (parsedBody.error) {
-          reject(parsedBody.error)
+          reject(parsedBody.error);
         } else {
           resolve();
         }

--- a/packages/testing/src/api/index.ts
+++ b/packages/testing/src/api/index.ts
@@ -147,9 +147,6 @@ export type LoadDatabaseRulesOptions = {
   databaseName: string;
   rules: string;
 };
-type LoadDatabaseRulesErrorBody = {
-  error?: string;
-};
 export function loadDatabaseRules(
   options: LoadDatabaseRulesOptions
 ): Promise<void> {
@@ -171,12 +168,10 @@ export function loadDatabaseRules(
         body: options.rules
       },
       (err, resp, body) => {
-        // This should always parse (so don't purposefully catch errors).
-        let parsedBody: LoadDatabaseRulesErrorBody = JSON.parse(body);
         if (err) {
           reject(err);
         } else if (resp.statusCode !== 200) {
-          reject(parsedBody.error);
+          reject(JSON.parse(body).error);
         } else {
           resolve();
         }


### PR DESCRIPTION
Case: User uses loadDatabaseRules method to upload broken rules.
Behavior before: Fail, but present success from SDK method.
Behavior now: Rejected promise from SDK method with compilation error message (i.e. line number)