### PR TITLE
Implement Promise finally

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - 8
+  - 10
 cache: yarn
 
 # Define global C++ compiler version

--- a/config/tsconfig.base.json
+++ b/config/tsconfig.base.json
@@ -14,6 +14,7 @@
       "es2015.symbol.wellknown",
       "es2015.core",
       "es2017.object",
+      "es2018.promise"
     ],
     "module": "ES2015",
     "moduleResolution": "node",

--- a/packages/firestore/src/util/async_queue.ts
+++ b/packages/firestore/src/util/async_queue.ts
@@ -167,6 +167,7 @@ class DelayedOperation<T extends unknown> implements CancelablePromise<T> {
   readonly [Symbol.toStringTag]: 'Promise';
   then = this.deferred.promise.then.bind(this.deferred.promise);
   catch = this.deferred.promise.catch.bind(this.deferred.promise);
+  finally = this.deferred.promise.finally.bind(this.deferred.promise);
 
   private handleDelayElapsed(): void {
     this.asyncQueue.enqueueAndForget(() => {

--- a/packages/firestore/src/util/promise.ts
+++ b/packages/firestore/src/util/promise.ts
@@ -23,7 +23,8 @@ export interface Rejecter {
   (reason?: Error): void;
 }
 
-export interface CancelablePromise<T> extends Pick<Promise<T>, Exclude<keyof Promise<T>, 'finally'>> {
+export interface CancelablePromise<T>
+  extends Pick<Promise<T>, Exclude<keyof Promise<T>, 'finally'>> {
   cancel(): void;
 }
 

--- a/packages/firestore/src/util/promise.ts
+++ b/packages/firestore/src/util/promise.ts
@@ -23,8 +23,7 @@ export interface Rejecter {
   (reason?: Error): void;
 }
 
-export interface CancelablePromise<T>
-  extends Pick<Promise<T>, Exclude<keyof Promise<T>, 'finally'>> {
+export interface CancelablePromise<T> extends Promise<T> {
   cancel(): void;
 }
 

--- a/packages/firestore/src/util/promise.ts
+++ b/packages/firestore/src/util/promise.ts
@@ -23,7 +23,7 @@ export interface Rejecter {
   (reason?: Error): void;
 }
 
-export interface CancelablePromise<T> extends Promise<T> {
+export interface CancelablePromise<T> extends Pick<Promise<T>, Exclude<keyof Promise<T>, 'finally'>> {
   cancel(): void;
 }
 


### PR DESCRIPTION
`finally` was added to the latest Promise spec. It [broke our CI](https://travis-ci.org/firebase/firebase-js-sdk/builds/580486955#L690) because `@types/node` is updated and starts using the latest Promise types.

I'm changing the interface to explicitly exclude `finally` to fix the issue.

