### PR TITLE
Fix prettier to avoid adding extra files.

### DIFF
--- a/tools/gitHooks/prettier.js
+++ b/tools/gitHooks/prettier.js
@@ -91,7 +91,7 @@ async function doPrettierCommit() {
   if (!hasDiff) return;
 
   const gitSpinner = ora(' Creating automated style commit').start();
-  await git.add('.');
+  await git.add(targetFiles);
 
   await git.commit('[AUTOMATED]: Prettier Code Styling');
   gitSpinner.stopAndPersist({


### PR DESCRIPTION
@var-const ran into an issue where he had some stray files in his git repo and our prettier pre-push hook errantly added them to git, committed them, and pushed them to github upon him running `git push`.

This is undesirable and borderline dangerous.  I believe the fix (thanks to the refactoring you did before) is to simply only add `targetFiles` rather than `.`.

Alternatively we could make the `hasDiff` check [here](https://github.com/firebase/firebase-js-sdk/blob/56301fdfe447dfd7b34432b5ba2fba5205b0707d/tools/gitHooks/prepush.js#L42) detect un-added files in your repo.