### PR TITLE
Add optimization to SortedSet.unionWith

### DIFF
--- a/packages/firestore/CHANGELOG.md
+++ b/packages/firestore/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
-- [fixed] Fixed a performance regression introduced in 1.7.0. (#2620)
+- [fixed] Fixed a performance regression introduced by the addition of
+  `Query.limitToLast(n: number)` in Firestore 1.7.0 (Firebase 7.3.0) (#2620).
 - [fixed] Fixed an issue where `CollectionReference.add()` would reject
   custom types when using `withConverter()`. (#2606)
 

--- a/packages/firestore/CHANGELOG.md
+++ b/packages/firestore/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Unreleased
+- [fixed] Fixed a performance regression introduced in 1.7.0. (#2620)
 - [fixed] Fixed an issue where `CollectionReference.add()` would reject
   custom types when using `withConverter()`. (#2606)
 

--- a/packages/firestore/src/util/sorted_set.ts
+++ b/packages/firestore/src/util/sorted_set.ts
@@ -136,7 +136,7 @@ export class SortedSet<T> {
   unionWith(other: SortedSet<T>): SortedSet<T> {
     let result: SortedSet<T> = this;
 
-    // Make sure `result` always refers to the larger one of the two set.
+    // Make sure `result` always refers to the larger one of the two sets.
     if (result.size < other.size) {
       result = other;
       other = this;

--- a/packages/firestore/src/util/sorted_set.ts
+++ b/packages/firestore/src/util/sorted_set.ts
@@ -135,6 +135,13 @@ export class SortedSet<T> {
 
   unionWith(other: SortedSet<T>): SortedSet<T> {
     let result: SortedSet<T> = this;
+
+    // Make sure `result` always refers to the larger one of the two set.
+    if (result.size < other.size) {
+      result = other;
+      other = this;
+    }
+
     other.forEach(elem => {
       result = result.add(elem);
     });

--- a/packages/testing/src/api/index.ts
+++ b/packages/testing/src/api/index.ts
@@ -134,7 +134,7 @@ function initializeApp(
         ({
           getToken: async () => ({ accessToken: accessToken }),
           getUid: () => null,
-          addAuthTokenListener: (listener) => {
+          addAuthTokenListener: listener => {
             // Call listener once immediately with predefined accessToken.
             listener(accessToken);
           },


### PR DESCRIPTION
This is a fix to https://github.com/firebase/firebase-js-sdk/issues/2620

Basically `SortedSet.unionWith` does not take the size of the two sets that it is merging into consideration.

What happens is, if there are two set: A that is empty, and B that has size of `N`. The union would take `O(N*logN)` while it could have been a no-op.