### PR TITLE
Call PlatformSupport.setPlatform() in generate_spec_json.js

### DIFF
--- a/packages/firestore/test/unit/generate_spec_json.js
+++ b/packages/firestore/test/unit/generate_spec_json.js
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2017 Google Inc.
+ * Copyright 2017 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/firestore/test/unit/generate_spec_json.js
+++ b/packages/firestore/test/unit/generate_spec_json.js
@@ -29,6 +29,8 @@ var fs = require('fs');
 var mkdirp = require('mkdirp');
 
 const describeSpec = require('./specs/describe_spec');
+const nodePlatform = require('../../src/platform_node/node_platform');
+const platform = require('../../src/platform/platform');
 
 /**
  * Write the spec test at the given path as a JSON file.
@@ -49,6 +51,8 @@ function writeToJSON(testFile, jsonFile) {
  * @param {array} args The command line arguments.
  */
 function main(args) {
+  platform.PlatformSupport.setPlatform(new nodePlatform.NodePlatform());
+
   if (args.length !== 3) {
     console.error('usage: ./generate_spec_json.sh path/to/output');
     return;


### PR DESCRIPTION
This fixes the following error when `generate_spec_json.js` is run:

```
Error: FIRESTORE (7.11.0) INTERNAL ASSERTION FAILED: Platform not set
```

This error was introduced by https://github.com/firebase/firebase-js-sdk/commit/cae46453 a few days ago.  The easy fix is to just set the platform in main().
