### PR TITLE
Make event params optional in logEvent

### DIFF
--- a/packages/analytics-types/index.d.ts
+++ b/packages/analytics-types/index.d.ts
@@ -46,7 +46,7 @@ export interface FirebaseAnalytics {
    */
   logEvent(
     eventName: EventNameString,
-    eventParams: EventParams,
+    eventParams?: EventParams,
     options?: AnalyticsCallOptions
   ): void;
 

--- a/packages/analytics/src/functions.test.ts
+++ b/packages/analytics/src/functions.test.ts
@@ -51,6 +51,18 @@ describe('FirebaseAnalytics methods', () => {
     );
   });
 
+  it('logEvent() with no event params calls gtag function correctly', () => {
+    logEvent(gtagStub, analyticsId, EventName.VIEW_ITEM);
+
+    expect(gtagStub).to.have.been.calledWith(
+      GtagCommand.EVENT,
+      EventName.VIEW_ITEM,
+      {
+        'send_to': analyticsId
+      }
+    );
+  });
+
   it('logEvent() globally calls gtag function correctly', () => {
     logEvent(
       gtagStub,
@@ -68,6 +80,22 @@ describe('FirebaseAnalytics methods', () => {
       {
         currency: 'USD'
       }
+    );
+  });
+
+  it('logEvent() with no event params globally calls gtag function correctly', () => {
+    logEvent(
+      gtagStub,
+      analyticsId,
+      EventName.ADD_TO_CART,
+      undefined,
+      { global: true }
+    );
+
+    expect(gtagStub).to.have.been.calledWith(
+      GtagCommand.EVENT,
+      EventName.ADD_TO_CART,
+      {}
     );
   });
 

--- a/packages/analytics/src/functions.test.ts
+++ b/packages/analytics/src/functions.test.ts
@@ -84,13 +84,9 @@ describe('FirebaseAnalytics methods', () => {
   });
 
   it('logEvent() with no event params globally calls gtag function correctly', () => {
-    logEvent(
-      gtagStub,
-      analyticsId,
-      EventName.ADD_TO_CART,
-      undefined,
-      { global: true }
-    );
+    logEvent(gtagStub, analyticsId, EventName.ADD_TO_CART, undefined, {
+      global: true
+    });
 
     expect(gtagStub).to.have.been.calledWith(
       GtagCommand.EVENT,

--- a/packages/analytics/src/functions.ts
+++ b/packages/analytics/src/functions.ts
@@ -34,10 +34,10 @@ export function logEvent(
   gtagFunction: Gtag,
   analyticsId: string,
   eventName: string,
-  eventParams: EventParams,
+  eventParams?: EventParams,
   options?: AnalyticsCallOptions
 ): void {
-  let params: EventParams | ControlParams = eventParams;
+  let params: EventParams | ControlParams = eventParams || {};
   if (!options || !options.global) {
     params = { ...eventParams, 'send_to': analyticsId };
   }

--- a/packages/firebase/index.d.ts
+++ b/packages/firebase/index.d.ts
@@ -4298,7 +4298,7 @@ declare namespace firebase.analytics {
      */
     logEvent<T extends string>(
       eventName: CustomEventName<T>,
-      eventParams: { [key: string]: any },
+      eventParams?: { [key: string]: any },
       options?: firebase.analytics.AnalyticsCallOptions
     ): void;
 


### PR DESCRIPTION
It seems like a common enough case to call logEvent with no params.  Making this allowable in the type, and ensuring there is a default in the gtag call.