### PR TITLE
Move test code to test helpers

### DIFF
--- a/packages/firestore/test/unit/specs/spec_test_runner.ts
+++ b/packages/firestore/test/unit/specs/spec_test_runner.ts
@@ -102,8 +102,10 @@ import {
   setMutation,
   TestSnapshotVersion,
   version,
-  byteStringFromString
+  byteStringFromString,
+  stringFromBase64String
 } from '../../util/helpers';
+import { encodeWatchChange } from '../../util/spec_test_helpers';
 import { SharedFakeWebStorage, TestPlatform } from '../../util/test_platform';
 import {
   clearTestPersistence,
@@ -852,7 +854,7 @@ abstract class TestRunner {
   }
 
   private async doWatchEvent(watchChange: WatchChange): Promise<void> {
-    const protoJSON = this.serializer.toTestWatchChange(watchChange);
+    const protoJSON = encodeWatchChange(watchChange);
     this.connection.watchStream!.callOnMessage(protoJSON);
 
     // Put a no-op in the queue so that we know when any outstanding RemoteStore
@@ -1158,7 +1160,13 @@ abstract class TestRunner {
       expect(actualTarget.query).to.deep.equal(expectedTarget.query);
       expect(actualTarget.targetId).to.equal(expectedTarget.targetId);
       expect(actualTarget.readTime).to.equal(expectedTarget.readTime);
-      expect(actualTarget.resumeToken).to.equal(expectedTarget.resumeToken);
+      expect(actualTarget.resumeToken).to.equal(
+        expectedTarget.resumeToken,
+        `ResumeToken does not match - expected:
+         ${stringFromBase64String(
+           expectedTarget.resumeToken
+         )}, actual: ${stringFromBase64String(expectedTarget.resumeToken)}`
+      );
       delete actualTargets[targetId];
     });
     expect(obj.size(actualTargets)).to.equal(

--- a/packages/firestore/test/util/helpers.ts
+++ b/packages/firestore/test/util/helpers.ts
@@ -512,7 +512,13 @@ export function byteStringFromString(value: string): ByteString {
   return ByteString.fromBase64String(base64);
 }
 
-/** Decodes a base 64 decoded string. */
+/** 
+ * Decodes a base 64 decoded string.
+ *
+ * Note that this is typed to accept Uint8Arrays to match the types used
+ * by the spec tests. Since the spec tests only use JSON strings, this method
+ * throws if an Uint8Array is passed.
+ */
 export function stringFromBase64String(
   value?: string | Uint8Array
 ): ByteString {

--- a/packages/firestore/test/util/helpers.ts
+++ b/packages/firestore/test/util/helpers.ts
@@ -512,6 +512,18 @@ export function byteStringFromString(value: string): ByteString {
   return ByteString.fromBase64String(base64);
 }
 
+/** Decodes a base 64 decoded string. */
+export function stringFromBase64String(
+  value?: string | Uint8Array
+): ByteString {
+  assert(
+    value === undefined || typeof value === 'string',
+    'Can only decode base64 encoded strings'
+  );
+  const base64 = PlatformSupport.getPlatform().btoa(value ?? '');
+  return ByteString.fromBase64String(base64);
+}
+
 /** Creates a resume token to match the given snapshot version. */
 export function resumeTokenForSnapshot(
   snapshotVersion: SnapshotVersion

--- a/packages/firestore/test/util/spec_test_helpers.ts
+++ b/packages/firestore/test/util/spec_test_helpers.ts
@@ -1,0 +1,116 @@
+/**
+ * @license
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  DocumentWatchChange,
+  ExistenceFilterChange,
+  WatchChange,
+  WatchTargetChange,
+  WatchTargetChangeState
+} from '../../src/remote/watch_change';
+import * as api from '../../src/protos/firestore_proto_api';
+import { Document, NoDocument } from '../../src/model/document';
+import { mapRpcCodeFromCode } from '../../src/remote/rpc_error';
+import { fail } from '../../src/util/assert';
+import { JsonProtoSerializer } from '../../src/remote/serializer';
+import { dbId } from './helpers';
+
+const serializer = new JsonProtoSerializer(dbId('project'), {
+  useProto3Json: true
+});
+
+export function encodeWatchChange(
+  watchChange: WatchChange
+): api.ListenResponse {
+  if (watchChange instanceof ExistenceFilterChange) {
+    return {
+      filter: {
+        count: watchChange.existenceFilter.count,
+        targetId: watchChange.targetId
+      }
+    };
+  }
+  if (watchChange instanceof DocumentWatchChange) {
+    if (watchChange.newDoc instanceof Document) {
+      const doc = watchChange.newDoc;
+      return {
+        documentChange: {
+          document: {
+            name: serializer.toName(doc.key),
+            fields: doc.toProto().mapValue.fields,
+            updateTime: serializer.toVersion(doc.version)
+          },
+          targetIds: watchChange.updatedTargetIds,
+          removedTargetIds: watchChange.removedTargetIds
+        }
+      };
+    } else if (watchChange.newDoc instanceof NoDocument) {
+      const doc = watchChange.newDoc;
+      return {
+        documentDelete: {
+          document: serializer.toName(doc.key),
+          readTime: serializer.toVersion(doc.version),
+          removedTargetIds: watchChange.removedTargetIds
+        }
+      };
+    } else if (watchChange.newDoc === null) {
+      return {
+        documentRemove: {
+          document: serializer.toName(watchChange.key),
+          removedTargetIds: watchChange.removedTargetIds
+        }
+      };
+    }
+  }
+  if (watchChange instanceof WatchTargetChange) {
+    let cause: api.Status | undefined = undefined;
+    if (watchChange.cause) {
+      cause = {
+        code: mapRpcCodeFromCode(watchChange.cause.code),
+        message: watchChange.cause.message
+      };
+    }
+    return {
+      targetChange: {
+        targetChangeType: encodeTargetChangeTargetChangeType(watchChange.state),
+        targetIds: watchChange.targetIds,
+        resumeToken: serializer.toBytes(watchChange.resumeToken),
+        cause
+      }
+    };
+  }
+  return fail('Unrecognized watch change: ' + JSON.stringify(watchChange));
+}
+
+function encodeTargetChangeTargetChangeType(
+  state: WatchTargetChangeState
+): api.TargetChangeTargetChangeType {
+  switch (state) {
+    case WatchTargetChangeState.Added:
+      return 'ADD';
+    case WatchTargetChangeState.Current:
+      return 'CURRENT';
+    case WatchTargetChangeState.NoChange:
+      return 'NO_CHANGE';
+    case WatchTargetChangeState.Removed:
+      return 'REMOVE';
+    case WatchTargetChangeState.Reset:
+      return 'RESET';
+    default:
+      return fail('Unknown WatchTargetChangeState: ' + state);
+  }
+}


### PR DESCRIPTION
This PR moves test-only code out of our serializer in order to reduce SDK size.

It also pretty-prints the resume token in Spec tests since all good PRs need to have at least one unrelated change... :)

