### PR TITLE
Refetch token if attempt was invalidated

### DIFF
--- a/packages/firestore/src/api/credentials.ts
+++ b/packages/firestore/src/api/credentials.ts
@@ -23,6 +23,7 @@ import {
   FirebaseAuthInternalName
 } from '@firebase/auth-interop-types';
 import { Provider } from '@firebase/component';
+import { logDebug } from '../util/log';
 
 // TODO(mikelehen): This should be split into multiple files and probably
 // moved to an auth/ folder to match other platforms.
@@ -214,10 +215,11 @@ export class FirebaseCredentialsProvider implements CredentialsProvider {
       // outstanding so the response is potentially for a previous user (which
       // user, we can't be sure).
       if (this.tokenCounter !== initialTokenCounter) {
-        throw new FirestoreError(
-          Code.ABORTED,
+        logDebug(
+          'FirebaseCredentialsProvider',
           'getToken aborted due to token change.'
         );
+        return this.getToken();
       } else {
         if (tokenData) {
           hardAssert(


### PR DESCRIPTION
When a token refresh fails because of we got a token callback while fetching the token, we could refetch the token instead of throwing an error with Code ABORTED.

This is meant to address https://github.com/firebase/firebase-js-sdk/issues/2923#issuecomment-638983250, which shows:

```
[Log] [2020-06-04T17:00:57.554Z]  @firebase/firestore: – "Firestore (7.14.5): PersistentStream" – "close with error: FirebaseError: [code=unknown]: Fetching auth token failed: getToken aborted due to token change." (vendor.js, line 179863)
[Error] [2020-06-04T17:00:57.555Z]  @firebase/firestore: – "Firestore (7.14.5): Could not reach Cloud Firestore backend. Connection failed 1 times. Most recent error: FirebaseError: [code=unknown]…"


