### PR TITLE
Make onSnapshot work with rxjs observers

### DIFF
--- a/.changeset/thin-ligers-fold.md
+++ b/.changeset/thin-ligers-fold.md
@@ -1,0 +1,6 @@
+---
+"@firebase/firestore": patch
+"firebase": patch
+---
+
+Fixed an issue where `onSnapshot` doesn't work with rxjs [Observer](https://rxjs-dev.firebaseapp.com/guide/observer).

--- a/.changeset/thin-ligers-fold.md
+++ b/.changeset/thin-ligers-fold.md
@@ -1,6 +1,2 @@
 ---
-"@firebase/firestore": patch
-"firebase": patch
 ---
-
-Fixed an issue where `onSnapshot` doesn't work with rxjs [Observer](https://rxjs-dev.firebaseapp.com/guide/observer).

--- a/packages/firestore/src/api/database.ts
+++ b/packages/firestore/src/api/database.ts
@@ -1169,9 +1169,9 @@ export class DocumentReference<T = firestore.DocumentData>
       const userObserver = args[currArg] as PartialObserver<
         firestore.DocumentSnapshot<T>
       >;
-      args[currArg] = userObserver.next;
-      args[currArg + 1] = userObserver.error;
-      args[currArg + 2] = userObserver.complete;
+      args[currArg] = userObserver.next?.bind(userObserver);
+      args[currArg + 1] = userObserver.error?.bind(userObserver);
+      args[currArg + 2] = userObserver.complete?.bind(userObserver);
     } else {
       validateArgType(
         'DocumentReference.onSnapshot',
@@ -2122,9 +2122,9 @@ export class Query<T = firestore.DocumentData> extends BaseQuery
       const userObserver = args[currArg] as PartialObserver<
         firestore.QuerySnapshot<T>
       >;
-      args[currArg] = userObserver.next;
-      args[currArg + 1] = userObserver.error;
-      args[currArg + 2] = userObserver.complete;
+      args[currArg] = userObserver.next?.bind(userObserver);
+      args[currArg + 1] = userObserver.error?.bind(userObserver);
+      args[currArg + 2] = userObserver.complete?.bind(userObserver);
     } else {
       validateArgType('Query.onSnapshot', 'function', currArg, args[currArg]);
       validateOptionalArgType(


### PR DESCRIPTION
It fixes an issue where passing rxjs `Observer` to `onSnapshot` causes error `Error: Uncaught TypeError: this._next is not a function`.
For example,
```
const data$ = rxjs.Observable.create(function subscribe(observer) {
  firebase.firestore().collection('test').onSnapshot(observer);
});

data$.subscribe({
  next: data => handleData(data)
});
```

A similar issue is being fixed for FCM - https://github.com/firebase/firebase-js-sdk/pull/3221
