### PR TITLE
Migrate installations to component framework

### DIFF
--- a/packages/app-types/index.d.ts
+++ b/packages/app-types/index.d.ts
@@ -1,3 +1,5 @@
+import { Provider } from '@firebase/component';
+
 /**
  * @license
  * Copyright 2017 Google Inc.

--- a/packages/app-types/index.d.ts
+++ b/packages/app-types/index.d.ts
@@ -1,5 +1,3 @@
-import { Provider } from '@firebase/component';
-
 /**
  * @license
  * Copyright 2017 Google Inc.

--- a/packages/installations/package.json
+++ b/packages/installations/package.json
@@ -53,6 +53,7 @@
   "dependencies": {
     "@firebase/installations-types": "0.2.1",
     "@firebase/util": "0.2.31",
+    "@firebase/component": "0.1.0",
     "idb": "3.0.2",
     "tslib": "1.10.0"
   }

--- a/packages/installations/src/index.ts
+++ b/packages/installations/src/index.ts
@@ -37,7 +37,7 @@ export function registerInstallations(instance: _FirebaseNamespace): void {
         return {
           app,
           getId: () => getId(app),
-          getToken: () => getToken(app),
+          getToken: (forceRefresh?: boolean) => getToken(app, forceRefresh),
           delete: () => deleteInstallation(app)
         };
       },

--- a/packages/installations/src/index.ts
+++ b/packages/installations/src/index.ts
@@ -22,7 +22,6 @@ import { FirebaseInstallations } from '@firebase/installations-types';
 import { deleteInstallation, getId, getToken } from './functions';
 import { extractAppConfig } from './helpers/extract-app-config';
 import { Provider, Component, ComponentType } from '@firebase/component';
-import { FirebaseApp } from '@firebase/app-types';
 
 export function registerInstallations(instance: _FirebaseNamespace): void {
   const installationsName = 'installations';
@@ -31,7 +30,7 @@ export function registerInstallations(instance: _FirebaseNamespace): void {
     new Component(
       installationsName,
       container => {
-        const app = container.getProvider<FirebaseApp>('app').getImmediate()!;
+        const app = container.getProvider('app').getImmediate();
         // Throws if app isn't configured properly.
         extractAppConfig(app);
 

--- a/packages/installations/src/index.ts
+++ b/packages/installations/src/index.ts
@@ -16,31 +16,35 @@
  */
 
 import firebase from '@firebase/app';
-import {
-  _FirebaseNamespace,
-  FirebaseServiceFactory
-} from '@firebase/app-types/private';
+import { _FirebaseNamespace } from '@firebase/app-types/private';
 import { FirebaseInstallations } from '@firebase/installations-types';
 
 import { deleteInstallation, getId, getToken } from './functions';
 import { extractAppConfig } from './helpers/extract-app-config';
+import { Provider, Component, ComponentType } from '@firebase/component';
+import { FirebaseApp } from '@firebase/app-types';
 
 export function registerInstallations(instance: _FirebaseNamespace): void {
   const installationsName = 'installations';
 
-  const factoryMethod: FirebaseServiceFactory = app => {
-    // Throws if app isn't configured properly.
-    extractAppConfig(app);
+  instance.INTERNAL.registerComponent(
+    new Component(
+      installationsName,
+      container => {
+        const app = container.getProvider<FirebaseApp>('app').getImmediate()!;
+        // Throws if app isn't configured properly.
+        extractAppConfig(app);
 
-    return {
-      app,
-      getId: () => getId(app),
-      getToken: (forceRefresh?: boolean) => getToken(app, forceRefresh),
-      delete: () => deleteInstallation(app)
-    };
-  };
-
-  instance.INTERNAL.registerService(installationsName, factoryMethod);
+        return {
+          app,
+          getId: () => getId(app),
+          getToken: () => getToken(app),
+          delete: () => deleteInstallation(app)
+        };
+      },
+      ComponentType.PUBLIC
+    )
+  );
 }
 
 registerInstallations(firebase as _FirebaseNamespace);
@@ -54,5 +58,11 @@ declare module '@firebase/app-types' {
   }
   interface FirebaseApp {
     installations(): FirebaseInstallations;
+  }
+}
+
+declare module '@firebase/component' {
+  interface ComponentContainer {
+    getProvider(name: 'installations'): Provider<FirebaseInstallations>;
   }
 }


### PR DESCRIPTION
### Context

go/firebase-js-platform
firebase/firebase-js-sdk#2316 implements the proposal.

### Changes

This PR changes `@firebase/installations` to use the component platform

### Dependencies

firebase/firebase-js-sdk#2316