### PR TITLE
Upgrade Firestore emulator to 1.10.4

### DIFF
--- a/scripts/emulator-testing/emulators/firestore-emulator.ts
+++ b/scripts/emulator-testing/emulators/firestore-emulator.ts
@@ -26,7 +26,7 @@ export class FirestoreEmulator extends Emulator {
       // Use locked version of emulator for test to be deterministic.
       // The latest version can be found from firestore emulator doc:
       // https://firebase.google.com/docs/firestore/security/test-rules-emulator
-      'https://storage.googleapis.com/firebase-preview-drop/emulator/cloud-firestore-emulator-v1.8.2.jar',
+      'https://storage.googleapis.com/firebase-preview-drop/emulator/cloud-firestore-emulator-v1.10.4.jar',
       port
     );
     this.projectId = projectId;


### PR DESCRIPTION
The emulator now sends resume tokens, which exercises more of the
system. In particular, this means that resuming queries now uses the
index-free query engine.