### PR TITLE
fix renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,13 +7,11 @@
   },
   "packageRules": [
     {
-      "packagePatterns": [
-        "^((?!^typescript$).)*$"
-      ],
       "minor": {
         "groupName": "all non-major dependencies",
         "groupSlug": "all-minor-patch"
-      }
+      },
+      "excludePackageNames": ["typescript"]
     }
   ],
   "ignoreDeps": [


### PR DESCRIPTION
Renovate seems to have a problem with regex(https://github.com/renovatebot/renovate/issues/4655). Our regex are causing config errors as a result, so I'm changing  to use a different field to workaround the issue.