### PR TITLE
Fix FirebaseApp overwriting FirebaseError name field

### DIFF
--- a/packages/app/src/errors.ts
+++ b/packages/app/src/errors.ts
@@ -28,19 +28,19 @@ export const enum AppError {
 
 const ERRORS: ErrorMap<AppError> = {
   [AppError.NO_APP]:
-    "No Firebase App '{$name}' has been created - " +
+    "No Firebase App '{$appName}' has been created - " +
     'call Firebase App.initializeApp()',
-  [AppError.BAD_APP_NAME]: "Illegal App name: '{$name}",
-  [AppError.DUPLICATE_APP]: "Firebase App named '{$name}' already exists",
-  [AppError.APP_DELETED]: "Firebase App named '{$name}' already deleted",
+  [AppError.BAD_APP_NAME]: "Illegal App name: '{$appName}",
+  [AppError.DUPLICATE_APP]: "Firebase App named '{$appName}' already exists",
+  [AppError.APP_DELETED]: "Firebase App named '{$appName}' already deleted",
   [AppError.DUPLICATE_SERVICE]:
-    "Firebase service named '{$name}' already registered",
+    "Firebase service named '{$appName}' already registered",
   [AppError.INVALID_APP_ARGUMENT]:
-    'firebase.{$name}() takes either no argument or a ' +
+    'firebase.{$appName}() takes either no argument or a ' +
     'Firebase App instance.'
 };
 
-type ErrorParams = { [key in AppError]: { name: string } };
+type ErrorParams = { [key in AppError]: { appName: string } };
 
 export const ERROR_FACTORY = new ErrorFactory<AppError, ErrorParams>(
   'app',

--- a/packages/app/src/firebaseApp.ts
+++ b/packages/app/src/firebaseApp.ts
@@ -203,7 +203,7 @@ export class FirebaseAppImpl implements FirebaseApp {
    */
   private checkDestroyed_(): void {
     if (this.isDeleted_) {
-      throw ERROR_FACTORY.create(AppError.APP_DELETED, { name: this.name_ });
+      throw ERROR_FACTORY.create(AppError.APP_DELETED, { appName: this.name_ });
     }
   }
 }

--- a/packages/app/src/firebaseNamespaceCore.ts
+++ b/packages/app/src/firebaseNamespaceCore.ts
@@ -104,7 +104,7 @@ export function createFirebaseNamespaceCore(
   function app(name?: string): FirebaseApp {
     name = name || DEFAULT_ENTRY_NAME;
     if (!contains(apps, name)) {
-      throw ERROR_FACTORY.create(AppError.NO_APP, { name });
+      throw ERROR_FACTORY.create(AppError.NO_APP, { appName: name });
     }
     return apps[name];
   }
@@ -137,11 +137,11 @@ export function createFirebaseNamespaceCore(
     const { name } = config;
 
     if (typeof name !== 'string' || !name) {
-      throw ERROR_FACTORY.create(AppError.BAD_APP_NAME, { name: String(name) });
+      throw ERROR_FACTORY.create(AppError.BAD_APP_NAME, { appName: String(name) });
     }
 
     if (contains(apps, name)) {
-      throw ERROR_FACTORY.create(AppError.DUPLICATE_APP, { name });
+      throw ERROR_FACTORY.create(AppError.DUPLICATE_APP, { appName: name });
     }
 
     const app = new firebaseAppImpl(
@@ -180,7 +180,7 @@ export function createFirebaseNamespaceCore(
   ): FirebaseServiceNamespace<FirebaseService> {
     // Cannot re-register a service that already exists
     if (factories[name]) {
-      throw ERROR_FACTORY.create(AppError.DUPLICATE_SERVICE, { name });
+      throw ERROR_FACTORY.create(AppError.DUPLICATE_SERVICE, { appName: name });
     }
 
     // Capture the service factory for later service instantiation
@@ -203,7 +203,7 @@ export function createFirebaseNamespaceCore(
         // Invalid argument.
         // This happens in the following case: firebase.storage('gs:/')
         throw ERROR_FACTORY.create(AppError.INVALID_APP_ARGUMENT, {
-          name
+          appName: name
         });
       }
 

--- a/packages/app/src/firebaseNamespaceCore.ts
+++ b/packages/app/src/firebaseNamespaceCore.ts
@@ -137,7 +137,9 @@ export function createFirebaseNamespaceCore(
     const { name } = config;
 
     if (typeof name !== 'string' || !name) {
-      throw ERROR_FACTORY.create(AppError.BAD_APP_NAME, { appName: String(name) });
+      throw ERROR_FACTORY.create(AppError.BAD_APP_NAME, {
+        appName: String(name)
+      });
     }
 
     if (contains(apps, name)) {

--- a/packages/app/src/lite/firebaseAppLite.ts
+++ b/packages/app/src/lite/firebaseAppLite.ts
@@ -168,7 +168,7 @@ export class FirebaseAppLiteImpl implements FirebaseApp {
    */
   private checkDestroyed_(): void {
     if (this.isDeleted_) {
-      throw ERROR_FACTORY.create(AppError.APP_DELETED, { name: this.name_ });
+      throw ERROR_FACTORY.create(AppError.APP_DELETED, { appName: this.name_ });
     }
   }
 }

--- a/packages/util/src/errors.ts
+++ b/packages/util/src/errors.ts
@@ -132,11 +132,6 @@ export class ErrorFactory<
     // TODO: Replace with Object.entries when lib is updated to es2017.
     for (const key of Object.keys(customData)) {
       if (key.slice(-1) !== '_') {
-        if (key in error) {
-          console.warn(
-            `Overwriting FirebaseError base field "${key}" can cause unexpected behavior.`
-          );
-        }
         error[key] = customData[key];
       }
     }

--- a/packages/util/src/errors.ts
+++ b/packages/util/src/errors.ts
@@ -132,6 +132,11 @@ export class ErrorFactory<
     // TODO: Replace with Object.entries when lib is updated to es2017.
     for (const key of Object.keys(customData)) {
       if (key.slice(-1) !== '_') {
+        if (key in error) {
+          console.warn(
+            `Overwriting FirebaseError base field "${key}" can cause unexpected behavior.`
+          );
+        }
         error[key] = customData[key];
       }
     }


### PR DESCRIPTION
Fixes https://github.com/firebase/firebase-js-sdk/issues/1891,
but as a long term solution for avoid overwriting fields in FirebaseError, we should create a separate field to hold the template parameters. Since it's a potential breaking change, we will wait for the next major version to change it.

I'm not sure why we want the template parameters in the FirebaseError, so maybe we don't need it anyway?

