### PR TITLE
Make instance logLevel setter able to process string input

### DIFF
--- a/packages/logger/src/logger.ts
+++ b/packages/logger/src/logger.ts
@@ -141,14 +141,15 @@ export class Logger {
    * The log level of the given Logger instance.
    */
   private _logLevel = defaultLogLevel;
-  get logLevel(): LogLevel {
+  get logLevel(): LogLevel | LogLevelString {
     return this._logLevel;
   }
-  set logLevel(val: LogLevel) {
-    if (!(val in LogLevel)) {
-      throw new TypeError('Invalid value assigned to `logLevel`');
+  set logLevel(val: LogLevel | LogLevelString) {
+    const newLevel = typeof val === 'string' ? levelStringToEnum[val] : val;
+    if (!(newLevel in LogLevel)) {
+      throw new TypeError(`Invalid value "${val}" assigned to \`logLevel\``);
     }
-    this._logLevel = val;
+    this._logLevel = newLevel;
   }
 
   /**
@@ -205,9 +206,8 @@ export class Logger {
 }
 
 export function setLogLevel(level: LogLevelString | LogLevel): void {
-  const newLevel = typeof level === 'string' ? levelStringToEnum[level] : level;
   instances.forEach(inst => {
-    inst.logLevel = newLevel;
+    inst.logLevel = level;
   });
 }
 

--- a/packages/logger/src/logger.ts
+++ b/packages/logger/src/logger.ts
@@ -141,15 +141,21 @@ export class Logger {
    * The log level of the given Logger instance.
    */
   private _logLevel = defaultLogLevel;
-  get logLevel(): LogLevel | LogLevelString {
+
+  get logLevel(): LogLevel {
     return this._logLevel;
   }
-  set logLevel(val: LogLevel | LogLevelString) {
-    const newLevel = typeof val === 'string' ? levelStringToEnum[val] : val;
-    if (!(newLevel in LogLevel)) {
+
+  set logLevel(val: LogLevel) {
+    if (!(val in LogLevel)) {
       throw new TypeError(`Invalid value "${val}" assigned to \`logLevel\``);
     }
-    this._logLevel = newLevel;
+    this._logLevel = val;
+  }
+
+  // Workaround for setter/getter having to be the same type.
+  setLogLevel(val: LogLevel | LogLevelString): void {
+    this._logLevel = typeof val === 'string' ? levelStringToEnum[val] : val;
   }
 
   /**
@@ -207,7 +213,7 @@ export class Logger {
 
 export function setLogLevel(level: LogLevelString | LogLevel): void {
   instances.forEach(inst => {
-    inst.logLevel = level;
+    inst.setLogLevel(level);
   });
 }
 


### PR DESCRIPTION
When Firestore and other users of Logger set log level on their instance only, this change allows them to use string input in addition to LogLevel enums. Firestore has a public interface that takes string input (just as the top-level `setLogLevel()` does) and needs to use this input to set logLevel on the Firestore logger instance only.