### PR TITLE
Clean up some serializer stuff.

### DIFF
--- a/integration/browserify/package.json
+++ b/integration/browserify/package.json
@@ -7,7 +7,7 @@
     "test": "karma start --single-run"
   },
   "dependencies": {
-    "firebase": "5.10.0"
+    "firebase": "5.10.1"
   },
   "devDependencies": {
     "@babel/core": "7.4.3",

--- a/integration/firebase-typings/package.json
+++ b/integration/firebase-typings/package.json
@@ -6,7 +6,7 @@
     "test": "tsc index.ts --outDir dist"
   },
   "dependencies": {
-    "firebase": "5.10.0"
+    "firebase": "5.10.1"
   },
   "devDependencies": {
     "typescript": "3.4.3"

--- a/integration/messaging/package.json
+++ b/integration/messaging/package.json
@@ -8,7 +8,7 @@
     "test:manual": "mocha --exit"
   },
   "dependencies": {
-    "firebase": "5.10.0"
+    "firebase": "5.10.1"
   },
   "devDependencies": {
     "chai": "4.2.0",

--- a/integration/typescript/package.json
+++ b/integration/typescript/package.json
@@ -6,7 +6,7 @@
     "test": "karma start --single-run"
   },
   "dependencies": {
-    "firebase": "5.10.0"
+    "firebase": "5.10.1"
   },
   "devDependencies": {
     "@babel/core": "7.4.3",

--- a/integration/webpack/package.json
+++ b/integration/webpack/package.json
@@ -7,7 +7,7 @@
     "test": "karma start --single-run"
   },
   "dependencies": {
-    "firebase": "5.10.0"
+    "firebase": "5.10.1"
   },
   "devDependencies": {
     "@babel/core": "7.4.3",

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@firebase/auth",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "main": "dist/auth.js",
   "module": "dist/auth.esm.js",
   "description": "Javascript library for Firebase Auth SDK",

--- a/packages/firebase/package.json
+++ b/packages/firebase/package.json
@@ -1,6 +1,6 @@
 {
   "name": "firebase",
-  "version": "5.10.0",
+  "version": "5.10.1",
   "description": "Firebase JavaScript library for web and Node.js",
   "author": "Firebase <firebase-support@google.com> (https://firebase.google.com/)",
   "license": "Apache-2.0",
@@ -37,9 +37,9 @@
   "react-native": "dist/index.rn.cjs.js",
   "dependencies": {
     "@firebase/app": "0.3.16",
-    "@firebase/auth": "0.10.0",
+    "@firebase/auth": "0.10.1",
     "@firebase/database": "0.3.19",
-    "@firebase/firestore": "1.2.0",
+    "@firebase/firestore": "1.2.1",
     "@firebase/functions": "0.4.5",
     "@firebase/messaging": "0.3.18",
     "@firebase/polyfill": "0.3.12",
@@ -58,6 +58,7 @@
   },
   "typings": "index.d.ts",
   "components": [
+    "app",
     "auth",
     "database",
     "firestore",

--- a/packages/firebase/rollup.config.js
+++ b/packages/firebase/rollup.config.js
@@ -73,6 +73,8 @@ const appBuilds = [
 ];
 
 const componentBuilds = pkg.components
+  // The "app" component is treated differently because it doesn't depend on itself.
+  .filter(component => component !== 'app')
   .map(component => {
     const pkg = require(`./${component}/package.json`);
     return [

--- a/packages/firestore/package.json
+++ b/packages/firestore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@firebase/firestore",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "",
   "author": "Firebase <firebase-support@google.com> (https://firebase.google.com/)",
   "scripts": {

--- a/packages/firestore/src/platform_node/load_protos.ts
+++ b/packages/firestore/src/platform_node/load_protos.ts
@@ -20,11 +20,12 @@ import * as grpc from 'grpc';
 import * as path from 'path';
 import * as ProtobufJS from 'protobufjs';
 
-export const protoLoaderOptions = {
+/** Used by tests so we can match @grpc/proto-loader behavior. */
+export const protoLoaderOptions: ProtobufJS.IConversionOptions = {
   longs: String,
   enums: String,
   defaults: true,
-  oneofs: true
+  oneofs: false
 };
 
 /**
@@ -44,12 +45,13 @@ export function loadProtos(): grpc.GrpcObject {
 
   const packageDefinition = protoLoader.loadSync(firestoreProtoFile, {
     ...protoLoaderOptions,
-    ...{ includeDirs: [root] }
+    includeDirs: [root]
   });
 
   return grpc.loadPackageDefinition(packageDefinition);
 }
 
+/** Used by tests so we can directly create ProtobufJS proto message objects from JSON protos. */
 export function loadRawProtos(): ProtobufJS.Root {
   const root = path.resolve(
     __dirname,

--- a/packages/firestore/src/remote/serializer.ts
+++ b/packages/firestore/src/remote/serializer.ts
@@ -207,7 +207,7 @@ export class JsonProtoSerializer {
    */
   private toTimestamp(timestamp: Timestamp): string {
     return {
-      seconds: timestamp.seconds,
+      seconds: '' + timestamp.seconds,
       nanos: timestamp.nanoseconds
       // tslint:disable-next-line:no-any
     } as any;
@@ -284,6 +284,10 @@ export class JsonProtoSerializer {
       );
       return Blob.fromBase64String(blob);
     } else {
+      assert(
+        !this.options.useProto3Json,
+        'Expected bytes to be passed in as Uint8Array, but got a string instead.'
+      );
       return Blob.fromUint8Array(blob);
     }
   }
@@ -444,15 +448,13 @@ export class JsonProtoSerializer {
   }
 
   fromValue(obj: api.Value): fieldValue.FieldValue {
-    // tslint:disable-next-line:no-any
-    const type = (obj as any)['value_type'];
-    if (hasTag(obj, type, 'nullValue')) {
+    if ('nullValue' in obj) {
       return fieldValue.NullValue.INSTANCE;
-    } else if (hasTag(obj, type, 'booleanValue')) {
+    } else if ('booleanValue' in obj) {
       return fieldValue.BooleanValue.of(obj.booleanValue!);
-    } else if (hasTag(obj, type, 'integerValue')) {
+    } else if ('integerValue' in obj) {
       return new fieldValue.IntegerValue(parseInt64(obj.integerValue!));
-    } else if (hasTag(obj, type, 'doubleValue')) {
+    } else if ('doubleValue' in obj) {
       if (this.options.useProto3Json) {
         // Proto 3 uses the string values 'NaN' and 'Infinity'.
         if ((obj.doubleValue as {}) === 'NaN') {
@@ -465,30 +467,30 @@ export class JsonProtoSerializer {
       }
 
       return new fieldValue.DoubleValue(obj.doubleValue!);
-    } else if (hasTag(obj, type, 'stringValue')) {
+    } else if ('stringValue' in obj) {
       return new fieldValue.StringValue(obj.stringValue!);
-    } else if (hasTag(obj, type, 'mapValue')) {
+    } else if ('mapValue' in obj) {
       return this.fromFields(obj.mapValue!.fields || {});
-    } else if (hasTag(obj, type, 'arrayValue')) {
+    } else if ('arrayValue' in obj) {
       // "values" is not present if the array is empty
       assertPresent(obj.arrayValue, 'arrayValue');
       const values = obj.arrayValue!.values || [];
       return new fieldValue.ArrayValue(values.map(v => this.fromValue(v)));
-    } else if (hasTag(obj, type, 'timestampValue')) {
+    } else if ('timestampValue' in obj) {
       assertPresent(obj.timestampValue, 'timestampValue');
       return new fieldValue.TimestampValue(
         this.fromTimestamp(obj.timestampValue!)
       );
-    } else if (hasTag(obj, type, 'geoPointValue')) {
+    } else if ('geoPointValue' in obj) {
       assertPresent(obj.geoPointValue, 'geoPointValue');
       const latitude = obj.geoPointValue!.latitude || 0;
       const longitude = obj.geoPointValue!.longitude || 0;
       return new fieldValue.GeoPointValue(new GeoPoint(latitude, longitude));
-    } else if (hasTag(obj, type, 'bytesValue')) {
+    } else if ('bytesValue' in obj) {
       assertPresent(obj.bytesValue, 'bytesValue');
       const blob = this.fromBlob(obj.bytesValue!);
       return new fieldValue.BlobValue(blob);
-    } else if (hasTag(obj, type, 'referenceValue')) {
+    } else if ('referenceValue' in obj) {
       assertPresent(obj.referenceValue, 'referenceValue');
       const resourceName = this.fromResourceName(obj.referenceValue!);
       const dbId = new DatabaseId(resourceName.get(1), resourceName.get(3));
@@ -596,11 +598,9 @@ export class JsonProtoSerializer {
   }
 
   fromMaybeDocument(result: api.BatchGetDocumentsResponse): MaybeDocument {
-    // tslint:disable-next-line:no-any
-    const type = (result as any)['result'];
-    if (hasTag(result, type, 'found')) {
+    if ('found' in result) {
       return this.fromFound(result);
-    } else if (hasTag(result, type, 'missing')) {
+    } else if ('missing' in result) {
       return this.fromMissing(result);
     }
     return fail('invalid batch get response: ' + JSON.stringify(result));
@@ -687,10 +687,8 @@ export class JsonProtoSerializer {
   }
 
   fromWatchChange(change: api.ListenResponse): WatchChange {
-    // tslint:disable-next-line:no-any
-    const type = (change as any)['response_type'];
     let watchChange: WatchChange;
-    if (hasTag(change, type, 'targetChange')) {
+    if ('targetChange' in change) {
       assertPresent(change.targetChange, 'targetChange');
       // proto3 default value is unset in JSON (undefined), so use 'NO_CHANGE'
       // if unset
@@ -708,7 +706,7 @@ export class JsonProtoSerializer {
         resumeToken,
         cause || null
       );
-    } else if (hasTag(change, type, 'documentChange')) {
+    } else if ('documentChange' in change) {
       assertPresent(change.documentChange, 'documentChange');
       assertPresent(change.documentChange!.document, 'documentChange.name');
       assertPresent(
@@ -740,7 +738,7 @@ export class JsonProtoSerializer {
         doc.key,
         doc
       );
-    } else if (hasTag(change, type, 'documentDelete')) {
+    } else if ('documentDelete' in change) {
       assertPresent(change.documentDelete, 'documentDelete');
       assertPresent(change.documentDelete!.document, 'documentDelete.document');
       const docDelete = change.documentDelete!;
@@ -751,14 +749,14 @@ export class JsonProtoSerializer {
       const doc = new NoDocument(key, version);
       const removedTargetIds = docDelete.removedTargetIds || [];
       watchChange = new DocumentWatchChange([], removedTargetIds, doc.key, doc);
-    } else if (hasTag(change, type, 'documentRemove')) {
+    } else if ('documentRemove' in change) {
       assertPresent(change.documentRemove, 'documentRemove');
       assertPresent(change.documentRemove!.document, 'documentRemove');
       const docRemove = change.documentRemove!;
       const key = this.fromName(docRemove.document!);
       const removedTargetIds = docRemove.removedTargetIds || [];
       watchChange = new DocumentWatchChange([], removedTargetIds, key, null);
-    } else if (hasTag(change, type, 'filter')) {
+    } else if ('filter' in change) {
       // TODO(dimond): implement existence filter parsing with strategy.
       assertPresent(change.filter, 'filter');
       assertPresent(change.filter!.targetId, 'filter.targetId');
@@ -795,9 +793,7 @@ export class JsonProtoSerializer {
     // We have only reached a consistent snapshot for the entire stream if there
     // is a read_time set and it applies to all targets (i.e. the list of
     // targets is empty). The backend is guaranteed to send such responses.
-    // tslint:disable-next-line:no-any
-    const type = (change as any)['response_type'];
-    if (!hasTag(change, type, 'targetChange')) {
+    if (!('targetChange' in change)) {
       return SnapshotVersion.MIN;
     }
     const targetChange = change.targetChange!;
@@ -963,26 +959,24 @@ export class JsonProtoSerializer {
   }
 
   private fromFieldTransform(proto: api.FieldTransform): FieldTransform {
-    // tslint:disable-next-line:no-any We need to match generated Proto types.
-    const type = (proto as any)['transform_type'];
     let transform: TransformOperation | null = null;
-    if (hasTag(proto, type, 'setToServerValue')) {
+    if ('setToServerValue' in proto) {
       assert(
         proto.setToServerValue === 'REQUEST_TIME',
         'Unknown server value transform proto: ' + JSON.stringify(proto)
       );
       transform = ServerTimestampTransform.instance;
-    } else if (hasTag(proto, type, 'appendMissingElements')) {
+    } else if ('appendMissingElements' in proto) {
       const values = proto.appendMissingElements!.values || [];
       transform = new ArrayUnionTransformOperation(
         values.map(v => this.fromValue(v))
       );
-    } else if (hasTag(proto, type, 'removeAllFromArray')) {
+    } else if ('removeAllFromArray' in proto) {
       const values = proto.removeAllFromArray!.values || [];
       transform = new ArrayRemoveTransformOperation(
         values.map(v => this.fromValue(v))
       );
-    } else if (hasTag(proto, type, 'increment')) {
+    } else if ('increment' in proto) {
       const operand = this.fromValue(proto.increment!);
       assert(
         operand instanceof NumberValue,
@@ -1359,36 +1353,4 @@ export class JsonProtoSerializer {
     const fields = paths.map(path => FieldPath.fromServerFormat(path));
     return FieldMask.fromArray(fields);
   }
-}
-
-/**
- * Checks for a specific oneof tag in a protocol buffer message.
- *
- * This intentionally accommodates two distinct cases:
- *
- * 1) Messages containing a type tag: these are the format produced by GRPC in
- * return values. These may contain default-value mappings for all tags in the
- * oneof but the type tag specifies which one was actually set.
- *
- * 2) Messages that don't contain a type tag: these are the format required by
- * GRPC as inputs. If we emitted objects with type tags, ProtoBuf.js would
- * choke claiming that the tags aren't fields in the Message.
- *
- * Allowing both formats here makes the serializer able to consume the outputs
- * it produces: for all messages it supports, fromX(toX(value)) == value.
- *
- * Note that case 2 suffers from ambiguity: if multiple tags are present
- * without a type tag then the callers are structured in such a way that the
- * first invocation will win. Since we only parse in this mode when parsing
- * the output of a serialize method this works, but it's not a general
- * solution.
- *
- * Unfortunately there is no general solution here because proto3 makes it
- * impossible to distinguish unset from explicitly set fields: both have the
- * default value for the type. Without the type tag but multiple value tags
- * it's possible to have default values for each tag in the oneof and not be
- * able to know which was actually in effect.
- */
-function hasTag(obj: {}, type: string, tag: string): boolean {
-  return type === tag || (!type && tag in obj);
 }

--- a/packages/rxfire/package.json
+++ b/packages/rxfire/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rxfire",
-  "version": "3.4.0",
+  "version": "3.4.1",
   "private": false,
   "description": "Firebase JavaScript library RxJS",
   "author": "Firebase <firebase-support@google.com> (https://firebase.google.com/)",
@@ -36,7 +36,7 @@
     "rxjs": "6.x.x"
   },
   "devDependencies": {
-    "firebase": "5.10.0",
+    "firebase": "5.10.1",
     "rxjs": "^6.4.0",
     "rollup": "1.10.0",
     "rollup-plugin-commonjs": "9.3.4",

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@firebase/testing",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "",
   "author": "Firebase <firebase-support@google.com> (https://firebase.google.com/)",
   "main": "dist/index.cjs.js",
@@ -15,7 +15,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "firebase": "5.10.0",
+    "firebase": "5.10.1",
     "@firebase/logger": "0.1.12",
     "@firebase/util": "0.2.13",
     "@types/request": "2.48.1",


### PR DESCRIPTION
Sorry, I decided to review https://github.com/firebase/firebase-js-sdk/pull/1669 in the form of a PR. 😄 Thanks for doing the hard work to get protobufjs upgraded and the tests working again.  This is basically a cleanup pass to convince myself that everything was working right and simplify the tests. In particular:

1. The switch to protobufjs 6.x seems to have removed the need for hasTag() (and actually it had broken our usage of it since the tags ended up changing from snake_case to camelCase so they never matched). So I've removed hasTag() and set `oneofs: false` in protoLoaderOptions so the virtual "fooType" fields are no longer added at all.
2. 'seconds' in timestamps can and should always be serialized as a string, since it's an int64 value but we weren't doing that. I fixed it, which removed some of the special casing in your roundtrip testing.
3. I reworked the expect...RoundTrip methods into a single unified one. I think this is simpler (and reduced some repetition) but if you have concerns, let me know.
4. I re-added the disabled useProto3Json assert that you had removed from serializer.ts and instead tweaked the offending test so it doesn't try to round-trip through protobufjs.