### PR TITLE
Release Query.limitToLast(n)

### DIFF
--- a/packages/firebase/index.d.ts
+++ b/packages/firebase/index.d.ts
@@ -8118,13 +8118,25 @@ declare namespace firebase.firestore {
     ): Query;
 
     /**
-     * Creates and returns a new Query where the results are limited to the
-     * specified number of documents.
+     * Creates and returns a new Query that only returns the first matching
+     * documents.
      *
      * @param limit The maximum number of items to return.
      * @return The created Query.
      */
     limit(limit: number): Query;
+
+    /**
+     * Creates and returns a new Query that only returns the last matching
+     * documents.
+     *
+     * You must specify at least one `orderBy` clause for `limitToLast` queries,
+     * otherwise an exception will be thrown thrown during execution.
+     *
+     * @param limit The maximum number of items to return.
+     * @return The created Query.
+     */
+    limitToLast(limit: number): Query;
 
     /**
      * Creates and returns a new Query that starts at the provided document

--- a/packages/firebase/index.d.ts
+++ b/packages/firebase/index.d.ts
@@ -8131,7 +8131,7 @@ declare namespace firebase.firestore {
      * documents.
      *
      * You must specify at least one `orderBy` clause for `limitToLast` queries,
-     * otherwise an exception will be thrown thrown during execution.
+     * otherwise an exception will be thrown during execution.
      *
      * @param limit The maximum number of items to return.
      * @return The created Query.

--- a/packages/firestore-types/index.d.ts
+++ b/packages/firestore-types/index.d.ts
@@ -1102,7 +1102,7 @@ export class Query {
    * documents.
    *
    * Queries with `limitToLast` must have at least one `orderBy` clause on
-   * one of the document fields, or an Exception will throw during execution.
+   * one of the document fields, or an Exception will be thrown during execution.
    *
    * @param limit The maximum number of items to return.
    * @return The created Query.

--- a/packages/firestore-types/index.d.ts
+++ b/packages/firestore-types/index.d.ts
@@ -1089,13 +1089,25 @@ export class Query {
   ): Query;
 
   /**
-   * Creates and returns a new Query that's additionally limited to only
-   * return up to the specified number of documents.
+   * Creates and returns a new Query that only returns the first matching
+   * documents.
    *
    * @param limit The maximum number of items to return.
    * @return The created Query.
    */
   limit(limit: number): Query;
+
+  /**
+   * Creates and returns a new Query that only returns the last matching
+   * documents.
+   *
+   * Queries with `limitToLast` must have at least one `orderBy` clause on
+   * one of the document fields, or an Exception will throw during execution.
+   *
+   * @param limit The maximum number of items to return.
+   * @return The created Query.
+   */
+  limitToLast(limit: number): Query;
 
   /**
    * Creates and returns a new Query that starts at the provided document

--- a/packages/firestore/CHANGELOG.md
+++ b/packages/firestore/CHANGELOG.md
@@ -5,8 +5,8 @@
   `.where()`. `in` finds documents where a specified field’s value is IN a
   specified array. `array-contains-any` finds documents where a specified field
   is an array and contains ANY element of a specified array.
-- [feature] Added `limitToLast(n: number)` to Firestore query, which returns 
-  the last `n` documents as the result.
+- [feature] Added `Query.limitToLast(n: number)` , which returns the last 
+  `n` documents as the result.
 
 # 1.6.3
 - [changed] Improved iOS 13 support by eliminating an additional crash in our

--- a/packages/firestore/CHANGELOG.md
+++ b/packages/firestore/CHANGELOG.md
@@ -5,6 +5,8 @@
   `.where()`. `in` finds documents where a specified field’s value is IN a
   specified array. `array-contains-any` finds documents where a specified field
   is an array and contains ANY element of a specified array.
+- [feature] Added `limitToLast(n: number)` to Firestore query, which returns 
+  the last `n` documents as the result.
 
 # 1.6.3
 - [changed] Improved iOS 13 support by eliminating an additional crash in our

--- a/packages/firestore/src/core/query.ts
+++ b/packages/firestore/src/core/query.ts
@@ -48,7 +48,7 @@ export class Query {
   private memoizedOrderBy: OrderBy[] | null = null;
 
   // The corresponding `Target` of this `Query` instance.
-  private target: Target | null = null;
+  private memorizedTarget: Target | null = null;
 
   /**
    * Initializes a Query with a path and optional additional query constraints.
@@ -343,9 +343,9 @@ export class Query {
    * representation.
    */
   toTarget(): Target {
-    if (!this.target) {
+    if (!this.memorizedTarget) {
       if (this.limitType === LimitType.First) {
-        this.target = new Target(
+        this.memorizedTarget = new Target(
           this.path,
           this.collectionGroup,
           this.orderBy,
@@ -374,7 +374,7 @@ export class Query {
           : null;
 
         // Now return as a LimitType.First query.
-        this.target = new Target(
+        this.memorizedTarget = new Target(
           this.path,
           this.collectionGroup,
           orderBys,
@@ -385,7 +385,7 @@ export class Query {
         );
       }
     }
-    return this.target!;
+    return this.memorizedTarget!;
   }
 
   private matchesPathAndCollectionGroup(doc: Document): boolean {

--- a/packages/firestore/src/core/query.ts
+++ b/packages/firestore/src/core/query.ts
@@ -30,6 +30,11 @@ import { Code, FirestoreError } from '../util/error';
 import { isNullOrUndefined } from '../util/types';
 import { Target } from './target';
 
+export enum LimitType {
+  First = 'F',
+  Last = 'L'
+}
+
 /**
  * Query encapsulates all the query attributes we support in the SDK. It can
  * be run against the LocalStore, as well as be converted to a `Target` to
@@ -55,6 +60,7 @@ export class Query {
     readonly explicitOrderBy: OrderBy[] = [],
     readonly filters: Filter[] = [],
     readonly limit: number | null = null,
+    readonly limitType: LimitType = LimitType.First,
     readonly startAt: Bound | null = null,
     readonly endAt: Bound | null = null
   ) {
@@ -133,6 +139,7 @@ export class Query {
       this.explicitOrderBy.slice(),
       newFilters,
       this.limit,
+      this.limitType,
       this.startAt,
       this.endAt
     );
@@ -148,18 +155,33 @@ export class Query {
       newOrderBy,
       this.filters.slice(),
       this.limit,
+      this.limitType,
       this.startAt,
       this.endAt
     );
   }
 
-  withLimit(limit: number | null): Query {
+  withLimitToFirst(limit: number | null): Query {
     return new Query(
       this.path,
       this.collectionGroup,
       this.explicitOrderBy.slice(),
       this.filters.slice(),
       limit,
+      LimitType.First,
+      this.startAt,
+      this.endAt
+    );
+  }
+
+  withLimitToLast(limit: number | null): Query {
+    return new Query(
+      this.path,
+      this.collectionGroup,
+      this.explicitOrderBy.slice(),
+      this.filters.slice(),
+      limit,
+      LimitType.Last,
       this.startAt,
       this.endAt
     );
@@ -172,6 +194,7 @@ export class Query {
       this.explicitOrderBy.slice(),
       this.filters.slice(),
       this.limit,
+      this.limitType,
       bound,
       this.endAt
     );
@@ -184,6 +207,7 @@ export class Query {
       this.explicitOrderBy.slice(),
       this.filters.slice(),
       this.limit,
+      this.limitType,
       this.startAt,
       bound
     );
@@ -202,6 +226,7 @@ export class Query {
       this.explicitOrderBy.slice(),
       this.filters.slice(),
       this.limit,
+      this.limitType,
       this.startAt,
       this.endAt
     );
@@ -227,15 +252,20 @@ export class Query {
   // example, use as a dictionary key, but the implementation is subject to
   // collisions. Make it collision-free.
   canonicalId(): string {
-    return this.toTarget().canonicalId();
+    return `${this.toTarget().canonicalId()}|lt:${this.limitType}`;
   }
 
   toString(): string {
-    return `Query(target=${this.toTarget().toString()})`;
+    return `Query(target=${this.toTarget().toString()}; limitType=${
+      this.limitType
+    })`;
   }
 
   isEqual(other: Query): boolean {
-    return this.toTarget().isEqual(other.toTarget());
+    return (
+      this.toTarget().isEqual(other.toTarget()) &&
+      this.limitType === other.limitType
+    );
   }
 
   docComparator(d1: Document, d2: Document): number {
@@ -264,8 +294,12 @@ export class Query {
     );
   }
 
-  hasLimit(): boolean {
-    return !isNullOrUndefined(this.limit);
+  hasLimitToFirst(): boolean {
+    return !isNullOrUndefined(this.limit) && this.limitType === LimitType.First;
+  }
+
+  hasLimitToLast(): boolean {
+    return !isNullOrUndefined(this.limit) && this.limitType === LimitType.Last;
   }
 
   getFirstOrderByField(): FieldPath | null {
@@ -304,17 +338,52 @@ export class Query {
     return this.collectionGroup !== null;
   }
 
+  /**
+   * Converts this `Query` instance to it's corresponding `Target`
+   * representation.
+   */
   toTarget(): Target {
     if (!this.target) {
-      this.target = new Target(
-        this.path,
-        this.collectionGroup,
-        this.orderBy,
-        this.filters,
-        this.limit,
-        this.startAt,
-        this.endAt
-      );
+      if (this.limitType === LimitType.First) {
+        this.target = new Target(
+          this.path,
+          this.collectionGroup,
+          this.orderBy,
+          this.filters,
+          this.limit,
+          this.startAt,
+          this.endAt
+        );
+      } else {
+        // Flip the orderBy directions since we want the last results
+        const orderBys = [] as OrderBy[];
+        for (const orderBy of this.orderBy) {
+          const dir =
+            orderBy.dir === Direction.DESCENDING
+              ? Direction.ASCENDING
+              : Direction.DESCENDING;
+          orderBys.push(new OrderBy(orderBy.field, dir));
+        }
+
+        // We need to swap the cursors to match the now-flipped query ordering.
+        const startAt = this.endAt
+          ? new Bound(this.endAt.position, !this.endAt.before)
+          : null;
+        const endAt = this.startAt
+          ? new Bound(this.startAt.position, !this.startAt.before)
+          : null;
+
+        // Now return as a LimitType.First query.
+        this.target = new Target(
+          this.path,
+          this.collectionGroup,
+          orderBys,
+          this.filters,
+          this.limit,
+          startAt,
+          endAt
+        );
+      }
     }
     return this.target!;
   }

--- a/packages/firestore/src/core/sync_engine.ts
+++ b/packages/firestore/src/core/sync_engine.ts
@@ -307,8 +307,8 @@ export class SyncEngine implements RemoteSyncer, SharedClientStateSyncer {
     const queryView = this.queryViewsByQuery.get(query)!;
     assert(!!queryView, 'Trying to unlisten on query not found:' + query);
 
-    // If it's not the only query mapped to the target, only clean up
-    // query view and keep the target active.
+    // Only clean up the query view and target if this is the only query mapped
+    // to the target.
     const queries = this.queriesByTarget[queryView.targetId];
     if (queries.length > 1) {
       this.queriesByTarget[queryView.targetId] = queries.filter(
@@ -1015,8 +1015,8 @@ export class SyncEngine implements RemoteSyncer, SharedClientStateSyncer {
    *
    * The synthesized result might be different from the original `Query`, but
    * since the synthesized `Query` should return the same results as the
-   * original one (only the presentation of results might differ), and this is
-   * only used for multi-tab, the potential difference will not cause issues.
+   * original one (only the presentation of results might differ), the potential
+   * difference will not cause issues.
    */
   // PORTING NOTE: Multi-tab only
   private synthesizeTargetToQuery(target: Target): Query {

--- a/packages/firestore/src/core/sync_engine.ts
+++ b/packages/firestore/src/core/sync_engine.ts
@@ -147,7 +147,7 @@ export class SyncEngine implements RemoteSyncer, SharedClientStateSyncer {
   private queryViewsByQuery = new ObjectMap<Query, QueryView>(q =>
     q.canonicalId()
   );
-  private queryViewsByTarget: { [targetId: number]: QueryView } = {};
+  private queriesByTarget: { [targetId: number]: Query[] } = {};
   private limboTargetsByKey = new SortedMap<DocumentKey, TargetId>(
     DocumentKey.comparator
   );
@@ -223,7 +223,7 @@ export class SyncEngine implements RemoteSyncer, SharedClientStateSyncer {
       targetId = queryData.targetId;
       viewSnapshot = await this.initializeViewAndComputeSnapshot(
         query,
-        queryData.targetId,
+        targetId,
         status === 'current'
       );
       if (this.isPrimary) {
@@ -270,7 +270,10 @@ export class SyncEngine implements RemoteSyncer, SharedClientStateSyncer {
 
     const data = new QueryView(query, targetId, view);
     this.queryViewsByQuery.set(query, data);
-    this.queryViewsByTarget[targetId] = data;
+    if (!this.queriesByTarget[targetId]) {
+      this.queriesByTarget[targetId] = [];
+    }
+    this.queriesByTarget[targetId].push(query);
     return viewChange.snapshot!;
   }
 
@@ -302,6 +305,8 @@ export class SyncEngine implements RemoteSyncer, SharedClientStateSyncer {
     const queryView = this.queryViewsByQuery.get(query)!;
     assert(!!queryView, 'Trying to unlisten on query not found:' + query);
 
+    // TODO(wuandy): Note this does not handle the case where multiple queries
+    // map to one target, and user request to unlisten on of the queries.
     if (this.isPrimary) {
       // We need to remove the local query target first to allow us to verify
       // whether any other client is still interested in this target.
@@ -312,18 +317,18 @@ export class SyncEngine implements RemoteSyncer, SharedClientStateSyncer {
 
       if (!targetRemainsActive) {
         await this.localStore
-          .releaseQuery(query, /*keepPersistedQueryData=*/ false)
+          .releaseTarget(queryView.targetId, /*keepPersistedQueryData=*/ false)
           .then(() => {
             this.sharedClientState.clearQueryState(queryView.targetId);
             this.remoteStore.unlisten(queryView.targetId);
-            this.removeAndCleanupQuery(queryView);
+            this.removeAndCleanupTarget(queryView.targetId);
           })
           .catch(ignoreIfPrimaryLeaseLoss);
       }
     } else {
-      this.removeAndCleanupQuery(queryView);
-      await this.localStore.releaseQuery(
-        query,
+      this.removeAndCleanupTarget(queryView.targetId);
+      await this.localStore.releaseTarget(
+        queryView.targetId,
         /*keepPersistedQueryData=*/ true
       );
     }
@@ -495,13 +500,10 @@ export class SyncEngine implements RemoteSyncer, SharedClientStateSyncer {
       );
       return this.applyRemoteEvent(event);
     } else {
-      const queryView = this.queryViewsByTarget[targetId];
-      assert(!!queryView, 'Unknown targetId: ' + targetId);
       await this.localStore
-        .releaseQuery(queryView.query, /* keepPersistedQueryData */ false)
-        .then(() => this.removeAndCleanupQuery(queryView))
+        .releaseTarget(targetId, /* keepPersistedQueryData */ false)
+        .then(() => this.removeAndCleanupTarget(targetId, err))
         .catch(ignoreIfPrimaryLeaseLoss);
-      this.syncEngineListener!.onWatchError(queryView.query, err);
     }
   }
 
@@ -681,17 +683,30 @@ export class SyncEngine implements RemoteSyncer, SharedClientStateSyncer {
     }
   }
 
-  private removeAndCleanupQuery(queryView: QueryView): void {
-    this.sharedClientState.removeLocalQueryTarget(queryView.targetId);
+  private removeAndCleanupTarget(
+    targetId: number,
+    error: Error | null = null
+  ): void {
+    this.sharedClientState.removeLocalQueryTarget(targetId);
 
-    this.queryViewsByQuery.delete(queryView.query);
-    delete this.queryViewsByTarget[queryView.targetId];
+    assert(
+      this.queriesByTarget[targetId] &&
+        this.queriesByTarget[targetId].length !== 0,
+      `There are no queries mapped to target id ${targetId}`
+    );
+
+    for (const query of this.queriesByTarget[targetId]) {
+      this.queryViewsByQuery.delete(query);
+      if (error) {
+        this.syncEngineListener!.onWatchError(query, error);
+      }
+    }
+
+    delete this.queriesByTarget[targetId];
 
     if (this.isPrimary) {
-      const limboKeys = this.limboDocumentRefs.referencesForId(
-        queryView.targetId
-      );
-      this.limboDocumentRefs.removeReferencesForId(queryView.targetId);
+      const limboKeys = this.limboDocumentRefs.referencesForId(targetId);
+      this.limboDocumentRefs.removeReferencesForId(targetId);
       limboKeys.forEach(limboKey => {
         const isReferenced = this.limboDocumentRefs.containsKey(limboKey);
         if (!isReferenced) {
@@ -710,6 +725,7 @@ export class SyncEngine implements RemoteSyncer, SharedClientStateSyncer {
       // This target already got removed, because the query failed.
       return;
     }
+
     this.remoteStore.unlisten(limboTargetId);
     this.limboTargetsByKey = this.limboTargetsByKey.remove(key);
     delete this.limboResolutionsByTarget[limboTargetId];
@@ -885,13 +901,19 @@ export class SyncEngine implements RemoteSyncer, SharedClientStateSyncer {
       const activeTargets: TargetId[] = [];
 
       let p = Promise.resolve();
-      objUtils.forEachNumber(this.queryViewsByTarget, (targetId, queryView) => {
+      objUtils.forEachNumber(this.queriesByTarget, (targetId, _) => {
         if (this.sharedClientState.isLocalQueryTarget(targetId)) {
           activeTargets.push(targetId);
         } else {
-          p = p.then(() => this.unlisten(queryView.query));
+          p = p.then(() => {
+            this.removeAndCleanupTarget(targetId);
+            return this.localStore.releaseTarget(
+              targetId,
+              /*keepPersistedQueryData=*/ true
+            );
+          });
         }
-        this.remoteStore.unlisten(queryView.targetId);
+        this.remoteStore.unlisten(targetId);
       });
       await p;
 
@@ -926,27 +948,34 @@ export class SyncEngine implements RemoteSyncer, SharedClientStateSyncer {
     const newViewSnapshots: ViewSnapshot[] = [];
     for (const targetId of targets) {
       let queryData: QueryData;
-      const queryView = this.queryViewsByTarget[targetId];
-      if (queryView) {
+      const queries = this.queriesByTarget[targetId];
+
+      if (queries && queries.length !== 0) {
         // For queries that have a local View, we need to update their state
         // in LocalStore (as the resume token and the snapshot version
         // might have changed) and reconcile their views with the persisted
         // state (the list of syncedDocuments may have gotten out of sync).
-        await this.localStore.releaseQuery(
-          queryView.query,
+        await this.localStore.releaseTarget(
+          targetId,
           /*keepPersistedQueryData=*/ true
         );
-        queryData = await this.localStore.allocateQuery(queryView.query);
-        const viewChange = await this.synchronizeViewAndComputeSnapshot(
-          queryView
-        );
-        if (viewChange.snapshot) {
-          newViewSnapshots.push(viewChange.snapshot);
+        queryData = await this.localStore.allocateTarget(queries[0].toTarget());
+
+        for (const query of queries) {
+          const queryView = this.queryViewsByQuery.get(query);
+          assert(!!queryView, `No query view found for ${query}`);
+
+          const viewChange = await this.synchronizeViewAndComputeSnapshot(
+            queryView!
+          );
+          if (viewChange.snapshot) {
+            newViewSnapshots.push(viewChange.snapshot);
+          }
         }
       } else {
         assert(
           this.isPrimary === true,
-          'A secondary tab should never have an active query without an active view.'
+          'A secondary tab should never have an active target without an active query.'
         );
         // For queries that never executed on this client, we need to
         // allocate the target in LocalStore and initialize a new View.
@@ -959,8 +988,10 @@ export class SyncEngine implements RemoteSyncer, SharedClientStateSyncer {
           /*current=*/ false
         );
       }
-      activeQueries.push(queryData);
+
+      activeQueries.push(queryData!);
     }
+
     this.syncEngineListener!.onWatchChange(newViewSnapshots);
     return activeQueries;
   }
@@ -983,7 +1014,7 @@ export class SyncEngine implements RemoteSyncer, SharedClientStateSyncer {
       return;
     }
 
-    if (this.queryViewsByTarget[targetId]) {
+    if (this.queriesByTarget[targetId]) {
       switch (state) {
         case 'current':
         case 'not-current': {
@@ -999,13 +1030,11 @@ export class SyncEngine implements RemoteSyncer, SharedClientStateSyncer {
           break;
         }
         case 'rejected': {
-          const queryView = this.queryViewsByTarget[targetId];
-          this.removeAndCleanupQuery(queryView);
-          await this.localStore.releaseQuery(
-            queryView.query,
-            /*keepPersistedQueryData=*/ true
+          await this.localStore.releaseTarget(
+            targetId,
+            /* keepPersistedQueryData */ true
           );
-          this.syncEngineListener!.onWatchError(queryView.query, error!);
+          this.removeAndCleanupTarget(targetId, error);
           break;
         }
         default:
@@ -1025,7 +1054,7 @@ export class SyncEngine implements RemoteSyncer, SharedClientStateSyncer {
 
     for (const targetId of added) {
       assert(
-        !this.queryViewsByTarget[targetId],
+        !this.queriesByTarget[targetId],
         'Trying to add an already active target'
       );
       const target = await this.localStore.getTarget(targetId);
@@ -1040,18 +1069,20 @@ export class SyncEngine implements RemoteSyncer, SharedClientStateSyncer {
     }
 
     for (const targetId of removed) {
-      const queryView = this.queryViewsByTarget[targetId];
-      // Check that the query is still active since the query might have been
+      // Check that the target is still active since the target might have been
       // removed if it has been rejected by the backend.
-      if (queryView) {
-        await this.localStore
-          .releaseQuery(queryView.query, /*keepPersistedQueryData=*/ false)
-          .then(() => {
-            this.remoteStore.unlisten(targetId);
-            this.removeAndCleanupQuery(queryView);
-          })
-          .catch(ignoreIfPrimaryLeaseLoss);
+      if (!this.queriesByTarget[targetId]) {
+        continue;
       }
+
+      // Release queries that are still active.
+      await this.localStore
+        .releaseTarget(targetId, /* keepPersistedQueryData */ false)
+        .then(() => {
+          this.remoteStore.unlisten(targetId);
+          this.removeAndCleanupTarget(targetId);
+        })
+        .catch(ignoreIfPrimaryLeaseLoss);
     }
   }
 
@@ -1074,9 +1105,17 @@ export class SyncEngine implements RemoteSyncer, SharedClientStateSyncer {
     if (limboResolution && limboResolution.receivedDocument) {
       return documentKeySet().add(limboResolution.key);
     } else {
-      return this.queryViewsByTarget[targetId]
-        ? this.queryViewsByTarget[targetId].view.syncedDocuments
-        : documentKeySet();
+      let keySet = documentKeySet();
+      const queries = this.queriesByTarget[targetId];
+      if (!queries) {
+        return keySet;
+      }
+      for (const query of queries) {
+        const queryView = this.queryViewsByQuery.get(query);
+        assert(!!queryView, `No query view found for ${query}`);
+        keySet = keySet.unionWith(queryView!.view.syncedDocuments);
+      }
+      return keySet;
     }
   }
 }

--- a/packages/firestore/src/core/sync_engine.ts
+++ b/packages/firestore/src/core/sync_engine.ts
@@ -49,8 +49,9 @@ import {
 import * as objUtils from '../util/obj';
 import { SortedSet } from '../util/sorted_set';
 import { ListenSequence } from './listen_sequence';
-import { Query } from './query';
+import { Query, LimitType } from './query';
 import { SnapshotVersion } from './snapshot_version';
+import { Target } from './target';
 import { TargetIdGenerator } from './target_id_generator';
 import { Transaction } from './transaction';
 import {
@@ -216,7 +217,8 @@ export class SyncEngine implements RemoteSyncer, SharedClientStateSyncer {
       this.sharedClientState.addLocalQueryTarget(targetId);
       viewSnapshot = queryView.view.computeInitialSnapshot();
     } else {
-      const queryData = await this.localStore.allocateQuery(query);
+      const queryData = await this.localStore.allocateTarget(query.toTarget());
+
       const status = this.sharedClientState.addLocalQueryTarget(
         queryData.targetId
       );
@@ -305,8 +307,18 @@ export class SyncEngine implements RemoteSyncer, SharedClientStateSyncer {
     const queryView = this.queryViewsByQuery.get(query)!;
     assert(!!queryView, 'Trying to unlisten on query not found:' + query);
 
-    // TODO(wuandy): Note this does not handle the case where multiple queries
-    // map to one target, and user request to unlisten on of the queries.
+    // If it's not the only query mapped to the target, only clean up
+    // query view and keep the target active.
+    const queries = this.queriesByTarget[queryView.targetId];
+    if (queries.length > 1) {
+      this.queriesByTarget[queryView.targetId] = queries.filter(
+        q => !q.isEqual(query)
+      );
+      this.queryViewsByQuery.delete(query);
+      return;
+    }
+
+    // No other queries are mapped to the target, clean up the query and the target.
     if (this.isPrimary) {
       // We need to remove the local query target first to allow us to verify
       // whether any other client is still interested in this target.
@@ -983,7 +995,7 @@ export class SyncEngine implements RemoteSyncer, SharedClientStateSyncer {
         assert(!!target, `Target for id ${targetId} not found`);
         queryData = await this.localStore.allocateTarget(target!);
         await this.initializeViewAndComputeSnapshot(
-          target!.toTargetQuery(),
+          this.synthesizeTargetToQuery(target!),
           targetId,
           /*current=*/ false
         );
@@ -994,6 +1006,30 @@ export class SyncEngine implements RemoteSyncer, SharedClientStateSyncer {
 
     this.syncEngineListener!.onWatchChange(newViewSnapshots);
     return activeQueries;
+  }
+
+  /**
+   * Creates a `Query` object from the specified `Target`. There is no way to
+   * obtain the original `Query`, so we synthesize a `Query` from the `Target`
+   * object.
+   *
+   * The synthesized result might be different from the original `Query`, but
+   * since the synthesized `Query` should return the same results as the
+   * original one (only the presentation of results might differ), and this is
+   * only used for multi-tab, the potential difference will not cause issues.
+   */
+  // PORTING NOTE: Multi-tab only
+  private synthesizeTargetToQuery(target: Target): Query {
+    return new Query(
+      target.path,
+      target.collectionGroup,
+      target.orderBy,
+      target.filters,
+      target.limit,
+      LimitType.First,
+      target.startAt,
+      target.endAt
+    );
   }
 
   // PORTING NOTE: Multi-tab only
@@ -1061,7 +1097,7 @@ export class SyncEngine implements RemoteSyncer, SharedClientStateSyncer {
       assert(!!target, `Query data for active target ${targetId} not found`);
       const queryData = await this.localStore.allocateTarget(target!);
       await this.initializeViewAndComputeSnapshot(
-        target!.toTargetQuery(),
+        this.synthesizeTargetToQuery(target!),
         queryData.targetId,
         /*current=*/ false
       );

--- a/packages/firestore/src/core/sync_engine.ts
+++ b/packages/firestore/src/core/sync_engine.ts
@@ -222,7 +222,8 @@ export class SyncEngine implements RemoteSyncer, SharedClientStateSyncer {
       );
       targetId = queryData.targetId;
       viewSnapshot = await this.initializeViewAndComputeSnapshot(
-        queryData,
+        query,
+        queryData.targetId,
         status === 'current'
       );
       if (this.isPrimary) {
@@ -239,10 +240,10 @@ export class SyncEngine implements RemoteSyncer, SharedClientStateSyncer {
    * snapshot.
    */
   private async initializeViewAndComputeSnapshot(
-    queryData: QueryData,
+    query: Query,
+    targetId: TargetId,
     current: boolean
   ): Promise<ViewSnapshot> {
-    const query = queryData.query;
     const queryResult = await this.localStore.executeQuery(
       query,
       /* usePreviousResults= */ true
@@ -250,7 +251,7 @@ export class SyncEngine implements RemoteSyncer, SharedClientStateSyncer {
     const view = new View(query, queryResult.remoteKeys);
     const viewDocChanges = view.computeDocChanges(queryResult.documents);
     const synthesizedTargetChange = TargetChange.createSynthesizedTargetChangeForCurrentChange(
-      queryData.targetId,
+      targetId,
       current && this.onlineState !== OnlineState.Offline
     );
     const viewChange = view.applyChanges(
@@ -267,9 +268,9 @@ export class SyncEngine implements RemoteSyncer, SharedClientStateSyncer {
       'applyChanges for new view should always return a snapshot'
     );
 
-    const data = new QueryView(query, queryData.targetId, view);
+    const data = new QueryView(query, targetId, view);
     this.queryViewsByQuery.set(query, data);
-    this.queryViewsByTarget[queryData.targetId] = data;
+    this.queryViewsByTarget[targetId] = data;
     return viewChange.snapshot!;
   }
 
@@ -747,7 +748,7 @@ export class SyncEngine implements RemoteSyncer, SharedClientStateSyncer {
       this.limboResolutionsByTarget[limboTargetId] = new LimboResolution(key);
       this.remoteStore.listen(
         new QueryData(
-          query,
+          query.toTarget(),
           limboTargetId,
           QueryPurpose.LimboResolution,
           ListenSequence.INVALID
@@ -948,12 +949,13 @@ export class SyncEngine implements RemoteSyncer, SharedClientStateSyncer {
           'A secondary tab should never have an active query without an active view.'
         );
         // For queries that never executed on this client, we need to
-        // allocate the query in LocalStore and initialize a new View.
-        const query = await this.localStore.getQueryForTarget(targetId);
-        assert(!!query, `Query data for target ${targetId} not found`);
-        queryData = await this.localStore.allocateQuery(query!);
+        // allocate the target in LocalStore and initialize a new View.
+        const target = await this.localStore.getTarget(targetId);
+        assert(!!target, `Target for id ${targetId} not found`);
+        queryData = await this.localStore.allocateTarget(target!);
         await this.initializeViewAndComputeSnapshot(
-          queryData,
+          target!.toTargetQuery(),
+          targetId,
           /*current=*/ false
         );
       }
@@ -1026,11 +1028,12 @@ export class SyncEngine implements RemoteSyncer, SharedClientStateSyncer {
         !this.queryViewsByTarget[targetId],
         'Trying to add an already active target'
       );
-      const query = await this.localStore.getQueryForTarget(targetId);
-      assert(!!query, `Query data for active target ${targetId} not found`);
-      const queryData = await this.localStore.allocateQuery(query!);
+      const target = await this.localStore.getTarget(targetId);
+      assert(!!target, `Query data for active target ${targetId} not found`);
+      const queryData = await this.localStore.allocateTarget(target!);
       await this.initializeViewAndComputeSnapshot(
-        queryData,
+        target!.toTargetQuery(),
+        queryData.targetId,
         /*current=*/ false
       );
       this.remoteStore.listen(queryData);

--- a/packages/firestore/src/core/target.ts
+++ b/packages/firestore/src/core/target.ts
@@ -1,0 +1,177 @@
+/**
+ * @license
+ * Copyright 2019 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { DocumentKey } from '../model/document_key';
+import { ResourcePath } from '../model/path';
+import { isNullOrUndefined } from '../util/types';
+import { Bound, Filter, OrderBy, Query } from './query';
+
+/**
+ * A Target represents the WatchTarget representation of a Query, which is used
+ * by the LocalStore and the RemoteStore to keep track of and to execute
+ * backend queries. While a Query can represent multiple Targets, each Targets
+ * maps to a single WatchTarget in RemoteStore and a single TargetData entry
+ * in persistence.
+ */
+export class Target {
+  private memoizedCanonicalId: string | null = null;
+
+  /**
+   * Initializes a Target with a path and optional additional query constraints.
+   * Path must currently be empty if this is a collection group query.
+   *
+   * NOTE: you should always construct `Target` from `Query.toTarget` instead of
+   * using this constructor, because `Query` provides an implicit `orderBy`
+   * property.
+   */
+  constructor(
+    readonly path: ResourcePath,
+    readonly collectionGroup: string | null = null,
+    readonly orderBy: OrderBy[] = [],
+    readonly filters: Filter[] = [],
+    readonly limit: number | null = null,
+    readonly startAt: Bound | null = null,
+    readonly endAt: Bound | null = null
+  ) {}
+
+  canonicalId(): string {
+    if (this.memoizedCanonicalId === null) {
+      let canonicalId = this.path.canonicalString();
+      if (this.collectionGroup !== null) {
+        canonicalId += '|cg:' + this.collectionGroup;
+      }
+      canonicalId += '|f:';
+      for (const filter of this.filters) {
+        canonicalId += filter.canonicalId();
+        canonicalId += ',';
+      }
+      canonicalId += '|ob:';
+      // TODO(dimond): make this collision resistant
+      for (const orderBy of this.orderBy) {
+        canonicalId += orderBy.canonicalId();
+        canonicalId += ',';
+      }
+      if (!isNullOrUndefined(this.limit)) {
+        canonicalId += '|l:';
+        canonicalId += this.limit!;
+      }
+      if (this.startAt) {
+        canonicalId += '|lb:';
+        canonicalId += this.startAt.canonicalId();
+      }
+      if (this.endAt) {
+        canonicalId += '|ub:';
+        canonicalId += this.endAt.canonicalId();
+      }
+      this.memoizedCanonicalId = canonicalId;
+    }
+    return this.memoizedCanonicalId;
+  }
+
+  toString(): string {
+    let str = this.path.canonicalString();
+    if (this.collectionGroup !== null) {
+      str += ' collectionGroup=' + this.collectionGroup;
+    }
+    if (this.filters.length > 0) {
+      str += `, filters: [${this.filters.join(', ')}]`;
+    }
+    if (!isNullOrUndefined(this.limit)) {
+      str += ', limit: ' + this.limit;
+    }
+    if (this.orderBy.length > 0) {
+      str += `, orderBy: [${this.orderBy.join(', ')}]`;
+    }
+    if (this.startAt) {
+      str += ', startAt: ' + this.startAt.canonicalId();
+    }
+    if (this.endAt) {
+      str += ', endAt: ' + this.endAt.canonicalId();
+    }
+    return `Target(${str})`;
+  }
+
+  isEqual(other: Target): boolean {
+    if (this.limit !== other.limit) {
+      return false;
+    }
+
+    if (this.orderBy.length !== other.orderBy.length) {
+      return false;
+    }
+
+    for (let i = 0; i < this.orderBy.length; i++) {
+      if (!this.orderBy[i].isEqual(other.orderBy[i])) {
+        return false;
+      }
+    }
+
+    if (this.filters.length !== other.filters.length) {
+      return false;
+    }
+
+    for (let i = 0; i < this.filters.length; i++) {
+      if (!this.filters[i].isEqual(other.filters[i])) {
+        return false;
+      }
+    }
+
+    if (this.collectionGroup !== other.collectionGroup) {
+      return false;
+    }
+
+    if (!this.path.isEqual(other.path)) {
+      return false;
+    }
+
+    if (
+      this.startAt !== null
+        ? !this.startAt.isEqual(other.startAt)
+        : other.startAt !== null
+    ) {
+      return false;
+    }
+
+    return this.endAt !== null
+      ? this.endAt.isEqual(other.endAt)
+      : other.endAt === null;
+  }
+
+  isDocumentQuery(): boolean {
+    return (
+      DocumentKey.isDocumentKey(this.path) &&
+      this.collectionGroup === null &&
+      this.filters.length === 0
+    );
+  }
+
+  /**
+   * Creates a `Query` object from this `Target`. Note the result might be
+   * different from the original `Query` from which we obtained this instance.
+   */
+  toTargetQuery(): Query {
+    return new Query(
+      this.path,
+      this.collectionGroup,
+      this.orderBy,
+      this.filters,
+      this.limit,
+      this.startAt,
+      this.endAt
+    );
+  }
+}

--- a/packages/firestore/src/core/target.ts
+++ b/packages/firestore/src/core/target.ts
@@ -18,7 +18,7 @@
 import { DocumentKey } from '../model/document_key';
 import { ResourcePath } from '../model/path';
 import { isNullOrUndefined } from '../util/types';
-import { Bound, Filter, OrderBy, Query } from './query';
+import { Bound, Filter, OrderBy } from './query';
 
 /**
  * A Target represents the WatchTarget representation of a Query, which is used
@@ -156,22 +156,6 @@ export class Target {
       DocumentKey.isDocumentKey(this.path) &&
       this.collectionGroup === null &&
       this.filters.length === 0
-    );
-  }
-
-  /**
-   * Creates a `Query` object from this `Target`. Note the result might be
-   * different from the original `Query` from which we obtained this instance.
-   */
-  toTargetQuery(): Query {
-    return new Query(
-      this.path,
-      this.collectionGroup,
-      this.orderBy,
-      this.filters,
-      this.limit,
-      this.startAt,
-      this.endAt
     );
   }
 }

--- a/packages/firestore/src/core/view.ts
+++ b/packages/firestore/src/core/view.ts
@@ -137,8 +137,12 @@ export class View {
     // Note that this should never get used in a refill (when previousChanges is
     // set), because there will only be adds -- no deletes or updates.
     const lastDocInLimit =
-      this.query.hasLimit() && oldDocumentSet.size === this.query.limit
+      this.query.hasLimitToFirst() && oldDocumentSet.size === this.query.limit
         ? oldDocumentSet.last()
+        : null;
+    const firstDocInLimit =
+      this.query.hasLimitToLast() && oldDocumentSet.size === this.query.limit
+        ? oldDocumentSet.first()
         : null;
 
     docChanges.inorderTraversal(
@@ -180,12 +184,14 @@ export class View {
               changeApplied = true;
 
               if (
-                lastDocInLimit &&
-                this.query.docComparator(newDoc, lastDocInLimit) > 0
+                (lastDocInLimit &&
+                  this.query.docComparator(newDoc, lastDocInLimit) > 0) ||
+                (firstDocInLimit &&
+                  this.query.docComparator(newDoc, firstDocInLimit) < 0)
               ) {
-                // This doc moved from inside the limit to after the limit.
-                // That means there may be some doc in the local cache that's
-                // actually less than this one.
+                // This doc moved from inside the limit to outside the limit.
+                // That means there may be some other doc in the local cache
+                // that should be included instead.
                 needsRefill = true;
               }
             }
@@ -200,7 +206,7 @@ export class View {
           changeSet.track({ type: ChangeType.Removed, doc: oldDoc });
           changeApplied = true;
 
-          if (lastDocInLimit) {
+          if (lastDocInLimit || firstDocInLimit) {
             // A doc was removed from a full limit query. We'll need to
             // requery from the local cache to see if we know about some other
             // doc that should be in the results.
@@ -223,14 +229,19 @@ export class View {
         }
       }
     );
-    if (this.query.hasLimit()) {
+
+    // Drop documents out to meet limit/limitToLast requirement.
+    if (this.query.hasLimitToFirst() || this.query.hasLimitToLast()) {
       while (newDocumentSet.size > this.query.limit!) {
-        const oldDoc = newDocumentSet.last();
+        const oldDoc = this.query.hasLimitToFirst()
+          ? newDocumentSet.last()
+          : newDocumentSet.first();
         newDocumentSet = newDocumentSet.delete(oldDoc!.key);
         newMutatedKeys = newMutatedKeys.delete(oldDoc!.key);
         changeSet.track({ type: ChangeType.Removed, doc: oldDoc! });
       }
     }
+
     assert(
       !needsRefill || !previousChanges,
       'View was refilled using docs that themselves needed refilling.'

--- a/packages/firestore/src/local/index_free_query_engine.ts
+++ b/packages/firestore/src/local/index_free_query_engine.ts
@@ -19,7 +19,7 @@ import { QueryEngine } from './query_engine';
 import { LocalDocumentsView } from './local_documents_view';
 import { PersistenceTransaction } from './persistence';
 import { PersistencePromise } from './persistence_promise';
-import { Query } from '../core/query';
+import { Query, LimitType } from '../core/query';
 import { SnapshotVersion } from '../core/snapshot_version';
 import {
   DocumentKeySet,
@@ -87,8 +87,9 @@ export class IndexFreeQueryEngine implements QueryEngine {
         const previousResults = this.applyQuery(query, documents);
 
         if (
-          query.hasLimit() &&
+          (query.hasLimitToFirst() || query.hasLimitToLast()) &&
           this.needsRefill(
+            query.limitType,
             previousResults,
             remoteKeys,
             lastLimboFreeSnapshotVersion
@@ -155,6 +156,7 @@ export class IndexFreeQueryEngine implements QueryEngine {
    * was last synchronized.
    */
   private needsRefill(
+    limitType: LimitType,
     sortedPreviousResults: SortedSet<Document>,
     remoteKeys: DocumentKeySet,
     limboFreeSnapshotVersion: SnapshotVersion
@@ -168,20 +170,22 @@ export class IndexFreeQueryEngine implements QueryEngine {
     // Limit queries are not eligible for index-free query execution if there is
     // a potential that an older document from cache now sorts before a document
     // that was previously part of the limit. This, however, can only happen if
-    // the last document of the limit sorts lower than it did when the query was
-    // last synchronized. If a document that is not the limit boundary sorts
-    // differently, the boundary of the limit itself did not change and
-    // documents from cache will continue to be "rejected" by this boundary.
-    // Therefore, we can ignore any modifications that don't affect the last
-    // document.
-    const lastDocumentInLimit = sortedPreviousResults.last();
-    if (!lastDocumentInLimit) {
+    // the document at the edge of the limit goes out of limit.
+    // If a document that is not the limit boundary sorts differently,
+    // the boundary of the limit itself did not change and documents from cache
+    // will continue to be "rejected" by this boundary. Therefore, we can ignore
+    // any modifications that don't affect the last document.
+    const docAtLimitEdge =
+      limitType === LimitType.First
+        ? sortedPreviousResults.last()
+        : sortedPreviousResults.first();
+    if (!docAtLimitEdge) {
       // We don't need to refill the query if there were already no documents.
       return false;
     }
     return (
-      lastDocumentInLimit.hasPendingWrites ||
-      lastDocumentInLimit.version.compareTo(limboFreeSnapshotVersion) > 0
+      docAtLimitEdge.hasPendingWrites ||
+      docAtLimitEdge.version.compareTo(limboFreeSnapshotVersion) > 0
     );
   }
 

--- a/packages/firestore/src/local/indexeddb_query_cache.ts
+++ b/packages/firestore/src/local/indexeddb_query_cache.ts
@@ -16,7 +16,6 @@
  */
 
 import { Timestamp } from '../api/timestamp';
-import { Query } from '../core/query';
 import { SnapshotVersion } from '../core/snapshot_version';
 import { ListenSequenceNumber, TargetId } from '../core/types';
 import { DocumentKeySet, documentKeySet } from '../model/collections';
@@ -46,6 +45,7 @@ import { PersistencePromise } from './persistence_promise';
 import { QueryCache } from './query_cache';
 import { QueryData } from './query_data';
 import { SimpleDb, SimpleDbStore, SimpleDbTransaction } from './simple_db';
+import { Target } from '../core/target';
 
 export class IndexedDbQueryCache implements QueryCache {
   constructor(
@@ -241,12 +241,12 @@ export class IndexedDbQueryCache implements QueryCache {
 
   getQueryData(
     transaction: PersistenceTransaction,
-    query: Query
+    target: Target
   ): PersistencePromise<QueryData | null> {
     // Iterating by the canonicalId may yield more than one result because
     // canonicalId values are not required to be unique per target. This query
     // depends on the queryTargets index to be efficient.
-    const canonicalId = query.canonicalId();
+    const canonicalId = target.canonicalId();
     const range = IDBKeyRange.bound(
       [canonicalId, Number.NEGATIVE_INFINITY],
       [canonicalId, Number.POSITIVE_INFINITY]
@@ -259,7 +259,7 @@ export class IndexedDbQueryCache implements QueryCache {
           const found = this.serializer.fromDbTarget(value);
           // After finding a potential match, check that the query is
           // actually equal to the requested query.
-          if (query.isEqual(found.query)) {
+          if (target.isEqual(found.target)) {
             result = found;
             control.done();
           }

--- a/packages/firestore/src/local/local_serializer.ts
+++ b/packages/firestore/src/local/local_serializer.ts
@@ -16,7 +16,6 @@
  */
 
 import { Timestamp } from '../api/timestamp';
-import { Query } from '../core/query';
 import { SnapshotVersion } from '../core/snapshot_version';
 import {
   Document,
@@ -31,6 +30,7 @@ import { JsonProtoSerializer } from '../remote/serializer';
 import { assert, fail } from '../util/assert';
 
 import { documentKeySet, DocumentKeySet } from '../model/collections';
+import { Target } from '../core/target';
 import { decode, encode, EncodedResourcePath } from './encoded_resource_path';
 import {
   DbMutationBatch,
@@ -210,14 +210,14 @@ export class LocalSerializer {
     // TODO(b/140573486): Convert to platform representation
     const resumeToken = dbTarget.resumeToken;
 
-    let query: Query;
+    let target: Target;
     if (isDocumentQuery(dbTarget.query)) {
-      query = this.remoteSerializer.fromDocumentsTarget(dbTarget.query);
+      target = this.remoteSerializer.fromDocumentsTarget(dbTarget.query);
     } else {
-      query = this.remoteSerializer.fromQueryTarget(dbTarget.query);
+      target = this.remoteSerializer.fromQueryTarget(dbTarget.query);
     }
     return new QueryData(
-      query,
+      target,
       dbTarget.targetId,
       QueryPurpose.Listen,
       dbTarget.lastListenSequenceNumber,
@@ -241,10 +241,10 @@ export class LocalSerializer {
       queryData.lastLimboFreeSnapshotVersion
     );
     let queryProto: DbQuery;
-    if (queryData.query.isDocumentQuery()) {
-      queryProto = this.remoteSerializer.toDocumentsTarget(queryData.query);
+    if (queryData.target.isDocumentQuery()) {
+      queryProto = this.remoteSerializer.toDocumentsTarget(queryData.target);
     } else {
-      queryProto = this.remoteSerializer.toQueryTarget(queryData.query);
+      queryProto = this.remoteSerializer.toQueryTarget(queryData.target);
     }
 
     let resumeToken: string;
@@ -263,7 +263,7 @@ export class LocalSerializer {
     // lastListenSequenceNumber is always 0 until we do real GC.
     return new DbTarget(
       queryData.targetId,
-      queryData.query.canonicalId(),
+      queryData.target.canonicalId(),
       dbTimestamp,
       resumeToken,
       queryData.sequenceNumber,

--- a/packages/firestore/src/local/local_store.ts
+++ b/packages/firestore/src/local/local_store.ts
@@ -814,15 +814,13 @@ export class LocalStore {
     );
   }
 
-  // TODO(wuandy): delete this temp method, it's only for change isolation.
-  allocateQuery(query: Query): Promise<QueryData> {
-    return this.allocateTarget(query.toTarget());
-  }
-
   /**
    * Assigns the given query an internal ID so that its results can be pinned so
    * they don't get GC'd. A query must be allocated in the local store before
    * the store can be used to manage its view.
+   *
+   * Allocating an already allocated `Target` will return the existing `QueryData`
+   * for that `Target`.
    */
   allocateTarget(target: Target): Promise<QueryData> {
     return this.persistence
@@ -853,15 +851,13 @@ export class LocalStore {
           });
       })
       .then(queryData => {
-        assert(
-          this.queryDataByTarget.get(queryData.targetId) === null,
-          'Tried to allocate an already allocated query: ' + target
-        );
-        this.queryDataByTarget = this.queryDataByTarget.insert(
-          queryData.targetId,
-          queryData
-        );
-        this.targetIdByTarget.set(target, queryData.targetId);
+        if (this.queryDataByTarget.get(queryData.targetId) === null) {
+          this.queryDataByTarget = this.queryDataByTarget.insert(
+            queryData.targetId,
+            queryData
+          );
+          this.targetIdByTarget.set(target, queryData.targetId);
+        }
         return queryData;
       });
   }
@@ -890,15 +886,17 @@ export class LocalStore {
    * `keepPersistedQueryData` is set to false and Eager GC enabled, the method
    * directly removes the associated query data from the query cache.
    *
-   * Calling `releaseTarget` multiple times with the same Target is an error.
+   * Releasing a non-existing `Target` is a no-op.
    */
   // PORTING NOTE: `keepPersistedQueryData` is multi-tab only.
   releaseTarget(
     targetId: number,
     keepPersistedQueryData: boolean
   ): Promise<void> {
-    const queryData = this.queryDataByTarget.get(targetId)!;
-    assert(!!queryData, 'Tried to release nonexistent target: ' + targetId);
+    const queryData = this.queryDataByTarget.get(targetId);
+    if (!queryData) {
+      return Promise.resolve();
+    }
 
     const mode = keepPersistedQueryData
       ? 'readwrite-idempotent'

--- a/packages/firestore/src/local/memory_query_cache.ts
+++ b/packages/firestore/src/local/memory_query_cache.ts
@@ -15,7 +15,6 @@
  * limitations under the License.
  */
 
-import { Query } from '../core/query';
 import { SnapshotVersion } from '../core/snapshot_version';
 import { TargetIdGenerator } from '../core/target_id_generator';
 import { ListenSequenceNumber, TargetId } from '../core/types';
@@ -31,12 +30,13 @@ import { PersistencePromise } from './persistence_promise';
 import { QueryCache } from './query_cache';
 import { QueryData } from './query_data';
 import { ReferenceSet } from './reference_set';
+import { Target } from '../core/target';
 
 export class MemoryQueryCache implements QueryCache {
   /**
    * Maps a query to the data about that query
    */
-  private queries = new ObjectMap<Query, QueryData>(q => q.canonicalId());
+  private targets = new ObjectMap<Target, QueryData>(t => t.canonicalId());
 
   /** The last received snapshot version. */
   private lastRemoteSnapshotVersion = SnapshotVersion.MIN;
@@ -64,7 +64,7 @@ export class MemoryQueryCache implements QueryCache {
     txn: PersistenceTransaction,
     f: (q: QueryData) => void
   ): PersistencePromise<void> {
-    this.queries.forEach((_, queryData) => f(queryData));
+    this.targets.forEach((_, queryData) => f(queryData));
     return PersistencePromise.resolve();
   }
 
@@ -103,7 +103,7 @@ export class MemoryQueryCache implements QueryCache {
   }
 
   private saveQueryData(queryData: QueryData): void {
-    this.queries.set(queryData.query, queryData);
+    this.targets.set(queryData.target, queryData);
     const targetId = queryData.targetId;
     if (targetId > this.highestTargetId) {
       this.highestTargetId = targetId;
@@ -118,7 +118,7 @@ export class MemoryQueryCache implements QueryCache {
     queryData: QueryData
   ): PersistencePromise<void> {
     assert(
-      !this.queries.has(queryData.query),
+      !this.targets.has(queryData.target),
       'Adding a query that already exists'
     );
     this.saveQueryData(queryData);
@@ -130,7 +130,7 @@ export class MemoryQueryCache implements QueryCache {
     transaction: PersistenceTransaction,
     queryData: QueryData
   ): PersistencePromise<void> {
-    assert(this.queries.has(queryData.query), 'Updating a non-existent query');
+    assert(this.targets.has(queryData.target), 'Updating a non-existent query');
     this.saveQueryData(queryData);
     return PersistencePromise.resolve();
   }
@@ -141,10 +141,10 @@ export class MemoryQueryCache implements QueryCache {
   ): PersistencePromise<void> {
     assert(this.targetCount > 0, 'Removing a target from an empty cache');
     assert(
-      this.queries.has(queryData.query),
+      this.targets.has(queryData.target),
       'Removing a non-existent target from the cache'
     );
-    this.queries.delete(queryData.query);
+    this.targets.delete(queryData.target);
     this.references.removeReferencesForId(queryData.targetId);
     this.targetCount -= 1;
     return PersistencePromise.resolve();
@@ -157,12 +157,12 @@ export class MemoryQueryCache implements QueryCache {
   ): PersistencePromise<number> {
     let count = 0;
     const removals: Array<PersistencePromise<void>> = [];
-    this.queries.forEach((key, queryData) => {
+    this.targets.forEach((key, queryData) => {
       if (
         queryData.sequenceNumber <= upperBound &&
         activeTargetIds.get(queryData.targetId) === null
       ) {
-        this.queries.delete(key);
+        this.targets.delete(key);
         removals.push(
           this.removeMatchingKeysForTargetId(transaction, queryData.targetId)
         );
@@ -180,9 +180,9 @@ export class MemoryQueryCache implements QueryCache {
 
   getQueryData(
     transaction: PersistenceTransaction,
-    query: Query
+    target: Target
   ): PersistencePromise<QueryData | null> {
-    const queryData = this.queries.get(query) || null;
+    const queryData = this.targets.get(target) || null;
     return PersistencePromise.resolve(queryData);
   }
 

--- a/packages/firestore/src/local/query_cache.ts
+++ b/packages/firestore/src/local/query_cache.ts
@@ -15,7 +15,6 @@
  * limitations under the License.
  */
 
-import { Query } from '../core/query';
 import { SnapshotVersion } from '../core/snapshot_version';
 import { ListenSequenceNumber, TargetId } from '../core/types';
 import { DocumentKeySet } from '../model/collections';
@@ -24,6 +23,7 @@ import { DocumentKey } from '../model/document_key';
 import { PersistenceTransaction } from './persistence';
 import { PersistencePromise } from './persistence_promise';
 import { QueryData } from './query_data';
+import { Target } from '../core/target';
 
 /**
  * Represents cached queries received from the remote backend.
@@ -123,13 +123,13 @@ export interface QueryCache {
   /**
    * Looks up a QueryData entry by query.
    *
-   * @param query The query corresponding to the entry to look up.
+   * @param target The query target corresponding to the entry to look up.
    * @return The cached QueryData entry, or null if the cache has no entry for
    * the query.
    */
   getQueryData(
     transaction: PersistenceTransaction,
-    query: Query
+    target: Target
   ): PersistencePromise<QueryData | null>;
 
   /**

--- a/packages/firestore/src/local/query_data.ts
+++ b/packages/firestore/src/local/query_data.ts
@@ -15,8 +15,8 @@
  * limitations under the License.
  */
 
-import { Query } from '../core/query';
 import { SnapshotVersion } from '../core/snapshot_version';
+import { Target } from '../core/target';
 import { ListenSequenceNumber, ProtoByteString, TargetId } from '../core/types';
 import { emptyByteString } from '../platform/platform';
 
@@ -37,10 +37,11 @@ export enum QueryPurpose {
 /**
  * An immutable set of metadata that the local store tracks for each query.
  */
+// TODO(wuandy): rename this to TargetData.
 export class QueryData {
   constructor(
     /** The query being listened to. */
-    readonly query: Query,
+    readonly target: Target,
     /**
      * The target ID to which the query corresponds; Assigned by the
      * LocalStore for user listens and by the SyncEngine for limbo watches.
@@ -72,7 +73,7 @@ export class QueryData {
   /** Creates a new query data instance with an updated sequence number. */
   withSequenceNumber(sequenceNumber: number): QueryData {
     return new QueryData(
-      this.query,
+      this.target,
       this.targetId,
       this.purpose,
       sequenceNumber,
@@ -91,7 +92,7 @@ export class QueryData {
     snapshotVersion: SnapshotVersion
   ): QueryData {
     return new QueryData(
-      this.query,
+      this.target,
       this.targetId,
       this.purpose,
       this.sequenceNumber,
@@ -109,7 +110,7 @@ export class QueryData {
     lastLimboFreeSnapshotVersion: SnapshotVersion
   ): QueryData {
     return new QueryData(
-      this.query,
+      this.target,
       this.targetId,
       this.purpose,
       this.sequenceNumber,
@@ -129,7 +130,7 @@ export class QueryData {
         other.lastLimboFreeSnapshotVersion
       ) &&
       this.resumeToken === other.resumeToken &&
-      this.query.isEqual(other.query)
+      this.target.isEqual(other.target)
     );
   }
 }

--- a/packages/firestore/src/local/shared_client_state.ts
+++ b/packages/firestore/src/local/shared_client_state.ts
@@ -110,6 +110,9 @@ export interface SharedClientState {
    * Associates a new Query Target ID with the local Firestore client. Returns
    * the new query state for the query (which can be 'current' if the query is
    * already associated with another tab).
+   *
+   * If the target id is already associated with local client, the method simply
+   * returns it's `QueryTargetState`.
    */
   addLocalQueryTarget(targetId: TargetId): QueryTargetState;
 
@@ -492,10 +495,6 @@ export class LocalClientState implements ClientState {
   activeTargetIds = targetIdSet();
 
   addQueryTarget(targetId: TargetId): void {
-    assert(
-      !this.activeTargetIds.has(targetId),
-      `Target with ID '${targetId}' already active.`
-    );
     this.activeTargetIds = this.activeTargetIds.add(targetId);
   }
 

--- a/packages/firestore/src/local/shared_client_state.ts
+++ b/packages/firestore/src/local/shared_client_state.ts
@@ -112,7 +112,7 @@ export interface SharedClientState {
    * already associated with another tab).
    *
    * If the target id is already associated with local client, the method simply
-   * returns it's `QueryTargetState`.
+   * returns its `QueryTargetState`.
    */
   addLocalQueryTarget(targetId: TargetId): QueryTargetState;
 

--- a/packages/firestore/src/remote/remote_store.ts
+++ b/packages/firestore/src/remote/remote_store.ts
@@ -238,12 +238,15 @@ export class RemoteStore implements TargetMetadataProvider {
     this.onlineStateTracker.set(OnlineState.Unknown);
   }
 
-  /** Starts new listen for the given query. Uses resume token if provided */
+  /**
+   * Starts new listen for the given query. Uses resume token if provided. It
+   * is a no-op if the target of given `QueryData` is already being listened.
+   */
   listen(queryData: QueryData): void {
-    assert(
-      !objUtils.contains(this.listenTargets, queryData.targetId),
-      'listen called with duplicate targetId!'
-    );
+    if (objUtils.contains(this.listenTargets, queryData.targetId)) {
+      return;
+    }
+
     // Mark this as something the client is currently listening for.
     this.listenTargets[queryData.targetId] = queryData;
 
@@ -255,12 +258,15 @@ export class RemoteStore implements TargetMetadataProvider {
     }
   }
 
-  /** Removes the listen from server */
+  /**
+   * Removes the listen from server. It is a no-op if the given target id is
+   * not being listened to.
+   */
   unlisten(targetId: TargetId): void {
-    assert(
-      objUtils.contains(this.listenTargets, targetId),
-      'unlisten called without assigned target ID!'
-    );
+    if (!objUtils.contains(this.listenTargets, targetId)) {
+      return;
+    }
+
     delete this.listenTargets[targetId];
     if (this.watchStream.isOpen()) {
       this.sendUnwatchRequest(targetId);

--- a/packages/firestore/src/remote/remote_store.ts
+++ b/packages/firestore/src/remote/remote_store.ts
@@ -462,7 +462,7 @@ export class RemoteStore implements TargetMetadataProvider {
       // that we flag the first re-listen this way without impacting future
       // listens of this target (that might happen e.g. on reconnect).
       const requestQueryData = new QueryData(
-        queryData.query,
+        queryData.target,
         targetId,
         QueryPurpose.ExistenceFilterMismatch,
         queryData.sequenceNumber

--- a/packages/firestore/src/remote/remote_store.ts
+++ b/packages/firestore/src/remote/remote_store.ts
@@ -240,7 +240,7 @@ export class RemoteStore implements TargetMetadataProvider {
 
   /**
    * Starts new listen for the given query. Uses resume token if provided. It
-   * is a no-op if the target of given `QueryData` is already being listened.
+   * is a no-op if the target of given `QueryData` is already being listened to.
    */
   listen(queryData: QueryData): void {
     if (objUtils.contains(this.listenTargets, queryData.targetId)) {

--- a/packages/firestore/src/remote/serializer.ts
+++ b/packages/firestore/src/remote/serializer.ts
@@ -29,6 +29,7 @@ import {
   Query
 } from '../core/query';
 import { SnapshotVersion } from '../core/snapshot_version';
+import { Target } from '../core/target';
 import { ProtoByteString, TargetId } from '../core/types';
 import { QueryData, QueryPurpose } from '../local/query_data';
 import { Document, MaybeDocument, NoDocument } from '../model/document';
@@ -1019,25 +1020,25 @@ export class JsonProtoSerializer {
     return new FieldTransform(fieldPath, transform!);
   }
 
-  toDocumentsTarget(query: Query): api.DocumentsTarget {
-    return { documents: [this.toQueryPath(query.path)] };
+  toDocumentsTarget(target: Target): api.DocumentsTarget {
+    return { documents: [this.toQueryPath(target.path)] };
   }
 
-  fromDocumentsTarget(documentsTarget: api.DocumentsTarget): Query {
+  fromDocumentsTarget(documentsTarget: api.DocumentsTarget): Target {
     const count = documentsTarget.documents!.length;
     assert(
       count === 1,
       'DocumentsTarget contained other than 1 document: ' + count
     );
     const name = documentsTarget.documents![0];
-    return Query.atPath(this.fromQueryPath(name));
+    return Query.atPath(this.fromQueryPath(name)).toTarget();
   }
 
-  toQueryTarget(query: Query): api.QueryTarget {
+  toQueryTarget(target: Target): api.QueryTarget {
     // Dissect the path into parent, collectionId, and optional key filter.
     const result: api.QueryTarget = { structuredQuery: {} };
-    const path = query.path;
-    if (query.collectionGroup !== null) {
+    const path = target.path;
+    if (target.collectionGroup !== null) {
       assert(
         path.length % 2 === 0,
         'Collection Group queries should be within a document path or root.'
@@ -1045,7 +1046,7 @@ export class JsonProtoSerializer {
       result.parent = this.toQueryPath(path);
       result.structuredQuery!.from = [
         {
-          collectionId: query.collectionGroup,
+          collectionId: target.collectionGroup,
           allDescendants: true
         }
       ];
@@ -1058,32 +1059,32 @@ export class JsonProtoSerializer {
       result.structuredQuery!.from = [{ collectionId: path.lastSegment() }];
     }
 
-    const where = this.toFilter(query.filters);
+    const where = this.toFilter(target.filters);
     if (where) {
       result.structuredQuery!.where = where;
     }
 
-    const orderBy = this.toOrder(query.orderBy);
+    const orderBy = this.toOrder(target.orderBy);
     if (orderBy) {
       result.structuredQuery!.orderBy = orderBy;
     }
 
-    const limit = this.toInt32Value(query.limit);
+    const limit = this.toInt32Value(target.limit);
     if (limit !== null) {
       result.structuredQuery!.limit = limit;
     }
 
-    if (query.startAt) {
-      result.structuredQuery!.startAt = this.toCursor(query.startAt);
+    if (target.startAt) {
+      result.structuredQuery!.startAt = this.toCursor(target.startAt);
     }
-    if (query.endAt) {
-      result.structuredQuery!.endAt = this.toCursor(query.endAt);
+    if (target.endAt) {
+      result.structuredQuery!.endAt = this.toCursor(target.endAt);
     }
 
     return result;
   }
 
-  fromQueryTarget(target: api.QueryTarget): Query {
+  fromQueryTarget(target: api.QueryTarget): Target {
     let path = this.fromQueryPath(target.parent!);
 
     const query = target.structuredQuery!;
@@ -1135,7 +1136,7 @@ export class JsonProtoSerializer {
       limit,
       startAt,
       endAt
-    );
+    ).toTarget();
   }
 
   toListenRequestLabels(
@@ -1166,12 +1167,12 @@ export class JsonProtoSerializer {
 
   toTarget(queryData: QueryData): api.Target {
     let result: api.Target;
-    const query = queryData.query;
+    const target = queryData.target;
 
-    if (query.isDocumentQuery()) {
-      result = { documents: this.toDocumentsTarget(query) };
+    if (target.isDocumentQuery()) {
+      result = { documents: this.toDocumentsTarget(target) };
     } else {
-      result = { query: this.toQueryTarget(query) };
+      result = { query: this.toQueryTarget(target) };
     }
 
     result.targetId = queryData.targetId;

--- a/packages/firestore/src/remote/serializer.ts
+++ b/packages/firestore/src/remote/serializer.ts
@@ -24,6 +24,7 @@ import {
   Direction,
   FieldFilter,
   Filter,
+  LimitType,
   Operator,
   OrderBy,
   Query
@@ -1134,6 +1135,7 @@ export class JsonProtoSerializer {
       orderBy,
       filterBy,
       limit,
+      LimitType.First,
       startAt,
       endAt
     ).toTarget();

--- a/packages/firestore/src/remote/watch_change.ts
+++ b/packages/firestore/src/remote/watch_change.ts
@@ -383,8 +383,8 @@ export class WatchChangeAggregator {
 
     const queryData = this.queryDataForActiveTarget(targetId);
     if (queryData) {
-      const query = queryData.query;
-      if (query.isDocumentQuery()) {
+      const target = queryData.target;
+      if (target.isDocumentQuery()) {
         if (expectedCount === 0) {
           // The existence filter told us the document does not exist. We deduce
           // that this document does not exist and apply a deleted document to
@@ -392,7 +392,7 @@ export class WatchChangeAggregator {
           // another query that will raise this document as part of a snapshot
           // until it is resolved, essentially exposing inconsistency between
           // queries.
-          const key = new DocumentKey(query.path);
+          const key = new DocumentKey(target.path);
           this.removeDocumentFromTarget(
             targetId,
             key,
@@ -426,7 +426,7 @@ export class WatchChangeAggregator {
     objUtils.forEachNumber(this.targetStates, (targetId, targetState) => {
       const queryData = this.queryDataForActiveTarget(targetId);
       if (queryData) {
-        if (targetState.current && queryData.query.isDocumentQuery()) {
+        if (targetState.current && queryData.target.isDocumentQuery()) {
           // Document queries for document that don't exist can produce an empty
           // result set. To update our local cache, we synthesize a document
           // delete if we have not previously received the document. This
@@ -436,7 +436,7 @@ export class WatchChangeAggregator {
           // TODO(dimond): Ideally we would have an explicit lookup query
           // instead resulting in an explicit delete message and we could
           // remove this special logic.
-          const key = new DocumentKey(queryData.query.path);
+          const key = new DocumentKey(queryData.target.path);
           if (
             this.pendingDocumentUpdates.get(key) === null &&
             !this.targetContainsDocument(targetId, key)

--- a/packages/firestore/src/util/input_validation.ts
+++ b/packages/firestore/src/util/input_validation.ts
@@ -451,6 +451,21 @@ export function invalidClassError(
   );
 }
 
+export function validatePositiveNumber(
+  functionName: string,
+  position: number,
+  n: number
+): void {
+  if (n <= 0) {
+    throw new FirestoreError(
+      Code.INVALID_ARGUMENT,
+      `Function "${functionName}()" requires its ${ordinal(
+        position
+      )} argument to be a positive number, but it was: ${n}.`
+    );
+  }
+}
+
 /** Converts a number to its english word representation */
 function ordinal(num: number): string {
   switch (num) {

--- a/packages/firestore/test/integration/api/query.test.ts
+++ b/packages/firestore/test/integration/api/query.test.ts
@@ -59,6 +59,14 @@ apiDescribe('Queries', (persistence: boolean) => {
     });
   });
 
+  it('cannot issue limitToLast queries without explicit order-by', () => {
+    return withTestCollection(persistence, {}, async collection => {
+      const expectedError =
+        'limitToLast() queries require specifying at least one orderBy() clause';
+      expect(() => collection.limitToLast(2).get()).to.throw(expectedError);
+    });
+  });
+
   it('can issue limit queries using descending sort order', () => {
     const testDocs = {
       a: { k: 'a', sort: 0 },
@@ -77,6 +85,230 @@ apiDescribe('Queries', (persistence: boolean) => {
             { k: 'c', sort: 1 }
           ]);
         });
+    });
+  });
+
+  it('can issue limitToLast queries using descending sort order', () => {
+    const testDocs = {
+      a: { k: 'a', sort: 0 },
+      b: { k: 'b', sort: 1 },
+      c: { k: 'c', sort: 1 },
+      d: { k: 'd', sort: 2 }
+    };
+    return withTestCollection(persistence, testDocs, collection => {
+      return collection
+        .orderBy('sort', 'desc')
+        .limitToLast(2)
+        .get()
+        .then(docs => {
+          expect(toDataArray(docs)).to.deep.equal([
+            { k: 'b', sort: 1 },
+            { k: 'a', sort: 0 }
+          ]);
+        });
+    });
+  });
+
+  it('can listen to limitToLast queries', () => {
+    const testDocs = {
+      a: { k: 'a', sort: 0 },
+      b: { k: 'b', sort: 1 },
+      c: { k: 'c', sort: 1 },
+      d: { k: 'd', sort: 2 }
+    };
+    return withTestCollection(persistence, testDocs, async collection => {
+      const storeEvent = new EventsAccumulator<firestore.QuerySnapshot>();
+      collection
+        .orderBy('sort', 'desc')
+        .limitToLast(2)
+        .onSnapshot(storeEvent.storeEvent);
+
+      let snapshot = await storeEvent.awaitEvent();
+      expect(toDataArray(snapshot)).to.deep.equal([
+        { k: 'b', sort: 1 },
+        { k: 'a', sort: 0 }
+      ]);
+
+      await collection.add({ k: 'e', sort: -1 });
+      snapshot = await storeEvent.awaitEvent();
+      expect(toDataArray(snapshot)).to.deep.equal([
+        { k: 'a', sort: 0 },
+        { k: 'e', sort: -1 }
+      ]);
+    });
+  });
+
+  // Two queries that mapped to the same target ID are referred to as
+  // "mirror queries". An example for a mirror query is a limitToLast()
+  // query and a limit() query that share the same backend Target ID.
+  // Since limitToLast() queries are sent to the backend with a modified
+  // orderBy() clause, they can map to the same target representation as
+  // limit() query, even if both queries appear separate to the user.
+  it('can listen to mirror queries', () => {
+    const testDocs = {
+      a: { k: 'a', sort: 0 },
+      b: { k: 'b', sort: 1 },
+      c: { k: 'c', sort: 1 },
+      d: { k: 'd', sort: 2 }
+    };
+    return withTestCollection(persistence, testDocs, async collection => {
+      const storeLimitEvent = new EventsAccumulator<firestore.QuerySnapshot>();
+      collection
+        .orderBy('sort', 'asc')
+        .limit(2)
+        .onSnapshot(storeLimitEvent.storeEvent);
+
+      const storeLimitToLastEvent = new EventsAccumulator<
+        firestore.QuerySnapshot
+      >();
+      collection
+        .orderBy('sort', 'desc')
+        .limitToLast(2)
+        .onSnapshot(storeLimitToLastEvent.storeEvent);
+
+      let snapshot = await storeLimitEvent.awaitEvent();
+      expect(toDataArray(snapshot)).to.deep.equal([
+        { k: 'a', sort: 0 },
+        { k: 'b', sort: 1 }
+      ]);
+
+      snapshot = await storeLimitToLastEvent.awaitEvent();
+      expect(toDataArray(snapshot)).to.deep.equal([
+        { k: 'b', sort: 1 },
+        { k: 'a', sort: 0 }
+      ]);
+
+      await collection.add({ k: 'e', sort: -1 });
+      snapshot = await storeLimitEvent.awaitEvent();
+      expect(toDataArray(snapshot)).to.deep.equal([
+        { k: 'e', sort: -1 },
+        { k: 'a', sort: 0 }
+      ]);
+
+      snapshot = await storeLimitToLastEvent.awaitEvent();
+      expect(toDataArray(snapshot)).to.deep.equal([
+        { k: 'a', sort: 0 },
+        { k: 'e', sort: -1 }
+      ]);
+    });
+  });
+
+  it('can unlisten from mirror queries', () => {
+    const testDocs = {
+      a: { k: 'a', sort: 0 },
+      b: { k: 'b', sort: 1 },
+      c: { k: 'c', sort: 1 },
+      d: { k: 'd', sort: 2 }
+    };
+    return withTestCollection(persistence, testDocs, async collection => {
+      const storeLimitEvent = new EventsAccumulator<firestore.QuerySnapshot>();
+      const limitUnlisten = collection
+        .orderBy('sort', 'asc')
+        .limit(2)
+        .onSnapshot(storeLimitEvent.storeEvent);
+
+      const storeLimitToLastEvent = new EventsAccumulator<
+        firestore.QuerySnapshot
+      >();
+      const limitToLastUnlisten = collection
+        .orderBy('sort', 'desc')
+        .limitToLast(2)
+        .onSnapshot(storeLimitToLastEvent.storeEvent);
+
+      await storeLimitEvent.awaitEvent();
+      await storeLimitToLastEvent.awaitEvent();
+
+      limitUnlisten();
+
+      await collection.add({ k: 'e', sort: -1 });
+      await storeLimitEvent.assertNoAdditionalEvents();
+      const snapshot = await storeLimitToLastEvent.awaitEvent();
+      // Check the limitToLast query still functions after the mirroring
+      // limit query is un-listened.
+      expect(toDataArray(snapshot)).to.deep.equal([
+        { k: 'a', sort: 0 },
+        { k: 'e', sort: -1 }
+      ]);
+
+      limitToLastUnlisten();
+
+      await collection.add({ k: 'f', sort: -1 });
+      await storeLimitToLastEvent.assertNoAdditionalEvents();
+    });
+  });
+
+  it('can relisten to mirror queries', () => {
+    const testDocs = {
+      a: { k: 'a', sort: 0 },
+      b: { k: 'b', sort: 1 },
+      c: { k: 'c', sort: 1 },
+      d: { k: 'd', sort: 2 }
+    };
+    return withTestCollection(persistence, testDocs, async collection => {
+      const storeLimitEvent = new EventsAccumulator<firestore.QuerySnapshot>();
+      let limitUnlisten = collection
+        .orderBy('sort', 'asc')
+        .limit(2)
+        .onSnapshot(storeLimitEvent.storeEvent);
+
+      const storeLimitToLastEvent = new EventsAccumulator<
+        firestore.QuerySnapshot
+      >();
+      let limitToLastUnlisten = collection
+        .orderBy('sort', 'desc')
+        .limitToLast(2)
+        .onSnapshot(storeLimitToLastEvent.storeEvent);
+
+      await storeLimitEvent.awaitEvent();
+      await storeLimitToLastEvent.awaitEvent();
+
+      // Unlisten then relisten limit query.
+      limitUnlisten();
+      limitUnlisten = collection
+        .orderBy('sort', 'asc')
+        .limit(2)
+        .onSnapshot(storeLimitEvent.storeEvent);
+      let snapshot = await storeLimitEvent.awaitEvent();
+      expect(toDataArray(snapshot)).to.deep.equal([
+        { k: 'a', sort: 0 },
+        { k: 'b', sort: 1 }
+      ]);
+
+      await collection.add({ k: 'e', sort: -1 });
+      // Verify limit query results.
+      snapshot = await storeLimitEvent.awaitEvent();
+      expect(toDataArray(snapshot)).to.deep.equal([
+        { k: 'e', sort: -1 },
+        { k: 'a', sort: 0 }
+      ]);
+      // Verify limitToLast query results.
+      snapshot = await storeLimitToLastEvent.awaitEvent();
+      expect(toDataArray(snapshot)).to.deep.equal([
+        { k: 'a', sort: 0 },
+        { k: 'e', sort: -1 }
+      ]);
+
+      // Unlisten to limitToLast, update a doc, then relisten limitToLast.
+      limitToLastUnlisten();
+      await collection.doc('a').update({ k: 'a', sort: -2 });
+      limitToLastUnlisten = collection
+        .orderBy('sort', 'desc')
+        .limitToLast(2)
+        .onSnapshot(storeLimitToLastEvent.storeEvent);
+
+      snapshot = await storeLimitEvent.awaitEvent();
+      // Checking limit query is still functioning when the mirroring
+      // limitToLast query is un-listened.
+      expect(toDataArray(snapshot)).to.deep.equal([
+        { k: 'a', sort: -2 },
+        { k: 'e', sort: -1 }
+      ]);
+
+      snapshot = await storeLimitToLastEvent.awaitEvent();
+      expect(toDataArray(snapshot)).to.deep.equal([
+        { k: 'e', sort: -1 },
+        { k: 'a', sort: -2 }
+      ]);
     });
   });
 

--- a/packages/firestore/test/integration/api/validation.test.ts
+++ b/packages/firestore/test/integration/api/validation.test.ts
@@ -795,12 +795,12 @@ apiDescribe('Validation:', (persistence: boolean) => {
     validationIt(persistence, 'with non-positive limit fail', db => {
       const collection = db.collection('test');
       expect(() => collection.limit(0)).to.throw(
-        'Invalid Query. Query limit (0) is invalid. Limit must be ' +
-          'positive.'
+        'Function "Query.limit()" requires its first argument to be a positive number, ' +
+          'but it was: 0.'
       );
-      expect(() => collection.limit(-1)).to.throw(
-        'Invalid Query. Query limit (-1) is invalid. Limit must be ' +
-          'positive.'
+      expect(() => collection.limitToLast(-1)).to.throw(
+        'Function "Query.limitToLast()" requires its first argument to be a positive number, ' +
+          'but it was: -1.'
       );
     });
 

--- a/packages/firestore/test/unit/core/query.test.ts
+++ b/packages/firestore/test/unit/core/query.test.ts
@@ -470,7 +470,8 @@ describe('Query', () => {
       .addFilter(filter('bar', '>', 2))
       .addOrderBy(orderBy('bar'));
 
-    const q7a = Query.atPath(path('foo')).withLimit(10);
+    const q7a = Query.atPath(path('foo')).withLimitToFirst(10);
+    const q8a = Query.atPath(path('foo')).withLimitToLast(10);
 
     const lip1a = bound([[DOCUMENT_KEY_NAME, 'coll/foo', 'asc']], true);
     const lip1b = bound([[DOCUMENT_KEY_NAME, 'coll/foo', 'asc']], false);
@@ -478,18 +479,18 @@ describe('Query', () => {
     // TODO(b/35851862): descending key ordering not supported yet
     // const lip3 = bound([[DOCUMENT_KEY_NAME, 'coll/bar', 'desc']]);
 
-    const q8a = Query.atPath(path('foo')).withStartAt(lip1a);
-    const q9a = Query.atPath(path('foo')).withStartAt(lip1b);
-    const q10a = Query.atPath(path('foo')).withStartAt(lip2);
-    const q11a = Query.atPath(path('foo')).withEndAt(lip1a);
-    const q12a = Query.atPath(path('foo')).withEndAt(lip1b);
-    const q13a = Query.atPath(path('foo')).withEndAt(lip2);
+    const q9a = Query.atPath(path('foo')).withStartAt(lip1a);
+    const q10a = Query.atPath(path('foo')).withStartAt(lip1b);
+    const q11a = Query.atPath(path('foo')).withStartAt(lip2);
+    const q12a = Query.atPath(path('foo')).withEndAt(lip1a);
+    const q13a = Query.atPath(path('foo')).withEndAt(lip1b);
+    const q14a = Query.atPath(path('foo')).withEndAt(lip2);
 
     // TODO(b/35851862): descending key ordering not supported yet
-    // const q14a = Query.atPath(path('foo'))
+    // const q15a = Query.atPath(path('foo'))
     // .addOrderBy(orderBy(DOCUMENT_KEY_NAME, 'desc'))
     // .withUpperBound(lip3, 'inclusive');
-    // const q15a = Query.atPath(path('foo'))
+    // const q16a = Query.atPath(path('foo'))
     // .addOrderBy(orderBy(DOCUMENT_KEY_NAME, 'desc'))
     // .withUpperBound(lip3, 'exclusive');
 
@@ -500,17 +501,17 @@ describe('Query', () => {
       5
     );
 
-    const q16a = Query.atPath(path('foo')).addFilter(
+    const q17a = Query.atPath(path('foo')).addFilter(
       filter('object', '==', { ref: relativeReference })
     );
-    const q16b = Query.atPath(path('foo')).addFilter(
+    const q17b = Query.atPath(path('foo')).addFilter(
       filter('object', '==', { ref: absoluteReference })
     );
 
-    const q17a = Query.atPath(path('foo')).addFilter(
+    const q18a = Query.atPath(path('foo')).addFilter(
       filter('array', '==', [relativeReference])
     );
-    const q17b = Query.atPath(path('foo')).addFilter(
+    const q18b = Query.atPath(path('foo')).addFilter(
       filter('array', '==', [absoluteReference])
     );
 
@@ -528,10 +529,11 @@ describe('Query', () => {
       [q11a],
       [q12a],
       [q13a],
-      //[q14a],
+      [q14a],
       //[q15a],
-      [q16a, q16b],
-      [q17a, q17b]
+      //[q16a],
+      [q17a, q17b],
+      [q18a, q18b]
     ];
 
     expectEqualitySets(queries, (q1, q2) => {
@@ -605,7 +607,7 @@ describe('Query', () => {
     query = baseQuery.addFilter(filter('foo', '==', 'bar'));
     expect(query.matchesAllDocuments()).to.be.false;
 
-    query = baseQuery.withLimit(1);
+    query = baseQuery.withLimitToFirst(1);
     expect(query.matchesAllDocuments()).to.be.false;
 
     query = baseQuery.withStartAt(bound([], true));

--- a/packages/firestore/test/unit/core/view.test.ts
+++ b/packages/firestore/test/unit/core/view.test.ts
@@ -174,7 +174,7 @@ describe('View', () => {
 
   it('removes documents for query with limit', () => {
     // shallow ancestor query
-    const query = Query.atPath(path('rooms/eros/messages')).withLimit(2);
+    const query = Query.atPath(path('rooms/eros/messages')).withLimitToFirst(2);
     const view = new View(query, documentKeySet());
 
     const doc1 = doc('rooms/eros/messages/1', 0, { text: 'msg1' });
@@ -206,7 +206,7 @@ describe('View', () => {
     // shallow ancestor query
     const query = Query.atPath(path('rooms/eros/messages'))
       .addOrderBy(orderBy('num'))
-      .withLimit(2);
+      .withLimitToFirst(2);
     const view = new View(query, documentKeySet());
 
     const doc1 = doc('rooms/eros/messages/1', 0, { num: 1 });
@@ -344,7 +344,7 @@ describe('View', () => {
   });
 
   it('returns needsRefill on delete limit query', () => {
-    const query = Query.atPath(path('rooms/eros/msgs')).withLimit(2);
+    const query = Query.atPath(path('rooms/eros/msgs')).withLimitToFirst(2);
     const doc1 = doc('rooms/eros/msgs/0', 0, {});
     const doc2 = doc('rooms/eros/msgs/1', 0, {});
     const view = new View(query, documentKeySet());
@@ -372,7 +372,7 @@ describe('View', () => {
   it('returns needsRefill on reorder in limit query', () => {
     const query = Query.atPath(path('rooms/eros/msgs'))
       .addOrderBy(orderBy('order'))
-      .withLimit(2);
+      .withLimitToFirst(2);
     const doc1 = doc('rooms/eros/msgs/0', 0, { order: 1 });
     let doc2 = doc('rooms/eros/msgs/1', 0, { order: 2 });
     const doc3 = doc('rooms/eros/msgs/2', 0, { order: 3 });
@@ -405,7 +405,7 @@ describe('View', () => {
   it("doesn't need refill on reorder within limit", () => {
     const query = Query.atPath(path('rooms/eros/msgs'))
       .addOrderBy(orderBy('order'))
-      .withLimit(3);
+      .withLimitToFirst(3);
     let doc1 = doc('rooms/eros/msgs/0', 0, { order: 1 });
     const doc2 = doc('rooms/eros/msgs/1', 0, { order: 2 });
     const doc3 = doc('rooms/eros/msgs/2', 0, { order: 3 });
@@ -434,7 +434,7 @@ describe('View', () => {
   it("doesn't need refill on reorder after limit query", () => {
     const query = Query.atPath(path('rooms/eros/msgs'))
       .addOrderBy(orderBy('order'))
-      .withLimit(3);
+      .withLimitToFirst(3);
     const doc1 = doc('rooms/eros/msgs/0', 0, { order: 1 });
     const doc2 = doc('rooms/eros/msgs/1', 0, { order: 2 });
     const doc3 = doc('rooms/eros/msgs/2', 0, { order: 3 });
@@ -461,7 +461,7 @@ describe('View', () => {
   });
 
   it("doesn't need refill for additions after the limit", () => {
-    const query = Query.atPath(path('rooms/eros/msgs')).withLimit(2);
+    const query = Query.atPath(path('rooms/eros/msgs')).withLimitToFirst(2);
     const doc1 = doc('rooms/eros/msgs/0', 0, {});
     const doc2 = doc('rooms/eros/msgs/1', 0, {});
     const view = new View(query, documentKeySet());
@@ -483,7 +483,7 @@ describe('View', () => {
   });
 
   it("doesn't need refill for deletions when not near the limit", () => {
-    const query = Query.atPath(path('rooms/eros/msgs')).withLimit(20);
+    const query = Query.atPath(path('rooms/eros/msgs')).withLimitToFirst(20);
     const doc1 = doc('rooms/eros/msgs/0', 0, {});
     const doc2 = doc('rooms/eros/msgs/1', 0, {});
     const view = new View(query, documentKeySet());
@@ -503,7 +503,7 @@ describe('View', () => {
   });
 
   it('handles applying irrelevant docs', () => {
-    const query = Query.atPath(path('rooms/eros/msgs')).withLimit(2);
+    const query = Query.atPath(path('rooms/eros/msgs')).withLimitToFirst(2);
     const doc1 = doc('rooms/eros/msgs/0', 0, {});
     const doc2 = doc('rooms/eros/msgs/1', 0, {});
     const view = new View(query, documentKeySet());

--- a/packages/firestore/test/unit/local/index_free_query_engine.test.ts
+++ b/packages/firestore/test/unit/local/index_free_query_engine.test.ts
@@ -264,7 +264,28 @@ describe('IndexFreeQueryEngine', () => {
   it('does not use initial results for limit query with document removal', async () => {
     const query = Query.atPath(path('coll'))
       .addFilter(filter('matches', '==', true))
-      .withLimit(1);
+      .withLimitToLast(1);
+
+    // While the backend would never add DocA to the set of remote keys, this
+    // allows us to easily simulate what would happen when a document no longer
+    // matches due to an out-of-band update.
+    await addDocument(NON_MATCHING_DOC_A);
+    await persistQueryMapping(NON_MATCHING_DOC_A.key);
+
+    await addDocument(MATCHING_DOC_B);
+
+    const docs = await expectFullCollectionQuery(() =>
+      runQuery(query, LAST_LIMBO_FREE_SNAPSHOT)
+    );
+
+    verifyResult(docs, [MATCHING_DOC_B]);
+  });
+
+  it('does not use initial results for limitToLast query with document removal', async () => {
+    const query = Query.atPath(path('coll'))
+      .addFilter(filter('matches', '==', true))
+      .addOrderBy(orderBy('order', 'desc'))
+      .withLimitToLast(1);
 
     // While the backend would never add DocA to the set of remote keys, this
     // allows us to easily simulate what would happen when a document no longer
@@ -285,7 +306,26 @@ describe('IndexFreeQueryEngine', () => {
     const query = Query.atPath(path('coll'))
       .addFilter(filter('matches', '==', true))
       .addOrderBy(orderBy('order', 'desc'))
-      .withLimit(1);
+      .withLimitToFirst(1);
+
+    // Add a query mapping for a document that matches, but that sorts below
+    // another document due to a pending write.
+    await addDocument(PENDING_MATCHING_DOC_A);
+    await persistQueryMapping(PENDING_MATCHING_DOC_A.key);
+
+    await addDocument(MATCHING_DOC_B);
+
+    const docs = await expectFullCollectionQuery(() =>
+      runQuery(query, LAST_LIMBO_FREE_SNAPSHOT)
+    );
+    verifyResult(docs, [MATCHING_DOC_B]);
+  });
+
+  it('does not use initial results for limitToLast query when first document has pending write', async () => {
+    const query = Query.atPath(path('coll'))
+      .addFilter(filter('matches', '==', true))
+      .addOrderBy(orderBy('order'))
+      .withLimitToLast(1);
 
     // Add a query mapping for a document that matches, but that sorts below
     // another document due to a pending write.
@@ -304,7 +344,27 @@ describe('IndexFreeQueryEngine', () => {
     const query = Query.atPath(path('coll'))
       .addFilter(filter('matches', '==', true))
       .addOrderBy(orderBy('order', 'desc'))
-      .withLimit(1);
+      .withLimitToFirst(1);
+
+    // Add a query mapping for a document that matches, but that sorts below
+    // another document based on an update that the SDK received after the
+    // query's snapshot was persisted.
+    await addDocument(UPDATED_DOC_A);
+    await persistQueryMapping(UPDATED_DOC_A.key);
+
+    await addDocument(MATCHING_DOC_B);
+
+    const docs = await expectFullCollectionQuery(() =>
+      runQuery(query, LAST_LIMBO_FREE_SNAPSHOT)
+    );
+    verifyResult(docs, [MATCHING_DOC_B]);
+  });
+
+  it('does not use initial results for limitToLast query when first document in limit has been updated out of band', async () => {
+    const query = Query.atPath(path('coll'))
+      .addFilter(filter('matches', '==', true))
+      .addOrderBy(orderBy('order'))
+      .withLimitToLast(1);
 
     // Add a query mapping for a document that matches, but that sorts below
     // another document based on an update that the SDK received after the
@@ -323,7 +383,7 @@ describe('IndexFreeQueryEngine', () => {
   it('uses initial results if last document in limit is unchanged', async () => {
     const query = Query.atPath(path('coll'))
       .addOrderBy(orderBy('order'))
-      .withLimit(2);
+      .withLimitToFirst(2);
 
     await addDocument(doc('coll/a', 1, { order: 1 }));
     await addDocument(doc('coll/b', 1, { order: 3 }));

--- a/packages/firestore/test/unit/local/local_store.test.ts
+++ b/packages/firestore/test/unit/local/local_store.test.ts
@@ -1058,7 +1058,7 @@ function genericLocalStoreTests(
 
   it('can execute mixed collection queries', async () => {
     const query = Query.atPath(path('foo'));
-    const queryData = await localStore.allocateQuery(query);
+    const queryData = await localStore.allocateTarget(query.toTarget());
     expect(queryData.targetId).to.equal(2);
     await localStore.applyRemoteEvent(
       docAddedRemoteEvent(doc('foo/baz', 10, { a: 'b' }), [2], [])
@@ -1122,7 +1122,7 @@ function genericLocalStoreTests(
   // eslint-disable-next-line no-restricted-properties
   (gcIsEager ? it.skip : it)('persists resume tokens', async () => {
     const query = Query.atPath(path('foo/bar'));
-    const queryData = await localStore.allocateQuery(query);
+    const queryData = await localStore.allocateTarget(query.toTarget());
     const targetId = queryData.targetId;
     const resumeToken = 'abc';
     const watchChange = new WatchTargetChange(
@@ -1145,7 +1145,7 @@ function genericLocalStoreTests(
     );
 
     // Should come back with the same resume token
-    const queryData2 = await localStore.allocateQuery(query);
+    const queryData2 = await localStore.allocateTarget(query.toTarget());
     expect(queryData2.resumeToken).to.deep.equal(resumeToken);
   });
 
@@ -1154,7 +1154,7 @@ function genericLocalStoreTests(
     'does not replace resume token with empty resume token',
     async () => {
       const query = Query.atPath(path('foo/bar'));
-      const queryData = await localStore.allocateQuery(query);
+      const queryData = await localStore.allocateTarget(query.toTarget());
       const targetId = queryData.targetId;
       const resumeToken = 'abc';
 
@@ -1191,7 +1191,7 @@ function genericLocalStoreTests(
       );
 
       // Should come back with the same resume token
-      const queryData2 = await localStore.allocateQuery(query);
+      const queryData2 = await localStore.allocateTarget(query.toTarget());
       expect(queryData2.resumeToken).to.deep.equal(resumeToken);
     }
   );

--- a/packages/firestore/test/unit/local/local_store.test.ts
+++ b/packages/firestore/test/unit/local/local_store.test.ts
@@ -1535,9 +1535,9 @@ function genericLocalStoreTests(
     // is advanced when we compute a limbo-free free view and that the mapping
     // is persisted when we release a query.
 
-    const query = Query.atPath(path('foo'));
+    const target = Query.atPath(path('foo')).toTarget();
 
-    const queryData = await localStore.allocateQuery(query);
+    const queryData = await localStore.allocateTarget(target);
 
     // Advance the query snapshot
     await localStore.applyRemoteEvent(
@@ -1548,7 +1548,7 @@ function genericLocalStoreTests(
     let cachedQueryData = await persistence.runTransaction(
       'getQueryData',
       'readonly-idempotent',
-      txn => localStore.getQueryData(txn, query)
+      txn => localStore.getQueryData(txn, target)
     );
     expect(
       cachedQueryData!.lastLimboFreeSnapshotVersion.isEqual(SnapshotVersion.MIN)
@@ -1561,20 +1561,20 @@ function genericLocalStoreTests(
     cachedQueryData = await persistence.runTransaction(
       'getQueryData',
       'readonly-idempotent',
-      txn => localStore.getQueryData(txn, query)
+      txn => localStore.getQueryData(txn, target)
     );
     expect(cachedQueryData!.lastLimboFreeSnapshotVersion.isEqual(version(10)))
       .to.be.true;
 
     // The last limbo free snapshot version is persisted even if we release the
     // query.
-    await localStore.releaseQuery(query, /* keepPersistedQueryData= */ false);
+    await localStore.releaseTarget(target, /* keepPersistedQueryData= */ false);
 
     if (!gcIsEager) {
       cachedQueryData = await persistence.runTransaction(
         'getQueryData',
         'readonly-idempotent',
-        txn => localStore.getQueryData(txn, query)
+        txn => localStore.getQueryData(txn, target)
       );
       expect(cachedQueryData!.lastLimboFreeSnapshotVersion.isEqual(version(10)))
         .to.be.true;

--- a/packages/firestore/test/unit/local/local_store.test.ts
+++ b/packages/firestore/test/unit/local/local_store.test.ts
@@ -20,6 +20,7 @@ import { PublicFieldValue } from '../../../src/api/field_value';
 import { Timestamp } from '../../../src/api/timestamp';
 import { User } from '../../../src/auth/user';
 import { Query } from '../../../src/core/query';
+import { Target } from '../../../src/core/target';
 import { TargetId, BatchId } from '../../../src/core/types';
 import { SnapshotVersion } from '../../../src/core/snapshot_version';
 import { IndexFreeQueryEngine } from '../../../src/local/index_free_query_engine';
@@ -199,22 +200,26 @@ class LocalStoreTester {
   }
 
   afterAllocatingQuery(query: Query): LocalStoreTester {
+    return this.afterAllocatingTarget(query.toTarget());
+  }
+
+  afterAllocatingTarget(target: Target): LocalStoreTester {
     this.prepareNextStep();
 
     this.promiseChain = this.promiseChain.then(() => {
-      return this.localStore.allocateQuery(query).then(result => {
+      return this.localStore.allocateTarget(target).then(result => {
         this.lastTargetId = result.targetId;
       });
     });
     return this;
   }
 
-  afterReleasingQuery(query: Query): LocalStoreTester {
+  afterReleasingTarget(targetId: number): LocalStoreTester {
     this.prepareNextStep();
 
     this.promiseChain = this.promiseChain.then(() => {
-      return this.localStore.releaseQuery(
-        query,
+      return this.localStore.releaseTarget(
+        targetId,
         /*keepPersistedQueryData=*/ false
       );
     });
@@ -546,7 +551,7 @@ function genericLocalStoreTests(
         doc('foo/bar', 0, { foo: 'bar' }, { hasLocalMutations: true })
       )
       .toContain(doc('foo/bar', 0, { foo: 'bar' }, { hasLocalMutations: true }))
-      .afterReleasingQuery(query)
+      .afterReleasingTarget(2)
       .afterAcknowledgingMutation({ documentVersion: 3 })
       .toReturnChanged(
         doc('foo/bar', 3, { foo: 'bar' }, { hasCommittedMutations: true })
@@ -704,7 +709,7 @@ function genericLocalStoreTests(
         .toReturnRemoved('foo/bar')
         .toContain(deletedDoc('foo/bar', 0))
         // remove the mutation so only the mutation is pinning the doc
-        .afterReleasingQuery(query)
+        .afterReleasingTarget(2)
         .afterAcknowledgingMutation({ documentVersion: 2 })
         .toReturnRemoved('foo/bar')
         .toNotContainIfEager(
@@ -727,7 +732,7 @@ function genericLocalStoreTests(
         .toReturnRemoved('foo/bar')
         .toContain(deletedDoc('foo/bar', 0))
         // Don't need to keep doc pinned anymore
-        .afterReleasingQuery(query)
+        .afterReleasingTarget(2)
         .afterAcknowledgingMutation({ documentVersion: 2 })
         .toReturnRemoved('foo/bar')
         .toNotContainIfEager(
@@ -773,7 +778,7 @@ function genericLocalStoreTests(
         doc('foo/bar', 1, { foo: 'bar' }, { hasLocalMutations: true })
       )
       .toContain(doc('foo/bar', 1, { foo: 'bar' }, { hasLocalMutations: true }))
-      .afterReleasingQuery(query)
+      .afterReleasingTarget(2)
       .afterAcknowledgingMutation({ documentVersion: 2 }) // delete mutation
       .toReturnChanged(
         doc('foo/bar', 2, { foo: 'bar' }, { hasLocalMutations: true })
@@ -895,9 +900,9 @@ function genericLocalStoreTests(
           .toReturnTargetId(2)
           .after(docAddedRemoteEvent(doc('foo/bar', 1, { foo: 'old' }), [2]))
           .after(patchMutation('foo/bar', { foo: 'bar' }))
-          // Release the query so that our target count goes back to 0 and we are considered
+          // Release the target so that our target count goes back to 0 and we are considered
           // up-to-date.
-          .afterReleasingQuery(query)
+          .afterReleasingTarget(2)
           .after(setMutation('foo/bah', { foo: 'bah' }))
           .after(deleteMutation('foo/baz'))
           .toContain(
@@ -935,9 +940,9 @@ function genericLocalStoreTests(
         .toReturnTargetId(2)
         .after(docAddedRemoteEvent(doc('foo/bar', 1, { foo: 'old' }), [2]))
         .after(patchMutation('foo/bar', { foo: 'bar' }))
-        // Release the query so that our target count goes back to 0 and we are considered
+        // Release the target so that our target count goes back to 0 and we are considered
         // up-to-date.
-        .afterReleasingQuery(query)
+        .afterReleasingTarget(2)
         .after(setMutation('foo/bah', { foo: 'bah' }))
         .after(deleteMutation('foo/baz'))
         .toContain(
@@ -990,7 +995,7 @@ function genericLocalStoreTests(
           removed: ['foo/bar', 'foo/baz']
         })
       )
-      .afterReleasingQuery(query)
+      .afterReleasingTarget(2)
       .toNotContain('foo/bar')
       .toNotContain('foo/baz')
       .finish();
@@ -1134,7 +1139,10 @@ function genericLocalStoreTests(
     await localStore.applyRemoteEvent(remoteEvent);
 
     // Stop listening so that the query should become inactive (but persistent)
-    await localStore.releaseQuery(query, /*keepPersistedQueryData=*/ false);
+    await localStore.releaseTarget(
+      queryData.targetId,
+      /*keepPersistedQueryData=*/ false
+    );
 
     // Should come back with the same resume token
     const queryData2 = await localStore.allocateQuery(query);
@@ -1177,7 +1185,10 @@ function genericLocalStoreTests(
       await localStore.applyRemoteEvent(remoteEvent2);
 
       // Stop listening so that the query should become inactive (but persistent)
-      await localStore.releaseQuery(query, /*keepPersistedQueryData=*/ false);
+      await localStore.releaseTarget(
+        targetId,
+        /*keepPersistedQueryData=*/ false
+      );
 
       // Should come back with the same resume token
       const queryData2 = await localStore.allocateQuery(query);
@@ -1568,7 +1579,10 @@ function genericLocalStoreTests(
 
     // The last limbo free snapshot version is persisted even if we release the
     // query.
-    await localStore.releaseTarget(target, /* keepPersistedQueryData= */ false);
+    await localStore.releaseTarget(
+      queryData.targetId,
+      /* keepPersistedQueryData= */ false
+    );
 
     if (!gcIsEager) {
       cachedQueryData = await persistence.runTransaction(
@@ -1652,7 +1666,7 @@ function genericLocalStoreTests(
             )
           )
           .after(localViewChanges(2, /* fromCache= */ false, {}))
-          .afterReleasingQuery(filteredQuery)
+          .afterReleasingTarget(2)
           // Start another query and add more matching documents to the collection.
           .afterAllocatingQuery(fullQuery)
           .toReturnTargetId(4)
@@ -1666,7 +1680,7 @@ function genericLocalStoreTests(
               []
             )
           )
-          .afterReleasingQuery(fullQuery)
+          .afterReleasingTarget(4)
           // Run the original query again and ensure that both the original
           // matches as well as all new matches are included in the result set.
           .afterAllocatingQuery(filteredQuery)
@@ -1714,7 +1728,7 @@ function genericLocalStoreTests(
             )
           )
           .after(localViewChanges(2, /* fromCache= */ false, {}))
-          .afterReleasingQuery(filteredQuery)
+          .afterReleasingTarget(2)
           // Modify one of the documents to no longer match while the filtered
           // query is inactive.
           .afterAllocatingQuery(fullQuery)
@@ -1729,7 +1743,7 @@ function genericLocalStoreTests(
               []
             )
           )
-          .afterReleasingQuery(fullQuery)
+          .afterReleasingTarget(4)
           // Run the original query again and ensure that both the original
           // matches as well as all new matches are included in the result set.
           .afterAllocatingQuery(filteredQuery)

--- a/packages/firestore/test/unit/local/lru_garbage_collector.test.ts
+++ b/packages/firestore/test/unit/local/lru_garbage_collector.test.ts
@@ -132,7 +132,7 @@ function genericLruGarbageCollectorTests(
   function nextQueryData(sequenceNumber: ListenSequenceNumber): QueryData {
     const targetId = ++previousTargetId;
     return new QueryData(
-      Query.atPath(path('path' + targetId)),
+      Query.atPath(path('path' + targetId)).toTarget(),
       targetId,
       QueryPurpose.Listen,
       sequenceNumber

--- a/packages/firestore/test/unit/local/test_query_cache.ts
+++ b/packages/firestore/test/unit/local/test_query_cache.ts
@@ -15,8 +15,8 @@
  * limitations under the License.
  */
 
-import { Query } from '../../../src/core/query';
 import { SnapshotVersion } from '../../../src/core/snapshot_version';
+import { Target } from '../../../src/core/target';
 import { ListenSequenceNumber, TargetId } from '../../../src/core/types';
 import { Persistence } from '../../../src/local/persistence';
 import { QueryCache } from '../../../src/local/query_cache';
@@ -67,12 +67,12 @@ export class TestQueryCache {
     );
   }
 
-  getQueryData(query: Query): Promise<QueryData | null> {
+  getQueryData(target: Target): Promise<QueryData | null> {
     return this.persistence.runTransaction(
       'getQueryData',
       'readonly-idempotent',
       txn => {
-        return this.cache.getQueryData(txn, query);
+        return this.cache.getQueryData(txn, target);
       }
     );
   }

--- a/packages/firestore/test/unit/remote/node/serializer.test.ts
+++ b/packages/firestore/test/unit/remote/node/serializer.test.ts
@@ -36,6 +36,7 @@ import {
   Query
 } from '../../../../src/core/query';
 import { SnapshotVersion } from '../../../../src/core/snapshot_version';
+import { Target } from '../../../../src/core/target';
 import { QueryData, QueryPurpose } from '../../../../src/local/query_data';
 import * as fieldValue from '../../../../src/model/field_value';
 import {
@@ -103,8 +104,8 @@ describe('Serializer', () => {
    * testing accept QueryData, but for the most part we're just testing
    * variations on Query.
    */
-  function wrapQueryData(query: Query): QueryData {
-    return new QueryData(query, 1, QueryPurpose.Listen, 2);
+  function wrapQueryData(target: Target): QueryData {
+    return new QueryData(target, 1, QueryPurpose.Listen, 2);
   }
 
   describe('converts value', () => {
@@ -901,18 +902,18 @@ describe('Serializer', () => {
   });
 
   it('encodes listen request labels', () => {
-    const query = Query.atPath(path('collection/key'));
-    let queryData = new QueryData(query, 2, QueryPurpose.Listen, 3);
+    const target = Query.atPath(path('collection/key')).toTarget();
+    let queryData = new QueryData(target, 2, QueryPurpose.Listen, 3);
 
     let result = s.toListenRequestLabels(queryData);
     expect(result).to.be.null;
 
-    queryData = new QueryData(query, 2, QueryPurpose.LimboResolution, 3);
+    queryData = new QueryData(target, 2, QueryPurpose.LimboResolution, 3);
     result = s.toListenRequestLabels(queryData);
     expect(result).to.deep.equal({ 'goog-listen-tags': 'limbo-document' });
 
     queryData = new QueryData(
-      query,
+      target,
       2,
       QueryPurpose.ExistenceFilterMismatch,
       3
@@ -927,7 +928,7 @@ describe('Serializer', () => {
     addEqualityMatcher();
 
     it('converts first-level key queries', () => {
-      const q = Query.atPath(path('docs/1'));
+      const q = Query.atPath(path('docs/1')).toTarget();
       const result = s.toTarget(wrapQueryData(q));
       expect(result).to.deep.equal({
         documents: { documents: ['projects/p/databases/d/documents/docs/1'] },
@@ -937,7 +938,7 @@ describe('Serializer', () => {
     });
 
     it('converts first-level ancestor queries', () => {
-      const q = Query.atPath(path('messages'));
+      const q = Query.atPath(path('messages')).toTarget();
       const result = s.toTarget(wrapQueryData(q));
       expect(result).to.deep.equal({
         query: {
@@ -958,7 +959,9 @@ describe('Serializer', () => {
     });
 
     it('converts nested ancestor queries', () => {
-      const q = Query.atPath(path('rooms/1/messages/10/attachments'));
+      const q = Query.atPath(
+        path('rooms/1/messages/10/attachments')
+      ).toTarget();
       const result = s.toTarget(wrapQueryData(q));
       const expected = {
         query: {
@@ -980,7 +983,9 @@ describe('Serializer', () => {
     });
 
     it('converts single filters at first-level collections', () => {
-      const q = Query.atPath(path('docs')).addFilter(filter('prop', '<', 42));
+      const q = Query.atPath(path('docs'))
+        .addFilter(filter('prop', '<', 42))
+        .toTarget();
       const result = s.toTarget(wrapQueryData(q));
       const expected = {
         query: {
@@ -1018,7 +1023,8 @@ describe('Serializer', () => {
         .addFilter(filter('name', '==', 'dimond'))
         .addFilter(filter('nan', '==', NaN))
         .addFilter(filter('null', '==', null))
-        .addFilter(filter('tags', 'array-contains', 'pending'));
+        .addFilter(filter('tags', 'array-contains', 'pending'))
+        .toTarget();
       const result = s.toTarget(wrapQueryData(q));
       const expected = {
         query: {
@@ -1084,9 +1090,9 @@ describe('Serializer', () => {
     });
 
     it('converts single filters on deeper collections', () => {
-      const q = Query.atPath(path('rooms/1/messages/10/attachments')).addFilter(
-        filter('prop', '<', 42)
-      );
+      const q = Query.atPath(path('rooms/1/messages/10/attachments'))
+        .addFilter(filter('prop', '<', 42))
+        .toTarget();
       const result = s.toTarget(wrapQueryData(q));
       const expected = {
         query: {
@@ -1119,7 +1125,9 @@ describe('Serializer', () => {
     });
 
     it('converts order bys', () => {
-      const q = Query.atPath(path('docs')).addOrderBy(orderBy('prop', 'asc'));
+      const q = Query.atPath(path('docs'))
+        .addOrderBy(orderBy('prop', 'asc'))
+        .toTarget();
       const result = s.toTarget(wrapQueryData(q));
       const expected = {
         query: {
@@ -1145,7 +1153,9 @@ describe('Serializer', () => {
     });
 
     it('converts limits', () => {
-      const q = Query.atPath(path('docs')).withLimit(26);
+      const q = Query.atPath(path('docs'))
+        .withLimit(26)
+        .toTarget();
       const result = s.toTarget(wrapQueryData(q));
       const expected = {
         query: {
@@ -1180,7 +1190,8 @@ describe('Serializer', () => {
             [[DOCUMENT_KEY_NAME, ref('p/d', 'foo/bar'), 'asc']],
             /*before=*/ false
           )
-        );
+        )
+        .toTarget();
       const result = s.toTarget(wrapQueryData(q));
       const expected = {
         query: {
@@ -1214,7 +1225,7 @@ describe('Serializer', () => {
     });
 
     it('converts resume tokens', () => {
-      const q = Query.atPath(path('docs'));
+      const q = Query.atPath(path('docs')).toTarget();
       const result = s.toTarget(
         new QueryData(
           q,

--- a/packages/firestore/test/unit/remote/node/serializer.test.ts
+++ b/packages/firestore/test/unit/remote/node/serializer.test.ts
@@ -1154,7 +1154,7 @@ describe('Serializer', () => {
 
     it('converts limits', () => {
       const q = Query.atPath(path('docs'))
-        .withLimit(26)
+        .withLimitToFirst(26)
         .toTarget();
       const result = s.toTarget(wrapQueryData(q));
       const expected = {

--- a/packages/firestore/test/unit/specs/limbo_spec.test.ts
+++ b/packages/firestore/test/unit/specs/limbo_spec.test.ts
@@ -16,7 +16,7 @@
  */
 
 import { Query } from '../../../src/core/query';
-import { deletedDoc, doc, filter, path } from '../../util/helpers';
+import { deletedDoc, doc, filter, path, orderBy } from '../../util/helpers';
 
 import { TimerId } from '../../../src/util/async_queue';
 import { Code } from '../../../src/util/error';
@@ -554,4 +554,89 @@ describeSpec('Limbo Documents:', [], () => {
         })
     );
   });
+
+  specTest(
+    'LimitToLast query from secondary results in no expected limbo doc',
+    ['multi-client'],
+    () => {
+      const limitToLast = Query.atPath(path('collection'))
+        .addOrderBy(orderBy('val', 'desc'))
+        .withLimitToLast(3);
+      const docA = doc('collection/a', 1000, { val: 11 });
+      const docB = doc('collection/b', 1000, { val: 12 });
+      const docC = doc('collection/c', 1000, { val: 13 });
+
+      const docA2 = doc('collection/a', 2000, { val: 5 });
+      const docB2 = doc('collection/b', 2000, { val: 6 });
+
+      const docD = doc('collection/d', 2000, { val: 7 });
+
+      return (
+        client(0)
+          .becomeVisible()
+          .client(1)
+          .userListens(limitToLast)
+          .client(0)
+          .expectListen(limitToLast)
+          .watchAcksFull(limitToLast, 1000, docA, docB, docC)
+          .client(1)
+          .expectEvents(limitToLast, { added: [docC, docB, docA] })
+          .client(0)
+          .watchResets()
+          .watchSends({ affects: [limitToLast] }, docA2, docB2, docD)
+          .watchCurrents(limitToLast, 'resume-token-2000')
+          .watchSnapshots(2000)
+          .client(1)
+          .expectEvents(limitToLast, {
+            added: [docD],
+            removed: [docC],
+            modified: [docB2, docA2]
+          })
+          .client(0)
+          // docC dropped out of limit in both local and backend result, hence
+          // it's not a limbo doc.
+          .expectLimboDocs()
+      );
+    }
+  );
+
+  specTest(
+    'LimitToLast query from secondary results in expected limbo doc',
+    ['multi-client'],
+    () => {
+      const limitToLast = Query.atPath(path('collection'))
+        .addOrderBy(orderBy('val', 'desc'))
+        .withLimitToLast(3);
+      const docA = doc('collection/a', 1000, { val: 11 });
+      const docB = doc('collection/b', 1000, { val: 12 });
+      const docC = doc('collection/c', 1000, { val: 13 });
+
+      const docA2 = doc('collection/a', 2000, { val: 11 });
+      const docB2 = doc('collection/b', 2000, { val: 12 });
+
+      const docD = doc('collection/d', 2000, { val: 100 });
+
+      return (
+        client(0)
+          .becomeVisible()
+          .client(1)
+          .userListens(limitToLast)
+          .client(0)
+          .expectListen(limitToLast)
+          .watchAcksFull(limitToLast, 1000, docA, docB, docC)
+          .client(1)
+          .expectEvents(limitToLast, { added: [docC, docB, docA] })
+          .client(0)
+          .watchResets()
+          .watchSends({ affects: [limitToLast] }, docA2, docB2, docD)
+          .watchCurrents(limitToLast, 'resume-token-2000')
+          .watchSnapshots(2000)
+          // docC dropped out of limit in from backend result, but still
+          // in local results, so it is in limbo now.
+          .expectLimboDocs(docC.key)
+          .client(1)
+          .expectEvents(limitToLast, { fromCache: true })
+      );
+    }
+  );
 });

--- a/packages/firestore/test/unit/specs/limbo_spec.test.ts
+++ b/packages/firestore/test/unit/specs/limbo_spec.test.ts
@@ -196,7 +196,7 @@ describeSpec('Limbo Documents:', [], () => {
     const fullQuery = Query.atPath(path('collection'));
     const limitQuery = Query.atPath(path('collection'))
       .addFilter(filter('include', '==', true))
-      .withLimit(1);
+      .withLimitToFirst(1);
     const docA = doc('collection/a', 1000, { key: 'a', include: true });
     const docB = doc('collection/b', 1000, { key: 'b', include: true });
     const docBQuery = Query.atPath(docB.key.path);
@@ -266,7 +266,7 @@ describeSpec('Limbo Documents:', [], () => {
       const fullQuery = Query.atPath(path('collection'));
       const limitQuery = Query.atPath(path('collection'))
         .addFilter(filter('include', '==', true))
-        .withLimit(1);
+        .withLimitToFirst(1);
       const docA = doc('collection/a', 1000, { key: 'a', include: true });
       const docB = doc('collection/b', 1000, { key: 'b', include: true });
       const docBQuery = Query.atPath(docB.key.path);

--- a/packages/firestore/test/unit/specs/limit_spec.test.ts
+++ b/packages/firestore/test/unit/specs/limit_spec.test.ts
@@ -23,7 +23,7 @@ import { client, spec } from './spec_builder';
 
 describeSpec('Limits:', [], () => {
   specTest('Documents in limit are replaced by remote event', [], () => {
-    const query1 = Query.atPath(path('collection')).withLimit(2);
+    const query1 = Query.atPath(path('collection')).withLimitToFirst(2);
     const doc1 = doc('collection/a', 1000, { key: 'a' });
     const doc2 = doc('collection/b', 1002, { key: 'b' });
     const doc3 = doc('collection/c', 1001, { key: 'c' });
@@ -46,7 +46,7 @@ describeSpec('Limits:', [], () => {
     "Documents outside of limit don't raise hasPendingWrites",
     [],
     () => {
-      const query1 = Query.atPath(path('collection')).withLimit(2);
+      const query1 = Query.atPath(path('collection')).withLimitToFirst(2);
       const doc1 = doc('collection/a', 1000, { key: 'a' });
       const doc2 = doc('collection/b', 1000, { key: 'b' });
 
@@ -68,7 +68,7 @@ describeSpec('Limits:', [], () => {
   );
 
   specTest('Deleted Document in limbo in full limit query', [], () => {
-    const query = Query.atPath(path('collection')).withLimit(2);
+    const query = Query.atPath(path('collection')).withLimitToFirst(2);
     const doc1 = doc('collection/a', 1000, { key: 'a' });
     const doc2 = doc('collection/b', 1001, { key: 'b' });
     const doc3 = doc('collection/c', 1002, { key: 'c' });
@@ -96,7 +96,7 @@ describeSpec('Limits:', [], () => {
   });
 
   specTest('Documents in limit can handle removed messages', [], () => {
-    const query1 = Query.atPath(path('collection')).withLimit(2);
+    const query1 = Query.atPath(path('collection')).withLimitToFirst(2);
     const doc1 = doc('collection/a', 1000, { key: 'a' });
     const doc2 = doc('collection/b', 1002, { key: 'b' });
     const doc3 = doc('collection/c', 1001, { key: 'c' });
@@ -123,8 +123,8 @@ describeSpec('Limits:', [], () => {
     'Documents in limit are can handle removed messages for only one of many query',
     [],
     () => {
-      const query1 = Query.atPath(path('collection')).withLimit(2);
-      const query2 = Query.atPath(path('collection')).withLimit(3);
+      const query1 = Query.atPath(path('collection')).withLimitToFirst(2);
+      const query2 = Query.atPath(path('collection')).withLimitToFirst(3);
       const doc1 = doc('collection/a', 1000, { key: 'a' });
       const doc2 = doc('collection/b', 1002, { key: 'b' });
       const doc3 = doc('collection/c', 1001, { key: 'c' });
@@ -164,7 +164,7 @@ describeSpec('Limits:', [], () => {
     );
     const limitQuery = Query.atPath(path('collection'))
       .addFilter(filter('matches', '==', true))
-      .withLimit(2);
+      .withLimitToFirst(2);
     const doc1 = doc('collection/a', 1001, { matches: true });
     const doc2 = doc('collection/b', 1002, { matches: true });
     const doc3 = doc('collection/c', 1000, { matches: true });
@@ -195,7 +195,7 @@ describeSpec('Limits:', [], () => {
       );
       const limitQuery = Query.atPath(path('collection'))
         .addFilter(filter('matches', '==', true))
-        .withLimit(2);
+        .withLimitToFirst(2);
       const doc1 = doc('collection/a', 1001, { matches: true });
       const doc2 = doc('collection/b', 1002, { matches: true });
       const doc3 = doc('collection/c', 1003, { matches: true });
@@ -227,7 +227,7 @@ describeSpec('Limits:', [], () => {
       const fullQuery = Query.atPath(path('collection'));
       const limitQuery = Query.atPath(path('collection'))
         .addOrderBy(orderBy('pos'))
-        .withLimit(2);
+        .withLimitToFirst(2);
       const doc1 = doc('collection/a', 1001, { pos: 1 });
       const doc2 = doc('collection/b', 1002, { pos: 2 });
       const doc3 = doc('collection/c', 1003, { pos: 3 });
@@ -260,7 +260,7 @@ describeSpec('Limits:', [], () => {
       const fullQuery = Query.atPath(path('collection'));
       const limitQuery = Query.atPath(path('collection'))
         .addOrderBy(orderBy('pos'))
-        .withLimit(2);
+        .withLimitToFirst(2);
       const doc1 = doc('collection/a', 1001, { pos: 1 });
       const doc1Edited = doc('collection/a', 1005, { pos: 4 });
       const doc2 = doc('collection/b', 1002, { pos: 2 });
@@ -296,7 +296,7 @@ describeSpec('Limits:', [], () => {
 
       const limitQuery = Query.atPath(path('collection'))
         .addOrderBy(orderBy('a'))
-        .withLimit(1);
+        .withLimitToFirst(1);
       const fullQuery = Query.atPath(path('collection')).addOrderBy(
         orderBy('a')
       );
@@ -372,7 +372,7 @@ describeSpec('Limits:', [], () => {
 
     const limitQuery = Query.atPath(path('collection'))
       .addOrderBy(orderBy('a'))
-      .withLimit(1);
+      .withLimitToFirst(1);
     const fullQuery = Query.atPath(path('collection')).addOrderBy(orderBy('a'));
 
     const firstDocument = doc('collection/a', 2001, { a: 1 });
@@ -412,7 +412,7 @@ describeSpec('Limits:', [], () => {
   });
 
   specTest('Multiple docs in limbo in full limit query', [], () => {
-    const query1 = Query.atPath(path('collection')).withLimit(2);
+    const query1 = Query.atPath(path('collection')).withLimitToFirst(2);
     const query2 = Query.atPath(path('collection'));
     const docA = doc('collection/a', 1000, { key: 'a' });
     const docB = doc('collection/b', 1001, { key: 'b' });
@@ -504,7 +504,7 @@ describeSpec('Limits:', [], () => {
     'Limit query is refilled by primary client',
     ['multi-client'],
     () => {
-      const query1 = Query.atPath(path('collection')).withLimit(2);
+      const query1 = Query.atPath(path('collection')).withLimitToFirst(2);
       const doc1 = doc('collection/a', 1000, { key: 'a' });
       const doc2 = doc('collection/b', 1002, { key: 'b' });
       const doc3 = doc('collection/c', 1001, { key: 'c' });
@@ -535,7 +535,7 @@ describeSpec('Limits:', [], () => {
     'Limit query includes write from secondary client ',
     ['multi-client'],
     () => {
-      const query1 = Query.atPath(path('collection')).withLimit(2);
+      const query1 = Query.atPath(path('collection')).withLimitToFirst(2);
       const doc1 = doc('collection/a', 1003, { key: 'a' });
       const doc1Local = doc(
         'collection/a',

--- a/packages/firestore/test/unit/specs/listen_spec.test.ts
+++ b/packages/firestore/test/unit/specs/listen_spec.test.ts
@@ -120,7 +120,7 @@ describeSpec('Listens:', [], () => {
     [],
     () => {
       const query1 = Query.atPath(path('collection'));
-      const query2 = Query.atPath(path('collection')).withLimit(10);
+      const query2 = Query.atPath(path('collection')).withLimitToFirst(10);
       const docA = doc('collection/a', 1000, { a: true });
       const docB = doc('collection/b', 1000, { b: true });
 

--- a/packages/firestore/test/unit/specs/spec_builder.ts
+++ b/packages/firestore/test/unit/specs/spec_builder.ts
@@ -263,11 +263,13 @@ export class SpecBuilder {
       throw new Error('Unlistening to query not listened to: ' + query);
     }
     const targetId = this.queryMapping.get(target)!;
-    if (this.config.useGarbageCollection) {
+    this.removeQueryFromActiveTargets(query, targetId);
+
+    if (this.config.useGarbageCollection && !this.activeTargets[targetId]) {
       this.queryMapping.delete(target);
       this.queryIdGenerator.purge(target);
     }
-    this.removeQueryFromActiveTargets(query, targetId);
+
     this.currentStep = {
       userUnlisten: [targetId, SpecBuilder.queryToSpec(query)],
       expectedState: { activeTargets: objUtils.shallowCopy(this.activeTargets) }
@@ -792,12 +794,12 @@ export class SpecBuilder {
     const target = query.toTarget();
     const targetId = this.queryMapping.get(target)!;
 
-    if (this.config.useGarbageCollection) {
+    this.removeQueryFromActiveTargets(query, targetId);
+
+    if (this.config.useGarbageCollection && !this.activeTargets[targetId]) {
       this.queryMapping.delete(target);
       this.queryIdGenerator.purge(target);
     }
-
-    this.removeQueryFromActiveTargets(query, targetId);
 
     const currentStep = this.currentStep!;
     currentStep.expectedState = currentStep.expectedState || {};

--- a/packages/firestore/test/unit/specs/spec_builder.ts
+++ b/packages/firestore/test/unit/specs/spec_builder.ts
@@ -876,7 +876,8 @@ export class SpecBuilder {
     if (query.collectionGroup !== null) {
       spec.collectionGroup = query.collectionGroup;
     }
-    if (query.hasLimit()) {
+    // TODO(limitToLast): Plumb through spec tests.
+    if (query.hasLimitToFirst()) {
       spec.limit = query.limit!;
     }
     if (query.filters) {

--- a/packages/firestore/test/unit/specs/spec_builder.ts
+++ b/packages/firestore/test/unit/specs/spec_builder.ts
@@ -16,6 +16,7 @@
  */
 
 import { FieldFilter, Filter, Query } from '../../../src/core/query';
+import { Target } from '../../../src/core/target';
 import { TargetIdGenerator } from '../../../src/core/target_id_generator';
 import { TargetId } from '../../../src/core/types';
 import {
@@ -39,7 +40,9 @@ import { TestSnapshotVersion } from '../../util/helpers';
 
 import { TimerId } from '../../../src/util/async_queue';
 import { RpcError } from './spec_rpc_error';
+import { ObjectMap } from '../../../src/util/obj_map';
 import {
+  parseQuery,
   runSpec,
   SpecConfig,
   SpecDocument,
@@ -54,15 +57,12 @@ import {
 
 // These types are used in a protected API by SpecBuilder and need to be
 // exported.
-export interface QueryMap {
-  [query: string]: TargetId;
-}
 export interface LimboMap {
   [key: string]: TargetId;
 }
 
 export interface ActiveTargetMap {
-  [targetId: string]: { query: SpecQuery; resumeToken: string };
+  [targetId: string]: { queries: SpecQuery[]; resumeToken: string };
 }
 
 /**
@@ -78,7 +78,7 @@ export interface ActiveTargetMap {
  */
 export class ClientMemoryState {
   activeTargets: ActiveTargetMap = {};
-  queryMapping: QueryMap = {};
+  queryMapping = new ObjectMap<Target, TargetId>(t => t.canonicalId());
   limboMapping: LimboMap = {};
 
   limboIdGenerator: TargetIdGenerator = TargetIdGenerator.forSyncEngine();
@@ -89,7 +89,7 @@ export class ClientMemoryState {
 
   /** Reset all internal memory state (as done during a client restart). */
   reset(): void {
-    this.queryMapping = {};
+    this.queryMapping = new ObjectMap<Target, TargetId>(t => t.canonicalId());
     this.limboMapping = {};
     this.activeTargets = {};
     this.limboIdGenerator = TargetIdGenerator.forSyncEngine();
@@ -108,38 +108,39 @@ export class ClientMemoryState {
  * active in multiple tabs.
  */
 class CachedTargetIdGenerator {
-  private queryMapping: QueryMap = {};
+  // TODO(wuandy): rename this to targetMapping.
+  private queryMapping = new ObjectMap<Target, TargetId>(t => t.canonicalId());
   private targetIdGenerator = TargetIdGenerator.forQueryCache();
 
   /**
-   * Returns a cached target ID for the provided query, or a new ID if no
+   * Returns a cached target ID for the provided Target, or a new ID if no
    * target ID has ever been assigned.
    */
-  next(query: Query): TargetId {
-    if (objUtils.contains(this.queryMapping, query.canonicalId())) {
-      return this.queryMapping[query.canonicalId()];
+  next(target: Target): TargetId {
+    if (this.queryMapping.has(target)) {
+      return this.queryMapping.get(target)!;
     }
     const targetId = this.targetIdGenerator.next();
-    this.queryMapping[query.canonicalId()] = targetId;
+    this.queryMapping.set(target, targetId);
     return targetId;
   }
 
-  /** Returns the target ID for a query that is known to exist. */
-  cachedId(query: Query): TargetId {
-    if (!objUtils.contains(this.queryMapping, query.canonicalId())) {
-      throw new Error("Target ID doesn't exists for query: " + query);
+  /** Returns the target ID for a target that is known to exist. */
+  cachedId(target: Target): TargetId {
+    if (!this.queryMapping.has(target)) {
+      throw new Error("Target ID doesn't exists for target: " + target);
     }
 
-    return this.queryMapping[query.canonicalId()];
+    return this.queryMapping.get(target)!;
   }
 
-  /** Remove the cached target ID for the provided query. */
-  purge(query: Query): void {
-    if (!objUtils.contains(this.queryMapping, query.canonicalId())) {
-      throw new Error("Target ID doesn't exists for query: " + query);
+  /** Remove the cached target ID for the provided target. */
+  purge(target: Target): void {
+    if (!this.queryMapping.has(target)) {
+      throw new Error("Target ID doesn't exists for target: " + target);
     }
 
-    delete this.queryMapping[query.canonicalId()];
+    this.queryMapping.delete(target);
   }
 }
 /**
@@ -171,7 +172,7 @@ export class SpecBuilder {
     return this.clientState.limboIdGenerator;
   }
 
-  private get queryMapping(): QueryMap {
+  private get queryMapping(): ObjectMap<Target, TargetId> {
     return this.clientState.queryMapping;
   }
 
@@ -217,22 +218,16 @@ export class SpecBuilder {
   userListens(query: Query, resumeToken?: string): this {
     this.nextStep();
 
+    const target = query.toTarget();
     let targetId: TargetId = 0;
-    if (objUtils.contains(this.queryMapping, query.canonicalId())) {
-      if (this.config.useGarbageCollection) {
-        throw new Error('Listening to same query twice: ' + query);
-      } else {
-        targetId = this.queryMapping[query.canonicalId()];
-      }
+    if (this.queryMapping.has(target)) {
+      targetId = this.queryMapping.get(target)!;
     } else {
-      targetId = this.queryIdGenerator.next(query);
+      targetId = this.queryIdGenerator.next(target);
     }
 
-    this.queryMapping[query.canonicalId()] = targetId;
-    this.activeTargets[targetId] = {
-      query: SpecBuilder.queryToSpec(query),
-      resumeToken: resumeToken || ''
-    };
+    this.queryMapping.set(target, targetId);
+    this.addQueryToActiveTargets(targetId, query, resumeToken);
     this.currentStep = {
       userListen: [targetId, SpecBuilder.queryToSpec(query)],
       expectedState: { activeTargets: objUtils.shallowCopy(this.activeTargets) }
@@ -245,16 +240,13 @@ export class SpecBuilder {
    * stream disconnect.
    */
   restoreListen(query: Query, resumeToken: string): this {
-    const targetId = this.queryMapping[query.canonicalId()];
+    const targetId = this.queryMapping.get(query.toTarget());
 
     if (isNullOrUndefined(targetId)) {
       throw new Error("Can't restore an unknown query: " + query);
     }
 
-    this.activeTargets[targetId] = {
-      query: SpecBuilder.queryToSpec(query),
-      resumeToken
-    };
+    this.addQueryToActiveTargets(targetId!, query, resumeToken);
 
     const currentStep = this.currentStep!;
     currentStep.expectedState = currentStep.expectedState || {};
@@ -266,15 +258,16 @@ export class SpecBuilder {
 
   userUnlistens(query: Query): this {
     this.nextStep();
-    if (!objUtils.contains(this.queryMapping, query.canonicalId())) {
+    const target = query.toTarget();
+    if (!this.queryMapping.has(target)) {
       throw new Error('Unlistening to query not listened to: ' + query);
     }
-    const targetId = this.queryMapping[query.canonicalId()];
+    const targetId = this.queryMapping.get(target)!;
     if (this.config.useGarbageCollection) {
-      delete this.queryMapping[query.canonicalId()];
-      this.queryIdGenerator.purge(query);
+      this.queryMapping.delete(target);
+      this.queryIdGenerator.purge(target);
     }
-    delete this.activeTargets[targetId];
+    this.removeQueryFromActiveTargets(query, targetId);
     this.currentStep = {
       userUnlisten: [targetId, SpecBuilder.queryToSpec(query)],
       expectedState: { activeTargets: objUtils.shallowCopy(this.activeTargets) }
@@ -426,10 +419,7 @@ export class SpecBuilder {
     const currentStep = this.currentStep!;
     this.clientState.activeTargets = {};
     targets.forEach(({ query, resumeToken }) => {
-      this.activeTargets[this.getTargetId(query)] = {
-        query: SpecBuilder.queryToSpec(query),
-        resumeToken
-      };
+      this.addQueryToActiveTargets(this.getTargetId(query), query, resumeToken);
     });
     currentStep.expectedState = currentStep.expectedState || {};
     currentStep.expectedState.activeTargets = objUtils.shallowCopy(
@@ -458,11 +448,12 @@ export class SpecBuilder {
       if (!objUtils.contains(this.limboMapping, path)) {
         this.limboMapping[path] = this.limboIdGenerator.next();
       }
-      this.activeTargets[this.limboMapping[path]] = {
-        query: SpecBuilder.queryToSpec(Query.atPath(key.path)),
-        // Limbo doc queries are currently always without resume token
-        resumeToken: ''
-      };
+      // Limbo doc queries are always without resume token
+      this.addQueryToActiveTargets(
+        this.limboMapping[path],
+        Query.atPath(key.path),
+        ''
+      );
     });
 
     currentStep.expectedState = currentStep.expectedState || {};
@@ -567,6 +558,8 @@ export class SpecBuilder {
     }
   }
 
+  // TODO(wuandy): watch* methods should really be dealing with Target, not
+  // Query, make this happen.
   watchAcks(query: Query): this {
     this.nextStep();
     this.currentStep = {
@@ -778,13 +771,11 @@ export class SpecBuilder {
   expectListen(query: Query, resumeToken?: string): this {
     this.assertStep('Expectations require previous step');
 
-    const targetId = this.queryIdGenerator.cachedId(query);
-    this.queryMapping[query.canonicalId()] = targetId;
+    const target = query.toTarget();
+    const targetId = this.queryIdGenerator.cachedId(target);
+    this.queryMapping.set(target, targetId);
 
-    this.activeTargets[targetId] = {
-      query: SpecBuilder.queryToSpec(query),
-      resumeToken: resumeToken || ''
-    };
+    this.addQueryToActiveTargets(targetId, query, resumeToken);
 
     const currentStep = this.currentStep!;
     currentStep.expectedState = currentStep.expectedState || {};
@@ -798,14 +789,15 @@ export class SpecBuilder {
   expectUnlisten(query: Query): this {
     this.assertStep('Expectations require previous step');
 
-    const targetId = this.queryMapping[query.canonicalId()];
+    const target = query.toTarget();
+    const targetId = this.queryMapping.get(target)!;
 
     if (this.config.useGarbageCollection) {
-      delete this.queryMapping[query.canonicalId()];
-      this.queryIdGenerator.purge(query);
+      this.queryMapping.delete(target);
+      this.queryIdGenerator.purge(target);
     }
 
-    delete this.activeTargets[targetId];
+    this.removeQueryFromActiveTargets(query, targetId);
 
     const currentStep = this.currentStep!;
     currentStep.expectedState = currentStep.expectedState || {};
@@ -876,9 +868,13 @@ export class SpecBuilder {
     if (query.collectionGroup !== null) {
       spec.collectionGroup = query.collectionGroup;
     }
-    // TODO(limitToLast): Plumb through spec tests.
     if (query.hasLimitToFirst()) {
       spec.limit = query.limit!;
+      spec.limitType = 'LimitToFirst';
+    }
+    if (query.hasLimitToLast()) {
+      spec.limit = query.limit!;
+      spec.limitType = 'LimitToLast';
     }
     if (query.filters) {
       spec.filters = query.filters.map((filter: Filter) => {
@@ -936,6 +932,53 @@ export class SpecBuilder {
     }
   }
 
+  /**
+   * Add the specified `Query` under give active targe id. If it is already
+   * added, this is a no-op.
+   */
+  private addQueryToActiveTargets(
+    targetId: number,
+    query: Query,
+    resumeToken?: string
+  ): void {
+    if (this.activeTargets[targetId]) {
+      const activeQueries = this.activeTargets[targetId].queries;
+      if (
+        !activeQueries.some(specQuery => parseQuery(specQuery).isEqual(query))
+      ) {
+        // `query` is not added yet.
+        this.activeTargets[targetId] = {
+          queries: [SpecBuilder.queryToSpec(query), ...activeQueries],
+          resumeToken: resumeToken || ''
+        };
+      } else {
+        this.activeTargets[targetId] = {
+          queries: activeQueries,
+          resumeToken: resumeToken || ''
+        };
+      }
+    } else {
+      this.activeTargets[targetId] = {
+        queries: [SpecBuilder.queryToSpec(query)],
+        resumeToken: resumeToken || ''
+      };
+    }
+  }
+
+  private removeQueryFromActiveTargets(query: Query, targetId: number): void {
+    const queriesAfterRemoval = this.activeTargets[targetId].queries.filter(
+      specQuery => !parseQuery(specQuery).isEqual(query)
+    );
+    if (queriesAfterRemoval.length > 0) {
+      this.activeTargets[targetId] = {
+        queries: queriesAfterRemoval,
+        resumeToken: this.activeTargets[targetId].resumeToken
+      };
+    } else {
+      delete this.activeTargets[targetId];
+    }
+  }
+
   private assertStep(msg: string): void {
     if (this.currentStep === null) {
       throw new Error('Expected a previous step: ' + msg);
@@ -943,7 +986,7 @@ export class SpecBuilder {
   }
 
   private getTargetId(query: Query): TargetId {
-    const queryTargetId = this.queryMapping[query.canonicalId()];
+    const queryTargetId = this.queryMapping.get(query.toTarget());
     const limboTargetId = this.limboMapping[query.path.canonicalString()];
     if (queryTargetId && limboTargetId) {
       // TODO(dimond): add support for query for doc and limbo doc at the same

--- a/packages/firestore/test/unit/specs/spec_test_runner.ts
+++ b/packages/firestore/test/unit/specs/spec_test_runner.ts
@@ -1190,7 +1190,7 @@ abstract class TestRunner {
     } else {
       let query = new Query(path(querySpec.path), querySpec.collectionGroup);
       if (querySpec.limit) {
-        query = query.withLimit(querySpec.limit);
+        query = query.withLimitToFirst(querySpec.limit);
       }
       if (querySpec.filters) {
         querySpec.filters.forEach(([field, op, value]) => {

--- a/packages/firestore/test/unit/specs/spec_test_runner.ts
+++ b/packages/firestore/test/unit/specs/spec_test_runner.ts
@@ -1113,7 +1113,7 @@ abstract class TestRunner {
       // despite the fact that it's not always the right value.
       const expectedTarget = this.serializer.toTarget(
         new QueryData(
-          this.parseQuery(expected.query),
+          this.parseQuery(expected.query).toTarget(),
           targetId,
           QueryPurpose.Listen,
           ARBITRARY_SEQUENCE_NUMBER,

--- a/packages/firestore/test/util/helpers.ts
+++ b/packages/firestore/test/util/helpers.ts
@@ -278,7 +278,7 @@ export function queryData(
   // Arbitrary value.
   const sequenceNumber = 0;
   return new QueryData(
-    query(path)._query,
+    query(path)._query.toTarget(),
     targetId,
     queryPurpose,
     sequenceNumber


### PR DESCRIPTION
  - Split `Query` and `Target` in the SDK.
  - Implement `limitToLast`.
  - Integration tests and spec tests for `limitToLast`.