### PR TITLE
Avoid auth trigger if we haven't yet received the initial user

### DIFF
--- a/packages/firestore/src/api/credentials.ts
+++ b/packages/firestore/src/api/credentials.ts
@@ -230,8 +230,9 @@ export class FirebaseCredentialsProvider implements CredentialsProvider {
     this.changeListener = null;
   }
 
-  // Auth.getUid() can return null even with a user logged in. It is because getUid() is synchronous, but
-  // the actual code populating Uid is asynchronous. This method should only be called in the AuthTokenListener callback
+  // Auth.getUid() can return null even with a user logged in. It is because 
+  // getUid() is synchronous, but the auth code populating Uid is asynchronous. 
+  // This method should only be called in the AuthTokenListener callback
   // to guarantee to get the actual user.
   private getUser(): User {
     const currentUid = (this.app as _FirebaseApp).INTERNAL.getUid();

--- a/packages/firestore/src/api/credentials.ts
+++ b/packages/firestore/src/api/credentials.ts
@@ -230,7 +230,7 @@ export class FirebaseCredentialsProvider implements CredentialsProvider {
     this.changeListener = null;
   }
 
-  // Auth.getUid() can return null even with a user logged in. It is because getUid() is synchronouse, but
+  // Auth.getUid() can return null even with a user logged in. It is because getUid() is synchronous, but
   // the actual code populating Uid is asynchronous. This method should only be called in the AuthTokenListener callback
   // to guarantee to get the actual user.
   private getUser(): User {

--- a/packages/firestore/src/api/credentials.ts
+++ b/packages/firestore/src/api/credentials.ts
@@ -230,8 +230,8 @@ export class FirebaseCredentialsProvider implements CredentialsProvider {
     this.changeListener = null;
   }
 
-  // Auth.getUid() can return null even with a user logged in. It is because 
-  // getUid() is synchronous, but the auth code populating Uid is asynchronous. 
+  // Auth.getUid() can return null even with a user logged in. It is because
+  // getUid() is synchronous, but the auth code populating Uid is asynchronous.
   // This method should only be called in the AuthTokenListener callback
   // to guarantee to get the actual user.
   private getUser(): User {


### PR DESCRIPTION
`this.currentUser = this.getUser();` in the constructor can return a null user even if a user is logged in. It is because the actual auth code that populates uid is asynchronous.

It is a problem because it causes an expensive and unnecessary user switching - we will initially call `this.changeListener` with a null user, then later call it with the actual user when `this.tokenListener` gets called.


https://github.com/firebase/firebase-js-sdk/pull/2137 tried to fix this issue. Its [initial fix](https://github.com/firebase/firebase-js-sdk/pull/2137/commits/bb3723a2c7edf4d895ad56aa021e756232e34407) is correct, but its final version is not. This PR is a copy of 2137's initial fix.
