### PR TITLE
Change a documentation link to match docs changes

### DIFF
--- a/packages/firebase/index.d.ts
+++ b/packages/firebase/index.d.ts
@@ -942,8 +942,8 @@ declare namespace firebase {
    *   https://firebase.google.com/docs/web/setup#add_firebase_to_your_app
    *   Add Firebase to your app} and
    * {@link
-   *   https://firebase.google.com/docs/web/setup#initialize_multiple_apps
-   *   Initialize multiple apps} for detailed documentation.
+   *   https://firebase.google.com/docs/web/setup#multiple-projects
+   *   Initialize multiple projects} for detailed documentation.
    *
    * @example
    * ```javascript


### PR DESCRIPTION
Docs team made some changes to where a link should go.