### PR TITLE
Update docs for UserCredential

### DIFF
--- a/packages/firebase/externs/firebase-auth-externs.js
+++ b/packages/firebase/externs/firebase-auth-externs.js
@@ -2036,6 +2036,20 @@ firebase.auth.Auth.prototype.updateCurrentUser = function(user) {};
  * operationType could be 'signIn' for a sign-in operation, 'link' for a linking
  * operation and 'reauthenticate' for a reauthentication operation.
  *
+ * Depending on the original operation, the <code>credential</code> field may contain
+ * one of the following subclasses of <code>AuthCredential</code>:
+ *
+ * <ul>
+ *   <li>
+ *    {@link firebase.auth.PhoneAuthCredential} for phone auth operations such as
+ *    <code>signInWithPhoneNumber</code>
+ *   </li>
+ *   <li>
+ *    {@link firebase.auth.OAuthCredential} for OAuth operations such as
+ *    <code>signInWithPopup</code>
+ *   </li>
+ * </ul>
+ *
  * @typedef {{
  *   user: ?firebase.User,
  *   credential: ?firebase.auth.AuthCredential,

--- a/packages/firebase/externs/firebase-auth-externs.js
+++ b/packages/firebase/externs/firebase-auth-externs.js
@@ -2050,6 +2050,9 @@ firebase.auth.Auth.prototype.updateCurrentUser = function(user) {};
  *   </li>
  * </ul>
  *
+ * For other sign-in operations, such as email/password sign-in, the <code>credential<field>
+ * will be null.
+ *
  * @typedef {{
  *   user: ?firebase.User,
  *   credential: ?firebase.auth.AuthCredential,

--- a/packages/firebase/index.d.ts
+++ b/packages/firebase/index.d.ts
@@ -4388,6 +4388,23 @@ declare namespace firebase.auth {
    * any additional user information that was returned from the identity provider.
    * operationType could be 'signIn' for a sign-in operation, 'link' for a linking
    * operation and 'reauthenticate' for a reauthentication operation.
+   * 
+   * Depending on the original operation, the <code>credential</code> field may contain
+   * one of the following subclasses of <code>AuthCredential</code>:
+   *
+   * <ul>
+   *   <li>
+   *    {@link firebase.auth.PhoneAuthCredential} for phone auth operations such as
+   *    <code>signInWithPhoneNumber</code>
+   *   </li>
+   *   <li>
+   *    {@link firebase.auth.OAuthCredential} for OAuth operations such as
+   *    <code>signInWithPopup</code>
+   *   </li>
+   * </ul>
+   *
+   * For other sign-in operations, such as email/password sign-in, the <code>credential<field>
+   * will be null.
    */
   type UserCredential = {
     additionalUserInfo?: firebase.auth.AdditionalUserInfo | null;


### PR DESCRIPTION
When you do an operation like `signInWithPopup` there's no pointer in the docs that tells you that you can cast `UserCredential#credential` as a subclass of `AuthCredential` so you can get the `accessToken`