### PR TITLE
Do not initialize performance if required apis are not available

### DIFF
--- a/packages/performance/index.ts
+++ b/packages/performance/index.ts
@@ -24,7 +24,6 @@ import {
 import { PerformanceController } from './src/controllers/perf';
 import { setupApi } from './src/services/api_service';
 import { SettingsService } from './src/services/settings_service';
-import { consoleLogger } from './src/utils/console_logger';
 import { ERROR_FACTORY, ErrorCode } from './src/utils/errors';
 import { FirebasePerformance } from '@firebase/performance-types';
 
@@ -50,14 +49,8 @@ export function registerPerformance(instance: FirebaseNamespace): void {
   );
 }
 
-if (window && fetch && Promise) {
-  setupApi(window);
-  registerPerformance(firebase);
-} else {
-  consoleLogger.info(
-    'Firebase Performance cannot start if browser does not support fetch and Promise.'
-  );
-}
+setupApi(window);
+registerPerformance(firebase);
 
 declare module '@firebase/app-types' {
   interface FirebaseNamespace {

--- a/packages/performance/src/controllers/perf.test.ts
+++ b/packages/performance/src/controllers/perf.test.ts
@@ -22,7 +22,7 @@ import { Trace } from '../resources/trace';
 import { Api, setupApi } from '../services/api_service';
 import { FirebaseApp } from '@firebase/app-types';
 import * as initializationService from '../services/initialization_service';
-
+import { consoleLogger } from '../utils/console_logger';
 import '../../test/setup';
 
 describe('Firebase Performance Test', () => {
@@ -46,9 +46,11 @@ describe('Firebase Performance Test', () => {
     it('does not initialize performance if the required apis are not available', () => {
       stub(Api.prototype, 'requiredApisAvailable').returns(false);
       stub(initializationService, 'getInitializationPromise');
+      stub(consoleLogger, 'info');
       new PerformanceController(fakeFirebaseApp);
 
       expect(initializationService.getInitializationPromise).not.be.called;
+      expect(consoleLogger.info).be.called;
     });
   });
 

--- a/packages/performance/src/controllers/perf.test.ts
+++ b/packages/performance/src/controllers/perf.test.ts
@@ -16,10 +16,14 @@
  */
 
 import { expect } from 'chai';
+import { stub } from 'sinon';
 import { PerformanceController } from '../controllers/perf';
 import { Trace } from '../resources/trace';
-import { setupApi } from '../services/api_service';
+import { Api, setupApi } from '../services/api_service';
 import { FirebaseApp } from '@firebase/app-types';
+import * as initializationService from '../services/initialization_service';
+
+import '../../test/setup';
 
 describe('Firebase Performance Test', () => {
   setupApi(window);
@@ -37,6 +41,16 @@ describe('Firebase Performance Test', () => {
   const fakeFirebaseApp = ({
     options: fakeFirebaseConfig
   } as unknown) as FirebaseApp;
+
+  describe('#constructor', () => {
+    it('does not initialize performance if the required apis are not available', () => {
+      stub(Api.prototype, 'requiredApisAvailable').returns(false);
+      stub(initializationService, 'getInitializationPromise');
+      new PerformanceController(fakeFirebaseApp);
+
+      expect(initializationService.getInitializationPromise).not.be.called;
+    });
+  });
 
   describe('#trace', () => {
     it('creates a custom trace', () => {

--- a/packages/performance/src/controllers/perf.ts
+++ b/packages/performance/src/controllers/perf.ts
@@ -18,12 +18,20 @@ import { Trace } from '../resources/trace';
 import { setupOobResources } from '../services/oob_resources_service';
 import { SettingsService } from '../services/settings_service';
 import { getInitializationPromise } from '../services/initialization_service';
+import { Api } from '../services/api_service';
 import { FirebaseApp } from '@firebase/app-types';
 import { FirebasePerformance } from '@firebase/performance-types';
+import { consoleLogger } from '../utils/console_logger';
 
 export class PerformanceController implements FirebasePerformance {
   constructor(readonly app: FirebaseApp) {
-    getInitializationPromise().then(setupOobResources, setupOobResources);
+    if (Api.getInstance().requiredApisAvailable()) {
+      getInitializationPromise().then(setupOobResources, setupOobResources);
+    } else {
+      consoleLogger.info(
+        'Firebase Performance cannot start if browser does not support fetch and Promise or cookie is disabled.'
+      );
+    }
   }
 
   trace(name: string): Trace {

--- a/packages/performance/src/services/api_service.ts
+++ b/packages/performance/src/services/api_service.ts
@@ -44,7 +44,7 @@ export class Api {
   private PerformanceObserver: typeof PerformanceObserver;
   private windowLocation: Location;
   onFirstInputDelay?: Function;
-  localStorage: Storage;
+  localStorage!: Storage;
   document: Document;
   navigator: Navigator;
 
@@ -57,7 +57,10 @@ export class Api {
     this.windowLocation = window.location;
     this.navigator = window.navigator;
     this.document = window.document;
-    this.localStorage = window.localStorage;
+    if (this.navigator && this.navigator.cookieEnabled) {
+      // If user blocks cookies on the browser, accessing localStorage will throw an exception.
+      this.localStorage = window.localStorage;
+    }
     if (window.perfMetrics && window.perfMetrics.onFirstInputDelay) {
       this.onFirstInputDelay = window.perfMetrics.onFirstInputDelay;
     }
@@ -102,6 +105,13 @@ export class Api {
       this.performance &&
       (this.performance.timeOrigin || this.performance.timing.navigationStart)
     );
+  }
+
+  requiredApisAvailable(): boolean {
+    if (fetch && Promise && this.navigator && this.navigator.cookieEnabled) {
+      return true;
+    }
+    return false;
   }
 
   setupObserver(

--- a/packages/performance/src/services/perf_logger.test.ts
+++ b/packages/performance/src/services/perf_logger.test.ts
@@ -38,6 +38,9 @@ describe('Performance Monitoring > perf_logger', () => {
   const EFFECTIVE_CONNECTION_TYPE = 2;
   const SERVICE_WORKER_STATUS = 3;
   const TIME_ORIGIN = 1556512199893.9033;
+  const TRACE_NAME = 'testTrace';
+  const START_TIME = 12345;
+  const DURATION = 321;
 
   let addToQueueStub: SinonStub<
     Array<{ message: string; eventTime: number }>,
@@ -80,9 +83,6 @@ describe('Performance Monitoring > perf_logger', () => {
 
   describe('logTrace', () => {
     it('creates, serializes and sends a trace to cc service', () => {
-      const TRACE_NAME = 'testTrace';
-      const START_TIME = 12345;
-      const DURATION = 321;
       const EXPECTED_TRACE_MESSAGE = `{"application_info":{"google_app_id":"${APP_ID}",\
 "app_instance_id":"${IID}","web_app_info":{"sdk_version":"${SDK_VERSION}",\
 "page_url":"${PAGE_URL}","service_worker_status":${SERVICE_WORKER_STATUS},\
@@ -100,6 +100,15 @@ describe('Performance Monitoring > perf_logger', () => {
       expect(addToQueueStub.getCall(0).args[0].message).to.be.equal(
         EXPECTED_TRACE_MESSAGE
       );
+    });
+
+    it('does not log an event if cookies are disabled in the browser', () => {
+      stub(Api.prototype, 'requiredApisAvailable').returns(false);
+      const trace = new Trace(TRACE_NAME);
+      trace.record(START_TIME, DURATION);
+      clock.tick(1);
+
+      expect(addToQueueStub).not.to.be.called;
     });
   });
 

--- a/packages/performance/src/services/perf_logger.ts
+++ b/packages/performance/src/services/perf_logger.ts
@@ -107,6 +107,10 @@ export function logTrace(trace: Trace): void {
   if (!settingsService.dataCollectionEnabled && !trace.isAuto) {
     return;
   }
+  // Do not log if required apis are not available.
+  if (!Api.getInstance().requiredApisAvailable()) {
+    return;
+  }
   // Only log the page load auto traces if page is visible.
   if (trace.isAuto && getVisibilityState() !== VisibilityState.VISIBLE) {
     return;


### PR DESCRIPTION
Context: https://github.com/firebase/firebase-js-sdk/issues/1774