### PR TITLE
Fixed default timeout for uploads

### DIFF
--- a/packages/storage/src/implementation/constants.ts
+++ b/packages/storage/src/implementation/constants.ts
@@ -40,7 +40,7 @@ export const DEFAULT_MAX_OPERATION_RETRY_TIME: number = 2 * 60 * 1000;
  *
  * The timeout for upload.
  */
-export const DEFAULT_MAX_UPLOAD_RETRY_TIME: number = 10 * 60 * 100;
+export const DEFAULT_MAX_UPLOAD_RETRY_TIME: number = 10 * 60 * 1000;
 
 /**
  * This is the value of Number.MIN_SAFE_INTEGER, which is not well supported


### PR DESCRIPTION
It seems like there was a missing zero for the milliseconds, which resulted in the max time being one minute instead of ten.
