### PR TITLE
Reject with indexeddb errors in RemoteConfig.fetch()

### DIFF
--- a/packages/remote-config/src/remote_config.ts
+++ b/packages/remote-config/src/remote_config.ts
@@ -88,7 +88,7 @@ export class RemoteConfig implements RemoteConfigType {
     private readonly _storageCache: StorageCache,
     private readonly _storage: Storage,
     private readonly _logger: Logger
-  ) {}
+  ) { }
 
   async activate(): Promise<boolean> {
     const [lastSuccessfulFetchResponse, activeConfigEtag] = await Promise.all([
@@ -129,41 +129,38 @@ export class RemoteConfig implements RemoteConfigType {
    * {@link DEFAULT_FETCH_TIMEOUT_SECONDS}.
    */
   async fetch(): Promise<void> {
-    return new Promise(async (resolve, reject) => {
-      // Aborts the request after the given timeout, causing the fetch call to
-      // reject with an AbortError.
-      //
-      // <p>Aborting after the request completes is a no-op, so we don't need a
-      // corresponding clearTimeout.
-      //
-      // Locating abort logic here because:
-      // * it uses a developer setting (timeout)
-      // * it applies to all retries (like curl's max-time arg)
-      // * it is consistent with the Fetch API's signal input
-      const abortSignal = new RemoteConfigAbortSignal();
+    // Aborts the request after the given timeout, causing the fetch call to
+    // reject with an AbortError.
+    //
+    // <p>Aborting after the request completes is a no-op, so we don't need a
+    // corresponding clearTimeout.
+    //
+    // Locating abort logic here because:
+    // * it uses a developer setting (timeout)
+    // * it applies to all retries (like curl's max-time arg)
+    // * it is consistent with the Fetch API's signal input
+    const abortSignal = new RemoteConfigAbortSignal();
 
-      setTimeout(async () => {
-        // Note a very low delay, eg < 10ms, can elapse before listeners are initialized.
-        abortSignal.abort();
-      }, this.settings.fetchTimeoutMillis);
+    setTimeout(async () => {
+      // Note a very low delay, eg < 10ms, can elapse before listeners are initialized.
+      abortSignal.abort();
+    }, this.settings.fetchTimeoutMillis);
 
-      // Catches *all* errors thrown by client so status can be set consistently.
-      try {
-        await this._client.fetch({
-          cacheMaxAgeMillis: this.settings.minimumFetchIntervalMillis,
-          signal: abortSignal
-        });
+    // Catches *all* errors thrown by client so status can be set consistently.
+    try {
+      await this._client.fetch({
+        cacheMaxAgeMillis: this.settings.minimumFetchIntervalMillis,
+        signal: abortSignal
+      });
 
-        await this._storageCache.setLastFetchStatus('success');
-        resolve();
-      } catch (e) {
-        const lastFetchStatus = hasErrorCode(e, ErrorCode.FETCH_THROTTLE)
-          ? 'throttle'
-          : 'failure';
-        await this._storageCache.setLastFetchStatus(lastFetchStatus);
-        reject(e);
-      }
-    });
+      await this._storageCache.setLastFetchStatus('success');
+    } catch (e) {
+      const lastFetchStatus = hasErrorCode(e, ErrorCode.FETCH_THROTTLE)
+        ? 'throttle'
+        : 'failure';
+      await this._storageCache.setLastFetchStatus(lastFetchStatus);
+      throw(e);
+    }
   }
 
   async fetchAndActivate(): Promise<boolean> {
@@ -197,7 +194,7 @@ export class RemoteConfig implements RemoteConfigType {
     if (!this._isInitializationComplete) {
       this._logger.debug(
         `A value was requested for key "${key}" before SDK initialization completed.` +
-          ' Await on ensureInitialized if the intent was to get a previously activated value.'
+        ' Await on ensureInitialized if the intent was to get a previously activated value.'
       );
     }
     const activeConfig = this._storageCache.getActiveConfig();
@@ -208,7 +205,7 @@ export class RemoteConfig implements RemoteConfigType {
     }
     this._logger.debug(
       `Returning static value for key "${key}".` +
-        ' Define a default or remote value if this is unintentional.'
+      ' Define a default or remote value if this is unintentional.'
     );
     return new Value('static');
   }

--- a/packages/remote-config/src/remote_config.ts
+++ b/packages/remote-config/src/remote_config.ts
@@ -88,7 +88,7 @@ export class RemoteConfig implements RemoteConfigType {
     private readonly _storageCache: StorageCache,
     private readonly _storage: Storage,
     private readonly _logger: Logger
-  ) { }
+  ) {}
 
   async activate(): Promise<boolean> {
     const [lastSuccessfulFetchResponse, activeConfigEtag] = await Promise.all([
@@ -159,7 +159,7 @@ export class RemoteConfig implements RemoteConfigType {
         ? 'throttle'
         : 'failure';
       await this._storageCache.setLastFetchStatus(lastFetchStatus);
-      throw(e);
+      throw e;
     }
   }
 
@@ -194,7 +194,7 @@ export class RemoteConfig implements RemoteConfigType {
     if (!this._isInitializationComplete) {
       this._logger.debug(
         `A value was requested for key "${key}" before SDK initialization completed.` +
-        ' Await on ensureInitialized if the intent was to get a previously activated value.'
+          ' Await on ensureInitialized if the intent was to get a previously activated value.'
       );
     }
     const activeConfig = this._storageCache.getActiveConfig();
@@ -205,7 +205,7 @@ export class RemoteConfig implements RemoteConfigType {
     }
     this._logger.debug(
       `Returning static value for key "${key}".` +
-      ' Define a default or remote value if this is unintentional.'
+        ' Define a default or remote value if this is unintentional.'
     );
     return new Value('static');
   }


### PR DESCRIPTION
`await this._storageCache.setLastFetchStatus(lastFetchStatus);` in the catch block can fail (e.g. in envs where indexeddb is not available), but the caller can't catch it because we don't catch it and the program just throws.

Refactored the code to use `async await` directly instead of wrapping fetch inside a Promise callback, so all errors will be caught and rejected properly. 

An alternative considered is to `try catch` in the `catch` block, then `reject`, but it makes the code more complicated and less readable.

It fixes https://github.com/firebase/firebase-js-sdk/issues/2373#issuecomment-558017676.