### PR TITLE
Fix updateToken

### DIFF
--- a/.changeset/cuddly-rivers-add.md
+++ b/.changeset/cuddly-rivers-add.md
@@ -1,0 +1,6 @@
+---
+"@firebase/messaging": patch
+"firebase": patch
+---
+
+Fixed an issue where we try to update token for every getToken() call because we don't save the updated token in the IndexedDB.

--- a/packages/messaging/src/core/token-management.ts
+++ b/packages/messaging/src/core/token-management.ts
@@ -118,9 +118,9 @@ async function updateToken(
     );
 
     const updatedTokenDetails: TokenDetails = {
+      ...tokenDetails,
       token: updatedToken,
-      createTime: Date.now(),
-      ...tokenDetails
+      createTime: Date.now()
     };
 
     await dbSet(firebaseDependencies, updatedTokenDetails);


### PR DESCRIPTION
It seems we are saving the old token back to indexeddb instead of the new token. The PR fixes it.