### PR TITLE
Firebase: Adjust undefined import causing IDE annoyances

### DIFF
--- a/packages/firebase/empty-import.d.ts
+++ b/packages/firebase/empty-import.d.ts
@@ -15,4 +15,4 @@
  * limitations under the License.
  */
 
-export = undefined;
+export type _firebase_empty = void;

--- a/packages/firebase/empty-import.d.ts
+++ b/packages/firebase/empty-import.d.ts
@@ -15,4 +15,6 @@
  * limitations under the License.
  */
 
-export type _firebase_empty = void;
+declare namespace empty {}
+
+export = empty;


### PR DESCRIPTION
This change attempts to prevent the auto-importing of an exported `undefined` value from `firebase/empty-import`, which predominantly occurs in VS Code.

Fixes #2203 
