### PR TITLE
Add license tags for new files since last license tag add

### DIFF
--- a/packages/firestore/index.console.ts
+++ b/packages/firestore/index.console.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2019 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/local/index_manager.ts
+++ b/packages/firestore/src/local/index_manager.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2019 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/local/indexeddb_index_manager.ts
+++ b/packages/firestore/src/local/indexeddb_index_manager.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2019 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/src/local/memory_index_manager.ts
+++ b/packages/firestore/src/local/memory_index_manager.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2019 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/integration/api/numeric_transforms.test.ts
+++ b/packages/firestore/test/integration/api/numeric_transforms.test.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/unit/local/index_manager.test.ts
+++ b/packages/firestore/test/unit/local/index_manager.test.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2019 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/unit/local/test_index_manager.ts
+++ b/packages/firestore/test/unit/local/test_index_manager.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2019 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/test/unit/specs/query_spec.test.ts
+++ b/packages/firestore/test/unit/specs/query_spec.test.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2019 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firestore/tools/console.build.js
+++ b/packages/firestore/tools/console.build.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2019 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
License tags are required for internal Google usage.