### PR TITLE
Improve AppError typings

### DIFF
--- a/packages/app/src/firebaseApp.ts
+++ b/packages/app/src/firebaseApp.ts
@@ -460,9 +460,7 @@ function error(code: AppError, args?: { [name: string]: any }) {
   throw appErrors.create(code, args);
 }
 
-// TypeScript does not support non-string indexes!
-// let errors: {[code: AppError: string} = {
-let errors: { [code: string]: string } = {
+const errors: { readonly [code in AppError]: string } = {
   'no-app':
     "No Firebase App '{$name}' has been created - " +
     'call Firebase App.initializeApp()',

--- a/packages/app/src/firebaseApp.ts
+++ b/packages/app/src/firebaseApp.ts
@@ -131,10 +131,12 @@ class FirebaseAppImpl implements FirebaseApp {
           })
         );
       })
-      .then((): void => {
-        this.isDeleted_ = true;
-        this.services_ = {};
-      });
+      .then(
+        (): void => {
+          this.isDeleted_ = true;
+          this.services_ = {};
+        }
+      );
   }
 
   /**


### PR DESCRIPTION
Randomly noticed this while looking into FirebaseError. This way TS will complain if the `errors` object is missing any `AppError` string, or contains a string that is not in `AppError`.

I'd still recommend using a `const enum` instead of a union type as `AppError` though.