### PR TITLE
Use `--concurrency 4` instead of `--parallel` for tests.

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "repl": "node tools/repl.js",
     "release": "node scripts/release/cli.js",
     "pretest": "node tools/pretest.js",
-    "test": "lerna run --parallel --stream test",
+    "test": "lerna run --concurrency 4 --stream test",
     "pretest:coverage": "mkdirp coverage",
     "test:coverage": "lcov-result-merger 'packages/**/lcov.info' | coveralls",
     "test:setup": "node tools/config.js",


### PR DESCRIPTION
I'm hoping this makes travis more reliable by limiting the amount of concurrency for our tests .

`--concurrency 4` was also slightly faster than `--parallel` on my local machine. Though any value above 1 was actually fairly comparable:

```
--parallel:      342.63s
--concurrency 1: 498.26s
--concurrency 2: 351.23s
--concurrency 3: 342.50s
--concurrency 4: 336.55s
--concurrency 5: 349.82s
--concurrency 6: 348.19s
--concurrency 7: 341.47s
--concurrency 8: 348.52s
```