### PR TITLE
Don't switch network status to UNKNOWN during user change

### DIFF
--- a/.changeset/cold-impalas-drop.md
+++ b/.changeset/cold-impalas-drop.md
@@ -1,0 +1,5 @@
+---
+"@firebase/firestore": patch
+---
+
+Fixes a bug that caused the client to not raise snapshots from cache if a user change happened while the network connection was disabled.

--- a/packages/firestore/exp/src/api/components.ts
+++ b/packages/firestore/exp/src/api/components.ts
@@ -98,7 +98,7 @@ export async function setOnlineComponentProvider(
   // The CredentialChangeListener of the online component provider takes
   // precedence over the offline component provider.
   firestore._setCredentialChangeListener(user =>
-    // TODO(firestoreexp): This should be enqueue retryable.
+    // TODO(firestoreexp): This should be enqueueRetryable.
     firestore._queue.enqueueAndForget(() =>
       onlineComponentProvider.remoteStore.handleCredentialChange(user)
     )

--- a/packages/firestore/exp/src/api/components.ts
+++ b/packages/firestore/exp/src/api/components.ts
@@ -98,6 +98,7 @@ export async function setOnlineComponentProvider(
   // The CredentialChangeListener of the online component provider takes
   // precedence over the offline component provider.
   firestore._setCredentialChangeListener(user =>
+    // TODO(firestoreexp): This should be enqueue retryable.
     firestore._queue.enqueueAndForget(() =>
       onlineComponentProvider.remoteStore.handleCredentialChange(user)
     )

--- a/packages/firestore/src/remote/remote_store.ts
+++ b/packages/firestore/src/remote/remote_store.ts
@@ -797,19 +797,17 @@ export class RemoteStore implements TargetMetadataProvider {
     );
 
     logDebug(LOG_TAG, 'RemoteStore received new credentials');
-
-    if (!this.canUseNetwork()) {
-      // If the network has been explicitly disabled, make sure we don't
-      // accidentally re-enable it.
-      return this.remoteSyncer.handleCredentialChange(user);
-    }
+    const canUseNetwork = this.canUseNetwork();
 
     // Tear down and re-create our network streams. This will ensure we get a
     // fresh auth token for the new user and re-fill the write pipeline with
     // new mutations from the LocalStore (since mutations are per-user).
     this.offlineCauses.add(OfflineCause.CredentialChange);
     await this.disableNetworkInternal();
-    this.onlineStateTracker.set(OnlineState.Unknown);
+    if (canUseNetwork) {
+      // Don't set the network status to Unknown if we are offline.
+      this.onlineStateTracker.set(OnlineState.Unknown);
+    }
     await this.remoteSyncer.handleCredentialChange(user);
     this.offlineCauses.delete(OfflineCause.CredentialChange);
     await this.enableNetworkInternal();

--- a/packages/firestore/test/unit/specs/offline_spec.test.ts
+++ b/packages/firestore/test/unit/specs/offline_spec.test.ts
@@ -239,4 +239,22 @@ describeSpec('Offline:', [], () => {
       );
     }
   );
+
+  specTest(
+    'Client stays offline during credential change',
+    ['exclusive'],
+    () => {
+      // Reproduces a bug that caused the client to switch to OnlineState
+      // `Unknown` during a credential change.
+
+      const query1 = query('collection');
+      return spec()
+        .disableNetwork()
+        .changeUser('user1')
+        .userListens(query1)
+        .expectEvents(query1, {
+          fromCache: true
+        });
+    }
+  );
 });

--- a/packages/firestore/test/unit/specs/offline_spec.test.ts
+++ b/packages/firestore/test/unit/specs/offline_spec.test.ts
@@ -240,21 +240,17 @@ describeSpec('Offline:', [], () => {
     }
   );
 
-  specTest(
-    'Client stays offline during credential change',
-    ['exclusive'],
-    () => {
-      // Reproduces a bug that caused the client to switch to OnlineState
-      // `Unknown` during a credential change.
+  specTest('Client stays offline during credential change', [], () => {
+    // Reproduces a bug that caused the client to switch to OnlineState
+    // `Unknown` during a credential change.
 
-      const query1 = query('collection');
-      return spec()
-        .disableNetwork()
-        .changeUser('user1')
-        .userListens(query1)
-        .expectEvents(query1, {
-          fromCache: true
-        });
-    }
-  );
+    const query1 = query('collection');
+    return spec()
+      .disableNetwork()
+      .changeUser('user1')
+      .userListens(query1)
+      .expectEvents(query1, {
+        fromCache: true
+      });
+  });
 });

--- a/packages/firestore/test/unit/specs/offline_spec.test.ts
+++ b/packages/firestore/test/unit/specs/offline_spec.test.ts
@@ -245,12 +245,15 @@ describeSpec('Offline:', [], () => {
     // `Unknown` during a credential change.
 
     const query1 = query('collection');
-    return spec()
-      .disableNetwork()
-      .changeUser('user1')
-      .userListens(query1)
-      .expectEvents(query1, {
-        fromCache: true
-      });
+    return (
+      spec()
+        .disableNetwork()
+        .changeUser('user1')
+        .userListens(query1)
+        // Client is still offline and we raise a `fromCache` event immediately
+        .expectEvents(query1, {
+          fromCache: true
+        })
+    );
   });
 });


### PR DESCRIPTION
The user change handling on Web resets the OnlineStatus to unknown even if we are offline. This breaks offline behavior for empty snapshots from cache, as we will stop raising empty snapshots.

This fixes a regression in the Web client. The Android and iOS client should have the correct behavior (see Android: https://github.com/firebase/firebase-android-sdk/blob/751684d3073329adef4cbca8865efa22c953fa5d/firebase-firestore/src/main/java/com/google/firebase/firestore/remote/RemoteStore.java#L319)