### PR TITLE
Add installations-exp packages to changeset ignore

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -14,6 +14,8 @@
     "@firebase/app-types-exp",
     "@firebase/functions-exp",
     "@firebase/functions-types-exp",
+    "@firebase/installations-exp",
+    "@firebase/installations-types-exp",
     "@firebase/testing",
     "firebase-exp",
     "@firebase/app-compat",


### PR DESCRIPTION
Was causing errors in changeset validation when running release.