### PR TITLE
Remove non-idempotent transactions

### DIFF
--- a/packages/firestore/src/local/persistence.ts
+++ b/packages/firestore/src/local/persistence.ts
@@ -63,10 +63,7 @@ export abstract class PersistenceTransaction {
 export type PersistenceTransactionMode =
   | 'readonly'
   | 'readwrite'
-  | 'readwrite-primary'
-  | 'readonly-idempotent'
-  | 'readwrite-idempotent'
-  | 'readwrite-primary-idempotent';
+  | 'readwrite-primary';
 
 /**
  * Callback type for primary state notifications. This callback can be

--- a/packages/firestore/src/local/simple_db.ts
+++ b/packages/firestore/src/local/simple_db.ts
@@ -32,11 +32,7 @@ const LOG_TAG = 'SimpleDb';
 const TRANSACTION_RETRY_COUNT = 3;
 
 // The different modes supported by `SimpleDb.runTransaction()`
-type SimpleDbTransactionMode =
-  | 'readonly'
-  | 'readwrite'
-  | 'readonly-idempotent'
-  | 'readwrite-idempotent';
+type SimpleDbTransactionMode = 'readonly' | 'readwrite';
 
 export interface SimpleDbSchemaConverter {
   createOrUpgrade(
@@ -276,8 +272,7 @@ export class SimpleDb {
     objectStores: string[],
     transactionFn: (transaction: SimpleDbTransaction) => PersistencePromise<T>
   ): Promise<T> {
-    const readonly = mode.startsWith('readonly');
-    const idempotent = mode.endsWith('idempotent');
+    const readonly = mode === 'readonly';
     let attemptNumber = 0;
 
     while (true) {
@@ -318,7 +313,6 @@ export class SimpleDb {
         // Note: We cannot use an instanceof check for FirestoreException, since the
         // exception is wrapped in a generic error by our async/await handling.
         const retryable =
-          idempotent &&
           error.name !== 'FirebaseError' &&
           attemptNumber < TRANSACTION_RETRY_COUNT;
         debug(

--- a/packages/firestore/test/unit/generate_spec_json.js
+++ b/packages/firestore/test/unit/generate_spec_json.js
@@ -65,7 +65,7 @@ function main(args) {
     var testName = specName.replace(/^specs\//, '');
     var filename = testName.replace(/[^A-Za-z\d]/g, '_') + '.json';
     var outputFile = outputPath + '/' + filename;
-    console.log("Generating " + outputFile);
+    console.log('Generating ' + outputFile);
     writeToJSON(testFiles[i], outputFile);
   }
 

--- a/packages/firestore/test/unit/local/encoded_resource_path.test.ts
+++ b/packages/firestore/test/unit/local/encoded_resource_path.test.ts
@@ -218,7 +218,7 @@ function runTransaction<T>(
     transaction: SimpleDbTransaction
   ) => PersistencePromise<T>
 ): Promise<T> {
-  return db.runTransaction<T>('readwrite-idempotent', ['test'], txn => {
+  return db.runTransaction<T>('readwrite', ['test'], txn => {
     return fn(txn.store<string, boolean>('test'), txn);
   });
 }

--- a/packages/firestore/test/unit/local/index_free_query_engine.test.ts
+++ b/packages/firestore/test/unit/local/index_free_query_engine.test.ts
@@ -144,31 +144,27 @@ describe('IndexFreeQueryEngine', () => {
       'Encountered runQuery() call not wrapped in expectIndexFreeQuery()/expectFullCollectionQuery()'
     );
 
-    return persistence.runTransaction(
-      'runQuery',
-      'readonly-idempotent',
-      txn => {
-        return targetCache
-          .getMatchingKeysForTargetId(txn, TEST_TARGET_ID)
-          .next(remoteKeys => {
-            return queryEngine
-              .getDocumentsMatchingQuery(
-                txn,
-                query,
-                lastLimboFreeSnapshot,
-                remoteKeys
-              )
-              .next(docs => {
-                const view = new View(query, remoteKeys);
-                const viewDocChanges = view.computeDocChanges(docs);
-                return view.applyChanges(
-                  viewDocChanges,
-                  /*updateLimboDocuments=*/ true
-                ).snapshot!.docs;
-              });
-          });
-      }
-    );
+    return persistence.runTransaction('runQuery', 'readonly', txn => {
+      return targetCache
+        .getMatchingKeysForTargetId(txn, TEST_TARGET_ID)
+        .next(remoteKeys => {
+          return queryEngine
+            .getDocumentsMatchingQuery(
+              txn,
+              query,
+              lastLimboFreeSnapshot,
+              remoteKeys
+            )
+            .next(docs => {
+              const view = new View(query, remoteKeys);
+              const viewDocChanges = view.computeDocChanges(docs);
+              return view.applyChanges(
+                viewDocChanges,
+                /*updateLimboDocuments=*/ true
+              ).snapshot!.docs;
+            });
+        });
+    });
   }
 
   beforeEach(async () => {

--- a/packages/firestore/test/unit/local/indexeddb_persistence.test.ts
+++ b/packages/firestore/test/unit/local/indexeddb_persistence.test.ts
@@ -223,7 +223,7 @@ describe('IndexedDbSchema: createOrUpgradeDb', () => {
     return withDb(2, db => {
       const sdb = new SimpleDb(db);
       return sdb.runTransaction(
-        'readwrite-idempotent',
+        'readwrite',
         [DbTarget.store, DbTargetGlobal.store, DbMutationBatch.store],
         txn => {
           const targets = txn.store<DbTargetKey, DbTarget>(DbTarget.store);
@@ -252,7 +252,7 @@ describe('IndexedDbSchema: createOrUpgradeDb', () => {
 
         const sdb = new SimpleDb(db);
         return sdb.runTransaction(
-          'readwrite-idempotent',
+          'readwrite',
           [DbTarget.store, DbTargetGlobal.store, DbMutationBatch.store],
           txn => {
             const targets = txn.store<DbTargetKey, DbTarget>(DbTarget.store);
@@ -317,47 +317,39 @@ describe('IndexedDbSchema: createOrUpgradeDb', () => {
 
     return withDb(3, db => {
       const sdb = new SimpleDb(db);
-      return sdb.runTransaction(
-        'readwrite-idempotent',
-        [DbMutationBatch.store],
-        txn => {
-          const store = txn.store(DbMutationBatch.store);
-          return PersistencePromise.forEach(
-            testMutations,
-            (testMutation: DbMutationBatch) => store.put(testMutation)
-          );
-        }
-      );
+      return sdb.runTransaction('readwrite', [DbMutationBatch.store], txn => {
+        const store = txn.store(DbMutationBatch.store);
+        return PersistencePromise.forEach(
+          testMutations,
+          (testMutation: DbMutationBatch) => store.put(testMutation)
+        );
+      });
     }).then(() =>
       withDb(4, db => {
         expect(db.version).to.be.equal(4);
         expect(getAllObjectStores(db)).to.have.members(V4_STORES);
 
         const sdb = new SimpleDb(db);
-        return sdb.runTransaction(
-          'readwrite-idempotent',
-          [DbMutationBatch.store],
-          txn => {
-            const store = txn.store<DbMutationBatchKey, DbMutationBatch>(
-              DbMutationBatch.store
-            );
-            let p = PersistencePromise.forEach(
-              testMutations,
-              (testMutation: DbMutationBatch) =>
-                store.get(testMutation.batchId).next(mutationBatch => {
-                  expect(mutationBatch).to.deep.equal(testMutation);
-                })
-            );
-            p = p.next(() => {
-              store
-                .add({} as any) // eslint-disable-line @typescript-eslint/no-explicit-any
-                .next(batchId => {
-                  expect(batchId).to.equal(43);
-                });
-            });
-            return p;
-          }
-        );
+        return sdb.runTransaction('readwrite', [DbMutationBatch.store], txn => {
+          const store = txn.store<DbMutationBatchKey, DbMutationBatch>(
+            DbMutationBatch.store
+          );
+          let p = PersistencePromise.forEach(
+            testMutations,
+            (testMutation: DbMutationBatch) =>
+              store.get(testMutation.batchId).next(mutationBatch => {
+                expect(mutationBatch).to.deep.equal(testMutation);
+              })
+          );
+          p = p.next(() => {
+            store
+              .add({} as any) // eslint-disable-line @typescript-eslint/no-explicit-any
+              .next(batchId => {
+                expect(batchId).to.equal(43);
+              });
+          });
+          return p;
+        });
       })
     );
   });
@@ -430,7 +422,7 @@ describe('IndexedDbSchema: createOrUpgradeDb', () => {
     return withDb(4, db => {
       const sdb = new SimpleDb(db);
       // We can only use the V4 stores here, since that's as far as we've upgraded.
-      return sdb.runTransaction('readwrite-idempotent', V4_STORES, txn => {
+      return sdb.runTransaction('readwrite', V4_STORES, txn => {
         const mutationBatchStore = txn.store<
           DbMutationBatchKey,
           DbMutationBatch
@@ -479,7 +471,7 @@ describe('IndexedDbSchema: createOrUpgradeDb', () => {
 
         const sdb = new SimpleDb(db);
         // There is no V5_STORES, continue using V4.
-        return sdb.runTransaction('readwrite-idempotent', V4_STORES, txn => {
+        return sdb.runTransaction('readwrite', V4_STORES, txn => {
           const mutationBatchStore = txn.store<
             DbMutationBatchKey,
             DbMutationBatch
@@ -531,7 +523,7 @@ describe('IndexedDbSchema: createOrUpgradeDb', () => {
       }));
       // V5 stores doesn't exist
       const sdb = new SimpleDb(db);
-      return sdb.runTransaction('readwrite-idempotent', V4_STORES, txn => {
+      return sdb.runTransaction('readwrite', V4_STORES, txn => {
         const store = txn.store<DbRemoteDocumentKey, DbRemoteDocument>(
           DbRemoteDocument.store
         );
@@ -544,7 +536,7 @@ describe('IndexedDbSchema: createOrUpgradeDb', () => {
     });
     await withDb(6, db => {
       const sdb = new SimpleDb(db);
-      return sdb.runTransaction('readwrite-idempotent', V6_STORES, txn => {
+      return sdb.runTransaction('readwrite', V6_STORES, txn => {
         const store = txn.store<
           DbRemoteDocumentGlobalKey,
           DbRemoteDocumentGlobal
@@ -567,7 +559,7 @@ describe('IndexedDbSchema: createOrUpgradeDb', () => {
       const serializer = TEST_SERIALIZER;
 
       const sdb = new SimpleDb(db);
-      return sdb.runTransaction('readwrite-idempotent', V6_STORES, txn => {
+      return sdb.runTransaction('readwrite', V6_STORES, txn => {
         const targetGlobalStore = txn.store<DbTargetGlobalKey, DbTargetGlobal>(
           DbTargetGlobal.store
         );
@@ -618,7 +610,7 @@ describe('IndexedDbSchema: createOrUpgradeDb', () => {
     // Now run the migration and verify
     await withDb(7, db => {
       const sdb = new SimpleDb(db);
-      return sdb.runTransaction('readwrite-idempotent', V6_STORES, txn => {
+      return sdb.runTransaction('readwrite', V6_STORES, txn => {
         const targetDocumentStore = txn.store<
           DbTargetDocumentKey,
           DbTargetDocument
@@ -669,7 +661,7 @@ describe('IndexedDbSchema: createOrUpgradeDb', () => {
 
     await withDb(7, db => {
       const sdb = new SimpleDb(db);
-      return sdb.runTransaction('readwrite-idempotent', V6_STORES, txn => {
+      return sdb.runTransaction('readwrite', V6_STORES, txn => {
         const remoteDocumentStore = txn.store<
           DbRemoteDocumentKey,
           DbRemoteDocument
@@ -706,7 +698,7 @@ describe('IndexedDbSchema: createOrUpgradeDb', () => {
     // Migrate to v8 and verify index entries.
     await withDb(8, db => {
       const sdb = new SimpleDb(db);
-      return sdb.runTransaction('readwrite-idempotent', V8_STORES, txn => {
+      return sdb.runTransaction('readwrite', V8_STORES, txn => {
         const collectionParentsStore = txn.store<
           DbCollectionParentKey,
           DbCollectionParent
@@ -748,7 +740,7 @@ describe('IndexedDbSchema: createOrUpgradeDb', () => {
 
     await withDb(8, db => {
       const sdb = new SimpleDb(db);
-      return sdb.runTransaction('readwrite-idempotent', V8_STORES, txn => {
+      return sdb.runTransaction('readwrite', V8_STORES, txn => {
         const remoteDocumentStore = txn.store<
           DbRemoteDocumentKey,
           DbRemoteDocument
@@ -824,7 +816,7 @@ describe('IndexedDbSchema: createOrUpgradeDb', () => {
 
     await withDb(9, db => {
       const sdb = new SimpleDb(db);
-      return sdb.runTransaction('readwrite-idempotent', V8_STORES, txn => {
+      return sdb.runTransaction('readwrite', V8_STORES, txn => {
         return addDocs(txn, oldDocPaths, /* version= */ 1).next(() =>
           addDocs(txn, newDocPaths, /* version= */ 2).next(() => {
             const remoteDocumentStore = txn.store<
@@ -858,7 +850,7 @@ describe('IndexedDbSchema: createOrUpgradeDb', () => {
 
     await withDb(9, db => {
       const sdb = new SimpleDb(db);
-      return sdb.runTransaction('readwrite-idempotent', V8_STORES, txn => {
+      return sdb.runTransaction('readwrite', V8_STORES, txn => {
         return addDocs(txn, oldDocPaths, /* version= */ 1).next(() =>
           addDocs(txn, newDocPaths, /* version= */ 2).next(() => {
             const remoteDocumentStore = txn.store<
@@ -920,16 +912,12 @@ describe('IndexedDb: canActAsPrimary', () => {
       SCHEMA_VERSION,
       new SchemaConverter(TEST_SERIALIZER)
     );
-    await simpleDb.runTransaction(
-      'readwrite-idempotent',
-      [DbPrimaryClient.store],
-      txn => {
-        const primaryStore = txn.store<DbPrimaryClientKey, DbPrimaryClient>(
-          DbPrimaryClient.store
-        );
-        return primaryStore.delete(DbPrimaryClient.key);
-      }
-    );
+    await simpleDb.runTransaction('readwrite', [DbPrimaryClient.store], txn => {
+      const primaryStore = txn.store<DbPrimaryClientKey, DbPrimaryClient>(
+        DbPrimaryClient.store
+      );
+      return primaryStore.delete(DbPrimaryClient.key);
+    });
     simpleDb.close();
   }
 
@@ -940,7 +928,7 @@ describe('IndexedDb: canActAsPrimary', () => {
       new SchemaConverter(TEST_SERIALIZER)
     );
     const leaseOwner = await simpleDb.runTransaction(
-      'readonly-idempotent',
+      'readonly',
       [DbPrimaryClient.store],
       txn => {
         const primaryStore = txn.store<DbPrimaryClientKey, DbPrimaryClient>(
@@ -1067,7 +1055,7 @@ describe('IndexedDb: canActAsPrimary', () => {
 
       await persistence.runTransaction(
         'regain lease',
-        'readwrite-primary-idempotent',
+        'readwrite-primary',
         () => PersistencePromise.resolve()
       );
 

--- a/packages/firestore/test/unit/local/local_store.test.ts
+++ b/packages/firestore/test/unit/local/local_store.test.ts
@@ -1567,7 +1567,7 @@ function genericLocalStoreTests(
     // At this point, we have not yet confirmed that the query is limbo free.
     let cachedTargetData = await persistence.runTransaction(
       'getTargetData',
-      'readonly-idempotent',
+      'readonly',
       txn => localStore.getTargetData(txn, target)
     );
     expect(
@@ -1582,7 +1582,7 @@ function genericLocalStoreTests(
     ]);
     cachedTargetData = await persistence.runTransaction(
       'getTargetData',
-      'readonly-idempotent',
+      'readonly',
       txn => localStore.getTargetData(txn, target)
     );
     expect(cachedTargetData!.lastLimboFreeSnapshotVersion.isEqual(version(10)))
@@ -1598,7 +1598,7 @@ function genericLocalStoreTests(
     if (!gcIsEager) {
       cachedTargetData = await persistence.runTransaction(
         'getTargetData',
-        'readonly-idempotent',
+        'readonly',
         txn => localStore.getTargetData(txn, target)
       );
       expect(

--- a/packages/firestore/test/unit/local/remote_document_cache.test.ts
+++ b/packages/firestore/test/unit/local/remote_document_cache.test.ts
@@ -91,14 +91,10 @@ describe('IndexedDbRemoteDocumentCache', () => {
   });
 
   function getLastReadTime(): Promise<SnapshotVersion> {
-    return persistence.runTransaction(
-      'getLastReadTime',
-      'readonly-idempotent',
-      txn => {
-        const remoteDocuments = persistence.getRemoteDocumentCache();
-        return remoteDocuments.getLastReadTime(txn);
-      }
-    );
+    return persistence.runTransaction('getLastReadTime', 'readonly', txn => {
+      const remoteDocuments = persistence.getRemoteDocumentCache();
+      return remoteDocuments.getLastReadTime(txn);
+    });
   }
 
   it('skips previous changes', async () => {

--- a/packages/firestore/test/unit/local/test_index_manager.ts
+++ b/packages/firestore/test/unit/local/test_index_manager.ts
@@ -32,7 +32,7 @@ export class TestIndexManager {
   addToCollectionParentIndex(collectionPath: ResourcePath): Promise<void> {
     return this.persistence.runTransaction(
       'addToCollectionParentIndex',
-      'readwrite-idempotent',
+      'readwrite',
       txn => {
         return this.indexManager.addToCollectionParentIndex(
           txn,
@@ -45,7 +45,7 @@ export class TestIndexManager {
   getCollectionParents(collectionId: string): Promise<ResourcePath[]> {
     return this.persistence.runTransaction(
       'getCollectionParents',
-      'readonly-idempotent',
+      'readonly',
       txn => {
         return this.indexManager.getCollectionParents(txn, collectionId);
       }

--- a/packages/firestore/test/unit/local/test_mutation_queue.ts
+++ b/packages/firestore/test/unit/local/test_mutation_queue.ts
@@ -35,18 +35,14 @@ export class TestMutationQueue {
   constructor(public persistence: Persistence, public queue: MutationQueue) {}
 
   checkEmpty(): Promise<boolean> {
-    return this.persistence.runTransaction(
-      'checkEmpty',
-      'readonly-idempotent',
-      txn => {
-        return this.queue.checkEmpty(txn);
-      }
-    );
+    return this.persistence.runTransaction('checkEmpty', 'readonly', txn => {
+      return this.queue.checkEmpty(txn);
+    });
   }
 
   countBatches(): Promise<number> {
     return this.persistence
-      .runTransaction('countBatches', 'readonly-idempotent', txn => {
+      .runTransaction('countBatches', 'readonly', txn => {
         return this.queue.getAllMutationBatches(txn);
       })
       .then(batches => batches.length);
@@ -68,7 +64,7 @@ export class TestMutationQueue {
   getLastStreamToken(): Promise<ByteString> {
     return this.persistence.runTransaction(
       'getLastStreamToken',
-      'readonly-idempotent',
+      'readonly',
       txn => {
         return this.queue.getLastStreamToken(txn);
       }
@@ -78,7 +74,7 @@ export class TestMutationQueue {
   setLastStreamToken(streamToken: ByteString): Promise<void> {
     return this.persistence.runTransaction(
       'setLastStreamToken',
-      'readwrite-primary-idempotent',
+      'readwrite-primary',
       txn => {
         return this.queue.setLastStreamToken(txn, streamToken);
       }
@@ -103,7 +99,7 @@ export class TestMutationQueue {
   lookupMutationBatch(batchId: BatchId): Promise<MutationBatch | null> {
     return this.persistence.runTransaction(
       'lookupMutationBatch',
-      'readonly-idempotent',
+      'readonly',
       txn => {
         return this.queue.lookupMutationBatch(txn, batchId);
       }
@@ -115,7 +111,7 @@ export class TestMutationQueue {
   ): Promise<MutationBatch | null> {
     return this.persistence.runTransaction(
       'getNextMutationBatchAfterBatchId',
-      'readonly-idempotent',
+      'readonly',
       txn => {
         return this.queue.getNextMutationBatchAfterBatchId(txn, batchId);
       }
@@ -125,7 +121,7 @@ export class TestMutationQueue {
   getAllMutationBatches(): Promise<MutationBatch[]> {
     return this.persistence.runTransaction(
       'getAllMutationBatches',
-      'readonly-idempotent',
+      'readonly',
       txn => {
         return this.queue.getAllMutationBatches(txn);
       }
@@ -137,7 +133,7 @@ export class TestMutationQueue {
   ): Promise<MutationBatch[]> {
     return this.persistence.runTransaction(
       'getAllMutationBatchesAffectingDocumentKey',
-      'readonly-idempotent',
+      'readonly',
       txn => {
         return this.queue.getAllMutationBatchesAffectingDocumentKey(
           txn,
@@ -157,7 +153,7 @@ export class TestMutationQueue {
 
     return this.persistence.runTransaction(
       'getAllMutationBatchesAffectingDocumentKeys',
-      'readonly-idempotent',
+      'readonly',
       txn => {
         return this.queue.getAllMutationBatchesAffectingDocumentKeys(
           txn,
@@ -170,7 +166,7 @@ export class TestMutationQueue {
   getAllMutationBatchesAffectingQuery(query: Query): Promise<MutationBatch[]> {
     return this.persistence.runTransaction(
       'getAllMutationBatchesAffectingQuery',
-      'readonly-idempotent',
+      'readonly',
       txn => {
         return this.queue.getAllMutationBatchesAffectingQuery(txn, query);
       }

--- a/packages/firestore/test/unit/local/test_remote_document_cache.ts
+++ b/packages/firestore/test/unit/local/test_remote_document_cache.ts
@@ -96,23 +96,15 @@ export class TestRemoteDocumentCache {
   }
 
   getEntry(documentKey: DocumentKey): Promise<MaybeDocument | null> {
-    return this.persistence.runTransaction(
-      'getEntry',
-      'readonly-idempotent',
-      txn => {
-        return this.cache.getEntry(txn, documentKey);
-      }
-    );
+    return this.persistence.runTransaction('getEntry', 'readonly', txn => {
+      return this.cache.getEntry(txn, documentKey);
+    });
   }
 
   getEntries(documentKeys: DocumentKeySet): Promise<NullableMaybeDocumentMap> {
-    return this.persistence.runTransaction(
-      'getEntries',
-      'readonly-idempotent',
-      txn => {
-        return this.cache.getEntries(txn, documentKeys);
-      }
-    );
+    return this.persistence.runTransaction('getEntries', 'readonly', txn => {
+      return this.cache.getEntries(txn, documentKeys);
+    });
   }
 
   getDocumentsMatchingQuery(
@@ -121,7 +113,7 @@ export class TestRemoteDocumentCache {
   ): Promise<DocumentMap> {
     return this.persistence.runTransaction(
       'getDocumentsMatchingQuery',
-      'readonly-idempotent',
+      'readonly',
       txn => {
         return this.cache.getDocumentsMatchingQuery(txn, query, sinceReadTime);
       }
@@ -144,10 +136,8 @@ export class TestRemoteDocumentCache {
   }
 
   getSize(): Promise<number> {
-    return this.persistence.runTransaction(
-      'get size',
-      'readonly-idempotent',
-      txn => this.cache.getSize(txn)
+    return this.persistence.runTransaction('get size', 'readonly', txn =>
+      this.cache.getSize(txn)
     );
   }
 

--- a/packages/firestore/test/unit/local/test_remote_document_change_buffer.ts
+++ b/packages/firestore/test/unit/local/test_remote_document_change_buffer.ts
@@ -40,13 +40,9 @@ export class TestRemoteDocumentChangeBuffer {
   }
 
   getEntry(documentKey: DocumentKey): Promise<MaybeDocument | null> {
-    return this.persistence.runTransaction(
-      'getEntry',
-      'readonly-idempotent',
-      txn => {
-        return this.buffer.getEntry(txn, documentKey);
-      }
-    );
+    return this.persistence.runTransaction('getEntry', 'readonly', txn => {
+      return this.buffer.getEntry(txn, documentKey);
+    });
   }
 
   apply(): Promise<void> {

--- a/packages/firestore/test/unit/local/test_target_cache.ts
+++ b/packages/firestore/test/unit/local/test_target_cache.ts
@@ -44,7 +44,7 @@ export class TestTargetCache {
   updateTargetData(targetData: TargetData): Promise<void> {
     return this.persistence.runTransaction(
       'updateTargetData',
-      'readwrite-primary-idempotent',
+      'readwrite-primary',
       txn => {
         return this.cache.updateTargetData(txn, targetData);
       }
@@ -54,7 +54,7 @@ export class TestTargetCache {
   getTargetCount(): Promise<number> {
     return this.persistence.runTransaction(
       'getTargetCount',
-      'readonly-idempotent',
+      'readonly',
       txn => {
         return this.cache.getTargetCount(txn);
       }
@@ -72,19 +72,15 @@ export class TestTargetCache {
   }
 
   getTargetData(target: Target): Promise<TargetData | null> {
-    return this.persistence.runTransaction(
-      'getTargetData',
-      'readonly-idempotent',
-      txn => {
-        return this.cache.getTargetData(txn, target);
-      }
-    );
+    return this.persistence.runTransaction('getTargetData', 'readonly', txn => {
+      return this.cache.getTargetData(txn, target);
+    });
   }
 
   getLastRemoteSnapshotVersion(): Promise<SnapshotVersion> {
     return this.persistence.runTransaction(
       'getLastRemoteSnapshotVersion',
-      'readonly-idempotent',
+      'readonly',
       txn => {
         return this.cache.getLastRemoteSnapshotVersion(txn);
       }
@@ -94,7 +90,7 @@ export class TestTargetCache {
   getHighestSequenceNumber(): Promise<ListenSequenceNumber> {
     return this.persistence.runTransaction(
       'getHighestSequenceNumber',
-      'readonly-idempotent',
+      'readonly',
       txn => {
         return this.cache.getHighestSequenceNumber(txn);
       }
@@ -141,13 +137,9 @@ export class TestTargetCache {
 
   getMatchingKeysForTargetId(targetId: TargetId): Promise<DocumentKey[]> {
     return this.persistence
-      .runTransaction(
-        'getMatchingKeysForTargetId',
-        'readonly-idempotent',
-        txn => {
-          return this.cache.getMatchingKeysForTargetId(txn, targetId);
-        }
-      )
+      .runTransaction('getMatchingKeysForTargetId', 'readonly', txn => {
+        return this.cache.getMatchingKeysForTargetId(txn, targetId);
+      })
       .then(keySet => {
         const result: DocumentKey[] = [];
         keySet.forEach(key => result.push(key));
@@ -166,13 +158,9 @@ export class TestTargetCache {
   }
 
   containsKey(key: DocumentKey): Promise<boolean> {
-    return this.persistence.runTransaction(
-      'containsKey',
-      'readonly-idempotent',
-      txn => {
-        return this.cache.containsKey(txn, key);
-      }
-    );
+    return this.persistence.runTransaction('containsKey', 'readonly', txn => {
+      return this.cache.containsKey(txn, key);
+    });
   }
 
   setTargetsMetadata(
@@ -181,7 +169,7 @@ export class TestTargetCache {
   ): Promise<void> {
     return this.persistence.runTransaction(
       'setTargetsMetadata',
-      'readwrite-primary-idempotent',
+      'readwrite-primary',
       txn =>
         this.cache.setTargetsMetadata(
           txn,

--- a/packages/firestore/test/unit/specs/spec_test_runner.ts
+++ b/packages/firestore/test/unit/specs/spec_test_runner.ts
@@ -1151,7 +1151,9 @@ abstract class TestRunner {
       expect(actualTarget.query).to.deep.equal(expectedTarget.query);
       expect(actualTarget.targetId).to.equal(expectedTarget.targetId);
       expect(actualTarget.readTime).to.equal(expectedTarget.readTime);
-      expect(actualTarget.resumeToken || '').to.equal(expectedTarget.resumeToken || '');
+      expect(actualTarget.resumeToken || '').to.equal(
+        expectedTarget.resumeToken || ''
+      );
       delete actualTargets[targetId];
     });
     expect(obj.size(actualTargets)).to.equal(
@@ -1655,15 +1657,11 @@ async function clearCurrentPrimaryLease(): Promise<void> {
     SCHEMA_VERSION,
     new SchemaConverter(TEST_SERIALIZER)
   );
-  await db.runTransaction(
-    'readwrite-idempotent',
-    [DbPrimaryClient.store],
-    txn => {
-      const primaryClientStore = txn.store<DbPrimaryClientKey, DbPrimaryClient>(
-        DbPrimaryClient.store
-      );
-      return primaryClientStore.delete(DbPrimaryClient.key);
-    }
-  );
+  await db.runTransaction('readwrite', [DbPrimaryClient.store], txn => {
+    const primaryClientStore = txn.store<DbPrimaryClientKey, DbPrimaryClient>(
+      DbPrimaryClient.store
+    );
+    return primaryClientStore.delete(DbPrimaryClient.key);
+  });
   db.close();
 }

--- a/packages/firestore/test/util/test_platform.ts
+++ b/packages/firestore/test/util/test_platform.ts
@@ -265,7 +265,7 @@ export class TestPlatform implements Platform {
 }
 
 /** Returns true if we are running under Node. */
-export function isNode() : boolean {
+export function isNode(): boolean {
   return (
     typeof process !== 'undefined' &&
     process.title !== undefined &&


### PR DESCRIPTION
Addressing an old TODO and treating all transactions as idempotent. We no longer use non-idempotent transactions:

https://cs.corp.google.com/search/?q=%22%27readwrite%27%22+file:%5E//depot/google3/third_party/javascript/firebase/src/packages/firestore/src/+package:%5Epiper$&type=cs
https://cs.corp.google.com/search/?q=%22%27readwrite-primary%27%22+file:%5E//depot/google3/third_party/javascript/firebase/src/packages/firestore/src/+package:%5Epiper$&type=cs
https://cs.corp.google.com/search/?q=%22%27readonly%27%22+file:%5E//depot/google3/third_party/javascript/firebase/src/packages/firestore/src/+package:%5Epiper$&type=cs

vs (as an example):
https://cs.corp.google.com/search/?q=%22%27readonly-idempotent%27%22+file:%5E//depot/google3/third_party/javascript/firebase/src/packages/firestore/src/+package:%5Epiper$&type=cs 

