### PR TITLE
Modify onSnapshot arguments

### DIFF
--- a/packages/rxfire/firestore/fromRef.ts
+++ b/packages/rxfire/firestore/fromRef.ts
@@ -25,7 +25,13 @@ function _fromRef(
 ): Observable<any> {
   /* eslint-enable @typescript-eslint/no-explicit-any */
   return new Observable(subscriber => {
-    const unsubscribe = ref.onSnapshot(options || {}, subscriber);
+    const unsubscribe = ref.onSnapshot(options || {
+      includeMetadataChanges: false
+    }, {
+      next: subscriber.next.bind(subscriber),
+      error: subscriber.error.bind(subscriber),
+      complete: subscriber.complete.bind(subscriber),
+    });
     return { unsubscribe };
   });
 }


### PR DESCRIPTION
  * Issue: https://github.com/firebase/firebase-js-sdk/issues/2383
  * There are two issues which are resolved by the PR:
    1. React Native Firebase could not handle empty options in `onSnapshot()`
    2. The `next`, `error` and `complete` callbacks lost the context of `this` and cause error when RNFirebase calls `next()`

### Testing

  * RxFire tests passed

