### PR TITLE
update types

### DIFF
--- a/packages/firestore/src/local/indexeddb_persistence.ts
+++ b/packages/firestore/src/local/indexeddb_persistence.ts
@@ -1200,7 +1200,7 @@ export class IndexedDbLruDelegate implements ReferenceDelegate, LruDelegate {
     docKey: DocumentKey
   ): PersistencePromise<boolean> {
     if (this.inMemoryPins!.containsKey(docKey)) {
-      return PersistencePromise.resolve(true);
+      return PersistencePromise.resolve<boolean>(true);
     } else {
       return mutationQueuesContainKey(txn, docKey);
     }

--- a/packages/firestore/src/local/simple_db.ts
+++ b/packages/firestore/src/local/simple_db.ts
@@ -223,7 +223,7 @@ export class SimpleDb {
  */
 export class IterationController {
   private shouldStop = false;
-  private nextKey: IDBValidKey | IDBKeyRange | null = null;
+  private nextKey: IDBValidKey | null = null;
 
   constructor(private dbCursor: IDBCursorWithValue) {}
 
@@ -231,7 +231,7 @@ export class IterationController {
     return this.shouldStop;
   }
 
-  get skipToKey(): IDBValidKey | IDBKeyRange | null {
+  get skipToKey(): IDBValidKey | null {
     return this.nextKey;
   }
 
@@ -250,7 +250,7 @@ export class IterationController {
    * This function can be called to skip to that next key, which could be
    * an index or a primary key.
    */
-  skip(key: IDBValidKey | IDBKeyRange): void {
+  skip(key: IDBValidKey): void {
     this.nextKey = key;
   }
 


### PR DESCRIPTION
Continue https://github.com/firebase/firebase-js-sdk/pull/1656

IDBKeyRange is no longer a valid type for `IDBCursor.continue()` in typescript 3.4.0