### PR TITLE
Adding missing export for DataSnapshot

### DIFF
--- a/packages/database/index.node.ts
+++ b/packages/database/index.node.ts
@@ -20,6 +20,7 @@ import { CONSTANTS, isNodeSdk } from '@firebase/util';
 import { FirebaseApp, FirebaseNamespace } from '@firebase/app-types';
 import { _FirebaseNamespace } from '@firebase/app-types/private';
 import { Database } from './src/api/Database';
+import { DataSnapshot } from './src/api/DataSnapshot';
 import { Query } from './src/api/Query';
 import { Reference } from './src/api/Reference';
 import { enableLogging } from './src/core/util/util';
@@ -55,6 +56,7 @@ export function initStandalone(app, url, version?: string) {
       Reference,
       Query,
       Database,
+      DataSnapshot,
       enableLogging,
       INTERNAL,
       ServerValue,
@@ -73,6 +75,7 @@ export function registerDatabase(instance: FirebaseNamespace) {
       Reference,
       Query,
       Database,
+      DataSnapshot,
       enableLogging,
       INTERNAL,
       ServerValue,

--- a/packages/database/index.ts
+++ b/packages/database/index.ts
@@ -19,6 +19,7 @@ import firebase from '@firebase/app';
 import { FirebaseApp, FirebaseNamespace } from '@firebase/app-types';
 import { _FirebaseNamespace } from '@firebase/app-types/private';
 import { Database } from './src/api/Database';
+import { DataSnapshot } from './src/api/DataSnapshot';
 import { Query } from './src/api/Query';
 import { Reference } from './src/api/Reference';
 import { enableLogging } from './src/core/util/util';
@@ -40,6 +41,7 @@ export function registerDatabase(instance: FirebaseNamespace) {
       Reference,
       Query,
       Database,
+      DataSnapshot,
       enableLogging,
       INTERNAL,
       ServerValue,


### PR DESCRIPTION
Fixes: https://github.com/firebase/firebase-js-sdk/issues/1384

We never exported DataSnapshot from the Database SDK, even though it is part of our types. With this PR, users will be able to directly access it (e.g. for instanceof checks). 