### PR TITLE
Updates isWorker() check 

### DIFF
--- a/packages/auth/src/utils.js
+++ b/packages/auth/src/utils.js
@@ -636,12 +636,13 @@ fireauth.util.isOpenerAnIframe = function(opt_win) {
 
 
 /**
- * @param {?Object=} opt_global The optional global scope.
+ * @param {?Object=} global The optional global scope.
  * @return {boolean} Whether current environment is a worker.
  */
-fireauth.util.isWorker = function(opt_global) {
-  var scope = opt_global || goog.global;
-  return typeof scope['window'] !== 'object' &&
+fireauth.util.isWorker = function(global) {
+  var scope = global || goog.global;
+  // WorkerGlobalScope only defined in worker environment.
+  return typeof scope['WorkerGlobalScope'] !== 'undefined' &&
          typeof scope['importScripts'] === 'function';
 };
 

--- a/packages/auth/test/utils_test.js
+++ b/packages/auth/test/utils_test.js
@@ -557,6 +557,7 @@ function testGetEnvironment_worker() {
 function testIsWorker() {
   assertFalse(fireauth.util.isWorker({'window': {}}));
   assertTrue(fireauth.util.isWorker({
+    'WorkerGlobalScope': function() {},
     'importScripts': function() {}
   }));
 }


### PR DESCRIPTION
Updates isWorker() check to test if importScripts and WorkerGlobalScope are defined. This removes check on window existence. Some developers resort to mocking window to use certain libraries in worker environment. This causes auth worker functionality to fail.

