### PR TITLE
Remove empty commit check

### DIFF
--- a/tools/gitHooks/precommit.js
+++ b/tools/gitHooks/precommit.js
@@ -80,17 +80,6 @@ $ git stash pop
     // Validate License headers exist
     await doLicense(changedFiles);
 
-    // Diff staged changes against last commit. Don't do an empty commit.
-    const postDiff = await git.diff(['--cached']);
-    if (!postDiff) {
-      console.error(chalk`
-{red Staged files are identical to previous commit after running formatting
-steps. Skipping commit.}
-
-`);
-      return process.exit(1);
-    }
-
     console.log(chalk`
 Pre-Push Validation Succeeded
 


### PR DESCRIPTION
This check is causing more trouble than it is worth. I intended it to catch the edge case where after a series of changes and undos, the code is only different from the previous commit in spacing and formatting, and a prettier pass reverts it so there is no difference, causing an empty commit.

This causes problems for people trying to merge and other cases, and isn't really worth it to try to avoid the occasional empty commit, which will be squashed in the merge to master anyway.