### PR TITLE
Run persistence and node tests in travis

### DIFF
--- a/packages/firestore/test/unit/local/lru_garbage_collector.test.ts
+++ b/packages/firestore/test/unit/local/lru_garbage_collector.test.ts
@@ -942,7 +942,7 @@ function genericLruGarbageCollectorTests(
     await initializeTestResources(LruParams.withCacheSize(100));
     expect(persistence.started).to.be.true;
 
-    // Add 50 targets and 10 documents to each.
+    // Add 50 targets and 5 documents to each.
     for (let i = 0; i < 50; i++) {
       // Use separate transactions so that each target and associated documents get their own
       // sequence number.
@@ -953,7 +953,7 @@ function genericLruGarbageCollectorTests(
           return addNextTargetInTransaction(txn).next(queryData => {
             const targetId = queryData.targetId;
             const promises: Array<PersistencePromise<void>> = [];
-            for (let j = 0; j < 10; j++) {
+            for (let j = 0; j < 5; j++) {
               promises.push(
                 cacheADocumentInTransaction(txn).next(docKey =>
                   queryCache.addMatchingKeys(
@@ -987,7 +987,7 @@ function genericLruGarbageCollectorTests(
     );
     expect(results.didRun).to.be.true;
     expect(results.targetsRemoved).to.equal(5);
-    expect(results.documentsRemoved).to.equal(50);
+    expect(results.documentsRemoved).to.equal(25);
 
     // Verify that we updated the cache size by checking that it's smaller now.
     const finalCacheSize = await persistence.runTransaction(
@@ -1004,8 +1004,8 @@ function genericLruGarbageCollectorTests(
     const params = new LruParams(100, 100, 5);
     await initializeTestResources(params);
 
-    // Add 50 targets and 10 documents to each.
-    for (let i = 0; i < 50; i++) {
+    // Add 25 targets and 5 documents to each.
+    for (let i = 0; i < 25; i++) {
       // Use separate transactions so that each target and associated documents get their own
       // sequence number.
       await persistence.runTransaction(
@@ -1015,7 +1015,7 @@ function genericLruGarbageCollectorTests(
           return addNextTargetInTransaction(txn).next(queryData => {
             const targetId = queryData.targetId;
             const promises: Array<PersistencePromise<void>> = [];
-            for (let j = 0; j < 10; j++) {
+            for (let j = 0; j < 5; j++) {
               promises.push(
                 cacheADocumentInTransaction(txn).next(docKey =>
                   queryCache.addMatchingKeys(

--- a/scripts/emulator-testing/firestore-test-runner.ts
+++ b/scripts/emulator-testing/firestore-test-runner.ts
@@ -24,7 +24,11 @@ import * as freePortFinder from 'find-free-port';
 import { ChildProcessPromise } from './emulators/emulator';
 import { FirestoreEmulator } from './emulators/firestore-emulator';
 
-function runTest(port: number, projectId: string): ChildProcessPromise {
+function runTest(
+  port: number,
+  projectId: string,
+  withPersistence: boolean
+): ChildProcessPromise {
   const options = {
     cwd: path.resolve(__dirname, '../../packages/firestore'),
     env: Object.assign({}, process.env, {
@@ -35,8 +39,12 @@ function runTest(port: number, projectId: string): ChildProcessPromise {
   };
   // TODO(b/113267261): Include browser test once WebChannel support is
   // ready in Firestore emulator.
-  // Use test:node:prod to allow runner's env var overrides to work.
-  return spawn('yarn', ['test:node:prod'], options);
+  // Use `prod` to allow test runner's env variable overrides to work.
+  if (withPersistence) {
+    return spawn('yarn', ['test:node:persistence:prod'], options);
+  } else {
+    return spawn('yarn', ['test:node:prod'], options);
+  }
 }
 
 async function run(): Promise<void> {
@@ -45,7 +53,8 @@ async function run(): Promise<void> {
   try {
     await emulator.download();
     await emulator.setUp();
-    await runTest(emulator.port, emulator.projectId);
+    await runTest(emulator.port, emulator.projectId, true);
+    await runTest(emulator.port, emulator.projectId, false);
   } finally {
     await emulator.tearDown();
   }


### PR DESCRIPTION
Currently, node persistence tests aren't being run on CI. This PR adds the node persistence tests to run on CI, but against the emulator as part of the `yarn test:travis` command.

Edited tests in LRU garbage collector to perform fewer writes, since the tests were timing out on CI.