### PR TITLE
Add Firestore ReactNative build

### DIFF
--- a/packages/firestore/index.rn.memory.ts
+++ b/packages/firestore/index.rn.memory.ts
@@ -21,13 +21,14 @@ import { FirebaseNamespace } from '@firebase/app-types';
 import { Firestore } from './src/api/database';
 import { MemoryComponentProvider } from './src/core/component_provider';
 import { configureForFirebase } from './src/platform/config';
+
 import './register-module';
-import './src/platform_node/node_init';
+import './src/platform_rn/rn_init';
 
 import { name, version } from './package.json';
 
 /**
- * Registers the memory-only Firestore build for Node with the components
+ * Registers the memory-only Firestore build for ReactNative with the components
  * framework.
  */
 export function registerFirestore(instance: FirebaseNamespace): void {
@@ -35,7 +36,7 @@ export function registerFirestore(instance: FirebaseNamespace): void {
     instance,
     (app, auth) => new Firestore(app, auth, new MemoryComponentProvider())
   );
-  instance.registerVersion(name, version, 'node');
+  instance.registerVersion(name, version, 'rn');
 }
 
 registerFirestore(firebase);

--- a/packages/firestore/index.rn.ts
+++ b/packages/firestore/index.rn.ts
@@ -14,28 +14,28 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import firebase from '@firebase/app';
 import { FirebaseNamespace } from '@firebase/app-types';
 
 import { Firestore } from './src/api/database';
-import { MemoryComponentProvider } from './src/core/component_provider';
+import { IndexedDbComponentProvider } from './src/core/component_provider';
 import { configureForFirebase } from './src/platform/config';
+
 import './register-module';
-import './src/platform_node/node_init';
+import './src/platform_rn/rn_init';
 
 import { name, version } from './package.json';
 
 /**
- * Registers the memory-only Firestore build for Node with the components
- * framework.
+ * Registers the main Firestore ReactNative build with the components framework.
+ * Persistence can be enabled via `firebase.firestore().enablePersistence()`.
  */
 export function registerFirestore(instance: FirebaseNamespace): void {
   configureForFirebase(
     instance,
-    (app, auth) => new Firestore(app, auth, new MemoryComponentProvider())
+    (app, auth) => new Firestore(app, auth, new IndexedDbComponentProvider())
   );
-  instance.registerVersion(name, version, 'node');
+  instance.registerVersion(name, version, 'rn');
 }
 
 registerFirestore(firebase);

--- a/packages/firestore/memory/package.json
+++ b/packages/firestore/memory/package.json
@@ -3,6 +3,7 @@
   "description": "A memory-only build of the Cloud Firestore JS SDK.",
   "main": "../dist/index.memory.node.cjs.js",
   "main-esm2017": "../dist/index.memory.node.esm2017.js",
+  "react-native": "../dist/index.memory.rn.esm2017.js",
   "browser": "../dist/index.memory.cjs.js",
   "module": "../dist/index.memory.esm.js",
   "esm2017": "../dist/index.memory.esm2017.js",

--- a/packages/firestore/package.json
+++ b/packages/firestore/package.json
@@ -59,7 +59,6 @@
     "@firebase/webchannel-wrapper": "0.2.41",
     "@grpc/grpc-js": "0.8.1",
     "@grpc/proto-loader": "^0.5.0",
-    "js-base64": "2.5.2",
     "tslib": "1.11.1"
   },
   "peerDependencies": {
@@ -70,7 +69,6 @@
     "@firebase/app-exp": "0.x",
     "@firebase/app-types-exp": "0.x",
     "@types/json-stable-stringify": "1.0.32",
-    "@types/js-base64": "2.3.1",
     "json-stable-stringify": "1.0.1",
     "protobufjs": "6.9.0",
     "rollup": "2.7.6",

--- a/packages/firestore/package.json
+++ b/packages/firestore/package.json
@@ -70,6 +70,7 @@
     "@firebase/app-exp": "0.x",
     "@firebase/app-types-exp": "0.x",
     "@types/json-stable-stringify": "1.0.32",
+    "@types/js-base64": "2.3.1",
     "json-stable-stringify": "1.0.1",
     "protobufjs": "6.9.0",
     "rollup": "2.7.6",

--- a/packages/firestore/package.json
+++ b/packages/firestore/package.json
@@ -41,6 +41,7 @@
   },
   "main": "dist/index.node.cjs.js",
   "main-esm2017": "dist/index.node.esm2017.js",
+  "react-native": "dist/index.rn.esm2017.js",
   "browser": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
   "esm2017": "dist/index.esm2017.js",
@@ -58,6 +59,7 @@
     "@firebase/webchannel-wrapper": "0.2.41",
     "@grpc/grpc-js": "0.8.1",
     "@grpc/proto-loader": "^0.5.0",
+    "js-base64": "2.5.2",
     "tslib": "1.11.1"
   },
   "peerDependencies": {

--- a/packages/firestore/rollup.config.es2017.js
+++ b/packages/firestore/rollup.config.es2017.js
@@ -100,6 +100,31 @@ const browserBuilds = [
   }
 ];
 
+const reactNativeBuilds = [
+  // Persistence build
+  {
+    input: 'index.rn.ts',
+    output: {
+      file: pkg['react-native'],
+      format: 'es',
+      sourcemap: true
+    },
+    plugins: browserBuildPlugins,
+    external: resolveBrowserExterns
+  },
+  // Memory-only build
+  {
+    input: 'index.rn.memory.ts',
+    output: {
+      file: path.resolve('./memory', memoryPkg['react-native']),
+      format: 'es',
+      sourcemap: true
+    },
+    plugins: browserBuildPlugins,
+    external: resolveBrowserExterns
+  }
+];
+
 // MARK: Node builds
 
 const nodeBuildPlugins = [
@@ -145,4 +170,4 @@ const nodeBuilds = [
   }
 ];
 
-export default [...browserBuilds, ...nodeBuilds];
+export default [...browserBuilds, ...reactNativeBuilds, ...nodeBuilds];

--- a/packages/firestore/src/platform_browser/browser_platform.ts
+++ b/packages/firestore/src/platform_browser/browser_platform.ts
@@ -19,7 +19,7 @@ import { DatabaseId, DatabaseInfo } from '../core/database_info';
 import { Platform } from '../platform/platform';
 import { Connection } from '../remote/connection';
 import { JsonProtoSerializer } from '../remote/serializer';
-import { ConnectivityMonitor } from './../remote/connectivity_monitor';
+import { ConnectivityMonitor } from '../remote/connectivity_monitor';
 
 import { NoopConnectivityMonitor } from '../remote/connectivity_monitor_noop';
 import { BrowserConnectivityMonitor } from './browser_connectivity_monitor';
@@ -27,13 +27,10 @@ import { WebChannelConnection } from './webchannel_connection';
 import { debugAssert } from '../util/assert';
 
 // Implements the Platform API for browsers and some browser-like environments
-// (including ReactNative).
+// (including ReactNative, which has its own ReactNativePlatform that extends
+// from this class).
 export class BrowserPlatform implements Platform {
-  readonly base64Available: boolean;
-
-  constructor() {
-    this.base64Available = typeof atob !== 'undefined';
-  }
+  readonly base64Available = typeof atob !== 'undefined';
 
   get document(): Document | null {
     // `document` is not always available, e.g. in ReactNative and WebWorkers.

--- a/packages/firestore/src/platform_rn/rn_init.ts
+++ b/packages/firestore/src/platform_rn/rn_init.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2017 Google LLC
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,16 +15,14 @@
  * limitations under the License.
  */
 
-import firebase from '../app';
-import { name, version } from '../package.json';
+import { PlatformSupport } from '../platform/platform';
+import { ReactNativePlatform } from './rn_platform';
 
-import '../auth';
-import '../database';
-// TODO(b/158625454): Storage doesn't actually work by default in RN (it uses
-//  `atob`). We should provide a RN build that works out of the box.
-import '../storage';
-import '../firestore';
-
-firebase.registerVersion(name, version, 'rn');
-
-export default firebase;
+/**
+ * This code needs to run before Firestore is used. This can be achieved in
+ * several ways:
+ *   1) Through the JSCompiler compiling this code and then (automatically)
+ *      executing it before exporting the Firestore symbols.
+ *   2) Through importing this module first in a Firestore main module
+ */
+PlatformSupport.setPlatform(new ReactNativePlatform());

--- a/packages/firestore/src/platform_rn/rn_platform.ts
+++ b/packages/firestore/src/platform_rn/rn_platform.ts
@@ -16,17 +16,21 @@
  */
 
 import { BrowserPlatform } from '../platform_browser/browser_platform';
-import { Base64 } from 'js-base64';
+import { base64 } from '@firebase/util';
 
 // Implements the Platform API for ReactNative.
 export class ReactNativePlatform extends BrowserPlatform {
   readonly base64Available = true;
 
   atob(encoded: string): string {
-    return Base64.decode(encoded);
+    // WebSafe uses a different URL-encoding safe alphabet that doesn't match
+    // the encoding used on the backend.
+    return base64.decodeString(encoded, /* webSafe =*/ false);
   }
 
   btoa(raw: string): string {
-    return Base64.encode(raw);
+    // WebSafe uses a different URL-encoding safe alphabet that doesn't match
+    // the encoding used on the backend.
+    return base64.encodeString(raw, /* webSafe =*/ false);
   }
 }

--- a/packages/firestore/src/platform_rn/rn_platform.ts
+++ b/packages/firestore/src/platform_rn/rn_platform.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2017 Google LLC
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,16 +15,18 @@
  * limitations under the License.
  */
 
-import firebase from '../app';
-import { name, version } from '../package.json';
+import { BrowserPlatform } from '../platform_browser/browser_platform';
+import { Base64 } from 'js-base64';
 
-import '../auth';
-import '../database';
-// TODO(b/158625454): Storage doesn't actually work by default in RN (it uses
-//  `atob`). We should provide a RN build that works out of the box.
-import '../storage';
-import '../firestore';
+// Implements the Platform API for ReactNative.
+export class ReactNativePlatform extends BrowserPlatform {
+  readonly base64Available = true;
 
-firebase.registerVersion(name, version, 'rn');
+  atob(encoded: string): string {
+    return Base64.decode(encoded);
+  }
 
-export default firebase;
+  btoa(raw: string): string {
+    return Base64.encode(raw);
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2130,6 +2130,11 @@
     "@types/minimatch" "*"
     "@types/node" "*"
 
+"@types/js-base64@2.3.1":
+  version "2.3.1"
+  resolved "https://registry.npmjs.org/@types/js-base64/-/js-base64-2.3.1.tgz#c39f14f129408a3d96a1105a650d8b2b6eeb4168"
+  integrity sha512-4RKbhIDGC87s4EBy2Cp2/5S2O6kmCRcZnD5KRCq1q9z2GhBte1+BdsfVKCpG8yKpDGNyEE2G6IqFIh6W2YwWPA==
+
 "@types/json-schema@^7.0.3":
   version "7.0.4"
   resolved "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.4.tgz#38fd73ddfd9b55abb1e1b2ed578cb55bd7b7d339"
@@ -8729,6 +8734,11 @@ jquery@^3.4.1:
   version "3.4.1"
   resolved "https://registry.npmjs.org/jquery/-/jquery-3.4.1.tgz#714f1f8d9dde4bdfa55764ba37ef214630d80ef2"
   integrity sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw==
+
+js-base64@2.5.2:
+  version "2.5.2"
+  resolved "https://registry.npmjs.org/js-base64/-/js-base64-2.5.2.tgz#313b6274dda718f714d00b3330bbae6e38e90209"
+  integrity sha512-Vg8czh0Q7sFBSUMWWArX/miJeBWYBPpdU/3M/DKSaekLMqrqVPaedp+5mZhie/r0lgrcaYBfwXatEew6gwgiQQ==
 
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2130,11 +2130,6 @@
     "@types/minimatch" "*"
     "@types/node" "*"
 
-"@types/js-base64@2.3.1":
-  version "2.3.1"
-  resolved "https://registry.npmjs.org/@types/js-base64/-/js-base64-2.3.1.tgz#c39f14f129408a3d96a1105a650d8b2b6eeb4168"
-  integrity sha512-4RKbhIDGC87s4EBy2Cp2/5S2O6kmCRcZnD5KRCq1q9z2GhBte1+BdsfVKCpG8yKpDGNyEE2G6IqFIh6W2YwWPA==
-
 "@types/json-schema@^7.0.3":
   version "7.0.4"
   resolved "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.4.tgz#38fd73ddfd9b55abb1e1b2ed578cb55bd7b7d339"
@@ -8734,11 +8729,6 @@ jquery@^3.4.1:
   version "3.4.1"
   resolved "https://registry.npmjs.org/jquery/-/jquery-3.4.1.tgz#714f1f8d9dde4bdfa55764ba37ef214630d80ef2"
   integrity sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw==
-
-js-base64@2.5.2:
-  version "2.5.2"
-  resolved "https://registry.npmjs.org/js-base64/-/js-base64-2.5.2.tgz#313b6274dda718f714d00b3330bbae6e38e90209"
-  integrity sha512-Vg8czh0Q7sFBSUMWWArX/miJeBWYBPpdU/3M/DKSaekLMqrqVPaedp+5mZhie/r0lgrcaYBfwXatEew6gwgiQQ==
 
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
This builds work out of the box in RN since it relies on js-base64 for base64 encoding.

Fixes https://github.com/firebase/firebase-js-sdk/issues/2667