### PR TITLE
Throw proper error for FieldValue transforms in arrays

### DIFF
--- a/packages/firestore/src/api/credentials.ts
+++ b/packages/firestore/src/api/credentials.ts
@@ -214,7 +214,6 @@ export class FirebaseCredentialsProvider implements CredentialsProvider {
       // outstanding so the response is potentially for a previous user (which
       // user, we can't be sure).
       if (this.tokenCounter !== initialTokenCounter) {
-        this.forceRefresh = true;
         throw new FirestoreError(
           Code.ABORTED,
           'getToken aborted due to token change.'

--- a/packages/firestore/src/api/credentials.ts
+++ b/packages/firestore/src/api/credentials.ts
@@ -214,6 +214,7 @@ export class FirebaseCredentialsProvider implements CredentialsProvider {
       // outstanding so the response is potentially for a previous user (which
       // user, we can't be sure).
       if (this.tokenCounter !== initialTokenCounter) {
+        this.forceRefresh = true;
         throw new FirestoreError(
           Code.ABORTED,
           'getToken aborted due to token change.'

--- a/packages/firestore/src/api/user_data_reader.ts
+++ b/packages/firestore/src/api/user_data_reader.ts
@@ -623,7 +623,7 @@ function parseSentinelFieldValue(
       `${value._methodName}() can only be used with update() and set()`
     );
   }
-  if (context.path === null) {
+  if (!context.path) {
     throw context.createError(
       `${value._methodName}() is not currently supported inside arrays`
     );

--- a/packages/firestore/test/integration/api/validation.test.ts
+++ b/packages/firestore/test/integration/api/validation.test.ts
@@ -472,6 +472,18 @@ apiDescribe('Validation:', (persistence: boolean) => {
 
     validationIt(
       persistence,
+      'must not contain field value transforms in arrays',
+      db => {
+        return expectWriteToFail(
+          db,
+          { 'array': [FieldValue.serverTimestamp()] },
+          'FieldValue.serverTimestamp() is not currently supported inside arrays'
+        );
+      }
+    );
+
+    validationIt(
+      persistence,
       'must not contain directly nested arrays.',
       db => {
         return expectWriteToFail(


### PR DESCRIPTION
Fixes a regression introduced in #3048 which changed the context.path variable from `Path|null` to `undefined|null`.

Fixes https://github.com/firebase/firebase-js-sdk/issues/3172