### PR TITLE
Add FieldValue methods to the Lite SDK

### DIFF
--- a/packages/firestore/lite/index.node.ts
+++ b/packages/firestore/lite/index.node.ts
@@ -20,6 +20,8 @@ import { Firestore } from './src/api/database';
 import { version } from '../package.json';
 import { Component, ComponentType } from '@firebase/component';
 
+import '../src/platform_node/node_init';
+
 export {
   Firestore,
   initializeFirestore,

--- a/packages/firestore/lite/index.node.ts
+++ b/packages/firestore/lite/index.node.ts
@@ -26,6 +26,15 @@ export {
   getFirestore
 } from './src/api/database';
 
+export {
+  FieldValue,
+  deleteField,
+  increment,
+  arrayRemove,
+  arrayUnion,
+  serverTimestamp
+} from './src/api/field_value';
+
 export function registerFirestore(): void {
   _registerComponent(
     new Component(

--- a/packages/firestore/lite/src/api/field_value.ts
+++ b/packages/firestore/lite/src/api/field_value.ts
@@ -1,0 +1,97 @@
+/**
+ * @license
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as firestore from '../../';
+
+import { validateAtLeastNumberOfArgs } from '../../../src/util/input_validation';
+import {
+  ArrayRemoveFieldValueImpl,
+  ArrayUnionFieldValueImpl,
+  DeleteFieldValueImpl,
+  NumericIncrementFieldValueImpl,
+  SerializableFieldValue,
+  ServerTimestampFieldValueImpl
+} from '../../../src/api/field_value';
+import { ParseContext } from '../../../src/api/user_data_reader';
+import { FieldTransform } from '../../../src/model/mutation';
+
+/** The public FieldValue class of the lite API. */
+export abstract class FieldValue extends SerializableFieldValue
+  implements firestore.FieldValue {}
+
+/**
+ * A delegate class that allows the FieldValue implementations returned by
+ * deleteField(), serverTimestamp(), arrayUnion(), arrayRemove() and
+ * increment() to be an instance of the lite FieldValue class declared above.
+ *
+ * We don't directly subclass `FieldValue` in the various field value
+ * implementations as the base FieldValue class differs between the lite, full
+ * and legacy SDK.
+ */
+class FieldValueDelegate extends FieldValue implements firestore.FieldValue {
+  readonly _methodName: string;
+
+  constructor(readonly _delegate: SerializableFieldValue) {
+    super();
+    this._methodName = _delegate._methodName;
+  }
+
+  _toFieldTransform(context: ParseContext): FieldTransform | null {
+    return this._delegate._toFieldTransform(context);
+  }
+
+  isEqual(other: firestore.FieldValue): boolean {
+    if (!(other instanceof FieldValueDelegate)) {
+      return false;
+    }
+    return this._delegate.isEqual(other._delegate);
+  }
+}
+
+export function deleteField(): firestore.FieldValue {
+  return new FieldValueDelegate(new DeleteFieldValueImpl('delete'));
+}
+
+export function serverTimestamp(): firestore.FieldValue {
+  return new FieldValueDelegate(
+    new ServerTimestampFieldValueImpl('serverTimestamp')
+  );
+}
+
+export function arrayUnion(...elements: unknown[]): firestore.FieldValue {
+  validateAtLeastNumberOfArgs('arrayUnion()', arguments, 1);
+  // NOTE: We don't actually parse the data until it's used in set() or
+  // update() since we need access to the Firestore instance.
+  return new FieldValueDelegate(
+    new ArrayUnionFieldValueImpl('arrayUnion', elements)
+  );
+}
+
+export function arrayRemove(...elements: unknown[]): firestore.FieldValue {
+  validateAtLeastNumberOfArgs('arrayRemove()', arguments, 1);
+  // NOTE: We don't actually parse the data until it's used in set() or
+  // update() since we need access to the Firestore instance.
+  return new FieldValueDelegate(
+    new ArrayRemoveFieldValueImpl('arrayRemove', elements)
+  );
+}
+
+export function increment(n: number): firestore.FieldValue {
+  return new FieldValueDelegate(
+    new NumericIncrementFieldValueImpl('increment', n)
+  );
+}

--- a/packages/firestore/lite/src/api/field_value.ts
+++ b/packages/firestore/lite/src/api/field_value.ts
@@ -75,7 +75,7 @@ export function serverTimestamp(): firestore.FieldValue {
 export function arrayUnion(...elements: unknown[]): firestore.FieldValue {
   validateAtLeastNumberOfArgs('arrayUnion()', arguments, 1);
   // NOTE: We don't actually parse the data until it's used in set() or
-  // update() since we need access to the Firestore instance.
+  // update() since we'd need the Firestore instance to do this.
   return new FieldValueDelegate(
     new ArrayUnionFieldValueImpl('arrayUnion', elements)
   );
@@ -84,7 +84,7 @@ export function arrayUnion(...elements: unknown[]): firestore.FieldValue {
 export function arrayRemove(...elements: unknown[]): firestore.FieldValue {
   validateAtLeastNumberOfArgs('arrayRemove()', arguments, 1);
   // NOTE: We don't actually parse the data until it's used in set() or
-  // update() since we need access to the Firestore instance.
+  // update() since we'd need the Firestore instance to do this.
   return new FieldValueDelegate(
     new ArrayRemoveFieldValueImpl('arrayRemove', elements)
   );

--- a/packages/firestore/lite/test/integration.test.ts
+++ b/packages/firestore/lite/test/integration.test.ts
@@ -65,6 +65,8 @@ describe('FieldValue', () => {
     expectEqual(FieldValue.delete(), FieldValue.delete());
     expectEqual(FieldValue.serverTimestamp(), FieldValue.serverTimestamp());
     expectNotEqual(FieldValue.delete(), FieldValue.serverTimestamp());
+    // TODO(firestorelite): Add test when field value is available
+    //expectNotEqual(FieldValue.delete(), documentId());
   });
 
   it('support instanceof checks', () => {

--- a/packages/firestore/lite/test/integration.test.ts
+++ b/packages/firestore/lite/test/integration.test.ts
@@ -23,6 +23,8 @@ import {
   getFirestore,
   initializeFirestore
 } from '../src/api/database';
+import { expectEqual, expectNotEqual } from '../../test/util/helpers';
+import { FieldValue } from '../../src/api/field_value';
 
 describe('Firestore', () => {
   it('can provide setting', () => {
@@ -55,5 +57,21 @@ describe('Firestore', () => {
     }).to.throw(
       'Firestore has already been started and its settings can no longer be changed.'
     );
+  });
+});
+
+describe('FieldValue', () => {
+  it('support equality checking with isEqual()', () => {
+    expectEqual(FieldValue.delete(), FieldValue.delete());
+    expectEqual(FieldValue.serverTimestamp(), FieldValue.serverTimestamp());
+    expectNotEqual(FieldValue.delete(), FieldValue.serverTimestamp());
+  });
+
+  it('support instanceof checks', () => {
+    expect(FieldValue.delete()).to.be.an.instanceOf(FieldValue);
+    expect(FieldValue.serverTimestamp()).to.be.an.instanceOf(FieldValue);
+    expect(FieldValue.increment(1)).to.be.an.instanceOf(FieldValue);
+    expect(FieldValue.arrayUnion('a')).to.be.an.instanceOf(FieldValue);
+    expect(FieldValue.arrayRemove('a')).to.be.an.instanceOf(FieldValue);
   });
 });

--- a/packages/firestore/src/api/field_value.ts
+++ b/packages/firestore/src/api/field_value.ts
@@ -61,17 +61,17 @@ export class DeleteFieldValueImpl extends SerializableFieldValue {
     } else if (context.dataSource === UserDataSource.Update) {
       debugAssert(
         context.path!.length > 0,
-        `${this._methodName}  at the top level should have already ` +
+        `${this._methodName}() at the top level should have already ` +
           'been handled.'
       );
       throw context.createError(
-        `${this._methodName} can only appear at the top level ` +
+        `${this._methodName}() can only appear at the top level ` +
           'of your update data'
       );
     } else {
       // We shouldn't encounter delete sentinels for queries or non-merge set() calls.
       throw context.createError(
-        `${this._methodName} cannot be used with set() unless you pass ` +
+        `${this._methodName}() cannot be used with set() unless you pass ` +
           '{merge:true}'
       );
     }

--- a/packages/firestore/src/api/field_value.ts
+++ b/packages/firestore/src/api/field_value.ts
@@ -213,7 +213,7 @@ export abstract class FieldValue extends SerializableFieldValue
   static arrayUnion(...elements: unknown[]): firestore.FieldValue {
     validateAtLeastNumberOfArgs('FieldValue.arrayUnion', arguments, 1);
     // NOTE: We don't actually parse the data until it's used in set() or
-    // update() since we need access to the Firestore instance.
+    // update() since we'd need the Firestore instance to do this.
     return new FieldValueDelegate(
       new ArrayUnionFieldValueImpl('FieldValue.arrayUnion', elements)
     );
@@ -222,7 +222,7 @@ export abstract class FieldValue extends SerializableFieldValue
   static arrayRemove(...elements: unknown[]): firestore.FieldValue {
     validateAtLeastNumberOfArgs('FieldValue.arrayRemove', arguments, 1);
     // NOTE: We don't actually parse the data until it's used in set() or
-    // update() since we need access to the Firestore instance.
+    // update() since we'd need the Firestore instance to do this.
     return new FieldValueDelegate(
       new ArrayRemoveFieldValueImpl('FieldValue.arrayRemove', elements)
     );

--- a/packages/firestore/src/api/field_value.ts
+++ b/packages/firestore/src/api/field_value.ts
@@ -37,11 +37,11 @@ import { debugAssert } from '../util/assert';
  * is shared between the full, lite and legacy SDK.
  */
 export abstract class SerializableFieldValue {
-  /** A pointer to the implementing class. */
-  abstract readonly _delegate: SerializableFieldValue;
-
   /** The public API endpoint that returns this class. */
   abstract readonly _methodName: string;
+
+  /** A pointer to the implementing class. */
+  readonly _delegate: SerializableFieldValue = this;
 
   abstract _toFieldTransform(context: ParseContext): FieldTransform | null;
 
@@ -49,8 +49,6 @@ export abstract class SerializableFieldValue {
 }
 
 export class DeleteFieldValueImpl extends SerializableFieldValue {
-  _delegate = this;
-
   constructor(readonly _methodName: string) {
     super();
   }
@@ -63,17 +61,17 @@ export class DeleteFieldValueImpl extends SerializableFieldValue {
     } else if (context.dataSource === UserDataSource.Update) {
       debugAssert(
         context.path!.length > 0,
-        'FieldValue.delete() at the top level should have already' +
-          ' been handled.'
+        `${this._methodName}  at the top level should have already ` +
+          'been handled.'
       );
       throw context.createError(
-        'FieldValue.delete() can only appear at the top level ' +
+        `${this._methodName} can only appear at the top level ` +
           'of your update data'
       );
     } else {
       // We shouldn't encounter delete sentinels for queries or non-merge set() calls.
       throw context.createError(
-        'FieldValue.delete() cannot be used with set() unless you pass ' +
+        `${this._methodName} cannot be used with set() unless you pass ` +
           '{merge:true}'
       );
     }
@@ -86,8 +84,6 @@ export class DeleteFieldValueImpl extends SerializableFieldValue {
 }
 
 export class ServerTimestampFieldValueImpl extends SerializableFieldValue {
-  _delegate = this;
-
   constructor(readonly _methodName: string) {
     super();
   }
@@ -102,8 +98,6 @@ export class ServerTimestampFieldValueImpl extends SerializableFieldValue {
 }
 
 export class ArrayUnionFieldValueImpl extends SerializableFieldValue {
-  _delegate = this;
-
   constructor(
     readonly _methodName: string,
     private readonly _elements: unknown[]
@@ -139,8 +133,6 @@ export class ArrayUnionFieldValueImpl extends SerializableFieldValue {
 }
 
 export class ArrayRemoveFieldValueImpl extends SerializableFieldValue {
-  _delegate = this;
-
   constructor(readonly _methodName: string, readonly _elements: unknown[]) {
     super();
   }
@@ -173,8 +165,6 @@ export class ArrayRemoveFieldValueImpl extends SerializableFieldValue {
 }
 
 export class NumericIncrementFieldValueImpl extends SerializableFieldValue {
-  _delegate = this;
-
   constructor(readonly _methodName: string, private readonly _operand: number) {
     super();
   }

--- a/packages/firestore/test/unit/api/field_value.test.ts
+++ b/packages/firestore/test/unit/api/field_value.test.ts
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+import { expect } from 'chai';
 import { FieldValue } from '../../../src/api/field_value';
 import { expectEqual, expectNotEqual } from '../../util/helpers';
 
@@ -23,5 +24,13 @@ describe('FieldValue', () => {
     expectEqual(FieldValue.delete(), FieldValue.delete());
     expectEqual(FieldValue.serverTimestamp(), FieldValue.serverTimestamp());
     expectNotEqual(FieldValue.delete(), FieldValue.serverTimestamp());
+  });
+
+  it('support instanceof checks', () => {
+    expect(FieldValue.delete()).to.be.an.instanceOf(FieldValue);
+    expect(FieldValue.serverTimestamp()).to.be.an.instanceOf(FieldValue);
+    expect(FieldValue.increment(1)).to.be.an.instanceOf(FieldValue);
+    expect(FieldValue.arrayUnion('a')).to.be.an.instanceOf(FieldValue);
+    expect(FieldValue.arrayRemove('a')).to.be.an.instanceOf(FieldValue);
   });
 });

--- a/packages/firestore/test/unit/api/field_value.test.ts
+++ b/packages/firestore/test/unit/api/field_value.test.ts
@@ -25,7 +25,6 @@ describe('FieldValue', () => {
     expectEqual(FieldValue.delete(), FieldValue.delete());
     expectEqual(FieldValue.serverTimestamp(), FieldValue.serverTimestamp());
     expectNotEqual(FieldValue.delete(), FieldValue.serverTimestamp());
-    expectNotEqual(FieldValue.delete(), FieldPath.documentId());
   });
 
   it('support instanceof checks', () => {

--- a/packages/firestore/test/unit/api/field_value.test.ts
+++ b/packages/firestore/test/unit/api/field_value.test.ts
@@ -17,6 +17,7 @@
 
 import { expect } from 'chai';
 import { FieldValue } from '../../../src/api/field_value';
+import { FieldPath } from '../../../src/api/field_path';
 import { expectEqual, expectNotEqual } from '../../util/helpers';
 
 describe('FieldValue', () => {
@@ -24,6 +25,7 @@ describe('FieldValue', () => {
     expectEqual(FieldValue.delete(), FieldValue.delete());
     expectEqual(FieldValue.serverTimestamp(), FieldValue.serverTimestamp());
     expectNotEqual(FieldValue.delete(), FieldValue.serverTimestamp());
+    expectNotEqual(FieldValue.delete(), FieldPath.documentId());
   });
 
   it('support instanceof checks', () => {

--- a/packages/firestore/test/unit/api/field_value.test.ts
+++ b/packages/firestore/test/unit/api/field_value.test.ts
@@ -17,7 +17,6 @@
 
 import { expect } from 'chai';
 import { FieldValue } from '../../../src/api/field_value';
-import { FieldPath } from '../../../src/api/field_path';
 import { expectEqual, expectNotEqual } from '../../util/helpers';
 
 describe('FieldValue', () => {

--- a/packages/firestore/test/util/helpers.ts
+++ b/packages/firestore/test/util/helpers.ts
@@ -241,7 +241,7 @@ export function patchMutation(
   // Replace '<DELETE>' from JSON with FieldValue
   forEach(json, (k, v) => {
     if (v === '<DELETE>') {
-      json[k] = new DeleteFieldValueImpl();
+      json[k] = new DeleteFieldValueImpl('FieldValue.delete');
     }
   });
   const parsed = testUserDataReader().parseUpdateData('patchMutation', json);


### PR DESCRIPTION
This PR adds the FieldValue methods to the Lite SDK.

It also solves a problem with the FieldValue methods in the current ("legacy") SDK. Our API promises that the FieldValue implementations returned by FieldValue.insertNameHere() methods are an instance of FieldValue. This was not the case anymore. I solved this by adding a wrapper type that wraps the FieldValue class in the Lite and Legacy SDK, which allows both SDKs to use different FieldValue types without duplicating all implementations.

This PR also prefixes the internal "toFieldTransform" method with an underscore since this is a class returned by the public API.