### PR TITLE
Remove dependency on global atob/btoa functions

### DIFF
--- a/packages/firestore/externs.json
+++ b/packages/firestore/externs.json
@@ -20,6 +20,7 @@
     "packages/component/dist/src/component_container.d.ts",
     "packages/logger/dist/src/logger.d.ts",
     "packages/webchannel-wrapper/src/index.d.ts",
+    "packages/util/dist/src/crypt.d.ts",
     "packages/util/dist/src/environment.d.ts",
     "packages/firestore/src/protos/firestore_proto_api.d.ts",
     "packages/firestore/dist/lib/src/util/error.d.ts",

--- a/packages/firestore/src/api/blob.ts
+++ b/packages/firestore/src/api/blob.ts
@@ -39,16 +39,6 @@ function assertUint8ArrayAvailable(): void {
   }
 }
 
-/** Helper function to assert Base64 functions are available at runtime. */
-function assertBase64Available(): void {
-  if (!PlatformSupport.getPlatform().base64Available) {
-    throw new FirestoreError(
-      Code.UNIMPLEMENTED,
-      'Blobs are unavailable in Firestore in this environment.'
-    );
-  }
-}
-
 /**
  * Immutable class holding a blob (binary data).
  * This class is directly exposed in the public API.
@@ -64,14 +54,12 @@ export class Blob {
   private _binaryString: string;
 
   private constructor(binaryString: string) {
-    assertBase64Available();
     this._binaryString = binaryString;
   }
 
   static fromBase64String(base64: string): Blob {
     validateExactNumberOfArgs('Blob.fromBase64String', arguments, 1);
     validateArgType('Blob.fromBase64String', 'string', 1, base64);
-    assertBase64Available();
     try {
       const binaryString = PlatformSupport.getPlatform().atob(base64);
       return new Blob(binaryString);
@@ -95,7 +83,6 @@ export class Blob {
 
   toBase64(): string {
     validateExactNumberOfArgs('Blob.toBase64', arguments, 0);
-    assertBase64Available();
     return PlatformSupport.getPlatform().btoa(this._binaryString);
   }
 

--- a/packages/firestore/src/platform/platform.ts
+++ b/packages/firestore/src/platform/platform.ts
@@ -48,9 +48,6 @@ export interface Platform {
 
   /** The Platform's 'document' implementation or null if not available. */
   readonly document: Document | null;
-
-  /** True if and only if the Base64 conversion functions are available. */
-  readonly base64Available: boolean;
 }
 
 /**

--- a/packages/firestore/src/platform_browser/browser_platform.ts
+++ b/packages/firestore/src/platform_browser/browser_platform.ts
@@ -24,12 +24,11 @@ import { ConnectivityMonitor } from './../remote/connectivity_monitor';
 import { NoopConnectivityMonitor } from '../remote/connectivity_monitor_noop';
 import { BrowserConnectivityMonitor } from './browser_connectivity_monitor';
 import { WebChannelConnection } from './webchannel_connection';
+import { base64 } from '@firebase/util';
 
 export class BrowserPlatform implements Platform {
-  readonly base64Available: boolean;
 
   constructor() {
-    this.base64Available = typeof atob !== 'undefined';
   }
 
   get document(): Document | null {
@@ -61,10 +60,10 @@ export class BrowserPlatform implements Platform {
   }
 
   atob(encoded: string): string {
-    return atob(encoded);
+    return base64.decodeString(encoded, /*webSafe=*/ false);
   }
 
   btoa(raw: string): string {
-    return btoa(raw);
+    return base64.encodeString(raw, /*webSafe=*/ false);
   }
 }

--- a/packages/firestore/src/platform_browser/browser_platform.ts
+++ b/packages/firestore/src/platform_browser/browser_platform.ts
@@ -27,10 +27,6 @@ import { WebChannelConnection } from './webchannel_connection';
 import { base64 } from '@firebase/util';
 
 export class BrowserPlatform implements Platform {
-
-  constructor() {
-  }
-
   get document(): Document | null {
     return typeof document !== 'undefined' ? document : null;
   }

--- a/packages/firestore/src/platform_node/node_platform.ts
+++ b/packages/firestore/src/platform_node/node_platform.ts
@@ -29,7 +29,6 @@ import { GrpcConnection } from './grpc_connection';
 import { loadProtos } from './load_protos';
 
 export class NodePlatform implements Platform {
-  readonly base64Available = true;
 
   readonly document = null;
 

--- a/packages/firestore/src/platform_node/node_platform.ts
+++ b/packages/firestore/src/platform_node/node_platform.ts
@@ -29,7 +29,6 @@ import { GrpcConnection } from './grpc_connection';
 import { loadProtos } from './load_protos';
 
 export class NodePlatform implements Platform {
-
   readonly document = null;
 
   get window(): Window | null {

--- a/packages/firestore/test/util/test_platform.ts
+++ b/packages/firestore/test/util/test_platform.ts
@@ -229,10 +229,6 @@ export class TestPlatform implements Platform {
     return this.mockWindow as any; //eslint-disable-line @typescript-eslint/no-explicit-any
   }
 
-  get base64Available(): boolean {
-    return this.basePlatform.base64Available;
-  }
-
   raiseVisibilityEvent(visibility: VisibilityState): void {
     if (this.mockDocument) {
       this.mockDocument.raiseVisibilityEvent(visibility);


### PR DESCRIPTION
Fixes #2667 

#2639 introduced use of `atob` in `ByteString`, which is causing the failure in environments where there is no global `atob` function. This PR removes the dependency on  global `atob` by using our own `atob` function when global `atob` is unavailable.