### PR TITLE
Add an interface to ServerValues that lets us read synctrees just in time

### DIFF
--- a/packages/database/src/core/Repo.ts
+++ b/packages/database/src/core/Repo.ts
@@ -423,7 +423,11 @@ export class Repo {
     const resolvedOnDisconnectTree = new SparseSnapshotTree();
     this.onDisconnect_.forEachTree(Path.Empty, (path, node) => {
       const resolved = resolveDeferredValueTree(
-        path, node, this.serverSyncTree_, serverValues);
+        path,
+        node,
+        this.serverSyncTree_,
+        serverValues
+      );
       resolvedOnDisconnectTree.remember(path, resolved);
     });
     let events: Event[] = [];

--- a/packages/database/src/core/Repo.ts
+++ b/packages/database/src/core/Repo.ts
@@ -364,10 +364,10 @@ export class Repo {
     const changedChildren: { [k: string]: Node } = {};
     each(childrenToMerge, (changedKey: string, changedValue: unknown) => {
       empty = false;
-      const newNodeUnresolved = nodeFromJSON(changedValue);
-      changedChildren[changedKey] = resolveDeferredValueSnapshot(
-        newNodeUnresolved,
-        this.serverSyncTree_.calcCompleteEventCache(path.child(changedKey)),
+      changedChildren[changedKey] = resolveDeferredValueTree(
+        path.child(changedKey),
+        nodeFromJSON(changedValue),
+        this.serverSyncTree_,
         serverValues
       );
     });
@@ -420,11 +420,12 @@ export class Repo {
     this.log_('onDisconnectEvents');
 
     const serverValues = this.generateServerValues();
-    const resolvedOnDisconnectTree = resolveDeferredValueTree(
-      this.onDisconnect_,
-      this.serverSyncTree_,
-      serverValues
-    );
+    const resolvedOnDisconnectTree = new SparseSnapshotTree();
+    this.onDisconnect_.forEachTree(Path.Empty, (path, node) => {
+      const resolved = resolveDeferredValueTree(
+        path, node, this.serverSyncTree_, serverValues);
+      resolvedOnDisconnectTree.remember(path, resolved);
+    });
     let events: Event[] = [];
 
     resolvedOnDisconnectTree.forEachTree(Path.Empty, (path, snap) => {

--- a/packages/database/src/core/util/ServerValues.ts
+++ b/packages/database/src/core/util/ServerValues.ts
@@ -26,6 +26,53 @@ import { ChildrenNode } from '../snap/ChildrenNode';
 import { SyncTree } from '../SyncTree';
 import { Indexable } from './misc';
 
+/* It's critical for performance that we not calculate actual values from a SyncTree
+ * unless and until the value is needed. Because we expose both a SyncTree and Node
+ * version of deferred value resolution, we ned a wrapper class that will let us share
+ * code.
+ *
+ * @see https://github.com/firebase/firebase-js-sdk/issues/2487
+ */
+interface DeferredExistingValue {
+  getImmediateChild(childName: string): DeferredExistingValue;
+  node(): Node;
+}
+
+class ExistingSnapshotValue implements DeferredExistingValue {
+  private node_: Node;
+  constructor(node: Node) {
+    this.node_ = node;
+  }
+
+  getImmediateChild(childName: string): DeferredExistingValue {
+    const child = this.node_.getImmediateChild(childName);
+    return new ExistingSnapshotValue(child);
+  }
+
+  node(): Node {
+    return this.node_;
+  }
+}
+
+class DeferredSyncTreeValue implements DeferredExistingValue {
+  private syncTree_: SyncTree;
+  private path_: Path;
+
+  constructor(syncTree: SyncTree, path: Path) {
+    this.syncTree_ = syncTree;
+    this.path_ = path;
+  }
+
+  getImmediateChild(childName: string): DeferredExistingValue {
+    const childPath = this.path_.child(childName);
+    return new DeferredSyncTreeValue(this.syncTree_, childPath);
+  }
+
+  node(): Node {
+    return this.syncTree_.calcCompleteEventCache(this.path_);
+  }
+}
+
 /**
  * Generate placeholders for deferred values.
  * @param {?Object} values
@@ -48,9 +95,9 @@ export const generateWithValues = function(
  * @param {!Object} serverValues
  * @return {!(string|number|boolean)}
  */
-export const resolveDeferredValue = function(
+export const resolveDeferredLeafValue = function(
   value: { [k: string]: unknown } | string | number | boolean,
-  existing: Node,
+  existingVal: DeferredExistingValue,
   serverValues: { [k: string]: unknown }
 ): string | number | boolean {
   if (!value || typeof value !== 'object') {
@@ -59,9 +106,9 @@ export const resolveDeferredValue = function(
   assert('.sv' in value, 'Unexpected leaf node or priority contents');
 
   if (typeof value['.sv'] === 'string') {
-    return resolveScalarDeferredValue(value['.sv'], existing, serverValues);
+    return resolveScalarDeferredValue(value['.sv'], existingVal, serverValues);
   } else if (typeof value['.sv'] === 'object') {
-    return resolveComplexDeferredValue(value['.sv'], existing, serverValues);
+    return resolveComplexDeferredValue(value['.sv'], existingVal, serverValues);
   } else {
     assert(false, 'Unexpected server value: ' + JSON.stringify(value, null, 2));
   }
@@ -69,7 +116,7 @@ export const resolveDeferredValue = function(
 
 const resolveScalarDeferredValue = function(
   op: string,
-  existing: Node,
+  existing: DeferredExistingValue,
   serverValues: { [k: string]: unknown }
 ): string | number | boolean {
   switch (op) {
@@ -82,7 +129,7 @@ const resolveScalarDeferredValue = function(
 
 const resolveComplexDeferredValue = function(
   op: object,
-  existing: Node,
+  existing: DeferredExistingValue,
   unused: { [k: string]: unknown }
 ): string | number | boolean {
   if (!op.hasOwnProperty('increment')) {
@@ -93,12 +140,18 @@ const resolveComplexDeferredValue = function(
     assert(false, 'Unexpected increment value: ' + delta);
   }
 
+  const existingNode = existing.node();
+  assert(
+    existingNode !== null && typeof existingNode !== 'undefined',
+    'Expected ChildrenNode.EMPTY_NODE for nulls'
+  );
+
   // Incrementing a non-number sets the value to the incremented amount
-  if (!existing.isLeafNode()) {
+  if (!existingNode.isLeafNode()) {
     return delta;
   }
 
-  const leaf = existing as LeafNode;
+  const leaf = existingNode as LeafNode;
   const existingVal = leaf.getValue();
   if (typeof existingVal !== 'number') {
     return delta;
@@ -122,14 +175,10 @@ export const resolveDeferredValueTree = function(
 ): SparseSnapshotTree {
   const resolvedTree = new SparseSnapshotTree();
   tree.forEachTree(new Path(''), (path, node) => {
-    const existing = syncTree.calcCompleteEventCache(path);
-    assert(
-      existing !== null && typeof existing !== 'undefined',
-      'Expected ChildrenNode.EMPTY_NODE for nulls'
-    );
+    const deferredExisting = new DeferredSyncTreeValue(syncTree, path);
     resolvedTree.remember(
       path,
-      resolveDeferredValueSnapshot(node, existing, serverValues)
+      resolveDeferredValue(node, deferredExisting, serverValues)
     );
   });
   return resolvedTree;
@@ -148,24 +197,36 @@ export const resolveDeferredValueSnapshot = function(
   existing: Node,
   serverValues: Indexable
 ): Node {
+  return resolveDeferredValue(
+    node,
+    new ExistingSnapshotValue(existing),
+    serverValues
+  );
+};
+
+function resolveDeferredValue(
+  node: Node,
+  existingVal: DeferredExistingValue,
+  serverValues: Indexable
+): Node {
   const rawPri = node.getPriority().val() as
     | Indexable
     | boolean
     | null
     | number
     | string;
-  const priority = resolveDeferredValue(
+  const priority = resolveDeferredLeafValue(
     rawPri,
-    existing.getPriority(),
+    existingVal.getImmediateChild('.priority'),
     serverValues
   );
   let newNode: Node;
 
   if (node.isLeafNode()) {
     const leafNode = node as LeafNode;
-    const value = resolveDeferredValue(
+    const value = resolveDeferredLeafValue(
       leafNode.getValue(),
-      existing,
+      existingVal,
       serverValues
     );
     if (
@@ -183,9 +244,9 @@ export const resolveDeferredValueSnapshot = function(
       newNode = newNode.updatePriority(new LeafNode(priority));
     }
     childrenNode.forEachChild(PRIORITY_INDEX, (childName, childNode) => {
-      const newChildNode = resolveDeferredValueSnapshot(
+      const newChildNode = resolveDeferredValue(
         childNode,
-        existing.getImmediateChild(childName),
+        existingVal.getImmediateChild(childName),
         serverValues
       );
       if (newChildNode !== childNode) {
@@ -194,4 +255,4 @@ export const resolveDeferredValueSnapshot = function(
     });
     return newNode;
   }
-};
+}

--- a/packages/database/src/core/util/ServerValues.ts
+++ b/packages/database/src/core/util/ServerValues.ts
@@ -164,24 +164,23 @@ const resolveComplexDeferredValue = function(
 /**
  * Recursively replace all deferred values and priorities in the tree with the
  * specified generated replacement values.
- * @param {!SparseSnapshotTree} tree
+ * @param {!Path} path path to which write is relative
+ * @param {!Node} node new data written at path
+ * @param {!SyncTree} syncTree current data
  * @param {!Object} serverValues
  * @return {!SparseSnapshotTree}
  */
 export const resolveDeferredValueTree = function(
-  tree: SparseSnapshotTree,
+  path: Path,
+  node: Node,
   syncTree: SyncTree,
   serverValues: Indexable
-): SparseSnapshotTree {
-  const resolvedTree = new SparseSnapshotTree();
-  tree.forEachTree(new Path(''), (path, node) => {
-    const deferredExisting = new DeferredSyncTreeValue(syncTree, path);
-    resolvedTree.remember(
-      path,
-      resolveDeferredValue(node, deferredExisting, serverValues)
-    );
-  });
-  return resolvedTree;
+): Node {
+  return resolveDeferredValue(
+    node,
+    new DeferredSyncTreeValue(syncTree, path),
+    serverValues
+  );
 };
 
 /**

--- a/packages/database/src/core/util/ServerValues.ts
+++ b/packages/database/src/core/util/ServerValues.ts
@@ -26,7 +26,7 @@ import { ChildrenNode } from '../snap/ChildrenNode';
 import { SyncTree } from '../SyncTree';
 import { Indexable } from './misc';
 
-/* It's critical for performance that we not calculate actual values from a SyncTree
+/* It's critical for performance that we do not calculate actual values from a SyncTree
  * unless and until the value is needed. Because we expose both a SyncTree and Node
  * version of deferred value resolution, we ned a wrapper class that will let us share
  * code.


### PR DESCRIPTION

Addresses #2487 by creating a new interface that lets us defer reading existing values from a SyncTree until it's actually needed and restricted to the smallest possible scope.