### PR TITLE
Fix accidental reversion due to bad merge

### DIFF
--- a/packages/firebase/index.d.ts
+++ b/packages/firebase/index.d.ts
@@ -5721,7 +5721,10 @@ declare namespace firebase.storage {
      */
     on(
       event: firebase.storage.TaskEvent,
-      nextOrObserver?: firebase.Observer<any> | null | ((a: Object) => any),
+      nextOrObserver?:
+        | firebase.Observer<UploadTaskSnapshot>
+        | null
+        | ((a: UploadTaskSnapshot) => any),
       error?: ((a: Error) => any) | null,
       complete?: (firebase.Unsubscribe) | null
     ): Function;
@@ -7209,14 +7212,14 @@ declare namespace firebase.firestore {
     /**
      * Returns a special value that can be used with `set()` or `update()` that tells
      * the server to increment the field's current value by the given value.
-     * 
+     *
      * If either the operand or the current field value uses floating point precision,
      * all arithmetic follows IEEE 754 semantics. If both values are integers,
      * values outside of JavaScript's safe number range (`Number.MIN_SAFE_INTEGER` to
      * `Number.MAX_SAFE_INTEGER`) are also subject to precision loss. Furthermore,
      * once processed by the Firestore backend, all integer operations are capped
      * between -2^63 and 2^63-1.
-     * 
+     *
      * If the current field value is not of type `number`, or if the field does not
      * yet exist, the transformation sets the field to the given value.
      *


### PR DESCRIPTION
Lost a previous fix to `index.d.ts` during merging of changes for docs.