### PR TITLE
Make vscode tests run against emulator

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -61,8 +61,9 @@
       ],
       "env": {
         "TS_NODE_CACHE": "NO",
-        "TS_NODE_COMPILER_OPTIONS" : "{\"module\":\"commonjs\"}"
-
+        "TS_NODE_COMPILER_OPTIONS" : "{\"module\":\"commonjs\"}",
+        "FIRESTORE_EMULATOR_PORT" : "8080",
+        "FIRESTORE_EMULATOR_PROJECT_ID" :  "test-emulator"
       },
       "sourceMaps": true,
       "protocol": "inspector"
@@ -84,8 +85,9 @@
       "env": {
         "USE_MOCK_PERSISTENCE": "YES",
         "TS_NODE_CACHE": "NO",
-        "TS_NODE_COMPILER_OPTIONS" : "{\"module\":\"commonjs\"}"
-
+        "TS_NODE_COMPILER_OPTIONS" : "{\"module\":\"commonjs\"}",
+        "FIRESTORE_EMULATOR_PORT" : "8080",
+        "FIRESTORE_EMULATOR_PROJECT_ID" :  "test-emulator"
       },
       "sourceMaps": true,
       "protocol": "inspector"


### PR DESCRIPTION
CLI invoked tests already run against the emulator by default, and the .vscode ones should as well. 