### PR TITLE
Add tech writer as codeowner for files causing doc changes.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -83,3 +83,7 @@ packages/analytics-types @hsubox76 @Feiyang1 @firebase/jssdk-global-approvers
 # Remote Config Code
 packages/remote-config @erikeldridge @firebase/jssdk-global-approvers
 packages/remote-config-types @erikeldridge @firebase/jssdk-global-approvers
+
+# Documentation Changes
+packages/firebase/index.d.ts @egilmorez
+scripts/docgen/content-sources/ @egilmorez


### PR DESCRIPTION
Will assign tech writer as reviewer for changes to `packages/firebase/index.d.ts` (reference doc source) and `scripts/docgen/content-sources/` (TOC and reference doc home page content).