### PR TITLE
Added react native build target

### DIFF
--- a/packages-exp/auth-compat-exp/index.rn.ts
+++ b/packages-exp/auth-compat-exp/index.rn.ts
@@ -1,0 +1,27 @@
+/**
+ * @license
+ * Copyright 2017 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * This is the file that people using React Native will actually import. You
+ * should only include this file if you have something specific about your
+ * implementation that mandates having a separate entrypoint. Otherwise you can
+ * just use index.ts
+ */
+
+import { testFxn } from './src';
+
+testFxn();

--- a/packages-exp/auth-compat-exp/package.json
+++ b/packages-exp/auth-compat-exp/package.json
@@ -8,6 +8,7 @@
   "browser": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
   "esm2017": "dist/index.esm2017.js",
+  "react-native": "dist/index.rn.cjs.js",
   "files": [
     "dist"
   ],

--- a/packages-exp/auth-compat-exp/rollup.config.js
+++ b/packages-exp/auth-compat-exp/rollup.config.js
@@ -53,7 +53,16 @@ const es5Builds = [
     output: [{ file: pkg.main, format: 'cjs', sourcemap: true }],
     plugins: es5BuildPlugins,
     external: id => deps.some(dep => id === dep || id.startsWith(`${dep}/`))
-  }
+  },
+  /**
+   * App React Native Builds
+   */
+  {
+    input: 'index.rn.ts',
+      output: [{ file: pkg['react-native'], format: 'cjs', sourcemap: true }],
+    plugins: es5BuildPlugins,
+      external: id => [...deps, 'react-native'].some(dep => id === dep || id.startsWith(`${dep}/`))
+  },
 ];
 
 /**


### PR DESCRIPTION
Adds react native target for dependency injection of package `react-native` (not `@react-native-community/async-storage` for consistency with old SDK) in compat layer.

Note that this build target wasn't added to auth-exp because the new package will need user specification on which package to use to setup.