### PR TITLE
Populate GMPID header

### DIFF
--- a/packages/storage/CHANGELOG.md
+++ b/packages/storage/CHANGELOG.md
@@ -1,2 +1,5 @@
+#Unreleased
+- [Changed] Added an additional header to all network requests that propagates the Firebase App ID.
+ 
+# 6.1.0 
 - [Feature] Added the support for List API.
-

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -16,7 +16,8 @@
     "dev": "rollup -c -w",
     "test": "run-p test:browser lint",
     "test:browser": "karma start --single-run",
-    "prepare": "yarn build"
+    "prepare": "yarn build",
+    "prettier": "prettier --write 'src/**/*.ts' 'test/**/*.ts'"
   },
   "license": "Apache-2.0",
   "dependencies": {

--- a/packages/storage/src/implementation/authwrapper.ts
+++ b/packages/storage/src/implementation/authwrapper.ts
@@ -44,6 +44,7 @@ export class AuthWrapper {
   private app_: FirebaseApp | null;
   private authProvider_: Provider<FirebaseAuthInternalName>;
   private bucket_: string | null = null;
+  private appId_: string | null = null;
 
   private storageRefMaker_: (p1: AuthWrapper, p2: Location) => Reference;
   private requestMaker_: requestMaker;
@@ -67,6 +68,7 @@ export class AuthWrapper {
       const options = this.app_.options;
       if (type.isDef(options)) {
         this.bucket_ = AuthWrapper.extractBucket_(options);
+        this.appId_ = options.appId ?? null;
       }
     }
     this.authProvider_ = authProvider;
@@ -138,7 +140,12 @@ export class AuthWrapper {
     authToken: string | null
   ): Request<T> {
     if (!this.deleted_) {
-      const request = this.requestMaker_(requestInfo, authToken, this.pool_);
+      const request = this.requestMaker_(
+        requestInfo,
+        this.appId_,
+        authToken,
+        this.pool_
+      );
       this.requestMap_.addRequest(request);
       return request;
     } else {

--- a/packages/storage/src/implementation/request.ts
+++ b/packages/storage/src/implementation/request.ts
@@ -280,17 +280,25 @@ export function addVersionHeader_(headers: Headers): void {
   headers['X-Firebase-Storage-Version'] = 'webjs/' + version;
 }
 
+export function addGmpidHeader_(headers: Headers, appId: string | null): void {
+  if (appId) {
+    headers['X-Firebase-GMPID'] = appId;
+  }
+}
+
 /**
  * @template T
  */
 export function makeRequest<T>(
   requestInfo: RequestInfo<T>,
+  appId: string | null,
   authToken: string | null,
   pool: XhrIoPool
 ): Request<T> {
   const queryPart = UrlUtils.makeQueryString(requestInfo.urlParams);
   const url = requestInfo.url + queryPart;
   const headers = Object.assign({}, requestInfo.headers);
+  addGmpidHeader_(headers, appId);
   addAuthHeader_(headers, authToken);
   addVersionHeader_(headers);
   return new NetworkRequest<T>(

--- a/packages/storage/src/implementation/requestmaker.ts
+++ b/packages/storage/src/implementation/requestmaker.ts
@@ -20,6 +20,7 @@ import { XhrIoPool } from './xhriopool';
 
 type requestMaker = <T>(
   requestInfo: RequestInfo<T>,
+  appId: string | null,
   authToken: string | null,
   pool: XhrIoPool
 ) => Request<T>;

--- a/packages/storage/test/request.test.ts
+++ b/packages/storage/test/request.test.ts
@@ -58,7 +58,7 @@ describe('Firebase Storage > Request', () => {
     requestInfo.headers[requestHeader] = requestValue;
     requestInfo.successCodes = [200, 234];
 
-    return makeRequest(requestInfo, null, makePool(spiedSend))
+    return makeRequest(requestInfo, null, null, makePool(spiedSend))
       .getPromise()
       .then(
         result => {
@@ -100,7 +100,7 @@ describe('Firebase Storage > Request', () => {
     requestInfo.urlParams[p1] = v1;
     requestInfo.urlParams[p2] = v2;
     requestInfo.body = 'thisistherequestbody';
-    return makeRequest(requestInfo, null, makePool(spiedSend))
+    return makeRequest(requestInfo, null, null, makePool(spiedSend))
       .getPromise()
       .then(
         () => {
@@ -143,7 +143,7 @@ describe('Firebase Storage > Request', () => {
       timeout
     );
 
-    return makeRequest(requestInfo, null, makePool(newSend))
+    return makeRequest(requestInfo, null, null, makePool(newSend))
       .getPromise()
       .then(
         () => {
@@ -165,7 +165,7 @@ describe('Firebase Storage > Request', () => {
       handler,
       timeout
     );
-    const request = makeRequest(requestInfo, null, makePool(null));
+    const request = makeRequest(requestInfo, null, null, makePool(null));
     const promise = request.getPromise().then(
       () => {
         assert.fail('Succeeded when handler gave error');
@@ -192,13 +192,52 @@ describe('Firebase Storage > Request', () => {
       handler,
       timeout
     );
-    const request = makeRequest(requestInfo, authToken, makePool(spiedSend));
+    const request = makeRequest(
+      requestInfo,
+      /* appId= */ null,
+      authToken,
+      makePool(spiedSend)
+    );
     return request.getPromise().then(
       () => {
         assert.isTrue(spiedSend.calledOnce);
         const args: unknown[] = spiedSend.getCall(0).args;
         const expectedHeaders: { [key: string]: string } = {
           Authorization: 'Firebase ' + authToken
+        };
+        expectedHeaders[versionHeaderName] = versionHeaderValue;
+        assert.deepEqual(args[4], expectedHeaders);
+      },
+      () => {
+        assert.fail('Request failed unexpectedly');
+      }
+    );
+  });
+
+  it('Sends APP ID along properly', () => {
+    const appId = 'myFirebaseApp';
+
+    function newSend(xhrio: TestingXhrIo): void {
+      xhrio.simulateResponse(200, '', {});
+    }
+    const spiedSend = sinon.spy(newSend);
+
+    function handler(): boolean {
+      return true;
+    }
+    const requestInfo = new RequestInfo(
+      'http://my-url.com/',
+      'GET',
+      handler,
+      timeout
+    );
+    const request = makeRequest(requestInfo, appId, null, makePool(spiedSend));
+    return request.getPromise().then(
+      () => {
+        assert.isTrue(spiedSend.calledOnce);
+        const args: unknown[] = spiedSend.getCall(0).args;
+        const expectedHeaders: { [key: string]: string } = {
+          'X-Firebase-GMPID': appId
         };
         expectedHeaders[versionHeaderName] = versionHeaderValue;
         assert.deepEqual(args[4], expectedHeaders);


### PR DESCRIPTION
This populates the GMPID header for Storage on Web. 

See https://github.com/firebase/firebase-android-sdk/blob/e95f91e64c79206549302e9f37341534c29f58af/firebase-storage/src/main/java/com/google/firebase/storage/network/NetworkRequest.java#L53 for reference.