### PR TITLE
Expose operation counts from Persistence layer (take 2)

### DIFF
--- a/packages/firestore/src/local/local_documents_view.ts
+++ b/packages/firestore/src/local/local_documents_view.ts
@@ -48,9 +48,9 @@ import { RemoteDocumentCache } from './remote_document_cache';
  */
 export class LocalDocumentsView {
   constructor(
-    private remoteDocumentCache: RemoteDocumentCache,
-    private mutationQueue: MutationQueue,
-    private indexManager: IndexManager
+    readonly remoteDocumentCache: RemoteDocumentCache,
+    readonly mutationQueue: MutationQueue,
+    readonly indexManager: IndexManager
   ) {}
 
   /**

--- a/packages/firestore/test/unit/local/forwarding_counting_query_engine.ts
+++ b/packages/firestore/test/unit/local/forwarding_counting_query_engine.ts
@@ -27,8 +27,8 @@ import { MutationQueue } from '../../../src/local/mutation_queue';
 
 /**
  * A test-only query engine that forwards all calls to the query engine
- * provided at construction time, but provides access to the number of
- * documents and mutations read.
+ * provided at construction time, while exposing to the number of documents and
+ * mutations read.
  */
 export class ForwardingCountingQueryEngine implements QueryEngine {
   /**
@@ -45,7 +45,7 @@ export class ForwardingCountingQueryEngine implements QueryEngine {
 
   constructor(private readonly queryEngine: QueryEngine) {}
 
-  resetCounts() : void {
+  resetCounts(): void {
     this.mutationsRead = 0;
     this.documentsRead = 0;
   }
@@ -64,9 +64,9 @@ export class ForwardingCountingQueryEngine implements QueryEngine {
 
   setLocalDocumentsView(localDocuments: LocalDocumentsView): void {
     const view = new LocalDocumentsView(
-        this.wrapRemoteDocumentCache(localDocuments.remoteDocumentCache),
-        this.wrapMutationQueue(localDocuments.mutationQueue),
-        localDocuments.indexManager
+      this.wrapRemoteDocumentCache(localDocuments.remoteDocumentCache),
+      this.wrapMutationQueue(localDocuments.mutationQueue),
+      localDocuments.indexManager
     );
 
     return this.queryEngine.setLocalDocumentsView(view);

--- a/packages/firestore/test/unit/local/forwarding_counting_query_engine.ts
+++ b/packages/firestore/test/unit/local/forwarding_counting_query_engine.ts
@@ -1,0 +1,154 @@
+/**
+ * @license
+ * Copyright 2019 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { QueryEngine } from '../../../src/local/query_engine';
+import { LocalDocumentsView } from '../../../src/local/local_documents_view';
+import { PersistenceTransaction } from '../../../src/local/persistence';
+import { Query } from '../../../src/core/query';
+import { SnapshotVersion } from '../../../src/core/snapshot_version';
+import { PersistencePromise } from '../../../src/local/persistence_promise';
+import { DocumentMap } from '../../../src/model/collections';
+import { RemoteDocumentCache } from '../../../src/local/remote_document_cache';
+import { MutationQueue } from '../../../src/local/mutation_queue';
+
+/**
+ * A test-only query engine that forwards all calls to the query engine
+ * provided at construction time, but provides access to the number of
+ * documents and mutations read.
+ */
+export class ForwardingCountingQueryEngine implements QueryEngine {
+  /**
+   * The number of mutations returned by the MutationQueue (since the last call
+   * to `resetCounts()`)
+   */
+  mutationsRead = 0;
+
+  /**
+   * The number of documents returned by the RemoteDocumentCache (since the
+   * last call to `resetCounts()`)
+   */
+  documentsRead = 0;
+
+  constructor(private readonly queryEngine: QueryEngine) {}
+
+  resetCounts() : void {
+    this.mutationsRead = 0;
+    this.documentsRead = 0;
+  }
+
+  getDocumentsMatchingQuery(
+    transaction: PersistenceTransaction,
+    query: Query,
+    sinceReadTime: SnapshotVersion
+  ): PersistencePromise<DocumentMap> {
+    return this.queryEngine.getDocumentsMatchingQuery(
+      transaction,
+      query,
+      sinceReadTime
+    );
+  }
+
+  setLocalDocumentsView(localDocuments: LocalDocumentsView): void {
+    const view = new LocalDocumentsView(
+        this.wrapRemoteDocumentCache(localDocuments.remoteDocumentCache),
+        this.wrapMutationQueue(localDocuments.mutationQueue),
+        localDocuments.indexManager
+    );
+
+    return this.queryEngine.setLocalDocumentsView(view);
+  }
+
+  private wrapRemoteDocumentCache(
+    target: RemoteDocumentCache
+  ): RemoteDocumentCache {
+    return {
+      getDocumentsMatchingQuery: (transaction, query, sinceReadTime) => {
+        return target
+          .getDocumentsMatchingQuery(transaction, query, sinceReadTime)
+          .next(result => {
+            this.documentsRead += result.size;
+            return result;
+          });
+      },
+      getEntries: (transaction, documentKeys) => {
+        return target.getEntries(transaction, documentKeys).next(result => {
+          this.documentsRead += result.size;
+          return result;
+        });
+      },
+      getEntry: (transaction, documentKey) => {
+        return target.getEntry(transaction, documentKey).next(result => {
+          this.documentsRead += result ? 1 : 0;
+          return result;
+        });
+      },
+      getNewDocumentChanges: target.getNewDocumentChanges,
+      getSize: target.getSize,
+      newChangeBuffer: target.newChangeBuffer
+    };
+  }
+
+  private wrapMutationQueue(target: MutationQueue): MutationQueue {
+    return {
+      acknowledgeBatch: target.acknowledgeBatch,
+      addMutationBatch: target.addMutationBatch,
+      checkEmpty: target.checkEmpty,
+      getAllMutationBatches: transaction => {
+        return target.getAllMutationBatches(transaction).next(result => {
+          this.mutationsRead += result.length;
+          return result;
+        });
+      },
+      getAllMutationBatchesAffectingDocumentKey: (transaction, documentKey) => {
+        return target
+          .getAllMutationBatchesAffectingDocumentKey(transaction, documentKey)
+          .next(result => {
+            this.mutationsRead += result.length;
+            return result;
+          });
+      },
+      getAllMutationBatchesAffectingDocumentKeys: (
+        transaction,
+        documentKeys
+      ) => {
+        return target
+          .getAllMutationBatchesAffectingDocumentKeys(transaction, documentKeys)
+          .next(result => {
+            this.mutationsRead += result.length;
+            return result;
+          });
+      },
+      getAllMutationBatchesAffectingQuery: (transaction, query) => {
+        return target
+          .getAllMutationBatchesAffectingQuery(transaction, query)
+          .next(result => {
+            this.mutationsRead += result.length;
+            return result;
+          });
+      },
+      getHighestUnacknowledgedBatchId: target.getHighestUnacknowledgedBatchId,
+      getLastStreamToken: target.getLastStreamToken,
+      getNextMutationBatchAfterBatchId: target.getNextMutationBatchAfterBatchId,
+      lookupMutationBatch: target.lookupMutationBatch,
+      lookupMutationKeys: target.lookupMutationKeys,
+      performConsistencyCheck: target.performConsistencyCheck,
+      removeCachedMutationKeys: target.removeCachedMutationKeys,
+      removeMutationBatch: target.removeMutationBatch,
+      setLastStreamToken: target.setLastStreamToken
+    };
+  }
+}

--- a/packages/firestore/test/unit/local/forwarding_counting_query_engine.ts
+++ b/packages/firestore/test/unit/local/forwarding_counting_query_engine.ts
@@ -29,7 +29,7 @@ import { MutationQueue } from '../../../src/local/mutation_queue';
  * A test-only query engine that forwards all API calls and exposes the number
  * of documents and mutations read.
  */
-export class ForwardingCountingQueryEngine implements QueryEngine {
+export class CountingQueryEngine implements QueryEngine {
   /**
    * The number of mutations returned by the MutationQueue (since the last call
    * to `resetCounts()`)
@@ -72,11 +72,11 @@ export class ForwardingCountingQueryEngine implements QueryEngine {
   }
 
   private wrapRemoteDocumentCache(
-    target: RemoteDocumentCache
+    subject: RemoteDocumentCache
   ): RemoteDocumentCache {
     return {
       getDocumentsMatchingQuery: (transaction, query, sinceReadTime) => {
-        return target
+        return subject
           .getDocumentsMatchingQuery(transaction, query, sinceReadTime)
           .next(result => {
             this.documentsRead += result.size;
@@ -84,36 +84,36 @@ export class ForwardingCountingQueryEngine implements QueryEngine {
           });
       },
       getEntries: (transaction, documentKeys) => {
-        return target.getEntries(transaction, documentKeys).next(result => {
+        return subject.getEntries(transaction, documentKeys).next(result => {
           this.documentsRead += result.size;
           return result;
         });
       },
       getEntry: (transaction, documentKey) => {
-        return target.getEntry(transaction, documentKey).next(result => {
+        return subject.getEntry(transaction, documentKey).next(result => {
           this.documentsRead += result ? 1 : 0;
           return result;
         });
       },
-      getNewDocumentChanges: target.getNewDocumentChanges,
-      getSize: target.getSize,
-      newChangeBuffer: target.newChangeBuffer
+      getNewDocumentChanges: subject.getNewDocumentChanges,
+      getSize: subject.getSize,
+      newChangeBuffer: subject.newChangeBuffer
     };
   }
 
-  private wrapMutationQueue(target: MutationQueue): MutationQueue {
+  private wrapMutationQueue(subject: MutationQueue): MutationQueue {
     return {
-      acknowledgeBatch: target.acknowledgeBatch,
-      addMutationBatch: target.addMutationBatch,
-      checkEmpty: target.checkEmpty,
+      acknowledgeBatch: subject.acknowledgeBatch,
+      addMutationBatch: subject.addMutationBatch,
+      checkEmpty: subject.checkEmpty,
       getAllMutationBatches: transaction => {
-        return target.getAllMutationBatches(transaction).next(result => {
+        return subject.getAllMutationBatches(transaction).next(result => {
           this.mutationsRead += result.length;
           return result;
         });
       },
       getAllMutationBatchesAffectingDocumentKey: (transaction, documentKey) => {
-        return target
+        return subject
           .getAllMutationBatchesAffectingDocumentKey(transaction, documentKey)
           .next(result => {
             this.mutationsRead += result.length;
@@ -124,7 +124,7 @@ export class ForwardingCountingQueryEngine implements QueryEngine {
         transaction,
         documentKeys
       ) => {
-        return target
+        return subject
           .getAllMutationBatchesAffectingDocumentKeys(transaction, documentKeys)
           .next(result => {
             this.mutationsRead += result.length;
@@ -132,22 +132,22 @@ export class ForwardingCountingQueryEngine implements QueryEngine {
           });
       },
       getAllMutationBatchesAffectingQuery: (transaction, query) => {
-        return target
+        return subject
           .getAllMutationBatchesAffectingQuery(transaction, query)
           .next(result => {
             this.mutationsRead += result.length;
             return result;
           });
       },
-      getHighestUnacknowledgedBatchId: target.getHighestUnacknowledgedBatchId,
-      getLastStreamToken: target.getLastStreamToken,
-      getNextMutationBatchAfterBatchId: target.getNextMutationBatchAfterBatchId,
-      lookupMutationBatch: target.lookupMutationBatch,
-      lookupMutationKeys: target.lookupMutationKeys,
-      performConsistencyCheck: target.performConsistencyCheck,
-      removeCachedMutationKeys: target.removeCachedMutationKeys,
-      removeMutationBatch: target.removeMutationBatch,
-      setLastStreamToken: target.setLastStreamToken
+      getHighestUnacknowledgedBatchId: subject.getHighestUnacknowledgedBatchId,
+      getLastStreamToken: subject.getLastStreamToken,
+      getNextMutationBatchAfterBatchId: subject.getNextMutationBatchAfterBatchId,
+      lookupMutationBatch: subject.lookupMutationBatch,
+      lookupMutationKeys: subject.lookupMutationKeys,
+      performConsistencyCheck: subject.performConsistencyCheck,
+      removeCachedMutationKeys: subject.removeCachedMutationKeys,
+      removeMutationBatch: subject.removeMutationBatch,
+      setLastStreamToken: subject.setLastStreamToken
     };
   }
 }

--- a/packages/firestore/test/unit/local/forwarding_counting_query_engine.ts
+++ b/packages/firestore/test/unit/local/forwarding_counting_query_engine.ts
@@ -26,9 +26,8 @@ import { RemoteDocumentCache } from '../../../src/local/remote_document_cache';
 import { MutationQueue } from '../../../src/local/mutation_queue';
 
 /**
- * A test-only query engine that forwards all calls to the query engine
- * provided at construction time, while exposing to the number of documents and
- * mutations read.
+ * A test-only query engine that forwards all API calls and exposes the number
+ * of documents and mutations read.
  */
 export class ForwardingCountingQueryEngine implements QueryEngine {
   /**

--- a/packages/firestore/test/unit/local/local_store.test.ts
+++ b/packages/firestore/test/unit/local/local_store.test.ts
@@ -73,7 +73,7 @@ import {
 } from '../../util/helpers';
 
 import { FieldValue, IntegerValue } from '../../../src/model/field_value';
-import { ForwardingCountingQueryEngine } from './forwarding_counting_query_engine';
+import { CountingQueryEngine } from './forwarding_counting_query_engine';
 import * as persistenceHelpers from './persistence_test_helpers';
 
 class LocalStoreTester {
@@ -84,7 +84,7 @@ class LocalStoreTester {
 
   constructor(
     public localStore: LocalStore,
-    private readonly queryEngine: ForwardingCountingQueryEngine,
+    private readonly queryEngine: CountingQueryEngine,
     readonly gcIsEager: boolean
   ) {}
 
@@ -375,11 +375,11 @@ function genericLocalStoreTests(
 ): void {
   let persistence: Persistence;
   let localStore: LocalStore;
-  let countingQueryEngine: ForwardingCountingQueryEngine;
+  let countingQueryEngine: CountingQueryEngine;
 
   beforeEach(async () => {
     persistence = await getPersistence();
-    countingQueryEngine = new ForwardingCountingQueryEngine(queryEngine);
+    countingQueryEngine = new CountingQueryEngine(queryEngine);
     localStore = new LocalStore(
       persistence,
       countingQueryEngine,

--- a/packages/firestore/test/unit/local/local_store.test.ts
+++ b/packages/firestore/test/unit/local/local_store.test.ts
@@ -73,8 +73,8 @@ import {
 } from '../../util/helpers';
 
 import { FieldValue, IntegerValue } from '../../../src/model/field_value';
-import * as persistenceHelpers from './persistence_test_helpers';
 import { ForwardingCountingQueryEngine } from './forwarding_counting_query_engine';
+import * as persistenceHelpers from './persistence_test_helpers';
 
 class LocalStoreTester {
   private promiseChain: Promise<void> = Promise.resolve();


### PR DESCRIPTION
"Sebastian uses his time wisely."

This is another take on https://github.com/firebase/firebase-js-sdk/pull/2164.

It solves the following issues:
- It doesn't add any stats that are not used/not tested.
- It doesn't add code to the main client.
- It removes the need to plumb a counter through the Persistence layer.
- it reduces the reliance on the exact implementation, but instead focuses more on the result of each operation.
- it gives us a reason to port this back to Android. 