### PR TITLE
Allow leading zeros in tryParseInt

### DIFF
--- a/packages/database/CHANGELOG.md
+++ b/packages/database/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Unreleased
+- [fixed] Fixed an issue that caused large numeric values with leading zeros to
+  not always be sorted correctly.
+
 - [changed] Internal cleanup to Node.JS support.
 
 # 6.4.0

--- a/packages/database/src/core/util/util.ts
+++ b/packages/database/src/core/util/util.ts
@@ -546,7 +546,7 @@ export const errorForServerCode = function(code: string, query: Query): Error {
  * @type {RegExp}
  * @private
  */
-export const INTEGER_REGEXP_ = new RegExp('^-?\\d{1,10}$');
+export const INTEGER_REGEXP_ = new RegExp('^-?(0*)\\d{1,10}$');
 
 /**
  * If the string contains a 32-bit integer, return it.  Else return null.

--- a/packages/database/test/path.test.ts
+++ b/packages/database/test/path.test.ts
@@ -20,8 +20,8 @@ import { Path } from '../src/core/util/Path';
 
 describe('Path Tests', function() {
   const expectGreater = function(left, right) {
-    expect(Path.comparePaths(new Path(left), new Path(right))).to.equal(1);
-    expect(Path.comparePaths(new Path(right), new Path(left))).to.equal(-1);
+    expect(Path.comparePaths(new Path(left), new Path(right))).to.be.greaterThan(0)
+    expect(Path.comparePaths(new Path(right), new Path(left))).to.be.lessThan(0);
   };
 
   const expectEqual = function(left, right) {
@@ -117,5 +117,6 @@ describe('Path Tests', function() {
     expectGreater('/ab', '/a');
     expectGreater('/a/b', '/a');
     expectGreater('/a/b', '/a//');
+    expectGreater('/a/0971500000', '/a/00403311635');
   });
 });

--- a/packages/database/test/path.test.ts
+++ b/packages/database/test/path.test.ts
@@ -20,8 +20,12 @@ import { Path } from '../src/core/util/Path';
 
 describe('Path Tests', function() {
   const expectGreater = function(left, right) {
-    expect(Path.comparePaths(new Path(left), new Path(right))).to.be.greaterThan(0)
-    expect(Path.comparePaths(new Path(right), new Path(left))).to.be.lessThan(0);
+    expect(
+      Path.comparePaths(new Path(left), new Path(right))
+    ).to.be.greaterThan(0);
+    expect(Path.comparePaths(new Path(right), new Path(left))).to.be.lessThan(
+      0
+    );
   };
 
   const expectEqual = function(left, right) {


### PR DESCRIPTION
Fixes https://buganizer.corp.google.com/issues/141298281

A customer noticed that we don't correctly order their documents. Some of their documents are using keys of the form "00x", where x is a 9 digit number. Our number check only allows for ten digits, and leading zeros can break this limit. This PR relaxes the check and matches the backend semantics.