### PR TITLE
Make 'handleClientStateEvent()/handleQueryTargetEvent()' idempotent

### DIFF
--- a/packages/firestore/src/core/sync_engine.ts
+++ b/packages/firestore/src/core/sync_engine.ts
@@ -1138,10 +1138,12 @@ export class SyncEngine implements RemoteSyncer, SharedClientStateSyncer {
     }
 
     for (const targetId of added) {
-      debugAssert(
-        !this.queriesByTarget.has(targetId),
-        'Trying to add an already active target'
-      );
+      if (this.queriesByTarget.has(targetId)) {
+        // A target might have been added in a previous attempt
+        logDebug(LOG_TAG, 'Adding an already active target ' + targetId);
+        continue;
+      }
+
       const target = await this.localStore.getTarget(targetId);
       debugAssert(
         !!target,

--- a/packages/firestore/src/local/local_store.ts
+++ b/packages/firestore/src/local/local_store.ts
@@ -879,11 +879,10 @@ export class LocalStore {
     keepPersistedTargetData: boolean
   ): Promise<void> {
     const targetData = this.targetDataByTarget.get(targetId);
-
-    if (targetData === null) {
-      logDebug(`Ignoring release of nonexistent target: ${targetId}`);
-      return Promise.resolve();
-    }
+    debugAssert(
+      targetData !== null,
+      `Tried to release nonexistent target: ${targetId}`
+    );
 
     const mode = keepPersistedTargetData ? 'readwrite' : 'readwrite-primary';
     return this.persistence

--- a/packages/firestore/src/local/local_store.ts
+++ b/packages/firestore/src/local/local_store.ts
@@ -879,10 +879,11 @@ export class LocalStore {
     keepPersistedTargetData: boolean
   ): Promise<void> {
     const targetData = this.targetDataByTarget.get(targetId);
-    debugAssert(
-      targetData !== null,
-      `Tried to release nonexistent target: ${targetId}`
-    );
+
+    if (targetData === null) {
+      logDebug(`Ignoring release of nonexistent target: ${targetId}`);
+      return Promise.resolve();
+    }
 
     const mode = keepPersistedTargetData ? 'readwrite' : 'readwrite-primary';
     return this.persistence

--- a/packages/firestore/test/unit/specs/recovery_spec.test.ts
+++ b/packages/firestore/test/unit/specs/recovery_spec.test.ts
@@ -102,6 +102,7 @@ describeSpec(
             // The primary client 0 receives a notification that the query can
             // be released, but it can only process the change after we recover
             // the database.
+            .expectActiveTargets({ query})
             .recoverDatabase()
             .runTimer(TimerId.AsyncQueueRetry)
             .expectActiveTargets()

--- a/packages/firestore/test/unit/specs/recovery_spec.test.ts
+++ b/packages/firestore/test/unit/specs/recovery_spec.test.ts
@@ -102,7 +102,7 @@ describeSpec(
             // The primary client 0 receives a notification that the query can
             // be released, but it can only process the change after we recover
             // the database.
-            .expectActiveTargets({ query})
+            .expectActiveTargets({ query })
             .recoverDatabase()
             .runTimer(TimerId.AsyncQueueRetry)
             .expectActiveTargets()

--- a/packages/firestore/test/unit/specs/spec_builder.ts
+++ b/packages/firestore/test/unit/specs/spec_builder.ts
@@ -446,7 +446,7 @@ export class SpecBuilder {
 
   /** Overrides the currently expected set of active targets. */
   expectActiveTargets(
-    ...targets: Array<{ query: Query; resumeToken: string }>
+    ...targets: Array<{ query: Query; resumeToken?: string }>
   ): this {
     this.assertStep('Active target expectation requires previous step');
     const currentStep = this.currentStep!;


### PR DESCRIPTION
This solves a problem where we were able to modify a in-memory state before the database transaction failed and also addresses issues where targets to allocate already existed or rejected targets were missing. 

I believe there are no other issues in the WebStorage callbacks.

Addresses #2755