### PR TITLE
Add the FCM secret to applicable CI paths.

### DIFF
--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -8,33 +8,33 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
-      - name: Set up Node (10)
-        uses: actions/setup-node@v1
-        with:
-          node-version: 10.x
-      - name: install Chrome stable
-        run: |
-          sudo apt-get update
-          sudo apt-get install google-chrome-stable
-      - name: Test setup and yarn install
-        run: |
-          cp config/ci.config.json config/project.json
-          yarn
-      - name: yarn build
-        run: yarn build
-      - name: Run unit tests
-        run: xvfb-run yarn test:ci
-        env:
-          FCM_TEST_PROJECT_SERVER_KEY: $${{secrets.FCM_TEST_PROJECT_SERVER_KEY}}
-      - name: Generate coverage file
-        run: yarn ci:coverage
-      - name: Run coverage
-        uses: coverallsapp/github-action@master
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          path-to-lcov: ./lcov-all.info
-        continue-on-error: true
+    - uses: actions/checkout@v2
+    - name: Set up Node (10)
+      uses: actions/setup-node@v1
+      with:
+        node-version: 10.x
+    - name: install Chrome stable
+      run: |
+        sudo apt-get update
+        sudo apt-get install google-chrome-stable
+    - name: Test setup and yarn install
+      run: |
+        cp config/ci.config.json config/project.json
+        yarn
+    - name: yarn build
+      run: yarn build
+    - name: Run unit tests
+      run: xvfb-run yarn test:ci
+      env:
+        FCM_TEST_PROJECT_SERVER_KEY: $${{secrets.FCM_TEST_PROJECT_SERVER_KEY}}
+    - name: Generate coverage file
+      run: yarn ci:coverage
+    - name: Run coverage
+      uses: coverallsapp/github-action@master
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        path-to-lcov: ./lcov-all.info
+      continue-on-error: true
   deploy:
     name: Canary Deploy
     runs-on: ubuntu-latest
@@ -42,49 +42,49 @@ jobs:
     needs: test
 
     steps:
-      - uses: actions/checkout@v2
-      - name: Checkout
-        # Canary release script requires git history and tags.
-        run: git fetch --prune --unshallow
-      - name: Set up Node (10)
-        uses: actions/setup-node@v1
-        with:
-          node-version: 10.x
-      - name: Yarn install
-        run: yarn
-      - name: Deploy canary
-        run: yarn release --canary
-        env:
-          NPM_TOKEN_ANALYTICS: ${{secrets.NPM_TOKEN_ANALYTICS}}
-          NPM_TOKEN_ANALYTICS_INTEROP_TYPES: ${{secrets.NPM_TOKEN_ANALYTICS_INTEROP_TYPES}}
-          NPM_TOKEN_ANALYTICS_TYPES: ${{secrets.NPM_TOKEN_ANALYTICS_TYPES}}
-          NPM_TOKEN_APP: ${{secrets.NPM_TOKEN_APP}}
-          NPM_TOKEN_APP_TYPES: ${{secrets.NPM_TOKEN_APP_TYPES}}
-          NPM_TOKEN_AUTH: ${{secrets.NPM_TOKEN_AUTH}}
-          NPM_TOKEN_AUTH_INTEROP_TYPES: ${{secrets.NPM_TOKEN_AUTH_INTEROP_TYPES}}
-          NPM_TOKEN_AUTH_TYPES: ${{secrets.NPM_TOKEN_AUTH_TYPES}}
-          NPM_TOKEN_COMPONENT: ${{secrets.NPM_TOKEN_COMPONENT}}
-          NPM_TOKEN_DATABASE: ${{secrets.NPM_TOKEN_DATABASE}}
-          NPM_TOKEN_DATABASE_TYPES: ${{secrets.NPM_TOKEN_DATABASE_TYPES}}
-          NPM_TOKEN_FIRESTORE: ${{secrets.NPM_TOKEN_FIRESTORE}}
-          NPM_TOKEN_FIRESTORE_TYPES: ${{secrets.NPM_TOKEN_FIRESTORE_TYPES}}
-          NPM_TOKEN_FUNCTIONS: ${{secrets.NPM_TOKEN_FUNCTIONS}}
-          NPM_TOKEN_FUNCTIONS_TYPES: ${{secrets.NPM_TOKEN_FUNCTIONS_TYPES}}
-          NPM_TOKEN_INSTALLATIONS: ${{secrets.NPM_TOKEN_INSTALLATIONS}}
-          NPM_TOKEN_INSTALLATIONS_TYPES: ${{secrets.NPM_TOKEN_INSTALLATIONS_TYPES}}
-          NPM_TOKEN_LOGGER: ${{secrets.NPM_TOKEN_LOGGER}}
-          NPM_TOKEN_MESSAGING: ${{secrets.NPM_TOKEN_MESSAGING}}
-          NPM_TOKEN_MESSAGING_TYPES: ${{secrets.NPM_TOKEN_MESSAGING_TYPES}}
-          NPM_TOKEN_PERFORMANCE: ${{secrets.NPM_TOKEN_PERFORMANCE}}
-          NPM_TOKEN_PERFORMANCE_TYPES: ${{secrets.NPM_TOKEN_PERFORMANCE_TYPES}}
-          NPM_TOKEN_POLYFILL: ${{secrets.NPM_TOKEN_POLYFILL}}
-          NPM_TOKEN_REMOTE_CONFIG: ${{secrets.NPM_TOKEN_REMOTE_CONFIG}}
-          NPM_TOKEN_REMOTE_CONFIG_TYPES: ${{secrets.NPM_TOKEN_REMOTE_CONFIG_TYPES}}
-          NPM_TOKEN_STORAGE: ${{secrets.NPM_TOKEN_STORAGE}}
-          NPM_TOKEN_STORAGE_TYPES: ${{secrets.NPM_TOKEN_STORAGE_TYPES}}
-          NPM_TOKEN_TESTING: ${{secrets.NPM_TOKEN_TESTING}}
-          NPM_TOKEN_UTIL: ${{secrets.NPM_TOKEN_UTIL}}
-          NPM_TOKEN_WEBCHANNEL_WRAPPER: ${{secrets.NPM_TOKEN_WEBCHANNEL_WRAPPER}}
-          NPM_TOKEN_FIREBASE: ${{secrets.NPM_TOKEN_FIREBASE}}
-          NPM_TOKEN_RXFIRE: ${{secrets.NPM_TOKEN_RXFIRE}}
-          CI: true
+    - uses: actions/checkout@v2
+    - name: Checkout
+      # Canary release script requires git history and tags.
+      run: git fetch --prune --unshallow
+    - name: Set up Node (10)
+      uses: actions/setup-node@v1
+      with:
+        node-version: 10.x
+    - name: Yarn install
+      run: yarn
+    - name: Deploy canary
+      run: yarn release --canary
+      env:
+        NPM_TOKEN_ANALYTICS: ${{secrets.NPM_TOKEN_ANALYTICS}}
+        NPM_TOKEN_ANALYTICS_INTEROP_TYPES: ${{secrets.NPM_TOKEN_ANALYTICS_INTEROP_TYPES}}
+        NPM_TOKEN_ANALYTICS_TYPES: ${{secrets.NPM_TOKEN_ANALYTICS_TYPES}}
+        NPM_TOKEN_APP: ${{secrets.NPM_TOKEN_APP}}
+        NPM_TOKEN_APP_TYPES: ${{secrets.NPM_TOKEN_APP_TYPES}}
+        NPM_TOKEN_AUTH: ${{secrets.NPM_TOKEN_AUTH}}
+        NPM_TOKEN_AUTH_INTEROP_TYPES: ${{secrets.NPM_TOKEN_AUTH_INTEROP_TYPES}}
+        NPM_TOKEN_AUTH_TYPES: ${{secrets.NPM_TOKEN_AUTH_TYPES}}
+        NPM_TOKEN_COMPONENT: ${{secrets.NPM_TOKEN_COMPONENT}}
+        NPM_TOKEN_DATABASE: ${{secrets.NPM_TOKEN_DATABASE}}
+        NPM_TOKEN_DATABASE_TYPES: ${{secrets.NPM_TOKEN_DATABASE_TYPES}}
+        NPM_TOKEN_FIRESTORE: ${{secrets.NPM_TOKEN_FIRESTORE}}
+        NPM_TOKEN_FIRESTORE_TYPES: ${{secrets.NPM_TOKEN_FIRESTORE_TYPES}}
+        NPM_TOKEN_FUNCTIONS: ${{secrets.NPM_TOKEN_FUNCTIONS}}
+        NPM_TOKEN_FUNCTIONS_TYPES: ${{secrets.NPM_TOKEN_FUNCTIONS_TYPES}}
+        NPM_TOKEN_INSTALLATIONS: ${{secrets.NPM_TOKEN_INSTALLATIONS}}
+        NPM_TOKEN_INSTALLATIONS_TYPES: ${{secrets.NPM_TOKEN_INSTALLATIONS_TYPES}}
+        NPM_TOKEN_LOGGER: ${{secrets.NPM_TOKEN_LOGGER}}
+        NPM_TOKEN_MESSAGING: ${{secrets.NPM_TOKEN_MESSAGING}}
+        NPM_TOKEN_MESSAGING_TYPES: ${{secrets.NPM_TOKEN_MESSAGING_TYPES}}
+        NPM_TOKEN_PERFORMANCE: ${{secrets.NPM_TOKEN_PERFORMANCE}}
+        NPM_TOKEN_PERFORMANCE_TYPES: ${{secrets.NPM_TOKEN_PERFORMANCE_TYPES}}
+        NPM_TOKEN_POLYFILL: ${{secrets.NPM_TOKEN_POLYFILL}}
+        NPM_TOKEN_REMOTE_CONFIG: ${{secrets.NPM_TOKEN_REMOTE_CONFIG}}
+        NPM_TOKEN_REMOTE_CONFIG_TYPES: ${{secrets.NPM_TOKEN_REMOTE_CONFIG_TYPES}}
+        NPM_TOKEN_STORAGE: ${{secrets.NPM_TOKEN_STORAGE}}
+        NPM_TOKEN_STORAGE_TYPES: ${{secrets.NPM_TOKEN_STORAGE_TYPES}}
+        NPM_TOKEN_TESTING: ${{secrets.NPM_TOKEN_TESTING}}
+        NPM_TOKEN_UTIL: ${{secrets.NPM_TOKEN_UTIL}}
+        NPM_TOKEN_WEBCHANNEL_WRAPPER: ${{secrets.NPM_TOKEN_WEBCHANNEL_WRAPPER}}
+        NPM_TOKEN_FIREBASE: ${{secrets.NPM_TOKEN_FIREBASE}}
+        NPM_TOKEN_RXFIRE: ${{secrets.NPM_TOKEN_RXFIRE}}
+        CI: true

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -8,33 +8,33 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Node (10)
-      uses: actions/setup-node@v1
-      with:
-        node-version: 10.x
-    - name: install Chrome stable
-      run: |
-        sudo apt-get update
-        sudo apt-get install google-chrome-stable
-    - name: Test setup and yarn install
-      run: |
-        cp config/ci.config.json config/project.json
-        yarn
-    - name: yarn build
-      run: yarn build
-    - name: Run unit tests
-      run: xvfb-run yarn test:ci
-      env:
-        FCM_TEST_PROJECT_SERVER_KEY: $${{secrets.FCM_TEST_PROJECT_SERVER_KEY}
-    - name: Generate coverage file
-      run: yarn ci:coverage
-    - name: Run coverage
-      uses: coverallsapp/github-action@master
-      with:
-        github-token: ${{ secrets.GITHUB_TOKEN }}
-        path-to-lcov: ./lcov-all.info
-      continue-on-error: true
+      - uses: actions/checkout@v2
+      - name: Set up Node (10)
+        uses: actions/setup-node@v1
+        with:
+          node-version: 10.x
+      - name: install Chrome stable
+        run: |
+          sudo apt-get update
+          sudo apt-get install google-chrome-stable
+      - name: Test setup and yarn install
+        run: |
+          cp config/ci.config.json config/project.json
+          yarn
+      - name: yarn build
+        run: yarn build
+      - name: Run unit tests
+        run: xvfb-run yarn test:ci
+        env:
+          FCM_TEST_PROJECT_SERVER_KEY: $${{secrets.FCM_TEST_PROJECT_SERVER_KEY}}
+      - name: Generate coverage file
+        run: yarn ci:coverage
+      - name: Run coverage
+        uses: coverallsapp/github-action@master
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path-to-lcov: ./lcov-all.info
+        continue-on-error: true
   deploy:
     name: Canary Deploy
     runs-on: ubuntu-latest
@@ -42,49 +42,49 @@ jobs:
     needs: test
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Checkout
-      # Canary release script requires git history and tags.
-      run: git fetch --prune --unshallow
-    - name: Set up Node (10)
-      uses: actions/setup-node@v1
-      with:
-        node-version: 10.x
-    - name: Yarn install
-      run: yarn
-    - name: Deploy canary
-      run: yarn release --canary
-      env:
-        NPM_TOKEN_ANALYTICS: ${{secrets.NPM_TOKEN_ANALYTICS}}
-        NPM_TOKEN_ANALYTICS_INTEROP_TYPES: ${{secrets.NPM_TOKEN_ANALYTICS_INTEROP_TYPES}}
-        NPM_TOKEN_ANALYTICS_TYPES: ${{secrets.NPM_TOKEN_ANALYTICS_TYPES}}
-        NPM_TOKEN_APP: ${{secrets.NPM_TOKEN_APP}}
-        NPM_TOKEN_APP_TYPES: ${{secrets.NPM_TOKEN_APP_TYPES}}
-        NPM_TOKEN_AUTH: ${{secrets.NPM_TOKEN_AUTH}}
-        NPM_TOKEN_AUTH_INTEROP_TYPES: ${{secrets.NPM_TOKEN_AUTH_INTEROP_TYPES}}
-        NPM_TOKEN_AUTH_TYPES: ${{secrets.NPM_TOKEN_AUTH_TYPES}}
-        NPM_TOKEN_COMPONENT: ${{secrets.NPM_TOKEN_COMPONENT}}
-        NPM_TOKEN_DATABASE: ${{secrets.NPM_TOKEN_DATABASE}}
-        NPM_TOKEN_DATABASE_TYPES: ${{secrets.NPM_TOKEN_DATABASE_TYPES}}
-        NPM_TOKEN_FIRESTORE: ${{secrets.NPM_TOKEN_FIRESTORE}}
-        NPM_TOKEN_FIRESTORE_TYPES: ${{secrets.NPM_TOKEN_FIRESTORE_TYPES}}
-        NPM_TOKEN_FUNCTIONS: ${{secrets.NPM_TOKEN_FUNCTIONS}}
-        NPM_TOKEN_FUNCTIONS_TYPES: ${{secrets.NPM_TOKEN_FUNCTIONS_TYPES}}
-        NPM_TOKEN_INSTALLATIONS: ${{secrets.NPM_TOKEN_INSTALLATIONS}}
-        NPM_TOKEN_INSTALLATIONS_TYPES: ${{secrets.NPM_TOKEN_INSTALLATIONS_TYPES}}
-        NPM_TOKEN_LOGGER: ${{secrets.NPM_TOKEN_LOGGER}}
-        NPM_TOKEN_MESSAGING: ${{secrets.NPM_TOKEN_MESSAGING}}
-        NPM_TOKEN_MESSAGING_TYPES: ${{secrets.NPM_TOKEN_MESSAGING_TYPES}}
-        NPM_TOKEN_PERFORMANCE: ${{secrets.NPM_TOKEN_PERFORMANCE}}
-        NPM_TOKEN_PERFORMANCE_TYPES: ${{secrets.NPM_TOKEN_PERFORMANCE_TYPES}}
-        NPM_TOKEN_POLYFILL: ${{secrets.NPM_TOKEN_POLYFILL}}
-        NPM_TOKEN_REMOTE_CONFIG: ${{secrets.NPM_TOKEN_REMOTE_CONFIG}}
-        NPM_TOKEN_REMOTE_CONFIG_TYPES: ${{secrets.NPM_TOKEN_REMOTE_CONFIG_TYPES}}
-        NPM_TOKEN_STORAGE: ${{secrets.NPM_TOKEN_STORAGE}}
-        NPM_TOKEN_STORAGE_TYPES: ${{secrets.NPM_TOKEN_STORAGE_TYPES}}
-        NPM_TOKEN_TESTING: ${{secrets.NPM_TOKEN_TESTING}}
-        NPM_TOKEN_UTIL: ${{secrets.NPM_TOKEN_UTIL}}
-        NPM_TOKEN_WEBCHANNEL_WRAPPER: ${{secrets.NPM_TOKEN_WEBCHANNEL_WRAPPER}}
-        NPM_TOKEN_FIREBASE: ${{secrets.NPM_TOKEN_FIREBASE}}
-        NPM_TOKEN_RXFIRE: ${{secrets.NPM_TOKEN_RXFIRE}}
-        CI: true
+      - uses: actions/checkout@v2
+      - name: Checkout
+        # Canary release script requires git history and tags.
+        run: git fetch --prune --unshallow
+      - name: Set up Node (10)
+        uses: actions/setup-node@v1
+        with:
+          node-version: 10.x
+      - name: Yarn install
+        run: yarn
+      - name: Deploy canary
+        run: yarn release --canary
+        env:
+          NPM_TOKEN_ANALYTICS: ${{secrets.NPM_TOKEN_ANALYTICS}}
+          NPM_TOKEN_ANALYTICS_INTEROP_TYPES: ${{secrets.NPM_TOKEN_ANALYTICS_INTEROP_TYPES}}
+          NPM_TOKEN_ANALYTICS_TYPES: ${{secrets.NPM_TOKEN_ANALYTICS_TYPES}}
+          NPM_TOKEN_APP: ${{secrets.NPM_TOKEN_APP}}
+          NPM_TOKEN_APP_TYPES: ${{secrets.NPM_TOKEN_APP_TYPES}}
+          NPM_TOKEN_AUTH: ${{secrets.NPM_TOKEN_AUTH}}
+          NPM_TOKEN_AUTH_INTEROP_TYPES: ${{secrets.NPM_TOKEN_AUTH_INTEROP_TYPES}}
+          NPM_TOKEN_AUTH_TYPES: ${{secrets.NPM_TOKEN_AUTH_TYPES}}
+          NPM_TOKEN_COMPONENT: ${{secrets.NPM_TOKEN_COMPONENT}}
+          NPM_TOKEN_DATABASE: ${{secrets.NPM_TOKEN_DATABASE}}
+          NPM_TOKEN_DATABASE_TYPES: ${{secrets.NPM_TOKEN_DATABASE_TYPES}}
+          NPM_TOKEN_FIRESTORE: ${{secrets.NPM_TOKEN_FIRESTORE}}
+          NPM_TOKEN_FIRESTORE_TYPES: ${{secrets.NPM_TOKEN_FIRESTORE_TYPES}}
+          NPM_TOKEN_FUNCTIONS: ${{secrets.NPM_TOKEN_FUNCTIONS}}
+          NPM_TOKEN_FUNCTIONS_TYPES: ${{secrets.NPM_TOKEN_FUNCTIONS_TYPES}}
+          NPM_TOKEN_INSTALLATIONS: ${{secrets.NPM_TOKEN_INSTALLATIONS}}
+          NPM_TOKEN_INSTALLATIONS_TYPES: ${{secrets.NPM_TOKEN_INSTALLATIONS_TYPES}}
+          NPM_TOKEN_LOGGER: ${{secrets.NPM_TOKEN_LOGGER}}
+          NPM_TOKEN_MESSAGING: ${{secrets.NPM_TOKEN_MESSAGING}}
+          NPM_TOKEN_MESSAGING_TYPES: ${{secrets.NPM_TOKEN_MESSAGING_TYPES}}
+          NPM_TOKEN_PERFORMANCE: ${{secrets.NPM_TOKEN_PERFORMANCE}}
+          NPM_TOKEN_PERFORMANCE_TYPES: ${{secrets.NPM_TOKEN_PERFORMANCE_TYPES}}
+          NPM_TOKEN_POLYFILL: ${{secrets.NPM_TOKEN_POLYFILL}}
+          NPM_TOKEN_REMOTE_CONFIG: ${{secrets.NPM_TOKEN_REMOTE_CONFIG}}
+          NPM_TOKEN_REMOTE_CONFIG_TYPES: ${{secrets.NPM_TOKEN_REMOTE_CONFIG_TYPES}}
+          NPM_TOKEN_STORAGE: ${{secrets.NPM_TOKEN_STORAGE}}
+          NPM_TOKEN_STORAGE_TYPES: ${{secrets.NPM_TOKEN_STORAGE_TYPES}}
+          NPM_TOKEN_TESTING: ${{secrets.NPM_TOKEN_TESTING}}
+          NPM_TOKEN_UTIL: ${{secrets.NPM_TOKEN_UTIL}}
+          NPM_TOKEN_WEBCHANNEL_WRAPPER: ${{secrets.NPM_TOKEN_WEBCHANNEL_WRAPPER}}
+          NPM_TOKEN_FIREBASE: ${{secrets.NPM_TOKEN_FIREBASE}}
+          NPM_TOKEN_RXFIRE: ${{secrets.NPM_TOKEN_RXFIRE}}
+          CI: true

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -25,6 +25,8 @@ jobs:
       run: yarn build
     - name: Run unit tests
       run: xvfb-run yarn test:ci
+      env:
+        FCM_TEST_PROJECT_SERVER_KEY: $${{secrets.FCM_TEST_PROJECT_SERVER_KEY}
     - name: Generate coverage file
       run: yarn ci:coverage
     - name: Run coverage

--- a/.github/workflows/test-changed.yml
+++ b/.github/workflows/test-changed.yml
@@ -28,3 +28,5 @@ jobs:
       run: yarn build
     - name: Run tests on changed packages
       run: xvfb-run yarn test:changed
+      env:
+        FCM_TEST_PROJECT_SERVER_KEY: $${{secrets.FCM_TEST_PROJECT_SERVER_KEY}}  


### PR DESCRIPTION
Context: I tried to check in theses changes along with my integration test changes. However, I am getting a `bad credential` response from FCM Send Service upon triggering a send request. This is a response thrown when the `server key`  is faulty or missing (local tests seems to indicated that my server key is functional). The remaining possible culprits include: 

  a) Secret checked in is somehow wrong (maybe a trailing space? etc) -or-
  b) Secrets must already be included in the ci runs prior than using it in a post-commit run -or-
  c) Secret is somehow not included into process.Env   

This PR is created to examine the validity of hypo b). Hopeful it would resolve the issue 🍺 