### PR TITLE
Address 'calling shutdown of undefined' warning

### DIFF
--- a/packages/firestore/test/unit/local/lru_garbage_collector.test.ts
+++ b/packages/firestore/test/unit/local/lru_garbage_collector.test.ts
@@ -104,12 +104,12 @@ function genericLruGarbageCollectorTests(
   async function initializeTestResources(
     params: LruParams = LruParams.DEFAULT
   ): Promise<void> {
-    if (persistence && persistence.started) {
-      await queue.enqueue(async () => {
+    await queue.enqueue(async () => {
+      if (persistence && persistence.started) {
         await persistence.shutdown();
         await PersistenceTestHelpers.clearTestPersistence();
-      });
-    }
+      }
+    });
     lruParams = params;
     persistence = await newPersistence(params, queue);
     targetCache = persistence.getTargetCache();


### PR DESCRIPTION
Something I noticed in a bunch of CI runs.
```
@firebase/firestore:     at http://localhost:8090/base/test/unit/bootstrap.js?26216e70590197792d0407ed7a3d00fec98dcefc:42468:89
@firebase/firestore:     at http://localhost:8090/base/test/unit/bootstrap.js?26216e70590197792d0407ed7a3d00fec98dcefc:36091:67776'
@firebase/firestore: ERROR: '[2020-08-10T21:44:55.724Z]  @firebase/firestore:', 'Firestore (7.17.2): INTERNAL UNHANDLED ERROR: ', 'TypeError: Cannot read property 'shutdown' of undefined
@firebase/firestore:     at http://localhost:8090/base/test/unit/bootstrap.js?26216e70590197792d0407ed7a3d00fec98dcefc:42471:74
@firebase/firestore:     at step (http://localhost:8090/base/test/unit/bootstrap.js?26216e70590197792d0407ed7a3d00fec98dcefc:29318:27)
@firebase/firestore:     at Object.next (http://localhost:8090/base/test/unit/bootstrap.js?26216e70590197792d0407ed7a3d00fec98dcefc:29299:57)
@firebase/firestore:     at http://localhost:8090/base/test/unit/bootstrap.js?26216e70590197792d0407ed7a3d00fec98dcefc:29292:75
@firebase/firestore:     at new Promise (<anonymous>)
@firebase/firestore:     at Object.__awaiter (http://localhost:8090/base/test/unit/bootstrap.js?26216e70590197792d0407ed7a3d00fec98dcefc:29288:16)
@firebase/firestore:     at http://localhost:8090/base/test/unit/bootstrap.js?26216e70590197792d0407ed7a3d00fec98dcefc:42468:89
@firebase/firestore:     at http://localhost:8090/base/test/unit/bootstrap.js?26216e70590197792d0407ed7a3d00fec98dcefc:36091:67776'
```