### PR TITLE
Prefix list results with correct bucket

### DIFF
--- a/packages/storage/src/implementation/list.ts
+++ b/packages/storage/src/implementation/list.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2019 Google Inc.
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/storage/src/implementation/list.ts
+++ b/packages/storage/src/implementation/list.ts
@@ -23,7 +23,6 @@ import { Location } from './location';
 import * as json from './json';
 import * as type from './type';
 import { ListResult } from '../list';
-import * as errors from './error';
 
 /**
  * Represents the simplified object metadata returned by List API.
@@ -52,6 +51,7 @@ const ITEMS_KEY = 'items';
 
 function fromBackendResponse(
   authWrapper: AuthWrapper,
+  bucket: string,
   resource: ListResultResponse
 ): ListResult {
   const listResult: ListResult = {
@@ -59,10 +59,6 @@ function fromBackendResponse(
     items: [],
     nextPageToken: resource['nextPageToken']
   };
-  const bucket = authWrapper.bucket();
-  if (bucket === null) {
-    throw errors.noDefaultBucket();
-  }
   if (resource[PREFIXES_KEY]) {
     for (const path of resource[PREFIXES_KEY]) {
       const pathWithoutTrailingSlash = path.replace(/\/$/, '');
@@ -86,6 +82,7 @@ function fromBackendResponse(
 
 export function fromResponseString(
   authWrapper: AuthWrapper,
+  bucket: string,
   resourceString: string
 ): ListResult | null {
   const obj = json.jsonObjectOrNull(resourceString);
@@ -93,7 +90,7 @@ export function fromResponseString(
     return null;
   }
   const resource = (obj as unknown) as ListResultResponse;
-  return fromBackendResponse(authWrapper, resource);
+  return fromBackendResponse(authWrapper, bucket, resource);
 }
 
 export function listOptionsValidator(p: unknown): void {

--- a/packages/storage/src/implementation/requests.ts
+++ b/packages/storage/src/implementation/requests.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2017 Google Inc.
+ * Copyright 2017 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/storage/src/implementation/requests.ts
+++ b/packages/storage/src/implementation/requests.ts
@@ -67,10 +67,15 @@ export function metadataHandler(
 }
 
 export function listHandler(
-  authWrapper: AuthWrapper, bucket: string, 
+  authWrapper: AuthWrapper,
+  bucket: string
 ): (p1: XhrIo, p2: string) => ListResult {
   function handler(xhr: XhrIo, text: string): ListResult {
-    const listResult = ListResultUtils.fromResponseString(authWrapper, bucket, text);
+    const listResult = ListResultUtils.fromResponseString(
+      authWrapper,
+      bucket,
+      text
+    );
     handlerCheck(listResult !== null);
     return listResult as ListResult;
   }

--- a/packages/storage/src/implementation/requests.ts
+++ b/packages/storage/src/implementation/requests.ts
@@ -67,10 +67,10 @@ export function metadataHandler(
 }
 
 export function listHandler(
-  authWrapper: AuthWrapper
+  authWrapper: AuthWrapper, bucket: string, 
 ): (p1: XhrIo, p2: string) => ListResult {
   function handler(xhr: XhrIo, text: string): ListResult {
-    const listResult = ListResultUtils.fromResponseString(authWrapper, text);
+    const listResult = ListResultUtils.fromResponseString(authWrapper, bucket, text);
     handlerCheck(listResult !== null);
     return listResult as ListResult;
   }
@@ -190,7 +190,7 @@ export function list(
   const requestInfo = new RequestInfo(
     url,
     method,
-    listHandler(authWrapper),
+    listHandler(authWrapper, location.bucket),
     timeout
   );
   requestInfo.urlParams = urlParams;

--- a/packages/storage/test/requests.test.ts
+++ b/packages/storage/test/requests.test.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2017 Google Inc.
+ * Copyright 2017 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/storage/test/requests.test.ts
+++ b/packages/storage/test/requests.test.ts
@@ -296,7 +296,7 @@ describe('Firebase Storage > Requests', () => {
         {
           name: 'a/a',
           bucket: differentBucket
-        },
+        }
       ],
       nextPageToken: pageToken
     };

--- a/packages/storage/test/requests.test.ts
+++ b/packages/storage/test/requests.test.ts
@@ -41,9 +41,11 @@ import { FirebaseApp } from '@firebase/app-types';
 
 describe('Firebase Storage > Requests', () => {
   const normalBucket = 'b';
+  const differentBucket = 'c';
   const locationRoot = new Location(normalBucket, '');
   const locationNormal = new Location(normalBucket, 'o');
   const locationNormalUrl = '/b/' + normalBucket + '/o/o';
+  const locationDifferentBucket = new Location(differentBucket, '');
   const locationNormalNoObjUrl = '/b/' + normalBucket + '/o';
   const locationEscapes = new Location('b/', 'o?');
   const locationEscapesUrl = '/b/b%2F/o/o%3F';
@@ -269,11 +271,11 @@ describe('Firebase Storage > Requests', () => {
       items: [
         {
           name: 'a/a',
-          bucket: 'fredzqm-staging'
+          bucket: normalBucket
         },
         {
           name: 'a/b',
-          bucket: 'fredzqm-staging'
+          bucket: normalBucket
         }
       ],
       nextPageToken: pageToken
@@ -284,6 +286,23 @@ describe('Firebase Storage > Requests', () => {
     assert.equal(listResult.items[0].fullPath, 'a/a');
     assert.equal(listResult.items[1].fullPath, 'a/b');
     assert.equal(listResult.nextPageToken, pageToken);
+  });
+
+  it('list handler with custom bucket', () => {
+    const requestInfo = requests.list(authWrapper, locationDifferentBucket);
+    const pageToken = 'YS9mLw==';
+    const listResponse = {
+      items: [
+        {
+          name: 'a/a',
+          bucket: differentBucket
+        },
+      ],
+      nextPageToken: pageToken
+    };
+    const listResponseString = JSON.stringify(listResponse);
+    const listResult = requestInfo.handler(fakeXhrIo({}), listResponseString);
+    assert.equal(listResult.items[0].bucket, differentBucket);
   });
 
   it('getDownloadUrl request info', () => {


### PR DESCRIPTION
We need to use the same bucket in the list response as in the list request.

Fixes https://b.corp.google.com/issues/152053124