### PR TITLE
[RxFire] Add missing type annotations

### DIFF
--- a/packages/rxfire/auth/index.ts
+++ b/packages/rxfire/auth/index.ts
@@ -26,7 +26,7 @@ import { switchMap } from 'rxjs/operators';
  * triggered on sign-in or sign-out.
  * @param auth firebase.auth.Auth
  */
-export function authState(auth: auth.Auth): Observable<User> {
+export function authState(auth: auth.Auth): Observable<User | null> {
   return new Observable(subscriber => {
     const unsubscribe = auth.onAuthStateChanged(subscriber);
     return { unsubscribe };
@@ -38,7 +38,7 @@ export function authState(auth: auth.Auth): Observable<User> {
  * sign-out, and token refresh events
  * @param auth firebase.auth.Auth
  */
-export function user(auth: auth.Auth): Observable<User> {
+export function user(auth: auth.Auth): Observable<User | null> {
   return new Observable(subscriber => {
     const unsubscribe = auth.onIdTokenChanged(subscriber);
     return { unsubscribe };

--- a/packages/rxfire/firestore/document/index.ts
+++ b/packages/rxfire/firestore/document/index.ts
@@ -20,9 +20,9 @@ import { fromDocRef } from '../fromRef';
 import { map } from 'rxjs/operators';
 import { Observable } from 'rxjs';
 
-export function doc(
-  ref: firestore.DocumentReference
-): Observable<firestore.DocumentSnapshot> {
+export function doc<T>(
+  ref: firestore.DocumentReference<T>
+): Observable<firestore.DocumentSnapshot<T>> {
   return fromDocRef(ref);
 }
 
@@ -31,7 +31,7 @@ export function doc(
  * @param query
  */
 export function docData<T>(
-  ref: firestore.DocumentReference,
+  ref: firestore.DocumentReference<T>,
   idField?: string
 ): Observable<T> {
   return doc(ref).pipe(map(snap => snapToData(snap, idField) as T));

--- a/packages/rxfire/firestore/fromRef.ts
+++ b/packages/rxfire/firestore/fromRef.ts
@@ -37,16 +37,16 @@ export function fromRef(
   return _fromRef(ref, options);
 }
 
-export function fromDocRef(
-  ref: firestore.DocumentReference,
+export function fromDocRef<T>(
+  ref: firestore.DocumentReference<T>,
   options?: firestore.SnapshotListenOptions
-): Observable<firestore.DocumentSnapshot> {
-  return fromRef(ref, options) as Observable<firestore.DocumentSnapshot>;
+): Observable<firestore.DocumentSnapshot<T>> {
+  return fromRef(ref, options) as Observable<firestore.DocumentSnapshot<T>>;
 }
 
-export function fromCollectionRef(
-  ref: firestore.Query,
+export function fromCollectionRef<T>(
+  ref: firestore.Query<T>,
   options?: firestore.SnapshotListenOptions
-): Observable<firestore.QuerySnapshot> {
-  return fromRef(ref, options) as Observable<firestore.QuerySnapshot>;
+): Observable<firestore.QuerySnapshot<T>> {
+  return fromRef(ref, options) as Observable<firestore.QuerySnapshot<T>>;
 }


### PR DESCRIPTION
Resolves #2996 

What this PR does:
- Adds missing generic type annotations (`rxfire/firestore`).
- Adds missing `null` annotation to `authState` and `user` functions (`rxfire/auth`).