### PR TITLE
Move husky hook to correct location

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
   "scripts": {
     "dev": "lerna run --parallel --scope @firebase/* --scope firebase --scope rxfire dev",
     "build": "lerna run --scope @firebase/* --scope firebase --scope rxfire prepare",
-    "prepush": "node tools/gitHooks/prepush.js",
     "link:packages": "lerna exec --scope @firebase/* --scope firebase --scope rxfire -- yarn link",
     "stage:packages": "./scripts/prepublish.sh",
     "repl": "node tools/repl.js",
@@ -122,5 +121,10 @@
     "webpack": "4.42.0",
     "yargs": "15.3.1",
     "lodash": "4.17.15"
+  },
+  "husky": {
+    "hooks": {
+      "pre-push": "node tools/gitHooks/prepush.js"
+    }
   }
 }

--- a/tools/gitHooks/prepush.js
+++ b/tools/gitHooks/prepush.js
@@ -61,6 +61,7 @@ $ git stash pop
 Pre-Push Validation Succeeded
 
 `);
+process.exit();
   } catch (err) {
     console.error(chalk`
 {red Pre-Push Validation Failed, error body below}

--- a/tools/gitHooks/prepush.js
+++ b/tools/gitHooks/prepush.js
@@ -61,7 +61,7 @@ $ git stash pop
 Pre-Push Validation Succeeded
 
 `);
-process.exit();
+    process.exit();
   } catch (err) {
     console.error(chalk`
 {red Pre-Push Validation Failed, error body below}


### PR DESCRIPTION
Putting a husky hook in `scripts` in `package.json` has been deprecated for a long time and seems to have been removed entirely in a recent upgrade, causing prepush steps to not run at all. Moved `prepush` hook to the correct location.