### PR TITLE
Fix Messaging test that fails in Firefox

### DIFF
--- a/packages/messaging/src/controllers/sw-controller.test.ts
+++ b/packages/messaging/src/controllers/sw-controller.test.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2017 Google Inc.
+ * Copyright 2017 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/messaging/src/controllers/sw-controller.test.ts
+++ b/packages/messaging/src/controllers/sw-controller.test.ts
@@ -277,7 +277,8 @@ describe('SwController', () => {
     });
 
     it('warns if there are more action buttons than the browser limit', async () => {
-      // This doesn't exist on Firefox.
+      // This doesn't exist on Firefox:
+      // https://developer.mozilla.org/en-US/docs/Web/API/notification/maxActions
       if (!Notification.maxActions) {
         return;
       }

--- a/packages/messaging/src/controllers/sw-controller.test.ts
+++ b/packages/messaging/src/controllers/sw-controller.test.ts
@@ -277,6 +277,10 @@ describe('SwController', () => {
     });
 
     it('warns if there are more action buttons than the browser limit', async () => {
+      // This doesn't exist on Firefox.
+      if (!Notification.maxActions) {
+        return;
+      }
       stub(Notification, 'maxActions').value(1);
 
       const warnStub = stub(console, 'warn');

--- a/packages/messaging/src/controllers/sw-controller.ts
+++ b/packages/messaging/src/controllers/sw-controller.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2017 Google Inc.
+ * Copyright 2017 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/messaging/src/controllers/sw-controller.ts
+++ b/packages/messaging/src/controllers/sw-controller.ts
@@ -340,6 +340,7 @@ function showNotification(details: NotificationDetails): Promise<void> {
 
   const { actions } = details;
   // Note: Firefox does not support the maxActions property.
+  // https://developer.mozilla.org/en-US/docs/Web/API/notification/maxActions
   const { maxActions } = Notification;
   if (actions && maxActions && actions.length > maxActions) {
     console.warn(

--- a/packages/messaging/src/controllers/sw-controller.ts
+++ b/packages/messaging/src/controllers/sw-controller.ts
@@ -339,6 +339,7 @@ function showNotification(details: NotificationDetails): Promise<void> {
   const title = details.title ?? '';
 
   const { actions } = details;
+  // Note: Firefox does not support the maxActions property.
   const { maxActions } = Notification;
   if (actions && maxActions && actions.length > maxActions) {
     console.warn(


### PR DESCRIPTION
A step towards fixing all cross-browser tests.  This is the only failing test for Messaging.