### PR TITLE
Remove "noImplicitAny: false" from the base TSConfig

### DIFF
--- a/config/tsconfig.base.json
+++ b/config/tsconfig.base.json
@@ -9,7 +9,6 @@
     ],
     "module": "ES2015",
     "moduleResolution": "node",
-    "noImplicitAny": false,
     "sourceMap": true,
     "target": "es5",
     "typeRoots": [

--- a/packages/messaging/tsconfig.json
+++ b/packages/messaging/tsconfig.json
@@ -4,7 +4,6 @@
     "outDir": "dist",
     "strict": true,
     "noUnusedLocals": true,
-    "noImplicitAny": true,
     "lib": [
       "dom",
       "es2017"


### PR DESCRIPTION
This option is `false` by default, so there is no need to set it to `false` explicitly.

Also because of this, when a package enables the `strict` option, they also need to enable `noImplicitAny` explicitly, even though it is already a part of the `strict` option.