### PR TITLE
Avoid using $httpHeaders in environments that don't send an Origin header.

### DIFF
--- a/packages/firestore/CHANGELOG.md
+++ b/packages/firestore/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Unreleased
+- [fixed] Fixed an issue where auth credentials were not respected in certain
+  browser environments (Electron 7, IE11 in trusted zone, UWP apps). (#1491)
+
+# 1.9.0
 - [feature] Added support for storing and retrieving custom types in Firestore.
   Added support for strongly typed collections, documents, and
   queries. You can now use `withConverter()` to supply a custom data

--- a/packages/firestore/src/platform_browser/webchannel_connection.ts
+++ b/packages/firestore/src/platform_browser/webchannel_connection.ts
@@ -25,7 +25,7 @@ import {
   XhrIo
 } from '@firebase/webchannel-wrapper';
 
-import { isReactNative } from '@firebase/util';
+import { isElectron, isIE, isReactNative, isUWP } from '@firebase/util';
 
 import { Token } from '../api/credentials';
 import { DatabaseId, DatabaseInfo } from '../core/database_info';
@@ -264,11 +264,11 @@ export class WebChannelConnection implements Connection {
     // formally defined here:
     // https://github.com/google/closure-library/blob/b0e1815b13fb92a46d7c9b3c30de5d6a396a3245/closure/goog/net/rpc/httpcors.js#L32
     //
-    // But for some unclear reason (see
-    // https://github.com/firebase/firebase-js-sdk/issues/703), this breaks
-    // ReactNative and so we exclude it, which just means ReactNative may be
-    // subject to the extra network roundtrip for CORS preflight.
-    if (!isReactNative()) {
+    // TODO(b/145624756): There is a backend bug where $httpHeaders isn't respected if the request
+    // doesn't have an Origin header. So we have to exclude a few browser environments that are
+    // known to (sometimes) not include an Origin. See
+    // https://github.com/firebase/firebase-js-sdk/issues/1491.
+    if (!isReactNative() && !isElectron() && !isIE() && !isUWP()) {
       request.httpHeadersOverwriteParam = '$httpHeaders';
     }
 

--- a/packages/util/src/environment.ts
+++ b/packages/util/src/environment.ts
@@ -83,6 +83,22 @@ export function isReactNative(): boolean {
   );
 }
 
+/** Detects Electron apps. */
+export function isElectron(): boolean {
+  return getUA().indexOf('electron/') >= 0;
+}
+
+/** Detects Internet Explorer. */
+export function isIE(): boolean {
+  const ua = getUA();
+  return ua.indexOf('MSIE ') >= 0 || ua.indexOf('Trident/') >= 0;
+}
+
+/** Detects Universal Windows Platform apps. */
+export function isUWP(): boolean {
+  return getUA().indexOf('MSAppHost/') >= 0;
+}
+
 /**
  * Detect whether the current SDK build is the Node version.
  *

--- a/packages/util/src/environment.ts
+++ b/packages/util/src/environment.ts
@@ -85,7 +85,7 @@ export function isReactNative(): boolean {
 
 /** Detects Electron apps. */
 export function isElectron(): boolean {
-  return getUA().indexOf('electron/') >= 0;
+  return getUA().indexOf('Electron/') >= 0;
 }
 
 /** Detects Internet Explorer. */


### PR DESCRIPTION
There is a backend bug (b/145624756) causing our $httpHeaders query param to be ignored if the request doesn't contain an Origin header.  Via https://github.com/firebase/firebase-js-sdk/issues/1491 we've found that several environments can run into this issue so until the backend issue is fixed we are excluding them from using $httpHeaders. This may incur an extra CORS preflight round-trip in some cases, but this is much better than having our Authorization header get ignored.