### PR TITLE
Index-Free: Track readTime in the RemoteDocument store

### DIFF
--- a/packages/firestore/src/local/indexeddb_persistence.ts
+++ b/packages/firestore/src/local/indexeddb_persistence.ts
@@ -70,7 +70,6 @@ import { QueryData } from './query_data';
 import { ReferenceSet } from './reference_set';
 import { ClientId } from './shared_client_state';
 import { SimpleDb, SimpleDbStore, SimpleDbTransaction } from './simple_db';
-import { SnapshotVersion } from '../core/snapshot_version';
 
 const LOG_TAG = 'IndexedDbPersistence';
 
@@ -1264,7 +1263,7 @@ export class IndexedDbLruDelegate implements ReferenceDelegate, LruDelegate {
 
     return iteration
       .next(() => PersistencePromise.waitFor(promises))
-      .next(() => changeBuffer.apply(txn, SnapshotVersion.forDeletedDoc()))
+      .next(() => changeBuffer.apply(txn))
       .next(() => documentCount);
   }
 

--- a/packages/firestore/src/local/indexeddb_persistence.ts
+++ b/packages/firestore/src/local/indexeddb_persistence.ts
@@ -70,6 +70,7 @@ import { QueryData } from './query_data';
 import { ReferenceSet } from './reference_set';
 import { ClientId } from './shared_client_state';
 import { SimpleDb, SimpleDbStore, SimpleDbTransaction } from './simple_db';
+import { SnapshotVersion } from '../core/snapshot_version';
 
 const LOG_TAG = 'IndexedDbPersistence';
 
@@ -1263,7 +1264,7 @@ export class IndexedDbLruDelegate implements ReferenceDelegate, LruDelegate {
 
     return iteration
       .next(() => PersistencePromise.waitFor(promises))
-      .next(() => changeBuffer.apply(txn))
+      .next(() => changeBuffer.apply(txn, SnapshotVersion.forDeletedDoc()))
       .next(() => documentCount);
   }
 

--- a/packages/firestore/src/local/indexeddb_remote_document_cache.ts
+++ b/packages/firestore/src/local/indexeddb_remote_document_cache.ts
@@ -462,7 +462,8 @@ export class IndexedDbRemoteDocumentCache implements RemoteDocumentCache {
     }
 
     protected applyChanges(
-      transaction: PersistenceTransaction
+      transaction: PersistenceTransaction,
+      readTime: SnapshotVersion
     ): PersistencePromise<void> {
       const promises: Array<PersistencePromise<void>> = [];
 
@@ -477,7 +478,8 @@ export class IndexedDbRemoteDocumentCache implements RemoteDocumentCache {
         );
         if (maybeDocument) {
           const doc = this.documentCache.serializer.toDbRemoteDocument(
-            maybeDocument
+            maybeDocument,
+            readTime
           );
           const size = dbDocumentSize(doc);
           sizeDelta += size - previousSize!;

--- a/packages/firestore/src/local/indexeddb_remote_document_cache.ts
+++ b/packages/firestore/src/local/indexeddb_remote_document_cache.ts
@@ -462,8 +462,7 @@ export class IndexedDbRemoteDocumentCache implements RemoteDocumentCache {
     }
 
     protected applyChanges(
-      transaction: PersistenceTransaction,
-      readTime: SnapshotVersion
+      transaction: PersistenceTransaction
     ): PersistencePromise<void> {
       const promises: Array<PersistencePromise<void>> = [];
 
@@ -479,7 +478,7 @@ export class IndexedDbRemoteDocumentCache implements RemoteDocumentCache {
         if (maybeDocument) {
           const doc = this.documentCache.serializer.toDbRemoteDocument(
             maybeDocument,
-            readTime
+            this.readTime!
           );
           const size = dbDocumentSize(doc);
           sizeDelta += size - previousSize!;

--- a/packages/firestore/src/local/indexeddb_schema.ts
+++ b/packages/firestore/src/local/indexeddb_schema.ts
@@ -308,7 +308,7 @@ export class DbTimestamp {
 }
 
 /** A timestamp type that can be used in IndexedDb keys. */
-export type DbTimestampKey = number[];
+export type DbTimestampKey = [/* seconds */ number, /* nanos */ number];
 
 // The key for the singleton object in the DbPrimaryClient is a single string.
 export type DbPrimaryClientKey = typeof DbPrimaryClient.key;
@@ -610,7 +610,7 @@ export class DbRemoteDocument {
    * An index that provides access to documents in a collection sorted by read
    * time.
    *
-   * This index is used to allow Index-Free queries to fetch newly changed
+   * This index is used to allow the RemoteDocumentCache to fetch newly changed
    * documents in a collection.
    */
   static collectionReadTimeIndex = 'collectionReadTimeIndex';
@@ -642,11 +642,17 @@ export class DbRemoteDocument {
      */
     public hasCommittedMutations: boolean | undefined,
 
-    /** When the document was read from the backend. */
+    /**
+     * When the document was read from the backend. Undefined for data written
+     * prior to schema version 9.
+     */
     public readTime: DbTimestampKey | undefined,
 
-    /** The path of the collection this document is part of. */
-    public parentPath: string | undefined
+    /**
+     * The path of the collection this document is part of. Undefined for data
+     * written prior to schema version 9.
+     */
+    public parentPath: string[] | undefined
   ) {}
 }
 

--- a/packages/firestore/src/local/indexeddb_schema.ts
+++ b/packages/firestore/src/local/indexeddb_schema.ts
@@ -45,8 +45,10 @@ import { SimpleDbSchemaConverter, SimpleDbTransaction } from './simple_db';
  * 6. Create document global for tracking document cache size.
  * 7. Ensure every cached document has a sentinel row with a sequence number.
  * 8. Add collection-parent index for Collection Group queries.
+ * 9. Change RemoteDocumentChanges store to be keyed by readTime rather than
+ *    an auto-incrementing ID. This is required for Index-Free queries.
  */
-export const SCHEMA_VERSION = 8;
+export const SCHEMA_VERSION = 9;
 
 /** Performs database creation and schema upgrades. */
 export class SchemaConverter implements SimpleDbSchemaConverter {
@@ -61,7 +63,7 @@ export class SchemaConverter implements SimpleDbSchemaConverter {
    */
   createOrUpgrade(
     db: IDBDatabase,
-    txn: SimpleDbTransaction,
+    txn: IDBTransaction,
     fromVersion: number,
     toVersion: number
   ): PersistencePromise<void> {
@@ -71,6 +73,8 @@ export class SchemaConverter implements SimpleDbSchemaConverter {
         toVersion <= SCHEMA_VERSION,
       `Unexpected schema upgrade from v${fromVersion} to v{toVersion}.`
     );
+
+    const simpleDbTransaction = new SimpleDbTransaction(txn);
 
     if (fromVersion < 1 && toVersion >= 1) {
       createPrimaryClientStore(db);
@@ -90,7 +94,7 @@ export class SchemaConverter implements SimpleDbSchemaConverter {
         dropQueryCache(db);
         createQueryCache(db);
       }
-      p = p.next(() => writeEmptyTargetGlobalEntry(txn));
+      p = p.next(() => writeEmptyTargetGlobalEntry(simpleDbTransaction));
     }
 
     if (fromVersion < 4 && toVersion >= 4) {
@@ -101,7 +105,9 @@ export class SchemaConverter implements SimpleDbSchemaConverter {
         // and write them back out. We preserve the existing batch IDs to guarantee
         // consistency with other object stores. Any further mutation batch IDs will
         // be auto-generated.
-        p = p.next(() => upgradeMutationBatchSchemaAndMigrateData(db, txn));
+        p = p.next(() =>
+          upgradeMutationBatchSchemaAndMigrateData(db, simpleDbTransaction)
+        );
       }
 
       p = p.next(() => {
@@ -111,24 +117,31 @@ export class SchemaConverter implements SimpleDbSchemaConverter {
     }
 
     if (fromVersion < 5 && toVersion >= 5) {
-      p = p.next(() => this.removeAcknowledgedMutations(txn));
+      p = p.next(() => this.removeAcknowledgedMutations(simpleDbTransaction));
     }
 
     if (fromVersion < 6 && toVersion >= 6) {
       p = p.next(() => {
         createDocumentGlobalStore(db);
-        return this.addDocumentGlobal(txn);
+        return this.addDocumentGlobal(simpleDbTransaction);
       });
     }
 
     if (fromVersion < 7 && toVersion >= 7) {
-      p = p.next(() => this.ensureSequenceNumbers(txn));
+      p = p.next(() => this.ensureSequenceNumbers(simpleDbTransaction));
     }
 
     if (fromVersion < 8 && toVersion >= 8) {
-      p = p.next(() => this.createCollectionParentIndex(db, txn));
+      p = p.next(() =>
+        this.createCollectionParentIndex(db, simpleDbTransaction)
+      );
     }
 
+    if (fromVersion < 9 && toVersion >= 9) {
+      p = p.next(() => {
+        createRemoteDocumentReadTimeIndex(txn);
+      });
+    }
     return p;
   }
 
@@ -293,6 +306,9 @@ function sentinelKey(path: ResourcePath): DbTargetDocumentKey {
 export class DbTimestamp {
   constructor(public seconds: number, public nanoseconds: number) {}
 }
+
+/** A timestamp type that can be used in IndexedDb keys. */
+export type DbTimestampKey = number[];
 
 // The key for the singleton object in the DbPrimaryClient is a single string.
 export type DbPrimaryClientKey = typeof DbPrimaryClient.key;
@@ -590,6 +606,17 @@ export class DbUnknownDocument {
 export class DbRemoteDocument {
   static store = 'remoteDocuments';
 
+  /**
+   * An index that provides access to documents in a collection sorted by read
+   * time.
+   *
+   * This index is used to allow Index-Free queries to fetch newly changed
+   * documents in a collection.
+   */
+  static collectionReadTimeIndex = 'collectionReadTimeIndex';
+
+  static collectionReadTimeIndexPath = ['parentPath', 'readTime'];
+
   constructor(
     /**
      * Set to an instance of DbUnknownDocument if the data for a document is
@@ -613,7 +640,13 @@ export class DbRemoteDocument {
      * documents are potentially inconsistent with the backend's copy and use
      * the write's commit version as their document version.
      */
-    public hasCommittedMutations: boolean | undefined
+    public hasCommittedMutations: boolean | undefined,
+
+    /** When the document was read from the backend. */
+    public readTime: DbTimestampKey | undefined,
+
+    /** The path of the collection this document is part of. */
+    public parentPath: string | undefined
   ) {}
 }
 
@@ -958,6 +991,19 @@ function createRemoteDocumentChangesStore(db: IDBDatabase): void {
 }
 
 /**
+ * Creates indices on the RemoteDocuments store used for both multi-tab
+ * and Index-Free queries.
+ */
+function createRemoteDocumentReadTimeIndex(txn: IDBTransaction): void {
+  const remoteDocumentStore = txn.objectStore(DbRemoteDocument.store);
+  remoteDocumentStore.createIndex(
+    DbRemoteDocument.collectionReadTimeIndex,
+    DbRemoteDocument.collectionReadTimeIndexPath,
+    { unique: false }
+  );
+}
+
+/**
  * A record of the metadata state of each client.
  *
  * PORTING NOTE: This is used to synchronize multi-tab state and does not need
@@ -1027,6 +1073,8 @@ export const V6_STORES = [...V4_STORES, DbRemoteDocumentGlobal.store];
 // V7 does not change the set of stores.
 
 export const V8_STORES = [...V6_STORES, DbCollectionParent.store];
+
+// V9 does not change the set of stores.
 
 /**
  * The list of all default IndexedDB stores used throughout the SDK. This is

--- a/packages/firestore/src/local/local_serializer.ts
+++ b/packages/firestore/src/local/local_serializer.ts
@@ -76,7 +76,7 @@ export class LocalSerializer {
     readTime: SnapshotVersion
   ): DbRemoteDocument {
     const dbReadTime = this.toDbTimestampKey(readTime);
-    const parentPath = maybeDoc.key.path.popLast().canonicalString();
+    const parentPath = maybeDoc.key.path.popLast().toArray();
     if (maybeDoc instanceof Document) {
       const doc = maybeDoc.proto
         ? maybeDoc.proto
@@ -114,7 +114,7 @@ export class LocalSerializer {
         parentPath
       );
     } else {
-      return fail('Unexpected MaybeDocumment');
+      return fail('Unexpected MaybeDocument');
     }
   }
 

--- a/packages/firestore/src/local/local_store.ts
+++ b/packages/firestore/src/local/local_store.ts
@@ -351,7 +351,7 @@ export class LocalStore {
           .next(() =>
             this.applyWriteToRemoteDocuments(txn, batchResult, documentBuffer)
           )
-          .next(() => documentBuffer.apply(txn, batchResult.commitVersion))
+          .next(() => documentBuffer.apply(txn))
           .next(() => this.mutationQueue.performConsistencyCheck(txn))
           .next(() => this.localDocuments.getDocuments(txn, affected));
       }
@@ -522,7 +522,7 @@ export class LocalStore {
                 (doc.version.compareTo(existingDoc.version) === 0 &&
                   existingDoc.hasPendingWrites)
               ) {
-                documentBuffer.addEntry(doc);
+                documentBuffer.addEntry(doc, remoteVersion);
                 changedDocs = changedDocs.insert(key, doc);
               } else if (
                 doc instanceof NoDocument &&
@@ -582,7 +582,7 @@ export class LocalStore {
         }
 
         return PersistencePromise.waitFor(promises)
-          .next(() => documentBuffer.apply(txn, remoteVersion))
+          .next(() => documentBuffer.apply(txn))
           .next(() => {
             return this.localDocuments.getLocalViewOfDocuments(
               txn,
@@ -863,7 +863,10 @@ export class LocalStore {
                   ' resulted in null'
               );
             } else {
-              documentBuffer.addEntry(doc);
+              // We use the commitVersion as the readTime rather than the
+              // document's updateTime since the updateTime is not advanced
+              // for updates that do not modify the underlying document.
+              documentBuffer.addEntry(doc, batchResult.commitVersion);
             }
           }
         });

--- a/packages/firestore/src/local/memory_persistence.ts
+++ b/packages/firestore/src/local/memory_persistence.ts
@@ -49,6 +49,7 @@ import { PersistencePromise } from './persistence_promise';
 import { QueryData } from './query_data';
 import { ReferenceSet } from './reference_set';
 import { ClientId } from './shared_client_state';
+import { SnapshotVersion } from '../core/snapshot_version';
 
 const LOG_TAG = 'MemoryPersistence';
 
@@ -268,6 +269,7 @@ export class MemoryEagerDelegate implements ReferenceDelegate {
   onTransactionCommitted(
     txn: PersistenceTransaction
   ): PersistencePromise<void> {
+    // Remove newly orphaned documents.
     const cache = this.persistence.getRemoteDocumentCache();
     const changeBuffer = cache.newChangeBuffer();
     return PersistencePromise.forEach(
@@ -281,7 +283,7 @@ export class MemoryEagerDelegate implements ReferenceDelegate {
       }
     ).next(() => {
       this._orphanedDocuments = null;
-      return changeBuffer.apply(txn);
+      return changeBuffer.apply(txn, SnapshotVersion.forDeletedDoc());
     });
   }
 
@@ -419,7 +421,9 @@ export class MemoryLruDelegate implements ReferenceDelegate, LruDelegate {
         }
       });
     });
-    return p.next(() => changeBuffer.apply(txn)).next(() => count);
+    return p
+      .next(() => changeBuffer.apply(txn, SnapshotVersion.forDeletedDoc()))
+      .next(() => count);
   }
 
   removeMutationReference(
@@ -465,7 +469,10 @@ export class MemoryLruDelegate implements ReferenceDelegate, LruDelegate {
   }
 
   documentSize(maybeDoc: MaybeDocument): number {
-    const remoteDocument = this.serializer.toDbRemoteDocument(maybeDoc);
+    const remoteDocument = this.serializer.toDbRemoteDocument(
+      maybeDoc,
+      SnapshotVersion.forDeletedDoc()
+    );
     let value: unknown;
     if (remoteDocument.document) {
       value = remoteDocument.document;

--- a/packages/firestore/src/local/memory_persistence.ts
+++ b/packages/firestore/src/local/memory_persistence.ts
@@ -49,7 +49,6 @@ import { PersistencePromise } from './persistence_promise';
 import { QueryData } from './query_data';
 import { ReferenceSet } from './reference_set';
 import { ClientId } from './shared_client_state';
-import { SnapshotVersion } from '../core/snapshot_version';
 
 const LOG_TAG = 'MemoryPersistence';
 
@@ -283,7 +282,7 @@ export class MemoryEagerDelegate implements ReferenceDelegate {
       }
     ).next(() => {
       this._orphanedDocuments = null;
-      return changeBuffer.apply(txn, SnapshotVersion.forDeletedDoc());
+      return changeBuffer.apply(txn);
     });
   }
 
@@ -421,9 +420,7 @@ export class MemoryLruDelegate implements ReferenceDelegate, LruDelegate {
         }
       });
     });
-    return p
-      .next(() => changeBuffer.apply(txn, SnapshotVersion.forDeletedDoc()))
-      .next(() => count);
+    return p.next(() => changeBuffer.apply(txn)).next(() => count);
   }
 
   removeMutationReference(
@@ -471,7 +468,7 @@ export class MemoryLruDelegate implements ReferenceDelegate, LruDelegate {
   documentSize(maybeDoc: MaybeDocument): number {
     const remoteDocument = this.serializer.toDbRemoteDocument(
       maybeDoc,
-      SnapshotVersion.forDeletedDoc()
+      maybeDoc.version
     );
     let value: unknown;
     if (remoteDocument.document) {

--- a/packages/firestore/src/local/remote_document_change_buffer.ts
+++ b/packages/firestore/src/local/remote_document_change_buffer.ts
@@ -23,6 +23,7 @@ import { ObjectMap } from '../util/obj_map';
 
 import { PersistenceTransaction } from './persistence';
 import { PersistencePromise } from './persistence_promise';
+import { SnapshotVersion } from '../core/snapshot_version';
 
 /**
  * An in-memory buffer of entries to be written to a RemoteDocumentCache.
@@ -59,7 +60,8 @@ export abstract class RemoteDocumentChangeBuffer {
   ): PersistencePromise<NullableMaybeDocumentMap>;
 
   protected abstract applyChanges(
-    transaction: PersistenceTransaction
+    transaction: PersistenceTransaction,
+    readTime: SnapshotVersion
   ): PersistencePromise<void>;
 
   /**
@@ -130,10 +132,13 @@ export abstract class RemoteDocumentChangeBuffer {
    * Applies buffered changes to the underlying RemoteDocumentCache, using
    * the provided transaction.
    */
-  apply(transaction: PersistenceTransaction): PersistencePromise<void> {
+  apply(
+    transaction: PersistenceTransaction,
+    readTime: SnapshotVersion
+  ): PersistencePromise<void> {
     this.assertNotApplied();
     this.changesApplied = true;
-    return this.applyChanges(transaction);
+    return this.applyChanges(transaction, readTime);
   }
 
   /** Helper to assert this.changes is not null  */

--- a/packages/firestore/src/local/remote_document_change_buffer.ts
+++ b/packages/firestore/src/local/remote_document_change_buffer.ts
@@ -47,6 +47,7 @@ export abstract class RemoteDocumentChangeBuffer {
     MaybeDocument | null
   > = new ObjectMap(key => key.toString());
 
+  // The read time to use for all added documents in this change buffer.
   protected readTime: SnapshotVersion | undefined;
 
   private changesApplied = false;
@@ -74,8 +75,9 @@ export abstract class RemoteDocumentChangeBuffer {
   addEntry(maybeDocument: MaybeDocument, readTime: SnapshotVersion): void {
     this.assertNotApplied();
 
-    // Assert that every read time matches since we only track a single read
-    // time per document change set.
+    // Right now (for simplicity) we just track a single readTime for all the
+    // added entries since we expect them to all be the same, but we could
+    // rework to store per-entry readTimes if necessary.
     assert(
       this.readTime === undefined || this.readTime.isEqual(readTime),
       'All changes in a RemoteDocumentChangeBuffer must have the same read time'

--- a/packages/firestore/src/local/simple_db.ts
+++ b/packages/firestore/src/local/simple_db.ts
@@ -108,9 +108,6 @@ export class SimpleDb {
           event.oldVersion
         );
         const db = (event.target as IDBOpenDBRequest).result;
-        // We are provided a version upgrade transaction from the request, so
-        // we wrap that in a SimpleDbTransaction to allow use of our friendlier
-        // API for schema migration operations.
         schemaConverter
           .createOrUpgrade(
             db,

--- a/packages/firestore/src/local/simple_db.ts
+++ b/packages/firestore/src/local/simple_db.ts
@@ -28,7 +28,7 @@ const LOG_TAG = 'SimpleDb';
 export interface SimpleDbSchemaConverter {
   createOrUpgrade(
     db: IDBDatabase,
-    txn: SimpleDbTransaction,
+    txn: IDBTransaction,
     fromVersion: number,
     toVersion: number
   ): PersistencePromise<void>;
@@ -111,9 +111,13 @@ export class SimpleDb {
         // We are provided a version upgrade transaction from the request, so
         // we wrap that in a SimpleDbTransaction to allow use of our friendlier
         // API for schema migration operations.
-        const txn = new SimpleDbTransaction(request.transaction!);
         schemaConverter
-          .createOrUpgrade(db, txn, event.oldVersion, SCHEMA_VERSION)
+          .createOrUpgrade(
+            db,
+            request.transaction!,
+            event.oldVersion,
+            SCHEMA_VERSION
+          )
           .next(() => {
             debug(
               LOG_TAG,

--- a/packages/firestore/test/integration/api/batch_writes.test.ts
+++ b/packages/firestore/test/integration/api/batch_writes.test.ts
@@ -125,6 +125,7 @@ apiDescribe('Database batch writes', (persistence: boolean) => {
   });
 
   it('can delete documents', () => {
+    // TODO(#1865): This test fails with node:persistence against Prod
     return integrationHelpers.withTestDoc(persistence, doc => {
       return doc
         .set({ foo: 'bar' })

--- a/packages/firestore/test/integration/api/database.test.ts
+++ b/packages/firestore/test/integration/api/database.test.ts
@@ -70,6 +70,7 @@ apiDescribe('Database', (persistence: boolean) => {
   });
 
   it('can delete a document', () => {
+    // TODO(#1865): This test fails with node:persistence against Prod
     return withTestDoc(persistence, docRef => {
       return docRef
         .set({ foo: 'bar' })

--- a/packages/firestore/test/unit/local/encoded_resource_path.test.ts
+++ b/packages/firestore/test/unit/local/encoded_resource_path.test.ts
@@ -33,7 +33,7 @@ const sep = '\u0001\u0001';
 class EncodedResourcePathSchemaConverter implements SimpleDbSchemaConverter {
   createOrUpgrade(
     db: IDBDatabase,
-    txn: SimpleDbTransaction,
+    txn: IDBTransaction,
     fromVersion: number,
     toVersion: number
   ): PersistencePromise<void> {

--- a/packages/firestore/test/unit/local/indexeddb_persistence.test.ts
+++ b/packages/firestore/test/unit/local/indexeddb_persistence.test.ts
@@ -52,7 +52,7 @@ import {
 import { LruParams } from '../../../src/local/lru_garbage_collector';
 import { PersistencePromise } from '../../../src/local/persistence_promise';
 import { ClientId } from '../../../src/local/shared_client_state';
-import { SimpleDb } from '../../../src/local/simple_db';
+import { SimpleDb, SimpleDbTransaction } from '../../../src/local/simple_db';
 import { PlatformSupport } from '../../../src/platform/platform';
 import { firestoreV1ApiClientInterfaces } from '../../../src/protos/firestore_proto_api';
 import { JsonProtoSerializer } from '../../../src/remote/serializer';
@@ -173,6 +173,24 @@ function getAllObjectStores(db: IDBDatabase): string[] {
   }
   objectStores.sort();
   return objectStores;
+}
+
+function addDocs(
+  txn: SimpleDbTransaction,
+  keys: string[],
+  version: number
+): PersistencePromise<void> {
+  const remoteDocumentStore = txn.store<DbRemoteDocumentKey, DbRemoteDocument>(
+    DbRemoteDocument.store
+  );
+  return PersistencePromise.forEach(keys, (key: string) => {
+    const remoteDoc = doc(key, version, { data: 'foo' });
+    const dbRemoteDoc = TEST_SERIALIZER.toDbRemoteDocument(
+      remoteDoc,
+      remoteDoc.version
+    );
+    return remoteDocumentStore.put(remoteDoc.key.path.toArray(), dbRemoteDoc);
+  });
 }
 
 describe('IndexedDbSchema: createOrUpgradeDb', () => {
@@ -758,59 +776,70 @@ describe('IndexedDbSchema: createOrUpgradeDb', () => {
       });
     });
 
-    // Migrate to v8 and verify that new documents are indexed.
+    // Migrate to v9 and verify that new documents are indexed.
     await withDb(9, db => {
       const sdb = new SimpleDb(db);
       return sdb.runTransaction('readwrite', V8_STORES, txn => {
-        const remoteDocumentStore = txn.store<
-          DbRemoteDocumentKey,
-          DbRemoteDocument
-        >(DbRemoteDocument.store);
-
         // Verify the existing remote document entries.
-        return PersistencePromise.forEach(existingDocPaths, (path: string) => {
-          const remoteDoc = doc(path, /*version=*/ 1, { data: 1 });
+        return addDocs(txn, existingDocPaths, /* version= */ 1).next(() =>
+          addDocs(txn, newDocPaths, /* version= */ 2).next(() => {
+            const remoteDocumentStore = txn.store<
+              DbRemoteDocumentKey,
+              DbRemoteDocument
+            >(DbRemoteDocument.store);
 
-          return remoteDocumentStore
-            .get(remoteDoc.key.path.toArray())
-            .next(value => {
-              expect(value).to.be.not.null;
-            });
-        })
-          .next(() => {
-            // Add new entries, which will be added to the index.
-            return PersistencePromise.forEach(newDocPaths, (path: string) => {
-              const remoteDoc = doc(path, /*version=*/ 2, { data: 1 });
-              const dbRemoteDoc = TEST_SERIALIZER.toDbRemoteDocument(
-                remoteDoc,
-                remoteDoc.version
-              );
-              return remoteDocumentStore.put(
-                remoteDoc.key.path.toArray(),
-                dbRemoteDoc
-              );
-            });
-          })
-          .next(() => {
-            // Verify that we can get recent changes in a collection filtered by read time.
-            const docsRead: string[] = [];
-            const lastReadTime = TEST_SERIALIZER.toDbTimestampKey(version(0));
+            // Verify that we can get recent changes in a collection filtered by
+            // read time.
+            const lastReadTime = TEST_SERIALIZER.toDbTimestampKey(version(1));
             const range = IDBKeyRange.lowerBound(
-              ['coll2', ...lastReadTime],
+              [['coll2'], lastReadTime],
               true
             );
             return remoteDocumentStore
-              .iterate(
-                { index: DbRemoteDocument.collectionReadTimeIndex, range },
-                (_, dbRemoteDoc) => {
-                  const doc = TEST_SERIALIZER.fromDbRemoteDocument(dbRemoteDoc);
-                  docsRead.push(doc.key.path.toString());
-                }
-              )
-              .next(() => {
-                expect(docsRead).to.have.members(['coll2/doc3', 'coll2/doc4']);
+              .loadAll(DbRemoteDocument.collectionReadTimeIndex, range)
+              .next(docsRead => {
+                const keys = docsRead.map(dbDoc => dbDoc.document!.name);
+                expect(keys).to.have.members([
+                  'projects/test-project/databases/(default)/documents/coll2/doc3',
+                  'projects/test-project/databases/(default)/documents/coll2/doc4'
+                ]);
               });
-          });
+          })
+        );
+      });
+    });
+  });
+
+  it('RemoteDocumentCache can filter documents by read time', async () => {
+    const oldDocPaths = ['coll/doc1', 'coll/doc2'];
+    const newDocPaths = ['coll/doc3', 'coll/doc4'];
+
+    await withDb(9, db => {
+      const sdb = new SimpleDb(db);
+      return sdb.runTransaction('readwrite', V8_STORES, txn => {
+        return addDocs(txn, oldDocPaths, /* version= */ 1).next(() =>
+          addDocs(txn, newDocPaths, /* version= */ 2).next(() => {
+            const remoteDocumentStore = txn.store<
+              DbRemoteDocumentKey,
+              DbRemoteDocument
+            >(DbRemoteDocument.store);
+
+            const lastReadTime = TEST_SERIALIZER.toDbTimestampKey(version(1));
+            const range = IDBKeyRange.lowerBound(
+              [['coll'], lastReadTime],
+              true
+            );
+            return remoteDocumentStore
+              .loadAll(DbRemoteDocument.collectionReadTimeIndex, range)
+              .next(docsRead => {
+                const keys = docsRead.map(dbDoc => dbDoc.document!.name);
+                expect(keys).to.have.members([
+                  'projects/test-project/databases/(default)/documents/coll/doc3',
+                  'projects/test-project/databases/(default)/documents/coll/doc4'
+                ]);
+              });
+          })
+        );
       });
     });
   });

--- a/packages/firestore/test/unit/local/lru_garbage_collector.test.ts
+++ b/packages/firestore/test/unit/local/lru_garbage_collector.test.ts
@@ -255,7 +255,7 @@ function genericLruGarbageCollectorTests(
     const changeBuffer = documentCache.newChangeBuffer();
     return changeBuffer.getEntry(txn, doc.key).next(() => {
       changeBuffer.addEntry(doc);
-      return changeBuffer.apply(txn);
+      return changeBuffer.apply(txn, doc.version);
     });
   }
 

--- a/packages/firestore/test/unit/local/lru_garbage_collector.test.ts
+++ b/packages/firestore/test/unit/local/lru_garbage_collector.test.ts
@@ -254,8 +254,8 @@ function genericLruGarbageCollectorTests(
   ): PersistencePromise<void> {
     const changeBuffer = documentCache.newChangeBuffer();
     return changeBuffer.getEntry(txn, doc.key).next(() => {
-      changeBuffer.addEntry(doc);
-      return changeBuffer.apply(txn, doc.version);
+      changeBuffer.addEntry(doc, doc.version);
+      return changeBuffer.apply(txn);
     });
   }
 

--- a/packages/firestore/test/unit/local/remote_document_change_buffer.test.ts
+++ b/packages/firestore/test/unit/local/remote_document_change_buffer.test.ts
@@ -65,13 +65,13 @@ describe('RemoteDocumentChangeBuffer', () => {
 
   it('can add entry and read it back', async () => {
     const newADoc = doc('coll/a', 43, { new: 'data' });
-    buffer.addEntry(newADoc);
+    buffer.addEntry(newADoc, newADoc.version);
     expectEqual(await buffer.getEntry(key('coll/a')), newADoc);
   });
 
   it('can remove entry', async () => {
     const newADoc = doc('coll/a', 43, { new: 'data' });
-    buffer.addEntry(newADoc);
+    buffer.addEntry(newADoc, newADoc.version);
     expect(await buffer.getEntry(key('coll/a'))).to.not.be.null;
     buffer.removeEntry(newADoc.key);
     expect(await buffer.getEntry(key('coll/a'))).to.be.null;
@@ -81,7 +81,7 @@ describe('RemoteDocumentChangeBuffer', () => {
     const newADoc = doc('coll/a', 43, { new: 'data' });
     // need to read first
     await buffer.getEntry(newADoc.key);
-    buffer.addEntry(newADoc);
+    buffer.addEntry(newADoc, newADoc.version);
     expectEqual(await buffer.getEntry(key('coll/a')), newADoc);
 
     // Reading directly against the cache should still yield the old result.
@@ -106,7 +106,7 @@ describe('RemoteDocumentChangeBuffer', () => {
   it('methods fail after apply.', async () => {
     await buffer.apply();
 
-    expect(() => buffer.addEntry(INITIAL_DOC)).to.throw();
+    expect(() => buffer.addEntry(INITIAL_DOC, INITIAL_DOC.version)).to.throw();
 
     let errors = 0;
     return buffer
@@ -115,5 +115,14 @@ describe('RemoteDocumentChangeBuffer', () => {
       .then(() => buffer.apply())
       .catch(() => errors++)
       .then(() => expect(errors).to.equal(2));
+  });
+
+  it('cannot add documents with different read times', async () => {
+    // This test merely validates an assert that was added to the
+    // RemoteDocumentChangeBuffer to simplify our tracking of document
+    // read times. If we do need to track documents with different read
+    // times, this test should simply be removed.
+    buffer.addEntry(INITIAL_DOC, version(1));
+    expect(() => buffer.addEntry(INITIAL_DOC, version(2))).to.throw();
   });
 });

--- a/packages/firestore/test/unit/local/remote_document_change_buffer.test.ts
+++ b/packages/firestore/test/unit/local/remote_document_change_buffer.test.ts
@@ -17,7 +17,7 @@
 
 import { expect } from 'chai';
 import { IndexedDbPersistence } from '../../../src/local/indexeddb_persistence';
-import { deletedDoc, doc, expectEqual, key } from '../../util/helpers';
+import { deletedDoc, doc, expectEqual, key, version } from '../../util/helpers';
 
 import {
   clearTestPersistence,
@@ -46,7 +46,10 @@ describe('RemoteDocumentChangeBuffer', () => {
       );
 
       // Add a couple initial items to the cache.
-      return cache.addEntries([INITIAL_DOC, deletedDoc('coll/b', 314)]);
+      return cache.addEntries(
+        [INITIAL_DOC, deletedDoc('coll/b', 314)],
+        version(314)
+      );
     });
   });
 

--- a/packages/firestore/test/unit/local/simple_db.test.ts
+++ b/packages/firestore/test/unit/local/simple_db.test.ts
@@ -62,7 +62,7 @@ function isIndexedDbMock(): boolean {
 class TestSchemaConverter implements SimpleDbSchemaConverter {
   createOrUpgrade(
     db: IDBDatabase,
-    txn: SimpleDbTransaction,
+    txn: IDBTransaction,
     fromVersion: number,
     toVersion: number
   ): PersistencePromise<void> {

--- a/packages/firestore/test/unit/local/test_remote_document_cache.ts
+++ b/packages/firestore/test/unit/local/test_remote_document_cache.ts
@@ -16,6 +16,8 @@
  */
 
 import { Query } from '../../../src/core/query';
+import { SnapshotVersion } from '../../../src/core/snapshot_version';
+import { IndexedDbRemoteDocumentCache } from '../../../src/local/indexeddb_remote_document_cache';
 import { Persistence } from '../../../src/local/persistence';
 import { PersistencePromise } from '../../../src/local/persistence_promise';
 import { RemoteDocumentCache } from '../../../src/local/remote_document_cache';
@@ -28,8 +30,6 @@ import {
 } from '../../../src/model/collections';
 import { MaybeDocument } from '../../../src/model/document';
 import { DocumentKey } from '../../../src/model/document_key';
-import { SnapshotVersion } from '../../../src/core/snapshot_version';
-import { IndexedDbRemoteDocumentCache } from '../../../src/local/indexeddb_remote_document_cache';
 
 /**
  * A wrapper around a RemoteDocumentCache that automatically creates a

--- a/packages/firestore/test/unit/local/test_remote_document_change_buffer.ts
+++ b/packages/firestore/test/unit/local/test_remote_document_change_buffer.ts
@@ -19,6 +19,7 @@ import { Persistence } from '../../../src/local/persistence';
 import { RemoteDocumentChangeBuffer } from '../../../src/local/remote_document_change_buffer';
 import { MaybeDocument } from '../../../src/model/document';
 import { DocumentKey } from '../../../src/model/document_key';
+import { SnapshotVersion } from '../../../src/core/snapshot_version';
 
 /**
  * A wrapper around a RemoteDocumentChangeBuffer that automatically creates a
@@ -49,7 +50,7 @@ export class TestRemoteDocumentChangeBuffer {
       'apply',
       'readwrite-primary',
       txn => {
-        return this.buffer.apply(txn);
+        return this.buffer.apply(txn, SnapshotVersion.forDeletedDoc());
       }
     );
   }

--- a/packages/firestore/test/unit/local/test_remote_document_change_buffer.ts
+++ b/packages/firestore/test/unit/local/test_remote_document_change_buffer.ts
@@ -31,8 +31,8 @@ export class TestRemoteDocumentChangeBuffer {
     public buffer: RemoteDocumentChangeBuffer
   ) {}
 
-  addEntry(maybeDocument: MaybeDocument): void {
-    this.buffer.addEntry(maybeDocument);
+  addEntry(maybeDocument: MaybeDocument, readTime: SnapshotVersion): void {
+    this.buffer.addEntry(maybeDocument, readTime);
   }
 
   removeEntry(key: DocumentKey): void {
@@ -50,7 +50,7 @@ export class TestRemoteDocumentChangeBuffer {
       'apply',
       'readwrite-primary',
       txn => {
-        return this.buffer.apply(txn, SnapshotVersion.forDeletedDoc());
+        return this.buffer.apply(txn);
       }
     );
   }


### PR DESCRIPTION
This a loosely based port of https://github.com/firebase/firebase-android-sdk/pull/615 and https://github.com/firebase/firebase-android-sdk/pull/686

It adds a read time index to the Remote Document Store that can be used for Index-Free queries.   I also wasn't able to find good documentation on what happens if I add an index to an existing ObjectStore, but I wrote a test that verifies that this works. 

A follow up PR uses a similar index for the Multi-Tab changelog.