### PR TITLE
Add a script to build only the SDK and its dependencies

### DIFF
--- a/packages/analytics/package.json
+++ b/packages/analytics/package.json
@@ -13,7 +13,7 @@
     "lint": "eslint -c .eslintrc.js '**/*.ts' --ignore-path '../../.gitignore'",
     "lint:fix": "eslint --fix -c .eslintrc.js '**/*.ts' --ignore-path '../../.gitignore'",
     "build": "rollup -c",
-    "build:deps": "lerna run --scope @firebase/analytics --include-dependencies build",
+    "build:deps": "lerna run --scope @firebase/'{app,analytics}' --include-dependencies build",
     "dev": "rollup -c -w",
     "test": "yarn type-check && yarn run-p lint test:browser",
     "test:browser": "karma start --single-run --nocache",

--- a/packages/analytics/package.json
+++ b/packages/analytics/package.json
@@ -13,6 +13,7 @@
     "lint": "eslint -c .eslintrc.js '**/*.ts' --ignore-path '../../.gitignore'",
     "lint:fix": "eslint --fix -c .eslintrc.js '**/*.ts' --ignore-path '../../.gitignore'",
     "build": "rollup -c",
+    "build:deps": "lerna run --scope @firebase/analytics --include-dependencies build",
     "dev": "rollup -c -w",
     "test": "yarn type-check && yarn run-p lint test:browser",
     "test:browser": "karma start --single-run --nocache",

--- a/packages/app/index.ts
+++ b/packages/app/index.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2017 Google Inc.
+ * Copyright 2017 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/app/index.ts
+++ b/packages/app/index.ts
@@ -21,7 +21,7 @@ import { isNode, isBrowser } from '@firebase/util';
 import { logger } from './src/logger';
 import { registerCoreComponents } from './src/registerCoreComponents';
 
-// Firebase Lite detection
+// Firebase Lite detection test
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 if (isBrowser() && (self as any).firebase !== undefined) {
   logger.warn(`

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -17,6 +17,7 @@
     "lint": "eslint -c .eslintrc.js '**/*.ts' --ignore-path '../../.gitignore'",
     "lint:fix": "eslint --fix -c .eslintrc.js '**/*.ts'  --ignore-path '../../.gitignore'",
     "build": "rollup -c",
+    "build:deps": "lerna run --scope @firebase/app --include-dependencies build",
     "dev": "rollup -c -w",
     "test": "yarn type-check && run-p lint test:browser test:node",
     "type-check": "tsc -p . --noEmit",

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -11,6 +11,7 @@
   ],
   "scripts": {
     "build": "gulp",
+    "build:deps": "lerna run --scope @firebase/auth --include-dependencies build",
     "demo": "./buildtools/run_demo.sh",
     "generate-test-files": "./buildtools/generate_test_files.sh",
     "prepare": "yarn build",

--- a/packages/component/package.json
+++ b/packages/component/package.json
@@ -14,6 +14,7 @@
     "lint": "eslint -c .eslintrc.js '**/*.ts' --ignore-path '../../.gitignore'",
     "lint:fix": "eslint --fix -c .eslintrc.js '**/*.ts' --ignore-path '../../.gitignore'",
     "build": "rollup -c",
+    "build:deps": "lerna run --scope @firebase/component --include-dependencies build",
     "dev": "rollup -c -w",
     "test": "yarn type-check && run-p lint test:browser test:node",
     "type-check": "tsc -p . --noEmit",

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -14,7 +14,7 @@
     "lint": "eslint -c .eslintrc.js '**/*.ts' --ignore-path '../../.gitignore'",
     "lint:fix": "eslint --fix -c .eslintrc.js '**/*.ts'  --ignore-path '../../.gitignore'",
     "build": "rollup -c",
-    "build:deps": "lerna run --scope @firebase/database --include-dependencies build",
+    "build:deps": "lerna run --scope @firebase/'{app,database}' --include-dependencies build",
     "dev": "rollup -c -w",
     "test": "run-p lint test:emulator",
     "test:all": "run-p lint test:browser test:node",

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -14,6 +14,7 @@
     "lint": "eslint -c .eslintrc.js '**/*.ts' --ignore-path '../../.gitignore'",
     "lint:fix": "eslint --fix -c .eslintrc.js '**/*.ts'  --ignore-path '../../.gitignore'",
     "build": "rollup -c",
+    "build:deps": "lerna run --scope @firebase/database --include-dependencies build",
     "dev": "rollup -c -w",
     "test": "run-p lint test:emulator",
     "test:all": "run-p lint test:browser test:node",

--- a/packages/firebase/package.json
+++ b/packages/firebase/package.json
@@ -30,6 +30,7 @@
   },
   "scripts": {
     "build": "rollup -c",
+    "build:deps": "lerna run --scope firebase --include-dependencies build",
     "dev": "rollup -c -w",
     "prepare": "yarn build"
   },

--- a/packages/firestore/package.json
+++ b/packages/firestore/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "prebuild": "tsc -d --downlevelIteration --declarationDir dist/lib --emitDeclarationOnly && tsc -m es2015 --moduleResolution node scripts/*.ts ",
     "build": "rollup -c",
-    "build:deps": "lerna run --scope @firebase/firestore --include-dependencies build",
+    "build:deps": "lerna run --scope @firebase/'{app,firestore}' --include-dependencies build",
     "build:console": "node tools/console.build.js",
     "dev": "rollup -c -w",
     "lint": "eslint -c .eslintrc.js '**/*.ts' --ignore-path '../../.gitignore'",

--- a/packages/firestore/package.json
+++ b/packages/firestore/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "prebuild": "tsc -d --downlevelIteration --declarationDir dist/lib --emitDeclarationOnly && tsc -m es2015 --moduleResolution node scripts/*.ts ",
     "build": "rollup -c",
+    "build:deps": "lerna run --scope @firebase/firestore --include-dependencies build",
     "build:console": "node tools/console.build.js",
     "dev": "rollup -c -w",
     "lint": "eslint -c .eslintrc.js '**/*.ts' --ignore-path '../../.gitignore'",

--- a/packages/functions/package.json
+++ b/packages/functions/package.json
@@ -14,6 +14,7 @@
     "lint": "eslint -c .eslintrc.js '**/*.ts' --ignore-path '../../.gitignore'",
     "lint:fix": "eslint --fix -c .eslintrc.js '**/*.ts' --ignore-path '../../.gitignore'",
     "build": "rollup -c",
+    "build:deps": "lerna run --scope @firebase/functions --include-dependencies build",
     "dev": "rollup -c -w",
     "test": "yarn type-check && run-p lint test:browser test:node",
     "type-check": "tsc -p . --noEmit",

--- a/packages/functions/package.json
+++ b/packages/functions/package.json
@@ -14,7 +14,7 @@
     "lint": "eslint -c .eslintrc.js '**/*.ts' --ignore-path '../../.gitignore'",
     "lint:fix": "eslint --fix -c .eslintrc.js '**/*.ts' --ignore-path '../../.gitignore'",
     "build": "rollup -c",
-    "build:deps": "lerna run --scope @firebase/functions --include-dependencies build",
+    "build:deps": "lerna run --scope @firebase/'{app,functions}' --include-dependencies build",
     "dev": "rollup -c -w",
     "test": "yarn type-check && run-p lint test:browser test:node",
     "type-check": "tsc -p . --noEmit",

--- a/packages/installations/package.json
+++ b/packages/installations/package.json
@@ -11,7 +11,7 @@
     "lint": "eslint -c .eslintrc.js '**/*.ts' --ignore-path '../../.gitignore'",
     "lint:fix": "eslint --fix -c .eslintrc.js '**/*.ts'  --ignore-path '../../.gitignore'",
     "build": "rollup -c",
-    "build:deps": "lerna run --scope @firebase/installations --include-dependencies build",
+    "build:deps": "lerna run --scope @firebase/'{app,installations}' --include-dependencies build",
     "test": "yarn type-check && yarn test:karma && yarn lint",
     "test:karma": "karma start --single-run",
     "test:debug": "karma start --browsers=Chrome --auto-watch",

--- a/packages/installations/package.json
+++ b/packages/installations/package.json
@@ -11,6 +11,7 @@
     "lint": "eslint -c .eslintrc.js '**/*.ts' --ignore-path '../../.gitignore'",
     "lint:fix": "eslint --fix -c .eslintrc.js '**/*.ts'  --ignore-path '../../.gitignore'",
     "build": "rollup -c",
+    "build:deps": "lerna run --scope @firebase/installations --include-dependencies build",
     "test": "yarn type-check && yarn test:karma && yarn lint",
     "test:karma": "karma start --single-run",
     "test:debug": "karma start --browsers=Chrome --auto-watch",

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -13,6 +13,7 @@
     "lint": "eslint -c .eslintrc.js '**/*.ts' --ignore-path '../../.gitignore'",
     "lint:fix": "eslint --fix -c .eslintrc.js '**/*.ts' --ignore-path '../../.gitignore'",
     "build": "rollup -c",
+    "build:deps": "lerna run --scope @firebase/logger --include-dependencies build",
     "dev": "rollup -c -w",
     "test": "run-p lint test:browser test:node",
     "test:browser": "karma start --single-run",

--- a/packages/messaging/package.json
+++ b/packages/messaging/package.json
@@ -13,7 +13,7 @@
     "lint": "eslint -c .eslintrc.js '**/*.ts' --ignore-path '../../.gitignore'",
     "lint:fix": "eslint --fix -c .eslintrc.js '**/*.ts' --ignore-path '../../.gitignore'",
     "build": "rollup -c",
-    "build:deps": "lerna run --scope @firebase/messaging --include-dependencies build",
+    "build:deps": "lerna run --scope @firebase/'{app,messaging}' --include-dependencies build",
     "dev": "rollup -c -w",
     "test": "run-p test:karma type-check lint",
     "test:karma": "karma start --single-run",

--- a/packages/messaging/package.json
+++ b/packages/messaging/package.json
@@ -13,6 +13,7 @@
     "lint": "eslint -c .eslintrc.js '**/*.ts' --ignore-path '../../.gitignore'",
     "lint:fix": "eslint --fix -c .eslintrc.js '**/*.ts' --ignore-path '../../.gitignore'",
     "build": "rollup -c",
+    "build:deps": "lerna run --scope @firebase/messaging --include-dependencies build",
     "dev": "rollup -c -w",
     "test": "run-p test:karma type-check lint",
     "test:karma": "karma start --single-run",

--- a/packages/performance/package.json
+++ b/packages/performance/package.json
@@ -14,6 +14,7 @@
     "lint": "eslint -c .eslintrc.js '**/*.ts' --ignore-path '../../.gitignore'",
     "lint:fix": "eslint --fix -c .eslintrc.js '**/*.ts'",
     "build": "rollup -c",
+    "build:deps": "lerna run --scope @firebase/performance --include-dependencies build",
     "dev": "rollup -c -w",
     "test": "run-p lint test:browser",
     "test:browser": "karma start --single-run",

--- a/packages/performance/package.json
+++ b/packages/performance/package.json
@@ -14,7 +14,7 @@
     "lint": "eslint -c .eslintrc.js '**/*.ts' --ignore-path '../../.gitignore'",
     "lint:fix": "eslint --fix -c .eslintrc.js '**/*.ts'",
     "build": "rollup -c",
-    "build:deps": "lerna run --scope @firebase/performance --include-dependencies build",
+    "build:deps": "lerna run --scope @firebase/'{app,performance}' --include-dependencies build",
     "dev": "rollup -c -w",
     "test": "run-p lint test:browser",
     "test:browser": "karma start --single-run",

--- a/packages/remote-config/package.json
+++ b/packages/remote-config/package.json
@@ -14,6 +14,7 @@
     "lint": "eslint -c .eslintrc.js '**/*.ts' --ignore-path '../../.gitignore'",
     "lint:fix": "eslint --fix -c .eslintrc.js '**/*.ts' --ignore-path '../../.gitignore'",
     "build": "rollup -c",
+    "build:deps": "lerna run --scope @firebase/remote-config --include-dependencies build",
     "dev": "rollup -c -w",
     "test": "run-p lint test:browser",
     "test:browser": "karma start --single-run",

--- a/packages/remote-config/package.json
+++ b/packages/remote-config/package.json
@@ -14,7 +14,7 @@
     "lint": "eslint -c .eslintrc.js '**/*.ts' --ignore-path '../../.gitignore'",
     "lint:fix": "eslint --fix -c .eslintrc.js '**/*.ts' --ignore-path '../../.gitignore'",
     "build": "rollup -c",
-    "build:deps": "lerna run --scope @firebase/remote-config --include-dependencies build",
+    "build:deps": "lerna run --scope @firebase/'{app,remote-config}' --include-dependencies build",
     "dev": "rollup -c -w",
     "test": "run-p lint test:browser",
     "test:browser": "karma start --single-run",

--- a/packages/rxfire/package.json
+++ b/packages/rxfire/package.json
@@ -24,6 +24,7 @@
     "lint": "eslint -c .eslintrc.js '**/*.ts' --ignore-path './.gitignore'",
     "lint:fix": "eslint --fix -c .eslintrc.js '**/*.ts' --ignore-path './.gitignore'",
     "build": "rollup -c",
+    "build:deps": "lerna run --scope rxfire --include-dependencies build",
     "dev": "rollup -c -w",
     "prepare": "yarn build",
     "test": "run-p lint test:browser",

--- a/packages/rxfire/package.json
+++ b/packages/rxfire/package.json
@@ -24,7 +24,7 @@
     "lint": "eslint -c .eslintrc.js '**/*.ts' --ignore-path './.gitignore'",
     "lint:fix": "eslint --fix -c .eslintrc.js '**/*.ts' --ignore-path './.gitignore'",
     "build": "rollup -c",
-    "build:deps": "lerna run --scope rxfire --include-dependencies build",
+    "build:deps": "lerna run --scope '{firebase,rxfire}' --include-dependencies build",
     "dev": "rollup -c -w",
     "prepare": "yarn build",
     "test": "run-p lint test:browser",

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -13,6 +13,7 @@
     "lint": "eslint -c .eslintrc.js '**/*.ts' --ignore-path '../../.gitignore'",
     "lint:fix": "eslint --fix -c .eslintrc.js '**/*.ts' --ignore-path '../../.gitignore'",
     "build": "rollup -c",
+    "build:deps": "lerna run --scope @firebase/storage --include-dependencies build",
     "dev": "rollup -c -w",
     "test": "run-p test:browser lint",
     "test:browser": "karma start --single-run",

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -13,7 +13,7 @@
     "lint": "eslint -c .eslintrc.js '**/*.ts' --ignore-path '../../.gitignore'",
     "lint:fix": "eslint --fix -c .eslintrc.js '**/*.ts' --ignore-path '../../.gitignore'",
     "build": "rollup -c",
-    "build:deps": "lerna run --scope @firebase/storage --include-dependencies build",
+    "build:deps": "lerna run --scope @firebase/'{app,storage}' --include-dependencies build",
     "dev": "rollup -c -w",
     "test": "run-p test:browser lint",
     "test:browser": "karma start --single-run",

--- a/packages/template/package.json
+++ b/packages/template/package.json
@@ -15,6 +15,7 @@
     "lint": "eslint -c .eslintrc.js '**/*.ts' --ignore-path '../../.gitignore'",
     "lint:fix": "eslint --fix -c .eslintrc.js '**/*.ts' --ignore-path '../../.gitignore'",
     "build": "rollup -c",
+    "build:deps": "lerna run --scope @firebase/template --include-dependencies build",
     "dev": "rollup -c -w",
     "test": "yarn type-check && run-p lint test:browser test:node",
     "test:browser": "karma start --single-run",

--- a/packages/template/package.json
+++ b/packages/template/package.json
@@ -15,7 +15,7 @@
     "lint": "eslint -c .eslintrc.js '**/*.ts' --ignore-path '../../.gitignore'",
     "lint:fix": "eslint --fix -c .eslintrc.js '**/*.ts' --ignore-path '../../.gitignore'",
     "build": "rollup -c",
-    "build:deps": "lerna run --scope @firebase/template --include-dependencies build",
+    "build:deps": "lerna run --scope @firebase/'{app,template}' --include-dependencies build",
     "dev": "rollup -c -w",
     "test": "yarn type-check && run-p lint test:browser test:node",
     "test:browser": "karma start --single-run",

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -9,6 +9,7 @@
   ],
   "scripts": {
     "build": "rollup -c",
+    "build:deps": "lerna run --scope @firebase/testing --include-dependencies build",
     "dev": "rollup -c -w",
     "test": "TS_NODE_CACHE=NO TS_NODE_COMPILER_OPTIONS='{\"module\":\"commonjs\"}' nyc --reporter lcovonly -- mocha 'test/{,!(browser)/**/}*.test.ts' --opts ../../config/mocha.node.opts",
     "prepare": "yarn build"

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -14,6 +14,7 @@
     "lint": "eslint -c .eslintrc.js '**/*.ts' --ignore-path '../../.gitignore'",
     "lint:fix": "eslint --fix -c .eslintrc.js '**/*.ts' --ignore-path '../../.gitignore'",
     "build": "rollup -c",
+    "build:deps": "lerna run --scope @firebase/util --include-dependencies build",
     "dev": "rollup -c -w",
     "test": "yarn type-check && run-p lint test:browser test:node",
     "type-check": "tsc -p . --noEmit",


### PR DESCRIPTION
Today, to work on a SDK, we usually run `yarn build` at the root folder first in order to build its dependencies. This step is quite slow because it is building the entire monorepo including repos that are not dependencies of the SDK.

This PR addresses the issue by adding a new npm script `build:deps` to each SDK, which builds the SDK and its dependencies in one command.

After this change, you don't need to run `yarn build` at the root folder any more. Instead, you would directly cd into your SDK directory and run `yarn build:deps`.

Build time improvement
`yarn build` at root -  234.25s
`yarn build:deps` in `pacakges/firestore` - 124.01s
`yarn build:deps` in `pacakges/database` - 33.34s

