### PR TITLE
[2.8/3] Add limitToLast implementation and tests.

### DIFF
--- a/packages/firebase/index.d.ts
+++ b/packages/firebase/index.d.ts
@@ -8081,7 +8081,7 @@ declare namespace firebase.firestore {
     /**
      * Creates and returns a new Query that only returns the first matching
      * documents.
-     * 
+     *
      * @param limit The maximum number of items to return.
      * @return The created Query.
      */
@@ -8090,7 +8090,7 @@ declare namespace firebase.firestore {
     /**
      * Creates and returns a new Query that only returns the last matching
      * documents.
-     * 
+     *
      * Queries with `limitToLast` must have at least one `orderBy` clause on
      * one of the document fields, or an Exception will throw during execution.
      *

--- a/packages/firebase/index.d.ts
+++ b/packages/firebase/index.d.ts
@@ -8091,8 +8091,8 @@ declare namespace firebase.firestore {
      * Creates and returns a new Query that only returns the last matching
      * documents.
      *
-     * Queries with `limitToLast` must have at least one `orderBy` clause on
-     * one of the document fields, or an Exception will throw during execution.
+     * You must specify at least one `orderBy` clause for `limitToLast` queries,
+     * otherwise an exception will be thrown thrown during execution.
      *
      * @param limit The maximum number of items to return.
      * @return The created Query.

--- a/packages/firebase/index.d.ts
+++ b/packages/firebase/index.d.ts
@@ -8079,17 +8079,20 @@ declare namespace firebase.firestore {
     ): Query;
 
     /**
-     * Creates and returns a new Query where only the first matching documents
-     * are returned as results.
-     *
+     * Creates and returns a new Query that only returns the first matching
+     * documents.
+     * 
      * @param limit The maximum number of items to return.
      * @return The created Query.
      */
     limit(limit: number): Query;
 
     /**
-     * Creates and returns a new Query where only the last matching documents
-     * are returned as results.
+     * Creates and returns a new Query that only returns the last matching
+     * documents.
+     * 
+     * Queries with `limitToLast` must have at least one `orderBy` clause on
+     * one of the document fields, or an Exception will throw during execution.
      *
      * @param limit The maximum number of items to return.
      * @return The created Query.

--- a/packages/firebase/index.d.ts
+++ b/packages/firebase/index.d.ts
@@ -8079,13 +8079,22 @@ declare namespace firebase.firestore {
     ): Query;
 
     /**
-     * Creates and returns a new Query where the results are limited to the
-     * specified number of documents.
+     * Creates and returns a new Query where only the first matching documents
+     * are returned as results.
      *
      * @param limit The maximum number of items to return.
      * @return The created Query.
      */
     limit(limit: number): Query;
+
+    /**
+     * Creates and returns a new Query where only the last matching documents
+     * are returned as results.
+     *
+     * @param limit The maximum number of items to return.
+     * @return The created Query.
+     */
+    limitToLast(limit: number): Query;
 
     /**
      * Creates and returns a new Query that starts at the provided document

--- a/packages/firestore-types/index.d.ts
+++ b/packages/firestore-types/index.d.ts
@@ -1085,7 +1085,7 @@ export class Query {
   /**
    * Creates and returns a new Query that only returns the first matching
    * documents.
-   * 
+   *
    * @param limit The maximum number of items to return.
    * @return The created Query.
    */
@@ -1094,7 +1094,7 @@ export class Query {
   /**
    * Creates and returns a new Query that only returns the last matching
    * documents.
-   * 
+   *
    * Queries with `limitToLast` must have at least one `orderBy` clause on
    * one of the document fields, or an Exception will throw during execution.
    *

--- a/packages/firestore-types/index.d.ts
+++ b/packages/firestore-types/index.d.ts
@@ -1083,17 +1083,20 @@ export class Query {
   ): Query;
 
   /**
-   * Creates and returns a new Query that's additionally limited to only
-   * return up to the specified number of documents.
-   *
+   * Creates and returns a new Query that only returns the first matching
+   * documents.
+   * 
    * @param limit The maximum number of items to return.
    * @return The created Query.
    */
   limit(limit: number): Query;
 
   /**
-   * Creates and returns a new Query where only the last matching documents
-   * are returned as results.
+   * Creates and returns a new Query that only returns the last matching
+   * documents.
+   * 
+   * Queries with `limitToLast` must have at least one `orderBy` clause on
+   * one of the document fields, or an Exception will throw during execution.
    *
    * @param limit The maximum number of items to return.
    * @return The created Query.

--- a/packages/firestore-types/index.d.ts
+++ b/packages/firestore-types/index.d.ts
@@ -1092,6 +1092,15 @@ export class Query {
   limit(limit: number): Query;
 
   /**
+   * Creates and returns a new Query where only the last matching documents
+   * are returned as results.
+   *
+   * @param limit The maximum number of items to return.
+   * @return The created Query.
+   */
+  limitToLast(limit: number): Query;
+
+  /**
    * Creates and returns a new Query that starts at the provided document
    * (inclusive). The starting position is relative to the order of the query.
    * The document must contain all of the fields provided in the orderBy of

--- a/packages/firestore/src/api/database.ts
+++ b/packages/firestore/src/api/database.ts
@@ -1540,14 +1540,14 @@ export class Query implements firestore.Query {
   limit(n: number): firestore.Query {
     validateExactNumberOfArgs('Query.limit', arguments, 1);
     validateArgType('Query.limit', 'number', 1, n);
-    validatePositiveNumber('limit', 1, n);
+    validatePositiveNumber('Query.limit', 1, n);
     return new Query(this._query.withLimitToFirst(n), this.firestore);
   }
 
   limitToLast(n: number): firestore.Query {
     validateExactNumberOfArgs('Query.limitToLast', arguments, 1);
     validateArgType('Query.limitToLast', 'number', 1, n);
-    validatePositiveNumber('limitToLast', 1, n);
+    validatePositiveNumber('Query.limitToLast', 1, n);
     return new Query(this._query.withLimitToLast(n), this.firestore);
   }
 

--- a/packages/firestore/src/api/database.ts
+++ b/packages/firestore/src/api/database.ts
@@ -71,7 +71,7 @@ import {
   validateOptionalArgType,
   validateOptionalArrayElements,
   validateOptionNames,
-  validatePositiveLimit,
+  validatePositiveNumber,
   validateStringEnum,
   valueDescription
 } from '../util/input_validation';
@@ -1540,14 +1540,14 @@ export class Query implements firestore.Query {
   limit(n: number): firestore.Query {
     validateExactNumberOfArgs('Query.limit', arguments, 1);
     validateArgType('Query.limit', 'number', 1, n);
-    validatePositiveLimit('limit', n);
+    validatePositiveNumber('limit', 1, n);
     return new Query(this._query.withLimitToFirst(n), this.firestore);
   }
 
   limitToLast(n: number): firestore.Query {
     validateExactNumberOfArgs('Query.limitToLast', arguments, 1);
     validateArgType('Query.limitToLast', 'number', 1, n);
-    validatePositiveLimit('limitToLast', n);
+    validatePositiveNumber('limitToLast', 1, n);
     return new Query(this._query.withLimitToLast(n), this.firestore);
   }
 

--- a/packages/firestore/src/api/database.ts
+++ b/packages/firestore/src/api/database.ts
@@ -1876,7 +1876,7 @@ export class Query implements firestore.Query {
     if (query.hasLimitToLast() && query.explicitOrderBy.length === 0) {
       throw new FirestoreError(
         Code.UNIMPLEMENTED,
-        'limitToLast() queries require specifying an orderBy() on at least on document field.'
+        'limitToLast() queries require specifying an orderBy() on at least one document field.'
       );
     }
   }

--- a/packages/firestore/src/core/query.ts
+++ b/packages/firestore/src/core/query.ts
@@ -62,8 +62,7 @@ export class Query {
     readonly limit: number | null = null,
     readonly limitType: LimitType = LimitType.First,
     readonly startAt: Bound | null = null,
-    readonly endAt: Bound | null = null,
-    readonly isTargetQuery: boolean = false
+    readonly endAt: Bound | null = null
   ) {
     if (this.startAt) {
       this.assertValidBound(this.startAt);

--- a/packages/firestore/src/core/query.ts
+++ b/packages/firestore/src/core/query.ts
@@ -31,8 +31,8 @@ import { isNullOrUndefined } from '../util/types';
 import { Target } from './target';
 
 export enum LimitType {
-  First = "F",
-  Last = "L"
+  First = 'F',
+  Last = 'L'
 }
 
 /**
@@ -257,11 +257,16 @@ export class Query {
   }
 
   toString(): string {
-    return `Query(target=${this.toTarget().toString()}; limitType=${this.limitType})`;
+    return `Query(target=${this.toTarget().toString()}; limitType=${
+      this.limitType
+    })`;
   }
 
   isEqual(other: Query): boolean {
-    return this.toTarget().isEqual(other.toTarget()) && (this.limitType === other.limitType);
+    return (
+      this.toTarget().isEqual(other.toTarget()) &&
+      this.limitType === other.limitType
+    );
   }
 
   docComparator(d1: Document, d2: Document): number {

--- a/packages/firestore/src/core/sync_engine.ts
+++ b/packages/firestore/src/core/sync_engine.ts
@@ -217,6 +217,7 @@ export class SyncEngine implements RemoteSyncer, SharedClientStateSyncer {
       viewSnapshot = queryView.view.computeInitialSnapshot();
     } else {
       const queryData = await this.localStore.allocateQuery(query);
+
       const status = this.sharedClientState.addLocalQueryTarget(
         queryData.targetId
       );

--- a/packages/firestore/src/core/sync_engine.ts
+++ b/packages/firestore/src/core/sync_engine.ts
@@ -1007,10 +1007,16 @@ export class SyncEngine implements RemoteSyncer, SharedClientStateSyncer {
     this.syncEngineListener!.onWatchChange(newViewSnapshots);
     return activeQueries;
   }
+
   /**
-   * Creates a `Query` object from this `Target`. There is no way to obtain
-   * the original `Query`, so we synthesize a `Query` from the `Target` object.
-   * The result might be different from the original `Query`,
+   * Creates a `Query` object from the specified `Target`. There is no way to
+   * obtain the original `Query`, so we synthesize a `Query` from the `Target`
+   * object.
+   *
+   * The synthesized result might be different from the original `Query`, but
+   * since the synthesized `Query` should return the same results as the
+   * original one (only the presentation of results might differ), and this is
+   * only used for multi-tab, the potential difference will not cause issues.
    */
   // PORTING NOTE: Multi-tab only
   private synthesizeTargetToQuery(target: Target): Query {

--- a/packages/firestore/src/core/sync_engine.ts
+++ b/packages/firestore/src/core/sync_engine.ts
@@ -995,7 +995,7 @@ export class SyncEngine implements RemoteSyncer, SharedClientStateSyncer {
         assert(!!target, `Target for id ${targetId} not found`);
         queryData = await this.localStore.allocateTarget(target!);
         await this.initializeViewAndComputeSnapshot(
-          this.targetToQuery(target!),
+          this.synthesizeTargetToQuery(target!),
           targetId,
           /*current=*/ false
         );
@@ -1008,11 +1008,12 @@ export class SyncEngine implements RemoteSyncer, SharedClientStateSyncer {
     return activeQueries;
   }
   /**
-   * Creates a `Query` object from this `Target`. Note the result might be
-   * different from the original `Query` from which we obtained this instance.
+   * Creates a `Query` object from this `Target`. There is no way to obtain
+   * the original `Query`, so we synthesize a `Query` from the `Target` object.
+   * The result might be different from the original `Query`,
    */
   // PORTING NOTE: Multi-tab only
-  private targetToQuery(target: Target): Query {
+  private synthesizeTargetToQuery(target: Target): Query {
     return new Query(
       target.path,
       target.collectionGroup,
@@ -1090,7 +1091,7 @@ export class SyncEngine implements RemoteSyncer, SharedClientStateSyncer {
       assert(!!target, `Query data for active target ${targetId} not found`);
       const queryData = await this.localStore.allocateTarget(target!);
       await this.initializeViewAndComputeSnapshot(
-        this.targetToQuery(target!),
+        this.synthesizeTargetToQuery(target!),
         queryData.targetId,
         /*current=*/ false
       );

--- a/packages/firestore/src/core/sync_engine.ts
+++ b/packages/firestore/src/core/sync_engine.ts
@@ -306,6 +306,8 @@ export class SyncEngine implements RemoteSyncer, SharedClientStateSyncer {
     const queryView = this.queryViewsByQuery.get(query)!;
     assert(!!queryView, 'Trying to unlisten on query not found:' + query);
 
+    // If it's not the only query mapped to the target, only clean up
+    // query view and keep the target active.
     const queries = this.queriesByTarget[queryView.targetId];
     if (queries.length > 1) {
       this.queriesByTarget[queryView.targetId] = queries.filter(
@@ -315,6 +317,7 @@ export class SyncEngine implements RemoteSyncer, SharedClientStateSyncer {
       return;
     }
 
+    // No other queries are mapped to the target, clean up the query and the target.
     if (this.isPrimary) {
       // We need to remove the local query target first to allow us to verify
       // whether any other client is still interested in this target.

--- a/packages/firestore/src/core/target.ts
+++ b/packages/firestore/src/core/target.ts
@@ -18,7 +18,7 @@
 import { DocumentKey } from '../model/document_key';
 import { ResourcePath } from '../model/path';
 import { isNullOrUndefined } from '../util/types';
-import { Bound, Filter, OrderBy, Query } from './query';
+import { Bound, Filter, OrderBy, Query, LimitType } from './query';
 
 /**
  * A Target represents the WatchTarget representation of a Query, which is used
@@ -170,6 +170,7 @@ export class Target {
       this.orderBy,
       this.filters,
       this.limit,
+      LimitType.First,
       this.startAt,
       this.endAt
     );

--- a/packages/firestore/src/core/target.ts
+++ b/packages/firestore/src/core/target.ts
@@ -18,7 +18,7 @@
 import { DocumentKey } from '../model/document_key';
 import { ResourcePath } from '../model/path';
 import { isNullOrUndefined } from '../util/types';
-import { Bound, Filter, OrderBy, Query, LimitType } from './query';
+import { Bound, Filter, OrderBy } from './query';
 
 /**
  * A Target represents the WatchTarget representation of a Query, which is used

--- a/packages/firestore/src/core/target.ts
+++ b/packages/firestore/src/core/target.ts
@@ -158,21 +158,4 @@ export class Target {
       this.filters.length === 0
     );
   }
-
-  /**
-   * Creates a `Query` object from this `Target`. Note the result might be
-   * different from the original `Query` from which we obtained this instance.
-   */
-  toTargetQuery(): Query {
-    return new Query(
-      this.path,
-      this.collectionGroup,
-      this.orderBy,
-      this.filters,
-      this.limit,
-      LimitType.First,
-      this.startAt,
-      this.endAt
-    );
-  }
 }

--- a/packages/firestore/src/core/view.ts
+++ b/packages/firestore/src/core/view.ts
@@ -137,8 +137,12 @@ export class View {
     // Note that this should never get used in a refill (when previousChanges is
     // set), because there will only be adds -- no deletes or updates.
     const lastDocInLimit =
-      this.query.hasLimit() && oldDocumentSet.size === this.query.limit
+      this.query.hasLimitToFirst() && oldDocumentSet.size === this.query.limit
         ? oldDocumentSet.last()
+        : null;
+    const firstDocInLimit =
+      this.query.hasLimitToLast() && oldDocumentSet.size === this.query.limit
+        ? oldDocumentSet.first()
         : null;
 
     docChanges.inorderTraversal(
@@ -180,12 +184,14 @@ export class View {
               changeApplied = true;
 
               if (
-                lastDocInLimit &&
-                this.query.docComparator(newDoc, lastDocInLimit) > 0
+                (lastDocInLimit &&
+                  this.query.docComparator(newDoc, lastDocInLimit) > 0) ||
+                (firstDocInLimit &&
+                  this.query.docComparator(newDoc, firstDocInLimit) < 0)
               ) {
-                // This doc moved from inside the limit to after the limit.
-                // That means there may be some doc in the local cache that's
-                // actually less than this one.
+                // This doc moved from inside the limit to outside the limit.
+                // That means there may be some other doc in the local cache
+                // that should be included instead.
                 needsRefill = true;
               }
             }
@@ -200,7 +206,7 @@ export class View {
           changeSet.track({ type: ChangeType.Removed, doc: oldDoc });
           changeApplied = true;
 
-          if (lastDocInLimit) {
+          if (lastDocInLimit || firstDocInLimit) {
             // A doc was removed from a full limit query. We'll need to
             // requery from the local cache to see if we know about some other
             // doc that should be in the results.
@@ -223,14 +229,19 @@ export class View {
         }
       }
     );
-    if (this.query.hasLimit()) {
+
+    // Drop documents out to meet limit/limitToLast requirement.
+    if (this.query.hasLimitToFirst() || this.query.hasLimitToLast()) {
       while (newDocumentSet.size > this.query.limit!) {
-        const oldDoc = newDocumentSet.last();
+        const oldDoc = this.query.hasLimitToFirst()
+          ? newDocumentSet.last()
+          : newDocumentSet.first();
         newDocumentSet = newDocumentSet.delete(oldDoc!.key);
         newMutatedKeys = newMutatedKeys.delete(oldDoc!.key);
         changeSet.track({ type: ChangeType.Removed, doc: oldDoc! });
       }
     }
+
     assert(
       !needsRefill || !previousChanges,
       'View was refilled using docs that themselves needed refilling.'

--- a/packages/firestore/src/local/index_free_query_engine.ts
+++ b/packages/firestore/src/local/index_free_query_engine.ts
@@ -170,12 +170,11 @@ export class IndexFreeQueryEngine implements QueryEngine {
     // Limit queries are not eligible for index-free query execution if there is
     // a potential that an older document from cache now sorts before a document
     // that was previously part of the limit. This, however, can only happen if
-    // the document at the edge of the limit when the query was last synchronized
-    // goes out of limit. If a document that is not the limit boundary sorts
-    // differently, the boundary of the limit itself did not change and
-    // documents from cache will continue to be "rejected" by this boundary.
-    // Therefore, we can ignore any modifications that don't affect the last
-    // document.
+    // the document at the edge of the limit goes out of limit.
+    // If a document that is not the limit boundary sorts differently,
+    // the boundary of the limit itself did not change and documents from cache
+    // will continue to be "rejected" by this boundary. Therefore, we can ignore
+    // any modifications that don't affect the last document.
     const docAtLimitEdge =
       limitType === LimitType.First
         ? sortedPreviousResults.last()

--- a/packages/firestore/src/local/index_free_query_engine.ts
+++ b/packages/firestore/src/local/index_free_query_engine.ts
@@ -19,7 +19,7 @@ import { QueryEngine } from './query_engine';
 import { LocalDocumentsView } from './local_documents_view';
 import { PersistenceTransaction } from './persistence';
 import { PersistencePromise } from './persistence_promise';
-import { Query } from '../core/query';
+import { Query, LimitType } from '../core/query';
 import { SnapshotVersion } from '../core/snapshot_version';
 import {
   DocumentKeySet,
@@ -87,9 +87,9 @@ export class IndexFreeQueryEngine implements QueryEngine {
         const previousResults = this.applyQuery(query, documents);
 
         if (
-          // TODO(wuandy): handle limitToLast as well.
-          query.hasLimitToFirst() &&
+          (query.hasLimitToFirst() || query.hasLimitToLast()) &&
           this.needsRefill(
+            query.limitType,
             previousResults,
             remoteKeys,
             lastLimboFreeSnapshotVersion
@@ -156,6 +156,7 @@ export class IndexFreeQueryEngine implements QueryEngine {
    * was last synchronized.
    */
   private needsRefill(
+    limitType: LimitType,
     sortedPreviousResults: SortedSet<Document>,
     remoteKeys: DocumentKeySet,
     limboFreeSnapshotVersion: SnapshotVersion
@@ -169,20 +170,23 @@ export class IndexFreeQueryEngine implements QueryEngine {
     // Limit queries are not eligible for index-free query execution if there is
     // a potential that an older document from cache now sorts before a document
     // that was previously part of the limit. This, however, can only happen if
-    // the last document of the limit sorts lower than it did when the query was
-    // last synchronized. If a document that is not the limit boundary sorts
+    // the document at the edge of the limit when the query was last synchronized
+    // goes out of limit. If a document that is not the limit boundary sorts
     // differently, the boundary of the limit itself did not change and
     // documents from cache will continue to be "rejected" by this boundary.
     // Therefore, we can ignore any modifications that don't affect the last
     // document.
-    const lastDocumentInLimit = sortedPreviousResults.last();
-    if (!lastDocumentInLimit) {
+    const docAtLimitEdge =
+      limitType === LimitType.First
+        ? sortedPreviousResults.last()
+        : sortedPreviousResults.first();
+    if (!docAtLimitEdge) {
       // We don't need to refill the query if there were already no documents.
       return false;
     }
     return (
-      lastDocumentInLimit.hasPendingWrites ||
-      lastDocumentInLimit.version.compareTo(limboFreeSnapshotVersion) > 0
+      docAtLimitEdge.hasPendingWrites ||
+      docAtLimitEdge.version.compareTo(limboFreeSnapshotVersion) > 0
     );
   }
 

--- a/packages/firestore/src/local/index_free_query_engine.ts
+++ b/packages/firestore/src/local/index_free_query_engine.ts
@@ -87,7 +87,8 @@ export class IndexFreeQueryEngine implements QueryEngine {
         const previousResults = this.applyQuery(query, documents);
 
         if (
-          query.hasLimit() &&
+          // TODO(wuandy): handle limitToLast as well.
+          query.hasLimitToFirst() &&
           this.needsRefill(
             previousResults,
             remoteKeys,

--- a/packages/firestore/src/local/local_store.ts
+++ b/packages/firestore/src/local/local_store.ts
@@ -814,15 +814,13 @@ export class LocalStore {
     );
   }
 
-  // TODO(wuandy): delete this temp method, it's only for change isolation.
-  allocateQuery(query: Query): Promise<QueryData> {
-    return this.allocateTarget(query.toTarget());
-  }
-
   /**
    * Assigns the given query an internal ID so that its results can be pinned so
    * they don't get GC'd. A query must be allocated in the local store before
    * the store can be used to manage its view.
+   *
+   * Allocating an already allocated `Target` will return the existing `QueryData`
+   * for that `Target`.
    */
   allocateTarget(target: Target): Promise<QueryData> {
     return this.persistence
@@ -853,15 +851,13 @@ export class LocalStore {
           });
       })
       .then(queryData => {
-        assert(
-          this.queryDataByTarget.get(queryData.targetId) === null,
-          'Tried to allocate an already allocated query: ' + target
-        );
-        this.queryDataByTarget = this.queryDataByTarget.insert(
-          queryData.targetId,
-          queryData
-        );
-        this.targetIdByTarget.set(target, queryData.targetId);
+        if (this.queryDataByTarget.get(queryData.targetId) === null) {
+          this.queryDataByTarget = this.queryDataByTarget.insert(
+            queryData.targetId,
+            queryData
+          );
+          this.targetIdByTarget.set(target, queryData.targetId);
+        }
         return queryData;
       });
   }
@@ -890,15 +886,17 @@ export class LocalStore {
    * `keepPersistedQueryData` is set to false and Eager GC enabled, the method
    * directly removes the associated query data from the query cache.
    *
-   * Calling `releaseTarget` multiple times with the same Target is an error.
+   * Releasing a non-existing `Target` is a no-op.
    */
   // PORTING NOTE: `keepPersistedQueryData` is multi-tab only.
   releaseTarget(
     targetId: number,
     keepPersistedQueryData: boolean
   ): Promise<void> {
-    const queryData = this.queryDataByTarget.get(targetId)!;
-    assert(!!queryData, 'Tried to release nonexistent target: ' + targetId);
+    const queryData = this.queryDataByTarget.get(targetId);
+    if (!queryData) {
+      return Promise.resolve();
+    }
 
     const mode = keepPersistedQueryData
       ? 'readwrite-idempotent'

--- a/packages/firestore/src/local/query_data.ts
+++ b/packages/firestore/src/local/query_data.ts
@@ -19,7 +19,6 @@ import { SnapshotVersion } from '../core/snapshot_version';
 import { Target } from '../core/target';
 import { ListenSequenceNumber, ProtoByteString, TargetId } from '../core/types';
 import { emptyByteString } from '../platform/platform';
-import { assert } from '../util/assert';
 
 /** An enumeration of the different purposes we have for queries. */
 export enum QueryPurpose {

--- a/packages/firestore/src/local/query_data.ts
+++ b/packages/firestore/src/local/query_data.ts
@@ -19,6 +19,7 @@ import { SnapshotVersion } from '../core/snapshot_version';
 import { Target } from '../core/target';
 import { ListenSequenceNumber, ProtoByteString, TargetId } from '../core/types';
 import { emptyByteString } from '../platform/platform';
+import { assert } from '../util/assert';
 
 /** An enumeration of the different purposes we have for queries. */
 export enum QueryPurpose {

--- a/packages/firestore/src/local/shared_client_state.ts
+++ b/packages/firestore/src/local/shared_client_state.ts
@@ -110,6 +110,9 @@ export interface SharedClientState {
    * Associates a new Query Target ID with the local Firestore client. Returns
    * the new query state for the query (which can be 'current' if the query is
    * already associated with another tab).
+   *
+   * If the target id is already associated with local client, the method simply
+   * returns it's `QueryTargetState`.
    */
   addLocalQueryTarget(targetId: TargetId): QueryTargetState;
 
@@ -492,10 +495,9 @@ export class LocalClientState implements ClientState {
   activeTargetIds = targetIdSet();
 
   addQueryTarget(targetId: TargetId): void {
-    assert(
-      !this.activeTargetIds.has(targetId),
-      `Target with ID '${targetId}' already active.`
-    );
+    if (this.activeTargetIds.has(targetId)) {
+      return;
+    }
     this.activeTargetIds = this.activeTargetIds.add(targetId);
   }
 

--- a/packages/firestore/src/local/shared_client_state.ts
+++ b/packages/firestore/src/local/shared_client_state.ts
@@ -495,9 +495,6 @@ export class LocalClientState implements ClientState {
   activeTargetIds = targetIdSet();
 
   addQueryTarget(targetId: TargetId): void {
-    if (this.activeTargetIds.has(targetId)) {
-      return;
-    }
     this.activeTargetIds = this.activeTargetIds.add(targetId);
   }
 

--- a/packages/firestore/src/remote/remote_store.ts
+++ b/packages/firestore/src/remote/remote_store.ts
@@ -238,12 +238,15 @@ export class RemoteStore implements TargetMetadataProvider {
     this.onlineStateTracker.set(OnlineState.Unknown);
   }
 
-  /** Starts new listen for the given query. Uses resume token if provided */
+  /**
+   * Starts new listen for the given query. Uses resume token if provided. It
+   * is a no-op if the target of given `QueryData` is already being listened.
+   */
   listen(queryData: QueryData): void {
-    assert(
-      !objUtils.contains(this.listenTargets, queryData.targetId),
-      'listen called with duplicate targetId!'
-    );
+    if (objUtils.contains(this.listenTargets, queryData.targetId)) {
+      return;
+    }
+
     // Mark this as something the client is currently listening for.
     this.listenTargets[queryData.targetId] = queryData;
 
@@ -255,12 +258,15 @@ export class RemoteStore implements TargetMetadataProvider {
     }
   }
 
-  /** Removes the listen from server */
+  /**
+   * Removes the listen from server. It is a no-op if the given target id is
+   * not being listened to.
+   */
   unlisten(targetId: TargetId): void {
-    assert(
-      objUtils.contains(this.listenTargets, targetId),
-      'unlisten called without assigned target ID!'
-    );
+    if (!objUtils.contains(this.listenTargets, targetId)) {
+      return;
+    }
+
     delete this.listenTargets[targetId];
     if (this.watchStream.isOpen()) {
       this.sendUnwatchRequest(targetId);

--- a/packages/firestore/src/remote/serializer.ts
+++ b/packages/firestore/src/remote/serializer.ts
@@ -24,6 +24,7 @@ import {
   Direction,
   FieldFilter,
   Filter,
+  LimitType,
   Operator,
   OrderBy,
   Query
@@ -1134,6 +1135,7 @@ export class JsonProtoSerializer {
       orderBy,
       filterBy,
       limit,
+      LimitType.First,
       startAt,
       endAt
     ).toTarget();

--- a/packages/firestore/src/util/input_validation.ts
+++ b/packages/firestore/src/util/input_validation.ts
@@ -451,6 +451,15 @@ export function invalidClassError(
   );
 }
 
+export function validatePositiveLimit(functionName: string, n: number): void {
+  if (n <= 0) {
+    throw new FirestoreError(
+      Code.INVALID_ARGUMENT,
+      `Function "${functionName}" created invalid Query. Query limit (${n}) is invalid. Limit must be positive.`
+    );
+  }
+}
+
 /** Converts a number to its english word representation */
 function ordinal(num: number): string {
   switch (num) {

--- a/packages/firestore/src/util/input_validation.ts
+++ b/packages/firestore/src/util/input_validation.ts
@@ -451,11 +451,17 @@ export function invalidClassError(
   );
 }
 
-export function validatePositiveLimit(functionName: string, n: number): void {
+export function validatePositiveNumber(
+  functionName: string,
+  position: number,
+  n: number
+): void {
   if (n <= 0) {
     throw new FirestoreError(
       Code.INVALID_ARGUMENT,
-      `Function "${functionName}" created invalid Query. Query limit (${n}) is invalid. Limit must be positive.`
+      `Function "${functionName}()" requires its ${ordinal(
+        position
+      )} argument to be a positive number, but it was: ${n}.`
     );
   }
 }

--- a/packages/firestore/test/integration/api/query.test.ts
+++ b/packages/firestore/test/integration/api/query.test.ts
@@ -247,7 +247,7 @@ apiDescribe('Queries', (persistence: boolean) => {
     });
   });
 
-  it.only('can relisten to mirror queries', () => {
+  it('can relisten to mirror queries', () => {
     const testDocs = {
       a: { k: 'a', sort: 0 },
       b: { k: 'b', sort: 1 },

--- a/packages/firestore/test/integration/api/query.test.ts
+++ b/packages/firestore/test/integration/api/query.test.ts
@@ -307,8 +307,7 @@ apiDescribe('Queries', (persistence: boolean) => {
         { k: 'e', sort: -1 }
       ]);
 
-      // Unlisten to both, update a doc, then relisten limitToLast.
-      limitUnlisten();
+      // Unlisten to limitToLast, update a doc, then relisten limitToLast.
       limitToLastUnlisten();
       await collection.doc('a').update({ k: 'a', sort: -2 });
       limitToLastUnlisten = collection
@@ -316,7 +315,11 @@ apiDescribe('Queries', (persistence: boolean) => {
         .limitToLast(2)
         .onSnapshot(storeLimitToLastEvent.storeEvent);
 
-      await storeLimitEvent.assertNoAdditionalEvents();
+      snapshot = await storeLimitEvent.awaitEvent();
+      expect(toDataArray(snapshot)).to.deep.equal([
+        { k: 'a', sort: -2 },
+        { k: 'e', sort: -1 }
+      ]);
 
       snapshot = await storeLimitToLastEvent.awaitEvent();
       expect(toDataArray(snapshot)).to.deep.equal([

--- a/packages/firestore/test/integration/api/query.test.ts
+++ b/packages/firestore/test/integration/api/query.test.ts
@@ -140,7 +140,7 @@ apiDescribe('Queries', (persistence: boolean) => {
     });
   });
 
-  // Queries that mapped to the same target ID are referred to as
+  // Two queries that mapped to the same target ID are referred to as
   // "mirror queries". An example for a mirror query is a limitToLast()
   // query and a limit() query that share the same backend Target ID.
   // Since limitToLast() queries are sent to the backend with a modified

--- a/packages/firestore/test/integration/api/query.test.ts
+++ b/packages/firestore/test/integration/api/query.test.ts
@@ -247,7 +247,7 @@ apiDescribe('Queries', (persistence: boolean) => {
     });
   });
 
-  it('can relisten to mirror queries', () => {
+  it.only('can relisten to mirror queries', () => {
     const testDocs = {
       a: { k: 'a', sort: 0 },
       b: { k: 'b', sort: 1 },

--- a/packages/firestore/test/integration/api/validation.test.ts
+++ b/packages/firestore/test/integration/api/validation.test.ts
@@ -797,11 +797,11 @@ apiDescribe('Validation:', (persistence: boolean) => {
     validationIt(persistence, 'with non-positive limit fail', db => {
       const collection = db.collection('test');
       expect(() => collection.limit(0)).to.throw(
-        'Invalid Query. Query limit (0) is invalid. Limit must be ' +
+        'Function "limit" created invalid Query. Query limit (0) is invalid. Limit must be ' +
           'positive.'
       );
-      expect(() => collection.limit(-1)).to.throw(
-        'Invalid Query. Query limit (-1) is invalid. Limit must be ' +
+      expect(() => collection.limitToLast(-1)).to.throw(
+        'Function "limitToLast" created invalid Query. Query limit (-1) is invalid. Limit must be ' +
           'positive.'
       );
     });

--- a/packages/firestore/test/integration/api/validation.test.ts
+++ b/packages/firestore/test/integration/api/validation.test.ts
@@ -797,11 +797,11 @@ apiDescribe('Validation:', (persistence: boolean) => {
     validationIt(persistence, 'with non-positive limit fail', db => {
       const collection = db.collection('test');
       expect(() => collection.limit(0)).to.throw(
-        'Function "limit()" requires its first argument to be a positive number, ' +
+        'Function "Query.limit()" requires its first argument to be a positive number, ' +
           'but it was: 0.'
       );
       expect(() => collection.limitToLast(-1)).to.throw(
-        'Function "limitToLast()" requires its first argument to be a positive number, ' +
+        'Function "Query.limitToLast()" requires its first argument to be a positive number, ' +
           'but it was: -1.'
       );
     });

--- a/packages/firestore/test/integration/api/validation.test.ts
+++ b/packages/firestore/test/integration/api/validation.test.ts
@@ -797,12 +797,12 @@ apiDescribe('Validation:', (persistence: boolean) => {
     validationIt(persistence, 'with non-positive limit fail', db => {
       const collection = db.collection('test');
       expect(() => collection.limit(0)).to.throw(
-        'Function "limit" created invalid Query. Query limit (0) is invalid. Limit must be ' +
-          'positive.'
+        'Function "limit()" requires its first argument to be a positive number, ' +
+          'but it was: 0.'
       );
       expect(() => collection.limitToLast(-1)).to.throw(
-        'Function "limitToLast" created invalid Query. Query limit (-1) is invalid. Limit must be ' +
-          'positive.'
+        'Function "limitToLast()" requires its first argument to be a positive number, ' +
+          'but it was: -1.'
       );
     });
 

--- a/packages/firestore/test/unit/core/query.test.ts
+++ b/packages/firestore/test/unit/core/query.test.ts
@@ -616,4 +616,33 @@ describe('Query', () => {
     query = baseQuery.withEndAt(bound([], true));
     expect(query.matchesAllDocuments()).to.be.false;
   });
+
+  it('can handle conversion to Targets from mirror queries', () => {
+    const limitQuery = Query.atPath(ResourcePath.fromString('collection'))
+      .addOrderBy(orderBy('foo'))
+      .addOrderBy(orderBy('bar', 'desc'))
+      .withStartAt(bound([['foo', 'foo', 'asc']], true))
+      .withLimitToFirst(10);
+    const fromLimit = limitQuery.toTarget();
+
+    const limitToLastQuery = Query.atPath(ResourcePath.fromString('collection'))
+      .addOrderBy(orderBy('foo', 'desc'))
+      .addOrderBy(orderBy('bar', 'asc'))
+      .withEndAt(bound([['foo', 'foo', 'desc']], false))
+      .withLimitToLast(10);
+    const fromLimitToLast = limitToLastQuery.toTarget();
+
+    expect(fromLimit.canonicalId()).to.equal(fromLimitToLast.canonicalId());
+    expect(fromLimit.isEqual(fromLimitToLast)).to.be.true;
+
+    expect(limitQuery.isEqual(fromLimit.toTargetQuery())).to.be.true;
+    expect(limitQuery.canonicalId()).to.equal(
+      fromLimit.toTargetQuery().canonicalId()
+    );
+
+    expect(limitQuery.isEqual(fromLimitToLast.toTargetQuery())).to.be.true;
+    expect(limitQuery.canonicalId()).to.equal(
+      fromLimitToLast.toTargetQuery().canonicalId()
+    );
+  });
 });

--- a/packages/firestore/test/unit/core/query.test.ts
+++ b/packages/firestore/test/unit/core/query.test.ts
@@ -616,33 +616,4 @@ describe('Query', () => {
     query = baseQuery.withEndAt(bound([], true));
     expect(query.matchesAllDocuments()).to.be.false;
   });
-
-  it('can handle conversion to Targets from mirror queries', () => {
-    const limitQuery = Query.atPath(ResourcePath.fromString('collection'))
-      .addOrderBy(orderBy('foo'))
-      .addOrderBy(orderBy('bar', 'desc'))
-      .withStartAt(bound([['foo', 'foo', 'asc']], true))
-      .withLimitToFirst(10);
-    const fromLimit = limitQuery.toTarget();
-
-    const limitToLastQuery = Query.atPath(ResourcePath.fromString('collection'))
-      .addOrderBy(orderBy('foo', 'desc'))
-      .addOrderBy(orderBy('bar', 'asc'))
-      .withEndAt(bound([['foo', 'foo', 'desc']], false))
-      .withLimitToLast(10);
-    const fromLimitToLast = limitToLastQuery.toTarget();
-
-    expect(fromLimit.canonicalId()).to.equal(fromLimitToLast.canonicalId());
-    expect(fromLimit.isEqual(fromLimitToLast)).to.be.true;
-
-    expect(limitQuery.isEqual(fromLimit.toTargetQuery())).to.be.true;
-    expect(limitQuery.canonicalId()).to.equal(
-      fromLimit.toTargetQuery().canonicalId()
-    );
-
-    expect(limitQuery.isEqual(fromLimitToLast.toTargetQuery())).to.be.true;
-    expect(limitQuery.canonicalId()).to.equal(
-      fromLimitToLast.toTargetQuery().canonicalId()
-    );
-  });
 });

--- a/packages/firestore/test/unit/core/query.test.ts
+++ b/packages/firestore/test/unit/core/query.test.ts
@@ -470,7 +470,8 @@ describe('Query', () => {
       .addFilter(filter('bar', '>', 2))
       .addOrderBy(orderBy('bar'));
 
-    const q7a = Query.atPath(path('foo')).withLimit(10);
+    const q7a = Query.atPath(path('foo')).withLimitToFirst(10);
+    const q8a = Query.atPath(path('foo')).withLimitToLast(10);
 
     const lip1a = bound([[DOCUMENT_KEY_NAME, 'coll/foo', 'asc']], true);
     const lip1b = bound([[DOCUMENT_KEY_NAME, 'coll/foo', 'asc']], false);
@@ -478,18 +479,18 @@ describe('Query', () => {
     // TODO(b/35851862): descending key ordering not supported yet
     // const lip3 = bound([[DOCUMENT_KEY_NAME, 'coll/bar', 'desc']]);
 
-    const q8a = Query.atPath(path('foo')).withStartAt(lip1a);
-    const q9a = Query.atPath(path('foo')).withStartAt(lip1b);
-    const q10a = Query.atPath(path('foo')).withStartAt(lip2);
-    const q11a = Query.atPath(path('foo')).withEndAt(lip1a);
-    const q12a = Query.atPath(path('foo')).withEndAt(lip1b);
-    const q13a = Query.atPath(path('foo')).withEndAt(lip2);
+    const q9a = Query.atPath(path('foo')).withStartAt(lip1a);
+    const q10a = Query.atPath(path('foo')).withStartAt(lip1b);
+    const q11a = Query.atPath(path('foo')).withStartAt(lip2);
+    const q12a = Query.atPath(path('foo')).withEndAt(lip1a);
+    const q13a = Query.atPath(path('foo')).withEndAt(lip1b);
+    const q14a = Query.atPath(path('foo')).withEndAt(lip2);
 
     // TODO(b/35851862): descending key ordering not supported yet
-    // const q14a = Query.atPath(path('foo'))
+    // const q15a = Query.atPath(path('foo'))
     // .addOrderBy(orderBy(DOCUMENT_KEY_NAME, 'desc'))
     // .withUpperBound(lip3, 'inclusive');
-    // const q15a = Query.atPath(path('foo'))
+    // const q16a = Query.atPath(path('foo'))
     // .addOrderBy(orderBy(DOCUMENT_KEY_NAME, 'desc'))
     // .withUpperBound(lip3, 'exclusive');
 
@@ -500,17 +501,17 @@ describe('Query', () => {
       5
     );
 
-    const q16a = Query.atPath(path('foo')).addFilter(
+    const q17a = Query.atPath(path('foo')).addFilter(
       filter('object', '==', { ref: relativeReference })
     );
-    const q16b = Query.atPath(path('foo')).addFilter(
+    const q17b = Query.atPath(path('foo')).addFilter(
       filter('object', '==', { ref: absoluteReference })
     );
 
-    const q17a = Query.atPath(path('foo')).addFilter(
+    const q18a = Query.atPath(path('foo')).addFilter(
       filter('array', '==', [relativeReference])
     );
-    const q17b = Query.atPath(path('foo')).addFilter(
+    const q18b = Query.atPath(path('foo')).addFilter(
       filter('array', '==', [absoluteReference])
     );
 
@@ -528,10 +529,11 @@ describe('Query', () => {
       [q11a],
       [q12a],
       [q13a],
-      //[q14a],
+      [q14a],
       //[q15a],
-      [q16a, q16b],
-      [q17a, q17b]
+      //[q16a],
+      [q17a, q17b],
+      [q18a, q18b]
     ];
 
     expectEqualitySets(queries, (q1, q2) => {
@@ -605,7 +607,7 @@ describe('Query', () => {
     query = baseQuery.addFilter(filter('foo', '==', 'bar'));
     expect(query.matchesAllDocuments()).to.be.false;
 
-    query = baseQuery.withLimit(1);
+    query = baseQuery.withLimitToFirst(1);
     expect(query.matchesAllDocuments()).to.be.false;
 
     query = baseQuery.withStartAt(bound([], true));

--- a/packages/firestore/test/unit/core/view.test.ts
+++ b/packages/firestore/test/unit/core/view.test.ts
@@ -174,7 +174,7 @@ describe('View', () => {
 
   it('removes documents for query with limit', () => {
     // shallow ancestor query
-    const query = Query.atPath(path('rooms/eros/messages')).withLimit(2);
+    const query = Query.atPath(path('rooms/eros/messages')).withLimitToFirst(2);
     const view = new View(query, documentKeySet());
 
     const doc1 = doc('rooms/eros/messages/1', 0, { text: 'msg1' });
@@ -206,7 +206,7 @@ describe('View', () => {
     // shallow ancestor query
     const query = Query.atPath(path('rooms/eros/messages'))
       .addOrderBy(orderBy('num'))
-      .withLimit(2);
+      .withLimitToFirst(2);
     const view = new View(query, documentKeySet());
 
     const doc1 = doc('rooms/eros/messages/1', 0, { num: 1 });
@@ -344,7 +344,7 @@ describe('View', () => {
   });
 
   it('returns needsRefill on delete limit query', () => {
-    const query = Query.atPath(path('rooms/eros/msgs')).withLimit(2);
+    const query = Query.atPath(path('rooms/eros/msgs')).withLimitToFirst(2);
     const doc1 = doc('rooms/eros/msgs/0', 0, {});
     const doc2 = doc('rooms/eros/msgs/1', 0, {});
     const view = new View(query, documentKeySet());
@@ -372,7 +372,7 @@ describe('View', () => {
   it('returns needsRefill on reorder in limit query', () => {
     const query = Query.atPath(path('rooms/eros/msgs'))
       .addOrderBy(orderBy('order'))
-      .withLimit(2);
+      .withLimitToFirst(2);
     const doc1 = doc('rooms/eros/msgs/0', 0, { order: 1 });
     let doc2 = doc('rooms/eros/msgs/1', 0, { order: 2 });
     const doc3 = doc('rooms/eros/msgs/2', 0, { order: 3 });
@@ -405,7 +405,7 @@ describe('View', () => {
   it("doesn't need refill on reorder within limit", () => {
     const query = Query.atPath(path('rooms/eros/msgs'))
       .addOrderBy(orderBy('order'))
-      .withLimit(3);
+      .withLimitToFirst(3);
     let doc1 = doc('rooms/eros/msgs/0', 0, { order: 1 });
     const doc2 = doc('rooms/eros/msgs/1', 0, { order: 2 });
     const doc3 = doc('rooms/eros/msgs/2', 0, { order: 3 });
@@ -434,7 +434,7 @@ describe('View', () => {
   it("doesn't need refill on reorder after limit query", () => {
     const query = Query.atPath(path('rooms/eros/msgs'))
       .addOrderBy(orderBy('order'))
-      .withLimit(3);
+      .withLimitToFirst(3);
     const doc1 = doc('rooms/eros/msgs/0', 0, { order: 1 });
     const doc2 = doc('rooms/eros/msgs/1', 0, { order: 2 });
     const doc3 = doc('rooms/eros/msgs/2', 0, { order: 3 });
@@ -461,7 +461,7 @@ describe('View', () => {
   });
 
   it("doesn't need refill for additions after the limit", () => {
-    const query = Query.atPath(path('rooms/eros/msgs')).withLimit(2);
+    const query = Query.atPath(path('rooms/eros/msgs')).withLimitToFirst(2);
     const doc1 = doc('rooms/eros/msgs/0', 0, {});
     const doc2 = doc('rooms/eros/msgs/1', 0, {});
     const view = new View(query, documentKeySet());
@@ -483,7 +483,7 @@ describe('View', () => {
   });
 
   it("doesn't need refill for deletions when not near the limit", () => {
-    const query = Query.atPath(path('rooms/eros/msgs')).withLimit(20);
+    const query = Query.atPath(path('rooms/eros/msgs')).withLimitToFirst(20);
     const doc1 = doc('rooms/eros/msgs/0', 0, {});
     const doc2 = doc('rooms/eros/msgs/1', 0, {});
     const view = new View(query, documentKeySet());
@@ -503,7 +503,7 @@ describe('View', () => {
   });
 
   it('handles applying irrelevant docs', () => {
-    const query = Query.atPath(path('rooms/eros/msgs')).withLimit(2);
+    const query = Query.atPath(path('rooms/eros/msgs')).withLimitToFirst(2);
     const doc1 = doc('rooms/eros/msgs/0', 0, {});
     const doc2 = doc('rooms/eros/msgs/1', 0, {});
     const view = new View(query, documentKeySet());

--- a/packages/firestore/test/unit/local/index_free_query_engine.test.ts
+++ b/packages/firestore/test/unit/local/index_free_query_engine.test.ts
@@ -264,7 +264,7 @@ describe('IndexFreeQueryEngine', () => {
   it('does not use initial results for limit query with document removal', async () => {
     const query = Query.atPath(path('coll'))
       .addFilter(filter('matches', '==', true))
-      .withLimitToFirst(1);
+      .withLimitToLast(1);
 
     // While the backend would never add DocA to the set of remote keys, this
     // allows us to easily simulate what would happen when a document no longer

--- a/packages/firestore/test/unit/local/index_free_query_engine.test.ts
+++ b/packages/firestore/test/unit/local/index_free_query_engine.test.ts
@@ -264,7 +264,7 @@ describe('IndexFreeQueryEngine', () => {
   it('does not use initial results for limit query with document removal', async () => {
     const query = Query.atPath(path('coll'))
       .addFilter(filter('matches', '==', true))
-      .withLimit(1);
+      .withLimitToFirst(1);
 
     // While the backend would never add DocA to the set of remote keys, this
     // allows us to easily simulate what would happen when a document no longer
@@ -285,7 +285,7 @@ describe('IndexFreeQueryEngine', () => {
     const query = Query.atPath(path('coll'))
       .addFilter(filter('matches', '==', true))
       .addOrderBy(orderBy('order', 'desc'))
-      .withLimit(1);
+      .withLimitToFirst(1);
 
     // Add a query mapping for a document that matches, but that sorts below
     // another document due to a pending write.
@@ -304,7 +304,7 @@ describe('IndexFreeQueryEngine', () => {
     const query = Query.atPath(path('coll'))
       .addFilter(filter('matches', '==', true))
       .addOrderBy(orderBy('order', 'desc'))
-      .withLimit(1);
+      .withLimitToFirst(1);
 
     // Add a query mapping for a document that matches, but that sorts below
     // another document based on an update that the SDK received after the
@@ -323,7 +323,7 @@ describe('IndexFreeQueryEngine', () => {
   it('uses initial results if last document in limit is unchanged', async () => {
     const query = Query.atPath(path('coll'))
       .addOrderBy(orderBy('order'))
-      .withLimit(2);
+      .withLimitToFirst(2);
 
     await addDocument(doc('coll/a', 1, { order: 1 }));
     await addDocument(doc('coll/b', 1, { order: 3 }));

--- a/packages/firestore/test/unit/local/local_store.test.ts
+++ b/packages/firestore/test/unit/local/local_store.test.ts
@@ -1058,7 +1058,7 @@ function genericLocalStoreTests(
 
   it('can execute mixed collection queries', async () => {
     const query = Query.atPath(path('foo'));
-    const queryData = await localStore.allocateQuery(query);
+    const queryData = await localStore.allocateTarget(query.toTarget());
     expect(queryData.targetId).to.equal(2);
     await localStore.applyRemoteEvent(
       docAddedRemoteEvent(doc('foo/baz', 10, { a: 'b' }), [2], [])
@@ -1122,7 +1122,7 @@ function genericLocalStoreTests(
   // eslint-disable-next-line no-restricted-properties
   (gcIsEager ? it.skip : it)('persists resume tokens', async () => {
     const query = Query.atPath(path('foo/bar'));
-    const queryData = await localStore.allocateQuery(query);
+    const queryData = await localStore.allocateTarget(query.toTarget());
     const targetId = queryData.targetId;
     const resumeToken = 'abc';
     const watchChange = new WatchTargetChange(
@@ -1145,7 +1145,7 @@ function genericLocalStoreTests(
     );
 
     // Should come back with the same resume token
-    const queryData2 = await localStore.allocateQuery(query);
+    const queryData2 = await localStore.allocateTarget(query.toTarget());
     expect(queryData2.resumeToken).to.deep.equal(resumeToken);
   });
 
@@ -1154,7 +1154,7 @@ function genericLocalStoreTests(
     'does not replace resume token with empty resume token',
     async () => {
       const query = Query.atPath(path('foo/bar'));
-      const queryData = await localStore.allocateQuery(query);
+      const queryData = await localStore.allocateTarget(query.toTarget());
       const targetId = queryData.targetId;
       const resumeToken = 'abc';
 
@@ -1191,7 +1191,7 @@ function genericLocalStoreTests(
       );
 
       // Should come back with the same resume token
-      const queryData2 = await localStore.allocateQuery(query);
+      const queryData2 = await localStore.allocateTarget(query.toTarget());
       expect(queryData2.resumeToken).to.deep.equal(resumeToken);
     }
   );

--- a/packages/firestore/test/unit/remote/node/serializer.test.ts
+++ b/packages/firestore/test/unit/remote/node/serializer.test.ts
@@ -1154,7 +1154,7 @@ describe('Serializer', () => {
 
     it('converts limits', () => {
       const q = Query.atPath(path('docs'))
-        .withLimit(26)
+        .withLimitToFirst(26)
         .toTarget();
       const result = s.toTarget(wrapQueryData(q));
       const expected = {

--- a/packages/firestore/test/unit/specs/limbo_spec.test.ts
+++ b/packages/firestore/test/unit/specs/limbo_spec.test.ts
@@ -196,7 +196,7 @@ describeSpec('Limbo Documents:', [], () => {
     const fullQuery = Query.atPath(path('collection'));
     const limitQuery = Query.atPath(path('collection'))
       .addFilter(filter('include', '==', true))
-      .withLimit(1);
+      .withLimitToFirst(1);
     const docA = doc('collection/a', 1000, { key: 'a', include: true });
     const docB = doc('collection/b', 1000, { key: 'b', include: true });
     const docBQuery = Query.atPath(docB.key.path);
@@ -266,7 +266,7 @@ describeSpec('Limbo Documents:', [], () => {
       const fullQuery = Query.atPath(path('collection'));
       const limitQuery = Query.atPath(path('collection'))
         .addFilter(filter('include', '==', true))
-        .withLimit(1);
+        .withLimitToFirst(1);
       const docA = doc('collection/a', 1000, { key: 'a', include: true });
       const docB = doc('collection/b', 1000, { key: 'b', include: true });
       const docBQuery = Query.atPath(docB.key.path);

--- a/packages/firestore/test/unit/specs/limit_spec.test.ts
+++ b/packages/firestore/test/unit/specs/limit_spec.test.ts
@@ -23,7 +23,7 @@ import { client, spec } from './spec_builder';
 
 describeSpec('Limits:', [], () => {
   specTest('Documents in limit are replaced by remote event', [], () => {
-    const query1 = Query.atPath(path('collection')).withLimit(2);
+    const query1 = Query.atPath(path('collection')).withLimitToFirst(2);
     const doc1 = doc('collection/a', 1000, { key: 'a' });
     const doc2 = doc('collection/b', 1002, { key: 'b' });
     const doc3 = doc('collection/c', 1001, { key: 'c' });
@@ -46,7 +46,7 @@ describeSpec('Limits:', [], () => {
     "Documents outside of limit don't raise hasPendingWrites",
     [],
     () => {
-      const query1 = Query.atPath(path('collection')).withLimit(2);
+      const query1 = Query.atPath(path('collection')).withLimitToFirst(2);
       const doc1 = doc('collection/a', 1000, { key: 'a' });
       const doc2 = doc('collection/b', 1000, { key: 'b' });
 
@@ -68,7 +68,7 @@ describeSpec('Limits:', [], () => {
   );
 
   specTest('Deleted Document in limbo in full limit query', [], () => {
-    const query = Query.atPath(path('collection')).withLimit(2);
+    const query = Query.atPath(path('collection')).withLimitToFirst(2);
     const doc1 = doc('collection/a', 1000, { key: 'a' });
     const doc2 = doc('collection/b', 1001, { key: 'b' });
     const doc3 = doc('collection/c', 1002, { key: 'c' });
@@ -96,7 +96,7 @@ describeSpec('Limits:', [], () => {
   });
 
   specTest('Documents in limit can handle removed messages', [], () => {
-    const query1 = Query.atPath(path('collection')).withLimit(2);
+    const query1 = Query.atPath(path('collection')).withLimitToFirst(2);
     const doc1 = doc('collection/a', 1000, { key: 'a' });
     const doc2 = doc('collection/b', 1002, { key: 'b' });
     const doc3 = doc('collection/c', 1001, { key: 'c' });
@@ -123,8 +123,8 @@ describeSpec('Limits:', [], () => {
     'Documents in limit are can handle removed messages for only one of many query',
     [],
     () => {
-      const query1 = Query.atPath(path('collection')).withLimit(2);
-      const query2 = Query.atPath(path('collection')).withLimit(3);
+      const query1 = Query.atPath(path('collection')).withLimitToFirst(2);
+      const query2 = Query.atPath(path('collection')).withLimitToFirst(3);
       const doc1 = doc('collection/a', 1000, { key: 'a' });
       const doc2 = doc('collection/b', 1002, { key: 'b' });
       const doc3 = doc('collection/c', 1001, { key: 'c' });
@@ -164,7 +164,7 @@ describeSpec('Limits:', [], () => {
     );
     const limitQuery = Query.atPath(path('collection'))
       .addFilter(filter('matches', '==', true))
-      .withLimit(2);
+      .withLimitToFirst(2);
     const doc1 = doc('collection/a', 1001, { matches: true });
     const doc2 = doc('collection/b', 1002, { matches: true });
     const doc3 = doc('collection/c', 1000, { matches: true });
@@ -195,7 +195,7 @@ describeSpec('Limits:', [], () => {
       );
       const limitQuery = Query.atPath(path('collection'))
         .addFilter(filter('matches', '==', true))
-        .withLimit(2);
+        .withLimitToFirst(2);
       const doc1 = doc('collection/a', 1001, { matches: true });
       const doc2 = doc('collection/b', 1002, { matches: true });
       const doc3 = doc('collection/c', 1003, { matches: true });
@@ -227,7 +227,7 @@ describeSpec('Limits:', [], () => {
       const fullQuery = Query.atPath(path('collection'));
       const limitQuery = Query.atPath(path('collection'))
         .addOrderBy(orderBy('pos'))
-        .withLimit(2);
+        .withLimitToFirst(2);
       const doc1 = doc('collection/a', 1001, { pos: 1 });
       const doc2 = doc('collection/b', 1002, { pos: 2 });
       const doc3 = doc('collection/c', 1003, { pos: 3 });
@@ -260,7 +260,7 @@ describeSpec('Limits:', [], () => {
       const fullQuery = Query.atPath(path('collection'));
       const limitQuery = Query.atPath(path('collection'))
         .addOrderBy(orderBy('pos'))
-        .withLimit(2);
+        .withLimitToFirst(2);
       const doc1 = doc('collection/a', 1001, { pos: 1 });
       const doc1Edited = doc('collection/a', 1005, { pos: 4 });
       const doc2 = doc('collection/b', 1002, { pos: 2 });
@@ -296,7 +296,7 @@ describeSpec('Limits:', [], () => {
 
       const limitQuery = Query.atPath(path('collection'))
         .addOrderBy(orderBy('a'))
-        .withLimit(1);
+        .withLimitToFirst(1);
       const fullQuery = Query.atPath(path('collection')).addOrderBy(
         orderBy('a')
       );
@@ -372,7 +372,7 @@ describeSpec('Limits:', [], () => {
 
     const limitQuery = Query.atPath(path('collection'))
       .addOrderBy(orderBy('a'))
-      .withLimit(1);
+      .withLimitToFirst(1);
     const fullQuery = Query.atPath(path('collection')).addOrderBy(orderBy('a'));
 
     const firstDocument = doc('collection/a', 2001, { a: 1 });
@@ -412,7 +412,7 @@ describeSpec('Limits:', [], () => {
   });
 
   specTest('Multiple docs in limbo in full limit query', [], () => {
-    const query1 = Query.atPath(path('collection')).withLimit(2);
+    const query1 = Query.atPath(path('collection')).withLimitToFirst(2);
     const query2 = Query.atPath(path('collection'));
     const docA = doc('collection/a', 1000, { key: 'a' });
     const docB = doc('collection/b', 1001, { key: 'b' });
@@ -504,7 +504,7 @@ describeSpec('Limits:', [], () => {
     'Limit query is refilled by primary client',
     ['multi-client'],
     () => {
-      const query1 = Query.atPath(path('collection')).withLimit(2);
+      const query1 = Query.atPath(path('collection')).withLimitToFirst(2);
       const doc1 = doc('collection/a', 1000, { key: 'a' });
       const doc2 = doc('collection/b', 1002, { key: 'b' });
       const doc3 = doc('collection/c', 1001, { key: 'c' });
@@ -535,7 +535,7 @@ describeSpec('Limits:', [], () => {
     'Limit query includes write from secondary client ',
     ['multi-client'],
     () => {
-      const query1 = Query.atPath(path('collection')).withLimit(2);
+      const query1 = Query.atPath(path('collection')).withLimitToFirst(2);
       const doc1 = doc('collection/a', 1003, { key: 'a' });
       const doc1Local = doc(
         'collection/a',

--- a/packages/firestore/test/unit/specs/listen_spec.test.ts
+++ b/packages/firestore/test/unit/specs/listen_spec.test.ts
@@ -15,9 +15,9 @@
  * limitations under the License.
  */
 
-import { Query, OrderBy, Direction } from '../../../src/core/query';
+import { Query } from '../../../src/core/query';
 import { Code } from '../../../src/util/error';
-import { deletedDoc, doc, filter, path, field } from '../../util/helpers';
+import { deletedDoc, doc, filter, path } from '../../util/helpers';
 
 import { TimerId } from '../../../src/util/async_queue';
 import { describeSpec, specTest } from './describe_spec';
@@ -883,30 +883,6 @@ describeSpec('Listens:', [], () => {
         .watchAcksFull(query, 1000)
         .client(1)
         .expectEvents(query, {});
-    }
-  );
-
-  specTest(
-    'Mirror queries from one secondary client',
-    ['multi-client', 'exclusive'],
-    () => {
-      const limit = Query.atPath(path('collection'))
-        .addOrderBy(new OrderBy(field('val'), Direction.ASCENDING))
-        .withLimitToFirst(2);
-      const docA = doc('collection/a', 1000, { val: 0 });
-      const docB = doc('collection/b', 1000, { val: 1 });
-      const docC = doc('collection/c', 1000, { val: 2 });
-
-      return client(0)
-        .becomeVisible()
-        .client(1)
-        .userListens(limit)
-        .client(0)
-        .expectListen(limit)
-        .watchAcks(limit)
-        .watchSends({ affects: [limit] }, docA, docB)
-        .client(1)
-        .expectEvents(limit, { added: [docA, docB] });
     }
   );
 

--- a/packages/firestore/test/unit/specs/listen_spec.test.ts
+++ b/packages/firestore/test/unit/specs/listen_spec.test.ts
@@ -120,7 +120,7 @@ describeSpec('Listens:', [], () => {
     [],
     () => {
       const query1 = Query.atPath(path('collection'));
-      const query2 = Query.atPath(path('collection')).withLimit(10);
+      const query2 = Query.atPath(path('collection')).withLimitToFirst(10);
       const docA = doc('collection/a', 1000, { a: true });
       const docB = doc('collection/b', 1000, { b: true });
 

--- a/packages/firestore/test/unit/specs/listen_spec.test.ts
+++ b/packages/firestore/test/unit/specs/listen_spec.test.ts
@@ -890,12 +890,12 @@ describeSpec('Listens:', [], () => {
     'Mirror queries from one secondary client',
     ['multi-client', 'exclusive'],
     () => {
-    const limit = Query.atPath(path('collection'))
-    .addOrderBy(new OrderBy(field('val'), Direction.ASCENDING))
-    .withLimitToFirst(2);
-    const docA = doc('collection/a', 1000, { val: 0 });
-    const docB = doc('collection/b', 1000, { val: 1 });
-    const docC = doc('collection/c', 1000, { val: 2 });
+      const limit = Query.atPath(path('collection'))
+        .addOrderBy(new OrderBy(field('val'), Direction.ASCENDING))
+        .withLimitToFirst(2);
+      const docA = doc('collection/a', 1000, { val: 0 });
+      const docB = doc('collection/b', 1000, { val: 1 });
+      const docC = doc('collection/c', 1000, { val: 2 });
 
       return client(0)
         .becomeVisible()
@@ -906,7 +906,7 @@ describeSpec('Listens:', [], () => {
         .watchAcks(limit)
         .watchSends({ affects: [limit] }, docA, docB)
         .client(1)
-        .expectEvents(limit, {added: [docA, docB] });
+        .expectEvents(limit, { added: [docA, docB] });
     }
   );
 

--- a/packages/firestore/test/unit/specs/listen_spec.test.ts
+++ b/packages/firestore/test/unit/specs/listen_spec.test.ts
@@ -15,9 +15,9 @@
  * limitations under the License.
  */
 
-import { Query } from '../../../src/core/query';
+import { Query, OrderBy, Direction } from '../../../src/core/query';
 import { Code } from '../../../src/util/error';
-import { deletedDoc, doc, filter, path } from '../../util/helpers';
+import { deletedDoc, doc, filter, path, field } from '../../util/helpers';
 
 import { TimerId } from '../../../src/util/async_queue';
 import { describeSpec, specTest } from './describe_spec';
@@ -883,6 +883,30 @@ describeSpec('Listens:', [], () => {
         .watchAcksFull(query, 1000)
         .client(1)
         .expectEvents(query, {});
+    }
+  );
+
+  specTest(
+    'Mirror queries from one secondary client',
+    ['multi-client', 'exclusive'],
+    () => {
+    const limit = Query.atPath(path('collection'))
+    .addOrderBy(new OrderBy(field('val'), Direction.ASCENDING))
+    .withLimitToFirst(2);
+    const docA = doc('collection/a', 1000, { val: 0 });
+    const docB = doc('collection/b', 1000, { val: 1 });
+    const docC = doc('collection/c', 1000, { val: 2 });
+
+      return client(0)
+        .becomeVisible()
+        .client(1)
+        .userListens(limit)
+        .client(0)
+        .expectListen(limit)
+        .watchAcks(limit)
+        .watchSends({ affects: [limit] }, docA, docB)
+        .client(1)
+        .expectEvents(limit, {added: [docA, docB] });
     }
   );
 

--- a/packages/firestore/test/unit/specs/spec_builder.ts
+++ b/packages/firestore/test/unit/specs/spec_builder.ts
@@ -876,7 +876,8 @@ export class SpecBuilder {
     if (query.collectionGroup !== null) {
       spec.collectionGroup = query.collectionGroup;
     }
-    if (query.hasLimit()) {
+    // TODO(limitToLast): Plumb through spec tests.
+    if (query.hasLimitToFirst()) {
       spec.limit = query.limit!;
     }
     if (query.filters) {

--- a/packages/firestore/test/unit/specs/spec_test_runner.ts
+++ b/packages/firestore/test/unit/specs/spec_test_runner.ts
@@ -1190,7 +1190,7 @@ abstract class TestRunner {
     } else {
       let query = new Query(path(querySpec.path), querySpec.collectionGroup);
       if (querySpec.limit) {
-        query = query.withLimit(querySpec.limit);
+        query = query.withLimitToFirst(querySpec.limit);
       }
       if (querySpec.filters) {
         querySpec.filters.forEach(([field, op, value]) => {


### PR DESCRIPTION
Spec tests are not in this PR, as I need to basically implement the target:query split and mapping in spec tests builder/runner. 

Figured it might be a good idea to have it reviewed without spec tests. Please let me know if you want them to be together.