### PR TITLE
Add mangled CJS build

### DIFF
--- a/packages/firestore/package.json
+++ b/packages/firestore/package.json
@@ -52,6 +52,7 @@
     "rollup-plugin-json": "4.0.0",
     "rollup-plugin-node-resolve": "5.2.0",
     "rollup-plugin-replace": "2.2.0",
+    "rollup-plugin-sourcemaps": "0.5.0",
     "rollup-plugin-terser": "5.1.3",
     "rollup-plugin-typescript2": "0.25.3",
     "ts-node": "8.5.4",

--- a/packages/firestore/rollup.config.js
+++ b/packages/firestore/rollup.config.js
@@ -88,23 +88,6 @@ const es5Builds = [
       )
   },
   /**
-   * Browser CJS Build
-   *
-   * The Browser CJS build is not mangled as Terser's property name mangling
-   * does not work well with CommonJS-style files.
-   */
-  {
-    input: 'index.ts',
-    output: { file: pkg.browser, format: 'cjs', sourcemap: true },
-    plugins: [
-      typescriptPlugin({
-        typescript,
-        cacheRoot: './.cache/cjs/'
-      }),
-      json()
-    ]
-  },
-  /**
    * Browser ESM Build
    */
   {
@@ -120,7 +103,14 @@ const es5Builds = [
       terser(terserOptions)
     ],
     external: id => deps.some(dep => id === dep || id.startsWith(`${dep}/`))
-  }
+  },
+  /**
+   * Browser CJS Build (based on the mangling in the ESM build above)
+   */
+  {
+    input: pkg.module,
+    output: { file: pkg.browser, format: 'cjs', sourcemap: true },
+  },
 ];
 
 /**

--- a/packages/firestore/rollup.config.js
+++ b/packages/firestore/rollup.config.js
@@ -105,7 +105,10 @@ const es5Builds = [
     external: id => deps.some(dep => id === dep || id.startsWith(`${dep}/`))
   },
   /**
-   * Browser CJS Build (based on the mangling in the ESM build above)
+   * Browser CJS Build 
+   * 
+   * This build is based on the mangling in the ESM build above, since
+   * Terser's Property name mangling doesn't work well with CJS's syntax.
    */
   {
     input: pkg.module,

--- a/packages/firestore/rollup.config.js
+++ b/packages/firestore/rollup.config.js
@@ -21,6 +21,7 @@ import json from 'rollup-plugin-json';
 import typescriptPlugin from 'rollup-plugin-typescript2';
 import replace from 'rollup-plugin-replace';
 import copy from 'rollup-plugin-copy-assets';
+import sourcemaps from 'rollup-plugin-sourcemaps';
 import typescript from 'typescript';
 import { terser } from 'rollup-plugin-terser';
 
@@ -113,6 +114,7 @@ const es5Builds = [
   {
     input: pkg.module,
     output: { file: pkg.browser, format: 'cjs', sourcemap: true },
+    plugins: [ sourcemaps() ]
   },
 ];
 


### PR DESCRIPTION
This adds a mangled CJS build for Firestore and works around the fact that Terser's mangling doesn't work well with CJS by relying on the ESM build.

Size of WebApp with Firebase App + Firestore CJS before:
./bundle.js  445 KiB       0  [emitted]  [big]  main

Size of WebApp with Firebase App + Firestore CJS after:
./bundle.js  384 KiB       0  [emitted]  [big]  main

I confirmed in a simple test app that the build works in browsers (but more testing is always appreciated).


