### PR TITLE
Make Converter passing explicit

### DIFF
--- a/packages/firestore/lite/src/api/reference.ts
+++ b/packages/firestore/lite/src/api/reference.ts
@@ -55,7 +55,7 @@ export class DocumentReference<T = firestore.DocumentData>
   constructor(
     readonly firestore: Firestore,
     key: DocumentKey,
-    readonly _converter?: firestore.FirestoreDataConverter<T>
+    readonly _converter: firestore.FirestoreDataConverter<T> | null
   ) {
     super(firestore._databaseId, key, _converter);
   }
@@ -79,7 +79,7 @@ export class Query<T = firestore.DocumentData> implements firestore.Query<T> {
   constructor(
     readonly firestore: Firestore,
     readonly _query: InternalQuery,
-    readonly _converter?: firestore.FirestoreDataConverter<T>
+    readonly _converter: firestore.FirestoreDataConverter<T> | null
   ) {}
 
   where(
@@ -153,7 +153,7 @@ export class CollectionReference<T = firestore.DocumentData> extends Query<T>
   constructor(
     readonly firestore: Firestore,
     readonly _path: ResourcePath,
-    readonly _converter?: firestore.FirestoreDataConverter<T>
+    readonly _converter: firestore.FirestoreDataConverter<T> | null
   ) {
     super(firestore, InternalQuery.atPath(_path), _converter);
   }

--- a/packages/firestore/lite/src/api/reference.ts
+++ b/packages/firestore/lite/src/api/reference.ts
@@ -189,12 +189,16 @@ export function collection(
   const path = ResourcePath.fromString(relativePath);
   if (parent instanceof Firestore) {
     validateCollectionPath(path);
-    return new CollectionReference(parent, path);
+    return new CollectionReference(parent, path, /* converter= */ null);
   } else {
     const doc = cast(parent, DocumentReference);
     const absolutePath = doc._key.path.child(path);
     validateCollectionPath(absolutePath);
-    return new CollectionReference(doc.firestore, absolutePath);
+    return new CollectionReference(
+      doc.firestore,
+      absolutePath,
+      /* converter= */ null
+    );
   }
 }
 
@@ -219,7 +223,11 @@ export function doc<T>(
   const path = ResourcePath.fromString(relativePath!);
   if (parent instanceof Firestore) {
     validateDocumentPath(path);
-    return new DocumentReference(parent, new DocumentKey(path));
+    return new DocumentReference(
+      parent,
+      new DocumentKey(path),
+      /* converter= */ null
+    );
   } else {
     const coll = cast(parent, CollectionReference);
     const absolutePath = coll._path.child(path);
@@ -248,7 +256,8 @@ export function parent<T>(
     } else {
       return new DocumentReference(
         child.firestore,
-        new DocumentKey(parentPath)
+        new DocumentKey(parentPath),
+        /* converter= */ null
       );
     }
   } else {

--- a/packages/firestore/lite/src/api/snapshot.ts
+++ b/packages/firestore/lite/src/api/snapshot.ts
@@ -38,7 +38,7 @@ export class DocumentSnapshot<T = firestore.DocumentData>
     private _firestore: Firestore,
     private _key: DocumentKey,
     private _document: Document | null,
-    private _converter?: firestore.FirestoreDataConverter<T>
+    private _converter: firestore.FirestoreDataConverter<T> | null
   ) {}
 
   get id(): string {

--- a/packages/firestore/lite/src/api/snapshot.ts
+++ b/packages/firestore/lite/src/api/snapshot.ts
@@ -66,7 +66,8 @@ export class DocumentSnapshot<T = firestore.DocumentData>
       const snapshot = new QueryDocumentSnapshot(
         this._firestore,
         this._key,
-        this._document
+        this._document,
+        /* converter= */ null
       );
       return this._converter.fromFirestore(snapshot);
     } else {
@@ -74,7 +75,8 @@ export class DocumentSnapshot<T = firestore.DocumentData>
         this._firestore._databaseId,
         /* timestampsInSnapshots= */ false,
         /* serverTimestampBehavior=*/ 'none',
-        key => new DocumentReference(this._firestore, key)
+        key =>
+          new DocumentReference(this._firestore, key, /* converter= */ null)
       );
       return userDataWriter.convertValue(this._document.toProto()) as T;
     }

--- a/packages/firestore/src/api/database.ts
+++ b/packages/firestore/src/api/database.ts
@@ -580,14 +580,22 @@ export class Firestore implements firestore.FirebaseFirestore, FirebaseService {
     validateExactNumberOfArgs('Firestore.collection', arguments, 1);
     validateArgType('Firestore.collection', 'non-empty string', 1, pathString);
     this.ensureClientConfigured();
-    return new CollectionReference(ResourcePath.fromString(pathString), this);
+    return new CollectionReference(
+      ResourcePath.fromString(pathString),
+      this,
+      /* converter= */ null
+    );
   }
 
   doc(pathString: string): firestore.DocumentReference {
     validateExactNumberOfArgs('Firestore.doc', arguments, 1);
     validateArgType('Firestore.doc', 'non-empty string', 1, pathString);
     this.ensureClientConfigured();
-    return DocumentReference.forPath(ResourcePath.fromString(pathString), this);
+    return DocumentReference.forPath(
+      ResourcePath.fromString(pathString),
+      this,
+      /* converter= */ null
+    );
   }
 
   collectionGroup(collectionId: string): firestore.Query {
@@ -608,7 +616,8 @@ export class Firestore implements firestore.FirebaseFirestore, FirebaseService {
     this.ensureClientConfigured();
     return new Query(
       new InternalQuery(ResourcePath.EMPTY_PATH, collectionId),
-      this
+      this,
+      /* converter= */ null
     );
   }
 
@@ -946,7 +955,7 @@ export class DocumentReference<T = firestore.DocumentData>
   constructor(
     public _key: DocumentKey,
     readonly firestore: Firestore,
-    readonly _converter?: firestore.FirestoreDataConverter<T>
+    readonly _converter: firestore.FirestoreDataConverter<T> | null
   ) {
     super(firestore._databaseId, _key, _converter);
     this._firestoreClient = this.firestore.ensureClientConfigured();
@@ -955,7 +964,7 @@ export class DocumentReference<T = firestore.DocumentData>
   static forPath<U>(
     path: ResourcePath,
     firestore: Firestore,
-    converter?: firestore.FirestoreDataConverter<U>
+    converter: firestore.FirestoreDataConverter<U> | null
   ): DocumentReference<U> {
     if (path.length % 2 !== 0) {
       throw new FirestoreError(
@@ -1001,7 +1010,11 @@ export class DocumentReference<T = firestore.DocumentData>
       );
     }
     const path = ResourcePath.fromString(pathString);
-    return new CollectionReference(this._key.path.child(path), this.firestore);
+    return new CollectionReference(
+      this._key.path.child(path),
+      this.firestore,
+      /* converter= */ null
+    );
   }
 
   isEqual(other: firestore.DocumentReference<T>): boolean {
@@ -1328,7 +1341,7 @@ export class DocumentSnapshot<T = firestore.DocumentData>
     public _document: Document | null,
     private _fromCache: boolean,
     private _hasPendingWrites: boolean,
-    private readonly _converter?: firestore.FirestoreDataConverter<T>
+    private readonly _converter: firestore.FirestoreDataConverter<T> | null
   ) {}
 
   data(options?: firestore.SnapshotOptions): T | undefined {
@@ -1345,7 +1358,8 @@ export class DocumentSnapshot<T = firestore.DocumentData>
           this._key,
           this._document,
           this._fromCache,
-          this._hasPendingWrites
+          this._hasPendingWrites,
+          /* converter= */ null
         );
         return this._converter.fromFirestore(snapshot, options);
       } else {
@@ -1353,7 +1367,8 @@ export class DocumentSnapshot<T = firestore.DocumentData>
           this._firestore._databaseId,
           this._firestore._areTimestampsInSnapshotsEnabled(),
           options.serverTimestamps || 'none',
-          key => new DocumentReference(key, this._firestore)
+          key =>
+            new DocumentReference(key, this._firestore, /* converter= */ null)
         );
         return userDataWriter.convertValue(this._document.toProto()) as T;
       }
@@ -1436,7 +1451,7 @@ export class Query<T = firestore.DocumentData> implements firestore.Query<T> {
   constructor(
     public _query: InternalQuery,
     readonly firestore: Firestore,
-    protected readonly _converter?: firestore.FirestoreDataConverter<T>
+    protected readonly _converter: firestore.FirestoreDataConverter<T> | null
   ) {}
 
   where(
@@ -2168,7 +2183,7 @@ export class QuerySnapshot<T = firestore.DocumentData>
     private readonly _firestore: Firestore,
     private readonly _originalQuery: InternalQuery,
     private readonly _snapshot: ViewSnapshot,
-    private readonly _converter?: firestore.FirestoreDataConverter<T>
+    private readonly _converter: firestore.FirestoreDataConverter<T> | null
   ) {
     this.metadata = new SnapshotMetadata(
       _snapshot.hasPendingWrites,
@@ -2279,7 +2294,7 @@ export class CollectionReference<T = firestore.DocumentData> extends Query<T>
   constructor(
     readonly _path: ResourcePath,
     firestore: Firestore,
-    _converter?: firestore.FirestoreDataConverter<T>
+    _converter: firestore.FirestoreDataConverter<T> | null
   ) {
     super(InternalQuery.atPath(_path), firestore, _converter);
     if (_path.length % 2 !== 1) {
@@ -2303,7 +2318,8 @@ export class CollectionReference<T = firestore.DocumentData> extends Query<T>
     } else {
       return new DocumentReference<firestore.DocumentData>(
         new DocumentKey(parentPath),
-        this.firestore
+        this.firestore,
+        /* converter= */ null
       );
     }
   }
@@ -2444,7 +2460,7 @@ export function changesFromSnapshot<T>(
   firestore: Firestore,
   includeMetadataChanges: boolean,
   snapshot: ViewSnapshot,
-  converter?: firestore.FirestoreDataConverter<T>
+  converter: firestore.FirestoreDataConverter<T> | null
 ): Array<firestore.DocumentChange<T>> {
   if (snapshot.oldDocs.isEmpty()) {
     // Special case the first snapshot because index calculation is easy and
@@ -2533,7 +2549,7 @@ function resultChangeType(type: ChangeType): firestore.DocumentChangeType {
  * call.
  */
 export function applyFirestoreDataConverter<T>(
-  converter: UntypedFirestoreDataConverter<T> | undefined,
+  converter: UntypedFirestoreDataConverter<T> | null,
   value: T,
   functionName: string
 ): [firestore.DocumentData, string] {

--- a/packages/firestore/src/api/user_data_reader.ts
+++ b/packages/firestore/src/api/user_data_reader.ts
@@ -65,7 +65,7 @@ export class DocumentKeyReference<T> {
   constructor(
     public readonly _databaseId: DatabaseId,
     public readonly _key: DocumentKey,
-    public readonly _converter?: UntypedFirestoreDataConverter<T>
+    public readonly _converter: UntypedFirestoreDataConverter<T> | null
   ) {}
 }
 

--- a/packages/firestore/test/unit/api/document_change.test.ts
+++ b/packages/firestore/test/unit/api/document_change.test.ts
@@ -53,7 +53,12 @@ describe('DocumentChange:', () => {
     const expected = documentSetAsArray(updatedSnapshot.docs);
     const actual = documentSetAsArray(initialSnapshot.docs);
 
-    const changes = changesFromSnapshot({} as Firestore, true, updatedSnapshot);
+    const changes = changesFromSnapshot(
+      {} as Firestore,
+      true,
+      updatedSnapshot,
+      /* converter= */ null
+    );
 
     for (const change of changes) {
       if (change.type !== 'added') {

--- a/packages/firestore/test/util/api_helpers.ts
+++ b/packages/firestore/test/util/api_helpers.ts
@@ -45,8 +45,8 @@ import { Provider, ComponentContainer } from '@firebase/component';
  */
 export const FIRESTORE = new Firestore(
   {
-    projectId: 'projectid',
-    database: 'database'
+    projectId: 'test-project',
+    database: '(default)'
   },
   new Provider('auth-internal', new ComponentContainer('default')),
   new IndexedDbComponentProvider()
@@ -57,11 +57,15 @@ export function firestore(): Firestore {
 }
 
 export function collectionReference(path: string): CollectionReference {
-  return new CollectionReference(pathFrom(path), firestore());
+  return new CollectionReference(
+    pathFrom(path),
+    firestore(),
+    /* converter= */ null
+  );
 }
 
 export function documentReference(path: string): DocumentReference {
-  return new DocumentReference(key(path), firestore());
+  return new DocumentReference(key(path), firestore(), /* converter= */ null);
 }
 
 export function documentSnapshot(
@@ -75,7 +79,8 @@ export function documentSnapshot(
       key(path),
       doc(path, 1, data),
       fromCache,
-      /* hasPendingWrites= */ false
+      /* hasPendingWrites= */ false,
+      /* converter= */ null
     );
   } else {
     return new DocumentSnapshot(
@@ -83,13 +88,18 @@ export function documentSnapshot(
       key(path),
       null,
       fromCache,
-      /* hasPendingWrites= */ false
+      /* hasPendingWrites= */ false,
+      /* converter= */ null
     );
   }
 }
 
 export function query(path: string): Query {
-  return new Query(InternalQuery.atPath(pathFrom(path)), firestore());
+  return new Query(
+    InternalQuery.atPath(pathFrom(path)),
+    firestore(),
+    /* converter= */ null
+  );
 }
 
 /**
@@ -135,5 +145,10 @@ export function querySnapshot(
     syncStateChanged,
     false
   );
-  return new QuerySnapshot(firestore(), query, viewSnapshot);
+  return new QuerySnapshot(
+    firestore(),
+    query,
+    viewSnapshot,
+    /* converter= */ null
+  );
 }

--- a/packages/firestore/test/util/helpers.ts
+++ b/packages/firestore/test/util/helpers.ts
@@ -89,10 +89,9 @@ import { ByteString } from '../../src/util/byte_string';
 import { PlatformSupport } from '../../src/platform/platform';
 import { JsonProtoSerializer } from '../../src/remote/serializer';
 import { Timestamp } from '../../src/api/timestamp';
-import { DocumentReference, Firestore } from '../../src/api/database';
+import { DocumentReference } from '../../src/api/database';
 import { DeleteFieldValueImpl } from '../../src/api/field_value';
 import { Code, FirestoreError } from '../../src/util/error';
-import { IndexedDbComponentProvider } from '../../src/core/component_provider';
 
 /* eslint-disable no-restricted-globals */
 

--- a/packages/firestore/test/util/helpers.ts
+++ b/packages/firestore/test/util/helpers.ts
@@ -84,7 +84,7 @@ import { primitiveComparator } from '../../src/util/misc';
 import { Dict, forEach } from '../../src/util/obj';
 import { SortedMap } from '../../src/util/sorted_map';
 import { SortedSet } from '../../src/util/sorted_set';
-import { query } from './api_helpers';
+import { FIRESTORE, query } from './api_helpers';
 import { ByteString } from '../../src/util/byte_string';
 import { PlatformSupport } from '../../src/platform/platform';
 import { JsonProtoSerializer } from '../../src/remote/serializer';
@@ -92,15 +92,9 @@ import { Timestamp } from '../../src/api/timestamp';
 import { DocumentReference, Firestore } from '../../src/api/database';
 import { DeleteFieldValueImpl } from '../../src/api/field_value';
 import { Code, FirestoreError } from '../../src/util/error';
+import { IndexedDbComponentProvider } from '../../src/core/component_provider';
 
 /* eslint-disable no-restricted-globals */
-
-// A Firestore that can be used in DocumentReferences and UserDataWriter.
-const fakeFirestore: Firestore = {
-  ensureClientConfigured: () => {},
-  _databaseId: new DatabaseId('test-project')
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-} as any;
 
 export type TestSnapshotVersion = number;
 
@@ -109,7 +103,7 @@ export function testUserDataWriter(): UserDataWriter {
     new DatabaseId('test-project'),
     /* timestampsInSnapshots= */ false,
     'none',
-    key => new DocumentReference(key, fakeFirestore)
+    key => new DocumentReference(key, FIRESTORE, /* converter= */ null)
   );
 }
 
@@ -133,7 +127,8 @@ export function version(v: TestSnapshotVersion): SnapshotVersion {
 export function ref(key: string, offset?: number): DocumentReference {
   return new DocumentReference(
     new DocumentKey(path(key, offset)),
-    fakeFirestore
+    FIRESTORE,
+    /* converter= */ null
   );
 }
 


### PR DESCRIPTION
One of the comments in the Transaction PR was about a missing converter argument. This PR should make these problems go away by no longer allowing `undefined`.

I also stumbled across a test Firestore that I can use instead of `fakeFirestore`.