### PR TITLE
Remove support for lastStreamToken

### DIFF
--- a/packages/firestore/src/local/indexeddb_mutation_queue.ts
+++ b/packages/firestore/src/local/indexeddb_mutation_queue.ts
@@ -26,7 +26,6 @@ import { BATCHID_UNKNOWN, MutationBatch } from '../model/mutation_batch';
 import { ResourcePath } from '../model/path';
 import { debugAssert, fail, hardAssert } from '../util/assert';
 import { primitiveComparator } from '../util/misc';
-import { ByteString } from '../util/byte_string';
 import { SortedMap } from '../util/sorted_map';
 import { SortedSet } from '../util/sorted_set';
 import { decodeResourcePath } from './encoded_resource_path';
@@ -116,40 +115,6 @@ export class IndexedDbMutationQueue implements MutationQueue {
         }
       )
       .next(() => empty);
-  }
-
-  acknowledgeBatch(
-    transaction: PersistenceTransaction,
-    batch: MutationBatch,
-    streamToken: ByteString
-  ): PersistencePromise<void> {
-    return this.getMutationQueueMetadata(transaction).next(metadata => {
-      // We can't store the resumeToken as a ByteString in IndexedDB, so we
-      // convert it to a Base64 string for storage.
-      metadata.lastStreamToken = streamToken.toBase64();
-
-      return mutationQueuesStore(transaction).put(metadata);
-    });
-  }
-
-  getLastStreamToken(
-    transaction: PersistenceTransaction
-  ): PersistencePromise<ByteString> {
-    return this.getMutationQueueMetadata(transaction).next<ByteString>(
-      metadata => ByteString.fromBase64String(metadata.lastStreamToken)
-    );
-  }
-
-  setLastStreamToken(
-    transaction: PersistenceTransaction,
-    streamToken: ByteString
-  ): PersistencePromise<void> {
-    return this.getMutationQueueMetadata(transaction).next(metadata => {
-      // We can't store the resumeToken as a ByteString in IndexedDB, so we
-      // convert it to a Base64 string for storage.
-      metadata.lastStreamToken = streamToken.toBase64();
-      return mutationQueuesStore(transaction).put(metadata);
-    });
   }
 
   addMutationBatch(

--- a/packages/firestore/src/local/indexeddb_schema.ts
+++ b/packages/firestore/src/local/indexeddb_schema.ts
@@ -423,6 +423,8 @@ export class DbMutationQueue {
      *
      * After sending this token, earlier tokens may not be used anymore so
      * only a single stream token is retained.
+     *
+     * NOTE: this is deprecated and no longer used by the code.
      */
     public lastStreamToken: string
   ) {}

--- a/packages/firestore/src/local/local_store.ts
+++ b/packages/firestore/src/local/local_store.ts
@@ -60,7 +60,6 @@ import { RemoteDocumentCache } from './remote_document_cache';
 import { RemoteDocumentChangeBuffer } from './remote_document_change_buffer';
 import { ClientId } from './shared_client_state';
 import { TargetData, TargetPurpose } from './target_data';
-import { ByteString } from '../util/byte_string';
 import { IndexedDbPersistence } from './indexeddb_persistence';
 import { IndexedDbMutationQueue } from './indexeddb_mutation_queue';
 import { IndexedDbRemoteDocumentCache } from './indexeddb_remote_document_cache';
@@ -378,11 +377,11 @@ export class LocalStore {
         const documentBuffer = this.remoteDocuments.newChangeBuffer({
           trackRemovals: true // Make sure document removals show up in `getNewDocumentChanges()`
         });
-        return this.mutationQueue
-          .acknowledgeBatch(txn, batchResult.batch, batchResult.streamToken)
-          .next(() =>
-            this.applyWriteToRemoteDocuments(txn, batchResult, documentBuffer)
-          )
+        return this.applyWriteToRemoteDocuments(
+          txn,
+          batchResult,
+          documentBuffer
+        )
           .next(() => documentBuffer.apply(txn))
           .next(() => this.mutationQueue.performConsistencyCheck(txn))
           .next(() => this.localDocuments.getDocuments(txn, affected));
@@ -429,32 +428,6 @@ export class LocalStore {
       'readonly',
       txn => {
         return this.mutationQueue.getHighestUnacknowledgedBatchId(txn);
-      }
-    );
-  }
-
-  /** Returns the last recorded stream token for the current user. */
-  getLastStreamToken(): Promise<ByteString> {
-    return this.persistence.runTransaction(
-      'Get last stream token',
-      'readonly',
-      txn => {
-        return this.mutationQueue.getLastStreamToken(txn);
-      }
-    );
-  }
-
-  /**
-   * Sets the stream token for the current user without acknowledging any
-   * mutation batch. This is usually only useful after a stream handshake or in
-   * response to an error that requires clearing the stream token.
-   */
-  setLastStreamToken(streamToken: ByteString): Promise<void> {
-    return this.persistence.runTransaction(
-      'Set last stream token',
-      'readwrite-primary',
-      txn => {
-        return this.mutationQueue.setLastStreamToken(txn, streamToken);
       }
     );
   }

--- a/packages/firestore/src/local/mutation_queue.ts
+++ b/packages/firestore/src/local/mutation_queue.ts
@@ -21,7 +21,6 @@ import { BatchId } from '../core/types';
 import { DocumentKey } from '../model/document_key';
 import { Mutation } from '../model/mutation';
 import { MutationBatch } from '../model/mutation_batch';
-import { ByteString } from '../util/byte_string';
 import { SortedMap } from '../util/sorted_map';
 
 import { PersistenceTransaction } from './persistence';
@@ -31,26 +30,6 @@ import { PersistencePromise } from './persistence_promise';
 export interface MutationQueue {
   /** Returns true if this queue contains no mutation batches. */
   checkEmpty(transaction: PersistenceTransaction): PersistencePromise<boolean>;
-
-  /**
-   * Acknowledges the given batch.
-   */
-  acknowledgeBatch(
-    transaction: PersistenceTransaction,
-    batch: MutationBatch,
-    streamToken: ByteString
-  ): PersistencePromise<void>;
-
-  /** Returns the current stream token for this mutation queue. */
-  getLastStreamToken(
-    transaction: PersistenceTransaction
-  ): PersistencePromise<ByteString>;
-
-  /** Sets the stream token for this mutation queue. */
-  setLastStreamToken(
-    transaction: PersistenceTransaction,
-    streamToken: ByteString
-  ): PersistencePromise<void>;
 
   /**
    * Creates a new mutation batch and adds it to this mutation queue.

--- a/packages/firestore/src/model/mutation_batch.ts
+++ b/packages/firestore/src/model/mutation_batch.ts
@@ -20,7 +20,6 @@ import { SnapshotVersion } from '../core/snapshot_version';
 import { BatchId } from '../core/types';
 import { hardAssert, debugAssert } from '../util/assert';
 import { arrayEquals } from '../util/misc';
-import { ByteString } from '../util/byte_string';
 import {
   documentKeySet,
   DocumentKeySet,
@@ -189,7 +188,6 @@ export class MutationBatchResult {
     readonly batch: MutationBatch,
     readonly commitVersion: SnapshotVersion,
     readonly mutationResults: MutationResult[],
-    readonly streamToken: ByteString,
     /**
      * A pre-computed mapping from each mutated document to the resulting
      * version.
@@ -205,8 +203,7 @@ export class MutationBatchResult {
   static from(
     batch: MutationBatch,
     commitVersion: SnapshotVersion,
-    results: MutationResult[],
-    streamToken: ByteString
+    results: MutationResult[]
   ): MutationBatchResult {
     hardAssert(
       batch.mutations.length === results.length,
@@ -222,12 +219,6 @@ export class MutationBatchResult {
       versionMap = versionMap.insert(mutations[i].key, results[i].version);
     }
 
-    return new MutationBatchResult(
-      batch,
-      commitVersion,
-      results,
-      streamToken,
-      versionMap
-    );
+    return new MutationBatchResult(batch, commitVersion, results, versionMap);
   }
 }

--- a/packages/firestore/src/remote/persistent_stream.ts
+++ b/packages/firestore/src/remote/persistent_stream.ts
@@ -669,7 +669,7 @@ export class PersistentWriteStream extends PersistentStream<
    * PersistentWriteStream manages propagating this value from responses to the
    * next request.
    */
-  lastStreamToken: ByteString = ByteString.EMPTY_BYTE_STRING;
+  private lastStreamToken: ByteString = ByteString.EMPTY_BYTE_STRING;
 
   /**
    * Tracks whether or not a handshake has been successfully exchanged and

--- a/packages/firestore/src/remote/persistent_stream.ts
+++ b/packages/firestore/src/remote/persistent_stream.ts
@@ -682,13 +682,13 @@ export class PersistentWriteStream extends PersistentStream<
   // Override of PersistentStream.start
   start(): void {
     this.handshakeComplete_ = false;
+    this.lastStreamToken = ByteString.EMPTY_BYTE_STRING;
     super.start();
   }
 
   protected tearDown(): void {
     if (this.handshakeComplete_) {
       this.writeMutations([]);
-      this.lastStreamToken = ByteString.EMPTY_BYTE_STRING;
     }
   }
 
@@ -742,6 +742,10 @@ export class PersistentWriteStream extends PersistentStream<
   writeHandshake(): void {
     debugAssert(this.isOpen(), 'Writing handshake requires an opened stream');
     debugAssert(!this.handshakeComplete_, 'Handshake already completed');
+    debugAssert(
+      this.lastStreamToken.isEqual(ByteString.EMPTY_BYTE_STRING),
+      'Stream token should be empty during handshake'
+    );
     // TODO(dimond): Support stream resumption. We intentionally do not set the
     // stream token on the handshake, ignoring any stream token we might have.
     const request: WriteRequest = {};

--- a/packages/firestore/src/remote/persistent_stream.ts
+++ b/packages/firestore/src/remote/persistent_stream.ts
@@ -688,6 +688,7 @@ export class PersistentWriteStream extends PersistentStream<
   protected tearDown(): void {
     if (this.handshakeComplete_) {
       this.writeMutations([]);
+      this.lastStreamToken = ByteString.EMPTY_BYTE_STRING;
     }
   }
 

--- a/packages/firestore/test/unit/local/counting_query_engine.ts
+++ b/packages/firestore/test/unit/local/counting_query_engine.ts
@@ -129,7 +129,6 @@ export class CountingQueryEngine implements QueryEngine {
 
   private wrapMutationQueue(subject: MutationQueue): MutationQueue {
     return {
-      acknowledgeBatch: subject.acknowledgeBatch,
       addMutationBatch: subject.addMutationBatch,
       checkEmpty: subject.checkEmpty,
       getAllMutationBatches: transaction => {
@@ -166,13 +165,11 @@ export class CountingQueryEngine implements QueryEngine {
           });
       },
       getHighestUnacknowledgedBatchId: subject.getHighestUnacknowledgedBatchId,
-      getLastStreamToken: subject.getLastStreamToken,
       getNextMutationBatchAfterBatchId:
         subject.getNextMutationBatchAfterBatchId,
       lookupMutationBatch: subject.lookupMutationBatch,
       performConsistencyCheck: subject.performConsistencyCheck,
-      removeMutationBatch: subject.removeMutationBatch,
-      setLastStreamToken: subject.setLastStreamToken
+      removeMutationBatch: subject.removeMutationBatch
     };
   }
 }

--- a/packages/firestore/test/unit/local/local_store.test.ts
+++ b/packages/firestore/test/unit/local/local_store.test.ts
@@ -182,12 +182,7 @@ class LocalStoreTester {
             options.transformResult ? [options.transformResult] : null
           )
         ];
-        const write = MutationBatchResult.from(
-          batch,
-          ver,
-          mutationResults,
-          /*streamToken=*/ ByteString.EMPTY_BYTE_STRING
-        );
+        const write = MutationBatchResult.from(batch, ver, mutationResults);
 
         return this.localStore.acknowledgeBatch(write);
       })

--- a/packages/firestore/test/unit/local/mutation_queue.test.ts
+++ b/packages/firestore/test/unit/local/mutation_queue.test.ts
@@ -27,14 +27,12 @@ import {
   key,
   patchMutation,
   path,
-  setMutation,
-  byteStringFromString
+  setMutation
 } from '../../util/helpers';
 
 import { addEqualityMatcher } from '../../util/equality_matcher';
 import * as persistenceHelpers from './persistence_test_helpers';
 import { TestMutationQueue } from './test_mutation_queue';
-import { ByteString } from '../../../src/util/byte_string';
 
 let persistence: Persistence;
 let mutationQueue: TestMutationQueue;
@@ -145,16 +143,6 @@ function genericMutationQueueTests(): void {
     expect(await mutationQueue.countBatches()).to.equal(1);
 
     await mutationQueue.removeMutationBatch(batch2);
-    expect(await mutationQueue.countBatches()).to.equal(0);
-  });
-
-  it('can acknowledge then remove', async () => {
-    const batch1 = await addMutationBatch();
-    expect(await mutationQueue.countBatches()).to.equal(1);
-
-    await mutationQueue.acknowledgeBatch(batch1, ByteString.EMPTY_BYTE_STRING);
-    await mutationQueue.removeMutationBatch(batch1);
-
     expect(await mutationQueue.countBatches()).to.equal(0);
   });
 
@@ -303,25 +291,6 @@ function genericMutationQueueTests(): void {
       query
     );
     expectEqualArrays(matches, expected);
-  });
-
-  it('can save the last stream token', async () => {
-    const streamToken1 = byteStringFromString('token1');
-    const streamToken2 = byteStringFromString('token2');
-
-    await mutationQueue.setLastStreamToken(streamToken1);
-
-    const batch1 = await addMutationBatch();
-
-    expect(await mutationQueue.getLastStreamToken()).to.deep.equal(
-      streamToken1
-    );
-
-    await mutationQueue.acknowledgeBatch(batch1, streamToken2);
-
-    expect(await mutationQueue.getLastStreamToken()).to.deep.equal(
-      streamToken2
-    );
   });
 
   it('can removeMutationBatch()', async () => {

--- a/packages/firestore/test/unit/local/test_mutation_queue.ts
+++ b/packages/firestore/test/unit/local/test_mutation_queue.ts
@@ -25,7 +25,6 @@ import { DocumentKey } from '../../../src/model/document_key';
 import { Mutation } from '../../../src/model/mutation';
 import { MutationBatch } from '../../../src/model/mutation_batch';
 import { SortedMap } from '../../../src/util/sorted_map';
-import { ByteString } from '../../../src/util/byte_string';
 
 /**
  * A wrapper around a MutationQueue that automatically creates a
@@ -46,39 +45,6 @@ export class TestMutationQueue {
         return this.queue.getAllMutationBatches(txn);
       })
       .then(batches => batches.length);
-  }
-
-  acknowledgeBatch(
-    batch: MutationBatch,
-    streamToken: ByteString
-  ): Promise<void> {
-    return this.persistence.runTransaction(
-      'acknowledgeThroughBatchId',
-      'readwrite-primary',
-      txn => {
-        return this.queue.acknowledgeBatch(txn, batch, streamToken);
-      }
-    );
-  }
-
-  getLastStreamToken(): Promise<ByteString> {
-    return this.persistence.runTransaction(
-      'getLastStreamToken',
-      'readonly',
-      txn => {
-        return this.queue.getLastStreamToken(txn);
-      }
-    );
-  }
-
-  setLastStreamToken(streamToken: ByteString): Promise<void> {
-    return this.persistence.runTransaction(
-      'setLastStreamToken',
-      'readwrite-primary',
-      txn => {
-        return this.queue.setLastStreamToken(txn, streamToken);
-      }
-    );
   }
 
   addMutationBatch(mutations: Mutation[]): Promise<MutationBatch> {


### PR DESCRIPTION
This extracts the Stream Token removal from https://github.com/firebase/firebase-js-sdk/pull/2995 into a separate PR, so it can be more easily reverted should the backend add full support for the stream tokens.

We are removing the Stream Tokens to ease IndexedDB recovery.

Proof of concept PR that implements IndexedDB recovery with Stream Tokens: https://github.com/firebase/firebase-js-sdk/pull/3131