### PR TITLE
docs: Remove wbr tags inserted by Typedoc

### DIFF
--- a/scripts/docgen/theme/partials/navigation.hbs
+++ b/scripts/docgen/theme/partials/navigation.hbs
@@ -1,12 +1,12 @@
 {{#if isVisible}}
     {{#if isLabel}}
         <li class="label {{cssClasses}}">
-            <span>{{{wbr title}}}</span>
+            <span>{{{title}}}</span>
         </li>
     {{else}}
         {{#unless isGlobals}}
         <li class="{{#if isInPath}}current{{/if}} {{cssClasses}}">
-            <a href="{{relativeURL url}}">{{{wbr title}}}</a>
+            <a href="{{relativeURL url}}">{{{title}}}</a>
             {{#if isInPath}}
                 {{#if children}}
                     <ul>


### PR DESCRIPTION
Remove `<wbr>` (word break) tags Typedoc automatically inserts into section headings (like method names).  This is invisible in the content body text but when devsite grabs the headings to create the right-side nav menu, it converts these to spaces, which puts spaces into method names. Any section heading that has a real space in it will have that space preserved.