### PR TITLE
Don't use "long" in Proto types

### DIFF
--- a/packages/firestore/src/protos/firestore_proto_api.d.ts
+++ b/packages/firestore/src/protos/firestore_proto_api.d.ts
@@ -363,7 +363,7 @@ export declare namespace firestoreV1ApiClientInterfaces {
     booleanValue?: boolean;
     integerValue?: string;
     doubleValue?: number;
-    timestampValue?: string | { seconds: long; nanos: long };
+    timestampValue?: string | { seconds: string; nanos: number };
     stringValue?: string;
     bytesValue?: string | Uint8Array;
     referenceValue?: string;


### PR DESCRIPTION
"long" is not defined and throws a diagnostic error:

Error: TypeScript Diagnostic Error : ../../firebase/firebase-js-sdk/packages/firestore/src/protos/firestore_proto_api.d.ts(366,42): error TS2304: Cannot find name 'long'.