### PR TITLE
Make yarn test:emulator work again

### DIFF
--- a/packages/firestore/package.json
+++ b/packages/firestore/package.json
@@ -17,7 +17,7 @@
     "test:browser:debug": "karma start --browsers=Chrome --auto-watch",
     "test:node": "TS_NODE_CACHE=NO TS_NODE_COMPILER_OPTIONS='{\"module\":\"commonjs\"}' nyc --reporter lcovonly -- mocha 'test/{,!(browser)/**/}*.test.ts' --file index.node.ts --opts ../../config/mocha.node.opts",
     "test:node:persistence": "USE_MOCK_PERSISTENCE=YES TS_NODE_CACHE=NO TS_NODE_COMPILER_OPTIONS='{\"module\":\"commonjs\"}' nyc --reporter lcovonly -- mocha 'test/{,!(browser)/**/}*.test.ts' --require ts-node/register --file index.node.ts --require test/util/node_persistence.ts --opts ../../config/mocha.node.opts",
-    "test:emulator": "ts-node ../../scripts/emulator-testing/firestore-test-runner.ts",
+    "test:emulator": "ts-node --compiler-options='{\"module\":\"commonjs\"}' ../../scripts/emulator-testing/firestore-test-runner.ts",
     "prepare": "yarn build"
   },
   "main": "dist/index.node.cjs.js",


### PR DESCRIPTION
Without the `module` set to `commonjs`, `yarn test:emulator` fails to `import * as tslib_1 from "tslib";`.

Other PRs will follow to set up travis testing against emulator.