### PR TITLE
Fix test:node:persistence command and make travis run it.

### DIFF
--- a/packages/firestore/package.json
+++ b/packages/firestore/package.json
@@ -11,7 +11,7 @@
     "lint:fix": "tslint --fix -p tsconfig.json -c tslint.json 'src/**/*.ts' 'test/**/*.ts'",
     "prettier": "prettier --write 'src/**/*.js' 'test/**/*.js' 'src/**/*.ts' 'test/**/*.ts'",
     "test": "run-s lint test:all",
-    "test:all": "run-p test:browser test:node:persistence",
+    "test:all": "run-p test:browser test:node",
     "test:browser": "karma start --single-run",
     "test:browser:debug": "karma start --browsers=Chrome --auto-watch",
     "test:node": "TS_NODE_CACHE=NO TS_NODE_COMPILER_OPTIONS='{\"module\":\"commonjs\"}' nyc --reporter lcovonly -- mocha 'test/{,!(browser)/**/}*.test.ts' --file index.node.ts --opts ../../config/mocha.node.opts",

--- a/packages/firestore/package.json
+++ b/packages/firestore/package.json
@@ -11,11 +11,11 @@
     "lint:fix": "tslint --fix -p tsconfig.json -c tslint.json 'src/**/*.ts' 'test/**/*.ts'",
     "prettier": "prettier --write 'src/**/*.js' 'test/**/*.js' 'src/**/*.ts' 'test/**/*.ts'",
     "test": "run-s lint test:all",
-    "test:all": "run-p test:browser test:node",
+    "test:all": "run-p test:browser test:node:persistence",
     "test:browser": "karma start --single-run",
     "test:browser:debug": "karma start --browsers=Chrome --auto-watch",
     "test:node": "TS_NODE_CACHE=NO TS_NODE_COMPILER_OPTIONS='{\"module\":\"commonjs\"}' nyc --reporter lcovonly -- mocha 'test/{,!(browser)/**/}*.test.ts' --file index.node.ts --opts ../../config/mocha.node.opts",
-    "test:node:persistence": "USE_MOCK_PERSISTENCE=YES TS_NODE_CACHE=NO TS_NODE_COMPILER_OPTIONS='{\"module\":\"commonjs\"}' nyc --reporter lcovonly -- mocha 'test/{,!(browser)/**/}*.test.ts' --file index.node.ts --require test/util/node_persistence.ts --opts ../../config/mocha.node.opts",
+    "test:node:persistence": "USE_MOCK_PERSISTENCE=YES TS_NODE_CACHE=NO TS_NODE_COMPILER_OPTIONS='{\"module\":\"commonjs\"}' nyc --reporter lcovonly -- mocha 'test/{,!(browser)/**/}*.test.ts' --require ts-node/register --file index.node.ts --require test/util/node_persistence.ts --opts ../../config/mocha.node.opts",
     "test:emulator": "ts-node ../../scripts/emulator-testing/firestore-test-runner.ts",
     "prepare": "npm run build"
   },


### PR DESCRIPTION
Since our code is TypeScript we use `--require ts-node/register` for mocha to
be able to run our code. We have this require in our global
`../../config/mocha.node.opts` file, but it apparently isn't applied before the
`--require test/util/node_persistence.ts` in our test:node:persistence
command-line. So I've had to add an explicit `--require ts-node/register` to
our command-line.
