### PR TITLE
delete services that implement the new FirebaseService interface

### DIFF
--- a/.changeset/small-grapes-teach.md
+++ b/.changeset/small-grapes-teach.md
@@ -1,0 +1,5 @@
+---
+"@firebase/component": patch
+---
+
+Correctly delete services that implement the new FirebaseService interface when calling provider.delete()

--- a/packages-exp/app-exp/src/api.test.ts
+++ b/packages-exp/app-exp/src/api.test.ts
@@ -29,7 +29,10 @@ import {
   onLog
 } from './api';
 import { DEFAULT_ENTRY_NAME } from './constants';
-import { _FirebaseAppInternal } from '@firebase/app-types-exp';
+import {
+  _FirebaseAppInternal,
+  _FirebaseService
+} from '@firebase/app-types-exp';
 import {
   _clearComponents,
   _components,
@@ -174,6 +177,33 @@ describe('API tests', () => {
 
       deleteApp(app).catch(() => {});
       expect(getApps().length).to.equal(0);
+    });
+
+    it('waits for all services being deleted', async () => {
+      _clearComponents();
+      let count = 0;
+      const comp1 = new Component(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        'test1' as any,
+        _container =>
+          ({
+            delete: async () => {
+              await Promise.resolve();
+              expect(count).to.equal(0);
+              count++;
+            }
+          } as _FirebaseService),
+        ComponentType.PUBLIC
+      );
+      _registerComponent(comp1);
+
+      const app = initializeApp({});
+      // create service instance
+      const test1Provider = _getProvider(app, 'test1' as any);
+      test1Provider.getImmediate();
+
+      await deleteApp(app);
+      expect(count).to.equal(1);
     });
   });
 

--- a/packages/component/src/provider.test.ts
+++ b/packages/component/src/provider.test.ts
@@ -19,6 +19,7 @@ import { expect } from 'chai';
 import { fake, SinonSpy } from 'sinon';
 import { ComponentContainer } from './component_container';
 import { FirebaseService } from '@firebase/app-types/private';
+import { _FirebaseService } from '@firebase/app-types-exp';
 import { Provider } from './provider';
 import { getFakeApp, getFakeComponent } from '../test/util';
 import '../test/setup';
@@ -202,13 +203,36 @@ describe('Provider', () => {
     });
 
     describe('delete()', () => {
-      it('calls delete() on the service instance that implements FirebaseService', () => {
+      it('calls delete() on the service instance that implements legacy FirebaseService', () => {
         const deleteFake = fake();
         const myService: FirebaseService = {
           app: getFakeApp(),
           INTERNAL: {
             delete: deleteFake
           }
+        };
+
+        // provide factory and create a service instance
+        provider.setComponent(
+          getFakeComponent(
+            'test',
+            () => myService,
+            false,
+            InstantiationMode.EAGER
+          )
+        );
+
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises
+        provider.delete();
+
+        expect(deleteFake).to.have.been.called;
+      });
+
+      it('calls delete() on the service instance that implements next FirebaseService', () => {
+        const deleteFake = fake();
+        const myService: _FirebaseService = {
+          app: getFakeApp(),
+          delete: deleteFake
         };
 
         // provide factory and create a service instance

--- a/packages/component/src/provider.ts
+++ b/packages/component/src/provider.ts
@@ -170,12 +170,16 @@ export class Provider<T extends Name> {
   async delete(): Promise<void> {
     const services = Array.from(this.instances.values());
 
-    await Promise.all(
-      services
-        .filter(service => 'INTERNAL' in service)
+    await Promise.all([
+      ...services
+        .filter(service => 'INTERNAL' in service) // legacy services
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        .map(service => (service as any).INTERNAL!.delete())
-    );
+        .map(service => (service as any).INTERNAL!.delete()),
+      ...services
+        .filter(service => 'delete' in service) // next services
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        .map(service => (service as any).delete())
+    ]);
   }
 
   isComponentSet(): boolean {


### PR DESCRIPTION
The [new FirebaseService interface](https://github.com/firebase/firebase-js-sdk/blob/master/packages-exp/app-types-exp/index.d.ts#L110) removes the `INTERNAL` namespace and moves the `delete()` method to the top level.