### PR TITLE
Standardize Firestore transaction errors

### DIFF
--- a/packages/firestore/src/core/sync_engine.ts
+++ b/packages/firestore/src/core/sync_engine.ts
@@ -417,6 +417,7 @@ export class SyncEngine implements RemoteSyncer, SharedClientStateSyncer {
             return Promise.reject<T>(error);
           }
           // TODO(klimt): Put in a retry delay?
+          console.warn('retried at count = ', retries);
           return this.runTransaction(updateFunction, retries - 1);
         });
     });

--- a/packages/firestore/src/core/sync_engine.ts
+++ b/packages/firestore/src/core/sync_engine.ts
@@ -417,7 +417,6 @@ export class SyncEngine implements RemoteSyncer, SharedClientStateSyncer {
             return Promise.reject<T>(error);
           }
           // TODO(klimt): Put in a retry delay?
-          console.warn('retried at count = ', retries);
           return this.runTransaction(updateFunction, retries - 1);
         });
     });

--- a/packages/firestore/src/core/transaction.ts
+++ b/packages/firestore/src/core/transaction.ts
@@ -117,7 +117,13 @@ export class Transaction {
    */
   private preconditionForUpdate(key: DocumentKey): Precondition {
     const version = this.readVersions.get(key);
-    if (version && !version.isEqual(SnapshotVersion.forDeletedDoc())) {
+    if (version && version.isEqual(SnapshotVersion.forDeletedDoc())) {
+      // The document doesn't exist, so fail the transaction.
+      throw new FirestoreError(
+        Code.INVALID_ARGUMENT,
+        "Can't update a document that doesn't exist."
+      );
+    } else if (version) {
       // Document exists, just base precondition on document update time.
       return Precondition.updateTime(version);
     } else {

--- a/packages/firestore/src/core/transaction.ts
+++ b/packages/firestore/src/core/transaction.ts
@@ -124,7 +124,7 @@ export class Transaction {
         "Can't update a document that doesn't exist."
       );
     } else if (version) {
-      // Document exists, just base precondition on document update time.
+      // Document exists, base precondition on document update time.
       return Precondition.updateTime(version);
     } else {
       // Document was not read, so we just use the preconditions for a blind

--- a/packages/firestore/src/core/transaction.ts
+++ b/packages/firestore/src/core/transaction.ts
@@ -118,6 +118,7 @@ export class Transaction {
   private preconditionForUpdate(key: DocumentKey): Precondition {
     const version = this.readVersions.get(key);
     if (version && !version.isEqual(SnapshotVersion.forDeletedDoc())) {
+      // Document exists, just base precondition on document update time.
       return Precondition.updateTime(version);
     } else {
       // Document was not read, so we just use the preconditions for a blind

--- a/packages/firestore/src/core/transaction.ts
+++ b/packages/firestore/src/core/transaction.ts
@@ -37,7 +37,7 @@ export class Transaction {
   private committed = false;
 
   /**
-   * An error that may have occurred as a consequence of a write. 
+   * An error that may have occurred as a consequence of a write.
    * If set, commit() will throw the stored error.
    */
   private lastWriteError: FirestoreError;

--- a/packages/firestore/src/core/transaction.ts
+++ b/packages/firestore/src/core/transaction.ts
@@ -67,13 +67,13 @@ export class Transaction {
   lookup(keys: DocumentKey[]): Promise<MaybeDocument[]> {
     if (this.committed) {
       throw new FirestoreError(
-        Code.FAILED_PRECONDITION,
+        Code.INVALID_ARGUMENT,
         'Transaction has already completed.'
       );
     }
     if (this.mutations.length > 0) {
       throw new FirestoreError(
-        Code.FAILED_PRECONDITION,
+        Code.INVALID_ARGUMENT,
         'Firestore transactions require all reads to be executed before all writes.'
       );
     }
@@ -92,7 +92,7 @@ export class Transaction {
   private write(mutations: Mutation[]): void {
     if (this.committed) {
       throw new FirestoreError(
-        Code.FAILED_PRECONDITION,
+        Code.INVALID_ARGUMENT,
         'Transaction has already completed.'
       );
     }
@@ -153,7 +153,7 @@ export class Transaction {
     });
     if (!unwritten.isEmpty()) {
       throw new FirestoreError(
-        Code.FAILED_PRECONDITION,
+        Code.INVALID_ARGUMENT,
         'Every document read in a transaction must also be written.'
       );
     }

--- a/packages/firestore/test/integration/api/transactions.test.ts
+++ b/packages/firestore/test/integration/api/transactions.test.ts
@@ -20,7 +20,6 @@ import { expect } from 'chai';
 import { Deferred } from '../../util/promise';
 import firebase from '../util/firebase_export';
 import * as integrationHelpers from '../util/helpers';
-import { fail } from '../../../src/util/assert';
 
 const apiDescribe = integrationHelpers.apiDescribe;
 

--- a/packages/firestore/test/integration/api/transactions.test.ts
+++ b/packages/firestore/test/integration/api/transactions.test.ts
@@ -464,7 +464,10 @@ apiDescribe('Database transactions', (persistence: boolean) => {
         })
         .catch((err: firestore.FirestoreError) => {
           expect(err).to.exist;
-          expect(err.code).to.equal('failed-precondition');
+          expect(err.code).to.equal('invalid-argument');
+          expect(err.message).to.contain(
+            'Firestore transactions require all reads to be executed'
+          );
         });
     });
   });
@@ -521,7 +524,7 @@ apiDescribe('Database transactions', (persistence: boolean) => {
           .then(() => expect.fail('transaction should fail'))
           .catch((err: firestore.FirestoreError) => {
             expect(err).to.exist;
-            expect(err.code).to.equal('failed-precondition');
+            expect(err.code).to.equal('invalid-argument');
             expect(err.message).to.contain(
               'Every document read in a transaction must also be ' + 'written'
             );

--- a/packages/firestore/test/integration/api/transactions.test.ts
+++ b/packages/firestore/test/integration/api/transactions.test.ts
@@ -405,8 +405,9 @@ apiDescribe('Database transactions', (persistence: boolean) => {
           // })
           // .then(snapshot => expect(snapshot.data()['count']).to.equal(16));
           .then(() => expect.fail('transaction should fail'))
-          .catch(err => {
+          .catch((err: firestore.FirestoreError) => {
             expect(err).to.exist;
+            expect(err.code).to.equal('invalid-argument');
             expect(err.message).to.contain(
               'Every document read in a transaction must also be ' + 'written'
             );


### PR DESCRIPTION
- Standardize errors based on the spreadsheet.
- Remove local validation for document not found in transactions.