### PR TITLE
Enable sourcemap generation throughout repo.

### DIFF
--- a/packages/app/rollup.config.js
+++ b/packages/app/rollup.config.js
@@ -41,8 +41,8 @@ export default [
   {
     input: 'index.ts',
     output: [
-      { file: pkg.browser, format: 'cjs' },
-      { file: pkg.module, format: 'es' }
+      { file: pkg.browser, format: 'cjs', sourcemap: true },
+      { file: pkg.module, format: 'es', sourcemap: true }
     ],
     plugins,
     external: id => deps.some(dep => id === dep || id.startsWith(`${dep}/`))
@@ -51,7 +51,8 @@ export default [
     input: 'index.node.ts',
     output: {
       file: pkg.main,
-      format: 'cjs'
+      format: 'cjs',
+      sourcemap: true
     },
     plugins,
     external: id => deps.some(dep => id === dep || id.startsWith(`${dep}/`))
@@ -60,7 +61,8 @@ export default [
     input: 'index.rn.ts',
     output: {
       file: pkg['react-native'],
-      format: 'cjs'
+      format: 'cjs',
+      sourcemap: true
     },
     plugins,
     external: id =>

--- a/packages/database/rollup.config.js
+++ b/packages/database/rollup.config.js
@@ -34,7 +34,7 @@ export default [
    */
   {
     input: 'index.node.ts',
-    output: [{ file: pkg.main, format: 'cjs' }],
+    output: [{ file: pkg.main, format: 'cjs', sourcemap: true }],
     plugins,
     external: id => deps.some(dep => id === dep || id.startsWith(`${dep}/`))
   },
@@ -44,8 +44,8 @@ export default [
   {
     input: 'index.ts',
     output: [
-      { file: pkg.browser, format: 'cjs' },
-      { file: pkg.module, format: 'es' }
+      { file: pkg.browser, format: 'cjs', sourcemap: true },
+      { file: pkg.module, format: 'es', sourcemap: true }
     ],
     plugins,
     external: id => deps.some(dep => id === dep || id.startsWith(`${dep}/`))

--- a/packages/firebase/package.json
+++ b/packages/firebase/package.json
@@ -51,6 +51,7 @@
     "rollup-plugin-commonjs": "9.2.1",
     "rollup-plugin-license": "0.8.1",
     "rollup-plugin-node-resolve": "4.0.1",
+    "rollup-plugin-sourcemaps": "0.4.2",
     "rollup-plugin-typescript2": "0.19.3",
     "rollup-plugin-uglify": "6.0.2",
     "typescript": "3.3.3"

--- a/packages/firebase/rollup.config.js
+++ b/packages/firebase/rollup.config.js
@@ -65,8 +65,8 @@ const appBuilds = [
   {
     input: 'app/index.ts',
     output: [
-      { file: resolve('app', appPkg.main), format: 'cjs' },
-      { file: resolve('app', appPkg.module), format: 'es' }
+      { file: resolve('app', appPkg.main), format: 'cjs', sourcemap: true },
+      { file: resolve('app', appPkg.module), format: 'es', sourcemap: true }
     ],
     plugins,
     external
@@ -101,8 +101,8 @@ const componentBuilds = components
       {
         input: `${component}/index.ts`,
         output: [
-          { file: resolve(component, pkg.main), format: 'cjs' },
-          { file: resolve(component, pkg.module), format: 'es' }
+          { file: resolve(component, pkg.main), format: 'cjs', sourcemap: true },
+          { file: resolve(component, pkg.module), format: 'es', sourcemap: true }
         ],
         plugins,
         external
@@ -156,8 +156,8 @@ const completeBuilds = [
   {
     input: 'src/index.ts',
     output: [
-      { file: pkg.browser, format: 'cjs' },
-      { file: pkg.module, format: 'es' }
+      { file: pkg.browser, format: 'cjs', sourcemap: true },
+      { file: pkg.module, format: 'es', sourcemap: true }
     ],
     plugins,
     external
@@ -167,6 +167,7 @@ const completeBuilds = [
     output: {
       file: 'firebase.js',
       format: 'umd',
+      sourcemap: true,
       name: GLOBAL_NAME
     },
     plugins: [...plugins, uglify()]
@@ -176,7 +177,7 @@ const completeBuilds = [
    */
   {
     input: 'src/index.node.ts',
-    output: { file: pkg.main, format: 'cjs' },
+    output: { file: pkg.main, format: 'cjs', sourcemap: true },
     plugins,
     external
   },
@@ -185,7 +186,7 @@ const completeBuilds = [
    */
   {
     input: 'src/index.rn.ts',
-    output: { file: pkg['react-native'], format: 'cjs' },
+    output: { file: pkg['react-native'], format: 'cjs', sourcemap: true },
     plugins,
     external
   }

--- a/packages/firebase/rollup.config.js
+++ b/packages/firebase/rollup.config.js
@@ -18,6 +18,7 @@
 import { resolve } from 'path';
 import resolveModule from 'rollup-plugin-node-resolve';
 import commonjs from 'rollup-plugin-commonjs';
+import sourcemaps from 'rollup-plugin-sourcemaps';
 import typescript from 'rollup-plugin-typescript2';
 import { uglify } from 'rollup-plugin-uglify';
 import pkg from './package.json';
@@ -41,6 +42,7 @@ const pkgsByName = {
 };
 
 const plugins = [
+  sourcemaps(),
   resolveModule(),
   typescript({
     typescript: require('typescript')

--- a/packages/firebase/rollup.config.js
+++ b/packages/firebase/rollup.config.js
@@ -103,8 +103,16 @@ const componentBuilds = components
       {
         input: `${component}/index.ts`,
         output: [
-          { file: resolve(component, pkg.main), format: 'cjs', sourcemap: true },
-          { file: resolve(component, pkg.module), format: 'es', sourcemap: true }
+          {
+            file: resolve(component, pkg.main),
+            format: 'cjs',
+            sourcemap: true
+          },
+          {
+            file: resolve(component, pkg.module),
+            format: 'es',
+            sourcemap: true
+          }
         ],
         plugins,
         external

--- a/packages/firestore/rollup.config.js
+++ b/packages/firestore/rollup.config.js
@@ -37,7 +37,7 @@ export default [
    */
   {
     input: 'index.node.ts',
-    output: [{ file: pkg.main, format: 'cjs' }],
+    output: [{ file: pkg.main, format: 'cjs', sourcemap: true }],
     plugins: [
       ...plugins,
       // Needed as we also use the *.proto files
@@ -59,8 +59,8 @@ export default [
   {
     input: 'index.ts',
     output: [
-      { file: pkg.browser, format: 'cjs' },
-      { file: pkg.module, format: 'es' }
+      { file: pkg.browser, format: 'cjs', sourcemap: true },
+      { file: pkg.module, format: 'es', sourcemap: true }
     ],
     plugins,
     external: id => deps.some(dep => id === dep || id.startsWith(`${dep}/`))

--- a/packages/functions/rollup.config.js
+++ b/packages/functions/rollup.config.js
@@ -35,8 +35,8 @@ export default [
   {
     input: 'index.ts',
     output: [
-      { file: pkg.browser, format: 'cjs' },
-      { file: pkg.module, format: 'es' }
+      { file: pkg.browser, format: 'cjs', sourcemap: true },
+      { file: pkg.module, format: 'es', sourcemap: true }
     ],
     plugins,
     external: id => deps.some(dep => id === dep || id.startsWith(`${dep}/`))
@@ -46,7 +46,7 @@ export default [
    */
   {
     input: 'index.node.ts',
-    output: [{ file: pkg.main, format: 'cjs' }],
+    output: [{ file: pkg.main, format: 'cjs', sourcemap: true }],
     plugins,
     external: id => deps.some(dep => id === dep || id.startsWith(`${dep}/`))
   }

--- a/packages/logger/rollup.config.js
+++ b/packages/logger/rollup.config.js
@@ -31,8 +31,8 @@ const deps = Object.keys(
 export default {
   input: 'index.ts',
   output: [
-    { file: pkg.main, format: 'cjs' },
-    { file: pkg.module, format: 'es' }
+    { file: pkg.main, format: 'cjs', sourcemap: true },
+    { file: pkg.module, format: 'es', sourcemap: true }
   ],
   plugins,
   external: id => deps.some(dep => id === dep || id.startsWith(`${dep}/`))

--- a/packages/messaging/rollup.config.js
+++ b/packages/messaging/rollup.config.js
@@ -31,8 +31,8 @@ const deps = Object.keys(
 export default {
   input: 'index.ts',
   output: [
-    { file: pkg.main, format: 'cjs' },
-    { file: pkg.module, format: 'es' }
+    { file: pkg.main, format: 'cjs', sourcemap: true },
+    { file: pkg.module, format: 'es', sourcemap: true }
   ],
   plugins,
   external: id => deps.some(dep => id === dep || id.startsWith(`${dep}/`))

--- a/packages/polyfill/rollup.config.js
+++ b/packages/polyfill/rollup.config.js
@@ -31,8 +31,8 @@ const deps = Object.keys(
 export default {
   input: 'index.ts',
   output: [
-    { file: pkg.main, format: 'cjs' },
-    { file: pkg.module, format: 'es' }
+    { file: pkg.main, format: 'cjs', sourcemap: true },
+    { file: pkg.module, format: 'es', sourcemap: true }
   ],
   plugins,
   external: id => deps.some(dep => id === dep || id.startsWith(`${dep}/`))

--- a/packages/rxfire/rollup.config.js
+++ b/packages/rxfire/rollup.config.js
@@ -59,8 +59,16 @@ const componentBuilds = components
       {
         input: `${component}/index.ts`,
         output: [
-          { file: resolve(component, pkg.main), format: 'cjs', sourcemap: true },
-          { file: resolve(component, pkg.module), format: 'es', sourcemap: true }
+          {
+            file: resolve(component, pkg.main),
+            format: 'cjs',
+            sourcemap: true
+          },
+          {
+            file: resolve(component, pkg.module),
+            format: 'es',
+            sourcemap: true
+          }
         ],
         plugins,
         external

--- a/packages/rxfire/rollup.config.js
+++ b/packages/rxfire/rollup.config.js
@@ -59,8 +59,8 @@ const componentBuilds = components
       {
         input: `${component}/index.ts`,
         output: [
-          { file: resolve(component, pkg.main), format: 'cjs' },
-          { file: resolve(component, pkg.module), format: 'es' }
+          { file: resolve(component, pkg.main), format: 'cjs', sourcemap: true },
+          { file: resolve(component, pkg.module), format: 'es', sourcemap: true }
         ],
         plugins,
         external

--- a/packages/storage/rollup.config.js
+++ b/packages/storage/rollup.config.js
@@ -31,8 +31,8 @@ const deps = Object.keys(
 export default {
   input: 'index.ts',
   output: [
-    { file: pkg.main, format: 'cjs' },
-    { file: pkg.module, format: 'es' }
+    { file: pkg.main, format: 'cjs', sourcemap: true },
+    { file: pkg.module, format: 'es', sourcemap: true }
   ],
   plugins,
   external: id => deps.some(dep => id === dep || id.startsWith(`${dep}/`))

--- a/packages/template/rollup.config.js
+++ b/packages/template/rollup.config.js
@@ -35,8 +35,8 @@ export default [
   {
     input: 'index.ts',
     output: [
-      { file: pkg.browser, format: 'cjs' },
-      { file: pkg.module, format: 'es' }
+      { file: pkg.browser, format: 'cjs', sourcemap: true },
+      { file: pkg.module, format: 'es', sourcemap: true }
     ],
     plugins,
     external: id => deps.some(dep => id === dep || id.startsWith(`${dep}/`))
@@ -46,7 +46,7 @@ export default [
    */
   {
     input: 'index.node.ts',
-    output: [{ file: pkg.main, format: 'cjs' }],
+    output: [{ file: pkg.main, format: 'cjs', sourcemap: true }],
     plugins,
     external: id => deps.some(dep => id === dep || id.startsWith(`${dep}/`))
   }

--- a/packages/testing/rollup.config.js
+++ b/packages/testing/rollup.config.js
@@ -32,7 +32,7 @@ const deps = Object.keys(
 
 export default {
   input: 'index.ts',
-  output: [{ file: pkg.main, format: 'cjs' }],
+  output: [{ file: pkg.main, format: 'cjs', sourcemap: true }],
   plugins: [
     ...plugins,
     // Needed as we also use the *.proto files

--- a/packages/util/rollup.config.js
+++ b/packages/util/rollup.config.js
@@ -35,8 +35,8 @@ export default [
   {
     input: 'index.ts',
     output: [
-      { file: pkg.browser, format: 'cjs' },
-      { file: pkg.module, format: 'es' }
+      { file: pkg.browser, format: 'cjs', sourcemap: true },
+      { file: pkg.module, format: 'es', sourcemap: true }
     ],
     plugins,
     external: id => deps.some(dep => id === dep || id.startsWith(`${dep}/`))
@@ -46,7 +46,7 @@ export default [
    */
   {
     input: 'index.node.ts',
-    output: [{ file: pkg.main, format: 'cjs' }],
+    output: [{ file: pkg.main, format: 'cjs', sourcemap: true }],
     plugins,
     external: id => deps.some(dep => id === dep || id.startsWith(`${dep}/`))
   }

--- a/packages/webchannel-wrapper/package.json
+++ b/packages/webchannel-wrapper/package.json
@@ -18,7 +18,7 @@
     "closure-builder": "2.3.4",
     "rollup": "1.2.3",
     "rollup-plugin-commonjs": "9.2.1",
-    "rollup-plugin-hypothetical": "2.1.0",
+    "rollup-plugin-sourcemaps": "0.4.2",
     "watch": "1.0.2"
   },
   "repository": {

--- a/packages/webchannel-wrapper/tools/build.js
+++ b/packages/webchannel-wrapper/tools/build.js
@@ -22,6 +22,7 @@ const sourcemaps = require('rollup-plugin-sourcemaps');
 
 const glob = closureBuilder.globSupport();
 const { resolve } = require('path');
+const { tmpdir } = require('os');
 
 const closureDefines = [
   // Avoid unsafe eval() calls (https://github.com/firebase/firebase-js-sdk/issues/798)
@@ -55,13 +56,15 @@ closureBuilder.build({
 });
 
 // esm build
+// We write the closure output to a temp file and then re-compile it with rollup.
+const filePath = `${tmpdir()}/index.js`
 closureBuilder.build(
   {
     name: 'firebase.webchannel.wrapper',
     srcs: glob([resolve(__dirname, '../src/**/*.js')]),
     externs: [resolve(__dirname, '../externs/overrides.js')],
-    out: 'dist/index.closure-es.js',
-    out_source_map: 'dist/index.closure-es.js.map',
+    out: filePath,
+    out_source_map: `${filePath}.map`,
     options: {
       closure: {
         output_wrapper:
@@ -73,7 +76,6 @@ closureBuilder.build(
     }
   },
   async function() {
-    const filePath = resolve(__dirname, '../dist/index.closure-es.js');
     const inputOptions = {
       input: filePath,
       plugins: [sourcemaps(), commonjs()]

--- a/packages/webchannel-wrapper/tools/build.js
+++ b/packages/webchannel-wrapper/tools/build.js
@@ -64,8 +64,8 @@ closureBuilder.build(
     out_source_map: 'dist/index.closure-es.js.map',
     options: {
       closure: {
-      output_wrapper:
-        "%output%\n//# sourceMappingURL=index.closure-es.js.map",
+        output_wrapper:
+          '%output%\n//# sourceMappingURL=index.closure-es.js.map',
         language_out: 'ECMASCRIPT5',
         compilation_level: 'ADVANCED',
         define: closureDefines
@@ -76,10 +76,7 @@ closureBuilder.build(
     const filePath = resolve(__dirname, '../dist/index.closure-es.js');
     const inputOptions = {
       input: filePath,
-      plugins: [
-        sourcemaps(),
-        commonjs()
-      ]
+      plugins: [sourcemaps(), commonjs()]
     };
 
     const outputOptions = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -12326,6 +12326,14 @@ rollup-plugin-replace@2.1.0:
     minimatch "^3.0.2"
     rollup-pluginutils "^2.0.1"
 
+rollup-plugin-sourcemaps@0.4.2:
+  version "0.4.2"
+  resolved "https://registry.npmjs.org/rollup-plugin-sourcemaps/-/rollup-plugin-sourcemaps-0.4.2.tgz#62125aa94087aadf7b83ef4dfaf629b473135e87"
+  integrity sha1-YhJaqUCHqt97g+9N+vYptHMTXoc=
+  dependencies:
+    rollup-pluginutils "^2.0.1"
+    source-map-resolve "^0.5.0"
+
 rollup-plugin-typescript2@0.19.3:
   version "0.19.3"
   resolved "https://registry.npmjs.org/rollup-plugin-typescript2/-/rollup-plugin-typescript2-0.19.3.tgz#713063233461765f030a2baa2640905c2656164f"
@@ -13557,9 +13565,9 @@ symbol-observable@^0.2.2:
   resolved "https://registry.npmjs.org/symbol-observable/-/symbol-observable-0.2.4.tgz#95a83db26186d6af7e7a18dbd9760a2f86d08f40"
   integrity sha1-lag9smGG1q9+ehjb2XYKL4bQj0A=
 
-"sync-promise@git+https://github.com/brettz9/sync-promise.git#full-sync-missing-promise-features":
+"sync-promise@https://github.com/brettz9/sync-promise#full-sync-missing-promise-features":
   version "1.0.1"
-  resolved "git+https://github.com/brettz9/sync-promise.git#25845a49a00aa2d2c985a5149b97c86a1fcdc75a"
+  resolved "https://github.com/brettz9/sync-promise#25845a49a00aa2d2c985a5149b97c86a1fcdc75a"
 
 syntax-error@^1.1.1:
   version "1.4.0"
@@ -14890,9 +14898,9 @@ websocket-extensions@>=0.1.1:
   resolved "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.3.tgz#5d2ff22977003ec687a4b87073dfbbac146ccf29"
   integrity sha512-nqHUnMXmBzT0w570r2JpJxfiSD1IzoI+HGVdd3aZ0yNi3ngvQ4jv1dtHt5VGxfI2yj5yqImPhOK4vmIh2xMbGg==
 
-"websql@git+https://github.com/brettz9/node-websql.git#configurable":
+"websql@https://github.com/brettz9/node-websql#configurable":
   version "0.4.4"
-  resolved "git+https://github.com/brettz9/node-websql.git#c9828a34c92eced64858fc19151ec099fd60e8dd"
+  resolved "https://github.com/brettz9/node-websql#c9828a34c92eced64858fc19151ec099fd60e8dd"
   dependencies:
     argsarray "^0.0.1"
     immediate "^3.2.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -12292,11 +12292,6 @@ rollup-plugin-copy-assets@1.1.0:
   dependencies:
     fs-extra "^5.0.0"
 
-rollup-plugin-hypothetical@2.1.0:
-  version "2.1.0"
-  resolved "https://registry.npmjs.org/rollup-plugin-hypothetical/-/rollup-plugin-hypothetical-2.1.0.tgz#7fec9a865ed7d0eac14ca6ee2b2c4088acdb1955"
-  integrity sha512-MlxPQTkMtiRUtyhIJ7FpBvTzWtar8eFBA+V7/J6Deg9fSgIIHwL6bJKK1Wl1uWSWtOrWhOmtsMwb9F6aagP/Pg==
-
 rollup-plugin-license@0.8.1:
   version "0.8.1"
   resolved "https://registry.npmjs.org/rollup-plugin-license/-/rollup-plugin-license-0.8.1.tgz#cdcfee2a32f27790e5019a2a7abd9234476ac589"


### PR DESCRIPTION
This enables (and improves) sourcemap generation throughout the repo.  My end goal was to be able to use source-map-explorer on any built artifact in order to better understand the bundle size.

NOTES:
1. I reworked the webchannel-wrapper build to actually generate the intermediate output file for our ESM build as it made it more straightforward to generate tho source map.
2. I had to add rollup-plugin-sourcemaps in order to make rollup notice / use existing sourcemaps (when we use compiled code as an input to a second build).
3. I enabled sourcemaps everywhere.  That may not be necessary, but AFAIK it doesn't hurt anything.