### PR TITLE
Avoid auth triggers if we haven't yet received the initial user.

### DIFF
--- a/packages/firestore/CHANGELOG.md
+++ b/packages/firestore/CHANGELOG.md
@@ -8,6 +8,8 @@
   data from disk.
 - [changed] Improved performance for queries with filters that only return a
   small subset of the documents in a collection.
+- [fixed] Fixed a race condition between authenticating and initializing
+  Firestore that could result in initial writes to the database being dropped.
 
 # 1.4.10
 - [changed] Transactions now perform exponential backoff before retrying.

--- a/packages/firestore/src/api/credentials.ts
+++ b/packages/firestore/src/api/credentials.ts
@@ -135,6 +135,7 @@ export class FirebaseCredentialsProvider implements CredentialsProvider {
 
   /** Tracks the current User. */
   private currentUser: User = User.UNAUTHENTICATED;
+  private receivedInitialUser: boolean = false;
 
   /**
    * Counter used to detect if the token changed while a getToken request was
@@ -151,6 +152,7 @@ export class FirebaseCredentialsProvider implements CredentialsProvider {
     this.tokenListener = () => {
       this.tokenCounter++;
       this.currentUser = this.getUser();
+      this.receivedInitialUser = true;
       if (this.changeListener) {
         this.changeListener(this.currentUser);
       }
@@ -210,7 +212,7 @@ export class FirebaseCredentialsProvider implements CredentialsProvider {
     this.changeListener = changeListener;
 
     // Fire the initial event, but only if we received the initial user
-    if (this.currentUser) {
+    if (this.receivedInitialUser) {
       changeListener(this.currentUser);
     }
   }

--- a/packages/firestore/src/api/credentials.ts
+++ b/packages/firestore/src/api/credentials.ts
@@ -135,7 +135,6 @@ export class FirebaseCredentialsProvider implements CredentialsProvider {
 
   /** Tracks the current User. */
   private currentUser: User = User.UNAUTHENTICATED;
-  private receivedInitialUser: boolean = false;
 
   /**
    * Counter used to detect if the token changed while a getToken request was
@@ -152,12 +151,12 @@ export class FirebaseCredentialsProvider implements CredentialsProvider {
     this.tokenListener = () => {
       this.tokenCounter++;
       this.currentUser = this.getUser();
-      this.receivedInitialUser = true;
       if (this.changeListener) {
         this.changeListener(this.currentUser);
       }
     };
 
+    this.currentUser = this.getUser();
     this.tokenCounter = 0;
 
     // Will fire at least once where we set this.currentUser
@@ -211,10 +210,8 @@ export class FirebaseCredentialsProvider implements CredentialsProvider {
     assert(!this.changeListener, 'Can only call setChangeListener() once.');
     this.changeListener = changeListener;
 
-    // Fire the initial event, but only if we received the initial user
-    if (this.receivedInitialUser) {
-      changeListener(this.currentUser);
-    }
+    // Fire the initial event
+    changeListener(this.currentUser);
   }
 
   removeChangeListener(): void {


### PR DESCRIPTION
https://github.com/firebase/firebase-js-sdk/pull/2078/ altered the
initial state of currentUser from undefined to not undefined, which
caused the if statement to unconditionally evaluate to true. This
results in a race condition that could cause some initial writes to the
database to be dropped.

Fixes https://github.com/firebase/firebase-js-sdk/issues/2135