### PR TITLE
Remove objectHashIgnoreUnknownHack

### DIFF
--- a/packages-exp/firebase-exp/package.json
+++ b/packages-exp/firebase-exp/package.json
@@ -42,7 +42,7 @@
     "rollup-plugin-node-resolve": "5.2.0",
     "rollup-plugin-sourcemaps": "0.5.0",
     "rollup-plugin-terser": "5.1.3",
-    "rollup-plugin-typescript2": "0.25.3",
+    "rollup-plugin-typescript2": "0.27.0",
     "rollup-plugin-uglify": "6.0.4",
     "gulp": "4.0.2",
     "gulp-sourcemaps": "2.6.5",

--- a/packages-exp/firebase-exp/rollup.config.js
+++ b/packages-exp/firebase-exp/rollup.config.js
@@ -68,23 +68,11 @@ function createUmdOutputConfig(output, componentName) {
 const plugins = [sourcemaps(), resolveModule(), json(), commonjs()];
 
 const typescriptPlugin = rollupTypescriptPlugin({
-  typescript,
-  // Workaround for typescript plugins that use async functions.
-  // In this case, `rollup-plugin-sourcemaps`.
-  // See https://github.com/ezolenko/rollup-plugin-typescript2/blob/master/README.md
-  objectHashIgnoreUnknownHack: true,
-  // For safety, given hack above (see link).
-  clean: true
+  typescript
 });
 
 const typescriptPluginUMD = rollupTypescriptPlugin({
   typescript,
-  // Workaround for typescript plugins that use async functions.
-  // In this case, `rollup-plugin-sourcemaps`.
-  // See https://github.com/ezolenko/rollup-plugin-typescript2/blob/master/README.md
-  objectHashIgnoreUnknownHack: true,
-  // For safety, given hack above (see link).
-  clean: true,
   tsconfigOverride: {
     compilerOptions: {
       declaration: false

--- a/packages-exp/firebase-exp/rollup.config.release.js
+++ b/packages-exp/firebase-exp/rollup.config.release.js
@@ -73,23 +73,11 @@ const plugins = [sourcemaps(), resolveModule(), json(), commonjs()];
 
 const typescriptPlugin = rollupTypescriptPlugin({
   typescript,
-  // Workaround for typescript plugins that use async functions.
-  // In this case, `rollup-plugin-sourcemaps`.
-  // See https://github.com/ezolenko/rollup-plugin-typescript2/blob/master/README.md
-  objectHashIgnoreUnknownHack: true,
-  // For safety, given hack above (see link).
-  clean: true,
   transformers: [importPathTransformer]
 });
 
 const typescriptPluginUMD = rollupTypescriptPlugin({
   typescript,
-  // Workaround for typescript plugins that use async functions.
-  // In this case, `rollup-plugin-sourcemaps`.
-  // See https://github.com/ezolenko/rollup-plugin-typescript2/blob/master/README.md
-  objectHashIgnoreUnknownHack: true,
-  // For safety, given hack above (see link).
-  clean: true,
   tsconfigOverride: {
     compilerOptions: {
       declaration: false

--- a/packages/firebase/rollup.config.js
+++ b/packages/firebase/rollup.config.js
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2018 Google Inc.
+ * Copyright 2018 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/firebase/rollup.config.js
+++ b/packages/firebase/rollup.config.js
@@ -64,13 +64,7 @@ const plugins = [
   sourcemaps(),
   resolveModule(),
   typescriptPlugin({
-    typescript,
-    // Workaround for typescript plugins that use async functions.
-    // In this case, `rollup-plugin-sourcemaps`.
-    // See https://github.com/ezolenko/rollup-plugin-typescript2/blob/master/README.md
-    objectHashIgnoreUnknownHack: true,
-    // For safety, given hack above (see link).
-    clean: true
+    typescript
   }),
   json(),
   commonjs()
@@ -234,13 +228,7 @@ const completeBuilds = [
         mainFields: ['lite', 'module', 'main']
       }),
       typescriptPlugin({
-        typescript,
-        // Workaround for typescript plugins that use async functions.
-        // In this case, `rollup-plugin-sourcemaps`.
-        // See https://github.com/ezolenko/rollup-plugin-typescript2/blob/master/README.md
-        objectHashIgnoreUnknownHack: true,
-        // For safety, given hack above (see link).
-        clean: true
+        typescript
       }),
       json(),
       commonjs(),
@@ -265,12 +253,6 @@ const completeBuilds = [
       }),
       typescriptPlugin({
         typescript,
-        // Workaround for typescript plugins that use async functions.
-        // In this case, `rollup-plugin-sourcemaps`.
-        // See https://github.com/ezolenko/rollup-plugin-typescript2/blob/master/README.md
-        objectHashIgnoreUnknownHack: true,
-        // For safety, given hack above (see link).
-        clean: true,
         tsconfigOverride: {
           compilerOptions: {
             target: 'es2017'

--- a/yarn.lock
+++ b/yarn.lock
@@ -6320,7 +6320,7 @@ find-cache-dir@^2.1.0:
     make-dir "^2.0.0"
     pkg-dir "^3.0.0"
 
-find-cache-dir@^3.0.0, find-cache-dir@^3.2.0, find-cache-dir@^3.3.1:
+find-cache-dir@^3.2.0, find-cache-dir@^3.3.1:
   version "3.3.1"
   resolved "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.1.tgz#89b33fad4a4670daa94f855f7fbe31d6d84fe880"
   integrity sha512-t2GDMt3oGC/v+BMwzmllWDuJF/xcDtE5j/fCGbqDD7OLuJkj0cfh1YSA5VKPvwMeLFLNDBkwOKZ2X85jGLVftQ==
@@ -12378,13 +12378,6 @@ resolve@1.1.7:
   resolved "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
   integrity sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=
 
-resolve@1.12.0:
-  version "1.12.0"
-  resolved "https://registry.npmjs.org/resolve/-/resolve-1.12.0.tgz#3fc644a35c84a48554609ff26ec52b66fa577df6"
-  integrity sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==
-  dependencies:
-    path-parse "^1.0.6"
-
 resolve@1.15.1, resolve@^1.1.4, resolve@^1.1.6, resolve@^1.1.7, resolve@^1.10.0, resolve@^1.11.0, resolve@^1.11.1, resolve@^1.12.0, resolve@^1.13.1, resolve@^1.3.2, resolve@^1.3.3, resolve@^1.4.0:
   version "1.15.1"
   resolved "https://registry.npmjs.org/resolve/-/resolve-1.15.1.tgz#27bdcdeffeaf2d6244b95bb0f9f4b4653451f3e8"
@@ -12579,17 +12572,6 @@ rollup-plugin-terser@5.3.0:
     serialize-javascript "^2.1.2"
     terser "^4.6.2"
 
-rollup-plugin-typescript2@0.25.3:
-  version "0.25.3"
-  resolved "https://registry.npmjs.org/rollup-plugin-typescript2/-/rollup-plugin-typescript2-0.25.3.tgz#a5fb2f0f85488789334ce540abe6c7011cbdf40f"
-  integrity sha512-ADkSaidKBovJmf5VBnZBZe+WzaZwofuvYdzGAKTN/J4hN7QJCFYAq7IrH9caxlru6T5qhX41PNFS1S4HqhsGQg==
-  dependencies:
-    find-cache-dir "^3.0.0"
-    fs-extra "8.1.0"
-    resolve "1.12.0"
-    rollup-pluginutils "2.8.1"
-    tslib "1.10.0"
-
 rollup-plugin-typescript2@0.27.0:
   version "0.27.0"
   resolved "https://registry.npmjs.org/rollup-plugin-typescript2/-/rollup-plugin-typescript2-0.27.0.tgz#95ff96f9e07d5000a9d2df4d76b548f9a1f83511"
@@ -12610,13 +12592,6 @@ rollup-plugin-uglify@6.0.4:
     jest-worker "^24.0.0"
     serialize-javascript "^2.1.2"
     uglify-js "^3.4.9"
-
-rollup-pluginutils@2.8.1:
-  version "2.8.1"
-  resolved "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.8.1.tgz#8fa6dd0697344938ef26c2c09d2488ce9e33ce97"
-  integrity sha512-J5oAoysWar6GuZo0s+3bZ6sVZAC0pfqKz68De7ZgDi5z63jOVZn1uJL/+z1jeKHNbGII8kAyHF5q8LnxSX5lQg==
-  dependencies:
-    estree-walker "^0.6.1"
 
 rollup-pluginutils@^2.5.0, rollup-pluginutils@^2.6.0, rollup-pluginutils@^2.8.1, rollup-pluginutils@^2.8.2:
   version "2.8.2"
@@ -14235,11 +14210,6 @@ ts-node@8.8.2:
     make-error "^1.1.1"
     source-map-support "^0.5.6"
     yn "3.1.1"
-
-tslib@1.10.0:
-  version "1.10.0"
-  resolved "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz#c3c19f95973fb0a62973fb09d90d961ee43e5c8a"
-  integrity sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==
 
 tslib@1.11.1, tslib@^1.10.0, tslib@^1.8.1, tslib@^1.9.0:
   version "1.11.1"


### PR DESCRIPTION
This hack is no longer needed as of `rollup-plugin-typescript2` version 0.26.0 and we are on 0.27.0.

`yarn build` and `yarn build:exp` succeeded after removal.

https://github.com/ezolenko/rollup-plugin-typescript2/pull/203