### PR TITLE
Don't delay retryable operations

### DIFF
--- a/packages/firestore/test/unit/specs/recovery_spec.test.ts
+++ b/packages/firestore/test/unit/specs/recovery_spec.test.ts
@@ -787,6 +787,7 @@ describeSpec('Persistence Recovery', ['no-ios', 'no-android'], () => {
           .expectActiveTargets({ query })
           // We are now user 2
           .expectEvents(query, { removed: [doc1], fromCache: true })
+          .runTimer(TimerId.AsyncQueueRetry)
           // We are now user 1
           .expectEvents(query, {
             added: [doc1],

--- a/packages/firestore/test/unit/specs/spec_test_runner.ts
+++ b/packages/firestore/test/unit/specs/spec_test_runner.ts
@@ -277,7 +277,7 @@ abstract class TestRunner {
   }
 
   async shutdown(): Promise<void> {
-    await this.queue.enqueue(async () => {
+    await this.queue.enqueueAndInitiateShutdown(async () => {
       if (this.started) {
         await this.doShutdown();
       }

--- a/packages/firestore/test/unit/util/async_queue.test.ts
+++ b/packages/firestore/test/unit/util/async_queue.test.ts
@@ -297,8 +297,7 @@ describe('AsyncQueue', () => {
 
     queue.enqueueRetryable(async () => {
       doStep(1);
-      if (completedSteps.length > 1) {
-      } else {
+      if (completedSteps.length === 1) {
         throw new IndexedDbTransactionError(
           new Error('Simulated retryable error')
         );
@@ -311,6 +310,65 @@ describe('AsyncQueue', () => {
 
     await blockingPromise.promise;
     expect(completedSteps).to.deep.equal([1, 1, 2]);
+  });
+
+  it('Doesn not delay retryable operations that succeed', async () => {
+    const queue = new AsyncQueue();
+    const completedSteps: number[] = [];
+    const doStep = (n: number): void => {
+      completedSteps.push(n);
+    };
+
+    queue.enqueueRetryable(async () => {
+      doStep(1);
+    });
+    queue.enqueueAndForget(async () => {
+      doStep(2);
+    });
+    await queue.enqueue(async () => {
+      doStep(3);
+    });
+
+    expect(completedSteps).to.deep.equal([1, 2, 3]);
+  });
+
+  it('Catches up when retryable operation fails', async () => {
+    const queue = new AsyncQueue();
+    const completedSteps: number[] = [];
+    const doStep = (n: number): void => {
+      completedSteps.push(n);
+    };
+
+    const blockingPromise = new Deferred<void>();
+
+    queue.enqueueRetryable(async () => {
+      doStep(1);
+      if (completedSteps.length === 1) {
+        throw new IndexedDbTransactionError(
+          new Error('Simulated retryable error')
+        );
+      }
+    });
+    queue.enqueueAndForget(async () => {
+      doStep(2);
+    });
+    queue.enqueueRetryable(async () => {
+      doStep(3);
+      blockingPromise.resolve();
+    });
+    await blockingPromise.promise;
+
+    // Once all existing retryable operations succeeded, they are scheduled
+    // in the order they are enqueued.
+    queue.enqueueAndForget(async () => {
+      doStep(4);
+    });
+    await queue.enqueue(async () => {
+      doStep(5);
+    });
+
+    await blockingPromise.promise;
+    expect(completedSteps).to.deep.equal([1, 2, 1, 3, 4, 5]);
   });
 
   it('Can drain (non-delayed) operations', async () => {

--- a/packages/firestore/test/unit/util/async_queue.test.ts
+++ b/packages/firestore/test/unit/util/async_queue.test.ts
@@ -312,7 +312,7 @@ describe('AsyncQueue', () => {
     expect(completedSteps).to.deep.equal([1, 1, 2]);
   });
 
-  it('Doesn not delay retryable operations that succeed', async () => {
+  it('Does not delay retryable operations that succeed', async () => {
     const queue = new AsyncQueue();
     const completedSteps: number[] = [];
     const doStep = (n: number): void => {


### PR DESCRIPTION
One of the behavior changes of `enqueueRetryable` (https://github.com/firebase/firebase-js-sdk/pull/2879) was that it only scheduled the next operation when the first operation succeeds. This means that any operation that was scheduled after the second retryable operation will run before this run:

```
enqueue(console.log(1))
enqueueRetryable(console.log(2))
enqueueRetryable(console.log(3))
enqueue(console.log(4))

-> prints 1,2,4,3 since 3 is only enqueued once 2 finishes
```

While theoretically okay, this still seems to cause some issues with the user change. This PR changes the retry behavior so that operations run in the original order if no failure occurred. 

Addresses https://github.com/firebase/firebase-js-sdk/issues/3218