### PR TITLE
Make sure the value that is set for a metric is an integer.

### DIFF
--- a/packages/performance-types/index.d.ts
+++ b/packages/performance-types/index.d.ts
@@ -63,7 +63,8 @@ export interface PerformanceTrace {
   ): void;
   /**
    * Adds to the value of a custom metric. If a custom metric with the provided name does not
-   * exist, it creates one with that name and the value equal to the given number.
+   * exist, it creates one with that name and the value equal to the given number. The value will be floored down to an
+   * integer.
    *
    * @param metricName The name of the custom metric.
    * @param num The number to be added to the value of the custom metric. If not provided, it
@@ -72,7 +73,8 @@ export interface PerformanceTrace {
   incrementMetric(metricName: string, num?: number): void;
   /**
    * Sets the value of the specified custom metric to the given number regardless of whether
-   * a metric with that name already exists on the trace instance or not.
+   * a metric with that name already exists on the trace instance or not. The value will be floored down to an
+   * integer.
    *
    * @param metricName Name of the custom metric.
    * @param num Value to of the custom metric.

--- a/packages/performance/src/resources/trace.test.ts
+++ b/packages/performance/src/resources/trace.test.ts
@@ -117,6 +117,13 @@ describe('Firebase Performance > trace', () => {
       expect(trace.getMetric('cacheHits')).to.eql(600);
     });
 
+    it('increments the metric value as an integer even if the value is provided in float.', () => {
+      trace.incrementMetric('cacheHits', 200);
+      trace.incrementMetric('cacheHits', 400.38);
+
+      expect(trace.getMetric('cacheHits')).to.eql(600);
+    });
+
     it('throws error if metric doesnt exist and has invalid name', () => {
       expect(() => trace.incrementMetric('_invalidMetric', 1)).to.throw();
     });

--- a/packages/performance/src/resources/trace.test.ts
+++ b/packages/performance/src/resources/trace.test.ts
@@ -117,7 +117,7 @@ describe('Firebase Performance > trace', () => {
       expect(trace.getMetric('cacheHits')).to.eql(600);
     });
 
-    it('increments the metric value as an integer even if the value is provided in float.', () => {
+    it('increments metric value as an integer even if the value is provided in float.', () => {
       trace.incrementMetric('cacheHits', 200);
       trace.incrementMetric('cacheHits', 400.38);
 

--- a/packages/performance/src/resources/trace.test.ts
+++ b/packages/performance/src/resources/trace.test.ts
@@ -129,6 +129,12 @@ describe('Firebase Performance > trace', () => {
       expect(trace.getMetric('cacheHits')).to.eql(200);
     });
 
+    it('sets the metric value as an integer even if the value is provided in float.', () => {
+      trace.putMetric('timelapse', 200.48);
+
+      expect(trace.getMetric('timelapse')).to.eql(200);
+    });
+
     it('replaces metric if it already exists.', () => {
       trace.putMetric('cacheHits', 200);
       trace.putMetric('cacheHits', 400);

--- a/packages/performance/src/resources/trace.test.ts
+++ b/packages/performance/src/resources/trace.test.ts
@@ -124,6 +124,13 @@ describe('Firebase Performance > trace', () => {
       expect(trace.getMetric('cacheHits')).to.eql(600);
     });
 
+    it('increments metric value with a negative float.', () => {
+      trace.incrementMetric('cacheHits', 200);
+      trace.incrementMetric('cacheHits', -230.38);
+
+      expect(trace.getMetric('cacheHits')).to.eql(-31);
+    });
+
     it('throws error if metric doesnt exist and has invalid name', () => {
       expect(() => trace.incrementMetric('_invalidMetric', 1)).to.throw();
     });

--- a/packages/performance/src/resources/trace.ts
+++ b/packages/performance/src/resources/trace.ts
@@ -153,7 +153,7 @@ export class Trace implements PerformanceTrace {
     if (this.counters[counter] === undefined) {
       this.putMetric(counter, 0);
     }
-    this.counters[counter] += num;
+    this.counters[counter] += Math.floor(num);
   }
 
   /**

--- a/packages/performance/src/resources/trace.ts
+++ b/packages/performance/src/resources/trace.ts
@@ -155,13 +155,7 @@ export class Trace implements PerformanceTrace {
     if (this.counters[counter] === undefined) {
       this.putMetric(counter, 0);
     }
-    const valueAsInteger: number = Math.floor(numAsInteger);
-    if (valueAsInteger < numAsInteger) {
-      consoleLogger.info(
-        `Metric value should be an Integer, setting the value as : ${valueAsInteger}.`
-      );
-    }
-    this.counters[counter] += valueAsInteger;
+    this.counters[counter] += this.convertMetricValueToInteger(numAsInteger);
   }
 
   /**
@@ -172,13 +166,7 @@ export class Trace implements PerformanceTrace {
    */
   putMetric(counter: string, numAsInteger: number): void {
     if (isValidMetricName(counter, this.name)) {
-      const valueAsInteger: number = Math.floor(numAsInteger);
-      if (valueAsInteger < numAsInteger) {
-        consoleLogger.info(
-          `Metric value should be an Integer, setting the value as : ${valueAsInteger}.`
-        );
-      }
-      this.counters[counter] = valueAsInteger;
+      this.counters[counter] = this.convertMetricValueToInteger(numAsInteger);
     } else {
       throw ERROR_FACTORY.create(ErrorCode.INVALID_CUSTOM_METRIC_NAME, {
         customMetricName: counter
@@ -260,6 +248,22 @@ export class Trace implements PerformanceTrace {
         (perfMeasureEntry.startTime + this.api.getTimeOrigin()) * 1000
       );
     }
+  }
+
+  /**
+   * Converts the provided value to an integer value to be used in case of a metric.
+   * @param providedValue Provided number value of the metric that needs to be converted to an integer.
+   *
+   * @returns Converted integer number to be set for the metric.
+   */
+  private convertMetricValueToInteger(providedValue: number): number {
+    const valueAsInteger: number = Math.floor(providedValue);
+    if (valueAsInteger < providedValue) {
+      consoleLogger.info(
+        `Metric value should be an Integer, setting the value as : ${valueAsInteger}.`
+      );
+    }
+    return valueAsInteger;
   }
 
   /**

--- a/packages/performance/src/resources/trace.ts
+++ b/packages/performance/src/resources/trace.ts
@@ -33,6 +33,7 @@ import {
 } from '../utils/attributes_utils';
 import { isValidMetricName } from '../utils/metric_utils';
 import { PerformanceTrace } from '@firebase/performance-types';
+import { consoleLogger } from '../utils/console_logger';
 
 const enum TraceState {
   UNINITIALIZED = 1,
@@ -154,7 +155,13 @@ export class Trace implements PerformanceTrace {
     if (this.counters[counter] === undefined) {
       this.putMetric(counter, 0);
     }
-    this.counters[counter] += Math.floor(numAsInteger);
+    const valueAsInteger: number = Math.floor(numAsInteger);
+    if (valueAsInteger < numAsInteger) {
+      consoleLogger.info(
+        `Metric value should be an Integer, setting the value as : ${valueAsInteger}.`
+      );
+    }
+    this.counters[counter] += valueAsInteger;
   }
 
   /**
@@ -165,7 +172,13 @@ export class Trace implements PerformanceTrace {
    */
   putMetric(counter: string, numAsInteger: number): void {
     if (isValidMetricName(counter, this.name)) {
-      this.counters[counter] = Math.floor(numAsInteger);
+      const valueAsInteger: number = Math.floor(numAsInteger);
+      if (valueAsInteger < numAsInteger) {
+        consoleLogger.info(
+          `Metric value should be an Integer, setting the value as : ${valueAsInteger}.`
+        );
+      }
+      this.counters[counter] = valueAsInteger;
     } else {
       throw ERROR_FACTORY.create(ErrorCode.INVALID_CUSTOM_METRIC_NAME, {
         customMetricName: counter

--- a/packages/performance/src/resources/trace.ts
+++ b/packages/performance/src/resources/trace.ts
@@ -158,13 +158,13 @@ export class Trace implements PerformanceTrace {
 
   /**
    * Sets a custom metric to a specified value. Will create a new custom metric if one with the
-   * given name does not exist.
+   * given name does not exist. The value will be floored down to an integer.
    * @param counter Name of the custom metric
    * @param num Set custom metric to this value
    */
   putMetric(counter: string, num: number): void {
     if (isValidMetricName(counter, this.name)) {
-      this.counters[counter] = num;
+      this.counters[counter] = Math.floor(num);
     } else {
       throw ERROR_FACTORY.create(ErrorCode.INVALID_CUSTOM_METRIC_NAME, {
         customMetricName: counter

--- a/packages/performance/src/resources/trace.ts
+++ b/packages/performance/src/resources/trace.ts
@@ -148,24 +148,24 @@ export class Trace implements PerformanceTrace {
    * custom metric if one with the given name does not exist. The value will be floored down to an
    * integer.
    * @param counter Name of the custom metric
-   * @param num Increment by value
+   * @param numAsInteger Increment by value
    */
-  incrementMetric(counter: string, num = 1): void {
+  incrementMetric(counter: string, numAsInteger = 1): void {
     if (this.counters[counter] === undefined) {
       this.putMetric(counter, 0);
     }
-    this.counters[counter] += Math.floor(num);
+    this.counters[counter] += Math.floor(numAsInteger);
   }
 
   /**
    * Sets a custom metric to a specified value. Will create a new custom metric if one with the
    * given name does not exist. The value will be floored down to an integer.
    * @param counter Name of the custom metric
-   * @param num Set custom metric to this value
+   * @param numAsInteger Set custom metric to this value
    */
-  putMetric(counter: string, num: number): void {
+  putMetric(counter: string, numAsInteger: number): void {
     if (isValidMetricName(counter, this.name)) {
-      this.counters[counter] = Math.floor(num);
+      this.counters[counter] = Math.floor(numAsInteger);
     } else {
       throw ERROR_FACTORY.create(ErrorCode.INVALID_CUSTOM_METRIC_NAME, {
         customMetricName: counter

--- a/packages/performance/src/resources/trace.ts
+++ b/packages/performance/src/resources/trace.ts
@@ -145,7 +145,8 @@ export class Trace implements PerformanceTrace {
 
   /**
    * Increments a custom metric by a certain number or 1 if number not specified. Will create a new
-   * custom metric if one with the given name does not exist.
+   * custom metric if one with the given name does not exist. The value will be floored down to an
+   * integer.
    * @param counter Name of the custom metric
    * @param num Increment by value
    */

--- a/packages/performance/src/utils/metric_utils.ts
+++ b/packages/performance/src/utils/metric_utils.ts
@@ -21,6 +21,7 @@ import {
   FIRST_INPUT_DELAY_COUNTER_NAME,
   OOB_TRACE_PAGE_LOAD_PREFIX
 } from '../constants';
+import { consoleLogger } from '../utils/console_logger';
 
 const MAX_METRIC_NAME_LENGTH = 100;
 const RESERVED_AUTO_PREFIX = '_';
@@ -44,4 +45,20 @@ export function isValidMetricName(name: string, traceName?: string): boolean {
       oobMetrics.indexOf(name) > -1) ||
     !name.startsWith(RESERVED_AUTO_PREFIX)
   );
+}
+
+/**
+ * Converts the provided value to an integer value to be used in case of a metric.
+ * @param providedValue Provided number value of the metric that needs to be converted to an integer.
+ *
+ * @returns Converted integer number to be set for the metric.
+ */
+export function convertMetricValueToInteger(providedValue: number): number {
+  const valueAsInteger: number = Math.floor(providedValue);
+  if (valueAsInteger < providedValue) {
+    consoleLogger.info(
+      `Metric value should be an Integer, setting the value as : ${valueAsInteger}.`
+    );
+  }
+  return valueAsInteger;
 }


### PR DESCRIPTION
Firebase Performance BE just allows the value of counter to be an integer. Currently the counter value could be set as a float and this would fail in processing.