### PR TITLE
Remove the capability of sending events to clearcut from the Performance SDK.

### DIFF
--- a/packages/performance/src/services/remote_config_service.test.ts
+++ b/packages/performance/src/services/remote_config_service.test.ts
@@ -236,5 +236,39 @@ describe('Performance Monitoring > remote_config_service', () => {
 
       expect(SettingsService.getInstance().loggingEnabled).to.be.true;
     });
+
+    it('gets the config from RC even with deprecated transport flag', async () => {
+      // Expired local config.
+      const EXPIRY_LOCAL_STORAGE_VALUE = '1556524895320';
+      const STRINGIFIED_CUSTOM_CONFIG = `{"entries":{\
+        "fpr_vc_network_request_sampling_rate":"0.250000",\
+        "fpr_log_transport_web_percent":"100.0",\
+        "fpr_vc_session_sampling_rate":"0.250000","fpr_vc_trace_sampling_rate":"0.500000"},\
+        "state":"UPDATE"}`;
+
+      const { storageGetItemStub: getItemStub } = setup(
+        {
+          expiry: EXPIRY_LOCAL_STORAGE_VALUE,
+          config: STRINGIFIED_CUSTOM_CONFIG
+        },
+        { reject: false, value: new Response(STRINGIFIED_CONFIG) }
+      );
+
+      await getConfig(IID);
+
+      expect(getItemStub).to.be.calledOnce;
+      expect(SettingsService.getInstance().loggingEnabled).to.be.true;
+      expect(SettingsService.getInstance().logEndPointUrl).to.equal(LOG_URL);
+      expect(SettingsService.getInstance().transportKey).to.equal(
+        TRANSPORT_KEY
+      );
+      expect(SettingsService.getInstance().logSource).to.equal(LOG_SOURCE);
+      expect(
+        SettingsService.getInstance().networkRequestsSamplingRate
+      ).to.equal(NETWORK_SAMPLIG_RATE);
+      expect(SettingsService.getInstance().tracesSamplingRate).to.equal(
+        TRACE_SAMPLING_RATE
+      );
+    });
   });
 });

--- a/packages/performance/src/services/remote_config_service.test.ts
+++ b/packages/performance/src/services/remote_config_service.test.ts
@@ -20,7 +20,7 @@ import { SettingsService } from './settings_service';
 import { CONFIG_EXPIRY_LOCAL_STORAGE_KEY } from '../constants';
 import { setupApi, Api } from './api_service';
 import * as iidService from './iid_service';
-import { getConfig, isDestFl } from './remote_config_service';
+import { getConfig } from './remote_config_service';
 import { FirebaseApp } from '@firebase/app-types';
 import '../../test/setup';
 
@@ -37,7 +37,6 @@ describe('Performance Monitoring > remote_config_service', () => {
   "fpr_log_endpoint_url":"https://firebaselogging.test.com",\
   "fpr_log_transport_key":"pseudo-transport-key",\
   "fpr_log_source":"2","fpr_vc_network_request_sampling_rate":"0.250000",\
-  "fpr_log_transport_web_percent":"100.0",\
   "fpr_vc_session_sampling_rate":"0.250000","fpr_vc_trace_sampling_rate":"0.500000"},\
   "state":"UPDATE"}`;
   const PROJECT_ID = 'project1';
@@ -135,7 +134,6 @@ describe('Performance Monitoring > remote_config_service', () => {
         TRANSPORT_KEY
       );
       expect(SettingsService.getInstance().logSource).to.equal(LOG_SOURCE);
-      expect(SettingsService.getInstance().shouldSendToFl).to.be.true;
       expect(
         SettingsService.getInstance().networkRequestsSamplingRate
       ).to.equal(NETWORK_SAMPLIG_RATE);
@@ -176,7 +174,6 @@ describe('Performance Monitoring > remote_config_service', () => {
         TRANSPORT_KEY
       );
       expect(SettingsService.getInstance().logSource).to.equal(LOG_SOURCE);
-      expect(SettingsService.getInstance().shouldSendToFl).to.be.true;
       expect(
         SettingsService.getInstance().networkRequestsSamplingRate
       ).to.equal(NETWORK_SAMPLIG_RATE);
@@ -238,133 +235,6 @@ describe('Performance Monitoring > remote_config_service', () => {
       await getConfig(IID);
 
       expect(SettingsService.getInstance().loggingEnabled).to.be.true;
-    });
-
-    it('marks event destination to cc if there is no template', async () => {
-      setup(
-        {
-          // Expired local config.
-          expiry: '1556524895320',
-          config: NOT_VALID_CONFIG
-        },
-        { reject: false, value: new Response('{"state":"NO_TEMPLATE"}') }
-      );
-      await getConfig(IID);
-
-      // If no template, will send to cc.
-      expect(SettingsService.getInstance().shouldSendToFl).to.be.false;
-    });
-
-    it('marks event destination to cc if instance state unspecified', async () => {
-      setup(
-        {
-          // Expired local config.
-          expiry: '1556524895320',
-          config: NOT_VALID_CONFIG
-        },
-        {
-          reject: false,
-          value: new Response('{"state":"INSTANCE_STATE_UNSPECIFIED"}')
-        }
-      );
-      await getConfig(IID);
-
-      // If instance state unspecified, will send to cc.
-      expect(SettingsService.getInstance().shouldSendToFl).to.be.false;
-    });
-
-    it("marks event destination to cc if state doesn't exist", async () => {
-      setup(
-        {
-          // Expired local config.
-          expiry: '1556524895320',
-          config: NOT_VALID_CONFIG
-        },
-        { reject: false, value: new Response('{}') }
-      );
-      await getConfig(IID);
-
-      // If "state" doesn't exist, will send to cc.
-      expect(SettingsService.getInstance().shouldSendToFl).to.be.false;
-    });
-
-    it('marks event destination to Fl if template exists but no rollout flag', async () => {
-      const CONFIG_WITHOUT_ROLLOUT_FLAG = `{"entries":{"fpr_enabled":"true",\
-    "fpr_log_endpoint_url":"https://firebaselogging.test.com",\
-    "fpr_log_source":"2","fpr_vc_network_request_sampling_rate":"0.250000",\
-    "fpr_vc_session_sampling_rate":"0.250000","fpr_vc_trace_sampling_rate":"0.500000"},\
-    "state":"UPDATE"}`;
-      setup(
-        {
-          // Expired local config.
-          expiry: '1556524895320',
-          config: NOT_VALID_CONFIG
-        },
-        { reject: false, value: new Response(CONFIG_WITHOUT_ROLLOUT_FLAG) }
-      );
-      await getConfig(IID);
-
-      // If template exists but no rollout flag, will send to Fl.
-      expect(SettingsService.getInstance().shouldSendToFl).to.be.true;
-    });
-
-    it('marks event destination to cc when instance is outside of rollout range', async () => {
-      const CONFIG_WITH_ROLLOUT_FLAG_10 = `{"entries":{"fpr_enabled":"true",\
-    "fpr_log_endpoint_url":"https://firebaselogging.test.com",\
-    "fpr_log_source":"2","fpr_vc_network_request_sampling_rate":"0.250000",\
-    "fpr_log_transport_web_percent":"10.0",\
-    "fpr_vc_session_sampling_rate":"0.250000","fpr_vc_trace_sampling_rate":"0.500000"},\
-    "state":"UPDATE"}`;
-      setup(
-        {
-          // Expired local config.
-          expiry: '1556524895320',
-          config: NOT_VALID_CONFIG
-        },
-        { reject: false, value: new Response(CONFIG_WITH_ROLLOUT_FLAG_10) }
-      );
-      await getConfig(IID);
-
-      // If rollout flag exists, will send to cc when this instance is out of rollout scope.
-      expect(SettingsService.getInstance().shouldSendToFl).to.be.false;
-    });
-
-    it('marks event destination to Fl when instance is within rollout range', async () => {
-      const CONFIG_WITH_ROLLOUT_FLAG_40 = `{"entries":{"fpr_enabled":"true",\
-    "fpr_log_endpoint_url":"https://firebaselogging.test.com",\
-    "fpr_log_source":"2","fpr_vc_network_request_sampling_rate":"0.250000",\
-    "fpr_log_transport_web_percent":"40.0",\
-    "fpr_vc_session_sampling_rate":"0.250000","fpr_vc_trace_sampling_rate":"0.500000"},\
-    "state":"UPDATE"}`;
-      setup(
-        {
-          // Expired local config.
-          expiry: '1556524895320',
-          config: NOT_VALID_CONFIG
-        },
-        { reject: false, value: new Response(CONFIG_WITH_ROLLOUT_FLAG_40) }
-      );
-      await getConfig(IID);
-
-      // If rollout flag exists, will send to Fl when this instance is within rollout scope.
-      expect(SettingsService.getInstance().shouldSendToFl).to.be.true;
-    });
-  });
-
-  describe('isDestFl', () => {
-    it('marks traffic to cc when rollout percentage is 0', () => {
-      const shouldSendToFl = isDestFl('abc', 0); // Hash percentage of "abc" is 38%.
-      expect(shouldSendToFl).to.be.false;
-    });
-
-    it('marks traffic to Fl when rollout percentage is 100', () => {
-      const shouldSendToFl = isDestFl('abc', 100); // Hash percentage of "abc" is 38%.
-      expect(shouldSendToFl).to.be.true;
-    });
-
-    it('marks traffic to Fl if hash percentage is lower than rollout percentage 50%', () => {
-      const shouldSendToFl = isDestFl('abc', 50); // Hash percentage of "abc" is 38%.
-      expect(shouldSendToFl).to.be.true;
     });
   });
 });

--- a/packages/performance/src/services/remote_config_service.ts
+++ b/packages/performance/src/services/remote_config_service.ts
@@ -72,7 +72,7 @@ export function getConfig(iid: string): Promise<void> {
   }
 
   return getRemoteConfig(iid)
-    .then(config => processConfig(config))
+    .then(processConfig)
     .then(
       config => storeConfig(config),
       /** Do nothing for error, use defaults set in settings service. */
@@ -162,7 +162,7 @@ function getRemoteConfig(
  * is valid.
  */
 function processConfig(
-  config: RemoteConfigResponse | undefined
+  config?: RemoteConfigResponse
 ): RemoteConfigResponse | undefined {
   if (!config) {
     return config;

--- a/packages/performance/src/services/remote_config_service.ts
+++ b/packages/performance/src/services/remote_config_service.ts
@@ -231,30 +231,3 @@ function configValid(expiry: string): boolean {
 function shouldLogAfterSampling(samplingRate: number): boolean {
   return Math.random() <= samplingRate;
 }
-
-/**
- * True if event should be sent to Fl transport endpoint rather than CC transport endpoint.
- * rolloutPercent is in range [0.0, 100.0].
- * @param iid Installation ID which identifies a web app installed on client.
- * @param rolloutPercent the possibility of this app sending events to Fl endpoint.
- * @return true if this installation should send events to Fl endpoint.
- */
-export function isDestFl(iid: string, rolloutPercent: number): boolean {
-  if (iid.length === 0) {
-    return false;
-  }
-  return getHashPercent(iid) < rolloutPercent;
-}
-/**
- * Generate integer value range in [0, 99]. Implementation from String.hashCode() in Java.
- * @param seed Same seed will generate consistent hash value using this algorithm.
- * @return Hash value in range [0, 99], generated from seed and hash algorithm.
- */
-function getHashPercent(seed: string): number {
-  let hash = 0;
-  for (let i = 0; i < seed.length; i++) {
-    hash = (hash << 3) + hash - seed.charCodeAt(i);
-  }
-  hash = Math.abs(hash % 100);
-  return hash;
-}

--- a/packages/performance/src/services/remote_config_service.ts
+++ b/packages/performance/src/services/remote_config_service.ts
@@ -34,7 +34,6 @@ interface SecondaryConfig {
   logSource?: number;
   logEndPointUrl?: string;
   transportKey?: string;
-  shouldSendToFl?: boolean;
   tracesSamplingRate?: number;
   networkRequestsSamplingRate?: number;
 }
@@ -42,14 +41,7 @@ interface SecondaryConfig {
 // These values will be used if the remote config object is successfully
 // retrieved, but the template does not have these fields.
 const DEFAULT_CONFIGS: SecondaryConfig = {
-  loggingEnabled: true,
-  shouldSendToFl: true
-};
-
-// These values will be used if the remote config object is successfully
-// retrieved, but the config object state shows unspecified or no template.
-const NO_TEMPLATE_CONFIGS: SecondaryConfig = {
-  shouldSendToFl: false
+  loggingEnabled: true
 };
 
 /* eslint-disable camelcase */
@@ -75,12 +67,12 @@ const FIS_AUTH_PREFIX = 'FIREBASE_INSTALLATIONS_AUTH';
 export function getConfig(iid: string): Promise<void> {
   const config = getStoredConfig();
   if (config) {
-    processConfig(iid, config);
+    processConfig(config);
     return Promise.resolve();
   }
 
   return getRemoteConfig(iid)
-    .then(config => processConfig(iid, config))
+    .then(config => processConfig(config))
     .then(
       config => storeConfig(config),
       /** Do nothing for error, use defaults set in settings service. */
@@ -170,7 +162,6 @@ function getRemoteConfig(
  * is valid.
  */
 function processConfig(
-  iid: string,
   config: RemoteConfigResponse | undefined
 ): RemoteConfigResponse | undefined {
   if (!config) {
@@ -178,7 +169,6 @@ function processConfig(
   }
   const settingsServiceInstance = SettingsService.getInstance();
   const entries = config.entries || {};
-  const state = config.state;
   if (entries.fpr_enabled !== undefined) {
     // TODO: Change the assignment of loggingEnabled once the received type is
     // known.
@@ -206,32 +196,6 @@ function processConfig(
     settingsServiceInstance.transportKey = entries.fpr_log_transport_key;
   } else if (DEFAULT_CONFIGS.transportKey) {
     settingsServiceInstance.transportKey = DEFAULT_CONFIGS.transportKey;
-  }
-
-  // If config object state indicates that no template has been set, that means it is new user of
-  // Performance Monitoring and should use the old log endpoint, because it is guaranteed to work.
-  if (
-    state === undefined ||
-    state === 'INSTANCE_STATE_UNSPECIFIED' ||
-    state === 'NO_TEMPLATE'
-  ) {
-    if (NO_TEMPLATE_CONFIGS.shouldSendToFl !== undefined) {
-      settingsServiceInstance.shouldSendToFl =
-        NO_TEMPLATE_CONFIGS.shouldSendToFl;
-    }
-  } else if (entries.fpr_log_transport_web_percent) {
-    // If config object state doesn't indicate no template, it can only be UPDATE for now.
-    // - Performance Monitoring doesn't set etag in request, therefore state cannot be NO_CHANGE.
-    // - Sampling rate flags and master flag are required, therefore state cannot be EMPTY_CONFIG.
-    // If config object state is UPDATE and rollout flag is present, determine endpoint by iid.
-    settingsServiceInstance.shouldSendToFl = isDestFl(
-      iid,
-      Number(entries.fpr_log_transport_web_percent)
-    );
-  } else if (DEFAULT_CONFIGS.shouldSendToFl !== undefined) {
-    // If config object state is UPDATE and rollout flag is not present, that means rollout is
-    // complete and rollout flag is deprecated, therefore dispatch events to new transport endpoint.
-    settingsServiceInstance.shouldSendToFl = DEFAULT_CONFIGS.shouldSendToFl;
   }
 
   if (entries.fpr_vc_network_request_sampling_rate !== undefined) {

--- a/packages/performance/src/services/settings_service.ts
+++ b/packages/performance/src/services/settings_service.ts
@@ -47,8 +47,6 @@ export class SettingsService {
 
   transportKey = mergeStrings('AzSC8r6ReiGqFMyfvgow', 'Iayx0u-XT3vksVM-pIV');
 
-  shouldSendToFl = false;
-
   // Source type for performance event logs.
   logSource = 462;
 

--- a/packages/performance/src/services/transport_service.test.ts
+++ b/packages/performance/src/services/transport_service.test.ts
@@ -47,7 +47,6 @@ describe('Firebase Performance > transport_service', () => {
     fetchStub.restore();
     clock.restore();
     resetTransportService();
-    SettingsService.getInstance().shouldSendToFl = false;
   });
 
   it('throws an error when logging an empty message', () => {
@@ -87,7 +86,6 @@ describe('Firebase Performance > transport_service', () => {
     const setting = SettingsService.getInstance();
     const flTransportFullUrl =
       setting.flTransportEndpointUrl + '?key=' + setting.transportKey;
-    setting.shouldSendToFl = true;
     fetchStub.withArgs(flTransportFullUrl, match.any).resolves(
       // DELETE_REQUEST means event dispatch is successful.
       new Response(

--- a/packages/performance/src/services/transport_service.ts
+++ b/packages/performance/src/services/transport_service.ts
@@ -112,7 +112,7 @@ function dispatchQueueEvents(): void {
   };
   /* eslint-enable camelcase */
 
-  postToEndpoint(data, staged).catch(() => {
+  sendEventsToFl(data, staged).catch(() => {
     // If the request fails for some reason, add the events that were attempted
     // back to the primary queue to retry later.
     queue = [...staged, ...queue];
@@ -120,18 +120,6 @@ function dispatchQueueEvents(): void {
     consoleLogger.info(`Tries left: ${remainingTries}.`);
     processQueue(DEFAULT_SEND_INTERVAL_MS);
   });
-}
-
-function postToEndpoint(
-  data: TransportBatchLogFormat,
-  staged: BatchEvent[]
-): Promise<void> {
-  // Gradually rollout traffic from cc to transport using remote config.
-  if (SettingsService.getInstance().shouldSendToFl) {
-    return sendEventsToFl(data, staged);
-  } else {
-    return sendEventsToCc(data);
-  }
 }
 
 function sendEventsToFl(
@@ -165,29 +153,6 @@ function sendEventsToFl(
         consoleLogger.info(`Retry transport request later.`);
       }
 
-      remainingTries = DEFAULT_REMAINING_TRIES;
-      // Schedule the next process.
-      processQueue(requestOffset);
-    });
-}
-
-function sendEventsToCc(data: TransportBatchLogFormat): Promise<void> {
-  return fetch(SettingsService.getInstance().logEndPointUrl, {
-    method: 'POST',
-    body: JSON.stringify(data)
-  })
-    .then(res => {
-      if (!res.ok) {
-        consoleLogger.info('Call to Firebase backend failed.');
-      }
-      return res.json();
-    })
-    .then(res => {
-      const wait = Number(res.next_request_wait_millis);
-      // Find the next call wait time from the response.
-      const requestOffset = isNaN(wait)
-        ? DEFAULT_SEND_INTERVAL_MS
-        : Math.max(DEFAULT_SEND_INTERVAL_MS, wait);
       remainingTries = DEFAULT_REMAINING_TRIES;
       // Schedule the next process.
       processQueue(requestOffset);


### PR DESCRIPTION
Remove the capability of sending events to clearcut from the Performance SDK. This removes the need for fetching the RC configs to decide on the dispatch destination - so that is removed in the settings service and remote config service.