### PR TITLE
Update SequenceNumber in LocalStore.applyRemoteEvent

### DIFF
--- a/packages/firestore/src/local/local_store.ts
+++ b/packages/firestore/src/local/local_store.ts
@@ -501,10 +501,9 @@ export class LocalStore {
             const resumeToken = change.resumeToken;
             // Update the resume token if the change includes one.
             if (resumeToken.length > 0) {
-              const newQueryData = oldQueryData.withResumeToken(
-                resumeToken,
-                remoteVersion
-              );
+              const newQueryData = oldQueryData
+                .withResumeToken(resumeToken, remoteVersion)
+                .withSequenceNumber(txn.currentSequenceNumber);
               this.queryDataByTarget[targetId] = newQueryData;
 
               // Update the query data if there are target changes (or if


### PR DESCRIPTION
iOS and Android update the sequence number in LcoalStore.applyRemoteEvent(). This prevents LRU GC for a query that does not explicitly go through releaseQuery.