### PR TITLE
database sdk not correctly inferring emulator namespace name

### DIFF
--- a/packages/database/src/core/RepoManager.ts
+++ b/packages/database/src/core/RepoManager.ts
@@ -99,8 +99,8 @@ export class RepoManager {
       );
     }
 
-    const parsedUrl = parseRepoInfo(dbUrl);
-    const repoInfo = parsedUrl.repoInfo;
+    let parsedUrl = parseRepoInfo(dbUrl);
+    let repoInfo = parsedUrl.repoInfo;
 
     let dbEmulatorHost: string | undefined = undefined;
     if (typeof process !== 'undefined') {
@@ -108,6 +108,8 @@ export class RepoManager {
     }
     if (dbEmulatorHost) {
       dbUrl = `http://${dbEmulatorHost}?ns=${repoInfo.namespace}`;
+      parsedUrl = parseRepoInfo(dbUrl);
+      repoInfo = parsedUrl.repoInfo;
     }
 
     validateUrl('Invalid Firebase Database URL', 1, parsedUrl);

--- a/packages/database/test/database.test.ts
+++ b/packages/database/test/database.test.ts
@@ -88,6 +88,15 @@ describe('Database Tests', function() {
     expect(db.ref().toString()).to.equal('https://bar.firebaseio.com/');
   });
 
+  it('Interprets FIREBASE_DATABASE_EMULATOR_HOST var correctly', function() {
+    process.env['FIREBASE_DATABASE_EMULATOR_HOST'] = "localhost:9000";
+    var db = defaultApp.database('https://bar.firebaseio.com');
+    expect(db).to.be.ok;
+    expect(db.repo_.repoInfo_.namespace).to.equal('bar');
+    expect(db.repo_.repoInfo_.host).to.equal('localhost:9000');
+    delete process.env['FIREBASE_DATABASE_EMULATOR_HOST'];
+  })
+
   it('Different instances for different URLs', function() {
     var db1 = defaultApp.database('http://foo1.bar.com');
     var db2 = defaultApp.database('http://foo2.bar.com');

--- a/packages/database/test/database.test.ts
+++ b/packages/database/test/database.test.ts
@@ -89,13 +89,13 @@ describe('Database Tests', function() {
   });
 
   it('Interprets FIREBASE_DATABASE_EMULATOR_HOST var correctly', function() {
-    process.env['FIREBASE_DATABASE_EMULATOR_HOST'] = "localhost:9000";
+    process.env['FIREBASE_DATABASE_EMULATOR_HOST'] = 'localhost:9000';
     var db = defaultApp.database('https://bar.firebaseio.com');
     expect(db).to.be.ok;
     expect(db.repo_.repoInfo_.namespace).to.equal('bar');
     expect(db.repo_.repoInfo_.host).to.equal('localhost:9000');
     delete process.env['FIREBASE_DATABASE_EMULATOR_HOST'];
-  })
+  });
 
   it('Different instances for different URLs', function() {
     var db1 = defaultApp.database('http://foo1.bar.com');


### PR DESCRIPTION
In https://github.com/firebase/firebase-js-sdk/pull/2016, we added logic for inferring the namespace name to pass to the RTDB emulator from the result of `parseRepoInfo`, but we didn't actually create a repo class to communicate with it.