### PR TITLE
Fix changeset checker regex

### DIFF
--- a/scripts/check_changeset.ts
+++ b/scripts/check_changeset.ts
@@ -72,7 +72,7 @@ async function parseChangesetFile(changesetFile: string) {
     .filter(line => line)
     .map(line => {
       const [packageName] = line.split(':');
-      return packageName.replace(/'/g, '');
+      return packageName.replace(/['"]/g, '');
     });
   return changesetPackages;
 }


### PR DESCRIPTION
Should work for single or double quotes in changeset file.