### PR TITLE
Update auth.md

### DIFF
--- a/packages/rxfire/docs/auth.md
+++ b/packages/rxfire/docs/auth.md
@@ -62,7 +62,7 @@ The `idToken()` function creates an observable that emits the `idToken` refreshe
 | **function**    | `idToken()`                                 |
 | **params**      | `auth.Auth`                              |
 | **import path** | `rxfire/auth`                            |
-| **return**      | `Observable<string or null>`              |
+| **return**      | `Observable<string\|null>`              |
 
 #### TypeScript Example
 ```ts

--- a/packages/rxfire/docs/auth.md
+++ b/packages/rxfire/docs/auth.md
@@ -62,7 +62,7 @@ The `idToken()` function creates an observable that emits the `idToken` refreshe
 | **function**    | `idToken()`                                 |
 | **params**      | `auth.Auth`                              |
 | **import path** | `rxfire/auth`                            |
-| **return**      | `Observable<string | null>`              |
+| **return**      | `Observable<string or null>`              |
 
 #### TypeScript Example
 ```ts


### PR DESCRIPTION
The return value of the idToken() had a breaking style change for how markdown works as the "|" symbol cut off the rest of the line as Markdown thinks that | was closing the table.