### PR TITLE
Update outdated deps

### DIFF
--- a/packages/rules-unit-testing/package.json
+++ b/packages/rules-unit-testing/package.json
@@ -21,9 +21,9 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "firebase": "7.17.2",
+    "firebase": "7.18.0",
     "@firebase/logger": "0.2.6",
-    "@firebase/util": "0.3.0",
+    "@firebase/util": "0.3.1",
     "request": "2.88.2"
   },
   "devDependencies": {


### PR DESCRIPTION
We did a release in parallel when `rules-unit-testing` was added to the repo, so some deps are outdated. The PR fixes it.