### PR TITLE
Upgrade to Firestore Emulator 1.6.2

### DIFF
--- a/scripts/emulator-testing/emulators/firestore-emulator.ts
+++ b/scripts/emulator-testing/emulators/firestore-emulator.ts
@@ -28,6 +28,6 @@ export class FirestoreEmulator extends Emulator {
     // The latest version can be found from firestore emulator doc:
     // https://firebase.google.com/docs/firestore/security/test-rules-emulator
     this.binaryUrl =
-      'https://storage.googleapis.com/firebase-preview-drop/emulator/cloud-firestore-emulator-v1.5.0.jar';
+      'https://storage.googleapis.com/firebase-preview-drop/emulator/cloud-firestore-emulator-v1.6.2.jar';
   }
 }


### PR DESCRIPTION
This just brings us up-to-date without any functional changes as far as
the SDK is concerned.