### PR TITLE
Use explicit String constants for OnlineState

### DIFF
--- a/packages/firestore/src/core/event_manager.ts
+++ b/packages/firestore/src/core/event_manager.ts
@@ -51,7 +51,7 @@ export class EventManager implements SyncEngineListener {
     q.canonicalId()
   );
 
-  private onlineState: OnlineState = OnlineState.Unknown;
+  private onlineState: OnlineState = 'Unknown';
 
   private snapshotsInSyncListeners: Set<Observer<void>> = new Set();
 
@@ -209,7 +209,7 @@ export class QueryListener {
 
   private snap: ViewSnapshot | null = null;
 
-  private onlineState: OnlineState = OnlineState.Unknown;
+  private onlineState: OnlineState = 'Unknown';
 
   constructor(
     readonly query: Query,
@@ -300,7 +300,7 @@ export class QueryListener {
 
     // NOTE: We consider OnlineState.Unknown as online (it should become Offline
     // or Online if we wait long enough).
-    const maybeOnline = onlineState !== OnlineState.Offline;
+    const maybeOnline = onlineState !== 'Offline';
     // Don't raise the event if we're online, aren't synced yet (checked
     // above) and are waiting for a sync.
     if (this.options.waitForSyncWhenOnline && maybeOnline) {
@@ -312,7 +312,7 @@ export class QueryListener {
     }
 
     // Raise data from cache if we have any documents or we are offline
-    return !snap.docs.isEmpty() || onlineState === OnlineState.Offline;
+    return !snap.docs.isEmpty() || onlineState === 'Offline';
   }
 
   private shouldRaiseEvent(snap: ViewSnapshot): boolean {

--- a/packages/firestore/src/core/sync_engine.ts
+++ b/packages/firestore/src/core/sync_engine.ts
@@ -167,7 +167,7 @@ export class SyncEngine implements RemoteSyncer, SharedClientStateSyncer {
   // startup. In the interim, a client should only be considered primary if
   // `isPrimary` is true.
   private isPrimary: undefined | boolean = undefined;
-  private onlineState: OnlineState = OnlineState.Unknown;
+  private onlineState: OnlineState = 'Unknown';
 
   constructor(
     private localStore: LocalStore,
@@ -253,7 +253,7 @@ export class SyncEngine implements RemoteSyncer, SharedClientStateSyncer {
     const viewDocChanges = view.computeDocChanges(queryResult.documents);
     const synthesizedTargetChange = TargetChange.createSynthesizedTargetChangeForCurrentChange(
       targetId,
-      current && this.onlineState !== OnlineState.Offline
+      current && this.onlineState !== 'Offline'
     );
     const viewChange = view.applyChanges(
       viewDocChanges,

--- a/packages/firestore/src/core/types.ts
+++ b/packages/firestore/src/core/types.ts
@@ -39,29 +39,28 @@ export type MutationBatchState = 'pending' | 'acknowledged' | 'rejected';
  * offline (e.g. get() calls shouldn't wait for data from the server and
  * snapshot events should set metadata.isFromCache=true).
  */
-export enum OnlineState {
+export type OnlineState =
   /**
    * The Firestore client is in an unknown online state. This means the client
    * is either not actively trying to establish a connection or it is currently
    * trying to establish a connection, but it has not succeeded or failed yet.
    * Higher-level components should not operate in offline mode.
    */
-  Unknown,
+  | 'Unknown'
 
   /**
    * The client is connected and the connections are healthy. This state is
    * reached after a successful connection and there has been at least one
    * successful message received from the backends.
    */
-  Online,
+  | 'Online'
 
   /**
    * The client is either trying to establish a connection but failing, or it
    * has been explicitly marked offline via a call to disableNetwork().
    * Higher-level components should operate in offline mode.
    */
-  Offline
-}
+  | 'Offline';
 
 /** The source of an online state event. */
 export enum OnlineStateSource {

--- a/packages/firestore/src/core/view.ts
+++ b/packages/firestore/src/core/view.ts
@@ -336,7 +336,7 @@ export class View {
    * ViewChange if the view's syncState changes as a result.
    */
   applyOnlineStateChange(onlineState: OnlineState): ViewChange {
-    if (this.current && onlineState === OnlineState.Offline) {
+    if (this.current && onlineState === 'Offline') {
       // If we're offline, set `current` to false and then call applyChanges()
       // to refresh our syncState and generate a ViewChange as appropriate. We
       // are guaranteed to get a new TargetChange that sets `current` back to

--- a/packages/firestore/src/local/shared_client_state.ts
+++ b/packages/firestore/src/local/shared_client_state.ts
@@ -409,13 +409,14 @@ export class SharedOnlineState {
 
     const validData =
       typeof onlineState === 'object' &&
-      onlineState.onlineState in OnlineState &&
+      ['Unknown', 'Online', 'Offline'].indexOf(onlineState.onlineState) !==
+        -1 &&
       typeof onlineState.clientId === 'string';
 
     if (validData) {
       return new SharedOnlineState(
         onlineState.clientId,
-        OnlineState[onlineState.onlineState as keyof typeof OnlineState]
+        onlineState.onlineState as OnlineState
       );
     } else {
       error(LOG_TAG, `Failed to parse online state: ${value}`);
@@ -860,7 +861,7 @@ export class WebStorageSharedClientState implements SharedClientState {
   private persistOnlineState(onlineState: OnlineState): void {
     const entry: SharedOnlineStateSchema = {
       clientId: this.localClientId,
-      onlineState: OnlineState[onlineState]
+      onlineState: onlineState
     };
     this.storage.setItem(this.onlineStateKey, JSON.stringify(entry));
   }

--- a/packages/firestore/src/local/shared_client_state.ts
+++ b/packages/firestore/src/local/shared_client_state.ts
@@ -861,7 +861,7 @@ export class WebStorageSharedClientState implements SharedClientState {
   private persistOnlineState(onlineState: OnlineState): void {
     const entry: SharedOnlineStateSchema = {
       clientId: this.localClientId,
-      onlineState: onlineState
+      onlineState
     };
     this.storage.setItem(this.onlineStateKey, JSON.stringify(entry));
   }

--- a/packages/firestore/src/remote/online_state_tracker.ts
+++ b/packages/firestore/src/remote/online_state_tracker.ts
@@ -50,7 +50,7 @@ const ONLINE_STATE_TIMEOUT_MS = 10 * 1000;
  */
 export class OnlineStateTracker {
   /** The current OnlineState. */
-  private state = OnlineState.Unknown;
+  private state: OnlineState = 'Unknown';
 
   /**
    * A count of consecutive failures to open the stream. If it reaches the
@@ -87,7 +87,7 @@ export class OnlineStateTracker {
    */
   handleWatchStreamStart(): void {
     if (this.watchStreamFailures === 0) {
-      this.setAndBroadcast(OnlineState.Unknown);
+      this.setAndBroadcast('Unknown');
 
       assert(
         this.onlineStateTimer === null,
@@ -99,14 +99,14 @@ export class OnlineStateTracker {
         () => {
           this.onlineStateTimer = null;
           assert(
-            this.state === OnlineState.Unknown,
+            this.state === 'Unknown',
             'Timer should be canceled if we transitioned to a different state.'
           );
           this.logClientOfflineWarningIfNecessary(
             `Backend didn't respond within ${ONLINE_STATE_TIMEOUT_MS / 1000} ` +
               `seconds.`
           );
-          this.setAndBroadcast(OnlineState.Offline);
+          this.setAndBroadcast('Offline');
 
           // NOTE: handleWatchStreamFailure() will continue to increment
           // watchStreamFailures even though we are already marked Offline,
@@ -125,8 +125,8 @@ export class OnlineStateTracker {
    * actually transition to the 'Offline' state.
    */
   handleWatchStreamFailure(error: FirestoreError): void {
-    if (this.state === OnlineState.Online) {
-      this.setAndBroadcast(OnlineState.Unknown);
+    if (this.state === 'Online') {
+      this.setAndBroadcast('Unknown');
 
       // To get to OnlineState.Online, set() must have been called which would
       // have reset our heuristics.
@@ -142,7 +142,7 @@ export class OnlineStateTracker {
             `times. Most recent error: ${error.toString()}`
         );
 
-        this.setAndBroadcast(OnlineState.Offline);
+        this.setAndBroadcast('Offline');
       }
     }
   }
@@ -158,7 +158,7 @@ export class OnlineStateTracker {
     this.clearOnlineStateTimer();
     this.watchStreamFailures = 0;
 
-    if (newState === OnlineState.Online) {
+    if (newState === 'Online') {
       // We've connected to watch at least once. Don't warn the developer
       // about being offline going forward.
       this.shouldWarnClientIsOffline = false;

--- a/packages/firestore/src/remote/remote_store.ts
+++ b/packages/firestore/src/remote/remote_store.ts
@@ -191,7 +191,7 @@ export class RemoteStore implements TargetMetadataProvider {
       if (this.shouldStartWatchStream()) {
         this.startWatchStream();
       } else {
-        this.onlineStateTracker.set(OnlineState.Unknown);
+        this.onlineStateTracker.set('Unknown');
       }
 
       // This will start the write stream if necessary.
@@ -208,7 +208,7 @@ export class RemoteStore implements TargetMetadataProvider {
     await this.disableNetworkInternal();
 
     // Set the OnlineState to Offline so get()s return from cache, etc.
-    this.onlineStateTracker.set(OnlineState.Offline);
+    this.onlineStateTracker.set('Offline');
   }
 
   private async disableNetworkInternal(): Promise<void> {
@@ -234,7 +234,7 @@ export class RemoteStore implements TargetMetadataProvider {
 
     // Set the OnlineState to Unknown (rather than Offline) to avoid potentially
     // triggering spurious listener events with cached data, etc.
-    this.onlineStateTracker.set(OnlineState.Unknown);
+    this.onlineStateTracker.set('Unknown');
   }
 
   /**
@@ -279,7 +279,7 @@ export class RemoteStore implements TargetMetadataProvider {
         // Revert to OnlineState.Unknown if the watch stream is not open and we
         // have no listeners, since without any listens to send we cannot
         // confirm if the stream is healthy and upgrade to OnlineState.Online.
-        this.onlineStateTracker.set(OnlineState.Unknown);
+        this.onlineStateTracker.set('Unknown');
       }
     }
   }
@@ -371,7 +371,7 @@ export class RemoteStore implements TargetMetadataProvider {
       // No need to restart watch stream because there are no active targets.
       // The online state is set to unknown because there is no active attempt
       // at establishing a connection
-      this.onlineStateTracker.set(OnlineState.Unknown);
+      this.onlineStateTracker.set('Unknown');
     }
   }
 
@@ -380,7 +380,7 @@ export class RemoteStore implements TargetMetadataProvider {
     snapshotVersion: SnapshotVersion
   ): Promise<void> {
     // Mark the client as online since we got a message from the server
-    this.onlineStateTracker.set(OnlineState.Online);
+    this.onlineStateTracker.set('Online');
 
     if (
       watchChange instanceof WatchTargetChange &&
@@ -708,7 +708,7 @@ export class RemoteStore implements TargetMetadataProvider {
   private async restartNetwork(): Promise<void> {
     this.networkEnabled = false;
     await this.disableNetworkInternal();
-    this.onlineStateTracker.set(OnlineState.Unknown);
+    this.onlineStateTracker.set('Unknown');
     await this.enableNetwork();
   }
 
@@ -732,7 +732,7 @@ export class RemoteStore implements TargetMetadataProvider {
       await this.enableNetwork();
     } else if (!isPrimary) {
       await this.disableNetworkInternal();
-      this.onlineStateTracker.set(OnlineState.Unknown);
+      this.onlineStateTracker.set('Unknown');
     }
   }
 }

--- a/packages/firestore/test/unit/core/event_manager.test.ts
+++ b/packages/firestore/test/unit/core/event_manager.test.ts
@@ -144,9 +144,9 @@ describe('EventManager', () => {
     const eventManager = new EventManager(syncEngineSpy);
 
     await eventManager.listen(fakeListener1);
-    expect(events).to.deep.equal([OnlineState.Unknown]);
-    eventManager.onOnlineStateChange(OnlineState.Online);
-    expect(events).to.deep.equal([OnlineState.Unknown, OnlineState.Online]);
+    expect(events).to.deep.equal(['Unknown']);
+    eventManager.onOnlineStateChange('Online');
+    expect(events).to.deep.equal(['Unknown', 'Online']);
   });
 });
 
@@ -478,10 +478,10 @@ describe('QueryListener', () => {
     const snap3 = view.applyChanges(changes3, true, ackTarget(doc1, doc2))
       .snapshot!;
 
-    listener.applyOnlineStateChange(OnlineState.Online); // no event
+    listener.applyOnlineStateChange('Online'); // no event
     listener.onViewSnapshot(snap1); // no event
-    listener.applyOnlineStateChange(OnlineState.Unknown); // no event
-    listener.applyOnlineStateChange(OnlineState.Online); // no event
+    listener.applyOnlineStateChange('Unknown'); // no event
+    listener.applyOnlineStateChange('Online'); // no event
     listener.onViewSnapshot(snap2); // no event
     listener.onViewSnapshot(snap3); // event because synced
 
@@ -516,11 +516,11 @@ describe('QueryListener', () => {
     const changes2 = view.computeDocChanges(documentUpdates(doc2));
     const snap2 = view.applyChanges(changes2, true).snapshot!;
 
-    listener.applyOnlineStateChange(OnlineState.Online); // no event
+    listener.applyOnlineStateChange('Online'); // no event
     listener.onViewSnapshot(snap1); // no event
-    listener.applyOnlineStateChange(OnlineState.Offline); // event
-    listener.applyOnlineStateChange(OnlineState.Online); // no event
-    listener.applyOnlineStateChange(OnlineState.Offline); // no event
+    listener.applyOnlineStateChange('Offline'); // event
+    listener.applyOnlineStateChange('Online'); // no event
+    listener.applyOnlineStateChange('Offline'); // no event
     listener.onViewSnapshot(snap2); // another event
 
     const expectedSnap1 = {
@@ -554,9 +554,9 @@ describe('QueryListener', () => {
     const changes1 = view.computeDocChanges(documentUpdates());
     const snap1 = view.applyChanges(changes1, true).snapshot!;
 
-    listener.applyOnlineStateChange(OnlineState.Online); // no event
+    listener.applyOnlineStateChange('Online'); // no event
     listener.onViewSnapshot(snap1); // no event
-    listener.applyOnlineStateChange(OnlineState.Offline); // event
+    listener.applyOnlineStateChange('Offline'); // event
 
     const expectedSnap = {
       query,
@@ -580,7 +580,7 @@ describe('QueryListener', () => {
     const changes1 = view.computeDocChanges(documentUpdates());
     const snap1 = view.applyChanges(changes1, true).snapshot!;
 
-    listener.applyOnlineStateChange(OnlineState.Offline);
+    listener.applyOnlineStateChange('Offline');
     listener.onViewSnapshot(snap1);
 
     const expectedSnap = {

--- a/packages/firestore/test/unit/local/web_storage_shared_client_state.test.ts
+++ b/packages/firestore/test/unit/local/web_storage_shared_client_state.test.ts
@@ -97,7 +97,7 @@ class TestSharedClientSyncer implements SharedClientStateSyncer {
     [targetId: number]: { state: QueryTargetState; error?: FirestoreError };
   } = {};
   private activeTargets = targetIdSet();
-  private onlineState = OnlineState.Unknown;
+  private onlineState: OnlineState = 'Unknown';
 
   constructor(public activeClients: ClientId[]) {}
 
@@ -412,27 +412,27 @@ describe('WebStorageSharedClientState', () => {
 
     it('with targets from existing client', async () => {
       // The prior client has two active query targets
-      await verifyState([3, 4], OnlineState.Unknown);
+      await verifyState([3, 4], 'Unknown');
 
       sharedClientState.addLocalQueryTarget(4);
-      await verifyState([3, 4], OnlineState.Unknown);
+      await verifyState([3, 4], 'Unknown');
 
       sharedClientState.addLocalQueryTarget(5);
-      await verifyState([3, 4, 5], OnlineState.Unknown);
+      await verifyState([3, 4, 5], 'Unknown');
 
       sharedClientState.removeLocalQueryTarget(5);
-      await verifyState([3, 4], OnlineState.Unknown);
+      await verifyState([3, 4], 'Unknown');
     });
 
     it('with targets from new client', async () => {
       // The prior client has two active query targets
-      await verifyState([3, 4], OnlineState.Unknown);
+      await verifyState([3, 4], 'Unknown');
 
       const oldState = new LocalClientState();
       oldState.addQueryTarget(5);
 
       writeToWebStorage(secondaryClientStateKey, oldState.toWebStorageJSON());
-      await verifyState([3, 4, 5], OnlineState.Unknown);
+      await verifyState([3, 4, 5], 'Unknown');
 
       const updatedState = new LocalClientState();
       updatedState.addQueryTarget(5);
@@ -442,15 +442,15 @@ describe('WebStorageSharedClientState', () => {
         secondaryClientStateKey,
         updatedState.toWebStorageJSON()
       );
-      await verifyState([3, 4, 5, 6], OnlineState.Unknown);
+      await verifyState([3, 4, 5, 6], 'Unknown');
 
       writeToWebStorage(secondaryClientStateKey, null);
-      await verifyState([3, 4], OnlineState.Unknown);
+      await verifyState([3, 4], 'Unknown');
     });
 
     it('with online state from new client', async () => {
       // The prior client has two active query targets
-      await verifyState([3, 4], OnlineState.Unknown);
+      await verifyState([3, 4], 'Unknown');
 
       // Ensure that client is considered active
       const oldState = new LocalClientState();
@@ -463,7 +463,7 @@ describe('WebStorageSharedClientState', () => {
           clientId: secondaryClientId
         })
       );
-      await verifyState([3, 4], OnlineState.Unknown);
+      await verifyState([3, 4], 'Unknown');
 
       writeToWebStorage(
         onlineStateKey(),
@@ -472,7 +472,7 @@ describe('WebStorageSharedClientState', () => {
           clientId: secondaryClientId
         })
       );
-      await verifyState([3, 4], OnlineState.Offline);
+      await verifyState([3, 4], 'Offline');
 
       writeToWebStorage(
         onlineStateKey(),
@@ -481,12 +481,12 @@ describe('WebStorageSharedClientState', () => {
           clientId: secondaryClientId
         })
       );
-      await verifyState([3, 4], OnlineState.Online);
+      await verifyState([3, 4], 'Online');
     });
 
     it('ignores online state from inactive client', async () => {
       // The prior client has two active query targets
-      await verifyState([3, 4], OnlineState.Unknown);
+      await verifyState([3, 4], 'Unknown');
 
       // The secondary client is inactive and its online state is ignored.
       writeToWebStorage(
@@ -497,7 +497,7 @@ describe('WebStorageSharedClientState', () => {
         })
       );
 
-      await verifyState([3, 4], OnlineState.Unknown);
+      await verifyState([3, 4], 'Unknown');
 
       // Ensure that client is considered active
       const oldState = new LocalClientState();
@@ -511,7 +511,7 @@ describe('WebStorageSharedClientState', () => {
         })
       );
 
-      await verifyState([3, 4], OnlineState.Online);
+      await verifyState([3, 4], 'Online');
     });
 
     it('ignores invalid data', async () => {
@@ -522,11 +522,11 @@ describe('WebStorageSharedClientState', () => {
       };
 
       // The prior instance has two active query targets
-      await verifyState([3, 4], OnlineState.Unknown);
+      await verifyState([3, 4], 'Unknown');
 
       // We ignore the newly added target.
       writeToWebStorage(secondaryClientStateKey, JSON.stringify(invalidState));
-      await verifyState([3, 4], OnlineState.Unknown);
+      await verifyState([3, 4], 'Unknown');
     });
   });
 


### PR DESCRIPTION
@Feiyang1 noticed in a sample app that multitab is not able to parse OnlineStates since the constants are rewritten to __PRIVATE_OnlineState:

```
@firebase/firestore: Firestore (7.9.1): SharedClientState Failed to parse online state: {"clientId":"Xnj51M6igYRWov1EHcwt","onlineState":"__PRIVATE_Unknown"}
```

This PR removes the enum usage for OnlineState, to make sure that the constant names are not mangled.

Multi-Tab uses the same concept for its other "enums": https://github.com/firebase/firebase-js-sdk/blob/bb1f4dee32dc4ee41066e176378e1b63aa1e1d14/packages/firestore/src/local/shared_client_state.ts#L209

As a guide, the size impact of this PR:
- +7 bytes versus master (before GZIP)
- -43 bytes versus master (after GZIP) WHEEE