### PR TITLE
Take WatchStream offline when IndexedDB is unavailable

### DIFF
--- a/packages/firestore/src/remote/remote_store.ts
+++ b/packages/firestore/src/remote/remote_store.ts
@@ -436,12 +436,7 @@ export class RemoteStore implements TargetMetadataProvider {
           await this.raiseWatchSnapshot(snapshotVersion);
         }
       } catch (e) {
-        logDebug(
-          LOG_TAG,
-          'Failed to raise snapshot for %s: %s',
-          snapshotVersion.toString(),
-          e
-        );
+        logDebug(LOG_TAG, 'Failed to raise snapshot:', e);
         await this.disableNetworkUntilRecovery(e);
       }
     }

--- a/packages/firestore/src/remote/remote_store.ts
+++ b/packages/firestore/src/remote/remote_store.ts
@@ -464,7 +464,7 @@ export class RemoteStore implements TargetMetadataProvider {
       await this.disableNetworkInternal();
       this.onlineStateTracker.set(OnlineState.Offline);
       
-      // Probe IndexedDB periodically and re-enable network.
+      // Probe IndexedDB periodically and re-enable network
       this.asyncQueue.enqueueRetryable(async () => {
         logDebug(LOG_TAG, 'Retrying IndexedDB access');
         // Issue a simple read operation to determine if IndexedDB recovered.

--- a/packages/firestore/test/unit/specs/recovery_spec.test.ts
+++ b/packages/firestore/test/unit/specs/recovery_spec.test.ts
@@ -21,6 +21,7 @@ import { TimerId } from '../../../src/util/async_queue';
 import { Query } from '../../../src/core/query';
 import { Code } from '../../../src/util/error';
 import { doc, path } from '../../util/helpers';
+import { RpcError } from './spec_rpc_error';
 
 describeSpec('Persistence Recovery', ['no-ios', 'no-android'], () => {
   specTest(
@@ -196,4 +197,79 @@ describeSpec('Persistence Recovery', ['no-ios', 'no-android'], () => {
       .watchAcksFull(query2, 1)
       .expectEvents(query2, {});
   });
+
+  specTest(
+    'Recovers when watch update cannot be persisted',
+    ['durable-persistence'],
+    () => {
+      const query = Query.atPath(path('collection'));
+      const doc1 = doc('collection/key1', 1000, { foo: 'a' });
+      const doc2 = doc('collection/key2', 2000, { foo: 'b' });
+      return spec()
+        .userListens(query)
+        .watchAcksFull(query, 1000, doc1)
+        .expectEvents(query, {
+          added: [doc1]
+        })
+        .watchSends({ affects: [query] }, doc2)
+        .failDatabase()
+        .watchSnapshots(1500)
+        // `failDatabase()` causes us to go offline.
+        .expectActiveTargets()
+        .recoverDatabase()
+        .runTimer(TimerId.AsyncQueueRetry)
+        .expectActiveTargets({ query, resumeToken: 'resume-token-1000' })
+        .watchAcksFull(query, 2000, doc2)
+        .expectEvents(query, {
+          added: [doc2]
+        });
+    }
+  );
+
+  specTest(
+    'Recovers when watch rejection cannot be persisted',
+    ['durable-persistence'],
+    () => {
+      const doc1Query = Query.atPath(path('collection/key1'));
+      const doc2Query = Query.atPath(path('collection/key2'));
+      const doc1a = doc('collection/key1', 1000, { foo: 'a' });
+      const doc1b = doc('collection/key1', 4000, { foo: 'a', updated: true });
+      const doc2 = doc('collection/key2', 2000, { foo: 'b' });
+      return spec()
+        .userListens(doc1Query)
+        .watchAcksFull(doc1Query, 1000, doc1a)
+        .expectEvents(doc1Query, {
+          added: [doc1a]
+        })
+        .userListens(doc2Query)
+        .watchAcksFull(doc2Query, 2000, doc2)
+        .expectEvents(doc2Query, {
+          added: [doc2]
+        })
+        .failDatabase()
+        .watchRemoves(
+          doc1Query,
+          new RpcError(Code.PERMISSION_DENIED, 'Simulated target error')
+        )
+        // `failDatabase()` causes us to go offline.
+        .expectActiveTargets()
+        .recoverDatabase()
+        .runTimer(TimerId.AsyncQueueRetry)
+        .expectActiveTargets(
+          { query: doc1Query, resumeToken: 'resume-token-1000' },
+          { query: doc2Query, resumeToken: 'resume-token-2000' }
+        )
+        .watchAcksFull(doc1Query, 3000)
+        .watchRemoves(
+          doc2Query,
+          new RpcError(Code.PERMISSION_DENIED, 'Simulated target error')
+        )
+        .expectEvents(doc2Query, { errorCode: Code.PERMISSION_DENIED })
+        .watchSends({ affects: [doc1Query] }, doc1b)
+        .watchSnapshots(4000)
+        .expectEvents(doc1Query, {
+          modified: [doc1b]
+        });
+    }
+  );
 });


### PR DESCRIPTION
This PR takes the network offline if we fail to talk to IndexedDB when applying a query snapshot or rejection.

Also cleans up some Promise handling in RemoteStore.

Addresses #2755