### PR TITLE
add packages to dep list for peer dep requirement

### DIFF
--- a/packages/firebase/package.json
+++ b/packages/firebase/package.json
@@ -38,6 +38,7 @@
   "react-native": "dist/index.rn.cjs.js",
   "dependencies": {
     "@firebase/app": "0.4.1",
+    "@firebase/app-types": "0.4.0",
     "@firebase/auth": "0.11.2",
     "@firebase/database": "0.4.1",
     "@firebase/firestore": "1.3.1",
@@ -45,7 +46,8 @@
     "@firebase/messaging": "0.3.20",
     "@firebase/polyfill": "0.3.14",
     "@firebase/storage": "0.2.16",
-    "@firebase/performance": "0.2.2"
+    "@firebase/performance": "0.2.2",
+    "@firebase/util": "0.2.15"
   },
   "devDependencies": {
     "git-rev-sync": "1.12.0",


### PR DESCRIPTION
`@firebase/{component}` has a peer dependency on `@firebase/app-types` and some has peer dependency on `@firebase/util`. 

Since firebase depends on `@firebase/{component}` directly, it should list all the peer dependencies from `@firebase/{component}` as its dependency, otherwise yarn will complain with unmet peer dependency warning.
The fact that `@firebase/app-types` is a dependency of `@firebase/app` is not enough as explained in https://github.com/yarnpkg/yarn/issues/5347#issuecomment-386288470

This is not a problem with npm because npm doesn't care how the peer dependencies are installed as long as they are there.
