### PR TITLE
Updated externs for AuthCredential serialization/deserialzation

### DIFF
--- a/packages/firebase/externs/firebase-auth-externs.js
+++ b/packages/firebase/externs/firebase-auth-externs.js
@@ -70,6 +70,27 @@ firebase.auth.AuthCredential.prototype.providerId;
  */
 firebase.auth.AuthCredential.prototype.signInMethod;
 
+
+/**
+ * Static method to deserialize a JSON representation of an object into an
+ * {@link firebase.auth.AuthCredential}. Input can be either Object or the
+ * stringified representation of the object. When string is provided,
+ * JSON.parse would be called first. If the JSON input does not represent an
+ * `AuthCredential`, null is returned.
+ * @param {string|!Object} json The plain object representation of an
+ *     AuthCredential.
+ * @return {?firebase.auth.AuthCredential} The auth credential.
+ */
+firebase.auth.AuthCredential.fromJSON = function(json) {};
+
+
+/**
+ * Returns a JSON-serializable representation of this object.
+ * @return {!Object} The plain object representation of the `AuthCredential`.
+ */
+firebase.auth.AuthCredential.prototype.toJSON = function() {};
+
+
 /**
  * Interface that represents the OAuth credentials returned by an OAuth
  * provider. Implementations specify the details about each auth provider's

--- a/packages/firebase/index.d.ts
+++ b/packages/firebase/index.d.ts
@@ -2691,7 +2691,7 @@ declare namespace firebase.auth {
      * stringified representation of the object. When string is provided,
      * JSON.parse would be called first. If the JSON input does not represent
      * an`AuthCredential`, null is returned.
-     * @param {!Object|string} json The plain object representation of an
+     * @param json The plain object representation of an
      *     AuthCredential.
      */
     static fromJSON(json: Object | string): AuthCredential | null;


### PR DESCRIPTION
1. Added `toJSON` and `fromJSON` in auth externs
2. Removed redundant type declaration in JSdocs. 