### PR TITLE
Fix firestore build:release script

### DIFF
--- a/packages/firestore/package.json
+++ b/packages/firestore/package.json
@@ -10,7 +10,7 @@
     "bundle": "rollup -c",
     "build": "run-p 'bundle rollup.config.browser.js' 'bundle rollup.config.browser.memory.js' 'bundle rollup.config.node.js' 'bundle rollup.config.node.memory.js' 'bundle rollup.config.rn.js' 'bundle rollup.config.rn.memory.js' build:lite build:exp",
     "build:scripts": "tsc -moduleResolution node --module commonjs scripts/*.ts && ls scripts/*.js | xargs -I % sh -c 'terser %  -o %'",
-    "build:release": "rollup -c rollup.config.es2017.js && rollup -c rollup.config.es5.js",
+    "build:release": "run-p 'bundle rollup.config.browser.js' 'bundle rollup.config.browser.memory.js' 'bundle rollup.config.node.js' 'bundle rollup.config.node.memory.js' 'bundle rollup.config.rn.js' 'bundle rollup.config.rn.memory.js'",
     "build:deps": "lerna run --scope @firebase/'{app,firestore}' --include-dependencies build",
     "build:console": "node tools/console.build.js",
     "build:exp": "rollup -c rollup.config.exp.js",


### PR DESCRIPTION
Fix `build:release` to match new `build` minus exp and lite.