### PR TITLE
Add setLogLevel()

### DIFF
--- a/packages/firestore/exp/index.d.ts
+++ b/packages/firestore/exp/index.d.ts
@@ -52,7 +52,13 @@ export interface SnapshotMetadata {
   isEqual(other: SnapshotMetadata): boolean;
 }
 
-export type LogLevel = 'debug' | 'error' | 'silent';
+export type LogLevel =
+  | 'debug'
+  | 'error'
+  | 'silent'
+  | 'warn'
+  | 'info'
+  | 'verbose';
 
 export function setLogLevel(logLevel: LogLevel): void;
 
@@ -169,10 +175,7 @@ export class Transaction {
 
   get<T>(documentRef: DocumentReference<T>): Promise<DocumentSnapshot<T>>;
 
-  set<T>(
-    documentRef: DocumentReference<T>,
-    data: T,
-  ): Transaction;
+  set<T>(documentRef: DocumentReference<T>, data: T): Transaction;
   set<T>(
     documentRef: DocumentReference<T>,
     data: Partial<T>,
@@ -193,10 +196,7 @@ export class Transaction {
 export class WriteBatch {
   private constructor();
 
-  set<T>(
-    documentRef: DocumentReference<T>,
-    data: T,
-  ): WriteBatch;
+  set<T>(documentRef: DocumentReference<T>, data: T): WriteBatch;
   set<T>(
     documentRef: DocumentReference<T>,
     data: Partial<T>,

--- a/packages/firestore/lite/index.d.ts
+++ b/packages/firestore/lite/index.d.ts
@@ -33,7 +33,13 @@ export interface Settings {
   ignoreUndefinedProperties?: boolean;
 }
 
-export type LogLevel = 'debug' | 'error' | 'silent';
+export type LogLevel =
+  | 'debug'
+  | 'error'
+  | 'silent'
+  | 'warn'
+  | 'info'
+  | 'verbose';
 
 export function setLogLevel(logLevel: LogLevel): void;
 

--- a/packages/firestore/lite/index.node.ts
+++ b/packages/firestore/lite/index.node.ts
@@ -38,6 +38,8 @@ export {
   serverTimestamp
 } from './src/api/field_value';
 
+export { setLogLevel } from '../src/util/log';
+
 export function registerFirestore(): void {
   _registerComponent(
     new Component(


### PR DESCRIPTION
This adds setLogLevel() to the lite SDK. Note that (at least for now) we don't validate API input, so we don't need to call the wrapper. Discussion on this is still pending.
