### PR TITLE
Fix bug causing extra Node doc files to not be deleted

### DIFF
--- a/scripts/docgen/generate-docs.js
+++ b/scripts/docgen/generate-docs.js
@@ -182,8 +182,8 @@ function checkForUnlistedFiles(filenamesFromToc, shouldRemove) {
         filename !== 'globals'
       ) {
         if (shouldRemove) {
-          console.log(`REMOVING ${filename} - not listed in toc.yaml.`);
-          removePromises.push(() => fs.unlink(`${docPath}/${filename}`));
+          console.log(`REMOVING ${docPath}/${filename}.html - not listed in toc.yaml.`);
+          removePromises.push(fs.unlink(`${docPath}/${filename}.html`));
         } else {
           // This is just a warning, it doesn't need to finish before
           // the process continues.
@@ -195,7 +195,8 @@ function checkForUnlistedFiles(filenamesFromToc, shouldRemove) {
       }
     });
     if (shouldRemove) {
-      return Promise.all(removePromises).then(() => htmlFiles);
+      return Promise.all(removePromises)
+        .then(() => htmlFiles.filter(filename => filenamesFromToc.includes(filename)));
     } else {
       return htmlFiles;
     }

--- a/scripts/docgen/generate-docs.js
+++ b/scripts/docgen/generate-docs.js
@@ -182,7 +182,9 @@ function checkForUnlistedFiles(filenamesFromToc, shouldRemove) {
         filename !== 'globals'
       ) {
         if (shouldRemove) {
-          console.log(`REMOVING ${docPath}/${filename}.html - not listed in toc.yaml.`);
+          console.log(
+            `REMOVING ${docPath}/${filename}.html - not listed in toc.yaml.`
+          );
           removePromises.push(fs.unlink(`${docPath}/${filename}.html`));
         } else {
           // This is just a warning, it doesn't need to finish before
@@ -195,8 +197,9 @@ function checkForUnlistedFiles(filenamesFromToc, shouldRemove) {
       }
     });
     if (shouldRemove) {
-      return Promise.all(removePromises)
-        .then(() => htmlFiles.filter(filename => filenamesFromToc.includes(filename)));
+      return Promise.all(removePromises).then(() =>
+        htmlFiles.filter(filename => filenamesFromToc.includes(filename))
+      );
     } else {
       return htmlFiles;
     }


### PR DESCRIPTION
There was an error in the doc generation script where extraneous files generated in the Node doc process weren't getting deleted.  Missing an html extension and not invoking the unlink function.