### PR TITLE
Add bundle size analysis to all packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@ dist
 /config/project.json
 scripts/docgen/html
 
+# Bundle analysis
+analysis_tmp
+
 # OS Specific Files
 .DS_Store
 

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -12,12 +12,15 @@
   ],
   "scripts": {
     "build": "rollup -c",
+    "build:analysis": "rollup -c --analysis",
     "dev": "rollup -c -w",
     "test": "run-p test:browser test:node",
     "test:browser": "karma start --single-run",
     "test:browser:debug": "karma start --browsers Chrome --auto-watch",
     "test:node": "TS_NODE_CACHE=NO TS_NODE_COMPILER_OPTIONS='{\"module\":\"commonjs\"}' nyc --reporter lcovonly -- mocha test/**/*.test.* --opts ../../config/mocha.node.opts",
-    "prepare": "npm run build"
+    "prepare": "npm run build",
+    "analyze:bundle": "source-map-explorer ./analysis_tmp/index.js",
+    "analyze": "run-s build:analysis analyze:bundle"
   },
   "license": "Apache-2.0",
   "dependencies": {
@@ -48,8 +51,10 @@
     "rollup": "1.2.3",
     "rollup-plugin-replace": "2.1.0",
     "rollup-plugin-typescript2": "0.19.3",
+    "rollup-plugin-uglify": "6.0.2",
     "sinon": "4.5.0",
     "source-map-loader": "0.2.3",
+    "source-map-explorer": "1.7.0",
     "ts-loader": "3.5.0",
     "ts-node": "5.0.1",
     "typescript": "3.3.3",

--- a/packages/app/rollup.config.js
+++ b/packages/app/rollup.config.js
@@ -17,6 +17,7 @@
 
 import typescript from 'rollup-plugin-typescript2';
 import replace from 'rollup-plugin-replace';
+import { uglify } from 'rollup-plugin-uglify';
 import pkg from './package.json';
 
 import firebasePkg from '../firebase/package.json';
@@ -37,7 +38,7 @@ const deps = Object.keys(
   Object.assign({}, pkg.peerDependencies, pkg.dependencies)
 );
 
-export default [
+const buildTargets = [
   {
     input: 'index.ts',
     output: [
@@ -69,3 +70,27 @@ export default [
       )
   }
 ];
+
+const analysisTargets = [
+  /**
+   * Build for Bundle Analysis
+   */
+  {
+    input: 'index.ts',
+    output: [
+      { file: 'analysis_tmp/index.js', format: 'cjs', sourcemap: true }
+    ],
+    plugins: [
+      ...plugins,
+      uglify()
+    ],
+    external: id => deps.some(dep => id === dep || id.startsWith(`${dep}/`))
+  }
+];
+
+export default commandLineArgs => {
+  if (commandLineArgs.analysis) {
+    return analysisTargets;
+  }
+  return buildTargets;
+};

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -11,13 +11,16 @@
   ],
   "scripts": {
     "build": "rollup -c",
+    "build:analysis": "rollup -c --analysis",
     "dev": "rollup -c -w",
     "test": "yarn test:emulator",
     "test:all": "run-p test:browser test:node",
     "test:browser": "karma start --single-run",
     "test:node": "TS_NODE_CACHE=NO TS_NODE_COMPILER_OPTIONS='{\"module\":\"commonjs\"}' nyc --reporter lcovonly -- mocha 'test/{,!(browser)/**/}*.test.ts' -r src/nodePatches.ts --opts ../../config/mocha.node.opts",
     "test:emulator": "ts-node --compiler-options='{\"module\":\"commonjs\"}' ../../scripts/emulator-testing/database-test-runner.ts",
-    "prepare": "npm run build"
+    "prepare": "npm run build",
+    "analyze:bundle": "source-map-explorer ./analysis_tmp/index.js",
+    "analyze": "run-s build:analysis analyze:bundle"
   },
   "license": "Apache-2.0",
   "peerDependencies": {
@@ -51,8 +54,10 @@
     "nyc": "11.6.0",
     "rollup": "1.2.3",
     "rollup-plugin-typescript2": "0.19.3",
+    "rollup-plugin-uglify": "6.0.2",
     "sinon": "4.5.0",
     "source-map-loader": "0.2.3",
+    "source-map-explorer": "1.7.0",
     "ts-loader": "3.5.0",
     "ts-node": "5.0.1",
     "typescript": "3.3.3",

--- a/packages/database/rollup.config.js
+++ b/packages/database/rollup.config.js
@@ -16,6 +16,7 @@
  */
 
 import typescript from 'rollup-plugin-typescript2';
+import { uglify } from 'rollup-plugin-uglify';
 import pkg from './package.json';
 
 const plugins = [
@@ -28,7 +29,7 @@ const deps = Object.keys(
   Object.assign({}, pkg.peerDependencies, pkg.dependencies)
 );
 
-export default [
+const buildTargets = [
   /**
    * Node.js Build
    */
@@ -51,3 +52,27 @@ export default [
     external: id => deps.some(dep => id === dep || id.startsWith(`${dep}/`))
   }
 ];
+
+const analysisTargets = [
+  /**
+   * Build for Bundle Analysis
+   */
+  {
+    input: 'index.ts',
+    output: [
+      { file: 'analysis_tmp/index.js', format: 'cjs', sourcemap: true }
+    ],
+    plugins: [
+      ...plugins,
+      uglify()
+    ],
+    external: id => deps.some(dep => id === dep || id.startsWith(`${dep}/`))
+  }
+];
+
+export default commandLineArgs => {
+  if (commandLineArgs.analysis) {
+    return analysisTargets;
+  }
+  return buildTargets;
+};

--- a/packages/firestore/package.json
+++ b/packages/firestore/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "build": "rollup -c",
     "build:console": "node tools/console.build.js",
+    "build:analysis": "rollup -c --analysis",
     "dev": "rollup -c -w",
     "lint": "tslint -p tsconfig.json -c tslint.json 'src/**/*.ts' 'test/**/*.ts'",
     "lint:fix": "tslint --fix -p tsconfig.json -c tslint.json 'src/**/*.ts' 'test/**/*.ts'",
@@ -17,7 +18,9 @@
     "test:node": "TS_NODE_CACHE=NO TS_NODE_COMPILER_OPTIONS='{\"module\":\"commonjs\"}' nyc --reporter lcovonly -- mocha 'test/{,!(browser)/**/}*.test.ts' --require index.node.ts --opts ../../config/mocha.node.opts",
     "test:node:persistence": "USE_MOCK_PERSISTENCE=YES TS_NODE_CACHE=NO nyc --reporter lcovonly -- mocha 'test/{,!(browser)/**/}*.test.ts' --require index.node.ts --require test/util/node_persistence.ts --opts ../../config/mocha.node.opts",
     "test:emulator": "ts-node ../../scripts/emulator-testing/firestore-test-runner.ts",
-    "prepare": "npm run build"
+    "prepare": "npm run build",
+    "analyze:bundle": "source-map-explorer ./analysis_tmp/index.js",
+    "analyze": "run-s build:analysis analyze:bundle"
   },
   "main": "dist/index.node.cjs.js",
   "browser": "dist/index.cjs.js",
@@ -66,8 +69,10 @@
     "rollup-plugin-node-resolve": "4.0.1",
     "rollup-plugin-replace": "2.1.0",
     "rollup-plugin-typescript2": "0.19.3",
+    "rollup-plugin-uglify": "6.0.2",
     "sinon": "4.5.0",
     "source-map-loader": "0.2.3",
+    "source-map-explorer": "1.7.0",
     "ts-loader": "3.5.0",
     "ts-node": "5.0.1",
     "tslint": "5.9.1",

--- a/packages/firestore/rollup.config.js
+++ b/packages/firestore/rollup.config.js
@@ -18,8 +18,8 @@
 import typescript from 'rollup-plugin-typescript2';
 import replace from 'rollup-plugin-replace';
 import copy from 'rollup-plugin-copy-assets';
-import pkg from './package.json';
 import { uglify } from 'rollup-plugin-uglify';
+import pkg from './package.json';
 
 const plugins = [
   typescript({

--- a/packages/firestore/rollup.config.js
+++ b/packages/firestore/rollup.config.js
@@ -19,7 +19,7 @@ import typescript from 'rollup-plugin-typescript2';
 import replace from 'rollup-plugin-replace';
 import copy from 'rollup-plugin-copy-assets';
 import pkg from './package.json';
-import { dirname, resolve } from 'path';
+import { uglify } from 'rollup-plugin-uglify';
 
 const plugins = [
   typescript({
@@ -31,7 +31,7 @@ const deps = Object.keys(
   Object.assign({}, pkg.peerDependencies, pkg.dependencies)
 );
 
-export default [
+const buildTargets = [
   /**
    * Node.js Build
    */
@@ -66,3 +66,27 @@ export default [
     external: id => deps.some(dep => id === dep || id.startsWith(`${dep}/`))
   }
 ];
+
+const analysisTargets = [
+  /**
+   * Build for Bundle Analysis
+   */
+  {
+    input: 'index.ts',
+    output: [
+      { file: 'analysis_tmp/index.js', format: 'cjs', sourcemap: true }
+    ],
+    plugins: [
+      ...plugins,
+      uglify()
+    ],
+    external: id => deps.some(dep => id === dep || id.startsWith(`${dep}/`))
+  }
+];
+
+export default commandLineArgs => {
+  if (commandLineArgs.analysis) {
+    return analysisTargets;
+  }
+  return buildTargets;
+};

--- a/packages/functions/package.json
+++ b/packages/functions/package.json
@@ -11,13 +11,16 @@
   ],
   "scripts": {
     "build": "rollup -c",
+    "build:analysis": "rollup -c --analysis",
     "dev": "rollup -c -w",
     "test": "run-p test:browser test:node",
     "test:browser": "karma start --single-run",
     "test:browser:debug": "karma start --browsers=Chrome --auto-watch",
     "test:node": "TS_NODE_COMPILER_OPTIONS='{\"module\":\"commonjs\"}' nyc --reporter lcovonly -- mocha 'test/{,!(browser)/**/}*.test.ts' --require index.node.ts --opts ../../config/mocha.node.opts",
     "test:emulator": "env FIREBASE_FUNCTIONS_EMULATOR_ORIGIN=http://localhost:5005 run-p test:node",
-    "prepare": "npm run build"
+    "prepare": "npm run build",
+    "analyze:bundle": "source-map-explorer ./analysis_tmp/index.js",
+    "analyze": "run-s build:analysis analyze:bundle"
   },
   "license": "Apache-2.0",
   "peerDependencies": {
@@ -44,8 +47,10 @@
     "nyc": "11.6.0",
     "rollup": "1.2.3",
     "rollup-plugin-typescript2": "0.19.3",
+    "rollup-plugin-uglify": "6.0.2",
     "sinon": "4.5.0",
     "source-map-loader": "0.2.3",
+    "source-map-explorer": "1.7.0",
     "ts-loader": "3.5.0",
     "ts-node": "5.0.1",
     "tslint": "5.9.1",

--- a/packages/functions/rollup.config.js
+++ b/packages/functions/rollup.config.js
@@ -16,6 +16,7 @@
  */
 
 import typescript from 'rollup-plugin-typescript2';
+import { uglify } from 'rollup-plugin-uglify';
 import pkg from './package.json';
 
 const plugins = [
@@ -28,7 +29,7 @@ const deps = Object.keys(
   Object.assign({}, pkg.peerDependencies, pkg.dependencies)
 );
 
-export default [
+const buildTargets = [
   /**
    * Browser Builds
    */
@@ -51,3 +52,27 @@ export default [
     external: id => deps.some(dep => id === dep || id.startsWith(`${dep}/`))
   }
 ];
+
+const analysisTargets = [
+  /**
+   * Build for Bundle Analysis
+   */
+  {
+    input: 'index.ts',
+    output: [
+      { file: 'analysis_tmp/index.js', format: 'cjs', sourcemap: true }
+    ],
+    plugins: [
+      ...plugins,
+      uglify()
+    ],
+    external: id => deps.some(dep => id === dep || id.startsWith(`${dep}/`))
+  }
+];
+
+export default commandLineArgs => {
+  if (commandLineArgs.analysis) {
+    return analysisTargets;
+  }
+  return buildTargets;
+};

--- a/packages/messaging/package.json
+++ b/packages/messaging/package.json
@@ -10,6 +10,7 @@
   ],
   "scripts": {
     "build": "rollup -c",
+    "build:analysis": "rollup -c --analysis",
     "dev": "rollup -c -w",
     "test": "run-p test:karma type-check lint",
     "test:karma": "karma start --single-run",
@@ -17,7 +18,9 @@
     "prepare": "npm run build",
     "type-check": "tsc --noEmit",
     "lint": "tslint -p .",
-    "lint:fix": "yarn lint --fix"
+    "lint:fix": "yarn lint --fix",
+    "analyze:bundle": "source-map-explorer ./analysis_tmp/index.js",
+    "analyze": "run-s build:analysis analyze:bundle"
   },
   "license": "Apache-2.0",
   "peerDependencies": {
@@ -47,6 +50,8 @@
     "npm-run-all": "4.1.5",
     "rollup": "1.2.3",
     "rollup-plugin-typescript2": "0.19.3",
+    "rollup-plugin-uglify": "6.0.2",
+    "source-map-explorer": "1.7.0",
     "sinon": "4.5.0",
     "tslint": "5.9.1",
     "typescript": "3.3.3"

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -10,10 +10,13 @@
   ],
   "scripts": {
     "build": "rollup -c",
+    "build:analysis": "rollup -c --analysis",
     "dev": "rollup -c -w",
     "test": "run-p test:browser",
     "test:browser": "karma start --single-run",
-    "prepare": "npm run build"
+    "prepare": "npm run build",
+    "analyze:bundle": "source-map-explorer ./analysis_tmp/index.js",
+    "analyze": "run-s build:analysis analyze:bundle"
   },
   "license": "Apache-2.0",
   "dependencies": {
@@ -41,8 +44,10 @@
     "npm-run-all": "4.1.5",
     "rollup": "1.2.3",
     "rollup-plugin-typescript2": "0.19.3",
+    "rollup-plugin-uglify": "6.0.2",
     "sinon": "4.5.0",
     "source-map-loader": "0.2.3",
+    "source-map-explorer": "1.7.0",
     "ts-loader": "3.5.0",
     "typescript": "3.3.3",
     "webpack": "3.11.0"

--- a/packages/template/package.json
+++ b/packages/template/package.json
@@ -12,11 +12,14 @@
   ],
   "scripts": {
     "build": "rollup -c",
+    "build:analysis": "rollup -c --analysis",
     "dev": "rollup -c -w",
     "test": "run-p test:browser test:node",
     "test:browser": "karma start --single-run",
     "test:node": "TS_NODE_COMPILER_OPTIONS='{\"module\":\"commonjs\"}' nyc --reporter lcovonly -- mocha test/**/*.test.* --opts ../../config/mocha.node.opts",
-    "prepare": "npm run build"
+    "prepare": "npm run build",
+    "analyze:bundle": "source-map-explorer ./analysis_tmp/index.js",
+    "analyze": "run-s build:analysis analyze:bundle"
   },
   "peerDependencies": {
     "@firebase/app": "0.x",
@@ -45,6 +48,8 @@
     "nyc": "11.6.0",
     "rollup": "1.2.3",
     "rollup-plugin-typescript2": "0.19.3",
+    "rollup-plugin-uglify": "6.0.2",
+    "source-map-explorer": "1.7.0",
     "ts-loader": "3.5.0",
     "ts-node": "5.0.1",
     "typescript": "3.3.3",

--- a/packages/template/rollup.config.js
+++ b/packages/template/rollup.config.js
@@ -17,6 +17,7 @@
 
 import typescript from 'rollup-plugin-typescript2';
 import pkg from './package.json';
+import { uglify } from 'rollup-plugin-uglify';
 
 const plugins = [
   typescript({
@@ -28,7 +29,7 @@ const deps = Object.keys(
   Object.assign({}, pkg.peerDependencies, pkg.dependencies)
 );
 
-export default [
+const buildTargets = [
   /**
    * Browser Builds
    */
@@ -51,3 +52,27 @@ export default [
     external: id => deps.some(dep => id === dep || id.startsWith(`${dep}/`))
   }
 ];
+
+const analysisTargets = [
+  /**
+   * Build for Bundle Analysis
+   */
+  {
+    input: 'index.ts',
+    output: [
+      { file: 'analysis_tmp/index.js', format: 'cjs', sourcemap: true }
+    ],
+    plugins: [
+      ...plugins,
+      uglify()
+    ],
+    external: id => deps.some(dep => id === dep || id.startsWith(`${dep}/`))
+  }
+];
+
+export default commandLineArgs => {
+  if (commandLineArgs.analysis) {
+    return analysisTargets;
+  }
+  return buildTargets;
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -3053,6 +3053,11 @@ browserslist@^3.0.0:
     caniuse-lite "^1.0.30000835"
     electron-to-chromium "^1.3.45"
 
+btoa@^1.1.2:
+  version "1.2.1"
+  resolved "https://registry.npmjs.org/btoa/-/btoa-1.2.1.tgz#01a9909f8b2c93f6bf680ba26131eb30f7fa3d73"
+  integrity sha512-SB4/MIGlsiVkMcHmT+pSmIPoNDoHg+7cMzmt3Uxt628MTz2487DKSqK/fuhFBrkuqrYv5UCEnACpF4dTFNKc/g==
+
 buffer-crc32@^0.2.1, buffer-crc32@~0.2.3:
   version "0.2.13"
   resolved "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz#0d333e3f00eac50aa1454abd30ef8c2a5d9a7242"
@@ -4837,6 +4842,11 @@ dns-sync@^0.1.3:
     debug "^2"
     shelljs "~0.5"
 
+docopt@^0.6.2:
+  version "0.6.2"
+  resolved "https://registry.npmjs.org/docopt/-/docopt-0.6.2.tgz#b28e9e2220da5ec49f7ea5bb24a47787405eeb11"
+  integrity sha1-so6eIiDaXsSffqW7JKR3h0Be6xE=
+
 dom-serialize@^2.2.0:
   version "2.2.1"
   resolved "https://registry.npmjs.org/dom-serialize/-/dom-serialize-2.2.1.tgz#562ae8999f44be5ea3076f5419dcd59eb43ac95b"
@@ -4952,6 +4962,11 @@ ee-first@1.1.1:
   version "1.1.1"
   resolved "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
   integrity sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=
+
+ejs@^2.6.1:
+  version "2.6.1"
+  resolved "https://registry.npmjs.org/ejs/-/ejs-2.6.1.tgz#498ec0d495655abc6f23cd61868d926464071aa0"
+  integrity sha512-0xy4A/twfrRCnkhfk8ErDi5DqdAsAqeGxht4xkCUrsvhhbQNs7E+4jV0CN7+NKIY0aHE72+XvqtBIXzD31ZbXQ==
 
 electron-to-chromium@^1.3.45:
   version "1.3.46"
@@ -12755,6 +12770,13 @@ rimraf@2, rimraf@2.6.2, rimraf@2.x.x, rimraf@^2.2.8, rimraf@^2.5.1, rimraf@^2.5.
   dependencies:
     glob "^7.0.5"
 
+rimraf@~2.6.2:
+  version "2.6.3"
+  resolved "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz#b2d104fe0d8fb27cf9e0a1cda8262dd3833c6cab"
+  integrity sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==
+  dependencies:
+    glob "^7.1.3"
+
 ripemd160@^2.0.0, ripemd160@^2.0.1:
   version "2.0.1"
   resolved "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.1.tgz#0f4584295c53a3628af7e6d79aca21ce57d1c6e7"
@@ -13482,6 +13504,20 @@ source-list-map@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.0.tgz#aaa47403f7b245a92fbc97ea08f250d6087ed085"
   integrity sha512-I2UmuJSRr/T8jisiROLU3A3ltr+swpniSmNPI4Ml3ZCX6tVnDsuZzK7F2hl5jTqbZBWCEKlj5HRQiPExXLgE8A==
+
+source-map-explorer@1.7.0:
+  version "1.7.0"
+  resolved "https://registry.npmjs.org/source-map-explorer/-/source-map-explorer-1.7.0.tgz#d6ff79eaf11990223c35ced78788c09d6e864968"
+  integrity sha512-S9Tb48Ia4ozNLvr0khOzygfoFjtzRVLD/h2I0VzwUoWz+rmuvNMzuzmbAHcK7/F6Gley3yhr1Mhoavokv5qg8A==
+  dependencies:
+    btoa "^1.1.2"
+    convert-source-map "^1.1.1"
+    docopt "^0.6.2"
+    ejs "^2.6.1"
+    glob "^7.1.2"
+    opn "^5.3.0"
+    source-map "^0.5.1"
+    temp "^0.9.0"
 
 source-map-loader@0.2.3:
   version "0.2.3"
@@ -14234,6 +14270,13 @@ temp-write@^3.4.0:
     temp-dir "^1.0.0"
     uuid "^3.0.1"
 
+temp@^0.9.0:
+  version "0.9.0"
+  resolved "https://registry.npmjs.org/temp/-/temp-0.9.0.tgz#61391795a11bd9738d4c4d7f55f012cb8f55edaa"
+  integrity sha512-YfUhPQCJoNQE5N+FJQcdPz63O3x3sdT4Xju69Gj4iZe0lBKOtnAMi0SLj9xKhGkcGhsxThvTJ/usxtFPo438zQ==
+  dependencies:
+    rimraf "~2.6.2"
+
 term-size@^1.2.0:
   version "1.2.0"
   resolved "https://registry.npmjs.org/term-size/-/term-size-1.2.0.tgz#458b83887f288fc56d6fffbfad262e26638efa69"
@@ -14704,15 +14747,15 @@ typedoc@0.14.2:
     typedoc-default-themes "^0.5.0"
     typescript "3.2.x"
 
-typescript@3.3.3:
-  version "3.3.3"
-  resolved "https://registry.npmjs.org/typescript/-/typescript-3.3.3.tgz#f1657fc7daa27e1a8930758ace9ae8da31403221"
-  integrity sha512-Y21Xqe54TBVp+VDSNbuDYdGw0BpoR/Q6wo/+35M8PAU0vipahnyduJWirxxdxjsAkS7hue53x2zp8gz7F05u0A==
-
 typescript@3.2.x:
   version "3.2.4"
   resolved "https://registry.npmjs.org/typescript/-/typescript-3.2.4.tgz#c585cb952912263d915b462726ce244ba510ef3d"
   integrity sha512-0RNDbSdEokBeEAkgNbxJ+BLwSManFy9TeXz8uW+48j/xhEXv1ePME60olyzw2XzUqUBNAYFeJadIqAgNqIACwg==
+
+typescript@3.3.3:
+  version "3.3.3"
+  resolved "https://registry.npmjs.org/typescript/-/typescript-3.3.3.tgz#f1657fc7daa27e1a8930758ace9ae8da31403221"
+  integrity sha512-Y21Xqe54TBVp+VDSNbuDYdGw0BpoR/Q6wo/+35M8PAU0vipahnyduJWirxxdxjsAkS7hue53x2zp8gz7F05u0A==
 
 typeson-registry@1.0.0-alpha.20:
   version "1.0.0-alpha.20"


### PR DESCRIPTION
Added bundle size analysis to all packages, so we can better understand where the bytes are coming from in the bundle and gain insights on how we can improve it. 

To see the analysis for you package, cd into your package and run `npm run analyze`