### PR TITLE
Add CHANGELOG for Fireperf transport update from proto2 to proto3

### DIFF
--- a/packages/performance/CHANGELOG.md
+++ b/packages/performance/CHANGELOG.md
@@ -1,0 +1,2 @@
+# Unreleased
+- [changed] Internal transport protocol update from proto2 to proto3.


### PR DESCRIPTION
Add changelog about proto2 -> proto3 upgrade on Firebase Performance transport.

Changelog is helpful for Firebase JS team to compose release note of new version. Released changes will be moved to public version in CHANGLOG.md.

Example: https://github.com/firebase/firebase-js-sdk/blob/master/packages/database/CHANGELOG.md