### PR TITLE
Directly check for existence of gtag script tag

### DIFF
--- a/packages/analytics/index.test.ts
+++ b/packages/analytics/index.test.ts
@@ -27,10 +27,8 @@ import {
 import { getFakeApp } from './testing/get-fake-app';
 import { FirebaseApp } from '@firebase/app-types';
 import { GtagCommand, EventName } from './src/constants';
-import {
-  findGtagScriptOnPage,
-  removeGtagScript
-} from './testing/gtag-script-util';
+import { findGtagScriptOnPage } from './src/helpers';
+import { removeGtagScript } from './testing/gtag-script-util';
 
 let analyticsInstance: FirebaseAnalytics = {} as FirebaseAnalytics;
 const analyticsId = 'abcd-efgh';

--- a/packages/analytics/index.ts
+++ b/packages/analytics/index.ts
@@ -33,7 +33,6 @@ declare global {
  * Type constant for Firebase Analytics.
  */
 const ANALYTICS_TYPE = 'analytics';
-
 export function registerAnalytics(instance: _FirebaseNamespace): void {
   instance.INTERNAL.registerService(
     ANALYTICS_TYPE,

--- a/packages/analytics/src/constants.ts
+++ b/packages/analytics/src/constants.ts
@@ -21,6 +21,8 @@ export const ANALYTICS_ID_FIELD = 'measurementId';
 export const GA_FID_KEY = 'firebase_id';
 export const ORIGIN_KEY = 'origin';
 
+export const GTAG_URL = 'https://www.googletagmanager.com/gtag/js';
+
 export enum GtagCommand {
   EVENT = 'event',
   SET = 'set',

--- a/packages/analytics/src/factory.ts
+++ b/packages/analytics/src/factory.ts
@@ -34,7 +34,7 @@ import {
   insertScriptTag,
   getOrCreateDataLayer,
   wrapOrCreateGtag,
-  hasDataLayer
+  findGtagScriptOnPage
 } from './helpers';
 import { ANALYTICS_ID_FIELD } from './constants';
 import { AnalyticsError, ERROR_FACTORY } from './errors';
@@ -122,9 +122,8 @@ export function factory(
     // Steps here should only be done once per page: creation or wrapping
     // of dataLayer and global gtag function.
 
-    // Presence of previously existing dataLayer used to detect if user has
-    // already put the gtag snippet on this page.
-    if (!hasDataLayer(dataLayerName)) {
+    // Detect if user has already put the gtag <script> tag on this page.
+    if (!findGtagScriptOnPage()) {
       insertScriptTag(dataLayerName);
     }
     getOrCreateDataLayer(dataLayerName);

--- a/packages/analytics/src/helpers.test.ts
+++ b/packages/analytics/src/helpers.test.ts
@@ -51,8 +51,8 @@ describe('FirebaseAnalytics methods', () => {
   });
 
   it('getOrCreateDataLayer is able to correctly identify an existing data layer', () => {
-    delete window['dataLayer'];
-    expect(getOrCreateDataLayer('dataLayer')).to.deep.equal([]);
+    const existingDataLayer = window['dataLayer'] = [];
+    expect(getOrCreateDataLayer('dataLayer')).to.equal(existingDataLayer);
   });
 
   it('insertScriptIfNeeded inserts script tag', () => {

--- a/packages/analytics/src/helpers.test.ts
+++ b/packages/analytics/src/helpers.test.ts
@@ -249,27 +249,6 @@ describe('FirebaseAnalytics methods', () => {
       existingGtagStub.reset();
     });
 
-    // it('wrapped window.gtag function waits for initialization promises before sending events', async () => {
-    //   const deferred = new Deferred<void>();
-    //   wrapOrCreateGtag(
-    //     { [mockAnalyticsId]: deferred.promise },
-    //     'dataLayer',
-    //     'gtag'
-    //   );
-    //   (window['gtag'] as Gtag)(GtagCommand.EVENT, 'purchase', {
-    //     'transaction_id': 'abcd123'
-    //   });
-    //   await Promise.resolve(); // Clear async event stack but not pending FID promise.
-    //   expect(existingGtagStub).to.not.be.called;
-    //   deferred.resolve(); // Resolves gaid initialization promise.
-    //   await Promise.resolve(); // wait for the next cycle
-    //   expect(existingGtagStub).to.be.calledWith(
-    //     GtagCommand.EVENT,
-    //     'purchase',
-    //     { 'transaction_id': 'abcd123' }
-    //   );
-    // });
-
     it('new window.gtag function waits for all initialization promises before sending group events', async () => {
       const deferred = new Deferred<void>();
       const deferred2 = new Deferred<void>();

--- a/packages/analytics/src/helpers.test.ts
+++ b/packages/analytics/src/helpers.test.ts
@@ -21,7 +21,7 @@ import '../testing/setup';
 import { DataLayer, Gtag } from '@firebase/analytics-types';
 import {
   initializeGAId,
-  hasDataLayer,
+  getOrCreateDataLayer,
   insertScriptTag,
   wrapOrCreateGtag,
   findGtagScriptOnPage
@@ -45,13 +45,14 @@ describe('FirebaseAnalytics methods', () => {
     });
   });
 
-  it('hasDataLayer is able to correctly identify an existing data layer', () => {
-    expect(hasDataLayer('dataLayer')).to.be.false;
-    window['dataLayer'] = [];
-    expect(hasDataLayer('dataLayer')).to.be.true;
-    window['dataLayer'] = 'hello';
-    expect(hasDataLayer('dataLayer')).to.be.false;
+  it('getOrCreateDataLayer is able to create a new data layer if none exists', () => {
     delete window['dataLayer'];
+    expect(getOrCreateDataLayer('dataLayer')).to.deep.equal([]);
+  });
+
+  it('getOrCreateDataLayer is able to correctly identify an existing data layer', () => {
+    delete window['dataLayer'];
+    expect(getOrCreateDataLayer('dataLayer')).to.deep.equal([]);
   });
 
   it('insertScriptIfNeeded inserts script tag', () => {

--- a/packages/analytics/src/helpers.test.ts
+++ b/packages/analytics/src/helpers.test.ts
@@ -23,11 +23,11 @@ import {
   initializeGAId,
   hasDataLayer,
   insertScriptTag,
-  wrapOrCreateGtag
+  wrapOrCreateGtag,
+  findGtagScriptOnPage
 } from './helpers';
 import { getFakeApp } from '../testing/get-fake-app';
 import { GtagCommand } from './constants';
-import { findGtagScriptOnPage } from '../testing/gtag-script-util';
 import { Deferred } from '@firebase/util';
 
 const mockAnalyticsId = 'abcd-efgh-ijkl';

--- a/packages/analytics/src/helpers.test.ts
+++ b/packages/analytics/src/helpers.test.ts
@@ -51,7 +51,7 @@ describe('FirebaseAnalytics methods', () => {
   });
 
   it('getOrCreateDataLayer is able to correctly identify an existing data layer', () => {
-    const existingDataLayer = window['dataLayer'] = [];
+    const existingDataLayer = (window['dataLayer'] = []);
     expect(getOrCreateDataLayer('dataLayer')).to.equal(existingDataLayer);
   });
 

--- a/packages/analytics/src/helpers.ts
+++ b/packages/analytics/src/helpers.ts
@@ -62,10 +62,6 @@ export async function initializeGAId(
   });
 }
 
-export function hasDataLayer(dataLayerName: string): boolean {
-  return Array.isArray(window[dataLayerName]);
-}
-
 export function insertScriptTag(dataLayerName: string): void {
   const script = document.createElement('script');
   // We are not providing an analyticsId in the URL because it would trigger a `page_view`
@@ -81,9 +77,8 @@ export function insertScriptTag(dataLayerName: string): void {
 export function getOrCreateDataLayer(dataLayerName: string): DataLayer {
   // Check for existing dataLayer and create if needed.
   let dataLayer: DataLayer = [];
-  if (hasDataLayer(dataLayerName)) {
+  if (Array.isArray(window[dataLayerName])) {
     dataLayer = window[dataLayerName] as DataLayer;
-    console.log('returning existing datalayer', dataLayer.toString());
   } else {
     dataLayer = window[dataLayerName] = [];
   }

--- a/packages/analytics/src/helpers.ts
+++ b/packages/analytics/src/helpers.ts
@@ -27,7 +27,8 @@ import {
   GtagCommand,
   ANALYTICS_ID_FIELD,
   GA_FID_KEY,
-  ORIGIN_KEY
+  ORIGIN_KEY,
+  GTAG_URL
 } from './constants';
 import '@firebase/installations';
 
@@ -69,7 +70,7 @@ export function insertScriptTag(dataLayerName: string): void {
   const script = document.createElement('script');
   // We are not providing an analyticsId in the URL because it would trigger a `page_view`
   // without fid. We will initialize ga-id using gtag (config) command together with fid.
-  script.src = `https://www.googletagmanager.com/gtag/js?l=${dataLayerName}`;
+  script.src = `${GTAG_URL}?l=${dataLayerName}`;
   script.async = true;
   document.head.appendChild(script);
 }
@@ -82,6 +83,7 @@ export function getOrCreateDataLayer(dataLayerName: string): DataLayer {
   let dataLayer: DataLayer = [];
   if (hasDataLayer(dataLayerName)) {
     dataLayer = window[dataLayerName] as DataLayer;
+    console.log('returning existing datalayer', dataLayer.toString());
   } else {
     dataLayer = window[dataLayerName] = [];
   }
@@ -205,4 +207,17 @@ export function wrapOrCreateGtag(
     gtagCore,
     wrappedGtag: window[gtagFunctionName] as Gtag
   };
+}
+
+/**
+ * Returns first script tag in DOM matching our gtag url pattern.
+ */
+export function findGtagScriptOnPage(): HTMLScriptElement | null {
+  const scriptTags = window.document.getElementsByTagName('script');
+  for (const tag of Object.values(scriptTags)) {
+    if (tag.src && tag.src.includes(GTAG_URL)) {
+      return tag;
+    }
+  }
+  return null;
 }

--- a/packages/analytics/src/helpers.ts
+++ b/packages/analytics/src/helpers.ts
@@ -80,7 +80,7 @@ export function getOrCreateDataLayer(dataLayerName: string): DataLayer {
   if (Array.isArray(window[dataLayerName])) {
     dataLayer = window[dataLayerName] as DataLayer;
   } else {
-    dataLayer = window[dataLayerName] = [];
+    window[dataLayerName] = dataLayer;
   }
   return dataLayer;
 }

--- a/packages/analytics/testing/gtag-script-util.ts
+++ b/packages/analytics/testing/gtag-script-util.ts
@@ -14,24 +14,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-export function findGtagScriptOnPage(): HTMLScriptElement | null {
-  const scriptTags = window.document.getElementsByTagName('script');
-  for (const tag of Object.values(scriptTags)) {
-    if (tag.src) {
-      if (tag.src.includes('googletagmanager')) {
-        return tag;
-      }
-    }
-  }
-  return null;
-}
+import { GTAG_URL } from '../src/constants';
 
 export function removeGtagScript(): void {
   const scriptTags = window.document.getElementsByTagName('script');
   for (const tag of Object.values(scriptTags)) {
     if (tag.src) {
-      if (tag.src.includes('googletagmanager') && tag.parentElement) {
+      if (tag.src.includes(GTAG_URL) && tag.parentElement) {
         tag.parentElement!.removeChild(tag);
       }
     }


### PR DESCRIPTION
We previously checked for pre-existence of a gtag script by looking for `window.dataLayer`. This is not an accurate check in some cases, such as if the user is using Google Tag Manager on the page, which creates a `window.dataLayer` but does not insert a script tag to download `gtag.js`.

This change directly checks the DOM for existence of such a script tag, and we will insert it if not found.