### PR TITLE
Minor deviation in the rxjs firestore examples

### DIFF
--- a/packages/rxfire/docs/firestore.md
+++ b/packages/rxfire/docs/firestore.md
@@ -148,7 +148,7 @@ const davidDoc = db.doc('users/david');
 davidDoc.set({ name: 'David' });
 
 collectionChanges(db.collection('users'))
-  .subscribe(changes => { console.log(users) });
+  .subscribe(changes => { console.log(changes) });
 
 // Listen to only 'added' events
 collectionChanges(db.collection('users'), ['added'])
@@ -181,7 +181,7 @@ const davidDoc = db.doc('users/david');
 davidDoc.set({ name: 'David' });
 
 sortedChanges(db.collection('users'))
-  .subscribe(changes => { console.log(users) });
+  .subscribe(changes => { console.log(changes) });
 
 // Listen to only 'added' events
 docChanges(db.collection('users'), ['added'])


### PR DESCRIPTION
 To make the code example more consistent with the other examples in the .md file  the function should print `changes` and not `users`. It's also a bit weird to print `users` and not `changes`.