### PR TITLE
Disable use of $httpHeaders in Cordova

### DIFF
--- a/packages/firestore/CHANGELOG.md
+++ b/packages/firestore/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Unreleased
+- [fixed] Fixed an issue where auth credentials were not respected in Cordova
+  environments (#2626).
 - [fixed] Fixed a performance regression introduced by the addition of
   `Query.limitToLast(n: number)` in Firestore 1.7.0 (Firebase 7.3.0) (#2620).
 - [fixed] Fixed an issue where `CollectionReference.add()` would reject
-  custom types when using `withConverter()`. (#2606)
+  custom types when using `withConverter()` (#2606).
 
 # 1.9.3
 - [fixed] Fixed an issue where auth credentials were not respected in some

--- a/packages/firestore/src/platform_browser/webchannel_connection.ts
+++ b/packages/firestore/src/platform_browser/webchannel_connection.ts
@@ -29,6 +29,7 @@ import {
   isBrowserExtension,
   isElectron,
   isIE,
+  isMobileCordova,
   isReactNative,
   isUWP
 } from '@firebase/util';
@@ -275,6 +276,7 @@ export class WebChannelConnection implements Connection {
     // known to (sometimes) not include an Origin. See
     // https://github.com/firebase/firebase-js-sdk/issues/1491.
     if (
+      !isMobileCordova() &&
       !isReactNative() &&
       !isElectron() &&
       !isIE() &&


### PR DESCRIPTION
Fixes  #2586 