### PR TITLE
Retry WebStorage operations

### DIFF
--- a/packages/firestore/CHANGELOG.md
+++ b/packages/firestore/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Unreleased
+- [fixed] Fixed a source of IndexedDB-related crashes for tabs that receive 
+  multi-tab notifications while the file system is locked.
+
+# 1.10.2
 - [fixed] Temporarily reverted the use of window.crypto to generate document
   IDs to address compatibility issues with IE 11, WebWorkers, and React Native.
 - [changed] Firestore now limits the number of concurrent document lookups it

--- a/packages/firestore/src/core/component_provider.ts
+++ b/packages/firestore/src/core/component_provider.ts
@@ -40,7 +40,6 @@ import { IndexFreeQueryEngine } from '../local/index_free_query_engine';
 import { IndexedDbPersistence } from '../local/indexeddb_persistence';
 import {
   MemoryEagerDelegate,
-  MemoryLruDelegate,
   MemoryPersistence
 } from '../local/memory_persistence';
 
@@ -185,23 +184,6 @@ export class MemoryComponentProvider {
     throw new FirestoreError(
       Code.FAILED_PRECONDITION,
       MEMORY_ONLY_PERSISTENCE_ERROR_MESSAGE
-    );
-  }
-}
-
-/**
- * Provides all components needed for Firestore with in-memory persistence.
- * Uses LRU garbage collection.
- */
-export class MemoryLruComponentProvider extends MemoryComponentProvider {
-  createPersistence(cfg: ComponentConfiguration): Persistence {
-    debugAssert(
-      !cfg.persistenceSettings.durable,
-      'Can only start memory persistence'
-    );
-    return new MemoryPersistence(
-      cfg.clientId,
-      p => new MemoryLruDelegate(p, LruParams.DEFAULT)
     );
   }
 }

--- a/packages/firestore/src/core/transaction_runner.ts
+++ b/packages/firestore/src/core/transaction_runner.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2019 Google Inc.
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/firestore/src/core/transaction_runner.ts
+++ b/packages/firestore/src/core/transaction_runner.ts
@@ -42,7 +42,7 @@ export class TransactionRunner<T> {
   ) {
     this.backoff = new ExponentialBackoff(
       this.asyncQueue,
-      TimerId.RetryTransaction
+      TimerId.TransactionRetry
     );
   }
 

--- a/packages/firestore/src/local/shared_client_state.ts
+++ b/packages/firestore/src/local/shared_client_state.ts
@@ -755,7 +755,7 @@ export class WebStorageSharedClientState implements SharedClientState {
         return;
       }
 
-      this.queue.enqueueAndForget(async () => {
+      this.queue.enqueueRetryable(async () => {
         if (!this.started) {
           this.earlyEvents.push(event);
           return;

--- a/packages/firestore/src/remote/backoff.ts
+++ b/packages/firestore/src/remote/backoff.ts
@@ -127,20 +127,16 @@ export class ExponentialBackoff {
           `delay with jitter: ${desiredDelayWithJitterMs} ms, ` +
           `last attempt: ${delaySoFarMs} ms ago)`
       );
-      this.timerPromise = this.queue.enqueueAfterDelay(
-        this.timerId,
-        remainingDelayMs,
-        () => {
-          this.lastAttemptTime = Date.now();
-          return op();
-        }
-      );
-    } else {
-      this.queue.enqueueAndForget(() => {
+    }
+
+    this.timerPromise = this.queue.enqueueAfterDelay(
+      this.timerId,
+      remainingDelayMs,
+      () => {
         this.lastAttemptTime = Date.now();
         return op();
-      });
-    }
+      }
+    );
 
     // Apply backoff factor to determine next delay and ensure it is within
     // bounds.

--- a/packages/firestore/src/util/async_queue.ts
+++ b/packages/firestore/src/util/async_queue.ts
@@ -70,7 +70,7 @@ export const enum TimerId {
    * A timer used to retry transactions. Since there can be multiple concurrent
    * transactions, multiple of these may be in the queue at a given time.
    */
-  RetryTransaction = 'retry_transaction',
+  TransactionRetry = 'transaction_retry',
 
   /**
    * A timer used to retry operations scheduled via retryable AsyncQueue
@@ -207,7 +207,7 @@ export class AsyncQueue {
 
   // The last retryable operation. Retryable operation are run in order and
   // retried with backoff.
-  private retryableTail = Promise.resolve();
+  private retryableTail: Promise<void> = Promise.resolve();
 
   // Is this AsyncQueue being shut down? Once it is set to true, it will not
   // be changed again.

--- a/packages/firestore/test/integration/api_internal/transaction.test.ts
+++ b/packages/firestore/test/integration/api_internal/transaction.test.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2019 Google Inc.
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/firestore/test/integration/api_internal/transaction.test.ts
+++ b/packages/firestore/test/integration/api_internal/transaction.test.ts
@@ -36,7 +36,7 @@ apiDescribe(
       let started = 0;
 
       return integrationHelpers.withTestDb(persistence, db => {
-        asyncQueue(db).skipDelaysForTimerId(TimerId.RetryTransaction);
+        asyncQueue(db).skipDelaysForTimerId(TimerId.TransactionRetry);
         const doc = db.collection('counters').doc();
         return doc
           .set({
@@ -93,7 +93,7 @@ apiDescribe(
       let counter = 0;
 
       return integrationHelpers.withTestDb(persistence, db => {
-        asyncQueue(db).skipDelaysForTimerId(TimerId.RetryTransaction);
+        asyncQueue(db).skipDelaysForTimerId(TimerId.TransactionRetry);
         const doc = db.collection('counters').doc();
         return doc
           .set({
@@ -148,7 +148,7 @@ apiDescribe(
 
     it('handle reading a doc twice with different versions', () => {
       return integrationHelpers.withTestDb(persistence, db => {
-        asyncQueue(db).skipDelaysForTimerId(TimerId.RetryTransaction);
+        asyncQueue(db).skipDelaysForTimerId(TimerId.TransactionRetry);
         const doc = db.collection('counters').doc();
         let counter = 0;
         return doc

--- a/packages/firestore/test/unit/specs/recovery_spec.test.ts
+++ b/packages/firestore/test/unit/specs/recovery_spec.test.ts
@@ -42,8 +42,8 @@ describeSpec(
             // Client 1 has received the WebStorage notification that the write
             // has been acknowledged, but failed to process the change. Hence,
             // we did not get a user callback. We schedule the first retry and
-            // make sure that it cannot be processed until `recoverDatabase`
-            // is called.
+            // make sure that it also does not get processed until 
+            // `recoverDatabase` is called.
             .runTimer(TimerId.AsyncQueueRetry)
             .recoverDatabase()
             .runTimer(TimerId.AsyncQueueRetry)

--- a/packages/firestore/test/unit/specs/recovery_spec.test.ts
+++ b/packages/firestore/test/unit/specs/recovery_spec.test.ts
@@ -40,7 +40,7 @@ describeSpec(
             .writeAcks('collection/a', 1, { expectUserCallback: false })
             .client(1)
             // Client 1 has received the WebStorage notification that the write
-            // has been acknowledged, but failed to process the change. Hence, 
+            // has been acknowledged, but failed to process the change. Hence,
             // we did not get a user callback. We schedule the first retry and
             // make sure that it cannot be processed until `recoverDatabase`
             // is called.

--- a/packages/firestore/test/unit/specs/recovery_spec.test.ts
+++ b/packages/firestore/test/unit/specs/recovery_spec.test.ts
@@ -1,0 +1,71 @@
+/**
+ * @license
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describeSpec, specTest } from './describe_spec';
+import { client } from './spec_builder';
+import { TimerId } from '../../../src/util/async_queue';
+import { Query } from '../../../src/core/query';
+import { path } from '../../util/helpers';
+
+describeSpec(
+  'Persistence Recovery',
+  ['durable-persistence', 'no-ios', 'no-android'],
+  () => {
+    specTest(
+      'Write is acknowledged by primary client (with recovery)',
+      ['multi-client'],
+      () => {
+        return client(0)
+          .expectPrimaryState(true)
+          .client(1)
+          .expectPrimaryState(false)
+          .userSets('collection/a', { v: 1 })
+          .failDatabase()
+          .client(0)
+          .writeAcks('collection/a', 1, { expectUserCallback: false })
+          .client(1)
+          .recoverDatabase()
+          .runTimer(TimerId.AsyncQueueRetry)
+          .expectUserCallbacks({
+            acknowledged: ['collection/a']
+          });
+      }
+    );
+
+    specTest(
+      'Query raises events in secondary client  (with recovery)',
+      ['multi-client'],
+      () => {
+        const query = Query.atPath(path('collection'));
+
+        return client(0)
+          .expectPrimaryState(true)
+          .client(1)
+          .expectPrimaryState(false)
+          .userListens(query)
+          .failDatabase()
+          .client(0)
+          .expectListen(query)
+          .watchAcksFull(query, 1000)
+          .client(1)
+          .recoverDatabase()
+          .runTimer(TimerId.AsyncQueueRetry)
+          .expectEvents(query, {});
+      }
+    );
+  }
+);

--- a/packages/firestore/test/unit/specs/remote_store_spec.test.ts
+++ b/packages/firestore/test/unit/specs/remote_store_spec.test.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2017 Google Inc.
+ * Copyright 2017 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -84,36 +84,4 @@ describeSpec('Remote store:', [], () => {
         .expectEvents(query, { added: [doc1] })
     );
   });
-
-  // TODO(b/72313632): This test is web-only because the Android / iOS spec
-  // tests exclude backoff entirely.
-  specTest(
-    'Handles user changes while offline (b/74749605).',
-    ['no-android', 'no-ios'],
-    () => {
-      const query = Query.atPath(path('collection'));
-      return (
-        spec()
-          .userListens(query)
-
-          // close the stream (this should trigger retry with backoff; but don't
-          // run it in an attempt to reproduce b/74749605).
-          .watchStreamCloses(Code.UNAVAILABLE, { runBackoffTimer: false })
-          .expectEvents(query, { fromCache: true })
-
-          // Because we didn't let the backoff timer run and restart the watch
-          // stream, there will be no active targets.
-          .expectActiveTargets()
-
-          // Change user (will shut down existing streams and start new ones).
-          .changeUser('abc')
-          // Our query should be sent to the new stream.
-          .expectActiveTargets({ query, resumeToken: '' })
-
-          // Close the (newly-created) stream as if it too failed (should trigger
-          // retry with backoff, potentially reproducing the crash in b/74749605).
-          .watchStreamCloses(Code.UNAVAILABLE)
-      );
-    }
-  );
 });

--- a/packages/firestore/test/unit/specs/remote_store_spec.test.ts
+++ b/packages/firestore/test/unit/specs/remote_store_spec.test.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2017 Google LLC
+ * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -84,4 +84,36 @@ describeSpec('Remote store:', [], () => {
         .expectEvents(query, { added: [doc1] })
     );
   });
+
+  // TODO(b/72313632): This test is web-only because the Android / iOS spec
+  // tests exclude backoff entirely.
+  specTest(
+    'Handles user changes while offline (b/74749605).',
+    ['no-android', 'no-ios'],
+    () => {
+      const query = Query.atPath(path('collection'));
+      return (
+        spec()
+          .userListens(query)
+
+          // close the stream (this should trigger retry with backoff; but don't
+          // run it in an attempt to reproduce b/74749605).
+          .watchStreamCloses(Code.UNAVAILABLE, { runBackoffTimer: false })
+          .expectEvents(query, { fromCache: true })
+
+          // Because we didn't let the backoff timer run and restart the watch
+          // stream, there will be no active targets.
+          .expectActiveTargets()
+
+          // Change user (will shut down existing streams and start new ones).
+          .changeUser('abc')
+          // Our query should be sent to the new stream.
+          .expectActiveTargets({ query, resumeToken: '' })
+
+          // Close the (newly-created) stream as if it too failed (should trigger
+          // retry with backoff, potentially reproducing the crash in b/74749605).
+          .watchStreamCloses(Code.UNAVAILABLE)
+      );
+    }
+  );
 });

--- a/packages/firestore/test/unit/specs/spec_builder.ts
+++ b/packages/firestore/test/unit/specs/spec_builder.ts
@@ -418,6 +418,22 @@ export class SpecBuilder {
     return this;
   }
 
+  failDatabase(): this {
+    this.nextStep();
+    this.currentStep = {
+      failDatabase: true
+    };
+    return this;
+  }
+
+  recoverDatabase(): this {
+    this.nextStep();
+    this.currentStep = {
+      failDatabase: false
+    };
+    return this;
+  }
+
   expectIsShutdown(): this {
     this.assertStep('Active target expectation requires previous step');
     const currentStep = this.currentStep!;
@@ -716,19 +732,14 @@ export class SpecBuilder {
     return this;
   }
 
-  watchStreamCloses(error: Code, opts?: { runBackoffTimer: boolean }): this {
-    if (!opts) {
-      opts = { runBackoffTimer: true };
-    }
-
+  watchStreamCloses(error: Code): this {
     this.nextStep();
     this.currentStep = {
       watchStreamClose: {
         error: {
           code: mapRpcCodeFromCode(error),
           message: 'Simulated Backend Error'
-        },
-        runBackoffTimer: opts.runBackoffTimer
+        }
       }
     };
     return this;

--- a/packages/firestore/test/unit/specs/spec_builder.ts
+++ b/packages/firestore/test/unit/specs/spec_builder.ts
@@ -732,14 +732,19 @@ export class SpecBuilder {
     return this;
   }
 
-  watchStreamCloses(error: Code): this {
+  watchStreamCloses(error: Code, opts?: { runBackoffTimer: boolean }): this {
+    if (!opts) {
+      opts = { runBackoffTimer: true };
+    }
+
     this.nextStep();
     this.currentStep = {
       watchStreamClose: {
         error: {
           code: mapRpcCodeFromCode(error),
           message: 'Simulated Backend Error'
-        }
+        },
+        runBackoffTimer: opts.runBackoffTimer
       }
     };
     return this;

--- a/packages/firestore/test/unit/specs/spec_builder.ts
+++ b/packages/firestore/test/unit/specs/spec_builder.ts
@@ -418,6 +418,7 @@ export class SpecBuilder {
     return this;
   }
 
+  /** Fails all database operations until `recoverDatabase()` is called. */
   failDatabase(): this {
     this.nextStep();
     this.currentStep = {
@@ -426,6 +427,7 @@ export class SpecBuilder {
     return this;
   }
 
+  /** Stops failing database operations. */
   recoverDatabase(): this {
     this.nextStep();
     this.currentStep = {

--- a/packages/firestore/test/unit/specs/spec_test_components.ts
+++ b/packages/firestore/test/unit/specs/spec_test_components.ts
@@ -1,3 +1,20 @@
+/**
+ * @license
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import {
   ComponentConfiguration,
   IndexedDbComponentProvider,

--- a/packages/firestore/test/unit/specs/spec_test_components.ts
+++ b/packages/firestore/test/unit/specs/spec_test_components.ts
@@ -1,0 +1,146 @@
+import {
+  ComponentConfiguration,
+  IndexedDbComponentProvider,
+  MemoryComponentProvider
+} from '../../../src/core/component_provider';
+import {
+  GarbageCollectionScheduler,
+  Persistence,
+  PersistenceTransaction,
+  PersistenceTransactionMode,
+  PrimaryStateListener,
+  ReferenceDelegate
+} from '../../../src/local/persistence';
+import { ClientId } from '../../../src/local/shared_client_state';
+import { User } from '../../../src/auth/user';
+import { MutationQueue } from '../../../src/local/mutation_queue';
+import { TargetCache } from '../../../src/local/target_cache';
+import { RemoteDocumentCache } from '../../../src/local/remote_document_cache';
+import { IndexManager } from '../../../src/local/index_manager';
+import { PersistencePromise } from '../../../src/local/persistence_promise';
+import { debugAssert } from '../../../src/util/assert';
+import {
+  MemoryEagerDelegate,
+  MemoryLruDelegate,
+  MemoryPersistence
+} from '../../../src/local/memory_persistence';
+import { LruParams } from '../../../src/local/lru_garbage_collector';
+
+/**
+ * A test-only persistence implementation that delegates all calls to the
+ * underlying IndexedDB or Memory-based persistence implementations and is able
+ * to inject transaction failures.
+ */
+export class MockPersistence implements Persistence {
+  injectFailures = false;
+
+  constructor(private readonly delegate: Persistence) {}
+
+  start(): Promise<void> {
+    return this.delegate.start();
+  }
+
+  get started(): boolean {
+    return this.delegate.started;
+  }
+
+  get referenceDelegate(): ReferenceDelegate {
+    return this.delegate.referenceDelegate;
+  }
+
+  shutdown(): Promise<void> {
+    return this.delegate.shutdown();
+  }
+
+  setPrimaryStateListener(
+    primaryStateListener: PrimaryStateListener
+  ): Promise<void> {
+    return this.delegate.setPrimaryStateListener(primaryStateListener);
+  }
+
+  setDatabaseDeletedListener(
+    databaseDeletedListener: () => Promise<void>
+  ): void {
+    this.delegate.setDatabaseDeletedListener(databaseDeletedListener);
+  }
+
+  setNetworkEnabled(networkEnabled: boolean): void {
+    this.delegate.setNetworkEnabled(networkEnabled);
+  }
+
+  getActiveClients(): Promise<ClientId[]> {
+    return this.delegate.getActiveClients();
+  }
+
+  getMutationQueue(user: User): MutationQueue {
+    return this.delegate.getMutationQueue(user);
+  }
+
+  getTargetCache(): TargetCache {
+    return this.delegate.getTargetCache();
+  }
+
+  getRemoteDocumentCache(): RemoteDocumentCache {
+    return this.delegate.getRemoteDocumentCache();
+  }
+
+  getIndexManager(): IndexManager {
+    return this.delegate.getIndexManager();
+  }
+
+  runTransaction<T>(
+    action: string,
+    mode: PersistenceTransactionMode,
+    transactionOperation: (
+      transaction: PersistenceTransaction
+    ) => PersistencePromise<T>
+  ): Promise<T> {
+    if (this.injectFailures) {
+      return Promise.reject(new Error('Injected Failure'));
+    } else {
+      return this.delegate.runTransaction(action, mode, transactionOperation);
+    }
+  }
+}
+
+export class MockIndexedDbComponentProvider extends IndexedDbComponentProvider {
+  persistence!: MockPersistence;
+
+  createGarbageCollectionScheduler(
+    cfg: ComponentConfiguration
+  ): GarbageCollectionScheduler | null {
+    return null;
+  }
+
+  createPersistence(cfg: ComponentConfiguration): Persistence {
+    return new MockPersistence(super.createPersistence(cfg));
+  }
+}
+
+export class MockMemoryComponentProvider extends MemoryComponentProvider {
+  persistence!: MockPersistence;
+
+  constructor(private readonly gcEnabled: boolean) {
+    super();
+  }
+
+  createGarbageCollectionScheduler(
+    cfg: ComponentConfiguration
+  ): GarbageCollectionScheduler | null {
+    return null;
+  }
+
+  createPersistence(cfg: ComponentConfiguration): Persistence {
+    debugAssert(
+      !cfg.persistenceSettings.durable,
+      'Can only start memory persistence'
+    );
+    const persistence = new MemoryPersistence(
+      cfg.clientId,
+      this.gcEnabled
+        ? MemoryEagerDelegate.factory
+        : p => new MemoryLruDelegate(p, LruParams.DEFAULT)
+    );
+    return new MockPersistence(persistence);
+  }
+}

--- a/packages/firestore/test/unit/specs/spec_test_runner.ts
+++ b/packages/firestore/test/unit/specs/spec_test_runner.ts
@@ -841,7 +841,10 @@ abstract class TestRunner {
       )
     );
     // The watch stream should re-open if we have active listeners.
-    if (!this.queryListeners.isEmpty()) {
+    if (spec.runBackoffTimer && !this.queryListeners.isEmpty()) {
+      await this.queue.runDelayedOperationsEarly(
+        TimerId.ListenStreamConnectionBackoff
+      );
       await this.connection.waitForWatchOpen();
     }
   }
@@ -1550,6 +1553,7 @@ export interface SpecWatchSnapshot {
 
 export interface SpecWatchStreamClose {
   error: SpecError;
+  runBackoffTimer: boolean;
 }
 
 export interface SpecWriteAck {

--- a/packages/firestore/test/unit/util/async_queue.test.ts
+++ b/packages/firestore/test/unit/util/async_queue.test.ts
@@ -212,7 +212,7 @@ describe('AsyncQueue', () => {
     queue.enqueueRetryable(async () => {
       doStep(1);
       if (completedSteps.length === 1) {
-        throw new Error("Let's retry");
+        throw new Error('Simulated retryable error');
       }
     });
     await queue.runDelayedOperationsEarly(TimerId.AsyncQueueRetry);
@@ -244,7 +244,7 @@ describe('AsyncQueue', () => {
     queue.enqueueRetryable(async () => {
       doStep(1);
       if (completedSteps.length === 1) {
-        throw new Error("Let's retry");
+        throw new Error('Simulated retryable error');
       }
     });
 
@@ -270,7 +270,7 @@ describe('AsyncQueue', () => {
       doStep(1);
       if (completedSteps.length > 1) {
       } else {
-        throw new Error("Let's retry");
+        throw new Error('Simulated retryable error');
       }
     });
     queue.enqueueRetryable(async () => {

--- a/packages/firestore/test/unit/util/async_queue.test.ts
+++ b/packages/firestore/test/unit/util/async_queue.test.ts
@@ -247,11 +247,11 @@ describe('AsyncQueue', () => {
         throw new Error("Let's retry");
       }
     });
-    
+
     // Verify that only one attempt has been made
     await queue.drain();
     expect(completedSteps).to.deep.equal([1]);
-    
+
     // Fast forward all operations
     await queue.runDelayedOperationsEarly(TimerId.AsyncQueueRetry);
     expect(completedSteps).to.deep.equal([1, 1]);
@@ -265,7 +265,7 @@ describe('AsyncQueue', () => {
     };
 
     const blockingPromise = new Deferred<void>();
-    
+
     queue.enqueueRetryable(async () => {
       doStep(1);
       if (completedSteps.length > 1) {

--- a/packages/firestore/test/unit/util/async_queue.test.ts
+++ b/packages/firestore/test/unit/util/async_queue.test.ts
@@ -203,6 +203,85 @@ describe('AsyncQueue', () => {
     expect(completedSteps).to.deep.equal([1, 2, 3, 4]);
   });
 
+  it('Retries retryable operations', async () => {
+    const queue = new AsyncQueue();
+    const completedSteps: number[] = [];
+    const doStep = (n: number): void => {
+      completedSteps.push(n);
+    };
+    queue.enqueueRetryable(async () => {
+      doStep(1);
+      if (completedSteps.length === 1) {
+        throw new Error("Let's retry");
+      }
+    });
+    await queue.runDelayedOperationsEarly(TimerId.AsyncQueueRetry);
+    expect(completedSteps).to.deep.equal([1, 1]);
+  });
+
+  it('Schedules first retryable attempt with no delay', async () => {
+    const queue = new AsyncQueue();
+    const completedSteps: number[] = [];
+    const doStep = (n: number): void => {
+      completedSteps.push(n);
+    };
+    queue.enqueueRetryable(async () => {
+      doStep(1);
+    });
+    expect(queue.containsDelayedOperation(TimerId.AsyncQueueRetry)).to.be.false;
+    // Use `drain()` instead of runDelayedOperationsEarly since the
+    // operation was scheduled directly on the queue.
+    await queue.drain();
+    expect(completedSteps).to.deep.equal([1]);
+  });
+
+  it('Retries retryable operations with backoff', async () => {
+    const queue = new AsyncQueue();
+    const completedSteps: number[] = [];
+    const doStep = (n: number): void => {
+      completedSteps.push(n);
+    };
+    queue.enqueueRetryable(async () => {
+      doStep(1);
+      if (completedSteps.length === 1) {
+        throw new Error("Let's retry");
+      }
+    });
+    
+    // Verify that only one attempt has been made
+    await queue.drain();
+    expect(completedSteps).to.deep.equal([1]);
+    
+    // Fast forward all operations
+    await queue.runDelayedOperationsEarly(TimerId.AsyncQueueRetry);
+    expect(completedSteps).to.deep.equal([1, 1]);
+  });
+
+  it('Retries retryable operations in order', async () => {
+    const queue = new AsyncQueue();
+    const completedSteps: number[] = [];
+    const doStep = (n: number): void => {
+      completedSteps.push(n);
+    };
+
+    const blockingPromise = new Deferred<void>();
+    
+    queue.enqueueRetryable(async () => {
+      doStep(1);
+      if (completedSteps.length > 1) {
+      } else {
+        throw new Error("Let's retry");
+      }
+    });
+    queue.enqueueRetryable(async () => {
+      doStep(2);
+      blockingPromise.resolve();
+    });
+
+    await blockingPromise.promise;
+    expect(completedSteps).to.deep.equal([1, 1, 2]);
+  });
+
   it('Can drain (non-delayed) operations', async () => {
     const queue = new AsyncQueue();
     const completedSteps: number[] = [];

--- a/packages/firestore/test/util/test_platform.ts
+++ b/packages/firestore/test/util/test_platform.ts
@@ -62,7 +62,9 @@ export class FakeWindow {
         this.storageListeners.push(listener);
         break;
       case 'unload':
-        // The spec tests currently do not rely on 'unload' listeners.
+      case 'visibilitychange':
+        // The spec tests currently do not rely on `unload`/`visibilitychange`
+        // listeners.
         break;
       default:
         fail(`MockWindow doesn't support events of type '${type}'`);


### PR DESCRIPTION
This PR allows us to recover from IndexedDB failures when a Multi-Tab operation scheduled via a WebStorage notification fails. 

To do this:
- It introduces the concept of "retryable" operations. These are directly retried on the AsyncQueue.
- All retryable operations use the same retry mechanism. It is assumed that if the first retryable operation fails, the second would fail to.
- Retries use the same exponential backoff that we use for our streams (down to the delays).

Since a operation that is schedule via a `DelayedOperation` is always run after all other operations, the PR also changes the backoff handler to use `AsyncQueue.enqueue` directly if the backoff is zero. This is not required, but not doing this breaks all tests that rely on WebStorage since `AsyncQueue.drain()` does not drain delayed operations. 
I tried to make this change in the AsyncQueue directly, but it would require to return us to create a new way to create CancellableOperations from `enqueue()`.
A side effect of this is that the spec tests way to fast-forward the backoff timer doesn't work as it did before - the first backoff timer cannot be fast-forwarded and any subsequent attempts are not always scheduled. This causes some tests to time out as we sometimes wait for the backoff to expire. I changed the SpecTests to always skip the backoff delays, which speeds up all tests considerably (faster than on master).

Note: I wasn't able to figure out how to make the test "handles user changes while offline (b/74749605)" work, since the test relies on a backoff for the first attempt.