### PR TITLE
Issue 2393

### DIFF
--- a/packages/firebase/index.d.ts
+++ b/packages/firebase/index.d.ts
@@ -1602,6 +1602,7 @@ declare namespace firebase.performance {
      */
     getAttributes(): { [key: string]: string };
   }
+  function isSupported(): boolean;
 }
 
 /**
@@ -1771,6 +1772,8 @@ declare namespace firebase.remoteConfig {
    * Defines levels of Remote Config logging.
    */
   export type LogLevel = 'debug' | 'error' | 'silent';
+
+  function isSupported(): boolean;
 }
 
 declare namespace firebase.functions {

--- a/packages/performance/index.ts
+++ b/packages/performance/index.ts
@@ -42,10 +42,6 @@ export function registerPerformance(instance: FirebaseNamespace): void {
     if (typeof window === 'undefined') {
       throw ERROR_FACTORY.create(ErrorCode.NO_WINDOW);
     }
-    if (!isSupported()) {
-      throw ERROR_FACTORY.create(ErrorCode.UNSUPPORTED_BROWSER);
-    }
-
     setupApi(window);
     SettingsService.getInstance().firebaseAppInstance = app;
     SettingsService.getInstance().installationsService = installations;
@@ -68,6 +64,9 @@ export function registerPerformance(instance: FirebaseNamespace): void {
         const installations = container
           .getProvider('installations')
           .getImmediate();
+        if (!isSupported()) {
+          throw ERROR_FACTORY.create(ErrorCode.UNSUPPORTED_BROWSER);
+        }
 
         return factoryMethod(app, installations);
       },

--- a/packages/performance/src/utils/errors.ts
+++ b/packages/performance/src/utils/errors.ts
@@ -31,7 +31,8 @@ export const enum ErrorCode {
   INVALID_ATTRIBUTE_NAME = 'invalid attribute name',
   INVALID_ATTRIBUTE_VALUE = 'invalid attribute value',
   INVALID_CUSTOM_METRIC_NAME = 'invalid custom metric name',
-  INVALID_STRING_MERGER_PARAMETER = 'invalid String merger input'
+  INVALID_STRING_MERGER_PARAMETER = 'invalid String merger input',
+  UNSUPPORTED_BROWSER = 'unsupported-browser'
 }
 
 const ERROR_DESCRIPTION_MAP: { readonly [key in ErrorCode]: string } = {
@@ -52,7 +53,9 @@ const ERROR_DESCRIPTION_MAP: { readonly [key in ErrorCode]: string } = {
   [ErrorCode.INVALID_CUSTOM_METRIC_NAME]:
     'Custom metric name {$customMetricName} is invalid',
   [ErrorCode.INVALID_STRING_MERGER_PARAMETER]:
-    'Input for String merger is invalid, contact support team to resolve.'
+    'Input for String merger is invalid, contact support team to resolve.',
+  [ErrorCode.UNSUPPORTED_BROWSER]:
+    "This browser doesn't support the API's required to use the firebase SDK."
 };
 
 interface ErrorParams {

--- a/packages/remote-config/index.ts
+++ b/packages/remote-config/index.ts
@@ -44,15 +44,17 @@ declare global {
   }
 }
 
+const NAMESPACE_EXPORTS = {
+  isSupported
+};
+
 export function registerRemoteConfig(
   firebaseInstance: _FirebaseNamespace
 ): void {
   firebaseInstance.INTERNAL.registerComponent(
-    new Component(
-      'remoteConfig',
-      remoteConfigFactory,
-      ComponentType.PUBLIC
-    ).setMultipleInstances(true)
+    new Component('remoteConfig', remoteConfigFactory, ComponentType.PUBLIC)
+      .setMultipleInstances(true)
+      .setServiceProps(NAMESPACE_EXPORTS)
   );
 
   firebaseInstance.registerVersion(packageName, version);
@@ -70,6 +72,10 @@ export function registerRemoteConfig(
     // Guards against the SDK being used in non-browser environments.
     if (typeof window === 'undefined') {
       throw ERROR_FACTORY.create(ErrorCode.REGISTRATION_WINDOW);
+    }
+
+    if (!isSupported()) {
+      throw ERROR_FACTORY.create(ErrorCode.UNSUPPORTED_BROWSER);
     }
 
     // Normalizes optional inputs.
@@ -133,9 +139,51 @@ declare module '@firebase/app-types' {
   interface FirebaseNamespace {
     remoteConfig?: {
       (app?: FirebaseApp): RemoteConfigType;
+      isSupported(): boolean;
     };
   }
   interface FirebaseApp {
     remoteConfig(): RemoteConfigType;
   }
+}
+
+function isSupported(): boolean {
+  if (self && 'ServiceWorkerGlobalScope' in self) {
+    // Running in ServiceWorker context
+    return isSWControllerSupported();
+  } else {
+    // Assume we are in the window context.
+    return isWindowControllerSupported();
+  }
+}
+
+/**
+ * Checks to see if the required APIs exist.
+ */
+function isWindowControllerSupported(): boolean {
+  return (
+    'indexedDB' in window &&
+    indexedDB !== null &&
+    navigator.cookieEnabled &&
+    'serviceWorker' in navigator &&
+    'PushManager' in window &&
+    'Notification' in window &&
+    'fetch' in window &&
+    ServiceWorkerRegistration.prototype.hasOwnProperty('showNotification') &&
+    PushSubscription.prototype.hasOwnProperty('getKey')
+  );
+}
+
+/**
+ * Checks to see if the required APIs exist within SW Context.
+ */
+function isSWControllerSupported(): boolean {
+  return (
+    'indexedDB' in self &&
+    indexedDB !== null &&
+    'PushManager' in self &&
+    'Notification' in self &&
+    ServiceWorkerRegistration.prototype.hasOwnProperty('showNotification') &&
+    PushSubscription.prototype.hasOwnProperty('getKey')
+  );
 }

--- a/packages/remote-config/src/errors.ts
+++ b/packages/remote-config/src/errors.ts
@@ -30,7 +30,8 @@ export const enum ErrorCode {
   FETCH_TIMEOUT = 'fetch-timeout',
   FETCH_THROTTLE = 'fetch-throttle',
   FETCH_PARSE = 'fetch-client-parse',
-  FETCH_STATUS = 'fetch-status'
+  FETCH_STATUS = 'fetch-status',
+  UNSUPPORTED_BROWSER = 'unsupported-browser'
 }
 
 const ERROR_DESCRIPTION_MAP: { readonly [key in ErrorCode]: string } = {
@@ -64,7 +65,9 @@ const ERROR_DESCRIPTION_MAP: { readonly [key in ErrorCode]: string } = {
     'Fetch client could not parse response.' +
     ' Original error: {$originalErrorMessage}.',
   [ErrorCode.FETCH_STATUS]:
-    'Fetch server returned an HTTP error status. HTTP status: {$httpStatus}.'
+    'Fetch server returned an HTTP error status. HTTP status: {$httpStatus}.',
+  [ErrorCode.UNSUPPORTED_BROWSER]:
+    "This browser doesn't support the API's required to use the firebase SDK."
 };
 
 // Note this is effectively a type system binding a code to params. This approach overlaps with the


### PR DESCRIPTION
a fix for issue #2393 on performance and remote-config module. 

Throw runtime error (UNSUPPORTED_BROWSER) on initialization of the instance when IndexedDB is not supported in some browser situations.

The fix is tested on Safari and Firefox private window rendering iframe with https://github.com/tomsun/firebase-js-sdk-securityerror-example provided in the issue conversation. 

