### PR TITLE
Use the FID from the server if client FID generation fails

### DIFF
--- a/packages/firebase/package.json
+++ b/packages/firebase/package.json
@@ -43,7 +43,7 @@
     "@firebase/database": "0.4.6",
     "@firebase/firestore": "1.4.2",
     "@firebase/functions": "0.4.10",
-    "@firebase/installations": "0.1.7",
+    "@firebase/installations": "0.2.0",
     "@firebase/messaging": "0.4.3",
     "@firebase/polyfill": "0.3.14",
     "@firebase/storage": "0.3.4",

--- a/packages/installations/package.json
+++ b/packages/installations/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@firebase/installations",
-  "version": "0.1.7",
+  "version": "0.2.0",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
   "esm2017": "dist/index.esm2017.js",

--- a/packages/installations/src/api/create-installation.test.ts
+++ b/packages/installations/src/api/create-installation.test.ts
@@ -58,7 +58,8 @@ describe('createInstallation', () => {
         token:
           'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCeKKF2QT4fwpMeJf36POk6yJV_adQssw5c',
         expiresIn: '604800s'
-      }
+      },
+      fid: FID
     };
     fetchSpy = stub(self, 'fetch');
   });

--- a/packages/installations/src/api/create-installation.ts
+++ b/packages/installations/src/api/create-installation.ts
@@ -55,7 +55,7 @@ export async function createInstallation(
   if (response.ok) {
     const responseValue: CreateInstallationResponse = await response.json();
     const registeredInstallationEntry: RegisteredInstallationEntry = {
-      fid,
+      fid: responseValue.fid,
       registrationStatus: RequestStatus.COMPLETED,
       refreshToken: responseValue.refreshToken,
       authToken: extractAuthTokenInfoFromResponse(responseValue.authToken)

--- a/packages/installations/src/helpers/buffer-to-base64-url-safe.test.ts
+++ b/packages/installations/src/helpers/buffer-to-base64-url-safe.test.ts
@@ -28,10 +28,4 @@ describe('bufferToBase64', () => {
       BASE_64_REPRESENTATION
     );
   });
-
-  it('returns a base64 representation of an ArrayBuffer', () => {
-    expect(bufferToBase64UrlSafe(TYPED_ARRAY_REPRESENTATION.buffer)).to.equal(
-      BASE_64_REPRESENTATION
-    );
-  });
 });

--- a/packages/installations/src/helpers/buffer-to-base64-url-safe.ts
+++ b/packages/installations/src/helpers/buffer-to-base64-url-safe.ts
@@ -15,10 +15,7 @@
  * limitations under the License.
  */
 
-export function bufferToBase64UrlSafe(
-  buffer: ArrayBuffer | Uint8Array
-): string {
-  const array = buffer instanceof Uint8Array ? buffer : new Uint8Array(buffer);
+export function bufferToBase64UrlSafe(array: Uint8Array): string {
   const b64 = btoa(String.fromCharCode(...array));
   return b64.replace(/\+/g, '-').replace(/\//g, '_');
 }

--- a/packages/installations/src/helpers/generate-fid.test.ts
+++ b/packages/installations/src/helpers/generate-fid.test.ts
@@ -18,7 +18,7 @@
 import { expect } from 'chai';
 import { stub } from 'sinon';
 import '../testing/setup';
-import { generateFid } from './generate-fid';
+import { generateFid, VALID_FID } from './generate-fid';
 
 /** A few random values to generate a FID from. */
 // prettier-ignore
@@ -52,8 +52,6 @@ const EXPECTED_FIDS = [
   'cAAAAAAAAAAAAAAAAAAAAA',
   'f_____________________'
 ];
-
-const VALID_FID = /^[cdef][A-Za-z0-9_-]{21}$/;
 
 describe('generateFid', () => {
   it('deterministically generates FIDs based on crypto.getRandomValues', () => {
@@ -117,4 +115,11 @@ describe('generateFid', () => {
       });
     }
   }).timeout(30000);
+
+  it('returns an empty string if FID generation fails', () => {
+    stub(crypto, 'getRandomValues').throws();
+
+    const fid = generateFid();
+    expect(fid).to.equal('');
+  });
 });

--- a/packages/installations/src/helpers/generate-fid.test.ts
+++ b/packages/installations/src/helpers/generate-fid.test.ts
@@ -18,7 +18,7 @@
 import { expect } from 'chai';
 import { stub } from 'sinon';
 import '../testing/setup';
-import { generateFid, VALID_FID } from './generate-fid';
+import { generateFid, VALID_FID_PATTERN } from './generate-fid';
 
 /** A few random values to generate a FID from. */
 // prettier-ignore
@@ -75,7 +75,10 @@ describe('generateFid', () => {
   it('generates valid FIDs', () => {
     for (let i = 0; i < 1000; i++) {
       const fid = generateFid();
-      expect(VALID_FID.test(fid)).to.equal(true, `${fid} is not a valid FID`);
+      expect(VALID_FID_PATTERN.test(fid)).to.equal(
+        true,
+        `${fid} is not a valid FID`
+      );
     }
   });
 

--- a/packages/installations/src/helpers/generate-fid.ts
+++ b/packages/installations/src/helpers/generate-fid.ts
@@ -28,6 +28,8 @@ export function generateFid(): string {
     // A valid FID has exactly 22 base64 characters, which is 132 bits, or 16.5
     // bytes. our implementation generates a 17 byte array instead.
     const fidByteArray = new Uint8Array(17);
+    const crypto =
+      self.crypto || ((self as unknown) as { msCrypto: Crypto }).msCrypto;
     crypto.getRandomValues(fidByteArray);
 
     // Replace the first 4 random bits with the constant FID header of 0b0111.

--- a/packages/installations/src/helpers/generate-fid.ts
+++ b/packages/installations/src/helpers/generate-fid.ts
@@ -17,17 +17,29 @@
 
 import { bufferToBase64UrlSafe } from './buffer-to-base64-url-safe';
 
-/** Generates a new FID using random values from Web Crypto API. */
+export const VALID_FID = /^[cdef][\w-]{21}$/;
+
+/**
+ * Generates a new FID using random values from Web Crypto API.
+ * Returns an empty string if FID generation fails for any reason.
+ */
 export function generateFid(): string {
-  // A valid FID has exactly 22 base64 characters, which is 132 bits, or 16.5
-  // bytes. our implementation generates a 17 byte array instead.
-  const fidByteArray = new Uint8Array(17);
-  crypto.getRandomValues(fidByteArray);
+  try {
+    // A valid FID has exactly 22 base64 characters, which is 132 bits, or 16.5
+    // bytes. our implementation generates a 17 byte array instead.
+    const fidByteArray = new Uint8Array(17);
+    crypto.getRandomValues(fidByteArray);
 
-  // Replace the first 4 random bits with the constant FID header of 0b0111.
-  fidByteArray[0] = 0b01110000 + (fidByteArray[0] % 0b00010000);
+    // Replace the first 4 random bits with the constant FID header of 0b0111.
+    fidByteArray[0] = 0b01110000 + (fidByteArray[0] % 0b00010000);
 
-  return encode(fidByteArray);
+    const fid = encode(fidByteArray);
+
+    return VALID_FID.test(fid) ? fid : '';
+  } catch {
+    // FID generation errored
+    return '';
+  }
 }
 
 /** Converts a FID Uint8Array to a base64 string representation. */

--- a/packages/installations/src/helpers/generate-fid.ts
+++ b/packages/installations/src/helpers/generate-fid.ts
@@ -17,7 +17,8 @@
 
 import { bufferToBase64UrlSafe } from './buffer-to-base64-url-safe';
 
-export const VALID_FID = /^[cdef][\w-]{21}$/;
+export const VALID_FID_PATTERN = /^[cdef][\w-]{21}$/;
+export const INVALID_FID = '';
 
 /**
  * Generates a new FID using random values from Web Crypto API.
@@ -37,10 +38,10 @@ export function generateFid(): string {
 
     const fid = encode(fidByteArray);
 
-    return VALID_FID.test(fid) ? fid : '';
+    return VALID_FID_PATTERN.test(fid) ? fid : INVALID_FID;
   } catch {
     // FID generation errored
-    return '';
+    return INVALID_FID;
   }
 }
 

--- a/packages/installations/src/helpers/get-installation-entry.test.ts
+++ b/packages/installations/src/helpers/get-installation-entry.test.ts
@@ -29,7 +29,7 @@ import { getFakeAppConfig } from '../testing/get-fake-app';
 import '../testing/setup';
 import { ERROR_FACTORY, ErrorCode } from '../util/errors';
 import { sleep } from '../util/sleep';
-import * as fidGenerator from './generate-fid';
+import * as generateFidModule from './generate-fid';
 import { getInstallationEntry } from './get-installation-entry';
 import { get, set } from './idb-manager';
 
@@ -180,9 +180,10 @@ describe('getInstallationEntry', () => {
     let generateInstallationEntrySpy: SinonStub<[], string>;
 
     beforeEach(() => {
-      generateInstallationEntrySpy = stub(fidGenerator, 'generateFid').returns(
-        FID
-      );
+      generateInstallationEntrySpy = stub(
+        generateFidModule,
+        'generateFid'
+      ).returns(FID);
     });
 
     it('returns a new pending InstallationEntry and triggers createInstallation', async () => {
@@ -263,7 +264,7 @@ describe('getInstallationEntry', () => {
       clock = useFakeTimers({ shouldAdvanceTime: true });
 
       // FID generation fails.
-      generateInstallationEntrySpy.returns('');
+      generateInstallationEntrySpy.returns(generateFidModule.INVALID_FID);
 
       const getInstallationEntryPromise = getInstallationEntry(appConfig);
 

--- a/packages/installations/src/helpers/get-installation-entry.ts
+++ b/packages/installations/src/helpers/get-installation-entry.ts
@@ -20,7 +20,8 @@ import { AppConfig } from '../interfaces/app-config';
 import {
   InProgressInstallationEntry,
   InstallationEntry,
-  RequestStatus
+  RequestStatus,
+  RegisteredInstallationEntry
 } from '../interfaces/installation-entry';
 import { PENDING_TIMEOUT_MS } from '../util/constants';
 import { ERROR_FACTORY, ErrorCode, isServerError } from '../util/errors';
@@ -30,7 +31,7 @@ import { remove, set, update } from './idb-manager';
 
 export interface InstallationEntryWithRegistrationPromise {
   installationEntry: InstallationEntry;
-  registrationPromise?: Promise<void>;
+  registrationPromise?: Promise<RegisteredInstallationEntry>;
 }
 
 /**
@@ -40,26 +41,33 @@ export interface InstallationEntryWithRegistrationPromise {
 export async function getInstallationEntry(
   appConfig: AppConfig
 ): Promise<InstallationEntryWithRegistrationPromise> {
-  let registrationPromise: Promise<void> | undefined;
+  let registrationPromise: Promise<RegisteredInstallationEntry> | undefined;
+
+  const installationEntry = await update(
+    appConfig,
+    (oldEntry?: InstallationEntry): InstallationEntry => {
+      const installationEntry = updateOrCreateInstallationEntry(oldEntry);
+      const entryWithPromise = triggerRegistrationIfNecessary(
+        appConfig,
+        installationEntry
+      );
+      registrationPromise = entryWithPromise.registrationPromise;
+      return entryWithPromise.installationEntry;
+    }
+  );
+
+  if (installationEntry.fid === '') {
+    // FID generation failed. Waiting for the FID from the server.
+    return { installationEntry: await registrationPromise! };
+  }
 
   return {
-    installationEntry: await update(
-      appConfig,
-      (oldEntry?: InstallationEntry): InstallationEntry => {
-        const installationEntry = updateOrCreateFid(oldEntry);
-        const entryWithPromise = triggerRegistrationIfNecessary(
-          appConfig,
-          installationEntry
-        );
-        registrationPromise = entryWithPromise.registrationPromise;
-        return entryWithPromise.installationEntry;
-      }
-    ),
+    installationEntry,
     registrationPromise
   };
 }
 
-function updateOrCreateFid(
+function updateOrCreateInstallationEntry(
   oldEntry: InstallationEntry | undefined
 ): InstallationEntry {
   const entry: InstallationEntry = oldEntry || {
@@ -124,13 +132,13 @@ function triggerRegistrationIfNecessary(
 async function registerInstallation(
   appConfig: AppConfig,
   installationEntry: InProgressInstallationEntry
-): Promise<void> {
+): Promise<RegisteredInstallationEntry> {
   try {
     const registeredInstallationEntry = await createInstallation(
       appConfig,
       installationEntry
     );
-    await set(appConfig, registeredInstallationEntry);
+    return set(appConfig, registeredInstallationEntry);
   } catch (e) {
     if (isServerError(e) && e.serverCode === 409) {
       // Server returned a "FID can not be used" error.
@@ -148,7 +156,9 @@ async function registerInstallation(
 }
 
 /** Call if FID registration is pending. */
-async function waitUntilFidRegistration(appConfig: AppConfig): Promise<void> {
+async function waitUntilFidRegistration(
+  appConfig: AppConfig
+): Promise<RegisteredInstallationEntry> {
   // Unfortunately, there is no way of reliably observing when a value in
   // IndexedDB changes (yet, see https://github.com/WICG/indexed-db-observers),
   // so we need to poll.
@@ -164,6 +174,8 @@ async function waitUntilFidRegistration(appConfig: AppConfig): Promise<void> {
   if (entry.registrationStatus === RequestStatus.NOT_STARTED) {
     throw ERROR_FACTORY.create(ErrorCode.CREATE_INSTALLATION_FAILED);
   }
+
+  return entry;
 }
 
 /**

--- a/packages/installations/src/helpers/get-installation-entry.ts
+++ b/packages/installations/src/helpers/get-installation-entry.ts
@@ -26,7 +26,7 @@ import {
 import { PENDING_TIMEOUT_MS } from '../util/constants';
 import { ERROR_FACTORY, ErrorCode, isServerError } from '../util/errors';
 import { sleep } from '../util/sleep';
-import { generateFid } from './generate-fid';
+import { generateFid, INVALID_FID } from './generate-fid';
 import { remove, set, update } from './idb-manager';
 
 export interface InstallationEntryWithRegistrationPromise {
@@ -56,7 +56,7 @@ export async function getInstallationEntry(
     }
   );
 
-  if (installationEntry.fid === '') {
+  if (installationEntry.fid === INVALID_FID) {
     // FID generation failed. Waiting for the FID from the server.
     return { installationEntry: await registrationPromise! };
   }

--- a/packages/installations/src/interfaces/api-response.ts
+++ b/packages/installations/src/interfaces/api-response.ts
@@ -18,6 +18,7 @@
 export interface CreateInstallationResponse {
   readonly refreshToken: string;
   readonly authToken: GenerateAuthTokenResponse;
+  readonly fid: string;
 }
 
 export interface GenerateAuthTokenResponse {

--- a/packages/performance/package.json
+++ b/packages/performance/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "@firebase/logger": "0.1.17",
-    "@firebase/installations": "0.1.7",
+    "@firebase/installations": "0.2.0",
     "@firebase/util": "0.2.20",
     "@firebase/performance-types": "0.0.2",
     "tslib": "1.9.3"


### PR DESCRIPTION
Starting from SDK v0.2.0, the server will start returning a valid FID instead of returning an error if the client tries to register an invalid FID, and the SDK will save that FID to the DB, replacing the invalid one. In case of a failure with client side FID generation, `getId` will wait for a valid FID from the server before resolving instead of throwing or returning an invalid FID.