### PR TITLE
LimitToLast: back port some changes from android

### DIFF
--- a/packages/firestore/src/core/query.ts
+++ b/packages/firestore/src/core/query.ts
@@ -48,7 +48,7 @@ export class Query {
   private memoizedOrderBy: OrderBy[] | null = null;
 
   // The corresponding `Target` of this `Query` instance.
-  private memorizedTarget: Target | null = null;
+  private memoizedTarget: Target | null = null;
 
   /**
    * Initializes a Query with a path and optional additional query constraints.
@@ -343,9 +343,9 @@ export class Query {
    * representation.
    */
   toTarget(): Target {
-    if (!this.memorizedTarget) {
+    if (!this.memoizedTarget) {
       if (this.limitType === LimitType.First) {
-        this.memorizedTarget = new Target(
+        this.memoizedTarget = new Target(
           this.path,
           this.collectionGroup,
           this.orderBy,
@@ -374,7 +374,7 @@ export class Query {
           : null;
 
         // Now return as a LimitType.First query.
-        this.memorizedTarget = new Target(
+        this.memoizedTarget = new Target(
           this.path,
           this.collectionGroup,
           orderBys,
@@ -385,7 +385,7 @@ export class Query {
         );
       }
     }
-    return this.memorizedTarget!;
+    return this.memoizedTarget!;
   }
 
   private matchesPathAndCollectionGroup(doc: Document): boolean {

--- a/packages/firestore/src/local/local_store.ts
+++ b/packages/firestore/src/local/local_store.ts
@@ -890,7 +890,10 @@ export class LocalStore {
     keepPersistedTargetData: boolean
   ): Promise<void> {
     const targetData = this.targetDataByTarget.get(targetId);
-    assert(targetData !== null, `Tried to release nonexistent target: ${targetId}`);
+    assert(
+      targetData !== null,
+      `Tried to release nonexistent target: ${targetId}`
+    );
 
     const mode = keepPersistedTargetData
       ? 'readwrite-idempotent'

--- a/packages/firestore/src/local/local_store.ts
+++ b/packages/firestore/src/local/local_store.ts
@@ -890,9 +890,7 @@ export class LocalStore {
     keepPersistedTargetData: boolean
   ): Promise<void> {
     const targetData = this.targetDataByTarget.get(targetId);
-    if (!targetData) {
-      return Promise.resolve();
-    }
+    assert(targetData !== null, `Tried to release nonexistent target: ${targetId}`);
 
     const mode = keepPersistedTargetData
       ? 'readwrite-idempotent'
@@ -917,7 +915,7 @@ export class LocalStore {
           return PersistencePromise.forEach(removed, (key: DocumentKey) =>
             this.persistence.referenceDelegate.removeReference(txn, key)
           ).next(() => {
-            this.persistence.referenceDelegate.removeTarget(txn, targetData);
+            this.persistence.referenceDelegate.removeTarget(txn, targetData!);
           });
         } else {
           return PersistencePromise.resolve();
@@ -925,7 +923,7 @@ export class LocalStore {
       })
       .then(() => {
         this.targetDataByTarget = this.targetDataByTarget.remove(targetId);
-        this.targetIdByTarget.delete(targetData.target);
+        this.targetIdByTarget.delete(targetData!.target);
       });
   }
 

--- a/packages/firestore/src/remote/remote_event.ts
+++ b/packages/firestore/src/remote/remote_event.ts
@@ -127,11 +127,12 @@ export class TargetChange {
 
   /**
    * HACK: Views require TargetChanges in order to determine whether the view is
-   * CURRENT, but secondary tabs don't receive remote events. So this method is
-   * used to create a synthesized TargetChanges that can be used to apply a
-   * CURRENT status change to a View, for queries executed in a different tab.
+   * CURRENT, but secondary tabs or new queries mapped to an active target don't
+   * receive remote events (yet). So this method is used to create a synthesized
+   * TargetChanges that can be used to apply a CURRENT status change to a View,
+   * for queries executed in a different tab, or for the new queries to raise
+   * snapshots with correct CURRENT status.
    */
-  // PORTING NOTE: Multi-tab only
   static createSynthesizedTargetChangeForCurrentChange(
     targetId: TargetId,
     current: boolean

--- a/packages/firestore/src/remote/remote_event.ts
+++ b/packages/firestore/src/remote/remote_event.ts
@@ -126,12 +126,9 @@ export class TargetChange {
   ) {}
 
   /**
-   * HACK: Views require TargetChanges in order to determine whether the view is
-   * CURRENT, but secondary tabs or new queries mapped to an active target don't
-   * receive remote events (yet). So this method is used to create a synthesized
-   * TargetChanges that can be used to apply a CURRENT status change to a View,
-   * for queries executed in a different tab, or for the new queries to raise
-   * snapshots with correct CURRENT status.
+   * This method is used to create a synthesized TargetChanges that can be used to
+   * apply a CURRENT status change to a View (for queries executed in a different
+   * tab) or for new queries (to raise snapshots with correct CURRENT status).
    */
   static createSynthesizedTargetChangeForCurrentChange(
     targetId: TargetId,

--- a/packages/firestore/src/remote/remote_store.ts
+++ b/packages/firestore/src/remote/remote_store.ts
@@ -263,8 +263,10 @@ export class RemoteStore implements TargetMetadataProvider {
    * not being listened to.
    */
   unlisten(targetId: TargetId): void {
-    assert(objUtils.contains(this.listenTargets, targetId),
-        `unlisten called on target no currently watched: ${targetId}`);
+    assert(
+      objUtils.contains(this.listenTargets, targetId),
+      `unlisten called on target no currently watched: ${targetId}`
+    );
 
     delete this.listenTargets[targetId];
     if (this.watchStream.isOpen()) {

--- a/packages/firestore/src/remote/remote_store.ts
+++ b/packages/firestore/src/remote/remote_store.ts
@@ -263,9 +263,8 @@ export class RemoteStore implements TargetMetadataProvider {
    * not being listened to.
    */
   unlisten(targetId: TargetId): void {
-    if (!objUtils.contains(this.listenTargets, targetId)) {
-      return;
-    }
+    assert(objUtils.contains(this.listenTargets, targetId),
+        `unlisten called on target no currently watched: ${targetId}`);
 
     delete this.listenTargets[targetId];
     if (this.watchStream.isOpen()) {


### PR DESCRIPTION
* s/memorized/memoized
* Disallow double-unlisten (remote store) and double-releasing (local store)
* Consolidate duplicated integration tests
* Mark synthesizeTargetChange as non-multitab