### PR TITLE
Fix #2822: consistent write timing between refs and WriteBatch

### DIFF
--- a/packages/firestore/src/api/database.ts
+++ b/packages/firestore/src/api/database.ts
@@ -948,12 +948,14 @@ export class WriteBatch implements firestore.WriteBatch {
     return this;
   }
 
-  async commit(): Promise<void> {
+  commit(): Promise<void> {
     this.verifyNotCommitted();
     this._committed = true;
     if (this._mutations.length > 0) {
       return this._firestore.ensureClientConfigured().write(this._mutations);
     }
+
+    return Promise.resolve();
   }
 
   private verifyNotCommitted(): void {


### PR DESCRIPTION
This PR fixes #2822.

It ensures `this._firestore.ensureClientConfigured().write(this._mutations);` is being executed in the same event loop as the call of `batch.commit()`.