### PR TITLE
Fix regression for merge with increment

### DIFF
--- a/packages/firestore/CHANGELOG.md
+++ b/packages/firestore/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Unreleased
+- [fixed] Fixed a regression introduced in v7.14.2 that incorrectly applied
+  a `FieldValue.increment` in combination with `set({...}, {merge: true})`.
 - [fixed] Firestore now rejects `onSnapshot()` listeners if they cannot be
   registered in IndexedDB. Previously, these errors crashed the client.
 - [fixed] Firestore now rejects write operations if they cannot be persisted

--- a/packages/firestore/src/api/field_value.ts
+++ b/packages/firestore/src/api/field_value.ts
@@ -102,12 +102,17 @@ export class ArrayUnionFieldValueImpl extends FieldValueImpl {
     // Although array transforms are used with writes, the actual elements
     // being uniomed or removed are not considered writes since they cannot
     // contain any FieldValue sentinels, etc.
-    const parseContext = context.contextWith({
-      dataSource: UserDataSource.Argument,
-      methodName: this._methodName
-    });
+    const parseContext = new ParseContext(
+      {
+        dataSource: UserDataSource.Argument,
+        methodName: this._methodName,
+        arrayElement: true
+      },
+      context.databaseId,
+      context.serializer
+    );
     const parsedElements = this._elements.map(
-      (element, i) => parseData(element, parseContext.childContextForArray(i))!
+      element => parseData(element, parseContext)!
     );
     const arrayUnion = new ArrayUnionTransformOperation(parsedElements);
     return new FieldTransform(context.path!, arrayUnion);
@@ -128,12 +133,17 @@ export class ArrayRemoveFieldValueImpl extends FieldValueImpl {
     // Although array transforms are used with writes, the actual elements
     // being unioned or removed are not considered writes since they cannot
     // contain any FieldValue sentinels, etc.
-    const parseContext = context.contextWith({
-      dataSource: UserDataSource.Argument,
-      methodName: this._methodName
-    });
+    const parseContext = new ParseContext(
+      {
+        dataSource: UserDataSource.Argument,
+        methodName: this._methodName,
+        arrayElement: true
+      },
+      context.databaseId,
+      context.serializer
+    );
     const parsedElements = this._elements.map(
-      (element, i) => parseData(element, parseContext.childContextForArray(i))!
+      element => parseData(element, parseContext)!
     );
     const arrayUnion = new ArrayRemoveTransformOperation(parsedElements);
     return new FieldTransform(context.path!, arrayUnion);
@@ -151,8 +161,15 @@ export class NumericIncrementFieldValueImpl extends FieldValueImpl {
   }
 
   toFieldTransform(context: ParseContext): FieldTransform {
-    context.contextWith({ methodName: this._methodName });
-    const operand = parseData(this._operand, context)!;
+    const parseContext = new ParseContext(
+      {
+        dataSource: UserDataSource.Argument,
+        methodName: this._methodName
+      },
+      context.databaseId,
+      context.serializer
+    );
+    const operand = parseData(this._operand, parseContext)!;
     const numericIncrement = new NumericIncrementTransformOperation(
       context.serializer,
       operand

--- a/packages/firestore/src/api/user_data_reader.ts
+++ b/packages/firestore/src/api/user_data_reader.ts
@@ -138,12 +138,12 @@ interface ContextSettings {
    * A path within the object being parsed. This could be an empty path (in
    * which case the context represents the root of the data being parsed), or a
    * nonempty path (indicating the context represents a nested location within
-   * the data). Defaults to null.
+   * the data).
    */
   readonly path?: FieldPath;
   /**
    * Whether or not this context corresponds to an element of an array.
-   * Defaults to false.
+   * If not set, elements are treated as if they were outside of arrays.
    */
   readonly arrayElement?: boolean;
 }
@@ -219,7 +219,7 @@ export class ParseContext {
 
   childContextForArray(index: number): ParseContext {
     // TODO(b/34871131): We don't support array paths right now; so make path
-    // null.
+    // undefined.
     return this.contextWith({ path: undefined, arrayElement: true });
   }
 

--- a/packages/firestore/src/api/user_data_reader.ts
+++ b/packages/firestore/src/api/user_data_reader.ts
@@ -138,11 +138,14 @@ interface ContextSettings {
    * A path within the object being parsed. This could be an empty path (in
    * which case the context represents the root of the data being parsed), or a
    * nonempty path (indicating the context represents a nested location within
-   * the data).
+   * the data). Defaults to null.
    */
-  readonly path: FieldPath | null;
-  /** Whether or not this context corresponds to an element of an array. */
-  readonly arrayElement: boolean;
+  readonly path?: FieldPath;
+  /**
+   * Whether or not this context corresponds to an element of an array.
+   * Defaults to false.
+   */
+  readonly arrayElement?: boolean;
 }
 
 /** A "context" object passed around while parsing user data. */
@@ -181,7 +184,7 @@ export class ParseContext {
     this.fieldMask = fieldMask || [];
   }
 
-  get path(): FieldPath | null {
+  get path(): FieldPath | undefined {
     return this.settings.path;
   }
 
@@ -201,14 +204,14 @@ export class ParseContext {
   }
 
   childContextForField(field: string): ParseContext {
-    const childPath = this.path == null ? null : this.path.child(field);
+    const childPath = this.path?.child(field);
     const context = this.contextWith({ path: childPath, arrayElement: false });
     context.validatePathSegment(field);
     return context;
   }
 
   childContextForFieldPath(field: FieldPath): ParseContext {
-    const childPath = this.path == null ? null : this.path.child(field);
+    const childPath = this.path?.child(field);
     const context = this.contextWith({ path: childPath, arrayElement: false });
     context.validatePath();
     return context;
@@ -217,12 +220,12 @@ export class ParseContext {
   childContextForArray(index: number): ParseContext {
     // TODO(b/34871131): We don't support array paths right now; so make path
     // null.
-    return this.contextWith({ path: null, arrayElement: true });
+    return this.contextWith({ path: undefined, arrayElement: true });
   }
 
   createError(reason: string): Error {
     const fieldDescription =
-      this.path === null || this.path.isEmpty()
+      !this.path || this.path.isEmpty()
         ? ''
         : ` (found in field ${this.path.toString()})`;
     return new FirestoreError(
@@ -246,7 +249,7 @@ export class ParseContext {
   private validatePath(): void {
     // TODO(b/34871131): Remove null check once we have proper paths for fields
     // within arrays.
-    if (this.path === null) {
+    if (!this.path) {
       return;
     }
     for (let i = 0; i < this.path.length; i++) {

--- a/packages/firestore/test/integration/api/numeric_transforms.test.ts
+++ b/packages/firestore/test/integration/api/numeric_transforms.test.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2018 Google Inc.
+ * Copyright 2018 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -137,6 +137,14 @@ apiDescribe('Numeric Transforms:', (persistence: boolean) => {
       await writeInitialData({ sum: 'overwrite' });
       await docRef.update('sum', FieldValue.increment(13.37));
       await expectLocalAndRemoteValue(13.37);
+    });
+  });
+
+  it('increments with set() and merge:true', async () => {
+    await withTestSetup(async () => {
+      await writeInitialData({ sum: 1 });
+      await docRef.set({ sum: FieldValue.increment(1337) }, { merge: true });
+      await expectLocalAndRemoteValue(1338);
     });
   });
 


### PR DESCRIPTION
This reverts a behavior change in https://github.com/firebase/firebase-js-sdk/pull/3001

Before this PR, the parse contexts we used to parse ArrayTransform and Increment values was detached from the original parse context that was used to parse the update. Thus, setting the field path for the value that was being incremented did not end up modifying the context that was used to generate the Proto. The result of this was `{ updateMask: [] }`. By removing the copy, we ended up with `{ updateMask: ['sum'] }`, which ended up rewriting the value before applying the increment.

Fixes https://github.com/firebase/firebase-js-sdk/issues/3045