### PR TITLE
Don't log Cancelled warning when stream is closed

### DIFF
--- a/packages/firestore/src/platform/node/grpc_connection.ts
+++ b/packages/firestore/src/platform/node/grpc_connection.ts
@@ -230,15 +230,17 @@ export class GrpcConnection implements Connection {
     });
 
     grpcStream.on('error', (grpcError: ServiceError) => {
-      logWarn(
-        LOG_TAG,
-        'GRPC stream error. Code:',
-        grpcError.code,
-        'Message:',
-        grpcError.message
-      );
-      const code = mapCodeFromRpcCode(grpcError.code);
-      close(new FirestoreError(code, grpcError.message));
+      if (!closed) {
+        logWarn(
+          LOG_TAG,
+          'GRPC stream error. Code:',
+          grpcError.code,
+          'Message:',
+          grpcError.message
+        );
+        const code = mapCodeFromRpcCode(grpcError.code);
+        close(new FirestoreError(code, grpcError.message));
+      }
     });
 
     logDebug(LOG_TAG, 'Opening GRPC stream');


### PR DESCRIPTION
The firestore-exp tests show this error when run under Node (not under ts-node):

CANCELLED - The operation was cancelled.

It happens after tests have finished running and is very timing dependent. It seems to have to side effects, so this PR silences this warning. See also https://grpc.github.io/grpc/core/md_doc_statuscodes.html ("The operation was cancelled, typically by the caller.")


