### PR TITLE
De-dupe module registration

### DIFF
--- a/packages/firestore/index.node.ts
+++ b/packages/firestore/index.node.ts
@@ -15,8 +15,8 @@
  * limitations under the License.
  */
 import firebase from '@firebase/app';
-import * as types from '@firebase/firestore-types';
 import { configureForFirebase } from './src/platform/config';
+import './register-module';
 import './src/platform_node/node_init';
 import { FirebaseNamespace } from '@firebase/app-types';
 
@@ -28,29 +28,3 @@ export function registerFirestore(instance: FirebaseNamespace): void {
 }
 
 registerFirestore(firebase);
-
-declare module '@firebase/app-types' {
-  interface FirebaseNamespace {
-    firestore?: {
-      (app?: FirebaseApp): types.FirebaseFirestore;
-      Blob: typeof types.Blob;
-      CollectionReference: typeof types.CollectionReference;
-      DocumentReference: typeof types.DocumentReference;
-      DocumentSnapshot: typeof types.DocumentSnapshot;
-      FieldPath: typeof types.FieldPath;
-      FieldValue: typeof types.FieldValue;
-      Firestore: typeof types.FirebaseFirestore;
-      GeoPoint: typeof types.GeoPoint;
-      Query: typeof types.Query;
-      QueryDocumentSnapshot: typeof types.QueryDocumentSnapshot;
-      QuerySnapshot: typeof types.QuerySnapshot;
-      Timestamp: typeof types.Timestamp;
-      Transaction: typeof types.Transaction;
-      WriteBatch: typeof types.WriteBatch;
-      setLogLevel: typeof types.setLogLevel;
-    };
-  }
-  interface FirebaseApp {
-    firestore?(): types.FirebaseFirestore;
-  }
-}

--- a/packages/firestore/index.ts
+++ b/packages/firestore/index.ts
@@ -17,9 +17,9 @@
 
 import firebase from '@firebase/app';
 import { configureForFirebase } from './src/platform/config';
+import './register-module';
 import './src/platform_browser/browser_init';
 
-import * as types from '@firebase/firestore-types';
 import { FirebaseNamespace } from '@firebase/app-types';
 
 import { name, version } from './package.json';
@@ -30,29 +30,3 @@ export function registerFirestore(instance: FirebaseNamespace): void {
 }
 
 registerFirestore(firebase);
-
-declare module '@firebase/app-types' {
-  interface FirebaseNamespace {
-    firestore?: {
-      (app?: FirebaseApp): types.FirebaseFirestore;
-      Blob: typeof types.Blob;
-      CollectionReference: typeof types.CollectionReference;
-      DocumentReference: typeof types.DocumentReference;
-      DocumentSnapshot: typeof types.DocumentSnapshot;
-      FieldPath: typeof types.FieldPath;
-      FieldValue: typeof types.FieldValue;
-      Firestore: typeof types.FirebaseFirestore;
-      GeoPoint: typeof types.GeoPoint;
-      Query: typeof types.Query;
-      QueryDocumentSnapshot: typeof types.QueryDocumentSnapshot;
-      QuerySnapshot: typeof types.QuerySnapshot;
-      Timestamp: typeof types.Timestamp;
-      Transaction: typeof types.Transaction;
-      WriteBatch: typeof types.WriteBatch;
-      setLogLevel: typeof types.setLogLevel;
-    };
-  }
-  interface FirebaseApp {
-    firestore?(): types.FirebaseFirestore;
-  }
-}

--- a/packages/firestore/register-module.ts
+++ b/packages/firestore/register-module.ts
@@ -1,0 +1,44 @@
+/**
+ * @license
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as types from '@firebase/firestore-types';
+
+declare module '@firebase/app-types' {
+  interface FirebaseNamespace {
+    firestore?: {
+      (app?: FirebaseApp): types.FirebaseFirestore;
+      Blob: typeof types.Blob;
+      CollectionReference: typeof types.CollectionReference;
+      DocumentReference: typeof types.DocumentReference;
+      DocumentSnapshot: typeof types.DocumentSnapshot;
+      FieldPath: typeof types.FieldPath;
+      FieldValue: typeof types.FieldValue;
+      Firestore: typeof types.FirebaseFirestore;
+      GeoPoint: typeof types.GeoPoint;
+      Query: typeof types.Query;
+      QueryDocumentSnapshot: typeof types.QueryDocumentSnapshot;
+      QuerySnapshot: typeof types.QuerySnapshot;
+      Timestamp: typeof types.Timestamp;
+      Transaction: typeof types.Transaction;
+      WriteBatch: typeof types.WriteBatch;
+      setLogLevel: typeof types.setLogLevel;
+    };
+  }
+  interface FirebaseApp {
+    firestore?(): types.FirebaseFirestore;
+  }
+}


### PR DESCRIPTION
This simplifies adding a new Memory-only Firestore build.