### PR TITLE
Surface transaction errors in browser

### DIFF
--- a/packages/firestore/src/platform_browser/webchannel_connection.ts
+++ b/packages/firestore/src/platform_browser/webchannel_connection.ts
@@ -32,7 +32,7 @@ import { SDK_VERSION } from '../core/version';
 import { Connection, Stream } from '../remote/connection';
 import {
   mapCodeFromRpcStatus,
-  mapCodeFromHttpReponse
+  mapCodeFromHttpResponseErrorStatus
 } from '../remote/rpc_error';
 import { StreamBridge } from '../remote/stream_bridge';
 import { assert, fail } from '../util/assert';
@@ -124,8 +124,12 @@ export class WebChannelConnection implements Connection {
               );
               if (status > 0) {
                 const responseError = xhr.getResponseJson().error;
-                if (!!responseError) {
-                  const firestoreErrorCode = mapCodeFromHttpReponse(
+                if (
+                  !!responseError &&
+                  !!responseError.status &&
+                  !!responseError.message
+                ) {
+                  const firestoreErrorCode = mapCodeFromHttpResponseErrorStatus(
                     responseError.status
                   );
                   reject(

--- a/packages/firestore/src/remote/rpc_error.ts
+++ b/packages/firestore/src/remote/rpc_error.ts
@@ -300,13 +300,14 @@ export function mapCodeFromHttpStatus(status: number): Code {
 }
 
 /**
- * Converts an HTTP error response to the equivalent error code.
+ * Converts an HTTP response's error status to the equivalent error code.
  *
- * @param status An HTTP error response ("FAILED_PRECONDITION", "UNKNOWN", etc.)
+ * @param status An HTTP error response status ("FAILED_PRECONDITION",
+ * "UNKNOWN", etc.)
  * @returns The equivalent Code. Non-matching responses are mapped to
  *     Code.UNKNOWN.
  */
-export function mapCodeFromHttpReponse(status: string): Code {
+export function mapCodeFromHttpResponseErrorStatus(status: string): Code {
   const serverError = status.toLowerCase().replace('_', '-');
   return Object.values(Code).indexOf(serverError as Code) >= 0
     ? (serverError as Code)

--- a/packages/firestore/src/remote/rpc_error.ts
+++ b/packages/firestore/src/remote/rpc_error.ts
@@ -298,3 +298,17 @@ export function mapCodeFromHttpStatus(status: number): Code {
       return Code.UNKNOWN;
   }
 }
+
+/**
+ * Converts an HTTP error response to the equivalent error code.
+ *
+ * @param status An HTTP error response ("FAILED_PRECONDITION", "UNKNOWN", etc.)
+ * @returns The equivalent Code. Non-matching responses are mapped to
+ *     Code.UNKNOWN.
+ */
+export function mapCodeFromHttpReponse(status: string): Code {
+  const serverError = status.toLowerCase().replace('_', '-');
+  return Object.values(Code).indexOf(serverError as Code) >= 0
+    ? (serverError as Code)
+    : Code.UNKNOWN;
+}


### PR DESCRIPTION
Transactions made via http surface all 400 errors as INVALID_ARGUMENT, when they could also be FAILED_PRECONDITION or OUT_OF_RANGE ([code](https://github.com/firebase/firebase-js-sdk/blob/master/packages/firestore/src/remote/rpc_error.ts#L247)).

When possible, parse the error message to determine if the server returned a more specific error code.