### PR TITLE
Allow firestore to recover quicker when a network change occurs

### DIFF
--- a/packages/firestore/CHANGELOG.md
+++ b/packages/firestore/CHANGELOG.md
@@ -6,6 +6,8 @@
   if you continue to use `experimentalTabSynchronization`.
 - [feature] You can now query across all collections in your database with a
   given collection ID using the `FirebaseFirestore.collectionGroup()` method.
+- [changed] Firestore now recovers more quickly from long periods without
+  network access (#1809).
 
 # 1.1.4
 - [feature] Added an `experimentalForceLongPolling` setting that that can be

--- a/packages/firestore/CHANGELOG.md
+++ b/packages/firestore/CHANGELOG.md
@@ -1,13 +1,15 @@
 
 # Unreleased
+- [changed] Firestore now recovers more quickly after network connectivity
+  changes (airplane mode, Wi-Fi availability, etc.).
+
+# 1.3.0
 - [changed] Deprecated the `experimentalTabSynchronization` setting in favor of 
   `synchronizeTabs`. If you use multi-tab synchronization, it is recommended
   that you update your call to `enablePersistence()`. Firestore logs an error
   if you continue to use `experimentalTabSynchronization`.
 - [feature] You can now query across all collections in your database with a
   given collection ID using the `FirebaseFirestore.collectionGroup()` method.
-- [changed] Firestore now recovers more quickly from long periods without
-  network access (#1809).
 
 # 1.1.4
 - [feature] Added an `experimentalForceLongPolling` setting that that can be

--- a/packages/firestore/src/core/firestore_client.ts
+++ b/packages/firestore/src/core/firestore_client.ts
@@ -1,4 +1,3 @@
-import { ConnectivityMonitor } from './../remote/connectivity_monitor';
 /**
  * @license
  * Copyright 2017 Google Inc.

--- a/packages/firestore/src/core/firestore_client.ts
+++ b/packages/firestore/src/core/firestore_client.ts
@@ -1,3 +1,4 @@
+import { ConnectivityMonitor } from './../remote/connectivity_monitor';
 /**
  * @license
  * Copyright 2017 Google Inc.
@@ -417,6 +418,8 @@ export class FirestoreClient {
             this.localStore
           );
         }
+
+        const connectivityMonitor = this.platform.newConnectivityMonitor();
         const serializer = this.platform.newSerializer(
           this.databaseInfo.databaseId
         );
@@ -442,7 +445,8 @@ export class FirestoreClient {
           this.localStore,
           datastore,
           this.asyncQueue,
-          remoteStoreOnlineStateChangedHandler
+          remoteStoreOnlineStateChangedHandler,
+          connectivityMonitor
         );
 
         this.syncEngine = new SyncEngine(

--- a/packages/firestore/src/remote/remote_store.ts
+++ b/packages/firestore/src/remote/remote_store.ts
@@ -707,7 +707,7 @@ export class RemoteStore implements TargetMetadataProvider {
       // Tear down and re-create our network streams. This will ensure we get a fresh auth token
       // for the new user and re-fill the write pipeline with new mutations from the LocalStore
       // (since mutations are per-user).
-    log.debug(LOG_TAG, 'RemoteStore restarting streams for new credential');
+      log.debug(LOG_TAG, 'RemoteStore restarting streams for new credential');
       await this.restartNetwork();
     }
   }

--- a/packages/firestore/test/unit/specs/spec_test_runner.ts
+++ b/packages/firestore/test/unit/specs/spec_test_runner.ts
@@ -453,11 +453,13 @@ abstract class TestRunner {
         OnlineStateSource.SharedClientState
       );
     };
+    const connectivityMonitor = this.platform.newConnectivityMonitor();
     this.remoteStore = new RemoteStore(
       this.localStore,
       this.datastore,
       this.queue,
-      remoteStoreOnlineStateChangedHandler
+      remoteStoreOnlineStateChangedHandler,
+      connectivityMonitor
     );
     this.syncEngine = new SyncEngine(
       this.localStore,


### PR DESCRIPTION
reference: b/35928432
[Android PR](https://github.com/firebase/firebase-android-sdk/pull/217/files)