### PR TITLE
Allow shared usage of Transaction

### DIFF
--- a/packages/firestore/src/core/component_provider.ts
+++ b/packages/firestore/src/core/component_provider.ts
@@ -162,6 +162,7 @@ export class MemoryComponentProvider implements ComponentProvider {
     return new SyncEngine(
       this.localStore,
       this.remoteStore,
+      cfg.datastore,
       this.sharedClientState,
       cfg.initialUser,
       cfg.maxConcurrentLimboResolutions
@@ -219,6 +220,7 @@ export class IndexedDbComponentProvider extends MemoryComponentProvider {
     const syncEngine = new MultiTabSyncEngine(
       this.localStore,
       this.remoteStore,
+      cfg.datastore,
       this.sharedClientState,
       cfg.initialUser,
       cfg.maxConcurrentLimboResolutions

--- a/packages/firestore/src/core/sync_engine.ts
+++ b/packages/firestore/src/core/sync_engine.ts
@@ -74,6 +74,7 @@ import {
 import { ViewSnapshot } from './view_snapshot';
 import { AsyncQueue, wrapInUserErrorIfRecoverable } from '../util/async_queue';
 import { TransactionRunner } from './transaction_runner';
+import { Datastore } from '../remote/datastore';
 
 const LOG_TAG = 'SyncEngine';
 
@@ -185,6 +186,7 @@ export class SyncEngine implements RemoteSyncer {
   constructor(
     protected localStore: LocalStore,
     protected remoteStore: RemoteStore,
+    protected datastore: Datastore,
     // PORTING NOTE: Manages state synchronization in multi-tab environments.
     protected sharedClientState: SharedClientState,
     private currentUser: User,
@@ -390,7 +392,7 @@ export class SyncEngine implements RemoteSyncer {
   ): void {
     new TransactionRunner<T>(
       asyncQueue,
-      this.remoteStore,
+      this.datastore,
       updateFunction,
       deferred
     ).run();
@@ -924,6 +926,7 @@ export class MultiTabSyncEngine extends SyncEngine
   constructor(
     protected localStore: MultiTabLocalStore,
     remoteStore: RemoteStore,
+    datastore: Datastore,
     sharedClientState: SharedClientState,
     currentUser: User,
     maxConcurrentLimboResolutions: number
@@ -931,6 +934,7 @@ export class MultiTabSyncEngine extends SyncEngine
     super(
       localStore,
       remoteStore,
+      datastore,
       sharedClientState,
       currentUser,
       maxConcurrentLimboResolutions

--- a/packages/firestore/src/core/transaction_runner.ts
+++ b/packages/firestore/src/core/transaction_runner.ts
@@ -19,7 +19,7 @@ import { Deferred } from '../util/promise';
 import { TimerId, AsyncQueue } from '../util/async_queue';
 import { ExponentialBackoff } from '../remote/backoff';
 import { Transaction } from './transaction';
-import { RemoteStore } from '../remote/remote_store';
+import { Datastore } from '../remote/datastore';
 import { isNullOrUndefined } from '../util/types';
 import { isPermanentError } from '../remote/rpc_error';
 import { FirestoreError } from '../util/error';
@@ -36,7 +36,7 @@ export class TransactionRunner<T> {
 
   constructor(
     private readonly asyncQueue: AsyncQueue,
-    private readonly remoteStore: RemoteStore,
+    private readonly datastore: Datastore,
     private readonly updateFunction: (transaction: Transaction) => Promise<T>,
     private readonly deferred: Deferred<T>
   ) {
@@ -53,7 +53,7 @@ export class TransactionRunner<T> {
 
   private runWithBackOff(): void {
     this.backoff.backoffAndRun(async () => {
-      const transaction = this.remoteStore.createTransaction();
+      const transaction = new Transaction(this.datastore);
       const userPromise = this.tryRunUpdateFunction(transaction);
       if (userPromise) {
         userPromise

--- a/packages/firestore/src/remote/remote_store.ts
+++ b/packages/firestore/src/remote/remote_store.ts
@@ -16,7 +16,6 @@
  */
 
 import { SnapshotVersion } from '../core/snapshot_version';
-import { Transaction } from '../core/transaction';
 import { OnlineState, TargetId } from '../core/types';
 import { ignoreIfPrimaryLeaseLoss, LocalStore } from '../local/local_store';
 import { TargetData, TargetPurpose } from '../local/target_data';
@@ -757,10 +756,6 @@ export class RemoteStore implements TargetMetadataProvider {
     } else {
       // Transient error, just let the retry logic kick in.
     }
-  }
-
-  createTransaction(): Transaction {
-    return new Transaction(this.datastore);
   }
 
   private async restartNetwork(): Promise<void> {


### PR DESCRIPTION
This PR:
- Removes the need to round-trip through RemoteStore to create a Transaction.
- Extracts the read path of Transaction to a separate class, as the different APIs return different DocumentSnapshots.
- Removes the SortedMap dependency in Transaction to reduce code size in the Lite SDK.
