### PR TITLE
Add getJSON method

### DIFF
--- a/packages/remote-config-types/index.d.ts
+++ b/packages/remote-config-types/index.d.ts
@@ -75,6 +75,13 @@ export interface RemoteConfig {
   getBoolean(key: string): boolean;
 
   /**
+   * Gets the value for the given key as a json.
+   *
+   * Convenience method for calling <code>remoteConfig.getValue(key).asJSON()</code>.
+   */
+  getJSON(key: string): unknown;
+
+  /**
    * Gets the value for the given key as a number.
    *
    * Convenience method for calling <code>remoteConfig.getValue(key).asNumber()</code>.
@@ -121,6 +128,11 @@ export interface Value {
    * "1", "true", "t", "yes", "y", "on". Other values are interpreted as false.
    */
   asBoolean(): boolean;
+
+  /**
+   * Gets the value as a json. Comparable to calling <code>JSON.parse(value) || null</code>.
+   */
+  asJSON(): unknown;
 
   /**
    * Gets the value as a number. Comparable to calling <code>Number(value) || 0</code>.

--- a/packages/remote-config/src/remote_config.ts
+++ b/packages/remote-config/src/remote_config.ts
@@ -182,6 +182,10 @@ export class RemoteConfig implements RemoteConfigType {
     return this.getValue(key).asBoolean();
   }
 
+  getJSON(key: string): unknown {
+    return this.getValue(key).asJSON();
+  }
+
   getNumber(key: string): number {
     return this.getValue(key).asNumber();
   }

--- a/packages/remote-config/src/value.ts
+++ b/packages/remote-config/src/value.ts
@@ -20,6 +20,7 @@ import { Value as ValueType, ValueSource } from '@firebase/remote-config-types';
 const DEFAULT_VALUE_FOR_BOOLEAN = false;
 const DEFAULT_VALUE_FOR_STRING = '';
 const DEFAULT_VALUE_FOR_NUMBER = 0;
+const DEFAULT_VALUE_FOR_JSON = null;
 
 const BOOLEAN_TRUTHY_VALUES = ['1', 'true', 't', 'yes', 'y', 'on'];
 
@@ -49,6 +50,18 @@ export class Value implements ValueType {
       num = DEFAULT_VALUE_FOR_NUMBER;
     }
     return num;
+  }
+
+  asJSON(): unknown {
+    if (this._source === 'static') {
+      return DEFAULT_VALUE_FOR_JSON;
+    }
+    try {
+      const json = JSON.parse(this._value);
+      return json;
+    } catch (error) {
+      return DEFAULT_VALUE_FOR_JSON;
+    }
   }
 
   getSource(): ValueSource {

--- a/packages/remote-config/test/remote_config.test.ts
+++ b/packages/remote-config/test/remote_config.test.ts
@@ -39,13 +39,15 @@ describe('RemoteConfig', () => {
     key1: 'active_config_value_1',
     key2: 'active_config_value_2',
     key3: 'true',
-    key4: '123'
+    key4: '123',
+    key5: '{"key": "value"}'
   };
   const DEFAULT_CONFIG = {
     key1: 'default_config_value_1',
     key2: 'default_config_value_2',
     key3: 'false',
     key4: '345',
+    key5: '{"key": "value"}',
     test: 'test'
   };
 
@@ -252,6 +254,25 @@ describe('RemoteConfig', () => {
     });
   });
 
+  describe('getJSON', () => {
+    it('returns the active value if available', () => {
+      getActiveConfigStub.returns(ACTIVE_CONFIG);
+      rc.defaultConfig = DEFAULT_CONFIG;
+
+      expect(rc.getJSON('key5')).to.eql(JSON.parse(ACTIVE_CONFIG.key5));
+    });
+
+    it('returns the default value if active is not available', () => {
+      rc.defaultConfig = DEFAULT_CONFIG;
+
+      expect(rc.getJSON('key5')).to.eql(JSON.parse(DEFAULT_CONFIG.key5));
+    });
+
+    it('returns the static value if active and default are not available', () => {
+      expect(rc.getJSON('key1')).to.eq(null);
+    });
+  });
+
   describe('getString', () => {
     it('returns the active value if available', () => {
       getActiveConfigStub.returns(ACTIVE_CONFIG);
@@ -300,6 +321,7 @@ describe('RemoteConfig', () => {
         key2: new Value('remote', ACTIVE_CONFIG.key2),
         key3: new Value('remote', ACTIVE_CONFIG.key3),
         key4: new Value('remote', ACTIVE_CONFIG.key4),
+        key5: new Value('remote', ACTIVE_CONFIG.key5),
         test: new Value('default', DEFAULT_CONFIG.test)
       });
     });
@@ -312,6 +334,7 @@ describe('RemoteConfig', () => {
         key2: new Value('default', DEFAULT_CONFIG.key2),
         key3: new Value('default', DEFAULT_CONFIG.key3),
         key4: new Value('default', DEFAULT_CONFIG.key4),
+        key5: new Value('default', DEFAULT_CONFIG.key5),
         test: new Value('default', DEFAULT_CONFIG.test)
       });
     });

--- a/packages/remote-config/test/value.test.ts
+++ b/packages/remote-config/test/value.test.ts
@@ -54,6 +54,26 @@ describe('Value', () => {
     });
   });
 
+  describe('asJSON', () => {
+    it('returns static default json if source is static', () => {
+      expect(new Value('static').asJSON()).to.eq(null);
+    });
+
+    it('returns value as a json', () => {
+      expect(new Value('remote', '{"key": "value"}').asJSON()).to.eql({
+        key: 'value'
+      });
+      expect(new Value('default', '[1, 5, "false"]').asJSON()).to.eql([
+        1,
+        5,
+        'false'
+      ]);
+      expect(new Value('default', '33').asJSON()).to.eq(33);
+      expect(new Value('default', 'false').asJSON()).to.be.false;
+      expect(new Value('default', 'random string').asJSON()).to.eq(null);
+    });
+  });
+
   describe('asNumber', () => {
     it('returns static default number if source is static', () => {
       expect(new Value('static').asNumber()).to.eq(0);


### PR DESCRIPTION
## Context: 

- There is a method called [jsonValue](https://firebase.google.com/docs/reference/swift/firebaseremoteconfig/api/reference/Classes/RemoteConfigValue?/c:objc(cs)FIRRemoteConfigValue(py)JSONValue) in the iOS and Android SDKs. ([FIRConfigValue](https://github.com/firebase/firebase-ios-sdk/blob/master/FirebaseRemoteConfig/Sources/FIRConfigValue.m#L63-L75))
- The method is not available on the Web, but the Firebase console has a JSON Editor, so it would be nice to have a method to get JSON.

![nikuman_Firebase_コンソール](https://user-images.githubusercontent.com/2681007/85228934-8f573900-b421-11ea-8e7b-f19c137556a8.png)


## This PR did the following:

- [x] Add getJSON method ✍️ 
- [x] Add unit test ✅ 