### PR TITLE
Fix test runners based on changes in #1561

### DIFF
--- a/packages/firestore/.idea/runConfigurations/All_Tests.xml
+++ b/packages/firestore/.idea/runConfigurations/All_Tests.xml
@@ -1,14 +1,17 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="All Tests" type="mocha-javascript-test-runner" factoryName="Mocha">
+  <configuration default="false" name="All Tests" type="mocha-javascript-test-runner">
     <node-interpreter>project</node-interpreter>
     <node-options />
+    <mocha-package>$PROJECT_DIR$/../../node_modules/mocha</mocha-package>
     <working-directory>$PROJECT_DIR$</working-directory>
     <pass-parent-env>true</pass-parent-env>
-    <envs />
+    <envs>
+      <env name="TS_NODE_COMPILER_OPTIONS" value="{&quot;module&quot;:&quot;commonjs&quot;}" />
+    </envs>
     <ui>bdd</ui>
     <extra-mocha-options>--require ts-node/register/type-check --require index.node.ts --timeout 5000</extra-mocha-options>
     <test-kind>PATTERN</test-kind>
     <test-pattern>test/{,!(browser)/**/}*.test.ts</test-pattern>
-    <method />
+    <method v="2" />
   </configuration>
 </component>

--- a/packages/firestore/.idea/runConfigurations/All_Tests__w__Mock_Persistence_.xml
+++ b/packages/firestore/.idea/runConfigurations/All_Tests__w__Mock_Persistence_.xml
@@ -1,16 +1,18 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="All Tests (w/ Mock Persistence)" type="mocha-javascript-test-runner" factoryName="Mocha">
+  <configuration default="false" name="All Tests (w/ Mock Persistence)" type="mocha-javascript-test-runner">
     <node-interpreter>project</node-interpreter>
     <node-options />
+    <mocha-package>$PROJECT_DIR$/../../node_modules/mocha</mocha-package>
     <working-directory>$PROJECT_DIR$</working-directory>
     <pass-parent-env>true</pass-parent-env>
     <envs>
       <env name="USE_MOCK_PERSISTENCE" value="YES" />
+      <env name="TS_NODE_COMPILER_OPTIONS" value="{&quot;module&quot;:&quot;commonjs&quot;}" />
     </envs>
     <ui>bdd</ui>
     <extra-mocha-options>--require ts-node/register/type-check --require index.node.ts --require test/util/node_persistence.ts --timeout 5000</extra-mocha-options>
     <test-kind>PATTERN</test-kind>
     <test-pattern>test/{,!(browser)/**/}*.test.ts</test-pattern>
-    <method />
+    <method v="2" />
   </configuration>
 </component>

--- a/packages/firestore/.idea/runConfigurations/Integration_Tests.xml
+++ b/packages/firestore/.idea/runConfigurations/Integration_Tests.xml
@@ -1,14 +1,17 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="Integration Tests" type="mocha-javascript-test-runner" factoryName="Mocha">
+  <configuration default="false" name="Integration Tests" type="mocha-javascript-test-runner">
     <node-interpreter>project</node-interpreter>
     <node-options />
+    <mocha-package>$PROJECT_DIR$/../../node_modules/mocha</mocha-package>
     <working-directory>$PROJECT_DIR$</working-directory>
     <pass-parent-env>true</pass-parent-env>
-    <envs />
+    <envs>
+      <env name="TS_NODE_COMPILER_OPTIONS" value="{&quot;module&quot;:&quot;commonjs&quot;}" />
+    </envs>
     <ui>bdd</ui>
     <extra-mocha-options>--require ts-node/register/type-check --require index.node.ts --timeout 5000</extra-mocha-options>
     <test-kind>PATTERN</test-kind>
     <test-pattern>test/integration/{,!(browser)/**/}*.test.ts</test-pattern>
-    <method />
+    <method v="2" />
   </configuration>
 </component>

--- a/packages/firestore/.idea/runConfigurations/Integration_Tests__w__Mock_Persistence_.xml
+++ b/packages/firestore/.idea/runConfigurations/Integration_Tests__w__Mock_Persistence_.xml
@@ -1,16 +1,18 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="Integration Tests (w/ Mock Persistence)" type="mocha-javascript-test-runner" factoryName="Mocha">
+  <configuration default="false" name="Integration Tests (w/ Mock Persistence)" type="mocha-javascript-test-runner">
     <node-interpreter>project</node-interpreter>
     <node-options />
+    <mocha-package>$PROJECT_DIR$/../../node_modules/mocha</mocha-package>
     <working-directory>$PROJECT_DIR$</working-directory>
     <pass-parent-env>true</pass-parent-env>
     <envs>
       <env name="USE_MOCK_PERSISTENCE" value="YES" />
+      <env name="TS_NODE_COMPILER_OPTIONS" value="{&quot;module&quot;:&quot;commonjs&quot;}" />
     </envs>
     <ui>bdd</ui>
     <extra-mocha-options>--require ts-node/register/type-check --require index.node.ts --require test/util/node_persistence.ts --timeout 5000</extra-mocha-options>
     <test-kind>PATTERN</test-kind>
     <test-pattern>test/integration/{,!(browser)/**/}*.test.ts</test-pattern>
-    <method />
+    <method v="2" />
   </configuration>
 </component>

--- a/packages/firestore/.idea/runConfigurations/Unit_Tests.xml
+++ b/packages/firestore/.idea/runConfigurations/Unit_Tests.xml
@@ -1,14 +1,17 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="Unit Tests" type="mocha-javascript-test-runner" factoryName="Mocha">
+  <configuration default="false" name="Unit Tests" type="mocha-javascript-test-runner">
     <node-interpreter>project</node-interpreter>
     <node-options />
+    <mocha-package>$PROJECT_DIR$/../../node_modules/mocha</mocha-package>
     <working-directory>$PROJECT_DIR$</working-directory>
     <pass-parent-env>true</pass-parent-env>
-    <envs />
+    <envs>
+      <env name="TS_NODE_COMPILER_OPTIONS" value="{&quot;module&quot;:&quot;commonjs&quot;}" />
+    </envs>
     <ui>bdd</ui>
     <extra-mocha-options>--require ts-node/register/type-check --require index.node.ts</extra-mocha-options>
     <test-kind>PATTERN</test-kind>
     <test-pattern>test/unit/{,!(browser)/**/}*.test.ts</test-pattern>
-    <method />
+    <method v="2" />
   </configuration>
 </component>

--- a/packages/firestore/.idea/runConfigurations/Unit_Tests__w__Mock_Persistence_.xml
+++ b/packages/firestore/.idea/runConfigurations/Unit_Tests__w__Mock_Persistence_.xml
@@ -1,16 +1,18 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="Unit Tests (w/ Mock Persistence)" type="mocha-javascript-test-runner" factoryName="Mocha">
+  <configuration default="false" name="Unit Tests (w/ Mock Persistence)" type="mocha-javascript-test-runner">
     <node-interpreter>project</node-interpreter>
     <node-options />
+    <mocha-package>$PROJECT_DIR$/../../node_modules/mocha</mocha-package>
     <working-directory>$PROJECT_DIR$</working-directory>
     <pass-parent-env>true</pass-parent-env>
     <envs>
       <env name="USE_MOCK_PERSISTENCE" value="YES" />
+      <env name="TS_NODE_COMPILER_OPTIONS" value="{&quot;module&quot;:&quot;commonjs&quot;}" />
     </envs>
     <ui>bdd</ui>
     <extra-mocha-options>--require ts-node/register/type-check --require index.node.ts --require test/util/node_persistence.ts</extra-mocha-options>
     <test-kind>PATTERN</test-kind>
     <test-pattern>test/unit/{,!(browser)/**/}*.test.ts</test-pattern>
-    <method />
+    <method v="2" />
   </configuration>
 </component>

--- a/packages/firestore/package.json
+++ b/packages/firestore/package.json
@@ -15,7 +15,7 @@
     "test:browser": "karma start --single-run",
     "test:browser:debug": "karma start --browsers=Chrome --auto-watch",
     "test:node": "TS_NODE_CACHE=NO TS_NODE_COMPILER_OPTIONS='{\"module\":\"commonjs\"}' nyc --reporter lcovonly -- mocha 'test/{,!(browser)/**/}*.test.ts' --file index.node.ts --opts ../../config/mocha.node.opts",
-    "test:node:persistence": "USE_MOCK_PERSISTENCE=YES TS_NODE_CACHE=NO nyc --reporter lcovonly -- mocha 'test/{,!(browser)/**/}*.test.ts' --file index.node.ts --require test/util/node_persistence.ts --opts ../../config/mocha.node.opts",
+    "test:node:persistence": "USE_MOCK_PERSISTENCE=YES TS_NODE_CACHE=NO TS_NODE_COMPILER_OPTIONS='{\"module\":\"commonjs\"}' nyc --reporter lcovonly -- mocha 'test/{,!(browser)/**/}*.test.ts' --file index.node.ts --require test/util/node_persistence.ts --opts ../../config/mocha.node.opts",
     "test:emulator": "ts-node ../../scripts/emulator-testing/firestore-test-runner.ts",
     "prepare": "npm run build"
   },


### PR DESCRIPTION
Fix `yarn test:node:persistence` in packages/firestore and also IntelliJ test runner definitions.

#1561 added a requirement that all test runs include an environment variable of `TS_NODE_COMPILER_OPTIONS={"module":"commonjs"}`. This change propagates this into some Firestore-specific locations.