### PR TITLE
correct package name for remote-config

### DIFF
--- a/packages/remote-config/README.md
+++ b/packages/remote-config/README.md
@@ -1,4 +1,4 @@
-# @firebase/remoteconfig
+# @firebase/remote-config
 
 This is the [Remote Config](https://firebase.google.com/docs/remote-config/) component of the
 [Firebase JS SDK](https://www.npmjs.com/package/firebase).


### PR DESCRIPTION
The package name is wrong in README.md. This pr corrects it.