### PR TITLE
Add Query/getQuery

### DIFF
--- a/packages/firestore/lite/index.node.ts
+++ b/packages/firestore/lite/index.node.ts
@@ -37,6 +37,7 @@ export {
   doc,
   parent,
   getDoc,
+  getQuery,
   deleteDoc,
   setDoc,
   updateDoc,

--- a/packages/firestore/lite/src/api/database.ts
+++ b/packages/firestore/lite/src/api/database.ts
@@ -34,8 +34,8 @@ import {
   terminateDatastore
 } from '../../../src/remote/datastore';
 import { PlatformSupport } from '../../../src/platform/platform';
-import { Deferred } from '../../../src/util/promise';
 import { cast } from './util';
+import { Settings } from '../../';
 
 // settings() defaults:
 const DEFAULT_HOST = 'firestore.googleapis.com';
@@ -52,8 +52,8 @@ export class Firestore implements firestore.FirebaseFirestore {
   private readonly _credentials: CredentialsProvider;
 
   // Assigned via _configureClient()/_ensureClientConfigured()
-  _settings?: firestore.Settings;
-  private readonly _datastoreDeferred = new Deferred<Datastore>();
+  private _settings?: firestore.Settings;
+  private _datastorePromise?: Promise<Datastore>;
 
   constructor(
     app: FirebaseApp,
@@ -78,31 +78,29 @@ export class Firestore implements firestore.FirebaseFirestore {
       );
     }
     this._settings = settings;
-
-    const databaseInfo = this._makeDatabaseInfo(settings);
-
-    // Kick off initializing the datastore but don't actually wait for it.
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
-    PlatformSupport.getPlatform()
-      .loadConnection(databaseInfo)
-      .then(connection => {
-        const serializer = PlatformSupport.getPlatform().newSerializer(
-          databaseInfo.databaseId
-        );
-        const datastore = newDatastore(
-          connection,
-          this._credentials,
-          serializer
-        );
-        this._datastoreDeferred.resolve(datastore);
-      });
   }
 
-  _ensureClientConfigured(): Promise<Datastore> {
+  _getSettings(): Settings {
     if (!this._settings) {
       this._settings = {};
     }
-    return this._datastoreDeferred.promise;
+    return this._settings;
+  }
+
+  _getDatastore(): Promise<Datastore> {
+    if (!this._datastorePromise) {
+      const databaseInfo = this._makeDatabaseInfo(this._getSettings());
+      this._datastorePromise = PlatformSupport.getPlatform()
+        .loadConnection(databaseInfo)
+        .then(connection => {
+          const serializer = PlatformSupport.getPlatform().newSerializer(
+            databaseInfo.databaseId
+          );
+          return newDatastore(connection, this._credentials, serializer);
+        });
+    }
+
+    return this._datastorePromise;
   }
 
   private _makeDatabaseInfo(settings: firestore.Settings): DatabaseInfo {
@@ -149,6 +147,6 @@ export function terminate(
   // TODO(firestorelite): Call _removeServiceInstance when available
   const firestoreClient = cast(firestore, Firestore);
   return firestoreClient
-    ._ensureClientConfigured()
+    ._getDatastore()
     .then(datastore => terminateDatastore(datastore));
 }

--- a/packages/firestore/lite/src/api/reference.ts
+++ b/packages/firestore/lite/src/api/reference.ts
@@ -387,6 +387,7 @@ export function getDoc<T>(
   });
 }
 
+// TODO(firestorelite): Consider renaming to getDocs
 export function getQuery<T>(
   query: firestore.Query<T>
 ): Promise<firestore.QuerySnapshot<T>> {

--- a/packages/firestore/lite/src/api/reference.ts
+++ b/packages/firestore/lite/src/api/reference.ts
@@ -58,9 +58,9 @@ import {
   validateArgType,
   validateCollectionPath,
   validateDocumentPath,
+  validateExactNumberOfArgs,
   validatePositiveNumber
 } from '../../../src/util/input_validation';
-import { Code, FirestoreError } from '../../../src/util/error';
 import { FieldPath as ExternalFieldPath } from '../../../src/api/field_path';
 
 /**
@@ -236,21 +236,8 @@ export class Query<T = firestore.DocumentData> extends BaseQuery
     before: boolean
   ): Bound {
     if (docOrField instanceof DocumentSnapshot) {
-      if (fields.length > 0) {
-        throw new FirestoreError(
-          Code.INVALID_ARGUMENT,
-          `Too many arguments provided to ${methodName}().`
-        );
-      }
-      const snap = docOrField;
-      if (!snap.exists) {
-        throw new FirestoreError(
-          Code.NOT_FOUND,
-          `Can't use a DocumentSnapshot that doesn't exist for ` +
-            `${methodName}().`
-        );
-      }
-      return this.boundFromDocument(snap._document!, before);
+      validateExactNumberOfArgs(methodName, [docOrField, ...fields], 1);
+      return this.boundFromDocument(methodName, docOrField._document, before);
     } else {
       const allFields = [docOrField].concat(fields);
       return this.boundFromFields(methodName, allFields, before);

--- a/packages/firestore/lite/src/api/snapshot.ts
+++ b/packages/firestore/lite/src/api/snapshot.ts
@@ -37,7 +37,7 @@ export class DocumentSnapshot<T = firestore.DocumentData>
   constructor(
     private _firestore: Firestore,
     private _key: DocumentKey,
-    private _document: Document | null,
+    public _document: Document | null,
     private _converter?: firestore.FirestoreDataConverter<T>
   ) {}
 
@@ -104,6 +104,35 @@ export class QueryDocumentSnapshot<T = firestore.DocumentData>
   implements firestore.QueryDocumentSnapshot<T> {
   data(): T {
     return super.data() as T;
+  }
+}
+
+export class QuerySnapshot<T = firestore.DocumentData>
+  implements firestore.QuerySnapshot<T> {
+  constructor(
+    readonly query: firestore.Query<T>,
+    private readonly _docs: Array<QueryDocumentSnapshot<T>>
+  ) {}
+
+  get docs(): Array<firestore.QueryDocumentSnapshot<T>> {
+    return [...this._docs];
+  }
+
+  get size(): number {
+    return this.docs.length;
+  }
+
+  get empty(): boolean {
+    return this.docs.length === 0;
+  }
+
+  forEach(
+    callback: (result: firestore.QueryDocumentSnapshot<T>) => void,
+    thisArg?: unknown
+  ): void {
+    this._docs.forEach(doc => {
+      callback.call(thisArg, doc);
+    });
   }
 }
 

--- a/packages/firestore/lite/src/api/snapshot.ts
+++ b/packages/firestore/lite/src/api/snapshot.ts
@@ -130,9 +130,7 @@ export class QuerySnapshot<T = firestore.DocumentData>
     callback: (result: firestore.QueryDocumentSnapshot<T>) => void,
     thisArg?: unknown
   ): void {
-    this._docs.forEach(doc => {
-      callback.call(thisArg, doc);
-    });
+    this._docs.forEach(callback, thisArg);
   }
 }
 

--- a/packages/firestore/lite/src/api/transaction.ts
+++ b/packages/firestore/lite/src/api/transaction.ts
@@ -47,13 +47,7 @@ export class Transaction implements firestore.Transaction {
     private readonly _firestore: Firestore,
     private readonly _transaction: InternalTransaction
   ) {
-    // Kick off configuring the client, which freezes the settings.
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
-    _firestore._ensureClientConfigured();
-    this._dataReader = newUserDataReader(
-      _firestore._databaseId,
-      _firestore._settings!
-    );
+    this._dataReader = newUserDataReader(_firestore);
   }
 
   get<T>(
@@ -167,7 +161,7 @@ export function runTransaction<T>(
   updateFunction: (transaction: firestore.Transaction) => Promise<T>
 ): Promise<T> {
   const firestoreClient = cast(firestore, Firestore);
-  return firestoreClient._ensureClientConfigured().then(async datastore => {
+  return firestoreClient._getDatastore().then(async datastore => {
     const deferred = new Deferred<T>();
     new TransactionRunner<T>(
       new AsyncQueue(),

--- a/packages/firestore/lite/src/api/write_batch.ts
+++ b/packages/firestore/lite/src/api/write_batch.ts
@@ -42,13 +42,7 @@ export class WriteBatch implements firestore.WriteBatch {
   private _committed = false;
 
   constructor(private readonly _firestore: Firestore) {
-    // Kick off configuring the client, which freezes the settings.
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
-    _firestore._ensureClientConfigured();
-    this._dataReader = newUserDataReader(
-      _firestore._databaseId,
-      _firestore._settings!
-    );
+    this._dataReader = newUserDataReader(_firestore);
   }
 
   set<T>(documentRef: firestore.DocumentReference<T>, value: T): WriteBatch;
@@ -140,7 +134,7 @@ export class WriteBatch implements firestore.WriteBatch {
     this._committed = true;
     if (this._mutations.length > 0) {
       return this._firestore
-        ._ensureClientConfigured()
+        ._getDatastore()
         .then(datastore => invokeCommitRpc(datastore, this._mutations));
     }
 

--- a/packages/firestore/lite/test/helpers.ts
+++ b/packages/firestore/lite/test/helpers.ts
@@ -68,6 +68,20 @@ export function withTestDocAndInitialData(
   });
 }
 
+export function withTestCollectionAndInitialData(
+  data: firestore.DocumentData[],
+  fn: (doc: firestore.CollectionReference) => void | Promise<void>
+): Promise<void> {
+  return withTestDb(async db => {
+    const coll = collection(db, AutoId.newId());
+    for (const element of data) {
+      const ref = doc(coll);
+      await setDoc(ref, element);
+    }
+    return fn(coll);
+  });
+}
+
 export function withTestCollection(
   fn: (doc: firestore.CollectionReference) => void | Promise<void>
 ): Promise<void> {

--- a/packages/firestore/src/api/database.ts
+++ b/packages/firestore/src/api/database.ts
@@ -1528,7 +1528,19 @@ export class BaseQuery {
    * of the query or if any of the fields in the order by are an uncommitted
    * server timestamp.
    */
-  protected boundFromDocument(doc: Document, before: boolean): Bound {
+  protected boundFromDocument(
+    methodName: string,
+    doc: Document | null,
+    before: boolean
+  ): Bound {
+    if (!doc) {
+      throw new FirestoreError(
+        Code.NOT_FOUND,
+        `Can't use a DocumentSnapshot that doesn't exist for ` +
+          `${methodName}().`
+      );
+    }
+
     const components: api.Value[] = [];
 
     // Because people expect to continue/end a query at the exact document
@@ -2003,21 +2015,8 @@ export class Query<T = firestore.DocumentData> extends BaseQuery
   ): Bound {
     validateDefined(methodName, 1, docOrField);
     if (docOrField instanceof DocumentSnapshot) {
-      if (fields.length > 0) {
-        throw new FirestoreError(
-          Code.INVALID_ARGUMENT,
-          `Too many arguments provided to ${methodName}().`
-        );
-      }
-      const snap = docOrField;
-      if (!snap.exists) {
-        throw new FirestoreError(
-          Code.NOT_FOUND,
-          `Can't use a DocumentSnapshot that doesn't exist for ` +
-            `${methodName}().`
-        );
-      }
-      return this.boundFromDocument(snap._document!, before);
+      validateExactNumberOfArgs(methodName, [docOrField, ...fields], 1);
+      return this.boundFromDocument(methodName, docOrField._document, before);
     } else {
       const allFields = [docOrField].concat(fields);
       return this.boundFromFields(methodName, allFields, before);

--- a/packages/firestore/src/api/database.ts
+++ b/packages/firestore/src/api/database.ts
@@ -1691,7 +1691,7 @@ export class BaseQuery {
         );
       }
       return refValue(this._databaseId, new DocumentKey(path));
-    } else if (documentIdValue instanceof DocumentReference) {
+    } else if (documentIdValue instanceof DocumentKeyReference) {
       return refValue(this._databaseId, documentIdValue._key);
     } else {
       throw new FirestoreError(

--- a/packages/firestore/src/core/query.ts
+++ b/packages/firestore/src/core/query.ts
@@ -47,6 +47,9 @@ export const enum LimitType {
  * query the RemoteStore results.
  */
 export class Query {
+  // TODO(firestorelite): Refactor this class so that methods that are not used
+  // in the Lite client become tree-shakeable.
+
   static atPath(path: ResourcePath): Query {
     return new Query(path);
   }

--- a/packages/firestore/src/util/input_validation.ts
+++ b/packages/firestore/src/util/input_validation.ts
@@ -58,7 +58,7 @@ export function validateNoArgs(functionName: string, args: IArguments): void {
  */
 export function validateExactNumberOfArgs(
   functionName: string,
-  args: IArguments,
+  args: ArrayLike<unknown>,
   numberOfArgs: number
 ): void {
   if (args.length !== numberOfArgs) {

--- a/packages/firestore/test/util/api_helpers.ts
+++ b/packages/firestore/test/util/api_helpers.ts
@@ -57,11 +57,17 @@ export function firestore(): Firestore {
 }
 
 export function collectionReference(path: string): CollectionReference {
-  return new CollectionReference(pathFrom(path), firestore());
+  const firestoreClient = firestore();
+  // eslint-disable-next-line @typescript-eslint/no-floating-promises
+  firestoreClient.ensureClientConfigured();
+  return new CollectionReference(pathFrom(path), firestoreClient);
 }
 
 export function documentReference(path: string): DocumentReference {
-  return new DocumentReference(key(path), firestore());
+  const firestoreClient = firestore();
+  // eslint-disable-next-line @typescript-eslint/no-floating-promises
+  firestoreClient.ensureClientConfigured();
+  return new DocumentReference(key(path), firestoreClient);
 }
 
 export function documentSnapshot(

--- a/packages/firestore/test/util/api_helpers.ts
+++ b/packages/firestore/test/util/api_helpers.ts
@@ -62,7 +62,7 @@ export function collectionReference(path: string): CollectionReference {
   firestoreClient.ensureClientConfigured();
   return new CollectionReference(
     pathFrom(path),
-    firestore(),
+    firestoreClient,
     /* converter= */ null
   );
 }
@@ -71,7 +71,11 @@ export function documentReference(path: string): DocumentReference {
   const firestoreClient = firestore();
   // eslint-disable-next-line @typescript-eslint/no-floating-promises
   firestoreClient.ensureClientConfigured();
-  return new DocumentReference(key(path), firestore(), /* converter= */ null);
+  return new DocumentReference(
+    key(path),
+    firestoreClient,
+    /* converter= */ null
+  );
 }
 
 export function documentSnapshot(


### PR DESCRIPTION
This adds all Query filters and getQuery to the light client. As part of this, I moved a lot the internal logic from the "legacy" Query class to BaseQuery, which allows me to share most of the validation logic.