### PR TITLE
Temporarily remove firebase devDependency from rxfire

### DIFF
--- a/packages/rxfire/package.json
+++ b/packages/rxfire/package.json
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "firebase": "7.16.0",
-    "rollup": "2.21.0",
+    "rollup": "2.7.6",
     "rollup-plugin-commonjs": "10.1.0",
     "rollup-plugin-node-resolve": "5.2.0",
     "rollup-plugin-typescript2": "0.27.1",


### PR DESCRIPTION
Rxfire has a dependency on firebase in both peerDependencies and devDependencies, and when changesets script sees the peerDependency version requirement (a broad range) is met, it skips updating the devDependency version. This causes problems in our release process. Temporarily removing until we can make a PR to the Changesets project that may help fix this.