### PR TITLE
Fix VS Code launch.json to look for mocha/karma in right location.

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -68,7 +68,7 @@
       "type": "node",
       "request": "launch",
       "name": "Firestore Integration Tests (Node)",
-      "program": "${workspaceRoot}/packages/firestore/node_modules/.bin/_mocha",
+      "program": "${workspaceRoot}/node_modules/.bin/_mocha",
       "cwd": "${workspaceRoot}/packages/firestore",
       "args": [
         "--require", "ts-node/register/type-check",
@@ -90,7 +90,7 @@
       "type": "node",
       "request": "launch",
       "name": "Firestore Integration Tests (Node / Persistence)",
-      "program": "${workspaceRoot}/packages/firestore/node_modules/.bin/_mocha",
+      "program": "${workspaceRoot}/node_modules/.bin/_mocha",
       "cwd": "${workspaceRoot}/packages/firestore",
       "args": [
         "--require", "ts-node/register/type-check",
@@ -114,7 +114,7 @@
       "type": "node",
       "request": "launch",
       "name": "Firestore Unit Tests (Browser)",
-      "program": "${workspaceRoot}/packages/firestore/node_modules/.bin/karma",
+      "program": "${workspaceRoot}/node_modules/.bin/karma",
       "cwd": "${workspaceRoot}/packages/firestore",
       "args": [
         "start",
@@ -127,7 +127,7 @@
       "type": "node",
       "request": "launch",
       "name": "Firestore Integration Tests (Browser)",
-      "program": "${workspaceRoot}/packages/firestore/node_modules/.bin/karma",
+      "program": "${workspaceRoot}/node_modules/.bin/karma",
       "cwd": "${workspaceRoot}/packages/firestore",
       "args": [
         "start",


### PR DESCRIPTION
Due to aeeaa14361d76d3c06fead95a2fd2359b28ad62e we need to look for mocha / karma in the root node_modules folder instead of relative to packages/firestore.
