### PR TITLE
Revert: Use crypo RNG for auto ID generation to reduce conflicts

### DIFF
--- a/packages/firestore/src/platform/platform.ts
+++ b/packages/firestore/src/platform/platform.ts
@@ -43,12 +43,6 @@ export interface Platform {
   /** Converts a binary string to a Base64 encoded string. */
   btoa(raw: string): string;
 
-  /**
-   * Generates `nBytes` of random bytes. If `nBytes` is negative, an empty array
-   * will be returned.
-   */
-  randomBytes(nBytes: number): Uint8Array;
-
   /** The Platform's 'window' implementation or null if not available. */
   readonly window: Window | null;
 

--- a/packages/firestore/src/platform_browser/browser_platform.ts
+++ b/packages/firestore/src/platform_browser/browser_platform.ts
@@ -25,10 +25,6 @@ import { NoopConnectivityMonitor } from '../remote/connectivity_monitor_noop';
 import { BrowserConnectivityMonitor } from './browser_connectivity_monitor';
 import { WebChannelConnection } from './webchannel_connection';
 
-// Polyfill for IE
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const crypto = window.crypto || (window as any).msCrypto;
-
 export class BrowserPlatform implements Platform {
   readonly useProto3Json = true;
   readonly base64Available: boolean;

--- a/packages/firestore/src/platform_browser/browser_platform.ts
+++ b/packages/firestore/src/platform_browser/browser_platform.ts
@@ -68,14 +68,4 @@ export class BrowserPlatform implements Platform {
   btoa(raw: string): string {
     return btoa(raw);
   }
-
-  randomBytes(nBytes: number): Uint8Array {
-    if (nBytes <= 0) {
-      return new Uint8Array();
-    }
-
-    const v = new Uint8Array(nBytes);
-    crypto.getRandomValues(v);
-    return v;
-  }
 }

--- a/packages/firestore/src/platform_node/node_platform.ts
+++ b/packages/firestore/src/platform_node/node_platform.ts
@@ -15,7 +15,6 @@
  * limitations under the License.
  */
 
-import { randomBytes } from 'crypto';
 import { inspect } from 'util';
 
 import { DatabaseId, DatabaseInfo } from '../core/database_info';
@@ -75,13 +74,5 @@ export class NodePlatform implements Platform {
 
   btoa(raw: string): string {
     return new Buffer(raw, 'binary').toString('base64');
-  }
-
-  randomBytes(nBytes: number): Uint8Array {
-    if (nBytes <= 0) {
-      return new Uint8Array();
-    }
-
-    return randomBytes(nBytes);
   }
 }

--- a/packages/firestore/src/util/misc.ts
+++ b/packages/firestore/src/util/misc.ts
@@ -16,7 +16,6 @@
  */
 
 import { assert } from './assert';
-import { PlatformSupport } from '../platform/platform';
 
 export type EventHandler<E> = (value: E) => void;
 export interface Indexable {
@@ -29,17 +28,8 @@ export class AutoId {
     const chars =
       'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
     let autoId = '';
-    while (autoId.length < 20) {
-      const bytes = PlatformSupport.getPlatform().randomBytes(40);
-      bytes.forEach(b => {
-        // Length of `chars` is 62. We only take bytes between 0 and 62*4-1
-        // (both inclusive). The value is then evenly mapped to indices of `char`
-        // via a modulo operation.
-        const maxValue = 62 * 4 - 1;
-        if (autoId.length < 20 && b <= maxValue) {
-          autoId += chars.charAt(b % 62);
-        }
-      });
+    for (let i = 0; i < 20; i++) {
+      autoId += chars.charAt(Math.floor(Math.random() * chars.length));
     }
     assert(autoId.length === 20, 'Invalid auto ID: ' + autoId);
     return autoId;

--- a/packages/firestore/src/util/misc.ts
+++ b/packages/firestore/src/util/misc.ts
@@ -31,7 +31,7 @@ export class AutoId {
     let autoId = '';
     while (autoId.length < 20) {
       const bytes = PlatformSupport.getPlatform().randomBytes(40);
-      for (const b of Array.from(bytes)) {
+      bytes.forEach(b => {
         // Length of `chars` is 62. We only take bytes between 0 and 62*4-1
         // (both inclusive). The value is then evenly mapped to indices of `char`
         // via a modulo operation.
@@ -39,7 +39,7 @@ export class AutoId {
         if (autoId.length < 20 && b <= maxValue) {
           autoId += chars.charAt(b % 62);
         }
-      }
+      });
     }
     assert(autoId.length === 20, 'Invalid auto ID: ' + autoId);
     return autoId;

--- a/packages/firestore/test/util/test_platform.ts
+++ b/packages/firestore/test/util/test_platform.ts
@@ -266,10 +266,6 @@ export class TestPlatform implements Platform {
   btoa(raw: string): string {
     return this.basePlatform.btoa(raw);
   }
-
-  randomBytes(nBytes: number): Uint8Array {
-    return this.basePlatform.randomBytes(nBytes);
-  }
 }
 
 /** Returns true if we are running under Node. */


### PR DESCRIPTION
This PR temporarily reverts the feature #2764: Use a cryptographically-strong random number generator for generating document IDs.  We received several bug reports from users prompting us to revisit the implementation.  In order to unblock those users, I am temporarily reverting the feature so that it can be picked up in tomorrow's release.

The issues in question are: #2832, #2858, and #2870.