### PR TITLE
Fix canary release

### DIFF
--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -48,6 +48,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    - name: Checkout
+      # Canary release script requires git history and tags.
+      run: git fetch --prune --unshallow
     - name: Set up Node (10)
       uses: actions/setup-node@v1
       with:


### PR DESCRIPTION
Canary script is skipping release because checkout v2 doesn't have history it needs to compare.