### PR TITLE
Remove base64 encoding of resume tokens in spec tests.

### DIFF
--- a/packages/firestore/test/unit/specs/spec_builder.ts
+++ b/packages/firestore/test/unit/specs/spec_builder.ts
@@ -952,21 +952,18 @@ export class SpecBuilder {
         // `query` is not added yet.
         this.activeTargets[targetId] = {
           queries: [SpecBuilder.queryToSpec(query), ...activeQueries],
-          // Convert to base64 string so it can later be parsed into ByteString.
-          resumeToken: PlatformSupport.getPlatform().btoa(resumeToken || '')
+          resumeToken: resumeToken || ''
         };
       } else {
         this.activeTargets[targetId] = {
           queries: activeQueries,
-          // Convert to base64 string so it can later be parsed into ByteString.
-          resumeToken: PlatformSupport.getPlatform().btoa(resumeToken || '')
+          resumeToken: resumeToken || ''
         };
       }
     } else {
       this.activeTargets[targetId] = {
         queries: [SpecBuilder.queryToSpec(query)],
-        // Convert to base64 string so it can later be parsed into ByteString.
-        resumeToken: PlatformSupport.getPlatform().btoa(resumeToken || '')
+        resumeToken: resumeToken || ''
       };
     }
   }

--- a/packages/firestore/test/unit/specs/spec_builder.ts
+++ b/packages/firestore/test/unit/specs/spec_builder.ts
@@ -54,7 +54,6 @@ import {
   SpecWriteAck,
   SpecWriteFailure
 } from './spec_test_runner';
-import { PlatformSupport } from '../../../src/platform/platform';
 
 // These types are used in a protected API by SpecBuilder and need to be
 // exported.

--- a/packages/firestore/test/unit/specs/spec_test_runner.ts
+++ b/packages/firestore/test/unit/specs/spec_test_runner.ts
@@ -1151,11 +1151,7 @@ abstract class TestRunner {
       expect(actualTarget.query).to.deep.equal(expectedTarget.query);
       expect(actualTarget.targetId).to.equal(expectedTarget.targetId);
       expect(actualTarget.readTime).to.equal(expectedTarget.readTime);
-      // actualTarget's resumeToken is a string, but the serialized
-      // resumeToken will be a base64 string, so we need to convert it back.
-      expect(actualTarget.resumeToken || '').to.equal(
-        this.platform.atob(expectedTarget.resumeToken || '')
-      );
+      expect(actualTarget.resumeToken || '').to.equal(expectedTarget.resumeToken || '');
       delete actualTargets[targetId];
     });
     expect(obj.size(actualTargets)).to.equal(


### PR DESCRIPTION
Fixes: #2759