### PR TITLE
Add DocumentReference

### DIFF
--- a/packages/firestore/lite/index.node.ts
+++ b/packages/firestore/lite/index.node.ts
@@ -26,6 +26,8 @@ export {
   getFirestore
 } from './src/api/database';
 
+export { DocumentReference } from './src/api/reference';
+
 export function registerFirestore(): void {
   _registerComponent(
     new Component(

--- a/packages/firestore/lite/src/api/reference.ts
+++ b/packages/firestore/lite/src/api/reference.ts
@@ -1,0 +1,51 @@
+/**
+ * @license
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as firestore from '../../index';
+
+import { DocumentKey } from '../../../src/model/document_key';
+import { Firestore } from './database';
+import { DocumentKeyReference } from '../../../src/api/user_data_reader';
+
+/**
+ * A reference to a particular document in a collection in the database.
+ */
+export class DocumentReference<T = firestore.DocumentData>
+  extends DocumentKeyReference<T>
+  implements firestore.DocumentReference<T> {
+  constructor(
+    readonly firestore: Firestore,
+    key: DocumentKey,
+    readonly _converter?: firestore.FirestoreDataConverter<T>
+  ) {
+    super(firestore._databaseId, key, _converter);
+  }
+
+  get id(): string {
+    return this._key.path.lastSegment();
+  }
+
+  get path(): string {
+    return this._key.path.canonicalString();
+  }
+
+  withConverter<U>(
+    converter: firestore.FirestoreDataConverter<U>
+  ): firestore.DocumentReference<U> {
+    return new DocumentReference<U>(this.firestore, this._key, converter);
+  }
+}

--- a/packages/firestore/src/api/user_data_reader.ts
+++ b/packages/firestore/src/api/user_data_reader.ts
@@ -50,6 +50,15 @@ import { PlatformSupport } from '../platform/platform';
 const RESERVED_FIELD_REGEX = /^__.*__$/;
 
 /**
+ * An untyped Firestore Data Converter interface that is shared between the
+ * lite, full and legacy SDK.
+ */
+export interface UntypedFirestoreDataConverter<T> {
+  toFirestore(modelObject: T): firestore.DocumentData;
+  fromFirestore(snapshot: unknown, options?: unknown): T;
+}
+
+/**
  * A reference to a document in a Firebase project.
  *
  * This class serves as a common base class for the public DocumentReferences
@@ -59,7 +68,7 @@ export class DocumentKeyReference<T> {
   constructor(
     public readonly _databaseId: DatabaseId,
     public readonly _key: DocumentKey,
-    public readonly _converter?: firestore.FirestoreDataConverter<T>
+    public readonly _converter?: UntypedFirestoreDataConverter<T>
   ) {}
 }
 


### PR DESCRIPTION
This adds the DocumentReference type to the Lite SDK. 

Inspired by https://github.com/firebase/firebase-js-sdk/blob/4a70e17f009ea6ab4949178b64c9bbeb68c88af5/packages/firestore/src/api/database.ts#L937