### PR TITLE
Add forceOwnership to firestore-exp

### DIFF
--- a/packages/firestore/exp-types/index.d.ts
+++ b/packages/firestore/exp-types/index.d.ts
@@ -36,6 +36,10 @@ export interface Settings {
   cacheSizeBytes?: number;
 }
 
+export interface PersistenceSettings {
+  forceOwnership?: boolean;
+}
+
 export interface SnapshotListenOptions {
   readonly includeMetadataChanges?: boolean;
 }
@@ -95,9 +99,9 @@ export function waitForPendingWrites(
 export function enableNetwork(firestore: FirebaseFirestore): Promise<void>;
 export function disableNetwork(firestore: FirebaseFirestore): Promise<void>;
 
-// TODO(firestoreexp): Add experimentalForceOwningTab support
 export function enableIndexedDbPersistence(
-  firestore: FirebaseFirestore
+  firestore: FirebaseFirestore,
+  persistenceSettings?: PersistenceSettings
 ): Promise<void>;
 export function enableMultiTabIndexedDbPersistence(
   firestore: FirebaseFirestore
@@ -405,8 +409,6 @@ export function updateDoc(
 ): Promise<void>;
 export function deleteDoc(reference: DocumentReference<unknown>): Promise<void>;
 
-// TODO(firestoreexp): Update API Proposal to use FirestoreError in these
-// callbacks
 export function onSnapshot<T>(
   reference: DocumentReference<T>,
   observer: {

--- a/packages/firestore/exp/src/api/database.ts
+++ b/packages/firestore/exp/src/api/database.ts
@@ -62,6 +62,7 @@ import {
   remoteStoreDisableNetwork,
   remoteStoreEnableNetwork
 } from '../../../src/remote/remote_store';
+import { PersistenceSettings } from '../../../exp-types';
 
 const LOG_TAG = 'Firestore';
 
@@ -197,7 +198,8 @@ export function getFirestore(app: FirebaseApp): Firestore {
 }
 
 export function enableIndexedDbPersistence(
-  firestore: firestore.FirebaseFirestore
+  firestore: firestore.FirebaseFirestore,
+  persistenceSettings?: PersistenceSettings
 ): Promise<void> {
   const firestoreImpl = cast(firestore, Firestore);
   verifyNotInitialized(firestoreImpl);
@@ -214,7 +216,6 @@ export function enableIndexedDbPersistence(
   );
 
   return firestoreImpl._queue.enqueue(async () => {
-    // TODO(firestoreexp): Add forceOwningTab
     await setOfflineComponentProvider(
       firestoreImpl,
       {
@@ -222,7 +223,7 @@ export function enableIndexedDbPersistence(
         synchronizeTabs: false,
         cacheSizeBytes:
           settings.cacheSizeBytes || LruParams.DEFAULT_CACHE_SIZE_BYTES,
-        forceOwningTab: false
+        forceOwningTab: !!persistenceSettings?.forceOwnership
       },
       offlineComponentProvider
     );


### PR DESCRIPTION
This adds "experimentalForceOwningTab" to the experimental SDK. Exposed as "forceOwnership" - comments welcome.