### PR TITLE
Make @firebase/app-next have single entry point

### DIFF
--- a/common/api-review/app-exp.api.md
+++ b/common/api-review/app-exp.api.md
@@ -5,39 +5,29 @@
 ```ts
 
 import { Component } from '@firebase/component';
-import { FirebaseApp } from '@firebase/app-types';
-import { FirebaseAppConfig } from '@firebase/app-types';
-import { FirebaseOptions } from '@firebase/app-types';
+import { FirebaseApp } from '@firebase/app-types-exp';
+import { FirebaseAppConfig } from '@firebase/app-types-exp';
+import { FirebaseOptions } from '@firebase/app-types-exp';
 import { LogCallback } from '@firebase/logger';
 import { LogLevel } from '@firebase/logger';
 import { LogOptions } from '@firebase/logger';
 import { Name } from '@firebase/component';
 import { Provider } from '@firebase/component';
 
-// Warning: (ae-internal-missing-underscore) The name "addComponent" should be prefixed with an underscore because the declaration is marked as @internal
-//
 // @internal (undocumented)
-export function addComponent(app: FirebaseApp, component: Component): void;
+export function _addComponent(app: FirebaseApp, component: Component): void;
 
-// Warning: (ae-internal-missing-underscore) The name "addOrOverwriteComponent" should be prefixed with an underscore because the declaration is marked as @internal
-//
 // @internal (undocumented)
-export function addOrOverwriteComponent(app: FirebaseApp, component: Component): void;
+export function _addOrOverwriteComponent(app: FirebaseApp, component: Component): void;
 
-// Warning: (ae-internal-missing-underscore) The name "apps" should be prefixed with an underscore because the declaration is marked as @internal
-//
 // @internal (undocumented)
-export const apps: Map<string, FirebaseApp>;
+export const _apps: Map<string, FirebaseApp>;
 
-// Warning: (ae-internal-missing-underscore) The name "clearComponents" should be prefixed with an underscore because the declaration is marked as @internal
-//
 // @internal
-export function clearComponents(): void;
+export function _clearComponents(): void;
 
-// Warning: (ae-internal-missing-underscore) The name "components" should be prefixed with an underscore because the declaration is marked as @internal
-//
 // @internal
-export const components: Map<string, Component<any>>;
+export const _components: Map<string, Component<any>>;
 
 // @public
 export function deleteApp(app: FirebaseApp): Promise<void>;
@@ -48,10 +38,8 @@ export function getApp(name?: string): FirebaseApp;
 // @public
 export function getApps(): FirebaseApp[];
 
-// Warning: (ae-internal-missing-underscore) The name "getProvider" should be prefixed with an underscore because the declaration is marked as @internal
-//
 // @internal (undocumented)
-export function getProvider<T extends Name>(app: FirebaseApp, name: T): Provider<T>;
+export function _getProvider<T extends Name>(app: FirebaseApp, name: T): Provider<T>;
 
 // @public
 export function initializeApp(options: FirebaseOptions, name?: string): FirebaseApp;
@@ -64,10 +52,8 @@ export { LogLevel }
 // @public
 export function onLog(logCallback: LogCallback | null, options?: LogOptions): void;
 
-// Warning: (ae-internal-missing-underscore) The name "registerComponent" should be prefixed with an underscore because the declaration is marked as @internal
-//
 // @internal (undocumented)
-export function registerComponent(component: Component): boolean;
+export function _registerComponent(component: Component): boolean;
 
 // @public
 export function registerVersion(libraryKeyOrName: string, version: string, variant?: string): void;

--- a/common/api-review/app-exp.api.md
+++ b/common/api-review/app-exp.api.md
@@ -4,12 +4,40 @@
 
 ```ts
 
+import { Component } from '@firebase/component';
 import { FirebaseApp } from '@firebase/app-types';
 import { FirebaseAppConfig } from '@firebase/app-types';
 import { FirebaseOptions } from '@firebase/app-types';
 import { LogCallback } from '@firebase/logger';
 import { LogLevel } from '@firebase/logger';
 import { LogOptions } from '@firebase/logger';
+import { Name } from '@firebase/component';
+import { Provider } from '@firebase/component';
+
+// Warning: (ae-internal-missing-underscore) The name "addComponent" should be prefixed with an underscore because the declaration is marked as @internal
+//
+// @internal (undocumented)
+export function addComponent(app: FirebaseApp, component: Component): void;
+
+// Warning: (ae-internal-missing-underscore) The name "addOrOverwriteComponent" should be prefixed with an underscore because the declaration is marked as @internal
+//
+// @internal (undocumented)
+export function addOrOverwriteComponent(app: FirebaseApp, component: Component): void;
+
+// Warning: (ae-internal-missing-underscore) The name "apps" should be prefixed with an underscore because the declaration is marked as @internal
+//
+// @internal (undocumented)
+export const apps: Map<string, FirebaseApp>;
+
+// Warning: (ae-internal-missing-underscore) The name "clearComponents" should be prefixed with an underscore because the declaration is marked as @internal
+//
+// @internal
+export function clearComponents(): void;
+
+// Warning: (ae-internal-missing-underscore) The name "components" should be prefixed with an underscore because the declaration is marked as @internal
+//
+// @internal
+export const components: Map<string, Component<any>>;
 
 // @public
 export function deleteApp(app: FirebaseApp): Promise<void>;
@@ -19,6 +47,11 @@ export function getApp(name?: string): FirebaseApp;
 
 // @public
 export function getApps(): FirebaseApp[];
+
+// Warning: (ae-internal-missing-underscore) The name "getProvider" should be prefixed with an underscore because the declaration is marked as @internal
+//
+// @internal (undocumented)
+export function getProvider<T extends Name>(app: FirebaseApp, name: T): Provider<T>;
 
 // @public
 export function initializeApp(options: FirebaseOptions, name?: string): FirebaseApp;
@@ -30,6 +63,11 @@ export { LogLevel }
 
 // @public
 export function onLog(logCallback: LogCallback | null, options?: LogOptions): void;
+
+// Warning: (ae-internal-missing-underscore) The name "registerComponent" should be prefixed with an underscore because the declaration is marked as @internal
+//
+// @internal (undocumented)
+export function registerComponent(component: Component): boolean;
 
 // @public
 export function registerVersion(libraryKeyOrName: string, version: string, variant?: string): void;

--- a/config/api-extractor.json
+++ b/config/api-extractor.json
@@ -184,7 +184,7 @@
     /**
      * (REQUIRED) Whether to generate the .d.ts rollup file.
      */
-    "enabled": true,
+    "enabled": false,
 
     /**
      * Specifies the output path for a .d.ts rollup file to be generated without any trimming.

--- a/packages-exp/app-exp/api-extractor.json
+++ b/packages-exp/app-exp/api-extractor.json
@@ -1,5 +1,10 @@
 {
     "extends": "../../config/api-extractor.json",
     // Point it to your entry point d.ts file. 
-    "mainEntryPointFilePath": "<projectFolder>/dist/esm5/packages-exp/app-exp/src/index.d.ts"
+    "mainEntryPointFilePath": "<projectFolder>/dist/packages-exp/app-exp/src/index.d.ts",
+    "dtsRollup": {
+        "enabled": true,
+        "untrimmedFilePath": "<projectFolder>/dist/<unscopedPackageName>.d.ts",
+        "publicTrimmedFilePath": "<projectFolder>/dist/<unscopedPackageName>-public.d.ts"
+    }
 }

--- a/packages-exp/app-exp/internal/package.json
+++ b/packages-exp/app-exp/internal/package.json
@@ -1,8 +1,0 @@
-{
-    "name": "@firebase/app-exp/internal",
-    "main": "../dist/cjs/internal.js",
-    "browser": "../dist/esm5/internal.js",
-    "module": "../dist/esm5/internal.js",
-    "esm2017": "../dist/esm2017/internal.js",
-    "typings": "../dist/esm5/packages-exp/app-exp/src/internal.d.ts"
-}

--- a/packages-exp/app-exp/package.json
+++ b/packages-exp/app-exp/package.json
@@ -4,18 +4,18 @@
   "private": true,
   "description": "FirebaseApp",
   "author": "Firebase <firebase-support@google.com> (https://firebase.google.com/)",
-  "main": "dist/cjs/index.js",
-  "browser": "dist/esm5/index.js",
-  "module": "dist/esm5/index.js",
-  "esm2017": "dist/esm2017/index.js",
+  "main": "dist/index.cjs.js",
+  "browser": "dist/index.esm5.js",
+  "module": "dist/index.esm5.js",
+  "esm2017": "dist/index.esm2017.js",
   "files": [
     "dist"
   ],
   "scripts": {
     "lint": "eslint -c .eslintrc.js '**/*.ts' --ignore-path '../../.gitignore'",
     "lint:fix": "eslint --fix -c .eslintrc.js '**/*.ts' --ignore-path '../../.gitignore'",
-    "build": "rollup -c",
-    "build:release": "rollup -c rollup.config.release.js",
+    "build": "rollup -c && yarn api-report",
+    "build:release": "rollup -c rollup.config.release.js && yarn api-report && ./use_public_typings.js",
     "build:deps": "lerna run --scope @firebase/app-exp --include-dependencies build",
     "dev": "rollup -c -w",
     "test": "yarn type-check && run-p lint test:browser test:node",
@@ -26,7 +26,7 @@
     "api-report": "api-extractor run --local --verbose",
     "predoc": "node ../../scripts/exp/remove-exp.js temp",
     "doc": "api-documenter markdown --input temp --output docs",
-    "build:doc": "yarn build && yarn api-report && yarn doc"
+    "build:doc": "yarn build && yarn doc"
   },
   "dependencies": {
     "@firebase/app-types-exp": "0.800.0",
@@ -51,7 +51,7 @@
   "bugs": {
     "url": "https://github.com/firebase/firebase-js-sdk/issues"
   },
-  "typings": "dist/esm5/packages-exp/app-exp/src/index.d.ts",
+  "typings": "./dist/app-exp.d.ts",
   "nyc": {
     "extension": [
       ".ts"

--- a/packages-exp/app-exp/package.json
+++ b/packages-exp/app-exp/package.json
@@ -15,7 +15,7 @@
     "lint": "eslint -c .eslintrc.js '**/*.ts' --ignore-path '../../.gitignore'",
     "lint:fix": "eslint --fix -c .eslintrc.js '**/*.ts' --ignore-path '../../.gitignore'",
     "build": "rollup -c && yarn api-report",
-    "build:release": "rollup -c rollup.config.release.js && yarn api-report && ./use_public_typings.js",
+    "build:release": "rollup -c rollup.config.release.js && yarn api-report && node ./use_public_typings.js",
     "build:deps": "lerna run --scope @firebase/app-exp --include-dependencies build",
     "dev": "rollup -c -w",
     "test": "yarn type-check && run-p lint test:browser test:node",

--- a/packages-exp/app-exp/rollup.config.js
+++ b/packages-exp/app-exp/rollup.config.js
@@ -39,11 +39,8 @@ const es5Builds = [
    * Browser Builds
    */
   {
-    input: {
-      index: 'src/index.ts',
-      internal: 'src/internal.ts'
-    },
-    output: [{ dir: 'dist/esm5', format: 'es', sourcemap: true }],
+    input: 'src/index.ts',
+    output: [{ file: pkg.browser, format: 'es', sourcemap: true }],
     plugins: es5BuildPlugins,
     external: id => deps.some(dep => id === dep || id.startsWith(`${dep}/`))
   },
@@ -51,11 +48,8 @@ const es5Builds = [
    * Node.js Build
    */
   {
-    input: {
-      index: 'src/index.ts',
-      internal: 'src/internal.ts'
-    },
-    output: [{ dir: 'dist/cjs', format: 'cjs', sourcemap: true }],
+    input: 'src/index.ts',
+    output: [{ file: pkg.main, format: 'cjs', sourcemap: true }],
     plugins: es5BuildPlugins,
     external: id => deps.some(dep => id === dep || id.startsWith(`${dep}/`))
   }
@@ -83,12 +77,9 @@ const es2017Builds = [
    *  Browser Builds
    */
   {
-    input: {
-      index: 'src/index.ts',
-      internal: 'src/internal.ts'
-    },
+    input: 'src/index.ts',
     output: {
-      dir: 'dist/esm2017',
+      file: pkg.esm2017,
       format: 'es',
       sourcemap: true
     },

--- a/packages-exp/app-exp/rollup.config.release.js
+++ b/packages-exp/app-exp/rollup.config.release.js
@@ -57,7 +57,10 @@ const es5Builds = [
     input: 'src/index.ts',
     output: [{ file: pkg.main, format: 'cjs', sourcemap: true }],
     plugins: es5BuildPlugins,
-    external: id => deps.some(dep => id === dep || id.startsWith(`${dep}/`))
+    external: id => deps.some(dep => id === dep || id.startsWith(`${dep}/`)),
+    treeshake: {
+      moduleSideEffects: false
+    }
   }
 ];
 
@@ -92,7 +95,10 @@ const es2017Builds = [
       sourcemap: true
     },
     plugins: es2017BuildPlugins,
-    external: id => deps.some(dep => id === dep || id.startsWith(`${dep}/`))
+    external: id => deps.some(dep => id === dep || id.startsWith(`${dep}/`)),
+    treeshake: {
+      moduleSideEffects: false
+    }
   }
 ];
 

--- a/packages-exp/app-exp/rollup.config.release.js
+++ b/packages-exp/app-exp/rollup.config.release.js
@@ -42,11 +42,8 @@ const es5Builds = [
    * Browser Builds
    */
   {
-    input: {
-      index: 'src/index.ts',
-      internal: 'src/internal.ts'
-    },
-    output: [{ dir: 'dist/esm5', format: 'es', sourcemap: true }],
+    input: 'src/index.ts',
+    output: [{ file: pkg.browser, format: 'es', sourcemap: true }],
     plugins: es5BuildPlugins,
     external: id => deps.some(dep => id === dep || id.startsWith(`${dep}/`)),
     treeshake: {
@@ -57,11 +54,8 @@ const es5Builds = [
    * Node.js Build
    */
   {
-    input: {
-      index: 'src/index.ts',
-      internal: 'src/internal.ts'
-    },
-    output: [{ dir: 'dist/cjs', format: 'cjs', sourcemap: true }],
+    input: 'src/index.ts',
+    output: [{ file: pkg.main, format: 'cjs', sourcemap: true }],
     plugins: es5BuildPlugins,
     external: id => deps.some(dep => id === dep || id.startsWith(`${dep}/`))
   }
@@ -91,12 +85,9 @@ const es2017Builds = [
    *  Browser Builds
    */
   {
-    input: {
-      index: 'src/index.ts',
-      internal: 'src/internal.ts'
-    },
+    input: 'src/index.ts',
     output: {
-      dir: 'dist/esm2017',
+      file: pkg.esm2017,
       format: 'es',
       sourcemap: true
     },

--- a/packages-exp/app-exp/src/api.test.ts
+++ b/packages-exp/app-exp/src/api.test.ts
@@ -111,7 +111,9 @@ describe('API tests', () => {
 
       const app = initializeApp({}) as _FirebaseAppInternal;
       // -1 here to not count the FirebaseApp provider that's added during initializeApp
-      expect(app.container.getProviders().length - 1).to.equal(_components.size);
+      expect(app.container.getProviders().length - 1).to.equal(
+        _components.size
+      );
     });
   });
 

--- a/packages-exp/app-exp/src/api.test.ts
+++ b/packages-exp/app-exp/src/api.test.ts
@@ -31,10 +31,10 @@ import {
 import { DEFAULT_ENTRY_NAME } from './constants';
 import { _FirebaseAppInternal } from '@firebase/app-types-exp';
 import {
-  clearComponents,
-  components,
-  registerComponent,
-  getProvider
+  _clearComponents,
+  _components,
+  _registerComponent,
+  _getProvider
 } from './internal';
 import { createTestComponent } from '../test/util';
 import { Component, ComponentType } from '@firebase/component';
@@ -103,15 +103,15 @@ describe('API tests', () => {
     });
 
     it('adds registered components to App', () => {
-      clearComponents();
+      _clearComponents();
       const comp1 = createTestComponent('test1');
       const comp2 = createTestComponent('test2');
-      registerComponent(comp1);
-      registerComponent(comp2);
+      _registerComponent(comp1);
+      _registerComponent(comp2);
 
       const app = initializeApp({}) as _FirebaseAppInternal;
       // -1 here to not count the FirebaseApp provider that's added during initializeApp
-      expect(app.container.getProviders().length - 1).to.equal(components.size);
+      expect(app.container.getProviders().length - 1).to.equal(_components.size);
     });
   });
 
@@ -177,49 +177,49 @@ describe('API tests', () => {
 
   describe('registerVersion', () => {
     afterEach(() => {
-      clearComponents();
+      _clearComponents();
     });
 
     it('will register an official version component without warnings', () => {
       const warnStub = stub(console, 'warn');
-      const initialSize = components.size;
+      const initialSize = _components.size;
 
       registerVersion('@firebase/analytics', '1.2.3');
-      expect(components.get('fire-analytics-version')).to.exist;
-      expect(components.size).to.equal(initialSize + 1);
+      expect(_components.get('fire-analytics-version')).to.exist;
+      expect(_components.size).to.equal(initialSize + 1);
 
       expect(warnStub.called).to.be.false;
     });
 
     it('will register an arbitrary version component without warnings', () => {
       const warnStub = stub(console, 'warn');
-      const initialSize = components.size;
+      const initialSize = _components.size;
 
       registerVersion('angularfire', '1.2.3');
-      expect(components.get('angularfire-version')).to.exist;
-      expect(components.size).to.equal(initialSize + 1);
+      expect(_components.get('angularfire-version')).to.exist;
+      expect(_components.size).to.equal(initialSize + 1);
 
       expect(warnStub.called).to.be.false;
     });
 
     it('will do nothing if registerVersion() is given illegal characters', () => {
       const warnStub = stub(console, 'warn');
-      const initialSize = components.size;
+      const initialSize = _components.size;
 
       registerVersion('remote config', '1.2.3');
       expect(warnStub.args[0][1]).to.include('library name "remote config"');
-      expect(components.size).to.equal(initialSize);
+      expect(_components.size).to.equal(initialSize);
 
       registerVersion('remote-config', '1.2/3');
       expect(warnStub.args[1][1]).to.include('version name "1.2/3"');
-      expect(components.size).to.equal(initialSize);
+      expect(_components.size).to.equal(initialSize);
     });
   });
 
   describe('User Log Methods', () => {
     describe('Integration Tests', () => {
       beforeEach(() => {
-        clearComponents();
+        _clearComponents();
       });
 
       it(`respects log level set through setLogLevel()`, () => {
@@ -227,7 +227,7 @@ describe('API tests', () => {
         const infoSpy = spy(console, 'info');
         const logSpy = spy(console, 'log');
         const app = initializeApp({});
-        registerComponent(
+        _registerComponent(
           new Component(
             'test-shell',
             () => {
@@ -252,7 +252,7 @@ describe('API tests', () => {
           )
         );
 
-        getProvider(app, 'test-shell').getImmediate();
+        _getProvider(app, 'test-shell').getImmediate();
       });
 
       it(`correctly triggers callback given to onLog()`, () => {
@@ -260,7 +260,7 @@ describe('API tests', () => {
         let result: any = null;
         // Note: default log level is INFO.
         const app = initializeApp({});
-        registerComponent(
+        _registerComponent(
           new Component(
             'test-shell',
             () => {
@@ -279,7 +279,7 @@ describe('API tests', () => {
             ComponentType.PUBLIC
           )
         );
-        getProvider(app, 'test-shell').getImmediate();
+        _getProvider(app, 'test-shell').getImmediate();
       });
     });
   });

--- a/packages-exp/app-exp/src/api.ts
+++ b/packages-exp/app-exp/src/api.ts
@@ -31,7 +31,7 @@ import {
 } from '@firebase/component';
 import { version } from '../../../packages/firebase/package.json';
 import { FirebaseAppImpl } from './firebaseApp';
-import { apps, components, registerComponent } from './internal';
+import { _apps, _components, _registerComponent } from './internal';
 import { logger } from './logger';
 import {
   LogLevel,
@@ -130,18 +130,18 @@ export function initializeApp(
     });
   }
 
-  if (apps.has(name)) {
+  if (_apps.has(name)) {
     throw ERROR_FACTORY.create(AppError.DUPLICATE_APP, { appName: name });
   }
 
   const container = new ComponentContainer(name);
-  for (const component of components.values()) {
+  for (const component of _components.values()) {
     container.addComponent(component);
   }
 
   const newApp = new FirebaseAppImpl(options, config, container);
 
-  apps.set(name, newApp);
+  _apps.set(name, newApp);
 
   return newApp;
 }
@@ -176,7 +176,7 @@ export function initializeApp(
  * @public
  */
 export function getApp(name: string = DEFAULT_ENTRY_NAME): FirebaseApp {
-  const app = apps.get(name);
+  const app = _apps.get(name);
   if (!app) {
     throw ERROR_FACTORY.create(AppError.NO_APP, { appName: name });
   }
@@ -189,7 +189,7 @@ export function getApp(name: string = DEFAULT_ENTRY_NAME): FirebaseApp {
  * @public
  */
 export function getApps(): FirebaseApp[] {
-  return Array.from(apps.values());
+  return Array.from(_apps.values());
 }
 
 /**
@@ -211,8 +211,8 @@ export function getApps(): FirebaseApp[] {
  */
 export async function deleteApp(app: FirebaseApp): Promise<void> {
   const name = app.name;
-  if (apps.has(name)) {
-    apps.delete(name);
+  if (_apps.has(name)) {
+    _apps.delete(name);
     await (app as _FirebaseAppInternal).container
       .getProviders()
       .map(provider => provider.delete());
@@ -261,7 +261,7 @@ export function registerVersion(
     logger.warn(warning.join(' '));
     return;
   }
-  registerComponent(
+  _registerComponent(
     new Component(
       `${library}-version` as Name,
       () => ({ library, version }),

--- a/packages-exp/app-exp/src/index.ts
+++ b/packages-exp/app-exp/src/index.ts
@@ -25,5 +25,6 @@
 import { registerCoreComponents } from './registerCoreComponents';
 
 export * from './api';
+export * from './internal';
 
 registerCoreComponents();

--- a/packages-exp/app-exp/src/internal.test.ts
+++ b/packages-exp/app-exp/src/internal.test.ts
@@ -21,11 +21,11 @@ import '../test/setup';
 import { createTestComponent, TestService } from '../test/util';
 import { initializeApp, getApps, deleteApp } from './api';
 import {
-  addComponent,
-  addOrOverwriteComponent,
-  registerComponent,
-  components,
-  clearComponents
+  _addComponent,
+  _addOrOverwriteComponent,
+  _registerComponent,
+  _components,
+  _clearComponents
 } from './internal';
 import { _FirebaseAppInternal } from '@firebase/app-types-exp';
 
@@ -47,7 +47,7 @@ describe('Internal API tests', () => {
       const app = initializeApp({}) as _FirebaseAppInternal;
       const testComp = createTestComponent('test');
 
-      addComponent(app, testComp);
+      _addComponent(app, testComp);
 
       expect(app.container.getProvider('test').getComponent()).to.equal(
         testComp
@@ -58,9 +58,9 @@ describe('Internal API tests', () => {
       const app = initializeApp({}) as _FirebaseAppInternal;
       const testComp = createTestComponent('test');
 
-      addComponent(app, testComp);
+      _addComponent(app, testComp);
 
-      expect(() => addComponent(app, testComp)).to.not.throw();
+      expect(() => _addComponent(app, testComp)).to.not.throw();
       expect(app.container.getProvider('test').getComponent()).to.equal(
         testComp
       );
@@ -72,7 +72,7 @@ describe('Internal API tests', () => {
       const app = initializeApp({}) as _FirebaseAppInternal;
       const testComp = createTestComponent('test');
 
-      addOrOverwriteComponent(app, testComp);
+      _addOrOverwriteComponent(app, testComp);
 
       expect(app.container.getProvider('test').getComponent()).to.equal(
         testComp
@@ -84,8 +84,8 @@ describe('Internal API tests', () => {
       const testComp1 = createTestComponent('test');
       const testComp2 = createTestComponent('test');
 
-      addOrOverwriteComponent(app, testComp1);
-      addOrOverwriteComponent(app, testComp2);
+      _addOrOverwriteComponent(app, testComp1);
+      _addOrOverwriteComponent(app, testComp2);
 
       expect(app.container.getProvider('test').getComponent()).to.equal(
         testComp2
@@ -95,7 +95,7 @@ describe('Internal API tests', () => {
 
   describe('registerComponent', () => {
     afterEach(() => {
-      clearComponents();
+      _clearComponents();
     });
 
     it('caches a component and registers it with all Apps', () => {
@@ -106,28 +106,28 @@ describe('Internal API tests', () => {
       const stub2 = stub(app2.container, 'addComponent').callThrough();
 
       const testComp = createTestComponent('test');
-      registerComponent(testComp);
+      _registerComponent(testComp);
 
-      expect(components.get('test')).to.equal(testComp);
+      expect(_components.get('test')).to.equal(testComp);
       expect(stub1).to.have.been.calledWith(testComp);
       expect(stub2).to.have.been.calledWith(testComp);
     });
 
     it('returns true if registration is successful', () => {
       const testComp = createTestComponent('test');
-      expect(components.size).to.equal(0);
-      expect(registerComponent(testComp)).to.be.true;
-      expect(components.get('test')).to.equal(testComp);
+      expect(_components.size).to.equal(0);
+      expect(_registerComponent(testComp)).to.be.true;
+      expect(_components.get('test')).to.equal(testComp);
     });
 
     it('does NOT throw when registering duplicate components and returns false', () => {
       const testComp1 = createTestComponent('test');
       const testComp2 = createTestComponent('test');
-      expect(components.size).to.equal(0);
-      expect(registerComponent(testComp1)).to.be.true;
-      expect(components.get('test')).to.equal(testComp1);
-      expect(registerComponent(testComp2)).to.be.false;
-      expect(components.get('test')).to.equal(testComp1);
+      expect(_components.size).to.equal(0);
+      expect(_registerComponent(testComp1)).to.be.true;
+      expect(_components.get('test')).to.equal(testComp1);
+      expect(_registerComponent(testComp2)).to.be.false;
+      expect(_components.get('test')).to.equal(testComp1);
     });
   });
 });

--- a/packages-exp/app-exp/src/internal.ts
+++ b/packages-exp/app-exp/src/internal.ts
@@ -22,7 +22,7 @@ import { logger } from './logger';
 /**
  * @internal
  */
-export const apps = new Map<string, FirebaseApp>();
+export const _apps = new Map<string, FirebaseApp>();
 
 /**
  * Registered components.
@@ -30,14 +30,14 @@ export const apps = new Map<string, FirebaseApp>();
  * @internal
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const components = new Map<string, Component<any>>();
+export const _components = new Map<string, Component<any>>();
 
 /**
  * @param component - the component being added to this app's container
  * 
  * @internal
  */
-export function addComponent(app: FirebaseApp, component: Component): void {
+export function _addComponent(app: FirebaseApp, component: Component): void {
   try {
     (app as _FirebaseAppInternal).container.addComponent(component);
   } catch (e) {
@@ -52,7 +52,7 @@ export function addComponent(app: FirebaseApp, component: Component): void {
  * 
  * @internal
  */
-export function addOrOverwriteComponent(
+export function _addOrOverwriteComponent(
   app: FirebaseApp,
   component: Component
 ): void {
@@ -66,9 +66,9 @@ export function addOrOverwriteComponent(
  * 
  * @internal
  */
-export function registerComponent(component: Component): boolean {
+export function _registerComponent(component: Component): boolean {
   const componentName = component.name;
-  if (components.has(componentName)) {
+  if (_components.has(componentName)) {
     logger.debug(
       `There were multiple attempts to register component ${componentName}.`
     );
@@ -76,11 +76,11 @@ export function registerComponent(component: Component): boolean {
     return false;
   }
 
-  components.set(componentName, component);
+  _components.set(componentName, component);
 
   // add the component to existing app instances
-  for (const app of apps.values()) {
-    addComponent(app as _FirebaseAppInternal, component);
+  for (const app of _apps.values()) {
+    _addComponent(app as _FirebaseAppInternal, component);
   }
 
   return true;
@@ -95,7 +95,7 @@ export function registerComponent(component: Component): boolean {
  * 
  * @internal
  */
-export function getProvider<T extends Name>(
+export function _getProvider<T extends Name>(
   app: FirebaseApp,
   name: T
 ): Provider<T> {
@@ -107,6 +107,6 @@ export function getProvider<T extends Name>(
  * 
  * @internal
  */
-export function clearComponents(): void {
-  components.clear();
+export function _clearComponents(): void {
+  _components.clear();
 }

--- a/packages-exp/app-exp/src/internal.ts
+++ b/packages-exp/app-exp/src/internal.ts
@@ -19,15 +19,23 @@ import { _FirebaseAppInternal, FirebaseApp } from '@firebase/app-types-exp';
 import { Component, Provider, Name } from '@firebase/component';
 import { logger } from './logger';
 
+/**
+ * @internal
+ */
 export const apps = new Map<string, FirebaseApp>();
 
-// Registered components. Private Components only. Public components are not needed any more because
-// the public APIs are directly exported from the respective packages.
+/**
+ * Registered components.
+ * 
+ * @internal
+ */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const components = new Map<string, Component<any>>();
 
 /**
- * @param component the component being added to this app's container
+ * @param component - the component being added to this app's container
+ * 
+ * @internal
  */
 export function addComponent(app: FirebaseApp, component: Component): void {
   try {
@@ -40,6 +48,10 @@ export function addComponent(app: FirebaseApp, component: Component): void {
   }
 }
 
+/**
+ * 
+ * @internal
+ */
 export function addOrOverwriteComponent(
   app: FirebaseApp,
   component: Component
@@ -49,8 +61,10 @@ export function addOrOverwriteComponent(
 
 /**
  *
- * @param component
+ * @param component - the component to register
  * @returns whether or not the component is registered successfully
+ * 
+ * @internal
  */
 export function registerComponent(component: Component): boolean {
   const componentName = component.name;
@@ -72,6 +86,15 @@ export function registerComponent(component: Component): boolean {
   return true;
 }
 
+/**
+ * 
+ * @param app - FirebaseApp instance
+ * @param name - service name
+ * 
+ * @returns the provider for the service with the matching name
+ * 
+ * @internal
+ */
 export function getProvider<T extends Name>(
   app: FirebaseApp,
   name: T
@@ -81,6 +104,8 @@ export function getProvider<T extends Name>(
 
 /**
  * Test only
+ * 
+ * @internal
  */
 export function clearComponents(): void {
   components.clear();

--- a/packages-exp/app-exp/src/internal.ts
+++ b/packages-exp/app-exp/src/internal.ts
@@ -26,7 +26,7 @@ export const _apps = new Map<string, FirebaseApp>();
 
 /**
  * Registered components.
- * 
+ *
  * @internal
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -34,7 +34,7 @@ export const _components = new Map<string, Component<any>>();
 
 /**
  * @param component - the component being added to this app's container
- * 
+ *
  * @internal
  */
 export function _addComponent(app: FirebaseApp, component: Component): void {
@@ -49,7 +49,7 @@ export function _addComponent(app: FirebaseApp, component: Component): void {
 }
 
 /**
- * 
+ *
  * @internal
  */
 export function _addOrOverwriteComponent(
@@ -63,7 +63,7 @@ export function _addOrOverwriteComponent(
  *
  * @param component - the component to register
  * @returns whether or not the component is registered successfully
- * 
+ *
  * @internal
  */
 export function _registerComponent(component: Component): boolean {
@@ -87,12 +87,12 @@ export function _registerComponent(component: Component): boolean {
 }
 
 /**
- * 
+ *
  * @param app - FirebaseApp instance
  * @param name - service name
- * 
+ *
  * @returns the provider for the service with the matching name
- * 
+ *
  * @internal
  */
 export function _getProvider<T extends Name>(
@@ -104,7 +104,7 @@ export function _getProvider<T extends Name>(
 
 /**
  * Test only
- * 
+ *
  * @internal
  */
 export function _clearComponents(): void {

--- a/packages-exp/app-exp/src/registerCoreComponents.ts
+++ b/packages-exp/app-exp/src/registerCoreComponents.ts
@@ -18,11 +18,11 @@
 import { Component, ComponentType } from '@firebase/component';
 import { PlatformLoggerService } from './platformLoggerService';
 import { name, version } from '../package.json';
-import { registerComponent } from './internal';
+import { _registerComponent } from './internal';
 import { registerVersion } from './api';
 
 export function registerCoreComponents(variant?: string): void {
-  registerComponent(
+  _registerComponent(
     new Component(
       'platform-logger',
       container => new PlatformLoggerService(container),

--- a/packages-exp/app-exp/use_public_typings.js
+++ b/packages-exp/app-exp/use_public_typings.js
@@ -1,0 +1,11 @@
+const { writeFile } = require('fs');
+
+// point typings field to the public d.ts file in package.json
+const packageJson = require('./package.json');
+packageJson.typings = './dist/app-exp-public.d.ts';
+
+writeFile(
+    './package.json',
+    `${JSON.stringify(packageJson, null, 2)}\n`,
+    { encoding: 'utf-8' }
+);

--- a/packages-exp/app-exp/use_public_typings.js
+++ b/packages-exp/app-exp/use_public_typings.js
@@ -2,13 +2,13 @@ const { writeFileSync } = require('fs');
 
 // point typings field to the public d.ts file in package.json
 const PUBLIC_TYPINGS_PATH = './dist/app-exp-public.d.ts';
-console.log(`Updating the typings field to the public d.ts file ${PUBLIC_TYPINGS_PATH}`)
+console.log(
+  `Updating the typings field to the public d.ts file ${PUBLIC_TYPINGS_PATH}`
+);
 
 const packageJson = require('./package.json');
 packageJson.typings = PUBLIC_TYPINGS_PATH;
 
-writeFileSync(
-    './package.json',
-    `${JSON.stringify(packageJson, null, 2)}\n`,
-    { encoding: 'utf-8' }
-);
+writeFileSync('./package.json', `${JSON.stringify(packageJson, null, 2)}\n`, {
+  encoding: 'utf-8'
+});

--- a/packages-exp/app-exp/use_public_typings.js
+++ b/packages-exp/app-exp/use_public_typings.js
@@ -1,10 +1,13 @@
-const { writeFile } = require('fs');
+const { writeFileSync } = require('fs');
 
 // point typings field to the public d.ts file in package.json
-const packageJson = require('./package.json');
-packageJson.typings = './dist/app-exp-public.d.ts';
+const PUBLIC_TYPINGS_PATH = './dist/app-exp-public.d.ts';
+console.log(`Updating the typings field to the public d.ts file ${PUBLIC_TYPINGS_PATH}`)
 
-writeFile(
+const packageJson = require('./package.json');
+packageJson.typings = PUBLIC_TYPINGS_PATH;
+
+writeFileSync(
     './package.json',
     `${JSON.stringify(packageJson, null, 2)}\n`,
     { encoding: 'utf-8' }

--- a/packages-exp/app-exp/use_public_typings.js
+++ b/packages-exp/app-exp/use_public_typings.js
@@ -1,3 +1,20 @@
+/**
+ * @license
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 const { writeFileSync } = require('fs');
 
 // point typings field to the public d.ts file in package.json


### PR DESCRIPTION
Previously internal functions are exported in the submodule `@firebase/app-exp/internal`. This PR changes to directly export them in `@firebase/app-exp`. It removes the `internal` folder and the package.json inside it and simplifies the build configuration. It also makes it harder for developers to use our internal methods accidentally.

We generate 2 d.ts files as part of the build process.  One has only public API and is used to publish to npm, so developers won't be able to import internal methods. The other one has both public and internal APIs and is used during development, so other Firebase SDKs can import the internal methods.