### PR TITLE
Add support for collection(coll) and doc(doc)

### DIFF
--- a/packages/firestore/exp/index.d.ts
+++ b/packages/firestore/exp/index.d.ts
@@ -110,6 +110,10 @@ export function collection(
   collectionPath: string
 ): CollectionReference<DocumentData>;
 export function collection(
+  reference: CollectionReference<unknown>,
+  collectionPath: string
+): CollectionReference<DocumentData>;
+export function collection(
   reference: DocumentReference,
   collectionPath: string
 ): CollectionReference<DocumentData>;
@@ -121,6 +125,10 @@ export function doc<T>(
   reference: CollectionReference<T>,
   documentPath?: string
 ): DocumentReference<T>;
+export function doc(
+  reference: DocumentReference<unknown>,
+  documentPath: string
+): DocumentReference<DocumentData>;
 export function parent(
   reference: CollectionReference<unknown>
 ): DocumentReference<DocumentData> | null;

--- a/packages/firestore/lite/index.d.ts
+++ b/packages/firestore/lite/index.d.ts
@@ -71,6 +71,10 @@ export function collection(
   collectionPath: string
 ): CollectionReference<DocumentData>;
 export function collection(
+  reference: CollectionReference<unknown>,
+  collectionPath: string
+): CollectionReference<DocumentData>;
+export function collection(
   reference: DocumentReference,
   collectionPath: string
 ): CollectionReference<DocumentData>;
@@ -82,6 +86,10 @@ export function doc<T>(
   reference: CollectionReference<T>,
   documentPath?: string
 ): DocumentReference<T>;
+export function doc(
+  reference: DocumentReference<unknown>,
+  documentPath: string
+): DocumentReference<DocumentData>;
 export function parent(
   reference: CollectionReference<unknown>
 ): DocumentReference<DocumentData> | null;

--- a/packages/firestore/lite/src/api/reference.ts
+++ b/packages/firestore/lite/src/api/reference.ts
@@ -284,24 +284,42 @@ export function collection(
   collectionPath: string
 ): CollectionReference<firestore.DocumentData>;
 export function collection(
+  reference: firestore.CollectionReference<unknown>,
+  collectionPath: string
+): CollectionReference<firestore.DocumentData>;
+export function collection(
   reference: firestore.DocumentReference,
   collectionPath: string
 ): CollectionReference<firestore.DocumentData>;
 export function collection(
-  parent: firestore.FirebaseFirestore | firestore.DocumentReference<unknown>,
+  parent:
+    | firestore.FirebaseFirestore
+    | firestore.DocumentReference<unknown>
+    | firestore.CollectionReference<unknown>,
   relativePath: string
 ): CollectionReference<firestore.DocumentData> {
   validateArgType('collection', 'non-empty string', 2, relativePath);
-  const path = ResourcePath.fromString(relativePath);
   if (parent instanceof Firestore) {
-    validateCollectionPath(path);
-    return new CollectionReference(parent, path, /* converter= */ null);
+    const absolutePath = ResourcePath.fromString(relativePath);
+    validateCollectionPath(absolutePath);
+    return new CollectionReference(parent, absolutePath, /* converter= */ null);
   } else {
-    const doc = cast(parent, DocumentReference);
-    const absolutePath = doc._key.path.child(path);
+    if (
+      !(parent instanceof DocumentReference) &&
+      !(parent instanceof CollectionReference)
+    ) {
+      throw new FirestoreError(
+        Code.INVALID_ARGUMENT,
+        'Expected first argument to collection() to be a CollectionReference, ' +
+          'a DocumentReference or FirebaseFirestore'
+      );
+    }
+    const absolutePath = ResourcePath.fromString(
+      `${parent.path}/${relativePath}`
+    );
     validateCollectionPath(absolutePath);
     return new CollectionReference(
-      doc.firestore,
+      parent.firestore,
       absolutePath,
       /* converter= */ null
     );
@@ -340,8 +358,15 @@ export function doc<T>(
   reference: firestore.CollectionReference<T>,
   documentPath?: string
 ): DocumentReference<T>;
+export function doc(
+  reference: firestore.DocumentReference<unknown>,
+  documentPath: string
+): DocumentReference<firestore.DocumentData>;
 export function doc<T>(
-  parent: firestore.FirebaseFirestore | firestore.CollectionReference<T>,
+  parent:
+    | firestore.FirebaseFirestore
+    | firestore.CollectionReference<T>
+    | firestore.DocumentReference<unknown>,
   relativePath?: string
 ): DocumentReference {
   // We allow omission of 'pathString' but explicitly prohibit passing in both
@@ -350,22 +375,34 @@ export function doc<T>(
     relativePath = AutoId.newId();
   }
   validateArgType('doc', 'non-empty string', 2, relativePath);
-  const path = ResourcePath.fromString(relativePath!);
+
   if (parent instanceof Firestore) {
-    validateDocumentPath(path);
+    const absolutePath = ResourcePath.fromString(relativePath!);
+    validateDocumentPath(absolutePath);
     return new DocumentReference(
       parent,
-      new DocumentKey(path),
+      new DocumentKey(absolutePath),
       /* converter= */ null
     );
   } else {
-    const coll = cast(parent, CollectionReference);
-    const absolutePath = coll._path.child(path);
+    if (
+      !(parent instanceof DocumentReference) &&
+      !(parent instanceof CollectionReference)
+    ) {
+      throw new FirestoreError(
+        Code.INVALID_ARGUMENT,
+        'Expected first argument to collection() to be a CollectionReference, ' +
+          'a DocumentReference or FirebaseFirestore'
+      );
+    }
+    const absolutePath = ResourcePath.fromString(
+      `${parent.path}/${relativePath}`
+    );
     validateDocumentPath(absolutePath);
     return new DocumentReference(
-      coll.firestore,
+      parent.firestore,
       new DocumentKey(absolutePath),
-      coll._converter
+      parent instanceof CollectionReference ? parent._converter : null
     );
   }
 }

--- a/packages/firestore/lite/test/integration.test.ts
+++ b/packages/firestore/lite/test/integration.test.ts
@@ -1064,6 +1064,16 @@ describe('withConverter() support', () => {
     });
   });
 
+  it('keeps the converter when calling parent() with a DocumentReference', () => {
+    return withTestDb(async db => {
+      const coll = doc(db, 'root/doc').withConverter(postConverter);
+      const typedColl = parent(coll)!;
+      expect(
+        refEqual(typedColl, collection(db, 'root').withConverter(postConverter))
+      ).to.be.true;
+    });
+  });
+
   it('drops the converter when calling parent() with a CollectionReference', () => {
     return withTestDb(async db => {
       const coll = collection(db, 'root/doc/parent').withConverter(

--- a/packages/firestore/lite/test/integration.test.ts
+++ b/packages/firestore/lite/test/integration.test.ts
@@ -143,12 +143,30 @@ describe('Firestore', () => {
 });
 
 describe('doc', () => {
-  it('can provide name', () => {
+  it('can be used relative to Firestore root', () => {
     return withTestDb(db => {
       const result = doc(db, 'coll/doc');
       expect(result).to.be.an.instanceOf(DocumentReference);
       expect(result.id).to.equal('doc');
       expect(result.path).to.equal('coll/doc');
+    });
+  });
+
+  it('can be used relative to collection', () => {
+    return withTestDb(db => {
+      const result = doc(collection(db, 'coll'), 'doc');
+      expect(result).to.be.an.instanceOf(DocumentReference);
+      expect(result.id).to.equal('doc');
+      expect(result.path).to.equal('coll/doc');
+    });
+  });
+
+  it('can be relative to doc', () => {
+    return withTestDb(db => {
+      const result = doc(doc(db, 'coll/doc'), 'subcoll/subdoc');
+      expect(result).to.be.an.instanceOf(DocumentReference);
+      expect(result.id).to.equal('subdoc');
+      expect(result.path).to.equal('coll/doc/subcoll/subdoc');
     });
   });
 
@@ -179,9 +197,27 @@ describe('doc', () => {
 });
 
 describe('collection', () => {
-  it('can provide name', () => {
+  it('can be used relative to Firestore root', () => {
     return withTestDb(db => {
       const result = collection(db, 'coll/doc/subcoll');
+      expect(result).to.be.an.instanceOf(CollectionReference);
+      expect(result.id).to.equal('subcoll');
+      expect(result.path).to.equal('coll/doc/subcoll');
+    });
+  });
+
+  it('can be used relative to collection', () => {
+    return withTestDb(db => {
+      const result = collection(collection(db, 'coll'), 'doc/subcoll');
+      expect(result).to.be.an.instanceOf(CollectionReference);
+      expect(result.id).to.equal('subcoll');
+      expect(result.path).to.equal('coll/doc/subcoll');
+    });
+  });
+
+  it('can be used relative to doc', () => {
+    return withTestDb(db => {
+      const result = collection(doc(db, 'coll/doc'), 'subcoll');
       expect(result).to.be.an.instanceOf(CollectionReference);
       expect(result.id).to.equal('subcoll');
       expect(result.path).to.equal('coll/doc/subcoll');
@@ -196,7 +232,7 @@ describe('collection', () => {
       // TODO(firestorelite): Explore returning a more helpful message
       // (e.g. "Empty document paths are not supported.")
       expect(() => collection(doc(db, 'coll/doc'), '')).to.throw(
-        'Function doc() requires its second argument to be of type non-empty string, but it was: ""'
+        'Function collection() requires its second argument to be of type non-empty string, but it was: ""'
       );
       expect(() => collection(doc(db, 'coll/doc'), 'coll/doc')).to.throw(
         'Invalid collection path (coll/doc/coll/doc). Path points to a document.'
@@ -945,8 +981,7 @@ describe('equality', () => {
         const query1a = collRef.orderBy('foo');
         const query1b = collRef.orderBy('foo', 'asc');
         const query2 = collRef.orderBy('foo', 'desc');
-        // TODO(firestorelite): Should we allow `collectionRef(collRef, 'a/b')?
-        const query3 = collection(doc(collRef, 'a'), 'b').orderBy('foo');
+        const query3 = collection(collRef, 'a/b').orderBy('foo');
 
         expect(queryEqual(query1a, query1b)).to.be.true;
         expect(queryEqual(query1a, query2)).to.be.false;


### PR DESCRIPTION
This adds new methods, which are pending review in go/firestore-next-amendment.

The new collection methods allows direct access to subcollections. Instead of `collection(doc(coll, 'a'), 'b')` we now support `collection(coll, 'a/b')`. This matches the behavior of this method when call with `db` (Firestore) already.

The same change is made for `doc`.