### PR TITLE
Make notifyLocalViewChanges idempotent

### DIFF
--- a/packages/firestore/src/core/sync_engine.ts
+++ b/packages/firestore/src/core/sync_engine.ts
@@ -682,8 +682,7 @@ export class SyncEngine implements RemoteSyncer {
     this.queriesByTarget.delete(targetId);
 
     if (this.isPrimaryClient) {
-      const limboKeys = this.limboDocumentRefs.referencesForId(targetId);
-      this.limboDocumentRefs.removeReferencesForId(targetId);
+      const limboKeys = this.limboDocumentRefs.removeReferencesForId(targetId);
       limboKeys.forEach(limboKey => {
         const isReferenced = this.limboDocumentRefs.containsKey(limboKey);
         if (!isReferenced) {

--- a/packages/firestore/src/local/indexeddb_mutation_queue.ts
+++ b/packages/firestore/src/local/indexeddb_mutation_queue.ts
@@ -519,7 +519,7 @@ export class IndexedDbMutationQueue implements MutationQueue {
       return PersistencePromise.forEach(
         removedDocuments,
         (key: DocumentKey) => {
-          return this.referenceDelegate.removeMutationReference(
+          return this.referenceDelegate.markPotentiallyOrphaned(
             transaction,
             key
           );

--- a/packages/firestore/src/local/indexeddb_persistence.ts
+++ b/packages/firestore/src/local/indexeddb_persistence.ts
@@ -1070,8 +1070,6 @@ function clientMetadataStore(
 
 /** Provides LRU functionality for IndexedDB persistence. */
 export class IndexedDbLruDelegate implements ReferenceDelegate, LruDelegate {
-  private inMemoryPins: ReferenceSet | null = null;
-
   readonly garbageCollector: LruGarbageCollector;
 
   constructor(private readonly db: IndexedDbPersistence, params: LruParams) {
@@ -1081,14 +1079,14 @@ export class IndexedDbLruDelegate implements ReferenceDelegate, LruDelegate {
   getSequenceNumberCount(
     txn: PersistenceTransaction
   ): PersistencePromise<number> {
-    const docCountPromise = this.orphanedDocmentCount(txn);
+    const docCountPromise = this.orphanedDocumentCount(txn);
     const targetCountPromise = this.db.getTargetCache().getTargetCount(txn);
     return targetCountPromise.next(targetCount =>
       docCountPromise.next(docCount => targetCount + docCount)
     );
   }
 
-  private orphanedDocmentCount(
+  private orphanedDocumentCount(
     txn: PersistenceTransaction
   ): PersistencePromise<number> {
     let orphanedCount = 0;
@@ -1113,12 +1111,9 @@ export class IndexedDbLruDelegate implements ReferenceDelegate, LruDelegate {
     );
   }
 
-  setInMemoryPins(inMemoryPins: ReferenceSet): void {
-    this.inMemoryPins = inMemoryPins;
-  }
-
   addReference(
     txn: PersistenceTransaction,
+    targetId: TargetId,
     key: DocumentKey
   ): PersistencePromise<void> {
     return writeSentinelKey(txn, key);
@@ -1126,6 +1121,7 @@ export class IndexedDbLruDelegate implements ReferenceDelegate, LruDelegate {
 
   removeReference(
     txn: PersistenceTransaction,
+    targetId: TargetId,
     key: DocumentKey
   ): PersistencePromise<void> {
     return writeSentinelKey(txn, key);
@@ -1141,7 +1137,7 @@ export class IndexedDbLruDelegate implements ReferenceDelegate, LruDelegate {
       .removeTargets(txn, upperBound, activeTargetIds);
   }
 
-  removeMutationReference(
+  markPotentiallyOrphaned(
     txn: PersistenceTransaction,
     key: DocumentKey
   ): PersistencePromise<void> {
@@ -1158,11 +1154,7 @@ export class IndexedDbLruDelegate implements ReferenceDelegate, LruDelegate {
     txn: PersistenceTransaction,
     docKey: DocumentKey
   ): PersistencePromise<boolean> {
-    if (this.inMemoryPins!.containsKey(docKey)) {
-      return PersistencePromise.resolve<boolean>(true);
-    } else {
-      return mutationQueuesContainKey(txn, docKey);
-    }
+    return mutationQueuesContainKey(txn, docKey);
   }
 
   removeOrphanedDocuments(

--- a/packages/firestore/src/local/indexeddb_persistence.ts
+++ b/packages/firestore/src/local/indexeddb_persistence.ts
@@ -70,7 +70,6 @@ import {
   ReferenceDelegate
 } from './persistence';
 import { PersistencePromise } from './persistence_promise';
-import { ReferenceSet } from './reference_set';
 import { ClientId } from './shared_client_state';
 import { TargetData } from './target_data';
 import { SimpleDb, SimpleDbStore, SimpleDbTransaction } from './simple_db';

--- a/packages/firestore/src/local/indexeddb_target_cache.ts
+++ b/packages/firestore/src/local/indexeddb_target_cache.ts
@@ -284,7 +284,7 @@ export class IndexedDbTargetCache implements TargetCache {
     keys.forEach(key => {
       const path = encodeResourcePath(key.path);
       promises.push(store.put(new DbTargetDocument(targetId, path)));
-      promises.push(this.referenceDelegate.addReference(txn, key));
+      promises.push(this.referenceDelegate.addReference(txn, targetId, key));
     });
     return PersistencePromise.waitFor(promises);
   }
@@ -301,7 +301,7 @@ export class IndexedDbTargetCache implements TargetCache {
       const path = encodeResourcePath(key.path);
       return PersistencePromise.waitFor([
         store.delete([targetId, path]),
-        this.referenceDelegate.removeReference(txn, key)
+        this.referenceDelegate.removeReference(txn, targetId, key)
       ]);
     });
   }

--- a/packages/firestore/src/local/local_store.ts
+++ b/packages/firestore/src/local/local_store.ts
@@ -56,7 +56,6 @@ import {
 import { PersistencePromise } from './persistence_promise';
 import { TargetCache } from './target_cache';
 import { QueryEngine } from './query_engine';
-import { ReferenceSet } from './reference_set';
 import { RemoteDocumentCache } from './remote_document_cache';
 import { RemoteDocumentChangeBuffer } from './remote_document_change_buffer';
 import { ClientId } from './shared_client_state';

--- a/packages/firestore/src/local/memory_mutation_queue.ts
+++ b/packages/firestore/src/local/memory_mutation_queue.ts
@@ -299,7 +299,7 @@ export class MemoryMutationQueue implements MutationQueue {
     return PersistencePromise.forEach(batch.mutations, (mutation: Mutation) => {
       const ref = new DocReference(mutation.key, batch.batchId);
       references = references.delete(ref);
-      return this.referenceDelegate.removeMutationReference(
+      return this.referenceDelegate.markPotentiallyOrphaned(
         transaction,
         mutation.key
       );

--- a/packages/firestore/src/local/memory_persistence.ts
+++ b/packages/firestore/src/local/memory_persistence.ts
@@ -184,7 +184,7 @@ export interface MemoryReferenceDelegate extends ReferenceDelegate {
 }
 
 export class MemoryEagerDelegate implements MemoryReferenceDelegate {
-  /** Manages all documents that are active in Query views. */
+  /** Tracks all documents that are active in Query views. */
   private localViewReferences: ReferenceSet = new ReferenceSet();
   /** The list of documents that are potentially GCed after each transaction. */
   private _orphanedDocuments: Set<DocumentKey> | null = null;

--- a/packages/firestore/src/local/memory_persistence.ts
+++ b/packages/firestore/src/local/memory_persistence.ts
@@ -29,7 +29,7 @@ import {
   LruParams
 } from './lru_garbage_collector';
 import { ListenSequence } from '../core/listen_sequence';
-import { ListenSequenceNumber } from '../core/types';
+import { ListenSequenceNumber, TargetId } from '../core/types';
 import { estimateByteSize } from '../model/values';
 import { MemoryIndexManager } from './memory_index_manager';
 import { MemoryMutationQueue } from './memory_mutation_queue';
@@ -184,7 +184,9 @@ export interface MemoryReferenceDelegate extends ReferenceDelegate {
 }
 
 export class MemoryEagerDelegate implements MemoryReferenceDelegate {
-  private inMemoryPins: ReferenceSet | null = null;
+  /** Manages all documents that are active in Query views. */
+  private localViewReferences: ReferenceSet = new ReferenceSet();
+  /** The list of documents that are potentially GCed after each transaction. */
   private _orphanedDocuments: Set<DocumentKey> | null = null;
 
   private constructor(private readonly persistence: MemoryPersistence) {}
@@ -201,27 +203,27 @@ export class MemoryEagerDelegate implements MemoryReferenceDelegate {
     }
   }
 
-  setInMemoryPins(inMemoryPins: ReferenceSet): void {
-    this.inMemoryPins = inMemoryPins;
-  }
-
   addReference(
     txn: PersistenceTransaction,
+    targetId: TargetId,
     key: DocumentKey
   ): PersistencePromise<void> {
+    this.localViewReferences.addReference(key, targetId);
     this.orphanedDocuments.delete(key);
     return PersistencePromise.resolve();
   }
 
   removeReference(
     txn: PersistenceTransaction,
+    targetId: TargetId,
     key: DocumentKey
   ): PersistencePromise<void> {
+    this.localViewReferences.removeReference(key, targetId);
     this.orphanedDocuments.add(key);
     return PersistencePromise.resolve();
   }
 
-  removeMutationReference(
+  markPotentiallyOrphaned(
     txn: PersistenceTransaction,
     key: DocumentKey
   ): PersistencePromise<void> {
@@ -233,6 +235,10 @@ export class MemoryEagerDelegate implements MemoryReferenceDelegate {
     txn: PersistenceTransaction,
     targetData: TargetData
   ): PersistencePromise<void> {
+    const orphaned = this.localViewReferences.removeReferencesForId(
+      targetData.targetId
+    );
+    orphaned.forEach(key => this.orphanedDocuments.add(key));
     const cache = this.persistence.getTargetCache();
     return cache
       .getMatchingKeysForTargetId(txn, targetData.targetId)
@@ -290,15 +296,15 @@ export class MemoryEagerDelegate implements MemoryReferenceDelegate {
     key: DocumentKey
   ): PersistencePromise<boolean> {
     return PersistencePromise.or([
+      () =>
+        PersistencePromise.resolve(this.localViewReferences.containsKey(key)),
       () => this.persistence.getTargetCache().containsKey(txn, key),
-      () => this.persistence.mutationQueuesContainKey(txn, key),
-      () => PersistencePromise.resolve(this.inMemoryPins!.containsKey(key))
+      () => this.persistence.mutationQueuesContainKey(txn, key)
     ]);
   }
 }
 
 export class MemoryLruDelegate implements ReferenceDelegate, LruDelegate {
-  private inMemoryPins: ReferenceSet | null = null;
   private orphanedSequenceNumbers: ObjectMap<
     DocumentKey,
     ListenSequenceNumber
@@ -371,10 +377,6 @@ export class MemoryLruDelegate implements ReferenceDelegate, LruDelegate {
     );
   }
 
-  setInMemoryPins(inMemoryPins: ReferenceSet): void {
-    this.inMemoryPins = inMemoryPins;
-  }
-
   removeTargets(
     txn: PersistenceTransaction,
     upperBound: ListenSequenceNumber,
@@ -403,7 +405,7 @@ export class MemoryLruDelegate implements ReferenceDelegate, LruDelegate {
     return p.next(() => changeBuffer.apply(txn)).next(() => count);
   }
 
-  removeMutationReference(
+  markPotentiallyOrphaned(
     txn: PersistenceTransaction,
     key: DocumentKey
   ): PersistencePromise<void> {
@@ -421,6 +423,7 @@ export class MemoryLruDelegate implements ReferenceDelegate, LruDelegate {
 
   addReference(
     txn: PersistenceTransaction,
+    targetId: TargetId,
     key: DocumentKey
   ): PersistencePromise<void> {
     this.orphanedSequenceNumbers.set(key, txn.currentSequenceNumber);
@@ -429,6 +432,7 @@ export class MemoryLruDelegate implements ReferenceDelegate, LruDelegate {
 
   removeReference(
     txn: PersistenceTransaction,
+    targetId: TargetId,
     key: DocumentKey
   ): PersistencePromise<void> {
     this.orphanedSequenceNumbers.set(key, txn.currentSequenceNumber);
@@ -458,7 +462,6 @@ export class MemoryLruDelegate implements ReferenceDelegate, LruDelegate {
   ): PersistencePromise<boolean> {
     return PersistencePromise.or([
       () => this.persistence.mutationQueuesContainKey(txn, key),
-      () => PersistencePromise.resolve(this.inMemoryPins!.containsKey(key)),
       () => this.persistence.getTargetCache().containsKey(txn, key),
       () => {
         const orphanedAt = this.orphanedSequenceNumbers.get(key);

--- a/packages/firestore/src/local/memory_target_cache.ts
+++ b/packages/firestore/src/local/memory_target_cache.ts
@@ -191,14 +191,7 @@ export class MemoryTargetCache implements TargetCache {
     targetId: TargetId
   ): PersistencePromise<void> {
     this.references.addReferences(keys, targetId);
-    const referenceDelegate = this.persistence.referenceDelegate;
-    const promises: Array<PersistencePromise<void>> = [];
-    if (referenceDelegate) {
-      keys.forEach(key => {
-        promises.push(referenceDelegate.addReference(txn, key));
-      });
-    }
-    return PersistencePromise.waitFor(promises);
+    return PersistencePromise.resolve();
   }
 
   removeMatchingKeys(
@@ -211,7 +204,7 @@ export class MemoryTargetCache implements TargetCache {
     const promises: Array<PersistencePromise<void>> = [];
     if (referenceDelegate) {
       keys.forEach(key => {
-        promises.push(referenceDelegate.removeReference(txn, key));
+        promises.push(referenceDelegate.markPotentiallyOrphaned(txn, key));
       });
     }
     return PersistencePromise.waitFor(promises);

--- a/packages/firestore/test/unit/local/lru_garbage_collector.test.ts
+++ b/packages/firestore/test/unit/local/lru_garbage_collector.test.ts
@@ -36,7 +36,6 @@ import {
 
 import { PersistencePromise } from '../../../src/local/persistence_promise';
 import { TargetCache } from '../../../src/local/target_cache';
-import { ReferenceSet } from '../../../src/local/reference_set';
 import { RemoteDocumentCache } from '../../../src/local/remote_document_cache';
 import { TargetData, TargetPurpose } from '../../../src/local/target_data';
 import { documentKeySet } from '../../../src/model/collections';

--- a/packages/firestore/test/unit/local/lru_garbage_collector.test.ts
+++ b/packages/firestore/test/unit/local/lru_garbage_collector.test.ts
@@ -122,7 +122,6 @@ function genericLruGarbageCollectorTests(
       txn => PersistencePromise.resolve(txn.currentSequenceNumber)
     );
     const referenceDelegate = persistence.referenceDelegate;
-    referenceDelegate.setInMemoryPins(new ReferenceSet());
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     garbageCollector = ((referenceDelegate as any) as LruDelegate)
       .garbageCollector;
@@ -175,7 +174,7 @@ function genericLruGarbageCollectorTests(
     txn: PersistenceTransaction,
     key: DocumentKey
   ): PersistencePromise<void> {
-    return persistence.referenceDelegate.removeMutationReference(txn, key);
+    return persistence.referenceDelegate.markPotentiallyOrphaned(txn, key);
   }
 
   function markDocumentEligibleForGC(key: DocumentKey): Promise<void> {

--- a/packages/firestore/test/unit/local/mutation_queue.test.ts
+++ b/packages/firestore/test/unit/local/mutation_queue.test.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2017 Google Inc.
+ * Copyright 2017 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/firestore/test/unit/local/mutation_queue.test.ts
+++ b/packages/firestore/test/unit/local/mutation_queue.test.ts
@@ -20,7 +20,6 @@ import { User } from '../../../src/auth/user';
 import { Query } from '../../../src/core/query';
 import { IndexedDbPersistence } from '../../../src/local/indexeddb_persistence';
 import { Persistence } from '../../../src/local/persistence';
-import { ReferenceSet } from '../../../src/local/reference_set';
 import { documentKeySet } from '../../../src/model/collections';
 import { MutationBatch } from '../../../src/model/mutation_batch';
 import {

--- a/packages/firestore/test/unit/local/mutation_queue.test.ts
+++ b/packages/firestore/test/unit/local/mutation_queue.test.ts
@@ -72,7 +72,6 @@ function genericMutationQueueTests(): void {
   addEqualityMatcher();
 
   beforeEach(() => {
-    persistence.referenceDelegate.setInMemoryPins(new ReferenceSet());
     mutationQueue = new TestMutationQueue(
       persistence,
       persistence.getMutationQueue(new User('user'))

--- a/packages/firestore/test/unit/local/target_cache.test.ts
+++ b/packages/firestore/test/unit/local/target_cache.test.ts
@@ -21,7 +21,6 @@ import { SnapshotVersion } from '../../../src/core/snapshot_version';
 import { TargetId } from '../../../src/core/types';
 import { IndexedDbPersistence } from '../../../src/local/indexeddb_persistence';
 import { Persistence } from '../../../src/local/persistence';
-import { ReferenceSet } from '../../../src/local/reference_set';
 import { TargetData, TargetPurpose } from '../../../src/local/target_data';
 import { addEqualityMatcher } from '../../util/equality_matcher';
 import {

--- a/packages/firestore/test/unit/local/target_cache.test.ts
+++ b/packages/firestore/test/unit/local/target_cache.test.ts
@@ -143,7 +143,6 @@ function genericTargetCacheTests(
   let persistence: Persistence;
   beforeEach(async () => {
     persistence = await persistencePromise();
-    persistence.referenceDelegate.setInMemoryPins(new ReferenceSet());
     cache = new TestTargetCache(persistence, persistence.getTargetCache());
   });
 

--- a/packages/firestore/test/unit/specs/listen_spec.test.ts
+++ b/packages/firestore/test/unit/specs/listen_spec.test.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2017 Google Inc.
+ * Copyright 2017 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
This changes `notifyLocalViewChanges` so that it has not side effects if the transaction fails. The main change is that I removed the indirection of the reference delegate to ask the LocalStore what documents are "pinned". Instead, the Local Store directly tells the reference delegate about every document that is added to a View.

Adresses #2755