### PR TITLE
Make ordering for BooleanValues explicit

### DIFF
--- a/packages/firestore/CHANGELOG.md
+++ b/packages/firestore/CHANGELOG.md
@@ -1,8 +1,4 @@
 # Unreleased
-- [fixed] Fixed an issue with our field ordering if the field values that were 
-  compared where both boolean.
-
-#  1.9.4
 - [fixed] Fixed an issue where auth credentials were not respected in Cordova
   environments (#2626).
 - [fixed] Fixed a performance regression introduced by the addition of

--- a/packages/firestore/CHANGELOG.md
+++ b/packages/firestore/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Unreleased
+- [fixed] Fixed an issue with our field ordering if the field values that were 
+  compared where both boolean.
+
+#  1.9.4
 - [fixed] Fixed an issue where auth credentials were not respected in Cordova
   environments (#2626).
 - [fixed] Fixed a performance regression introduced by the addition of

--- a/packages/firestore/src/model/field_value.ts
+++ b/packages/firestore/src/model/field_value.ts
@@ -203,7 +203,7 @@ export class BooleanValue extends FieldValue {
 
   compareTo(other: FieldValue): number {
     if (other instanceof BooleanValue) {
-      return primitiveComparator(this, other);
+      return primitiveComparator(this.internalValue, other.internalValue);
     }
     return this.defaultCompareTo(other);
   }


### PR DESCRIPTION
The implementation in `master` relies on the valueOf() semantics, which ends up comparing the Object value using JavaScript magic (but happens to match the desired outcome). Instead, we should directly compare the internal boolean value.