### PR TITLE
Ensure consistent JSON Serialization of DocumentKeys

### DIFF
--- a/packages/firestore/CHANGELOG.md
+++ b/packages/firestore/CHANGELOG.md
@@ -8,6 +8,9 @@
   While this feature is not yet available, all schema changes are included
   in this release. Once you upgrade, you will not be able to use an older version
   of the Firestore SDK with persistence enabled.
+- [fixed] Fixed an issue with IndexedDb persistence that triggered an internal
+  assert for Queries that use nested DocumentReferences in where() clauses
+  (#1524, #1596).
 
 # 1.0.4
 - [fixed] Fixed an uncaught promise error occurring when `enablePersistence()`

--- a/packages/firestore/src/core/sync_engine.ts
+++ b/packages/firestore/src/core/sync_engine.ts
@@ -204,7 +204,7 @@ export class SyncEngine implements RemoteSyncer, SharedClientStateSyncer {
 
     const queryView = this.queryViewsByQuery.get(query);
     if (queryView) {
-      // PORTING NOTE: With Mult-Tab Web, it is possible that a query view
+      // PORTING NOTE: With Multi-Tab Web, it is possible that a query view
       // already exists when EventManager calls us for the first time. This
       // happens when the primary tab is already listening to this query on
       // behalf of another tab and the user of the primary also starts listening

--- a/packages/firestore/src/model/field_value.ts
+++ b/packages/firestore/src/model/field_value.ts
@@ -614,7 +614,7 @@ export class ObjectValue extends FieldValue {
   }
 
   toString(): string {
-    return JSON.stringify(this.value());
+    return this.internalValue.toString();
   }
 
   private child(childName: string): FieldValue | undefined {
@@ -688,6 +688,7 @@ export class ArrayValue extends FieldValue {
   }
 
   toString(): string {
-    return JSON.stringify(this.value());
+    const descriptions = this.internalValue.map(v => v.toString());
+    return `[${descriptions.join(',')}]`;
   }
 }

--- a/packages/firestore/src/model/path.ts
+++ b/packages/firestore/src/model/path.ts
@@ -23,7 +23,7 @@ export const DOCUMENT_KEY_NAME = '__name__';
 /**
  * Path represents an ordered sequence of string segments.
  */
-export abstract class Path {
+abstract class Path {
   private segments: string[];
   private offset: number;
   private len: number;
@@ -31,6 +31,14 @@ export abstract class Path {
   constructor(segments: string[], offset?: number, length?: number) {
     this.init(segments, offset, length);
   }
+
+  /**
+   * Returns a String representation.
+   *
+   * Implementing classes are required to provide deterministic implementations as
+   * the String representation is used to obtain canonical Query IDs.
+   */
+  abstract toString(): string;
 
   /**
    * An initialization method that can be called from outside the constructor.
@@ -71,10 +79,6 @@ export abstract class Path {
 
   get length(): number {
     return this.len;
-  }
-
-  toJSON(): string[] {
-    return this.segments.slice(this.offset, this.limit());
   }
 
   isEqual(other: Path): boolean {

--- a/packages/firestore/src/model/path.ts
+++ b/packages/firestore/src/model/path.ts
@@ -73,6 +73,10 @@ export abstract class Path {
     return this.len;
   }
 
+  toJSON(): string[] {
+    return this.segments.slice(this.offset, this.limit());
+  }
+
   isEqual(other: Path): boolean {
     return Path.comparator(this, other) === 0;
   }

--- a/packages/firestore/src/util/sorted_map.ts
+++ b/packages/firestore/src/util/sorted_map.ts
@@ -143,6 +143,15 @@ export class SortedMap<K, V> {
     });
   }
 
+  toString(): string {
+    const descriptions: string[] = [];
+    this.inorderTraversal((k, v) => {
+      descriptions.push(`${k}:${v}`);
+      return false;
+    });
+    return `{${descriptions.join(', ')}}`;
+  }
+
   // Traverses the map in reverse key order and calls the specified action
   // function for each key/value pair. If action returns true, traversal is
   // aborted.

--- a/packages/firestore/test/integration/api/query.test.ts
+++ b/packages/firestore/test/integration/api/query.test.ts
@@ -703,7 +703,13 @@ apiDescribe('Queries', persistence => {
         ref: ref.firestore.doc('f/c'),
         geoPoint: new GeoPoint(0, 0),
         buffer: Blob.fromBase64String('Zm9v'),
-        time: Timestamp.now()
+        time: Timestamp.now(),
+        array: [
+          ref.firestore.doc('f/c'),
+          new GeoPoint(0, 0),
+          Blob.fromBase64String('Zm9v'),
+          Timestamp.now()
+        ]
       };
       await ref.add({ data });
 

--- a/packages/firestore/test/unit/core/query.test.ts
+++ b/packages/firestore/test/unit/core/query.test.ts
@@ -383,6 +383,27 @@ describe('Query', () => {
     // .addOrderBy(orderBy(DOCUMENT_KEY_NAME, 'desc'))
     // .withUpperBound(lip3, 'exclusive');
 
+    const relativeReference = ref('project1/database1', 'col/doc');
+    const absoluteReference = ref(
+      'project1/database1',
+      'projects/project1/databases/database1/documents/col/doc',
+      5
+    );
+
+    const q16a = Query.atPath(path('foo')).addFilter(
+      filter('object', '==', { ref: relativeReference })
+    );
+    const q16b = Query.atPath(path('foo')).addFilter(
+      filter('object', '==', { ref: absoluteReference })
+    );
+
+    const q17a = Query.atPath(path('foo')).addFilter(
+      filter('array', '==', [relativeReference])
+    );
+    const q17b = Query.atPath(path('foo')).addFilter(
+      filter('array', '==', [absoluteReference])
+    );
+
     const queries = [
       [q1a, q1b],
       [q2a, q2b],
@@ -396,9 +417,11 @@ describe('Query', () => {
       [q10a],
       [q11a],
       [q12a],
-      [q13a]
+      [q13a],
       //[q14a],
       //[q15a],
+      [q16a, q16b],
+      [q17a, q17b]
     ];
 
     expectEqualitySets(queries, (q1, q2) => {

--- a/packages/firestore/test/unit/model/path.test.ts
+++ b/packages/firestore/test/unit/model/path.test.ts
@@ -171,6 +171,12 @@ describe('Path', () => {
     expect(abc.isPrefixOf(ba)).to.equal(false);
   });
 
+  it('respects offset during JSON serialization', () => {
+    const path1 = new ResourcePath(['c']);
+    const path2 = new ResourcePath(['a', 'b', 'c'], 2);
+    expect(JSON.stringify(path1)).to.equal(JSON.stringify(path2));
+  });
+
   it('can be constructed from field path.', () => {
     const path = FieldPath.fromServerFormat('foo\\..bar\\\\.baz');
     expect(path.toArray()).to.deep.equal(['foo.', 'bar\\', 'baz']);

--- a/packages/firestore/test/unit/model/path.test.ts
+++ b/packages/firestore/test/unit/model/path.test.ts
@@ -171,12 +171,6 @@ describe('Path', () => {
     expect(abc.isPrefixOf(ba)).to.equal(false);
   });
 
-  it('respects offset during JSON serialization', () => {
-    const path1 = new ResourcePath(['c']);
-    const path2 = new ResourcePath(['a', 'b', 'c'], 2);
-    expect(JSON.stringify(path1)).to.equal(JSON.stringify(path2));
-  });
-
   it('can be constructed from field path.', () => {
     const path = FieldPath.fromServerFormat('foo\\..bar\\\\.baz');
     expect(path.toArray()).to.deep.equal(['foo.', 'bar\\', 'baz']);

--- a/packages/firestore/test/util/helpers.ts
+++ b/packages/firestore/test/util/helpers.ts
@@ -105,10 +105,14 @@ export function version(v: TestSnapshotVersion): SnapshotVersion {
   return SnapshotVersion.fromMicroseconds(v);
 }
 
-export function ref(dbIdStr: string, keyStr: string): DocumentKeyReference {
+export function ref(
+  dbIdStr: string,
+  keyStr: string,
+  offset?: number
+): DocumentKeyReference {
   const [project, database] = dbIdStr.split('/', 2);
   const dbId = new DatabaseId(project, database);
-  return new DocumentKeyReference(dbId, key(keyStr));
+  return new DocumentKeyReference(dbId, new DocumentKey(path(keyStr, offset)));
 }
 
 export function doc(


### PR DESCRIPTION
Fixes https://github.com/firebase/firebase-js-sdk/issues/1524

The DocumentKey serialization to canonical Query IDs is different once a Query is round-tripped through IndexedDb. After the round-trip, we include the project and database ID in the JSON serialized canonical ID. Since we use this ID as a Map key in SyncEngine, we need to ensure that these IDs are consistent.

This is technically a minor breaking change since it means that existing Queries that filter by DocumentReferences will no longer be read back from persistence. Instead, we will treat them as new queries and GC the old query.