### PR TITLE
Generate stable JSON from generate_spec_json.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -128,5 +128,9 @@
     "hooks": {
       "pre-push": "node tools/gitHooks/prepush.js"
     }
+  },
+  "dependencies": {
+    "@types/json-stable-stringify": "^1.0.32",
+    "json-stable-stringify": "^1.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -128,9 +128,5 @@
     "hooks": {
       "pre-push": "node tools/gitHooks/prepush.js"
     }
-  },
-  "dependencies": {
-    "@types/json-stable-stringify": "^1.0.32",
-    "json-stable-stringify": "^1.0.1"
   }
 }

--- a/packages/firestore/package.json
+++ b/packages/firestore/package.json
@@ -49,6 +49,8 @@
     "@firebase/app-types": "0.x"
   },
   "devDependencies": {
+    "@types/json-stable-stringify": "^1.0.32",
+    "json-stable-stringify": "^1.0.1",
     "protobufjs": "6.8.9",
     "rollup": "2.0.6",
     "rollup-plugin-copy-assets": "1.1.0",

--- a/packages/firestore/package.json
+++ b/packages/firestore/package.json
@@ -49,8 +49,8 @@
     "@firebase/app-types": "0.x"
   },
   "devDependencies": {
-    "@types/json-stable-stringify": "^1.0.32",
-    "json-stable-stringify": "^1.0.1",
+    "@types/json-stable-stringify": "1.0.32",
+    "json-stable-stringify": "1.0.1",
     "protobufjs": "6.8.9",
     "rollup": "2.0.6",
     "rollup-plugin-copy-assets": "1.1.0",

--- a/packages/firestore/test/unit/specs/describe_spec.ts
+++ b/packages/firestore/test/unit/specs/describe_spec.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2017 Google Inc.
+ * Copyright 2017 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/yarn.lock
+++ b/yarn.lock
@@ -2116,6 +2116,11 @@
   resolved "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.3.tgz#bdfd69d61e464dcc81b25159c270d75a73c1a636"
   integrity sha512-Il2DtDVRGDcqjDtE+rF8iqg1CArehSK84HZJCT7AMITlyXRBpuPhqGLDQMowraqqu1coEaimg4ZOqggt6L6L+A==
 
+"@types/json-stable-stringify@^1.0.32":
+  version "1.0.32"
+  resolved "https://registry.npmjs.org/@types/json-stable-stringify/-/json-stable-stringify-1.0.32.tgz#121f6917c4389db3923640b2e68de5fa64dda88e"
+  integrity sha512-q9Q6+eUEGwQkv4Sbst3J4PNgDOvpuVuKj79Hl/qnmBMEIPzB5QoFRUtjcgcg2xNUZyYUGXBk5wYIBKHt0A+Mxw==
+
 "@types/long@*", "@types/long@^4.0.0":
   version "4.0.0"
   resolved "https://registry.npmjs.org/@types/long/-/long-4.0.0.tgz#719551d2352d301ac8b81db732acb6bdc28dbdef"
@@ -8918,6 +8923,13 @@ json-stable-stringify-without-jsonify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
   integrity sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=
+
+json-stable-stringify@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz#9a759d39c5f2ff503fd5300646ed445f88c4f9af"
+  integrity sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=
+  dependencies:
+    jsonify "~0.0.0"
 
 json-stable-stringify@~0.0.0:
   version "0.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2116,7 +2116,7 @@
   resolved "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.3.tgz#bdfd69d61e464dcc81b25159c270d75a73c1a636"
   integrity sha512-Il2DtDVRGDcqjDtE+rF8iqg1CArehSK84HZJCT7AMITlyXRBpuPhqGLDQMowraqqu1coEaimg4ZOqggt6L6L+A==
 
-"@types/json-stable-stringify@^1.0.32":
+"@types/json-stable-stringify@1.0.32":
   version "1.0.32"
   resolved "https://registry.npmjs.org/@types/json-stable-stringify/-/json-stable-stringify-1.0.32.tgz#121f6917c4389db3923640b2e68de5fa64dda88e"
   integrity sha512-q9Q6+eUEGwQkv4Sbst3J4PNgDOvpuVuKj79Hl/qnmBMEIPzB5QoFRUtjcgcg2xNUZyYUGXBk5wYIBKHt0A+Mxw==
@@ -8924,7 +8924,7 @@ json-stable-stringify-without-jsonify@^1.0.1:
   resolved "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
   integrity sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=
 
-json-stable-stringify@^1.0.1:
+json-stable-stringify@1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz#9a759d39c5f2ff503fd5300646ed445f88c4f9af"
   integrity sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=


### PR DESCRIPTION
Currently, the JSON generated by `generate_spec_json.js` uses `JSON.stringify()`, which generates JSON with the keys ordered by the order in which they are set in the objects.  As a result, code changes that alter the order in which the keys as added but have no other side effects cause different stringified JSON to be generated, resulting in unnecessarily-noisy diffs.

This PR changes `generate_spec_json.js` to use the third-party `json-stable-stringify` library: https://www.npmjs.com/package/json-stable-stringify.  This library produces JSON that has a stable key ordering, resulting in diffs when and only when keys are added, removed, or have their values modified.

I also implemented a custom comparator so that the generated JSON has a semblance of human readability, with the test "configuration" at the top and the "expected" blocks at the bottom.

I will submit follow-up PRs to the Android and iOS repositories with the new, stable JSON.  These PRs will be very noisy but will allow for cleaner future diffs.