### PR TITLE
Remove 'no-android' tags from spec tests for limbo resolution throttling

### DIFF
--- a/packages/firestore/test/unit/specs/limbo_spec.test.ts
+++ b/packages/firestore/test/unit/specs/limbo_spec.test.ts
@@ -644,7 +644,7 @@ describeSpec('Limbo Documents:', [], () => {
     'Limbo resolution throttling with all results at once from watch',
     // TODO(dconeybe) Remove the 'no-*' tags as these platforms implement limbo
     //  resolution throttling.
-    ['no-android', 'no-ios'],
+    ['no-ios'],
     () => {
       const query = Query.atPath(path('collection'));
       const doc1 = doc('collection/a', 1000, { key: 'a' });
@@ -721,7 +721,7 @@ describeSpec('Limbo Documents:', [], () => {
     'Limbo resolution throttling with results one at a time from watch',
     // TODO(dconeybe) Remove the 'no-*' tags as these platforms implement limbo
     //  resolution throttling.
-    ['no-android', 'no-ios'],
+    ['no-ios'],
     () => {
       const query = Query.atPath(path('collection'));
       const doc1 = doc('collection/a', 1000, { key: 'a' });
@@ -801,7 +801,7 @@ describeSpec('Limbo Documents:', [], () => {
     'Limbo resolution throttling when a limbo listen is rejected.',
     // TODO(dconeybe) Remove the 'no-*' tags as these platforms implement limbo
     //  resolution throttling.
-    ['no-android', 'no-ios'],
+    ['no-ios'],
     () => {
       const query = Query.atPath(path('collection'));
       const doc1 = doc('collection/a', 1000, { key: 'a' });
@@ -854,7 +854,7 @@ describeSpec('Limbo Documents:', [], () => {
     'Limbo resolution throttling with existence filter mismatch',
     // TODO(dconeybe) Remove the 'no-*' tags as these platforms implement limbo
     //  resolution throttling.
-    ['no-android', 'no-ios'],
+    ['no-ios'],
     () => {
       const query = Query.atPath(path('collection'));
       const docA1 = doc('collection/a1', 1000, { key: 'a1' });


### PR DESCRIPTION
Limbo resolution throttling is now implemented in Android, and, therefore, the spec tests for that feature should be enabled: https://github.com/firebase/firebase-android-sdk/pull/1374