### PR TITLE
Update rollup warning message in Node.

### DIFF
--- a/packages/app/index.ts
+++ b/packages/app/index.ts
@@ -60,8 +60,8 @@ firebaseNamespace.initializeApp = function(...args: any) {
       "resolve.mainFields":
       https://webpack.js.org/configuration/resolve/#resolvemainfields
       
-      If using Rollup, use the rollup-plugin-node-resolve plugin and set "module"
-      to false and "main" to true:
+      If using Rollup, use the rollup-plugin-node-resolve plugin and set the
+      "mainFields" field to ['main', 'module'].
       https://github.com/rollup/rollup-plugin-node-resolve
       `);
   }

--- a/packages/app/index.ts
+++ b/packages/app/index.ts
@@ -60,8 +60,8 @@ firebaseNamespace.initializeApp = function(...args: any) {
       "resolve.mainFields":
       https://webpack.js.org/configuration/resolve/#resolvemainfields
       
-      If using Rollup, use the rollup-plugin-node-resolve plugin and set the
-      "mainFields" field to ['main', 'module'].
+      If using Rollup, use the rollup-plugin-node-resolve plugin and specify "main"
+      as the first item in "mainFields", e.g. ['main', 'module'].
       https://github.com/rollup/rollup-plugin-node-resolve
       `);
   }


### PR DESCRIPTION
This rollup plugin has deprecated the boolean "module" and "main" fields in favor of a "mainFields" array.  Updating warning message to match.