### PR TITLE
Update docs to link to CDN guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 The Firebase JavaScript SDK implements the client-side libraries used by
 applications using Firebase services. This SDK is distributed via:
 
-- CDN (`<script src="https://www.gstatic.com/firebasejs/5.5.3/firebase.js"></script>`)
+- [CDN](https://firebase.google.com/docs/web/setup/#add-sdks-initialize)
 - [npm package](https://www.npmjs.com/package/firebase)
 - [Bower package](https://github.com/firebase/firebase-bower)
 

--- a/scripts/docgen/content-sources/js/HOME.md
+++ b/scripts/docgen/content-sources/js/HOME.md
@@ -2,7 +2,7 @@
 The Firebase JavaScript SDK implements the client-side libraries used by
 applications using Firebase services. This SDK is distributed via:
 
-- CDN (`<script src="https://www.gstatic.com/firebasejs/{{ web_sdk_version }}/firebase.js"></script>`)
+- [CDN](/docs/web/setup/#add-sdks-initialize)
 - [npm package](https://www.npmjs.com/package/firebase)
 - [Bower package](https://github.com/firebase/firebase-bower)
 

--- a/scripts/docgen/content-sources/node/HOME.md
+++ b/scripts/docgen/content-sources/node/HOME.md
@@ -2,7 +2,7 @@
 The Firebase JavaScript SDK implements the client-side libraries used by
 applications using Firebase services. This SDK is distributed via:
 
-- CDN (`<script src="https://www.gstatic.com/firebasejs/{{ web_sdk_version }}/firebase.js"></script>`)
+- [CDN](/docs/web/setup/#add-sdks-initialize)
 - [npm package](https://www.npmjs.com/package/firebase)
 - [Bower package](https://github.com/firebase/firebase-bower)
 


### PR DESCRIPTION
Script tag snippet next to CDN option looks odd and is misleading (points users at use all-in-one package, which is not recommended).  Using a link to direct users to appropriate documentation page instead.