### PR TITLE
Rename Blob to Bytes

### DIFF
--- a/packages/firestore/exp-types/index.d.ts
+++ b/packages/firestore/exp-types/index.d.ts
@@ -171,7 +171,7 @@ export class Timestamp {
   valueOf(): string;
 }
 
-export class Blob {
+export class Bytes {
   private constructor();
 
   static fromBase64String(base64: string): Blob;

--- a/packages/firestore/exp/dependencies.json
+++ b/packages/firestore/exp/dependencies.json
@@ -1,41 +1,31 @@
 {
-    "Blob": {
+    "Bytes": {
         "dependencies": {
             "functions": [
                 "argToString",
-                "assertUint8ArrayAvailable",
                 "binaryStringFromUint8Array",
                 "decodeBase64",
                 "encodeBase64",
                 "fail",
                 "formatJSON",
-                "formatPlural",
                 "getMessageOrStack",
                 "hardAssert",
-                "invalidClassError",
                 "isIndexedDbTransactionError",
-                "isPlainObject",
                 "logDebug",
                 "logError",
-                "ordinal",
                 "primitiveComparator",
                 "randomBytes",
                 "registerFirestore",
                 "removeComponents",
                 "removeComponents$1",
-                "tryGetCustomObjectType",
                 "uint8ArrayFromBinaryString",
-                "validateArgType",
-                "validateExactNumberOfArgs",
-                "validateType",
-                "valueDescription",
                 "wrapInUserErrorIfRecoverable"
             ],
             "classes": [
                 "AsyncQueue",
                 "AutoId",
-                "Blob",
                 "ByteString",
+                "Bytes",
                 "DatabaseId",
                 "DatabaseInfo",
                 "Deferred",
@@ -50,7 +40,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 21515
+        "sizeInBytes": 18456
     },
     "CollectionReference": {
         "dependencies": {
@@ -92,7 +82,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 18744
+        "sizeInBytes": 18635
     },
     "DocumentReference": {
         "dependencies": {
@@ -134,13 +124,12 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 20116
+        "sizeInBytes": 20083
     },
     "DocumentSnapshot": {
         "dependencies": {
             "functions": [
                 "argToString",
-                "assertUint8ArrayAvailable",
                 "binaryStringFromUint8Array",
                 "cast",
                 "createError",
@@ -189,8 +178,8 @@
                 "AutoId",
                 "BaseFieldPath",
                 "BasePath",
-                "Blob",
                 "ByteString",
+                "Bytes",
                 "DatabaseId",
                 "DatabaseInfo",
                 "Deferred",
@@ -219,7 +208,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 39654
+        "sizeInBytes": 39147
     },
     "FieldPath": {
         "dependencies": {
@@ -269,7 +258,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 23188
+        "sizeInBytes": 23079
     },
     "FieldValue": {
         "dependencies": {
@@ -308,7 +297,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 16818
+        "sizeInBytes": 16709
     },
     "FirebaseFirestore": {
         "dependencies": {
@@ -345,7 +334,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 16727
+        "sizeInBytes": 16618
     },
     "GeoPoint": {
         "dependencies": {
@@ -391,7 +380,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 19636
+        "sizeInBytes": 19527
     },
     "Query": {
         "dependencies": {
@@ -429,7 +418,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 16920
+        "sizeInBytes": 16811
     },
     "QueryConstraint": {
         "dependencies": {
@@ -467,13 +456,12 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 16733
+        "sizeInBytes": 16624
     },
     "QueryDocumentSnapshot": {
         "dependencies": {
             "functions": [
                 "argToString",
-                "assertUint8ArrayAvailable",
                 "binaryStringFromUint8Array",
                 "cast",
                 "createError",
@@ -522,8 +510,8 @@
                 "AutoId",
                 "BaseFieldPath",
                 "BasePath",
-                "Blob",
                 "ByteString",
+                "Bytes",
                 "DatabaseId",
                 "DatabaseInfo",
                 "Deferred",
@@ -552,13 +540,12 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 39664
+        "sizeInBytes": 39157
     },
     "QuerySnapshot": {
         "dependencies": {
             "functions": [
                 "argToString",
-                "assertUint8ArrayAvailable",
                 "binaryStringFromUint8Array",
                 "cast",
                 "changesFromSnapshot",
@@ -609,8 +596,8 @@
                 "AutoId",
                 "BaseFieldPath",
                 "BasePath",
-                "Blob",
                 "ByteString",
+                "Bytes",
                 "DatabaseId",
                 "DatabaseInfo",
                 "Deferred",
@@ -641,7 +628,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 42295
+        "sizeInBytes": 41788
     },
     "SnapshotMetadata": {
         "dependencies": {
@@ -679,7 +666,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 16942
+        "sizeInBytes": 16833
     },
     "Timestamp": {
         "dependencies": {
@@ -717,7 +704,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 18328
+        "sizeInBytes": 18219
     },
     "Transaction": {
         "dependencies": {
@@ -725,7 +712,6 @@
                 "applyFirestoreDataConverter",
                 "argToString",
                 "arrayEquals",
-                "assertUint8ArrayAvailable",
                 "binaryStringFromUint8Array",
                 "blobEquals",
                 "cast",
@@ -808,8 +794,8 @@
                 "AutoId",
                 "BaseFieldPath",
                 "BasePath",
-                "Blob",
                 "ByteString",
+                "Bytes",
                 "DatabaseId",
                 "DatabaseInfo",
                 "Deferred",
@@ -859,7 +845,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 63180
+        "sizeInBytes": 62687
     },
     "WriteBatch": {
         "dependencies": {
@@ -867,7 +853,6 @@
                 "applyFirestoreDataConverter",
                 "argToString",
                 "arrayEquals",
-                "assertUint8ArrayAvailable",
                 "binaryStringFromUint8Array",
                 "blobEquals",
                 "cast",
@@ -947,8 +932,8 @@
                 "AutoId",
                 "BaseFieldPath",
                 "BasePath",
-                "Blob",
                 "ByteString",
+                "Bytes",
                 "DatabaseId",
                 "DatabaseInfo",
                 "Deferred",
@@ -989,7 +974,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 55917
+        "sizeInBytes": 55275
     },
     "addDoc": {
         "dependencies": {
@@ -1007,7 +992,7 @@
                 "applyNumericIncrementTransformOperationToLocalView",
                 "applyPatchMutationToLocalView",
                 "applyPatchMutationToRemoteDocument",
-                "applyRemoteEvent",
+                "applyRemoteEventToLocalCache",
                 "applySetMutationToLocalView",
                 "applySetMutationToRemoteDocument",
                 "applyTransformMutationToLocalView",
@@ -1019,7 +1004,6 @@
                 "arrayEquals",
                 "asNumber",
                 "assertPresent",
-                "assertUint8ArrayAvailable",
                 "binaryStringFromUint8Array",
                 "blobEquals",
                 "boundEquals",
@@ -1251,9 +1235,9 @@
                 "AutoId",
                 "BaseFieldPath",
                 "BasePath",
-                "Blob",
                 "Bound",
                 "ByteString",
+                "Bytes",
                 "CollectionReference",
                 "DatabaseId",
                 "DatabaseInfo",
@@ -1366,14 +1350,13 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 214087
+        "sizeInBytes": 213593
     },
     "arrayRemove": {
         "dependencies": {
             "functions": [
                 "argToString",
                 "arrayRemove",
-                "assertUint8ArrayAvailable",
                 "binaryStringFromUint8Array",
                 "createError",
                 "createSentinelChildContext",
@@ -1386,7 +1369,6 @@
                 "fullyQualifiedPrefixPath",
                 "getMessageOrStack",
                 "hardAssert",
-                "invalidClassError",
                 "isEmpty",
                 "isIndexedDbTransactionError",
                 "isNegativeZero",
@@ -1429,8 +1411,8 @@
                 "AsyncQueue",
                 "AutoId",
                 "BasePath",
-                "Blob",
                 "ByteString",
+                "Bytes",
                 "DatabaseId",
                 "DatabaseInfo",
                 "Deferred",
@@ -1455,14 +1437,13 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 36209
+        "sizeInBytes": 35214
     },
     "arrayUnion": {
         "dependencies": {
             "functions": [
                 "argToString",
                 "arrayUnion",
-                "assertUint8ArrayAvailable",
                 "binaryStringFromUint8Array",
                 "createError",
                 "createSentinelChildContext",
@@ -1475,7 +1456,6 @@
                 "fullyQualifiedPrefixPath",
                 "getMessageOrStack",
                 "hardAssert",
-                "invalidClassError",
                 "isEmpty",
                 "isIndexedDbTransactionError",
                 "isNegativeZero",
@@ -1518,8 +1498,8 @@
                 "AsyncQueue",
                 "AutoId",
                 "BasePath",
-                "Blob",
                 "ByteString",
+                "Bytes",
                 "DatabaseId",
                 "DatabaseInfo",
                 "Deferred",
@@ -1544,7 +1524,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 36201
+        "sizeInBytes": 35206
     },
     "clearIndexedDbPersistence": {
         "dependencies": {
@@ -1593,7 +1573,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 30195
+        "sizeInBytes": 30086
     },
     "collection": {
         "dependencies": {
@@ -1648,7 +1628,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 24823
+        "sizeInBytes": 24790
     },
     "collectionGroup": {
         "dependencies": {
@@ -1699,7 +1679,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 23208
+        "sizeInBytes": 23099
     },
     "deleteDoc": {
         "dependencies": {
@@ -1715,7 +1695,7 @@
                 "applyNumericIncrementTransformOperationToLocalView",
                 "applyPatchMutationToLocalView",
                 "applyPatchMutationToRemoteDocument",
-                "applyRemoteEvent",
+                "applyRemoteEventToLocalCache",
                 "applySetMutationToLocalView",
                 "applySetMutationToRemoteDocument",
                 "applyTransformMutationToLocalView",
@@ -2035,7 +2015,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 196418
+        "sizeInBytes": 196533
     },
     "deleteField": {
         "dependencies": {
@@ -2077,7 +2057,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 17784
+        "sizeInBytes": 17675
     },
     "disableNetwork": {
         "dependencies": {
@@ -2093,7 +2073,7 @@
                 "applyNumericIncrementTransformOperationToLocalView",
                 "applyPatchMutationToLocalView",
                 "applyPatchMutationToRemoteDocument",
-                "applyRemoteEvent",
+                "applyRemoteEventToLocalCache",
                 "applySetMutationToLocalView",
                 "applySetMutationToRemoteDocument",
                 "applyTransformMutationToLocalView",
@@ -2412,7 +2392,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 196036
+        "sizeInBytes": 196151
     },
     "doc": {
         "dependencies": {
@@ -2467,7 +2447,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 24874
+        "sizeInBytes": 24841
     },
     "documentId": {
         "dependencies": {
@@ -2518,7 +2498,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 23238
+        "sizeInBytes": 23129
     },
     "enableIndexedDbPersistence": {
         "dependencies": {
@@ -2642,6 +2622,7 @@
                 "getPostMutationVersion",
                 "getWindow",
                 "globalTargetStore",
+                "handleUserChange",
                 "hardAssert",
                 "ignoreIfPrimaryLeaseLoss",
                 "immediateSuccessor",
@@ -2885,7 +2866,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 199048
+        "sizeInBytes": 200588
     },
     "enableMultiTabIndexedDbPersistence": {
         "dependencies": {
@@ -2904,7 +2885,7 @@
                 "applyPatchMutationToLocalView",
                 "applyPatchMutationToRemoteDocument",
                 "applyPrimaryState",
-                "applyRemoteEvent",
+                "applyRemoteEventToLocalCache",
                 "applySetMutationToLocalView",
                 "applySetMutationToRemoteDocument",
                 "applyTargetState",
@@ -3364,7 +3345,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 304821
+        "sizeInBytes": 304936
     },
     "enableNetwork": {
         "dependencies": {
@@ -3380,7 +3361,7 @@
                 "applyNumericIncrementTransformOperationToLocalView",
                 "applyPatchMutationToLocalView",
                 "applyPatchMutationToRemoteDocument",
-                "applyRemoteEvent",
+                "applyRemoteEventToLocalCache",
                 "applySetMutationToLocalView",
                 "applySetMutationToRemoteDocument",
                 "applyTransformMutationToLocalView",
@@ -3699,13 +3680,12 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 196033
+        "sizeInBytes": 196148
     },
     "endAt": {
         "dependencies": {
             "functions": [
                 "argToString",
-                "assertUint8ArrayAvailable",
                 "binaryStringFromUint8Array",
                 "cast",
                 "createError",
@@ -3784,9 +3764,9 @@
                 "AutoId",
                 "BaseFieldPath",
                 "BasePath",
-                "Blob",
                 "Bound",
                 "ByteString",
+                "Bytes",
                 "DatabaseId",
                 "DatabaseInfo",
                 "Deferred",
@@ -3822,13 +3802,12 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 53208
+        "sizeInBytes": 52667
     },
     "endBefore": {
         "dependencies": {
             "functions": [
                 "argToString",
-                "assertUint8ArrayAvailable",
                 "binaryStringFromUint8Array",
                 "cast",
                 "createError",
@@ -3907,9 +3886,9 @@
                 "AutoId",
                 "BaseFieldPath",
                 "BasePath",
-                "Blob",
                 "Bound",
                 "ByteString",
+                "Bytes",
                 "DatabaseId",
                 "DatabaseInfo",
                 "Deferred",
@@ -3945,7 +3924,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 53219
+        "sizeInBytes": 52678
     },
     "getDoc": {
         "dependencies": {
@@ -3961,7 +3940,7 @@
                 "applyNumericIncrementTransformOperationToLocalView",
                 "applyPatchMutationToLocalView",
                 "applyPatchMutationToRemoteDocument",
-                "applyRemoteEvent",
+                "applyRemoteEventToLocalCache",
                 "applySetMutationToLocalView",
                 "applySetMutationToRemoteDocument",
                 "applyTransformMutationToLocalView",
@@ -3973,7 +3952,6 @@
                 "arrayEquals",
                 "asNumber",
                 "assertPresent",
-                "assertUint8ArrayAvailable",
                 "binaryStringFromUint8Array",
                 "blobEquals",
                 "boundEquals",
@@ -4196,9 +4174,9 @@
                 "AutoId",
                 "BaseFieldPath",
                 "BasePath",
-                "Blob",
                 "Bound",
                 "ByteString",
+                "Bytes",
                 "DatabaseId",
                 "DatabaseInfo",
                 "Datastore",
@@ -4313,7 +4291,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 212441
+        "sizeInBytes": 212082
     },
     "getDocFromCache": {
         "dependencies": {
@@ -4336,7 +4314,6 @@
                 "argToString",
                 "arrayEquals",
                 "asNumber",
-                "assertUint8ArrayAvailable",
                 "binaryStringFromUint8Array",
                 "blobEquals",
                 "boundEquals",
@@ -4391,6 +4368,7 @@
                 "getOfflineComponentProvider",
                 "getPostMutationVersion",
                 "getPreviousValue",
+                "handleUserChange",
                 "hardAssert",
                 "invalidClassError",
                 "isArray",
@@ -4476,9 +4454,9 @@
                 "AutoId",
                 "BaseFieldPath",
                 "BasePath",
-                "Blob",
                 "Bound",
                 "ByteString",
+                "Bytes",
                 "DatabaseId",
                 "DatabaseInfo",
                 "Deferred",
@@ -4555,7 +4533,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 118383
+        "sizeInBytes": 119449
     },
     "getDocFromServer": {
         "dependencies": {
@@ -4571,7 +4549,7 @@
                 "applyNumericIncrementTransformOperationToLocalView",
                 "applyPatchMutationToLocalView",
                 "applyPatchMutationToRemoteDocument",
-                "applyRemoteEvent",
+                "applyRemoteEventToLocalCache",
                 "applySetMutationToLocalView",
                 "applySetMutationToRemoteDocument",
                 "applyTransformMutationToLocalView",
@@ -4583,7 +4561,6 @@
                 "arrayEquals",
                 "asNumber",
                 "assertPresent",
-                "assertUint8ArrayAvailable",
                 "binaryStringFromUint8Array",
                 "blobEquals",
                 "boundEquals",
@@ -4806,9 +4783,9 @@
                 "AutoId",
                 "BaseFieldPath",
                 "BasePath",
-                "Blob",
                 "Bound",
                 "ByteString",
+                "Bytes",
                 "DatabaseId",
                 "DatabaseInfo",
                 "Datastore",
@@ -4923,7 +4900,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 212497
+        "sizeInBytes": 212138
     },
     "getDocs": {
         "dependencies": {
@@ -4939,7 +4916,7 @@
                 "applyNumericIncrementTransformOperationToLocalView",
                 "applyPatchMutationToLocalView",
                 "applyPatchMutationToRemoteDocument",
-                "applyRemoteEvent",
+                "applyRemoteEventToLocalCache",
                 "applySetMutationToLocalView",
                 "applySetMutationToRemoteDocument",
                 "applyTransformMutationToLocalView",
@@ -4951,7 +4928,6 @@
                 "arrayEquals",
                 "asNumber",
                 "assertPresent",
-                "assertUint8ArrayAvailable",
                 "binaryStringFromUint8Array",
                 "blobEquals",
                 "boundEquals",
@@ -5176,9 +5152,9 @@
                 "AutoId",
                 "BaseFieldPath",
                 "BasePath",
-                "Blob",
                 "Bound",
                 "ByteString",
+                "Bytes",
                 "DatabaseId",
                 "DatabaseInfo",
                 "Datastore",
@@ -5295,7 +5271,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 215004
+        "sizeInBytes": 214645
     },
     "getDocsFromCache": {
         "dependencies": {
@@ -5318,7 +5294,6 @@
                 "argToString",
                 "arrayEquals",
                 "asNumber",
-                "assertUint8ArrayAvailable",
                 "binaryStringFromUint8Array",
                 "blobEquals",
                 "boundEquals",
@@ -5377,6 +5352,7 @@
                 "getOfflineComponentProvider",
                 "getPostMutationVersion",
                 "getPreviousValue",
+                "handleUserChange",
                 "hardAssert",
                 "invalidClassError",
                 "isArray",
@@ -5464,9 +5440,9 @@
                 "AutoId",
                 "BaseFieldPath",
                 "BasePath",
-                "Blob",
                 "Bound",
                 "ByteString",
+                "Bytes",
                 "DatabaseId",
                 "DatabaseInfo",
                 "Deferred",
@@ -5550,7 +5526,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 131563
+        "sizeInBytes": 132629
     },
     "getDocsFromServer": {
         "dependencies": {
@@ -5566,7 +5542,7 @@
                 "applyNumericIncrementTransformOperationToLocalView",
                 "applyPatchMutationToLocalView",
                 "applyPatchMutationToRemoteDocument",
-                "applyRemoteEvent",
+                "applyRemoteEventToLocalCache",
                 "applySetMutationToLocalView",
                 "applySetMutationToRemoteDocument",
                 "applyTransformMutationToLocalView",
@@ -5578,7 +5554,6 @@
                 "arrayEquals",
                 "asNumber",
                 "assertPresent",
-                "assertUint8ArrayAvailable",
                 "binaryStringFromUint8Array",
                 "blobEquals",
                 "boundEquals",
@@ -5802,9 +5777,9 @@
                 "AutoId",
                 "BaseFieldPath",
                 "BasePath",
-                "Blob",
                 "Bound",
                 "ByteString",
+                "Bytes",
                 "DatabaseId",
                 "DatabaseInfo",
                 "Datastore",
@@ -5921,7 +5896,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 214742
+        "sizeInBytes": 214383
     },
     "getFirestore": {
         "dependencies": {
@@ -5959,7 +5934,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 16803
+        "sizeInBytes": 16694
     },
     "increment": {
         "dependencies": {
@@ -6009,7 +5984,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 18649
+        "sizeInBytes": 18540
     },
     "initializeFirestore": {
         "dependencies": {
@@ -6048,7 +6023,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 18107
+        "sizeInBytes": 17998
     },
     "limit": {
         "dependencies": {
@@ -6094,7 +6069,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 19234
+        "sizeInBytes": 19125
     },
     "limitToLast": {
         "dependencies": {
@@ -6140,7 +6115,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 19258
+        "sizeInBytes": 19149
     },
     "onSnapshot": {
         "dependencies": {
@@ -6156,7 +6131,7 @@
                 "applyNumericIncrementTransformOperationToLocalView",
                 "applyPatchMutationToLocalView",
                 "applyPatchMutationToRemoteDocument",
-                "applyRemoteEvent",
+                "applyRemoteEventToLocalCache",
                 "applySetMutationToLocalView",
                 "applySetMutationToRemoteDocument",
                 "applyTransformMutationToLocalView",
@@ -6168,7 +6143,6 @@
                 "arrayEquals",
                 "asNumber",
                 "assertPresent",
-                "assertUint8ArrayAvailable",
                 "binaryStringFromUint8Array",
                 "blobEquals",
                 "boundEquals",
@@ -6395,9 +6369,9 @@
                 "AutoId",
                 "BaseFieldPath",
                 "BasePath",
-                "Blob",
                 "Bound",
                 "ByteString",
+                "Bytes",
                 "DatabaseId",
                 "DatabaseInfo",
                 "Datastore",
@@ -6514,7 +6488,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 216087
+        "sizeInBytes": 215728
     },
     "onSnapshotsInSync": {
         "dependencies": {
@@ -6530,7 +6504,7 @@
                 "applyNumericIncrementTransformOperationToLocalView",
                 "applyPatchMutationToLocalView",
                 "applyPatchMutationToRemoteDocument",
-                "applyRemoteEvent",
+                "applyRemoteEventToLocalCache",
                 "applySetMutationToLocalView",
                 "applySetMutationToRemoteDocument",
                 "applyTransformMutationToLocalView",
@@ -6851,7 +6825,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 196882
+        "sizeInBytes": 196997
     },
     "orderBy": {
         "dependencies": {
@@ -6919,7 +6893,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 28879
+        "sizeInBytes": 28770
     },
     "parent": {
         "dependencies": {
@@ -6968,7 +6942,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 22884
+        "sizeInBytes": 22851
     },
     "query": {
         "dependencies": {
@@ -7008,7 +6982,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 17501
+        "sizeInBytes": 17392
     },
     "queryEqual": {
         "dependencies": {
@@ -7084,7 +7058,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 33450
+        "sizeInBytes": 33341
     },
     "refEqual": {
         "dependencies": {
@@ -7132,7 +7106,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 22431
+        "sizeInBytes": 22398
     },
     "runTransaction": {
         "dependencies": {
@@ -7141,7 +7115,6 @@
                 "argToString",
                 "arrayEquals",
                 "assertPresent",
-                "assertUint8ArrayAvailable",
                 "binaryStringFromUint8Array",
                 "blobEquals",
                 "cast",
@@ -7256,8 +7229,8 @@
                 "AutoId",
                 "BaseFieldPath",
                 "BasePath",
-                "Blob",
                 "ByteString",
+                "Bytes",
                 "DatabaseId",
                 "DatabaseInfo",
                 "Datastore",
@@ -7319,7 +7292,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 82111
+        "sizeInBytes": 81653
     },
     "serverTimestamp": {
         "dependencies": {
@@ -7364,7 +7337,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 17795
+        "sizeInBytes": 17686
     },
     "setDoc": {
         "dependencies": {
@@ -7381,7 +7354,7 @@
                 "applyNumericIncrementTransformOperationToLocalView",
                 "applyPatchMutationToLocalView",
                 "applyPatchMutationToRemoteDocument",
-                "applyRemoteEvent",
+                "applyRemoteEventToLocalCache",
                 "applySetMutationToLocalView",
                 "applySetMutationToRemoteDocument",
                 "applyTransformMutationToLocalView",
@@ -7393,7 +7366,6 @@
                 "arrayEquals",
                 "asNumber",
                 "assertPresent",
-                "assertUint8ArrayAvailable",
                 "binaryStringFromUint8Array",
                 "blobEquals",
                 "boundEquals",
@@ -7624,9 +7596,9 @@
                 "AutoId",
                 "BaseFieldPath",
                 "BasePath",
-                "Blob",
                 "Bound",
                 "ByteString",
+                "Bytes",
                 "DatabaseId",
                 "DatabaseInfo",
                 "Datastore",
@@ -7737,7 +7709,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 212369
+        "sizeInBytes": 211875
     },
     "setLogLevel": {
         "dependencies": {
@@ -7775,14 +7747,13 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 16769
+        "sizeInBytes": 16660
     },
     "snapshotEqual": {
         "dependencies": {
             "functions": [
                 "argToString",
                 "arrayEquals",
-                "assertUint8ArrayAvailable",
                 "binaryStringFromUint8Array",
                 "blobEquals",
                 "boundEquals",
@@ -7852,9 +7823,9 @@
                 "AutoId",
                 "BaseFieldPath",
                 "BasePath",
-                "Blob",
                 "Bound",
                 "ByteString",
+                "Bytes",
                 "DatabaseId",
                 "DatabaseInfo",
                 "Deferred",
@@ -7889,13 +7860,12 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 50939
+        "sizeInBytes": 50432
     },
     "startAfter": {
         "dependencies": {
             "functions": [
                 "argToString",
-                "assertUint8ArrayAvailable",
                 "binaryStringFromUint8Array",
                 "cast",
                 "createError",
@@ -7974,9 +7944,9 @@
                 "AutoId",
                 "BaseFieldPath",
                 "BasePath",
-                "Blob",
                 "Bound",
                 "ByteString",
+                "Bytes",
                 "DatabaseId",
                 "DatabaseInfo",
                 "Deferred",
@@ -8012,13 +7982,12 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 53229
+        "sizeInBytes": 52688
     },
     "startAt": {
         "dependencies": {
             "functions": [
                 "argToString",
-                "assertUint8ArrayAvailable",
                 "binaryStringFromUint8Array",
                 "cast",
                 "createError",
@@ -8097,9 +8066,9 @@
                 "AutoId",
                 "BaseFieldPath",
                 "BasePath",
-                "Blob",
                 "Bound",
                 "ByteString",
+                "Bytes",
                 "DatabaseId",
                 "DatabaseInfo",
                 "Deferred",
@@ -8135,7 +8104,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 53219
+        "sizeInBytes": 52678
     },
     "terminate": {
         "dependencies": {
@@ -8174,7 +8143,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 17299
+        "sizeInBytes": 17190
     },
     "updateDoc": {
         "dependencies": {
@@ -8190,7 +8159,7 @@
                 "applyNumericIncrementTransformOperationToLocalView",
                 "applyPatchMutationToLocalView",
                 "applyPatchMutationToRemoteDocument",
-                "applyRemoteEvent",
+                "applyRemoteEventToLocalCache",
                 "applySetMutationToLocalView",
                 "applySetMutationToRemoteDocument",
                 "applyTransformMutationToLocalView",
@@ -8202,7 +8171,6 @@
                 "arrayEquals",
                 "asNumber",
                 "assertPresent",
-                "assertUint8ArrayAvailable",
                 "binaryStringFromUint8Array",
                 "blobEquals",
                 "boundEquals",
@@ -8435,9 +8403,9 @@
                 "AutoId",
                 "BaseFieldPath",
                 "BasePath",
-                "Blob",
                 "Bound",
                 "ByteString",
+                "Bytes",
                 "DatabaseId",
                 "DatabaseInfo",
                 "Datastore",
@@ -8550,7 +8518,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 213868
+        "sizeInBytes": 213374
     },
     "waitForPendingWrites": {
         "dependencies": {
@@ -8566,7 +8534,7 @@
                 "applyNumericIncrementTransformOperationToLocalView",
                 "applyPatchMutationToLocalView",
                 "applyPatchMutationToRemoteDocument",
-                "applyRemoteEvent",
+                "applyRemoteEventToLocalCache",
                 "applySetMutationToLocalView",
                 "applySetMutationToRemoteDocument",
                 "applyTransformMutationToLocalView",
@@ -8884,7 +8852,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 195825
+        "sizeInBytes": 195940
     },
     "where": {
         "dependencies": {
@@ -8892,7 +8860,6 @@
                 "argToString",
                 "arrayEquals",
                 "arrayValueContains",
-                "assertUint8ArrayAvailable",
                 "binaryStringFromUint8Array",
                 "blobEquals",
                 "cast",
@@ -8992,8 +8959,8 @@
                 "AutoId",
                 "BaseFieldPath",
                 "BasePath",
-                "Blob",
                 "ByteString",
+                "Bytes",
                 "DatabaseId",
                 "DatabaseInfo",
                 "Deferred",
@@ -9031,7 +8998,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 59634
+        "sizeInBytes": 58992
     },
     "writeBatch": {
         "dependencies": {
@@ -9048,7 +9015,7 @@
                 "applyNumericIncrementTransformOperationToLocalView",
                 "applyPatchMutationToLocalView",
                 "applyPatchMutationToRemoteDocument",
-                "applyRemoteEvent",
+                "applyRemoteEventToLocalCache",
                 "applySetMutationToLocalView",
                 "applySetMutationToRemoteDocument",
                 "applyTransformMutationToLocalView",
@@ -9060,7 +9027,6 @@
                 "arrayEquals",
                 "asNumber",
                 "assertPresent",
-                "assertUint8ArrayAvailable",
                 "binaryStringFromUint8Array",
                 "blobEquals",
                 "boundEquals",
@@ -9295,9 +9261,9 @@
                 "AutoId",
                 "BaseFieldPath",
                 "BasePath",
-                "Blob",
                 "Bound",
                 "ByteString",
+                "Bytes",
                 "DatabaseId",
                 "DatabaseInfo",
                 "Datastore",
@@ -9412,6 +9378,6 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 217535
+        "sizeInBytes": 217041
     }
 }

--- a/packages/firestore/exp/index.ts
+++ b/packages/firestore/exp/index.ts
@@ -91,7 +91,7 @@ export {
 
 export { setLogLevel } from '../src/util/log';
 
-export { Blob } from '../src/api/blob';
+export { Bytes } from '../lite/src/api/bytes';
 
 export { writeBatch } from './src/api/write_batch';
 

--- a/packages/firestore/exp/src/api/snapshot.ts
+++ b/packages/firestore/exp/src/api/snapshot.ts
@@ -40,6 +40,7 @@ import {
 } from '../../../src/api/database';
 import { Code, FirestoreError } from '../../../src/util/error';
 import { ViewSnapshot } from '../../../src/core/view_snapshot';
+import { Bytes } from '../../../lite/src/api/bytes';
 
 const DEFAULT_SERVER_TIMESTAMP_BEHAVIOR: ServerTimestampBehavior = 'none';
 
@@ -87,7 +88,8 @@ export class DocumentSnapshot<T = firestore.DocumentData>
             this._firestore,
             /* converter= */ null,
             key.path
-          )
+          ),
+        bytes => new Bytes(bytes)
       );
       return userDataWriter.convertValue(this._document.toProto()) as T;
     }
@@ -107,7 +109,8 @@ export class DocumentSnapshot<T = firestore.DocumentData>
           /* timestampsInSnapshots= */ true,
           options.serverTimestamps || DEFAULT_SERVER_TIMESTAMP_BEHAVIOR,
           key =>
-            new DocumentReference(this._firestore, this._converter, key.path)
+            new DocumentReference(this._firestore, this._converter, key.path),
+          bytes => new Bytes(bytes)
         );
         return userDataWriter.convertValue(value);
       }

--- a/packages/firestore/exp/test/shim.ts
+++ b/packages/firestore/exp/test/shim.ts
@@ -731,6 +731,14 @@ export class FieldPath implements legacy.FieldPath {
 export class Blob implements legacy.Blob {
   constructor(readonly _delegate: BytesExp) {}
 
+  static fromBase64String(base64: string): Blob {
+    return new Blob(BytesExp.fromBase64String(base64));
+  }
+
+  static fromUint8Array(array: Uint8Array): Blob {
+    return new Blob(BytesExp.fromUint8Array(array));
+  }
+
   toBase64(): string {
     return this._delegate.toBase64();
   }

--- a/packages/firestore/exp/test/shim.ts
+++ b/packages/firestore/exp/test/shim.ts
@@ -66,13 +66,14 @@ import {
   limitToLast,
   limit,
   orderBy,
-  where
+  where,
+  Bytes as BytesExp
 } from '../../exp/index';
 import { UntypedFirestoreDataConverter } from '../../src/api/user_data_reader';
 import { isPartialObserver, PartialObserver } from '../../src/api/observer';
 import { isPlainObject } from '../../src/util/input_validation';
 
-export { GeoPoint, Blob, Timestamp } from '../index';
+export { GeoPoint, Timestamp } from '../index';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
@@ -727,6 +728,22 @@ export class FieldPath implements legacy.FieldPath {
   }
 }
 
+export class Blob implements legacy.Blob {
+  constructor(readonly _delegate: BytesExp) {}
+
+  toBase64(): string {
+    return this._delegate.toBase64();
+  }
+
+  toUint8Array(): Uint8Array {
+    return this._delegate.toUint8Array();
+  }
+
+  isEqual(other: Blob): boolean {
+    return this._delegate.isEqual(other._delegate);
+  }
+}
+
 /**
  * Takes document data that uses the firestore-exp API types and replaces them
  * with the API types defined in this shim.
@@ -736,6 +753,8 @@ function wrap(value: any): any {
     return value.map(v => wrap(v));
   } else if (value instanceof FieldPathExp) {
     return new FieldPath(...value._internalPath.toArray());
+  } else if (value instanceof BytesExp) {
+    return new Blob(value);
   } else if (value instanceof DocumentReferenceExp) {
     // TODO(mrschmidt): Ideally, we should use an existing instance of
     // FirebaseFirestore here rather than instantiating a new instance
@@ -763,6 +782,8 @@ function unwrap(value: any): any {
   } else if (value instanceof FieldPath) {
     return value._delegate;
   } else if (value instanceof FieldValue) {
+    return value._delegate;
+  } else if (value instanceof Blob) {
     return value._delegate;
   } else if (value instanceof DocumentReference) {
     return value._delegate;

--- a/packages/firestore/lite-types/index.d.ts
+++ b/packages/firestore/lite-types/index.d.ts
@@ -131,7 +131,7 @@ export class Timestamp {
   valueOf(): string;
 }
 
-export class Blob {
+export class Bytes {
   private constructor();
 
   static fromBase64String(base64: string): Blob;

--- a/packages/firestore/lite/dependencies.json
+++ b/packages/firestore/lite/dependencies.json
@@ -1,34 +1,24 @@
 {
-    "Blob": {
+    "Bytes": {
         "dependencies": {
             "functions": [
                 "argToString",
-                "assertUint8ArrayAvailable",
                 "binaryStringFromUint8Array",
                 "decodeBase64",
                 "encodeBase64",
                 "fail",
                 "formatJSON",
-                "formatPlural",
                 "hardAssert",
-                "invalidClassError",
-                "isPlainObject",
                 "logDebug",
                 "logError",
-                "ordinal",
                 "primitiveComparator",
                 "registerFirestore",
                 "removeComponents",
-                "tryGetCustomObjectType",
-                "uint8ArrayFromBinaryString",
-                "validateArgType",
-                "validateExactNumberOfArgs",
-                "validateType",
-                "valueDescription"
+                "uint8ArrayFromBinaryString"
             ],
             "classes": [
-                "Blob",
                 "ByteString",
+                "Bytes",
                 "DatabaseId",
                 "FirebaseCredentialsProvider",
                 "Firestore",
@@ -38,7 +28,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 12362
+        "sizeInBytes": 9275
     },
     "CollectionReference": {
         "dependencies": {
@@ -68,7 +58,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 9591
+        "sizeInBytes": 9454
     },
     "DocumentReference": {
         "dependencies": {
@@ -98,13 +88,12 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 10963
+        "sizeInBytes": 10902
     },
     "DocumentSnapshot": {
         "dependencies": {
             "functions": [
                 "argToString",
-                "assertUint8ArrayAvailable",
                 "binaryStringFromUint8Array",
                 "cast",
                 "createError",
@@ -146,8 +135,8 @@
             "classes": [
                 "BaseFieldPath",
                 "BasePath",
-                "Blob",
                 "ByteString",
+                "Bytes",
                 "DatabaseId",
                 "DocumentKey",
                 "DocumentKeyReference",
@@ -169,7 +158,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 28960
+        "sizeInBytes": 28501
     },
     "FieldPath": {
         "dependencies": {
@@ -207,7 +196,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 14035
+        "sizeInBytes": 13898
     },
     "FieldValue": {
         "dependencies": {
@@ -234,7 +223,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 7665
+        "sizeInBytes": 7528
     },
     "FirebaseFirestore": {
         "dependencies": {
@@ -259,7 +248,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 7572
+        "sizeInBytes": 7435
     },
     "GeoPoint": {
         "dependencies": {
@@ -293,7 +282,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 10426
+        "sizeInBytes": 10346
     },
     "Query": {
         "dependencies": {
@@ -319,7 +308,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 7767
+        "sizeInBytes": 7630
     },
     "QueryConstraint": {
         "dependencies": {
@@ -345,13 +334,12 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 7580
+        "sizeInBytes": 7443
     },
     "QueryDocumentSnapshot": {
         "dependencies": {
             "functions": [
                 "argToString",
-                "assertUint8ArrayAvailable",
                 "binaryStringFromUint8Array",
                 "cast",
                 "createError",
@@ -393,8 +381,8 @@
             "classes": [
                 "BaseFieldPath",
                 "BasePath",
-                "Blob",
                 "ByteString",
+                "Bytes",
                 "DatabaseId",
                 "DocumentKey",
                 "DocumentKeyReference",
@@ -416,7 +404,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 28965
+        "sizeInBytes": 28506
     },
     "QuerySnapshot": {
         "dependencies": {
@@ -442,7 +430,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 7806
+        "sizeInBytes": 7669
     },
     "Timestamp": {
         "dependencies": {
@@ -468,7 +456,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 9108
+        "sizeInBytes": 9038
     },
     "Transaction": {
         "dependencies": {
@@ -476,7 +464,6 @@
                 "applyFirestoreDataConverter",
                 "argToString",
                 "arrayEquals",
-                "assertUint8ArrayAvailable",
                 "binaryStringFromUint8Array",
                 "blobEquals",
                 "cast",
@@ -552,8 +539,8 @@
             "classes": [
                 "BaseFieldPath",
                 "BasePath",
-                "Blob",
                 "ByteString",
+                "Bytes",
                 "DatabaseId",
                 "DeleteFieldValueImpl",
                 "Document",
@@ -594,7 +581,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 51878
+        "sizeInBytes": 51433
     },
     "WriteBatch": {
         "dependencies": {
@@ -602,7 +589,6 @@
                 "applyFirestoreDataConverter",
                 "argToString",
                 "arrayEquals",
-                "assertUint8ArrayAvailable",
                 "binaryStringFromUint8Array",
                 "blobEquals",
                 "cast",
@@ -675,8 +661,8 @@
             "classes": [
                 "BaseFieldPath",
                 "BasePath",
-                "Blob",
                 "ByteString",
+                "Bytes",
                 "DatabaseId",
                 "DeleteFieldValueImpl",
                 "DeleteMutation",
@@ -712,7 +698,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 46640
+        "sizeInBytes": 46094
     },
     "addDoc": {
         "dependencies": {
@@ -721,7 +707,6 @@
                 "applyFirestoreDataConverter",
                 "argToString",
                 "arrayEquals",
-                "assertUint8ArrayAvailable",
                 "binaryStringFromUint8Array",
                 "blobEquals",
                 "cast",
@@ -816,8 +801,8 @@
                 "AutoId",
                 "BaseFieldPath",
                 "BasePath",
-                "Blob",
                 "ByteString",
+                "Bytes",
                 "CollectionReference",
                 "DatabaseId",
                 "DatabaseInfo",
@@ -861,14 +846,13 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 55128
+        "sizeInBytes": 54753
     },
     "arrayRemove": {
         "dependencies": {
             "functions": [
                 "argToString",
                 "arrayRemove",
-                "assertUint8ArrayAvailable",
                 "binaryStringFromUint8Array",
                 "createError",
                 "createSentinelChildContext",
@@ -880,7 +864,6 @@
                 "formatPlural",
                 "fullyQualifiedPrefixPath",
                 "hardAssert",
-                "invalidClassError",
                 "isEmpty",
                 "isNegativeZero",
                 "isPlainObject",
@@ -917,8 +900,8 @@
                 "ArrayRemoveFieldValueImpl",
                 "ArrayRemoveTransformOperation",
                 "BasePath",
-                "Blob",
                 "ByteString",
+                "Bytes",
                 "DatabaseId",
                 "DocumentKeyReference",
                 "FieldTransform",
@@ -938,14 +921,13 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 26932
+        "sizeInBytes": 26033
     },
     "arrayUnion": {
         "dependencies": {
             "functions": [
                 "argToString",
                 "arrayUnion",
-                "assertUint8ArrayAvailable",
                 "binaryStringFromUint8Array",
                 "createError",
                 "createSentinelChildContext",
@@ -957,7 +939,6 @@
                 "formatPlural",
                 "fullyQualifiedPrefixPath",
                 "hardAssert",
-                "invalidClassError",
                 "isEmpty",
                 "isNegativeZero",
                 "isPlainObject",
@@ -994,8 +975,8 @@
                 "ArrayUnionFieldValueImpl",
                 "ArrayUnionTransformOperation",
                 "BasePath",
-                "Blob",
                 "ByteString",
+                "Bytes",
                 "DatabaseId",
                 "DocumentKeyReference",
                 "FieldTransform",
@@ -1015,7 +996,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 26924
+        "sizeInBytes": 26025
     },
     "collection": {
         "dependencies": {
@@ -1058,7 +1039,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 15670
+        "sizeInBytes": 15609
     },
     "collectionGroup": {
         "dependencies": {
@@ -1097,7 +1078,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 14055
+        "sizeInBytes": 13918
     },
     "deleteDoc": {
         "dependencies": {
@@ -1170,7 +1151,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 25037
+        "sizeInBytes": 25147
     },
     "deleteField": {
         "dependencies": {
@@ -1200,7 +1181,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 8631
+        "sizeInBytes": 8494
     },
     "doc": {
         "dependencies": {
@@ -1245,7 +1226,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 16222
+        "sizeInBytes": 16161
     },
     "documentId": {
         "dependencies": {
@@ -1284,13 +1265,12 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 14085
+        "sizeInBytes": 13948
     },
     "endAt": {
         "dependencies": {
             "functions": [
                 "argToString",
-                "assertUint8ArrayAvailable",
                 "binaryStringFromUint8Array",
                 "cast",
                 "createError",
@@ -1362,9 +1342,9 @@
             "classes": [
                 "BaseFieldPath",
                 "BasePath",
-                "Blob",
                 "Bound",
                 "ByteString",
+                "Bytes",
                 "DatabaseId",
                 "DocumentKey",
                 "DocumentKeyReference",
@@ -1395,13 +1375,12 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 43931
+        "sizeInBytes": 43486
     },
     "endBefore": {
         "dependencies": {
             "functions": [
                 "argToString",
-                "assertUint8ArrayAvailable",
                 "binaryStringFromUint8Array",
                 "cast",
                 "createError",
@@ -1473,9 +1452,9 @@
             "classes": [
                 "BaseFieldPath",
                 "BasePath",
-                "Blob",
                 "Bound",
                 "ByteString",
+                "Bytes",
                 "DatabaseId",
                 "DocumentKey",
                 "DocumentKeyReference",
@@ -1506,7 +1485,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 43942
+        "sizeInBytes": 43497
     },
     "getDoc": {
         "dependencies": {
@@ -1514,7 +1493,6 @@
                 "argToString",
                 "arrayEquals",
                 "assertPresent",
-                "assertUint8ArrayAvailable",
                 "binaryStringFromUint8Array",
                 "blobEquals",
                 "cast",
@@ -1589,8 +1567,8 @@
             "classes": [
                 "BaseFieldPath",
                 "BasePath",
-                "Blob",
                 "ByteString",
+                "Bytes",
                 "DatabaseId",
                 "DatabaseInfo",
                 "Datastore",
@@ -1624,25 +1602,16 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 45402
+        "sizeInBytes": 45103
     },
     "getDocs": {
         "dependencies": {
             "functions": [
                 "argToString",
                 "arrayEquals",
-                "arrayValueContains",
-                "assertUint8ArrayAvailable",
                 "binaryStringFromUint8Array",
                 "blobEquals",
                 "cast",
-                "compareArrays",
-                "compareBlobs",
-                "compareGeoPoints",
-                "compareMaps",
-                "compareNumbers",
-                "compareReferences",
-                "compareTimestamps",
                 "createError",
                 "createMetadata",
                 "debugCast",
@@ -1666,13 +1635,11 @@
                 "geoPointEquals",
                 "getDatastore",
                 "getDocs",
-                "getEncodedDatabaseId",
                 "getLocalWriteTime",
                 "getPreviousValue",
                 "hardAssert",
                 "invalidClassError",
                 "invokeRunQueryRpc",
-                "isArray",
                 "isMapValue",
                 "isNanValue",
                 "isNegativeZero",
@@ -1724,18 +1691,15 @@
                 "validateHasExplicitOrderByForLimitToLast",
                 "validateNamedArrayAtLeastNumberOfElements",
                 "validateType",
-                "valueCompare",
                 "valueDescription",
                 "valueEquals"
             ],
             "classes": [
-                "ArrayContainsAnyFilter",
-                "ArrayContainsFilter",
                 "BaseFieldPath",
                 "BasePath",
-                "Blob",
                 "Bound",
                 "ByteString",
+                "Bytes",
                 "DatabaseId",
                 "DatabaseInfo",
                 "Datastore",
@@ -1746,20 +1710,15 @@
                 "DocumentKeyReference",
                 "DocumentReference",
                 "DocumentSnapshot",
-                "FieldFilter",
                 "FieldPath",
                 "FieldPath$1",
                 "FieldPath$2",
-                "Filter",
                 "FirebaseCredentialsProvider",
                 "Firestore",
                 "FirestoreError",
                 "GeoPoint",
                 "GrpcConnection",
-                "InFilter",
                 "JsonProtoSerializer",
-                "KeyFieldFilter",
-                "KeyFieldInFilter",
                 "MaybeDocument",
                 "OAuthToken",
                 "ObjectValue",
@@ -1778,7 +1737,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 57670
+        "sizeInBytes": 51171
     },
     "getFirestore": {
         "dependencies": {
@@ -1804,7 +1763,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 7651
+        "sizeInBytes": 7514
     },
     "increment": {
         "dependencies": {
@@ -1842,7 +1801,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 9496
+        "sizeInBytes": 9359
     },
     "initializeFirestore": {
         "dependencies": {
@@ -1868,7 +1827,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 7737
+        "sizeInBytes": 7600
     },
     "limit": {
         "dependencies": {
@@ -1902,7 +1861,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 10081
+        "sizeInBytes": 9944
     },
     "limitToLast": {
         "dependencies": {
@@ -1936,7 +1895,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 10105
+        "sizeInBytes": 9968
     },
     "orderBy": {
         "dependencies": {
@@ -1992,7 +1951,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 19726
+        "sizeInBytes": 19589
     },
     "parent": {
         "dependencies": {
@@ -2029,7 +1988,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 13731
+        "sizeInBytes": 13670
     },
     "query": {
         "dependencies": {
@@ -2057,25 +2016,17 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 8348
+        "sizeInBytes": 8211
     },
     "queryEqual": {
         "dependencies": {
             "functions": [
                 "argToString",
                 "arrayEquals",
-                "arrayValueContains",
                 "binaryStringFromUint8Array",
                 "blobEquals",
                 "boundEquals",
                 "cast",
-                "compareArrays",
-                "compareBlobs",
-                "compareGeoPoints",
-                "compareMaps",
-                "compareNumbers",
-                "compareReferences",
-                "compareTimestamps",
                 "decodeBase64",
                 "encodeBase64",
                 "fail",
@@ -2084,11 +2035,8 @@
                 "geoPointEquals",
                 "getLocalWriteTime",
                 "hardAssert",
-                "isArray",
-                "isNanValue",
                 "isNegativeZero",
                 "isNullOrUndefined",
-                "isNullValue",
                 "isServerTimestamp",
                 "logDebug",
                 "logError",
@@ -2111,38 +2059,28 @@
                 "timestampEquals",
                 "typeOrder",
                 "uint8ArrayFromBinaryString",
-                "valueCompare",
                 "valueEquals"
             ],
             "classes": [
-                "ArrayContainsAnyFilter",
-                "ArrayContainsFilter",
                 "BasePath",
                 "Bound",
                 "ByteString",
                 "DatabaseId",
-                "DocumentKey",
-                "FieldFilter",
                 "FieldPath",
-                "Filter",
                 "FirebaseCredentialsProvider",
                 "Firestore",
                 "FirestoreError",
-                "InFilter",
-                "KeyFieldFilter",
-                "KeyFieldInFilter",
                 "OAuthToken",
                 "OrderBy",
                 "Query",
                 "QueryImpl",
-                "ResourcePath",
                 "TargetImpl",
                 "Timestamp",
                 "User"
             ],
             "variables": []
         },
-        "sizeInBytes": 31633
+        "sizeInBytes": 24160
     },
     "refEqual": {
         "dependencies": {
@@ -2178,7 +2116,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 13278
+        "sizeInBytes": 13217
     },
     "runTransaction": {
         "dependencies": {
@@ -2187,7 +2125,6 @@
                 "argToString",
                 "arrayEquals",
                 "assertPresent",
-                "assertUint8ArrayAvailable",
                 "binaryStringFromUint8Array",
                 "blobEquals",
                 "cast",
@@ -2221,7 +2158,6 @@
                 "getLocalWriteTime",
                 "getMessageOrStack",
                 "getPreviousValue",
-                "getWindow",
                 "hardAssert",
                 "invalidClassError",
                 "invokeBatchGetDocumentsRpc",
@@ -2299,8 +2235,8 @@
                 "AsyncQueue",
                 "BaseFieldPath",
                 "BasePath",
-                "Blob",
                 "ByteString",
+                "Bytes",
                 "DatabaseId",
                 "DatabaseInfo",
                 "Datastore",
@@ -2357,7 +2293,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 77256
+        "sizeInBytes": 76519
     },
     "serverTimestamp": {
         "dependencies": {
@@ -2390,7 +2326,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 8619
+        "sizeInBytes": 8482
     },
     "setDoc": {
         "dependencies": {
@@ -2398,7 +2334,6 @@
                 "applyFirestoreDataConverter",
                 "argToString",
                 "arrayEquals",
-                "assertUint8ArrayAvailable",
                 "binaryStringFromUint8Array",
                 "blobEquals",
                 "cast",
@@ -2488,8 +2423,8 @@
                 "ArrayUnionTransformOperation",
                 "BaseFieldPath",
                 "BasePath",
-                "Blob",
                 "ByteString",
+                "Bytes",
                 "DatabaseId",
                 "DatabaseInfo",
                 "Datastore",
@@ -2530,7 +2465,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 51491
+        "sizeInBytes": 51116
     },
     "setLogLevel": {
         "dependencies": {
@@ -2556,26 +2491,17 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 7616
+        "sizeInBytes": 7479
     },
     "snapshotEqual": {
         "dependencies": {
             "functions": [
                 "argToString",
                 "arrayEquals",
-                "arrayValueContains",
-                "assertUint8ArrayAvailable",
                 "binaryStringFromUint8Array",
                 "blobEquals",
                 "boundEquals",
                 "cast",
-                "compareArrays",
-                "compareBlobs",
-                "compareGeoPoints",
-                "compareMaps",
-                "compareNumbers",
-                "compareReferences",
-                "compareTimestamps",
                 "createError",
                 "decodeBase64",
                 "encodeBase64",
@@ -2593,11 +2519,8 @@
                 "getPreviousValue",
                 "hardAssert",
                 "invalidClassError",
-                "isArray",
-                "isNanValue",
                 "isNegativeZero",
                 "isNullOrUndefined",
-                "isNullValue",
                 "isPlainObject",
                 "isServerTimestamp",
                 "isValidResourceName",
@@ -2629,35 +2552,27 @@
                 "validateExactNumberOfArgs",
                 "validateNamedArrayAtLeastNumberOfElements",
                 "validateType",
-                "valueCompare",
                 "valueDescription",
                 "valueEquals"
             ],
             "classes": [
-                "ArrayContainsAnyFilter",
-                "ArrayContainsFilter",
                 "BaseFieldPath",
                 "BasePath",
-                "Blob",
                 "Bound",
                 "ByteString",
+                "Bytes",
                 "DatabaseId",
                 "DocumentKey",
                 "DocumentKeyReference",
                 "DocumentReference",
                 "DocumentSnapshot",
-                "FieldFilter",
                 "FieldPath",
                 "FieldPath$1",
                 "FieldPath$2",
-                "Filter",
                 "FirebaseCredentialsProvider",
                 "Firestore",
                 "FirestoreError",
                 "GeoPoint",
-                "InFilter",
-                "KeyFieldFilter",
-                "KeyFieldInFilter",
                 "OAuthToken",
                 "OrderBy",
                 "Query",
@@ -2672,13 +2587,12 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 44083
+        "sizeInBytes": 37322
     },
     "startAfter": {
         "dependencies": {
             "functions": [
                 "argToString",
-                "assertUint8ArrayAvailable",
                 "binaryStringFromUint8Array",
                 "cast",
                 "createError",
@@ -2750,9 +2664,9 @@
             "classes": [
                 "BaseFieldPath",
                 "BasePath",
-                "Blob",
                 "Bound",
                 "ByteString",
+                "Bytes",
                 "DatabaseId",
                 "DocumentKey",
                 "DocumentKeyReference",
@@ -2783,13 +2697,12 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 43952
+        "sizeInBytes": 43507
     },
     "startAt": {
         "dependencies": {
             "functions": [
                 "argToString",
-                "assertUint8ArrayAvailable",
                 "binaryStringFromUint8Array",
                 "cast",
                 "createError",
@@ -2861,9 +2774,9 @@
             "classes": [
                 "BaseFieldPath",
                 "BasePath",
-                "Blob",
                 "Bound",
                 "ByteString",
+                "Bytes",
                 "DatabaseId",
                 "DocumentKey",
                 "DocumentKeyReference",
@@ -2894,7 +2807,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 43942
+        "sizeInBytes": 43497
     },
     "terminate": {
         "dependencies": {
@@ -2921,14 +2834,13 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 8149
+        "sizeInBytes": 8012
     },
     "updateDoc": {
         "dependencies": {
             "functions": [
                 "argToString",
                 "arrayEquals",
-                "assertUint8ArrayAvailable",
                 "binaryStringFromUint8Array",
                 "blobEquals",
                 "cast",
@@ -3020,8 +2932,8 @@
                 "ArrayUnionTransformOperation",
                 "BaseFieldPath",
                 "BasePath",
-                "Blob",
                 "ByteString",
+                "Bytes",
                 "DatabaseId",
                 "DatabaseInfo",
                 "Datastore",
@@ -3065,7 +2977,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 54598
+        "sizeInBytes": 54223
     },
     "where": {
         "dependencies": {
@@ -3073,7 +2985,6 @@
                 "argToString",
                 "arrayEquals",
                 "arrayValueContains",
-                "assertUint8ArrayAvailable",
                 "binaryStringFromUint8Array",
                 "blobEquals",
                 "cast",
@@ -3084,10 +2995,12 @@
                 "compareNumbers",
                 "compareReferences",
                 "compareTimestamps",
+                "conflictingOps",
                 "createError",
                 "decodeBase64",
                 "encodeBase64",
                 "errorMessage",
+                "extractDocumentKeysFromArrayValue",
                 "fail",
                 "fieldPathFromArgument$1",
                 "fieldPathFromDotSeparatedString",
@@ -3164,8 +3077,8 @@
                 "ArrayContainsFilter",
                 "BaseFieldPath",
                 "BasePath",
-                "Blob",
                 "ByteString",
+                "Bytes",
                 "DatabaseId",
                 "DocumentKey",
                 "DocumentKeyReference",
@@ -3182,6 +3095,8 @@
                 "JsonProtoSerializer",
                 "KeyFieldFilter",
                 "KeyFieldInFilter",
+                "KeyFieldNotInFilter",
+                "NotInFilter",
                 "OAuthToken",
                 "ParseContext",
                 "Query",
@@ -3196,7 +3111,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 49321
+        "sizeInBytes": 49811
     },
     "writeBatch": {
         "dependencies": {
@@ -3204,7 +3119,6 @@
                 "applyFirestoreDataConverter",
                 "argToString",
                 "arrayEquals",
-                "assertUint8ArrayAvailable",
                 "binaryStringFromUint8Array",
                 "blobEquals",
                 "cast",
@@ -3298,8 +3212,8 @@
                 "ArrayUnionTransformOperation",
                 "BaseFieldPath",
                 "BasePath",
-                "Blob",
                 "ByteString",
+                "Bytes",
                 "DatabaseId",
                 "DatabaseInfo",
                 "Datastore",
@@ -3345,6 +3259,6 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 58299
+        "sizeInBytes": 57924
     }
 }

--- a/packages/firestore/lite/index.ts
+++ b/packages/firestore/lite/index.ts
@@ -80,7 +80,7 @@ export { Transaction, runTransaction } from './src/api/transaction';
 
 export { setLogLevel } from '../src/util/log';
 
-export { Blob } from '../src/api/blob';
+export { Bytes } from './src/api/bytes';
 
 export { GeoPoint } from '../src/api/geo_point';
 

--- a/packages/firestore/lite/src/api/bytes.ts
+++ b/packages/firestore/lite/src/api/bytes.ts
@@ -1,0 +1,59 @@
+/**
+ * @license
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Code, FirestoreError } from '../../../src/util/error';
+import { ByteString } from '../../../src/util/byte_string';
+
+/** Immutable class holding binary data in the Lite and modular SDK. */
+export class Bytes {
+  _byteString: ByteString;
+
+  constructor(byteString: ByteString) {
+    this._byteString = byteString;
+  }
+
+  static fromBase64String(base64: string): Bytes {
+    try {
+      return new Bytes(ByteString.fromBase64String(base64));
+    } catch (e) {
+      throw new FirestoreError(
+        Code.INVALID_ARGUMENT,
+        'Failed to construct Bytes from Base64 string: ' + e
+      );
+    }
+  }
+
+  static fromUint8Array(array: Uint8Array): Bytes {
+    return new Bytes(ByteString.fromUint8Array(array));
+  }
+
+  toBase64(): string {
+    return this._byteString.toBase64();
+  }
+
+  toUint8Array(): Uint8Array {
+    return this._byteString.toUint8Array();
+  }
+
+  toString(): string {
+    return 'Bytes(base64: ' + this.toBase64() + ')';
+  }
+
+  isEqual(other: Bytes): boolean {
+    return this._byteString.isEqual(other._byteString);
+  }
+}

--- a/packages/firestore/lite/src/api/snapshot.ts
+++ b/packages/firestore/lite/src/api/snapshot.ts
@@ -30,6 +30,7 @@ import {
   UntypedFirestoreDataConverter
 } from '../../../src/api/user_data_reader';
 import { arrayEquals } from '../../../src/util/misc';
+import { Bytes } from './bytes';
 
 export class DocumentSnapshot<T = firestore.DocumentData>
   implements firestore.DocumentSnapshot<T> {
@@ -84,7 +85,8 @@ export class DocumentSnapshot<T = firestore.DocumentData>
             this._firestore,
             /* converter= */ null,
             key.path
-          )
+          ),
+        bytes => new Bytes(bytes)
       );
       return userDataWriter.convertValue(this._document.toProto()) as T;
     }
@@ -101,7 +103,8 @@ export class DocumentSnapshot<T = firestore.DocumentData>
           /* timestampsInSnapshots= */ true,
           /* serverTimestampBehavior=*/ 'none',
           key =>
-            new DocumentReference(this._firestore, this._converter, key.path)
+            new DocumentReference(this._firestore, this._converter, key.path),
+          bytes => new Bytes(bytes)
         );
         return userDataWriter.convertValue(value);
       }

--- a/packages/firestore/lite/test/integration.test.ts
+++ b/packages/firestore/lite/test/integration.test.ts
@@ -81,6 +81,7 @@ import {
 } from '../../test/integration/util/settings';
 import { expectEqual, expectNotEqual } from '../../test/util/helpers';
 import { Timestamp } from '../../src/api/timestamp';
+import { Bytes } from '../src/api/bytes';
 
 use(chaiAsPromised);
 
@@ -713,6 +714,17 @@ describe('DocumentSnapshot', () => {
       }
       expect(documentData).to.deep.equal({ foo: 1 });
     });
+  });
+
+  it('returns Bytes', () => {
+    return withTestDocAndInitialData(
+      { bytes: Bytes.fromBase64String('aa') },
+      async docRef => {
+        const docSnap = await getDoc(docRef);
+        let bytes = docSnap.get('bytes')!;
+        expect(bytes.constructor.name).to.equal('Bytes');
+      }
+    );
   });
 });
 

--- a/packages/firestore/lite/test/integration.test.ts
+++ b/packages/firestore/lite/test/integration.test.ts
@@ -721,7 +721,7 @@ describe('DocumentSnapshot', () => {
       { bytes: Bytes.fromBase64String('aa') },
       async docRef => {
         const docSnap = await getDoc(docRef);
-        let bytes = docSnap.get('bytes')!;
+        const bytes = docSnap.get('bytes')!;
         expect(bytes.constructor.name).to.equal('Bytes');
       }
     );

--- a/packages/firestore/src/api/blob.ts
+++ b/packages/firestore/src/api/blob.ts
@@ -23,6 +23,7 @@ import {
   validateExactNumberOfArgs
 } from '../util/input_validation';
 import { ByteString } from '../util/byte_string';
+import { Bytes } from '../../lite/src/api/bytes';
 
 /** Helper function to assert Uint8Array is available at runtime. */
 function assertUint8ArrayAvailable(): void {
@@ -51,14 +52,9 @@ function assertBase64Available(): void {
  * Note that while you can't hide the constructor in JavaScript code, we are
  * using the hack above to make sure no-one outside this module can call it.
  */
-export class Blob {
-  // Prefix with underscore to signal that we consider this not part of the
-  // public API and to prevent it from showing up for autocompletion.
-  _byteString: ByteString;
-
+export class Blob extends Bytes {
   constructor(byteString: ByteString) {
-    assertBase64Available();
-    this._byteString = byteString;
+    super(byteString);
   }
 
   static fromBase64String(base64: string): Blob {
@@ -87,13 +83,13 @@ export class Blob {
   toBase64(): string {
     validateExactNumberOfArgs('Blob.toBase64', arguments, 0);
     assertBase64Available();
-    return this._byteString.toBase64();
+    return super.toBase64();
   }
 
   toUint8Array(): Uint8Array {
     validateExactNumberOfArgs('Blob.toUint8Array', arguments, 0);
     assertUint8ArrayAvailable();
-    return this._byteString.toUint8Array();
+    return super.toUint8Array();
   }
 
   toString(): string {
@@ -101,6 +97,6 @@ export class Blob {
   }
 
   isEqual(other: Blob): boolean {
-    return this._byteString.isEqual(other._byteString);
+    return super.isEqual(other);
   }
 }

--- a/packages/firestore/src/api/blob.ts
+++ b/packages/firestore/src/api/blob.ts
@@ -91,8 +91,4 @@ export class Blob extends Bytes {
   toString(): string {
     return 'Blob(base64: ' + this.toBase64() + ')';
   }
-
-  isEqual(other: Blob): boolean {
-    return super.isEqual(other);
-  }
 }

--- a/packages/firestore/src/api/blob.ts
+++ b/packages/firestore/src/api/blob.ts
@@ -53,10 +53,6 @@ function assertBase64Available(): void {
  * using the hack above to make sure no-one outside this module can call it.
  */
 export class Blob extends Bytes {
-  constructor(byteString: ByteString) {
-    super(byteString);
-  }
-
   static fromBase64String(base64: string): Blob {
     validateExactNumberOfArgs('Blob.fromBase64String', arguments, 1);
     validateArgType('Blob.fromBase64String', 'string', 1, base64);

--- a/packages/firestore/src/api/database.ts
+++ b/packages/firestore/src/api/database.ts
@@ -45,6 +45,7 @@ import {
 
 import { FirebaseApp } from '@firebase/app-types';
 import { _FirebaseApp, FirebaseService } from '@firebase/app-types/private';
+import { Blob } from './blob';
 import { DatabaseId, DatabaseInfo } from '../core/database_info';
 import { ListenOptions } from '../core/event_manager';
 import {
@@ -1369,7 +1370,8 @@ export class DocumentSnapshot<T = DocumentData>
           this._firestore._areTimestampsInSnapshotsEnabled(),
           options.serverTimestamps || 'none',
           key =>
-            new DocumentReference(key, this._firestore, /* converter= */ null)
+            new DocumentReference(key, this._firestore, /* converter= */ null),
+          bytes => new Blob(bytes)
         );
         return userDataWriter.convertValue(this._document.toProto()) as T;
       }
@@ -1393,7 +1395,8 @@ export class DocumentSnapshot<T = DocumentData>
           this._firestore._databaseId,
           this._firestore._areTimestampsInSnapshotsEnabled(),
           options.serverTimestamps || 'none',
-          key => new DocumentReference(key, this._firestore, this._converter)
+          key => new DocumentReference(key, this._firestore, this._converter),
+          bytes => new Blob(bytes)
         );
         return userDataWriter.convertValue(value);
       }

--- a/packages/firestore/src/api/user_data_reader.ts
+++ b/packages/firestore/src/api/user_data_reader.ts
@@ -51,6 +51,7 @@ import { BaseFieldPath, fromDotSeparatedString } from './field_path';
 import { DeleteFieldValueImpl, SerializableFieldValue } from './field_value';
 import { GeoPoint } from './geo_point';
 import { newSerializer } from '../platform/serializer';
+import { Bytes } from '../../lite/src/api/bytes';
 
 const RESERVED_FIELD_REGEX = /^__.*__$/;
 
@@ -711,8 +712,8 @@ function parseScalarValue(
         longitude: value.longitude
       }
     };
-  } else if (value instanceof Blob) {
-    return { bytesValue: toBytes(context.serializer, value) };
+  } else if (value instanceof Bytes) {
+    return { bytesValue: toBytes(context.serializer, value._byteString) };
   } else if (value instanceof DocumentKeyReference) {
     const thisDb = context.databaseId;
     const otherDb = value._databaseId;
@@ -753,7 +754,7 @@ function looksLikeJsonObject(input: unknown): boolean {
     !(input instanceof Date) &&
     !(input instanceof Timestamp) &&
     !(input instanceof GeoPoint) &&
-    !(input instanceof Blob) &&
+    !(input instanceof Bytes) &&
     !(input instanceof DocumentKeyReference) &&
     !(input instanceof SerializableFieldValue)
   );

--- a/packages/firestore/src/api/user_data_reader.ts
+++ b/packages/firestore/src/api/user_data_reader.ts
@@ -46,7 +46,6 @@ import {
   toResourceName,
   toTimestamp
 } from '../remote/serializer';
-import { Blob } from './blob';
 import { BaseFieldPath, fromDotSeparatedString } from './field_path';
 import { DeleteFieldValueImpl, SerializableFieldValue } from './field_value';
 import { GeoPoint } from './geo_point';

--- a/packages/firestore/src/api/user_data_writer.ts
+++ b/packages/firestore/src/api/user_data_writer.ts
@@ -25,7 +25,6 @@ import {
   Value as ProtoValue
 } from '../protos/firestore_proto_api';
 import { DocumentKeyReference } from './user_data_reader';
-import { Blob } from './blob';
 import { GeoPoint } from './geo_point';
 import { Timestamp } from './timestamp';
 import { DatabaseId } from '../core/database_info';

--- a/packages/firestore/src/api/user_data_writer.ts
+++ b/packages/firestore/src/api/user_data_writer.ts
@@ -46,6 +46,8 @@ import { TypeOrder } from '../model/object_value';
 import { ResourcePath } from '../model/path';
 import { isValidResourceName } from '../remote/serializer';
 import { logError } from '../util/log';
+import { ByteString } from '../util/byte_string';
+import { Bytes } from '../../lite/src/api/bytes';
 
 export type ServerTimestampBehavior = 'estimate' | 'previous' | 'none';
 
@@ -60,7 +62,8 @@ export class UserDataWriter {
     private readonly serverTimestampBehavior: ServerTimestampBehavior,
     private readonly referenceFactory: (
       key: DocumentKey
-    ) => DocumentKeyReference<DocumentData>
+    ) => DocumentKeyReference<DocumentData>,
+    private readonly bytesFactory: (bytes: ByteString) => Bytes
   ) {}
 
   convertValue(value: ProtoValue): unknown {
@@ -78,7 +81,7 @@ export class UserDataWriter {
       case TypeOrder.StringValue:
         return value.stringValue!;
       case TypeOrder.BlobValue:
-        return new Blob(normalizeByteString(value.bytesValue!));
+        return this.bytesFactory(normalizeByteString(value.bytesValue!));
       case TypeOrder.RefValue:
         return this.convertReference(value.referenceValue!);
       case TypeOrder.GeoPointValue:

--- a/packages/firestore/src/remote/serializer.ts
+++ b/packages/firestore/src/remote/serializer.ts
@@ -265,7 +265,7 @@ function fromTimestamp(date: ProtoTimestamp): Timestamp {
  */
 export function toBytes(
   serializer: JsonProtoSerializer,
-  bytes: Blob | ByteString
+  bytes: ByteString
 ): string | Uint8Array {
   if (serializer.useProto3Json) {
     return bytes.toBase64();

--- a/packages/firestore/src/remote/serializer.ts
+++ b/packages/firestore/src/remote/serializer.ts
@@ -15,7 +15,6 @@
  * limitations under the License.
  */
 
-import { Blob } from '../api/blob';
 import { Timestamp } from '../api/timestamp';
 import { DatabaseId } from '../core/database_info';
 import {

--- a/packages/firestore/test/util/helpers.ts
+++ b/packages/firestore/test/util/helpers.ts
@@ -113,7 +113,8 @@ export function testUserDataWriter(): UserDataWriter {
     TEST_DATABASE_ID,
     /* timestampsInSnapshots= */ false,
     'none',
-    key => new DocumentReference(key, FIRESTORE, /* converter= */ null)
+    key => new DocumentReference(key, FIRESTORE, /* converter= */ null),
+    bytes => new Blob(bytes)
   );
 }
 


### PR DESCRIPTION
As part of go/firestore-next-amendment-amendment, we decided to rename Blob to Bytes to avoid name clashes with the JavaScript Blob type.

Couple notes:
- I created a new type instead of renaming the export since the error messages would have been incorrect. 
- I removed the now incorrect error messages in the new type.
- I believe all of our platforms now support byte conversion (since we have the Polyfill for ReactNative, which was required to make stream resumption work). Hence, I did not port the validation.
- The old Blob type now extends Bytes to make it easier for the serializer to use common logic.