### PR TITLE
Browser Extension Check for Analytics Module

### DIFF
--- a/.changeset/spicy-masks-sort.md
+++ b/.changeset/spicy-masks-sort.md
@@ -1,5 +1,5 @@
 ---
-"@firebase/analytics": minor
+"@firebase/analytics": patch 
 ---
 
 Browser Extension Check for Analytics Module

--- a/.changeset/spicy-masks-sort.md
+++ b/.changeset/spicy-masks-sort.md
@@ -1,5 +1,6 @@
 ---
+"@firebase/firebase": patch
 "@firebase/analytics": patch 
 ---
 
-Browser Extension Check for Analytics Module
+Added Browser Extension check for Firebase Analytics. analytics.isSupported() will now return Promise<false> for extension environments. 

--- a/packages/analytics/index.ts
+++ b/packages/analytics/index.ts
@@ -35,7 +35,8 @@ import { ERROR_FACTORY, AnalyticsError } from './src/errors';
 import {
   isIndexedDBAvailable,
   validateIndexedDBOpenable,
-  areCookiesEnabled
+  areCookiesEnabled,
+  isBrowserExtension
 } from '@firebase/util';
 import { name, version } from './package.json';
 
@@ -109,19 +110,25 @@ declare module '@firebase/app-types' {
 }
 
 /**
- * this is a public static method provided to users that wraps three different checks:
+ * this is a public static method provided to users that wraps four different checks:
  *
+ * 1. check if it's not a browser extension environment.
  * 1. check if cookie is enabled in current browser.
- * 2. check if IndexedDB is supported by the browser environment.
- * 3. check if the current browser context is valid for using IndexedDB.
+ * 3. check if IndexedDB is supported by the browser environment.
+ * 4. check if the current browser context is valid for using IndexedDB.
+ *
  */
 async function isSupported(): Promise<boolean> {
+  if (isBrowserExtension()) {
+    return false;
+  }
   if (!areCookiesEnabled()) {
     return false;
   }
   if (!isIndexedDBAvailable()) {
     return false;
   }
+
   try {
     const isDBOpenable: boolean = await validateIndexedDBOpenable();
     return isDBOpenable;

--- a/packages/analytics/src/errors.ts
+++ b/packages/analytics/src/errors.ts
@@ -25,7 +25,8 @@ export const enum AnalyticsError {
   INTEROP_COMPONENT_REG_FAILED = 'interop-component-reg-failed',
   INDEXED_DB_UNSUPPORTED = 'indexedDB-unsupported',
   INVALID_INDEXED_DB_CONTEXT = 'invalid-indexedDB-context',
-  COOKIES_NOT_ENABLED = 'cookies-not-enabled'
+  COOKIES_NOT_ENABLED = 'cookies-not-enabled',
+  INVALID_ANALYTICS_CONTEXT = 'invalid-analytics-context'
 }
 
 const ERRORS: ErrorMap<AnalyticsError> = {
@@ -50,7 +51,9 @@ const ERRORS: ErrorMap<AnalyticsError> = {
     'Wrap initialization of analytics in analytics.isSupported() ' +
     'to prevent initialization in unsupported environments',
   [AnalyticsError.COOKIES_NOT_ENABLED]:
-    'Cookies are not enabled in this browser environment. Analytics requires cookies to be enabled.'
+    'Cookies are not enabled in this browser environment. Analytics requires cookies to be enabled.',
+  [AnalyticsError.INVALID_ANALYTICS_CONTEXT]:
+    'Analytics module is not supported in browser extensions environemnt.'
 };
 
 interface ErrorParams {

--- a/packages/analytics/src/errors.ts
+++ b/packages/analytics/src/errors.ts
@@ -53,7 +53,7 @@ const ERRORS: ErrorMap<AnalyticsError> = {
   [AnalyticsError.COOKIES_NOT_ENABLED]:
     'Cookies are not enabled in this browser environment. Analytics requires cookies to be enabled.',
   [AnalyticsError.INVALID_ANALYTICS_CONTEXT]:
-    'Analytics module is not supported in browser extensions environemnt.'
+    'Firebase Analytics is not supported in browser extensions.'
 };
 
 interface ErrorParams {

--- a/packages/analytics/src/factory.ts
+++ b/packages/analytics/src/factory.ts
@@ -41,7 +41,10 @@ import { FirebaseInstallations } from '@firebase/installations-types';
 import {
   isIndexedDBAvailable,
   validateIndexedDBOpenable,
-  areCookiesEnabled
+  areCookiesEnabled,
+  isBrowser,
+  ErrorFactory,
+  isBrowserExtension
 } from '@firebase/util';
 
 /**
@@ -122,6 +125,9 @@ export function factory(
   app: FirebaseApp,
   installations: FirebaseInstallations
 ): FirebaseAnalytics {
+  if (isBrowserExtension()) {
+    throw ERROR_FACTORY.create(AnalyticsError.INVALID_ANALYTICS_CONTEXT);
+  }
   if (!areCookiesEnabled()) {
     throw ERROR_FACTORY.create(AnalyticsError.COOKIES_NOT_ENABLED);
   }

--- a/packages/analytics/src/factory.ts
+++ b/packages/analytics/src/factory.ts
@@ -42,8 +42,6 @@ import {
   isIndexedDBAvailable,
   validateIndexedDBOpenable,
   areCookiesEnabled,
-  isBrowser,
-  ErrorFactory,
   isBrowserExtension
 } from '@firebase/util';
 


### PR DESCRIPTION
added browser extension check to analytics module; prevent initialization if not in a browser context. 