### PR TITLE
Rename prepare to build, so build is not triggered after yarn install

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   ],
   "scripts": {
     "dev": "lerna run --parallel --scope @firebase/* --scope firebase --scope rxfire dev",
-    "prepare": "lerna run --scope @firebase/* --scope firebase --scope rxfire prepare",
+    "build": "lerna run --scope @firebase/* --scope firebase --scope rxfire prepare",
     "prepush": "node tools/gitHooks/prepush.js",
     "link:packages": "lerna exec --scope @firebase/* --scope firebase --scope rxfire -- yarn link",
     "stage:packages": "./scripts/prepublish.sh",

--- a/scripts/release/cli.js
+++ b/scripts/release/cli.js
@@ -65,7 +65,7 @@ const { argv } = require('yargs');
      * If there are no packages that have been updated
      * skip the release cycle
      */
-    if (!await hasUpdatedPackages()) {
+    if (!(await hasUpdatedPackages())) {
       console.log('No packages need to be updated. Exiting...');
       return;
     }

--- a/scripts/release/cli.js
+++ b/scripts/release/cli.js
@@ -31,8 +31,7 @@ const {
   getCurrentSha,
   hasDiff,
   pushUpdatesToGithub,
-  resetWorkingTree,
-  treeAtHead
+  resetWorkingTree
 } = require('./utils/git');
 const {
   packageVersionUpdate,
@@ -40,7 +39,7 @@ const {
   validateReadyToPush,
   validateVersions
 } = require('./utils/inquirer');
-const { reinstallDeps } = require('./utils/yarn');
+const { reinstallDeps, buildPackages } = require('./utils/yarn');
 const { runTests, setupTestDeps } = require('./utils/tests');
 const { publishToNpm } = require('./utils/npm');
 const { bannerText } = require('./utils/banner');
@@ -155,9 +154,9 @@ const { argv } = require('yargs');
     await updateWorkspaceVersions(versions, argv.canary);
 
     /**
-     * Users can pass --skipRebuild to skip the rebuild step
+     * Users can pass --skipReinstall to skip the installation step
      */
-    if (!argv.skipRebuild) {
+    if (!argv.skipReinstall) {
       /**
        * Clean install dependencies
        */
@@ -165,6 +164,11 @@ const { argv } = require('yargs');
       await cleanTree();
       await reinstallDeps();
     }
+
+    /**
+     * build packages
+     */
+    await buildPackages();
 
     /**
      * Don't do the following for canary releases:

--- a/scripts/release/utils/yarn.js
+++ b/scripts/release/utils/yarn.js
@@ -32,3 +32,17 @@ exports.reinstallDeps = async () => {
     throw err;
   }
 };
+
+exports.buildPackages = async () => {
+  try {
+    const spinner = ora(' Building Packages').start();
+    await spawn('yarn', ['build'], {
+      cwd: root
+    });
+    spinner.stopAndPersist({
+      symbol: '✅'
+    });
+  } catch (err) {
+    throw err;
+  }
+};


### PR DESCRIPTION
`yarn install` takes a long time at the repo level. Part of it is because we automatically trigger a build for all packages after installation. This change uncouples build script from yarn install at repo level.