### PR TITLE
run size reports in parallel in CI

### DIFF
--- a/.github/workflows/health-metrics-test.yml
+++ b/.github/workflows/health-metrics-test.yml
@@ -3,7 +3,7 @@ name: Health Metrics
 on: [push, pull_request]
 
 jobs:
-  binary-size-test:
+  binary-size:
     name: Binary Size
     if: github.event_name == 'push' || !(github.event.pull_request.head.repo.fork)
     runs-on: ubuntu-latest
@@ -19,12 +19,28 @@ jobs:
       - uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
         with:
           service_account_key: ${{ secrets.GCP_SA_KEY }}
-      - run: cp config/ci.config.json config/project.json
       - run: yarn install
       - run: yarn build
       - name: Run health-metrics/binary-size test
         run: yarn size-report
+  modular-export-size:
+    name: Binary Size For Modular Exports
+    if: github.event_name == 'push' || !(github.event.pull_request.head.repo.fork)
+    runs-on: ubuntu-latest
+    env:
+      METRICS_SERVICE_URL: ${{ secrets.METRICS_SERVICE_URL }}
+      GITHUB_PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
+      GITHUB_PULL_REQUEST_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 10.x
+      - uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
+        with:
+          service_account_key: ${{ secrets.GCP_SA_KEY }}
+      - run: yarn install
+      - run: yarn build
       - name: Run health-metrics/modular-exports-binary-size test
         run: yarn modular-export-size-report
-
   # TODO(yifany): Enable startup times testing on CI.

--- a/.github/workflows/health-metrics-test.yml
+++ b/.github/workflows/health-metrics-test.yml
@@ -2,15 +2,16 @@ name: Health Metrics
 
 on: [push, pull_request]
 
+env:
+  METRICS_SERVICE_URL: ${{ secrets.METRICS_SERVICE_URL }}
+  GITHUB_PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
+  GITHUB_PULL_REQUEST_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+
 jobs:
   binary-size:
     name: Binary Size
     if: github.event_name == 'push' || !(github.event.pull_request.head.repo.fork)
     runs-on: ubuntu-latest
-    env:
-      METRICS_SERVICE_URL: ${{ secrets.METRICS_SERVICE_URL }}
-      GITHUB_PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
-      GITHUB_PULL_REQUEST_BASE_SHA: ${{ github.event.pull_request.base.sha }}
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
@@ -27,10 +28,6 @@ jobs:
     name: Binary Size For Modular Exports
     if: github.event_name == 'push' || !(github.event.pull_request.head.repo.fork)
     runs-on: ubuntu-latest
-    env:
-      METRICS_SERVICE_URL: ${{ secrets.METRICS_SERVICE_URL }}
-      GITHUB_PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
-      GITHUB_PULL_REQUEST_BASE_SHA: ${{ github.event.pull_request.base.sha }}
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1

--- a/scripts/size_report/report_binary_size.ts
+++ b/scripts/size_report/report_binary_size.ts
@@ -93,12 +93,12 @@ async function generateReportForNPMPackages(): Promise<Report[]> {
   return reports;
 
   function collectBinarySize(path: string) {
-    const promise = new Promise<void>(async resolve => {
-      const packageJsonPath = `${path}/package.json`;
-      if (!fs.existsSync(packageJsonPath)) {
-        return;
-      }
+    const packageJsonPath = `${path}/package.json`;
+    if (!fs.existsSync(packageJsonPath)) {
+      return;
+    }
 
+    const promise = new Promise<void>(async resolve => {
       const packageJson = require(packageJsonPath);
 
       for (const field of fields) {


### PR DESCRIPTION
1. run the regular size report and modular export size report in parallel
2. fix an issue where the regular size report exit before the report is created