### PR TITLE
Strip messages for fail() and hardAssert()

### DIFF
--- a/packages/firestore/rollup.shared.js
+++ b/packages/firestore/rollup.shared.js
@@ -44,8 +44,8 @@ const externsPaths = externs.map(p => path.resolve(__dirname, '../../', p));
 const publicIdentifiers = extractPublicIdentifiers(externsPaths);
 
 /**
- * Transformers that remove all debugAsserts and appends a __PRIVATE_ prefix to
- * all internal symbols.
+ * Transformers that remove calls to `debugAssert`, messages for 'fail` and
+ * `hardAssert` and appends a __PRIVATE_ prefix to all internal symbols.
  */
 export const firestoreTransformers = [
   service => ({

--- a/packages/firestore/scripts/remove-asserts.ts
+++ b/packages/firestore/scripts/remove-asserts.ts
@@ -30,8 +30,8 @@ export function removeAsserts(
   };
 }
 
-/** 
- * Transformer that removes all "debugAssert" statements from the SDK and 
+/**
+ * Transformer that removes all "debugAssert" statements from the SDK and
  * removes the custom message for fail() and hardAssert().
  */
 class RemoveAsserts {
@@ -64,10 +64,14 @@ class RemoveAsserts {
           const method = declaration.name!.text;
           if (method === 'debugAssert') {
             return ts.createEmptyStatement();
-          } else if (method === 'hardAssert') {  // Remove the log message
-            return ts.createCall(declaration.name!, /*typeArgs*/ undefined, [node.arguments[0]])
-          } else if (method === 'fail') {  // Remove the log message
-            return ts.createCall(declaration.name!, /*typeArgs*/ undefined, [])
+          } else if (method === 'hardAssert') {
+            // Remove the log message but keep the assertion
+            return ts.createCall(declaration.name!, /*typeArgs*/ undefined, [
+              node.arguments[0]
+            ]);
+          } else if (method === 'fail') {
+            // Remove the log message
+            return ts.createCall(declaration.name!, /*typeArgs*/ undefined, []);
           }
         }
       }

--- a/packages/firestore/scripts/remove-asserts.ts
+++ b/packages/firestore/scripts/remove-asserts.ts
@@ -30,7 +30,10 @@ export function removeAsserts(
   };
 }
 
-/** Transformer that removes all "debugAssert" statements from the SDK. */
+/** 
+ * Transformer that removes all "debugAssert" statements from the SDK and 
+ * removes the custom message for fail() and hardAssert().
+ */
 class RemoveAsserts {
   constructor(private readonly typeChecker: ts.TypeChecker) {}
 
@@ -61,6 +64,10 @@ class RemoveAsserts {
           const method = declaration.name!.text;
           if (method === 'debugAssert') {
             return ts.createEmptyStatement();
+          } else if (method === 'hardAssert') {  // Remove the log message
+            return ts.createCall(declaration.name!, /*typeArgs*/ undefined, [node.arguments[0]])
+          } else if (method === 'fail') {  // Remove the log message
+            return ts.createCall(declaration.name!, /*typeArgs*/ undefined, [])
           }
         }
       }

--- a/packages/firestore/src/util/assert.ts
+++ b/packages/firestore/src/util/assert.ts
@@ -20,12 +20,13 @@ import { logError } from './log';
 
 /**
  * Unconditionally fails, throwing an Error with the given message.
+ * Messages are stripped in production builds.
  *
  * Returns `never` and can be used in expressions:
  * @example
  * let futureVar = fail('not implemented yet');
  */
-export function fail(failure: string): never {
+export function fail(failure: string = 'Unexpected state'): never {
   // Log the failure in addition to throw an exception, just in case the
   // exception is swallowed.
   const message =
@@ -41,10 +42,12 @@ export function fail(failure: string): never {
 /**
  * Fails if the given assertion condition is false, throwing an Error with the
  * given message if it did.
+ *
+ * Messages are stripped in production builds.
  */
 export function hardAssert(
   assertion: boolean,
-  message: string
+  message?: string
 ): asserts assertion {
   if (!assertion) {
     fail(message);

--- a/packages/firestore/test/unit/specs/recovery_spec.test.ts
+++ b/packages/firestore/test/unit/specs/recovery_spec.test.ts
@@ -42,7 +42,7 @@ describeSpec(
             // Client 1 has received the WebStorage notification that the write
             // has been acknowledged, but failed to process the change. Hence,
             // we did not get a user callback. We schedule the first retry and
-            // make sure that it also does not get processed until 
+            // make sure that it also does not get processed until
             // `recoverDatabase` is called.
             .runTimer(TimerId.AsyncQueueRetry)
             .recoverDatabase()


### PR DESCRIPTION
Goal: Reduce size of SDK by stripping error messages that should not show up in production builds. We can still trace the original error by looking at the stacktrace.