### PR TITLE
Update command to run the Firestore emulator

### DIFF
--- a/packages/firestore/CONTRIBUTING.md
+++ b/packages/firestore/CONTRIBUTING.md
@@ -34,7 +34,7 @@ on port 8080, which is default when running it via CLI.
     ```
   * Run the emulator
     ```
-    firebase serve --only firestore
+    firebase emulators:start --only firestore
     ```
 
 ### Running Firestore Tests


### PR DESCRIPTION
At some point the command to run the Firestore emulator changed from

```
firebase serve --only firestore
```

to

```
firebase emulators:start --only firestore
```

This PR updates `CONTRIBUTING.md` to reflect this update.