### PR TITLE
Fixing Document.toString()

### DIFF
--- a/packages/firestore/src/model/document.ts
+++ b/packages/firestore/src/model/document.ts
@@ -150,7 +150,7 @@ export class Document extends MaybeDocument {
 
   toString(): string {
     return (
-      `Document(${this.key}, ${this.version}, ${this.data.toString()}, ` +
+      `Document(${this.key}, ${this.version}, ${this.data().toString()}, ` +
       `{hasLocalMutations: ${this.hasLocalMutations}}), ` +
       `{hasCommittedMutations: ${this.hasCommittedMutations}})`
     );


### PR DESCRIPTION
This broke when data became data() in https://github.com/firebase/firebase-js-sdk/pull/2115
