### PR TITLE
Don't fail client if lease refresh fails

### DIFF
--- a/packages/firestore/CHANGELOG.md
+++ b/packages/firestore/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Unreleased
+- [changed] The client can now recover if certain periodic IndexedDB operations
+  fail.
+
+# 1.6.3
 - [changed] Improved iOS 13 support by eliminating an additional crash in our
   IndexedDB persistence layer.
 

--- a/packages/firestore/src/local/simple_db.ts
+++ b/packages/firestore/src/local/simple_db.ts
@@ -314,7 +314,7 @@ export class SimpleDb {
         // TODO(schmidt-sebastian): We could probably be smarter about this and
         // not retry exceptions that are likely unrecoverable (such as quota
         // exceeded errors).
-        
+
         // Note: We cannot use an instanceof check for FirestoreException, since the
         // exception is wrapped in a generic error by our async/await handling.
         const retryable =

--- a/packages/firestore/test/unit/local/indexeddb_persistence.test.ts
+++ b/packages/firestore/test/unit/local/indexeddb_persistence.test.ts
@@ -933,6 +933,28 @@ describe('IndexedDb: canActAsPrimary', () => {
     simpleDb.close();
   }
 
+  async function getCurrentLeaseOwner(): Promise<ClientId | null> {
+    const simpleDb = await SimpleDb.openOrCreate(
+      INDEXEDDB_TEST_DATABASE_NAME,
+      SCHEMA_VERSION,
+      new SchemaConverter(TEST_SERIALIZER)
+    );
+    const leaseOwner = await simpleDb.runTransaction(
+      'readwrite-idempotent',
+      [DbPrimaryClient.store],
+      txn => {
+        const primaryStore = txn.store<DbPrimaryClientKey, DbPrimaryClient>(
+          DbPrimaryClient.store
+        );
+        return primaryStore
+          .get(DbPrimaryClient.key)
+          .next(owner => (owner ? owner.ownerId : null));
+      }
+    );
+    simpleDb.close();
+    return leaseOwner;
+  }
+
   beforeEach(() => {
     return SimpleDb.delete(INDEXEDDB_TEST_DATABASE_NAME);
   });
@@ -1033,6 +1055,23 @@ describe('IndexedDb: canActAsPrimary', () => {
         isPrimary = primaryState;
       });
       expect(isPrimary).to.be.true;
+    });
+  });
+
+  it('regains lease if available', () => {
+    return withPersistence('clientA', async persistence => {
+      expect(await getCurrentLeaseOwner()).to.not.be.null;
+
+      await clearPrimaryLease();
+      expect(await getCurrentLeaseOwner()).to.be.null;
+
+      await persistence.runTransaction(
+        'regain lease',
+        'readwrite-primary',
+        () => PersistencePromise.resolve()
+      );
+
+      expect(await getCurrentLeaseOwner()).to.not.be.null;
     });
   });
 });

--- a/packages/firestore/test/unit/local/indexeddb_persistence.test.ts
+++ b/packages/firestore/test/unit/local/indexeddb_persistence.test.ts
@@ -1067,7 +1067,7 @@ describe('IndexedDb: canActAsPrimary', () => {
 
       await persistence.runTransaction(
         'regain lease',
-        'readwrite-primary',
+        'readwrite-primary-idempotent',
         () => PersistencePromise.resolve()
       );
 

--- a/packages/firestore/test/unit/local/indexeddb_persistence.test.ts
+++ b/packages/firestore/test/unit/local/indexeddb_persistence.test.ts
@@ -940,7 +940,7 @@ describe('IndexedDb: canActAsPrimary', () => {
       new SchemaConverter(TEST_SERIALIZER)
     );
     const leaseOwner = await simpleDb.runTransaction(
-      'readwrite-idempotent',
+      'readonly-idempotent',
       [DbPrimaryClient.store],
       txn => {
         const primaryStore = txn.store<DbPrimaryClientKey, DbPrimaryClient>(


### PR DESCRIPTION
This PR:
- Makes the lease refresh idempotent by moving the `primaryStateListener` callback outside of the transaction function. Note that it call still get called with `primaryStateListener(false)`, as calling that repeatedly should not have any side effects.
- Changes transactions to obtain the IndexedDB lease even if they don't already have it.

Addresses https://github.com/firebase/firebase-js-sdk/issues/2232