### PR TITLE
Update integration tests to use firestore.js

### DIFF
--- a/integration/firestore/gulpfile.js
+++ b/integration/firestore/gulpfile.js
@@ -34,7 +34,11 @@ function copyTests() {
    * Therefore these tests and helpers cannot have any src/ dependencies.
    */
   const testBase = resolve(__dirname, '../../packages/firestore/test');
-  const firebaseSdk = resolve(__dirname, '../../packages/firebase/firebase.js');
+  const firebaseAppSdk = 'firebase/app/dist/index.esm.js';
+  const firebaseFirestoreSdk = resolve(
+    __dirname,
+    '../../packages/firestore/dist/index.esm.js'
+  );
   return gulp
     .src(
       [
@@ -58,7 +62,8 @@ function copyTests() {
          * differences, as well as different paths to a valid firebase_export
          */
         /import\s+firebase\s+from\s+('|")[^\1]+firebase_export\1;?/,
-        `import * as firebase from '${firebaseSdk}';`
+        `import firebase from '${firebaseAppSdk}';
+         import '${firebaseFirestoreSdk}';`
       )
     )
     .pipe(


### PR DESCRIPTION
This change will allow us to replace firestore.js in our Integration Tests with a minified version without having to provide a minified firebase.js

Credit to @hsubox76 for figuring this all out for me.