### PR TITLE
remove -exp deps from firestore in preparation to enabling changeset

### DIFF
--- a/packages/firestore/package.json
+++ b/packages/firestore/package.json
@@ -67,8 +67,6 @@
     "@firebase/app-types": "0.x"
   },
   "devDependencies": {
-    "@firebase/app-exp": "0.x",
-    "@firebase/app-types-exp": "0.x",
     "@rollup/plugin-alias": "3.1.1",
     "@types/json-stable-stringify": "1.0.32",
     "json-stable-stringify": "1.0.1",


### PR DESCRIPTION
We are excluding -exp packages from being handled by changeset, so no other packages should take dependencies on them. It should not have any impact on Firestore since we have already disabled linting for them https://github.com/firebase/firebase-js-sdk/blob/master/packages/firestore/.eslintrc.js#L57.