### PR TITLE
Use string concatenation instead of array join for making RPC URLs

### DIFF
--- a/packages/firestore/src/platform_browser/webchannel_connection.ts
+++ b/packages/firestore/src/platform_browser/webchannel_connection.ts
@@ -415,6 +415,16 @@ export class WebChannelConnection implements Connection {
   makeUrl(rpcName: string): string {
     const urlRpcName = RPC_NAME_REST_MAPPING[rpcName];
     assert(urlRpcName !== undefined, 'Unknown REST mapping for: ' + rpcName);
-    return `${this.baseUrl}/${RPC_URL_VERSION}/projects/${this.databaseId.projectId}/databases/${this.databaseId.database}/documents:${urlRpcName}`;
+    return `${
+      this.baseUrl
+    }/${
+      RPC_URL_VERSION
+    }/projects/${
+      this.databaseId.projectId
+    }/databases/${
+      this.databaseId.database
+    }/documents:${
+      urlRpcName
+    }`;
   }
 }

--- a/packages/firestore/src/platform_browser/webchannel_connection.ts
+++ b/packages/firestore/src/platform_browser/webchannel_connection.ts
@@ -415,16 +415,6 @@ export class WebChannelConnection implements Connection {
   makeUrl(rpcName: string): string {
     const urlRpcName = RPC_NAME_REST_MAPPING[rpcName];
     assert(urlRpcName !== undefined, 'Unknown REST mapping for: ' + rpcName);
-    const url = [this.baseUrl, '/', RPC_URL_VERSION];
-    url.push('/projects/');
-    url.push(this.databaseId.projectId);
-
-    url.push('/databases/');
-    url.push(this.databaseId.database);
-    url.push('/documents');
-
-    url.push(':');
-    url.push(urlRpcName);
-    return url.join('');
+    return `${ this.baseUrl }/${ RPC_URL_VERSION }/projects/${ this.databaseId.projectId }/databases/${ this.databaseId.database }/documents:${ urlRpcName }`;
   }
 }

--- a/packages/firestore/src/platform_browser/webchannel_connection.ts
+++ b/packages/firestore/src/platform_browser/webchannel_connection.ts
@@ -415,6 +415,16 @@ export class WebChannelConnection implements Connection {
   makeUrl(rpcName: string): string {
     const urlRpcName = RPC_NAME_REST_MAPPING[rpcName];
     assert(urlRpcName !== undefined, 'Unknown REST mapping for: ' + rpcName);
-    return `${this.baseUrl}/${RPC_URL_VERSION}/projects/${this.databaseId.projectId}/databases/${this.databaseId.database}/documents:${urlRpcName}`;
+    return (
+      this.baseUrl +
+      '/' +
+      RPC_URL_VERSION +
+      '/projects/' +
+      this.databaseId.projectId +
+      '/databases/' +
+      this.databaseId.database +
+      '/documents:' +
+      urlRpcName
+    );
   }
 }

--- a/packages/firestore/src/platform_browser/webchannel_connection.ts
+++ b/packages/firestore/src/platform_browser/webchannel_connection.ts
@@ -415,16 +415,6 @@ export class WebChannelConnection implements Connection {
   makeUrl(rpcName: string): string {
     const urlRpcName = RPC_NAME_REST_MAPPING[rpcName];
     assert(urlRpcName !== undefined, 'Unknown REST mapping for: ' + rpcName);
-    return `${
-      this.baseUrl
-    }/${
-      RPC_URL_VERSION
-    }/projects/${
-      this.databaseId.projectId
-    }/databases/${
-      this.databaseId.database
-    }/documents:${
-      urlRpcName
-    }`;
+    return `${this.baseUrl}/${RPC_URL_VERSION}/projects/${this.databaseId.projectId}/databases/${this.databaseId.database}/documents:${urlRpcName}`;
   }
 }

--- a/packages/firestore/src/platform_browser/webchannel_connection.ts
+++ b/packages/firestore/src/platform_browser/webchannel_connection.ts
@@ -415,6 +415,6 @@ export class WebChannelConnection implements Connection {
   makeUrl(rpcName: string): string {
     const urlRpcName = RPC_NAME_REST_MAPPING[rpcName];
     assert(urlRpcName !== undefined, 'Unknown REST mapping for: ' + rpcName);
-    return `${ this.baseUrl }/${ RPC_URL_VERSION }/projects/${ this.databaseId.projectId }/databases/${ this.databaseId.database }/documents:${ urlRpcName }`;
+    return `${this.baseUrl}/${RPC_URL_VERSION}/projects/${this.databaseId.projectId}/databases/${this.databaseId.database}/documents:${urlRpcName}`;
   }
 }


### PR DESCRIPTION
From array to string template converted for better readability