### PR TITLE
Mark collectGarbage idempotent

### DIFF
--- a/packages/firestore/src/local/local_store.ts
+++ b/packages/firestore/src/local/local_store.ts
@@ -1035,7 +1035,7 @@ export class LocalStore {
   collectGarbage(garbageCollector: LruGarbageCollector): Promise<LruResults> {
     return this.persistence.runTransaction(
       'Collect garbage',
-      'readwrite-primary',
+      'readwrite-primary-idempotent',
       txn => garbageCollector.collect(txn, this.queryDataByTarget)
     );
   }


### PR DESCRIPTION
I looked through all the code that is called from `collectGarbage()` (and there is a lot), but it seems like there is no in-memory state that is modified during garbage collection. It seems safe to be re-run.

FWIW, we could also blindly swallow all errors that `collectGarbage()` might throw, but then we would likely never receive feedback about any LRU problems.