### PR TITLE
Ignore IndexedDB failures during garbage collection

### DIFF
--- a/packages/firestore/src/local/lru_garbage_collector.ts
+++ b/packages/firestore/src/local/lru_garbage_collector.ts
@@ -274,7 +274,7 @@ export class LruScheduler implements GarbageCollectionScheduler {
           await localStore.collectGarbage(this.garbageCollector);
         } catch (e) {
           if (e.name === 'IndexedDbTransactionError') {
-            logDebug(LOG_TAG, 'Ignoring IndexedDB error during LRU: ', e);
+            logDebug(LOG_TAG, 'Ignoring IndexedDB error during garbage collection: ', e);
           } else {
             await ignoreIfPrimaryLeaseLoss(e);
           }

--- a/packages/firestore/src/local/lru_garbage_collector.ts
+++ b/packages/firestore/src/local/lru_garbage_collector.ts
@@ -32,6 +32,8 @@ import {
 import { PersistencePromise } from './persistence_promise';
 import { TargetData } from './target_data';
 
+const LOG_TAG = 'LruGarbageCollector';
+
 /**
  * Persistence layers intending to use LRU Garbage collection should have reference delegates that
  * implement this interface. This interface defines the operations that the LRU garbage collector
@@ -265,13 +267,19 @@ export class LruScheduler implements GarbageCollectionScheduler {
     this.gcTask = this.asyncQueue.enqueueAfterDelay(
       TimerId.LruGarbageCollection,
       delay,
-      () => {
+      async () => {
         this.gcTask = null;
         this.hasRun = true;
-        return localStore
-          .collectGarbage(this.garbageCollector)
-          .then(() => this.scheduleGC(localStore))
-          .catch(ignoreIfPrimaryLeaseLoss);
+        try {
+          await localStore.collectGarbage(this.garbageCollector);
+        } catch (e) {
+          if (e.name === 'IndexedDbTransactionError') {
+            logDebug(LOG_TAG, 'Ignoring IndexedDB error during LRU: ', e);
+          } else {
+            await ignoreIfPrimaryLeaseLoss(e);
+          }
+        }
+        await this.scheduleGC(localStore);
       }
     );
   }

--- a/packages/firestore/test/unit/local/lru_garbage_collector.test.ts
+++ b/packages/firestore/test/unit/local/lru_garbage_collector.test.ts
@@ -52,6 +52,7 @@ import { key, path, version, wrapObject } from '../../util/helpers';
 import { SortedMap } from '../../../src/util/sorted_map';
 import * as PersistenceTestHelpers from './persistence_test_helpers';
 import { primitiveComparator } from '../../../src/util/misc';
+import { IndexedDbTransactionError } from '../../../src/local/simple_db';
 
 describe('IndexedDbLruDelegate', () => {
   if (!IndexedDbPersistence.isAvailable()) {

--- a/packages/firestore/test/unit/local/lru_garbage_collector.test.ts
+++ b/packages/firestore/test/unit/local/lru_garbage_collector.test.ts
@@ -52,7 +52,6 @@ import { key, path, version, wrapObject } from '../../util/helpers';
 import { SortedMap } from '../../../src/util/sorted_map';
 import * as PersistenceTestHelpers from './persistence_test_helpers';
 import { primitiveComparator } from '../../../src/util/misc';
-import { IndexedDbTransactionError } from '../../../src/local/simple_db';
 
 describe('IndexedDbLruDelegate', () => {
   if (!IndexedDbPersistence.isAvailable()) {


### PR DESCRIPTION
Rationale is that they the LRU task will retry its run when it is invoked next.

There are no tests since the GC scheduling code is not tested right now. Let me know if you would like me to add tests.

Note that there is a behavior change: If the primary lease is lost, the GC run is rescheduled. It will however get stoped in
https://github.com/firebase/firebase-js-sdk/blob/5a60243bf264967819fc5c3897892084c5eb4d43/packages/firestore/src/core/component_provider.ts#L203


Addresses #2755