### PR TITLE
Implement limbo resolution throttling.

### DIFF
--- a/packages/firestore/src/core/firestore_client.ts
+++ b/packages/firestore/src/core/firestore_client.ts
@@ -53,6 +53,7 @@ import { OnlineState, OnlineStateSource } from './types';
 import { ViewSnapshot } from './view_snapshot';
 
 const LOG_TAG = 'FirestoreClient';
+const MAX_CONCURRENT_LIMBO_RESOLUTIONS = 100;
 
 /** DOMException error code constants. */
 const DOM_EXCEPTION_INVALID_STATE = 11;
@@ -369,7 +370,8 @@ export class FirestoreClient {
           this.localStore,
           this.remoteStore,
           this.sharedClientState,
-          user
+          user,
+          MAX_CONCURRENT_LIMBO_RESOLUTIONS
         );
 
         this.sharedClientState.onlineStateHandler = sharedClientStateOnlineStateChangedHandler;

--- a/packages/firestore/src/core/sync_engine.ts
+++ b/packages/firestore/src/core/sync_engine.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2017 Google Inc.
+ * Copyright 2017 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/firestore/src/core/sync_engine.ts
+++ b/packages/firestore/src/core/sync_engine.ts
@@ -188,7 +188,7 @@ export class SyncEngine implements RemoteSyncer, SharedClientStateSyncer {
     // PORTING NOTE: Manages state synchronization in multi-tab environments.
     private sharedClientState: SharedClientState,
     private currentUser: User,
-    private maxConcurrentLimboResolutions: number = 100
+    private maxConcurrentLimboResolutions: number
   ) {}
 
   // Only used for testing.

--- a/packages/firestore/test/unit/specs/limbo_spec.test.ts
+++ b/packages/firestore/test/unit/specs/limbo_spec.test.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2017 Google Inc.
+ * Copyright 2017 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/firestore/test/unit/specs/limbo_spec.test.ts
+++ b/packages/firestore/test/unit/specs/limbo_spec.test.ts
@@ -639,4 +639,267 @@ describeSpec('Limbo Documents:', [], () => {
       );
     }
   );
+
+  specTest(
+    'Limbo resolution throttling with all results at once from watch',
+    ['no-ios'],
+    () => {
+      const query = Query.atPath(path('collection'));
+      const doc1 = doc('collection/a', 1000, { key: 'a' });
+      const doc2 = doc('collection/b', 1000, { key: 'b' });
+      const doc3 = doc('collection/c', 1000, { key: 'c' });
+      const limboQuery1 = Query.atPath(doc1.key.path);
+      const limboQuery2 = Query.atPath(doc2.key.path);
+      const limboQuery3 = Query.atPath(doc3.key.path);
+
+      return (
+        spec()
+          .withMaxConcurrentLimboResolutions(2)
+          .userListens(query)
+          .watchAcksFull(query, 1000, doc1, doc2, doc3)
+          .expectEvents(query, {
+            added: [doc1, doc2, doc3]
+          })
+          .watchResets(query)
+          .watchSends({ affects: [query] })
+          .watchCurrents(query, 'resume-token-2000')
+          .watchSnapshots(2000)
+          .expectLimboDocsEx({
+            activeKeys: [doc1.key, doc2.key],
+            inactiveKeys: [doc3.key]
+          })
+          // Limbo document causes query to be "inconsistent"
+          .expectEvents(query, { fromCache: true })
+          .watchAcks(limboQuery1)
+          .watchAcks(limboQuery2)
+          .watchCurrents(limboQuery1, 'resume-token-2001')
+          .watchCurrents(limboQuery2, 'resume-token-2001')
+          .watchSnapshots(2001)
+          .expectLimboDocs(doc3.key)
+          .expectEvents(query, {
+            removed: [doc1, doc2],
+            fromCache: true
+          })
+          .watchAcks(limboQuery3)
+          .watchCurrents(limboQuery3, 'resume-token-2001')
+          .watchSnapshots(2001)
+          .expectLimboDocs()
+          .expectEvents(query, {
+            removed: [doc3],
+            fromCache: false
+          })
+      );
+    }
+  );
+
+  specTest(
+    'Limbo resolution throttling with results one at a time from watch',
+    ['no-ios'],
+    () => {
+      const query = Query.atPath(path('collection'));
+      const doc1 = doc('collection/a', 1000, { key: 'a' });
+      const doc2 = doc('collection/b', 1000, { key: 'b' });
+      const doc3 = doc('collection/c', 1000, { key: 'c' });
+      const limboQuery1 = Query.atPath(doc1.key.path);
+      const limboQuery2 = Query.atPath(doc2.key.path);
+      const limboQuery3 = Query.atPath(doc3.key.path);
+
+      return (
+        spec()
+          .withMaxConcurrentLimboResolutions(2)
+          .userListens(query)
+          .watchAcksFull(query, 1000, doc1, doc2, doc3)
+          .expectEvents(query, {
+            added: [doc1, doc2, doc3]
+          })
+          .watchResets(query)
+          .watchSends({ affects: [query] })
+          .watchCurrents(query, 'resume-token-2000')
+          .watchSnapshots(2000)
+          .expectLimboDocsEx({
+            activeKeys: [doc1.key, doc2.key],
+            inactiveKeys: [doc3.key]
+          })
+          // Limbo document causes query to be "inconsistent"
+          .expectEvents(query, { fromCache: true })
+          .watchAcks(limboQuery1)
+          .watchCurrents(limboQuery1, 'resume-token-2001')
+          .watchSnapshots(2001)
+          .expectLimboDocs(doc2.key, doc3.key)
+          .expectEvents(query, {
+            removed: [doc1],
+            fromCache: true
+          })
+          .watchAcks(limboQuery2)
+          .watchCurrents(limboQuery2, 'resume-token-2001')
+          .watchSnapshots(2001)
+          .expectLimboDocs(doc3.key)
+          .expectEvents(query, {
+            removed: [doc2],
+            fromCache: true
+          })
+          .watchAcks(limboQuery3)
+          .watchCurrents(limboQuery3, 'resume-token-2001')
+          .watchSnapshots(2001)
+          .expectLimboDocs()
+          .expectEvents(query, {
+            removed: [doc3],
+            fromCache: false
+          })
+      );
+    }
+  );
+
+  specTest(
+    'Limbo resolution throttling when a limbo listen is rejected.',
+    ['no-ios'],
+    () => {
+      const query = Query.atPath(path('collection'));
+      const doc1 = doc('collection/a', 1000, { key: 'a' });
+      const doc2 = doc('collection/b', 1000, { key: 'b' });
+      const limboQuery1 = Query.atPath(doc1.key.path);
+      const limboQuery2 = Query.atPath(doc2.key.path);
+
+      return (
+        spec()
+          .withMaxConcurrentLimboResolutions(1)
+          .userListens(query)
+          .watchAcksFull(query, 1000, doc1, doc2)
+          .expectEvents(query, { added: [doc1, doc2] })
+          // Watch tells us that the query results have changed to the empty
+          // set, which makes our local cache inconsistent with the remote
+          // state, causing a fromCache=true event to be raised.
+          .watchResets(query)
+          .watchSends({ affects: [query] })
+          .watchCurrents(query, 'resume-token-1001')
+          .watchSnapshots(1001)
+          // Both doc1 and doc2 are in limbo, but the maximum number of limbo
+          // listens was set to 1, which causes doc1 to get resolved and doc2
+          // to get enqueued.
+          .expectLimboDocsEx({
+            activeKeys: [doc1.key],
+            inactiveKeys: [doc2.key]
+          })
+          // Limbo document causes query to be "inconsistent"
+          .expectEvents(query, { fromCache: true })
+          .watchRemoves(
+            limboQuery1,
+            new RpcError(Code.RESOURCE_EXHAUSTED, 'Resource exhausted')
+          )
+          // When a limbo listen gets rejected, we assume that it was deleted.
+          // But now that doc1 is resolved, the limbo resolution for doc2 can
+          // start.
+          .expectLimboDocs(doc2.key)
+          .expectEvents(query, { removed: [doc1], fromCache: true })
+          // Reject the listen for the second limbo resolution as well, in order
+          // to exercise the code path of a rejected limbo resolution without
+          // any enqueued limbo resolutions.
+          .watchRemoves(
+            limboQuery2,
+            new RpcError(Code.RESOURCE_EXHAUSTED, 'Resource exhausted')
+          )
+          .expectLimboDocs()
+          .expectEvents(query, { removed: [doc2] })
+      );
+    }
+  );
+
+  specTest(
+    // This test exercises the steps that resulted in unbounded reads that
+    // motivated throttling:
+    // https://github.com/firebase/firebase-js-sdk/issues/2683
+    'Limbo resolution throttling with existence filter mismatch',
+    ['no-ios'],
+    () => {
+      const query = Query.atPath(path('collection'));
+      const docA1 = doc('collection/a1', 1000, { key: 'a1' });
+      const docA2 = doc('collection/a2', 1000, { key: 'a2' });
+      const docA3 = doc('collection/a3', 1000, { key: 'a3' });
+      const docB1 = doc('collection/b1', 1000, { key: 'b1' });
+      const docB2 = doc('collection/b2', 1000, { key: 'b2' });
+      const docB3 = doc('collection/b3', 1000, { key: 'b3' });
+      const docA1Query = Query.atPath(docA1.key.path);
+      const docA2Query = Query.atPath(docA2.key.path);
+      const docA3Query = Query.atPath(docA3.key.path);
+
+      return (
+        spec()
+          .withMaxConcurrentLimboResolutions(2)
+          .userListens(query)
+          .watchAcks(query)
+          .watchSends({ affects: [query] }, docA1, docA2, docA3)
+          .watchCurrents(query, 'resume-token-1000')
+          .watchSnapshots(1000)
+          .expectEvents(query, { added: [docA1, docA2, docA3] })
+          // At this point the query is consistent and matches 3 documents:
+          // docA1, docA2, and docA3. Then, network connectivity is lost.
+          .disableNetwork()
+          // The query listener is notified that the results are being served
+          // from cache since without network connection there is no way to know
+          // if we are in sync with the server.
+          .expectEvents(query, { fromCache: true })
+          .enableNetwork()
+          // The network connection has come back so the client re-registers
+          // the listener, providing the resume token from before. Watch will
+          // then send updates that occurred since the timestamp encoded in the
+          // resume token.
+          .restoreListen(query, 'resume-token-1000')
+          .watchAcks(query)
+          // Watch now tells us that the query results on the server are docB1,
+          // docB2, and docB3, along with an existence filter to state that the
+          // total number of documents that match the query is 3.
+          .watchSends({ affects: [query] }, docB1, docB2, docB3)
+          .watchFilters([query], docB1.key, docB2.key, docB3.key)
+          .watchSnapshots(1001)
+          // The query listener is now inconsistent because it had thought that
+          // the set of matching documents was docA1, docA2, and docA3 but the
+          // server just told us that the set of matching documents is
+          // completely different: docB1, docB2, and docB3. So the query
+          // notifies the user that these documents were added, but still says
+          // fromCache=true because we need to resolve docA1, docA2, and docA3.
+          .expectEvents(query, {
+            added: [docB1, docB2, docB3],
+            fromCache: true
+          })
+          // After the existence filter mismatch the client re-listens without
+          // a resume token.
+          .expectActiveTargets({ query, resumeToken: '' })
+          // When the existence filter mismatch was detected, we removed then
+          // re-added the target; therefore, watch acknowledges the removal.
+          .watchRemoves(query)
+          // Watch has re-run the query and returns the same result set: docB1,
+          // docB2, and docB3. This puts docA1, docA2, and docA3 into limbo,
+          // which the client then issues queries to resolve. Since the maximum
+          // number of concurrent limbo resolutions was set to 2, only the first
+          // two limbo resolutions are started, with the 3rd being enqueued.
+          .watchAcksFull(query, 1002, docB1, docB2, docB3)
+          .expectLimboDocsEx({
+            activeKeys: [docA1.key, docA2.key],
+            inactiveKeys: [docA3.key]
+          })
+          .watchAcks(docA1Query)
+          .watchAcks(docA2Query)
+          .watchCurrents(docA1Query, 'resume-token-1003')
+          .watchCurrents(docA2Query, 'resume-token-1003')
+          .watchSnapshots(1003)
+          // Watch has now confirmed that docA1 and docA2 have been deleted. So
+          // the listener sends an event that the documents have
+          // been removed; however, since docA3 is still enqueued for limbo
+          // resolution the results are still from cache; however, now that
+          // there are 0 limbo resolutions in progress, the limbo resolution for
+          // docA3 is started.
+          .expectEvents(query, { removed: [docA1, docA2], fromCache: true })
+          .expectLimboDocs(docA3.key)
+          .watchAcks(docA3Query)
+          .watchCurrents(docA3Query, 'resume-token-1004')
+          .watchSnapshots(1004)
+          // Watch has now confirmed that docA3 has been deleted. So the
+          // listener sends an event about this and now specifies
+          // fromCache=false since we are in sync with the server and all docs
+          // that were in limbo have been resolved.
+          .expectEvents(query, { removed: [docA3] })
+          .expectLimboDocs()
+      );
+    }
+  );
 });

--- a/packages/firestore/test/unit/specs/limbo_spec.test.ts
+++ b/packages/firestore/test/unit/specs/limbo_spec.test.ts
@@ -674,7 +674,7 @@ describeSpec('Limbo Documents:', [], () => {
           .watchCurrents(query, 'resume-token-2000')
           .watchSnapshots(2000)
           .expectLimboDocs(doc1.key, doc2.key)
-          .expectInactiveLimboDocs(doc3.key, doc4.key, doc5.key)
+          .expectEnqueuedLimboDocs(doc3.key, doc4.key, doc5.key)
           // Limbo document causes query to be "inconsistent"
           .expectEvents(query, { fromCache: true })
           .watchAcks(limboQuery1)
@@ -689,7 +689,7 @@ describeSpec('Limbo Documents:', [], () => {
           })
           // Start the second round of limbo resolutions.
           .expectLimboDocs(doc3.key, doc4.key)
-          .expectInactiveLimboDocs(doc5.key)
+          .expectEnqueuedLimboDocs(doc5.key)
           .watchAcks(limboQuery3)
           .watchAcks(limboQuery4)
           // Resolve limbo documents doc3 and doc4 in a single snapshot.
@@ -702,7 +702,7 @@ describeSpec('Limbo Documents:', [], () => {
           })
           // Start the final round of limbo resolutions.
           .expectLimboDocs(doc5.key)
-          .expectInactiveLimboDocs()
+          .expectEnqueuedLimboDocs()
           .watchAcks(limboQuery5)
           // Resolve limbo document doc5.
           .watchCurrents(limboQuery5, 'resume-token-2003')
@@ -712,7 +712,7 @@ describeSpec('Limbo Documents:', [], () => {
             fromCache: false
           })
           .expectLimboDocs()
-          .expectInactiveLimboDocs()
+          .expectEnqueuedLimboDocs()
       );
     }
   );
@@ -751,7 +751,7 @@ describeSpec('Limbo Documents:', [], () => {
           .watchCurrents(query, 'resume-token-2000')
           .watchSnapshots(2000)
           .expectLimboDocs(doc1.key, doc2.key)
-          .expectInactiveLimboDocs(doc3.key, doc4.key, doc5.key)
+          .expectEnqueuedLimboDocs(doc3.key, doc4.key, doc5.key)
           // Limbo document causes query to be "inconsistent"
           .expectEvents(query, { fromCache: true })
           .watchAcks(limboQuery1)
@@ -762,7 +762,7 @@ describeSpec('Limbo Documents:', [], () => {
           .expectEvents(query, { removed: [doc1], fromCache: true })
           // Start the next limbo resolution since one has finished.
           .expectLimboDocs(doc2.key, doc3.key)
-          .expectInactiveLimboDocs(doc4.key, doc5.key)
+          .expectEnqueuedLimboDocs(doc4.key, doc5.key)
           .watchAcks(limboQuery3)
           // Resolve the limbo documents doc2 in its own snapshot.
           .watchCurrents(limboQuery2, 'resume-token-2002')
@@ -770,7 +770,7 @@ describeSpec('Limbo Documents:', [], () => {
           .expectEvents(query, { removed: [doc2], fromCache: true })
           // Start the next limbo resolution since one has finished.
           .expectLimboDocs(doc3.key, doc4.key)
-          .expectInactiveLimboDocs(doc5.key)
+          .expectEnqueuedLimboDocs(doc5.key)
           .watchAcks(limboQuery4)
           // Resolve the limbo documents doc3 in its own snapshot.
           .watchCurrents(limboQuery3, 'resume-token-2003')
@@ -778,7 +778,7 @@ describeSpec('Limbo Documents:', [], () => {
           .expectEvents(query, { removed: [doc3], fromCache: true })
           // Start the next limbo resolution since one has finished.
           .expectLimboDocs(doc4.key, doc5.key)
-          .expectInactiveLimboDocs()
+          .expectEnqueuedLimboDocs()
           .watchAcks(limboQuery5)
           // Resolve the limbo documents doc4 in its own snapshot.
           .watchCurrents(limboQuery4, 'resume-token-2004')
@@ -786,13 +786,13 @@ describeSpec('Limbo Documents:', [], () => {
           .expectEvents(query, { removed: [doc4], fromCache: true })
           // The final limbo document listen is already active; resolve it.
           .expectLimboDocs(doc5.key)
-          .expectInactiveLimboDocs()
+          .expectEnqueuedLimboDocs()
           // Resolve the limbo documents doc5 in its own snapshot.
           .watchCurrents(limboQuery5, 'resume-token-2005')
           .watchSnapshots(2005)
           .expectEvents(query, { removed: [doc5], fromCache: false })
           .expectLimboDocs()
-          .expectInactiveLimboDocs()
+          .expectEnqueuedLimboDocs()
       );
     }
   );
@@ -823,7 +823,7 @@ describeSpec('Limbo Documents:', [], () => {
           .watchCurrents(query, 'resume-token-1001')
           .watchSnapshots(2000)
           .expectLimboDocs(doc1.key)
-          .expectInactiveLimboDocs(doc2.key)
+          .expectEnqueuedLimboDocs(doc2.key)
           // Limbo document causes query to be "inconsistent"
           .expectEvents(query, { fromCache: true })
           .watchRemoves(
@@ -835,7 +835,7 @@ describeSpec('Limbo Documents:', [], () => {
           // start.
           .expectEvents(query, { removed: [doc1], fromCache: true })
           .expectLimboDocs(doc2.key)
-          .expectInactiveLimboDocs()
+          .expectEnqueuedLimboDocs()
           // Reject the listen for the second limbo resolution as well, in order
           // to exercise the code path of a rejected limbo resolution without
           // any enqueued limbo resolutions.
@@ -845,7 +845,7 @@ describeSpec('Limbo Documents:', [], () => {
           )
           .expectEvents(query, { removed: [doc2] })
           .expectLimboDocs()
-          .expectInactiveLimboDocs()
+          .expectEnqueuedLimboDocs()
       );
     }
   );
@@ -910,7 +910,7 @@ describeSpec('Limbo Documents:', [], () => {
           .watchAcksFull(query, 1002, docB1, docB2, docB3)
           // The docAs are now in limbo; the client begins limbo resolution.
           .expectLimboDocs(docA1.key, docA2.key)
-          .expectInactiveLimboDocs(docA3.key)
+          .expectEnqueuedLimboDocs(docA3.key)
           .watchAcks(docA1Query)
           .watchAcks(docA2Query)
           .watchCurrents(docA1Query, 'resume-token-1003')
@@ -918,13 +918,13 @@ describeSpec('Limbo Documents:', [], () => {
           .watchSnapshots(1003)
           .expectEvents(query, { removed: [docA1, docA2], fromCache: true })
           .expectLimboDocs(docA3.key)
-          .expectInactiveLimboDocs()
+          .expectEnqueuedLimboDocs()
           .watchAcks(docA3Query)
           .watchCurrents(docA3Query, 'resume-token-1004')
           .watchSnapshots(1004)
           .expectEvents(query, { removed: [docA3] })
           .expectLimboDocs()
-          .expectInactiveLimboDocs()
+          .expectEnqueuedLimboDocs()
       );
     }
   );

--- a/packages/firestore/test/unit/specs/spec_builder.ts
+++ b/packages/firestore/test/unit/specs/spec_builder.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2017 Google Inc.
+ * Copyright 2017 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/firestore/test/unit/specs/spec_builder.ts
+++ b/packages/firestore/test/unit/specs/spec_builder.ts
@@ -359,7 +359,7 @@ export class SpecBuilder {
       expectedState: {
         activeTargets: {},
         activeLimboDocs: [],
-        inactiveLimboDocs: []
+        enqueuedLimboDocs: []
       }
     };
     return this;
@@ -388,7 +388,7 @@ export class SpecBuilder {
       expectedState: {
         activeTargets: {},
         activeLimboDocs: [],
-        inactiveLimboDocs: []
+        enqueuedLimboDocs: []
       }
     };
     // Reset our mappings / target ids since all existing listens will be
@@ -404,7 +404,7 @@ export class SpecBuilder {
       expectedState: {
         activeTargets: {},
         activeLimboDocs: [],
-        inactiveLimboDocs: []
+        enqueuedLimboDocs: []
       }
     };
     // Reset our mappings / target ids since all existing listens will be
@@ -477,14 +477,15 @@ export class SpecBuilder {
   }
 
   /**
-   * Expects a document to be in limbo, but *without* a targetId.
+   * Expects a document to be in limbo, enqueued for limbo resolution, and
+   * therefore *without* an active targetId.
    */
-  expectInactiveLimboDocs(...keys: DocumentKey[]): this {
+  expectEnqueuedLimboDocs(...keys: DocumentKey[]): this {
     this.assertStep('Limbo expectation requires previous step');
     const currentStep = this.currentStep!;
 
     currentStep.expectedState = currentStep.expectedState || {};
-    currentStep.expectedState.inactiveLimboDocs = keys.map(k =>
+    currentStep.expectedState.enqueuedLimboDocs = keys.map(k =>
       SpecBuilder.keyToSpec(k)
     );
 

--- a/packages/firestore/test/unit/specs/spec_test_runner.ts
+++ b/packages/firestore/test/unit/specs/spec_test_runner.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2017 Google Inc.
+ * Copyright 2017 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/firestore/test/unit/specs/spec_test_runner.ts
+++ b/packages/firestore/test/unit/specs/spec_test_runner.ts
@@ -511,22 +511,13 @@ abstract class TestRunner {
       remoteStoreOnlineStateChangedHandler,
       connectivityMonitor
     );
-    if (this.maxConcurrentLimboResolutions) {
-      this.syncEngine = new SyncEngine(
-        this.localStore,
-        this.remoteStore,
-        this.sharedClientState,
-        this.user,
-        this.maxConcurrentLimboResolutions
-      );
-    } else {
-      this.syncEngine = new SyncEngine(
-        this.localStore,
-        this.remoteStore,
-        this.sharedClientState,
-        this.user
-      );
-    }
+    this.syncEngine = new SyncEngine(
+      this.localStore,
+      this.remoteStore,
+      this.sharedClientState,
+      this.user,
+      this.maxConcurrentLimboResolutions ?? Number.MAX_SAFE_INTEGER
+    );
 
     // Set up wiring between sync engine and other components
     this.remoteStore.syncEngine = this.syncEngine;

--- a/packages/firestore/test/unit/specs/spec_test_runner.ts
+++ b/packages/firestore/test/unit/specs/spec_test_runner.ts
@@ -1094,7 +1094,7 @@ abstract class TestRunner {
       // Always validate that the expected limbo docs match the actual limbo
       // docs
       this.validateActiveLimboDocs();
-      this.validateEnqeuedLimboDocs();
+      this.validateEnqueuedLimboDocs();
       // Always validate that the expected active targets match the actual
       // active targets
       await this.validateActiveTargets();
@@ -1135,7 +1135,7 @@ abstract class TestRunner {
     );
   }
 
-  private validateEnqeuedLimboDocs(): void {
+  private validateEnqueuedLimboDocs(): void {
     let actualLimboDocs = new SortedSet<DocumentKey>(DocumentKey.comparator);
     this.syncEngine.enqueuedLimboDocumentResolutions().forEach(key => {
       actualLimboDocs = actualLimboDocs.add(key);


### PR DESCRIPTION
This change was motivated by the following bug report: https://github.com/firebase/firebase-js-sdk/issues/2683.  In summary, the issue was that when a large number of documents went into limbo (in this case 15,000 documents) then this would cause 15,000 document listens, which would result in "resource-exhausted" errors.  The client would then back off for a bit but would try the listens again, which would again result in "resource-exhausted" errors.  And the cycle would continue.  Worst of all, the customer was being billed for all of these reads that had no beneficial effects for the clients.

In order to avoid this situation, this PR modifies the limbo resolution logic to "throttle" the limbo resolutions.  It does this by allowing at most 100 concurrent limbo resolutions.  Limbo resolutions in excess of this limit are queued up and not started until another limbo resolution completes.  This fix should avoid the "resource-exhausted" errors and the infinite read loop.