### PR TITLE
Treat empty maps correctly in Document.get()

### DIFF
--- a/packages/firestore/CHANGELOG.md
+++ b/packages/firestore/CHANGELOG.md
@@ -1,4 +1,9 @@
-# Unreleased (1.5.0)
+# Unreleased
+- [fixed] Fixed a regression that caused queries with nested field filters to
+  crash the client if the field was not present in the local copy of the
+  document. 
+
+# 1.5.0
 - [feature] Added a `Firestore.waitForPendingWrites()` method that
   allows users to wait until all pending writes are acknowledged by the
   Firestore backend.

--- a/packages/firestore/src/model/document.ts
+++ b/packages/firestore/src/model/document.ts
@@ -120,7 +120,7 @@ export class Document extends MaybeDocument {
   data(): ObjectValue {
     if (!this.objectValue) {
       let result = ObjectValue.EMPTY;
-      obj.forEach(this.proto!.fields, (key: string, value: api.Value) => {
+      obj.forEach(this.proto!.fields || {}, (key: string, value: api.Value) => {
         result = result.set(new FieldPath([key]), this.converter!(value));
       });
       this.objectValue = result;
@@ -170,11 +170,11 @@ export class Document extends MaybeDocument {
       'Can only call getProtoField() when proto is defined'
     );
 
-    let protoValue: api.Value | undefined = this.proto!.fields[
-      path.firstSegment()
-    ];
+    let protoValue: api.Value | undefined = this.proto!.fields
+      ? this.proto!.fields[path.firstSegment()]
+      : undefined;
     for (let i = 1; i < path.length; ++i) {
-      if (!protoValue || !protoValue.mapValue) {
+      if (!protoValue || !protoValue.mapValue || !protoValue.mapValue.fields) {
         return undefined;
       }
       protoValue = protoValue.mapValue.fields[path.get(i)];

--- a/packages/firestore/src/protos/firestore_proto_api.d.ts
+++ b/packages/firestore/src/protos/firestore_proto_api.d.ts
@@ -22,8 +22,10 @@
    @typescript-eslint/interface-name-prefix,  @typescript-eslint/class-name-casing 
 */
 export declare type ApiClientHookFactory = any;
-export declare type ApiClientObjectMap<T> = { [k: string]: T };
 export declare type PromiseRequestService = any;
+export interface ApiClientObjectMap<T>  {
+  [k: string]: T
+}
 
 export declare type CompositeFilterOp = 'OPERATOR_UNSPECIFIED' | 'AND';
 export interface ICompositeFilterOpEnum {

--- a/packages/firestore/src/protos/firestore_proto_api.d.ts
+++ b/packages/firestore/src/protos/firestore_proto_api.d.ts
@@ -22,7 +22,7 @@
    @typescript-eslint/interface-name-prefix,  @typescript-eslint/class-name-casing 
 */
 export declare type ApiClientHookFactory = any;
-export declare type ApiClientObjectMap<T> = any;
+export declare type ApiClientObjectMap<T> = { [k: string]: T };
 export declare type PromiseRequestService = any;
 
 export declare type CompositeFilterOp = 'OPERATOR_UNSPECIFIED' | 'AND';

--- a/packages/firestore/src/protos/firestore_proto_api.d.ts
+++ b/packages/firestore/src/protos/firestore_proto_api.d.ts
@@ -23,8 +23,8 @@
 */
 export declare type ApiClientHookFactory = any;
 export declare type PromiseRequestService = any;
-export interface ApiClientObjectMap<T>  {
-  [k: string]: T
+export interface ApiClientObjectMap<T> {
+  [k: string]: T;
 }
 
 export declare type CompositeFilterOp = 'OPERATOR_UNSPECIFIED' | 'AND';

--- a/packages/firestore/test/integration/api/query.test.ts
+++ b/packages/firestore/test/integration/api/query.test.ts
@@ -819,4 +819,20 @@ apiDescribe('Queries', (persistence: boolean) => {
       }
     });
   });
+
+  it('can use filter with nested field', () => {
+    // Reproduces https://github.com/firebase/firebase-js-sdk/issues/2204
+    const testDocs = {
+      a: {},
+      b: { map: {} },
+      c: { map: { nested: {} } },
+      d: { map: { nested: 'foo' } }
+    };
+
+    return withTestCollection(persistence, testDocs, async coll => {
+      await coll.get(); // Populate the cache
+      const snapshot = await coll.where('map.nested', '==', 'foo').get();
+      expect(toDataArray(snapshot)).to.deep.equal([{ map: { nested: 'foo' } }]);
+    });
+  });
 });


### PR DESCRIPTION
Fixes https://github.com/firebase/firebase-js-sdk/issues/2204

This fixes the types for MapValue.fields  so that tslint catches undefined violations and removes the violation in `getProtoField` that caused https://github.com/firebase/firebase-js-sdk/issues/2204

Note that is seems pretty involved to write a test for this since this code is only hit in Query processing and not in DocumentSnapshot.get() (see https://github.com/firebase/firebase-js-sdk/blob/4016987a72fa87eea5171dd718d20f9e5dde8123/packages/firestore/src/api/database.ts#L1346). If requested, I can add this test next week.