### PR TITLE
Exclude -compat from build:release

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "dev": "lerna run --parallel --scope @firebase/* --scope firebase --scope rxfire dev",
     "build": "lerna run --scope @firebase/app-exp build:deps && lerna run --scope @firebase/* --scope firebase --scope rxfire --ignore @firebase/app-exp build",
     "build:exp": "lerna run --scope @firebase/*-exp --scope @firebase/*-compat --scope firebase-exp build",
-    "build:release": "lerna run --scope @firebase/app-exp build:deps && lerna run --scope @firebase/* --scope firebase --scope rxfire --ignore @firebase/*-exp prepare",
+    "build:release": "lerna run --scope @firebase/app-exp build:deps && lerna run --scope @firebase/* --scope firebase --scope rxfire --ignore @firebase/*-exp --ignore @firebase/*-compat prepare",
     "build:exp:release": "yarn --cwd packages/app build:deps && lerna run --scope @firebase/*-exp --scope @firebase/*-compat --scope firebase-exp prepare && yarn --cwd packages-exp/app-exp typings:public",
     "build:changed": "ts-node-script scripts/ci-test/build_changed.ts",
     "link:packages": "lerna exec --scope @firebase/* --scope firebase --scope rxfire -- yarn link",


### PR DESCRIPTION
`app-compat` build fails in this flow, blocking release.