### PR TITLE
Run integration/firestore tests for Firestore code changes

### DIFF
--- a/packages/firestore/src/core/component_provider.ts
+++ b/packages/firestore/src/core/component_provider.ts
@@ -44,7 +44,7 @@ import {
 } from '../local/memory_persistence';
 
 const MEMORY_ONLY_PERSISTENCE_ERROR_MESSAGE =
-  'You are using the memory-only build of Firestore. Persistence support is ' +
+  'You ARE using the memory-only build of Firestore. Persistence support is ' +
   'only available via the @firebase/firestore bundle or the ' +
   'firebase-firestore.js build.';
 

--- a/packages/firestore/src/core/component_provider.ts
+++ b/packages/firestore/src/core/component_provider.ts
@@ -44,7 +44,7 @@ import {
 } from '../local/memory_persistence';
 
 const MEMORY_ONLY_PERSISTENCE_ERROR_MESSAGE =
-  'You ARE using the memory-only build of Firestore. Persistence support is ' +
+  'You are using the memory-only build of Firestore. Persistence support is ' +
   'only available via the @firebase/firestore bundle or the ' +
   'firebase-firestore.js build.';
 

--- a/scripts/run_changed.js
+++ b/scripts/run_changed.js
@@ -70,7 +70,8 @@ const specialPaths = {
     'packages/database'
   ],
   'scripts/emulator-testing/firestore-test-runner.ts': ['packages/firestore'],
-  'scripts/emulator-testing/database-test-runner.ts': ['packages/database']
+  'scripts/emulator-testing/database-test-runner.ts': ['packages/database'],
+  'packages/firestore': ['integration/firestore']
 };
 
 /**
@@ -95,10 +96,11 @@ async function getChangedPackages() {
       return { testAll: true };
     }
     // Files outside a package dir that should trigger its tests.
-    if (specialPaths[filename]) {
-      for (const targetPackage of specialPaths[filename]) {
-        changedPackages[targetPackage] = 'dependency';
-      }
+    const matchingSpecialPaths = Object.keys(specialPaths).filter(path =>
+      filename.startsWith(path)
+    );
+    for (const targetPackage of specialPaths[matchingSpecialPaths]) {
+      changedPackages[targetPackage] = 'dependency';
     }
     // Check for changed files inside package dirs.
     const match = filename.match('^(packages(-exp)?/[a-zA-Z0-9-]+)/.*');

--- a/scripts/run_changed.js
+++ b/scripts/run_changed.js
@@ -96,18 +96,14 @@ async function getChangedPackages() {
       return { testAll: true };
     }
     // Files outside a package dir that should trigger its tests.
-    console.log(filename);
     const matchingSpecialPaths = Object.keys(specialPaths).filter(path =>
       filename.startsWith(path)
     );
-    console.log(matchingSpecialPaths);
     for (const matchingSpecialPath of matchingSpecialPaths) {
       for (const targetPackage of specialPaths[matchingSpecialPath]) {
         changedPackages[targetPackage] = 'dependency';
       }
     }
-    console.log(changedPackages);
-    throw new Error('foo');
     // Check for changed files inside package dirs.
     const match = filename.match('^(packages(-exp)?/[a-zA-Z0-9-]+)/.*');
     if (match && match[1]) {

--- a/scripts/run_changed.js
+++ b/scripts/run_changed.js
@@ -96,12 +96,18 @@ async function getChangedPackages() {
       return { testAll: true };
     }
     // Files outside a package dir that should trigger its tests.
+    console.log(filename);
     const matchingSpecialPaths = Object.keys(specialPaths).filter(path =>
       filename.startsWith(path)
     );
-    for (const targetPackage of specialPaths[matchingSpecialPaths]) {
-      changedPackages[targetPackage] = 'dependency';
+    console.log(matchingSpecialPaths);
+    for (const matchingSpecialPath of matchingSpecialPaths) {
+      for (const targetPackage of specialPaths[matchingSpecialPath]) {
+        changedPackages[targetPackage] = 'dependency';
+      }
     }
+    console.log(changedPackages);
+    throw new Error('foo');
     // Check for changed files inside package dirs.
     const match = filename.match('^(packages(-exp)?/[a-zA-Z0-9-]+)/.*');
     if (match && match[1]) {


### PR DESCRIPTION
@thebrianchen noticed that one of our integration tests that only runs as part of integration/firestore broke. It looks like this was possible because we did not run those tests as part of Firestore changes.