### PR TITLE
Fix CDN link

### DIFF
--- a/scripts/docgen/content-sources/js/HOME.md
+++ b/scripts/docgen/content-sources/js/HOME.md
@@ -2,7 +2,7 @@
 The Firebase JavaScript SDK implements the client-side libraries used by
 applications using Firebase services. This SDK is distributed via:
 
-- CDN (`<script src="https://www.gstatic.com/firebasejs/{{ web_sdk_version }}/firebase.js"></script>`)
+- [CDN](https://firebase.google.com/docs/web/setup/#add-sdks-initialize)
 - [npm package](https://www.npmjs.com/package/firebase)
 - [Bower package](https://github.com/firebase/firebase-bower)
 

--- a/scripts/docgen/content-sources/node/HOME.md
+++ b/scripts/docgen/content-sources/node/HOME.md
@@ -2,7 +2,7 @@
 The Firebase JavaScript SDK implements the client-side libraries used by
 applications using Firebase services. This SDK is distributed via:
 
-- CDN (`<script src="https://www.gstatic.com/firebasejs/{{ web_sdk_version }}/firebase.js"></script>`)
+- [CDN](https://firebase.google.com/docs/web/setup/#add-sdks-initialize)
 - [npm package](https://www.npmjs.com/package/firebase)
 - [Bower package](https://github.com/firebase/firebase-bower)
 


### PR DESCRIPTION
Switching our CDN link over to the per-feature approach used in the Web setup guide.

Staged internally at https://firebase.devsite.corp.google.com/docs/reference/js?skip_cache=true

Thanks!
