### PR TITLE
Index-Free: Persist the lastLimboFreeSnapshot version

### DIFF
--- a/packages/firestore/src/core/view_snapshot.ts
+++ b/packages/firestore/src/core/view_snapshot.ts
@@ -168,8 +168,8 @@ export class ViewSnapshot {
       changes,
       mutatedKeys,
       fromCache,
-      true,
-      false
+      /* syncStateChanged= */ true,
+      /* excludesMetadataChanges= */ false
     );
   }
 

--- a/packages/firestore/src/local/indexeddb_schema.ts
+++ b/packages/firestore/src/local/indexeddb_schema.ts
@@ -787,6 +787,12 @@ export class DbTarget {
      */
     public lastListenSequenceNumber: number,
     /**
+     * Denotes the maximum snapshot version at which the associated query view
+     * contained no limbo documents.  Undefined for data written prior to
+     * schema version 9.
+     */
+    public lastLimboFreeSnapshotVersion: DbTimestamp | undefined,
+    /**
      * The query for this target.
      *
      * Because canonical ids are not unique we must store the actual query. We

--- a/packages/firestore/src/local/local_store.ts
+++ b/packages/firestore/src/local/local_store.ts
@@ -662,14 +662,14 @@ export class LocalStore {
 
             this.localViewReferences.addReferences(
               viewChange.addedKeys,
-              viewChange.targetId
+              targetId
             );
             this.localViewReferences.removeReferences(
               viewChange.removedKeys,
-              viewChange.targetId
+              targetId
             );
 
-            if (viewChange.fromCache) {
+            if (!viewChange.fromCache) {
               const queryData = this.queryDataByTarget[targetId];
               assert(
                 queryData !== undefined,

--- a/packages/firestore/src/local/local_view_changes.ts
+++ b/packages/firestore/src/local/local_view_changes.ts
@@ -27,6 +27,7 @@ import { documentKeySet, DocumentKeySet } from '../model/collections';
 export class LocalViewChanges {
   constructor(
     readonly targetId: TargetId,
+    readonly fromCache: boolean,
     readonly addedKeys: DocumentKeySet,
     readonly removedKeys: DocumentKeySet
   ) {}
@@ -51,6 +52,11 @@ export class LocalViewChanges {
       }
     }
 
-    return new LocalViewChanges(targetId, addedKeys, removedKeys);
+    return new LocalViewChanges(
+      targetId,
+      viewSnapshot.fromCache,
+      addedKeys,
+      removedKeys
+    );
   }
 }

--- a/packages/firestore/src/local/query_data.ts
+++ b/packages/firestore/src/local/query_data.ts
@@ -48,10 +48,18 @@ export class QueryData {
     readonly targetId: TargetId,
     /** The purpose of the query. */
     readonly purpose: QueryPurpose,
-    /** The sequence number of the last transaction during which this query data was modified */
+    /**
+     * The sequence number of the last transaction during which this query data
+     * was modified.
+     */
     readonly sequenceNumber: ListenSequenceNumber,
     /** The latest snapshot version seen for this target. */
     readonly snapshotVersion: SnapshotVersion = SnapshotVersion.MIN,
+    /**
+     * The maximum snapshot version at which the associated query view
+     * contained no limbo documents.
+     */
+    readonly lastLimboFreeSnapshotVersion: SnapshotVersion = SnapshotVersion.MIN,
     /**
      * An opaque, server-assigned token that allows watching a query to be
      * resumed after disconnecting without retransmitting all the data that
@@ -69,6 +77,7 @@ export class QueryData {
       this.purpose,
       sequenceNumber,
       this.snapshotVersion,
+      this.lastLimboFreeSnapshotVersion,
       this.resumeToken
     );
   }
@@ -87,7 +96,26 @@ export class QueryData {
       this.purpose,
       this.sequenceNumber,
       snapshotVersion,
+      this.lastLimboFreeSnapshotVersion,
       resumeToken
+    );
+  }
+
+  /**
+   * Creates a new query data instance with an updated last limbo free
+   * snapshot version number.
+   */
+  withLastLimboFreeSnapshotVersion(
+    lastLimboFreeSnapshotVersion: SnapshotVersion
+  ): QueryData {
+    return new QueryData(
+      this.query,
+      this.targetId,
+      this.purpose,
+      this.sequenceNumber,
+      this.snapshotVersion,
+      lastLimboFreeSnapshotVersion,
+      this.resumeToken
     );
   }
 
@@ -97,6 +125,9 @@ export class QueryData {
       this.purpose === other.purpose &&
       this.sequenceNumber === other.sequenceNumber &&
       this.snapshotVersion.isEqual(other.snapshotVersion) &&
+      this.lastLimboFreeSnapshotVersion.isEqual(
+        other.lastLimboFreeSnapshotVersion
+      ) &&
       this.resumeToken === other.resumeToken &&
       this.query.isEqual(other.query)
     );

--- a/packages/firestore/test/unit/local/local_store.test.ts
+++ b/packages/firestore/test/unit/local/local_store.test.ts
@@ -844,13 +844,21 @@ function genericLocalStoreTests(
       .after(setMutation('foo/baz', { foo: 'baz' }))
       .toContain(doc('foo/bar', 1, { foo: 'bar' }))
       .toContain(doc('foo/baz', 0, { foo: 'baz' }, { hasLocalMutations: true }))
-      .after(localViewChanges(2, { added: ['foo/bar', 'foo/baz'] }))
+      .after(
+        localViewChanges(2, /* fromCache= */ false, {
+          added: ['foo/bar', 'foo/baz']
+        })
+      )
       .after(docUpdateRemoteEvent(doc('foo/bar', 1, { foo: 'bar' }), [], [2]))
       .after(docUpdateRemoteEvent(doc('foo/baz', 2, { foo: 'baz' }), [2]))
       .afterAcknowledgingMutation({ documentVersion: 2 })
       .toContain(doc('foo/bar', 1, { foo: 'bar' }))
       .toContain(doc('foo/baz', 2, { foo: 'baz' }))
-      .after(localViewChanges(2, { removed: ['foo/bar', 'foo/baz'] }))
+      .after(
+        localViewChanges(2, /* fromCache= */ false, {
+          removed: ['foo/bar', 'foo/baz']
+        })
+      )
       .afterReleasingQuery(query)
       .toNotContain('foo/bar')
       .toNotContain('foo/baz')

--- a/packages/firestore/test/unit/remote/node/serializer.test.ts
+++ b/packages/firestore/test/unit/remote/node/serializer.test.ts
@@ -88,7 +88,6 @@ describe('Serializer', () => {
   const proto3JsonSerializer = new JsonProtoSerializer(partition, {
     useProto3Json: true
   });
-  const emptyResumeToken = new Uint8Array(0);
   const protos = loadRawProtos();
 
   // tslint:disable:variable-name
@@ -105,14 +104,7 @@ describe('Serializer', () => {
    * variations on Query.
    */
   function wrapQueryData(query: Query): QueryData {
-    return new QueryData(
-      query,
-      1,
-      QueryPurpose.Listen,
-      2,
-      SnapshotVersion.MIN,
-      emptyResumeToken
-    );
+    return new QueryData(query, 1, QueryPurpose.Listen, 2);
   }
 
   describe('converts value', () => {
@@ -1195,6 +1187,7 @@ describe('Serializer', () => {
           1,
           QueryPurpose.Listen,
           4,
+          SnapshotVersion.MIN,
           SnapshotVersion.MIN,
           new Uint8Array([1, 2, 3])
         )

--- a/packages/firestore/test/unit/specs/spec_test_runner.ts
+++ b/packages/firestore/test/unit/specs/spec_test_runner.ts
@@ -1072,6 +1072,7 @@ abstract class TestRunner {
           QueryPurpose.Listen,
           ARBITRARY_SEQUENCE_NUMBER,
           SnapshotVersion.MIN,
+          SnapshotVersion.MIN,
           expected.resumeToken
         )
       );

--- a/packages/firestore/test/util/helpers.ts
+++ b/packages/firestore/test/util/helpers.ts
@@ -435,6 +435,7 @@ export function limboChanges(changes: {
 
 export function localViewChanges(
   targetId: TargetId,
+  fromCache: boolean,
   changes: { added?: string[]; removed?: string[] }
 ): LocalViewChanges {
   if (!changes.added) {
@@ -453,7 +454,7 @@ export function localViewChanges(
     keyStr => (removedKeys = removedKeys.add(key(keyStr)))
   );
 
-  return new LocalViewChanges(targetId, addedKeys, removedKeys);
+  return new LocalViewChanges(targetId, fromCache, addedKeys, removedKeys);
 }
 
 /** Creates a resume token to match the given snapshot version. */


### PR DESCRIPTION
This PR ports the end state of 

https://github.com/firebase/firebase-android-sdk/pull/771
https://github.com/firebase/firebase-android-sdk/pull/767
https://github.com/firebase/firebase-android-sdk/pull/699
https://github.com/firebase/firebase-android-sdk/pull/616

Since there is a bunch of back and forth in these PRs, I based it on a combined diff: https://gist.github.com/schmidt-sebastian/d6c28b541d48442f19e50f9c78d78d6e