### PR TITLE
Change test:node:persistence to use --require instead of --file so it actually works.

### DIFF
--- a/packages/firestore/package.json
+++ b/packages/firestore/package.json
@@ -16,7 +16,7 @@
     "test:browser": "karma start --single-run",
     "test:browser:debug": "karma start --browsers=Chrome --auto-watch",
     "test:node": "TS_NODE_CACHE=NO TS_NODE_COMPILER_OPTIONS='{\"module\":\"commonjs\"}' nyc --reporter lcovonly -- mocha 'test/{,!(browser)/**/}*.test.ts' --file index.node.ts --opts ../../config/mocha.node.opts",
-    "test:node:persistence": "USE_MOCK_PERSISTENCE=YES TS_NODE_CACHE=NO TS_NODE_COMPILER_OPTIONS='{\"module\":\"commonjs\"}' nyc --reporter lcovonly -- mocha 'test/{,!(browser)/**/}*.test.ts' --require ts-node/register --file index.node.ts --require test/util/node_persistence.ts --opts ../../config/mocha.node.opts",
+    "test:node:persistence": "USE_MOCK_PERSISTENCE=YES TS_NODE_CACHE=NO TS_NODE_COMPILER_OPTIONS='{\"module\":\"commonjs\"}' nyc --reporter lcovonly -- mocha 'test/{,!(browser)/**/}*.test.ts' --require ts-node/register --require index.node.ts --require test/util/node_persistence.ts --opts ../../config/mocha.node.opts",
     "test:emulator": "ts-node --compiler-options='{\"module\":\"commonjs\"}' ../../scripts/emulator-testing/firestore-test-runner.ts",
     "prepare": "yarn build"
   },


### PR DESCRIPTION
Without this, I get:

Error: not supported
    at Root.loadSync (/usr/local/google/home/mikelehen/src/firebase-js-sdk/node_modules/@grpc/proto-loader/node_modules/protobufjs/src/root.js:234:15)

So somehow the protobuf code doesn't realize it's running in node or something...