### PR TITLE
Include add_payment_info and page_view events

### DIFF
--- a/packages/firebase/index.d.ts
+++ b/packages/firebase/index.d.ts
@@ -3961,8 +3961,8 @@ declare namespace firebase.analytics {
      * ```
      */
     app: firebase.app.App;
-              
-     /**
+
+    /**
      * Sends analytics event with given `eventParams`. This method
      * automatically associates this logged event with this Firebase web
      * app instance on this device.
@@ -3972,10 +3972,10 @@ declare namespace firebase.analytics {
      */
     logEvent(
       eventName: 'add_payment_info',
-      eventParams?: {},
+      eventParams?: { [key: string]: any },
       options?: firebase.analytics.AnalyticsCallOptions
     ): void;
-    
+
     /**
      * Sends analytics event with given `eventParams`. This method
      * automatically associates this logged event with this Firebase web
@@ -4090,8 +4090,8 @@ declare namespace firebase.analytics {
       },
       options?: firebase.analytics.AnalyticsCallOptions
     ): void;
-               
-     /**
+
+    /**
      * Sends analytics event with given `eventParams`. This method
      * automatically associates this logged event with this Firebase web
      * app instance on this device.
@@ -4101,7 +4101,12 @@ declare namespace firebase.analytics {
      */
     logEvent(
       eventName: 'page_view',
-      eventParams?: {},
+      eventParams: {
+        page_title?: string;
+        page_location?: string;
+        page_path?: string;
+        [key: string]: any;
+      },
       options?: firebase.analytics.AnalyticsCallOptions
     ): void;
 

--- a/packages/firebase/index.d.ts
+++ b/packages/firebase/index.d.ts
@@ -3961,7 +3961,21 @@ declare namespace firebase.analytics {
      * ```
      */
     app: firebase.app.App;
-
+              
+     /**
+     * Sends analytics event with given `eventParams`. This method
+     * automatically associates this logged event with this Firebase web
+     * app instance on this device.
+     * List of official event parameters can be found in
+     * {@link https://developers.google.com/gtagjs/reference/event
+     * the gtag.js reference documentation}.
+     */
+    logEvent(
+      eventName: 'add_payment_info',
+      eventParams?: {},
+      options?: firebase.analytics.AnalyticsCallOptions
+    ): void;
+    
     /**
      * Sends analytics event with given `eventParams`. This method
      * automatically associates this logged event with this Firebase web
@@ -4074,6 +4088,20 @@ declare namespace firebase.analytics {
         method?: EventParams['method'];
         [key: string]: any;
       },
+      options?: firebase.analytics.AnalyticsCallOptions
+    ): void;
+               
+     /**
+     * Sends analytics event with given `eventParams`. This method
+     * automatically associates this logged event with this Firebase web
+     * app instance on this device.
+     * List of official event parameters can be found in
+     * {@link https://developers.google.com/gtagjs/reference/event
+     * the gtag.js reference documentation}.
+     */
+    logEvent(
+      eventName: 'page_view',
+      eventParams?: {},
       options?: firebase.analytics.AnalyticsCallOptions
     ): void;
 


### PR DESCRIPTION
Typescript currently throws a fit when trying to log either the `add_payment_info` or `page_view` events with `firebase.analytics.logEvent()`.  The error goes a little something like... 

`Argument of type '"add_payment_info"' is not assignable to parameter of type 'never'.`

These two are the only default events without parameters and also don't have function overloads defined—meaning the following line assigns them to `never`.
https://github.com/firebase/firebase-js-sdk/blob/07cd70d4e694080c0114076fe2be821c951ed75b/packages/firebase/index.d.ts#L4336

I think adding these two definitions patches things right up.