### PR TITLE
[Deprecated] Messaging onPush should await onBackgroundMessage handler (in favor of https://github.com/firebase/firebase-js-sdk/pull/3780)

### DIFF
--- a/packages/messaging/src/controllers/sw-controller.ts
+++ b/packages/messaging/src/controllers/sw-controller.ts
@@ -206,9 +206,9 @@ export class SwController implements FirebaseMessaging, FirebaseService {
       const payload = externalizePayload(internalPayload);
 
       if (typeof this.bgMessageHandler === 'function') {
-        this.bgMessageHandler(payload);
+        await this.bgMessageHandler(payload);
       } else {
-        this.bgMessageHandler.next(payload);
+        await this.bgMessageHandler.next(payload);
       }
     }
   }


### PR DESCRIPTION
Await onBackgroundMessage handler on onPush method. This PR fixes #3725