### PR TITLE
Auth deprecation

### DIFF
--- a/packages/auth-types/index.d.ts
+++ b/packages/auth-types/index.d.ts
@@ -40,7 +40,9 @@ export interface User extends UserInfo {
   reauthenticateAndRetrieveDataWithCredential(
     credential: AuthCredential
   ): Promise<UserCredential>;
-  reauthenticateWithCredential(credential: AuthCredential): Promise<UserCredential>;
+  reauthenticateWithCredential(
+    credential: AuthCredential
+  ): Promise<UserCredential>;
   reauthenticateWithPhoneNumber(
     phoneNumber: string,
     applicationVerifier: ApplicationVerifier

--- a/packages/auth-types/index.d.ts
+++ b/packages/auth-types/index.d.ts
@@ -27,7 +27,7 @@ export interface User extends UserInfo {
   linkAndRetrieveDataWithCredential(
     credential: AuthCredential
   ): Promise<UserCredential>;
-  linkWithCredential(credential: AuthCredential): Promise<User>;
+  linkWithCredential(credential: AuthCredential): Promise<UserCredential>;
   linkWithPhoneNumber(
     phoneNumber: string,
     applicationVerifier: ApplicationVerifier
@@ -40,7 +40,7 @@ export interface User extends UserInfo {
   reauthenticateAndRetrieveDataWithCredential(
     credential: AuthCredential
   ): Promise<UserCredential>;
-  reauthenticateWithCredential(credential: AuthCredential): Promise<void>;
+  reauthenticateWithCredential(credential: AuthCredential): Promise<UserCredential>;
   reauthenticateWithPhoneNumber(
     phoneNumber: string,
     applicationVerifier: ApplicationVerifier
@@ -277,12 +277,7 @@ export class FirebaseAuth {
     email: string,
     password: string
   ): Promise<UserCredential>;
-  createUserAndRetrieveDataWithEmailAndPassword(
-    email: string,
-    password: string
-  ): Promise<UserCredential>;
   currentUser: User | null;
-  fetchProvidersForEmail(email: string): Promise<Array<string>>;
   fetchSignInMethodsForEmail(email: string): Promise<Array<string>>;
   isSignInWithEmailLink(emailLink: string): boolean;
   getRedirectResult(): Promise<UserCredential>;
@@ -311,15 +306,9 @@ export class FirebaseAuth {
     credential: AuthCredential
   ): Promise<UserCredential>;
   signInAnonymously(): Promise<UserCredential>;
-  signInAnonymouslyAndRetrieveData(): Promise<UserCredential>;
-  signInWithCredential(credential: AuthCredential): Promise<User>;
+  signInWithCredential(credential: AuthCredential): Promise<UserCredential>;
   signInWithCustomToken(token: string): Promise<UserCredential>;
-  signInAndRetrieveDataWithCustomToken(token: string): Promise<UserCredential>;
   signInWithEmailAndPassword(
-    email: string,
-    password: string
-  ): Promise<UserCredential>;
-  signInAndRetrieveDataWithEmailAndPassword(
     email: string,
     password: string
   ): Promise<UserCredential>;

--- a/packages/auth/src/auth.js
+++ b/packages/auth/src/auth.js
@@ -1433,36 +1433,6 @@ fireauth.Auth.prototype.signInWithCustomToken = function(token) {
 
 
 /**
- * Signs in a user asynchronously using a custom token and returns any
- * additional user info data or credentials returned form the backend. It has
- * been deprecated in favor of signInWithCustomToken.
- * @param {string} token The custom token to sign in with.
- * @return {!goog.Promise<!fireauth.AuthEventManager.Result>}
- */
-fireauth.Auth.prototype.signInAndRetrieveDataWithCustomToken = function(token) {
-  fireauth.deprecation.log(
-      fireauth.deprecation.Deprecations.SIGN_IN_WITH_CUSTOM_TOKEN);
-  return this.signInWithCustomToken(token);
-};
-
-
-/**
- * Sign in using an email and password and returns any additional user info
- * data or credentials returned form the backend. It has been deprecated in
- * favor of signInWithEmailAndPassword.
- * @param {string} email The email to sign in with.
- * @param {string} password The password to sign in with.
- * @return {!goog.Promise<!fireauth.AuthEventManager.Result>}
- */
-fireauth.Auth.prototype.signInAndRetrieveDataWithEmailAndPassword =
-    function(email, password) {
-  fireauth.deprecation.log(
-      fireauth.deprecation.Deprecations.SIGN_IN_WITH_EMAIL_AND_PASSWORD);
-  return this.signInWithEmailAndPassword(email, password);
-};
-
-
-/**
  * Sign in using an email and password and returns any additional user info
  * data or credentials returned form the backend.
  * @param {string} email The email to sign in with.
@@ -1503,46 +1473,12 @@ fireauth.Auth.prototype.createUserWithEmailAndPassword =
 
 
 /**
- * Creates a new email and password account and returns any additional user
- * info data or credentials returned form the backend. It has been deprecated
- * in favor of createUserWithEmailAndPassword.
- * @param {string} email The email to sign up with.
- * @param {string} password The password to sign up with.
- * @return {!goog.Promise<!fireauth.AuthEventManager.Result>}
- */
-fireauth.Auth.prototype.createUserAndRetrieveDataWithEmailAndPassword =
-    function(email, password) {
-  fireauth.deprecation.log(
-      fireauth.deprecation.Deprecations.CREATE_USER_WITH_EMAIL_AND_PASSWORD);
-  return this.createUserWithEmailAndPassword(email, password);
-};
-
-
-/**
- * Logs into Firebase with the given 3rd party credentials. It has been
- * deprecated in favor of signInAndRetrieveDataWithCredential.
- * @param {!fireauth.AuthCredential} credential The auth credential.
- * @return {!goog.Promise<!fireauth.AuthUser>}
- */
-fireauth.Auth.prototype.signInWithCredential = function(credential) {
-  fireauth.deprecation.log(
-      fireauth.deprecation.Deprecations.SIGN_IN_WITH_CREDENTIAL);
-  // Get signInAndRetrieveDataWithCredential result and return the user only.
-  return this.signInAndRetrieveDataWithCredential(credential)
-      .then(function(result) {
-        return result['user'];
-      });
-};
-
-
-/**
  * Logs into Firebase with the given 3rd party credentials and returns any
  * additional user info data or credentials returned form the backend.
  * @param {!fireauth.AuthCredential} credential The Auth credential.
  * @return {!goog.Promise<!fireauth.AuthEventManager.Result>}
  */
-fireauth.Auth.prototype.signInAndRetrieveDataWithCredential =
-    function(credential) {
+fireauth.Auth.prototype.signInWithCredential = function(credential) {
   // Credential could be extended in the future, so leave it to credential to
   // decide how to retrieve ID token.
   var self = this;
@@ -1554,6 +1490,21 @@ fireauth.Auth.prototype.signInAndRetrieveDataWithCredential =
     return self.signInWithIdTokenProvider_(
         credential.getIdTokenProvider(self.getRpcHandler()));
   });
+};
+
+
+/**
+ * Logs into Firebase with the given 3rd party credentials and returns any
+ * additional user info data or credentials returned form the backend. It has
+ * been deprecated in favor of signInWithCredential.
+ * @param {!fireauth.AuthCredential} credential The Auth credential.
+ * @return {!goog.Promise<!fireauth.AuthEventManager.Result>}
+ */
+fireauth.Auth.prototype.signInAndRetrieveDataWithCredential =
+    function(credential) {
+  fireauth.deprecation.log(
+      fireauth.deprecation.Deprecations.SIGN_IN_WITH_CREDENTIAL);
+  return this.signInWithCredential(credential);
 };
 
 
@@ -1604,19 +1555,6 @@ fireauth.Auth.prototype.signInAnonymously = function() {
           });
     }
   });
-};
-
-
-/**
- * Signs in a user anonymously and returns any additional user info data or
- * credentials returned form the backend. It has been deprecated in favor of
- * signInWithAnonymously.
- * @return {!goog.Promise<!fireauth.AuthEventManager.Result>}
- */
-fireauth.Auth.prototype.signInAnonymouslyAndRetrieveData = function() {
-  fireauth.deprecation.log(
-      fireauth.deprecation.Deprecations.SIGN_IN_ANONYMOUSLY);
-  return this.signInAnonymously();
 };
 
 
@@ -1863,22 +1801,6 @@ fireauth.Auth.prototype.registerPendingPromise_ = function(p) {
   });
   // Return the promise.
   return p;
-};
-
-
-/**
- * Gets the list of IDPs that can be used to log in for the given email address.
- * It has been deprecated in favor of fetchSignInMethodsForEmail.
- * @param {string} email The email address.
- * @return {!goog.Promise<!Array<!fireauth.idp.ProviderId>>}
- */
-fireauth.Auth.prototype.fetchProvidersForEmail = function(email) {
-  fireauth.deprecation.log(
-      fireauth.deprecation.Deprecations.FETCH_PROVIDERS_FOR_EMAIL);
-  return /** @type {!goog.Promise<!Array<!fireauth.idp.ProviderId>>} */ (
-      this.registerPendingPromise_(
-      this.getRpcHandler().fetchProvidersForIdentifier(email)
-      ));
 };
 
 

--- a/packages/auth/src/authuser.js
+++ b/packages/auth/src/authuser.js
@@ -1123,11 +1123,27 @@ fireauth.AuthUser.prototype.extractLinkedAccounts_ = function(resp) {
  * Reauthenticates a user using a fresh credential, to be used before operations
  * such as updatePassword that require tokens from recent login attempts. It
  * also returns any additional user info data or credentials returned form the
- * backend.
+ * backend. It has been deprecated in favor of reauthenticateWithCredential.
  * @param {!fireauth.AuthCredential} credential
  * @return {!goog.Promise<!fireauth.AuthEventManager.Result>}
  */
 fireauth.AuthUser.prototype.reauthenticateAndRetrieveDataWithCredential =
+    function(credential) {
+  fireauth.deprecation.log(
+      fireauth.deprecation.Deprecations.REAUTH_WITH_CREDENTIAL);
+  return this.reauthenticateWithCredential(credential);
+};
+
+
+/**
+ * Reauthenticates a user using a fresh credential, to be used before operations
+ * such as updatePassword that require tokens from recent login attempts. It
+ * also returns any additional user info data or credentials returned form the
+ * backend.
+ * @param {!fireauth.AuthCredential} credential
+ * @return {!goog.Promise<!fireauth.AuthEventManager.Result>}
+ */
+fireauth.AuthUser.prototype.reauthenticateWithCredential =
     function(credential) {
   var self = this;
   var userCredential = null;
@@ -1159,25 +1175,6 @@ fireauth.AuthUser.prototype.reauthenticateAndRetrieveDataWithCredential =
 
 
 /**
- * Reauthenticates a user using a fresh credential, to be used before operations
- * such as updatePassword that require tokens from recent login attempts. It has
- * been deprecated in favor of reauthenticateAndRetrieveDataWithCredential.
- * @param {!fireauth.AuthCredential} credential
- * @return {!goog.Promise<void>}
- */
-fireauth.AuthUser.prototype.reauthenticateWithCredential =
-    function(credential) {
-  fireauth.deprecation.log(
-      fireauth.deprecation.Deprecations.REAUTH_WITH_CREDENTIAL);
-  // Get reauthenticateAndRetrieveDataWithCredential result and return void.
-  return this.reauthenticateAndRetrieveDataWithCredential(credential)
-      .then(function(result) {
-        // Do not return anything. Promise should resolve with void.
-      });
-};
-
-
-/**
  * Reloads the user and then checks if a provider is already linked. If so,
  * this returns a Promise that rejects. Note that state change listeners are not
  * notified on success, so that operations using this can make changes and then
@@ -1205,13 +1202,28 @@ fireauth.AuthUser.prototype.checkIfAlreadyLinked_ =
 
 /**
  * Links a provider to the current user and returns any additional user info
- * data or credentials returned form the backend.
+ * data or credentials returned form the backend. It has been deprecated in
+ * favor of linkWithCredential.
  * @param {!fireauth.AuthCredential} credential The credential from the Auth
  *     provider.
  * @return {!goog.Promise<!fireauth.AuthEventManager.Result>}
  */
 fireauth.AuthUser.prototype.linkAndRetrieveDataWithCredential =
     function(credential) {
+  fireauth.deprecation.log(
+      fireauth.deprecation.Deprecations.LINK_WITH_CREDENTIAL);
+  return this.linkWithCredential(credential);
+};
+
+
+/**
+ * Links a provider to the current user and returns any additional user info
+ * data or credentials returned form the backend.
+ * @param {!fireauth.AuthCredential} credential The credential from the Auth
+ *     provider.
+ * @return {!goog.Promise<!fireauth.AuthEventManager.Result>}
+ */
+fireauth.AuthUser.prototype.linkWithCredential = function(credential) {
   var self = this;
   var userCredential = null;
   // Register this pending promise. This will also check for user invalidation.
@@ -1239,24 +1251,6 @@ fireauth.AuthUser.prototype.linkAndRetrieveDataWithCredential =
 
 
 /**
- * Links a provider to the current user. It has been deprecated in favor of
- * linkAndRetrieveDataWithCredential.
- * @param {!fireauth.AuthCredential} credential The credential from the Auth
- *     provider.
- * @return {!goog.Promise<!fireauth.AuthUser>}
- */
-fireauth.AuthUser.prototype.linkWithCredential = function(credential) {
-  fireauth.deprecation.log(
-      fireauth.deprecation.Deprecations.LINK_WITH_CREDENTIAL);
-  // Get linkAndRetrieveDataWithCredential result and return the user only.
-  return this.linkAndRetrieveDataWithCredential(credential)
-      .then(function(result) {
-        return result['user'];
-      });
-};
-
-
-/**
  * Links a phone number using the App verifier instance and returns a
  * promise that resolves with the confirmation result which on confirmation
  * will resolve with the UserCredential object.
@@ -1280,7 +1274,7 @@ fireauth.AuthUser.prototype.linkWithPhoneNumber =
                     phoneNumber,
                     appVerifier,
                     // This will check again if the credential is linked.
-                    goog.bind(self.linkAndRetrieveDataWithCredential, self));
+                    goog.bind(self.linkWithCredential, self));
               })));
 };
 
@@ -1307,7 +1301,7 @@ fireauth.AuthUser.prototype.reauthenticateWithPhoneNumber =
                 self.getAuth_(),
                 phoneNumber,
                 appVerifier,
-                goog.bind(self.reauthenticateAndRetrieveDataWithCredential,
+                goog.bind(self.reauthenticateWithCredential,
                     self));
           }),
           // Skip invalidation check as reauthentication could revalidate a

--- a/packages/auth/src/deprecation.js
+++ b/packages/auth/src/deprecation.js
@@ -36,9 +36,9 @@ fireauth.deprecation.Deprecations = {
   REAUTH_WITH_CREDENTIAL: 'firebase.User.prototype.reauthenticateAndRetrieveD' +
       'ataWithCredential is deprecated. Please use firebase.User.prototype.re' +
       'authenticateWithCredential instead.',
-  SIGN_IN_WITH_CREDENTIAL: 'firebase.auth.Auth.prototype.signInWithCredential' +
-      ' is deprecated. Please use firebase.auth.Auth.prototype.signInAndRetri' +
-      'eveDataWithCredential instead.'
+  SIGN_IN_WITH_CREDENTIAL: 'firebase.auth.Auth.prototype.signInAndRetrieveDat' +
+      'aWithCredential is deprecated. Please use firebase.auth.Auth.prototype' +
+      '.signInWithCredential instead.'
 };
 
 

--- a/packages/auth/src/deprecation.js
+++ b/packages/auth/src/deprecation.js
@@ -30,30 +30,15 @@ goog.require('fireauth.util');
  * @enum {string}
  */
 fireauth.deprecation.Deprecations = {
-  CREATE_USER_WITH_EMAIL_AND_PASSWORD: 'firebase.auth.Auth.prototype.createUs' +
-      'erAndRetrieveDataWithEmailAndPassword is deprecated. Please use fireba' +
-      'se.auth.Auth.prototype.createUserWithEmailAndPassword instead.',
-  FETCH_PROVIDERS_FOR_EMAIL: 'firebase.auth.Auth.prototype.fetchProvidersForE' +
-      'mail is deprecated. Please use firebase.auth.Auth.prototype.fetchSignI' +
-      'nMethodsForEmail instead.',
-  LINK_WITH_CREDENTIAL: 'firebase.User.prototype.linkWithCredential is deprec' +
-      'ated. Please use firebase.User.prototype.linkAndRetrieveDataWithCreden' +
+  LINK_WITH_CREDENTIAL: 'firebase.User.prototype.linkAndRetrieveDataWithCrede' +
+      'ntial is deprecated. Please use firebase.User.prototype.linkWithCreden' +
       'tial instead.',
-  REAUTH_WITH_CREDENTIAL: 'firebase.User.prototype.reauthenticateWithCredenti' +
-      'al is deprecated. Please use firebase.User.prototype.reauthenticateAnd' +
-      'RetrieveDataWithCredential instead.',
-  SIGN_IN_ANONYMOUSLY: 'firebase.auth.Auth.prototype.signInAnonymouslyAndRetr' +
-      'ieveData is deprecated. Please use firebase.auth.Auth.prototype.signIn' +
-      'Anonymously instead.',
+  REAUTH_WITH_CREDENTIAL: 'firebase.User.prototype.reauthenticateAndRetrieveD' +
+      'ataWithCredential is deprecated. Please use firebase.User.prototype.re' +
+      'authenticateWithCredential instead.',
   SIGN_IN_WITH_CREDENTIAL: 'firebase.auth.Auth.prototype.signInWithCredential' +
       ' is deprecated. Please use firebase.auth.Auth.prototype.signInAndRetri' +
-      'eveDataWithCredential instead.',
-  SIGN_IN_WITH_CUSTOM_TOKEN: 'firebase.auth.Auth.prototype.signInAndRetrieveD' +
-      'ataWithCustomToken is deprecated. Please use firebase.auth.Auth.protot' +
-      'ype.signInWithCustomToken instead.',
-  SIGN_IN_WITH_EMAIL_AND_PASSWORD: 'firebase.auth.Auth.prototype.signInAndRet' +
-      'rieveDataWithEmailAndPassword is deprecated. Please use firebase.auth.' +
-      'Auth.prototype.signInWithEmailAndPassword instead.'
+      'eveDataWithCredential instead.'
 };
 
 

--- a/packages/auth/src/exports_auth.js
+++ b/packages/auth/src/exports_auth.js
@@ -68,14 +68,6 @@ fireauth.exportlib.exportPrototypeMethods(
         name: 'createUserWithEmailAndPassword',
         args: [fireauth.args.string('email'), fireauth.args.string('password')]
       },
-      createUserAndRetrieveDataWithEmailAndPassword: {
-        name: 'createUserAndRetrieveDataWithEmailAndPassword',
-        args: [fireauth.args.string('email'), fireauth.args.string('password')]
-      },
-      fetchProvidersForEmail: {
-        name: 'fetchProvidersForEmail',
-        args: [fireauth.args.string('email')]
-      },
       fetchSignInMethodsForEmail: {
         name: 'fetchSignInMethodsForEmail',
         args: [fireauth.args.string('email')]
@@ -140,20 +132,12 @@ fireauth.exportlib.exportPrototypeMethods(
         name: 'signInAnonymously',
         args: []
       },
-      signInAnonymouslyAndRetrieveData: {
-        name: 'signInAnonymouslyAndRetrieveData',
-        args: []
-      },
       signInWithCredential: {
         name: 'signInWithCredential',
         args: [fireauth.args.authCredential()]
       },
       signInWithCustomToken: {
         name: 'signInWithCustomToken',
-        args: [fireauth.args.string('token')]
-      },
-      signInAndRetrieveDataWithCustomToken: {
-        name: 'signInAndRetrieveDataWithCustomToken',
         args: [fireauth.args.string('token')]
       },
       signInWithEmailAndPassword: {
@@ -165,10 +149,6 @@ fireauth.exportlib.exportPrototypeMethods(
         args: [
           fireauth.args.string('email'), fireauth.args.string('emailLink', true)
         ]
-      },
-      signInAndRetrieveDataWithEmailAndPassword: {
-        name: 'signInAndRetrieveDataWithEmailAndPassword',
-        args: [fireauth.args.string('email'), fireauth.args.string('password')]
       },
       signInWithPhoneNumber: {
         name: 'signInWithPhoneNumber',

--- a/packages/auth/test/auth_test.js
+++ b/packages/auth/test/auth_test.js
@@ -1359,44 +1359,6 @@ function testAuth_onAuthStateChanged() {
 }
 
 
-function testFetchProvidersForEmail() {
-  // Record deprecation warning calls.
-  stubs.replace(
-      fireauth.deprecation,
-      'log',
-      goog.testing.recordFunction());
-  var email = 'foo@bar.com';
-  var expectedProviders = ['bar.com', 'google.com'];
-
-  asyncTestCase.waitForSignals(1);
-
-  // Simulate successful RpcHandler fetchProvidersForIdentifier.
-  stubs.replace(
-      fireauth.RpcHandler.prototype,
-      'fetchProvidersForIdentifier',
-      function(data) {
-        assertObjectEquals(email, data);
-        return goog.Promise.resolve(expectedProviders);
-      });
-
-  app1 = firebase.initializeApp(config1, appId1);
-  auth1 = app1.auth();
-  auth1.fetchProvidersForEmail(email)
-      .then(function(providers) {
-        assertArrayEquals(expectedProviders, providers);
-        asyncTestCase.signal();
-      });
-  assertAuthTokenListenerCalledOnce(auth1);
-  // Confirm warning shown.
-  /** @suppress {missingRequire} */
-  assertEquals(1, fireauth.deprecation.log.getCallCount());
-  /** @suppress {missingRequire} */
-  assertEquals(
-      fireauth.deprecation.Deprecations.FETCH_PROVIDERS_FOR_EMAIL,
-      fireauth.deprecation.log.getLastCall().getArgument(0));
-}
-
-
 function testFetchSignInMethodsForEmail() {
   var email = 'foo@bar.com';
   var expectedSignInMethods = ['password', 'google.com'];
@@ -4197,93 +4159,6 @@ function testAuth_signInWithCustomToken_error() {
 }
 
 
-function testAuth_signInAndRetrieveDataWithCustomToken_success() {
-  // Tests successful signInAndRetrieveDataWithCustomToken.
-  // Record deprecation warning calls.
-  stubs.replace(
-      fireauth.deprecation,
-      'log',
-      goog.testing.recordFunction());
-  var expectedCustomToken = 'CUSTOM_TOKEN';
-  // Initialize expected user.
-  var user1 = new fireauth.AuthUser(
-      config3, expectedTokenResponse, accountInfo);
-  var expectedResult = {
-    'user': user1,
-    'credential': null,
-    'additionalUserInfo': {'providerId': null, 'isNewUser': false},
-    'operationType': fireauth.constants.OperationType.SIGN_IN
-  };
-  stubs.replace(
-      fireauth.Auth.prototype,
-      'signInWithCustomToken',
-      function(customToken) {
-        assertEquals(expectedCustomToken, customToken);
-        return goog.Promise.resolve(
-            fireauth.object.makeReadonlyCopy(expectedResult));
-      });
-  asyncTestCase.waitForSignals(1);
-  app1 = firebase.initializeApp(config3, appId1);
-  auth1 = app1.auth();
-  // Sign in and retrieve data with custom token.
-  auth1.signInAndRetrieveDataWithCustomToken(expectedCustomToken)
-      .then(function(result) {
-        // Returned user credential should match expected one.
-        fireauth.common.testHelper.assertUserCredentialResponse(
-            expectedResult['user'],
-            expectedResult['credential'],
-            expectedResult['additionalUserInfo'],
-            expectedResult['operationType'],
-            result);
-        asyncTestCase.signal();
-      });
-  // Confirm warning shown.
-  /** @suppress {missingRequire} */
-  assertEquals(1, fireauth.deprecation.log.getCallCount());
-  /** @suppress {missingRequire} */
-  assertEquals(
-      fireauth.deprecation.Deprecations.SIGN_IN_WITH_CUSTOM_TOKEN,
-      fireauth.deprecation.log.getLastCall().getArgument(0));
-}
-
-
-function testAuth_signInAndRetrieveDataWithCustomToken_error() {
-  // Tests unsuccessful signInAndRetrieveDataWithCustomToken.
-  // Record deprecation warning calls.
-  stubs.replace(
-      fireauth.deprecation,
-      'log',
-      goog.testing.recordFunction());
-  // Expected RPC error.
-  var expectedError =
-      new fireauth.AuthError(fireauth.authenum.Error.INTERNAL_ERROR);
-  var expectedCustomToken = 'CUSTOM_TOKEN';
-  stubs.replace(
-      fireauth.Auth.prototype,
-      'signInWithCustomToken',
-      function(customToken) {
-        assertEquals(expectedCustomToken, customToken);
-        return goog.Promise.reject(expectedError);
-      });
-  asyncTestCase.waitForSignals(1);
-  app1 = firebase.initializeApp(config3, appId1);
-  auth1 = app1.auth();
-  // signInAndRetrieveDataWithCustomToken should throw the expected error.
-  auth1.signInAndRetrieveDataWithCustomToken(expectedCustomToken)
-      .thenCatch(function(err) {
-        fireauth.common.testHelper.assertErrorEquals(expectedError, err);
-        asyncTestCase.signal();
-      });
-  // Confirm warning shown.
-  /** @suppress {missingRequire} */
-  assertEquals(1, fireauth.deprecation.log.getCallCount());
-  /** @suppress {missingRequire} */
-  assertEquals(
-      fireauth.deprecation.Deprecations.SIGN_IN_WITH_CUSTOM_TOKEN,
-      fireauth.deprecation.log.getLastCall().getArgument(0));
-}
-
-
 function testAuth_signInWithEmailLink_success() {
   // Tests successful signInWithEmailLink.
   fireauth.AuthEventManager.ENABLED = true;
@@ -4575,99 +4450,6 @@ function testAuth_signInWithEmailAndPassword_error() {
 }
 
 
-function testAuth_signInAndRetrieveDataWithEmailAndPassword_success() {
-  // Tests successful signInAndRetrieveDataWithEmailAndPassword.
-  // Record deprecation warning calls.
-  stubs.replace(
-      fireauth.deprecation,
-      'log',
-      goog.testing.recordFunction());
-  fireauth.AuthEventManager.ENABLED = true;
-  // Expected email and password.
-  var expectedEmail = 'user@example.com';
-  var expectedPass = 'password';
-  // Initialize expected user.
-  var user1 = new fireauth.AuthUser(
-      config3, expectedTokenResponse4, accountInfo);
-  var expectedResult = {
-    'user': user1,
-    'credential': null,
-    'additionalUserInfo': {'providerId': 'password', 'isNewUser': false},
-    'operationType': fireauth.constants.OperationType.SIGN_IN
-  };
-  stubs.replace(
-      fireauth.Auth.prototype,
-      'signInWithEmailAndPassword',
-      function(email, password) {
-        assertEquals(expectedEmail, email);
-        assertEquals(expectedPass, password);
-        return goog.Promise.resolve(
-            fireauth.object.makeReadonlyCopy(expectedResult));
-      });
-  asyncTestCase.waitForSignals(1);
-  app1 = firebase.initializeApp(config3, appId1);
-  auth1 = app1.auth();
-  // Sign in and retrieve data with email and password.
-  auth1.signInAndRetrieveDataWithEmailAndPassword(expectedEmail, expectedPass)
-      .then(function(result) {
-        fireauth.common.testHelper.assertUserCredentialResponse(
-            expectedResult['user'],
-            expectedResult['credential'],
-            expectedResult['additionalUserInfo'],
-            expectedResult['operationType'],
-            result);
-        asyncTestCase.signal();
-      });
-  // Confirm warning shown.
-  /** @suppress {missingRequire} */
-  assertEquals(1, fireauth.deprecation.log.getCallCount());
-  /** @suppress {missingRequire} */
-  assertEquals(
-      fireauth.deprecation.Deprecations.SIGN_IN_WITH_EMAIL_AND_PASSWORD,
-      fireauth.deprecation.log.getLastCall().getArgument(0));
-}
-
-
-function testAuth_signInAndRetrieveDataWithEmailAndPassword_error() {
-  // Tests unsuccessful signInAndRetrieveDataWithEmailAndPassword.
-  // Record deprecation warning calls.
-  stubs.replace(
-      fireauth.deprecation,
-      'log',
-      goog.testing.recordFunction());
-  fireauth.AuthEventManager.ENABLED = true;
-  // Expected email and password.
-  var expectedEmail = 'user@example.com';
-  var expectedPass = 'password';
-  // Expected RPC error.
-  var expectedError =
-      new fireauth.AuthError(fireauth.authenum.Error.INTERNAL_ERROR);
-  stubs.replace(
-      fireauth.Auth.prototype,
-      'signInWithEmailAndPassword',
-      function(email, password) {
-        assertEquals(expectedEmail, email);
-        assertEquals(expectedPass, password);
-        return goog.Promise.reject(expectedError);
-      });
-  asyncTestCase.waitForSignals(1);
-  app1 = firebase.initializeApp(config3, appId1);
-  auth1 = app1.auth();
-  auth1.signInAndRetrieveDataWithEmailAndPassword(expectedEmail, expectedPass)
-      .thenCatch(function(error) {
-        fireauth.common.testHelper.assertErrorEquals(expectedError, error);
-        asyncTestCase.signal();
-      });
-  // Confirm warning shown.
-  /** @suppress {missingRequire} */
-  assertEquals(1, fireauth.deprecation.log.getCallCount());
-  /** @suppress {missingRequire} */
-  assertEquals(
-      fireauth.deprecation.Deprecations.SIGN_IN_WITH_EMAIL_AND_PASSWORD,
-      fireauth.deprecation.log.getLastCall().getArgument(0));
-}
-
-
 function testAuth_createUserWithEmailAndPassword_success() {
   // Tests successful createUserWithEmailAndPassword.
   fireauth.AuthEventManager.ENABLED = true;
@@ -4767,101 +4549,9 @@ function testAuth_createUserWithEmailAndPassword_error() {
 }
 
 
-function testAuth_createUserAndRetrieveDataWithEmailAndPassword_success() {
-  // Tests successful createUserAndRetrieveDataWithEmailAndPassword.
-  // Record deprecation warning calls.
-  stubs.replace(
-      fireauth.deprecation,
-      'log',
-      goog.testing.recordFunction());
-  // Expected email and password.
-  var expectedEmail = 'user@example.com';
-  var expectedPass = 'password';
-  // Initialize expected user.
-  var user1 = new fireauth.AuthUser(
-      config3, expectedTokenResponse4, accountInfo);
-  var expectedResult = {
-    'user': user1,
-    'credential': null,
-    'additionalUserInfo': {'providerId': 'password', 'isNewUser': true},
-    'operationType': fireauth.constants.OperationType.SIGN_IN
-  };
-  stubs.replace(
-      fireauth.Auth.prototype,
-      'createUserWithEmailAndPassword',
-      function(email, password) {
-        assertEquals(expectedEmail, email);
-        assertEquals(expectedPass, password);
-        return goog.Promise.resolve(
-            fireauth.object.makeReadonlyCopy(expectedResult));
-      });
-  asyncTestCase.waitForSignals(1);
-  app1 = firebase.initializeApp(config3, appId1);
-  auth1 = app1.auth();
-  auth1.createUserAndRetrieveDataWithEmailAndPassword(
-      expectedEmail, expectedPass)
-      .then(function(result) {
-        fireauth.common.testHelper.assertUserCredentialResponse(
-            expectedResult['user'],
-            expectedResult['credential'],
-            expectedResult['additionalUserInfo'],
-            expectedResult['operationType'],
-            result);
-        asyncTestCase.signal();
-      });
-  // Confirm warning shown.
-  /** @suppress {missingRequire} */
-  assertEquals(1, fireauth.deprecation.log.getCallCount());
-  /** @suppress {missingRequire} */
-  assertEquals(
-      fireauth.deprecation.Deprecations.CREATE_USER_WITH_EMAIL_AND_PASSWORD,
-      fireauth.deprecation.log.getLastCall().getArgument(0));
-}
-
-
-function testAuth_createUserAndRetrieveDataWithEmailAndPassword_error() {
-  // Tests unsuccessful createUserAndRetrieveDataWithEmailAndPassword.
-  // Record deprecation warning calls.
-  stubs.replace(
-      fireauth.deprecation,
-      'log',
-      goog.testing.recordFunction());
-  // Expected email and password.
-  var expectedEmail = 'user@example.com';
-  var expectedPass = 'password';
-  // Expected RPC error.
-  var expectedError =
-      new fireauth.AuthError(fireauth.authenum.Error.INTERNAL_ERROR);
-  stubs.replace(
-      fireauth.Auth.prototype,
-      'createUserWithEmailAndPassword',
-      function(email, password) {
-        assertEquals(expectedEmail, email);
-        assertEquals(expectedPass, password);
-        return goog.Promise.reject(expectedError);
-      });
-  asyncTestCase.waitForSignals(1);
-  app1 = firebase.initializeApp(config3, appId1);
-  auth1 = app1.auth();
-  auth1.createUserAndRetrieveDataWithEmailAndPassword(
-      expectedEmail, expectedPass)
-      .thenCatch(function(error) {
-        fireauth.common.testHelper.assertErrorEquals(expectedError, error);
-        asyncTestCase.signal();
-      });
-  // Confirm warning shown.
-  /** @suppress {missingRequire} */
-  assertEquals(1, fireauth.deprecation.log.getCallCount());
-  /** @suppress {missingRequire} */
-  assertEquals(
-      fireauth.deprecation.Deprecations.CREATE_USER_WITH_EMAIL_AND_PASSWORD,
-      fireauth.deprecation.log.getLastCall().getArgument(0));
-}
-
-
-function testAuth_signInWithCredential_success() {
-  // Stub signInAndRetrieveDataWithCredential and confirm same response is used
-  // for signInWithCredential without only the user returned.
+function testAuth_signInAndRetrieveDataWithCredential_success() {
+  // Stub signInWithCredential and confirm same response is used for
+  // signInAndRetrieveDataWithCredential.
   // Record deprecation warning calls.
   stubs.replace(
       fireauth.deprecation,
@@ -4869,7 +4559,7 @@ function testAuth_signInWithCredential_success() {
       goog.testing.recordFunction());
   stubs.replace(
       fireauth.Auth.prototype,
-      'signInAndRetrieveDataWithCredential',
+      'signInWithCredential',
       function(cred) {
         assertEquals(expectedGoogleCredential, cred);
         return goog.Promise.resolve(expectedResponse);
@@ -4890,11 +4580,11 @@ function testAuth_signInWithCredential_success() {
     'additionalUserInfo': expectedAdditionalUserInfo,
     'operationType': fireauth.constants.OperationType.SIGN_IN
   };
-  // signInWithCredential using Google OAuth credential.
-  auth1.signInWithCredential(expectedGoogleCredential)
-      .then(function(user) {
+  // signInAndRetrieveDataWithCredential using Google OAuth credential.
+  auth1.signInAndRetrieveDataWithCredential(expectedGoogleCredential)
+      .then(function(userCredential) {
         // Confirm expected response.
-        assertEquals(user1, user);
+        assertEquals(expectedResponse, userCredential);
         asyncTestCase.signal();
       });
   // Confirm warning shown.
@@ -4907,9 +4597,9 @@ function testAuth_signInWithCredential_success() {
 }
 
 
-function testAuth_signInWithCredential_error() {
-  // Stub signInAndRetrieveDataWithCredential and confirm same error is thrown
-  // for signInWithCredential.
+function testAuth_signInAndRetrieveDataWithCredential_error() {
+  // Stub signInWithCredential and confirm same error is thrown for
+  // signInAndRetrieveDataWithCredential.
   // Record deprecation warning calls.
   stubs.replace(
       fireauth.deprecation,
@@ -4917,7 +4607,7 @@ function testAuth_signInWithCredential_error() {
       goog.testing.recordFunction());
   stubs.replace(
       fireauth.Auth.prototype,
-      'signInAndRetrieveDataWithCredential',
+      'signInWithCredential',
       function(cred) {
         assertEquals(expectedGoogleCredential, cred);
         return goog.Promise.reject(expectedError);
@@ -4931,8 +4621,8 @@ function testAuth_signInWithCredential_error() {
   // Expected error.
   var expectedError = new fireauth.AuthError(
       fireauth.authenum.Error.NEED_CONFIRMATION);
-  // signInWithCredential using Google OAuth credential.
-  auth1.signInWithCredential(expectedGoogleCredential)
+  // signInAndRetrieveDataWithCredential using Google OAuth credential.
+  auth1.signInAndRetrieveDataWithCredential(expectedGoogleCredential)
       .thenCatch(function(error) {
         // Confirm expected error.
         fireauth.common.testHelper.assertErrorEquals(expectedError, error);
@@ -4948,9 +4638,8 @@ function testAuth_signInWithCredential_error() {
 }
 
 
-function testAuth_signInAndRetrieveDataWithCredential_success() {
-  // Tests successful signInAndRetrieveDataWithCredential using OAuth
-  // credential.
+function testAuth_signInWithCredential_success() {
+  // Tests successful signInWithCredential using OAuth credential.
   fireauth.AuthEventManager.ENABLED = true;
   // Simulate successful RpcHandler verifyAssertion.
   stubs.replace(
@@ -4996,8 +4685,8 @@ function testAuth_signInAndRetrieveDataWithCredential_success() {
   // Initialize expected user.
   var user1 = new fireauth.AuthUser(
       config3, expectedTokenResponse, accountInfo);
-  // signInAndRetrieveDataWithCredential using Google OAuth credential.
-  auth1.signInAndRetrieveDataWithCredential(expectedGoogleCredential)
+  // signInWithCredential using Google OAuth credential.
+  auth1.signInWithCredential(expectedGoogleCredential)
       .then(function(result) {
         // Confirm fireauth.Auth.prototype.signInWithIdTokenResponse is called
         // underneath. This will save the new user in storage and trigger auth
@@ -5029,9 +4718,9 @@ function testAuth_signInAndRetrieveDataWithCredential_success() {
 }
 
 
-function testAuth_signInAndRetrieveDataWithCredential_nonhttp_success() {
-  // Tests successful signInAndRetrieveDataWithCredential using OAuth credential
-  // in a non HTTP environment.
+function testAuth_signInWithCredential_nonhttp_success() {
+  // Tests successful signInWithCredential using OAuth credential in a non
+  // HTTP environment.
   fireauth.AuthEventManager.ENABLED = true;
   // Non http or https environment.
   stubs.replace(
@@ -5088,8 +4777,8 @@ function testAuth_signInAndRetrieveDataWithCredential_nonhttp_success() {
   // Initialize expected user.
   var user1 = new fireauth.AuthUser(
       config3, expectedTokenResponse, accountInfo);
-  // signInAndRetrieveDataWithCredential using Google OAuth credential.
-  auth1.signInAndRetrieveDataWithCredential(expectedGoogleCredential)
+  // signInWithCredential using Google OAuth credential.
+  auth1.signInWithCredential(expectedGoogleCredential)
       .then(function(result) {
         // Confirm fireauth.Auth.prototype.signInWithIdTokenResponse is called
         // underneath. This will save the new user in storage and trigger Auth
@@ -5121,9 +4810,8 @@ function testAuth_signInAndRetrieveDataWithCredential_nonhttp_success() {
 }
 
 
-function testAuth_signInAndRetrieveDataWithCredential_emailPassCredential() {
-  // Tests successful signInAndRetrieveDataWithCredential using email and
-  // password credential.
+function testAuth_signInWithCredential_emailPassCredential() {
+  // Tests successful signInWithCredential using email and password credential.
   fireauth.AuthEventManager.ENABLED = true;
   // Expected email and password.
   var expectedEmail = 'user@example.com';
@@ -5170,8 +4858,8 @@ function testAuth_signInAndRetrieveDataWithCredential_emailPassCredential() {
   auth1 = app1.auth();
   // Email/password credential.
   var cred = fireauth.EmailAuthProvider.credential(expectedEmail, expectedPass);
-  // signInAndRetrieveDataWithCredential using email and password credential.
-  auth1.signInAndRetrieveDataWithCredential(cred)
+  // signInWithCredential using email and password credential.
+  auth1.signInWithCredential(cred)
       .then(function(result) {
         // Confirm fireauth.Auth.prototype.signInWithIdTokenResponse is called
         // underneath. This will save the new user in storage and trigger Auth
@@ -5203,8 +4891,8 @@ function testAuth_signInAndRetrieveDataWithCredential_emailPassCredential() {
 }
 
 
-function testAuth_signInAndRetrieveDataWithCredential_error() {
-  // Tests unsuccessful signInAndRetrieveDataWithCredential.
+function testAuth_signInWithCredential_error() {
+  // Tests unsuccessful signInWithCredential.
   fireauth.AuthEventManager.ENABLED = true;
   // Expected rpc error.
   var expectedError = new fireauth.AuthError(
@@ -5237,9 +4925,9 @@ function testAuth_signInAndRetrieveDataWithCredential_error() {
   asyncTestCase.waitForSignals(1);
   app1 = firebase.initializeApp(config3, appId1);
   auth1 = app1.auth();
-  // signInAndRetrieveDataWithCredential with a Google credential should throw
+  // signInWithCredential with a Google credential should throw
   // the expected error.
-  auth1.signInAndRetrieveDataWithCredential(expectedGoogleCredential)
+  auth1.signInWithCredential(expectedGoogleCredential)
       .thenCatch(function(error) {
         fireauth.common.testHelper.assertErrorEquals(expectedError, error);
         asyncTestCase.signal();
@@ -5440,80 +5128,6 @@ function testAuth_signInAnonymously_error() {
   auth1 = app1.auth();
   // signInAnonymously should fail with expected error.
   auth1.signInAnonymously().thenCatch(function(error) {
-    fireauth.common.testHelper.assertErrorEquals(expectedError, error);
-    asyncTestCase.signal();
-  });
-}
-
-
-function testAuth_signInAnonymouslyAndRetrieveData_success() {
-  // Tests successful signInAnonymouslyAndRetrieveData.
-  // Record deprecation warning calls.
-  stubs.replace(
-      fireauth.deprecation,
-      'log',
-      goog.testing.recordFunction());
-  // Initialize expected anonymous user.
-  var user1 = new fireauth.AuthUser(
-      config3, expectedTokenResponse, accountInfo);
-  var expectedResult = {
-    'user': user1,
-    'credential': null,
-    'additionalUserInfo': {'providerId': null, 'isNewUser': true},
-    'operationType': fireauth.constants.OperationType.SIGN_IN
-  };
-  stubs.replace(
-      fireauth.Auth.prototype,
-      'signInAnonymously',
-      function() {
-        user1.updateProperty('isAnonymous', true);
-        return goog.Promise.resolve(
-            fireauth.object.makeReadonlyCopy(expectedResult));
-      });
-  asyncTestCase.waitForSignals(1);
-  app1 = firebase.initializeApp(config3, appId1);
-  auth1 = app1.auth();
-  auth1.signInAnonymouslyAndRetrieveData().then(function(result) {
-    fireauth.common.testHelper.assertUserCredentialResponse(
-            expectedResult['user'],
-            expectedResult['credential'],
-            expectedResult['additionalUserInfo'],
-            expectedResult['operationType'],
-            result);
-    assertTrue(result['user']['isAnonymous']);
-    asyncTestCase.signal();
-  });
-  // Confirm warning shown.
-  /** @suppress {missingRequire} */
-  assertEquals(1, fireauth.deprecation.log.getCallCount());
-  /** @suppress {missingRequire} */
-  assertEquals(
-      fireauth.deprecation.Deprecations.SIGN_IN_ANONYMOUSLY,
-      fireauth.deprecation.log.getLastCall().getArgument(0));
-}
-
-
-function testAuth_signInAnonymouslyAndRetrieveData_error() {
-  // Tests unsuccessful signInAnonymouslyAndRetrieveData.
-  // Record deprecation warning calls.
-  stubs.replace(
-      fireauth.deprecation,
-      'log',
-      goog.testing.recordFunction());
-  // Expected RPC error.
-  var expectedError = new fireauth.AuthError(
-      fireauth.authenum.Error.INTERNAL_ERROR);
-  stubs.replace(
-      fireauth.Auth.prototype,
-      'signInAnonymously',
-      function() {
-        return goog.Promise.reject(expectedError);
-      });
-  asyncTestCase.waitForSignals(1);
-  app1 = firebase.initializeApp(config3, appId1);
-  auth1 = app1.auth();
-  // signInAnonymouslyAndRetrieveData should fail with expected error.
-  auth1.signInAnonymouslyAndRetrieveData().thenCatch(function(error) {
     fireauth.common.testHelper.assertErrorEquals(expectedError, error);
     asyncTestCase.signal();
   });
@@ -9471,7 +9085,7 @@ function testAuth_signInWithPhoneNumber_success() {
       return goog.Promise.resolve(expectedRecaptchaToken);
     }
   };
-  // Expected promise to be returned by signInAndRetrieveDataWithCredential.
+  // Expected promise to be returned by signInWithCredential.
   var expectedPromise = new goog.Promise(function(resolve, reject) {});
   // Phone Auth provider instance.
   var phoneAuthProviderInstance =
@@ -9489,11 +9103,11 @@ function testAuth_signInWithPhoneNumber_success() {
   phoneAuthProviderInstance.verifyPhoneNumber(
       expectedPhoneNumber, appVerifier)
       .$returns(goog.Promise.resolve(expectedVerificationId)).$once();
-  // Code confirmation should call signInAndRetrieveDataWithCredential with the
-  // expected credential.
+  // Code confirmation should call signInWithCredential with the expected
+  // credential.
   stubs.replace(
       fireauth.Auth.prototype,
-      'signInAndRetrieveDataWithCredential',
+      'signInWithCredential',
       goog.testing.recordFunction(function(cred) {
         // Confirm expected credential passed.
         assertObjectEquals(
@@ -9517,12 +9131,11 @@ function testAuth_signInWithPhoneNumber_success() {
         // Confirm signInAndRetrieveDataWithCredential called once.
         assertEquals(
             1,
-            fireauth.Auth.prototype.signInAndRetrieveDataWithCredential
-                .getCallCount());
+            fireauth.Auth.prototype.signInWithCredential.getCallCount());
         // Confirm signInAndRetrieveDataWithCredential is bound to auth1.
         assertEquals(
             auth1,
-            fireauth.Auth.prototype.signInAndRetrieveDataWithCredential
+            fireauth.Auth.prototype.signInWithCredential
                 .getLastCall().getThis());
         asyncTestCase.signal();
       });

--- a/packages/firebase/externs/firebase-auth-externs.js
+++ b/packages/firebase/externs/firebase-auth-externs.js
@@ -70,7 +70,6 @@ firebase.auth.AuthCredential.prototype.providerId;
  */
 firebase.auth.AuthCredential.prototype.signInMethod;
 
-
 /**
  * Static method to deserialize a JSON representation of an object into an
  * {@link firebase.auth.AuthCredential}. Input can be either Object or the
@@ -83,13 +82,11 @@ firebase.auth.AuthCredential.prototype.signInMethod;
  */
 firebase.auth.AuthCredential.fromJSON = function(json) {};
 
-
 /**
  * Returns a JSON-serializable representation of this object.
  * @return {!Object} The plain object representation of the `AuthCredential`.
  */
 firebase.auth.AuthCredential.prototype.toJSON = function() {};
-
 
 /**
  * Interface that represents the OAuth credentials returned by an OAuth

--- a/packages/firebase/externs/firebase-auth-externs.js
+++ b/packages/firebase/externs/firebase-auth-externs.js
@@ -336,9 +336,6 @@ firebase.User.prototype.sendEmailVerification = function(actionCodeSettings) {};
 /**
  * Links the user account with the given credentials.
  *
- * This method is deprecated. Use
- * {@link firebase.User#linkAndRetrieveDataWithCredential} instead.
- *
  * <h4>Error Codes</h4>
  * <dl>
  * <dt>auth/provider-already-linked</dt>
@@ -369,7 +366,7 @@ firebase.User.prototype.sendEmailVerification = function(actionCodeSettings) {};
  *     ({@link firebase.auth.AuthCredential}) fields are also provided.
  *     You have to link the credential to the existing user with that email if
  *     you wish to continue signing in with that credential. To do so, call
- *     {@link firebase.auth.Auth#fetchProvidersForEmail}, sign in to
+ *     {@link firebase.auth.Auth#fetchSignInMethodsForEmail}, sign in to
  *     <code>error.email</code> via one of the providers returned and then
  *     {@link firebase.User#linkWithCredential} the original credential to that
  *     newly signed in user.</dd>
@@ -395,13 +392,16 @@ firebase.User.prototype.sendEmailVerification = function(actionCodeSettings) {};
  * </dl>
  *
  * @param {!firebase.auth.AuthCredential} credential The auth credential.
- * @return {!firebase.Promise<!firebase.User>}
+ * @return {!firebase.Promise<!firebase.auth.UserCredential>}
  */
 firebase.User.prototype.linkWithCredential = function(credential) {};
 
 /**
  * Links the user account with the given credentials, and returns any available
  * additional user information, such as user name.
+ *
+ * This method is deprecated. Use
+ * {@link firebase.User#linkWithCredential} instead.
  *
  * <h4>Error Codes</h4>
  * <dl>
@@ -433,7 +433,7 @@ firebase.User.prototype.linkWithCredential = function(credential) {};
  *     ({@link firebase.auth.AuthCredential}) fields are also provided.
  *     You have to link the credential to the existing user with that email if
  *     you wish to continue signing in with that credential. To do so, call
- *     {@link firebase.auth.Auth#fetchProvidersForEmail}, sign in to
+ *     {@link firebase.auth.Auth#fetchSignInMethodsForEmail}, sign in to
  *     <code>error.email</code> via one of the providers returned and then
  *     {@link firebase.User#linkWithCredential} the original credential to that
  *     newly signed in user.</dd>
@@ -531,9 +531,6 @@ firebase.User.prototype.unlink = function(providerId) {};
  * such as {@link firebase.User#updatePassword} that require tokens from recent
  * sign-in attempts.
  *
- * This method is deprecated. Use
- * {@link firebase.User#reauthenticateAndRetrieveDataWithCredential} instead.
- *
  * <h4>Error Codes</h4>
  * <dl>
  * <dt>auth/user-mismatch</dt>
@@ -564,7 +561,7 @@ firebase.User.prototype.unlink = function(providerId) {};
  * </dl>
  *
  * @param {!firebase.auth.AuthCredential} credential
- * @return {!firebase.Promise<void>}
+ * @return {!firebase.Promise<firebase.auth.UserCredential>}
  */
 firebase.User.prototype.reauthenticateWithCredential = function(credential) {};
 
@@ -573,6 +570,9 @@ firebase.User.prototype.reauthenticateWithCredential = function(credential) {};
  * additional user information, such as user name. Use before operations
  * such as {@link firebase.User#updatePassword} that require tokens from recent
  * sign-in attempts.
+ *
+ * This method is deprecated. Use
+ * {@link firebase.User#reauthenticateWithCredential} instead.
  *
  * <h4>Error Codes</h4>
  * <dl>
@@ -1060,60 +1060,6 @@ firebase.auth.Auth.prototype.settings;
 
 /**
  * Creates a new user account associated with the specified email address and
- * password and returns any additional user info data or credentials.
- *
- * This method is deprecated. Use
- * {@link firebase.auth.Auth#createUserWithEmailAndPassword} instead.
- *
- * On successful creation of the user account, this user will also be
- * signed in to your application.
- *
- * User account creation can fail if the account already exists or the password
- * is invalid.
- *
- * Note: The email address acts as a unique identifier for the user and
- * enables an email-based password reset.  This function will create
- * a new user account and set the initial user password.
- *
- * <h4>Error Codes</h4>
- * <dl>
- * <dt>auth/email-already-in-use</dt>
- * <dd>Thrown if there already exists an account with the given email
- *     address.</dd>
- * <dt>auth/invalid-email</dt>
- * <dd>Thrown if the email address is not valid.</dd>
- * <dt>auth/operation-not-allowed</dt>
- * <dd>Thrown if email/password accounts are not enabled. Enable email/password
- *     accounts in the Firebase Console, under the Auth tab.</dd>
- * <dt>auth/weak-password</dt>
- * <dd>Thrown if the password is not strong enough.</dd>
- * </dl>
- *
- * @example
- * firebase.auth().createUserAndRetrieveDataWithEmailAndPassword(email, password)
- *     .catch(function(error) {
- *       // Handle Errors here.
- *       var errorCode = error.code;
- *       var errorMessage = error.message;
- *       if (errorCode == 'auth/weak-password') {
- *         alert('The password is too weak.');
- *       } else {
- *         alert(errorMessage);
- *       }
- *       console.log(error);
- *     });
- *
- * @param {string} email The user's email address.
- * @param {string} password The user's chosen password.
- * @return {!firebase.Promise<!firebase.auth.UserCredential>}
- */
-firebase.auth.Auth.prototype.createUserAndRetrieveDataWithEmailAndPassword = function(
-  email,
-  password
-) {};
-
-/**
- * Creates a new user account associated with the specified email address and
  * password.
  *
  * On successful creation of the user account, this user will also be
@@ -1162,24 +1108,6 @@ firebase.auth.Auth.prototype.createUserWithEmailAndPassword = function(
   email,
   password
 ) {};
-
-/**
- * Gets the list of provider IDs that can be used to sign in for the given email
- * address. Useful for an "identifier-first" sign-in flow.
- *
- * This method is deprecated. Use
- * {@link firebase.auth.Auth#fetchSignInMethodsForEmail} instead.
- *
- * <h4>Error Codes</h4>
- * <dl>
- * <dt>auth/invalid-email</dt>
- * <dd>Thrown if the email address is not valid.</dd>
- * </dl>
- *
- * @param {string} email An email address.
- * @return {!firebase.Promise<!Array<string>>}
- */
-firebase.auth.Auth.prototype.fetchProvidersForEmail = function(email) {};
 
 /**
  * Gets the list of possible sign in methods for the given email address. This
@@ -1443,15 +1371,12 @@ firebase.auth.Auth.prototype.confirmPasswordReset = function(
 /**
  * Asynchronously signs in with the given credentials.
  *
- * This method is deprecated. Use
- * {@link firebase.auth.Auth#signInAndRetrieveDataWithCredential} instead.
- *
  * <h4>Error Codes</h4>
  * <dl>
  * <dt>auth/account-exists-with-different-credential</dt>
  * <dd>Thrown if there already exists an account with the email address
  *     asserted by the credential. Resolve this by calling
- *     {@link firebase.auth.Auth#fetchProvidersForEmail} and then asking the
+ *     {@link firebase.auth.Auth#fetchSignInMethodsForEmail} and then asking the
  *     user to sign in using one of the returned providers. Once the user is
  *     signed in, the original credential can be linked to the user with
  *     {@link firebase.User#linkWithCredential}.</dd>
@@ -1501,7 +1426,7 @@ firebase.auth.Auth.prototype.confirmPasswordReset = function(
  *  });
  *
  * @param {!firebase.auth.AuthCredential} credential The auth credential.
- * @return {!firebase.Promise<!firebase.User>}
+ * @return {!firebase.Promise<!firebase.auth.UserCredential>}
  */
 firebase.auth.Auth.prototype.signInWithCredential = function(credential) {};
 
@@ -1509,12 +1434,15 @@ firebase.auth.Auth.prototype.signInWithCredential = function(credential) {};
  * Asynchronously signs in with the given credentials, and returns any available
  * additional user information, such as user name.
  *
+ * This method is deprecated. Use
+ * {@link firebase.auth.Auth#signInWithCredential} instead.
+ *
  * <h4>Error Codes</h4>
  * <dl>
  * <dt>auth/account-exists-with-different-credential</dt>
  * <dd>Thrown if there already exists an account with the email address
  *     asserted by the credential. Resolve this by calling
- *     {@link firebase.auth.Auth#fetchProvidersForEmail} and then asking the
+ *     {@link firebase.auth.Auth#fetchSignInMethodsForEmail} and then asking the
  *     user to sign in using one of the returned providers. Once the user is
  *     signed in, the original credential can be linked to the user with
  *     {@link firebase.User#linkWithCredential}.</dd>
@@ -1560,47 +1488,6 @@ firebase.auth.Auth.prototype.signInAndRetrieveDataWithCredential = function(
 ) {};
 
 /**
- * Signs in a user asynchronously using a custom token and returns any
- * additional user info data or credentials.
- *
- * This method is deprecated. Use
- * {@link firebase.auth.Auth#signInWithCustomToken} instead.
- *
- * Custom tokens are used to integrate Firebase Auth with existing auth systems,
- * and must be generated by the auth backend.
- *
- * Fails with an error if the token is invalid, expired, or not accepted by the
- * Firebase Auth service.
- *
- * <h4>Error Codes</h4>
- * <dl>
- * <dt>auth/custom-token-mismatch</dt>
- * <dd>Thrown if the custom token is for a different Firebase App.</dd>
- * <dt>auth/invalid-custom-token</dt>
- * <dd>Thrown if the custom token format is incorrect.</dd>
- * </dl>
- *
- * @example
- * firebase.auth().signInAndRetrieveDataWithCustomToken(token)
- *     .catch(function(error) {
- *       // Handle Errors here.
- *       var errorCode = error.code;
- *       var errorMessage = error.message;
- *       if (errorCode === 'auth/invalid-custom-token') {
- *         alert('The token you provided is not valid.');
- *       } else {
- *         console.error(error);
- *       }
- *     });
- *
- * @param {string} token The custom token to sign in with.
- * @return {!firebase.Promise<!firebase.auth.UserCredential>}
- */
-firebase.auth.Auth.prototype.signInAndRetrieveDataWithCustomToken = function(
-  token
-) {};
-
-/**
  * Asynchronously signs in using a custom token.
  *
  * Custom tokens are used to integrate Firebase Auth with existing auth systems,
@@ -1633,59 +1520,6 @@ firebase.auth.Auth.prototype.signInAndRetrieveDataWithCustomToken = function(
  * @return {!firebase.Promise<!firebase.auth.UserCredential>}
  */
 firebase.auth.Auth.prototype.signInWithCustomToken = function(token) {};
-
-/**
- * Asynchronously signs in using an email and password and returns any additional
- * user info data or credentials.
- *
- * This method is deprecated. Use
- * {@link firebase.auth.Auth#signInWithEmailAndPassword} instead.
- *
- * Fails with an error if the email address and password do not match.
- *
- * Note: The user's password is NOT the password used to access the user's email
- * account. The email address serves as a unique identifier for the user, and
- * the password is used to access the user's account in your Firebase project.
- *
- * See also:
- * {@link firebase.auth.Auth#createUserAndRetrieveDataWithEmailAndPassword}.
- *
- * <h4>Error Codes</h4>
- * <dl>
- * <dt>auth/invalid-email</dt>
- * <dd>Thrown if the email address is not valid.</dd>
- * <dt>auth/user-disabled</dt>
- * <dd>Thrown if the user corresponding to the given email has been
- *     disabled.</dd>
- * <dt>auth/user-not-found</dt>
- * <dd>Thrown if there is no user corresponding to the given email.</dd>
- * <dt>auth/wrong-password</dt>
- * <dd>Thrown if the password is invalid for the given email, or the account
- *     corresponding to the email does not have a password set.</dd>
- * </dl>
- *
- * @example
- * firebase.auth().signInAndRetrieveDataWithEmailAndPassword(email, password)
- *     .catch(function(error) {
- *       // Handle Errors here.
- *       var errorCode = error.code;
- *       var errorMessage = error.message;
- *       if (errorCode === 'auth/wrong-password') {
- *         alert('Wrong password.');
- *       } else {
- *         alert(errorMessage);
- *       }
- *       console.log(error);
- *     });
- *
- * @param {string} email The users email address.
- * @param {string} password The users password.
- * @return {!firebase.Promise<!firebase.auth.UserCredential>}
- */
-firebase.auth.Auth.prototype.signInAndRetrieveDataWithEmailAndPassword = function(
-  email,
-  password
-) {};
 
 /**
  * Asynchronously signs in using an email and password.
@@ -1860,41 +1694,6 @@ firebase.auth.ConfirmationResult.prototype.verificationId;
 firebase.auth.ConfirmationResult.prototype.confirm = function(
   verificationCode
 ) {};
-
-/**
- * Signs in a user anonymously and returns any additional user info data or
- * credentials.
- *
- * This method is deprecated. Use
- * {@link firebase.auth.Auth#signInAnonymously} instead.
- *
- * If there is already an anonymous user signed in, that user with
- * additional date will be returned; otherwise, a new anonymous user
- * identity will be created and returned.
- *
- * <h4>Error Codes</h4>
- * <dl>
- * <dt>auth/operation-not-allowed</dt>
- * <dd>Thrown if anonymous accounts are not enabled. Enable anonymous accounts
- *     in the Firebase Console, under the Auth tab.</dd>
- * </dl>
- *
- * @example
- * firebase.auth().signInAnonymouslyAndRetrieveData().catch(function(error) {
- *   // Handle Errors here.
- *   var errorCode = error.code;
- *   var errorMessage = error.message;
- *
- *   if (errorCode === 'auth/operation-not-allowed') {
- *     alert('You must enable Anonymous auth in the Firebase Console.');
- *   } else {
- *     console.error(error);
- *   }
- * });
- *
- * @return {!firebase.Promise<!firebase.auth.UserCredential>}
- */
-firebase.auth.Auth.prototype.signInAnonymouslyAndRetrieveData = function() {};
 
 /**
  * Asynchronously signs in as an anonymous user.

--- a/packages/firebase/index.d.ts
+++ b/packages/firebase/index.d.ts
@@ -129,6 +129,9 @@ declare namespace firebase {
      * Links the user account with the given credentials and returns any available
      * additional user information, such as user name.
      *
+     * This method is deprecated. Use
+     * {@link firebase.User.linkWithCredential} instead.
+     *
      * <h4>Error Codes</h4>
      * <dl>
      * <dt>auth/provider-already-linked</dt>
@@ -159,7 +162,7 @@ declare namespace firebase {
      *     ({@link firebase.auth.AuthCredential}) fields are also provided.
      *     You have to link the credential to the existing user with that email if
      *     you wish to continue signing in with that credential. To do so, call
-     *     {@link firebase.auth.Auth.fetchProvidersForEmail}, sign in to
+     *     {@link firebase.auth.Auth.fetchSignInMethodsForEmail}, sign in to
      *     <code>error.email</code> via one of the providers returned and then
      *     {@link firebase.User.linkWithCredential} the original credential to that
      *     newly signed in user.</dd>
@@ -192,9 +195,6 @@ declare namespace firebase {
     /**
      * Links the user account with the given credentials.
      *
-     * This method is deprecated. Use
-     * {@link firebase.User.linkAndRetrieveDataWithCredential} instead.
-     *
      * <h4>Error Codes</h4>
      * <dl>
      * <dt>auth/provider-already-linked</dt>
@@ -225,7 +225,7 @@ declare namespace firebase {
      *     ({@link firebase.auth.AuthCredential}) fields are also provided.
      *     You have to link the credential to the existing user with that email if
      *     you wish to continue signing in with that credential. To do so, call
-     *     {@link firebase.auth.Auth.fetchProvidersForEmail}, sign in to
+     *     {@link firebase.auth.Auth.fetchSignInMethodsForEmail}, sign in to
      *     <code>error.email</code> via one of the providers returned and then
      *     {@link firebase.User.linkWithCredential} the original credential to that
      *     newly signed in user.</dd>
@@ -254,7 +254,7 @@ declare namespace firebase {
      */
     linkWithCredential(
       credential: firebase.auth.AuthCredential
-    ): Promise<firebase.User>;
+    ): Promise<firebase.auth.UserCredential>;
     /**
      * Links the user account with the given phone number.
      *
@@ -334,7 +334,7 @@ declare namespace firebase {
      *     ({@link firebase.auth.AuthCredential}) fields are also provided.
      *     You have to link the credential to the existing user with that email if
      *     you wish to continue signing in with that credential. To do so, call
-     *     {@link firebase.auth.Auth.fetchProvidersForEmail}, sign in to
+     *     {@link firebase.auth.Auth.fetchSignInMethodsForEmail}, sign in to
      *     <code>error.email</code> via one of the providers returned and then
      *     {@link firebase.User.linkWithCredential} the original credential to that
      *     newly signed in user.</dd>
@@ -433,6 +433,9 @@ declare namespace firebase {
      * such as {@link firebase.User.updatePassword} that require tokens from recent
      * sign-in attempts.
      *
+     * This method is deprecated. Use
+     * {@link firebase.User.reauthenticateWithCredential} instead.
+     *
      * <h4>Error Codes</h4>
      * <dl>
      * <dt>auth/user-mismatch</dt>
@@ -472,9 +475,6 @@ declare namespace firebase {
      * such as {@link firebase.User.updatePassword} that require tokens from recent
      * sign-in attempts.
      *
-     * This method is deprecated. Use
-     * {@link firebase.User.reauthenticateAndRetrieveDataWithCredential} instead.
-     *
      * <h4>Error Codes</h4>
      * <dl>
      * <dt>auth/user-mismatch</dt>
@@ -508,7 +508,7 @@ declare namespace firebase {
      */
     reauthenticateWithCredential(
       credential: firebase.auth.AuthCredential
-    ): Promise<void>;
+    ): Promise<firebase.auth.UserCredential>;
     /**
      * Re-authenticates a user using a fresh credential. Use before operations
      * such as {@link firebase.User.updatePassword} that require tokens from recent
@@ -1521,59 +1521,6 @@ declare namespace firebase.auth {
      * @param newPassword The new password.
      */
     confirmPasswordReset(code: string, newPassword: string): Promise<void>;
-    /**
-     * Creates a new user account associated with the specified email address and
-     * password and returns any additional user info data or credentials.
-     *
-     * This method is deprecated. Use
-     * {@link firebase.auth.Auth.createUserWithEmailAndPassword} instead.
-     *
-     * On successful creation of the user account, this user will also be
-     * signed in to your application.
-     *
-     * User account creation can fail if the account already exists or the password
-     * is invalid.
-     *
-     * Note: The email address acts as a unique identifier for the user and
-     * enables an email-based password reset.  This function will create
-     * a new user account and set the initial user password.
-     *
-     * <h4>Error Codes</h4>
-     * <dl>
-     * <dt>auth/email-already-in-use</dt>
-     * <dd>Thrown if there already exists an account with the given email
-     *     address.</dd>
-     * <dt>auth/invalid-email</dt>
-     * <dd>Thrown if the email address is not valid.</dd>
-     * <dt>auth/operation-not-allowed</dt>
-     * <dd>Thrown if email/password accounts are not enabled. Enable email/password
-     *     accounts in the Firebase Console, under the Auth tab.</dd>
-     * <dt>auth/weak-password</dt>
-     * <dd>Thrown if the password is not strong enough.</dd>
-     * </dl>
-     *
-     * @example
-     * ```javascript
-     * firebase.auth().createUserAndRetrieveDataWithEmailAndPassword(email, password)
-     *     .catch(function(error) {
-     *       // Handle Errors here.
-     *       var errorCode = error.code;
-     *       var errorMessage = error.message;
-     *       if (errorCode == 'auth/weak-password') {
-     *         alert('The password is too weak.');
-     *       } else {
-     *         alert(errorMessage);
-     *       }
-     *       console.log(error);
-     *     });
-     * ```
-     * @param email The user's email address.
-     * @param password The user's chosen password.
-     */
-    createUserAndRetrieveDataWithEmailAndPassword(
-      email: string,
-      password: string
-    ): Promise<firebase.auth.UserCredential>;
 
     /**
      * Creates a new user account associated with the specified email address and
@@ -1631,21 +1578,6 @@ declare namespace firebase.auth {
     currentUser: firebase.User | null;
 
     /**
-     * Gets the list of provider IDs that can be used to sign in for the given email
-     * address. Useful for an "identifier-first" sign-in flow.
-     *
-     * This method is deprecated. Use
-     * {@link firebase.auth.Auth.fetchSignInMethodsForEmail} instead.
-     *
-     * <h4>Error Codes</h4>
-     * <dl>
-     * <dt>auth/invalid-email</dt>
-     * <dd>Thrown if the email address is not valid.</dd>
-     * </dl>
-     */
-    fetchProvidersForEmail(email: string): Promise<Array<string>>;
-
-    /**
      * Gets the list of possible sign in methods for the given email address. This
      * is useful to differentiate methods of sign-in for the same provider,
      * eg. `EmailAuthProvider` which has 2 methods of sign-in, email/password and
@@ -1675,7 +1607,7 @@ declare namespace firebase.auth {
      * <dt>auth/account-exists-with-different-credential</dt>
      * <dd>Thrown if there already exists an account with the email address
      *     asserted by the credential. Resolve this by calling
-     *     {@link firebase.auth.Auth.fetchProvidersForEmail} with the error.email
+     *     {@link firebase.auth.Auth.fetchSignInMethodsForEmail} with the error.email
      *     and then asking the user to sign in using one of the returned providers.
      *     Once the user is signed in, the original credential retrieved from the
      *     error.credential can be linked to the user with
@@ -1707,7 +1639,7 @@ declare namespace firebase.auth {
      *     ({@link firebase.auth.AuthCredential}) fields are also provided.
      *     You have to link the credential to the existing user with that email if
      *     you wish to continue signing in with that credential. To do so, call
-     *     {@link firebase.auth.Auth.fetchProvidersForEmail}, sign in to
+     *     {@link firebase.auth.Auth.fetchSignInMethodsForEmail}, sign in to
      *     <code>error.email</code> via one of the providers returned and then
      *     {@link firebase.User.linkWithCredential} the original credential to that
      *     newly signed in user.</dd>
@@ -1761,7 +1693,7 @@ declare namespace firebase.auth {
      *   // In case of auth/account-exists-with-different-credential error,
      *   // you can fetch the providers using this:
      *   if (error.code === 'auth/account-exists-with-different-credential') {
-     *     auth.fetchProvidersForEmail(email).then(function(providers) {
+     *     auth.fetchSignInMethodsForEmail(email).then(function(providers) {
      *       // The returned 'providers' is a list of the available providers
      *       // linked to the email address. Please refer to the guide for a more
      *       // complete explanation on how to recover from this error.
@@ -2029,12 +1961,15 @@ declare namespace firebase.auth {
      * Asynchronously signs in with the given credentials, and returns any available
      * additional user information, such as user name.
      *
+     * This method is deprecated. Use
+     * {@link firebase.auth.Auth.signInWithCredential} instead.
+     *
      * <h4>Error Codes</h4>
      * <dl>
      * <dt>auth/account-exists-with-different-credential</dt>
      * <dd>Thrown if there already exists an account with the email address
      *     asserted by the credential. Resolve this by calling
-     *     {@link firebase.auth.Auth.fetchProvidersForEmail} and then asking the
+     *     {@link firebase.auth.Auth.fetchSignInMethodsForEmail} and then asking the
      *     user to sign in using one of the returned providers. Once the user is
      *     signed in, the original credential can be linked to the user with
      *     {@link firebase.User.linkWithCredential}.</dd>
@@ -2110,52 +2045,14 @@ declare namespace firebase.auth {
     signInAnonymously(): Promise<firebase.auth.UserCredential>;
 
     /**
-     * Signs in a user anonymously and returns any additional user info data or
-     * credentials.
-     *
-     * This method is deprecated. Use
-     * {@link firebase.auth.Auth.signInAnonymously} instead.
-     *
-     * If there is already an anonymous user signed in, that user with
-     * additional date will be returned; otherwise, a new anonymous user
-     * identity will be created and returned.
-     *
-     * <h4>Error Codes</h4>
-     * <dl>
-     * <dt>auth/operation-not-allowed</dt>
-     * <dd>Thrown if anonymous accounts are not enabled. Enable anonymous accounts
-     *     in the Firebase Console, under the Auth tab.</dd>
-     * </dl>
-     *
-     * @example
-     * ```javascript
-     * firebase.auth().signInAnonymouslyAndRetrieveData().catch(function(error) {
-     *   // Handle Errors here.
-     *   var errorCode = error.code;
-     *   var errorMessage = error.message;
-     *
-     *   if (errorCode === 'auth/operation-not-allowed') {
-     *     alert('You must enable Anonymous auth in the Firebase Console.');
-     *   } else {
-     *     console.error(error);
-     *   }
-     * });
-     * ```
-     */
-    signInAnonymouslyAndRetrieveData(): Promise<firebase.auth.UserCredential>;
-
-    /**
      * Asynchronously signs in with the given credentials.
-     *
-     * This method is deprecated. Use
-     * {@link firebase.auth.Auth.signInAndRetrieveDataWithCredential} instead.
      *
      * <h4>Error Codes</h4>
      * <dl>
      * <dt>auth/account-exists-with-different-credential</dt>
      * <dd>Thrown if there already exists an account with the email address
      *     asserted by the credential. Resolve this by calling
-     *     {@link firebase.auth.Auth.fetchProvidersForEmail} and then asking the
+     *     {@link firebase.auth.Auth.fetchSignInMethodsForEmail} and then asking the
      *     user to sign in using one of the returned providers. Once the user is
      *     signed in, the original credential can be linked to the user with
      *     {@link firebase.User.linkWithCredential}.</dd>
@@ -2210,7 +2107,7 @@ declare namespace firebase.auth {
      */
     signInWithCredential(
       credential: firebase.auth.AuthCredential
-    ): Promise<firebase.User>;
+    ): Promise<firebase.auth.UserCredential>;
     /**
      * Asynchronously signs in using a custom token.
      *
@@ -2245,47 +2142,6 @@ declare namespace firebase.auth {
      * @param token The custom token to sign in with.
      */
     signInWithCustomToken(token: string): Promise<firebase.auth.UserCredential>;
-    /**
-     * Signs in a user asynchronously using a custom token and returns any
-     * additional user info data or credentials.
-     *
-     * This method is deprecated. Use
-     * {@link firebase.auth.Auth.signInWithCustomToken} instead.
-     *
-     * Custom tokens are used to integrate Firebase Auth with existing auth systems,
-     * and must be generated by the auth backend.
-     *
-     * Fails with an error if the token is invalid, expired, or not accepted by the
-     * Firebase Auth service.
-     *
-     * <h4>Error Codes</h4>
-     * <dl>
-     * <dt>auth/custom-token-mismatch</dt>
-     * <dd>Thrown if the custom token is for a different Firebase App.</dd>
-     * <dt>auth/invalid-custom-token</dt>
-     * <dd>Thrown if the custom token format is incorrect.</dd>
-     * </dl>
-     *
-     * @example
-     * ```javascript
-     * firebase.auth().signInAndRetrieveDataWithCustomToken(token)
-     *     .catch(function(error) {
-     *       // Handle Errors here.
-     *       var errorCode = error.code;
-     *       var errorMessage = error.message;
-     *       if (errorCode === 'auth/invalid-custom-token') {
-     *         alert('The token you provided is not valid.');
-     *       } else {
-     *         console.error(error);
-     *       }
-     *     });
-     * ```
-     *
-     * @param token The custom token to sign in with.
-     */
-    signInAndRetrieveDataWithCustomToken(
-      token: string
-    ): Promise<firebase.auth.UserCredential>;
     /**
      * Asynchronously signs in using an email and password.
      *
@@ -2335,59 +2191,6 @@ declare namespace firebase.auth {
       password: string
     ): Promise<firebase.auth.UserCredential>;
 
-    /**
-     * Asynchronously signs in using an email and password and returns any additional
-     * user info data or credentials.
-     *
-     * This method is deprecated. Use
-     * {@link firebase.auth.Auth.signInWithEmailAndPassword} instead.
-     *
-     * Fails with an error if the email address and password do not match.
-     *
-     * Note: The user's password is NOT the password used to access the user's email
-     * account. The email address serves as a unique identifier for the user, and
-     * the password is used to access the user's account in your Firebase project.
-     *
-     * See also:
-     * {@link firebase.auth.Auth.createUserAndRetrieveDataWithEmailAndPassword}.
-     *
-     * <h4>Error Codes</h4>
-     * <dl>
-     * <dt>auth/invalid-email</dt>
-     * <dd>Thrown if the email address is not valid.</dd>
-     * <dt>auth/user-disabled</dt>
-     * <dd>Thrown if the user corresponding to the given email has been
-     *     disabled.</dd>
-     * <dt>auth/user-not-found</dt>
-     * <dd>Thrown if there is no user corresponding to the given email.</dd>
-     * <dt>auth/wrong-password</dt>
-     * <dd>Thrown if the password is invalid for the given email, or the account
-     *     corresponding to the email does not have a password set.</dd>
-     * </dl>
-     *
-     * @example
-     * ```javascript
-     * firebase.auth().signInAndRetrieveDataWithEmailAndPassword(email, password)
-     *     .catch(function(error) {
-     *       // Handle Errors here.
-     *       var errorCode = error.code;
-     *       var errorMessage = error.message;
-     *       if (errorCode === 'auth/wrong-password') {
-     *         alert('Wrong password.');
-     *       } else {
-     *         alert(errorMessage);
-     *       }
-     *       console.log(error);
-     *     });
-     * ```
-     *
-     * @param email The users email address.
-     * @param password The users password.
-     */
-    signInAndRetrieveDataWithEmailAndPassword(
-      email: string,
-      password: string
-    ): Promise<firebase.auth.UserCredential>;
     /**
      * Asynchronously signs in using a phone number. This method sends a code via
      * SMS to the given phone number, and returns a
@@ -2495,7 +2298,7 @@ declare namespace firebase.auth {
      * <dt>auth/account-exists-with-different-credential</dt>
      * <dd>Thrown if there already exists an account with the email address
      *     asserted by the credential. Resolve this by calling
-     *     {@link firebase.auth.Auth.fetchProvidersForEmail} with the error.email
+     *     {@link firebase.auth.Auth.fetchSignInMethodsForEmail} with the error.email
      *     and then asking the user to sign in using one of the returned providers.
      *     Once the user is signed in, the original credential retrieved from the
      *     error.credential can be linked to the user with
@@ -2559,7 +2362,7 @@ declare namespace firebase.auth {
      *   // In case of auth/account-exists-with-different-credential error,
      *   // you can fetch the providers using this:
      *   if (error.code === 'auth/account-exists-with-different-credential') {
-     *     auth.fetchProvidersForEmail(email).then(function(providers) {
+     *     auth.fetchSignInMethodsForEmail(email).then(function(providers) {
      *       // The returned 'providers' is a list of the available providers
      *       // linked to the email address. Please refer to the guide for a more
      *       // complete explanation on how to recover from this error.

--- a/packages/firebase/index.d.ts
+++ b/packages/firebase/index.d.ts
@@ -126,6 +126,7 @@ declare namespace firebase {
     getIdToken(forceRefresh?: boolean): Promise<string>;
     isAnonymous: boolean;
     /**
+     * @deprecated
      * Links the user account with the given credentials and returns any available
      * additional user information, such as user name.
      *
@@ -428,6 +429,7 @@ declare namespace firebase {
     phoneNumber: string | null;
     providerData: (firebase.UserInfo | null)[];
     /**
+     * @deprecated
      * Re-authenticates a user using a fresh credential, and returns any available
      * additional user information, such as user name. Use before operations
      * such as {@link firebase.User.updatePassword} that require tokens from recent
@@ -1958,6 +1960,7 @@ declare namespace firebase.auth {
     setPersistence(persistence: firebase.auth.Auth.Persistence): Promise<void>;
 
     /**
+     * @deprecated
      * Asynchronously signs in with the given credentials, and returns any available
      * additional user information, such as user name.
      *


### PR DESCRIPTION
Removed the 5 APIs being deprecated last year:
1. signInAndRetrieveDataWithCustomToken()
2. signInAnonymouslyAndRetrieveData()
3. createUserAndRetrieveDataWithEmailAndPassword()
4. signInAndRetrieveDataWithEmailAndPassword()
5. fetchProvidersForEmail()

Updated 3 APIs to return UserCredential:
1. Updated signInWithCredential to return UserCredential
2. Updated linkWithCredential to return UserCredential
3. Updated reauthenticateWithCredential to return UserCredential

Marked 3 APIs deprecated:
1. Deprecated signInAndRetrieveDataWithCredential
2. Deprecated linkAndRetrieveDataWithCredential
3. Deprecated reauthenticateAndRetrieveDataWithCredential