### PR TITLE
Split `Query` into `Query` and `Target`.

### DIFF
--- a/packages/firestore/src/api/database.ts
+++ b/packages/firestore/src/api/database.ts
@@ -633,7 +633,7 @@ export class Firestore implements firestore.FirebaseFirestore, FirebaseService {
     }
     this.ensureClientConfigured();
     return new Query(
-      new InternalQuery(ResourcePath.EMPTY_PATH, collectionId),
+      InternalQuery.newQuery(ResourcePath.EMPTY_PATH, collectionId),
       this
     );
   }

--- a/packages/firestore/src/core/firestore_client.ts
+++ b/packages/firestore/src/core/firestore_client.ts
@@ -583,7 +583,7 @@ export class FirestoreClient {
     this.verifyNotTerminated();
     return this.asyncQueue
       .enqueue(() => {
-        return this.localStore.executeQuery(query);
+        return this.localStore.executeTargetQuery(query.toTarget());
       })
       .then((docs: DocumentMap) => {
         const remoteKeys: DocumentKeySet = documentKeySet();

--- a/packages/firestore/src/core/target.ts
+++ b/packages/firestore/src/core/target.ts
@@ -1,0 +1,446 @@
+/**
+ * @license
+ * Copyright 2019 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Document } from '../model/document';
+import { DocumentKey } from '../model/document_key';
+import { FieldPath, ResourcePath } from '../model/path';
+import { assert } from '../util/assert';
+import { isNullOrUndefined } from '../util/types';
+import {
+  OrderBy,
+  Bound,
+  Direction,
+  FieldFilter,
+  Filter,
+  Operator,
+  Query,
+  KEY_ORDERING_ASC,
+  KEY_ORDERING_DESC
+} from './query';
+
+export class Target {
+  static atPath(path: ResourcePath): Target {
+    return new Target(path);
+  }
+
+  private memoizedCanonicalId: string | null = null;
+  private memoizedOrderBy: OrderBy[] | null = null;
+
+  /**
+   * Initializes a Target with a path and optional additional query constraints.
+   * Path must currently be empty if this is a collection group query.
+   */
+  constructor(
+    readonly path: ResourcePath,
+    readonly collectionGroup: string | null = null,
+    readonly explicitOrderBy: OrderBy[] = [],
+    readonly filters: Filter[] = [],
+    readonly limit: number | null = null,
+    readonly startAt: Bound | null = null,
+    readonly endAt: Bound | null = null
+  ) {
+    if (this.startAt) {
+      this.assertValidBound(this.startAt);
+    }
+    if (this.endAt) {
+      this.assertValidBound(this.endAt);
+    }
+  }
+
+  get orderBy(): OrderBy[] {
+    if (this.memoizedOrderBy === null) {
+      const inequalityField = this.getInequalityFilterField();
+      const firstOrderByField = this.getFirstOrderByField();
+      if (inequalityField !== null && firstOrderByField === null) {
+        // In order to implicitly add key ordering, we must also add the
+        // inequality filter field for it to be a valid query.
+        // Note that the default inequality field and key ordering is ascending.
+        if (inequalityField.isKeyField()) {
+          this.memoizedOrderBy = [KEY_ORDERING_ASC];
+        } else {
+          this.memoizedOrderBy = [
+            new OrderBy(inequalityField),
+            KEY_ORDERING_ASC
+          ];
+        }
+      } else {
+        assert(
+          inequalityField === null ||
+            (firstOrderByField !== null &&
+              inequalityField.isEqual(firstOrderByField)),
+          'First orderBy should match inequality field.'
+        );
+        this.memoizedOrderBy = [];
+        let foundKeyOrdering = false;
+        for (const orderBy of this.explicitOrderBy) {
+          this.memoizedOrderBy.push(orderBy);
+          if (orderBy.field.isKeyField()) {
+            foundKeyOrdering = true;
+          }
+        }
+        if (!foundKeyOrdering) {
+          // The order of the implicit key ordering always matches the last
+          // explicit order by
+          const lastDirection =
+            this.explicitOrderBy.length > 0
+              ? this.explicitOrderBy[this.explicitOrderBy.length - 1].dir
+              : Direction.ASCENDING;
+          this.memoizedOrderBy.push(
+            lastDirection === Direction.ASCENDING
+              ? KEY_ORDERING_ASC
+              : KEY_ORDERING_DESC
+          );
+        }
+      }
+    }
+    return this.memoizedOrderBy;
+  }
+
+  addFilter(filter: Filter): Target {
+    assert(
+      this.getInequalityFilterField() == null ||
+        !(filter instanceof FieldFilter) ||
+        !filter.isInequality() ||
+        filter.field.isEqual(this.getInequalityFilterField()!),
+      'Target must only have one inequality field.'
+    );
+
+    assert(!this.isDocumentQuery(), 'No filtering allowed for document query');
+
+    const newFilters = this.filters.concat([filter]);
+    return new Target(
+      this.path,
+      this.collectionGroup,
+      this.explicitOrderBy.slice(),
+      newFilters,
+      this.limit,
+      this.startAt,
+      this.endAt
+    );
+  }
+
+  addOrderBy(orderBy: OrderBy): Target {
+    assert(!this.startAt && !this.endAt, 'Bounds must be set after orderBy');
+    // TODO(dimond): validate that orderBy does not list the same key twice.
+    const newOrderBy = this.explicitOrderBy.concat([orderBy]);
+    return new Target(
+      this.path,
+      this.collectionGroup,
+      newOrderBy,
+      this.filters.slice(),
+      this.limit,
+      this.startAt,
+      this.endAt
+    );
+  }
+
+  withLimit(limit: number | null): Target {
+    return new Target(
+      this.path,
+      this.collectionGroup,
+      this.explicitOrderBy.slice(),
+      this.filters.slice(),
+      limit,
+      this.startAt,
+      this.endAt
+    );
+  }
+
+  withStartAt(bound: Bound): Target {
+    return new Target(
+      this.path,
+      this.collectionGroup,
+      this.explicitOrderBy.slice(),
+      this.filters.slice(),
+      this.limit,
+      bound,
+      this.endAt
+    );
+  }
+
+  withEndAt(bound: Bound): Target {
+    return new Target(
+      this.path,
+      this.collectionGroup,
+      this.explicitOrderBy.slice(),
+      this.filters.slice(),
+      this.limit,
+      this.startAt,
+      bound
+    );
+  }
+
+  /**
+   * Helper to convert a collection group query into a collection query at a
+   * specific path. This is used when executing collection group queries, since
+   * we have to split the query into a set of collection queries at multiple
+   * paths.
+   */
+  asCollectionQueryAtPath(path: ResourcePath): Target {
+    return new Target(
+      path,
+      /*collectionGroup=*/ null,
+      this.explicitOrderBy.slice(),
+      this.filters.slice(),
+      this.limit,
+      this.startAt,
+      this.endAt
+    );
+  }
+
+  // TODO(b/29183165): This is used to get a unique string from a query to, for
+  // example, use as a dictionary key, but the implementation is subject to
+  // collisions. Make it collision-free.
+  canonicalId(): string {
+    if (this.memoizedCanonicalId === null) {
+      let canonicalId = this.path.canonicalString();
+      if (this.isCollectionGroupQuery()) {
+        canonicalId += '|cg:' + this.collectionGroup;
+      }
+      canonicalId += '|f:';
+      for (const filter of this.filters) {
+        canonicalId += filter.canonicalId();
+        canonicalId += ',';
+      }
+      canonicalId += '|ob:';
+      // TODO(dimond): make this collision resistant
+      for (const orderBy of this.orderBy) {
+        canonicalId += orderBy.canonicalId();
+        canonicalId += ',';
+      }
+      if (!isNullOrUndefined(this.limit)) {
+        canonicalId += '|l:';
+        canonicalId += this.limit!;
+      }
+      if (this.startAt) {
+        canonicalId += '|lb:';
+        canonicalId += this.startAt.canonicalId();
+      }
+      if (this.endAt) {
+        canonicalId += '|ub:';
+        canonicalId += this.endAt.canonicalId();
+      }
+      this.memoizedCanonicalId = canonicalId;
+    }
+    return this.memoizedCanonicalId;
+  }
+
+  toQuery(): Query {
+    return new Query(this);
+  }
+
+  toString(): string {
+    let str = 'Target(' + this.path.canonicalString();
+    if (this.isCollectionGroupQuery()) {
+      str += ' collectionGroup=' + this.collectionGroup;
+    }
+    if (this.filters.length > 0) {
+      str += `, filters: [${this.filters.join(', ')}]`;
+    }
+    if (!isNullOrUndefined(this.limit)) {
+      str += ', limit: ' + this.limit;
+    }
+    if (this.explicitOrderBy.length > 0) {
+      str += `, orderBy: [${this.explicitOrderBy.join(', ')}]`;
+    }
+    if (this.startAt) {
+      str += ', startAt: ' + this.startAt.canonicalId();
+    }
+    if (this.endAt) {
+      str += ', endAt: ' + this.endAt.canonicalId();
+    }
+
+    return str + ')';
+  }
+
+  isEqual(other: Target): boolean {
+    if (this.limit !== other.limit) {
+      return false;
+    }
+
+    if (this.orderBy.length !== other.orderBy.length) {
+      return false;
+    }
+
+    for (let i = 0; i < this.orderBy.length; i++) {
+      if (!this.orderBy[i].isEqual(other.orderBy[i])) {
+        return false;
+      }
+    }
+
+    if (this.filters.length !== other.filters.length) {
+      return false;
+    }
+
+    for (let i = 0; i < this.filters.length; i++) {
+      if (!this.filters[i].isEqual(other.filters[i])) {
+        return false;
+      }
+    }
+
+    if (this.collectionGroup !== other.collectionGroup) {
+      return false;
+    }
+
+    if (!this.path.isEqual(other.path)) {
+      return false;
+    }
+
+    if (
+      this.startAt !== null
+        ? !this.startAt.isEqual(other.startAt)
+        : other.startAt !== null
+    ) {
+      return false;
+    }
+
+    return this.endAt !== null
+      ? this.endAt.isEqual(other.endAt)
+      : other.endAt === null;
+  }
+
+  docComparator(d1: Document, d2: Document): number {
+    let comparedOnKeyField = false;
+    for (const orderBy of this.orderBy) {
+      const comp = orderBy.compare(d1, d2);
+      if (comp !== 0) {
+        return comp;
+      }
+      comparedOnKeyField = comparedOnKeyField || orderBy.field.isKeyField();
+    }
+    // Assert that we actually compared by key
+    assert(
+      comparedOnKeyField,
+      "orderBy used that doesn't compare on key field"
+    );
+    return 0;
+  }
+
+  matches(doc: Document): boolean {
+    return (
+      this.matchesPathAndCollectionGroup(doc) &&
+      this.matchesOrderBy(doc) &&
+      this.matchesFilters(doc) &&
+      this.matchesBounds(doc)
+    );
+  }
+
+  hasLimit(): boolean {
+    return !isNullOrUndefined(this.limit);
+  }
+
+  getFirstOrderByField(): FieldPath | null {
+    return this.explicitOrderBy.length > 0
+      ? this.explicitOrderBy[0].field
+      : null;
+  }
+
+  getInequalityFilterField(): FieldPath | null {
+    for (const filter of this.filters) {
+      if (filter instanceof FieldFilter && filter.isInequality()) {
+        return filter.field;
+      }
+    }
+    return null;
+  }
+
+  // Checks if any of the provided Operators are included in the query and
+  // returns the first one that is, or null if none are.
+  findFilterOperator(operators: Operator[]): Operator | null {
+    for (const filter of this.filters) {
+      if (filter instanceof FieldFilter) {
+        if (operators.indexOf(filter.op) >= 0) {
+          return filter.op;
+        }
+      }
+    }
+    return null;
+  }
+
+  isDocumentQuery(): boolean {
+    return (
+      DocumentKey.isDocumentKey(this.path) &&
+      this.collectionGroup === null &&
+      this.filters.length === 0
+    );
+  }
+
+  isCollectionGroupQuery(): boolean {
+    return this.collectionGroup !== null;
+  }
+
+  private matchesPathAndCollectionGroup(doc: Document): boolean {
+    const docPath = doc.key.path;
+    if (this.collectionGroup !== null) {
+      // NOTE: this.path is currently always empty since we don't expose Collection
+      // Group queries rooted at a document path yet.
+      return (
+        doc.key.hasCollectionId(this.collectionGroup) &&
+        this.path.isPrefixOf(docPath)
+      );
+    } else if (DocumentKey.isDocumentKey(this.path)) {
+      // exact match for document queries
+      return this.path.isEqual(docPath);
+    } else {
+      // shallow ancestor queries by default
+      return this.path.isImmediateParentOf(docPath);
+    }
+  }
+
+  /**
+   * A document must have a value for every ordering clause in order to show up
+   * in the results.
+   */
+  private matchesOrderBy(doc: Document): boolean {
+    for (const orderBy of this.explicitOrderBy) {
+      // order by key always matches
+      if (!orderBy.field.isKeyField() && doc.field(orderBy.field) === null) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private matchesFilters(doc: Document): boolean {
+    for (const filter of this.filters) {
+      if (!filter.matches(doc)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /**
+   * Makes sure a document is within the bounds, if provided.
+   */
+  private matchesBounds(doc: Document): boolean {
+    if (this.startAt && !this.startAt.sortsBeforeDocument(this.orderBy, doc)) {
+      return false;
+    }
+    if (this.endAt && this.endAt.sortsBeforeDocument(this.orderBy, doc)) {
+      return false;
+    }
+    return true;
+  }
+
+  private assertValidBound(bound: Bound): void {
+    assert(
+      bound.position.length <= this.orderBy.length,
+      'Bound is longer than orderBy'
+    );
+  }
+}

--- a/packages/firestore/src/local/indexeddb_mutation_queue.ts
+++ b/packages/firestore/src/local/indexeddb_mutation_queue.ts
@@ -17,7 +17,7 @@
 
 import { Timestamp } from '../api/timestamp';
 import { User } from '../auth/user';
-import { Query } from '../core/query';
+import { Target } from '../core/target';
 import { BatchId, ProtoByteString } from '../core/types';
 import { DocumentKeySet } from '../model/collections';
 import { DocumentKey } from '../model/document_key';
@@ -394,20 +394,20 @@ export class IndexedDbMutationQueue implements MutationQueue {
     );
   }
 
-  getAllMutationBatchesAffectingQuery(
+  getAllMutationBatchesAffectingTarget(
     transaction: PersistenceTransaction,
-    query: Query
+    target: Target
   ): PersistencePromise<MutationBatch[]> {
     assert(
-      !query.isDocumentQuery(),
+      !target.isDocumentQuery(),
       "Document queries shouldn't go down this path"
     );
     assert(
-      !query.isCollectionGroupQuery(),
+      !target.isCollectionGroupQuery(),
       'CollectionGroup queries should be handled in LocalDocumentsView'
     );
 
-    const queryPath = query.path;
+    const queryPath = target.path;
     const immediateChildrenLength = queryPath.length + 1;
 
     // TODO(mcg): Actually implement a single-collection query

--- a/packages/firestore/src/local/indexeddb_persistence.ts
+++ b/packages/firestore/src/local/indexeddb_persistence.ts
@@ -66,7 +66,7 @@ import {
   ReferenceDelegate
 } from './persistence';
 import { PersistencePromise } from './persistence_promise';
-import { QueryData } from './query_data';
+import { TargetData } from './target_data';
 import { ReferenceSet } from './reference_set';
 import { ClientId } from './shared_client_state';
 import { SimpleDb, SimpleDbStore, SimpleDbTransaction } from './simple_db';
@@ -1136,7 +1136,7 @@ export class IndexedDbLruDelegate implements ReferenceDelegate, LruDelegate {
 
   forEachTarget(
     txn: PersistenceTransaction,
-    f: (q: QueryData) => void
+    f: (q: TargetData) => void
   ): PersistencePromise<void> {
     return this.db.getQueryCache().forEachTarget(txn, f);
   }
@@ -1240,9 +1240,9 @@ export class IndexedDbLruDelegate implements ReferenceDelegate, LruDelegate {
 
   removeTarget(
     txn: PersistenceTransaction,
-    queryData: QueryData
+    targetData: TargetData
   ): PersistencePromise<void> {
-    const updated = queryData.withSequenceNumber(txn.currentSequenceNumber);
+    const updated = targetData.withSequenceNumber(txn.currentSequenceNumber);
     return this.db.getQueryCache().updateQueryData(txn, updated);
   }
 

--- a/packages/firestore/src/local/indexeddb_query_cache.ts
+++ b/packages/firestore/src/local/indexeddb_query_cache.ts
@@ -16,8 +16,8 @@
  */
 
 import { Timestamp } from '../api/timestamp';
-import { Query } from '../core/query';
 import { SnapshotVersion } from '../core/snapshot_version';
+import { Target } from '../core/target';
 import { ListenSequenceNumber, TargetId } from '../core/types';
 import { DocumentKeySet, documentKeySet } from '../model/collections';
 import { DocumentKey } from '../model/document_key';
@@ -241,12 +241,12 @@ export class IndexedDbQueryCache implements QueryCache {
 
   getQueryData(
     transaction: PersistenceTransaction,
-    query: Query
+    target: Target
   ): PersistencePromise<QueryData | null> {
     // Iterating by the canonicalId may yield more than one result because
     // canonicalId values are not required to be unique per target. This query
     // depends on the queryTargets index to be efficient.
-    const canonicalId = query.canonicalId();
+    const canonicalId = target.canonicalId();
     const range = IDBKeyRange.bound(
       [canonicalId, Number.NEGATIVE_INFINITY],
       [canonicalId, Number.POSITIVE_INFINITY]
@@ -259,7 +259,7 @@ export class IndexedDbQueryCache implements QueryCache {
           const found = this.serializer.fromDbTarget(value);
           // After finding a potential match, check that the query is
           // actually equal to the requested query.
-          if (query.isEqual(found.query)) {
+          if (target.isEqual(found.target)) {
             result = found;
             control.done();
           }

--- a/packages/firestore/src/local/local_serializer.ts
+++ b/packages/firestore/src/local/local_serializer.ts
@@ -16,7 +16,7 @@
  */
 
 import { Timestamp } from '../api/timestamp';
-import { Query } from '../core/query';
+import { Target } from '../core/target';
 import { SnapshotVersion } from '../core/snapshot_version';
 import {
   Document,
@@ -180,14 +180,14 @@ export class LocalSerializer {
   /** Decodes a DbTarget into QueryData */
   fromDbTarget(dbTarget: DbTarget): QueryData {
     const version = this.fromDbTimestamp(dbTarget.readTime);
-    let query: Query;
+    let target: Target;
     if (isDocumentQuery(dbTarget.query)) {
-      query = this.remoteSerializer.fromDocumentsTarget(dbTarget.query);
+      target = this.remoteSerializer.fromDocumentsTarget(dbTarget.query);
     } else {
-      query = this.remoteSerializer.fromQueryTarget(dbTarget.query);
+      target = this.remoteSerializer.fromQueryTarget(dbTarget.query);
     }
     return new QueryData(
-      query,
+      target,
       dbTarget.targetId,
       QueryPurpose.Listen,
       dbTarget.lastListenSequenceNumber,
@@ -207,10 +207,10 @@ export class LocalSerializer {
     );
     const dbTimestamp = this.toDbTimestamp(queryData.snapshotVersion);
     let queryProto: DbQuery;
-    if (queryData.query.isDocumentQuery()) {
-      queryProto = this.remoteSerializer.toDocumentsTarget(queryData.query);
+    if (queryData.target.isDocumentQuery()) {
+      queryProto = this.remoteSerializer.toDocumentsTarget(queryData.target);
     } else {
-      queryProto = this.remoteSerializer.toQueryTarget(queryData.query);
+      queryProto = this.remoteSerializer.toQueryTarget(queryData.target);
     }
 
     let resumeToken: string;
@@ -229,7 +229,7 @@ export class LocalSerializer {
     // lastListenSequenceNumber is always 0 until we do real GC.
     return new DbTarget(
       queryData.targetId,
-      queryData.query.canonicalId(),
+      queryData.target.canonicalId(),
       dbTimestamp,
       resumeToken,
       queryData.sequenceNumber,

--- a/packages/firestore/src/local/lru_garbage_collector.ts
+++ b/packages/firestore/src/local/lru_garbage_collector.ts
@@ -27,7 +27,7 @@ import { ignoreIfPrimaryLeaseLoss } from './indexeddb_persistence';
 import { LocalStore } from './local_store';
 import { PersistenceTransaction } from './persistence';
 import { PersistencePromise } from './persistence_promise';
-import { QueryData } from './query_data';
+import { TargetData } from './target_data';
 
 /**
  * Persistence layers intending to use LRU Garbage collection should have reference delegates that
@@ -40,7 +40,7 @@ export interface LruDelegate {
   /** Enumerates all the targets in the QueryCache. */
   forEachTarget(
     txn: PersistenceTransaction,
-    f: (target: QueryData) => void
+    f: (target: TargetData) => void
   ): PersistencePromise<void>;
 
   getSequenceNumberCount(

--- a/packages/firestore/src/local/memory_persistence.ts
+++ b/packages/firestore/src/local/memory_persistence.ts
@@ -46,7 +46,7 @@ import {
   ReferenceDelegate
 } from './persistence';
 import { PersistencePromise } from './persistence_promise';
-import { QueryData } from './query_data';
+import { TargetData } from './target_data';
 import { ReferenceSet } from './reference_set';
 import { ClientId } from './shared_client_state';
 
@@ -250,15 +250,15 @@ export class MemoryEagerDelegate implements ReferenceDelegate {
 
   removeTarget(
     txn: PersistenceTransaction,
-    queryData: QueryData
+    targetData: TargetData
   ): PersistencePromise<void> {
     const cache = this.persistence.getQueryCache();
     return cache
-      .getMatchingKeysForTargetId(txn, queryData.targetId)
+      .getMatchingKeysForTargetId(txn, targetData.targetId)
       .next(keys => {
         keys.forEach(key => this.orphanedDocuments.add(key));
       })
-      .next(() => cache.removeQueryData(txn, queryData));
+      .next(() => cache.removeQueryData(txn, targetData));
   }
 
   onTransactionStarted(): void {
@@ -344,7 +344,7 @@ export class MemoryLruDelegate implements ReferenceDelegate, LruDelegate {
 
   forEachTarget(
     txn: PersistenceTransaction,
-    f: (q: QueryData) => void
+    f: (q: TargetData) => void
   ): PersistencePromise<void> {
     return this.persistence.getQueryCache().forEachTarget(txn, f);
   }
@@ -432,9 +432,9 @@ export class MemoryLruDelegate implements ReferenceDelegate, LruDelegate {
 
   removeTarget(
     txn: PersistenceTransaction,
-    queryData: QueryData
+    targetData: TargetData
   ): PersistencePromise<void> {
-    const updated = queryData.withSequenceNumber(txn.currentSequenceNumber);
+    const updated = targetData.withSequenceNumber(txn.currentSequenceNumber);
     return this.persistence.getQueryCache().updateQueryData(txn, updated);
   }
 

--- a/packages/firestore/src/local/memory_remote_document_cache.ts
+++ b/packages/firestore/src/local/memory_remote_document_cache.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { Query } from '../core/query';
+import { Target } from '../core/target';
 import {
   DocumentKeySet,
   documentKeySet,
@@ -123,29 +123,29 @@ export class MemoryRemoteDocumentCache implements RemoteDocumentCache {
     return PersistencePromise.resolve(results);
   }
 
-  getDocumentsMatchingQuery(
+  getDocumentsMatchingTarget(
     transaction: PersistenceTransaction,
-    query: Query
+    target: Target
   ): PersistencePromise<DocumentMap> {
     assert(
-      !query.isCollectionGroupQuery(),
+      !target.isCollectionGroupQuery(),
       'CollectionGroup queries should be handled in LocalDocumentsView'
     );
     let results = documentMap();
 
     // Documents are ordered by key, so we can use a prefix scan to narrow down
-    // the documents we need to match the query against.
-    const prefix = new DocumentKey(query.path.child(''));
+    // the documents we need to match the target against.
+    const prefix = new DocumentKey(target.path.child(''));
     const iterator = this.docs.getIteratorFrom(prefix);
     while (iterator.hasNext()) {
       const {
         key,
         value: { maybeDocument }
       } = iterator.getNext();
-      if (!query.path.isPrefixOf(key.path)) {
+      if (!target.path.isPrefixOf(key.path)) {
         break;
       }
-      if (maybeDocument instanceof Document && query.matches(maybeDocument)) {
+      if (maybeDocument instanceof Document && target.matches(maybeDocument)) {
         results = results.insert(maybeDocument.key, maybeDocument);
       }
     }

--- a/packages/firestore/src/local/mutation_queue.ts
+++ b/packages/firestore/src/local/mutation_queue.ts
@@ -16,7 +16,7 @@
  */
 
 import { Timestamp } from '../api/timestamp';
-import { Query } from '../core/query';
+import { Target } from '../core/target';
 import { BatchId, ProtoByteString } from '../core/types';
 import { DocumentKeySet } from '../model/collections';
 import { DocumentKey } from '../model/document_key';
@@ -158,24 +158,24 @@ export interface MutationQueue {
 
   /**
    * Finds all mutation batches that could affect the results for the given
-   * query. Not all mutations in a batch will necessarily affect the query, so
+   * target. Not all mutations in a batch will necessarily affect the target, so
    * when looping through the batch you'll need to check that the mutation
-   * itself matches the query.
+   * itself matches the target.
    *
    * Batches are guaranteed to be in sorted order.
    *
    * Note that because of this requirement implementations are free to return
    * mutation batches that don't match the query at all if it's convenient.
    *
-   * NOTE: A PatchMutation does not need to include all fields in the query
+   * NOTE: A PatchMutation does not need to include all fields in the target
    * filter criteria in order to be a match (but any fields it does contain do
    * need to match).
    */
   // TODO(mikelehen): This should perhaps return an enumerator, though I'm not
   // sure we can avoid loading them all in memory.
-  getAllMutationBatchesAffectingQuery(
+  getAllMutationBatchesAffectingTarget(
     transaction: PersistenceTransaction,
-    query: Query
+    target: Target
   ): PersistencePromise<MutationBatch[]>;
 
   /**

--- a/packages/firestore/src/local/persistence.ts
+++ b/packages/firestore/src/local/persistence.ts
@@ -23,7 +23,7 @@ import { IndexManager } from './index_manager';
 import { MutationQueue } from './mutation_queue';
 import { PersistencePromise } from './persistence_promise';
 import { QueryCache } from './query_cache';
-import { QueryData } from './query_data';
+import { TargetData } from './target_data';
 import { ReferenceSet } from './reference_set';
 import { RemoteDocumentCache } from './remote_document_cache';
 import { ClientId } from './shared_client_state';
@@ -89,7 +89,7 @@ export interface ReferenceDelegate {
    */
   removeTarget(
     txn: PersistenceTransaction,
-    queryData: QueryData
+    targetData: TargetData
   ): PersistencePromise<void>;
 
   /** Notify the delegate that a document is no longer being mutated by the user. */

--- a/packages/firestore/src/local/query_cache.ts
+++ b/packages/firestore/src/local/query_cache.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { Query } from '../core/query';
+import { Target } from '../core/target';
 import { SnapshotVersion } from '../core/snapshot_version';
 import { ListenSequenceNumber, TargetId } from '../core/types';
 import { DocumentKeySet } from '../model/collections';
@@ -121,15 +121,15 @@ export interface QueryCache {
   ): PersistencePromise<number>;
 
   /**
-   * Looks up a QueryData entry by query.
+   * Looks up a QueryData entry by target.
    *
-   * @param query The query corresponding to the entry to look up.
+   * @param target The target query corresponding to the entry to look up.
    * @return The cached QueryData entry, or null if the cache has no entry for
-   * the query.
+   * the target query.
    */
   getQueryData(
     transaction: PersistenceTransaction,
-    query: Query
+    target: Target
   ): PersistencePromise<QueryData | null>;
 
   /**

--- a/packages/firestore/src/local/query_cache.ts
+++ b/packages/firestore/src/local/query_cache.ts
@@ -23,12 +23,12 @@ import { DocumentKey } from '../model/document_key';
 
 import { PersistenceTransaction } from './persistence';
 import { PersistencePromise } from './persistence_promise';
-import { QueryData } from './query_data';
+import { TargetData } from './target_data';
 
 /**
  * Represents cached queries received from the remote backend.
  *
- * The cache is keyed by Query and entries in the cache are QueryData instances.
+ * The cache is keyed by Query and entries in the cache are TargetData instances.
  */
 export interface QueryCache {
   /**
@@ -55,11 +55,11 @@ export interface QueryCache {
   ): PersistencePromise<ListenSequenceNumber>;
 
   /**
-   * Call provided function with each `QueryData` that we have cached.
+   * Call provided function with each `TargetData` that we have cached.
    */
   forEachTarget(
     txn: PersistenceTransaction,
-    f: (q: QueryData) => void
+    f: (q: TargetData) => void
   ): PersistencePromise<void>;
 
   /**
@@ -79,26 +79,26 @@ export interface QueryCache {
   /**
    * Adds an entry in the cache.
    *
-   * The cache key is extracted from `queryData.query`. The key must not already
+   * The cache key is extracted from `targetData.query`. The key must not already
    * exist in the cache.
    *
-   * @param queryData A QueryData instance to put in the cache.
+   * @param targetData A TargetData instance to put in the cache.
    */
   addQueryData(
     transaction: PersistenceTransaction,
-    queryData: QueryData
+    targetData: TargetData
   ): PersistencePromise<void>;
 
   /**
    * Updates an entry in the cache.
    *
-   * The cache key is extracted from `queryData.query`. The entry must already
+   * The cache key is extracted from `targetData.query`. The entry must already
    * exist in the cache, and it will be replaced.
-   * @param {QueryData} queryData The QueryData to be replaced into the cache.
+   * @param {TargetData} targetData The TargetData to be replaced into the cache.
    */
   updateQueryData(
     transaction: PersistenceTransaction,
-    queryData: QueryData
+    targetData: TargetData
   ): PersistencePromise<void>;
 
   /**
@@ -109,7 +109,7 @@ export interface QueryCache {
    */
   removeQueryData(
     transaction: PersistenceTransaction,
-    queryData: QueryData
+    targetData: TargetData
   ): PersistencePromise<void>;
 
   /**
@@ -121,29 +121,29 @@ export interface QueryCache {
   ): PersistencePromise<number>;
 
   /**
-   * Looks up a QueryData entry by target.
+   * Looks up a TargetData entry by target.
    *
    * @param target The target query corresponding to the entry to look up.
-   * @return The cached QueryData entry, or null if the cache has no entry for
+   * @return The cached TargetData entry, or null if the cache has no entry for
    * the target query.
    */
   getQueryData(
     transaction: PersistenceTransaction,
     target: Target
-  ): PersistencePromise<QueryData | null>;
+  ): PersistencePromise<TargetData | null>;
 
   /**
-   * Looks up a QueryData entry by target ID.
+   * Looks up a TargetData entry by target ID.
    *
-   * @param targetId The target ID of the QueryData entry to look up.
-   * @return The cached QueryData entry, or null if the cache has no entry for
+   * @param targetId The target ID of the TargetData entry to look up.
+   * @return The cached TargetData entry, or null if the cache has no entry for
    * the query.
    */
   // PORTING NOTE: Multi-tab only.
   getQueryDataForTarget(
     txn: PersistenceTransaction,
     targetId: TargetId
-  ): PersistencePromise<QueryData | null>;
+  ): PersistencePromise<TargetData | null>;
 
   /**
    * Adds the given document keys to cached query results of the given target

--- a/packages/firestore/src/local/query_data.ts
+++ b/packages/firestore/src/local/query_data.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { Query } from '../core/query';
+import { Target } from '../core/target';
 import { SnapshotVersion } from '../core/snapshot_version';
 import { ListenSequenceNumber, ProtoByteString, TargetId } from '../core/types';
 import { emptyByteString } from '../platform/platform';
@@ -39,32 +39,32 @@ export enum QueryPurpose {
  */
 export class QueryData {
   constructor(
-    /** The query being listened to. */
-    readonly query: Query,
+    /** The target query being listened to. */
+    readonly target: Target,
     /**
      * The target ID to which the query corresponds; Assigned by the
      * LocalStore for user listens and by the SyncEngine for limbo watches.
      */
     readonly targetId: TargetId,
-    /** The purpose of the query. */
+    /** The purpose of the target query. */
     readonly purpose: QueryPurpose,
-    /** The sequence number of the last transaction during which this query data was modified */
+    /** The sequence number of the last transaction during which this target data was modified */
     readonly sequenceNumber: ListenSequenceNumber,
     /** The latest snapshot version seen for this target. */
     readonly snapshotVersion: SnapshotVersion = SnapshotVersion.MIN,
     /**
-     * An opaque, server-assigned token that allows watching a query to be
+     * An opaque, server-assigned token that allows watching a target to be
      * resumed after disconnecting without retransmitting all the data that
-     * matches the query. The resume token essentially identifies a point in
+     * matches the target. The resume token essentially identifies a point in
      * time from which the server should resume sending results.
      */
     readonly resumeToken: ProtoByteString = emptyByteString()
   ) {}
 
-  /** Creates a new query data instance with an updated sequence number. */
+  /** Creates a new target data instance with an updated sequence number. */
   withSequenceNumber(sequenceNumber: number): QueryData {
     return new QueryData(
-      this.query,
+      this.target,
       this.targetId,
       this.purpose,
       sequenceNumber,
@@ -74,7 +74,7 @@ export class QueryData {
   }
 
   /**
-   * Creates a new query data instance with an updated resume token and
+   * Creates a new target data instance with an updated resume token and
    * snapshot version.
    */
   withResumeToken(
@@ -82,7 +82,7 @@ export class QueryData {
     snapshotVersion: SnapshotVersion
   ): QueryData {
     return new QueryData(
-      this.query,
+      this.target,
       this.targetId,
       this.purpose,
       this.sequenceNumber,
@@ -98,7 +98,7 @@ export class QueryData {
       this.sequenceNumber === other.sequenceNumber &&
       this.snapshotVersion.isEqual(other.snapshotVersion) &&
       this.resumeToken === other.resumeToken &&
-      this.query.isEqual(other.query)
+      this.target.isEqual(other.target)
     );
   }
 }

--- a/packages/firestore/src/local/remote_document_cache.ts
+++ b/packages/firestore/src/local/remote_document_cache.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { Query } from '../core/query';
+import { Target } from '../core/target';
 import {
   DocumentKeySet,
   DocumentMap,
@@ -63,19 +63,19 @@ export interface RemoteDocumentCache {
   ): PersistencePromise<NullableMaybeDocumentMap>;
 
   /**
-   * Executes a query against the cached Document entries.
+   * Executes a target query against the cached Document entries.
    *
    * Implementations may return extra documents if convenient. The results
    * should be re-filtered by the consumer before presenting them to the user.
    *
    * Cached NoDocument entries have no bearing on query results.
    *
-   * @param query The query to match documents against.
+   * @param target The target query to match documents against.
    * @return The set of matching documents.
    */
-  getDocumentsMatchingQuery(
+  getDocumentsMatchingTarget(
     transaction: PersistenceTransaction,
-    query: Query
+    query: Target
   ): PersistencePromise<DocumentMap>;
 
   /**

--- a/packages/firestore/src/local/target_data.ts
+++ b/packages/firestore/src/local/target_data.ts
@@ -35,9 +35,9 @@ export enum QueryPurpose {
 }
 
 /**
- * An immutable set of metadata that the local store tracks for each query.
+ * An immutable set of metadata that the local store tracks for each target query.
  */
-export class QueryData {
+export class TargetData {
   constructor(
     /** The target query being listened to. */
     readonly target: Target,
@@ -62,8 +62,8 @@ export class QueryData {
   ) {}
 
   /** Creates a new target data instance with an updated sequence number. */
-  withSequenceNumber(sequenceNumber: number): QueryData {
-    return new QueryData(
+  withSequenceNumber(sequenceNumber: number): TargetData {
+    return new TargetData(
       this.target,
       this.targetId,
       this.purpose,
@@ -80,8 +80,8 @@ export class QueryData {
   withResumeToken(
     resumeToken: ProtoByteString,
     snapshotVersion: SnapshotVersion
-  ): QueryData {
-    return new QueryData(
+  ): TargetData {
+    return new TargetData(
       this.target,
       this.targetId,
       this.purpose,
@@ -91,7 +91,7 @@ export class QueryData {
     );
   }
 
-  isEqual(other: QueryData): boolean {
+  isEqual(other: TargetData): boolean {
     return (
       this.targetId === other.targetId &&
       this.purpose === other.purpose &&

--- a/packages/firestore/src/remote/persistent_stream.ts
+++ b/packages/firestore/src/remote/persistent_stream.ts
@@ -18,7 +18,7 @@
 import { CredentialsProvider, Token } from '../api/credentials';
 import { SnapshotVersion } from '../core/snapshot_version';
 import { ProtoByteString, TargetId } from '../core/types';
-import { QueryData } from '../local/query_data';
+import { TargetData } from '../local/target_data';
 import { Mutation, MutationResult } from '../model/mutation';
 import * as api from '../protos/firestore_proto_api';
 import { assert } from '../util/assert';
@@ -569,12 +569,12 @@ export class PersistentListenStream extends PersistentStream<
    * affect the query will be streamed back as WatchChange messages that
    * reference the targetId.
    */
-  watch(queryData: QueryData): void {
+  watch(targetData: TargetData): void {
     const request: ListenRequest = {};
     request.database = this.serializer.encodedDatabaseId;
-    request.addTarget = this.serializer.toTarget(queryData);
+    request.addTarget = this.serializer.toTarget(targetData);
 
-    const labels = this.serializer.toListenRequestLabels(queryData);
+    const labels = this.serializer.toListenRequestLabels(targetData);
     if (labels) {
       request.labels = labels;
     }

--- a/packages/firestore/src/remote/remote_store.ts
+++ b/packages/firestore/src/remote/remote_store.ts
@@ -462,7 +462,7 @@ export class RemoteStore implements TargetMetadataProvider {
       // that we flag the first re-listen this way without impacting future
       // listens of this target (that might happen e.g. on reconnect).
       const requestQueryData = new QueryData(
-        queryData.query,
+        queryData.target,
         targetId,
         QueryPurpose.ExistenceFilterMismatch,
         queryData.sequenceNumber

--- a/packages/firestore/src/remote/remote_syncer.ts
+++ b/packages/firestore/src/remote/remote_syncer.ts
@@ -38,7 +38,7 @@ export interface RemoteSyncer {
    * backend for any active target.
    *
    * @param targetId The targetID corresponds to one previously initiated by the
-   * user as part of QueryData passed to listen() on RemoteStore.
+   * user as part of TargetData passed to listen() on RemoteStore.
    * @param error A description of the condition that has forced the rejection.
    * Nearly always this will be an indication that the user is no longer
    * authorized to see the data matching the target.

--- a/packages/firestore/src/remote/serializer.ts
+++ b/packages/firestore/src/remote/serializer.ts
@@ -30,7 +30,7 @@ import {
 import { SnapshotVersion } from '../core/snapshot_version';
 import { Target } from '../core/target';
 import { ProtoByteString, TargetId } from '../core/types';
-import { QueryData, QueryPurpose } from '../local/query_data';
+import { TargetData, QueryPurpose } from '../local/target_data';
 import { Document, MaybeDocument, NoDocument } from '../model/document';
 import { DocumentKey } from '../model/document_key';
 import * as fieldValue from '../model/field_value';
@@ -1113,9 +1113,9 @@ export class JsonProtoSerializer {
   }
 
   toListenRequestLabels(
-    queryData: QueryData
+    targetData: TargetData
   ): api.ApiClientObjectMap<string> | null {
-    const value = this.toLabel(queryData.purpose);
+    const value = this.toLabel(targetData.purpose);
     if (value == null) {
       return null;
     } else {
@@ -1138,9 +1138,9 @@ export class JsonProtoSerializer {
     }
   }
 
-  toTarget(queryData: QueryData): api.Target {
+  toTarget(targetData: TargetData): api.Target {
     let result: api.Target;
-    const target = queryData.target;
+    const target = targetData.target;
 
     if (target.isDocumentQuery()) {
       result = { documents: this.toDocumentsTarget(target) };
@@ -1148,11 +1148,11 @@ export class JsonProtoSerializer {
       result = { query: this.toQueryTarget(target) };
     }
 
-    result.targetId = queryData.targetId;
+    result.targetId = targetData.targetId;
 
-    if (queryData.resumeToken.length > 0) {
+    if (targetData.resumeToken.length > 0) {
       result.resumeToken = this.unsafeCastProtoByteString(
-        queryData.resumeToken
+        targetData.resumeToken
       );
     }
 

--- a/packages/firestore/src/remote/serializer.ts
+++ b/packages/firestore/src/remote/serializer.ts
@@ -25,10 +25,10 @@ import {
   FieldFilter,
   Filter,
   Operator,
-  OrderBy,
-  Query
+  OrderBy
 } from '../core/query';
 import { SnapshotVersion } from '../core/snapshot_version';
+import { Target } from '../core/target';
 import { ProtoByteString, TargetId } from '../core/types';
 import { QueryData, QueryPurpose } from '../local/query_data';
 import { Document, MaybeDocument, NoDocument } from '../model/document';
@@ -993,25 +993,25 @@ export class JsonProtoSerializer {
     return new FieldTransform(fieldPath, transform!);
   }
 
-  toDocumentsTarget(query: Query): api.DocumentsTarget {
-    return { documents: [this.toQueryPath(query.path)] };
+  toDocumentsTarget(target: Target): api.DocumentsTarget {
+    return { documents: [this.toQueryPath(target.path)] };
   }
 
-  fromDocumentsTarget(documentsTarget: api.DocumentsTarget): Query {
+  fromDocumentsTarget(documentsTarget: api.DocumentsTarget): Target {
     const count = documentsTarget.documents!.length;
     assert(
       count === 1,
       'DocumentsTarget contained other than 1 document: ' + count
     );
     const name = documentsTarget.documents![0];
-    return Query.atPath(this.fromQueryPath(name));
+    return Target.atPath(this.fromQueryPath(name));
   }
 
-  toQueryTarget(query: Query): api.QueryTarget {
+  toQueryTarget(target: Target): api.QueryTarget {
     // Dissect the path into parent, collectionId, and optional key filter.
     const result: api.QueryTarget = { structuredQuery: {} };
-    const path = query.path;
-    if (query.collectionGroup !== null) {
+    const path = target.path;
+    if (target.collectionGroup !== null) {
       assert(
         path.length % 2 === 0,
         'Collection Group queries should be within a document path or root.'
@@ -1019,7 +1019,7 @@ export class JsonProtoSerializer {
       result.parent = this.toQueryPath(path);
       result.structuredQuery!.from = [
         {
-          collectionId: query.collectionGroup,
+          collectionId: target.collectionGroup,
           allDescendants: true
         }
       ];
@@ -1032,32 +1032,32 @@ export class JsonProtoSerializer {
       result.structuredQuery!.from = [{ collectionId: path.lastSegment() }];
     }
 
-    const where = this.toFilter(query.filters);
+    const where = this.toFilter(target.filters);
     if (where) {
       result.structuredQuery!.where = where;
     }
 
-    const orderBy = this.toOrder(query.orderBy);
+    const orderBy = this.toOrder(target.orderBy);
     if (orderBy) {
       result.structuredQuery!.orderBy = orderBy;
     }
 
-    const limit = this.toInt32Value(query.limit);
+    const limit = this.toInt32Value(target.limit);
     if (limit !== undefined) {
       result.structuredQuery!.limit = limit;
     }
 
-    if (query.startAt) {
-      result.structuredQuery!.startAt = this.toCursor(query.startAt);
+    if (target.startAt) {
+      result.structuredQuery!.startAt = this.toCursor(target.startAt);
     }
-    if (query.endAt) {
-      result.structuredQuery!.endAt = this.toCursor(query.endAt);
+    if (target.endAt) {
+      result.structuredQuery!.endAt = this.toCursor(target.endAt);
     }
 
     return result;
   }
 
-  fromQueryTarget(target: api.QueryTarget): Query {
+  fromQueryTarget(target: api.QueryTarget): Target {
     let path = this.fromQueryPath(target.parent!);
 
     const query = target.structuredQuery!;
@@ -1101,7 +1101,7 @@ export class JsonProtoSerializer {
       endAt = this.fromCursor(query.endAt);
     }
 
-    return new Query(
+    return new Target(
       path,
       collectionGroup,
       orderBy,
@@ -1140,12 +1140,12 @@ export class JsonProtoSerializer {
 
   toTarget(queryData: QueryData): api.Target {
     let result: api.Target;
-    const query = queryData.query;
+    const target = queryData.target;
 
-    if (query.isDocumentQuery()) {
-      result = { documents: this.toDocumentsTarget(query) };
+    if (target.isDocumentQuery()) {
+      result = { documents: this.toDocumentsTarget(target) };
     } else {
-      result = { query: this.toQueryTarget(query) };
+      result = { query: this.toQueryTarget(target) };
     }
 
     result.targetId = queryData.targetId;

--- a/packages/firestore/src/remote/watch_change.ts
+++ b/packages/firestore/src/remote/watch_change.ts
@@ -383,8 +383,8 @@ export class WatchChangeAggregator {
 
     const queryData = this.queryDataForActiveTarget(targetId);
     if (queryData) {
-      const query = queryData.query;
-      if (query.isDocumentQuery()) {
+      const target = queryData.target;
+      if (target.isDocumentQuery()) {
         if (expectedCount === 0) {
           // The existence filter told us the document does not exist. We deduce
           // that this document does not exist and apply a deleted document to
@@ -392,7 +392,7 @@ export class WatchChangeAggregator {
           // another query that will raise this document as part of a snapshot
           // until it is resolved, essentially exposing inconsistency between
           // queries.
-          const key = new DocumentKey(query.path);
+          const key = new DocumentKey(target.path);
           this.removeDocumentFromTarget(
             targetId,
             key,
@@ -426,7 +426,7 @@ export class WatchChangeAggregator {
     objUtils.forEachNumber(this.targetStates, (targetId, targetState) => {
       const queryData = this.queryDataForActiveTarget(targetId);
       if (queryData) {
-        if (targetState.current && queryData.query.isDocumentQuery()) {
+        if (targetState.current && queryData.target.isDocumentQuery()) {
           // Document queries for document that don't exist can produce an empty
           // result set. To update our local cache, we synthesize a document
           // delete if we have not previously received the document. This
@@ -436,7 +436,7 @@ export class WatchChangeAggregator {
           // TODO(dimond): Ideally we would have an explicit lookup query
           // instead resulting in an explicit delete message and we could
           // remove this special logic.
-          const key = new DocumentKey(queryData.query.path);
+          const key = new DocumentKey(queryData.target.path);
           if (
             this.pendingDocumentUpdates.get(key) === null &&
             !this.targetContainsDocument(targetId, key)

--- a/packages/firestore/test/unit/local/local_store.test.ts
+++ b/packages/firestore/test/unit/local/local_store.test.ts
@@ -913,8 +913,8 @@ function genericLocalStoreTests(
 
   it('can execute mixed collection queries', async () => {
     const target = Target.atPath(path('foo'));
-    const queryData = await localStore.allocateTarget(target);
-    expect(queryData.targetId).to.equal(2);
+    const targetData = await localStore.allocateTarget(target);
+    expect(targetData.targetId).to.equal(2);
     await localStore.applyRemoteEvent(
       docAddedRemoteEvent(doc('foo/baz', 10, { a: 'b' }), [2], [])
     );
@@ -938,8 +938,8 @@ function genericLocalStoreTests(
       return;
     }
     const target = Target.atPath(path('foo/bar'));
-    const queryData = await localStore.allocateTarget(target);
-    const targetId = queryData.targetId;
+    const targetData = await localStore.allocateTarget(target);
+    const targetId = targetData.targetId;
     const resumeToken = 'abc';
     const watchChange = new WatchTargetChange(
       WatchTargetChangeState.Current,
@@ -948,7 +948,7 @@ function genericLocalStoreTests(
     );
     const aggregator = new WatchChangeAggregator({
       getRemoteKeysForTarget: () => documentKeySet(),
-      getQueryDataForTarget: () => queryData
+      getQueryDataForTarget: () => targetData
     });
     aggregator.handleTargetChange(watchChange);
     const remoteEvent = aggregator.createRemoteEvent(version(1000));
@@ -967,8 +967,8 @@ function genericLocalStoreTests(
       return;
     }
     const target = Target.atPath(path('foo/bar'));
-    const queryData = await localStore.allocateTarget(target);
-    const targetId = queryData.targetId;
+    const targetData = await localStore.allocateTarget(target);
+    const targetId = targetData.targetId;
     const resumeToken = 'abc';
 
     const watchChange1 = new WatchTargetChange(
@@ -978,7 +978,7 @@ function genericLocalStoreTests(
     );
     const aggregator1 = new WatchChangeAggregator({
       getRemoteKeysForTarget: () => documentKeySet(),
-      getQueryDataForTarget: () => queryData
+      getQueryDataForTarget: () => targetData
     });
     aggregator1.handleTargetChange(watchChange1);
     const remoteEvent1 = aggregator1.createRemoteEvent(version(1000));
@@ -991,7 +991,7 @@ function genericLocalStoreTests(
     );
     const aggregator2 = new WatchChangeAggregator({
       getRemoteKeysForTarget: () => documentKeySet(),
-      getQueryDataForTarget: () => queryData
+      getQueryDataForTarget: () => targetData
     });
     aggregator2.handleTargetChange(watchChange2);
     const remoteEvent2 = aggregator2.createRemoteEvent(version(2000));

--- a/packages/firestore/test/unit/local/lru_garbage_collector.test.ts
+++ b/packages/firestore/test/unit/local/lru_garbage_collector.test.ts
@@ -19,7 +19,7 @@ import { expect } from 'chai';
 import { Timestamp } from '../../../src/api/timestamp';
 import { User } from '../../../src/auth/user';
 import { ListenSequence } from '../../../src/core/listen_sequence';
-import { Query } from '../../../src/core/query';
+import { Target } from '../../../src/core/target';
 import { SnapshotVersion } from '../../../src/core/snapshot_version';
 import { ListenSequenceNumber, TargetId } from '../../../src/core/types';
 import { IndexedDbPersistence } from '../../../src/local/indexeddb_persistence';
@@ -130,7 +130,7 @@ function genericLruGarbageCollectorTests(
   function nextQueryData(sequenceNumber: ListenSequenceNumber): QueryData {
     const targetId = ++previousTargetId;
     return new QueryData(
-      Query.atPath(path('path' + targetId)),
+      Target.atPath(path('path' + targetId)),
       targetId,
       QueryPurpose.Listen,
       sequenceNumber

--- a/packages/firestore/test/unit/local/mutation_queue.test.ts
+++ b/packages/firestore/test/unit/local/mutation_queue.test.ts
@@ -17,7 +17,7 @@
 
 import { expect } from 'chai';
 import { User } from '../../../src/auth/user';
-import { Query } from '../../../src/core/query';
+import { Target } from '../../../src/core/target';
 import { IndexedDbPersistence } from '../../../src/local/indexeddb_persistence';
 import { Persistence } from '../../../src/local/persistence';
 import { ReferenceSet } from '../../../src/local/reference_set';
@@ -281,9 +281,9 @@ function genericMutationQueueTests(): void {
       batches.push(batch);
     }
     const expected = [batches[1], batches[2], batches[4]];
-    const query = Query.atPath(path('foo'));
+    const target = Target.atPath(path('foo'));
     const matches = await mutationQueue.getAllMutationBatchesAffectingQuery(
-      query
+      target
     );
     expectEqualArrays(matches, expected);
   });
@@ -299,9 +299,9 @@ function genericMutationQueueTests(): void {
       setMutation('foo/baz', value)
     ]);
     const expected = [batch1, batch2];
-    const query = Query.atPath(path('foo'));
+    const target = Target.atPath(path('foo'));
     const matches = await mutationQueue.getAllMutationBatchesAffectingQuery(
-      query
+      target
     );
     expectEqualArrays(matches, expected);
   });

--- a/packages/firestore/test/unit/local/query_cache.test.ts
+++ b/packages/firestore/test/unit/local/query_cache.test.ts
@@ -21,7 +21,7 @@ import { SnapshotVersion } from '../../../src/core/snapshot_version';
 import { TargetId } from '../../../src/core/types';
 import { IndexedDbPersistence } from '../../../src/local/indexeddb_persistence';
 import { Persistence } from '../../../src/local/persistence';
-import { QueryData, QueryPurpose } from '../../../src/local/query_data';
+import { TargetData, QueryPurpose } from '../../../src/local/target_data';
 import { ReferenceSet } from '../../../src/local/reference_set';
 import { addEqualityMatcher } from '../../util/equality_matcher';
 import {
@@ -64,7 +64,7 @@ describe('IndexedDbQueryCache', () => {
     const snapshotVersion = SnapshotVersion.fromTimestamp(new Timestamp(1, 2));
     const target = Target.atPath(path('rooms'));
     await queryCache1.addQueryData(
-      new QueryData(
+      new TargetData(
         target,
         targetId,
         QueryPurpose.Listen,
@@ -107,7 +107,7 @@ function genericQueryCacheTests(
   const QUERY_GARAGES = Target.atPath(path('garages'));
 
   /**
-   * Creates a new QueryData object from the the given parameters, synthesizing
+   * Creates a new TargetData object from the the given parameters, synthesizing
    * a resume token from the snapshot version.
    */
   let previousSequenceNumber = 0;
@@ -115,13 +115,13 @@ function genericQueryCacheTests(
     target: Target,
     targetId: TargetId,
     version?: number
-  ): QueryData {
+  ): TargetData {
     if (version === undefined) {
       version = 0;
     }
     const snapshotVersion = SnapshotVersion.fromMicroseconds(version);
     const resumeToken = resumeTokenForSnapshot(snapshotVersion);
-    return new QueryData(
+    return new TargetData(
       target,
       targetId,
       QueryPurpose.Listen,
@@ -146,16 +146,16 @@ function genericQueryCacheTests(
   });
 
   it('returns null for query not in cache', () => {
-    return cache.getQueryData(QUERY_ROOMS).then(queryData => {
-      expect(queryData).to.equal(null);
+    return cache.getQueryData(QUERY_ROOMS).then(targetData => {
+      expect(targetData).to.equal(null);
     });
   });
 
   it('can set and read a query', async () => {
-    const queryData = testQueryData(QUERY_ROOMS, 1, 1);
-    await cache.addQueryData(queryData);
-    const read = await cache.getQueryData(queryData.target);
-    expect(read).to.deep.equal(queryData);
+    const targetData = testQueryData(QUERY_ROOMS, 1, 1);
+    await cache.addQueryData(targetData);
+    const read = await cache.getQueryData(targetData.target);
+    expect(read).to.deep.equal(targetData);
   });
 
   it('handles canonical ID collisions', async () => {
@@ -201,9 +201,9 @@ function genericQueryCacheTests(
   });
 
   it('can remove a query', async () => {
-    const queryData = testQueryData(QUERY_ROOMS, 1, 1);
-    await cache.addQueryData(queryData);
-    await cache.removeQueryData(queryData);
+    const targetData = testQueryData(QUERY_ROOMS, 1, 1);
+    await cache.addQueryData(targetData);
+    await cache.removeQueryData(targetData);
     const read = await cache.getQueryData(QUERY_ROOMS);
     expect(read).to.equal(null);
   });
@@ -360,9 +360,9 @@ function genericQueryCacheTests(
   });
 
   it('sets the highest sequence number', async () => {
-    const query1 = new QueryData(QUERY_ROOMS, 1, QueryPurpose.Listen, 10);
+    const query1 = new TargetData(QUERY_ROOMS, 1, QueryPurpose.Listen, 10);
     await cache.addQueryData(query1);
-    const query2 = new QueryData(QUERY_HALLS, 2, QueryPurpose.Listen, 20);
+    const query2 = new TargetData(QUERY_HALLS, 2, QueryPurpose.Listen, 20);
     await cache.addQueryData(query2);
     expect(await cache.getHighestSequenceNumber()).to.equal(20);
 
@@ -370,7 +370,7 @@ function genericQueryCacheTests(
     await cache.removeQueryData(query2);
     expect(await cache.getHighestSequenceNumber()).to.equal(20);
 
-    const query3 = new QueryData(QUERY_GARAGES, 3, QueryPurpose.Listen, 100);
+    const query3 = new TargetData(QUERY_GARAGES, 3, QueryPurpose.Listen, 100);
     await cache.addQueryData(query3);
     expect(await cache.getHighestSequenceNumber()).to.equal(100);
 

--- a/packages/firestore/test/unit/local/query_cache.test.ts
+++ b/packages/firestore/test/unit/local/query_cache.test.ts
@@ -16,7 +16,7 @@
  */
 
 import { expect } from 'chai';
-import { Query } from '../../../src/core/query';
+import { Target } from '../../../src/core/target';
 import { SnapshotVersion } from '../../../src/core/snapshot_version';
 import { TargetId } from '../../../src/core/types';
 import { IndexedDbPersistence } from '../../../src/local/indexeddb_persistence';
@@ -62,10 +62,10 @@ describe('IndexedDbQueryCache', () => {
     const originalSequenceNumber = 1234;
     const targetId = 5;
     const snapshotVersion = SnapshotVersion.fromTimestamp(new Timestamp(1, 2));
-    const query = Query.atPath(path('rooms'));
+    const target = Target.atPath(path('rooms'));
     await queryCache1.addQueryData(
       new QueryData(
-        query,
+        target,
         targetId,
         QueryPurpose.Listen,
         originalSequenceNumber,
@@ -102,9 +102,9 @@ function genericQueryCacheTests(
   addEqualityMatcher();
   let cache: TestQueryCache;
 
-  const QUERY_ROOMS = Query.atPath(path('rooms'));
-  const QUERY_HALLS = Query.atPath(path('halls'));
-  const QUERY_GARAGES = Query.atPath(path('garages'));
+  const QUERY_ROOMS = Target.atPath(path('rooms'));
+  const QUERY_HALLS = Target.atPath(path('halls'));
+  const QUERY_GARAGES = Target.atPath(path('garages'));
 
   /**
    * Creates a new QueryData object from the the given parameters, synthesizing
@@ -112,7 +112,7 @@ function genericQueryCacheTests(
    */
   let previousSequenceNumber = 0;
   function testQueryData(
-    query: Query,
+    target: Target,
     targetId: TargetId,
     version?: number
   ): QueryData {
@@ -122,7 +122,7 @@ function genericQueryCacheTests(
     const snapshotVersion = SnapshotVersion.fromMicroseconds(version);
     const resumeToken = resumeTokenForSnapshot(snapshotVersion);
     return new QueryData(
-      query,
+      target,
       targetId,
       QueryPurpose.Listen,
       ++previousSequenceNumber,
@@ -154,15 +154,15 @@ function genericQueryCacheTests(
   it('can set and read a query', async () => {
     const queryData = testQueryData(QUERY_ROOMS, 1, 1);
     await cache.addQueryData(queryData);
-    const read = await cache.getQueryData(queryData.query);
+    const read = await cache.getQueryData(queryData.target);
     expect(read).to.deep.equal(queryData);
   });
 
   it('handles canonical ID collisions', async () => {
     // Type information is currently lost in our canonicalID implementations so
     // this currently an easy way to force colliding canonicalIDs
-    const q1 = Query.atPath(path('a')).addFilter(filter('foo', '==', 1));
-    const q2 = Query.atPath(path('a')).addFilter(filter('foo', '==', '1'));
+    const q1 = Target.atPath(path('a')).addFilter(filter('foo', '==', 1));
+    const q2 = Target.atPath(path('a')).addFilter(filter('foo', '==', '1'));
     expect(q1.canonicalId()).to.equal(q2.canonicalId());
 
     const data1 = testQueryData(q1, 1, 1);
@@ -196,7 +196,7 @@ function genericQueryCacheTests(
     await cache.addQueryData(testQueryData(QUERY_ROOMS, 1, 1));
     const updated = testQueryData(QUERY_ROOMS, 1, 2);
     await cache.updateQueryData(updated);
-    const retrieved = await cache.getQueryData(updated.query);
+    const retrieved = await cache.getQueryData(updated.target);
     expect(retrieved).to.deep.equal(updated);
   });
 

--- a/packages/firestore/test/unit/local/remote_document_cache.test.ts
+++ b/packages/firestore/test/unit/local/remote_document_cache.test.ts
@@ -16,7 +16,7 @@
  */
 
 import { expect } from 'chai';
-import { Query } from '../../../src/core/query';
+import { Target } from '../../../src/core/target';
 import { IndexedDbPersistence } from '../../../src/local/indexeddb_persistence';
 import { PersistenceTransaction } from '../../../src/local/persistence';
 import { PersistencePromise } from '../../../src/local/persistence_promise';
@@ -398,8 +398,8 @@ function genericRemoteDocumentCacheTests(
       doc('c/1', VERSION, DOC_DATA)
     ]);
 
-    const query = new Query(path('b'));
-    const matchingDocs = await cache.getDocumentsMatchingQuery(query);
+    const target = new Target(path('b'));
+    const matchingDocs = await cache.getDocumentsMatchingQuery(target);
 
     assertMatches(
       [doc('b/1', VERSION, DOC_DATA), doc('b/2', VERSION, DOC_DATA)],

--- a/packages/firestore/test/unit/local/test_mutation_queue.ts
+++ b/packages/firestore/test/unit/local/test_mutation_queue.ts
@@ -16,7 +16,7 @@
  */
 
 import { Timestamp } from '../../../src/api/timestamp';
-import { Query } from '../../../src/core/query';
+import { Target } from '../../../src/core/target';
 import { BatchId, ProtoByteString } from '../../../src/core/types';
 import { MutationQueue } from '../../../src/local/mutation_queue';
 import { Persistence } from '../../../src/local/persistence';
@@ -168,12 +168,14 @@ export class TestMutationQueue {
     );
   }
 
-  getAllMutationBatchesAffectingQuery(query: Query): Promise<MutationBatch[]> {
+  getAllMutationBatchesAffectingQuery(
+    target: Target
+  ): Promise<MutationBatch[]> {
     return this.persistence.runTransaction(
       'getAllMutationBatchesAffectingQuery',
       'readonly',
       txn => {
-        return this.queue.getAllMutationBatchesAffectingQuery(txn, query);
+        return this.queue.getAllMutationBatchesAffectingTarget(txn, target);
       }
     );
   }

--- a/packages/firestore/test/unit/local/test_query_cache.ts
+++ b/packages/firestore/test/unit/local/test_query_cache.ts
@@ -20,7 +20,7 @@ import { SnapshotVersion } from '../../../src/core/snapshot_version';
 import { ListenSequenceNumber, TargetId } from '../../../src/core/types';
 import { Persistence } from '../../../src/local/persistence';
 import { QueryCache } from '../../../src/local/query_cache';
-import { QueryData } from '../../../src/local/query_data';
+import { TargetData } from '../../../src/local/target_data';
 import { documentKeySet } from '../../../src/model/collections';
 import { DocumentKey } from '../../../src/model/document_key';
 
@@ -31,18 +31,18 @@ import { DocumentKey } from '../../../src/model/document_key';
 export class TestQueryCache {
   constructor(public persistence: Persistence, public cache: QueryCache) {}
 
-  addQueryData(queryData: QueryData): Promise<void> {
+  addQueryData(targetData: TargetData): Promise<void> {
     return this.persistence.runTransaction('addQueryData', 'readwrite', txn => {
-      return this.cache.addQueryData(txn, queryData);
+      return this.cache.addQueryData(txn, targetData);
     });
   }
 
-  updateQueryData(queryData: QueryData): Promise<void> {
+  updateQueryData(targetData: TargetData): Promise<void> {
     return this.persistence.runTransaction(
       'updateQueryData',
       'readwrite-primary',
       txn => {
-        return this.cache.updateQueryData(txn, queryData);
+        return this.cache.updateQueryData(txn, targetData);
       }
     );
   }
@@ -53,17 +53,17 @@ export class TestQueryCache {
     });
   }
 
-  removeQueryData(queryData: QueryData): Promise<void> {
+  removeQueryData(targetData: TargetData): Promise<void> {
     return this.persistence.runTransaction(
       'addQueryData',
       'readwrite-primary',
       txn => {
-        return this.cache.removeQueryData(txn, queryData);
+        return this.cache.removeQueryData(txn, targetData);
       }
     );
   }
 
-  getQueryData(target: Target): Promise<QueryData | null> {
+  getQueryData(target: Target): Promise<TargetData | null> {
     return this.persistence.runTransaction('getQueryData', 'readonly', txn => {
       return this.cache.getQueryData(txn, target);
     });

--- a/packages/firestore/test/unit/local/test_query_cache.ts
+++ b/packages/firestore/test/unit/local/test_query_cache.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { Query } from '../../../src/core/query';
+import { Target } from '../../../src/core/target';
 import { SnapshotVersion } from '../../../src/core/snapshot_version';
 import { ListenSequenceNumber, TargetId } from '../../../src/core/types';
 import { Persistence } from '../../../src/local/persistence';
@@ -63,9 +63,9 @@ export class TestQueryCache {
     );
   }
 
-  getQueryData(query: Query): Promise<QueryData | null> {
+  getQueryData(target: Target): Promise<QueryData | null> {
     return this.persistence.runTransaction('getQueryData', 'readonly', txn => {
-      return this.cache.getQueryData(txn, query);
+      return this.cache.getQueryData(txn, target);
     });
   }
 

--- a/packages/firestore/test/unit/local/test_remote_document_cache.ts
+++ b/packages/firestore/test/unit/local/test_remote_document_cache.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { Query } from '../../../src/core/query';
+import { Target } from '../../../src/core/target';
 import { IndexedDbRemoteDocumentCache } from '../../../src/local/indexeddb_remote_document_cache';
 import { Persistence } from '../../../src/local/persistence';
 import { PersistencePromise } from '../../../src/local/persistence_promise';
@@ -91,12 +91,12 @@ export class TestRemoteDocumentCache {
     });
   }
 
-  getDocumentsMatchingQuery(query: Query): Promise<DocumentMap> {
+  getDocumentsMatchingQuery(target: Target): Promise<DocumentMap> {
     return this.persistence.runTransaction(
       'getDocumentsMatchingQuery',
       'readonly',
       txn => {
-        return this.cache.getDocumentsMatchingQuery(txn, query);
+        return this.cache.getDocumentsMatchingTarget(txn, target);
       }
     );
   }

--- a/packages/firestore/test/unit/remote/node/serializer.test.ts
+++ b/packages/firestore/test/unit/remote/node/serializer.test.ts
@@ -36,7 +36,7 @@ import {
 } from '../../../../src/core/query';
 import { Target } from '../../../../src/core/target';
 import { SnapshotVersion } from '../../../../src/core/snapshot_version';
-import { QueryData, QueryPurpose } from '../../../../src/local/query_data';
+import { TargetData, QueryPurpose } from '../../../../src/local/target_data';
 import * as fieldValue from '../../../../src/model/field_value';
 import {
   DeleteMutation,
@@ -100,12 +100,12 @@ describe('Serializer', () => {
   // tslint:enable:variable-name
 
   /**
-   * Wraps the given query in QueryData. This is useful because the APIs we're
-   * testing accept QueryData, but for the most part we're just testing
+   * Wraps the given query in TargetData. This is useful because the APIs we're
+   * testing accept TargetData, but for the most part we're just testing
    * variations on Target.
    */
-  function wrapQueryData(target: Target): QueryData {
-    return new QueryData(
+  function wrapQueryData(target: Target): TargetData {
+    return new TargetData(
       target,
       1,
       QueryPurpose.Listen,
@@ -876,22 +876,22 @@ describe('Serializer', () => {
 
   it('encodes listen request labels', () => {
     const query = Target.atPath(path('collection/key'));
-    let queryData = new QueryData(query, 2, QueryPurpose.Listen, 3);
+    let targetData = new TargetData(query, 2, QueryPurpose.Listen, 3);
 
-    let result = s.toListenRequestLabels(queryData);
+    let result = s.toListenRequestLabels(targetData);
     expect(result).to.be.null;
 
-    queryData = new QueryData(query, 2, QueryPurpose.LimboResolution, 3);
-    result = s.toListenRequestLabels(queryData);
+    targetData = new TargetData(query, 2, QueryPurpose.LimboResolution, 3);
+    result = s.toListenRequestLabels(targetData);
     expect(result).to.deep.equal({ 'goog-listen-tags': 'limbo-document' });
 
-    queryData = new QueryData(
+    targetData = new TargetData(
       query,
       2,
       QueryPurpose.ExistenceFilterMismatch,
       3
     );
-    result = s.toListenRequestLabels(queryData);
+    result = s.toListenRequestLabels(targetData);
     expect(result).to.deep.equal({
       'goog-listen-tags': 'existence-filter-mismatch'
     });
@@ -1190,7 +1190,7 @@ describe('Serializer', () => {
     it('converts resume tokens', () => {
       const q = Target.atPath(path('docs'));
       const result = s.toTarget(
-        new QueryData(
+        new TargetData(
           q,
           1,
           QueryPurpose.Listen,

--- a/packages/firestore/test/unit/remote/node/serializer.test.ts
+++ b/packages/firestore/test/unit/remote/node/serializer.test.ts
@@ -32,9 +32,9 @@ import {
   InFilter,
   KeyFieldFilter,
   Operator,
-  OrderBy,
-  Query
+  OrderBy
 } from '../../../../src/core/query';
+import { Target } from '../../../../src/core/target';
 import { SnapshotVersion } from '../../../../src/core/snapshot_version';
 import { QueryData, QueryPurpose } from '../../../../src/local/query_data';
 import * as fieldValue from '../../../../src/model/field_value';
@@ -102,11 +102,11 @@ describe('Serializer', () => {
   /**
    * Wraps the given query in QueryData. This is useful because the APIs we're
    * testing accept QueryData, but for the most part we're just testing
-   * variations on Query.
+   * variations on Target.
    */
-  function wrapQueryData(query: Query): QueryData {
+  function wrapQueryData(target: Target): QueryData {
     return new QueryData(
-      query,
+      target,
       1,
       QueryPurpose.Listen,
       2,
@@ -875,7 +875,7 @@ describe('Serializer', () => {
   });
 
   it('encodes listen request labels', () => {
-    const query = Query.atPath(path('collection/key'));
+    const query = Target.atPath(path('collection/key'));
     let queryData = new QueryData(query, 2, QueryPurpose.Listen, 3);
 
     let result = s.toListenRequestLabels(queryData);
@@ -901,7 +901,7 @@ describe('Serializer', () => {
     addEqualityMatcher();
 
     it('converts first-level key queries', () => {
-      const q = Query.atPath(path('docs/1'));
+      const q = Target.atPath(path('docs/1'));
       const result = s.toTarget(wrapQueryData(q));
       expect(result).to.deep.equal({
         documents: { documents: ['projects/p/databases/d/documents/docs/1'] },
@@ -911,7 +911,7 @@ describe('Serializer', () => {
     });
 
     it('converts first-level ancestor queries', () => {
-      const q = Query.atPath(path('messages'));
+      const q = Target.atPath(path('messages'));
       const result = s.toTarget(wrapQueryData(q));
       expect(result).to.deep.equal({
         query: {
@@ -932,7 +932,7 @@ describe('Serializer', () => {
     });
 
     it('converts nested ancestor queries', () => {
-      const q = Query.atPath(path('rooms/1/messages/10/attachments'));
+      const q = Target.atPath(path('rooms/1/messages/10/attachments'));
       const result = s.toTarget(wrapQueryData(q));
       const expected = {
         query: {
@@ -954,7 +954,7 @@ describe('Serializer', () => {
     });
 
     it('converts single filters at first-level collections', () => {
-      const q = Query.atPath(path('docs')).addFilter(filter('prop', '<', 42));
+      const q = Target.atPath(path('docs')).addFilter(filter('prop', '<', 42));
       const result = s.toTarget(wrapQueryData(q));
       const expected = {
         query: {
@@ -987,7 +987,7 @@ describe('Serializer', () => {
     });
 
     it('converts multiple filters at first-level collections', () => {
-      const q = Query.atPath(path('docs'))
+      const q = Target.atPath(path('docs'))
         .addFilter(filter('prop', '<', 42))
         .addFilter(filter('name', '==', 'dimond'))
         .addFilter(filter('nan', '==', NaN))
@@ -1058,9 +1058,9 @@ describe('Serializer', () => {
     });
 
     it('converts single filters on deeper collections', () => {
-      const q = Query.atPath(path('rooms/1/messages/10/attachments')).addFilter(
-        filter('prop', '<', 42)
-      );
+      const q = Target.atPath(
+        path('rooms/1/messages/10/attachments')
+      ).addFilter(filter('prop', '<', 42));
       const result = s.toTarget(wrapQueryData(q));
       const expected = {
         query: {
@@ -1093,7 +1093,7 @@ describe('Serializer', () => {
     });
 
     it('converts order bys', () => {
-      const q = Query.atPath(path('docs')).addOrderBy(orderBy('prop', 'asc'));
+      const q = Target.atPath(path('docs')).addOrderBy(orderBy('prop', 'asc'));
       const result = s.toTarget(wrapQueryData(q));
       const expected = {
         query: {
@@ -1119,7 +1119,7 @@ describe('Serializer', () => {
     });
 
     it('converts limits', () => {
-      const q = Query.atPath(path('docs')).withLimit(26);
+      const q = Target.atPath(path('docs')).withLimit(26);
       const result = s.toTarget(wrapQueryData(q));
       const expected = {
         query: {
@@ -1142,7 +1142,7 @@ describe('Serializer', () => {
     });
 
     it('converts startAt/endAt', () => {
-      const q = Query.atPath(path('docs'))
+      const q = Target.atPath(path('docs'))
         .withStartAt(
           bound(
             [[DOCUMENT_KEY_NAME, ref('p/d', 'foo/bar'), 'asc']],
@@ -1188,7 +1188,7 @@ describe('Serializer', () => {
     });
 
     it('converts resume tokens', () => {
-      const q = Query.atPath(path('docs'));
+      const q = Target.atPath(path('docs'));
       const result = s.toTarget(
         new QueryData(
           q,

--- a/packages/firestore/test/unit/remote/remote_event.test.ts
+++ b/packages/firestore/test/unit/remote/remote_event.test.ts
@@ -18,7 +18,7 @@
 import { expect } from 'chai';
 import { SnapshotVersion } from '../../../src/core/snapshot_version';
 import { TargetId } from '../../../src/core/types';
-import { QueryData, QueryPurpose } from '../../../src/local/query_data';
+import { TargetData, QueryPurpose } from '../../../src/local/target_data';
 import { DocumentKeySet, documentKeySet } from '../../../src/model/collections';
 import { DocumentKey } from '../../../src/model/document_key';
 import { emptyByteString } from '../../../src/platform/platform';
@@ -37,7 +37,7 @@ import {
   doc,
   expectEqual,
   keys,
-  queryData,
+  targetData,
   resumeTokenForSnapshot,
   size,
   updateMapping,
@@ -45,7 +45,7 @@ import {
 } from '../../util/helpers';
 
 interface TargetMap {
-  [targetId: string]: QueryData;
+  [targetId: string]: TargetData;
 }
 interface PendingTargetResponses {
   [targetId: string]: number;
@@ -54,7 +54,7 @@ interface PendingTargetResponses {
 function listens(...targetIds: TargetId[]): TargetMap {
   const targets: TargetMap = {};
   for (const target of targetIds) {
-    targets[target] = queryData(target, QueryPurpose.Listen, 'coll');
+    targets[target] = targetData(target, QueryPurpose.Listen, 'coll');
   }
 
   return targets;
@@ -63,7 +63,7 @@ function listens(...targetIds: TargetId[]): TargetMap {
 function limboListens(...targetIds: TargetId[]): TargetMap {
   const targets: TargetMap = {};
   for (const target of targetIds) {
-    targets[target] = queryData(
+    targets[target] = targetData(
       target,
       QueryPurpose.LimboResolution,
       'coll/limbo'

--- a/packages/firestore/test/unit/specs/query_spec.test.ts
+++ b/packages/firestore/test/unit/specs/query_spec.test.ts
@@ -38,7 +38,7 @@ function specWithCachedDocs(...docs: Document[]): SpecBuilder {
 
 describeSpec('Queries:', [], () => {
   specTest('Collection Group query', [], () => {
-    const cgQuery = new Query(ResourcePath.EMPTY_PATH, 'cg');
+    const cgQuery = Query.newQuery(ResourcePath.EMPTY_PATH, 'cg');
     const cgQueryWithFilter = cgQuery.addFilter(filter('val', '==', 1));
     const docs = [
       doc('cg/1', 1000, { val: 1 }),
@@ -61,7 +61,7 @@ describeSpec('Queries:', [], () => {
   });
 
   specTest('Collection Group query with mutations', [], () => {
-    const cgQuery = new Query(ResourcePath.EMPTY_PATH, 'cg');
+    const cgQuery = Query.newQuery(ResourcePath.EMPTY_PATH, 'cg');
     const cgQueryWithFilter = cgQuery.addFilter(filter('val', '==', 1));
     const cachedDocs = [
       doc('cg/1', 1000, { val: 1 }),

--- a/packages/firestore/test/unit/specs/spec_test_runner.ts
+++ b/packages/firestore/test/unit/specs/spec_test_runner.ts
@@ -49,7 +49,7 @@ import { LocalStore } from '../../../src/local/local_store';
 import { LruParams } from '../../../src/local/lru_garbage_collector';
 import { MemoryPersistence } from '../../../src/local/memory_persistence';
 import { Persistence } from '../../../src/local/persistence';
-import { QueryData, QueryPurpose } from '../../../src/local/query_data';
+import { TargetData, QueryPurpose } from '../../../src/local/target_data';
 import {
   ClientId,
   MemorySharedClientState,
@@ -1108,7 +1108,7 @@ abstract class TestRunner {
       // encode that in the spec tests. For now, hard-code that it's a listen
       // despite the fact that it's not always the right value.
       const expectedTarget = this.serializer.toTarget(
-        new QueryData(
+        new TargetData(
           this.parseQuery(expected.query).toTarget(),
           targetId,
           QueryPurpose.Listen,

--- a/packages/firestore/test/unit/specs/spec_test_runner.ts
+++ b/packages/firestore/test/unit/specs/spec_test_runner.ts
@@ -1109,7 +1109,7 @@ abstract class TestRunner {
       // despite the fact that it's not always the right value.
       const expectedTarget = this.serializer.toTarget(
         new QueryData(
-          this.parseQuery(expected.query),
+          this.parseQuery(expected.query).toTarget(),
           targetId,
           QueryPurpose.Listen,
           ARBITRARY_SEQUENCE_NUMBER,
@@ -1183,7 +1183,10 @@ abstract class TestRunner {
     if (typeof querySpec === 'string') {
       return Query.atPath(path(querySpec));
     } else {
-      let query = new Query(path(querySpec.path), querySpec.collectionGroup);
+      let query = Query.newQuery(
+        path(querySpec.path),
+        querySpec.collectionGroup
+      );
       if (querySpec.limit) {
         query = query.withLimit(querySpec.limit);
       }

--- a/packages/firestore/test/util/helpers.ts
+++ b/packages/firestore/test/util/helpers.ts
@@ -276,7 +276,7 @@ export function queryData(
   // Arbitrary value.
   const sequenceNumber = 0;
   return new QueryData(
-    query(path)._query,
+    query(path)._query.toTarget(),
     targetId,
     queryPurpose,
     sequenceNumber

--- a/packages/firestore/test/util/helpers.ts
+++ b/packages/firestore/test/util/helpers.ts
@@ -43,7 +43,7 @@ import {
   ViewChange
 } from '../../src/core/view';
 import { LocalViewChanges } from '../../src/local/local_view_changes';
-import { QueryData, QueryPurpose } from '../../src/local/query_data';
+import { TargetData, QueryPurpose } from '../../src/local/target_data';
 import {
   DocumentKeySet,
   documentKeySet,
@@ -268,14 +268,14 @@ export function bound(
   return new Bound(components, before);
 }
 
-export function queryData(
+export function targetData(
   targetId: TargetId,
   queryPurpose: QueryPurpose,
   path: string
-): QueryData {
+): TargetData {
   // Arbitrary value.
   const sequenceNumber = 0;
-  return new QueryData(
+  return new TargetData(
     query(path)._query.toTarget(),
     targetId,
     queryPurpose,
@@ -301,7 +301,7 @@ export function docAddedRemoteEvent(
     getQueryDataForTarget: targetId => {
       if (allTargets.indexOf(targetId) !== -1) {
         const collectionPath = docs[0].key.path.popLast();
-        return queryData(
+        return targetData(
           targetId,
           QueryPurpose.Listen,
           collectionPath.toString()
@@ -353,7 +353,7 @@ export function docUpdateRemoteEvent(
         limboTargets && limboTargets.indexOf(targetId) !== -1
           ? QueryPurpose.LimboResolution
           : QueryPurpose.Listen;
-      return queryData(targetId, purpose, doc.key.toString());
+      return targetData(targetId, purpose, doc.key.toString());
     }
   });
   aggregator.handleDocumentChange(docChange);


### PR DESCRIPTION
Splitting `Query` and `Target` to serve different purpose: `Query` for queries with local features, `Target` for queries sent to backend.

It's probably best to review this in the commit order, the most significant commits come first, the bulk renaming commits come after those.