### PR TITLE
use non strict mode when generating doc

### DIFF
--- a/scripts/docgen/tsconfig.json
+++ b/scripts/docgen/tsconfig.json
@@ -1,3 +1,6 @@
 {
-  "extends": "../../config/tsconfig.base.json"
+  "extends": "../../config/tsconfig.base.json",
+  "compilerOptions": {
+    "strict": false
+  }
 }


### PR DESCRIPTION
non strict mode generates nicer documentation, so we use non strict mode.

In strict mode, optional parameters have `undefined` as part of its type definition in addition to the `Optional` label.
