### PR TITLE
Add query() test helper

### DIFF
--- a/packages/firestore/test/unit/api/document_change.test.ts
+++ b/packages/firestore/test/unit/api/document_change.test.ts
@@ -32,7 +32,7 @@ import {
   documentSetAsArray,
   key,
   orderBy,
-  path
+  query
 } from '../../util/helpers';
 import { firestore } from '../../util/api_helpers';
 
@@ -85,7 +85,7 @@ describe('DocumentChange:', () => {
   }
 
   it('positions are correct for additions', () => {
-    const query = Query.atPath(path('c'));
+    const query1 = query('c');
     const initialDocs = [
       doc('c/a', 1, {}),
       doc('c/c', 1, {}),
@@ -93,11 +93,11 @@ describe('DocumentChange:', () => {
     ];
     const updates = [doc('c/b', 2, {}), doc('c/d', 2, {})];
 
-    expectPositions(query, initialDocs, updates);
+    expectPositions(query1, initialDocs, updates);
   });
 
   it('positions are correct for deletions', () => {
-    const query = Query.atPath(path('c'));
+    const query1 = query('c');
     const initialDocs = [
       doc('c/a', 1, {}),
       doc('c/b', 1, {}),
@@ -105,11 +105,11 @@ describe('DocumentChange:', () => {
     ];
     const updates = [key('c/a'), key('c/c')];
 
-    expectPositions(query, initialDocs, updates);
+    expectPositions(query1, initialDocs, updates);
   });
 
   it('positions are correct for modifications', () => {
-    const query = Query.atPath(path('c'));
+    const query1 = query('c');
     const initialDocs = [
       doc('c/a', 1, { value: 'a-1' }),
       doc('c/b', 1, { value: 'b-1' }),
@@ -120,11 +120,11 @@ describe('DocumentChange:', () => {
       doc('c/c', 2, { value: 'c-2' })
     ];
 
-    expectPositions(query, initialDocs, updates);
+    expectPositions(query1, initialDocs, updates);
   });
 
   it('positions are correct for sort order changes', () => {
-    const query = Query.atPath(path('c')).addOrderBy(orderBy('sort'));
+    const query1 = query('c', orderBy('sort'));
     const initialDocs = [
       doc('c/a', 1, { sort: 10 }),
       doc('c/b', 1, { sort: 20 }),
@@ -138,11 +138,11 @@ describe('DocumentChange:', () => {
       doc('c/a', 2, { sort: 35 })
     ];
 
-    expectPositions(query, initialDocs, updates);
+    expectPositions(query1, initialDocs, updates);
   });
 
   it('positions are correct for randomly chosen examples', () => {
-    const query = Query.atPath(path('c')).addOrderBy(orderBy('sort'));
+    const query1 = query('c', orderBy('sort'));
     for (let run = 0; run < 100; run++) {
       const initialDocs: Document[] = [];
       const updates: Array<DocumentKey | Document> = [];
@@ -165,7 +165,7 @@ describe('DocumentChange:', () => {
         }
       }
 
-      expectPositions(query, initialDocs, updates);
+      expectPositions(query1, initialDocs, updates);
     }
   });
 });

--- a/packages/firestore/test/unit/core/query.test.ts
+++ b/packages/firestore/test/unit/core/query.test.ts
@@ -37,7 +37,7 @@ import {
   expectEqualitySets,
   filter,
   orderBy,
-  path,
+  query,
   ref,
   wrap
 } from '../../util/helpers';
@@ -105,12 +105,8 @@ describe('Query', () => {
   });
 
   it('matches primitive values for filters', () => {
-    const query1 = Query.atPath(path('collection')).addFilter(
-      filter('sort', '>=', 2)
-    );
-    const query2 = Query.atPath(path('collection')).addFilter(
-      filter('sort', '<=', 2)
-    );
+    const query1 = query('collection', filter('sort', '>=', 2));
+    const query2 = query('collection', filter('sort', '<=', 2));
     const doc1 = doc('collection/1', 0, { sort: 1 });
     const doc2 = doc('collection/2', 0, { sort: 2 });
     const doc3 = doc('collection/3', 0, { sort: 3 });
@@ -131,17 +127,15 @@ describe('Query', () => {
   });
 
   it('matches array-contains filters', () => {
-    const query = Query.atPath(path('collection')).addFilter(
-      filter('array', 'array-contains', 42)
-    );
+    const query1 = query('collection', filter('array', 'array-contains', 42));
 
     // not an array
     let document = doc('collection/1', 0, { array: 1 });
-    expect(queryMatches(query, document)).to.be.false;
+    expect(queryMatches(query1, document)).to.be.false;
 
     // empty array.
     document = doc('collection/1', 0, { array: [] });
-    expect(queryMatches(query, document)).to.be.false;
+    expect(queryMatches(query1, document)).to.be.false;
 
     // array without element (and make sure it doesn't match in a nested field
     // or a different field).
@@ -149,16 +143,17 @@ describe('Query', () => {
       array: [41, '42', { a: 42, b: [42] }],
       different: [42]
     });
-    expect(queryMatches(query, document)).to.be.false;
+    expect(queryMatches(query1, document)).to.be.false;
 
     // array with element.
     document = doc('collection/1', 0, { array: [1, '2', 42, { a: 1 }] });
-    expect(queryMatches(query, document)).to.be.true;
+    expect(queryMatches(query1, document)).to.be.true;
   });
 
   it('matches array-contains filters with object values', () => {
     // Search for arrays containing the object { a: [42] }
-    const query = Query.atPath(path('collection')).addFilter(
+    const query1 = query(
+      'collection',
       filter('array', 'array-contains', { a: [42] })
     );
 
@@ -166,81 +161,79 @@ describe('Query', () => {
     let document = doc('collection/1', 0, {
       array: [{ a: 42 }, { a: [42, 43] }, { b: [42] }, { a: [42], b: 42 }]
     });
-    expect(queryMatches(query, document)).to.be.false;
+    expect(queryMatches(query1, document)).to.be.false;
 
     // array with element.
     document = doc('collection/1', 0, {
       array: [1, '2', 42, { a: [42] }]
     });
-    expect(queryMatches(query, document)).to.be.true;
+    expect(queryMatches(query1, document)).to.be.true;
   });
 
   it('matches IN filters', () => {
-    const query = Query.atPath(path('collection')).addFilter(
-      filter('zip', 'in', [12345])
-    );
+    const query1 = query('collection', filter('zip', 'in', [12345]));
 
     let document = doc('collection/1', 0, { zip: 12345 });
-    expect(queryMatches(query, document)).to.be.true;
+    expect(queryMatches(query1, document)).to.be.true;
 
     // Value matches in array.
     document = doc('collection/1', 0, { zip: [12345] });
-    expect(queryMatches(query, document)).to.be.false;
+    expect(queryMatches(query1, document)).to.be.false;
 
     // Non-type match.
     document = doc('collection/1', 0, { zip: '123435' });
-    expect(queryMatches(query, document)).to.be.false;
+    expect(queryMatches(query1, document)).to.be.false;
 
     // Nested match.
     document = doc('collection/1', 0, {
       zip: [123, '12345', { zip: 12345, b: [42] }]
     });
-    expect(queryMatches(query, document)).to.be.false;
+    expect(queryMatches(query1, document)).to.be.false;
   });
 
   it('matches IN filters with object values', () => {
-    const query = Query.atPath(path('collection')).addFilter(
-      filter('zip', 'in', [{ a: [42] }])
-    );
+    const query1 = query('collection', filter('zip', 'in', [{ a: [42] }]));
 
     // Containing object in array.
     let document = doc('collection/1', 0, {
       zip: [{ a: 42 }]
     });
-    expect(queryMatches(query, document)).to.be.false;
+    expect(queryMatches(query1, document)).to.be.false;
 
     // Containing object.
     document = doc('collection/1', 0, {
       zip: { a: [42] }
     });
-    expect(queryMatches(query, document)).to.be.true;
+    expect(queryMatches(query1, document)).to.be.true;
   });
 
   it('matches array-contains-any filters', () => {
-    const query = Query.atPath(path('collection')).addFilter(
+    const query1 = query(
+      'collection',
       filter('zip', 'array-contains-any', [12345])
     );
 
     let document = doc('collection/1', 0, { zip: [12345] });
-    expect(queryMatches(query, document)).to.be.true;
+    expect(queryMatches(query1, document)).to.be.true;
 
     // Value matches in non-array.
     document = doc('collection/1', 0, { zip: 12345 });
-    expect(queryMatches(query, document)).to.be.false;
+    expect(queryMatches(query1, document)).to.be.false;
 
     // Non-type match.
     document = doc('collection/1', 0, { zip: ['12345'] });
-    expect(queryMatches(query, document)).to.be.false;
+    expect(queryMatches(query1, document)).to.be.false;
 
     // Nested match.
     document = doc('collection/1', 0, {
       zip: [123, '12345', { zip: [12345], b: [42] }]
     });
-    expect(queryMatches(query, document)).to.be.false;
+    expect(queryMatches(query1, document)).to.be.false;
   });
 
   it('matches array-contains-any filters with object values', () => {
-    const query = Query.atPath(path('collection')).addFilter(
+    const query1 = query(
+      'collection',
       filter('zip', 'array-contains-any', [{ a: [42] }])
     );
 
@@ -248,56 +241,48 @@ describe('Query', () => {
     let document = doc('collection/1', 0, {
       zip: [{ a: [42] }]
     });
-    expect(queryMatches(query, document)).to.be.true;
+    expect(queryMatches(query1, document)).to.be.true;
 
     // Containing object.
     document = doc('collection/1', 0, {
       zip: { a: [42] }
     });
-    expect(queryMatches(query, document)).to.be.false;
+    expect(queryMatches(query1, document)).to.be.false;
   });
 
   it('matches NaN for filters', () => {
-    const query = Query.atPath(path('collection')).addFilter(
-      filter('sort', '==', NaN)
-    );
+    const query1 = query('collection', filter('sort', '==', NaN));
     const doc1 = doc('collection/1', 0, { sort: NaN });
     const doc2 = doc('collection/2', 0, { sort: 2 });
     const doc3 = doc('collection/3', 0, { sort: 3.1 });
     const doc4 = doc('collection/4', 0, { sort: false });
     const doc5 = doc('collection/5', 0, { sort: 'string' });
 
-    expect(queryMatches(query, doc1)).to.equal(true);
-    expect(queryMatches(query, doc2)).to.equal(false);
-    expect(queryMatches(query, doc3)).to.equal(false);
-    expect(queryMatches(query, doc4)).to.equal(false);
-    expect(queryMatches(query, doc5)).to.equal(false);
+    expect(queryMatches(query1, doc1)).to.equal(true);
+    expect(queryMatches(query1, doc2)).to.equal(false);
+    expect(queryMatches(query1, doc3)).to.equal(false);
+    expect(queryMatches(query1, doc4)).to.equal(false);
+    expect(queryMatches(query1, doc5)).to.equal(false);
   });
 
   it('matches null for filters', () => {
-    const query = Query.atPath(path('collection')).addFilter(
-      filter('sort', '==', null)
-    );
+    const query1 = query('collection', filter('sort', '==', null));
     const doc1 = doc('collection/1', 0, { sort: null });
     const doc2 = doc('collection/2', 0, { sort: 2 });
     const doc3 = doc('collection/3', 0, { sort: 3.1 });
     const doc4 = doc('collection/4', 0, { sort: false });
     const doc5 = doc('collection/5', 0, { sort: 'string' });
 
-    expect(queryMatches(query, doc1)).to.equal(true);
-    expect(queryMatches(query, doc2)).to.equal(false);
-    expect(queryMatches(query, doc3)).to.equal(false);
-    expect(queryMatches(query, doc4)).to.equal(false);
-    expect(queryMatches(query, doc5)).to.equal(false);
+    expect(queryMatches(query1, doc1)).to.equal(true);
+    expect(queryMatches(query1, doc2)).to.equal(false);
+    expect(queryMatches(query1, doc3)).to.equal(false);
+    expect(queryMatches(query1, doc4)).to.equal(false);
+    expect(queryMatches(query1, doc5)).to.equal(false);
   });
 
   it('matches complex objects for filters', () => {
-    const query1 = Query.atPath(path('collection')).addFilter(
-      filter('sort', '<=', 2)
-    );
-    const query2 = Query.atPath(path('collection')).addFilter(
-      filter('sort', '>=', 2)
-    );
+    const query1 = query('collection', filter('sort', '<=', 2));
+    const query2 = query('collection', filter('sort', '>=', 2));
 
     const doc1 = doc('collection/1', 0, { sort: 2 });
     const doc2 = doc('collection/2', 0, { sort: [] });
@@ -325,19 +310,17 @@ describe('Query', () => {
   });
 
   it("doesn't crash querying unset fields", () => {
-    const query = Query.atPath(path('collection')).addFilter(
-      filter('sort', '==', 2)
-    );
+    const query1 = query('collection', filter('sort', '==', 2));
 
     const doc1 = doc('collection/1', 0, { sort: 2 });
     const doc2 = doc('collection/1', 0, {});
 
-    expect(queryMatches(query, doc1)).to.equal(true);
-    expect(queryMatches(query, doc2)).to.equal(false);
+    expect(queryMatches(query1, doc1)).to.equal(true);
+    expect(queryMatches(query1, doc2)).to.equal(false);
   });
 
   it("doesn't remove complex objects with orderBy", () => {
-    const query = Query.atPath(path('collection')).addOrderBy(orderBy('sort'));
+    const query1 = query('collection', orderBy('sort'));
 
     const doc1 = doc('collection/1', 0, { sort: 2 });
     const doc2 = doc('collection/2', 0, { sort: [] });
@@ -345,15 +328,15 @@ describe('Query', () => {
     const doc4 = doc('collection/4', 0, { sort: { foo: 2 } });
     const doc5 = doc('collection/5', 0, { sort: { foo: 'bar' } });
 
-    expect(queryMatches(query, doc1)).to.equal(true);
-    expect(queryMatches(query, doc2)).to.equal(true);
-    expect(queryMatches(query, doc3)).to.equal(true);
-    expect(queryMatches(query, doc4)).to.equal(true);
-    expect(queryMatches(query, doc5)).to.equal(true);
+    expect(queryMatches(query1, doc1)).to.equal(true);
+    expect(queryMatches(query1, doc2)).to.equal(true);
+    expect(queryMatches(query1, doc3)).to.equal(true);
+    expect(queryMatches(query1, doc4)).to.equal(true);
+    expect(queryMatches(query1, doc5)).to.equal(true);
   });
 
   it('filters based on array value', () => {
-    const baseQuery = Query.atPath(path('collection'));
+    const baseQuery = query('collection');
     const doc1 = doc('collection/doc', 0, { tags: ['foo', 1, true] });
     const matchingFilters = [filter('tags', '==', ['foo', 1, true])];
     const nonMatchingFilters = [
@@ -362,15 +345,17 @@ describe('Query', () => {
       filter('tags', '==', ['foo', true, 1])
     ];
     for (const filter of matchingFilters) {
-      expect(queryMatches(baseQuery.addFilter(filter), doc1)).to.equal(true);
+      const filteredQuery = baseQuery.addFilter(filter);
+      expect(queryMatches(filteredQuery, doc1)).to.equal(true);
     }
     for (const filter of nonMatchingFilters) {
-      expect(queryMatches(baseQuery.addFilter(filter), doc1)).to.equal(false);
+      const filteredQuery = baseQuery.addFilter(filter);
+      expect(queryMatches(filteredQuery, doc1)).to.equal(false);
     }
   });
 
   it('filters based on object value', () => {
-    const baseQuery = Query.atPath(path('collection'));
+    const baseQuery = query('collection');
     const doc1 = doc('collection/doc', 0, {
       tags: { foo: 'foo', a: 0, b: true, c: NaN }
     });
@@ -384,15 +369,17 @@ describe('Query', () => {
       filter('tags', '==', { foo: 'foo', a: 0, b: true })
     ];
     for (const filter of matchingFilters) {
-      expect(queryMatches(baseQuery.addFilter(filter), doc1)).to.equal(true);
+      const filteredQuery = baseQuery.addFilter(filter);
+      expect(queryMatches(filteredQuery, doc1)).to.equal(true);
     }
     for (const filter of nonMatchingFilters) {
-      expect(queryMatches(baseQuery.addFilter(filter), doc1)).to.equal(false);
+      const filteredQuery = baseQuery.addFilter(filter);
+      expect(queryMatches(filteredQuery, doc1)).to.equal(false);
     }
   });
 
   it('sorts documents in the correct order', () => {
-    const query = Query.atPath(path('collection')).addOrderBy(orderBy('sort'));
+    const query1 = query('collection', orderBy('sort'));
 
     const docs = [
       doc('collection/1', 0, { sort: null }),
@@ -411,13 +398,11 @@ describe('Query', () => {
       doc('collection/1', 0, { sort: ref('collection/id1') })
     ];
 
-    expectCorrectComparisons(docs, newQueryComparator(query));
+    expectCorrectComparisons(docs, newQueryComparator(query1));
   });
 
   it('sorts documents using multiple fields', () => {
-    const query = Query.atPath(path('collection'))
-      .addOrderBy(orderBy('sort1'))
-      .addOrderBy(orderBy('sort2'));
+    const query1 = query('collection', orderBy('sort1'), orderBy('sort2'));
 
     const docs = [
       doc('collection/1', 0, { sort1: 1, sort2: 1 }),
@@ -432,13 +417,15 @@ describe('Query', () => {
       doc('collection/1', 0, { sort1: 2, sort2: 3 })
     ];
 
-    expectCorrectComparisons(docs, newQueryComparator(query));
+    expectCorrectComparisons(docs, newQueryComparator(query1));
   });
 
   it('sorts documents with descending too', () => {
-    const query = Query.atPath(path('collection'))
-      .addOrderBy(orderBy('sort1', 'desc'))
-      .addOrderBy(orderBy('sort2', 'desc'));
+    const query1 = query(
+      'collection',
+      orderBy('sort1', 'desc'),
+      orderBy('sort2', 'desc')
+    );
 
     const docs = [
       doc('collection/1', 0, { sort1: 2, sort2: 3 }),
@@ -453,40 +440,28 @@ describe('Query', () => {
       doc('collection/1', 0, { sort1: 1, sort2: 1 })
     ];
 
-    expectCorrectComparisons(docs, newQueryComparator(query));
+    expectCorrectComparisons(docs, newQueryComparator(query1));
   });
 
   it('generates canonical ids', () => {
     /* tslint:disable:variable-name */
-    const q1a = Query.atPath(path('foo'))
-      .addFilter(filter('i1', '<', 2))
-      .addFilter(filter('i2', '==', 3));
-    const q1b = Query.atPath(path('foo'))
-      .addFilter(filter('i1', '<', 2))
-      .addFilter(filter('i2', '==', 3));
+    const q1a = query('foo', filter('i1', '<', 2), filter('i2', '==', 3));
+    const q1b = query('foo', filter('i1', '<', 2), filter('i2', '==', 3));
 
-    const q2a = Query.atPath(path('foo'));
-    const q2b = Query.atPath(path('foo'));
+    const q2a = query('foo');
+    const q2b = query('foo');
 
-    const q3a = Query.atPath(path('foo/bar'));
-    const q3b = Query.atPath(path('foo/bar'));
+    const q3a = query('foo/bar');
+    const q3b = query('foo/bar');
 
-    const q4a = Query.atPath(path('foo'))
-      .addOrderBy(orderBy('foo'))
-      .addOrderBy(orderBy('bar'));
-    const q4b = Query.atPath(path('foo'))
-      .addOrderBy(orderBy('foo'))
-      .addOrderBy(orderBy('bar'));
-    const q5a = Query.atPath(path('foo'))
-      .addOrderBy(orderBy('bar'))
-      .addOrderBy(orderBy('foo'));
+    const q4a = query('foo', orderBy('foo'), orderBy('bar'));
+    const q4b = query('foo', orderBy('foo'), orderBy('bar'));
+    const q5a = query('foo', orderBy('bar'), orderBy('foo'));
 
-    const q6a = Query.atPath(path('foo'))
-      .addFilter(filter('bar', '>', 2))
-      .addOrderBy(orderBy('bar'));
+    const q6a = query('foo', filter('bar', '>', 2), orderBy('bar'));
 
-    const q7a = Query.atPath(path('foo')).withLimitToFirst(10);
-    const q8a = Query.atPath(path('foo')).withLimitToLast(10);
+    const q7a = query('foo').withLimitToFirst(10);
+    const q8a = query('foo').withLimitToLast(10);
 
     const lip1a = bound([[DOCUMENT_KEY_NAME, 'coll/foo', 'asc']], true);
     const lip1b = bound([[DOCUMENT_KEY_NAME, 'coll/foo', 'asc']], false);
@@ -494,19 +469,19 @@ describe('Query', () => {
     // TODO(b/35851862): descending key ordering not supported yet
     // const lip3 = bound([[DOCUMENT_KEY_NAME, 'coll/bar', 'desc']]);
 
-    const q9a = Query.atPath(path('foo')).withStartAt(lip1a);
-    const q10a = Query.atPath(path('foo')).withStartAt(lip1b);
-    const q11a = Query.atPath(path('foo')).withStartAt(lip2);
-    const q12a = Query.atPath(path('foo')).withEndAt(lip1a);
-    const q13a = Query.atPath(path('foo')).withEndAt(lip1b);
-    const q14a = Query.atPath(path('foo')).withEndAt(lip2);
+    const q9a = query('foo').withStartAt(lip1a);
+    const q10a = query('foo').withStartAt(lip1b);
+    const q11a = query('foo').withStartAt(lip2);
+    const q12a = query('foo').withEndAt(lip1a);
+    const q13a = query('foo').withEndAt(lip1b);
+    const q14a = query('foo').withEndAt(lip2);
 
     // TODO(b/35851862): descending key ordering not supported yet
-    // const q15a = Query.atPath(path('foo'))
-    // .addOrderBy(orderBy(DOCUMENT_KEY_NAME, 'desc'))
+    // const q15a = query('foo')
+    // .addOderBy(orderBy(DOCUMENT_KEY_NAME, 'desc'))
     // .withUpperBound(lip3, 'inclusive');
-    // const q16a = Query.atPath(path('foo'))
-    // .addOrderBy(orderBy(DOCUMENT_KEY_NAME, 'desc'))
+    // const q16a = query('foo')
+    // .addOderBy(orderBy(DOCUMENT_KEY_NAME, 'desc'))
     // .withUpperBound(lip3, 'exclusive');
 
     const relativeReference = ref('col/doc');
@@ -515,19 +490,17 @@ describe('Query', () => {
       5
     );
 
-    const q17a = Query.atPath(path('foo')).addFilter(
+    const q17a = query(
+      'foo',
       filter('object', '==', { ref: relativeReference })
     );
-    const q17b = Query.atPath(path('foo')).addFilter(
+    const q17b = query(
+      'foo',
       filter('object', '==', { ref: absoluteReference })
     );
 
-    const q18a = Query.atPath(path('foo')).addFilter(
-      filter('array', '==', [relativeReference])
-    );
-    const q18b = Query.atPath(path('foo')).addFilter(
-      filter('array', '==', [absoluteReference])
-    );
+    const q18a = query('foo', filter('array', '==', [relativeReference]));
+    const q18b = query('foo', filter('array', '==', [absoluteReference]));
 
     const queries = [
       [q1a, q1b],
@@ -563,103 +536,99 @@ describe('Query', () => {
     // This test aims to ensure that we do not break canonical IDs, as they are
     // used as keys in the TargetCache.
 
-    const baseQuery = Query.atPath(path('collection'));
+    const baseQuery = query('collection');
 
     assertCanonicalId(baseQuery, 'collection|f:|ob:__name__asc');
     assertCanonicalId(
-      baseQuery.addFilter(filter('a', '>', 'a')),
+      query('collection', filter('a', '>', 'a')),
       'collection|f:a>a|ob:aasc,__name__asc'
     );
     assertCanonicalId(
-      baseQuery.addFilter(filter('a', '<=', new GeoPoint(90.0, -90.0))),
+      query('collection', filter('a', '<=', new GeoPoint(90.0, -90.0))),
       'collection|f:a<=geo(90,-90)|ob:aasc,__name__asc'
     );
     assertCanonicalId(
-      baseQuery.addFilter(filter('a', '<=', new Timestamp(60, 3000))),
+      query('collection', filter('a', '<=', new Timestamp(60, 3000))),
       'collection|f:a<=time(60,3000)|ob:aasc,__name__asc'
     );
     assertCanonicalId(
-      baseQuery.addFilter(
+      query(
+        'collection',
         filter('a', '>=', Blob.fromUint8Array(new Uint8Array([1, 2, 3])))
       ),
       'collection|f:a>=AQID|ob:aasc,__name__asc'
     );
     assertCanonicalId(
-      baseQuery.addFilter(filter('a', '==', [1, 2, 3])),
+      query('collection', filter('a', '==', [1, 2, 3])),
       'collection|f:a==[1,2,3]|ob:__name__asc'
     );
     assertCanonicalId(
-      baseQuery.addFilter(filter('a', '==', NaN)),
+      query('collection', filter('a', '==', NaN)),
       'collection|f:a==NaN|ob:__name__asc'
     );
     assertCanonicalId(
-      baseQuery.addFilter(filter('__name__', '==', ref('collection/id'))),
+      query('collection', filter('__name__', '==', ref('collection/id'))),
       'collection|f:__name__==collection/id|ob:__name__asc'
     );
     assertCanonicalId(
-      baseQuery.addFilter(
+      query(
+        'collection',
         filter('a', '==', { 'a': 'b', 'inner': { 'd': 'c' } })
       ),
       'collection|f:a=={a:b,inner:{d:c}}|ob:__name__asc'
     );
     assertCanonicalId(
-      baseQuery.addFilter(filter('a', 'in', [1, 2, 3])),
+      query('collection', filter('a', 'in', [1, 2, 3])),
       'collection|f:ain[1,2,3]|ob:__name__asc'
     );
     assertCanonicalId(
-      baseQuery.addFilter(filter('a', 'array-contains-any', [1, 2, 3])),
+      query('collection', filter('a', 'array-contains-any', [1, 2, 3])),
       'collection|f:aarray-contains-any[1,2,3]|ob:__name__asc'
     );
     assertCanonicalId(
-      baseQuery.addFilter(filter('a', 'array-contains', 'a')),
+      query('collection', filter('a', 'array-contains', 'a')),
       'collection|f:aarray-containsa|ob:__name__asc'
     );
     assertCanonicalId(
-      baseQuery.addOrderBy(orderBy('a')),
+      query('collection', orderBy('a')),
       'collection|f:|ob:aasc,__name__asc'
     );
     assertCanonicalId(
-      baseQuery
-        .addOrderBy(orderBy('a', 'asc'))
-        .addOrderBy(orderBy('b', 'asc'))
-        .withStartAt(
-          bound(
-            [
-              ['a', 'foo', 'asc'],
-              ['b', [1, 2, 3], 'asc']
-            ],
-            true
-          )
-        ),
+      query('collection', orderBy('a', 'asc'), orderBy('b', 'asc')).withStartAt(
+        bound(
+          [
+            ['a', 'foo', 'asc'],
+            ['b', [1, 2, 3], 'asc']
+          ],
+          true
+        )
+      ),
       'collection|f:|ob:aasc,basc,__name__asc|lb:b:foo,[1,2,3]'
     );
     assertCanonicalId(
-      baseQuery
-        .addOrderBy(orderBy('a', 'desc'))
-        .addOrderBy(orderBy('b', 'desc'))
-        .withEndAt(
-          bound(
-            [
-              ['a', 'foo', 'desc'],
-              ['b', [1, 2, 3], 'desc']
-            ],
-            false
-          )
-        ),
+      query('collection', orderBy('a', 'desc'), orderBy('b', 'desc')).withEndAt(
+        bound(
+          [
+            ['a', 'foo', 'desc'],
+            ['b', [1, 2, 3], 'desc']
+          ],
+          false
+        )
+      ),
       'collection|f:|ob:adesc,bdesc,__name__desc|ub:a:foo,[1,2,3]'
     );
     assertCanonicalId(
-      baseQuery.withLimitToFirst(5),
+      query('collection').withLimitToFirst(5),
       'collection|f:|ob:__name__asc|l:5'
     );
     assertCanonicalId(
-      baseQuery.withLimitToLast(5),
+      query('collection').withLimitToLast(5),
       'collection|f:|ob:__name__desc|l:5'
     );
   });
 
   it("generates the correct implicit order by's", () => {
-    const baseQuery = Query.atPath(path('foo'));
+    const baseQuery = query('foo');
     // Default is ascending
     expect(baseQuery.orderBy).to.deep.equal([orderBy(DOCUMENT_KEY_NAME)]);
     // Explicit key ordering is respected
@@ -712,26 +681,26 @@ describe('Query', () => {
   });
 
   it('matchesAllDocuments() considers filters, orders and bounds', () => {
-    const baseQuery = Query.atPath(ResourcePath.fromString('collection'));
+    const baseQuery = query('collection');
     expect(baseQuery.matchesAllDocuments()).to.be.true;
 
-    let query = baseQuery.addOrderBy(orderBy('__name__'));
-    expect(query.matchesAllDocuments()).to.be.true;
+    let query1 = query('collection', orderBy('__name__'));
+    expect(query1.matchesAllDocuments()).to.be.true;
 
-    query = baseQuery.addOrderBy(orderBy('foo'));
-    expect(query.matchesAllDocuments()).to.be.false;
+    query1 = query('collection', orderBy('foo'));
+    expect(query1.matchesAllDocuments()).to.be.false;
 
-    query = baseQuery.addFilter(filter('foo', '==', 'bar'));
-    expect(query.matchesAllDocuments()).to.be.false;
+    query1 = query('collection', filter('foo', '==', 'bar'));
+    expect(query1.matchesAllDocuments()).to.be.false;
 
-    query = baseQuery.withLimitToFirst(1);
-    expect(query.matchesAllDocuments()).to.be.false;
+    query1 = query('foo').withLimitToFirst(1);
+    expect(query1.matchesAllDocuments()).to.be.false;
 
-    query = baseQuery.withStartAt(bound([], true));
-    expect(query.matchesAllDocuments()).to.be.false;
+    query1 = baseQuery.withStartAt(bound([], true));
+    expect(query1.matchesAllDocuments()).to.be.false;
 
-    query = baseQuery.withEndAt(bound([], true));
-    expect(query.matchesAllDocuments()).to.be.false;
+    query1 = baseQuery.withEndAt(bound([], true));
+    expect(query1.matchesAllDocuments()).to.be.false;
   });
 
   function assertCanonicalId(query: Query, expectedCanonicalId: string): void {

--- a/packages/firestore/test/unit/core/view.test.ts
+++ b/packages/firestore/test/unit/core/view.test.ts
@@ -16,7 +16,6 @@
  */
 
 import { expect } from 'chai';
-import { Query } from '../../../src/core/query';
 import { View } from '../../../src/core/view';
 import { ChangeType } from '../../../src/core/view_snapshot';
 import { documentKeySet } from '../../../src/model/collections';
@@ -30,7 +29,7 @@ import {
   keySet,
   limboChanges,
   orderBy,
-  path,
+  query,
   updateMapping,
   version
 } from '../../util/helpers';
@@ -38,8 +37,8 @@ import {
 describe('View', () => {
   it('adds documents based on query', () => {
     // shallow ancestor query
-    const query = Query.atPath(path('rooms/eros/messages'));
-    const view = new View(query, documentKeySet());
+    const query1 = query('rooms/eros/messages');
+    const view = new View(query1, documentKeySet());
 
     const doc1 = doc('rooms/eros/messages/1', 0, { text: 'msg1' });
     const doc2 = doc('rooms/eros/messages/2', 0, { text: 'msg2' });
@@ -52,7 +51,7 @@ describe('View', () => {
       ackTarget(doc1, doc2, doc3)
     ).snapshot!;
 
-    expect(snapshot.query).to.deep.equal(query);
+    expect(snapshot.query).to.deep.equal(query1);
     expect(documentSetAsArray(snapshot.docs)).to.deep.equal([doc1, doc2]);
     expect(snapshot.docChanges).to.deep.equal([
       { type: ChangeType.Added, doc: doc1 },
@@ -65,8 +64,8 @@ describe('View', () => {
 
   it('removes documents', () => {
     // shallow ancestor query
-    const query = Query.atPath(path('rooms/eros/messages'));
-    const view = new View(query, documentKeySet());
+    const query1 = query('rooms/eros/messages');
+    const view = new View(query1, documentKeySet());
 
     const doc1 = doc('rooms/eros/messages/1', 0, { text: 'msg1' });
     const doc2 = doc('rooms/eros/messages/2', 0, { text: 'msg2' });
@@ -80,7 +79,7 @@ describe('View', () => {
     const snapshot = view.applyChanges(changes, true, ackTarget(doc1, doc3))
       .snapshot!;
 
-    expect(snapshot.query).to.deep.equal(query);
+    expect(snapshot.query).to.deep.equal(query1);
     expect(documentSetAsArray(snapshot.docs)).to.deep.equal([doc1, doc3]);
     expect(snapshot.docChanges).to.deep.equal([
       { type: ChangeType.Removed, doc: doc2 },
@@ -92,8 +91,8 @@ describe('View', () => {
 
   it('returns null if there are no changes', () => {
     // shallow ancestor query
-    const query = Query.atPath(path('rooms/eros/messages'));
-    const view = new View(query, documentKeySet());
+    const query1 = query('rooms/eros/messages');
+    const view = new View(query1, documentKeySet());
 
     const doc1 = doc('rooms/eros/messages/1', 0, { text: 'msg1' });
     const doc2 = doc('rooms/eros/messages/2', 0, { text: 'msg2' });
@@ -106,17 +105,15 @@ describe('View', () => {
   });
 
   it('does not return null for the first changes', () => {
-    const query = Query.atPath(path('rooms/eros/messages'));
-    const view = new View(query, documentKeySet());
+    const query1 = query('rooms/eros/messages');
+    const view = new View(query1, documentKeySet());
     expect(applyDocChanges(view)).not.to.equal(null);
   });
 
   it('filters documents based on query with filter', () => {
     // shallow ancestor query
-    const query = Query.atPath(path('rooms/eros/messages')).addFilter(
-      filter('sort', '<=', 2)
-    );
-    const view = new View(query, documentKeySet());
+    const query1 = query('rooms/eros/messages', filter('sort', '<=', 2));
+    const view = new View(query1, documentKeySet());
 
     const doc1 = doc('rooms/eros/messages/1', 0, { sort: 1 });
     const doc2 = doc('rooms/eros/messages/2', 0, { sort: 2 });
@@ -127,7 +124,7 @@ describe('View', () => {
     const snapshot = applyDocChanges(view, doc1, doc2, doc3, doc4, doc5)
       .snapshot!;
 
-    expect(snapshot.query).to.deep.equal(query);
+    expect(snapshot.query).to.deep.equal(query1);
     expect(documentSetAsArray(snapshot.docs)).to.deep.equal([doc1, doc5, doc2]);
     expect(snapshot.docChanges).to.deep.equal([
       { type: ChangeType.Added, doc: doc1 },
@@ -140,10 +137,8 @@ describe('View', () => {
 
   it('updates documents based on query with filter', () => {
     // shallow ancestor query
-    const query = Query.atPath(path('rooms/eros/messages')).addFilter(
-      filter('sort', '<=', 2)
-    );
-    const view = new View(query, documentKeySet());
+    const query1 = query('rooms/eros/messages', filter('sort', '<=', 2));
+    const view = new View(query1, documentKeySet());
 
     const doc1 = doc('rooms/eros/messages/1', 0, { sort: 1 });
     const doc2 = doc('rooms/eros/messages/2', 0, { sort: 3 });
@@ -158,7 +153,7 @@ describe('View', () => {
     const newDoc4 = doc('rooms/eros/messages/4', 1, { sort: 0 });
 
     snapshot = applyDocChanges(view, newDoc2, newDoc3, newDoc4).snapshot!;
-    expect(snapshot.query).to.deep.equal(query);
+    expect(snapshot.query).to.deep.equal(query1);
 
     expect(documentSetAsArray(snapshot.docs)).to.deep.equal([
       newDoc4,
@@ -174,8 +169,8 @@ describe('View', () => {
 
   it('removes documents for query with limit', () => {
     // shallow ancestor query
-    const query = Query.atPath(path('rooms/eros/messages')).withLimitToFirst(2);
-    const view = new View(query, documentKeySet());
+    const query1 = query('rooms/eros/messages').withLimitToFirst(2);
+    const view = new View(query1, documentKeySet());
 
     const doc1 = doc('rooms/eros/messages/1', 0, { text: 'msg1' });
     const doc2 = doc('rooms/eros/messages/2', 0, { text: 'msg2' });
@@ -192,7 +187,7 @@ describe('View', () => {
       ackTarget(doc1, doc2, doc3)
     ).snapshot!;
 
-    expect(snapshot.query).to.deep.equal(query);
+    expect(snapshot.query).to.deep.equal(query1);
     expect(documentSetAsArray(snapshot.docs)).to.deep.equal([doc1, doc2]);
     expect(snapshot.docChanges).to.deep.equal([
       { type: ChangeType.Removed, doc: doc3 },
@@ -204,10 +199,11 @@ describe('View', () => {
 
   it("doesn't report changes for documents beyond limit of query", () => {
     // shallow ancestor query
-    const query = Query.atPath(path('rooms/eros/messages'))
-      .addOrderBy(orderBy('num'))
-      .withLimitToFirst(2);
-    const view = new View(query, documentKeySet());
+    const query1 = query(
+      'rooms/eros/messages',
+      orderBy('num')
+    ).withLimitToFirst(2);
+    const view = new View(query1, documentKeySet());
 
     const doc1 = doc('rooms/eros/messages/1', 0, { num: 1 });
     let doc2 = doc('rooms/eros/messages/2', 0, { num: 2 });
@@ -235,7 +231,7 @@ describe('View', () => {
       ackTarget(doc1, doc2, doc3, doc4)
     ).snapshot!;
 
-    expect(snapshot.query).to.deep.equal(query);
+    expect(snapshot.query).to.deep.equal(query1);
     expect(documentSetAsArray(snapshot.docs)).to.deep.equal([doc1, doc3]);
     expect(snapshot.docChanges).to.deep.equal([
       { type: ChangeType.Removed, doc: doc2 },
@@ -246,11 +242,11 @@ describe('View', () => {
   });
 
   it('keeps track of limbo documents', () => {
-    const query = Query.atPath(path('rooms/eros/msgs'));
+    const query1 = query('rooms/eros/msgs');
     const doc1 = doc('rooms/eros/msgs/0', 0, {});
     const doc2 = doc('rooms/eros/msgs/1', 0, {});
     const doc3 = doc('rooms/eros/msgs/2', 0, {});
-    const view = new View(query, documentKeySet());
+    const view = new View(query1, documentKeySet());
 
     let changes = view.computeDocChanges(documentUpdates(doc1));
     let viewChange = view.applyChanges(changes, true);
@@ -291,8 +287,8 @@ describe('View', () => {
   });
 
   it('is marked from cache with limbo documents', () => {
-    const query = Query.atPath(path('rooms/eros/msgs'));
-    const view = new View(query, documentKeySet());
+    const query1 = query('rooms/eros/msgs');
+    const view = new View(query1, documentKeySet());
     const doc1 = doc('rooms/eros/msgs/0', 0, {});
     const doc2 = doc('rooms/eros/msgs/1', 0, {});
 
@@ -329,14 +325,14 @@ describe('View', () => {
   });
 
   it('resumes queries without creating limbo documents', () => {
-    const query = Query.atPath(path('rooms/eros/msgs'));
+    const query1 = query('rooms/eros/msgs');
     const doc1 = doc('rooms/eros/msgs/0', 0, {});
     const doc2 = doc('rooms/eros/msgs/1', 0, {});
 
     // Unlike other cases, here the view is initialized with a set of previously
     // synced documents which happens when listening to a previously listened-to
     // query.
-    const view = new View(query, keySet(doc1.key, doc2.key));
+    const view = new View(query1, keySet(doc1.key, doc2.key));
 
     const changes = view.computeDocChanges(documentUpdates());
     const change = view.applyChanges(changes, true, ackTarget());
@@ -344,10 +340,10 @@ describe('View', () => {
   });
 
   it('returns needsRefill on delete limit query', () => {
-    const query = Query.atPath(path('rooms/eros/msgs')).withLimitToFirst(2);
+    const query1 = query('rooms/eros/msgs').withLimitToFirst(2);
     const doc1 = doc('rooms/eros/msgs/0', 0, {});
     const doc2 = doc('rooms/eros/msgs/1', 0, {});
-    const view = new View(query, documentKeySet());
+    const view = new View(query1, documentKeySet());
 
     // Start with a full view.
     let changes = view.computeDocChanges(documentUpdates(doc1, doc2));
@@ -370,13 +366,13 @@ describe('View', () => {
   });
 
   it('returns needsRefill on reorder in limit query', () => {
-    const query = Query.atPath(path('rooms/eros/msgs'))
-      .addOrderBy(orderBy('order'))
-      .withLimitToFirst(2);
+    const query1 = query('rooms/eros/msgs', orderBy('order')).withLimitToFirst(
+      2
+    );
     const doc1 = doc('rooms/eros/msgs/0', 0, { order: 1 });
     let doc2 = doc('rooms/eros/msgs/1', 0, { order: 2 });
     const doc3 = doc('rooms/eros/msgs/2', 0, { order: 3 });
-    const view = new View(query, documentKeySet());
+    const view = new View(query1, documentKeySet());
 
     // Start with a full view.
     let changes = view.computeDocChanges(documentUpdates(doc1, doc2, doc3));
@@ -403,15 +399,15 @@ describe('View', () => {
   });
 
   it("doesn't need refill on reorder within limit", () => {
-    const query = Query.atPath(path('rooms/eros/msgs'))
-      .addOrderBy(orderBy('order'))
-      .withLimitToFirst(3);
+    const query1 = query('rooms/eros/msgs', orderBy('order')).withLimitToFirst(
+      3
+    );
     let doc1 = doc('rooms/eros/msgs/0', 0, { order: 1 });
     const doc2 = doc('rooms/eros/msgs/1', 0, { order: 2 });
     const doc3 = doc('rooms/eros/msgs/2', 0, { order: 3 });
     const doc4 = doc('rooms/eros/msgs/3', 0, { order: 4 });
     const doc5 = doc('rooms/eros/msgs/4', 0, { order: 5 });
-    const view = new View(query, documentKeySet());
+    const view = new View(query1, documentKeySet());
 
     // Start with a full view.
     let changes = view.computeDocChanges(
@@ -432,15 +428,15 @@ describe('View', () => {
   });
 
   it("doesn't need refill on reorder after limit query", () => {
-    const query = Query.atPath(path('rooms/eros/msgs'))
-      .addOrderBy(orderBy('order'))
-      .withLimitToFirst(3);
+    const query1 = query('rooms/eros/msgs', orderBy('order')).withLimitToFirst(
+      3
+    );
     const doc1 = doc('rooms/eros/msgs/0', 0, { order: 1 });
     const doc2 = doc('rooms/eros/msgs/1', 0, { order: 2 });
     const doc3 = doc('rooms/eros/msgs/2', 0, { order: 3 });
     let doc4 = doc('rooms/eros/msgs/3', 0, { order: 4 });
     const doc5 = doc('rooms/eros/msgs/4', 0, { order: 5 });
-    const view = new View(query, documentKeySet());
+    const view = new View(query1, documentKeySet());
 
     // Start with a full view.
     let changes = view.computeDocChanges(
@@ -461,10 +457,10 @@ describe('View', () => {
   });
 
   it("doesn't need refill for additions after the limit", () => {
-    const query = Query.atPath(path('rooms/eros/msgs')).withLimitToFirst(2);
+    const query1 = query('rooms/eros/msgs').withLimitToFirst(2);
     const doc1 = doc('rooms/eros/msgs/0', 0, {});
     const doc2 = doc('rooms/eros/msgs/1', 0, {});
-    const view = new View(query, documentKeySet());
+    const view = new View(query1, documentKeySet());
 
     // Start with a full view.
     let changes = view.computeDocChanges(documentUpdates(doc1, doc2));
@@ -483,10 +479,11 @@ describe('View', () => {
   });
 
   it("doesn't need refill for deletions when not near the limit", () => {
-    const query = Query.atPath(path('rooms/eros/msgs')).withLimitToFirst(20);
+    const query1 = query('rooms/eros/msgs').withLimitToFirst(20);
+
     const doc1 = doc('rooms/eros/msgs/0', 0, {});
     const doc2 = doc('rooms/eros/msgs/1', 0, {});
-    const view = new View(query, documentKeySet());
+    const view = new View(query1, documentKeySet());
 
     let changes = view.computeDocChanges(documentUpdates(doc1, doc2));
     expect(changes.documentSet.size).to.equal(2);
@@ -503,10 +500,10 @@ describe('View', () => {
   });
 
   it('handles applying irrelevant docs', () => {
-    const query = Query.atPath(path('rooms/eros/msgs')).withLimitToFirst(2);
+    const query1 = query('rooms/eros/msgs').withLimitToFirst(2);
     const doc1 = doc('rooms/eros/msgs/0', 0, {});
     const doc2 = doc('rooms/eros/msgs/1', 0, {});
-    const view = new View(query, documentKeySet());
+    const view = new View(query1, documentKeySet());
 
     // Start with a full view.
     let changes = view.computeDocChanges(documentUpdates(doc1, doc2));
@@ -525,10 +522,10 @@ describe('View', () => {
   });
 
   it('computes mutatedDocKeys', () => {
-    const query = Query.atPath(path('rooms/eros/msgs'));
+    const query1 = query('rooms/eros/msgs');
     const doc1 = doc('rooms/eros/msgs/0', 0, {});
     const doc2 = doc('rooms/eros/msgs/1', 0, {});
-    const view = new View(query, documentKeySet());
+    const view = new View(query1, documentKeySet());
     // Start with a full view.
     let changes = view.computeDocChanges(documentUpdates(doc1, doc2));
     view.applyChanges(changes, true);
@@ -543,10 +540,10 @@ describe('View', () => {
     'computes removes keys from mutatedDocKeys when new doc does not have ' +
       'local changes',
     () => {
-      const query = Query.atPath(path('rooms/eros/msgs'));
+      const query1 = query('rooms/eros/msgs');
       const doc1 = doc('rooms/eros/msgs/0', 0, {});
       const doc2 = doc('rooms/eros/msgs/1', 0, {}, { hasLocalMutations: true });
-      const view = new View(query, documentKeySet());
+      const view = new View(query1, documentKeySet());
       // Start with a full view.
       let changes = view.computeDocChanges(documentUpdates(doc1, doc2));
       view.applyChanges(changes, true);
@@ -560,10 +557,10 @@ describe('View', () => {
   );
 
   it('remembers local mutations from previous snapshot', () => {
-    const query = Query.atPath(path('rooms/eros/msgs'));
+    const query1 = query('rooms/eros/msgs');
     const doc1 = doc('rooms/eros/msgs/0', 0, {});
     const doc2 = doc('rooms/eros/msgs/1', 0, {}, { hasLocalMutations: true });
-    const view = new View(query, documentKeySet());
+    const view = new View(query1, documentKeySet());
     // Start with a full view.
     let changes = view.computeDocChanges(documentUpdates(doc1, doc2));
     view.applyChanges(changes, true);
@@ -575,10 +572,10 @@ describe('View', () => {
   });
 
   it('remembers local mutations from previous call to computeDocChanges', () => {
-    const query = Query.atPath(path('rooms/eros/msgs'));
+    const query1 = query('rooms/eros/msgs');
     const doc1 = doc('rooms/eros/msgs/0', 0, {});
     const doc2 = doc('rooms/eros/msgs/1', 0, {}, { hasLocalMutations: true });
-    const view = new View(query, documentKeySet());
+    const view = new View(query1, documentKeySet());
     // Start with a full view.
     let changes = view.computeDocChanges(documentUpdates(doc1, doc2));
     expect(changes.mutatedKeys).to.deep.equal(keySet(doc2.key));

--- a/packages/firestore/test/unit/local/indexeddb_persistence.test.ts
+++ b/packages/firestore/test/unit/local/indexeddb_persistence.test.ts
@@ -18,7 +18,6 @@
 import * as chaiAsPromised from 'chai-as-promised';
 
 import { expect, use } from 'chai';
-import { Query } from '../../../src/core/query';
 import { SnapshotVersion } from '../../../src/core/snapshot_version';
 import {
   decodeResourcePath,
@@ -64,7 +63,7 @@ import { firestoreV1ApiClientInterfaces } from '../../../src/protos/firestore_pr
 import { JsonProtoSerializer } from '../../../src/remote/serializer';
 import { AsyncQueue, TimerId } from '../../../src/util/async_queue';
 import { FirestoreError } from '../../../src/util/error';
-import { doc, filter, path, version } from '../../util/helpers';
+import { doc, filter, path, query, version } from '../../util/helpers';
 import { MockIndexedDbPersistence } from '../specs/spec_test_components';
 import {
   INDEXEDDB_TEST_DATABASE_NAME,
@@ -793,9 +792,7 @@ describe('IndexedDbSchema: createOrUpgradeDb', () => {
       return sdb.runTransaction('readwrite', V8_STORES, txn => {
         const targetsStore = txn.store<DbTargetKey, DbTarget>(DbTarget.store);
 
-        const filteredQuery = Query.atPath(path('collection')).addFilter(
-          filter('foo', '==', 'bar')
-        );
+        const filteredQuery = query('collection', filter('foo', '==', 'bar'));
         const initialTargetData = new TargetData(
           filteredQuery.toTarget(),
           /* targetId= */ 2,

--- a/packages/firestore/test/unit/local/local_store.test.ts
+++ b/packages/firestore/test/unit/local/local_store.test.ts
@@ -73,7 +73,7 @@ import {
   mapAsArray,
   noChangeEvent,
   patchMutation,
-  path,
+  query,
   setMutation,
   TestSnapshotVersion,
   transformMutation,
@@ -529,7 +529,7 @@ function genericLocalStoreTests(
         doc('foo/bar', 0, { foo: 'bar' }, { hasLocalMutations: true })
       )
       .toContain(doc('foo/bar', 0, { foo: 'bar' }, { hasLocalMutations: true }))
-      .afterAllocatingQuery(Query.atPath(path('foo')))
+      .afterAllocatingQuery(query('foo'))
       .after(docUpdateRemoteEvent(doc('foo/bar', 2, { it: 'changed' }), [2]))
       .toReturnChanged(
         doc('foo/bar', 2, { foo: 'bar' }, { hasLocalMutations: true })
@@ -545,7 +545,7 @@ function genericLocalStoreTests(
       return (
         expectLocalStore()
           // Start a query so that acks must be held.
-          .afterAllocatingQuery(Query.atPath(path('foo')))
+          .afterAllocatingQuery(query('foo'))
           .toReturnTargetId(2)
           .after(setMutation('foo/bar', { foo: 'bar' }))
           .toReturnChanged(
@@ -584,9 +584,9 @@ function genericLocalStoreTests(
   );
 
   it('handles NoDocument -> SetMutation -> Ack', () => {
-    const query = Query.atPath(path('foo'));
+    const query1 = query('foo');
     return expectLocalStore()
-      .afterAllocatingQuery(query)
+      .afterAllocatingQuery(query1)
       .toReturnTargetId(2)
       .after(docUpdateRemoteEvent(deletedDoc('foo/bar', 2), [2]))
       .toReturnRemoved('foo/bar')
@@ -609,7 +609,7 @@ function genericLocalStoreTests(
 
   it('handles SetMutation -> NoDocument', () => {
     return expectLocalStore()
-      .afterAllocatingQuery(Query.atPath(path('foo')))
+      .afterAllocatingQuery(query('foo'))
       .toReturnTargetId(2)
       .after(setMutation('foo/bar', { foo: 'bar' }))
       .toReturnChanged(
@@ -626,7 +626,7 @@ function genericLocalStoreTests(
   it('handles Document -> SetMutation -> Ack ->  Document', () => {
     return (
       expectLocalStore()
-        .afterAllocatingQuery(Query.atPath(path('foo')))
+        .afterAllocatingQuery(query('foo'))
         .toReturnTargetId(2)
         .after(docAddedRemoteEvent(doc('foo/bar', 2, { it: 'base' }), [2]))
         .toReturnChanged(doc('foo/bar', 2, { it: 'base' }))
@@ -669,7 +669,7 @@ function genericLocalStoreTests(
       .after(patchMutation('foo/bar', { foo: 'bar' }))
       .toReturnRemoved('foo/bar')
       .toNotContain('foo/bar')
-      .afterAllocatingQuery(Query.atPath(path('foo')))
+      .afterAllocatingQuery(query('foo'))
       .toReturnTargetId(2)
       .after(docUpdateRemoteEvent(doc('foo/bar', 1, { it: 'base' }), [2]))
       .toReturnChanged(
@@ -720,7 +720,7 @@ function genericLocalStoreTests(
       .afterAcknowledgingMutation({ documentVersion: 1 })
       .toReturnChanged(unknownDoc('foo/bar', 1))
       .toNotContainIfEager(unknownDoc('foo/bar', 1))
-      .afterAllocatingQuery(Query.atPath(path('foo')))
+      .afterAllocatingQuery(query('foo'))
       .toReturnTargetId(2)
       .after(docUpdateRemoteEvent(doc('foo/bar', 1, { it: 'base' }), [2]))
       .toReturnChanged(doc('foo/bar', 1, { it: 'base' }))
@@ -742,10 +742,10 @@ function genericLocalStoreTests(
   });
 
   it('handles Document -> DeleteMutation -> Ack', () => {
-    const query = Query.atPath(path('foo'));
+    const query1 = query('foo');
     return (
       expectLocalStore()
-        .afterAllocatingQuery(query)
+        .afterAllocatingQuery(query1)
         .toReturnTargetId(2)
         .after(docUpdateRemoteEvent(doc('foo/bar', 1, { it: 'base' }), [2]))
         .toReturnChanged(doc('foo/bar', 1, { it: 'base' }))
@@ -765,10 +765,10 @@ function genericLocalStoreTests(
   });
 
   it('handles DeleteMutation -> Document -> Ack', () => {
-    const query = Query.atPath(path('foo'));
+    const query1 = query('foo');
     return (
       expectLocalStore()
-        .afterAllocatingQuery(query)
+        .afterAllocatingQuery(query1)
         .toReturnTargetId(2)
         .after(deleteMutation('foo/bar'))
         .toReturnRemoved('foo/bar')
@@ -789,7 +789,7 @@ function genericLocalStoreTests(
 
   it('handles Document -> NoDocument -> Document', () => {
     return expectLocalStore()
-      .afterAllocatingQuery(Query.atPath(path('foo')))
+      .afterAllocatingQuery(query('foo'))
       .toReturnTargetId(2)
       .after(docUpdateRemoteEvent(doc('foo/bar', 1, { it: 'base' }), [2]))
       .toReturnChanged(doc('foo/bar', 1, { it: 'base' }))
@@ -804,7 +804,7 @@ function genericLocalStoreTests(
   });
 
   it('handles SetMutation -> PatchMutation -> Document -> Ack -> Ack', () => {
-    const query = Query.atPath(path('foo'));
+    const query1 = query('foo');
     return expectLocalStore()
       .after(setMutation('foo/bar', { foo: 'old' }))
       .toReturnChanged(
@@ -816,7 +816,7 @@ function genericLocalStoreTests(
         doc('foo/bar', 0, { foo: 'bar' }, { hasLocalMutations: true })
       )
       .toContain(doc('foo/bar', 0, { foo: 'bar' }, { hasLocalMutations: true }))
-      .afterAllocatingQuery(query)
+      .afterAllocatingQuery(query1)
       .toReturnTargetId(2)
       .after(docUpdateRemoteEvent(doc('foo/bar', 1, { it: 'base' }), [2]))
       .toReturnChanged(
@@ -923,9 +923,9 @@ function genericLocalStoreTests(
 
   // eslint-disable-next-line no-restricted-properties
   (gcIsEager ? it : it.skip)('collects garbage after ChangeBatch', () => {
-    const query = Query.atPath(path('foo'));
+    const query1 = query('foo');
     return expectLocalStore()
-      .afterAllocatingQuery(query)
+      .afterAllocatingQuery(query1)
       .toReturnTargetId(2)
       .after(docAddedRemoteEvent(doc('foo/bar', 2, { foo: 'bar' }), [2]))
       .toContain(doc('foo/bar', 2, { foo: 'bar' }))
@@ -938,10 +938,10 @@ function genericLocalStoreTests(
   (gcIsEager ? it : it.skip)(
     'collects garbage after acknowledged mutation',
     () => {
-      const query = Query.atPath(path('foo'));
+      const query1 = query('foo');
       return (
         expectLocalStore()
-          .afterAllocatingQuery(query)
+          .afterAllocatingQuery(query1)
           .toReturnTargetId(2)
           .after(docAddedRemoteEvent(doc('foo/bar', 1, { foo: 'old' }), [2]))
           .after(patchMutation('foo/bar', { foo: 'bar' }))
@@ -978,10 +978,10 @@ function genericLocalStoreTests(
 
   // eslint-disable-next-line no-restricted-properties
   (gcIsEager ? it : it.skip)('collects garbage after rejected mutation', () => {
-    const query = Query.atPath(path('foo'));
+    const query1 = query('foo');
     return (
       expectLocalStore()
-        .afterAllocatingQuery(query)
+        .afterAllocatingQuery(query1)
         .toReturnTargetId(2)
         .after(docAddedRemoteEvent(doc('foo/bar', 1, { foo: 'old' }), [2]))
         .after(patchMutation('foo/bar', { foo: 'bar' }))
@@ -1017,9 +1017,9 @@ function genericLocalStoreTests(
 
   // eslint-disable-next-line no-restricted-properties
   (gcIsEager ? it : it.skip)('pins documents in the local view', () => {
-    const query = Query.atPath(path('foo'));
+    const query1 = query('foo');
     return expectLocalStore()
-      .afterAllocatingQuery(query)
+      .afterAllocatingQuery(query1)
       .toReturnTargetId(2)
       .after(docAddedRemoteEvent(doc('foo/bar', 1, { foo: 'bar' }), [2]))
       .after(setMutation('foo/baz', { foo: 'baz' }))
@@ -1068,7 +1068,7 @@ function genericLocalStoreTests(
       ])
       .then(() => {
         return localStore.executeQuery(
-          Query.atPath(path('foo/bar')),
+          query('foo/bar'),
           /* usePreviousResults= */ true
         );
       })
@@ -1090,7 +1090,7 @@ function genericLocalStoreTests(
       ])
       .then(() => {
         return localStore.executeQuery(
-          Query.atPath(path('foo')),
+          query('foo'),
           /* usePreviousResults= */ true
         );
       })
@@ -1102,8 +1102,8 @@ function genericLocalStoreTests(
   });
 
   it('can execute mixed collection queries', async () => {
-    const query = Query.atPath(path('foo'));
-    const targetData = await localStore.allocateTarget(query.toTarget());
+    const query1 = query('foo');
+    const targetData = await localStore.allocateTarget(query1.toTarget());
     expect(targetData.targetId).to.equal(2);
     await localStore.applyRemoteEvent(
       docAddedRemoteEvent(doc('foo/baz', 10, { a: 'b' }), [2], [])
@@ -1113,7 +1113,7 @@ function genericLocalStoreTests(
     );
     await localStore.localWrite([setMutation('foo/bonk', { a: 'b' })]);
     const { documents } = await localStore.executeQuery(
-      query,
+      query1,
       /* usePreviousResults= */ true
     );
     expect(mapAsArray(documents)).to.deep.equal([
@@ -1127,10 +1127,8 @@ function genericLocalStoreTests(
   });
 
   it('reads all documents for initial collection queries', () => {
-    const firstQuery = Query.atPath(path('foo'));
-    const secondQuery = Query.atPath(path('foo')).addFilter(
-      filter('matches', '==', true)
-    );
+    const firstQuery = query('foo');
+    const secondQuery = query('foo', filter('matches', '==', true));
 
     return expectLocalStore()
       .afterAllocatingQuery(firstQuery)
@@ -1166,8 +1164,8 @@ function genericLocalStoreTests(
 
   // eslint-disable-next-line no-restricted-properties
   (gcIsEager ? it.skip : it)('persists resume tokens', async () => {
-    const query = Query.atPath(path('foo/bar'));
-    const targetData = await localStore.allocateTarget(query.toTarget());
+    const query1 = query('foo/bar');
+    const targetData = await localStore.allocateTarget(query1.toTarget());
     const targetId = targetData.targetId;
     const resumeToken = byteStringFromString('abc');
     const watchChange = new WatchTargetChange(
@@ -1190,7 +1188,7 @@ function genericLocalStoreTests(
     );
 
     // Should come back with the same resume token
-    const targetData2 = await localStore.allocateTarget(query.toTarget());
+    const targetData2 = await localStore.allocateTarget(query1.toTarget());
     expect(targetData2.resumeToken).to.deep.equal(resumeToken);
   });
 
@@ -1198,8 +1196,8 @@ function genericLocalStoreTests(
   (gcIsEager ? it.skip : it)(
     'does not replace resume token with empty resume token',
     async () => {
-      const query = Query.atPath(path('foo/bar'));
-      const targetData = await localStore.allocateTarget(query.toTarget());
+      const query1 = query('foo/bar');
+      const targetData = await localStore.allocateTarget(query1.toTarget());
       const targetId = targetData.targetId;
       const resumeToken = byteStringFromString('abc');
 
@@ -1236,7 +1234,7 @@ function genericLocalStoreTests(
       );
 
       // Should come back with the same resume token
-      const targetData2 = await localStore.allocateTarget(query.toTarget());
+      const targetData2 = await localStore.allocateTarget(query1.toTarget());
       expect(targetData2.resumeToken).to.deep.equal(resumeToken);
     }
   );
@@ -1307,10 +1305,10 @@ function genericLocalStoreTests(
   );
 
   it('handles SetMutation -> TransformMutation -> RemoteEvent -> TransformMutation', () => {
-    const query = Query.atPath(path('foo'));
+    const query1 = query('foo');
     return (
       expectLocalStore()
-        .afterAllocatingQuery(query)
+        .afterAllocatingQuery(query1)
         .toReturnTargetId(2)
         .after(setMutation('foo/bar', { sum: 0 }))
         .toReturnChanged(
@@ -1367,10 +1365,10 @@ function genericLocalStoreTests(
   });
 
   it('holds back only non-idempotent transforms', () => {
-    const query = Query.atPath(path('foo'));
+    const query1 = query('foo');
     return (
       expectLocalStore()
-        .afterAllocatingQuery(query)
+        .afterAllocatingQuery(query1)
         .toReturnTargetId(2)
         .after(setMutation('foo/bar', { sum: 0, arrayUnion: [] }))
         .toReturnChanged(
@@ -1436,9 +1434,9 @@ function genericLocalStoreTests(
   });
 
   it('handles MergeMutation with Transform -> RemoteEvent', () => {
-    const query = Query.atPath(path('foo'));
+    const query1 = query('foo');
     return expectLocalStore()
-      .afterAllocatingQuery(query)
+      .afterAllocatingQuery(query1)
       .toReturnTargetId(2)
       .afterMutations([
         patchMutation('foo/bar', {}, Precondition.none()),
@@ -1462,9 +1460,9 @@ function genericLocalStoreTests(
     // Note: This test reflects the current behavior, but it may be preferable
     // to replay the mutation once we receive the first value from the backend.
 
-    const query = Query.atPath(path('foo'));
+    const query1 = query('foo');
     return expectLocalStore()
-      .afterAllocatingQuery(query)
+      .afterAllocatingQuery(query1)
       .toReturnTargetId(2)
       .afterMutations([
         patchMutation('foo/bar', {}),
@@ -1497,10 +1495,10 @@ function genericLocalStoreTests(
   });
 
   it('only persists updates for documents when version changes', () => {
-    const query = Query.atPath(path('foo'));
+    const query1 = query('foo');
     return (
       expectLocalStore()
-        .afterAllocatingQuery(query)
+        .afterAllocatingQuery(query1)
         .toReturnTargetId(2)
         .afterRemoteEvent(
           docAddedRemoteEvent(doc('foo/bar', 1, { val: 'old' }), [2])
@@ -1532,12 +1530,10 @@ function genericLocalStoreTests(
     // This test verifies that once a target mapping has been written, only
     // documents that match the query are read from the RemoteDocumentCache.
 
-    const query = Query.atPath(path('foo')).addFilter(
-      filter('matches', '==', true)
-    );
+    const query1 = query('foo', filter('matches', '==', true));
     return (
       expectLocalStore()
-        .afterAllocatingQuery(query)
+        .afterAllocatingQuery(query1)
         .toReturnTargetId(2)
         .after(setMutation('foo/a', { matches: true }))
         .after(setMutation('foo/b', { matches: true }))
@@ -1545,7 +1541,7 @@ function genericLocalStoreTests(
         .afterAcknowledgingMutation({ documentVersion: 10 })
         .afterAcknowledgingMutation({ documentVersion: 10 })
         .afterAcknowledgingMutation({ documentVersion: 10 })
-        .afterExecutingQuery(query)
+        .afterExecutingQuery(query1)
         // Execute the query, but note that we read all existing documents
         // from the RemoteDocumentCache since we do not yet have target
         // mapping.
@@ -1568,7 +1564,7 @@ function genericLocalStoreTests(
           )
         )
         .after(localViewChanges(2, /* fromCache= */ false, {}))
-        .afterExecutingQuery(query)
+        .afterExecutingQuery(query1)
         .toHaveRead({ documentsByKey: 2, documentsByQuery: 0 })
         .toReturnChanged(
           doc('foo/a', 10, { matches: true }),
@@ -1583,7 +1579,7 @@ function genericLocalStoreTests(
     // is advanced when we compute a limbo-free free view and that the mapping
     // is persisted when we release a query.
 
-    const target = Query.atPath(path('foo')).toTarget();
+    const target = query('foo').toTarget();
 
     const targetData = await localStore.allocateTarget(target);
 
@@ -1647,25 +1643,23 @@ function genericLocalStoreTests(
       // include documents that were modified by local edits after the target
       // mapping was written.
 
-      const query = Query.atPath(path('foo')).addFilter(
-        filter('matches', '==', true)
-      );
+      const query1 = query('foo', filter('matches', '==', true));
       return (
         expectLocalStore()
-          .afterAllocatingQuery(query)
+          .afterAllocatingQuery(query1)
           .toReturnTargetId(2)
           .after(
             docAddedRemoteEvent([doc('foo/a', 10, { matches: true })], [2], [])
           )
           .after(localViewChanges(2, /* fromCache= */ false, {}))
           // Execute the query based on the RemoteEvent.
-          .afterExecutingQuery(query)
+          .afterExecutingQuery(query1)
           .toReturnChanged(doc('foo/a', 10, { matches: true }))
           // Write a document.
           .after(setMutation('foo/b', { matches: true }))
           // Execute the query and make sure that the pending mutation is
           // included in the result.
-          .afterExecutingQuery(query)
+          .afterExecutingQuery(query1)
           .toReturnChanged(
             doc('foo/a', 10, { matches: true }),
             doc('foo/b', 0, { matches: true }, { hasLocalMutations: true })
@@ -1673,7 +1667,7 @@ function genericLocalStoreTests(
           .afterAcknowledgingMutation({ documentVersion: 11 })
           // Execute the query and make sure that the acknowledged mutation is
           // included in the result.
-          .afterExecutingQuery(query)
+          .afterExecutingQuery(query1)
           .toReturnChanged(
             doc('foo/a', 10, { matches: true }),
             doc('foo/b', 11, { matches: true }, { hasCommittedMutations: true })
@@ -1691,10 +1685,8 @@ function genericLocalStoreTests(
       // include documents that were modified by other queries after the target
       // mapping was written.
 
-      const filteredQuery = Query.atPath(path('foo')).addFilter(
-        filter('matches', '==', true)
-      );
-      const fullQuery = Query.atPath(path('foo'));
+      const filteredQuery = query('foo', filter('matches', '==', true));
+      const fullQuery = query('foo');
       return (
         expectLocalStore()
           .afterAllocatingQuery(filteredQuery)
@@ -1745,10 +1737,8 @@ function genericLocalStoreTests(
       // This test verifies that documents that once matched a query are
       // post-filtered if they no longer match the query filter.
 
-      const filteredQuery = Query.atPath(path('foo')).addFilter(
-        filter('matches', '==', true)
-      );
-      const fullQuery = Query.atPath(path('foo'));
+      const filteredQuery = query('foo', filter('matches', '==', true));
+      const fullQuery = query('foo');
       return (
         expectLocalStore()
           // Add two document results for a simple filter query

--- a/packages/firestore/test/unit/local/lru_garbage_collector.test.ts
+++ b/packages/firestore/test/unit/local/lru_garbage_collector.test.ts
@@ -19,7 +19,6 @@ import { expect } from 'chai';
 import { Timestamp } from '../../../src/api/timestamp';
 import { User } from '../../../src/auth/user';
 import { ListenSequence } from '../../../src/core/listen_sequence';
-import { Query } from '../../../src/core/query';
 import { ListenSequenceNumber, TargetId } from '../../../src/core/types';
 import { IndexedDbPersistence } from '../../../src/local/indexeddb_persistence';
 import {
@@ -47,7 +46,7 @@ import {
   SetMutation
 } from '../../../src/model/mutation';
 import { AsyncQueue } from '../../../src/util/async_queue';
-import { key, path, version, wrapObject } from '../../util/helpers';
+import { key, version, wrapObject, query } from '../../util/helpers';
 import { SortedMap } from '../../../src/util/sorted_map';
 import * as PersistenceTestHelpers from './persistence_test_helpers';
 import { primitiveComparator } from '../../../src/util/misc';
@@ -129,7 +128,7 @@ function genericLruGarbageCollectorTests(
   function nextTargetData(sequenceNumber: ListenSequenceNumber): TargetData {
     const targetId = ++previousTargetId;
     return new TargetData(
-      Query.atPath(path('path' + targetId)).toTarget(),
+      query('path' + targetId).toTarget(),
       targetId,
       TargetPurpose.Listen,
       sequenceNumber

--- a/packages/firestore/test/unit/local/mutation_queue.test.ts
+++ b/packages/firestore/test/unit/local/mutation_queue.test.ts
@@ -17,7 +17,6 @@
 
 import { expect } from 'chai';
 import { User } from '../../../src/auth/user';
-import { Query } from '../../../src/core/query';
 import { IndexedDbPersistence } from '../../../src/local/indexeddb_persistence';
 import { Persistence } from '../../../src/local/persistence';
 import { documentKeySet } from '../../../src/model/collections';
@@ -26,7 +25,7 @@ import {
   expectEqualArrays,
   key,
   patchMutation,
-  path,
+  query,
   setMutation
 } from '../../util/helpers';
 
@@ -266,9 +265,9 @@ function genericMutationQueueTests(): void {
       batches.push(batch);
     }
     const expected = [batches[1], batches[2], batches[4]];
-    const query = Query.atPath(path('foo'));
+    const query1 = query('foo');
     const matches = await mutationQueue.getAllMutationBatchesAffectingQuery(
-      query
+      query1
     );
     expectEqualArrays(matches, expected);
   });
@@ -284,9 +283,9 @@ function genericMutationQueueTests(): void {
       setMutation('foo/baz', value)
     ]);
     const expected = [batch1, batch2];
-    const query = Query.atPath(path('foo'));
+    const query1 = query('foo');
     const matches = await mutationQueue.getAllMutationBatchesAffectingQuery(
-      query
+      query1
     );
     expectEqualArrays(matches, expected);
   });

--- a/packages/firestore/test/unit/local/remote_document_cache.test.ts
+++ b/packages/firestore/test/unit/local/remote_document_cache.test.ts
@@ -16,7 +16,6 @@
  */
 
 import { expect } from 'chai';
-import { Query } from '../../../src/core/query';
 import { SnapshotVersion } from '../../../src/core/snapshot_version';
 import { IndexedDbPersistence } from '../../../src/local/indexeddb_persistence';
 import { MaybeDocument } from '../../../src/model/document';
@@ -25,7 +24,7 @@ import {
   doc,
   expectEqual,
   key,
-  path,
+  query,
   removedDoc,
   version
 } from '../../util/helpers';
@@ -368,9 +367,9 @@ function genericRemoteDocumentCacheTests(
       version(VERSION)
     );
 
-    const query = new Query(path('b'));
+    const query1 = query('b');
     const matchingDocs = await cache.getDocumentsMatchingQuery(
-      query,
+      query1,
       SnapshotVersion.min()
     );
 
@@ -394,9 +393,9 @@ function genericRemoteDocumentCacheTests(
       /* readTime= */ version(13)
     );
 
-    const query = new Query(path('b'));
+    const query1 = query('b');
     const matchingDocs = await cache.getDocumentsMatchingQuery(
-      query,
+      query1,
       /* sinceReadTime= */ version(12)
     );
     assertMatches([doc('b/new', 3, DOC_DATA)], matchingDocs);
@@ -412,9 +411,9 @@ function genericRemoteDocumentCacheTests(
       /* readTime= */ version(1)
     );
 
-    const query = new Query(path('b'));
+    const query1 = query('b');
     const matchingDocs = await cache.getDocumentsMatchingQuery(
-      query,
+      query1,
       /* sinceReadTime= */ version(1)
     );
     assertMatches([doc('b/old', 1, DOC_DATA)], matchingDocs);

--- a/packages/firestore/test/unit/local/target_cache.test.ts
+++ b/packages/firestore/test/unit/local/target_cache.test.ts
@@ -16,7 +16,6 @@
  */
 
 import { expect } from 'chai';
-import { Query } from '../../../src/core/query';
 import { SnapshotVersion } from '../../../src/core/snapshot_version';
 import { TargetId } from '../../../src/core/types';
 import { IndexedDbPersistence } from '../../../src/local/indexeddb_persistence';
@@ -26,7 +25,7 @@ import { addEqualityMatcher } from '../../util/equality_matcher';
 import {
   filter,
   key,
-  path,
+  query,
   resumeTokenForSnapshot,
   version
 } from '../../util/helpers';
@@ -70,7 +69,7 @@ describe('IndexedDbTargetCache', () => {
     const lastLimboFreeSnapshotVersion = SnapshotVersion.fromTimestamp(
       new Timestamp(3, 4)
     );
-    const target = Query.atPath(path('rooms')).toTarget();
+    const target = query('rooms').toTarget();
     const targetData = new TargetData(
       target,
       targetId,
@@ -114,9 +113,9 @@ function genericTargetCacheTests(
   addEqualityMatcher({ equalsFn: targetEquals, forType: TargetImpl });
   let cache: TestTargetCache;
 
-  const QUERY_ROOMS = Query.atPath(path('rooms')).toTarget();
-  const QUERY_HALLS = Query.atPath(path('halls')).toTarget();
-  const QUERY_GARAGES = Query.atPath(path('garages')).toTarget();
+  const QUERY_ROOMS = query('rooms').toTarget();
+  const QUERY_HALLS = query('halls').toTarget();
+  const QUERY_GARAGES = query('garages').toTarget();
 
   /**
    * Creates a new TargetData object from the the given parameters, synthesizing
@@ -173,12 +172,8 @@ function genericTargetCacheTests(
   it('handles canonical ID collisions', async () => {
     // Type information is currently lost in our canonicalID implementations so
     // this currently an easy way to force colliding canonicalIDs
-    const q1 = Query.atPath(path('a'))
-      .addFilter(filter('foo', '==', 1))
-      .toTarget();
-    const q2 = Query.atPath(path('a'))
-      .addFilter(filter('foo', '==', '1'))
-      .toTarget();
+    const q1 = query('a', filter('foo', '==', 1)).toTarget();
+    const q2 = query('a', filter('foo', '==', '1')).toTarget();
     expect(canonifyTarget(q1)).to.equal(canonifyTarget(q2));
 
     const data1 = testTargetData(q1, 1, 1);

--- a/packages/firestore/test/unit/remote/serializer.helper.ts
+++ b/packages/firestore/test/unit/remote/serializer.helper.ts
@@ -32,8 +32,7 @@ import {
   InFilter,
   KeyFieldFilter,
   Operator,
-  OrderBy,
-  Query
+  OrderBy
 } from '../../../src/core/query';
 import { SnapshotVersion } from '../../../src/core/snapshot_version';
 import { Target, targetEquals, TargetImpl } from '../../../src/core/target';
@@ -97,7 +96,7 @@ import {
   key,
   orderBy,
   patchMutation,
-  path,
+  query,
   ref,
   setMutation,
   testUserDataReader,
@@ -948,7 +947,7 @@ export function serializerTest(
     });
 
     it('encodes listen request labels', () => {
-      const target = Query.atPath(path('collection/key')).toTarget();
+      const target = query('collection/key').toTarget();
       let targetData = new TargetData(target, 2, TargetPurpose.Listen, 3);
 
       let result = toListenRequestLabels(s, targetData);
@@ -974,17 +973,18 @@ export function serializerTest(
       addEqualityMatcher({ equalsFn: targetEquals, forType: TargetImpl });
 
       it('converts first-level key queries', () => {
-        const q = Query.atPath(path('docs/1')).toTarget();
+        const q = query('docs/1').toTarget();
         const result = toTarget(s, wrapTargetData(q));
         expect(result).to.deep.equal({
           documents: { documents: ['projects/p/databases/d/documents/docs/1'] },
           targetId: 1
         });
-        expect(fromDocumentsTarget(toDocumentsTarget(s, q))).to.deep.equal(q);
+        const target = fromDocumentsTarget(toDocumentsTarget(s, q));
+        expect(target).to.deep.equal(q);
       });
 
       it('converts first-level ancestor queries', () => {
-        const q = Query.atPath(path('messages')).toTarget();
+        const q = query('messages').toTarget();
         const result = toTarget(s, wrapTargetData(q));
         expect(result).to.deep.equal({
           query: {
@@ -1005,9 +1005,7 @@ export function serializerTest(
       });
 
       it('converts nested ancestor queries', () => {
-        const q = Query.atPath(
-          path('rooms/1/messages/10/attachments')
-        ).toTarget();
+        const q = query('rooms/1/messages/10/attachments').toTarget();
         const result = toTarget(s, wrapTargetData(q));
         const expected = {
           query: {
@@ -1029,9 +1027,7 @@ export function serializerTest(
       });
 
       it('converts single filters at first-level collections', () => {
-        const q = Query.atPath(path('docs'))
-          .addFilter(filter('prop', '<', 42))
-          .toTarget();
+        const q = query('docs', filter('prop', '<', 42)).toTarget();
         const result = toTarget(s, wrapTargetData(q));
         const expected = {
           query: {
@@ -1064,13 +1060,14 @@ export function serializerTest(
       });
 
       it('converts multiple filters at first-level collections', () => {
-        const q = Query.atPath(path('docs'))
-          .addFilter(filter('prop', '<', 42))
-          .addFilter(filter('name', '==', 'dimond'))
-          .addFilter(filter('nan', '==', NaN))
-          .addFilter(filter('null', '==', null))
-          .addFilter(filter('tags', 'array-contains', 'pending'))
-          .toTarget();
+        const q = query(
+          'docs',
+          filter('prop', '<', 42),
+          filter('name', '==', 'dimond'),
+          filter('nan', '==', NaN),
+          filter('null', '==', null),
+          filter('tags', 'array-contains', 'pending')
+        ).toTarget();
         const result = toTarget(s, wrapTargetData(q));
         const expected = {
           query: {
@@ -1136,9 +1133,10 @@ export function serializerTest(
       });
 
       it('converts single filters on deeper collections', () => {
-        const q = Query.atPath(path('rooms/1/messages/10/attachments'))
-          .addFilter(filter('prop', '<', 42))
-          .toTarget();
+        const q = query(
+          'rooms/1/messages/10/attachments',
+          filter('prop', '<', 42)
+        ).toTarget();
         const result = toTarget(s, wrapTargetData(q));
         const expected = {
           query: {
@@ -1171,9 +1169,7 @@ export function serializerTest(
       });
 
       it('converts order bys', () => {
-        const q = Query.atPath(path('docs'))
-          .addOrderBy(orderBy('prop', 'asc'))
-          .toTarget();
+        const q = query('docs', orderBy('prop', 'asc')).toTarget();
         const result = toTarget(s, wrapTargetData(q));
         const expected = {
           query: {
@@ -1199,7 +1195,7 @@ export function serializerTest(
       });
 
       it('converts limits', () => {
-        const q = Query.atPath(path('docs')).withLimitToFirst(26).toTarget();
+        const q = query('docs').withLimitToFirst(26).toTarget();
         const result = toTarget(s, wrapTargetData(q));
         const expected = {
           query: {
@@ -1222,7 +1218,7 @@ export function serializerTest(
       });
 
       it('converts startAt/endAt', () => {
-        const q = Query.atPath(path('docs'))
+        const q = query('docs')
           .withStartAt(
             bound(
               [[DOCUMENT_KEY_NAME, ref('foo/bar'), 'asc']],
@@ -1275,7 +1271,7 @@ export function serializerTest(
       });
 
       it('converts resume tokens', () => {
-        const q = Query.atPath(path('docs')).toTarget();
+        const q = query('docs').toTarget();
         const result = toTarget(
           s,
           new TargetData(

--- a/packages/firestore/test/unit/specs/collection_spec.test.ts
+++ b/packages/firestore/test/unit/specs/collection_spec.test.ts
@@ -15,15 +15,14 @@
  * limitations under the License.
  */
 
-import { Query } from '../../../src/core/query';
-import { doc, path } from '../../util/helpers';
+import { doc, query } from '../../util/helpers';
 
 import { describeSpec, specTest } from './describe_spec';
 import { spec } from './spec_builder';
 
 describeSpec('Collections:', [], () => {
   specTest('Events are raised after watch ack', [], () => {
-    const query1 = Query.atPath(path('collection'));
+    const query1 = query('collection');
     const doc1 = doc('collection/key', 1000, { foo: 'bar' });
     return spec()
       .userListens(query1)
@@ -34,7 +33,7 @@ describeSpec('Collections:', [], () => {
   });
 
   specTest('Events are raised for local sets before watch ack', [], () => {
-    const query1 = Query.atPath(path('collection'));
+    const query1 = query('collection');
     const doc1 = doc(
       'collection/key',
       0,

--- a/packages/firestore/test/unit/specs/existence_filter_spec.test.ts
+++ b/packages/firestore/test/unit/specs/existence_filter_spec.test.ts
@@ -17,7 +17,7 @@
 
 import { Query } from '../../../src/core/query';
 import { Code } from '../../../src/util/error';
-import { deletedDoc, doc, path } from '../../util/helpers';
+import { deletedDoc, doc, query } from '../../util/helpers';
 
 import { describeSpec, specTest } from './describe_spec';
 import { spec } from './spec_builder';
@@ -25,188 +25,188 @@ import { RpcError } from './spec_rpc_error';
 
 describeSpec('Existence Filters:', [], () => {
   specTest('Existence filter match', [], () => {
-    const query = Query.atPath(path('collection'));
+    const query1 = query('collection');
     const doc1 = doc('collection/1', 1000, { v: 1 });
     return spec()
-      .userListens(query)
-      .watchAcksFull(query, 1000, doc1)
-      .expectEvents(query, { added: [doc1] })
-      .watchFilters([query], doc1.key)
+      .userListens(query1)
+      .watchAcksFull(query1, 1000, doc1)
+      .expectEvents(query1, { added: [doc1] })
+      .watchFilters([query1], doc1.key)
       .watchSnapshots(2000);
   });
 
   specTest('Existence filter match after pending update', [], () => {
-    const query = Query.atPath(path('collection'));
+    const query1 = query('collection');
     const doc1 = doc('collection/1', 2000, { v: 2 });
     return spec()
-      .userListens(query)
-      .watchAcks(query)
-      .watchCurrents(query, 'resume-token-1000')
+      .userListens(query1)
+      .watchAcks(query1)
+      .watchCurrents(query1, 'resume-token-1000')
       .watchSnapshots(2000)
-      .expectEvents(query, {})
-      .watchSends({ affects: [query] }, doc1)
-      .watchFilters([query], doc1.key)
+      .expectEvents(query1, {})
+      .watchSends({ affects: [query1] }, doc1)
+      .watchFilters([query1], doc1.key)
       .watchSnapshots(2000)
-      .expectEvents(query, { added: [doc1] });
+      .expectEvents(query1, { added: [doc1] });
   });
 
   specTest('Existence filter with empty target', [], () => {
-    const query = Query.atPath(path('collection'));
+    const query1 = query('collection');
     const doc1 = doc('collection/1', 2000, { v: 2 });
     return spec()
-      .userListens(query)
-      .watchAcks(query)
-      .watchCurrents(query, 'resume-token-1000')
+      .userListens(query1)
+      .watchAcks(query1)
+      .watchCurrents(query1, 'resume-token-1000')
       .watchSnapshots(2000)
-      .expectEvents(query, {})
-      .watchFilters([query], doc1.key)
+      .expectEvents(query1, {})
+      .watchFilters([query1], doc1.key)
       .watchSnapshots(2000)
-      .expectEvents(query, { fromCache: true });
+      .expectEvents(query1, { fromCache: true });
   });
 
   specTest('Existence filter ignored with pending target', [], () => {
-    const query = Query.atPath(path('collection'));
+    const query1 = query('collection');
     const doc1 = doc('collection/1', 2000, { v: 2 });
     return (
       spec()
         .withGCEnabled(false)
-        .userListens(query)
-        .watchAcksFull(query, 1000, doc1)
-        .expectEvents(query, { added: [doc1] })
-        .userUnlistens(query)
-        .userListens(query, 'resume-token-1000')
-        .expectEvents(query, { added: [doc1], fromCache: true })
+        .userListens(query1)
+        .watchAcksFull(query1, 1000, doc1)
+        .expectEvents(query1, { added: [doc1] })
+        .userUnlistens(query1)
+        .userListens(query1, 'resume-token-1000')
+        .expectEvents(query1, { added: [doc1], fromCache: true })
         // The empty existence filter is ignored since Watch hasn't ACKed the
         // target
-        .watchFilters([query])
-        .watchRemoves(query)
-        .watchAcks(query)
-        .watchCurrents(query, 'resume-token-2000')
+        .watchFilters([query1])
+        .watchRemoves(query1)
+        .watchAcks(query1)
+        .watchCurrents(query1, 'resume-token-2000')
         .watchSnapshots(2000)
-        .expectEvents(query, {})
+        .expectEvents(query1, {})
     );
   });
 
   specTest('Existence filter mismatch triggers re-run of query', [], () => {
-    const query = Query.atPath(path('collection'));
+    const query1 = query('collection');
     const doc1 = doc('collection/1', 1000, { v: 1 });
     const doc2 = doc('collection/2', 1000, { v: 2 });
     return (
       spec()
-        .userListens(query)
-        .watchAcksFull(query, 1000, doc1, doc2)
-        .expectEvents(query, { added: [doc1, doc2] })
-        .watchFilters([query], doc1.key) // in the next sync doc2 was deleted
+        .userListens(query1)
+        .watchAcksFull(query1, 1000, doc1, doc2)
+        .expectEvents(query1, { added: [doc1, doc2] })
+        .watchFilters([query1], doc1.key) // in the next sync doc2 was deleted
         .watchSnapshots(2000)
         // query is now marked as "inconsistent" because of filter mismatch
-        .expectEvents(query, { fromCache: true })
-        .expectActiveTargets({ query, resumeToken: '' })
-        .watchRemoves(query) // Acks removal of query
-        .watchAcksFull(query, 2000, doc1)
+        .expectEvents(query1, { fromCache: true })
+        .expectActiveTargets({ query: query1, resumeToken: '' })
+        .watchRemoves(query1) // Acks removal of query
+        .watchAcksFull(query1, 2000, doc1)
         .expectLimboDocs(doc2.key) // doc2 is now in limbo
         .ackLimbo(2000, deletedDoc('collection/2', 2000))
         .expectLimboDocs() // doc2 is no longer in limbo
-        .expectEvents(query, {
+        .expectEvents(query1, {
           removed: [doc2]
         })
     );
   });
 
   specTest('Existence filter mismatch will drop resume token', [], () => {
-    const query = Query.atPath(path('collection'));
+    const query1 = query('collection');
     const doc1 = doc('collection/1', 1000, { v: 1 });
     const doc2 = doc('collection/2', 1000, { v: 2 });
     return (
       spec()
-        .userListens(query)
-        .watchAcks(query)
-        .watchSends({ affects: [query] }, doc1, doc2)
-        .watchCurrents(query, 'existence-filter-resume-token')
+        .userListens(query1)
+        .watchAcks(query1)
+        .watchSends({ affects: [query1] }, doc1, doc2)
+        .watchCurrents(query1, 'existence-filter-resume-token')
         .watchSnapshots(1000)
-        .expectEvents(query, { added: [doc1, doc2] })
+        .expectEvents(query1, { added: [doc1, doc2] })
         .watchStreamCloses(Code.UNAVAILABLE)
         .expectActiveTargets({
-          query,
+          query: query1,
           resumeToken: 'existence-filter-resume-token'
         })
-        .watchAcks(query)
-        .watchFilters([query], doc1.key) // in the next sync doc2 was deleted
+        .watchAcks(query1)
+        .watchFilters([query1], doc1.key) // in the next sync doc2 was deleted
         .watchSnapshots(2000)
         // query is now marked as "inconsistent" because of filter mismatch
-        .expectEvents(query, { fromCache: true })
-        .expectActiveTargets({ query, resumeToken: '' })
-        .watchRemoves(query) // Acks removal of query
-        .watchAcksFull(query, 2000, doc1)
+        .expectEvents(query1, { fromCache: true })
+        .expectActiveTargets({ query: query1, resumeToken: '' })
+        .watchRemoves(query1) // Acks removal of query
+        .watchAcksFull(query1, 2000, doc1)
         .expectLimboDocs(doc2.key) // doc2 is now in limbo
         .ackLimbo(2000, deletedDoc('collection/2', 2000))
         .expectLimboDocs() // doc2 is no longer in limbo
-        .expectEvents(query, {
+        .expectEvents(query1, {
           removed: [doc2]
         })
     );
   });
 
   specTest('Existence filter handled at global snapshot', [], () => {
-    const query = Query.atPath(path('collection'));
+    const query1 = query('collection');
     const doc1 = doc('collection/1', 1000, { v: 1 });
     const doc2 = doc('collection/2', 2000, { v: 2 });
     const doc3 = doc('collection/3', 3000, { v: 3 });
     return (
       spec()
-        .userListens(query)
-        .watchAcksFull(query, 1000, doc1)
-        .expectEvents(query, { added: [doc1] })
+        .userListens(query1)
+        .watchAcksFull(query1, 1000, doc1)
+        .expectEvents(query1, { added: [doc1] })
         // Send a mismatching existence filter with two documents, but don't
         // send a new global snapshot. We should not see an event until we
         // receive the snapshot.
-        .watchFilters([query], doc1.key, doc2.key)
-        .watchSends({ affects: [query] }, doc3)
+        .watchFilters([query1], doc1.key, doc2.key)
+        .watchSends({ affects: [query1] }, doc3)
         .watchSnapshots(2000)
         // The query result includes doc3, but is marked as "inconsistent"
         // due to the filter mismatch
-        .expectEvents(query, { added: [doc3], fromCache: true })
-        .expectActiveTargets({ query, resumeToken: '' })
-        .watchRemoves(query) // Acks removal of query
-        .watchAcksFull(query, 3000, doc1, doc2, doc3)
-        .expectEvents(query, { added: [doc2] })
+        .expectEvents(query1, { added: [doc3], fromCache: true })
+        .expectActiveTargets({ query: query1, resumeToken: '' })
+        .watchRemoves(query1) // Acks removal of query
+        .watchAcksFull(query1, 3000, doc1, doc2, doc3)
+        .expectEvents(query1, { added: [doc2] })
     );
   });
 
   specTest('Existence filter synthesizes deletes', [], () => {
-    const query = Query.atPath(path('collection/a'));
+    const query1 = query('collection/a');
     const docA = doc('collection/a', 1000, { v: 1 });
     return spec()
-      .userListens(query)
-      .watchAcksFull(query, 1000, docA)
-      .expectEvents(query, { added: [docA] })
-      .watchFilters([query])
+      .userListens(query1)
+      .watchAcksFull(query1, 1000, docA)
+      .expectEvents(query1, { added: [docA] })
+      .watchFilters([query1])
       .watchSnapshots(2000)
-      .expectEvents(query, { removed: [docA] });
+      .expectEvents(query1, { removed: [docA] });
   });
 
   specTest('Existence filter limbo resolution is denied', [], () => {
-    const query = Query.atPath(path('collection'));
+    const query1 = query('collection');
     const doc1 = doc('collection/1', 1000, { v: 1 });
     const doc2 = doc('collection/2', 1000, { v: 2 });
     return (
       spec()
-        .userListens(query)
-        .watchAcksFull(query, 1000, doc1, doc2)
-        .expectEvents(query, { added: [doc1, doc2] })
-        .watchFilters([query], doc1.key) // in the next sync doc2 was deleted
+        .userListens(query1)
+        .watchAcksFull(query1, 1000, doc1, doc2)
+        .expectEvents(query1, { added: [doc1, doc2] })
+        .watchFilters([query1], doc1.key) // in the next sync doc2 was deleted
         .watchSnapshots(2000)
         // query is now marked as "inconsistent" because of filter mismatch
-        .expectEvents(query, { fromCache: true })
-        .expectActiveTargets({ query, resumeToken: '' })
-        .watchRemoves(query) // Acks removal of query
-        .watchAcksFull(query, 2000, doc1)
+        .expectEvents(query1, { fromCache: true })
+        .expectActiveTargets({ query: query1, resumeToken: '' })
+        .watchRemoves(query1) // Acks removal of query
+        .watchAcksFull(query1, 2000, doc1)
         .expectLimboDocs(doc2.key) // doc2 is now in limbo
         .watchRemoves(
           Query.atPath(doc2.key.path),
           new RpcError(Code.PERMISSION_DENIED, 'no')
         )
         .expectLimboDocs() // doc2 is no longer in limbo
-        .expectEvents(query, {
+        .expectEvents(query1, {
           removed: [doc2]
         })
     );

--- a/packages/firestore/test/unit/specs/limbo_spec.test.ts
+++ b/packages/firestore/test/unit/specs/limbo_spec.test.ts
@@ -16,7 +16,7 @@
  */
 
 import { Query } from '../../../src/core/query';
-import { deletedDoc, doc, filter, path, orderBy } from '../../util/helpers';
+import { deletedDoc, doc, filter, orderBy, query } from '../../util/helpers';
 
 import { TimerId } from '../../../src/util/async_queue';
 import { Code } from '../../../src/util/error';
@@ -29,7 +29,7 @@ describeSpec('Limbo Documents:', [], () => {
     'Limbo documents are deleted without an existence filter',
     [],
     () => {
-      const query1 = Query.atPath(path('collection'));
+      const query1 = query('collection');
       const doc1 = doc('collection/a', 1000, { key: 'a' });
       const limboQuery = Query.atPath(doc1.key.path);
       return (
@@ -59,7 +59,7 @@ describeSpec('Limbo Documents:', [], () => {
   );
 
   specTest('Limbo documents are deleted with an existence filter', [], () => {
-    const query1 = Query.atPath(path('collection'));
+    const query1 = query('collection');
     const doc1 = doc('collection/a', 1000, { key: 'a' });
     const limboQuery = Query.atPath(doc1.key.path);
     return (
@@ -88,9 +88,7 @@ describeSpec('Limbo Documents:', [], () => {
   });
 
   specTest('Limbo documents are resolved with updates', [], () => {
-    const query1 = Query.atPath(path('collection')).addFilter(
-      filter('key', '==', 'a')
-    );
+    const query1 = query('collection', filter('key', '==', 'a'));
     const doc1a = doc('collection/a', 1000, { key: 'a' });
     const doc1b = doc('collection/a', 1002, { key: 'b' });
     const limboQuery = Query.atPath(doc1a.key.path);
@@ -123,12 +121,8 @@ describeSpec('Limbo Documents:', [], () => {
     'Limbo documents are resolved with updates in different snapshot than "current"',
     [],
     () => {
-      const query1 = Query.atPath(path('collection')).addFilter(
-        filter('key', '==', 'a')
-      );
-      const query2 = Query.atPath(path('collection')).addFilter(
-        filter('key', '==', 'b')
-      );
+      const query1 = query('collection', filter('key', '==', 'a'));
+      const query2 = query('collection', filter('key', '==', 'b'));
       const doc1a = doc('collection/a', 1000, { key: 'a' });
       const doc1b = doc('collection/a', 1002, { key: 'b' });
       const limboQuery = Query.atPath(doc1a.key.path);
@@ -171,32 +165,33 @@ describeSpec('Limbo Documents:', [], () => {
   );
 
   specTest('Document remove message will cause docs to go in limbo', [], () => {
-    const query = Query.atPath(path('collection'));
+    const query1 = query('collection');
     const doc1 = doc('collection/a', 1000, { key: 'a' });
     const doc2 = doc('collection/b', 1001, { key: 'b' });
     const deletedDoc2 = deletedDoc('collection/b', 1004);
     return (
       spec()
-        .userListens(query)
-        .watchAcksFull(query, 1002, doc1, doc2)
-        .expectEvents(query, { added: [doc1, doc2] })
-        .watchRemovesDoc(doc2.key, query)
+        .userListens(query1)
+        .watchAcksFull(query1, 1002, doc1, doc2)
+        .expectEvents(query1, { added: [doc1, doc2] })
+        .watchRemovesDoc(doc2.key, query1)
         .watchSnapshots(1003)
         .expectLimboDocs(doc2.key)
         // Limbo document causes query to be "inconsistent"
-        .expectEvents(query, { fromCache: true })
+        .expectEvents(query1, { fromCache: true })
         .ackLimbo(1004, deletedDoc2)
         .expectLimboDocs()
-        .expectEvents(query, { removed: [doc2] })
+        .expectEvents(query1, { removed: [doc2] })
     );
   });
 
   // Regression test for b/72533250.
   specTest('Limbo resolution handles snapshot before CURRENT', [], () => {
-    const fullQuery = Query.atPath(path('collection'));
-    const limitQuery = Query.atPath(path('collection'))
-      .addFilter(filter('include', '==', true))
-      .withLimitToFirst(1);
+    const fullQuery = query('collection');
+    const limitQuery = query(
+      'collection',
+      filter('include', '==', true)
+    ).withLimitToFirst(1);
     const docA = doc('collection/a', 1000, { key: 'a', include: true });
     const docB = doc('collection/b', 1000, { key: 'b', include: true });
     const docBQuery = Query.atPath(docB.key.path);
@@ -263,10 +258,11 @@ describeSpec('Limbo Documents:', [], () => {
     'Limbo resolution handles snapshot before CURRENT [no document update]',
     [],
     () => {
-      const fullQuery = Query.atPath(path('collection'));
-      const limitQuery = Query.atPath(path('collection'))
-        .addFilter(filter('include', '==', true))
-        .withLimitToFirst(1);
+      const fullQuery = query('collection');
+      const limitQuery = query(
+        'collection',
+        filter('include', '==', true)
+      ).withLimitToFirst(1);
       const docA = doc('collection/a', 1000, { key: 'a', include: true });
       const docB = doc('collection/b', 1000, { key: 'b', include: true });
       const docBQuery = Query.atPath(docB.key.path);
@@ -328,10 +324,8 @@ describeSpec('Limbo Documents:', [], () => {
     // This test reproduces a customer issue where a failed limbo resolution
     // triggered an assert because we added a document to the cache with a
     // read time of zero.
-    const filteredQuery = Query.atPath(path('collection')).addFilter(
-      filter('matches', '==', true)
-    );
-    const fullQuery = Query.atPath(path('collection'));
+    const filteredQuery = query('collection', filter('matches', '==', true));
+    const fullQuery = query('collection');
     const remoteDoc = doc('collection/a', 1000, { matches: true });
     const localDoc = doc(
       'collection/a',
@@ -377,7 +371,7 @@ describeSpec('Limbo Documents:', [], () => {
         // This is internally propagated as a NoDocument with
         // SnapshotVersion.min() and a read time of zero.
         .watchRemoves(
-          Query.atPath(path('collection/a')),
+          query('collection/a'),
           new RpcError(Code.PERMISSION_DENIED, 'Permission denied')
         )
         .expectEvents(fullQuery, { removed: [remoteDoc] })
@@ -389,7 +383,7 @@ describeSpec('Limbo Documents:', [], () => {
     'Limbo docs are resolved by primary client',
     ['multi-client'],
     () => {
-      const query = Query.atPath(path('collection'));
+      const query1 = query('collection');
       const docA = doc('collection/a', 1000, { key: 'a' });
       const docB = doc('collection/b', 1001, { key: 'b' });
       const deletedDocB = deletedDoc('collection/b', 1004);
@@ -397,23 +391,23 @@ describeSpec('Limbo Documents:', [], () => {
       return client(0)
         .expectPrimaryState(true)
         .client(1)
-        .userListens(query)
+        .userListens(query1)
         .client(0)
-        .expectListen(query)
-        .watchAcksFull(query, 1002, docA, docB)
+        .expectListen(query1)
+        .watchAcksFull(query1, 1002, docA, docB)
         .client(1)
-        .expectEvents(query, { added: [docA, docB] })
+        .expectEvents(query1, { added: [docA, docB] })
         .client(0)
-        .watchRemovesDoc(docB.key, query)
+        .watchRemovesDoc(docB.key, query1)
         .watchSnapshots(1003)
         .expectLimboDocs(docB.key)
         .client(1)
-        .expectEvents(query, { fromCache: true })
+        .expectEvents(query1, { fromCache: true })
         .client(0)
         .ackLimbo(1004, deletedDocB)
         .expectLimboDocs()
         .client(1)
-        .expectEvents(query, { removed: [docB] });
+        .expectEvents(query1, { removed: [docB] });
     }
   );
 
@@ -421,7 +415,7 @@ describeSpec('Limbo Documents:', [], () => {
     'Limbo documents are resolved after primary tab failover',
     ['multi-client'],
     () => {
-      const query = Query.atPath(path('collection'));
+      const query1 = query('collection');
       const docA = doc('collection/a', 1000, { key: 'a' });
       const docB = doc('collection/b', 1001, { key: 'b' });
       const deletedDocB = deletedDoc('collection/b', 1005);
@@ -429,27 +423,27 @@ describeSpec('Limbo Documents:', [], () => {
       return client(0, false)
         .expectPrimaryState(true)
         .client(1)
-        .userListens(query)
+        .userListens(query1)
         .client(0)
-        .expectListen(query)
-        .watchAcksFull(query, 1 * 1e6, docA, docB)
+        .expectListen(query1)
+        .watchAcksFull(query1, 1 * 1e6, docA, docB)
         .client(1)
-        .expectEvents(query, { added: [docA, docB] })
+        .expectEvents(query1, { added: [docA, docB] })
         .client(0)
-        .watchRemovesDoc(docB.key, query)
+        .watchRemovesDoc(docB.key, query1)
         .watchSnapshots(2 * 1e6)
         .expectLimboDocs(docB.key)
         .shutdown()
         .client(1)
-        .expectEvents(query, { fromCache: true })
+        .expectEvents(query1, { fromCache: true })
         .runTimer(TimerId.ClientMetadataRefresh)
         .expectPrimaryState(true)
-        .expectListen(query, 'resume-token-1000000')
-        .watchAcksFull(query, 3 * 1e6)
+        .expectListen(query1, 'resume-token-1000000')
+        .watchAcksFull(query1, 3 * 1e6)
         .expectLimboDocs(docB.key)
         .ackLimbo(4 * 1e6, deletedDocB)
         .expectLimboDocs()
-        .expectEvents(query, { removed: [docB] });
+        .expectEvents(query1, { removed: [docB] });
     }
   );
 
@@ -457,7 +451,7 @@ describeSpec('Limbo Documents:', [], () => {
     'Limbo documents survive primary state transitions',
     ['multi-client'],
     () => {
-      const query = Query.atPath(path('collection'));
+      const query1 = query('collection');
       const docA = doc('collection/a', 1000, { key: 'a' });
       const docB = doc('collection/b', 1001, { key: 'b' });
       const docC = doc('collection/c', 1002, { key: 'c' });
@@ -466,45 +460,43 @@ describeSpec('Limbo Documents:', [], () => {
 
       return client(0, false)
         .expectPrimaryState(true)
-        .userListens(query)
-        .watchAcksFull(query, 1 * 1e6, docA, docB, docC)
-        .expectEvents(query, { added: [docA, docB, docC] })
-        .watchRemovesDoc(docB.key, query)
-        .watchRemovesDoc(docC.key, query)
+        .userListens(query1)
+        .watchAcksFull(query1, 1 * 1e6, docA, docB, docC)
+        .expectEvents(query1, { added: [docA, docB, docC] })
+        .watchRemovesDoc(docB.key, query1)
+        .watchRemovesDoc(docC.key, query1)
         .watchSnapshots(2 * 1e6)
-        .expectEvents(query, { fromCache: true })
+        .expectEvents(query1, { fromCache: true })
         .expectLimboDocs(docB.key, docC.key)
         .client(1)
         .stealPrimaryLease()
-        .expectListen(query, 'resume-token-1000000')
+        .expectListen(query1, 'resume-token-1000000')
         .client(0)
         .runTimer(TimerId.ClientMetadataRefresh)
         .expectPrimaryState(false)
         .expectLimboDocs()
         .client(1)
-        .watchAcksFull(query, 3 * 1e6)
+        .watchAcksFull(query1, 3 * 1e6)
         .expectLimboDocs(docB.key, docC.key)
         .ackLimbo(3 * 1e6, deletedDocB)
         .expectLimboDocs(docC.key)
         .client(0)
-        .expectEvents(query, { removed: [docB], fromCache: true })
+        .expectEvents(query1, { removed: [docB], fromCache: true })
         .stealPrimaryLease()
-        .expectListen(query, 'resume-token-1000000')
-        .watchAcksFull(query, 5 * 1e6)
+        .expectListen(query1, 'resume-token-1000000')
+        .watchAcksFull(query1, 5 * 1e6)
         .expectLimboDocs(docC.key)
         .ackLimbo(6 * 1e6, deletedDocC)
         .expectLimboDocs()
-        .expectEvents(query, { removed: [docC] });
+        .expectEvents(query1, { removed: [docC] });
     }
   );
 
   specTest('Limbo documents stay consistent between views', [], () => {
     // This tests verifies that a document is consistent between views, even
     // if the document is only in Limbo in one of them.
-    const originalQuery = Query.atPath(path('collection'));
-    const filteredQuery = Query.atPath(path('collection')).addFilter(
-      filter('matches', '==', true)
-    );
+    const originalQuery = query('collection');
+    const filteredQuery = query('collection', filter('matches', '==', true));
 
     const docA = doc('collection/a', 1000, { matches: true });
     const docADirty = doc(
@@ -559,9 +551,10 @@ describeSpec('Limbo Documents:', [], () => {
     'LimitToLast query from secondary results in no expected limbo doc',
     ['multi-client'],
     () => {
-      const limitToLast = Query.atPath(path('collection'))
-        .addOrderBy(orderBy('val', 'desc'))
-        .withLimitToLast(3);
+      const limitToLast = query(
+        'collection',
+        orderBy('val', 'desc')
+      ).withLimitToLast(3);
       const docA = doc('collection/a', 1000, { val: 11 });
       const docB = doc('collection/b', 1000, { val: 12 });
       const docC = doc('collection/c', 1000, { val: 13 });
@@ -604,9 +597,10 @@ describeSpec('Limbo Documents:', [], () => {
     'LimitToLast query from secondary results in expected limbo doc',
     ['multi-client'],
     () => {
-      const limitToLast = Query.atPath(path('collection'))
-        .addOrderBy(orderBy('val', 'desc'))
-        .withLimitToLast(3);
+      const limitToLast = query(
+        'collection',
+        orderBy('val', 'desc')
+      ).withLimitToLast(3);
       const docA = doc('collection/a', 1000, { val: 11 });
       const docB = doc('collection/b', 1000, { val: 12 });
       const docC = doc('collection/c', 1000, { val: 13 });
@@ -646,7 +640,7 @@ describeSpec('Limbo Documents:', [], () => {
     //  resolution throttling.
     ['no-ios'],
     () => {
-      const query = Query.atPath(path('collection'));
+      const query1 = query('collection');
       const doc1 = doc('collection/a', 1000, { key: 'a' });
       const doc2 = doc('collection/b', 1000, { key: 'b' });
       const doc3 = doc('collection/c', 1000, { key: 'c' });
@@ -664,26 +658,26 @@ describeSpec('Limbo Documents:', [], () => {
       return (
         spec()
           .withMaxConcurrentLimboResolutions(2)
-          .userListens(query)
-          .watchAcksFull(query, 1000, doc1, doc2, doc3, doc4, doc5)
-          .expectEvents(query, {
+          .userListens(query1)
+          .watchAcksFull(query1, 1000, doc1, doc2, doc3, doc4, doc5)
+          .expectEvents(query1, {
             added: [doc1, doc2, doc3, doc4, doc5]
           })
-          .watchResets(query)
-          .watchSends({ affects: [query] })
-          .watchCurrents(query, 'resume-token-2000')
+          .watchResets(query1)
+          .watchSends({ affects: [query1] })
+          .watchCurrents(query1, 'resume-token-2000')
           .watchSnapshots(2000)
           .expectLimboDocs(doc1.key, doc2.key)
           .expectEnqueuedLimboDocs(doc3.key, doc4.key, doc5.key)
           // Limbo document causes query to be "inconsistent"
-          .expectEvents(query, { fromCache: true })
+          .expectEvents(query1, { fromCache: true })
           .watchAcks(limboQuery1)
           .watchAcks(limboQuery2)
           // Resolve limbo documents doc1 and doc2 in a single snapshot.
           .watchCurrents(limboQuery1, 'resume-token-2001')
           .watchCurrents(limboQuery2, 'resume-token-2001')
           .watchSnapshots(2001)
-          .expectEvents(query, {
+          .expectEvents(query1, {
             removed: [doc1, doc2],
             fromCache: true
           })
@@ -696,7 +690,7 @@ describeSpec('Limbo Documents:', [], () => {
           .watchCurrents(limboQuery3, 'resume-token-2002')
           .watchCurrents(limboQuery4, 'resume-token-2002')
           .watchSnapshots(2002)
-          .expectEvents(query, {
+          .expectEvents(query1, {
             removed: [doc3, doc4],
             fromCache: true
           })
@@ -707,7 +701,7 @@ describeSpec('Limbo Documents:', [], () => {
           // Resolve limbo document doc5.
           .watchCurrents(limboQuery5, 'resume-token-2003')
           .watchSnapshots(2003)
-          .expectEvents(query, {
+          .expectEvents(query1, {
             removed: [doc5],
             fromCache: false
           })
@@ -723,7 +717,7 @@ describeSpec('Limbo Documents:', [], () => {
     //  resolution throttling.
     ['no-ios'],
     () => {
-      const query = Query.atPath(path('collection'));
+      const query1 = query('collection');
       const doc1 = doc('collection/a', 1000, { key: 'a' });
       const doc2 = doc('collection/b', 1000, { key: 'b' });
       const doc3 = doc('collection/c', 1000, { key: 'c' });
@@ -741,25 +735,25 @@ describeSpec('Limbo Documents:', [], () => {
       return (
         spec()
           .withMaxConcurrentLimboResolutions(2)
-          .userListens(query)
-          .watchAcksFull(query, 1000, doc1, doc2, doc3, doc4, doc5)
-          .expectEvents(query, {
+          .userListens(query1)
+          .watchAcksFull(query1, 1000, doc1, doc2, doc3, doc4, doc5)
+          .expectEvents(query1, {
             added: [doc1, doc2, doc3, doc4, doc5]
           })
-          .watchResets(query)
-          .watchSends({ affects: [query] })
-          .watchCurrents(query, 'resume-token-2000')
+          .watchResets(query1)
+          .watchSends({ affects: [query1] })
+          .watchCurrents(query1, 'resume-token-2000')
           .watchSnapshots(2000)
           .expectLimboDocs(doc1.key, doc2.key)
           .expectEnqueuedLimboDocs(doc3.key, doc4.key, doc5.key)
           // Limbo document causes query to be "inconsistent"
-          .expectEvents(query, { fromCache: true })
+          .expectEvents(query1, { fromCache: true })
           .watchAcks(limboQuery1)
           .watchAcks(limboQuery2)
           // Resolve the limbo documents doc1 in its own snapshot.
           .watchCurrents(limboQuery1, 'resume-token-2001')
           .watchSnapshots(2001)
-          .expectEvents(query, { removed: [doc1], fromCache: true })
+          .expectEvents(query1, { removed: [doc1], fromCache: true })
           // Start the next limbo resolution since one has finished.
           .expectLimboDocs(doc2.key, doc3.key)
           .expectEnqueuedLimboDocs(doc4.key, doc5.key)
@@ -767,7 +761,7 @@ describeSpec('Limbo Documents:', [], () => {
           // Resolve the limbo documents doc2 in its own snapshot.
           .watchCurrents(limboQuery2, 'resume-token-2002')
           .watchSnapshots(2002)
-          .expectEvents(query, { removed: [doc2], fromCache: true })
+          .expectEvents(query1, { removed: [doc2], fromCache: true })
           // Start the next limbo resolution since one has finished.
           .expectLimboDocs(doc3.key, doc4.key)
           .expectEnqueuedLimboDocs(doc5.key)
@@ -775,7 +769,7 @@ describeSpec('Limbo Documents:', [], () => {
           // Resolve the limbo documents doc3 in its own snapshot.
           .watchCurrents(limboQuery3, 'resume-token-2003')
           .watchSnapshots(2003)
-          .expectEvents(query, { removed: [doc3], fromCache: true })
+          .expectEvents(query1, { removed: [doc3], fromCache: true })
           // Start the next limbo resolution since one has finished.
           .expectLimboDocs(doc4.key, doc5.key)
           .expectEnqueuedLimboDocs()
@@ -783,14 +777,14 @@ describeSpec('Limbo Documents:', [], () => {
           // Resolve the limbo documents doc4 in its own snapshot.
           .watchCurrents(limboQuery4, 'resume-token-2004')
           .watchSnapshots(2004)
-          .expectEvents(query, { removed: [doc4], fromCache: true })
+          .expectEvents(query1, { removed: [doc4], fromCache: true })
           // The final limbo document listen is already active; resolve it.
           .expectLimboDocs(doc5.key)
           .expectEnqueuedLimboDocs()
           // Resolve the limbo documents doc5 in its own snapshot.
           .watchCurrents(limboQuery5, 'resume-token-2005')
           .watchSnapshots(2005)
-          .expectEvents(query, { removed: [doc5], fromCache: false })
+          .expectEvents(query1, { removed: [doc5], fromCache: false })
           .expectLimboDocs()
           .expectEnqueuedLimboDocs()
       );
@@ -803,7 +797,7 @@ describeSpec('Limbo Documents:', [], () => {
     //  resolution throttling.
     ['no-ios'],
     () => {
-      const query = Query.atPath(path('collection'));
+      const query1 = query('collection');
       const doc1 = doc('collection/a', 1000, { key: 'a' });
       const doc2 = doc('collection/b', 1000, { key: 'b' });
       const limboQuery1 = Query.atPath(doc1.key.path);
@@ -815,17 +809,17 @@ describeSpec('Limbo Documents:', [], () => {
       return (
         spec()
           .withMaxConcurrentLimboResolutions(1)
-          .userListens(query)
-          .watchAcksFull(query, 1000, doc1, doc2)
-          .expectEvents(query, { added: [doc1, doc2] })
-          .watchResets(query)
-          .watchSends({ affects: [query] })
-          .watchCurrents(query, 'resume-token-1001')
+          .userListens(query1)
+          .watchAcksFull(query1, 1000, doc1, doc2)
+          .expectEvents(query1, { added: [doc1, doc2] })
+          .watchResets(query1)
+          .watchSends({ affects: [query1] })
+          .watchCurrents(query1, 'resume-token-1001')
           .watchSnapshots(2000)
           .expectLimboDocs(doc1.key)
           .expectEnqueuedLimboDocs(doc2.key)
           // Limbo document causes query to be "inconsistent"
-          .expectEvents(query, { fromCache: true })
+          .expectEvents(query1, { fromCache: true })
           .watchRemoves(
             limboQuery1,
             new RpcError(Code.RESOURCE_EXHAUSTED, 'Resource exhausted')
@@ -833,7 +827,7 @@ describeSpec('Limbo Documents:', [], () => {
           // When a limbo listen gets rejected, we assume that it was deleted.
           // But now that doc1 is resolved, the limbo resolution for doc2 can
           // start.
-          .expectEvents(query, { removed: [doc1], fromCache: true })
+          .expectEvents(query1, { removed: [doc1], fromCache: true })
           .expectLimboDocs(doc2.key)
           .expectEnqueuedLimboDocs()
           // Reject the listen for the second limbo resolution as well, in order
@@ -843,7 +837,7 @@ describeSpec('Limbo Documents:', [], () => {
             limboQuery2,
             new RpcError(Code.RESOURCE_EXHAUSTED, 'Resource exhausted')
           )
-          .expectEvents(query, { removed: [doc2] })
+          .expectEvents(query1, { removed: [doc2] })
           .expectLimboDocs()
           .expectEnqueuedLimboDocs()
       );
@@ -856,7 +850,7 @@ describeSpec('Limbo Documents:', [], () => {
     //  resolution throttling.
     ['no-ios'],
     () => {
-      const query = Query.atPath(path('collection'));
+      const query1 = query('collection');
       const docA1 = doc('collection/a1', 1000, { key: 'a1' });
       const docA2 = doc('collection/a2', 1000, { key: 'a2' });
       const docA3 = doc('collection/a3', 1000, { key: 'a3' });
@@ -874,40 +868,40 @@ describeSpec('Limbo Documents:', [], () => {
       return (
         spec()
           .withMaxConcurrentLimboResolutions(2)
-          .userListens(query)
-          .watchAcks(query)
-          .watchSends({ affects: [query] }, docA1, docA2, docA3)
-          .watchCurrents(query, 'resume-token-1000')
+          .userListens(query1)
+          .watchAcks(query1)
+          .watchSends({ affects: [query1] }, docA1, docA2, docA3)
+          .watchCurrents(query1, 'resume-token-1000')
           .watchSnapshots(1000)
-          .expectEvents(query, { added: [docA1, docA2, docA3] })
+          .expectEvents(query1, { added: [docA1, docA2, docA3] })
           // Simulate that the client loses network connection.
           .disableNetwork()
           // Limbo document causes query to be "inconsistent"
-          .expectEvents(query, { fromCache: true })
+          .expectEvents(query1, { fromCache: true })
           .enableNetwork()
-          .restoreListen(query, 'resume-token-1000')
-          .watchAcks(query)
+          .restoreListen(query1, 'resume-token-1000')
+          .watchAcks(query1)
           // While this client was disconnected, another client deleted all the
           // docAs replaced them with docBs. If Watch has to re-run the
           // underlying query when this client re-listens, Watch won't be able
           // to tell that docAs were deleted and will only send us existing
           // documents that changed since the resume token. This will cause it
           // to just send the docBs with an existence filter with a count of 3.
-          .watchSends({ affects: [query] }, docB1, docB2, docB3)
-          .watchFilters([query], docB1.key, docB2.key, docB3.key)
+          .watchSends({ affects: [query1] }, docB1, docB2, docB3)
+          .watchFilters([query1], docB1.key, docB2.key, docB3.key)
           .watchSnapshots(1001)
-          .expectEvents(query, {
+          .expectEvents(query1, {
             added: [docB1, docB2, docB3],
             fromCache: true
           })
           // The view now contains the docAs and the docBs (6 documents), but
           // the existence filter indicated only 3 should match. This causes
           // the client to re-listen without a resume token.
-          .expectActiveTargets({ query, resumeToken: '' })
+          .expectActiveTargets({ query: query1, resumeToken: '' })
           // When the existence filter mismatch was detected, the client removed
           // then re-added the target. Watch needs to acknowledge the removal.
-          .watchRemoves(query)
-          .watchAcksFull(query, 1002, docB1, docB2, docB3)
+          .watchRemoves(query1)
+          .watchAcksFull(query1, 1002, docB1, docB2, docB3)
           // The docAs are now in limbo; the client begins limbo resolution.
           .expectLimboDocs(docA1.key, docA2.key)
           .expectEnqueuedLimboDocs(docA3.key)
@@ -916,13 +910,13 @@ describeSpec('Limbo Documents:', [], () => {
           .watchCurrents(docA1Query, 'resume-token-1003')
           .watchCurrents(docA2Query, 'resume-token-1003')
           .watchSnapshots(1003)
-          .expectEvents(query, { removed: [docA1, docA2], fromCache: true })
+          .expectEvents(query1, { removed: [docA1, docA2], fromCache: true })
           .expectLimboDocs(docA3.key)
           .expectEnqueuedLimboDocs()
           .watchAcks(docA3Query)
           .watchCurrents(docA3Query, 'resume-token-1004')
           .watchSnapshots(1004)
-          .expectEvents(query, { removed: [docA3] })
+          .expectEvents(query1, { removed: [docA3] })
           .expectLimboDocs()
           .expectEnqueuedLimboDocs()
       );

--- a/packages/firestore/test/unit/specs/limit_spec.test.ts
+++ b/packages/firestore/test/unit/specs/limit_spec.test.ts
@@ -15,15 +15,13 @@
  * limitations under the License.
  */
 
-import { Query } from '../../../src/core/query';
-import { deletedDoc, doc, filter, orderBy, path } from '../../util/helpers';
-
+import { deletedDoc, doc, filter, orderBy, query } from '../../util/helpers';
 import { describeSpec, specTest } from './describe_spec';
 import { client, spec } from './spec_builder';
 
 describeSpec('Limits:', [], () => {
   specTest('Documents in limit are replaced by remote event', [], () => {
-    const query1 = Query.atPath(path('collection')).withLimitToFirst(2);
+    const query1 = query('collection').withLimitToFirst(2);
     const doc1 = doc('collection/a', 1000, { key: 'a' });
     const doc2 = doc('collection/b', 1002, { key: 'b' });
     const doc3 = doc('collection/c', 1001, { key: 'c' });
@@ -46,7 +44,7 @@ describeSpec('Limits:', [], () => {
     "Documents outside of limit don't raise hasPendingWrites",
     [],
     () => {
-      const query1 = Query.atPath(path('collection')).withLimitToFirst(2);
+      const query1 = query('collection').withLimitToFirst(2);
       const doc1 = doc('collection/a', 1000, { key: 'a' });
       const doc2 = doc('collection/b', 1000, { key: 'b' });
 
@@ -68,27 +66,27 @@ describeSpec('Limits:', [], () => {
   );
 
   specTest('Deleted Document in limbo in full limit query', [], () => {
-    const query = Query.atPath(path('collection')).withLimitToFirst(2);
+    const query1 = query('collection').withLimitToFirst(2);
     const doc1 = doc('collection/a', 1000, { key: 'a' });
     const doc2 = doc('collection/b', 1001, { key: 'b' });
     const doc3 = doc('collection/c', 1002, { key: 'c' });
     return (
       spec()
-        .userListens(query)
-        .watchAcksFull(query, 1002, doc1, doc2)
-        .expectEvents(query, {
+        .userListens(query1)
+        .watchAcksFull(query1, 1002, doc1, doc2)
+        .expectEvents(query1, {
           added: [doc1, doc2]
         })
-        .watchResets(query)
-        .watchSends({ affects: [query] }, doc2, doc3)
-        .watchCurrents(query, 'resume-token-' + 2000)
+        .watchResets(query1)
+        .watchSends({ affects: [query1] }, doc2, doc3)
+        .watchCurrents(query1, 'resume-token-' + 2000)
         .watchSnapshots(2000)
         .expectLimboDocs(doc1.key)
         // Limbo document causes query to be "inconsistent"
-        .expectEvents(query, { fromCache: true })
+        .expectEvents(query1, { fromCache: true })
         .ackLimbo(2000, deletedDoc('collection/a', 2000))
         .expectLimboDocs()
-        .expectEvents(query, {
+        .expectEvents(query1, {
           added: [doc3],
           removed: [doc1]
         })
@@ -96,7 +94,7 @@ describeSpec('Limits:', [], () => {
   });
 
   specTest('Documents in limit can handle removed messages', [], () => {
-    const query1 = Query.atPath(path('collection')).withLimitToFirst(2);
+    const query1 = query('collection').withLimitToFirst(2);
     const doc1 = doc('collection/a', 1000, { key: 'a' });
     const doc2 = doc('collection/b', 1002, { key: 'b' });
     const doc3 = doc('collection/c', 1001, { key: 'c' });
@@ -123,8 +121,8 @@ describeSpec('Limits:', [], () => {
     'Documents in limit are can handle removed messages for only one of many query',
     [],
     () => {
-      const query1 = Query.atPath(path('collection')).withLimitToFirst(2);
-      const query2 = Query.atPath(path('collection')).withLimitToFirst(3);
+      const query1 = query('collection').withLimitToFirst(2);
+      const query2 = query('collection').withLimitToFirst(3);
       const doc1 = doc('collection/a', 1000, { key: 'a' });
       const doc2 = doc('collection/b', 1002, { key: 'b' });
       const doc3 = doc('collection/c', 1001, { key: 'c' });
@@ -159,12 +157,8 @@ describeSpec('Limits:', [], () => {
     // This test verifies that our Query handling backfills a limit query from
     // cache even if the backend has not told us that an existing
     // RemoteDocument is within the limit.
-    const fullQuery = Query.atPath(path('collection')).addFilter(
-      filter('matches', '==', true)
-    );
-    const limitQuery = Query.atPath(path('collection'))
-      .addFilter(filter('matches', '==', true))
-      .withLimitToFirst(2);
+    const fullQuery = query('collection', filter('matches', '==', true));
+    const limitQuery = fullQuery.withLimitToFirst(2);
     const doc1 = doc('collection/a', 1001, { matches: true });
     const doc2 = doc('collection/b', 1002, { matches: true });
     const doc3 = doc('collection/c', 1000, { matches: true });
@@ -190,12 +184,8 @@ describeSpec('Limits:', [], () => {
     () => {
       // Verify that views for limit queries are re-filled even if the initial
       // snapshot does not contain the requested number of results.
-      const fullQuery = Query.atPath(path('collection')).addFilter(
-        filter('matches', '==', true)
-      );
-      const limitQuery = Query.atPath(path('collection'))
-        .addFilter(filter('matches', '==', true))
-        .withLimitToFirst(2);
+      const fullQuery = query('collection', filter('matches', '==', true));
+      const limitQuery = fullQuery.withLimitToFirst(2);
       const doc1 = doc('collection/a', 1001, { matches: true });
       const doc2 = doc('collection/b', 1002, { matches: true });
       const doc3 = doc('collection/c', 1003, { matches: true });
@@ -224,10 +214,10 @@ describeSpec('Limits:', [], () => {
       // Verify that views for limit queries contain the correct set of documents
       // even if a previously matching document receives a latency-compensate update
       // that makes it sort below an older document.
-      const fullQuery = Query.atPath(path('collection'));
-      const limitQuery = Query.atPath(path('collection'))
-        .addOrderBy(orderBy('pos'))
-        .withLimitToFirst(2);
+      const fullQuery = query('collection');
+      const limitQuery = query('collection', orderBy('pos')).withLimitToFirst(
+        2
+      );
       const doc1 = doc('collection/a', 1001, { pos: 1 });
       const doc2 = doc('collection/b', 1002, { pos: 2 });
       const doc3 = doc('collection/c', 1003, { pos: 3 });
@@ -257,10 +247,10 @@ describeSpec('Limits:', [], () => {
       // Verify that views for limit queries contain the correct set of documents
       // even if a previously matching document receives an update from the backend
       // that makes it sort below an older document.
-      const fullQuery = Query.atPath(path('collection'));
-      const limitQuery = Query.atPath(path('collection'))
-        .addOrderBy(orderBy('pos'))
-        .withLimitToFirst(2);
+      const fullQuery = query('collection');
+      const limitQuery = query('collection', orderBy('pos')).withLimitToFirst(
+        2
+      );
       const doc1 = doc('collection/a', 1001, { pos: 1 });
       const doc1Edited = doc('collection/a', 1005, { pos: 4 });
       const doc2 = doc('collection/b', 1002, { pos: 2 });
@@ -294,12 +284,8 @@ describeSpec('Limits:', [], () => {
       // This test verifies that views for limit queries are updated even
       // when documents are deleted while the query is inactive.
 
-      const limitQuery = Query.atPath(path('collection'))
-        .addOrderBy(orderBy('a'))
-        .withLimitToFirst(1);
-      const fullQuery = Query.atPath(path('collection')).addOrderBy(
-        orderBy('a')
-      );
+      const limitQuery = query('collection', orderBy('a')).withLimitToFirst(1);
+      const fullQuery = query('collection', orderBy('a'));
 
       const firstDocument = doc('collection/a', 1001, { a: 1 });
       const firstDocumentDeleted = deletedDoc('collection/a', 1003);
@@ -370,10 +356,8 @@ describeSpec('Limits:', [], () => {
     // This test verifies that a resumed limit query will not contain documents
     // that fell out of the limit while the query was inactive.
 
-    const limitQuery = Query.atPath(path('collection'))
-      .addOrderBy(orderBy('a'))
-      .withLimitToFirst(1);
-    const fullQuery = Query.atPath(path('collection')).addOrderBy(orderBy('a'));
+    const limitQuery = query('collection', orderBy('a')).withLimitToFirst(1);
+    const fullQuery = query('collection', orderBy('a'));
 
     const firstDocument = doc('collection/a', 2001, { a: 1 });
     const firstDocumentUpdated = doc('collection/a', 2003, { a: 3 });
@@ -412,8 +396,8 @@ describeSpec('Limits:', [], () => {
   });
 
   specTest('Multiple docs in limbo in full limit query', [], () => {
-    const query1 = Query.atPath(path('collection')).withLimitToFirst(2);
-    const query2 = Query.atPath(path('collection'));
+    const query1 = query('collection').withLimitToFirst(2);
+    const query2 = query('collection');
     const docA = doc('collection/a', 1000, { key: 'a' });
     const docB = doc('collection/b', 1001, { key: 'b' });
     const docC = doc('collection/c', 1002, { key: 'c' });
@@ -504,7 +488,7 @@ describeSpec('Limits:', [], () => {
     'Limit query is refilled by primary client',
     ['multi-client'],
     () => {
-      const query1 = Query.atPath(path('collection')).withLimitToFirst(2);
+      const query1 = query('collection').withLimitToFirst(2);
       const doc1 = doc('collection/a', 1000, { key: 'a' });
       const doc2 = doc('collection/b', 1002, { key: 'b' });
       const doc3 = doc('collection/c', 1001, { key: 'c' });
@@ -535,7 +519,7 @@ describeSpec('Limits:', [], () => {
     'Limit query includes write from secondary client ',
     ['multi-client'],
     () => {
-      const query1 = Query.atPath(path('collection')).withLimitToFirst(2);
+      const query1 = query('collection').withLimitToFirst(2);
       const doc1 = doc('collection/a', 1003, { key: 'a' });
       const doc1Local = doc(
         'collection/a',

--- a/packages/firestore/test/unit/specs/listen_spec.test.ts
+++ b/packages/firestore/test/unit/specs/listen_spec.test.ts
@@ -15,9 +15,8 @@
  * limitations under the License.
  */
 
-import { Query } from '../../../src/core/query';
 import { Code } from '../../../src/util/error';
-import { deletedDoc, doc, filter, orderBy, path } from '../../util/helpers';
+import { deletedDoc, doc, filter, orderBy, query } from '../../util/helpers';
 
 import { TimerId } from '../../../src/util/async_queue';
 import { describeSpec, specTest } from './describe_spec';
@@ -31,16 +30,16 @@ describeSpec('Listens:', [], () => {
     ['eager-gc'],
     'Explicitly tests eager GC behavior',
     () => {
-      const query = Query.atPath(path('collection'));
+      const query1 = query('collection');
       const docA = doc('collection/a', 1000, { key: 'a' });
       return (
         spec()
-          .userListens(query)
-          .watchAcksFull(query, 1000, docA)
-          .expectEvents(query, { added: [docA] })
-          .userUnlistens(query)
+          .userListens(query1)
+          .watchAcksFull(query1, 1000, docA)
+          .expectEvents(query1, { added: [docA] })
+          .userUnlistens(query1)
           // should get no events.
-          .userListens(query)
+          .userListens(query1)
       );
     }
   );
@@ -50,10 +49,8 @@ describeSpec('Listens:', [], () => {
     ['eager-gc'],
     '',
     () => {
-      const filteredQuery = Query.atPath(path('collection')).addFilter(
-        filter('matches', '==', true)
-      );
-      const unfilteredQuery = Query.atPath(path('collection'));
+      const filteredQuery = query('collection', filter('matches', '==', true));
+      const unfilteredQuery = query('collection');
       const docA = doc('collection/a', 1000, { matches: true });
       const docB = doc('collection/b', 1000, { matches: true });
       return (
@@ -80,22 +77,22 @@ describeSpec('Listens:', [], () => {
   );
 
   specTest('Contents of query update when new data is received.', [], () => {
-    const query = Query.atPath(path('collection'));
+    const query1 = query('collection');
     const docA = doc('collection/a', 1000, { key: 'a' });
     const docB = doc('collection/b', 2000, { key: 'b' });
     return spec()
-      .userListens(query)
-      .watchAcksFull(query, 1000, docA)
-      .expectEvents(query, { added: [docA] })
-      .watchSends({ affects: [query] }, docB)
+      .userListens(query1)
+      .watchAcksFull(query1, 1000, docA)
+      .expectEvents(query1, { added: [docA] })
+      .watchSends({ affects: [query1] }, docB)
       .watchSnapshots(2000)
-      .expectEvents(query, { added: [docB] });
+      .expectEvents(query1, { added: [docB] });
   });
 
   specTest("Doesn't raise events for empty target", [], () => {
-    const query1 = Query.atPath(path('collection1'));
-    const query2 = Query.atPath(path('collection2'));
-    const query3 = Query.atPath(path('collection3'));
+    const query1 = query('collection1');
+    const query2 = query('collection2');
+    const query3 = query('collection3');
     const docA = doc('collection2/a', 1000, { key: 'a' });
     return (
       spec()
@@ -116,7 +113,7 @@ describeSpec('Listens:', [], () => {
   });
 
   specTest("Doesn't include unknown documents in cached result", [], () => {
-    const query1 = Query.atPath(path('collection'));
+    const query1 = query('collection');
     const existingDoc = doc(
       'collection/exists',
       0,
@@ -135,7 +132,7 @@ describeSpec('Listens:', [], () => {
   });
 
   specTest("Doesn't raise 'hasPendingWrites' for deletes", [], () => {
-    const query1 = Query.atPath(path('collection'));
+    const query1 = query('collection');
     const docA = doc('collection/a', 1000, { key: 'a' });
 
     return spec()
@@ -153,8 +150,8 @@ describeSpec('Listens:', [], () => {
     'Ensure correct query results with latency-compensated deletes',
     [],
     () => {
-      const query1 = Query.atPath(path('collection'));
-      const query2 = Query.atPath(path('collection')).withLimitToFirst(10);
+      const query1 = query('collection');
+      const query2 = query1.withLimitToFirst(10);
       const docA = doc('collection/a', 1000, { a: true });
       const docB = doc('collection/b', 1000, { b: true });
 
@@ -177,20 +174,20 @@ describeSpec('Listens:', [], () => {
   );
 
   specTest('Does not raise event for initial document delete', [], () => {
-    const query = Query.atPath(path('collection'));
+    const query1 = query('collection');
     const missingDoc = deletedDoc('collection/a', 1000);
     return (
       spec()
-        .userListens(query)
-        .watchAcks(query)
+        .userListens(query1)
+        .watchAcks(query1)
         // To indicate the document doesn't exist, watch sends a DocumentDelete
         // message as if the document previously existed and now is being
         // deleted/removed from the target.
-        .watchSends({ removed: [query] }, missingDoc)
+        .watchSends({ removed: [query1] }, missingDoc)
         .watchSnapshots(1000)
-        .watchCurrents(query, 'resume-token-2000')
+        .watchCurrents(query1, 'resume-token-2000')
         .watchSnapshots(2000)
-        .expectEvents(query, { fromCache: false })
+        .expectEvents(query1, { fromCache: false })
     );
   });
 
@@ -198,42 +195,42 @@ describeSpec('Listens:', [], () => {
     'Will process removals without waiting for a consistent snapshot',
     [],
     () => {
-      const query = Query.atPath(path('collection'));
+      const query1 = query('collection');
 
       return spec()
-        .userListens(query)
-        .watchAcks(query)
+        .userListens(query1)
+        .watchAcks(query1)
         .watchRemoves(
-          query,
+          query1,
           new RpcError(Code.RESOURCE_EXHAUSTED, 'Resource exhausted')
         )
-        .expectEvents(query, { errorCode: Code.RESOURCE_EXHAUSTED });
+        .expectEvents(query1, { errorCode: Code.RESOURCE_EXHAUSTED });
     }
   );
 
   specTest('Will re-issue listen for errored target', [], () => {
-    const query = Query.atPath(path('collection'));
+    const query1 = query('collection');
 
     return spec()
       .withGCEnabled(false)
-      .userListens(query)
-      .watchAcks(query)
+      .userListens(query1)
+      .watchAcks(query1)
       .watchRemoves(
-        query,
+        query1,
         new RpcError(Code.RESOURCE_EXHAUSTED, 'Resource exhausted')
       )
-      .expectEvents(query, { errorCode: Code.RESOURCE_EXHAUSTED })
-      .userListens(query)
-      .watchAcksFull(query, 1000)
-      .expectEvents(query, {});
+      .expectEvents(query1, { errorCode: Code.RESOURCE_EXHAUSTED })
+      .userListens(query1)
+      .watchAcksFull(query1, 1000)
+      .expectEvents(query1, {});
   });
 
   // It can happen that we need to process watch messages for previously failed
   // targets, because target failures are handled out of band.
   // This test verifies that the code does not crash in this case.
   specTest('Will gracefully process failed targets', [], () => {
-    const query1 = Query.atPath(path('collection1'));
-    const query2 = Query.atPath(path('collection2'));
+    const query1 = query('collection1');
+    const query2 = query('collection2');
     const docA = doc('collection1/a', 1000, { a: true });
     const docB = doc('collection2/a', 1001, { b: true });
 
@@ -263,7 +260,7 @@ describeSpec('Listens:', [], () => {
     'Will gracefully handle watch stream reverting snapshots',
     [],
     () => {
-      const query = Query.atPath(path('collection'));
+      const query1 = query('collection');
       const docAv1 = doc('collection/a', 1000, { v: 'v1000' });
       const docAv2 = doc('collection/a', 2000, { v: 'v2000' });
 
@@ -271,25 +268,25 @@ describeSpec('Listens:', [], () => {
         spec()
           // Disable GC so the cache persists across listens.
           .withGCEnabled(false)
-          .userListens(query)
-          .watchAcksFull(query, 1000, docAv1)
-          .expectEvents(query, { added: [docAv1] })
-          .watchSends({ affects: [query] }, docAv2)
+          .userListens(query1)
+          .watchAcksFull(query1, 1000, docAv1)
+          .expectEvents(query1, { added: [docAv1] })
+          .watchSends({ affects: [query1] }, docAv2)
           .watchSnapshots(2000)
-          .expectEvents(query, { modified: [docAv2] })
+          .expectEvents(query1, { modified: [docAv2] })
           // Remove and re-add listener.
-          .userUnlistens(query)
-          .watchRemoves(query)
-          .userListens(query, 'resume-token-1000')
-          .expectEvents(query, { added: [docAv2], fromCache: true })
+          .userUnlistens(query1)
+          .watchRemoves(query1)
+          .userListens(query1, 'resume-token-1000')
+          .expectEvents(query1, { added: [docAv2], fromCache: true })
           // watch sends old snapshot.
-          .watchAcksFull(query, 1000, docAv1)
+          .watchAcksFull(query1, 1000, docAv1)
           // no error and no events
 
           // should get events once stream is caught up.
-          .watchSends({ affects: [query] }, docAv2)
+          .watchSends({ affects: [query1] }, docAv2)
           .watchSnapshots(2000)
-          .expectEvents(query, { fromCache: false })
+          .expectEvents(query1, { fromCache: false })
       );
     }
   );
@@ -299,7 +296,7 @@ describeSpec('Listens:', [], () => {
     'Will gracefully handle watch stream reverting snapshots (with restart)',
     ['durable-persistence'],
     () => {
-      const query = Query.atPath(path('collection'));
+      const query1 = query('collection');
       const docAv1 = doc('collection/a', 1000, { v: 'v1000' });
       const docAv2 = doc('collection/a', 2000, { v: 'v2000' });
 
@@ -307,33 +304,31 @@ describeSpec('Listens:', [], () => {
         spec()
           // Disable GC so the cache persists across listens.
           .withGCEnabled(false)
-          .userListens(query)
-          .watchAcksFull(query, 1000, docAv1)
-          .expectEvents(query, { added: [docAv1] })
-          .watchSends({ affects: [query] }, docAv2)
+          .userListens(query1)
+          .watchAcksFull(query1, 1000, docAv1)
+          .expectEvents(query1, { added: [docAv1] })
+          .watchSends({ affects: [query1] }, docAv2)
           .watchSnapshots(2000)
-          .expectEvents(query, { modified: [docAv2] })
+          .expectEvents(query1, { modified: [docAv2] })
           // restart the client and re-listen.
           .restart()
-          .userListens(query, 'resume-token-1000')
-          .expectEvents(query, { added: [docAv2], fromCache: true })
+          .userListens(query1, 'resume-token-1000')
+          .expectEvents(query1, { added: [docAv2], fromCache: true })
           // watch sends old snapshot.
-          .watchAcksFull(query, 1000, docAv1)
+          .watchAcksFull(query1, 1000, docAv1)
           // no error and no events
 
           // should get events once stream is caught up.
-          .watchSends({ affects: [query] }, docAv2)
+          .watchSends({ affects: [query1] }, docAv2)
           .watchSnapshots(2000)
-          .expectEvents(query, { fromCache: false })
+          .expectEvents(query1, { fromCache: false })
       );
     }
   );
 
   specTest('Individual documents cannot revert', [], () => {
-    const allQuery = Query.atPath(path('collection'));
-    const visibleQuery = Query.atPath(path('collection')).addFilter(
-      filter('visible', '==', true)
-    );
+    const allQuery = query('collection');
+    const visibleQuery = query('collection', filter('visible', '==', true));
     const docAv1 = doc('collection/a', 1000, { visible: true, v: 'v1000' });
     const docAv2 = doc('collection/a', 2000, { visible: false, v: 'v2000' });
     const docAv3 = doc('collection/a', 3000, { visible: false, v: 'v3000' });
@@ -374,10 +369,8 @@ describeSpec('Listens:', [], () => {
   });
 
   specTest('Individual (deleted) documents cannot revert', [], () => {
-    const allQuery = Query.atPath(path('collection'));
-    const visibleQuery = Query.atPath(path('collection')).addFilter(
-      filter('visible', '==', true)
-    );
+    const allQuery = query('collection');
+    const visibleQuery = query('collection', filter('visible', '==', true));
     const docAv1 = doc('collection/a', 1000, { visible: true, v: 'v1000' });
     const docAv2 = doc('collection/a', 2000, { visible: false, v: 'v2000' });
     const docAv3 = deletedDoc('collection/a', 3000);
@@ -420,7 +413,7 @@ describeSpec('Listens:', [], () => {
   });
 
   specTest('Waits until Watch catches up to local deletes ', [], () => {
-    const query1 = Query.atPath(path('collection'));
+    const query1 = query('collection');
     const docAv1 = doc('collection/a', 1000, { v: '1' });
     const docAv2 = doc('collection/a', 2000, { v: '2' });
     const docAv3 = doc('collection/a', 3000, { v: '3' });
@@ -452,30 +445,30 @@ describeSpec('Listens:', [], () => {
       [type: string]: number;
     }): number => requestCounts.addTarget + requestCounts.removeTarget;
 
-    const query = Query.atPath(path('collection'));
+    const query1 = query('collection');
     const docA = doc('collection/a', 1000, { key: 'a' });
     const docB = doc('collection/b', 2000, { key: 'b' });
     return spec()
-      .userListens(query)
+      .userListens(query1)
       .expectWatchStreamRequestCount(
         expectRequestCount({ addTarget: 1, removeTarget: 0 })
       )
-      .watchAcksFull(query, 1000, docA)
-      .expectEvents(query, { added: [docA] })
+      .watchAcksFull(query1, 1000, docA)
+      .expectEvents(query1, { added: [docA] })
       .disableNetwork()
-      .expectEvents(query, { fromCache: true })
+      .expectEvents(query1, { fromCache: true })
       .enableNetwork()
-      .restoreListen(query, 'resume-token-1000')
+      .restoreListen(query1, 'resume-token-1000')
       .expectWatchStreamRequestCount(
         expectRequestCount({ addTarget: 2, removeTarget: 0 })
       )
-      .watchAcksFull(query, 2000, docB)
-      .expectEvents(query, { added: [docB] });
+      .watchAcksFull(query1, 2000, docB)
+      .expectEvents(query1, { added: [docB] });
   });
 
   specTest('Synthesizes deletes for missing document', [], () => {
-    const collQuery = Query.atPath(path('collection'));
-    const docQuery = Query.atPath(path('collection/a'));
+    const collQuery = query('collection');
+    const docQuery = query('collection/a');
     const docA = doc('collection/a', 1000, { key: 'a' });
     const docB = doc('collection/b', 1000, { key: 'a' });
     return (
@@ -510,149 +503,147 @@ describeSpec('Listens:', [], () => {
   });
 
   specTest('Re-opens target without existence filter', [], () => {
-    const query = Query.atPath(path('collection'));
+    const query1 = query('collection');
     const docA = doc('collection/a', 1000, { key: 'a' });
     const deletedDocA = deletedDoc('collection/a', 2000);
     return spec()
       .withGCEnabled(false)
-      .userListens(query)
-      .watchAcksFull(query, 1000, docA)
-      .expectEvents(query, { added: [docA] })
-      .userUnlistens(query)
-      .watchRemoves(query)
-      .userListens(query, 'resume-token-1000')
-      .expectEvents(query, { added: [docA], fromCache: true })
-      .watchAcks(query)
-      .watchSends({ removed: [query] }, deletedDocA)
-      .watchCurrents(query, 'resume-token-2000')
+      .userListens(query1)
+      .watchAcksFull(query1, 1000, docA)
+      .expectEvents(query1, { added: [docA] })
+      .userUnlistens(query1)
+      .watchRemoves(query1)
+      .userListens(query1, 'resume-token-1000')
+      .expectEvents(query1, { added: [docA], fromCache: true })
+      .watchAcks(query1)
+      .watchSends({ removed: [query1] }, deletedDocA)
+      .watchCurrents(query1, 'resume-token-2000')
       .watchSnapshots(2000)
-      .expectEvents(query, { removed: [docA] });
+      .expectEvents(query1, { removed: [docA] });
   });
 
   specTest('Ignores update from inactive target', [], () => {
-    const query = Query.atPath(path('collection'));
+    const query1 = query('collection');
     const docA = doc('collection/a', 1000, { key: 'a' });
     const docB = doc('collection/b', 2000, { key: 'b' });
     return spec()
       .withGCEnabled(false)
-      .userListens(query)
-      .watchAcksFull(query, 1000, docA)
-      .expectEvents(query, { added: [docA] })
-      .userUnlistens(query)
-      .watchSends({ affects: [query] }, docB)
+      .userListens(query1)
+      .watchAcksFull(query1, 1000, docA)
+      .expectEvents(query1, { added: [docA] })
+      .userUnlistens(query1)
+      .watchSends({ affects: [query1] }, docB)
       .watchSnapshots(2000)
-      .watchRemoves(query)
-      .userListens(query, 'resume-token-1000')
-      .expectEvents(query, { added: [docA], fromCache: true });
+      .watchRemoves(query1)
+      .userListens(query1, 'resume-token-1000')
+      .expectEvents(query1, { added: [docA], fromCache: true });
   });
 
   specTest(
     'Does not synthesize deletes for previously acked documents',
     [],
     () => {
-      const query = Query.atPath(path('collection/a'));
+      const query1 = query('collection/a');
       const docA = doc('collection/a', 1000, { key: 'a' });
       return (
         spec()
           .withGCEnabled(false)
-          .userListens(query)
-          .watchAcks(query)
-          .watchSends({ affects: [query] }, docA)
+          .userListens(query1)
+          .watchAcks(query1)
+          .watchSends({ affects: [query1] }, docA)
           .watchSnapshots(1000)
-          .expectEvents(query, { added: [docA], fromCache: true })
-          .watchCurrents(query, 'resume-token-2000')
+          .expectEvents(query1, { added: [docA], fromCache: true })
+          .watchCurrents(query1, 'resume-token-2000')
           .watchSnapshots(2000)
           // The snapshot is empty, but we have received 'docA' in a previous
           // snapshot and don't synthesize a document delete.
-          .expectEvents(query, { fromCache: false })
-          .userUnlistens(query)
-          .userListens(query, 'resume-token-2000')
-          .expectEvents(query, { added: [docA], fromCache: true })
+          .expectEvents(query1, { fromCache: false })
+          .userUnlistens(query1)
+          .userListens(query1, 'resume-token-2000')
+          .expectEvents(query1, { added: [docA], fromCache: true })
       );
     }
   );
 
   specTest('Query is rejected and re-listened to', [], () => {
-    const query = Query.atPath(path('collection'));
+    const query1 = query('collection');
 
     return spec()
       .withGCEnabled(false)
-      .userListens(query)
+      .userListens(query1)
       .watchRemoves(
-        query,
+        query1,
         new RpcError(Code.RESOURCE_EXHAUSTED, 'Resource exhausted')
       )
-      .expectEvents(query, { errorCode: Code.RESOURCE_EXHAUSTED })
-      .userListens(query)
-      .watchAcksFull(query, 1000)
-      .expectEvents(query, {});
+      .expectEvents(query1, { errorCode: Code.RESOURCE_EXHAUSTED })
+      .userListens(query1)
+      .watchAcksFull(query1, 1000)
+      .expectEvents(query1, {});
   });
 
   specTest('Persists resume token sent with target', [], () => {
-    const query = Query.atPath(path('collection'));
+    const query1 = query('collection');
     const docA = doc('collection/a', 2000, { key: 'a' });
     return spec()
       .withGCEnabled(false)
-      .userListens(query)
-      .watchAcksFull(query, 1000)
-      .expectEvents(query, {})
-      .watchSends({ affects: [query] }, docA)
-      .watchSnapshots(2000, [query], 'resume-token-2000')
+      .userListens(query1)
+      .watchAcksFull(query1, 1000)
+      .expectEvents(query1, {})
+      .watchSends({ affects: [query1] }, docA)
+      .watchSnapshots(2000, [query1], 'resume-token-2000')
       .watchSnapshots(2000)
-      .expectEvents(query, { added: [docA] })
-      .userUnlistens(query)
-      .watchRemoves(query)
-      .userListens(query, 'resume-token-2000')
-      .expectEvents(query, { added: [docA], fromCache: true })
-      .watchAcksFull(query, 3000)
-      .expectEvents(query, {});
+      .expectEvents(query1, { added: [docA] })
+      .userUnlistens(query1)
+      .watchRemoves(query1)
+      .userListens(query1, 'resume-token-2000')
+      .expectEvents(query1, { added: [docA], fromCache: true })
+      .watchAcksFull(query1, 3000)
+      .expectEvents(query1, {});
   });
 
   specTest('Array-contains queries support resuming', [], () => {
-    const query = Query.atPath(path('collection')).addFilter(
-      filter('array', 'array-contains', 42)
-    );
+    const query1 = query('collection', filter('array', 'array-contains', 42));
     const docA = doc('collection/a', 2000, { foo: 'bar', array: [1, 42, 3] });
     return spec()
       .withGCEnabled(false)
-      .userListens(query)
-      .watchAcksFull(query, 1000)
-      .expectEvents(query, {})
-      .watchSends({ affects: [query] }, docA)
-      .watchSnapshots(2000, [query], 'resume-token-2000')
+      .userListens(query1)
+      .watchAcksFull(query1, 1000)
+      .expectEvents(query1, {})
+      .watchSends({ affects: [query1] }, docA)
+      .watchSnapshots(2000, [query1], 'resume-token-2000')
       .watchSnapshots(2000)
-      .expectEvents(query, { added: [docA] })
-      .userUnlistens(query)
-      .watchRemoves(query)
-      .userListens(query, 'resume-token-2000')
-      .expectEvents(query, { added: [docA], fromCache: true })
-      .watchAcksFull(query, 3000)
-      .expectEvents(query, {});
+      .expectEvents(query1, { added: [docA] })
+      .userUnlistens(query1)
+      .watchRemoves(query1)
+      .userListens(query1, 'resume-token-2000')
+      .expectEvents(query1, { added: [docA], fromCache: true })
+      .watchAcksFull(query1, 3000)
+      .expectEvents(query1, {});
   });
 
   specTest('Persists global resume tokens on unlisten', [], () => {
-    const query = Query.atPath(path('collection'));
+    const query1 = query('collection');
     const docA = doc('collection/a', 1000, { key: 'a' });
 
     return (
       spec()
         .withGCEnabled(false)
-        .userListens(query)
-        .watchAcksFull(query, 1000, docA)
-        .expectEvents(query, { added: [docA] })
+        .userListens(query1)
+        .watchAcksFull(query1, 1000, docA)
+        .expectEvents(query1, { added: [docA] })
 
         // Some time later, watch sends an updated resume token and the user stops
         // listening.
         .watchSnapshots(2000, [], 'resume-token-2000')
-        .userUnlistens(query)
-        .watchRemoves(query)
+        .userUnlistens(query1)
+        .watchRemoves(query1)
 
-        .userListens(query, 'resume-token-2000')
-        .expectEvents(query, { added: [docA], fromCache: true })
-        .watchAcks(query)
-        .watchCurrents(query, 'resume-token-3000')
+        .userListens(query1, 'resume-token-2000')
+        .expectEvents(query1, { added: [docA], fromCache: true })
+        .watchAcks(query1)
+        .watchCurrents(query1, 'resume-token-3000')
         .watchSnapshots(3000)
-        .expectEvents(query, { fromCache: false })
+        .expectEvents(query1, { fromCache: false })
     );
   });
 
@@ -660,27 +651,27 @@ describeSpec('Listens:', [], () => {
     'Omits global resume tokens for a short while',
     ['durable-persistence'],
     () => {
-      const query = Query.atPath(path('collection'));
+      const query1 = query('collection');
       const docA = doc('collection/a', 1000, { key: 'a' });
 
       return (
         spec()
           .withGCEnabled(false)
-          .userListens(query)
-          .watchAcksFull(query, 1000, docA)
-          .expectEvents(query, { added: [docA] })
+          .userListens(query1)
+          .watchAcksFull(query1, 1000, docA)
+          .expectEvents(query1, { added: [docA] })
 
           // One millisecond later, watch sends an updated resume token but the
           // user doesn't manage to unlisten before restart.
           .watchSnapshots(2000, [], 'resume-token-2000')
           .restart()
 
-          .userListens(query, 'resume-token-1000')
-          .expectEvents(query, { added: [docA], fromCache: true })
-          .watchAcks(query)
-          .watchCurrents(query, 'resume-token-3000')
+          .userListens(query1, 'resume-token-1000')
+          .expectEvents(query1, { added: [docA], fromCache: true })
+          .watchAcks(query1)
+          .watchCurrents(query1, 'resume-token-3000')
           .watchSnapshots(3000)
-          .expectEvents(query, { fromCache: false })
+          .expectEvents(query1, { fromCache: false })
       );
     }
   );
@@ -693,85 +684,85 @@ describeSpec('Listens:', [], () => {
       const minutesLater = 5 * 60 * 1e6 + initialVersion;
       const evenLater = 1000 + minutesLater;
 
-      const query = Query.atPath(path('collection'));
+      const query1 = query('collection');
       const docA = doc('collection/a', initialVersion, { key: 'a' });
 
       return (
         spec()
           .withGCEnabled(false)
-          .userListens(query)
-          .watchAcksFull(query, initialVersion, docA)
-          .expectEvents(query, { added: [docA] })
+          .userListens(query1)
+          .watchAcksFull(query1, initialVersion, docA)
+          .expectEvents(query1, { added: [docA] })
 
           // 5 minutes later, watch sends an updated resume token but the user
           // doesn't manage to unlisten before restart.
           .watchSnapshots(minutesLater, [], 'resume-token-minutes-later')
           .restart()
 
-          .userListens(query, 'resume-token-minutes-later')
-          .expectEvents(query, { added: [docA], fromCache: true })
-          .watchAcks(query)
-          .watchCurrents(query, 'resume-token-even-later')
+          .userListens(query1, 'resume-token-minutes-later')
+          .expectEvents(query1, { added: [docA], fromCache: true })
+          .watchAcks(query1)
+          .watchCurrents(query1, 'resume-token-even-later')
           .watchSnapshots(evenLater)
-          .expectEvents(query, { fromCache: false })
+          .expectEvents(query1, { fromCache: false })
       );
     }
   );
 
   specTest('Query is executed by primary client', ['multi-client'], () => {
-    const query = Query.atPath(path('collection'));
+    const query1 = query('collection');
     const docA = doc('collection/a', 1000, { key: 'a' });
 
     return client(0)
       .becomeVisible()
       .client(1)
-      .userListens(query)
+      .userListens(query1)
       .client(0)
-      .expectListen(query)
-      .watchAcks(query)
-      .watchSends({ affects: [query] }, docA)
+      .expectListen(query1)
+      .watchAcks(query1)
+      .watchSends({ affects: [query1] }, docA)
       .watchSnapshots(1000)
       .client(1)
-      .expectEvents(query, { added: [docA], fromCache: true })
+      .expectEvents(query1, { added: [docA], fromCache: true })
       .client(0)
-      .watchCurrents(query, 'resume-token-2000')
+      .watchCurrents(query1, 'resume-token-2000')
       .watchSnapshots(2000)
       .client(1)
-      .expectEvents(query, { fromCache: false });
+      .expectEvents(query1, { fromCache: false });
   });
 
   specTest(
     'Query is shared between primary and secondary client',
     ['multi-client'],
     () => {
-      const query = Query.atPath(path('collection'));
+      const query1 = query('collection');
       const docA = doc('collection/a', 1000, { key: 'a' });
       const docB = doc('collection/b', 2000, { key: 'a' });
 
       return client(0)
         .becomeVisible()
-        .userListens(query)
-        .watchAcksFull(query, 1000, docA)
-        .expectEvents(query, { added: [docA] })
+        .userListens(query1)
+        .watchAcksFull(query1, 1000, docA)
+        .expectEvents(query1, { added: [docA] })
         .client(1)
-        .userListens(query)
-        .expectEvents(query, { added: [docA] })
+        .userListens(query1)
+        .expectEvents(query1, { added: [docA] })
         .client(2)
-        .userListens(query)
-        .expectEvents(query, { added: [docA] })
+        .userListens(query1)
+        .expectEvents(query1, { added: [docA] })
         .client(0)
-        .watchSends({ affects: [query] }, docB)
+        .watchSends({ affects: [query1] }, docB)
         .watchSnapshots(2000)
-        .expectEvents(query, { added: [docB] })
+        .expectEvents(query1, { added: [docB] })
         .client(1)
-        .expectEvents(query, { added: [docB] })
+        .expectEvents(query1, { added: [docB] })
         .client(2)
-        .expectEvents(query, { added: [docB] });
+        .expectEvents(query1, { added: [docB] });
     }
   );
 
   specTest('Query is joined by primary client', ['multi-client'], () => {
-    const query = Query.atPath(path('collection'));
+    const query1 = query('collection');
     const docA = doc('collection/a', 1000, { key: 'a' });
     const docB = doc('collection/b', 2000, { key: 'b' });
     const docC = doc('collection/c', 3000, { key: 'c' });
@@ -779,144 +770,144 @@ describeSpec('Listens:', [], () => {
     return client(0)
       .expectPrimaryState(true)
       .client(1)
-      .userListens(query)
+      .userListens(query1)
       .client(0)
-      .expectListen(query)
-      .watchAcksFull(query, 100, docA)
+      .expectListen(query1)
+      .watchAcksFull(query1, 100, docA)
       .client(1)
-      .expectEvents(query, { added: [docA] })
+      .expectEvents(query1, { added: [docA] })
       .client(0)
-      .watchSends({ affects: [query] }, docB)
+      .watchSends({ affects: [query1] }, docB)
       .watchSnapshots(2000)
-      .userListens(query)
-      .expectEvents(query, { added: [docA, docB] })
-      .watchSends({ affects: [query] }, docC)
+      .userListens(query1)
+      .expectEvents(query1, { added: [docA, docB] })
+      .watchSends({ affects: [query1] }, docC)
       .watchSnapshots(3000)
-      .expectEvents(query, { added: [docC] })
+      .expectEvents(query1, { added: [docC] })
       .client(1)
-      .expectEvents(query, { added: [docB] })
-      .expectEvents(query, { added: [docC] });
+      .expectEvents(query1, { added: [docB] })
+      .expectEvents(query1, { added: [docC] });
   });
 
   specTest(
     'Query only raises events in participating clients',
     ['multi-client'],
     () => {
-      const query = Query.atPath(path('collection'));
+      const query1 = query('collection');
       const docA = doc('collection/a', 1000, { key: 'a' });
 
       return client(0)
         .becomeVisible()
         .client(1)
         .client(2)
-        .userListens(query)
+        .userListens(query1)
         .client(3)
-        .userListens(query)
+        .userListens(query1)
         .client(0) // No events
-        .expectListen(query)
-        .watchAcksFull(query, 1000, docA)
+        .expectListen(query1)
+        .watchAcksFull(query1, 1000, docA)
         .client(1) // No events
         .client(2)
-        .expectEvents(query, { added: [docA] })
+        .expectEvents(query1, { added: [docA] })
         .client(3)
-        .expectEvents(query, { added: [docA] });
+        .expectEvents(query1, { added: [docA] });
     }
   );
 
   specTest('Query is unlistened to by primary client', ['multi-client'], () => {
-    const query = Query.atPath(path('collection'));
+    const query1 = query('collection');
     const docA = doc('collection/a', 1000, { key: 'a' });
     const docB = doc('collection/b', 2000, { key: 'a' });
 
     return client(0)
       .becomeVisible()
-      .userListens(query)
-      .watchAcksFull(query, 1000, docA)
-      .expectEvents(query, { added: [docA] })
+      .userListens(query1)
+      .watchAcksFull(query1, 1000, docA)
+      .expectEvents(query1, { added: [docA] })
       .client(1)
-      .userListens(query)
-      .expectEvents(query, { added: [docA] })
+      .userListens(query1)
+      .expectEvents(query1, { added: [docA] })
       .client(0)
-      .userUnlistens(query)
-      .expectListen(query)
-      .watchSends({ affects: [query] }, docB)
+      .userUnlistens(query1)
+      .expectListen(query1)
+      .watchSends({ affects: [query1] }, docB)
       .watchSnapshots(2000)
       .client(1)
-      .expectEvents(query, { added: [docB] })
-      .userUnlistens(query)
+      .expectEvents(query1, { added: [docB] })
+      .userUnlistens(query1)
       .client(0)
-      .expectUnlisten(query);
+      .expectUnlisten(query1);
   });
 
   specTest('Query is resumed by secondary client', ['multi-client'], () => {
-    const query = Query.atPath(path('collection'));
+    const query1 = query('collection');
     const docA = doc('collection/a', 1000, { key: 'a' });
     const docB = doc('collection/b', 2000, { key: 'a' });
 
     return client(0, /* withGcEnabled= */ false)
       .becomeVisible()
       .client(1)
-      .userListens(query)
+      .userListens(query1)
       .client(0)
-      .expectListen(query)
-      .watchAcksFull(query, 1000, docA)
+      .expectListen(query1)
+      .watchAcksFull(query1, 1000, docA)
       .client(1)
-      .expectEvents(query, { added: [docA] })
-      .userUnlistens(query)
+      .expectEvents(query1, { added: [docA] })
+      .userUnlistens(query1)
       .client(0)
-      .expectUnlisten(query)
-      .watchRemoves(query)
+      .expectUnlisten(query1)
+      .watchRemoves(query1)
       .client(1)
-      .userListens(query)
-      .expectEvents(query, { added: [docA], fromCache: true })
+      .userListens(query1)
+      .expectEvents(query1, { added: [docA], fromCache: true })
       .client(0)
-      .expectListen(query, 'resume-token-1000')
-      .watchAcksFull(query, 2000, docB)
+      .expectListen(query1, 'resume-token-1000')
+      .watchAcksFull(query1, 2000, docB)
       .client(1)
-      .expectEvents(query, { added: [docB] });
+      .expectEvents(query1, { added: [docB] });
   });
 
   specTest('Query is rejected by primary client', ['multi-client'], () => {
-    const query = Query.atPath(path('collection'));
+    const query1 = query('collection');
 
     return client(0)
       .becomeVisible()
       .client(1)
-      .userListens(query)
+      .userListens(query1)
       .client(0)
-      .expectListen(query)
+      .expectListen(query1)
       .watchRemoves(
-        query,
+        query1,
         new RpcError(Code.RESOURCE_EXHAUSTED, 'Resource exhausted')
       )
       .client(1)
-      .expectEvents(query, { errorCode: Code.RESOURCE_EXHAUSTED });
+      .expectEvents(query1, { errorCode: Code.RESOURCE_EXHAUSTED });
   });
 
   specTest(
     'Query is rejected and re-listened to by secondary client',
     ['multi-client'],
     () => {
-      const query = Query.atPath(path('collection'));
+      const query1 = query('collection');
 
       return client(0)
         .becomeVisible()
         .client(1)
-        .userListens(query)
+        .userListens(query1)
         .client(0)
-        .expectListen(query)
+        .expectListen(query1)
         .watchRemoves(
-          query,
+          query1,
           new RpcError(Code.RESOURCE_EXHAUSTED, 'Resource exhausted')
         )
         .client(1)
-        .expectEvents(query, { errorCode: Code.RESOURCE_EXHAUSTED })
-        .userListens(query)
+        .expectEvents(query1, { errorCode: Code.RESOURCE_EXHAUSTED })
+        .userListens(query1)
         .client(0)
-        .expectListen(query)
-        .watchAcksFull(query, 1000)
+        .expectListen(query1)
+        .watchAcksFull(query1, 1000)
         .client(1)
-        .expectEvents(query, {});
+        .expectEvents(query1, {});
     }
   );
 
@@ -924,12 +915,13 @@ describeSpec('Listens:', [], () => {
     'Mirror queries from same secondary client',
     ['multi-client'],
     () => {
-      const limit = Query.atPath(path('collection'))
-        .addOrderBy(orderBy('val', 'asc'))
-        .withLimitToFirst(2);
-      const limitToLast = Query.atPath(path('collection'))
-        .addOrderBy(orderBy('val', 'desc'))
-        .withLimitToLast(2);
+      const limit = query('collection', orderBy('val', 'asc')).withLimitToFirst(
+        2
+      );
+      const limitToLast = query(
+        'collection',
+        orderBy('val', 'desc')
+      ).withLimitToLast(2);
       const docA = doc('collection/a', 1000, { val: 0 });
       const docB = doc('collection/b', 1000, { val: 1 });
       const docC = doc('collection/c', 2000, { val: 0 });
@@ -964,12 +956,13 @@ describeSpec('Listens:', [], () => {
     'Mirror queries from different secondary client',
     ['multi-client'],
     () => {
-      const limit = Query.atPath(path('collection'))
-        .addOrderBy(orderBy('val', 'asc'))
-        .withLimitToFirst(2);
-      const limitToLast = Query.atPath(path('collection'))
-        .addOrderBy(orderBy('val', 'desc'))
-        .withLimitToLast(2);
+      const limit = query('collection', orderBy('val', 'asc')).withLimitToFirst(
+        2
+      );
+      const limitToLast = query(
+        'collection',
+        orderBy('val', 'desc')
+      ).withLimitToLast(2);
       const docA = doc('collection/a', 1000, { val: 0 });
       const docB = doc('collection/b', 1000, { val: 1 });
       const docC = doc('collection/c', 2000, { val: 0 });
@@ -1002,12 +995,13 @@ describeSpec('Listens:', [], () => {
     'Mirror queries from primary and secondary client',
     ['multi-client'],
     () => {
-      const limit = Query.atPath(path('collection'))
-        .addOrderBy(orderBy('val', 'asc'))
-        .withLimitToFirst(2);
-      const limitToLast = Query.atPath(path('collection'))
-        .addOrderBy(orderBy('val', 'desc'))
-        .withLimitToLast(2);
+      const limit = query('collection', orderBy('val', 'asc')).withLimitToFirst(
+        2
+      );
+      const limitToLast = query(
+        'collection',
+        orderBy('val', 'desc')
+      ).withLimitToLast(2);
       const docA = doc('collection/a', 1000, { val: 0 });
       const docB = doc('collection/b', 1000, { val: 1 });
       const docC = doc('collection/c', 2000, { val: 0 });
@@ -1063,12 +1057,13 @@ describeSpec('Listens:', [], () => {
   );
 
   specTest('Can listen/unlisten to mirror queries.', [], () => {
-    const limit = Query.atPath(path('collection'))
-      .addOrderBy(orderBy('val', 'asc'))
-      .withLimitToFirst(2);
-    const limitToLast = Query.atPath(path('collection'))
-      .addOrderBy(orderBy('val', 'desc'))
-      .withLimitToLast(2);
+    const limit = query('collection', orderBy('val', 'asc')).withLimitToFirst(
+      2
+    );
+    const limitToLast = query(
+      'collection',
+      orderBy('val', 'desc')
+    ).withLimitToLast(2);
     const docA = doc('collection/a', 1000, { val: 0 });
     const docB = doc('collection/b', 1000, { val: 1 });
     const docC = doc('collection/c', 2000, { val: 0 });
@@ -1108,33 +1103,33 @@ describeSpec('Listens:', [], () => {
     "Secondary client uses primary client's online state",
     ['multi-client'],
     () => {
-      const query = Query.atPath(path('collection'));
+      const query1 = query('collection');
 
       return client(0)
         .becomeVisible()
         .client(1)
-        .userListens(query)
+        .userListens(query1)
         .client(0)
-        .expectListen(query)
-        .watchAcksFull(query, 1000)
+        .expectListen(query1)
+        .watchAcksFull(query1, 1000)
         .client(1)
-        .expectEvents(query, {})
+        .expectEvents(query1, {})
         .client(0)
         .disableNetwork()
         .client(1)
-        .expectEvents(query, { fromCache: true })
+        .expectEvents(query1, { fromCache: true })
         .client(0)
         .enableNetwork()
-        .expectListen(query, 'resume-token-1000')
-        .watchAcksFull(query, 2000)
+        .expectListen(query1, 'resume-token-1000')
+        .watchAcksFull(query1, 2000)
         .client(1)
-        .expectEvents(query, {});
+        .expectEvents(query1, {});
     }
   );
 
   specTest('New client uses existing online state', ['multi-client'], () => {
-    const query1 = Query.atPath(path('collection'));
-    const query2 = Query.atPath(path('collection'));
+    const query1 = query('collection');
+    const query2 = query('collection');
 
     return (
       client(0)
@@ -1161,28 +1156,28 @@ describeSpec('Listens:', [], () => {
     'New client becomes primary if no client has its network enabled',
     ['multi-client'],
     () => {
-      const query = Query.atPath(path('collection'));
+      const query1 = query('collection');
 
       return client(0)
-        .userListens(query)
-        .watchAcksFull(query, 1000)
-        .expectEvents(query, {})
+        .userListens(query1)
+        .watchAcksFull(query1, 1000)
+        .expectEvents(query1, {})
         .client(1)
-        .userListens(query)
-        .expectEvents(query, {})
+        .userListens(query1)
+        .expectEvents(query1, {})
         .client(0)
         .disableNetwork()
-        .expectEvents(query, { fromCache: true })
+        .expectEvents(query1, { fromCache: true })
         .client(1)
-        .expectEvents(query, { fromCache: true })
+        .expectEvents(query1, { fromCache: true })
         .client(2)
-        .expectListen(query, 'resume-token-1000')
+        .expectListen(query1, 'resume-token-1000')
         .expectPrimaryState(true)
-        .watchAcksFull(query, 2000)
+        .watchAcksFull(query1, 2000)
         .client(0)
-        .expectEvents(query, {})
+        .expectEvents(query1, {})
         .client(1)
-        .expectEvents(query, {});
+        .expectEvents(query1, {});
     }
   );
 
@@ -1190,31 +1185,31 @@ describeSpec('Listens:', [], () => {
     "Secondary client's online state is ignored",
     ['multi-client'],
     () => {
-      const query = Query.atPath(path('collection'));
+      const query1 = query('collection');
       const docA = doc('collection/a', 2000, { key: 'a' });
 
       return (
         client(0)
           .becomeVisible()
           .client(1)
-          .userListens(query)
+          .userListens(query1)
           .client(0)
-          .expectListen(query)
-          .watchAcksFull(query, 1000)
+          .expectListen(query1)
+          .watchAcksFull(query1, 1000)
           .client(1)
-          .expectEvents(query, {})
+          .expectEvents(query1, {})
           .disableNetwork() // Ignored since this is the secondary client.
           .client(0)
-          .watchSends({ affects: [query] }, docA)
+          .watchSends({ affects: [query1] }, docA)
           .watchSnapshots(2000)
           .client(1)
-          .expectEvents(query, { added: [docA] })
+          .expectEvents(query1, { added: [docA] })
           .client(0)
           .disableNetwork()
           // Client remains primary since all clients are offline.
           .expectPrimaryState(true)
           .client(1)
-          .expectEvents(query, { fromCache: true })
+          .expectEvents(query1, { fromCache: true })
           .expectPrimaryState(false)
       );
     }
@@ -1224,15 +1219,15 @@ describeSpec('Listens:', [], () => {
     "Offline state doesn't persist if primary is shut down",
     ['multi-client'],
     () => {
-      const query = Query.atPath(path('collection'));
+      const query1 = query('collection');
 
       return client(0)
-        .userListens(query)
+        .userListens(query1)
         .disableNetwork()
-        .expectEvents(query, { fromCache: true })
+        .expectEvents(query1, { fromCache: true })
         .shutdown()
         .client(1)
-        .userListens(query); // No event since the online state is 'Unknown'.
+        .userListens(query1); // No event since the online state is 'Unknown'.
     }
   );
 
@@ -1240,37 +1235,37 @@ describeSpec('Listens:', [], () => {
     'Listen is re-listened to after primary tab failover',
     ['multi-client'],
     () => {
-      const query = Query.atPath(path('collection'));
+      const query1 = query('collection');
       const docA = doc('collection/a', 1000, { key: 'a' });
       const docB = doc('collection/b', 2000, { key: 'b' });
 
       return client(0)
         .expectPrimaryState(true)
         .client(1)
-        .userListens(query)
+        .userListens(query1)
         .client(0)
-        .expectListen(query)
-        .watchAcksFull(query, 1000, docA)
+        .expectListen(query1)
+        .watchAcksFull(query1, 1000, docA)
         .client(1)
-        .expectEvents(query, { added: [docA] })
+        .expectEvents(query1, { added: [docA] })
         .client(2)
-        .userListens(query)
-        .expectEvents(query, { added: [docA] })
+        .userListens(query1)
+        .expectEvents(query1, { added: [docA] })
         .client(0)
         .shutdown()
         .client(1)
         .runTimer(TimerId.ClientMetadataRefresh)
         .expectPrimaryState(true)
-        .expectListen(query, 'resume-token-1000')
-        .watchAcksFull(query, 2000, docB)
-        .expectEvents(query, { added: [docB] })
+        .expectListen(query1, 'resume-token-1000')
+        .watchAcksFull(query1, 2000, docB)
+        .expectEvents(query1, { added: [docB] })
         .client(2)
-        .expectEvents(query, { added: [docB] });
+        .expectEvents(query1, { added: [docB] });
     }
   );
 
   specTest('Listen is established in new primary tab', ['multi-client'], () => {
-    const query = Query.atPath(path('collection'));
+    const query1 = query('collection');
     const docA = doc('collection/a', 1000, { key: 'a' });
     const docB = doc('collection/b', 2000, { key: 'b' });
 
@@ -1279,26 +1274,26 @@ describeSpec('Listens:', [], () => {
     // did not previously listen to.
     return client(0)
       .expectPrimaryState(true)
-      .userListens(query)
-      .watchAcksFull(query, 1000, docA)
-      .expectEvents(query, { added: [docA] })
+      .userListens(query1)
+      .watchAcksFull(query1, 1000, docA)
+      .expectEvents(query1, { added: [docA] })
       .client(1) // Start up and initialize the second client.
       .client(2)
-      .userListens(query)
-      .expectEvents(query, { added: [docA] })
+      .userListens(query1)
+      .expectEvents(query1, { added: [docA] })
       .client(0)
       .shutdown()
       .client(1)
       .runTimer(TimerId.ClientMetadataRefresh)
       .expectPrimaryState(true)
-      .expectListen(query, 'resume-token-1000')
-      .watchAcksFull(query, 2000, docB)
+      .expectListen(query1, 'resume-token-1000')
+      .watchAcksFull(query1, 2000, docB)
       .client(2)
-      .expectEvents(query, { added: [docB] });
+      .expectEvents(query1, { added: [docB] });
   });
 
   specTest('Query recovers after primary takeover', ['multi-client'], () => {
-    const query = Query.atPath(path('collection'));
+    const query1 = query('collection');
     const docA = doc('collection/a', 1000, { key: 'a' });
     const docB = doc('collection/b', 2000, { key: 'b' });
     const docC = doc('collection/c', 3000, { key: 'c' });
@@ -1306,33 +1301,33 @@ describeSpec('Listens:', [], () => {
     return (
       client(0)
         .expectPrimaryState(true)
-        .userListens(query)
-        .watchAcksFull(query, 1000, docA)
-        .expectEvents(query, { added: [docA] })
+        .userListens(query1)
+        .watchAcksFull(query1, 1000, docA)
+        .expectEvents(query1, { added: [docA] })
         .client(1)
-        .userListens(query)
-        .expectEvents(query, { added: [docA] })
+        .userListens(query1)
+        .expectEvents(query1, { added: [docA] })
         .stealPrimaryLease()
-        .expectListen(query, 'resume-token-1000')
-        .watchAcksFull(query, 2000, docB)
-        .expectEvents(query, { added: [docB] })
+        .expectListen(query1, 'resume-token-1000')
+        .watchAcksFull(query1, 2000, docB)
+        .expectEvents(query1, { added: [docB] })
         .client(0)
         // Client 0 ignores all events until it transitions to secondary
         .client(1)
-        .watchSends({ affects: [query] }, docC)
+        .watchSends({ affects: [query1] }, docC)
         .watchSnapshots(3000)
-        .expectEvents(query, { added: [docC] })
+        .expectEvents(query1, { added: [docC] })
         .client(0)
         .runTimer(TimerId.ClientMetadataRefresh)
         // Client 0 recovers from its lease loss and applies the updates from
         // client 1
         .expectPrimaryState(false)
-        .expectEvents(query, { added: [docB, docC] })
+        .expectEvents(query1, { added: [docB, docC] })
     );
   });
 
   specTest('Query bounces between primaries', ['multi-client'], () => {
-    const query = Query.atPath(path('collection'));
+    const query1 = query('collection');
     const docA = doc('collection/a', 1000, { key: 'a' });
     const docB = doc('collection/b', 2000, { key: 'b' });
     const docC = doc('collection/c', 3000, { key: 'c' });
@@ -1343,54 +1338,54 @@ describeSpec('Listens:', [], () => {
     return client(1)
       .expectPrimaryState(true)
       .client(0)
-      .userListens(query)
+      .userListens(query1)
       .client(1)
-      .expectListen(query)
-      .watchAcksFull(query, 1000, docA)
+      .expectListen(query1)
+      .watchAcksFull(query1, 1000, docA)
       .client(0)
-      .expectEvents(query, { added: [docA] })
+      .expectEvents(query1, { added: [docA] })
       .client(2)
       .stealPrimaryLease()
-      .expectListen(query, 'resume-token-1000')
+      .expectListen(query1, 'resume-token-1000')
       .client(1)
       .runTimer(TimerId.ClientMetadataRefresh)
       .expectPrimaryState(false)
       .client(2)
-      .watchAcksFull(query, 2000, docB)
+      .watchAcksFull(query1, 2000, docB)
       .client(0)
-      .expectEvents(query, { added: [docB] })
+      .expectEvents(query1, { added: [docB] })
       .client(1)
       .stealPrimaryLease()
-      .expectListen(query, 'resume-token-2000')
-      .watchAcksFull(query, 3000, docC)
+      .expectListen(query1, 'resume-token-2000')
+      .watchAcksFull(query1, 3000, docC)
       .client(0)
-      .expectEvents(query, { added: [docC] });
+      .expectEvents(query1, { added: [docC] });
   });
 
   specTest(
     'Unresponsive primary ignores watch update',
     ['multi-client'],
     () => {
-      const query = Query.atPath(path('collection'));
+      const query1 = query('collection');
       const docA = doc('collection/a', 1000, { key: 'a' });
 
       return (
         client(0)
           .expectPrimaryState(true)
           .client(1)
-          .userListens(query)
+          .userListens(query1)
           .client(0)
-          .expectListen(query)
+          .expectListen(query1)
           .client(1)
           .stealPrimaryLease()
           .client(0)
           // Send a watch update to client 0, who is longer primary (but doesn't
           // know it yet). The watch update gets ignored.
-          .watchAcksFull(query, 1000, docA)
+          .watchAcksFull(query1, 1000, docA)
           .client(1)
-          .expectListen(query)
-          .watchAcksFull(query, 1000, docA)
-          .expectEvents(query, { added: [docA] })
+          .expectListen(query1)
+          .watchAcksFull(query1, 1000, docA)
+          .expectEvents(query1, { added: [docA] })
       );
     }
   );
@@ -1399,7 +1394,7 @@ describeSpec('Listens:', [], () => {
     'Listen is established in newly started primary',
     ['multi-client'],
     () => {
-      const query = Query.atPath(path('collection'));
+      const query1 = query('collection');
       const docA = doc('collection/a', 1000, { key: 'a' });
       const docB = doc('collection/b', 2000, { key: 'b' });
 
@@ -1409,20 +1404,20 @@ describeSpec('Listens:', [], () => {
       return client(0)
         .expectPrimaryState(true)
         .client(1)
-        .userListens(query)
+        .userListens(query1)
         .client(0)
-        .expectListen(query)
-        .watchAcksFull(query, 1000, docA)
+        .expectListen(query1)
+        .watchAcksFull(query1, 1000, docA)
         .client(1)
-        .expectEvents(query, { added: [docA] })
+        .expectEvents(query1, { added: [docA] })
         .client(0)
         .shutdown()
         .client(2)
         .expectPrimaryState(true)
-        .expectListen(query, 'resume-token-1000')
-        .watchAcksFull(query, 2000, docB)
+        .expectListen(query1, 'resume-token-1000')
+        .watchAcksFull(query1, 2000, docB)
         .client(1)
-        .expectEvents(query, { added: [docB] });
+        .expectEvents(query1, { added: [docB] });
     }
   );
 
@@ -1430,18 +1425,18 @@ describeSpec('Listens:', [], () => {
     'Previous primary immediately regains primary lease',
     ['multi-client'],
     () => {
-      const query = Query.atPath(path('collection'));
+      const query1 = query('collection');
       const docA = doc('collection/a', 2000, { key: 'a' });
 
       return (
         client(0)
-          .userListens(query)
-          .watchAcksFull(query, 1000)
-          .expectEvents(query, {})
+          .userListens(query1)
+          .watchAcksFull(query1, 1000)
+          .expectEvents(query1, {})
           .client(1)
           .stealPrimaryLease()
-          .expectListen(query, 'resume-token-1000')
-          .watchAcksFull(query, 2000, docA)
+          .expectListen(query1, 'resume-token-1000')
+          .watchAcksFull(query1, 2000, docA)
           .shutdown()
           .client(0)
           .expectPrimaryState(true)
@@ -1449,8 +1444,8 @@ describeSpec('Listens:', [], () => {
           // is already eligible to obtain it again.
           .runTimer(TimerId.ClientMetadataRefresh)
           .expectPrimaryState(true)
-          .expectListen(query, 'resume-token-2000')
-          .expectEvents(query, { added: [docA] })
+          .expectListen(query1, 'resume-token-2000')
+          .expectEvents(query1, { added: [docA] })
       );
     }
   );
@@ -1479,7 +1474,7 @@ describeSpec('Listens:', [], () => {
   );
 
   specTest('onSnapshotsInSync fires for metadata changes', [], () => {
-    const query = Query.atPath(path('collection'));
+    const query1 = query('collection');
     const docAv1 = doc('collection/a', 1000, { v: 1 });
     const docAv2Local = doc(
       'collection/a',
@@ -1490,21 +1485,21 @@ describeSpec('Listens:', [], () => {
     const docAv2 = doc('collection/a', 2000, { v: 2 });
 
     return spec()
-      .userListens(query)
-      .watchAcksFull(query, 1000, docAv1)
-      .expectEvents(query, { added: [docAv1] })
+      .userListens(query1)
+      .watchAcksFull(query1, 1000, docAv1)
+      .expectEvents(query1, { added: [docAv1] })
       .userAddsSnapshotsInSyncListener()
       .expectSnapshotsInSyncEvent()
       .userSets('collection/a', { v: 2 })
-      .expectEvents(query, {
+      .expectEvents(query1, {
         hasPendingWrites: true,
         modified: [docAv2Local]
       })
       .expectSnapshotsInSyncEvent()
-      .watchSends({ affects: [query] }, docAv2)
+      .watchSends({ affects: [query1] }, docAv2)
       .watchSnapshots(2000)
       .writeAcks('collection/a', 2000)
-      .expectEvents(query, {
+      .expectEvents(query1, {
         metadata: [docAv2]
       })
       .expectSnapshotsInSyncEvent();
@@ -1514,8 +1509,8 @@ describeSpec('Listens:', [], () => {
     'onSnapshotsInSync fires once for multiple event snapshots',
     [],
     () => {
-      const query1 = Query.atPath(path('collection'));
-      const query2 = Query.atPath(path('collection/a'));
+      const query1 = query('collection');
+      const query2 = query('collection/a');
       const docAv1 = doc('collection/a', 1000, { v: 1 });
       const docAv2Local = doc(
         'collection/a',
@@ -1559,7 +1554,7 @@ describeSpec('Listens:', [], () => {
   );
 
   specTest('onSnapshotsInSync fires for multiple listeners', [], () => {
-    const query = Query.atPath(path('collection'));
+    const query1 = query('collection');
     const docAv1 = doc('collection/a', 1000, { v: 1 });
     const docAv2Local = doc(
       'collection/a',
@@ -1581,13 +1576,13 @@ describeSpec('Listens:', [], () => {
     );
 
     return spec()
-      .userListens(query)
-      .watchAcksFull(query, 1000, docAv1)
-      .expectEvents(query, { added: [docAv1] })
+      .userListens(query1)
+      .watchAcksFull(query1, 1000, docAv1)
+      .expectEvents(query1, { added: [docAv1] })
       .userAddsSnapshotsInSyncListener()
       .expectSnapshotsInSyncEvent()
       .userSets('collection/a', { v: 2 })
-      .expectEvents(query, {
+      .expectEvents(query1, {
         hasPendingWrites: true,
         modified: [docAv2Local]
       })
@@ -1597,14 +1592,14 @@ describeSpec('Listens:', [], () => {
       .userAddsSnapshotsInSyncListener()
       .expectSnapshotsInSyncEvent()
       .userSets('collection/a', { v: 3 })
-      .expectEvents(query, {
+      .expectEvents(query1, {
         hasPendingWrites: true,
         modified: [docAv3Local]
       })
       .expectSnapshotsInSyncEvent(3)
       .userRemovesSnapshotsInSyncListener()
       .userSets('collection/a', { v: 4 })
-      .expectEvents(query, {
+      .expectEvents(query1, {
         hasPendingWrites: true,
         modified: [docAv4Local]
       })

--- a/packages/firestore/test/unit/specs/orderby_spec.test.ts
+++ b/packages/firestore/test/unit/specs/orderby_spec.test.ts
@@ -15,17 +15,13 @@
  * limitations under the License.
  */
 
-import { Query } from '../../../src/core/query';
-import { doc, orderBy, path } from '../../util/helpers';
-
+import { doc, orderBy, query } from '../../util/helpers';
 import { describeSpec, specTest } from './describe_spec';
 import { spec } from './spec_builder';
 
 describeSpec('OrderBy:', [], () => {
   specTest('orderBy applies filtering based on local state', [], () => {
-    const query1 = Query.atPath(path('collection')).addOrderBy(
-      orderBy('sort', 'asc')
-    );
+    const query1 = query('collection', orderBy('sort', 'asc'));
     const doc1 = doc(
       'collection/a',
       0,
@@ -59,22 +55,20 @@ describeSpec('OrderBy:', [], () => {
   });
 
   specTest('orderBy applies to existing documents', [], () => {
-    const query = Query.atPath(path('collection')).addOrderBy(
-      orderBy('sort', 'asc')
-    );
+    const query1 = query('collection', orderBy('sort', 'asc'));
     const docA = doc('collection/a', 1000, { key: 'a', sort: 2 });
     const docB = doc('collection/b', 1001, { key: 'b', sort: 1 });
 
     return spec()
       .withGCEnabled(false)
-      .userListens(query)
-      .watchAcksFull(query, 1002, docA, docB)
-      .expectEvents(query, { added: [docB, docA] })
-      .userUnlistens(query)
-      .watchRemoves(query)
-      .userListens(query, 'resume-token-1002')
-      .expectEvents(query, { added: [docB, docA], fromCache: true })
-      .watchAcksFull(query, 1002)
-      .expectEvents(query, {});
+      .userListens(query1)
+      .watchAcksFull(query1, 1002, docA, docB)
+      .expectEvents(query1, { added: [docB, docA] })
+      .userUnlistens(query1)
+      .watchRemoves(query1)
+      .userListens(query1, 'resume-token-1002')
+      .expectEvents(query1, { added: [docB, docA], fromCache: true })
+      .watchAcksFull(query1, 1002)
+      .expectEvents(query1, {});
   });
 });

--- a/packages/firestore/test/unit/specs/perf_spec.test.ts
+++ b/packages/firestore/test/unit/specs/perf_spec.test.ts
@@ -17,7 +17,7 @@
 
 import { Query } from '../../../src/core/query';
 import { Document } from '../../../src/model/document';
-import { doc, filter, orderBy, path } from '../../util/helpers';
+import { doc, filter, orderBy, query } from '../../util/helpers';
 
 import { describeSpec, specTest } from './describe_spec';
 import { spec } from './spec_builder';
@@ -47,7 +47,7 @@ describeSpec(
         const steps = spec().withGCEnabled(false);
 
         for (let i = 0; i < STEP_COUNT; ++i) {
-          const query = Query.atPath(path(`collection/${i}`));
+          const query1 = query(`collection/${i}`);
           const docLocal = doc(
             `collection/${i}`,
             0,
@@ -59,18 +59,18 @@ describeSpec(
           });
 
           steps
-            .userListens(query)
+            .userListens(query1)
             .userSets(`collection/${i}`, { doc: i })
-            .expectEvents(query, {
+            .expectEvents(query1, {
               added: [docLocal],
               fromCache: true,
               hasPendingWrites: true
             })
             .writeAcks(`collection/${i}`, docRemote.version.toMicroseconds())
-            .watchAcksFull(query, ++currentVersion, docRemote)
-            .expectEvents(query, { metadata: [docRemote] })
-            .userUnlistens(query)
-            .watchRemoves(query);
+            .watchAcksFull(query1, ++currentVersion, docRemote)
+            .expectEvents(query1, { metadata: [docRemote] })
+            .userUnlistens(query1)
+            .watchRemoves(query1);
         }
         return steps;
       }
@@ -78,8 +78,8 @@ describeSpec(
 
     specTest('Write 100 documents and raise a snapshot', [], () => {
       const cachedDocumentCount = 100;
-
-      const query = Query.atPath(path(`collection`)).addOrderBy(orderBy('v'));
+      9;
+      const query1 = query(`collection`, orderBy('v'));
       const steps = spec().withGCEnabled(false);
       const docs: Document[] = [];
 
@@ -92,13 +92,13 @@ describeSpec(
 
       for (let i = 1; i <= STEP_COUNT; ++i) {
         steps
-          .userListens(query)
-          .expectEvents(query, {
+          .userListens(query1)
+          .expectEvents(query1, {
             added: docs,
             fromCache: true,
             hasPendingWrites: true
           })
-          .userUnlistens(query);
+          .userUnlistens(query1);
       }
 
       return steps;
@@ -121,7 +121,7 @@ describeSpec(
       'Update a document and wait for snapshot with existing listen',
       [],
       () => {
-        const query = Query.atPath(path(`collection/doc`));
+        const query1 = query(`collection/doc`);
 
         let currentVersion = 1;
         const steps = spec().withGCEnabled(false);
@@ -136,16 +136,16 @@ describeSpec(
         let lastRemoteVersion = currentVersion;
 
         steps
-          .userListens(query)
+          .userListens(query1)
           .userSets(`collection/doc`, { v: 0 })
-          .expectEvents(query, {
+          .expectEvents(query1, {
             added: [docLocal],
             fromCache: true,
             hasPendingWrites: true
           })
           .writeAcks(`collection/doc`, docRemote.version.toMicroseconds())
-          .watchAcksFull(query, ++currentVersion, docRemote)
-          .expectEvents(query, { metadata: [docRemote] });
+          .watchAcksFull(query1, ++currentVersion, docRemote)
+          .expectEvents(query1, { metadata: [docRemote] });
 
         for (let i = 1; i <= STEP_COUNT; ++i) {
           docLocal = doc(
@@ -159,14 +159,14 @@ describeSpec(
 
           steps
             .userPatches(`collection/doc`, { v: i })
-            .expectEvents(query, {
+            .expectEvents(query1, {
               modified: [docLocal],
               hasPendingWrites: true
             })
             .writeAcks(`collection/doc`, docRemote.version.toMicroseconds())
-            .watchSends({ affects: [query] }, docRemote)
+            .watchSends({ affects: [query1] }, docRemote)
             .watchSnapshots(++currentVersion)
-            .expectEvents(query, { metadata: [docRemote] });
+            .expectEvents(query1, { metadata: [docRemote] });
         }
         return steps;
       }
@@ -178,15 +178,15 @@ describeSpec(
       () => {
         const documentsPerStep = 100;
 
-        const query = Query.atPath(path(`collection`)).addOrderBy(orderBy('v'));
+        const query1 = query(`collection`, orderBy('v'));
         const steps = spec().withGCEnabled(false);
 
         let currentVersion = 1;
 
         steps
-          .userListens(query)
-          .watchAcksFull(query, currentVersion)
-          .expectEvents(query, {});
+          .userListens(query1)
+          .watchAcksFull(query1, currentVersion)
+          .expectEvents(query1, {});
 
         for (let i = 1; i <= STEP_COUNT; ++i) {
           const docs: Document[] = [];
@@ -200,9 +200,9 @@ describeSpec(
           const changeType = i === 1 ? 'added' : 'modified';
 
           steps
-            .watchSends({ affects: [query] }, ...docs)
+            .watchSends({ affects: [query1] }, ...docs)
             .watchSnapshots(++currentVersion)
-            .expectEvents(query, { [changeType]: docs });
+            .expectEvents(query1, { [changeType]: docs });
         }
 
         return steps;
@@ -221,7 +221,7 @@ describeSpec(
 
         for (let i = 1; i <= STEP_COUNT; ++i) {
           const collPath = `collection/${i}/coll`;
-          const query = Query.atPath(path(collPath)).addOrderBy(orderBy('v'));
+          const query1 = query(collPath, orderBy('v'));
 
           const docs: Document[] = [];
           for (let j = 0; j < documentsPerStep; ++j) {
@@ -229,17 +229,17 @@ describeSpec(
           }
 
           steps
-            .userListens(query)
-            .watchAcksFull(query, ++currentVersion, ...docs)
-            .expectEvents(query, { added: docs })
-            .userUnlistens(query)
-            .watchRemoves(query)
-            .userListens(query, 'resume-token-' + currentVersion)
-            .expectEvents(query, { added: docs, fromCache: true })
-            .watchAcksFull(query, ++currentVersion)
-            .expectEvents(query, {})
-            .userUnlistens(query)
-            .watchRemoves(query);
+            .userListens(query1)
+            .watchAcksFull(query1, ++currentVersion, ...docs)
+            .expectEvents(query1, { added: docs })
+            .userUnlistens(query1)
+            .watchRemoves(query1)
+            .userListens(query1, 'resume-token-' + currentVersion)
+            .expectEvents(query1, { added: docs, fromCache: true })
+            .watchAcksFull(query1, ++currentVersion)
+            .expectEvents(query1, {})
+            .userUnlistens(query1)
+            .watchRemoves(query1);
         }
 
         return steps;
@@ -265,11 +265,9 @@ describeSpec(
         // Create `queriesPerStep` listens, each against collPath but with a
         // unique query constraint.
         for (let j = 0; j < queriesPerStep; ++j) {
-          const query = Query.atPath(path(collPath)).addFilter(
-            filter('val', '<=', j)
-          );
-          queries.push(query);
-          steps.userListens(query).watchAcks(query);
+          const query1 = query(collPath, filter('val', '<=', j));
+          queries.push(query1);
+          steps.userListens(query1).watchAcks(query1);
         }
 
         steps
@@ -304,8 +302,8 @@ describeSpec(
         const steps = spec().withGCEnabled(false);
 
         const collPath = `collection`;
-        const query = Query.atPath(path(collPath)).addOrderBy(orderBy('val'));
-        steps.userListens(query).watchAcks(query);
+        const query1 = query(collPath, orderBy('val'));
+        steps.userListens(query1).watchAcks(query1);
 
         const allDocs: Document[] = [];
 
@@ -316,21 +314,23 @@ describeSpec(
             val: j
           });
           allDocs.push(document);
-          steps.watchSends({ affects: [query] }, document);
+          steps.watchSends({ affects: [query1] }, document);
         }
 
-        steps.watchCurrents(query, `current-version-${++currentVersion}`);
+        steps.watchCurrents(query1, `current-version-${++currentVersion}`);
         steps.watchSnapshots(currentVersion);
-        steps.expectEvents(query, { added: allDocs });
-        steps.userUnlistens(query).watchRemoves(query);
+        steps.expectEvents(query1, { added: allDocs });
+        steps.userUnlistens(query1).watchRemoves(query1);
 
         for (let i = 1; i <= STEP_COUNT; ++i) {
           // Create `queryCount` listens, each against collPath but with a
           // unique query constraint.
           for (let j = 0; j < queryCount; ++j) {
-            const partialQuery = Query.atPath(path(collPath))
-              .addFilter(filter('val', '>=', j * matchingCount))
-              .addFilter(filter('val', '<', (j + 1) * matchingCount));
+            const partialQuery = query(
+              collPath,
+              filter('val', '>=', j * matchingCount),
+              filter('val', '<', (j + 1) * matchingCount)
+            );
             steps.userListens(partialQuery);
             steps.expectEvents(partialQuery, {
               added: allDocs.slice(j * matchingCount, (j + 1) * matchingCount),

--- a/packages/firestore/test/unit/specs/query_spec.test.ts
+++ b/packages/firestore/test/unit/specs/query_spec.test.ts
@@ -16,22 +16,22 @@
  */
 
 import { Query } from '../../../src/core/query';
-import { doc, filter, path } from '../../util/helpers';
+import { doc, filter, query } from '../../util/helpers';
 
 import { Document } from '../../../src/model/document';
-import { ResourcePath } from '../../../src/model/path';
 import { describeSpec, specTest } from './describe_spec';
 import { spec, SpecBuilder } from './spec_builder';
+import { ResourcePath } from '../../../src/model/path';
 
 // Helper to seed the cache with the specified docs by listening to each one.
 function specWithCachedDocs(...docs: Document[]): SpecBuilder {
   let builder = spec();
   for (const doc of docs) {
-    const query = Query.atPath(doc.key.path);
+    const query1 = Query.atPath(doc.key.path);
     builder = builder
-      .userListens(query)
-      .watchAcksFull(query, 1000, doc)
-      .expectEvents(query, { added: [doc] });
+      .userListens(query1)
+      .watchAcksFull(query1, 1000, doc)
+      .expectEvents(query1, { added: [doc] });
   }
   return builder;
 }
@@ -103,7 +103,7 @@ describeSpec('Queries:', [], () => {
     'Latency-compensated updates are included in query results',
     [],
     () => {
-      const fullQuery = Query.atPath(path('collection'));
+      const fullQuery = query('collection');
       const filteredQuery = fullQuery.addFilter(filter('match', '==', true));
       const docA = doc('collection/a', 1000, { match: false });
       const docAv2Local = doc(

--- a/packages/firestore/test/unit/specs/recovery_spec.test.ts
+++ b/packages/firestore/test/unit/specs/recovery_spec.test.ts
@@ -20,7 +20,7 @@ import { client, spec } from './spec_builder';
 import { TimerId } from '../../../src/util/async_queue';
 import { Query } from '../../../src/core/query';
 import { Code } from '../../../src/util/error';
-import { deletedDoc, doc, filter, path } from '../../util/helpers';
+import { deletedDoc, doc, filter, query } from '../../util/helpers';
 import { RpcError } from './spec_rpc_error';
 
 // The IndexedDB action that the Watch stream uses to detect if IndexedDB access
@@ -91,22 +91,22 @@ describeSpec('Persistence Recovery', ['no-ios', 'no-android'], () => {
     'Query raises events in secondary client (with recovery)',
     ['multi-client'],
     () => {
-      const query = Query.atPath(path('collection'));
+      const query1 = query('collection');
       const doc1 = doc('collection/doc', 1, { foo: 'a' });
 
       return client(0)
         .expectPrimaryState(true)
         .client(1)
         .expectPrimaryState(false)
-        .userListens(query)
+        .userListens(query1)
         .failDatabaseTransactions('Get new document changes')
         .client(0)
-        .expectListen(query)
-        .watchAcksFull(query, 1000, doc1)
+        .expectListen(query1)
+        .watchAcksFull(query1, 1000, doc1)
         .client(1)
         .recoverDatabase()
         .runTimer(TimerId.AsyncQueueRetry)
-        .expectEvents(query, { added: [doc1] });
+        .expectEvents(query1, { added: [doc1] });
     }
   );
 
@@ -114,29 +114,29 @@ describeSpec('Persistence Recovery', ['no-ios', 'no-android'], () => {
     'Query is listened to by primary (with recovery)',
     ['multi-client'],
     () => {
-      const query = Query.atPath(path('collection'));
+      const query1 = query('collection');
 
       return (
         client(0)
           .expectPrimaryState(true)
           .failDatabaseTransactions('Allocate target', 'Get target data')
           .client(1)
-          .userListens(query)
+          .userListens(query1)
           .client(0)
           // The primary client 0 receives a WebStorage notification about the
           // new query, but it cannot load the target from IndexedDB. The
           // query will only be listened to once we recover the database.
           .recoverDatabase()
           .runTimer(TimerId.AsyncQueueRetry)
-          .expectListen(query)
+          .expectListen(query1)
           .failDatabaseTransactions('Release target')
           .client(1)
-          .userUnlistens(query)
+          .userUnlistens(query1)
           .client(0)
           // The primary client 0 receives a notification that the query can
           // be released, but it can only process the change after we recover
           // the database.
-          .expectActiveTargets({ query })
+          .expectActiveTargets({ query: query1 })
           .recoverDatabase()
           .runTimer(TimerId.AsyncQueueRetry)
           .expectActiveTargets()
@@ -148,7 +148,7 @@ describeSpec('Persistence Recovery', ['no-ios', 'no-android'], () => {
     'Query with active view recovers after primary tab failover (with recovery)',
     ['multi-client'],
     () => {
-      const query = Query.atPath(path('collection'));
+      const query1 = query('collection');
       const docA = doc('collection/a', 1000, { key: 'a' });
       const docB = doc('collection/b', 2000, { key: 'b' });
 
@@ -157,14 +157,14 @@ describeSpec('Persistence Recovery', ['no-ios', 'no-android'], () => {
           .expectPrimaryState(true)
           .client(1)
           // Register a query in the secondary client
-          .userListens(query)
+          .userListens(query1)
           .client(0)
-          .expectListen(query)
-          .watchAcksFull(query, 1000, docA)
+          .expectListen(query1)
+          .watchAcksFull(query1, 1000, docA)
           // Shutdown the primary client to release its lease
           .shutdown()
           .client(1)
-          .expectEvents(query, { added: [docA] })
+          .expectEvents(query1, { added: [docA] })
           // Run the lease refresh to attempt taking over the primary lease. The
           // first lease refresh fails with a simulated transaction failure.
           .failDatabaseTransactions('Allocate target')
@@ -173,9 +173,9 @@ describeSpec('Persistence Recovery', ['no-ios', 'no-android'], () => {
           .recoverDatabase()
           .runTimer(TimerId.AsyncQueueRetry)
           .expectPrimaryState(true)
-          .expectListen(query, 'resume-token-1000')
-          .watchAcksFull(query, 2000, docB)
-          .expectEvents(query, { added: [docB] })
+          .expectListen(query1, 'resume-token-1000')
+          .watchAcksFull(query1, 2000, docB)
+          .expectEvents(query1, { added: [docB] })
       );
     }
   );
@@ -184,7 +184,7 @@ describeSpec('Persistence Recovery', ['no-ios', 'no-android'], () => {
     'Query without active view recovers after primary tab failover (with recovery)',
     ['multi-client'],
     () => {
-      const query = Query.atPath(path('collection'));
+      const query1 = query('collection');
       const docA = doc('collection/a', 1000, { key: 'a' });
       const docB = doc('collection/b', 2000, { key: 'b' });
 
@@ -195,12 +195,12 @@ describeSpec('Persistence Recovery', ['no-ios', 'no-android'], () => {
           .client(1)
           .client(2)
           // Register a query in the third client
-          .userListens(query)
+          .userListens(query1)
           .client(0)
-          .expectListen(query)
-          .watchAcksFull(query, 1000, docA)
+          .expectListen(query1)
+          .watchAcksFull(query1, 1000, docA)
           .client(2)
-          .expectEvents(query, { added: [docA] })
+          .expectEvents(query1, { added: [docA] })
           .client(0)
           // Shutdown the primary client to release its lease
           .shutdown()
@@ -214,10 +214,10 @@ describeSpec('Persistence Recovery', ['no-ios', 'no-android'], () => {
           .recoverDatabase()
           .runTimer(TimerId.AsyncQueueRetry)
           .expectPrimaryState(true)
-          .expectListen(query, 'resume-token-1000')
-          .watchAcksFull(query, 2000, docB)
+          .expectListen(query1, 'resume-token-1000')
+          .watchAcksFull(query1, 2000, docB)
           .client(2)
-          .expectEvents(query, { added: [docB] })
+          .expectEvents(query1, { added: [docB] })
       );
     }
   );
@@ -297,7 +297,7 @@ describeSpec('Persistence Recovery', ['no-ios', 'no-android'], () => {
   });
 
   specTest('Does not surface non-persisted writes', [], () => {
-    const query = Query.atPath(path('collection'));
+    const query1 = query('collection');
     const doc1Local = doc(
       'collection/key1',
       0,
@@ -313,9 +313,9 @@ describeSpec('Persistence Recovery', ['no-ios', 'no-android'], () => {
     );
     const doc3 = doc('collection/key3', 2, { foo: 'c' });
     return spec()
-      .userListens(query)
+      .userListens(query1)
       .userSets('collection/key1', { foo: 'a' })
-      .expectEvents(query, {
+      .expectEvents(query1, {
         added: [doc1Local],
         fromCache: true,
         hasPendingWrites: true
@@ -325,15 +325,15 @@ describeSpec('Persistence Recovery', ['no-ios', 'no-android'], () => {
       .expectUserCallbacks({ rejected: ['collection/key2'] })
       .recoverDatabase()
       .userSets('collection/key3', { foo: 'c' })
-      .expectEvents(query, {
+      .expectEvents(query1, {
         added: [doc3Local],
         fromCache: true,
         hasPendingWrites: true
       })
       .writeAcks('collection/key1', 1)
       .writeAcks('collection/key3', 2)
-      .watchAcksFull(query, 2, doc1, doc3)
-      .expectEvents(query, { metadata: [doc1, doc3] });
+      .watchAcksFull(query1, 2, doc1, doc3)
+      .expectEvents(query1, { metadata: [doc1, doc3] });
   });
 
   specTest('Recovers when write acknowledgment cannot be persisted', [], () => {
@@ -400,7 +400,7 @@ describeSpec('Persistence Recovery', ['no-ios', 'no-android'], () => {
   );
 
   specTest('Writes are pending until acknowledgement is persisted', [], () => {
-    const query = Query.atPath(path('collection'));
+    const query1 = query('collection');
     const doc1Local = doc(
       'collection/a',
       0,
@@ -417,31 +417,34 @@ describeSpec('Persistence Recovery', ['no-ios', 'no-android'], () => {
     const doc2 = doc('collection/b', 1002, { v: 2 });
     return (
       spec()
-        .userListens(query)
-        .watchAcksFull(query, 1000)
-        .expectEvents(query, {})
+        .userListens(query1)
+        .watchAcksFull(query1, 1000)
+        .expectEvents(query1, {})
         .userSets('collection/a', { v: 1 })
-        .expectEvents(query, { added: [doc1Local], hasPendingWrites: true })
+        .expectEvents(query1, { added: [doc1Local], hasPendingWrites: true })
         .userSets('collection/b', { v: 2 })
-        .expectEvents(query, { added: [doc2Local], hasPendingWrites: true })
+        .expectEvents(query1, { added: [doc2Local], hasPendingWrites: true })
         .failDatabaseTransactions('Acknowledge batch')
         .writeAcks('collection/a', 1, { expectUserCallback: false })
         // The write ack cannot be persisted and the client goes offline, which
         // clears all active targets, but doesn't raise a new snapshot since
         // the document is still marked `hasPendingWrites`.
-        .expectEvents(query, { fromCache: true, hasPendingWrites: true })
+        .expectEvents(query1, { fromCache: true, hasPendingWrites: true })
         .expectActiveTargets()
         .recoverDatabase()
         .runTimer(TimerId.AsyncQueueRetry)
         // Client is back online
-        .expectActiveTargets({ query, resumeToken: 'resume-token-1000' })
+        .expectActiveTargets({
+          query: query1,
+          resumeToken: 'resume-token-1000'
+        })
         .expectUserCallbacks({ acknowledged: ['collection/a'] })
-        .watchAcksFull(query, 1001, doc1)
-        .expectEvents(query, { metadata: [doc1], hasPendingWrites: true })
+        .watchAcksFull(query1, 1001, doc1)
+        .expectEvents(query1, { metadata: [doc1], hasPendingWrites: true })
         .writeAcks('collection/b', 2)
-        .watchSends({ affects: [query] }, doc2)
+        .watchSends({ affects: [query1] }, doc2)
         .watchSnapshots(1002)
-        .expectEvents(query, { metadata: [doc2] })
+        .expectEvents(query1, { metadata: [doc2] })
     );
   });
 
@@ -449,7 +452,7 @@ describeSpec('Persistence Recovery', ['no-ios', 'no-android'], () => {
     'Surfaces local documents if notifyLocalViewChanges fails',
     [],
     () => {
-      const query = Query.atPath(path('collection'));
+      const query1 = query('collection');
       const doc1Local = doc(
         'collection/key1',
         0,
@@ -459,10 +462,10 @@ describeSpec('Persistence Recovery', ['no-ios', 'no-android'], () => {
       const doc1 = doc('collection/key1', 1, { foo: 'a' });
       const doc2 = doc('collection/key2', 2, { foo: 'b' });
       return spec()
-        .userListens(query)
+        .userListens(query1)
         .failDatabaseTransactions('notifyLocalViewChanges')
         .userSets('collection/key1', { foo: 'a' })
-        .expectEvents(query, {
+        .expectEvents(query1, {
           added: [doc1Local],
           fromCache: true,
           hasPendingWrites: true
@@ -471,8 +474,8 @@ describeSpec('Persistence Recovery', ['no-ios', 'no-android'], () => {
         .runTimer(TimerId.AsyncQueueRetry)
         .writeAcks('collection/key1', 1)
         .failDatabaseTransactions('notifyLocalViewChanges')
-        .watchAcksFull(query, 1000, doc1, doc2)
-        .expectEvents(query, {
+        .watchAcksFull(query1, 1000, doc1, doc2)
+        .expectEvents(query1, {
           metadata: [doc1],
           added: [doc2]
         });
@@ -483,35 +486,35 @@ describeSpec('Persistence Recovery', ['no-ios', 'no-android'], () => {
     'Excludes documents from future queries even if notifyLocalViewChanges fails',
     [],
     () => {
-      const query = Query.atPath(path('collection'));
+      const query1 = query('collection');
       const doc1 = doc('collection/key1', 1000, { foo: 'a' });
       const deletedDoc1 = deletedDoc('collection/key1', 2000);
       return (
         spec()
           .withGCEnabled(false)
-          .userListens(query)
-          .watchAcksFull(query, 1000, doc1)
-          .expectEvents(query, {
+          .userListens(query1)
+          .watchAcksFull(query1, 1000, doc1)
+          .expectEvents(query1, {
             added: [doc1]
           })
           .failDatabaseTransactions('notifyLocalViewChanges')
-          .watchSends({ removed: [query] }, deletedDoc1)
+          .watchSends({ removed: [query1] }, deletedDoc1)
           .watchSnapshots(2000)
-          .expectEvents(query, {
+          .expectEvents(query1, {
             removed: [doc1]
           })
           .recoverDatabase()
-          .userUnlistens(query)
+          .userUnlistens(query1)
           // No event since the document was removed
-          .userListens(query, 'resume-token-1000')
+          .userListens(query1, 'resume-token-1000')
       );
     }
   );
 
   specTest('Fails targets that cannot be allocated', [], () => {
-    const query1 = Query.atPath(path('collection1'));
-    const query2 = Query.atPath(path('collection2'));
-    const query3 = Query.atPath(path('collection3'));
+    const query1 = query('collection1');
+    const query2 = query('collection2');
+    const query3 = query('collection3');
     return spec()
       .userListens(query1)
       .watchAcksFull(query1, 1)
@@ -526,8 +529,8 @@ describeSpec('Persistence Recovery', ['no-ios', 'no-android'], () => {
   });
 
   specTest('Can re-add failed target', [], () => {
-    const query1 = Query.atPath(path('collection1'));
-    const query2 = Query.atPath(path('collection2'));
+    const query1 = query('collection1');
+    const query2 = query('collection2');
     return spec()
       .userListens(query1)
       .watchAcksFull(query1, 1)
@@ -542,28 +545,31 @@ describeSpec('Persistence Recovery', ['no-ios', 'no-android'], () => {
   });
 
   specTest('Recovers when watch update cannot be persisted', [], () => {
-    const query = Query.atPath(path('collection'));
+    const query1 = query('collection');
     const doc1 = doc('collection/key1', 1000, { foo: 'a' });
     const doc2 = doc('collection/key2', 2000, { foo: 'b' });
     return (
       spec()
         .withGCEnabled(false)
-        .userListens(query)
-        .watchAcksFull(query, 1000, doc1)
-        .expectEvents(query, {
+        .userListens(query1)
+        .watchAcksFull(query1, 1000, doc1)
+        .expectEvents(query1, {
           added: [doc1]
         })
-        .watchSends({ affects: [query] }, doc2)
+        .watchSends({ affects: [query1] }, doc2)
         .failDatabaseTransactions('Get last remote snapshot version')
         .watchSnapshots(1500)
         // `failDatabaseTransactions()` causes us to go offline.
         .expectActiveTargets()
-        .expectEvents(query, { fromCache: true })
+        .expectEvents(query1, { fromCache: true })
         .recoverDatabase()
         .runTimer(TimerId.AsyncQueueRetry)
-        .expectActiveTargets({ query, resumeToken: 'resume-token-1000' })
-        .watchAcksFull(query, 2000, doc2)
-        .expectEvents(query, {
+        .expectActiveTargets({
+          query: query1,
+          resumeToken: 'resume-token-1000'
+        })
+        .watchAcksFull(query1, 2000, doc2)
+        .expectEvents(query1, {
           added: [doc2]
         })
     );
@@ -573,8 +579,8 @@ describeSpec('Persistence Recovery', ['no-ios', 'no-android'], () => {
     // This test verifies that the client ignores failures during the
     // 'Release target' transaction.
 
-    const doc1Query = Query.atPath(path('collection/key1'));
-    const doc2Query = Query.atPath(path('collection/key2'));
+    const doc1Query = query('collection/key1');
+    const doc2Query = query('collection/key2');
     const doc1a = doc('collection/key1', 1000, { foo: 'a' });
     const doc1b = doc('collection/key1', 4000, { foo: 'a', updated: true });
     const doc2 = doc('collection/key2', 2000, { foo: 'b' });
@@ -622,10 +628,8 @@ describeSpec('Persistence Recovery', ['no-ios', 'no-android'], () => {
     'Recovers when Limbo acknowledgement cannot be persisted',
     [],
     () => {
-      const fullQuery = Query.atPath(path('collection'));
-      const filteredQuery = Query.atPath(path('collection')).addFilter(
-        filter('included', '==', true)
-      );
+      const fullQuery = query('collection');
+      const filteredQuery = query('collection', filter('included', '==', true));
       const doc1a = doc('collection/key1', 1, { included: true });
       const doc1b = doc('collection/key1', 1500, { included: false });
       const limboQuery = Query.atPath(doc1a.key.path);
@@ -666,10 +670,8 @@ describeSpec('Persistence Recovery', ['no-ios', 'no-android'], () => {
   );
 
   specTest('Recovers when Limbo rejection cannot be persisted', [], () => {
-    const fullQuery = Query.atPath(path('collection'));
-    const filteredQuery = Query.atPath(path('collection')).addFilter(
-      filter('included', '==', true)
-    );
+    const fullQuery = query('collection');
+    const filteredQuery = query('collection', filter('included', '==', true));
     const doc1 = doc('collection/key1', 1, { included: true });
     const limboQuery = Query.atPath(doc1.key.path);
     return spec()
@@ -714,7 +716,7 @@ describeSpec('Persistence Recovery', ['no-ios', 'no-android'], () => {
     'User change handles transaction failures (with recovery)',
     ['durable-persistence'],
     () => {
-      const query = Query.atPath(path('collection'));
+      const query1 = query('collection');
       const doc1 = doc(
         'collection/key1',
         0,
@@ -725,8 +727,8 @@ describeSpec('Persistence Recovery', ['no-ios', 'no-android'], () => {
         spec()
           .changeUser('user1')
           .userSets('collection/key1', { foo: 'a' })
-          .userListens(query)
-          .expectEvents(query, {
+          .userListens(query1)
+          .expectEvents(query1, {
             added: [doc1],
             fromCache: true,
             hasPendingWrites: true
@@ -737,16 +739,16 @@ describeSpec('Persistence Recovery', ['no-ios', 'no-android'], () => {
           .expectActiveTargets()
           .recoverDatabase()
           .runTimer(TimerId.AsyncQueueRetry)
-          .expectActiveTargets({ query })
-          .expectEvents(query, { removed: [doc1], fromCache: true })
+          .expectActiveTargets({ query: query1 })
+          .expectEvents(query1, { removed: [doc1], fromCache: true })
           .failDatabaseTransactions('Handle user change')
           .changeUser('user1')
           // The network is offline due to the failed user change
           .expectActiveTargets()
           .recoverDatabase()
           .runTimer(TimerId.AsyncQueueRetry)
-          .expectActiveTargets({ query })
-          .expectEvents(query, {
+          .expectActiveTargets({ query: query1 })
+          .expectEvents(query1, {
             added: [doc1],
             fromCache: true,
             hasPendingWrites: true
@@ -759,7 +761,7 @@ describeSpec('Persistence Recovery', ['no-ios', 'no-android'], () => {
     'Multiple user changes during transaction failure (with recovery)',
     ['durable-persistence'],
     () => {
-      const query = Query.atPath(path('collection'));
+      const query1 = query('collection');
       const doc1 = doc(
         'collection/key1',
         0,
@@ -770,8 +772,8 @@ describeSpec('Persistence Recovery', ['no-ios', 'no-android'], () => {
         spec()
           .changeUser('user1')
           .userSets('collection/key1', { foo: 'a' })
-          .userListens(query)
-          .expectEvents(query, {
+          .userListens(query1)
+          .expectEvents(query1, {
             added: [doc1],
             fromCache: true,
             hasPendingWrites: true
@@ -784,12 +786,12 @@ describeSpec('Persistence Recovery', ['no-ios', 'no-android'], () => {
           .changeUser('user1')
           .recoverDatabase()
           .runTimer(TimerId.AsyncQueueRetry)
-          .expectActiveTargets({ query })
+          .expectActiveTargets({ query: query1 })
           // We are now user 2
-          .expectEvents(query, { removed: [doc1], fromCache: true })
+          .expectEvents(query1, { removed: [doc1], fromCache: true })
           .runTimer(TimerId.AsyncQueueRetry)
           // We are now user 1
-          .expectEvents(query, {
+          .expectEvents(query1, {
             added: [doc1],
             fromCache: true,
             hasPendingWrites: true
@@ -799,43 +801,43 @@ describeSpec('Persistence Recovery', ['no-ios', 'no-android'], () => {
   );
 
   specTest('Unlisten succeeds when target release fails', [], () => {
-    const query = Query.atPath(path('collection'));
+    const query1 = query('collection');
     const doc1 = doc('collection/key1', 1, { foo: 'a' });
     return spec()
-      .userListens(query)
-      .watchAcksFull(query, 1000, doc1)
-      .expectEvents(query, {
+      .userListens(query1)
+      .watchAcksFull(query1, 1000, doc1)
+      .expectEvents(query1, {
         added: [doc1]
       })
       .failDatabaseTransactions('Release target')
-      .userUnlistens(query)
+      .userUnlistens(query1)
       .expectActiveTargets();
   });
 
   specTest('Can re-listen to query when unlisten fails', [], () => {
-    const query = Query.atPath(path('collection'));
+    const query1 = query('collection');
     const doc1 = doc('collection/key1', 1, { foo: 'a' });
     const doc2 = doc('collection/key2', 2, { foo: 'b' });
     return spec()
       .withGCEnabled(false)
-      .userListens(query)
-      .watchAcksFull(query, 1000, doc1)
-      .expectEvents(query, {
+      .userListens(query1)
+      .watchAcksFull(query1, 1000, doc1)
+      .expectEvents(query1, {
         added: [doc1]
       })
       .failDatabaseTransactions('Release target')
-      .userUnlistens(query)
-      .watchRemoves(query)
+      .userUnlistens(query1)
+      .watchRemoves(query1)
       .recoverDatabase()
-      .userListens(query, 'resume-token-1000')
-      .expectEvents(query, {
+      .userListens(query1, 'resume-token-1000')
+      .expectEvents(query1, {
         added: [doc1],
         fromCache: true
       })
-      .watchAcksFull(query, 2000, doc2)
-      .expectEvents(query, {
+      .watchAcksFull(query1, 2000, doc2)
+      .expectEvents(query1, {
         added: [doc2]
       })
-      .userUnlistens(query);
+      .userUnlistens(query1);
   });
 });

--- a/packages/firestore/test/unit/specs/remote_store_spec.test.ts
+++ b/packages/firestore/test/unit/specs/remote_store_spec.test.ts
@@ -15,73 +15,72 @@
  * limitations under the License.
  */
 
-import { Query } from '../../../src/core/query';
 import { Code } from '../../../src/util/error';
-import { doc, path } from '../../util/helpers';
+import { doc, query } from '../../util/helpers';
 
 import { describeSpec, specTest } from './describe_spec';
 import { spec } from './spec_builder';
 
 describeSpec('Remote store:', [], () => {
   specTest('Waits for watch to remove targets', [], () => {
-    const query = Query.atPath(path('collection'));
+    const query1 = query('collection');
     const doc1 = doc('collection/a', 1000, { key: 'a' });
     return spec()
       .withGCEnabled(false)
-      .userListens(query)
-      .watchAcks(query)
-      .userUnlistens(query) // Now we simulate a quick unlisten.
-      .userListens(query) // But add it back before watch acks it.
-      .watchSends({ affects: [query] }, doc1) // Should be ignored.
-      .watchCurrents(query, 'resume-token')
+      .userListens(query1)
+      .watchAcks(query1)
+      .userUnlistens(query1) // Now we simulate a quick unlisten.
+      .userListens(query1) // But add it back before watch acks it.
+      .watchSends({ affects: [query1] }, doc1) // Should be ignored.
+      .watchCurrents(query1, 'resume-token')
       .watchSnapshots(1000)
-      .watchRemoves(query) // Finally watch decides to ack the removal.
-      .watchAcksFull(query, 1001, doc1) // Now watch should ack the query.
-      .expectEvents(query, { added: [doc1] }); // This should work now.
+      .watchRemoves(query1) // Finally watch decides to ack the removal.
+      .watchAcksFull(query1, 1001, doc1) // Now watch should ack the query.
+      .expectEvents(query1, { added: [doc1] }); // This should work now.
   });
 
   specTest('Waits for watch to ack last target add', [], () => {
-    const query = Query.atPath(path('collection'));
+    const query1 = query('collection');
     const doc1 = doc('collection/a', 1000, { key: 'a' });
     const doc2 = doc('collection/b', 1000, { key: 'b' });
     const doc3 = doc('collection/c', 1000, { key: 'c' });
     const doc4 = doc('collection/d', 1000, { key: 'd' });
     return spec()
       .withGCEnabled(false)
-      .userListens(query)
-      .watchAcks(query)
-      .userUnlistens(query) // Now we simulate a quick unlisten.
-      .userListens(query) // But add it back before watch acks it.
-      .userUnlistens(query) // But do it a few more times...
-      .userListens(query)
-      .userUnlistens(query)
-      .userListens(query)
-      .watchSends({ affects: [query] }, doc1) // Should be ignored.
-      .watchCurrents(query, 'resume-token')
+      .userListens(query1)
+      .watchAcks(query1)
+      .userUnlistens(query1) // Now we simulate a quick unlisten.
+      .userListens(query1) // But add it back before watch acks it.
+      .userUnlistens(query1) // But do it a few more times...
+      .userListens(query1)
+      .userUnlistens(query1)
+      .userListens(query1)
+      .watchSends({ affects: [query1] }, doc1) // Should be ignored.
+      .watchCurrents(query1, 'resume-token')
       .watchSnapshots(1000)
-      .watchRemoves(query) // Finally watch decides to ack the FIRST removal.
-      .watchAcksFull(query, 1001, doc2) // Now watch should ack the second listen.
-      .watchRemoves(query) // Finally watch decides to ack the SECOND removal.
-      .watchAcksFull(query, 1001, doc3) // Now watch should ack the second listen.
-      .watchRemoves(query) // Finally watch decides to ack the THIRD removal.
-      .watchAcksFull(query, 1001, doc4) // Now watch should ack the query.
-      .expectEvents(query, { added: [doc4] }); // This should work now.
+      .watchRemoves(query1) // Finally watch decides to ack the FIRST removal.
+      .watchAcksFull(query1, 1001, doc2) // Now watch should ack the second listen.
+      .watchRemoves(query1) // Finally watch decides to ack the SECOND removal.
+      .watchAcksFull(query1, 1001, doc3) // Now watch should ack the second listen.
+      .watchRemoves(query1) // Finally watch decides to ack the THIRD removal.
+      .watchAcksFull(query1, 1001, doc4) // Now watch should ack the query.
+      .expectEvents(query1, { added: [doc4] }); // This should work now.
   });
 
   specTest('Cleans up watch state correctly', [], () => {
-    const query = Query.atPath(path('collection'));
+    const query1 = query('collection');
     const doc1 = doc('collection/a', 1000, { key: 'a' });
     return (
       spec()
         .withGCEnabled(false)
-        .userListens(query)
+        .userListens(query1)
         // Close before we get an ack, this should reset our pending
         // target counts.
         .watchStreamCloses(Code.UNAVAILABLE)
-        .expectEvents(query, { fromCache: true })
+        .expectEvents(query1, { fromCache: true })
 
-        .watchAcksFull(query, 1001, doc1)
-        .expectEvents(query, { added: [doc1] })
+        .watchAcksFull(query1, 1001, doc1)
+        .expectEvents(query1, { added: [doc1] })
     );
   });
 
@@ -91,15 +90,15 @@ describeSpec('Remote store:', [], () => {
     'Handles user changes while offline (b/74749605).',
     ['no-android', 'no-ios'],
     () => {
-      const query = Query.atPath(path('collection'));
+      const query1 = query('collection');
       return (
         spec()
-          .userListens(query)
+          .userListens(query1)
 
           // close the stream (this should trigger retry with backoff; but don't
           // run it in an attempt to reproduce b/74749605).
           .watchStreamCloses(Code.UNAVAILABLE, { runBackoffTimer: false })
-          .expectEvents(query, { fromCache: true })
+          .expectEvents(query1, { fromCache: true })
 
           // Because we didn't let the backoff timer run and restart the watch
           // stream, there will be no active targets.
@@ -108,7 +107,7 @@ describeSpec('Remote store:', [], () => {
           // Change user (will shut down existing streams and start new ones).
           .changeUser('abc')
           // Our query should be sent to the new stream.
-          .expectActiveTargets({ query, resumeToken: '' })
+          .expectActiveTargets({ query: query1, resumeToken: '' })
 
           // Close the (newly-created) stream as if it too failed (should trigger
           // retry with backoff, potentially reproducing the crash in b/74749605).

--- a/packages/firestore/test/unit/specs/resume_token_spec.test.ts
+++ b/packages/firestore/test/unit/specs/resume_token_spec.test.ts
@@ -15,43 +15,45 @@
  * limitations under the License.
  */
 
-import { Query } from '../../../src/core/query';
 import { Code } from '../../../src/util/error';
-import { doc, path } from '../../util/helpers';
+import { doc, query } from '../../util/helpers';
 
 import { describeSpec, specTest } from './describe_spec';
 import { spec } from './spec_builder';
 
 describeSpec('Resume tokens:', [], () => {
   specTest('Resume tokens are sent after watch stream restarts', [], () => {
-    const query = Query.atPath(path('collection'));
+    const query1 = query('collection');
     const doc1 = doc('collection/a', 1000, { key: 'a' });
     return spec()
-      .userListens(query)
-      .watchAcks(query)
-      .watchSends({ affects: [query] }, doc1)
-      .watchCurrents(query, 'custom-query-resume-token')
+      .userListens(query1)
+      .watchAcks(query1)
+      .watchSends({ affects: [query1] }, doc1)
+      .watchCurrents(query1, 'custom-query-resume-token')
       .watchSnapshots(1000)
-      .expectEvents(query, { added: [doc1] })
+      .expectEvents(query1, { added: [doc1] })
       .watchStreamCloses(Code.UNAVAILABLE)
-      .expectActiveTargets({ query, resumeToken: 'custom-query-resume-token' });
+      .expectActiveTargets({
+        query: query1,
+        resumeToken: 'custom-query-resume-token'
+      });
   });
 
   specTest('Resume tokens are used across new listens', [], () => {
-    const query = Query.atPath(path('collection'));
+    const query1 = query('collection');
     const doc1 = doc('collection/a', 1000, { key: 'a' });
     return spec()
       .withGCEnabled(false)
-      .userListens(query)
-      .watchAcks(query)
-      .watchSends({ affects: [query] }, doc1)
-      .watchCurrents(query, 'custom-query-resume-token')
+      .userListens(query1)
+      .watchAcks(query1)
+      .watchSends({ affects: [query1] }, doc1)
+      .watchCurrents(query1, 'custom-query-resume-token')
       .watchSnapshots(1000)
-      .expectEvents(query, { added: [doc1] })
-      .userUnlistens(query)
-      .userListens(query, 'custom-query-resume-token')
-      .expectEvents(query, { fromCache: true, added: [doc1] })
-      .watchAcks(query)
+      .expectEvents(query1, { added: [doc1] })
+      .userUnlistens(query1)
+      .userListens(query1, 'custom-query-resume-token')
+      .expectEvents(query1, { fromCache: true, added: [doc1] })
+      .watchAcks(query1)
       .watchSnapshots(1001);
   });
 });

--- a/packages/firestore/test/unit/specs/spec_test_runner.ts
+++ b/packages/firestore/test/unit/specs/spec_test_runner.ts
@@ -85,6 +85,7 @@ import {
   orderBy,
   patchMutation,
   path,
+  query,
   setMutation,
   stringFromBase64String,
   TestSnapshotVersion,
@@ -127,7 +128,7 @@ const ARBITRARY_SEQUENCE_NUMBER = 2;
 
 export function parseQuery(querySpec: string | SpecQuery): Query {
   if (typeof querySpec === 'string') {
-    return Query.atPath(path(querySpec));
+    return query(querySpec);
   } else {
     let query = new Query(path(querySpec.path), querySpec.collectionGroup);
     if (querySpec.limit) {

--- a/packages/firestore/test/util/helpers.ts
+++ b/packages/firestore/test/util/helpers.ts
@@ -34,8 +34,10 @@ import {
   Bound,
   Direction,
   FieldFilter,
+  Filter,
   Operator,
-  OrderBy
+  OrderBy,
+  Query
 } from '../../src/core/query';
 import { SnapshotVersion } from '../../src/core/snapshot_version';
 import { TargetId } from '../../src/core/types';
@@ -88,7 +90,7 @@ import { primitiveComparator } from '../../src/util/misc';
 import { Dict, forEach } from '../../src/util/obj';
 import { SortedMap } from '../../src/util/sorted_map';
 import { SortedSet } from '../../src/util/sorted_set';
-import { FIRESTORE, query } from './api_helpers';
+import { FIRESTORE } from './api_helpers';
 import { ByteString } from '../../src/util/byte_string';
 import { decodeBase64, encodeBase64 } from '../../src/platform/base64';
 import { JsonProtoSerializer } from '../../src/remote/serializer';
@@ -293,6 +295,21 @@ export function bound(
   return new Bound(components, before);
 }
 
+export function query(
+  resourcePath: string,
+  ...constraints: Array<OrderBy | Filter>
+): Query {
+  let q = Query.atPath(path(resourcePath));
+  for (const constraint of constraints) {
+    if (constraint instanceof Filter) {
+      q = q.addFilter(constraint);
+    } else {
+      q = q.addOrderBy(constraint);
+    }
+  }
+  return q;
+}
+
 export function targetData(
   targetId: TargetId,
   queryPurpose: TargetPurpose,
@@ -301,7 +318,7 @@ export function targetData(
   // Arbitrary value.
   const sequenceNumber = 0;
   return new TargetData(
-    query(path)._query.toTarget(),
+    query(path).toTarget(),
     targetId,
     queryPurpose,
     sequenceNumber


### PR DESCRIPTION
This is mechanical test refactor that is part of https://github.com/firebase/firebase-js-sdk/pull/3390, but extracted out to make it easier to review. It adds a test helper that hides some of the indirection that a functional Query API brings with it.

Most of this PR is renaming `query` to `query1` for local variables to avoid name clashes.

No functional changes. The new test helper is in the very last file.