### PR TITLE
Add Firestore lite build, add test

### DIFF
--- a/packages/firestore/lite/index.d.ts
+++ b/packages/firestore/lite/index.d.ts
@@ -1,0 +1,359 @@
+/**
+ * @license
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// import { FirebaseApp, FirebaseNamespace } from '@firebase/app-types';
+//
+// export type DocumentData = { [field: string]: any };
+//
+// export type UpdateData = { [fieldPath: string]: any };
+
+export interface Settings {
+  host?: string;
+  ssl?: boolean;
+}
+
+export function initializeFirestore(
+  firestore: FirebaseFirestore,
+  settings: Settings
+): void;
+
+// export type LogLevel = 'debug' | 'error' | 'silent';
+//
+// export function setLogLevel(logLevel: LogLevel): void;
+//
+// export interface FirestoreDataConverter<T> {
+//   toFirestore(modelObject: T): DocumentData;
+//
+//   fromFirestore(snapshot: QueryDocumentSnapshot): T;
+// }
+
+export interface FirebaseFirestore {
+  //   collection(collectionPath: string): CollectionReference<DocumentData>;
+  //
+  //   doc(documentPath: string): DocumentReference<DocumentData>;
+  //
+  //   collectionGroup(collectionId: string): Query<DocumentData>;
+}
+
+// export class GeoPoint {
+//   constructor(latitude: number, longitude: number);
+//
+//   readonly latitude: number;
+//   readonly longitude: number;
+//
+//   isEqual(other: GeoPoint): boolean;
+// }
+//
+// export class Timestamp {
+//   constructor(seconds: number, nanoseconds: number);
+//
+//   static now(): Timestamp;
+//
+//   static fromDate(date: Date): Timestamp;
+//
+//   static fromMillis(milliseconds: number): Timestamp;
+//
+//   readonly seconds: number;
+//   readonly nanoseconds: number;
+//
+//   toDate(): Date;
+//
+//   toMillis(): number;
+//
+//   isEqual(other: Timestamp): boolean;
+//
+//   valueOf(): string;
+// }
+//
+// export class Blob {
+//   private constructor();
+//
+//   static fromBase64String(base64: string): Blob;
+//
+//   static fromUint8Array(array: Uint8Array): Blob;
+//
+//   public toBase64(): string;
+//
+//   public toUint8Array(): Uint8Array;
+//
+//   isEqual(other: Blob): boolean;
+// }
+//
+// export class Transaction {
+//   private constructor();
+//
+//   get<T>(documentRef: DocumentReference<T>): Promise<DocumentSnapshot<T>>;
+//
+//   set<T>(
+//     documentRef: DocumentReference<T>,
+//     data: T,
+//     options?: SetOptions
+//   ): Transaction;
+//
+//   update(documentRef: DocumentReference<any>, data: UpdateData): Transaction;
+//   update(
+//     documentRef: DocumentReference<any>,
+//     field: string | FieldPath,
+//     value: any,
+//     ...moreFieldsAndValues: any[]
+//   ): Transaction;
+//
+//   delete(documentRef: DocumentReference<any>): Transaction;
+// }
+//
+// export class WriteBatch {
+//   private constructor();
+//
+//   set<T>(
+//     documentRef: DocumentReference<T>,
+//     data: T,
+//     options?: SetOptions
+//   ): WriteBatch;
+//
+//   update(documentRef: DocumentReference<any>, data: UpdateData): WriteBatch;
+//   update(
+//     documentRef: DocumentReference<any>,
+//     field: string | FieldPath,
+//     value: any,
+//     ...moreFieldsAndValues: any[]
+//   ): WriteBatch;
+//
+//   delete(documentRef: DocumentReference<any>): WriteBatch;
+//
+//   commit(): Promise<void>;
+// }
+//
+// export interface SetOptions {
+//   readonly merge?: boolean;
+//   readonly mergeFields?: (string | FieldPath)[];
+// }
+//
+// export interface DocumentReference<T = DocumentData> {
+//   readonly id: string;
+//   readonly firestore: FirebaseFirestore;
+//   readonly parent: CollectionReference<T>;
+//   readonly path: string;
+//
+//   collection(collectionPath: string): CollectionReference<DocumentData>;
+//
+//   isEqual(other: DocumentReference<T>): boolean;
+//
+//   withConverter<U>(converter: FirestoreDataConverter<U>): DocumentReference<U>;
+// }
+//
+// export interface DocumentSnapshot<T = DocumentData> {
+//   readonly exists: boolean;
+//   readonly ref: DocumentReference<T>;
+//   readonly id: string;
+//
+//   data(): T | undefined;
+//
+//   get(fieldPath: string | FieldPath): any;
+//
+//   isEqual(other: DocumentSnapshot<T>): boolean;
+// }
+//
+// export interface QueryDocumentSnapshot<T = DocumentData>
+//   extends DocumentSnapshot<T> {
+//   data(): T;
+// }
+//
+// export type OrderByDirection = 'desc' | 'asc';
+//
+// export type WhereFilterOp =
+//   | '<'
+//   | '<='
+//   | '=='
+//   | '>='
+//   | '>'
+//   | 'array-contains'
+//   | 'in'
+//   | 'array-contains-any';
+//
+// export interface Query<T = DocumentData> {
+//   readonly firestore: FirebaseFirestore;
+//
+//   where(
+//     fieldPath: string | FieldPath,
+//     opStr: WhereFilterOp,
+//     value: any
+//   ): Query<T>;
+//
+//   orderBy(
+//     fieldPath: string | FieldPath,
+//     directionStr?: OrderByDirection
+//   ): Query<T>;
+//
+//   limit(limit: number): Query<T>;
+//
+//   limitToLast(limit: number): Query<T>;
+//
+//   startAt(snapshot: DocumentSnapshot<any>): Query<T>;
+//   startAt(...fieldValues: any[]): Query<T>;
+//
+//   startAfter(snapshot: DocumentSnapshot<any>): Query<T>;
+//   startAfter(...fieldValues: any[]): Query<T>;
+//
+//   endBefore(snapshot: DocumentSnapshot<any>): Query<T>;
+//   endBefore(...fieldValues: any[]): Query<T>;
+//
+//   endAt(snapshot: DocumentSnapshot<any>): Query<T>;
+//   endAt(...fieldValues: any[]): Query<T>;
+//
+//   isEqual(other: Query<T>): boolean;
+//
+//   withConverter<U>(converter: FirestoreDataConverter<U>): Query<U>;
+// }
+//
+// export class QuerySnapshot<T = DocumentData> {
+//   private constructor();
+//
+//   readonly query: Query<T>;
+//   readonly docs: Array<QueryDocumentSnapshot<T>>;
+//   readonly size: number;
+//   readonly empty: boolean;
+//
+//   docChanges(): Array<DocumentChange<T>>;
+//
+//   forEach(
+//     callback: (result: QueryDocumentSnapshot<T>) => void,
+//     thisArg?: any
+//   ): void;
+//
+//   isEqual(other: QuerySnapshot<T>): boolean;
+// }
+//
+// export type DocumentChangeType = 'added' | 'removed' | 'modified';
+//
+// export interface DocumentChange<T = DocumentData> {
+//   readonly type: DocumentChangeType;
+//   readonly doc: QueryDocumentSnapshot<T>;
+//   readonly oldIndex: number;
+//   readonly newIndex: number;
+// }
+//
+// export interface CollectionReference<T = DocumentData> extends Query<T> {
+//   readonly id: string;
+//   readonly parent: DocumentReference<DocumentData> | null;
+//   readonly path: string;
+//
+//   doc(documentPath?: string): DocumentReference<T>;
+//
+//   add(data: T): Promise<DocumentReference<T>>;
+//
+//   isEqual(other: CollectionReference<T>): boolean;
+//
+//   withConverter<U>(
+//     converter: FirestoreDataConverter<U>
+//   ): CollectionReference<U>;
+// }
+//
+// export class FieldValue {
+//   private constructor();
+//   isEqual(other: FieldValue): boolean;
+// }
+//
+// export class FieldPath {
+//   constructor(...fieldNames: string[]);
+//   isEqual(other: FieldPath): boolean;
+// }
+//
+// // MARK: Initialization methods
+//
+// export function initializeFirestore(
+//   firestore: FirebaseFirestore,
+//   settings: Settings
+// ): Promise<void>;
+//
+// // MARK: Firestore methods
+//
+// export function terminate(firestore: FirebaseFirestore): Promise<void>;
+//
+// export function writeBatch(firestore: FirebaseFirestore): WriteBatch;
+//
+// export function runTransaction<T>(
+//   firestore: FirebaseFirestore,
+//   updateFunction: (transaction: Transaction) => Promise<T>
+// ): Promise<T>;
+//
+// // MARK: DocumentReference methods
+//
+// export function getDocument<T>(
+//   reference: DocumentReference<T>
+// ): Promise<DocumentSnapshot<T>>;
+//
+// export function deleteDocument(reference: DocumentReference): Promise<void>;
+//
+// export function updateDocument(
+//   reference: DocumentReference,
+//   data: UpdateData
+// ): Promise<void>;
+//
+// export function updateDocument(
+//   field: string | FieldPath,
+//   value: any,
+//   ...moreFieldsAndValues: any[]
+// ): Promise<void>;
+//
+// export function setDocument<T>(
+//   reference: DocumentReference<T>,
+//   data: T,
+//   options?: SetOptions
+// ): Promise<void>;
+//
+// export function addDocument<T>(
+//   reference: CollectionReference<T>,
+//   data: T
+// ): Promise<DocumentSnapshot<T>>;
+//
+// // MARK: CollectionReference methods
+// export function getDocuments<T>(query: Query<T>): Promise<QuerySnapshot<T>>;
+//
+// // MARK: FieldPath methods
+// export function documentId(): FieldPath;
+//
+// // MARK: FieldValue methods
+// export function serverTimestamp(): FieldValue;
+// export function deleteField(): FieldValue;
+// export function arrayUnion(...elements: any[]): FieldValue;
+// export function arrayRemove(...elements: any[]): FieldValue;
+// export function increment(n: number): FieldValue;
+//
+// export type FirestoreErrorCode =
+//   | 'cancelled'
+//   | 'unknown'
+//   | 'invalid-argument'
+//   | 'deadline-exceeded'
+//   | 'not-found'
+//   | 'already-exists'
+//   | 'permission-denied'
+//   | 'resource-exhausted'
+//   | 'failed-precondition'
+//   | 'aborted'
+//   | 'out-of-range'
+//   | 'unimplemented'
+//   | 'internal'
+//   | 'unavailable'
+//   | 'data-loss'
+//   | 'unauthenticated';
+//
+// export interface FirestoreError {
+//   code: FirestoreErrorCode;
+//   message: string;
+//   name: string;
+//   stack?: string;
+// }

--- a/packages/firestore/lite/index.node.ts
+++ b/packages/firestore/lite/index.node.ts
@@ -1,0 +1,21 @@
+/**
+ * @license
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export {
+  Firestore as FirebaseFirestore,
+  initializeFirestore
+} from './src/api/database';

--- a/packages/firestore/lite/src/api/database.ts
+++ b/packages/firestore/lite/src/api/database.ts
@@ -54,10 +54,7 @@ class FirestoreSettings {
   }
 
   isEqual(other: FirestoreSettings): boolean {
-    return (
-      this.host === other.host &&
-      this.ssl === other.ssl
-    );
+    return this.host === other.host && this.ssl === other.ssl;
   }
 }
 
@@ -66,19 +63,18 @@ class FirestoreSettings {
  */
 export class Firestore implements firestore.FirebaseFirestore, FirebaseService {
   private readonly _firebaseApp: FirebaseApp;
-  private _settings: FirestoreSettings;
+  private _settings = new FirestoreSettings({});
 
   constructor(app: FirebaseApp) {
     this._firebaseApp = app;
-    this._settings = new FirestoreSettings({});
   }
 
   get app(): FirebaseApp {
     return this._firebaseApp;
   }
 
-  _configureClient(settings: Settings): void {
-    this._settings = new FirestoreSettings(settings);
+  _configureClient(settings: FirestoreSettings): void {
+    this._settings = settings;
   }
 }
 
@@ -87,7 +83,9 @@ export interface Settings {
   ssl?: boolean;
 }
 
-export function initializeFirestore(firstore: Firestore, settings?: Settings) {
-  firstore._configureClient(settings ?? {});
+export function initializeFirestore(
+  firstore: Firestore,
+  settings?: Settings
+): void {
+  firstore._configureClient(new FirestoreSettings(settings ?? {}));
 }
-

--- a/packages/firestore/lite/src/api/database.ts
+++ b/packages/firestore/lite/src/api/database.ts
@@ -1,0 +1,93 @@
+/**
+ * @license
+ * Copyright 2017 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as firestore from '../../';
+
+import { FirebaseApp } from '@firebase/app-types';
+import { Code, FirestoreError } from '../../../src/util/error';
+import { FirebaseService } from '@firebase/app-types/private';
+
+// settings() defaults:
+const DEFAULT_HOST = 'firestore.googleapis.com';
+const DEFAULT_SSL = true;
+
+/**
+ * A concrete type describing all the values that can be applied via a
+ * user-supplied firestore.Settings object. This is a separate type so that
+ * defaults can be supplied and the value can be checked for equality.
+ */
+class FirestoreSettings {
+  /** The hostname to connect to. */
+  readonly host: string;
+
+  /** Whether to use SSL when connecting. */
+  readonly ssl: boolean;
+
+  constructor(settings: firestore.Settings) {
+    if (settings.host === undefined) {
+      if (settings.ssl !== undefined) {
+        throw new FirestoreError(
+          Code.INVALID_ARGUMENT,
+          "Can't provide ssl option if host option is not set"
+        );
+      }
+      this.host = DEFAULT_HOST;
+      this.ssl = DEFAULT_SSL;
+    } else {
+      this.host = settings.host;
+      this.ssl = settings.ssl ?? DEFAULT_SSL;
+    }
+  }
+
+  isEqual(other: FirestoreSettings): boolean {
+    return (
+      this.host === other.host &&
+      this.ssl === other.ssl
+    );
+  }
+}
+
+/**
+ * The root reference to the database.
+ */
+export class Firestore implements firestore.FirebaseFirestore, FirebaseService {
+  private readonly _firebaseApp: FirebaseApp;
+  private _settings: FirestoreSettings;
+
+  constructor(app: FirebaseApp) {
+    this._firebaseApp = app;
+    this._settings = new FirestoreSettings({});
+  }
+
+  get app(): FirebaseApp {
+    return this._firebaseApp;
+  }
+
+  _configureClient(settings: Settings): void {
+    this._settings = new FirestoreSettings(settings);
+  }
+}
+
+export interface Settings {
+  host?: string;
+  ssl?: boolean;
+}
+
+export function initializeFirestore(firstore: Firestore, settings?: Settings) {
+  firstore._configureClient(settings ?? {});
+}
+

--- a/packages/firestore/lite/test/dependencies.test.ts
+++ b/packages/firestore/lite/test/dependencies.test.ts
@@ -25,7 +25,7 @@ import { expect } from 'chai';
  * This functions builds a simple JS app that only depends on the provided
  * export. It then uses Rollup to gather all top-level classes and functions
  * that that the export depends on.
- * 
+ *
  * @return a list of dependencies for the given export
  */
 async function extractDependencies(exportName: string): Promise<string[]> {
@@ -40,7 +40,7 @@ async function extractDependencies(exportName: string): Promise<string[]> {
 
   // Run Rollup on the JavaScript above to produce a tree-shaken build
   const bundle = await rollup.rollup({
-    input: input,
+    input,
     external: id => id.startsWith('@firebase/')
   });
   await bundle.write({ file: output, format: 'es' });

--- a/packages/firestore/lite/test/dependencies.test.ts
+++ b/packages/firestore/lite/test/dependencies.test.ts
@@ -49,7 +49,7 @@ async function extractDependencies(exportName: string): Promise<string[]> {
 
   const dependencies: string[] = [];
   for (const line of afterContent.split('\n')) {
-    const identifierRe = /^(?:async )?(?:function|class) ?([\w]*)/;
+    const identifierRe = /^(?:async )?(?:function|class) ([\w]*)/;
     const match = line.match(identifierRe);
     if (match) {
       dependencies.push(match[1]);

--- a/packages/firestore/lite/test/dependencies.test.ts
+++ b/packages/firestore/lite/test/dependencies.test.ts
@@ -1,0 +1,78 @@
+/**
+ * @license
+ * Copyright 2017 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as rollup from 'rollup';
+import * as tmp from 'tmp';
+import * as fs from 'fs';
+import * as path from 'path';
+import { expect } from 'chai';
+
+/**
+ * This functions builds a simple JS app that only depends on the provided
+ * export. It then uses Rollup to gather all top-level classes and functions
+ * that that the export depends on.
+ * 
+ * @return a list of dependencies for the given export
+ */
+async function extractDependencies(exportName: string): Promise<string[]> {
+  const input = tmp.fileSync().name;
+  const output = tmp.fileSync().name;
+
+  const beforeContent = `export { ${exportName} } from '${path.resolve(
+    __dirname,
+    '../../dist/lite/index.js'
+  )}';`;
+  fs.writeFileSync(input, beforeContent);
+
+  // Run Rollup on the JavaScript above to produce a tree-shaken build
+  const bundle = await rollup.rollup({
+    input: input,
+    external: id => id.startsWith('@firebase/')
+  });
+  await bundle.write({ file: output, format: 'es' });
+
+  const afterContent = fs.readFileSync(output, 'utf-8');
+
+  const dependencies: string[] = [];
+  for (const line of afterContent.split('\n')) {
+    const identifierRe = /^(?:async )?(?:function|class) ?([\w]*)/;
+    const match = line.match(identifierRe);
+    if (match) {
+      dependencies.push(match[1]);
+    }
+  }
+  dependencies.sort();
+  return dependencies;
+}
+
+describe('Dependencies', () => {
+  it('FirebaseFirestore', async () => {
+    const dependencies = await extractDependencies('FirebaseFirestore');
+
+    expect(dependencies).to.have.members([
+      'Firestore',
+      'FirestoreError',
+      'FirestoreSettings'
+    ]);
+  });
+
+  it('initializeFirestore', async () => {
+    const dependencies = await extractDependencies('initializeFirestore');
+
+    expect(dependencies).to.have.members(['initializeFirestore']);
+  });
+});

--- a/packages/firestore/package.json
+++ b/packages/firestore/package.json
@@ -11,11 +11,12 @@
     "build": "rollup -c rollup.config.es2017.js && rollup -c rollup.config.es5.js",
     "build:deps": "lerna run --scope @firebase/'{app,firestore}' --include-dependencies build",
     "build:console": "node tools/console.build.js",
+    "build:lite": "rollup -c rollup.config.lite.js",
     "predev": "yarn prebuild",
     "dev": "rollup -c -w",
     "lint": "eslint -c .eslintrc.js '**/*.ts' --ignore-path '../../.gitignore'",
     "lint:fix": "eslint --fix -c .eslintrc.js '**/*.ts' --ignore-path '../../.gitignore'",
-    "prettier": "prettier --write '*.ts' '*.js' 'src/**/*.js' 'test/**/*.js' 'src/**/*.ts' 'test/**/*.ts'",
+    "prettier": "prettier --write '*.ts' '*.js' 'src/**/*.js' 'test/**/*.js' 'src/**/*.ts' 'test/**/*.ts' 'lite/**/*.ts'",
     "test": "run-s lint test:all",
     "test:all": "run-p test:browser test:travis test:minified",
     "test:browser": "karma start --single-run",
@@ -26,6 +27,8 @@
     "test:node:persistence:prod": "USE_MOCK_PERSISTENCE=YES TS_NODE_CACHE=NO TS_NODE_COMPILER_OPTIONS='{\"module\":\"commonjs\"}' nyc --reporter lcovonly -- mocha 'test/{,!(browser)/**/}*.test.ts' --require ts-node/register --require index.node.ts --require test/util/node_persistence.ts --opts ../../config/mocha.node.opts",
     "test:travis": "ts-node --compiler-options='{\"module\":\"commonjs\"}' ../../scripts/emulator-testing/firestore-test-runner.ts",
     "test:minified": "(cd ../../integration/firestore ; yarn test)",
+    "pretest:lite": "yarn build:lite",
+    "test:lite": "FIRESTORE_EMULATOR_PORT=8080 FIRESTORE_EMULATOR_PROJECT_ID=test-emulator TS_NODE_CACHE=NO TS_NODE_COMPILER_OPTIONS='{\"module\":\"commonjs\"}' nyc --reporter lcovonly -- mocha 'lite/test/**/*.test.ts' --file lite/index.node.ts --opts ../../config/mocha.node.opts",
     "prepare": "yarn build"
   },
   "main": "dist/index.node.cjs.js",
@@ -54,6 +57,7 @@
   },
   "devDependencies": {
     "@types/json-stable-stringify": "1.0.32",
+    "@types/tmp": "0.1.0",
     "json-stable-stringify": "1.0.1",
     "protobufjs": "6.8.9",
     "rollup": "2.6.1",
@@ -64,6 +68,7 @@
     "rollup-plugin-sourcemaps": "0.5.0",
     "rollup-plugin-terser": "5.3.0",
     "rollup-plugin-typescript2": "0.27.0",
+    "tmp": "0.1.0",
     "ts-node": "8.8.2",
     "typescript": "3.8.3"
   },

--- a/packages/firestore/rollup.config.lite.js
+++ b/packages/firestore/rollup.config.lite.js
@@ -1,0 +1,52 @@
+/**
+ * @license
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import json from 'rollup-plugin-json';
+import typescriptPlugin from 'rollup-plugin-typescript2';
+import typescript from 'typescript';
+
+import { resolveNodeExterns } from './rollup.shared';
+
+const defaultPlugins = [
+  typescriptPlugin({
+    typescript,
+    tsconfigOverride: {
+      compilerOptions: {
+        target: 'es2017'
+      }
+    },
+    clean: true
+  }),
+  json({ preferConst: true })
+];
+
+const nodeBuilds = [
+  {
+    input: './lite/index.node.ts',
+    output: {
+      file: './dist/lite/index.js',
+      format: 'es'
+    },
+    plugins: defaultPlugins,
+    external: resolveNodeExterns,
+    treeshake: {
+      tryCatchDeoptimization: false
+    }
+  }
+];
+
+export default [...nodeBuilds];

--- a/packages/firestore/test/unit/specs/spec_test_components.ts
+++ b/packages/firestore/test/unit/specs/spec_test_components.ts
@@ -51,7 +51,7 @@ export class MockMemoryPersistence extends MemoryPersistence {
       transaction: PersistenceTransaction
     ) => PersistencePromise<T>
   ): Promise<T> {
-    if (this.injectFailures) { 
+    if (this.injectFailures) {
       return Promise.reject(
         new IndexedDbTransactionError(new Error('Simulated retryable error'))
       );

--- a/yarn.lock
+++ b/yarn.lock
@@ -2183,6 +2183,11 @@
   resolved "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-6.0.1.tgz#681df970358c82836b42f989188d133e218c458e"
   integrity sha512-yYezQwGWty8ziyYLdZjwxyMb0CZR49h8JALHGrxjQHWlqGgc8kLdHEgWrgL0uZ29DMvEVBDnHU2Wg36zKSIUtA==
 
+"@types/tmp@0.1.0":
+  version "0.1.0"
+  resolved "https://registry.npmjs.org/@types/tmp/-/tmp-0.1.0.tgz#19cf73a7bcf641965485119726397a096f0049bd"
+  integrity sha512-6IwZ9HzWbCq6XoQWhxLpDjuADodH/MKXRUIDFudvgjcVdjFknvmR+DNsoUeer4XPrEnrZs04Jj+kfV9pFsrhmA==
+
 "@types/tough-cookie@*":
   version "4.0.0"
   resolved "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.0.tgz#fef1904e4668b6e5ecee60c52cc6a078ffa6697d"
@@ -14058,7 +14063,7 @@ tmp@0.0.33, tmp@0.0.x, tmp@^0.0.33:
   dependencies:
     os-tmpdir "~1.0.2"
 
-tmp@^0.1.0:
+tmp@0.1.0, tmp@^0.1.0:
   version "0.1.0"
   resolved "https://registry.npmjs.org/tmp/-/tmp-0.1.0.tgz#ee434a4e22543082e294ba6201dcc6eafefa2877"
   integrity sha512-J7Z2K08jbGcdA1kkQpJSqLF6T0tdQqpR2pnSUXsIchbPdTI9v3e85cLW0d6WDhwuAleOV71j2xWs8qMPfK7nKw==


### PR DESCRIPTION
This adds the first of many APIs for the Firestore lite build and it adds a test that verifies the dependency chains. The actual Firestore code is very far from correct, but I wanted to see if we could check in the new build and test configuration.