### PR TITLE
 Fix Spec tests 'Limbo documents stay consistent'

### DIFF
--- a/packages/firestore/test/unit/specs/describe_spec.ts
+++ b/packages/firestore/test/unit/specs/describe_spec.ts
@@ -33,7 +33,7 @@ const NO_ANDROID_TAG = 'no-android';
 const NO_IOS_TAG = 'no-ios';
 // The remaining tags specify features that must be present to run a given test
 // Multi-client related tests (which imply persistence).
-const MULTI_CLIENT_TAG = 'multi-client';
+export const MULTI_CLIENT_TAG = 'multi-client';
 const EAGER_GC_TAG = 'eager-gc';
 const DURABLE_PERSISTENCE_TAG = 'durable-persistence';
 const BENCHMARK_TAG = 'benchmark';
@@ -173,7 +173,7 @@ export function specTest(
       const fullName = `${mode} ${name}`;
       const queuedTest = runner(fullName, async () => {
         const start = Date.now();
-        await spec.runAsTest(fullName, usePersistence);
+        await spec.runAsTest(fullName, tags, usePersistence);
         const end = Date.now();
         if (tags.indexOf(BENCHMARK_TAG) >= 0) {
           // eslint-disable-next-line no-console

--- a/packages/firestore/test/unit/specs/limbo_spec.test.ts
+++ b/packages/firestore/test/unit/specs/limbo_spec.test.ts
@@ -439,25 +439,27 @@ describeSpec('Limbo Documents:', [], () => {
     // This tests verifies that a document is consistent between views, even
     // if the document is only in Limbo in one of them.
     const originalQuery = Query.atPath(path('collection'));
-    const filteredQuery = Query.atPath(path('collection'))
-      .addFilter(filter('matches', '==', true));
+    const filteredQuery = Query.atPath(path('collection')).addFilter(
+      filter('matches', '==', true)
+    );
 
     const docA = doc('collection/a', 1000, { matches: true });
     const docADirty = doc(
       'collection/a',
       1000,
-      {  matches: true },
+      { matches: true },
       { hasCommittedMutations: true }
     );
     const docBDirty = doc(
       'collection/b',
       1001,
-      {  matches: true },
+      { matches: true },
       { hasCommittedMutations: true }
     );
 
     return (
-      client(0)
+      spec()
+        .withGCEnabled(false)
         .userSets('collection/a', { matches: true })
         .userSets('collection/b', { matches: true })
         .writeAcks('collection/a', 1000)

--- a/packages/firestore/test/unit/specs/spec_builder.ts
+++ b/packages/firestore/test/unit/specs/spec_builder.ts
@@ -195,9 +195,13 @@ export class SpecBuilder {
    * Run the spec as a test. If persistence is available it will run it with and
    * without persistence enabled.
    */
-  runAsTest(name: string, usePersistence: boolean): Promise<void> {
+  runAsTest(
+    name: string,
+    tags: string[],
+    usePersistence: boolean
+  ): Promise<void> {
     this.nextStep();
-    return runSpec(name, usePersistence, this.config, this.steps);
+    return runSpec(name, tags, usePersistence, this.config, this.steps);
   }
 
   // Configures Garbage Collection behavior (on or off). Default is on.

--- a/packages/firestore/test/unit/specs/spec_test_runner.ts
+++ b/packages/firestore/test/unit/specs/spec_test_runner.ts
@@ -1282,7 +1282,7 @@ export async function runSpec(
   try {
     await sequence(steps, async step => {
       assert(
-        step.clientIndex === undefined || tags.indexOf(MULTI_CLIENT_TAG) != -1,
+        step.clientIndex === undefined || tags.indexOf(MULTI_CLIENT_TAG) !== -1,
         "Cannot use 'client()' to initialize a test that is not tagged with " +
           "'multi-client'. Did you mean to use 'spec()'?"
       );

--- a/packages/firestore/test/unit/specs/spec_test_runner.ts
+++ b/packages/firestore/test/unit/specs/spec_test_runner.ts
@@ -109,6 +109,7 @@ import {
   TEST_PERSISTENCE_PREFIX,
   TEST_SERIALIZER
 } from '../local/persistence_test_helpers';
+import { MULTI_CLIENT_TAG } from './describe_spec';
 
 const ARBITRARY_SEQUENCE_NUMBER = 2;
 
@@ -1236,6 +1237,7 @@ class IndexedDbTestRunner extends TestRunner {
  */
 export async function runSpec(
   name: string,
+  tags: string[],
   usePersistence: boolean,
   config: SpecConfig,
   steps: SpecStep[]
@@ -1279,6 +1281,12 @@ export async function runSpec(
   let count = 0;
   try {
     await sequence(steps, async step => {
+      assert(
+        step.clientIndex === undefined || tags.indexOf(MULTI_CLIENT_TAG) != -1,
+        "Cannot use 'client()' to initialize a test that is not tagged with " +
+          "'multi-client'. Did you mean to use 'spec()'?"
+      );
+
       ++count;
       lastStep = step;
       return ensureRunner(step.clientIndex || 0).then(runner =>


### PR DESCRIPTION
The  'Limbo documents stay consistent' used the multi-client runner instead of the spec-runner. This PR fixes the test and adds an assert to make sure that this doesn't happen again.