### PR TITLE
Empty import typings for firebase/storage

### DIFF
--- a/packages/firebase/storage/package.json
+++ b/packages/firebase/storage/package.json
@@ -1,5 +1,6 @@
 {
   "name": "firebase/storage",
   "main": "dist/index.cjs.js",
-  "module": "dist/index.esm.js"
+  "module": "dist/index.esm.js",
+  "typings": "../empty-import.d.ts"
 }


### PR DESCRIPTION
Similar to #1792 `firebase/storage` was missing a typing reference.