### PR TITLE
Port matchesAllDocuments()

### DIFF
--- a/packages/firestore/src/core/query.ts
+++ b/packages/firestore/src/core/query.ts
@@ -199,6 +199,22 @@ export class Query {
     );
   }
 
+  /**
+   * Returns true if this query does not specify any query constraints that
+   * could remove results.
+   */
+  matchesAllDocuments(): boolean {
+    return (
+      this.filters.length === 0 &&
+      this.limit === null &&
+      this.startAt == null &&
+      this.endAt == null &&
+      (this.explicitOrderBy.length === 0 ||
+        (this.explicitOrderBy.length === 1 &&
+          this.getFirstOrderByField()!.isKeyField()))
+    );
+  }
+
   // TODO(b/29183165): This is used to get a unique string from a query to, for
   // example, use as a dictionary key, but the implementation is subject to
   // collisions. Make it collision-free.

--- a/packages/firestore/src/core/query.ts
+++ b/packages/firestore/src/core/query.ts
@@ -211,7 +211,7 @@ export class Query {
       this.endAt == null &&
       (this.explicitOrderBy.length === 0 ||
         (this.explicitOrderBy.length === 1 &&
-          this.getFirstOrderByField()!.isKeyField()))
+          this.explicitOrderBy[0].field.isKeyField()))
     );
   }
 

--- a/packages/firestore/test/unit/core/query.test.ts
+++ b/packages/firestore/test/unit/core/query.test.ts
@@ -591,4 +591,27 @@ describe('Query', () => {
       orderBy(DOCUMENT_KEY_NAME, 'asc')
     ]);
   });
+
+  it('matchesAllDocuments() considers filters, orders and bounds', () => {
+    const baseQuery = Query.atPath(ResourcePath.fromString('collection'));
+    expect(baseQuery.matchesAllDocuments()).to.be.true;
+
+    let query = baseQuery.addOrderBy(orderBy('__name__'));
+    expect(query.matchesAllDocuments()).to.be.true;
+
+    query = baseQuery.addOrderBy(orderBy('foo'));
+    expect(query.matchesAllDocuments()).to.be.false;
+
+    query = baseQuery.addFilter(filter('foo', '==', 'bar'));
+    expect(query.matchesAllDocuments()).to.be.false;
+
+    query = baseQuery.withLimit(1);
+    expect(query.matchesAllDocuments()).to.be.false;
+
+    query = baseQuery.withStartAt(bound([], true));
+    expect(query.matchesAllDocuments()).to.be.false;
+
+    query = baseQuery.withEndAt(bound([], true));
+    expect(query.matchesAllDocuments()).to.be.false;
+  });
 });


### PR DESCRIPTION
Ports:
- https://github.com/firebase/firebase-android-sdk/blob/master/firebase-firestore/src/main/java/com/google/firebase/firestore/core/Query.java#L123
- https://github.com/firebase/firebase-android-sdk/blob/master/firebase-firestore/src/test/java/com/google/firebase/firestore/core/QueryTest.java#L534

This will be used to opt out Index-Free query processing for queries that match all documents.