### PR TITLE
Make IntellJ test runners connect to Emulator

### DIFF
--- a/packages/firestore/.idea/runConfigurations/All_Tests__Emulator_.xml
+++ b/packages/firestore/.idea/runConfigurations/All_Tests__Emulator_.xml
@@ -1,18 +1,19 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="Integration Tests (w/ Mock Persistence)" type="mocha-javascript-test-runner">
+  <configuration default="false" name="All Tests (Emulator)" type="mocha-javascript-test-runner">
     <node-interpreter>project</node-interpreter>
     <node-options />
     <mocha-package>$PROJECT_DIR$/../../node_modules/mocha</mocha-package>
     <working-directory>$PROJECT_DIR$</working-directory>
     <pass-parent-env>true</pass-parent-env>
     <envs>
-      <env name="USE_MOCK_PERSISTENCE" value="YES" />
       <env name="TS_NODE_COMPILER_OPTIONS" value="{&quot;module&quot;:&quot;commonjs&quot;}" />
+      <env name="FIRESTORE_EMULATOR_PORT" value="8080" />
+      <env name="FIRESTORE_EMULATOR_PROJECT_ID" value="xyz-abc-123" />
     </envs>
     <ui>bdd</ui>
-    <extra-mocha-options>--require ts-node/register/type-check --require index.node.ts --require test/util/node_persistence.ts --timeout 5000</extra-mocha-options>
+    <extra-mocha-options>--require ts-node/register/type-check --require index.node.ts --timeout 5000</extra-mocha-options>
     <test-kind>PATTERN</test-kind>
-    <test-pattern>test/integration/{,!(browser)/**/}*.test.ts</test-pattern>
+    <test-pattern>test/{,!(browser)/**/}*.test.ts</test-pattern>
     <method v="2" />
   </configuration>
 </component>

--- a/packages/firestore/.idea/runConfigurations/All_Tests__Emulator_w__Mock_Persistence_.xml
+++ b/packages/firestore/.idea/runConfigurations/All_Tests__Emulator_w__Mock_Persistence_.xml
@@ -1,5 +1,5 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="All Tests (w/ Mock Persistence)" type="mocha-javascript-test-runner">
+  <configuration default="false" name="All Tests (Emulator w/ Mock Persistence)" type="mocha-javascript-test-runner">
     <node-interpreter>project</node-interpreter>
     <node-options />
     <mocha-package>$PROJECT_DIR$/../../node_modules/mocha</mocha-package>
@@ -8,6 +8,8 @@
     <envs>
       <env name="USE_MOCK_PERSISTENCE" value="YES" />
       <env name="TS_NODE_COMPILER_OPTIONS" value="{&quot;module&quot;:&quot;commonjs&quot;}" />
+      <env name="FIRESTORE_EMULATOR_PORT" value="8080" />
+      <env name="FIRESTORE_EMULATOR_PROJECT_ID" value="abc-xyz-123" />
     </envs>
     <ui>bdd</ui>
     <extra-mocha-options>--require ts-node/register/type-check --require index.node.ts --require test/util/node_persistence.ts --timeout 5000</extra-mocha-options>

--- a/packages/firestore/.idea/runConfigurations/Integration_Tests__Emulator_.xml
+++ b/packages/firestore/.idea/runConfigurations/Integration_Tests__Emulator_.xml
@@ -1,5 +1,5 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="All Tests" type="mocha-javascript-test-runner">
+  <configuration default="false" name="Integration Tests (Emulator)" type="mocha-javascript-test-runner">
     <node-interpreter>project</node-interpreter>
     <node-options />
     <mocha-package>$PROJECT_DIR$/../../node_modules/mocha</mocha-package>
@@ -7,11 +7,13 @@
     <pass-parent-env>true</pass-parent-env>
     <envs>
       <env name="TS_NODE_COMPILER_OPTIONS" value="{&quot;module&quot;:&quot;commonjs&quot;}" />
+      <env name="FIRESTORE_EMULATOR_PORT" value="8080" />
+      <env name="FIRESTORE_EMULATOR_PROJECT_ID" value="abc-xyz-123" />
     </envs>
     <ui>bdd</ui>
     <extra-mocha-options>--require ts-node/register/type-check --require index.node.ts --timeout 5000</extra-mocha-options>
     <test-kind>PATTERN</test-kind>
-    <test-pattern>test/{,!(browser)/**/}*.test.ts</test-pattern>
+    <test-pattern>test/integration/{,!(browser)/**/}*.test.ts</test-pattern>
     <method v="2" />
   </configuration>
 </component>

--- a/packages/firestore/.idea/runConfigurations/Integration_Tests__Emulator_w__Mock_Persistence_.xml
+++ b/packages/firestore/.idea/runConfigurations/Integration_Tests__Emulator_w__Mock_Persistence_.xml
@@ -1,15 +1,18 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="Integration Tests" type="mocha-javascript-test-runner">
+  <configuration default="false" name="Integration Tests (Emulator w/ Mock Persistence)" type="mocha-javascript-test-runner">
     <node-interpreter>project</node-interpreter>
     <node-options />
     <mocha-package>$PROJECT_DIR$/../../node_modules/mocha</mocha-package>
     <working-directory>$PROJECT_DIR$</working-directory>
     <pass-parent-env>true</pass-parent-env>
     <envs>
+      <env name="USE_MOCK_PERSISTENCE" value="YES" />
       <env name="TS_NODE_COMPILER_OPTIONS" value="{&quot;module&quot;:&quot;commonjs&quot;}" />
+      <env name="FIRESTORE_EMULATOR_PORT" value="8080" />
+      <env name="FIRESTORE_EMULATOR_PROJECT_ID" value="abc-xyz-123" />
     </envs>
     <ui>bdd</ui>
-    <extra-mocha-options>--require ts-node/register/type-check --require index.node.ts --timeout 5000</extra-mocha-options>
+    <extra-mocha-options>--require ts-node/register/type-check --require index.node.ts --require test/util/node_persistence.ts --timeout 5000</extra-mocha-options>
     <test-kind>PATTERN</test-kind>
     <test-pattern>test/integration/{,!(browser)/**/}*.test.ts</test-pattern>
     <method v="2" />


### PR DESCRIPTION
This matches the AndroidStudio test runners that by default connect to the emulator.