### PR TITLE
Tighten the typing in the Firebase Performance package

### DIFF
--- a/packages/performance/src/services/api_service.ts
+++ b/packages/performance/src/services/api_service.ts
@@ -15,20 +15,25 @@
  * limitations under the License.
  */
 
-import {ERROR_FACTORY, ErrorCode} from '../utils/errors';
+import { ERROR_FACTORY, ErrorCode } from '../utils/errors';
 
 declare global {
   interface Window {
     PerformanceObserver: typeof PerformanceObserver;
-    perfMetrics?: {onFirstInputDelay: Function};
+    perfMetrics?: { onFirstInputDelay: Function };
   }
 }
 
-let apiInstance: Api|undefined;
-let windowInstance: Window|undefined;
+let apiInstance: Api | undefined;
+let windowInstance: Window | undefined;
 
 export type EntryType =
-    |'mark'|'measure'|'paint'|'resource'|'frame'|'navigation';
+  | 'mark'
+  | 'measure'
+  | 'paint'
+  | 'resource'
+  | 'frame'
+  | 'navigation';
 
 /**
  * This class holds a reference to various browser related objects injected by
@@ -99,9 +104,9 @@ export class Api {
   getTimeOrigin(): number {
     // Polyfill the time origin with performance.timing.navigationStart.
     return (
-        this.performance &&
-        (this.performance.timeOrigin ||
-         this.performance.timing.navigationStart));
+      this.performance &&
+      (this.performance.timeOrigin || this.performance.timing.navigationStart)
+    );
   }
 
   requiredApisAvailable(): boolean {
@@ -112,7 +117,9 @@ export class Api {
   }
 
   setupObserver(
-      entryType: EntryType, callback: (entry: PerformanceEntry) => void): void {
+    entryType: EntryType,
+    callback: (entry: PerformanceEntry) => void
+  ): void {
     if (!this.PerformanceObserver) {
       return;
     }
@@ -124,7 +131,7 @@ export class Api {
     });
 
     // Start observing the entry types you care about.
-    observer.observe({entryTypes: [entryType]});
+    observer.observe({ entryTypes: [entryType] });
   }
 
   static getInstance(): Api {

--- a/packages/performance/src/services/api_service.ts
+++ b/packages/performance/src/services/api_service.ts
@@ -15,40 +15,36 @@
  * limitations under the License.
  */
 
-import { ERROR_FACTORY, ErrorCode } from '../utils/errors';
+import {ERROR_FACTORY, ErrorCode} from '../utils/errors';
 
 declare global {
   interface Window {
     PerformanceObserver: typeof PerformanceObserver;
-    perfMetrics?: { onFirstInputDelay: Function };
+    perfMetrics?: {onFirstInputDelay: Function};
   }
 }
 
-let apiInstance: Api | undefined;
-let windowInstance: Window | undefined;
+let apiInstance: Api|undefined;
+let windowInstance: Window|undefined;
 
 export type EntryType =
-  | 'mark'
-  | 'measure'
-  | 'paint'
-  | 'resource'
-  | 'frame'
-  | 'navigation';
+    |'mark'|'measure'|'paint'|'resource'|'frame'|'navigation';
 
 /**
- * This class holds a reference to various browser related objects injected by set methods.
+ * This class holds a reference to various browser related objects injected by
+ * set methods.
  */
 export class Api {
-  private performance: Performance;
+  private readonly performance: Performance;
   /** PreformanceObserver constructor function. */
-  private PerformanceObserver: typeof PerformanceObserver;
-  private windowLocation: Location;
-  onFirstInputDelay?: Function;
-  localStorage!: Storage;
-  document: Document;
-  navigator: Navigator;
+  private readonly PerformanceObserver: typeof PerformanceObserver;
+  private readonly windowLocation: Location;
+  readonly onFirstInputDelay?: Function;
+  readonly localStorage?: Storage;
+  readonly document: Document;
+  readonly navigator: Navigator;
 
-  constructor(window?: Window) {
+  constructor(readonly window?: Window) {
     if (!window) {
       throw ERROR_FACTORY.create(ErrorCode.NO_WINDOW);
     }
@@ -58,7 +54,8 @@ export class Api {
     this.navigator = window.navigator;
     this.document = window.document;
     if (this.navigator && this.navigator.cookieEnabled) {
-      // If user blocks cookies on the browser, accessing localStorage will throw an exception.
+      // If user blocks cookies on the browser, accessing localStorage will
+      // throw an exception.
       this.localStorage = window.localStorage;
     }
     if (window.perfMetrics && window.perfMetrics.onFirstInputDelay) {
@@ -102,9 +99,9 @@ export class Api {
   getTimeOrigin(): number {
     // Polyfill the time origin with performance.timing.navigationStart.
     return (
-      this.performance &&
-      (this.performance.timeOrigin || this.performance.timing.navigationStart)
-    );
+        this.performance &&
+        (this.performance.timeOrigin ||
+         this.performance.timing.navigationStart));
   }
 
   requiredApisAvailable(): boolean {
@@ -115,9 +112,7 @@ export class Api {
   }
 
   setupObserver(
-    entryType: EntryType,
-    callback: (entry: PerformanceEntry) => void
-  ): void {
+      entryType: EntryType, callback: (entry: PerformanceEntry) => void): void {
     if (!this.PerformanceObserver) {
       return;
     }
@@ -129,7 +124,7 @@ export class Api {
     });
 
     // Start observing the entry types you care about.
-    observer.observe({ entryTypes: [entryType] });
+    observer.observe({entryTypes: [entryType]});
   }
 
   static getInstance(): Api {

--- a/packages/performance/src/services/remote_config_service.ts
+++ b/packages/performance/src/services/remote_config_service.ts
@@ -15,13 +15,17 @@
  * limitations under the License.
  */
 
-import {CONFIG_EXPIRY_LOCAL_STORAGE_KEY, CONFIG_LOCAL_STORAGE_KEY, SDK_VERSION} from '../constants';
-import {consoleLogger} from '../utils/console_logger';
-import {ERROR_FACTORY, ErrorCode} from '../utils/errors';
+import {
+  CONFIG_EXPIRY_LOCAL_STORAGE_KEY,
+  CONFIG_LOCAL_STORAGE_KEY,
+  SDK_VERSION
+} from '../constants';
+import { consoleLogger } from '../utils/console_logger';
+import { ERROR_FACTORY, ErrorCode } from '../utils/errors';
 
-import {Api} from './api_service';
-import {getAuthTokenPromise} from './iid_service';
-import {SettingsService} from './settings_service';
+import { Api } from './api_service';
+import { getAuthTokenPromise } from './iid_service';
+import { SettingsService } from './settings_service';
 
 const REMOTE_CONFIG_SDK_VERSION = '0.0.1';
 
@@ -65,14 +69,15 @@ export function getConfig(iid: string): Promise<void> {
   }
 
   return getRemoteConfig(iid)
-      .then(config => processConfig(config))
-      .then(
-          config => storeConfig(config),
-          /** Do nothing for error, use defaults set in settings service. */
-          () => {});
+    .then(config => processConfig(config))
+    .then(
+      config => storeConfig(config),
+      /** Do nothing for error, use defaults set in settings service. */
+      () => {}
+    );
 }
 
-function getStoredConfig(): RemoteConfigResponse|undefined {
+function getStoredConfig(): RemoteConfigResponse | undefined {
   const localStorage = Api.getInstance().localStorage;
   if (!localStorage) {
     return;
@@ -94,7 +99,7 @@ function getStoredConfig(): RemoteConfigResponse|undefined {
   }
 }
 
-function storeConfig(config: RemoteConfigResponse|undefined): void {
+function storeConfig(config: RemoteConfigResponse | undefined): void {
   const localStorage = Api.getInstance().localStorage;
   if (!config || !localStorage) {
     return;
@@ -102,49 +107,50 @@ function storeConfig(config: RemoteConfigResponse|undefined): void {
 
   localStorage.setItem(CONFIG_LOCAL_STORAGE_KEY, JSON.stringify(config));
   localStorage.setItem(
-      CONFIG_EXPIRY_LOCAL_STORAGE_KEY,
-      String(
-          Date.now() +
-          SettingsService.getInstance().configTimeToLive * 60 * 60 * 1000));
+    CONFIG_EXPIRY_LOCAL_STORAGE_KEY,
+    String(
+      Date.now() +
+        SettingsService.getInstance().configTimeToLive * 60 * 60 * 1000
+    )
+  );
 }
 
 const COULD_NOT_GET_CONFIG_MSG =
-    'Could not fetch config, will use default configs';
+  'Could not fetch config, will use default configs';
 
-function getRemoteConfig(iid: string): Promise<RemoteConfigResponse|undefined> {
+function getRemoteConfig(
+  iid: string
+): Promise<RemoteConfigResponse | undefined> {
   // Perf needs auth token only to retrieve remote config.
   return getAuthTokenPromise()
-      .then(authToken => {
-        const projectId = SettingsService.getInstance().getProjectId();
-        const configEndPoint =
-            `https://firebaseremoteconfig.googleapis.com/v1/projects/${
-                projectId}/namespaces/fireperf:fetch?key=${
-                SettingsService.getInstance().getApiKey()}`;
-        const request = new Request(configEndPoint, {
-          method: 'POST',
-          headers: {Authorization: `${FIS_AUTH_PREFIX} ${authToken}`},
-          /* eslint-disable camelcase */
-          body: JSON.stringify({
-            app_instance_id: iid,
-            app_instance_id_token: authToken,
-            app_id: SettingsService.getInstance().getAppId(),
-            app_version: SDK_VERSION,
-            sdk_version: REMOTE_CONFIG_SDK_VERSION
-          })
-          /* eslint-enable camelcase */
-        });
-        return fetch(request).then(response => {
-          if (response.ok) {
-            return response.json() as RemoteConfigResponse;
-          }
-          // In case response is not ok. This will be caught by catch.
-          throw ERROR_FACTORY.create(ErrorCode.RC_NOT_OK);
-        });
-      })
-      .catch(() => {
-        consoleLogger.info(COULD_NOT_GET_CONFIG_MSG);
-        return undefined;
+    .then(authToken => {
+      const projectId = SettingsService.getInstance().getProjectId();
+      const configEndPoint = `https://firebaseremoteconfig.googleapis.com/v1/projects/${projectId}/namespaces/fireperf:fetch?key=${SettingsService.getInstance().getApiKey()}`;
+      const request = new Request(configEndPoint, {
+        method: 'POST',
+        headers: { Authorization: `${FIS_AUTH_PREFIX} ${authToken}` },
+        /* eslint-disable camelcase */
+        body: JSON.stringify({
+          app_instance_id: iid,
+          app_instance_id_token: authToken,
+          app_id: SettingsService.getInstance().getAppId(),
+          app_version: SDK_VERSION,
+          sdk_version: REMOTE_CONFIG_SDK_VERSION
+        })
+        /* eslint-enable camelcase */
       });
+      return fetch(request).then(response => {
+        if (response.ok) {
+          return response.json() as RemoteConfigResponse;
+        }
+        // In case response is not ok. This will be caught by catch.
+        throw ERROR_FACTORY.create(ErrorCode.RC_NOT_OK);
+      });
+    })
+    .catch(() => {
+      consoleLogger.info(COULD_NOT_GET_CONFIG_MSG);
+      return undefined;
+    });
 }
 
 /**
@@ -152,8 +158,9 @@ function getRemoteConfig(iid: string): Promise<RemoteConfigResponse|undefined> {
  * This method only runs if call is successful or config in storage
  * is valie.
  */
-function processConfig(config: RemoteConfigResponse|
-                       undefined): RemoteConfigResponse|undefined {
+function processConfig(
+  config: RemoteConfigResponse | undefined
+): RemoteConfigResponse | undefined {
   if (!config) {
     return config;
   }
@@ -163,7 +170,7 @@ function processConfig(config: RemoteConfigResponse|
     // TODO: Change the assignment of loggingEnabled once the received type is
     // known.
     settingsServiceInstance.loggingEnabled =
-        String(entries.fpr_enabled) === 'true';
+      String(entries.fpr_enabled) === 'true';
   } else if (SECONDARY_CONFIGS.loggingEnabled !== undefined) {
     // Config retrieved successfully, but there is no fpr_enabled in template.
     // Use secondary configs value.
@@ -180,24 +187,28 @@ function processConfig(config: RemoteConfigResponse|
     settingsServiceInstance.logEndPointUrl = SECONDARY_CONFIGS.logEndPointUrl;
   }
   if (entries.fpr_vc_network_request_sampling_rate !== undefined) {
-    settingsServiceInstance.networkRequestsSamplingRate =
-        Number(entries.fpr_vc_network_request_sampling_rate);
+    settingsServiceInstance.networkRequestsSamplingRate = Number(
+      entries.fpr_vc_network_request_sampling_rate
+    );
   } else if (SECONDARY_CONFIGS.networkRequestsSamplingRate !== undefined) {
     settingsServiceInstance.networkRequestsSamplingRate =
-        SECONDARY_CONFIGS.networkRequestsSamplingRate;
+      SECONDARY_CONFIGS.networkRequestsSamplingRate;
   }
   if (entries.fpr_vc_trace_sampling_rate !== undefined) {
-    settingsServiceInstance.tracesSamplingRate =
-        Number(entries.fpr_vc_trace_sampling_rate);
+    settingsServiceInstance.tracesSamplingRate = Number(
+      entries.fpr_vc_trace_sampling_rate
+    );
   } else if (SECONDARY_CONFIGS.tracesSamplingRate !== undefined) {
     settingsServiceInstance.tracesSamplingRate =
-        SECONDARY_CONFIGS.tracesSamplingRate;
+      SECONDARY_CONFIGS.tracesSamplingRate;
   }
   // Set the per session trace and network logging flags.
-  settingsServiceInstance.logTraceAfterSampling =
-      shouldLogAfterSampling(settingsServiceInstance.tracesSamplingRate);
+  settingsServiceInstance.logTraceAfterSampling = shouldLogAfterSampling(
+    settingsServiceInstance.tracesSamplingRate
+  );
   settingsServiceInstance.logNetworkAfterSampling = shouldLogAfterSampling(
-      settingsServiceInstance.networkRequestsSamplingRate);
+    settingsServiceInstance.networkRequestsSamplingRate
+  );
   return config;
 }
 

--- a/packages/performance/src/utils/attributes_utils.ts
+++ b/packages/performance/src/utils/attributes_utils.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { Api } from '../services/api_service';
+import {Api} from '../services/api_service';
 
 // The values and orders of the following enums should not be changed.
 const enum ServiceWorkerStatus {
@@ -37,6 +37,20 @@ const enum EffectiveConnectionType {
   CONNECTION_2G = 2,
   CONNECTION_3G = 3,
   CONNECTION_4G = 4
+}
+
+
+/**
+ * NetworkInformation
+ *
+ * ref: https://developer.mozilla.org/en-US/docs/Web/API/NetworkInformation
+ */
+interface NetworkInformation {
+  readonly effectiveType?: 'slow-2g'|'2g'|'3g'|'4g';
+}
+
+interface NavigatorWithConnection extends Navigator {
+  readonly connection: NetworkInformation;
 }
 
 const RESERVED_ATTRIBUTE_PREFIXES = ['firebase_', 'google_', 'ga_'];
@@ -72,10 +86,9 @@ export function getVisibilityState(): VisibilityState {
 
 export function getEffectiveConnectionType(): EffectiveConnectionType {
   const navigator = Api.getInstance().navigator;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const navigatorConnection = (navigator as any).connection;
+  const navigatorConnection = (navigator as NavigatorWithConnection).connection;
   const effectiveType =
-    navigatorConnection && navigatorConnection.effectiveType;
+      navigatorConnection && navigatorConnection.effectiveType;
   switch (effectiveType) {
     case 'slow-2g':
       return EffectiveConnectionType.CONNECTION_SLOW_2G;
@@ -94,9 +107,8 @@ export function isValidCustomAttributeName(name: string): boolean {
   if (name.length === 0 || name.length > MAX_ATTRIBUTE_NAME_LENGTH) {
     return false;
   }
-  const matchesReservedPrefix = RESERVED_ATTRIBUTE_PREFIXES.some(prefix =>
-    name.startsWith(prefix)
-  );
+  const matchesReservedPrefix =
+      RESERVED_ATTRIBUTE_PREFIXES.some(prefix => name.startsWith(prefix));
   return !matchesReservedPrefix && !!name.match(ATTRIBUTE_FORMAT_REGEX);
 }
 

--- a/packages/performance/src/utils/attributes_utils.ts
+++ b/packages/performance/src/utils/attributes_utils.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import {Api} from '../services/api_service';
+import { Api } from '../services/api_service';
 
 // The values and orders of the following enums should not be changed.
 const enum ServiceWorkerStatus {
@@ -39,14 +39,13 @@ const enum EffectiveConnectionType {
   CONNECTION_4G = 4
 }
 
-
 /**
  * NetworkInformation
  *
  * ref: https://developer.mozilla.org/en-US/docs/Web/API/NetworkInformation
  */
 interface NetworkInformation {
-  readonly effectiveType?: 'slow-2g'|'2g'|'3g'|'4g';
+  readonly effectiveType?: 'slow-2g' | '2g' | '3g' | '4g';
 }
 
 interface NavigatorWithConnection extends Navigator {
@@ -88,7 +87,7 @@ export function getEffectiveConnectionType(): EffectiveConnectionType {
   const navigator = Api.getInstance().navigator;
   const navigatorConnection = (navigator as NavigatorWithConnection).connection;
   const effectiveType =
-      navigatorConnection && navigatorConnection.effectiveType;
+    navigatorConnection && navigatorConnection.effectiveType;
   switch (effectiveType) {
     case 'slow-2g':
       return EffectiveConnectionType.CONNECTION_SLOW_2G;
@@ -107,8 +106,9 @@ export function isValidCustomAttributeName(name: string): boolean {
   if (name.length === 0 || name.length > MAX_ATTRIBUTE_NAME_LENGTH) {
     return false;
   }
-  const matchesReservedPrefix =
-      RESERVED_ATTRIBUTE_PREFIXES.some(prefix => name.startsWith(prefix));
+  const matchesReservedPrefix = RESERVED_ATTRIBUTE_PREFIXES.some(prefix =>
+    name.startsWith(prefix)
+  );
   return !matchesReservedPrefix && !!name.match(ATTRIBUTE_FORMAT_REGEX);
 }
 


### PR DESCRIPTION
- Remove usage of 'any' for accessing navigator.connection -- prefer a defined interface.
- Make fields in the `ApiService` readonly where possible
- Remove the assertion operator on `ApiService.localStorage` and truly declare it as optional; Update downstream usage to reflect this.