### PR TITLE
Make MemoryLru tree-shakeable

### DIFF
--- a/packages/firestore/test/unit/generate_spec_json.js
+++ b/packages/firestore/test/unit/generate_spec_json.js
@@ -65,7 +65,7 @@ function main(args) {
     var testName = specName.replace(/^specs\//, '');
     var filename = testName.replace(/[^A-Za-z\d]/g, '_') + '.json';
     var outputFile = outputPath + '/' + filename;
-    console.log("Generating " + outputFile);
+    console.log('Generating ' + outputFile);
     writeToJSON(testFiles[i], outputFile);
   }
 

--- a/packages/firestore/test/unit/local/persistence_test_helpers.ts
+++ b/packages/firestore/test/unit/local/persistence_test_helpers.ts
@@ -29,7 +29,11 @@ import {
 import { IndexedDbPersistence } from '../../../src/local/indexeddb_persistence';
 import { LocalSerializer } from '../../../src/local/local_serializer';
 import { LruParams } from '../../../src/local/lru_garbage_collector';
-import { MemoryPersistence } from '../../../src/local/memory_persistence';
+import {
+  MemoryEagerDelegate,
+  MemoryLruDelegate,
+  MemoryPersistence
+} from '../../../src/local/memory_persistence';
 import {
   ClientId,
   WebStorageSharedClientState
@@ -122,13 +126,16 @@ export async function testIndexedDbPersistence(
 
 /** Creates and starts a MemoryPersistence instance for testing. */
 export async function testMemoryEagerPersistence(): Promise<MemoryPersistence> {
-  return MemoryPersistence.createEagerPersistence(AutoId.newId());
+  return new MemoryPersistence(AutoId.newId(), p => new MemoryEagerDelegate(p));
 }
 
 export async function testMemoryLruPersistence(
   params: LruParams = LruParams.DEFAULT
 ): Promise<MemoryPersistence> {
-  return MemoryPersistence.createLruPersistence(AutoId.newId(), params);
+  return new MemoryPersistence(
+    AutoId.newId(),
+    p => new MemoryLruDelegate(p, params)
+  );
 }
 
 /** Clears the persistence in tests */

--- a/packages/firestore/test/unit/specs/spec_test_runner.ts
+++ b/packages/firestore/test/unit/specs/spec_test_runner.ts
@@ -47,7 +47,11 @@ import {
 } from '../../../src/local/indexeddb_schema';
 import { LocalStore } from '../../../src/local/local_store';
 import { LruParams } from '../../../src/local/lru_garbage_collector';
-import { MemoryPersistence } from '../../../src/local/memory_persistence';
+import {
+  MemoryEagerDelegate,
+  MemoryLruDelegate,
+  MemoryPersistence
+} from '../../../src/local/memory_persistence';
 import { Persistence } from '../../../src/local/persistence';
 import {
   ClientId,
@@ -81,7 +85,7 @@ import {
 import { assert, fail } from '../../../src/util/assert';
 import { AsyncQueue, TimerId } from '../../../src/util/async_queue';
 import { FirestoreError } from '../../../src/util/error';
-import { primitiveComparator } from '../../../src/util/misc';
+import { AutoId, primitiveComparator } from '../../../src/util/misc';
 import * as obj from '../../../src/util/obj';
 import { ObjectMap } from '../../../src/util/obj_map';
 import { Deferred, sequence } from '../../../src/util/promise';
@@ -1151,7 +1155,9 @@ abstract class TestRunner {
       expect(actualTarget.query).to.deep.equal(expectedTarget.query);
       expect(actualTarget.targetId).to.equal(expectedTarget.targetId);
       expect(actualTarget.readTime).to.equal(expectedTarget.readTime);
-      expect(actualTarget.resumeToken || '').to.equal(expectedTarget.resumeToken || '');
+      expect(actualTarget.resumeToken || '').to.equal(
+        expectedTarget.resumeToken || ''
+      );
       delete actualTargets[targetId];
     });
     expect(obj.size(actualTargets)).to.equal(
@@ -1236,12 +1242,11 @@ class MemoryTestRunner extends TestRunner {
     gcEnabled: boolean
   ): Promise<Persistence> {
     return Promise.resolve(
-      gcEnabled
-        ? MemoryPersistence.createEagerPersistence(this.clientId)
-        : MemoryPersistence.createLruPersistence(
-            this.clientId,
-            LruParams.DEFAULT
-          )
+      new MemoryPersistence(this.clientId, p =>
+        gcEnabled
+          ? new MemoryEagerDelegate(p)
+          : new MemoryLruDelegate(p, LruParams.DEFAULT)
+      )
     );
   }
 }

--- a/packages/firestore/test/unit/specs/spec_test_runner.ts
+++ b/packages/firestore/test/unit/specs/spec_test_runner.ts
@@ -85,7 +85,7 @@ import {
 import { assert, fail } from '../../../src/util/assert';
 import { AsyncQueue, TimerId } from '../../../src/util/async_queue';
 import { FirestoreError } from '../../../src/util/error';
-import { AutoId, primitiveComparator } from '../../../src/util/misc';
+import { primitiveComparator } from '../../../src/util/misc';
 import * as obj from '../../../src/util/obj';
 import { ObjectMap } from '../../../src/util/obj_map';
 import { Deferred, sequence } from '../../../src/util/promise';

--- a/packages/firestore/test/util/test_platform.ts
+++ b/packages/firestore/test/util/test_platform.ts
@@ -265,7 +265,7 @@ export class TestPlatform implements Platform {
 }
 
 /** Returns true if we are running under Node. */
-export function isNode() : boolean {
+export function isNode(): boolean {
   return (
     typeof process !== 'undefined' &&
     process.title !== undefined &&


### PR DESCRIPTION
Our hard-coded dependency means that tree-shaking doesn't remove the unused LRU code for memory persistence. This PR removes the dependency and should also completely remove the estimated byte size accounting in the field value rewrite.

Before:
317762  firebase-firestore.js
274464  firebase-firestore.memory.js

After:
315861  firebase-firestore.js
270591  firebase-firestore.memory.js

