### PR TITLE
Expose toJSON and fromJSON on AuthCredential

### DIFF
--- a/packages/auth-types/index.d.ts
+++ b/packages/auth-types/index.d.ts
@@ -248,7 +248,8 @@ export interface UserMetadata {
 
 export type Persistence = string;
 
-export abstract class OAuthCredential extends AuthCredential {
+export class OAuthCredential extends AuthCredential {
+  private constructor();
   idToken?: string;
   accessToken?: string;
   secret?: string;

--- a/packages/auth-types/index.d.ts
+++ b/packages/auth-types/index.d.ts
@@ -104,7 +104,7 @@ export interface ApplicationVerifier {
   verify(): Promise<string>;
 }
 
-export class AuthCredential {
+export abstract class AuthCredential {
   providerId: string;
   signInMethod: string;
   toJSON(): Object;
@@ -183,16 +183,10 @@ export interface IdTokenResult {
   };
 }
 
-export interface OAuthProviderOptions {
-  idToken?: string;
-  accessToken?: string;
-  rawNonce?: string;
-}
-
 export class OAuthProvider implements AuthProvider {
   providerId: string;
   addScope(scope: string): AuthProvider;
-  credential(options: OAuthProviderOptions): OAuthCredential;
+  credential(idToken?: string, accessToken?: string): OAuthCredential;
   setCustomParameters(customOAuthParameters: Object): AuthProvider;
 }
 
@@ -254,7 +248,7 @@ export interface UserMetadata {
 
 export type Persistence = string;
 
-export class OAuthCredential extends AuthCredential {
+export abstract class OAuthCredential extends AuthCredential {
   idToken?: string;
   accessToken?: string;
   secret?: string;

--- a/packages/auth-types/index.d.ts
+++ b/packages/auth-types/index.d.ts
@@ -104,9 +104,11 @@ export interface ApplicationVerifier {
   verify(): Promise<string>;
 }
 
-export interface AuthCredential {
+export class AuthCredential {
   providerId: string;
   signInMethod: string;
+  toJSON(): Object;
+  static fromJSON(json: Object | string): AuthCredential | null;
 }
 
 export interface AuthProvider {
@@ -181,10 +183,16 @@ export interface IdTokenResult {
   };
 }
 
+export interface OAuthProviderOptions {
+  idToken?: string;
+  accessToken?: string;
+  rawNonce?: string;
+}
+
 export class OAuthProvider implements AuthProvider {
   providerId: string;
   addScope(scope: string): AuthProvider;
-  credential(idToken?: string, accessToken?: string): OAuthCredential;
+  credential(options: OAuthProviderOptions): OAuthCredential;
   setCustomParameters(customOAuthParameters: Object): AuthProvider;
 }
 
@@ -246,7 +254,7 @@ export interface UserMetadata {
 
 export type Persistence = string;
 
-export interface OAuthCredential extends AuthCredential {
+export class OAuthCredential extends AuthCredential {
   idToken?: string;
   accessToken?: string;
   secret?: string;

--- a/packages/auth/src/exports_auth.js
+++ b/packages/auth/src/exports_auth.js
@@ -18,20 +18,25 @@
 goog.provide('fireauth.exports');
 
 goog.require('fireauth.Auth');
+goog.require('fireauth.AuthCredential');
 goog.require('fireauth.AuthError');
 goog.require('fireauth.AuthErrorWithCredential');
 goog.require('fireauth.AuthSettings');
 goog.require('fireauth.AuthUser');
 goog.require('fireauth.ConfirmationResult');
+goog.require('fireauth.EmailAuthCredential');
 goog.require('fireauth.EmailAuthProvider');
 goog.require('fireauth.FacebookAuthProvider');
 goog.require('fireauth.GRecaptchaMockFactory');
 goog.require('fireauth.GithubAuthProvider');
 goog.require('fireauth.GoogleAuthProvider');
 goog.require('fireauth.InvalidOriginError');
+goog.require('fireauth.OAuthCredential');
 goog.require('fireauth.OAuthProvider');
+goog.require('fireauth.PhoneAuthCredential');
 goog.require('fireauth.PhoneAuthProvider');
 goog.require('fireauth.RecaptchaVerifier');
+goog.require('fireauth.SAMLAuthCredential');
 goog.require('fireauth.SAMLAuthProvider');
 goog.require('fireauth.TwitterAuthProvider');
 goog.require('fireauth.args');
@@ -397,11 +402,28 @@ fireauth.exportlib.exportPrototypeMethods(
     });
 
 fireauth.exportlib.exportFunction(
+    fireauth.AuthCredential, 'fromJSON',
+    fireauth.AuthCredential.fromPlainObject, [
+      fireauth.args.or(fireauth.args.string(), fireauth.args.object(), 'json')
+    ]);
+
+fireauth.exportlib.exportFunction(
     fireauth.EmailAuthProvider, 'credential',
     fireauth.EmailAuthProvider.credential, [
       fireauth.args.string('email'),
       fireauth.args.string('password')
     ]);
+
+fireauth.exportlib.exportPrototypeMethods(
+    fireauth.EmailAuthCredential.prototype, {
+     toPlainObject: {
+        name: 'toJSON',
+        // This shouldn't take an argument but a blank string is being passed
+        // on JSON.stringify and causing this to fail with an argument error.
+        // So allow an optional string.
+        args: [fireauth.args.string(null, true)]
+      }
+    });
 
 fireauth.exportlib.exportPrototypeMethods(
     fireauth.FacebookAuthProvider.prototype, {
@@ -489,12 +511,12 @@ fireauth.exportlib.exportPrototypeMethods(
       credential: {
         name: 'credential',
         args: [
+          fireauth.args.or(
+              fireauth.args.string(),
+              fireauth.args.or(fireauth.args.object(), fireauth.args.null()),
+              'optionsOrIdToken'),
           fireauth.args.or(fireauth.args.string(), fireauth.args.null(),
-              'idToken', true),
-          fireauth.args.or(fireauth.args.string(), fireauth.args.null(),
-              'accessToken', true),
-          fireauth.args.or(fireauth.args.string(), fireauth.args.null(),
-              'nonce', true)
+              'accessToken', true)
         ]
       },
       setCustomParameters: {
@@ -502,6 +524,29 @@ fireauth.exportlib.exportPrototypeMethods(
         args: [fireauth.args.object('customOAuthParameters')]
       }
     });
+
+fireauth.exportlib.exportPrototypeMethods(
+    fireauth.OAuthCredential.prototype, {
+     toPlainObject: {
+        name: 'toJSON',
+        // This shouldn't take an argument but a blank string is being passed
+        // on JSON.stringify and causing this to fail with an argument error.
+        // So allow an optional string.
+        args: [fireauth.args.string(null, true)]
+      }
+    });
+
+fireauth.exportlib.exportPrototypeMethods(
+    fireauth.SAMLAuthCredential.prototype, {
+     toPlainObject: {
+        name: 'toJSON',
+        // This shouldn't take an argument but a blank string is being passed
+        // on JSON.stringify and causing this to fail with an argument error.
+        // So allow an optional string.
+        args: [fireauth.args.string(null, true)]
+      }
+    });
+
 fireauth.exportlib.exportFunction(
     fireauth.PhoneAuthProvider, 'credential',
     fireauth.PhoneAuthProvider.credential, [
@@ -516,6 +561,17 @@ fireauth.exportlib.exportPrototypeMethods(
           fireauth.args.string('phoneNumber'),
           fireauth.args.applicationVerifier()
         ]
+      }
+    });
+
+fireauth.exportlib.exportPrototypeMethods(
+    fireauth.PhoneAuthCredential.prototype, {
+     toPlainObject: {
+        name: 'toJSON',
+        // This shouldn't take an argument but a blank string is being passed
+        // on JSON.stringify and causing this to fail with an argument error.
+        // So allow an optional string.
+        args: [fireauth.args.string(null, true)]
       }
     });
 
@@ -592,6 +648,7 @@ fireauth.exportlib.exportPrototypeMethods(
 
     var namespace = {
       'Auth': fireauth.Auth,
+      'AuthCredential': fireauth.AuthCredential,
       'Error': fireauth.AuthError
     };
     fireauth.exportlib.exportFunction(namespace,

--- a/packages/auth/test/rpchandler_test.js
+++ b/packages/auth/test/rpchandler_test.js
@@ -3599,8 +3599,10 @@ function testVerifyAssertion_needConfirmationError_oauthResponseAndEmail() {
  */
 function testVerifyAssertion_needConfirmationError_nonceIdToken() {
   // Expected error thrown with OIDC credential containing nonce.
-  var credential = new fireauth.OAuthProvider('oidc.provider').credential(
-      'OIDC_ID_TOKEN', null, 'NONCE');
+  var credential = new fireauth.OAuthProvider('oidc.provider').credential({
+    'idToken': 'OIDC_ID_TOKEN',
+    'rawNonce': 'NONCE'
+  });
   var expectedError = new fireauth.AuthErrorWithCredential(
       fireauth.authenum.Error.NEED_CONFIRMATION,
       {
@@ -3645,8 +3647,10 @@ function testVerifyAssertion_needConfirmationError_nonceIdToken() {
  */
 function testVerifyAssertion_needConfirmationError_idTokenSessionId() {
   // Expected error thrown with OIDC credential containing nonce.
-  var credential = new fireauth.OAuthProvider('oidc.provider').credential(
-      'OIDC_ID_TOKEN', null, 'NONCE');
+  var credential = new fireauth.OAuthProvider('oidc.provider').credential({
+    'idToken': 'OIDC_ID_TOKEN',
+    'rawNonce': 'NONCE'
+  });
   var expectedError = new fireauth.AuthErrorWithCredential(
       fireauth.authenum.Error.NEED_CONFIRMATION,
       {
@@ -3879,8 +3883,10 @@ function testVerifyAssertion_credAlreadyInUseError_oauthResponseAndEmail() {
  */
 function testVerifyAssertion_credAlreadyInUseError_nonceIdToken() {
   // Expected error thrown with OIDC credential containing nonce.
-  var credential = new fireauth.OAuthProvider('oidc.provider').credential(
-      'OIDC_ID_TOKEN', null, 'NONCE');
+  var credential = new fireauth.OAuthProvider('oidc.provider').credential({
+    'idToken': 'OIDC_ID_TOKEN',
+    'rawNonce': 'NONCE'
+  });
   // Credential already in use error returned.
   var expectedError = new fireauth.AuthErrorWithCredential(
       fireauth.authenum.Error.CREDENTIAL_ALREADY_IN_USE,
@@ -3928,8 +3934,10 @@ function testVerifyAssertion_credAlreadyInUseError_nonceIdToken() {
  */
 function testVerifyAssertion_credAlreadyInUseError_idTokenSessionId() {
   // Expected error thrown with OIDC credential containing nonce.
-  var credential = new fireauth.OAuthProvider('oidc.provider').credential(
-      'OIDC_ID_TOKEN', null, 'NONCE');
+  var credential = new fireauth.OAuthProvider('oidc.provider').credential({
+    'idToken': 'OIDC_ID_TOKEN',
+    'rawNonce': 'NONCE'
+  });
   // Credential already in use error returned.
   var expectedError = new fireauth.AuthErrorWithCredential(
       fireauth.authenum.Error.CREDENTIAL_ALREADY_IN_USE,
@@ -4082,8 +4090,10 @@ function testVerifyAssertion_emailExistsError_oauthResponseAndEmail() {
  */
 function testVerifyAssertion_emailExistsError_nonceIdToken() {
   // Expected error thrown with OIDC credential containing nonce.
-  var credential = new fireauth.OAuthProvider('oidc.provider').credential(
-      'OIDC_ID_TOKEN', null, 'NONCE');
+  var credential = new fireauth.OAuthProvider('oidc.provider').credential({
+    'idToken': 'OIDC_ID_TOKEN',
+    'rawNonce': 'NONCE'
+  });
   // Credential already in use error returned.
   var expectedError = new fireauth.AuthErrorWithCredential(
       fireauth.authenum.Error.EMAIL_EXISTS,
@@ -4131,8 +4141,10 @@ function testVerifyAssertion_emailExistsError_nonceIdToken() {
  */
 function testVerifyAssertion_emailExistsError_idTokenSessionId() {
   // Expected error thrown with OIDC credential containing nonce.
-  var credential = new fireauth.OAuthProvider('oidc.provider').credential(
-      'OIDC_ID_TOKEN', null, 'NONCE');
+  var credential = new fireauth.OAuthProvider('oidc.provider').credential({
+    'idToken': 'OIDC_ID_TOKEN',
+    'rawNonce': 'NONCE'
+  });
   // Credential already in use error returned.
   var expectedError = new fireauth.AuthErrorWithCredential(
       fireauth.authenum.Error.EMAIL_EXISTS,

--- a/packages/firebase/index.d.ts
+++ b/packages/firebase/index.d.ts
@@ -2680,7 +2680,7 @@ declare namespace firebase.auth {
    * requirements.
    *
    */
-  interface AuthCredential {
+  class AuthCredential {
     /**
      * The authentication provider ID for the credential.
      * For example, 'facebook.com', or 'google.com'.
@@ -2693,6 +2693,21 @@ declare namespace firebase.auth {
      * {@link firebase.auth.Auth.fetchSignInMethodsForEmail}.
      */
     signInMethod: string;
+    /**
+     * Returns a JSON-serializable representation of this object.
+     */
+    toJSON(): Object;
+    /**
+     * Static method to deserialize a JSON representation of an object into an 
+     * {@link firebase.auth.AuthCredential}. Input can be either Object or the 
+     * stringified representation of the object. When string is provided, 
+     * JSON.parse would be called first.
+     * @param {!Object|string} json The plain object representation of an
+     *     AuthCredential.
+     */
+    static fromJSON(
+      json: Object | string
+    ): AuthCredential | null;
   }
 
   /**
@@ -2701,7 +2716,7 @@ declare namespace firebase.auth {
    * credential requirements.
    *
    */
-  interface OAuthCredential extends AuthCredential {
+  class OAuthCredential extends AuthCredential {
     /**
      * The OAuth ID token associated with the credential if it belongs to an
      * OIDC provider, such as `google.com`.
@@ -3176,6 +3191,26 @@ declare namespace firebase.auth {
   }
 
   /**
+   * Interface representing the options for initializing an
+   * {@link firebase.auth.OAuthCredential}. For OIDC ID tokens with nonce claim, the
+   * raw nonce has to also be provided.
+   */
+  interface OAuthProviderOptions {
+    /**
+     * The OAuth ID token.
+     */
+    idToken?: string;
+    /**
+     * The OAuth access token.
+     */
+    accessToken?: string;
+    /**
+     * The OIDC raw nonce.
+     */
+    rawNonce?: string;
+  }
+
+  /**
    * Generic OAuth provider.
    *
    * @example
@@ -3228,17 +3263,16 @@ declare namespace firebase.auth {
      * // `googleUser` from the onsuccess Google Sign In callback.
      * // Initialize a generate OAuth provider with a `google.com` providerId.
      * var provider = new firebase.auth.OAuthProvider('google.com');
-     * var credential = provider.credential(
-     *     googleUser.getAuthResponse().id_token);
+     * var credential = provider.credential({
+     *     'idToken': googleUser.getAuthResponse().id_token});
      * firebase.auth().signInWithCredential(credential)
      * ```
      *
-     * @param {?string=} idToken The OAuth ID token if OIDC compliant.
-     * @param {?string=} accessToken The OAuth access token.
+     * @param {!firebase.auth.OAuthProviderOptions} options The options object 
+     *     containing the ID token, access token and raw nonce
      */
     credential(
-      idToken?: string,
-      accessToken?: string
+      options: OAuthProviderOptions
     ): firebase.auth.OAuthCredential;
     /**
      * Sets the OAuth custom parameters to pass in an OAuth request for popup

--- a/packages/firebase/index.d.ts
+++ b/packages/firebase/index.d.ts
@@ -2660,7 +2660,8 @@ declare namespace firebase.auth {
      * Static method to deserialize a JSON representation of an object into an
      * {@link firebase.auth.AuthCredential}. Input can be either Object or the
      * stringified representation of the object. When string is provided,
-     * JSON.parse would be called first.
+     * JSON.parse would be called first. If the JSON input does not represent 
+     * an`AuthCredential`, null is returned.
      * @param {!Object|string} json The plain object representation of an
      *     AuthCredential.
      */
@@ -2673,7 +2674,8 @@ declare namespace firebase.auth {
    * credential requirements.
    *
    */
-  abstract class OAuthCredential extends AuthCredential {
+  class OAuthCredential extends AuthCredential {
+    private constructor();
     /**
      * The OAuth ID token associated with the credential if it belongs to an
      * OIDC provider, such as `google.com`.

--- a/packages/firebase/index.d.ts
+++ b/packages/firebase/index.d.ts
@@ -2660,7 +2660,7 @@ declare namespace firebase.auth {
      * Static method to deserialize a JSON representation of an object into an
      * {@link firebase.auth.AuthCredential}. Input can be either Object or the
      * stringified representation of the object. When string is provided,
-     * JSON.parse would be called first. If the JSON input does not represent 
+     * JSON.parse would be called first. If the JSON input does not represent
      * an`AuthCredential`, null is returned.
      * @param {!Object|string} json The plain object representation of an
      *     AuthCredential.
@@ -7224,14 +7224,14 @@ declare namespace firebase.firestore {
     /**
      * Returns a special value that can be used with `set()` or `update()` that tells
      * the server to increment the field's current value by the given value.
-     * 
+     *
      * If either the operand or the current field value uses floating point precision,
      * all arithmetic follows IEEE 754 semantics. If both values are integers,
      * values outside of JavaScript's safe number range (`Number.MIN_SAFE_INTEGER` to
      * `Number.MAX_SAFE_INTEGER`) are also subject to precision loss. Furthermore,
      * once processed by the Firestore backend, all integer operations are capped
      * between -2^63 and 2^63-1.
-     * 
+     *
      * If the current field value is not of type `number`, or if the field does not
      * yet exist, the transformation sets the field to the given value.
      *

--- a/packages/firebase/index.d.ts
+++ b/packages/firebase/index.d.ts
@@ -2680,7 +2680,7 @@ declare namespace firebase.auth {
    * requirements.
    *
    */
-  class AuthCredential {
+  abstract class AuthCredential {
     /**
      * The authentication provider ID for the credential.
      * For example, 'facebook.com', or 'google.com'.
@@ -2698,16 +2698,14 @@ declare namespace firebase.auth {
      */
     toJSON(): Object;
     /**
-     * Static method to deserialize a JSON representation of an object into an 
-     * {@link firebase.auth.AuthCredential}. Input can be either Object or the 
-     * stringified representation of the object. When string is provided, 
+     * Static method to deserialize a JSON representation of an object into an
+     * {@link firebase.auth.AuthCredential}. Input can be either Object or the
+     * stringified representation of the object. When string is provided,
      * JSON.parse would be called first.
      * @param {!Object|string} json The plain object representation of an
      *     AuthCredential.
      */
-    static fromJSON(
-      json: Object | string
-    ): AuthCredential | null;
+    static fromJSON(json: Object | string): AuthCredential | null;
   }
 
   /**
@@ -2716,7 +2714,7 @@ declare namespace firebase.auth {
    * credential requirements.
    *
    */
-  class OAuthCredential extends AuthCredential {
+  abstract class OAuthCredential extends AuthCredential {
     /**
      * The OAuth ID token associated with the credential if it belongs to an
      * OIDC provider, such as `google.com`.
@@ -3191,26 +3189,6 @@ declare namespace firebase.auth {
   }
 
   /**
-   * Interface representing the options for initializing an
-   * {@link firebase.auth.OAuthCredential}. For OIDC ID tokens with nonce claim, the
-   * raw nonce has to also be provided.
-   */
-  interface OAuthProviderOptions {
-    /**
-     * The OAuth ID token.
-     */
-    idToken?: string;
-    /**
-     * The OAuth access token.
-     */
-    accessToken?: string;
-    /**
-     * The OIDC raw nonce.
-     */
-    rawNonce?: string;
-  }
-
-  /**
    * Generic OAuth provider.
    *
    * @example
@@ -3263,16 +3241,17 @@ declare namespace firebase.auth {
      * // `googleUser` from the onsuccess Google Sign In callback.
      * // Initialize a generate OAuth provider with a `google.com` providerId.
      * var provider = new firebase.auth.OAuthProvider('google.com');
-     * var credential = provider.credential({
-     *     'idToken': googleUser.getAuthResponse().id_token});
+     * var credential = provider.credential(
+     *     googleUser.getAuthResponse().id_token);
      * firebase.auth().signInWithCredential(credential)
      * ```
      *
-     * @param {!firebase.auth.OAuthProviderOptions} options The options object 
-     *     containing the ID token, access token and raw nonce
+     * @param {?string=} idToken The OAuth ID token if OIDC compliant.
+     * @param {?string=} accessToken The OAuth access token.
      */
     credential(
-      options: OAuthProviderOptions
+      idToken?: string,
+      accessToken?: string
     ): firebase.auth.OAuthCredential;
     /**
      * Sets the OAuth custom parameters to pass in an OAuth request for popup


### PR DESCRIPTION
- Exposed toJSON and fromJSON on AuthCredential.
- Changed AuthCredential from interface to abstract class as fromJSON is a static method.
- Changed the OAuthCredential constructor to take a OAuthProviderOptions object, but not expose the API to public. The constructor change is backward compatible as it still can take idToken and accessToken string.  