### PR TITLE
Create FCM's CHANGELOG.md with a release note.

### DIFF
--- a/packages/messaging/CHANGELOG.md
+++ b/packages/messaging/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Unreleased
+- [fixed] Fixed an issue introduced in 7.7.0 where the FCM switched to provide base64-encoded VAPID key
+to [PushManager](https://developer.mozilla.org/en-US/docs/Web/API/PushManager) for push 
+subscribtion. For backward compatibility, the SDK switched back to use VAPID key in type (ArrayBuffer)[https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer].

--- a/packages/messaging/CHANGELOG.md
+++ b/packages/messaging/CHANGELOG.md
@@ -1,3 +1,4 @@
 # Unreleased
-- [fixed] Fixed an issue introduced in 7.7.0, when FCM switched to provide base64-encoded VAPID 
-key to [PushManager](https://developer.mozilla.org/en-US/docs/Web/API/PushManager) for push subscribtion. For backward compatibility, the SDK has switched back to using VAPID key in type [ArrayBuffer](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer).
+
+- [fixed] Fixed an issue introduced in 7.7.0, when FCM switched to provide base64-encoded VAPID
+  key to [PushManager](https://developer.mozilla.org/en-US/docs/Web/API/PushManager) for push subscription. For backward compatibility, the SDK has switched back to using VAPID key in type [ArrayBuffer](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer).

--- a/packages/messaging/CHANGELOG.md
+++ b/packages/messaging/CHANGELOG.md
@@ -1,4 +1,3 @@
 # Unreleased
-- [fixed] Fixed an issue introduced in 7.7.0 where the FCM switched to provide base64-encoded VAPID key
-to [PushManager](https://developer.mozilla.org/en-US/docs/Web/API/PushManager) for push 
-subscribtion. For backward compatibility, the SDK switched back to use VAPID key in type (ArrayBuffer)[https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer].
+- [fixed] Fixed an issue introduced in 7.7.0, when FCM switched to provide base64-encoded VAPID 
+key to [PushManager](https://developer.mozilla.org/en-US/docs/Web/API/PushManager) for push subscribtion. For backward compatibility, the SDK has switched back to using VAPID key in type [ArrayBuffer](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer).


### PR DESCRIPTION
FCM starts to have CHANGELOG.md for release notes (Thanks to the JS core and DevRel folks for creating/reviewing the previous release notes).

The first entry include the release note  that is meant for the release scheduled on 2020-04-02.
The fix will address the issues in https://github.com/firebase/firebase-js-sdk/issues/2712