### PR TITLE
Allow for copyrights to be assigned to Google LLC

### DIFF
--- a/tools/gitHooks/license.js
+++ b/tools/gitHooks/license.js
@@ -11,7 +11,7 @@ const root = resolve(__dirname, '../..');
 const git = simpleGit(root);
 const licenseHeader = `/**
  * @license
- * Copyright 2020 Google Inc.
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,14 +35,13 @@ async function doLicenseCommit() {
     ignore: ['**/node_modules/**', '**/dist/**']
   });
 
+  const copyrightPattern = /Copyright \d{4} Google (Inc\.|LLC)/;
+
   // Files with no license block at all.
   const fileContents = await Promise.all(paths.map(path => fs.readFile(path)));
   const filesMissingLicensePaths = fileContents
     .map((buffer, idx) => ({ buffer, path: paths[idx] }))
-    .filter(
-      ({ buffer }) =>
-        String(buffer).match(/Copyright \d{4} Google Inc\./) == null
-    );
+    .filter(({ buffer }) => String(buffer).match(copyrightPattern) == null);
 
   await Promise.all(
     filesMissingLicensePaths.map(({ buffer, path }) => {
@@ -64,7 +63,7 @@ async function doLicenseCommit() {
       const lines = String(buffer).split('\n');
       let newLines = [];
       for (const line of lines) {
-        if (line.match(/Copyright \d{4} Google Inc\./)) {
+        if (line.match(copyrightPattern)) {
           const indent = line.split('*')[0]; // Get whitespace to match
           newLines.push(indent + '* @license');
         }

--- a/tools/gitHooks/license.js
+++ b/tools/gitHooks/license.js
@@ -18,7 +18,6 @@
 const { promisify } = require('util');
 const { resolve } = require('path');
 const simpleGit = require('simple-git/promise');
-const chalk = require('chalk');
 const globRaw = require('glob');
 const fs = require('mz/fs');
 const ora = require('ora');

--- a/tools/gitHooks/license.js
+++ b/tools/gitHooks/license.js
@@ -1,3 +1,20 @@
+/**
+ * @license
+ * Copyright 2017 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 const { promisify } = require('util');
 const { resolve } = require('path');
 const simpleGit = require('simple-git/promise');

--- a/tools/gitHooks/license.js
+++ b/tools/gitHooks/license.js
@@ -45,6 +45,7 @@ const licenseHeader = `/**
 `;
 
 const copyrightPattern = /Copyright \d{4} Google (Inc\.|LLC)/;
+const oldCopyrightPattern = /(\s*\*\s*Copyright \d{4}) Google Inc\./;
 
 async function readFiles(paths) {
   const fileContents = await Promise.all(paths.map(path => fs.readFile(path)));
@@ -64,6 +65,16 @@ function addLicenceTag(contents) {
     }
     newLines.push(line);
   }
+  return newLines.join('\n');
+}
+
+function rewriteCopyrightLine(contents) {
+  const lines = contents.split('\n');
+  let newLines = lines.map(line => {
+    return line.replace(oldCopyrightPattern, (_, leader) => {
+      return leader + ' Google LLC';
+    });
+  });
   return newLines.join('\n');
 }
 
@@ -88,6 +99,11 @@ async function doLicenseCommit() {
       // Files with no @license tag.
       if (result.match(/@license/) == null) {
         result = addLicenceTag(result);
+      }
+
+      // Files with the old form of copyright notice.
+      if (result.match(oldCopyrightPattern) != null) {
+        result = rewriteCopyrightLine(result);
       }
 
       if (contents !== result) {

--- a/tools/gitHooks/license.js
+++ b/tools/gitHooks/license.js
@@ -15,14 +15,11 @@
  * limitations under the License.
  */
 
-const { promisify } = require('util');
 const { resolve } = require('path');
 const simpleGit = require('simple-git/promise');
-const globRaw = require('glob');
 const fs = require('mz/fs');
 const ora = require('ora');
 
-const glob = promisify(globRaw);
 const root = resolve(__dirname, '../..');
 const git = simpleGit(root);
 const licenseHeader = `/**
@@ -78,12 +75,11 @@ function rewriteCopyrightLine(contents) {
   return newLines.join('\n');
 }
 
-async function doLicenseCommit() {
+async function doLicenseCommit(changedFiles) {
   const licenseSpinner = ora(' Validating License Headers').start();
 
-  const paths = await glob('**/*.+(ts|js)', {
-    ignore: ['**/node_modules/**', '**/dist/**']
-  });
+  const paths = changedFiles.filter(line => line.match(/(js|ts)$/));
+  if (paths.length === 0) return;
 
   const files = await readFiles(paths);
 

--- a/tools/gitHooks/prepush.js
+++ b/tools/gitHooks/prepush.js
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2017 Google Inc.
+ * Copyright 2017 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tools/gitHooks/prepush.js
+++ b/tools/gitHooks/prepush.js
@@ -44,11 +44,18 @@ $ git stash pop
       return process.exit(1);
     }
 
+    const diff = await git.diff([
+      '--name-only',
+      '--diff-filter=d',
+      'origin/master...HEAD'
+    ]);
+    const changedFiles = diff.split('\n');
+
     // Style the code
-    await doPrettierCommit();
+    await doPrettierCommit(changedFiles);
 
     // Validate License headers exist
-    await doLicenseCommit();
+    await doLicenseCommit(changedFiles);
 
     console.log(chalk`
 Pre-Push Validation Succeeded

--- a/tools/gitHooks/prettier.js
+++ b/tools/gitHooks/prettier.js
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2017 Google Inc.
+ * Copyright 2017 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tools/gitHooks/prettier.js
+++ b/tools/gitHooks/prettier.js
@@ -56,21 +56,16 @@ function checkVersion() {
   });
 }
 
-async function doPrettierCommit() {
+async function doPrettierCommit(changedFiles) {
   try {
     await checkVersion();
   } catch (e) {
     console.error(e);
     return process.exit(1);
   }
-  const diff = await git.diff([
-    '--name-only',
-    'origin/master...HEAD',
-    '--diff-filter',
-    'd'
-  ]);
+
   // Only run on .js or .ts files.
-  const targetFiles = diff.split('\n').filter(line => line.match(/(js|ts)$/));
+  const targetFiles = changedFiles.filter(line => line.match(/(js|ts)$/));
   if (targetFiles.length === 0) return;
 
   const stylingSpinner = ora(


### PR DESCRIPTION
Current guidance at go/copyright calls for copyright to be assigned to Google LLC, like so:

```
Copyright 2020 Google LLC
```

This change makes this the default without changing existing files. Going forward, any changed files will have their copyright line changed to match.

Note that 1ef26d56 shows what this rewrite will look like.