### PR TITLE
Fix for #1491: Disable use of $httpHeaders in browser extensions too.

### DIFF
--- a/packages/firestore/CHANGELOG.md
+++ b/packages/firestore/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Unreleased
+- [fixed] Fixed an issue where auth credentials were not respected in some
+  Firefox or Chrome extensions. (#1491)
+
+# 1.9.2
 - [fixed] Fixed an issue where auth credentials were not respected in certain
   browser environments (Electron 7, IE11 in trusted zone, UWP apps). (#1491)
 

--- a/packages/firestore/src/platform_browser/webchannel_connection.ts
+++ b/packages/firestore/src/platform_browser/webchannel_connection.ts
@@ -25,7 +25,13 @@ import {
   XhrIo
 } from '@firebase/webchannel-wrapper';
 
-import { isElectron, isIE, isReactNative, isUWP } from '@firebase/util';
+import {
+  isBrowserExtension,
+  isElectron,
+  isIE,
+  isReactNative,
+  isUWP
+} from '@firebase/util';
 
 import { Token } from '../api/credentials';
 import { DatabaseId, DatabaseInfo } from '../core/database_info';
@@ -268,7 +274,13 @@ export class WebChannelConnection implements Connection {
     // doesn't have an Origin header. So we have to exclude a few browser environments that are
     // known to (sometimes) not include an Origin. See
     // https://github.com/firebase/firebase-js-sdk/issues/1491.
-    if (!isReactNative() && !isElectron() && !isIE() && !isUWP()) {
+    if (
+      !isReactNative() &&
+      !isElectron() &&
+      !isIE() &&
+      !isUWP() &&
+      !isBrowserExtension()
+    ) {
       request.httpHeadersOverwriteParam = '$httpHeaders';
     }
 

--- a/packages/util/src/environment.ts
+++ b/packages/util/src/environment.ts
@@ -75,8 +75,8 @@ export function isBrowser(): boolean {
 /**
  * Detect browser extensions (Chrome and Firefox at least).
  */
-declare var chrome: any;
-declare var browser: any;
+declare const chrome: { runtime?: unknown };
+declare const browser: { runtime?: unknown };
 export function isBrowserExtension(): boolean {
   return (
     (typeof chrome === 'object' && chrome.runtime !== undefined) ||

--- a/packages/util/src/environment.ts
+++ b/packages/util/src/environment.ts
@@ -73,6 +73,18 @@ export function isBrowser(): boolean {
 }
 
 /**
+ * Detect browser extensions (Chrome and Firefox at least).
+ */
+declare var chrome: any;
+declare var browser: any;
+export function isBrowserExtension(): boolean {
+  return (
+    (typeof chrome === 'object' && chrome.runtime !== undefined) ||
+    (typeof browser === 'object' && browser.runtime !== undefined)
+  );
+}
+
+/**
  * Detect React Native.
  *
  * @return true if ReactNative environment is detected.

--- a/packages/util/src/environment.ts
+++ b/packages/util/src/environment.ts
@@ -75,13 +75,19 @@ export function isBrowser(): boolean {
 /**
  * Detect browser extensions (Chrome and Firefox at least).
  */
-declare const chrome: { runtime?: unknown };
-declare const browser: { runtime?: unknown };
+interface BrowserRuntime {
+  id?: unknown;
+}
+declare const chrome: { runtime?: BrowserRuntime };
+declare const browser: { runtime?: BrowserRuntime };
 export function isBrowserExtension(): boolean {
-  return (
-    (typeof chrome === 'object' && chrome.runtime !== undefined) ||
-    (typeof browser === 'object' && browser.runtime !== undefined)
-  );
+  const runtime =
+    typeof chrome === 'object'
+      ? chrome.runtime
+      : typeof browser === 'object'
+      ? browser.runtime
+      : undefined;
+  return typeof runtime === 'object' && runtime.id !== undefined;
 }
 
 /**


### PR DESCRIPTION
This is a follow-up to https://github.com/firebase/firebase-js-sdk/pull/2464.

@wu-hui Can you test this with your repro extension?
@wilhuff Can you review?
@hsubox76 Can you review the util changes?
