### PR TITLE
infer namespace from subdomain in database emulator environment variable

### DIFF
--- a/packages/database/src/core/RepoManager.ts
+++ b/packages/database/src/core/RepoManager.ts
@@ -104,7 +104,7 @@ export class RepoManager {
 
     let dbEmulatorHost = process.env[FIREBASE_DATABASE_EMULATOR_HOST_VAR];
     if (dbEmulatorHost) {
-      dbUrl = `http://${dbEmulatorHost}?ns=${parseURL(dbUrl).subdomain}`;
+      dbUrl = `http://${dbEmulatorHost}?ns=${repoInfo.namespace}`;
     }
 
     validateUrl('Invalid Firebase Database URL', 1, parsedUrl);

--- a/packages/database/src/core/RepoManager.ts
+++ b/packages/database/src/core/RepoManager.ts
@@ -19,7 +19,7 @@ import { FirebaseApp } from '@firebase/app-types';
 import { safeGet } from '@firebase/util';
 import { Repo } from './Repo';
 import { fatal } from './util/util';
-import { parseRepoInfo } from './util/libs/parser';
+import { parseRepoInfo, parseURL } from './util/libs/parser';
 import { validateUrl } from './util/validation';
 import './Repo_transaction';
 import { Database } from '../api/Database';
@@ -104,7 +104,7 @@ export class RepoManager {
 
     let dbEmulatorHost = process.env[FIREBASE_DATABASE_EMULATOR_HOST_VAR];
     if (dbEmulatorHost) {
-      dbUrl = `http://${dbEmulatorHost}?ns=${parsedUrl.subdomain}`;
+      dbUrl = `http://${dbEmulatorHost}?ns=${parseURL(dbUrl).subdomain}`;
     }
 
     validateUrl('Invalid Firebase Database URL', 1, parsedUrl);

--- a/packages/database/src/core/RepoManager.ts
+++ b/packages/database/src/core/RepoManager.ts
@@ -90,12 +90,8 @@ export class RepoManager {
    * @return {!Database}
    */
   databaseFromApp(app: FirebaseApp, url?: string): Database {
-    let dbEmulatorHost = process.env[FIREBASE_DATABASE_EMULATOR_HOST_VAR];
-    if (dbEmulatorHost) {
-      dbEmulatorHost = `http://${dbEmulatorHost}`;
-    }
     const dbUrl: string =
-      url || dbEmulatorHost || app.options[DATABASE_URL_OPTION];
+      url || app.options[DATABASE_URL_OPTION];
     if (dbUrl === undefined) {
       fatal(
         "Can't determine Firebase Database URL.  Be sure to include " +
@@ -106,6 +102,11 @@ export class RepoManager {
 
     const parsedUrl = parseRepoInfo(dbUrl);
     const repoInfo = parsedUrl.repoInfo;
+
+    let dbEmulatorHost = process.env[FIREBASE_DATABASE_EMULATOR_HOST_VAR];
+    if (dbEmulatorHost) {
+      dbUrl = `http://${dbEmulatorHost}?ns=${parsedUrl.subdomain}`;
+    }
 
     validateUrl('Invalid Firebase Database URL', 1, parsedUrl);
     if (!parsedUrl.path.isEmpty()) {

--- a/packages/database/src/core/RepoManager.ts
+++ b/packages/database/src/core/RepoManager.ts
@@ -90,7 +90,7 @@ export class RepoManager {
    * @return {!Database}
    */
   databaseFromApp(app: FirebaseApp, url?: string): Database {
-    let dbUrl: string = url || app.options[DATABASE_URL_OPTION];
+    let dbUrl: string | undefined = url || app.options[DATABASE_URL_OPTION];
     if (dbUrl === undefined) {
       fatal(
         "Can't determine Firebase Database URL.  Be sure to include " +

--- a/packages/database/src/core/RepoManager.ts
+++ b/packages/database/src/core/RepoManager.ts
@@ -90,8 +90,7 @@ export class RepoManager {
    * @return {!Database}
    */
   databaseFromApp(app: FirebaseApp, url?: string): Database {
-    const dbUrl: string =
-      url || app.options[DATABASE_URL_OPTION];
+    const dbUrl: string = url || app.options[DATABASE_URL_OPTION];
     if (dbUrl === undefined) {
       fatal(
         "Can't determine Firebase Database URL.  Be sure to include " +

--- a/packages/database/src/core/RepoManager.ts
+++ b/packages/database/src/core/RepoManager.ts
@@ -90,7 +90,7 @@ export class RepoManager {
    * @return {!Database}
    */
   databaseFromApp(app: FirebaseApp, url?: string): Database {
-    const dbUrl: string = url || app.options[DATABASE_URL_OPTION];
+    let dbUrl: string = url || app.options[DATABASE_URL_OPTION];
     if (dbUrl === undefined) {
       fatal(
         "Can't determine Firebase Database URL.  Be sure to include " +

--- a/packages/database/src/core/util/libs/parser.ts
+++ b/packages/database/src/core/util/libs/parser.ts
@@ -160,9 +160,6 @@ export const parseURL = function(
     let queryParams = decodeQuery(
       dataURL.substring(Math.min(dataURL.length, questionMarkInd))
     );
-    if (process.env['FIREBASE_DATABASE_EMULATOR_HOST']) {
-      scheme = 'http';
-    }
     // If we have a port, use scheme for determining if it's secure.
     colonInd = host.indexOf(':');
     if (colonInd >= 0) {

--- a/packages/database/src/core/util/libs/parser.ts
+++ b/packages/database/src/core/util/libs/parser.ts
@@ -161,7 +161,7 @@ export const parseURL = function(
       dataURL.substring(Math.min(dataURL.length, questionMarkInd))
     );
     if (process.env['FIREBASE_DATABASE_EMULATOR_HOST']) {
-      scheme = "http";
+      scheme = 'http';
     }
     // If we have a port, use scheme for determining if it's secure.
     colonInd = host.indexOf(':');

--- a/packages/database/src/core/util/libs/parser.ts
+++ b/packages/database/src/core/util/libs/parser.ts
@@ -160,7 +160,9 @@ export const parseURL = function(
     let queryParams = decodeQuery(
       dataURL.substring(Math.min(dataURL.length, questionMarkInd))
     );
-
+    if (process.env['FIREBASE_DATABASE_EMULATOR_HOST']) {
+      scheme = "http";
+    }
     // If we have a port, use scheme for determining if it's secure.
     colonInd = host.indexOf(':');
     if (colonInd >= 0) {

--- a/packages/database/src/core/util/libs/parser.ts
+++ b/packages/database/src/core/util/libs/parser.ts
@@ -160,6 +160,7 @@ export const parseURL = function(
     let queryParams = decodeQuery(
       dataURL.substring(Math.min(dataURL.length, questionMarkInd))
     );
+
     // If we have a port, use scheme for determining if it's secure.
     colonInd = host.indexOf(':');
     if (colonInd >= 0) {


### PR DESCRIPTION
https://github.com/firebase/firebase-js-sdk/pull/2005 added support for point the RTDB javascript sdk at the database emulator. This change improves it by inferring the namespace name from the parsed `databaseURL`  app option field.