### PR TITLE
Migrate storage to component framework

### DIFF
--- a/packages/storage/index.ts
+++ b/packages/storage/index.ts
@@ -16,11 +16,7 @@
  */
 
 import firebase from '@firebase/app';
-import { FirebaseApp } from '@firebase/app-types';
-import {
-  FirebaseServiceFactory,
-  _FirebaseNamespace
-} from '@firebase/app-types/private';
+import { _FirebaseNamespace } from '@firebase/app-types/private';
 import { StringFormat } from './src/implementation/string';
 import { TaskEvent, TaskState } from './src/implementation/taskenums';
 
@@ -28,6 +24,11 @@ import { XhrIoPool } from './src/implementation/xhriopool';
 import { Reference } from './src/reference';
 import { Service } from './src/service';
 import * as types from '@firebase/storage-types';
+import {
+  Component,
+  ComponentType,
+  ComponentContainer
+} from '@firebase/component';
 
 /**
  * Type constant for Firebase Storage.
@@ -35,12 +36,16 @@ import * as types from '@firebase/storage-types';
 const STORAGE_TYPE = 'storage';
 
 function factory(
-  app: FirebaseApp,
-  unused: unknown,
+  container: ComponentContainer,
   url?: string
 ): types.FirebaseStorage {
+  // Dependencies
+  const app = container.getProvider('app').getImmediate();
+  const authProvider = container.getProvider('auth-internal');
+
   return (new Service(
     app,
+    authProvider,
     new XhrIoPool(),
     url
   ) as unknown) as types.FirebaseStorage;
@@ -55,13 +60,10 @@ export function registerStorage(instance: _FirebaseNamespace): void {
     Storage: Service,
     Reference
   };
-  instance.INTERNAL.registerService(
-    STORAGE_TYPE,
-    factory as FirebaseServiceFactory,
-    namespaceExports,
-    undefined,
-    // Allow multiple storage instances per app.
-    true
+  instance.INTERNAL.registerComponent(
+    new Component(STORAGE_TYPE, factory, ComponentType.PUBLIC)
+      .setServiceProps(namespaceExports)
+      .setMultipleInstances(true)
   );
 }
 

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "@firebase/storage-types": "0.3.5",
     "@firebase/util": "0.2.31",
+    "@firebase/component": "0.1.0",
     "tslib": "1.10.0"
   },
   "peerDependencies": {

--- a/packages/storage/src/service.ts
+++ b/packages/storage/src/service.ts
@@ -22,6 +22,8 @@ import { Location } from './implementation/location';
 import * as RequestExports from './implementation/request';
 import { XhrIoPool } from './implementation/xhriopool';
 import { Reference } from './reference';
+import { Provider } from '@firebase/component';
+import { FirebaseAuthInternal } from '@firebase/auth-interop-types';
 
 /**
  * A service that provides firebaseStorage.Reference instances.
@@ -35,12 +37,18 @@ export class Service {
   private bucket_: Location | null = null;
   private internals_: ServiceInternals;
 
-  constructor(app: FirebaseApp, pool: XhrIoPool, url?: string) {
+  constructor(
+    app: FirebaseApp,
+    authProvider: Provider<FirebaseAuthInternal>,
+    pool: XhrIoPool,
+    url?: string
+  ) {
     function maker(authWrapper: AuthWrapper, loc: Location): Reference {
       return new Reference(authWrapper, loc);
     }
     this.authWrapper_ = new AuthWrapper(
       app,
+      authProvider,
       maker,
       RequestExports.makeRequest,
       this,

--- a/packages/storage/test/reference.test.ts
+++ b/packages/storage/test/reference.test.ts
@@ -26,9 +26,16 @@ import { Service } from '../src/service';
 import * as testShared from './testshared';
 import { SendHook, TestingXhrIo } from './xhrio';
 import { DEFAULT_HOST } from '../src/implementation/constants';
+import { FirebaseAuthInternal } from '@firebase/auth-interop-types';
+import { Provider } from '@firebase/component';
+
 /* eslint-disable @typescript-eslint/no-floating-promises */
-function makeFakeService(app: FirebaseApp, sendHook: SendHook): Service {
-  return new Service(app, testShared.makePool(sendHook));
+function makeFakeService(
+  app: FirebaseApp,
+  authProvider: Provider<FirebaseAuthInternal>,
+  sendHook: SendHook
+): Service {
+  return new Service(app, authProvider, testShared.makePool(sendHook));
 }
 
 function makeStorage(url: string): Reference {
@@ -38,6 +45,7 @@ function makeStorage(url: string): Reference {
 
   const authWrapper = new AuthWrapper(
     null,
+    testShared.emptyAuthProvider,
     maker,
     makeRequest,
     ({} as any) as Service,
@@ -190,7 +198,11 @@ describe('Firebase Storage > Reference', () => {
       done();
     }
 
-    const service = makeFakeService(testShared.fakeAppNoAuth, newSend);
+    const service = makeFakeService(
+      testShared.fakeApp,
+      testShared.emptyAuthProvider,
+      newSend
+    );
     const ref = service.refFromURL('gs://test-bucket');
     ref.child('foo').getMetadata();
   });
@@ -212,7 +224,11 @@ describe('Firebase Storage > Reference', () => {
       done();
     }
 
-    const service = makeFakeService(testShared.fakeApp, newSend);
+    const service = makeFakeService(
+      testShared.fakeApp,
+      testShared.fakeAuthProvider,
+      newSend
+    );
     const ref = service.refFromURL('gs://test-bucket');
     ref.child('foo').getMetadata();
   });

--- a/packages/storage/test/requests.test.ts
+++ b/packages/storage/test/requests.test.ts
@@ -28,7 +28,11 @@ import { XhrIoPool } from '../src/implementation/xhriopool';
 import { Metadata } from '../src/metadata';
 import { Reference } from '../src/reference';
 import { Service } from '../src/service';
-import { assertObjectIncludes, fakeXhrIo } from './testshared';
+import {
+  assertObjectIncludes,
+  fakeXhrIo,
+  fakeAuthProvider
+} from './testshared';
 import {
   DEFAULT_HOST,
   CONFIG_STORAGE_BUCKET_KEY
@@ -61,6 +65,7 @@ describe('Firebase Storage > Requests', () => {
 
   const authWrapper = new AuthWrapper(
     mockApp,
+    fakeAuthProvider,
     (authWrapper, loc) => {
       return new Reference(authWrapper, loc);
     },

--- a/packages/storage/test/service.test.ts
+++ b/packages/storage/test/service.test.ts
@@ -22,9 +22,9 @@ import * as testShared from './testshared';
 import { DEFAULT_HOST } from '../src/implementation/constants';
 import { FirebaseStorageError } from '../src/implementation/error';
 
-const fakeAppGs = testShared.makeFakeApp(null, 'gs://mybucket');
-const fakeAppGsEndingSlash = testShared.makeFakeApp(null, 'gs://mybucket/');
-const fakeAppInvalidGs = testShared.makeFakeApp(null, 'gs://mybucket/hello');
+const fakeAppGs = testShared.makeFakeApp('gs://mybucket');
+const fakeAppGsEndingSlash = testShared.makeFakeApp('gs://mybucket/');
+const fakeAppInvalidGs = testShared.makeFakeApp('gs://mybucket/hello');
 const xhrIoPool = new XhrIoPool();
 
 function makeGsUrl(child: string = ''): string {
@@ -33,7 +33,11 @@ function makeGsUrl(child: string = ''): string {
 
 describe('Firebase Storage > Service', () => {
   describe('simple constructor', () => {
-    const service = new Service(testShared.fakeApp, xhrIoPool);
+    const service = new Service(
+      testShared.fakeApp,
+      testShared.fakeAuthProvider,
+      xhrIoPool
+    );
     it('Root refs point to the right place', () => {
       const ref = service.ref();
       assert.equal(ref.toString(), makeGsUrl());
@@ -65,6 +69,7 @@ describe('Firebase Storage > Service', () => {
     it('gs:// custom bucket constructor refs point to the right place', () => {
       const service = new Service(
         testShared.fakeApp,
+        testShared.fakeAuthProvider,
         xhrIoPool,
         'gs://foo-bar.appspot.com'
       );
@@ -74,6 +79,7 @@ describe('Firebase Storage > Service', () => {
     it('http:// custom bucket constructor refs point to the right place', () => {
       const service = new Service(
         testShared.fakeApp,
+        testShared.fakeAuthProvider,
         xhrIoPool,
         `http://${DEFAULT_HOST}/v1/b/foo-bar.appspot.com/o`
       );
@@ -83,6 +89,7 @@ describe('Firebase Storage > Service', () => {
     it('https:// custom bucket constructor refs point to the right place', () => {
       const service = new Service(
         testShared.fakeApp,
+        testShared.fakeAuthProvider,
         xhrIoPool,
         `https://${DEFAULT_HOST}/v1/b/foo-bar.appspot.com/o`
       );
@@ -93,6 +100,7 @@ describe('Firebase Storage > Service', () => {
     it('Bare bucket name constructor refs point to the right place', () => {
       const service = new Service(
         testShared.fakeApp,
+        testShared.fakeAuthProvider,
         xhrIoPool,
         'foo-bar.appspot.com'
       );
@@ -102,6 +110,7 @@ describe('Firebase Storage > Service', () => {
     it('Child refs point to the right place', () => {
       const service = new Service(
         testShared.fakeApp,
+        testShared.fakeAuthProvider,
         xhrIoPool,
         'foo-bar.appspot.com'
       );
@@ -110,28 +119,45 @@ describe('Firebase Storage > Service', () => {
     });
     it('Throws trying to construct with a gs:// URL containing an object path', () => {
       const error = testShared.assertThrows(() => {
-        new Service(testShared.fakeApp, xhrIoPool, 'gs://bucket/object/');
+        new Service(
+          testShared.fakeApp,
+          testShared.fakeAuthProvider,
+          xhrIoPool,
+          'gs://bucket/object/'
+        );
       }, 'storage/invalid-default-bucket');
       assert.match(error.message, /Invalid default bucket/);
     });
   });
   describe('default bucket config', () => {
     it('gs:// works without ending slash', () => {
-      const service = new Service(fakeAppGs, xhrIoPool);
+      const service = new Service(
+        fakeAppGs,
+        testShared.fakeAuthProvider,
+        xhrIoPool
+      );
       assert.equal(service.ref().toString(), 'gs://mybucket/');
     });
     it('gs:// works with ending slash', () => {
-      const service = new Service(fakeAppGsEndingSlash, xhrIoPool);
+      const service = new Service(
+        fakeAppGsEndingSlash,
+        testShared.fakeAuthProvider,
+        xhrIoPool
+      );
       assert.equal(service.ref().toString(), 'gs://mybucket/');
     });
     it('Throws when config bucket is gs:// with an object path', () => {
       testShared.assertThrows(() => {
-        new Service(fakeAppInvalidGs, xhrIoPool);
+        new Service(fakeAppInvalidGs, testShared.fakeAuthProvider, xhrIoPool);
       }, 'storage/invalid-default-bucket');
     });
   });
   describe('refFromURL', () => {
-    const service = new Service(testShared.fakeApp, xhrIoPool);
+    const service = new Service(
+      testShared.fakeApp,
+      testShared.fakeAuthProvider,
+      xhrIoPool
+    );
     it('Throws on non-URL arg', () => {
       const error = testShared.assertThrows(() => {
         service.refFromURL('path/to/child');
@@ -158,7 +184,11 @@ describe('Firebase Storage > Service', () => {
     });
   });
   describe('Argument verification', () => {
-    const service = new Service(testShared.fakeApp, xhrIoPool);
+    const service = new Service(
+      testShared.fakeApp,
+      testShared.fakeAuthProvider,
+      xhrIoPool
+    );
     describe('ref', () => {
       it('Throws with two args', () => {
         testShared.assertThrows(
@@ -272,7 +302,11 @@ describe('Firebase Storage > Service', () => {
   });
 
   describe('Deletion', () => {
-    const service = new Service(testShared.fakeApp, xhrIoPool);
+    const service = new Service(
+      testShared.fakeApp,
+      testShared.fakeAuthProvider,
+      xhrIoPool
+    );
     it('In-flight requests are canceled when the service is deleted', () => {
       const ref = service.refFromURL('gs://mybucket/image.jpg');
       const toReturn = ref.getMetadata().then(

--- a/packages/storage/test/task.test.ts
+++ b/packages/storage/test/task.test.ts
@@ -26,7 +26,12 @@ import { Headers } from '../src/implementation/xhrio';
 import { Reference } from '../src/reference';
 import { Service } from '../src/service';
 import { UploadTask } from '../src/task';
-import { assertThrows, bind as fbsBind, makePool } from './testshared';
+import {
+  assertThrows,
+  bind as fbsBind,
+  makePool,
+  emptyAuthProvider
+} from './testshared';
 import { StringHeaders, TestingXhrIo } from './xhrio';
 
 const testLocation = new Location('bucket', 'object');
@@ -63,6 +68,7 @@ function authWrapperWithHandler(handler: RequestHandler): AuthWrapper {
 
   return new AuthWrapper(
     null,
+    emptyAuthProvider,
     () => {
       return {} as Reference;
     },

--- a/packages/storage/test/testshared.ts
+++ b/packages/storage/test/testshared.ts
@@ -22,18 +22,27 @@ import * as type from '../src/implementation/type';
 import { Headers, XhrIo } from '../src/implementation/xhrio';
 import { XhrIoPool } from '../src/implementation/xhriopool';
 import { SendHook, StringHeaders, TestingXhrIo } from './xhrio';
+import { FirebaseAuthInternal } from '@firebase/auth-interop-types';
+import {
+  Provider,
+  ComponentContainer,
+  Component,
+  ComponentType
+} from '@firebase/component';
 
 export const authToken = 'totally-legit-auth-token';
 export const bucket = 'mybucket';
-export const fakeApp = makeFakeApp({ accessToken: authToken });
-export const fakeAppNoAuth = makeFakeApp(null);
+export const fakeApp = makeFakeApp();
+export const fakeAuthProvider = makeFakeAuthProvider({
+  accessToken: authToken
+});
+export const emptyAuthProvider = new Provider<FirebaseAuthInternal>(
+  'auth-internal',
+  new ComponentContainer('storage-container')
+);
 
-export function makeFakeApp(token: {} | null, bucketArg?: string): FirebaseApp {
+export function makeFakeApp(bucketArg?: string): FirebaseApp {
   const app: any = {};
-  app.INTERNAL = {};
-  app.INTERNAL.getToken = function() {
-    return Promise.resolve(token);
-  };
   app.options = {};
   if (type.isDef(bucketArg)) {
     app.options[constants.CONFIG_STORAGE_BUCKET_KEY] = bucketArg;
@@ -41,6 +50,26 @@ export function makeFakeApp(token: {} | null, bucketArg?: string): FirebaseApp {
     app.options[constants.CONFIG_STORAGE_BUCKET_KEY] = bucket;
   }
   return app as FirebaseApp;
+}
+
+export function makeFakeAuthProvider(
+  token: {} | null
+): Provider<FirebaseAuthInternal> {
+  const provider = new Provider(
+    'auth-internal',
+    new ComponentContainer('storage-container')
+  );
+  provider.setComponent(
+    new Component(
+      'auth-internal',
+      () => ({
+        getToken: () => Promise.resolve(token)
+      }),
+      ComponentType.PRIVATE
+    )
+  );
+
+  return provider as Provider<FirebaseAuthInternal>;
 }
 
 export function makePool(sendHook: SendHook | null): XhrIoPool {


### PR DESCRIPTION
### Context

go/firebase-js-platform
https://github.com/firebase/firebase-js-sdk/pull/2316 implements the proposal.

### Changes

This PR changes `@firebase/storage` to use the component platform implemented in https://github.com/firebase/firebase-js-sdk/pull/2316

### Dependencies

https://github.com/firebase/firebase-js-sdk/pull/2316
https://github.com/firebase/firebase-js-sdk/pull/2317