### PR TITLE
Backport updates from Android (multiple changes)

### DIFF
--- a/packages/firebase/index.d.ts
+++ b/packages/firebase/index.d.ts
@@ -6182,20 +6182,20 @@ declare namespace firebase.firestore {
      * Clears the persistent storage. This includes pending writes and cached
      * documents.
      *
-     * Must be called while the firestore instance is not started (after the app is
-     * shutdown or when the app is first initialized). On startup, this method
-     * must be called before other methods (other than settings()). If the
-     * firestore instance is still running, the promise will be rejected with
-     * the error code of `failed-precondition`.
+     * Must be called while the firestore instance is not started (after the app
+     * is shutdown or when the app is first initialized). On startup, this
+     * method must be called before other methods (other than settings()). If
+     * the firestore instance is still running, the promise will be rejected
+     * with the error code of `failed-precondition`.
      *
      * Note: clearPersistence() is primarily intended to help write reliable
-     * tests that use Firestore. It uses the most efficient mechanism possible
-     * for dropping existing data but does not attempt to securely overwrite or
+     * tests that use Cloud Firestore. It uses an efficient mechanism for
+     * dropping existing data but does not attempt to securely overwrite or
      * otherwise make cached data unrecoverable. For applications that are
-     * sensitive to the disclosure of cache data in between user sessions we
-     * strongly recommend not to enable persistence in the first place.
+     * sensitive to the disclosure of cached data in between user sessions, we
+     * strongly recommend not enabling persistence at all.
      *
-     * @return A promise that is resolved once the persistent storage has been
+     * @return A promise that is resolved when the persistent storage is
      * cleared. Otherwise, the promise is rejected with an error.
      */
     clearPersistence(): Promise<void>;

--- a/packages/firestore-types/index.d.ts
+++ b/packages/firestore-types/index.d.ts
@@ -240,20 +240,20 @@ export class FirebaseFirestore {
    * Clears the persistent storage. This includes pending writes and cached
    * documents.
    *
-   * Must be called while the firestore instance is not started (after the app is
-   * shutdown or when the app is first initialized). On startup, this method
-   * must be called before other methods (other than settings()). If the
-   * firestore instance is still running, the promise will be rejected with
-   * the error code of `failed-precondition`.
+   * Must be called while the firestore instance is not started (after the app
+   * is shutdown or when the app is first initialized). On startup, this
+   * method must be called before other methods (other than settings()). If
+   * the firestore instance is still running, the promise will be rejected
+   * with the error code of `failed-precondition`.
    *
    * Note: clearPersistence() is primarily intended to help write reliable
-   * tests that use Firestore. It uses the most efficient mechanism possible
-   * for dropping existing data but does not attempt to securely overwrite or
+   * tests that use Cloud Firestore. It uses an efficient mechanism for
+   * dropping existing data but does not attempt to securely overwrite or
    * otherwise make cached data unrecoverable. For applications that are
-   * sensitive to the disclosure of cache data in between user sessions we
-   * strongly recommend not to enable persistence in the first place.
+   * sensitive to the disclosure of cached data in between user sessions, we
+   * strongly recommend not enabling persistence at all.
    *
-   * @return A promise that is resolved once the persistent storage has been
+   * @return A promise that is resolved when the persistent storage is
    * cleared. Otherwise, the promise is rejected with an error.
    */
   clearPersistence(): Promise<void>;

--- a/packages/firestore/src/api/database.ts
+++ b/packages/firestore/src/api/database.ts
@@ -1434,8 +1434,7 @@ export class Query implements firestore.Query {
     if (fieldPath.isKeyField()) {
       if (
         operator === Operator.ARRAY_CONTAINS ||
-        operator === Operator.ARRAY_CONTAINS_ANY ||
-        operator === Operator.IN
+        operator === Operator.ARRAY_CONTAINS_ANY
       ) {
         throw new FirestoreError(
           Code.INVALID_ARGUMENT,
@@ -1507,6 +1506,20 @@ export class Query implements firestore.Query {
             Code.INVALID_ARGUMENT,
             `Invalid Query. '${operator.toString()}' filters support a ` +
               'maximum of 10 elements in the value array.'
+          );
+        }
+        if (value.indexOf(null) >= 0) {
+          throw new FirestoreError(
+            Code.INVALID_ARGUMENT,
+            `Invalid Query. '${operator.toString()}' filters cannot contain 'null' ` +
+              'in the value array.'
+          );
+        }
+        if (value.filter(element => Number.isNaN(element)).length > 0) {
+          throw new FirestoreError(
+            Code.INVALID_ARGUMENT,
+            `Invalid Query. '${operator.toString()}' filters cannot contain 'NaN' ` +
+              'in the value array.'
           );
         }
       }

--- a/packages/firestore/src/api/database.ts
+++ b/packages/firestore/src/api/database.ts
@@ -1428,7 +1428,7 @@ export class Query implements firestore.Query {
       validateStringEnum('Query.where', whereFilterOpEnums, 2, opStr);
     }
 
-    let fieldValue;
+    let fieldValue: FieldValue;
     const fieldPath = fieldPathFromArgument('Query.where', field);
     const operator = Operator.fromString(opStr);
     if (fieldPath.isKeyField()) {
@@ -1441,87 +1441,22 @@ export class Query implements firestore.Query {
           `Invalid Query. You can't perform '${operator.toString()}' ` +
             'queries on FieldPath.documentId().'
         );
-      }
-      if (typeof value === 'string') {
-        if (value === '') {
-          throw new FirestoreError(
-            Code.INVALID_ARGUMENT,
-            'Function Query.where() requires its third parameter to be a ' +
-              'valid document ID if the first parameter is ' +
-              'FieldPath.documentId(), but it was an empty string.'
-          );
+      } else if (operator === Operator.IN) {
+        this.validateDisjunctiveFilterElements(value, operator);
+        const referenceList: FieldValue[] = [];
+        for (const arrayValue of value as FieldValue[]) {
+          referenceList.push(this.parseDocumentIdValue(arrayValue));
         }
-        if (
-          !this._query.isCollectionGroupQuery() &&
-          value.indexOf('/') !== -1
-        ) {
-          throw new FirestoreError(
-            Code.INVALID_ARGUMENT,
-            `Invalid third parameter to Query.where(). When querying a collection by ` +
-              `FieldPath.documentId(), the value provided must be a plain document ID, but ` +
-              `'${value}' contains a slash.`
-          );
-        }
-        const path = this._query.path.child(ResourcePath.fromString(value));
-        if (!DocumentKey.isDocumentKey(path)) {
-          throw new FirestoreError(
-            Code.INVALID_ARGUMENT,
-            `Invalid third parameter to Query.where(). When querying a collection group by ` +
-              `FieldPath.documentId(), the value provided must result in a valid document path, ` +
-              `but '${path}' is not because it has an odd number of segments (${
-                path.length
-              }).`
-          );
-        }
-        fieldValue = new RefValue(
-          this.firestore._databaseId,
-          new DocumentKey(path)
-        );
-      } else if (value instanceof DocumentReference) {
-        const ref = value as DocumentReference;
-        fieldValue = new RefValue(this.firestore._databaseId, ref._key);
+        fieldValue = new ArrayValue(referenceList);
       } else {
-        throw new FirestoreError(
-          Code.INVALID_ARGUMENT,
-          `Function Query.where() requires its third parameter to be a ` +
-            `string or a DocumentReference if the first parameter is ` +
-            `FieldPath.documentId(), but it was: ` +
-            `${valueDescription(value)}.`
-        );
+        fieldValue = this.parseDocumentIdValue(value);
       }
     } else {
       if (
         operator === Operator.IN ||
         operator === Operator.ARRAY_CONTAINS_ANY
       ) {
-        if (!Array.isArray(value) || value.length === 0) {
-          throw new FirestoreError(
-            Code.INVALID_ARGUMENT,
-            'Invalid Query. A non-empty array is required for ' +
-              `'${operator.toString()}' filters.`
-          );
-        }
-        if (value.length > 10) {
-          throw new FirestoreError(
-            Code.INVALID_ARGUMENT,
-            `Invalid Query. '${operator.toString()}' filters support a ` +
-              'maximum of 10 elements in the value array.'
-          );
-        }
-        if (value.indexOf(null) >= 0) {
-          throw new FirestoreError(
-            Code.INVALID_ARGUMENT,
-            `Invalid Query. '${operator.toString()}' filters cannot contain 'null' ` +
-              'in the value array.'
-          );
-        }
-        if (value.filter(element => Number.isNaN(element)).length > 0) {
-          throw new FirestoreError(
-            Code.INVALID_ARGUMENT,
-            `Invalid Query. '${operator.toString()}' filters cannot contain 'NaN' ` +
-              'in the value array.'
-          );
-        }
+        this.validateDisjunctiveFilterElements(value, operator);
       }
       fieldValue = this.firestore._dataConverter.parseQueryValue(
         'Query.where',
@@ -1957,6 +1892,98 @@ export class Query implements firestore.Query {
         error: reject
       }
     );
+  }
+
+  /**
+   * Parses the given documentIdValue into a ReferenceValue, throwing
+   * appropriate errors if the value is anything other than a DocumentReference
+   * or String, or if the string is malformed.
+   */
+  private parseDocumentIdValue(documentIdValue: unknown): RefValue {
+    if (typeof documentIdValue === 'string') {
+      if (documentIdValue === '') {
+        throw new FirestoreError(
+          Code.INVALID_ARGUMENT,
+          'Function Query.where() requires its third parameter to be a ' +
+            'valid document ID if the first parameter is ' +
+            'FieldPath.documentId(), but it was an empty string.'
+        );
+      }
+      if (
+        !this._query.isCollectionGroupQuery() &&
+        documentIdValue.indexOf('/') !== -1
+      ) {
+        throw new FirestoreError(
+          Code.INVALID_ARGUMENT,
+          `Invalid third parameter to Query.where(). When querying a collection by ` +
+            `FieldPath.documentId(), the value provided must be a plain document ID, but ` +
+            `'${documentIdValue}' contains a slash.`
+        );
+      }
+      const path = this._query.path.child(
+        ResourcePath.fromString(documentIdValue)
+      );
+      if (!DocumentKey.isDocumentKey(path)) {
+        throw new FirestoreError(
+          Code.INVALID_ARGUMENT,
+          `Invalid third parameter to Query.where(). When querying a collection group by ` +
+            `FieldPath.documentId(), the value provided must result in a valid document path, ` +
+            `but '${path}' is not because it has an odd number of segments (${
+              path.length
+            }).`
+        );
+      }
+      return new RefValue(this.firestore._databaseId, new DocumentKey(path));
+    } else if (documentIdValue instanceof DocumentReference) {
+      const ref = documentIdValue as DocumentReference;
+      return new RefValue(this.firestore._databaseId, ref._key);
+    } else {
+      throw new FirestoreError(
+        Code.INVALID_ARGUMENT,
+        `Function Query.where() requires its third parameter to be a ` +
+          `string or a DocumentReference if the first parameter is ` +
+          `FieldPath.documentId(), but it was: ` +
+          `${valueDescription(documentIdValue)}.`
+      );
+    }
+  }
+
+  /**
+   * Validates that the value passed into a disjunctrive filter satisfies all
+   * array requirements.
+   */
+  private validateDisjunctiveFilterElements(
+    value: unknown,
+    operator: Operator
+  ): void {
+    if (!Array.isArray(value) || value.length === 0) {
+      throw new FirestoreError(
+        Code.INVALID_ARGUMENT,
+        'Invalid Query. A non-empty array is required for ' +
+          `'${operator.toString()}' filters.`
+      );
+    }
+    if (value.length > 10) {
+      throw new FirestoreError(
+        Code.INVALID_ARGUMENT,
+        `Invalid Query. '${operator.toString()}' filters support a ` +
+          'maximum of 10 elements in the value array.'
+      );
+    }
+    if (value.indexOf(null) >= 0) {
+      throw new FirestoreError(
+        Code.INVALID_ARGUMENT,
+        `Invalid Query. '${operator.toString()}' filters cannot contain 'null' ` +
+          'in the value array.'
+      );
+    }
+    if (value.filter(element => Number.isNaN(element)).length > 0) {
+      throw new FirestoreError(
+        Code.INVALID_ARGUMENT,
+        `Invalid Query. '${operator.toString()}' filters cannot contain 'NaN' ` +
+          'in the value array.'
+      );
+    }
   }
 
   private validateNewFilter(filter: Filter): void {

--- a/packages/firestore/src/core/query.ts
+++ b/packages/firestore/src/core/query.ts
@@ -689,12 +689,11 @@ export class ArrayContainsAnyFilter extends FieldFilter {
   }
 
   matches(doc: Document): boolean {
-    const arrayValue = this.value;
     const other = doc.field(this.field);
     return (
       other instanceof ArrayValue &&
       other.internalValue.some(lhsElem => {
-        return arrayValue.contains(lhsElem);
+        return this.value.contains(lhsElem);
       })
     );
   }

--- a/packages/firestore/test/integration/api/query.test.ts
+++ b/packages/firestore/test/integration/api/query.test.ts
@@ -586,24 +586,26 @@ apiDescribe('Queries', (persistence: boolean) => {
   );
 
   (isRunningAgainstEmulator() ? it : it.skip)(
-  'can use IN filters by document ID', async () => {
-    const testDocs = {
-      aa: { key: 'aa' },
-      ab: { key: 'ab' },
-      ba: { key: 'ba' },
-      bb: { key: 'bb' }
-    };
-    await withTestCollection(persistence, testDocs, async coll => {
-      const snapshot = await coll
-        .where(FieldPath.documentId(), inOp, ['aa', 'ab'])
-        .get();
+    'can use IN filters by document ID',
+    async () => {
+      const testDocs = {
+        aa: { key: 'aa' },
+        ab: { key: 'ab' },
+        ba: { key: 'ba' },
+        bb: { key: 'bb' }
+      };
+      await withTestCollection(persistence, testDocs, async coll => {
+        const snapshot = await coll
+          .where(FieldPath.documentId(), inOp, ['aa', 'ab'])
+          .get();
 
-      expect(toDataArray(snapshot)).to.deep.equal([
-        {key: 'aa'},
-        {key: 'ab'}
-      ]);
-    });
-  });
+        expect(toDataArray(snapshot)).to.deep.equal([
+          { key: 'aa' },
+          { key: 'ab' }
+        ]);
+      });
+    }
+  );
 
   // TODO(in-queries): Enable browser tests once backend support is ready.
   (isRunningAgainstEmulator() ? it : it.skip)(

--- a/packages/firestore/test/integration/api/query.test.ts
+++ b/packages/firestore/test/integration/api/query.test.ts
@@ -585,6 +585,26 @@ apiDescribe('Queries', (persistence: boolean) => {
     }
   );
 
+  (isRunningAgainstEmulator() ? it : it.skip)(
+  'can use IN filters by document ID', async () => {
+    const testDocs = {
+      aa: { key: 'aa' },
+      ab: { key: 'ab' },
+      ba: { key: 'ba' },
+      bb: { key: 'bb' }
+    };
+    await withTestCollection(persistence, testDocs, async coll => {
+      const snapshot = await coll
+        .where(FieldPath.documentId(), inOp, ['aa', 'ab'])
+        .get();
+
+      expect(toDataArray(snapshot)).to.deep.equal([
+        {key: 'aa'},
+        {key: 'ab'}
+      ]);
+    });
+  });
+
   // TODO(in-queries): Enable browser tests once backend support is ready.
   (isRunningAgainstEmulator() ? it : it.skip)(
     'can use array-contains-any filters',

--- a/packages/firestore/test/integration/api/validation.test.ts
+++ b/packages/firestore/test/integration/api/validation.test.ts
@@ -1265,14 +1265,6 @@ apiDescribe('Validation:', (persistence: boolean) => {
         );
 
         expect(() =>
-          collection.where(FieldPath.documentId(), inOp, [1, 2])
-        ).to.throw(
-          'Function Query.where() requires its third parameter to be ' +
-            'a valid document ID if the first parameter is ' +
-            'FieldPath.documentId(), but it was: an array.'
-        );
-
-        expect(() =>
           collection.where(FieldPath.documentId(), 'array-contains', 1)
         ).to.throw(
           "Invalid Query. You can't perform 'array-contains' queries on " +
@@ -1284,6 +1276,50 @@ apiDescribe('Validation:', (persistence: boolean) => {
         ).to.throw(
           "Invalid Query. You can't perform 'array-contains-any' queries on " +
             'FieldPath.documentId().'
+        );
+      }
+    );
+
+    validationIt(
+      persistence,
+      'using IN and document id must have proper document references in array',
+      db => {
+        const collection = db.collection('test');
+
+        expect(() =>
+          collection.where(FieldPath.documentId(), inOp, [collection.path])
+        ).not.to.throw();
+
+        expect(() =>
+          collection.where(FieldPath.documentId(), inOp, [''])
+        ).to.throw(
+          'Function Query.where() requires its third parameter to be ' +
+            'a valid document ID if the first parameter is ' +
+            'FieldPath.documentId(), but it was an empty string.'
+        );
+
+        expect(() =>
+          collection.where(FieldPath.documentId(), inOp, ['foo/bar/baz'])
+        ).to.throw(
+          `Invalid third parameter to Query.where(). When querying a collection by ` +
+            `FieldPath.documentId(), the value provided must be a plain document ID, but ` +
+            `'foo/bar/baz' contains a slash.`
+        );
+
+        expect(() =>
+          collection.where(FieldPath.documentId(), inOp, [1, 2])
+        ).to.throw(
+          'Function Query.where() requires its third parameter to be ' +
+            'a string or a DocumentReference if the first parameter is ' +
+            'FieldPath.documentId(), but it was: 1.'
+        );
+
+        expect(() =>
+          db.collectionGroup('foo').where(FieldPath.documentId(), inOp, ['foo'])
+        ).to.throw(
+          `Invalid third parameter to Query.where(). When querying a collection group by ` +
+            `FieldPath.documentId(), the value provided must result in a valid document path, ` +
+            `but 'foo' is not because it has an odd number of segments (1).`
         );
       }
     );

--- a/packages/firestore/test/integration/api/validation.test.ts
+++ b/packages/firestore/test/integration/api/validation.test.ts
@@ -1137,7 +1137,7 @@ apiDescribe('Validation:', (persistence: boolean) => {
 
     validationIt(
       persistence,
-      'follow array requirements for disjunctive filters',
+      'enforce array requirements for disjunctive filters',
       db => {
         expect(() => db.collection('test').where('foo', inOp, 2)).to.throw(
           "Invalid Query. A non-empty array is required for 'in' filters."

--- a/packages/firestore/test/integration/api/validation.test.ts
+++ b/packages/firestore/test/integration/api/validation.test.ts
@@ -1003,125 +1003,99 @@ apiDescribe('Validation:', (persistence: boolean) => {
       }
     );
 
-    validationIt(
-      persistence,
-      'cannot have multiple array-contains filters.',
-      db => {
-        expect(() =>
-          db
-            .collection('test')
-            .where('foo', 'array-contains', 1)
-            .where('foo', 'array-contains', 2)
-        ).to.throw(
-          "Invalid query. You cannot use more than one 'array-contains' filter."
-        );
-      }
-    );
+    validationIt(persistence, 'with multiple array filters fail', db => {
+      expect(() =>
+        db
+          .collection('test')
+          .where('foo', 'array-contains', 1)
+          .where('foo', 'array-contains', 2)
+      ).to.throw(
+        "Invalid query. You cannot use more than one 'array-contains' filter."
+      );
 
-    validationIt(
-      persistence,
-      'cannot have multiple IN or array-contains-any filters.',
-      db => {
-        expect(() =>
-          db
-            .collection('test')
-            .where('foo', inOp, [1, 2])
-            .where('foo', inOp, [2, 3])
-        ).to.throw("Invalid query. You cannot use more than one 'in' filter.");
+      expect(() =>
+        db
+          .collection('test')
+          .where('foo', 'array-contains', 1)
+          .where('foo', arrayContainsAnyOp, [2, 3])
+      ).to.throw(
+        "Invalid query. You cannot use 'array-contains-any' filters with " +
+          "'array-contains' filters."
+      );
 
-        expect(() =>
-          db
-            .collection('test')
-            .where('foo', arrayContainsAnyOp, [1, 2])
-            .where('foo', arrayContainsAnyOp, [2, 3])
-        ).to.throw(
-          "Invalid query. You cannot use more than one 'array-contains-any'" +
-            ' filter.'
-        );
-      }
-    );
+      expect(() =>
+        db
+          .collection('test')
+          .where('foo', arrayContainsAnyOp, [2, 3])
+          .where('foo', 'array-contains', 1)
+      ).to.throw(
+        "Invalid query. You cannot use 'array-contains' filters with " +
+          "'array-contains-any' filters."
+      );
+    });
 
-    validationIt(
-      persistence,
-      'cannot have array-contains filter with array-contains-any filter.',
-      db => {
-        expect(() =>
-          db
-            .collection('test')
-            .where('foo', 'array-contains', 1)
-            .where('foo', arrayContainsAnyOp, [2, 3])
-        ).to.throw(
-          "Invalid query. You cannot use 'array-contains-any' filters with " +
-            "'array-contains' filters."
-        );
+    validationIt(persistence, 'with multiple disjunctive filters fail', db => {
+      expect(() =>
+        db
+          .collection('test')
+          .where('foo', inOp, [1, 2])
+          .where('foo', inOp, [2, 3])
+      ).to.throw("Invalid query. You cannot use more than one 'in' filter.");
 
-        expect(() =>
-          db
-            .collection('test')
-            .where('foo', arrayContainsAnyOp, [2, 3])
-            .where('foo', 'array-contains', 1)
-        ).to.throw(
-          "Invalid query. You cannot use 'array-contains' filters with " +
-            "'array-contains-any' filters."
-        );
-      }
-    );
+      expect(() =>
+        db
+          .collection('test')
+          .where('foo', arrayContainsAnyOp, [1, 2])
+          .where('foo', arrayContainsAnyOp, [2, 3])
+      ).to.throw(
+        "Invalid query. You cannot use more than one 'array-contains-any'" +
+          ' filter.'
+      );
 
-    validationIt(
-      persistence,
-      'cannot have array-contains-any filter with in filter.',
-      db => {
-        expect(() =>
-          db
-            .collection('test')
-            .where('foo', arrayContainsAnyOp, [2, 3])
-            .where('foo', inOp, [2, 3])
-        ).to.throw(
-          "Invalid query. You cannot use 'in' filters with " +
-            "'array-contains-any' filters."
-        );
+      expect(() =>
+        db
+          .collection('test')
+          .where('foo', arrayContainsAnyOp, [2, 3])
+          .where('foo', inOp, [2, 3])
+      ).to.throw(
+        "Invalid query. You cannot use 'in' filters with " +
+          "'array-contains-any' filters."
+      );
 
-        expect(() =>
-          db
-            .collection('test')
-            .where('foo', inOp, [2, 3])
-            .where('foo', arrayContainsAnyOp, [2, 3])
-        ).to.throw(
-          "Invalid query. You cannot use 'array-contains-any' filters with " +
-            "'in' filters."
-        );
-      }
-    );
+      expect(() =>
+        db
+          .collection('test')
+          .where('foo', inOp, [2, 3])
+          .where('foo', arrayContainsAnyOp, [2, 3])
+      ).to.throw(
+        "Invalid query. You cannot use 'array-contains-any' filters with " +
+          "'in' filters."
+      );
 
-    // This is redundant with the above tests, but makes sure our validation
-    // doesn't get confused.
-    validationIt(
-      persistence,
-      'cannot have array-contains, array-contains-any, and in filter.',
-      db => {
-        expect(() =>
-          db
-            .collection('test')
-            .where('foo', inOp, [2, 3])
-            .where('foo', 'array-contains', 1)
-            .where('foo', arrayContainsAnyOp, [2])
-        ).to.throw(
-          "Invalid query. You cannot use 'array-contains-any' filters with " +
-            "'in' filters."
-        );
+      // This is redundant with the above tests, but makes sure our validation
+      // doesn't get confused.
+      expect(() =>
+        db
+          .collection('test')
+          .where('foo', inOp, [2, 3])
+          .where('foo', 'array-contains', 1)
+          .where('foo', arrayContainsAnyOp, [2])
+      ).to.throw(
+        "Invalid query. You cannot use 'array-contains-any' filters with " +
+          "'in' filters."
+      );
 
-        expect(() =>
-          db
-            .collection('test')
-            .where('foo', 'array-contains', 1)
-            .where('foo', inOp, [2, 3])
-            .where('foo', arrayContainsAnyOp, [2])
-        ).to.throw(
-          "Invalid query. You cannot use 'array-contains-any' filters with " +
-            "'in' filters."
-        );
-      }
-    );
+      expect(() =>
+        db
+          .collection('test')
+          .where('foo', 'array-contains', 1)
+          .where('foo', inOp, [2, 3])
+          .where('foo', arrayContainsAnyOp, [2])
+      ).to.throw(
+        "Invalid query. You cannot use 'array-contains-any' filters with " +
+          "'in' filters."
+      );
+    });
 
     validationIt(
       persistence,
@@ -1163,7 +1137,7 @@ apiDescribe('Validation:', (persistence: boolean) => {
 
     validationIt(
       persistence,
-      'cannot have an IN or array-contains-any filter with non-array values.',
+      'follow array requirements for disjunctive filters',
       db => {
         expect(() => db.collection('test').where('foo', inOp, 2)).to.throw(
           "Invalid Query. A non-empty array is required for 'in' filters."
@@ -1175,31 +1149,7 @@ apiDescribe('Validation:', (persistence: boolean) => {
           'Invalid Query. A non-empty array is required for ' +
             "'array-contains-any' filters."
         );
-      }
-    );
 
-    validationIt(
-      persistence,
-      'cannot have an IN or array-contains-any filter with empty arrays.',
-      db => {
-        expect(() => db.collection('test').where('foo', inOp, [])).to.throw(
-          "Invalid Query. A non-empty array is required for 'in' filters."
-        );
-
-        expect(() =>
-          db.collection('test').where('foo', arrayContainsAnyOp, [])
-        ).to.throw(
-          'Invalid Query. A non-empty array is required for ' +
-            "'array-contains-any' filters."
-        );
-      }
-    );
-
-    validationIt(
-      persistence,
-      'cannot have an IN or array-contains-any filter with more than 10 ' +
-        'elements.',
-      db => {
         expect(() =>
           db
             .collection('test')
@@ -1217,6 +1167,45 @@ apiDescribe('Validation:', (persistence: boolean) => {
         ).to.throw(
           "Invalid Query. 'array-contains-any' filters support a maximum of " +
             '10 elements in the value array.'
+        );
+
+        expect(() => db.collection('test').where('foo', inOp, [])).to.throw(
+          "Invalid Query. A non-empty array is required for 'in' filters."
+        );
+
+        expect(() =>
+          db.collection('test').where('foo', arrayContainsAnyOp, [])
+        ).to.throw(
+          'Invalid Query. A non-empty array is required for ' +
+            "'array-contains-any' filters."
+        );
+
+        expect(() =>
+          db.collection('test').where('foo', inOp, [3, null])
+        ).to.throw(
+          "Invalid Query. 'in' filters cannot contain 'null' in the value array."
+        );
+
+        expect(() =>
+          db.collection('test').where('foo', arrayContainsAnyOp, [3, null])
+        ).to.throw(
+          "Invalid Query. 'array-contains-any' filters cannot contain 'null' " +
+            'in the value array.'
+        );
+
+        expect(() =>
+          db.collection('test').where('foo', inOp, [2, Number.NaN])
+        ).to.throw(
+          "Invalid Query. 'in' filters cannot contain 'NaN' in the value array."
+        );
+
+        expect(() =>
+          db
+            .collection('test')
+            .where('foo', arrayContainsAnyOp, [2, Number.NaN])
+        ).to.throw(
+          "Invalid Query. 'array-contains-any' filters cannot contain 'NaN' " +
+            'in the value array.'
         );
       }
     );
@@ -1276,6 +1265,14 @@ apiDescribe('Validation:', (persistence: boolean) => {
         );
 
         expect(() =>
+          collection.where(FieldPath.documentId(), inOp, [1, 2])
+        ).to.throw(
+          'Function Query.where() requires its third parameter to be ' +
+            'a valid document ID if the first parameter is ' +
+            'FieldPath.documentId(), but it was: an array.'
+        );
+
+        expect(() =>
           collection.where(FieldPath.documentId(), 'array-contains', 1)
         ).to.throw(
           "Invalid Query. You can't perform 'array-contains' queries on " +
@@ -1286,13 +1283,6 @@ apiDescribe('Validation:', (persistence: boolean) => {
           collection.where(FieldPath.documentId(), arrayContainsAnyOp, 1)
         ).to.throw(
           "Invalid Query. You can't perform 'array-contains-any' queries on " +
-            'FieldPath.documentId().'
-        );
-
-        expect(() =>
-          collection.where(FieldPath.documentId(), inOp, [1, 2])
-        ).to.throw(
-          "Invalid Query. You can't perform 'in' queries on " +
             'FieldPath.documentId().'
         );
       }


### PR DESCRIPTION
Backporting changes from Android IN queries: 
- [#519](https://github.com/firebase/firebase-android-sdk/pull/519#discussion_r294032999): filter for `null` and `NaN` and reorganize tests to match Android SDK
- [#550](https://github.com/firebase/firebase-android-sdk/pull/550): update doc comments for `clearPersistence()` to include Rachel's edits
- [#560](https://github.com/firebase/firebase-android-sdk/pull/560): Allow IN queries with field path and array of documentIds

This change introduces `KeyFieldInFilter`, which stacks on top of @wilhuff's refactor (#1894). This will be ported to Android when he refactors the Android client.

TODO: After this change goes in, I will update the error messages inside `parseDocumentIdValue()` to match the Android SDK, since those error messages are more generally applicable to both IN queries and KeyFieldFilter queries.