### PR TITLE
Move prepush scripts to precommit

### DIFF
--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-push": "node tools/gitHooks/prepush.js"
+      "pre-commit": "node tools/gitHooks/precommit.js"
     }
   }
 }

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -32,9 +32,10 @@ async function getChangedFiles() {
 }
 exports.getChangedFiles = getChangedFiles;
 
-async function getChangedPackages() {
+async function getChangedPackages(changedFiles) {
   const changedPackages = new Set();
-  for (const filename of await getChangedFiles()) {
+  const files = changedFiles || (await getChangedFiles());
+  for (const filename of files) {
     // Check for changed files inside package dirs.
     const match = filename.match('^(packages(-exp)?/[a-zA-Z0-9-]+)/.*');
     if (match && match[1]) {

--- a/tools/gitHooks/license.js
+++ b/tools/gitHooks/license.js
@@ -115,26 +115,24 @@ async function doLicenseCommit(changedFiles) {
     symbol: '✅'
   });
 
-  const hasDiff = await git.diff();
+  // Diff unstaged (prettier writes) against staged.
+  const stageDiff = await git.diff(['--name-only']);
 
-  if (!hasDiff) {
-    console.log(
-      chalk`\n{red License pass caused no changes.} Skipping commit.\n`
-    );
+  if (!stageDiff) {
+    console.log(chalk`\n{red License pass caused no changes.}\n`);
     return;
+  } else {
+    console.log(
+      `License script modified ${stageDiff.split('\n').length - 1} files.`
+    );
   }
 
-  const gitSpinner = ora(' Creating automated license commit').start();
+  const gitSpinner = ora(' Git staging license text modifications.').start();
   await git.add('.');
 
-  const commit = await git.commit('[AUTOMATED]: License Headers');
-
   gitSpinner.stopAndPersist({
-    symbol: '✅'
+    symbol: '▶️'
   });
-  console.log(
-    chalk`{green Commited ${commit.commit} to branch ${commit.branch}}`
-  );
 }
 
 module.exports = {

--- a/tools/gitHooks/license.js
+++ b/tools/gitHooks/license.js
@@ -76,7 +76,7 @@ function rewriteCopyrightLine(contents) {
   return newLines.join('\n');
 }
 
-async function doLicenseCommit(changedFiles) {
+async function doLicense(changedFiles) {
   const licenseSpinner = ora(' Validating License Headers').start();
 
   const paths = changedFiles.filter(line => line.match(/(js|ts)$/));
@@ -115,7 +115,7 @@ async function doLicenseCommit(changedFiles) {
     symbol: '✅'
   });
 
-  // Diff unstaged (prettier writes) against staged.
+  // Diff unstaged (license writes) against staged.
   const stageDiff = await git.diff(['--name-only']);
 
   if (!stageDiff) {
@@ -136,5 +136,5 @@ async function doLicenseCommit(changedFiles) {
 }
 
 module.exports = {
-  doLicenseCommit
+  doLicense
 };

--- a/tools/gitHooks/precommit.js
+++ b/tools/gitHooks/precommit.js
@@ -15,8 +15,8 @@
  * limitations under the License.
  */
 
-const { doPrettierCommit } = require('./prettier');
-const { doLicenseCommit } = require('./license');
+const { doPrettier } = require('./prettier');
+const { doLicense } = require('./license');
 const { resolve } = require('path');
 const simpleGit = require('simple-git/promise');
 const ora = require('ora');
@@ -75,11 +75,17 @@ $ git stash pop
     const changedFiles = diff.split('\n');
 
     // Style the code
-    await doPrettierCommit(changedFiles);
+    await doPrettier(changedFiles);
 
     // Validate License headers exist
-    await doLicenseCommit(changedFiles);
+    await doLicense(changedFiles);
 
+<<<<<<< HEAD
+=======
+    // Generate API reports
+    await doApiReports(changedFiles);
+
+>>>>>>> 391f3e4b... Address some PR comments
     // Diff staged changes against last commit. Don't do an empty commit.
     const postDiff = await git.diff(['--cached']);
     if (!postDiff) {

--- a/tools/gitHooks/precommit.js
+++ b/tools/gitHooks/precommit.js
@@ -19,6 +19,7 @@ const { doPrettierCommit } = require('./prettier');
 const { doLicenseCommit } = require('./license');
 const { resolve } = require('path');
 const simpleGit = require('simple-git/promise');
+const ora = require('ora');
 const chalk = require('chalk');
 
 // Computed Deps
@@ -44,11 +45,33 @@ $ git stash pop
       return process.exit(1);
     }
 
-    const diff = await git.diff([
-      '--name-only',
-      '--diff-filter=d',
-      'origin/master...HEAD'
-    ]);
+    // Try to get most current origin/master.
+    const fetchSpinner = ora(
+      ' Fetching latest version of master branch.'
+    ).start();
+    try {
+      await git.fetch('origin', 'master');
+      fetchSpinner.stopAndPersist({
+        symbol: '✅'
+      });
+    } catch (e) {
+      fetchSpinner.stopAndPersist({
+        symbol: '⚠️'
+      });
+      console.warn(
+        chalk`\n{yellow} Unable to fetch latest version of master, diff may be stale.`
+      );
+    }
+
+    // Diff staged changes against origin/master...HEAD (common ancestor of HEAD and origin/master).
+    const mergeBase = await git.raw(['merge-base', 'origin/master', 'HEAD']);
+    let diffOptions = ['--name-only', '--diff-filter=d', '--cached'];
+    if (mergeBase) {
+      diffOptions.push(mergeBase.trim());
+    } else {
+      diffOptions.push('origin/master');
+    }
+    const diff = await git.diff(diffOptions);
     const changedFiles = diff.split('\n');
 
     // Style the code
@@ -56,6 +79,17 @@ $ git stash pop
 
     // Validate License headers exist
     await doLicenseCommit(changedFiles);
+
+    // Diff staged changes against last commit. Don't do an empty commit.
+    const postDiff = await git.diff(['--cached']);
+    if (!postDiff) {
+      console.error(chalk`
+{red Staged files are identical to previous commit after running formatting
+steps. Skipping commit.}
+
+`);
+      return process.exit(1);
+    }
 
     console.log(chalk`
 Pre-Push Validation Succeeded

--- a/tools/gitHooks/precommit.js
+++ b/tools/gitHooks/precommit.js
@@ -80,12 +80,6 @@ $ git stash pop
     // Validate License headers exist
     await doLicense(changedFiles);
 
-<<<<<<< HEAD
-=======
-    // Generate API reports
-    await doApiReports(changedFiles);
-
->>>>>>> 391f3e4b... Address some PR comments
     // Diff staged changes against last commit. Don't do an empty commit.
     const postDiff = await git.diff(['--cached']);
     if (!postDiff) {

--- a/tools/gitHooks/prettier.js
+++ b/tools/gitHooks/prettier.js
@@ -56,7 +56,7 @@ function checkVersion() {
   });
 }
 
-async function doPrettierCommit(changedFiles) {
+async function doPrettier(changedFiles) {
   try {
     await checkVersion();
   } catch (e) {
@@ -108,5 +108,5 @@ async function doPrettierCommit(changedFiles) {
 }
 
 module.exports = {
-  doPrettierCommit
+  doPrettier
 };


### PR DESCRIPTION
Moved prepush scripts (prettier, license, api-report) to run on precommit. Since they now run on staged and not committed files, they only `git add` and do not create commits.  Some changes have been made to properly diff staged files against master, or staged files against unstaged files, as appropriate.

Also attempts to fetch `origin/master` before diffing to reduce anomalies caused by stale clones.