### PR TITLE
Switch back to user NPM token

### DIFF
--- a/.github/workflows/deploy-canary.yml
+++ b/.github/workflows/deploy-canary.yml
@@ -19,15 +19,14 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: 10.x
-        registry-url: 'https://wombat-dressing-room.appspot.com/firebase/_ns/'
+        registry-url: 'https://registry.npmjs.org'
     - name: Yarn install
       run: yarn
     - name: yarn build
       run: yarn build
     - name: Deploy canary
       run: |
-        npm config set //wombat-dressing-room.appspot.com/mypackage/_ns:authToken=$NODE_AUTH_TOKEN
-        npm config set scope "@firebase"
+        npm config set //registry.npmjs.org/:_authToken=$NODE_AUTH_TOKEN
         yarn release --canary
       env:
         NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}


### PR DESCRIPTION
Was unsuccessful trying to set up wombat-dressing-room publish method, likely to take much longer than a few days.  Switching back to previous token so canary releases won't be blocked in the meantime.