### PR TITLE
Allow lite usage for WriteBatch, Transaction, UserDataReader, UserDataWriter

### DIFF
--- a/packages/firestore/src/core/component_provider.ts
+++ b/packages/firestore/src/core/component_provider.ts
@@ -162,6 +162,7 @@ export class MemoryComponentProvider implements ComponentProvider {
     return new SyncEngine(
       this.localStore,
       this.remoteStore,
+      cfg.datastore,
       this.sharedClientState,
       cfg.initialUser,
       cfg.maxConcurrentLimboResolutions
@@ -219,6 +220,7 @@ export class IndexedDbComponentProvider extends MemoryComponentProvider {
     const syncEngine = new MultiTabSyncEngine(
       this.localStore,
       this.remoteStore,
+      cfg.datastore,
       this.sharedClientState,
       cfg.initialUser,
       cfg.maxConcurrentLimboResolutions

--- a/packages/firestore/src/core/sync_engine.ts
+++ b/packages/firestore/src/core/sync_engine.ts
@@ -74,6 +74,7 @@ import {
 import { ViewSnapshot } from './view_snapshot';
 import { AsyncQueue, wrapInUserErrorIfRecoverable } from '../util/async_queue';
 import { TransactionRunner } from './transaction_runner';
+import { Datastore } from '../remote/datastore';
 
 const LOG_TAG = 'SyncEngine';
 
@@ -185,6 +186,7 @@ export class SyncEngine implements RemoteSyncer {
   constructor(
     protected localStore: LocalStore,
     protected remoteStore: RemoteStore,
+    protected datastore: Datastore,
     // PORTING NOTE: Manages state synchronization in multi-tab environments.
     protected sharedClientState: SharedClientState,
     private currentUser: User,
@@ -390,7 +392,7 @@ export class SyncEngine implements RemoteSyncer {
   ): void {
     new TransactionRunner<T>(
       asyncQueue,
-      this.remoteStore,
+      this.datastore,
       updateFunction,
       deferred
     ).run();
@@ -924,6 +926,7 @@ export class MultiTabSyncEngine extends SyncEngine
   constructor(
     protected localStore: MultiTabLocalStore,
     remoteStore: RemoteStore,
+    datastore: Datastore,
     sharedClientState: SharedClientState,
     currentUser: User,
     maxConcurrentLimboResolutions: number
@@ -931,6 +934,7 @@ export class MultiTabSyncEngine extends SyncEngine
     super(
       localStore,
       remoteStore,
+      datastore,
       sharedClientState,
       currentUser,
       maxConcurrentLimboResolutions

--- a/packages/firestore/src/core/transaction_runner.ts
+++ b/packages/firestore/src/core/transaction_runner.ts
@@ -19,7 +19,7 @@ import { Deferred } from '../util/promise';
 import { TimerId, AsyncQueue } from '../util/async_queue';
 import { ExponentialBackoff } from '../remote/backoff';
 import { Transaction } from './transaction';
-import { RemoteStore } from '../remote/remote_store';
+import { Datastore } from '../remote/datastore';
 import { isNullOrUndefined } from '../util/types';
 import { isPermanentError } from '../remote/rpc_error';
 import { FirestoreError } from '../util/error';
@@ -36,7 +36,7 @@ export class TransactionRunner<T> {
 
   constructor(
     private readonly asyncQueue: AsyncQueue,
-    private readonly remoteStore: RemoteStore,
+    private readonly datastore: Datastore,
     private readonly updateFunction: (transaction: Transaction) => Promise<T>,
     private readonly deferred: Deferred<T>
   ) {
@@ -53,7 +53,7 @@ export class TransactionRunner<T> {
 
   private runWithBackOff(): void {
     this.backoff.backoffAndRun(async () => {
-      const transaction = this.remoteStore.createTransaction();
+      const transaction = new Transaction(this.datastore);
       const userPromise = this.tryRunUpdateFunction(transaction);
       if (userPromise) {
         userPromise

--- a/packages/firestore/src/remote/datastore.ts
+++ b/packages/firestore/src/remote/datastore.ts
@@ -18,7 +18,7 @@
 import { CredentialsProvider } from '../api/credentials';
 import { MaybeDocument, Document } from '../model/document';
 import { DocumentKey } from '../model/document_key';
-import { Mutation, MutationResult } from '../model/mutation';
+import { Mutation } from '../model/mutation';
 import * as api from '../protos/firestore_proto_api';
 import { debugCast, hardAssert } from '../util/assert';
 import { Code, FirestoreError } from '../util/error';
@@ -106,20 +106,13 @@ export function newDatastore(
 export async function invokeCommitRpc(
   datastore: Datastore,
   mutations: Mutation[]
-): Promise<MutationResult[]> {
+): Promise<void> {
   const datastoreImpl = debugCast(datastore, DatastoreImpl);
   const params = {
     database: datastoreImpl.serializer.encodedDatabaseId,
     writes: mutations.map(m => datastoreImpl.serializer.toMutation(m))
   };
-  const response = await datastoreImpl.invokeRPC<
-    api.CommitRequest,
-    api.CommitResponse
-  >('Commit', params);
-  return datastoreImpl.serializer.fromWriteResults(
-    response.writeResults,
-    response.commitTime
-  );
+  await datastoreImpl.invokeRPC('Commit', params);
 }
 
 export async function invokeBatchGetDocumentsRpc(

--- a/packages/firestore/src/remote/remote_store.ts
+++ b/packages/firestore/src/remote/remote_store.ts
@@ -16,7 +16,6 @@
  */
 
 import { SnapshotVersion } from '../core/snapshot_version';
-import { Transaction } from '../core/transaction';
 import { OnlineState, TargetId } from '../core/types';
 import { ignoreIfPrimaryLeaseLoss, LocalStore } from '../local/local_store';
 import { TargetData, TargetPurpose } from '../local/target_data';
@@ -757,10 +756,6 @@ export class RemoteStore implements TargetMetadataProvider {
     } else {
       // Transient error, just let the retry logic kick in.
     }
-  }
-
-  createTransaction(): Transaction {
-    return new Transaction(this.datastore);
   }
 
   private async restartNetwork(): Promise<void> {

--- a/packages/firestore/test/integration/remote/remote.test.ts
+++ b/packages/firestore/test/integration/remote/remote.test.ts
@@ -32,12 +32,7 @@ describe('Remote Storage', () => {
   it('can write', () => {
     return withTestDatastore(async ds => {
       const mutation = setMutation('docs/1', { sort: 1 });
-      const result = await invokeCommitRpc(ds, [mutation]);
-      expect(result.length).to.equal(1);
-
-      const version = result[0].version;
-      expect(version).not.to.equal(null);
-      expect(SnapshotVersion.min().compareTo(version!)).to.be.lessThan(0);
+      await invokeCommitRpc(ds, [mutation]);
     });
   });
 

--- a/packages/firestore/test/util/helpers.ts
+++ b/packages/firestore/test/util/helpers.ts
@@ -105,7 +105,12 @@ const fakeFirestore: Firestore = {
 export type TestSnapshotVersion = number;
 
 export function testUserDataWriter(): UserDataWriter {
-  return new UserDataWriter(fakeFirestore, /* timestampsInSnapshots= */ false);
+  return new UserDataWriter(
+    new DatabaseId('test-project'),
+    /* timestampsInSnapshots= */ false,
+    'none',
+    key => new DocumentReference(key, fakeFirestore)
+  );
 }
 
 export function testUserDataReader(useProto3Json?: boolean): UserDataReader {


### PR DESCRIPTION
This PR allows the Lite SDK to re-use WriteBatch, Transaction, UserDataReader, UserDataWriter.

It does this by:

- Introducing a common base type for all DocumentReference APIS. DocumentKeyReference exposes all state that is common between the Lite, Full and Legacy SDKs.
- Updating UserDataReader and UserDataWriter to use the DocumentKeyReference.
- Removing the need to round-trip through RemoteStore to create a Transaction.
- Extracting the read path of Transaction to a separate class, as the different APIs return different DocumentSnapshots.
- Removing the SortedMap dependency in Transaction to reduce code size in the Lite SDK.

This can be seen in a WIP PR: https://github.com/firebase/firebase-js-sdk/pull/3094