### PR TITLE
Remove unnecessary tsconfig.json flags.

### DIFF
--- a/packages/firestore/tsconfig.json
+++ b/packages/firestore/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "../../config/tsconfig.base.json",
   "compilerOptions": {
     "outDir": "dist",
+    "noImplicitThis": false,
     "strictBindCallApply": false,
     "strictPropertyInitialization": false
   },

--- a/packages/firestore/tsconfig.json
+++ b/packages/firestore/tsconfig.json
@@ -2,11 +2,6 @@
   "extends": "../../config/tsconfig.base.json",
   "compilerOptions": {
     "outDir": "dist",
-    "strictFunctionTypes": true,
-    "strictNullChecks": true,
-    "noImplicitAny": true,
-    "alwaysStrict": false,
-    "noImplicitThis": false,
     "strictBindCallApply": false,
     "strictPropertyInitialization": false
   },


### PR DESCRIPTION
tsconfig.base.json enables "strict" now which implicitly enables
"strictFunctionTypes", "strictNullChecks", and "noImplicitAny" (see https://www.typescriptlang.org/docs/handbook/compiler-options.html) so we don't need
to do so explicitly.

We were disabling "alwaysStrict" but that was unnecessary since we have no violations.