### PR TITLE
Enable strict mode on all packages except firestore and database

### DIFF
--- a/config/tsconfig.base.json
+++ b/config/tsconfig.base.json
@@ -3,8 +3,7 @@
   "compilerOptions": {
     "declaration": true,
     "importHelpers": true,
-    "strictNullChecks": true,
-    "noImplicitAny": true,
+    "strict": true,
     "lib": [
       "es5",
       "dom",

--- a/packages/app/tsconfig.json
+++ b/packages/app/tsconfig.json
@@ -2,8 +2,7 @@
   "extends": "../../config/tsconfig.base.json",
   "compilerOptions": {
     "outDir": "dist",
-    "resolveJsonModule": true,
-    "strict": true
+    "resolveJsonModule": true
   },
   "exclude": ["dist/**/*"]
 }

--- a/packages/database/tsconfig.json
+++ b/packages/database/tsconfig.json
@@ -2,8 +2,7 @@
   "extends": "../../config/tsconfig.base.json",
   "compilerOptions": {
     "outDir": "dist",
-    "strictNullChecks": false,
-    "noImplicitAny": false
+    "strict": false
   },
   "exclude": [
     "dist/**/*"

--- a/packages/firebase/tsconfig.json
+++ b/packages/firebase/tsconfig.json
@@ -3,8 +3,7 @@
   "compilerOptions": {
     "outDir": "dist",
     "declaration": false,
-    "allowSyntheticDefaultImports": true,
-    "strict": true
+    "allowSyntheticDefaultImports": true
   },
   "exclude": [
     "dist/**/*"

--- a/packages/firestore/tsconfig.json
+++ b/packages/firestore/tsconfig.json
@@ -3,7 +3,12 @@
   "compilerOptions": {
     "outDir": "dist",
     "strictFunctionTypes": true,
-    "strictNullChecks": true
+    "strictNullChecks": true,
+    "noImplicitAny": true,
+    "alwaysStrict": false,
+    "noImplicitThis": false,
+    "strictBindCallApply": false,
+    "strictPropertyInitialization": false
   },
   "exclude": [
     "dist/**/*"

--- a/packages/functions/tsconfig.json
+++ b/packages/functions/tsconfig.json
@@ -1,8 +1,7 @@
 {
   "extends": "../../config/tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "dist",
-    "strict": true
+    "outDir": "dist"
   },
   "exclude": [
     "dist/**/*"

--- a/packages/installations/tsconfig.json
+++ b/packages/installations/tsconfig.json
@@ -3,8 +3,6 @@
   "compilerOptions": {
     "downlevelIteration": true,
     "resolveJsonModule": true,
-
-    "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noImplicitReturns": true,

--- a/packages/logger/tsconfig.json
+++ b/packages/logger/tsconfig.json
@@ -1,8 +1,7 @@
 {
   "extends": "../../config/tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "dist",
-    "strict": true
+    "outDir": "dist"
   },
   "exclude": [
     "dist/**/*"

--- a/packages/messaging/tsconfig.json
+++ b/packages/messaging/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "../../config/tsconfig.base.json",
   "compilerOptions": {
     "outDir": "dist",
-    "strict": true,
     "noUnusedLocals": true,
     "lib": [
       "dom",

--- a/packages/performance/tsconfig.json
+++ b/packages/performance/tsconfig.json
@@ -3,7 +3,6 @@
   "compilerOptions": {
     "outDir": "dist",
     "resolveJsonModule": true,
-    "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noImplicitReturns": true,

--- a/packages/rxfire/firestore/collection/index.ts
+++ b/packages/rxfire/firestore/collection/index.ts
@@ -180,7 +180,7 @@ export function auditTrail(
   events?: firestore.DocumentChangeType[]
 ): Observable<firestore.DocumentChange[]> {
   return collectionChanges(query, events).pipe(
-    scan((current, action) => [...current, ...action], [])
+    scan((current, action) => [...current, ...action], [] as firestore.DocumentChange[])
   );
 }
 

--- a/packages/rxfire/firestore/collection/index.ts
+++ b/packages/rxfire/firestore/collection/index.ts
@@ -180,7 +180,10 @@ export function auditTrail(
   events?: firestore.DocumentChangeType[]
 ): Observable<firestore.DocumentChange[]> {
   return collectionChanges(query, events).pipe(
-    scan((current, action) => [...current, ...action], [] as firestore.DocumentChange[])
+    scan(
+      (current, action) => [...current, ...action],
+      [] as firestore.DocumentChange[]
+    )
   );
 }
 

--- a/packages/storage/tsconfig.json
+++ b/packages/storage/tsconfig.json
@@ -1,8 +1,7 @@
 {
   "extends": "../../config/tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "dist",
-    "strict": true
+    "outDir": "dist"
   },
   "exclude": [
     "dist/**/*"

--- a/packages/testing/tsconfig.json
+++ b/packages/testing/tsconfig.json
@@ -1,8 +1,7 @@
 {
   "extends": "../../config/tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "dist",
-    "strict": true
+    "outDir": "dist"
   },
   "exclude": [
     "dist/**/*"

--- a/packages/util/tsconfig.json
+++ b/packages/util/tsconfig.json
@@ -1,8 +1,7 @@
 {
   "extends": "../../config/tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "dist",
-    "strict": true
+    "outDir": "dist"
   },
   "exclude": [
     "dist/**/*"


### PR DESCRIPTION
Most packages have already had the flag enabled, this change enables it on the global `tsconfig.base.json` and removes the flags on individual `tsconfig.json` files.  Database is skipped because we have decided not to update it to strict mode, and Firestore will be updated soon.