### PR TITLE
Allow using Firestore from the Admin SDK with RxFire

### DIFF
--- a/packages/rxfire/firestore/fromRef.ts
+++ b/packages/rxfire/firestore/fromRef.ts
@@ -20,7 +20,10 @@ import { Observable } from 'rxjs';
 
 function _fromRef(ref: any): Observable<any> {
   return new Observable(subscriber => {
-    const unsubscribe = ref.onSnapshot(subscriber);
+    const unsubscribe = ref.onSnapshot(
+      subscriber.next.bind(subscriber),
+      subscriber.error.bind(subscriber)
+    );
     return { unsubscribe };
   });
 }


### PR DESCRIPTION
### Discussion
This change allows using the Firestore implementation from the Admin SDK with the various Firestore methods from RxFire (`collectionData()`, `docData()`, etc.) This is currently not possible, as previously discussed in #1215.

Relevant documentation:
  - For client SDK (`@firebase/firestore`): https://firebase.google.com/docs/reference/js/firebase.firestore.Query.html#onsnapshot
  - For admin/node SDK (`@google-cloud/firestore`): https://cloud.google.com/nodejs/docs/reference/firestore/1.3.x/Query#onSnapshot

*PS: I hope y'all have a great time at I/O!*

### Testing
All existing tests pass.

### API Changes
None.