### PR TITLE
remove prerender and unloaded from visibilityState

### DIFF
--- a/packages/performance/src/utils/attribute_utils.test.ts
+++ b/packages/performance/src/utils/attribute_utils.test.ts
@@ -86,15 +86,6 @@ describe('Firebase Performance > attribute_utils', () => {
       expect(getVisibilityState()).to.be.eql(VisibilityState.HIDDEN);
     });
 
-    it('returns prerender when document is prerender', () => {
-      stub(Api, 'getInstance').returns(({
-        document: {
-          visibilityState: 'prerender'
-        }
-      } as unknown) as Api);
-      expect(getVisibilityState()).to.be.eql(VisibilityState.PRERENDER);
-    });
-
     it('returns unknown when document is unknown', () => {
       stub(Api, 'getInstance').returns(({
         document: {

--- a/packages/performance/src/utils/attributes_utils.ts
+++ b/packages/performance/src/utils/attributes_utils.ts
@@ -28,8 +28,7 @@ const enum ServiceWorkerStatus {
 export enum VisibilityState {
   UNKNOWN = 0,
   VISIBLE = 1,
-  HIDDEN = 2,
-  UNLOADED = 4
+  HIDDEN = 2
 }
 
 const enum EffectiveConnectionType {

--- a/packages/performance/src/utils/attributes_utils.ts
+++ b/packages/performance/src/utils/attributes_utils.ts
@@ -29,7 +29,6 @@ export enum VisibilityState {
   UNKNOWN = 0,
   VISIBLE = 1,
   HIDDEN = 2,
-  PRERENDER = 3,
   UNLOADED = 4
 }
 
@@ -67,8 +66,6 @@ export function getVisibilityState(): VisibilityState {
       return VisibilityState.VISIBLE;
     case 'hidden':
       return VisibilityState.HIDDEN;
-    case 'prerender':
-      return VisibilityState.PRERENDER;
     default:
       return VisibilityState.UNKNOWN;
   }


### PR DESCRIPTION
`prerender` is deprecated and removed from the spec according to https://developer.mozilla.org/en-US/docs/Web/API/Document/visibilityState

Typescript has removed it from `VisibilityState` type and https://github.com/firebase/firebase-js-sdk/pull/2344 fails because of it.

This PR removes `prerender` from our own code.