### PR TITLE
Skip test output for successful tests

### DIFF
--- a/scripts/run_changed.js
+++ b/scripts/run_changed.js
@@ -156,17 +156,16 @@ async function runTests(pathList) {
       testProcess.stdout.on('data', data => {
         stdio += data.toString();
       });
-      testProcess.stderr.on('data', data =>  {
+      testProcess.stderr.on('data', data => {
         stderr += data.toString();
       });
 
       await testProcess;
-
       console.log('Success: ' + testPath);
     } catch (e) {
       console.error('Failure: ' + testPath);
       console.log(stdio);
-      console.log(stderr);
+      console.error(stderr);
       throw new Error(`Error running tests in ${testPath}.`);
     }
   }

--- a/scripts/run_changed.js
+++ b/scripts/run_changed.js
@@ -147,11 +147,26 @@ async function getChangedPackages() {
 async function runTests(pathList) {
   if (!pathList) return;
   for (const testPath of pathList) {
+    var stdio = '';
+    var stderr = '';
+    
     try {
-      await spawn('yarn', ['--cwd', testPath, 'test'], {
-        stdio: 'inherit'
+      var testProcess = spawn('yarn', ['--cwd', testPath, 'test']);
+
+      testProcess.stdout.on('data', function (data) {
+        stdio += data.toString();
       });
+      testProcess.stderr.on('data', function (data) {
+        stderr += data.toString();
+      });
+      
+      await testProcess;
+      
+      console.log('Success: ' + testPath);
     } catch (e) {
+      console.error('Failure: '+ testPath);
+      console.log(stdio);
+      console.log(stderr);
       throw new Error(`Error running tests in ${testPath}.`);
     }
   }

--- a/scripts/run_changed.js
+++ b/scripts/run_changed.js
@@ -149,22 +149,22 @@ async function runTests(pathList) {
   for (const testPath of pathList) {
     var stdio = '';
     var stderr = '';
-    
+
     try {
       var testProcess = spawn('yarn', ['--cwd', testPath, 'test']);
 
-      testProcess.stdout.on('data', function (data) {
+      testProcess.stdout.on('data', data => {
         stdio += data.toString();
       });
-      testProcess.stderr.on('data', function (data) {
+      testProcess.stderr.on('data', data =>  {
         stderr += data.toString();
       });
-      
+
       await testProcess;
-      
+
       console.log('Success: ' + testPath);
     } catch (e) {
-      console.error('Failure: '+ testPath);
+      console.error('Failure: ' + testPath);
       console.log(stdio);
       console.log(stderr);
       throw new Error(`Error running tests in ${testPath}.`);


### PR DESCRIPTION
This is my attempt to get rid of the scrolling when debugging a CI failure. I don't know how to test this though since this PR is going to trigger a run of all tests.