### PR TITLE
 Added an internal API to allow removing a service instance

### DIFF
--- a/packages/app-types/private.d.ts
+++ b/packages/app-types/private.d.ts
@@ -74,6 +74,7 @@ export interface FirebaseAppInternals {
 
 export interface _FirebaseApp extends FirebaseApp {
   INTERNAL: FirebaseAppInternals;
+  _removeServiceInstance: (name: string, instanceIdentifier?: string) => void
 }
 export interface _FirebaseNamespace extends FirebaseNamespace {
   INTERNAL: {

--- a/packages/app-types/private.d.ts
+++ b/packages/app-types/private.d.ts
@@ -74,7 +74,7 @@ export interface FirebaseAppInternals {
 
 export interface _FirebaseApp extends FirebaseApp {
   INTERNAL: FirebaseAppInternals;
-  _removeServiceInstance: (name: string, instanceIdentifier?: string) => void
+  _removeServiceInstance: (name: string, instanceIdentifier?: string) => void;
 }
 export interface _FirebaseNamespace extends FirebaseNamespace {
   INTERNAL: {

--- a/packages/app/src/firebaseApp.ts
+++ b/packages/app/src/firebaseApp.ts
@@ -170,11 +170,11 @@ export class FirebaseAppImpl implements FirebaseApp {
   }
   /**
    * Remove a service instance from the cache, so we will create a new instance for this service
-   * when people try to get this service again. 
-   * 
+   * when people try to get this service again.
+   *
    * NOTE: currently only firestore is using this functionality to support firestore shutdown.
-   * 
-   * @param name The service name 
+   *
+   * @param name The service name
    * @param instanceIdentifier instance identifier in case multiple instances are allowed
    * @internal
    */

--- a/packages/app/src/firebaseApp.ts
+++ b/packages/app/src/firebaseApp.ts
@@ -129,7 +129,7 @@ export class FirebaseAppImpl implements FirebaseApp {
    * Return a service instance associated with this app (creating it
    * on demand), identified by the passed instanceIdentifier.
    *
-   * NOTE: Currently storage is the only one that is leveraging this
+   * NOTE: Currently storage and functions are the only ones that are leveraging this
    * functionality. They invoke it by calling:
    *
    * ```javascript
@@ -167,6 +167,24 @@ export class FirebaseAppImpl implements FirebaseApp {
     }
 
     return this.services_[name][instanceIdentifier];
+  }
+  /**
+   * Remove a service instance from the cache, so we will create a new instance for this service
+   * when people try to get this service again. 
+   * 
+   * NOTE: currently only firestore is using this functionality to support firestore shutdown.
+   * 
+   * @param name The service name 
+   * @param instanceIdentifier instance identifier in case multiple instances are allowed
+   * @internal
+   */
+  _removeServiceInstance(
+    name: string,
+    instanceIdentifier: string = DEFAULT_ENTRY_NAME
+  ): void {
+    if (this.services_[name] && this.services_[name][instanceIdentifier]) {
+      delete this.services_[name][instanceIdentifier];
+    }
   }
 
   /**

--- a/packages/app/test/firebaseApp.test.ts
+++ b/packages/app/test/firebaseApp.test.ts
@@ -294,6 +294,32 @@ function executeFirebaseTests(): void {
 
       assert.notEqual(service, (firebase as any).test());
     });
+
+    it(`Should create a new instance of a service after removing the existing instance - for service that supports multiple instances`, () => {
+      const app = firebase.initializeApp({});
+      (firebase as _FirebaseNamespace).INTERNAL.registerService(
+        'multiInstance',
+        (...args) => {
+          const [app, , instanceIdentifier] = args;
+          return new TestService(app, instanceIdentifier);
+        },
+        undefined,
+        undefined,
+        true
+      );
+
+      // default instance
+      const instance1 = (firebase.app() as any).multiInstance();
+      const serviceIdentifier = 'custom instance identifier';
+      const instance2 = (firebase.app() as any).multiInstance(serviceIdentifier);
+
+      (app as _FirebaseApp)._removeServiceInstance('multiInstance', serviceIdentifier);
+
+      // default instance should not be changed
+      assert.equal(instance1, (firebase.app() as any).multiInstance());
+
+      assert.notEqual(instance2, (firebase.app() as any).multiInstance(serviceIdentifier));
+    });
   });
 }
 
@@ -484,7 +510,7 @@ function firebaseAppTests(
 }
 
 class TestService implements FirebaseService {
-  constructor(private app_: FirebaseApp, public instanceIdentifier?: string) {}
+  constructor(private app_: FirebaseApp, public instanceIdentifier?: string) { }
 
   // TODO(koss): Shouldn't this just be an added method on
   // the service instance?

--- a/packages/app/test/firebaseApp.test.ts
+++ b/packages/app/test/firebaseApp.test.ts
@@ -276,6 +276,24 @@ function executeFirebaseTests(): void {
           assert.equal('tokenFor1', token!.accessToken);
         });
     });
+
+    it(`Should create a new instance of a service after removing the existing instance`, () => {
+      const app = firebase.initializeApp({});
+      (firebase as _FirebaseNamespace).INTERNAL.registerService(
+        'test',
+        (app: FirebaseApp) => {
+          return new TestService(app);
+        }
+      );
+
+      const service = (firebase as any).test();
+
+      assert.equal(service, (firebase as any).test());
+
+      (app as _FirebaseApp)._removeServiceInstance('test');
+
+      assert.notEqual(service, (firebase as any).test());
+    });
   });
 }
 

--- a/packages/app/test/firebaseApp.test.ts
+++ b/packages/app/test/firebaseApp.test.ts
@@ -311,14 +311,22 @@ function executeFirebaseTests(): void {
       // default instance
       const instance1 = (firebase.app() as any).multiInstance();
       const serviceIdentifier = 'custom instance identifier';
-      const instance2 = (firebase.app() as any).multiInstance(serviceIdentifier);
+      const instance2 = (firebase.app() as any).multiInstance(
+        serviceIdentifier
+      );
 
-      (app as _FirebaseApp)._removeServiceInstance('multiInstance', serviceIdentifier);
+      (app as _FirebaseApp)._removeServiceInstance(
+        'multiInstance',
+        serviceIdentifier
+      );
 
       // default instance should not be changed
       assert.equal(instance1, (firebase.app() as any).multiInstance());
 
-      assert.notEqual(instance2, (firebase.app() as any).multiInstance(serviceIdentifier));
+      assert.notEqual(
+        instance2,
+        (firebase.app() as any).multiInstance(serviceIdentifier)
+      );
     });
   });
 }
@@ -510,7 +518,7 @@ function firebaseAppTests(
 }
 
 class TestService implements FirebaseService {
-  constructor(private app_: FirebaseApp, public instanceIdentifier?: string) { }
+  constructor(private app_: FirebaseApp, public instanceIdentifier?: string) {}
 
   // TODO(koss): Shouldn't this just be an added method on
   // the service instance?


### PR DESCRIPTION
Usage: `(app as _FirebaseApp)._removeServiceInstance('serviceName')`