### PR TITLE
Fix broken CI

### DIFF
--- a/packages-exp/app-exp/package.json
+++ b/packages-exp/app-exp/package.json
@@ -24,9 +24,9 @@
   },
   "dependencies": {
     "@firebase/app-types-exp": "0.800.0",
-    "@firebase/util": "0.2.43",
-    "@firebase/logger": "0.2.0",
-    "@firebase/component": "0.1.8",
+    "@firebase/util": "0.2.44",
+    "@firebase/logger": "0.2.1",
+    "@firebase/component": "0.1.9",
     "tslib": "1.11.1"
   },
   "license": "Apache-2.0",


### PR DESCRIPTION
CI was breaking. After `packages-exp/app-exp` was added, we did not modify the release script to update `@firebase` deps in `package.json` files in the `packages-exp` directory, so these deps were a version behind, causing type clashes.  Will do that in an additional PR.