### PR TITLE
Fix promises in Analytics tests

### DIFF
--- a/packages/analytics/index.ts
+++ b/packages/analytics/index.ts
@@ -19,7 +19,7 @@ import '@firebase/installations';
 import { FirebaseAnalytics } from '@firebase/analytics-types';
 import { FirebaseAnalyticsInternal } from '@firebase/analytics-interop-types';
 import { _FirebaseNamespace } from '@firebase/app-types/private';
-import { factory, settings, resetGlobalVars } from './src/factory';
+import { factory, settings, resetGlobalVars, getGlobalVars } from './src/factory';
 import { EventName } from './src/constants';
 import {
   Component,
@@ -82,7 +82,7 @@ export function registerAnalytics(instance: _FirebaseNamespace): void {
   }
 }
 
-export { factory, settings, resetGlobalVars };
+export { factory, settings, resetGlobalVars, getGlobalVars };
 
 registerAnalytics(firebase as _FirebaseNamespace);
 

--- a/packages/analytics/src/factory.ts
+++ b/packages/analytics/src/factory.ts
@@ -86,6 +86,15 @@ export function resetGlobalVars(
 }
 
 /**
+ * For testing
+ */
+export function getGlobalVars(): { initializedIdPromisesMap: { [gaId: string]: Promise<void> }} {
+  return {
+    initializedIdPromisesMap
+  };
+}
+
+/**
  * This must be run before calling firebase.analytics() or it won't
  * have any effect.
  * @param options Custom gtag and dataLayer names.

--- a/packages/analytics/src/helpers.test.ts
+++ b/packages/analytics/src/helpers.test.ts
@@ -80,10 +80,10 @@ describe('FirebaseAnalytics methods', () => {
     });
 
     it('new window.gtag function waits for all initialization promises before sending group events', async () => {
-      const deferred = new Deferred<void>();
-      const deferred2 = new Deferred<void>();
+      const initPromise1 = new Deferred<void>();
+      const initPromise2 = new Deferred<void>();
       wrapOrCreateGtag(
-        { [mockAnalyticsId]: deferred.promise, otherId: deferred2.promise },
+        { [mockAnalyticsId]: initPromise1.promise, otherId: initPromise2.promise },
         'dataLayer',
         'gtag'
       );
@@ -92,15 +92,13 @@ describe('FirebaseAnalytics methods', () => {
         'transaction_id': 'abcd123',
         'send_to': 'some_group'
       });
-      await Promise.resolve(); // Clear async event stack but not pending initialization promises.
       expect((window['dataLayer'] as DataLayer).length).to.equal(0);
 
-      deferred.resolve(); // Resolves first initialization promise.
-      await Promise.resolve(); // wait for the next cycle
+      initPromise1.resolve(); // Resolves first initialization promise.
       expect((window['dataLayer'] as DataLayer).length).to.equal(0);
 
-      deferred2.resolve(); // Resolves second initialization promise.
-      await Promise.resolve(); // wait for the next cycle
+      initPromise2.resolve(); // Resolves second initialization promise.
+      await Promise.all([initPromise1, initPromise2]); // Wait for resolution of Promise.all()
 
       expect((window['dataLayer'] as DataLayer).length).to.equal(1);
     });
@@ -109,10 +107,10 @@ describe('FirebaseAnalytics methods', () => {
       'new window.gtag function waits for all initialization promises before sending ' +
         'event with at least one unknown send_to ID',
       async () => {
-        const deferred = new Deferred<void>();
-        const deferred2 = new Deferred<void>();
+        const initPromise1 = new Deferred<void>();
+        const initPromise2 = new Deferred<void>();
         wrapOrCreateGtag(
-          { [mockAnalyticsId]: deferred.promise, otherId: deferred2.promise },
+          { [mockAnalyticsId]: initPromise1.promise, otherId: initPromise2.promise },
           'dataLayer',
           'gtag'
         );
@@ -121,15 +119,13 @@ describe('FirebaseAnalytics methods', () => {
           'transaction_id': 'abcd123',
           'send_to': [mockAnalyticsId, 'some_group']
         });
-        await Promise.resolve(); // Clear async event stack but not pending initialization promises.
         expect((window['dataLayer'] as DataLayer).length).to.equal(0);
 
-        deferred.resolve(); // Resolves first initialization promise.
-        await Promise.resolve(); // wait for the next cycle
+        initPromise1.resolve(); // Resolves first initialization promise.
         expect((window['dataLayer'] as DataLayer).length).to.equal(0);
 
-        deferred2.resolve(); // Resolves second initialization promise.
-        await Promise.resolve(); // wait for the next cycle
+        initPromise2.resolve(); // Resolves second initialization promise.
+        await Promise.all([initPromise1, initPromise2]); // Wait for resolution of Promise.all()
 
         expect((window['dataLayer'] as DataLayer).length).to.equal(1);
       }
@@ -139,10 +135,10 @@ describe('FirebaseAnalytics methods', () => {
       'new window.gtag function waits for all initialization promises before sending ' +
         'events with no send_to field',
       async () => {
-        const deferred = new Deferred<void>();
-        const deferred2 = new Deferred<void>();
+        const initPromise1 = new Deferred<void>();
+        const initPromise2 = new Deferred<void>();
         wrapOrCreateGtag(
-          { [mockAnalyticsId]: deferred.promise, otherId: deferred2.promise },
+          { [mockAnalyticsId]: initPromise1.promise, otherId: initPromise2.promise },
           'dataLayer',
           'gtag'
         );
@@ -150,15 +146,13 @@ describe('FirebaseAnalytics methods', () => {
         (window['gtag'] as Gtag)(GtagCommand.EVENT, 'purchase', {
           'transaction_id': 'abcd123'
         });
-        await Promise.resolve(); // Clear async event stack but not pending initialization promises.
         expect((window['dataLayer'] as DataLayer).length).to.equal(0);
 
-        deferred.resolve(); // Resolves first initialization promise.
-        await Promise.resolve(); // wait for the next cycle
+        initPromise1.resolve(); // Resolves first initialization promise.
         expect((window['dataLayer'] as DataLayer).length).to.equal(0);
 
-        deferred2.resolve(); // Resolves second initialization promise.
-        await Promise.resolve(); // wait for the next cycle
+        initPromise2.resolve(); // Resolves second initialization promise.
+        await Promise.all([initPromise1, initPromise2]); // Wait for resolution of Promise.all()
 
         expect((window['dataLayer'] as DataLayer).length).to.equal(1);
       }
@@ -168,10 +162,10 @@ describe('FirebaseAnalytics methods', () => {
       'new window.gtag function only waits for firebase initialization promise ' +
         'before sending event only targeted to Firebase instance GA ID',
       async () => {
-        const deferred = new Deferred<void>();
-        const deferred2 = new Deferred<void>();
+        const initPromise1 = new Deferred<void>();
+        const initPromise2 = new Deferred<void>();
         wrapOrCreateGtag(
-          { [mockAnalyticsId]: deferred.promise, otherId: deferred2.promise },
+          { [mockAnalyticsId]: initPromise1.promise, otherId: initPromise2.promise },
           'dataLayer',
           'gtag'
         );
@@ -180,11 +174,10 @@ describe('FirebaseAnalytics methods', () => {
           'transaction_id': 'abcd123',
           'send_to': mockAnalyticsId
         });
-        await Promise.resolve(); // Clear async event stack but not pending initialization promises.
         expect((window['dataLayer'] as DataLayer).length).to.equal(0);
 
-        deferred.resolve(); // Resolves first initialization promise.
-        await Promise.resolve(); // wait for the next cycle
+        initPromise1.resolve(); // Resolves first initialization promise.
+        await Promise.all([initPromise1]); // Wait for resolution of Promise.all()
 
         expect((window['dataLayer'] as DataLayer).length).to.equal(1);
       }
@@ -196,7 +189,7 @@ describe('FirebaseAnalytics methods', () => {
       (window['gtag'] as Gtag)(GtagCommand.EVENT, 'purchase', {
         'transaction_id': 'abcd123'
       });
-      await Promise.resolve(); // Clear async event stack.
+      await Promise.all([]); // Promise.all() always runs before event call, even if empty.
       expect((window['dataLayer'] as DataLayer).length).to.equal(1);
     });
 
@@ -212,9 +205,9 @@ describe('FirebaseAnalytics methods', () => {
     });
 
     it('new window.gtag function waits for initialization promise when sending "config" calls', async () => {
-      const deferred = new Deferred<void>();
+      const initPromise1 = new Deferred<void>();
       wrapOrCreateGtag(
-        { [mockAnalyticsId]: deferred.promise },
+        { [mockAnalyticsId]: initPromise1.promise },
         'dataLayer',
         'gtag'
       );
@@ -222,11 +215,10 @@ describe('FirebaseAnalytics methods', () => {
       (window['gtag'] as Gtag)(GtagCommand.CONFIG, mockAnalyticsId, {
         'language': 'en'
       });
-      await Promise.resolve();
       expect((window['dataLayer'] as DataLayer).length).to.equal(0);
 
-      deferred.resolve();
-      await Promise.resolve();
+      initPromise1.resolve();
+      await Promise.all([initPromise1]); // Wait for resolution of Promise.all()
 
       expect((window['dataLayer'] as DataLayer).length).to.equal(1);
     });
@@ -237,7 +229,7 @@ describe('FirebaseAnalytics methods', () => {
       (window['gtag'] as Gtag)(GtagCommand.CONFIG, mockAnalyticsId, {
         'transaction_id': 'abcd123'
       });
-      await Promise.resolve(); // Clear async event stack.
+      await Promise.resolve(); // Config call is always chained onto a promise, even if empty.
       expect((window['dataLayer'] as DataLayer).length).to.equal(1);
     });
   });
@@ -254,10 +246,10 @@ describe('FirebaseAnalytics methods', () => {
     });
 
     it('new window.gtag function waits for all initialization promises before sending group events', async () => {
-      const deferred = new Deferred<void>();
-      const deferred2 = new Deferred<void>();
+      const initPromise1 = new Deferred<void>();
+      const initPromise2 = new Deferred<void>();
       wrapOrCreateGtag(
-        { [mockAnalyticsId]: deferred.promise, otherId: deferred2.promise },
+        { [mockAnalyticsId]: initPromise1.promise, otherId: initPromise2.promise },
         'dataLayer',
         'gtag'
       );
@@ -265,15 +257,13 @@ describe('FirebaseAnalytics methods', () => {
         'transaction_id': 'abcd123',
         'send_to': 'some_group'
       });
-      await Promise.resolve(); // Clear async event stack but not pending initialization promises.
       expect(existingGtagStub).to.not.be.called;
 
-      deferred.resolve(); // Resolves first initialization promise.
-      await Promise.resolve(); // wait for the next cycle
+      initPromise1.resolve(); // Resolves first initialization promise.
       expect(existingGtagStub).to.not.be.called;
 
-      deferred2.resolve(); // Resolves second initialization promise.
-      await Promise.resolve(); // wait for the next cycle
+      initPromise2.resolve(); // Resolves second initialization promise.
+      await Promise.all([initPromise1, initPromise2]); // Wait for resolution of Promise.all()
 
       expect(existingGtagStub).to.be.calledWith(GtagCommand.EVENT, 'purchase', {
         'send_to': 'some_group',
@@ -285,10 +275,10 @@ describe('FirebaseAnalytics methods', () => {
       'new window.gtag function waits for all initialization promises before sending ' +
         'event with at least one unknown send_to ID',
       async () => {
-        const deferred = new Deferred<void>();
-        const deferred2 = new Deferred<void>();
+        const initPromise1 = new Deferred<void>();
+        const initPromise2 = new Deferred<void>();
         wrapOrCreateGtag(
-          { [mockAnalyticsId]: deferred.promise, otherId: deferred2.promise },
+          { [mockAnalyticsId]: initPromise1.promise, otherId: initPromise2.promise },
           'dataLayer',
           'gtag'
         );
@@ -296,15 +286,13 @@ describe('FirebaseAnalytics methods', () => {
           'transaction_id': 'abcd123',
           'send_to': [mockAnalyticsId, 'some_group']
         });
-        await Promise.resolve(); // Clear async event stack but not pending initialization promises.
         expect(existingGtagStub).to.not.be.called;
 
-        deferred.resolve(); // Resolves first initialization promise.
-        await Promise.resolve(); // wait for the next cycle
+        initPromise1.resolve(); // Resolves first initialization promise.
         expect(existingGtagStub).to.not.be.called;
 
-        deferred2.resolve(); // Resolves second initialization promise.
-        await Promise.resolve(); // wait for the next cycle
+        initPromise2.resolve(); // Resolves second initialization promise.
+        await Promise.all([initPromise1, initPromise2]); // Wait for resolution of Promise.all()
 
         expect(existingGtagStub).to.be.calledWith(
           GtagCommand.EVENT,
@@ -321,25 +309,23 @@ describe('FirebaseAnalytics methods', () => {
       'new window.gtag function waits for all initialization promises before sending ' +
         'events with no send_to field',
       async () => {
-        const deferred = new Deferred<void>();
-        const deferred2 = new Deferred<void>();
+        const initPromise1 = new Deferred<void>();
+        const initPromise2 = new Deferred<void>();
         wrapOrCreateGtag(
-          { [mockAnalyticsId]: deferred.promise, otherId: deferred2.promise },
+          { [mockAnalyticsId]: initPromise1.promise, otherId: initPromise2.promise },
           'dataLayer',
           'gtag'
         );
         (window['gtag'] as Gtag)(GtagCommand.EVENT, 'purchase', {
           'transaction_id': 'abcd123'
         });
-        await Promise.resolve(); // Clear async event stack but not pending initialization promises.
         expect(existingGtagStub).to.not.be.called;
 
-        deferred.resolve(); // Resolves first initialization promise.
-        await Promise.resolve(); // wait for the next cycle
+        initPromise1.resolve(); // Resolves first initialization promise.
         expect(existingGtagStub).to.not.be.called;
 
-        deferred2.resolve(); // Resolves second initialization promise.
-        await Promise.resolve(); // wait for the next cycle
+        initPromise2.resolve(); // Resolves second initialization promise.
+        await Promise.all([initPromise1, initPromise2]); // Wait for resolution of Promise.all()
 
         expect(existingGtagStub).to.be.calledWith(
           GtagCommand.EVENT,
@@ -353,10 +339,10 @@ describe('FirebaseAnalytics methods', () => {
       'new window.gtag function only waits for firebase initialization promise ' +
         'before sending event only targeted to Firebase instance GA ID',
       async () => {
-        const deferred = new Deferred<void>();
-        const deferred2 = new Deferred<void>();
+        const initPromise1 = new Deferred<void>();
+        const initPromise2 = new Deferred<void>();
         wrapOrCreateGtag(
-          { [mockAnalyticsId]: deferred.promise, otherId: deferred2.promise },
+          { [mockAnalyticsId]: initPromise1.promise, otherId: initPromise2.promise },
           'dataLayer',
           'gtag'
         );
@@ -364,11 +350,10 @@ describe('FirebaseAnalytics methods', () => {
           'transaction_id': 'abcd123',
           'send_to': mockAnalyticsId
         });
-        await Promise.resolve(); // Clear async event stack but not pending initialization promises.
         expect(existingGtagStub).to.not.be.called;
 
-        deferred.resolve(); // Resolves first initialization promise.
-        await Promise.resolve(); // wait for the next cycle
+        initPromise1.resolve(); // Resolves first initialization promise.
+        await Promise.all([initPromise1]); // Wait for resolution of Promise.all()
 
         expect(existingGtagStub).to.be.calledWith(
           GtagCommand.EVENT,
@@ -384,7 +369,7 @@ describe('FirebaseAnalytics methods', () => {
       (window['gtag'] as Gtag)(GtagCommand.EVENT, 'purchase', {
         'transaction_id': 'abcd321'
       });
-      await Promise.resolve(); // Clear async event stack.
+      await Promise.all([]); // Promise.all() always runs before event call, even if empty.
       expect(existingGtagStub).to.be.calledWith(GtagCommand.EVENT, 'purchase', {
         'transaction_id': 'abcd321'
       });
@@ -404,9 +389,9 @@ describe('FirebaseAnalytics methods', () => {
     });
 
     it('new window.gtag function waits for initialization promise when sending "config" calls', async () => {
-      const deferred = new Deferred<void>();
+      const initPromise1 = new Deferred<void>();
       wrapOrCreateGtag(
-        { [mockAnalyticsId]: deferred.promise },
+        { [mockAnalyticsId]: initPromise1.promise },
         'dataLayer',
         'gtag'
       );
@@ -414,11 +399,10 @@ describe('FirebaseAnalytics methods', () => {
       (window['gtag'] as Gtag)(GtagCommand.CONFIG, mockAnalyticsId, {
         'language': 'en'
       });
-      await Promise.resolve();
       expect(existingGtagStub).to.not.be.called;
 
-      deferred.resolve();
-      await Promise.resolve();
+      initPromise1.resolve();
+      await Promise.all([initPromise1]); // Wait for resolution of Promise.all()
 
       expect(existingGtagStub).to.be.calledWith(
         GtagCommand.CONFIG,
@@ -435,7 +419,7 @@ describe('FirebaseAnalytics methods', () => {
       (window['gtag'] as Gtag)(GtagCommand.CONFIG, mockAnalyticsId, {
         'transaction_id': 'abcd123'
       });
-      await Promise.resolve(); // Clear async event stack.
+      await Promise.resolve(); // Config call is always chained onto a promise, even if empty.
       expect(existingGtagStub).to.be.calledWith(
         GtagCommand.CONFIG,
         mockAnalyticsId,

--- a/packages/analytics/testing/get-fake-firebase-services.ts
+++ b/packages/analytics/testing/get-fake-firebase-services.ts
@@ -41,10 +41,11 @@ export function getFakeApp(measurementId?: string): FirebaseApp {
 }
 
 export function getFakeInstallations(
-  fid: string = 'fid-1234'
+  fid: string = 'fid-1234',
+  onFidResolve?: Function
 ): FirebaseInstallations {
   return {
-    getId: async () => fid,
+    getId: async () => { onFidResolve && onFidResolve(); return fid; },
     getToken: async () => 'authToken',
     onIdChange: () => () => undefined,
     delete: async () => undefined


### PR DESCRIPTION
More strongly tie promise `await`s in Analytics tests to the actual function being waited for, rather than generic ticks.  This will prevent test errors when upgrading `tslib` to a new version that handles promises more correctly.