### PR TITLE
Remove enum overhead

### DIFF
--- a/packages/firestore/src/api/user_data_converter.ts
+++ b/packages/firestore/src/api/user_data_converter.ts
@@ -126,7 +126,7 @@ export class ParsedUpdateData {
  * for determining which error conditions apply during parsing and providing
  * better error messages.
  */
-enum UserDataSource {
+const enum UserDataSource {
   Set,
   Update,
   MergeSet,

--- a/packages/firestore/src/core/event_manager.ts
+++ b/packages/firestore/src/core/event_manager.ts
@@ -51,7 +51,7 @@ export class EventManager implements SyncEngineListener {
     q.canonicalId()
   );
 
-  private onlineState: OnlineState = 'Unknown';
+  private onlineState: OnlineState = OnlineState.Unknown;
 
   private snapshotsInSyncListeners: Set<Observer<void>> = new Set();
 
@@ -209,7 +209,7 @@ export class QueryListener {
 
   private snap: ViewSnapshot | null = null;
 
-  private onlineState: OnlineState = 'Unknown';
+  private onlineState: OnlineState = OnlineState.Unknown;
 
   constructor(
     readonly query: Query,
@@ -300,7 +300,7 @@ export class QueryListener {
 
     // NOTE: We consider OnlineState.Unknown as online (it should become Offline
     // or Online if we wait long enough).
-    const maybeOnline = onlineState !== 'Offline';
+    const maybeOnline = onlineState !== OnlineState.Offline;
     // Don't raise the event if we're online, aren't synced yet (checked
     // above) and are waiting for a sync.
     if (this.options.waitForSyncWhenOnline && maybeOnline) {
@@ -312,7 +312,7 @@ export class QueryListener {
     }
 
     // Raise data from cache if we have any documents or we are offline
-    return !snap.docs.isEmpty() || onlineState === 'Offline';
+    return !snap.docs.isEmpty() || onlineState === OnlineState.Offline;
   }
 
   private shouldRaiseEvent(snap: ViewSnapshot): boolean {

--- a/packages/firestore/src/core/event_manager.ts
+++ b/packages/firestore/src/core/event_manager.ts
@@ -51,7 +51,7 @@ export class EventManager implements SyncEngineListener {
     q.canonicalId()
   );
 
-  private onlineState: OnlineState = OnlineState.Unknown;
+  private onlineState = OnlineState.Unknown;
 
   private snapshotsInSyncListeners: Set<Observer<void>> = new Set();
 
@@ -209,7 +209,7 @@ export class QueryListener {
 
   private snap: ViewSnapshot | null = null;
 
-  private onlineState: OnlineState = OnlineState.Unknown;
+  private onlineState = OnlineState.Unknown;
 
   constructor(
     readonly query: Query,

--- a/packages/firestore/src/core/query.ts
+++ b/packages/firestore/src/core/query.ts
@@ -30,7 +30,7 @@ import { Code, FirestoreError } from '../util/error';
 import { isNullOrUndefined } from '../util/types';
 import { Target } from './target';
 
-export enum LimitType {
+export const enum LimitType {
   First = 'F',
   Last = 'L'
 }

--- a/packages/firestore/src/core/sync_engine.ts
+++ b/packages/firestore/src/core/sync_engine.ts
@@ -167,7 +167,7 @@ export class SyncEngine implements RemoteSyncer, SharedClientStateSyncer {
   // startup. In the interim, a client should only be considered primary if
   // `isPrimary` is true.
   private isPrimary: undefined | boolean = undefined;
-  private onlineState: OnlineState = OnlineState.Unknown;
+  private onlineState = OnlineState.Unknown;
 
   constructor(
     private localStore: LocalStore,

--- a/packages/firestore/src/core/sync_engine.ts
+++ b/packages/firestore/src/core/sync_engine.ts
@@ -167,7 +167,7 @@ export class SyncEngine implements RemoteSyncer, SharedClientStateSyncer {
   // startup. In the interim, a client should only be considered primary if
   // `isPrimary` is true.
   private isPrimary: undefined | boolean = undefined;
-  private onlineState: OnlineState = 'Unknown';
+  private onlineState: OnlineState = OnlineState.Unknown;
 
   constructor(
     private localStore: LocalStore,
@@ -253,7 +253,7 @@ export class SyncEngine implements RemoteSyncer, SharedClientStateSyncer {
     const viewDocChanges = view.computeDocChanges(queryResult.documents);
     const synthesizedTargetChange = TargetChange.createSynthesizedTargetChangeForCurrentChange(
       targetId,
-      current && this.onlineState !== 'Offline'
+      current && this.onlineState !== OnlineState.Offline
     );
     const viewChange = view.applyChanges(
       viewDocChanges,

--- a/packages/firestore/src/core/target_id_generator.ts
+++ b/packages/firestore/src/core/target_id_generator.ts
@@ -20,7 +20,7 @@ import { TargetId } from './types';
 
 const RESERVED_BITS = 1;
 
-enum GeneratorIds {
+const enum GeneratorIds {
   QueryCache = 0, // The target IDs for user-issued queries are even (end in 0).
   SyncEngine = 1 // The target IDs for limbo detection are odd (end in 1).
 }

--- a/packages/firestore/src/core/types.ts
+++ b/packages/firestore/src/core/types.ts
@@ -63,7 +63,7 @@ export type OnlineState =
   | 'Offline';
 
 /** The source of an online state event. */
-export enum OnlineStateSource {
+export const enum OnlineStateSource {
   RemoteStore,
   SharedClientState
 }

--- a/packages/firestore/src/core/types.ts
+++ b/packages/firestore/src/core/types.ts
@@ -46,21 +46,21 @@ export const enum OnlineState {
    * trying to establish a connection, but it has not succeeded or failed yet.
    * Higher-level components should not operate in offline mode.
    */
-  Unknown = "Unknown",
+  Unknown = 'Unknown',
 
   /**
    * The client is connected and the connections are healthy. This state is
    * reached after a successful connection and there has been at least one
    * successful message received from the backends.
    */
-  Online = "Online",
+  Online = 'Online',
 
   /**
    * The client is either trying to establish a connection but failing, or it
    * has been explicitly marked offline via a call to disableNetwork().
    * Higher-level components should operate in offline mode.
    */
-  Offline = "Offline"
+  Offline = 'Offline'
 }
 
 /** The source of an online state event. */

--- a/packages/firestore/src/core/types.ts
+++ b/packages/firestore/src/core/types.ts
@@ -39,28 +39,29 @@ export type MutationBatchState = 'pending' | 'acknowledged' | 'rejected';
  * offline (e.g. get() calls shouldn't wait for data from the server and
  * snapshot events should set metadata.isFromCache=true).
  */
-export type OnlineState =
+export enum OnlineState {
   /**
    * The Firestore client is in an unknown online state. This means the client
    * is either not actively trying to establish a connection or it is currently
    * trying to establish a connection, but it has not succeeded or failed yet.
    * Higher-level components should not operate in offline mode.
    */
-  | 'Unknown'
+  Unknown,
 
   /**
    * The client is connected and the connections are healthy. This state is
    * reached after a successful connection and there has been at least one
    * successful message received from the backends.
    */
-  | 'Online'
+  Online,
 
   /**
    * The client is either trying to establish a connection but failing, or it
    * has been explicitly marked offline via a call to disableNetwork().
    * Higher-level components should operate in offline mode.
    */
-  | 'Offline';
+  Offline
+}
 
 /** The source of an online state event. */
 export const enum OnlineStateSource {

--- a/packages/firestore/src/core/types.ts
+++ b/packages/firestore/src/core/types.ts
@@ -38,6 +38,9 @@ export type MutationBatchState = 'pending' | 'acknowledged' | 'rejected';
  * primarily used by the View / EventManager code to change their behavior while
  * offline (e.g. get() calls shouldn't wait for data from the server and
  * snapshot events should set metadata.isFromCache=true).
+ * 
+ * The string values should not be changed since they are persisted in
+ * WebStorage.
  */
 export const enum OnlineState {
   /**

--- a/packages/firestore/src/core/types.ts
+++ b/packages/firestore/src/core/types.ts
@@ -39,28 +39,28 @@ export type MutationBatchState = 'pending' | 'acknowledged' | 'rejected';
  * offline (e.g. get() calls shouldn't wait for data from the server and
  * snapshot events should set metadata.isFromCache=true).
  */
-export enum OnlineState {
+export const enum OnlineState {
   /**
    * The Firestore client is in an unknown online state. This means the client
    * is either not actively trying to establish a connection or it is currently
    * trying to establish a connection, but it has not succeeded or failed yet.
    * Higher-level components should not operate in offline mode.
    */
-  Unknown,
+  Unknown = "Unknown",
 
   /**
    * The client is connected and the connections are healthy. This state is
    * reached after a successful connection and there has been at least one
    * successful message received from the backends.
    */
-  Online,
+  Online = "Online",
 
   /**
    * The client is either trying to establish a connection but failing, or it
    * has been explicitly marked offline via a call to disableNetwork().
    * Higher-level components should operate in offline mode.
    */
-  Offline
+  Offline = "Offline"
 }
 
 /** The source of an online state event. */

--- a/packages/firestore/src/core/view.ts
+++ b/packages/firestore/src/core/view.ts
@@ -336,7 +336,7 @@ export class View {
    * ViewChange if the view's syncState changes as a result.
    */
   applyOnlineStateChange(onlineState: OnlineState): ViewChange {
-    if (this.current && onlineState === 'Offline') {
+    if (this.current && onlineState === OnlineState.Offline) {
       // If we're offline, set `current` to false and then call applyChanges()
       // to refresh our syncState and generate a ViewChange as appropriate. We
       // are guaranteed to get a new TargetChange that sets `current` back to

--- a/packages/firestore/src/core/view_snapshot.ts
+++ b/packages/firestore/src/core/view_snapshot.ts
@@ -25,10 +25,10 @@ import { DocumentKeySet } from '../model/collections';
 import { Query } from './query';
 
 export const enum ChangeType {
-  Added = 0,
-  Removed = 1,
-  Modified = 2,
-  Metadata = 3
+  Added ,
+  Removed ,
+  Modified,
+  Metadata
 }
 
 export interface DocumentViewChange {

--- a/packages/firestore/src/core/view_snapshot.ts
+++ b/packages/firestore/src/core/view_snapshot.ts
@@ -25,8 +25,8 @@ import { DocumentKeySet } from '../model/collections';
 import { Query } from './query';
 
 export const enum ChangeType {
-  Added ,
-  Removed ,
+  Added,
+  Removed,
   Modified,
   Metadata
 }

--- a/packages/firestore/src/core/view_snapshot.ts
+++ b/packages/firestore/src/core/view_snapshot.ts
@@ -24,11 +24,11 @@ import { SortedMap } from '../util/sorted_map';
 import { DocumentKeySet } from '../model/collections';
 import { Query } from './query';
 
-export enum ChangeType {
-  Added,
-  Removed,
-  Modified,
-  Metadata
+export const enum ChangeType {
+  Added = 0,
+  Removed = 1,
+  Modified = 2,
+  Metadata = 3
 }
 
 export interface DocumentViewChange {
@@ -36,7 +36,7 @@ export interface DocumentViewChange {
   doc: Document;
 }
 
-export enum SyncState {
+export const enum SyncState {
   Local,
   Synced
 }

--- a/packages/firestore/src/local/shared_client_state.ts
+++ b/packages/firestore/src/local/shared_client_state.ts
@@ -409,14 +409,13 @@ export class SharedOnlineState {
 
     const validData =
       typeof onlineState === 'object' &&
-      ['Unknown', 'Online', 'Offline'].indexOf(onlineState.onlineState) !==
-        -1 &&
+      onlineState.onlineState in OnlineState &&
       typeof onlineState.clientId === 'string';
 
     if (validData) {
       return new SharedOnlineState(
         onlineState.clientId,
-        onlineState.onlineState as OnlineState
+        OnlineState[onlineState.onlineState as keyof typeof OnlineState]
       );
     } else {
       error(LOG_TAG, `Failed to parse online state: ${value}`);
@@ -861,7 +860,7 @@ export class WebStorageSharedClientState implements SharedClientState {
   private persistOnlineState(onlineState: OnlineState): void {
     const entry: SharedOnlineStateSchema = {
       clientId: this.localClientId,
-      onlineState
+      onlineState: OnlineState[onlineState]
     };
     this.storage.setItem(this.onlineStateKey, JSON.stringify(entry));
   }

--- a/packages/firestore/src/local/shared_client_state.ts
+++ b/packages/firestore/src/local/shared_client_state.ts
@@ -409,13 +409,14 @@ export class SharedOnlineState {
 
     const validData =
       typeof onlineState === 'object' &&
-      onlineState.onlineState in OnlineState &&
+      ['Unknown', 'Online', 'Offline'].indexOf(onlineState.onlineState) !==
+        -1 &&
       typeof onlineState.clientId === 'string';
 
     if (validData) {
       return new SharedOnlineState(
         onlineState.clientId,
-        OnlineState[onlineState.onlineState as keyof typeof OnlineState]
+        onlineState.onlineState as OnlineState
       );
     } else {
       error(LOG_TAG, `Failed to parse online state: ${value}`);
@@ -860,7 +861,7 @@ export class WebStorageSharedClientState implements SharedClientState {
   private persistOnlineState(onlineState: OnlineState): void {
     const entry: SharedOnlineStateSchema = {
       clientId: this.localClientId,
-      onlineState: OnlineState[onlineState]
+      onlineState: onlineState
     };
     this.storage.setItem(this.onlineStateKey, JSON.stringify(entry));
   }

--- a/packages/firestore/src/local/shared_client_state.ts
+++ b/packages/firestore/src/local/shared_client_state.ts
@@ -861,7 +861,7 @@ export class WebStorageSharedClientState implements SharedClientState {
   private persistOnlineState(onlineState: OnlineState): void {
     const entry: SharedOnlineStateSchema = {
       clientId: this.localClientId,
-      onlineState: onlineState
+      onlineState
     };
     this.storage.setItem(this.onlineStateKey, JSON.stringify(entry));
   }

--- a/packages/firestore/src/local/target_data.ts
+++ b/packages/firestore/src/local/target_data.ts
@@ -21,7 +21,7 @@ import { ListenSequenceNumber, TargetId } from '../core/types';
 import { ByteString } from '../util/byte_string';
 
 /** An enumeration of the different purposes we have for targets. */
-export enum TargetPurpose {
+export const enum TargetPurpose {
   /** A regular, normal query target. */
   Listen,
 

--- a/packages/firestore/src/model/field_value.ts
+++ b/packages/firestore/src/model/field_value.ts
@@ -48,7 +48,7 @@ export interface JsonObject<T> {
   [name: string]: T;
 }
 
-export enum TypeOrder {
+export const enum TypeOrder {
   // This order is defined by the backend.
   NullValue = 0,
   BooleanValue = 1,
@@ -63,7 +63,7 @@ export enum TypeOrder {
 }
 
 /** Defines the return value for pending server timestamps. */
-export enum ServerTimestampBehavior {
+export const enum ServerTimestampBehavior {
   Default,
   Estimate,
   Previous

--- a/packages/firestore/src/model/mutation.ts
+++ b/packages/firestore/src/model/mutation.ts
@@ -117,7 +117,7 @@ export class MutationResult {
   ) {}
 }
 
-export enum MutationType {
+export const enum MutationType {
   Set,
   Patch,
   Transform,

--- a/packages/firestore/src/remote/online_state_tracker.ts
+++ b/packages/firestore/src/remote/online_state_tracker.ts
@@ -50,7 +50,7 @@ const ONLINE_STATE_TIMEOUT_MS = 10 * 1000;
  */
 export class OnlineStateTracker {
   /** The current OnlineState. */
-  private state: OnlineState = 'Unknown';
+  private state = OnlineState.Unknown;
 
   /**
    * A count of consecutive failures to open the stream. If it reaches the
@@ -87,7 +87,7 @@ export class OnlineStateTracker {
    */
   handleWatchStreamStart(): void {
     if (this.watchStreamFailures === 0) {
-      this.setAndBroadcast('Unknown');
+      this.setAndBroadcast(OnlineState.Unknown);
 
       assert(
         this.onlineStateTimer === null,
@@ -99,14 +99,14 @@ export class OnlineStateTracker {
         () => {
           this.onlineStateTimer = null;
           assert(
-            this.state === 'Unknown',
+            this.state === OnlineState.Unknown,
             'Timer should be canceled if we transitioned to a different state.'
           );
           this.logClientOfflineWarningIfNecessary(
             `Backend didn't respond within ${ONLINE_STATE_TIMEOUT_MS / 1000} ` +
               `seconds.`
           );
-          this.setAndBroadcast('Offline');
+          this.setAndBroadcast(OnlineState.Offline);
 
           // NOTE: handleWatchStreamFailure() will continue to increment
           // watchStreamFailures even though we are already marked Offline,
@@ -125,8 +125,8 @@ export class OnlineStateTracker {
    * actually transition to the 'Offline' state.
    */
   handleWatchStreamFailure(error: FirestoreError): void {
-    if (this.state === 'Online') {
-      this.setAndBroadcast('Unknown');
+    if (this.state === OnlineState.Online) {
+      this.setAndBroadcast(OnlineState.Unknown);
 
       // To get to OnlineState.Online, set() must have been called which would
       // have reset our heuristics.
@@ -142,7 +142,7 @@ export class OnlineStateTracker {
             `times. Most recent error: ${error.toString()}`
         );
 
-        this.setAndBroadcast('Offline');
+        this.setAndBroadcast(OnlineState.Offline);
       }
     }
   }
@@ -158,7 +158,7 @@ export class OnlineStateTracker {
     this.clearOnlineStateTimer();
     this.watchStreamFailures = 0;
 
-    if (newState === 'Online') {
+    if (newState === OnlineState.Online) {
       // We've connected to watch at least once. Don't warn the developer
       // about being offline going forward.
       this.shouldWarnClientIsOffline = false;

--- a/packages/firestore/src/remote/persistent_stream.ts
+++ b/packages/firestore/src/remote/persistent_stream.ts
@@ -63,7 +63,7 @@ export interface WriteRequest extends api.WriteRequest {
  *               stop() called or
  *               idle timer expired
  */
-enum PersistentStreamState {
+const enum PersistentStreamState {
   /**
    * The streaming RPC is not yet running and there's no error condition.
    * Calling start() will start the stream immediately without backoff.

--- a/packages/firestore/src/remote/remote_store.ts
+++ b/packages/firestore/src/remote/remote_store.ts
@@ -191,7 +191,7 @@ export class RemoteStore implements TargetMetadataProvider {
       if (this.shouldStartWatchStream()) {
         this.startWatchStream();
       } else {
-        this.onlineStateTracker.set('Unknown');
+        this.onlineStateTracker.set(OnlineState.Unknown);
       }
 
       // This will start the write stream if necessary.
@@ -208,7 +208,7 @@ export class RemoteStore implements TargetMetadataProvider {
     await this.disableNetworkInternal();
 
     // Set the OnlineState to Offline so get()s return from cache, etc.
-    this.onlineStateTracker.set('Offline');
+    this.onlineStateTracker.set(OnlineState.Offline);
   }
 
   private async disableNetworkInternal(): Promise<void> {
@@ -234,7 +234,7 @@ export class RemoteStore implements TargetMetadataProvider {
 
     // Set the OnlineState to Unknown (rather than Offline) to avoid potentially
     // triggering spurious listener events with cached data, etc.
-    this.onlineStateTracker.set('Unknown');
+    this.onlineStateTracker.set(OnlineState.Unknown);
   }
 
   /**
@@ -279,7 +279,7 @@ export class RemoteStore implements TargetMetadataProvider {
         // Revert to OnlineState.Unknown if the watch stream is not open and we
         // have no listeners, since without any listens to send we cannot
         // confirm if the stream is healthy and upgrade to OnlineState.Online.
-        this.onlineStateTracker.set('Unknown');
+        this.onlineStateTracker.set(OnlineState.Unknown);
       }
     }
   }
@@ -371,7 +371,7 @@ export class RemoteStore implements TargetMetadataProvider {
       // No need to restart watch stream because there are no active targets.
       // The online state is set to unknown because there is no active attempt
       // at establishing a connection
-      this.onlineStateTracker.set('Unknown');
+      this.onlineStateTracker.set(OnlineState.Unknown);
     }
   }
 
@@ -380,7 +380,7 @@ export class RemoteStore implements TargetMetadataProvider {
     snapshotVersion: SnapshotVersion
   ): Promise<void> {
     // Mark the client as online since we got a message from the server
-    this.onlineStateTracker.set('Online');
+    this.onlineStateTracker.set(OnlineState.Online);
 
     if (
       watchChange instanceof WatchTargetChange &&
@@ -708,7 +708,7 @@ export class RemoteStore implements TargetMetadataProvider {
   private async restartNetwork(): Promise<void> {
     this.networkEnabled = false;
     await this.disableNetworkInternal();
-    this.onlineStateTracker.set('Unknown');
+    this.onlineStateTracker.set(OnlineState.Unknown);
     await this.enableNetwork();
   }
 
@@ -732,7 +732,7 @@ export class RemoteStore implements TargetMetadataProvider {
       await this.enableNetwork();
     } else if (!isPrimary) {
       await this.disableNetworkInternal();
-      this.onlineStateTracker.set('Unknown');
+      this.onlineStateTracker.set(OnlineState.Unknown);
     }
   }
 }

--- a/packages/firestore/src/remote/rpc_error.ts
+++ b/packages/firestore/src/remote/rpc_error.ts
@@ -27,9 +27,9 @@ import * as log from '../util/log';
  *
  * Important! The names of these identifiers matter because the string forms
  * are used for reverse lookups from the webchannel stream. Do NOT change the
- * names of these identifiers.
+ * names of these identifiers or change this into a const enum. 
  */
-const enum RpcCode {
+enum RpcCode {
   OK = 0,
   CANCELLED = 1,
   UNKNOWN = 2,

--- a/packages/firestore/src/remote/rpc_error.ts
+++ b/packages/firestore/src/remote/rpc_error.ts
@@ -29,7 +29,7 @@ import * as log from '../util/log';
  * are used for reverse lookups from the webchannel stream. Do NOT change the
  * names of these identifiers.
  */
-enum RpcCode {
+const enum RpcCode {
   OK = 0,
   CANCELLED = 1,
   UNKNOWN = 2,

--- a/packages/firestore/src/remote/rpc_error.ts
+++ b/packages/firestore/src/remote/rpc_error.ts
@@ -27,7 +27,7 @@ import * as log from '../util/log';
  *
  * Important! The names of these identifiers matter because the string forms
  * are used for reverse lookups from the webchannel stream. Do NOT change the
- * names of these identifiers or change this into a const enum. 
+ * names of these identifiers or change this into a const enum.
  */
 enum RpcCode {
   OK = 0,

--- a/packages/firestore/src/remote/watch_change.ts
+++ b/packages/firestore/src/remote/watch_change.ts
@@ -74,7 +74,7 @@ export class ExistenceFilterChange {
   ) {}
 }
 
-export enum WatchTargetChangeState {
+export const enum WatchTargetChangeState {
   NoChange,
   Added,
   Removed,

--- a/packages/firestore/src/util/async_queue.ts
+++ b/packages/firestore/src/util/async_queue.ts
@@ -31,7 +31,7 @@ type TimerHandle = any;
  *
  * The string values are used when encoding these timer IDs in JSON spec tests.
  */
-export enum TimerId {
+export const enum TimerId {
   /** All can be used with runDelayedOperationsEarly() to run all timers. */
   All = 'all',
 

--- a/packages/firestore/src/util/log.ts
+++ b/packages/firestore/src/util/log.ts
@@ -21,7 +21,7 @@ import { PlatformSupport } from '../platform/platform';
 
 const logClient = new Logger('@firebase/firestore');
 
-export enum LogLevel {
+export const enum LogLevel {
   DEBUG,
   ERROR,
   SILENT

--- a/packages/firestore/test/unit/core/event_manager.test.ts
+++ b/packages/firestore/test/unit/core/event_manager.test.ts
@@ -144,9 +144,9 @@ describe('EventManager', () => {
     const eventManager = new EventManager(syncEngineSpy);
 
     await eventManager.listen(fakeListener1);
-    expect(events).to.deep.equal(['Unknown']);
-    eventManager.onOnlineStateChange('Online');
-    expect(events).to.deep.equal(['Unknown', 'Online']);
+    expect(events).to.deep.equal([OnlineState.Unknown]);
+    eventManager.onOnlineStateChange(OnlineState.Online);
+    expect(events).to.deep.equal([OnlineState.Unknown, OnlineState.Online]);
   });
 });
 
@@ -478,10 +478,10 @@ describe('QueryListener', () => {
     const snap3 = view.applyChanges(changes3, true, ackTarget(doc1, doc2))
       .snapshot!;
 
-    listener.applyOnlineStateChange('Online'); // no event
+    listener.applyOnlineStateChange(OnlineState.Online); // no event
     listener.onViewSnapshot(snap1); // no event
-    listener.applyOnlineStateChange('Unknown'); // no event
-    listener.applyOnlineStateChange('Online'); // no event
+    listener.applyOnlineStateChange(OnlineState.Unknown); // no event
+    listener.applyOnlineStateChange(OnlineState.Online); // no event
     listener.onViewSnapshot(snap2); // no event
     listener.onViewSnapshot(snap3); // event because synced
 
@@ -516,11 +516,11 @@ describe('QueryListener', () => {
     const changes2 = view.computeDocChanges(documentUpdates(doc2));
     const snap2 = view.applyChanges(changes2, true).snapshot!;
 
-    listener.applyOnlineStateChange('Online'); // no event
+    listener.applyOnlineStateChange(OnlineState.Online); // no event
     listener.onViewSnapshot(snap1); // no event
-    listener.applyOnlineStateChange('Offline'); // event
-    listener.applyOnlineStateChange('Online'); // no event
-    listener.applyOnlineStateChange('Offline'); // no event
+    listener.applyOnlineStateChange(OnlineState.Offline); // event
+    listener.applyOnlineStateChange(OnlineState.Online); // no event
+    listener.applyOnlineStateChange(OnlineState.Offline); // no event
     listener.onViewSnapshot(snap2); // another event
 
     const expectedSnap1 = {
@@ -554,9 +554,9 @@ describe('QueryListener', () => {
     const changes1 = view.computeDocChanges(documentUpdates());
     const snap1 = view.applyChanges(changes1, true).snapshot!;
 
-    listener.applyOnlineStateChange('Online'); // no event
+    listener.applyOnlineStateChange(OnlineState.Online); // no event
     listener.onViewSnapshot(snap1); // no event
-    listener.applyOnlineStateChange('Offline'); // event
+    listener.applyOnlineStateChange(OnlineState.Offline); // event
 
     const expectedSnap = {
       query,
@@ -580,7 +580,7 @@ describe('QueryListener', () => {
     const changes1 = view.computeDocChanges(documentUpdates());
     const snap1 = view.applyChanges(changes1, true).snapshot!;
 
-    listener.applyOnlineStateChange('Offline');
+    listener.applyOnlineStateChange(OnlineState.Offline);
     listener.onViewSnapshot(snap1);
 
     const expectedSnap = {

--- a/packages/firestore/test/unit/local/web_storage_shared_client_state.test.ts
+++ b/packages/firestore/test/unit/local/web_storage_shared_client_state.test.ts
@@ -97,7 +97,7 @@ class TestSharedClientSyncer implements SharedClientStateSyncer {
     [targetId: number]: { state: QueryTargetState; error?: FirestoreError };
   } = {};
   private activeTargets = targetIdSet();
-  private onlineState: OnlineState = 'Unknown';
+  private onlineState = OnlineState.Unknown;
 
   constructor(public activeClients: ClientId[]) {}
 
@@ -412,27 +412,27 @@ describe('WebStorageSharedClientState', () => {
 
     it('with targets from existing client', async () => {
       // The prior client has two active query targets
-      await verifyState([3, 4], 'Unknown');
+      await verifyState([3, 4], OnlineState.Unknown);
 
       sharedClientState.addLocalQueryTarget(4);
-      await verifyState([3, 4], 'Unknown');
+      await verifyState([3, 4], OnlineState.Unknown);
 
       sharedClientState.addLocalQueryTarget(5);
-      await verifyState([3, 4, 5], 'Unknown');
+      await verifyState([3, 4, 5], OnlineState.Unknown);
 
       sharedClientState.removeLocalQueryTarget(5);
-      await verifyState([3, 4], 'Unknown');
+      await verifyState([3, 4], OnlineState.Unknown);
     });
 
     it('with targets from new client', async () => {
       // The prior client has two active query targets
-      await verifyState([3, 4], 'Unknown');
+      await verifyState([3, 4], OnlineState.Unknown);
 
       const oldState = new LocalClientState();
       oldState.addQueryTarget(5);
 
       writeToWebStorage(secondaryClientStateKey, oldState.toWebStorageJSON());
-      await verifyState([3, 4, 5], 'Unknown');
+      await verifyState([3, 4, 5], OnlineState.Unknown);
 
       const updatedState = new LocalClientState();
       updatedState.addQueryTarget(5);
@@ -442,15 +442,15 @@ describe('WebStorageSharedClientState', () => {
         secondaryClientStateKey,
         updatedState.toWebStorageJSON()
       );
-      await verifyState([3, 4, 5, 6], 'Unknown');
+      await verifyState([3, 4, 5, 6], OnlineState.Unknown);
 
       writeToWebStorage(secondaryClientStateKey, null);
-      await verifyState([3, 4], 'Unknown');
+      await verifyState([3, 4], OnlineState.Unknown);
     });
 
     it('with online state from new client', async () => {
       // The prior client has two active query targets
-      await verifyState([3, 4], 'Unknown');
+      await verifyState([3, 4], OnlineState.Unknown);
 
       // Ensure that client is considered active
       const oldState = new LocalClientState();
@@ -463,7 +463,7 @@ describe('WebStorageSharedClientState', () => {
           clientId: secondaryClientId
         })
       );
-      await verifyState([3, 4], 'Unknown');
+      await verifyState([3, 4], OnlineState.Unknown);
 
       writeToWebStorage(
         onlineStateKey(),
@@ -472,7 +472,7 @@ describe('WebStorageSharedClientState', () => {
           clientId: secondaryClientId
         })
       );
-      await verifyState([3, 4], 'Offline');
+      await verifyState([3, 4], OnlineState.Offline);
 
       writeToWebStorage(
         onlineStateKey(),
@@ -481,12 +481,12 @@ describe('WebStorageSharedClientState', () => {
           clientId: secondaryClientId
         })
       );
-      await verifyState([3, 4], 'Online');
+      await verifyState([3, 4], OnlineState.Online);
     });
 
     it('ignores online state from inactive client', async () => {
       // The prior client has two active query targets
-      await verifyState([3, 4], 'Unknown');
+      await verifyState([3, 4], OnlineState.Unknown);
 
       // The secondary client is inactive and its online state is ignored.
       writeToWebStorage(
@@ -497,7 +497,7 @@ describe('WebStorageSharedClientState', () => {
         })
       );
 
-      await verifyState([3, 4], 'Unknown');
+      await verifyState([3, 4], OnlineState.Unknown);
 
       // Ensure that client is considered active
       const oldState = new LocalClientState();
@@ -511,7 +511,7 @@ describe('WebStorageSharedClientState', () => {
         })
       );
 
-      await verifyState([3, 4], 'Online');
+      await verifyState([3, 4], OnlineState.Online);
     });
 
     it('ignores invalid data', async () => {
@@ -522,11 +522,11 @@ describe('WebStorageSharedClientState', () => {
       };
 
       // The prior instance has two active query targets
-      await verifyState([3, 4], 'Unknown');
+      await verifyState([3, 4], OnlineState.Unknown);
 
       // We ignore the newly added target.
       writeToWebStorage(secondaryClientStateKey, JSON.stringify(invalidState));
-      await verifyState([3, 4], 'Unknown');
+      await verifyState([3, 4], OnlineState.Unknown);
     });
   });
 


### PR DESCRIPTION
This removes the overhead that Enums introduce in TypeScript by changing our enums to "const enums" which can be inlined: https://www.typescriptlang.org/docs/handbook/enums.html#const-enums

This also reverts some of the changes that were made to the OnlineState enum and uses the same solution.

Size before: 318393 bytes (90882 gzipped)
Size after: 315811 bytes (89863 gzipped - 1.2%)