### PR TITLE
Remove Logger from performance backend log use case

### DIFF
--- a/packages/performance/src/services/cc_service.test.ts
+++ b/packages/performance/src/services/cc_service.test.ts
@@ -17,7 +17,6 @@
 
 import { stub, useFakeTimers, SinonStub } from 'sinon';
 import { use, expect } from 'chai';
-import { Logger, LogLevel } from '@firebase/logger';
 import * as sinonChai from 'sinon-chai';
 
 use(sinonChai);
@@ -50,9 +49,8 @@ describe('Firebase Performance > cc_service', () => {
     });
 
     it('throws an error when logging an empty message', () => {
-      const logger = new Logger('@firebase/performance/cc');
       expect(() => {
-        testCCHandler(logger, LogLevel.SILENT, '');
+        testCCHandler('');
       }).to.throw;
     });
 
@@ -69,7 +67,6 @@ describe('Firebase Performance > cc_service', () => {
     });
 
     it('attempts to log an event to clearcut after DEFAULT_SEND_INTERVAL_MS if queue not empty', () => {
-      const logger = new Logger('@firebase/performance/cc');
 
       fetchStub.resolves(
         new Response('', {
@@ -78,7 +75,7 @@ describe('Firebase Performance > cc_service', () => {
         })
       );
 
-      testCCHandler(logger, LogLevel.SILENT, 'someEvent');
+      testCCHandler('someEvent');
       clock.tick(DEFAULT_SEND_INTERVAL_MS);
       expect(fetchStub).to.have.been.calledOnce;
     });

--- a/packages/performance/src/services/cc_service.test.ts
+++ b/packages/performance/src/services/cc_service.test.ts
@@ -67,7 +67,6 @@ describe('Firebase Performance > cc_service', () => {
     });
 
     it('attempts to log an event to clearcut after DEFAULT_SEND_INTERVAL_MS if queue not empty', () => {
-
       fetchStub.resolves(
         new Response('', {
           status: 200,

--- a/packages/performance/src/services/cc_service.ts
+++ b/packages/performance/src/services/cc_service.ts
@@ -136,7 +136,6 @@ export function ccHandler(
   serializer: (...args: any[]) => string
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
 ): (...args: any[]) => void {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   return (...args) => {
     const message = serializer(...args);
     addToQueue({

--- a/packages/performance/src/services/cc_service.ts
+++ b/packages/performance/src/services/cc_service.ts
@@ -15,7 +15,6 @@
  * limitations under the License.
  */
 
-import { LogHandler, Logger, LogLevel } from '@firebase/logger';
 import { SettingsService } from './settings_service';
 import { ERROR_FACTORY, ErrorCode } from '../utils/errors';
 import { consoleLogger } from '../utils/console_logger';
@@ -135,10 +134,10 @@ function addToQueue(evt: BatchEvent): void {
 export function ccHandler(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   serializer: (...args: any[]) => string
-): LogHandler {
-  // The underscores for loggerInstance and level parameters are added to avoid the
-  // noUnusedParameters related error.
-  return (_loggerInstance: Logger, _level: LogLevel, ...args) => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+): (...args: any[]) => void {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return (...args) => {
     const message = serializer(...args);
     addToQueue({
       message,

--- a/packages/performance/src/services/cc_service.ts
+++ b/packages/performance/src/services/cc_service.ts
@@ -134,8 +134,7 @@ function addToQueue(evt: BatchEvent): void {
 export function ccHandler(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   serializer: (...args: any[]) => string
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-): (...args: any[]) => void {
+): (...args: unknown[]) => void {
   return (...args) => {
     const message = serializer(...args);
     addToQueue({

--- a/packages/performance/src/services/perf_logger.test.ts
+++ b/packages/performance/src/services/perf_logger.test.ts
@@ -17,7 +17,6 @@
 
 import { stub, SinonStub, useFakeTimers, SinonFakeTimers } from 'sinon';
 import { Trace } from '../resources/trace';
-import { LogHandler, Logger, LogLevel } from '@firebase/logger';
 import * as ccService from './cc_service';
 import * as iidService from './iid_service';
 import { expect } from 'chai';
@@ -49,8 +48,8 @@ describe('Performance Monitoring > perf_logger', () => {
   let getIidStub: SinonStub<[], string | undefined>;
   let clock: SinonFakeTimers;
 
-  function mockCcHandler(serializer: (...args: any[]) => string): LogHandler {
-    return (_loggerInstance: Logger, _level: LogLevel, ...args) => {
+  function mockCcHandler(serializer: (...args: any[]) => string): (...args: any[]) => void {
+    return (...args) => {
       const message = serializer(...args);
       addToQueueStub({
         message,

--- a/packages/performance/src/services/perf_logger.test.ts
+++ b/packages/performance/src/services/perf_logger.test.ts
@@ -48,7 +48,9 @@ describe('Performance Monitoring > perf_logger', () => {
   let getIidStub: SinonStub<[], string | undefined>;
   let clock: SinonFakeTimers;
 
-  function mockCcHandler(serializer: (...args: any[]) => string): (...args: any[]) => void {
+  function mockCcHandler(
+    serializer: (...args: any[]) => string
+  ): (...args: any[]) => void {
     return (...args) => {
       const message = serializer(...args);
       addToQueueStub({

--- a/packages/performance/src/services/perf_logger.ts
+++ b/packages/performance/src/services/perf_logger.ts
@@ -85,9 +85,15 @@ interface TraceMetric {
 
 /* eslint-enble camelcase */
 
-let logger: (resource: NetworkRequest | Trace, resourceType: ResourceType) => void | undefined;
+let logger: (
+  resource: NetworkRequest | Trace,
+  resourceType: ResourceType
+) => void | undefined;
 // This method is not called before initialization.
-function sendLog(resource: NetworkRequest | Trace, resourceType: ResourceType): void {
+function sendLog(
+  resource: NetworkRequest | Trace,
+  resourceType: ResourceType
+): void {
   if (!logger) {
     logger = ccHandler(serializer);
   }
@@ -159,7 +165,10 @@ export function logNetworkRequest(networkRequest: NetworkRequest): void {
   setTimeout(() => sendLog(networkRequest, ResourceType.NetworkRequest), 0);
 }
 
-function serializer(resource: NetworkRequest | Trace, resourceType: ResourceType): string {
+function serializer(
+  resource: NetworkRequest | Trace,
+  resourceType: ResourceType
+): string {
   if (resourceType === ResourceType.NetworkRequest) {
     return serializeNetworkRequest(resource as NetworkRequest);
   }

--- a/packages/performance/src/services/perf_logger.ts
+++ b/packages/performance/src/services/perf_logger.ts
@@ -86,14 +86,14 @@ interface TraceMetric {
 /* eslint-enble camelcase */
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-let logger: (...args: any[]) => void | undefined;
+let logger: (resource: {}, resourceType: ResourceType) => void | undefined;
 // This method is not called before initialization.
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-function sendLog(...args: any[]): void {
+function sendLog(resource: {}, resourceType: ResourceType): void {
   if (!logger) {
     logger = ccHandler(serializer);
   }
-  logger(...args);
+  logger(resource, resourceType);
 }
 
 export function logTrace(trace: Trace): void {

--- a/packages/performance/src/services/perf_logger.ts
+++ b/packages/performance/src/services/perf_logger.ts
@@ -85,11 +85,9 @@ interface TraceMetric {
 
 /* eslint-enble camelcase */
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-let logger: (resource: {}, resourceType: ResourceType) => void | undefined;
+let logger: (resource: unknown, resourceType: ResourceType) => void | undefined;
 // This method is not called before initialization.
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function sendLog(resource: {}, resourceType: ResourceType): void {
+function sendLog(resource: unknown, resourceType: ResourceType): void {
   if (!logger) {
     logger = ccHandler(serializer);
   }
@@ -161,7 +159,7 @@ export function logNetworkRequest(networkRequest: NetworkRequest): void {
   setTimeout(() => sendLog(networkRequest, ResourceType.NetworkRequest), 0);
 }
 
-function serializer(resource: {}, resourceType: ResourceType): string {
+function serializer(resource: unknown, resourceType: ResourceType): string {
   if (resourceType === ResourceType.NetworkRequest) {
     return serializeNetworkRequest(resource as NetworkRequest);
   }

--- a/packages/performance/src/services/perf_logger.ts
+++ b/packages/performance/src/services/perf_logger.ts
@@ -85,9 +85,9 @@ interface TraceMetric {
 
 /* eslint-enble camelcase */
 
-let logger: (resource: unknown, resourceType: ResourceType) => void | undefined;
+let logger: (resource: NetworkRequest | Trace, resourceType: ResourceType) => void | undefined;
 // This method is not called before initialization.
-function sendLog(resource: unknown, resourceType: ResourceType): void {
+function sendLog(resource: NetworkRequest | Trace, resourceType: ResourceType): void {
   if (!logger) {
     logger = ccHandler(serializer);
   }
@@ -159,7 +159,7 @@ export function logNetworkRequest(networkRequest: NetworkRequest): void {
   setTimeout(() => sendLog(networkRequest, ResourceType.NetworkRequest), 0);
 }
 
-function serializer(resource: unknown, resourceType: ResourceType): string {
+function serializer(resource: NetworkRequest | Trace, resourceType: ResourceType): string {
   if (resourceType === ResourceType.NetworkRequest) {
     return serializeNetworkRequest(resource as NetworkRequest);
   }

--- a/packages/performance/src/services/perf_logger.ts
+++ b/packages/performance/src/services/perf_logger.ts
@@ -30,7 +30,6 @@ import {
   isPerfInitialized,
   getInitializationPromise
 } from './initialization_service';
-import { Logger } from '@firebase/logger';
 import { ccHandler } from './cc_service';
 import { SDK_VERSION } from '../constants';
 
@@ -83,17 +82,22 @@ interface TraceMetric {
   counters?: Array<{ key: string; value: number }>;
   custom_attributes?: Array<{ key: string; value: string }>;
 }
+
+interface CCLogger {
+  log: (...args: unknown[]) => void
+}
+
 /* eslint-enble camelcase */
 
-let logger: Logger | undefined;
+let logger: CCLogger | undefined;
 // This method is not called before initialization.
-function getLogger(): Logger {
+function getLogger(): CCLogger {
   if (logger) {
     return logger;
   }
-  const ccLogger = ccHandler(serializer);
-  logger = new Logger('@firebase/performance/cc');
-  logger.logHandler = ccLogger;
+  logger = {
+    log: ccHandler(serializer)
+  };
   return logger;
 }
 

--- a/packages/performance/src/services/perf_logger.ts
+++ b/packages/performance/src/services/perf_logger.ts
@@ -88,7 +88,7 @@ interface TraceMetric {
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 let logger: (resource: {}, resourceType: ResourceType) => void | undefined;
 // This method is not called before initialization.
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 function sendLog(resource: {}, resourceType: ResourceType): void {
   if (!logger) {
     logger = ccHandler(serializer);
@@ -158,10 +158,7 @@ export function logNetworkRequest(networkRequest: NetworkRequest): void {
     return;
   }
 
-  setTimeout(
-    () => sendLog(networkRequest, ResourceType.NetworkRequest),
-    0
-  );
+  setTimeout(() => sendLog(networkRequest, ResourceType.NetworkRequest), 0);
 }
 
 function serializer(resource: {}, resourceType: ResourceType): string {

--- a/packages/performance/src/services/perf_logger.ts
+++ b/packages/performance/src/services/perf_logger.ts
@@ -83,22 +83,17 @@ interface TraceMetric {
   custom_attributes?: Array<{ key: string; value: string }>;
 }
 
-interface CCLogger {
-  log: (...args: unknown[]) => void
-}
-
 /* eslint-enble camelcase */
 
-let logger: CCLogger | undefined;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let logger: (...args: any[]) => void | undefined;
 // This method is not called before initialization.
-function getLogger(): CCLogger {
-  if (logger) {
-    return logger;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+function sendLog(...args: any[]): void {
+  if (!logger) {
+    logger = ccHandler(serializer);
   }
-  logger = {
-    log: ccHandler(serializer)
-  };
-  return logger;
+  logger(...args);
 }
 
 export function logTrace(trace: Trace): void {
@@ -141,7 +136,7 @@ export function logTrace(trace: Trace): void {
 
 function sendTraceLog(trace: Trace): void {
   if (getIid()) {
-    setTimeout(() => getLogger().log(trace, ResourceType.Trace), 0);
+    setTimeout(() => sendLog(trace, ResourceType.Trace), 0);
   }
 }
 
@@ -164,7 +159,7 @@ export function logNetworkRequest(networkRequest: NetworkRequest): void {
   }
 
   setTimeout(
-    () => getLogger().log(networkRequest, ResourceType.NetworkRequest),
+    () => sendLog(networkRequest, ResourceType.NetworkRequest),
     0
   );
 }


### PR DESCRIPTION
In preparation for some changes to `Logger` that will open up some methods to users, we should remove it from this internal use case that doesn't make use of any of `Logger`'s functionality anyway.