### PR TITLE
Take RemoteStore offline during user change

### DIFF
--- a/packages/firestore/src/core/firestore_client.ts
+++ b/packages/firestore/src/core/firestore_client.ts
@@ -179,9 +179,9 @@ export class FirestoreClient {
           persistenceResult
         ).then(initializationDone.resolve, initializationDone.reject);
       } else {
-        this.asyncQueue.enqueueRetryable(() => {
-          return this.handleCredentialChange(user);
-        });
+        this.asyncQueue.enqueueAndForget(() =>
+          this.remoteStore.handleCredentialChange(user)
+        );
       }
     });
 
@@ -337,13 +337,6 @@ export class FirestoreClient {
         'The client has already been terminated.'
       );
     }
-  }
-
-  private handleCredentialChange(user: User): Promise<void> {
-    this.asyncQueue.verifyOperationInProgress();
-
-    logDebug(LOG_TAG, 'Credential Changed. Current user: ' + user.uid);
-    return this.syncEngine.handleCredentialChange(user);
   }
 
   /** Disables the network connection. Pending operations will not complete. */

--- a/packages/firestore/src/core/firestore_client.ts
+++ b/packages/firestore/src/core/firestore_client.ts
@@ -179,7 +179,7 @@ export class FirestoreClient {
           persistenceResult
         ).then(initializationDone.resolve, initializationDone.reject);
       } else {
-        this.asyncQueue.enqueueAndForget(() =>
+        this.asyncQueue.enqueueRetryable(() =>
           this.remoteStore.handleCredentialChange(user)
         );
       }

--- a/packages/firestore/src/core/sync_engine.ts
+++ b/packages/firestore/src/core/sync_engine.ts
@@ -860,10 +860,12 @@ export class SyncEngine implements RemoteSyncer {
     );
   }
 
-  async handleCredentialChange(user: User): Promise<void> {
+  async handleUserChange(user: User): Promise<void> {
     const userChanged = !this.currentUser.isEqual(user);
 
     if (userChanged) {
+      logDebug(LOG_TAG, 'User change. New user:', user.toKey());
+
       const result = await this.localStore.handleUserChange(user);
       this.currentUser = user;
 
@@ -879,8 +881,6 @@ export class SyncEngine implements RemoteSyncer {
       );
       await this.emitNewSnapsAndNotifyLocalStore(result.affectedDocuments);
     }
-
-    await this.remoteStore.handleCredentialChange();
   }
 
   enableNetwork(): Promise<void> {

--- a/packages/firestore/src/core/sync_engine.ts
+++ b/packages/firestore/src/core/sync_engine.ts
@@ -860,7 +860,7 @@ export class SyncEngine implements RemoteSyncer {
     );
   }
 
-  async handleUserChange(user: User): Promise<void> {
+  async handleCredentialChange(user: User): Promise<void> {
     const userChanged = !this.currentUser.isEqual(user);
 
     if (userChanged) {

--- a/packages/firestore/src/remote/remote_store.ts
+++ b/packages/firestore/src/remote/remote_store.ts
@@ -776,7 +776,7 @@ export class RemoteStore implements TargetMetadataProvider {
 
     await this.disableNetworkInternal();
     this.onlineStateTracker.set(OnlineState.Unknown);
-    await this.syncEngine.handleUserChange(user);
+    await this.syncEngine.handleCredentialChange(user);
 
     this.offlineCauses.delete(OfflineCause.CredentialChange);
     await this.enableNetworkInternal();

--- a/packages/firestore/src/remote/remote_syncer.ts
+++ b/packages/firestore/src/remote/remote_syncer.ts
@@ -20,6 +20,7 @@ import { DocumentKeySet } from '../model/collections';
 import { MutationBatchResult } from '../model/mutation_batch';
 import { FirestoreError } from '../util/error';
 import { RemoteEvent } from './remote_event';
+import { User } from '../auth/user';
 
 /**
  * An interface that describes the actions the RemoteStore needs to perform on
@@ -65,4 +66,10 @@ export interface RemoteSyncer {
    * the last snapshot.
    */
   getRemoteKeysForTarget(targetId: TargetId): DocumentKeySet;
+
+  /**
+   * Updates all local state to match the pending mutations for the given user.
+   * May be called repeatedly for the same user.
+   */
+  handleUserChange(user: User): Promise<void>;
 }

--- a/packages/firestore/src/remote/remote_syncer.ts
+++ b/packages/firestore/src/remote/remote_syncer.ts
@@ -71,5 +71,5 @@ export interface RemoteSyncer {
    * Updates all local state to match the pending mutations for the given user.
    * May be called repeatedly for the same user.
    */
-  handleUserChange(user: User): Promise<void>;
+  handleCredentialChange(user: User): Promise<void>;
 }

--- a/packages/firestore/test/unit/specs/recovery_spec.test.ts
+++ b/packages/firestore/test/unit/specs/recovery_spec.test.ts
@@ -754,4 +754,46 @@ describeSpec('Persistence Recovery', ['no-ios', 'no-android'], () => {
       );
     }
   );
+
+  specTest(
+    'Multiple user changes during transaction failure (with recovery)',
+    ['durable-persistence'],
+    () => {
+      const query = Query.atPath(path('collection'));
+      const doc1 = doc(
+        'collection/key1',
+        0,
+        { foo: 'a' },
+        { hasLocalMutations: true }
+      );
+      return (
+        spec()
+          .changeUser('user1')
+          .userSets('collection/key1', { foo: 'a' })
+          .userListens(query)
+          .expectEvents(query, {
+            added: [doc1],
+            fromCache: true,
+            hasPendingWrites: true
+          })
+          // Change the user to user2 and back to user1 while IndexedDB is failed
+          .failDatabaseTransactions('Handle user change')
+          .changeUser('user2')
+          // The network is offline due to the failed user change
+          .expectActiveTargets()
+          .changeUser('user1')
+          .recoverDatabase()
+          .runTimer(TimerId.AsyncQueueRetry)
+          .expectActiveTargets({ query })
+          // We are now user 2
+          .expectEvents(query, { removed: [doc1], fromCache: true })
+          // We are now user 1
+          .expectEvents(query, {
+            added: [doc1],
+            fromCache: true,
+            hasPendingWrites: true
+          })
+      );
+    }
+  );
 });

--- a/packages/firestore/test/unit/specs/recovery_spec.test.ts
+++ b/packages/firestore/test/unit/specs/recovery_spec.test.ts
@@ -721,29 +721,37 @@ describeSpec('Persistence Recovery', ['no-ios', 'no-android'], () => {
         { foo: 'a' },
         { hasLocalMutations: true }
       );
-      return spec()
-        .changeUser('user1')
-        .userSets('collection/key1', { foo: 'a' })
-        .userListens(query)
-        .expectEvents(query, {
-          added: [doc1],
-          fromCache: true,
-          hasPendingWrites: true
-        })
-        .failDatabaseTransactions('Handle user change')
-        .changeUser('user2')
-        .recoverDatabase()
-        .runTimer(TimerId.AsyncQueueRetry)
-        .expectEvents(query, { removed: [doc1], fromCache: true })
-        .failDatabaseTransactions('Handle user change')
-        .changeUser('user1')
-        .recoverDatabase()
-        .runTimer(TimerId.AsyncQueueRetry)
-        .expectEvents(query, {
-          added: [doc1],
-          fromCache: true,
-          hasPendingWrites: true
-        });
+      return (
+        spec()
+          .changeUser('user1')
+          .userSets('collection/key1', { foo: 'a' })
+          .userListens(query)
+          .expectEvents(query, {
+            added: [doc1],
+            fromCache: true,
+            hasPendingWrites: true
+          })
+          .failDatabaseTransactions('Handle user change')
+          .changeUser('user2')
+          // The network is offline due to the failed user change
+          .expectActiveTargets()
+          .recoverDatabase()
+          .runTimer(TimerId.AsyncQueueRetry)
+          .expectActiveTargets({ query })
+          .expectEvents(query, { removed: [doc1], fromCache: true })
+          .failDatabaseTransactions('Handle user change')
+          .changeUser('user1')
+          // The network is offline due to the failed user change
+          .expectActiveTargets()
+          .recoverDatabase()
+          .runTimer(TimerId.AsyncQueueRetry)
+          .expectActiveTargets({ query })
+          .expectEvents(query, {
+            added: [doc1],
+            fromCache: true,
+            hasPendingWrites: true
+          })
+      );
     }
   );
 });

--- a/packages/firestore/test/unit/specs/spec_test_runner.ts
+++ b/packages/firestore/test/unit/specs/spec_test_runner.ts
@@ -716,8 +716,11 @@ abstract class TestRunner {
 
   private async doChangeUser(user: string | null): Promise<void> {
     this.user = new User(user);
-    return this.queue.enqueue(() =>
-      this.remoteStore.handleCredentialChange(this.user)
+    // We don't block on `handleCredentialChange` as it may not get executed
+    // during an IndexedDb failure. Non-recovery tests will pick up the user
+    // change when the AsyncQueue is drained.
+    this.queue.enqueueRetryable(() =>
+      this.remoteStore.handleCredentialChange(new User(user))
     );
   }
 

--- a/packages/firestore/test/unit/specs/spec_test_runner.ts
+++ b/packages/firestore/test/unit/specs/spec_test_runner.ts
@@ -716,7 +716,7 @@ abstract class TestRunner {
 
   private async doChangeUser(user: string | null): Promise<void> {
     this.user = new User(user);
-    // We don't block on `handleCredentialChange` as it may not get executed
+    // We don't block on `handleUserChange` as it may not get executed
     // during an IndexedDb failure. Non-recovery tests will pick up the user
     // change when the AsyncQueue is drained.
     this.queue.enqueueRetryable(() =>

--- a/packages/firestore/test/unit/specs/spec_test_runner.ts
+++ b/packages/firestore/test/unit/specs/spec_test_runner.ts
@@ -716,17 +716,9 @@ abstract class TestRunner {
 
   private async doChangeUser(user: string | null): Promise<void> {
     this.user = new User(user);
-    const deferred = new Deferred<void>();
-    await this.queue.enqueueRetryable(async () => {
-      try {
-        await this.syncEngine.handleCredentialChange(this.user);
-      } finally {
-        // Resolve the deferred Promise even if the operation failed. This allows
-        // the spec tests to manually retry the failed user change.
-        deferred.resolve();
-      }
-    });
-    return deferred.promise;
+    return this.queue.enqueue(() =>
+      this.remoteStore.handleCredentialChange(this.user)
+    );
   }
 
   private async doFailDatabase(

--- a/packages/firestore/test/unit/specs/spec_test_runner.ts
+++ b/packages/firestore/test/unit/specs/spec_test_runner.ts
@@ -716,7 +716,7 @@ abstract class TestRunner {
 
   private async doChangeUser(user: string | null): Promise<void> {
     this.user = new User(user);
-    // We don't block on `handleUserChange` as it may not get executed
+    // We don't block on `handleCredentialChange` as it may not get executed
     // during an IndexedDb failure. Non-recovery tests will pick up the user
     // change when the AsyncQueue is drained.
     this.queue.enqueueRetryable(() =>


### PR DESCRIPTION
This changes the user change to be much more explicit:

- At first, we take RemoteStore offline
- Then SyncEngine applies the user change (with recovery)
- Only when the user change in SyncEngine succeeds do we take the network back online

Replaces https://github.com/firebase/firebase-js-sdk/pull/3192

Fixes #3179