### PR TITLE
Add '@override' annotation to RecaptchaVerifier.Verify method in AuthClient externs.

### DIFF
--- a/packages/firebase/externs/firebase-client-auth-externs.js
+++ b/packages/firebase/externs/firebase-client-auth-externs.js
@@ -497,5 +497,6 @@ firebase.auth.RecaptchaVerifier.prototype.render = function () {};
  * Waits for the user to solve the reCAPTCHA and resolves with the reCAPTCHA
  * token.
  * @return {!firebase.Promise<string>} A Promise for the reCAPTCHA token.
+ * @override
  */
 firebase.auth.RecaptchaVerifier.prototype.verify = function () {};

--- a/packages/firebase/externs/firebase-firestore-externs.js
+++ b/packages/firebase/externs/firebase-firestore-externs.js
@@ -755,7 +755,7 @@ firebase.firestore.DocumentSnapshot.prototype.metadata;
 
 /**
  * An object containing all the data in a document.
- * @type {Object}
+ * @typedef {Object}
  */
 firebase.firestore.DocumentData;
 


### PR DESCRIPTION
Adds an `@override` annotation on the RecaptchaVerifier.Verify in AuthClient externs

--

This is needed because this interface implements the `firebase.auth.ApplicationVerifier` type.

This resolves a Closure compiler warning message

tag @hsubox76 