### PR TITLE
Adding Limit/Limbo spec tests for go/index-free

### DIFF
--- a/packages/firestore/test/unit/specs/limit_spec.test.ts
+++ b/packages/firestore/test/unit/specs/limit_spec.test.ts
@@ -162,22 +162,22 @@ describeSpec('Limits:', [], () => {
     const fullQuery = Query.atPath(path('collection')).addFilter(
       filter('matches', '==', true)
     );
-    const queryWithLimit = Query.atPath(path('collection'))
+    const limitQuery = Query.atPath(path('collection'))
       .addFilter(filter('matches', '==', true))
       .withLimit(2);
-    const doc1 = doc('collection/a', 1001, { key: 'a', matches: true });
-    const doc2 = doc('collection/b', 1002, { key: 'b', matches: true });
-    const doc3 = doc('collection/c', 1000, { key: 'c', matches: true });
+    const doc1 = doc('collection/a', 1001, {  matches: true });
+    const doc2 = doc('collection/b', 1002, {  matches: true });
+    const doc3 = doc('collection/c', 1000, {  matches: true });
     return spec()
       .withGCEnabled(false)
       .userListens(fullQuery)
       .watchAcksFull(fullQuery, 1002, doc1, doc2, doc3)
       .expectEvents(fullQuery, { added: [doc1, doc2, doc3] })
       .userUnlistens(fullQuery)
-      .userListens(queryWithLimit)
-      .expectEvents(queryWithLimit, { added: [doc1, doc2], fromCache: true })
-      .userSets('collection/a', { key: 'a', matches: false })
-      .expectEvents(queryWithLimit, {
+      .userListens(limitQuery)
+      .expectEvents(limitQuery, { added: [doc1, doc2], fromCache: true })
+      .userSets('collection/a', {  matches: false })
+      .expectEvents(limitQuery, {
         added: [doc3],
         removed: [doc1],
         fromCache: true

--- a/packages/firestore/test/unit/specs/spec_test_runner.ts
+++ b/packages/firestore/test/unit/specs/spec_test_runner.ts
@@ -1021,11 +1021,11 @@ abstract class TestRunner {
       );
     });
     for (const expectedLimboDoc of this.expectedLimboDocs) {
-      expect(
-        actualLimboDocs.get(expectedLimboDoc),
+      expect(actualLimboDocs.get(expectedLimboDoc)).to.not.equal(
+        null,
         'Expected doc to be in limbo, but was not: ' +
           expectedLimboDoc.toString()
-      ).to.be.ok;
+      );
       actualLimboDocs = actualLimboDocs.remove(expectedLimboDoc);
     }
     expect(actualLimboDocs.size).to.equal(


### PR DESCRIPTION
Adding 2 tests for edge cases that require us to parse more documents that contained in the TargetQueryMapping.