### PR TITLE
Amendment for the Tree-Shakeable API

### DIFF
--- a/packages/firestore/exp/index.d.ts
+++ b/packages/firestore/exp/index.d.ts
@@ -67,7 +67,9 @@ export interface FirestoreDataConverter<T> {
   toFirestore(modelObject: Partial<T>, options: SetOptions): DocumentData;
   fromFirestore(
     snapshot: QueryDocumentSnapshot<DocumentData>,
-    options: SnapshotOptions
+    // Make optional to make this assignable to the converter in the Lite SDK
+    // This makes sure that the Lite API remains a true subset.
+    options?: SnapshotOptions
   ): T;
 }
 
@@ -249,6 +251,8 @@ export class DocumentReference<T = DocumentData> {
   readonly id: string;
   readonly firestore: FirebaseFirestore;
   readonly path: string;
+  // Add a 'converter' property to match Query
+  readonly converter: FirestoreDataConverter<T>|null;
   withConverter<U>(converter: FirestoreDataConverter<U>): DocumentReference<U>;
 }
 
@@ -288,6 +292,9 @@ export class Query<T = DocumentData> {
   protected constructor();
   readonly type: 'collection' | 'query';
   readonly firestore: FirebaseFirestore;
+  // Add a 'converter' property since Typescript cannot deduce the generic type
+  // param `T` if it is not referenced in the API.
+  readonly converter: FirestoreDataConverter<T>|null;
 
   withConverter<U>(converter: FirestoreDataConverter<U>): Query<U>;
 }

--- a/packages/firestore/lite/index.d.ts
+++ b/packages/firestore/lite/index.d.ts
@@ -201,6 +201,7 @@ export class DocumentReference<T = DocumentData> {
   readonly id: string;
   readonly firestore: FirebaseFirestore;
   readonly path: string;
+  readonly converter: FirestoreDataConverter<T>|null;
   withConverter<U>(converter: FirestoreDataConverter<U>): DocumentReference<U>;
 }
 
@@ -234,6 +235,7 @@ export class Query<T = DocumentData> {
   protected constructor();
   readonly type: 'collection' | 'query';
   readonly firestore: FirebaseFirestore;
+  readonly converter: FirestoreDataConverter<T>|null;
 
   withConverter<U>(converter: FirestoreDataConverter<U>): Query<U>;
 }


### PR DESCRIPTION
- Allow calls to `collection(coll, 'a/b')` on top of `collection(doc, 'a')`, which matches `collection(db, 'a/b')`
- Change `DocumentReference`/`CollectionReference`/`Query` to be non-ducktype compatible with one another.
- Make `Query` methods tree-shakebale using a new `QueryConstraint` type.
- Add a 'converter' property to `Query` and `DocumentReference` to help TypeScript infer the generic type.
- Update all `Error` types to `FirestoreError`
- Update `getQuery()` to `getDocs()`

Comments with rationale inline.