### PR TITLE
Remove backgroundChannelTest and testUrl from WebChannelOptions

### DIFF
--- a/packages/firestore/src/platform_browser/webchannel_connection.ts
+++ b/packages/firestore/src/platform_browser/webchannel_connection.ts
@@ -228,11 +228,6 @@ export class WebChannelConnection implements Connection {
     ];
     const webchannelTransport = createWebChannelTransport();
     const request: WebChannelOptions = {
-      // Background channel test avoids the initial two test calls and decreases
-      // initial cold start time.
-      // TODO(dimond): wenboz@ mentioned this might affect use with proxies and
-      // we should monitor closely for any reports.
-      backgroundChannelTest: true,
       // Required for backend stickiness, routing behavior is based on this
       // parameter.
       httpSessionIdParam: 'gsessionid',

--- a/packages/webchannel-wrapper/externs/overrides.js
+++ b/packages/webchannel-wrapper/externs/overrides.js
@@ -45,9 +45,6 @@ goog.net.WebChannel.Options.concurrentRequestLimit;
 /** @type {boolean|undefined} */
 goog.net.WebChannel.Options.supportsCrossDomainXhr;
 
-/** @type {string|undefined} */
-goog.net.WebChannel.Options.testUrl;
-
 /** @type {boolean|undefined} */
 goog.net.WebChannel.Options.sendRawJson;
 
@@ -57,7 +54,6 @@ goog.net.WebChannel.Options.httpSessionIdParam;
 /** @type {string|undefined} */
 goog.net.WebChannel.Options.httpHeadersOverwriteParam;
 
-/** @type {boolean|undefined} */
 goog.net.WebChannel.Options.backgroundChannelTest;
 
 /** @type {boolean|undefined} */

--- a/packages/webchannel-wrapper/src/index.d.ts
+++ b/packages/webchannel-wrapper/src/index.d.ts
@@ -85,11 +85,9 @@ export interface WebChannelOptions {
   clientProtocolHeaderRequired?: boolean;
   concurrentRequestLimit?: number;
   supportsCrossDomainXhr?: boolean;
-  testUrl?: string;
   sendRawJson?: boolean;
   httpSessionIdParam?: string;
   httpHeadersOverwriteParam?: string;
-  backgroundChannelTest?: boolean;
   forceLongPolling?: boolean;
   fastHandshake?: boolean;
   disableRedac?: boolean;


### PR DESCRIPTION
These will be deprecated in an upcoming google-closure-library release

Note: `backgroundChannelTest` already defaults to `true` and we don't use `testUrl`.

This replays cl/296469267 and cl/296469871.
