### PR TITLE
Fix messaging in chrome extension pages (#2846)

### DIFF
--- a/packages/messaging/src/controllers/sw-controller.ts
+++ b/packages/messaging/src/controllers/sw-controller.ts
@@ -297,7 +297,7 @@ function hasVisibleClients(clientList: WindowClient[]): boolean {
       client.visibilityState === 'visible' &&
       // Ignore chrome-extension clients as that matches the background pages
       // of extensions, which are always considered visible for some reason.
-      !client.url.startsWith('chrome-extension://')
+      !(client.url.startsWith('chrome-extension://') && client.url.endsWith("_generated_background_page.html"))
   );
 }
 


### PR DESCRIPTION
Fixed problem with not working `onMessage` handler in chrome extension pages.