### PR TITLE
Expose static members of public types in ESM2017 build

### DIFF
--- a/packages/firestore/src/util/api.ts
+++ b/packages/firestore/src/util/api.ts
@@ -52,9 +52,6 @@ export function makeConstructorPrivate<T extends Function>(
     }
   }
 
-  // Copy instance methods/members
-  Object.assign(PublicConstructor, cls);
-
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   return PublicConstructor as any;
 }

--- a/packages/firestore/src/util/api.ts
+++ b/packages/firestore/src/util/api.ts
@@ -17,7 +17,7 @@
 
 import { Code, FirestoreError } from './error';
 
-/** List of JavaScript built-in members that cannot be reassigned. */
+/** List of JavaScript builtins that cannot be reassigned. */
 const RESERVED_READONLY_PROPS = ['length', 'name'];
 
 /**


### PR DESCRIPTION
`makeConstructorPrivate` currently does not re-assign static members in the ESM2017 build, which essentially breaks the static methods on Blob, FieldValue and FieldPath.