### PR TITLE
Throw error in subsequent function calls after the client is shutdown

### DIFF
--- a/packages/firestore/src/api/database.ts
+++ b/packages/firestore/src/api/database.ts
@@ -495,6 +495,7 @@ export class Firestore implements firestore.FirebaseFirestore, FirebaseService {
     delete: async (options?: {
       purgePersistenceWithDataLoss?: boolean;
     }): Promise<void> => {
+      this.ensureClientConfigured();
       if (this._firestoreClient) {
         return this._firestoreClient.shutdown(options);
       }

--- a/packages/firestore/src/api/database.ts
+++ b/packages/firestore/src/api/database.ts
@@ -495,6 +495,8 @@ export class Firestore implements firestore.FirebaseFirestore, FirebaseService {
     delete: async (options?: {
       purgePersistenceWithDataLoss?: boolean;
     }): Promise<void> => {
+      // The client must be initalized to ensure that all subsequent API usage
+      // throws an exception.
       this.ensureClientConfigured();
       if (this._firestoreClient) {
         return this._firestoreClient.shutdown(options);

--- a/packages/firestore/src/api/database.ts
+++ b/packages/firestore/src/api/database.ts
@@ -498,9 +498,7 @@ export class Firestore implements firestore.FirebaseFirestore, FirebaseService {
       // The client must be initalized to ensure that all subsequent API usage
       // throws an exception.
       this.ensureClientConfigured();
-      if (this._firestoreClient) {
-        return this._firestoreClient.shutdown(options);
-      }
+      return this._firestoreClient!.shutdown(options);
     }
   };
 

--- a/packages/firestore/test/integration/api/database.test.ts
+++ b/packages/firestore/test/integration/api/database.test.ts
@@ -920,12 +920,12 @@ apiDescribe('Database', persistence => {
   });
 
   it('rejects subsequent method calls after shutdown() is called', async () => {
-    return withTestDbNoShutdown(persistence, db => {
+    return withTestDb(persistence, db => {
       return db.INTERNAL.delete().then(() => {
         expect(() => {
           db.disableNetwork();
         }).to.throw(
-          'The client has already been shutdown. Please restart the client.'
+          'The client has already been shutdown.'
         );
       });
     });

--- a/packages/firestore/test/integration/api/database.test.ts
+++ b/packages/firestore/test/integration/api/database.test.ts
@@ -919,20 +919,17 @@ apiDescribe('Database', persistence => {
     });
   });
 
-  (persistence ? it : it.skip)(
-    'rejects subsequent method calls after shutdown() is called',
-    async () => {
-      return withTestDbNoShutdown(persistence, db => {
-        return db.INTERNAL.delete().then(() => {
-          expect(() => {
-            db.disableNetwork();
-          }).to.throw(
-            'The client has already been shutdown. Please restart the client.'
-          );
-        });
+  it('rejects subsequent method calls after shutdown() is called', async () => {
+    return withTestDbNoShutdown(persistence, db => {
+      return db.INTERNAL.delete().then(() => {
+        expect(() => {
+          db.disableNetwork();
+        }).to.throw(
+          'The client has already been shutdown. Please restart the client.'
+        );
       });
-    }
-  );
+    });
+  });
 
   it('can get documents while offline', async () => {
     await withTestDoc(persistence, async docRef => {

--- a/packages/firestore/test/integration/api/database.test.ts
+++ b/packages/firestore/test/integration/api/database.test.ts
@@ -31,6 +31,7 @@ import {
   apiDescribe,
   withTestCollection,
   withTestDb,
+  withTestDbNoShutdown,
   withTestDbs,
   withTestDoc,
   withTestDocAndInitialData
@@ -918,19 +919,20 @@ apiDescribe('Database', persistence => {
     });
   });
 
-  it('rejects subsequent method calls after shutdown() is called', async () => {
-    return withTestDoc(persistence, docRef => {
-      const firestore = docRef.firestore;
-
-      return firestore.INTERNAL.delete().then(() => {
-        expect(() => {
-          firestore.disableNetwork();
-        }).to.throw(
-          'The client has already been shutdown. Please restart the client.'
-        );
+  (persistence ? it : it.skip)(
+    'rejects subsequent method calls after shutdown() is called',
+    async () => {
+      return withTestDbNoShutdown(persistence, db => {
+        return db.INTERNAL.delete().then(() => {
+          expect(() => {
+            db.disableNetwork();
+          }).to.throw(
+            'The client has already been shutdown. Please restart the client.'
+          );
+        });
       });
-    });
-  });
+    }
+  );
 
   it('can get documents while offline', async () => {
     await withTestDoc(persistence, async docRef => {

--- a/packages/firestore/test/integration/api/database.test.ts
+++ b/packages/firestore/test/integration/api/database.test.ts
@@ -918,6 +918,20 @@ apiDescribe('Database', persistence => {
     });
   });
 
+  it('rejects subsequent method calls after shutdown() is called', async () => {
+    return withTestDoc(persistence, docRef => {
+      const firestore = docRef.firestore;
+
+      return firestore.INTERNAL.delete().then(() => {
+        expect(() => {
+          firestore.disableNetwork();
+        }).to.throw(
+          'The client has already been shutdown. Please restart the client.'
+        );
+      });
+    });
+  });
+
   it('can get documents while offline', async () => {
     await withTestDoc(persistence, async docRef => {
       const firestore = docRef.firestore;

--- a/packages/firestore/test/integration/api/database.test.ts
+++ b/packages/firestore/test/integration/api/database.test.ts
@@ -31,7 +31,6 @@ import {
   apiDescribe,
   withTestCollection,
   withTestDb,
-  withTestDbNoShutdown,
   withTestDbs,
   withTestDoc,
   withTestDocAndInitialData

--- a/packages/firestore/test/integration/api/database.test.ts
+++ b/packages/firestore/test/integration/api/database.test.ts
@@ -924,9 +924,7 @@ apiDescribe('Database', persistence => {
       return db.INTERNAL.delete().then(() => {
         expect(() => {
           db.disableNetwork();
-        }).to.throw(
-          'The client has already been shutdown.'
-        );
+        }).to.throw('The client has already been shutdown.');
       });
     });
   });

--- a/packages/firestore/test/integration/util/helpers.ts
+++ b/packages/firestore/test/integration/util/helpers.ts
@@ -144,6 +144,26 @@ export function withTestDb(
   });
 }
 
+/**
+ * Does not invoke shutdown at the end of the test. Caller must manually
+ * shutdown the DB. 
+ */
+export function withTestDbNoShutdown(
+  persistence: boolean,
+  fn: (db: firestore.FirebaseFirestore) => Promise<void>
+): Promise<void> {
+  return withTestDbsSettings(
+    persistence,
+    DEFAULT_PROJECT_ID,
+    DEFAULT_SETTINGS,
+    1,
+    /* invokeShutdown= */ false,
+    ([db]) => {
+      return fn(db);
+    }
+  );
+}
+
 /** Runs provided fn with a db for an alternate project id. */
 export function withAlternateTestDb(
   persistence: boolean,
@@ -154,6 +174,7 @@ export function withAlternateTestDb(
     ALT_PROJECT_ID,
     DEFAULT_SETTINGS,
     1,
+    /* invokeShutdown= */ true,
     ([db]) => {
       return fn(db);
     }
@@ -170,6 +191,7 @@ export function withTestDbs(
     DEFAULT_PROJECT_ID,
     DEFAULT_SETTINGS,
     numDbs,
+    /* invokeShutdown= */ true,
     fn
   );
 }
@@ -181,6 +203,7 @@ export function withTestDbsSettings(
   projectId: string,
   settings: firestore.Settings,
   numDbs: number,
+  invokeShutdown: boolean,
   fn: (db: firestore.FirebaseFirestore[]) => Promise<void>
 ): Promise<void> {
   if (numDbs === 0) {
@@ -213,11 +236,13 @@ export function withTestDbsSettings(
       return wipeDb(dbs[0]).then(() =>
         dbs.reduce(
           (chain, db) =>
-            chain.then(
-              db.INTERNAL.delete.bind(this, {
-                purgePersistenceWithDataLoss: true
-              })
-            ),
+            chain.then(() => {
+              if (invokeShutdown === true) {
+                db.INTERNAL.delete.bind(this, {
+                  purgePersistenceWithDataLoss: true
+                });
+              }
+            }),
           Promise.resolve()
         )
       );
@@ -288,6 +313,7 @@ export function withTestCollectionSettings(
     DEFAULT_PROJECT_ID,
     settings,
     2,
+    /* invokeShutdown= */ true,
     ([testDb, setupDb]) => {
       // Abuse .doc() to get a random ID.
       const collectionId = 'test-collection-' + testDb.collection('x').doc().id;

--- a/packages/firestore/test/integration/util/helpers.ts
+++ b/packages/firestore/test/integration/util/helpers.ts
@@ -146,7 +146,7 @@ export function withTestDb(
 
 /**
  * Does not invoke shutdown at the end of the test. Caller must manually
- * shutdown the DB. 
+ * shutdown the DB.
  */
 export function withTestDbNoShutdown(
   persistence: boolean,


### PR DESCRIPTION
Context: b/38324305

Please take a look! Couldn't figure out how to cancel existing listeners and pending promises just yet, but will try to figure it out.

For some reason, the test passed the first time, but no longer passes with persistence = false. Gonna close this PR until I figure out what's wrong.