### PR TITLE
feat(sw-controller): compare host instead of href for getWindowClient

### DIFF
--- a/packages/messaging/src/controllers/sw-controller.ts
+++ b/packages/messaging/src/controllers/sw-controller.ts
@@ -273,13 +273,13 @@ function getNotificationData(
 async function getWindowClient(url: string): Promise<WindowClient | null> {
   // Use URL to normalize the URL when comparing to windowClients.
   // This at least handles whether to include trailing slashes or not
-  const parsedURL = new URL(url, self.location.href).href;
+  const parsedURL = new URL(url, self.location.href);
 
   const clientList = await getClientList();
 
   for (const client of clientList) {
-    const parsedClientUrl = new URL(client.url, self.location.href).href;
-    if (parsedClientUrl === parsedURL) {
+    const parsedClientUrl = new URL(client.url, self.location.href);
+    if (parsedClientUrl.host === parsedURL.host) {
       return client;
     }
   }


### PR DESCRIPTION
Hello folks, 

Instead of comparing the href (cause the user can be in a other page), we compare the host and take the first page that has the same host

Fix: https://github.com/firebase/firebase-js-sdk/issues/390