### PR TITLE
Remove FieldFilter instanceof checks

### DIFF
--- a/packages/firestore/exp/dependencies.json
+++ b/packages/firestore/exp/dependencies.json
@@ -1013,7 +1013,6 @@
                 "applyTransformOperationToRemoteDocument",
                 "argToString",
                 "arrayEquals",
-                "arrayValueContains",
                 "asNumber",
                 "assertPresent",
                 "assertUint8ArrayAvailable",
@@ -1237,8 +1236,6 @@
             ],
             "classes": [
                 "AddedLimboDocument",
-                "ArrayContainsAnyFilter",
-                "ArrayContainsFilter",
                 "ArrayRemoveTransformOperation",
                 "ArrayUnionTransformOperation",
                 "AsyncQueue",
@@ -1268,22 +1265,17 @@
                 "ExistenceFilter",
                 "ExistenceFilterChange",
                 "ExponentialBackoff",
-                "FieldFilter",
                 "FieldMask",
                 "FieldPath",
                 "FieldPath$1",
-                "Filter",
                 "FirebaseCredentialsProvider",
                 "Firestore",
                 "Firestore$1",
                 "FirestoreError",
                 "GeoPoint",
                 "GrpcConnection",
-                "InFilter",
                 "IndexFreeQueryEngine",
                 "JsonProtoSerializer",
-                "KeyFieldFilter",
-                "KeyFieldInFilter",
                 "LLRBEmptyNode",
                 "LLRBNode",
                 "LimboResolution",
@@ -1367,7 +1359,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 220962
+        "sizeInBytes": 218141
     },
     "arrayRemove": {
         "dependencies": {
@@ -1722,7 +1714,6 @@
                 "applyTransformOperationToRemoteDocument",
                 "argToString",
                 "arrayEquals",
-                "arrayValueContains",
                 "asNumber",
                 "assertPresent",
                 "binaryStringFromUint8Array",
@@ -1917,8 +1908,6 @@
             ],
             "classes": [
                 "AddedLimboDocument",
-                "ArrayContainsAnyFilter",
-                "ArrayContainsFilter",
                 "ArrayRemoveTransformOperation",
                 "ArrayUnionTransformOperation",
                 "AsyncQueue",
@@ -1945,20 +1934,15 @@
                 "ExistenceFilter",
                 "ExistenceFilterChange",
                 "ExponentialBackoff",
-                "FieldFilter",
                 "FieldMask",
                 "FieldPath",
-                "Filter",
                 "FirebaseCredentialsProvider",
                 "Firestore",
                 "Firestore$1",
                 "FirestoreError",
                 "GrpcConnection",
-                "InFilter",
                 "IndexFreeQueryEngine",
                 "JsonProtoSerializer",
-                "KeyFieldFilter",
-                "KeyFieldInFilter",
                 "LLRBEmptyNode",
                 "LLRBNode",
                 "LimboResolution",
@@ -2037,7 +2021,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 203350
+        "sizeInBytes": 200529
     },
     "deleteField": {
         "dependencies": {
@@ -2101,7 +2085,6 @@
                 "applyTransformOperationToRemoteDocument",
                 "argToString",
                 "arrayEquals",
-                "arrayValueContains",
                 "asNumber",
                 "assertPresent",
                 "binaryStringFromUint8Array",
@@ -2297,8 +2280,6 @@
             ],
             "classes": [
                 "AddedLimboDocument",
-                "ArrayContainsAnyFilter",
-                "ArrayContainsFilter",
                 "ArrayRemoveTransformOperation",
                 "ArrayUnionTransformOperation",
                 "AsyncQueue",
@@ -2323,20 +2304,15 @@
                 "ExistenceFilter",
                 "ExistenceFilterChange",
                 "ExponentialBackoff",
-                "FieldFilter",
                 "FieldMask",
                 "FieldPath",
-                "Filter",
                 "FirebaseCredentialsProvider",
                 "Firestore",
                 "Firestore$1",
                 "FirestoreError",
                 "GrpcConnection",
-                "InFilter",
                 "IndexFreeQueryEngine",
                 "JsonProtoSerializer",
-                "KeyFieldFilter",
-                "KeyFieldInFilter",
                 "LLRBEmptyNode",
                 "LLRBNode",
                 "LimboResolution",
@@ -2415,7 +2391,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 202968
+        "sizeInBytes": 200147
     },
     "doc": {
         "dependencies": {
@@ -2887,7 +2863,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 209084
+        "sizeInBytes": 208911
     },
     "enableMultiTabIndexedDbPersistence": {
         "dependencies": {
@@ -3355,7 +3331,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 307194
+        "sizeInBytes": 307077
     },
     "enableNetwork": {
         "dependencies": {
@@ -3377,7 +3353,6 @@
                 "applyTransformOperationToRemoteDocument",
                 "argToString",
                 "arrayEquals",
-                "arrayValueContains",
                 "asNumber",
                 "assertPresent",
                 "binaryStringFromUint8Array",
@@ -3573,8 +3548,6 @@
             ],
             "classes": [
                 "AddedLimboDocument",
-                "ArrayContainsAnyFilter",
-                "ArrayContainsFilter",
                 "ArrayRemoveTransformOperation",
                 "ArrayUnionTransformOperation",
                 "AsyncQueue",
@@ -3599,20 +3572,15 @@
                 "ExistenceFilter",
                 "ExistenceFilterChange",
                 "ExponentialBackoff",
-                "FieldFilter",
                 "FieldMask",
                 "FieldPath",
-                "Filter",
                 "FirebaseCredentialsProvider",
                 "Firestore",
                 "Firestore$1",
                 "FirestoreError",
                 "GrpcConnection",
-                "InFilter",
                 "IndexFreeQueryEngine",
                 "JsonProtoSerializer",
-                "KeyFieldFilter",
-                "KeyFieldInFilter",
                 "LLRBEmptyNode",
                 "LLRBNode",
                 "LimboResolution",
@@ -3691,7 +3659,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 202965
+        "sizeInBytes": 200144
     },
     "endAt": {
         "dependencies": {
@@ -3959,7 +3927,6 @@
                 "applyTransformOperationToRemoteDocument",
                 "argToString",
                 "arrayEquals",
-                "arrayValueContains",
                 "asNumber",
                 "assertPresent",
                 "assertUint8ArrayAvailable",
@@ -4173,8 +4140,6 @@
             ],
             "classes": [
                 "AddedLimboDocument",
-                "ArrayContainsAnyFilter",
-                "ArrayContainsFilter",
                 "ArrayRemoveTransformOperation",
                 "ArrayUnionTransformOperation",
                 "AsyncObserver",
@@ -4206,23 +4171,18 @@
                 "ExistenceFilter",
                 "ExistenceFilterChange",
                 "ExponentialBackoff",
-                "FieldFilter",
                 "FieldMask",
                 "FieldPath",
                 "FieldPath$1",
                 "FieldPath$2",
-                "Filter",
                 "FirebaseCredentialsProvider",
                 "Firestore",
                 "Firestore$1",
                 "FirestoreError",
                 "GeoPoint",
                 "GrpcConnection",
-                "InFilter",
                 "IndexFreeQueryEngine",
                 "JsonProtoSerializer",
-                "KeyFieldFilter",
-                "KeyFieldInFilter",
                 "LLRBEmptyNode",
                 "LLRBNode",
                 "LimboResolution",
@@ -4306,7 +4266,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 219316
+        "sizeInBytes": 216495
     },
     "getDocFromCache": {
         "dependencies": {
@@ -4328,7 +4288,6 @@
                 "applyTransformOperationToRemoteDocument",
                 "argToString",
                 "arrayEquals",
-                "arrayValueContains",
                 "asNumber",
                 "assertUint8ArrayAvailable",
                 "binaryStringFromUint8Array",
@@ -4399,10 +4358,8 @@
                 "isIndexedDbTransactionError",
                 "isInteger",
                 "isMapValue",
-                "isNanValue",
                 "isNegativeZero",
                 "isNullOrUndefined",
-                "isNullValue",
                 "isNumber",
                 "isPlainObject",
                 "isServerTimestamp",
@@ -4469,8 +4426,6 @@
                 "wrapInUserErrorIfRecoverable"
             ],
             "classes": [
-                "ArrayContainsAnyFilter",
-                "ArrayContainsFilter",
                 "ArrayRemoveTransformOperation",
                 "ArrayUnionTransformOperation",
                 "AsyncQueue",
@@ -4492,21 +4447,16 @@
                 "DocumentSnapshot",
                 "DocumentSnapshot$1",
                 "ExponentialBackoff",
-                "FieldFilter",
                 "FieldMask",
                 "FieldPath",
                 "FieldPath$1",
                 "FieldPath$2",
-                "Filter",
                 "FirebaseCredentialsProvider",
                 "Firestore",
                 "Firestore$1",
                 "FirestoreError",
                 "GeoPoint",
-                "InFilter",
                 "IndexFreeQueryEngine",
-                "KeyFieldFilter",
-                "KeyFieldInFilter",
                 "LLRBEmptyNode",
                 "LLRBNode",
                 "ListenSequence",
@@ -4563,7 +4513,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 134557
+        "sizeInBytes": 131638
     },
     "getDocFromServer": {
         "dependencies": {
@@ -4585,7 +4535,6 @@
                 "applyTransformOperationToRemoteDocument",
                 "argToString",
                 "arrayEquals",
-                "arrayValueContains",
                 "asNumber",
                 "assertPresent",
                 "assertUint8ArrayAvailable",
@@ -4799,8 +4748,6 @@
             ],
             "classes": [
                 "AddedLimboDocument",
-                "ArrayContainsAnyFilter",
-                "ArrayContainsFilter",
                 "ArrayRemoveTransformOperation",
                 "ArrayUnionTransformOperation",
                 "AsyncObserver",
@@ -4832,23 +4779,18 @@
                 "ExistenceFilter",
                 "ExistenceFilterChange",
                 "ExponentialBackoff",
-                "FieldFilter",
                 "FieldMask",
                 "FieldPath",
                 "FieldPath$1",
                 "FieldPath$2",
-                "Filter",
                 "FirebaseCredentialsProvider",
                 "Firestore",
                 "Firestore$1",
                 "FirestoreError",
                 "GeoPoint",
                 "GrpcConnection",
-                "InFilter",
                 "IndexFreeQueryEngine",
                 "JsonProtoSerializer",
-                "KeyFieldFilter",
-                "KeyFieldInFilter",
                 "LLRBEmptyNode",
                 "LLRBNode",
                 "LimboResolution",
@@ -4932,7 +4874,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 219372
+        "sizeInBytes": 216551
     },
     "getDocs": {
         "dependencies": {
@@ -4954,7 +4896,6 @@
                 "applyTransformOperationToRemoteDocument",
                 "argToString",
                 "arrayEquals",
-                "arrayValueContains",
                 "asNumber",
                 "assertPresent",
                 "assertUint8ArrayAvailable",
@@ -5170,8 +5111,6 @@
             ],
             "classes": [
                 "AddedLimboDocument",
-                "ArrayContainsAnyFilter",
-                "ArrayContainsFilter",
                 "ArrayRemoveTransformOperation",
                 "ArrayUnionTransformOperation",
                 "AsyncObserver",
@@ -5203,23 +5142,18 @@
                 "ExistenceFilter",
                 "ExistenceFilterChange",
                 "ExponentialBackoff",
-                "FieldFilter",
                 "FieldMask",
                 "FieldPath",
                 "FieldPath$1",
                 "FieldPath$2",
-                "Filter",
                 "FirebaseCredentialsProvider",
                 "Firestore",
                 "Firestore$1",
                 "FirestoreError",
                 "GeoPoint",
                 "GrpcConnection",
-                "InFilter",
                 "IndexFreeQueryEngine",
                 "JsonProtoSerializer",
-                "KeyFieldFilter",
-                "KeyFieldInFilter",
                 "LLRBEmptyNode",
                 "LLRBNode",
                 "LimboResolution",
@@ -5305,7 +5239,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 221879
+        "sizeInBytes": 219058
     },
     "getDocsFromCache": {
         "dependencies": {
@@ -5327,7 +5261,6 @@
                 "applyTransformOperationToRemoteDocument",
                 "argToString",
                 "arrayEquals",
-                "arrayValueContains",
                 "asNumber",
                 "assertUint8ArrayAvailable",
                 "binaryStringFromUint8Array",
@@ -5400,10 +5333,8 @@
                 "isIndexedDbTransactionError",
                 "isInteger",
                 "isMapValue",
-                "isNanValue",
                 "isNegativeZero",
                 "isNullOrUndefined",
-                "isNullValue",
                 "isNumber",
                 "isPlainObject",
                 "isServerTimestamp",
@@ -5473,8 +5404,6 @@
             ],
             "classes": [
                 "AddedLimboDocument",
-                "ArrayContainsAnyFilter",
-                "ArrayContainsFilter",
                 "ArrayRemoveTransformOperation",
                 "ArrayUnionTransformOperation",
                 "AsyncQueue",
@@ -5498,21 +5427,16 @@
                 "DocumentSnapshot",
                 "DocumentSnapshot$1",
                 "ExponentialBackoff",
-                "FieldFilter",
                 "FieldMask",
                 "FieldPath",
                 "FieldPath$1",
                 "FieldPath$2",
-                "Filter",
                 "FirebaseCredentialsProvider",
                 "Firestore",
                 "Firestore$1",
                 "FirestoreError",
                 "GeoPoint",
-                "InFilter",
                 "IndexFreeQueryEngine",
-                "KeyFieldFilter",
-                "KeyFieldInFilter",
                 "LLRBEmptyNode",
                 "LLRBNode",
                 "ListenSequence",
@@ -5574,7 +5498,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 146808
+        "sizeInBytes": 143889
     },
     "getDocsFromServer": {
         "dependencies": {
@@ -5596,7 +5520,6 @@
                 "applyTransformOperationToRemoteDocument",
                 "argToString",
                 "arrayEquals",
-                "arrayValueContains",
                 "asNumber",
                 "assertPresent",
                 "assertUint8ArrayAvailable",
@@ -5811,8 +5734,6 @@
             ],
             "classes": [
                 "AddedLimboDocument",
-                "ArrayContainsAnyFilter",
-                "ArrayContainsFilter",
                 "ArrayRemoveTransformOperation",
                 "ArrayUnionTransformOperation",
                 "AsyncObserver",
@@ -5844,23 +5765,18 @@
                 "ExistenceFilter",
                 "ExistenceFilterChange",
                 "ExponentialBackoff",
-                "FieldFilter",
                 "FieldMask",
                 "FieldPath",
                 "FieldPath$1",
                 "FieldPath$2",
-                "Filter",
                 "FirebaseCredentialsProvider",
                 "Firestore",
                 "Firestore$1",
                 "FirestoreError",
                 "GeoPoint",
                 "GrpcConnection",
-                "InFilter",
                 "IndexFreeQueryEngine",
                 "JsonProtoSerializer",
-                "KeyFieldFilter",
-                "KeyFieldInFilter",
                 "LLRBEmptyNode",
                 "LLRBNode",
                 "LimboResolution",
@@ -5946,7 +5862,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 221617
+        "sizeInBytes": 218796
     },
     "getFirestore": {
         "dependencies": {
@@ -6187,7 +6103,6 @@
                 "applyTransformOperationToRemoteDocument",
                 "argToString",
                 "arrayEquals",
-                "arrayValueContains",
                 "asNumber",
                 "assertPresent",
                 "assertUint8ArrayAvailable",
@@ -6405,8 +6320,6 @@
             ],
             "classes": [
                 "AddedLimboDocument",
-                "ArrayContainsAnyFilter",
-                "ArrayContainsFilter",
                 "ArrayRemoveTransformOperation",
                 "ArrayUnionTransformOperation",
                 "AsyncObserver",
@@ -6438,23 +6351,18 @@
                 "ExistenceFilter",
                 "ExistenceFilterChange",
                 "ExponentialBackoff",
-                "FieldFilter",
                 "FieldMask",
                 "FieldPath",
                 "FieldPath$1",
                 "FieldPath$2",
-                "Filter",
                 "FirebaseCredentialsProvider",
                 "Firestore",
                 "Firestore$1",
                 "FirestoreError",
                 "GeoPoint",
                 "GrpcConnection",
-                "InFilter",
                 "IndexFreeQueryEngine",
                 "JsonProtoSerializer",
-                "KeyFieldFilter",
-                "KeyFieldInFilter",
                 "LLRBEmptyNode",
                 "LLRBNode",
                 "LimboResolution",
@@ -6540,7 +6448,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 222962
+        "sizeInBytes": 220141
     },
     "onSnapshotsInSync": {
         "dependencies": {
@@ -6562,7 +6470,6 @@
                 "applyTransformOperationToRemoteDocument",
                 "argToString",
                 "arrayEquals",
-                "arrayValueContains",
                 "asNumber",
                 "assertPresent",
                 "binaryStringFromUint8Array",
@@ -6759,8 +6666,6 @@
             ],
             "classes": [
                 "AddedLimboDocument",
-                "ArrayContainsAnyFilter",
-                "ArrayContainsFilter",
                 "ArrayRemoveTransformOperation",
                 "ArrayUnionTransformOperation",
                 "AsyncObserver",
@@ -6786,20 +6691,15 @@
                 "ExistenceFilter",
                 "ExistenceFilterChange",
                 "ExponentialBackoff",
-                "FieldFilter",
                 "FieldMask",
                 "FieldPath",
-                "Filter",
                 "FirebaseCredentialsProvider",
                 "Firestore",
                 "Firestore$1",
                 "FirestoreError",
                 "GrpcConnection",
-                "InFilter",
                 "IndexFreeQueryEngine",
                 "JsonProtoSerializer",
-                "KeyFieldFilter",
-                "KeyFieldInFilter",
                 "LLRBEmptyNode",
                 "LLRBNode",
                 "LimboResolution",
@@ -6878,7 +6778,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 203814
+        "sizeInBytes": 200993
     },
     "orderBy": {
         "dependencies": {
@@ -7042,18 +6942,10 @@
             "functions": [
                 "argToString",
                 "arrayEquals",
-                "arrayValueContains",
                 "binaryStringFromUint8Array",
                 "blobEquals",
                 "boundEquals",
                 "cast",
-                "compareArrays",
-                "compareBlobs",
-                "compareGeoPoints",
-                "compareMaps",
-                "compareNumbers",
-                "compareReferences",
-                "compareTimestamps",
                 "decodeBase64",
                 "encodeBase64",
                 "fail",
@@ -7064,12 +6956,9 @@
                 "getMessageOrStack",
                 "getWindow",
                 "hardAssert",
-                "isArray",
                 "isIndexedDbTransactionError",
-                "isNanValue",
                 "isNegativeZero",
                 "isNullOrUndefined",
-                "isNullValue",
                 "isServerTimestamp",
                 "logDebug",
                 "logError",
@@ -7094,12 +6983,9 @@
                 "timestampEquals",
                 "typeOrder",
                 "uint8ArrayFromBinaryString",
-                "valueCompare",
                 "valueEquals"
             ],
             "classes": [
-                "ArrayContainsAnyFilter",
-                "ArrayContainsFilter",
                 "AsyncQueue",
                 "AutoId",
                 "BasePath",
@@ -7109,30 +6995,23 @@
                 "DatabaseInfo",
                 "Deferred",
                 "DelayedOperation",
-                "DocumentKey",
                 "ExponentialBackoff",
-                "FieldFilter",
                 "FieldPath",
-                "Filter",
                 "FirebaseCredentialsProvider",
                 "Firestore",
                 "Firestore$1",
                 "FirestoreError",
-                "InFilter",
-                "KeyFieldFilter",
-                "KeyFieldInFilter",
                 "OAuthToken",
                 "OrderBy",
                 "Query",
                 "QueryImpl",
-                "ResourcePath",
                 "TargetImpl",
                 "Timestamp",
                 "User"
             ],
             "variables": []
         },
-        "sizeInBytes": 40888
+        "sizeInBytes": 33485
     },
     "refEqual": {
         "dependencies": {
@@ -7435,7 +7314,6 @@
                 "applyTransformOperationToRemoteDocument",
                 "argToString",
                 "arrayEquals",
-                "arrayValueContains",
                 "asNumber",
                 "assertPresent",
                 "assertUint8ArrayAvailable",
@@ -7658,8 +7536,6 @@
             ],
             "classes": [
                 "AddedLimboDocument",
-                "ArrayContainsAnyFilter",
-                "ArrayContainsFilter",
                 "ArrayRemoveTransformOperation",
                 "ArrayUnionTransformOperation",
                 "AsyncQueue",
@@ -7688,22 +7564,17 @@
                 "ExistenceFilter",
                 "ExistenceFilterChange",
                 "ExponentialBackoff",
-                "FieldFilter",
                 "FieldMask",
                 "FieldPath",
                 "FieldPath$1",
-                "Filter",
                 "FirebaseCredentialsProvider",
                 "Firestore",
                 "Firestore$1",
                 "FirestoreError",
                 "GeoPoint",
                 "GrpcConnection",
-                "InFilter",
                 "IndexFreeQueryEngine",
                 "JsonProtoSerializer",
-                "KeyFieldFilter",
-                "KeyFieldInFilter",
                 "LLRBEmptyNode",
                 "LLRBNode",
                 "LimboResolution",
@@ -7786,7 +7657,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 219244
+        "sizeInBytes": 216423
     },
     "setLogLevel": {
         "dependencies": {
@@ -7831,20 +7702,12 @@
             "functions": [
                 "argToString",
                 "arrayEquals",
-                "arrayValueContains",
                 "assertUint8ArrayAvailable",
                 "binaryStringFromUint8Array",
                 "blobEquals",
                 "boundEquals",
                 "cast",
                 "changesFromSnapshot",
-                "compareArrays",
-                "compareBlobs",
-                "compareGeoPoints",
-                "compareMaps",
-                "compareNumbers",
-                "compareReferences",
-                "compareTimestamps",
                 "createError",
                 "decodeBase64",
                 "encodeBase64",
@@ -7864,12 +7727,9 @@
                 "getWindow",
                 "hardAssert",
                 "invalidClassError",
-                "isArray",
                 "isIndexedDbTransactionError",
-                "isNanValue",
                 "isNegativeZero",
                 "isNullOrUndefined",
-                "isNullValue",
                 "isPlainObject",
                 "isServerTimestamp",
                 "isValidResourceName",
@@ -7904,13 +7764,10 @@
                 "validateExactNumberOfArgs",
                 "validateNamedArrayAtLeastNumberOfElements",
                 "validateType",
-                "valueCompare",
                 "valueDescription",
                 "valueEquals"
             ],
             "classes": [
-                "ArrayContainsAnyFilter",
-                "ArrayContainsFilter",
                 "AsyncQueue",
                 "AutoId",
                 "BaseFieldPath",
@@ -7928,19 +7785,14 @@
                 "DocumentSnapshot",
                 "DocumentSnapshot$1",
                 "ExponentialBackoff",
-                "FieldFilter",
                 "FieldPath",
                 "FieldPath$1",
                 "FieldPath$2",
-                "Filter",
                 "FirebaseCredentialsProvider",
                 "Firestore",
                 "Firestore$1",
                 "FirestoreError",
                 "GeoPoint",
-                "InFilter",
-                "KeyFieldFilter",
-                "KeyFieldInFilter",
                 "OAuthToken",
                 "OrderBy",
                 "Query",
@@ -7957,7 +7809,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 57219
+        "sizeInBytes": 50917
     },
     "startAfter": {
         "dependencies": {
@@ -8264,7 +8116,6 @@
                 "applyTransformOperationToRemoteDocument",
                 "argToString",
                 "arrayEquals",
-                "arrayValueContains",
                 "asNumber",
                 "assertPresent",
                 "assertUint8ArrayAvailable",
@@ -8489,8 +8340,6 @@
             ],
             "classes": [
                 "AddedLimboDocument",
-                "ArrayContainsAnyFilter",
-                "ArrayContainsFilter",
                 "ArrayRemoveTransformOperation",
                 "ArrayUnionTransformOperation",
                 "AsyncQueue",
@@ -8520,23 +8369,18 @@
                 "ExistenceFilter",
                 "ExistenceFilterChange",
                 "ExponentialBackoff",
-                "FieldFilter",
                 "FieldMask",
                 "FieldPath",
                 "FieldPath$1",
                 "FieldPath$2",
-                "Filter",
                 "FirebaseCredentialsProvider",
                 "Firestore",
                 "Firestore$1",
                 "FirestoreError",
                 "GeoPoint",
                 "GrpcConnection",
-                "InFilter",
                 "IndexFreeQueryEngine",
                 "JsonProtoSerializer",
-                "KeyFieldFilter",
-                "KeyFieldInFilter",
                 "LLRBEmptyNode",
                 "LLRBNode",
                 "LimboResolution",
@@ -8619,7 +8463,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 220743
+        "sizeInBytes": 217922
     },
     "waitForPendingWrites": {
         "dependencies": {
@@ -8641,7 +8485,6 @@
                 "applyTransformOperationToRemoteDocument",
                 "argToString",
                 "arrayEquals",
-                "arrayValueContains",
                 "asNumber",
                 "assertPresent",
                 "binaryStringFromUint8Array",
@@ -8836,8 +8679,6 @@
             ],
             "classes": [
                 "AddedLimboDocument",
-                "ArrayContainsAnyFilter",
-                "ArrayContainsFilter",
                 "ArrayRemoveTransformOperation",
                 "ArrayUnionTransformOperation",
                 "AsyncQueue",
@@ -8862,20 +8703,15 @@
                 "ExistenceFilter",
                 "ExistenceFilterChange",
                 "ExponentialBackoff",
-                "FieldFilter",
                 "FieldMask",
                 "FieldPath",
-                "Filter",
                 "FirebaseCredentialsProvider",
                 "Firestore",
                 "Firestore$1",
                 "FirestoreError",
                 "GrpcConnection",
-                "InFilter",
                 "IndexFreeQueryEngine",
                 "JsonProtoSerializer",
-                "KeyFieldFilter",
-                "KeyFieldInFilter",
                 "LLRBEmptyNode",
                 "LLRBNode",
                 "LimboResolution",
@@ -8954,7 +8790,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 202757
+        "sizeInBytes": 199936
     },
     "where": {
         "dependencies": {
@@ -9097,7 +8933,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 58576
+        "sizeInBytes": 58541
     },
     "writeBatch": {
         "dependencies": {
@@ -9120,7 +8956,6 @@
                 "applyTransformOperationToRemoteDocument",
                 "argToString",
                 "arrayEquals",
-                "arrayValueContains",
                 "asNumber",
                 "assertPresent",
                 "assertUint8ArrayAvailable",
@@ -9347,8 +9182,6 @@
             ],
             "classes": [
                 "AddedLimboDocument",
-                "ArrayContainsAnyFilter",
-                "ArrayContainsFilter",
                 "ArrayRemoveTransformOperation",
                 "ArrayUnionTransformOperation",
                 "AsyncQueue",
@@ -9378,23 +9211,18 @@
                 "ExistenceFilter",
                 "ExistenceFilterChange",
                 "ExponentialBackoff",
-                "FieldFilter",
                 "FieldMask",
                 "FieldPath",
                 "FieldPath$1",
                 "FieldPath$2",
-                "Filter",
                 "FirebaseCredentialsProvider",
                 "Firestore",
                 "Firestore$1",
                 "FirestoreError",
                 "GeoPoint",
                 "GrpcConnection",
-                "InFilter",
                 "IndexFreeQueryEngine",
                 "JsonProtoSerializer",
-                "KeyFieldFilter",
-                "KeyFieldInFilter",
                 "LLRBEmptyNode",
                 "LLRBNode",
                 "LimboResolution",
@@ -9479,6 +9307,6 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 224410
+        "sizeInBytes": 221589
     }
 }

--- a/packages/firestore/src/core/query.ts
+++ b/packages/firestore/src/core/query.ts
@@ -699,9 +699,12 @@ export function canonifyFilter(filter: Filter): string {
 }
 
 export function filterEquals(f1: Filter, f2: Filter): boolean {
+  debugAssert(
+    f1 instanceof FieldFilter && f2 instanceof FieldFilter,
+    'Only FieldFilters can be compared'
+  );
+
   return (
-    f1 instanceof FieldFilter &&
-    f2 instanceof FieldFilter &&
     f1.op === f2.op &&
     f1.field.isEqual(f2.field) &&
     valueEquals(f1.value, f2.value)

--- a/packages/firestore/src/remote/serializer.ts
+++ b/packages/firestore/src/remote/serializer.ts
@@ -982,11 +982,11 @@ function toFilter(filters: Filter[]): api.Filter | undefined {
     return;
   }
   const protos = filters.map(filter => {
-    if (filter instanceof FieldFilter) {
-      return toUnaryOrFieldFilter(filter);
-    } else {
-      return fail('Unrecognized filter: ' + JSON.stringify(filter));
-    }
+    debugAssert(
+      filter instanceof FieldFilter,
+      'Only FieldFilters are supported'
+    );
+    return toUnaryOrFieldFilter(filter);
   });
   if (protos.length === 1) {
     return protos[0];


### PR DESCRIPTION
The SDK is meant to support different kind of Filters in the future, but for now only FieldFilters are supported. This is ensured via instanceof checks. These pull in the whole prototype and can be expensive in terms of code size. This PR mitigates some of that.