### PR TITLE
Try to fix flaky analytics test

### DIFF
--- a/packages/analytics/index.test.ts
+++ b/packages/analytics/index.test.ts
@@ -77,6 +77,9 @@ describe('FirebaseAnalytics instance tests', () => {
       delete window['dataLayer'];
       removeGtagScript();
     });
+    afterEach(() => {
+      gtagStub.reset();
+    });
     it('Contains reference to parent app', () => {
       expect(analyticsInstance.app).to.equal(app);
     });
@@ -111,7 +114,6 @@ describe('FirebaseAnalytics instance tests', () => {
           currency: 'USD'
         }
       );
-      gtagStub.reset();
     });
     it('setCurrentScreen() method exists on instance', () => {
       expect(analyticsInstance.setCurrentScreen).to.be.instanceOf(Function);
@@ -151,8 +153,11 @@ describe('FirebaseAnalytics instance tests', () => {
       delete window[customDataLayerName];
       removeGtagScript();
     });
+    afterEach(() => {
+      gtagStub.reset();
+    });
     it('Calls gtag correctly on logEvent (instance)', async () => {
-      analyticsInstance.logEvent(EventName.ADD_SHIPPING_INFO, {
+      analyticsInstance.logEvent(EventName.ADD_PAYMENT_INFO, {
         currency: 'USD'
       });
       // Clear event stack of async FID call.
@@ -174,13 +179,12 @@ describe('FirebaseAnalytics instance tests', () => {
       await Promise.all(Object.values(initializedIdPromisesMap));
       expect(gtagStub).to.have.been.calledWith(
         GtagCommand.EVENT,
-        EventName.ADD_SHIPPING_INFO,
+        EventName.ADD_PAYMENT_INFO,
         {
           'send_to': 'abcd-efgh',
           currency: 'USD'
         }
       );
-      gtagStub.reset();
     });
   });
 

--- a/packages/analytics/index.test.ts
+++ b/packages/analytics/index.test.ts
@@ -77,9 +77,6 @@ describe('FirebaseAnalytics instance tests', () => {
       delete window['dataLayer'];
       removeGtagScript();
     });
-    afterEach(() => {
-      gtagStub.reset();
-    });
     it('Contains reference to parent app', () => {
       expect(analyticsInstance.app).to.equal(app);
     });
@@ -91,6 +88,7 @@ describe('FirebaseAnalytics instance tests', () => {
       // For IE: Need then() or else "expect" runs immediately on FID resolve
       // before the other statements in initializeGAId.
       await fidDeferred.promise.then();
+      console.log('callCount', gtagStub.callCount);
       expect(gtagStub).to.have.been.calledWith('js');
       expect(gtagStub).to.have.been.calledWith(
         GtagCommand.CONFIG,
@@ -113,6 +111,7 @@ describe('FirebaseAnalytics instance tests', () => {
           currency: 'USD'
         }
       );
+      gtagStub.reset();
     });
     it('setCurrentScreen() method exists on instance', () => {
       expect(analyticsInstance.setCurrentScreen).to.be.instanceOf(Function);
@@ -152,11 +151,8 @@ describe('FirebaseAnalytics instance tests', () => {
       delete window[customDataLayerName];
       removeGtagScript();
     });
-    afterEach(() => {
-      gtagStub.reset();
-    });
     it('Calls gtag correctly on logEvent (instance)', async () => {
-      analyticsInstance.logEvent(EventName.ADD_PAYMENT_INFO, {
+      analyticsInstance.logEvent(EventName.ADD_SHIPPING_INFO, {
         currency: 'USD'
       });
       // Clear event stack of async FID call.
@@ -178,12 +174,13 @@ describe('FirebaseAnalytics instance tests', () => {
       await Promise.all(Object.values(initializedIdPromisesMap));
       expect(gtagStub).to.have.been.calledWith(
         GtagCommand.EVENT,
-        EventName.ADD_PAYMENT_INFO,
+        EventName.ADD_SHIPPING_INFO,
         {
           'send_to': 'abcd-efgh',
           currency: 'USD'
         }
       );
+      gtagStub.reset();
     });
   });
 

--- a/packages/analytics/index.test.ts
+++ b/packages/analytics/index.test.ts
@@ -91,7 +91,6 @@ describe('FirebaseAnalytics instance tests', () => {
       // For IE: Need then() or else "expect" runs immediately on FID resolve
       // before the other statements in initializeGAId.
       await fidDeferred.promise.then();
-      console.log('callCount', gtagStub.callCount);
       expect(gtagStub).to.have.been.calledWith('js');
       expect(gtagStub).to.have.been.calledWith(
         GtagCommand.CONFIG,

--- a/packages/analytics/index.test.ts
+++ b/packages/analytics/index.test.ts
@@ -87,10 +87,9 @@ describe('FirebaseAnalytics instance tests', () => {
       analyticsInstance.logEvent(EventName.ADD_PAYMENT_INFO, {
         currency: 'USD'
       });
-      // Clear event stack of async FID call.
-      // For IE: Need then() or else "expect" runs immediately on FID resolve
-      // before the other statements in initializeGAId.
-      await fidDeferred.promise.then();
+      // Clear event stack of initialization promise.
+      const { initializedIdPromisesMap } = getGlobalVars();
+      await Promise.all(Object.values(initializedIdPromisesMap));
       expect(gtagStub).to.have.been.calledWith('js');
       expect(gtagStub).to.have.been.calledWith(
         GtagCommand.CONFIG,
@@ -101,10 +100,6 @@ describe('FirebaseAnalytics instance tests', () => {
           update: true
         }
       );
-      // Clear event stack of initialization promise.
-      const { initializedIdPromisesMap } = getGlobalVars();
-      await Promise.all(Object.values(initializedIdPromisesMap));
-      // await Promise.resolve().then(() => {});
       expect(gtagStub).to.have.been.calledWith(
         GtagCommand.EVENT,
         EventName.ADD_PAYMENT_INFO,
@@ -159,10 +154,9 @@ describe('FirebaseAnalytics instance tests', () => {
       analyticsInstance.logEvent(EventName.ADD_PAYMENT_INFO, {
         currency: 'USD'
       });
-      // Clear event stack of async FID call.
-      // For IE: Need then() or else "expect" runs immediately on FID resolve
-      // before the other statements in initializeGAId.
-      await fidDeferred.promise.then();
+      // Clear event stack of initialization promise.
+      const { initializedIdPromisesMap } = getGlobalVars();
+      await Promise.all(Object.values(initializedIdPromisesMap));
       expect(gtagStub).to.have.been.calledWith('js');
       expect(gtagStub).to.have.been.calledWith(
         GtagCommand.CONFIG,
@@ -173,9 +167,6 @@ describe('FirebaseAnalytics instance tests', () => {
           update: true
         }
       );
-      // Clear event stack of initialization promise.
-      const { initializedIdPromisesMap } = getGlobalVars();
-      await Promise.all(Object.values(initializedIdPromisesMap));
       expect(gtagStub).to.have.been.calledWith(
         GtagCommand.EVENT,
         EventName.ADD_PAYMENT_INFO,


### PR DESCRIPTION
Cannot reproduce flaky analytics test but making a change that will hopefully make the test more stable.

Test relies on some tricky timing to test a couple of calls when FID promise has resolved but initialization promise hasn't. It was already causing some problems on IE and may be causing occasional flaky failures. Switch to just making all `expect` calls after initialization promise has resolved.