### PR TITLE
Fix bug in terminate()

### DIFF
--- a/packages/firestore/exp/src/api/database.ts
+++ b/packages/firestore/exp/src/api/database.ts
@@ -134,8 +134,12 @@ export class Firestore extends LiteFirestore
     debugAssert(!this._terminated, 'Cannot invoke _terminate() more than once');
     return this._queue.enqueueAndInitiateShutdown(async () => {
       await super._terminate();
-      this._credentials.removeChangeListener();
       await removeComponents(this);
+
+      // `removeChangeListener` must be called after shutting down the
+      // RemoteStore as it will prevent the RemoteStore from retrieving
+      // auth tokens.
+      this._credentials.removeChangeListener();
     });
   }
 }


### PR DESCRIPTION
Found this in https://github.com/firebase/firebase-js-sdk/blob/8a8e60ada7f012b198c2c26089daff85c8270ee2/packages/firestore/src/core/firestore_client.ts#L375
