### PR TITLE
Empty import typings for firebase/performance

### DIFF
--- a/packages/firebase/performance/package.json
+++ b/packages/firebase/performance/package.json
@@ -1,5 +1,6 @@
 {
     "name": "firebase/performance",
     "main": "dist/index.cjs.js",
-    "module": "dist/index.esm.js"
+    "module": "dist/index.esm.js",
+    "typings": "../empty-import.d.ts"
 }


### PR DESCRIPTION
`firebase/performance` is missing a typing reference.