### PR TITLE
fix an obnoxious uglify issue

### DIFF
--- a/packages/database/CHANGELOG.md
+++ b/packages/database/CHANGELOG.md
@@ -1,3 +1,4 @@
 # Unreleased
+- [fixed] Fixed an uglify issue in minified scripts (`firebase.js` and `firebase-database.js`) where multi-byte UTF-8 characters were encoded incorrectly. 
 - [changed] Improved consistency between the type annotations for `Query.on`/`Reference.on`, 
   `Query.off`/`Reference.off` and `Query.once`/`Reference.once` (#1188, #1204).

--- a/packages/database/CHANGELOG.md
+++ b/packages/database/CHANGELOG.md
@@ -1,4 +1,4 @@
 # Unreleased
-- [fixed] Fixed an uglify issue in minified scripts (`firebase.js` and `firebase-database.js`) where multi-byte UTF-8 characters were encoded incorrectly. 
+- [fixed] Fixed an issue where multi-byte UTF-8 characters would not be written correctly when using `firebase.js` or `firebase-database.js` (https://github.com/firebase/firebase-js-sdk/issues/2035).
 - [changed] Improved consistency between the type annotations for `Query.on`/`Reference.on`, 
   `Query.off`/`Reference.off` and `Query.once`/`Reference.once` (#1188, #1204).

--- a/packages/database/CHANGELOG.md
+++ b/packages/database/CHANGELOG.md
@@ -1,4 +1,4 @@
 # Unreleased
-- [fixed] Fixed an issue where multi-byte UTF-8 characters would not be written correctly when using `firebase.js` or `firebase-database.js` (https://github.com/firebase/firebase-js-sdk/issues/2035).
+- [fixed] Fixed an issue where multi-byte UTF-8 characters would not be written correctly when using `firebase.js` or `firebase-database.js` (#2035).
 - [changed] Improved consistency between the type annotations for `Query.on`/`Reference.on`, 
   `Query.off`/`Reference.off` and `Query.once`/`Reference.once` (#1188, #1204).

--- a/yarn.lock
+++ b/yarn.lock
@@ -4322,7 +4322,7 @@ commander@^2.12.1, commander@^2.8.1:
   resolved "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz#df46e867d0fc2aec66a34662b406a9ccafff5b0f"
   integrity sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==
 
-commander@^2.20.0:
+commander@^2.20.0, commander@~2.20.0:
   version "2.20.0"
   resolved "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz#d58bb2b5c1ee8f87b0d340027e9e94e222c5a422"
   integrity sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==
@@ -14382,11 +14382,11 @@ uglify-js@^2.6:
     uglify-to-browserify "~1.0.0"
 
 uglify-js@^3.1.4, uglify-js@^3.4.9:
-  version "3.4.9"
-  resolved "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.9.tgz#af02f180c1207d76432e473ed24a28f4a782bae3"
-  integrity sha512-8CJsbKOtEbnJsTyv6LE6m6ZKniqMiFWmm9sRbopbkGs3gMPPfd3Fh8iIA4Ykv5MgaTbqHr4BaoGLJLZNhsrW1Q==
+  version "3.6.0"
+  resolved "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.0.tgz#704681345c53a8b2079fb6cec294b05ead242ff5"
+  integrity sha512-W+jrUHJr3DXKhrsS7NUVxn3zqMOFn0hL/Ei6v0anCIMoKC93TjcflTagwIHLW7SfMFfiQuktQyFVCFHGUE0+yg==
   dependencies:
-    commander "~2.17.1"
+    commander "~2.20.0"
     source-map "~0.6.1"
 
 uglify-to-browserify@~1.0.0:


### PR DESCRIPTION
@ryanpbrewster reported an issue where `uglify-js` uglify [this function](https://github.com/firebase/firebase-js-sdk/blob/master/packages/util/src/crypt.ts#L18) incorrectly. As a result, the uglified code does wrong thing on multi-byte utf8 characters.
This function is being used in RTDB, so some user data in RTDB might have been corrupted.

As an illustration 
```javascript
arr[idx++] = 0;
arr[idx++] = 1;
```
is turned into:
```
arr[idx++] = (arr[idx++] = 1, 0)
```

 The issue doesn't exist in the latest `uglify-js` anymore, so we upgrade `uglify-js` to 3.6.0

Fixes: #2035