### PR TITLE
Fix performance regression. Add tests against actual server behavior.

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,7 +8,7 @@
       "type": "node",
       "request": "launch",
       "name": "RTDB Unit Tests (Node)",
-      "program": "${workspaceRoot}/packages/firestore/node_modules/.bin/_mocha",
+      "program": "${workspaceRoot}/packages/firebase/node_modules/.bin/_mocha",
       "cwd": "${workspaceRoot}/packages/database",
       "args": [
         "test/{,!(browser)/**/}*.test.ts",

--- a/packages/database/src/core/Repo.ts
+++ b/packages/database/src/core/Repo.ts
@@ -367,7 +367,7 @@ export class Repo {
       const newNodeUnresolved = nodeFromJSON(changedValue);
       changedChildren[changedKey] = resolveDeferredValueSnapshot(
         newNodeUnresolved,
-        this.serverSyncTree_.calcCompleteEventCache(path),
+        this.serverSyncTree_.calcCompleteEventCache(path.child(changedKey)),
         serverValues
       );
     });

--- a/packages/database/test/servervalues.test.ts
+++ b/packages/database/test/servervalues.test.ts
@@ -94,6 +94,7 @@ describe('ServerValue tests', () => {
 
         node.off('value');
         expect(values).to.deep.equal(expected);
+        node.database.goOnline();
       });
     }
   });

--- a/scripts/emulator-testing/emulators/database-emulator.ts
+++ b/scripts/emulator-testing/emulators/database-emulator.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2018 Google Inc.
+ * Copyright 2018 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,7 +28,7 @@ export class DatabaseEmulator extends Emulator {
       // Use locked version of emulator for test to be deterministic.
       // The latest version can be found from database emulator doc:
       // https://firebase.google.com/docs/database/security/test-rules-emulator
-      'https://storage.googleapis.com/firebase-preview-drop/emulator/firebase-database-emulator-v3.5.0.jar',
+      'https://storage.googleapis.com/firebase-preview-drop/emulator/firebase-database-emulator-v4.4.1.jar',
       port
     );
     this.namespace = namespace;


### PR DESCRIPTION
Work in progress. I understand the bug fix that Mike wanted us to apply, though the result would still be pessimal (would require us to calculate resolved values always even if the there was no server values).

In trying to test the bug/fix I ran into some issues. It seems like the update command and racy sets are failing. The "handles sparse updates" test fails because the second {increment: X} is resolved as a set X. Some extra debug statements in the racy write case seem to suggest that the values are incrementing and re-decrementing with server-side results. The emulator itself seems to work, so I'm not sure what the problem is yet. Maybe the SyncTree?
