### PR TITLE
Update license checking script.

### DIFF
--- a/packages/auth/demo/public/sample-config.js
+++ b/packages/auth/demo/public/sample-config.js
@@ -1,4 +1,5 @@
 /*
+ * @license
  * Copyright 2017 Google Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/packages/auth/demo/public/sample-config.js
+++ b/packages/auth/demo/public/sample-config.js
@@ -1,4 +1,5 @@
 /*
+* @license
  * Copyright 2017 Google Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/packages/auth/demo/public/sample-config.js
+++ b/packages/auth/demo/public/sample-config.js
@@ -1,5 +1,4 @@
 /*
-* @license
  * Copyright 2017 Google Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/packages/firebase/performance/index.ts
+++ b/packages/firebase/performance/index.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/firebase/performance/index.ts
+++ b/packages/firebase/performance/index.ts
@@ -1,5 +1,6 @@
 /**
- * Copyright 2017 Google Inc.
+ * @license
+ * Copyright 2019 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/firebase/performance/index.ts
+++ b/packages/firebase/performance/index.ts
@@ -1,6 +1,5 @@
 /**
- * @license
- * Copyright 2019 Google Inc.
+ * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/performance-types/index.d.ts
+++ b/packages/performance-types/index.d.ts
@@ -1,5 +1,5 @@
 /**
-* @license
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/performance-types/index.d.ts
+++ b/packages/performance-types/index.d.ts
@@ -1,4 +1,5 @@
 /**
+* @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/performance/karma.conf.js
+++ b/packages/performance/karma.conf.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/performance/karma.conf.js
+++ b/packages/performance/karma.conf.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/performance/rollup.config.js
+++ b/packages/performance/rollup.config.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/performance/rollup.config.js
+++ b/packages/performance/rollup.config.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/performance/src/constants.ts
+++ b/packages/performance/src/constants.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/performance/src/constants.ts
+++ b/packages/performance/src/constants.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/performance/src/controllers/perf.ts
+++ b/packages/performance/src/controllers/perf.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2019 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/performance/src/controllers/perf.ts
+++ b/packages/performance/src/controllers/perf.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2019 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/tools/gitHooks/license.js
+++ b/tools/gitHooks/license.js
@@ -52,13 +52,12 @@ async function doLicenseCommit() {
   );
 
   // Files with no @license tag.
-  const appendedFileContents = await Promise.all(paths.map(path => fs.readFile(path)));
+  const appendedFileContents = await Promise.all(
+    paths.map(path => fs.readFile(path))
+  );
   const filesMissingTagPaths = appendedFileContents
     .map((buffer, idx) => ({ buffer, path: paths[idx] }))
-    .filter(
-      ({ buffer }) =>
-        String(buffer).match(/@license/) == null
-    );
+    .filter(({ buffer }) => String(buffer).match(/@license/) == null);
 
   await Promise.all(
     filesMissingTagPaths.map(({ buffer, path }) => {
@@ -66,7 +65,7 @@ async function doLicenseCommit() {
       let newLines = [];
       for (const line of lines) {
         if (line.match(/Copyright \d{4} Google Inc\./)) {
-          newLines.push('* @license')
+          newLines.push('* @license');
         }
         newLines.push(line);
       }

--- a/tools/gitHooks/license.js
+++ b/tools/gitHooks/license.js
@@ -65,7 +65,8 @@ async function doLicenseCommit() {
       let newLines = [];
       for (const line of lines) {
         if (line.match(/Copyright \d{4} Google Inc\./)) {
-          newLines.push('* @license');
+          const indent = line.split('*')[0]; // Get whitespace to match
+          newLines.push(indent + '* @license');
         }
         newLines.push(line);
       }


### PR DESCRIPTION
We have a script that automatically adds the entire license block but it doesn't add `@license` tags (required for internal Google use) if the block exists and is just missing the tag.  Updated the script to add these tags as well, and ran it on existing files.