### PR TITLE
Avoid rebuilding the repo during the global test run

### DIFF
--- a/integration/firestore/package.json
+++ b/integration/firestore/package.json
@@ -3,9 +3,10 @@
   "version": "1.0.1",
   "private": true,
   "scripts": {
-    "build": "(cd ../../ ; yarn build) ; gulp compile-tests",
+    "build": "gulp compile-tests",
+    "build:deps": "cd ../../ ; yarn build",
     "pretest:manual": "yarn build",
-    "pretest:debug": "yarn build",
+    "pretest:debug": "yarn build:deps && yarn build",
     "test": "echo 'Automated tests temporarily disabled, run `yarn test:manual` to execute these tests'",
     "test:manual": "karma start --single-run",
     "test:debug": "karma start --auto-watch --browsers Chrome"


### PR DESCRIPTION
We don't want to rebuild the whole repo when running tests. It will slow down `yarn test` at the root of the repo and CI.