### PR TITLE
Allow failing of individual transactions

### DIFF
--- a/packages/firestore/test/unit/specs/spec_builder.ts
+++ b/packages/firestore/test/unit/specs/spec_builder.ts
@@ -45,6 +45,7 @@ import {
   parseQuery,
   runSpec,
   SpecConfig,
+  SpecDatabaseFailures,
   SpecDocument,
   SpecQuery,
   SpecQueryFilter,
@@ -435,12 +436,15 @@ export class SpecBuilder {
     return this;
   }
 
-  /** Fails all database operations until `recoverDatabase()` is called. */
-  failDatabase(): this {
+  /**
+   * Fails the specified database transaction until `recoverDatabase()` is
+   * called.
+   */
+  failDatabaseTransactions(failureMode: SpecDatabaseFailures): this {
     this.nextStep();
     this.injectFailures = true;
     this.currentStep = {
-      failDatabase: true
+      failDatabase: failureMode
     };
     return this;
   }

--- a/packages/firestore/test/unit/specs/spec_test_components.ts
+++ b/packages/firestore/test/unit/specs/spec_test_components.ts
@@ -104,7 +104,7 @@ function failTransactionIfNeeded(
       throw fail('Failure mode not specified for action: ' + action);
     } else if (shouldFail) {
       throw new IndexedDbTransactionError(
-        new Error('Simulated retryable error' + action)
+        new Error('Simulated retryable error: ' + action)
       );
     }
   }


### PR DESCRIPTION
Disclaimer: This is pretty ugly... feedback appreciated :)

The idea of the PR is to expand the new "failDatabase" spec test feature to allow the tests to specify which transaction action to fail. This allows individualized failures for operations that spawn multiple actions. Currently, we only test scenarios where the first transaction fails. This will allows us to test what happens if the first transaction succeeds and the second one fails.