### PR TITLE
Fix NotInFilter matches

### DIFF
--- a/packages/firestore/exp/src/api/transaction.ts
+++ b/packages/firestore/exp/src/api/transaction.ts
@@ -29,7 +29,8 @@ import { Transaction as InternalTransaction } from '../../../src/core/transactio
 import { validateReference } from '../../../lite/src/api/write_batch';
 import { getDatastore } from '../../../lite/src/api/components';
 
-export class Transaction extends LiteTransaction
+export class Transaction
+  extends LiteTransaction
   implements firestore.Transaction {
   // This class implements the same logic as the Transaction API in the Lite SDK
   // but is subclassed in order to return its own DocumentSnapshot types.

--- a/packages/firestore/lite/src/api/field_value.ts
+++ b/packages/firestore/lite/src/api/field_value.ts
@@ -30,7 +30,8 @@ import { ParseContext } from '../../../src/api/user_data_reader';
 import { FieldTransform } from '../../../src/model/mutation';
 
 /** The public FieldValue class of the lite API. */
-export abstract class FieldValue extends SerializableFieldValue
+export abstract class FieldValue
+  extends SerializableFieldValue
   implements firestore.FieldValue {}
 
 /**

--- a/packages/firestore/src/core/query.ts
+++ b/packages/firestore/src/core/query.ts
@@ -855,6 +855,11 @@ export class NotInFilter extends FieldFilter {
   }
 
   matches(doc: Document): boolean {
+    if (
+      arrayValueContains(this.value.arrayValue!, { nullValue: 'NULL_VALUE' })
+    ) {
+      return false;
+    }
     const other = doc.field(this.field);
     return other !== null && !arrayValueContains(this.value.arrayValue!, other);
   }

--- a/packages/firestore/test/integration/api/query.test.ts
+++ b/packages/firestore/test/integration/api/query.test.ts
@@ -24,7 +24,6 @@ import { EventsAccumulator } from '../util/events_accumulator';
 import * as firebaseExport from '../util/firebase_export';
 import {
   apiDescribe,
-  isRunningAgainstEmulator,
   notEqualOp,
   notInOp,
   toChangesArray,
@@ -687,101 +686,82 @@ apiDescribe('Queries', (persistence: boolean) => {
     });
   });
 
-  // eslint-disable-next-line no-restricted-properties
-  (isRunningAgainstEmulator() ? it : it.skip)(
-    'can use != filters',
-    async () => {
-      const testDocs = {
-        a: { zip: 98101 },
-        b: { zip: 91102 },
-        c: { zip: '98101' },
-        d: { zip: [98101] },
-        e: { zip: ['98101', { zip: 98101 }] },
-        f: { zip: { code: 500 } },
-        g: { zip: [98101, 98102] },
-        h: { code: 500 },
-        i: { zip: null },
-        j: { zip: Number.NaN }
-      };
+  it('can use != filters', async () => {
+    const testDocs = {
+      a: { zip: 98101 },
+      b: { zip: 91102 },
+      c: { zip: '98101' },
+      d: { zip: [98101] },
+      e: { zip: ['98101', { zip: 98101 }] },
+      f: { zip: { code: 500 } },
+      g: { zip: [98101, 98102] },
+      h: { code: 500 },
+      i: { zip: null },
+      j: { zip: Number.NaN }
+    };
 
-      await withTestCollection(persistence, testDocs, async coll => {
-        let expected = { ...testDocs };
-        // @ts-expect-error
-        delete expected.a;
-        // @ts-expect-error
-        delete expected.h;
-        // @ts-expect-error
-        delete expected.i;
-        const snapshot = await coll.where('zip', notEqualOp, 98101).get();
-        expect(toDataArray(snapshot)).to.have.deep.members(
-          Object.values(expected)
-        );
+    await withTestCollection(persistence, testDocs, async coll => {
+      let expected = { ...testDocs };
+      delete expected.a;
+      delete expected.h;
+      delete expected.i;
+      const snapshot = await coll.where('zip', notEqualOp, 98101).get();
+      expect(toDataArray(snapshot)).to.have.deep.members(
+        Object.values(expected)
+      );
 
-        // With objects.
-        const snapshot2 = await coll
-          .where('zip', notEqualOp, { code: 500 })
-          .get();
-        expected = { ...testDocs };
-        // @ts-expect-error
-        delete expected.f;
-        // @ts-expect-error
-        delete expected.h;
-        // @ts-expect-error
-        delete expected.i;
-        expect(toDataArray(snapshot2)).to.have.deep.members(
-          Object.values(expected)
-        );
+      // With objects.
+      const snapshot2 = await coll
+        .where('zip', notEqualOp, { code: 500 })
+        .get();
+      expected = { ...testDocs };
+      delete expected.f;
+      delete expected.h;
+      delete expected.i;
+      expect(toDataArray(snapshot2)).to.have.deep.members(
+        Object.values(expected)
+      );
 
-        // With null.
-        const snapshot3 = await coll.where('zip', notEqualOp, null).get();
-        expected = { ...testDocs };
-        // @ts-expect-error
-        delete expected.h;
-        // @ts-expect-error
-        delete expected.i;
-        expect(toDataArray(snapshot3)).to.have.deep.members(
-          Object.values(expected)
-        );
+      // With null.
+      const snapshot3 = await coll.where('zip', notEqualOp, null).get();
+      expected = { ...testDocs };
+      delete expected.h;
+      delete expected.i;
+      expect(toDataArray(snapshot3)).to.have.deep.members(
+        Object.values(expected)
+      );
 
-        // With NaN.
-        const snapshot4 = await coll.where('zip', notEqualOp, Number.NaN).get();
-        expected = { ...testDocs };
-        // @ts-expect-error
-        delete expected.h;
-        // @ts-expect-error
-        delete expected.i;
-        // @ts-expect-error
-        delete expected.j;
-        expect(toDataArray(snapshot4)).to.have.deep.members(
-          Object.values(expected)
-        );
-      });
-    }
-  );
+      // With NaN.
+      const snapshot4 = await coll.where('zip', notEqualOp, Number.NaN).get();
+      expected = { ...testDocs };
+      delete expected.h;
+      delete expected.i;
+      delete expected.j;
+      expect(toDataArray(snapshot4)).to.have.deep.members(
+        Object.values(expected)
+      );
+    });
+  });
 
-  // eslint-disable-next-line no-restricted-properties
-  (isRunningAgainstEmulator() ? it : it.skip)(
-    'can use != filters by document ID',
-    async () => {
-      const testDocs = {
-        aa: { key: 'aa' },
-        ab: { key: 'ab' },
-        ba: { key: 'ba' },
-        bb: { key: 'bb' }
-      };
-      await withTestCollection(persistence, testDocs, async coll => {
-        const snapshot = await coll
-          .where(FieldPath.documentId(), notEqualOp, 'aa')
-          .get();
+  it('can use != filters by document ID', async () => {
+    const testDocs = {
+      aa: { key: 'aa' },
+      ab: { key: 'ab' },
+      ba: { key: 'ba' },
+      bb: { key: 'bb' }
+    };
+    await withTestCollection(persistence, testDocs, async coll => {
+      const snapshot = await coll
+        .where(FieldPath.documentId(), notEqualOp, 'aa')
+        .get();
 
-        expect(toDataArray(snapshot)).to.deep.equal([
-          { key: 'ab' },
-          { key: 'ba' },
-          { key: 'bb' }
-        ]);
-      });
-    }
-  );
+      expect(toDataArray(snapshot)).to.deep.equal([
+        { key: 'ab' },
+        { key: 'ba' },
+        { key: 'bb' }
+      ]);
+    });
+  });
 
   it('can use array-contains filters', async () => {
     const testDocs = {
@@ -851,100 +831,79 @@ apiDescribe('Queries', (persistence: boolean) => {
     });
   });
 
-  // eslint-disable-next-line no-restricted-properties
-  (isRunningAgainstEmulator() ? it : it.skip)(
-    'can use NOT_IN filters',
-    async () => {
-      const testDocs = {
-        a: { zip: 98101 },
-        b: { zip: 91102 },
-        c: { zip: 98103 },
-        d: { zip: [98101] },
-        e: { zip: ['98101', { zip: 98101 }] },
-        f: { zip: { code: 500 } },
-        g: { zip: [98101, 98102] },
-        h: { code: 500 },
-        i: { zip: null },
-        j: { zip: Number.NaN }
-      };
+  it('can use NOT_IN filters', async () => {
+    const testDocs = {
+      a: { zip: 98101 },
+      b: { zip: 91102 },
+      c: { zip: 98103 },
+      d: { zip: [98101] },
+      e: { zip: ['98101', { zip: 98101 }] },
+      f: { zip: { code: 500 } },
+      g: { zip: [98101, 98102] },
+      h: { code: 500 },
+      i: { zip: null },
+      j: { zip: Number.NaN }
+    };
 
-      await withTestCollection(persistence, testDocs, async coll => {
-        let expected = { ...testDocs };
-        // @ts-expect-error
-        delete expected.a;
-        // @ts-expect-error
-        delete expected.c;
-        // @ts-expect-error
-        delete expected.g;
-        // @ts-expect-error
-        delete expected.h;
-        const snapshot = await coll
-          .where('zip', notInOp, [98101, 98103, [98101, 98102]])
-          .get();
-        expect(toDataArray(snapshot)).to.deep.equal(Object.values(expected));
+    await withTestCollection(persistence, testDocs, async coll => {
+      let expected = { ...testDocs };
+      delete expected.a;
+      delete expected.c;
+      delete expected.g;
+      delete expected.h;
+      const snapshot = await coll
+        .where('zip', notInOp, [98101, 98103, [98101, 98102]])
+        .get();
+      expect(toDataArray(snapshot)).to.deep.equal(Object.values(expected));
 
-        // With objects.
-        const snapshot2 = await coll
-          .where('zip', notInOp, [{ code: 500 }])
-          .get();
-        expected = { ...testDocs };
-        // @ts-expect-error
-        delete expected.f;
-        // @ts-expect-error
-        delete expected.h;
-        expect(toDataArray(snapshot2)).to.deep.equal(Object.values(expected));
+      // With objects.
+      const snapshot2 = await coll.where('zip', notInOp, [{ code: 500 }]).get();
+      expected = { ...testDocs };
+      delete expected.f;
+      delete expected.h;
+      expect(toDataArray(snapshot2)).to.deep.equal(Object.values(expected));
 
-        // With null.
-        const snapshot3 = await coll.where('zip', notInOp, [null]).get();
-        expect(toDataArray(snapshot3)).to.deep.equal([]);
+      // With null.
+      const snapshot3 = await coll.where('zip', notInOp, [null]).get();
+      expect(toDataArray(snapshot3)).to.deep.equal([]);
 
-        // With NaN.
-        const snapshot4 = await coll.where('zip', notInOp, [Number.NaN]).get();
-        expected = { ...testDocs };
-        // @ts-expect-error
-        delete expected.h;
-        // @ts-expect-error
-        delete expected.j;
-        expect(toDataArray(snapshot4)).to.deep.equal(Object.values(expected));
+      // With NaN.
+      const snapshot4 = await coll.where('zip', notInOp, [Number.NaN]).get();
+      expected = { ...testDocs };
+      delete expected.h;
+      delete expected.j;
+      expect(toDataArray(snapshot4)).to.deep.equal(Object.values(expected));
 
-        // With NaN and a number.
-        const snapshot5 = await coll
-          .where('zip', notInOp, [Number.NaN, 98101])
-          .get();
-        expected = { ...testDocs };
-        // @ts-expect-error
-        delete expected.a;
-        // @ts-expect-error
-        delete expected.h;
-        // @ts-expect-error
-        delete expected.j;
-        expect(toDataArray(snapshot5)).to.deep.equal(Object.values(expected));
-      });
-    }
-  );
+      // With NaN and a number.
+      const snapshot5 = await coll
+        .where('zip', notInOp, [Number.NaN, 98101])
+        .get();
+      expected = { ...testDocs };
+      delete expected.a;
+      delete expected.h;
+      delete expected.j;
+      expect(toDataArray(snapshot5)).to.deep.equal(Object.values(expected));
+    });
+  });
 
-  // eslint-disable-next-line no-restricted-properties
-  (isRunningAgainstEmulator() ? it : it.skip)(
-    'can use NOT_IN filters by document ID',
-    async () => {
-      const testDocs = {
-        aa: { key: 'aa' },
-        ab: { key: 'ab' },
-        ba: { key: 'ba' },
-        bb: { key: 'bb' }
-      };
-      await withTestCollection(persistence, testDocs, async coll => {
-        const snapshot = await coll
-          .where(FieldPath.documentId(), notInOp, ['aa', 'ab'])
-          .get();
+  it('can use NOT_IN filters by document ID', async () => {
+    const testDocs = {
+      aa: { key: 'aa' },
+      ab: { key: 'ab' },
+      ba: { key: 'ba' },
+      bb: { key: 'bb' }
+    };
+    await withTestCollection(persistence, testDocs, async coll => {
+      const snapshot = await coll
+        .where(FieldPath.documentId(), notInOp, ['aa', 'ab'])
+        .get();
 
-        expect(toDataArray(snapshot)).to.deep.equal([
-          { key: 'ba' },
-          { key: 'bb' }
-        ]);
-      });
-    }
-  );
+      expect(toDataArray(snapshot)).to.deep.equal([
+        { key: 'ba' },
+        { key: 'bb' }
+      ]);
+    });
+  });
 
   it('can use array-contains-any filters', async () => {
     const testDocs = {

--- a/packages/firestore/test/integration/api/query.test.ts
+++ b/packages/firestore/test/integration/api/query.test.ts
@@ -832,7 +832,8 @@ apiDescribe('Queries', (persistence: boolean) => {
     });
   });
 
-  it('can use NOT_IN filters', async () => {
+  // TODO(ne-queries): re-enable in next PR to make public.
+  it.skip('can use NOT_IN filters', async () => {
     const testDocs = {
       a: { zip: 98101 },
       b: { zip: 91102 },

--- a/packages/firestore/test/integration/api/query.test.ts
+++ b/packages/firestore/test/integration/api/query.test.ts
@@ -701,7 +701,8 @@ apiDescribe('Queries', (persistence: boolean) => {
     };
 
     await withTestCollection(persistence, testDocs, async coll => {
-      let expected = { ...testDocs };
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      let expected: { [name: string]: any } = { ...testDocs };
       delete expected.a;
       delete expected.h;
       delete expected.i;
@@ -846,7 +847,8 @@ apiDescribe('Queries', (persistence: boolean) => {
     };
 
     await withTestCollection(persistence, testDocs, async coll => {
-      let expected = { ...testDocs };
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      let expected: { [name: string]: any } = { ...testDocs };
       delete expected.a;
       delete expected.c;
       delete expected.g;

--- a/packages/firestore/test/integration/api/query.test.ts
+++ b/packages/firestore/test/integration/api/query.test.ts
@@ -833,6 +833,7 @@ apiDescribe('Queries', (persistence: boolean) => {
   });
 
   // TODO(ne-queries): re-enable in next PR to make public.
+  // eslint-disable-next-line no-restricted-properties
   it.skip('can use NOT_IN filters', async () => {
     const testDocs = {
       a: { zip: 98101 },

--- a/packages/firestore/test/integration/util/helpers.ts
+++ b/packages/firestore/test/integration/util/helpers.ts
@@ -19,8 +19,7 @@ import * as firestore from '@firebase/firestore-types';
 import {
   ALT_PROJECT_ID,
   DEFAULT_PROJECT_ID,
-  DEFAULT_SETTINGS,
-  USE_EMULATOR
+  DEFAULT_SETTINGS
 } from './settings';
 import * as firebaseExport from './firebase_export';
 
@@ -287,7 +286,3 @@ export const notEqualOp = '!=' as firestore.WhereFilterOp;
 // repeatedly. Once we expose 'not-in' publicly we can remove it and just use 'in'
 // in all the tests.
 export const notInOp = 'not-in' as firestore.WhereFilterOp;
-
-export function isRunningAgainstEmulator(): boolean {
-  return USE_EMULATOR;
-}

--- a/packages/firestore/test/unit/remote/serializer.helper.ts
+++ b/packages/firestore/test/unit/remote/serializer.helper.ts
@@ -938,6 +938,29 @@ export function serializerTest(
         expect(roundtripped).to.be.instanceof(NotInFilter);
       });
 
+      it('converts not-in with null', () => {
+        const input = filter('field', 'not-in', [null]);
+        const actual = toUnaryOrFieldFilter(input);
+        expect(actual).to.deep.equal({
+          fieldFilter: {
+            field: { fieldPath: 'field' },
+            op: 'NOT_IN',
+            value: {
+              arrayValue: {
+                values: [
+                  {
+                    nullValue: 'NULL_VALUE'
+                  }
+                ]
+              }
+            }
+          }
+        });
+        const roundtripped = fromFieldFilter(actual);
+        expect(roundtripped).to.deep.equal(input);
+        expect(roundtripped).to.be.instanceof(NotInFilter);
+      });
+
       it('converts array-contains-any', () => {
         const input = filter('field', 'array-contains-any', [42]);
         const actual = toUnaryOrFieldFilter(input);


### PR DESCRIPTION
Porting over from [Android](https://github.com/firebase/firebase-android-sdk/pull/1947).

Making integration tests run against prod since protos are now public. Tests are currently failing b/c the client proxy has not been fully released yet, but they should be passing by EOW.