### PR TITLE
Add a timeout to git fetch in precommit hook

### DIFF
--- a/tools/gitHooks/precommit.js
+++ b/tools/gitHooks/precommit.js
@@ -36,7 +36,7 @@ $ git stash -u
 $ git stash pop
 `;
 
-const FETCH_TIMEOUT = 100;
+const FETCH_TIMEOUT = 10 * 1000; // 10 seconds
 
 function timeoutPromise(millis) {
   return new Promise((resolve, reject) => {
@@ -70,7 +70,7 @@ function timeoutPromise(millis) {
         symbol: '⚠️'
       });
       console.warn(
-        chalk`\n{yellow Unable to fetch latest version of master, diff may be stale.}`
+        chalk`\n{yellow WARNING: Unable to fetch latest version of master, diff may be stale.}`
       );
     }
 

--- a/tools/gitHooks/precommit.js
+++ b/tools/gitHooks/precommit.js
@@ -36,6 +36,14 @@ $ git stash -u
 $ git stash pop
 `;
 
+const FETCH_TIMEOUT = 100;
+
+function timeoutPromise(millis) {
+  return new Promise((resolve, reject) => {
+    setTimeout(reject, millis);
+  });
+}
+
 (async () => {
   try {
     const hasDiff = !!(await git.diff());
@@ -50,7 +58,10 @@ $ git stash pop
       ' Fetching latest version of master branch.'
     ).start();
     try {
-      await git.fetch('origin', 'master');
+      await Promise.race([
+        git.fetch('origin', 'master'),
+        timeoutPromise(FETCH_TIMEOUT)
+      ]);
       fetchSpinner.stopAndPersist({
         symbol: '✅'
       });
@@ -59,7 +70,7 @@ $ git stash pop
         symbol: '⚠️'
       });
       console.warn(
-        chalk`\n{yellow} Unable to fetch latest version of master, diff may be stale.`
+        chalk`\n{yellow Unable to fetch latest version of master, diff may be stale.}`
       );
     }
 


### PR DESCRIPTION
I was always a bit nervous about putting a network request into a precommit hook. This will fail the fetch and continue the commit if it doesn't fetch within 10 seconds. If it fails the only cost is that the prettier and license diffs may be a bit outdated, not worth blocking a commit. But it seems useful to at least attempt to fetch first, if it doesn't take too long.