### PR TITLE
Fix the compiling errors for firebase-admin

### DIFF
--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -25,8 +25,9 @@
   "dependencies": {
     "@firebase/database-types": "0.4.9",
     "@firebase/logger": "0.1.32",
-    "@firebase/util": "0.2.35",
+    "@firebase/util": "0.2.35", 
     "@firebase/component": "0.1.0",
+    "@firebase/auth-interop-types": "0.1.1",
     "faye-websocket": "0.11.3",
     "tslib": "1.10.0"
   },

--- a/packages/database/src/api/Database.ts
+++ b/packages/database/src/api/Database.ts
@@ -32,7 +32,7 @@ import { FirebaseDatabase } from '@firebase/database-types';
  * Class representing a firebase database.
  * @implements {FirebaseService}
  */
-export class Database implements FirebaseService, FirebaseDatabase {
+export class Database implements FirebaseService {
   INTERNAL: DatabaseInternals;
   private root_: Reference;
 

--- a/packages/database/src/api/Reference.ts
+++ b/packages/database/src/api/Reference.ts
@@ -43,7 +43,7 @@ export interface ReferenceConstructor {
   new (repo: Repo, path: Path): Reference;
 }
 
-export class Reference extends Query implements types.Reference {
+export class Reference extends Query {
   public then: (a?: any) => Promise<any>;
   public catch: (a?: Error) => Promise<any>;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -846,6 +846,10 @@
   integrity sha512-M6q3MtHzk0NQPs1PB+SXSJtkDtK8WXJh+1B1WVJQp5HTURadzj9t1bUb/Fjhq+K57lKsOgL60r8WGmE7vks1eg==
   dependencies:
     semver "^6.2.0"
+"@firebase/auth-interop-types@0.1.1":
+  version "0.1.1"
+  resolved "https://registry.npmjs.org/@firebase/auth-interop-types/-/auth-interop-types-0.1.1.tgz#b3e1bc5ea8b2df1c376b5fc14aae8a3572dbcace"
+  integrity sha512-rNpCOyCspZvNDoQVQLQQgWAGBMB2ClCWKN1c8cEFgLNFgnMJrjVB+tcL7KW2q2UjKa7l8Mxgwys7szTiEDAcvA==
 
 "@grpc/proto-loader@^0.5.0":
   version "0.5.2"
@@ -13349,7 +13353,6 @@ symbol-observable@^1.1.0:
 
 "sync-promise@git+https://github.com/brettz9/sync-promise.git#full-sync-missing-promise-features":
   version "1.0.1"
-  uid "25845a49a00aa2d2c985a5149b97c86a1fcdc75a"
   resolved "git+https://github.com/brettz9/sync-promise.git#25845a49a00aa2d2c985a5149b97c86a1fcdc75a"
 
 syntax-error@^1.1.1:
@@ -14625,7 +14628,6 @@ websocket-extensions@>=0.1.1:
 
 "websql@git+https://github.com/brettz9/node-websql.git#configurable-secure2":
   version "1.0.0"
-  uid "5149bc0763376ca757fc32dc74345ada0467bfbb"
   resolved "git+https://github.com/brettz9/node-websql.git#5149bc0763376ca757fc32dc74345ada0467bfbb"
   dependencies:
     argsarray "^0.0.1"


### PR DESCRIPTION
The typing changes made in https://github.com/firebase/firebase-js-sdk/pull/2378 broke `firebase-admin` compilation which uses strict mode which is not enabled for database.