### PR TITLE
Add rel=preconnect to improve page load

### DIFF
--- a/packages/analytics/src/helpers.ts
+++ b/packages/analytics/src/helpers.ts
@@ -70,6 +70,8 @@ export function insertScriptTag(dataLayerName: string): void {
   // without fid. We will initialize ga-id using gtag (config) command together with fid.
   script.src = `${GTAG_URL}?l=${dataLayerName}`;
   script.async = true;
+  // https://web.dev/uses-rel-preconnect/?utm_source=lighthouse&utm_medium=devtools#improve-page-load-speed-with-preconnect
+  script.rel = 'preconnect'; 
   document.head.appendChild(script);
 }
 


### PR DESCRIPTION
I audited my website after adding firebase analytics, and saw it is missing an attribute suggested by lighthouse to improve page load
https://web.dev/uses-rel-preconnect/?utm_source=lighthouse&utm_medium=devtools#improve-page-load-speed-with-preconnect