### PR TITLE
Disable React Native build

### DIFF
--- a/packages/firebase/src/index.rn.ts
+++ b/packages/firebase/src/index.rn.ts
@@ -23,7 +23,6 @@ import '../database';
 // TODO(b/158625454): Storage doesn't actually work by default in RN (it uses
 //  `atob`). We should provide a RN build that works out of the box.
 import '../storage';
-import '../firestore';
 
 firebase.registerVersion(name, version, 'rn');
 

--- a/packages/firestore/memory/package.json
+++ b/packages/firestore/memory/package.json
@@ -3,7 +3,6 @@
   "description": "A memory-only build of the Cloud Firestore JS SDK.",
   "main": "../dist/index.memory.node.cjs.js",
   "main-esm2017": "../dist/index.memory.node.esm2017.js",
-  "react-native": "../dist/index.memory.rn.esm2017.js",
   "browser": "../dist/index.memory.cjs.js",
   "module": "../dist/index.memory.esm.js",
   "esm2017": "../dist/index.memory.esm2017.js",

--- a/packages/firestore/package.json
+++ b/packages/firestore/package.json
@@ -43,7 +43,6 @@
   },
   "main": "dist/index.node.cjs.js",
   "main-esm2017": "dist/index.node.esm2017.js",
-  "react-native": "dist/index.rn.esm2017.js",
   "browser": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
   "esm2017": "dist/index.esm2017.js",

--- a/packages/firestore/rollup.config.es2017.js
+++ b/packages/firestore/rollup.config.es2017.js
@@ -108,31 +108,6 @@ const reactNativeBuildPlugins = [
   ...browserBuildPlugins.slice(1)
 ];
 
-const reactNativeBuilds = [
-  // Persistence build
-  {
-    input: 'index.rn.ts',
-    output: {
-      file: pkg['react-native'],
-      format: 'es',
-      sourcemap: true
-    },
-    plugins: reactNativeBuildPlugins,
-    external: resolveBrowserExterns
-  },
-  // Memory-only build
-  {
-    input: 'index.rn.memory.ts',
-    output: {
-      file: path.resolve('./memory', memoryPkg['react-native']),
-      format: 'es',
-      sourcemap: true
-    },
-    plugins: reactNativeBuildPlugins,
-    external: resolveBrowserExterns
-  }
-];
-
 // MARK: Node builds
 
 const nodeBuildPlugins = [
@@ -179,4 +154,4 @@ const nodeBuilds = [
   }
 ];
 
-export default [...browserBuilds, ...reactNativeBuilds, ...nodeBuilds];
+export default [...browserBuilds, ...nodeBuilds];


### PR DESCRIPTION
The current build has a major issue with base64 encoding, which breaks the WriteStream and likely Query resumption on the Watch Stream. This PR removes the files that make this functionality accessible.

Fixes https://github.com/firebase/firebase-js-sdk/issues/3243