### PR TITLE
Allow shared usage of WriteBatch

### DIFF
--- a/packages/firestore/src/remote/datastore.ts
+++ b/packages/firestore/src/remote/datastore.ts
@@ -18,7 +18,7 @@
 import { CredentialsProvider } from '../api/credentials';
 import { MaybeDocument, Document } from '../model/document';
 import { DocumentKey } from '../model/document_key';
-import { Mutation, MutationResult } from '../model/mutation';
+import { Mutation } from '../model/mutation';
 import * as api from '../protos/firestore_proto_api';
 import { debugCast, hardAssert } from '../util/assert';
 import { Code, FirestoreError } from '../util/error';
@@ -106,20 +106,13 @@ export function newDatastore(
 export async function invokeCommitRpc(
   datastore: Datastore,
   mutations: Mutation[]
-): Promise<MutationResult[]> {
+): Promise<void> {
   const datastoreImpl = debugCast(datastore, DatastoreImpl);
   const params = {
     database: datastoreImpl.serializer.encodedDatabaseId,
     writes: mutations.map(m => datastoreImpl.serializer.toMutation(m))
   };
-  const response = await datastoreImpl.invokeRPC<
-    api.CommitRequest,
-    api.CommitResponse
-  >('Commit', params);
-  return datastoreImpl.serializer.fromWriteResults(
-    response.writeResults,
-    response.commitTime
-  );
+  await datastoreImpl.invokeRPC('Commit', params);
 }
 
 export async function invokeBatchGetDocumentsRpc(

--- a/packages/firestore/test/integration/remote/remote.test.ts
+++ b/packages/firestore/test/integration/remote/remote.test.ts
@@ -32,12 +32,7 @@ describe('Remote Storage', () => {
   it('can write', () => {
     return withTestDatastore(async ds => {
       const mutation = setMutation('docs/1', { sort: 1 });
-      const result = await invokeCommitRpc(ds, [mutation]);
-      expect(result.length).to.equal(1);
-
-      const version = result[0].version;
-      expect(version).not.to.equal(null);
-      expect(SnapshotVersion.min().compareTo(version!)).to.be.lessThan(0);
+      await invokeCommitRpc(ds, [mutation]);
     });
   });
 


### PR DESCRIPTION
This allows the Lite SDK to use the existing WriteBatch class by removing the dependency on Firestore. It allows removes some unused code in `invokeCommitRpc` that makes constructing WriteBatch from the Lite SDK more cumbersome since we would have to suppress the return type.