### PR TITLE
Add Database.Servervalue.increment(x)

### DIFF
--- a/packages/database/src/api/Database.ts
+++ b/packages/database/src/api/Database.ts
@@ -38,6 +38,13 @@ export class Database implements FirebaseService {
   static readonly ServerValue = {
     TIMESTAMP: {
       '.sv': 'timestamp'
+    },
+    _increment: (x: number) => {
+      return {
+        '.sv': {
+          'increment': x
+        }
+      };
     }
   };
 

--- a/packages/database/src/core/Repo.ts
+++ b/packages/database/src/core/Repo.ts
@@ -307,8 +307,10 @@ export class Repo {
     // (b) store unresolved paths on JSON parse
     const serverValues = this.generateServerValues();
     const newNodeUnresolved = nodeFromJSON(newVal, newPriority);
+    const existing = this.serverSyncTree_.calcCompleteEventCache(path);
     const newNode = resolveDeferredValueSnapshot(
       newNodeUnresolved,
+      existing,
       serverValues
     );
 
@@ -359,6 +361,7 @@ export class Repo {
       const newNodeUnresolved = nodeFromJSON(changedValue);
       changedChildren[changedKey] = resolveDeferredValueSnapshot(
         newNodeUnresolved,
+        this.serverSyncTree_.calcCompleteEventCache(path),
         serverValues
       );
     });
@@ -413,6 +416,7 @@ export class Repo {
     const serverValues = this.generateServerValues();
     const resolvedOnDisconnectTree = resolveDeferredValueTree(
       this.onDisconnect_,
+      this.serverSyncTree_,
       serverValues
     );
     let events: Event[] = [];

--- a/packages/database/src/core/Repo_transaction.ts
+++ b/packages/database/src/core/Repo_transaction.ts
@@ -245,6 +245,7 @@ Repo.prototype.startTransaction = function(
     const newNodeUnresolved = nodeFromJSON(newVal, priorityForNode);
     const newNode = resolveDeferredValueSnapshot(
       newNodeUnresolved,
+      currentState,
       serverValues
     );
     transaction.currentOutputSnapshotRaw = newNodeUnresolved;
@@ -522,6 +523,7 @@ Repo.prototype.startTransaction = function(
           const serverValues = this.generateServerValues();
           const newNodeResolved = resolveDeferredValueSnapshot(
             newDataNode,
+            currentNode,
             serverValues
           );
 

--- a/packages/database/src/core/SyncTree.ts
+++ b/packages/database/src/core/SyncTree.ts
@@ -474,8 +474,10 @@ export class SyncTree {
   }
 
   /**
-   * Returns a complete cache, if we have one, of the data at a particular path. The location must have a listener above
-   * it, but as this is only used by transaction code, that should always be the case anyways.
+   * Returns a complete cache, if we have one, of the data at a particular path. If the location does not have a
+   * listener above it, we will get a false "null". This shouldn't be a problem because transactions will always
+   * have a listener above, and atomic operations would correctly show a jitter of <increment value> ->
+   *     <incremented total> as the write is applied locally and then acknowledged at the server.
    *
    * Note: this method will *include* hidden writes from transaction with applyLocally set to false.
    *
@@ -485,7 +487,7 @@ export class SyncTree {
   calcCompleteEventCache(
     path: Path,
     writeIdsToExclude?: number[]
-  ): Node | null {
+  ): Node {
     const includeHiddenSets = true;
     const writeTree = this.pendingWriteTree_;
     const serverCache = this.syncPointTree_.findOnPath(path, function(

--- a/packages/database/src/core/SyncTree.ts
+++ b/packages/database/src/core/SyncTree.ts
@@ -484,10 +484,7 @@ export class SyncTree {
    * @param path The path to the data we want
    * @param writeIdsToExclude A specific set to be excluded
    */
-  calcCompleteEventCache(
-    path: Path,
-    writeIdsToExclude?: number[]
-  ): Node {
+  calcCompleteEventCache(path: Path, writeIdsToExclude?: number[]): Node {
     const includeHiddenSets = true;
     const writeTree = this.pendingWriteTree_;
     const serverCache = this.syncPointTree_.findOnPath(path, function(

--- a/packages/database/test/servervalues.test.ts
+++ b/packages/database/test/servervalues.test.ts
@@ -1,0 +1,95 @@
+/**
+ * @license
+ * Copyright 2019 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { expect } from 'chai';
+import { getRandomNode } from './helpers/util';
+import { Database } from '../src/api/Database';
+import { Reference } from '../src/api/Reference';
+import { nodeFromJSON } from '../src/core/snap/nodeFromJSON';
+
+describe('ServerValue tests', () => {
+  it('resolves timestamps locally', async () => {
+    const node = getRandomNode() as Reference;
+    const start = Date.now();
+    const values: Array<number> = [];
+    node.on('value', snap => {
+      expect(typeof snap.val()).to.equal('number');
+      values.push(snap.val() as number);
+    });
+    await node.set(Database.ServerValue.TIMESTAMP);
+    node.off('value');
+
+    // By the time the write is acknowledged, we should have a local and
+    // server version of the timestamp.
+    expect(values.length).to.equal(2);
+    values.forEach(serverTime => {
+      const delta = Math.abs(serverTime - start);
+      expect(delta).to.be.lessThan(1000);
+    });
+  });
+
+  it('handles increments without listeners', () => {
+    // Ensure that increments don't explode when the SyncTree must return a null
+    // node (i.e. ChildrenNode.EMPTY_NODE) because there is not yet any synced
+    // data.
+    const node = getRandomNode() as Reference;
+    const addOne = Database.ServerValue._increment(1);
+
+    node.set(addOne);
+  });
+
+  it('handles increments locally', async () => {
+    const node = getRandomNode() as Reference;
+    const addOne = Database.ServerValue._increment(1);
+
+    // Must go offline because the latest emulator may not support this server op
+    // This also means we can't await node operations, which would block the test.
+    node.database.goOffline();
+    try {
+      const values: Array<any> = [];
+      const expected: Array<any> = [];
+      node.on('value', snap => values.push(snap.val()));
+
+      // null -> increment(x) = x
+      node.set(addOne);
+      expected.push(1);
+
+      // x -> increment(y) = x + y
+      node.set(5);
+      node.set(addOne);
+      expected.push(5);
+      expected.push(6);
+
+      // str -> increment(x) = x
+      node.set('hello');
+      node.set(addOne);
+      expected.push('hello');
+      expected.push(1);
+
+      // obj -> increment(x) = x
+      node.set({ 'hello': 'world' });
+      node.set(addOne);
+      expected.push({ 'hello': 'world' });
+      expected.push(1);
+
+      node.off('value');
+      expect(values).to.deep.equal(expected);
+    } finally {
+      node.database.goOnline();
+    }
+  });
+});


### PR DESCRIPTION
Per offline discussions, it looks like this is pretty simple to add; we just change resolveDeferredValueSnapshot to also accept a cached value.

Added tests for ServeValues in general.

Forgive my lake of familiarity: do we edit packages/database-types directly? While I understand we don't actually want the feature to be exposed directly yet, it seems weird that extending ServerValues in database.ts didn't change database-types/index.ts