### PR TITLE
Enable strictNullChecks for scripts/emulator-testing/

### DIFF
--- a/scripts/emulator-testing/emulators/database-emulator.ts
+++ b/scripts/emulator-testing/emulators/database-emulator.ts
@@ -23,14 +23,15 @@ export class DatabaseEmulator extends Emulator {
   namespace: string;
 
   constructor(port = 8088, namespace = 'test-emulator') {
-    super(port);
+    super(
+      'database-emulator.jar',
+      // Use locked version of emulator for test to be deterministic.
+      // The latest version can be found from database emulator doc:
+      // https://firebase.google.com/docs/database/security/test-rules-emulator
+      'https://storage.googleapis.com/firebase-preview-drop/emulator/firebase-database-emulator-v3.5.0.jar',
+      port
+    );
     this.namespace = namespace;
-    this.binaryName = 'database-emulator.jar';
-    // Use locked version of emulator for test to be deterministic.
-    // The latest version can be found from database emulator doc:
-    // https://firebase.google.com/docs/database/security/test-rules-emulator
-    this.binaryUrl =
-      'https://storage.googleapis.com/firebase-preview-drop/emulator/firebase-database-emulator-v3.5.0.jar';
   }
 
   setPublicRules(): Promise<number> {

--- a/scripts/emulator-testing/emulators/emulator.ts
+++ b/scripts/emulator-testing/emulators/emulator.ts
@@ -29,16 +29,14 @@ export interface ChildProcessPromise extends Promise<void> {
 }
 
 export abstract class Emulator {
-  binaryName: string;
-  binaryUrl: string;
-  binaryPath: string;
+  binaryPath: string | null = null;
+  emulator: ChildProcess | null = null;
 
-  emulator: ChildProcess;
-  port: number;
-
-  constructor(port: number) {
-    this.port = port;
-  }
+  constructor(
+    private binaryName: string,
+    private binaryUrl: string,
+    public port: number
+  ) {}
 
   download(): Promise<void> {
     return new Promise<void>((resolve, reject) => {
@@ -71,6 +69,9 @@ export abstract class Emulator {
 
   setUp(): Promise<void> {
     return new Promise<void>((resolve, reject) => {
+      if (!this.binaryPath) {
+        throw new Error('You must call download() before setUp()');
+      }
       const promise: ChildProcessPromise = spawn(
         'java',
         ['-jar', path.basename(this.binaryPath), '--port', this.port],

--- a/scripts/emulator-testing/emulators/firestore-emulator.ts
+++ b/scripts/emulator-testing/emulators/firestore-emulator.ts
@@ -21,13 +21,14 @@ export class FirestoreEmulator extends Emulator {
   projectId: string;
 
   constructor(port: number, projectId = 'test-emulator') {
-    super(port);
+    super(
+      'firestore-emulator.jar',
+      // Use locked version of emulator for test to be deterministic.
+      // The latest version can be found from firestore emulator doc:
+      // https://firebase.google.com/docs/firestore/security/test-rules-emulator
+      'https://storage.googleapis.com/firebase-preview-drop/emulator/cloud-firestore-emulator-v1.5.0.jar',
+      port
+    );
     this.projectId = projectId;
-    this.binaryName = 'firestore-emulator.jar';
-    // Use locked version of emulator for test to be deterministic.
-    // The latest version can be found from firestore emulator doc:
-    // https://firebase.google.com/docs/firestore/security/test-rules-emulator
-    this.binaryUrl =
-      'https://storage.googleapis.com/firebase-preview-drop/emulator/cloud-firestore-emulator-v1.6.2.jar';
   }
 }

--- a/scripts/emulator-testing/tsconfig.json
+++ b/scripts/emulator-testing/tsconfig.json
@@ -1,3 +1,7 @@
 {
-  "extends": "../../config/tsconfig.base.json"
+  "extends": "../../config/tsconfig.base.json",
+
+  "compilerOptions": {
+    "strictNullChecks": true
+  }
 }


### PR DESCRIPTION
I took the emulator-related part out of https://github.com/firebase/firebase-js-sdk/pull/1941/files and reworked it a bit (trying not to use `!` assertions).  I'll work on all the Firestore stuff next (sorry for being so slow).

NOTE: I left out the `stdio: 'inherit'` lines you changed to `stdio: ['inherit', process.stdout, process.stderr]` as I couldn't figure out what that was for.  Let me know if I should pull that in for some reason.