### PR TITLE
upgrade grpc-js

### DIFF
--- a/packages/firestore/package.json
+++ b/packages/firestore/package.json
@@ -56,7 +56,7 @@
     "@firebase/logger": "0.2.5",
     "@firebase/util": "0.2.48",
     "@firebase/webchannel-wrapper": "0.2.41",
-    "@grpc/grpc-js": "0.8.1",
+    "@grpc/grpc-js": "^1.0.0",
     "@grpc/proto-loader": "^0.5.0",
     "tslib": "1.11.1"
   },


### PR DESCRIPTION
Fixes https://github.com/firebase/firebase-js-sdk/issues/3196

Changed it to `^1.0.0`. @schmidt-sebastian Are you comfortable with the caret range? Does `grpc-js` follow semver? 