### PR TITLE
Address potential IndexedDB failure in synchronizeQueryViewsAndRaiseSnapshots

### DIFF
--- a/packages/firestore/src/core/sync_engine.ts
+++ b/packages/firestore/src/core/sync_engine.ts
@@ -1110,14 +1110,10 @@ export class MultiTabSyncEngine extends SyncEngine
       const queries = this.queriesByTarget.get(targetId);
 
       if (queries && queries.length !== 0) {
-        // For queries that have a local View, we need to update their state
-        // in LocalStore (as the resume token and the snapshot version
+        // For queries that have a local View, we fetch their current state
+        // from LocalStore (as the resume token and the snapshot version
         // might have changed) and reconcile their views with the persisted
         // state (the list of syncedDocuments may have gotten out of sync).
-        await this.localStore.releaseTarget(
-          targetId,
-          /*keepPersistedTargetData=*/ true
-        );
         targetData = await this.localStore.allocateTarget(
           queries[0].toTarget()
         );
@@ -1136,7 +1132,7 @@ export class MultiTabSyncEngine extends SyncEngine
       } else {
         debugAssert(
           transitionToPrimary,
-          'A secondary tab should never have an active target without an active query.'
+          'A secondary tab should never have an active view without an active target.'
         );
         // For queries that never executed on this client, we need to
         // allocate the target in LocalStore and initialize a new View.

--- a/packages/firestore/src/local/indexeddb_persistence.ts
+++ b/packages/firestore/src/local/indexeddb_persistence.ts
@@ -404,7 +404,7 @@ export class IndexedDbPersistence implements Persistence {
               return this.verifyPrimaryLease(txn).next(success => {
                 if (!success) {
                   this.isPrimary = false;
-                  this.queue.enqueueAndForget(() =>
+                  this.queue.enqueueRetryable(() =>
                     this.primaryStateListener(false)
                   );
                 }
@@ -444,7 +444,7 @@ export class IndexedDbPersistence implements Persistence {
       })
       .then(isPrimary => {
         if (this.isPrimary !== isPrimary) {
-          this.queue.enqueueAndForget(() =>
+          this.queue.enqueueRetryable(() =>
             this.primaryStateListener(isPrimary)
           );
         }
@@ -805,7 +805,7 @@ export class IndexedDbPersistence implements Persistence {
                   `Failed to obtain primary lease for action '${action}'.`
                 );
                 this.isPrimary = false;
-                this.queue.enqueueAndForget(() =>
+                this.queue.enqueueRetryable(() =>
                   this.primaryStateListener(false)
                 );
                 throw new FirestoreError(

--- a/packages/firestore/src/local/local_store.ts
+++ b/packages/firestore/src/local/local_store.ts
@@ -831,7 +831,17 @@ export class LocalStore {
           });
       })
       .then(targetData => {
-        if (this.targetDataByTarget.get(targetData.targetId) === null) {
+        // If Multi-Tab is enabled, the existing target data may be newer than
+        // the in-memory data
+        const cachedTargetData = this.targetDataByTarget.get(
+          targetData.targetId
+        );
+        if (
+          cachedTargetData === null ||
+          targetData.snapshotVersion.compareTo(
+            cachedTargetData.snapshotVersion
+          ) > 0
+        ) {
           this.targetDataByTarget = this.targetDataByTarget.insert(
             targetData.targetId,
             targetData

--- a/packages/firestore/test/unit/specs/listen_spec.test.ts
+++ b/packages/firestore/test/unit/specs/listen_spec.test.ts
@@ -17,7 +17,7 @@
 
 import { Query } from '../../../src/core/query';
 import { Code } from '../../../src/util/error';
-import { deletedDoc, doc, filter, path, orderBy } from '../../util/helpers';
+import { deletedDoc, doc, filter, orderBy, path } from '../../util/helpers';
 
 import { TimerId } from '../../../src/util/async_queue';
 import { describeSpec, specTest } from './describe_spec';

--- a/packages/firestore/test/unit/specs/recovery_spec.test.ts
+++ b/packages/firestore/test/unit/specs/recovery_spec.test.ts
@@ -153,7 +153,7 @@ describeSpec('Persistence Recovery', ['no-ios', 'no-android'], () => {
       const docB = doc('collection/b', 2000, { key: 'b' });
 
       return (
-        client(0, false)
+        client(0)
           .expectPrimaryState(true)
           .client(1)
           // Register a query in the secondary client
@@ -189,7 +189,7 @@ describeSpec('Persistence Recovery', ['no-ios', 'no-android'], () => {
       const docB = doc('collection/b', 2000, { key: 'b' });
 
       return (
-        client(0, false)
+        client(0)
           .expectPrimaryState(true)
           // Initialize a second client that doesn't have any active targets
           .client(1)


### PR DESCRIPTION
This removes a `releaseQuery` call from Multi-Tab synchronization. The idea of this code path in synchronizeQueryViewsAndRaiseSnapshots is that it releases and re-allocates a query if a new primary already has a local query view but needs to make sure that it matches the data in IndexedDB before starting a Listen.

We should not need to call `releaseTarget`  here, since it overwrites the target data with potentially stale state. Instead, we just load the latest state via `allocateTarget` which has the ability to load a target from disk or from memory. I added a check to also update the in-memory data when it is stale, but I wasn't able to find any difference for this using a spec tests I hacked together (not committed).

Addresses #2755