### PR TITLE
Update HttpMethod from hardcode value '1' to networkRequest object value

### DIFF
--- a/packages/performance/src/services/perf_logger.test.ts
+++ b/packages/performance/src/services/perf_logger.test.ts
@@ -143,7 +143,7 @@ describe('Performance Monitoring > perf_logger', () => {
 "visibility_state":${VISIBILITY_STATE},"effective_connection_type":${EFFECTIVE_CONNECTION_TYPE}},\
 "application_process_state":0},\
 "network_request_metric":{"url":"${RESOURCE_PERFORMANCE_ENTRY.name}",\
-"http_method":1,"http_response_code":200,\
+"http_method":0,"http_response_code":200,\
 "response_payload_bytes":${RESOURCE_PERFORMANCE_ENTRY.transferSize},\
 "client_start_time_us":${START_TIME},\
 "time_to_response_completed_us":${TIME_TO_RESPONSE_COMPLETED}}}`;

--- a/packages/performance/src/services/perf_logger.ts
+++ b/packages/performance/src/services/perf_logger.ts
@@ -171,7 +171,7 @@ function serializer(resource: {}, resourceType: ResourceType): string {
 function serializeNetworkRequest(networkRequest: NetworkRequest): string {
   const networkRequestMetric: NetworkRequestMetric = {
     url: networkRequest.url,
-    http_method: 1,
+    http_method: networkRequest.httpMethod || 0,
     http_response_code: 200,
     response_payload_bytes: networkRequest.responsePayloadBytes,
     client_start_time_us: networkRequest.startTimeUs,


### PR DESCRIPTION
Browser API doesn't support retrieving HTTP method value currently. Firebase Performance SDK hard coded 1 as HTTP method value to bypass validation check. Firebase Performance service now accpets 0 as value, thus updating SDK to apply HTTP method value from networkRequest object.