### PR TITLE
Add invokeRunQueryRpc()

### DIFF
--- a/packages/firestore/src/protos/firestore_proto_api.d.ts
+++ b/packages/firestore/src/protos/firestore_proto_api.d.ts
@@ -314,6 +314,7 @@ export declare namespace firestoreV1ApiClientInterfaces {
     transaction?: string;
   }
   interface RunQueryRequest {
+    parent?: string;
     structuredQuery?: StructuredQuery;
     transaction?: string;
     newTransaction?: TransactionOptions;

--- a/packages/firestore/src/remote/datastore.ts
+++ b/packages/firestore/src/remote/datastore.ts
@@ -171,7 +171,7 @@ export async function invokeRunQueryRpc(
 
   return (
     response
-      // Filter RunQueryResponses that only contain readTimes.
+      // Omit RunQueryResponses that only contain readTimes.
       .filter(proto => !!proto.document)
       .map(proto => datastoreImpl.serializer.fromDocument(proto.document!))
   );

--- a/packages/firestore/src/remote/datastore.ts
+++ b/packages/firestore/src/remote/datastore.ts
@@ -16,7 +16,7 @@
  */
 
 import { CredentialsProvider } from '../api/credentials';
-import { MaybeDocument } from '../model/document';
+import { MaybeDocument, Document } from '../model/document';
 import { DocumentKey } from '../model/document_key';
 import { Mutation, MutationResult } from '../model/mutation';
 import * as api from '../protos/firestore_proto_api';
@@ -31,6 +31,7 @@ import {
   WriteStreamListener
 } from './persistent_stream';
 import { AsyncQueue } from '../util/async_queue';
+import { Query } from '../core/query';
 
 /**
  * Datastore and its related methods are a wrapper around the external Google
@@ -147,6 +148,33 @@ export async function invokeBatchGetDocumentsRpc(
     result.push(doc);
   });
   return result;
+}
+
+export async function invokeRunQueryRpc(
+  datastore: Datastore,
+  query: Query
+): Promise<Document[]> {
+  const datastoreImpl = debugCast(datastore, DatastoreImpl);
+  const { structuredQuery, parent } = datastoreImpl.serializer.toQueryTarget(
+    query.toTarget()
+  );
+  const params = {
+    database: datastoreImpl.serializer.encodedDatabaseId,
+    parent,
+    structuredQuery
+  };
+
+  const response = await datastoreImpl.invokeStreamingRPC<
+    api.RunQueryRequest,
+    api.RunQueryResponse
+  >('RunQuery', params);
+
+  return (
+    response
+      // Filter RunQueryResponses that only contain readTimes.
+      .filter(proto => !!proto.document)
+      .map(proto => datastoreImpl.serializer.fromDocument(proto.document!))
+  );
 }
 
 export function newPersistentWriteStream(


### PR DESCRIPTION
This adds a new `invokeRunQueryRpc` RPC that is used (and tested) in the Lite SDK to run queries via Rest.

This is similar to https://github.com/firebase/firebase-js-sdk/blob/96cd91dd7825f845ce860ffb98703dc48716b81b/packages/firestore/src/remote/datastore.ts#L124

Note: 
- The Query RPC needs a parent set. The types are not correct in `master`. See https://github.com/googleapis/googleapis/blob/master/google/firestore/v1/firestore.proto#L442

- RunQueryResponse returns a stream of documents followed by an empty result which just has `readTime` set. See https://github.com/googleapis/googleapis/blob/master/google/firestore/v1/firestore.proto#L477