### PR TITLE
rxfire: objectVal bugfix

### DIFF
--- a/packages/rxfire/database/object/index.ts
+++ b/packages/rxfire/database/object/index.ts
@@ -44,8 +44,15 @@ export function objectVal<T>(
 }
 
 export function changeToData(change: QueryChange, keyField?: string): {} {
+  const val = change.snapshot.val();
+
+  // val can be a primitive type
+  if (typeof val !== 'object') {
+    return val;
+  }
+
   return {
-    ...change.snapshot.val(),
+    ...val,
     ...(keyField ? { [keyField]: change.snapshot.key } : null)
   };
 }


### PR DESCRIPTION
Fixing a bug where RxFire's `objectVal` will return an empty object if the result of `snapshot.val()` is not an object. For example:

database data:
```json
{
    "counter": 7
}
```

code:
```js
fromRef(firebase.database().ref('counter')).pipe(value => console.log(value));
```

logs `{}` instead of the expected `7`.