### PR TITLE
Remove instanceof IndexedDbRemoteDocumentCache check

### DIFF
--- a/packages/firestore/src/local/local_store.ts
+++ b/packages/firestore/src/local/local_store.ts
@@ -1112,18 +1112,11 @@ export class LocalStore {
    */
   // PORTING NOTE: Multi-tab only.
   async synchronizeLastDocumentChangeReadTime(): Promise<void> {
-    if (this.remoteDocuments instanceof IndexedDbRemoteDocumentCache) {
-      const remoteDocumentCache = this.remoteDocuments;
-      return this.persistence
-        .runTransaction(
-          'Synchronize last document change read time',
-          'readonly-idempotent',
-          txn => remoteDocumentCache.getLastDocumentChange(txn)
-        )
-        .then(({ readTime }) => {
-          this.lastDocumentChangeReadTime = readTime;
-        });
-    }
+    this.lastDocumentChangeReadTime = await this.persistence.runTransaction(
+      'Synchronize last document change read time',
+      'readonly-idempotent',
+      txn => this.remoteDocuments.getLastReadTime(txn)
+    );
   }
 }
 

--- a/packages/firestore/src/local/memory_remote_document_cache.ts
+++ b/packages/firestore/src/local/memory_remote_document_cache.ts
@@ -188,6 +188,12 @@ export class MemoryRemoteDocumentCache implements RemoteDocumentCache {
     );
   }
 
+  getLastReadTime(
+    transaction: PersistenceTransaction
+  ): PersistencePromise<SnapshotVersion> {
+    return PersistencePromise.resolve(SnapshotVersion.MIN);
+  }
+
   newChangeBuffer(options?: {
     trackRemovals: boolean;
   }): RemoteDocumentChangeBuffer {

--- a/packages/firestore/src/local/remote_document_cache.ts
+++ b/packages/firestore/src/local/remote_document_cache.ts
@@ -96,6 +96,15 @@ export interface RemoteDocumentCache {
   }>;
 
   /**
+   * Returns the read time of the most recently read document in the cache, or
+   * SnapshotVersion.MIN if not available.
+   */
+  // PORTING NOTE: This is only used for multi-tab synchronization.
+  getLastReadTime(
+    transaction: PersistenceTransaction
+  ): PersistencePromise<SnapshotVersion>;
+
+  /**
    * Provides access to add or update the contents of the cache. The buffer
    * handles proper size accounting for the change.
    *

--- a/packages/firestore/test/integration/api_internal/database.test.ts
+++ b/packages/firestore/test/integration/api_internal/database.test.ts
@@ -68,7 +68,7 @@ apiDescribe('Database (with internal API)', (persistence: boolean) => {
       }
     );
   });
-  
+
   it('app delete leads to instance termination', async () => {
     await withTestDoc(persistence, async docRef => {
       await docRef.set({ foo: 'bar' });

--- a/packages/firestore/test/unit/local/counting_query_engine.ts
+++ b/packages/firestore/test/unit/local/counting_query_engine.ts
@@ -115,6 +115,7 @@ export class CountingQueryEngine implements QueryEngine {
         });
       },
       getNewDocumentChanges: subject.getNewDocumentChanges,
+      getLastReadTime: subject.getLastReadTime,
       getSize: subject.getSize,
       newChangeBuffer: subject.newChangeBuffer
     };

--- a/packages/firestore/test/unit/local/remote_document_cache.test.ts
+++ b/packages/firestore/test/unit/local/remote_document_cache.test.ts
@@ -90,16 +90,13 @@ describe('IndexedDbRemoteDocumentCache', () => {
     await persistenceHelpers.clearTestPersistence();
   });
 
-  function getLastDocumentChange(): Promise<{
-    changedDoc: MaybeDocument | undefined;
-    readTime: SnapshotVersion;
-  }> {
+  function getLastReadTime(): Promise<SnapshotVersion> {
     return persistence.runTransaction(
-      'getLastDocumentChange',
+      'getLastReadTime',
       'readonly-idempotent',
       txn => {
         const remoteDocuments = persistence.getRemoteDocumentCache();
-        return remoteDocuments.getLastDocumentChange(txn);
+        return remoteDocuments.getLastReadTime(txn);
       }
     );
   }
@@ -115,7 +112,7 @@ describe('IndexedDbRemoteDocumentCache', () => {
       dontPurgeData: true
     });
     cache = new TestRemoteDocumentCache(persistence);
-    const { readTime } = await getLastDocumentChange();
+    const readTime = await getLastReadTime();
     const { changedDocs } = await cache.getNewDocumentChanges(readTime);
     assertMatches([], changedDocs);
   });


### PR DESCRIPTION
Goal: remove `instanceof IndexedDbRemoteDocumentCache` check in LocalStore to allow me to drop the import.

Realized: We don't even use the document result from getLastDocumentChange. So I changed it to only return the read time.