### PR TITLE
Provide warning and potential workaround for iOS Safari bug described by #1670.

### DIFF
--- a/packages/firestore/CHANGELOG.md
+++ b/packages/firestore/CHANGELOG.md
@@ -2,16 +2,17 @@
 # Unreleased
 - [feature] Added `clearPersistence()`, which clears the persistent storage
   including pending writes and cached documents. This is intended to help
-  write reliable tests (#449). 
-- [changed] Added logging / custom error message for iOS safari bug described
-  in #1670.
+  write reliable tests (#449).
+- [changed] Added logging and a custom error message to help users hitting
+  https://bugs.webkit.org/show_bug.cgi?id=197050 (a bug in iOS 12.2 causing
+  the SDK to potentially crash when persistence is enabled).
 
 # 1.3.3
 - [changed] Firestore now recovers more quickly after network connectivity
   changes (airplane mode, Wi-Fi availability, etc.).
 
 # 1.3.0
-- [changed] Deprecated the `experimentalTabSynchronization` setting in favor of 
+- [changed] Deprecated the `experimentalTabSynchronization` setting in favor of
   `synchronizeTabs`. If you use multi-tab synchronization, it is recommended
   that you update your call to `enablePersistence()`. Firestore logs an error
   if you continue to use `experimentalTabSynchronization`.

--- a/packages/firestore/CHANGELOG.md
+++ b/packages/firestore/CHANGELOG.md
@@ -3,6 +3,8 @@
 - [feature] Added `clearPersistence()`, which clears the persistent storage
   including pending writes and cached documents. This is intended to help
   write reliable tests (#449). 
+- [changed] Added logging / custom error message for iOS safari bug described
+  in #1670.
 
 # 1.3.3
 - [changed] Firestore now recovers more quickly after network connectivity

--- a/packages/firestore/src/local/simple_db.ts
+++ b/packages/firestore/src/local/simple_db.ts
@@ -15,13 +15,13 @@
  * limitations under the License.
  */
 
+import { getUA } from '@firebase/util';
 import { assert } from '../util/assert';
 import { Code, FirestoreError } from '../util/error';
 import { debug, error } from '../util/log';
 import { Deferred } from '../util/promise';
 import { SCHEMA_VERSION } from './indexeddb_schema';
 import { PersistencePromise } from './persistence_promise';
-import { getUA } from '@firebase/util';
 
 const LOG_TAG = 'SimpleDb';
 

--- a/packages/firestore/src/local/simple_db.ts
+++ b/packages/firestore/src/local/simple_db.ts
@@ -17,10 +17,11 @@
 
 import { assert } from '../util/assert';
 import { Code, FirestoreError } from '../util/error';
-import { debug } from '../util/log';
+import { debug, error } from '../util/log';
 import { Deferred } from '../util/promise';
 import { SCHEMA_VERSION } from './indexeddb_schema';
 import { PersistencePromise } from './persistence_promise';
+import { getUA } from '@firebase/util';
 
 const LOG_TAG = 'SimpleDb';
 
@@ -149,8 +150,7 @@ export class SimpleDb {
     }
 
     // Check the UA string to find out the browser.
-    // TODO(mikelehen): Move this logic into packages/util/environment.ts
-    const ua = window.navigator.userAgent;
+    const ua = getUA();
 
     // IE 10
     // ua = 'Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; Trident/6.0)';
@@ -195,7 +195,12 @@ export class SimpleDb {
   /** Parse User Agent to determine iOS version. Returns -1 if not found. */
   static getIOSVersion(ua: string): number {
     const iOSVersionRegex = ua.match(/i(?:phone|pad|pod) os ([\d_]+)/i);
-    const version = iOSVersionRegex ? iOSVersionRegex[1].split('_')[0] : '-1';
+    const version = iOSVersionRegex
+      ? iOSVersionRegex[1]
+          .split('_')
+          .slice(0, 2)
+          .join('.')
+      : '-1';
     return Number(version);
   }
 
@@ -212,7 +217,21 @@ export class SimpleDb {
     return Number(version);
   }
 
-  constructor(private db: IDBDatabase) {}
+  constructor(private db: IDBDatabase) {
+    const iOSVersion = SimpleDb.getIOSVersion(getUA());
+    // NOTE: According to https://bugs.webkit.org/show_bug.cgi?id=197050, the
+    // bug we're checking for should exist in iOS >= 12.2 and < 13, but for
+    // whatever reason it's much harder to hit after 12.2 so we only proactively
+    // log on 12.2.
+    if (iOSVersion === 12.2) {
+      error(
+        'Firestore persistence on iOS 12.2 suffers from a bug in iOS 12.2 ' +
+          'Safari that may cause your app to stop working. See ' +
+          'https://stackoverflow.com/q/56496296/110915 for details ' +
+          'and potential workaround.'
+      );
+    }
+  }
 
   setVersionChangeListener(
     versionChangeListener: (event: IDBVersionChangeEvent) => void
@@ -359,7 +378,9 @@ export class SimpleDbTransaction {
       }
     };
     this.transaction.onerror = (event: Event) => {
-      this.completionDeferred.reject((event.target as IDBRequest).error!);
+      const error = (event.target as IDBRequest).error!;
+      checkForAndReportiOSError(error);
+      this.completionDeferred.reject(error);
     };
   }
 
@@ -578,7 +599,9 @@ export class SimpleDbStore<
     const cursorRequest = this.cursor({});
     return new PersistencePromise((resolve, reject) => {
       cursorRequest.onerror = (event: Event) => {
-        reject((event.target as IDBRequest).error!);
+        const error = (event.target as IDBRequest).error!;
+        checkForAndReportiOSError(error);
+        reject(error);
       };
       cursorRequest.onsuccess = (event: Event) => {
         const cursor: IDBCursorWithValue = (event.target as IDBRequest).result;
@@ -692,7 +715,35 @@ function wrapRequest<R>(request: IDBRequest): PersistencePromise<R> {
     };
 
     request.onerror = (event: Event) => {
-      reject((event.target as IDBRequest).error!);
+      const error = (event.target as IDBRequest).error!;
+      checkForAndReportiOSError(error);
+      reject(error);
     };
   });
+}
+
+// Guard so we only report the error once.
+let reportedIOSError = false;
+function checkForAndReportiOSError(error: DOMException): void {
+  if (reportedIOSError) {
+    return;
+  }
+  const iOSVersion = SimpleDb.getIOSVersion(getUA());
+  if (iOSVersion >= 12.2 && iOSVersion < 13) {
+    const IOS_ERROR =
+      'An internal error was encountered in the Indexed Database server';
+    if (error.message.indexOf(IOS_ERROR) >= 0) {
+      reportedIOSError = true;
+      // Throw a global exception outside of this promise chain, for the user to
+      // potentially catch.
+      setTimeout(() => {
+        throw new FirestoreError(
+          'internal',
+          `IOS_INDEXEDDB_BUG1: IndexedDb has thrown '${IOS_ERROR}'. This is likely ` +
+            `due to an unavoidable bug in iOS. See https://stackoverflow.com/q/56496296/110915 ` +
+            `for details and potential workaround.`
+        );
+      }, 0);
+    }
+  }
 }

--- a/packages/firestore/src/local/simple_db.ts
+++ b/packages/firestore/src/local/simple_db.ts
@@ -225,10 +225,10 @@ export class SimpleDb {
     // log on 12.2.
     if (iOSVersion === 12.2) {
       error(
-        'Firestore persistence on iOS 12.2 suffers from a bug in iOS 12.2 ' +
+        'Firestore persistence suffers from a bug in iOS 12.2 ' +
           'Safari that may cause your app to stop working. See ' +
           'https://stackoverflow.com/q/56496296/110915 for details ' +
-          'and potential workaround.'
+          'and a potential workaround.'
       );
     }
   }
@@ -741,7 +741,7 @@ function checkForAndReportiOSError(error: DOMException): void {
           'internal',
           `IOS_INDEXEDDB_BUG1: IndexedDb has thrown '${IOS_ERROR}'. This is likely ` +
             `due to an unavoidable bug in iOS. See https://stackoverflow.com/q/56496296/110915 ` +
-            `for details and potential workaround.`
+            `for details and a potential workaround.`
         );
       }, 0);
     }

--- a/packages/firestore/test/unit/local/simple_db.test.ts
+++ b/packages/firestore/test/unit/local/simple_db.test.ts
@@ -132,8 +132,8 @@ describe('SimpleDb', () => {
     const androidAgent =
       'Mozilla/5.0 (Linux; U; Android 2.2.1; fr-fr; Desire HD Build/FRG83D)' +
       ' AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1';
-    expect(SimpleDb.getIOSVersion(iPhoneSafariAgent)).to.equal(10);
-    expect(SimpleDb.getIOSVersion(iPadSafariAgent)).to.equal(9);
+    expect(SimpleDb.getIOSVersion(iPhoneSafariAgent)).to.equal(10.14);
+    expect(SimpleDb.getIOSVersion(iPadSafariAgent)).to.equal(9.0);
     expect(SimpleDb.getAndroidVersion(androidAgent)).to.equal(2.2);
   });
 


### PR DESCRIPTION
* On iOS 12.2 we proactively warn about the "internal error was encountered in
  Indexed Database Server" Bug.
* When the bug is actually encountered on iOS >= 12.2 an < 13 we log a custom
  error message.

Both log message and error link to https://stackoverflow.com/q/56496296/110915 which
provides potential error handling / recovery example.
