### PR TITLE
Disable health-metrics test in pull requests from forked repo.

### DIFF
--- a/.github/workflows/health-metrics-test.yml
+++ b/.github/workflows/health-metrics-test.yml
@@ -5,6 +5,7 @@ on: [push, pull_request]
 jobs:
   binary-size-test:
     name: Binary Size
+    if: github.event_name == 'push' || !(github.event.pull_request.head.repo.fork)
     runs-on: ubuntu-latest
     env:
       METRICS_SERVICE_URL: ${{ secrets.METRICS_SERVICE_URL }}


### PR DESCRIPTION
Health metrics tests use secrets in this repo to work properly. However, secrets are not available in workflows triggered by pull requests from forked repo, therefore the metrics tests will always fail there. Disabling it to avoid leaving a failure mark on those pull requests.

https://help.github.com/en/actions/configuring-and-managing-workflows/creating-and-storing-encrypted-secrets#using-encrypted-secrets-in-a-workflow