### PR TITLE
b/66181677: WebChannel: Disable log redaction for potential performance improvement.

### DIFF
--- a/packages/firestore/src/platform_browser/webchannel_connection.ts
+++ b/packages/firestore/src/platform_browser/webchannel_connection.ts
@@ -217,7 +217,11 @@ export class WebChannelConnection implements Connection {
         // set it very large (5-10 minutes) and rely on the browser's builtin
         // timeouts to kick in if the request isn't working.
         forwardChannelRequestTimeoutMs: 10 * 60 * 1000
-      }
+      },
+      // Disables redaction of potentially customer-sensitive information from
+      // webchannel log messages. Since we don't enable logging, this is
+      // unnecessary and so we want to avoid the performance hit.
+      disableRedact: true
     };
 
     this.modifyHeadersForRequest(request.initMessageHeaders, token);

--- a/packages/webchannel-wrapper/externs/overrides.js
+++ b/packages/webchannel-wrapper/externs/overrides.js
@@ -65,3 +65,6 @@ goog.net.WebChannel.Options.fastHandshake;
 
 /** @type {!Object<string, boolean|number>|undefined} */
 goog.net.WebChannel.Options.internalChannelParams;
+
+/** @type {boolean|undefined} */
+goog.net.WebChannel.Options.disableReact;


### PR DESCRIPTION
See https://github.com/google/closure-library/blob/7d6ec4f903cefed13f0b53c6815f7ec62213b4f1/closure/goog/labs/net/webchannel.js#L168 for context.