### PR TITLE
Fix display of deprecated tags in generated docs.

### DIFF
--- a/packages/firebase/index.d.ts
+++ b/packages/firebase/index.d.ts
@@ -183,7 +183,7 @@ declare namespace firebase {
      *     {@link firebase.auth.PhoneAuthProvider.credential}  and the verification
      *     ID of the credential is not valid.</dd>
      * </dl>
-     * 
+     *
      * @deprecated  This method is deprecated. Use
      * {@link firebase.User.linkWithCredential} instead.
      *

--- a/packages/firebase/index.d.ts
+++ b/packages/firebase/index.d.ts
@@ -126,12 +126,8 @@ declare namespace firebase {
     getIdToken(forceRefresh?: boolean): Promise<string>;
     isAnonymous: boolean;
     /**
-     * @deprecated
      * Links the user account with the given credentials and returns any available
      * additional user information, such as user name.
-     *
-     * This method is deprecated. Use
-     * {@link firebase.User.linkWithCredential} instead.
      *
      * <h4>Error Codes</h4>
      * <dl>
@@ -187,6 +183,9 @@ declare namespace firebase {
      *     {@link firebase.auth.PhoneAuthProvider.credential}  and the verification
      *     ID of the credential is not valid.</dd>
      * </dl>
+     * 
+     * @deprecated  This method is deprecated. Use
+     * {@link firebase.User.linkWithCredential} instead.
      *
      * @param credential The auth credential.
      */
@@ -429,14 +428,10 @@ declare namespace firebase {
     phoneNumber: string | null;
     providerData: (firebase.UserInfo | null)[];
     /**
-     * @deprecated
      * Re-authenticates a user using a fresh credential, and returns any available
      * additional user information, such as user name. Use before operations
      * such as {@link firebase.User.updatePassword} that require tokens from recent
      * sign-in attempts.
-     *
-     * This method is deprecated. Use
-     * {@link firebase.User.reauthenticateWithCredential} instead.
      *
      * <h4>Error Codes</h4>
      * <dl>
@@ -466,6 +461,10 @@ declare namespace firebase {
      *     {@link firebase.auth.PhoneAuthProvider.credential}  and the verification
      *     ID of the credential is not valid.</dd>
      * </dl>
+     *
+     * @deprecated
+     * This method is deprecated. Use
+     * {@link firebase.User.reauthenticateWithCredential} instead.
      *
      * @param credential
      */
@@ -2158,12 +2157,8 @@ declare namespace firebase.auth {
     setPersistence(persistence: firebase.auth.Auth.Persistence): Promise<void>;
 
     /**
-     * @deprecated
      * Asynchronously signs in with the given credentials, and returns any available
      * additional user information, such as user name.
-     *
-     * This method is deprecated. Use
-     * {@link firebase.auth.Auth.signInWithCredential} instead.
      *
      * <h4>Error Codes</h4>
      * <dl>
@@ -2201,6 +2196,10 @@ declare namespace firebase.auth {
      *     {@link firebase.auth.PhoneAuthProvider.credential}  and the verification
      *     ID of the credential is not valid.</dd>
      * </dl>
+     *
+     * @deprecated
+     * This method is deprecated. Use
+     * {@link firebase.auth.Auth.signInWithCredential} instead.
      *
      * @example
      * ```javascript

--- a/scripts/docgen/theme/assets/css/firebase.css
+++ b/scripts/docgen/theme/assets/css/firebase.css
@@ -51,3 +51,13 @@
 .firebase-docs li.tsd-description:not(:last-child) {
     margin-bottom: 20px;
 }
+
+.firebase-docs .deprecated-tag-section {
+    border-bottom: 1px solid #eee;
+}
+
+.firebase-docs dt.tag-deprecated {
+    background-color: #dd2c00;
+    border-color: transparent;
+    color: white;
+}

--- a/scripts/docgen/theme/partials/comment.hbs
+++ b/scripts/docgen/theme/partials/comment.hbs
@@ -1,6 +1,16 @@
 {{#with comment}}
     {{#if hasVisibleComponent}}
         <div class="tsd-comment tsd-typography">
+            {{#if tags}}
+                {{#each tags}}
+                    {{#ifCond tagName '==' "deprecated"}}
+                    <dl class="tsd-comment-tags deprecated-tag-section">
+                        <dt class="tag-{{tagName}}">{{tagName}}</dt>
+                        <dd class="tag-body-{{tagName}}">{{#markdown}}{{{text}}}{{/markdown}}</dd>
+                    </dl>
+                    {{/ifCond}}
+                {{/each}}
+            {{/if}}
             {{#if shortText}}
                 <div class="lead">
                     {{#markdown}}{{{shortText}}}{{/markdown}}
@@ -14,8 +24,11 @@
                     {{#each tags}}
                         {{#ifCond tagName '==' "webonly"}}
                         {{else}}
-                        <dt class="tag-{{tagName}}">{{tagName}}</dt>
-                        <dd class="tag-body-{{tagName}}">{{#markdown}}{{{text}}}{{/markdown}}</dd>
+                            {{#ifCond tagName '==' "deprecated"}}
+                            {{else}}
+                            <dt class="tag-{{tagName}}">{{tagName}}</dt>
+                            <dd class="tag-body-{{tagName}}">{{#markdown}}{{{text}}}{{/markdown}}</dd>
+                            {{/ifCond}}
                         {{/ifCond}}
                     {{/each}}
                 </dl>


### PR DESCRIPTION
Unfortunately Typedoc requires tags to be below the body text of a comment or it will include the body text as part of the tag immediately above it.

However, we want the contents of `@deprecated` tags to appear at the top of the corresponding entry in the documentation, in order to have the most visibility.  So although we still have to put the `@deprecated` tag below the main body text in a comment, this change modifies the Handlebars template so any `@deprecated` tag will be displayed at the top of its entry.

Also added some styling to make the deprecated tag stand out, per request from docs team.