### PR TITLE
Enable Typescript strict flag for app, logger, and util packages

### DIFF
--- a/packages/app/index.ts
+++ b/packages/app/index.ts
@@ -43,7 +43,10 @@ if (isBrowser() && (self as any).firebase !== undefined) {
 const firebaseNamespace = createFirebaseNamespace();
 const initializeApp = firebaseNamespace.initializeApp;
 
-firebaseNamespace.initializeApp = function() {
+// TODO: This disable can be removed and the 'ignoreRestArgs' option added to
+// the no-explicit-any rule when ESlint releases it.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+firebaseNamespace.initializeApp = function(...args: any) {
   // Environment check before initializing app
   // Do the check in initializeApp, so people have a chance to disable it by setting logLevel
   // in @firebase/logger
@@ -62,7 +65,7 @@ firebaseNamespace.initializeApp = function() {
       https://github.com/rollup/rollup-plugin-node-resolve
       `);
   }
-  return initializeApp.apply(undefined, arguments as any);
+  return initializeApp.apply(undefined, args);
 };
 
 export const firebase = firebaseNamespace;

--- a/packages/app/index.ts
+++ b/packages/app/index.ts
@@ -15,7 +15,11 @@
  * limitations under the License.
  */
 
-import { FirebaseNamespace } from '@firebase/app-types';
+import {
+  FirebaseNamespace,
+  FirebaseOptions,
+  FirebaseAppConfig
+} from '@firebase/app-types';
 import { createFirebaseNamespace } from './src/firebaseNamespace';
 import { isNode, isBrowser } from '@firebase/util';
 import { Logger } from '@firebase/logger';
@@ -43,7 +47,10 @@ if (isBrowser() && (self as any).firebase !== undefined) {
 const firebaseNamespace = createFirebaseNamespace();
 const initializeApp = firebaseNamespace.initializeApp;
 
-firebaseNamespace.initializeApp = function() {
+firebaseNamespace.initializeApp = function(
+  ...args: [FirebaseOptions, FirebaseAppConfig | undefined] &
+    [FirebaseOptions, string | undefined]
+) {
   // Environment check before initializing app
   // Do the check in initializeApp, so people have a chance to disable it by setting logLevel
   // in @firebase/logger
@@ -62,8 +69,7 @@ firebaseNamespace.initializeApp = function() {
       https://github.com/rollup/rollup-plugin-node-resolve
       `);
   }
-
-  return initializeApp.apply(undefined, arguments);
+  return initializeApp.apply(undefined, args);
 };
 
 export const firebase = firebaseNamespace;

--- a/packages/app/index.ts
+++ b/packages/app/index.ts
@@ -15,11 +15,7 @@
  * limitations under the License.
  */
 
-import {
-  FirebaseNamespace,
-  FirebaseOptions,
-  FirebaseAppConfig
-} from '@firebase/app-types';
+import { FirebaseNamespace } from '@firebase/app-types';
 import { createFirebaseNamespace } from './src/firebaseNamespace';
 import { isNode, isBrowser } from '@firebase/util';
 import { Logger } from '@firebase/logger';
@@ -47,10 +43,7 @@ if (isBrowser() && (self as any).firebase !== undefined) {
 const firebaseNamespace = createFirebaseNamespace();
 const initializeApp = firebaseNamespace.initializeApp;
 
-firebaseNamespace.initializeApp = function(
-  ...args: [FirebaseOptions, FirebaseAppConfig | undefined] &
-    [FirebaseOptions, string | undefined]
-) {
+firebaseNamespace.initializeApp = function() {
   // Environment check before initializing app
   // Do the check in initializeApp, so people have a chance to disable it by setting logLevel
   // in @firebase/logger
@@ -69,7 +62,7 @@ firebaseNamespace.initializeApp = function(
       https://github.com/rollup/rollup-plugin-node-resolve
       `);
   }
-  return initializeApp.apply(undefined, args);
+  return initializeApp.apply(undefined, arguments as any);
 };
 
 export const firebase = firebaseNamespace;

--- a/packages/app/src/firebaseNamespaceCore.ts
+++ b/packages/app/src/firebaseNamespaceCore.ts
@@ -225,10 +225,7 @@ export function createFirebaseNamespaceCore(
     // @ts-ignore
     firebaseAppImpl.prototype[name] = function(...args: any) {
       const serviceFxn = this._getService.bind(this, name);
-      return serviceFxn.apply(
-        this,
-        allowMultipleInstances ? args : []
-      );
+      return serviceFxn.apply(this, allowMultipleInstances ? args : []);
     };
 
     return serviceNamespace;

--- a/packages/app/src/firebaseNamespaceCore.ts
+++ b/packages/app/src/firebaseNamespaceCore.ts
@@ -225,11 +225,12 @@ export function createFirebaseNamespaceCore(
     // TODO: The eslint disable can be removed and the 'ignoreRestArgs' option added to
     // the no-explicit-any rule when ESlint releases it.
     // @ts-ignore
-    firebaseAppImpl.prototype[name] = function(...args: any) {
-      // eslint-disable-line @typescript-eslint/no-explicit-any
-      const serviceFxn = this._getService.bind(this, name);
-      return serviceFxn.apply(this, allowMultipleInstances ? args : []);
-    };
+    firebaseAppImpl.prototype[name] =
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      function(...args: any) {
+        const serviceFxn = this._getService.bind(this, name);
+        return serviceFxn.apply(this, allowMultipleInstances ? args : []);
+      };
 
     return serviceNamespace;
   }

--- a/packages/app/src/firebaseNamespaceCore.ts
+++ b/packages/app/src/firebaseNamespaceCore.ts
@@ -225,7 +225,8 @@ export function createFirebaseNamespaceCore(
     // TODO: The eslint disable can be removed and the 'ignoreRestArgs' option added to
     // the no-explicit-any rule when ESlint releases it.
     // @ts-ignore
-    firebaseAppImpl.prototype[name] = function(...args: any) { // eslint-disable-line @typescript-eslint/no-explicit-any
+    firebaseAppImpl.prototype[name] = function(...args: any) {
+      // eslint-disable-line @typescript-eslint/no-explicit-any
       const serviceFxn = this._getService.bind(this, name);
       return serviceFxn.apply(this, allowMultipleInstances ? args : []);
     };

--- a/packages/app/src/firebaseNamespaceCore.ts
+++ b/packages/app/src/firebaseNamespaceCore.ts
@@ -225,7 +225,7 @@ export function createFirebaseNamespaceCore(
     // @ts-ignore
     firebaseAppImpl.prototype[name] = function(...args) {
       const serviceFxn = this._getService.bind(this, name);
-      return serviceFxn.apply(this, allowMultipleInstances ? args : []);
+      return serviceFxn.apply(this, allowMultipleInstances ? args as [(string|undefined)] : []);
     };
 
     return serviceNamespace;

--- a/packages/app/src/firebaseNamespaceCore.ts
+++ b/packages/app/src/firebaseNamespaceCore.ts
@@ -225,7 +225,10 @@ export function createFirebaseNamespaceCore(
     // @ts-ignore
     firebaseAppImpl.prototype[name] = function(...args) {
       const serviceFxn = this._getService.bind(this, name);
-      return serviceFxn.apply(this, allowMultipleInstances ? args as [(string|undefined)] : []);
+      return serviceFxn.apply(
+        this,
+        allowMultipleInstances ? (args as [(string | undefined)]) : []
+      );
     };
 
     return serviceNamespace;

--- a/packages/app/src/firebaseNamespaceCore.ts
+++ b/packages/app/src/firebaseNamespaceCore.ts
@@ -223,11 +223,11 @@ export function createFirebaseNamespaceCore(
 
     // Patch the FirebaseAppImpl prototype
     // @ts-ignore
-    firebaseAppImpl.prototype[name] = function(...args) {
+    firebaseAppImpl.prototype[name] = function(...args: any) {
       const serviceFxn = this._getService.bind(this, name);
       return serviceFxn.apply(
         this,
-        allowMultipleInstances ? (args as [(string | undefined)]) : []
+        allowMultipleInstances ? args : []
       );
     };
 

--- a/packages/app/src/firebaseNamespaceCore.ts
+++ b/packages/app/src/firebaseNamespaceCore.ts
@@ -222,8 +222,10 @@ export function createFirebaseNamespaceCore(
     namespace[name] = serviceNamespace;
 
     // Patch the FirebaseAppImpl prototype
+    // TODO: The eslint disable can be removed and the 'ignoreRestArgs' option added to
+    // the no-explicit-any rule when ESlint releases it.
     // @ts-ignore
-    firebaseAppImpl.prototype[name] = function(...args: any) {
+    firebaseAppImpl.prototype[name] = function(...args: any) { // eslint-disable-line @typescript-eslint/no-explicit-any
       const serviceFxn = this._getService.bind(this, name);
       return serviceFxn.apply(this, allowMultipleInstances ? args : []);
     };

--- a/packages/app/src/firebaseNamespaceCore.ts
+++ b/packages/app/src/firebaseNamespaceCore.ts
@@ -222,10 +222,10 @@ export function createFirebaseNamespaceCore(
     namespace[name] = serviceNamespace;
 
     // Patch the FirebaseAppImpl prototype
-    // TODO: The eslint disable can be removed and the 'ignoreRestArgs' option added to
-    // the no-explicit-any rule when ESlint releases it.
     // @ts-ignore
     firebaseAppImpl.prototype[name] =
+      // TODO: The eslint disable can be removed and the 'ignoreRestArgs'
+      // option added to the no-explicit-any rule when ESlint releases it.
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       function(...args: any) {
         const serviceFxn = this._getService.bind(this, name);

--- a/packages/app/tsconfig.json
+++ b/packages/app/tsconfig.json
@@ -2,9 +2,8 @@
   "extends": "../../config/tsconfig.base.json",
   "compilerOptions": {
     "outDir": "dist",
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "strict": true
   },
-  "exclude": [
-    "dist/**/*"
-  ]
+  "exclude": ["dist/**/*"]
 }

--- a/packages/logger/tsconfig.json
+++ b/packages/logger/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../config/tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "dist"
+    "outDir": "dist",
+    "strict": true
   },
   "exclude": [
     "dist/**/*"

--- a/packages/util/src/crypt.ts
+++ b/packages/util/src/crypt.ts
@@ -310,7 +310,7 @@ class Base64 {
       }
     }
   }
-};
+}
 
 /**
  * URL-safe base64 encoding

--- a/packages/util/src/crypt.ts
+++ b/packages/util/src/crypt.ts
@@ -86,68 +86,55 @@ const byteArrayToString = function(bytes: number[]): string {
 };
 
 // Static lookup maps, lazily populated by init_()
-export const base64 = {
+class Base64 {
   /**
    * Maps bytes to characters.
-   * @type {Object}
-   * @private
    */
-  byteToCharMap_: null,
+  byteToCharMap_: { [key: number]: string } | null = null;
 
   /**
    * Maps characters to bytes.
-   * @type {Object}
-   * @private
    */
-  charToByteMap_: null,
+  charToByteMap_: { [key: string]: number } | null = null;
 
   /**
    * Maps bytes to websafe characters.
-   * @type {Object}
-   * @private
    */
-  byteToCharMapWebSafe_: null,
+  byteToCharMapWebSafe_: { [key: number]: string } | null = null;
 
   /**
    * Maps websafe characters to bytes.
-   * @type {Object}
-   * @private
    */
-  charToByteMapWebSafe_: null,
+  charToByteMapWebSafe_: { [key: string]: number } | null = null;
 
   /**
-   * Our default alphabet, shared between
+   * Our default alphabet shared between
    * ENCODED_VALS and ENCODED_VALS_WEBSAFE
-   * @type {string}
    */
-  ENCODED_VALS_BASE:
-    'ABCDEFGHIJKLMNOPQRSTUVWXYZ' + 'abcdefghijklmnopqrstuvwxyz' + '0123456789',
+  ENCODED_VALS_BASE: string =
+    'ABCDEFGHIJKLMNOPQRSTUVWXYZ' + 'abcdefghijklmnopqrstuvwxyz' + '0123456789';
 
   /**
    * Our default alphabet. Value 64 (=) is special; it means "nothing."
-   * @type {string}
    */
-  get ENCODED_VALS() {
+  get ENCODED_VALS(): string {
     return this.ENCODED_VALS_BASE + '+/=';
-  },
+  }
 
   /**
    * Our websafe alphabet.
-   * @type {string}
    */
-  get ENCODED_VALS_WEBSAFE() {
+  get ENCODED_VALS_WEBSAFE(): string {
     return this.ENCODED_VALS_BASE + '-_.';
-  },
+  }
 
   /**
    * Whether this browser supports the atob and btoa functions. This extension
    * started at Mozilla but is now implemented by many browsers. We use the
    * ASSUME_* variables to avoid pulling in the full useragent detection library
    * but still allowing the standard per-browser compilations.
-   *
-   * @type {boolean}
    */
-  HAS_NATIVE_SUPPORT: typeof atob === 'function',
+  HAS_NATIVE_SUPPORT: boolean = typeof atob === 'function';
 
   /**
    * Base64-encode an array of bytes.
@@ -165,11 +152,11 @@ export const base64 = {
 
     this.init_();
 
-    const byteToCharMap: number[] = webSafe
-      ? this.byteToCharMapWebSafe_
-      : this.byteToCharMap_;
+    const byteToCharMap = webSafe
+      ? this.byteToCharMapWebSafe_!
+      : this.byteToCharMap_!;
 
-    const output: number[] = [];
+    const output = [];
 
     for (let i = 0; i < input.length; i += 3) {
       const byte1 = input[i];
@@ -200,7 +187,7 @@ export const base64 = {
     }
 
     return output.join('');
-  },
+  }
 
   /**
    * Base64-encode a string.
@@ -217,7 +204,7 @@ export const base64 = {
       return btoa(input);
     }
     return this.encodeByteArray(stringToByteArray(input), webSafe);
-  },
+  }
 
   /**
    * Base64-decode a string.
@@ -234,7 +221,7 @@ export const base64 = {
       return atob(input);
     }
     return byteArrayToString(this.decodeStringToByteArray(input, webSafe));
-  },
+  }
 
   /**
    * Base64-decode a string.
@@ -255,8 +242,8 @@ export const base64 = {
     this.init_();
 
     const charToByteMap = webSafe
-      ? this.charToByteMapWebSafe_
-      : this.charToByteMap_;
+      ? this.charToByteMapWebSafe_!
+      : this.charToByteMap_!;
 
     const output: number[] = [];
 
@@ -294,14 +281,14 @@ export const base64 = {
     }
 
     return output;
-  },
+  }
 
   /**
    * Lazy static initialization function. Called before
    * accessing any of the static map variables.
    * @private
    */
-  init_() {
+  init_(): void {
     if (!this.byteToCharMap_) {
       this.byteToCharMap_ = {};
       this.charToByteMap_ = {};
@@ -350,3 +337,5 @@ export const base64Decode = function(str: string): string | null {
   }
   return null;
 };
+
+export const base64 = new Base64();

--- a/packages/util/src/deferred.ts
+++ b/packages/util/src/deferred.ts
@@ -17,12 +17,12 @@
 
 export class Deferred<R> {
   promise: Promise<R>;
-  reject: (value?: unknown) => void;
-  resolve: (value?: unknown) => void;
+  reject: (value?: unknown) => void = () => {};
+  resolve: (value?: unknown) => void = () => {};
   constructor() {
     this.promise = new Promise((resolve, reject) => {
-      this.resolve = resolve;
-      this.reject = reject;
+      this.resolve = resolve as (value?: unknown) => void;
+      this.reject = reject as (value?: unknown) => void;
     });
   }
 

--- a/packages/util/src/obj.ts
+++ b/packages/util/src/obj.ts
@@ -108,7 +108,7 @@ export const map = function<V>(
 ) {
   var res: UtilObject<V> = {};
   for (var key in obj) {
-    res[key] = fn.call(context, obj[key], key, obj);
+    res[key] = fn.call(context, obj[key], key, obj) as V;
   }
   return res;
 };

--- a/packages/util/src/obj.ts
+++ b/packages/util/src/obj.ts
@@ -103,12 +103,12 @@ export const getCount = function<V>(obj: UtilObject<V>): number {
 
 export const map = function<V>(
   obj: UtilObject<V>,
-  fn: (value: V, key: string | number, obj: UtilObject<V>) => unknown,
+  fn: (value: V, key: string | number, obj: UtilObject<V>) => V,
   context?: unknown
 ) {
   var res: UtilObject<V> = {};
   for (var key in obj) {
-    res[key] = fn.call(context, obj[key], key, obj) as V;
+    res[key] = fn.call(context, obj[key], key, obj);
   }
   return res;
 };

--- a/packages/util/src/subscribe.ts
+++ b/packages/util/src/subscribe.ts
@@ -141,7 +141,13 @@ class ObserverProxy<T> implements Observer<T> {
     }
 
     // Assemble an Observer object when passed as callback functions.
-    if (implementsAnyMethods(nextOrObserver as { [key: string]: unknown}, ['next', 'error', 'complete'])) {
+    if (
+      implementsAnyMethods(nextOrObserver as { [key: string]: unknown }, [
+        'next',
+        'error',
+        'complete'
+      ])
+    ) {
       observer = nextOrObserver as Observer<T>;
     } else {
       observer = {

--- a/packages/util/src/subscribe.ts
+++ b/packages/util/src/subscribe.ts
@@ -78,7 +78,7 @@ class ObserverProxy<T> implements Observer<T> {
   // Micro-task scheduling by calling task.then().
   private task = Promise.resolve();
   private finalized = false;
-  private finalError: Error;
+  private finalError?: Error;
 
   /**
    * @param executor Function which can make calls to a single Observer
@@ -126,7 +126,7 @@ class ObserverProxy<T> implements Observer<T> {
    *   call to subscribe().
    */
   subscribe(
-    nextOrObserver: PartialObserver<T> | Function,
+    nextOrObserver?: PartialObserver<T> | Function,
     error?: ErrorFn,
     complete?: CompleteFn
   ): Unsubscribe {
@@ -141,7 +141,7 @@ class ObserverProxy<T> implements Observer<T> {
     }
 
     // Assemble an Observer object when passed as callback functions.
-    if (implementsAnyMethods(nextOrObserver, ['next', 'error', 'complete'])) {
+    if (implementsAnyMethods(nextOrObserver as { [key: string]: unknown}, ['next', 'error', 'complete'])) {
       observer = nextOrObserver as Observer<T>;
     } else {
       observer = {

--- a/packages/util/tsconfig.json
+++ b/packages/util/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../config/tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "dist"
+    "outDir": "dist",
+    "strict": true
   },
   "exclude": [
     "dist/**/*"


### PR DESCRIPTION
Turned on Typescript `strict` flag for app, logger, and util packages.  This encompasses a number of more specific flags.