### PR TITLE
Serialize Timestamps as string (per proto3 JSON format).

### DIFF
--- a/packages/firestore/CHANGELOG.md
+++ b/packages/firestore/CHANGELOG.md
@@ -2,6 +2,8 @@
 - [fixed] Fixed a regression that caused queries with nested field filters to
   crash the client if the field was not present in the local copy of the
   document. 
+- [fixed] Fixed an issue that caused requests with timestamps to Firestore
+  Emulator to fail.
 
 # 1.5.0
 - [feature] Added a `Firestore.waitForPendingWrites()` method that

--- a/packages/firestore/test/unit/remote/node/serializer.test.ts
+++ b/packages/firestore/test/unit/remote/node/serializer.test.ts
@@ -321,6 +321,12 @@ describe('Serializer', () => {
 
       expect(
         proto3JsonSerializer.toValue(
+          new fieldValue.TimestampValue(new Timestamp(1488872578, 916000))
+        )
+      ).to.deep.equal({ timestampValue: '2017-03-07T07:42:58.000916000Z' });
+
+      expect(
+        proto3JsonSerializer.toValue(
           new fieldValue.TimestampValue(new Timestamp(1488872578, 0))
         )
       ).to.deep.equal({ timestampValue: '2017-03-07T07:42:58.000000000Z' });

--- a/packages/firestore/test/unit/remote/node/serializer.test.ts
+++ b/packages/firestore/test/unit/remote/node/serializer.test.ts
@@ -303,31 +303,27 @@ describe('Serializer', () => {
     it('converts TimestampValue to string (useProto3Json=true)', () => {
       expect(
         proto3JsonSerializer.toValue(
-          new fieldValue.TimestampValue(new Timestamp(1488872578, 916123456)))
-      ).to.deep.equal(
-        { timestampValue: '2017-03-07T07:42:58.916123456Z' }
-      );
+          new fieldValue.TimestampValue(new Timestamp(1488872578, 916123456))
+        )
+      ).to.deep.equal({ timestampValue: '2017-03-07T07:42:58.916123456Z' });
 
       expect(
         proto3JsonSerializer.toValue(
-          new fieldValue.TimestampValue(new Timestamp(1488872578, 916123000)))
-      ).to.deep.equal(
-        { timestampValue: '2017-03-07T07:42:58.916123000Z' }
-      );
+          new fieldValue.TimestampValue(new Timestamp(1488872578, 916123000))
+        )
+      ).to.deep.equal({ timestampValue: '2017-03-07T07:42:58.916123000Z' });
 
       expect(
         proto3JsonSerializer.toValue(
-          new fieldValue.TimestampValue(new Timestamp(1488872578, 916000000)))
-      ).to.deep.equal(
-        { timestampValue: '2017-03-07T07:42:58.916000000Z' }
-      );
+          new fieldValue.TimestampValue(new Timestamp(1488872578, 916000000))
+        )
+      ).to.deep.equal({ timestampValue: '2017-03-07T07:42:58.916000000Z' });
 
       expect(
         proto3JsonSerializer.toValue(
-          new fieldValue.TimestampValue(new Timestamp(1488872578, 0)))
-      ).to.deep.equal(
-        { timestampValue: '2017-03-07T07:42:58.000000000Z' }
-      );
+          new fieldValue.TimestampValue(new Timestamp(1488872578, 0))
+        )
+      ).to.deep.equal({ timestampValue: '2017-03-07T07:42:58.000000000Z' });
     });
 
     it('converts GeoPointValue', () => {

--- a/packages/firestore/test/unit/remote/node/serializer.test.ts
+++ b/packages/firestore/test/unit/remote/node/serializer.test.ts
@@ -300,6 +300,36 @@ describe('Serializer', () => {
       );
     });
 
+    it('converts TimestampValue to string (useProto3Json=true)', () => {
+      expect(
+        proto3JsonSerializer.toValue(
+          new fieldValue.TimestampValue(new Timestamp(1488872578, 916123456)))
+      ).to.deep.equal(
+        { timestampValue: '2017-03-07T07:42:58.916123456Z' }
+      );
+
+      expect(
+        proto3JsonSerializer.toValue(
+          new fieldValue.TimestampValue(new Timestamp(1488872578, 916123000)))
+      ).to.deep.equal(
+        { timestampValue: '2017-03-07T07:42:58.916123000Z' }
+      );
+
+      expect(
+        proto3JsonSerializer.toValue(
+          new fieldValue.TimestampValue(new Timestamp(1488872578, 916000000)))
+      ).to.deep.equal(
+        { timestampValue: '2017-03-07T07:42:58.916000000Z' }
+      );
+
+      expect(
+        proto3JsonSerializer.toValue(
+          new fieldValue.TimestampValue(new Timestamp(1488872578, 0)))
+      ).to.deep.equal(
+        { timestampValue: '2017-03-07T07:42:58.000000000Z' }
+      );
+    });
+
     it('converts GeoPointValue', () => {
       const example = new GeoPoint(1.23, 4.56);
       const expected = {


### PR DESCRIPTION
This fixes using timestamps with the Firestore Emulator. This is similar to #2228, but for timestamps.

### Discussion

(Internal tracking ID: 37282237)

### Testing

Tested manually against the Firestore Emulator and production Firestore.

### API Changes

None.