### PR TITLE
exclude karma-sauce-launcher in dep auto update

### DIFF
--- a/integration/browserify/.ncurc.json
+++ b/integration/browserify/.ncurc.json
@@ -1,5 +1,6 @@
 {
     "upgrade": true,
     "reject": [
+        "karma-sauce-launcher"
     ]
 }

--- a/integration/browserify/package.json
+++ b/integration/browserify/package.json
@@ -19,7 +19,7 @@
     "karma-chrome-launcher": "2.2.0",
     "karma-firefox-launcher": "1.1.0",
     "karma-mocha": "1.3.0",
-    "karma-sauce-launcher": "2.0.2",
+    "karma-sauce-launcher": "1.2.0",
     "karma-spec-reporter": "0.0.32",
     "mkdirp": "0.5.1",
     "mocha": "6.0.2"

--- a/integration/typescript/.ncurc.json
+++ b/integration/typescript/.ncurc.json
@@ -1,5 +1,6 @@
 {
     "upgrade": true,
     "reject": [
+        "karma-sauce-launcher"
     ]
 }

--- a/integration/typescript/package.json
+++ b/integration/typescript/package.json
@@ -20,7 +20,7 @@
     "karma-chrome-launcher": "2.2.0",
     "karma-firefox-launcher": "1.1.0",
     "karma-mocha": "1.3.0",
-    "karma-sauce-launcher": "2.0.2",
+    "karma-sauce-launcher": "1.2.0",
     "karma-spec-reporter": "0.0.32",
     "karma-typescript": "4.0.0",
     "mocha": "6.0.2",

--- a/integration/webpack/.ncurc.json
+++ b/integration/webpack/.ncurc.json
@@ -1,5 +1,6 @@
 {
     "upgrade": true,
     "reject": [
+        "karma-sauce-launcher"
     ]
 }

--- a/integration/webpack/package.json
+++ b/integration/webpack/package.json
@@ -18,7 +18,7 @@
     "karma-chrome-launcher": "2.2.0",
     "karma-firefox-launcher": "1.1.0",
     "karma-mocha": "1.3.0",
-    "karma-sauce-launcher": "2.0.2",
+    "karma-sauce-launcher": "1.2.0",
     "karma-spec-reporter": "0.0.32",
     "mocha": "6.0.2",
     "webpack": "4.29.6",

--- a/packages/app/.ncurc.json
+++ b/packages/app/.ncurc.json
@@ -1,5 +1,6 @@
 {
     "upgrade": true,
     "reject": [
+        "karma-sauce-launcher"
     ]
 }

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -38,7 +38,7 @@
     "karma-coverage-istanbul-reporter": "2.0.5",
     "karma-firefox-launcher": "1.1.0",
     "karma-mocha": "1.3.0",
-    "karma-sauce-launcher": "2.0.2",
+    "karma-sauce-launcher": "1.2.0",
     "karma-sourcemap-loader": "0.3.7",
     "karma-spec-reporter": "0.0.32",
     "karma-webpack": "3.0.5",

--- a/packages/database/.ncurc.json
+++ b/packages/database/.ncurc.json
@@ -1,5 +1,6 @@
 {
     "upgrade": true,
     "reject": [
+        "karma-sauce-launcher"
     ]
 }

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -42,7 +42,7 @@
     "karma-cli": "2.0.0",
     "karma-firefox-launcher": "1.1.0",
     "karma-mocha": "1.3.0",
-    "karma-sauce-launcher": "2.0.2",
+    "karma-sauce-launcher": "1.2.0",
     "karma-sourcemap-loader": "0.3.7",
     "karma-spec-reporter": "0.0.32",
     "karma-webpack": "3.0.5",

--- a/packages/firestore/.ncurc.json
+++ b/packages/firestore/.ncurc.json
@@ -1,6 +1,7 @@
 {
     "upgrade": true,
     "reject": [
-        "long"
+        "long",
+        "karma-sauce-launcher"
     ]
 }

--- a/packages/firestore/package.json
+++ b/packages/firestore/package.json
@@ -50,7 +50,7 @@
     "karma-cli": "2.0.0",
     "karma-firefox-launcher": "1.1.0",
     "karma-mocha": "1.3.0",
-    "karma-sauce-launcher": "2.0.2",
+    "karma-sauce-launcher": "1.2.0",
     "karma-sourcemap-loader": "0.3.7",
     "karma-spec-reporter": "0.0.32",
     "karma-summary-reporter": "1.6.0",

--- a/packages/functions/.ncurc.json
+++ b/packages/functions/.ncurc.json
@@ -1,5 +1,6 @@
 {
     "upgrade": true,
     "reject": [
+        "karma-sauce-launcher"
     ]
 }

--- a/packages/functions/package.json
+++ b/packages/functions/package.json
@@ -35,7 +35,7 @@
     "karma-cli": "2.0.0",
     "karma-firefox-launcher": "1.1.0",
     "karma-mocha": "1.3.0",
-    "karma-sauce-launcher": "2.0.2",
+    "karma-sauce-launcher": "1.2.0",
     "karma-sourcemap-loader": "0.3.7",
     "karma-spec-reporter": "0.0.32",
     "karma-webpack": "3.0.5",

--- a/packages/logger/.ncurc.json
+++ b/packages/logger/.ncurc.json
@@ -1,5 +1,6 @@
 {
     "upgrade": true,
     "reject": [
+        "karma-sauce-launcher"
     ]
 }

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -28,7 +28,7 @@
     "karma-cli": "2.0.0",
     "karma-firefox-launcher": "1.1.0",
     "karma-mocha": "1.3.0",
-    "karma-sauce-launcher": "2.0.2",
+    "karma-sauce-launcher": "1.2.0",
     "karma-spec-reporter": "0.0.32",
     "karma-webpack": "3.0.5",
     "mocha": "6.0.2",

--- a/packages/messaging/.ncurc.json
+++ b/packages/messaging/.ncurc.json
@@ -1,5 +1,6 @@
 {
     "upgrade": true,
     "reject": [
+        "karma-sauce-launcher"
     ]
 }

--- a/packages/messaging/package.json
+++ b/packages/messaging/package.json
@@ -40,7 +40,7 @@
     "karma-firefox-launcher": "1.1.0",
     "karma-mocha": "1.3.0",
     "karma-safari-launcher": "1.0.0",
-    "karma-sauce-launcher": "2.0.2",
+    "karma-sauce-launcher": "1.2.0",
     "karma-sourcemap-loader": "0.3.7",
     "karma-spec-reporter": "0.0.32",
     "mocha": "6.0.2",

--- a/packages/rxfire/.ncurc.json
+++ b/packages/rxfire/.ncurc.json
@@ -1,5 +1,6 @@
 {
     "upgrade": true,
     "reject": [
+        "karma-sauce-launcher"
     ]
 }

--- a/packages/rxfire/package.json
+++ b/packages/rxfire/package.json
@@ -54,7 +54,7 @@
     "karma-cli": "2.0.0",
     "karma-firefox-launcher": "1.1.0",
     "karma-mocha": "1.3.0",
-    "karma-sauce-launcher": "2.0.2",
+    "karma-sauce-launcher": "1.2.0",
     "karma-sourcemap-loader": "0.3.7",
     "karma-spec-reporter": "0.0.32",
     "karma-webpack": "3.0.5",

--- a/packages/storage/.ncurc.json
+++ b/packages/storage/.ncurc.json
@@ -1,5 +1,6 @@
 {
     "upgrade": true,
     "reject": [
+        "karma-sauce-launcher"
     ]
 }

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -34,7 +34,7 @@
     "karma-cli": "2.0.0",
     "karma-firefox-launcher": "1.1.0",
     "karma-mocha": "1.3.0",
-    "karma-sauce-launcher": "2.0.2",
+    "karma-sauce-launcher": "1.2.0",
     "karma-sourcemap-loader": "0.3.7",
     "karma-spec-reporter": "0.0.32",
     "karma-webpack": "3.0.5",

--- a/packages/template/.ncurc.json
+++ b/packages/template/.ncurc.json
@@ -1,5 +1,6 @@
 {
     "upgrade": true,
     "reject": [
+        "karma-sauce-launcher"
     ]
 }

--- a/packages/template/package.json
+++ b/packages/template/package.json
@@ -37,7 +37,7 @@
     "karma-cli": "2.0.0",
     "karma-firefox-launcher": "1.1.0",
     "karma-mocha": "1.3.0",
-    "karma-sauce-launcher": "2.0.2",
+    "karma-sauce-launcher": "1.2.0",
     "karma-spec-reporter": "0.0.32",
     "karma-webpack": "3.0.5",
     "mocha": "6.0.2",

--- a/packages/util/.ncurc.json
+++ b/packages/util/.ncurc.json
@@ -1,5 +1,6 @@
 {
     "upgrade": true,
     "reject": [
+        "karma-sauce-launcher"
     ]
 }

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -31,7 +31,7 @@
     "karma-cli": "2.0.0",
     "karma-firefox-launcher": "1.1.0",
     "karma-mocha": "1.3.0",
-    "karma-sauce-launcher": "2.0.2",
+    "karma-sauce-launcher": "1.2.0",
     "karma-spec-reporter": "0.0.32",
     "karma-webpack": "3.0.5",
     "mocha": "6.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2174,7 +2174,7 @@ archiver-utils@^1.3.0:
     normalize-path "^2.0.0"
     readable-stream "^2.0.0"
 
-archiver@^2.1.1:
+archiver@2.1.1, archiver@^2.1.1:
   version "2.1.1"
   resolved "https://registry.npmjs.org/archiver/-/archiver-2.1.1.tgz#ff662b4a78201494a3ee544d3a33fe7496509ebc"
   integrity sha1-/2YrSnggFJSj7lRNOjP+dJZQnrw=
@@ -2482,6 +2482,13 @@ async@1.x, async@^1.3.0, async@^1.4.0, async@^1.5.2:
   version "1.5.2"
   resolved "https://registry.npmjs.org/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
   integrity sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=
+
+async@2.0.1:
+  version "2.0.1"
+  resolved "https://registry.npmjs.org/async/-/async-2.0.1.tgz#b709cc0280a9c36f09f4536be823c838a9049e25"
+  integrity sha1-twnMAoCpw28J9FNr6CPIOKkEniU=
+  dependencies:
+    lodash "^4.8.0"
 
 async@2.6.0, async@^2.0.0, async@^2.0.1, async@^2.1.2, async@^2.3.0, async@^2.4.0, async@^2.5.0:
   version "2.6.0"
@@ -8227,14 +8234,15 @@ karma-safari-launcher@1.0.0:
   resolved "https://registry.npmjs.org/karma-safari-launcher/-/karma-safari-launcher-1.0.0.tgz#96982a2cc47d066aae71c553babb28319115a2ce"
   integrity sha1-lpgqLMR9BmquccVTursoMZEVos4=
 
-karma-sauce-launcher@2.0.2:
-  version "2.0.2"
-  resolved "https://registry.npmjs.org/karma-sauce-launcher/-/karma-sauce-launcher-2.0.2.tgz#dbf98e70d86bf287b03a537cf637eb7aefa975c3"
-  integrity sha512-jLUFaJhHMcKpxFWUesyWYihzM5FvQiJsDwGcCtKeOy2lsWhkVw0V0Byqb1d+wU6myU1mribBtsIcub23HS4kWA==
+karma-sauce-launcher@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.npmjs.org/karma-sauce-launcher/-/karma-sauce-launcher-1.2.0.tgz#6f2558ddef3cf56879fa27540c8ae9f8bfd16bca"
+  integrity sha512-lEhtGRGS+3Yw6JSx/vJY9iQyHNtTjcojrSwNzqNUOaDceKDu9dPZqA/kr69bUO9G2T6GKbu8AZgXqy94qo31Jg==
   dependencies:
-    sauce-connect-launcher "^1.2.4"
-    saucelabs "^1.5.0"
-    selenium-webdriver "^4.0.0-alpha.1"
+    q "^1.5.0"
+    sauce-connect-launcher "^1.2.2"
+    saucelabs "^1.4.0"
+    wd "^1.4.0"
 
 karma-sourcemap-loader@0.3.7:
   version "0.3.7"
@@ -10948,7 +10956,7 @@ q@1.4.1:
   resolved "https://registry.npmjs.org/q/-/q-1.4.1.tgz#55705bcd93c5f3673530c2c2cbc0c2b3addc286e"
   integrity sha1-VXBbzZPF82c1MMLCy8DCs63cKG4=
 
-q@^1.4.1, q@^1.5.1:
+q@^1.4.1, q@^1.5.0, q@^1.5.1:
   version "1.5.1"
   resolved "https://registry.npmjs.org/q/-/q-1.5.1.tgz#7e32f75b41381291d04611f1bf14109ac00651d7"
   integrity sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=
@@ -11830,7 +11838,7 @@ safe-regex@^1.1.0:
   resolved "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
-sauce-connect-launcher@^1.2.2, sauce-connect-launcher@^1.2.4:
+sauce-connect-launcher@^1.2.2:
   version "1.2.4"
   resolved "https://registry.npmjs.org/sauce-connect-launcher/-/sauce-connect-launcher-1.2.4.tgz#8d38f85242a9fbede1b2303b559f7e20c5609a1c"
   integrity sha512-X2vfwulR6brUGiicXKxPm1GJ7dBEeP1II450Uv4bHGrcGOapZNgzJvn9aioea5IC5BPp/7qjKdE3xbbTBIVXMA==
@@ -11841,7 +11849,7 @@ sauce-connect-launcher@^1.2.2, sauce-connect-launcher@^1.2.4:
     lodash "^4.16.6"
     rimraf "^2.5.4"
 
-saucelabs@^1.5.0:
+saucelabs@^1.4.0, saucelabs@^1.5.0:
   version "1.5.0"
   resolved "https://registry.npmjs.org/saucelabs/-/saucelabs-1.5.0.tgz#9405a73c360d449b232839919a86c396d379fd9d"
   integrity sha512-jlX3FGdWvYf4Q3LFfFWS1QvPg3IGCGWxIc8QBFdPTbpTJnt/v17FHXYVAn7C8sHf1yUXo2c7yIM0isDryfYtHQ==
@@ -11897,16 +11905,6 @@ selenium-webdriver@3.6.0, selenium-webdriver@^3.0.1:
   version "3.6.0"
   resolved "https://registry.npmjs.org/selenium-webdriver/-/selenium-webdriver-3.6.0.tgz#2ba87a1662c020b8988c981ae62cb2a01298eafc"
   integrity sha512-WH7Aldse+2P5bbFBO4Gle/nuQOdVwpHMTL6raL3uuBj/vPG07k6uzt3aiahu352ONBr5xXh0hDlM3LhtXPOC4Q==
-  dependencies:
-    jszip "^3.1.3"
-    rimraf "^2.5.4"
-    tmp "0.0.30"
-    xml2js "^0.4.17"
-
-selenium-webdriver@^4.0.0-alpha.1:
-  version "4.0.0-alpha.1"
-  resolved "https://registry.npmjs.org/selenium-webdriver/-/selenium-webdriver-4.0.0-alpha.1.tgz#cc93415e21d2dc1dfd85dfc5f6b55f3ac53933b1"
-  integrity sha512-z88rdjHAv3jmTZ7KSGUkTvo4rGzcDGMq0oXWHNIDK96Gs31JKVdu9+FMtT4KBrVoibg8dUicJDok6GnqqttO5Q==
   dependencies:
     jszip "^3.1.3"
     rimraf "^2.5.4"
@@ -13757,6 +13755,11 @@ value-or-function@^3.0.0:
   resolved "https://registry.npmjs.org/value-or-function/-/value-or-function-3.0.0.tgz#1c243a50b595c1be54a754bfece8563b9ff8d813"
   integrity sha1-HCQ6ULWVwb5Up1S/7OhWO5/42BM=
 
+vargs@0.1.0:
+  version "0.1.0"
+  resolved "https://registry.npmjs.org/vargs/-/vargs-0.1.0.tgz#6b6184da6520cc3204ce1b407cac26d92609ebff"
+  integrity sha1-a2GE2mUgzDIEzhtAfKwm2SYJ6/8=
+
 vary@^1, vary@~1.1.2:
   version "1.1.2"
   resolved "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
@@ -13866,6 +13869,19 @@ wcwidth@^1.0.0, wcwidth@^1.0.1:
   integrity sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=
   dependencies:
     defaults "^1.0.3"
+
+wd@^1.4.0:
+  version "1.11.1"
+  resolved "https://registry.npmjs.org/wd/-/wd-1.11.1.tgz#21a33e21977ad20522bb189f6529c3b55ac3862c"
+  integrity sha512-XNK6EbOrXF7cG8f3pbps6mb/+xPGZH2r1AL1zGJluGynA/Xt6ip1Tvqj2AkavyDFworreaGXoe+0AP/r7EX9pg==
+  dependencies:
+    archiver "2.1.1"
+    async "2.0.1"
+    lodash "4.17.11"
+    mkdirp "^0.5.1"
+    q "1.4.1"
+    request "2.88.0"
+    vargs "0.1.0"
 
 webdriver-js-extender@2.1.0:
   version "2.1.0"


### PR DESCRIPTION
The latest karma-sauce-launcher requires node > 8.9.0 which is restricter than the current > 8.0.0 requirement. Instead of further restricting developers with regards to the node version, I'm downgrading it and excluding it from the dependency auto updates.