### PR TITLE
Fix storage Reference.put() param type in top-level index.d.ts

### DIFF
--- a/packages/firebase/index.d.ts
+++ b/packages/firebase/index.d.ts
@@ -5440,7 +5440,7 @@ declare namespace firebase.storage {
      *     and manage the upload.
      */
     put(
-      data: any | any | any,
+      data: Blob | Uint8Array | ArrayBuffer,
       metadata?: firebase.storage.UploadMetadata
     ): firebase.storage.UploadTask;
     /**


### PR DESCRIPTION
Not sure how it got entered incorrectly, but fixing to match `storage-types/index.d.ts`