### PR TITLE
Allow Collection.add() to use custom objects

### DIFF
--- a/packages/firestore/CHANGELOG.md
+++ b/packages/firestore/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Unreleased
+- [fixed] Fixed an issue where `CollectionReference.add()` would reject
+  custom types when using `withConverter()`. (#2606)
+
+# 1.9.3
 - [fixed] Fixed an issue where auth credentials were not respected in some
   Firefox or Chrome extensions. (#1491)
 - [changed] Firestore previously required that every document read in a

--- a/packages/firestore/src/api/database.ts
+++ b/packages/firestore/src/api/database.ts
@@ -2461,7 +2461,10 @@ export class CollectionReference<T = firestore.DocumentData> extends Query<T>
 
   add(value: T): Promise<firestore.DocumentReference<T>> {
     validateExactNumberOfArgs('CollectionReference.add', arguments, 1);
-    validateArgType('CollectionReference.add', 'object', 1, value);
+    const convertedValue = this._converter
+      ? this._converter.toFirestore(value)
+      : value;
+    validateArgType('CollectionReference.add', 'object', 1, convertedValue);
     const docRef = this.doc();
     return docRef.set(value).then(() => docRef);
   }

--- a/packages/firestore/test/integration/api/database.test.ts
+++ b/packages/firestore/test/integration/api/database.test.ts
@@ -1214,12 +1214,9 @@ apiDescribe('Database', (persistence: boolean) => {
 
     it('for CollectionReference.withConverter()', () => {
       return withTestDb(persistence, async db => {
-        const docRef = db
-          .collection('posts')
-          .withConverter(postConverter)
-          .doc();
+        const coll = db.collection('posts').withConverter(postConverter);
 
-        await docRef.set(new Post('post', 'author'));
+        const docRef = await coll.add(new Post('post', 'author'));
         const postData = await docRef.get();
         const post = postData.data();
         expect(post).to.not.equal(undefined);

--- a/scripts/emulator-testing/emulators/firestore-emulator.ts
+++ b/scripts/emulator-testing/emulators/firestore-emulator.ts
@@ -26,7 +26,7 @@ export class FirestoreEmulator extends Emulator {
       // Use locked version of emulator for test to be deterministic.
       // The latest version can be found from firestore emulator doc:
       // https://firebase.google.com/docs/firestore/security/test-rules-emulator
-      'https://storage.googleapis.com/firebase-preview-drop/emulator/cloud-firestore-emulator-v1.8.2.jar',
+      'https://storage.googleapis.com/firebase-preview-drop/emulator/cloud-firestore-emulator-v1.10.4.jar',
       port
     );
     this.projectId = projectId;

--- a/scripts/emulator-testing/emulators/firestore-emulator.ts
+++ b/scripts/emulator-testing/emulators/firestore-emulator.ts
@@ -26,7 +26,7 @@ export class FirestoreEmulator extends Emulator {
       // Use locked version of emulator for test to be deterministic.
       // The latest version can be found from firestore emulator doc:
       // https://firebase.google.com/docs/firestore/security/test-rules-emulator
-      'https://storage.googleapis.com/firebase-preview-drop/emulator/cloud-firestore-emulator-v1.10.4.jar',
+      'https://storage.googleapis.com/firebase-preview-drop/emulator/cloud-firestore-emulator-v1.8.2.jar',
       port
     );
     this.projectId = projectId;


### PR DESCRIPTION
Fixes #2606 

One downside to this approach is if the underlying `DocumentReference.set()` fails, the function name in the error message will not say `CollectionReference.add()` (see `applyFirestoreDataConverter`). I thought about how to refactor `set()` to allow the function name to be passed down, but ultimately decided that this approach is cleaner + the developer can see the stack trace and deduce that for themselves.