### PR TITLE
Turn on Typescript strict option for Firestore

### DIFF
--- a/packages/firestore/src/api/credentials.ts
+++ b/packages/firestore/src/api/credentials.ts
@@ -134,7 +134,7 @@ export class FirebaseCredentialsProvider implements CredentialsProvider {
   private tokenListener: ((token: string | null) => void) | null = null;
 
   /** Tracks the current User. */
-  private currentUser: User;
+  private currentUser?: User;
 
   /**
    * Counter used to detect if the token changed while a getToken request was
@@ -192,7 +192,7 @@ export class FirebaseCredentialsProvider implements CredentialsProvider {
               typeof tokenData.accessToken === 'string',
               'Invalid tokenData returned from getToken():' + tokenData
             );
-            return new OAuthToken(tokenData.accessToken, this.currentUser);
+            return new OAuthToken(tokenData.accessToken, this.currentUser!);
           } else {
             return null;
           }

--- a/packages/firestore/src/api/database.ts
+++ b/packages/firestore/src/api/database.ts
@@ -283,12 +283,12 @@ class FirestoreSettings {
 }
 
 class FirestoreConfig {
-  databaseId: DatabaseId;
-  persistenceKey: string;
-  credentials: CredentialsProvider;
-  firebaseApp: FirebaseApp;
-  settings: FirestoreSettings;
-  persistence: boolean;
+  databaseId!: DatabaseId;
+  persistenceKey!: string;
+  credentials!: CredentialsProvider;
+  firebaseApp?: FirebaseApp;
+  settings!: FirestoreSettings;
+  persistence?: boolean;
 }
 
 /**
@@ -313,7 +313,7 @@ export class Firestore implements firestore.FirebaseFirestore, FirebaseService {
   // TODO(mikelehen): Use modularized initialization instead.
   readonly _queue = new AsyncQueue();
 
-  _dataConverter: UserDataConverter;
+  _dataConverter!: UserDataConverter;
 
   constructor(databaseIdOrApp: FirestoreDatabase | FirebaseApp) {
     const config = new FirestoreConfig();

--- a/packages/firestore/src/core/event_manager.ts
+++ b/packages/firestore/src/core/event_manager.ts
@@ -28,8 +28,8 @@ import { DocumentViewChange, ChangeType, ViewSnapshot } from './view_snapshot';
  * tracked by EventManager.
  */
 class QueryListenersInfo {
-  viewSnap: ViewSnapshot | null;
-  targetId: TargetId;
+  viewSnap: ViewSnapshot | null = null;
+  targetId?: TargetId;
   listeners: QueryListener[] = [];
 }
 
@@ -81,7 +81,7 @@ export class EventManager implements SyncEngineListener {
         return targetId;
       });
     } else {
-      return Promise.resolve(queryInfo.targetId);
+      return Promise.resolve(queryInfo.targetId!);
     }
   }
 
@@ -166,7 +166,7 @@ export class QueryListener {
 
   private options: ListenOptions;
 
-  private snap: ViewSnapshot;
+  private snap?: ViewSnapshot;
 
   private onlineState: OnlineState = OnlineState.Unknown;
 

--- a/packages/firestore/src/core/firestore_client.ts
+++ b/packages/firestore/src/core/firestore_client.ts
@@ -96,21 +96,20 @@ export class FirestoreClient {
   // NOTE: These should technically have '|undefined' in the types, since
   // they're initialized asynchronously rather than in the constructor, but
   // given that all work is done on the async queue and we assert that
-  // initialization completes before any other work is queued, we're cheating
-  // with the types rather than littering the code with '!' or unnecessary
-  // undefined checks.
-  private eventMgr: EventManager;
-  private persistence: Persistence;
-  private localStore: LocalStore;
-  private remoteStore: RemoteStore;
-  private syncEngine: SyncEngine;
+  // initialization completes before any other work is queued, we use !
+  // to guarantee these will be initialized when called.
+  private eventMgr!: EventManager;
+  private persistence!: Persistence;
+  private localStore!: LocalStore;
+  private remoteStore!: RemoteStore;
+  private syncEngine!: SyncEngine;
   private lruScheduler?: LruScheduler;
 
   private readonly clientId = AutoId.newId();
   private _clientShutdown = false;
 
   // PORTING NOTE: SharedClientState is only used for multi-tab web.
-  private sharedClientState: SharedClientState;
+  private sharedClientState!: SharedClientState;
 
   constructor(
     private platform: Platform,

--- a/packages/firestore/src/core/sync_engine.ts
+++ b/packages/firestore/src/core/sync_engine.ts
@@ -109,7 +109,7 @@ class LimboResolution {
    * decide whether it needs to manufacture a delete event for the target once
    * the target is CURRENT.
    */
-  receivedDocument: boolean;
+  receivedDocument: boolean = false;
 }
 
 /**

--- a/packages/firestore/src/core/target_id_generator.ts
+++ b/packages/firestore/src/core/target_id_generator.ts
@@ -42,7 +42,8 @@ enum GeneratorIds {
 // TODO(mrschmidt): Explore removing this class in favor of generating these IDs
 // directly in SyncEngine and LocalStore.
 export class TargetIdGenerator {
-  private nextId: TargetId;
+  // This is assigned in this.seek(), which is called in the constructor.
+  private nextId!: TargetId;
 
   /**
    * Instantiates a new TargetIdGenerator. If a seed is provided, the generator

--- a/packages/firestore/src/local/indexeddb_persistence.ts
+++ b/packages/firestore/src/local/indexeddb_persistence.ts
@@ -236,23 +236,23 @@ export class IndexedDbPersistence implements Persistence {
   private readonly document: Document | null;
   private readonly window: Window;
 
-  private simpleDb: SimpleDb;
+  private simpleDb!: SimpleDb;
   private _started = false;
   private isPrimary = false;
   private networkEnabled = true;
   private dbName: string;
 
   /** Our window.unload handler, if registered. */
-  private windowUnloadHandler: (() => void) | null;
+  private windowUnloadHandler: (() => void) | null = null;
   private inForeground = false;
 
   private serializer: LocalSerializer;
 
   /** Our 'visibilitychange' listener if registered. */
-  private documentVisibilityHandler: ((e?: Event) => void) | null;
+  private documentVisibilityHandler: ((e?: Event) => void) | null = null;
 
   /** The client metadata refresh task. */
-  private clientMetadataRefresher: CancelablePromise<void>;
+  private clientMetadataRefresher?: CancelablePromise<void>;
 
   /** The last time we garbage collected the Remote Document Changelog. */
   private lastGarbageCollectionTime = Number.NEGATIVE_INFINITY;
@@ -267,7 +267,7 @@ export class IndexedDbPersistence implements Persistence {
   private readonly indexManager: IndexedDbIndexManager;
   private readonly remoteDocumentCache: IndexedDbRemoteDocumentCache;
   private readonly webStorage: Storage;
-  private listenSequence: ListenSequence;
+  private listenSequence!: ListenSequence;
   readonly referenceDelegate: IndexedDbLruDelegate;
 
   // Note that `multiClientParams` must be present to enable multi-client support while multi-tab
@@ -1131,7 +1131,7 @@ function clientMetadataStore(
 
 /** Provides LRU functionality for IndexedDB persistence. */
 export class IndexedDbLruDelegate implements ReferenceDelegate, LruDelegate {
-  private inMemoryPins: ReferenceSet | null;
+  private inMemoryPins: ReferenceSet | null = null;
 
   readonly garbageCollector: LruGarbageCollector;
 

--- a/packages/firestore/src/local/lru_garbage_collector.ts
+++ b/packages/firestore/src/local/lru_garbage_collector.ts
@@ -217,7 +217,7 @@ const REGULAR_GC_DELAY_MS = 5 * 60 * 1000;
  * whether or not GC is enabled, as well as which delay to use before the next run.
  */
 export class LruScheduler {
-  private hasRun: boolean;
+  private hasRun: boolean = false;
   private gcTask: CancelablePromise<void> | null;
 
   constructor(

--- a/packages/firestore/src/local/memory_persistence.ts
+++ b/packages/firestore/src/local/memory_persistence.ts
@@ -207,8 +207,9 @@ export class MemoryTransaction implements PersistenceTransaction {
 }
 
 export class MemoryEagerDelegate implements ReferenceDelegate {
-  private inMemoryPins: ReferenceSet | null;
-  private orphanedDocuments: Set<DocumentKey>;
+  private inMemoryPins: ReferenceSet | null = null;
+  // Will be set by onTransactionStarted().
+  private orphanedDocuments!: Set<DocumentKey>;
 
   constructor(private readonly persistence: MemoryPersistence) {}
 
@@ -308,7 +309,7 @@ export class MemoryEagerDelegate implements ReferenceDelegate {
 }
 
 export class MemoryLruDelegate implements ReferenceDelegate, LruDelegate {
-  private inMemoryPins: ReferenceSet | null;
+  private inMemoryPins: ReferenceSet | null = null;
   private orphanedSequenceNumbers: ObjectMap<
     DocumentKey,
     ListenSequenceNumber

--- a/packages/firestore/src/local/persistence.ts
+++ b/packages/firestore/src/local/persistence.ts
@@ -36,7 +36,8 @@ import { ClientId } from './shared_client_state';
  * on persistence.
  */
 export abstract class PersistenceTransaction {
-  readonly currentSequenceNumber: ListenSequenceNumber;
+  // Classes that extend/implement this class always assign this in the constructor.
+  readonly currentSequenceNumber!: ListenSequenceNumber;
 }
 
 /**

--- a/packages/firestore/src/local/persistence_promise.ts
+++ b/packages/firestore/src/local/persistence_promise.ts
@@ -231,7 +231,7 @@ export class PersistencePromise<T> {
   ): PersistencePromise<void> {
     const promises: Array<PersistencePromise<void>> = [];
     collection.forEach((r, s) => {
-      promises.push(f.call(this, r, s));
+      promises.push(f.call(this, r, s as S));
     });
     return this.waitFor(promises);
   }

--- a/packages/firestore/src/model/field_value.ts
+++ b/packages/firestore/src/model/field_value.ts
@@ -119,7 +119,7 @@ export type FieldType = null | boolean | number | string | {};
  * A field value represents a datatype as stored by Firestore.
  */
 export abstract class FieldValue {
-  readonly typeOrder: TypeOrder;
+  readonly typeOrder?: TypeOrder;
 
   abstract value(options?: FieldValueOptions): FieldType;
   abstract isEqual(other: FieldValue): boolean;

--- a/packages/firestore/src/model/mutation.ts
+++ b/packages/firestore/src/model/mutation.ts
@@ -259,9 +259,10 @@ export class Precondition {
  * to some source document.
  */
 export abstract class Mutation {
-  readonly type: MutationType;
-  readonly key: DocumentKey;
-  readonly precondition: Precondition;
+  readonly type?: MutationType;
+  // All classes extending this class assign key in the constructor.
+  readonly key!: DocumentKey;
+  readonly precondition?: Precondition;
 
   /**
    * Applies this mutation to the given MaybeDocument or null for the purposes

--- a/packages/firestore/src/model/path.ts
+++ b/packages/firestore/src/model/path.ts
@@ -24,9 +24,10 @@ export const DOCUMENT_KEY_NAME = '__name__';
  * Path represents an ordered sequence of string segments.
  */
 abstract class Path {
-  private segments: string[];
-  private offset: number;
-  private len: number;
+  // These are definitely set in init().
+  private segments!: string[];
+  private offset!: number;
+  private len!: number;
 
   constructor(segments: string[], offset?: number, length?: number) {
     this.init(segments, offset, length);

--- a/packages/firestore/src/remote/backoff.ts
+++ b/packages/firestore/src/remote/backoff.ts
@@ -30,7 +30,7 @@ const LOG_TAG = 'ExponentialBackoff';
  * delays causing spikes of load to the backend.
  */
 export class ExponentialBackoff {
-  private currentBaseMs: number;
+  private currentBaseMs: number = 0;
   private timerPromise: CancelablePromise<void> | null = null;
   /** The last backoff attempt, as epoch milliseconds. */
   private lastAttemptTime = Date.now();

--- a/packages/firestore/src/remote/persistent_stream.ts
+++ b/packages/firestore/src/remote/persistent_stream.ts
@@ -676,8 +676,10 @@ export class PersistentWriteStream extends PersistentStream<
    *
    * PersistentWriteStream manages propagating this value from responses to the
    * next request.
+   * 
+   * This is never null checked but it is zero-length-checked.
    */
-  lastStreamToken: ProtoByteString;
+  lastStreamToken: ProtoByteString = '';
 
   /**
    * Tracks whether or not a handshake has been successfully exchanged and

--- a/packages/firestore/src/remote/persistent_stream.ts
+++ b/packages/firestore/src/remote/persistent_stream.ts
@@ -676,7 +676,7 @@ export class PersistentWriteStream extends PersistentStream<
    *
    * PersistentWriteStream manages propagating this value from responses to the
    * next request.
-   * 
+   *
    * This is never null checked but it is zero-length-checked.
    */
   lastStreamToken: ProtoByteString = '';

--- a/packages/firestore/src/remote/remote_store.ts
+++ b/packages/firestore/src/remote/remote_store.ts
@@ -169,7 +169,8 @@ export class RemoteStore implements TargetMetadataProvider {
   }
 
   /** SyncEngine to notify of watch and write events. */
-  syncEngine: RemoteSyncer;
+  // Will be initialized during FirestoreClient initialization.
+  syncEngine!: RemoteSyncer;
 
   /**
    * Starts up the remote store, creating streams, restoring state from

--- a/packages/firestore/src/remote/stream_bridge.ts
+++ b/packages/firestore/src/remote/stream_bridge.ts
@@ -26,9 +26,9 @@ import { Stream } from './connection';
  * interface. The stream callbacks are invoked with the callOn... methods.
  */
 export class StreamBridge<I, O> implements Stream<I, O> {
-  private wrappedOnOpen: () => void | undefined;
-  private wrappedOnClose: (err?: FirestoreError) => void | undefined;
-  private wrappedOnMessage: (msg: O) => void | undefined;
+  private wrappedOnOpen?: () => void | undefined;
+  private wrappedOnClose?: (err?: FirestoreError) => void | undefined;
+  private wrappedOnMessage?: (msg: O) => void | undefined;
 
   private sendFn: (msg: I) => void;
   private closeFn: () => void;

--- a/packages/firestore/src/util/async_queue.ts
+++ b/packages/firestore/src/util/async_queue.ts
@@ -193,7 +193,7 @@ export class AsyncQueue {
   private delayedOperations: Array<DelayedOperation<unknown>> = [];
 
   // visible for testing
-  failure: Error;
+  failure?: Error;
 
   // Flag set while there's an outstanding AsyncQueue operation, used for
   // assertion sanity-checks.
@@ -279,7 +279,7 @@ export class AsyncQueue {
     );
     this.delayedOperations.push(delayedOp);
 
-    return delayedOp;
+    return delayedOp as DelayedOperation<T>;
   }
 
   private verifyNotFailed(): void {

--- a/packages/firestore/src/util/promise.ts
+++ b/packages/firestore/src/util/promise.ts
@@ -29,8 +29,10 @@ export interface CancelablePromise<T> extends Promise<T> {
 
 export class Deferred<R> {
   promise: Promise<R>;
-  resolve: Resolver<R>;
-  reject: Rejecter;
+  // These are assigned in the constructor, but Typescript does not recognize
+  // it because it is async.
+  resolve!: Resolver<R>;
+  reject!: Rejecter;
 
   constructor() {
     this.promise = new Promise((resolve: Resolver<R>, reject: Rejecter) => {

--- a/packages/firestore/src/util/sorted_map.ts
+++ b/packages/firestore/src/util/sorted_map.ts
@@ -526,11 +526,15 @@ export class LLRBNode<K, V> {
 
 // Represents an empty node (a leaf node in the Red-Black Tree).
 export class LLRBEmptyNode<K, V> {
-  key: K;
-  value: V;
-  color: boolean;
-  left: LLRBNode<K, V>;
-  right: LLRBNode<K, V>;
+  // These values actually can be and are undefined but the isEmpty() check
+  // in each SortedMap function will bail out before they are called.
+  // Typing them as possibly null or undefined causes many errors because
+  // we do not null check every property.
+  key!: K;
+  value!: V;
+  color!: boolean;
+  left!: LLRBNode<K, V>;
+  right!: LLRBNode<K, V>;
   size = 0;
 
   // Returns a copy of the current node.

--- a/packages/firestore/test/integration/bootstrap.ts
+++ b/packages/firestore/test/integration/bootstrap.ts
@@ -29,5 +29,5 @@ import '../../index';
 const testsContext = (require as any).context('.', true, /.test$/);
 const browserTests = testsContext
   .keys()
-  .filter(file => file.indexOf('/node/') < 0);
+  .filter((file: string) => file.indexOf('/node/') < 0);
 browserTests.forEach(testsContext);

--- a/packages/firestore/test/integration/browser/webchannel.test.ts
+++ b/packages/firestore/test/integration/browser/webchannel.test.ts
@@ -42,7 +42,7 @@ describeFn('WebChannel', () => {
     const makeUrl = conn.makeUrl.bind(conn);
 
     it('includes project ID and database ID', () => {
-      const url = makeUrl('Commit', {});
+      const url = makeUrl('Commit');
       expect(url).to.equal(
         'http://example.com/v1/projects/testproject/' +
           'databases/(default)/documents:commit'

--- a/packages/firestore/test/integration/util/events_accumulator.ts
+++ b/packages/firestore/test/integration/util/events_accumulator.ts
@@ -27,7 +27,7 @@ export class EventsAccumulator<
   T extends firestore.DocumentSnapshot | firestore.QuerySnapshot
 > {
   private events: T[] = [];
-  private waitingFor: number;
+  private waitingFor: number = 0;
   private deferred: Deferred<T[]> | null = null;
   private rejectAdditionalEvents = false;
 

--- a/packages/firestore/test/integration/util/helpers.ts
+++ b/packages/firestore/test/integration/util/helpers.ts
@@ -93,7 +93,9 @@ export function isRunningAgainstEmulator(): boolean {
  * persistence both disabled and enabled (if the browser is supported).
  */
 export const apiDescribe = apiDescribeInternal.bind(null, describe);
+// @ts-ignore Patching a prototypal function.
 apiDescribe.skip = apiDescribeInternal.bind(null, describe.skip);
+// @ts-ignore Patching a prototypal function.
 apiDescribe.only = apiDescribeInternal.bind(null, describe.only);
 
 function apiDescribeInternal(

--- a/packages/firestore/test/unit/specs/spec_builder.ts
+++ b/packages/firestore/test/unit/specs/spec_builder.ts
@@ -77,11 +77,12 @@ export interface ActiveTargetMap {
  * the tests.
  */
 export class ClientMemoryState {
-  activeTargets: ActiveTargetMap;
-  queryMapping: QueryMap;
-  limboMapping: LimboMap;
+  // These values are set by reset() which is called in the constructor.
+  activeTargets!: ActiveTargetMap;
+  queryMapping!: QueryMap;
+  limboMapping!: LimboMap;
 
-  limboIdGenerator: TargetIdGenerator;
+  limboIdGenerator!: TargetIdGenerator;
 
   constructor() {
     this.reset();

--- a/packages/firestore/test/unit/specs/spec_test_runner.ts
+++ b/packages/firestore/test/unit/specs/spec_test_runner.ts
@@ -357,9 +357,10 @@ class SharedWriteTracker {
 abstract class TestRunner {
   protected queue: AsyncQueue;
 
-  private connection: MockConnection;
-  private eventManager: EventManager;
-  private syncEngine: SyncEngine;
+  // These will be initialized by start().
+  private connection!: MockConnection;
+  private eventManager!: EventManager;
+  private syncEngine!: SyncEngine;
 
   private eventList: QueryEvent[] = [];
   private acknowledgedDocs: string[];
@@ -376,11 +377,12 @@ abstract class TestRunner {
 
   private networkEnabled = true;
 
-  private datastore: Datastore;
-  private localStore: LocalStore;
-  private remoteStore: RemoteStore;
-  private persistence: Persistence;
-  protected sharedClientState: SharedClientState;
+  // These will be initialized by start().
+  private datastore!: Datastore;
+  private localStore!: LocalStore;
+  private remoteStore!: RemoteStore;
+  private persistence!: Persistence;
+  protected sharedClientState!: SharedClientState;
   private useGarbageCollection: boolean;
   private numClients: number;
   private databaseInfo: DatabaseInfo;

--- a/packages/firestore/test/util/equality_matcher.ts
+++ b/packages/firestore/test/util/equality_matcher.ts
@@ -87,9 +87,8 @@ export function addEqualityMatcher(): void {
       // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
       const assertEql = (_super: (r: unknown, l: unknown) => boolean) => {
         originalFunction = originalFunction || _super;
-        return function(...args: unknown[]): void {
+        return function(this: {}, expected?: unknown, msg?: unknown): void {
           if (isActive) {
-            const [expected, msg] = args;
             utils.flag(this, 'message', msg);
             const actual = utils.flag(this, 'object');
 
@@ -106,7 +105,7 @@ export function addEqualityMatcher(): void {
               /*showDiff=*/ true
             );
           } else if (originalFunction) {
-            originalFunction.apply(this, args);
+            originalFunction.call(this, expected, msg);
           }
         };
       };

--- a/packages/firestore/test/util/promise.ts
+++ b/packages/firestore/test/util/promise.ts
@@ -25,8 +25,9 @@ export interface Rejecter {
 
 export class Deferred<R> {
   promise: Promise<R>;
-  resolve: Resolver<R>;
-  reject: Rejecter;
+  // Assigned in constructor.
+  resolve!: Resolver<R>;
+  reject!: Rejecter;
 
   constructor() {
     this.promise = new Promise((resolve: Resolver<R>, reject: Rejecter) => {

--- a/packages/firestore/test/util/test_platform.ts
+++ b/packages/firestore/test/util/test_platform.ts
@@ -89,7 +89,7 @@ export class FakeWindow {
  */
 export class FakeDocument {
   private _visibilityState: VisibilityState = 'hidden';
-  private visibilityListener: EventListener | null;
+  private visibilityListener: EventListener | null = null;
 
   get visibilityState(): VisibilityState {
     return this._visibilityState;

--- a/packages/firestore/tsconfig.json
+++ b/packages/firestore/tsconfig.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "outDir": "dist",
     "strictFunctionTypes": true,
-    "strictNullChecks": true
+    "strictNullChecks": true,
+    "strict": true
   },
   "exclude": [
     "dist/**/*"

--- a/scripts/emulator-testing/emulators/emulator.ts
+++ b/scripts/emulator-testing/emulators/emulator.ts
@@ -29,11 +29,14 @@ export interface ChildProcessPromise extends Promise<void> {
 }
 
 export abstract class Emulator {
-  binaryName: string;
-  binaryUrl: string;
-  binaryPath: string;
+  // Always set in constructor of extended classes.
+  binaryName!: string;
+  binaryUrl!: string;
+  // Set in download() which is always called.
+  binaryPath!: string;
 
-  emulator: ChildProcess;
+  // Set in setUp() which is always called.
+  emulator!: ChildProcess;
   port: number;
 
   constructor(port: number) {
@@ -76,7 +79,7 @@ export abstract class Emulator {
         ['-jar', path.basename(this.binaryPath), '--port', this.port],
         {
           cwd: path.dirname(this.binaryPath),
-          stdio: 'inherit'
+          stdio: ['inherit', process.stdout, process.stderr]
         }
       );
       promise.catch(reject);

--- a/scripts/emulator-testing/firestore-test-runner.ts
+++ b/scripts/emulator-testing/firestore-test-runner.ts
@@ -31,7 +31,7 @@ function runTest(port: number, projectId: string): ChildProcessPromise {
       FIRESTORE_EMULATOR_PORT: port,
       FIRESTORE_EMULATOR_PROJECT_ID: projectId
     }),
-    stdio: 'inherit'
+    stdio: ['inherit', process.stdout, process.stderr]
   };
   // TODO(b/113267261): Include browser test once WebChannel support is
   // ready in Firestore emulator.


### PR DESCRIPTION
Set `strict: true` in Typescript compiler options.  This required setting a lot of initial values for variables  or promising the compiler (with `!`) that these values would be set before being used, so please check I have guessed the correct values or that the guarantees are correct.