### PR TITLE
Add more messages to prettier prepush to help diagnose intermittent problems

### DIFF
--- a/tools/gitHooks/license.js
+++ b/tools/gitHooks/license.js
@@ -19,6 +19,7 @@ const { resolve } = require('path');
 const simpleGit = require('simple-git/promise');
 const fs = require('mz/fs');
 const ora = require('ora');
+const chalk = require('chalk');
 
 const root = resolve(__dirname, '../..');
 const git = simpleGit(root);

--- a/tools/gitHooks/license.js
+++ b/tools/gitHooks/license.js
@@ -116,16 +116,24 @@ async function doLicenseCommit(changedFiles) {
 
   const hasDiff = await git.diff();
 
-  if (!hasDiff) return;
+  if (!hasDiff) {
+    console.log(
+      chalk`\n{red License pass caused no changes.} Skipping commit.\n`
+    );
+    return;
+  }
 
   const gitSpinner = ora(' Creating automated license commit').start();
   await git.add('.');
 
-  await git.commit('[AUTOMATED]: License Headers');
+  const commit = await git.commit('[AUTOMATED]: License Headers');
 
   gitSpinner.stopAndPersist({
     symbol: '✅'
   });
+  console.log(
+    chalk`{green Commited ${commit.commit} to branch ${commit.branch}}`
+  );
 }
 
 module.exports = {

--- a/tools/gitHooks/prettier.js
+++ b/tools/gitHooks/prettier.js
@@ -105,7 +105,7 @@ async function doPrettierCommit(changedFiles) {
     symbol: '✅'
   });
   console.log(
-    chalk`\n{green Commited ${commit.commit} to branch ${commit.branch}}`
+    chalk`{green Commited ${commit.commit} to branch ${commit.branch}}`
   );
 }
 

--- a/tools/gitHooks/prettier.js
+++ b/tools/gitHooks/prettier.js
@@ -100,7 +100,7 @@ async function doPrettierCommit(changedFiles) {
   const gitSpinner = ora(' Creating automated style commit').start();
   await git.add(targetFiles);
 
-  const commit = await git.commit('[AUTOMATED]: Prettier Code Styling');
+  const commit =  await git.commit('[AUTOMATED]: Prettier Code Styling');
   console.log(
     chalk`{green Commited ${commit.commit} to branch ${commit.branch}}`
   );

--- a/tools/gitHooks/prettier.js
+++ b/tools/gitHooks/prettier.js
@@ -66,7 +66,9 @@ async function doPrettierCommit(changedFiles) {
 
   // Only run on .js or .ts files.
   const targetFiles = changedFiles.filter(line => line.match(/(js|ts)$/));
-  if (targetFiles.length === 0) return;
+  if (targetFiles.length === 0) {
+    console.log('No files changed.');
+  };
 
   const stylingSpinner = ora(
     ` Formatting ${targetFiles.length} files with prettier`

--- a/tools/gitHooks/prettier.js
+++ b/tools/gitHooks/prettier.js
@@ -100,7 +100,7 @@ async function doPrettierCommit(changedFiles) {
   const gitSpinner = ora(' Creating automated style commit').start();
   await git.add(targetFiles);
 
-  const commit =  await git.commit('[AUTOMATED]: Prettier Code Styling');
+  const commit = await git.commit('[AUTOMATED]: Prettier Code Styling');
   console.log(
     chalk`{green Commited ${commit.commit} to branch ${commit.branch}}`
   );

--- a/tools/gitHooks/prettier.js
+++ b/tools/gitHooks/prettier.js
@@ -68,7 +68,7 @@ async function doPrettierCommit(changedFiles) {
   const targetFiles = changedFiles.filter(line => line.match(/(js|ts)$/));
   if (targetFiles.length === 0) {
     console.log('No files changed.');
-  };
+  }
 
   const stylingSpinner = ora(
     ` Formatting ${targetFiles.length} files with prettier`

--- a/tools/gitHooks/prettier.js
+++ b/tools/gitHooks/prettier.js
@@ -100,7 +100,7 @@ async function doPrettierCommit(changedFiles) {
   const gitSpinner = ora(' Creating automated style commit').start();
   await git.add(targetFiles);
 
-  const commit =  await git.commit('[AUTOMATED]: Prettier Code Styling');
+  const commit = await git.commit('[AUTOMATED]: Prettier Code Styling');
   gitSpinner.stopAndPersist({
     symbol: '✅'
   });

--- a/tools/gitHooks/prettier.js
+++ b/tools/gitHooks/prettier.js
@@ -90,12 +90,20 @@ async function doPrettierCommit(changedFiles) {
 
   const hasDiff = await git.diff();
 
-  if (!hasDiff) return;
+  if (!hasDiff) {
+    console.log(
+      chalk`\n{red Prettier formatting caused no changes.} Skipping commit.\n`
+    );
+    return;
+  }
 
   const gitSpinner = ora(' Creating automated style commit').start();
   await git.add(targetFiles);
 
-  await git.commit('[AUTOMATED]: Prettier Code Styling');
+  const commit = await git.commit('[AUTOMATED]: Prettier Code Styling');
+  console.log(
+    chalk`{green Commited ${commit.commit} to branch ${commit.branch}}`
+  );
   gitSpinner.stopAndPersist({
     symbol: '✅'
   });

--- a/tools/gitHooks/prettier.js
+++ b/tools/gitHooks/prettier.js
@@ -100,13 +100,13 @@ async function doPrettierCommit(changedFiles) {
   const gitSpinner = ora(' Creating automated style commit').start();
   await git.add(targetFiles);
 
-  const commit = await git.commit('[AUTOMATED]: Prettier Code Styling');
-  console.log(
-    chalk`{green Commited ${commit.commit} to branch ${commit.branch}}`
-  );
+  const commit =  await git.commit('[AUTOMATED]: Prettier Code Styling');
   gitSpinner.stopAndPersist({
     symbol: '✅'
   });
+  console.log(
+    chalk`\n{green Commited ${commit.commit} to branch ${commit.branch}}`
+  );
 }
 
 module.exports = {


### PR DESCRIPTION
Some contributors have reported problems where the prettier prepush commit does not work. Sometimes the problem seems to be that the commit happens but is not pushed, and will be pushed if the user does a second push immediately after. Maybe some additional log messages will help us narrow down the problem when it happens again.