### PR TITLE
Add full license to generated files in internal deploy only

### DIFF
--- a/packages/firebase/rollup-internal.config.js
+++ b/packages/firebase/rollup-internal.config.js
@@ -23,13 +23,21 @@
 // When run in google3, original rollup.config.js will have been renamed to rollup-main.config.js.
 import baseBuilds from './rollup-main.config.js';
 import license from 'rollup-plugin-license';
-import gitRev from 'git-rev-sync';
-import pkg from './package.json';
 
 const firebaseLicense = license({
-  banner: `@license Firebase v${pkg.version}
-    Build: rev-${gitRev.short()}
-    Terms: https://firebase.google.com/terms/`
+  banner: `Copyright ${new Date().getFullYear()} Google Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.`
 });
 
 const buildsWithLicense = baseBuilds.map(build => {


### PR DESCRIPTION
Internal deploy guidelines require the full license to be included in generated files, we previously were using only an abbreviated format. Not sure what the origin of the abbreviated format was.