### PR TITLE
Exclude packages that fail cross-browser tests

### DIFF
--- a/scripts/run_saucelabs.js
+++ b/scripts/run_saucelabs.js
@@ -39,7 +39,15 @@ const testFiles = configFiles.length
   : glob
       .sync(`{packages,integration}/*/karma.conf.js`)
       // Automated tests in integration/firestore are currently disabled.
-      .filter(name => !name.includes('integration/firestore'));
+      // TODO: Fix failing tests in other packages.
+      .filter(
+        name =>
+          !name.includes('integration/firestore') &&
+          !name.includes('packages/messaging') &&
+          !name.includes('packages/installations') &&
+          !name.includes('packages/functions') &&
+          !name.includes('packages/database')
+      );
 
 // Get CI build number or generate one if running locally.
 const buildNumber =


### PR DESCRIPTION
We're in the process of finding a better cross-browser testing solution but in the meantime, the Saucelabs tests are a guaranteed failing check and not very useful.  Excluding the packages that need their tests fixed will at least allow test failures to mean something, and not create an alarming failed check most of the time.