### PR TITLE
Ensure run_changed errors on packages without test script

### DIFF
--- a/packages-exp/firebase-exp/package.json
+++ b/packages-exp/firebase-exp/package.json
@@ -30,7 +30,9 @@
     "build": "rollup -c && gulp firebase-js",
     "build:release": "rollup -c rollup.config.release.js && gulp firebase-js",
     "dev": "rollup -c -w",
-    "prepare": "yarn build:release"
+    "prepare": "yarn build:release",
+    "test": "echo 'No test suite for firebase wrapper'",
+    "test:ci": "echo 'No test suite for firebase wrapper'"
   },
   "dependencies": {
     "@firebase/app-exp": "0.0.800"

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -19,7 +19,6 @@
     "build": "rollup -c",
     "build:deps": "lerna run --scope @firebase/app --include-dependencies build",
     "dev": "rollup -c -w",
-    "test": "yarn type-check && run-p lint test:browser test:node",
     "test:ci": "node ../../scripts/run_tests_in_ci.js",
     "type-check": "tsc -p . --noEmit",
     "test:browser": "karma start --single-run",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -19,6 +19,7 @@
     "build": "rollup -c",
     "build:deps": "lerna run --scope @firebase/app --include-dependencies build",
     "dev": "rollup -c -w",
+    "test": "yarn type-check && run-p lint test:browser test:node",
     "test:ci": "node ../../scripts/run_tests_in_ci.js",
     "type-check": "tsc -p . --noEmit",
     "test:browser": "karma start --single-run",

--- a/packages/firebase/package.json
+++ b/packages/firebase/package.json
@@ -36,7 +36,9 @@
     "build": "rollup -c",
     "build:deps": "lerna run --scope firebase --include-dependencies build",
     "dev": "rollup -c -w",
-    "prepare": "yarn build"
+    "prepare": "yarn build",
+    "test": "echo 'No test suite for firebase wrapper'",
+    "test:ci": "echo 'No test suite for firebase wrapper'"
   },
   "main": "dist/index.node.cjs.js",
   "browser": "dist/index.cjs.js",

--- a/packages/webchannel-wrapper/package.json
+++ b/packages/webchannel-wrapper/package.json
@@ -12,7 +12,9 @@
   "scripts": {
     "dev": "watch 'yarn build' src",
     "build": "gulp",
-    "prepare": "yarn build"
+    "prepare": "yarn build",
+    "test": "echo 'No test suite for webchannel-wrapper'",
+    "test:ci": "echo 'No test suite for webchannel-wrapper'"
   },
   "license": "Apache-2.0",
   "devDependencies": {

--- a/scripts/run_changed.js
+++ b/scripts/run_changed.js
@@ -153,7 +153,7 @@ async function runTests(pathList) {
         stdio: 'inherit'
       });
     } catch (e) {
-      throw new Error(`Error running tests in ${testPath}.`);
+      throw new Error(`Error running "yarn ${testCommand}" in ${testPath}.`);
     }
   }
 }
@@ -185,7 +185,7 @@ async function main() {
       await runTests(Object.keys(changedPackages));
     }
   } catch (e) {
-    console.error(e);
+    console.error(chalk`{red ${e}}`);
     process.exit(1);
   }
 }

--- a/scripts/run_changed.js
+++ b/scripts/run_changed.js
@@ -25,6 +25,7 @@ const git = simpleGit(root);
 
 // use test:ci command in CI
 const testCommand = !!process.env.CI ? 'test:ci' : 'test';
+// const testCommand = 'print';
 /**
  * Changes to these files warrant running all tests.
  */
@@ -104,10 +105,8 @@ async function getChangedPackages() {
     if (match && match[1]) {
       const changedPackage = require(resolve(root, match[1], 'package.json'));
       if (changedPackage) {
-        if (changedPackage.scripts.test) {
-          // Add the package itself.
-          changedPackages[match[1]] = 'direct';
-        }
+        // Add the package itself.
+        changedPackages[match[1]] = 'direct';
         // Add packages that depend on it.
         for (const package in depGraph) {
           if (depGraph[package].includes(changedPackage.name)) {
@@ -117,7 +116,7 @@ async function getChangedPackages() {
                 depData.location,
                 'package.json'
               ));
-              if (depPkgJson && depPkgJson.scripts.test) {
+              if (depPkgJson) {
                 const depPath = depData.location.replace(`${root}/`, '');
                 if (!changedPackages[depPath]) {
                   changedPackages[depPath] = 'dependency';

--- a/scripts/run_changed.js
+++ b/scripts/run_changed.js
@@ -25,7 +25,7 @@ const git = simpleGit(root);
 
 // use test:ci command in CI
 const testCommand = !!process.env.CI ? 'test:ci' : 'test';
-// const testCommand = 'print';
+
 /**
  * Changes to these files warrant running all tests.
  */


### PR DESCRIPTION
For a more safety, we would like `run_changed.js` (the script behind the Test Changed Packages workflow) to fail if it finds a package without a "test" or "test:ci" script (whichever command it is running).

A maintainer can put placeholder stubs for those scripts if the package does not have tests to run, but this will prevent accidentally forgetting to add a test script.

Added stubs for these scripts to packages that did not have them.