### PR TITLE
Set functions-types-exp package to private

### DIFF
--- a/packages-exp/functions-types-exp/package.json
+++ b/packages-exp/functions-types-exp/package.json
@@ -2,6 +2,7 @@
   "name": "@firebase/functions-types-exp",
   "version": "0.0.800",
   "description": "@firebase/functions Types",
+  "private": true,
   "author": "Firebase <firebase-support@google.com> (https://firebase.google.com/)",
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
This was overlooked in https://github.com/firebase/firebase-js-sdk/pull/3051.