### PR TITLE
Add types to ErrorFactory message parameters

### DIFF
--- a/packages/app/src/errors.ts
+++ b/packages/app/src/errors.ts
@@ -40,8 +40,10 @@ const ERRORS: ErrorMap<AppError> = {
     'Firebase App instance.'
 };
 
-const appErrors = new ErrorFactory<AppError>('app', 'Firebase', ERRORS);
+type ErrorParams = { [key in AppError]: { name: string } };
 
-export function error(code: AppError, args?: { [name: string]: any }) {
-  throw appErrors.create(code, args);
-}
+export const ERROR_FACTORY = new ErrorFactory<AppError, ErrorParams>(
+  'app',
+  'Firebase',
+  ERRORS
+);

--- a/packages/app/src/firebaseApp.ts
+++ b/packages/app/src/firebaseApp.ts
@@ -27,7 +27,7 @@ import {
   FirebaseAppInternals
 } from '@firebase/app-types/private';
 import { deepCopy, deepExtend } from '@firebase/util';
-import { error, AppError } from './errors';
+import { AppError, ERROR_FACTORY } from './errors';
 import { DEFAULT_ENTRY_NAME } from './constants';
 
 interface ServicesCache {
@@ -202,7 +202,7 @@ export class FirebaseAppImpl implements FirebaseApp {
    */
   private checkDestroyed_(): void {
     if (this.isDeleted_) {
-      error(AppError.APP_DELETED, { name: this.name_ });
+      throw ERROR_FACTORY.create(AppError.APP_DELETED, { name: this.name_ });
     }
   }
 }

--- a/packages/app/src/firebaseNamespaceCore.ts
+++ b/packages/app/src/firebaseNamespaceCore.ts
@@ -31,7 +31,7 @@ import {
 } from '@firebase/app-types/private';
 import { deepExtend, patchProperty } from '@firebase/util';
 import { FirebaseAppImpl } from './firebaseApp';
-import { error, AppError } from './errors';
+import { ERROR_FACTORY, AppError } from './errors';
 import { FirebaseAppLiteImpl } from './lite/firebaseAppLite';
 import { DEFAULT_ENTRY_NAME } from './constants';
 
@@ -104,7 +104,7 @@ export function createFirebaseNamespaceCore(
   function app(name?: string): FirebaseApp {
     name = name || DEFAULT_ENTRY_NAME;
     if (!contains(apps, name)) {
-      error(AppError.NO_APP, { name: name });
+      throw ERROR_FACTORY.create(AppError.NO_APP, { name: name });
     }
     return apps[name];
   }
@@ -133,11 +133,11 @@ export function createFirebaseNamespaceCore(
     const { name } = config;
 
     if (typeof name !== 'string' || !name) {
-      error(AppError.BAD_APP_NAME, { name: String(name) });
+      throw ERROR_FACTORY.create(AppError.BAD_APP_NAME, { name: String(name) });
     }
 
     if (contains(apps, name)) {
-      error(AppError.DUPLICATE_APP, { name: name });
+      throw ERROR_FACTORY.create(AppError.DUPLICATE_APP, { name: name });
     }
 
     const app = new firebaseAppImpl(
@@ -176,7 +176,7 @@ export function createFirebaseNamespaceCore(
   ): FirebaseServiceNamespace<FirebaseService> {
     // Cannot re-register a service that already exists
     if (factories[name]) {
-      error(AppError.DUPLICATE_SERVICE, { name: name });
+      throw ERROR_FACTORY.create(AppError.DUPLICATE_SERVICE, { name: name });
     }
 
     // Capture the service factory for later service instantiation
@@ -197,7 +197,9 @@ export function createFirebaseNamespaceCore(
       if (typeof appArg[name] !== 'function') {
         // Invalid argument.
         // This happens in the following case: firebase.storage('gs:/')
-        error(AppError.INVALID_APP_ARGUMENT, { name: name });
+        throw ERROR_FACTORY.create(AppError.INVALID_APP_ARGUMENT, {
+          name: name
+        });
       }
 
       // Forward service instance lookup to the FirebaseApp.

--- a/packages/app/src/lite/firebaseAppLite.ts
+++ b/packages/app/src/lite/firebaseAppLite.ts
@@ -26,7 +26,7 @@ import {
   FirebaseService
 } from '@firebase/app-types/private';
 import { deepCopy, deepExtend } from '@firebase/util';
-import { error, AppError } from '../errors';
+import { ERROR_FACTORY, AppError } from '../errors';
 import { DEFAULT_ENTRY_NAME } from '../constants';
 
 interface ServicesCache {
@@ -168,7 +168,7 @@ export class FirebaseAppLiteImpl implements FirebaseApp {
    */
   private checkDestroyed_(): void {
     if (this.isDeleted_) {
-      error(AppError.APP_DELETED, { name: this.name_ });
+      throw ERROR_FACTORY.create(AppError.APP_DELETED, { name: this.name_ });
     }
   }
 }

--- a/packages/installations/src/util/errors.ts
+++ b/packages/installations/src/util/errors.ts
@@ -43,7 +43,13 @@ const ERROR_DESCRIPTION_MAP: { readonly [key in ErrorCode]: string } = {
     "Can't delete installation while there is a pending registration request."
 };
 
-export const ERROR_FACTORY = new ErrorFactory(
+interface ErrorParams {
+  [ErrorCode.REQUEST_FAILED]: {
+    requestName: string;
+  } & ServerErrorData;
+}
+
+export const ERROR_FACTORY = new ErrorFactory<ErrorCode, ErrorParams>(
   SERVICE,
   SERVICE_NAME,
   ERROR_DESCRIPTION_MAP

--- a/packages/messaging/src/models/errors.ts
+++ b/packages/messaging/src/models/errors.ts
@@ -157,7 +157,15 @@ export const ERROR_MAP: ErrorMap<ErrorCode> = {
     'The public VAPID key did not equal 65 bytes when decrypted.'
 };
 
-export const errorFactory = new ErrorFactory(
+interface ErrorParams {
+  [ErrorCode.FAILED_DEFAULT_REGISTRATION]: { browserErrorMessage: string };
+  [ErrorCode.TOKEN_SUBSCRIBE_FAILED]: { errorInfo: string };
+  [ErrorCode.TOKEN_UNSUBSCRIBE_FAILED]: { errorInfo: string };
+  [ErrorCode.TOKEN_UPDATE_FAILED]: { errorInfo: string };
+  [ErrorCode.UNABLE_TO_RESUBSCRIBE]: { errorInfo: string };
+}
+
+export const errorFactory = new ErrorFactory<ErrorCode, ErrorParams>(
   'messaging',
   'Messaging',
   ERROR_MAP

--- a/packages/messaging/src/models/iid-model.ts
+++ b/packages/messaging/src/models/iid-model.ts
@@ -72,7 +72,9 @@ export class IidModel {
 
       responseData = await response.json();
     } catch (err) {
-      throw errorFactory.create(ErrorCode.TOKEN_SUBSCRIBE_FAILED);
+      throw errorFactory.create(ErrorCode.TOKEN_SUBSCRIBE_FAILED, {
+        errorInfo: err
+      });
     }
 
     if (responseData.error) {
@@ -144,7 +146,9 @@ export class IidModel {
       );
       responseData = await response.json();
     } catch (err) {
-      throw errorFactory.create(ErrorCode.TOKEN_UPDATE_FAILED);
+      throw errorFactory.create(ErrorCode.TOKEN_UPDATE_FAILED, {
+        errorInfo: err
+      });
     }
 
     if (responseData.error) {
@@ -196,7 +200,9 @@ export class IidModel {
         });
       }
     } catch (err) {
-      throw errorFactory.create(ErrorCode.TOKEN_UNSUBSCRIBE_FAILED);
+      throw errorFactory.create(ErrorCode.TOKEN_UNSUBSCRIBE_FAILED, {
+        errorInfo: err
+      });
     }
   }
 }

--- a/packages/performance/src/utils/errors.ts
+++ b/packages/performance/src/utils/errors.ts
@@ -43,7 +43,12 @@ const ERROR_DESCRIPTION_MAP: { readonly [key in ErrorCode]: string } = {
   [ErrorCode.RC_NOT_OK]: 'RC response is not ok'
 };
 
-export const ERROR_FACTORY = new ErrorFactory(
+interface ErrorParams {
+  [ErrorCode.TRACE_STARTED_BEFORE]: { traceName: string };
+  [ErrorCode.TRACE_STOPPED_BEFORE]: { traceName: string };
+}
+
+export const ERROR_FACTORY = new ErrorFactory<ErrorCode, ErrorParams>(
   SERVICE,
   SERVICE_NAME,
   ERROR_DESCRIPTION_MAP

--- a/packages/util/test/errors.test.ts
+++ b/packages/util/test/errors.test.ts
@@ -32,7 +32,17 @@ const ERROR_MAP: ErrorMap<ErrorCode> = {
     'I decided to use {$code} to represent the error code from my server.'
 };
 
-const ERROR_FACTORY = new ErrorFactory<ErrorCode>('fake', 'Fake', ERROR_MAP);
+interface ErrorParams {
+  'file-not-found': { file: string };
+  'anon-replace': { repl_: string };
+  'overwrite-field': { code: string };
+}
+
+const ERROR_FACTORY = new ErrorFactory<ErrorCode, ErrorParams>(
+  'fake',
+  'Fake',
+  ERROR_MAP
+);
 
 describe('FirebaseError', () => {
   it('creates an Error', () => {
@@ -68,7 +78,9 @@ describe('FirebaseError', () => {
   });
 
   it('uses the key in the template if the replacement is missing', () => {
-    const e = ERROR_FACTORY.create('file-not-found', { fileX: 'foo.txt' });
+    const e = ERROR_FACTORY.create('file-not-found', {
+      fileX: 'foo.txt'
+    } as any);
     assert.equal(e.code, 'fake/file-not-found');
     assert.equal(
       e.message,


### PR DESCRIPTION
This makes it possible to have static type checking for error parameters.

Example:

```typescript
const enum ErrorCode {
  WITH_PARAMS = 'with-params',
  WITHOUT_PARAMS = 'without-params'
}

const ERROR_MAP: ErrorMap<ErrorCode> = {
  [ErrorCode.WITH_PARAMS]:
    'This message has {$param} and maybe also {$optParam}.',
  [ErrorCode.WITHOUT_PARAMS]: "This message doesn't have any parameters."
};

interface ErrorParams {
  [ErrorCode.WITH_PARAMS]: { param: string; optParam?: string };
}

const ERROR_FACTORY = new ErrorFactory<ErrorCode, ErrorParams>(
  'service',
  'serviceName',
  ERROR_MAP
);

ERROR_FACTORY.create(ErrorCode.WITH_PARAMS); // error
ERROR_FACTORY.create(ErrorCode.WITH_PARAMS, undefined); // error with strict
ERROR_FACTORY.create(ErrorCode.WITH_PARAMS, null); // error with strict
ERROR_FACTORY.create(ErrorCode.WITH_PARAMS, {}); // error
ERROR_FACTORY.create(ErrorCode.WITH_PARAMS, { param: 'param' }); // good
ERROR_FACTORY.create(ErrorCode.WITH_PARAMS, {
  param: 'param',
  optParam: 'optParam'
}); // good
ERROR_FACTORY.create(ErrorCode.WITH_PARAMS, {
  param: 'param',
  otherParam: 'otherParam'
}); // error
ERROR_FACTORY.create(ErrorCode.WITHOUT_PARAMS); // good
ERROR_FACTORY.create(ErrorCode.WITHOUT_PARAMS, undefined); // error
ERROR_FACTORY.create(ErrorCode.WITHOUT_PARAMS, null); // error
ERROR_FACTORY.create(ErrorCode.WITHOUT_PARAMS, {}); // error
ERROR_FACTORY.create(ErrorCode.WITHOUT_PARAMS, { param: 'param' }); // error
ERROR_FACTORY.create('randomCode'); // error

// This works the same for all ErrorCode values.
const ERROR_FACTORY_WITHOUT_PARAMS = new ErrorFactory<ErrorCode>(
  'service',
  'serviceName',
  ERROR_MAP
);

// Same as WITHOUT_PARAMS before, only works with a single argument.
ERROR_FACTORY_WITHOUT_PARAMS.create(ErrorCode.WITHOUT_PARAMS); // good
ERROR_FACTORY_WITHOUT_PARAMS.create(ErrorCode.WITHOUT_PARAMS, undefined); // error
ERROR_FACTORY_WITHOUT_PARAMS.create(ErrorCode.WITHOUT_PARAMS, null); // error
ERROR_FACTORY_WITHOUT_PARAMS.create(ErrorCode.WITHOUT_PARAMS, {}); // error
ERROR_FACTORY_WITHOUT_PARAMS.create(ErrorCode.WITHOUT_PARAMS, {
  param: 'param'
}); // error
ERROR_FACTORY_WITHOUT_PARAMS.create('randomCode'); // error
```