### PR TITLE
Improved query performance in the face of subcollections.

### DIFF
--- a/packages/firestore/CHANGELOG.md
+++ b/packages/firestore/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Unreleased
+- [changed] Improved performance when querying over documents that contain
+  subcollections.
+
+# 1.0.4
 - [fixed] Fixed an uncaught promise error occurring when `enablePersistence()`
   was called in a second tab (#1531).
 

--- a/packages/firestore/test/unit/local/remote_document_cache.test.ts
+++ b/packages/firestore/test/unit/local/remote_document_cache.test.ts
@@ -402,6 +402,7 @@ function genericRemoteDocumentCacheTests(
     await cache.addEntries([
       doc('a/1', VERSION, DOC_DATA),
       doc('b/1', VERSION, DOC_DATA),
+      doc('b/1/z/1', VERSION, DOC_DATA),
       doc('b/2', VERSION, DOC_DATA),
       doc('c/1', VERSION, DOC_DATA)
     ]);


### PR DESCRIPTION
Ports an optimization from Android where we skip parsing documents that are in
subcollections beneath the collection we're querying over.
