### PR TITLE
Remove "cyclic" references

### DIFF
--- a/packages/firestore/src/api/database.ts
+++ b/packages/firestore/src/api/database.ts
@@ -1462,15 +1462,15 @@ export class Query<T = firestore.DocumentData> implements firestore.Query<T> {
     const fieldPath = fieldPathFromArgument('Query.where', field);
     if (fieldPath.isKeyField()) {
       if (
-        opStr === Operator.ARRAY_CONTAINS ||
-        opStr === Operator.ARRAY_CONTAINS_ANY
+        op === Operator.ARRAY_CONTAINS ||
+        op === Operator.ARRAY_CONTAINS_ANY
       ) {
         throw new FirestoreError(
           Code.INVALID_ARGUMENT,
           `Invalid Query. You can't perform '${op}' ` +
             'queries on FieldPath.documentId().'
         );
-      } else if (opStr === Operator.IN) {
+      } else if (op === Operator.IN) {
         this.validateDisjunctiveFilterElements(value, op);
         const referenceList: api.Value[] = [];
         for (const arrayValue of value as api.Value[]) {
@@ -1481,7 +1481,7 @@ export class Query<T = firestore.DocumentData> implements firestore.Query<T> {
         fieldValue = this.parseDocumentIdValue(value);
       }
     } else {
-      if (opStr === Operator.IN || opStr === Operator.ARRAY_CONTAINS_ANY) {
+      if (op === Operator.IN || op === Operator.ARRAY_CONTAINS_ANY) {
         this.validateDisjunctiveFilterElements(value, op);
       }
       fieldValue = this.firestore._dataReader.parseQueryValue(

--- a/packages/firestore/src/api/database.ts
+++ b/packages/firestore/src/api/database.ts
@@ -836,7 +836,7 @@ export class WriteBatch implements firestore.WriteBatch {
             convertedValue
           );
     this._mutations = this._mutations.concat(
-      parsed.toMutations(ref._key, Precondition.NONE)
+      parsed.toMutations(ref._key, Precondition.none())
     );
     return this;
   }
@@ -906,7 +906,7 @@ export class WriteBatch implements firestore.WriteBatch {
       this._firestore
     );
     this._mutations = this._mutations.concat(
-      new DeleteMutation(ref._key, Precondition.NONE)
+      new DeleteMutation(ref._key, Precondition.none())
     );
     return this;
   }
@@ -1031,7 +1031,7 @@ export class DocumentReference<T = firestore.DocumentData>
           )
         : this.firestore._dataReader.parseSetData(functionName, convertedValue);
     return this._firestoreClient.write(
-      parsed.toMutations(this._key, Precondition.NONE)
+      parsed.toMutations(this._key, Precondition.none())
     );
   }
 
@@ -1075,7 +1075,7 @@ export class DocumentReference<T = firestore.DocumentData>
   delete(): Promise<void> {
     validateExactNumberOfArgs('DocumentReference.delete', arguments, 0);
     return this._firestoreClient.write([
-      new DeleteMutation(this._key, Precondition.NONE)
+      new DeleteMutation(this._key, Precondition.none())
     ]);
   }
 
@@ -1460,7 +1460,7 @@ export class Query<T = firestore.DocumentData> implements firestore.Query<T> {
 
     let fieldValue: api.Value;
     const fieldPath = fieldPathFromArgument('Query.where', field);
-    const operator = Operator.fromString(opStr);
+    const operator = opStr as Operator;
     if (fieldPath.isKeyField()) {
       if (
         operator === Operator.ARRAY_CONTAINS ||
@@ -1492,7 +1492,7 @@ export class Query<T = firestore.DocumentData> implements firestore.Query<T> {
         'Query.where',
         value,
         // We only allow nested arrays for IN queries.
-        /** allowArrays = */ operator === Operator.IN ? true : false
+        /** allowArrays = */ operator === Operator.IN
       );
     }
     const filter = FieldFilter.create(fieldPath, operator, fieldValue);

--- a/packages/firestore/src/core/snapshot_version.ts
+++ b/packages/firestore/src/core/snapshot_version.ts
@@ -22,14 +22,12 @@ import { Timestamp } from '../api/timestamp';
  * timestamp, such as update_time or read_time.
  */
 export class SnapshotVersion {
-  static readonly MIN = new SnapshotVersion(new Timestamp(0, 0));
-
   static fromTimestamp(value: Timestamp): SnapshotVersion {
     return new SnapshotVersion(value);
   }
 
-  static forDeletedDoc(): SnapshotVersion {
-    return SnapshotVersion.MIN;
+  static min(): SnapshotVersion {
+    return new SnapshotVersion(new Timestamp(0, 0));
   }
 
   private constructor(private timestamp: Timestamp) {}

--- a/packages/firestore/src/core/sync_engine.ts
+++ b/packages/firestore/src/core/sync_engine.ts
@@ -33,7 +33,7 @@ import {
 import { MaybeDocument, NoDocument } from '../model/document';
 import { DocumentKey } from '../model/document_key';
 import { Mutation } from '../model/mutation';
-import { MutationBatchResult, BATCHID_UNKNOWN } from '../model/mutation_batch';
+import { BATCHID_UNKNOWN, MutationBatchResult } from '../model/mutation_batch';
 import { RemoteEvent, TargetChange } from '../remote/remote_event';
 import { RemoteStore } from '../remote/remote_store';
 import { RemoteSyncer } from '../remote/remote_syncer';
@@ -52,7 +52,7 @@ import {
 } from '../local/shared_client_state_syncer';
 import { SortedSet } from '../util/sorted_set';
 import { ListenSequence } from './listen_sequence';
-import { Query, LimitType } from './query';
+import { LimitType, Query } from './query';
 import { SnapshotVersion } from './snapshot_version';
 import { Target } from './target';
 import { TargetIdGenerator } from './target_id_generator';
@@ -504,11 +504,11 @@ export class SyncEngine implements RemoteSyncer {
       );
       documentUpdates = documentUpdates.insert(
         limboKey,
-        new NoDocument(limboKey, SnapshotVersion.forDeletedDoc())
+        new NoDocument(limboKey, SnapshotVersion.min())
       );
       const resolvedLimboDocuments = documentKeySet().add(limboKey);
       const event = new RemoteEvent(
-        SnapshotVersion.MIN,
+        SnapshotVersion.min(),
         /* targetChanges= */ new Map<TargetId, TargetChange>(),
         /* targetMismatches= */ new SortedSet<TargetId>(primitiveComparator),
         documentUpdates,

--- a/packages/firestore/src/local/index_free_query_engine.ts
+++ b/packages/firestore/src/local/index_free_query_engine.ts
@@ -78,7 +78,7 @@ export class IndexFreeQueryEngine implements QueryEngine {
 
     // Queries that have never seen a snapshot without limbo free documents
     // should also be run as a full collection scan.
-    if (lastLimboFreeSnapshotVersion.isEqual(SnapshotVersion.MIN)) {
+    if (lastLimboFreeSnapshotVersion.isEqual(SnapshotVersion.min())) {
       return this.executeFullCollectionScan(transaction, query);
     }
 
@@ -204,7 +204,7 @@ export class IndexFreeQueryEngine implements QueryEngine {
     return this.localDocumentsView!.getDocumentsMatchingQuery(
       transaction,
       query,
-      SnapshotVersion.MIN
+      SnapshotVersion.min()
     );
   }
 }

--- a/packages/firestore/src/local/indexeddb_remote_document_cache.ts
+++ b/packages/firestore/src/local/indexeddb_remote_document_cache.ts
@@ -252,7 +252,7 @@ export class IndexedDbRemoteDocumentCache implements RemoteDocumentCache {
     const immediateChildrenPathLength = query.path.length + 1;
 
     const iterationOptions: IterateOptions = {};
-    if (sinceReadTime.isEqual(SnapshotVersion.MIN)) {
+    if (sinceReadTime.isEqual(SnapshotVersion.min())) {
       // Documents are ordered by key, so we can use a prefix scan to narrow
       // down the documents we need to match the query against.
       const startKey = query.path.toArray();
@@ -330,7 +330,7 @@ export class IndexedDbRemoteDocumentCache implements RemoteDocumentCache {
 
   /**
    * Returns the read time of the most recently read document in the cache, or
-   * SnapshotVersion.MIN if not available.
+   * SnapshotVersion.min() if not available.
    */
   // PORTING NOTE: This is only used for multi-tab synchronization.
   getLastReadTime(
@@ -338,8 +338,8 @@ export class IndexedDbRemoteDocumentCache implements RemoteDocumentCache {
   ): PersistencePromise<SnapshotVersion> {
     const documentsStore = remoteDocumentsStore(transaction);
 
-    // If there are no existing entries, we return SnapshotVersion.MIN.
-    let readTime = SnapshotVersion.MIN;
+    // If there are no existing entries, we return SnapshotVersion.min().
+    let readTime = SnapshotVersion.min();
 
     return documentsStore
       .iterate(
@@ -396,7 +396,7 @@ export class IndexedDbRemoteDocumentCache implements RemoteDocumentCache {
       const doc = this.serializer.fromDbRemoteDocument(dbRemoteDoc);
       if (
         doc instanceof NoDocument &&
-        doc.version.isEqual(SnapshotVersion.forDeletedDoc())
+        doc.version.isEqual(SnapshotVersion.min())
       ) {
         // The document is a sentinel removal and should only be used in the
         // `getNewDocumentChanges()`.
@@ -453,7 +453,7 @@ export class IndexedDbRemoteDocumentCache implements RemoteDocumentCache {
         );
         if (maybeDocument) {
           debugAssert(
-            !this.readTime.isEqual(SnapshotVersion.MIN),
+            !this.readTime.isEqual(SnapshotVersion.min()),
             'Cannot add a document with a read time of zero'
           );
           const doc = this.documentCache.serializer.toDbRemoteDocument(
@@ -473,7 +473,7 @@ export class IndexedDbRemoteDocumentCache implements RemoteDocumentCache {
             // with a version of 0 and ignored by `maybeDecodeDocument()` but
             // preserved in `getNewDocumentChanges()`.
             const deletedDoc = this.documentCache.serializer.toDbRemoteDocument(
-              new NoDocument(key, SnapshotVersion.forDeletedDoc()),
+              new NoDocument(key, SnapshotVersion.min()),
               this.readTime
             );
             promises.push(

--- a/packages/firestore/src/local/indexeddb_schema.ts
+++ b/packages/firestore/src/local/indexeddb_schema.ts
@@ -1011,7 +1011,7 @@ function writeEmptyTargetGlobalEntry(
   const metadata = new DbTargetGlobal(
     /*highestTargetId=*/ 0,
     /*lastListenSequenceNumber=*/ 0,
-    SnapshotVersion.MIN.toTimestamp(),
+    SnapshotVersion.min().toTimestamp(),
     /*targetCount=*/ 0
   );
   return globalStore.put(DbTargetGlobal.key, metadata);

--- a/packages/firestore/src/local/local_documents_view.ts
+++ b/packages/firestore/src/local/local_documents_view.ts
@@ -134,7 +134,7 @@ export class LocalDocumentsView {
         docs.forEach((key, maybeDoc) => {
           // TODO(http://b/32275378): Don't conflate missing / deleted.
           if (!maybeDoc) {
-            maybeDoc = new NoDocument(key, SnapshotVersion.forDeletedDoc());
+            maybeDoc = new NoDocument(key, SnapshotVersion.min());
           }
           results = results.insert(key, maybeDoc);
         });
@@ -148,7 +148,7 @@ export class LocalDocumentsView {
    *
    * @param transaction The persistence transaction.
    * @param query The query to match documents against.
-   * @param sinceReadTime If not set to SnapshotVersion.MIN, return only
+   * @param sinceReadTime If not set to SnapshotVersion.min(), return only
    *     documents that have been read since this snapshot version (exclusive).
    */
   getDocumentsMatchingQuery(

--- a/packages/firestore/src/local/local_serializer.ts
+++ b/packages/firestore/src/local/local_serializer.ts
@@ -177,7 +177,7 @@ export class LocalSerializer {
     const lastLimboFreeSnapshotVersion =
       dbTarget.lastLimboFreeSnapshotVersion !== undefined
         ? this.fromDbTimestamp(dbTarget.lastLimboFreeSnapshotVersion)
-        : SnapshotVersion.MIN;
+        : SnapshotVersion.min();
 
     let target: Target;
     if (isDocumentQuery(dbTarget.query)) {

--- a/packages/firestore/src/local/local_store.ts
+++ b/packages/firestore/src/local/local_store.ts
@@ -193,7 +193,7 @@ export class LocalStore {
    *
    * PORTING NOTE: This is only used for multi-tab synchronization.
    */
-  protected lastDocumentChangeReadTime = SnapshotVersion.MIN;
+  protected lastDocumentChangeReadTime = SnapshotVersion.min();
 
   constructor(
     /** Manages our in-memory or durable persistence. */
@@ -563,13 +563,13 @@ export class LocalStore {
 
               // Note: The order of the steps below is important, since we want
               // to ensure that rejected limbo resolutions (which fabricate
-              // NoDocuments with SnapshotVersion.MIN) never add documents to
+              // NoDocuments with SnapshotVersion.min()) never add documents to
               // cache.
               if (
                 doc instanceof NoDocument &&
-                doc.version.isEqual(SnapshotVersion.MIN)
+                doc.version.isEqual(SnapshotVersion.min())
               ) {
-                // NoDocuments with SnapshotVersion.MIN are used in manufactured
+                // NoDocuments with SnapshotVersion.min() are used in manufactured
                 // events. We remove these documents from cache since we lost
                 // access.
                 documentBuffer.removeEntry(key, remoteVersion);
@@ -581,7 +581,7 @@ export class LocalStore {
                   existingDoc.hasPendingWrites)
               ) {
                 debugAssert(
-                  !SnapshotVersion.MIN.isEqual(remoteVersion),
+                  !SnapshotVersion.min().isEqual(remoteVersion),
                   'Cannot add a document when the remote version is zero'
                 );
                 documentBuffer.addEntry(doc, remoteVersion);
@@ -614,7 +614,7 @@ export class LocalStore {
         // can synthesize remote events when we get permission denied errors while
         // trying to resolve the state of a locally cached document that is in
         // limbo.
-        if (!remoteVersion.isEqual(SnapshotVersion.MIN)) {
+        if (!remoteVersion.isEqual(SnapshotVersion.min())) {
           const updateRemoteVersion = this.targetCache
             .getLastRemoteSnapshotVersion(txn)
             .next(lastRemoteSnapshotVersion => {
@@ -910,7 +910,7 @@ export class LocalStore {
     query: Query,
     usePreviousResults: boolean
   ): Promise<QueryResult> {
-    let lastLimboFreeSnapshotVersion = SnapshotVersion.MIN;
+    let lastLimboFreeSnapshotVersion = SnapshotVersion.min();
     let remoteKeys = documentKeySet();
 
     return this.persistence.runTransaction('Execute query', 'readonly', txn => {
@@ -932,7 +932,7 @@ export class LocalStore {
             query,
             usePreviousResults
               ? lastLimboFreeSnapshotVersion
-              : SnapshotVersion.MIN,
+              : SnapshotVersion.min(),
             usePreviousResults ? remoteKeys : documentKeySet()
           )
         )

--- a/packages/firestore/src/local/memory_remote_document_cache.ts
+++ b/packages/firestore/src/local/memory_remote_document_cache.ts
@@ -78,7 +78,7 @@ export class MemoryRemoteDocumentCache implements RemoteDocumentCache {
     readTime: SnapshotVersion
   ): PersistencePromise<void> {
     debugAssert(
-      !readTime.isEqual(SnapshotVersion.MIN),
+      !readTime.isEqual(SnapshotVersion.min()),
       'Cannot add a document with a read time of zero'
     );
 

--- a/packages/firestore/src/local/memory_target_cache.ts
+++ b/packages/firestore/src/local/memory_target_cache.ts
@@ -39,7 +39,7 @@ export class MemoryTargetCache implements TargetCache {
   private targets = new ObjectMap<Target, TargetData>(t => t.canonicalId());
 
   /** The last received snapshot version. */
-  private lastRemoteSnapshotVersion = SnapshotVersion.MIN;
+  private lastRemoteSnapshotVersion = SnapshotVersion.min();
   /** The highest numbered target ID encountered. */
   private highestTargetId: TargetId = 0;
   /** The highest sequence number encountered. */

--- a/packages/firestore/src/local/remote_document_cache.ts
+++ b/packages/firestore/src/local/remote_document_cache.ts
@@ -71,7 +71,7 @@ export interface RemoteDocumentCache {
    * Cached NoDocument entries have no bearing on query results.
    *
    * @param query The query to match documents against.
-   * @param sinceReadTime If not set to SnapshotVersion.MIN, return only
+   * @param sinceReadTime If not set to SnapshotVersion.min(), return only
    *     documents that have been read since this snapshot version (exclusive).
    * @return The set of matching documents.
    */

--- a/packages/firestore/src/local/simple_query_engine.ts
+++ b/packages/firestore/src/local/simple_query_engine.ts
@@ -52,7 +52,7 @@ export class SimpleQueryEngine implements QueryEngine {
     return this.localDocumentsView.getDocumentsMatchingQuery(
       transaction,
       query,
-      SnapshotVersion.MIN
+      SnapshotVersion.min()
     );
   }
 }

--- a/packages/firestore/src/local/target_data.ts
+++ b/packages/firestore/src/local/target_data.ts
@@ -54,12 +54,12 @@ export class TargetData {
      */
     readonly sequenceNumber: ListenSequenceNumber,
     /** The latest snapshot version seen for this target. */
-    readonly snapshotVersion: SnapshotVersion = SnapshotVersion.MIN,
+    readonly snapshotVersion: SnapshotVersion = SnapshotVersion.min(),
     /**
      * The maximum snapshot version at which the associated view
      * contained no limbo documents.
      */
-    readonly lastLimboFreeSnapshotVersion: SnapshotVersion = SnapshotVersion.MIN,
+    readonly lastLimboFreeSnapshotVersion: SnapshotVersion = SnapshotVersion.min(),
     /**
      * An opaque, server-assigned token that allows watching a target to be
      * resumed after disconnecting without retransmitting all the data that

--- a/packages/firestore/src/model/mutation.ts
+++ b/packages/firestore/src/model/mutation.ts
@@ -133,8 +133,6 @@ export const enum MutationType {
  * (meaning no precondition).
  */
 export class Precondition {
-  static readonly NONE = new Precondition();
-
   private constructor(
     readonly updateTime?: SnapshotVersion,
     readonly exists?: boolean
@@ -143,6 +141,11 @@ export class Precondition {
       updateTime === undefined || exists === undefined,
       'Precondition can specify "exists" or "updateTime" but not both'
     );
+  }
+
+  /** Creates a new empty Precondition. */
+  static none(): Precondition {
+    return new Precondition();
   }
 
   /** Creates a new Precondition with an exists flag. */
@@ -314,7 +317,7 @@ export abstract class Mutation {
    * Returns the version from the given document for use as the result of a
    * mutation. Mutations are defined to return the version of the base document
    * only if it is an existing document. Deleted and unknown documents have a
-   * post-mutation version of SnapshotVersion.MIN.
+   * post-mutation version of SnapshotVersion.min().
    */
   protected static getPostMutationVersion(
     maybeDoc: MaybeDocument | null
@@ -322,7 +325,7 @@ export abstract class Mutation {
     if (maybeDoc instanceof Document) {
       return maybeDoc.version;
     } else {
-      return SnapshotVersion.MIN;
+      return SnapshotVersion.min();
     }
   }
 }
@@ -781,7 +784,7 @@ export class DeleteMutation extends Mutation {
         'Can only apply mutation to document with same key'
       );
     }
-    return new NoDocument(this.key, SnapshotVersion.forDeletedDoc());
+    return new NoDocument(this.key, SnapshotVersion.min());
   }
 
   extractBaseValue(maybeDoc: MaybeDocument | null): null {

--- a/packages/firestore/src/remote/remote_event.ts
+++ b/packages/firestore/src/remote/remote_event.ts
@@ -78,7 +78,7 @@ export class RemoteEvent {
       )
     );
     return new RemoteEvent(
-      SnapshotVersion.MIN,
+      SnapshotVersion.min(),
       targetChanges,
       targetIdSet(),
       maybeDocumentMap(),

--- a/packages/firestore/src/remote/remote_store.ts
+++ b/packages/firestore/src/remote/remote_store.ts
@@ -402,11 +402,11 @@ export class RemoteStore implements TargetMetadataProvider {
       this.watchChangeAggregator!.handleTargetChange(watchChange);
     }
 
-    if (!snapshotVersion.isEqual(SnapshotVersion.MIN)) {
+    if (!snapshotVersion.isEqual(SnapshotVersion.min())) {
       const lastRemoteSnapshotVersion = await this.localStore.getLastRemoteSnapshotVersion();
       if (snapshotVersion.compareTo(lastRemoteSnapshotVersion) >= 0) {
         // We have received a target change with a global snapshot if the snapshot
-        // version is not equal to SnapshotVersion.MIN.
+        // version is not equal to SnapshotVersion.min().
         await this.raiseWatchSnapshot(snapshotVersion);
       }
     }
@@ -419,7 +419,7 @@ export class RemoteStore implements TargetMetadataProvider {
    */
   private raiseWatchSnapshot(snapshotVersion: SnapshotVersion): Promise<void> {
     debugAssert(
-      !snapshotVersion.isEqual(SnapshotVersion.MIN),
+      !snapshotVersion.isEqual(SnapshotVersion.min()),
       "Can't raise event for unknown SnapshotVersion"
     );
     const remoteEvent = this.watchChangeAggregator!.createRemoteEvent(

--- a/packages/firestore/src/remote/serializer.ts
+++ b/packages/firestore/src/remote/serializer.ts
@@ -77,21 +77,21 @@ import { isNanValue, isNullValue, normalizeTimestamp } from '../model/values';
 
 const DIRECTIONS = (() => {
   const dirs: { [dir: string]: api.OrderDirection } = {};
-  dirs[Direction.ASCENDING.name] = 'ASCENDING';
-  dirs[Direction.DESCENDING.name] = 'DESCENDING';
+  dirs[Direction.ASCENDING] = 'ASCENDING';
+  dirs[Direction.DESCENDING] = 'DESCENDING';
   return dirs;
 })();
 
 const OPERATORS = (() => {
   const ops: { [op: string]: api.FieldFilterOp } = {};
-  ops[Operator.LESS_THAN.name] = 'LESS_THAN';
-  ops[Operator.LESS_THAN_OR_EQUAL.name] = 'LESS_THAN_OR_EQUAL';
-  ops[Operator.GREATER_THAN.name] = 'GREATER_THAN';
-  ops[Operator.GREATER_THAN_OR_EQUAL.name] = 'GREATER_THAN_OR_EQUAL';
-  ops[Operator.EQUAL.name] = 'EQUAL';
-  ops[Operator.ARRAY_CONTAINS.name] = 'ARRAY_CONTAINS';
-  ops[Operator.IN.name] = 'IN';
-  ops[Operator.ARRAY_CONTAINS_ANY.name] = 'ARRAY_CONTAINS_ANY';
+  ops[Operator.LESS_THAN] = 'LESS_THAN';
+  ops[Operator.LESS_THAN_OR_EQUAL] = 'LESS_THAN_OR_EQUAL';
+  ops[Operator.GREATER_THAN] = 'GREATER_THAN';
+  ops[Operator.GREATER_THAN_OR_EQUAL] = 'GREATER_THAN_OR_EQUAL';
+  ops[Operator.EQUAL] = 'EQUAL';
+  ops[Operator.ARRAY_CONTAINS] = 'ARRAY_CONTAINS';
+  ops[Operator.IN] = 'IN';
+  ops[Operator.ARRAY_CONTAINS_ANY] = 'ARRAY_CONTAINS_ANY';
   return ops;
 })();
 
@@ -467,7 +467,7 @@ export class JsonProtoSerializer {
       const key = this.fromName(docDelete.document);
       const version = docDelete.readTime
         ? this.fromVersion(docDelete.readTime)
-        : SnapshotVersion.forDeletedDoc();
+        : SnapshotVersion.min();
       const doc = new NoDocument(key, version);
       const removedTargetIds = docDelete.removedTargetIds || [];
       watchChange = new DocumentWatchChange([], removedTargetIds, doc.key, doc);
@@ -516,14 +516,14 @@ export class JsonProtoSerializer {
     // is a read_time set and it applies to all targets (i.e. the list of
     // targets is empty). The backend is guaranteed to send such responses.
     if (!('targetChange' in change)) {
-      return SnapshotVersion.MIN;
+      return SnapshotVersion.min();
     }
     const targetChange = change.targetChange!;
     if (targetChange.targetIds && targetChange.targetIds.length) {
-      return SnapshotVersion.MIN;
+      return SnapshotVersion.min();
     }
     if (!targetChange.readTime) {
-      return SnapshotVersion.MIN;
+      return SnapshotVersion.min();
     }
     return this.fromVersion(targetChange.readTime);
   }
@@ -568,7 +568,7 @@ export class JsonProtoSerializer {
   fromMutation(proto: api.Write): Mutation {
     const precondition = proto.currentDocument
       ? this.fromPrecondition(proto.currentDocument)
-      : Precondition.NONE;
+      : Precondition.none();
 
     if (proto.update) {
       assertPresent(proto.update.name, 'name');
@@ -622,7 +622,7 @@ export class JsonProtoSerializer {
     } else if (precondition.exists !== undefined) {
       return Precondition.exists(precondition.exists);
     } else {
-      return Precondition.NONE;
+      return Precondition.none();
     }
   }
 
@@ -635,7 +635,7 @@ export class JsonProtoSerializer {
       ? this.fromVersion(proto.updateTime)
       : this.fromVersion(commitTime);
 
-    if (version.isEqual(SnapshotVersion.MIN)) {
+    if (version.isEqual(SnapshotVersion.min())) {
       // The Firestore Emulator currently returns an update time of 0 for
       // deletes of non-existing documents (rather than null). This breaks the
       // test "get deleted doc while offline with source=cache" as NoDocuments
@@ -947,7 +947,7 @@ export class JsonProtoSerializer {
 
   // visible for testing
   toDirection(dir: Direction): api.OrderDirection {
-    return DIRECTIONS[dir.name];
+    return DIRECTIONS[dir];
   }
 
   // visible for testing
@@ -964,7 +964,7 @@ export class JsonProtoSerializer {
 
   // visible for testing
   toOperatorName(op: Operator): api.FieldFilterOp {
-    return OPERATORS[op.name];
+    return OPERATORS[op];
   }
 
   fromOperatorName(op: api.FieldFilterOp): Operator {

--- a/packages/firestore/src/remote/watch_change.ts
+++ b/packages/firestore/src/remote/watch_change.ts
@@ -399,7 +399,7 @@ export class WatchChangeAggregator {
           this.removeDocumentFromTarget(
             targetId,
             key,
-            new NoDocument(key, SnapshotVersion.forDeletedDoc())
+            new NoDocument(key, SnapshotVersion.min())
           );
         } else {
           hardAssert(

--- a/packages/firestore/src/util/input_validation.ts
+++ b/packages/firestore/src/util/input_validation.ts
@@ -297,14 +297,15 @@ export function validateNamedOptionalPropertyEquals<T>(
  * @param functionName Function making the validation call.
  * @param enums Array containing all possible values for the enum.
  * @param position Position of the argument in `functionName`.
- * @param argument Arugment to validate.
+ * @param argument Argument to validate.
+ * @return The value as T if the argument can be converted.
  */
 export function validateStringEnum<T>(
   functionName: string,
-  enums: string[],
+  enums: T[],
   position: number,
   argument: unknown
-): void {
+): T {
   if (!enums.some(element => element === argument)) {
     throw new FirestoreError(
       Code.INVALID_ARGUMENT,
@@ -313,6 +314,7 @@ export function validateStringEnum<T>(
         `values: ${enums.join(', ')}`
     );
   }
+  return argument as T;
 }
 
 /** Helper to validate the type of a provided input. */

--- a/packages/firestore/test/integration/remote/remote.test.ts
+++ b/packages/firestore/test/integration/remote/remote.test.ts
@@ -38,7 +38,7 @@ describe('Remote Storage', () => {
         expect(result.length).to.equal(1);
         const version = result[0].version;
         expect(version).not.to.equal(null);
-        expect(SnapshotVersion.MIN.compareTo(version!)).to.be.lessThan(0);
+        expect(SnapshotVersion.min().compareTo(version!)).to.be.lessThan(0);
       });
     });
   });
@@ -61,7 +61,7 @@ describe('Remote Storage', () => {
           if (doc instanceof Document) {
             expect(doc.data()).to.deep.equal(mutation.value);
             expect(doc.key).to.deep.equal(k);
-            expect(SnapshotVersion.MIN.compareTo(doc.version)).to.be.lessThan(
+            expect(SnapshotVersion.min().compareTo(doc.version)).to.be.lessThan(
               0
             );
           }
@@ -78,7 +78,9 @@ describe('Remote Storage', () => {
         expect(doc).to.be.an.instanceof(NoDocument);
         if (doc instanceof NoDocument) {
           expect(doc.key).to.deep.equal(k);
-          expect(SnapshotVersion.MIN.compareTo(doc.version)).to.be.lessThan(0);
+          expect(SnapshotVersion.min().compareTo(doc.version)).to.be.lessThan(
+            0
+          );
         }
       });
     });

--- a/packages/firestore/test/unit/local/index_free_query_engine.test.ts
+++ b/packages/firestore/test/unit/local/index_free_query_engine.test.ts
@@ -60,7 +60,7 @@ const MATCHING_DOC_B = doc('coll/b', 1, { matches: true, order: 2 });
 const UPDATED_MATCHING_DOC_B = doc('coll/b', 11, { matches: true, order: 2 });
 
 const LAST_LIMBO_FREE_SNAPSHOT = version(10);
-const MISSING_LAST_LIMBO_FREE_SNAPSHOT = SnapshotVersion.MIN;
+const MISSING_LAST_LIMBO_FREE_SNAPSHOT = SnapshotVersion.min();
 
 /**
  * A LocalDocumentsView wrapper that inspects the arguments to
@@ -74,7 +74,7 @@ class TestLocalDocumentsView extends LocalDocumentsView {
     query: Query,
     sinceReadTime: SnapshotVersion
   ): PersistencePromise<DocumentMap> {
-    const indexFreeExecution = !SnapshotVersion.MIN.isEqual(sinceReadTime);
+    const indexFreeExecution = !SnapshotVersion.min().isEqual(sinceReadTime);
 
     expect(indexFreeExecution).to.eq(
       this.expectIndexFreeExecution,

--- a/packages/firestore/test/unit/local/indexeddb_persistence.test.ts
+++ b/packages/firestore/test/unit/local/indexeddb_persistence.test.ts
@@ -224,7 +224,7 @@ describe('IndexedDbSchema: createOrUpgradeDb', () => {
     const resetTargetGlobal = new DbTargetGlobal(
       /*highestTargetId=*/ 0,
       /*highestListenSequencNumber=*/ 0,
-      /*lastRemoteSnapshotVersion=*/ SnapshotVersion.MIN.toTimestamp(),
+      /*lastRemoteSnapshotVersion=*/ SnapshotVersion.min().toTimestamp(),
       /*targetCount=*/ 0
     );
 

--- a/packages/firestore/test/unit/local/local_store.test.ts
+++ b/packages/firestore/test/unit/local/local_store.test.ts
@@ -1457,7 +1457,7 @@ function genericLocalStoreTests(
       .afterAllocatingQuery(query)
       .toReturnTargetId(2)
       .afterMutations([
-        patchMutation('foo/bar', {}, Precondition.NONE),
+        patchMutation('foo/bar', {}, Precondition.none()),
         transformMutation('foo/bar', { sum: PublicFieldValue.increment(1) })
       ])
       .toReturnChanged(
@@ -1620,7 +1620,7 @@ function genericLocalStoreTests(
     );
     expect(
       cachedTargetData!.lastLimboFreeSnapshotVersion.isEqual(
-        SnapshotVersion.MIN
+        SnapshotVersion.min()
       )
     ).to.be.true;
 

--- a/packages/firestore/test/unit/local/lru_garbage_collector.test.ts
+++ b/packages/firestore/test/unit/local/lru_garbage_collector.test.ts
@@ -276,7 +276,7 @@ function genericLruGarbageCollectorTests(
     return new SetMutation(
       key,
       wrapObject({ baz: 'hello', world: 2 }),
-      Precondition.NONE
+      Precondition.none()
     );
   }
 

--- a/packages/firestore/test/unit/local/remote_document_cache.test.ts
+++ b/packages/firestore/test/unit/local/remote_document_cache.test.ts
@@ -125,7 +125,7 @@ describe('IndexedDbRemoteDocumentCache', () => {
     );
 
     let { changedDocs, readTime } = await cache.getNewDocumentChanges(
-      SnapshotVersion.MIN
+      SnapshotVersion.min()
     );
     assertMatches(
       [
@@ -143,7 +143,7 @@ describe('IndexedDbRemoteDocumentCache', () => {
 
   it('can get empty changes', async () => {
     const { changedDocs } = await cache.getNewDocumentChanges(
-      SnapshotVersion.MIN
+      SnapshotVersion.min()
     );
     assertMatches([], changedDocs);
   });
@@ -160,7 +160,7 @@ describe('IndexedDbRemoteDocumentCache', () => {
     await cache.removeEntry(key('a/2'), version(4));
 
     const { changedDocs } = await cache.getNewDocumentChanges(
-      SnapshotVersion.MIN
+      SnapshotVersion.min()
     );
     assertMatches(
       [doc('a/1', 1, DOC_DATA), removedDoc('a/2'), doc('a/3', 3, DOC_DATA)],
@@ -378,7 +378,7 @@ function genericRemoteDocumentCacheTests(
     const query = new Query(path('b'));
     const matchingDocs = await cache.getDocumentsMatchingQuery(
       query,
-      SnapshotVersion.MIN
+      SnapshotVersion.min()
     );
 
     assertMatches(

--- a/packages/firestore/test/unit/local/target_cache.test.ts
+++ b/packages/firestore/test/unit/local/target_cache.test.ts
@@ -135,7 +135,7 @@ function genericTargetCacheTests(
       TargetPurpose.Listen,
       ++previousSequenceNumber,
       snapshotVersion,
-      /* lastLimboFreeSnapshotVersion= */ SnapshotVersion.MIN,
+      /* lastLimboFreeSnapshotVersion= */ SnapshotVersion.min(),
       resumeToken
     );
   }
@@ -349,7 +349,7 @@ function genericTargetCacheTests(
 
   it('can get / set targets metadata', async () => {
     expect(await cache.getLastRemoteSnapshotVersion()).to.deep.equal(
-      SnapshotVersion.MIN
+      SnapshotVersion.min()
     );
 
     // Can set the snapshot version.

--- a/packages/firestore/test/unit/model/mutation.test.ts
+++ b/packages/firestore/test/unit/model/mutation.test.ts
@@ -95,7 +95,7 @@ describe('Mutation', () => {
     const patch = patchMutation(
       'collection/key',
       { 'foo.bar': 'new-bar-value' },
-      Precondition.NONE
+      Precondition.none()
     );
 
     const patchedDoc = patch.applyToLocalView(baseDoc, baseDoc, timestamp);
@@ -116,7 +116,7 @@ describe('Mutation', () => {
     const patch = patchMutation(
       'collection/key',
       { 'foo.bar': 'new-bar-value' },
-      Precondition.NONE
+      Precondition.none()
     );
 
     const patchedDoc = patch.applyToLocalView(baseDoc, baseDoc, timestamp);

--- a/packages/firestore/test/unit/remote/remote_event.test.ts
+++ b/packages/firestore/test/unit/remote/remote_event.test.ts
@@ -459,7 +459,13 @@ describe('RemoteEvent', () => {
     expect(event.targetMismatches.size).to.equal(1);
     expect(event.targetChanges.size).to.equal(1);
 
-    const expected = updateMapping(SnapshotVersion.MIN, [], [], [doc1], false);
+    const expected = updateMapping(
+      SnapshotVersion.min(),
+      [],
+      [],
+      [doc1],
+      false
+    );
     expectTargetChangeEquals(event.targetChanges.get(1)!, expected);
   });
 

--- a/packages/firestore/test/unit/remote/serializer.helper.ts
+++ b/packages/firestore/test/unit/remote/serializer.helper.ts
@@ -56,7 +56,6 @@ import {
   WatchTargetChangeState
 } from '../../../src/remote/watch_change';
 import { Code, FirestoreError } from '../../../src/util/error';
-import { forEach } from '../../../src/util/obj';
 import { addEqualityMatcher } from '../../util/equality_matcher';
 import {
   bound,
@@ -566,7 +565,7 @@ export function serializerTest(
 
     describe('toMutation', () => {
       it('converts DeleteMutation', () => {
-        const mutation = new DeleteMutation(key('docs/1'), Precondition.NONE);
+        const mutation = new DeleteMutation(key('docs/1'), Precondition.none());
         const result = s.toMutation(mutation);
         expect(result).to.deep.equal({
           delete: 'projects/p/databases/d/documents/docs/1'
@@ -609,7 +608,7 @@ export function serializerTest(
         const mutation = patchMutation(
           'bar/baz',
           { a: 'b', num: 1, 'some.deep.thing': 2 },
-          Precondition.NONE
+          Precondition.none()
         );
         const proto = {
           update: s.toMutationDocument(mutation.key, mutation.data),
@@ -1250,8 +1249,8 @@ export function serializerTest(
             1,
             TargetPurpose.Listen,
             4,
-            SnapshotVersion.MIN,
-            SnapshotVersion.MIN,
+            SnapshotVersion.min(),
+            SnapshotVersion.min(),
             ByteString.fromUint8Array(new Uint8Array([1, 2, 3]))
           )
         );
@@ -1279,14 +1278,20 @@ export function serializerTest(
       addEqualityMatcher();
 
       it('contains all Operators', () => {
-        // giant hack
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        forEach(Operator as any, (name, op) => {
-          if (op instanceof Operator) {
-            expect(s.toOperatorName(op), 'for name').to.exist;
-            expect(s.fromOperatorName(s.toOperatorName(op))).to.deep.equal(op);
-          }
-        });
+        const allOperators = [
+          Operator.LESS_THAN,
+          Operator.LESS_THAN_OR_EQUAL,
+          Operator.EQUAL,
+          Operator.GREATER_THAN,
+          Operator.GREATER_THAN_OR_EQUAL,
+          Operator.ARRAY_CONTAINS,
+          Operator.IN,
+          Operator.ARRAY_CONTAINS_ANY
+        ];
+
+        for (const op of allOperators) {
+          expect(s.fromOperatorName(s.toOperatorName(op))).to.deep.equal(op);
+        }
       });
     });
 
@@ -1294,14 +1299,11 @@ export function serializerTest(
       addEqualityMatcher();
 
       it('contains all Directions', () => {
-        // giant hack
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        forEach(Direction as any, (name, dir) => {
-          if (dir instanceof Direction) {
-            expect(s.toDirection(dir), 'for ' + name).to.exist;
-            expect(s.fromDirection(s.toDirection(dir))).to.deep.equal(dir);
-          }
-        });
+        const allDirections = [Direction.ASCENDING, Direction.DESCENDING];
+
+        for (const dir of allDirections) {
+          expect(s.fromDirection(s.toDirection(dir))).to.deep.equal(dir);
+        }
       });
     });
 

--- a/packages/firestore/test/unit/specs/limbo_spec.test.ts
+++ b/packages/firestore/test/unit/specs/limbo_spec.test.ts
@@ -375,7 +375,7 @@ describeSpec('Limbo Documents:', [], () => {
         .expectLimboDocs(remoteDoc.key)
         // Fail the Limbo resolution which removes the document from the view.
         // This is internally propagated as a NoDocument with
-        // SnapshotVersion.MIN and a read time of zero.
+        // SnapshotVersion.min() and a read time of zero.
         .watchRemoves(
           Query.atPath(path('collection/a')),
           new RpcError(Code.PERMISSION_DENIED, 'Permission denied')

--- a/packages/firestore/test/unit/specs/spec_builder.ts
+++ b/packages/firestore/test/unit/specs/spec_builder.ts
@@ -923,7 +923,7 @@ export class SpecBuilder {
           // TODO(dimond): Support non-JSON primitive values?
           return [
             filter.field.canonicalString(),
-            filter.op.name,
+            filter.op,
             userDataWriter.convertValue(filter.value)
           ] as SpecQueryFilter;
         } else {
@@ -935,7 +935,7 @@ export class SpecBuilder {
       spec.orderBys = query.explicitOrderBy.map(orderBy => {
         return [
           orderBy.field.canonicalString(),
-          orderBy.dir.name
+          orderBy.dir
         ] as SpecQueryOrderBy;
       });
     }

--- a/packages/firestore/test/unit/specs/spec_test_components.ts
+++ b/packages/firestore/test/unit/specs/spec_test_components.ts
@@ -51,7 +51,7 @@ export class MockMemoryPersistence extends MemoryPersistence {
       transaction: PersistenceTransaction
     ) => PersistencePromise<T>
   ): Promise<T> {
-    if (this.injectFailures) { 
+    if (this.injectFailures) {
       return Promise.reject(
         new IndexedDbTransactionError(new Error('Simulated retryable error'))
       );

--- a/packages/firestore/test/unit/specs/spec_test_runner.ts
+++ b/packages/firestore/test/unit/specs/spec_test_runner.ts
@@ -1174,8 +1174,8 @@ abstract class TestRunner {
           targetId,
           TargetPurpose.Listen,
           ARBITRARY_SEQUENCE_NUMBER,
-          SnapshotVersion.MIN,
-          SnapshotVersion.MIN,
+          SnapshotVersion.min(),
+          SnapshotVersion.min(),
           byteStringFromString(expected.resumeToken)
         )
       );

--- a/packages/firestore/test/util/helpers.ts
+++ b/packages/firestore/test/util/helpers.ts
@@ -171,7 +171,7 @@ export function unknownDoc(
 }
 
 export function removedDoc(keyStr: string): NoDocument {
-  return new NoDocument(key(keyStr), SnapshotVersion.forDeletedDoc());
+  return new NoDocument(key(keyStr), SnapshotVersion.min());
 }
 
 export function wrap(value: unknown): api.Value {
@@ -226,7 +226,7 @@ export function blob(...bytes: number[]): Blob {
 
 export function filter(path: string, op: string, value: unknown): FieldFilter {
   const dataValue = wrap(value);
-  const operator = Operator.fromString(op);
+  const operator = op as Operator;
   const filter = FieldFilter.create(field(path), operator, dataValue);
 
   if (filter instanceof FieldFilter) {
@@ -240,7 +240,7 @@ export function setMutation(
   keyStr: string,
   json: JsonObject<unknown>
 ): SetMutation {
-  return new SetMutation(key(keyStr), wrapObject(json), Precondition.NONE);
+  return new SetMutation(key(keyStr), wrapObject(json), Precondition.none());
 }
 
 export function patchMutation(
@@ -262,7 +262,7 @@ export function patchMutation(
 }
 
 export function deleteMutation(keyStr: string): DeleteMutation {
-  return new DeleteMutation(key(keyStr), Precondition.NONE);
+  return new DeleteMutation(key(keyStr), Precondition.none());
 }
 
 /**
@@ -364,7 +364,7 @@ export function docAddedRemoteEvent(
     }
   });
 
-  let version = SnapshotVersion.MIN;
+  let version = SnapshotVersion.min();
 
   for (const doc of docs) {
     debugAssert(
@@ -451,7 +451,7 @@ export function addTargetMapping(
   ...docsOrKeys: Array<Document | string>
 ): TargetChange {
   return updateMapping(
-    SnapshotVersion.MIN,
+    SnapshotVersion.min(),
     docsOrKeys,
     [],
     [],
@@ -463,7 +463,7 @@ export function ackTarget(
   ...docsOrKeys: Array<Document | string>
 ): TargetChange {
   return updateMapping(
-    SnapshotVersion.MIN,
+    SnapshotVersion.min(),
     docsOrKeys,
     [],
     [],
@@ -538,7 +538,7 @@ export function stringFromBase64String(value?: string | Uint8Array): string {
 export function resumeTokenForSnapshot(
   snapshotVersion: SnapshotVersion
 ): ByteString {
-  if (snapshotVersion.isEqual(SnapshotVersion.MIN)) {
+  if (snapshotVersion.isEqual(SnapshotVersion.min())) {
     return ByteString.EMPTY_BYTE_STRING;
   } else {
     return byteStringFromString(snapshotVersion.toString());
@@ -588,7 +588,7 @@ export function documentUpdates(
     } else if (docOrKey instanceof DocumentKey) {
       changes = changes.insert(
         docOrKey,
-        new NoDocument(docOrKey, SnapshotVersion.forDeletedDoc())
+        new NoDocument(docOrKey, SnapshotVersion.min())
       );
     }
   }


### PR DESCRIPTION
Static members of classes introduce something akin to cyclic references, which prevents the Rollup build from detecting that code is unused. A simple example is:

```
class Precondition {
   static NONE = new Precondition();
}
```

This translates to the following JavaScript code:

```
class Precondition {
}
Precondition.NONE = new Precondition(); 
```

In this example, Rollup doesn't know whether `NONE = new Precondition()` is side-effect free, and hence keeps the member and the class. This PR removes all static member variables and replaces them either with const enums (which are inlined) or member functions.

