### PR TITLE
Hide messages from build tools and test runners for passed packages

### DIFF
--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -24,7 +24,7 @@ jobs:
     - name: yarn build
       run: yarn build
     - name: Run unit tests
-      run: xvfb-run yarn test
+      run: xvfb-run yarn test:ci
     - name: Generate coverage file
       run: yarn ci:coverage
     - name: Run coverage

--- a/common/api-review/app-exp.api.md
+++ b/common/api-review/app-exp.api.md
@@ -5,9 +5,9 @@
 ```ts
 
 import { Component } from '@firebase/component';
-import { FirebaseApp } from '@firebase/app-types-exp';
-import { FirebaseAppConfig } from '@firebase/app-types-exp';
-import { FirebaseOptions } from '@firebase/app-types-exp';
+import { FirebaseApp } from '@firebase/app-types';
+import { FirebaseAppConfig } from '@firebase/app-types';
+import { FirebaseOptions } from '@firebase/app-types';
 import { LogCallback } from '@firebase/logger';
 import { LogLevel } from '@firebase/logger';
 import { LogOptions } from '@firebase/logger';

--- a/common/api-review/app-exp.api.md
+++ b/common/api-review/app-exp.api.md
@@ -5,9 +5,9 @@
 ```ts
 
 import { Component } from '@firebase/component';
-import { FirebaseApp } from '@firebase/app-types';
-import { FirebaseAppConfig } from '@firebase/app-types';
-import { FirebaseOptions } from '@firebase/app-types';
+import { FirebaseApp } from '@firebase/app-types-exp';
+import { FirebaseAppConfig } from '@firebase/app-types-exp';
+import { FirebaseOptions } from '@firebase/app-types-exp';
 import { LogCallback } from '@firebase/logger';
 import { LogLevel } from '@firebase/logger';
 import { LogOptions } from '@firebase/logger';

--- a/integration/browserify/package.json
+++ b/integration/browserify/package.json
@@ -4,7 +4,8 @@
   "version": "0.2.1",
   "scripts": {
     "pretest": "mkdirp dist && browserify src/namespace.test.js -o dist/namespace.test.js",
-    "test": "karma start --single-run"
+    "test": "karma start --single-run",
+    "test:ci": "node ../../scripts/run_tests_in_ci.js"
   },
   "dependencies": {
     "firebase": "7.14.2"

--- a/integration/firebase-typings/package.json
+++ b/integration/firebase-typings/package.json
@@ -3,7 +3,8 @@
   "private": true,
   "version": "0.2.1",
   "scripts": {
-    "test": "tsc"
+    "test": "tsc",
+    "test:ci": "node ../../scripts/run_tests_in_ci.js"
   },
   "dependencies": {
     "firebase": "7.14.2"

--- a/integration/firestore/package.json
+++ b/integration/firestore/package.json
@@ -7,6 +7,7 @@
     "build:persistence": "INCLUDE_FIRESTORE_PERSISTENCE=true gulp compile-tests",
     "build:memory": "INCLUDE_FIRESTORE_PERSISTENCE=false gulp compile-tests",
     "test": "yarn build:memory; karma start --single-run; yarn build:persistence; karma start --single-run;",
+    "test:ci": "node ../../scripts/run_tests_in_ci.js",
     "test:persistence": " yarn build:persistence; karma start --single-run",
     "test:memory": "yarn build:memory; karma start --single-run",
     "test:debug:persistence": "yarn build:deps; yarn build:persistence; karma start --auto-watch --browsers Chrome",

--- a/integration/typescript/package.json
+++ b/integration/typescript/package.json
@@ -3,7 +3,8 @@
   "private": true,
   "version": "0.2.1",
   "scripts": {
-    "test": "karma start --single-run"
+    "test": "karma start --single-run",
+    "test:ci": "node ../../scripts/run_tests_in_ci.js"
   },
   "dependencies": {
     "firebase": "7.14.2"

--- a/integration/webpack/package.json
+++ b/integration/webpack/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "scripts": {
     "pretest": "webpack",
-    "test": "karma start --single-run"
+    "test": "karma start --single-run",
+    "test:ci": "node ../../scripts/run_tests_in_ci.js"
   },
   "dependencies": {
     "firebase": "7.14.2"

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "release": "node scripts/release/cli.js",
     "pretest": "node tools/pretest.js",
     "test": "lerna run --concurrency 4 --stream test",
+    "test:ci": "lerna run --concurrency 4 --stream test:ci",
     "test:exp": "lerna run --concurrency 4 --stream --scope @firebase/*-exp --scope firebase-exp test",
     "pretest:coverage": "mkdirp coverage",
     "ci:coverage": "lcov-result-merger 'packages/**/lcov.info' 'lcov-all.info'",

--- a/packages-exp/app-exp/package.json
+++ b/packages-exp/app-exp/package.json
@@ -19,6 +19,7 @@
     "build:deps": "lerna run --scope @firebase/app-exp --include-dependencies build",
     "dev": "rollup -c -w",
     "test": "yarn type-check && run-p lint test:browser test:node",
+    "test:ci": "node ../../scripts/run_tests_in_ci.js",
     "test:browser": "karma start --single-run",
     "test:node": "TS_NODE_COMPILER_OPTIONS='{\"module\":\"commonjs\"}' nyc --reporter lcovonly -- mocha src/**/*.test.ts --config ../../config/mocharc.node.js",
     "type-check": "tsc -p . --noEmit",

--- a/packages/analytics/package.json
+++ b/packages/analytics/package.json
@@ -16,6 +16,7 @@
     "build:deps": "lerna run --scope @firebase/'{app,analytics}' --include-dependencies build",
     "dev": "rollup -c -w",
     "test": "yarn type-check && yarn run-p lint test:browser",
+    "test:ci": "node ../../scripts/run_tests_in_ci.js",
     "test:browser": "karma start --single-run --nocache",
     "type-check": "tsc -p . --noEmit",
     "prepare": "yarn build"

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -20,6 +20,7 @@
     "build:deps": "lerna run --scope @firebase/app --include-dependencies build",
     "dev": "rollup -c -w",
     "test": "yarn type-check && run-p lint test:browser test:node",
+    "test:ci": "node ../../scripts/run_tests_in_ci.js",
     "type-check": "tsc -p . --noEmit",
     "test:browser": "karma start --single-run",
     "test:browser:debug": "karma start --browsers Chrome --auto-watch",

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -16,7 +16,8 @@
     "generate-test-files": "./buildtools/generate_test_files.sh",
     "prepare": "yarn build",
     "serve": "yarn build && yarn generate-test-files && gulp serve",
-    "test": "yarn generate-test-files && ./buildtools/run_tests.sh"
+    "test": "yarn generate-test-files && ./buildtools/run_tests.sh",
+    "test:ci": "node ../../scripts/run_tests_in_ci.js"
   },
   "license": "Apache-2.0",
   "dependencies": {

--- a/packages/component/package.json
+++ b/packages/component/package.json
@@ -17,6 +17,7 @@
     "build:deps": "lerna run --scope @firebase/component --include-dependencies build",
     "dev": "rollup -c -w",
     "test": "yarn type-check && run-p lint test:browser test:node",
+    "test:ci": "node ../../scripts/run_tests_in_ci.js",
     "type-check": "tsc -p . --noEmit",
     "test:browser": "karma start --single-run",
     "test:node": "TS_NODE_COMPILER_OPTIONS='{\"module\":\"commonjs\"}' nyc --reporter lcovonly -- mocha src/**/*.test.ts --config ../../config/mocharc.node.js",

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -17,6 +17,7 @@
     "build:deps": "lerna run --scope @firebase/'{app,database}' --include-dependencies build",
     "dev": "rollup -c -w",
     "test": "run-p lint test:emulator",
+    "test:ci": "node ../../scripts/run_tests_in_ci.js",
     "test:all": "run-p lint test:browser test:node",
     "test:browser": "karma start --single-run",
     "test:node": "TS_NODE_FILES=true TS_NODE_CACHE=NO TS_NODE_COMPILER_OPTIONS='{\"module\":\"commonjs\"}' nyc --reporter lcovonly -- mocha 'test/{,!(browser)/**/}*.test.ts' --file index.node.ts --config ../../config/mocharc.node.js",

--- a/packages/firestore/package.json
+++ b/packages/firestore/package.json
@@ -17,6 +17,7 @@
     "lint:fix": "eslint --fix -c .eslintrc.js '**/*.ts' --ignore-path '../../.gitignore'",
     "prettier": "prettier --write '*.ts' '*.js' 'src/**/*.js' 'test/**/*.js' 'src/**/*.ts' 'test/**/*.ts'",
     "test": "run-s lint test:all",
+    "test:ci": "node ../../scripts/run_tests_in_ci.js",
     "test:all": "run-p test:browser test:travis test:minified",
     "test:browser": "karma start --single-run",
     "test:browser:debug": "karma start --browsers=Chrome --auto-watch",

--- a/packages/functions/package.json
+++ b/packages/functions/package.json
@@ -17,6 +17,7 @@
     "build:deps": "lerna run --scope @firebase/'{app,functions}' --include-dependencies build",
     "dev": "rollup -c -w",
     "test": "yarn type-check && run-p lint test:browser test:node",
+    "test:ci": "node ../../scripts/run_tests_in_ci.js",
     "type-check": "tsc -p . --noEmit",
     "test:browser": "karma start --single-run",
     "test:browser:debug": "karma start --browsers=Chrome --auto-watch",

--- a/packages/installations/package.json
+++ b/packages/installations/package.json
@@ -13,6 +13,7 @@
     "build": "rollup -c",
     "build:deps": "lerna run --scope @firebase/'{app,installations}' --include-dependencies build",
     "test": "yarn type-check && yarn test:karma && yarn lint",
+    "test:ci": "node ../../scripts/run_tests_in_ci.js",
     "test:karma": "karma start --single-run",
     "test:debug": "karma start --browsers=Chrome --auto-watch",
     "type-check": "tsc -p . --noEmit",

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -16,6 +16,7 @@
     "build:deps": "lerna run --scope @firebase/logger --include-dependencies build",
     "dev": "rollup -c -w",
     "test": "run-p lint test:browser test:node",
+    "test:ci": "node ../../scripts/run_tests_in_ci.js",
     "test:browser": "karma start --single-run",
     "test:browser:debug": "karma start --browsers Chrome --auto-watch",
     "test:node": "TS_NODE_COMPILER_OPTIONS='{\"module\":\"commonjs\"}' nyc --reporter lcovonly -- mocha test/**/*.test.* --config ../../config/mocharc.node.js",

--- a/packages/messaging/package.json
+++ b/packages/messaging/package.json
@@ -16,6 +16,7 @@
     "build:deps": "lerna run --scope @firebase/'{app,messaging}' --include-dependencies build",
     "dev": "rollup -c -w",
     "test": "run-p test:karma type-check lint",
+    "test:ci": "node ../../scripts/run_tests_in_ci.js",
     "test:karma": "karma start --single-run",
     "test:debug": "karma start --browsers=Chrome --auto-watch",
     "prepare": "yarn build",

--- a/packages/performance/package.json
+++ b/packages/performance/package.json
@@ -17,6 +17,7 @@
     "build:deps": "lerna run --scope @firebase/'{app,performance}' --include-dependencies build",
     "dev": "rollup -c -w",
     "test": "run-p lint test:browser",
+    "test:ci": "node ../../scripts/run_tests_in_ci.js",
     "test:browser": "karma start --single-run",
     "test:debug": "karma start --browsers=Chrome --auto-watch",
     "prepare": "yarn build",

--- a/packages/remote-config/package.json
+++ b/packages/remote-config/package.json
@@ -17,6 +17,7 @@
     "build:deps": "lerna run --scope @firebase/'{app,remote-config}' --include-dependencies build",
     "dev": "rollup -c -w",
     "test": "run-p lint test:browser",
+    "test:ci": "node ../../scripts/run_tests_in_ci.js",
     "test:browser": "karma start --single-run",
     "test:debug": "karma start --browsers=Chrome --auto-watch",
     "prettier": "prettier --write '{src,test}/**/*.{js,ts}'",

--- a/packages/rxfire/package.json
+++ b/packages/rxfire/package.json
@@ -28,6 +28,7 @@
     "dev": "rollup -c -w",
     "prepare": "yarn build",
     "test": "run-p lint test:browser",
+    "test:ci": "node ../../scripts/run_tests_in_ci.js",
     "test:browser": "karma start --single-run",
     "test:browser:debug": "karma start --browsers=Chrome --auto-watch"
   },

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -16,6 +16,7 @@
     "build:deps": "lerna run --scope @firebase/'{app,storage}' --include-dependencies build",
     "dev": "rollup -c -w",
     "test": "run-p test:browser lint",
+    "test:ci": "node ../../scripts/run_tests_in_ci.js",
     "test:browser": "karma start --single-run",
     "prepare": "yarn build",
     "prettier": "prettier --write 'src/**/*.ts' 'test/**/*.ts'"

--- a/packages/template/package.json
+++ b/packages/template/package.json
@@ -18,6 +18,7 @@
     "build:deps": "lerna run --scope @firebase/'{app,template}' --include-dependencies build",
     "dev": "rollup -c -w",
     "test": "yarn type-check && run-p lint test:browser test:node",
+    "test:ci": "node ../../scripts/run_tests_in_ci.js",
     "test:browser": "karma start --single-run",
     "test:node": "TS_NODE_COMPILER_OPTIONS='{\"module\":\"commonjs\"}' nyc --reporter lcovonly -- mocha src/**/*.test.* --config ../../config/mocharc.node.js",
     "type-check": "tsc -p . --noEmit",

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -15,6 +15,7 @@
     "build:deps": "lerna run --scope @firebase/testing --include-dependencies build",
     "dev": "rollup -c -w",
     "test": "TS_NODE_CACHE=NO TS_NODE_COMPILER_OPTIONS='{\"module\":\"commonjs\"}' nyc --reporter lcovonly -- mocha 'test/{,!(browser)/**/}*.test.ts' --config ../../config/mocharc.node.js",
+    "test:ci": "node ../../scripts/run_tests_in_ci.js",
     "prepare": "yarn build"
   },
   "license": "Apache-2.0",

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -17,6 +17,7 @@
     "build:deps": "lerna run --scope @firebase/util --include-dependencies build",
     "dev": "rollup -c -w",
     "test": "yarn type-check && run-p lint test:browser test:node",
+    "test:ci": "node ../../scripts/run_tests_in_ci.js",
     "type-check": "tsc -p . --noEmit",
     "test:browser": "karma start --single-run",
     "test:node": "TS_NODE_CACHE=NO TS_NODE_COMPILER_OPTIONS='{\"module\":\"commonjs\"}' nyc --reporter lcovonly -- mocha test/**/*.test.* --config ../../config/mocharc.node.js",

--- a/scripts/run_changed.js
+++ b/scripts/run_changed.js
@@ -24,7 +24,7 @@ const root = resolve(__dirname, '..');
 const git = simpleGit(root);
 
 // use test:ci command in CI
-const testCommand = !!process.env.CI ? 'test:ci': 'test';
+const testCommand = !!process.env.CI ? 'test:ci' : 'test';
 /**
  * Changes to these files warrant running all tests.
  */

--- a/scripts/run_changed.js
+++ b/scripts/run_changed.js
@@ -23,6 +23,8 @@ const simpleGit = require('simple-git/promise');
 const root = resolve(__dirname, '..');
 const git = simpleGit(root);
 
+// use test:ci command in CI
+const testCommand = !!process.env.CI ? 'test:ci': 'test';
 /**
  * Changes to these files warrant running all tests.
  */
@@ -148,7 +150,7 @@ async function runTests(pathList) {
   if (!pathList) return;
   for (const testPath of pathList) {
     try {
-      await spawn('yarn', ['--cwd', testPath, 'test'], {
+      await spawn('yarn', ['--cwd', testPath, testCommand], {
         stdio: 'inherit'
       });
     } catch (e) {
@@ -161,7 +163,7 @@ async function main() {
   try {
     const { testAll, changedPackages = {} } = await getChangedPackages();
     if (testAll) {
-      await spawn('yarn', ['test'], {
+      await spawn('yarn', [testCommand], {
         stdio: 'inherit'
       });
     } else {
@@ -178,6 +180,8 @@ async function main() {
           console.log(chalk`{yellow ${filename} (depends on modified files)}`);
         }
       }
+
+      changedPackages['packages/app'] = 'direct';
       await runTests(alwaysRunTestPaths);
       await runTests(Object.keys(changedPackages));
     }

--- a/scripts/run_tests_in_ci.js
+++ b/scripts/run_tests_in_ci.js
@@ -1,0 +1,30 @@
+const { argv } = require('yargs');
+const path = require('path');
+const { spawn } = require('child-process-promise');
+
+(async () => {
+    const myPath = argv._[0] || '.'; // default to the current directory
+    const dir = path.resolve(myPath);
+    const { name } = require(`${dir}/package.json`);
+
+    let stdio = '';
+    let stderr = '';
+    try {
+        const testProcess = spawn('yarn', ['--cwd', dir, 'test']);
+
+        testProcess.childProcess.stdout.on('data', data => {
+            stdio += data.toString();
+        });
+        testProcess.childProcess.stderr.on('data', data => {
+            stderr += data.toString();
+        });
+
+        await testProcess;
+        console.log('Success: ' + name);
+    } catch (e) {
+        console.error('Failure: ' + name);
+        console.log(stdio);
+        console.error(stderr);
+        process.exit(1);
+    }
+})();

--- a/scripts/run_tests_in_ci.js
+++ b/scripts/run_tests_in_ci.js
@@ -3,28 +3,28 @@ const path = require('path');
 const { spawn } = require('child-process-promise');
 
 (async () => {
-    const myPath = argv._[0] || '.'; // default to the current directory
-    const dir = path.resolve(myPath);
-    const { name } = require(`${dir}/package.json`);
+  const myPath = argv._[0] || '.'; // default to the current directory
+  const dir = path.resolve(myPath);
+  const { name } = require(`${dir}/package.json`);
 
-    let stdio = '';
-    let stderr = '';
-    try {
-        const testProcess = spawn('yarn', ['--cwd', dir, 'test']);
+  let stdio = '';
+  let stderr = '';
+  try {
+    const testProcess = spawn('yarn', ['--cwd', dir, 'test']);
 
-        testProcess.childProcess.stdout.on('data', data => {
-            stdio += data.toString();
-        });
-        testProcess.childProcess.stderr.on('data', data => {
-            stderr += data.toString();
-        });
+    testProcess.childProcess.stdout.on('data', data => {
+      stdio += data.toString();
+    });
+    testProcess.childProcess.stderr.on('data', data => {
+      stderr += data.toString();
+    });
 
-        await testProcess;
-        console.log('Success: ' + name);
-    } catch (e) {
-        console.error('Failure: ' + name);
-        console.log(stdio);
-        console.error(stderr);
-        process.exit(1);
-    }
+    await testProcess;
+    console.log('Success: ' + name);
+  } catch (e) {
+    console.error('Failure: ' + name);
+    console.log(stdio);
+    console.error(stderr);
+    process.exit(1);
+  }
 })();

--- a/scripts/run_tests_in_ci.js
+++ b/scripts/run_tests_in_ci.js
@@ -1,3 +1,20 @@
+/**
+ * @license
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 const { argv } = require('yargs');
 const path = require('path');
 const { spawn } = require('child-process-promise');

--- a/scripts/run_tests_in_ci.js
+++ b/scripts/run_tests_in_ci.js
@@ -24,13 +24,13 @@ const { spawn } = require('child-process-promise');
   const dir = path.resolve(myPath);
   const { name } = require(`${dir}/package.json`);
 
-  let stdio = '';
+  let stdout = '';
   let stderr = '';
   try {
     const testProcess = spawn('yarn', ['--cwd', dir, 'test']);
 
     testProcess.childProcess.stdout.on('data', data => {
-      stdio += data.toString();
+      stdout += data.toString();
     });
     testProcess.childProcess.stderr.on('data', data => {
       stderr += data.toString();
@@ -40,7 +40,7 @@ const { spawn } = require('child-process-promise');
     console.log('Success: ' + name);
   } catch (e) {
     console.error('Failure: ' + name);
-    console.log(stdio);
+    console.log(stdout);
     console.error(stderr);
     process.exit(1);
   }


### PR DESCRIPTION
This is a followup PR for https://github.com/firebase/firebase-js-sdk/pull/2980. It further reduces clutter in the CI explorer.

Credit: https://github.com/firebase/firebase-js-sdk/pull/2954