### PR TITLE
Change the order of checks in applyRemoteEvent()

### DIFF
--- a/packages/firestore/src/local/local_store.ts
+++ b/packages/firestore/src/local/local_store.ts
@@ -528,7 +528,7 @@ export class LocalStore {
                 // NoDocuments with SnapshotVersion.MIN are used in manufactured
                 // events. We remove these documents from cache since we lost
                 // access.
-                documentBuffer.addEntry(doc);
+                documentBuffer.removeEntry(key);
                 changedDocs = changedDocs.insert(key, doc);
               } else if (
                 existingDoc == null ||
@@ -542,7 +542,7 @@ export class LocalStore {
                 //  !SnapshotVersion.MIN.isEqual(remoteEvent.snapshotVersion),
                 //  'Cannot add a document when the remote version is zero'
                 // );
-                documentBuffer.removeEntry(key);
+                documentBuffer.addEntry(doc);
                 changedDocs = changedDocs.insert(key, doc);
               } else {
                 log.debug(

--- a/packages/firestore/src/local/local_store.ts
+++ b/packages/firestore/src/local/local_store.ts
@@ -536,12 +536,14 @@ export class LocalStore {
                 (doc.version.compareTo(existingDoc.version) === 0 &&
                   existingDoc.hasPendingWrites)
               ) {
-                // TODO(index-free): Comment in this assert when we enable
+                // TODO(index-free): Make this an assert when we enable
                 // Index-Free queries
-                // assert(
-                //  !SnapshotVersion.MIN.isEqual(remoteEvent.snapshotVersion),
-                //  'Cannot add a document when the remote version is zero'
-                // );
+                if (SnapshotVersion.MIN.isEqual(remoteEvent.snapshotVersion)) {
+                  log.error(
+                    LOG_TAG,
+                    'Cannot add a document when the remote version is zero'
+                  );
+                }
                 documentBuffer.addEntry(doc);
                 changedDocs = changedDocs.insert(key, doc);
               } else {

--- a/packages/firestore/test/unit/local/local_store.test.ts
+++ b/packages/firestore/test/unit/local/local_store.test.ts
@@ -239,7 +239,7 @@ class LocalStoreTester {
   toContain(doc: MaybeDocument): LocalStoreTester {
     this.promiseChain = this.promiseChain.then(() => {
       return this.localStore.readDocument(doc.key).then(result => {
-        expectEqual(result, doc);
+        expectEqual(result, doc, `Expected ${result ? result.toString() : null} to match ${doc.toString()}.`);
       });
     });
     return this;

--- a/packages/firestore/test/unit/local/local_store.test.ts
+++ b/packages/firestore/test/unit/local/local_store.test.ts
@@ -239,7 +239,13 @@ class LocalStoreTester {
   toContain(doc: MaybeDocument): LocalStoreTester {
     this.promiseChain = this.promiseChain.then(() => {
       return this.localStore.readDocument(doc.key).then(result => {
-        expectEqual(result, doc, `Expected ${result ? result.toString() : null} to match ${doc.toString()}.`);
+        expectEqual(
+          result,
+          doc,
+          `Expected ${
+            result ? result.toString() : null
+          } to match ${doc.toString()}.`
+        );
       });
     });
     return this;

--- a/packages/firestore/test/unit/local/local_store.test.ts
+++ b/packages/firestore/test/unit/local/local_store.test.ts
@@ -765,7 +765,7 @@ function genericLocalStoreTests(
       expectLocalStore()
         .afterAllocatingQuery(query)
         .toReturnTargetId(2)
-        .after(docAddedRemoteEvent(doc('foo/bar', 0, { foo: 'old' }), [2]))
+        .after(docAddedRemoteEvent(doc('foo/bar', 1, { foo: 'old' }), [2]))
         .after(patchMutation('foo/bar', { foo: 'bar' }))
         // Release the query so that our target count goes back to 0 and we are considered
         // up-to-date.
@@ -773,7 +773,7 @@ function genericLocalStoreTests(
         .after(setMutation('foo/bah', { foo: 'bah' }))
         .after(deleteMutation('foo/baz'))
         .toContain(
-          doc('foo/bar', 0, { foo: 'bar' }, { hasLocalMutations: true })
+          doc('foo/bar', 1, { foo: 'bar' }, { hasLocalMutations: true })
         )
         .toContain(
           doc('foo/bah', 0, { foo: 'bah' }, { hasLocalMutations: true })
@@ -806,7 +806,7 @@ function genericLocalStoreTests(
       expectLocalStore()
         .afterAllocatingQuery(query)
         .toReturnTargetId(2)
-        .after(docAddedRemoteEvent(doc('foo/bar', 0, { foo: 'old' }), [2]))
+        .after(docAddedRemoteEvent(doc('foo/bar', 1, { foo: 'old' }), [2]))
         .after(patchMutation('foo/bar', { foo: 'bar' }))
         // Release the query so that our target count goes back to 0 and we are considered
         // up-to-date.
@@ -814,7 +814,7 @@ function genericLocalStoreTests(
         .after(setMutation('foo/bah', { foo: 'bah' }))
         .after(deleteMutation('foo/baz'))
         .toContain(
-          doc('foo/bar', 0, { foo: 'bar' }, { hasLocalMutations: true })
+          doc('foo/bar', 1, { foo: 'bar' }, { hasLocalMutations: true })
         )
         .toContain(
           doc('foo/bah', 0, { foo: 'bah' }, { hasLocalMutations: true })


### PR DESCRIPTION
If there is a chance that a limbo resolution fails for a document that no longer exists, we could get into a state where we write a document into the RemoteDocumentCache with a snapshot version of zero. By re-ordering the statements, we make sure this does not happen

Port of https://github.com/firebase/firebase-android-sdk/pull/802