### PR TITLE
Discourage use of 'window' and 'document'

### DIFF
--- a/packages/firestore/.eslintrc.js
+++ b/packages/firestore/.eslintrc.js
@@ -16,6 +16,17 @@ module.exports = {
         varsIgnorePattern: '^_',
         args: 'none'
       }
+    ],
+    'no-restricted-globals': [
+      'error',
+      {
+        'name': 'window',
+        'message': 'Use `PlatformSupport.getPlatform().window` instead.'
+      },
+      {
+        'name': 'document',
+        'message': 'Use `PlatformSupport.getPlatform().document` instead.'
+      }
     ]
   },
   overrides: [

--- a/packages/firestore/src/local/simple_db.ts
+++ b/packages/firestore/src/local/simple_db.ts
@@ -23,6 +23,9 @@ import { Deferred } from '../util/promise';
 import { SCHEMA_VERSION } from './indexeddb_schema';
 import { PersistencePromise } from './persistence_promise';
 
+// References to `window` are guarded by SimpleDb.isAvailable()
+/* eslint-disable no-restricted-globals */
+
 const LOG_TAG = 'SimpleDb';
 
 /**

--- a/packages/firestore/src/platform_browser/browser_connectivity_monitor.ts
+++ b/packages/firestore/src/platform_browser/browser_connectivity_monitor.ts
@@ -22,6 +22,9 @@ import {
   NetworkStatus
 } from './../remote/connectivity_monitor';
 
+// References to `window` are guarded by BrowserConnectivityMonitor.isAvailable()
+/* eslint-disable no-restricted-globals */
+
 const LOG_TAG = 'ConnectivityMonitor';
 
 /**

--- a/packages/firestore/src/platform_browser/browser_platform.ts
+++ b/packages/firestore/src/platform_browser/browser_platform.ts
@@ -20,11 +20,12 @@ import { Platform } from '../platform/platform';
 import { Connection } from '../remote/connection';
 import { JsonProtoSerializer } from '../remote/serializer';
 import { ConnectivityMonitor } from './../remote/connectivity_monitor';
-
 import { NoopConnectivityMonitor } from '../remote/connectivity_monitor_noop';
 import { BrowserConnectivityMonitor } from './browser_connectivity_monitor';
 import { WebChannelConnection } from './webchannel_connection';
 
+// Implements the Platform API for browsers and some browser-like environments
+// (including ReactNative).
 export class BrowserPlatform implements Platform {
   readonly useProto3Json = true;
   readonly base64Available: boolean;
@@ -34,10 +35,14 @@ export class BrowserPlatform implements Platform {
   }
 
   get document(): Document | null {
+    // `document` is not always available, e.g. in ReactNative and WebWorkers.
+    // eslint-disable-next-line no-restricted-globals
     return typeof document !== 'undefined' ? document : null;
   }
 
   get window(): Window | null {
+    // `window` is not always available, e.g. in ReactNative and WebWorkers.
+    // eslint-disable-next-line no-restricted-globals
     return typeof window !== 'undefined' ? window : null;
   }
 

--- a/packages/firestore/src/platform_node/node_platform.ts
+++ b/packages/firestore/src/platform_node/node_platform.ts
@@ -36,6 +36,7 @@ export class NodePlatform implements Platform {
 
   get window(): Window | null {
     if (process.env.USE_MOCK_PERSISTENCE === 'YES') {
+      // eslint-disable-next-line no-restricted-globals
       return window;
     }
 

--- a/packages/firestore/test/integration/browser/webchannel.test.ts
+++ b/packages/firestore/test/integration/browser/webchannel.test.ts
@@ -22,6 +22,8 @@ import * as api from '../../../src/protos/firestore_proto_api';
 import { DEFAULT_PROJECT_ID } from '../util/helpers';
 import { getDefaultDatabaseInfo } from '../util/internal_helpers';
 
+/* eslint-disable no-restricted-globals */
+
 // We need to check both `window` and `window.navigator` to make sure we are
 // not running in Node with IndexedDBShim.
 const describeFn =

--- a/packages/firestore/test/integration/util/helpers.ts
+++ b/packages/firestore/test/integration/util/helpers.ts
@@ -17,6 +17,9 @@
 
 import * as firestore from '@firebase/firestore-types';
 import firebase from './firebase_export';
+
+/* eslint-disable no-restricted-globals */
+
 /**
  * NOTE: These helpers are used by api/ tests and therefore may not have any
  * dependencies on src/ files.

--- a/packages/firestore/test/unit/local/indexeddb_persistence.test.ts
+++ b/packages/firestore/test/unit/local/indexeddb_persistence.test.ts
@@ -73,6 +73,8 @@ import {
   TEST_SERIALIZER
 } from './persistence_test_helpers';
 
+/* eslint-disable no-restricted-globals */
+
 function withDb(
   schemaVersion: number,
   fn: (db: IDBDatabase) => Promise<void>

--- a/packages/firestore/test/unit/local/persistence_promise.test.ts
+++ b/packages/firestore/test/unit/local/persistence_promise.test.ts
@@ -20,6 +20,8 @@ import { PersistencePromise } from '../../../src/local/persistence_promise';
 
 import * as chaiAsPromised from 'chai-as-promised';
 
+/* eslint-disable no-restricted-globals */
+
 use(chaiAsPromised);
 
 describe('PersistencePromise', () => {

--- a/packages/firestore/test/unit/local/persistence_test_helpers.ts
+++ b/packages/firestore/test/unit/local/persistence_test_helpers.ts
@@ -49,6 +49,8 @@ import { AsyncQueue } from '../../../src/util/async_queue';
 import { FirestoreError } from '../../../src/util/error';
 import { AutoId } from '../../../src/util/misc';
 
+/* eslint-disable no-restricted-globals */
+
 /** The prefix used by the keys that Firestore writes to Local Storage. */
 const LOCAL_STORAGE_PREFIX = 'firestore_';
 

--- a/packages/firestore/test/unit/local/web_storage_shared_client_state.test.ts
+++ b/packages/firestore/test/unit/local/web_storage_shared_client_state.test.ts
@@ -49,6 +49,8 @@ import {
   populateWebStorage
 } from './persistence_test_helpers';
 
+/* eslint-disable no-restricted-globals */
+
 const AUTHENTICATED_USER = new User('test');
 const UNAUTHENTICATED_USER = User.UNAUTHENTICATED;
 const TEST_ERROR = new FirestoreError('internal', 'Test Error');

--- a/packages/firestore/test/util/helpers.ts
+++ b/packages/firestore/test/util/helpers.ts
@@ -93,6 +93,8 @@ import { PlatformSupport } from '../../src/platform/platform';
 import { JsonProtoSerializer } from '../../src/remote/serializer';
 import { Timestamp } from '../../src/api/timestamp';
 
+/* eslint-disable no-restricted-globals */
+
 export type TestSnapshotVersion = number;
 
 /**

--- a/packages/firestore/test/util/test_platform.ts
+++ b/packages/firestore/test/util/test_platform.ts
@@ -23,6 +23,8 @@ import { assert, fail } from '../../src/util/assert';
 import { ConnectivityMonitor } from './../../src/remote/connectivity_monitor';
 import { NoopConnectivityMonitor } from './../../src/remote/connectivity_monitor_noop';
 
+/* eslint-disable no-restricted-globals */
+
 /**
  * `Window` fake that implements the event and storage API that is used by
  * Firestore.


### PR DESCRIPTION
This should help us find issues such as https://github.com/firebase/firebase-js-sdk/issues/2870 before they surface in ReactNative and WebWorkers.

