### PR TITLE
Fix v7.6.2 sw response compatibility with v7.8.1 client

### DIFF
--- a/packages/messaging/src/controllers/window-controller.ts
+++ b/packages/messaging/src/controllers/window-controller.ts
@@ -178,7 +178,10 @@ export class WindowController implements FirebaseMessaging, FirebaseService {
   }
 
   private async messageEventListener(event: MessageEvent): Promise<void> {
-    if (!event.data?.firebaseMessaging) {
+    if (
+      !event.data?.firebaseMessaging &&
+      (!event.data?.firebaseMessagingType || !event.data?.firebaseMessagingData)
+      ) {
       // Not a message from FCM
       return;
     }


### PR DESCRIPTION
https://github.com/firebase/firebase-js-sdk/issues/2590#issuecomment-585863435 We can reproduce it, the `sw` won't get the updated version (7.8.1) and retained the old ones (7.6.2). This is just a temporary fix while @Feiyang1 is looking for a way to update the `sw` syncly upon refreshing the page.
