### PR TITLE
Upgrade Firestore Emulator to 1.8.2

### DIFF
--- a/scripts/emulator-testing/emulators/firestore-emulator.ts
+++ b/scripts/emulator-testing/emulators/firestore-emulator.ts
@@ -26,7 +26,7 @@ export class FirestoreEmulator extends Emulator {
       // Use locked version of emulator for test to be deterministic.
       // The latest version can be found from firestore emulator doc:
       // https://firebase.google.com/docs/firestore/security/test-rules-emulator
-      'https://storage.googleapis.com/firebase-preview-drop/emulator/cloud-firestore-emulator-v1.5.0.jar',
+      'https://storage.googleapis.com/firebase-preview-drop/emulator/cloud-firestore-emulator-v1.8.2.jar',
       port
     );
     this.projectId = projectId;


### PR DESCRIPTION
This should fix the CI failure in https://github.com/firebase/firebase-js-sdk/pull/2128

1.5.0 returns the following response to a delete of a non-existing doc:

```
Firestore (6.4.0) [Connection]: GRPC stream sending: { streamToken: <Buffer 30>,
  writes: 
   [ { delete: 'projects/test-emulator/databases/(default)/documents/test-collection/8ZFesMAbTQGIuVox8P17' } ] }
Firestore (6.4.0) [Connection]: GRPC stream received: { writeResults: 
   [ { transformResults: [], updateTime: { seconds: '0', nanos: 0 } } ],
  streamId: '',
  streamToken: <Buffer 31>,
  commitTime: { seconds: '0', nanos: 0 } }
```

I believe newer version now return a proper commit and update time.
