### PR TITLE
Store the coerced base value in the BaseMutation

### DIFF
--- a/packages/firestore/CHANGELOG.md
+++ b/packages/firestore/CHANGELOG.md
@@ -1,5 +1,8 @@
 
 # Unreleased
+- [fixed] Fixed an internal assertion that was triggered when an update
+   with a `FieldValue.serverTimestamp()` and an update with a
+  `FieldValue.increment()` were pending for the same document.
 - [feature] Added `clearPersistence()`, which clears the persistent storage
   including pending writes and cached documents. This is intended to help
   write reliable tests (#449).

--- a/packages/firestore/src/local/local_store.ts
+++ b/packages/firestore/src/local/local_store.ts
@@ -27,7 +27,7 @@ import {
   maybeDocumentMap,
   MaybeDocumentMap
 } from '../model/collections';
-import { Document, MaybeDocument } from '../model/document';
+import { MaybeDocument } from '../model/document';
 import { DocumentKey } from '../model/document_key';
 import { Mutation, PatchMutation, Precondition } from '../model/mutation';
 import {
@@ -40,7 +40,6 @@ import { assert } from '../util/assert';
 import * as log from '../util/log';
 import * as objUtils from '../util/obj';
 
-import { ObjectValue } from '../model/field_value';
 import { LocalDocumentsView } from './local_documents_view';
 import { LocalViewChanges } from './local_view_changes';
 import { LruGarbageCollector, LruResults } from './lru_garbage_collector';
@@ -272,7 +271,7 @@ export class LocalStore {
             const baseMutations: Mutation[] = [];
 
             for (const mutation of mutations) {
-              let baseValue = mutation.extractBaseValue(
+              const baseValue = mutation.extractBaseValue(
                 existingDocs.get(mutation.key)
               );
               if (baseValue != null) {

--- a/packages/firestore/src/model/field_value.ts
+++ b/packages/firestore/src/model/field_value.ts
@@ -606,7 +606,10 @@ export class ObjectValue extends FieldValue {
     return field;
   }
 
-  /** Recursively extracts the FieldPaths that are set in this ObjectValue. */
+  /**
+   * Returns a FieldMask built from all FieldPaths starting from this ObjectValue,
+   * including paths from nested objects.
+   */
   fieldMask(): FieldMask {
     let fields = new SortedSet<FieldPath>(FieldPath.comparator);
     this.internalValue.forEach((key, value) => {

--- a/packages/firestore/src/model/mutation.ts
+++ b/packages/firestore/src/model/mutation.ts
@@ -277,9 +277,9 @@ export abstract class Mutation {
   ): MaybeDocument | null;
 
   /**
-   * If applicable, returns the base value to persist with this mutation. If a
-   * base value is provided, the mutation is always applied to this base value,
-   * even if document has already beenupdated.
+   * If this mutation is not idempotent, returns the base value to persist with
+   * this mutation. If a base value is returned, the mutation is always applied
+   * to this base value, even if document has already been updated.
    *
    * The base value is a sparse object that consists of only the document
    * fields for which this mutation contains a non-idempotent transformation

--- a/packages/firestore/src/model/mutation.ts
+++ b/packages/firestore/src/model/mutation.ts
@@ -582,11 +582,11 @@ export class TransformMutation extends Mutation {
   extractBaseValue(maybeDoc: MaybeDocument | null): ObjectValue | null {
     let baseObject: ObjectValue | null = null;
     for (const fieldTransform of this.fieldTransforms) {
-      let existingValue =
+      const existingValue =
         maybeDoc instanceof Document
           ? maybeDoc.field(fieldTransform.field)
           : undefined;
-      let coercedValue = fieldTransform.transform.computeBaseValue(
+      const coercedValue = fieldTransform.transform.computeBaseValue(
         existingValue || null
       );
 
@@ -695,7 +695,7 @@ export class TransformMutation extends Mutation {
         previousValue = maybeDoc.field(fieldTransform.field);
       }
 
-      if (previousValue == undefined && baseDoc instanceof Document) {
+      if (previousValue === null && baseDoc instanceof Document) {
         // If the current document does not contain a value for the mutated
         // field, use the value that existed before applying this mutation
         // batch. This solves an edge case where a PatchMutation clears the

--- a/packages/firestore/src/model/mutation.ts
+++ b/packages/firestore/src/model/mutation.ts
@@ -73,27 +73,6 @@ export class FieldMask {
     return found;
   }
 
-  /**
-   * Applies this field mask to the provided object value and returns an object
-   * that only contains fields that are specified in both the input object and
-   * this field mask.
-   */
-  applyTo(data: ObjectValue): ObjectValue {
-    let filteredObject = ObjectValue.EMPTY;
-    this.fields.forEach(fieldMaskPath => {
-      if (fieldMaskPath.isEmpty()) {
-        return data;
-      } else {
-        const newValue = data.field(fieldMaskPath);
-        if (newValue !== undefined) {
-          filteredObject = filteredObject.set(fieldMaskPath, newValue);
-        }
-      }
-    });
-
-    return filteredObject;
-  }
-
   isEqual(other: FieldMask): boolean {
     return this.fields.isEqual(other.fields);
   }
@@ -105,11 +84,6 @@ export class FieldTransform {
     readonly field: FieldPath,
     readonly transform: TransformOperation
   ) {}
-
-  /** Whether this field transform is idempotent. */
-  get isIdempotent(): boolean {
-    return this.transform.isIdempotent;
-  }
 
   isEqual(other: FieldTransform): boolean {
     return (
@@ -302,17 +276,25 @@ export abstract class Mutation {
     localWriteTime: Timestamp
   ): MaybeDocument | null;
 
-  abstract isEqual(other: Mutation): boolean;
-
   /**
-   * If applicable, returns the field mask for this mutation. Fields that are
-   * not included in this field mask are not modified when this mutation is
-   * applied. Mutations that replace the entire document return 'null'.
+   * If applicable, returns the base value to persist with this mutation. If a
+   * base value is provided, the mutation is always applied to this base value,
+   * even if document has already beenupdated.
+   *
+   * The base value is a sparse object that consists of only the document
+   * fields for which this mutation contains a non-idempotent transformation
+   * (e.g. a numeric increment). The provided alue guarantees consistent
+   * behavior for non-idempotent transforms and allow us to return the same
+   * latency-compensated value even if the backend has already applied the
+   * mutation. The base value is null for idempotent mutations, as they can be
+   * re-played even if the backend has already applied them.
+   *
+   * @return a base value to store along with the mutation, or null for
+   * idempotent mutations.
    */
-  abstract get fieldMask(): FieldMask | null;
+  abstract extractBaseValue(maybeDoc: MaybeDocument | null): ObjectValue | null;
 
-  /** Returns whether all operations in the mutation are idempotent. */
-  abstract get isIdempotent(): boolean;
+  abstract isEqual(other: Mutation): boolean;
 
   protected verifyKeyMatches(maybeDoc: MaybeDocument | null): void {
     if (maybeDoc != null) {
@@ -393,11 +375,7 @@ export class SetMutation extends Mutation {
     });
   }
 
-  get isIdempotent(): true {
-    return true;
-  }
-
-  get fieldMask(): null {
+  extractBaseValue(maybeDoc: MaybeDocument | null): null {
     return null;
   }
 
@@ -479,8 +457,8 @@ export class PatchMutation extends Mutation {
     });
   }
 
-  get isIdempotent(): true {
-    return true;
+  extractBaseValue(maybeDoc: MaybeDocument | null): null {
+    return null;
   }
 
   isEqual(other: Mutation): boolean {
@@ -592,6 +570,7 @@ export class TransformMutation extends Mutation {
     const doc = this.requireDocument(maybeDoc);
     const transformResults = this.localTransformResults(
       localWriteTime,
+      maybeDoc,
       baseDoc
     );
     const newData = this.transformObject(doc.data, transformResults);
@@ -600,22 +579,29 @@ export class TransformMutation extends Mutation {
     });
   }
 
-  get isIdempotent(): boolean {
+  extractBaseValue(maybeDoc: MaybeDocument | null): ObjectValue | null {
+    let baseObject: ObjectValue | null = null;
     for (const fieldTransform of this.fieldTransforms) {
-      if (!fieldTransform.isIdempotent) {
-        return false;
+      let existingValue =
+        maybeDoc instanceof Document
+          ? maybeDoc.field(fieldTransform.field)
+          : undefined;
+      let coercedValue = fieldTransform.transform.computeBaseValue(
+        existingValue || null
+      );
+
+      if (coercedValue != null) {
+        if (baseObject == null) {
+          baseObject = ObjectValue.EMPTY.set(
+            fieldTransform.field,
+            coercedValue
+          );
+        } else {
+          baseObject = baseObject.set(fieldTransform.field, coercedValue);
+        }
       }
     }
-
-    return true;
-  }
-
-  get fieldMask(): FieldMask {
-    let fieldMask = new SortedSet<FieldPath>(FieldPath.comparator);
-    this.fieldTransforms.forEach(
-      transform => (fieldMask = fieldMask.add(transform.field))
-    );
-    return new FieldMask(fieldMask);
+    return baseObject;
   }
 
   isEqual(other: Mutation): boolean {
@@ -690,24 +676,35 @@ export class TransformMutation extends Mutation {
    *
    * @param localWriteTime The local time of the transform mutation (used to
    *     generate ServerTimestampValues).
+   * @param maybeDoc The current state of the document after applying all
+   *     previous mutations.
    * @param baseDoc The document prior to applying this mutation batch.
    * @return The transform results list.
    */
   private localTransformResults(
     localWriteTime: Timestamp,
+    maybeDoc: MaybeDocument | null,
     baseDoc: MaybeDocument | null
   ): FieldValue[] {
     const transformResults = [] as FieldValue[];
     for (const fieldTransform of this.fieldTransforms) {
       const transform = fieldTransform.transform;
 
-      let previousValue: FieldValue | null = null;
-      if (baseDoc instanceof Document) {
-        previousValue = baseDoc.field(fieldTransform.field) || null;
+      let previousValue: FieldValue | undefined = undefined;
+      if (maybeDoc instanceof Document) {
+        previousValue = maybeDoc.field(fieldTransform.field);
+      }
+
+      if (previousValue == undefined && baseDoc instanceof Document) {
+        // If the current document does not contain a value for the mutated
+        // field, use the value that existed before applying this mutation
+        // batch. This solves an edge case where a PatchMutation clears the
+        // values in a nested map before the TransformMutation is applied.
+        previousValue = baseDoc.field(fieldTransform.field);
       }
 
       transformResults.push(
-        transform.applyToLocalView(previousValue, localWriteTime)
+        transform.applyToLocalView(previousValue || null, localWriteTime)
       );
     }
     return transformResults;
@@ -779,19 +776,15 @@ export class DeleteMutation extends Mutation {
     return new NoDocument(this.key, SnapshotVersion.forDeletedDoc());
   }
 
+  extractBaseValue(maybeDoc: MaybeDocument | null): null {
+    return null;
+  }
+
   isEqual(other: Mutation): boolean {
     return (
       other instanceof DeleteMutation &&
       this.key.isEqual(other.key) &&
       this.precondition.isEqual(other.precondition)
     );
-  }
-
-  get isIdempotent(): true {
-    return true;
-  }
-
-  get fieldMask(): null {
-    return null;
   }
 }

--- a/packages/firestore/src/model/transform_operation.ts
+++ b/packages/firestore/src/model/transform_operation.ts
@@ -48,9 +48,10 @@ export interface TransformOperation {
   ): FieldValue;
 
   /**
-   * If applicable, returns the base value to persist for this transform. If a
-   * base value is provided, the transform operation is always applied to this
-   * base value, even if document has already been updated.
+   * If this transform operation is not idempotent, returns the base value to
+   * persist for this transform. If a base value is returned, the transform
+   * operation is always applied to this base value, even if document has
+   * already been updated.
    *
    * Base values provide consistent behavior for non-idempotent transforms and
    * allow us to return the same latency-compensated value even if the backend

--- a/packages/firestore/src/model/transform_operation.ts
+++ b/packages/firestore/src/model/transform_operation.ts
@@ -29,9 +29,6 @@ import {
 
 /** Represents a transform within a TransformMutation. */
 export interface TransformOperation {
-  /** Whether this field transform is idempotent. */
-  readonly isIdempotent: boolean;
-
   /**
    * Computes the local transform result against the provided `previousValue`,
    * optionally using the provided localWriteTime.
@@ -50,13 +47,27 @@ export interface TransformOperation {
     transformResult: FieldValue | null
   ): FieldValue;
 
+  /**
+   * If applicable, returns the base value to persist for this transform. If a
+   * base value is provided, the transform operation is always applied to this
+   * base value, even if document has already been updated.
+   *
+   * Base values provide consistent behavior for non-idempotent transforms and
+   * allow us to return the same latency-compensated value even if the backend
+   * has already applied the transform operation. The base value is null for
+   * idempotent transforms, as they can be re-played even if the backend has
+   * already applied them.
+   *
+   * @return a base value to store along with the mutation, or null for
+   * idempotent transforms.
+   */
+  computeBaseValue(previousValue: FieldValue | null): FieldValue | null;
+
   isEqual(other: TransformOperation): boolean;
 }
 
 /** Transforms a value into a server-generated timestamp. */
 export class ServerTimestampTransform implements TransformOperation {
-  readonly isIdempotent = true;
-
   private constructor() {}
   static instance = new ServerTimestampTransform();
 
@@ -74,6 +85,10 @@ export class ServerTimestampTransform implements TransformOperation {
     return transformResult!;
   }
 
+  computeBaseValue(previousValue: FieldValue | null): FieldValue | null {
+    return null; // Server timestamps are idempotent and don't require a base value.
+  }
+
   isEqual(other: TransformOperation): boolean {
     return other instanceof ServerTimestampTransform;
   }
@@ -81,8 +96,6 @@ export class ServerTimestampTransform implements TransformOperation {
 
 /** Transforms an array value via a union operation. */
 export class ArrayUnionTransformOperation implements TransformOperation {
-  readonly isIdempotent = true;
-
   constructor(readonly elements: FieldValue[]) {}
 
   applyToLocalView(
@@ -112,6 +125,10 @@ export class ArrayUnionTransformOperation implements TransformOperation {
     return new ArrayValue(result);
   }
 
+  computeBaseValue(previousValue: FieldValue | null): FieldValue | null {
+    return null; // Array transforms are idempotent and don't require a base value.
+  }
+
   isEqual(other: TransformOperation): boolean {
     return (
       other instanceof ArrayUnionTransformOperation &&
@@ -122,8 +139,6 @@ export class ArrayUnionTransformOperation implements TransformOperation {
 
 /** Transforms an array value via a remove operation. */
 export class ArrayRemoveTransformOperation implements TransformOperation {
-  readonly isIdempotent = true;
-
   constructor(readonly elements: FieldValue[]) {}
 
   applyToLocalView(
@@ -151,6 +166,10 @@ export class ArrayRemoveTransformOperation implements TransformOperation {
     return new ArrayValue(result);
   }
 
+  computeBaseValue(previousValue: FieldValue | null): FieldValue | null {
+    return null; // Array transforms are idempotent and don't require a base value.
+  }
+
   isEqual(other: TransformOperation): boolean {
     return (
       other instanceof ArrayRemoveTransformOperation &&
@@ -166,14 +185,13 @@ export class ArrayRemoveTransformOperation implements TransformOperation {
  * arithmetic is used and precision loss can occur for values greater than 2^53.
  */
 export class NumericIncrementTransformOperation implements TransformOperation {
-  readonly isIdempotent = false;
-
   constructor(readonly operand: NumberValue) {}
 
   applyToLocalView(
     previousValue: FieldValue | null,
     localWriteTime: Timestamp
   ): FieldValue {
+    const baseValue = this.computeBaseValue(previousValue);
     // PORTING NOTE: Since JavaScript's integer arithmetic is limited to 53 bit
     // precision and resolves overflows by reducing precision, we do not
     // manually cap overflows at 2^63.
@@ -181,18 +199,14 @@ export class NumericIncrementTransformOperation implements TransformOperation {
     // Return an integer value iff the previous value and the operand is an
     // integer.
     if (
-      previousValue instanceof IntegerValue &&
+      baseValue instanceof IntegerValue &&
       this.operand instanceof IntegerValue
     ) {
-      const sum = previousValue.internalValue + this.operand.internalValue;
+      const sum = baseValue.internalValue + this.operand.internalValue;
       return new IntegerValue(sum);
-    } else if (previousValue instanceof NumberValue) {
-      const sum = previousValue.internalValue + this.operand.internalValue;
-      return new DoubleValue(sum);
     } else {
-      // If the existing value is not a number, use the value of the transform as
-      // the new base value.
-      return this.operand;
+      const sum = baseValue.internalValue + this.operand.internalValue;
+      return new DoubleValue(sum);
     }
   }
 
@@ -205,6 +219,16 @@ export class NumericIncrementTransformOperation implements TransformOperation {
       "Didn't receive transformResult for NUMERIC_ADD transform"
     );
     return transformResult!;
+  }
+
+  /**
+   * Inspects the provided value, returning the provided value if it is already
+   * a NumberValue, otherwise returning a coerced IntegerValue of 0.
+   */
+  computeBaseValue(previousValue: FieldValue | null): NumberValue {
+    return previousValue instanceof NumberValue
+      ? previousValue
+      : new IntegerValue(0);
   }
 
   isEqual(other: TransformOperation): boolean {

--- a/packages/firestore/test/integration/api/numeric_transforms.test.ts
+++ b/packages/firestore/test/integration/api/numeric_transforms.test.ts
@@ -163,4 +163,55 @@ apiDescribe('Numeric Transforms:', (persistence: boolean) => {
       expect(snap.get('sum')).to.be.closeTo(0.111, DOUBLE_EPSILON);
     });
   });
+
+  it('increment twice in a batch', async () => {
+    await withTestSetup(async () => {
+      await writeInitialData({ sum: 'overwrite' });
+
+      const batch = docRef.firestore.batch();
+      batch.update(docRef, 'sum', FieldValue.increment(1));
+      batch.update(docRef, 'sum', FieldValue.increment(1));
+      await batch.commit();
+
+      await expectLocalAndRemoteValue(2);
+    });
+  });
+
+  it('increment, delete and increment in a batch', async () => {
+    await withTestSetup(async () => {
+      await writeInitialData({ sum: 'overwrite' });
+
+      const batch = docRef.firestore.batch();
+      batch.update(docRef, 'sum', FieldValue.increment(1));
+      batch.update(docRef, 'sum', FieldValue.delete());
+      batch.update(docRef, 'sum', FieldValue.increment(3));
+      await batch.commit();
+
+      await expectLocalAndRemoteValue(3);
+    });
+  });
+
+  it('increment on top of ServerTimestamp', async () => {
+    // This test stacks two pending transforms (a ServerTimestamp and an Increment transform)
+    // and reproduces the setup that was reported in
+    // https://github.com/firebase/firebase-android-sdk/issues/491
+    // In our original code, a NumericIncrementTransformOperation could cause us to decode the
+    // ServerTimestamp as part of a PatchMutation, which triggered an assertion failure.
+    await withTestSetup(async () => {
+      await docRef.firestore.disableNetwork();
+
+      docRef.set({ val: FieldValue.serverTimestamp() });
+      let snap = await accumulator.awaitLocalEvent();
+      expect(snap.get('val', { serverTimestamps: 'estimate' })).to.not.be.null;
+
+      docRef.set({ val: FieldValue.increment(1) });
+      snap = await accumulator.awaitLocalEvent();
+      expect(snap.get('val')).to.equal(1);
+
+      await docRef.firestore.enableNetwork();
+
+      snap = await accumulator.awaitRemoteEvent();
+      expect(snap.get('val')).to.equal(1);
+    });
+  });
 });

--- a/packages/firestore/test/integration/api/server_timestamp.test.ts
+++ b/packages/firestore/test/integration/api/server_timestamp.test.ts
@@ -209,11 +209,11 @@ apiDescribe('Server Timestamps', (persistence: boolean) => {
   });
 
   it('can return previous value', () => {
-    // The following update includes an update of the nested map "deep", which
-    // updates it to contain a single ServerTimestamp. As such, the update is
-    // split into two mutations: One that sets "deep" to an empty map and
-    // overwrites the previous ServerTimestamp value and a second ransform that
-    // writes the new ServerTimestamp. This step in the test verifies that we can
+    // The following test includes an update of the nested map "deep", which
+    // updates it to contain a single ServerTimestamp. This update is split
+    // into two mutations: One that sets "deep" to an empty map and overwrites
+    // the previous ServerTimestamp value and a second transform that writes
+    // the new ServerTimestamp. This step in the test verifies that we can
     // still access the old ServerTimestamp value (from `previousSnapshot`) even
     // though it was removed in an intermediate step.
 

--- a/packages/firestore/test/integration/api/server_timestamp.test.ts
+++ b/packages/firestore/test/integration/api/server_timestamp.test.ts
@@ -209,6 +209,14 @@ apiDescribe('Server Timestamps', (persistence: boolean) => {
   });
 
   it('can return previous value', () => {
+    // The following update includes an update of the nested map "deep", which
+    // updates it to contain a single ServerTimestamp. As such, the update is
+    // split into two mutations: One that sets "deep" to an empty map and
+    // overwrites the previous ServerTimestamp value and a second ransform that
+    // writes the new ServerTimestamp. This step in the test verifies that we can
+    // still access the old ServerTimestamp value (from `previousSnapshot`) even
+    // though it was removed in an intermediate step.
+
     let previousSnapshot: firestore.DocumentSnapshot;
 
     return withTestSetup(() => {

--- a/packages/firestore/test/unit/model/field_value.test.ts
+++ b/packages/firestore/test/unit/model/field_value.test.ts
@@ -27,6 +27,7 @@ import {
   expectEqualitySets,
   field,
   key,
+  mask,
   ref,
   wrap,
   wrapObject
@@ -309,6 +310,24 @@ describe('FieldValue', () => {
     expect(objValue2.value()).to.deep.equal(expected);
     expect(objValue3.value()).to.deep.equal(expected);
     expect(objValue4.value()).to.deep.equal(expected);
+  });
+
+  it('provides field mask', () => {
+    const objValue = wrapObject({
+      a: 'b',
+      map: { a: 1, b: true, c: 'string', nested: { d: 'e' } },
+      emptymap: {}
+    });
+    const expectedMask = mask(
+      'a',
+      'map.a',
+      'map.b',
+      'map.c',
+      'map.nested.d',
+      'emptymap'
+    );
+    const actualMask = objValue.fieldMask();
+    expect(actualMask.isEqual(expectedMask)).to.be.true;
   });
 
   it('compares values for equality', () => {

--- a/packages/firestore/test/unit/model/mutation.test.ts
+++ b/packages/firestore/test/unit/model/mutation.test.ts
@@ -637,22 +637,22 @@ describe('Mutation', () => {
       ignore: 'foo',
       double: 42.0,
       long: 42,
-      string: 'foo',
+      text: 'foo',
       map: {},
-      nested: { ignore: 'foo', double: 42.0, long: 42, string: 'foo', map: {} }
+      nested: { ignore: 'foo', double: 42.0, long: 42, text: 'foo', map: {} }
     };
     const baseDoc = doc('collection/key', 0, allValues);
 
     const allTransforms = {
       double: FieldValue.increment(1),
       long: FieldValue.increment(1),
-      string: FieldValue.increment(1),
+      text: FieldValue.increment(1),
       map: FieldValue.increment(1),
       missing: FieldValue.increment(1),
       nested: {
         double: FieldValue.increment(1),
         long: FieldValue.increment(1),
-        string: FieldValue.increment(1),
+        text: FieldValue.increment(1),
         map: FieldValue.increment(1),
         missing: FieldValue.increment(1)
       }
@@ -662,10 +662,10 @@ describe('Mutation', () => {
     const expectedBaseValue = wrap({
       double: 42.0,
       long: 42,
-      string: 0,
+      text: 0,
       map: 0,
       missing: 0,
-      nested: { double: 42.0, long: 42, string: 0, map: 0, missing: 0 }
+      nested: { double: 42.0, long: 42, text: 0, map: 0, missing: 0 }
     });
     const actualBaseValue = transform.extractBaseValue(baseDoc);
 

--- a/packages/firestore/test/util/helpers.ts
+++ b/packages/firestore/test/util/helpers.ts
@@ -67,6 +67,7 @@ import {
 } from '../../src/model/field_value';
 import {
   DeleteMutation,
+  FieldMask,
   MutationResult,
   PatchMutation,
   Precondition,
@@ -179,6 +180,14 @@ export function path(path: string, offset?: number): ResourcePath {
 
 export function field(path: string): FieldPath {
   return fromDotSeparatedString(path)._internalPath;
+}
+
+export function mask(...paths: string[]): FieldMask {
+  let fieldPaths = new SortedSet<FieldPath>(FieldPath.comparator);
+  for (const path of paths) {
+    fieldPaths = fieldPaths.add(field(path));
+  }
+  return FieldMask.fromSet(fieldPaths);
 }
 
 export function blob(...bytes: number[]): Blob {


### PR DESCRIPTION
Port of https://github.com/firebase/firebase-android-sdk/pull/564

The PR changes what we store in a BaseMutation. With the changes here, every transform operation computes what it needs to store in the BaseMutation. For Numeric increment, this is either an existing numeric value or the IntegerValue.of(0), replacing all invalid base values at time of creation.