### PR TITLE
Recognize and return TENANT_ID_MISMATCH error code

### DIFF
--- a/packages/auth/src/rpchandler.js
+++ b/packages/auth/src/rpchandler.js
@@ -2511,6 +2511,8 @@ fireauth.RpcHandler.getDeveloperError_ =
       fireauth.authenum.Error.UNSUPPORTED_TENANT_OPERATION;
   errorMap[fireauth.RpcHandler.ServerError.INVALID_TENANT_ID] =
       fireauth.authenum.Error.INVALID_TENANT_ID;
+  errorMap[fireauth.RpcHandler.ServerError.TENANT_ID_MISMATCH] =
+      fireauth.authenum.Error.TENANT_ID_MISMATCH;
 
   // User actions (sign-up or deletion) disabled errors.
   errorMap[fireauth.RpcHandler.ServerError.ADMIN_ONLY_OPERATION] =

--- a/packages/auth/test/rpchandler_test.js
+++ b/packages/auth/test/rpchandler_test.js
@@ -2436,6 +2436,8 @@ function testVerifyCustomToken_serverCaughtError() {
       fireauth.authenum.Error.CREDENTIAL_MISMATCH;
   errorMap[fireauth.RpcHandler.ServerError.INVALID_TENANT_ID] =
       fireauth.authenum.Error.INVALID_TENANT_ID;
+  errorMap[fireauth.RpcHandler.ServerError.TENANT_ID_MISMATCH] =
+      fireauth.authenum.Error.TENANT_ID_MISMATCH;
 
   assertServerErrorsAreHandled(function() {
     return rpcHandler.verifyCustomToken(token);


### PR DESCRIPTION
Error was already present, but wasn't wired in.