### PR TITLE
Ignore failures for notifyLocalViewChanges

### DIFF
--- a/packages/firestore/test/unit/specs/recovery_spec.test.ts
+++ b/packages/firestore/test/unit/specs/recovery_spec.test.ts
@@ -215,7 +215,9 @@ describeSpec('Persistence Recovery', ['no-ios', 'no-android'], () => {
         .userListens(query)
         .failDatabaseTransactions({
           'Locally write mutations': false,
-          notifyLocalViewChanges: true
+          notifyLocalViewChanges: true,
+          'Get next mutation batch': false,
+          'Set last stream token': false
         })
         .userSets('collection/key1', { foo: 'a' })
         .expectEvents(query, {
@@ -248,6 +250,7 @@ describeSpec('Persistence Recovery', ['no-ios', 'no-android'], () => {
       const deletedDoc1 = deletedDoc('collection/key1', 2000);
       return (
         spec()
+          .withGCEnabled(false)
           .userListens(query)
           .watchAcksFull(query, 1000, doc1)
           .expectEvents(query, {
@@ -266,7 +269,7 @@ describeSpec('Persistence Recovery', ['no-ios', 'no-android'], () => {
           .recoverDatabase()
           .userUnlistens(query)
           // No event since the document was removed
-          .userListens(query)
+          .userListens(query, 'resume-token-1000')
       );
     }
   );

--- a/packages/firestore/test/unit/specs/recovery_spec.test.ts
+++ b/packages/firestore/test/unit/specs/recovery_spec.test.ts
@@ -20,7 +20,7 @@ import { client, spec } from './spec_builder';
 import { TimerId } from '../../../src/util/async_queue';
 import { Query } from '../../../src/core/query';
 import { Code } from '../../../src/util/error';
-import { doc, filter, path } from '../../util/helpers';
+import { deletedDoc, doc, filter, path } from '../../util/helpers';
 import { RpcError } from './spec_rpc_error';
 
 describeSpec('Persistence Recovery', ['no-ios', 'no-android'], () => {
@@ -124,24 +124,34 @@ describeSpec('Persistence Recovery', ['no-ios', 'no-android'], () => {
   );
 
   specTest('Recovers when write cannot be persisted', [], () => {
-    return spec()
-      .userSets('collection/key1', { foo: 'a' })
-      .expectNumOutstandingWrites(1)
-      .failDatabaseTransactions({
-        'Locally write mutations': true,
-        notifyLocalViewChanges: true,
-        'Get next mutation batch': true,
-        'Get last stream token': true
-      })
-      .userSets('collection/key2', { bar: 'b' })
-      .expectUserCallbacks({ rejected: ['collection/key2'] })
-      .recoverDatabase()
-      .expectNumOutstandingWrites(1)
-      .userSets('collection/key3', { baz: 'c' })
-      .expectNumOutstandingWrites(2)
-      .writeAcks('collection/key1', 1)
-      .writeAcks('collection/key3', 2)
-      .expectNumOutstandingWrites(0);
+    return (
+      spec()
+        .userSets('collection/key1', { foo: 'a' })
+        .expectNumOutstandingWrites(1)
+        // We fail the write if we cannot persist the local mutation (via
+        // 'Locally write mutations').
+        .failDatabaseTransactions({
+          'Locally write mutations': true
+        })
+        .userSets('collection/key2', { bar: 'b' })
+        .expectUserCallbacks({ rejected: ['collection/key2'] })
+        // The write is considered successful if we can persist the local mutation
+        // but fail to update view assignments (via 'notifyLocalViewChanges').
+        .failDatabaseTransactions({
+          'Locally write mutations': false,
+          notifyLocalViewChanges: true,
+          'Get next mutation batch': false
+        })
+        .userSets('collection/key3', { bar: 'b' })
+        .recoverDatabase()
+        .expectNumOutstandingWrites(2)
+        .userSets('collection/key4', { baz: 'c' })
+        .expectNumOutstandingWrites(3)
+        .writeAcks('collection/key1', 1)
+        .writeAcks('collection/key3', 2)
+        .writeAcks('collection/key4', 3)
+        .expectNumOutstandingWrites(0)
+    );
   });
 
   specTest('Does not surface non-persisted writes', [], () => {
@@ -187,6 +197,79 @@ describeSpec('Persistence Recovery', ['no-ios', 'no-android'], () => {
       .watchAcksFull(query, 2, doc1, doc3)
       .expectEvents(query, { metadata: [doc1, doc3] });
   });
+
+  specTest(
+    'Surfaces local documents if notifyLocalViewChanges fails',
+    [],
+    () => {
+      const query = Query.atPath(path('collection'));
+      const doc1Local = doc(
+        'collection/key1',
+        0,
+        { foo: 'a' },
+        { hasLocalMutations: true }
+      );
+      const doc1 = doc('collection/key1', 1, { foo: 'a' });
+      const doc2 = doc('collection/key2', 2, { foo: 'b' });
+      return spec()
+        .userListens(query)
+        .failDatabaseTransactions({
+          'Locally write mutations': false,
+          notifyLocalViewChanges: true
+        })
+        .userSets('collection/key1', { foo: 'a' })
+        .expectEvents(query, {
+          added: [doc1Local],
+          fromCache: true,
+          hasPendingWrites: true
+        })
+        .recoverDatabase()
+        .runTimer(TimerId.AsyncQueueRetry)
+        .writeAcks('collection/key1', 1)
+        .failDatabaseTransactions({
+          'Apply remote event': false,
+          notifyLocalViewChanges: true,
+          'Get last remote snapshot version': false
+        })
+        .watchAcksFull(query, 1000, doc1, doc2)
+        .expectEvents(query, {
+          metadata: [doc1],
+          added: [doc2]
+        });
+    }
+  );
+
+  specTest(
+    'Excludes documents from future queries even if notifyLocalViewChanges fails',
+    [],
+    () => {
+      const query = Query.atPath(path('collection'));
+      const doc1 = doc('collection/key1', 1000, { foo: 'a' });
+      const deletedDoc1 = deletedDoc('collection/key1', 2000);
+      return (
+        spec()
+          .userListens(query)
+          .watchAcksFull(query, 1000, doc1)
+          .expectEvents(query, {
+            added: [doc1]
+          })
+          .failDatabaseTransactions({
+            'Apply remote event': false,
+            notifyLocalViewChanges: true,
+            'Get last remote snapshot version': false
+          })
+          .watchSends({ removed: [query] }, deletedDoc1)
+          .watchSnapshots(2000)
+          .expectEvents(query, {
+            removed: [doc1]
+          })
+          .recoverDatabase()
+          .userUnlistens(query)
+          // No event since the document was removed
+          .userListens(query)
+      );
+    }
+  );
 
   specTest('Fails targets that cannot be allocated', [], () => {
     const query1 = Query.atPath(path('collection1'));


### PR DESCRIPTION
This adds code to ignore failures during `notifyLocalViewChanges`. This should only affect LRU GC and only mean that the documents get GCed earlier.

If we have to add recovery logic we probably need to buffer these changes and apply them via `enqueueRetryable` before running LRU GC. That's why I am hoping that we don't need to.

Disclaimer: I am not sure if this is actually correct, but I hope it is.

Addresses #2755