### PR TITLE
Use yarn install --frozen-lockfile in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,10 @@ env:
 before_install:
   # Yarn defaults to an old version, make sure we
   # get an up to date version
-  - npm install -g yarn@1.13.0
+  - npm install -g yarn@latest
   - '[ "${NPM_TOKEN+x}" ] && echo "//registry.npmjs.org/:_authToken=\${NPM_TOKEN}" > $HOME/.npmrc || echo "Skipping .npmrc creation";'
-
+install:
+  - yarn install --frozen-lockfile
 before_script:
   - cp config/ci.config.json config/project.json
   - yarn build

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,16 @@ env:
   global:
     - CXX=g++-4.8
 before_install:
-  # Yarn defaults to an old version, make sure we
-  # get an up to date version
+  # Yarn defaults to an old version, make sure we get an up to date version
   - npm install -g yarn@1.15.2
   - '[ "${NPM_TOKEN+x}" ] && echo "//registry.npmjs.org/:_authToken=\${NPM_TOKEN}" > $HOME/.npmrc || echo "Skipping .npmrc creation";'
 install:
+  # --frozen-lockfile doesn’t generate a yarn.lock lockfile and should fail if an update is needed.
+  # This will make sure that yarn.lock file in the PR is consistent with package.json.
+  #
+  # Due to a yarn issue (https://github.com/yarnpkg/yarn/issues/5840), --frozen-lockfile doesn't
+  # actually fail if an update is required, but integrity check from tools/pretest.js will catch
+  # the issue, so it still works as expected.
   - yarn install --frozen-lockfile
 before_script:
   - cp config/ci.config.json config/project.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ env:
 before_install:
   # Yarn defaults to an old version, make sure we
   # get an up to date version
-  - npm install -g yarn@latest
+  - npm install -g yarn@1.15.2
   - '[ "${NPM_TOKEN+x}" ] && echo "//registry.npmjs.org/:_authToken=\${NPM_TOKEN}" > $HOME/.npmrc || echo "Skipping .npmrc creation";'
 install:
   - yarn install --frozen-lockfile


### PR DESCRIPTION
From [yarn documentation](https://yarnpkg.com/lang/en/docs/cli/install/):

> yarn install --frozen-lockfile
> Don’t generate a yarn.lock lockfile and fail if an update is needed.

With this change, our CI build should fail during the install phase if the lock file wasn't updated properly. But it won't, because this [doesn't actually work](https://github.com/yarnpkg/yarn/issues/5840) :neutral_face:. I guess if they ever fix this bug, it will start working. And then we can remove the integrity check from `tools/pretest.js`.

Also changes the fixed yarn version to `latest`, so that we won't have to change it manually after new yarn releases.