### PR TITLE
Fix up build scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,9 +22,9 @@
   ],
   "scripts": {
     "dev": "lerna run --parallel --scope @firebase/* --scope firebase --scope rxfire dev",
-    "build": "lerna run --scope @firebase/* --scope firebase --scope rxfire build",
+    "build": "lerna run --scope @firebase/app-exp build:deps && lerna run --scope @firebase/* --scope firebase --scope rxfire --ignore @firebase/app-exp build",
     "build:exp": "lerna run --scope @firebase/*-exp --scope firebase-exp build",
-    "build:release": "lerna run --scope @firebase/app-exp build:deps && lerna run --scope @firebase/* --scope firebase --ignore @firebase/*-exp --ignore firebase-exp prepare",
+    "build:release": "lerna run --scope @firebase/app-exp build:deps && lerna run --scope @firebase/* --scope firebase --scope rxfire --ignore @firebase/*-exp prepare",
     "build:exp:release": "yarn --cwd packages/app build:deps && lerna run --scope @firebase/*-exp --scope firebase-exp prepare && yarn --cwd packages-exp/app-exp typings:public",
     "link:packages": "lerna exec --scope @firebase/* --scope firebase --scope rxfire -- yarn link",
     "stage:packages": "./scripts/prepublish.sh",


### PR DESCRIPTION
Change `build` to ensure app-exp builds before other packages, now that firestore needs a `d.ts` file from it.

The diff on `build:release` looks weird but I added rxfire (which was unintentionally missing) and removed `--ignore firebase-exp` because it wouldn't be included based on previous --scope params anyway. Tested to make sure this is true.