### PR TITLE
Set canary publish to use wombat-dressing-room proxy

### DIFF
--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -55,14 +55,41 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: 10.x
-        registry-url: 'https://registry.npmjs.org'
     - name: Yarn install
       run: yarn
-    - name: yarn build
-      run: yarn build
     - name: Deploy canary
-      run: |
-        npm config set //registry.npmjs.org/:_authToken=$NODE_AUTH_TOKEN
-        yarn release --canary
+      run: yarn release --canary
       env:
-        NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+        NPM_TOKEN_ANALYTICS: ${{secrets.NPM_TOKEN_ANALYTICS}}
+        NPM_TOKEN_ANALYTICS_INTEROP_TYPES: ${{secrets.NPM_TOKEN_ANALYTICS_INTEROP_TYPES}}
+        NPM_TOKEN_ANALYTICS_TYPES: ${{secrets.NPM_TOKEN_ANALYTICS_TYPES}}
+        NPM_TOKEN_APP: ${{secrets.NPM_TOKEN_APP}}
+        NPM_TOKEN_APP_TYPES: ${{secrets.NPM_TOKEN_APP_TYPES}}
+        NPM_TOKEN_AUTH: ${{secrets.NPM_TOKEN_AUTH}}
+        NPM_TOKEN_AUTH_INTEROP_TYPES: ${{secrets.NPM_TOKEN_AUTH_INTEROP_TYPES}}
+        NPM_TOKEN_AUTH_TYPES: ${{secrets.NPM_TOKEN_AUTH_TYPES}}
+        NPM_TOKEN_COMPONENT: ${{secrets.NPM_TOKEN_COMPONENT}}
+        NPM_TOKEN_DATABASE: ${{secrets.NPM_TOKEN_DATABASE}}
+        NPM_TOKEN_DATABASE_TYPES: ${{secrets.NPM_TOKEN_DATABASE_TYPES}}
+        NPM_TOKEN_FIRESTORE: ${{secrets.NPM_TOKEN_FIRESTORE}}
+        NPM_TOKEN_FIRESTORE_TYPES: ${{secrets.NPM_TOKEN_FIRESTORE_TYPES}}
+        NPM_TOKEN_FUNCTIONS: ${{secrets.NPM_TOKEN_FUNCTIONS}}
+        NPM_TOKEN_FUNCTIONS_TYPES: ${{secrets.NPM_TOKEN_FUNCTIONS_TYPES}}
+        NPM_TOKEN_INSTALLATIONS: ${{secrets.NPM_TOKEN_INSTALLATIONS}}
+        NPM_TOKEN_INSTALLATIONS_TYPES: ${{secrets.NPM_TOKEN_INSTALLATIONS_TYPES}}
+        NPM_TOKEN_LOGGER: ${{secrets.NPM_TOKEN_LOGGER}}
+        NPM_TOKEN_MESSAGING: ${{secrets.NPM_TOKEN_MESSAGING}}
+        NPM_TOKEN_MESSAGING_TYPES: ${{secrets.NPM_TOKEN_MESSAGING_TYPES}}
+        NPM_TOKEN_PERFORMANCE: ${{secrets.NPM_TOKEN_PERFORMANCE}}
+        NPM_TOKEN_PERFORMANCE_TYPES: ${{secrets.NPM_TOKEN_PERFORMANCE_TYPES}}
+        NPM_TOKEN_POLYFILL: ${{secrets.NPM_TOKEN_POLYFILL}}
+        NPM_TOKEN_REMOTE_CONFIG: ${{secrets.NPM_TOKEN_REMOTE_CONFIG}}
+        NPM_TOKEN_REMOTE_CONFIG_TYPES: ${{secrets.NPM_TOKEN_REMOTE_CONFIG_TYPES}}
+        NPM_TOKEN_STORAGE: ${{secrets.NPM_TOKEN_STORAGE}}
+        NPM_TOKEN_STORAGE_TYPES: ${{secrets.NPM_TOKEN_STORAGE_TYPES}}
+        NPM_TOKEN_TESTING: ${{secrets.NPM_TOKEN_TESTING}}
+        NPM_TOKEN_UTIL: ${{secrets.NPM_TOKEN_UTIL}}
+        NPM_TOKEN_WEBCHANNEL_WRAPPER: ${{secrets.NPM_TOKEN_WEBCHANNEL_WRAPPER}}
+        NPM_TOKEN_FIREBASE: ${{secrets.NPM_TOKEN_FIREBASE}}
+        NPM_TOKEN_RXFIRE: ${{secrets.NPM_TOKEN_RXFIRE}}
+        CI: true

--- a/scripts/release/cli.js
+++ b/scripts/release/cli.js
@@ -79,8 +79,10 @@ const { argv } = require('yargs');
     /**
      * Log the user who will be publishing the packages
      */
-    const { stdout: whoami } = await exec('npm whoami');
-    console.log(`Publishing as ${whoami}`);
+    if (!process.env.CI) {
+      const { stdout: whoami } = await exec('npm whoami');
+      console.log(`Publishing as ${whoami}`);
+    }
 
     /**
      * Determine if the current release is a staging or production release


### PR DESCRIPTION
For best security practices, modify post-merge canary NPM publish to use wombat-dressing-room to publish.

Package-specific registry token is written to .npmrc before each publish command.