### PR TITLE
Small fix: Firestore's fromCache description

### DIFF
--- a/packages/firebase/index.d.ts
+++ b/packages/firebase/index.d.ts
@@ -8046,11 +8046,10 @@ declare namespace firebase.firestore {
     readonly hasPendingWrites: boolean;
 
     /**
-     * True if the snapshot includes local writes (`set()` or
-     * `update()` calls) that haven't been committed to the backend yet.
-     * If your listener has opted into
-     * metadata updates (via `SnapshotListenOptions`)
-     * you will receive another snapshot with `fromCache` equal to false once
+     * True if the snapshot was created from cached data rather than guaranteed
+     * up-to-date server data. If your listener has opted into metadata updates
+     * (via `SnapshotListenOptions`)
+     * you will receive another snapshot with `fromCache` set to false once
      * the client has received up-to-date data from the backend.
      */
     readonly fromCache: boolean;


### PR DESCRIPTION
The [reference docs for `firebase.firestore.SnapshotMetadata.fromCache`](https://firebase.google.com/docs/reference/js/firebase.firestore.SnapshotMetadata.html#fromcache) are currently incorrect. They say:

> **True if the snapshot includes local writes (set() or update() calls) that haven't been committed to the backend yet.** If your listener has opted into metadata updates (via SnapshotListenOptions) you will receive another snapshot with fromCache equal to false once the client has received up-to-date data from the backend.

This looks like a partial copy-paste from [`hasPendingWrites`](https://firebase.google.com/docs/reference/js/firebase.firestore.SnapshotMetadata.html#has-pending-writes).

In this PR, I've copy pasted the correct description from `firebase-firestore-externs.js`:

https://github.com/firebase/firebase-js-sdk/blob/6e45e6a1cbcfa0fae29769fa4b81fc0350186981/packages/firebase/externs/firebase-firestore-externs.js#L673-L682




