### PR TITLE
Add yarn script that runs tests on non-exp packages only

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "pretest": "node tools/pretest.js",
     "test": "lerna run --concurrency 4 --stream test",
     "test:ci": "lerna run --concurrency 4 --stream test:ci",
+    "test:release": "lerna run --concurrency 4 --ignore @firebase/*-exp --ignore firebase-exp --stream test:ci",
     "test:exp": "lerna run --concurrency 4 --stream --scope @firebase/*-exp --scope firebase-exp test",
     "pretest:coverage": "mkdirp coverage",
     "ci:coverage": "lcov-result-merger 'packages/**/lcov.info' 'lcov-all.info'",

--- a/scripts/release/utils/tests.js
+++ b/scripts/release/utils/tests.js
@@ -21,7 +21,7 @@ const ora = require('ora');
 
 exports.runTests = async () => {
   try {
-    await spawn('yarn', ['test'], {
+    await spawn('yarn', ['test:release'], {
       cwd: root,
       stdio: 'inherit'
     });


### PR DESCRIPTION
Need this script for release, to avoid testing unbuilt -exp packages.

Also switch to `test:ci` because we don't need passing tests to be that verbose during release.