### PR TITLE
Marking SimpleDb calls as idempotent

### DIFF
--- a/packages/firestore/src/local/indexeddb_persistence.ts
+++ b/packages/firestore/src/local/indexeddb_persistence.ts
@@ -327,20 +327,17 @@ export class IndexedDbPersistence implements Persistence {
 
         return this.startRemoteDocumentCache();
       })
-      .then(() => {
-        return this.simpleDb.runTransaction(
+      .then(() =>
+        this.simpleDb.runTransaction(
           'readonly-idempotent',
           [DbTargetGlobal.store],
-          txn => {
-            return getHighestListenSequenceNumber(txn).next(
-              highestListenSequenceNumber => {
-                this.listenSequence = new ListenSequence(
-                  highestListenSequenceNumber,
-                  this.sequenceNumberSyncer
-                );
-              }
-            );
-          }
+          txn => getHighestListenSequenceNumber(txn)
+        )
+      )
+      .then(highestListenSequenceNumber => {
+        this.listenSequence = new ListenSequence(
+          highestListenSequenceNumber,
+          this.sequenceNumberSyncer
         );
       })
       .then(() => {

--- a/packages/firestore/src/local/indexeddb_persistence.ts
+++ b/packages/firestore/src/local/indexeddb_persistence.ts
@@ -329,7 +329,7 @@ export class IndexedDbPersistence implements Persistence {
       })
       .then(() => {
         return this.simpleDb.runTransaction(
-          'readonly',
+          'readonly-idempotent',
           [DbTargetGlobal.store],
           txn => {
             return getHighestListenSequenceNumber(txn).next(
@@ -654,7 +654,7 @@ export class IndexedDbPersistence implements Persistence {
     this.detachVisibilityHandler();
     this.detachWindowUnloadHook();
     await this.simpleDb.runTransaction(
-      'readwrite',
+      'readwrite-idempotent',
       [DbPrimaryClient.store, DbClientMetadata.store],
       txn => {
         return this.releasePrimaryLeaseIfHeld(txn).next(() =>
@@ -686,7 +686,7 @@ export class IndexedDbPersistence implements Persistence {
 
   getActiveClients(): Promise<ClientId[]> {
     return this.simpleDb.runTransaction(
-      'readonly',
+      'readonly-idempotent',
       [DbClientMetadata.store],
       txn => {
         return clientMetadataStore(txn)

--- a/packages/firestore/src/local/simple_db.ts
+++ b/packages/firestore/src/local/simple_db.ts
@@ -260,8 +260,8 @@ export class SimpleDb {
     objectStores: string[],
     transactionFn: (transaction: SimpleDbTransaction) => PersistencePromise<T>
   ): Promise<T> {
-    let readonly = mode.startsWith('idempotent');
-    let idempotent = mode.endsWith('idempotent');
+    const readonly = mode.startsWith('readonly');
+    const idempotent = mode.endsWith('idempotent');
     let attemptNumber = 0;
 
     while (true) {

--- a/packages/firestore/test/unit/local/encoded_resource_path.test.ts
+++ b/packages/firestore/test/unit/local/encoded_resource_path.test.ts
@@ -216,12 +216,7 @@ function runTransaction<T>(
     transaction: SimpleDbTransaction
   ) => PersistencePromise<T>
 ): Promise<T> {
-  return db.runTransaction<T>(
-    'readwrite',
-    /* idempotent= */ false,
-    ['test'],
-    txn => {
-      return fn(txn.store<string, boolean>('test'), txn);
-    }
-  );
+  return db.runTransaction<T>('readwrite', ['test'], txn => {
+    return fn(txn.store<string, boolean>('test'), txn);
+  });
 }

--- a/packages/firestore/test/unit/local/encoded_resource_path.test.ts
+++ b/packages/firestore/test/unit/local/encoded_resource_path.test.ts
@@ -217,12 +217,7 @@ function runTransaction<T>(
     transaction: SimpleDbTransaction
   ) => PersistencePromise<T>
 ): Promise<T> {
-  return db.runTransaction<T>(
-    'readwrite-idempotent',
-    ['test'],
-    txn => {
-      return fn(txn.store<string, boolean>('test'), txn);
-    }
-  );
-
+  return db.runTransaction<T>('readwrite-idempotent', ['test'], txn => {
+    return fn(txn.store<string, boolean>('test'), txn);
+  });
 }

--- a/packages/firestore/test/unit/local/encoded_resource_path.test.ts
+++ b/packages/firestore/test/unit/local/encoded_resource_path.test.ts
@@ -182,12 +182,13 @@ async function assertOrdered(paths: ResourcePath[]): Promise<void> {
   });
   paths.reverse();
 
-  const selected: string[] = [];
-  await runTransaction(simpleStore => {
-    selected.splice(0); // The function might get re-run.
-    return simpleStore.iterate({ keysOnly: true }, key => {
-      selected.push(key);
-    });
+  const selected = await runTransaction(simpleStore => {
+    const allKeys: string[] = [];
+    return simpleStore
+      .iterate({ keysOnly: true }, key => {
+        allKeys.push(key);
+      })
+      .next(() => allKeys);
   });
 
   // Finally, verify all the orderings.

--- a/packages/firestore/test/unit/local/encoded_resource_path.test.ts
+++ b/packages/firestore/test/unit/local/encoded_resource_path.test.ts
@@ -216,7 +216,12 @@ function runTransaction<T>(
     transaction: SimpleDbTransaction
   ) => PersistencePromise<T>
 ): Promise<T> {
-  return db.runTransaction<T>('readwrite', ['test'], txn => {
-    return fn(txn.store<string, boolean>('test'), txn);
-  });
+  return db.runTransaction<T>(
+    'readwrite',
+    /* idempotent= */ false,
+    ['test'],
+    txn => {
+      return fn(txn.store<string, boolean>('test'), txn);
+    }
+  );
 }

--- a/packages/firestore/test/unit/local/encoded_resource_path.test.ts
+++ b/packages/firestore/test/unit/local/encoded_resource_path.test.ts
@@ -184,6 +184,7 @@ async function assertOrdered(paths: ResourcePath[]): Promise<void> {
 
   const selected: string[] = [];
   await runTransaction(simpleStore => {
+    selected.splice(0); // The function might get re-run.
     return simpleStore.iterate({ keysOnly: true }, key => {
       selected.push(key);
     });
@@ -216,7 +217,12 @@ function runTransaction<T>(
     transaction: SimpleDbTransaction
   ) => PersistencePromise<T>
 ): Promise<T> {
-  return db.runTransaction<T>('readwrite', ['test'], txn => {
-    return fn(txn.store<string, boolean>('test'), txn);
-  });
+  return db.runTransaction<T>(
+    'readwrite-idempotent',
+    ['test'],
+    txn => {
+      return fn(txn.store<string, boolean>('test'), txn);
+    }
+  );
+
 }

--- a/packages/firestore/test/unit/local/indexeddb_persistence.test.ts
+++ b/packages/firestore/test/unit/local/indexeddb_persistence.test.ts
@@ -223,7 +223,7 @@ describe('IndexedDbSchema: createOrUpgradeDb', () => {
     return withDb(2, db => {
       const sdb = new SimpleDb(db);
       return sdb.runTransaction(
-        'readwrite',
+        'readwrite-idempotent',
         [DbTarget.store, DbTargetGlobal.store, DbMutationBatch.store],
         txn => {
           const targets = txn.store<DbTargetKey, DbTarget>(DbTarget.store);
@@ -252,7 +252,7 @@ describe('IndexedDbSchema: createOrUpgradeDb', () => {
 
         const sdb = new SimpleDb(db);
         return sdb.runTransaction(
-          'readwrite',
+          'readwrite-idempotent',
           [DbTarget.store, DbTargetGlobal.store, DbMutationBatch.store],
           txn => {
             const targets = txn.store<DbTargetKey, DbTarget>(DbTarget.store);
@@ -317,7 +317,7 @@ describe('IndexedDbSchema: createOrUpgradeDb', () => {
 
     return withDb(3, db => {
       const sdb = new SimpleDb(db);
-      return sdb.runTransaction('readwrite', [DbMutationBatch.store], txn => {
+      return sdb.runTransaction('readwrite-idempotent', [DbMutationBatch.store], txn => {
         const store = txn.store(DbMutationBatch.store);
         return PersistencePromise.forEach(
           testMutations,
@@ -330,7 +330,7 @@ describe('IndexedDbSchema: createOrUpgradeDb', () => {
         expect(getAllObjectStores(db)).to.have.members(V4_STORES);
 
         const sdb = new SimpleDb(db);
-        return sdb.runTransaction('readwrite', [DbMutationBatch.store], txn => {
+        return sdb.runTransaction('readwrite-idempotent', [DbMutationBatch.store], txn => {
           const store = txn.store<DbMutationBatchKey, DbMutationBatch>(
             DbMutationBatch.store
           );
@@ -422,7 +422,7 @@ describe('IndexedDbSchema: createOrUpgradeDb', () => {
     return withDb(4, db => {
       const sdb = new SimpleDb(db);
       // We can only use the V4 stores here, since that's as far as we've upgraded.
-      return sdb.runTransaction('readwrite', V4_STORES, txn => {
+      return sdb.runTransaction('readwrite-idempotent', V4_STORES, txn => {
         const mutationBatchStore = txn.store<
           DbMutationBatchKey,
           DbMutationBatch
@@ -471,7 +471,7 @@ describe('IndexedDbSchema: createOrUpgradeDb', () => {
 
         const sdb = new SimpleDb(db);
         // There is no V5_STORES, continue using V4.
-        return sdb.runTransaction('readwrite', V4_STORES, txn => {
+        return sdb.runTransaction('readwrite-idempotent', V4_STORES, txn => {
           const mutationBatchStore = txn.store<
             DbMutationBatchKey,
             DbMutationBatch
@@ -523,7 +523,7 @@ describe('IndexedDbSchema: createOrUpgradeDb', () => {
       }));
       // V5 stores doesn't exist
       const sdb = new SimpleDb(db);
-      return sdb.runTransaction('readwrite', V4_STORES, txn => {
+      return sdb.runTransaction('readwrite-idempotent', V4_STORES, txn => {
         const store = txn.store<DbRemoteDocumentKey, DbRemoteDocument>(
           DbRemoteDocument.store
         );
@@ -536,7 +536,7 @@ describe('IndexedDbSchema: createOrUpgradeDb', () => {
     });
     await withDb(6, db => {
       const sdb = new SimpleDb(db);
-      return sdb.runTransaction('readonly', V6_STORES, txn => {
+      return sdb.runTransaction('readwrite-idempotent', V6_STORES, txn => {
         const store = txn.store<
           DbRemoteDocumentGlobalKey,
           DbRemoteDocumentGlobal
@@ -559,7 +559,7 @@ describe('IndexedDbSchema: createOrUpgradeDb', () => {
       const serializer = TEST_SERIALIZER;
 
       const sdb = new SimpleDb(db);
-      return sdb.runTransaction('readwrite', V6_STORES, txn => {
+      return sdb.runTransaction('readwrite-idempotent', V6_STORES, txn => {
         const targetGlobalStore = txn.store<DbTargetGlobalKey, DbTargetGlobal>(
           DbTargetGlobal.store
         );
@@ -610,7 +610,7 @@ describe('IndexedDbSchema: createOrUpgradeDb', () => {
     // Now run the migration and verify
     await withDb(7, db => {
       const sdb = new SimpleDb(db);
-      return sdb.runTransaction('readonly', V6_STORES, txn => {
+      return sdb.runTransaction('readwrite-idempotent', V6_STORES, txn => {
         const targetDocumentStore = txn.store<
           DbTargetDocumentKey,
           DbTargetDocument
@@ -661,7 +661,7 @@ describe('IndexedDbSchema: createOrUpgradeDb', () => {
 
     await withDb(7, db => {
       const sdb = new SimpleDb(db);
-      return sdb.runTransaction('readwrite', V6_STORES, txn => {
+      return sdb.runTransaction('readwrite-idempotent', V6_STORES, txn => {
         const remoteDocumentStore = txn.store<
           DbRemoteDocumentKey,
           DbRemoteDocument
@@ -698,7 +698,7 @@ describe('IndexedDbSchema: createOrUpgradeDb', () => {
     // Migrate to v8 and verify index entries.
     await withDb(8, db => {
       const sdb = new SimpleDb(db);
-      return sdb.runTransaction('readwrite', V8_STORES, txn => {
+      return sdb.runTransaction('readwrite-idempotent', V8_STORES, txn => {
         const collectionParentsStore = txn.store<
           DbCollectionParentKey,
           DbCollectionParent
@@ -740,7 +740,7 @@ describe('IndexedDbSchema: createOrUpgradeDb', () => {
 
     await withDb(8, db => {
       const sdb = new SimpleDb(db);
-      return sdb.runTransaction('readwrite', V8_STORES, txn => {
+      return sdb.runTransaction('readwrite-idempotent', V8_STORES, txn => {
         const remoteDocumentStore = txn.store<
           DbRemoteDocumentKey,
           DbRemoteDocument
@@ -769,7 +769,7 @@ describe('IndexedDbSchema: createOrUpgradeDb', () => {
     // Migrate to v9 and verify that new documents are indexed.
     await withDb(9, db => {
       const sdb = new SimpleDb(db);
-      return sdb.runTransaction('readwrite', V8_STORES, txn => {
+      return sdb.runTransaction('readwrite-idempotent', V8_STORES, txn => {
         const remoteDocumentStore = txn.store<
           DbRemoteDocumentKey,
           DbRemoteDocument
@@ -816,7 +816,7 @@ describe('IndexedDbSchema: createOrUpgradeDb', () => {
 
     await withDb(9, db => {
       const sdb = new SimpleDb(db);
-      return sdb.runTransaction('readwrite', V8_STORES, txn => {
+      return sdb.runTransaction('readwrite-idempotent', V8_STORES, txn => {
         return addDocs(txn, oldDocPaths, /* version= */ 1).next(() =>
           addDocs(txn, newDocPaths, /* version= */ 2).next(() => {
             const remoteDocumentStore = txn.store<
@@ -850,7 +850,7 @@ describe('IndexedDbSchema: createOrUpgradeDb', () => {
 
     await withDb(9, db => {
       const sdb = new SimpleDb(db);
-      return sdb.runTransaction('readwrite', V8_STORES, txn => {
+      return sdb.runTransaction('readwrite-idempotent', V8_STORES, txn => {
         return addDocs(txn, oldDocPaths, /* version= */ 1).next(() =>
           addDocs(txn, newDocPaths, /* version= */ 2).next(() => {
             const remoteDocumentStore = txn.store<
@@ -912,7 +912,7 @@ describe('IndexedDb: canActAsPrimary', () => {
       SCHEMA_VERSION,
       new SchemaConverter(TEST_SERIALIZER)
     );
-    await simpleDb.runTransaction('readwrite', [DbPrimaryClient.store], txn => {
+    await simpleDb.runTransaction('readwrite-idempotent', [DbPrimaryClient.store], txn => {
       const primaryStore = txn.store<DbPrimaryClientKey, DbPrimaryClient>(
         DbPrimaryClient.store
       );

--- a/packages/firestore/test/unit/local/indexeddb_persistence.test.ts
+++ b/packages/firestore/test/unit/local/indexeddb_persistence.test.ts
@@ -224,7 +224,6 @@ describe('IndexedDbSchema: createOrUpgradeDb', () => {
       const sdb = new SimpleDb(db);
       return sdb.runTransaction(
         'readwrite',
-        /* idempotent= */ false,
         [DbTarget.store, DbTargetGlobal.store, DbMutationBatch.store],
         txn => {
           const targets = txn.store<DbTargetKey, DbTarget>(DbTarget.store);
@@ -254,7 +253,6 @@ describe('IndexedDbSchema: createOrUpgradeDb', () => {
         const sdb = new SimpleDb(db);
         return sdb.runTransaction(
           'readwrite',
-          /* idempotent= */ false,
           [DbTarget.store, DbTargetGlobal.store, DbMutationBatch.store],
           txn => {
             const targets = txn.store<DbTargetKey, DbTarget>(DbTarget.store);
@@ -319,49 +317,39 @@ describe('IndexedDbSchema: createOrUpgradeDb', () => {
 
     return withDb(3, db => {
       const sdb = new SimpleDb(db);
-      return sdb.runTransaction(
-        'readwrite',
-        /* idempotent= */ false,
-        [DbMutationBatch.store],
-        txn => {
-          const store = txn.store(DbMutationBatch.store);
-          return PersistencePromise.forEach(
-            testMutations,
-            (testMutation: DbMutationBatch) => store.put(testMutation)
-          );
-        }
-      );
+      return sdb.runTransaction('readwrite', [DbMutationBatch.store], txn => {
+        const store = txn.store(DbMutationBatch.store);
+        return PersistencePromise.forEach(
+          testMutations,
+          (testMutation: DbMutationBatch) => store.put(testMutation)
+        );
+      });
     }).then(() =>
       withDb(4, db => {
         expect(db.version).to.be.equal(4);
         expect(getAllObjectStores(db)).to.have.members(V4_STORES);
 
         const sdb = new SimpleDb(db);
-        return sdb.runTransaction(
-          'readwrite',
-          /* idempotent= */ false,
-          [DbMutationBatch.store],
-          txn => {
-            const store = txn.store<DbMutationBatchKey, DbMutationBatch>(
-              DbMutationBatch.store
-            );
-            let p = PersistencePromise.forEach(
-              testMutations,
-              (testMutation: DbMutationBatch) =>
-                store.get(testMutation.batchId).next(mutationBatch => {
-                  expect(mutationBatch).to.deep.equal(testMutation);
-                })
-            );
-            p = p.next(() => {
-              store
-                .add({} as any) // eslint-disable-line @typescript-eslint/no-explicit-any
-                .next(batchId => {
-                  expect(batchId).to.equal(43);
-                });
-            });
-            return p;
-          }
-        );
+        return sdb.runTransaction('readwrite', [DbMutationBatch.store], txn => {
+          const store = txn.store<DbMutationBatchKey, DbMutationBatch>(
+            DbMutationBatch.store
+          );
+          let p = PersistencePromise.forEach(
+            testMutations,
+            (testMutation: DbMutationBatch) =>
+              store.get(testMutation.batchId).next(mutationBatch => {
+                expect(mutationBatch).to.deep.equal(testMutation);
+              })
+          );
+          p = p.next(() => {
+            store
+              .add({} as any) // eslint-disable-line @typescript-eslint/no-explicit-any
+              .next(batchId => {
+                expect(batchId).to.equal(43);
+              });
+          });
+          return p;
+        });
       })
     );
   });
@@ -434,11 +422,56 @@ describe('IndexedDbSchema: createOrUpgradeDb', () => {
     return withDb(4, db => {
       const sdb = new SimpleDb(db);
       // We can only use the V4 stores here, since that's as far as we've upgraded.
-      return sdb.runTransaction(
-        'readwrite',
-        /* idempotent= */ false,
-        V4_STORES,
-        txn => {
+      return sdb.runTransaction('readwrite', V4_STORES, txn => {
+        const mutationBatchStore = txn.store<
+          DbMutationBatchKey,
+          DbMutationBatch
+        >(DbMutationBatch.store);
+        const documentMutationStore = txn.store<
+          DbDocumentMutationKey,
+          DbDocumentMutation
+        >(DbDocumentMutation.store);
+        const mutationQueuesStore = txn.store<
+          DbMutationQueueKey,
+          DbMutationQueue
+        >(DbMutationQueue.store);
+        // Manually populate the mutation queue and create all indicies.
+        return PersistencePromise.forEach(
+          testMutations,
+          (testMutation: DbMutationBatch) => {
+            return mutationBatchStore.put(testMutation).next(() => {
+              return PersistencePromise.forEach(
+                testMutation.mutations,
+                (write: firestoreV1ApiClientInterfaces.Write) => {
+                  const indexKey = DbDocumentMutation.key(
+                    testMutation.userId,
+                    path(write.update!.name!, 5),
+                    testMutation.batchId
+                  );
+                  return documentMutationStore.put(
+                    indexKey,
+                    DbDocumentMutation.PLACEHOLDER
+                  );
+                }
+              );
+            });
+          }
+        ).next(() =>
+          // Populate the mutation queues' metadata
+          PersistencePromise.waitFor([
+            mutationQueuesStore.put(new DbMutationQueue('foo', 2, '')),
+            mutationQueuesStore.put(new DbMutationQueue('bar', 3, '')),
+            mutationQueuesStore.put(new DbMutationQueue('empty', -1, ''))
+          ])
+        );
+      });
+    }).then(() =>
+      withDb(5, db => {
+        expect(db.version).to.be.equal(5);
+
+        const sdb = new SimpleDb(db);
+        // There is no V5_STORES, continue using V4.
+        return sdb.runTransaction('readwrite', V4_STORES, txn => {
           const mutationBatchStore = txn.store<
             DbMutationBatchKey,
             DbMutationBatch
@@ -451,82 +484,27 @@ describe('IndexedDbSchema: createOrUpgradeDb', () => {
             DbMutationQueueKey,
             DbMutationQueue
           >(DbMutationQueue.store);
-          // Manually populate the mutation queue and create all indicies.
-          return PersistencePromise.forEach(
-            testMutations,
-            (testMutation: DbMutationBatch) => {
-              return mutationBatchStore.put(testMutation).next(() => {
-                return PersistencePromise.forEach(
-                  testMutation.mutations,
-                  (write: firestoreV1ApiClientInterfaces.Write) => {
-                    const indexKey = DbDocumentMutation.key(
-                      testMutation.userId,
-                      path(write.update!.name!, 5),
-                      testMutation.batchId
-                    );
-                    return documentMutationStore.put(
-                      indexKey,
-                      DbDocumentMutation.PLACEHOLDER
-                    );
-                  }
-                );
-              });
-            }
-          ).next(() =>
-            // Populate the mutation queues' metadata
-            PersistencePromise.waitFor([
-              mutationQueuesStore.put(new DbMutationQueue('foo', 2, '')),
-              mutationQueuesStore.put(new DbMutationQueue('bar', 3, '')),
-              mutationQueuesStore.put(new DbMutationQueue('empty', -1, ''))
-            ])
+
+          // Verify that all but the two pending mutations have been cleared
+          // by the migration.
+          let p = mutationBatchStore.count().next(count => {
+            expect(count).to.deep.equal(2);
+          });
+          p = p.next(() =>
+            documentMutationStore.count().next(count => {
+              expect(count).to.equal(2);
+            })
           );
-        }
-      );
-    }).then(() =>
-      withDb(5, db => {
-        expect(db.version).to.be.equal(5);
 
-        const sdb = new SimpleDb(db);
-        // There is no V5_STORES, continue using V4.
-        return sdb.runTransaction(
-          'readwrite',
-          /* idempotent= */ false,
-          V4_STORES,
-          txn => {
-            const mutationBatchStore = txn.store<
-              DbMutationBatchKey,
-              DbMutationBatch
-            >(DbMutationBatch.store);
-            const documentMutationStore = txn.store<
-              DbDocumentMutationKey,
-              DbDocumentMutation
-            >(DbDocumentMutation.store);
-            const mutationQueuesStore = txn.store<
-              DbMutationQueueKey,
-              DbMutationQueue
-            >(DbMutationQueue.store);
-
-            // Verify that all but the two pending mutations have been cleared
-            // by the migration.
-            let p = mutationBatchStore.count().next(count => {
-              expect(count).to.deep.equal(2);
-            });
-            p = p.next(() =>
-              documentMutationStore.count().next(count => {
-                expect(count).to.equal(2);
-              })
-            );
-
-            // Verify that we still have one metadata entry for each existing
-            // queue
-            p = p.next(() =>
-              mutationQueuesStore.count().next(count => {
-                expect(count).to.equal(3);
-              })
-            );
-            return p;
-          }
-        );
+          // Verify that we still have one metadata entry for each existing
+          // queue
+          p = p.next(() =>
+            mutationQueuesStore.count().next(count => {
+              expect(count).to.equal(3);
+            })
+          );
+          return p;
+        });
       })
     );
   });
@@ -545,40 +523,30 @@ describe('IndexedDbSchema: createOrUpgradeDb', () => {
       }));
       // V5 stores doesn't exist
       const sdb = new SimpleDb(db);
-      return sdb.runTransaction(
-        'readwrite',
-        /* idempotent= */ false,
-        V4_STORES,
-        txn => {
-          const store = txn.store<DbRemoteDocumentKey, DbRemoteDocument>(
-            DbRemoteDocument.store
-          );
-          return PersistencePromise.forEach(
-            dbRemoteDocs,
-            ({ dbKey, dbDoc }: { dbKey: string[]; dbDoc: DbRemoteDocument }) =>
-              store.put(dbKey, dbDoc)
-          );
-        }
-      );
+      return sdb.runTransaction('readwrite', V4_STORES, txn => {
+        const store = txn.store<DbRemoteDocumentKey, DbRemoteDocument>(
+          DbRemoteDocument.store
+        );
+        return PersistencePromise.forEach(
+          dbRemoteDocs,
+          ({ dbKey, dbDoc }: { dbKey: string[]; dbDoc: DbRemoteDocument }) =>
+            store.put(dbKey, dbDoc)
+        );
+      });
     });
     await withDb(6, db => {
       const sdb = new SimpleDb(db);
-      return sdb.runTransaction(
-        'readonly',
-        /* idempotent= */ false,
-        V6_STORES,
-        txn => {
-          const store = txn.store<
-            DbRemoteDocumentGlobalKey,
-            DbRemoteDocumentGlobal
-          >(DbRemoteDocumentGlobal.store);
-          return store.get(DbRemoteDocumentGlobal.key).next(metadata => {
-            // We don't really care what the size is, just that it's greater than 0.
-            // Our sizing algorithm may change at some point.
-            expect(metadata!.byteSize).to.be.greaterThan(0);
-          });
-        }
-      );
+      return sdb.runTransaction('readonly', V6_STORES, txn => {
+        const store = txn.store<
+          DbRemoteDocumentGlobalKey,
+          DbRemoteDocumentGlobal
+        >(DbRemoteDocumentGlobal.store);
+        return store.get(DbRemoteDocumentGlobal.key).next(metadata => {
+          // We don't really care what the size is, just that it's greater than 0.
+          // Our sizing algorithm may change at some point.
+          expect(metadata!.byteSize).to.be.greaterThan(0);
+        });
+      });
     });
   });
 
@@ -591,91 +559,80 @@ describe('IndexedDbSchema: createOrUpgradeDb', () => {
       const serializer = TEST_SERIALIZER;
 
       const sdb = new SimpleDb(db);
-      return sdb.runTransaction(
-        'readwrite',
-        /* idempotent= */ false,
-        V6_STORES,
-        txn => {
-          const targetGlobalStore = txn.store<
-            DbTargetGlobalKey,
-            DbTargetGlobal
-          >(DbTargetGlobal.store);
-          const remoteDocumentStore = txn.store<
-            DbRemoteDocumentKey,
-            DbRemoteDocument
-          >(DbRemoteDocument.store);
-          const targetDocumentStore = txn.store<
-            DbTargetDocumentKey,
-            DbTargetDocument
-          >(DbTargetDocument.store);
-          return targetGlobalStore
-            .get(DbTargetGlobal.key)
-            .next(metadata => {
-              expect(metadata).to.not.be.null;
-              metadata!.highestListenSequenceNumber = newSequenceNumber;
-              return targetGlobalStore.put(DbTargetGlobal.key, metadata!);
-            })
-            .next(() => {
-              // Set up some documents (we only need the keys)
-              // For the odd ones, add sentinel rows.
-              const promises: Array<PersistencePromise<void>> = [];
-              for (let i = 0; i < 10; i++) {
-                const document = doc('docs/doc_' + i, 1, { foo: 'bar' });
+      return sdb.runTransaction('readwrite', V6_STORES, txn => {
+        const targetGlobalStore = txn.store<DbTargetGlobalKey, DbTargetGlobal>(
+          DbTargetGlobal.store
+        );
+        const remoteDocumentStore = txn.store<
+          DbRemoteDocumentKey,
+          DbRemoteDocument
+        >(DbRemoteDocument.store);
+        const targetDocumentStore = txn.store<
+          DbTargetDocumentKey,
+          DbTargetDocument
+        >(DbTargetDocument.store);
+        return targetGlobalStore
+          .get(DbTargetGlobal.key)
+          .next(metadata => {
+            expect(metadata).to.not.be.null;
+            metadata!.highestListenSequenceNumber = newSequenceNumber;
+            return targetGlobalStore.put(DbTargetGlobal.key, metadata!);
+          })
+          .next(() => {
+            // Set up some documents (we only need the keys)
+            // For the odd ones, add sentinel rows.
+            const promises: Array<PersistencePromise<void>> = [];
+            for (let i = 0; i < 10; i++) {
+              const document = doc('docs/doc_' + i, 1, { foo: 'bar' });
+              promises.push(
+                remoteDocumentStore.put(
+                  document.key.path.toArray(),
+                  serializer.toDbRemoteDocument(document, document.version)
+                )
+              );
+              if (i % 2 === 1) {
                 promises.push(
-                  remoteDocumentStore.put(
-                    document.key.path.toArray(),
-                    serializer.toDbRemoteDocument(document, document.version)
+                  targetDocumentStore.put(
+                    new DbTargetDocument(
+                      0,
+                      encode(document.key.path),
+                      oldSequenceNumber
+                    )
                   )
                 );
-                if (i % 2 === 1) {
-                  promises.push(
-                    targetDocumentStore.put(
-                      new DbTargetDocument(
-                        0,
-                        encode(document.key.path),
-                        oldSequenceNumber
-                      )
-                    )
-                  );
-                }
               }
-              return PersistencePromise.waitFor(promises);
-            });
-        }
-      );
+            }
+            return PersistencePromise.waitFor(promises);
+          });
+      });
     });
 
     // Now run the migration and verify
     await withDb(7, db => {
       const sdb = new SimpleDb(db);
-      return sdb.runTransaction(
-        'readonly',
-        /* idempotent= */ false,
-        V6_STORES,
-        txn => {
-          const targetDocumentStore = txn.store<
-            DbTargetDocumentKey,
-            DbTargetDocument
-          >(DbTargetDocument.store);
-          const range = IDBKeyRange.bound(
-            [0],
-            [1],
-            /*lowerOpen=*/ false,
-            /*upperOpen=*/ true
-          );
-          return targetDocumentStore.iterate(
-            { range },
-            ([_, path], targetDocument) => {
-              const decoded = decode(path);
-              const lastSegment = decoded.lastSegment();
-              const docNum = +lastSegment.split('_')[1];
-              const expected =
-                docNum % 2 === 1 ? oldSequenceNumber : newSequenceNumber;
-              expect(targetDocument.sequenceNumber).to.equal(expected);
-            }
-          );
-        }
-      );
+      return sdb.runTransaction('readonly', V6_STORES, txn => {
+        const targetDocumentStore = txn.store<
+          DbTargetDocumentKey,
+          DbTargetDocument
+        >(DbTargetDocument.store);
+        const range = IDBKeyRange.bound(
+          [0],
+          [1],
+          /*lowerOpen=*/ false,
+          /*upperOpen=*/ true
+        );
+        return targetDocumentStore.iterate(
+          { range },
+          ([_, path], targetDocument) => {
+            const decoded = decode(path);
+            const lastSegment = decoded.lastSegment();
+            const docNum = +lastSegment.split('_')[1];
+            const expected =
+              docNum % 2 === 1 ? oldSequenceNumber : newSequenceNumber;
+            expect(targetDocument.sequenceNumber).to.equal(expected);
+          }
+        );
+      });
     });
   });
 
@@ -704,78 +661,62 @@ describe('IndexedDbSchema: createOrUpgradeDb', () => {
 
     await withDb(7, db => {
       const sdb = new SimpleDb(db);
-      return sdb.runTransaction(
-        'readwrite',
-        /* idempotent= */ false,
-        V6_STORES,
-        txn => {
-          const remoteDocumentStore = txn.store<
-            DbRemoteDocumentKey,
-            DbRemoteDocument
-          >(DbRemoteDocument.store);
-          const documentMutationStore = txn.store<
-            DbDocumentMutationKey,
-            DbDocumentMutation
-          >(DbDocumentMutation.store);
-          // We "cheat" and only write the DbDocumentMutation index entries, since that's
-          // all the migration uses.
-          return PersistencePromise.forEach(writePaths, (writePath: string) => {
-            const indexKey = DbDocumentMutation.key(
-              'dummy-uid',
-              path(writePath),
-              /*dummy batchId=*/ 123
-            );
-            return documentMutationStore.put(
-              indexKey,
-              DbDocumentMutation.PLACEHOLDER
-            );
-          }).next(() => {
-            // Write the remote document entries.
-            return PersistencePromise.forEach(
-              remoteDocPaths,
-              (path: string) => {
-                const remoteDoc = doc(path, /*version=*/ 1, { data: 1 });
-                return remoteDocumentStore.put(
-                  remoteDoc.key.path.toArray(),
-                  TEST_SERIALIZER.toDbRemoteDocument(
-                    remoteDoc,
-                    remoteDoc.version
-                  )
-                );
-              }
+      return sdb.runTransaction('readwrite', V6_STORES, txn => {
+        const remoteDocumentStore = txn.store<
+          DbRemoteDocumentKey,
+          DbRemoteDocument
+        >(DbRemoteDocument.store);
+        const documentMutationStore = txn.store<
+          DbDocumentMutationKey,
+          DbDocumentMutation
+        >(DbDocumentMutation.store);
+        // We "cheat" and only write the DbDocumentMutation index entries, since that's
+        // all the migration uses.
+        return PersistencePromise.forEach(writePaths, (writePath: string) => {
+          const indexKey = DbDocumentMutation.key(
+            'dummy-uid',
+            path(writePath),
+            /*dummy batchId=*/ 123
+          );
+          return documentMutationStore.put(
+            indexKey,
+            DbDocumentMutation.PLACEHOLDER
+          );
+        }).next(() => {
+          // Write the remote document entries.
+          return PersistencePromise.forEach(remoteDocPaths, (path: string) => {
+            const remoteDoc = doc(path, /*version=*/ 1, { data: 1 });
+            return remoteDocumentStore.put(
+              remoteDoc.key.path.toArray(),
+              TEST_SERIALIZER.toDbRemoteDocument(remoteDoc, remoteDoc.version)
             );
           });
-        }
-      );
+        });
+      });
     });
 
     // Migrate to v8 and verify index entries.
     await withDb(8, db => {
       const sdb = new SimpleDb(db);
-      return sdb.runTransaction(
-        'readwrite',
-        /* idempotent= */ false,
-        V8_STORES,
-        txn => {
-          const collectionParentsStore = txn.store<
-            DbCollectionParentKey,
-            DbCollectionParent
-          >(DbCollectionParent.store);
-          return collectionParentsStore.loadAll().next(indexEntries => {
-            const actualParents: { [key: string]: string[] } = {};
-            for (const { collectionId, parent } of indexEntries) {
-              let parents = actualParents[collectionId];
-              if (!parents) {
-                parents = [];
-                actualParents[collectionId] = parents;
-              }
-              parents.push(decode(parent).toString());
+      return sdb.runTransaction('readwrite', V8_STORES, txn => {
+        const collectionParentsStore = txn.store<
+          DbCollectionParentKey,
+          DbCollectionParent
+        >(DbCollectionParent.store);
+        return collectionParentsStore.loadAll().next(indexEntries => {
+          const actualParents: { [key: string]: string[] } = {};
+          for (const { collectionId, parent } of indexEntries) {
+            let parents = actualParents[collectionId];
+            if (!parents) {
+              parents = [];
+              actualParents[collectionId] = parents;
             }
+            parents.push(decode(parent).toString());
+          }
 
-            expect(actualParents).to.deep.equal(expectedParents);
-          });
-        }
-      );
+          expect(actualParents).to.deep.equal(expectedParents);
+        });
+      });
     });
   });
 
@@ -799,86 +740,73 @@ describe('IndexedDbSchema: createOrUpgradeDb', () => {
 
     await withDb(8, db => {
       const sdb = new SimpleDb(db);
-      return sdb.runTransaction(
-        'readwrite',
-        /* idempotent= */ false,
-        V8_STORES,
-        txn => {
-          const remoteDocumentStore = txn.store<
-            DbRemoteDocumentKey,
-            DbRemoteDocument
-          >(DbRemoteDocument.store);
+      return sdb.runTransaction('readwrite', V8_STORES, txn => {
+        const remoteDocumentStore = txn.store<
+          DbRemoteDocumentKey,
+          DbRemoteDocument
+        >(DbRemoteDocument.store);
 
-          // Write the remote document entries.
-          return PersistencePromise.forEach(
-            existingDocPaths,
-            (path: string) => {
-              const remoteDoc = doc(path, /*version=*/ 1, { data: 1 });
+        // Write the remote document entries.
+        return PersistencePromise.forEach(existingDocPaths, (path: string) => {
+          const remoteDoc = doc(path, /*version=*/ 1, { data: 1 });
 
-              const dbRemoteDoc = TEST_SERIALIZER.toDbRemoteDocument(
-                remoteDoc,
-                remoteDoc.version
-              );
-              // Mimic the old serializer and delete previously unset values
-              delete dbRemoteDoc.readTime;
-              delete dbRemoteDoc.parentPath;
-
-              return remoteDocumentStore.put(
-                remoteDoc.key.path.toArray(),
-                dbRemoteDoc
-              );
-            }
+          const dbRemoteDoc = TEST_SERIALIZER.toDbRemoteDocument(
+            remoteDoc,
+            remoteDoc.version
           );
-        }
-      );
+          // Mimic the old serializer and delete previously unset values
+          delete dbRemoteDoc.readTime;
+          delete dbRemoteDoc.parentPath;
+
+          return remoteDocumentStore.put(
+            remoteDoc.key.path.toArray(),
+            dbRemoteDoc
+          );
+        });
+      });
     });
 
     // Migrate to v9 and verify that new documents are indexed.
     await withDb(9, db => {
       const sdb = new SimpleDb(db);
-      return sdb.runTransaction(
-        'readwrite',
-        /* idempotent= */ false,
-        V8_STORES,
-        txn => {
-          const remoteDocumentStore = txn.store<
-            DbRemoteDocumentKey,
-            DbRemoteDocument
-          >(DbRemoteDocument.store);
+      return sdb.runTransaction('readwrite', V8_STORES, txn => {
+        const remoteDocumentStore = txn.store<
+          DbRemoteDocumentKey,
+          DbRemoteDocument
+        >(DbRemoteDocument.store);
 
-          // Verify the existing remote document entries.
-          return remoteDocumentStore
-            .loadAll()
-            .next(docsRead => {
-              const keys = docsRead.map(dbDoc => dbDoc.document!.name);
-              expect(keys).to.have.members([
-                'projects/test-project/databases/(default)/documents/coll1/doc1',
-                'projects/test-project/databases/(default)/documents/coll1/doc2',
-                'projects/test-project/databases/(default)/documents/coll2/doc1',
-                'projects/test-project/databases/(default)/documents/coll2/doc2'
-              ]);
-            })
-            .next(() => addDocs(txn, newDocPaths, /* version= */ 2))
-            .next(() => {
-              // Verify that we can get recent changes in a collection filtered by
-              // read time.
-              const lastReadTime = TEST_SERIALIZER.toDbTimestampKey(version(1));
-              const range = IDBKeyRange.lowerBound(
-                [['coll2'], lastReadTime],
-                true
-              );
-              return remoteDocumentStore
-                .loadAll(DbRemoteDocument.collectionReadTimeIndex, range)
-                .next(docsRead => {
-                  const keys = docsRead.map(dbDoc => dbDoc.document!.name);
-                  expect(keys).to.have.members([
-                    'projects/test-project/databases/(default)/documents/coll2/doc3',
-                    'projects/test-project/databases/(default)/documents/coll2/doc4'
-                  ]);
-                });
-            });
-        }
-      );
+        // Verify the existing remote document entries.
+        return remoteDocumentStore
+          .loadAll()
+          .next(docsRead => {
+            const keys = docsRead.map(dbDoc => dbDoc.document!.name);
+            expect(keys).to.have.members([
+              'projects/test-project/databases/(default)/documents/coll1/doc1',
+              'projects/test-project/databases/(default)/documents/coll1/doc2',
+              'projects/test-project/databases/(default)/documents/coll2/doc1',
+              'projects/test-project/databases/(default)/documents/coll2/doc2'
+            ]);
+          })
+          .next(() => addDocs(txn, newDocPaths, /* version= */ 2))
+          .next(() => {
+            // Verify that we can get recent changes in a collection filtered by
+            // read time.
+            const lastReadTime = TEST_SERIALIZER.toDbTimestampKey(version(1));
+            const range = IDBKeyRange.lowerBound(
+              [['coll2'], lastReadTime],
+              true
+            );
+            return remoteDocumentStore
+              .loadAll(DbRemoteDocument.collectionReadTimeIndex, range)
+              .next(docsRead => {
+                const keys = docsRead.map(dbDoc => dbDoc.document!.name);
+                expect(keys).to.have.members([
+                  'projects/test-project/databases/(default)/documents/coll2/doc3',
+                  'projects/test-project/databases/(default)/documents/coll2/doc4'
+                ]);
+              });
+          });
+      });
     });
   });
 
@@ -888,36 +816,31 @@ describe('IndexedDbSchema: createOrUpgradeDb', () => {
 
     await withDb(9, db => {
       const sdb = new SimpleDb(db);
-      return sdb.runTransaction(
-        'readwrite',
-        /* idempotent= */ false,
-        V8_STORES,
-        txn => {
-          return addDocs(txn, oldDocPaths, /* version= */ 1).next(() =>
-            addDocs(txn, newDocPaths, /* version= */ 2).next(() => {
-              const remoteDocumentStore = txn.store<
-                DbRemoteDocumentKey,
-                DbRemoteDocument
-              >(DbRemoteDocument.store);
+      return sdb.runTransaction('readwrite', V8_STORES, txn => {
+        return addDocs(txn, oldDocPaths, /* version= */ 1).next(() =>
+          addDocs(txn, newDocPaths, /* version= */ 2).next(() => {
+            const remoteDocumentStore = txn.store<
+              DbRemoteDocumentKey,
+              DbRemoteDocument
+            >(DbRemoteDocument.store);
 
-              const lastReadTime = TEST_SERIALIZER.toDbTimestampKey(version(1));
-              const range = IDBKeyRange.lowerBound(
-                [['coll'], lastReadTime],
-                true
-              );
-              return remoteDocumentStore
-                .loadAll(DbRemoteDocument.collectionReadTimeIndex, range)
-                .next(docsRead => {
-                  const keys = docsRead.map(dbDoc => dbDoc.document!.name);
-                  expect(keys).to.have.members([
-                    'projects/test-project/databases/(default)/documents/coll/doc3',
-                    'projects/test-project/databases/(default)/documents/coll/doc4'
-                  ]);
-                });
-            })
-          );
-        }
-      );
+            const lastReadTime = TEST_SERIALIZER.toDbTimestampKey(version(1));
+            const range = IDBKeyRange.lowerBound(
+              [['coll'], lastReadTime],
+              true
+            );
+            return remoteDocumentStore
+              .loadAll(DbRemoteDocument.collectionReadTimeIndex, range)
+              .next(docsRead => {
+                const keys = docsRead.map(dbDoc => dbDoc.document!.name);
+                expect(keys).to.have.members([
+                  'projects/test-project/databases/(default)/documents/coll/doc3',
+                  'projects/test-project/databases/(default)/documents/coll/doc4'
+                ]);
+              });
+          })
+        );
+      });
     });
   });
 
@@ -927,33 +850,28 @@ describe('IndexedDbSchema: createOrUpgradeDb', () => {
 
     await withDb(9, db => {
       const sdb = new SimpleDb(db);
-      return sdb.runTransaction(
-        'readwrite',
-        /* idempotent= */ false,
-        V8_STORES,
-        txn => {
-          return addDocs(txn, oldDocPaths, /* version= */ 1).next(() =>
-            addDocs(txn, newDocPaths, /* version= */ 2).next(() => {
-              const remoteDocumentStore = txn.store<
-                DbRemoteDocumentKey,
-                DbRemoteDocument
-              >(DbRemoteDocument.store);
+      return sdb.runTransaction('readwrite', V8_STORES, txn => {
+        return addDocs(txn, oldDocPaths, /* version= */ 1).next(() =>
+          addDocs(txn, newDocPaths, /* version= */ 2).next(() => {
+            const remoteDocumentStore = txn.store<
+              DbRemoteDocumentKey,
+              DbRemoteDocument
+            >(DbRemoteDocument.store);
 
-              const lastReadTime = TEST_SERIALIZER.toDbTimestampKey(version(1));
-              const range = IDBKeyRange.lowerBound(lastReadTime, true);
-              return remoteDocumentStore
-                .loadAll(DbRemoteDocument.readTimeIndex, range)
-                .next(docsRead => {
-                  const keys = docsRead.map(dbDoc => dbDoc.document!.name);
-                  expect(keys).to.have.members([
-                    'projects/test-project/databases/(default)/documents/coll1/new',
-                    'projects/test-project/databases/(default)/documents/coll2/new'
-                  ]);
-                });
-            })
-          );
-        }
-      );
+            const lastReadTime = TEST_SERIALIZER.toDbTimestampKey(version(1));
+            const range = IDBKeyRange.lowerBound(lastReadTime, true);
+            return remoteDocumentStore
+              .loadAll(DbRemoteDocument.readTimeIndex, range)
+              .next(docsRead => {
+                const keys = docsRead.map(dbDoc => dbDoc.document!.name);
+                expect(keys).to.have.members([
+                  'projects/test-project/databases/(default)/documents/coll1/new',
+                  'projects/test-project/databases/(default)/documents/coll2/new'
+                ]);
+              });
+          })
+        );
+      });
     });
   });
 
@@ -994,17 +912,12 @@ describe('IndexedDb: canActAsPrimary', () => {
       SCHEMA_VERSION,
       new SchemaConverter(TEST_SERIALIZER)
     );
-    await simpleDb.runTransaction(
-      'readwrite',
-      /* idempotent= */ false,
-      [DbPrimaryClient.store],
-      txn => {
-        const primaryStore = txn.store<DbPrimaryClientKey, DbPrimaryClient>(
-          DbPrimaryClient.store
-        );
-        return primaryStore.delete(DbPrimaryClient.key);
-      }
-    );
+    await simpleDb.runTransaction('readwrite', [DbPrimaryClient.store], txn => {
+      const primaryStore = txn.store<DbPrimaryClientKey, DbPrimaryClient>(
+        DbPrimaryClient.store
+      );
+      return primaryStore.delete(DbPrimaryClient.key);
+    });
     simpleDb.close();
   }
 

--- a/packages/firestore/test/unit/local/simple_db.test.ts
+++ b/packages/firestore/test/unit/local/simple_db.test.ts
@@ -93,7 +93,7 @@ describe('SimpleDb', () => {
       transaction: SimpleDbTransaction
     ) => PersistencePromise<T>
   ): Promise<T> {
-    return db.runTransaction<T>('readwrite', ['users'], txn => {
+    return db.runTransaction<T>('readwrite-idempotent', ['users'], txn => {
       return fn(txn.store<number, User>('users'), txn);
     });
   }
@@ -481,7 +481,7 @@ describe('SimpleDb', () => {
       ['foo', 'd'],
       ['foob']
     ];
-    await db.runTransaction('readwrite', ['users', 'docs'], txn => {
+    await db.runTransaction('readwrite-idempotent', ['users', 'docs'], txn => {
       const docsStore = txn.store<string[], string>('docs');
       return PersistencePromise.waitFor(
         keys.map(key => {
@@ -491,7 +491,7 @@ describe('SimpleDb', () => {
       );
     });
 
-    await db.runTransaction('readonly', ['docs'], txn => {
+    await db.runTransaction('readonly-idempotent', ['docs'], txn => {
       const store = txn.store<string[], string>('docs');
       const range = IDBKeyRange.bound(['foo'], ['foo', 'c']);
       return store.loadAll(range).next(results => {

--- a/packages/firestore/test/unit/local/simple_db.test.ts
+++ b/packages/firestore/test/unit/local/simple_db.test.ts
@@ -566,7 +566,7 @@ describe('SimpleDb', () => {
     let attemptCount = 0;
 
     await expect(
-      db.runTransaction('readonly', /* idempotent= */ true, ['users'], txn => {
+      db.runTransaction('readwrite', /* idempotent= */ true, ['users'], txn => {
         ++attemptCount;
         txn.abort();
         return PersistencePromise.reject(new Error('Aborted'));
@@ -580,7 +580,7 @@ describe('SimpleDb', () => {
     let attemptCount = 0;
 
     await expect(
-      db.runTransaction('readonly', /* idempotent= */ false, ['users'], txn => {
+      db.runTransaction('readwrite', /* idempotent= */ false, ['users'], txn => {
         ++attemptCount;
         const store = txn.store<string[], typeof dummyUser>('users');
         return store

--- a/packages/firestore/test/unit/local/simple_db.test.ts
+++ b/packages/firestore/test/unit/local/simple_db.test.ts
@@ -580,16 +580,21 @@ describe('SimpleDb', () => {
     let attemptCount = 0;
 
     await expect(
-      db.runTransaction('readwrite', /* idempotent= */ false, ['users'], txn => {
-        ++attemptCount;
-        const store = txn.store<string[], typeof dummyUser>('users');
-        return store
-          .add(dummyUser)
-          .next(() => {
-            return store.add(dummyUser);
-          })
-          .next(() => 'Uncaught unique key violation');
-      })
+      db.runTransaction(
+        'readwrite',
+        /* idempotent= */ false,
+        ['users'],
+        txn => {
+          ++attemptCount;
+          const store = txn.store<string[], typeof dummyUser>('users');
+          return store
+            .add(dummyUser)
+            .next(() => {
+              return store.add(dummyUser);
+            })
+            .next(() => 'Uncaught unique key violation');
+        }
+      )
     ).to.eventually.be.rejectedWith('Uncaught unique key violation');
 
     expect(attemptCount).to.equal(1);

--- a/packages/firestore/test/unit/specs/spec_test_runner.ts
+++ b/packages/firestore/test/unit/specs/spec_test_runner.ts
@@ -1650,16 +1650,11 @@ async function clearCurrentPrimaryLease(): Promise<void> {
     SCHEMA_VERSION,
     new SchemaConverter(TEST_SERIALIZER)
   );
-  await db.runTransaction(
-    'readwrite',
-    /* idempotent= */ false,
-    [DbPrimaryClient.store],
-    txn => {
-      const primaryClientStore = txn.store<DbPrimaryClientKey, DbPrimaryClient>(
-        DbPrimaryClient.store
-      );
-      return primaryClientStore.delete(DbPrimaryClient.key);
-    }
-  );
+  await db.runTransaction('readwrite', [DbPrimaryClient.store], txn => {
+    const primaryClientStore = txn.store<DbPrimaryClientKey, DbPrimaryClient>(
+      DbPrimaryClient.store
+    );
+    return primaryClientStore.delete(DbPrimaryClient.key);
+  });
   db.close();
 }

--- a/packages/firestore/test/unit/specs/spec_test_runner.ts
+++ b/packages/firestore/test/unit/specs/spec_test_runner.ts
@@ -1650,11 +1650,15 @@ async function clearCurrentPrimaryLease(): Promise<void> {
     SCHEMA_VERSION,
     new SchemaConverter(TEST_SERIALIZER)
   );
-  await db.runTransaction('readwrite', [DbPrimaryClient.store], txn => {
-    const primaryClientStore = txn.store<DbPrimaryClientKey, DbPrimaryClient>(
-      DbPrimaryClient.store
-    );
-    return primaryClientStore.delete(DbPrimaryClient.key);
-  });
+  await db.runTransaction(
+    'readwrite-idempotent',
+    [DbPrimaryClient.store],
+    txn => {
+      const primaryClientStore = txn.store<DbPrimaryClientKey, DbPrimaryClient>(
+        DbPrimaryClient.store
+      );
+      return primaryClientStore.delete(DbPrimaryClient.key);
+    }
+  );
   db.close();
 }

--- a/packages/firestore/test/unit/specs/spec_test_runner.ts
+++ b/packages/firestore/test/unit/specs/spec_test_runner.ts
@@ -1650,11 +1650,16 @@ async function clearCurrentPrimaryLease(): Promise<void> {
     SCHEMA_VERSION,
     new SchemaConverter(TEST_SERIALIZER)
   );
-  await db.runTransaction('readwrite', [DbPrimaryClient.store], txn => {
-    const primaryClientStore = txn.store<DbPrimaryClientKey, DbPrimaryClient>(
-      DbPrimaryClient.store
-    );
-    return primaryClientStore.delete(DbPrimaryClient.key);
-  });
+  await db.runTransaction(
+    'readwrite',
+    /* idempotent= */ false,
+    [DbPrimaryClient.store],
+    txn => {
+      const primaryClientStore = txn.store<DbPrimaryClientKey, DbPrimaryClient>(
+        DbPrimaryClient.store
+      );
+      return primaryClientStore.delete(DbPrimaryClient.key);
+    }
+  );
   db.close();
 }


### PR DESCRIPTION
This PR marks all straightforward calls of SimpleDb.runTransaction as idempotent. Most of the usage is in test.

This was verified via a manual code audit and via a test hack (not checked in) that fails the first run of idempotent transactions.