### PR TITLE
Don't serialize/deserialize stream token

### DIFF
--- a/packages/firestore/src/protos/firestore_proto_api.d.ts
+++ b/packages/firestore/src/protos/firestore_proto_api.d.ts
@@ -393,7 +393,7 @@ export declare namespace firestoreV1ApiClientInterfaces {
   }
   interface WriteResponse {
     streamId?: string;
-    streamToken?: string;
+    streamToken?: string | Uint8Array;
     writeResults?: WriteResult[];
     commitTime?: Timestamp;
   }


### PR DESCRIPTION
We don't need to roundtrip the stream token through our Base64 serializer.

Note: This is not the fix to the RN breakage. We are adding full base64 support in https://github.com/firebase/firebase-js-sdk/pull/3251