### PR TITLE
Index-Free: Filter document queries by read time

### DIFF
--- a/packages/firestore/src/local/indexeddb_remote_document_cache.ts
+++ b/packages/firestore/src/local/indexeddb_remote_document_cache.ts
@@ -46,7 +46,12 @@ import { PersistenceTransaction } from './persistence';
 import { PersistencePromise } from './persistence_promise';
 import { RemoteDocumentCache } from './remote_document_cache';
 import { RemoteDocumentChangeBuffer } from './remote_document_change_buffer';
-import { SimpleDb, SimpleDbStore, SimpleDbTransaction } from './simple_db';
+import {
+  IterateOptions,
+  SimpleDb,
+  SimpleDbStore,
+  SimpleDbTransaction
+} from './simple_db';
 import { ObjectMap } from '../util/obj_map';
 
 export class IndexedDbRemoteDocumentCache implements RemoteDocumentCache {
@@ -257,7 +262,8 @@ export class IndexedDbRemoteDocumentCache implements RemoteDocumentCache {
 
   getDocumentsMatchingQuery(
     transaction: PersistenceTransaction,
-    query: Query
+    query: Query,
+    sinceReadTime: SnapshotVersion
   ): PersistencePromise<DocumentMap> {
     assert(
       !query.isCollectionGroupQuery(),
@@ -267,12 +273,27 @@ export class IndexedDbRemoteDocumentCache implements RemoteDocumentCache {
 
     const immediateChildrenPathLength = query.path.length + 1;
 
-    // Documents are ordered by key, so we can use a prefix scan to narrow down
-    // the documents we need to match the query against.
-    const startKey = query.path.toArray();
-    const range = IDBKeyRange.lowerBound(startKey);
+    const iterationOptions: IterateOptions = {};
+    if (sinceReadTime.isEqual(SnapshotVersion.MIN)) {
+      // Documents are ordered by key, so we can use a prefix scan to narrow
+      // down the documents we need to match the query against.
+      const startKey = query.path.toArray();
+      iterationOptions.range = IDBKeyRange.lowerBound(startKey);
+    } else {
+      // Execute an index-free query and filter by read time. This is safe
+      // since all document changes to queries that have a
+      // lastLimboFreeSnapshotVersion (`sinceReadTime`) have a read time set.
+      const collectionKey = query.path.toArray();
+      const readTimeKey = this.serializer.toDbTimestampKey(sinceReadTime);
+      iterationOptions.range = IDBKeyRange.lowerBound(
+        [collectionKey, readTimeKey],
+        /* open= */ true
+      );
+      iterationOptions.index = DbRemoteDocument.collectionReadTimeIndex;
+    }
+
     return remoteDocumentsStore(transaction)
-      .iterate({ range }, (key, dbRemoteDoc, control) => {
+      .iterate(iterationOptions, (key, dbRemoteDoc, control) => {
         // The query is actually returning any path that starts with the query
         // path prefix which may include documents in subcollections. For
         // example, a query on 'rooms' will return rooms/abc/messages/xyx but we
@@ -440,6 +461,10 @@ export class IndexedDbRemoteDocumentCache implements RemoteDocumentCache {
           `Cannot modify a document that wasn't read (for ${key})`
         );
         if (maybeDocument) {
+          assert(
+            !this.readTime.isEqual(SnapshotVersion.MIN),
+            'Cannot add a document with a read time of zero'
+          );
           const doc = this.documentCache.serializer.toDbRemoteDocument(
             maybeDocument,
             this.readTime

--- a/packages/firestore/src/local/local_store.ts
+++ b/packages/firestore/src/local/local_store.ts
@@ -819,7 +819,11 @@ export class LocalStore {
    */
   executeQuery(query: Query): Promise<DocumentMap> {
     return this.persistence.runTransaction('Execute query', 'readonly', txn => {
-      return this.localDocuments.getDocumentsMatchingQuery(txn, query);
+      return this.localDocuments.getDocumentsMatchingQuery(
+        txn,
+        query,
+        SnapshotVersion.MIN
+      );
     });
   }
 

--- a/packages/firestore/src/local/remote_document_cache.ts
+++ b/packages/firestore/src/local/remote_document_cache.ts
@@ -28,6 +28,7 @@ import { DocumentKey } from '../model/document_key';
 import { PersistenceTransaction } from './persistence';
 import { PersistencePromise } from './persistence_promise';
 import { RemoteDocumentChangeBuffer } from './remote_document_change_buffer';
+import { SnapshotVersion } from '../core/snapshot_version';
 
 /**
  * Represents cached documents received from the remote backend.
@@ -71,11 +72,14 @@ export interface RemoteDocumentCache {
    * Cached NoDocument entries have no bearing on query results.
    *
    * @param query The query to match documents against.
+   * @param sinceReadTime If not set to SnapshotVersion.MIN, return only
+   *     documents that have been read since this snapshot version (exclusive).
    * @return The set of matching documents.
    */
   getDocumentsMatchingQuery(
     transaction: PersistenceTransaction,
-    query: Query
+    query: Query,
+    sinceReadTime: SnapshotVersion
   ): PersistencePromise<DocumentMap>;
 
   /**

--- a/packages/firestore/test/unit/local/local_store.test.ts
+++ b/packages/firestore/test/unit/local/local_store.test.ts
@@ -759,7 +759,7 @@ function genericLocalStoreTests(
       expectLocalStore()
         .afterAllocatingQuery(query)
         .toReturnTargetId(2)
-        .after(docAddedRemoteEvent(doc('foo/bar', 0, { foo: 'old' }), [2]))
+        .after(docAddedRemoteEvent(doc('foo/bar', 1, { foo: 'old' }), [2]))
         .after(patchMutation('foo/bar', { foo: 'bar' }))
         // Release the query so that our target count goes back to 0 and we are considered
         // up-to-date.
@@ -767,7 +767,7 @@ function genericLocalStoreTests(
         .after(setMutation('foo/bah', { foo: 'bah' }))
         .after(deleteMutation('foo/baz'))
         .toContain(
-          doc('foo/bar', 0, { foo: 'bar' }, { hasLocalMutations: true })
+          doc('foo/bar', 1, { foo: 'bar' }, { hasLocalMutations: true })
         )
         .toContain(
           doc('foo/bah', 0, { foo: 'bah' }, { hasLocalMutations: true })
@@ -800,7 +800,7 @@ function genericLocalStoreTests(
       expectLocalStore()
         .afterAllocatingQuery(query)
         .toReturnTargetId(2)
-        .after(docAddedRemoteEvent(doc('foo/bar', 0, { foo: 'old' }), [2]))
+        .after(docAddedRemoteEvent(doc('foo/bar', 1, { foo: 'old' }), [2]))
         .after(patchMutation('foo/bar', { foo: 'bar' }))
         // Release the query so that our target count goes back to 0 and we are considered
         // up-to-date.
@@ -808,7 +808,7 @@ function genericLocalStoreTests(
         .after(setMutation('foo/bah', { foo: 'bah' }))
         .after(deleteMutation('foo/baz'))
         .toContain(
-          doc('foo/bar', 0, { foo: 'bar' }, { hasLocalMutations: true })
+          doc('foo/bar', 1, { foo: 'bar' }, { hasLocalMutations: true })
         )
         .toContain(
           doc('foo/bah', 0, { foo: 'bah' }, { hasLocalMutations: true })

--- a/packages/firestore/test/unit/local/test_remote_document_cache.ts
+++ b/packages/firestore/test/unit/local/test_remote_document_cache.ts
@@ -107,12 +107,15 @@ export class TestRemoteDocumentCache {
     });
   }
 
-  getDocumentsMatchingQuery(query: Query): Promise<DocumentMap> {
+  getDocumentsMatchingQuery(
+    query: Query,
+    sinceReadTime: SnapshotVersion
+  ): Promise<DocumentMap> {
     return this.persistence.runTransaction(
       'getDocumentsMatchingQuery',
       'readonly',
       txn => {
-        return this.cache.getDocumentsMatchingQuery(txn, query);
+        return this.cache.getDocumentsMatchingQuery(txn, query, sinceReadTime);
       }
     );
   }


### PR DESCRIPTION
This PR adds the ability to getAllDocumentsMatchingQuery() to skip documents older than a given update time. This allows us to only scan for documents that have been modified since the Query's Target Mapping has been persisted.

Port of https://github.com/firebase/firebase-android-sdk/pull/617