### PR TITLE
Fix Emulator URL in database CI

### DIFF
--- a/packages/testing/src/api/index.ts
+++ b/packages/testing/src/api/index.ts
@@ -120,7 +120,9 @@ function initializeApp(
 ): firebase.app.App {
   let appOptions: { [key: string]: string } = {};
   if (databaseName) {
-    appOptions['databaseURL'] = `http://${DATABASE_ADDRESS}?ns=${databaseName}`;
+    appOptions[
+      'databaseURL'
+    ] = `http://${DATABASE_ADDRESS}/?ns=${databaseName}`;
   }
   if (projectId) {
     appOptions['projectId'] = projectId;


### PR DESCRIPTION
This should fix the CI failures in https://github.com/firebase/firebase-js-sdk/pull/3038/checks?check_run_id=675464771

cc @fredzqm - Just an FYI, it looks like we are no longer parsing `http://localhost:8080?ns=foo` URLs correctly, which should be fine since they are not valid. For reference: https://stackoverflow.com/questions/1617058/ok-to-skip-slash-before-query-string