### PR TITLE
Raise an error for enablePersistence() in memory-only build

### DIFF
--- a/packages/firestore/src/core/component_provider.ts
+++ b/packages/firestore/src/core/component_provider.ts
@@ -133,10 +133,12 @@ export class MemoryComponentProvider implements ComponentProvider {
   }
 
   createPersistence(cfg: ComponentConfiguration): Persistence {
-    debugAssert(
-      !cfg.persistenceSettings.durable,
-      'Can only start memory persistence'
-    );
+    if (cfg.persistenceSettings.durable) {
+      throw new FirestoreError(
+        Code.FAILED_PRECONDITION,
+        MEMORY_ONLY_PERSISTENCE_ERROR_MESSAGE
+      );
+    }
     return new MemoryPersistence(MemoryEagerDelegate.factory);
   }
 


### PR DESCRIPTION
This fixes a regression in the memory-only build that went unnoticed because we never ran the memory-only integration tests on CI (see https://github.com/firebase/firebase-js-sdk/pull/3127).

We need to throw the right error if `enablePersistence()` is used in the memory-only build. If it is used, the "durable" flag will be true in the MemoryComponentProvider, which should trigger a user-level exception and not a debugAssert.