### PR TITLE
Fix closure line to match internal conformance requirements

### DIFF
--- a/packages/auth/src/authcredential.js
+++ b/packages/auth/src/authcredential.js
@@ -36,7 +36,7 @@ goog.provide('fireauth.SAMLAuthCredential');
 goog.provide('fireauth.SAMLAuthProvider');
 goog.provide('fireauth.TwitterAuthProvider');
 
-goog.forwardDeclare('fireauth.RpcHandler');
+goog.requireType('fireauth.RpcHandler');
 goog.require('fireauth.ActionCodeInfo');
 goog.require('fireauth.ActionCodeURL');
 goog.require('fireauth.AuthError');


### PR DESCRIPTION
There is an internal deprecation of `forwardDeclare`. Internal deployment has already been modified by an automated change, changing our source of truth to match.