### PR TITLE
Downgrade karma-coverage-istanbul-reporter to fix 0% coverage issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "karma": "5.1.0",
     "karma-chrome-launcher": "3.1.0",
     "karma-cli": "2.0.0",
-    "karma-coverage-istanbul-reporter": "3.0.3",
+    "karma-coverage-istanbul-reporter": "2.1.1",
     "karma-firefox-launcher": "1.3.0",
     "karma-mocha": "2.0.1",
     "karma-safari-launcher": "1.0.0",

--- a/repo-scripts/changelog-generator/package.json
+++ b/repo-scripts/changelog-generator/package.json
@@ -14,7 +14,8 @@
     "build": "tsc",
     "build:dev": "tsc -w",
     "test": "yarn type-check",
-    "prepare": "yarn build"
+    "prepare": "yarn build",
+    "type-check": "tsc -p . --noEmit"
   },
   "dependencies": {
     "@changesets/types": "3.1.0",


### PR DESCRIPTION
Upgrading `karma-coverage-istanbul-reporter` to `3.0.3` broke the coverage report. Revert to previous version.