### PR TITLE
Refactor FirebaseError

### DIFF
--- a/packages/app-types/private.d.ts
+++ b/packages/app-types/private.d.ts
@@ -22,7 +22,7 @@
 
 import { FirebaseApp, FirebaseNamespace } from '@firebase/app-types';
 import { Observer, Subscribe } from '@firebase/util';
-import { FirebaseError } from '@firebase/util';
+import { FirebaseError, ErrorFactory } from '@firebase/util';
 
 export interface FirebaseServiceInternals {
   /**
@@ -59,18 +59,6 @@ export interface FirebaseServiceFactory {
  */
 export interface FirebaseServiceNamespace<T extends FirebaseService> {
   (app?: FirebaseApp): T;
-}
-
-export interface FirebaseErrorFactory<T> {
-  create(code: T, data?: { [prop: string]: any }): FirebaseError;
-}
-
-export interface FirebaseErrorFactoryClass {
-  new (
-    service: string,
-    serviceName: string,
-    errors: { [code: string]: string }
-  ): FirebaseErrorFactory<any>;
 }
 
 export interface FirebaseAuthTokenData {
@@ -155,6 +143,6 @@ export interface _FirebaseNamespace extends FirebaseNamespace {
     /**
      * Use to construct all thrown FirebaseError's.
      */
-    ErrorFactory: FirebaseErrorFactoryClass;
+    ErrorFactory: typeof ErrorFactory;
   };
 }

--- a/packages/app/src/errors.ts
+++ b/packages/app/src/errors.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { ErrorFactory } from '@firebase/util';
+import { ErrorFactory, ErrorMap } from '@firebase/util';
 
 export const enum AppError {
   NO_APP = 'no-app',
@@ -26,7 +26,7 @@ export const enum AppError {
   INVALID_APP_ARGUMENT = 'invalid-app-argument'
 }
 
-const errors: { readonly [code in AppError]: string } = {
+const errors: ErrorMap<AppError> = {
   [AppError.NO_APP]:
     "No Firebase App '{$name}' has been created - " +
     'call Firebase App.initializeApp()',
@@ -40,7 +40,7 @@ const errors: { readonly [code in AppError]: string } = {
     'Firebase App instance.'
 };
 
-let appErrors = new ErrorFactory<AppError>('app', 'Firebase', errors);
+const appErrors = new ErrorFactory('app', 'Firebase', errors);
 
 export function error(code: AppError, args?: { [name: string]: any }) {
   throw appErrors.create(code, args);

--- a/packages/messaging/src/models/errors.ts
+++ b/packages/messaging/src/models/errors.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { ErrorFactory } from '@firebase/util';
+import { ErrorFactory, ErrorMap } from '@firebase/util';
 
 export const enum ErrorCode {
   AVAILABLE_IN_WINDOW = 'only-available-in-window',
@@ -59,7 +59,7 @@ export const enum ErrorCode {
   PUBLIC_KEY_DECRYPTION_FAILED = 'public-vapid-key-decryption-failed'
 }
 
-export const ERROR_MAP: { [code in ErrorCode]: string } = {
+export const ERROR_MAP: ErrorMap<ErrorCode> = {
   [ErrorCode.AVAILABLE_IN_WINDOW]:
     'This method is available in a Window context.',
   [ErrorCode.AVAILABLE_IN_SW]:
@@ -156,7 +156,7 @@ export const ERROR_MAP: { [code in ErrorCode]: string } = {
     'The public VAPID key did not equal ' + '65 bytes when decrypted.'
 };
 
-export const errorFactory: ErrorFactory<string> = new ErrorFactory(
+export const errorFactory = new ErrorFactory(
   'messaging',
   'Messaging',
   ERROR_MAP

--- a/packages/util/index.ts
+++ b/packages/util/index.ts
@@ -28,9 +28,8 @@ export {
 } from './src/environment';
 export {
   ErrorFactory,
-  ErrorList,
+  ErrorMap,
   FirebaseError,
-  patchCapture,
   StringLike
 } from './src/errors';
 export { jsonEval, stringify } from './src/json';

--- a/packages/util/src/errors.ts
+++ b/packages/util/src/errors.ts
@@ -54,115 +54,95 @@
  *     }
  *   }
  */
-export type ErrorList<T> = { [code: string]: string };
+
+export type ErrorMap<ErrorCode extends string> = {
+  readonly [K in ErrorCode]: string
+};
 
 const ERROR_NAME = 'FirebaseError';
 
 export interface StringLike {
-  toString: () => string;
+  toString(): string;
 }
 
-let captureStackTrace: (obj: Object, fn?: Function) => void = (Error as any)
-  .captureStackTrace;
-
-// Export for faking in tests
-export function patchCapture(captureFake?: any): any {
-  let result: any = captureStackTrace;
-  captureStackTrace = captureFake;
-  return result;
+export interface ErrorData {
+  [key: string]: StringLike | undefined;
 }
 
-export interface FirebaseError {
-  // Unique code for error - format is service/error-code-string
-  code: string;
+export interface FirebaseError extends Error, ErrorData {
+  // Unique code for error - format is service/error-code-string.
+  readonly code: string;
 
   // Developer-friendly error message.
-  message: string;
+  readonly message: string;
 
-  // Always 'FirebaseError'
-  name: string;
+  // Always 'FirebaseError'.
+  readonly name: typeof ERROR_NAME;
 
-  // Where available - stack backtrace in a string
-  stack: string;
+  // Where available - stack backtrace in a string.
+  readonly stack?: string;
 }
 
-export class FirebaseError implements FirebaseError {
-  public stack: string;
-  public name: string;
+// Based on code from:
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error#Custom_Error_Types
+export class FirebaseError extends Error {
+  readonly name = ERROR_NAME;
 
-  constructor(public code: string, public message: string) {
-    let stack: string;
-    // We want the stack value, if implemented by Error
-    if (captureStackTrace) {
-      // Patches this.stack, omitted calls above ErrorFactory#create
-      captureStackTrace(this, ErrorFactory.prototype.create);
-    } else {
-      try {
-        // In case of IE11, stack will be set only after error is raised.
-        // https://docs.microsoft.com/en-us/scripting/javascript/reference/stack-property-error-javascript
-        throw Error.apply(this, arguments);
-      } catch (err) {
-        this.name = ERROR_NAME;
-        // Make non-enumerable getter for the property.
-        Object.defineProperty(this, 'stack', {
-          get: function() {
-            return err.stack;
-          }
-        });
-      }
+  constructor(readonly code: string, message: string) {
+    super(message);
+
+    // Fix For ES5
+    // https://github.com/Microsoft/TypeScript-wiki/blob/master/Breaking-Changes.md#extending-built-ins-like-error-array-and-map-may-no-longer-work
+    Object.setPrototypeOf(this, FirebaseError.prototype);
+
+    // Maintains proper stack trace for where our error was thrown.
+    // Only available on V8.
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, ErrorFactory.prototype.create);
     }
   }
 }
 
-// Back-door inheritance
-FirebaseError.prototype = Object.create(Error.prototype) as FirebaseError;
-FirebaseError.prototype.constructor = FirebaseError;
-(FirebaseError.prototype as any).name = ERROR_NAME;
-
-export class ErrorFactory<T extends string> {
-  // Matches {$name}, by default.
-  public pattern = /\{\$([^}]+)}/g;
-
+export class ErrorFactory<ErrorCode extends string> {
   constructor(
-    private service: string,
-    private serviceName: string,
-    private errors: ErrorList<T>
-  ) {
-    // empty
-  }
+    private readonly service: string,
+    private readonly serviceName: string,
+    private readonly errors: ErrorMap<ErrorCode>
+  ) {}
 
-  create(code: T, data?: { [prop: string]: StringLike }): FirebaseError {
-    if (data === undefined) {
-      data = {};
-    }
+  create(code: ErrorCode, data: ErrorData = {}): FirebaseError {
+    const fullCode = `${this.service}/${code}`;
+    const template = this.errors[code];
 
-    let template = this.errors[code as string];
+    const message = template ? replaceTemplate(template, data) : 'Error';
+    // Service Name: Error message (service/code).
+    const fullMessage = `${this.serviceName}: ${message} (${fullCode}).`;
 
-    let fullCode = this.service + '/' + code;
-    let message: string;
+    const error = new FirebaseError(fullCode, fullMessage);
 
-    if (template === undefined) {
-      message = 'Error';
-    } else {
-      message = template.replace(this.pattern, (match, key) => {
-        let value = data![key];
-        return value !== undefined ? value.toString() : '<' + key + '?>';
-      });
-    }
-
-    // Service: Error message (service/code).
-    message = this.serviceName + ': ' + message + ' (' + fullCode + ').';
-    let err = new FirebaseError(fullCode, message);
-
-    // Populate the Error object with message parts for programmatic
-    // accesses (e.g., e.file).
-    for (let prop in data) {
-      if (!data.hasOwnProperty(prop) || prop.slice(-1) === '_') {
-        continue;
+    // Keys with an underscore at the end of their name are not included in
+    // error.data for some reason.
+    // TODO: Replace with Object.entries when lib is updated to es2017.
+    for (const key of Object.keys(data)) {
+      if (key.slice(-1) !== '_') {
+        if (key in error) {
+          console.warn(
+            `Overwriting FirebaseError base field "${key}" can cause unexpected behavior.`
+          );
+        }
+        error[key] = data[key];
       }
-      (err as any)[prop] = data[prop];
     }
 
-    return err;
+    return error;
   }
 }
+
+function replaceTemplate(template: string, data: ErrorData): string {
+  return template.replace(PATTERN, (_, key) => {
+    const value = data[key];
+    return value != null ? value.toString() : `<${key}?>`;
+  });
+}
+
+const PATTERN = /\{\$([^}]+)}/g;

--- a/packages/util/test/errors.test.ts
+++ b/packages/util/test/errors.test.ts
@@ -15,102 +15,103 @@
  * limitations under the License.
  */
 import { assert } from 'chai';
-import { ErrorFactory, ErrorList, patchCapture } from '../src/errors';
+import { stub } from 'sinon';
+import { ErrorFactory, ErrorMap, FirebaseError } from '../src/errors';
 
-type Err = 'generic-error' | 'file-not-found' | 'anon-replace';
+type ErrorCode =
+  | 'generic-error'
+  | 'file-not-found'
+  | 'anon-replace'
+  | 'overwrite-field';
 
-let errors = {
+const ERROR_MAP: ErrorMap<ErrorCode> = {
   'generic-error': 'Unknown error',
   'file-not-found': "Could not find file: '{$file}'",
-  'anon-replace': 'Hello, {$repl_}!'
-} as ErrorList<Err>;
+  'anon-replace': 'Hello, {$repl_}!',
+  'overwrite-field':
+    'I decided to use {$code} to represent the error code from my server.'
+};
 
-let error = new ErrorFactory<Err>('fake', 'Fake', errors);
+const ERROR_FACTORY = new ErrorFactory<ErrorCode>('fake', 'Fake', ERROR_MAP);
 
 describe('FirebaseError', () => {
-  it('create', () => {
-    let e = error.create('generic-error');
+  it('creates an Error', () => {
+    const e = ERROR_FACTORY.create('generic-error');
+    assert.instanceOf(e, Error);
+    assert.instanceOf(e, FirebaseError);
     assert.equal(e.code, 'fake/generic-error');
     assert.equal(e.message, 'Fake: Unknown error (fake/generic-error).');
   });
 
-  it('String replacement', () => {
-    let e = error.create('file-not-found', { file: 'foo.txt' });
+  it('replaces template values with data', () => {
+    const e = ERROR_FACTORY.create('file-not-found', { file: 'foo.txt' });
     assert.equal(e.code, 'fake/file-not-found');
     assert.equal(
       e.message,
       "Fake: Could not find file: 'foo.txt' (fake/file-not-found)."
     );
-    assert.equal((e as any).file, 'foo.txt');
+    assert.equal(e.file, 'foo.txt');
   });
 
-  it('Anonymous String replacement', () => {
-    let e = error.create('anon-replace', { repl_: 'world' });
+  it('anonymously replaces template values with data', () => {
+    const e = ERROR_FACTORY.create('anon-replace', { repl_: 'world' });
     assert.equal(e.code, 'fake/anon-replace');
     assert.equal(e.message, 'Fake: Hello, world! (fake/anon-replace).');
-    assert.isUndefined((e as any).repl_);
+    assert.isUndefined(e.repl_);
   });
 
-  it('Missing template', () => {
+  it('uses "Error" as template when template is missing', () => {
     // Cast to avoid compile-time error.
-    let e = error.create(('no-such-code' as any) as Err);
+    const e = ERROR_FACTORY.create(('no-such-code' as any) as ErrorCode);
     assert.equal(e.code, 'fake/no-such-code');
     assert.equal(e.message, 'Fake: Error (fake/no-such-code).');
   });
 
-  it('Missing replacement', () => {
-    let e = error.create('file-not-found', { fileX: 'foo.txt' });
+  it('uses the key in the template if the replacement is missing', () => {
+    const e = ERROR_FACTORY.create('file-not-found', { fileX: 'foo.txt' });
     assert.equal(e.code, 'fake/file-not-found');
     assert.equal(
       e.message,
       "Fake: Could not find file: '<file?>' (fake/file-not-found)."
     );
   });
-});
 
-// Run the stack trace tests with, and without, Error.captureStackTrace
-let realCapture = patchCapture();
-stackTests(realCapture);
-stackTests(undefined);
+  it('warns if overwriting a base error field with custom data', () => {
+    const warnStub = stub(console, 'warn');
+    const e = ERROR_FACTORY.create('overwrite-field', {
+      code: 'overwritten code'
+    });
+    assert.equal(e.code, 'overwritten code');
+    // TODO: use sinon-chai for this.
+    assert.ok(
+      warnStub.calledOnceWith(
+        'Overwriting FirebaseError base field "code" can cause unexpected behavior.'
+      )
+    );
+    warnStub.restore();
+  });
 
-function stackTests(fakeCapture: any) {
-  let saveCapture: any;
+  it('has stack', () => {
+    const e = ERROR_FACTORY.create('generic-error');
+    // Multi-line match trick - .* does not match \n
+    assert.match(e.stack, /FirebaseError[\s\S]/);
+  });
 
-  describe(
-    'Error#stack tests - Error.captureStackTrace is ' +
-      (fakeCapture ? 'defined' : 'NOT defined'),
-    () => {
-      before(() => {
-        saveCapture = patchCapture(fakeCapture);
-      });
-
-      after(() => {
-        patchCapture(saveCapture);
-      });
-
-      it('has stack', () => {
-        let e = error.create('generic-error');
-        // Multi-line match trick - .* does not match \n
-        assert.match(e.stack, /FirebaseError[\s\S]/);
-      });
-
-      it('stack frames', () => {
-        try {
-          dummy1();
-          assert.ok(false);
-        } catch (e) {
-          assert.match(e.stack, /dummy2[\s\S]*?dummy1/);
-        }
-      });
+  it('has function names in stack trace in correct order', () => {
+    try {
+      dummy1();
+      assert.ok(false);
+    } catch (e) {
+      assert.instanceOf(e, FirebaseError);
+      assert.match(e.stack, /dummy2[\s\S]*?dummy1/);
     }
-  );
-}
+  });
+});
 
 function dummy1() {
   dummy2();
 }
 
 function dummy2() {
-  let error = new ErrorFactory<Err>('dummy', 'Dummy', errors);
-  throw error.create('generic-error');
+  throw ERROR_FACTORY.create('generic-error');
 }


### PR DESCRIPTION
- Fixes and improves types.
- Uses `extends Error` and `super` instead of messing with prototypes for inheritance.
- Fixes inheritance for ES5 using `setPrototypeOf`, [as recommended by TS](https://github.com/Microsoft/TypeScript-wiki/blob/master/Breaking-Changes.md#extending-built-ins-like-error-array-and-map-may-no-longer-work).
- Displays a console warning if an entry from `error.data` overwrites a `FirebaseError` property.
- Removes the ability to define a custom pattern for template replacement, which should make packages more consistent. Nobody was actually using that feature anyway.
- Removes `patchCapture`. We run our tests in many browsers, including IE11 and Edge, so there is no need to fake remove `captureStackTrace`.
- Renames `ErrorList` to `ErrorMap`.
- Uses the actual `ErrorFactory` types in app-types package.