### PR TITLE
Request for ealy comments: IndexedDB recovery

### DIFF
--- a/packages/firestore/src/local/local_serializer.ts
+++ b/packages/firestore/src/local/local_serializer.ts
@@ -170,7 +170,7 @@ export class LocalSerializer {
       mutations
     );
   }
-  
+
   /** Decodes a DbTarget into TargetData */
   fromDbTarget(dbTarget: DbTarget): TargetData {
     const version = this.fromDbTimestamp(dbTarget.readTime);

--- a/packages/firestore/src/local/local_store.ts
+++ b/packages/firestore/src/local/local_store.ts
@@ -65,6 +65,8 @@ import { ByteString } from '../util/byte_string';
 
 const LOG_TAG = 'LocalStore';
 
+const REMOTE_SNAPSHOT_REVERTED_ERROR_MSG = 'Remote version went back in time';
+
 /** The result of a write to the local store. */
 export interface LocalWriteResult {
   batchId: BatchId;
@@ -511,155 +513,155 @@ export class LocalStore {
 
     return this.persistence
       .runTransaction('Apply remote event', 'readwrite-primary', txn => {
-        const documentBuffer = this.remoteDocuments.newChangeBuffer({
-          trackRemovals: true // Make sure document removals show up in `getNewDocumentChanges()`
-        });
+        return this.targetCache
+          .getLastRemoteSnapshotVersion(txn)
+          .next(lastRemoteSnapshotVersion => {
+            const promises = [] as Array<PersistencePromise<void>>;
 
-        // Reset newTargetDataByTargetMap in case this transaction gets re-run.
-        newTargetDataByTargetMap = this.targetDataByTarget;
-
-        const promises = [] as Array<PersistencePromise<void>>;
-        remoteEvent.targetChanges.forEach((change, targetId) => {
-          const oldTargetData = newTargetDataByTargetMap.get(targetId);
-          if (!oldTargetData) {
-            return;
-          }
-
-          // Only update the remote keys if the target is still active. This
-          // ensures that we can persist the updated target data along with
-          // the updated assignment.
-          promises.push(
-            this.targetCache
-              .removeMatchingKeys(txn, change.removedDocuments, targetId)
-              .next(() => {
-                return this.targetCache.addMatchingKeys(
-                  txn,
-                  change.addedDocuments,
-                  targetId
-                );
-              })
-          );
-
-          const resumeToken = change.resumeToken;
-          // Update the resume token if the change includes one.
-          if (resumeToken.approximateByteSize() > 0) {
-            const newTargetData = oldTargetData
-              .withResumeToken(resumeToken, remoteVersion)
-              .withSequenceNumber(txn.currentSequenceNumber);
-            newTargetDataByTargetMap = newTargetDataByTargetMap.insert(
-              targetId,
-              newTargetData
-            );
-
-            // Update the target data if there are target changes (or if
-            // sufficient time has passed since the last update).
-            if (
-              LocalStore.shouldPersistTargetData(
-                oldTargetData,
-                newTargetData,
-                change
-              )
-            ) {
-              promises.push(
-                this.targetCache.updateTargetData(txn, newTargetData)
-              );
-            }
-          }
-        });
-
-        let changedDocs = maybeDocumentMap();
-        let updatedKeys = documentKeySet();
-        remoteEvent.documentUpdates.forEach((key, doc) => {
-          updatedKeys = updatedKeys.add(key);
-        });
-
-        // Each loop iteration only affects its "own" doc, so it's safe to get all the remote
-        // documents in advance in a single call.
-        promises.push(
-          documentBuffer.getEntries(txn, updatedKeys).next(existingDocs => {
-            remoteEvent.documentUpdates.forEach((key, doc) => {
-              const existingDoc = existingDocs.get(key);
-
-              // Note: The order of the steps below is important, since we want
-              // to ensure that rejected limbo resolutions (which fabricate
-              // NoDocuments with SnapshotVersion.MIN) never add documents to
-              // cache.
-              if (
-                doc instanceof NoDocument &&
-                doc.version.isEqual(SnapshotVersion.MIN)
-              ) {
-                // NoDocuments with SnapshotVersion.MIN are used in manufactured
-                // events. We remove these documents from cache since we lost
-                // access.
-                documentBuffer.removeEntry(key, remoteVersion);
-                changedDocs = changedDocs.insert(key, doc);
-              } else if (
-                existingDoc == null ||
-                doc.version.compareTo(existingDoc.version) > 0 ||
-                (doc.version.compareTo(existingDoc.version) === 0 &&
-                  existingDoc.hasPendingWrites)
-              ) {
-                assert(
-                  !SnapshotVersion.MIN.isEqual(remoteVersion),
-                  'Cannot add a document when the remote version is zero'
-                );
-                documentBuffer.addEntry(doc, remoteVersion);
-                changedDocs = changedDocs.insert(key, doc);
-              } else {
-                logDebug(
-                  LOG_TAG,
-                  'Ignoring outdated watch update for ',
-                  key,
-                  '. Current version:',
-                  existingDoc.version,
-                  ' Watch version:',
-                  doc.version
-                );
-              }
-
-              if (remoteEvent.resolvedLimboDocuments.has(key)) {
-                promises.push(
-                  this.persistence.referenceDelegate.updateLimboDocument(
-                    txn,
-                    key
+            // HACK: The only reason we allow a null snapshot version is so that we
+            // can synthesize remote events when we get permission denied errors while
+            // trying to resolve the state of a locally cached document that is in
+            // limbo.
+            if (!remoteVersion.isEqual(SnapshotVersion.MIN)) {
+              if (remoteVersion.compareTo(lastRemoteSnapshotVersion) < 0) {
+                return PersistencePromise.reject<MaybeDocumentMap>(
+                  new FirestoreError(
+                    Code.FAILED_PRECONDITION,
+                    REMOTE_SNAPSHOT_REVERTED_ERROR_MSG
                   )
                 );
               }
-            });
-          })
-        );
-
-        // HACK: The only reason we allow a null snapshot version is so that we
-        // can synthesize remote events when we get permission denied errors while
-        // trying to resolve the state of a locally cached document that is in
-        // limbo.
-        if (!remoteVersion.isEqual(SnapshotVersion.MIN)) {
-          const updateRemoteVersion = this.targetCache
-            .getLastRemoteSnapshotVersion(txn)
-            .next(lastRemoteSnapshotVersion => {
-              assert(
-                remoteVersion.compareTo(lastRemoteSnapshotVersion) >= 0,
-                'Watch stream reverted to previous snapshot?? ' +
-                  remoteVersion +
-                  ' < ' +
-                  lastRemoteSnapshotVersion
+              promises.push(
+                this.targetCache.setTargetsMetadata(
+                  txn,
+                  txn.currentSequenceNumber,
+                  remoteVersion
+                )
               );
-              return this.targetCache.setTargetsMetadata(
-                txn,
-                txn.currentSequenceNumber,
-                remoteVersion
-              );
-            });
-          promises.push(updateRemoteVersion);
-        }
+            }
 
-        return PersistencePromise.waitFor(promises)
-          .next(() => documentBuffer.apply(txn))
-          .next(() => {
-            return this.localDocuments.getLocalViewOfDocuments(
-              txn,
-              changedDocs
+            const documentBuffer = this.remoteDocuments.newChangeBuffer({
+              trackRemovals: true // Make sure document removals show up in `getNewDocumentChanges()`
+            });
+
+            // Reset newTargetDataByTargetMap in case this transaction gets re-run.
+            newTargetDataByTargetMap = this.targetDataByTarget;
+
+            remoteEvent.targetChanges.forEach((change, targetId) => {
+              const oldTargetData = newTargetDataByTargetMap.get(targetId);
+              if (!oldTargetData) {
+                return;
+              }
+
+              // Only update the remote keys if the target is still active. This
+              // ensures that we can persist the updated target data along with
+              // the updated assignment.
+              promises.push(
+                this.targetCache
+                  .removeMatchingKeys(txn, change.removedDocuments, targetId)
+                  .next(() => {
+                    return this.targetCache.addMatchingKeys(
+                      txn,
+                      change.addedDocuments,
+                      targetId
+                    );
+                  })
+              );
+
+              const resumeToken = change.resumeToken;
+              // Update the resume token if the change includes one.
+              if (resumeToken.approximateByteSize() > 0) {
+                const newTargetData = oldTargetData
+                  .withResumeToken(resumeToken, remoteVersion)
+                  .withSequenceNumber(txn.currentSequenceNumber);
+                newTargetDataByTargetMap = newTargetDataByTargetMap.insert(
+                  targetId,
+                  newTargetData
+                );
+
+                // Update the target data if there are target changes (or if
+                // sufficient time has passed since the last update).
+                if (
+                  LocalStore.shouldPersistTargetData(
+                    oldTargetData,
+                    newTargetData,
+                    change
+                  )
+                ) {
+                  promises.push(
+                    this.targetCache.updateTargetData(txn, newTargetData)
+                  );
+                }
+              }
+            });
+
+            let changedDocs = maybeDocumentMap();
+            let updatedKeys = documentKeySet();
+            remoteEvent.documentUpdates.forEach((key, doc) => {
+              updatedKeys = updatedKeys.add(key);
+            });
+
+            // Each loop iteration only affects its "own" doc, so it's safe to get all the remote
+            // documents in advance in a single call.
+            promises.push(
+              documentBuffer.getEntries(txn, updatedKeys).next(existingDocs => {
+                remoteEvent.documentUpdates.forEach((key, doc) => {
+                  const existingDoc = existingDocs.get(key);
+
+                  // Note: The order of the steps below is important, since we want
+                  // to ensure that rejected limbo resolutions (which fabricate
+                  // NoDocuments with SnapshotVersion.MIN) never add documents to
+                  // cache.
+                  if (
+                    doc instanceof NoDocument &&
+                    doc.version.isEqual(SnapshotVersion.MIN)
+                  ) {
+                    // NoDocuments with SnapshotVersion.MIN are used in manufactured
+                    // events. We remove these documents from cache since we lost
+                    // access.
+                    documentBuffer.removeEntry(key, remoteVersion);
+                    changedDocs = changedDocs.insert(key, doc);
+                  } else if (
+                    existingDoc == null ||
+                    doc.version.compareTo(existingDoc.version) > 0 ||
+                    (doc.version.compareTo(existingDoc.version) === 0 &&
+                      existingDoc.hasPendingWrites)
+                  ) {
+                    assert(
+                      !SnapshotVersion.MIN.isEqual(remoteVersion),
+                      'Cannot add a document when the remote version is zero'
+                    );
+                    documentBuffer.addEntry(doc, remoteVersion);
+                    changedDocs = changedDocs.insert(key, doc);
+                  } else {
+                    logDebug(
+                      LOG_TAG,
+                      'Ignoring outdated watch update for ',
+                      key,
+                      '. Current version:',
+                      existingDoc.version,
+                      ' Watch version:',
+                      doc.version
+                    );
+                  }
+
+                  if (remoteEvent.resolvedLimboDocuments.has(key)) {
+                    promises.push(
+                      this.persistence.referenceDelegate.updateLimboDocument(
+                        txn,
+                        key
+                      )
+                    );
+                  }
+                });
+              })
             );
+
+            return PersistencePromise.waitFor(promises)
+              .next(() => documentBuffer.apply(txn))
+              .next(() =>
+                this.localDocuments.getLocalViewOfDocuments(txn, changedDocs)
+              );
           });
       })
       .then(changedDocs => {
@@ -1108,15 +1110,26 @@ export class LocalStore {
  * @param err An error returned by a LocalStore operation.
  * @return A Promise that resolves after we recovered, or the original error.
  */
-export async function ignoreIfPrimaryLeaseLoss(
-  err: FirestoreError
-): Promise<void> {
+export function handlePrimaryLeaseLoss(err: FirestoreError): boolean {
   if (
     err.code === Code.FAILED_PRECONDITION &&
     err.message === PRIMARY_LEASE_LOST_ERROR_MSG
   ) {
     logDebug(LOG_TAG, 'Unexpectedly lost primary lease');
+    return true;
   } else {
-    throw err;
+    return false;
+  }
+}
+
+export function handleOutdatedRemoteSnapshot(err: FirestoreError): boolean {
+  if (
+    err.code === Code.FAILED_PRECONDITION &&
+    err.message === REMOTE_SNAPSHOT_REVERTED_ERROR_MSG
+  ) {
+    logDebug(LOG_TAG, 'Remote version went back in time');
+    return true;
+  } else {
+    return false;
   }
 }

--- a/packages/firestore/src/local/lru_garbage_collector.ts
+++ b/packages/firestore/src/local/lru_garbage_collector.ts
@@ -24,7 +24,7 @@ import { primitiveComparator } from '../util/misc';
 import { CancelablePromise } from '../util/promise';
 import { SortedMap } from '../util/sorted_map';
 import { SortedSet } from '../util/sorted_set';
-import { ignoreIfPrimaryLeaseLoss, LocalStore } from './local_store';
+import { LocalStore } from './local_store';
 import { PersistenceTransaction } from './persistence';
 import { PersistencePromise } from './persistence_promise';
 import { TargetData } from './target_data';
@@ -265,7 +265,9 @@ export class LruScheduler {
         return localStore
           .collectGarbage(this.garbageCollector)
           .then(() => this.scheduleGC(localStore))
-          .catch(ignoreIfPrimaryLeaseLoss);
+          .catch(() => {
+            // TODO
+          });
       }
     );
   }

--- a/packages/firestore/test/unit/specs/recovery_spec.test.ts
+++ b/packages/firestore/test/unit/specs/recovery_spec.test.ts
@@ -1,0 +1,225 @@
+/**
+ * @license
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describeSpec, specTest } from './describe_spec';
+import { spec } from './spec_builder';
+import { Query } from '../../../src/core/query';
+import { doc, path } from '../../util/helpers';
+import { Code } from '../../../src/util/error';
+import { RpcError } from './spec_rpc_error';
+
+describeSpec(
+  'Persistence Recovery',
+  ['durable-persistence', 'no-ios', 'no-android'],
+  () => {
+    specTest('Recovers when write cannot be persisted', [], () => {
+      return spec()
+        .userSets('collection/key1', { foo: 'a' })
+        .expectNumOutstandingWrites(1)
+        .userSets('collection/key2', { bar: 'b' })
+        .failDatabaseTransaction({ rejectedDocs: ['collection/key2'] })
+        .expectNumOutstandingWrites(1)
+        .userSets('collection/key3', { baz: 'c' })
+        .expectNumOutstandingWrites(2)
+        .writeAcks('collection/key1', 1)
+        .writeAcks('collection/key3', 2)
+        .expectNumOutstandingWrites(0);
+    });
+
+    specTest('Does not surface non-persisted writes', [], () => {
+      const query = Query.atPath(path('collection'));
+      const doc1Local = doc(
+        'collection/key1',
+        0,
+        { foo: 'a' },
+        { hasLocalMutations: true }
+      );
+      const doc1 = doc('collection/key1', 1, { foo: 'a' });
+      const doc3Local = doc(
+        'collection/key3',
+        0,
+        { foo: 'c' },
+        { hasLocalMutations: true }
+      );
+      const doc3 = doc('collection/key3', 2, { foo: 'c' });
+      return spec()
+        .userListens(query)
+        .userSets('collection/key1', { foo: 'a' })
+        .expectEvents(query, {
+          added: [doc1Local],
+          fromCache: true,
+          hasPendingWrites: true
+        })
+        .userSets('collection/key2', { foo: 'b' })
+        .failDatabaseTransaction({ rejectedDocs: ['collection/key2'] })
+        .userSets('collection/key3', { foo: 'c' })
+        .expectEvents(query, {
+          added: [doc3Local],
+          fromCache: true,
+          hasPendingWrites: true
+        })
+        .writeAcks('collection/key1', 1)
+        .writeAcks('collection/key3', 2)
+        .watchAcksFull(query, 2, doc1, doc3)
+        .expectEvents(query, { metadata: [doc1, doc3] });
+    });
+
+    specTest(
+      'Recovers when write acknowledgement cannot be persisted (with restart)',
+      [],
+      () => {
+        return (
+          spec()
+            .userSets('collection/key1', { foo: 'a' })
+            .userSets('collection/key2', { foo: 'b' })
+            // Fail the write ack. We don't reject the user promise since we don't
+            // want the user to retry the write
+            .writeAcks('collection/key1', 1, { expectUserCallback: true })
+            .failDatabaseTransaction()
+            .expectNumOutstandingWrites(1)
+            // The write stream is now offline. It will reconnect when a new write
+            // is issued or upon client restart.
+            .restart()
+            .expectNumOutstandingWrites(2)
+            .failWrite(
+              'collection/key1',
+              new RpcError(Code.FAILED_PRECONDITION, 'Stream token invalid'),
+              { expectUserCallback: false }
+            )
+            .expectNumOutstandingWrites(1)
+            .writeAcks('collection/key2', 2, { expectUserCallback: false })
+            .expectNumOutstandingWrites(0)
+        );
+      }
+    );
+
+    specTest(
+      'Recovers when write acknowledgement cannot be persisted (with new write)',
+      [],
+      () => {
+        return (
+          spec()
+            .userSets('collection/key1', { foo: 'a' })
+            // Fail the write ack. We resolve the user promise since we don't want
+            // the user to retry the write
+            .writeAcks('collection/key1', 1, { expectUserCallback: true })
+            .failDatabaseTransaction()
+            // The write stream is now offline. It will reconnect when a new write
+            // is issued or upon client restart.
+            .userSets('collection/key2', { foo: 'b' })
+            .expectNumOutstandingWrites(2)
+            .failWrite(
+              'collection/key1',
+              new RpcError(Code.FAILED_PRECONDITION, 'Stream token invalid'),
+              { expectUserCallback: false }
+            )
+            .expectNumOutstandingWrites(1)
+            .writeAcks('collection/key2', 2)
+            .expectNumOutstandingWrites(0)
+        );
+      }
+    );
+
+    specTest(
+      'Recovers when write rejection cannot be persisted (with new write)',
+      [],
+      () => {
+        return (
+          spec()
+            .userPatches('collection/key1', { foo: 'a' })
+            .failWrite(
+              'collection/key1',
+              new RpcError(Code.FAILED_PRECONDITION, 'No document to update'),
+              { expectUserCallback: true }
+            )
+            .failDatabaseTransaction()
+            // The write stream is now offline. Re-opening the stream causes both
+            // writes to be send.
+            .userPatches('collection/key2', { foo: 'b' })
+            .expectNumOutstandingWrites(2)
+            .failWrite(
+              'collection/key1',
+              new RpcError(Code.FAILED_PRECONDITION, 'Stream token invalid'),
+              { expectUserCallback: false }
+            )
+            .expectNumOutstandingWrites(1)
+            .writeAcks('collection/key2', 2)
+            .expectNumOutstandingWrites(0)
+        );
+      }
+    );
+
+    specTest(
+      'Recovers when watch update cannot be persisted',
+      [],
+      () => {
+        const query = Query.atPath(path('collection'));
+        const doc1 = doc('collection/key1', 1, { foo: 'a' });
+        const doc2 = doc('collection/key2', 2, { foo: 'b' });
+        return spec()
+          .userListens(query)
+          .watchAcksFull(query, 1000, doc1)
+          .expectEvents(query, {
+            added: [doc1]
+          })
+          .watchSends({ affects: [query] }, doc2)
+          .watchSnapshots(2000)
+          .failDatabaseTransaction({ rejectedTargets: [query] })
+          .expectEvents(query, { errorCode: Code.INTERNAL })
+          .watchRemoves(query)
+          .userListens(query, 'resume-token-1000')
+          .expectEvents(query, {
+            added: [doc1],
+            fromCache: true
+          })
+          .watchAcksFull(query, 2000, doc2)
+          .expectEvents(query, {
+            added: [doc2]
+          });
+      }
+    );
+
+    specTest('Only fails targets that cannot be persisted', [], () => {
+      const query1 = Query.atPath(path('collection1'));
+      const query2 = Query.atPath(path('collection2'));
+      const doc1a = doc('collection1/keyA', 1, { foo: 'a' });
+      const doc2a = doc('collection2/keyA', 2, { foo: 'b' });
+      const doc1b = doc('collection1/keyB', 3, { foo: 'b' });
+      const doc2b = doc('collection2/keyB', 4, { foo: 'b' });
+      return spec()
+        .userListens(query1)
+        .watchAcksFull(query1, 1, doc1a)
+        .expectEvents(query1, {
+          added: [doc1a]
+        })
+        .userListens(query2)
+        .watchAcksFull(query2, 2, doc2a)
+        .expectEvents(query2, {
+          added: [doc2a]
+        })
+        .watchSends({ affects: [query1] }, doc1b)
+        .watchSnapshots(3)
+        .failDatabaseTransaction({ rejectedTargets: [query1] })
+        .expectEvents(query1, { errorCode: Code.INTERNAL })
+        .watchSends({ affects: [query2] }, doc2b)
+        .watchSnapshots(4)
+        .expectEvents(query2, {
+          added: [doc2b]
+        });
+    });
+  }
+);

--- a/packages/firestore/test/unit/specs/spec_test_runner.ts
+++ b/packages/firestore/test/unit/specs/spec_test_runner.ts
@@ -48,11 +48,17 @@ import {
 import { LocalStore } from '../../../src/local/local_store';
 import { LruParams } from '../../../src/local/lru_garbage_collector';
 import {
+  PersistenceTransaction,
+  PersistenceTransactionMode,
+  PrimaryStateListener,
+  Persistence,
+  ReferenceDelegate
+} from '../../../src/local/persistence';
+import {
   MemoryEagerDelegate,
   MemoryLruDelegate,
   MemoryPersistence
 } from '../../../src/local/memory_persistence';
-import { Persistence } from '../../../src/local/persistence';
 import {
   ClientId,
   MemorySharedClientState,
@@ -115,6 +121,11 @@ import {
 } from '../local/persistence_test_helpers';
 import { MULTI_CLIENT_TAG } from './describe_spec';
 import { ByteString } from '../../../src/util/byte_string';
+import { PersistencePromise } from '../../../src/local/persistence_promise';
+import { MutationQueue } from '../../../src/local/mutation_queue';
+import { TargetCache } from '../../../src/local/target_cache';
+import { RemoteDocumentCache } from '../../../src/local/remote_document_cache';
+import { IndexManager } from '../../../src/local/index_manager';
 import { SortedSet } from '../../../src/util/sorted_set';
 import { ActiveTargetMap, ActiveTargetSpec } from './spec_builder';
 
@@ -338,6 +349,79 @@ class MockConnection implements Connection {
 }
 
 /**
+ * A test-only persistence implementation that delegates all calls to the
+ * underlying IndexedDB or Memory-based persistence implementations and is able
+ * to inject failed transactions.
+ */
+export class MockPersistence implements Persistence {
+  injectFailures = false;
+
+  constructor(private readonly delegate: Persistence) {}
+
+  get started(): boolean {
+    return this.delegate.started;
+  }
+
+  get referenceDelegate(): ReferenceDelegate {
+    return this.delegate.referenceDelegate;
+  }
+
+  shutdown(): Promise<void> {
+    return this.delegate.shutdown();
+  }
+
+  setPrimaryStateListener(
+    primaryStateListener: PrimaryStateListener
+  ): Promise<void> {
+    return this.delegate.setPrimaryStateListener(primaryStateListener);
+  }
+
+  setDatabaseDeletedListener(
+    databaseDeletedListener: () => Promise<void>
+  ): void {
+    this.delegate.setDatabaseDeletedListener(databaseDeletedListener);
+  }
+
+  setNetworkEnabled(networkEnabled: boolean): void {
+    this.delegate.setNetworkEnabled(networkEnabled);
+  }
+
+  getActiveClients(): Promise<ClientId[]> {
+    return this.delegate.getActiveClients();
+  }
+
+  getMutationQueue(user: User): MutationQueue {
+    return this.delegate.getMutationQueue(user);
+  }
+
+  getTargetCache(): TargetCache {
+    return this.delegate.getTargetCache();
+  }
+
+  getRemoteDocumentCache(): RemoteDocumentCache {
+    return this.delegate.getRemoteDocumentCache();
+  }
+
+  getIndexManager(): IndexManager {
+    return this.delegate.getIndexManager();
+  }
+
+  runTransaction<T>(
+    action: string,
+    mode: PersistenceTransactionMode,
+    transactionOperation: (
+      transaction: PersistenceTransaction
+    ) => PersistencePromise<T>
+  ): Promise<T> {
+    if (this.injectFailures) {
+      return Promise.reject(new Error('Injected Failure'));
+    } else {
+      return this.delegate.runTransaction(action, mode, transactionOperation);
+    }
+  }
+}
+
+/**
  * Interface used for object that contain exactly one of either a view snapshot
  * or an error for the given query.
  */
@@ -391,6 +475,19 @@ class SharedWriteTracker {
     assert(this.writes.length > 0, 'No pending mutations');
     return this.writes.shift()!;
   }
+
+  removeAll(documentKey: string): void {
+    const filteredMutationBatches: Mutation[][] = [];
+    for (const mutations of this.writes) {
+      const filteredMutations = mutations.filter(
+        m => m.key.path.toString() !== documentKey
+      );
+      if (filteredMutations.length) {
+        filteredMutationBatches.push(filteredMutations);
+      }
+    }
+    this.writes = filteredMutationBatches;
+  }
 }
 
 abstract class TestRunner {
@@ -421,7 +518,7 @@ abstract class TestRunner {
   private datastore!: Datastore;
   private localStore!: LocalStore;
   private remoteStore!: RemoteStore;
-  private persistence!: Persistence;
+  private persistence!: MockPersistence;
   protected sharedClientState!: SharedClientState;
 
   private useGarbageCollection: boolean;
@@ -471,10 +568,11 @@ abstract class TestRunner {
 
   async start(): Promise<void> {
     this.sharedClientState = this.getSharedClientState();
-    this.persistence = await this.initPersistence(
+    const persistence = await this.initPersistence(
       this.serializer,
       this.useGarbageCollection
     );
+    this.persistence = new MockPersistence(persistence);
 
     const queryEngine = new IndexFreeQueryEngine();
     this.localStore = new LocalStore(this.persistence, queryEngine, this.user);
@@ -571,6 +669,8 @@ abstract class TestRunner {
   }
 
   private doStep(step: SpecStep): Promise<void> {
+    this.persistence.injectFailures = !!step.failDatabaseTransactions;
+
     if ('userListen' in step) {
       return this.doListen(step.userListen!);
     } else if ('userUnlisten' in step) {
@@ -715,9 +815,18 @@ abstract class TestRunner {
   private doMutations(mutations: Mutation[]): Promise<void> {
     const documentKeys = mutations.map(val => val.key.path.toString());
     const syncEngineCallback = new Deferred<void>();
+
     syncEngineCallback.promise.then(
       () => this.acknowledgedDocs.push(...documentKeys),
-      () => this.rejectedDocs.push(...documentKeys)
+      (e: Error) => {
+        this.rejectedDocs.push(...documentKeys);
+
+        if (e.message === 'Injected Failure') {
+          // The write was not persisted, so we remove it from `sharedWrites`
+          // again.
+          documentKeys.forEach(key => this.sharedWrites.removeAll(key));
+        }
+      }
     );
 
     this.sharedWrites.push(mutations);
@@ -1206,7 +1315,7 @@ abstract class TestRunner {
         `ResumeToken does not match - expected:
          ${stringFromBase64String(
            expectedTarget.resumeToken
-         )}, actual: ${stringFromBase64String(expectedTarget.resumeToken)}`
+         )}, actual: ${stringFromBase64String(actualTarget.resumeToken)}`
       );
       delete actualTargets[targetId];
     });
@@ -1473,6 +1582,9 @@ export interface SpecStep {
   writeAck?: SpecWriteAck;
   /** Fail a write */
   failWrite?: SpecWriteFailure;
+
+  /** Fail all database transactions. */
+  failDatabaseTransactions?: boolean;
 
   /**
    * Run a queued timer task (without waiting for the delay to expire). See

--- a/packages/firestore/test/unit/specs/write_spec.test.ts
+++ b/packages/firestore/test/unit/specs/write_spec.test.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2017 Google Inc.
+ * Copyright 2017 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -1082,9 +1082,11 @@ describeSpec('Writes:', [], () => {
         .client(0)
         // The old primary doesn't yet know that client 1 has stolen the
         // primary lease.
-        .expectListen(query2)
+        .expectListen(query2, 'resume-token-2000')
         .runTimer(TimerId.ClientMetadataRefresh)
         .expectPrimaryState(false)
+        .expectUnlisten(query1)
+        .expectUnlisten(query2)
         // Raise the metadata event from LocalStorage.
         .expectEvents(query1, {
           metadata: [docV1Acknowledged]

--- a/packages/firestore/test/util/helpers.ts
+++ b/packages/firestore/test/util/helpers.ts
@@ -524,13 +524,12 @@ export function byteStringFromString(value: string): ByteString {
  */
 export function stringFromBase64String(
   value?: string | Uint8Array
-): ByteString {
+): string {
   assert(
     value === undefined || typeof value === 'string',
     'Can only decode base64 encoded strings'
   );
-  const base64 = PlatformSupport.getPlatform().btoa(value ?? '');
-  return ByteString.fromBase64String(base64);
+  return PlatformSupport.getPlatform().atob(value ?? '');
 }
 
 /** Creates a resume token to match the given snapshot version. */


### PR DESCRIPTION
This PR is somewhere between exploration and hack. It is meant to provide a strategy for IndexedDB recovery.

So far, it recovers:
- When a Watch updates cannot be persisted. 
- When a mutation cannot be written to the mutation queue.
- When a mutation acknowledgement or rejection cannot be persisted.

Some notes: go/indexeddb-recovery