### PR TITLE
Fix imports for Console builds

### DIFF
--- a/packages/firestore/index.console.ts
+++ b/packages/firestore/index.console.ts
@@ -20,14 +20,14 @@
 
 export { Firestore, FirestoreDatabase } from './src/api/database';
 export {
-  PublicCollectionReference as CollectionReference,
-  PublicDocumentReference as DocumentReference,
-  PublicDocumentSnapshot as DocumentSnapshot,
-  PublicQuerySnapshot as QuerySnapshot,
-  PublicFieldValue as FieldValue,
-  PublicBlob as Blob
-} from './src/config';
+  CollectionReference,
+  DocumentReference,
+  DocumentSnapshot,
+  QuerySnapshot
+} from './src/api/database';
+export { Blob } from './src/api/blob';
 export { GeoPoint } from './src/api/geo_point';
 export { FirstPartyCredentialsSettings } from './src/api/credentials';
 export { FieldPath } from './src/api/field_path';
+export { FieldValue } from './src/api/field_value';
 export { Timestamp } from './src/api/timestamp';


### PR DESCRIPTION
I stumbled across this today: When I removed `makeConstructorPrivate` (https://github.com/firebase/firebase-js-sdk/pull/3309), I didn't change the imports in the `index.console.ts` file. This file is not part of our build and only used in Google3, hence nothing blew up (yet).