### PR TITLE
Update CI Triggers

### DIFF
--- a/.github/workflows/cross-browser-test.yml
+++ b/.github/workflows/cross-browser-test.yml
@@ -1,11 +1,9 @@
 name: Cross-Browser Test Flow
 
 on:
-  pull_request:
+  push:
     branches:
       - master
-    types:
-      - closed
 
 jobs:
   cross-browser-test:

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -1,9 +1,6 @@
-name: Run All Tests
+name: Test All Packages
 
-on: 
-  push:
-  schedule:
-    - cron: '0 6,18 * * *'
+on: push
 
 jobs:
   test:
@@ -39,7 +36,7 @@ jobs:
   deploy:
     name: Canary Deploy
     runs-on: ubuntu-latest
-    if: github.event.pull_request.merged
+    if: github.ref == 'refs/heads/master'
     needs: test
 
     steps:

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -1,11 +1,7 @@
 name: Run All Tests
 
 on: 
-  pull_request:
-    branches:
-      - master
-    types:
-      - closed
+  push:
   schedule:
     - cron: '0 6,18 * * *'
 

--- a/.github/workflows/test-changed.yml
+++ b/.github/workflows/test-changed.yml
@@ -1,6 +1,10 @@
-name: Push/PR
+name: Test Modified Packages
 
-on: [push, pull_request]
+on: 
+  pull_request:
+    branches:
+      - '*'
+      - '!master'
 
 jobs:
   test:

--- a/.github/workflows/test-changed.yml
+++ b/.github/workflows/test-changed.yml
@@ -1,10 +1,6 @@
 name: Test Modified Packages
 
-on: 
-  pull_request:
-    branches:
-      - '*'
-      - '!master'
+on: pull_request
 
 jobs:
   test:


### PR DESCRIPTION
Previously:
- "Run All Tests" ran when (1) a pull_request was closed and (2) the target branch was master. This left out some cases where we would want to run all tests, such as a direct merge to master.
- "Push/PR" ran tests on changed files, but the it runs 2 tests (1 each on the push trigger and PR trigger) that are redundant in most cases, and the "push" version may not diff correctly if the branch is stale, and may run too many tests.

Now:
- "Run All Tests" workflow is triggered on push to any branch. (Canary Deploy job only runs if the branch was master.)
- "Push/PR" renamed to "Test Modified Packages" and runs only on PR events (opened, synchronized, reopened) on any branch except master. This still may happen to run all tests if a key top level file was changed.
- "Cross Browser Test Flow" only runs on push to master.

Additionally, we will change the repo settings to ensure "Test Modified Packages" is a required check and "Run All Tests" is optional, so if it runs too many tests and fails a flaky test, it does not block merge.