### PR TITLE
Set typescript strict option to true for functions and testing

### DIFF
--- a/packages/firebase/tsconfig.json
+++ b/packages/firebase/tsconfig.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "outDir": "dist",
     "declaration": false,
-    "allowSyntheticDefaultImports": true
+    "allowSyntheticDefaultImports": true,
+    "strict": true
   },
   "exclude": [
     "dist/**/*"

--- a/packages/functions/src/api/service.ts
+++ b/packages/functions/src/api/service.ts
@@ -71,7 +71,7 @@ export class Service implements FirebaseFunctions, FirebaseService {
   private readonly serializer = new Serializer();
   private emulatorOrigin: string | null = null;
   private cancelAllRequests: Promise<void>;
-  private deleteService: Function;
+  private deleteService: Function = () => {};
 
   /**
    * Creates a new Functions service for the given app and (optional) region.

--- a/packages/functions/src/api/service.ts
+++ b/packages/functions/src/api/service.ts
@@ -71,7 +71,7 @@ export class Service implements FirebaseFunctions, FirebaseService {
   private readonly serializer = new Serializer();
   private emulatorOrigin: string | null = null;
   private cancelAllRequests: Promise<void>;
-  private deleteService: Function = () => {};
+  private deleteService!: Function;
 
   /**
    * Creates a new Functions service for the given app and (optional) region.

--- a/packages/functions/tsconfig.json
+++ b/packages/functions/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../config/tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "dist"
+    "outDir": "dist",
+    "strict": true
   },
   "exclude": [
     "dist/**/*"

--- a/packages/testing/test/database.test.ts
+++ b/packages/testing/test/database.test.ts
@@ -87,13 +87,16 @@ describe('Testing Module Tests', function() {
   });
 
   it('loadDatabaseRules() throws if no databaseName or rules', async function() {
+    //@ts-ignore This test is checking an invalid param.
     await expect(firebase.loadDatabaseRules.bind(null, {})).to.throw(
       /databaseName not specified/
     );
+    //@ts-ignore This test is checking an invalid param.
     await expect(firebase.loadDatabaseRules.bind(null, {
       databaseName: 'foo'
     }) as Promise<void>).to.throw(/must provide rules/);
     await expect(
+      //@ts-ignore This test is checking an invalid param.
       firebase.loadDatabaseRules.bind(null, { rules: '{}' })
     ).to.throw(/databaseName not specified/);
   });

--- a/packages/testing/test/database.test.ts
+++ b/packages/testing/test/database.test.ts
@@ -87,17 +87,17 @@ describe('Testing Module Tests', function() {
   });
 
   it('loadDatabaseRules() throws if no databaseName or rules', async function() {
-    //@ts-ignore This test is checking an invalid param.
-    await expect(firebase.loadDatabaseRules.bind(null, {})).to.throw(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await expect((firebase as any).loadDatabaseRules.bind(null, {})).to.throw(
       /databaseName not specified/
     );
-    //@ts-ignore This test is checking an invalid param.
-    await expect(firebase.loadDatabaseRules.bind(null, {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await expect((firebase as any).loadDatabaseRules.bind(null, {
       databaseName: 'foo'
     }) as Promise<void>).to.throw(/must provide rules/);
     await expect(
-      //@ts-ignore This test is checking an invalid param.
-      firebase.loadDatabaseRules.bind(null, { rules: '{}' })
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (firebase as any).loadDatabaseRules.bind(null, { rules: '{}' })
     ).to.throw(/databaseName not specified/);
   });
 

--- a/packages/testing/tsconfig.json
+++ b/packages/testing/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../config/tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "dist"
+    "outDir": "dist",
+    "strict": true
   },
   "exclude": [
     "dist/**/*"


### PR DESCRIPTION
Turn on "strict: true" option in Typescript compiler for functions, testing, and main firebase package.