### PR TITLE
Drop SortedSet from FieldMask

### DIFF
--- a/packages/firestore/src/model/mutation.ts
+++ b/packages/firestore/src/model/mutation.ts
@@ -20,7 +20,6 @@ import * as api from '../protos/firestore_proto_api';
 import { Timestamp } from '../api/timestamp';
 import { SnapshotVersion } from '../core/snapshot_version';
 import { debugAssert, fail, hardAssert } from '../util/assert';
-import { SortedSet } from '../util/sorted_set';
 
 import {
   Document,
@@ -45,18 +44,14 @@ import { arrayEquals } from '../util/misc';
  *             containing foo
  */
 export class FieldMask {
-  constructor(readonly fields: SortedSet<FieldPath>) {
+  constructor(readonly fields: FieldPath[]) {
     // TODO(dimond): validation of FieldMask
-  }
-
-  static fromSet(fields: SortedSet<FieldPath>): FieldMask {
-    return new FieldMask(fields);
-  }
-
-  static fromArray(fields: FieldPath[]): FieldMask {
-    let fieldsAsSet = new SortedSet<FieldPath>(FieldPath.comparator);
-    fields.forEach(fieldPath => (fieldsAsSet = fieldsAsSet.add(fieldPath)));
-    return new FieldMask(fieldsAsSet);
+    // Sort the field mask to support `FieldMask.isEqual()` and assert below.
+    fields.sort(FieldPath.comparator);
+    debugAssert(
+      !fields.some((v, i) => i !== 0 && v.isEqual(fields[i - 1])),
+      'FieldMask contains fields that are not unique'
+    );
   }
 
   /**
@@ -66,17 +61,16 @@ export class FieldMask {
    * This is an O(n) operation, where `n` is the size of the field mask.
    */
   covers(fieldPath: FieldPath): boolean {
-    let found = false;
-    this.fields.forEach(fieldMaskPath => {
+    for (const fieldMaskPath of this.fields) {
       if (fieldMaskPath.isPrefixOf(fieldPath)) {
-        found = true;
+        return true;
       }
-    });
-    return found;
+    }
+    return false;
   }
 
   isEqual(other: FieldMask): boolean {
-    return this.fields.isEqual(other.fields);
+    return arrayEquals(this.fields, other.fields, (l, r) => l.isEqual(r));
   }
 }
 

--- a/packages/firestore/src/model/mutation.ts
+++ b/packages/firestore/src/model/mutation.ts
@@ -50,7 +50,8 @@ export class FieldMask {
     fields.sort(FieldPath.comparator);
     debugAssert(
       !fields.some((v, i) => i !== 0 && v.isEqual(fields[i - 1])),
-      'FieldMask contains fields that are not unique'
+      'FieldMask contains field that is not unique: ' +
+        fields.find((v, i) => i !== 0 && v.isEqual(fields[i - 1]))!
     );
   }
 

--- a/packages/firestore/src/remote/serializer.ts
+++ b/packages/firestore/src/remote/serializer.ts
@@ -1086,8 +1086,7 @@ export class JsonProtoSerializer {
 
   fromDocumentMask(proto: api.DocumentMask): FieldMask {
     const paths = proto.fieldPaths || [];
-    const fields = paths.map(path => FieldPath.fromServerFormat(path));
-    return FieldMask.fromArray(fields);
+    return new FieldMask(paths.map(path => FieldPath.fromServerFormat(path)));
   }
 }
 

--- a/packages/firestore/test/integration/api/database.test.ts
+++ b/packages/firestore/test/integration/api/database.test.ts
@@ -531,6 +531,18 @@ apiDescribe('Database', (persistence: boolean) => {
     });
   });
 
+  it('can specify updated field multiple times', () => {
+    return withTestDoc(persistence, doc => {
+      return doc
+        .set({})
+        .then(() => doc.update('field', 100, new FieldPath('field'), 200))
+        .then(() => doc.get())
+        .then(docSnap => {
+          expect(docSnap.data()).to.deep.equal({ field: 200 });
+        });
+    });
+  });
+
   describe('documents: ', () => {
     const invalidDocValues = [undefined, null, 0, 'foo', ['a'], new Date()];
     for (const val of invalidDocValues) {

--- a/packages/firestore/test/unit/remote/serializer.helper.ts
+++ b/packages/firestore/test/unit/remote/serializer.helper.ts
@@ -540,7 +540,7 @@ export function serializerTest(
         const expected: api.DocumentMask = {
           fieldPaths: ['foo.`bar.baz\\qux`']
         };
-        const mask = FieldMask.fromArray([
+        const mask = new FieldMask([
           FieldPath.fromServerFormat('foo.bar\\.baz\\\\qux')
         ]);
         const actual = s.toDocumentMask(mask);
@@ -554,7 +554,7 @@ export function serializerTest(
       // TODO(b/34988481): Implement correct escaping
       // eslint-disable-next-line no-restricted-properties
       it.skip('converts a weird path', () => {
-        const expected = FieldMask.fromArray([
+        const expected = new FieldMask([
           FieldPath.fromServerFormat('foo.bar\\.baz\\\\qux')
         ]);
         const proto: api.DocumentMask = { fieldPaths: ['foo.`bar.baz\\qux`'] };

--- a/packages/firestore/test/unit/util/misc.test.ts
+++ b/packages/firestore/test/unit/util/misc.test.ts
@@ -18,6 +18,7 @@
 import { expect } from 'chai';
 import { immediateSuccessor } from '../../../src/util/misc';
 import { debugCast } from '../../../src/util/assert';
+import { mask } from '../../util/helpers';
 
 describe('immediateSuccessor', () => {
   it('generates the correct immediate successors', () => {
@@ -40,6 +41,14 @@ describe('typeCast', () => {
     const foo = new Foo();
     expect(() => debugCast(foo, Bar)).to.throw(
       "Expected type 'Bar', but was 'Foo'"
+    );
+  });
+});
+
+describe('FieldMask', () => {
+  it('cannot contain duplicate fields', () => {
+    expect(() => mask('a', 'b', 'a')).to.throw(
+      'FieldMask contains fields that are not unique'
     );
   });
 });

--- a/packages/firestore/test/unit/util/misc.test.ts
+++ b/packages/firestore/test/unit/util/misc.test.ts
@@ -48,7 +48,7 @@ describe('typeCast', () => {
 describe('FieldMask', () => {
   it('cannot contain duplicate fields', () => {
     expect(() => mask('a', 'b', 'a')).to.throw(
-      'FieldMask contains fields that are not unique'
+      'FieldMask contains field that is not unique: a'
     );
   });
 });

--- a/packages/firestore/test/util/helpers.ts
+++ b/packages/firestore/test/util/helpers.ts
@@ -212,11 +212,7 @@ export function field(path: string): FieldPath {
 }
 
 export function mask(...paths: string[]): FieldMask {
-  let fieldPaths = new SortedSet<FieldPath>(FieldPath.comparator);
-  for (const path of paths) {
-    fieldPaths = fieldPaths.add(field(path));
-  }
-  return FieldMask.fromSet(fieldPaths);
+  return new FieldMask(paths.map(v => field(v)));
 }
 
 export function blob(...bytes: number[]): Blob {


### PR DESCRIPTION
I would like to not use SortedSet in FieldMask since the Rest Wrapper API ideally does not pull in our custom Red Black Tree. FieldMasks are used in any update/set(merge:true) call.

Right now, I have a debug assert that makes sure FieldMasks only contain unique fields. This means we have to validate this as we turn user data into FieldMasks. We could also strip duplicated fields in the FieldMask constructor.