### PR TITLE
Add spec tests for limit queries with limbo documents

### DIFF
--- a/packages/firestore/src/remote/watch_change.ts
+++ b/packages/firestore/src/remote/watch_change.ts
@@ -29,6 +29,7 @@ import { DocumentKey } from '../model/document_key';
 import { emptyByteString } from '../platform/platform';
 import { assert, fail } from '../util/assert';
 import { FirestoreError } from '../util/error';
+import { debug } from '../util/log';
 import { primitiveComparator } from '../util/misc';
 import * as objUtils from '../util/obj';
 import { SortedMap } from '../util/sorted_map';
@@ -252,6 +253,8 @@ export interface TargetMetadataProvider {
    */
   getQueryDataForTarget(targetId: TargetId): QueryData | null;
 }
+
+const LOG_TAG = 'WatchChangeAggregator';
 
 /**
  * A helper class to accumulate watch changes into a RemoteEvent.
@@ -617,7 +620,11 @@ export class WatchChangeAggregator {
    * from watch.
    */
   protected isActiveTarget(targetId: TargetId): boolean {
-    return this.queryDataForActiveTarget(targetId) !== null;
+    const targetActive = this.queryDataForActiveTarget(targetId) !== null;
+    if (!targetActive) {
+      debug(LOG_TAG, 'Detected inactive target', targetId);
+    }
+    return targetActive;
   }
 
   /**

--- a/packages/firestore/src/util/log.ts
+++ b/packages/firestore/src/util/log.ts
@@ -59,10 +59,10 @@ export function setLogLevel(newLevel: LogLevel): void {
 }
 
 export function debug(tag: string, msg: string, ...obj: unknown[]): void {
-  //if (logClient.logLevel <= FirebaseLogLevel.DEBUG) {
-  const args = obj.map(argToString);
-  console.debug(`Firestore (${SDK_VERSION}) [${tag}]: ${msg}`, ...args);
-  //}
+  if (logClient.logLevel <= FirebaseLogLevel.DEBUG) {
+    const args = obj.map(argToString);
+    logClient.debug(`Firestore (${SDK_VERSION}) [${tag}]: ${msg}`, ...args);
+  }
 }
 
 export function error(msg: string, ...obj: unknown[]): void {

--- a/packages/firestore/src/util/log.ts
+++ b/packages/firestore/src/util/log.ts
@@ -59,10 +59,10 @@ export function setLogLevel(newLevel: LogLevel): void {
 }
 
 export function debug(tag: string, msg: string, ...obj: unknown[]): void {
-  if (logClient.logLevel <= FirebaseLogLevel.DEBUG) {
-    const args = obj.map(argToString);
-    logClient.debug(`Firestore (${SDK_VERSION}) [${tag}]: ${msg}`, ...args);
-  }
+  //if (logClient.logLevel <= FirebaseLogLevel.DEBUG) {
+  const args = obj.map(argToString);
+  console.debug(`Firestore (${SDK_VERSION}) [${tag}]: ${msg}`, ...args);
+  //}
 }
 
 export function error(msg: string, ...obj: unknown[]): void {

--- a/packages/firestore/test/unit/specs/limit_spec.test.ts
+++ b/packages/firestore/test/unit/specs/limit_spec.test.ts
@@ -214,16 +214,16 @@ describeSpec('Limits:', [], () => {
           .expectEvents(fullQuery, { added: [firstDocument], fromCache: true })
           .watchAcksFull(fullQuery, 1002, firstDocument, secondDocument)
           .expectEvents(fullQuery, { added: [secondDocument] })
-          // Watch sends us a remove for `firstDocument`, but doesn't tell us
-          // the new document state (we lost access). Since we don't know the
-          // state of the document, we mark it as limbo.
+          // Another client modified `firstDocument` and we lost access to it.
+          // Watch sends us a remove, but doesn't tell us the new document state.
+          // Since we don't know the state of the document, we mark it as limbo.
           .watchRemovesDoc(firstDocument.key, fullQuery)
           .watchSnapshots(1003)
           .expectEvents(fullQuery, { fromCache: true })
           .expectLimboDocs(firstDocument.key)
           .userUnlistens(fullQuery)
-          // We disregard our attempt to resolve the limbo state of
-          // `firstDocument` when we stop listening to `fullQuery`.
+          // Since we stop listening to `fullQuery`, we disregard our attempt to
+          // resolve the limbo state of `firstDocument`.
           .expectLimboDocs()
           .watchRemoves(fullQuery)
           // We restart the client, which clears the limbo target mapping in the
@@ -232,20 +232,29 @@ describeSpec('Limits:', [], () => {
           // however, uses new target IDs if a document goes in and out of limbo.
           .restart()
           // We listen to the limit query again. Note that we include
-          // `firstDocument` in the result since we did not resolve its limbo
-          // state.
+          // `firstDocument` in the local result since we did not resolve its
+          // limbo state.
           .userListens(limitQuery, 'resume-token-1001')
           .expectEvents(limitQuery, { added: [firstDocument], fromCache: true })
           .watchAcks(limitQuery)
-          // Watch lets us know that it can't reconstruct the query state from
-          // our resume token. Instead, we treat it as a the full query.
-          .watchResets(limitQuery)
+          // Watch resumes the query from the provided resume token, but does
+          // not guarantee to send us the removal of `firstDocument`. Instead,
+          // we receive an existence filter, which indicates that our view is
+          // out of sync.
           .watchSends({ affects: [limitQuery] }, secondDocument)
-          .watchCurrents(limitQuery, 'resume-token-1003')
-          .watchSnapshots(1003)
+          .watchFilters([limitQuery], secondDocument.key)
+          .watchSnapshots(1004)
+          .expectActiveTargets({ query: limitQuery, resumeToken: '' })
+          .watchRemoves(limitQuery)
+          .watchAcksFull(limitQuery, 1005, secondDocument)
+          // The snapshot after the existence filter mismatch triggers limbo
+          // resolution. The local view still contains `firstDocument` and
+          // hence we do not yet raise a new snapshot.
           .expectLimboDocs(firstDocument.key)
-          .ackLimbo(1004, firstDocumentDeleted)
+          .ackLimbo(1006, firstDocumentDeleted)
           .expectLimboDocs()
+          // We raise the final snapshot when limbo resolution completes. We now
+          // include `secondDocument`, which matches the backend result.
           .expectEvents(limitQuery, {
             added: [secondDocument],
             removed: [firstDocument]
@@ -263,28 +272,40 @@ describeSpec('Limits:', [], () => {
       .withLimit(1);
     const fullQuery = Query.atPath(path('collection')).addOrderBy(orderBy('a'));
 
-    const firstDocument = doc('collection/a', 1001, { a: 1 });
-    const firstDocumentUpdated = doc('collection/a', 1003, { a: 3 });
+    const firstDocument = doc('collection/a', 2001, { a: 1 });
+    const firstDocumentUpdated = doc('collection/a', 2003, { a: 3 });
     const secondDocument = doc('collection/c', 1000, { a: 2 });
 
-    return spec()
-      .withGCEnabled(false)
-      .userListens(limitQuery)
-      .watchAcksFull(limitQuery, 1001, firstDocument)
-      .expectEvents(limitQuery, { added: [firstDocument] })
-      .userUnlistens(limitQuery)
-      .watchRemoves(limitQuery)
-      .userListens(fullQuery)
-      .expectEvents(fullQuery, { added: [firstDocument], fromCache: true })
-      .watchAcksFull(fullQuery, 1003, firstDocumentUpdated, secondDocument)
-      .expectEvents(fullQuery, {
-        added: [secondDocument],
-        modified: [firstDocumentUpdated]
-      })
-      .userUnlistens(fullQuery)
-      .watchRemoves(fullQuery)
-      .userListens(limitQuery, 'resume-token-1001')
-      .expectEvents(limitQuery, { added: [secondDocument], fromCache: true });
+    return (
+      spec()
+        .withGCEnabled(false)
+        // We issue a limit query with an orderBy constraint.
+        .userListens(limitQuery)
+        .watchAcksFull(limitQuery, 2001, firstDocument)
+        .expectEvents(limitQuery, { added: [firstDocument] })
+        .userUnlistens(limitQuery)
+        .watchRemoves(limitQuery)
+        // We issue a second query which adds `secondDocument` to the cache. We
+        // also update `firstDocument` to sort after `secondDocument`.
+        // `secondDocument` is now older than `firstDocument` but sorts before it
+        // in the limit query.
+        .userListens(fullQuery)
+        .expectEvents(fullQuery, { added: [firstDocument], fromCache: true })
+        .watchAcksFull(fullQuery, 2003, firstDocumentUpdated, secondDocument)
+        .expectEvents(fullQuery, {
+          added: [secondDocument],
+          modified: [firstDocumentUpdated]
+        })
+        .userUnlistens(fullQuery)
+        .watchRemoves(fullQuery)
+        // Re-issue the limit query and verify that we return `secondDocument` from
+        // cache.
+        .userListens(limitQuery, 'resume-token-2001')
+        .expectEvents(limitQuery, {
+          added: [secondDocument],
+          fromCache: true
+        })
+    );
   });
 
   specTest('Multiple docs in limbo in full limit query', [], () => {

--- a/packages/firestore/test/unit/specs/limit_spec.test.ts
+++ b/packages/firestore/test/unit/specs/limit_spec.test.ts
@@ -298,8 +298,8 @@ describeSpec('Limits:', [], () => {
         })
         .userUnlistens(fullQuery)
         .watchRemoves(fullQuery)
-        // Re-issue the limit query and verify that we return `secondDocument` from
-        // cache.
+        // Re-issue the limit query and verify that we return `secondDocument`
+        // from cache.
         .userListens(limitQuery, 'resume-token-2001')
         .expectEvents(limitQuery, {
           added: [secondDocument],

--- a/packages/firestore/test/unit/specs/spec_test_runner.ts
+++ b/packages/firestore/test/unit/specs/spec_test_runner.ts
@@ -1016,9 +1016,12 @@ abstract class TestRunner {
     let actualLimboDocs = this.syncEngine.currentLimboDocs();
     // Validate that each limbo doc has an expected active target
     actualLimboDocs.forEach((key, targetId) => {
+      const targetIds: number[] = [];
+      obj.forEachNumber(this.expectedActiveTargets, id => targetIds.push(id));
       expect(obj.contains(this.expectedActiveTargets, targetId)).to.equal(
         true,
-        'Found limbo doc without an expected active target'
+        `Found limbo doc, but its target ID ${targetId} was not in the set of ` +
+          `expected active target IDs (${targetIds.join(', ')})`
       );
     });
     for (const expectedLimboDoc of this.expectedLimboDocs) {


### PR DESCRIPTION
This PR adds two spec tests that summarize an offline conversation about potential edge cases for index-free queries (good news is that they pass in the branch). I also made some improvements to our logging which hopefully can cut down future spec test debugging time.