### PR TITLE
Fix preconditions in transactions

### DIFF
--- a/packages/firestore/test/integration/api/transactions.test.ts
+++ b/packages/firestore/test/integration/api/transactions.test.ts
@@ -79,11 +79,11 @@ apiDescribe('Database transactions', (persistence: boolean) => {
   /**
    * Used for testing that all possible combinations of executing transactions
    * result in the desired document value or error.
-   * 
+   *
    * `run()`, `withExistingDoc()`, and `withNonexistentDoc()` don't actually do
    * anything except assign variables into the TransactionTester.
-   * 
-   * `expectDoc()`, `expectNoDoc()`, and `expectError()` will trigger the 
+   *
+   * `expectDoc()`, `expectNoDoc()`, and `expectError()` will trigger the
    * transaction to run and assert that the end result matches the input.
    */
   class TransactionTester {


### PR DESCRIPTION
Context: [b/135709736](http://b/135709736)
Currently,  if you read a non-existent document, then modify the document twice in the same transaction, each Write will include a precondition that the document did not exist. The server will reject this sequence since each precondition is applied on top of preceding writes in the transaction.

Instead, for the first write to a given key, generate a precondition that takes into account the read time and existence of the document, as we do today. For subsequent writes to a given key, generate a general precondition that only preserves the semantics of the operation: `set()` and `delete()` use  `Precondition(none)` and `update()` uses `Precondition(exists)`.

- Update precondition logic to buganizer spec.
- Reorder public and private methods in `transaction.ts`.
- Add table tests for testing transaction combinations.

