### PR TITLE
Use HTTP method provided by NetworkRequest object instead of hardcode…

### DIFF
--- a/packages/performance/src/services/perf_logger.test.ts
+++ b/packages/performance/src/services/perf_logger.test.ts
@@ -143,7 +143,7 @@ describe('Performance Monitoring > perf_logger', () => {
 "visibility_state":${VISIBILITY_STATE},"effective_connection_type":${EFFECTIVE_CONNECTION_TYPE}},\
 "application_process_state":0},\
 "network_request_metric":{"url":"${RESOURCE_PERFORMANCE_ENTRY.name}",\
-"http_method":1,"http_response_code":200,\
+"http_method":0,"http_response_code":200,\
 "response_payload_bytes":${RESOURCE_PERFORMANCE_ENTRY.transferSize},\
 "client_start_time_us":${START_TIME},\
 "time_to_response_completed_us":${TIME_TO_RESPONSE_COMPLETED}}}`;

--- a/packages/performance/src/services/perf_logger.ts
+++ b/packages/performance/src/services/perf_logger.ts
@@ -153,7 +153,7 @@ function serializer(resource: {}, resourceType: ResourceType): string {
 function serializeNetworkRequest(networkRequest: NetworkRequest): string {
   const networkRequestMetric: NetworkRequestMetric = {
     url: networkRequest.url,
-    http_method: 1,
+    http_method: networkRequest.httpMethod || 0,
     http_response_code: 200,
     response_payload_bytes: networkRequest.responsePayloadBytes,
     client_start_time_us: networkRequest.startTimeUs,


### PR DESCRIPTION
Currently we hardcoded "GET" as HttpMethod for network request in Performance. Switch to use the real value now. Since browser API doesn't support HTTPmethod retrieval, the value will be set as "UNKNOWN" for now. 