### PR TITLE
Fix timeout object null checking

### DIFF
--- a/packages/database/src/core/util/util.ts
+++ b/packages/database/src/core/util/util.ts
@@ -667,7 +667,7 @@ export const setTimeoutNonBlocking = function(
   time: number
 ): number | Object {
   const timeout: number | Object = setTimeout(fn, time);
-  if (typeof timeout === 'object' && (timeout as any)['unref']) {
+  if (typeof timeout === 'object' && timeout !== null && (timeout as any)['unref']) {
     (timeout as any)['unref']();
   }
   return timeout;


### PR DESCRIPTION
Object check in `setTimeoutNonBlocking` function does not take into account that `typeof null === 'object'`.

I attached an example error stack trace below.

This PR will fix the issue by adding `null` check for `timeout`.

```
/project/node_modules/@firebase/database/dist/index.node.cjs.js:735
    if (typeof timeout === 'object' && timeout['unref']) {

TypeError: Cannot read property 'unref' of null
    at setTimeoutNonBlocking (/project/node_modules/@firebase/database/src/core/util/util.ts:670:54)
    at Connection.Object.<anonymous>.Connection.onConnectionEstablished_ (/project/node_modules/@firebase/database/src/realtime/Connection.ts:453:7)
    at Connection.Object.<anonymous>.Connection.onHandshake_ (/project/node_modules/@firebase/database/src/realtime/Connection.ts:383:12)
    at Connection.Object.<anonymous>.Connection.onControl_ (/project/node_modules/@firebase/database/src/realtime/Connection.ts:336:14)
    at Connection.Object.<anonymous>.Connection.onPrimaryMessageReceived_ (/project/node_modules/@firebase/database/src/realtime/Connection.ts:307:12)
    at WebSocketConnection.onMessage (/project/node_modules/@firebase/database/src/realtime/Connection.ts:205:16)
    at WebSocketConnection.Object.<anonymous>.WebSocketConnection.appendFrame_ (/project/node_modules/@firebase/database/src/realtime/WebSocketConnection.ts:276:12)
    at WebSocketConnection.Object.<anonymous>.WebSocketConnection.handleIncomingFrame (/project/node_modules/@firebase/database/src/realtime/WebSocketConnection.ts:329:14)
    at Client.mySock.onmessage (/project/node_modules/@firebase/database/src/realtime/WebSocketConnection.ts:196:12)
    at Client.dispatchEvent (/project/node_modules/faye-websocket/lib/faye/websocket/api/event_target.js:22:30)
    at Client._receiveMessage (/project/node_modules/faye-websocket/lib/faye/websocket/api.js:150:10)
    at Client.<anonymous> (/project/node_modules/faye-websocket/lib/faye/websocket/api.js:34:49)
    at emitOne (events.js:121:20)
    at Client.emit (events.js:211:7)
    at Client.<anonymous> (/project/node_modules/websocket-driver/lib/websocket/driver/hybi.js:454:14)
    at pipe (/project/node_modules/websocket-extensions/lib/pipeline/index.js:37:40)
    at Pipeline.Object.<anonymous>.Pipeline._loop (/project/node_modules/websocket-extensions/lib/pipeline/index.js:44:3)
    at Pipeline.Object.<anonymous>.Pipeline.processIncomingMessage (/project/node_modules/websocket-extensions/lib/pipeline/index.js:13:8)
    at Extensions.processIncomingMessage (/project/node_modules/websocket-extensions/lib/websocket_extensions.js:133:20)
    at Client._emitMessage (/project/node_modules/websocket-driver/lib/websocket/driver/hybi.js:445:22)
    at Client._emitFrame (/project/node_modules/websocket-driver/lib/websocket/driver/hybi.js:405:19)
    at Client.parse (/project/node_modules/websocket-driver/lib/websocket/driver/hybi.js:141:18)
```