### PR TITLE
[NOT FOR SUBMISSION] Audit major components where `Document*` is now used.

### DIFF
--- a/packages/firestore/src/api/database.ts
+++ b/packages/firestore/src/api/database.ts
@@ -1242,6 +1242,9 @@ export interface SnapshotOptions extends firestore.SnapshotOptions {}
 export class DocumentSnapshot implements firestore.DocumentSnapshot {
   constructor(
     private _firestore: Firestore,
+    // DC: Type too broad. This should only ever be EXISTS or MISSING. Passing
+    // UNKNOWN would be a bug (we should never raise snapshots if we don't
+    // definitively know the document exists or not).
     public _document: Document,
     private _fromCache: boolean,
     private _hasPendingWrites: boolean
@@ -1363,6 +1366,8 @@ export class QueryDocumentSnapshot extends DocumentSnapshot
   implements firestore.QueryDocumentSnapshot {
   constructor(
     firestore: Firestore,
+    // DC: Type too broad. Should only accept DOCUMENT. Passing MISSING or
+    // UNKNOWN would be a bug.
     document: Document,
     fromCache: boolean,
     hasPendingWrites: boolean

--- a/packages/firestore/src/core/firestore_client.ts
+++ b/packages/firestore/src/core/firestore_client.ts
@@ -544,6 +544,12 @@ export class FirestoreClient {
     });
   }
 
+  // DC: Type may be too broad. This only returns EXISTS / MISSING at present
+  // which allows the return value to be passed directly to DocumentSnapshot,
+  // but you'd need to read the code to verify that UNKNOWN is never returned
+  // since the return value is now too broad.
+  // Sidenote: It might be cleaner to go ahead and return UNKNOWN and have the
+  // calling code generate the exception instead of throwing from this method.
   getDocumentFromLocalCache(docKey: DocumentKey): Promise<Document> {
     this.verifyNotShutdown();
     return this.asyncQueue

--- a/packages/firestore/src/core/query.ts
+++ b/packages/firestore/src/core/query.ts
@@ -306,6 +306,10 @@ export class Query {
       : other.endAt === null;
   }
 
+  // DC: Type benignly too broad. Only EXISTS entries can be in a query, so it
+  // is probably a bug to call this with anything else, but as written it'll
+  // silently sort UNKNOWN or MISSING documents first (I think?) which is
+  // probably not really harmful.
   docComparator(d1: Document, d2: Document): number {
     let comparedOnKeyField = false;
     for (const orderBy of this.orderBy) {
@@ -321,6 +325,9 @@ export class Query {
     return 0;
   }
 
+  // DC: Better type! This used to only allow EXISTS, but it's probably fine
+  // (more convenient even) to allow matches() to accept any type of Document
+  // entry.
   matches(doc: Document): boolean {
     return (
       doc.exists &&
@@ -741,6 +748,9 @@ export class Bound {
    * Returns true if a document sorts before a bound using the provided sort
    * order.
    */
+  // DC: Type benignly too broad. Only EXISTS document entries can be in a
+  // query, so it is probably a bug to call this on anything else, but we could
+  // allow it to "work" on MISSING / UNKNOWN entries with little harm.
   sortsBeforeDocument(orderBy: OrderBy[], doc: Document): boolean {
     assert(
       this.position.length <= orderBy.length,

--- a/packages/firestore/src/core/view.ts
+++ b/packages/firestore/src/core/view.ts
@@ -47,6 +47,8 @@ export class RemovedLimboDocument {
 /** The result of applying a set of doc changes to a view. */
 export interface ViewDocumentChanges {
   /** The new set of docs that should be in the view. */
+  // DC: Type too broad. Views can only contain EXISTS documents, but this now
+  // accepts UNKNOWN and MISSING document entries which would be a bug.
   documentSet: DocumentSet;
   /** The diff of these docs with the previous set of docs. */
   changeSet: DocumentChangeSet;
@@ -112,6 +114,10 @@ export class View {
    * @return a new set of docs, changes, and refill flag.
    */
   computeDocChanges(
+    // DC: Type may be too broad. Per the old code, this will not contain
+    // UNKNOWN documents. I'm not sure what it would mean to pass UNKNOWN
+    // documents or whether this code would handle them in a sane way. It would
+    // be better if we didn't have to think about it.
     docChanges: DocumentMap,
     previousChanges?: ViewDocumentChanges
   ): ViewDocumentChanges {
@@ -443,6 +449,9 @@ export class View {
    */
   // PORTING NOTE: Multi-tab only.
   synchronizeWithPersistedState(
+    // DC: Type too broad. THis can now contain UNKNOWN documents which would be
+    // invalid. Though FWIW the old code was already broader than needed
+    // (accepting MaybeDocumentMap) I think. :-/
     localDocs: DocumentMap,
     remoteKeys: DocumentKeySet
   ): ViewChange {

--- a/packages/firestore/src/local/local_documents_view.ts
+++ b/packages/firestore/src/local/local_documents_view.ts
@@ -53,6 +53,11 @@ export class LocalDocumentsView {
    * @return Local view of the document or null if we don't have any cached
    * state for it.
    */
+  // DC: Simpler type! This return type is now simpler (Document instead of
+  // MaybeDocument|null). Nice. Though the fact that we use "Document" for
+  // everything now means I can't necessarily assume that we really do use the
+  // full breadth of the return type (e.g. does the method really return UNKNOWN
+  // for an uncached document or might it reject the promise?).
   getDocument(
     transaction: PersistenceTransaction,
     key: DocumentKey
@@ -99,6 +104,11 @@ export class LocalDocumentsView {
    * If we don't have cached state for a document in `keys`, a missing Document
    * will be stored for that key in the resulting set.
    */
+  // DC: Type too broad. This could now return UNKNOWN document entries whereas
+  // it didn't before. And (at least as documented), we return MISSING documents
+  // for uncached documents. Since getDocuments() and getDocument() share a
+  // similar return type but represent uncached documents differently, this
+  // seems actively confusing.
   getDocuments(
     transaction: PersistenceTransaction,
     keys: DocumentKeySet
@@ -112,6 +122,7 @@ export class LocalDocumentsView {
    * Similar to `getDocuments`, but creates the local view from the given
    * `baseDocs` without retrieving documents from the local store.
    */
+  // DC: Type too broad. Same feedback as above.
   getLocalViewOfDocuments(
     transaction: PersistenceTransaction,
     baseDocs: DocumentMap
@@ -134,6 +145,9 @@ export class LocalDocumentsView {
   }
 
   /** Performs a query against the local view of all documents. */
+  // DC: Type too broad. This will only return EXISTS documents since documents
+  // must exist to match the query, and the broader return type could cause
+  // confusion.
   getDocumentsMatchingQuery(
     transaction: PersistenceTransaction,
     query: Query

--- a/packages/firestore/src/local/local_serializer.ts
+++ b/packages/firestore/src/local/local_serializer.ts
@@ -43,6 +43,8 @@ export class LocalSerializer {
   constructor(private remoteSerializer: JsonProtoSerializer) {}
 
   /** Decodes a remote document from storage locally to a Document. */
+  // DC: Simpler type! Can return EXISTS, MISSING, or UNKNOWN (once we merge
+  // CONTENTS_UNKNOWN and UNKNOWN) so the return type is appropriate.
   fromDbRemoteDocument(remoteDoc: DbRemoteDocument): Document {
     if (remoteDoc.document) {
       return this.remoteSerializer.fromDocument(
@@ -65,6 +67,8 @@ export class LocalSerializer {
   }
 
   /** Encodes a document for storage locally. */
+  // DC: Simpler type! Can encode EXISTS, MISSING, or UNKNOWN (once we merge
+  // CONTENTS_UNKNOWN and UNKNOWN) so the parameter type is appropriate.
   toDbRemoteDocument(maybeDoc: Document): DbRemoteDocument {
     switch (maybeDoc.type) {
       case DocumentType.EXISTS: {

--- a/packages/firestore/src/local/remote_document_cache.ts
+++ b/packages/firestore/src/local/remote_document_cache.ts
@@ -43,6 +43,7 @@ export interface RemoteDocumentCache {
    * @return The cached Document (existing or missing), or unknown if we have
    *     nothing cached.
    */
+  // DC: Simpler type!
   getEntry(
     transaction: PersistenceTransaction,
     documentKey: DocumentKey
@@ -55,6 +56,7 @@ export interface RemoteDocumentCache {
    * @return The cached Document entries indexed by key. If an entry is not
    *     cached, the corresponding key will be mapped to an unknown document.
    */
+  // DC: Simpler type!
   getEntries(
     transaction: PersistenceTransaction,
     documentKeys: DocumentKeySet
@@ -71,6 +73,9 @@ export interface RemoteDocumentCache {
    * @param query The query to match documents against.
    * @return The set of matching documents.
    */
+  // DC: Type too broad. This could now return MISSING and UNKNOWN documents
+  // which doesn't make sense and could be harmful (calling code has to filter
+  // them out).
   getDocumentsMatchingQuery(
     transaction: PersistenceTransaction,
     query: Query
@@ -86,6 +91,8 @@ export interface RemoteDocumentCache {
    * invocations will return document changes since the point of rejection.
    */
   // PORTING NOTE: This is only used for multi-tab synchronization.
+  // DC: Type may be too broad. Can now return UNKNOWN documents where it didn't
+  // before. Not sure if it's harmful.
   getNewDocumentChanges(
     transaction: PersistenceTransaction
   ): PersistencePromise<DocumentMap>;

--- a/packages/firestore/src/model/collections.ts
+++ b/packages/firestore/src/model/collections.ts
@@ -26,6 +26,13 @@ import { DocumentKey } from './document_key';
 
 /** Miscellaneous collection types / constants. */
 
+// DC: NOTE: Prior to this refactor, the broadest type typically used was
+// MaybeDocumentMap which would contain EXISTS and MISSING documents (ignoring
+// the unfortunate UnknownDocument), and UNKNOWN documents would just be omitted
+// from the map. NOW DocumentMap is too broad for most usages and we have two
+// ways to represent an uncached document: UNKNOWN or missing from the map. We
+// end up compensating for this with the getDocument() helper below, which helps
+// to re-unifies the two cases.
 export type DocumentMap = SortedMap<DocumentKey, Document>;
 
 const EMPTY_DOCUMENT_MAP = new SortedMap<DocumentKey, Document>(

--- a/packages/firestore/src/model/document_comparator.ts
+++ b/packages/firestore/src/model/document_comparator.ts
@@ -20,6 +20,7 @@ import { DocumentKey } from './document_key';
 
 export type DocumentComparator = (doc1: Document, doc2: Document) => number;
 
+// DC: Better type! Comparing UNKNOWN and MISSING documents could be handy.
 export function compareByKey(doc1: Document, doc2: Document): number {
   return DocumentKey.comparator(doc1.key, doc2.key);
 }

--- a/packages/firestore/src/model/document_set.ts
+++ b/packages/firestore/src/model/document_set.ts
@@ -28,6 +28,8 @@ import { DocumentKey } from './document_key';
  * comparator on top of what is provided to guarantee document equality based on
  * the key.
  */
+// DC: NOTE: This is now a much broader type (contains UNKNOWN / MISSING
+// documents) which seems likely to be harmful in at least some uses.
 export class DocumentSet {
   /**
    * Returns an empty copy of the existing DocumentSet, using the same

--- a/packages/firestore/src/model/mutation.ts
+++ b/packages/firestore/src/model/mutation.ts
@@ -182,6 +182,7 @@ export class Precondition {
    * Returns true if the preconditions is valid for the given document
    * (or null if no document is available).
    */
+  // DC: Simpler type!
   isValidFor(maybeDoc: Document): boolean {
     if (this.updateTime !== undefined) {
       return maybeDoc.exists && maybeDoc.version.isEqual(this.updateTime);
@@ -268,6 +269,7 @@ export abstract class Mutation {
    *     UnknownDocument if the mutation could not be applied to the locally
    *     cached base document.
    */
+  // DC: Simpler type!
   abstract applyToRemoteDocument(
     maybeDoc: Document,
     mutationResult: MutationResult
@@ -289,6 +291,7 @@ export abstract class Mutation {
    * @return The mutated document. The returned document may be null, but only
    *     if maybeDoc was null and the mutation would not create a new document.
    */
+  // DC: Simpler type!
   abstract applyToLocalView(
     maybeDoc: Document,
     baseDoc: Document,
@@ -307,6 +310,7 @@ export abstract class Mutation {
   /** Returns whether all operations in the mutation are idempotent. */
   abstract get isIdempotent(): boolean;
 
+  // DC: Simpler type!
   protected verifyKeyMatches(maybeDoc: Document): void {
     assert(
       maybeDoc.key.isEqual(this.key),
@@ -320,6 +324,7 @@ export abstract class Mutation {
    * only if it is an existing document. All non-existing documents have a
    * post-mutation version of SnapshotVersion.MIN.
    */
+  // DC: Simpler type!
   protected static getPostMutationVersion(maybeDoc: Document): SnapshotVersion {
     if (maybeDoc.exists) {
       return maybeDoc.version;

--- a/packages/firestore/src/model/mutation_batch.ts
+++ b/packages/firestore/src/model/mutation_batch.ts
@@ -67,6 +67,7 @@ export class MutationBatch {
    * @param batchResult The result of applying the MutationBatch to the
    * backend.
    */
+  // DC: Simpler type! (both maybeDoc and the return value)
   applyToRemoteDocument(
     docKey: DocumentKey,
     maybeDoc: Document,
@@ -103,6 +104,7 @@ export class MutationBatch {
    * @param docKey The key of the document to apply mutations to.
    * @param maybeDoc The document to apply mutations to.
    */
+  // DC: Simpler type! (both maybeDoc and the return value)
   applyToLocalView(docKey: DocumentKey, maybeDoc: Document): Document {
     assert(
       maybeDoc.key.isEqual(docKey),
@@ -141,6 +143,8 @@ export class MutationBatch {
    * Computes the local view for all provided documents given the mutations in
    * this batch.
    */
+  // DC: Type may be too broad. The input and output can now contain UNKNOWN
+  // documents where they couldn't before. This may be harmless.
   applyToLocalDocumentSet(maybeDocs: DocumentMap): DocumentMap {
     // TODO(mrschmidt): This implementation is O(n^2). If we apply the mutations
     // directly (as done in `applyToLocalView()`), we can reduce the complexity


### PR DESCRIPTION
Determine whether the type was broadened and if / to-what-degree it might be harmful.

NOTE: My audit mostly ignores CONTENTS_UNKNOWN documents since I am convinced we can/should merge that with UNKNOWN.  Assuming we didn't merge them, I think there's even more uncertainty about all of this code, since there are then 4 possible document types to worry about instead of 3.