### PR TITLE
Fix Firestore Performance spec test

### DIFF
--- a/packages/firestore/test/unit/specs/perf_spec.test.ts
+++ b/packages/firestore/test/unit/specs/perf_spec.test.ts
@@ -34,7 +34,7 @@ describeSpec(
       for (let i = 0; i < STEP_COUNT; ++i) {
         steps
           .userSets(`collection/{i}`, { doc: i })
-          .writeAcks(`collection/{i}`, i);
+          .writeAcks(`collection/{i}`, i + 1); // Prevent zero version
       }
       return steps;
     });


### PR DESCRIPTION
These tests are only run on demand. One of the tests broke when we stopped accepting zero version documents in the RemoteDocumentCache
