### PR TITLE
Exclude iOS Safari < 10.0 and Android < 4.4 when checking isAvailable() to enable persistence

### DIFF
--- a/packages/firestore/src/local/simple_db.ts
+++ b/packages/firestore/src/local/simple_db.ts
@@ -162,16 +162,16 @@ export class SimpleDb {
     // ua = 'Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML,
     // like Gecko) Chrome/39.0.2171.71 Safari/537.36 Edge/12.0';
 
-    const iOS = !!ua.match(/iPad/i) || !!ua.match(/iPhone/i);
-    const webkit = !!ua.match(/WebKit/i);
-    const iOSSafari = iOS && webkit && !ua.match(/CriOS/i);
-    console.log('is iOSSafari?: ', iOSSafari);
+    // iOS Safari: Disable for users running iOS version < 10.
+    const iOSSafari =
+      (!!ua.match(/iPad/i) || !!ua.match(/iPhone/i)) && !!ua.match(/WebKit/i);
+    const isUnsupportedIOS = iOSSafari && SimpleDb.getIOSVersion(ua) < 10;
 
     if (
       ua.indexOf('MSIE ') > 0 ||
       ua.indexOf('Trident/') > 0 ||
       ua.indexOf('Edge/') > 0 ||
-      iOSSafari
+      isUnsupportedIOS
     ) {
       return false;
     } else {
@@ -185,6 +185,15 @@ export class SimpleDb {
     store: string
   ): SimpleDbStore<KeyType, ValueType> {
     return txn.store<KeyType, ValueType>(store);
+  }
+
+  /** Parse User Agent to determine iOS version. Returns 0 if not found. */
+  static getIOSVersion(ua: string): number {
+    const iOSVersionRegex = ua.match(/i(?:phone|pad|pod) os ([\d_]+)/i);
+    const version = iOSVersionRegex
+      ? iOSVersionRegex[1].split('_')[0]
+      : '0';
+    return parseInt(version);
   }
 
   constructor(private db: IDBDatabase) {}

--- a/packages/firestore/src/local/simple_db.ts
+++ b/packages/firestore/src/local/simple_db.ts
@@ -163,7 +163,7 @@ export class SimpleDb {
     // like Gecko) Chrome/39.0.2171.71 Safari/537.36 Edge/12.0';
 
     // iOS Safari: Disable for users running iOS version < 10.
-    const iOSVersion = getIOSVersion(ua);
+    const iOSVersion = SimpleDb.getIOSVersion(ua);
     const isUnsupportedIOS = 0 < iOSVersion && iOSVersion < 10;
 
     if (

--- a/packages/firestore/src/local/simple_db.ts
+++ b/packages/firestore/src/local/simple_db.ts
@@ -176,7 +176,6 @@ export class SimpleDb {
       ua.indexOf('Edge/') > 0 ||
       isUnsupportedIOS ||
       isUnsupportedAndroid
-
     ) {
       return false;
     } else {

--- a/packages/firestore/src/local/simple_db.ts
+++ b/packages/firestore/src/local/simple_db.ts
@@ -163,9 +163,8 @@ export class SimpleDb {
     // like Gecko) Chrome/39.0.2171.71 Safari/537.36 Edge/12.0';
 
     // iOS Safari: Disable for users running iOS version < 10.
-    const iOSSafari =
-      (!!ua.match(/iPad/i) || !!ua.match(/iPhone/i)) && !!ua.match(/WebKit/i);
-    const isUnsupportedIOS = iOSSafari && SimpleDb.getIOSVersion(ua) < 10;
+    const iOSVersion = getIOSVersion(ua);
+    const isUnsupportedIOS = 0 < iOSVersion && iOSVersion < 10;
 
     if (
       ua.indexOf('MSIE ') > 0 ||
@@ -187,10 +186,10 @@ export class SimpleDb {
     return txn.store<KeyType, ValueType>(store);
   }
 
-  /** Parse User Agent to determine iOS version. Returns 0 if not found. */
+  /** Parse User Agent to determine iOS version. Returns -1 if not found. */
   static getIOSVersion(ua: string): number {
     const iOSVersionRegex = ua.match(/i(?:phone|pad|pod) os ([\d_]+)/i);
-    const version = iOSVersionRegex ? iOSVersionRegex[1].split('_')[0] : '0';
+    const version = iOSVersionRegex ? iOSVersionRegex[1].split('_')[0] : '-1';
     return parseInt(version);
   }
 

--- a/packages/firestore/src/local/simple_db.ts
+++ b/packages/firestore/src/local/simple_db.ts
@@ -166,9 +166,9 @@ export class SimpleDb {
     const iOSVersion = SimpleDb.getIOSVersion(ua);
     const isUnsupportedIOS = 0 < iOSVersion && iOSVersion < 10;
 
-    // Android browser: Disable for userse running version < 4.4.
+    // Android browser: Disable for userse running version < 4.5.
     const androidVersion = SimpleDb.getAndroidVersion(ua);
-    const isUnsupportedAndroid = 0 < androidVersion && androidVersion < 4.4;
+    const isUnsupportedAndroid = 0 < androidVersion && androidVersion < 4.5;
 
     if (
       ua.indexOf('MSIE ') > 0 ||

--- a/packages/firestore/src/local/simple_db.ts
+++ b/packages/firestore/src/local/simple_db.ts
@@ -190,7 +190,8 @@ export class SimpleDb {
   ): SimpleDbStore<KeyType, ValueType> {
     return txn.store<KeyType, ValueType>(store);
   }
-
+  
+  // visible for testing
   /** Parse User Agent to determine iOS version. Returns -1 if not found. */
   static getIOSVersion(ua: string): number {
     const iOSVersionRegex = ua.match(/i(?:phone|pad|pod) os ([\d_]+)/i);
@@ -198,9 +199,10 @@ export class SimpleDb {
     return Number(version);
   }
 
+  // visible for testing
   /** Parse User Agent to determine Android version. Returns -1 if not found. */
   static getAndroidVersion(ua: string): number {
-    const androidVersionRegex = ua.match(/Android (\d+(?:\.\d+)+)/i);
+    const androidVersionRegex = ua.match(/Android ([\d.]+)/i);
     const version = androidVersionRegex
       ? androidVersionRegex[1]
           .split('.')

--- a/packages/firestore/src/local/simple_db.ts
+++ b/packages/firestore/src/local/simple_db.ts
@@ -190,7 +190,7 @@ export class SimpleDb {
   ): SimpleDbStore<KeyType, ValueType> {
     return txn.store<KeyType, ValueType>(store);
   }
-  
+
   // visible for testing
   /** Parse User Agent to determine iOS version. Returns -1 if not found. */
   static getIOSVersion(ua: string): number {

--- a/packages/firestore/src/local/simple_db.ts
+++ b/packages/firestore/src/local/simple_db.ts
@@ -162,10 +162,16 @@ export class SimpleDb {
     // ua = 'Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML,
     // like Gecko) Chrome/39.0.2171.71 Safari/537.36 Edge/12.0';
 
+    const iOS = !!ua.match(/iPad/i) || !!ua.match(/iPhone/i);
+    const webkit = !!ua.match(/WebKit/i);
+    const iOSSafari = iOS && webkit && !ua.match(/CriOS/i);
+    console.log('is iOSSafari?: ', iOSSafari);
+
     if (
       ua.indexOf('MSIE ') > 0 ||
       ua.indexOf('Trident/') > 0 ||
-      ua.indexOf('Edge/') > 0
+      ua.indexOf('Edge/') > 0 ||
+      iOSSafari
     ) {
       return false;
     } else {

--- a/packages/firestore/src/local/simple_db.ts
+++ b/packages/firestore/src/local/simple_db.ts
@@ -166,11 +166,17 @@ export class SimpleDb {
     const iOSVersion = SimpleDb.getIOSVersion(ua);
     const isUnsupportedIOS = 0 < iOSVersion && iOSVersion < 10;
 
+    // Android browser: Disable for userse running version < 4.4.
+    const androidVersion = SimpleDb.getAndroidVersion(ua);
+    const isUnsupportedAndroid = 0 < androidVersion && androidVersion < 4.4;
+
     if (
       ua.indexOf('MSIE ') > 0 ||
       ua.indexOf('Trident/') > 0 ||
       ua.indexOf('Edge/') > 0 ||
-      isUnsupportedIOS
+      isUnsupportedIOS ||
+      isUnsupportedAndroid
+
     ) {
       return false;
     } else {
@@ -191,6 +197,19 @@ export class SimpleDb {
   static getIOSVersion(ua: string): number {
     const iOSVersionRegex = ua.match(/i(?:phone|pad|pod) os ([\d_]+)/i);
     const version = iOSVersionRegex ? iOSVersionRegex[1].split('_')[0] : '-1';
+    return Number(version);
+  }
+
+  // visible for testing
+  /** Parse User Agent to determine Android version. Returns -1 if not found. */
+  static getAndroidVersion(ua: string): number {
+    const androidVersionRegex = ua.match(/Android ([\d.]+)/i);
+    const version = androidVersionRegex
+      ? androidVersionRegex[1]
+          .split('.')
+          .slice(0, 2)
+          .join('.')
+      : '-1';
     return Number(version);
   }
 

--- a/packages/firestore/src/local/simple_db.ts
+++ b/packages/firestore/src/local/simple_db.ts
@@ -166,16 +166,15 @@ export class SimpleDb {
     const iOSVersion = SimpleDb.getIOSVersion(ua);
     const isUnsupportedIOS = 0 < iOSVersion && iOSVersion < 10;
 
-    // Android browser: Disable for userse running version < 4.4.
-    const androidVersion = SimpleDb.getAndroidVersion(ua);
-    const isUnsupportedAndroid = 0 < androidVersion && androidVersion < 4.4;
+    // Checks whether IndexedDB is supported on the browser
+    const noIndexedDB = typeof window === 'undefined' || window.indexedDB == null;
 
     if (
       ua.indexOf('MSIE ') > 0 ||
       ua.indexOf('Trident/') > 0 ||
       ua.indexOf('Edge/') > 0 ||
       isUnsupportedIOS ||
-      isUnsupportedAndroid
+      noIndexedDB
     ) {
       return false;
     } else {
@@ -196,19 +195,6 @@ export class SimpleDb {
   static getIOSVersion(ua: string): number {
     const iOSVersionRegex = ua.match(/i(?:phone|pad|pod) os ([\d_]+)/i);
     const version = iOSVersionRegex ? iOSVersionRegex[1].split('_')[0] : '-1';
-    return Number(version);
-  }
-
-  // visible for testing
-  /** Parse User Agent to determine Android version. Returns -1 if not found. */
-  static getAndroidVersion(ua: string): number {
-    const androidVersionRegex = ua.match(/Android ([\d.]+)/i);
-    const version = androidVersionRegex
-      ? androidVersionRegex[1]
-          .split('.')
-          .slice(0, 2)
-          .join('.')
-      : '-1';
     return Number(version);
   }
 

--- a/packages/firestore/src/local/simple_db.ts
+++ b/packages/firestore/src/local/simple_db.ts
@@ -167,7 +167,8 @@ export class SimpleDb {
     const isUnsupportedIOS = 0 < iOSVersion && iOSVersion < 10;
 
     // Checks whether IndexedDB is supported on the browser
-    const noIndexedDB = typeof window === 'undefined' || window.indexedDB == null;
+    const noIndexedDB =
+      typeof window === 'undefined' || window.indexedDB == null;
 
     if (
       ua.indexOf('MSIE ') > 0 ||

--- a/packages/firestore/src/local/simple_db.ts
+++ b/packages/firestore/src/local/simple_db.ts
@@ -190,9 +190,7 @@ export class SimpleDb {
   /** Parse User Agent to determine iOS version. Returns 0 if not found. */
   static getIOSVersion(ua: string): number {
     const iOSVersionRegex = ua.match(/i(?:phone|pad|pod) os ([\d_]+)/i);
-    const version = iOSVersionRegex
-      ? iOSVersionRegex[1].split('_')[0]
-      : '0';
+    const version = iOSVersionRegex ? iOSVersionRegex[1].split('_')[0] : '0';
     return parseInt(version);
   }
 

--- a/packages/firestore/src/local/simple_db.ts
+++ b/packages/firestore/src/local/simple_db.ts
@@ -166,16 +166,11 @@ export class SimpleDb {
     const iOSVersion = SimpleDb.getIOSVersion(ua);
     const isUnsupportedIOS = 0 < iOSVersion && iOSVersion < 10;
 
-    // Checks whether IndexedDB is supported on the browser
-    const noIndexedDB =
-      typeof window === 'undefined' || window.indexedDB == null;
-
     if (
       ua.indexOf('MSIE ') > 0 ||
       ua.indexOf('Trident/') > 0 ||
       ua.indexOf('Edge/') > 0 ||
-      isUnsupportedIOS ||
-      noIndexedDB
+      isUnsupportedIOS
     ) {
       return false;
     } else {

--- a/packages/firestore/src/local/simple_db.ts
+++ b/packages/firestore/src/local/simple_db.ts
@@ -166,11 +166,16 @@ export class SimpleDb {
     const iOSVersion = SimpleDb.getIOSVersion(ua);
     const isUnsupportedIOS = 0 < iOSVersion && iOSVersion < 10;
 
+    // Android browser: Disable for userse running version < 4.4.
+    const androidVersion = SimpleDb.getAndroidVersion(ua);
+    const isUnsupportedAndroid = 0 < androidVersion && androidVersion < 4.4;
+
     if (
       ua.indexOf('MSIE ') > 0 ||
       ua.indexOf('Trident/') > 0 ||
       ua.indexOf('Edge/') > 0 ||
-      isUnsupportedIOS
+      isUnsupportedIOS ||
+      isUnsupportedAndroid
     ) {
       return false;
     } else {
@@ -190,7 +195,19 @@ export class SimpleDb {
   static getIOSVersion(ua: string): number {
     const iOSVersionRegex = ua.match(/i(?:phone|pad|pod) os ([\d_]+)/i);
     const version = iOSVersionRegex ? iOSVersionRegex[1].split('_')[0] : '-1';
-    return parseInt(version);
+    return Number(version);
+  }
+
+  /** Parse User Agent to determine Android version. Returns -1 if not found. */
+  static getAndroidVersion(ua: string): number {
+    const androidVersionRegex = ua.match(/Android (\d+(?:\.\d+)+)/i);
+    const version = androidVersionRegex
+      ? androidVersionRegex[1]
+          .split('.')
+          .slice(0, 2)
+          .join('.')
+      : '-1';
+    return Number(version);
   }
 
   constructor(private db: IDBDatabase) {}

--- a/packages/firestore/test/unit/local/simple_db.test.ts
+++ b/packages/firestore/test/unit/local/simple_db.test.ts
@@ -129,12 +129,8 @@ describe('SimpleDb', () => {
     const iPadSafariAgent =
       'Mozilla/5.0 (iPad; CPU iPad OS 9_0 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko)' +
       ' Version/9.0 Mobile/13A344 Safari/601';
-    const androidAgent =
-      'Mozilla/5.0 (Linux; U; Android 2.2.1; fr-fr; Desire HD Build/FRG83D)' +
-      ' AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1';
     expect(SimpleDb.getIOSVersion(iPhoneSafariAgent)).to.equal(10);
     expect(SimpleDb.getIOSVersion(iPadSafariAgent)).to.equal(9);
-    expect(SimpleDb.getAndroidVersion(androidAgent)).to.equal(2.2);
   });
 
   it('can get', async () => {

--- a/packages/firestore/test/unit/local/simple_db.test.ts
+++ b/packages/firestore/test/unit/local/simple_db.test.ts
@@ -122,15 +122,18 @@ describe('SimpleDb', () => {
   after(() => SimpleDb.delete(dbName));
 
   it('regex test', () => {
-    const iPhoneSafariAgent10 =
+    const iPhoneSafariAgent =
       'Mozilla/5.0 (iPhone; CPU iPhone OS 10_14_4 like Mac OS X)' +
       ' AppleWebKit/600.1.4 (KHTML, like Gecko) Version/8.0 Mobile/12B411' +
       ' Safari/600.1.4';
-    const iPadSafariAgent9 =
+    const iPadSafariAgent =
       'Mozilla/5.0 (iPad; CPU iPad OS 9_0 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko)' +
       ' Version/9.0 Mobile/13A344 Safari/601';
-    expect(SimpleDb.getIOSVersion(iPhoneSafariAgent10)).to.equal(10);
-    expect(SimpleDb.getIOSVersion(iPadSafariAgent9)).to.equal(9);
+    const androidAgent = 'Mozilla/5.0 (Linux; U; Android 2.2.1; fr-fr; Desire HD Build/FRG83D)' +
+      ' AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1';
+    expect(SimpleDb.getIOSVersion(iPhoneSafariAgent)).to.equal(10);
+    expect(SimpleDb.getIOSVersion(iPadSafariAgent)).to.equal(9);
+    expect(SimpleDb.getAndroidVersion(androidAgent)).to.equal(2.2);
   });
 
   it('can get', async () => {

--- a/packages/firestore/test/unit/local/simple_db.test.ts
+++ b/packages/firestore/test/unit/local/simple_db.test.ts
@@ -129,7 +129,8 @@ describe('SimpleDb', () => {
     const iPadSafariAgent =
       'Mozilla/5.0 (iPad; CPU iPad OS 9_0 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko)' +
       ' Version/9.0 Mobile/13A344 Safari/601';
-    const androidAgent = 'Mozilla/5.0 (Linux; U; Android 2.2.1; fr-fr; Desire HD Build/FRG83D)' +
+    const androidAgent =
+      'Mozilla/5.0 (Linux; U; Android 2.2.1; fr-fr; Desire HD Build/FRG83D)' +
       ' AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1';
     expect(SimpleDb.getIOSVersion(iPhoneSafariAgent)).to.equal(10);
     expect(SimpleDb.getIOSVersion(iPadSafariAgent)).to.equal(9);

--- a/packages/firestore/test/unit/local/simple_db.test.ts
+++ b/packages/firestore/test/unit/local/simple_db.test.ts
@@ -129,8 +129,12 @@ describe('SimpleDb', () => {
     const iPadSafariAgent =
       'Mozilla/5.0 (iPad; CPU iPad OS 9_0 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko)' +
       ' Version/9.0 Mobile/13A344 Safari/601';
+    const androidAgent =
+      'Mozilla/5.0 (Linux; U; Android 2.2.1; fr-fr; Desire HD Build/FRG83D)' +
+      ' AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1';
     expect(SimpleDb.getIOSVersion(iPhoneSafariAgent)).to.equal(10);
     expect(SimpleDb.getIOSVersion(iPadSafariAgent)).to.equal(9);
+    expect(SimpleDb.getAndroidVersion(androidAgent)).to.equal(2.2);
   });
 
   it('can get', async () => {

--- a/packages/firestore/test/unit/local/simple_db.test.ts
+++ b/packages/firestore/test/unit/local/simple_db.test.ts
@@ -121,6 +121,18 @@ describe('SimpleDb', () => {
 
   after(() => SimpleDb.delete(dbName));
 
+  it('regex test', () => {
+    const iPhoneSafariAgent10 =
+      'Mozilla/5.0 (iPhone; CPU iPhone OS 10_14_4 like Mac OS X)' +
+      ' AppleWebKit/600.1.4 (KHTML, like Gecko) Version/8.0 Mobile/12B411' +
+      ' Safari/600.1.4';
+    const iPadSafariAgent9 =
+      'Mozilla/5.0 (iPad; CPU iPad OS 9_0 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko)' +
+      ' Version/9.0 Mobile/13A344 Safari/601';
+    expect(SimpleDb.getIOSVersion(iPhoneSafariAgent10)).to.equal(10);
+    expect(SimpleDb.getIOSVersion(iPadSafariAgent9)).to.equal(9);
+  });
+
   it('can get', async () => {
     await runTransaction(store => {
       return store


### PR DESCRIPTION
from: b/80403585, #443 

Reference for IndexedDB support: https://caniuse.com/#feat=indexeddb

Old error message [iOS Safari (iOS 9.1)] (error):
```
[2019-04-17T00:04:02.109Z]  @firebase/firestore: – "Firestore (5.9.4): INTERNAL UNHANDLED ERROR: " – "transaction@[native code]↵open@http://localhost:8080/firebase-firestore.js:1:16616…"
```

New error message (warning):
```
Error enabling offline storage. Falling back to storage disabled: FirebaseError: [code=unimplemented]: This platform is either missing IndexedDB or is known to have an incomplete implementation. Offline persistence has been disabled.
```