### PR TITLE
Remove source links from generated reference docs

### DIFF
--- a/scripts/docgen/theme/partials/member.sources.hbs
+++ b/scripts/docgen/theme/partials/member.sources.hbs
@@ -1,0 +1,11 @@
+<aside class="tsd-sources">
+    {{#if implementationOf}}
+        <p>Implementation of {{#with implementationOf}}{{> typeAndParent}}{{/with}}</p>
+    {{/if}}
+    {{#if inheritedFrom}}
+        <p>Inherited from {{#with inheritedFrom}}{{> typeAndParent}}{{/with}}</p>
+    {{/if}}
+    {{#if overwrites}}
+        <p>Overrides {{#with overwrites}}{{> typeAndParent}}{{/with}}</p>
+    {{/if}}
+</aside>


### PR DESCRIPTION
Typedoc adds a link to the source code for every symbol documented, and since we are currently using `index.d.ts` as our source, this is not very useful, and the link wrongly points to the local generated files dir anyway.  If we reach our goal of generating docs from source code we can restore this and fix the bad link prefix too.

This file basically overrides the [default Typedoc theme file of the same name](https://github.com/TypeStrong/typedoc-default-themes/blob/f992ea329904db58671a553c30171eb8fdfd3690/src/default/partials/member.sources.hbs) and removes the sources section.