### PR TITLE
Track AuthEvent with ID to remove duplicate events

### DIFF
--- a/packages/auth/src/authevent.js
+++ b/packages/auth/src/authevent.js
@@ -118,6 +118,23 @@ fireauth.AuthEvent.prototype.getEventId = function() {
 };
 
 
+/** @return {string} The event unique identifier. */
+fireauth.AuthEvent.prototype.getUid = function() {
+  var components = [];
+  components.push(this.type_);
+  if (this.eventId_) {
+    components.push(this.eventId_);
+  }
+  if (this.sessionId_) {
+    components.push(this.sessionId_);
+  }
+  if (this.tenantId_) {
+    components.push(this.tenantId_);
+  }
+  return components.join('-');
+};
+
+
 /** @return {?string} The url response of Auth event. */
 fireauth.AuthEvent.prototype.getUrlResponse = function() {
   return this.urlResponse_;

--- a/packages/auth/test/authevent_test.js
+++ b/packages/auth/test/authevent_test.js
@@ -214,6 +214,14 @@ function testAuthEvent_error() {
 
 
 function testAuthEvent() {
+  var unknownEvent = new fireauth.AuthEvent(
+      fireauth.AuthEvent.Type.UNKNOWN,
+      null,
+      null,
+      null,
+      new fireauth.AuthError(fireauth.authenum.Error.INTERNAL_ERROR));
+  assertEquals('unknown', unknownEvent.getUid());
+
   assertEquals(
       fireauth.AuthEvent.Type.SIGN_IN_VIA_POPUP,
       authEvent.getType());
@@ -225,6 +233,7 @@ function testAuthEvent() {
   assertNull(authEvent.getEventId());
   assertNull(authEvent.getError());
   assertFalse(authEvent.hasError());
+  assertEquals('signInViaPopup-SESSION_ID', authEvent.getUid());
 
   assertEquals(
       fireauth.AuthEvent.Type.SIGN_IN_VIA_REDIRECT,
@@ -235,6 +244,7 @@ function testAuthEvent() {
       authEvent2.getError());
   assertTrue(authEvent2.hasError());
   assertNull(authEvent2.getPostBody());
+  assertEquals('signInViaRedirect-12345678', authEvent2.getUid());
 }
 
 

--- a/packages/auth/test/authuser_test.js
+++ b/packages/auth/test/authuser_test.js
@@ -8787,9 +8787,15 @@ function testUser_linkWithPopup_timeout() {
   oAuthSignInHandlerInstance.startPopupTimeout(
       ignoreArgument, ignoreArgument, ignoreArgument)
       .$does(function(popupWin, onError, delay) {
+        // Do nothing on first call to simulate timeout.
+        return new goog.Promise(function(resolve, reject) {});
+      }).$once();
+  oAuthSignInHandlerInstance.startPopupTimeout(
+      ignoreArgument, ignoreArgument, ignoreArgument)
+      .$does(function(popupWin, onError, delay) {
         recordedHandler(expectedAuthEvent);
         return new goog.Promise(function(resolve, reject) {});
-      }).$times(2);
+      }).$once();
   mockControl.$replayAll();
   // Set the backend user info with no linked providers.
   stubs.replace(
@@ -8965,9 +8971,15 @@ function testUser_reauthenticateWithPopup_timeout() {
   oAuthSignInHandlerInstance.startPopupTimeout(
       ignoreArgument, ignoreArgument, ignoreArgument)
       .$does(function(popupWin, onError, delay) {
+        // Do nothing on first call to simulate timeout.
+        return new goog.Promise(function(resolve, reject) {});
+      }).$once();
+  oAuthSignInHandlerInstance.startPopupTimeout(
+      ignoreArgument, ignoreArgument, ignoreArgument)
+      .$does(function(popupWin, onError, delay) {
         recordedHandler(expectedAuthEvent);
         return new goog.Promise(function(resolve, reject) {});
-      }).$times(2);
+      }).$once();
   mockControl.$replayAll();
   // The expected popup window object.
   var expectedPopup = {


### PR DESCRIPTION
Track AuthEvents with event IDs/session IDs in AuthEventManager and ignore duplicate events. This will prevent race conditions when completing sign in with popup.