### PR TITLE
Try API requests again if they failed in a different function call

### DIFF
--- a/packages/installations/src/functions/get-id.test.ts
+++ b/packages/installations/src/functions/get-id.test.ts
@@ -20,7 +20,10 @@ import { SinonStub, stub } from 'sinon';
 import * as getInstallationEntryModule from '../helpers/get-installation-entry';
 import * as refreshAuthTokenModule from '../helpers/refresh-auth-token';
 import { AppConfig } from '../interfaces/app-config';
-import { RequestStatus } from '../interfaces/installation-entry';
+import {
+  RequestStatus,
+  RegisteredInstallationEntry
+} from '../interfaces/installation-entry';
 import { getFakeApp } from '../testing/get-fake-app';
 import '../testing/setup';
 import { getId } from './get-id';
@@ -45,7 +48,8 @@ describe('getId', () => {
       installationEntry: {
         fid: FID,
         registrationStatus: RequestStatus.NOT_STARTED
-      }
+      },
+      registrationPromise: Promise.resolve({} as RegisteredInstallationEntry)
     });
 
     const firebaseApp = getFakeApp();
@@ -69,7 +73,12 @@ describe('getId', () => {
     const refreshAuthTokenSpy = stub(
       refreshAuthTokenModule,
       'refreshAuthToken'
-    ).resolves('authToken');
+    ).resolves({
+      token: 'authToken',
+      expiresIn: 123456,
+      requestStatus: RequestStatus.COMPLETED,
+      creationTime: Date.now()
+    });
 
     const firebaseApp = getFakeApp();
     await getId(firebaseApp);

--- a/packages/installations/src/functions/get-id.ts
+++ b/packages/installations/src/functions/get-id.ts
@@ -19,7 +19,6 @@ import { FirebaseApp } from '@firebase/app-types';
 import { extractAppConfig } from '../helpers/extract-app-config';
 import { getInstallationEntry } from '../helpers/get-installation-entry';
 import { refreshAuthToken } from '../helpers/refresh-auth-token';
-import { RequestStatus } from '../interfaces/installation-entry';
 
 export async function getId(app: FirebaseApp): Promise<string> {
   const appConfig = extractAppConfig(app);
@@ -28,14 +27,11 @@ export async function getId(app: FirebaseApp): Promise<string> {
   );
 
   if (registrationPromise) {
-    // Suppress registration errors as they are not a problem for getId.
-    registrationPromise.catch(() => {});
-  }
-
-  if (installationEntry.registrationStatus === RequestStatus.COMPLETED) {
+    registrationPromise.catch(console.error);
+  } else {
     // If the installation is already registered, update the authentication
-    // token if needed. Suppress errors as they are not relevant to getId.
-    refreshAuthToken(appConfig).catch(() => {});
+    // token if needed.
+    refreshAuthToken(appConfig).catch(console.error);
   }
 
   return installationEntry.fid;

--- a/packages/installations/src/functions/get-token.ts
+++ b/packages/installations/src/functions/get-token.ts
@@ -20,8 +20,6 @@ import { extractAppConfig } from '../helpers/extract-app-config';
 import { getInstallationEntry } from '../helpers/get-installation-entry';
 import { refreshAuthToken } from '../helpers/refresh-auth-token';
 import { AppConfig } from '../interfaces/app-config';
-import { RequestStatus } from '../interfaces/installation-entry';
-import { ERROR_FACTORY, ErrorCode } from '../util/errors';
 
 export async function getToken(
   app: FirebaseApp,
@@ -33,21 +31,17 @@ export async function getToken(
 
   // At this point we either have a Registered Installation in the DB, or we've
   // already thrown an error.
-  return refreshAuthToken(appConfig, forceRefresh);
+  const authToken = await refreshAuthToken(appConfig, forceRefresh);
+  return authToken.token;
 }
 
 async function completeInstallationRegistration(
   appConfig: AppConfig
 ): Promise<void> {
-  const { installationEntry, registrationPromise } = await getInstallationEntry(
-    appConfig
-  );
+  const { registrationPromise } = await getInstallationEntry(appConfig);
 
   if (registrationPromise) {
     // A createInstallation request is in progress. Wait until it finishes.
     await registrationPromise;
-  } else if (installationEntry.registrationStatus !== RequestStatus.COMPLETED) {
-    // Installation ID can't be registered.
-    throw ERROR_FACTORY.create(ErrorCode.CREATE_INSTALLATION_FAILED);
   }
 }

--- a/packages/installations/src/helpers/extract-app-config.ts
+++ b/packages/installations/src/helpers/extract-app-config.ts
@@ -15,21 +15,44 @@
  * limitations under the License.
  */
 
-import { FirebaseApp } from '@firebase/app-types';
+import { FirebaseApp, FirebaseOptions } from '@firebase/app-types';
 import { AppConfig } from '../interfaces/app-config';
 import { ERROR_FACTORY, ErrorCode } from '../util/errors';
+import { FirebaseError } from '@firebase/util';
 
 export function extractAppConfig(app: FirebaseApp): AppConfig {
   if (!app || !app.options) {
-    throw ERROR_FACTORY.create(ErrorCode.MISSING_APP_CONFIG_VALUES);
+    throw getMissingValueError('App Configuration');
   }
 
-  const appName = app.name;
-  const { projectId, apiKey, appId } = app.options;
-
-  if (!appName || !projectId || !apiKey || !appId) {
-    throw ERROR_FACTORY.create(ErrorCode.MISSING_APP_CONFIG_VALUES);
+  if (!app.name) {
+    throw getMissingValueError('App Name');
   }
 
-  return { appName, projectId, apiKey, appId };
+  // Required app config keys
+  const configKeys: Array<keyof FirebaseOptions> = [
+    'projectId',
+    'apiKey',
+    'appId'
+  ];
+
+  for (const keyName of configKeys) {
+    if (!app.options[keyName]) {
+      // Cast required becase FirebaseOptions includes "[name: string]: any;".
+      throw getMissingValueError(keyName as string);
+    }
+  }
+
+  return {
+    appName: app.name,
+    projectId: app.options.projectId!,
+    apiKey: app.options.apiKey!,
+    appId: app.options.appId!
+  };
+}
+
+function getMissingValueError(valueName: string): FirebaseError {
+  return ERROR_FACTORY.create(ErrorCode.MISSING_APP_CONFIG_VALUES, {
+    valueName
+  });
 }

--- a/packages/installations/src/helpers/refresh-auth-token.test.ts
+++ b/packages/installations/src/helpers/refresh-auth-token.test.ts
@@ -93,7 +93,7 @@ describe('refreshAuthToken', () => {
     });
 
     it('returns the token from the DB', async () => {
-      const token = await refreshAuthToken(appConfig);
+      const { token } = await refreshAuthToken(appConfig);
       expect(token).to.equal(AUTH_TOKEN);
     });
 
@@ -105,7 +105,7 @@ describe('refreshAuthToken', () => {
     it('works even if the app is offline', async () => {
       stub(navigator, 'onLine').value(false);
 
-      const token = await refreshAuthToken(appConfig);
+      const { token } = await refreshAuthToken(appConfig);
       expect(token).to.equal(AUTH_TOKEN);
     });
   });
@@ -134,14 +134,14 @@ describe('refreshAuthToken', () => {
 
     it('returns a different token after expiration', async () => {
       const token1 = await refreshAuthToken(appConfig);
-      expect(token1).to.equal(DB_AUTH_TOKEN);
+      expect(token1.token).to.equal(DB_AUTH_TOKEN);
 
       // Wait 30 minutes.
       clock.tick('30:00');
 
       const token2 = await refreshAuthToken(appConfig);
-      await expect(token2).to.equal(AUTH_TOKEN);
-      await expect(token2).not.to.equal(DB_AUTH_TOKEN);
+      await expect(token2.token).to.equal(AUTH_TOKEN);
+      await expect(token2.token).not.to.equal(DB_AUTH_TOKEN);
       expect(generateAuthTokenSpy).to.be.calledOnce;
     });
   });
@@ -177,7 +177,7 @@ describe('refreshAuthToken', () => {
     });
 
     it('returns a new token', async () => {
-      const token = await refreshAuthToken(appConfig);
+      const { token } = await refreshAuthToken(appConfig);
       await expect(token).to.equal(AUTH_TOKEN);
       await expect(token).not.to.equal(DB_AUTH_TOKEN);
       expect(generateAuthTokenSpy).to.be.calledOnce;
@@ -190,7 +190,7 @@ describe('refreshAuthToken', () => {
     });
 
     it('saves the new token in the DB', async () => {
-      const token = await refreshAuthToken(appConfig);
+      const { token } = await refreshAuthToken(appConfig);
 
       const installationEntry = (await get(
         appConfig

--- a/packages/installations/src/util/errors.ts
+++ b/packages/installations/src/util/errors.ts
@@ -20,8 +20,6 @@ import { SERVICE, SERVICE_NAME } from './constants';
 
 export const enum ErrorCode {
   MISSING_APP_CONFIG_VALUES = 'missing-app-config-values',
-  CREATE_INSTALLATION_FAILED = 'create-installation-failed',
-  GENERATE_TOKEN_FAILED = 'generate-token-failed',
   NOT_REGISTERED = 'not-registered',
   INSTALLATION_NOT_FOUND = 'installation-not-found',
   REQUEST_FAILED = 'request-failed',
@@ -30,10 +28,8 @@ export const enum ErrorCode {
 }
 
 const ERROR_DESCRIPTION_MAP: { readonly [key in ErrorCode]: string } = {
-  [ErrorCode.MISSING_APP_CONFIG_VALUES]: 'Missing App configuration values.',
-  [ErrorCode.CREATE_INSTALLATION_FAILED]:
-    'Could not register Firebase Installation.',
-  [ErrorCode.GENERATE_TOKEN_FAILED]: 'Could not generate Auth Token.',
+  [ErrorCode.MISSING_APP_CONFIG_VALUES]:
+    'Missing App configuration value: "{$valueName}"',
   [ErrorCode.NOT_REGISTERED]: 'Firebase Installation is not registered.',
   [ErrorCode.INSTALLATION_NOT_FOUND]: 'Firebase Installation not found.',
   [ErrorCode.REQUEST_FAILED]:
@@ -44,6 +40,9 @@ const ERROR_DESCRIPTION_MAP: { readonly [key in ErrorCode]: string } = {
 };
 
 interface ErrorParams {
+  [ErrorCode.MISSING_APP_CONFIG_VALUES]: {
+    valueName: string;
+  };
   [ErrorCode.REQUEST_FAILED]: {
     requestName: string;
   } & ServerErrorData;


### PR DESCRIPTION
There isn't any useful error information if a request that was started in a different function call fails. Instead of throwing a useless error, try it again in the current function call.

Also makes the "missing app config values" error a little more helpful.