### PR TITLE
Add CHANGELOG.md entry for reverting the usage of 'crypto'

### DIFF
--- a/packages/firestore/CHANGELOG.md
+++ b/packages/firestore/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Unreleased
+- [fixed] Reverted the use of the "crypto" global since it caused some user
+  issues (#2872).
 - [changed] Firestore now limits the number of concurrent document lookups it
   will perform when resolving inconsistencies in the local cache (#2683).
 - [changed] Changed the in-memory representation of Firestore documents to

--- a/packages/firestore/CHANGELOG.md
+++ b/packages/firestore/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
-- [fixed] Reverted the use of the "crypto" global since it caused some user
-  issues (#2872).
+- [fixed] Temporarily reverted the use of window.crypto to generate document
+  IDs to address compatibility issues with IE 11, WebWorkers, and React Native.
 - [changed] Firestore now limits the number of concurrent document lookups it
   will perform when resolving inconsistencies in the local cache (#2683).
 - [changed] Changed the in-memory representation of Firestore documents to


### PR DESCRIPTION
This is the change log entry that was forgotten in https://github.com/firebase/firebase-js-sdk/pull/2872.