### PR TITLE
Add an interface Database

### DIFF
--- a/.changeset/thirty-flies-flow.md
+++ b/.changeset/thirty-flies-flow.md
@@ -1,0 +1,7 @@
+---
+"@firebase/database-types": patch
+"@firebase/database": patch
+---
+
+Added interface `Database` which is implemented by `FirebaseDatabase` to allow the use of interface instead of class for the instance type.
+It solves an issue admin SDK encountered where they only want to export the type, but Typescript thinks they are exporting the actual class.

--- a/.changeset/thirty-flies-flow.md
+++ b/.changeset/thirty-flies-flow.md
@@ -3,4 +3,4 @@
 "@firebase/database": patch
 ---
 
-Added interface `Database` which is implemented by `FirebaseDatabase. This allows consumer SDKs (such as the Firebase Admin SDK) to export the database types as an interface.
+Added interface `Database` which is implemented by `FirebaseDatabase`. This allows consumer SDKs (such as the Firebase Admin SDK) to export the database types as an interface.

--- a/.changeset/thirty-flies-flow.md
+++ b/.changeset/thirty-flies-flow.md
@@ -3,5 +3,4 @@
 "@firebase/database": patch
 ---
 
-Added interface `Database` which is implemented by `FirebaseDatabase` to allow the use of interface instead of class for the instance type.
-It solves an issue admin SDK encountered where they only want to export the type, but Typescript thinks they are exporting the actual class.
+Added interface `Database` which is implemented by `FirebaseDatabase. This allows consumer SDKs (such as the Firebase Admin SDK) to export the database types as an interface.

--- a/packages/database-types/index.d.ts
+++ b/packages/database-types/index.d.ts
@@ -32,9 +32,16 @@ export interface DataSnapshot {
   val(): any;
 }
 
-export class FirebaseDatabase {
-  private constructor();
+export interface Database {
+  app: FirebaseApp;
+  goOffline(): void;
+  goOnline(): void;
+  ref(path?: string | Reference): Reference;
+  refFromURL(url: string): Reference;
+}
 
+export class FirebaseDatabase implements Database {
+  private constructor();
   app: FirebaseApp;
   goOffline(): void;
   goOnline(): void;

--- a/packages/database/index.node.ts
+++ b/packages/database/index.node.ts
@@ -85,7 +85,7 @@ export function initStandalone(app: FirebaseApp, url: string, version: string) {
       app,
       authProvider,
       url
-    ) as types.FirebaseDatabase,
+    ) as types.Database,
     namespace: {
       Reference,
       Query,


### PR DESCRIPTION
The admin SDK wants to export the type of the instance of the `FirebaseDatabase` class in their namespace, but encountered an issue where Typescript thinks they are exporting the actual class from `@firebase/database-types` and compiles it to code that leads to runtime error:

```
var database_types_1 = require("@firebase/database-types");
```
Adding an interface that's implemented by `FirebaseDatabase` to work around the issue.

I tried to use `InstanceType<typeof FirebaseDatabase>` to get the type of the instance without creating a new type, but it doesn't work because the constructor is private 🤷 .