### PR TITLE
Support -0.0 in Firestore

### DIFF
--- a/packages/firestore/CHANGELOG.md
+++ b/packages/firestore/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Unreleased
+- [fixed] Fixed an issue where the number value `-0.0` would lose its sign when
+  stored in Firestore.
+
+# 1.10.0
 - [feature] Implemented `Timestamp.valueOf()` so that `Timestamp` objects can be
   compared for relative ordering using the JavaScript arithmetic comparison
   operators (#2632).

--- a/packages/firestore/src/core/types.ts
+++ b/packages/firestore/src/core/types.ts
@@ -38,7 +38,7 @@ export type MutationBatchState = 'pending' | 'acknowledged' | 'rejected';
  * primarily used by the View / EventManager code to change their behavior while
  * offline (e.g. get() calls shouldn't wait for data from the server and
  * snapshot events should set metadata.isFromCache=true).
- * 
+ *
  * The string values should not be changed since they are persisted in
  * WebStorage.
  */

--- a/packages/firestore/src/remote/serializer.ts
+++ b/packages/firestore/src/remote/serializer.ts
@@ -438,6 +438,8 @@ export class JsonProtoSerializer {
           return { doubleValue: 'Infinity' } as {};
         } else if (doubleValue === -Infinity) {
           return { doubleValue: '-Infinity' } as {};
+        } else if (typeUtils.isNegativeZero(doubleValue)) {
+          return { doubleValue: '-0' } as {};
         }
       }
       return { doubleValue: val.value() };
@@ -487,6 +489,8 @@ export class JsonProtoSerializer {
           return fieldValue.DoubleValue.POSITIVE_INFINITY;
         } else if ((obj.doubleValue as {}) === '-Infinity') {
           return fieldValue.DoubleValue.NEGATIVE_INFINITY;
+        } else if ((obj.doubleValue as {}) === '-0') {
+          return new fieldValue.DoubleValue(-0);
         }
       }
 

--- a/packages/firestore/src/util/types.ts
+++ b/packages/firestore/src/util/types.ts
@@ -44,7 +44,7 @@ export const MAX_SAFE_INTEGER: number =
  * Added to not rely on ES6 features.
  * @param value The value to test for being an integer
  */
-export const isInteger: (value: unknown) => boolean =
+export const isInteger: (value: unknown) => value is number =
   NumberAsAny.isInteger ||
   (value =>
     typeof value === 'number' &&
@@ -58,22 +58,22 @@ export function isNullOrUndefined(value: unknown): boolean {
   return value === null || value === undefined;
 }
 
+/** Returns whether the value represents -0.. */
+export function isNegativeZero(value: number) {
+  // Detect if the value is -0.0. Based on polyfill from
+  // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/is
+  return value === -0 && 1 / value === 1 / -0;
+}
+
 /**
  * Returns whether a value is an integer and in the safe integer range
  * @param value The value to test for being an integer and in the safe range
  */
 export function isSafeInteger(value: unknown): boolean {
-  if (value === -0) {
-    // Detect if the value is actually 0 and not -0 (JS returns true for
-    // `0 === -0`). `0` is a safe integer, -0 has to be stored as a double.
-    // Based on polyfill from
-    // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/is
-    return 1 / value === 1 / 0;
-  } else {
-    return (
-      isInteger(value) &&
-      (value as number) <= MAX_SAFE_INTEGER &&
-      (value as number) >= MIN_SAFE_INTEGER
-    );
-  }
+  return (
+    isInteger(value) &&
+    !isNegativeZero(value) &&
+    value <= MAX_SAFE_INTEGER &&
+    value >= MIN_SAFE_INTEGER
+  );
 }

--- a/packages/firestore/src/util/types.ts
+++ b/packages/firestore/src/util/types.ts
@@ -59,7 +59,7 @@ export function isNullOrUndefined(value: unknown): boolean {
 }
 
 /** Returns whether the value represents -0.. */
-export function isNegativeZero(value: number) {
+export function isNegativeZero(value: number) : boolean {
   // Detect if the value is -0.0. Based on polyfill from
   // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/is
   return value === -0 && 1 / value === 1 / -0;

--- a/packages/firestore/src/util/types.ts
+++ b/packages/firestore/src/util/types.ts
@@ -63,10 +63,11 @@ export function isNullOrUndefined(value: unknown): boolean {
  * @param value The value to test for being an integer and in the safe range
  */
 export function isSafeInteger(value: unknown): boolean {
-  // Implemented based on Object.is() polyfill from
-  // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/is
   if (value === -0) {
-    // +0 != -0
+    // Detect if the value is actually 0 and not -0 (JS returns true for
+    // `0 === -0`). `0` is a safe integer, -0 has to be stored as a double.
+    // Based on polyfill from
+    // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/is
     return 1 / value === 1 / 0;
   } else {
     return (

--- a/packages/firestore/src/util/types.ts
+++ b/packages/firestore/src/util/types.ts
@@ -63,20 +63,16 @@ export function isNullOrUndefined(value: unknown): boolean {
  * @param value The value to test for being an integer and in the safe range
  */
 export function isSafeInteger(value: unknown): boolean {
-  return (
-    isInteger(value) &&
-    (value as number) <= MAX_SAFE_INTEGER &&
-    (value as number) >= MIN_SAFE_INTEGER
-  );
-}
-
-/**
- * Safely checks if the number is NaN.
- */
-export function safeIsNaN(value: unknown): boolean {
-  if (NumberAsAny.IsNaN) {
-    return NumberAsAny.IsNaN(value);
+  // Implemented based on Object.is() polyfill from
+  // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/is
+  if (value === -0) {
+    // +0 != -0
+    return 1 / value === 1 / 0;
   } else {
-    return typeof value === 'number' && isNaN(value);
+    return (
+      isInteger(value) &&
+      (value as number) <= MAX_SAFE_INTEGER &&
+      (value as number) >= MIN_SAFE_INTEGER
+    );
   }
 }

--- a/packages/firestore/src/util/types.ts
+++ b/packages/firestore/src/util/types.ts
@@ -27,7 +27,7 @@ export function isNullOrUndefined(value: unknown): boolean {
   return value === null || value === undefined;
 }
 
-/** Returns whether the value represents -0.. */
+/** Returns whether the value represents -0. */
 export function isNegativeZero(value: number) : boolean {
   // Detect if the value is -0.0. Based on polyfill from
   // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/is

--- a/packages/firestore/test/integration/api/type.test.ts
+++ b/packages/firestore/test/integration/api/type.test.ts
@@ -47,6 +47,12 @@ apiDescribe('Firestore', (persistence: boolean) => {
     });
   });
 
+  it('can read and write number fields', () => {
+    return withTestDb(persistence, db => {
+      return expectRoundtrip(db, { a: 1, b: NaN, c: Infinity, d: -0.0 });
+    });
+  });
+
   it('can read and write array fields', () => {
     return withTestDb(persistence, db => {
       return expectRoundtrip(db, { array: [1, 'foo', { deep: true }, null] });

--- a/packages/firestore/test/util/equality_matcher.ts
+++ b/packages/firestore/test/util/equality_matcher.ts
@@ -34,26 +34,21 @@ export interface Equatable<T> {
  */
 
 function customDeepEqual(left: unknown, right: unknown): boolean {
-  /**
-   * START: Custom compare logic
-   */
   if (typeof left === 'object' && left && 'isEqual' in left) {
     return (left as Equatable<unknown>).isEqual(right);
   }
   if (typeof right === 'object' && right && 'isEqual' in right) {
     return (right as Equatable<unknown>).isEqual(left);
   }
-  /**
-   * END: Custom compare logic
-   */
-  if (left === 0.0 && right === 0.0) {
-    // Firestore treats -0.0 and +0.0 as not equals, even though JavaScript
-    // treats them as equal by default. Implemented based on MDN's Object.is()
-    // polyfill.
-    return 1 / left === 1 / right;
-  }
   if (left === right) {
-    return true;
+    if (left === 0.0 && right === 0.0) {
+      // Firestore treats -0.0 and +0.0 as not equals, even though JavaScript
+      // treats them as equal by default. Implemented based on MDN's Object.is()
+      // polyfill.
+      return 1 / left === 1 / right;
+    } else {
+      return true;
+    }
   }
   if (
     typeof left === 'number' &&

--- a/packages/firestore/test/util/equality_matcher.ts
+++ b/packages/firestore/test/util/equality_matcher.ts
@@ -46,6 +46,12 @@ function customDeepEqual(left: unknown, right: unknown): boolean {
   /**
    * END: Custom compare logic
    */
+  if (left === 0.0 && right === 0.0) {
+    // Firestore treats -0.0 and +0.0 as not equals, even though JavaScript
+    // treats them as equal by default. Implemented based on MDN's Object.is()
+    // polyfill.
+    return 1 / left === 1 / right;
+  }
   if (left === right) {
     return true;
   }


### PR DESCRIPTION
We have a couple of unit tests that verify that we treat DoubleValue -0.0 distinct from 0.0, but we were never storing -0.0 as a DoubleValue.