### PR TITLE
Util version bump

### DIFF
--- a/.changeset/short-cars-scream.md
+++ b/.changeset/short-cars-scream.md
@@ -1,7 +1,7 @@
 ---
 '@firebase/analytics': patch
 '@firebase/util': minor
-'firebase': minor
+'firebase': patch
 ---
 
 - Fix an error where an analytics PR included a change to `@firebase/util`, but

--- a/.changeset/short-cars-scream.md
+++ b/.changeset/short-cars-scream.md
@@ -1,0 +1,8 @@
+---
+'@firebase/analytics': patch
+'@firebase/util': patch
+'firebase': patch
+---
+
+Fix error where an analytics PR included a change to `@firebase/util`, but
+the util package was not properly included in the changeset for a patch bump.

--- a/.changeset/short-cars-scream.md
+++ b/.changeset/short-cars-scream.md
@@ -1,8 +1,11 @@
 ---
 '@firebase/analytics': patch
-'@firebase/util': patch
-'firebase': patch
+'@firebase/util': minor
+'firebase': minor
 ---
 
-Fix error where an analytics PR included a change to `@firebase/util`, but
-the util package was not properly included in the changeset for a patch bump.
+- Fix an error where an analytics PR included a change to `@firebase/util`, but
+  the util package was not properly included in the changeset for a patch bump.
+
+- `@firebase/util` adds environment check methods `isIndexedDBAvailable`
+  `validateIndexedDBOpenable`, and `areCookiesEnabled`.

--- a/packages/analytics/index.ts
+++ b/packages/analytics/index.ts
@@ -102,7 +102,6 @@ registerAnalytics(firebase as _FirebaseNamespace);
 declare module '@firebase/app-types' {
   interface FirebaseNamespace {
     analytics(app?: FirebaseApp): FirebaseAnalytics;
-    isSupported(): Promise<boolean>;
   }
   interface FirebaseApp {
     analytics(): FirebaseAnalytics;


### PR DESCRIPTION
I approved https://github.com/firebase/firebase-js-sdk/pull/3165/files without realizing that it required a util bump because util code was changed.

I'm not sure if the bump should be minor instead because it added 3 public util methods.

Hope to cherrypick and re-release.