### PR TITLE
add engines field to functions

### DIFF
--- a/config/functions/package.json
+++ b/config/functions/package.json
@@ -6,5 +6,8 @@
     "firebase-admin": "8.2.0",
     "firebase-functions": "3.1.0"
   },
-  "private": true
+  "private": true,
+  "engines": {
+    "node": "8"
+  }
 }


### PR DESCRIPTION
`engines` becomes a mandatory field after firebase-tools 7.0.0 https://github.com/firebase/firebase-tools/releases/tag/v7.0.0