### PR TITLE
De-mangle Node and CJS build

### DIFF
--- a/packages/firestore/src/util/api.ts
+++ b/packages/firestore/src/util/api.ts
@@ -47,7 +47,7 @@ export function makeConstructorPrivate<T extends Function>(
 
   // Copy any static methods/members
   Object.assign(PublicConstructor, cls);
-  
+
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   return PublicConstructor as any;
 }


### PR DESCRIPTION
Removes the mangling from the Node Firestore build, which is probably not as sensitive to size. The actual fix for Node is to just add externs for `GRPC` and `grpcloader`, but at this point I am kind of wary of doing this as we have no integration tests for the mangled Node build.

I also disabled Terser's whitespace and comment removal, since this was previously not applied to NPM builds. 
 
Fixes https://github.com/firebase/firebase-js-sdk/issues/2655