### PR TITLE
clean up emulator after test

### DIFF
--- a/scripts/emulator-testing/emulators/emulator.ts
+++ b/scripts/emulator-testing/emulators/emulator.ts
@@ -123,5 +123,10 @@ export abstract class Emulator {
       console.log(`Shutting down emulator, pid: [${this.emulator.pid}] ...`);
       this.emulator.kill();
     }
+
+    if (this.binaryPath) {
+      console.log(`Deleting the emulator jar at ${this.binaryPath}`);
+      fs.unlinkSync(this.binaryPath);
+    }
   }
 }


### PR DESCRIPTION
It seems we run out of disk space on GHA when downloading emulator jars for Firestore, Database and Testing SDK. This PR solves the problem by deleting the jar after the test.