### PR TITLE
Standardize auth-next style

### DIFF
--- a/packages-exp/auth-exp/src/api/account_management/account.test.ts
+++ b/packages-exp/auth-exp/src/api/account_management/account.test.ts
@@ -28,7 +28,7 @@ import { deleteAccount, deleteLinkedAccounts, getAccountInfo } from './account';
 
 use(chaiAsPromised);
 
-describe('deleteAccount', () => {
+describe('api/account_management/deleteAccount', () => {
   const request = {
     idToken: 'id-token'
   };
@@ -73,7 +73,7 @@ describe('deleteAccount', () => {
   });
 });
 
-describe('deleteLinkedAccounts', () => {
+describe('api/account_management/deleteLinkedAccounts', () => {
   const request = {
     idToken: 'id-token',
     deleteProvider: [ProviderId.GOOGLE]
@@ -128,7 +128,7 @@ describe('deleteLinkedAccounts', () => {
   });
 });
 
-describe('getAccountInfo', () => {
+describe('api/account_management/getAccountInfo', () => {
   const request = {
     idToken: 'id-token'
   };

--- a/packages-exp/auth-exp/src/api/account_management/account.ts
+++ b/packages-exp/auth-exp/src/api/account_management/account.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { Endpoint, HttpMethod, performApiRequest } from '../';
+import { Endpoint, HttpMethod, _performApiRequest } from '../';
 import { Auth } from '../../model/auth';
 import { APIMFAInfo } from '../../model/id_token';
 
@@ -27,7 +27,7 @@ export async function deleteAccount(
   auth: Auth,
   request: DeleteAccountRequest
 ): Promise<void> {
-  return performApiRequest<DeleteAccountRequest, void>(
+  return _performApiRequest<DeleteAccountRequest, void>(
     auth,
     HttpMethod.POST,
     Endpoint.DELETE_ACCOUNT,
@@ -57,7 +57,7 @@ export async function deleteLinkedAccounts(
   auth: Auth,
   request: DeleteLinkedAccountsRequest
 ): Promise<DeleteLinkedAccountsResponse> {
-  return performApiRequest<
+  return _performApiRequest<
     DeleteLinkedAccountsRequest,
     DeleteLinkedAccountsResponse
   >(auth, HttpMethod.POST, Endpoint.SET_ACCOUNT_INFO, request);
@@ -90,7 +90,7 @@ export async function getAccountInfo(
   auth: Auth,
   request: GetAccountInfoRequest
 ): Promise<GetAccountInfoResponse> {
-  return performApiRequest<GetAccountInfoRequest, GetAccountInfoResponse>(
+  return _performApiRequest<GetAccountInfoRequest, GetAccountInfoResponse>(
     auth,
     HttpMethod.POST,
     Endpoint.GET_ACCOUNT_INFO,

--- a/packages-exp/auth-exp/src/api/account_management/email_and_password.test.ts
+++ b/packages-exp/auth-exp/src/api/account_management/email_and_password.test.ts
@@ -27,7 +27,7 @@ import { resetPassword, updateEmailPassword } from './email_and_password';
 
 use(chaiAsPromised);
 
-describe('resetPassword', () => {
+describe('api/account_management/resetPassword', () => {
   const request = {
     oobCode: 'oob-code',
     newPassword: 'new-password'
@@ -76,7 +76,7 @@ describe('resetPassword', () => {
   });
 });
 
-describe('updateEmailPassword', () => {
+describe('api/account_management/updateEmailPassword', () => {
   const request = {
     idToken: 'id-token',
     returnSecureToken: true,

--- a/packages-exp/auth-exp/src/api/account_management/email_and_password.ts
+++ b/packages-exp/auth-exp/src/api/account_management/email_and_password.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { Endpoint, HttpMethod, performApiRequest } from '..';
+import { Endpoint, HttpMethod, _performApiRequest } from '..';
 import { Operation } from '../../model/action_code_info';
 import { Auth } from '../../model/auth';
 import { IdTokenResponse } from '../../model/id_token';
@@ -35,7 +35,7 @@ export async function resetPassword(
   auth: Auth,
   request: ResetPasswordRequest
 ): Promise<ResetPasswordResponse> {
-  return performApiRequest<ResetPasswordRequest, ResetPasswordResponse>(
+  return _performApiRequest<ResetPasswordRequest, ResetPasswordResponse>(
     auth,
     HttpMethod.POST,
     Endpoint.RESET_PASSWORD,
@@ -55,7 +55,7 @@ export async function updateEmailPassword(
   auth: Auth,
   request: UpdateEmailPasswordRequest
 ): Promise<UpdateEmailPasswordResponse> {
-  return performApiRequest<
+  return _performApiRequest<
     UpdateEmailPasswordRequest,
     UpdateEmailPasswordResponse
   >(auth, HttpMethod.POST, Endpoint.SET_ACCOUNT_INFO, request);

--- a/packages-exp/auth-exp/src/api/account_management/mfa.test.ts
+++ b/packages-exp/auth-exp/src/api/account_management/mfa.test.ts
@@ -27,7 +27,7 @@ import { enrollPhoneMfa, startEnrollPhoneMfa, withdrawMfa } from './mfa';
 
 use(chaiAsPromised);
 
-describe('startEnrollPhoneMfa', () => {
+describe('api/account_management/startEnrollPhoneMfa', () => {
   const request = {
     idToken: 'id-token',
     phoneEnrollmentInfo: {
@@ -81,7 +81,7 @@ describe('startEnrollPhoneMfa', () => {
   });
 });
 
-describe('enrollPhoneMfa', () => {
+describe('api/account_management/enrollPhoneMfa', () => {
   const request = {
     phoneVerificationInfo: {
       temporaryProof: 'temporary-proof',
@@ -136,7 +136,7 @@ describe('enrollPhoneMfa', () => {
   });
 });
 
-describe('withdrawMfa', () => {
+describe('api/account_management/withdrawMfa', () => {
   const request = {
     idToken: 'id-token',
     mfaEnrollmentId: 'mfa-enrollment-id'

--- a/packages-exp/auth-exp/src/api/account_management/mfa.ts
+++ b/packages-exp/auth-exp/src/api/account_management/mfa.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { Endpoint, HttpMethod, performApiRequest } from '..';
+import { Endpoint, HttpMethod, _performApiRequest } from '..';
 import { Auth } from '../../model/auth';
 import { IdTokenResponse } from '../../model/id_token';
 import { SignInWithPhoneNumberRequest } from '../authentication/sms';
@@ -39,7 +39,7 @@ export function startEnrollPhoneMfa(
   auth: Auth,
   request: StartPhoneMfaEnrollmentRequest
 ): Promise<StartPhoneMfaEnrollmentResponse> {
-  return performApiRequest<
+  return _performApiRequest<
     StartPhoneMfaEnrollmentRequest,
     StartPhoneMfaEnrollmentResponse
   >(auth, HttpMethod.POST, Endpoint.START_PHONE_MFA_ENROLLMENT, request);
@@ -55,7 +55,7 @@ export function enrollPhoneMfa(
   auth: Auth,
   request: PhoneMfaEnrollmentRequest
 ): Promise<PhoneMfaEnrollmentResponse> {
-  return performApiRequest<
+  return _performApiRequest<
     PhoneMfaEnrollmentRequest,
     PhoneMfaEnrollmentResponse
   >(auth, HttpMethod.POST, Endpoint.FINALIZE_PHONE_MFA_ENROLLMENT, request);
@@ -72,7 +72,7 @@ export function withdrawMfa(
   auth: Auth,
   request: WithdrawMfaRequest
 ): Promise<WithdrawMfaResponse> {
-  return performApiRequest<WithdrawMfaRequest, WithdrawMfaResponse>(
+  return _performApiRequest<WithdrawMfaRequest, WithdrawMfaResponse>(
     auth,
     HttpMethod.POST,
     Endpoint.WITHDRAW_MFA,

--- a/packages-exp/auth-exp/src/api/account_management/profile.test.ts
+++ b/packages-exp/auth-exp/src/api/account_management/profile.test.ts
@@ -27,7 +27,7 @@ import { updateProfile } from './profile';
 
 use(chaiAsPromised);
 
-describe('updateProfile', () => {
+describe('api/account_management/updateProfile', () => {
   const request = {
     idToken: 'my-token',
     email: 'test@foo.com',

--- a/packages-exp/auth-exp/src/api/account_management/profile.ts
+++ b/packages-exp/auth-exp/src/api/account_management/profile.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { Endpoint, HttpMethod, performApiRequest } from '..';
+import { Endpoint, HttpMethod, _performApiRequest } from '..';
 import { Auth } from '../../model/auth';
 import { IdTokenResponse } from '../../model/id_token';
 
@@ -34,7 +34,7 @@ export async function updateProfile(
   auth: Auth,
   request: UpdateProfileRequest
 ): Promise<UpdateProfileResponse> {
-  return performApiRequest<UpdateProfileRequest, UpdateProfileResponse>(
+  return _performApiRequest<UpdateProfileRequest, UpdateProfileResponse>(
     auth,
     HttpMethod.POST,
     Endpoint.SET_ACCOUNT_INFO,

--- a/packages-exp/auth-exp/src/api/authentication/create_auth_uri.test.ts
+++ b/packages-exp/auth-exp/src/api/authentication/create_auth_uri.test.ts
@@ -27,7 +27,7 @@ import { createAuthUri } from './create_auth_uri';
 
 use(chaiAsPromised);
 
-describe('createAuthUri', () => {
+describe('api/authentication/createAuthUri', () => {
   const request = {
     identifier: 'my-id',
     continueUri: 'example.com/redirectUri'

--- a/packages-exp/auth-exp/src/api/authentication/create_auth_uri.ts
+++ b/packages-exp/auth-exp/src/api/authentication/create_auth_uri.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { Endpoint, HttpMethod, performApiRequest } from '..';
+import { Endpoint, HttpMethod, _performApiRequest } from '..';
 import { Auth } from '../../model/auth';
 
 export interface CreateAuthUriRequest {
@@ -31,7 +31,7 @@ export async function createAuthUri(
   auth: Auth,
   request: CreateAuthUriRequest
 ): Promise<CreateAuthUriResponse> {
-  return performApiRequest<CreateAuthUriRequest, CreateAuthUriResponse>(
+  return _performApiRequest<CreateAuthUriRequest, CreateAuthUriResponse>(
     auth,
     HttpMethod.POST,
     Endpoint.CREATE_AUTH_URI,

--- a/packages-exp/auth-exp/src/api/authentication/custom_token.test.ts
+++ b/packages-exp/auth-exp/src/api/authentication/custom_token.test.ts
@@ -28,7 +28,7 @@ import { signInWithCustomToken } from './custom_token';
 
 use(chaiAsPromised);
 
-describe('signInWithCustomToken', () => {
+describe('api/authentication/signInWithCustomToken', () => {
   const request = {
     token: 'my-token'
   };

--- a/packages-exp/auth-exp/src/api/authentication/custom_token.ts
+++ b/packages-exp/auth-exp/src/api/authentication/custom_token.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { Endpoint, HttpMethod, performSignInRequest } from '..';
+import { Endpoint, HttpMethod, _performSignInRequest } from '..';
 import { Auth } from '../../model/auth';
 import { IdTokenResponse } from '../../model/id_token';
 
@@ -29,7 +29,7 @@ export async function signInWithCustomToken(
   auth: Auth,
   request: SignInWithCustomTokenRequest
 ): Promise<SignInWithCustomTokenResponse> {
-  return performSignInRequest<
+  return _performSignInRequest<
     SignInWithCustomTokenRequest,
     SignInWithCustomTokenResponse
   >(auth, HttpMethod.POST, Endpoint.SIGN_IN_WITH_CUSTOM_TOKEN, request);

--- a/packages-exp/auth-exp/src/api/authentication/email_and_password.test.ts
+++ b/packages-exp/auth-exp/src/api/authentication/email_and_password.test.ts
@@ -36,7 +36,7 @@ import { Operation } from '../../model/action_code_info';
 
 use(chaiAsPromised);
 
-describe('signInWithPassword', () => {
+describe('api/authentication/signInWithPassword', () => {
   const request = {
     returnSecureToken: true,
     email: 'test@foo.com',
@@ -88,153 +88,151 @@ describe('signInWithPassword', () => {
   });
 });
 
-describe('sendOobCode', () => {
-  context('VERIFY_EMAIL', () => {
-    const request: VerifyEmailRequest = {
-      requestType: Operation.VERIFY_EMAIL,
-      idToken: 'my-token'
-    };
+describe('api/authentication/sendEmailVerification', () => {
+  const request: VerifyEmailRequest = {
+    requestType: Operation.VERIFY_EMAIL,
+    idToken: 'my-token'
+  };
 
-    beforeEach(mockFetch.setUp);
-    afterEach(mockFetch.tearDown);
+  beforeEach(mockFetch.setUp);
+  afterEach(mockFetch.tearDown);
 
-    it('should POST to the correct endpoint', async () => {
-      const mock = mockEndpoint(Endpoint.SEND_OOB_CODE, {
-        email: 'test@foo.com'
-      });
-
-      const response = await sendEmailVerification(mockAuth, request);
-      expect(response.email).to.eq('test@foo.com');
-      expect(mock.calls[0].request).to.eql(request);
-      expect(mock.calls[0].method).to.eq('POST');
-      expect(mock.calls[0].headers).to.eql({
-        'Content-Type': 'application/json',
-        'X-Client-Version': 'testSDK/0.0.0'
-      });
+  it('should POST to the correct endpoint', async () => {
+    const mock = mockEndpoint(Endpoint.SEND_OOB_CODE, {
+      email: 'test@foo.com'
     });
 
-    it('should handle errors', async () => {
-      const mock = mockEndpoint(
-        Endpoint.SEND_OOB_CODE,
-        {
-          error: {
-            code: 400,
-            message: ServerError.INVALID_EMAIL,
-            errors: [
-              {
-                message: ServerError.INVALID_EMAIL
-              }
-            ]
-          }
-        },
-        400
-      );
-
-      await expect(sendEmailVerification(mockAuth, request)).to.be.rejectedWith(
-        FirebaseError,
-        'Firebase: The email address is badly formatted. (auth/invalid-email).'
-      );
-      expect(mock.calls[0].request).to.eql(request);
+    const response = await sendEmailVerification(mockAuth, request);
+    expect(response.email).to.eq('test@foo.com');
+    expect(mock.calls[0].request).to.eql(request);
+    expect(mock.calls[0].method).to.eq('POST');
+    expect(mock.calls[0].headers).to.eql({
+      'Content-Type': 'application/json',
+      'X-Client-Version': 'testSDK/0.0.0'
     });
   });
 
-  context('PASSWORD_RESET', () => {
-    const request: PasswordResetRequest = {
-      requestType: Operation.PASSWORD_RESET,
+  it('should handle errors', async () => {
+    const mock = mockEndpoint(
+      Endpoint.SEND_OOB_CODE,
+      {
+        error: {
+          code: 400,
+          message: ServerError.INVALID_EMAIL,
+          errors: [
+            {
+              message: ServerError.INVALID_EMAIL
+            }
+          ]
+        }
+      },
+      400
+    );
+
+    await expect(sendEmailVerification(mockAuth, request)).to.be.rejectedWith(
+      FirebaseError,
+      'Firebase: The email address is badly formatted. (auth/invalid-email).'
+    );
+    expect(mock.calls[0].request).to.eql(request);
+  });
+});
+
+describe('api/authentication/sendPasswordResetEmail', () => {
+  const request: PasswordResetRequest = {
+    requestType: Operation.PASSWORD_RESET,
+    email: 'test@foo.com'
+  };
+
+  beforeEach(mockFetch.setUp);
+  afterEach(mockFetch.tearDown);
+
+  it('should POST to the correct endpoint', async () => {
+    const mock = mockEndpoint(Endpoint.SEND_OOB_CODE, {
       email: 'test@foo.com'
-    };
-
-    beforeEach(mockFetch.setUp);
-    afterEach(mockFetch.tearDown);
-
-    it('should POST to the correct endpoint', async () => {
-      const mock = mockEndpoint(Endpoint.SEND_OOB_CODE, {
-        email: 'test@foo.com'
-      });
-
-      const response = await sendPasswordResetEmail(mockAuth, request);
-      expect(response.email).to.eq('test@foo.com');
-      expect(mock.calls[0].request).to.eql(request);
-      expect(mock.calls[0].method).to.eq('POST');
-      expect(mock.calls[0].headers).to.eql({
-        'Content-Type': 'application/json',
-        'X-Client-Version': 'testSDK/0.0.0'
-      });
     });
 
-    it('should handle errors', async () => {
-      const mock = mockEndpoint(
-        Endpoint.SEND_OOB_CODE,
-        {
-          error: {
-            code: 400,
-            message: ServerError.INVALID_EMAIL,
-            errors: [
-              {
-                message: ServerError.INVALID_EMAIL
-              }
-            ]
-          }
-        },
-        400
-      );
-
-      await expect(
-        sendPasswordResetEmail(mockAuth, request)
-      ).to.be.rejectedWith(
-        FirebaseError,
-        'Firebase: The email address is badly formatted. (auth/invalid-email).'
-      );
-      expect(mock.calls[0].request).to.eql(request);
+    const response = await sendPasswordResetEmail(mockAuth, request);
+    expect(response.email).to.eq('test@foo.com');
+    expect(mock.calls[0].request).to.eql(request);
+    expect(mock.calls[0].method).to.eq('POST');
+    expect(mock.calls[0].headers).to.eql({
+      'Content-Type': 'application/json',
+      'X-Client-Version': 'testSDK/0.0.0'
     });
   });
 
-  context('EMAIL_SIGNIN', () => {
-    const request: EmailSignInRequest = {
-      requestType: Operation.EMAIL_SIGNIN,
+  it('should handle errors', async () => {
+    const mock = mockEndpoint(
+      Endpoint.SEND_OOB_CODE,
+      {
+        error: {
+          code: 400,
+          message: ServerError.INVALID_EMAIL,
+          errors: [
+            {
+              message: ServerError.INVALID_EMAIL
+            }
+          ]
+        }
+      },
+      400
+    );
+
+    await expect(
+      sendPasswordResetEmail(mockAuth, request)
+    ).to.be.rejectedWith(
+      FirebaseError,
+      'Firebase: The email address is badly formatted. (auth/invalid-email).'
+    );
+    expect(mock.calls[0].request).to.eql(request);
+  });
+});
+
+describe('api/authentication/sendSignInLinkToEmail', () => {
+  const request: EmailSignInRequest = {
+    requestType: Operation.EMAIL_SIGNIN,
+    email: 'test@foo.com'
+  };
+
+  beforeEach(mockFetch.setUp);
+  afterEach(mockFetch.tearDown);
+
+  it('should POST to the correct endpoint', async () => {
+    const mock = mockEndpoint(Endpoint.SEND_OOB_CODE, {
       email: 'test@foo.com'
-    };
-
-    beforeEach(mockFetch.setUp);
-    afterEach(mockFetch.tearDown);
-
-    it('should POST to the correct endpoint', async () => {
-      const mock = mockEndpoint(Endpoint.SEND_OOB_CODE, {
-        email: 'test@foo.com'
-      });
-
-      const response = await sendSignInLinkToEmail(mockAuth, request);
-      expect(response.email).to.eq('test@foo.com');
-      expect(mock.calls[0].request).to.eql(request);
-      expect(mock.calls[0].method).to.eq('POST');
-      expect(mock.calls[0].headers).to.eql({
-        'Content-Type': 'application/json',
-        'X-Client-Version': 'testSDK/0.0.0'
-      });
     });
 
-    it('should handle errors', async () => {
-      const mock = mockEndpoint(
-        Endpoint.SEND_OOB_CODE,
-        {
-          error: {
-            code: 400,
-            message: ServerError.INVALID_EMAIL,
-            errors: [
-              {
-                message: ServerError.INVALID_EMAIL
-              }
-            ]
-          }
-        },
-        400
-      );
-
-      await expect(sendSignInLinkToEmail(mockAuth, request)).to.be.rejectedWith(
-        FirebaseError,
-        'Firebase: The email address is badly formatted. (auth/invalid-email).'
-      );
-      expect(mock.calls[0].request).to.eql(request);
+    const response = await sendSignInLinkToEmail(mockAuth, request);
+    expect(response.email).to.eq('test@foo.com');
+    expect(mock.calls[0].request).to.eql(request);
+    expect(mock.calls[0].method).to.eq('POST');
+    expect(mock.calls[0].headers).to.eql({
+      'Content-Type': 'application/json',
+      'X-Client-Version': 'testSDK/0.0.0'
     });
+  });
+
+  it('should handle errors', async () => {
+    const mock = mockEndpoint(
+      Endpoint.SEND_OOB_CODE,
+      {
+        error: {
+          code: 400,
+          message: ServerError.INVALID_EMAIL,
+          errors: [
+            {
+              message: ServerError.INVALID_EMAIL
+            }
+          ]
+        }
+      },
+      400
+    );
+
+    await expect(sendSignInLinkToEmail(mockAuth, request)).to.be.rejectedWith(
+      FirebaseError,
+      'Firebase: The email address is badly formatted. (auth/invalid-email).'
+    );
+    expect(mock.calls[0].request).to.eql(request);
   });
 });

--- a/packages-exp/auth-exp/src/api/authentication/email_and_password.test.ts
+++ b/packages-exp/auth-exp/src/api/authentication/email_and_password.test.ts
@@ -178,9 +178,7 @@ describe('api/authentication/sendPasswordResetEmail', () => {
       400
     );
 
-    await expect(
-      sendPasswordResetEmail(mockAuth, request)
-    ).to.be.rejectedWith(
+    await expect(sendPasswordResetEmail(mockAuth, request)).to.be.rejectedWith(
       FirebaseError,
       'Firebase: The email address is badly formatted. (auth/invalid-email).'
     );

--- a/packages-exp/auth-exp/src/api/authentication/email_and_password.ts
+++ b/packages-exp/auth-exp/src/api/authentication/email_and_password.ts
@@ -18,8 +18,8 @@
 import {
   Endpoint,
   HttpMethod,
-  performApiRequest,
-  performSignInRequest
+  _performApiRequest,
+  _performSignInRequest
 } from '..';
 import { Auth } from '../../model/auth';
 import { IdToken, IdTokenResponse } from '../../model/id_token';
@@ -40,7 +40,7 @@ export async function signInWithPassword(
   auth: Auth,
   request: SignInWithPasswordRequest
 ): Promise<SignInWithPasswordResponse> {
-  return performSignInRequest<
+  return _performSignInRequest<
     SignInWithPasswordRequest,
     SignInWithPasswordResponse
   >(auth, HttpMethod.POST, Endpoint.SIGN_IN_WITH_PASSWORD, request);
@@ -89,7 +89,7 @@ async function sendOobCode(
   auth: Auth,
   request: GetOobCodeRequest
 ): Promise<GetOobCodeResponse> {
-  return performApiRequest<GetOobCodeRequest, GetOobCodeResponse>(
+  return _performApiRequest<GetOobCodeRequest, GetOobCodeResponse>(
     auth,
     HttpMethod.POST,
     Endpoint.SEND_OOB_CODE,

--- a/packages-exp/auth-exp/src/api/authentication/email_link.test.ts
+++ b/packages-exp/auth-exp/src/api/authentication/email_link.test.ts
@@ -27,7 +27,7 @@ import { signInWithEmailLink } from './email_link';
 
 use(chaiAsPromised);
 
-describe('signInWithEmailLink', () => {
+describe('api/authentication/signInWithEmailLink', () => {
   const request = {
     email: 'foo@bar.com',
     oobCode: 'my-code'

--- a/packages-exp/auth-exp/src/api/authentication/email_link.ts
+++ b/packages-exp/auth-exp/src/api/authentication/email_link.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { Endpoint, HttpMethod, performSignInRequest } from '..';
+import { Endpoint, HttpMethod, _performSignInRequest } from '..';
 import { Auth } from '../../model/auth';
 import { IdTokenResponse } from '../../model/id_token';
 
@@ -33,7 +33,7 @@ export async function signInWithEmailLink(
   auth: Auth,
   request: SignInWithEmailLinkRequest
 ): Promise<SignInWithEmailLinkResponse> {
-  return performSignInRequest<
+  return _performSignInRequest<
     SignInWithEmailLinkRequest,
     SignInWithEmailLinkResponse
   >(auth, HttpMethod.POST, Endpoint.SIGN_IN_WITH_EMAIL_LINK, request);

--- a/packages-exp/auth-exp/src/api/authentication/idp.test.ts
+++ b/packages-exp/auth-exp/src/api/authentication/idp.test.ts
@@ -27,7 +27,7 @@ import { signInWithIdp } from './idp';
 
 use(chaiAsPromised);
 
-describe('signInWithIdp', () => {
+describe('api/authentication/signInWithIdp', () => {
   const request = {
     returnSecureToken: true,
     requestUri: 'request-uri',

--- a/packages-exp/auth-exp/src/api/authentication/idp.ts
+++ b/packages-exp/auth-exp/src/api/authentication/idp.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { Endpoint, HttpMethod, performSignInRequest } from '..';
+import { Endpoint, HttpMethod, _performSignInRequest } from '..';
 import { Auth } from '../../model/auth';
 import { IdToken, IdTokenResponse } from '../../model/id_token';
 
@@ -42,7 +42,7 @@ export async function signInWithIdp(
   auth: Auth,
   request: SignInWithIdpRequest
 ): Promise<SignInWithIdpResponse> {
-  return performSignInRequest<SignInWithIdpRequest, SignInWithIdpResponse>(
+  return _performSignInRequest<SignInWithIdpRequest, SignInWithIdpResponse>(
     auth,
     HttpMethod.POST,
     Endpoint.SIGN_IN_WITH_IDP,

--- a/packages-exp/auth-exp/src/api/authentication/mfa.test.ts
+++ b/packages-exp/auth-exp/src/api/authentication/mfa.test.ts
@@ -27,7 +27,7 @@ import { finalizeSignInPhoneMfa, startSignInPhoneMfa } from './mfa';
 
 use(chaiAsPromised);
 
-describe('startSignInPhoneMfa', () => {
+describe('api/authentication/startSignInPhoneMfa', () => {
   const request = {
     mfaPendingCredential: 'my-creds',
     mfaEnrollmentId: 'my-enrollment-id',
@@ -81,7 +81,7 @@ describe('startSignInPhoneMfa', () => {
   });
 });
 
-describe('finalizeSignInPhoneMfa', () => {
+describe('api/authentication/finalizeSignInPhoneMfa', () => {
   const request = {
     mfaPendingCredential: 'pending-cred',
     phoneVerificationInfo: {

--- a/packages-exp/auth-exp/src/api/authentication/mfa.ts
+++ b/packages-exp/auth-exp/src/api/authentication/mfa.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { Endpoint, HttpMethod, performApiRequest } from '..';
+import { Endpoint, HttpMethod, _performApiRequest } from '..';
 import { Auth } from '../../model/auth';
 import { IdTokenResponse } from '../../model/id_token';
 import { SignInWithIdpResponse } from './idp';
@@ -42,7 +42,7 @@ export function startSignInPhoneMfa(
   auth: Auth,
   request: StartPhoneMfaSignInRequest
 ): Promise<StartPhoneMfaSignInResponse> {
-  return performApiRequest<
+  return _performApiRequest<
     StartPhoneMfaSignInRequest,
     StartPhoneMfaSignInResponse
   >(auth, HttpMethod.POST, Endpoint.START_PHONE_MFA_SIGN_IN, request);
@@ -59,7 +59,7 @@ export function finalizeSignInPhoneMfa(
   auth: Auth,
   request: FinalizePhoneMfaSignInRequest
 ): Promise<FinalizePhoneMfaSignInResponse> {
-  return performApiRequest<
+  return _performApiRequest<
     FinalizePhoneMfaSignInRequest,
     FinalizePhoneMfaSignInResponse
   >(auth, HttpMethod.POST, Endpoint.FINALIZE_PHONE_MFA_SIGN_IN, request);

--- a/packages-exp/auth-exp/src/api/authentication/recaptcha.test.ts
+++ b/packages-exp/auth-exp/src/api/authentication/recaptcha.test.ts
@@ -27,7 +27,7 @@ import { getRecaptchaParams } from './recaptcha';
 
 use(chaiAsPromised);
 
-describe('getRecaptchaParams', () => {
+describe('api/authentication/getRecaptchaParams', () => {
   beforeEach(mockFetch.setUp);
   afterEach(mockFetch.tearDown);
 

--- a/packages-exp/auth-exp/src/api/authentication/recaptcha.ts
+++ b/packages-exp/auth-exp/src/api/authentication/recaptcha.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { Endpoint, HttpMethod, performApiRequest } from '..';
+import { Endpoint, HttpMethod, _performApiRequest } from '..';
 import { Auth } from '../../model/auth';
 
 interface GetRecaptchaParamResponse {
@@ -25,7 +25,7 @@ interface GetRecaptchaParamResponse {
 export async function getRecaptchaParams(auth: Auth): Promise<string> {
   return (
     (
-      await performApiRequest<void, GetRecaptchaParamResponse>(
+      await _performApiRequest<void, GetRecaptchaParamResponse>(
         auth,
         HttpMethod.GET,
         Endpoint.GET_RECAPTCHA_PARAM

--- a/packages-exp/auth-exp/src/api/authentication/sign_up.test.ts
+++ b/packages-exp/auth-exp/src/api/authentication/sign_up.test.ts
@@ -27,7 +27,7 @@ import { signUp } from './sign_up';
 
 use(chaiAsPromised);
 
-describe('signUp', () => {
+describe('api/authentication/signUp', () => {
   const request = {
     returnSecureToken: true,
     email: 'test@foo.com',

--- a/packages-exp/auth-exp/src/api/authentication/sign_up.ts
+++ b/packages-exp/auth-exp/src/api/authentication/sign_up.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { Endpoint, HttpMethod, performSignInRequest } from '..';
+import { Endpoint, HttpMethod, _performSignInRequest } from '..';
 import { Auth } from '../../model/auth';
 import { IdTokenResponse } from '../../model/id_token';
 
@@ -34,7 +34,7 @@ export async function signUp(
   auth: Auth,
   request: SignUpRequest
 ): Promise<SignUpResponse> {
-  return performSignInRequest<SignUpRequest, SignUpResponse>(
+  return _performSignInRequest<SignUpRequest, SignUpResponse>(
     auth,
     HttpMethod.POST,
     Endpoint.SIGN_UP,

--- a/packages-exp/auth-exp/src/api/authentication/sms.test.ts
+++ b/packages-exp/auth-exp/src/api/authentication/sms.test.ts
@@ -33,7 +33,7 @@ import {
 
 use(chaiAsPromised);
 
-describe('sendPhoneVerificationCode', () => {
+describe('api/authentication/sendPhoneVerificationCode', () => {
   const request = {
     phoneNumber: '123456789',
     recaptchaToken: 'captchad'
@@ -84,7 +84,7 @@ describe('sendPhoneVerificationCode', () => {
   });
 });
 
-describe('signInWithPhoneNumber', () => {
+describe('api/authentication/signInWithPhoneNumber', () => {
   const request = {
     temporaryProof: 'my-proof',
     phoneNumber: '1234567',
@@ -142,7 +142,7 @@ describe('signInWithPhoneNumber', () => {
   });
 });
 
-describe('linkWithPhoneNumber', () => {
+describe('api/authentication/linkWithPhoneNumber', () => {
   const request = {
     idToken: 'id-token',
     temporaryProof: 'my-proof',
@@ -201,7 +201,7 @@ describe('linkWithPhoneNumber', () => {
   });
 });
 
-describe('verifyPhoneNumberForExisting', () => {
+describe('api/authentication/verifyPhoneNumberForExisting', () => {
   const request = {
     temporaryProof: 'my-proof',
     phoneNumber: '1234567',

--- a/packages-exp/auth-exp/src/api/authentication/sms.ts
+++ b/packages-exp/auth-exp/src/api/authentication/sms.ts
@@ -18,8 +18,8 @@
 import {
   Endpoint,
   HttpMethod,
-  performApiRequest,
-  performSignInRequest
+  _performApiRequest,
+  _performSignInRequest
 } from '..';
 import { AuthErrorCode } from '../../core/errors';
 import { Auth } from '../../model/auth';
@@ -39,7 +39,7 @@ export async function sendPhoneVerificationCode(
   auth: Auth,
   request: SendPhoneVerificationCodeRequest
 ): Promise<SendPhoneVerificationCodeResponse> {
-  return performApiRequest<
+  return _performApiRequest<
     SendPhoneVerificationCodeRequest,
     SendPhoneVerificationCodeResponse
   >(auth, HttpMethod.POST, Endpoint.SEND_VERIFICATION_CODE, request);
@@ -66,7 +66,7 @@ export async function signInWithPhoneNumber(
   auth: Auth,
   request: SignInWithPhoneNumberRequest
 ): Promise<SignInWithPhoneNumberResponse> {
-  return performSignInRequest<
+  return _performSignInRequest<
     SignInWithPhoneNumberRequest,
     SignInWithPhoneNumberResponse
   >(auth, HttpMethod.POST, Endpoint.SIGN_IN_WITH_PHONE_NUMBER, request);
@@ -76,7 +76,7 @@ export async function linkWithPhoneNumber(
   auth: Auth,
   request: LinkWithPhoneNumberRequest
 ): Promise<SignInWithPhoneNumberResponse> {
-  return performSignInRequest<
+  return _performSignInRequest<
     LinkWithPhoneNumberRequest,
     SignInWithPhoneNumberResponse
   >(auth, HttpMethod.POST, Endpoint.SIGN_IN_WITH_PHONE_NUMBER, request);
@@ -101,7 +101,7 @@ export async function verifyPhoneNumberForExisting(
     ...request,
     operation: 'REAUTH'
   };
-  return performSignInRequest<
+  return _performSignInRequest<
     VerifyPhoneNumberForExistingRequest,
     SignInWithPhoneNumberResponse
   >(

--- a/packages-exp/auth-exp/src/api/index.test.ts
+++ b/packages-exp/auth-exp/src/api/index.test.ts
@@ -23,7 +23,7 @@ import {
   DEFAULT_API_TIMEOUT_MS,
   Endpoint,
   HttpMethod,
-  performApiRequest
+  _performApiRequest
 } from '.';
 import { mockEndpoint } from '../../test/api/helper';
 import { mockAuth } from '../../test/mock_auth';
@@ -33,7 +33,7 @@ import { AuthErrorCode } from '../core/errors';
 
 use(chaiAsPromised);
 
-describe('performApiRequest', () => {
+describe('api/_performApiRequest', () => {
   const request = {
     requestKey: 'request-value'
   };
@@ -48,7 +48,7 @@ describe('performApiRequest', () => {
 
     it('should set the correct request, method and HTTP Headers', async () => {
       const mock = mockEndpoint(Endpoint.SIGN_UP, serverResponse);
-      const response = await performApiRequest<
+      const response = await _performApiRequest<
         typeof request,
         typeof serverResponse
       >(mockAuth, HttpMethod.POST, Endpoint.SIGN_UP, request);
@@ -78,7 +78,7 @@ describe('performApiRequest', () => {
         },
         400
       );
-      const promise = performApiRequest<typeof request, typeof serverResponse>(
+      const promise = _performApiRequest<typeof request, typeof serverResponse>(
         mockAuth,
         HttpMethod.POST,
         Endpoint.SIGN_UP,
@@ -107,7 +107,7 @@ describe('performApiRequest', () => {
         },
         400
       );
-      const promise = performApiRequest<typeof request, typeof serverResponse>(
+      const promise = _performApiRequest<typeof request, typeof serverResponse>(
         mockAuth,
         HttpMethod.POST,
         Endpoint.SIGN_UP,
@@ -136,7 +136,7 @@ describe('performApiRequest', () => {
         },
         400
       );
-      const promise = performApiRequest<typeof request, typeof serverResponse>(
+      const promise = _performApiRequest<typeof request, typeof serverResponse>(
         mockAuth,
         HttpMethod.POST,
         Endpoint.SIGN_UP,
@@ -169,7 +169,7 @@ describe('performApiRequest', () => {
       fetchStub.callsFake(() => {
         return new Promise<never>(() => null);
       });
-      const promise = performApiRequest<typeof request, never>(
+      const promise = _performApiRequest<typeof request, never>(
         mockAuth,
         HttpMethod.POST,
         Endpoint.SIGN_UP,
@@ -189,7 +189,7 @@ describe('performApiRequest', () => {
           reject(new Error('network error'))
         );
       });
-      const promise = performApiRequest<typeof request, never>(
+      const promise = _performApiRequest<typeof request, never>(
         mockAuth,
         HttpMethod.POST,
         Endpoint.SIGN_UP,

--- a/packages-exp/auth-exp/src/api/index.ts
+++ b/packages-exp/auth-exp/src/api/index.ts
@@ -56,7 +56,7 @@ export enum Endpoint {
 
 export const DEFAULT_API_TIMEOUT_MS = new Delay(30_000, 60_000);
 
-export async function performApiRequest<T, V>(
+export async function _performApiRequest<T, V>(
   auth: Auth,
   method: HttpMethod,
   path: Endpoint,
@@ -131,14 +131,14 @@ export async function performApiRequest<T, V>(
   }
 }
 
-export async function performSignInRequest<T, V extends IdTokenResponse>(
+export async function _performSignInRequest<T, V extends IdTokenResponse>(
   auth: Auth,
   method: HttpMethod,
   path: Endpoint,
   request?: T,
   customErrorMap: Partial<ServerErrorMap<ServerError>> = {}
 ): Promise<V> {
-  const serverResponse = await performApiRequest<T, V>(
+  const serverResponse = await _performApiRequest<T, V>(
     auth,
     method,
     path,

--- a/packages-exp/auth-exp/src/core/action_code_url.test.ts
+++ b/packages-exp/auth-exp/src/core/action_code_url.test.ts
@@ -20,8 +20,8 @@ import { ActionCodeURL } from './action_code_url';
 import { mockAuth } from '../../test/mock_auth';
 import { Operation } from '../model/action_code_info';
 
-describe('ActionCodeURL', () => {
-  describe('_fromLink', () => {
+describe('core/action_code_url', () => {
+  describe('._fromLink', () => {
     it('should parse correctly formatted links', () => {
       const continueUrl = 'https://www.example.com/path/to/file?a=1&b=2#c=3';
       const actionLink =

--- a/packages-exp/auth-exp/src/core/auth/auth_impl.test.ts
+++ b/packages-exp/auth-exp/src/core/auth/auth_impl.test.ts
@@ -29,7 +29,7 @@ import { Persistence } from '../persistence';
 import { browserLocalPersistence } from '../persistence/browser';
 import { inMemoryPersistence } from '../persistence/in_memory';
 import { PersistenceUserManager } from '../persistence/persistence_user_manager';
-import { ClientPlatform, getClientVersion } from '../util/version';
+import { ClientPlatform, _getClientVersion } from '../util/version';
 import {
   DEFAULT_API_HOST,
   DEFAULT_API_SCHEME,
@@ -47,7 +47,7 @@ const FAKE_APP: FirebaseApp = {
   automaticDataCollectionEnabled: false
 };
 
-describe('AuthImpl', () => {
+describe('core/auth/auth_impl', () => {
   let auth: Auth;
   let persistenceStub: sinon.SinonStubbedInstance<Persistence>;
 
@@ -253,7 +253,7 @@ describe('AuthImpl', () => {
   });
 });
 
-describe('initializeAuth', () => {
+describe('core/auth/initializeAuth', () => {
   afterEach(sinon.restore);
 
   it('throws an API error if key not provided', () => {
@@ -318,7 +318,7 @@ describe('initializeAuth', () => {
         authDomain: FAKE_APP.options.authDomain,
         apiHost: DEFAULT_API_HOST,
         apiScheme: DEFAULT_API_SCHEME,
-        sdkClientVersion: getClientVersion(ClientPlatform.BROWSER)
+        sdkClientVersion: _getClientVersion(ClientPlatform.BROWSER)
       });
     });
   });

--- a/packages-exp/auth-exp/src/core/auth/auth_impl.ts
+++ b/packages-exp/auth-exp/src/core/auth/auth_impl.ts
@@ -33,7 +33,7 @@ import { AuthErrorCode } from '../errors';
 import { Persistence } from '../persistence';
 import { PersistenceUserManager } from '../persistence/persistence_user_manager';
 import { assert } from '../util/assert';
-import { ClientPlatform, getClientVersion } from '../util/version';
+import { ClientPlatform, _getClientVersion } from '../util/version';
 
 interface AsyncAction {
   (): Promise<void>;
@@ -200,7 +200,7 @@ export function initializeAuth(
     authDomain,
     apiHost: DEFAULT_API_HOST,
     apiScheme: DEFAULT_API_SCHEME,
-    sdkClientVersion: getClientVersion(ClientPlatform.BROWSER)
+    sdkClientVersion: _getClientVersion(ClientPlatform.BROWSER)
   };
 
   return new AuthImpl(app.name, config, hierarchy);

--- a/packages-exp/auth-exp/src/core/errors.test.ts
+++ b/packages-exp/auth-exp/src/core/errors.test.ts
@@ -18,7 +18,7 @@
 import { expect } from 'chai';
 import { AuthErrorCode, AUTH_ERROR_FACTORY } from './errors';
 
-describe('AUTH_ERROR_FACTORY', () => {
+describe('core/AUTH_ERROR_FACTORY', () => {
   it('should create an Auth namespaced FirebaseError', () => {
     const error = AUTH_ERROR_FACTORY.create(AuthErrorCode.INTERNAL_ERROR, {
       appName: 'my-app'

--- a/packages-exp/auth-exp/src/core/persistence/persistence_user_manager.test.ts
+++ b/packages-exp/auth-exp/src/core/persistence/persistence_user_manager.test.ts
@@ -49,7 +49,7 @@ function makePersistence(
 }
 
 describe('core/persistence/persistence_user_manager', () => {
-  describe('create', () => {
+  describe('.create', () => {
     it('defaults to inMemory if no list provided', async () => {
       const manager = await PersistenceUserManager.create(mockAuth, []);
       expect(manager.persistence).to.eq(inMemoryPersistence);

--- a/packages-exp/auth-exp/src/core/strategies/email.test.ts
+++ b/packages-exp/auth-exp/src/core/strategies/email.test.ts
@@ -33,7 +33,7 @@ import { fetchSignInMethodsForEmail, sendEmailVerification } from './email';
 use(chaiAsPromised);
 use(sinonChai);
 
-describe('fetchSignInMethodsForEmail', () => {
+describe('core/strategies/fetchSignInMethodsForEmail', () => {
   const email = 'foo@bar.com';
   const expectedSignInMethods = [ProviderId.PASSWORD, ProviderId.GOOGLE];
 
@@ -48,7 +48,7 @@ describe('fetchSignInMethodsForEmail', () => {
     expect(response).to.eql(expectedSignInMethods);
     expect(mock.calls[0].request).to.eql({
       identifier: email,
-      continueUri: location.getCurrentUrl()
+      continueUri: location._getCurrentUrl()
     });
   });
 
@@ -56,7 +56,7 @@ describe('fetchSignInMethodsForEmail', () => {
     let locationStub: SinonStub;
 
     beforeEach(() => {
-      locationStub = stub(location, 'isHttpOrHttps');
+      locationStub = stub(location, '_isHttpOrHttps');
       locationStub.callsFake(() => false);
     });
 
@@ -98,7 +98,7 @@ describe('fetchSignInMethodsForEmail', () => {
   });
 });
 
-describe('sendEmailVerification', () => {
+describe('core/strategies/sendEmailVerification', () => {
   const email = 'foo@bar.com';
   const user = testUser('my-user-uid', email);
   const idToken = 'id-token';

--- a/packages-exp/auth-exp/src/core/strategies/email.ts
+++ b/packages-exp/auth-exp/src/core/strategies/email.ts
@@ -27,7 +27,7 @@ import {
 } from '../../model/action_code_settings';
 import { Auth } from '../../model/auth';
 import { User } from '../../model/user';
-import { getCurrentUrl, isHttpOrHttps } from '../util/location';
+import { _getCurrentUrl, _isHttpOrHttps } from '../util/location';
 
 export async function fetchSignInMethodsForEmail(
   auth: Auth,
@@ -36,7 +36,7 @@ export async function fetchSignInMethodsForEmail(
   // createAuthUri returns an error if continue URI is not http or https.
   // For environments like Cordova, Chrome extensions, native frameworks, file
   // systems, etc, use http://localhost as continue URL.
-  const continueUri = isHttpOrHttps() ? getCurrentUrl() : 'http://localhost';
+  const continueUri = _isHttpOrHttps() ? _getCurrentUrl() : 'http://localhost';
   const request: CreateAuthUriRequest = {
     identifier: email,
     continueUri

--- a/packages-exp/auth-exp/src/core/strategies/email_and_password.test.ts
+++ b/packages-exp/auth-exp/src/core/strategies/email_and_password.test.ts
@@ -35,7 +35,7 @@ import {
 use(chaiAsPromised);
 use(sinonChai);
 
-describe('sendPasswordResetEmail', () => {
+describe('core/strategies/sendPasswordResetEmail', () => {
   const email = 'foo@bar.com';
 
   beforeEach(mockFetch.setUp);
@@ -126,7 +126,7 @@ describe('sendPasswordResetEmail', () => {
   });
 });
 
-describe('confirmPasswordReset', () => {
+describe('core/strategies/confirmPasswordReset', () => {
   const oobCode = 'oob-code';
   const newPassword = 'new-password';
 
@@ -166,7 +166,7 @@ describe('confirmPasswordReset', () => {
   });
 });
 
-describe('checkActionCode', () => {
+describe('core/strategies/checkActionCode', () => {
   const oobCode = 'oob-code';
   const email = 'foo@bar.com';
   const newEmail = 'new@email.com';
@@ -241,7 +241,7 @@ describe('checkActionCode', () => {
   });
 });
 
-describe('verifyPasswordResetCode', () => {
+describe('core/strategies/verifyPasswordResetCode', () => {
   const oobCode = 'oob-code';
   const email = 'foo@bar.com';
 

--- a/packages-exp/auth-exp/src/core/strategies/email_link.test.ts
+++ b/packages-exp/auth-exp/src/core/strategies/email_link.test.ts
@@ -121,7 +121,7 @@ describe('core/strategies/sendSignInLinkToEmail', () => {
   });
 });
 
-describe('icore/strategies/isSignInWithEmailLink', () => {
+describe('core/strategies/isSignInWithEmailLink', () => {
   context('simple links', () => {
     it('should recognize sign in links', () => {
       const link =

--- a/packages-exp/auth-exp/src/core/strategies/email_link.test.ts
+++ b/packages-exp/auth-exp/src/core/strategies/email_link.test.ts
@@ -30,7 +30,7 @@ import { sendSignInLinkToEmail, isSignInWithEmailLink } from './email_link';
 use(chaiAsPromised);
 use(sinonChai);
 
-describe('sendSignInLinkToEmail', () => {
+describe('core/strategies/sendSignInLinkToEmail', () => {
   const email = 'foo@bar.com';
 
   beforeEach(mockFetch.setUp);
@@ -121,7 +121,7 @@ describe('sendSignInLinkToEmail', () => {
   });
 });
 
-describe('isSignInWithEmailLink', () => {
+describe('icore/strategies/isSignInWithEmailLink', () => {
   context('simple links', () => {
     it('should recognize sign in links', () => {
       const link =

--- a/packages-exp/auth-exp/src/core/user/reload.test.ts
+++ b/packages-exp/auth-exp/src/core/user/reload.test.ts
@@ -41,33 +41,33 @@ const BASIC_USER_INFO: UserInfo = {
   providerId: ProviderId.FIREBASE,
   uid: 'uid',
   email: 'email',
-  displayName: 'displayName',
-  phoneNumber: 'phoneNumber',
-  photoURL: 'photoURL'
+  displayName: 'display-name',
+  phoneNumber: 'phone-number',
+  photoURL: 'photo-url'
 };
 
 const BASIC_PROVIDER_USER_INFO: ProviderUserInfo = {
   providerId: ProviderId.FIREBASE,
   rawId: 'uid',
   email: 'email',
-  displayName: 'displayName',
-  phoneNumber: 'phoneNumber',
-  photoUrl: 'photoURL'
+  displayName: 'display-name',
+  phoneNumber: 'phone-number',
+  photoUrl: 'photo-url'
 };
 
-describe('reload()', () => {
+describe('core/user/reload', () => {
   beforeEach(fetch.setUp);
   afterEach(fetch.tearDown);
 
   it('sets all the new properties', async () => {
     const serverUser: APIUserInfo = {
-      localId: 'localId',
-      displayName: 'displayName',
-      photoUrl: 'photoURL',
+      localId: 'local-id',
+      displayName: 'display-name',
+      photoUrl: 'photo-url',
       email: 'email',
       emailVerified: true,
-      phoneNumber: 'phoneNumber',
-      tenantId: 'tenantId',
+      phoneNumber: 'phone-number',
+      tenantId: 'tenant-id',
       createdAt: 123,
       lastLoginAt: 456
     };
@@ -78,13 +78,13 @@ describe('reload()', () => {
 
     const user = testUser('abc', '', true);
     await _reloadWithoutSaving(user);
-    expect(user.uid).to.eq('localId');
-    expect(user.displayName).to.eq('displayName');
-    expect(user.photoURL).to.eq('photoURL');
+    expect(user.uid).to.eq('local-id');
+    expect(user.displayName).to.eq('display-name');
+    expect(user.photoURL).to.eq('photo-url');
     expect(user.email).to.eq('email');
     expect(user.emailVerified).to.be.true;
-    expect(user.phoneNumber).to.eq('phoneNumber');
-    expect(user.tenantId).to.eq('tenantId');
+    expect(user.phoneNumber).to.eq('phone-number');
+    expect(user.tenantId).to.eq('tenant-id');
     expect(user.metadata).to.eql({
       creationTime: '123',
       lastSignInTime: '456'

--- a/packages-exp/auth-exp/src/core/user/token_manager.test.ts
+++ b/packages-exp/auth-exp/src/core/user/token_manager.test.ts
@@ -112,7 +112,7 @@ describe('core/user/token_manager', () => {
     });
   });
 
-  describe('fromPlainObject', () => {
+  describe('.fromPlainObject', () => {
     const errorString =
       'Firebase: An internal AuthError has occurred. (auth/internal-error).';
 

--- a/packages-exp/auth-exp/src/core/user/user_impl.test.ts
+++ b/packages-exp/auth-exp/src/core/user/user_impl.test.ts
@@ -15,11 +15,9 @@
  * limitations under the License.
  */
 
+import { FirebaseError } from '@firebase/util';
 import { expect, use } from 'chai';
 import * as chaiAsPromised from 'chai-as-promised';
-
-import { FirebaseError } from '@firebase/util';
-
 import { mockAuth } from '../../../test/mock_auth';
 import { IdTokenResponse } from '../../model/id_token';
 import { StsTokenManager } from './token_manager';
@@ -35,7 +33,7 @@ describe('core/user/user_impl', () => {
     stsTokenManager = new StsTokenManager();
   });
 
-  describe('constructor', () => {
+  describe('.constructor', () => {
     it('attaches required fields', () => {
       const user = new UserImpl({ uid: 'uid', auth, stsTokenManager });
       expect(user.auth).to.eq(auth);
@@ -102,7 +100,7 @@ describe('core/user/user_impl', () => {
     });
   });
 
-  describe('fromPlainObject', () => {
+  describe('.fromPlainObject', () => {
     const errorString =
       'Firebase: An internal AuthError has occurred. (auth/internal-error).';
 

--- a/packages-exp/auth-exp/src/core/util/assert.ts
+++ b/packages-exp/auth-exp/src/core/util/assert.ts
@@ -16,7 +16,7 @@
  */
 
 import { AuthErrorCode, AUTH_ERROR_FACTORY } from '../errors';
-import { logError } from './log';
+import { _logError } from './log';
 
 /**
  * Unconditionally fails, throwing a developer facing INTERNAL_ERROR
@@ -54,7 +54,7 @@ export function debugFail(failure: string): never {
   // Log the failure in addition to throw an exception, just in case the
   // exception is swallowed.
   const message = `INTERNAL ASSERTION FAILED: ` + failure;
-  logError(message);
+  _logError(message);
 
   // NOTE: We don't use FirebaseError here because these are internal failures
   // that cannot be handled by the user. (Also it would create a circular

--- a/packages-exp/auth-exp/src/core/util/browser.test.ts
+++ b/packages-exp/auth-exp/src/core/util/browser.test.ts
@@ -16,84 +16,84 @@
  */
 
 import { expect } from 'chai';
-import { getBrowserName, BrowserName } from './browser';
+import { _getBrowserName, BrowserName } from './browser';
 
-describe('getBrowserName', () => {
+describe('core/util/_getBrowserName', () => {
   it('should recognize Opera', () => {
     const userAgent =
       'Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/49.0.2623.110 Safari/537.36 OPR/36.0.2130.74';
-    expect(getBrowserName(userAgent)).to.eq(BrowserName.OPERA);
+    expect(_getBrowserName(userAgent)).to.eq(BrowserName.OPERA);
   });
 
   it('should recognize IE', () => {
     const userAgent =
       'Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Trident/5.0; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center PC 6.0; .NET4.0C)';
-    expect(getBrowserName(userAgent)).to.eq(BrowserName.IE);
+    expect(_getBrowserName(userAgent)).to.eq(BrowserName.IE);
   });
 
   it('should recognize Edge', () => {
     const userAgent =
       'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Safari/537.36 Edge/12.10240';
-    expect(getBrowserName(userAgent)).to.eq(BrowserName.EDGE);
+    expect(_getBrowserName(userAgent)).to.eq(BrowserName.EDGE);
   });
 
   it('should recognize Firefox', () => {
     const userAgent =
       'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:46.0) Gecko/20100101 Firefox/46.0';
-    expect(getBrowserName(userAgent)).to.eq(BrowserName.FIREFOX);
+    expect(_getBrowserName(userAgent)).to.eq(BrowserName.FIREFOX);
   });
 
   it('should recognize Silk', () => {
     const userAgent =
       'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Silk/44.1.54 like Chrome/44.0.2403.63 Safari/537.36';
-    expect(getBrowserName(userAgent)).to.eq(BrowserName.SILK);
+    expect(_getBrowserName(userAgent)).to.eq(BrowserName.SILK);
   });
 
   it('should recognize Safari', () => {
     const userAgent =
       'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11-4) AppleWebKit/601.5.17 (KHTML, like Gecko) Version/9.1 Safari/601.5.17';
-    expect(getBrowserName(userAgent)).to.eq(BrowserName.SAFARI);
+    expect(_getBrowserName(userAgent)).to.eq(BrowserName.SAFARI);
   });
 
   it('should recognize Chrome', () => {
     const userAgent =
       'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.94 Safari/537.36';
-    expect(getBrowserName(userAgent)).to.eq(BrowserName.CHROME);
+    expect(_getBrowserName(userAgent)).to.eq(BrowserName.CHROME);
   });
 
   it('should recognize Android', () => {
     const userAgent =
       'Mozilla/5.0 (Linux; U; Android 4.0.3; ko-kr; LG-L160L Build/IML74K) AppleWebkit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30';
-    expect(getBrowserName(userAgent)).to.eq(BrowserName.ANDROID);
+    expect(_getBrowserName(userAgent)).to.eq(BrowserName.ANDROID);
   });
 
   it('should recognize Blackberry', () => {
     const userAgent =
       'Mozilla/5.0 (BlackBerry; U; BlackBerry 9900; en) AppleWebKit/534.11+ (KHTML, like Gecko) Version/7.1.0.346 Mobile Safari/534.11+';
-    expect(getBrowserName(userAgent)).to.eq(BrowserName.BLACKBERRY);
+    expect(_getBrowserName(userAgent)).to.eq(BrowserName.BLACKBERRY);
   });
 
   it('should recognize IE Mobile', () => {
     const userAgent =
       'Mozilla/5.0 (compatible; MSIE 10.0; Windows Phone 8.0;Trident/6.0; IEMobile/10.0; ARM; Touch; NOKIA; Lumia 920)';
-    expect(getBrowserName(userAgent)).to.eq(BrowserName.IEMOBILE);
+    expect(_getBrowserName(userAgent)).to.eq(BrowserName.IEMOBILE);
   });
 
   it('should recognize WebOS', () => {
     const userAgent =
       'Mozilla/5.0 (webOS/1.3; U; en-US) AppleWebKit/525.27.1 (KHTML, like Gecko) Version/1.0 Safari/525.27.1 Desktop/1.0';
-    expect(getBrowserName(userAgent)).to.eq(BrowserName.WEBOS);
+    expect(_getBrowserName(userAgent)).to.eq(BrowserName.WEBOS);
   });
 
   it('should recognize an unlisted browser', () => {
     const userAgent =
       'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Awesome/2.0.012';
-    expect(getBrowserName(userAgent)).to.eq('Awesome');
+    expect(_getBrowserName(userAgent)).to.eq('Awesome');
   });
 
   it('should default to Other', () => {
     const userAgent =
       'Mozilla/5.0 (iPhone; CPU iPhone OS 8_2 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) Mobile/12D508 [FBAN/FBIOS;FBAV/27.0.0.10.12;FBBV/8291884;FBDV/iPhone7,1;FBMD/iPhone;FBSN/iPhone OS;FBSV/8.2;FBSS/3; FBCR/vodafoneIE;FBID/phone;FBLC/en_US;FBOP/5]';
-    expect(getBrowserName(userAgent)).to.eq(BrowserName.OTHER);
+    expect(_getBrowserName(userAgent)).to.eq(BrowserName.OTHER);
   });
 });

--- a/packages-exp/auth-exp/src/core/util/browser.ts
+++ b/packages-exp/auth-exp/src/core/util/browser.ts
@@ -36,7 +36,7 @@ export enum BrowserName {
 /**
  * Determine the browser for the purposes of reporting usage to the API
  */
-export function getBrowserName(userAgent: string): BrowserName | string {
+export function _getBrowserName(userAgent: string): BrowserName | string {
   const ua = userAgent.toLowerCase();
   if (ua.includes('opera/') || ua.includes('opr/') || ua.includes('opios/')) {
     return BrowserName.OPERA;

--- a/packages-exp/auth-exp/src/core/util/delay.test.ts
+++ b/packages-exp/auth-exp/src/core/util/delay.test.ts
@@ -21,7 +21,7 @@ import { restore, stub } from 'sinon';
 import { Delay, _OFFLINE_DELAY_MS } from './delay';
 import * as navigator from './navigator';
 
-describe('Delay.get()', () => {
+describe('core/util/delay', () => {
   const SHORT_DELAY = 30_000;
   const LONG_DELAY = 60_000;
 
@@ -47,7 +47,7 @@ describe('Delay.get()', () => {
   });
 
   it('should return quicker when offline', () => {
-    const mock = stub(navigator, 'isOnline');
+    const mock = stub(navigator, '_isOnline');
     mock.callsFake(() => false);
     const delay = new Delay(SHORT_DELAY, LONG_DELAY);
     expect(delay.get()).to.eq(_OFFLINE_DELAY_MS);

--- a/packages-exp/auth-exp/src/core/util/delay.ts
+++ b/packages-exp/auth-exp/src/core/util/delay.ts
@@ -16,7 +16,7 @@
  */
 
 import { isMobileCordova, isReactNative } from '@firebase/util';
-import { isOnline } from './navigator';
+import { _isOnline } from './navigator';
 import { debugAssert } from './assert';
 
 export const _OFFLINE_DELAY_MS = 5000;
@@ -43,7 +43,7 @@ export class Delay {
   }
 
   get(): number {
-    if (!isOnline()) {
+    if (!_isOnline()) {
       // Pick the shorter timeout.
       return Math.min(_OFFLINE_DELAY_MS, this.shortDelay);
     }

--- a/packages-exp/auth-exp/src/core/util/location.ts
+++ b/packages-exp/auth-exp/src/core/util/location.ts
@@ -15,14 +15,14 @@
  * limitations under the License.
  */
 
-export function getCurrentUrl(): string {
+export function _getCurrentUrl(): string {
   return self?.location?.href || '';
 }
 
-export function isHttpOrHttps(): boolean {
-  return getCurrentScheme() === 'http:' || getCurrentScheme() === 'https:';
+export function _isHttpOrHttps(): boolean {
+  return _getCurrentScheme() === 'http:' || _getCurrentScheme() === 'https:';
 }
 
-export function getCurrentScheme(): string | null {
+export function _getCurrentScheme(): string | null {
   return self?.location?.protocol || null;
 }

--- a/packages-exp/auth-exp/src/core/util/log.ts
+++ b/packages-exp/auth-exp/src/core/util/log.ts
@@ -23,21 +23,21 @@ export { LogLevel };
 const logClient = new Logger('@firebase/auth-exp');
 
 // Helper methods are needed because variables can't be exported as read/write
-export function getLogLevel(): LogLevel {
+export function _getLogLevel(): LogLevel {
   return logClient.logLevel;
 }
 
-export function setLogLevel(newLevel: LogLevel): void {
+export function _setLogLevel(newLevel: LogLevel): void {
   logClient.logLevel = newLevel;
 }
 
-export function logDebug(msg: string, ...args: string[]): void {
+export function _logDebug(msg: string, ...args: string[]): void {
   if (logClient.logLevel <= LogLevel.DEBUG) {
     logClient.debug(`Auth (${SDK_VERSION}): ${msg}`, ...args);
   }
 }
 
-export function logError(msg: string, ...args: string[]): void {
+export function _logError(msg: string, ...args: string[]): void {
   if (logClient.logLevel <= LogLevel.ERROR) {
     logClient.error(`Auth (${SDK_VERSION}): ${msg}`, ...args);
   }

--- a/packages-exp/auth-exp/src/core/util/navigator.ts
+++ b/packages-exp/auth-exp/src/core/util/navigator.ts
@@ -16,7 +16,7 @@
  */
 
 import { isBrowserExtension } from '@firebase/util';
-import { isHttpOrHttps } from './location';
+import { _isHttpOrHttps } from './location';
 
 /**
  * For some reason the TS library doesn't know about NetworkInformation
@@ -36,7 +36,7 @@ interface StandardNavigator extends Navigator {
 /**
  * Determine whether the browser is working online
  */
-export function isOnline(): boolean {
+export function _isOnline(): boolean {
   if (
     navigator &&
     typeof navigator.onLine === 'boolean' &&
@@ -45,7 +45,7 @@ export function isOnline(): boolean {
     // navigator.onLine behavior unless cordova-plugin-network-information is
     // installed which overwrites the native navigator.onLine value and
     // defines navigator.connection.
-    (isHttpOrHttps() ||
+    (_isHttpOrHttps() ||
       isBrowserExtension() ||
       typeof (navigator as StandardNavigator).connection !== 'undefined')
   ) {

--- a/packages-exp/auth-exp/src/core/util/version.test.ts
+++ b/packages-exp/auth-exp/src/core/util/version.test.ts
@@ -17,12 +17,12 @@
 
 import { SDK_VERSION } from '@firebase/app-exp';
 import { expect } from 'chai';
-import { ClientPlatform, getClientVersion } from './version';
+import { ClientPlatform, _getClientVersion } from './version';
 
-describe('getClientVersion', () => {
+describe('core/util/_getClientVersion', () => {
   context('browser', () => {
     it('should set the correct version', () => {
-      expect(getClientVersion(ClientPlatform.BROWSER)).to.eq(
+      expect(_getClientVersion(ClientPlatform.BROWSER)).to.eq(
         `Chrome/JsCore/${SDK_VERSION}/FirebaseCore-web`
       );
     });
@@ -30,7 +30,7 @@ describe('getClientVersion', () => {
 
   context('worker', () => {
     it('should set the correct version', () => {
-      expect(getClientVersion(ClientPlatform.WORKER)).to.eq(
+      expect(_getClientVersion(ClientPlatform.WORKER)).to.eq(
         `Chrome-Worker/JsCore/${SDK_VERSION}/FirebaseCore-web`
       );
     });
@@ -38,7 +38,7 @@ describe('getClientVersion', () => {
 
   context('React Native', () => {
     it('should set the correct version', () => {
-      expect(getClientVersion(ClientPlatform.REACT_NATIVE)).to.eq(
+      expect(_getClientVersion(ClientPlatform.REACT_NATIVE)).to.eq(
         `ReactNative/JsCore/${SDK_VERSION}/FirebaseCore-web`
       );
     });

--- a/packages-exp/auth-exp/src/core/util/version.ts
+++ b/packages-exp/auth-exp/src/core/util/version.ts
@@ -16,7 +16,7 @@
  */
 
 import { SDK_VERSION } from '@firebase/app-exp';
-import { getBrowserName } from './browser';
+import { _getBrowserName } from './browser';
 import { getUA } from '@firebase/util';
 
 const CLIENT_IMPLEMENTATION = 'JsCore';
@@ -41,18 +41,18 @@ enum ClientFramework {
  *
  * TODO: This should be set on the Auth object during initialization
  */
-export function getClientVersion(clientPlatform: ClientPlatform): string {
+export function _getClientVersion(clientPlatform: ClientPlatform): string {
   let reportedPlatform: string;
   switch (clientPlatform) {
     case ClientPlatform.BROWSER:
       // In a browser environment, report the browser name.
-      reportedPlatform = getBrowserName(getUA());
+      reportedPlatform = _getBrowserName(getUA());
       break;
     case ClientPlatform.WORKER:
       // Technically a worker runs from a browser but we need to differentiate a
       // worker from a browser.
       // For example: Chrome-Worker/JsCore/4.9.1/FirebaseCore-web.
-      reportedPlatform = `${getBrowserName(getUA())}-${clientPlatform}`;
+      reportedPlatform = `${_getBrowserName(getUA())}-${clientPlatform}`;
       break;
     default:
       reportedPlatform = clientPlatform;


### PR DESCRIPTION
- prefix directory for test blocks
- use kebab case for test values to make them visually distinct from
keys
- use '#' to prefix instance methods and '.' for class methods
- prefix all private exported methods with '_'