### PR TITLE
Small assorted fixes for better property name mangling support

### DIFF
--- a/packages/firestore/src/api/credentials.ts
+++ b/packages/firestore/src/api/credentials.ts
@@ -63,7 +63,9 @@ export class OAuthToken implements Token {
   type = 'OAuth' as TokenType;
   authHeaders: { [header: string]: string };
   constructor(value: string, public user: User) {
-    this.authHeaders = { Authorization: `Bearer ${value}` };
+    this.authHeaders = {};
+    // Set the headers using Object Literal notation to avoid minification
+    this.authHeaders['Authorization'] = `Bearer ${value}`;
   }
 }
 

--- a/packages/firestore/src/local/indexeddb_index_manager.ts
+++ b/packages/firestore/src/local/indexeddb_index_manager.ts
@@ -62,7 +62,7 @@ export class IndexedDbIndexManager implements IndexManager {
         this.collectionParentsCache.add(collectionPath);
       });
 
-      const collectionParent : DbCollectionParent = {
+      const collectionParent: DbCollectionParent = {
         collectionId,
         parent: encode(parentPath)
       };

--- a/packages/firestore/src/local/indexeddb_index_manager.ts
+++ b/packages/firestore/src/local/indexeddb_index_manager.ts
@@ -62,10 +62,11 @@ export class IndexedDbIndexManager implements IndexManager {
         this.collectionParentsCache.add(collectionPath);
       });
 
-      return collectionParentsStore(transaction).put({
+      const collectionParent : DbCollectionParent = {
         collectionId,
         parent: encode(parentPath)
-      });
+      };
+      return collectionParentsStore(transaction).put(collectionParent);
     }
     return PersistencePromise.resolve();
   }

--- a/packages/firestore/src/model/field_value.ts
+++ b/packages/firestore/src/model/field_value.ts
@@ -518,8 +518,8 @@ export class ObjectValue extends FieldValue {
       const it1 = this.internalValue.getIterator();
       const it2 = other.internalValue.getIterator();
       while (it1.hasNext() && it2.hasNext()) {
-        const next1: { key: string; value: FieldValue } = it1.getNext();
-        const next2: { key: string; value: FieldValue } = it2.getNext();
+        const next1 = it1.getNext();
+        const next2 = it2.getNext();
         if (next1.key !== next2.key || !next1.value.isEqual(next2.value)) {
           return false;
         }

--- a/packages/firestore/src/platform_browser/webchannel_connection.ts
+++ b/packages/firestore/src/platform_browser/webchannel_connection.ts
@@ -48,13 +48,13 @@ const LOG_TAG = 'Connection';
 const RPC_STREAM_SERVICE = 'google.firestore.v1.Firestore';
 const RPC_URL_VERSION = 'v1';
 
-/** 
- * Maps RPC names to the corresponding REST endpoint name. 
+/**
+ * Maps RPC names to the corresponding REST endpoint name.
  * Uses Object Literal notation to avoid renaming.
  */
 const RPC_NAME_REST_MAPPING: { [key: string]: string } = {};
-RPC_NAME_REST_MAPPING['BatchGetDocuments'] =  'batchGet';
-RPC_NAME_REST_MAPPING['Commit'] =  'commit';
+RPC_NAME_REST_MAPPING['BatchGetDocuments'] = 'batchGet';
+RPC_NAME_REST_MAPPING['Commit'] = 'commit';
 
 // TODO(b/38203344): The SDK_VERSION is set independently from Firebase because
 // we are doing out-of-band releases. Once we release as part of Firebase, we

--- a/packages/firestore/src/platform_browser/webchannel_connection.ts
+++ b/packages/firestore/src/platform_browser/webchannel_connection.ts
@@ -48,11 +48,13 @@ const LOG_TAG = 'Connection';
 const RPC_STREAM_SERVICE = 'google.firestore.v1.Firestore';
 const RPC_URL_VERSION = 'v1';
 
-/** Maps RPC names to the corresponding REST endpoint name. */
-const RPC_NAME_REST_MAPPING: { [key: string]: string } = {
-  BatchGetDocuments: 'batchGet',
-  Commit: 'commit'
-};
+/** 
+ * Maps RPC names to the corresponding REST endpoint name. 
+ * Uses Object Literal notation to avoid renaming.
+ */
+const RPC_NAME_REST_MAPPING: { [key: string]: string } = {};
+RPC_NAME_REST_MAPPING['BatchGetDocuments'] =  'batchGet';
+RPC_NAME_REST_MAPPING['Commit'] =  'commit';
 
 // TODO(b/38203344): The SDK_VERSION is set independently from Firebase because
 // we are doing out-of-band releases. Once we release as part of Firebase, we

--- a/packages/firestore/src/util/async_queue.ts
+++ b/packages/firestore/src/util/async_queue.ts
@@ -283,7 +283,7 @@ export class AsyncQueue {
     const newTail = this.tail.then(() => {
       this.operationInProgress = true;
       return op()
-        .catch(error => {
+        .catch((error:FirestoreError) => {
           this.failure = error;
           this.operationInProgress = false;
           const message = error.stack || error.message || '';

--- a/packages/firestore/src/util/async_queue.ts
+++ b/packages/firestore/src/util/async_queue.ts
@@ -283,7 +283,7 @@ export class AsyncQueue {
     const newTail = this.tail.then(() => {
       this.operationInProgress = true;
       return op()
-        .catch((error:FirestoreError) => {
+        .catch((error: FirestoreError) => {
           this.failure = error;
           this.operationInProgress = false;
           const message = error.stack || error.message || '';


### PR DESCRIPTION
I am sure there are more to come... but most of the explicit return type assignments that I had earlier might not be needed anymore (https://github.com/FirebasePrivate/sdk-minifier/pull/2)