### PR TITLE
Firestore Externs: @type -> @typedef

### DIFF
--- a/packages/firebase/externs/firebase-firestore-externs.js
+++ b/packages/firebase/externs/firebase-firestore-externs.js
@@ -755,7 +755,7 @@ firebase.firestore.DocumentSnapshot.prototype.metadata;
 
 /**
  * An object containing all the data in a document.
- * @type {Object}
+ * @typedef {Object}
  */
 firebase.firestore.DocumentData;
 


### PR DESCRIPTION
Adjust the Firestore Externs to use properly use `@typedef` instead of `@type`
---

The proper way to define what is effectively a "type alias" in Closure is to use `@typedef`.  On the other hand, the `@type` annotation would typically be used to define the type for a current object or a property on a class/interface.

I've confirmed in a very elaborate closure environment that this properly compiles ;)

tag @hsubox76 

