### PR TITLE
[Bugfix] Wrong "main" path for firestore/memory

### DIFF
--- a/packages/firebase/firestore/memory/package.json
+++ b/packages/firebase/firestore/memory/package.json
@@ -1,7 +1,7 @@
 {
   "name": "firebase/firestore/memory",
   "description": "A memory-only build of the Cloud Firestore JS SDK.",
-  "main": "dist/index.cjs.js",
+  "main": "dist/index.node.cjs.js",
   "module": "dist/index.esm.js",
   "typings": "../../empty-import.d.ts"
 }


### PR DESCRIPTION
# Problem

When doing the following, as mentioned [here](https://firebase.google.com/support/release-notes/js#version_7130_-_march_26_2020):

```js
import * as firebase from 'firebase/app';
import 'firebase/firestore/memory';
```

You get hit with the following error message:

```
Cannot find module 'firebase/firestore/memory' from ...
```

Turns out, the following files are generate to the dist folder...
* index.esm.js
* index.node.cjs.js

...but the "main" path in the package.json is set to `dist/index.cjs.js`.

# Solution
This PR fixes the main path to `index.node.cjs.js`, which fixes the import issues.