### PR TITLE
Remove mangling from Node build

### DIFF
--- a/packages/firestore/rollup.config.js
+++ b/packages/firestore/rollup.config.js
@@ -194,7 +194,11 @@ const browserBuilds = [
 // MARK: Node builds
 
 const nodeBuildPlugins = [
-  ...es5BuildPlugins,
+  typescriptPlugin({
+    typescript,
+    cacheRoot: `./.cache/node/`
+  }),
+  json(),
   // Needed as we also use the *.proto files
   copy({
     assets: ['./src/protos']


### PR DESCRIPTION
#2608 re-introduced mangling to the Node build, which wasn't mangled before. Since it uses CJS, the output is not minified very well. This reverts this change and makes sure the next release uses the same settings as the current release.
