### PR TITLE
Move Datastore to ComponentProvider

### DIFF
--- a/packages/firestore/lite/src/api/database.ts
+++ b/packages/firestore/lite/src/api/database.ts
@@ -92,9 +92,11 @@ export class Firestore
     if (!this._datastorePromise) {
       const settings = this._getSettings();
       const databaseInfo = this._makeDatabaseInfo(settings.host, settings.ssl);
+      const serializer = newSerializer(databaseInfo.databaseId);
+      const datastore = newDatastore(this._credentials, serializer);
       this._datastorePromise = newConnection(databaseInfo).then(connection => {
-        const serializer = newSerializer(databaseInfo.databaseId);
-        return newDatastore(connection, this._credentials, serializer);
+        datastore.start(connection);
+        return datastore;
       });
     }
 

--- a/packages/firestore/src/core/firestore_client.ts
+++ b/packages/firestore/src/core/firestore_client.ts
@@ -22,7 +22,6 @@ import { GarbageCollectionScheduler, Persistence } from '../local/persistence';
 import { Document, NoDocument } from '../model/document';
 import { DocumentKey } from '../model/document_key';
 import { Mutation } from '../model/mutation';
-import { newDatastore } from '../remote/datastore';
 import { RemoteStore } from '../remote/remote_store';
 import { AsyncQueue, wrapInUserErrorIfRecoverable } from '../util/async_queue';
 import { Code, FirestoreError } from '../util/error';
@@ -47,8 +46,6 @@ import {
   ComponentProvider,
   MemoryComponentProvider
 } from './component_provider';
-import { newConnection } from '../platform/connection';
-import { newSerializer } from '../platform/serializer';
 
 const LOG_TAG = 'FirestoreClient';
 const MAX_CONCURRENT_LIMBO_RESOLUTIONS = 100;
@@ -236,19 +233,11 @@ export class FirestoreClient {
     persistenceResult: Deferred<void>
   ): Promise<void> {
     try {
-      // TODO(mrschmidt): Ideally, ComponentProvider would also initialize
-      // Datastore (without duplicating the initializing logic once per
-      // provider).
-
-      const connection = await newConnection(this.databaseInfo);
-      const serializer = newSerializer(this.databaseInfo.databaseId);
-      const datastore = newDatastore(connection, this.credentials, serializer);
-
       await componentProvider.initialize({
         asyncQueue: this.asyncQueue,
         databaseInfo: this.databaseInfo,
-        datastore,
         clientId: this.clientId,
+        credentials: this.credentials,
         initialUser: user,
         maxConcurrentLimboResolutions: MAX_CONCURRENT_LIMBO_RESOLUTIONS,
         persistenceSettings

--- a/packages/firestore/src/remote/datastore.ts
+++ b/packages/firestore/src/remote/datastore.ts
@@ -20,7 +20,7 @@ import { Document, MaybeDocument } from '../model/document';
 import { DocumentKey } from '../model/document_key';
 import { Mutation } from '../model/mutation';
 import * as api from '../protos/firestore_proto_api';
-import { debugCast, hardAssert } from '../util/assert';
+import { debugAssert, debugCast, hardAssert } from '../util/assert';
 import { Code, FirestoreError } from '../util/error';
 import { Connection } from './connection';
 import {
@@ -46,10 +46,8 @@ import { Query } from '../core/query';
  * Cloud Datastore grpc API, which provides an interface that is more convenient
  * for the rest of the client SDK architecture to consume.
  */
-export class Datastore {
-  // Make sure that the structural type of `Datastore` is unique.
-  // See https://github.com/microsoft/TypeScript/issues/5451
-  private _ = undefined;
+export abstract class Datastore {
+  abstract start(connection: Connection): void;
 }
 
 /**
@@ -57,17 +55,18 @@ export class Datastore {
  * consumption.
  */
 class DatastoreImpl extends Datastore {
+  connection!: Connection;
   terminated = false;
 
   constructor(
-    readonly connection: Connection,
     readonly credentials: CredentialsProvider,
     readonly serializer: JsonProtoSerializer
   ) {
     super();
   }
 
-  private verifyNotTerminated(): void {
+  verifyInitialized(): void {
+    debugAssert(!!this.connection, 'Datastore.start() not called');
     if (this.terminated) {
       throw new FirestoreError(
         Code.FAILED_PRECONDITION,
@@ -76,9 +75,14 @@ class DatastoreImpl extends Datastore {
     }
   }
 
+  start(connection: Connection): void {
+    debugAssert(!this.connection, 'Datastore.start() already called');
+    this.connection = connection;
+  }
+
   /** Gets an auth token and invokes the provided RPC. */
   invokeRPC<Req, Resp>(rpcName: string, request: Req): Promise<Resp> {
-    this.verifyNotTerminated();
+    this.verifyInitialized();
     return this.credentials
       .getToken()
       .then(token => {
@@ -97,7 +101,7 @@ class DatastoreImpl extends Datastore {
     rpcName: string,
     request: Req
   ): Promise<Resp[]> {
-    this.verifyNotTerminated();
+    this.verifyInitialized();
     return this.credentials
       .getToken()
       .then(token => {
@@ -117,11 +121,10 @@ class DatastoreImpl extends Datastore {
 }
 
 export function newDatastore(
-  connection: Connection,
   credentials: CredentialsProvider,
   serializer: JsonProtoSerializer
 ): Datastore {
-  return new DatastoreImpl(connection, credentials, serializer);
+  return new DatastoreImpl(credentials, serializer);
 }
 
 export async function invokeCommitRpc(
@@ -200,6 +203,7 @@ export function newPersistentWriteStream(
   listener: WriteStreamListener
 ): PersistentWriteStream {
   const datastoreImpl = debugCast(datastore, DatastoreImpl);
+  datastoreImpl.verifyInitialized();
   return new PersistentWriteStream(
     queue,
     datastoreImpl.connection,
@@ -215,6 +219,7 @@ export function newPersistentWatchStream(
   listener: WatchStreamListener
 ): PersistentListenStream {
   const datastoreImpl = debugCast(datastore, DatastoreImpl);
+  datastoreImpl.verifyInitialized();
   return new PersistentListenStream(
     queue,
     datastoreImpl.connection,

--- a/packages/firestore/test/integration/util/internal_helpers.ts
+++ b/packages/firestore/test/integration/util/internal_helpers.ts
@@ -53,9 +53,10 @@ export function withTestDatastore(
   credentialsProvider: CredentialsProvider = new EmptyCredentialsProvider()
 ): Promise<void> {
   const databaseInfo = getDefaultDatabaseInfo();
-  return newConnection(databaseInfo).then(conn => {
+  return newConnection(databaseInfo).then(async conn => {
     const serializer = newSerializer(databaseInfo.databaseId);
-    const datastore = newDatastore(conn, credentialsProvider, serializer);
+    const datastore = newDatastore(credentialsProvider, serializer);
+    await datastore.start(conn);
     return fn(datastore);
   });
 }

--- a/packages/firestore/test/integration/util/internal_helpers.ts
+++ b/packages/firestore/test/integration/util/internal_helpers.ts
@@ -53,10 +53,10 @@ export function withTestDatastore(
   credentialsProvider: CredentialsProvider = new EmptyCredentialsProvider()
 ): Promise<void> {
   const databaseInfo = getDefaultDatabaseInfo();
-  return newConnection(databaseInfo).then(async conn => {
+  return newConnection(databaseInfo).then(conn => {
     const serializer = newSerializer(databaseInfo.databaseId);
     const datastore = newDatastore(credentialsProvider, serializer);
-    await datastore.start(conn);
+    datastore.start(conn);
     return fn(datastore);
   });
 }

--- a/packages/firestore/test/unit/specs/spec_test_runner.ts
+++ b/packages/firestore/test/unit/specs/spec_test_runner.ts
@@ -51,7 +51,6 @@ import { DocumentKey } from '../../../src/model/document_key';
 import { JsonObject } from '../../../src/model/object_value';
 import { Mutation } from '../../../src/model/mutation';
 import * as api from '../../../src/protos/firestore_proto_api';
-import { Datastore, newDatastore } from '../../../src/remote/datastore';
 import { ExistenceFilter } from '../../../src/remote/existence_filter';
 import { RemoteStore } from '../../../src/remote/remote_store';
 import { mapCodeFromRpcCode } from '../../../src/remote/rpc_error';
@@ -178,7 +177,6 @@ abstract class TestRunner {
   private networkEnabled = true;
 
   // Initialized asynchronously via start().
-  private datastore!: Datastore;
   private localStore!: LocalStore;
   private remoteStore!: RemoteStore;
   private persistence!: MockMemoryPersistence | MockIndexedDbPersistence;
@@ -233,18 +231,11 @@ abstract class TestRunner {
   }
 
   async start(): Promise<void> {
-    this.connection = new MockConnection(this.queue);
-    this.datastore = newDatastore(
-      this.connection,
-      new EmptyCredentialsProvider(),
-      this.serializer
-    );
-
     const componentProvider = await this.initializeComponentProvider(
       {
         asyncQueue: this.queue,
         databaseInfo: this.databaseInfo,
-        datastore: this.datastore,
+        credentials: new EmptyCredentialsProvider(),
         clientId: this.clientId,
         initialUser: this.user,
         maxConcurrentLimboResolutions:
@@ -257,6 +248,7 @@ abstract class TestRunner {
     this.sharedClientState = componentProvider.sharedClientState;
     this.persistence = componentProvider.persistence;
     this.localStore = componentProvider.localStore;
+    this.connection = componentProvider.connection;
     this.remoteStore = componentProvider.remoteStore;
     this.syncEngine = componentProvider.syncEngine;
     this.eventManager = componentProvider.eventManager;


### PR DESCRIPTION
This is the first step in my two step plan to split up the ComponentProvider into one that provides only the components that are needed to reach from cache and into one that provides the RemoteStore and other components needed for connectivity.