### PR TITLE
Do not throw error on duplicate service registration.

### DIFF
--- a/packages/app/index.ts
+++ b/packages/app/index.ts
@@ -18,9 +18,7 @@
 import { FirebaseNamespace } from '@firebase/app-types';
 import { createFirebaseNamespace } from './src/firebaseNamespace';
 import { isNode, isBrowser } from '@firebase/util';
-import { Logger } from '@firebase/logger';
-
-const logger = new Logger('@firebase/app');
+import { logger } from './src/logger';
 
 // Firebase Lite detection
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/app/src/errors.ts
+++ b/packages/app/src/errors.ts
@@ -22,7 +22,6 @@ export const enum AppError {
   BAD_APP_NAME = 'bad-app-name',
   DUPLICATE_APP = 'duplicate-app',
   APP_DELETED = 'app-deleted',
-  DUPLICATE_SERVICE = 'duplicate-service',
   INVALID_APP_ARGUMENT = 'invalid-app-argument'
 }
 
@@ -33,8 +32,6 @@ const ERRORS: ErrorMap<AppError> = {
   [AppError.BAD_APP_NAME]: "Illegal App name: '{$appName}",
   [AppError.DUPLICATE_APP]: "Firebase App named '{$appName}' already exists",
   [AppError.APP_DELETED]: "Firebase App named '{$appName}' already deleted",
-  [AppError.DUPLICATE_SERVICE]:
-    "Firebase service named '{$appName}' already registered",
   [AppError.INVALID_APP_ARGUMENT]:
     'firebase.{$appName}() takes either no argument or a ' +
     'Firebase App instance.'

--- a/packages/app/src/firebaseNamespaceCore.ts
+++ b/packages/app/src/firebaseNamespaceCore.ts
@@ -182,7 +182,10 @@ export function createFirebaseNamespaceCore(
   ): FirebaseServiceNamespace<FirebaseService> {
     // Cannot re-register a service that already exists
     if (factories[name]) {
-      throw ERROR_FACTORY.create(AppError.DUPLICATE_SERVICE, { appName: name });
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      return (namespace as any)[name] as FirebaseServiceNamespace<
+        FirebaseService
+      >;
     }
 
     // Capture the service factory for later service instantiation

--- a/packages/app/src/firebaseNamespaceCore.ts
+++ b/packages/app/src/firebaseNamespaceCore.ts
@@ -35,6 +35,7 @@ import { ERROR_FACTORY, AppError } from './errors';
 import { FirebaseAppLiteImpl } from './lite/firebaseAppLite';
 import { DEFAULT_ENTRY_NAME } from './constants';
 import { version } from '../../firebase/package.json';
+import { logger } from './logger';
 
 /**
  * Because auth can't share code with other components, we attach the utility functions
@@ -180,8 +181,9 @@ export function createFirebaseNamespaceCore(
     appHook?: AppHook,
     allowMultipleInstances = false
   ): FirebaseServiceNamespace<FirebaseService> {
-    // Cannot re-register a service that already exists
+    // If re-registering a service that already exists, return existing service
     if (factories[name]) {
+      logger.debug(`There were multiple attempts to register service ${name}.`);
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       return (namespace as any)[name] as FirebaseServiceNamespace<
         FirebaseService

--- a/packages/app/src/logger.ts
+++ b/packages/app/src/logger.ts
@@ -1,0 +1,4 @@
+
+import { Logger } from '@firebase/logger';
+
+export const logger = new Logger('@firebase/app');

--- a/packages/app/src/logger.ts
+++ b/packages/app/src/logger.ts
@@ -1,3 +1,20 @@
+/**
+ * @license
+ * Copyright 2019 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { Logger } from '@firebase/logger';
 
 export const logger = new Logger('@firebase/app');

--- a/packages/app/src/logger.ts
+++ b/packages/app/src/logger.ts
@@ -1,4 +1,3 @@
-
 import { Logger } from '@firebase/logger';
 
 export const logger = new Logger('@firebase/app');

--- a/packages/app/test/firebaseApp.test.ts
+++ b/packages/app/test/firebaseApp.test.ts
@@ -87,6 +87,32 @@ function executeFirebaseTests(): void {
       assert.equal(registrations, 2);
     });
 
+    it('Will do nothing if registerService is called again with the same name', () => {
+      let registrations = 0;
+      (firebase as _FirebaseNamespace).INTERNAL.registerService(
+        'test',
+        (app: FirebaseApp) => {
+          registrations += 1;
+          return new TestService(app);
+        }
+      );
+      firebase.initializeApp({});
+      assert.equal(registrations, 0);
+      (firebase as any).test();
+      assert.equal(registrations, 1);
+
+      (firebase as _FirebaseNamespace).INTERNAL.registerService(
+        'test',
+        (app: FirebaseApp) => {
+          registrations += 1;
+          return new TestService(app);
+        }
+      );
+
+      (firebase as any).test();
+      assert.equal(registrations, 1);
+    });
+
     it('Can lazy load a service', () => {
       let registrations = 0;
 

--- a/packages/app/test/firebaseApp.test.ts
+++ b/packages/app/test/firebaseApp.test.ts
@@ -89,33 +89,24 @@ function executeFirebaseTests(): void {
     });
 
     it('Will do nothing if registerService is called again with the same name', () => {
-      let registrations = 0;
       const registerStub = stub(
         (firebase as _FirebaseNamespace).INTERNAL,
         'registerService'
       ).callThrough();
       (firebase as _FirebaseNamespace).INTERNAL.registerService(
         'test',
-        (app: FirebaseApp) => {
-          registrations += 1;
-          return new TestService(app);
-        }
+        (app: FirebaseApp) => new TestService(app)
       );
       firebase.initializeApp({});
-      assert.equal(registrations, 0);
-      const service = (firebase as any).test();
-      assert.equal(registrations, 1);
+      const serviceNamespace = (firebase as any).test;
 
       (firebase as _FirebaseNamespace).INTERNAL.registerService(
         'test',
-        (app: FirebaseApp) => {
-          registrations += 1;
-          return new TestService(app);
-        }
+        (app: FirebaseApp) => new TestService(app)
       );
 
-      const service2 = (firebase as any).test();
-      assert.strictEqual(service, service2);
+      const serviceNamespace2 = (firebase as any).test;
+      assert.strictEqual(serviceNamespace, serviceNamespace2);
       assert.doesNotThrow(registerStub);
     });
 

--- a/packages/app/test/firebaseApp.test.ts
+++ b/packages/app/test/firebaseApp.test.ts
@@ -98,7 +98,7 @@ function executeFirebaseTests(): void {
       );
       firebase.initializeApp({});
       assert.equal(registrations, 0);
-      (firebase as any).test();
+      const service = (firebase as any).test();
       assert.equal(registrations, 1);
 
       (firebase as _FirebaseNamespace).INTERNAL.registerService(
@@ -109,8 +109,8 @@ function executeFirebaseTests(): void {
         }
       );
 
-      (firebase as any).test();
-      assert.equal(registrations, 1);
+      const service2 = (firebase as any).test();
+      assert.strictEqual(service, service2);
     });
 
     it('Can lazy load a service', () => {

--- a/packages/app/test/firebaseApp.test.ts
+++ b/packages/app/test/firebaseApp.test.ts
@@ -24,6 +24,7 @@ import {
 import { createFirebaseNamespace } from '../src/firebaseNamespace';
 import { createFirebaseNamespaceLite } from '../src/lite/firebaseNamespaceLite';
 import { assert } from 'chai';
+import { stub } from 'sinon';
 
 executeFirebaseTests();
 executeFirebaseLiteTests();
@@ -89,6 +90,8 @@ function executeFirebaseTests(): void {
 
     it('Will do nothing if registerService is called again with the same name', () => {
       let registrations = 0;
+      const registerStub =
+        stub((firebase as _FirebaseNamespace).INTERNAL, 'registerService').callThrough();
       (firebase as _FirebaseNamespace).INTERNAL.registerService(
         'test',
         (app: FirebaseApp) => {
@@ -111,6 +114,7 @@ function executeFirebaseTests(): void {
 
       const service2 = (firebase as any).test();
       assert.strictEqual(service, service2);
+      assert.doesNotThrow(registerStub);
     });
 
     it('Can lazy load a service', () => {

--- a/packages/app/test/firebaseApp.test.ts
+++ b/packages/app/test/firebaseApp.test.ts
@@ -90,8 +90,10 @@ function executeFirebaseTests(): void {
 
     it('Will do nothing if registerService is called again with the same name', () => {
       let registrations = 0;
-      const registerStub =
-        stub((firebase as _FirebaseNamespace).INTERNAL, 'registerService').callThrough();
+      const registerStub = stub(
+        (firebase as _FirebaseNamespace).INTERNAL,
+        'registerService'
+      ).callThrough();
       (firebase as _FirebaseNamespace).INTERNAL.registerService(
         'test',
         (app: FirebaseApp) => {


### PR DESCRIPTION
A change needed for when multiple components each internally depend on another component and may each try to register it.