### PR TITLE
Replace faye-websocket with ws

### DIFF
--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -29,7 +29,6 @@
     "@firebase/database-types": "0.4.0",
     "@firebase/logger": "0.1.14",
     "@firebase/util": "0.2.17",
-    "@types/ws": "6.0.1",
     "tslib": "1.9.3",
     "ws": "7.0.0"
   },
@@ -38,6 +37,7 @@
     "@types/mocha": "5.2.6",
     "@types/node": "11.13.9",
     "@types/sinon": "7.0.11",
+    "@types/ws": "6.0.1",
     "chai": "4.2.0",
     "karma": "4.1.0",
     "karma-chrome-launcher": "2.2.0",

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -29,8 +29,9 @@
     "@firebase/database-types": "0.4.0",
     "@firebase/logger": "0.1.14",
     "@firebase/util": "0.2.17",
-    "faye-websocket": "0.11.1",
-    "tslib": "1.9.3"
+    "@types/ws": "6.0.1",
+    "tslib": "1.9.3",
+    "ws": "7.0.0"
   },
   "devDependencies": {
     "@types/chai": "4.1.7",

--- a/packages/database/src/nodePatches.ts
+++ b/packages/database/src/nodePatches.ts
@@ -21,7 +21,7 @@ import {
   FIREBASE_LONGPOLL_COMMAND_CB_NAME,
   FIREBASE_LONGPOLL_DATA_CB_NAME
 } from './realtime/BrowserPollConnection';
-import { Client } from 'faye-websocket';
+import * as Client from 'ws';
 
 setWebSocketImpl(Client);
 

--- a/packages/database/src/realtime/WebSocketConnection.ts
+++ b/packages/database/src/realtime/WebSocketConnection.ts
@@ -156,7 +156,7 @@ export class WebSocketConnection implements Transport {
           }
         };
 
-        // Plumb appropriate http_proxy environment variable into faye-websocket if it exists.
+        // Plumb in appropriate http_proxy environment variable, if it exists.
         const env = process['env'];
         const proxy =
           this.connURL.indexOf('wss://') == 0

--- a/yarn.lock
+++ b/yarn.lock
@@ -1947,6 +1947,14 @@
   resolved "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-2.3.3.tgz#7f226d67d654ec9070e755f46daebf014628e9d9"
   integrity sha512-MDQLxNFRLasqS4UlkWMSACMKeSm1x4Q3TxzUC7KQUsh6RK1ZrQ0VEyE3yzXcBu+K8ejVj4wuX32eUG02yNp+YQ==
 
+"@types/ws@6.0.1":
+  version "6.0.1"
+  resolved "https://registry.npmjs.org/@types/ws/-/ws-6.0.1.tgz#ca7a3f3756aa12f62a0a62145ed14c6db25d5a28"
+  integrity sha512-EzH8k1gyZ4xih/MaZTXwT2xOkPiIMSrhQ9b8wrlX88L0T02eYsddatQlwVFlEPyEqV0ChpdpNnE51QPH6NVT4Q==
+  dependencies:
+    "@types/events" "*"
+    "@types/node" "*"
+
 "@webassemblyjs/ast@1.8.5":
   version "1.8.5"
   resolved "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.8.5.tgz#51b1c5fe6576a34953bf4b253df9f0d490d9e359"
@@ -2716,7 +2724,7 @@ async-each@^1.0.0:
   resolved "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz#19d386a1d9edc6e7c1c85d388aedbcc56d33602d"
   integrity sha1-GdOGodntxufByF04iu28xW0zYC0=
 
-async-limiter@~1.0.0:
+async-limiter@^1.0.0, async-limiter@~1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz#78faed8c3d074ab81f22b4e985d79e8738f720f8"
   integrity sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg==
@@ -5820,7 +5828,7 @@ fast-url-parser@^1.1.3:
   dependencies:
     punycode "^1.3.2"
 
-faye-websocket@0.11.1, faye-websocket@>=0.6.0:
+faye-websocket@>=0.6.0:
   version "0.11.1"
   resolved "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.1.tgz#f0efe18c4f56e4f40afc7e06c719fd5ee6188f38"
   integrity sha1-8O/hjE9W5PQK/H4Gxxn9XuYYjzg=
@@ -14698,6 +14706,13 @@ write-pkg@^3.1.0:
   dependencies:
     sort-keys "^2.0.0"
     write-json-file "^2.2.0"
+
+ws@7.0.0:
+  version "7.0.0"
+  resolved "https://registry.npmjs.org/ws/-/ws-7.0.0.tgz#79351cbc3f784b3c20d0821baf4b4ff809ffbf51"
+  integrity sha512-cknCal4k0EAOrh1SHHPPWWh4qm93g1IuGGGwBjWkXmCG7LsDtL8w9w+YVfaF+KSVwiHQKDIMsSLBVftKf9d1pg==
+  dependencies:
+    async-limiter "^1.0.0"
 
 ws@~3.3.1:
   version "3.3.3"


### PR DESCRIPTION
This seems to be more a more modern websocket library. In my local benchmarks its performance is comparable with faye-websocket.

I encountered an inexplicable race condition when testing against the RTDB emulator and eventually root-caused it to an issue with faye-websocket occasionally dropping the first frame it receives. ws does not have this issue.

I do not think this will have any significant impact on clients, but it may give us more breathing room in terms of future maintenance.