### PR TITLE
Add FirestoreDataConverter to toc files

### DIFF
--- a/scripts/docgen/content-sources/js/toc.yaml
+++ b/scripts/docgen/content-sources/js/toc.yaml
@@ -124,6 +124,8 @@ toc:
     path: /docs/reference/js/firebase.firestore.FieldValue
   - title: "Firestore"
     path: /docs/reference/js/firebase.firestore.Firestore
+  - title: "FirestoreDataConverter"
+    path: /docs/reference/js/firebase.firestore.FirestoreDataConverter
   - title: "FirestoreError"
     path: /docs/reference/js/firebase.firestore.FirestoreError
   - title: "GeoPoint"

--- a/scripts/docgen/content-sources/node/toc.yaml
+++ b/scripts/docgen/content-sources/node/toc.yaml
@@ -100,6 +100,8 @@ toc:
     path: /docs/reference/node/firebase.firestore.FieldValue
   - title: "Firestore"
     path: /docs/reference/node/firebase.firestore.Firestore
+  - title: "FirestoreDataConverter"
+    path: /docs/reference/node/firebase.firestore.FirestoreDataConverter
   - title: "FirestoreError"
     path: /docs/reference/node/firebase.firestore.FirestoreError
   - title: "GeoPoint"


### PR DESCRIPTION
Needs to be added to `toc.yaml` files in order to appear in documentation.