### PR TITLE
Fix typo in XMLHttpRequest import causing auth errors in Node

### DIFF
--- a/packages/app/index.node.ts
+++ b/packages/app/index.node.ts
@@ -22,7 +22,7 @@ import { createFirebaseNamespace } from './src/firebaseNamespace';
 // @ts-ignore
 import Storage from 'dom-storage';
 // @ts-ignore
-import XMLHttpRequest from 'xmlhttprequest';
+import { XMLHttpRequest } from 'xmlhttprequest';
 
 const _firebase = createFirebaseNamespace() as _FirebaseNamespace;
 


### PR DESCRIPTION
Should use destructuring syntax and not top-level export.