### PR TITLE
Tree-Shake ES5 classes

### DIFF
--- a/packages/firestore/package.json
+++ b/packages/firestore/package.json
@@ -51,6 +51,7 @@
   "devDependencies": {
     "protobufjs": "6.8.9",
     "rollup": "2.0.6",
+    "rollup-plugin-babel": "4.4.0",
     "rollup-plugin-copy-assets": "1.1.0",
     "rollup-plugin-json": "4.0.0",
     "rollup-plugin-node-resolve": "5.2.0",

--- a/packages/firestore/rollup.config.js
+++ b/packages/firestore/rollup.config.js
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2018 Google Inc.
+ * Copyright 2018 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -105,6 +105,13 @@ const es5BuildPlugins = [
     transformers: appendPrivatePrefixTransformers,
     cacheRoot: `./.cache/es5.mangled/`
   }),
+  {
+    transform(code) {
+      // Allow Rollup to drop unused classes. 
+      // See https://github.com/rollup/rollup/issues/2807
+      return code.replace(/\/\*\* @class \*\//g, "\/*@__PURE__*\/");
+    }
+  },
   json(),
   terser(manglePrivatePropertiesOptions)
 ];
@@ -152,7 +159,7 @@ const browserBuilds = [
       format: 'es',
       sourcemap: true
     },
-    plugins: es5BuildPlugins,
+    plugins: es2017BuildPlugins,
     external: resolveBrowserExterns
   },
   // ES2017 ESM build (memory-only)

--- a/packages/firestore/rollup.config.js
+++ b/packages/firestore/rollup.config.js
@@ -24,6 +24,7 @@ import copy from 'rollup-plugin-copy-assets';
 import sourcemaps from 'rollup-plugin-sourcemaps';
 import typescript from 'typescript';
 import { terser } from 'rollup-plugin-terser';
+import babel from 'rollup-plugin-babel';
 
 import pkg from './package.json';
 import memoryPkg from './memory/package.json';
@@ -101,19 +102,17 @@ export function resolveMemoryExterns(deps, externsId, referencedBy) {
 
 const es5BuildPlugins = [
   typescriptPlugin({
-    typescript,
+    typescript:  {
+      compilerOptions: {
+        target: 'es2017'
+      }
+    },
     transformers: appendPrivatePrefixTransformers,
     cacheRoot: `./.cache/es5.mangled/`
   }),
-  {
-    transform(code) {
-      // Allow Rollup to drop unused classes. 
-      // See https://github.com/rollup/rollup/issues/2807
-      return code.replace(/\/\*\* @class \*\//g, "\/*@__PURE__*\/");
-    }
-  },
   json(),
-  terser(manglePrivatePropertiesOptions)
+  terser(manglePrivatePropertiesOptions),
+  babel()
 ];
 
 const es2017BuildPlugins = [
@@ -202,16 +201,13 @@ const browserBuilds = [
 
 const nodeBuildPlugins = [
   typescriptPlugin({
-    typescript,
+    typescript:  {
+      compilerOptions: {
+        target: 'es2017'
+      }
+    },
     cacheRoot: `./.cache/node/`
   }),
-  {
-    transform(code) {
-      // Allow Rollup to drop unused classes. 
-      // See https://github.com/rollup/rollup/issues/2807
-      return code.replace(/\/\*\* @class \*\//g, "\/*@__PURE__*\/");
-    }
-  },
   json(),
   // Needed as we also use the *.proto files
   copy({
@@ -219,7 +215,8 @@ const nodeBuildPlugins = [
   }),
   replace({
     'process.env.FIRESTORE_PROTO_ROOT': JSON.stringify('src/protos')
-  })
+  }),
+  babel()
 ];
 
 const nodeBuilds = [

--- a/packages/firestore/rollup.config.js
+++ b/packages/firestore/rollup.config.js
@@ -205,6 +205,13 @@ const nodeBuildPlugins = [
     typescript,
     cacheRoot: `./.cache/node/`
   }),
+  {
+    transform(code) {
+      // Allow Rollup to drop unused classes. 
+      // See https://github.com/rollup/rollup/issues/2807
+      return code.replace(/\/\*\* @class \*\//g, "\/*@__PURE__*\/");
+    }
+  },
   json(),
   // Needed as we also use the *.proto files
   copy({

--- a/yarn.lock
+++ b/yarn.lock
@@ -229,7 +229,7 @@
   dependencies:
     "@babel/types" "^7.8.3"
 
-"@babel/helper-module-imports@^7.8.3":
+"@babel/helper-module-imports@^7.0.0", "@babel/helper-module-imports@^7.8.3":
   version "7.8.3"
   resolved "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.8.3.tgz#7fe39589b39c016331b6b8c3f441e8f0b1419498"
   integrity sha512-R0Bx3jippsbAEtzkpZ/6FIiuzOURPcMjHp+Z6xPe6DtApDJx+w7UYyOLanZqO8+wKR9G10s/FmHXvxaMd9s6Kg==
@@ -12590,6 +12590,14 @@ ripemd160@^2.0.0, ripemd160@^2.0.1:
   dependencies:
     hash-base "^3.0.0"
     inherits "^2.0.1"
+
+rollup-plugin-babel@4.4.0:
+  version "4.4.0"
+  resolved "https://registry.npmjs.org/rollup-plugin-babel/-/rollup-plugin-babel-4.4.0.tgz#d15bd259466a9d1accbdb2fe2fff17c52d030acb"
+  integrity sha512-Lek/TYp1+7g7I+uMfJnnSJ7YWoD58ajo6Oarhlex7lvUce+RCKRuGRSgztDO3/MF/PuGKmUL5iTHKf208UNszw==
+  dependencies:
+    "@babel/helper-module-imports" "^7.0.0"
+    rollup-pluginutils "^2.8.1"
 
 rollup-plugin-commonjs@10.1.0:
   version "10.1.0"


### PR DESCRIPTION
Rollup doesn't tree-shake ES5 classes since it cannot detect that they are side-effect free. The recommended way to solve this is to not use Typescript for the ES5 conversion, but Babel. Unfortunately, Typescript's ES5 is much smaller than Babels.

Luckily, the Internet answers all questions:

Typescript emits "@class" comment when a class is side-effect free:
https://github.com/microsoft/TypeScript/issues/13721

This can be rewritten to __PURE__ as show here:
https://github.com/rollup/rollup/issues/2807#issuecomment-486267624