### PR TITLE
ComponentProvider v2

### DIFF
--- a/packages/firestore/src/core/component_provider.ts
+++ b/packages/firestore/src/core/component_provider.ts
@@ -118,9 +118,7 @@ export class IndexedDbComponentProvider implements ComponentProvider {
     const persistenceKey = IndexedDbPersistence.buildStoragePrefix(
       cfg.databaseInfo
     );
-    const serializer = cfg.platform.newSerializer(
-      cfg.databaseInfo.databaseId
-    );
+    const serializer = cfg.platform.newSerializer(cfg.databaseInfo.databaseId);
     return IndexedDbPersistence.createIndexedDbPersistence({
       allowTabSynchronization: cfg.persistenceSettings.synchronizeTabs,
       persistenceKey,

--- a/packages/firestore/src/core/component_provider.ts
+++ b/packages/firestore/src/core/component_provider.ts
@@ -121,12 +121,45 @@ export abstract class ComponentProvider {
   }
 
   protected abstract createSharedClientState(): SharedClientState;
+
   protected abstract createPersistence(): Persistence;
+
   protected abstract createGarbageCollectionScheduler(): GarbageCollectionScheduler | null;
-  protected abstract createLocalStore(): LocalStore;
-  protected abstract createRemoteStore(): RemoteStore;
-  protected abstract createSyncEngine(): SyncEngine;
-  protected abstract createEventManager(): EventManager;
+
+  protected createLocalStore(): LocalStore {
+    return new LocalStore(
+      this.persistence,
+      new IndexFreeQueryEngine(),
+      this.initialUser
+    );
+  }
+  protected createSyncEngine(): SyncEngine {
+    return new SyncEngine(
+      this.localStore,
+      this.remoteStore,
+      this.sharedClientState,
+      this.initialUser,
+      this.maxConcurrentLimboResolutions
+    );
+  }
+
+  protected createEventManager(): EventManager {
+    return new EventManager(this.syncEngine);
+  }
+
+  protected createRemoteStore(): RemoteStore {
+    return new RemoteStore(
+      this.localStore,
+      this.datastore,
+      this.asyncQueue,
+      onlineState =>
+        this.syncEngine.applyOnlineStateChange(
+          onlineState,
+          OnlineStateSource.RemoteStore
+        ),
+      this.platform.newConnectivityMonitor()
+    );
+  }
 
   abstract clearPersistence(databaseId: DatabaseInfo): Promise<void>;
 }
@@ -135,10 +168,6 @@ export abstract class ComponentProvider {
  * Provides all components needed for Firestore with IndexedDB persistence.
  */
 export class IndexedDbComponentProvider extends ComponentProvider {
-  protected createEventManager(): EventManager {
-    return new EventManager(this.syncEngine);
-  }
-
   protected createGarbageCollectionScheduler(): GarbageCollectionScheduler | null {
     debugAssert(
       this.persistence instanceof IndexedDbPersistence,
@@ -147,14 +176,6 @@ export class IndexedDbComponentProvider extends ComponentProvider {
     const garbageCollector = this.persistence.referenceDelegate
       .garbageCollector;
     return new LruScheduler(garbageCollector, this.asyncQueue);
-  }
-
-  protected createLocalStore(): LocalStore {
-    return new LocalStore(
-      this.persistence,
-      new IndexFreeQueryEngine(),
-      this.initialUser
-    );
   }
 
   protected createPersistence(): Persistence {
@@ -181,20 +202,6 @@ export class IndexedDbComponentProvider extends ComponentProvider {
       ),
       sequenceNumberSyncer: this.sharedClientState
     });
-  }
-
-  protected createRemoteStore(): RemoteStore {
-    return new RemoteStore(
-      this.localStore,
-      this.datastore,
-      this.asyncQueue,
-      onlineState =>
-        this.syncEngine.applyOnlineStateChange(
-          onlineState,
-          OnlineStateSource.RemoteStore
-        ),
-      this.platform.newConnectivityMonitor()
-    );
   }
 
   protected createSharedClientState(): SharedClientState {
@@ -224,16 +231,6 @@ export class IndexedDbComponentProvider extends ComponentProvider {
     return new MemorySharedClientState();
   }
 
-  protected createSyncEngine(): SyncEngine {
-    return new SyncEngine(
-      this.localStore,
-      this.remoteStore,
-      this.sharedClientState,
-      this.initialUser,
-      this.maxConcurrentLimboResolutions
-    );
-  }
-
   clearPersistence(databaseInfo: DatabaseInfo): Promise<void> {
     const persistenceKey = IndexedDbPersistence.buildStoragePrefix(
       databaseInfo
@@ -259,20 +256,8 @@ export class MemoryComponentProvider extends ComponentProvider {
     super();
   }
 
-  protected createEventManager(): EventManager {
-    return new EventManager(this.syncEngine);
-  }
-
   protected createGarbageCollectionScheduler(): GarbageCollectionScheduler | null {
     return null;
-  }
-
-  protected createLocalStore(): LocalStore {
-    return new LocalStore(
-      this.persistence,
-      new IndexFreeQueryEngine(),
-      this.initialUser
-    );
   }
 
   protected createPersistence(): Persistence {
@@ -283,32 +268,8 @@ export class MemoryComponentProvider extends ComponentProvider {
     return new MemoryPersistence(this.clientId, this.referenceDelegateFactory);
   }
 
-  protected createRemoteStore(): RemoteStore {
-    return new RemoteStore(
-      this.localStore,
-      this.datastore,
-      this.asyncQueue,
-      onlineState =>
-        this.syncEngine.applyOnlineStateChange(
-          onlineState,
-          OnlineStateSource.RemoteStore
-        ),
-      this.platform.newConnectivityMonitor()
-    );
-  }
-
   protected createSharedClientState(): SharedClientState {
     return new MemorySharedClientState();
-  }
-
-  protected createSyncEngine(): SyncEngine {
-    return new SyncEngine(
-      this.localStore,
-      this.remoteStore,
-      this.sharedClientState,
-      this.initialUser,
-      this.maxConcurrentLimboResolutions
-    );
   }
 
   clearPersistence(): never {

--- a/packages/firestore/src/core/firestore_client.ts
+++ b/packages/firestore/src/core/firestore_client.ts
@@ -245,16 +245,16 @@ export class FirestoreClient {
         serializer
       );
 
-      await componentProvider.initialize(
-        this.asyncQueue,
-        this.databaseInfo,
-        this.platform,
+      await componentProvider.initialize({
+        asyncQueue: this.asyncQueue,
+        databaseInfo: this.databaseInfo,
+        platform: this.platform,
         datastore,
-        this.clientId,
-        user,
-        MAX_CONCURRENT_LIMBO_RESOLUTIONS,
+        clientId: this.clientId,
+        initialUser: user,
+        maxConcurrentLimboResolutions: MAX_CONCURRENT_LIMBO_RESOLUTIONS,
         persistenceSettings
-      );
+      });
 
       this.persistence = componentProvider.persistence;
       this.sharedClientState = componentProvider.sharedClientState;

--- a/packages/firestore/src/local/indexeddb_persistence.ts
+++ b/packages/firestore/src/local/indexeddb_persistence.ts
@@ -189,7 +189,7 @@ export class IndexedDbPersistence implements Persistence {
    */
   static MAIN_DATABASE = 'main';
 
-  static async createIndexedDbPersistence(options: {
+  static createIndexedDbPersistence(options: {
     allowTabSynchronization: boolean;
     persistenceKey: string;
     clientId: ClientId;
@@ -198,7 +198,7 @@ export class IndexedDbPersistence implements Persistence {
     queue: AsyncQueue;
     serializer: JsonProtoSerializer;
     sequenceNumberSyncer: SequenceNumberSyncer;
-  }): Promise<IndexedDbPersistence> {
+  }): IndexedDbPersistence {
     if (!IndexedDbPersistence.isAvailable()) {
       throw new FirestoreError(
         Code.UNIMPLEMENTED,
@@ -216,7 +216,6 @@ export class IndexedDbPersistence implements Persistence {
       options.serializer,
       options.sequenceNumberSyncer
     );
-    await persistence.start();
     return persistence;
   }
 
@@ -297,7 +296,7 @@ export class IndexedDbPersistence implements Persistence {
    *
    * @return {Promise<void>} Whether persistence was enabled.
    */
-  private start(): Promise<void> {
+  start(): Promise<void> {
     debugAssert(!this.started, 'IndexedDbPersistence double-started!');
     debugAssert(this.window !== null, "Expected 'window' to be defined");
 

--- a/packages/firestore/src/local/memory_persistence.ts
+++ b/packages/firestore/src/local/memory_persistence.ts
@@ -93,6 +93,10 @@ export class MemoryPersistence implements Persistence {
     );
   }
 
+  start(): Promise<void> {
+    return Promise.resolve();
+  }
+
   shutdown(): Promise<void> {
     // No durable state to ensure is closed on shutdown.
     this._started = false;

--- a/packages/firestore/src/local/persistence.ts
+++ b/packages/firestore/src/local/persistence.ts
@@ -170,6 +170,9 @@ export interface Persistence {
 
   readonly referenceDelegate: ReferenceDelegate;
 
+  /** Starts persistence. */
+  start(): Promise<void>;
+
   /**
    * Releases any resources held during eager shutdown.
    */

--- a/packages/firestore/src/util/assert.ts
+++ b/packages/firestore/src/util/assert.ts
@@ -51,7 +51,6 @@ export function hardAssert(
   }
 }
 
-
 /**
  * Fails if the given assertion condition is false, throwing an Error with the
  * given message if it did.

--- a/packages/firestore/test/unit/local/indexeddb_persistence.test.ts
+++ b/packages/firestore/test/unit/local/indexeddb_persistence.test.ts
@@ -135,6 +135,7 @@ async function withCustomPersistence(
     sequenceNumberSyncer: MOCK_SEQUENCE_NUMBER_SYNCER
   });
 
+  await persistence.start();
   await fn(persistence, platform, queue);
   await persistence.shutdown();
 }

--- a/packages/firestore/test/unit/local/persistence_test_helpers.ts
+++ b/packages/firestore/test/unit/local/persistence_test_helpers.ts
@@ -113,7 +113,7 @@ export async function testIndexedDbPersistence(
     await SimpleDb.delete(prefix + IndexedDbPersistence.MAIN_DATABASE);
   }
   const platform = PlatformSupport.getPlatform();
-  return IndexedDbPersistence.createIndexedDbPersistence({
+  const persistence = IndexedDbPersistence.createIndexedDbPersistence({
     allowTabSynchronization: !!options.synchronizeTabs,
     persistenceKey: TEST_PERSISTENCE_PREFIX,
     clientId,
@@ -123,6 +123,8 @@ export async function testIndexedDbPersistence(
     lruParams,
     sequenceNumberSyncer: MOCK_SEQUENCE_NUMBER_SYNCER
   });
+  await persistence.start();
+  return persistence;
 }
 
 /** Creates and starts a MemoryPersistence instance for testing. */

--- a/packages/firestore/test/unit/specs/spec_test_runner.ts
+++ b/packages/firestore/test/unit/specs/spec_test_runner.ts
@@ -50,10 +50,7 @@ import {
   MemoryEagerDelegate,
   MemoryLruDelegate
 } from '../../../src/local/memory_persistence';
-import {
-  GarbageCollectionScheduler,
-  Persistence
-} from '../../../src/local/persistence';
+import { Persistence } from '../../../src/local/persistence';
 import {
   ClientId,
   SharedClientState
@@ -401,7 +398,6 @@ abstract class TestRunner {
   private connection!: MockConnection;
   private eventManager!: EventManager;
   private syncEngine!: SyncEngine;
-  private gcScheduler!: GarbageCollectionScheduler | null;
 
   private eventList: QueryEvent[] = [];
   private acknowledgedDocs: string[];
@@ -497,7 +493,6 @@ abstract class TestRunner {
     this.remoteStore = componentProvider.remoteStore;
     this.syncEngine = componentProvider.syncEngine;
     this.eventManager = componentProvider.eventManager;
-    this.gcScheduler = componentProvider.gcScheduler;
 
     await this.persistence.setDatabaseDeletedListener(async () => {
       await this.shutdown();
@@ -918,10 +913,6 @@ abstract class TestRunner {
   }
 
   private async doShutdown(): Promise<void> {
-    if (this.gcScheduler) {
-      this.gcScheduler.stop();
-    }
-
     await this.remoteStore.shutdown();
     await this.sharedClientState.shutdown();
     // We don't delete the persisted data here since multi-clients may still

--- a/packages/firestore/test/unit/specs/spec_test_runner.ts
+++ b/packages/firestore/test/unit/specs/spec_test_runner.ts
@@ -22,7 +22,8 @@ import {
   ComponentConfiguration,
   ComponentProvider,
   IndexedDbComponentProvider,
-  MemoryComponentProvider
+  MemoryComponentProvider,
+  MemoryLruComponentProvider
 } from '../../../src/core/component_provider';
 import { DatabaseInfo } from '../../../src/core/database_info';
 import {
@@ -47,10 +48,6 @@ import {
   SchemaConverter
 } from '../../../src/local/indexeddb_schema';
 import { LocalStore } from '../../../src/local/local_store';
-import {
-  MemoryEagerDelegate,
-  MemoryLruDelegate
-} from '../../../src/local/memory_persistence';
 import {
   GarbageCollectionScheduler,
   Persistence
@@ -1282,13 +1279,11 @@ class MemoryTestRunner extends TestRunner {
     configuration: ComponentConfiguration,
     gcEnabled: boolean
   ): Promise<ComponentProvider> {
-    const persistenceProvider = new MemoryComponentProvider(
-      gcEnabled
-        ? MemoryEagerDelegate.factory
-        : p => new MemoryLruDelegate(p, LruParams.DEFAULT)
-    );
-    await persistenceProvider.initialize(configuration);
-    return persistenceProvider;
+    const componentProvider = gcEnabled
+      ? new MemoryComponentProvider()
+      : new MemoryLruComponentProvider();
+    await componentProvider.initialize(configuration);
+    return componentProvider;
   }
 }
 
@@ -1320,9 +1315,9 @@ class IndexedDbTestRunner extends TestRunner {
     configuration: ComponentConfiguration,
     gcEnabled: boolean
   ): Promise<ComponentProvider> {
-    const persistenceProvider = new IndexedDbComponentProvider();
-    await persistenceProvider.initialize(configuration);
-    return persistenceProvider;
+    const componentProvider = new IndexedDbComponentProvider();
+    await componentProvider.initialize(configuration);
+    return componentProvider;
   }
 
   static destroyPersistence(): Promise<void> {

--- a/packages/firestore/test/unit/util/async_queue.test.ts
+++ b/packages/firestore/test/unit/util/async_queue.test.ts
@@ -217,7 +217,7 @@ describe('AsyncQueue', () => {
     expect(completedSteps).to.deep.equal([1, 2]);
   });
 
-  it('Schedules operaions with respect to shut down', async () => {
+  it('Schedules operations with respect to shut down', async () => {
     const queue = new AsyncQueue();
     const completedSteps: number[] = [];
     const doStep = (n: number): Promise<void> =>


### PR DESCRIPTION
So... obviously the component provider design broke the other PR I had in flight. In https://github.com/firebase/firebase-js-sdk/pull/2879, I rely on the ability to provide a custom persistence implementation in the SpecTest that can inject failures. With the ComponentProvider as implemented, I would have to build up all components from scratch. It would be nice if I only needed to change the persistence layer.

I pushed three versions:
- e01a7c3 is cleaner, but increases size by 580b (full build) / 973b  (memory)
- 9725015 moves some shared code to ComponentBuilder. This only helps the full build (+241b instead of 580b)
- f1d4a49 gets rid of the abstract class and has a size increase of 311b (full) / 725b (memory)

I personally prefer the last option (the diff of this PR).