### PR TITLE
Add check if crypto.getRandomValues is available

### DIFF
--- a/.changeset/silver-trainers-rhyme.md
+++ b/.changeset/silver-trainers-rhyme.md
@@ -1,0 +1,5 @@
+---
+"@firebase/firestore": patch
+---
+
+Enable fallback for auto-generated identifiers in environments that support `crypto` but not `crypto.getRandomValues`.

--- a/packages/firestore/src/platform/browser/random_bytes.ts
+++ b/packages/firestore/src/platform/browser/random_bytes.ts
@@ -30,7 +30,7 @@ export function randomBytes(nBytes: number): Uint8Array {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     typeof self !== 'undefined' && (self.crypto || (self as any)['msCrypto']);
   const bytes = new Uint8Array(nBytes);
-  if (crypto && crypto.getRandomValues) {
+  if (crypto && typeof crypto.getRandomValues === 'function') {
     crypto.getRandomValues(bytes);
   } else {
     // Falls back to Math.random

--- a/packages/firestore/src/platform/browser/random_bytes.ts
+++ b/packages/firestore/src/platform/browser/random_bytes.ts
@@ -30,7 +30,7 @@ export function randomBytes(nBytes: number): Uint8Array {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     typeof self !== 'undefined' && (self.crypto || (self as any)['msCrypto']);
   const bytes = new Uint8Array(nBytes);
-  if (crypto) {
+  if (crypto && crypto.getRandomValues) {
     crypto.getRandomValues(bytes);
   } else {
     // Falls back to Math.random


### PR DESCRIPTION
On some IE11 the randomBytes helper crashes with "TypeError: getRandomValues is not defined". The reason is not clear, maybe something pollutes self.crypto with a bad polyfill. Nevertheless it makes sense to fall back to Math.random if crypto.getRandomValues is not available.