### PR TITLE
Remove duplicate test run

### DIFF
--- a/scripts/emulator-testing/firestore-test-runner.ts
+++ b/scripts/emulator-testing/firestore-test-runner.ts
@@ -48,6 +48,8 @@ async function run(): Promise<void> {
   try {
     await emulator.download();
     await emulator.setUp();
+    // When persistence is enabled, the test runner runs all tests
+    // twice (once with and once without persistence).
     await runTest(emulator.port, emulator.projectId, true);
   } finally {
     await emulator.tearDown();

--- a/scripts/emulator-testing/firestore-test-runner.ts
+++ b/scripts/emulator-testing/firestore-test-runner.ts
@@ -49,7 +49,6 @@ async function run(): Promise<void> {
     await emulator.download();
     await emulator.setUp();
     await runTest(emulator.port, emulator.projectId, true);
-    await runTest(emulator.port, emulator.projectId, false);
   } finally {
     await emulator.tearDown();
   }


### PR DESCRIPTION
The tests with persistence run all tests twice already - once with and once without persistence. Thus, we can skip the setting test run.
