### PR TITLE
Stop hacking around old gRPC misbehavior

### DIFF
--- a/packages/firestore/src/platform_node/grpc_connection.ts
+++ b/packages/firestore/src/platform_node/grpc_connection.ts
@@ -97,14 +97,7 @@ export class GrpcConnection implements Connection {
         : grpc.credentials.createInsecure();
       this.cachedStub = new this.firestore.Firestore(
         this.databaseInfo.host,
-        credentials,
-        {
-          // We do our own connection backoff (that for example is aware of whether or
-          // not a write stream error is permanent or not) so we don't want gRPC to do
-          // backoff on top of that. 100ms is the minimum value that gRPC allows.
-          'grpc.initial_reconnect_backoff_ms': 100,
-          'grpc.max_reconnect_backoff_ms': 100
-        }
+        credentials
       );
     }
     return this.cachedStub;


### PR DESCRIPTION
In gRPC 1.17 they released a feature that preferentially chooses to connect over the last channel that successfully connected. This fixes the underlying issue that we were hacking around with these config parameters.