### PR TITLE
Overhaul Documents

### DIFF
--- a/packages/firestore/src/core/query.ts
+++ b/packages/firestore/src/core/query.ts
@@ -323,6 +323,7 @@ export class Query {
 
   matches(doc: Document): boolean {
     return (
+      doc.exists &&
       this.matchesPathAndCollectionGroup(doc) &&
       this.matchesOrderBy(doc) &&
       this.matchesFilters(doc) &&

--- a/packages/firestore/src/core/snapshot_version.ts
+++ b/packages/firestore/src/core/snapshot_version.ts
@@ -36,7 +36,7 @@ export class SnapshotVersion {
     return new SnapshotVersion(value);
   }
 
-  static forDeletedDoc(): SnapshotVersion {
+  static forMissingDoc(): SnapshotVersion {
     return SnapshotVersion.MIN;
   }
 

--- a/packages/firestore/src/core/sync_engine.ts
+++ b/packages/firestore/src/core/sync_engine.ts
@@ -23,9 +23,9 @@ import { ReferenceSet } from '../local/reference_set';
 import {
   documentKeySet,
   DocumentKeySet,
-  MaybeDocumentMap
+  DocumentMap
 } from '../model/collections';
-import { MaybeDocument, NoDocument } from '../model/document';
+import { Document } from '../model/document';
 import { DocumentKey } from '../model/document_key';
 import { Mutation } from '../model/mutation';
 import { MutationBatchResult } from '../model/mutation_batch';
@@ -526,12 +526,12 @@ export class SyncEngine implements RemoteSyncer, SharedClientStateSyncer {
       // This is kind of a hack. Ideally, we would have a method in the local
       // store to purge a document. However, it would be tricky to keep all of
       // the local store's invariants with another method.
-      let documentUpdates = new SortedMap<DocumentKey, MaybeDocument>(
+      let documentUpdates = new SortedMap<DocumentKey, Document>(
         DocumentKey.comparator
       );
       documentUpdates = documentUpdates.insert(
         limboKey,
-        new NoDocument(limboKey, SnapshotVersion.forDeletedDoc())
+        Document.missing(limboKey, SnapshotVersion.forMissingDoc())
       );
       const resolvedLimboDocuments = documentKeySet().add(limboKey);
       const event = new RemoteEvent(
@@ -758,7 +758,7 @@ export class SyncEngine implements RemoteSyncer, SharedClientStateSyncer {
   }
 
   private async emitNewSnapsAndNotifyLocalStore(
-    changes: MaybeDocumentMap,
+    changes: DocumentMap,
     remoteEvent?: RemoteEvent
   ): Promise<void> {
     const newSnaps: ViewSnapshot[] = [];

--- a/packages/firestore/src/local/indexeddb_schema.ts
+++ b/packages/firestore/src/local/indexeddb_schema.ts
@@ -579,8 +579,8 @@ export class DbUnknownDocument {
  * - An "unknown document" representing a document that is known to exist (at
  * some version) but whose contents are unknown.
  *
- * Note: This is the persisted equivalent of a MaybeDocument and could perhaps
- * be made more general if necessary.
+ * Note: This is the persisted equivalent of a Document and could perhaps be
+ * made more general if necessary.
  */
 export class DbRemoteDocument {
   static store = 'remoteDocuments';

--- a/packages/firestore/src/local/memory_persistence.ts
+++ b/packages/firestore/src/local/memory_persistence.ts
@@ -16,7 +16,7 @@
  */
 
 import { User } from '../auth/user';
-import { MaybeDocument } from '../model/document';
+import { Document } from '../model/document';
 import { DocumentKey } from '../model/document_key';
 import { JsonProtoSerializer } from '../remote/serializer';
 import { fail } from '../util/assert';
@@ -105,8 +105,7 @@ export class MemoryPersistence implements Persistence {
     this._started = true;
     this.referenceDelegate = referenceDelegateFactory(this);
     this.queryCache = new MemoryQueryCache(this);
-    const sizer = (doc: MaybeDocument) =>
-      this.referenceDelegate.documentSize(doc);
+    const sizer = (doc: Document) => this.referenceDelegate.documentSize(doc);
     this.indexManager = new MemoryIndexManager();
     this.remoteDocumentCache = new MemoryRemoteDocumentCache(
       this.indexManager,
@@ -287,7 +286,7 @@ export class MemoryEagerDelegate implements ReferenceDelegate {
     });
   }
 
-  documentSize(doc: MaybeDocument): number {
+  documentSize(doc: Document): number {
     // For eager GC, we don't care about the document size, there are no size thresholds.
     return 0;
   }
@@ -457,7 +456,7 @@ export class MemoryLruDelegate implements ReferenceDelegate, LruDelegate {
     return PersistencePromise.resolve();
   }
 
-  documentSize(maybeDoc: MaybeDocument): number {
+  documentSize(maybeDoc: Document): number {
     const remoteDocument = this.serializer.toDbRemoteDocument(maybeDoc);
     let value: unknown;
     if (remoteDocument.document) {

--- a/packages/firestore/src/local/remote_document_cache.ts
+++ b/packages/firestore/src/local/remote_document_cache.ts
@@ -19,10 +19,10 @@ import { Query } from '../core/query';
 import {
   DocumentKeySet,
   DocumentMap,
-  MaybeDocumentMap,
-  NullableMaybeDocumentMap
+  DocumentMap,
+  DocumentMap
 } from '../model/collections';
-import { MaybeDocument } from '../model/document';
+import { Document } from '../model/document';
 import { DocumentKey } from '../model/document_key';
 
 import { PersistenceTransaction } from './persistence';
@@ -32,35 +32,33 @@ import { RemoteDocumentChangeBuffer } from './remote_document_change_buffer';
 /**
  * Represents cached documents received from the remote backend.
  *
- * The cache is keyed by DocumentKey and entries in the cache are MaybeDocument
- * instances, meaning we can cache both Document instances (an actual document
- * with data) as well as NoDocument instances (indicating that the document is
- * known to not exist).
+ * The cache is keyed by DocumentKey and entries are Documents that may be
+ * existing or missing.
  */
 export interface RemoteDocumentCache {
   /**
    * Looks up an entry in the cache.
    *
    * @param documentKey The key of the entry to look up.
-   * @return The cached Document or NoDocument entry, or null if we have nothing
-   * cached.
+   * @return The cached Document (existing or missing), or unknown if we have
+   *     nothing cached.
    */
   getEntry(
     transaction: PersistenceTransaction,
     documentKey: DocumentKey
-  ): PersistencePromise<MaybeDocument | null>;
+  ): PersistencePromise<Document>;
 
   /**
    * Looks up a set of entries in the cache.
    *
    * @param documentKeys The keys of the entries to look up.
-   * @return The cached Document or NoDocument entries indexed by key. If an entry is not cached,
-   *     the corresponding key will be mapped to a null value.
+   * @return The cached Document entries indexed by key. If an entry is not
+   *     cached, the corresponding key will be mapped to an unknown document.
    */
   getEntries(
     transaction: PersistenceTransaction,
     documentKeys: DocumentKeySet
-  ): PersistencePromise<NullableMaybeDocumentMap>;
+  ): PersistencePromise<DocumentMap>;
 
   /**
    * Executes a query against the cached Document entries.
@@ -68,7 +66,7 @@ export interface RemoteDocumentCache {
    * Implementations may return extra documents if convenient. The results
    * should be re-filtered by the consumer before presenting them to the user.
    *
-   * Cached NoDocument entries have no bearing on query results.
+   * Cached missing Document entries have no bearing on query results.
    *
    * @param query The query to match documents against.
    * @return The set of matching documents.
@@ -90,7 +88,7 @@ export interface RemoteDocumentCache {
   // PORTING NOTE: This is only used for multi-tab synchronization.
   getNewDocumentChanges(
     transaction: PersistenceTransaction
-  ): PersistencePromise<MaybeDocumentMap>;
+  ): PersistencePromise<DocumentMap>;
 
   /**
    * Provides access to add or update the contents of the cache. The buffer

--- a/packages/firestore/src/model/collections.ts
+++ b/packages/firestore/src/model/collections.ts
@@ -21,44 +21,42 @@ import { SortedSet } from '../util/sorted_set';
 
 import { TargetId } from '../core/types';
 import { primitiveComparator } from '../util/misc';
-import { Document, MaybeDocument } from './document';
+import { Document } from './document';
 import { DocumentKey } from './document_key';
 
 /** Miscellaneous collection types / constants. */
-export type DocumentSizeEntry = {
-  maybeDocument: MaybeDocument;
-  size: number;
-};
-
-export type MaybeDocumentMap = SortedMap<DocumentKey, MaybeDocument>;
-const EMPTY_MAYBE_DOCUMENT_MAP = new SortedMap<DocumentKey, MaybeDocument>(
-  DocumentKey.comparator
-);
-export function maybeDocumentMap(): MaybeDocumentMap {
-  return EMPTY_MAYBE_DOCUMENT_MAP;
-}
-
-export type NullableMaybeDocumentMap = SortedMap<
-  DocumentKey,
-  MaybeDocument | null
->;
-
-export function nullableMaybeDocumentMap(): NullableMaybeDocumentMap {
-  return maybeDocumentMap();
-}
-
-export type DocumentSizeEntries = {
-  maybeDocuments: NullableMaybeDocumentMap;
-  sizeMap: SortedMap<DocumentKey, number>;
-};
 
 export type DocumentMap = SortedMap<DocumentKey, Document>;
+
 const EMPTY_DOCUMENT_MAP = new SortedMap<DocumentKey, Document>(
   DocumentKey.comparator
 );
 export function documentMap(): DocumentMap {
   return EMPTY_DOCUMENT_MAP;
 }
+
+/**
+ * Any structure that can look up documents by key, where entries that are
+ * missing are returned as null.
+ */
+interface DocumentLookup {
+  get(key: DocumentKey): Document | null;
+}
+
+export function getDocument(key: DocumentKey, map: DocumentLookup): Document {
+  const doc = map.get(key);
+  return doc ? doc : Document.unknown(key);
+}
+
+export type DocumentSizeEntry = {
+  maybeDocument: Document;
+  size: number;
+};
+
+export type DocumentSizeEntries = {
+  maybeDocuments: DocumentMap;
+  sizeMap: SortedMap<DocumentKey, number>;
+};
 
 export type DocumentVersionMap = SortedMap<DocumentKey, SnapshotVersion>;
 const EMPTY_DOCUMENT_VERSION_MAP = new SortedMap<DocumentKey, SnapshotVersion>(

--- a/packages/firestore/src/model/document.ts
+++ b/packages/firestore/src/model/document.ts
@@ -24,55 +24,162 @@ import { FieldPath } from './path';
 
 import * as api from '../protos/firestore_proto_api';
 
-export interface DocumentOptions {
-  hasLocalMutations?: boolean;
+export interface MissingDocumentOptions {
   hasCommittedMutations?: boolean;
 }
 
-/**
- * The result of a lookup for a given path may be an existing document or a
- * marker that this document does not exist at a given version.
- */
-export abstract class MaybeDocument {
-  constructor(readonly key: DocumentKey, readonly version: SnapshotVersion) {}
-
-  static compareByKey(d1: MaybeDocument, d2: MaybeDocument): number {
-    return DocumentKey.comparator(d1.key, d2.key);
-  }
+export interface DocumentOptions {
+  hasLocalMutations?: boolean;
+  hasCommittedMutations?: boolean;
 
   /**
-   * Whether this document had a local mutation applied that has not yet been
-   * acknowledged by Watch.
+   * Memoized serialized form of the document for optimization purposes (avoids
+   * repeated serialization). Might be undefined.
    */
-  abstract get hasPendingWrites(): boolean;
+  memoizedProto?: api.Document;
+}
 
-  abstract isEqual(other: MaybeDocument | null | undefined): boolean;
+/**
+ * At a high level, Documents either exist or don't exist. However, when they
+ * don't exist there are different reasons why they don't exist and we treat
+ * these all differently in the cache.
+ */
+export enum DocumentType {
+  /**
+   * A document that is unknown to the client. It doesn't exist locally but
+   * may or may not exist on the server.
+   */
+  UNKNOWN,
 
-  abstract toString(): string;
+  /**
+   * A special case of UNKNOWN document whose contents are unknown but that is
+   * known to exist on the server. This kind of document comes about when the
+   * server accepts an update (i.e. a mutation with a precondition that the
+   * document exists) but the client didn't have any base document to which
+   * the mutation applied.
+   *
+   * Note that even though the server considers the document to exist, the
+   * client still presents a local view as if it didn't exist. This type exists
+   * to allow the client to record the version at which the server said the
+   * document did exist, so that we can avoid flickering back to old versions
+   * while listening for updates.
+   */
+  CONTENTS_UNKNOWN,
+
+  /**
+   * A document that's definitely known not to exist, either because the server
+   * said it was missing or because a local mutation deleted it.
+   */
+  MISSING,
+
+  /**
+   * A document that's known to exist and we know what's inside it.
+   */
+  EXISTS
+}
+
+enum DocumentState {
+  /** No mutations applied. Document was sent to us by Watch. */
+  SYNCED,
+
+  /**
+   * Local mutations applied via the mutation queue. Document is potentially
+   * inconsistent.
+   */
+  LOCAL_MUTATIONS,
+
+  /**
+   * Mutations applied based on a write acknowledgment. Document is potentially
+   * inconsistent.
+   */
+  COMMITTED_MUTATIONS
 }
 
 /**
  * Represents a document in Firestore with a key, version, data and whether the
  * data has local mutations applied to it.
+ *
+ *
+ * A class representing a deleted document.
+ * Version is set to 0 if we don't point to any specific time, otherwise it
+ * denotes time we know it didn't exist at.
+ *
+ * A class representing an existing document whose data is unknown (e.g. a
+ * document that was updated without a known base document).
  */
-export class Document extends MaybeDocument {
-  readonly hasLocalMutations: boolean;
-  readonly hasCommittedMutations: boolean;
+export class Document {
+  static unknown(key: DocumentKey): Document {
+    return new Document(
+      DocumentType.UNKNOWN,
+      key,
+      SnapshotVersion.MIN,
+      ObjectValue.EMPTY,
+      DocumentState.SYNCED // TODO(wilhuff): could also be LOCAL_MUTATIONS
+    );
+  }
 
-  constructor(
+  static contentsUnknown(key: DocumentKey, version: SnapshotVersion): Document {
+    return new Document(
+      DocumentType.CONTENTS_UNKNOWN,
+      key,
+      version,
+      ObjectValue.EMPTY,
+      DocumentState.COMMITTED_MUTATIONS
+    );
+  }
+
+  static missing(
     key: DocumentKey,
     version: SnapshotVersion,
+    options?: MissingDocumentOptions
+  ): Document {
+    const state = this.makeDocumentState(options);
+    return new Document(
+      DocumentType.MISSING,
+      key,
+      version,
+      ObjectValue.EMPTY,
+      state
+    );
+  }
+
+  static existing(
+    key: DocumentKey,
+    version: SnapshotVersion,
+    data: ObjectValue,
+    options?: DocumentOptions
+  ): Document {
+    const state = this.makeDocumentState(options);
+    return new Document(DocumentType.EXISTS, key, version, data, state);
+  }
+
+  private static makeDocumentState(options?: DocumentOptions): DocumentState {
+    if (options !== undefined) {
+      if (!!options.hasLocalMutations) {
+        return DocumentState.LOCAL_MUTATIONS;
+      } else if (!!options.hasCommittedMutations) {
+        return DocumentState.COMMITTED_MUTATIONS;
+      }
+    }
+
+    return DocumentState.SYNCED;
+  }
+
+  private constructor(
+    readonly type: DocumentType,
+    readonly key: DocumentKey,
+    readonly version: SnapshotVersion,
     readonly data: ObjectValue,
-    options: DocumentOptions,
+    readonly documentState: DocumentState,
     /**
      * Memoized serialized form of the document for optimization purposes (avoids repeated
      * serialization). Might be undefined.
      */
     readonly proto?: api.Document
-  ) {
-    super(key, version);
-    this.hasLocalMutations = !!options.hasLocalMutations;
-    this.hasCommittedMutations = !!options.hasCommittedMutations;
+  ) {}
+
+  static compareByKey(d1: Document, d2: Document): number {
+    return DocumentKey.comparator(d1.key, d2.key);
   }
 
   field(path: FieldPath): FieldValue | undefined {
@@ -88,7 +195,7 @@ export class Document extends MaybeDocument {
     return this.data.value();
   }
 
-  isEqual(other: MaybeDocument | null | undefined): boolean {
+  isEqual(other: Document | null | undefined): boolean {
     return (
       other instanceof Document &&
       this.key.isEqual(other.key) &&
@@ -100,13 +207,57 @@ export class Document extends MaybeDocument {
   }
 
   toString(): string {
+    switch (this.type) {
+      case DocumentType.UNKNOWN:
+        return `Document(UNKNOWN, ${this.key})`;
+      case DocumentType.CONTENTS_UNKNOWN:
+        return `Document(CONTENTS_UNKNOWN, ${this.key}, ${this.version})`;
+      case DocumentType.MISSING:
+        return `Document(MISSING, ${this.key}, ${this.version})`;
+      case DocumentType.EXISTS:
+        return (
+          `Document(${this.key}, ${this.version}, ${this.data.toString()}, ` +
+          `documentState=${this.documentState})`
+        );
+      default:
+        return fail('Unknown document type');
+    }
+  }
+
+  get exists(): boolean {
+    return this.type === DocumentType.EXISTS;
+  }
+
+  get missing(): boolean {
+    return this.type === DocumentType.MISSING;
+  }
+
+  get unknown(): boolean {
+    return this.type === DocumentType.UNKNOWN;
+  }
+
+  /**
+   * Returns true if the document is of some definite type: either existing
+   * or definitely missing.
+   */
+  get definite(): boolean {
     return (
-      `Document(${this.key}, ${this.version}, ${this.data.toString()}, ` +
-      `{hasLocalMutations: ${this.hasLocalMutations}}), ` +
-      `{hasCommittedMutations: ${this.hasCommittedMutations}})`
+      this.type === DocumentType.EXISTS || this.type === DocumentType.MISSING
     );
   }
 
+  get hasLocalMutations(): boolean {
+    return this.documentState === DocumentState.LOCAL_MUTATIONS;
+  }
+
+  get hasCommittedMutations(): boolean {
+    return this.documentState === DocumentState.COMMITTED_MUTATIONS;
+  }
+
+  /**
+   * Whether this document had a local mutation applied that has not yet been
+   * acknowledged by Watch.
+   */
   get hasPendingWrites(): boolean {
     return this.hasLocalMutations || this.hasCommittedMutations;
   }
@@ -119,66 +270,5 @@ export class Document extends MaybeDocument {
     } else {
       return fail("Trying to compare documents on fields that don't exist");
     }
-  }
-}
-
-/**
- * A class representing a deleted document.
- * Version is set to 0 if we don't point to any specific time, otherwise it
- * denotes time we know it didn't exist at.
- */
-export class NoDocument extends MaybeDocument {
-  readonly hasCommittedMutations: boolean;
-
-  constructor(
-    key: DocumentKey,
-    version: SnapshotVersion,
-    options?: DocumentOptions
-  ) {
-    super(key, version);
-    this.hasCommittedMutations = !!(options && options.hasCommittedMutations);
-  }
-
-  toString(): string {
-    return `NoDocument(${this.key}, ${this.version})`;
-  }
-
-  get hasPendingWrites(): boolean {
-    return this.hasCommittedMutations;
-  }
-
-  isEqual(other: MaybeDocument | null | undefined): boolean {
-    return (
-      other instanceof NoDocument &&
-      other.hasCommittedMutations === this.hasCommittedMutations &&
-      other.version.isEqual(this.version) &&
-      other.key.isEqual(this.key)
-    );
-  }
-}
-
-/**
- * A class representing an existing document whose data is unknown (e.g. a
- * document that was updated without a known base document).
- */
-export class UnknownDocument extends MaybeDocument {
-  constructor(key: DocumentKey, version: SnapshotVersion) {
-    super(key, version);
-  }
-
-  toString(): string {
-    return `UnknownDocument(${this.key}, ${this.version})`;
-  }
-
-  get hasPendingWrites(): boolean {
-    return true;
-  }
-
-  isEqual(other: MaybeDocument | null | undefined): boolean {
-    return (
-      other instanceof UnknownDocument &&
-      other.version.isEqual(this.version) &&
-      other.key.isEqual(this.key)
-    );
   }
 }

--- a/packages/firestore/src/model/document_set.ts
+++ b/packages/firestore/src/model/document_set.ts
@@ -28,7 +28,6 @@ import { DocumentKey } from './document_key';
  * comparator on top of what is provided to guarantee document equality based on
  * the key.
  */
-
 export class DocumentSet {
   /**
    * Returns an empty copy of the existing DocumentSet, using the same

--- a/packages/firestore/src/platform/platform.ts
+++ b/packages/firestore/src/platform/platform.ts
@@ -18,9 +18,9 @@
 import { DatabaseId, DatabaseInfo } from '../core/database_info';
 import { ProtoByteString } from '../core/types';
 import { Connection } from '../remote/connection';
+import { ConnectivityMonitor } from '../remote/connectivity_monitor';
 import { JsonProtoSerializer } from '../remote/serializer';
 import { fail } from '../util/assert';
-import { ConnectivityMonitor } from './../remote/connectivity_monitor';
 
 /**
  * Provides a common interface to load anything platform dependent, e.g.

--- a/packages/firestore/src/remote/datastore.ts
+++ b/packages/firestore/src/remote/datastore.ts
@@ -16,8 +16,8 @@
  */
 
 import { CredentialsProvider } from '../api/credentials';
-import { maybeDocumentMap } from '../model/collections';
-import { MaybeDocument } from '../model/document';
+import { documentMap } from '../model/collections';
+import { Document } from '../model/document';
 import { DocumentKey } from '../model/document_key';
 import { Mutation, MutationResult } from '../model/mutation';
 import * as api from '../protos/firestore_proto_api';
@@ -95,7 +95,7 @@ export class Datastore {
     });
   }
 
-  lookup(keys: DocumentKey[]): Promise<MaybeDocument[]> {
+  lookup(keys: DocumentKey[]): Promise<Document[]> {
     const params: BatchGetDocumentsRequest = {
       database: this.serializer.encodedDatabaseId,
       documents: keys.map(k => this.serializer.toName(k))
@@ -104,12 +104,12 @@ export class Datastore {
       BatchGetDocumentsRequest,
       api.BatchGetDocumentsResponse
     >('BatchGetDocuments', params).then(response => {
-      let docs = maybeDocumentMap();
+      let docs = documentMap();
       response.forEach(proto => {
         const doc = this.serializer.fromMaybeDocument(proto);
         docs = docs.insert(doc.key, doc);
       });
-      const result: MaybeDocument[] = [];
+      const result: Document[] = [];
       keys.forEach(key => {
         const doc = docs.get(key);
         assert(!!doc, 'Missing entity in write response for ' + key);

--- a/packages/firestore/src/remote/remote_event.ts
+++ b/packages/firestore/src/remote/remote_event.ts
@@ -20,8 +20,8 @@ import { ProtoByteString, TargetId } from '../core/types';
 import {
   documentKeySet,
   DocumentKeySet,
-  maybeDocumentMap,
-  MaybeDocumentMap,
+  documentMap,
+  DocumentMap,
   targetIdSet
 } from '../model/collections';
 import { emptyByteString } from '../platform/platform';
@@ -51,7 +51,7 @@ export class RemoteEvent {
      * A set of which documents have changed or been deleted, along with the
      * doc's new values (if not deleted).
      */
-    readonly documentUpdates: MaybeDocumentMap,
+    readonly documentUpdates: DocumentMap,
     /**
      * A set of which document updates are due only to limbo resolution targets.
      */
@@ -79,7 +79,7 @@ export class RemoteEvent {
       SnapshotVersion.MIN,
       targetChanges,
       targetIdSet(),
-      maybeDocumentMap(),
+      documentMap(),
       documentKeySet()
     );
   }

--- a/packages/firestore/test/integration/remote/remote.test.ts
+++ b/packages/firestore/test/integration/remote/remote.test.ts
@@ -17,11 +17,7 @@
 
 import { expect } from 'chai';
 import { SnapshotVersion } from '../../../src/core/snapshot_version';
-import {
-  Document,
-  MaybeDocument,
-  NoDocument
-} from '../../../src/model/document';
+import { Document } from '../../../src/model/document';
 import { MutationResult } from '../../../src/model/mutation';
 import { addEqualityMatcher } from '../../util/equality_matcher';
 import { key, setMutation } from '../../util/helpers';
@@ -53,12 +49,12 @@ describe('Remote Storage', () => {
         .then((result: MutationResult[]) => {
           return ds.lookup([k]);
         })
-        .then((docs: MaybeDocument[]) => {
+        .then((docs: Document[]) => {
           expect(docs.length).to.equal(1);
 
           const doc = docs[0];
           expect(doc).to.be.an.instanceof(Document);
-          if (doc instanceof Document) {
+          if (doc.exists) {
             expect(doc.data).to.deep.equal(mutation.value);
             expect(doc.key).to.deep.equal(k);
             expect(SnapshotVersion.MIN.compareTo(doc.version)).to.be.lessThan(
@@ -72,11 +68,11 @@ describe('Remote Storage', () => {
   it('can read deleted documents', () => {
     return withTestDatastore(ds => {
       const k = key('docs/2');
-      return ds.lookup([k]).then((docs: MaybeDocument[]) => {
+      return ds.lookup([k]).then((docs: Document[]) => {
         expect(docs.length).to.equal(1);
         const doc = docs[0];
-        expect(doc).to.be.an.instanceof(NoDocument);
-        if (doc instanceof NoDocument) {
+        expect(doc.missing).to.be.true;
+        if (doc.missing) {
           expect(doc.key).to.deep.equal(k);
           expect(SnapshotVersion.MIN.compareTo(doc.version)).to.be.lessThan(0);
         }

--- a/packages/firestore/test/unit/local/test_remote_document_cache.ts
+++ b/packages/firestore/test/unit/local/test_remote_document_cache.ts
@@ -27,13 +27,8 @@ import {
 import { PersistencePromise } from '../../../src/local/persistence_promise';
 import { RemoteDocumentCache } from '../../../src/local/remote_document_cache';
 import { RemoteDocumentChangeBuffer } from '../../../src/local/remote_document_change_buffer';
-import {
-  DocumentKeySet,
-  DocumentMap,
-  MaybeDocumentMap,
-  NullableMaybeDocumentMap
-} from '../../../src/model/collections';
-import { MaybeDocument } from '../../../src/model/document';
+import { DocumentKeySet, DocumentMap } from '../../../src/model/collections';
+import { Document } from '../../../src/model/document';
 import { DocumentKey } from '../../../src/model/document_key';
 
 /**
@@ -50,7 +45,7 @@ export abstract class TestRemoteDocumentCache {
    * Reads all of the documents first so we can safely add them and keep the size calculation in
    * sync.
    */
-  addEntries(maybeDocuments: MaybeDocument[]): Promise<void> {
+  addEntries(maybeDocuments: Document[]): Promise<void> {
     return this.persistence.runTransaction(
       'addEntry',
       'readwrite-primary',
@@ -83,13 +78,13 @@ export abstract class TestRemoteDocumentCache {
     documentKey: DocumentKey
   ): PersistencePromise<number>;
 
-  getEntry(documentKey: DocumentKey): Promise<MaybeDocument | null> {
+  getEntry(documentKey: DocumentKey): Promise<Document> {
     return this.persistence.runTransaction('getEntry', 'readonly', txn => {
       return this.cache.getEntry(txn, documentKey);
     });
   }
 
-  getEntries(documentKeys: DocumentKeySet): Promise<NullableMaybeDocumentMap> {
+  getEntries(documentKeys: DocumentKeySet): Promise<DocumentMap> {
     return this.persistence.runTransaction('getEntries', 'readonly', txn => {
       return this.cache.getEntries(txn, documentKeys);
     });
@@ -105,7 +100,7 @@ export abstract class TestRemoteDocumentCache {
     );
   }
 
-  getNewDocumentChanges(): Promise<MaybeDocumentMap> {
+  getNewDocumentChanges(): Promise<DocumentMap> {
     return this.persistence.runTransaction(
       'getNewDocumentChanges',
       'readonly',

--- a/packages/firestore/test/unit/local/test_remote_document_change_buffer.ts
+++ b/packages/firestore/test/unit/local/test_remote_document_change_buffer.ts
@@ -17,7 +17,7 @@
 
 import { Persistence } from '../../../src/local/persistence';
 import { RemoteDocumentChangeBuffer } from '../../../src/local/remote_document_change_buffer';
-import { MaybeDocument } from '../../../src/model/document';
+import { Document } from '../../../src/model/document';
 import { DocumentKey } from '../../../src/model/document_key';
 
 /**
@@ -30,11 +30,11 @@ export class TestRemoteDocumentChangeBuffer {
     public buffer: RemoteDocumentChangeBuffer
   ) {}
 
-  addEntry(maybeDocument: MaybeDocument): void {
+  addEntry(maybeDocument: Document): void {
     this.buffer.addEntry(maybeDocument);
   }
 
-  getEntry(documentKey: DocumentKey): Promise<MaybeDocument | null> {
+  getEntry(documentKey: DocumentKey): Promise<Document> {
     return this.persistence.runTransaction('getEntry', 'readonly', txn => {
       return this.buffer.getEntry(txn, documentKey);
     });

--- a/packages/firestore/test/unit/remote/node/serializer.test.ts
+++ b/packages/firestore/test/unit/remote/node/serializer.test.ts
@@ -72,6 +72,7 @@ import {
   ref,
   setMutation,
   transformMutation,
+  unknownDoc,
   version,
   wrap,
   wrapObject
@@ -1310,7 +1311,6 @@ describe('Serializer', () => {
       const expected = new DocumentWatchChange(
         [1, 2],
         [],
-        key('coll/1'),
         doc('coll/1', 5, { foo: 'bar' })
       );
       const actual = s.fromWatchChange({
@@ -1330,7 +1330,6 @@ describe('Serializer', () => {
       const expected = new DocumentWatchChange(
         [2],
         [1],
-        key('coll/1'),
         doc('coll/1', 5, { foo: 'bar' })
       );
       const actual = s.fromWatchChange({
@@ -1351,7 +1350,6 @@ describe('Serializer', () => {
       const expected = new DocumentWatchChange(
         [],
         [1, 2],
-        key('coll/1'),
         deletedDoc('coll/1', 5)
       );
       const actual = s.fromWatchChange({
@@ -1365,7 +1363,8 @@ describe('Serializer', () => {
     });
 
     it('converts document removes', () => {
-      const expected = new DocumentWatchChange([], [1, 2], key('coll/1'), null);
+      const doc = unknownDoc('coll/1');
+      const expected = new DocumentWatchChange([], [1, 2], doc);
       const actual = s.fromWatchChange({
         documentRemove: {
           document: s.toName(key('coll/1')),

--- a/packages/firestore/test/unit/remote/remote_event.test.ts
+++ b/packages/firestore/test/unit/remote/remote_event.test.ts
@@ -163,13 +163,8 @@ describe('RemoteEvent', () => {
     const existingDoc = doc('docs/1', 1, { value: 1 });
     const newDoc = doc('docs/2', 2, { value: 2 });
 
-    const change1 = new DocumentWatchChange(
-      [1, 2, 3],
-      [4, 5, 6],
-      existingDoc.key,
-      existingDoc
-    );
-    const change2 = new DocumentWatchChange([1, 4], [2, 6], newDoc.key, newDoc);
+    const change1 = new DocumentWatchChange([1, 2, 3], [4, 5, 6], existingDoc);
+    const change2 = new DocumentWatchChange([1, 4], [2, 6], newDoc);
     const existingKeys = keys(existingDoc);
 
     const event = createRemoteEvent({
@@ -214,10 +209,10 @@ describe('RemoteEvent', () => {
     // We're waiting for the unlisten and listen ack.
     const outstandingResponses = { 1: 2 };
 
-    const change1 = new DocumentWatchChange([1], [], doc1.key, doc1);
+    const change1 = new DocumentWatchChange([1], [], doc1);
     const change2 = new WatchTargetChange(WatchTargetChangeState.Removed, [1]);
     const change3 = new WatchTargetChange(WatchTargetChangeState.Added, [1]);
-    const change4 = new DocumentWatchChange([1], [], doc2.key, doc2);
+    const change4 = new DocumentWatchChange([1], [], doc2);
 
     const event = createRemoteEvent({
       snapshotVersion: 3,
@@ -241,7 +236,7 @@ describe('RemoteEvent', () => {
     // We're waiting for the removal ack.
     const outstandingResponses = { 1: 1 };
 
-    const change1 = new DocumentWatchChange([1], [], doc1.key, doc1);
+    const change1 = new DocumentWatchChange([1], [], doc1);
     const change2 = new WatchTargetChange(WatchTargetChangeState.Removed, [1]);
 
     const event = createRemoteEvent({
@@ -265,16 +260,16 @@ describe('RemoteEvent', () => {
     // Need to listen at target 1 for this to work.
     const targets = listens(1);
 
-    const change1 = new DocumentWatchChange([1], [], doc1.key, doc1);
+    const change1 = new DocumentWatchChange([1], [], doc1);
     // Reset stream, ignoring doc1
     const change2 = new WatchTargetChange(WatchTargetChangeState.Reset, [1]);
 
     // Add doc2, doc3
-    const change3 = new DocumentWatchChange([1], [], doc2.key, doc2);
-    const change4 = new DocumentWatchChange([1], [], doc3.key, doc3);
+    const change3 = new DocumentWatchChange([1], [], doc2);
+    const change4 = new DocumentWatchChange([1], [], doc3);
 
     // Remove doc2 again, should not show up in reset mapping.
-    const change5 = new DocumentWatchChange([], [1], doc2.key, doc2);
+    const change5 = new DocumentWatchChange([], [1], doc2);
 
     const event = createRemoteEvent({
       snapshotVersion: 3,
@@ -325,8 +320,8 @@ describe('RemoteEvent', () => {
     const doc1a = doc('docs/1', 1, { value: 1 });
     const doc1b = doc('docs/1', 1, { value: 2 });
 
-    const change1 = new DocumentWatchChange([1], [2], doc1a.key, doc1a);
-    const change2 = new DocumentWatchChange([2], [1], doc1b.key, doc1b);
+    const change1 = new DocumentWatchChange([1], [2], doc1a);
+    const change2 = new DocumentWatchChange([2], [1], doc1b);
 
     const event = createRemoteEvent({
       snapshotVersion: 3,
@@ -375,7 +370,7 @@ describe('RemoteEvent', () => {
     const doc1 = doc('docs/1', 1, { value: 1 });
     const doc2 = doc('docs/2', 2, { value: 2 });
 
-    const change1 = new DocumentWatchChange([1, 3], [2], doc1.key, doc1);
+    const change1 = new DocumentWatchChange([1, 3], [2], doc1);
     const change2 = new WatchTargetChange(WatchTargetChangeState.Current, [
       1,
       2,
@@ -384,7 +379,7 @@ describe('RemoteEvent', () => {
     const change3 = new WatchTargetChange(WatchTargetChangeState.Removed, [1]);
     const change4 = new WatchTargetChange(WatchTargetChangeState.Removed, [2]);
     const change5 = new WatchTargetChange(WatchTargetChangeState.Added, [1]);
-    const change6 = new DocumentWatchChange([1], [3], doc2.key, doc2);
+    const change6 = new DocumentWatchChange([1], [3], doc2);
 
     const event = createRemoteEvent({
       snapshotVersion: 3,
@@ -437,8 +432,8 @@ describe('RemoteEvent', () => {
 
     const doc1 = doc('docs/1', 1, { value: 1 });
     const doc2 = doc('docs/2', 1, { value: 1 });
-    const change1 = new DocumentWatchChange([1, 2], [], doc1.key, doc1);
-    const change2 = new DocumentWatchChange([2], [], doc2.key, doc2);
+    const change1 = new DocumentWatchChange([1, 2], [], doc1);
+    const change2 = new DocumentWatchChange([2], [], doc2);
 
     const aggregator = createAggregator({
       snapshotVersion: 3,
@@ -470,7 +465,7 @@ describe('RemoteEvent', () => {
     const targets = listens(1);
 
     const doc1 = doc('docs/1', 1, { value: 1 });
-    const addDoc = new DocumentWatchChange([1], [], doc1.key, doc1);
+    const addDoc = new DocumentWatchChange([1], [], doc1);
     const markCurrent = new WatchTargetChange(
       WatchTargetChangeState.Current,
       [1],
@@ -506,8 +501,8 @@ describe('RemoteEvent', () => {
     const updatedDoc2 = doc('docs/2', 3, { value: 2 });
     const doc3 = doc('docs/3', 3, { value: 3 });
 
-    const change1 = new DocumentWatchChange([1], [], doc1.key, doc1);
-    const change2 = new DocumentWatchChange([1], [], doc2.key, doc2);
+    const change1 = new DocumentWatchChange([1], [], doc1);
+    const change2 = new DocumentWatchChange([1], [], doc2);
 
     const aggregator = createAggregator({
       snapshotVersion: 3,
@@ -555,8 +550,8 @@ describe('RemoteEvent', () => {
     const doc2 = doc('docs/2', 2, { value: 2 });
     const updatedDoc2 = doc('docs/2', 3, { value: 2 });
 
-    const change1 = new DocumentWatchChange([1], [], doc1.key, doc1);
-    const change2 = new DocumentWatchChange([2], [], doc2.key, doc2);
+    const change1 = new DocumentWatchChange([1], [], doc1);
+    const change2 = new DocumentWatchChange([2], [], doc2);
 
     const aggregator = createAggregator({
       snapshotVersion: 3,
@@ -622,17 +617,11 @@ describe('RemoteEvent', () => {
     const updateTargetId = 1;
     const newDoc = doc('docs/new', 1, { key: 'value' });
     const existingDoc = doc('docs/existing', 1, { some: 'data' });
-    const newDocChange = new DocumentWatchChange(
-      [updateTargetId],
-      [],
-      newDoc.key,
-      newDoc
-    );
+    const newDocChange = new DocumentWatchChange([updateTargetId], [], newDoc);
 
     const existingDocChange = new DocumentWatchChange(
       [updateTargetId],
       [],
-      existingDoc.key,
       existingDoc
     );
 
@@ -660,9 +649,9 @@ describe('RemoteEvent', () => {
 
     // Target 2 is a limbo target
 
-    const docChange1 = new DocumentWatchChange([1, 2], [], doc1.key, doc1);
-    const docChange2 = new DocumentWatchChange([2], [], doc2.key, doc2);
-    const docChange3 = new DocumentWatchChange([1], [], doc3.key, doc3);
+    const docChange1 = new DocumentWatchChange([1, 2], [], doc1);
+    const docChange2 = new DocumentWatchChange([2], [], doc2);
+    const docChange3 = new DocumentWatchChange([1], [], doc3);
 
     const targetsChange = new WatchTargetChange(
       WatchTargetChangeState.Current,

--- a/packages/firestore/test/unit/specs/listen_spec.test.ts
+++ b/packages/firestore/test/unit/specs/listen_spec.test.ts
@@ -438,7 +438,7 @@ describeSpec('Listens:', [], () => {
         .userUnlistens(setupQuery)
         .watchRemoves(setupQuery)
 
-        // Now when the client listens expect the cached NoDocument to be
+        // Now when the client listens expect the cached missing Document to be
         // discarded because the global snapshot version exceeds what came
         // before.
         .userListens(allQuery)

--- a/packages/firestore/test/unit/specs/spec_test_runner.ts
+++ b/packages/firestore/test/unit/specs/spec_test_runner.ts
@@ -57,7 +57,7 @@ import {
   WebStorageSharedClientState
 } from '../../../src/local/shared_client_state';
 import { SimpleDb } from '../../../src/local/simple_db';
-import { DocumentOptions } from '../../../src/model/document';
+import { Document, DocumentOptions } from '../../../src/model/document';
 import { DocumentKey } from '../../../src/model/document_key';
 import { JsonObject } from '../../../src/model/field_value';
 import { Mutation } from '../../../src/model/mutation';
@@ -732,7 +732,6 @@ abstract class TestRunner {
       const change = new DocumentWatchChange(
         watchEntity.targets || [],
         watchEntity.removedTargets || [],
-        document.key,
         document
       );
       return this.doWatchEvent(change);
@@ -741,8 +740,7 @@ abstract class TestRunner {
       const change = new DocumentWatchChange(
         watchEntity.targets || [],
         watchEntity.removedTargets || [],
-        documentKey,
-        null
+        Document.unknown(documentKey)
       );
       return this.doWatchEvent(change);
     } else {

--- a/packages/firestore/test/util/api_helpers.ts
+++ b/packages/firestore/test/util/api_helpers.ts
@@ -36,7 +36,7 @@ import { DocumentKeySet } from '../../src/model/collections';
 import { Document } from '../../src/model/document';
 import { DocumentSet } from '../../src/model/document_set';
 import { JsonObject } from '../../src/model/field_value';
-import { doc, key, path as pathFrom } from './helpers';
+import { doc, key, path as pathFrom, unknownDoc } from './helpers';
 
 /**
  * A mock Firestore. Will not work for integration test.
@@ -63,23 +63,13 @@ export function documentSnapshot(
   data: JsonObject<unknown> | null,
   fromCache: boolean
 ): DocumentSnapshot {
-  if (data) {
-    return new DocumentSnapshot(
-      firestore(),
-      key(path),
-      doc(path, 1, data),
-      fromCache,
-      /* hasPendingWrites= */ false
-    );
-  } else {
-    return new DocumentSnapshot(
-      firestore(),
-      key(path),
-      null,
-      fromCache,
-      /* hasPendingWrites= */ false
-    );
-  }
+  const doc1 = data ? doc(path, 1, data) : unknownDoc(path);
+  return new DocumentSnapshot(
+    firestore(),
+    doc1,
+    fromCache,
+    /* hasPendingWrites= */ false
+  );
 }
 
 export function query(path: string): Query {


### PR DESCRIPTION
Remove different internal types for `MaybeDocument`, `Document`, `NoDocument`,
and `UnknownDocument`. These are all now just `Document`.

Also make Documents non-nullable nearly everywhere.

The change introduces a `DocumentType` enum and maps the old classes like
so:

| Before          | After                         |
| --------------- | ----------------------------- |
| `null`            | `DocumentType.UNKNOWN`          |
| `UnknownDocument` | `DocumentType.CONTENTS_UNKNOWN` |
| `NoDocument`      | `DocumentType.MISSING`          |
| `Document`        | `DocumentType.EXISTING`         |

Part of why this change works is that most of the system only cares
whether or not a document exists. We have several refinements of
non-existing documents for the purposes of caching but everywhere else
we can ignore it and just check `document.exists`. The `instanceof` checks
were usually over-constraining things.

The motivation for this change is in two parts:

  * It's always bugged me that we had so many `instanceof` checks around
  * In C++ we don't have `instanceof` anyway, so we have to do something
    else.

Also, this definitely addresses b/32275378.