### PR TITLE
Extract WebStorage schema

### DIFF
--- a/packages/firestore/src/local/shared_client_state.ts
+++ b/packages/firestore/src/local/shared_client_state.ts
@@ -37,33 +37,22 @@ import {
   QueryTargetState,
   SharedClientStateSyncer
 } from './shared_client_state_syncer';
+import {
+  CLIENT_STATE_KEY_PREFIX,
+  ClientStateSchema,
+  createWebStorageClientStateKey,
+  createWebStorageMutationBatchKey,
+  createWebStorageOnlineStateKey,
+  createWebStorageQueryTargetMetadataKey,
+  createWebStorageSequenceNumberKey,
+  MUTATION_BATCH_KEY_PREFIX,
+  MutationMetadataSchema,
+  QUERY_TARGET_KEY_PREFIX,
+  QueryTargetStateSchema,
+  SharedOnlineStateSchema
+} from './shared_client_state_schema';
 
 const LOG_TAG = 'SharedClientState';
-
-// The format of the LocalStorage key that stores the client state is:
-//     firestore_clients_<persistence_prefix>_<instance_key>
-const CLIENT_STATE_KEY_PREFIX = 'firestore_clients';
-
-// The format of the WebStorage key that stores the mutation state is:
-//     firestore_mutations_<persistence_prefix>_<batch_id>
-//     (for unauthenticated users)
-// or: firestore_mutations_<persistence_prefix>_<batch_id>_<user_uid>
-//
-// 'user_uid' is last to avoid needing to escape '_' characters that it might
-// contain.
-const MUTATION_BATCH_KEY_PREFIX = 'firestore_mutations';
-
-// The format of the WebStorage key that stores a query target's metadata is:
-//     firestore_targets_<persistence_prefix>_<target_id>
-const QUERY_TARGET_KEY_PREFIX = 'firestore_targets';
-
-// The WebStorage prefix that stores the primary tab's online state. The
-// format of the key is:
-//     firestore_online_state_<persistence_prefix>
-const ONLINE_STATE_KEY_PREFIX = 'firestore_online_state';
-// The WebStorage key prefix for the key that stores the last sequence number allocated. The key
-// looks like 'firestore_sequence_number_<persistence_prefix>'.
-const SEQUENCE_NUMBER_KEY_PREFIX = 'firestore_sequence_number';
 
 /**
  * A randomly-generated key assigned to each Firestore instance at startup.
@@ -187,17 +176,6 @@ export interface SharedClientState {
 }
 
 /**
- * The JSON representation of a mutation batch's metadata as used during
- * WebStorage serialization. The UserId and BatchId is omitted as it is
- * encoded as part of the key.
- */
-interface MutationMetadataSchema {
-  state: MutationBatchState;
-  error?: { code: string; message: string }; // Only set when state === 'rejected'
-  updateTimeMs: number;
-}
-
-/**
  * Holds the state of a mutation batch, including its user ID, batch ID and
  * whether the batch is 'pending', 'acknowledged' or 'rejected'.
  */
@@ -281,16 +259,6 @@ export class MutationMetadata {
 }
 
 /**
- * The JSON representation of a query target's state as used during WebStorage
- * serialization. The TargetId is omitted as it is encoded as part of the key.
- */
-interface QueryTargetStateSchema {
-  state: QueryTargetState;
-  error?: { code: string; message: string }; // Only set when state === 'rejected'
-  updateTimeMs: number;
-}
-
-/**
  * Holds the state of a query target, including its target ID and whether the
  * target is 'not-current', 'current' or 'rejected'.
  */
@@ -371,16 +339,6 @@ export class QueryTargetMetadata {
 }
 
 /**
- * The JSON representation of a clients's metadata as used during WebStorage
- * serialization. The ClientId is omitted here as it is encoded as part of the
- * key.
- */
-interface ClientStateSchema {
-  activeTargetIds: number[];
-  updateTimeMs: number;
-}
-
-/**
  * Metadata state of a single client denoting the query targets it is actively
  * listening to.
  */
@@ -432,20 +390,6 @@ class RemoteClientState implements ClientState {
       return null;
     }
   }
-}
-
-/**
- * The JSON representation of the system's online state, as written by the
- * primary client.
- */
-export interface SharedOnlineStateSchema {
-  /**
-   * The clientId of the client that wrote this onlineState value. Tracked so
-   * that on startup, clients can check if this client is still active when
-   * determining whether to apply this value or not.
-   */
-  readonly clientId: string;
-  readonly onlineState: string;
 }
 
 /**
@@ -567,10 +511,13 @@ export class WebStorageSharedClientState implements SharedClientState {
 
     this.storage = this.platform.window!.localStorage;
     this.currentUser = initialUser;
-    this.localClientStorageKey = this.toWebStorageClientStateKey(
+    this.localClientStorageKey = createWebStorageClientStateKey(
+      this.persistenceKey,
       this.localClientId
     );
-    this.sequenceNumberKey = `${SEQUENCE_NUMBER_KEY_PREFIX}_${persistenceKey}`;
+    this.sequenceNumberKey = createWebStorageSequenceNumberKey(
+      this.persistenceKey
+    );
     this.activeClients[this.localClientId] = new LocalClientState();
 
     this.clientStateKeyRe = new RegExp(
@@ -583,7 +530,7 @@ export class WebStorageSharedClientState implements SharedClientState {
       `^${QUERY_TARGET_KEY_PREFIX}_${escapedPersistenceKey}_(\\d+)$`
     );
 
-    this.onlineStateKey = `${ONLINE_STATE_KEY_PREFIX}_${persistenceKey}`;
+    this.onlineStateKey = createWebStorageOnlineStateKey(this.persistenceKey);
 
     // Rather than adding the storage observer during start(), we add the
     // storage observer during initialization. This ensures that we collect
@@ -620,7 +567,7 @@ export class WebStorageSharedClientState implements SharedClientState {
       }
 
       const storageItem = this.getItem(
-        this.toWebStorageClientStateKey(clientId)
+        createWebStorageClientStateKey(this.persistenceKey, clientId)
       );
       if (storageItem) {
         const clientState = RemoteClientState.fromWebStorageEntry(
@@ -707,7 +654,7 @@ export class WebStorageSharedClientState implements SharedClientState {
     // by another tab
     if (this.isActiveQueryTarget(targetId)) {
       const storageItem = this.storage.getItem(
-        this.toWebStorageQueryTargetMetadataKey(targetId)
+        createWebStorageQueryTargetMetadataKey(this.persistenceKey, targetId)
       );
 
       if (storageItem) {
@@ -737,7 +684,9 @@ export class WebStorageSharedClientState implements SharedClientState {
   }
 
   clearQueryState(targetId: TargetId): void {
-    this.removeItem(this.toWebStorageQueryTargetMetadataKey(targetId));
+    this.removeItem(
+      createWebStorageQueryTargetMetadataKey(this.persistenceKey, targetId)
+    );
   }
 
   updateQueryState(
@@ -891,12 +840,20 @@ export class WebStorageSharedClientState implements SharedClientState {
       state,
       error
     );
-    const mutationKey = this.toWebStorageMutationBatchKey(batchId);
+    const mutationKey = createWebStorageMutationBatchKey(
+      this.persistenceKey,
+      this.currentUser,
+      batchId
+    );
     this.setItem(mutationKey, mutationState.toWebStorageJSON());
   }
 
   private removeMutationState(batchId: BatchId): void {
-    const mutationKey = this.toWebStorageMutationBatchKey(batchId);
+    const mutationKey = createWebStorageMutationBatchKey(
+      this.persistenceKey,
+      this.currentUser,
+      batchId
+    );
     this.removeItem(mutationKey);
   }
 
@@ -913,35 +870,12 @@ export class WebStorageSharedClientState implements SharedClientState {
     state: QueryTargetState,
     error?: FirestoreError
   ): void {
-    const targetKey = this.toWebStorageQueryTargetMetadataKey(targetId);
+    const targetKey = createWebStorageQueryTargetMetadataKey(
+      this.persistenceKey,
+      targetId
+    );
     const targetMetadata = new QueryTargetMetadata(targetId, state, error);
     this.setItem(targetKey, targetMetadata.toWebStorageJSON());
-  }
-
-  /** Assembles the key for a client state in WebStorage */
-  private toWebStorageClientStateKey(clientId: ClientId): string {
-    assert(
-      clientId.indexOf('_') === -1,
-      `Client key cannot contain '_', but was '${clientId}'`
-    );
-
-    return `${CLIENT_STATE_KEY_PREFIX}_${this.persistenceKey}_${clientId}`;
-  }
-
-  /** Assembles the key for a query state in WebStorage */
-  private toWebStorageQueryTargetMetadataKey(targetId: TargetId): string {
-    return `${QUERY_TARGET_KEY_PREFIX}_${this.persistenceKey}_${targetId}`;
-  }
-
-  /** Assembles the key for a mutation batch in WebStorage */
-  private toWebStorageMutationBatchKey(batchId: BatchId): string {
-    let mutationKey = `${MUTATION_BATCH_KEY_PREFIX}_${this.persistenceKey}_${batchId}`;
-
-    if (this.currentUser.isAuthenticated()) {
-      mutationKey += `_${this.currentUser.uid}`;
-    }
-
-    return mutationKey;
   }
 
   /**

--- a/packages/firestore/src/local/shared_client_state_schema.ts
+++ b/packages/firestore/src/local/shared_client_state_schema.ts
@@ -1,0 +1,141 @@
+/**
+ * @license
+ * Copyright 2019 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { BatchId, MutationBatchState, TargetId } from '../core/types';
+import { QueryTargetState } from './shared_client_state_syncer';
+import { assert } from '../util/assert';
+import { ClientId } from './shared_client_state';
+import { User } from '../auth/user';
+
+// The format of the LocalStorage key that stores the client state is:
+//     firestore_clients_<persistence_prefix>_<instance_key>
+export const CLIENT_STATE_KEY_PREFIX = 'firestore_clients';
+
+/** Assembles the key for a client state in WebStorage */
+export function createWebStorageClientStateKey(
+  persistenceKey: string,
+  clientId: ClientId
+): string {
+  assert(
+    clientId.indexOf('_') === -1,
+    `Client key cannot contain '_', but was '${clientId}'`
+  );
+
+  return `${CLIENT_STATE_KEY_PREFIX}_${persistenceKey}_${clientId}`;
+}
+
+/**
+ * The JSON representation of a clients's metadata as used during WebStorage
+ * serialization. The ClientId is omitted here as it is encoded as part of the
+ * key.
+ */
+export interface ClientStateSchema {
+  activeTargetIds: number[];
+  updateTimeMs: number;
+}
+
+// The format of the WebStorage key that stores the mutation state is:
+//     firestore_mutations_<persistence_prefix>_<batch_id>
+//     (for unauthenticated users)
+// or: firestore_mutations_<persistence_prefix>_<batch_id>_<user_uid>
+//
+// 'user_uid' is last to avoid needing to escape '_' characters that it might
+// contain.
+export const MUTATION_BATCH_KEY_PREFIX = 'firestore_mutations';
+
+/** Assembles the key for a mutation batch in WebStorage */
+export function createWebStorageMutationBatchKey(
+  persistenceKey: string,
+  user: User,
+  batchId: BatchId
+): string {
+  let mutationKey = `${MUTATION_BATCH_KEY_PREFIX}_${persistenceKey}_${batchId}`;
+
+  if (user.isAuthenticated()) {
+    mutationKey += `_${user.uid}`;
+  }
+
+  return mutationKey;
+}
+
+/**
+ * The JSON representation of a mutation batch's metadata as used during
+ * WebStorage serialization. The UserId and BatchId is omitted as it is
+ * encoded as part of the key.
+ */
+export interface MutationMetadataSchema {
+  state: MutationBatchState;
+  error?: { code: string; message: string }; // Only set when state === 'rejected'
+  updateTimeMs: number;
+}
+
+// The format of the WebStorage key that stores a query target's metadata is:
+//     firestore_targets_<persistence_prefix>_<target_id>
+export const QUERY_TARGET_KEY_PREFIX = 'firestore_targets';
+
+/** Assembles the key for a query state in WebStorage */
+export function createWebStorageQueryTargetMetadataKey(
+  persistenceKey: string,
+  targetId: TargetId
+): string {
+  return `${QUERY_TARGET_KEY_PREFIX}_${persistenceKey}_${targetId}`;
+}
+
+/**
+ * The JSON representation of a query target's state as used during WebStorage
+ * serialization. The TargetId is omitted as it is encoded as part of the key.
+ */
+export interface QueryTargetStateSchema {
+  state: QueryTargetState;
+  error?: { code: string; message: string }; // Only set when state === 'rejected'
+  updateTimeMs: number;
+}
+
+// The WebStorage prefix that stores the primary tab's online state. The
+// format of the key is:
+//     firestore_online_state_<persistence_prefix>
+export const ONLINE_STATE_KEY_PREFIX = 'firestore_online_state';
+
+/** Assembles the key for the online state of the primary tab. */
+export function createWebStorageOnlineStateKey(persistenceKey: string): string {
+  return `${ONLINE_STATE_KEY_PREFIX}_${persistenceKey}`;
+}
+
+/**
+ * The JSON representation of the system's online state, as written by the
+ * primary client.
+ */
+export interface SharedOnlineStateSchema {
+  /**
+   * The clientId of the client that wrote this onlineState value. Tracked so
+   * that on startup, clients can check if this client is still active when
+   * determining whether to apply this value or not.
+   */
+  readonly clientId: string;
+  readonly onlineState: string;
+}
+
+// The WebStorage key prefix for the key that stores the last sequence number allocated. The key
+// looks like 'firestore_sequence_number_<persistence_prefix>'.
+export const SEQUENCE_NUMBER_KEY_PREFIX = 'firestore_sequence_number';
+
+/** Assembles the key for the current sequence number. */
+export function createWebStorageSequenceNumberKey(
+  persistenceKey: string
+): string {
+  return `${SEQUENCE_NUMBER_KEY_PREFIX}_${persistenceKey}`;
+}


### PR DESCRIPTION
This PR moves all the schema parts of SharedClientState to a new file. We can then use the generated .d.ts file to make sure the schema doesn't get minified.

AFAIK, this is the only file that uses a schema in WebStorage. The Zombie key is assembled as a string, and the value is also only a string.