### PR TITLE
Add internal delete method to functions

### DIFF
--- a/packages/functions/src/api/service.ts
+++ b/packages/functions/src/api/service.ts
@@ -203,7 +203,7 @@ export class Service implements FirebaseFunctions, FirebaseService {
       this.cancelAllRequests
     ]);
 
-    // If service was deleted, interrupted response returns undefined.
+    // If service was deleted, interrupted response throws an error.
     if (!response) {
       throw new HttpsErrorImpl(
         'cancelled',

--- a/packages/functions/src/api/service.ts
+++ b/packages/functions/src/api/service.ts
@@ -74,7 +74,7 @@ export class Service implements FirebaseFunctions {
     this.cancelAllRequests = new Promise(resolve => {
       this.deleteService = () => {
         resolve();
-      }
+      };
     });
   }
 

--- a/packages/functions/src/api/service.ts
+++ b/packages/functions/src/api/service.ts
@@ -16,6 +16,7 @@
  */
 
 import { FirebaseApp } from '@firebase/app-types';
+import { FirebaseService } from '@firebase/app-types/private';
 import firebase from '@firebase/app';
 import {
   FirebaseFunctions,
@@ -53,7 +54,7 @@ function failAfter(millis: number): Promise<HttpResponse> {
 /**
  * The main class for the Firebase Functions SDK.
  */
-export class Service implements FirebaseFunctions {
+export class Service implements FirebaseFunctions, FirebaseService {
   private readonly contextProvider: ContextProvider;
   private readonly serializer = new Serializer();
   private emulatorOrigin: string | null = null;

--- a/packages/functions/src/api/service.ts
+++ b/packages/functions/src/api/service.ts
@@ -74,7 +74,7 @@ export class Service implements FirebaseFunctions, FirebaseService {
     // Cancels all ongoing requests when resolved.
     this.cancelAllRequests = new Promise(resolve => {
       this.deleteService = () => {
-        resolve();
+        return resolve();
       };
     });
   }
@@ -85,8 +85,7 @@ export class Service implements FirebaseFunctions, FirebaseService {
 
   INTERNAL = {
     delete: (): Promise<void> => {
-      this.deleteService();
-      return Promise.resolve();
+      return this.deleteService();
     }
   };
 
@@ -206,7 +205,10 @@ export class Service implements FirebaseFunctions, FirebaseService {
 
     // If service was deleted, interrupted response returns undefined.
     if (!response) {
-      return;
+      throw new HttpsErrorImpl(
+        'cancelled',
+        'Firebase Functions instance was deleted.'
+      );
     }
 
     // Check for an error status, regardless of http status.


### PR DESCRIPTION
The functions service lacks an `INTERNAL.delete()` method which I think is the cause of https://github.com/firebase/firebase-js-sdk/issues/1683. This adds a delete method which resolves a top-level promise on the service instance which should cancel any ongoing request promises.