### PR TITLE
Check for process.env in isMockPersistence

### DIFF
--- a/packages/firestore/src/local/simple_db.ts
+++ b/packages/firestore/src/local/simple_db.ts
@@ -209,6 +209,7 @@ export class SimpleDb {
   static isMockPersistence(): boolean {
     return (
       typeof process !== 'undefined' &&
+      typeof process.env !== 'undefined' &&
       process.env.USE_MOCK_PERSISTENCE === 'YES'
     );
   }

--- a/packages/firestore/src/local/simple_db.ts
+++ b/packages/firestore/src/local/simple_db.ts
@@ -207,11 +207,7 @@ export class SimpleDb {
    * (see https://github.com/axemclion/IndexedDBShim).
    */
   static isMockPersistence(): boolean {
-    return (
-      typeof process !== 'undefined' &&
-      typeof process.env !== 'undefined' &&
-      process.env.USE_MOCK_PERSISTENCE === 'YES'
-    );
+    return process?.env?.USE_MOCK_PERSISTENCE === 'YES';
   }
 
   /** Helper to get a typed SimpleDbStore from a transaction. */

--- a/packages/firestore/src/local/simple_db.ts
+++ b/packages/firestore/src/local/simple_db.ts
@@ -207,7 +207,10 @@ export class SimpleDb {
    * (see https://github.com/axemclion/IndexedDBShim).
    */
   static isMockPersistence(): boolean {
-    return process?.env?.USE_MOCK_PERSISTENCE === 'YES';
+    return (
+      typeof process !== 'undefined' &&
+      process.env?.USE_MOCK_PERSISTENCE === 'YES'
+    );
   }
 
   /** Helper to get a typed SimpleDbStore from a transaction. */

--- a/packages/firestore/test/util/test_platform.ts
+++ b/packages/firestore/test/util/test_platform.ts
@@ -45,7 +45,8 @@ export class FakeWindow {
     });
     this.fakeIndexedDb =
       fakeIndexedDb ||
-      (typeof window !== 'undefined' && window.indexedDB) || null;
+      (typeof window !== 'undefined' && window.indexedDB) ||
+      null;
   }
 
   get localStorage(): Storage {


### PR DESCRIPTION
Fixes #2404. 

In this particular instance, the user's `process` variable was defined, but `process.env` was not defined, which triggered an error when checking for `process.env.USE_MOCK_PERSISTENCE`. 
