### PR TITLE
add @firebase/analytics to firebase deps

### DIFF
--- a/packages/firebase/package.json
+++ b/packages/firebase/package.json
@@ -50,6 +50,7 @@
     "@firebase/storage": "0.3.12",
     "@firebase/performance": "0.2.19",
     "@firebase/remote-config": "0.1.0",
+    "@firebase/analytics": "0.1.0",
     "@firebase/util": "0.2.28"
   },
   "devDependencies": {

--- a/packages/firebase/src/index.cdn.ts
+++ b/packages/firebase/src/index.cdn.ts
@@ -36,5 +36,7 @@ import '../functions';
 import '../messaging';
 import '../storage';
 import '../performance';
+import '../analytics';
+import '../remote-config';
 
 export default firebase;

--- a/packages/firebase/src/index.ts
+++ b/packages/firebase/src/index.ts
@@ -45,5 +45,7 @@ import '../functions';
 import '../messaging';
 import '../storage';
 import '../performance';
+import '../analytics';
+import '../remote-config';
 
 export default firebase;


### PR DESCRIPTION
`@firebase/analytics` should be a dependency of `firebase`, so it's not bundled inside `firebase`.
The issue is reported here at https://github.com/firebase/firebase-js-sdk/issues/2213.