### PR TITLE
Ignore primary lease loss in maybeGarbageCollectMultiClientState

### DIFF
--- a/packages/firestore/src/local/indexeddb_persistence.ts
+++ b/packages/firestore/src/local/indexeddb_persistence.ts
@@ -72,6 +72,7 @@ import { ReferenceSet } from './reference_set';
 import { ClientId } from './shared_client_state';
 import { TargetData } from './target_data';
 import { SimpleDb, SimpleDbStore, SimpleDbTransaction } from './simple_db';
+import {ignoreIfPrimaryLeaseLoss} from "./local_store";
 
 const LOG_TAG = 'IndexedDbPersistence';
 
@@ -489,7 +490,7 @@ export class IndexedDbPersistence implements Persistence {
             ).next(() => inactive);
           });
         }
-      );
+      ).catch(err => ignoreIfPrimaryLeaseLoss(err).then(() => []));
 
       // Delete potential leftover entries that may continue to mark the
       // inactive clients as zombied in LocalStorage.

--- a/packages/firestore/src/local/indexeddb_persistence.ts
+++ b/packages/firestore/src/local/indexeddb_persistence.ts
@@ -72,8 +72,6 @@ import { ReferenceSet } from './reference_set';
 import { ClientId } from './shared_client_state';
 import { TargetData } from './target_data';
 import { SimpleDb, SimpleDbStore, SimpleDbTransaction } from './simple_db';
-import { ignoreIfPrimaryLeaseLoss } from './local_store';
-
 const LOG_TAG = 'IndexedDbPersistence';
 
 /**
@@ -490,7 +488,12 @@ export class IndexedDbPersistence implements Persistence {
             ).next(() => inactive);
           });
         }
-      ).catch(err => ignoreIfPrimaryLeaseLoss(err).then(() => []));
+      ).catch(() => {
+        // Ignore primary lease violations or any other type of error.
+        // We don't use `ignoreIfPrimaryLeaseLoss` since we don't want to depend
+        // on LocalStore.
+        return [];
+      });
 
       // Delete potential leftover entries that may continue to mark the
       // inactive clients as zombied in LocalStorage.

--- a/packages/firestore/src/local/indexeddb_persistence.ts
+++ b/packages/firestore/src/local/indexeddb_persistence.ts
@@ -72,7 +72,7 @@ import { ReferenceSet } from './reference_set';
 import { ClientId } from './shared_client_state';
 import { TargetData } from './target_data';
 import { SimpleDb, SimpleDbStore, SimpleDbTransaction } from './simple_db';
-import {ignoreIfPrimaryLeaseLoss} from "./local_store";
+import { ignoreIfPrimaryLeaseLoss } from './local_store';
 
 const LOG_TAG = 'IndexedDbPersistence';
 

--- a/packages/firestore/src/local/indexeddb_persistence.ts
+++ b/packages/firestore/src/local/indexeddb_persistence.ts
@@ -489,8 +489,9 @@ export class IndexedDbPersistence implements Persistence {
           });
         }
       ).catch(() => {
-        // Ignore primary lease violations or any other type of error.
-        // We don't use `ignoreIfPrimaryLeaseLoss` since we don't want to depend
+        // Ignore primary lease violations or any other type of error. The next
+        // primary will run `maybeGarbageCollectMultiClientState()` again.
+        // We don't use `ignoreIfPrimaryLeaseLoss()` since we don't want to depend
         // on LocalStore.
         return [];
       });


### PR DESCRIPTION
This ignores the error if the primary lease is somehow lost between updateClientMetadataAndTryBecomePrimary() and maybeGarbageCollectMultiClientState(). There is no special recovery logic needed as the next primary will run the periodic GC.

Fixes https://github.com/firebase/firebase-js-sdk/issues/2555
