### PR TITLE
Add Query to Target ID Map

### DIFF
--- a/packages/firestore/test/unit/local/forwarding_counting_query_engine.ts
+++ b/packages/firestore/test/unit/local/forwarding_counting_query_engine.ts
@@ -141,7 +141,8 @@ export class CountingQueryEngine implements QueryEngine {
       },
       getHighestUnacknowledgedBatchId: subject.getHighestUnacknowledgedBatchId,
       getLastStreamToken: subject.getLastStreamToken,
-      getNextMutationBatchAfterBatchId: subject.getNextMutationBatchAfterBatchId,
+      getNextMutationBatchAfterBatchId:
+        subject.getNextMutationBatchAfterBatchId,
       lookupMutationBatch: subject.lookupMutationBatch,
       lookupMutationKeys: subject.lookupMutationKeys,
       performConsistencyCheck: subject.performConsistencyCheck,


### PR DESCRIPTION
This PR replaces the O(n) loop in getQueryData() with a key lookup in an ObjectMap. This follows the precedent in SyncEngine (and maybe eventually leads us down the path of merging the different query tracking mechanisms).