### PR TITLE
Rollback: Upgrade Firestore emulator 1.10.4

### DIFF
--- a/scripts/emulator-testing/emulators/firestore-emulator.ts
+++ b/scripts/emulator-testing/emulators/firestore-emulator.ts
@@ -26,7 +26,7 @@ export class FirestoreEmulator extends Emulator {
       // Use locked version of emulator for test to be deterministic.
       // The latest version can be found from firestore emulator doc:
       // https://firebase.google.com/docs/firestore/security/test-rules-emulator
-      'https://storage.googleapis.com/firebase-preview-drop/emulator/cloud-firestore-emulator-v1.10.4.jar',
+      'https://storage.googleapis.com/firebase-preview-drop/emulator/cloud-firestore-emulator-v1.8.2.jar',
       port
     );
     this.projectId = projectId;


### PR DESCRIPTION
Rolling back #2602 

Emulator 1.10.4 causes current integration tests to fail. Rolling back to 1.8.2 for now.