### PR TITLE
Fix a regression that leads to larger bundle size

### DIFF
--- a/config/tsconfig.base.json
+++ b/config/tsconfig.base.json
@@ -19,7 +19,6 @@
     "moduleResolution": "node",
     "sourceMap": true,
     "target": "es5",
-    "downlevelIteration": true,
     "typeRoots": [
       "../node_modules/@types"
     ]

--- a/packages/database/tsconfig.json
+++ b/packages/database/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../../config/tsconfig.base.json",
   "compilerOptions": {
     "outDir": "dist",
-    "strict": false
+    "strict": false,
+    "downlevelIteration": true
   },
   "exclude": [
     "dist/**/*"

--- a/packages/util/src/crypt.ts
+++ b/packages/util/src/crypt.ts
@@ -86,10 +86,10 @@ const byteArrayToString = function(bytes: number[]): string {
 };
 
 interface Base64 {
-  byteToCharMap_: { [key: number]: string } | null ;
-  charToByteMap_: { [key: string]: number } | null ;
-  byteToCharMapWebSafe_: { [key: number]: string } | null ;
-  charToByteMapWebSafe_: { [key: string]: number } | null ;
+  byteToCharMap_: { [key: number]: string } | null;
+  charToByteMap_: { [key: string]: number } | null;
+  byteToCharMapWebSafe_: { [key: number]: string } | null;
+  charToByteMapWebSafe_: { [key: string]: number } | null;
   ENCODED_VALS_BASE: string;
   readonly ENCODED_VALS: string;
   readonly ENCODED_VALS_WEBSAFE: string;
@@ -99,7 +99,6 @@ interface Base64 {
   decodeString(input: string, webSafe: boolean): string;
   decodeStringToByteArray(input: string, webSafe: boolean): number[];
   init_(): void;
-
 }
 
 // We define it as an object literal instead of a class because a class compiled down to es5 can't

--- a/packages/util/src/crypt.ts
+++ b/packages/util/src/crypt.ts
@@ -85,56 +85,88 @@ const byteArrayToString = function(bytes: number[]): string {
   return out.join('');
 };
 
+interface Base64 {
+  byteToCharMap_: { [key: number]: string } | null ;
+  charToByteMap_: { [key: string]: number } | null ;
+  byteToCharMapWebSafe_: { [key: number]: string } | null ;
+  charToByteMapWebSafe_: { [key: string]: number } | null ;
+  ENCODED_VALS_BASE: string;
+  readonly ENCODED_VALS: string;
+  readonly ENCODED_VALS_WEBSAFE: string;
+  HAS_NATIVE_SUPPORT: boolean;
+  encodeByteArray(input: number[] | Uint8Array, webSafe?: boolean): string;
+  encodeString(input: string, webSafe?: boolean): string;
+  decodeString(input: string, webSafe: boolean): string;
+  decodeStringToByteArray(input: string, webSafe: boolean): number[];
+  init_(): void;
+
+}
+
+// We define it as an object literal instead of a class because a class compiled down to es5 can't
+// be treeshaked. https://github.com/rollup/rollup/issues/1691
 // Static lookup maps, lazily populated by init_()
-class Base64 {
+export const base64: Base64 = {
   /**
    * Maps bytes to characters.
+   * @type {Object}
+   * @private
    */
-  byteToCharMap_: { [key: number]: string } | null = null;
+  byteToCharMap_: null,
 
   /**
    * Maps characters to bytes.
+   * @type {Object}
+   * @private
    */
-  charToByteMap_: { [key: string]: number } | null = null;
+  charToByteMap_: null,
 
   /**
    * Maps bytes to websafe characters.
+   * @type {Object}
+   * @private
    */
-  byteToCharMapWebSafe_: { [key: number]: string } | null = null;
+  byteToCharMapWebSafe_: null,
 
   /**
    * Maps websafe characters to bytes.
+   * @type {Object}
+   * @private
    */
-  charToByteMapWebSafe_: { [key: string]: number } | null = null;
+  charToByteMapWebSafe_: null,
 
   /**
-   * Our default alphabet shared between
+   * Our default alphabet, shared between
    * ENCODED_VALS and ENCODED_VALS_WEBSAFE
+   * @type {string}
    */
-  ENCODED_VALS_BASE: string =
-    'ABCDEFGHIJKLMNOPQRSTUVWXYZ' + 'abcdefghijklmnopqrstuvwxyz' + '0123456789';
+  ENCODED_VALS_BASE:
+    'ABCDEFGHIJKLMNOPQRSTUVWXYZ' + 'abcdefghijklmnopqrstuvwxyz' + '0123456789',
 
   /**
    * Our default alphabet. Value 64 (=) is special; it means "nothing."
+   * @type {string}
    */
-  get ENCODED_VALS(): string {
+  get ENCODED_VALS() {
     return this.ENCODED_VALS_BASE + '+/=';
-  }
+  },
 
   /**
    * Our websafe alphabet.
+   * @type {string}
    */
-  get ENCODED_VALS_WEBSAFE(): string {
+  get ENCODED_VALS_WEBSAFE() {
     return this.ENCODED_VALS_BASE + '-_.';
-  }
+  },
 
   /**
    * Whether this browser supports the atob and btoa functions. This extension
    * started at Mozilla but is now implemented by many browsers. We use the
    * ASSUME_* variables to avoid pulling in the full useragent detection library
    * but still allowing the standard per-browser compilations.
+   *
+   * @type {boolean}
    */
-  HAS_NATIVE_SUPPORT: boolean = typeof atob === 'function';
+  HAS_NATIVE_SUPPORT: typeof atob === 'function',
 
   /**
    * Base64-encode an array of bytes.
@@ -187,7 +219,7 @@ class Base64 {
     }
 
     return output.join('');
-  }
+  },
 
   /**
    * Base64-encode a string.
@@ -204,7 +236,7 @@ class Base64 {
       return btoa(input);
     }
     return this.encodeByteArray(stringToByteArray(input), webSafe);
-  }
+  },
 
   /**
    * Base64-decode a string.
@@ -221,7 +253,7 @@ class Base64 {
       return atob(input);
     }
     return byteArrayToString(this.decodeStringToByteArray(input, webSafe));
-  }
+  },
 
   /**
    * Base64-decode a string.
@@ -281,14 +313,14 @@ class Base64 {
     }
 
     return output;
-  }
+  },
 
   /**
    * Lazy static initialization function. Called before
    * accessing any of the static map variables.
    * @private
    */
-  init_(): void {
+  init_() {
     if (!this.byteToCharMap_) {
       this.byteToCharMap_ = {};
       this.charToByteMap_ = {};
@@ -310,7 +342,7 @@ class Base64 {
       }
     }
   }
-}
+};
 
 /**
  * URL-safe base64 encoding
@@ -337,5 +369,3 @@ export const base64Decode = function(str: string): string | null {
   }
   return null;
 };
-
-export const base64 = new Base64();

--- a/packages/util/src/crypt.ts
+++ b/packages/util/src/crypt.ts
@@ -107,28 +107,22 @@ interface Base64 {
 export const base64: Base64 = {
   /**
    * Maps bytes to characters.
-   * @type {Object}
-   * @private
    */
   byteToCharMap_: null,
 
   /**
    * Maps characters to bytes.
-   * @type {Object}
-   * @private
    */
   charToByteMap_: null,
 
   /**
    * Maps bytes to websafe characters.
-   * @type {Object}
    * @private
    */
   byteToCharMapWebSafe_: null,
 
   /**
    * Maps websafe characters to bytes.
-   * @type {Object}
    * @private
    */
   charToByteMapWebSafe_: null,
@@ -136,14 +130,12 @@ export const base64: Base64 = {
   /**
    * Our default alphabet, shared between
    * ENCODED_VALS and ENCODED_VALS_WEBSAFE
-   * @type {string}
    */
   ENCODED_VALS_BASE:
     'ABCDEFGHIJKLMNOPQRSTUVWXYZ' + 'abcdefghijklmnopqrstuvwxyz' + '0123456789',
 
   /**
    * Our default alphabet. Value 64 (=) is special; it means "nothing."
-   * @type {string}
    */
   get ENCODED_VALS() {
     return this.ENCODED_VALS_BASE + '+/=';
@@ -151,7 +143,6 @@ export const base64: Base64 = {
 
   /**
    * Our websafe alphabet.
-   * @type {string}
    */
   get ENCODED_VALS_WEBSAFE() {
     return this.ENCODED_VALS_BASE + '-_.';
@@ -163,7 +154,6 @@ export const base64: Base64 = {
    * ASSUME_* variables to avoid pulling in the full useragent detection library
    * but still allowing the standard per-browser compilations.
    *
-   * @type {boolean}
    */
   HAS_NATIVE_SUPPORT: typeof atob === 'function',
 


### PR DESCRIPTION
1. `downlevelIteration` adds support for iteration protocol for es5 target, but it adds extra codes for simple array iteration. 
Since it is only required by database, I am only setting it in database's tsconfig.json instead of in the global tsconfig.json to prevent the bloat.

2. `base64` was defined as an object literal before. When we enabled typescript `strict` flag, it was changed to a class. Class that are compiled down to es5 can't be treeshaked in rollup, so base64 is included in all packages that depend on `@firebase/util` though they don't use base64. This changes base64 back to object literal with type safety.
