### PR TITLE
Make spec tests easier to debug

### DIFF
--- a/packages/firestore/test/unit/specs/describe_spec.ts
+++ b/packages/firestore/test/unit/specs/describe_spec.ts
@@ -166,12 +166,12 @@ export function specTest(
       ? [true, false]
       : [false];
     for (const usePersistence of persistenceModes) {
-      const spec = builder();
       const runner = getTestRunner(tags, usePersistence);
       const timeout = getTestTimeout(tags);
       const mode = usePersistence ? '(Persistence)' : '(Memory)';
       const fullName = `${mode} ${name}`;
       const queuedTest = runner(fullName, async () => {
+        const spec = builder();
         const start = Date.now();
         await spec.runAsTest(fullName, tags, usePersistence);
         const end = Date.now();


### PR DESCRIPTION
With this simple change, tests missing the "exclusive" tag will not be translated into JSON. Hence, we can set breakpoints in the spec builder functions. It's really a win win.

I also expect this to speed up our spec tests so much that this changes the way we look at unit testing. I am talking microseconds.
