### PR TITLE
Deprecate messaging.requestPermission

### DIFF
--- a/packages/firebase/index.d.ts
+++ b/packages/firebase/index.d.ts
@@ -5247,6 +5247,9 @@ declare namespace firebase.messaging {
       completed?: firebase.CompleteFn
     ): firebase.Unsubscribe;
     /**
+     * @deprecated Use Notification.requestPermission() instead.
+     * https://developer.mozilla.org/en-US/docs/Web/API/Notification/requestPermission
+     *
      * Notification permissions are required to send a user push messages.
      * Calling this method displays the permission dialog to the user and
      * resolves if the permission is granted.

--- a/packages/firebase/index.d.ts
+++ b/packages/firebase/index.d.ts
@@ -5247,15 +5247,15 @@ declare namespace firebase.messaging {
       completed?: firebase.CompleteFn
     ): firebase.Unsubscribe;
     /**
-     * @deprecated Use Notification.requestPermission() instead.
-     * https://developer.mozilla.org/en-US/docs/Web/API/Notification/requestPermission
-     *
      * Notification permissions are required to send a user push messages.
      * Calling this method displays the permission dialog to the user and
      * resolves if the permission is granted.
      *
      * @return The promise resolves if permission is
      *   granted. Otherwise, the promise is rejected with an error.
+     *
+     * @deprecated Use Notification.requestPermission() instead.
+     * https://developer.mozilla.org/en-US/docs/Web/API/Notification/requestPermission
      */
     requestPermission(): Promise<void>;
     /**

--- a/packages/messaging-types/index.d.ts
+++ b/packages/messaging-types/index.d.ts
@@ -38,6 +38,10 @@ export class FirebaseMessaging {
     error?: ErrorFn,
     completed?: CompleteFn
   ): Unsubscribe;
+  /**
+   * @deprecated Use Notification.requestPermission() instead.
+   * https://developer.mozilla.org/en-US/docs/Web/API/Notification/requestPermission
+   */
   requestPermission(): Promise<void>;
   setBackgroundMessageHandler(
     callback: (payload: any) => Promise<any> | void

--- a/packages/messaging/src/controllers/base-controller.ts
+++ b/packages/messaging/src/controllers/base-controller.ts
@@ -281,6 +281,10 @@ export abstract class BaseController implements FirebaseMessaging {
   // The following methods should only be available in the window.
   //
 
+  /**
+   * @deprecated Use Notification.requestPermission() instead.
+   * https://developer.mozilla.org/en-US/docs/Web/API/Notification/requestPermission
+   */
   requestPermission(): Promise<void> {
     throw errorFactory.create(ErrorCode.AVAILABLE_IN_WINDOW);
   }

--- a/packages/messaging/src/controllers/window-controller.ts
+++ b/packages/messaging/src/controllers/window-controller.ts
@@ -89,6 +89,9 @@ export class WindowController extends BaseController {
   }
 
   /**
+   * @deprecated Use Notification.requestPermission() instead.
+   * https://developer.mozilla.org/en-US/docs/Web/API/Notification/requestPermission
+   *
    * Request permission if it is not currently granted
    *
    * @return Resolves if the permission was granted, otherwise rejects

--- a/packages/messaging/src/controllers/window-controller.ts
+++ b/packages/messaging/src/controllers/window-controller.ts
@@ -89,12 +89,12 @@ export class WindowController extends BaseController {
   }
 
   /**
-   * @deprecated Use Notification.requestPermission() instead.
-   * https://developer.mozilla.org/en-US/docs/Web/API/Notification/requestPermission
-   *
    * Request permission if it is not currently granted
    *
    * @return Resolves if the permission was granted, otherwise rejects
+   *
+   * @deprecated Use Notification.requestPermission() instead.
+   * https://developer.mozilla.org/en-US/docs/Web/API/Notification/requestPermission
    */
   async requestPermission(): Promise<void> {
     if (this.getNotificationPermission_() === 'granted') {


### PR DESCRIPTION
I'll also update our documentation and guides to use `Notification.requestPermission()` instead of `messaging.requestPermission()`.