### PR TITLE
Add tslib to Installations dependencies

### DIFF
--- a/packages/installations/package.json
+++ b/packages/installations/package.json
@@ -51,6 +51,7 @@
   "dependencies": {
     "@firebase/installations-types": "0.1.0",
     "@firebase/util": "0.2.15",
-    "idb": "3.0.2"
+    "idb": "3.0.2",
+    "tslib": "1.9.3"
   }
 }


### PR DESCRIPTION
This allows Rollup to detect `tslib` as an external dependency and doesn't bundle it in the package builds. It should prevent `tslib` being bundled twice in the main build.