### PR TITLE
Resolve Performance test failures and add unit tests for proto3 data transport format

### DIFF
--- a/packages/performance/src/services/cc_service.test.ts
+++ b/packages/performance/src/services/cc_service.test.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { stub, useFakeTimers, SinonStub } from 'sinon';
+import { stub, useFakeTimers, SinonStub, SinonFakeTimers } from 'sinon';
 import { use, expect } from 'chai';
 import { Logger, LogLevel, LogHandler } from '@firebase/logger';
 import * as sinonChai from 'sinon-chai';
@@ -27,12 +27,12 @@ use(sinonChai);
 // Starts date at timestamp 1 instead of 0, otherwise it causes validation errors.
 import { ccHandler } from './cc_service';
 // eslint-disable-next-line
-describe.only('Firebase Performance > cc_service', () => {
+describe('Firebase Performance > cc_service', () => {
   describe('ccHandler', () => {
     let fetchStub: SinonStub<[RequestInfo, RequestInit?], Promise<Response>>;
-    let clock: sinon.SinonFakeTimers;
     const INITIAL_SEND_TIME_DELAY_MS = 5.5 * 1000;
     const DEFAULT_SEND_INTERVAL_MS = 10 * 1000;
+    let clock: SinonFakeTimers;
     let testCCHandler: LogHandler;
 
     beforeEach(() => {
@@ -45,46 +45,62 @@ describe.only('Firebase Performance > cc_service', () => {
 
     afterEach(() => {
       fetchStub.restore();
+      clock.restore();
     });
 
+    // First setTimeout in cc_service#processQueue(timeOffset) happens before useFakeTimers() is
+    // called. Therefore all tests need to wait for first timeout to finish before starting the
+    // actual test logic.
+    function waitForFirstTimeout(callback: () => void): void {
+      setTimeout(() => {
+        callback();
+      }, 10 * DEFAULT_SEND_INTERVAL_MS);
+    }
+
     it('throws an error when logging an empty message', () => {
-      const logger = new Logger('@firebase/performance/cc');
-      expect(() => {
-        testCCHandler(logger, LogLevel.SILENT, '');
-      }).to.throw;
+      waitForFirstTimeout(() => {
+        const logger = new Logger('@firebase/performance/cc');
+        expect(() => {
+          testCCHandler(logger, LogLevel.SILENT, '');
+        }).to.throw;
+      });
     });
 
     it('does not attempt to log an event to clearcut after INITIAL_SEND_TIME_DELAY_MS if queue is empty', () => {
-      fetchStub.resolves(
-        new Response('', {
-          status: 200,
-          headers: { 'Content-type': 'application/json' }
-        })
-      );
+      waitForFirstTimeout(() => {
+        fetchStub.resolves(
+          new Response('', {
+            status: 200,
+            headers: { 'Content-type': 'application/json' }
+          })
+        );
 
-      clock.tick(INITIAL_SEND_TIME_DELAY_MS);
-      expect(fetchStub).to.not.have.been.called;
+        clock.tick(INITIAL_SEND_TIME_DELAY_MS);
+        expect(fetchStub).to.not.have.been.called;
+      });
     });
 
     it('attempts to log an event to clearcut after DEFAULT_SEND_INTERVAL_MS if queue not empty', () => {
-      const logger = new Logger('@firebase/performance/cc');
+      waitForFirstTimeout(() => {
+        const logger = new Logger('@firebase/performance/cc');
 
-      fetchStub.resolves(
-        new Response('', {
-          status: 200,
-          headers: { 'Content-type': 'application/json' }
-        })
-      );
+        fetchStub.resolves(
+          new Response('', {
+            status: 200,
+            headers: { 'Content-type': 'application/json' }
+          })
+        );
 
-      testCCHandler(logger, LogLevel.DEBUG, 'someEvent');
-      clock.tick(20 * DEFAULT_SEND_INTERVAL_MS);
+        testCCHandler(logger, LogLevel.DEBUG, 'someEvent');
+        clock.tick(100 * DEFAULT_SEND_INTERVAL_MS);
 
-      expect(fetchStub).to.have.been.calledOnce;
-      expect(fetchStub).to.have.been.calledWith({
-        body: `{"request_time_ms": ,"client_info":{"client_type":1,\
+        expect(fetchStub).to.have.been.calledOnce;
+        expect(fetchStub).to.have.been.calledWith({
+          body: `{"request_time_ms": ,"client_info":{"client_type":1,\
   "js_client_info":{}},"log_source":462,"log_event":[{"source_extension_json_proto3":"someEvent",\
   "event_time_ms":${1}}]}`,
-        method: 'POST'
+          method: 'POST'
+        });
       });
     });
   });


### PR DESCRIPTION
1. Add a timeout wait function to cc_service.test.ts because the first setTimeout() happens before fake timer is used. (Resolve test failure from Travis CI)
2. Remove .only() from cc_service.test.ts file so other Fireperf test can be run.
3. Add unit tests to validate proto3 format serialization works as expected.