### PR TITLE
Refer to properties in constructor as members

### DIFF
--- a/packages/firestore/src/api/database.ts
+++ b/packages/firestore/src/api/database.ts
@@ -2102,8 +2102,8 @@ export class QuerySnapshot implements firestore.QuerySnapshot {
     private _snapshot: ViewSnapshot
   ) {
     this.metadata = new SnapshotMetadata(
-      _snapshot.hasPendingWrites,
-      _snapshot.fromCache
+      this._snapshot.hasPendingWrites,
+      this._snapshot.fromCache
     );
   }
 

--- a/packages/firestore/src/api/timestamp.ts
+++ b/packages/firestore/src/api/timestamp.ts
@@ -34,30 +34,30 @@ export class Timestamp {
   }
 
   constructor(readonly seconds: number, readonly nanoseconds: number) {
-    if (nanoseconds < 0) {
+    if (this.nanoseconds < 0) {
       throw new FirestoreError(
         Code.INVALID_ARGUMENT,
-        'Timestamp nanoseconds out of range: ' + nanoseconds
+        'Timestamp nanoseconds out of range: ' + this.nanoseconds
       );
     }
-    if (nanoseconds >= 1e9) {
+    if (this.nanoseconds >= 1e9) {
       throw new FirestoreError(
         Code.INVALID_ARGUMENT,
-        'Timestamp nanoseconds out of range: ' + nanoseconds
+        'Timestamp nanoseconds out of range: ' + this.nanoseconds
       );
     }
     // Midnight at the beginning of 1/1/1 is the earliest Firestore supports.
-    if (seconds < -62135596800) {
+    if (this.seconds < -62135596800) {
       throw new FirestoreError(
         Code.INVALID_ARGUMENT,
-        'Timestamp seconds out of range: ' + seconds
+        'Timestamp seconds out of range: ' + this.seconds
       );
     }
     // This will break in the year 10,000.
-    if (seconds >= 253402300800) {
+    if (this.seconds >= 253402300800) {
       throw new FirestoreError(
         Code.INVALID_ARGUMENT,
-        'Timestamp seconds out of range: ' + seconds
+        'Timestamp seconds out of range: ' + this.seconds
       );
     }
   }

--- a/packages/firestore/src/api/user_data_converter.ts
+++ b/packages/firestore/src/api/user_data_converter.ts
@@ -189,7 +189,8 @@ class ParseContext {
     if (fieldTransforms === undefined) {
       this.validatePath();
     }
-    this.arrayElement = arrayElement !== undefined ? arrayElement : false;
+    this.arrayElement =
+      this.arrayElement !== undefined ? this.arrayElement : false;
     this.fieldTransforms = fieldTransforms || [];
     this.fieldMask = fieldMask || [];
   }

--- a/packages/firestore/src/core/query.ts
+++ b/packages/firestore/src/core/query.ts
@@ -823,7 +823,7 @@ export class OrderBy {
       dir = Direction.ASCENDING;
     }
     this.dir = dir;
-    this.isKeyOrderBy = field.isKeyField();
+    this.isKeyOrderBy = this.field.isKeyField();
   }
 
   compare(d1: Document, d2: Document): number {

--- a/packages/firestore/src/core/target_id_generator.ts
+++ b/packages/firestore/src/core/target_id_generator.ts
@@ -51,8 +51,8 @@ export class TargetIdGenerator {
    */
   constructor(private generatorId: number, seed?: number) {
     assert(
-      (generatorId & RESERVED_BITS) === generatorId,
-      `Generator ID ${generatorId} contains more than ${RESERVED_BITS} reserved bits`
+      (this.generatorId & RESERVED_BITS) === this.generatorId,
+      `Generator ID ${this.generatorId} contains more than ${RESERVED_BITS} reserved bits`
     );
     this.seek(seed !== undefined ? seed : this.generatorId);
   }

--- a/packages/firestore/src/core/view.ts
+++ b/packages/firestore/src/core/view.ts
@@ -90,7 +90,9 @@ export class View {
     /** Documents included in the remote target */
     private _syncedDocuments: DocumentKeySet
   ) {
-    this.documentSet = new DocumentSet(query.docComparator.bind(query));
+    this.documentSet = new DocumentSet(
+      this.query.docComparator.bind(this.query)
+    );
   }
 
   /**

--- a/packages/firestore/src/local/local_store.ts
+++ b/packages/firestore/src/local/local_store.ts
@@ -192,15 +192,15 @@ export class LocalStore {
     initialUser: User
   ) {
     assert(
-      persistence.started,
+      this.persistence.started,
       'LocalStore was passed an unstarted persistence implementation'
     );
     this.persistence.referenceDelegate.setInMemoryPins(
       this.localViewReferences
     );
-    this.mutationQueue = persistence.getMutationQueue(initialUser);
-    this.remoteDocuments = persistence.getRemoteDocumentCache();
-    this.queryCache = persistence.getQueryCache();
+    this.mutationQueue = this.persistence.getMutationQueue(initialUser);
+    this.remoteDocuments = this.persistence.getRemoteDocumentCache();
+    this.queryCache = this.persistence.getQueryCache();
     this.localDocuments = new LocalDocumentsView(
       this.remoteDocuments,
       this.mutationQueue,

--- a/packages/firestore/src/remote/persistent_stream.ts
+++ b/packages/firestore/src/remote/persistent_stream.ts
@@ -177,7 +177,7 @@ export abstract class PersistentStream<
     private credentialsProvider: CredentialsProvider,
     protected listener: ListenerType
   ) {
-    this.backoff = new ExponentialBackoff(queue, connectionTimerId);
+    this.backoff = new ExponentialBackoff(this.queue, connectionTimerId);
   }
 
   /**


### PR DESCRIPTION
This fixes build problems with both the Google Closure Compiler and the terser rollup plugin.