### PR TITLE
Make initial view test actually use index-free queries

### DIFF
--- a/packages/firestore/test/unit/specs/limit_spec.test.ts
+++ b/packages/firestore/test/unit/specs/limit_spec.test.ts
@@ -218,7 +218,7 @@ describeSpec('Limits:', [], () => {
   );
 
   specTest(
-    'Initial snapshots for limit queries are re-filled from cache (with uncommitted change)',
+    'Initial snapshots for limit queries are re-filled from cache (with latency-compensated edit)',
     [],
     () => {
       // Verify that views for limit queries contain the correct set of documents
@@ -251,7 +251,7 @@ describeSpec('Limits:', [], () => {
   );
 
   specTest(
-    'Initial snapshots for limit queries are re-filled from cache (with committed change)',
+    'Initial snapshots for limit queries are re-filled from cache (with update from backend)',
     [],
     () => {
       // Verify that views for limit queries contain the correct set of documents

--- a/packages/firestore/test/unit/specs/limit_spec.test.ts
+++ b/packages/firestore/test/unit/specs/limit_spec.test.ts
@@ -201,18 +201,18 @@ describeSpec('Limits:', [], () => {
       const doc3 = doc('collection/c', 1003, { matches: true });
       return spec()
         .withGCEnabled(false)
+        .userListens(fullQuery)
+        .watchAcksFull(fullQuery, 1003, doc1, doc2, doc3)
+        .expectEvents(fullQuery, { added: [doc1, doc2, doc3] })
+        .userUnlistens(fullQuery)
         .userListens(limitQuery)
-        .watchAcksFull(limitQuery, 1002, doc1, doc2)
-        .expectEvents(limitQuery, { added: [doc1, doc2] })
+        .expectEvents(limitQuery, { added: [doc1, doc2], fromCache: true })
+        .watchAcksFull(limitQuery, 1004, doc1, doc2)
+        .expectEvents(limitQuery, {})
         .userUnlistens(limitQuery)
         .watchRemoves(limitQuery)
-        .userListens(fullQuery)
-        .expectEvents(fullQuery, { added: [doc1, doc2], fromCache: true })
-        .watchAcksFull(fullQuery, 1003, doc1, doc2, doc3)
-        .expectEvents(fullQuery, { added: [doc3] })
-        .userUnlistens(fullQuery)
         .userSets('collection/a', { matches: false })
-        .userListens(limitQuery, 'resume-token-1002')
+        .userListens(limitQuery, 'resume-token-1004')
         .expectEvents(limitQuery, { added: [doc2, doc3], fromCache: true });
     }
   );

--- a/packages/firestore/test/unit/specs/limit_spec.test.ts
+++ b/packages/firestore/test/unit/specs/limit_spec.test.ts
@@ -201,12 +201,18 @@ describeSpec('Limits:', [], () => {
       const doc3 = doc('collection/c', 1003, { matches: true });
       return spec()
         .withGCEnabled(false)
+        .userListens(limitQuery)
+        .watchAcksFull(limitQuery, 1002, doc1, doc2)
+        .expectEvents(limitQuery, { added: [doc1, doc2] })
+        .userUnlistens(limitQuery)
+        .watchRemoves(limitQuery)
         .userListens(fullQuery)
+        .expectEvents(fullQuery, { added: [doc1, doc2], fromCache: true })
         .watchAcksFull(fullQuery, 1003, doc1, doc2, doc3)
-        .expectEvents(fullQuery, { added: [doc1, doc2, doc3] })
+        .expectEvents(fullQuery, { added: [doc3] })
         .userUnlistens(fullQuery)
         .userSets('collection/a', { matches: false })
-        .userListens(limitQuery)
+        .userListens(limitQuery, 'resume-token-1002')
         .expectEvents(limitQuery, { added: [doc2, doc3], fromCache: true });
     }
   );


### PR DESCRIPTION
Update the spec test I wrote on Friday to actually use index-free queries. Note that I still have all tests passing even with this change.