### PR TITLE
Check for converter in Query.isEqual()

### DIFF
--- a/packages/firestore/src/api/database.ts
+++ b/packages/firestore/src/api/database.ts
@@ -1648,7 +1648,9 @@ export class Query<T = firestore.DocumentData> implements firestore.Query<T> {
       throw invalidClassError('isEqual', 'Query', 1, other);
     }
     return (
-      this.firestore === other.firestore && this._query.isEqual(other._query)
+      this.firestore === other.firestore &&
+      this._query.isEqual(other._query) &&
+      this._converter === other._converter
     );
   }
 

--- a/packages/firestore/test/integration/api/database.test.ts
+++ b/packages/firestore/test/integration/api/database.test.ts
@@ -1374,5 +1374,23 @@ apiDescribe('Database', (persistence: boolean) => {
         expect(usersCollection!.isEqual(db.doc('users/user1'))).to.be.true;
       });
     });
+
+    it('checks converter when comparing with isEqual()', () => {
+      return withTestDb(persistence, async db => {
+        const postConverter2 = { ...postConverter };
+
+        const postsCollection = db
+          .collection('users/user1/posts')
+          .withConverter(postConverter);
+        const postsCollection2 = db
+          .collection('users/user1/posts')
+          .withConverter(postConverter2);
+        expect(postsCollection.isEqual(postsCollection2)).to.be.false;
+
+        const docRef = db.doc('some/doc').withConverter(postConverter);
+        const docRef2 = db.doc('some/doc').withConverter(postConverter2);
+        expect(docRef.isEqual(docRef2)).to.be.false;
+      });
+    });
   });
 });


### PR DESCRIPTION
We have been checking the converter when performing equality checks in `DocumentReference`, but not for `Query` and `CollectionReference`. This PR standardizes all classes that contain converters to check for them when making equality checks.

Also, @schmidt-sebastian, wouldn't this be considered a breaking change?