### PR TITLE
Roll back to 6.2.1 and add RN and XMLHttpRequest fixes

### DIFF
--- a/packages/app/index.node.ts
+++ b/packages/app/index.node.ts
@@ -21,8 +21,8 @@ import { createFirebaseNamespace } from './src/firebaseNamespace';
 // Node specific packages.
 // @ts-ignore
 import Storage from 'dom-storage';
-// @ts-ignore
-import XMLHttpRequest from 'xmlhttprequest';
+// @ts-ignore`
+import { XMLHttpRequest } from 'xmlhttprequest';
 
 const _firebase = createFirebaseNamespace() as _FirebaseNamespace;
 

--- a/packages/app/index.node.ts
+++ b/packages/app/index.node.ts
@@ -21,7 +21,7 @@ import { createFirebaseNamespace } from './src/firebaseNamespace';
 // Node specific packages.
 // @ts-ignore
 import Storage from 'dom-storage';
-// @ts-ignore`
+// @ts-ignore
 import { XMLHttpRequest } from 'xmlhttprequest';
 
 const _firebase = createFirebaseNamespace() as _FirebaseNamespace;

--- a/packages/app/index.rn.ts
+++ b/packages/app/index.rn.ts
@@ -24,19 +24,8 @@ import { createFirebaseNamespace } from './src/firebaseNamespace';
  * some of our tests because of duplicate symbols, we are using require syntax
  * here
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-let AsyncStorage: any;
-
-try {
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
-  AsyncStorage = require('@react-native-community/async-storage');
-} catch (e) {
-  if (e.code !== 'MODULE_NOT_FOUND') {
-    throw e;
-  }
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
-  AsyncStorage = require('react-native').AsyncStorage;
-}
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { AsyncStorage } = require('react-native');
 
 const _firebase = createFirebaseNamespace() as _FirebaseNamespace;
 


### PR DESCRIPTION
6.2.2 fixed a React Native bug but introduced a Firestore regression.  Rolling back to 6.2.1 and CPing the RN fix.  Also fixing a bug introduced in 6.2.1 causing Auth errors for Node users.