### PR TITLE
Retry all non-Firestore exceptions

### DIFF
--- a/packages/firestore/src/local/simple_db.ts
+++ b/packages/firestore/src/local/simple_db.ts
@@ -298,6 +298,9 @@ export class SimpleDb {
         // TODO(schmidt-sebastian): We could probably be smarter about this and
         // not retry exceptions that are likely unrecoverable (such as quota
         // exceeded errors).
+        
+        // Note: We cannot use an instanceof check for FirestoreException, since the
+        // exception is wrapped in a generic error by our async/await handling.
         const retryable =
           idempotent &&
           error.name !== 'FirebaseError' &&

--- a/packages/firestore/src/local/simple_db.ts
+++ b/packages/firestore/src/local/simple_db.ts
@@ -801,13 +801,3 @@ function checkForAndReportiOSError(error: DOMException): Error {
   }
   return error;
 }
-
-/** Checks whether an error is a DOMException (e.g. as thrown by IndexedDb). */
-function isDomException(error: Error): boolean {
-  // DOMException is not a global type in Node with persistence, and hence we
-  // check the constructor name if the type in unknown.
-  return (
-    (typeof DOMException !== 'undefined' && error instanceof DOMException) ||
-    error.constructor.name === 'DOMException'
-  );
-}

--- a/packages/firestore/src/local/simple_db.ts
+++ b/packages/firestore/src/local/simple_db.ts
@@ -294,23 +294,23 @@ export class SimpleDb {
         // caller.
         await transaction.completionPromise;
         return transactionFnResult;
-      } catch (e) {
+      } catch (error) {
         // TODO(schmidt-sebastian): We could probably be smarter about this and
         // not retry exceptions that are likely unrecoverable (such as quota
         // exceeded errors).
         const retryable =
           idempotent &&
-          isDomException(e) &&
+          error.name !== 'FirebaseError' &&
           attemptNumber < TRANSACTION_RETRY_COUNT;
         debug(
           LOG_TAG,
           'Transaction failed with error: %s. Retrying: %s.',
-          e.message,
+          error.message,
           retryable
         );
 
         if (!retryable) {
-          return Promise.reject(e);
+          return Promise.reject(error);
         }
       }
     }

--- a/packages/firestore/test/unit/local/simple_db.test.ts
+++ b/packages/firestore/test/unit/local/simple_db.test.ts
@@ -28,6 +28,7 @@ import {
 import { PersistencePromise } from '../../../src/local/persistence_promise';
 
 import { fail } from '../../../src/util/assert';
+import { Code, FirestoreError } from '../../../src/util/error';
 
 use(chaiAsPromised);
 
@@ -551,8 +552,8 @@ describe('SimpleDb', () => {
     await expect(
       db.runTransaction('readwrite-idempotent', ['users'], txn => {
         ++attemptCount;
-        txn.abort();
-        return PersistencePromise.reject(new Error('Aborted'));
+        txn.abort(new FirestoreError(Code.ABORTED, 'Aborted'));
+        return PersistencePromise.reject(new Error());
       })
     ).to.eventually.be.rejected;
 


### PR DESCRIPTION
Our users are still seeing IndexedDB errors on iOS 13 (using IONIC/Cordova). One of the possible reasons is that some environments might not throw DOMExceptions, which would lead us to not retry. This PR flips our logic around and only skips retries if the underlying exception is a non-Firestore exception.

Fixes https://github.com/firebase/firebase-js-sdk/issues/2232