### PR TITLE
Add test for getHighestListenSequenceNumber() recovery

### DIFF
--- a/packages/firestore/src/local/indexeddb_persistence.ts
+++ b/packages/firestore/src/local/indexeddb_persistence.ts
@@ -45,7 +45,6 @@ import {
   DbPrimaryClient,
   DbPrimaryClientKey,
   DbTargetDocument,
-  DbTargetGlobal,
   SCHEMA_VERSION,
   SchemaConverter
 } from './indexeddb_schema';
@@ -306,10 +305,13 @@ export class IndexedDbPersistence implements Persistence {
 
         this.scheduleClientMetadataAndPrimaryLeaseRefreshes();
 
-        return this.simpleDb.runTransaction(
+        return this.runTransaction(
+          'getHighestListenSequenceNumber',
           'readonly',
-          [DbTargetGlobal.store],
-          txn => getHighestListenSequenceNumber(txn)
+          txn =>
+            getHighestListenSequenceNumber(
+              (txn as IndexedDbTransaction).simpleDbTransaction
+            )
         );
       })
       .then(highestListenSequenceNumber => {

--- a/packages/firestore/src/local/indexeddb_persistence.ts
+++ b/packages/firestore/src/local/indexeddb_persistence.ts
@@ -50,7 +50,6 @@ import {
 } from './indexeddb_schema';
 import {
   documentTargetStore,
-  getHighestListenSequenceNumber,
   IndexedDbTargetCache
 } from './indexeddb_target_cache';
 import { LocalSerializer } from './local_serializer';
@@ -308,10 +307,7 @@ export class IndexedDbPersistence implements Persistence {
         return this.runTransaction(
           'getHighestListenSequenceNumber',
           'readonly',
-          txn =>
-            getHighestListenSequenceNumber(
-              (txn as IndexedDbTransaction).simpleDbTransaction
-            )
+          txn => this.targetCache.getHighestSequenceNumber(txn)
         );
       })
       .then(highestListenSequenceNumber => {

--- a/packages/firestore/src/local/indexeddb_schema.ts
+++ b/packages/firestore/src/local/indexeddb_schema.ts
@@ -235,6 +235,10 @@ export class SchemaConverter implements SimpleDbSchemaConverter {
     );
 
     return globalTargetStore.get(DbTargetGlobal.key).next(metadata => {
+      debugAssert(
+        !!metadata,
+        'Metadata should have been written during the version 3 migration'
+      );
       const writeSentinelKey = (
         path: ResourcePath
       ): PersistencePromise<void> => {

--- a/packages/firestore/src/local/indexeddb_schema.ts
+++ b/packages/firestore/src/local/indexeddb_schema.ts
@@ -28,7 +28,6 @@ import {
   EncodedResourcePath
 } from './encoded_resource_path';
 import { removeMutationBatch } from './indexeddb_mutation_queue';
-import { getHighestListenSequenceNumber } from './indexeddb_target_cache';
 import { dbDocumentSize } from './indexeddb_remote_document_cache';
 import { LocalSerializer } from './local_serializer';
 import { MemoryCollectionParentIndex } from './memory_index_manager';
@@ -231,8 +230,11 @@ export class SchemaConverter implements SimpleDbSchemaConverter {
     const documentsStore = txn.store<DbRemoteDocumentKey, DbRemoteDocument>(
       DbRemoteDocument.store
     );
+    const globalTargetStore = txn.store<DbTargetGlobalKey, DbTargetGlobal>(
+      DbTargetGlobal.store
+    );
 
-    return getHighestListenSequenceNumber(txn).next(currentSequenceNumber => {
+    return globalTargetStore.get(DbTargetGlobal.key).next(metadata => {
       const writeSentinelKey = (
         path: ResourcePath
       ): PersistencePromise<void> => {
@@ -240,7 +242,7 @@ export class SchemaConverter implements SimpleDbSchemaConverter {
           new DbTargetDocument(
             0,
             encodeResourcePath(path),
-            currentSequenceNumber
+            metadata!.highestListenSequenceNumber!
           )
         );
       };

--- a/packages/firestore/test/unit/specs/recovery_spec.test.ts
+++ b/packages/firestore/test/unit/specs/recovery_spec.test.ts
@@ -464,12 +464,12 @@ describeSpec('Persistence Recovery', ['no-ios', 'no-android'], () => {
           fromCache: true,
           hasPendingWrites: true
         })
-        .failDatabaseTransactions({ 'Handle user change': true })
+        .failDatabaseTransactions('Handle user change')
         .changeUser('user2')
         .recoverDatabase()
         .runTimer(TimerId.AsyncQueueRetry)
         .expectEvents(query, { removed: [doc1], fromCache: true })
-        .failDatabaseTransactions({ 'Handle user change': true })
+        .failDatabaseTransactions('Handle user change')
         .changeUser('user1')
         .recoverDatabase()
         .runTimer(TimerId.AsyncQueueRetry)

--- a/packages/firestore/test/unit/specs/spec_test_runner.ts
+++ b/packages/firestore/test/unit/specs/spec_test_runner.ts
@@ -1215,7 +1215,8 @@ export type PersistenceAction =
   | 'Get target data'
   | 'Get new document changes'
   | 'Synchronize last document change read time'
-  | 'updateClientMetadataAndTryBecomePrimary';
+  | 'updateClientMetadataAndTryBecomePrimary'
+  | 'getHighestListenSequenceNumber';
 
 /** Specifies failure or success for a list of database actions. */
 export type SpecDatabaseFailures = Partial<


### PR DESCRIPTION
This adds a test that verify that we can bubble up the exception from `getHighestListenSequenceNumber` to `enablePersistence()`. The client can then proceed with MemoryPersistence: https://github.com/firebase/firebase-js-sdk/blob/3de5763b76d19314db1355072b9e0d9ccea70ccc/packages/firestore/src/core/firestore_client.ts#L325

Addresses #2755