### PR TITLE
Remove remaining static references

### DIFF
--- a/packages/firestore/lite/src/api/reference.ts
+++ b/packages/firestore/lite/src/api/reference.ts
@@ -322,7 +322,7 @@ export function collectionGroup(
 
   return new Query(
     firestoreClient,
-    new InternalQuery(ResourcePath.EMPTY_PATH, collectionId),
+    new InternalQuery(ResourcePath.emptyPath(), collectionId),
     /* converter= */ null
   );
 }

--- a/packages/firestore/lite/test/dependencies.json
+++ b/packages/firestore/lite/test/dependencies.json
@@ -31,13 +31,10 @@
                 "uint8ArrayFromBinaryString",
                 "validateArgType",
                 "validateExactNumberOfArgs",
-                "validateNamedArrayAtLeastNumberOfElements",
                 "validateType",
                 "valueDescription"
             ],
             "classes": [
-                "BaseFieldPath",
-                "BasePath",
                 "Blob",
                 "ByteString",
                 "DatabaseId",
@@ -45,22 +42,18 @@
                 "Datastore",
                 "DatastoreImpl",
                 "Deferred",
-                "DocumentKey",
-                "FieldPath",
-                "FieldPath$1",
                 "FirebaseCredentialsProvider",
                 "Firestore",
                 "FirestoreError",
                 "GrpcConnection",
                 "JsonProtoSerializer",
                 "OAuthToken",
-                "ResourcePath",
                 "StreamBridge",
                 "User"
             ],
             "variables": []
         },
-        "sizeInBytes": 26906
+        "sizeInBytes": 20773
     },
     "CollectionReference": {
         "dependencies": {
@@ -242,7 +235,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 97991
+        "sizeInBytes": 97894
     },
     "DocumentReference": {
         "dependencies": {
@@ -252,10 +245,7 @@
                 "debugAssert",
                 "fail",
                 "formatJSON",
-                "formatPlural",
                 "hardAssert",
-                "invalidClassError",
-                "isPlainObject",
                 "loadProtos",
                 "logDebug",
                 "logError",
@@ -265,41 +255,29 @@
                 "newDatastore",
                 "newSerializer",
                 "nodePromise",
-                "ordinal",
                 "primitiveComparator",
-                "registerFirestore",
-                "tryGetCustomObjectType",
-                "validateArgType",
-                "validateNamedArrayAtLeastNumberOfElements",
-                "validateType",
-                "valueDescription"
+                "registerFirestore"
             ],
             "classes": [
-                "BaseFieldPath",
-                "BasePath",
                 "DatabaseId",
                 "DatabaseInfo",
                 "Datastore",
                 "DatastoreImpl",
                 "Deferred",
-                "DocumentKey",
                 "DocumentKeyReference",
                 "DocumentReference",
-                "FieldPath",
-                "FieldPath$1",
                 "FirebaseCredentialsProvider",
                 "Firestore",
                 "FirestoreError",
                 "GrpcConnection",
                 "JsonProtoSerializer",
                 "OAuthToken",
-                "ResourcePath",
                 "StreamBridge",
                 "User"
             ],
             "variables": []
         },
-        "sizeInBytes": 24655
+        "sizeInBytes": 16449
     },
     "DocumentSnapshot": {
         "dependencies": {
@@ -384,7 +362,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 37604
+        "sizeInBytes": 37505
     },
     "FieldPath": {
         "dependencies": {
@@ -397,7 +375,6 @@
                 "formatJSON",
                 "formatPlural",
                 "hardAssert",
-                "invalidClassError",
                 "isPlainObject",
                 "loadProtos",
                 "logDebug",
@@ -425,9 +402,7 @@
                 "Datastore",
                 "DatastoreImpl",
                 "Deferred",
-                "DocumentKey",
                 "FieldPath",
-                "FieldPath$1",
                 "FieldPath$2",
                 "FirebaseCredentialsProvider",
                 "Firestore",
@@ -435,13 +410,12 @@
                 "GrpcConnection",
                 "JsonProtoSerializer",
                 "OAuthToken",
-                "ResourcePath",
                 "StreamBridge",
                 "User"
             ],
             "variables": []
         },
-        "sizeInBytes": 24748
+        "sizeInBytes": 22816
     },
     "FieldValue": {
         "dependencies": {
@@ -451,10 +425,7 @@
                 "debugAssert",
                 "fail",
                 "formatJSON",
-                "formatPlural",
                 "hardAssert",
-                "invalidClassError",
-                "isPlainObject",
                 "loadProtos",
                 "logDebug",
                 "logError",
@@ -464,26 +435,15 @@
                 "newDatastore",
                 "newSerializer",
                 "nodePromise",
-                "ordinal",
                 "primitiveComparator",
-                "registerFirestore",
-                "tryGetCustomObjectType",
-                "validateArgType",
-                "validateNamedArrayAtLeastNumberOfElements",
-                "validateType",
-                "valueDescription"
+                "registerFirestore"
             ],
             "classes": [
-                "BaseFieldPath",
-                "BasePath",
                 "DatabaseId",
                 "DatabaseInfo",
                 "Datastore",
                 "DatastoreImpl",
                 "Deferred",
-                "DocumentKey",
-                "FieldPath",
-                "FieldPath$1",
                 "FieldValue",
                 "FirebaseCredentialsProvider",
                 "Firestore",
@@ -491,14 +451,13 @@
                 "GrpcConnection",
                 "JsonProtoSerializer",
                 "OAuthToken",
-                "ResourcePath",
                 "SerializableFieldValue",
                 "StreamBridge",
                 "User"
             ],
             "variables": []
         },
-        "sizeInBytes": 24247
+        "sizeInBytes": 16041
     },
     "FirebaseFirestore": {
         "dependencies": {
@@ -508,10 +467,7 @@
                 "debugAssert",
                 "fail",
                 "formatJSON",
-                "formatPlural",
                 "hardAssert",
-                "invalidClassError",
-                "isPlainObject",
                 "loadProtos",
                 "logDebug",
                 "logError",
@@ -521,39 +477,27 @@
                 "newDatastore",
                 "newSerializer",
                 "nodePromise",
-                "ordinal",
                 "primitiveComparator",
-                "registerFirestore",
-                "tryGetCustomObjectType",
-                "validateArgType",
-                "validateNamedArrayAtLeastNumberOfElements",
-                "validateType",
-                "valueDescription"
+                "registerFirestore"
             ],
             "classes": [
-                "BaseFieldPath",
-                "BasePath",
                 "DatabaseId",
                 "DatabaseInfo",
                 "Datastore",
                 "DatastoreImpl",
                 "Deferred",
-                "DocumentKey",
-                "FieldPath",
-                "FieldPath$1",
                 "FirebaseCredentialsProvider",
                 "Firestore",
                 "FirestoreError",
                 "GrpcConnection",
                 "JsonProtoSerializer",
                 "OAuthToken",
-                "ResourcePath",
                 "StreamBridge",
                 "User"
             ],
             "variables": []
         },
-        "sizeInBytes": 24154
+        "sizeInBytes": 15948
     },
     "GeoPoint": {
         "dependencies": {
@@ -565,7 +509,6 @@
                 "formatJSON",
                 "formatPlural",
                 "hardAssert",
-                "invalidClassError",
                 "isPlainObject",
                 "loadProtos",
                 "logDebug",
@@ -582,21 +525,15 @@
                 "tryGetCustomObjectType",
                 "validateArgType",
                 "validateExactNumberOfArgs",
-                "validateNamedArrayAtLeastNumberOfElements",
                 "validateType",
                 "valueDescription"
             ],
             "classes": [
-                "BaseFieldPath",
-                "BasePath",
                 "DatabaseId",
                 "DatabaseInfo",
                 "Datastore",
                 "DatastoreImpl",
                 "Deferred",
-                "DocumentKey",
-                "FieldPath",
-                "FieldPath$1",
                 "FirebaseCredentialsProvider",
                 "Firestore",
                 "FirestoreError",
@@ -604,13 +541,12 @@
                 "GrpcConnection",
                 "JsonProtoSerializer",
                 "OAuthToken",
-                "ResourcePath",
                 "StreamBridge",
                 "User"
             ],
             "variables": []
         },
-        "sizeInBytes": 25247
+        "sizeInBytes": 18837
     },
     "Query": {
         "dependencies": {
@@ -778,7 +714,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 87202
+        "sizeInBytes": 87105
     },
     "QueryDocumentSnapshot": {
         "dependencies": {
@@ -863,7 +799,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 37609
+        "sizeInBytes": 37510
     },
     "QuerySnapshot": {
         "dependencies": {
@@ -873,10 +809,7 @@
                 "debugAssert",
                 "fail",
                 "formatJSON",
-                "formatPlural",
                 "hardAssert",
-                "invalidClassError",
-                "isPlainObject",
                 "loadProtos",
                 "logDebug",
                 "logError",
@@ -886,26 +819,15 @@
                 "newDatastore",
                 "newSerializer",
                 "nodePromise",
-                "ordinal",
                 "primitiveComparator",
-                "registerFirestore",
-                "tryGetCustomObjectType",
-                "validateArgType",
-                "validateNamedArrayAtLeastNumberOfElements",
-                "validateType",
-                "valueDescription"
+                "registerFirestore"
             ],
             "classes": [
-                "BaseFieldPath",
-                "BasePath",
                 "DatabaseId",
                 "DatabaseInfo",
                 "Datastore",
                 "DatastoreImpl",
                 "Deferred",
-                "DocumentKey",
-                "FieldPath",
-                "FieldPath$1",
                 "FirebaseCredentialsProvider",
                 "Firestore",
                 "FirestoreError",
@@ -913,13 +835,12 @@
                 "JsonProtoSerializer",
                 "OAuthToken",
                 "QuerySnapshot",
-                "ResourcePath",
                 "StreamBridge",
                 "User"
             ],
             "variables": []
         },
-        "sizeInBytes": 24388
+        "sizeInBytes": 16182
     },
     "Timestamp": {
         "dependencies": {
@@ -929,10 +850,7 @@
                 "debugAssert",
                 "fail",
                 "formatJSON",
-                "formatPlural",
                 "hardAssert",
-                "invalidClassError",
-                "isPlainObject",
                 "loadProtos",
                 "logDebug",
                 "logError",
@@ -942,40 +860,28 @@
                 "newDatastore",
                 "newSerializer",
                 "nodePromise",
-                "ordinal",
                 "primitiveComparator",
-                "registerFirestore",
-                "tryGetCustomObjectType",
-                "validateArgType",
-                "validateNamedArrayAtLeastNumberOfElements",
-                "validateType",
-                "valueDescription"
+                "registerFirestore"
             ],
             "classes": [
-                "BaseFieldPath",
-                "BasePath",
                 "DatabaseId",
                 "DatabaseInfo",
                 "Datastore",
                 "DatastoreImpl",
                 "Deferred",
-                "DocumentKey",
-                "FieldPath",
-                "FieldPath$1",
                 "FirebaseCredentialsProvider",
                 "Firestore",
                 "FirestoreError",
                 "GrpcConnection",
                 "JsonProtoSerializer",
                 "OAuthToken",
-                "ResourcePath",
                 "StreamBridge",
                 "Timestamp",
                 "User"
             ],
             "variables": []
         },
-        "sizeInBytes": 25690
+        "sizeInBytes": 17484
     },
     "Transaction": {
         "dependencies": {
@@ -1112,7 +1018,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 68364
+        "sizeInBytes": 68267
     },
     "WriteBatch": {
         "dependencies": {
@@ -1224,7 +1130,6 @@
                 "DeleteFieldValueImpl",
                 "DeleteMutation",
                 "Document",
-                "DocumentKey",
                 "DocumentKeyReference",
                 "DocumentReference",
                 "FieldMask",
@@ -1265,7 +1170,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 72158
+        "sizeInBytes": 71350
     },
     "addDoc": {
         "dependencies": {
@@ -1474,7 +1379,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 108269
+        "sizeInBytes": 108172
     },
     "arrayRemove": {
         "dependencies": {
@@ -1543,7 +1448,6 @@
                 "validateArgType",
                 "validateAtLeastNumberOfArgs",
                 "validateExactNumberOfArgs",
-                "validateNamedArrayAtLeastNumberOfElements",
                 "validatePlainObject",
                 "validateType",
                 "valueDescription",
@@ -1552,7 +1456,6 @@
             "classes": [
                 "ArrayRemoveFieldValueImpl",
                 "ArrayRemoveTransformOperation",
-                "BaseFieldPath",
                 "BasePath",
                 "Blob",
                 "ByteString",
@@ -1561,10 +1464,7 @@
                 "Datastore",
                 "DatastoreImpl",
                 "Deferred",
-                "DocumentKey",
                 "DocumentKeyReference",
-                "FieldPath",
-                "FieldPath$1",
                 "FieldTransform",
                 "FieldValue",
                 "FieldValueDelegate",
@@ -1584,7 +1484,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 44182
+        "sizeInBytes": 40675
     },
     "arrayUnion": {
         "dependencies": {
@@ -1653,7 +1553,6 @@
                 "validateArgType",
                 "validateAtLeastNumberOfArgs",
                 "validateExactNumberOfArgs",
-                "validateNamedArrayAtLeastNumberOfElements",
                 "validatePlainObject",
                 "validateType",
                 "valueDescription",
@@ -1662,7 +1561,6 @@
             "classes": [
                 "ArrayUnionFieldValueImpl",
                 "ArrayUnionTransformOperation",
-                "BaseFieldPath",
                 "BasePath",
                 "Blob",
                 "ByteString",
@@ -1671,10 +1569,7 @@
                 "Datastore",
                 "DatastoreImpl",
                 "Deferred",
-                "DocumentKey",
                 "DocumentKeyReference",
-                "FieldPath",
-                "FieldPath$1",
                 "FieldTransform",
                 "FieldValue",
                 "FieldValueDelegate",
@@ -1694,7 +1589,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 44190
+        "sizeInBytes": 40683
     },
     "collection": {
         "dependencies": {
@@ -1878,7 +1773,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 98619
+        "sizeInBytes": 98522
     },
     "collectionGroup": {
         "dependencies": {
@@ -2060,7 +1955,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 98050
+        "sizeInBytes": 97954
     },
     "deleteDoc": {
         "dependencies": {
@@ -2079,13 +1974,11 @@
                 "encodeBase64",
                 "fail",
                 "formatJSON",
-                "formatPlural",
                 "fullyQualifiedPrefixPath",
                 "geoPointEquals",
                 "getEncodedDatabaseId",
                 "getLocalWriteTime",
                 "hardAssert",
-                "invalidClassError",
                 "invokeCommitRpc",
                 "isArray",
                 "isDouble",
@@ -2093,7 +1986,6 @@
                 "isMapValue",
                 "isNegativeZero",
                 "isNumber",
-                "isPlainObject",
                 "isServerTimestamp",
                 "loadProtos",
                 "logDebug",
@@ -2110,7 +2002,6 @@
                 "numberEquals",
                 "objectEquals",
                 "objectSize",
-                "ordinal",
                 "primitiveComparator",
                 "registerFirestore",
                 "serverTimestamp",
@@ -2126,19 +2017,13 @@
                 "toResourceName",
                 "toTimestamp",
                 "toVersion",
-                "tryGetCustomObjectType",
                 "typeOrder",
                 "uint8ArrayFromBinaryString",
-                "validateArgType",
-                "validateNamedArrayAtLeastNumberOfElements",
-                "validateType",
-                "valueDescription",
                 "valueEquals"
             ],
             "classes": [
                 "ArrayRemoveTransformOperation",
                 "ArrayUnionTransformOperation",
-                "BaseFieldPath",
                 "BasePath",
                 "ByteString",
                 "DatabaseId",
@@ -2148,11 +2033,9 @@
                 "Deferred",
                 "DeleteMutation",
                 "Document",
-                "DocumentKey",
                 "DocumentKeyReference",
                 "DocumentReference",
                 "FieldPath",
-                "FieldPath$1",
                 "FirebaseCredentialsProvider",
                 "Firestore",
                 "FirestoreError",
@@ -2180,7 +2063,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 53665
+        "sizeInBytes": 49685
     },
     "deleteField": {
         "dependencies": {
@@ -2191,10 +2074,7 @@
                 "deleteField",
                 "fail",
                 "formatJSON",
-                "formatPlural",
                 "hardAssert",
-                "invalidClassError",
-                "isPlainObject",
                 "loadProtos",
                 "logDebug",
                 "logError",
@@ -2204,27 +2084,16 @@
                 "newDatastore",
                 "newSerializer",
                 "nodePromise",
-                "ordinal",
                 "primitiveComparator",
-                "registerFirestore",
-                "tryGetCustomObjectType",
-                "validateArgType",
-                "validateNamedArrayAtLeastNumberOfElements",
-                "validateType",
-                "valueDescription"
+                "registerFirestore"
             ],
             "classes": [
-                "BaseFieldPath",
-                "BasePath",
                 "DatabaseId",
                 "DatabaseInfo",
                 "Datastore",
                 "DatastoreImpl",
                 "Deferred",
                 "DeleteFieldValueImpl",
-                "DocumentKey",
-                "FieldPath",
-                "FieldPath$1",
                 "FieldValue",
                 "FieldValueDelegate",
                 "FirebaseCredentialsProvider",
@@ -2233,14 +2102,13 @@
                 "GrpcConnection",
                 "JsonProtoSerializer",
                 "OAuthToken",
-                "ResourcePath",
                 "SerializableFieldValue",
                 "StreamBridge",
                 "User"
             ],
             "variables": []
         },
-        "sizeInBytes": 25321
+        "sizeInBytes": 17115
     },
     "doc": {
         "dependencies": {
@@ -2426,7 +2294,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 99440
+        "sizeInBytes": 99343
     },
     "documentId": {
         "dependencies": {
@@ -2440,7 +2308,6 @@
                 "formatJSON",
                 "formatPlural",
                 "hardAssert",
-                "invalidClassError",
                 "isPlainObject",
                 "loadProtos",
                 "logDebug",
@@ -2468,9 +2335,7 @@
                 "Datastore",
                 "DatastoreImpl",
                 "Deferred",
-                "DocumentKey",
                 "FieldPath",
-                "FieldPath$1",
                 "FieldPath$2",
                 "FirebaseCredentialsProvider",
                 "Firestore",
@@ -2478,13 +2343,12 @@
                 "GrpcConnection",
                 "JsonProtoSerializer",
                 "OAuthToken",
-                "ResourcePath",
                 "StreamBridge",
                 "User"
             ],
             "variables": []
         },
-        "sizeInBytes": 24798
+        "sizeInBytes": 22866
     },
     "getDoc": {
         "dependencies": {
@@ -2601,7 +2465,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 46997
+        "sizeInBytes": 46898
     },
     "getFirestore": {
         "dependencies": {
@@ -2611,11 +2475,8 @@
                 "debugAssert",
                 "fail",
                 "formatJSON",
-                "formatPlural",
                 "getFirestore",
                 "hardAssert",
-                "invalidClassError",
-                "isPlainObject",
                 "loadProtos",
                 "logDebug",
                 "logError",
@@ -2625,39 +2486,27 @@
                 "newDatastore",
                 "newSerializer",
                 "nodePromise",
-                "ordinal",
                 "primitiveComparator",
-                "registerFirestore",
-                "tryGetCustomObjectType",
-                "validateArgType",
-                "validateNamedArrayAtLeastNumberOfElements",
-                "validateType",
-                "valueDescription"
+                "registerFirestore"
             ],
             "classes": [
-                "BaseFieldPath",
-                "BasePath",
                 "DatabaseId",
                 "DatabaseInfo",
                 "Datastore",
                 "DatastoreImpl",
                 "Deferred",
-                "DocumentKey",
-                "FieldPath",
-                "FieldPath$1",
                 "FirebaseCredentialsProvider",
                 "Firestore",
                 "FirestoreError",
                 "GrpcConnection",
                 "JsonProtoSerializer",
                 "OAuthToken",
-                "ResourcePath",
                 "StreamBridge",
                 "User"
             ],
             "variables": []
         },
-        "sizeInBytes": 24233
+        "sizeInBytes": 16027
     },
     "getQuery": {
         "dependencies": {
@@ -2848,7 +2697,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 93121
+        "sizeInBytes": 93024
     },
     "increment": {
         "dependencies": {
@@ -2917,14 +2766,12 @@
                 "uint8ArrayFromBinaryString",
                 "validateArgType",
                 "validateExactNumberOfArgs",
-                "validateNamedArrayAtLeastNumberOfElements",
                 "validatePlainObject",
                 "validateType",
                 "valueDescription",
                 "valueEquals"
             ],
             "classes": [
-                "BaseFieldPath",
                 "BasePath",
                 "Blob",
                 "ByteString",
@@ -2933,10 +2780,7 @@
                 "Datastore",
                 "DatastoreImpl",
                 "Deferred",
-                "DocumentKey",
                 "DocumentKeyReference",
-                "FieldPath",
-                "FieldPath$1",
                 "FieldTransform",
                 "FieldValue",
                 "FieldValueDelegate",
@@ -2958,7 +2802,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 44121
+        "sizeInBytes": 40614
     },
     "initializeFirestore": {
         "dependencies": {
@@ -2968,11 +2812,8 @@
                 "debugAssert",
                 "fail",
                 "formatJSON",
-                "formatPlural",
                 "hardAssert",
                 "initializeFirestore",
-                "invalidClassError",
-                "isPlainObject",
                 "loadProtos",
                 "logDebug",
                 "logError",
@@ -2982,39 +2823,27 @@
                 "newDatastore",
                 "newSerializer",
                 "nodePromise",
-                "ordinal",
                 "primitiveComparator",
-                "registerFirestore",
-                "tryGetCustomObjectType",
-                "validateArgType",
-                "validateNamedArrayAtLeastNumberOfElements",
-                "validateType",
-                "valueDescription"
+                "registerFirestore"
             ],
             "classes": [
-                "BaseFieldPath",
-                "BasePath",
                 "DatabaseId",
                 "DatabaseInfo",
                 "Datastore",
                 "DatastoreImpl",
                 "Deferred",
-                "DocumentKey",
-                "FieldPath",
-                "FieldPath$1",
                 "FirebaseCredentialsProvider",
                 "Firestore",
                 "FirestoreError",
                 "GrpcConnection",
                 "JsonProtoSerializer",
                 "OAuthToken",
-                "ResourcePath",
                 "StreamBridge",
                 "User"
             ],
             "variables": []
         },
-        "sizeInBytes": 24319
+        "sizeInBytes": 16113
     },
     "parent": {
         "dependencies": {
@@ -3197,7 +3026,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 98334
+        "sizeInBytes": 98237
     },
     "queryEqual": {
         "dependencies": {
@@ -3366,7 +3195,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 87406
+        "sizeInBytes": 87309
     },
     "refEqual": {
         "dependencies": {
@@ -3549,7 +3378,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 98276
+        "sizeInBytes": 98179
     },
     "runTransaction": {
         "dependencies": {
@@ -3729,7 +3558,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 90952
+        "sizeInBytes": 90855
     },
     "serverTimestamp": {
         "dependencies": {
@@ -3739,10 +3568,7 @@
                 "debugAssert",
                 "fail",
                 "formatJSON",
-                "formatPlural",
                 "hardAssert",
-                "invalidClassError",
-                "isPlainObject",
                 "loadProtos",
                 "logDebug",
                 "logError",
@@ -3752,28 +3578,17 @@
                 "newDatastore",
                 "newSerializer",
                 "nodePromise",
-                "ordinal",
                 "primitiveComparator",
                 "registerFirestore",
                 "serverTimestamp",
-                "serverTimestamp$1",
-                "tryGetCustomObjectType",
-                "validateArgType",
-                "validateNamedArrayAtLeastNumberOfElements",
-                "validateType",
-                "valueDescription"
+                "serverTimestamp$1"
             ],
             "classes": [
-                "BaseFieldPath",
-                "BasePath",
                 "DatabaseId",
                 "DatabaseInfo",
                 "Datastore",
                 "DatastoreImpl",
                 "Deferred",
-                "DocumentKey",
-                "FieldPath",
-                "FieldPath$1",
                 "FieldTransform",
                 "FieldValue",
                 "FieldValueDelegate",
@@ -3783,7 +3598,6 @@
                 "GrpcConnection",
                 "JsonProtoSerializer",
                 "OAuthToken",
-                "ResourcePath",
                 "SerializableFieldValue",
                 "ServerTimestampFieldValueImpl",
                 "ServerTimestampTransform",
@@ -3792,7 +3606,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 26107
+        "sizeInBytes": 17901
     },
     "setDoc": {
         "dependencies": {
@@ -3904,7 +3718,6 @@
                 "DeleteFieldValueImpl",
                 "DeleteMutation",
                 "Document",
-                "DocumentKey",
                 "DocumentKeyReference",
                 "DocumentReference",
                 "FieldMask",
@@ -3943,7 +3756,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 70457
+        "sizeInBytes": 69649
     },
     "setLogLevel": {
         "dependencies": {
@@ -3953,10 +3766,7 @@
                 "debugAssert",
                 "fail",
                 "formatJSON",
-                "formatPlural",
                 "hardAssert",
-                "invalidClassError",
-                "isPlainObject",
                 "loadProtos",
                 "logDebug",
                 "logError",
@@ -3966,40 +3776,28 @@
                 "newDatastore",
                 "newSerializer",
                 "nodePromise",
-                "ordinal",
                 "primitiveComparator",
                 "registerFirestore",
-                "setLogLevel",
-                "tryGetCustomObjectType",
-                "validateArgType",
-                "validateNamedArrayAtLeastNumberOfElements",
-                "validateType",
-                "valueDescription"
+                "setLogLevel"
             ],
             "classes": [
-                "BaseFieldPath",
-                "BasePath",
                 "DatabaseId",
                 "DatabaseInfo",
                 "Datastore",
                 "DatastoreImpl",
                 "Deferred",
-                "DocumentKey",
-                "FieldPath",
-                "FieldPath$1",
                 "FirebaseCredentialsProvider",
                 "Firestore",
                 "FirestoreError",
                 "GrpcConnection",
                 "JsonProtoSerializer",
                 "OAuthToken",
-                "ResourcePath",
                 "StreamBridge",
                 "User"
             ],
             "variables": []
         },
-        "sizeInBytes": 24198
+        "sizeInBytes": 15992
     },
     "snapshotEqual": {
         "dependencies": {
@@ -4170,7 +3968,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 88139
+        "sizeInBytes": 88042
     },
     "terminate": {
         "dependencies": {
@@ -4182,10 +3980,7 @@
                 "debugCast",
                 "fail",
                 "formatJSON",
-                "formatPlural",
                 "hardAssert",
-                "invalidClassError",
-                "isPlainObject",
                 "loadProtos",
                 "logDebug",
                 "logError",
@@ -4195,41 +3990,29 @@
                 "newDatastore",
                 "newSerializer",
                 "nodePromise",
-                "ordinal",
                 "primitiveComparator",
                 "registerFirestore",
                 "terminate",
-                "terminateDatastore",
-                "tryGetCustomObjectType",
-                "validateArgType",
-                "validateNamedArrayAtLeastNumberOfElements",
-                "validateType",
-                "valueDescription"
+                "terminateDatastore"
             ],
             "classes": [
-                "BaseFieldPath",
-                "BasePath",
                 "DatabaseId",
                 "DatabaseInfo",
                 "Datastore",
                 "DatastoreImpl",
                 "Deferred",
-                "DocumentKey",
-                "FieldPath",
-                "FieldPath$1",
                 "FirebaseCredentialsProvider",
                 "Firestore",
                 "FirestoreError",
                 "GrpcConnection",
                 "JsonProtoSerializer",
                 "OAuthToken",
-                "ResourcePath",
                 "StreamBridge",
                 "User"
             ],
             "variables": []
         },
-        "sizeInBytes": 24991
+        "sizeInBytes": 16785
     },
     "updateDoc": {
         "dependencies": {
@@ -4340,7 +4123,6 @@
                 "DeleteFieldValueImpl",
                 "DeleteMutation",
                 "Document",
-                "DocumentKey",
                 "DocumentKeyReference",
                 "DocumentReference",
                 "FieldMask",
@@ -4380,7 +4162,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 70548
+        "sizeInBytes": 69740
     },
     "writeBatch": {
         "dependencies": {
@@ -4493,7 +4275,6 @@
                 "DeleteFieldValueImpl",
                 "DeleteMutation",
                 "Document",
-                "DocumentKey",
                 "DocumentKeyReference",
                 "DocumentReference",
                 "FieldMask",
@@ -4534,6 +4315,6 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 72238
+        "sizeInBytes": 71430
     }
 }

--- a/packages/firestore/src/api/database.ts
+++ b/packages/firestore/src/api/database.ts
@@ -613,7 +613,7 @@ export class Firestore implements firestore.FirebaseFirestore, FirebaseService {
     }
     this.ensureClientConfigured();
     return new Query(
-      new InternalQuery(ResourcePath.EMPTY_PATH, collectionId),
+      new InternalQuery(ResourcePath.emptyPath(), collectionId),
       this,
       /* converter= */ null
     );

--- a/packages/firestore/src/api/field_path.ts
+++ b/packages/firestore/src/api/field_path.ts
@@ -76,18 +76,14 @@ export class FieldPath extends BaseFieldPath implements firestore.FieldPath {
     super(fieldNames);
   }
 
-  /**
-   * Internal Note: The backend doesn't technically support querying by
-   * document ID. Instead it queries by the entire document name (full path
-   * included), but in the cases we currently support documentId(), the net
-   * effect is the same.
-   */
-  private static readonly _DOCUMENT_ID = new FieldPath(
-    InternalFieldPath.keyField().canonicalString()
-  );
-
   static documentId(): FieldPath {
-    return FieldPath._DOCUMENT_ID;
+    /**
+     * Internal Note: The backend doesn't technically support querying by
+     * document ID. Instead it queries by the entire document name (full path
+     * included), but in the cases we currently support documentId(), the net
+     * effect is the same.
+     */
+    return new FieldPath(InternalFieldPath.keyField().canonicalString());
   }
 
   isEqual(other: firestore.FieldPath): boolean {

--- a/packages/firestore/src/api/user_data_reader.ts
+++ b/packages/firestore/src/api/user_data_reader.ts
@@ -485,7 +485,7 @@ export class UserDataReader {
       {
         dataSource,
         methodName,
-        path: FieldPath.EMPTY_PATH,
+        path: FieldPath.emptyPath(),
         arrayElement: false
       },
       this.databaseId,

--- a/packages/firestore/src/local/encoded_resource_path.ts
+++ b/packages/firestore/src/local/encoded_resource_path.ts
@@ -124,7 +124,7 @@ export function decodeResourcePath(path: EncodedResourcePath): ResourcePath {
       path.charAt(0) === escapeChar && path.charAt(1) === encodedSeparatorChar,
       'Non-empty path ' + path + ' had length 2'
     );
-    return ResourcePath.EMPTY_PATH;
+    return ResourcePath.emptyPath();
   }
 
   // Escape characters cannot exist past the second-to-last position in the

--- a/packages/firestore/src/local/reference_set.ts
+++ b/packages/firestore/src/local/reference_set.ts
@@ -20,6 +20,7 @@ import { documentKeySet, DocumentKeySet } from '../model/collections';
 import { DocumentKey } from '../model/document_key';
 import { primitiveComparator } from '../util/misc';
 import { SortedSet } from '../util/sorted_set';
+import { ResourcePath } from '../model/path';
 
 /**
  * A collection of references to a document from some kind of numbered entity
@@ -77,7 +78,7 @@ export class ReferenceSet {
    * removed.
    */
   removeReferencesForId(id: TargetId | BatchId): DocumentKey[] {
-    const emptyKey = DocumentKey.EMPTY;
+    const emptyKey = new DocumentKey(new ResourcePath([]));
     const startRef = new DocReference(emptyKey, id);
     const endRef = new DocReference(emptyKey, id + 1);
     const keys: DocumentKey[] = [];
@@ -98,7 +99,7 @@ export class ReferenceSet {
   }
 
   referencesForId(id: TargetId | BatchId): DocumentKeySet {
-    const emptyKey = DocumentKey.EMPTY;
+    const emptyKey = new DocumentKey(new ResourcePath([]));
     const startRef = new DocReference(emptyKey, id);
     const endRef = new DocReference(emptyKey, id + 1);
     let keys = documentKeySet();

--- a/packages/firestore/src/model/document_key.ts
+++ b/packages/firestore/src/model/document_key.ts
@@ -50,8 +50,6 @@ export class DocumentKey {
     return this.path.toString();
   }
 
-  static EMPTY = new DocumentKey(new ResourcePath([]));
-
   static comparator(k1: DocumentKey, k2: DocumentKey): number {
     return ResourcePath.comparator(k1.path, k2.path);
   }

--- a/packages/firestore/src/model/object_value.ts
+++ b/packages/firestore/src/model/object_value.ts
@@ -181,7 +181,7 @@ export class ObjectValueBuilder {
   /** Returns an ObjectValue with all mutations applied. */
   build(): ObjectValue {
     const mergedResult = this.applyOverlay(
-      FieldPath.EMPTY_PATH,
+      FieldPath.emptyPath(),
       this.overlayMap
     );
     if (mergedResult != null) {
@@ -197,7 +197,7 @@ export class ObjectValueBuilder {
    * changes).
    *
    * @param currentPath The path at the current nesting level. Can be set to
-   * FieldValue.EMPTY_PATH to represent the root.
+   * FieldValue.emptyPath() to represent the root.
    * @param currentOverlays The overlays at the current nesting level in the
    * same format as `overlayMap`.
    * @return The merged data at `currentPath` or null if no modifications

--- a/packages/firestore/src/model/path.ts
+++ b/packages/firestore/src/model/path.ts
@@ -234,7 +234,9 @@ export class ResourcePath extends BasePath<ResourcePath> {
     return new ResourcePath(segments);
   }
 
-  static EMPTY_PATH = new ResourcePath([]);
+  static emptyPath(): ResourcePath {
+    return new ResourcePath([]);
+  }
 }
 
 const identifierRegExp = /^[_a-zA-Z][_a-zA-Z0-9]*$/;
@@ -357,5 +359,7 @@ export class FieldPath extends BasePath<FieldPath> {
     return new FieldPath(segments);
   }
 
-  static EMPTY_PATH = new FieldPath([]);
+  static emptyPath(): FieldPath {
+    return new FieldPath([]);
+  }
 }

--- a/packages/firestore/src/remote/serializer.ts
+++ b/packages/firestore/src/remote/serializer.ts
@@ -348,7 +348,7 @@ function fromQueryPath(name: string): ResourcePath {
   // ability to read the v1beta1 form for compatibility with queries persisted
   // in the local target cache.
   if (resourceName.length === 4) {
-    return ResourcePath.EMPTY_PATH;
+    return ResourcePath.emptyPath();
   }
   return extractLocalPathFromResourceName(resourceName);
 }

--- a/packages/firestore/test/unit/local/encoded_resource_path.test.ts
+++ b/packages/firestore/test/unit/local/encoded_resource_path.test.ts
@@ -74,7 +74,7 @@ describe('EncodedResourcePath', () => {
   after(() => SimpleDb.delete(dbName));
 
   it('encodes resource paths', async () => {
-    await assertEncoded(sep, ResourcePath.EMPTY_PATH);
+    await assertEncoded(sep, ResourcePath.emptyPath());
     await assertEncoded('\u0001\u0010' + sep, path('\0'));
     await assertEncoded('\u0002' + sep, path('\u0002'));
 
@@ -102,7 +102,7 @@ describe('EncodedResourcePath', () => {
 
   it('orders resource paths', async () => {
     await assertOrdered([
-      ResourcePath.EMPTY_PATH,
+      ResourcePath.emptyPath(),
       path('\0'),
       path('\u0001'),
       path('\u0002'),
@@ -117,7 +117,7 @@ describe('EncodedResourcePath', () => {
     ]);
 
     await assertOrdered([
-      ResourcePath.EMPTY_PATH,
+      ResourcePath.emptyPath(),
       path('foo'),
       new ResourcePath(['foo', '']),
       new ResourcePath(['foo', 'bar']),

--- a/packages/firestore/test/unit/specs/query_spec.test.ts
+++ b/packages/firestore/test/unit/specs/query_spec.test.ts
@@ -38,7 +38,7 @@ function specWithCachedDocs(...docs: Document[]): SpecBuilder {
 
 describeSpec('Queries:', [], () => {
   specTest('Collection Group query', [], () => {
-    const cgQuery = new Query(ResourcePath.EMPTY_PATH, 'cg');
+    const cgQuery = new Query(ResourcePath.emptyPath(), 'cg');
     const cgQueryWithFilter = cgQuery.addFilter(filter('val', '==', 1));
     const docs = [
       doc('cg/1', 1000, { val: 1 }),
@@ -61,7 +61,7 @@ describeSpec('Queries:', [], () => {
   });
 
   specTest('Collection Group query with mutations', [], () => {
-    const cgQuery = new Query(ResourcePath.EMPTY_PATH, 'cg');
+    const cgQuery = new Query(ResourcePath.emptyPath(), 'cg');
     const cgQueryWithFilter = cgQuery.addFilter(filter('val', '==', 1));
     const cachedDocs = [
       doc('cg/1', 1000, { val: 1 }),


### PR DESCRIPTION
This changes:

- ResourcePath.EMPTY_PATH to ResourcePath.emptyPath()
- FIeldPath.EMPTYPATH to FIeldPath.emptyPath()
- FIeldPath._DOCUMENT_ID (inlined, only 1 usage)
- DocumentKey.EMPTY ((inlined, only 2 usages)