### PR TITLE
Update analytics ecommerce event and param types

### DIFF
--- a/packages/analytics-types/index.d.ts
+++ b/packages/analytics-types/index.d.ts
@@ -143,6 +143,14 @@ export interface EventParams {
   value?: number;
   event_label?: string;
   event_category?: string;
+  shipping_tier?: string;
+  item_list?: string;
+  item_list_id?: string;
+  item_list_name?: string;
+  promotion_id?: string;
+  promotion_name?: string;
+  payment_type?: string;
+  affiliation?: string;
 }
 
 /**
@@ -158,6 +166,7 @@ export interface CustomParams {
  */
 export type EventNameString =
   | 'add_payment_info'
+  | 'add_shipping_info'
   | 'add_to_cart'
   | 'add_to_wishlist'
   | 'begin_checkout'
@@ -172,10 +181,13 @@ export type EventNameString =
   | 'screen_view'
   | 'search'
   | 'select_content'
+  | 'select_item'
+  | 'select_promotion'
   | 'set_checkout_option'
   | 'share'
   | 'sign_up'
   | 'timing_complete'
+  | 'view_cart'
   | 'view_item'
   | 'view_item_list'
   | 'view_promotion'
@@ -184,17 +196,39 @@ export type EventNameString =
 export type Currency = string | number;
 
 export interface Item {
-  brand?: string;
-  category?: string;
-  creative_name?: string;
-  creative_slot?: string;
-  id?: string;
-  location_id?: string;
-  name?: string;
+  item_id?: string;
+  item_name?: string;
+  item_brand?: string;
+  item_category?: string;
+  item_category2?: string;
+  item_category3?: string;
+  item_category4?: string;
+  item_category5?: string;
+  item_variant?: string;
   price?: Currency;
   quantity?: number;
+  index?: string;
+  coupon?: string;
+  item_list_name?: string;
+  item_list_id?: string;
+  discount?: Currency;
+  affiliation?: string;
+  creative_name?: string;
+  creative_slot?: string;
+  promotion_id?: string;
+  promotion_name?: string;
+  location_id?: string;
+  /** @deprecated Use item_brand instead. */
+  brand?: string;
+  /** @deprecated Use item_category instead. */
+  category?: string;
+  /** @deprecated Use item_id instead. */
+  id?: string;
+  /** @deprecated Use item_name instead. */
+  name?: string;
 }
 
+/** @deprecated Use Item instead. */
 export interface Promotion {
   creative_name?: string;
   creative_slot?: string;

--- a/packages/analytics-types/index.d.ts
+++ b/packages/analytics-types/index.d.ts
@@ -144,7 +144,6 @@ export interface EventParams {
   event_label?: string;
   event_category?: string;
   shipping_tier?: string;
-  item_list?: string;
   item_list_id?: string;
   item_list_name?: string;
   promotion_id?: string;

--- a/packages/analytics/src/constants.ts
+++ b/packages/analytics/src/constants.ts
@@ -34,10 +34,12 @@ export enum GtagCommand {
  * Any other string is also allowed.
  */
 export enum EventName {
+  ADD_SHIPPING_INFO = 'add_shipping_info',
   ADD_PAYMENT_INFO = 'add_payment_info',
   ADD_TO_CART = 'add_to_cart',
   ADD_TO_WISHLIST = 'add_to_wishlist',
   BEGIN_CHECKOUT = 'begin_checkout',
+  /** @deprecated */
   CHECKOUT_PROGRESS = 'checkout_progress',
   EXCEPTION = 'exception',
   GENERATE_LEAD = 'generate_lead',
@@ -49,10 +51,14 @@ export enum EventName {
   SCREEN_VIEW = 'screen_view',
   SEARCH = 'search',
   SELECT_CONTENT = 'select_content',
+  SELECT_ITEM = 'select_item',
+  SELECT_PROMOTION = 'select_promotion',
+  /** @deprecated */
   SET_CHECKOUT_OPTION = 'set_checkout_option',
   SHARE = 'share',
   SIGN_UP = 'sign_up',
   TIMING_COMPLETE = 'timing_complete',
+  VIEW_CART = 'view_cart',
   VIEW_ITEM = 'view_item',
   VIEW_ITEM_LIST = 'view_item_list',
   VIEW_PROMOTION = 'view_promotion',

--- a/packages/firebase/index.d.ts
+++ b/packages/firebase/index.d.ts
@@ -4008,7 +4008,35 @@ declare namespace firebase.analytics {
      */
     logEvent(
       eventName: 'add_payment_info',
-      eventParams?: { [key: string]: any },
+      eventParams?: {
+        coupon?: EventParams['coupon'];
+        currency?: EventParams['currency'];
+        items?: EventParams['items'];
+        payment_type?: EventParams['payment_type'];
+        value?: EventParams['value'];
+        [key: string]: any;
+      },
+      options?: firebase.analytics.AnalyticsCallOptions
+    ): void;
+
+    /**
+     * Sends analytics event with given `eventParams`. This method
+     * automatically associates this logged event with this Firebase web
+     * app instance on this device.
+     * List of official event parameters can be found in
+     * {@link https://developers.google.com/gtagjs/reference/event
+     * the gtag.js reference documentation}.
+     */
+    logEvent(
+      eventName: 'add_shipping_info',
+      eventParams: {
+        coupon?: EventParams['coupon'];
+        currency?: EventParams['currency'];
+        items?: EventParams['items'];
+        shipping_tier?: EventParams['shipping_tier'];
+        value?: EventParams['value'];
+        [key: string]: any;
+      },
       options?: firebase.analytics.AnalyticsCallOptions
     ): void;
 
@@ -4155,7 +4183,7 @@ declare namespace firebase.analytics {
      * the gtag.js reference documentation}.
      */
     logEvent(
-      eventName: 'purchase',
+      eventName: 'purchase' | 'refund',
       eventParams: {
         value?: EventParams['value'];
         currency?: EventParams['currency'];
@@ -4164,28 +4192,7 @@ declare namespace firebase.analytics {
         shipping?: EventParams['shipping'];
         items?: EventParams['items'];
         coupon?: EventParams['coupon'];
-        [key: string]: any;
-      },
-      options?: firebase.analytics.AnalyticsCallOptions
-    ): void;
-
-    /**
-     * Sends analytics event with given `eventParams`. This method
-     * automatically associates this logged event with this Firebase web
-     * app instance on this device.
-     * List of official event parameters can be found in
-     * {@link https://developers.google.com/gtagjs/reference/event
-     * the gtag.js reference documentation}.
-     */
-    logEvent(
-      eventName: 'refund',
-      eventParams: {
-        value?: EventParams['value'];
-        currency?: EventParams['currency'];
-        transaction_id: EventParams['transaction_id'];
-        tax?: EventParams['tax'];
-        shipping?: EventParams['shipping'];
-        items?: EventParams['items'];
+        affiliation?: EventParams['affiliation'];
         [key: string]: any;
       },
       options?: firebase.analytics.AnalyticsCallOptions
@@ -4244,6 +4251,44 @@ declare namespace firebase.analytics {
         promotions?: EventParams['promotions'];
         content_type?: EventParams['content_type'];
         content_id?: EventParams['content_id'];
+        [key: string]: any;
+      },
+      options?: firebase.analytics.AnalyticsCallOptions
+    ): void;
+
+    /**
+     * Sends analytics event with given `eventParams`. This method
+     * automatically associates this logged event with this Firebase web
+     * app instance on this device.
+     * List of official event parameters can be found in
+     * {@link https://developers.google.com/gtagjs/reference/event
+     * the gtag.js reference documentation}.
+     */
+    logEvent(
+      eventName: 'select_item',
+      eventParams: {
+        items?: EventParams['items'];
+        item_list_name?: EventParams['item_list_name'];
+        item_list_id?: EventParams['item_list_id'];
+        [key: string]: any;
+      },
+      options?: firebase.analytics.AnalyticsCallOptions
+    ): void;
+
+    /**
+     * Sends analytics event with given `eventParams`. This method
+     * automatically associates this logged event with this Firebase web
+     * app instance on this device.
+     * List of official event parameters can be found in
+     * {@link https://developers.google.com/gtagjs/reference/event
+     * the gtag.js reference documentation}.
+     */
+    logEvent(
+      eventName: 'select_promotion' | 'view_promotion',
+      eventParams: {
+        items?: EventParams['items'];
+        promotion_id?: EventParams['promotion_id'];
+        promotion_name?: EventParams['promotion_name'];
         [key: string]: any;
       },
       options?: firebase.analytics.AnalyticsCallOptions
@@ -4332,9 +4377,11 @@ declare namespace firebase.analytics {
      * the gtag.js reference documentation}.
      */
     logEvent(
-      eventName: 'view_item' | 'view_item_list',
+      eventName: 'view_cart' | 'view_item',
       eventParams: {
+        currency?: EventParams['currency'];
         items?: EventParams['items'];
+        value?: EventParams['value'];
         [key: string]: any;
       },
       options?: firebase.analytics.AnalyticsCallOptions
@@ -4349,9 +4396,11 @@ declare namespace firebase.analytics {
      * the gtag.js reference documentation}.
      */
     logEvent(
-      eventName: 'view_promotion',
+      eventName: 'view_item_list',
       eventParams: {
-        promotions?: EventParams['promotions'];
+        items?: EventParams['items'];
+        item_list_name?: EventParams['item_list_name'];
+        item_list_id?: EventParams['item_list_id'];
         [key: string]: any;
       },
       options?: firebase.analytics.AnalyticsCallOptions
@@ -4477,6 +4526,14 @@ declare namespace firebase.analytics {
     value?: number;
     event_label?: string;
     event_category: string;
+    shipping_tier?: string;
+    item_list?: string;
+    item_list_id?: string;
+    item_list_name?: string;
+    promotion_id?: string;
+    promotion_name?: string;
+    payment_type?: string;
+    affiliation?: string;
   }
 
   /**
@@ -4492,6 +4549,7 @@ declare namespace firebase.analytics {
    */
   export type EventNameString =
     | 'add_payment_info'
+    | 'add_shipping_info'
     | 'add_to_cart'
     | 'add_to_wishlist'
     | 'begin_checkout'
@@ -4506,10 +4564,13 @@ declare namespace firebase.analytics {
     | 'screen_view'
     | 'search'
     | 'select_content'
+    | 'select_item'
+    | 'select_promotion'
     | 'set_checkout_option'
     | 'share'
     | 'sign_up'
     | 'timing_complete'
+    | 'view_cart'
     | 'view_item'
     | 'view_item_list'
     | 'view_promotion'
@@ -4522,9 +4583,11 @@ declare namespace firebase.analytics {
    */
   export enum EventName {
     ADD_PAYMENT_INFO = 'add_payment_info',
+    ADD_SHIPPING_INFO = 'add_shipping_info',
     ADD_TO_CART = 'add_to_cart',
     ADD_TO_WISHLIST = 'add_to_wishlist',
     BEGIN_CHECKOUT = 'begin_checkout',
+    /** @deprecated */
     CHECKOUT_PROGRESS = 'checkout_progress',
     EXCEPTION = 'exception',
     GENERATE_LEAD = 'generate_lead',
@@ -4536,10 +4599,14 @@ declare namespace firebase.analytics {
     SCREEN_VIEW = 'screen_view',
     SEARCH = 'search',
     SELECT_CONTENT = 'select_content',
+    SELECT_ITEM = 'select_item',
+    SELECT_PROMOTION = 'select_promotion',
+    /** @deprecated */
     SET_CHECKOUT_OPTION = 'set_checkout_option',
     SHARE = 'share',
     SIGN_UP = 'sign_up',
     TIMING_COMPLETE = 'timing_complete',
+    VIEW_CART = 'view_cart',
     VIEW_ITEM = 'view_item',
     VIEW_ITEM_LIST = 'view_item_list',
     VIEW_PROMOTION = 'view_promotion',
@@ -4549,17 +4616,39 @@ declare namespace firebase.analytics {
   export type Currency = string | number;
 
   export interface Item {
-    brand?: string;
-    category?: string;
-    creative_name?: string;
-    creative_slot?: string;
-    id?: string;
-    location_id?: string;
-    name?: string;
+    item_id?: string;
+    item_name?: string;
+    item_brand?: string;
+    item_category?: string;
+    item_category2?: string;
+    item_category3?: string;
+    item_category4?: string;
+    item_category5?: string;
+    item_variant?: string;
     price?: Currency;
     quantity?: number;
+    index?: string;
+    coupon?: string;
+    item_list_name?: string;
+    item_list_id?: string;
+    discount?: Currency;
+    affiliation?: string;
+    creative_name?: string;
+    creative_slot?: string;
+    promotion_id?: string;
+    promotion_name?: string;
+    location_id?: string;
+    /** @deprecated Use item_brand instead. */
+    brand?: string;
+    /** @deprecated Use item_category instead. */
+    category?: string;
+    /** @deprecated Use item_id instead. */
+    id?: string;
+    /** @deprecated Use item_name instead. */
+    name?: string;
   }
 
+  /** @deprecated Use Item instead. */
   export interface Promotion {
     creative_name?: string;
     creative_slot?: string;

--- a/packages/firebase/index.d.ts
+++ b/packages/firebase/index.d.ts
@@ -4002,7 +4002,7 @@ declare namespace firebase.analytics {
      * Sends analytics event with given `eventParams`. This method
      * automatically associates this logged event with this Firebase web
      * app instance on this device.
-     * List of official event parameters can be found in
+     * List of recommended event parameters can be found in
      * {@link https://developers.google.com/gtagjs/reference/event
      * the gtag.js reference documentation}.
      */
@@ -4023,7 +4023,7 @@ declare namespace firebase.analytics {
      * Sends analytics event with given `eventParams`. This method
      * automatically associates this logged event with this Firebase web
      * app instance on this device.
-     * List of official event parameters can be found in
+     * List of recommended event parameters can be found in
      * {@link https://developers.google.com/gtagjs/reference/event
      * the gtag.js reference documentation}.
      */
@@ -4044,7 +4044,7 @@ declare namespace firebase.analytics {
      * Sends analytics event with given `eventParams`. This method
      * automatically associates this logged event with this Firebase web
      * app instance on this device.
-     * List of official event parameters can be found in
+     * List of recommended event parameters can be found in
      * {@link https://developers.google.com/gtagjs/reference/event
      * the gtag.js reference documentation}.
      */
@@ -4063,7 +4063,7 @@ declare namespace firebase.analytics {
      * Sends analytics event with given `eventParams`. This method
      * automatically associates this logged event with this Firebase web
      * app instance on this device.
-     * List of official event parameters can be found in
+     * List of recommended event parameters can be found in
      * {@link https://developers.google.com/gtagjs/reference/event
      * the gtag.js reference documentation}.
      */
@@ -4083,7 +4083,7 @@ declare namespace firebase.analytics {
      * Sends analytics event with given `eventParams`. This method
      * automatically associates this logged event with this Firebase web
      * app instance on this device.
-     * List of official event parameters can be found in
+     * List of recommended event parameters can be found in
      * {@link https://developers.google.com/gtagjs/reference/event
      * the gtag.js reference documentation}.
      */
@@ -4105,7 +4105,7 @@ declare namespace firebase.analytics {
      * Sends analytics event with given `eventParams`. This method
      * automatically associates this logged event with this Firebase web
      * app instance on this device.
-     * List of official event parameters can be found in
+     * List of recommended event parameters can be found in
      * {@link https://developers.google.com/gtagjs/reference/event
      * the gtag.js reference documentation}.
      */
@@ -4123,7 +4123,7 @@ declare namespace firebase.analytics {
      * Sends analytics event with given `eventParams`. This method
      * automatically associates this logged event with this Firebase web
      * app instance on this device.
-     * List of official event parameters can be found in
+     * List of recommended event parameters can be found in
      * {@link https://developers.google.com/gtagjs/reference/event
      * the gtag.js reference documentation}.
      */
@@ -4142,7 +4142,7 @@ declare namespace firebase.analytics {
      * Sends analytics event with given `eventParams`. This method
      * automatically associates this logged event with this Firebase web
      * app instance on this device.
-     * List of official event parameters can be found in
+     * List of recommended event parameters can be found in
      * {@link https://developers.google.com/gtagjs/reference/event
      * the gtag.js reference documentation}.
      */
@@ -4159,7 +4159,7 @@ declare namespace firebase.analytics {
      * Sends analytics event with given `eventParams`. This method
      * automatically associates this logged event with this Firebase web
      * app instance on this device.
-     * List of official event parameters can be found in
+     * List of recommended event parameters can be found in
      * {@link https://developers.google.com/gtagjs/reference/event
      * the gtag.js reference documentation}.
      */
@@ -4178,7 +4178,7 @@ declare namespace firebase.analytics {
      * Sends analytics event with given `eventParams`. This method
      * automatically associates this logged event with this Firebase web
      * app instance on this device.
-     * List of official event parameters can be found in
+     * List of recommended event parameters can be found in
      * {@link https://developers.google.com/gtagjs/reference/event
      * the gtag.js reference documentation}.
      */
@@ -4202,7 +4202,7 @@ declare namespace firebase.analytics {
      * Sends analytics event with given `eventParams`. This method
      * automatically associates this logged event with this Firebase web
      * app instance on this device.
-     * List of official event parameters can be found in
+     * List of recommended event parameters can be found in
      * {@link https://developers.google.com/gtagjs/reference/event
      * the gtag.js reference documentation}.
      */
@@ -4223,7 +4223,7 @@ declare namespace firebase.analytics {
      * Sends analytics event with given `eventParams`. This method
      * automatically associates this logged event with this Firebase web
      * app instance on this device.
-     * List of official event parameters can be found in
+     * List of recommended event parameters can be found in
      * {@link https://developers.google.com/gtagjs/reference/event
      * the gtag.js reference documentation}.
      */
@@ -4240,7 +4240,7 @@ declare namespace firebase.analytics {
      * Sends analytics event with given `eventParams`. This method
      * automatically associates this logged event with this Firebase web
      * app instance on this device.
-     * List of official event parameters can be found in
+     * List of recommended event parameters can be found in
      * {@link https://developers.google.com/gtagjs/reference/event
      * the gtag.js reference documentation}.
      */
@@ -4260,7 +4260,7 @@ declare namespace firebase.analytics {
      * Sends analytics event with given `eventParams`. This method
      * automatically associates this logged event with this Firebase web
      * app instance on this device.
-     * List of official event parameters can be found in
+     * List of recommended event parameters can be found in
      * {@link https://developers.google.com/gtagjs/reference/event
      * the gtag.js reference documentation}.
      */
@@ -4279,7 +4279,7 @@ declare namespace firebase.analytics {
      * Sends analytics event with given `eventParams`. This method
      * automatically associates this logged event with this Firebase web
      * app instance on this device.
-     * List of official event parameters can be found in
+     * List of recommended event parameters can be found in
      * {@link https://developers.google.com/gtagjs/reference/event
      * the gtag.js reference documentation}.
      */
@@ -4298,7 +4298,7 @@ declare namespace firebase.analytics {
      * Sends analytics event with given `eventParams`. This method
      * automatically associates this logged event with this Firebase web
      * app instance on this device.
-     * List of official event parameters can be found in
+     * List of recommended event parameters can be found in
      * {@link https://developers.google.com/gtagjs/reference/event
      * the gtag.js reference documentation}.
      */
@@ -4316,7 +4316,7 @@ declare namespace firebase.analytics {
      * Sends analytics event with given `eventParams`. This method
      * automatically associates this logged event with this Firebase web
      * app instance on this device.
-     * List of official event parameters can be found in
+     * List of recommended event parameters can be found in
      * {@link https://developers.google.com/gtagjs/reference/event
      * the gtag.js reference documentation}.
      */
@@ -4335,7 +4335,7 @@ declare namespace firebase.analytics {
      * Sends analytics event with given `eventParams`. This method
      * automatically associates this logged event with this Firebase web
      * app instance on this device.
-     * List of official event parameters can be found in
+     * List of recommended event parameters can be found in
      * {@link https://developers.google.com/gtagjs/reference/event
      * the gtag.js reference documentation}.
      */
@@ -4352,7 +4352,7 @@ declare namespace firebase.analytics {
      * Sends analytics event with given `eventParams`. This method
      * automatically associates this logged event with this Firebase web
      * app instance on this device.
-     * List of official event parameters can be found in
+     * List of recommended event parameters can be found in
      * {@link https://developers.google.com/gtagjs/reference/event
      * the gtag.js reference documentation}.
      */
@@ -4372,7 +4372,7 @@ declare namespace firebase.analytics {
      * Sends analytics event with given `eventParams`. This method
      * automatically associates this logged event with this Firebase web
      * app instance on this device.
-     * List of official event parameters can be found in
+     * List of recommended event parameters can be found in
      * {@link https://developers.google.com/gtagjs/reference/event
      * the gtag.js reference documentation}.
      */
@@ -4391,7 +4391,7 @@ declare namespace firebase.analytics {
      * Sends analytics event with given `eventParams`. This method
      * automatically associates this logged event with this Firebase web
      * app instance on this device.
-     * List of official event parameters can be found in
+     * List of recommended event parameters can be found in
      * {@link https://developers.google.com/gtagjs/reference/event
      * the gtag.js reference documentation}.
      */
@@ -4410,7 +4410,7 @@ declare namespace firebase.analytics {
      * Sends analytics event with given `eventParams`. This method
      * automatically associates this logged event with this Firebase web
      * app instance on this device.
-     * List of official event parameters can be found in
+     * List of recommended event parameters can be found in
      * {@link https://developers.google.com/gtagjs/reference/event
      * the gtag.js reference documentation}.
      */

--- a/packages/firebase/index.d.ts
+++ b/packages/firebase/index.d.ts
@@ -4527,7 +4527,6 @@ declare namespace firebase.analytics {
     event_label?: string;
     event_category: string;
     shipping_tier?: string;
-    item_list?: string;
     item_list_id?: string;
     item_list_name?: string;
     promotion_id?: string;


### PR DESCRIPTION
Update Analytics types and method signatures to reflect GA's enhanced ecommerce options.

- Some events and params have been added.
- Some have been deprecated.
- Some existing methods have the number of suggested params expanded.

The latter should only affect IDE autocomplete. All event params are always optional and any additional arbitrary param is always allowed.

This changes the public API and will require a documentation update.

Internal bug for this feature: b/151107871