### PR TITLE
Add `repository.directory` field to all `package.json` files

### DIFF
--- a/packages/app-types/package.json
+++ b/packages/app-types/package.json
@@ -12,8 +12,9 @@
     "private.d.ts"
   ],
   "repository": {
+    "directory": "packages/app-types",
     "type": "git",
-    "url": "https://github.com/firebase/firebase-js-sdk/tree/master/packages/app-types"
+    "url": "https://github.com/firebase/firebase-js-sdk.git"
   },
   "bugs": {
     "url": "https://github.com/firebase/firebase-js-sdk/issues"

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -56,8 +56,9 @@
     "webpack": "4.29.6"
   },
   "repository": {
+    "directory": "packages/app",
     "type": "git",
-    "url": "https://github.com/firebase/firebase-js-sdk/tree/master/packages/app"
+    "url": "https://github.com/firebase/firebase-js-sdk.git"
   },
   "bugs": {
     "url": "https://github.com/firebase/firebase-js-sdk/issues"

--- a/packages/auth-types/package.json
+++ b/packages/auth-types/package.json
@@ -15,8 +15,9 @@
     "@firebase/util": "0.x"
   },
   "repository": {
+    "directory": "packages/auth-types",
     "type": "git",
-    "url": "https://github.com/firebase/firebase-js-sdk/tree/master/packages/auth-types"
+    "url": "https://github.com/firebase/firebase-js-sdk.git"
   },
   "bugs": {
     "url": "https://github.com/firebase/firebase-js-sdk/issues"

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -33,8 +33,9 @@
     "protractor": "5.4.2"
   },
   "repository": {
+    "directory": "packages/auth",
     "type": "git",
-    "url": "https://github.com/firebase/firebase-js-sdk/tree/master/packages/auth"
+    "url": "https://github.com/firebase/firebase-js-sdk.git"
   },
   "peerDependencies": {
     "@firebase/app": "0.x"

--- a/packages/database-types/package.json
+++ b/packages/database-types/package.json
@@ -14,8 +14,9 @@
     "@firebase/app-types": "0.x"
   },
   "repository": {
+    "directory": "packages/database-types",
     "type": "git",
-    "url": "https://github.com/firebase/firebase-js-sdk/tree/master/packages/database-types"
+    "url": "https://github.com/firebase/firebase-js-sdk.git"
   },
   "bugs": {
     "url": "https://github.com/firebase/firebase-js-sdk/issues"

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -59,8 +59,9 @@
     "webpack": "4.29.6"
   },
   "repository": {
+    "directory": "packages/database",
     "type": "git",
-    "url": "https://github.com/firebase/firebase-js-sdk/tree/master/packages/database"
+    "url": "https://github.com/firebase/firebase-js-sdk.git"
   },
   "bugs": {
     "url": "https://github.com/firebase/firebase-js-sdk/issues"

--- a/packages/firestore-types/package.json
+++ b/packages/firestore-types/package.json
@@ -14,8 +14,9 @@
     "@firebase/app-types": "0.x"
   },
   "repository": {
+    "directory": "packages/firestore-types",
     "type": "git",
-    "url": "https://github.com/firebase/firebase-js-sdk/tree/master/packages/firestore-types"
+    "url": "https://github.com/firebase/firebase-js-sdk.git"
   },
   "bugs": {
     "url": "https://github.com/firebase/firebase-js-sdk/issues"

--- a/packages/firestore/package.json
+++ b/packages/firestore/package.json
@@ -76,8 +76,9 @@
     "yargs": "13.2.2"
   },
   "repository": {
+    "directory": "packages/firestore",
     "type": "git",
-    "url": "https://github.com/firebase/firebase-js-sdk/tree/master/packages/firestore"
+    "url": "https://github.com/firebase/firebase-js-sdk.git"
   },
   "bugs": {
     "url": "https://github.com/firebase/firebase-js-sdk/issues"

--- a/packages/functions-types/package.json
+++ b/packages/functions-types/package.json
@@ -11,8 +11,9 @@
     "index.d.ts"
   ],
   "repository": {
+    "directory": "packages/functions-types",
     "type": "git",
-    "url": "https://github.com/firebase/firebase-js-sdk/tree/master/packages/functions-types"
+    "url": "https://github.com/firebase/firebase-js-sdk.git"
   },
   "bugs": {
     "url": "https://github.com/firebase/firebase-js-sdk/issues"

--- a/packages/functions/package.json
+++ b/packages/functions/package.json
@@ -54,8 +54,9 @@
     "yargs": "13.2.2"
   },
   "repository": {
+    "directory": "packages/functions",
     "type": "git",
-    "url": "https://github.com/firebase/firebase-js-sdk/tree/master/packages/functions"
+    "url": "https://github.com/firebase/firebase-js-sdk.git"
   },
   "bugs": {
     "url": "https://github.com/firebase/firebase-js-sdk/issues"

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -42,8 +42,9 @@
     "webpack": "4.29.6"
   },
   "repository": {
+    "directory": "packages/logger",
     "type": "git",
-    "url": "https://github.com/firebase/firebase-js-sdk/tree/master/packages/logger"
+    "url": "https://github.com/firebase/firebase-js-sdk.git"
   },
   "bugs": {
     "url": "https://github.com/firebase/firebase-js-sdk/issues"

--- a/packages/messaging-types/package.json
+++ b/packages/messaging-types/package.json
@@ -14,8 +14,9 @@
     "@firebase/app-types": "0.x"
   },
   "repository": {
+    "directory": "packages/messaging-types",
     "type": "git",
-    "url": "https://github.com/firebase/firebase-js-sdk/tree/master/packages/messaging-types"
+    "url": "https://github.com/firebase/firebase-js-sdk.git"
   },
   "bugs": {
     "url": "https://github.com/firebase/firebase-js-sdk/issues"

--- a/packages/messaging/package.json
+++ b/packages/messaging/package.json
@@ -52,8 +52,9 @@
     "typescript": "3.3.3"
   },
   "repository": {
+    "directory": "packages/messaging",
     "type": "git",
-    "url": "https://github.com/firebase/firebase-js-sdk/tree/master/packages/messaging"
+    "url": "https://github.com/firebase/firebase-js-sdk.git"
   },
   "bugs": {
     "url": "https://github.com/firebase/firebase-js-sdk/issues"

--- a/packages/polyfill/package.json
+++ b/packages/polyfill/package.json
@@ -25,8 +25,9 @@
     "rollup-plugin-typescript2": "0.19.3"
   },
   "repository": {
+    "directory": "packages/polyfill",
     "type": "git",
-    "url": "https://github.com/firebase/firebase-js-sdk/tree/master/packages/polyfill"
+    "url": "https://github.com/firebase/firebase-js-sdk.git"
   },
   "bugs": {
     "url": "https://github.com/firebase/firebase-js-sdk/issues"

--- a/packages/storage-types/package.json
+++ b/packages/storage-types/package.json
@@ -15,8 +15,9 @@
     "@firebase/util": "0.x"
   },
   "repository": {
+    "directory": "packages/storage-types",
     "type": "git",
-    "url": "https://github.com/firebase/firebase-js-sdk/tree/master/packages/storage-types"
+    "url": "https://github.com/firebase/firebase-js-sdk.git"
   },
   "bugs": {
     "url": "https://github.com/firebase/firebase-js-sdk/issues"

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -48,8 +48,9 @@
     "webpack": "4.29.6"
   },
   "repository": {
+    "directory": "packages/storage",
     "type": "git",
-    "url": "https://github.com/firebase/firebase-js-sdk/tree/master/packages/storage"
+    "url": "https://github.com/firebase/firebase-js-sdk.git"
   },
   "bugs": {
     "url": "https://github.com/firebase/firebase-js-sdk/issues"

--- a/packages/template-types/package.json
+++ b/packages/template-types/package.json
@@ -12,8 +12,9 @@
     "index.d.ts"
   ],
   "repository": {
+    "directory": "packages/template-types",
     "type": "git",
-    "url": "https://github.com/firebase/firebase-js-sdk/tree/master/packages/template-types"
+    "url": "https://github.com/firebase/firebase-js-sdk.git"
   },
   "bugs": {
     "url": "https://github.com/firebase/firebase-js-sdk/issues"

--- a/packages/template/package.json
+++ b/packages/template/package.json
@@ -51,8 +51,9 @@
     "webpack": "4.29.6"
   },
   "repository": {
+    "directory": "packages/template",
     "type": "git",
-    "url": "https://github.com/firebase/firebase-js-sdk/tree/master/packages/template"
+    "url": "https://github.com/firebase/firebase-js-sdk.git"
   },
   "bugs": {
     "url": "https://github.com/firebase/firebase-js-sdk/issues"

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -33,8 +33,9 @@
     "rollup-plugin-typescript2": "0.19.3"
   },
   "repository": {
+    "directory": "packages/testing",
     "type": "git",
-    "url": "https://github.com/firebase/firebase-js-sdk/tree/master/packages/testing"
+    "url": "https://github.com/firebase/firebase-js-sdk.git"
   },
   "typings": "dist/index.d.ts",
   "bugs": {

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -45,8 +45,9 @@
     "webpack": "4.29.6"
   },
   "repository": {
+    "directory": "packages/util",
     "type": "git",
-    "url": "https://github.com/firebase/firebase-js-sdk/tree/master/packages/util"
+    "url": "https://github.com/firebase/firebase-js-sdk.git"
   },
   "bugs": {
     "url": "https://github.com/firebase/firebase-js-sdk/issues"

--- a/packages/webchannel-wrapper/package.json
+++ b/packages/webchannel-wrapper/package.json
@@ -22,8 +22,9 @@
     "watch": "1.0.2"
   },
   "repository": {
+    "directory": "packages/webchannel-wrapper",
     "type": "git",
-    "url": "https://github.com/firebase/firebase-js-sdk/tree/master/packages/webchannel-wrapper"
+    "url": "https://github.com/firebase/firebase-js-sdk.git"
   },
   "bugs": {
     "url": "https://github.com/firebase/firebase-js-sdk/issues"


### PR DESCRIPTION
npm supports links to `package.json` files that are not in a root of a repostiory by supplying `directory` field in `repository`, see https://docs.npmjs.com/files/package.json.html#repository