### PR TITLE
Only iterate across active targets in WatchChangeAggregator

### DIFF
--- a/packages/firestore/src/api/database.ts
+++ b/packages/firestore/src/api/database.ts
@@ -2620,7 +2620,7 @@ function applyFirestoreDataConverter<T>(
   return [convertedValue, functionName];
 }
 
-function contains(obj: object, key: string): obj is { key : unknown } {
+function contains(obj: object, key: string): obj is { key: unknown } {
   return Object.prototype.hasOwnProperty.call(obj, key);
 }
 

--- a/packages/firestore/src/remote/watch_change.ts
+++ b/packages/firestore/src/remote/watch_change.ts
@@ -367,7 +367,11 @@ export class WatchChangeAggregator {
     if (targetChange.targetIds.length > 0) {
       targetChange.targetIds.forEach(fn);
     } else {
-      this.targetStates.forEach((_, targetId) => fn(targetId));
+      this.targetStates.forEach((_, targetId) => {
+        if (this.isActiveTarget(targetId)) {
+          fn(targetId);
+        }
+      });
     }
   }
 


### PR DESCRIPTION
Follow up from the customer issue in which Firestore was iterating through inactive targets multiple times in the logs. 

Additional change from prettier in database.ts that was probably not pushed up.