### PR TITLE
Move isShutdown to state expectations

### DIFF
--- a/packages/firestore/test/unit/local/persistence_test_helpers.ts
+++ b/packages/firestore/test/unit/local/persistence_test_helpers.ts
@@ -144,8 +144,8 @@ export async function testMemoryLruPersistence(
 }
 
 /** Clears the persistence in tests */
-export async function clearTestPersistence(): Promise<void> {
-  await IndexedDbPersistence.clearPersistence(TEST_PERSISTENCE_PREFIX);
+export function clearTestPersistence(): Promise<void> {
+  return IndexedDbPersistence.clearPersistence(TEST_PERSISTENCE_PREFIX);
 }
 
 class NoOpSharedClientStateSyncer implements SharedClientStateSyncer {

--- a/packages/firestore/test/unit/specs/spec_builder.ts
+++ b/packages/firestore/test/unit/specs/spec_builder.ts
@@ -395,12 +395,10 @@ export class SpecBuilder {
   }
 
   expectIsShutdown(): this {
-    this.nextStep();
-    this.currentStep = {
-      stateExpect: {
-        isShutdown: true
-      }
-    };
+    this.assertStep('Active target expectation requires previous step');
+    const currentStep = this.currentStep!;
+    currentStep.stateExpect = currentStep.stateExpect || {};
+    currentStep.stateExpect.isShutdown = true;
     return this;
   }
 

--- a/packages/firestore/test/unit/specs/spec_builder.ts
+++ b/packages/firestore/test/unit/specs/spec_builder.ts
@@ -397,7 +397,9 @@ export class SpecBuilder {
   expectIsShutdown(): this {
     this.nextStep();
     this.currentStep = {
-      expectIsShutdown: true
+      stateExpect: {
+        isShutdown: true
+      }
     };
     return this;
   }

--- a/packages/firestore/test/unit/specs/spec_test_runner.ts
+++ b/packages/firestore/test/unit/specs/spec_test_runner.ts
@@ -569,8 +569,6 @@ abstract class TestRunner {
       return this.doRestart();
     } else if ('shutdown' in step) {
       return this.doShutdown();
-    } else if ('expectIsShutdown' in step) {
-      return this.doExpectIsShutdown();
     } else if ('applyClientState' in step) {
       // PORTING NOTE: Only used by web multi-tab tests.
       return this.doApplyClientState(step.applyClientState!);
@@ -885,11 +883,6 @@ abstract class TestRunner {
     this.started = false;
   }
 
-  /** Asserts that the client is shutdown by  */
-  private async doExpectIsShutdown(): Promise<void> {
-    expect(this.started).to.equal(false);
-  }
-
   private async doClearPersistence(): Promise<void> {
     await clearTestPersistence();
   }
@@ -984,6 +977,9 @@ abstract class TestRunner {
       }
       if ('isPrimary' in expectation) {
         expect(this.isPrimaryClient).to.eq(expectation.isPrimary!, 'isPrimary');
+      }
+      if ('isShutdown' in expectation) {
+        expect(this.started).to.equal(!expectation.isShutdown);
       }
     }
 
@@ -1396,9 +1392,6 @@ export interface SpecStep {
   /** Shut down the client and close it network connection. */
   shutdown?: true;
 
-  /** Assert that the firestore client is shutdown. */
-  expectIsShutdown?: true;
-
   /**
    * Optional list of expected events.
    * If not provided, the test will fail if the step causes events to be raised.
@@ -1577,6 +1570,8 @@ export interface StateExpectation {
    * Whether the instance holds the primary lease. Used in multi-client tests.
    */
   isPrimary?: boolean;
+  /** Whether the client is shutdown. */
+  isShutdown?: boolean;
   /**
    * Current expected active targets. Verified in each step until overwritten.
    */


### PR DESCRIPTION
I would like to move the `isShutdown` to the Spec test state expectations. That should help me in my futile attempts to auto-generate spec tests.