### PR TITLE
remove comments and whitespaces in builds

### DIFF
--- a/packages/analytics/package.json
+++ b/packages/analytics/package.json
@@ -38,7 +38,7 @@
     "rollup-plugin-json": "4.0.0",
     "rollup-plugin-node-resolve": "5.2.0",
     "rollup-plugin-typescript2": "0.26.0",
-    "rollup-plugin-uglify": "6.0.4",
+    "rollup-plugin-terser": "5.3.0",
     "typescript": "3.8.3"
   },
   "repository": {

--- a/packages/analytics/rollup.config.js
+++ b/packages/analytics/rollup.config.js
@@ -19,6 +19,7 @@ import json from 'rollup-plugin-json';
 import typescriptPlugin from 'rollup-plugin-typescript2';
 import typescript from 'typescript';
 import pkg from './package.json';
+import { terser } from 'rollup-plugin-terser';
 
 const deps = Object.keys(
   Object.assign({}, pkg.peerDependencies, pkg.dependencies)
@@ -31,7 +32,14 @@ const es5BuildPlugins = [
   typescriptPlugin({
     typescript
   }),
-  json()
+  json(),
+  terser({ // remove comments only, so size presubmit can do code size diff correctly.
+    output: {
+      comments: false
+    },
+    compress: false,
+    mangle: false
+  })
 ];
 
 const es5Builds = [
@@ -61,7 +69,14 @@ const es2017BuildPlugins = [
       }
     }
   }),
-  json({ preferConst: true })
+  json({ preferConst: true }),
+  terser({ // remove comments only, so size presubmit can do code size diff correctly.
+    output: {
+      comments: false
+    },
+    compress: false,
+    mangle: false
+  })
 ];
 
 const es2017Builds = [

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -40,6 +40,7 @@
     "rollup-plugin-json": "4.0.0",
     "rollup-plugin-replace": "2.2.0",
     "rollup-plugin-typescript2": "0.26.0",
+    "rollup-plugin-terser": "5.3.0",
     "typescript": "3.8.3"
   },
   "repository": {

--- a/packages/app/rollup.config.js
+++ b/packages/app/rollup.config.js
@@ -19,6 +19,7 @@ import typescriptPlugin from 'rollup-plugin-typescript2';
 import json from 'rollup-plugin-json';
 import typescript from 'typescript';
 import pkg from './package.json';
+import { terser } from 'rollup-plugin-terser';
 
 const deps = Object.keys(
   Object.assign({}, pkg.peerDependencies, pkg.dependencies)
@@ -31,7 +32,14 @@ const es5BuildPlugins = [
   typescriptPlugin({
     typescript
   }),
-  json()
+  json(),
+  terser({ // remove comments only, so size presubmit can do code size diff correctly.
+    output: {
+      comments: false
+    },
+    compress: false,
+    mangle: false
+  })
 ];
 
 const es5Builds = [
@@ -93,6 +101,13 @@ const es2017BuildPlugins = [
   }),
   json({
     preferConst: true
+  }),
+  terser({ // remove comments only, so size presubmit can do code size diff correctly.
+    output: {
+      comments: false
+    },
+    compress: false,
+    mangle: false
   })
 ];
 

--- a/packages/component/package.json
+++ b/packages/component/package.json
@@ -29,6 +29,7 @@
   "devDependencies": {
     "rollup": "2.0.6",
     "rollup-plugin-typescript2": "0.26.0",
+    "rollup-plugin-terser": "5.3.0",
     "typescript": "3.8.3"
   },
   "repository": {

--- a/packages/component/rollup.config.js
+++ b/packages/component/rollup.config.js
@@ -18,6 +18,7 @@
 import typescriptPlugin from 'rollup-plugin-typescript2';
 import typescript from 'typescript';
 import pkg from './package.json';
+import { terser } from 'rollup-plugin-terser';
 
 const deps = Object.keys(
   Object.assign({}, pkg.peerDependencies, pkg.dependencies)
@@ -29,6 +30,13 @@ const deps = Object.keys(
 const es5BuildPlugins = [
   typescriptPlugin({
     typescript
+  }),
+  terser({ // remove comments only, so size presubmit can do code size diff correctly.
+    output: {
+      comments: false
+    },
+    compress: false,
+    mangle: false
   })
 ];
 
@@ -58,6 +66,13 @@ const es2017BuildPlugins = [
         target: 'es2017'
       }
     }
+  }),
+  terser({ // remove comments only, so size presubmit can do code size diff correctly.
+    output: {
+      comments: false
+    },
+    compress: false,
+    mangle: false
   })
 ];
 

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -38,6 +38,7 @@
     "@firebase/app-types": "0.6.0",
     "rollup": "2.0.6",
     "rollup-plugin-typescript2": "0.26.0",
+    "rollup-plugin-terser": "5.3.0",
     "typescript": "3.8.3"
   },
   "repository": {

--- a/packages/database/rollup.config.js
+++ b/packages/database/rollup.config.js
@@ -19,6 +19,7 @@ import json from 'rollup-plugin-json';
 import typescriptPlugin from 'rollup-plugin-typescript2';
 import typescript from 'typescript';
 import pkg from './package.json';
+import { terser } from 'rollup-plugin-terser';
 
 const deps = Object.keys(
   Object.assign({}, pkg.peerDependencies, pkg.dependencies)
@@ -31,7 +32,14 @@ const es5BuildPlugins = [
   typescriptPlugin({
     typescript
   }),
-  json()
+  json(),
+  terser({ // remove comments only, so size presubmit can do code size diff correctly.
+    output: {
+      comments: false
+    },
+    compress: false,
+    mangle: false
+  })
 ];
 
 const es5Builds = [
@@ -70,7 +78,14 @@ const es2017BuildPlugins = [
       }
     }
   }),
-  json({ preferConst: true })
+  json({ preferConst: true }),
+  terser({ // remove comments only, so size presubmit can do code size diff correctly.
+    output: {
+      comments: false
+    },
+    compress: false,
+    mangle: false
+  })
 ];
 
 const es2017Builds = [

--- a/packages/firestore/terser.config.js
+++ b/packages/firestore/terser.config.js
@@ -44,7 +44,7 @@ export const appendPrivatePrefixTransformers = [
  */
 export const manglePrivatePropertiesOptions = {
   output: {
-    comments: 'all',
+    comments: false,
     beautify: true
   },
   mangle: {

--- a/packages/functions/package.json
+++ b/packages/functions/package.json
@@ -32,6 +32,7 @@
     "@firebase/messaging": "0.6.10",
     "rollup": "2.0.6",
     "rollup-plugin-typescript2": "0.26.0",
+    "rollup-plugin-terser": "5.3.0",
     "typescript": "3.8.3"
   },
   "repository": {

--- a/packages/functions/rollup.config.js
+++ b/packages/functions/rollup.config.js
@@ -19,6 +19,7 @@ import json from 'rollup-plugin-json';
 import typescriptPlugin from 'rollup-plugin-typescript2';
 import typescript from 'typescript';
 import pkg from './package.json';
+import { terser } from 'rollup-plugin-terser';
 
 const deps = Object.keys(
   Object.assign({}, pkg.peerDependencies, pkg.dependencies)
@@ -31,7 +32,14 @@ const es5BuildPlugins = [
   typescriptPlugin({
     typescript
   }),
-  json()
+  json(),
+  terser({ // remove comments only, so size presubmit can do code size diff correctly.
+    output: {
+      comments: false
+    },
+    compress: false,
+    mangle: false
+  })
 ];
 
 const es5Builds = [
@@ -67,7 +75,14 @@ const es2017BuildPlugins = [
       }
     }
   }),
-  json({ preferConst: true })
+  json({ preferConst: true }),
+  terser({ // remove comments only, so size presubmit can do code size diff correctly.
+    output: {
+      comments: false
+    },
+    compress: false,
+    mangle: false
+  })
 ];
 
 /**

--- a/packages/installations/package.json
+++ b/packages/installations/package.json
@@ -34,7 +34,7 @@
     "rollup-plugin-json": "4.0.0",
     "rollup-plugin-node-resolve": "5.2.0",
     "rollup-plugin-typescript2": "0.26.0",
-    "rollup-plugin-uglify": "6.0.4",
+    "rollup-plugin-terser": "5.3.0",
     "typescript": "3.8.3"
   },
   "peerDependencies": {

--- a/packages/installations/rollup.config.js
+++ b/packages/installations/rollup.config.js
@@ -19,13 +19,24 @@ import json from 'rollup-plugin-json';
 import typescriptPlugin from 'rollup-plugin-typescript2';
 import pkg from './package.json';
 import typescript from 'typescript';
+import { terser } from 'rollup-plugin-terser';
 
 const deps = Object.keys({ ...pkg.peerDependencies, ...pkg.dependencies });
 
 /**
  * ES5 Builds
  */
-const es5BuildPlugins = [typescriptPlugin({ typescript }), json()];
+const es5BuildPlugins = [
+  typescriptPlugin({ typescript }), 
+  json(),
+  terser({ // remove comments only, so size presubmit can do code size diff correctly.
+    output: {
+      comments: false
+    },
+    compress: false,
+    mangle: false
+  })
+];
 
 const es5Builds = [
   {
@@ -51,7 +62,14 @@ const es2017BuildPlugins = [
       }
     }
   }),
-  json({ preferConst: true })
+  json({ preferConst: true }),
+  terser({ // remove comments only, so size presubmit can do code size diff correctly.
+    output: {
+      comments: false
+    },
+    compress: false,
+    mangle: false
+  })
 ];
 
 const es2017Builds = [

--- a/packages/installations/test-app/rollup.config.js
+++ b/packages/installations/test-app/rollup.config.js
@@ -19,7 +19,7 @@ import typescriptPlugin from 'rollup-plugin-typescript2';
 import resolve from 'rollup-plugin-node-resolve';
 import commonjs from 'rollup-plugin-commonjs';
 import json from 'rollup-plugin-json';
-import { uglify } from 'rollup-plugin-uglify';
+import { terser } from 'rollup-plugin-terser';
 import typescript from 'typescript';
 
 /**
@@ -42,7 +42,7 @@ export default [
       json(),
       resolve(),
       commonjs(),
-      uglify()
+      terser()
     ]
   }
 ];

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -24,6 +24,7 @@
   "devDependencies": {
     "rollup": "2.0.6",
     "rollup-plugin-typescript2": "0.26.0",
+    "rollup-plugin-terser": "5.3.0",
     "typescript": "3.8.3"
   },
   "repository": {

--- a/packages/logger/rollup.config.js
+++ b/packages/logger/rollup.config.js
@@ -18,6 +18,7 @@
 import typescriptPlugin from 'rollup-plugin-typescript2';
 import typescript from 'typescript';
 import pkg from './package.json';
+import { terser } from 'rollup-plugin-terser';
 
 /**
  * ES5 Builds
@@ -25,6 +26,13 @@ import pkg from './package.json';
 const es5BuildPlugins = [
   typescriptPlugin({
     typescript
+  }),
+  terser({ // remove comments only, so size presubmit can do code size diff correctly.
+    output: {
+      comments: false
+    },
+    compress: false,
+    mangle: false
   })
 ];
 
@@ -55,6 +63,13 @@ const es2017BuildPlugins = [
         target: 'es2017'
       }
     }
+  }),
+  terser({ // remove comments only, so size presubmit can do code size diff correctly.
+    output: {
+      comments: false
+    },
+    compress: false,
+    mangle: false
   })
 ];
 

--- a/packages/messaging/package.json
+++ b/packages/messaging/package.json
@@ -36,6 +36,7 @@
   "devDependencies": {
     "rollup": "2.0.6",
     "rollup-plugin-typescript2": "0.26.0",
+    "rollup-plugin-terser": "5.3.0",
     "ts-essentials": "6.0.2",
     "typescript": "3.8.3"
   },

--- a/packages/messaging/rollup.config.js
+++ b/packages/messaging/rollup.config.js
@@ -19,6 +19,7 @@ import json from 'rollup-plugin-json';
 import typescriptPlugin from 'rollup-plugin-typescript2';
 import typescript from 'typescript';
 import pkg from './package.json';
+import { terser } from 'rollup-plugin-terser';
 
 const deps = Object.keys(
   Object.assign({}, pkg.peerDependencies, pkg.dependencies)
@@ -31,7 +32,14 @@ const es5BuildPlugins = [
   typescriptPlugin({
     typescript
   }),
-  json()
+  json(),
+  terser({ // remove comments only, so size presubmit can do code size diff correctly.
+    output: {
+      comments: false
+    },
+    compress: false,
+    mangle: false
+  })
 ];
 
 const es5Builds = [
@@ -58,7 +66,14 @@ const es2017BuildPlugins = [
       }
     }
   }),
-  json({ preferConst: true })
+  json({ preferConst: true }),
+  terser({ // remove comments only, so size presubmit can do code size diff correctly.
+    output: {
+      comments: false
+    },
+    compress: false,
+    mangle: false
+  })
 ];
 
 const es2017Builds = [

--- a/packages/performance/package.json
+++ b/packages/performance/package.json
@@ -38,6 +38,7 @@
     "rollup": "2.0.6",
     "rollup-plugin-json": "4.0.0",
     "rollup-plugin-typescript2": "0.26.0",
+    "rollup-plugin-terser": "5.3.0",
     "typescript": "3.8.3"
   },
   "repository": {

--- a/packages/performance/rollup.config.js
+++ b/packages/performance/rollup.config.js
@@ -19,6 +19,7 @@ import json from 'rollup-plugin-json';
 import typescriptPlugin from 'rollup-plugin-typescript2';
 import typescript from 'typescript';
 import pkg from './package.json';
+import { terser } from 'rollup-plugin-terser';
 
 const deps = Object.keys(
   Object.assign({}, pkg.peerDependencies, pkg.dependencies)
@@ -27,7 +28,17 @@ const deps = Object.keys(
 /**
  * ES5 Builds
  */
-const es5BuildPlugins = [typescriptPlugin({ typescript }), json()];
+const es5BuildPlugins = [
+  typescriptPlugin({ typescript }), 
+  json(),
+  terser({ // remove comments only, so size presubmit can do code size diff correctly.
+    output: {
+      comments: false
+    },
+    compress: false,
+    mangle: false
+  })
+];
 
 const es5Builds = [
   {
@@ -54,7 +65,14 @@ const es2017BuildPlugins = [
       }
     }
   }),
-  json({ preferConst: true })
+  json({ preferConst: true }),
+  terser({ // remove comments only, so size presubmit can do code size diff correctly.
+    output: {
+      comments: false
+    },
+    compress: false,
+    mangle: false
+  })
 ];
 
 const es2017Builds = [

--- a/packages/remote-config/package.json
+++ b/packages/remote-config/package.json
@@ -37,6 +37,7 @@
   "devDependencies": {
     "rollup": "2.0.6",
     "rollup-plugin-typescript2": "0.26.0",
+    "rollup-plugin-terser": "5.3.0",
     "typescript": "3.8.3"
   },
   "repository": {

--- a/packages/remote-config/rollup.config.js
+++ b/packages/remote-config/rollup.config.js
@@ -19,6 +19,7 @@ import json from 'rollup-plugin-json'; // Enables package.json import in TypeScr
 import typescriptPlugin from 'rollup-plugin-typescript2';
 import typescript from 'typescript';
 import pkg from './package.json';
+import { terser } from 'rollup-plugin-terser';
 
 const deps = Object.keys(
   Object.assign({}, pkg.peerDependencies, pkg.dependencies)
@@ -31,7 +32,14 @@ const es5BuildPlugins = [
   typescriptPlugin({
     typescript
   }),
-  json()
+  json(),
+  terser({ // remove comments only, so size presubmit can do code size diff correctly.
+    output: {
+      comments: false
+    },
+    compress: false,
+    mangle: false
+  })
 ];
 
 const es5Builds = [
@@ -61,7 +69,14 @@ const es2017BuildPlugins = [
       }
     }
   }),
-  json({ preferConst: true })
+  json({ preferConst: true }),
+  terser({ // remove comments only, so size presubmit can do code size diff correctly.
+    output: {
+      comments: false
+    },
+    compress: false,
+    mangle: false
+  })
 ];
 
 const es2017Builds = [

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -33,6 +33,7 @@
   "devDependencies": {
     "rollup": "2.0.6",
     "rollup-plugin-typescript2": "0.26.0",
+    "rollup-plugin-terser": "5.3.0",
     "typescript": "3.8.3"
   },
   "repository": {

--- a/packages/storage/rollup.config.js
+++ b/packages/storage/rollup.config.js
@@ -19,6 +19,7 @@ import json from 'rollup-plugin-json';
 import typescriptPlugin from 'rollup-plugin-typescript2';
 import typescript from 'typescript';
 import pkg from './package.json';
+import { terser } from 'rollup-plugin-terser';
 
 const deps = Object.keys(
   Object.assign({}, pkg.peerDependencies, pkg.dependencies)
@@ -30,7 +31,14 @@ const es5BuildPlugins = [
   typescriptPlugin({
     typescript
   }),
-  json()
+  json(),
+  terser({ // remove comments only, so size presubmit can do code size diff correctly.
+    output: {
+      comments: false
+    },
+    compress: false,
+    mangle: false
+  })
 ];
 
 const es5Builds = [
@@ -57,7 +65,14 @@ const es2017BuildPlugins = [
       }
     }
   }),
-  json({ preferConst: true })
+  json({ preferConst: true }),
+  terser({ // remove comments only, so size presubmit can do code size diff correctly.
+    output: {
+      comments: false
+    },
+    compress: false,
+    mangle: false
+  })
 ];
 
 const es2017Builds = [

--- a/packages/template/package.json
+++ b/packages/template/package.json
@@ -34,6 +34,7 @@
   "devDependencies": {
     "rollup": "2.0.6",
     "rollup-plugin-typescript2": "0.26.0",
+    "rollup-plugin-terser": "5.3.0",
     "typescript": "3.8.3"
   },
   "repository": {

--- a/packages/template/rollup.config.js
+++ b/packages/template/rollup.config.js
@@ -16,6 +16,7 @@
  */
 
 import typescriptPlugin from 'rollup-plugin-typescript2';
+import { terser } from 'rollup-plugin-terser';
 import typescript from 'typescript';
 import pkg from './package.json';
 
@@ -29,6 +30,13 @@ const deps = Object.keys(
 const es5BuildPlugins = [
   typescriptPlugin({
     typescript
+  }),
+  terser({ // remove comments only, so size presubmit can do code size diff correctly.
+    output: {
+      comments: false
+    },
+    compress: false,
+    mangle: false
   })
 ];
 
@@ -67,6 +75,13 @@ const es2017BuildPlugins = [
         target: 'es2017'
       }
     }
+  }),
+  terser({ // remove comments only, so size presubmit can do code size diff correctly.
+    output: {
+      comments: false
+    },
+    compress: false,
+    mangle: false
   })
 ];
 

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -26,7 +26,8 @@
     "rollup": "2.0.6",
     "rollup-plugin-copy-assets": "1.1.0",
     "rollup-plugin-replace": "2.2.0",
-    "rollup-plugin-typescript2": "0.26.0"
+    "rollup-plugin-typescript2": "0.26.0",
+    "rollup-plugin-terser": "5.3.0"
   },
   "repository": {
     "directory": "packages/testing",

--- a/packages/testing/rollup.config.js
+++ b/packages/testing/rollup.config.js
@@ -20,10 +20,18 @@ import pkg from './package.json';
 import replace from 'rollup-plugin-replace';
 import copy from 'rollup-plugin-copy-assets';
 import typescript from 'typescript';
+import { terser } from 'rollup-plugin-terser';
 
 const plugins = [
   typescriptPlugin({
     typescript
+  }),
+  terser({ // remove comments only, so size presubmit can do code size diff correctly.
+    output: {
+      comments: false
+    },
+    compress: false,
+    mangle: false
   })
 ];
 

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -28,6 +28,7 @@
   "devDependencies": {
     "rollup": "2.0.6",
     "rollup-plugin-typescript2": "0.26.0",
+    "rollup-plugin-terser": "5.3.0",
     "typescript": "3.8.3"
   },
   "repository": {

--- a/packages/util/rollup.config.js
+++ b/packages/util/rollup.config.js
@@ -18,6 +18,7 @@
 import typescriptPlugin from 'rollup-plugin-typescript2';
 import typescript from 'typescript';
 import pkg from './package.json';
+import { terser } from 'rollup-plugin-terser';
 
 const deps = Object.keys(
   Object.assign({}, pkg.peerDependencies, pkg.dependencies)
@@ -30,6 +31,13 @@ const deps = Object.keys(
 const es5BuildPlugins = [
   typescriptPlugin({
     typescript
+  }),
+  terser({ // remove comments only, so size presubmit can do code size diff correctly.
+    output: {
+      comments: false
+    },
+    compress: false,
+    mangle: false
   })
 ];
 
@@ -68,6 +76,13 @@ const es2017BuildPlugins = [
         target: 'es2017'
       }
     }
+  }),
+  terser({ // remove comments only, so size presubmit can do code size diff correctly.
+    output: {
+      comments: false
+    },
+    compress: false,
+    mangle: false
   })
 ];
 


### PR DESCRIPTION
In preparation to enable size presubmit(https://github.com/firebase/firebase-js-sdk/pull/2744), this PR removes comments and whitespaces in our builds, so the size diffs are not skewed by comment changes.

Will wait for the CI to finish to see how much latency this change introduces.