### PR TITLE
Simplify logging

### DIFF
--- a/packages/firestore/src/api/database.ts
+++ b/packages/firestore/src/api/database.ts
@@ -68,10 +68,7 @@ import {
   validateStringEnum,
   valueDescription
 } from '../util/input_validation';
-// eslint-disable-next-line import/no-duplicates
-import * as log from '../util/log';
-// eslint-disable-next-line import/no-duplicates
-import { LogLevel } from '../util/log';
+import { DEBUG, ERROR, log, setLogLevel, SILENT } from '../util/log';
 import { AutoId } from '../util/misc';
 import * as objUtils from '../util/obj';
 import { Deferred, Rejecter, Resolver } from '../util/promise';
@@ -198,13 +195,18 @@ class FirestoreSettings {
     // Nobody should set timestampsInSnapshots anymore, but the error depends on
     // whether they set it to true or false...
     if (settings.timestampsInSnapshots === true) {
-      log.error(`
+      log(
+        ERROR,
+        `
   The timestampsInSnapshots setting now defaults to true and you no
   longer need to explicitly set it. In a future release, the setting
   will be removed entirely and so it is recommended that you remove it
-  from your firestore.settings() call now.`);
+  from your firestore.settings() call now.`
+      );
     } else if (settings.timestampsInSnapshots === false) {
-      log.error(`
+      log(
+        ERROR,
+        `
   The timestampsInSnapshots setting will soon be removed. YOU MUST UPDATE
   YOUR CODE.
 
@@ -223,7 +225,8 @@ class FirestoreSettings {
   timestamp.toDate();
 
   Please audit all existing usages of Date when you enable the new
-  behavior.`);
+  behavior.`
+      );
     }
     this.timestampsInSnapshots = objUtils.defaulted(
       settings.timestampsInSnapshots,
@@ -394,7 +397,8 @@ export class Firestore implements firestore.FirebaseFirestore, FirebaseService {
 
     if (settings) {
       if (settings.experimentalTabSynchronization !== undefined) {
-        log.error(
+        log(
+          ERROR,
           "The 'experimentalTabSynchronization' setting has been renamed to " +
             "'synchronizeTabs'. In a future release, the setting will be removed " +
             'and it is recommended that you update your ' +
@@ -653,31 +657,18 @@ export class Firestore implements firestore.FirebaseFirestore, FirebaseService {
     return new WriteBatch(this);
   }
 
-  static get logLevel(): firestore.LogLevel {
-    switch (log.getLogLevel()) {
-      case LogLevel.DEBUG:
-        return 'debug';
-      case LogLevel.ERROR:
-        return 'error';
-      case LogLevel.SILENT:
-        return 'silent';
-      default:
-        return fail('Unknown log level: ' + log.getLogLevel());
-    }
-  }
-
   static setLogLevel(level: firestore.LogLevel): void {
     validateExactNumberOfArgs('Firestore.setLogLevel', arguments, 1);
     validateArgType('Firestore.setLogLevel', 'non-empty string', 1, level);
     switch (level) {
       case 'debug':
-        log.setLogLevel(log.LogLevel.DEBUG);
+        setLogLevel(DEBUG);
         break;
       case 'error':
-        log.setLogLevel(log.LogLevel.ERROR);
+        setLogLevel(ERROR);
         break;
       case 'silent':
-        log.setLogLevel(log.LogLevel.SILENT);
+        setLogLevel(SILENT);
         break;
       default:
         throw new FirestoreError(

--- a/packages/firestore/src/api/database.ts
+++ b/packages/firestore/src/api/database.ts
@@ -68,7 +68,7 @@ import {
   validateStringEnum,
   valueDescription
 } from '../util/input_validation';
-import { DEBUG, ERROR, log, setLogLevel, SILENT } from '../util/log';
+import { logError, setLogLevel, LogLevel } from '../util/log';
 import { AutoId } from '../util/misc';
 import * as objUtils from '../util/obj';
 import { Deferred, Rejecter, Resolver } from '../util/promise';
@@ -195,18 +195,13 @@ class FirestoreSettings {
     // Nobody should set timestampsInSnapshots anymore, but the error depends on
     // whether they set it to true or false...
     if (settings.timestampsInSnapshots === true) {
-      log(
-        ERROR,
-        `
+      logError(`
   The timestampsInSnapshots setting now defaults to true and you no
   longer need to explicitly set it. In a future release, the setting
   will be removed entirely and so it is recommended that you remove it
-  from your firestore.settings() call now.`
-      );
+  from your firestore.settings() call now.`);
     } else if (settings.timestampsInSnapshots === false) {
-      log(
-        ERROR,
-        `
+      logError(`
   The timestampsInSnapshots setting will soon be removed. YOU MUST UPDATE
   YOUR CODE.
 
@@ -225,8 +220,7 @@ class FirestoreSettings {
   timestamp.toDate();
 
   Please audit all existing usages of Date when you enable the new
-  behavior.`
-      );
+  behavior.`);
     }
     this.timestampsInSnapshots = objUtils.defaulted(
       settings.timestampsInSnapshots,
@@ -397,8 +391,7 @@ export class Firestore implements firestore.FirebaseFirestore, FirebaseService {
 
     if (settings) {
       if (settings.experimentalTabSynchronization !== undefined) {
-        log(
-          ERROR,
+        logError(
           "The 'experimentalTabSynchronization' setting has been renamed to " +
             "'synchronizeTabs'. In a future release, the setting will be removed " +
             'and it is recommended that you update your ' +
@@ -662,13 +655,13 @@ export class Firestore implements firestore.FirebaseFirestore, FirebaseService {
     validateArgType('Firestore.setLogLevel', 'non-empty string', 1, level);
     switch (level) {
       case 'debug':
-        setLogLevel(DEBUG);
+        setLogLevel(LogLevel.DEBUG);
         break;
       case 'error':
-        setLogLevel(ERROR);
+        setLogLevel(LogLevel.ERROR);
         break;
       case 'silent':
-        setLogLevel(SILENT);
+        setLogLevel(LogLevel.SILENT);
         break;
       default:
         throw new FirestoreError(

--- a/packages/firestore/src/api/database.ts
+++ b/packages/firestore/src/api/database.ts
@@ -68,7 +68,7 @@ import {
   validateStringEnum,
   valueDescription
 } from '../util/input_validation';
-import {logError, setLogLevel, LogLevel, getLogLevel} from '../util/log';
+import { logError, setLogLevel, LogLevel, getLogLevel } from '../util/log';
 import { AutoId } from '../util/misc';
 import * as objUtils from '../util/obj';
 import { Deferred, Rejecter, Resolver } from '../util/promise';

--- a/packages/firestore/src/api/database.ts
+++ b/packages/firestore/src/api/database.ts
@@ -68,7 +68,7 @@ import {
   validateStringEnum,
   valueDescription
 } from '../util/input_validation';
-import { logError, setLogLevel, LogLevel } from '../util/log';
+import {logError, setLogLevel, LogLevel, getLogLevel} from '../util/log';
 import { AutoId } from '../util/misc';
 import * as objUtils from '../util/obj';
 import { Deferred, Rejecter, Resolver } from '../util/promise';
@@ -648,6 +648,19 @@ export class Firestore implements firestore.FirebaseFirestore, FirebaseService {
     this.ensureClientConfigured();
 
     return new WriteBatch(this);
+  }
+
+  static get logLevel(): firestore.LogLevel {
+    switch (getLogLevel()) {
+      case LogLevel.DEBUG:
+        return 'debug';
+      case LogLevel.ERROR:
+        return 'error';
+      case LogLevel.SILENT:
+        return 'silent';
+      default:
+        return fail('Unknown log level: ' + getLogLevel());
+    }
   }
 
   static setLogLevel(level: firestore.LogLevel): void {

--- a/packages/firestore/src/api/database.ts
+++ b/packages/firestore/src/api/database.ts
@@ -654,12 +654,11 @@ export class Firestore implements firestore.FirebaseFirestore, FirebaseService {
     switch (getLogLevel()) {
       case LogLevel.DEBUG:
         return 'debug';
-      case LogLevel.ERROR:
-        return 'error';
       case LogLevel.SILENT:
         return 'silent';
       default:
-        return fail('Unknown log level: ' + getLogLevel());
+        // The default log level is error
+        return 'error';
     }
   }
 

--- a/packages/firestore/src/api/user_data_writer.ts
+++ b/packages/firestore/src/api/user_data_writer.ts
@@ -19,8 +19,6 @@ import * as firestore from '@firebase/firestore-types';
 
 import * as api from '../protos/firestore_proto_api';
 
-import { log, ERROR } from '../util/log';
-
 import { DocumentReference, Firestore } from './database';
 import { Blob } from './blob';
 import { GeoPoint } from './geo_point';
@@ -42,6 +40,7 @@ import { forEach } from '../util/obj';
 import { TypeOrder } from '../model/field_value';
 import { ResourcePath } from '../model/path';
 import { isValidResourceName } from '../remote/serializer';
+import { log, ERROR } from '../util/log';
 
 export type ServerTimestampBehavior = 'estimate' | 'previous' | 'none';
 

--- a/packages/firestore/src/api/user_data_writer.ts
+++ b/packages/firestore/src/api/user_data_writer.ts
@@ -40,7 +40,7 @@ import { forEach } from '../util/obj';
 import { TypeOrder } from '../model/field_value';
 import { ResourcePath } from '../model/path';
 import { isValidResourceName } from '../remote/serializer';
-import { log, ERROR } from '../util/log';
+import { logError } from '../util/log';
 
 export type ServerTimestampBehavior = 'estimate' | 'previous' | 'none';
 
@@ -139,8 +139,7 @@ export class UserDataWriter<T = firestore.DocumentData> {
 
     if (!databaseId.isEqual(this.firestore._databaseId)) {
       // TODO(b/64130202): Somehow support foreign references.
-      log(
-        ERROR,
+      logError(
         `Document ${key} contains a document ` +
           `reference within a different database (` +
           `${databaseId.projectId}/${databaseId.database}) which is not ` +

--- a/packages/firestore/src/api/user_data_writer.ts
+++ b/packages/firestore/src/api/user_data_writer.ts
@@ -18,7 +18,8 @@
 import * as firestore from '@firebase/firestore-types';
 
 import * as api from '../protos/firestore_proto_api';
-import * as log from '../util/log';
+
+import { log, ERROR } from '../util/log';
 
 import { DocumentReference, Firestore } from './database';
 import { Blob } from './blob';
@@ -139,7 +140,8 @@ export class UserDataWriter<T = firestore.DocumentData> {
 
     if (!databaseId.isEqual(this.firestore._databaseId)) {
       // TODO(b/64130202): Somehow support foreign references.
-      log.error(
+      log(
+        ERROR,
         `Document ${key} contains a document ` +
           `reference within a different database (` +
           `${databaseId.projectId}/${databaseId.database}) which is not ` +

--- a/packages/firestore/src/core/firestore_client.ts
+++ b/packages/firestore/src/core/firestore_client.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2017 Google Inc.
+ * Copyright 2017 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,7 +33,7 @@ import { Datastore } from '../remote/datastore';
 import { RemoteStore } from '../remote/remote_store';
 import { AsyncQueue } from '../util/async_queue';
 import { Code, FirestoreError } from '../util/error';
-import { debug } from '../util/log';
+import { DEBUG, log } from '../util/log';
 import { Deferred } from '../util/promise';
 import {
   EventManager,
@@ -324,7 +324,7 @@ export class FirestoreClient {
    * implementation is available in this.persistence.
    */
   private initializeRest(user: User): Promise<void> {
-    debug(LOG_TAG, 'Initializing. user=', user.uid);
+    log(DEBUG, LOG_TAG, 'Initializing. user=', user.uid);
     return this.platform
       .loadConnection(this.databaseInfo)
       .then(async connection => {
@@ -406,7 +406,7 @@ export class FirestoreClient {
   private handleCredentialChange(user: User): Promise<void> {
     this.asyncQueue.verifyOperationInProgress();
 
-    debug(LOG_TAG, 'Credential Changed. Current user: ' + user.uid);
+    log(DEBUG, LOG_TAG, 'Credential Changed. Current user: ' + user.uid);
     return this.syncEngine.handleCredentialChange(user);
   }
 

--- a/packages/firestore/src/core/firestore_client.ts
+++ b/packages/firestore/src/core/firestore_client.ts
@@ -33,7 +33,7 @@ import { Datastore } from '../remote/datastore';
 import { RemoteStore } from '../remote/remote_store';
 import { AsyncQueue } from '../util/async_queue';
 import { Code, FirestoreError } from '../util/error';
-import { DEBUG, log } from '../util/log';
+import { logDebug } from '../util/log';
 import { Deferred } from '../util/promise';
 import {
   EventManager,
@@ -324,7 +324,7 @@ export class FirestoreClient {
    * implementation is available in this.persistence.
    */
   private initializeRest(user: User): Promise<void> {
-    log(DEBUG, LOG_TAG, 'Initializing. user=', user.uid);
+    logDebug(LOG_TAG, 'Initializing. user=', user.uid);
     return this.platform
       .loadConnection(this.databaseInfo)
       .then(async connection => {
@@ -406,7 +406,7 @@ export class FirestoreClient {
   private handleCredentialChange(user: User): Promise<void> {
     this.asyncQueue.verifyOperationInProgress();
 
-    log(DEBUG, LOG_TAG, 'Credential Changed. Current user: ' + user.uid);
+    logDebug(LOG_TAG, 'Credential Changed. Current user: ' + user.uid);
     return this.syncEngine.handleCredentialChange(user);
   }
 

--- a/packages/firestore/src/core/sync_engine.ts
+++ b/packages/firestore/src/core/sync_engine.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2017 Google Inc.
+ * Copyright 2017 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,7 +34,7 @@ import { RemoteStore } from '../remote/remote_store';
 import { RemoteSyncer } from '../remote/remote_syncer';
 import { assert, fail } from '../util/assert';
 import { Code, FirestoreError } from '../util/error';
-import * as log from '../util/log';
+import { DEBUG, log } from '../util/log';
 import { primitiveComparator } from '../util/misc';
 import { ObjectMap } from '../util/obj_map';
 import { Deferred } from '../util/promise';
@@ -535,7 +535,7 @@ export class SyncEngine implements RemoteSyncer, SharedClientStateSyncer {
       // had, we would have cached the affected documents), and so we will just
       // see any resulting document changes via normal remote document updates
       // as applicable.
-      log.debug(LOG_TAG, 'Cannot apply mutation batch with id: ' + batchId);
+      log(DEBUG, LOG_TAG, 'Cannot apply mutation batch with id: ' + batchId);
       return;
     }
 
@@ -611,7 +611,8 @@ export class SyncEngine implements RemoteSyncer, SharedClientStateSyncer {
    */
   async registerPendingWritesCallback(callback: Deferred<void>): Promise<void> {
     if (!this.remoteStore.canUseNetwork()) {
-      log.debug(
+      log(
+        DEBUG,
         LOG_TAG,
         'The network is disabled. The task returned by ' +
           "'awaitPendingWrites()' will not complete until the network is enabled."
@@ -751,7 +752,7 @@ export class SyncEngine implements RemoteSyncer, SharedClientStateSyncer {
         this.limboDocumentRefs.addReference(limboChange.key, targetId);
         this.trackLimboChange(limboChange);
       } else if (limboChange instanceof RemovedLimboDocument) {
-        log.debug(LOG_TAG, 'Document no longer in limbo: ' + limboChange.key);
+        log(DEBUG, LOG_TAG, 'Document no longer in limbo: ' + limboChange.key);
         this.limboDocumentRefs.removeReference(limboChange.key, targetId);
         const isReferenced = this.limboDocumentRefs.containsKey(
           limboChange.key
@@ -769,7 +770,7 @@ export class SyncEngine implements RemoteSyncer, SharedClientStateSyncer {
   private trackLimboChange(limboChange: AddedLimboDocument): void {
     const key = limboChange.key;
     if (!this.limboTargetsByKey.get(key)) {
-      log.debug(LOG_TAG, 'New document in limbo: ' + key);
+      log(DEBUG, LOG_TAG, 'New document in limbo: ' + key);
       const limboTargetId = this.limboTargetIdGenerator.next();
       const query = Query.atPath(key.path);
       this.limboResolutionsByTarget[limboTargetId] = new LimboResolution(key);
@@ -1047,7 +1048,7 @@ export class SyncEngine implements RemoteSyncer, SharedClientStateSyncer {
     if (this.isPrimary) {
       // If we receive a target state notification via WebStorage, we are
       // either already secondary or another tab has taken the primary lease.
-      log.debug(LOG_TAG, 'Ignoring unexpected query state notification.');
+      log(DEBUG, LOG_TAG, 'Ignoring unexpected query state notification.');
       return;
     }
 

--- a/packages/firestore/src/core/sync_engine.ts
+++ b/packages/firestore/src/core/sync_engine.ts
@@ -34,7 +34,7 @@ import { RemoteStore } from '../remote/remote_store';
 import { RemoteSyncer } from '../remote/remote_syncer';
 import { assert, fail } from '../util/assert';
 import { Code, FirestoreError } from '../util/error';
-import { DEBUG, log } from '../util/log';
+import { logDebug } from '../util/log';
 import { primitiveComparator } from '../util/misc';
 import { ObjectMap } from '../util/obj_map';
 import { Deferred } from '../util/promise';
@@ -535,7 +535,7 @@ export class SyncEngine implements RemoteSyncer, SharedClientStateSyncer {
       // had, we would have cached the affected documents), and so we will just
       // see any resulting document changes via normal remote document updates
       // as applicable.
-      log(DEBUG, LOG_TAG, 'Cannot apply mutation batch with id: ' + batchId);
+      logDebug(LOG_TAG, 'Cannot apply mutation batch with id: ' + batchId);
       return;
     }
 
@@ -611,8 +611,7 @@ export class SyncEngine implements RemoteSyncer, SharedClientStateSyncer {
    */
   async registerPendingWritesCallback(callback: Deferred<void>): Promise<void> {
     if (!this.remoteStore.canUseNetwork()) {
-      log(
-        DEBUG,
+      logDebug(
         LOG_TAG,
         'The network is disabled. The task returned by ' +
           "'awaitPendingWrites()' will not complete until the network is enabled."
@@ -752,7 +751,7 @@ export class SyncEngine implements RemoteSyncer, SharedClientStateSyncer {
         this.limboDocumentRefs.addReference(limboChange.key, targetId);
         this.trackLimboChange(limboChange);
       } else if (limboChange instanceof RemovedLimboDocument) {
-        log(DEBUG, LOG_TAG, 'Document no longer in limbo: ' + limboChange.key);
+        logDebug(LOG_TAG, 'Document no longer in limbo: ' + limboChange.key);
         this.limboDocumentRefs.removeReference(limboChange.key, targetId);
         const isReferenced = this.limboDocumentRefs.containsKey(
           limboChange.key
@@ -770,7 +769,7 @@ export class SyncEngine implements RemoteSyncer, SharedClientStateSyncer {
   private trackLimboChange(limboChange: AddedLimboDocument): void {
     const key = limboChange.key;
     if (!this.limboTargetsByKey.get(key)) {
-      log(DEBUG, LOG_TAG, 'New document in limbo: ' + key);
+      logDebug(LOG_TAG, 'New document in limbo: ' + key);
       const limboTargetId = this.limboTargetIdGenerator.next();
       const query = Query.atPath(key.path);
       this.limboResolutionsByTarget[limboTargetId] = new LimboResolution(key);
@@ -1048,7 +1047,7 @@ export class SyncEngine implements RemoteSyncer, SharedClientStateSyncer {
     if (this.isPrimary) {
       // If we receive a target state notification via WebStorage, we are
       // either already secondary or another tab has taken the primary lease.
-      log(DEBUG, LOG_TAG, 'Ignoring unexpected query state notification.');
+      logDebug(LOG_TAG, 'Ignoring unexpected query state notification.');
       return;
     }
 

--- a/packages/firestore/src/local/index_free_query_engine.ts
+++ b/packages/firestore/src/local/index_free_query_engine.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2019 Google Inc.
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,7 +28,7 @@ import {
 } from '../model/collections';
 import { Document } from '../model/document';
 import { assert } from '../util/assert';
-import { debug, getLogLevel, LogLevel } from '../util/log';
+import { DEBUG, getLogLevel, log } from '../util/log';
 import { SortedSet } from '../util/sorted_set';
 
 // TOOD(b/140938512): Drop SimpleQueryEngine and rename IndexFreeQueryEngine.
@@ -98,8 +98,9 @@ export class IndexFreeQueryEngine implements QueryEngine {
           return this.executeFullCollectionScan(transaction, query);
         }
 
-        if (getLogLevel() <= LogLevel.DEBUG) {
-          debug(
+        if (getLogLevel() <= DEBUG) {
+          log(
+            DEBUG,
             'IndexFreeQueryEngine',
             'Re-using previous result from %s to execute query: %s',
             lastLimboFreeSnapshotVersion.toString(),
@@ -193,8 +194,9 @@ export class IndexFreeQueryEngine implements QueryEngine {
     transaction: PersistenceTransaction,
     query: Query
   ): PersistencePromise<DocumentMap> {
-    if (getLogLevel() <= LogLevel.DEBUG) {
-      debug(
+    if (getLogLevel() <= DEBUG) {
+      log(
+        DEBUG,
         'IndexFreeQueryEngine',
         'Using full collection scan to execute query: %s',
         query.toString()

--- a/packages/firestore/src/local/index_free_query_engine.ts
+++ b/packages/firestore/src/local/index_free_query_engine.ts
@@ -19,7 +19,7 @@ import { QueryEngine } from './query_engine';
 import { LocalDocumentsView } from './local_documents_view';
 import { PersistenceTransaction } from './persistence';
 import { PersistencePromise } from './persistence_promise';
-import { Query, LimitType } from '../core/query';
+import { LimitType, Query } from '../core/query';
 import { SnapshotVersion } from '../core/snapshot_version';
 import {
   DocumentKeySet,
@@ -28,7 +28,7 @@ import {
 } from '../model/collections';
 import { Document } from '../model/document';
 import { assert } from '../util/assert';
-import { DEBUG, getLogLevel, log } from '../util/log';
+import { getLogLevel, LogLevel, logDebug } from '../util/log';
 import { SortedSet } from '../util/sorted_set';
 
 // TOOD(b/140938512): Drop SimpleQueryEngine and rename IndexFreeQueryEngine.
@@ -98,9 +98,8 @@ export class IndexFreeQueryEngine implements QueryEngine {
           return this.executeFullCollectionScan(transaction, query);
         }
 
-        if (getLogLevel() <= DEBUG) {
-          log(
-            DEBUG,
+        if (getLogLevel() <= LogLevel.DEBUG) {
+          logDebug(
             'IndexFreeQueryEngine',
             'Re-using previous result from %s to execute query: %s',
             lastLimboFreeSnapshotVersion.toString(),
@@ -194,9 +193,8 @@ export class IndexFreeQueryEngine implements QueryEngine {
     transaction: PersistenceTransaction,
     query: Query
   ): PersistencePromise<DocumentMap> {
-    if (getLogLevel() <= DEBUG) {
-      log(
-        DEBUG,
+    if (getLogLevel() <= LogLevel.DEBUG) {
+      logDebug(
         'IndexFreeQueryEngine',
         'Using full collection scan to execute query: %s',
         query.toString()

--- a/packages/firestore/src/local/indexeddb_persistence.ts
+++ b/packages/firestore/src/local/indexeddb_persistence.ts
@@ -26,7 +26,7 @@ import { JsonProtoSerializer } from '../remote/serializer';
 import { assert, fail } from '../util/assert';
 import { AsyncQueue, TimerId } from '../util/async_queue';
 import { Code, FirestoreError } from '../util/error';
-import * as log from '../util/log';
+import { DEBUG, ERROR, log } from '../util/log';
 import { CancelablePromise } from '../util/promise';
 
 import { decode, encode, EncodedResourcePath } from './encoded_resource_path';
@@ -427,7 +427,8 @@ export class IndexedDbPersistence implements Persistence {
           throw e;
         }
 
-        log.debug(
+        log(
+          DEBUG,
           LOG_TAG,
           'Releasing owner lease after error during lease refresh',
           e
@@ -634,7 +635,8 @@ export class IndexedDbPersistence implements Persistence {
       })
       .next(canActAsPrimary => {
         if (this.isPrimary !== canActAsPrimary) {
-          log.debug(
+          log(
+            DEBUG,
             LOG_TAG,
             `Client ${
               canActAsPrimary ? 'is' : 'is not'
@@ -760,7 +762,7 @@ export class IndexedDbPersistence implements Persistence {
       transaction: PersistenceTransaction
     ) => PersistencePromise<T>
   ): Promise<T> {
-    log.debug(LOG_TAG, 'Starting transaction:', action);
+    log(DEBUG, LOG_TAG, 'Starting transaction:', action);
 
     const simpleDbMode = mode === 'readonly' ? 'readonly' : 'readwrite';
 
@@ -790,7 +792,8 @@ export class IndexedDbPersistence implements Persistence {
             })
             .next(holdsPrimaryLease => {
               if (!holdsPrimaryLease) {
-                log.error(
+                log(
+                  ERROR,
                   `Failed to obtain primary lease for action '${action}'.`
                 );
                 this.isPrimary = false;
@@ -897,7 +900,7 @@ export class IndexedDbPersistence implements Persistence {
     const store = primaryClientStore(txn);
     return store.get(DbPrimaryClient.key).next(primaryClient => {
       if (this.isLocalClient(primaryClient)) {
-        log.debug(LOG_TAG, 'Releasing primary lease.');
+        log(DEBUG, LOG_TAG, 'Releasing primary lease.');
         return store.delete(DbPrimaryClient.key);
       } else {
         return PersistencePromise.resolve();
@@ -913,7 +916,8 @@ export class IndexedDbPersistence implements Persistence {
     if (updateTimeMs < minAcceptable) {
       return false;
     } else if (updateTimeMs > maxAcceptable) {
-      log.error(
+      log(
+        ERROR,
         `Detected an update time that is in the future: ${updateTimeMs} > ${maxAcceptable}`
       );
       return false;
@@ -1007,7 +1011,8 @@ export class IndexedDbPersistence implements Persistence {
       const isZombied =
         this.webStorage.getItem(this.zombiedClientLocalStorageKey(clientId)) !==
         null;
-      log.debug(
+      log(
+        DEBUG,
         LOG_TAG,
         `Client '${clientId}' ${
           isZombied ? 'is' : 'is not'
@@ -1016,7 +1021,7 @@ export class IndexedDbPersistence implements Persistence {
       return isZombied;
     } catch (e) {
       // Gracefully handle if LocalStorage isn't working.
-      log.error(LOG_TAG, 'Failed to get zombied client id.', e);
+      log(ERROR, LOG_TAG, 'Failed to get zombied client id.', e);
       return false;
     }
   }
@@ -1033,7 +1038,7 @@ export class IndexedDbPersistence implements Persistence {
       );
     } catch (e) {
       // Gracefully handle if LocalStorage isn't available / working.
-      log.error('Failed to set zombie client id.', e);
+      log(ERROR, 'Failed to set zombie client id.', e);
     }
   }
 

--- a/packages/firestore/src/local/local_store.ts
+++ b/packages/firestore/src/local/local_store.ts
@@ -39,7 +39,7 @@ import {
 import { RemoteEvent, TargetChange } from '../remote/remote_event';
 import { assert } from '../util/assert';
 import { Code, FirestoreError } from '../util/error';
-import { DEBUG, log } from '../util/log';
+import { logDebug } from '../util/log';
 import { primitiveComparator } from '../util/misc';
 import * as objUtils from '../util/obj';
 import { ObjectMap } from '../util/obj_map';
@@ -610,8 +610,7 @@ export class LocalStore {
                 documentBuffer.addEntry(doc, remoteVersion);
                 changedDocs = changedDocs.insert(key, doc);
               } else {
-                log(
-                  DEBUG,
+                logDebug(
                   LOG_TAG,
                   'Ignoring outdated watch update for ',
                   key,
@@ -1120,7 +1119,7 @@ export async function ignoreIfPrimaryLeaseLoss(
     err.code === Code.FAILED_PRECONDITION &&
     err.message === PRIMARY_LEASE_LOST_ERROR_MSG
   ) {
-    log(DEBUG, LOG_TAG, 'Unexpectedly lost primary lease');
+    logDebug(LOG_TAG, 'Unexpectedly lost primary lease');
   } else {
     throw err;
   }

--- a/packages/firestore/src/local/local_store.ts
+++ b/packages/firestore/src/local/local_store.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2017 Google Inc.
+ * Copyright 2017 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,7 +39,7 @@ import {
 import { RemoteEvent, TargetChange } from '../remote/remote_event';
 import { assert } from '../util/assert';
 import { Code, FirestoreError } from '../util/error';
-import * as log from '../util/log';
+import { DEBUG, log } from '../util/log';
 import { primitiveComparator } from '../util/misc';
 import * as objUtils from '../util/obj';
 import { ObjectMap } from '../util/obj_map';
@@ -610,7 +610,8 @@ export class LocalStore {
                 documentBuffer.addEntry(doc, remoteVersion);
                 changedDocs = changedDocs.insert(key, doc);
               } else {
-                log.debug(
+                log(
+                  DEBUG,
                   LOG_TAG,
                   'Ignoring outdated watch update for ',
                   key,
@@ -1119,7 +1120,7 @@ export async function ignoreIfPrimaryLeaseLoss(
     err.code === Code.FAILED_PRECONDITION &&
     err.message === PRIMARY_LEASE_LOST_ERROR_MSG
   ) {
-    log.debug(LOG_TAG, 'Unexpectedly lost primary lease');
+    log(DEBUG, LOG_TAG, 'Unexpectedly lost primary lease');
   } else {
     throw err;
   }

--- a/packages/firestore/src/local/lru_garbage_collector.ts
+++ b/packages/firestore/src/local/lru_garbage_collector.ts
@@ -19,7 +19,7 @@ import { ListenSequence } from '../core/listen_sequence';
 import { ListenSequenceNumber, TargetId } from '../core/types';
 import { assert } from '../util/assert';
 import { AsyncQueue, TimerId } from '../util/async_queue';
-import { DEBUG, getLogLevel, log } from '../util/log';
+import { getLogLevel, logDebug, LogLevel } from '../util/log';
 import { primitiveComparator } from '../util/misc';
 import { CancelablePromise } from '../util/promise';
 import { SortedMap } from '../util/sorted_map';
@@ -252,8 +252,7 @@ export class LruScheduler {
   private scheduleGC(localStore: LocalStore): void {
     assert(this.gcTask === null, 'Cannot schedule GC while a task is pending');
     const delay = this.hasRun ? REGULAR_GC_DELAY_MS : INITIAL_GC_DELAY_MS;
-    log(
-      DEBUG,
+    logDebug(
       'LruGarbageCollector',
       `Garbage collection scheduled in ${delay}ms`
     );
@@ -340,14 +339,13 @@ export class LruGarbageCollector {
     if (
       this.params.cacheSizeCollectionThreshold === LruParams.COLLECTION_DISABLED
     ) {
-      log(DEBUG, 'LruGarbageCollector', 'Garbage collection skipped; disabled');
+      logDebug('LruGarbageCollector', 'Garbage collection skipped; disabled');
       return PersistencePromise.resolve(GC_DID_NOT_RUN);
     }
 
     return this.getCacheSize(txn).next(cacheSize => {
       if (cacheSize < this.params.cacheSizeCollectionThreshold) {
-        log(
-          DEBUG,
+        logDebug(
           'LruGarbageCollector',
           `Garbage collection skipped; Cache size ${cacheSize} ` +
             `is lower than threshold ${this.params.cacheSizeCollectionThreshold}`
@@ -379,8 +377,7 @@ export class LruGarbageCollector {
       .next(sequenceNumbers => {
         // Cap at the configured max
         if (sequenceNumbers > this.params.maximumSequenceNumbersToCollect) {
-          log(
-            DEBUG,
+          logDebug(
             'LruGarbageCollector',
             'Capping sequence numbers to collect down ' +
               `to the maximum of ${this.params.maximumSequenceNumbersToCollect} ` +
@@ -414,7 +411,7 @@ export class LruGarbageCollector {
       .next(documentsRemoved => {
         removedDocumentsTs = Date.now();
 
-        if (getLogLevel() <= DEBUG) {
+        if (getLogLevel() <= LogLevel.DEBUG) {
           const desc =
             'LRU Garbage Collection\n' +
             `\tCounted targets in ${countedTargetsTs - startTs}ms\n` +
@@ -425,7 +422,7 @@ export class LruGarbageCollector {
             `\tRemoved ${documentsRemoved} documents in ` +
             `${removedDocumentsTs - removedTargetsTs}ms\n` +
             `Total Duration: ${removedDocumentsTs - startTs}ms`;
-          log(DEBUG, 'LruGarbageCollector', desc);
+          logDebug('LruGarbageCollector', desc);
         }
 
         return PersistencePromise.resolve<LruResults>({

--- a/packages/firestore/src/local/memory_persistence.ts
+++ b/packages/firestore/src/local/memory_persistence.ts
@@ -20,7 +20,7 @@ import { Document, MaybeDocument } from '../model/document';
 import { DocumentKey } from '../model/document_key';
 import { assert, fail } from '../util/assert';
 import { Code, FirestoreError } from '../util/error';
-import { DEBUG, log } from '../util/log';
+import { logDebug } from '../util/log';
 import * as obj from '../util/obj';
 import { ObjectMap } from '../util/obj_map';
 import { encode } from './encoded_resource_path';
@@ -172,7 +172,7 @@ export class MemoryPersistence implements Persistence {
       transaction: PersistenceTransaction
     ) => PersistencePromise<T>
   ): Promise<T> {
-    log(DEBUG, LOG_TAG, 'Starting transaction:', action);
+    logDebug(LOG_TAG, 'Starting transaction:', action);
     const txn = new MemoryTransaction(this.listenSequence.next());
     this.referenceDelegate.onTransactionStarted();
     return transactionOperation(txn)

--- a/packages/firestore/src/local/memory_persistence.ts
+++ b/packages/firestore/src/local/memory_persistence.ts
@@ -20,7 +20,7 @@ import { Document, MaybeDocument } from '../model/document';
 import { DocumentKey } from '../model/document_key';
 import { assert, fail } from '../util/assert';
 import { Code, FirestoreError } from '../util/error';
-import { debug } from '../util/log';
+import { DEBUG, log } from '../util/log';
 import * as obj from '../util/obj';
 import { ObjectMap } from '../util/obj_map';
 import { encode } from './encoded_resource_path';
@@ -172,7 +172,7 @@ export class MemoryPersistence implements Persistence {
       transaction: PersistenceTransaction
     ) => PersistencePromise<T>
   ): Promise<T> {
-    debug(LOG_TAG, 'Starting transaction:', action);
+    log(DEBUG, LOG_TAG, 'Starting transaction:', action);
     const txn = new MemoryTransaction(this.listenSequence.next());
     this.referenceDelegate.onTransactionStarted();
     return transactionOperation(txn)

--- a/packages/firestore/src/local/shared_client_state.ts
+++ b/packages/firestore/src/local/shared_client_state.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2018 Google Inc.
+ * Copyright 2018 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,7 +29,7 @@ import { Platform } from '../platform/platform';
 import { assert } from '../util/assert';
 import { AsyncQueue } from '../util/async_queue';
 import { Code, FirestoreError } from '../util/error';
-import { debug, error } from '../util/log';
+import { log, ERROR, DEBUG } from '../util/log';
 import * as objUtils from '../util/obj';
 import { SortedSet } from '../util/sorted_set';
 import { isSafeInteger } from '../util/types';
@@ -233,7 +233,8 @@ export class MutationMetadata {
         firestoreError
       );
     } else {
-      error(
+      log(
+        ERROR,
         LOG_TAG,
         `Failed to parse mutation state for ID '${batchId}': ${value}`
       );
@@ -313,7 +314,8 @@ export class QueryTargetMetadata {
         firestoreError
       );
     } else {
-      error(
+      log(
+        ERROR,
         LOG_TAG,
         `Failed to parse target state for ID '${targetId}': ${value}`
       );
@@ -383,7 +385,8 @@ class RemoteClientState implements ClientState {
     if (validData) {
       return new RemoteClientState(clientId, activeTargetIdsSet);
     } else {
-      error(
+      log(
+        ERROR,
         LOG_TAG,
         `Failed to parse client data for instance '${clientId}': ${value}`
       );
@@ -419,7 +422,7 @@ export class SharedOnlineState {
         onlineState.onlineState as OnlineState
       );
     } else {
-      error(LOG_TAG, `Failed to parse online state: ${value}`);
+      log(ERROR, LOG_TAG, `Failed to parse online state: ${value}`);
       return null;
     }
   }
@@ -729,26 +732,27 @@ export class WebStorageSharedClientState implements SharedClientState {
 
   private getItem(key: string): string | null {
     const value = this.storage.getItem(key);
-    debug(LOG_TAG, 'READ', key, value);
+    log(DEBUG, LOG_TAG, 'READ', key, value);
     return value;
   }
 
   private setItem(key: string, value: string): void {
-    debug(LOG_TAG, 'SET', key, value);
+    log(DEBUG, LOG_TAG, 'SET', key, value);
     this.storage.setItem(key, value);
   }
 
   private removeItem(key: string): void {
-    debug(LOG_TAG, 'REMOVE', key);
+    log(DEBUG, LOG_TAG, 'REMOVE', key);
     this.storage.removeItem(key);
   }
 
   private handleWebStorageEvent(event: StorageEvent): void {
     if (event.storageArea === this.storage) {
-      debug(LOG_TAG, 'EVENT', event.key, event.newValue);
+      log(DEBUG, LOG_TAG, 'EVENT', event.key, event.newValue);
 
       if (event.key === this.localClientStorageKey) {
-        error(
+        log(
+          ERROR,
           'Received WebStorage notification for local change. Another client might have ' +
             'garbage-collected our state'
         );
@@ -948,7 +952,8 @@ export class WebStorageSharedClientState implements SharedClientState {
     mutationBatch: MutationMetadata
   ): Promise<void> {
     if (mutationBatch.user.uid !== this.currentUser.uid) {
-      debug(
+      log(
+        DEBUG,
         LOG_TAG,
         `Ignoring mutation for non-active user ${mutationBatch.user.uid}`
       );
@@ -1029,7 +1034,7 @@ function fromWebStorageSequenceNumber(
       assert(typeof parsed === 'number', 'Found non-numeric sequence number');
       sequenceNumber = parsed;
     } catch (e) {
-      error(LOG_TAG, 'Failed to read sequence number from WebStorage', e);
+      log(ERROR, LOG_TAG, 'Failed to read sequence number from WebStorage', e);
     }
   }
   return sequenceNumber;

--- a/packages/firestore/src/local/shared_client_state.ts
+++ b/packages/firestore/src/local/shared_client_state.ts
@@ -29,7 +29,7 @@ import { Platform } from '../platform/platform';
 import { assert } from '../util/assert';
 import { AsyncQueue } from '../util/async_queue';
 import { Code, FirestoreError } from '../util/error';
-import { log, ERROR, DEBUG } from '../util/log';
+import { logError, logDebug } from '../util/log';
 import * as objUtils from '../util/obj';
 import { SortedSet } from '../util/sorted_set';
 import { isSafeInteger } from '../util/types';
@@ -233,8 +233,7 @@ export class MutationMetadata {
         firestoreError
       );
     } else {
-      log(
-        ERROR,
+      logError(
         LOG_TAG,
         `Failed to parse mutation state for ID '${batchId}': ${value}`
       );
@@ -314,8 +313,7 @@ export class QueryTargetMetadata {
         firestoreError
       );
     } else {
-      log(
-        ERROR,
+      logError(
         LOG_TAG,
         `Failed to parse target state for ID '${targetId}': ${value}`
       );
@@ -385,8 +383,7 @@ class RemoteClientState implements ClientState {
     if (validData) {
       return new RemoteClientState(clientId, activeTargetIdsSet);
     } else {
-      log(
-        ERROR,
+      logError(
         LOG_TAG,
         `Failed to parse client data for instance '${clientId}': ${value}`
       );
@@ -422,7 +419,7 @@ export class SharedOnlineState {
         onlineState.onlineState as OnlineState
       );
     } else {
-      log(ERROR, LOG_TAG, `Failed to parse online state: ${value}`);
+      logError(LOG_TAG, `Failed to parse online state: ${value}`);
       return null;
     }
   }
@@ -732,27 +729,26 @@ export class WebStorageSharedClientState implements SharedClientState {
 
   private getItem(key: string): string | null {
     const value = this.storage.getItem(key);
-    log(DEBUG, LOG_TAG, 'READ', key, value);
+    logDebug(LOG_TAG, 'READ', key, value);
     return value;
   }
 
   private setItem(key: string, value: string): void {
-    log(DEBUG, LOG_TAG, 'SET', key, value);
+    logDebug(LOG_TAG, 'SET', key, value);
     this.storage.setItem(key, value);
   }
 
   private removeItem(key: string): void {
-    log(DEBUG, LOG_TAG, 'REMOVE', key);
+    logDebug(LOG_TAG, 'REMOVE', key);
     this.storage.removeItem(key);
   }
 
   private handleWebStorageEvent(event: StorageEvent): void {
     if (event.storageArea === this.storage) {
-      log(DEBUG, LOG_TAG, 'EVENT', event.key, event.newValue);
+      logDebug(LOG_TAG, 'EVENT', event.key, event.newValue);
 
       if (event.key === this.localClientStorageKey) {
-        log(
-          ERROR,
+        logError(
           'Received WebStorage notification for local change. Another client might have ' +
             'garbage-collected our state'
         );
@@ -952,8 +948,7 @@ export class WebStorageSharedClientState implements SharedClientState {
     mutationBatch: MutationMetadata
   ): Promise<void> {
     if (mutationBatch.user.uid !== this.currentUser.uid) {
-      log(
-        DEBUG,
+      logDebug(
         LOG_TAG,
         `Ignoring mutation for non-active user ${mutationBatch.user.uid}`
       );
@@ -1034,7 +1029,7 @@ function fromWebStorageSequenceNumber(
       assert(typeof parsed === 'number', 'Found non-numeric sequence number');
       sequenceNumber = parsed;
     } catch (e) {
-      log(ERROR, LOG_TAG, 'Failed to read sequence number from WebStorage', e);
+      logError(LOG_TAG, 'Failed to read sequence number from WebStorage', e);
     }
   }
   return sequenceNumber;

--- a/packages/firestore/src/local/simple_db.ts
+++ b/packages/firestore/src/local/simple_db.ts
@@ -18,7 +18,7 @@
 import { getUA } from '@firebase/util';
 import { assert } from '../util/assert';
 import { Code, FirestoreError } from '../util/error';
-import { DEBUG, log, ERROR } from '../util/log';
+import { logDebug, logError } from '../util/log';
 import { Deferred } from '../util/promise';
 import { SCHEMA_VERSION } from './indexeddb_schema';
 import { PersistencePromise } from './persistence_promise';
@@ -68,7 +68,7 @@ export class SimpleDb {
       SimpleDb.isAvailable(),
       'IndexedDB not supported in current environment.'
     );
-    log(DEBUG, LOG_TAG, 'Opening database:', name);
+    logDebug(LOG_TAG, 'Opening database:', name);
     return new PersistencePromise<SimpleDb>((resolve, reject) => {
       // TODO(mikelehen): Investigate browser compatibility.
       // https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API/Using_IndexedDB
@@ -111,8 +111,7 @@ export class SimpleDb {
       };
 
       request.onupgradeneeded = (event: IDBVersionChangeEvent) => {
-        log(
-          DEBUG,
+        logDebug(
           LOG_TAG,
           'Database "' + name + '" requires upgrade from version:',
           event.oldVersion
@@ -126,8 +125,7 @@ export class SimpleDb {
             SCHEMA_VERSION
           )
           .next(() => {
-            log(
-              DEBUG,
+            logDebug(
               LOG_TAG,
               'Database upgrade to version ' + SCHEMA_VERSION + ' complete'
             );
@@ -138,7 +136,7 @@ export class SimpleDb {
 
   /** Deletes the specified database. */
   static delete(name: string): Promise<void> {
-    log(DEBUG, LOG_TAG, 'Removing database:', name);
+    logDebug(LOG_TAG, 'Removing database:', name);
     return wrapRequest<void>(window.indexedDB.deleteDatabase(name)).toPromise();
   }
 
@@ -252,8 +250,7 @@ export class SimpleDb {
     // whatever reason it's much harder to hit after 12.2 so we only proactively
     // log on 12.2.
     if (iOSVersion === 12.2) {
-      log(
-        ERROR,
+      logError(
         'Firestore persistence suffers from a bug in iOS 12.2 ' +
           'Safari that may cause your app to stop working. See ' +
           'https://stackoverflow.com/q/56496296/110915 for details ' +
@@ -318,8 +315,7 @@ export class SimpleDb {
         const retryable =
           error.name !== 'FirebaseError' &&
           attemptNumber < TRANSACTION_RETRY_COUNT;
-        log(
-          DEBUG,
+        logDebug(
           LOG_TAG,
           'Transaction failed with error: %s. Retrying: %s.',
           error.message,
@@ -459,8 +455,7 @@ export class SimpleDbTransaction {
     }
 
     if (!this.aborted) {
-      log(
-        DEBUG,
+      logDebug(
         LOG_TAG,
         'Aborting transaction:',
         error ? error.message : 'Client-initiated abort'
@@ -519,10 +514,10 @@ export class SimpleDbStore<
   ): PersistencePromise<void> {
     let request;
     if (value !== undefined) {
-      log(DEBUG, LOG_TAG, 'PUT', this.store.name, keyOrValue, value);
+      logDebug(LOG_TAG, 'PUT', this.store.name, keyOrValue, value);
       request = this.store.put(value, keyOrValue as KeyType);
     } else {
-      log(DEBUG, LOG_TAG, 'PUT', this.store.name, '<auto-key>', keyOrValue);
+      logDebug(LOG_TAG, 'PUT', this.store.name, '<auto-key>', keyOrValue);
       request = this.store.put(keyOrValue as ValueType);
     }
     return wrapRequest<void>(request);
@@ -536,7 +531,7 @@ export class SimpleDbStore<
    * @return The key of the value to add.
    */
   add(value: ValueType): PersistencePromise<KeyType> {
-    log(DEBUG, LOG_TAG, 'ADD', this.store.name, value, value);
+    logDebug(LOG_TAG, 'ADD', this.store.name, value, value);
     const request = this.store.add(value as ValueType);
     return wrapRequest<KeyType>(request);
   }
@@ -557,13 +552,13 @@ export class SimpleDbStore<
       if (result === undefined) {
         result = null;
       }
-      log(DEBUG, LOG_TAG, 'GET', this.store.name, key, result);
+      logDebug(LOG_TAG, 'GET', this.store.name, key, result);
       return result;
     });
   }
 
   delete(key: KeyType | IDBKeyRange): PersistencePromise<void> {
-    log(DEBUG, LOG_TAG, 'DELETE', this.store.name, key);
+    logDebug(LOG_TAG, 'DELETE', this.store.name, key);
     const request = this.store.delete(key);
     return wrapRequest<void>(request);
   }
@@ -575,7 +570,7 @@ export class SimpleDbStore<
    * Returns the number of rows in the store.
    */
   count(): PersistencePromise<number> {
-    log(DEBUG, LOG_TAG, 'COUNT', this.store.name);
+    logDebug(LOG_TAG, 'COUNT', this.store.name);
     const request = this.store.count();
     return wrapRequest<number>(request);
   }
@@ -603,7 +598,7 @@ export class SimpleDbStore<
     indexOrRange?: string | IDBKeyRange,
     range?: IDBKeyRange
   ): PersistencePromise<void> {
-    log(DEBUG, LOG_TAG, 'DELETE ALL', this.store.name);
+    logDebug(LOG_TAG, 'DELETE ALL', this.store.name);
     const options = this.options(indexOrRange, range);
     options.keysOnly = false;
     const cursor = this.cursor(options);

--- a/packages/firestore/src/local/simple_db.ts
+++ b/packages/firestore/src/local/simple_db.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2017 Google Inc.
+ * Copyright 2017 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@
 import { getUA } from '@firebase/util';
 import { assert } from '../util/assert';
 import { Code, FirestoreError } from '../util/error';
-import { debug, error } from '../util/log';
+import { DEBUG, log, ERROR } from '../util/log';
 import { Deferred } from '../util/promise';
 import { SCHEMA_VERSION } from './indexeddb_schema';
 import { PersistencePromise } from './persistence_promise';
@@ -68,7 +68,7 @@ export class SimpleDb {
       SimpleDb.isAvailable(),
       'IndexedDB not supported in current environment.'
     );
-    debug(LOG_TAG, 'Opening database:', name);
+    log(DEBUG, LOG_TAG, 'Opening database:', name);
     return new PersistencePromise<SimpleDb>((resolve, reject) => {
       // TODO(mikelehen): Investigate browser compatibility.
       // https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API/Using_IndexedDB
@@ -111,7 +111,8 @@ export class SimpleDb {
       };
 
       request.onupgradeneeded = (event: IDBVersionChangeEvent) => {
-        debug(
+        log(
+          DEBUG,
           LOG_TAG,
           'Database "' + name + '" requires upgrade from version:',
           event.oldVersion
@@ -125,7 +126,8 @@ export class SimpleDb {
             SCHEMA_VERSION
           )
           .next(() => {
-            debug(
+            log(
+              DEBUG,
               LOG_TAG,
               'Database upgrade to version ' + SCHEMA_VERSION + ' complete'
             );
@@ -136,7 +138,7 @@ export class SimpleDb {
 
   /** Deletes the specified database. */
   static delete(name: string): Promise<void> {
-    debug(LOG_TAG, 'Removing database:', name);
+    log(DEBUG, LOG_TAG, 'Removing database:', name);
     return wrapRequest<void>(window.indexedDB.deleteDatabase(name)).toPromise();
   }
 
@@ -250,7 +252,8 @@ export class SimpleDb {
     // whatever reason it's much harder to hit after 12.2 so we only proactively
     // log on 12.2.
     if (iOSVersion === 12.2) {
-      error(
+      log(
+        ERROR,
         'Firestore persistence suffers from a bug in iOS 12.2 ' +
           'Safari that may cause your app to stop working. See ' +
           'https://stackoverflow.com/q/56496296/110915 for details ' +
@@ -315,7 +318,8 @@ export class SimpleDb {
         const retryable =
           error.name !== 'FirebaseError' &&
           attemptNumber < TRANSACTION_RETRY_COUNT;
-        debug(
+        log(
+          DEBUG,
           LOG_TAG,
           'Transaction failed with error: %s. Retrying: %s.',
           error.message,
@@ -455,7 +459,8 @@ export class SimpleDbTransaction {
     }
 
     if (!this.aborted) {
-      debug(
+      log(
+        DEBUG,
         LOG_TAG,
         'Aborting transaction:',
         error ? error.message : 'Client-initiated abort'
@@ -514,10 +519,10 @@ export class SimpleDbStore<
   ): PersistencePromise<void> {
     let request;
     if (value !== undefined) {
-      debug(LOG_TAG, 'PUT', this.store.name, keyOrValue, value);
+      log(DEBUG, LOG_TAG, 'PUT', this.store.name, keyOrValue, value);
       request = this.store.put(value, keyOrValue as KeyType);
     } else {
-      debug(LOG_TAG, 'PUT', this.store.name, '<auto-key>', keyOrValue);
+      log(DEBUG, LOG_TAG, 'PUT', this.store.name, '<auto-key>', keyOrValue);
       request = this.store.put(keyOrValue as ValueType);
     }
     return wrapRequest<void>(request);
@@ -531,7 +536,7 @@ export class SimpleDbStore<
    * @return The key of the value to add.
    */
   add(value: ValueType): PersistencePromise<KeyType> {
-    debug(LOG_TAG, 'ADD', this.store.name, value, value);
+    log(DEBUG, LOG_TAG, 'ADD', this.store.name, value, value);
     const request = this.store.add(value as ValueType);
     return wrapRequest<KeyType>(request);
   }
@@ -552,13 +557,13 @@ export class SimpleDbStore<
       if (result === undefined) {
         result = null;
       }
-      debug(LOG_TAG, 'GET', this.store.name, key, result);
+      log(DEBUG, LOG_TAG, 'GET', this.store.name, key, result);
       return result;
     });
   }
 
   delete(key: KeyType | IDBKeyRange): PersistencePromise<void> {
-    debug(LOG_TAG, 'DELETE', this.store.name, key);
+    log(DEBUG, LOG_TAG, 'DELETE', this.store.name, key);
     const request = this.store.delete(key);
     return wrapRequest<void>(request);
   }
@@ -570,7 +575,7 @@ export class SimpleDbStore<
    * Returns the number of rows in the store.
    */
   count(): PersistencePromise<number> {
-    debug(LOG_TAG, 'COUNT', this.store.name);
+    log(DEBUG, LOG_TAG, 'COUNT', this.store.name);
     const request = this.store.count();
     return wrapRequest<number>(request);
   }
@@ -598,7 +603,7 @@ export class SimpleDbStore<
     indexOrRange?: string | IDBKeyRange,
     range?: IDBKeyRange
   ): PersistencePromise<void> {
-    debug(LOG_TAG, 'DELETE ALL', this.store.name);
+    log(DEBUG, LOG_TAG, 'DELETE ALL', this.store.name);
     const options = this.options(indexOrRange, range);
     options.keysOnly = false;
     const cursor = this.cursor(options);

--- a/packages/firestore/src/platform_browser/browser_connectivity_monitor.ts
+++ b/packages/firestore/src/platform_browser/browser_connectivity_monitor.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2019 Google Inc.
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { debug } from '../util/log';
+import { log, DEBUG } from '../util/log';
 import {
   ConnectivityMonitor,
   ConnectivityMonitorCallback,
@@ -53,14 +53,14 @@ export class BrowserConnectivityMonitor implements ConnectivityMonitor {
   }
 
   private onNetworkAvailable(): void {
-    debug(LOG_TAG, 'Network connectivity changed: AVAILABLE');
+    log(DEBUG, LOG_TAG, 'Network connectivity changed: AVAILABLE');
     for (const callback of this.callbacks) {
       callback(NetworkStatus.AVAILABLE);
     }
   }
 
   private onNetworkUnavailable(): void {
-    debug(LOG_TAG, 'Network connectivity changed: UNAVAILABLE');
+    log(DEBUG, LOG_TAG, 'Network connectivity changed: UNAVAILABLE');
     for (const callback of this.callbacks) {
       callback(NetworkStatus.UNAVAILABLE);
     }

--- a/packages/firestore/src/platform_browser/browser_connectivity_monitor.ts
+++ b/packages/firestore/src/platform_browser/browser_connectivity_monitor.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { log, DEBUG } from '../util/log';
+import { logDebug } from '../util/log';
 import {
   ConnectivityMonitor,
   ConnectivityMonitorCallback,
@@ -53,14 +53,14 @@ export class BrowserConnectivityMonitor implements ConnectivityMonitor {
   }
 
   private onNetworkAvailable(): void {
-    log(DEBUG, LOG_TAG, 'Network connectivity changed: AVAILABLE');
+    logDebug(LOG_TAG, 'Network connectivity changed: AVAILABLE');
     for (const callback of this.callbacks) {
       callback(NetworkStatus.AVAILABLE);
     }
   }
 
   private onNetworkUnavailable(): void {
-    log(DEBUG, LOG_TAG, 'Network connectivity changed: UNAVAILABLE');
+    logDebug(LOG_TAG, 'Network connectivity changed: UNAVAILABLE');
     for (const callback of this.callbacks) {
       callback(NetworkStatus.UNAVAILABLE);
     }

--- a/packages/firestore/src/platform_browser/webchannel_connection.ts
+++ b/packages/firestore/src/platform_browser/webchannel_connection.ts
@@ -45,7 +45,7 @@ import {
 import { StreamBridge } from '../remote/stream_bridge';
 import { assert, fail } from '../util/assert';
 import { Code, FirestoreError } from '../util/error';
-import { DEBUG, log } from '../util/log';
+import { logDebug } from '../util/log';
 import { Indexable } from '../util/misc';
 import { Rejecter, Resolver } from '../util/promise';
 import { StringMap } from '../util/types';
@@ -114,19 +114,18 @@ export class WebChannelConnection implements Connection {
           switch (xhr.getLastErrorCode()) {
             case ErrorCode.NO_ERROR:
               const json = xhr.getResponseJson() as Resp;
-              log(DEBUG, LOG_TAG, 'XHR received:', JSON.stringify(json));
+              logDebug(LOG_TAG, 'XHR received:', JSON.stringify(json));
               resolve(json);
               break;
             case ErrorCode.TIMEOUT:
-              log(DEBUG, LOG_TAG, 'RPC "' + rpcName + '" timed out');
+              logDebug(LOG_TAG, 'RPC "' + rpcName + '" timed out');
               reject(
                 new FirestoreError(Code.DEADLINE_EXCEEDED, 'Request time out')
               );
               break;
             case ErrorCode.HTTP_ERROR:
               const status = xhr.getStatus();
-              log(
-                DEBUG,
+              logDebug(
                 LOG_TAG,
                 'RPC "' + rpcName + '" failed with status:',
                 status,
@@ -161,7 +160,7 @@ export class WebChannelConnection implements Connection {
               } else {
                 // If we received an HTTP_ERROR but there's no status code,
                 // it's most probably a connection issue
-                log(DEBUG, LOG_TAG, 'RPC "' + rpcName + '" failed');
+                logDebug(LOG_TAG, 'RPC "' + rpcName + '" failed');
                 reject(
                   new FirestoreError(Code.UNAVAILABLE, 'Connection failed.')
                 );
@@ -180,7 +179,7 @@ export class WebChannelConnection implements Connection {
               );
           }
         } finally {
-          log(DEBUG, LOG_TAG, 'RPC "' + rpcName + '" completed.');
+          logDebug(LOG_TAG, 'RPC "' + rpcName + '" completed.');
         }
       });
 
@@ -191,7 +190,7 @@ export class WebChannelConnection implements Connection {
       delete jsonObj.database;
 
       const requestString = JSON.stringify(jsonObj);
-      log(DEBUG, LOG_TAG, 'XHR sending: ', url + ' ' + requestString);
+      logDebug(LOG_TAG, 'XHR sending: ', url + ' ' + requestString);
       // Content-Type: text/plain will avoid preflight requests which might
       // mess with CORS and redirects by proxies. If we add custom headers
       // we will need to change this code to potentially use the
@@ -283,7 +282,7 @@ export class WebChannelConnection implements Connection {
     }
 
     const url = urlParts.join('');
-    log(DEBUG, LOG_TAG, 'Creating WebChannel: ' + url + ' ' + request);
+    logDebug(LOG_TAG, 'Creating WebChannel: ' + url + ' ' + request);
     const channel = webchannelTransport.createWebChannel(url, request);
 
     // WebChannel supports sending the first message with the handshake - saving
@@ -302,14 +301,14 @@ export class WebChannelConnection implements Connection {
       sendFn: (msg: Req) => {
         if (!closed) {
           if (!opened) {
-            log(DEBUG, LOG_TAG, 'Opening WebChannel transport.');
+            logDebug(LOG_TAG, 'Opening WebChannel transport.');
             channel.open();
             opened = true;
           }
-          log(DEBUG, LOG_TAG, 'WebChannel sending:', msg);
+          logDebug(LOG_TAG, 'WebChannel sending:', msg);
           channel.send(msg);
         } else {
-          log(DEBUG, LOG_TAG, 'Not sending because WebChannel is closed:', msg);
+          logDebug(LOG_TAG, 'Not sending because WebChannel is closed:', msg);
         }
       },
       closeFn: () => channel.close()
@@ -338,14 +337,14 @@ export class WebChannelConnection implements Connection {
 
     unguardedEventListen(WebChannel.EventType.OPEN, () => {
       if (!closed) {
-        log(DEBUG, LOG_TAG, 'WebChannel transport opened.');
+        logDebug(LOG_TAG, 'WebChannel transport opened.');
       }
     });
 
     unguardedEventListen(WebChannel.EventType.CLOSE, () => {
       if (!closed) {
         closed = true;
-        log(DEBUG, LOG_TAG, 'WebChannel transport closed');
+        logDebug(LOG_TAG, 'WebChannel transport closed');
         streamBridge.callOnClose();
       }
     });
@@ -353,7 +352,7 @@ export class WebChannelConnection implements Connection {
     unguardedEventListen<Error>(WebChannel.EventType.ERROR, err => {
       if (!closed) {
         closed = true;
-        log(DEBUG, LOG_TAG, 'WebChannel transport errored:', err);
+        logDebug(LOG_TAG, 'WebChannel transport errored:', err);
         streamBridge.callOnClose(
           new FirestoreError(
             Code.UNAVAILABLE,
@@ -386,7 +385,7 @@ export class WebChannelConnection implements Connection {
             msgDataOrError.error ||
             (msgDataOrError as WebChannelError[])[0]?.error;
           if (error) {
-            log(DEBUG, LOG_TAG, 'WebChannel received error:', error);
+            logDebug(LOG_TAG, 'WebChannel received error:', error);
             // error.status will be a string like 'OK' or 'NOT_FOUND'.
             const status: string = error.status;
             let code = mapCodeFromRpcStatus(status);
@@ -404,7 +403,7 @@ export class WebChannelConnection implements Connection {
             streamBridge.callOnClose(new FirestoreError(code, message));
             channel.close();
           } else {
-            log(DEBUG, LOG_TAG, 'WebChannel received:', msgData);
+            logDebug(LOG_TAG, 'WebChannel received:', msgData);
             streamBridge.callOnMessage(msgData);
           }
         }

--- a/packages/firestore/src/platform_browser/webchannel_connection.ts
+++ b/packages/firestore/src/platform_browser/webchannel_connection.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2017 Google Inc.
+ * Copyright 2017 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,7 +45,7 @@ import {
 import { StreamBridge } from '../remote/stream_bridge';
 import { assert, fail } from '../util/assert';
 import { Code, FirestoreError } from '../util/error';
-import * as log from '../util/log';
+import { DEBUG, log } from '../util/log';
 import { Indexable } from '../util/misc';
 import { Rejecter, Resolver } from '../util/promise';
 import { StringMap } from '../util/types';
@@ -114,18 +114,19 @@ export class WebChannelConnection implements Connection {
           switch (xhr.getLastErrorCode()) {
             case ErrorCode.NO_ERROR:
               const json = xhr.getResponseJson() as Resp;
-              log.debug(LOG_TAG, 'XHR received:', JSON.stringify(json));
+              log(DEBUG, LOG_TAG, 'XHR received:', JSON.stringify(json));
               resolve(json);
               break;
             case ErrorCode.TIMEOUT:
-              log.debug(LOG_TAG, 'RPC "' + rpcName + '" timed out');
+              log(DEBUG, LOG_TAG, 'RPC "' + rpcName + '" timed out');
               reject(
                 new FirestoreError(Code.DEADLINE_EXCEEDED, 'Request time out')
               );
               break;
             case ErrorCode.HTTP_ERROR:
               const status = xhr.getStatus();
-              log.debug(
+              log(
+                DEBUG,
                 LOG_TAG,
                 'RPC "' + rpcName + '" failed with status:',
                 status,
@@ -160,7 +161,7 @@ export class WebChannelConnection implements Connection {
               } else {
                 // If we received an HTTP_ERROR but there's no status code,
                 // it's most probably a connection issue
-                log.debug(LOG_TAG, 'RPC "' + rpcName + '" failed');
+                log(DEBUG, LOG_TAG, 'RPC "' + rpcName + '" failed');
                 reject(
                   new FirestoreError(Code.UNAVAILABLE, 'Connection failed.')
                 );
@@ -179,7 +180,7 @@ export class WebChannelConnection implements Connection {
               );
           }
         } finally {
-          log.debug(LOG_TAG, 'RPC "' + rpcName + '" completed.');
+          log(DEBUG, LOG_TAG, 'RPC "' + rpcName + '" completed.');
         }
       });
 
@@ -190,7 +191,7 @@ export class WebChannelConnection implements Connection {
       delete jsonObj.database;
 
       const requestString = JSON.stringify(jsonObj);
-      log.debug(LOG_TAG, 'XHR sending: ', url + ' ' + requestString);
+      log(DEBUG, LOG_TAG, 'XHR sending: ', url + ' ' + requestString);
       // Content-Type: text/plain will avoid preflight requests which might
       // mess with CORS and redirects by proxies. If we add custom headers
       // we will need to change this code to potentially use the
@@ -282,7 +283,7 @@ export class WebChannelConnection implements Connection {
     }
 
     const url = urlParts.join('');
-    log.debug(LOG_TAG, 'Creating WebChannel: ' + url + ' ' + request);
+    log(DEBUG, LOG_TAG, 'Creating WebChannel: ' + url + ' ' + request);
     const channel = webchannelTransport.createWebChannel(url, request);
 
     // WebChannel supports sending the first message with the handshake - saving
@@ -301,14 +302,14 @@ export class WebChannelConnection implements Connection {
       sendFn: (msg: Req) => {
         if (!closed) {
           if (!opened) {
-            log.debug(LOG_TAG, 'Opening WebChannel transport.');
+            log(DEBUG, LOG_TAG, 'Opening WebChannel transport.');
             channel.open();
             opened = true;
           }
-          log.debug(LOG_TAG, 'WebChannel sending:', msg);
+          log(DEBUG, LOG_TAG, 'WebChannel sending:', msg);
           channel.send(msg);
         } else {
-          log.debug(LOG_TAG, 'Not sending because WebChannel is closed:', msg);
+          log(DEBUG, LOG_TAG, 'Not sending because WebChannel is closed:', msg);
         }
       },
       closeFn: () => channel.close()
@@ -337,14 +338,14 @@ export class WebChannelConnection implements Connection {
 
     unguardedEventListen(WebChannel.EventType.OPEN, () => {
       if (!closed) {
-        log.debug(LOG_TAG, 'WebChannel transport opened.');
+        log(DEBUG, LOG_TAG, 'WebChannel transport opened.');
       }
     });
 
     unguardedEventListen(WebChannel.EventType.CLOSE, () => {
       if (!closed) {
         closed = true;
-        log.debug(LOG_TAG, 'WebChannel transport closed');
+        log(DEBUG, LOG_TAG, 'WebChannel transport closed');
         streamBridge.callOnClose();
       }
     });
@@ -352,7 +353,7 @@ export class WebChannelConnection implements Connection {
     unguardedEventListen<Error>(WebChannel.EventType.ERROR, err => {
       if (!closed) {
         closed = true;
-        log.debug(LOG_TAG, 'WebChannel transport errored:', err);
+        log(DEBUG, LOG_TAG, 'WebChannel transport errored:', err);
         streamBridge.callOnClose(
           new FirestoreError(
             Code.UNAVAILABLE,
@@ -385,7 +386,7 @@ export class WebChannelConnection implements Connection {
             msgDataOrError.error ||
             (msgDataOrError as WebChannelError[])[0]?.error;
           if (error) {
-            log.debug(LOG_TAG, 'WebChannel received error:', error);
+            log(DEBUG, LOG_TAG, 'WebChannel received error:', error);
             // error.status will be a string like 'OK' or 'NOT_FOUND'.
             const status: string = error.status;
             let code = mapCodeFromRpcStatus(status);
@@ -403,7 +404,7 @@ export class WebChannelConnection implements Connection {
             streamBridge.callOnClose(new FirestoreError(code, message));
             channel.close();
           } else {
-            log.debug(LOG_TAG, 'WebChannel received:', msgData);
+            log(DEBUG, LOG_TAG, 'WebChannel received:', msgData);
             streamBridge.callOnMessage(msgData);
           }
         }

--- a/packages/firestore/src/platform_node/grpc_connection.ts
+++ b/packages/firestore/src/platform_node/grpc_connection.ts
@@ -30,7 +30,7 @@ import { mapCodeFromRpcCode } from '../remote/rpc_error';
 import { StreamBridge } from '../remote/stream_bridge';
 import { assert } from '../util/assert';
 import { FirestoreError } from '../util/error';
-import { DEBUG, ERROR, log } from '../util/log';
+import { logError, logDebug } from '../util/log';
 import { NodeCallback, nodePromise } from '../util/node_api';
 import { Deferred } from '../util/promise';
 
@@ -91,7 +91,7 @@ export class GrpcConnection implements Connection {
 
   private ensureActiveStub(): GeneratedGrpcStub {
     if (!this.cachedStub) {
-      log(DEBUG, LOG_TAG, 'Creating Firestore stub.');
+      logDebug(LOG_TAG, 'Creating Firestore stub.');
       const credentials = this.databaseInfo.ssl
         ? grpc.credentials.createSsl()
         : grpc.credentials.createInsecure();
@@ -112,18 +112,13 @@ export class GrpcConnection implements Connection {
     const metadata = createMetadata(this.databaseInfo, token);
 
     return nodePromise((callback: NodeCallback<Resp>) => {
-      log(DEBUG, LOG_TAG, `RPC '${rpcName}' invoked with request:`, request);
+      logDebug(LOG_TAG, `RPC '${rpcName}' invoked with request:`, request);
       return stub[rpcName](
         request,
         metadata,
         (grpcError?: grpc.ServiceError, value?: Resp) => {
           if (grpcError) {
-            log(
-              DEBUG,
-              LOG_TAG,
-              `RPC '${rpcName}' failed with error:`,
-              grpcError
-            );
+            logDebug(LOG_TAG, `RPC '${rpcName}' failed with error:`, grpcError);
             callback(
               new FirestoreError(
                 mapCodeFromRpcCode(grpcError.code),
@@ -131,8 +126,7 @@ export class GrpcConnection implements Connection {
               )
             );
           } else {
-            log(
-              DEBUG,
+            logDebug(
               LOG_TAG,
               `RPC '${rpcName}' completed with response:`,
               value
@@ -152,8 +146,7 @@ export class GrpcConnection implements Connection {
     const results: Resp[] = [];
     const responseDeferred = new Deferred<Resp[]>();
 
-    log(
-      DEBUG,
+    logDebug(
       LOG_TAG,
       `RPC '${rpcName}' invoked (streaming) with request:`,
       request
@@ -162,15 +155,15 @@ export class GrpcConnection implements Connection {
     const metadata = createMetadata(this.databaseInfo, token);
     const stream = stub[rpcName](request, metadata);
     stream.on('data', (response: Resp) => {
-      log(DEBUG, LOG_TAG, `RPC ${rpcName} received result:`, response);
+      logDebug(LOG_TAG, `RPC ${rpcName} received result:`, response);
       results.push(response);
     });
     stream.on('end', () => {
-      log(DEBUG, LOG_TAG, `RPC '${rpcName}' completed.`);
+      logDebug(LOG_TAG, `RPC '${rpcName}' completed.`);
       responseDeferred.resolve(results);
     });
     stream.on('error', (grpcError: grpc.ServiceError) => {
-      log(DEBUG, LOG_TAG, `RPC '${rpcName}' failed with error:`, grpcError);
+      logDebug(LOG_TAG, `RPC '${rpcName}' failed with error:`, grpcError);
       const code = mapCodeFromRpcCode(grpcError.code);
       responseDeferred.reject(new FirestoreError(code, grpcError.message));
     });
@@ -199,46 +192,40 @@ export class GrpcConnection implements Connection {
     const stream = new StreamBridge<Req, Resp>({
       sendFn: (msg: Req) => {
         if (!closed) {
-          log(DEBUG, LOG_TAG, 'GRPC stream sending:', msg);
+          logDebug(LOG_TAG, 'GRPC stream sending:', msg);
           try {
             grpcStream.write(msg);
           } catch (e) {
             // This probably means we didn't conform to the proto.  Make sure to
             // log the message we sent.
-            log(ERROR, 'Failure sending:', msg);
-            log(ERROR, 'Error:', e);
+            logError('Failure sending:', msg);
+            logError('Error:', e);
             throw e;
           }
         } else {
-          log(
-            DEBUG,
-            LOG_TAG,
-            'Not sending because gRPC stream is closed:',
-            msg
-          );
+          logDebug(LOG_TAG, 'Not sending because gRPC stream is closed:', msg);
         }
       },
       closeFn: () => {
-        log(DEBUG, LOG_TAG, 'GRPC stream closed locally via close().');
+        logDebug(LOG_TAG, 'GRPC stream closed locally via close().');
         close();
       }
     });
 
     grpcStream.on('data', (msg: Resp) => {
       if (!closed) {
-        log(DEBUG, LOG_TAG, 'GRPC stream received:', msg);
+        logDebug(LOG_TAG, 'GRPC stream received:', msg);
         stream.callOnMessage(msg);
       }
     });
 
     grpcStream.on('end', () => {
-      log(DEBUG, LOG_TAG, 'GRPC stream ended.');
+      logDebug(LOG_TAG, 'GRPC stream ended.');
       close();
     });
 
     grpcStream.on('error', (grpcError: grpc.ServiceError) => {
-      log(
-        DEBUG,
+      logDebug(
         LOG_TAG,
         'GRPC stream error. Code:',
         grpcError.code,
@@ -249,7 +236,7 @@ export class GrpcConnection implements Connection {
       close(new FirestoreError(code, grpcError.message));
     });
 
-    log(DEBUG, LOG_TAG, 'Opening GRPC stream');
+    logDebug(LOG_TAG, 'Opening GRPC stream');
     // TODO(dimond): Since grpc has no explicit open status (or does it?) we
     // simulate an onOpen in the next loop after the stream had it's listeners
     // registered

--- a/packages/firestore/src/remote/backoff.ts
+++ b/packages/firestore/src/remote/backoff.ts
@@ -16,7 +16,7 @@
  */
 
 import { AsyncQueue, TimerId } from '../util/async_queue';
-import { DEBUG, log } from '../util/log';
+import { logDebug } from '../util/log';
 import { CancelablePromise } from '../util/promise';
 const LOG_TAG = 'ExponentialBackoff';
 
@@ -120,8 +120,7 @@ export class ExponentialBackoff {
     );
 
     if (this.currentBaseMs > 0) {
-      log(
-        DEBUG,
+      logDebug(
         LOG_TAG,
         `Backing off for ${remainingDelayMs} ms ` +
           `(base delay: ${this.currentBaseMs} ms, ` +

--- a/packages/firestore/src/remote/backoff.ts
+++ b/packages/firestore/src/remote/backoff.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2017 Google Inc.
+ * Copyright 2017 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
  */
 
 import { AsyncQueue, TimerId } from '../util/async_queue';
-import * as log from '../util/log';
+import { DEBUG, log } from '../util/log';
 import { CancelablePromise } from '../util/promise';
 const LOG_TAG = 'ExponentialBackoff';
 
@@ -120,7 +120,8 @@ export class ExponentialBackoff {
     );
 
     if (this.currentBaseMs > 0) {
-      log.debug(
+      log(
+        DEBUG,
         LOG_TAG,
         `Backing off for ${remainingDelayMs} ms ` +
           `(base delay: ${this.currentBaseMs} ms, ` +

--- a/packages/firestore/src/remote/online_state_tracker.ts
+++ b/packages/firestore/src/remote/online_state_tracker.ts
@@ -19,7 +19,7 @@ import { OnlineState } from '../core/types';
 import { assert } from '../util/assert';
 import { AsyncQueue, TimerId } from '../util/async_queue';
 import { FirestoreError } from '../util/error';
-import { log, ERROR, DEBUG } from '../util/log';
+import { logError, logDebug } from '../util/log';
 import { CancelablePromise } from '../util/promise';
 
 const LOG_TAG = 'OnlineStateTracker';
@@ -181,10 +181,10 @@ export class OnlineStateTracker {
       `Internet connection at the moment. The client will operate in offline ` +
       `mode until it is able to successfully connect to the backend.`;
     if (this.shouldWarnClientIsOffline) {
-      log(ERROR, message);
+      logError(message);
       this.shouldWarnClientIsOffline = false;
     } else {
-      log(DEBUG, LOG_TAG, message);
+      logDebug(LOG_TAG, message);
     }
   }
 

--- a/packages/firestore/src/remote/online_state_tracker.ts
+++ b/packages/firestore/src/remote/online_state_tracker.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2018 Google Inc.
+ * Copyright 2018 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@ import { OnlineState } from '../core/types';
 import { assert } from '../util/assert';
 import { AsyncQueue, TimerId } from '../util/async_queue';
 import { FirestoreError } from '../util/error';
-import * as log from '../util/log';
+import { log, ERROR, DEBUG } from '../util/log';
 import { CancelablePromise } from '../util/promise';
 
 const LOG_TAG = 'OnlineStateTracker';
@@ -181,10 +181,10 @@ export class OnlineStateTracker {
       `Internet connection at the moment. The client will operate in offline ` +
       `mode until it is able to successfully connect to the backend.`;
     if (this.shouldWarnClientIsOffline) {
-      log.error(message);
+      log(ERROR, message);
       this.shouldWarnClientIsOffline = false;
     } else {
-      log.debug(LOG_TAG, message);
+      log(DEBUG, LOG_TAG, message);
     }
   }
 

--- a/packages/firestore/src/remote/persistent_stream.ts
+++ b/packages/firestore/src/remote/persistent_stream.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2017 Google Inc.
+ * Copyright 2017 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ import * as api from '../protos/firestore_proto_api';
 import { assert } from '../util/assert';
 import { AsyncQueue, TimerId } from '../util/async_queue';
 import { Code, FirestoreError } from '../util/error';
-import * as log from '../util/log';
+import { DEBUG, ERROR, log } from '../util/log';
 
 import { CancelablePromise } from '../util/promise';
 import { isNullOrUndefined } from '../util/types';
@@ -328,8 +328,9 @@ export abstract class PersistentStream<
       this.backoff.reset();
     } else if (error && error.code === Code.RESOURCE_EXHAUSTED) {
       // Log the error. (Probably either 'quota exceeded' or 'max queue length reached'.)
-      log.error(error.toString());
-      log.error(
+      log(ERROR, error.toString());
+      log(
+        ERROR,
         'Using maximum backoff delay to prevent overloading the backend.'
       );
       this.backoff.resetToMax();
@@ -466,7 +467,7 @@ export abstract class PersistentStream<
   // Visible for tests
   handleStreamClose(error?: FirestoreError): Promise<void> {
     assert(this.isStarted(), "Can't handle server close on non-started stream");
-    log.debug(LOG_TAG, `close with error: ${error}`);
+    log(DEBUG, LOG_TAG, `close with error: ${error}`);
 
     this.stream = null;
 
@@ -491,7 +492,8 @@ export abstract class PersistentStream<
         if (this.closeCount === startCloseCount) {
           return fn();
         } else {
-          log.debug(
+          log(
+            DEBUG,
             LOG_TAG,
             'stream callback skipped by getCloseGuardedDispatcher.'
           );

--- a/packages/firestore/src/remote/persistent_stream.ts
+++ b/packages/firestore/src/remote/persistent_stream.ts
@@ -24,7 +24,7 @@ import * as api from '../protos/firestore_proto_api';
 import { assert } from '../util/assert';
 import { AsyncQueue, TimerId } from '../util/async_queue';
 import { Code, FirestoreError } from '../util/error';
-import { DEBUG, ERROR, log } from '../util/log';
+import { logError, logDebug } from '../util/log';
 
 import { CancelablePromise } from '../util/promise';
 import { isNullOrUndefined } from '../util/types';
@@ -328,9 +328,8 @@ export abstract class PersistentStream<
       this.backoff.reset();
     } else if (error && error.code === Code.RESOURCE_EXHAUSTED) {
       // Log the error. (Probably either 'quota exceeded' or 'max queue length reached'.)
-      log(ERROR, error.toString());
-      log(
-        ERROR,
+      logError(error.toString());
+      logError(
         'Using maximum backoff delay to prevent overloading the backend.'
       );
       this.backoff.resetToMax();
@@ -467,7 +466,7 @@ export abstract class PersistentStream<
   // Visible for tests
   handleStreamClose(error?: FirestoreError): Promise<void> {
     assert(this.isStarted(), "Can't handle server close on non-started stream");
-    log(DEBUG, LOG_TAG, `close with error: ${error}`);
+    logDebug(LOG_TAG, `close with error: ${error}`);
 
     this.stream = null;
 
@@ -492,8 +491,7 @@ export abstract class PersistentStream<
         if (this.closeCount === startCloseCount) {
           return fn();
         } else {
-          log(
-            DEBUG,
+          logDebug(
             LOG_TAG,
             'stream callback skipped by getCloseGuardedDispatcher.'
           );

--- a/packages/firestore/src/remote/remote_store.ts
+++ b/packages/firestore/src/remote/remote_store.ts
@@ -28,7 +28,7 @@ import {
 } from '../model/mutation_batch';
 import { assert } from '../util/assert';
 import { FirestoreError } from '../util/error';
-import { log, DEBUG } from '../util/log';
+import { logDebug } from '../util/log';
 import * as objUtils from '../util/obj';
 
 import { DocumentKeySet } from '../model/collections';
@@ -138,8 +138,7 @@ export class RemoteStore implements TargetMetadataProvider {
     this.connectivityMonitor.addCallback((status: NetworkStatus) => {
       asyncQueue.enqueueAndForget(async () => {
         if (this.canUseNetwork()) {
-          log(
-            DEBUG,
+          logDebug(
             LOG_TAG,
             'Restarting streams for network reachability change.'
           );
@@ -217,8 +216,7 @@ export class RemoteStore implements TargetMetadataProvider {
     await this.watchStream.stop();
 
     if (this.writePipeline.length > 0) {
-      log(
-        DEBUG,
+      logDebug(
         LOG_TAG,
         `Stopping write stream with ${this.writePipeline.length} pending writes`
       );
@@ -229,7 +227,7 @@ export class RemoteStore implements TargetMetadataProvider {
   }
 
   async shutdown(): Promise<void> {
-    log(DEBUG, LOG_TAG, 'RemoteStore shutting down.');
+    logDebug(LOG_TAG, 'RemoteStore shutting down.');
     this.networkEnabled = false;
     await this.disableNetworkInternal();
     this.connectivityMonitor.shutdown();
@@ -662,8 +660,7 @@ export class RemoteStore implements TargetMetadataProvider {
     // no longer valid. Note that the handshake does not count as a write: see
     // comments on isPermanentWriteError for details.
     if (isPermanentError(error.code)) {
-      log(
-        DEBUG,
+      logDebug(
         LOG_TAG,
         'RemoteStore error before completed handshake; resetting stream token: ',
         this.writeStream.lastStreamToken
@@ -720,7 +717,7 @@ export class RemoteStore implements TargetMetadataProvider {
       // Tear down and re-create our network streams. This will ensure we get a fresh auth token
       // for the new user and re-fill the write pipeline with new mutations from the LocalStore
       // (since mutations are per-user).
-      log(DEBUG, LOG_TAG, 'RemoteStore restarting streams for new credential');
+      logDebug(LOG_TAG, 'RemoteStore restarting streams for new credential');
       await this.restartNetwork();
     }
   }

--- a/packages/firestore/src/remote/remote_store.ts
+++ b/packages/firestore/src/remote/remote_store.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2017 Google Inc.
+ * Copyright 2017 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,7 +28,7 @@ import {
 } from '../model/mutation_batch';
 import { assert } from '../util/assert';
 import { FirestoreError } from '../util/error';
-import * as log from '../util/log';
+import { log, DEBUG } from '../util/log';
 import * as objUtils from '../util/obj';
 
 import { DocumentKeySet } from '../model/collections';
@@ -138,7 +138,8 @@ export class RemoteStore implements TargetMetadataProvider {
     this.connectivityMonitor.addCallback((status: NetworkStatus) => {
       asyncQueue.enqueueAndForget(async () => {
         if (this.canUseNetwork()) {
-          log.debug(
+          log(
+            DEBUG,
             LOG_TAG,
             'Restarting streams for network reachability change.'
           );
@@ -216,7 +217,8 @@ export class RemoteStore implements TargetMetadataProvider {
     await this.watchStream.stop();
 
     if (this.writePipeline.length > 0) {
-      log.debug(
+      log(
+        DEBUG,
         LOG_TAG,
         `Stopping write stream with ${this.writePipeline.length} pending writes`
       );
@@ -227,7 +229,7 @@ export class RemoteStore implements TargetMetadataProvider {
   }
 
   async shutdown(): Promise<void> {
-    log.debug(LOG_TAG, 'RemoteStore shutting down.');
+    log(DEBUG, LOG_TAG, 'RemoteStore shutting down.');
     this.networkEnabled = false;
     await this.disableNetworkInternal();
     this.connectivityMonitor.shutdown();
@@ -660,7 +662,8 @@ export class RemoteStore implements TargetMetadataProvider {
     // no longer valid. Note that the handshake does not count as a write: see
     // comments on isPermanentWriteError for details.
     if (isPermanentError(error.code)) {
-      log.debug(
+      log(
+        DEBUG,
         LOG_TAG,
         'RemoteStore error before completed handshake; resetting stream token: ',
         this.writeStream.lastStreamToken
@@ -717,7 +720,7 @@ export class RemoteStore implements TargetMetadataProvider {
       // Tear down and re-create our network streams. This will ensure we get a fresh auth token
       // for the new user and re-fill the write pipeline with new mutations from the LocalStore
       // (since mutations are per-user).
-      log.debug(LOG_TAG, 'RemoteStore restarting streams for new credential');
+      log(DEBUG, LOG_TAG, 'RemoteStore restarting streams for new credential');
       await this.restartNetwork();
     }
   }

--- a/packages/firestore/src/remote/rpc_error.ts
+++ b/packages/firestore/src/remote/rpc_error.ts
@@ -17,7 +17,7 @@
 
 import { fail } from '../util/assert';
 import { Code } from '../util/error';
-import { ERROR, log } from '../util/log';
+import { logError } from '../util/log';
 
 /**
  * Error Codes describing the different ways GRPC can fail. These are copied
@@ -131,7 +131,7 @@ export function mapCodeFromRpcCode(code: number | undefined): Code {
   if (code === undefined) {
     // This shouldn't normally happen, but in certain error cases (like trying
     // to send invalid proto messages) we may get an error with no GRPC code.
-    log(ERROR, 'GRPC error has no .code');
+    logError('GRPC error has no .code');
     return Code.UNKNOWN;
   }
 

--- a/packages/firestore/src/remote/rpc_error.ts
+++ b/packages/firestore/src/remote/rpc_error.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2017 Google Inc.
+ * Copyright 2017 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
 
 import { fail } from '../util/assert';
 import { Code } from '../util/error';
-import * as log from '../util/log';
+import { ERROR, log } from '../util/log';
 
 /**
  * Error Codes describing the different ways GRPC can fail. These are copied
@@ -131,7 +131,7 @@ export function mapCodeFromRpcCode(code: number | undefined): Code {
   if (code === undefined) {
     // This shouldn't normally happen, but in certain error cases (like trying
     // to send invalid proto messages) we may get an error with no GRPC code.
-    log.error('GRPC error has no .code');
+    log(ERROR, 'GRPC error has no .code');
     return Code.UNKNOWN;
   }
 

--- a/packages/firestore/src/remote/watch_change.ts
+++ b/packages/firestore/src/remote/watch_change.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2017 Google Inc.
+ * Copyright 2017 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,7 +28,7 @@ import { Document, MaybeDocument, NoDocument } from '../model/document';
 import { DocumentKey } from '../model/document_key';
 import { assert, fail } from '../util/assert';
 import { FirestoreError } from '../util/error';
-import { debug } from '../util/log';
+import { log, DEBUG } from '../util/log';
 import { primitiveComparator } from '../util/misc';
 import * as objUtils from '../util/obj';
 import { SortedMap } from '../util/sorted_map';
@@ -625,7 +625,7 @@ export class WatchChangeAggregator {
   protected isActiveTarget(targetId: TargetId): boolean {
     const targetActive = this.targetDataForActiveTarget(targetId) !== null;
     if (!targetActive) {
-      debug(LOG_TAG, 'Detected inactive target', targetId);
+      log(DEBUG, LOG_TAG, 'Detected inactive target', targetId);
     }
     return targetActive;
   }

--- a/packages/firestore/src/remote/watch_change.ts
+++ b/packages/firestore/src/remote/watch_change.ts
@@ -28,7 +28,7 @@ import { Document, MaybeDocument, NoDocument } from '../model/document';
 import { DocumentKey } from '../model/document_key';
 import { assert, fail } from '../util/assert';
 import { FirestoreError } from '../util/error';
-import { log, DEBUG } from '../util/log';
+import { logDebug } from '../util/log';
 import { primitiveComparator } from '../util/misc';
 import * as objUtils from '../util/obj';
 import { SortedMap } from '../util/sorted_map';
@@ -625,7 +625,7 @@ export class WatchChangeAggregator {
   protected isActiveTarget(targetId: TargetId): boolean {
     const targetActive = this.targetDataForActiveTarget(targetId) !== null;
     if (!targetActive) {
-      log(DEBUG, LOG_TAG, 'Detected inactive target', targetId);
+      logDebug(LOG_TAG, 'Detected inactive target', targetId);
     }
     return targetActive;
   }

--- a/packages/firestore/src/util/assert.ts
+++ b/packages/firestore/src/util/assert.ts
@@ -16,7 +16,7 @@
  */
 
 import { SDK_VERSION } from '../core/version';
-import { log, ERROR } from './log';
+import { logError } from './log';
 
 /**
  * Unconditionally fails, throwing an Error with the given message.
@@ -30,7 +30,7 @@ export function fail(failure: string): never {
   // exception is swallowed.
   const message =
     `FIRESTORE (${SDK_VERSION}) INTERNAL ASSERTION FAILED: ` + failure;
-  log(ERROR, message);
+  logError(message);
 
   // NOTE: We don't use FirestoreError here because these are internal failures
   // that cannot be handled by the user. (Also it would create a circular

--- a/packages/firestore/src/util/assert.ts
+++ b/packages/firestore/src/util/assert.ts
@@ -16,7 +16,6 @@
  */
 
 import { SDK_VERSION } from '../core/version';
-
 import { log, ERROR } from './log';
 
 /**

--- a/packages/firestore/src/util/assert.ts
+++ b/packages/firestore/src/util/assert.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2017 Google Inc.
+ * Copyright 2017 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
 
 import { SDK_VERSION } from '../core/version';
 
-import { error } from './log';
+import { log, ERROR } from './log';
 
 /**
  * Unconditionally fails, throwing an Error with the given message.
@@ -31,7 +31,7 @@ export function fail(failure: string): never {
   // exception is swallowed.
   const message =
     `FIRESTORE (${SDK_VERSION}) INTERNAL ASSERTION FAILED: ` + failure;
-  error(message);
+  log(ERROR, message);
 
   // NOTE: We don't use FirestoreError here because these are internal failures
   // that cannot be handled by the user. (Also it would create a circular

--- a/packages/firestore/src/util/async_queue.ts
+++ b/packages/firestore/src/util/async_queue.ts
@@ -17,7 +17,7 @@
 
 import { assert, fail } from './assert';
 import { Code, FirestoreError } from './error';
-import { ERROR, log } from './log';
+import { logError } from './log';
 import { CancelablePromise, Deferred } from './promise';
 
 // Accept any return type from setTimeout().
@@ -287,7 +287,7 @@ export class AsyncQueue {
           this.failure = error;
           this.operationInProgress = false;
           const message = error.stack || error.message || '';
-          log(ERROR, 'INTERNAL UNHANDLED ERROR: ', message);
+          logError('INTERNAL UNHANDLED ERROR: ', message);
 
           // Escape the promise chain and throw the error globally so that
           // e.g. any global crash reporting library detects and reports it.

--- a/packages/firestore/src/util/async_queue.ts
+++ b/packages/firestore/src/util/async_queue.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2017 Google Inc.
+ * Copyright 2017 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
 
 import { assert, fail } from './assert';
 import { Code, FirestoreError } from './error';
-import * as log from './log';
+import { ERROR, log } from './log';
 import { CancelablePromise, Deferred } from './promise';
 
 // Accept any return type from setTimeout().
@@ -287,7 +287,7 @@ export class AsyncQueue {
           this.failure = error;
           this.operationInProgress = false;
           const message = error.stack || error.message || '';
-          log.error('INTERNAL UNHANDLED ERROR: ', message);
+          log(ERROR, 'INTERNAL UNHANDLED ERROR: ', message);
 
           // Escape the promise chain and throw the error globally so that
           // e.g. any global crash reporting library detects and reports it.

--- a/packages/firestore/src/util/log.ts
+++ b/packages/firestore/src/util/log.ts
@@ -19,9 +19,7 @@ import { Logger, LogLevel } from '@firebase/logger';
 import { SDK_VERSION } from '../core/version';
 import { PlatformSupport } from '../platform/platform';
 
-export const DEBUG = LogLevel.DEBUG;
-export const ERROR = LogLevel.ERROR;
-export const SILENT = LogLevel.SILENT;
+export { LogLevel };
 
 const logClient = new Logger('@firebase/firestore');
 
@@ -34,8 +32,15 @@ export function setLogLevel(newLevel: LogLevel): void {
   logClient.logLevel = newLevel;
 }
 
-export function log(logLevel: LogLevel, msg: string, ...obj: unknown[]): void {
-  if (logClient.logLevel <= logLevel) {
+export function logDebug(msg: string, ...obj: unknown[]): void {
+  if (logClient.logLevel <= LogLevel.DEBUG) {
+    const args = obj.map(argToString);
+    logClient.error(`Firestore (${SDK_VERSION}): ${msg}`, ...args);
+  }
+}
+
+export function logError(msg: string, ...obj: unknown[]): void {
+  if (logClient.logLevel <= LogLevel.ERROR) {
     const args = obj.map(argToString);
     logClient.error(`Firestore (${SDK_VERSION}): ${msg}`, ...args);
   }

--- a/packages/firestore/src/util/log.ts
+++ b/packages/firestore/src/util/log.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2017 Google Inc.
+ * Copyright 2017 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,58 +15,27 @@
  * limitations under the License.
  */
 
-import { Logger, LogLevel as FirebaseLogLevel } from '@firebase/logger';
+import { Logger, LogLevel } from '@firebase/logger';
 import { SDK_VERSION } from '../core/version';
 import { PlatformSupport } from '../platform/platform';
 
-const logClient = new Logger('@firebase/firestore');
+export const DEBUG = LogLevel.DEBUG;
+export const ERROR = LogLevel.ERROR;
+export const SILENT = LogLevel.SILENT;
 
-export const enum LogLevel {
-  DEBUG,
-  ERROR,
-  SILENT
-}
+const logClient = new Logger('@firebase/firestore');
 
 // Helper methods are needed because variables can't be exported as read/write
 export function getLogLevel(): LogLevel {
-  if (logClient.logLevel === FirebaseLogLevel.DEBUG) {
-    return LogLevel.DEBUG;
-  } else if (logClient.logLevel === FirebaseLogLevel.SILENT) {
-    return LogLevel.SILENT;
-  } else {
-    return LogLevel.ERROR;
-  }
+  return logClient.logLevel;
 }
+
 export function setLogLevel(newLevel: LogLevel): void {
-  /**
-   * Map the new log level to the associated Firebase Log Level
-   */
-  switch (newLevel) {
-    case LogLevel.DEBUG:
-      logClient.logLevel = FirebaseLogLevel.DEBUG;
-      break;
-    case LogLevel.ERROR:
-      logClient.logLevel = FirebaseLogLevel.ERROR;
-      break;
-    case LogLevel.SILENT:
-      logClient.logLevel = FirebaseLogLevel.SILENT;
-      break;
-    default:
-      logClient.error(
-        `Firestore (${SDK_VERSION}): Invalid value passed to \`setLogLevel\``
-      );
-  }
+  logClient.logLevel = newLevel;
 }
 
-export function debug(tag: string, msg: string, ...obj: unknown[]): void {
-  if (logClient.logLevel <= FirebaseLogLevel.DEBUG) {
-    const args = obj.map(argToString);
-    logClient.debug(`Firestore (${SDK_VERSION}) [${tag}]: ${msg}`, ...args);
-  }
-}
-
-export function error(msg: string, ...obj: unknown[]): void {
-  if (logClient.logLevel <= FirebaseLogLevel.ERROR) {
+export function log(logLevel: LogLevel, msg: string, ...obj: unknown[]): void {
+  if (logClient.logLevel <= logLevel) {
     const args = obj.map(argToString);
     logClient.error(`Firestore (${SDK_VERSION}): ${msg}`, ...args);
   }

--- a/packages/firestore/test/unit/util/async_queue.test.ts
+++ b/packages/firestore/test/unit/util/async_queue.test.ts
@@ -18,7 +18,7 @@
 import { expect } from 'chai';
 import { AsyncQueue, TimerId } from '../../../src/util/async_queue';
 import { Code } from '../../../src/util/error';
-import { getLogLevel, setLogLevel, SILENT } from '../../../src/util/log';
+import { getLogLevel, setLogLevel, LogLevel } from '../../../src/util/log';
 import { Deferred, Rejecter, Resolver } from '../../../src/util/promise';
 
 describe('AsyncQueue', () => {
@@ -76,7 +76,7 @@ describe('AsyncQueue', () => {
 
     // Disable logging for this test to avoid the assertion being logged
     const oldLogLevel = getLogLevel();
-    setLogLevel(SILENT);
+    setLogLevel(LogLevel.SILENT);
 
     // Schedule a failing operation and make sure it's handled correctly.
     const op1Promise = queue

--- a/packages/firestore/test/unit/util/async_queue.test.ts
+++ b/packages/firestore/test/unit/util/async_queue.test.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2017 Google Inc.
+ * Copyright 2017 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@
 import { expect } from 'chai';
 import { AsyncQueue, TimerId } from '../../../src/util/async_queue';
 import { Code } from '../../../src/util/error';
-import { getLogLevel, LogLevel, setLogLevel } from '../../../src/util/log';
+import { getLogLevel, setLogLevel, SILENT } from '../../../src/util/log';
 import { Deferred, Rejecter, Resolver } from '../../../src/util/promise';
 
 describe('AsyncQueue', () => {
@@ -76,7 +76,7 @@ describe('AsyncQueue', () => {
 
     // Disable logging for this test to avoid the assertion being logged
     const oldLogLevel = getLogLevel();
-    setLogLevel(LogLevel.SILENT);
+    setLogLevel(SILENT);
 
     // Schedule a failing operation and make sure it's handled correctly.
     const op1Promise = queue


### PR DESCRIPTION
Small cleanup for our logging.

The main reason for going down this path is that I am trying to remove namespace imports and I don't want to refer to `error` and `debug` as free-standing functions.