### PR TITLE
 Add explicit type parameters for typescript 3.4

### DIFF
--- a/packages/firestore/src/local/lru_garbage_collector.ts
+++ b/packages/firestore/src/local/lru_garbage_collector.ts
@@ -433,7 +433,7 @@ export class LruGarbageCollector {
           log.debug('LruGarbageCollector', desc);
         }
 
-        return PersistencePromise.resolve({
+        return PersistencePromise.resolve<LruResults>({
           didRun: true,
           sequenceNumbersCollected: sequenceNumbersToCollect,
           targetsRemoved,

--- a/packages/firestore/src/local/persistence_promise.ts
+++ b/packages/firestore/src/local/persistence_promise.ts
@@ -207,7 +207,9 @@ export class PersistencePromise<T> {
   static or(
     predicates: Array<() => PersistencePromise<boolean>>
   ): PersistencePromise<boolean> {
-    let p: PersistencePromise<boolean> = PersistencePromise.resolve<boolean>(false);
+    let p: PersistencePromise<boolean> = PersistencePromise.resolve<boolean>(
+      false
+    );
     for (const predicate of predicates) {
       p = p.next(isTrue => {
         if (isTrue) {

--- a/packages/firestore/src/local/persistence_promise.ts
+++ b/packages/firestore/src/local/persistence_promise.ts
@@ -207,7 +207,7 @@ export class PersistencePromise<T> {
   static or(
     predicates: Array<() => PersistencePromise<boolean>>
   ): PersistencePromise<boolean> {
-    let p: PersistencePromise<boolean> = PersistencePromise.resolve(false);
+    let p: PersistencePromise<boolean> = PersistencePromise.resolve<boolean>(false);
     for (const predicate of predicates) {
       p = p.next(isTrue => {
         if (isTrue) {


### PR DESCRIPTION
Due to improved type inference in typescript 3.4, we need to provide explicit type parameters in the following cases, otherwise we will get an error - https://travis-ci.org/firebase/firebase-js-sdk/builds/514917024#L696

Typescript version will be updated in PR https://github.com/firebase/firebase-js-sdk/pull/1654.