### PR TITLE
Fix `GeoPoint` field values with a zero coordinate failing input validation

### DIFF
--- a/packages/firestore/src/api/user_data_writer.ts
+++ b/packages/firestore/src/api/user_data_writer.ts
@@ -75,10 +75,11 @@ export class UserDataWriter<T = firestore.DocumentData> {
       case TypeOrder.RefValue:
         return this.convertReference(value.referenceValue!);
       case TypeOrder.GeoPointValue:
-        return new GeoPoint(
-          value.geoPointValue!.latitude!,
-          value.geoPointValue!.longitude!
-        );
+        // `geoPointValue` stores zeroes as undefined, which will fail
+        // `GeoPoint` constructor's argument validation if used directly.
+        const latitude = value.geoPointValue!.latitude! || 0;
+        const longitude = value.geoPointValue!.longitude! || 0;
+        return new GeoPoint(latitude, longitude);
       case TypeOrder.ArrayValue:
         return this.convertArray(value.arrayValue!);
       case TypeOrder.ObjectValue:

--- a/packages/firestore/src/api/user_data_writer.ts
+++ b/packages/firestore/src/api/user_data_writer.ts
@@ -94,7 +94,10 @@ export class UserDataWriter<T = firestore.DocumentData> {
   }
 
   private convertGeoPoint(value: api.LatLng): GeoPoint {
-    return new GeoPoint(normalizeNumber(value.latitude), normalizeNumber(value.longitude));
+    return new GeoPoint(
+      normalizeNumber(value.latitude),
+      normalizeNumber(value.longitude)
+    );
   }
 
   private convertArray(arrayValue: api.ArrayValue): unknown[] {

--- a/packages/firestore/src/api/user_data_writer.ts
+++ b/packages/firestore/src/api/user_data_writer.ts
@@ -75,11 +75,7 @@ export class UserDataWriter<T = firestore.DocumentData> {
       case TypeOrder.RefValue:
         return this.convertReference(value.referenceValue!);
       case TypeOrder.GeoPointValue:
-        // `geoPointValue` stores zeroes as undefined, which will fail
-        // `GeoPoint` constructor's argument validation if used directly.
-        const latitude = value.geoPointValue!.latitude! || 0;
-        const longitude = value.geoPointValue!.longitude! || 0;
-        return new GeoPoint(latitude, longitude);
+        return this.convertGeoPoint(value.geoPointValue!);
       case TypeOrder.ArrayValue:
         return this.convertArray(value.arrayValue!);
       case TypeOrder.ObjectValue:
@@ -95,6 +91,10 @@ export class UserDataWriter<T = firestore.DocumentData> {
       result[key] = this.convertValue(value);
     });
     return result;
+  }
+
+  private convertGeoPoint(value: api.LatLng): GeoPoint {
+    return new GeoPoint(normalizeNumber(value.latitude), normalizeNumber(value.longitude));
   }
 
   private convertArray(arrayValue: api.ArrayValue): unknown[] {

--- a/packages/firestore/test/integration/api/type.test.ts
+++ b/packages/firestore/test/integration/api/type.test.ts
@@ -62,15 +62,22 @@ apiDescribe('Firestore', (persistence: boolean) => {
   it('can read and write geo point fields', () => {
     return withTestDoc(persistence, doc => {
       return doc
-        .set({ geopoint: new GeoPoint(1.23, 4.56) })
-        .then(() => {
+        .set({
+            geopoint1: new GeoPoint(1.23, 4.56),
+            geopoint2: new GeoPoint(0, 0)
+          }).then(() => {
           return doc.get();
         })
         .then(docSnapshot => {
-          const latLong = docSnapshot.data()!['geopoint'];
+          const latLong = docSnapshot.data()!['geopoint1'];
           expect(latLong instanceof GeoPoint).to.equal(true);
           expect(latLong.latitude).to.equal(1.23);
           expect(latLong.longitude).to.equal(4.56);
+
+          const zeroLatLong = docSnapshot.data()!['geopoint2'];
+          expect(zeroLatLong instanceof GeoPoint).to.equal(true);
+          expect(zeroLatLong.latitude).to.equal(0);
+          expect(zeroLatLong.longitude).to.equal(0);
         });
     });
   });

--- a/packages/firestore/test/integration/api/type.test.ts
+++ b/packages/firestore/test/integration/api/type.test.ts
@@ -63,9 +63,10 @@ apiDescribe('Firestore', (persistence: boolean) => {
     return withTestDoc(persistence, doc => {
       return doc
         .set({
-            geopoint1: new GeoPoint(1.23, 4.56),
-            geopoint2: new GeoPoint(0, 0)
-          }).then(() => {
+          geopoint1: new GeoPoint(1.23, 4.56),
+          geopoint2: new GeoPoint(0, 0)
+        })
+        .then(() => {
           return doc.get();
         })
         .then(docSnapshot => {


### PR DESCRIPTION
Fix the regression introduced in #2784: a `GeoPoint` where at least one of the coordinates is zero doesn't marshal properly. This is because zeroes happen to be serialized as `undefined` (presumably because protos normally treat zero values and the absence of a value interchangeably) which then fails the strict input validation in `GeoPoint`.

Fixes #3006.