### PR TITLE
Add listAll() to storage-types

### DIFF
--- a/packages/storage-types/index.d.ts
+++ b/packages/storage-types/index.d.ts
@@ -51,6 +51,7 @@ export interface Reference {
   storage: Storage;
   toString(): string;
   updateMetadata(metadata: SettableMetadata): Promise<FullMetadata>;
+  listAll(): Promise<ListResult>;
   list(options?: ListOptions): Promise<ListResult>;
 }
 


### PR DESCRIPTION
I forgot to add `listAll` to storage-types in https://github.com/firebase/firebase-js-sdk/pull/1610