### PR TITLE
Sort classes properly in doc.

### DIFF
--- a/scripts/docgen/content-sources/js/toc.yaml
+++ b/scripts/docgen/content-sources/js/toc.yaml
@@ -26,12 +26,10 @@ toc:
     path: /docs/reference/js/firebase.auth.AuthCredential
   - title: "AuthError"
     path: /docs/reference/js/firebase.auth.AuthError
-  - title: "AuthSettings"
-    path: /docs/reference/js/firebase.auth.AuthSettings
-  - title: "OAuthCredential"
-    path: /docs/reference/js/firebase.auth.OAuthCredential
   - title: "AuthProvider"
     path: /docs/reference/js/firebase.auth.AuthProvider
+  - title: "AuthSettings"
+    path: /docs/reference/js/firebase.auth.AuthSettings
   - title: "ConfirmationResult"
     path: /docs/reference/js/firebase.auth.ConfirmationResult
   - title: "EmailAuthProvider"
@@ -46,40 +44,43 @@ toc:
     path: /docs/reference/js/firebase.auth.GoogleAuthProvider
   - title: "IdTokenResult"
     path: /docs/reference/js/firebase.auth.IDTokenResult
-  - title: "TwitterAuthProvider"
-    path: /docs/reference/js/firebase.auth.TwitterAuthProvider
+  - title: "OAuthCredential"
+    path: /docs/reference/js/firebase.auth.OAuthCredential
   - title: "OAuthProvider"
     path: /docs/reference/js/firebase.auth.OAuthProvider
   - title: "PhoneAuthProvider"
     path: /docs/reference/js/firebase.auth.PhoneAuthProvider
-  - title: "SAMLAuthProvider"
-    path: /docs/reference/js/firebase.auth.SAMLAuthProvider
   - title: "RecaptchaVerifier"
     path: /docs/reference/js/firebase.auth.RecaptchaVerifier
-  - title: "UserMetadata"
-    path: /docs/reference/js/firebase.auth.UserMetadata
+  - title: "SAMLAuthProvider"
+    path: /docs/reference/js/firebase.auth.SAMLAuthProvider
+  - title: "TwitterAuthProvider"
+    path: /docs/reference/js/firebase.auth.TwitterAuthProvider
   - title: "User"
     path: /docs/reference/js/firebase.User
   - title: "UserInfo"
     path: /docs/reference/js/firebase.UserInfo
+  - title: "UserMetadata"
+    path: /docs/reference/js/firebase.auth.UserMetadata
 
 - title: "firebase.database"
   path: /docs/reference/js/firebase.database
   section:
-  - title: "Database"
-    path: /docs/reference/js/firebase.database.Database
   - title: "DataSnapshot"
     path: /docs/reference/js/firebase.database.DataSnapshot
+  - title: "Database"
+    path: /docs/reference/js/firebase.database.Database
   - title: "OnDisconnect"
     path: /docs/reference/js/firebase.database.OnDisconnect
+  - title: "Query"
+    path: /docs/reference/js/firebase.database.Query
   - title: "Reference"
     path: /docs/reference/js/firebase.database.Reference
   - title: "ServerValue"
     path: /docs/reference/js/firebase.database.ServerValue
   - title: "ThenableReference"
     path: /docs/reference/js/firebase.database.ThenableReference
-  - title: "Query"
-    path: /docs/reference/js/firebase.database.Query
+
 - title: "firebase.firestore"
   path: /docs/reference/js/firebase.firestore
   section:
@@ -167,21 +168,21 @@ toc:
 - title: "firebase.storage"
   path: /docs/reference/js/firebase.storage
   section:
-  - title: "Storage"
-    path: /docs/reference/js/firebase.storage.Storage
   - title: "FullMetadata"
     path: /docs/reference/js/firebase.storage.FullMetadata
+  - title: "ListOptions"
+    path: /docs/reference/js/firebase.storage.ListOptions
+  - title: "ListResult"
+    path: /docs/reference/js/firebase.storage.ListResult
   - title: "Reference"
     path: /docs/reference/js/firebase.storage.Reference
   - title: "SettableMetadata"
     path: /docs/reference/js/firebase.storage.SettableMetadata
+  - title: "Storage"
+    path: /docs/reference/js/firebase.storage.Storage
   - title: "UploadMetadata"
     path: /docs/reference/js/firebase.storage.UploadMetadata
   - title: "UploadTask"
     path: /docs/reference/js/firebase.storage.UploadTask
   - title: "UploadTaskSnapshot"
     path: /docs/reference/js/firebase.storage.UploadTaskSnapshot
-  - title: "ListOptions"
-    path: /docs/reference/js/firebase.storage.ListOptions
-  - title: "ListResult"
-    path: /docs/reference/js/firebase.storage.ListResult

--- a/scripts/docgen/content-sources/node/toc.yaml
+++ b/scripts/docgen/content-sources/node/toc.yaml
@@ -26,12 +26,10 @@ toc:
     path: /docs/reference/node/firebase.auth.AuthCredential
   - title: "AuthError"
     path: /docs/reference/node/firebase.auth.AuthError
-  - title: "AuthSettings"
-    path: /docs/reference/node/firebase.auth.AuthSettings
-  - title: "OAuthCredential"
-    path: /docs/reference/node/firebase.auth.OAuthCredential
   - title: "AuthProvider"
     path: /docs/reference/node/firebase.auth.AuthProvider
+  - title: "AuthSettings"
+    path: /docs/reference/node/firebase.auth.AuthSettings
   - title: "ConfirmationResult"
     path: /docs/reference/node/firebase.auth.ConfirmationResult
   - title: "EmailAuthProvider"
@@ -46,38 +44,40 @@ toc:
     path: /docs/reference/node/firebase.auth.GoogleAuthProvider
   - title: "IdTokenResult"
     path: /docs/reference/node/firebase.auth.IDTokenResult
-  - title: "TwitterAuthProvider"
-    path: /docs/reference/node/firebase.auth.TwitterAuthProvider
+  - title: "OAuthCredential"
+    path: /docs/reference/node/firebase.auth.OAuthCredential
   - title: "OAuthProvider"
     path: /docs/reference/node/firebase.auth.OAuthProvider
   - title: "PhoneAuthProvider"
     path: /docs/reference/node/firebase.auth.PhoneAuthProvider
   - title: "SAMLAuthProvider"
     path: /docs/reference/node/firebase.auth.SAMLAuthProvider
-  - title: "UserMetadata"
-    path: /docs/reference/node/firebase.auth.UserMetadata
+  - title: "TwitterAuthProvider"
+    path: /docs/reference/node/firebase.auth.TwitterAuthProvider
   - title: "User"
     path: /docs/reference/node/firebase.User
   - title: "UserInfo"
     path: /docs/reference/node/firebase.UserInfo
+  - title: "UserMetadata"
+    path: /docs/reference/node/firebase.auth.UserMetadata
 
 - title: "firebase.database"
   path: /docs/reference/node/firebase.database
   section:
-  - title: "Database"
-    path: /docs/reference/node/firebase.database.Database
   - title: "DataSnapshot"
     path: /docs/reference/node/firebase.database.DataSnapshot
+  - title: "Database"
+    path: /docs/reference/node/firebase.database.Database
   - title: "OnDisconnect"
     path: /docs/reference/node/firebase.database.OnDisconnect
+  - title: "Query"
+    path: /docs/reference/node/firebase.database.Query
   - title: "Reference"
     path: /docs/reference/node/firebase.database.Reference
   - title: "ServerValue"
     path: /docs/reference/node/firebase.database.ServerValue
   - title: "ThenableReference"
     path: /docs/reference/node/firebase.database.ThenableReference
-  - title: "Query"
-    path: /docs/reference/node/firebase.database.Query
 
 - title: "firebase.firestore"
   path: /docs/reference/node/firebase.firestore


### PR DESCRIPTION
The ordering currently doesn't make sense:
https://firebase.google.com/docs/reference/js/firebase.auth
https://firebase.google.com/docs/reference/js/firebase.storage

This fixes b/141303832.

