### PR TITLE
b/125385470: Fix transactions w/ auth issue on NodeJS.

### DIFF
--- a/packages/firestore/CHANGELOG.md
+++ b/packages/firestore/CHANGELOG.md
@@ -11,6 +11,8 @@
 - [fixed] Fixed an issue with IndexedDb persistence that triggered an internal
   assert for Queries that use nested DocumentReferences in where() clauses
   (#1524, #1596).
+- [fixed] Fixed an issue where transactions in a Node.JS app could be sent
+  without auth credentials, leading to Permission Denied errors.
 
 # 1.0.4
 - [fixed] Fixed an uncaught promise error occurring when `enablePersistence()`


### PR DESCRIPTION
In https://github.com/firebase/firebase-js-sdk/commit/81cd260aeb729c5003952988b19d5b32788510d4 we moved to sending our auth metadata directly in each RPC call, but for RPCs that take a callback (i.e. non-streaming RPCs like we use to commit a transaction), the auth metadata must be passed *before* the callback, but we were unconditionally passing it as the last argument: https://github.com/firebase/firebase-js-sdk/blob/a18b2905a161f302bf0fad7a32dd82507932093e/packages/firestore/src/platform_node/grpc_connection.ts#L145

I've fixed this by removing the getRpcCallable() helper which I felt wasn't being that helpful anymore. I also cleaned up ensureActiveStub() which accepted a token but didn't do anything with it.