### PR TITLE
use Ubuntu 16.04 (Xenial) image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ before_script:
   - yarn build
 
 # Misc Addons/Configs
-dist: trusty
+dist: xenial
 sudo: required
 addons:
   firefox: "66.0"


### PR DESCRIPTION
Google has dropped Ubuntu 14.04 (Trusty) support for Chrome with their latest release today, so we change to use Ubuntu 16.04 (Xenial) image instead.
