### PR TITLE
Fix externals for packages/firebase builds

### DIFF
--- a/packages/firebase/rollup.config.js
+++ b/packages/firebase/rollup.config.js
@@ -70,7 +70,8 @@ const plugins = [
   commonjs()
 ];
 
-const external = Object.keys(pkg.dependencies || {});
+const deps = [...Object.keys(pkg.dependencies || {}), 'tslib'];
+const external = id => deps.some(dep => id === dep || id.startsWith(`${dep}/`));
 
 /**
  * Global UMD Build

--- a/packages/firebase/rollup.config.js
+++ b/packages/firebase/rollup.config.js
@@ -70,7 +70,7 @@ const plugins = [
   commonjs()
 ];
 
-const deps = [...Object.keys(pkg.dependencies || {}), 'tslib'];
+const deps = Object.keys(pkg.dependencies || {});
 const external = id => deps.some(dep => id === dep || id.startsWith(`${dep}/`));
 
 /**


### PR DESCRIPTION
Externals should include tslib and use `startsWith` pattern.