### PR TITLE
Make default testing project easier to select

### DIFF
--- a/tools/config.js
+++ b/tools/config.js
@@ -58,8 +58,9 @@ Promise.resolve(userToken || cachedToken)
           name: 'projectId',
           message: 'Which project would you like to use to test?',
           choices: projects
-            .sort(project => 
-              project.name.toLowerCase().includes('jscore') ? -1 : 1)
+            .sort(project =>
+              project.name.toLowerCase().includes('jscore') ? -1 : 1
+            )
             .map(project => ({
               name: `${project.name} (${project.id})`,
               value: project

--- a/tools/config.js
+++ b/tools/config.js
@@ -57,10 +57,13 @@ Promise.resolve(userToken || cachedToken)
           type: 'list',
           name: 'projectId',
           message: 'Which project would you like to use to test?',
-          choices: projects.map(project => ({
-            name: `${project.name} (${project.id})`,
-            value: project
-          }))
+          choices: projects
+            .sort(project => 
+              project.name.toLowerCase().includes('jscore') ? -1 : 1)
+            .map(project => ({
+              name: `${project.name} (${project.id})`,
+              value: project
+            }))
         }
       ]);
 


### PR DESCRIPTION
This will put projects with "jscore" in the name at the top of the selection list when the release script prompts which project to test with.  All other projects are still included in the same order as before.