### PR TITLE
Fix bug in AsyncQueue visibility handler

### DIFF
--- a/.changeset/tidy-elephants-beam.md
+++ b/.changeset/tidy-elephants-beam.md
@@ -1,0 +1,5 @@
+---
+"@firebase/firestore": patch
+---
+
+Fixed a bug that caused slow retries for IndexedDB operations even when a webpage re-entered the foreground.

--- a/packages/firestore/src/local/indexeddb_persistence.ts
+++ b/packages/firestore/src/local/indexeddb_persistence.ts
@@ -294,8 +294,8 @@ export class IndexedDbPersistence implements Persistence {
     debugAssert(!this.started, 'IndexedDbPersistence double-started!');
     debugAssert(this.window !== null, "Expected 'window' to be defined");
 
-    // NOTE: This is expected to fail sometimes (in the case of another tab 
-    // already having the persistence lock), so it's the first thing we should 
+    // NOTE: This is expected to fail sometimes (in the case of another tab
+    // already having the persistence lock), so it's the first thing we should
     // do.
     return this.updateClientMetadataAndTryBecomePrimary()
       .then(() => {


### PR DESCRIPTION
I wanted to add logging for the visibility handler in AsyncQueue, which is good because it made me realize that I attached the visibility handler to the wrong object.