### PR TITLE
Expose operation counts from Persistence layer

### DIFF
--- a/packages/firestore/src/core/firestore_client.ts
+++ b/packages/firestore/src/core/firestore_client.ts
@@ -384,7 +384,9 @@ export class FirestoreClient {
    * @returns A promise that will successfully resolve.
    */
   private startMemoryPersistence(): Promise<LruGarbageCollector | null> {
-    this.persistence = MemoryPersistence.createEagerPersistence(this.clientId);
+    this.persistence = MemoryPersistence.createEagerPersistence({
+      clientId: this.clientId
+    });
     this.sharedClientState = new MemorySharedClientState();
     return Promise.resolve(null);
   }

--- a/packages/firestore/src/local/mutation_queue.ts
+++ b/packages/firestore/src/local/mutation_queue.ts
@@ -211,3 +211,6 @@ export interface MutationQueue {
     transaction: PersistenceTransaction
   ): PersistencePromise<void>;
 }
+
+/** The tag used by the StatsCollector. */
+export const MUTATION_QUEUE_STATS_TAG = 'mutations';

--- a/packages/firestore/src/local/remote_document_cache.ts
+++ b/packages/firestore/src/local/remote_document_cache.ts
@@ -113,3 +113,6 @@ export interface RemoteDocumentCache {
    */
   getSize(transaction: PersistenceTransaction): PersistencePromise<number>;
 }
+
+/** The tag used by the StatsCollector. */
+export const REMOTE_DOCUMENT_CACHE_STATS_TAG = 'documents';

--- a/packages/firestore/src/local/simple_query_engine.ts
+++ b/packages/firestore/src/local/simple_query_engine.ts
@@ -46,8 +46,6 @@ export class SimpleQueryEngine implements QueryEngine {
       'setLocalDocumentsView() not called'
     );
 
-    // TODO: Once LocalDocumentsView provides a getCollectionDocuments()
-    // method, we should call that here and then filter the results.
     return this.localDocumentsView!.getDocumentsMatchingQuery(
       transaction,
       query,

--- a/packages/firestore/src/local/stats_collector.ts
+++ b/packages/firestore/src/local/stats_collector.ts
@@ -1,0 +1,95 @@
+/**
+ * @license
+ * Copyright 2019 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Collects the operation count from the persistence layer. Implementing
+ * subclasses can expose this information to measure the efficiency of
+ * persistence operations.
+ *
+ * The only consumer of operation counts is currently the LocalStoreTestCase
+ * (via `AccumulatingStatsCollector`). If you are not interested in the stats,
+ * you can use `newNoOpStatsCollector()` to create a default empty stats
+ * collector.
+ */
+export class StatsCollector {
+  /** Records the number of rows read for the given tag. */
+  recordRowsRead(tag: string, count: number): void {}
+
+  /** Records the number of rows deleted for the given tag. */
+  recordRowsDeleted(tag: string, count: number): void {}
+
+  /** Records the number of rows written for the given tag. */
+  recordRowsWritten(tag: string, count: number): void {}
+
+  /** Creates a stats collector that ignores all calls. */
+  static newNoOpStatsCollector(): StatsCollector {
+    return new StatsCollector();
+  }
+}
+
+/* A test-only collector of operation counts from the persistence layer. */
+export class AccumulatingStatsCollector extends StatsCollector {
+  private rowsRead = new Map<string, number>();
+  private rowsDeleted = new Map<string, number>();
+  private rowsWritten = new Map<string, number>();
+
+  recordRowsRead(tag: string, count: number): void {
+    const currentValue = this.rowsRead.get(tag);
+    this.rowsRead.set(tag, (currentValue || 0) + count);
+  }
+
+  recordRowsDeleted(tag: string, count: number): void {
+    const currentValue = this.rowsRead.get(tag);
+    this.rowsDeleted.set(tag, (currentValue || 0) + count);
+  }
+
+  recordRowsWritten(tag: string, count: number): void {
+    const currentValue = this.rowsRead.get(tag);
+    this.rowsWritten.set(tag, (currentValue || 0) + count);
+  }
+
+  /** Reset all operation counts */
+  reset(): void {
+    this.rowsRead.clear();
+    this.rowsDeleted.clear();
+    this.rowsWritten.clear();
+  }
+
+  /**
+   * Returns the number of rows read for the given tag since the last call to
+   * `reset()`.
+   */
+  getRowsRead(tag: string): number {
+    return this.rowsRead.get(tag) || 0;
+  }
+
+  /**
+   * Returns the number of rows written for the given tag since the last call to
+   * `reset()`.
+   */
+  getRowsWritten(tag: string): number {
+    return this.rowsWritten.get(tag) || 0;
+  }
+
+  /**
+   * Returns the number of rows deleted for the given tag since the last call to
+   * `reset()`.
+   */
+  getRowsDeleted(tag: string): number {
+    return this.rowsDeleted.get(tag) || 0;
+  }
+}

--- a/packages/firestore/test/unit/local/indexeddb_persistence.test.ts
+++ b/packages/firestore/test/unit/local/indexeddb_persistence.test.ts
@@ -49,7 +49,6 @@ import {
   V6_STORES,
   V8_STORES
 } from '../../../src/local/indexeddb_schema';
-import { LruParams } from '../../../src/local/lru_garbage_collector';
 import { PersistencePromise } from '../../../src/local/persistence_promise';
 import { ClientId } from '../../../src/local/shared_client_state';
 import { SimpleDb, SimpleDbTransaction } from '../../../src/local/simple_db';
@@ -126,7 +125,6 @@ async function withCustomPersistence(
     platform,
     queue,
     serializer,
-    lruParams: LruParams.DEFAULT,
     sequenceNumberSyncer: MOCK_SEQUENCE_NUMBER_SYNCER
   });
 

--- a/packages/firestore/test/unit/local/persistence_test_helpers.ts
+++ b/packages/firestore/test/unit/local/persistence_test_helpers.ts
@@ -39,6 +39,7 @@ import {
   SharedClientStateSyncer
 } from '../../../src/local/shared_client_state_syncer';
 import { SimpleDb } from '../../../src/local/simple_db';
+import { StatsCollector } from '../../../src/local/stats_collector';
 import { PlatformSupport } from '../../../src/platform/platform';
 import { JsonProtoSerializer } from '../../../src/remote/serializer';
 import { AsyncQueue } from '../../../src/util/async_queue';
@@ -97,9 +98,10 @@ export async function testIndexedDbPersistence(
   options: {
     dontPurgeData?: boolean;
     synchronizeTabs?: boolean;
+    statsCollector?: StatsCollector;
     queue?: AsyncQueue;
   } = {},
-  lruParams: LruParams = LruParams.DEFAULT
+  lruParams?: LruParams
 ): Promise<IndexedDbPersistence> {
   const queue = options.queue || new AsyncQueue();
   const clientId = AutoId.newId();
@@ -116,23 +118,29 @@ export async function testIndexedDbPersistence(
     queue,
     serializer: JSON_SERIALIZER,
     lruParams,
-    sequenceNumberSyncer: MOCK_SEQUENCE_NUMBER_SYNCER
+    sequenceNumberSyncer: MOCK_SEQUENCE_NUMBER_SYNCER,
+    statsCollector: options.statsCollector
   });
 }
 
 /** Creates and starts a MemoryPersistence instance for testing. */
-export async function testMemoryEagerPersistence(): Promise<MemoryPersistence> {
-  return MemoryPersistence.createEagerPersistence(AutoId.newId());
+export async function testMemoryEagerPersistence(
+  statsCollector?: StatsCollector
+): Promise<MemoryPersistence> {
+  return MemoryPersistence.createEagerPersistence({
+    clientId: AutoId.newId(),
+    statsCollector
+  });
 }
 
 export async function testMemoryLruPersistence(
-  params: LruParams = LruParams.DEFAULT
+  lruParams?: LruParams
 ): Promise<MemoryPersistence> {
-  return MemoryPersistence.createLruPersistence(
-    AutoId.newId(),
-    JSON_SERIALIZER,
-    params
-  );
+  return MemoryPersistence.createLruPersistence({
+    clientId: AutoId.newId(),
+    serializer: JSON_SERIALIZER,
+    lruParams
+  });
 }
 
 /** Clears the persistence in tests */

--- a/packages/firestore/test/unit/local/web_storage_shared_client_state.test.ts
+++ b/packages/firestore/test/unit/local/web_storage_shared_client_state.test.ts
@@ -44,9 +44,9 @@ import { AutoId } from '../../../src/util/misc';
 import * as objUtils from '../../../src/util/obj';
 import { SortedSet } from '../../../src/util/sorted_set';
 import {
-  clearWebStorage,
   TEST_PERSISTENCE_PREFIX,
-  populateWebStorage
+  populateWebStorage,
+  clearWebStorage
 } from './persistence_test_helpers';
 
 const AUTHENTICATED_USER = new User('test');

--- a/packages/firestore/test/unit/specs/spec_test_runner.ts
+++ b/packages/firestore/test/unit/specs/spec_test_runner.ts
@@ -46,7 +46,6 @@ import {
   SchemaConverter
 } from '../../../src/local/indexeddb_schema';
 import { LocalStore } from '../../../src/local/local_store';
-import { LruParams } from '../../../src/local/lru_garbage_collector';
 import { MemoryPersistence } from '../../../src/local/memory_persistence';
 import { Persistence } from '../../../src/local/persistence';
 import { QueryData, QueryPurpose } from '../../../src/local/query_data';
@@ -1190,12 +1189,11 @@ class MemoryTestRunner extends TestRunner {
   ): Promise<Persistence> {
     return Promise.resolve(
       gcEnabled
-        ? MemoryPersistence.createEagerPersistence(this.clientId)
-        : MemoryPersistence.createLruPersistence(
-            this.clientId,
-            serializer,
-            LruParams.DEFAULT
-          )
+        ? MemoryPersistence.createEagerPersistence({ clientId: this.clientId })
+        : MemoryPersistence.createLruPersistence({
+            clientId: this.clientId,
+            serializer
+          })
     );
   }
 }
@@ -1227,7 +1225,6 @@ class IndexedDbTestRunner extends TestRunner {
       platform: this.platform,
       queue: this.queue,
       serializer,
-      lruParams: LruParams.DEFAULT,
       sequenceNumberSyncer: this.sharedClientState
     });
   }


### PR DESCRIPTION
This is a port of https://github.com/firebase/firebase-android-sdk/pull/595

The ultimate goal of this PR is to allow us write unit tests that count how many items are processed during query execution. For this to work, this PR adds a StatsCollector. The RemoteDocumentCache and the MutationQueue have been updated to provide stats for every read, delete and insert operation. I tried to ensure that they counts between the different backing stores would match and added a unit test that ensures that this is true for a small subset of the operations. 

I also changed the way that MemoryPersistence gets initialized to align it a bit closer with IndexedDbPersistence.

There are likely a bunch of issues with the stats accounting that we could either:
- Ignore.
- Uncover by adding more unit test.
- Address by removing the stats accounting for areas of this PR that are not tested.

We could also drop this PR altogether and only do the counting on one platform.