### PR TITLE
Tree-shake LocalStore's implementation

### DIFF
--- a/packages/firestore/exp/dependencies.json
+++ b/packages/firestore/exp/dependencies.json
@@ -11,7 +11,6 @@
                 "formatJSON",
                 "formatPlural",
                 "getMessageOrStack",
-                "getWindow",
                 "hardAssert",
                 "invalidClassError",
                 "isIndexedDbTransactionError",
@@ -29,7 +28,8 @@
                 "validateArgType",
                 "validateExactNumberOfArgs",
                 "validateType",
-                "valueDescription"
+                "valueDescription",
+                "wrapInUserErrorIfRecoverable"
             ],
             "classes": [
                 "AsyncQueue",
@@ -50,7 +50,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 21617
+        "sizeInBytes": 21515
     },
     "CollectionReference": {
         "dependencies": {
@@ -59,7 +59,6 @@
                 "fail",
                 "formatJSON",
                 "getMessageOrStack",
-                "getWindow",
                 "hardAssert",
                 "isIndexedDbTransactionError",
                 "isNullOrUndefined",
@@ -70,7 +69,8 @@
                 "randomBytes",
                 "registerFirestore",
                 "removeComponents",
-                "removeComponents$1"
+                "removeComponents$1",
+                "wrapInUserErrorIfRecoverable"
             ],
             "classes": [
                 "AsyncQueue",
@@ -92,7 +92,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 18846
+        "sizeInBytes": 18744
     },
     "DocumentReference": {
         "dependencies": {
@@ -101,7 +101,6 @@
                 "fail",
                 "formatJSON",
                 "getMessageOrStack",
-                "getWindow",
                 "hardAssert",
                 "isIndexedDbTransactionError",
                 "logDebug",
@@ -110,7 +109,8 @@
                 "randomBytes",
                 "registerFirestore",
                 "removeComponents",
-                "removeComponents$1"
+                "removeComponents$1",
+                "wrapInUserErrorIfRecoverable"
             ],
             "classes": [
                 "AsyncQueue",
@@ -134,7 +134,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 20218
+        "sizeInBytes": 20116
     },
     "DocumentSnapshot": {
         "dependencies": {
@@ -157,7 +157,6 @@
                 "getLocalWriteTime",
                 "getMessageOrStack",
                 "getPreviousValue",
-                "getWindow",
                 "hardAssert",
                 "invalidClassError",
                 "isIndexedDbTransactionError",
@@ -182,7 +181,8 @@
                 "validateExactNumberOfArgs",
                 "validateNamedArrayAtLeastNumberOfElements",
                 "validateType",
-                "valueDescription"
+                "valueDescription",
+                "wrapInUserErrorIfRecoverable"
             ],
             "classes": [
                 "AsyncQueue",
@@ -219,7 +219,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 39632
+        "sizeInBytes": 39654
     },
     "FieldPath": {
         "dependencies": {
@@ -230,7 +230,6 @@
                 "formatJSON",
                 "formatPlural",
                 "getMessageOrStack",
-                "getWindow",
                 "hardAssert",
                 "isIndexedDbTransactionError",
                 "isPlainObject",
@@ -246,7 +245,8 @@
                 "validateArgType",
                 "validateNamedArrayAtLeastNumberOfElements",
                 "validateType",
-                "valueDescription"
+                "valueDescription",
+                "wrapInUserErrorIfRecoverable"
             ],
             "classes": [
                 "AsyncQueue",
@@ -269,7 +269,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 23290
+        "sizeInBytes": 23188
     },
     "FieldValue": {
         "dependencies": {
@@ -278,7 +278,6 @@
                 "fail",
                 "formatJSON",
                 "getMessageOrStack",
-                "getWindow",
                 "hardAssert",
                 "isIndexedDbTransactionError",
                 "logDebug",
@@ -287,7 +286,8 @@
                 "randomBytes",
                 "registerFirestore",
                 "removeComponents",
-                "removeComponents$1"
+                "removeComponents$1",
+                "wrapInUserErrorIfRecoverable"
             ],
             "classes": [
                 "AsyncQueue",
@@ -308,7 +308,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 16920
+        "sizeInBytes": 16818
     },
     "FirebaseFirestore": {
         "dependencies": {
@@ -317,7 +317,6 @@
                 "fail",
                 "formatJSON",
                 "getMessageOrStack",
-                "getWindow",
                 "hardAssert",
                 "isIndexedDbTransactionError",
                 "logDebug",
@@ -326,7 +325,8 @@
                 "randomBytes",
                 "registerFirestore",
                 "removeComponents",
-                "removeComponents$1"
+                "removeComponents$1",
+                "wrapInUserErrorIfRecoverable"
             ],
             "classes": [
                 "AsyncQueue",
@@ -345,7 +345,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 16829
+        "sizeInBytes": 16727
     },
     "GeoPoint": {
         "dependencies": {
@@ -355,7 +355,6 @@
                 "formatJSON",
                 "formatPlural",
                 "getMessageOrStack",
-                "getWindow",
                 "hardAssert",
                 "isIndexedDbTransactionError",
                 "isPlainObject",
@@ -371,7 +370,8 @@
                 "validateArgType",
                 "validateExactNumberOfArgs",
                 "validateType",
-                "valueDescription"
+                "valueDescription",
+                "wrapInUserErrorIfRecoverable"
             ],
             "classes": [
                 "AsyncQueue",
@@ -391,7 +391,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 19681
+        "sizeInBytes": 19636
     },
     "Query": {
         "dependencies": {
@@ -400,7 +400,6 @@
                 "fail",
                 "formatJSON",
                 "getMessageOrStack",
-                "getWindow",
                 "hardAssert",
                 "isIndexedDbTransactionError",
                 "logDebug",
@@ -409,7 +408,8 @@
                 "randomBytes",
                 "registerFirestore",
                 "removeComponents",
-                "removeComponents$1"
+                "removeComponents$1",
+                "wrapInUserErrorIfRecoverable"
             ],
             "classes": [
                 "AsyncQueue",
@@ -429,7 +429,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 17022
+        "sizeInBytes": 16920
     },
     "QueryConstraint": {
         "dependencies": {
@@ -438,7 +438,6 @@
                 "fail",
                 "formatJSON",
                 "getMessageOrStack",
-                "getWindow",
                 "hardAssert",
                 "isIndexedDbTransactionError",
                 "logDebug",
@@ -447,7 +446,8 @@
                 "randomBytes",
                 "registerFirestore",
                 "removeComponents",
-                "removeComponents$1"
+                "removeComponents$1",
+                "wrapInUserErrorIfRecoverable"
             ],
             "classes": [
                 "AsyncQueue",
@@ -467,7 +467,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 16835
+        "sizeInBytes": 16733
     },
     "QueryDocumentSnapshot": {
         "dependencies": {
@@ -490,7 +490,6 @@
                 "getLocalWriteTime",
                 "getMessageOrStack",
                 "getPreviousValue",
-                "getWindow",
                 "hardAssert",
                 "invalidClassError",
                 "isIndexedDbTransactionError",
@@ -515,7 +514,8 @@
                 "validateExactNumberOfArgs",
                 "validateNamedArrayAtLeastNumberOfElements",
                 "validateType",
-                "valueDescription"
+                "valueDescription",
+                "wrapInUserErrorIfRecoverable"
             ],
             "classes": [
                 "AsyncQueue",
@@ -552,7 +552,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 39642
+        "sizeInBytes": 39664
     },
     "QuerySnapshot": {
         "dependencies": {
@@ -576,7 +576,6 @@
                 "getLocalWriteTime",
                 "getMessageOrStack",
                 "getPreviousValue",
-                "getWindow",
                 "hardAssert",
                 "invalidClassError",
                 "isIndexedDbTransactionError",
@@ -602,7 +601,8 @@
                 "validateExactNumberOfArgs",
                 "validateNamedArrayAtLeastNumberOfElements",
                 "validateType",
-                "valueDescription"
+                "valueDescription",
+                "wrapInUserErrorIfRecoverable"
             ],
             "classes": [
                 "AsyncQueue",
@@ -641,7 +641,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 42273
+        "sizeInBytes": 42295
     },
     "SnapshotMetadata": {
         "dependencies": {
@@ -650,7 +650,6 @@
                 "fail",
                 "formatJSON",
                 "getMessageOrStack",
-                "getWindow",
                 "hardAssert",
                 "isIndexedDbTransactionError",
                 "logDebug",
@@ -659,7 +658,8 @@
                 "randomBytes",
                 "registerFirestore",
                 "removeComponents",
-                "removeComponents$1"
+                "removeComponents$1",
+                "wrapInUserErrorIfRecoverable"
             ],
             "classes": [
                 "AsyncQueue",
@@ -679,7 +679,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 17044
+        "sizeInBytes": 16942
     },
     "Timestamp": {
         "dependencies": {
@@ -688,7 +688,6 @@
                 "fail",
                 "formatJSON",
                 "getMessageOrStack",
-                "getWindow",
                 "hardAssert",
                 "isIndexedDbTransactionError",
                 "logDebug",
@@ -697,7 +696,8 @@
                 "randomBytes",
                 "registerFirestore",
                 "removeComponents",
-                "removeComponents$1"
+                "removeComponents$1",
+                "wrapInUserErrorIfRecoverable"
             ],
             "classes": [
                 "AsyncQueue",
@@ -717,7 +717,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 18363
+        "sizeInBytes": 18328
     },
     "Transaction": {
         "dependencies": {
@@ -747,7 +747,6 @@
                 "getLocalWriteTime",
                 "getMessageOrStack",
                 "getPreviousValue",
-                "getWindow",
                 "hardAssert",
                 "invalidClassError",
                 "isEmpty",
@@ -801,7 +800,8 @@
                 "validateReference",
                 "validateType",
                 "valueDescription",
-                "valueEquals"
+                "valueEquals",
+                "wrapInUserErrorIfRecoverable"
             ],
             "classes": [
                 "AsyncQueue",
@@ -859,7 +859,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 63158
+        "sizeInBytes": 63180
     },
     "WriteBatch": {
         "dependencies": {
@@ -887,7 +887,6 @@
                 "geoPointEquals",
                 "getLocalWriteTime",
                 "getMessageOrStack",
-                "getWindow",
                 "hardAssert",
                 "invalidClassError",
                 "isEmpty",
@@ -940,7 +939,8 @@
                 "validateReference",
                 "validateType",
                 "valueDescription",
-                "valueEquals"
+                "valueEquals",
+                "wrapInUserErrorIfRecoverable"
             ],
             "classes": [
                 "AsyncQueue",
@@ -989,12 +989,14 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 55895
+        "sizeInBytes": 55917
     },
     "addDoc": {
         "dependencies": {
             "functions": [
+                "acknowledgeBatch",
                 "addDoc",
+                "allocateTarget",
                 "applyArrayRemoveTransformOperation",
                 "applyArrayUnionTransformOperation",
                 "applyDeleteMutationToLocalView",
@@ -1005,12 +1007,14 @@
                 "applyNumericIncrementTransformOperationToLocalView",
                 "applyPatchMutationToLocalView",
                 "applyPatchMutationToRemoteDocument",
+                "applyRemoteEvent",
                 "applySetMutationToLocalView",
                 "applySetMutationToRemoteDocument",
                 "applyTransformMutationToLocalView",
                 "applyTransformMutationToRemoteDocument",
                 "applyTransformOperationToLocalView",
                 "applyTransformOperationToRemoteDocument",
+                "applyWriteToRemoteDocuments",
                 "argToString",
                 "arrayEquals",
                 "asNumber",
@@ -1058,6 +1062,7 @@
                 "encodeBase64",
                 "enqueueWrite",
                 "errorMessage",
+                "executeQuery",
                 "extractFieldMask",
                 "extractLocalPathFromResourceName",
                 "extractMutationBaseValue",
@@ -1084,6 +1089,9 @@
                 "fullyQualifiedPrefixPath",
                 "geoPointEquals",
                 "getEncodedDatabaseId",
+                "getHighestUnacknowledgedBatchId",
+                "getLastRemoteSnapshotVersion",
+                "getLocalTargetData",
                 "getLocalWriteTime",
                 "getLogLevel",
                 "getMessageOrStack",
@@ -1091,7 +1099,7 @@
                 "getOnlineComponentProvider",
                 "getPostMutationVersion",
                 "getSyncEngine",
-                "getWindow",
+                "handleUserChange",
                 "hardAssert",
                 "ignoreIfPrimaryLeaseLoss",
                 "invalidClassError",
@@ -1118,6 +1126,7 @@
                 "isWrite",
                 "loadProtos",
                 "localTransformResults",
+                "localWrite",
                 "logDebug",
                 "logError",
                 "logWarn",
@@ -1137,10 +1146,12 @@
                 "newSyncEngine",
                 "newTarget",
                 "newUserDataReader",
+                "nextMutationBatch",
                 "nodePromise",
                 "normalizeByteString",
                 "normalizeNumber",
                 "normalizeTimestamp",
+                "notifyLocalViewChanges",
                 "nullableMaybeDocumentMap",
                 "numberEquals",
                 "objectEquals",
@@ -1167,6 +1178,8 @@
                 "queryToTarget",
                 "randomBytes",
                 "registerFirestore",
+                "rejectBatch",
+                "releaseTarget",
                 "removeComponents",
                 "removeComponents$1",
                 "requireDocument",
@@ -1174,6 +1187,7 @@
                 "serverTransformResults",
                 "setOfflineComponentProvider",
                 "setOnlineComponentProvider",
+                "shouldPersistTargetData",
                 "snapshotChangesMap",
                 "sortsBeforeDocument",
                 "stringifyFilter",
@@ -1352,7 +1366,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 212435
+        "sizeInBytes": 214087
     },
     "arrayRemove": {
         "dependencies": {
@@ -1371,7 +1385,6 @@
                 "formatPlural",
                 "fullyQualifiedPrefixPath",
                 "getMessageOrStack",
-                "getWindow",
                 "hardAssert",
                 "invalidClassError",
                 "isEmpty",
@@ -1407,7 +1420,8 @@
                 "validateExactNumberOfArgs",
                 "validatePlainObject",
                 "validateType",
-                "valueDescription"
+                "valueDescription",
+                "wrapInUserErrorIfRecoverable"
             ],
             "classes": [
                 "ArrayRemoveFieldValueImpl",
@@ -1441,7 +1455,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 36187
+        "sizeInBytes": 36209
     },
     "arrayUnion": {
         "dependencies": {
@@ -1460,7 +1474,6 @@
                 "formatPlural",
                 "fullyQualifiedPrefixPath",
                 "getMessageOrStack",
-                "getWindow",
                 "hardAssert",
                 "invalidClassError",
                 "isEmpty",
@@ -1496,7 +1509,8 @@
                 "validateExactNumberOfArgs",
                 "validatePlainObject",
                 "validateType",
-                "valueDescription"
+                "valueDescription",
+                "wrapInUserErrorIfRecoverable"
             ],
             "classes": [
                 "ArrayUnionFieldValueImpl",
@@ -1530,7 +1544,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 36179
+        "sizeInBytes": 36201
     },
     "clearIndexedDbPersistence": {
         "dependencies": {
@@ -1542,7 +1556,6 @@
                 "fail",
                 "formatJSON",
                 "getMessageOrStack",
-                "getWindow",
                 "hardAssert",
                 "indexedDbClearPersistence",
                 "indexedDbStoragePrefix",
@@ -1554,6 +1567,7 @@
                 "registerFirestore",
                 "removeComponents",
                 "removeComponents$1",
+                "wrapInUserErrorIfRecoverable",
                 "wrapRequest"
             ],
             "classes": [
@@ -1579,7 +1593,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 29944
+        "sizeInBytes": 30195
     },
     "collection": {
         "dependencies": {
@@ -1589,7 +1603,6 @@
                 "fail",
                 "formatJSON",
                 "getMessageOrStack",
-                "getWindow",
                 "hardAssert",
                 "isIndexedDbTransactionError",
                 "isNullOrUndefined",
@@ -1607,7 +1620,8 @@
                 "validateArgType",
                 "validateCollectionPath",
                 "validateType",
-                "valueDescription"
+                "valueDescription",
+                "wrapInUserErrorIfRecoverable"
             ],
             "classes": [
                 "AsyncQueue",
@@ -1634,7 +1648,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 24925
+        "sizeInBytes": 24823
     },
     "collectionGroup": {
         "dependencies": {
@@ -1645,7 +1659,6 @@
                 "fail",
                 "formatJSON",
                 "getMessageOrStack",
-                "getWindow",
                 "hardAssert",
                 "isIndexedDbTransactionError",
                 "isNullOrUndefined",
@@ -1662,7 +1675,8 @@
                 "tryGetCustomObjectType",
                 "validateArgType",
                 "validateType",
-                "valueDescription"
+                "valueDescription",
+                "wrapInUserErrorIfRecoverable"
             ],
             "classes": [
                 "AsyncQueue",
@@ -1685,11 +1699,13 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 23310
+        "sizeInBytes": 23208
     },
     "deleteDoc": {
         "dependencies": {
             "functions": [
+                "acknowledgeBatch",
+                "allocateTarget",
                 "applyArrayRemoveTransformOperation",
                 "applyArrayUnionTransformOperation",
                 "applyDeleteMutationToLocalView",
@@ -1699,12 +1715,14 @@
                 "applyNumericIncrementTransformOperationToLocalView",
                 "applyPatchMutationToLocalView",
                 "applyPatchMutationToRemoteDocument",
+                "applyRemoteEvent",
                 "applySetMutationToLocalView",
                 "applySetMutationToRemoteDocument",
                 "applyTransformMutationToLocalView",
                 "applyTransformMutationToRemoteDocument",
                 "applyTransformOperationToLocalView",
                 "applyTransformOperationToRemoteDocument",
+                "applyWriteToRemoteDocuments",
                 "argToString",
                 "arrayEquals",
                 "asNumber",
@@ -1749,6 +1767,7 @@
                 "documentVersionMap",
                 "encodeBase64",
                 "enqueueWrite",
+                "executeQuery",
                 "extractFieldMask",
                 "extractLocalPathFromResourceName",
                 "extractMutationBaseValue",
@@ -1771,6 +1790,9 @@
                 "fullyQualifiedPrefixPath",
                 "geoPointEquals",
                 "getEncodedDatabaseId",
+                "getHighestUnacknowledgedBatchId",
+                "getLastRemoteSnapshotVersion",
+                "getLocalTargetData",
                 "getLocalWriteTime",
                 "getLogLevel",
                 "getMessageOrStack",
@@ -1778,7 +1800,7 @@
                 "getOnlineComponentProvider",
                 "getPostMutationVersion",
                 "getSyncEngine",
-                "getWindow",
+                "handleUserChange",
                 "hardAssert",
                 "ignoreIfPrimaryLeaseLoss",
                 "isArray",
@@ -1801,6 +1823,7 @@
                 "isValidResourceName",
                 "loadProtos",
                 "localTransformResults",
+                "localWrite",
                 "logDebug",
                 "logError",
                 "logWarn",
@@ -1818,10 +1841,12 @@
                 "newSerializer",
                 "newSyncEngine",
                 "newTarget",
+                "nextMutationBatch",
                 "nodePromise",
                 "normalizeByteString",
                 "normalizeNumber",
                 "normalizeTimestamp",
+                "notifyLocalViewChanges",
                 "nullableMaybeDocumentMap",
                 "numberEquals",
                 "objectEquals",
@@ -1841,6 +1866,8 @@
                 "queryToTarget",
                 "randomBytes",
                 "registerFirestore",
+                "rejectBatch",
+                "releaseTarget",
                 "removeComponents",
                 "removeComponents$1",
                 "requireDocument",
@@ -1848,6 +1875,7 @@
                 "serverTransformResults",
                 "setOfflineComponentProvider",
                 "setOnlineComponentProvider",
+                "shouldPersistTargetData",
                 "snapshotChangesMap",
                 "sortsBeforeDocument",
                 "stringifyFilter",
@@ -2007,7 +2035,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 194823
+        "sizeInBytes": 196418
     },
     "deleteField": {
         "dependencies": {
@@ -2017,7 +2045,6 @@
                 "fail",
                 "formatJSON",
                 "getMessageOrStack",
-                "getWindow",
                 "hardAssert",
                 "isIndexedDbTransactionError",
                 "logDebug",
@@ -2026,7 +2053,8 @@
                 "randomBytes",
                 "registerFirestore",
                 "removeComponents",
-                "removeComponents$1"
+                "removeComponents$1",
+                "wrapInUserErrorIfRecoverable"
             ],
             "classes": [
                 "AsyncQueue",
@@ -2049,11 +2077,13 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 17886
+        "sizeInBytes": 17784
     },
     "disableNetwork": {
         "dependencies": {
             "functions": [
+                "acknowledgeBatch",
+                "allocateTarget",
                 "applyArrayRemoveTransformOperation",
                 "applyArrayUnionTransformOperation",
                 "applyDeleteMutationToLocalView",
@@ -2063,12 +2093,14 @@
                 "applyNumericIncrementTransformOperationToLocalView",
                 "applyPatchMutationToLocalView",
                 "applyPatchMutationToRemoteDocument",
+                "applyRemoteEvent",
                 "applySetMutationToLocalView",
                 "applySetMutationToRemoteDocument",
                 "applyTransformMutationToLocalView",
                 "applyTransformMutationToRemoteDocument",
                 "applyTransformOperationToLocalView",
                 "applyTransformOperationToRemoteDocument",
+                "applyWriteToRemoteDocuments",
                 "argToString",
                 "arrayEquals",
                 "asNumber",
@@ -2113,6 +2145,7 @@
                 "documentVersionMap",
                 "encodeBase64",
                 "enqueueNetworkEnabled",
+                "executeQuery",
                 "extractFieldMask",
                 "extractLocalPathFromResourceName",
                 "extractMutationBaseValue",
@@ -2135,6 +2168,9 @@
                 "fullyQualifiedPrefixPath",
                 "geoPointEquals",
                 "getEncodedDatabaseId",
+                "getHighestUnacknowledgedBatchId",
+                "getLastRemoteSnapshotVersion",
+                "getLocalTargetData",
                 "getLocalWriteTime",
                 "getLogLevel",
                 "getMessageOrStack",
@@ -2143,7 +2179,7 @@
                 "getPersistence",
                 "getPostMutationVersion",
                 "getRemoteStore",
-                "getWindow",
+                "handleUserChange",
                 "hardAssert",
                 "ignoreIfPrimaryLeaseLoss",
                 "isArray",
@@ -2166,6 +2202,7 @@
                 "isValidResourceName",
                 "loadProtos",
                 "localTransformResults",
+                "localWrite",
                 "logDebug",
                 "logError",
                 "logWarn",
@@ -2183,10 +2220,12 @@
                 "newSerializer",
                 "newSyncEngine",
                 "newTarget",
+                "nextMutationBatch",
                 "nodePromise",
                 "normalizeByteString",
                 "normalizeNumber",
                 "normalizeTimestamp",
+                "notifyLocalViewChanges",
                 "nullableMaybeDocumentMap",
                 "numberEquals",
                 "objectEquals",
@@ -2206,6 +2245,8 @@
                 "queryToTarget",
                 "randomBytes",
                 "registerFirestore",
+                "rejectBatch",
+                "releaseTarget",
                 "removeComponents",
                 "removeComponents$1",
                 "requireDocument",
@@ -2213,6 +2254,7 @@
                 "serverTransformResults",
                 "setOfflineComponentProvider",
                 "setOnlineComponentProvider",
+                "shouldPersistTargetData",
                 "snapshotChangesMap",
                 "sortsBeforeDocument",
                 "stringifyFilter",
@@ -2370,7 +2412,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 194441
+        "sizeInBytes": 196036
     },
     "doc": {
         "dependencies": {
@@ -2380,7 +2422,6 @@
                 "fail",
                 "formatJSON",
                 "getMessageOrStack",
-                "getWindow",
                 "hardAssert",
                 "isIndexedDbTransactionError",
                 "isNullOrUndefined",
@@ -2398,7 +2439,8 @@
                 "validateArgType",
                 "validateDocumentPath",
                 "validateType",
-                "valueDescription"
+                "valueDescription",
+                "wrapInUserErrorIfRecoverable"
             ],
             "classes": [
                 "AsyncQueue",
@@ -2425,7 +2467,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 24976
+        "sizeInBytes": 24874
     },
     "documentId": {
         "dependencies": {
@@ -2437,7 +2479,6 @@
                 "formatJSON",
                 "formatPlural",
                 "getMessageOrStack",
-                "getWindow",
                 "hardAssert",
                 "isIndexedDbTransactionError",
                 "isPlainObject",
@@ -2453,7 +2494,8 @@
                 "validateArgType",
                 "validateNamedArrayAtLeastNumberOfElements",
                 "validateType",
-                "valueDescription"
+                "valueDescription",
+                "wrapInUserErrorIfRecoverable"
             ],
             "classes": [
                 "AsyncQueue",
@@ -2476,7 +2518,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 23340
+        "sizeInBytes": 23238
     },
     "enableIndexedDbPersistence": {
         "dependencies": {
@@ -2557,10 +2599,8 @@
                 "encodeResourcePath",
                 "encodeSegment",
                 "encodeSeparator",
-                "extractFieldMask",
+                "extractDocumentKeysFromArrayValue",
                 "extractLocalPathFromResourceName",
-                "extractMutationBaseValue",
-                "extractTransformMutationBaseValue",
                 "fail",
                 "fieldTransformEquals",
                 "filterEquals",
@@ -2719,6 +2759,7 @@
                 "valueCompare",
                 "valueEquals",
                 "verifyNotInitialized",
+                "wrapInUserErrorIfRecoverable",
                 "wrapRequest",
                 "writeEmptyTargetGlobalEntry",
                 "writeSentinelKey"
@@ -2780,6 +2821,7 @@
                 "JsonProtoSerializer",
                 "KeyFieldFilter",
                 "KeyFieldInFilter",
+                "KeyFieldNotInFilter",
                 "LLRBEmptyNode",
                 "LLRBNode",
                 "ListenSequence",
@@ -2804,6 +2846,7 @@
                 "Mutation",
                 "MutationBatch",
                 "NoDocument",
+                "NotInFilter",
                 "NumericIncrementTransformOperation",
                 "OAuthToken",
                 "ObjectMap",
@@ -2842,11 +2885,13 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 208911
+        "sizeInBytes": 199048
     },
     "enableMultiTabIndexedDbPersistence": {
         "dependencies": {
             "functions": [
+                "acknowledgeBatch",
+                "allocateTarget",
                 "applyActiveTargetsChange",
                 "applyArrayRemoveTransformOperation",
                 "applyArrayUnionTransformOperation",
@@ -2859,6 +2904,7 @@
                 "applyPatchMutationToLocalView",
                 "applyPatchMutationToRemoteDocument",
                 "applyPrimaryState",
+                "applyRemoteEvent",
                 "applySetMutationToLocalView",
                 "applySetMutationToRemoteDocument",
                 "applyTargetState",
@@ -2866,6 +2912,7 @@
                 "applyTransformMutationToRemoteDocument",
                 "applyTransformOperationToLocalView",
                 "applyTransformOperationToRemoteDocument",
+                "applyWriteToRemoteDocuments",
                 "argToString",
                 "arrayEquals",
                 "arrayValueContains",
@@ -2937,6 +2984,8 @@
                 "encodeResourcePath",
                 "encodeSegment",
                 "encodeSeparator",
+                "executeQuery",
+                "extractDocumentKeysFromArrayValue",
                 "extractFieldMask",
                 "extractLocalPathFromResourceName",
                 "extractMutationBaseValue",
@@ -2987,6 +3036,9 @@
                 "getCachedTarget",
                 "getDocument",
                 "getEncodedDatabaseId",
+                "getHighestUnacknowledgedBatchId",
+                "getLastRemoteSnapshotVersion",
+                "getLocalTargetData",
                 "getLocalWriteTime",
                 "getLogLevel",
                 "getMessageOrStack",
@@ -2995,6 +3047,7 @@
                 "getPostMutationVersion",
                 "getWindow",
                 "globalTargetStore",
+                "handleUserChange",
                 "hardAssert",
                 "ignoreIfPrimaryLeaseLoss",
                 "immediateSuccessor",
@@ -3022,6 +3075,7 @@
                 "isValidResourceName",
                 "loadProtos",
                 "localTransformResults",
+                "localWrite",
                 "logDebug",
                 "logError",
                 "logWarn",
@@ -3045,10 +3099,12 @@
                 "newSerializer",
                 "newSyncEngine",
                 "newTarget",
+                "nextMutationBatch",
                 "nodePromise",
                 "normalizeByteString",
                 "normalizeNumber",
                 "normalizeTimestamp",
+                "notifyLocalViewChanges",
                 "nullableMaybeDocumentMap",
                 "numberEquals",
                 "objectEquals",
@@ -3069,6 +3125,8 @@
                 "queryToTarget",
                 "randomBytes",
                 "registerFirestore",
+                "rejectBatch",
+                "releaseTarget",
                 "remoteDocumentsStore",
                 "removeCachedMutationBatchMetadata",
                 "removeComponents",
@@ -3083,6 +3141,7 @@
                 "serverTransformResults",
                 "setOfflineComponentProvider",
                 "setOnlineComponentProvider",
+                "shouldPersistTargetData",
                 "snapshotChangesMap",
                 "sortsBeforeDocument",
                 "stringifyFilter",
@@ -3212,6 +3271,7 @@
                 "JsonProtoSerializer",
                 "KeyFieldFilter",
                 "KeyFieldInFilter",
+                "KeyFieldNotInFilter",
                 "LLRBEmptyNode",
                 "LLRBNode",
                 "LimboResolution",
@@ -3243,6 +3303,7 @@
                 "MutationResult",
                 "NoDocument",
                 "NoopConnectivityMonitor",
+                "NotInFilter",
                 "NumericIncrementTransformOperation",
                 "OAuthToken",
                 "ObjectMap",
@@ -3303,11 +3364,13 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 301371
+        "sizeInBytes": 304821
     },
     "enableNetwork": {
         "dependencies": {
             "functions": [
+                "acknowledgeBatch",
+                "allocateTarget",
                 "applyArrayRemoveTransformOperation",
                 "applyArrayUnionTransformOperation",
                 "applyDeleteMutationToLocalView",
@@ -3317,12 +3380,14 @@
                 "applyNumericIncrementTransformOperationToLocalView",
                 "applyPatchMutationToLocalView",
                 "applyPatchMutationToRemoteDocument",
+                "applyRemoteEvent",
                 "applySetMutationToLocalView",
                 "applySetMutationToRemoteDocument",
                 "applyTransformMutationToLocalView",
                 "applyTransformMutationToRemoteDocument",
                 "applyTransformOperationToLocalView",
                 "applyTransformOperationToRemoteDocument",
+                "applyWriteToRemoteDocuments",
                 "argToString",
                 "arrayEquals",
                 "asNumber",
@@ -3367,6 +3432,7 @@
                 "enableNetwork",
                 "encodeBase64",
                 "enqueueNetworkEnabled",
+                "executeQuery",
                 "extractFieldMask",
                 "extractLocalPathFromResourceName",
                 "extractMutationBaseValue",
@@ -3389,6 +3455,9 @@
                 "fullyQualifiedPrefixPath",
                 "geoPointEquals",
                 "getEncodedDatabaseId",
+                "getHighestUnacknowledgedBatchId",
+                "getLastRemoteSnapshotVersion",
+                "getLocalTargetData",
                 "getLocalWriteTime",
                 "getLogLevel",
                 "getMessageOrStack",
@@ -3397,7 +3466,7 @@
                 "getPersistence",
                 "getPostMutationVersion",
                 "getRemoteStore",
-                "getWindow",
+                "handleUserChange",
                 "hardAssert",
                 "ignoreIfPrimaryLeaseLoss",
                 "isArray",
@@ -3420,6 +3489,7 @@
                 "isValidResourceName",
                 "loadProtos",
                 "localTransformResults",
+                "localWrite",
                 "logDebug",
                 "logError",
                 "logWarn",
@@ -3437,10 +3507,12 @@
                 "newSerializer",
                 "newSyncEngine",
                 "newTarget",
+                "nextMutationBatch",
                 "nodePromise",
                 "normalizeByteString",
                 "normalizeNumber",
                 "normalizeTimestamp",
+                "notifyLocalViewChanges",
                 "nullableMaybeDocumentMap",
                 "numberEquals",
                 "objectEquals",
@@ -3460,6 +3532,8 @@
                 "queryToTarget",
                 "randomBytes",
                 "registerFirestore",
+                "rejectBatch",
+                "releaseTarget",
                 "removeComponents",
                 "removeComponents$1",
                 "requireDocument",
@@ -3467,6 +3541,7 @@
                 "serverTransformResults",
                 "setOfflineComponentProvider",
                 "setOnlineComponentProvider",
+                "shouldPersistTargetData",
                 "snapshotChangesMap",
                 "sortsBeforeDocument",
                 "stringifyFilter",
@@ -3624,7 +3699,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 194438
+        "sizeInBytes": 196033
     },
     "endAt": {
         "dependencies": {
@@ -3649,7 +3724,6 @@
                 "getLocalWriteTime",
                 "getMessageOrStack",
                 "getPreviousValue",
-                "getWindow",
                 "hardAssert",
                 "invalidClassError",
                 "isCollectionGroupQuery",
@@ -3702,7 +3776,8 @@
                 "validateNamedArrayAtLeastNumberOfElements",
                 "validatePlainObject",
                 "validateType",
-                "valueDescription"
+                "valueDescription",
+                "wrapInUserErrorIfRecoverable"
             ],
             "classes": [
                 "AsyncQueue",
@@ -3747,7 +3822,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 53186
+        "sizeInBytes": 53208
     },
     "endBefore": {
         "dependencies": {
@@ -3772,7 +3847,6 @@
                 "getLocalWriteTime",
                 "getMessageOrStack",
                 "getPreviousValue",
-                "getWindow",
                 "hardAssert",
                 "invalidClassError",
                 "isCollectionGroupQuery",
@@ -3825,7 +3899,8 @@
                 "validateNamedArrayAtLeastNumberOfElements",
                 "validatePlainObject",
                 "validateType",
-                "valueDescription"
+                "valueDescription",
+                "wrapInUserErrorIfRecoverable"
             ],
             "classes": [
                 "AsyncQueue",
@@ -3870,11 +3945,13 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 53197
+        "sizeInBytes": 53219
     },
     "getDoc": {
         "dependencies": {
             "functions": [
+                "acknowledgeBatch",
+                "allocateTarget",
                 "applyArrayRemoveTransformOperation",
                 "applyArrayUnionTransformOperation",
                 "applyDeleteMutationToLocalView",
@@ -3884,12 +3961,14 @@
                 "applyNumericIncrementTransformOperationToLocalView",
                 "applyPatchMutationToLocalView",
                 "applyPatchMutationToRemoteDocument",
+                "applyRemoteEvent",
                 "applySetMutationToLocalView",
                 "applySetMutationToRemoteDocument",
                 "applyTransformMutationToLocalView",
                 "applyTransformMutationToRemoteDocument",
                 "applyTransformOperationToLocalView",
                 "applyTransformOperationToRemoteDocument",
+                "applyWriteToRemoteDocuments",
                 "argToString",
                 "arrayEquals",
                 "asNumber",
@@ -3938,6 +4017,7 @@
                 "enqueueListen",
                 "enqueueReadDocumentViaSnapshotListener",
                 "errorMessage",
+                "executeQuery",
                 "extractFieldMask",
                 "extractLocalPathFromResourceName",
                 "extractMutationBaseValue",
@@ -3966,6 +4046,9 @@
                 "getDoc",
                 "getEncodedDatabaseId",
                 "getEventManager",
+                "getHighestUnacknowledgedBatchId",
+                "getLastRemoteSnapshotVersion",
+                "getLocalTargetData",
                 "getLocalWriteTime",
                 "getLogLevel",
                 "getMessageOrStack",
@@ -3973,7 +4056,7 @@
                 "getOnlineComponentProvider",
                 "getPostMutationVersion",
                 "getPreviousValue",
-                "getWindow",
+                "handleUserChange",
                 "hardAssert",
                 "ignoreIfPrimaryLeaseLoss",
                 "invalidClassError",
@@ -3998,6 +4081,7 @@
                 "isValidResourceName",
                 "loadProtos",
                 "localTransformResults",
+                "localWrite",
                 "logDebug",
                 "logError",
                 "logWarn",
@@ -4015,10 +4099,12 @@
                 "newSerializer",
                 "newSyncEngine",
                 "newTarget",
+                "nextMutationBatch",
                 "nodePromise",
                 "normalizeByteString",
                 "normalizeNumber",
                 "normalizeTimestamp",
+                "notifyLocalViewChanges",
                 "nullableMaybeDocumentMap",
                 "numberEquals",
                 "objectEquals",
@@ -4039,6 +4125,8 @@
                 "queryToTarget",
                 "randomBytes",
                 "registerFirestore",
+                "rejectBatch",
+                "releaseTarget",
                 "removeComponents",
                 "removeComponents$1",
                 "requireDocument",
@@ -4046,6 +4134,7 @@
                 "serverTransformResults",
                 "setOfflineComponentProvider",
                 "setOnlineComponentProvider",
+                "shouldPersistTargetData",
                 "snapshotChangesMap",
                 "sortsBeforeDocument",
                 "stringifyFilter",
@@ -4224,7 +4313,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 210789
+        "sizeInBytes": 212441
     },
     "getDocFromCache": {
         "dependencies": {
@@ -4284,9 +4373,6 @@
                 "encodeBase64",
                 "enqueueReadDocumentFromCache",
                 "errorMessage",
-                "extractFieldMask",
-                "extractMutationBaseValue",
-                "extractTransformMutationBaseValue",
                 "fail",
                 "fieldPathFromArgument$1",
                 "fieldPathFromDotSeparatedString",
@@ -4305,7 +4391,6 @@
                 "getOfflineComponentProvider",
                 "getPostMutationVersion",
                 "getPreviousValue",
-                "getWindow",
                 "hardAssert",
                 "invalidClassError",
                 "isArray",
@@ -4351,6 +4436,7 @@
                 "queryOrderBy",
                 "queryToTarget",
                 "randomBytes",
+                "readLocalDocument",
                 "registerFirestore",
                 "removeComponents",
                 "removeComponents$1",
@@ -4405,7 +4491,6 @@
                 "DocumentSnapshot",
                 "DocumentSnapshot$1",
                 "ExponentialBackoff",
-                "FieldMask",
                 "FieldPath",
                 "FieldPath$1",
                 "FieldPath$2",
@@ -4459,7 +4544,6 @@
                 "SortedMapIterator",
                 "SortedSet",
                 "SortedSetIterator",
-                "TargetData",
                 "TargetIdGenerator",
                 "TargetImpl",
                 "Timestamp",
@@ -4471,11 +4555,13 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 131638
+        "sizeInBytes": 118383
     },
     "getDocFromServer": {
         "dependencies": {
             "functions": [
+                "acknowledgeBatch",
+                "allocateTarget",
                 "applyArrayRemoveTransformOperation",
                 "applyArrayUnionTransformOperation",
                 "applyDeleteMutationToLocalView",
@@ -4485,12 +4571,14 @@
                 "applyNumericIncrementTransformOperationToLocalView",
                 "applyPatchMutationToLocalView",
                 "applyPatchMutationToRemoteDocument",
+                "applyRemoteEvent",
                 "applySetMutationToLocalView",
                 "applySetMutationToRemoteDocument",
                 "applyTransformMutationToLocalView",
                 "applyTransformMutationToRemoteDocument",
                 "applyTransformOperationToLocalView",
                 "applyTransformOperationToRemoteDocument",
+                "applyWriteToRemoteDocuments",
                 "argToString",
                 "arrayEquals",
                 "asNumber",
@@ -4539,6 +4627,7 @@
                 "enqueueListen",
                 "enqueueReadDocumentViaSnapshotListener",
                 "errorMessage",
+                "executeQuery",
                 "extractFieldMask",
                 "extractLocalPathFromResourceName",
                 "extractMutationBaseValue",
@@ -4567,6 +4656,9 @@
                 "getDocFromServer",
                 "getEncodedDatabaseId",
                 "getEventManager",
+                "getHighestUnacknowledgedBatchId",
+                "getLastRemoteSnapshotVersion",
+                "getLocalTargetData",
                 "getLocalWriteTime",
                 "getLogLevel",
                 "getMessageOrStack",
@@ -4574,7 +4666,7 @@
                 "getOnlineComponentProvider",
                 "getPostMutationVersion",
                 "getPreviousValue",
-                "getWindow",
+                "handleUserChange",
                 "hardAssert",
                 "ignoreIfPrimaryLeaseLoss",
                 "invalidClassError",
@@ -4599,6 +4691,7 @@
                 "isValidResourceName",
                 "loadProtos",
                 "localTransformResults",
+                "localWrite",
                 "logDebug",
                 "logError",
                 "logWarn",
@@ -4616,10 +4709,12 @@
                 "newSerializer",
                 "newSyncEngine",
                 "newTarget",
+                "nextMutationBatch",
                 "nodePromise",
                 "normalizeByteString",
                 "normalizeNumber",
                 "normalizeTimestamp",
+                "notifyLocalViewChanges",
                 "nullableMaybeDocumentMap",
                 "numberEquals",
                 "objectEquals",
@@ -4640,6 +4735,8 @@
                 "queryToTarget",
                 "randomBytes",
                 "registerFirestore",
+                "rejectBatch",
+                "releaseTarget",
                 "removeComponents",
                 "removeComponents$1",
                 "requireDocument",
@@ -4647,6 +4744,7 @@
                 "serverTransformResults",
                 "setOfflineComponentProvider",
                 "setOnlineComponentProvider",
+                "shouldPersistTargetData",
                 "snapshotChangesMap",
                 "sortsBeforeDocument",
                 "stringifyFilter",
@@ -4825,11 +4923,13 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 210845
+        "sizeInBytes": 212497
     },
     "getDocs": {
         "dependencies": {
             "functions": [
+                "acknowledgeBatch",
+                "allocateTarget",
                 "applyArrayRemoveTransformOperation",
                 "applyArrayUnionTransformOperation",
                 "applyDeleteMutationToLocalView",
@@ -4839,12 +4939,14 @@
                 "applyNumericIncrementTransformOperationToLocalView",
                 "applyPatchMutationToLocalView",
                 "applyPatchMutationToRemoteDocument",
+                "applyRemoteEvent",
                 "applySetMutationToLocalView",
                 "applySetMutationToRemoteDocument",
                 "applyTransformMutationToLocalView",
                 "applyTransformMutationToRemoteDocument",
                 "applyTransformOperationToLocalView",
                 "applyTransformOperationToRemoteDocument",
+                "applyWriteToRemoteDocuments",
                 "argToString",
                 "arrayEquals",
                 "asNumber",
@@ -4893,6 +4995,7 @@
                 "enqueueExecuteQueryViaSnapshotListener",
                 "enqueueListen",
                 "errorMessage",
+                "executeQuery",
                 "extractFieldMask",
                 "extractLocalPathFromResourceName",
                 "extractMutationBaseValue",
@@ -4921,6 +5024,9 @@
                 "getDocs",
                 "getEncodedDatabaseId",
                 "getEventManager",
+                "getHighestUnacknowledgedBatchId",
+                "getLastRemoteSnapshotVersion",
+                "getLocalTargetData",
                 "getLocalWriteTime",
                 "getLogLevel",
                 "getMessageOrStack",
@@ -4928,7 +5034,7 @@
                 "getOnlineComponentProvider",
                 "getPostMutationVersion",
                 "getPreviousValue",
-                "getWindow",
+                "handleUserChange",
                 "hardAssert",
                 "ignoreIfPrimaryLeaseLoss",
                 "invalidClassError",
@@ -4953,6 +5059,7 @@
                 "isValidResourceName",
                 "loadProtos",
                 "localTransformResults",
+                "localWrite",
                 "logDebug",
                 "logError",
                 "logWarn",
@@ -4970,10 +5077,12 @@
                 "newSerializer",
                 "newSyncEngine",
                 "newTarget",
+                "nextMutationBatch",
                 "nodePromise",
                 "normalizeByteString",
                 "normalizeNumber",
                 "normalizeTimestamp",
+                "notifyLocalViewChanges",
                 "nullableMaybeDocumentMap",
                 "numberEquals",
                 "objectEquals",
@@ -4994,6 +5103,8 @@
                 "queryToTarget",
                 "randomBytes",
                 "registerFirestore",
+                "rejectBatch",
+                "releaseTarget",
                 "removeComponents",
                 "removeComponents$1",
                 "requireDocument",
@@ -5002,6 +5113,7 @@
                 "serverTransformResults",
                 "setOfflineComponentProvider",
                 "setOnlineComponentProvider",
+                "shouldPersistTargetData",
                 "snapshotChangesMap",
                 "sortsBeforeDocument",
                 "stringifyFilter",
@@ -5183,7 +5295,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 213352
+        "sizeInBytes": 215004
     },
     "getDocsFromCache": {
         "dependencies": {
@@ -5245,9 +5357,7 @@
                 "encodeBase64",
                 "enqueueExecuteQueryFromCache",
                 "errorMessage",
-                "extractFieldMask",
-                "extractMutationBaseValue",
-                "extractTransformMutationBaseValue",
+                "executeQuery",
                 "fail",
                 "fieldPathFromArgument$1",
                 "fieldPathFromDotSeparatedString",
@@ -5260,13 +5370,13 @@
                 "geoPointEquals",
                 "getDocsFromCache",
                 "getLocalStore",
+                "getLocalTargetData",
                 "getLocalWriteTime",
                 "getLogLevel",
                 "getMessageOrStack",
                 "getOfflineComponentProvider",
                 "getPostMutationVersion",
                 "getPreviousValue",
-                "getWindow",
                 "hardAssert",
                 "invalidClassError",
                 "isArray",
@@ -5371,7 +5481,6 @@
                 "DocumentSnapshot",
                 "DocumentSnapshot$1",
                 "ExponentialBackoff",
-                "FieldMask",
                 "FieldPath",
                 "FieldPath$1",
                 "FieldPath$2",
@@ -5428,7 +5537,6 @@
                 "SortedMapIterator",
                 "SortedSet",
                 "SortedSetIterator",
-                "TargetData",
                 "TargetIdGenerator",
                 "TargetImpl",
                 "Timestamp",
@@ -5442,11 +5550,13 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 143889
+        "sizeInBytes": 131563
     },
     "getDocsFromServer": {
         "dependencies": {
             "functions": [
+                "acknowledgeBatch",
+                "allocateTarget",
                 "applyArrayRemoveTransformOperation",
                 "applyArrayUnionTransformOperation",
                 "applyDeleteMutationToLocalView",
@@ -5456,12 +5566,14 @@
                 "applyNumericIncrementTransformOperationToLocalView",
                 "applyPatchMutationToLocalView",
                 "applyPatchMutationToRemoteDocument",
+                "applyRemoteEvent",
                 "applySetMutationToLocalView",
                 "applySetMutationToRemoteDocument",
                 "applyTransformMutationToLocalView",
                 "applyTransformMutationToRemoteDocument",
                 "applyTransformOperationToLocalView",
                 "applyTransformOperationToRemoteDocument",
+                "applyWriteToRemoteDocuments",
                 "argToString",
                 "arrayEquals",
                 "asNumber",
@@ -5510,6 +5622,7 @@
                 "enqueueExecuteQueryViaSnapshotListener",
                 "enqueueListen",
                 "errorMessage",
+                "executeQuery",
                 "extractFieldMask",
                 "extractLocalPathFromResourceName",
                 "extractMutationBaseValue",
@@ -5538,6 +5651,9 @@
                 "getDocsFromServer",
                 "getEncodedDatabaseId",
                 "getEventManager",
+                "getHighestUnacknowledgedBatchId",
+                "getLastRemoteSnapshotVersion",
+                "getLocalTargetData",
                 "getLocalWriteTime",
                 "getLogLevel",
                 "getMessageOrStack",
@@ -5545,7 +5661,7 @@
                 "getOnlineComponentProvider",
                 "getPostMutationVersion",
                 "getPreviousValue",
-                "getWindow",
+                "handleUserChange",
                 "hardAssert",
                 "ignoreIfPrimaryLeaseLoss",
                 "invalidClassError",
@@ -5570,6 +5686,7 @@
                 "isValidResourceName",
                 "loadProtos",
                 "localTransformResults",
+                "localWrite",
                 "logDebug",
                 "logError",
                 "logWarn",
@@ -5587,10 +5704,12 @@
                 "newSerializer",
                 "newSyncEngine",
                 "newTarget",
+                "nextMutationBatch",
                 "nodePromise",
                 "normalizeByteString",
                 "normalizeNumber",
                 "normalizeTimestamp",
+                "notifyLocalViewChanges",
                 "nullableMaybeDocumentMap",
                 "numberEquals",
                 "objectEquals",
@@ -5611,6 +5730,8 @@
                 "queryToTarget",
                 "randomBytes",
                 "registerFirestore",
+                "rejectBatch",
+                "releaseTarget",
                 "removeComponents",
                 "removeComponents$1",
                 "requireDocument",
@@ -5619,6 +5740,7 @@
                 "serverTransformResults",
                 "setOfflineComponentProvider",
                 "setOnlineComponentProvider",
+                "shouldPersistTargetData",
                 "snapshotChangesMap",
                 "sortsBeforeDocument",
                 "stringifyFilter",
@@ -5799,7 +5921,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 213090
+        "sizeInBytes": 214742
     },
     "getFirestore": {
         "dependencies": {
@@ -5809,7 +5931,6 @@
                 "formatJSON",
                 "getFirestore",
                 "getMessageOrStack",
-                "getWindow",
                 "hardAssert",
                 "isIndexedDbTransactionError",
                 "logDebug",
@@ -5818,7 +5939,8 @@
                 "randomBytes",
                 "registerFirestore",
                 "removeComponents",
-                "removeComponents$1"
+                "removeComponents$1",
+                "wrapInUserErrorIfRecoverable"
             ],
             "classes": [
                 "AsyncQueue",
@@ -5837,7 +5959,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 16905
+        "sizeInBytes": 16803
     },
     "increment": {
         "dependencies": {
@@ -5846,7 +5968,6 @@
                 "fail",
                 "formatJSON",
                 "getMessageOrStack",
-                "getWindow",
                 "hardAssert",
                 "increment",
                 "isIndexedDbTransactionError",
@@ -5861,7 +5982,8 @@
                 "removeComponents$1",
                 "toDouble",
                 "toInteger",
-                "toNumber"
+                "toNumber",
+                "wrapInUserErrorIfRecoverable"
             ],
             "classes": [
                 "AsyncQueue",
@@ -5887,7 +6009,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 18751
+        "sizeInBytes": 18649
     },
     "initializeFirestore": {
         "dependencies": {
@@ -5896,7 +6018,6 @@
                 "fail",
                 "formatJSON",
                 "getMessageOrStack",
-                "getWindow",
                 "hardAssert",
                 "initializeFirestore",
                 "isIndexedDbTransactionError",
@@ -5906,7 +6027,8 @@
                 "randomBytes",
                 "registerFirestore",
                 "removeComponents",
-                "removeComponents$1"
+                "removeComponents$1",
+                "wrapInUserErrorIfRecoverable"
             ],
             "classes": [
                 "AsyncQueue",
@@ -5926,7 +6048,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 18209
+        "sizeInBytes": 18107
     },
     "limit": {
         "dependencies": {
@@ -5935,7 +6057,6 @@
                 "fail",
                 "formatJSON",
                 "getMessageOrStack",
-                "getWindow",
                 "hardAssert",
                 "isIndexedDbTransactionError",
                 "isNullOrUndefined",
@@ -5949,7 +6070,8 @@
                 "registerFirestore",
                 "removeComponents",
                 "removeComponents$1",
-                "validatePositiveNumber"
+                "validatePositiveNumber",
+                "wrapInUserErrorIfRecoverable"
             ],
             "classes": [
                 "AsyncQueue",
@@ -5972,7 +6094,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 19336
+        "sizeInBytes": 19234
     },
     "limitToLast": {
         "dependencies": {
@@ -5981,7 +6103,6 @@
                 "fail",
                 "formatJSON",
                 "getMessageOrStack",
-                "getWindow",
                 "hardAssert",
                 "isIndexedDbTransactionError",
                 "isNullOrUndefined",
@@ -5995,7 +6116,8 @@
                 "registerFirestore",
                 "removeComponents",
                 "removeComponents$1",
-                "validatePositiveNumber"
+                "validatePositiveNumber",
+                "wrapInUserErrorIfRecoverable"
             ],
             "classes": [
                 "AsyncQueue",
@@ -6018,11 +6140,13 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 19360
+        "sizeInBytes": 19258
     },
     "onSnapshot": {
         "dependencies": {
             "functions": [
+                "acknowledgeBatch",
+                "allocateTarget",
                 "applyArrayRemoveTransformOperation",
                 "applyArrayUnionTransformOperation",
                 "applyDeleteMutationToLocalView",
@@ -6032,12 +6156,14 @@
                 "applyNumericIncrementTransformOperationToLocalView",
                 "applyPatchMutationToLocalView",
                 "applyPatchMutationToRemoteDocument",
+                "applyRemoteEvent",
                 "applySetMutationToLocalView",
                 "applySetMutationToRemoteDocument",
                 "applyTransformMutationToLocalView",
                 "applyTransformMutationToRemoteDocument",
                 "applyTransformOperationToLocalView",
                 "applyTransformOperationToRemoteDocument",
+                "applyWriteToRemoteDocuments",
                 "argToString",
                 "arrayEquals",
                 "asNumber",
@@ -6086,6 +6212,7 @@
                 "encodeBase64",
                 "enqueueListen",
                 "errorMessage",
+                "executeQuery",
                 "extractFieldMask",
                 "extractLocalPathFromResourceName",
                 "extractMutationBaseValue",
@@ -6113,6 +6240,9 @@
                 "geoPointEquals",
                 "getEncodedDatabaseId",
                 "getEventManager",
+                "getHighestUnacknowledgedBatchId",
+                "getLastRemoteSnapshotVersion",
+                "getLocalTargetData",
                 "getLocalWriteTime",
                 "getLogLevel",
                 "getMessageOrStack",
@@ -6120,7 +6250,7 @@
                 "getOnlineComponentProvider",
                 "getPostMutationVersion",
                 "getPreviousValue",
-                "getWindow",
+                "handleUserChange",
                 "hardAssert",
                 "ignoreIfPrimaryLeaseLoss",
                 "implementsAnyMethods",
@@ -6147,6 +6277,7 @@
                 "isValidResourceName",
                 "loadProtos",
                 "localTransformResults",
+                "localWrite",
                 "logDebug",
                 "logError",
                 "logWarn",
@@ -6164,10 +6295,12 @@
                 "newSerializer",
                 "newSyncEngine",
                 "newTarget",
+                "nextMutationBatch",
                 "nodePromise",
                 "normalizeByteString",
                 "normalizeNumber",
                 "normalizeTimestamp",
+                "notifyLocalViewChanges",
                 "nullableMaybeDocumentMap",
                 "numberEquals",
                 "objectEquals",
@@ -6189,6 +6322,8 @@
                 "queryToTarget",
                 "randomBytes",
                 "registerFirestore",
+                "rejectBatch",
+                "releaseTarget",
                 "removeComponents",
                 "removeComponents$1",
                 "requireDocument",
@@ -6197,6 +6332,7 @@
                 "serverTransformResults",
                 "setOfflineComponentProvider",
                 "setOnlineComponentProvider",
+                "shouldPersistTargetData",
                 "snapshotChangesMap",
                 "sortsBeforeDocument",
                 "stringifyFilter",
@@ -6378,11 +6514,13 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 214435
+        "sizeInBytes": 216087
     },
     "onSnapshotsInSync": {
         "dependencies": {
             "functions": [
+                "acknowledgeBatch",
+                "allocateTarget",
                 "applyArrayRemoveTransformOperation",
                 "applyArrayUnionTransformOperation",
                 "applyDeleteMutationToLocalView",
@@ -6392,12 +6530,14 @@
                 "applyNumericIncrementTransformOperationToLocalView",
                 "applyPatchMutationToLocalView",
                 "applyPatchMutationToRemoteDocument",
+                "applyRemoteEvent",
                 "applySetMutationToLocalView",
                 "applySetMutationToRemoteDocument",
                 "applyTransformMutationToLocalView",
                 "applyTransformMutationToRemoteDocument",
                 "applyTransformOperationToLocalView",
                 "applyTransformOperationToRemoteDocument",
+                "applyWriteToRemoteDocuments",
                 "argToString",
                 "arrayEquals",
                 "asNumber",
@@ -6441,6 +6581,7 @@
                 "documentVersionMap",
                 "encodeBase64",
                 "enqueueSnapshotsInSyncListen",
+                "executeQuery",
                 "extractFieldMask",
                 "extractLocalPathFromResourceName",
                 "extractMutationBaseValue",
@@ -6464,13 +6605,16 @@
                 "geoPointEquals",
                 "getEncodedDatabaseId",
                 "getEventManager",
+                "getHighestUnacknowledgedBatchId",
+                "getLastRemoteSnapshotVersion",
+                "getLocalTargetData",
                 "getLocalWriteTime",
                 "getLogLevel",
                 "getMessageOrStack",
                 "getOfflineComponentProvider",
                 "getOnlineComponentProvider",
                 "getPostMutationVersion",
-                "getWindow",
+                "handleUserChange",
                 "hardAssert",
                 "ignoreIfPrimaryLeaseLoss",
                 "implementsAnyMethods",
@@ -6495,6 +6639,7 @@
                 "isValidResourceName",
                 "loadProtos",
                 "localTransformResults",
+                "localWrite",
                 "logDebug",
                 "logError",
                 "logWarn",
@@ -6512,10 +6657,12 @@
                 "newSerializer",
                 "newSyncEngine",
                 "newTarget",
+                "nextMutationBatch",
                 "nodePromise",
                 "normalizeByteString",
                 "normalizeNumber",
                 "normalizeTimestamp",
+                "notifyLocalViewChanges",
                 "nullableMaybeDocumentMap",
                 "numberEquals",
                 "objectEquals",
@@ -6536,6 +6683,8 @@
                 "queryToTarget",
                 "randomBytes",
                 "registerFirestore",
+                "rejectBatch",
+                "releaseTarget",
                 "removeComponents",
                 "removeComponents$1",
                 "requireDocument",
@@ -6543,6 +6692,7 @@
                 "serverTransformResults",
                 "setOfflineComponentProvider",
                 "setOnlineComponentProvider",
+                "shouldPersistTargetData",
                 "snapshotChangesMap",
                 "sortsBeforeDocument",
                 "stringifyFilter",
@@ -6701,7 +6851,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 195287
+        "sizeInBytes": 196882
     },
     "orderBy": {
         "dependencies": {
@@ -6717,7 +6867,6 @@
                 "formatPlural",
                 "fromDotSeparatedString",
                 "getMessageOrStack",
-                "getWindow",
                 "hardAssert",
                 "invalidClassError",
                 "isIndexedDbTransactionError",
@@ -6740,7 +6889,8 @@
                 "validateNewOrderBy",
                 "validateOrderByAndInequalityMatch",
                 "validateType",
-                "valueDescription"
+                "valueDescription",
+                "wrapInUserErrorIfRecoverable"
             ],
             "classes": [
                 "AsyncQueue",
@@ -6769,7 +6919,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 28981
+        "sizeInBytes": 28879
     },
     "parent": {
         "dependencies": {
@@ -6779,7 +6929,6 @@
                 "fail",
                 "formatJSON",
                 "getMessageOrStack",
-                "getWindow",
                 "hardAssert",
                 "isIndexedDbTransactionError",
                 "isNullOrUndefined",
@@ -6791,7 +6940,8 @@
                 "randomBytes",
                 "registerFirestore",
                 "removeComponents",
-                "removeComponents$1"
+                "removeComponents$1",
+                "wrapInUserErrorIfRecoverable"
             ],
             "classes": [
                 "AsyncQueue",
@@ -6818,7 +6968,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 22986
+        "sizeInBytes": 22884
     },
     "query": {
         "dependencies": {
@@ -6828,7 +6978,6 @@
                 "fail",
                 "formatJSON",
                 "getMessageOrStack",
-                "getWindow",
                 "hardAssert",
                 "isIndexedDbTransactionError",
                 "logDebug",
@@ -6838,7 +6987,8 @@
                 "randomBytes",
                 "registerFirestore",
                 "removeComponents",
-                "removeComponents$1"
+                "removeComponents$1",
+                "wrapInUserErrorIfRecoverable"
             ],
             "classes": [
                 "AsyncQueue",
@@ -6858,7 +7008,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 17603
+        "sizeInBytes": 17501
     },
     "queryEqual": {
         "dependencies": {
@@ -6877,7 +7027,6 @@
                 "geoPointEquals",
                 "getLocalWriteTime",
                 "getMessageOrStack",
-                "getWindow",
                 "hardAssert",
                 "isIndexedDbTransactionError",
                 "isNegativeZero",
@@ -6906,7 +7055,8 @@
                 "timestampEquals",
                 "typeOrder",
                 "uint8ArrayFromBinaryString",
-                "valueEquals"
+                "valueEquals",
+                "wrapInUserErrorIfRecoverable"
             ],
             "classes": [
                 "AsyncQueue",
@@ -6934,7 +7084,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 33485
+        "sizeInBytes": 33450
     },
     "refEqual": {
         "dependencies": {
@@ -6943,7 +7093,6 @@
                 "fail",
                 "formatJSON",
                 "getMessageOrStack",
-                "getWindow",
                 "hardAssert",
                 "isIndexedDbTransactionError",
                 "isNullOrUndefined",
@@ -6955,7 +7104,8 @@
                 "refEqual",
                 "registerFirestore",
                 "removeComponents",
-                "removeComponents$1"
+                "removeComponents$1",
+                "wrapInUserErrorIfRecoverable"
             ],
             "classes": [
                 "AsyncQueue",
@@ -6982,7 +7132,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 22533
+        "sizeInBytes": 22431
     },
     "runTransaction": {
         "dependencies": {
@@ -7025,7 +7175,6 @@
                 "getLocalWriteTime",
                 "getMessageOrStack",
                 "getPreviousValue",
-                "getWindow",
                 "hardAssert",
                 "invalidClassError",
                 "invokeBatchGetDocumentsRpc",
@@ -7097,7 +7246,8 @@
                 "validateReference",
                 "validateType",
                 "valueDescription",
-                "valueEquals"
+                "valueEquals",
+                "wrapInUserErrorIfRecoverable"
             ],
             "classes": [
                 "ArrayRemoveTransformOperation",
@@ -7169,7 +7319,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 81911
+        "sizeInBytes": 82111
     },
     "serverTimestamp": {
         "dependencies": {
@@ -7178,7 +7328,6 @@
                 "fail",
                 "formatJSON",
                 "getMessageOrStack",
-                "getWindow",
                 "hardAssert",
                 "isIndexedDbTransactionError",
                 "logDebug",
@@ -7188,7 +7337,8 @@
                 "registerFirestore",
                 "removeComponents",
                 "removeComponents$1",
-                "serverTimestamp$1"
+                "serverTimestamp$1",
+                "wrapInUserErrorIfRecoverable"
             ],
             "classes": [
                 "AsyncQueue",
@@ -7214,11 +7364,13 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 17897
+        "sizeInBytes": 17795
     },
     "setDoc": {
         "dependencies": {
             "functions": [
+                "acknowledgeBatch",
+                "allocateTarget",
                 "applyArrayRemoveTransformOperation",
                 "applyArrayUnionTransformOperation",
                 "applyDeleteMutationToLocalView",
@@ -7229,12 +7381,14 @@
                 "applyNumericIncrementTransformOperationToLocalView",
                 "applyPatchMutationToLocalView",
                 "applyPatchMutationToRemoteDocument",
+                "applyRemoteEvent",
                 "applySetMutationToLocalView",
                 "applySetMutationToRemoteDocument",
                 "applyTransformMutationToLocalView",
                 "applyTransformMutationToRemoteDocument",
                 "applyTransformOperationToLocalView",
                 "applyTransformOperationToRemoteDocument",
+                "applyWriteToRemoteDocuments",
                 "argToString",
                 "arrayEquals",
                 "asNumber",
@@ -7281,6 +7435,7 @@
                 "encodeBase64",
                 "enqueueWrite",
                 "errorMessage",
+                "executeQuery",
                 "extractFieldMask",
                 "extractLocalPathFromResourceName",
                 "extractMutationBaseValue",
@@ -7307,6 +7462,9 @@
                 "fullyQualifiedPrefixPath",
                 "geoPointEquals",
                 "getEncodedDatabaseId",
+                "getHighestUnacknowledgedBatchId",
+                "getLastRemoteSnapshotVersion",
+                "getLocalTargetData",
                 "getLocalWriteTime",
                 "getLogLevel",
                 "getMessageOrStack",
@@ -7314,7 +7472,7 @@
                 "getOnlineComponentProvider",
                 "getPostMutationVersion",
                 "getSyncEngine",
-                "getWindow",
+                "handleUserChange",
                 "hardAssert",
                 "ignoreIfPrimaryLeaseLoss",
                 "invalidClassError",
@@ -7341,6 +7499,7 @@
                 "isWrite",
                 "loadProtos",
                 "localTransformResults",
+                "localWrite",
                 "logDebug",
                 "logError",
                 "logWarn",
@@ -7360,10 +7519,12 @@
                 "newSyncEngine",
                 "newTarget",
                 "newUserDataReader",
+                "nextMutationBatch",
                 "nodePromise",
                 "normalizeByteString",
                 "normalizeNumber",
                 "normalizeTimestamp",
+                "notifyLocalViewChanges",
                 "nullableMaybeDocumentMap",
                 "numberEquals",
                 "objectEquals",
@@ -7390,6 +7551,8 @@
                 "queryToTarget",
                 "randomBytes",
                 "registerFirestore",
+                "rejectBatch",
+                "releaseTarget",
                 "removeComponents",
                 "removeComponents$1",
                 "requireDocument",
@@ -7398,6 +7561,7 @@
                 "setDoc",
                 "setOfflineComponentProvider",
                 "setOnlineComponentProvider",
+                "shouldPersistTargetData",
                 "snapshotChangesMap",
                 "sortsBeforeDocument",
                 "stringifyFilter",
@@ -7573,7 +7737,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 210717
+        "sizeInBytes": 212369
     },
     "setLogLevel": {
         "dependencies": {
@@ -7582,7 +7746,6 @@
                 "fail",
                 "formatJSON",
                 "getMessageOrStack",
-                "getWindow",
                 "hardAssert",
                 "isIndexedDbTransactionError",
                 "logDebug",
@@ -7592,7 +7755,8 @@
                 "registerFirestore",
                 "removeComponents",
                 "removeComponents$1",
-                "setLogLevel"
+                "setLogLevel",
+                "wrapInUserErrorIfRecoverable"
             ],
             "classes": [
                 "AsyncQueue",
@@ -7611,7 +7775,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 16871
+        "sizeInBytes": 16769
     },
     "snapshotEqual": {
         "dependencies": {
@@ -7640,7 +7804,6 @@
                 "getLocalWriteTime",
                 "getMessageOrStack",
                 "getPreviousValue",
-                "getWindow",
                 "hardAssert",
                 "invalidClassError",
                 "isIndexedDbTransactionError",
@@ -7681,7 +7844,8 @@
                 "validateNamedArrayAtLeastNumberOfElements",
                 "validateType",
                 "valueDescription",
-                "valueEquals"
+                "valueEquals",
+                "wrapInUserErrorIfRecoverable"
             ],
             "classes": [
                 "AsyncQueue",
@@ -7725,7 +7889,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 50917
+        "sizeInBytes": 50939
     },
     "startAfter": {
         "dependencies": {
@@ -7749,7 +7913,6 @@
                 "getLocalWriteTime",
                 "getMessageOrStack",
                 "getPreviousValue",
-                "getWindow",
                 "hardAssert",
                 "invalidClassError",
                 "isCollectionGroupQuery",
@@ -7803,7 +7966,8 @@
                 "validateNamedArrayAtLeastNumberOfElements",
                 "validatePlainObject",
                 "validateType",
-                "valueDescription"
+                "valueDescription",
+                "wrapInUserErrorIfRecoverable"
             ],
             "classes": [
                 "AsyncQueue",
@@ -7848,7 +8012,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 53207
+        "sizeInBytes": 53229
     },
     "startAt": {
         "dependencies": {
@@ -7872,7 +8036,6 @@
                 "getLocalWriteTime",
                 "getMessageOrStack",
                 "getPreviousValue",
-                "getWindow",
                 "hardAssert",
                 "invalidClassError",
                 "isCollectionGroupQuery",
@@ -7926,7 +8089,8 @@
                 "validateNamedArrayAtLeastNumberOfElements",
                 "validatePlainObject",
                 "validateType",
-                "valueDescription"
+                "valueDescription",
+                "wrapInUserErrorIfRecoverable"
             ],
             "classes": [
                 "AsyncQueue",
@@ -7971,7 +8135,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 53197
+        "sizeInBytes": 53219
     },
     "terminate": {
         "dependencies": {
@@ -7981,7 +8145,6 @@
                 "fail",
                 "formatJSON",
                 "getMessageOrStack",
-                "getWindow",
                 "hardAssert",
                 "isIndexedDbTransactionError",
                 "logDebug",
@@ -7991,7 +8154,8 @@
                 "registerFirestore",
                 "removeComponents",
                 "removeComponents$1",
-                "terminate"
+                "terminate",
+                "wrapInUserErrorIfRecoverable"
             ],
             "classes": [
                 "AsyncQueue",
@@ -8010,11 +8174,13 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 17401
+        "sizeInBytes": 17299
     },
     "updateDoc": {
         "dependencies": {
             "functions": [
+                "acknowledgeBatch",
+                "allocateTarget",
                 "applyArrayRemoveTransformOperation",
                 "applyArrayUnionTransformOperation",
                 "applyDeleteMutationToLocalView",
@@ -8024,12 +8190,14 @@
                 "applyNumericIncrementTransformOperationToLocalView",
                 "applyPatchMutationToLocalView",
                 "applyPatchMutationToRemoteDocument",
+                "applyRemoteEvent",
                 "applySetMutationToLocalView",
                 "applySetMutationToRemoteDocument",
                 "applyTransformMutationToLocalView",
                 "applyTransformMutationToRemoteDocument",
                 "applyTransformOperationToLocalView",
                 "applyTransformOperationToRemoteDocument",
+                "applyWriteToRemoteDocuments",
                 "argToString",
                 "arrayEquals",
                 "asNumber",
@@ -8076,6 +8244,7 @@
                 "encodeBase64",
                 "enqueueWrite",
                 "errorMessage",
+                "executeQuery",
                 "extractFieldMask",
                 "extractLocalPathFromResourceName",
                 "extractMutationBaseValue",
@@ -8103,6 +8272,9 @@
                 "fullyQualifiedPrefixPath",
                 "geoPointEquals",
                 "getEncodedDatabaseId",
+                "getHighestUnacknowledgedBatchId",
+                "getLastRemoteSnapshotVersion",
+                "getLocalTargetData",
                 "getLocalWriteTime",
                 "getLogLevel",
                 "getMessageOrStack",
@@ -8110,7 +8282,7 @@
                 "getOnlineComponentProvider",
                 "getPostMutationVersion",
                 "getSyncEngine",
-                "getWindow",
+                "handleUserChange",
                 "hardAssert",
                 "ignoreIfPrimaryLeaseLoss",
                 "invalidClassError",
@@ -8137,6 +8309,7 @@
                 "isWrite",
                 "loadProtos",
                 "localTransformResults",
+                "localWrite",
                 "logDebug",
                 "logError",
                 "logWarn",
@@ -8156,10 +8329,12 @@
                 "newSyncEngine",
                 "newTarget",
                 "newUserDataReader",
+                "nextMutationBatch",
                 "nodePromise",
                 "normalizeByteString",
                 "normalizeNumber",
                 "normalizeTimestamp",
+                "notifyLocalViewChanges",
                 "nullableMaybeDocumentMap",
                 "numberEquals",
                 "objectEquals",
@@ -8187,6 +8362,8 @@
                 "queryToTarget",
                 "randomBytes",
                 "registerFirestore",
+                "rejectBatch",
+                "releaseTarget",
                 "removeComponents",
                 "removeComponents$1",
                 "requireDocument",
@@ -8194,6 +8371,7 @@
                 "serverTransformResults",
                 "setOfflineComponentProvider",
                 "setOnlineComponentProvider",
+                "shouldPersistTargetData",
                 "snapshotChangesMap",
                 "sortsBeforeDocument",
                 "stringifyFilter",
@@ -8372,11 +8550,13 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 212216
+        "sizeInBytes": 213868
     },
     "waitForPendingWrites": {
         "dependencies": {
             "functions": [
+                "acknowledgeBatch",
+                "allocateTarget",
                 "applyArrayRemoveTransformOperation",
                 "applyArrayUnionTransformOperation",
                 "applyDeleteMutationToLocalView",
@@ -8386,12 +8566,14 @@
                 "applyNumericIncrementTransformOperationToLocalView",
                 "applyPatchMutationToLocalView",
                 "applyPatchMutationToRemoteDocument",
+                "applyRemoteEvent",
                 "applySetMutationToLocalView",
                 "applySetMutationToRemoteDocument",
                 "applyTransformMutationToLocalView",
                 "applyTransformMutationToRemoteDocument",
                 "applyTransformOperationToLocalView",
                 "applyTransformOperationToRemoteDocument",
+                "applyWriteToRemoteDocuments",
                 "argToString",
                 "arrayEquals",
                 "asNumber",
@@ -8435,6 +8617,7 @@
                 "documentVersionMap",
                 "encodeBase64",
                 "enqueueWaitForPendingWrites",
+                "executeQuery",
                 "extractFieldMask",
                 "extractLocalPathFromResourceName",
                 "extractMutationBaseValue",
@@ -8457,6 +8640,9 @@
                 "fullyQualifiedPrefixPath",
                 "geoPointEquals",
                 "getEncodedDatabaseId",
+                "getHighestUnacknowledgedBatchId",
+                "getLastRemoteSnapshotVersion",
+                "getLocalTargetData",
                 "getLocalWriteTime",
                 "getLogLevel",
                 "getMessageOrStack",
@@ -8464,7 +8650,7 @@
                 "getOnlineComponentProvider",
                 "getPostMutationVersion",
                 "getSyncEngine",
-                "getWindow",
+                "handleUserChange",
                 "hardAssert",
                 "ignoreIfPrimaryLeaseLoss",
                 "isArray",
@@ -8487,6 +8673,7 @@
                 "isValidResourceName",
                 "loadProtos",
                 "localTransformResults",
+                "localWrite",
                 "logDebug",
                 "logError",
                 "logWarn",
@@ -8504,10 +8691,12 @@
                 "newSerializer",
                 "newSyncEngine",
                 "newTarget",
+                "nextMutationBatch",
                 "nodePromise",
                 "normalizeByteString",
                 "normalizeNumber",
                 "normalizeTimestamp",
+                "notifyLocalViewChanges",
                 "nullableMaybeDocumentMap",
                 "numberEquals",
                 "objectEquals",
@@ -8527,6 +8716,8 @@
                 "queryToTarget",
                 "randomBytes",
                 "registerFirestore",
+                "rejectBatch",
+                "releaseTarget",
                 "removeComponents",
                 "removeComponents$1",
                 "requireDocument",
@@ -8534,6 +8725,7 @@
                 "serverTransformResults",
                 "setOfflineComponentProvider",
                 "setOnlineComponentProvider",
+                "shouldPersistTargetData",
                 "snapshotChangesMap",
                 "sortsBeforeDocument",
                 "stringifyFilter",
@@ -8692,7 +8884,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 194230
+        "sizeInBytes": 195825
     },
     "where": {
         "dependencies": {
@@ -8711,10 +8903,12 @@
                 "compareNumbers",
                 "compareReferences",
                 "compareTimestamps",
+                "conflictingOps",
                 "createError",
                 "decodeBase64",
                 "encodeBase64",
                 "errorMessage",
+                "extractDocumentKeysFromArrayValue",
                 "fail",
                 "fieldPathFromArgument$1",
                 "fieldPathFromDotSeparatedString",
@@ -8726,7 +8920,6 @@
                 "geoPointEquals",
                 "getLocalWriteTime",
                 "getMessageOrStack",
-                "getWindow",
                 "hardAssert",
                 "invalidClassError",
                 "isArray",
@@ -8789,7 +8982,8 @@
                 "valueCompare",
                 "valueDescription",
                 "valueEquals",
-                "where"
+                "where",
+                "wrapInUserErrorIfRecoverable"
             ],
             "classes": [
                 "ArrayContainsAnyFilter",
@@ -8821,6 +9015,8 @@
                 "JsonProtoSerializer",
                 "KeyFieldFilter",
                 "KeyFieldInFilter",
+                "KeyFieldNotInFilter",
+                "NotInFilter",
                 "OAuthToken",
                 "ParseContext",
                 "Query",
@@ -8835,11 +9031,13 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 58541
+        "sizeInBytes": 59634
     },
     "writeBatch": {
         "dependencies": {
             "functions": [
+                "acknowledgeBatch",
+                "allocateTarget",
                 "applyArrayRemoveTransformOperation",
                 "applyArrayUnionTransformOperation",
                 "applyDeleteMutationToLocalView",
@@ -8850,12 +9048,14 @@
                 "applyNumericIncrementTransformOperationToLocalView",
                 "applyPatchMutationToLocalView",
                 "applyPatchMutationToRemoteDocument",
+                "applyRemoteEvent",
                 "applySetMutationToLocalView",
                 "applySetMutationToRemoteDocument",
                 "applyTransformMutationToLocalView",
                 "applyTransformMutationToRemoteDocument",
                 "applyTransformOperationToLocalView",
                 "applyTransformOperationToRemoteDocument",
+                "applyWriteToRemoteDocuments",
                 "argToString",
                 "arrayEquals",
                 "asNumber",
@@ -8902,6 +9102,7 @@
                 "encodeBase64",
                 "enqueueWrite",
                 "errorMessage",
+                "executeQuery",
                 "extractFieldMask",
                 "extractLocalPathFromResourceName",
                 "extractMutationBaseValue",
@@ -8929,6 +9130,9 @@
                 "fullyQualifiedPrefixPath",
                 "geoPointEquals",
                 "getEncodedDatabaseId",
+                "getHighestUnacknowledgedBatchId",
+                "getLastRemoteSnapshotVersion",
+                "getLocalTargetData",
                 "getLocalWriteTime",
                 "getLogLevel",
                 "getMessageOrStack",
@@ -8936,7 +9140,7 @@
                 "getOnlineComponentProvider",
                 "getPostMutationVersion",
                 "getSyncEngine",
-                "getWindow",
+                "handleUserChange",
                 "hardAssert",
                 "ignoreIfPrimaryLeaseLoss",
                 "invalidClassError",
@@ -8963,6 +9167,7 @@
                 "isWrite",
                 "loadProtos",
                 "localTransformResults",
+                "localWrite",
                 "logDebug",
                 "logError",
                 "logWarn",
@@ -8982,10 +9187,12 @@
                 "newSyncEngine",
                 "newTarget",
                 "newUserDataReader",
+                "nextMutationBatch",
                 "nodePromise",
                 "normalizeByteString",
                 "normalizeNumber",
                 "normalizeTimestamp",
+                "notifyLocalViewChanges",
                 "nullableMaybeDocumentMap",
                 "numberEquals",
                 "objectEquals",
@@ -9014,6 +9221,8 @@
                 "queryToTarget",
                 "randomBytes",
                 "registerFirestore",
+                "rejectBatch",
+                "releaseTarget",
                 "removeComponents",
                 "removeComponents$1",
                 "requireDocument",
@@ -9021,6 +9230,7 @@
                 "serverTransformResults",
                 "setOfflineComponentProvider",
                 "setOnlineComponentProvider",
+                "shouldPersistTargetData",
                 "snapshotChangesMap",
                 "sortsBeforeDocument",
                 "stringifyFilter",
@@ -9202,6 +9412,6 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 215883
+        "sizeInBytes": 217535
     }
 }

--- a/packages/firestore/exp/src/api/components.ts
+++ b/packages/firestore/exp/src/api/components.ts
@@ -23,7 +23,7 @@ import {
   OfflineComponentProvider,
   OnlineComponentProvider
 } from '../../../src/core/component_provider';
-import { LocalStore } from '../../../src/local/local_store';
+import {handleUserChange, LocalStore} from '../../../src/local/local_store';
 import { Deferred } from '../../../src/util/promise';
 import { logDebug } from '../../../src/util/log';
 import { SyncEngine } from '../../../src/core/sync_engine';
@@ -65,7 +65,7 @@ export async function setOfflineComponentProvider(
     firestore._queue.enqueueAndForget(() =>
       // TODO(firestorexp): Make sure handleUserChange is a no-op if user
       // didn't change
-      offlineComponentProvider.localStore.handleUserChange(user)
+      handleUserChange(offlineComponentProvider.localStore, user)
     )
   );
   // When a user calls clearPersistence() in one client, all other clients

--- a/packages/firestore/src/core/firestore_client.ts
+++ b/packages/firestore/src/core/firestore_client.ts
@@ -19,7 +19,11 @@ import { GetOptions } from '@firebase/firestore-types';
 
 import { CredentialsProvider } from '../api/credentials';
 import { User } from '../auth/user';
-import { LocalStore } from '../local/local_store';
+import {
+  executeQuery,
+  LocalStore,
+  readLocalDocument
+} from '../local/local_store';
 import { GarbageCollectionScheduler, Persistence } from '../local/persistence';
 import { Document, NoDocument } from '../model/document';
 import { DocumentKey } from '../model/document_key';
@@ -613,7 +617,7 @@ export async function enqueueReadDocumentFromCache(
   const deferred = new Deferred<Document | null>();
   await asyncQueue.enqueue(async () => {
     try {
-      const maybeDoc = await localStore.readDocument(docKey);
+      const maybeDoc = await readLocalDocument(localStore, docKey);
       if (maybeDoc instanceof Document) {
         deferred.resolve(maybeDoc);
       } else if (maybeDoc instanceof NoDocument) {
@@ -717,7 +721,8 @@ export async function enqueueExecuteQueryFromCache(
   const deferred = new Deferred<ViewSnapshot>();
   await asyncQueue.enqueue(async () => {
     try {
-      const queryResult = await localStore.executeQuery(
+      const queryResult = await executeQuery(
+        localStore,
         query,
         /* usePreviousResults= */ true
       );

--- a/packages/firestore/src/core/sync_engine.ts
+++ b/packages/firestore/src/core/sync_engine.ts
@@ -17,13 +17,23 @@
 
 import { User } from '../auth/user';
 import {
+  applyRemoteEventToLocalCache,
   getNewDocumentChanges,
   getCachedTarget,
   ignoreIfPrimaryLeaseLoss,
   LocalStore,
   getActiveClientsFromPersistence,
   lookupMutationDocuments,
-  removeCachedMutationBatchMetadata
+  removeCachedMutationBatchMetadata,
+  allocateTarget,
+  executeQuery,
+  releaseTarget,
+  rejectBatch,
+  acknowledgeBatch,
+  getHighestUnacknowledgedBatchId,
+  localWrite,
+  notifyLocalViewChanges,
+  handleUserChange
 } from '../local/local_store';
 import { LocalViewChanges } from '../local/local_view_changes';
 import { ReferenceSet } from '../local/reference_set';
@@ -47,7 +57,6 @@ import { primitiveComparator } from '../util/misc';
 import { ObjectMap } from '../util/obj_map';
 import { Deferred } from '../util/promise';
 import { SortedMap } from '../util/sorted_map';
-
 import { ClientId, SharedClientState } from '../local/shared_client_state';
 import { QueryTargetState } from '../local/shared_client_state_syncer';
 import { SortedSet } from '../util/sorted_set';
@@ -301,7 +310,8 @@ class SyncEngineImpl implements SyncEngine {
       this.sharedClientState.addLocalQueryTarget(targetId);
       viewSnapshot = queryView.view.computeInitialSnapshot();
     } else {
-      const targetData = await this.localStore.allocateTarget(
+      const targetData = await allocateTarget(
+        this.localStore,
         queryToTarget(query)
       );
 
@@ -331,7 +341,8 @@ class SyncEngineImpl implements SyncEngine {
     targetId: TargetId,
     current: boolean
   ): Promise<ViewSnapshot> {
-    const queryResult = await this.localStore.executeQuery(
+    const queryResult = await executeQuery(
+      this.localStore,
       query,
       /* usePreviousResults= */ true
     );
@@ -394,8 +405,11 @@ class SyncEngineImpl implements SyncEngine {
       );
 
       if (!targetRemainsActive) {
-        await this.localStore
-          .releaseTarget(queryView.targetId, /*keepPersistedTargetData=*/ false)
+        await releaseTarget(
+          this.localStore,
+          queryView.targetId,
+          /*keepPersistedTargetData=*/ false
+        )
           .then(() => {
             this.sharedClientState.clearQueryState(queryView.targetId);
             this.remoteStore.unlisten(queryView.targetId);
@@ -405,7 +419,8 @@ class SyncEngineImpl implements SyncEngine {
       }
     } else {
       this.removeAndCleanupTarget(queryView.targetId);
-      await this.localStore.releaseTarget(
+      await releaseTarget(
+        this.localStore,
         queryView.targetId,
         /*keepPersistedTargetData=*/ true
       );
@@ -416,7 +431,7 @@ class SyncEngineImpl implements SyncEngine {
     this.assertSubscribed('write()');
 
     try {
-      const result = await this.localStore.localWrite(batch);
+      const result = await localWrite(this.localStore, batch);
       this.sharedClientState.addPendingMutation(result.batchId);
       this.addMutationCallback(result.batchId, userCallback);
       await this.emitNewSnapsAndNotifyLocalStore(result.changes);
@@ -432,7 +447,10 @@ class SyncEngineImpl implements SyncEngine {
   async applyRemoteEvent(remoteEvent: RemoteEvent): Promise<void> {
     this.assertSubscribed('applyRemoteEvent()');
     try {
-      const changes = await this.localStore.applyRemoteEvent(remoteEvent);
+      const changes = await applyRemoteEventToLocalCache(
+        this.localStore,
+        remoteEvent
+      );
       // Update `receivedDocument` as appropriate for any limbo targets.
       remoteEvent.targetChanges.forEach((targetChange, targetId) => {
         const limboResolution = this.activeLimboResolutionsByTarget.get(
@@ -550,8 +568,11 @@ class SyncEngineImpl implements SyncEngine {
       this.activeLimboResolutionsByTarget.delete(targetId);
       this.pumpEnqueuedLimboResolutions();
     } else {
-      await this.localStore
-        .releaseTarget(targetId, /* keepPersistedTargetData */ false)
+      await releaseTarget(
+        this.localStore,
+        targetId,
+        /* keepPersistedTargetData */ false
+      )
         .then(() => this.removeAndCleanupTarget(targetId, err))
         .catch(ignoreIfPrimaryLeaseLoss);
     }
@@ -565,7 +586,8 @@ class SyncEngineImpl implements SyncEngine {
     const batchId = mutationBatchResult.batch.batchId;
 
     try {
-      const changes = await this.localStore.acknowledgeBatch(
+      const changes = await acknowledgeBatch(
+        this.localStore,
         mutationBatchResult
       );
 
@@ -590,7 +612,7 @@ class SyncEngineImpl implements SyncEngine {
     this.assertSubscribed('rejectFailedWrite()');
 
     try {
-      const changes = await this.localStore.rejectBatch(batchId);
+      const changes = await rejectBatch(this.localStore, batchId);
 
       // The local store may or may not be able to apply the write result and
       // raise events immediately (depending on whether the watcher is caught up),
@@ -616,7 +638,9 @@ class SyncEngineImpl implements SyncEngine {
     }
 
     try {
-      const highestBatchId = await this.localStore.getHighestUnacknowledgedBatchId();
+      const highestBatchId = await getHighestUnacknowledgedBatchId(
+        this.localStore
+      );
       if (highestBatchId === BATCHID_UNKNOWN) {
         // Trigger the callback right away if there is no pending writes at the moment.
         callback.resolve();
@@ -840,14 +864,16 @@ class SyncEngineImpl implements SyncEngine {
             // The query has a limit and some docs were removed, so we need
             // to re-run the query against the local store to make sure we
             // didn't lose any good docs that had been past the limit.
-            return this.localStore
-              .executeQuery(queryView.query, /* usePreviousResults= */ false)
-              .then(({ documents }) => {
-                return queryView.view.computeDocChanges(
-                  documents,
-                  viewDocChanges
-                );
-              });
+            return executeQuery(
+              this.localStore,
+              queryView.query,
+              /* usePreviousResults= */ false
+            ).then(({ documents }) => {
+              return queryView.view.computeDocChanges(
+                documents,
+                viewDocChanges
+              );
+            });
           })
           .then((viewDocChanges: ViewDocumentChanges) => {
             const targetChange =
@@ -882,7 +908,7 @@ class SyncEngineImpl implements SyncEngine {
 
     await Promise.all(queriesProcessed);
     this.syncEngineListener!.onWatchChange(newSnaps);
-    await this.localStore.notifyLocalViewChanges(docChangesInAllViews);
+    await notifyLocalViewChanges(this.localStore, docChangesInAllViews);
   }
 
   assertSubscribed(fnName: string): void {
@@ -898,7 +924,7 @@ class SyncEngineImpl implements SyncEngine {
     if (userChanged) {
       logDebug(LOG_TAG, 'User change. New user:', user.toKey());
 
-      const result = await this.localStore.handleUserChange(user);
+      const result = await handleUserChange(this.localStore, user);
       this.currentUser = user;
 
       // Fails tasks waiting for pending writes requested by previous user.
@@ -971,7 +997,8 @@ async function synchronizeViewAndComputeSnapshot(
   queryView: QueryView
 ): Promise<ViewChange> {
   const syncEngineImpl = debugCast(syncEngine, SyncEngineImpl);
-  const queryResult = await syncEngineImpl.localStore.executeQuery(
+  const queryResult = await executeQuery(
+    syncEngineImpl.localStore,
     queryView.query,
     /* usePreviousResults= */ true
   );
@@ -1066,7 +1093,8 @@ export async function applyPrimaryState(
       } else {
         p = p.then(() => {
           syncEngineImpl.removeAndCleanupTarget(targetId);
-          return syncEngineImpl.localStore.releaseTarget(
+          return releaseTarget(
+            syncEngineImpl.localStore,
             targetId,
             /*keepPersistedTargetData=*/ true
           );
@@ -1130,7 +1158,8 @@ async function synchronizeQueryViewsAndRaiseSnapshots(
       // from LocalStore (as the resume token and the snapshot version
       // might have changed) and reconcile their views with the persisted
       // state (the list of syncedDocuments may have gotten out of sync).
-      targetData = await syncEngineImpl.localStore.allocateTarget(
+      targetData = await allocateTarget(
+        syncEngineImpl.localStore,
         queryToTarget(queries[0])
       );
 
@@ -1158,7 +1187,7 @@ async function synchronizeQueryViewsAndRaiseSnapshots(
       // allocate the target in LocalStore and initialize a new View.
       const target = await getCachedTarget(syncEngineImpl.localStore, targetId);
       debugAssert(!!target, `Target for id ${targetId} not found`);
-      targetData = await syncEngineImpl.localStore.allocateTarget(target);
+      targetData = await allocateTarget(syncEngineImpl.localStore, target);
       await syncEngineImpl.initializeViewAndComputeSnapshot(
         synthesizeTargetToQuery(target!),
         targetId,
@@ -1236,7 +1265,8 @@ export async function applyTargetState(
         break;
       }
       case 'rejected': {
-        await syncEngineImpl.localStore.releaseTarget(
+        await releaseTarget(
+          syncEngineImpl.localStore,
           targetId,
           /* keepPersistedTargetData */ true
         );
@@ -1269,7 +1299,7 @@ export async function applyActiveTargetsChange(
 
     const target = await getCachedTarget(syncEngineImpl.localStore, targetId);
     debugAssert(!!target, `Query data for active target ${targetId} not found`);
-    const targetData = await syncEngineImpl.localStore.allocateTarget(target);
+    const targetData = await allocateTarget(syncEngineImpl.localStore, target);
     await syncEngineImpl.initializeViewAndComputeSnapshot(
       synthesizeTargetToQuery(target),
       targetData.targetId,
@@ -1286,8 +1316,11 @@ export async function applyActiveTargetsChange(
     }
 
     // Release queries that are still active.
-    await syncEngineImpl.localStore
-      .releaseTarget(targetId, /* keepPersistedTargetData */ false)
+    await releaseTarget(
+      syncEngineImpl.localStore,
+      targetId,
+      /* keepPersistedTargetData */ false
+    )
       .then(() => {
         syncEngineImpl.remoteStore.unlisten(targetId);
         syncEngineImpl.removeAndCleanupTarget(targetId);

--- a/packages/firestore/src/local/local_store.ts
+++ b/packages/firestore/src/local/local_store.ts
@@ -74,6 +74,15 @@ import { isIndexedDbTransactionError } from './simple_db';
 
 const LOG_TAG = 'LocalStore';
 
+/**
+ * The maximum time to leave a resume token buffered without writing it out.
+ * This value is arbitrary: it's long enough to avoid several writes
+ * (possibly indefinitely if updates come more frequently than this) but
+ * short enough that restarting after crashing will still have a pretty
+ * recent resume token.
+ */
+const RESUME_TOKEN_MAX_AGE_MICROS = 5 * 60 * 1e6;
+
 /** The result of a write to the local store. */
 export interface LocalWriteResult {
   batchId: BatchId;
@@ -143,131 +152,11 @@ export interface QueryResult {
  * These Promises will only be rejected on an I/O error or other internal
  * (unexpected) failure (e.g. failed assert) and always represent an
  * unrecoverable error (should be caught / reported by the async_queue).
+ *
+ * This methods retains one interface to help TypeScript narrow down the type.
+ * All other methods are free functions.
  */
 export interface LocalStore {
-  /**
-   * Tells the LocalStore that the currently authenticated user has changed.
-   *
-   * In response the local store switches the mutation queue to the new user and
-   * returns any resulting document changes.
-   */
-  // PORTING NOTE: Android and iOS only return the documents affected by the
-  // change.
-  handleUserChange(user: User): Promise<UserChangeResult>;
-
-  /* Accept locally generated Mutations and commit them to storage. */
-  localWrite(mutations: Mutation[]): Promise<LocalWriteResult>;
-
-  /**
-   * Acknowledge the given batch.
-   *
-   * On the happy path when a batch is acknowledged, the local store will
-   *
-   *  + remove the batch from the mutation queue;
-   *  + apply the changes to the remote document cache;
-   *  + recalculate the latency compensated view implied by those changes (there
-   *    may be mutations in the queue that affect the documents but haven't been
-   *    acknowledged yet); and
-   *  + give the changed documents back the sync engine
-   *
-   * @returns The resulting (modified) documents.
-   */
-  acknowledgeBatch(batchResult: MutationBatchResult): Promise<MaybeDocumentMap>;
-
-  /**
-   * Remove mutations from the MutationQueue for the specified batch;
-   * LocalDocuments will be recalculated.
-   *
-   * @returns The resulting modified documents.
-   */
-  rejectBatch(batchId: BatchId): Promise<MaybeDocumentMap>;
-
-  /**
-   * Returns the largest (latest) batch id in mutation queue that is pending
-   * server response.
-   *
-   * Returns `BATCHID_UNKNOWN` if the queue is empty.
-   */
-  getHighestUnacknowledgedBatchId(): Promise<BatchId>;
-
-  /**
-   * Returns the last consistent snapshot processed (used by the RemoteStore to
-   * determine whether to buffer incoming snapshots from the backend).
-   */
-  getLastRemoteSnapshotVersion(): Promise<SnapshotVersion>;
-
-  /**
-   * Update the "ground-state" (remote) documents. We assume that the remote
-   * event reflects any write batches that have been acknowledged or rejected
-   * (i.e. we do not re-apply local mutations to updates from this event).
-   *
-   * LocalDocuments are re-calculated if there are remaining mutations in the
-   * queue.
-   */
-  applyRemoteEvent(remoteEvent: RemoteEvent): Promise<MaybeDocumentMap>;
-
-  /**
-   * Notify local store of the changed views to locally pin documents.
-   */
-  notifyLocalViewChanges(viewChanges: LocalViewChanges[]): Promise<void>;
-
-  /**
-   * Gets the mutation batch after the passed in batchId in the mutation queue
-   * or null if empty.
-   * @param afterBatchId If provided, the batch to search after.
-   * @returns The next mutation or null if there wasn't one.
-   */
-  nextMutationBatch(afterBatchId?: BatchId): Promise<MutationBatch | null>;
-
-  /**
-   * Read the current value of a Document with a given key or null if not
-   * found - used for testing.
-   */
-  readDocument(key: DocumentKey): Promise<MaybeDocument | null>;
-
-  /**
-   * Assigns the given target an internal ID so that its results can be pinned so
-   * they don't get GC'd. A target must be allocated in the local store before
-   * the store can be used to manage its view.
-   *
-   * Allocating an already allocated `Target` will return the existing `TargetData`
-   * for that `Target`.
-   */
-  allocateTarget(target: Target): Promise<TargetData>;
-
-  /**
-   * Returns the TargetData as seen by the LocalStore, including updates that may
-   * have not yet been persisted to the TargetCache.
-   */
-  // Visible for testing.
-  getTargetData(
-    transaction: PersistenceTransaction,
-    target: Target
-  ): PersistencePromise<TargetData | null>;
-
-  /**
-   * Unpin all the documents associated with the given target. If
-   * `keepPersistedTargetData` is set to false and Eager GC enabled, the method
-   * directly removes the associated target data from the target cache.
-   *
-   * Releasing a non-existing `Target` is a no-op.
-   */
-  // PORTING NOTE: `keepPersistedTargetData` is multi-tab only.
-  releaseTarget(
-    targetId: number,
-    keepPersistedTargetData: boolean
-  ): Promise<void>;
-
-  /**
-   * Runs the specified query against the local store and returns the results,
-   * potentially taking advantage of query data from previous executions (such
-   * as the set of remote keys).
-   *
-   * @param usePreviousResults Whether results from previous executions can
-   * be used to optimize this query execution.
-   */
-  executeQuery(query: Query, usePreviousResults: boolean): Promise<QueryResult>;
-
   collectGarbage(garbageCollector: LruGarbageCollector): Promise<LruResults>;
 }
 
@@ -280,15 +169,6 @@ export interface LocalStore {
  * functions, such that they are tree-shakeable.
  */
 class LocalStoreImpl implements LocalStore {
-  /**
-   * The maximum time to leave a resume token buffered without writing it out.
-   * This value is arbitrary: it's long enough to avoid several writes
-   * (possibly indefinitely if updates come more frequently than this) but
-   * short enough that restarting after crashing will still have a pretty
-   * recent resume token.
-   */
-  private static readonly RESUME_TOKEN_MAX_AGE_MICROS = 5 * 60 * 1e6;
-
   /**
    * The set of all mutations that have been sent but not yet been applied to
    * the backend.
@@ -317,7 +197,7 @@ class LocalStoreImpl implements LocalStore {
 
   /** Maps a target to its targetID. */
   // TODO(wuandy): Evaluate if TargetId can be part of Target.
-  private targetIdByTarget = new ObjectMap<Target, TargetId>(
+  targetIdByTarget = new ObjectMap<Target, TargetId>(
     t => canonifyTarget(t),
     targetEquals
   );
@@ -332,7 +212,7 @@ class LocalStoreImpl implements LocalStore {
   constructor(
     /** Manages our in-memory or durable persistence. */
     readonly persistence: Persistence,
-    private queryEngine: QueryEngine,
+    readonly queryEngine: QueryEngine,
     initialUser: User
   ) {
     debugAssert(
@@ -350,91 +230,127 @@ class LocalStoreImpl implements LocalStore {
     this.queryEngine.setLocalDocumentsView(this.localDocuments);
   }
 
-  async handleUserChange(user: User): Promise<UserChangeResult> {
-    let newMutationQueue = this.mutationQueue;
-    let newLocalDocuments = this.localDocuments;
-
-    const result = await this.persistence.runTransaction(
-      'Handle user change',
-      'readonly',
-      txn => {
-        // Swap out the mutation queue, grabbing the pending mutation batches
-        // before and after.
-        let oldBatches: MutationBatch[];
-        return this.mutationQueue
-          .getAllMutationBatches(txn)
-          .next(promisedOldBatches => {
-            oldBatches = promisedOldBatches;
-
-            newMutationQueue = this.persistence.getMutationQueue(user);
-
-            // Recreate our LocalDocumentsView using the new
-            // MutationQueue.
-            newLocalDocuments = new LocalDocumentsView(
-              this.remoteDocuments,
-              newMutationQueue,
-              this.persistence.getIndexManager()
-            );
-            return newMutationQueue.getAllMutationBatches(txn);
-          })
-          .next(newBatches => {
-            const removedBatchIds: BatchId[] = [];
-            const addedBatchIds: BatchId[] = [];
-
-            // Union the old/new changed keys.
-            let changedKeys = documentKeySet();
-
-            for (const batch of oldBatches) {
-              removedBatchIds.push(batch.batchId);
-              for (const mutation of batch.mutations) {
-                changedKeys = changedKeys.add(mutation.key);
-              }
-            }
-
-            for (const batch of newBatches) {
-              addedBatchIds.push(batch.batchId);
-              for (const mutation of batch.mutations) {
-                changedKeys = changedKeys.add(mutation.key);
-              }
-            }
-
-            // Return the set of all (potentially) changed documents and the list
-            // of mutation batch IDs that were affected by change.
-            return newLocalDocuments
-              .getDocuments(txn, changedKeys)
-              .next(affectedDocuments => {
-                return {
-                  affectedDocuments,
-                  removedBatchIds,
-                  addedBatchIds
-                };
-              });
-          });
-      }
+  collectGarbage(garbageCollector: LruGarbageCollector): Promise<LruResults> {
+    return this.persistence.runTransaction(
+      'Collect garbage',
+      'readwrite-primary',
+      txn => garbageCollector.collect(txn, this.targetDataByTarget)
     );
-
-    this.mutationQueue = newMutationQueue;
-    this.localDocuments = newLocalDocuments;
-    this.queryEngine.setLocalDocumentsView(this.localDocuments);
-
-    return result;
   }
+}
 
-  localWrite(mutations: Mutation[]): Promise<LocalWriteResult> {
-    const localWriteTime = Timestamp.now();
-    const keys = mutations.reduce(
-      (keys, m) => keys.add(m.key),
-      documentKeySet()
-    );
+export function newLocalStore(
+  /** Manages our in-memory or durable persistence. */
+  persistence: Persistence,
+  queryEngine: QueryEngine,
+  initialUser: User
+): LocalStore {
+  return new LocalStoreImpl(persistence, queryEngine, initialUser);
+}
 
-    let existingDocs: MaybeDocumentMap;
+/**
+ * Tells the LocalStore that the currently authenticated user has changed.
+ *
+ * In response the local store switches the mutation queue to the new user and
+ * returns any resulting document changes.
+ */
+// PORTING NOTE: Android and iOS only return the documents affected by the
+// change.
+export async function handleUserChange(
+  localStore: LocalStore,
+  user: User
+): Promise<UserChangeResult> {
+  const localStoreImpl = debugCast(localStore, LocalStoreImpl);
+  let newMutationQueue = localStoreImpl.mutationQueue;
+  let newLocalDocuments = localStoreImpl.localDocuments;
 
-    return this.persistence
-      .runTransaction('Locally write mutations', 'readwrite', txn => {
-        // Load and apply all existing mutations. This lets us compute the
-        // current base state for all non-idempotent transforms before applying
-        // any additional user-provided writes.
-        return this.localDocuments.getDocuments(txn, keys).next(docs => {
+  const result = await localStoreImpl.persistence.runTransaction(
+    'Handle user change',
+    'readonly',
+    txn => {
+      // Swap out the mutation queue, grabbing the pending mutation batches
+      // before and after.
+      let oldBatches: MutationBatch[];
+      return localStoreImpl.mutationQueue
+        .getAllMutationBatches(txn)
+        .next(promisedOldBatches => {
+          oldBatches = promisedOldBatches;
+
+          newMutationQueue = localStoreImpl.persistence.getMutationQueue(user);
+
+          // Recreate our LocalDocumentsView using the new
+          // MutationQueue.
+          newLocalDocuments = new LocalDocumentsView(
+            localStoreImpl.remoteDocuments,
+            newMutationQueue,
+            localStoreImpl.persistence.getIndexManager()
+          );
+          return newMutationQueue.getAllMutationBatches(txn);
+        })
+        .next(newBatches => {
+          const removedBatchIds: BatchId[] = [];
+          const addedBatchIds: BatchId[] = [];
+
+          // Union the old/new changed keys.
+          let changedKeys = documentKeySet();
+
+          for (const batch of oldBatches) {
+            removedBatchIds.push(batch.batchId);
+            for (const mutation of batch.mutations) {
+              changedKeys = changedKeys.add(mutation.key);
+            }
+          }
+
+          for (const batch of newBatches) {
+            addedBatchIds.push(batch.batchId);
+            for (const mutation of batch.mutations) {
+              changedKeys = changedKeys.add(mutation.key);
+            }
+          }
+
+          // Return the set of all (potentially) changed documents and the list
+          // of mutation batch IDs that were affected by change.
+          return newLocalDocuments
+            .getDocuments(txn, changedKeys)
+            .next(affectedDocuments => {
+              return {
+                affectedDocuments,
+                removedBatchIds,
+                addedBatchIds
+              };
+            });
+        });
+    }
+  );
+
+  localStoreImpl.mutationQueue = newMutationQueue;
+  localStoreImpl.localDocuments = newLocalDocuments;
+  localStoreImpl.queryEngine.setLocalDocumentsView(
+    localStoreImpl.localDocuments
+  );
+
+  return result;
+}
+
+/* Accept locally generated Mutations and commit them to storage. */
+export function localWrite(
+  localStore: LocalStore,
+  mutations: Mutation[]
+): Promise<LocalWriteResult> {
+  const localStoreImpl = debugCast(localStore, LocalStoreImpl);
+  const localWriteTime = Timestamp.now();
+  const keys = mutations.reduce((keys, m) => keys.add(m.key), documentKeySet());
+
+  let existingDocs: MaybeDocumentMap;
+
+  return localStoreImpl.persistence
+    .runTransaction('Locally write mutations', 'readwrite', txn => {
+      // Load and apply all existing mutations. This lets us compute the
+      // current base state for all non-idempotent transforms before applying
+      // any additional user-provided writes.
+      return localStoreImpl.localDocuments
+        .getDocuments(txn, keys)
+        .next(docs => {
           existingDocs = docs;
 
           // For non-idempotent mutations (such as `FieldValue.increment()`),
@@ -464,505 +380,626 @@ class LocalStoreImpl implements LocalStore {
             }
           }
 
-          return this.mutationQueue.addMutationBatch(
+          return localStoreImpl.mutationQueue.addMutationBatch(
             txn,
             localWriteTime,
             baseMutations,
             mutations
           );
         });
-      })
-      .then(batch => {
-        const changes = batch.applyToLocalDocumentSet(existingDocs);
-        return { batchId: batch.batchId, changes };
+    })
+    .then(batch => {
+      const changes = batch.applyToLocalDocumentSet(existingDocs);
+      return { batchId: batch.batchId, changes };
+    });
+}
+
+/**
+ * Acknowledge the given batch.
+ *
+ * On the happy path when a batch is acknowledged, the local store will
+ *
+ *  + remove the batch from the mutation queue;
+ *  + apply the changes to the remote document cache;
+ *  + recalculate the latency compensated view implied by those changes (there
+ *    may be mutations in the queue that affect the documents but haven't been
+ *    acknowledged yet); and
+ *  + give the changed documents back the sync engine
+ *
+ * @returns The resulting (modified) documents.
+ */
+export function acknowledgeBatch(
+  localStore: LocalStore,
+  batchResult: MutationBatchResult
+): Promise<MaybeDocumentMap> {
+  const localStoreImpl = debugCast(localStore, LocalStoreImpl);
+  return localStoreImpl.persistence.runTransaction(
+    'Acknowledge batch',
+    'readwrite-primary',
+    txn => {
+      const affected = batchResult.batch.keys();
+      const documentBuffer = localStoreImpl.remoteDocuments.newChangeBuffer({
+        trackRemovals: true // Make sure document removals show up in `getNewDocumentChanges()`
       });
-  }
+      return applyWriteToRemoteDocuments(
+        localStoreImpl,
+        txn,
+        batchResult,
+        documentBuffer
+      )
+        .next(() => documentBuffer.apply(txn))
+        .next(() => localStoreImpl.mutationQueue.performConsistencyCheck(txn))
+        .next(() => localStoreImpl.localDocuments.getDocuments(txn, affected));
+    }
+  );
+}
 
-  acknowledgeBatch(
-    batchResult: MutationBatchResult
-  ): Promise<MaybeDocumentMap> {
-    return this.persistence.runTransaction(
-      'Acknowledge batch',
-      'readwrite-primary',
-      txn => {
-        const affected = batchResult.batch.keys();
-        const documentBuffer = this.remoteDocuments.newChangeBuffer({
-          trackRemovals: true // Make sure document removals show up in `getNewDocumentChanges()`
-        });
-        return this.applyWriteToRemoteDocuments(
-          txn,
-          batchResult,
-          documentBuffer
-        )
-          .next(() => documentBuffer.apply(txn))
-          .next(() => this.mutationQueue.performConsistencyCheck(txn))
-          .next(() => this.localDocuments.getDocuments(txn, affected));
-      }
-    );
-  }
-
-  rejectBatch(batchId: BatchId): Promise<MaybeDocumentMap> {
-    return this.persistence.runTransaction(
-      'Reject batch',
-      'readwrite-primary',
-      txn => {
-        let affectedKeys: DocumentKeySet;
-        return this.mutationQueue
-          .lookupMutationBatch(txn, batchId)
-          .next((batch: MutationBatch | null) => {
-            hardAssert(batch !== null, 'Attempt to reject nonexistent batch!');
-            affectedKeys = batch.keys();
-            return this.mutationQueue.removeMutationBatch(txn, batch);
-          })
-          .next(() => {
-            return this.mutationQueue.performConsistencyCheck(txn);
-          })
-          .next(() => {
-            return this.localDocuments.getDocuments(txn, affectedKeys);
-          });
-      }
-    );
-  }
-
-  getHighestUnacknowledgedBatchId(): Promise<BatchId> {
-    return this.persistence.runTransaction(
-      'Get highest unacknowledged batch id',
-      'readonly',
-      txn => {
-        return this.mutationQueue.getHighestUnacknowledgedBatchId(txn);
-      }
-    );
-  }
-
-  getLastRemoteSnapshotVersion(): Promise<SnapshotVersion> {
-    return this.persistence.runTransaction(
-      'Get last remote snapshot version',
-      'readonly',
-      txn => this.targetCache.getLastRemoteSnapshotVersion(txn)
-    );
-  }
-
-  applyRemoteEvent(remoteEvent: RemoteEvent): Promise<MaybeDocumentMap> {
-    const remoteVersion = remoteEvent.snapshotVersion;
-    let newTargetDataByTargetMap = this.targetDataByTarget;
-
-    return this.persistence
-      .runTransaction('Apply remote event', 'readwrite-primary', txn => {
-        const documentBuffer = this.remoteDocuments.newChangeBuffer({
-          trackRemovals: true // Make sure document removals show up in `getNewDocumentChanges()`
-        });
-
-        // Reset newTargetDataByTargetMap in case this transaction gets re-run.
-        newTargetDataByTargetMap = this.targetDataByTarget;
-
-        const promises = [] as Array<PersistencePromise<void>>;
-        remoteEvent.targetChanges.forEach((change, targetId) => {
-          const oldTargetData = newTargetDataByTargetMap.get(targetId);
-          if (!oldTargetData) {
-            return;
-          }
-
-          // Only update the remote keys if the target is still active. This
-          // ensures that we can persist the updated target data along with
-          // the updated assignment.
-          promises.push(
-            this.targetCache
-              .removeMatchingKeys(txn, change.removedDocuments, targetId)
-              .next(() => {
-                return this.targetCache.addMatchingKeys(
-                  txn,
-                  change.addedDocuments,
-                  targetId
-                );
-              })
-          );
-
-          const resumeToken = change.resumeToken;
-          // Update the resume token if the change includes one.
-          if (resumeToken.approximateByteSize() > 0) {
-            const newTargetData = oldTargetData
-              .withResumeToken(resumeToken, remoteVersion)
-              .withSequenceNumber(txn.currentSequenceNumber);
-            newTargetDataByTargetMap = newTargetDataByTargetMap.insert(
-              targetId,
-              newTargetData
-            );
-
-            // Update the target data if there are target changes (or if
-            // sufficient time has passed since the last update).
-            if (
-              LocalStoreImpl.shouldPersistTargetData(
-                oldTargetData,
-                newTargetData,
-                change
-              )
-            ) {
-              promises.push(
-                this.targetCache.updateTargetData(txn, newTargetData)
-              );
-            }
-          }
-        });
-
-        let changedDocs = maybeDocumentMap();
-        let updatedKeys = documentKeySet();
-        remoteEvent.documentUpdates.forEach((key, doc) => {
-          updatedKeys = updatedKeys.add(key);
-        });
-
-        // Each loop iteration only affects its "own" doc, so it's safe to get all the remote
-        // documents in advance in a single call.
-        promises.push(
-          documentBuffer.getEntries(txn, updatedKeys).next(existingDocs => {
-            remoteEvent.documentUpdates.forEach((key, doc) => {
-              const existingDoc = existingDocs.get(key);
-
-              // Note: The order of the steps below is important, since we want
-              // to ensure that rejected limbo resolutions (which fabricate
-              // NoDocuments with SnapshotVersion.min()) never add documents to
-              // cache.
-              if (
-                doc instanceof NoDocument &&
-                doc.version.isEqual(SnapshotVersion.min())
-              ) {
-                // NoDocuments with SnapshotVersion.min() are used in manufactured
-                // events. We remove these documents from cache since we lost
-                // access.
-                documentBuffer.removeEntry(key, remoteVersion);
-                changedDocs = changedDocs.insert(key, doc);
-              } else if (
-                existingDoc == null ||
-                doc.version.compareTo(existingDoc.version) > 0 ||
-                (doc.version.compareTo(existingDoc.version) === 0 &&
-                  existingDoc.hasPendingWrites)
-              ) {
-                debugAssert(
-                  !SnapshotVersion.min().isEqual(remoteVersion),
-                  'Cannot add a document when the remote version is zero'
-                );
-                documentBuffer.addEntry(doc, remoteVersion);
-                changedDocs = changedDocs.insert(key, doc);
-              } else {
-                logDebug(
-                  LOG_TAG,
-                  'Ignoring outdated watch update for ',
-                  key,
-                  '. Current version:',
-                  existingDoc.version,
-                  ' Watch version:',
-                  doc.version
-                );
-              }
-
-              if (remoteEvent.resolvedLimboDocuments.has(key)) {
-                promises.push(
-                  this.persistence.referenceDelegate.updateLimboDocument(
-                    txn,
-                    key
-                  )
-                );
-              }
-            });
-          })
+/**
+ * Remove mutations from the MutationQueue for the specified batch;
+ * LocalDocuments will be recalculated.
+ *
+ * @returns The resulting modified documents.
+ */
+export function rejectBatch(
+  localStore: LocalStore,
+  batchId: BatchId
+): Promise<MaybeDocumentMap> {
+  const localStoreImpl = debugCast(localStore, LocalStoreImpl);
+  return localStoreImpl.persistence.runTransaction(
+    'Reject batch',
+    'readwrite-primary',
+    txn => {
+      let affectedKeys: DocumentKeySet;
+      return localStoreImpl.mutationQueue
+        .lookupMutationBatch(txn, batchId)
+        .next((batch: MutationBatch | null) => {
+          hardAssert(batch !== null, 'Attempt to reject nonexistent batch!');
+          affectedKeys = batch.keys();
+          return localStoreImpl.mutationQueue.removeMutationBatch(txn, batch);
+        })
+        .next(() => localStoreImpl.mutationQueue.performConsistencyCheck(txn))
+        .next(() =>
+          localStoreImpl.localDocuments.getDocuments(txn, affectedKeys)
         );
+    }
+  );
+}
 
-        // HACK: The only reason we allow a null snapshot version is so that we
-        // can synthesize remote events when we get permission denied errors while
-        // trying to resolve the state of a locally cached document that is in
-        // limbo.
-        if (!remoteVersion.isEqual(SnapshotVersion.min())) {
-          const updateRemoteVersion = this.targetCache
-            .getLastRemoteSnapshotVersion(txn)
-            .next(lastRemoteSnapshotVersion => {
-              debugAssert(
-                remoteVersion.compareTo(lastRemoteSnapshotVersion) >= 0,
-                'Watch stream reverted to previous snapshot?? ' +
-                  remoteVersion +
-                  ' < ' +
-                  lastRemoteSnapshotVersion
-              );
-              return this.targetCache.setTargetsMetadata(
-                txn,
-                txn.currentSequenceNumber,
-                remoteVersion
-              );
-            });
-          promises.push(updateRemoteVersion);
+/**
+ * Returns the largest (latest) batch id in mutation queue that is pending
+ * server response.
+ *
+ * Returns `BATCHID_UNKNOWN` if the queue is empty.
+ */
+export function getHighestUnacknowledgedBatchId(
+  localStore: LocalStore
+): Promise<BatchId> {
+  const localStoreImpl = debugCast(localStore, LocalStoreImpl);
+  return localStoreImpl.persistence.runTransaction(
+    'Get highest unacknowledged batch id',
+    'readonly',
+    txn => localStoreImpl.mutationQueue.getHighestUnacknowledgedBatchId(txn)
+  );
+}
+
+/**
+ * Returns the last consistent snapshot processed (used by the RemoteStore to
+ * determine whether to buffer incoming snapshots from the backend).
+ */
+export function getLastRemoteSnapshotVersion(
+  localStore: LocalStore
+): Promise<SnapshotVersion> {
+  const localStoreImpl = debugCast(localStore, LocalStoreImpl);
+  return localStoreImpl.persistence.runTransaction(
+    'Get last remote snapshot version',
+    'readonly',
+    txn => localStoreImpl.targetCache.getLastRemoteSnapshotVersion(txn)
+  );
+}
+
+/**
+ * Update the "ground-state" (remote) documents. We assume that the remote
+ * event reflects any write batches that have been acknowledged or rejected
+ * (i.e. we do not re-apply local mutations to updates from this event).
+ *
+ * LocalDocuments are re-calculated if there are remaining mutations in the
+ * queue.
+ */
+export function applyRemoteEventToLocalCache(
+  localStore: LocalStore,
+  remoteEvent: RemoteEvent
+): Promise<MaybeDocumentMap> {
+  const localStoreImpl = debugCast(localStore, LocalStoreImpl);
+  const remoteVersion = remoteEvent.snapshotVersion;
+  let newTargetDataByTargetMap = localStoreImpl.targetDataByTarget;
+
+  return localStoreImpl.persistence
+    .runTransaction('Apply remote event', 'readwrite-primary', txn => {
+      const documentBuffer = localStoreImpl.remoteDocuments.newChangeBuffer({
+        trackRemovals: true // Make sure document removals show up in `getNewDocumentChanges()`
+      });
+
+      // Reset newTargetDataByTargetMap in case this transaction gets re-run.
+      newTargetDataByTargetMap = localStoreImpl.targetDataByTarget;
+
+      const promises = [] as Array<PersistencePromise<void>>;
+      remoteEvent.targetChanges.forEach((change, targetId) => {
+        const oldTargetData = newTargetDataByTargetMap.get(targetId);
+        if (!oldTargetData) {
+          return;
         }
 
-        return PersistencePromise.waitFor(promises)
-          .next(() => documentBuffer.apply(txn))
-          .next(() => {
-            return this.localDocuments.getLocalViewOfDocuments(
+        // Only update the remote keys if the target is still active. This
+        // ensures that we can persist the updated target data along with
+        // the updated assignment.
+        promises.push(
+          localStoreImpl.targetCache
+            .removeMatchingKeys(txn, change.removedDocuments, targetId)
+            .next(() => {
+              return localStoreImpl.targetCache.addMatchingKeys(
+                txn,
+                change.addedDocuments,
+                targetId
+              );
+            })
+        );
+
+        const resumeToken = change.resumeToken;
+        // Update the resume token if the change includes one.
+        if (resumeToken.approximateByteSize() > 0) {
+          const newTargetData = oldTargetData
+            .withResumeToken(resumeToken, remoteVersion)
+            .withSequenceNumber(txn.currentSequenceNumber);
+          newTargetDataByTargetMap = newTargetDataByTargetMap.insert(
+            targetId,
+            newTargetData
+          );
+
+          // Update the target data if there are target changes (or if
+          // sufficient time has passed since the last update).
+          if (shouldPersistTargetData(oldTargetData, newTargetData, change)) {
+            promises.push(
+              localStoreImpl.targetCache.updateTargetData(txn, newTargetData)
+            );
+          }
+        }
+      });
+
+      let changedDocs = maybeDocumentMap();
+      let updatedKeys = documentKeySet();
+      remoteEvent.documentUpdates.forEach((key, doc) => {
+        updatedKeys = updatedKeys.add(key);
+      });
+
+      // Each loop iteration only affects its "own" doc, so it's safe to get all the remote
+      // documents in advance in a single call.
+      promises.push(
+        documentBuffer.getEntries(txn, updatedKeys).next(existingDocs => {
+          remoteEvent.documentUpdates.forEach((key, doc) => {
+            const existingDoc = existingDocs.get(key);
+
+            // Note: The order of the steps below is important, since we want
+            // to ensure that rejected limbo resolutions (which fabricate
+            // NoDocuments with SnapshotVersion.min()) never add documents to
+            // cache.
+            if (
+              doc instanceof NoDocument &&
+              doc.version.isEqual(SnapshotVersion.min())
+            ) {
+              // NoDocuments with SnapshotVersion.min() are used in manufactured
+              // events. We remove these documents from cache since we lost
+              // access.
+              documentBuffer.removeEntry(key, remoteVersion);
+              changedDocs = changedDocs.insert(key, doc);
+            } else if (
+              existingDoc == null ||
+              doc.version.compareTo(existingDoc.version) > 0 ||
+              (doc.version.compareTo(existingDoc.version) === 0 &&
+                existingDoc.hasPendingWrites)
+            ) {
+              debugAssert(
+                !SnapshotVersion.min().isEqual(remoteVersion),
+                'Cannot add a document when the remote version is zero'
+              );
+              documentBuffer.addEntry(doc, remoteVersion);
+              changedDocs = changedDocs.insert(key, doc);
+            } else {
+              logDebug(
+                LOG_TAG,
+                'Ignoring outdated watch update for ',
+                key,
+                '. Current version:',
+                existingDoc.version,
+                ' Watch version:',
+                doc.version
+              );
+            }
+
+            if (remoteEvent.resolvedLimboDocuments.has(key)) {
+              promises.push(
+                localStoreImpl.persistence.referenceDelegate.updateLimboDocument(
+                  txn,
+                  key
+                )
+              );
+            }
+          });
+        })
+      );
+
+      // HACK: The only reason we allow a null snapshot version is so that we
+      // can synthesize remote events when we get permission denied errors while
+      // trying to resolve the state of a locally cached document that is in
+      // limbo.
+      if (!remoteVersion.isEqual(SnapshotVersion.min())) {
+        const updateRemoteVersion = localStoreImpl.targetCache
+          .getLastRemoteSnapshotVersion(txn)
+          .next(lastRemoteSnapshotVersion => {
+            debugAssert(
+              remoteVersion.compareTo(lastRemoteSnapshotVersion) >= 0,
+              'Watch stream reverted to previous snapshot?? ' +
+                remoteVersion +
+                ' < ' +
+                lastRemoteSnapshotVersion
+            );
+            return localStoreImpl.targetCache.setTargetsMetadata(
               txn,
-              changedDocs
+              txn.currentSequenceNumber,
+              remoteVersion
             );
           });
-      })
-      .then(changedDocs => {
-        this.targetDataByTarget = newTargetDataByTargetMap;
-        return changedDocs;
-      });
+        promises.push(updateRemoteVersion);
+      }
+
+      return PersistencePromise.waitFor(promises)
+        .next(() => documentBuffer.apply(txn))
+        .next(() => {
+          return localStoreImpl.localDocuments.getLocalViewOfDocuments(
+            txn,
+            changedDocs
+          );
+        });
+    })
+    .then(changedDocs => {
+      localStoreImpl.targetDataByTarget = newTargetDataByTargetMap;
+      return changedDocs;
+    });
+}
+
+/**
+ * Returns true if the newTargetData should be persisted during an update of
+ * an active target. TargetData should always be persisted when a target is
+ * being released and should not call this function.
+ *
+ * While the target is active, TargetData updates can be omitted when nothing
+ * about the target has changed except metadata like the resume token or
+ * snapshot version. Occasionally it's worth the extra write to prevent these
+ * values from getting too stale after a crash, but this doesn't have to be
+ * too frequent.
+ */
+function shouldPersistTargetData(
+  oldTargetData: TargetData,
+  newTargetData: TargetData,
+  change: TargetChange
+): boolean {
+  hardAssert(
+    newTargetData.resumeToken.approximateByteSize() > 0,
+    'Attempted to persist target data with no resume token'
+  );
+
+  // Always persist target data if we don't already have a resume token.
+  if (oldTargetData.resumeToken.approximateByteSize() === 0) {
+    return true;
   }
 
-  /**
-   * Returns true if the newTargetData should be persisted during an update of
-   * an active target. TargetData should always be persisted when a target is
-   * being released and should not call this function.
-   *
-   * While the target is active, TargetData updates can be omitted when nothing
-   * about the target has changed except metadata like the resume token or
-   * snapshot version. Occasionally it's worth the extra write to prevent these
-   * values from getting too stale after a crash, but this doesn't have to be
-   * too frequent.
-   */
-  private static shouldPersistTargetData(
-    oldTargetData: TargetData,
-    newTargetData: TargetData,
-    change: TargetChange
-  ): boolean {
-    hardAssert(
-      newTargetData.resumeToken.approximateByteSize() > 0,
-      'Attempted to persist target data with no resume token'
-    );
-
-    // Always persist target data if we don't already have a resume token.
-    if (oldTargetData.resumeToken.approximateByteSize() === 0) {
-      return true;
-    }
-
-    // Don't allow resume token changes to be buffered indefinitely. This
-    // allows us to be reasonably up-to-date after a crash and avoids needing
-    // to loop over all active queries on shutdown. Especially in the browser
-    // we may not get time to do anything interesting while the current tab is
-    // closing.
-    const timeDelta =
-      newTargetData.snapshotVersion.toMicroseconds() -
-      oldTargetData.snapshotVersion.toMicroseconds();
-    if (timeDelta >= this.RESUME_TOKEN_MAX_AGE_MICROS) {
-      return true;
-    }
-
-    // Otherwise if the only thing that has changed about a target is its resume
-    // token it's not worth persisting. Note that the RemoteStore keeps an
-    // in-memory view of the currently active targets which includes the current
-    // resume token, so stream failure or user changes will still use an
-    // up-to-date resume token regardless of what we do here.
-    const changes =
-      change.addedDocuments.size +
-      change.modifiedDocuments.size +
-      change.removedDocuments.size;
-    return changes > 0;
+  // Don't allow resume token changes to be buffered indefinitely. This
+  // allows us to be reasonably up-to-date after a crash and avoids needing
+  // to loop over all active queries on shutdown. Especially in the browser
+  // we may not get time to do anything interesting while the current tab is
+  // closing.
+  const timeDelta =
+    newTargetData.snapshotVersion.toMicroseconds() -
+    oldTargetData.snapshotVersion.toMicroseconds();
+  if (timeDelta >= RESUME_TOKEN_MAX_AGE_MICROS) {
+    return true;
   }
 
-  async notifyLocalViewChanges(viewChanges: LocalViewChanges[]): Promise<void> {
-    try {
-      await this.persistence.runTransaction(
-        'notifyLocalViewChanges',
-        'readwrite',
-        txn => {
-          return PersistencePromise.forEach(
-            viewChanges,
-            (viewChange: LocalViewChanges) => {
-              return PersistencePromise.forEach(
-                viewChange.addedKeys,
+  // Otherwise if the only thing that has changed about a target is its resume
+  // token it's not worth persisting. Note that the RemoteStore keeps an
+  // in-memory view of the currently active targets which includes the current
+  // resume token, so stream failure or user changes will still use an
+  // up-to-date resume token regardless of what we do here.
+  const changes =
+    change.addedDocuments.size +
+    change.modifiedDocuments.size +
+    change.removedDocuments.size;
+  return changes > 0;
+}
+
+/**
+ * Notify local store of the changed views to locally pin documents.
+ */
+export async function notifyLocalViewChanges(
+  localStore: LocalStore,
+  viewChanges: LocalViewChanges[]
+): Promise<void> {
+  const localStoreImpl = debugCast(localStore, LocalStoreImpl);
+  try {
+    await localStoreImpl.persistence.runTransaction(
+      'notifyLocalViewChanges',
+      'readwrite',
+      txn => {
+        return PersistencePromise.forEach(
+          viewChanges,
+          (viewChange: LocalViewChanges) => {
+            return PersistencePromise.forEach(
+              viewChange.addedKeys,
+              (key: DocumentKey) =>
+                localStoreImpl.persistence.referenceDelegate.addReference(
+                  txn,
+                  viewChange.targetId,
+                  key
+                )
+            ).next(() =>
+              PersistencePromise.forEach(
+                viewChange.removedKeys,
                 (key: DocumentKey) =>
-                  this.persistence.referenceDelegate.addReference(
+                  localStoreImpl.persistence.referenceDelegate.removeReference(
                     txn,
                     viewChange.targetId,
                     key
                   )
-              ).next(() =>
-                PersistencePromise.forEach(
-                  viewChange.removedKeys,
-                  (key: DocumentKey) =>
-                    this.persistence.referenceDelegate.removeReference(
-                      txn,
-                      viewChange.targetId,
-                      key
-                    )
-                )
-              );
-            }
-          );
-        }
-      );
-    } catch (e) {
-      if (isIndexedDbTransactionError(e)) {
-        // If `notifyLocalViewChanges` fails, we did not advance the sequence
-        // number for the documents that were included in this transaction.
-        // This might trigger them to be deleted earlier than they otherwise
-        // would have, but it should not invalidate the integrity of the data.
-        logDebug(LOG_TAG, 'Failed to update sequence numbers: ' + e);
-      } else {
-        throw e;
-      }
-    }
-
-    for (const viewChange of viewChanges) {
-      const targetId = viewChange.targetId;
-
-      if (!viewChange.fromCache) {
-        const targetData = this.targetDataByTarget.get(targetId);
-        debugAssert(
-          targetData !== null,
-          `Can't set limbo-free snapshot version for unknown target: ${targetId}`
-        );
-
-        // Advance the last limbo free snapshot version
-        const lastLimboFreeSnapshotVersion = targetData.snapshotVersion;
-        const updatedTargetData = targetData.withLastLimboFreeSnapshotVersion(
-          lastLimboFreeSnapshotVersion
-        );
-        this.targetDataByTarget = this.targetDataByTarget.insert(
-          targetId,
-          updatedTargetData
-        );
-      }
-    }
-  }
-
-  nextMutationBatch(afterBatchId?: BatchId): Promise<MutationBatch | null> {
-    return this.persistence.runTransaction(
-      'Get next mutation batch',
-      'readonly',
-      txn => {
-        if (afterBatchId === undefined) {
-          afterBatchId = BATCHID_UNKNOWN;
-        }
-        return this.mutationQueue.getNextMutationBatchAfterBatchId(
-          txn,
-          afterBatchId
+              )
+            );
+          }
         );
       }
     );
+  } catch (e) {
+    if (isIndexedDbTransactionError(e)) {
+      // If `notifyLocalViewChanges` fails, we did not advance the sequence
+      // number for the documents that were included in this transaction.
+      // This might trigger them to be deleted earlier than they otherwise
+      // would have, but it should not invalidate the integrity of the data.
+      logDebug(LOG_TAG, 'Failed to update sequence numbers: ' + e);
+    } else {
+      throw e;
+    }
   }
 
-  readDocument(key: DocumentKey): Promise<MaybeDocument | null> {
-    return this.persistence.runTransaction('read document', 'readonly', txn => {
-      return this.localDocuments.getDocument(txn, key);
-    });
-  }
+  for (const viewChange of viewChanges) {
+    const targetId = viewChange.targetId;
 
-  allocateTarget(target: Target): Promise<TargetData> {
-    return this.persistence
-      .runTransaction('Allocate target', 'readwrite', txn => {
-        let targetData: TargetData;
-        return this.targetCache
-          .getTargetData(txn, target)
-          .next((cached: TargetData | null) => {
-            if (cached) {
-              // This target has been listened to previously, so reuse the
-              // previous targetID.
-              // TODO(mcg): freshen last accessed date?
-              targetData = cached;
-              return PersistencePromise.resolve(targetData);
-            } else {
-              return this.targetCache.allocateTargetId(txn).next(targetId => {
+    if (!viewChange.fromCache) {
+      const targetData = localStoreImpl.targetDataByTarget.get(targetId);
+      debugAssert(
+        targetData !== null,
+        `Can't set limbo-free snapshot version for unknown target: ${targetId}`
+      );
+
+      // Advance the last limbo free snapshot version
+      const lastLimboFreeSnapshotVersion = targetData.snapshotVersion;
+      const updatedTargetData = targetData.withLastLimboFreeSnapshotVersion(
+        lastLimboFreeSnapshotVersion
+      );
+      localStoreImpl.targetDataByTarget = localStoreImpl.targetDataByTarget.insert(
+        targetId,
+        updatedTargetData
+      );
+    }
+  }
+}
+
+/**
+ * Gets the mutation batch after the passed in batchId in the mutation queue
+ * or null if empty.
+ * @param afterBatchId If provided, the batch to search after.
+ * @returns The next mutation or null if there wasn't one.
+ */
+export function nextMutationBatch(
+  localStore: LocalStore,
+  afterBatchId?: BatchId
+): Promise<MutationBatch | null> {
+  const localStoreImpl = debugCast(localStore, LocalStoreImpl);
+  return localStoreImpl.persistence.runTransaction(
+    'Get next mutation batch',
+    'readonly',
+    txn => {
+      if (afterBatchId === undefined) {
+        afterBatchId = BATCHID_UNKNOWN;
+      }
+      return localStoreImpl.mutationQueue.getNextMutationBatchAfterBatchId(
+        txn,
+        afterBatchId
+      );
+    }
+  );
+}
+
+/**
+ * Read the current value of a Document with a given key or null if not
+ * found - used for testing.
+ */
+export function readLocalDocument(
+  localStore: LocalStore,
+  key: DocumentKey
+): Promise<MaybeDocument | null> {
+  const localStoreImpl = debugCast(localStore, LocalStoreImpl);
+  return localStoreImpl.persistence.runTransaction(
+    'read document',
+    'readonly',
+    txn => localStoreImpl.localDocuments.getDocument(txn, key)
+  );
+}
+
+/**
+ * Assigns the given target an internal ID so that its results can be pinned so
+ * they don't get GC'd. A target must be allocated in the local store before
+ * the store can be used to manage its view.
+ *
+ * Allocating an already allocated `Target` will return the existing `TargetData`
+ * for that `Target`.
+ */
+export function allocateTarget(
+  localStore: LocalStore,
+  target: Target
+): Promise<TargetData> {
+  const localStoreImpl = debugCast(localStore, LocalStoreImpl);
+  return localStoreImpl.persistence
+    .runTransaction('Allocate target', 'readwrite', txn => {
+      let targetData: TargetData;
+      return localStoreImpl.targetCache
+        .getTargetData(txn, target)
+        .next((cached: TargetData | null) => {
+          if (cached) {
+            // This target has been listened to previously, so reuse the
+            // previous targetID.
+            // TODO(mcg): freshen last accessed date?
+            targetData = cached;
+            return PersistencePromise.resolve(targetData);
+          } else {
+            return localStoreImpl.targetCache
+              .allocateTargetId(txn)
+              .next(targetId => {
                 targetData = new TargetData(
                   target,
                   targetId,
                   TargetPurpose.Listen,
                   txn.currentSequenceNumber
                 );
-                return this.targetCache
+                return localStoreImpl.targetCache
                   .addTargetData(txn, targetData)
                   .next(() => targetData);
               });
-            }
-          });
-      })
-      .then(targetData => {
-        // If Multi-Tab is enabled, the existing target data may be newer than
-        // the in-memory data
-        const cachedTargetData = this.targetDataByTarget.get(
-          targetData.targetId
-        );
-        if (
-          cachedTargetData === null ||
-          targetData.snapshotVersion.compareTo(
-            cachedTargetData.snapshotVersion
-          ) > 0
-        ) {
-          this.targetDataByTarget = this.targetDataByTarget.insert(
-            targetData.targetId,
-            targetData
-          );
-          this.targetIdByTarget.set(target, targetData.targetId);
-        }
-        return targetData;
-      });
-  }
-
-  getTargetData(
-    transaction: PersistenceTransaction,
-    target: Target
-  ): PersistencePromise<TargetData | null> {
-    const targetId = this.targetIdByTarget.get(target);
-    if (targetId !== undefined) {
-      return PersistencePromise.resolve<TargetData | null>(
-        this.targetDataByTarget.get(targetId)
+          }
+        });
+    })
+    .then(targetData => {
+      // If Multi-Tab is enabled, the existing target data may be newer than
+      // the in-memory data
+      const cachedTargetData = localStoreImpl.targetDataByTarget.get(
+        targetData.targetId
       );
-    } else {
-      return this.targetCache.getTargetData(transaction, target);
-    }
-  }
+      if (
+        cachedTargetData === null ||
+        targetData.snapshotVersion.compareTo(cachedTargetData.snapshotVersion) >
+          0
+      ) {
+        localStoreImpl.targetDataByTarget = localStoreImpl.targetDataByTarget.insert(
+          targetData.targetId,
+          targetData
+        );
+        localStoreImpl.targetIdByTarget.set(target, targetData.targetId);
+      }
+      return targetData;
+    });
+}
 
-  async releaseTarget(
-    targetId: number,
-    keepPersistedTargetData: boolean
-  ): Promise<void> {
-    const targetData = this.targetDataByTarget.get(targetId);
-    debugAssert(
-      targetData !== null,
-      `Tried to release nonexistent target: ${targetId}`
+/**
+ * Returns the TargetData as seen by the LocalStore, including updates that may
+ * have not yet been persisted to the TargetCache.
+ */
+// Visible for testing.
+export function getLocalTargetData(
+  localStore: LocalStore,
+  transaction: PersistenceTransaction,
+  target: Target
+): PersistencePromise<TargetData | null> {
+  const localStoreImpl = debugCast(localStore, LocalStoreImpl);
+  const targetId = localStoreImpl.targetIdByTarget.get(target);
+  if (targetId !== undefined) {
+    return PersistencePromise.resolve<TargetData | null>(
+      localStoreImpl.targetDataByTarget.get(targetId)
     );
+  } else {
+    return localStoreImpl.targetCache.getTargetData(transaction, target);
+  }
+}
 
-    const mode = keepPersistedTargetData ? 'readwrite' : 'readwrite-primary';
+/**
+ * Unpin all the documents associated with the given target. If
+ * `keepPersistedTargetData` is set to false and Eager GC enabled, the method
+ * directly removes the associated target data from the target cache.
+ *
+ * Releasing a non-existing `Target` is a no-op.
+ */
+// PORTING NOTE: `keepPersistedTargetData` is multi-tab only.
+export async function releaseTarget(
+  localStore: LocalStore,
+  targetId: number,
+  keepPersistedTargetData: boolean
+): Promise<void> {
+  const localStoreImpl = debugCast(localStore, LocalStoreImpl);
+  const targetData = localStoreImpl.targetDataByTarget.get(targetId);
+  debugAssert(
+    targetData !== null,
+    `Tried to release nonexistent target: ${targetId}`
+  );
 
-    try {
-      if (!keepPersistedTargetData) {
-        await this.persistence.runTransaction('Release target', mode, txn => {
-          return this.persistence.referenceDelegate.removeTarget(
+  const mode = keepPersistedTargetData ? 'readwrite' : 'readwrite-primary';
+
+  try {
+    if (!keepPersistedTargetData) {
+      await localStoreImpl.persistence.runTransaction(
+        'Release target',
+        mode,
+        txn => {
+          return localStoreImpl.persistence.referenceDelegate.removeTarget(
             txn,
             targetData!
           );
-        });
-      }
-    } catch (e) {
-      if (isIndexedDbTransactionError(e)) {
-        // All `releaseTarget` does is record the final metadata state for the
-        // target, but we've been recording this periodically during target
-        // activity. If we lose this write this could cause a very slight
-        // difference in the order of target deletion during GC, but we
-        // don't define exact LRU semantics so this is acceptable.
-        logDebug(
-          LOG_TAG,
-          `Failed to update sequence numbers for target ${targetId}: ${e}`
-        );
-      } else {
-        throw e;
-      }
+        }
+      );
     }
-
-    this.targetDataByTarget = this.targetDataByTarget.remove(targetId);
-    this.targetIdByTarget.delete(targetData!.target);
+  } catch (e) {
+    if (isIndexedDbTransactionError(e)) {
+      // All `releaseTarget` does is record the final metadata state for the
+      // target, but we've been recording this periodically during target
+      // activity. If we lose this write this could cause a very slight
+      // difference in the order of target deletion during GC, but we
+      // don't define exact LRU semantics so this is acceptable.
+      logDebug(
+        LOG_TAG,
+        `Failed to update sequence numbers for target ${targetId}: ${e}`
+      );
+    } else {
+      throw e;
+    }
   }
 
-  executeQuery(
-    query: Query,
-    usePreviousResults: boolean
-  ): Promise<QueryResult> {
-    let lastLimboFreeSnapshotVersion = SnapshotVersion.min();
-    let remoteKeys = documentKeySet();
+  localStoreImpl.targetDataByTarget = localStoreImpl.targetDataByTarget.remove(
+    targetId
+  );
+  localStoreImpl.targetIdByTarget.delete(targetData!.target);
+}
 
-    return this.persistence.runTransaction('Execute query', 'readonly', txn => {
-      return this.getTargetData(txn, queryToTarget(query))
+/**
+ * Runs the specified query against the local store and returns the results,
+ * potentially taking advantage of query data from previous executions (such
+ * as the set of remote keys).
+ *
+ * @param usePreviousResults Whether results from previous executions can
+ * be used to optimize this query execution.
+ */
+export function executeQuery(
+  localStore: LocalStore,
+  query: Query,
+  usePreviousResults: boolean
+): Promise<QueryResult> {
+  const localStoreImpl = debugCast(localStore, LocalStoreImpl);
+  let lastLimboFreeSnapshotVersion = SnapshotVersion.min();
+  let remoteKeys = documentKeySet();
+
+  return localStoreImpl.persistence.runTransaction(
+    'Execute query',
+    'readonly',
+    txn => {
+      return getLocalTargetData(localStoreImpl, txn, queryToTarget(query))
         .next(targetData => {
           if (targetData) {
             lastLimboFreeSnapshotVersion =
               targetData.lastLimboFreeSnapshotVersion;
-            return this.targetCache
+            return localStoreImpl.targetCache
               .getMatchingKeysForTargetId(txn, targetData.targetId)
               .next(result => {
                 remoteKeys = result;
@@ -970,7 +1007,7 @@ class LocalStoreImpl implements LocalStore {
           }
         })
         .next(() =>
-          this.queryEngine.getDocumentsMatchingQuery(
+          localStoreImpl.queryEngine.getDocumentsMatchingQuery(
             txn,
             query,
             usePreviousResults
@@ -982,70 +1019,54 @@ class LocalStoreImpl implements LocalStore {
         .next(documents => {
           return { documents, remoteKeys };
         });
-    });
-  }
-
-  private applyWriteToRemoteDocuments(
-    txn: PersistenceTransaction,
-    batchResult: MutationBatchResult,
-    documentBuffer: RemoteDocumentChangeBuffer
-  ): PersistencePromise<void> {
-    const batch = batchResult.batch;
-    const docKeys = batch.keys();
-    let promiseChain = PersistencePromise.resolve();
-    docKeys.forEach(docKey => {
-      promiseChain = promiseChain
-        .next(() => {
-          return documentBuffer.getEntry(txn, docKey);
-        })
-        .next((remoteDoc: MaybeDocument | null) => {
-          let doc = remoteDoc;
-          const ackVersion = batchResult.docVersions.get(docKey);
-          hardAssert(
-            ackVersion !== null,
-            'ackVersions should contain every doc in the write.'
-          );
-          if (!doc || doc.version.compareTo(ackVersion!) < 0) {
-            doc = batch.applyToRemoteDocument(docKey, doc, batchResult);
-            if (!doc) {
-              debugAssert(
-                !remoteDoc,
-                'Mutation batch ' +
-                  batch +
-                  ' applied to document ' +
-                  remoteDoc +
-                  ' resulted in null'
-              );
-            } else {
-              // We use the commitVersion as the readTime rather than the
-              // document's updateTime since the updateTime is not advanced
-              // for updates that do not modify the underlying document.
-              documentBuffer.addEntry(doc, batchResult.commitVersion);
-            }
-          }
-        });
-    });
-    return promiseChain.next(() =>
-      this.mutationQueue.removeMutationBatch(txn, batch)
-    );
-  }
-
-  collectGarbage(garbageCollector: LruGarbageCollector): Promise<LruResults> {
-    return this.persistence.runTransaction(
-      'Collect garbage',
-      'readwrite-primary',
-      txn => garbageCollector.collect(txn, this.targetDataByTarget)
-    );
-  }
+    }
+  );
 }
 
-export function newLocalStore(
-  /** Manages our in-memory or durable persistence. */
-  persistence: Persistence,
-  queryEngine: QueryEngine,
-  initialUser: User
-): LocalStore {
-  return new LocalStoreImpl(persistence, queryEngine, initialUser);
+function applyWriteToRemoteDocuments(
+  localStoreImpl: LocalStoreImpl,
+  txn: PersistenceTransaction,
+  batchResult: MutationBatchResult,
+  documentBuffer: RemoteDocumentChangeBuffer
+): PersistencePromise<void> {
+  const batch = batchResult.batch;
+  const docKeys = batch.keys();
+  let promiseChain = PersistencePromise.resolve();
+  docKeys.forEach(docKey => {
+    promiseChain = promiseChain
+      .next(() => {
+        return documentBuffer.getEntry(txn, docKey);
+      })
+      .next((remoteDoc: MaybeDocument | null) => {
+        let doc = remoteDoc;
+        const ackVersion = batchResult.docVersions.get(docKey);
+        hardAssert(
+          ackVersion !== null,
+          'ackVersions should contain every doc in the write.'
+        );
+        if (!doc || doc.version.compareTo(ackVersion!) < 0) {
+          doc = batch.applyToRemoteDocument(docKey, doc, batchResult);
+          if (!doc) {
+            debugAssert(
+              !remoteDoc,
+              'Mutation batch ' +
+                batch +
+                ' applied to document ' +
+                remoteDoc +
+                ' resulted in null'
+            );
+          } else {
+            // We use the commitVersion as the readTime rather than the
+            // document's updateTime since the updateTime is not advanced
+            // for updates that do not modify the underlying document.
+            documentBuffer.addEntry(doc, batchResult.commitVersion);
+          }
+        }
+      });
+  });
+  return promiseChain.next(() =>
+    localStoreImpl.mutationQueue.removeMutationBatch(txn, batch)
+  );
 }
 
 /** Returns the local view of the documents affected by a mutation batch. */

--- a/packages/firestore/src/local/local_store.ts
+++ b/packages/firestore/src/local/local_store.ts
@@ -153,7 +153,7 @@ export interface QueryResult {
  * (unexpected) failure (e.g. failed assert) and always represent an
  * unrecoverable error (should be caught / reported by the async_queue).
  *
- * This methods retains one interface to help TypeScript narrow down the type.
+ * This interface retains one method to help TypeScript narrow down the type.
  * All other methods are free functions.
  */
 export interface LocalStore {
@@ -332,7 +332,7 @@ export async function handleUserChange(
   return result;
 }
 
-/* Accept locally generated Mutations and commit them to storage. */
+/* Accepts locally generated Mutations and commit them to storage. */
 export function localWrite(
   localStore: LocalStore,
   mutations: Mutation[]
@@ -395,7 +395,7 @@ export function localWrite(
 }
 
 /**
- * Acknowledge the given batch.
+ * Acknowledges the given batch.
  *
  * On the happy path when a batch is acknowledged, the local store will
  *
@@ -435,7 +435,7 @@ export function acknowledgeBatch(
 }
 
 /**
- * Remove mutations from the MutationQueue for the specified batch;
+ * Removes mutations from the MutationQueue for the specified batch;
  * LocalDocuments will be recalculated.
  *
  * @returns The resulting modified documents.
@@ -498,7 +498,7 @@ export function getLastRemoteSnapshotVersion(
 }
 
 /**
- * Update the "ground-state" (remote) documents. We assume that the remote
+ * Updates the "ground-state" (remote) documents. We assume that the remote
  * event reflects any write batches that have been acknowledged or rejected
  * (i.e. we do not re-apply local mutations to updates from this event).
  *
@@ -717,7 +717,7 @@ function shouldPersistTargetData(
 }
 
 /**
- * Notify local store of the changed views to locally pin documents.
+ * Notifies local store of the changed views to locally pin documents.
  */
 export async function notifyLocalViewChanges(
   localStore: LocalStore,
@@ -817,7 +817,7 @@ export function nextMutationBatch(
 }
 
 /**
- * Read the current value of a Document with a given key or null if not
+ * Reads the current value of a Document with a given key or null if not
  * found - used for testing.
  */
 export function readLocalDocument(
@@ -917,7 +917,7 @@ export function getLocalTargetData(
 }
 
 /**
- * Unpin all the documents associated with the given target. If
+ * Unpins all the documents associated with the given target. If
  * `keepPersistedTargetData` is set to false and Eager GC enabled, the method
  * directly removes the associated target data from the target cache.
  *

--- a/packages/firestore/src/remote/remote_store.ts
+++ b/packages/firestore/src/remote/remote_store.ts
@@ -17,7 +17,11 @@
 
 import { SnapshotVersion } from '../core/snapshot_version';
 import { OnlineState, TargetId } from '../core/types';
-import { LocalStore } from '../local/local_store';
+import {
+  LocalStore,
+  getLastRemoteSnapshotVersion,
+  nextMutationBatch
+} from '../local/local_store';
 import { TargetData, TargetPurpose } from '../local/target_data';
 import { MutationResult } from '../model/mutation';
 import {
@@ -438,7 +442,9 @@ export class RemoteStore implements TargetMetadataProvider {
 
     if (!snapshotVersion.isEqual(SnapshotVersion.min())) {
       try {
-        const lastRemoteSnapshotVersion = await this.localStore.getLastRemoteSnapshotVersion();
+        const lastRemoteSnapshotVersion = await getLastRemoteSnapshotVersion(
+          this.localStore
+        );
         if (snapshotVersion.compareTo(lastRemoteSnapshotVersion) >= 0) {
           // We have received a target change with a global snapshot if the snapshot
           // version is not equal to SnapshotVersion.min().
@@ -479,7 +485,7 @@ export class RemoteStore implements TargetMetadataProvider {
         // Use a simple read operation to determine if IndexedDB recovered.
         // Ideally, we would expose a health check directly on SimpleDb, but
         // RemoteStore only has access to persistence through LocalStore.
-        op = () => this.localStore.getLastRemoteSnapshotVersion();
+        op = () => getLastRemoteSnapshotVersion(this.localStore);
       }
 
       // Probe IndexedDB periodically and re-enable network
@@ -603,7 +609,8 @@ export class RemoteStore implements TargetMetadataProvider {
 
     while (this.canAddToWritePipeline()) {
       try {
-        const batch = await this.localStore.nextMutationBatch(
+        const batch = await nextMutationBatch(
+          this.localStore,
           lastBatchIdRetrieved
         );
 

--- a/packages/firestore/test/unit/local/local_store.test.ts
+++ b/packages/firestore/test/unit/local/local_store.test.ts
@@ -28,10 +28,21 @@ import { SnapshotVersion } from '../../../src/core/snapshot_version';
 import { IndexFreeQueryEngine } from '../../../src/local/index_free_query_engine';
 import { IndexedDbPersistence } from '../../../src/local/indexeddb_persistence';
 import {
+  applyRemoteEventToLocalCache,
   LocalStore,
   LocalWriteResult,
   newLocalStore,
-  synchronizeLastDocumentChangeReadTime
+  synchronizeLastDocumentChangeReadTime,
+  notifyLocalViewChanges,
+  acknowledgeBatch,
+  readLocalDocument,
+  localWrite,
+  executeQuery,
+  allocateTarget,
+  releaseTarget,
+  getLocalTargetData,
+  getHighestUnacknowledgedBatchId,
+  rejectBatch
 } from '../../../src/local/local_store';
 import { LocalViewChanges } from '../../../src/local/local_view_changes';
 import { Persistence } from '../../../src/local/persistence';
@@ -129,9 +140,7 @@ class LocalStoreTester {
     this.prepareNextStep();
 
     this.promiseChain = this.promiseChain
-      .then(() => {
-        return this.localStore.localWrite(mutations);
-      })
+      .then(() => localWrite(this.localStore, mutations))
       .then((result: LocalWriteResult) => {
         this.batches.push(
           new MutationBatch(result.batchId, Timestamp.now(), [], mutations)
@@ -145,9 +154,7 @@ class LocalStoreTester {
     this.prepareNextStep();
 
     this.promiseChain = this.promiseChain
-      .then(() => {
-        return this.localStore.applyRemoteEvent(remoteEvent);
-      })
+      .then(() => applyRemoteEventToLocalCache(this.localStore, remoteEvent))
       .then((result: MaybeDocumentMap) => {
         this.lastChanges = result;
       });
@@ -158,7 +165,7 @@ class LocalStoreTester {
     this.prepareNextStep();
 
     this.promiseChain = this.promiseChain.then(() =>
-      this.localStore.notifyLocalViewChanges([viewChanges])
+      notifyLocalViewChanges(this.localStore, [viewChanges])
     );
     return this;
   }
@@ -185,7 +192,7 @@ class LocalStoreTester {
         ];
         const write = MutationBatchResult.from(batch, ver, mutationResults);
 
-        return this.localStore.acknowledgeBatch(write);
+        return acknowledgeBatch(this.localStore, write);
       })
       .then((changes: MaybeDocumentMap) => {
         this.lastChanges = changes;
@@ -197,9 +204,7 @@ class LocalStoreTester {
     this.prepareNextStep();
 
     this.promiseChain = this.promiseChain
-      .then(() => {
-        return this.localStore.rejectBatch(this.batches.shift()!.batchId);
-      })
+      .then(() => rejectBatch(this.localStore, this.batches.shift()!.batchId))
       .then((changes: MaybeDocumentMap) => {
         this.lastChanges = changes;
       });
@@ -213,36 +218,37 @@ class LocalStoreTester {
   afterAllocatingTarget(target: Target): LocalStoreTester {
     this.prepareNextStep();
 
-    this.promiseChain = this.promiseChain.then(() => {
-      return this.localStore.allocateTarget(target).then(result => {
+    this.promiseChain = this.promiseChain.then(() =>
+      allocateTarget(this.localStore, target).then(result => {
         this.lastTargetId = result.targetId;
-      });
-    });
+      })
+    );
     return this;
   }
 
   afterReleasingTarget(targetId: number): LocalStoreTester {
     this.prepareNextStep();
 
-    this.promiseChain = this.promiseChain.then(() => {
-      return this.localStore.releaseTarget(
+    this.promiseChain = this.promiseChain.then(() =>
+      releaseTarget(
+        this.localStore,
         targetId,
         /*keepPersistedTargetData=*/ false
-      );
-    });
+      )
+    );
     return this;
   }
 
   afterExecutingQuery(query: Query): LocalStoreTester {
     this.prepareNextStep();
 
-    this.promiseChain = this.promiseChain.then(() => {
-      return this.localStore
-        .executeQuery(query, /* usePreviousResults= */ true)
-        .then(({ documents }) => {
+    this.promiseChain = this.promiseChain.then(() =>
+      executeQuery(this.localStore, query, /* usePreviousResults= */ true).then(
+        ({ documents }) => {
           this.lastChanges = documents;
-        });
-    });
+        }
+      )
+    );
     return this;
   }
 
@@ -344,7 +350,7 @@ class LocalStoreTester {
 
   toContain(doc: MaybeDocument): LocalStoreTester {
     this.promiseChain = this.promiseChain.then(() => {
-      return this.localStore.readDocument(doc.key).then(result => {
+      return readLocalDocument(this.localStore, doc.key).then(result => {
         expectEqual(
           result,
           doc,
@@ -358,11 +364,11 @@ class LocalStoreTester {
   }
 
   toNotContain(keyStr: string): LocalStoreTester {
-    this.promiseChain = this.promiseChain.then(() => {
-      return this.localStore.readDocument(key(keyStr)).then(result => {
+    this.promiseChain = this.promiseChain.then(() =>
+      readLocalDocument(this.localStore, key(keyStr)).then(result => {
         expect(result).to.be.null;
-      });
-    });
+      })
+    );
     return this;
   }
 
@@ -375,11 +381,11 @@ class LocalStoreTester {
   }
 
   toReturnHighestUnacknowledgeBatchId(expectedId: BatchId): LocalStoreTester {
-    this.promiseChain = this.promiseChain.then(() => {
-      return this.localStore.getHighestUnacknowledgedBatchId().then(actual => {
+    this.promiseChain = this.promiseChain.then(() =>
+      getHighestUnacknowledgedBatchId(this.localStore).then(actual => {
         expect(actual).to.equal(expectedId);
-      });
-    });
+      })
+    );
     return this;
   }
 
@@ -1060,14 +1066,14 @@ function genericLocalStoreTests(
 
   it('can execute document queries', () => {
     const localStore = expectLocalStore().localStore;
-    return localStore
-      .localWrite([
-        setMutation('foo/bar', { foo: 'bar' }),
-        setMutation('foo/baz', { foo: 'baz' }),
-        setMutation('foo/bar/Foo/Bar', { Foo: 'Bar' })
-      ])
+    return localWrite(localStore, [
+      setMutation('foo/bar', { foo: 'bar' }),
+      setMutation('foo/baz', { foo: 'baz' }),
+      setMutation('foo/bar/Foo/Bar', { Foo: 'Bar' })
+    ])
       .then(() => {
-        return localStore.executeQuery(
+        return executeQuery(
+          localStore,
           query('foo/bar'),
           /* usePreviousResults= */ true
         );
@@ -1080,16 +1086,16 @@ function genericLocalStoreTests(
 
   it('can execute collection queries', () => {
     const localStore = expectLocalStore().localStore;
-    return localStore
-      .localWrite([
-        setMutation('fo/bar', { fo: 'bar' }),
-        setMutation('foo/bar', { foo: 'bar' }),
-        setMutation('foo/baz', { foo: 'baz' }),
-        setMutation('foo/bar/Foo/Bar', { Foo: 'Bar' }),
-        setMutation('fooo/blah', { fooo: 'blah' })
-      ])
+    return localWrite(localStore, [
+      setMutation('fo/bar', { fo: 'bar' }),
+      setMutation('foo/bar', { foo: 'bar' }),
+      setMutation('foo/baz', { foo: 'baz' }),
+      setMutation('foo/bar/Foo/Bar', { Foo: 'Bar' }),
+      setMutation('fooo/blah', { fooo: 'blah' })
+    ])
       .then(() => {
-        return localStore.executeQuery(
+        return executeQuery(
+          localStore,
           query('foo'),
           /* usePreviousResults= */ true
         );
@@ -1103,16 +1109,19 @@ function genericLocalStoreTests(
 
   it('can execute mixed collection queries', async () => {
     const query1 = query('foo');
-    const targetData = await localStore.allocateTarget(queryToTarget(query1));
+    const targetData = await allocateTarget(localStore, queryToTarget(query1));
     expect(targetData.targetId).to.equal(2);
-    await localStore.applyRemoteEvent(
+    await applyRemoteEventToLocalCache(
+      localStore,
       docAddedRemoteEvent(doc('foo/baz', 10, { a: 'b' }), [2], [])
     );
-    await localStore.applyRemoteEvent(
+    await applyRemoteEventToLocalCache(
+      localStore,
       docUpdateRemoteEvent(doc('foo/bar', 20, { a: 'b' }), [2], [])
     );
-    await localStore.localWrite([setMutation('foo/bonk', { a: 'b' })]);
-    const { documents } = await localStore.executeQuery(
+    await localWrite(localStore, [setMutation('foo/bonk', { a: 'b' })]);
+    const { documents } = await executeQuery(
+      localStore,
       query1,
       /* usePreviousResults= */ true
     );
@@ -1165,7 +1174,7 @@ function genericLocalStoreTests(
   // eslint-disable-next-line no-restricted-properties
   (gcIsEager ? it.skip : it)('persists resume tokens', async () => {
     const query1 = query('foo/bar');
-    const targetData = await localStore.allocateTarget(queryToTarget(query1));
+    const targetData = await allocateTarget(localStore, queryToTarget(query1));
     const targetId = targetData.targetId;
     const resumeToken = byteStringFromString('abc');
     const watchChange = new WatchTargetChange(
@@ -1179,16 +1188,17 @@ function genericLocalStoreTests(
     });
     aggregator.handleTargetChange(watchChange);
     const remoteEvent = aggregator.createRemoteEvent(version(1000));
-    await localStore.applyRemoteEvent(remoteEvent);
+    await applyRemoteEventToLocalCache(localStore, remoteEvent);
 
     // Stop listening so that the query should become inactive (but persistent)
-    await localStore.releaseTarget(
+    await releaseTarget(
+      localStore,
       targetData.targetId,
       /*keepPersistedTargetData=*/ false
     );
 
     // Should come back with the same resume token
-    const targetData2 = await localStore.allocateTarget(queryToTarget(query1));
+    const targetData2 = await allocateTarget(localStore, queryToTarget(query1));
     expect(targetData2.resumeToken).to.deep.equal(resumeToken);
   });
 
@@ -1197,7 +1207,10 @@ function genericLocalStoreTests(
     'does not replace resume token with empty resume token',
     async () => {
       const query1 = query('foo/bar');
-      const targetData = await localStore.allocateTarget(queryToTarget(query1));
+      const targetData = await allocateTarget(
+        localStore,
+        queryToTarget(query1)
+      );
       const targetId = targetData.targetId;
       const resumeToken = byteStringFromString('abc');
 
@@ -1212,7 +1225,7 @@ function genericLocalStoreTests(
       });
       aggregator1.handleTargetChange(watchChange1);
       const remoteEvent1 = aggregator1.createRemoteEvent(version(1000));
-      await localStore.applyRemoteEvent(remoteEvent1);
+      await applyRemoteEventToLocalCache(localStore, remoteEvent1);
 
       const watchChange2 = new WatchTargetChange(
         WatchTargetChangeState.Current,
@@ -1225,16 +1238,18 @@ function genericLocalStoreTests(
       });
       aggregator2.handleTargetChange(watchChange2);
       const remoteEvent2 = aggregator2.createRemoteEvent(version(2000));
-      await localStore.applyRemoteEvent(remoteEvent2);
+      await applyRemoteEventToLocalCache(localStore, remoteEvent2);
 
       // Stop listening so that the query should become inactive (but persistent)
-      await localStore.releaseTarget(
+      await releaseTarget(
+        localStore,
         targetId,
         /*keepPersistedTargetData=*/ false
       );
 
       // Should come back with the same resume token
-      const targetData2 = await localStore.allocateTarget(
+      const targetData2 = await allocateTarget(
+        localStore,
         queryToTarget(query1)
       );
       expect(targetData2.resumeToken).to.deep.equal(resumeToken);
@@ -1583,10 +1598,11 @@ function genericLocalStoreTests(
 
     const target = queryToTarget(query('foo'));
 
-    const targetData = await localStore.allocateTarget(target);
+    const targetData = await allocateTarget(localStore, target);
 
     // Advance the query snapshot
-    await localStore.applyRemoteEvent(
+    await applyRemoteEventToLocalCache(
+      localStore,
       noChangeEvent(
         /* targetId= */ targetData.targetId,
         /* snapshotVersion= */ 10,
@@ -1598,7 +1614,7 @@ function genericLocalStoreTests(
     let cachedTargetData = await persistence.runTransaction(
       'getTargetData',
       'readonly',
-      txn => localStore.getTargetData(txn, target)
+      txn => getLocalTargetData(localStore, txn, target)
     );
     expect(
       cachedTargetData!.lastLimboFreeSnapshotVersion.isEqual(
@@ -1607,20 +1623,21 @@ function genericLocalStoreTests(
     ).to.be.true;
 
     // Mark the view synced, which updates the last limbo free snapshot version.
-    await localStore.notifyLocalViewChanges([
+    await notifyLocalViewChanges(localStore, [
       localViewChanges(2, /* fromCache= */ false, {})
     ]);
     cachedTargetData = await persistence.runTransaction(
       'getTargetData',
       'readonly',
-      txn => localStore.getTargetData(txn, target)
+      txn => getLocalTargetData(localStore, txn, target)
     );
     expect(cachedTargetData!.lastLimboFreeSnapshotVersion.isEqual(version(10)))
       .to.be.true;
 
     // The last limbo free snapshot version is persisted even if we release the
     // query.
-    await localStore.releaseTarget(
+    await releaseTarget(
+      localStore,
       targetData.targetId,
       /* keepPersistedTargetData= */ false
     );
@@ -1629,7 +1646,7 @@ function genericLocalStoreTests(
       cachedTargetData = await persistence.runTransaction(
         'getTargetData',
         'readonly',
-        txn => localStore.getTargetData(txn, target)
+        txn => getLocalTargetData(localStore, txn, target)
       );
       expect(
         cachedTargetData!.lastLimboFreeSnapshotVersion.isEqual(version(10))


### PR DESCRIPTION
This follows the precedent set in https://github.com/firebase/firebase-js-sdk/pull/3561 and tree-shakes all of LocalStore, making it possible to separate write and watch logic (once all PRs are merged). This diff is much easier to review in IntelliJ, as it does a better job detecting whitespace-only changes.