### PR TITLE
Increase timeout for flaky test

### DIFF
--- a/repo-scripts/size-analysis/test/size-analysis.test.ts
+++ b/repo-scripts/size-analysis/test/size-analysis.test.ts
@@ -196,7 +196,9 @@ describe('extractDeclarations on .d.ts file', () => {
     expect(extractedDeclarations.variables).to.include.members(['aVar']);
   });
 });
-describe('extractDeclarations on js bundle file', () => {
+//TODO: Temporarily disabled due to causing timeout issues.
+// eslint-disable-next-line no-restricted-globals
+xdescribe('extractDeclarations on js bundle file', () => {
   let subsetExportsBundleFile: string;
   let extractedDeclarations: MemberList;
   before(() => {

--- a/repo-scripts/size-analysis/test/size-analysis.test.ts
+++ b/repo-scripts/size-analysis/test/size-analysis.test.ts
@@ -196,9 +196,7 @@ describe('extractDeclarations on .d.ts file', () => {
     expect(extractedDeclarations.variables).to.include.members(['aVar']);
   });
 });
-//TODO: Temporarily disabled due to causing timeout issues.
-// eslint-disable-next-line no-restricted-globals
-xdescribe('extractDeclarations on js bundle file', () => {
+describe('extractDeclarations on js bundle file', () => {
   let subsetExportsBundleFile: string;
   let extractedDeclarations: MemberList;
   before(() => {
@@ -250,7 +248,7 @@ xdescribe('extractDeclarations on js bundle file', () => {
     classesArray.sort();
     expect(extractedDeclarations.classes).to.have.members(classesArray);
   });
-});
+}).timeout(120000);
 
 describe('test dedup helper function', () => {
   it('test dedup with non-empty entries', () => {

--- a/repo-scripts/size-analysis/test/size-analysis.test.ts
+++ b/repo-scripts/size-analysis/test/size-analysis.test.ts
@@ -199,7 +199,8 @@ describe('extractDeclarations on .d.ts file', () => {
 describe('extractDeclarations on js bundle file', () => {
   let subsetExportsBundleFile: string;
   let extractedDeclarations: MemberList;
-  before(() => {
+  before(function () {
+    this.timeout(120000);
     const start = Date.now();
     const testModuleDtsFile: string = getTestModuleDtsFilePath();
     const map: Map<string, string> = buildMap(
@@ -248,7 +249,7 @@ describe('extractDeclarations on js bundle file', () => {
     classesArray.sort();
     expect(extractedDeclarations.classes).to.have.members(classesArray);
   });
-}).timeout(120000);
+});
 
 describe('test dedup helper function', () => {
   it('test dedup with non-empty entries', () => {


### PR DESCRIPTION
Test is consistently exceeding timeout of 60s. Extending `before` timeout to 120s.