### PR TITLE
Don't use interface types

### DIFF
--- a/packages/firestore/exp/dependencies.json
+++ b/packages/firestore/exp/dependencies.json
@@ -32,15 +32,15 @@
                 "DelayedOperation",
                 "ExponentialBackoff",
                 "FirebaseCredentialsProvider",
-                "Firestore",
-                "Firestore$1",
+                "FirebaseFirestore",
+                "FirebaseFirestore$1",
                 "FirestoreError",
                 "OAuthToken",
                 "User"
             ],
             "variables": []
         },
-        "sizeInBytes": 18556
+        "sizeInBytes": 18596
     },
     "CollectionReference": {
         "dependencies": {
@@ -74,22 +74,22 @@
                 "Deferred",
                 "DelayedOperation",
                 "DocumentKey",
-                "DocumentKeyReference",
                 "DocumentReference",
                 "ExponentialBackoff",
                 "FirebaseCredentialsProvider",
-                "Firestore",
-                "Firestore$1",
+                "FirebaseFirestore",
+                "FirebaseFirestore$1",
                 "FirestoreError",
                 "OAuthToken",
                 "Query",
                 "QueryImpl",
                 "ResourcePath",
-                "User"
+                "User",
+                "_DocumentKeyReference"
             ],
             "variables": []
         },
-        "sizeInBytes": 22787
+        "sizeInBytes": 22829
     },
     "DocumentReference": {
         "dependencies": {
@@ -123,29 +123,28 @@
                 "Deferred",
                 "DelayedOperation",
                 "DocumentKey",
-                "DocumentKeyReference",
                 "DocumentReference",
                 "ExponentialBackoff",
                 "FirebaseCredentialsProvider",
-                "Firestore",
-                "Firestore$1",
+                "FirebaseFirestore",
+                "FirebaseFirestore$1",
                 "FirestoreError",
                 "OAuthToken",
                 "Query",
                 "QueryImpl",
                 "ResourcePath",
-                "User"
+                "User",
+                "_DocumentKeyReference"
             ],
             "variables": []
         },
-        "sizeInBytes": 22785
+        "sizeInBytes": 22827
     },
     "DocumentSnapshot": {
         "dependencies": {
             "functions": [
                 "argToString",
                 "binaryStringFromUint8Array",
-                "cast",
                 "createError",
                 "decodeBase64",
                 "encodeBase64",
@@ -194,7 +193,6 @@
             "classes": [
                 "AsyncQueue",
                 "AutoId",
-                "BaseFieldPath",
                 "BasePath",
                 "ByteString",
                 "Bytes",
@@ -204,17 +202,15 @@
                 "Deferred",
                 "DelayedOperation",
                 "DocumentKey",
-                "DocumentKeyReference",
                 "DocumentReference",
                 "DocumentSnapshot",
                 "DocumentSnapshot$1",
                 "ExponentialBackoff",
                 "FieldPath",
                 "FieldPath$1",
-                "FieldPath$2",
                 "FirebaseCredentialsProvider",
-                "Firestore",
-                "Firestore$1",
+                "FirebaseFirestore",
+                "FirebaseFirestore$1",
                 "FirestoreError",
                 "GeoPoint",
                 "OAuthToken",
@@ -225,17 +221,18 @@
                 "ResourcePath",
                 "Timestamp",
                 "User",
-                "UserDataWriter"
+                "UserDataWriter",
+                "_BaseFieldPath",
+                "_DocumentKeyReference"
             ],
             "variables": []
         },
-        "sizeInBytes": 41849
+        "sizeInBytes": 41241
     },
     "FieldPath": {
         "dependencies": {
             "functions": [
                 "argToString",
-                "cast",
                 "fail",
                 "formatJSON",
                 "formatPlural",
@@ -261,7 +258,6 @@
             "classes": [
                 "AsyncQueue",
                 "AutoId",
-                "BaseFieldPath",
                 "BasePath",
                 "DatabaseId",
                 "DatabaseInfo",
@@ -271,15 +267,16 @@
                 "FieldPath",
                 "FieldPath$2",
                 "FirebaseCredentialsProvider",
-                "Firestore",
-                "Firestore$1",
+                "FirebaseFirestore",
+                "FirebaseFirestore$1",
                 "FirestoreError",
                 "OAuthToken",
-                "User"
+                "User",
+                "_BaseFieldPath"
             ],
             "variables": []
         },
-        "sizeInBytes": 23179
+        "sizeInBytes": 22777
     },
     "FieldValue": {
         "dependencies": {
@@ -309,16 +306,16 @@
                 "ExponentialBackoff",
                 "FieldValue",
                 "FirebaseCredentialsProvider",
-                "Firestore",
-                "Firestore$1",
+                "FirebaseFirestore",
+                "FirebaseFirestore$1",
                 "FirestoreError",
                 "OAuthToken",
-                "SerializableFieldValue",
-                "User"
+                "User",
+                "_SerializableFieldValue"
             ],
             "variables": []
         },
-        "sizeInBytes": 16809
+        "sizeInBytes": 16851
     },
     "FirebaseFirestore": {
         "dependencies": {
@@ -347,15 +344,15 @@
                 "DelayedOperation",
                 "ExponentialBackoff",
                 "FirebaseCredentialsProvider",
-                "Firestore",
-                "Firestore$1",
+                "FirebaseFirestore",
+                "FirebaseFirestore$1",
                 "FirestoreError",
                 "OAuthToken",
                 "User"
             ],
             "variables": []
         },
-        "sizeInBytes": 16718
+        "sizeInBytes": 16766
     },
     "GeoPoint": {
         "dependencies": {
@@ -392,8 +389,8 @@
                 "DelayedOperation",
                 "ExponentialBackoff",
                 "FirebaseCredentialsProvider",
-                "Firestore",
-                "Firestore$1",
+                "FirebaseFirestore",
+                "FirebaseFirestore$1",
                 "FirestoreError",
                 "GeoPoint",
                 "OAuthToken",
@@ -401,7 +398,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 19627
+        "sizeInBytes": 19667
     },
     "Query": {
         "dependencies": {
@@ -430,8 +427,8 @@
                 "DelayedOperation",
                 "ExponentialBackoff",
                 "FirebaseCredentialsProvider",
-                "Firestore",
-                "Firestore$1",
+                "FirebaseFirestore",
+                "FirebaseFirestore$1",
                 "FirestoreError",
                 "OAuthToken",
                 "Query",
@@ -439,7 +436,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 16911
+        "sizeInBytes": 16951
     },
     "QueryConstraint": {
         "dependencies": {
@@ -468,8 +465,8 @@
                 "DelayedOperation",
                 "ExponentialBackoff",
                 "FirebaseCredentialsProvider",
-                "Firestore",
-                "Firestore$1",
+                "FirebaseFirestore",
+                "FirebaseFirestore$1",
                 "FirestoreError",
                 "OAuthToken",
                 "QueryConstraint",
@@ -477,14 +474,13 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 16724
+        "sizeInBytes": 16764
     },
     "QueryDocumentSnapshot": {
         "dependencies": {
             "functions": [
                 "argToString",
                 "binaryStringFromUint8Array",
-                "cast",
                 "createError",
                 "decodeBase64",
                 "encodeBase64",
@@ -533,7 +529,6 @@
             "classes": [
                 "AsyncQueue",
                 "AutoId",
-                "BaseFieldPath",
                 "BasePath",
                 "ByteString",
                 "Bytes",
@@ -543,17 +538,15 @@
                 "Deferred",
                 "DelayedOperation",
                 "DocumentKey",
-                "DocumentKeyReference",
                 "DocumentReference",
                 "DocumentSnapshot",
                 "DocumentSnapshot$1",
                 "ExponentialBackoff",
                 "FieldPath",
                 "FieldPath$1",
-                "FieldPath$2",
                 "FirebaseCredentialsProvider",
-                "Firestore",
-                "Firestore$1",
+                "FirebaseFirestore",
+                "FirebaseFirestore$1",
                 "FirestoreError",
                 "GeoPoint",
                 "OAuthToken",
@@ -564,18 +557,19 @@
                 "ResourcePath",
                 "Timestamp",
                 "User",
-                "UserDataWriter"
+                "UserDataWriter",
+                "_BaseFieldPath",
+                "_DocumentKeyReference"
             ],
             "variables": []
         },
-        "sizeInBytes": 41859
+        "sizeInBytes": 41251
     },
     "QuerySnapshot": {
         "dependencies": {
             "functions": [
                 "argToString",
                 "binaryStringFromUint8Array",
-                "cast",
                 "changesFromSnapshot",
                 "createError",
                 "decodeBase64",
@@ -626,7 +620,6 @@
             "classes": [
                 "AsyncQueue",
                 "AutoId",
-                "BaseFieldPath",
                 "BasePath",
                 "ByteString",
                 "Bytes",
@@ -636,17 +629,15 @@
                 "Deferred",
                 "DelayedOperation",
                 "DocumentKey",
-                "DocumentKeyReference",
                 "DocumentReference",
                 "DocumentSnapshot",
                 "DocumentSnapshot$1",
                 "ExponentialBackoff",
                 "FieldPath",
                 "FieldPath$1",
-                "FieldPath$2",
                 "FirebaseCredentialsProvider",
-                "Firestore",
-                "Firestore$1",
+                "FirebaseFirestore",
+                "FirebaseFirestore$1",
                 "FirestoreError",
                 "GeoPoint",
                 "OAuthToken",
@@ -659,11 +650,13 @@
                 "SnapshotMetadata",
                 "Timestamp",
                 "User",
-                "UserDataWriter"
+                "UserDataWriter",
+                "_BaseFieldPath",
+                "_DocumentKeyReference"
             ],
             "variables": []
         },
-        "sizeInBytes": 44490
+        "sizeInBytes": 43882
     },
     "SnapshotMetadata": {
         "dependencies": {
@@ -692,8 +685,8 @@
                 "DelayedOperation",
                 "ExponentialBackoff",
                 "FirebaseCredentialsProvider",
-                "Firestore",
-                "Firestore$1",
+                "FirebaseFirestore",
+                "FirebaseFirestore$1",
                 "FirestoreError",
                 "OAuthToken",
                 "SnapshotMetadata",
@@ -701,7 +694,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 16933
+        "sizeInBytes": 16973
     },
     "Timestamp": {
         "dependencies": {
@@ -730,8 +723,8 @@
                 "DelayedOperation",
                 "ExponentialBackoff",
                 "FirebaseCredentialsProvider",
-                "Firestore",
-                "Firestore$1",
+                "FirebaseFirestore",
+                "FirebaseFirestore$1",
                 "FirestoreError",
                 "OAuthToken",
                 "Timestamp",
@@ -739,7 +732,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 18319
+        "sizeInBytes": 18359
     },
     "Transaction": {
         "dependencies": {
@@ -749,7 +742,6 @@
                 "arrayEquals",
                 "binaryStringFromUint8Array",
                 "blobEquals",
-                "cast",
                 "createError",
                 "decodeBase64",
                 "encodeBase64",
@@ -831,7 +823,6 @@
             "classes": [
                 "AsyncQueue",
                 "AutoId",
-                "BaseFieldPath",
                 "BasePath",
                 "ByteString",
                 "Bytes",
@@ -843,7 +834,6 @@
                 "DeleteFieldValueImpl",
                 "Document",
                 "DocumentKey",
-                "DocumentKeyReference",
                 "DocumentReference",
                 "DocumentSnapshot",
                 "DocumentSnapshot$1",
@@ -853,8 +843,8 @@
                 "FieldPath$1",
                 "FieldPath$2",
                 "FirebaseCredentialsProvider",
-                "Firestore",
-                "Firestore$1",
+                "FirebaseFirestore",
+                "FirebaseFirestore$1",
                 "FirestoreError",
                 "GeoPoint",
                 "JsonProtoSerializer",
@@ -874,7 +864,6 @@
                 "QueryDocumentSnapshot$1",
                 "QueryImpl",
                 "ResourcePath",
-                "SerializableFieldValue",
                 "SetMutation",
                 "SnapshotMetadata",
                 "Timestamp",
@@ -883,11 +872,14 @@
                 "TransformMutation",
                 "User",
                 "UserDataReader",
-                "UserDataWriter"
+                "UserDataWriter",
+                "_BaseFieldPath",
+                "_DocumentKeyReference",
+                "_SerializableFieldValue"
             ],
             "variables": []
         },
-        "sizeInBytes": 65389
+        "sizeInBytes": 64924
     },
     "WriteBatch": {
         "dependencies": {
@@ -897,7 +889,6 @@
                 "arrayEquals",
                 "binaryStringFromUint8Array",
                 "blobEquals",
-                "cast",
                 "createError",
                 "decodeBase64",
                 "encodeBase64",
@@ -927,7 +918,6 @@
                 "logDebug",
                 "logError",
                 "looksLikeJsonObject",
-                "newQueryForPath",
                 "newSerializer",
                 "newUserDataReader",
                 "normalizeByteString",
@@ -961,11 +951,8 @@
                 "typeOrder",
                 "uint8ArrayFromBinaryString",
                 "validateArgType",
-                "validateCollectionPath",
-                "validateDocumentPath",
                 "validateExactNumberOfArgs",
                 "validateNamedArrayAtLeastNumberOfElements",
-                "validateNonEmptyArgument",
                 "validatePlainObject",
                 "validateReference",
                 "validateType",
@@ -976,28 +963,23 @@
             "classes": [
                 "AsyncQueue",
                 "AutoId",
-                "BaseFieldPath",
                 "BasePath",
                 "ByteString",
                 "Bytes",
-                "CollectionReference",
                 "DatabaseId",
                 "DatabaseInfo",
                 "Deferred",
                 "DelayedOperation",
                 "DeleteFieldValueImpl",
                 "DeleteMutation",
-                "DocumentKey",
-                "DocumentKeyReference",
-                "DocumentReference",
                 "ExponentialBackoff",
                 "FieldMask",
                 "FieldPath",
                 "FieldPath$1",
                 "FieldPath$2",
                 "FirebaseCredentialsProvider",
-                "Firestore",
-                "Firestore$1",
+                "FirebaseFirestore",
+                "FirebaseFirestore$1",
                 "FirestoreError",
                 "GeoPoint",
                 "JsonProtoSerializer",
@@ -1010,20 +992,20 @@
                 "ParsedUpdateData",
                 "PatchMutation",
                 "Precondition",
-                "Query",
-                "QueryImpl",
                 "ResourcePath",
-                "SerializableFieldValue",
                 "SetMutation",
                 "Timestamp",
                 "TransformMutation",
                 "User",
                 "UserDataReader",
-                "WriteBatch"
+                "WriteBatch",
+                "_BaseFieldPath",
+                "_DocumentKeyReference",
+                "_SerializableFieldValue"
             ],
             "variables": []
         },
-        "sizeInBytes": 57977
+        "sizeInBytes": 53877
     },
     "addDoc": {
         "dependencies": {
@@ -1031,7 +1013,6 @@
                 "acknowledgeBatch",
                 "addDoc",
                 "addMutationCallback",
-                "addNetworkStatusChangedHandler",
                 "addToWritePipeline",
                 "applyArrayRemoveTransformOperation",
                 "applyArrayUnionTransformOperation",
@@ -1285,7 +1266,6 @@
                 "ArrayUnionTransformOperation",
                 "AsyncQueue",
                 "AutoId",
-                "BaseFieldPath",
                 "BasePath",
                 "Bound",
                 "ByteString",
@@ -1301,7 +1281,6 @@
                 "DocReference",
                 "Document",
                 "DocumentKey",
-                "DocumentKeyReference",
                 "DocumentReference",
                 "EventManagerImpl",
                 "ExponentialBackoff",
@@ -1309,8 +1288,8 @@
                 "FieldPath",
                 "FieldPath$1",
                 "FirebaseCredentialsProvider",
-                "Firestore",
-                "Firestore$1",
+                "FirebaseFirestore",
+                "FirebaseFirestore$1",
                 "FirestoreError",
                 "GeoPoint",
                 "GrpcConnection",
@@ -1362,7 +1341,6 @@
                 "RemoteDocumentChangeBuffer",
                 "RemoteStoreImpl",
                 "ResourcePath",
-                "SerializableFieldValue",
                 "ServerTimestampTransform",
                 "SetMutation",
                 "SnapshotVersion",
@@ -1380,11 +1358,14 @@
                 "UnknownDocument",
                 "User",
                 "UserDataReader",
-                "VerifyMutation"
+                "VerifyMutation",
+                "_BaseFieldPath",
+                "_DocumentKeyReference",
+                "_SerializableFieldValue"
             ],
             "variables": []
         },
-        "sizeInBytes": 168317
+        "sizeInBytes": 168161
     },
     "arrayRemove": {
         "dependencies": {
@@ -1451,27 +1432,27 @@
                 "DatabaseInfo",
                 "Deferred",
                 "DelayedOperation",
-                "DocumentKeyReference",
                 "ExponentialBackoff",
                 "FieldTransform",
                 "FieldValue",
                 "FieldValueDelegate",
                 "FirebaseCredentialsProvider",
-                "Firestore",
-                "Firestore$1",
+                "FirebaseFirestore",
+                "FirebaseFirestore$1",
                 "FirestoreError",
                 "GeoPoint",
                 "OAuthToken",
                 "ParseContext",
                 "ResourcePath",
-                "SerializableFieldValue",
                 "Timestamp",
                 "TransformOperation",
-                "User"
+                "User",
+                "_DocumentKeyReference",
+                "_SerializableFieldValue"
             ],
             "variables": []
         },
-        "sizeInBytes": 35314
+        "sizeInBytes": 35362
     },
     "arrayUnion": {
         "dependencies": {
@@ -1538,33 +1519,32 @@
                 "DatabaseInfo",
                 "Deferred",
                 "DelayedOperation",
-                "DocumentKeyReference",
                 "ExponentialBackoff",
                 "FieldTransform",
                 "FieldValue",
                 "FieldValueDelegate",
                 "FirebaseCredentialsProvider",
-                "Firestore",
-                "Firestore$1",
+                "FirebaseFirestore",
+                "FirebaseFirestore$1",
                 "FirestoreError",
                 "GeoPoint",
                 "OAuthToken",
                 "ParseContext",
                 "ResourcePath",
-                "SerializableFieldValue",
                 "Timestamp",
                 "TransformOperation",
-                "User"
+                "User",
+                "_DocumentKeyReference",
+                "_SerializableFieldValue"
             ],
             "variables": []
         },
-        "sizeInBytes": 35306
+        "sizeInBytes": 35354
     },
     "clearIndexedDbPersistence": {
         "dependencies": {
             "functions": [
                 "argToString",
-                "cast",
                 "checkForAndReportiOSError",
                 "clearIndexedDbPersistence",
                 "fail",
@@ -1593,8 +1573,8 @@
                 "DelayedOperation",
                 "ExponentialBackoff",
                 "FirebaseCredentialsProvider",
-                "Firestore",
-                "Firestore$1",
+                "FirebaseFirestore",
+                "FirebaseFirestore$1",
                 "FirestoreError",
                 "IndexedDbTransactionError",
                 "IterationController",
@@ -1607,7 +1587,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 30180
+        "sizeInBytes": 29742
     },
     "collection": {
         "dependencies": {
@@ -1642,28 +1622,27 @@
                 "Deferred",
                 "DelayedOperation",
                 "DocumentKey",
-                "DocumentKeyReference",
                 "DocumentReference",
                 "ExponentialBackoff",
                 "FirebaseCredentialsProvider",
-                "Firestore",
-                "Firestore$1",
+                "FirebaseFirestore",
+                "FirebaseFirestore$1",
                 "FirestoreError",
                 "OAuthToken",
                 "Query",
                 "QueryImpl",
                 "ResourcePath",
-                "User"
+                "User",
+                "_DocumentKeyReference"
             ],
             "variables": []
         },
-        "sizeInBytes": 23520
+        "sizeInBytes": 23570
     },
     "collectionGroup": {
         "dependencies": {
             "functions": [
                 "argToString",
-                "cast",
                 "collectionGroup",
                 "fail",
                 "formatJSON",
@@ -1691,8 +1670,8 @@
                 "DelayedOperation",
                 "ExponentialBackoff",
                 "FirebaseCredentialsProvider",
-                "Firestore",
-                "Firestore$1",
+                "FirebaseFirestore",
+                "FirebaseFirestore$1",
                 "FirestoreError",
                 "OAuthToken",
                 "Query",
@@ -1702,14 +1681,13 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 20767
+        "sizeInBytes": 20343
     },
     "deleteDoc": {
         "dependencies": {
             "functions": [
                 "acknowledgeBatch",
                 "addMutationCallback",
-                "addNetworkStatusChangedHandler",
                 "addToWritePipeline",
                 "applyArrayRemoveTransformOperation",
                 "applyArrayUnionTransformOperation",
@@ -1844,7 +1822,6 @@
                 "newLocalStore",
                 "newPersistentWriteStream",
                 "newQueryComparator",
-                "newQueryForPath",
                 "newRemoteStore",
                 "newSerializer",
                 "newSyncEngine",
@@ -1922,9 +1899,6 @@
                 "triggerPendingWritesCallbacks",
                 "typeOrder",
                 "uint8ArrayFromBinaryString",
-                "validateCollectionPath",
-                "validateDocumentPath",
-                "validateNonEmptyArgument",
                 "valueCompare",
                 "valueEquals",
                 "wrapInUserErrorIfRecoverable"
@@ -1937,7 +1911,6 @@
                 "BasePath",
                 "Bound",
                 "ByteString",
-                "CollectionReference",
                 "DatabaseId",
                 "DatabaseInfo",
                 "Datastore",
@@ -1948,15 +1921,13 @@
                 "DocReference",
                 "Document",
                 "DocumentKey",
-                "DocumentKeyReference",
-                "DocumentReference",
                 "EventManagerImpl",
                 "ExponentialBackoff",
                 "FieldMask",
                 "FieldPath",
                 "FirebaseCredentialsProvider",
-                "Firestore",
-                "Firestore$1",
+                "FirebaseFirestore",
+                "FirebaseFirestore$1",
                 "FirestoreError",
                 "GrpcConnection",
                 "IndexFreeQueryEngine",
@@ -1999,7 +1970,6 @@
                 "PersistentStream",
                 "PersistentWriteStream",
                 "Precondition",
-                "Query",
                 "QueryImpl",
                 "ReferenceSet",
                 "RemoteDocumentChangeBuffer",
@@ -2025,7 +1995,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 151990
+        "sizeInBytes": 149069
     },
     "deleteField": {
         "dependencies": {
@@ -2058,16 +2028,16 @@
                 "FieldValue",
                 "FieldValueDelegate",
                 "FirebaseCredentialsProvider",
-                "Firestore",
-                "Firestore$1",
+                "FirebaseFirestore",
+                "FirebaseFirestore$1",
                 "FirestoreError",
                 "OAuthToken",
-                "SerializableFieldValue",
-                "User"
+                "User",
+                "_SerializableFieldValue"
             ],
             "variables": []
         },
-        "sizeInBytes": 17775
+        "sizeInBytes": 17818
     },
     "disableNetwork": {
         "dependencies": {
@@ -2109,7 +2079,6 @@
                 "canonifyTarget",
                 "canonifyTimestamp",
                 "canonifyValue",
-                "cast",
                 "coercedFieldValuesArray",
                 "compareArrays",
                 "compareBlobs",
@@ -2262,8 +2231,8 @@
                 "ExponentialBackoff",
                 "FieldPath",
                 "FirebaseCredentialsProvider",
-                "Firestore",
-                "Firestore$1",
+                "FirebaseFirestore",
+                "FirebaseFirestore$1",
                 "FirestoreError",
                 "GrpcConnection",
                 "IndexFreeQueryEngine",
@@ -2326,7 +2295,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 127070
+        "sizeInBytes": 126626
     },
     "doc": {
         "dependencies": {
@@ -2361,28 +2330,27 @@
                 "Deferred",
                 "DelayedOperation",
                 "DocumentKey",
-                "DocumentKeyReference",
                 "DocumentReference",
                 "ExponentialBackoff",
                 "FirebaseCredentialsProvider",
-                "Firestore",
-                "Firestore$1",
+                "FirebaseFirestore",
+                "FirebaseFirestore$1",
                 "FirestoreError",
                 "OAuthToken",
                 "Query",
                 "QueryImpl",
                 "ResourcePath",
-                "User"
+                "User",
+                "_DocumentKeyReference"
             ],
             "variables": []
         },
-        "sizeInBytes": 23575
+        "sizeInBytes": 23625
     },
     "documentId": {
         "dependencies": {
             "functions": [
                 "argToString",
-                "cast",
                 "documentId",
                 "fail",
                 "formatJSON",
@@ -2409,7 +2377,6 @@
             "classes": [
                 "AsyncQueue",
                 "AutoId",
-                "BaseFieldPath",
                 "BasePath",
                 "DatabaseId",
                 "DatabaseInfo",
@@ -2419,21 +2386,21 @@
                 "FieldPath",
                 "FieldPath$2",
                 "FirebaseCredentialsProvider",
-                "Firestore",
-                "Firestore$1",
+                "FirebaseFirestore",
+                "FirebaseFirestore$1",
                 "FirestoreError",
                 "OAuthToken",
-                "User"
+                "User",
+                "_BaseFieldPath"
             ],
             "variables": []
         },
-        "sizeInBytes": 23229
+        "sizeInBytes": 22827
     },
     "enableIndexedDbPersistence": {
         "dependencies": {
             "functions": [
                 "acknowledgeBatch",
-                "addNetworkStatusChangedHandler",
                 "addToWritePipeline",
                 "applyArrayRemoveTransformOperation",
                 "applyArrayUnionTransformOperation",
@@ -2478,7 +2445,6 @@
                 "canonifyTarget",
                 "canonifyTimestamp",
                 "canonifyValue",
-                "cast",
                 "checkForAndReportiOSError",
                 "clientMetadataStore",
                 "coercedFieldValuesArray",
@@ -2782,8 +2748,8 @@
                 "FieldTransform",
                 "Filter",
                 "FirebaseCredentialsProvider",
-                "Firestore",
-                "Firestore$1",
+                "FirebaseFirestore",
+                "FirebaseFirestore$1",
                 "FirestoreError",
                 "GrpcConnection",
                 "InFilter",
@@ -2876,13 +2842,12 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 237428
+        "sizeInBytes": 236935
     },
     "enableMultiTabIndexedDbPersistence": {
         "dependencies": {
             "functions": [
                 "acknowledgeBatch",
-                "addNetworkStatusChangedHandler",
                 "addToWritePipeline",
                 "allocateTarget",
                 "applyActiveTargetsChange",
@@ -2935,7 +2900,6 @@
                 "canonifyTarget",
                 "canonifyTimestamp",
                 "canonifyValue",
-                "cast",
                 "checkForAndReportiOSError",
                 "cleanUpWatchStreamState",
                 "clientMetadataStore",
@@ -3303,8 +3267,8 @@
                 "FieldTransform",
                 "Filter",
                 "FirebaseCredentialsProvider",
-                "Firestore",
-                "Firestore$1",
+                "FirebaseFirestore",
+                "FirebaseFirestore$1",
                 "FirestoreError",
                 "GrpcConnection",
                 "InFilter",
@@ -3414,7 +3378,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 305188
+        "sizeInBytes": 304574
     },
     "enableNetwork": {
         "dependencies": {
@@ -3456,7 +3420,6 @@
                 "canonifyTarget",
                 "canonifyTimestamp",
                 "canonifyValue",
-                "cast",
                 "coercedFieldValuesArray",
                 "compareArrays",
                 "compareBlobs",
@@ -3609,8 +3572,8 @@
                 "ExponentialBackoff",
                 "FieldPath",
                 "FirebaseCredentialsProvider",
-                "Firestore",
-                "Firestore$1",
+                "FirebaseFirestore",
+                "FirebaseFirestore$1",
                 "FirestoreError",
                 "GrpcConnection",
                 "IndexFreeQueryEngine",
@@ -3673,15 +3636,15 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 127012
+        "sizeInBytes": 126568
     },
     "endAt": {
         "dependencies": {
             "functions": [
                 "argToString",
                 "binaryStringFromUint8Array",
-                "cast",
                 "createError",
+                "debugCast",
                 "decodeBase64",
                 "encodeBase64",
                 "endAt",
@@ -3760,7 +3723,6 @@
             "classes": [
                 "AsyncQueue",
                 "AutoId",
-                "BaseFieldPath",
                 "BasePath",
                 "Bound",
                 "ByteString",
@@ -3771,16 +3733,14 @@
                 "Deferred",
                 "DelayedOperation",
                 "DocumentKey",
-                "DocumentKeyReference",
                 "DocumentReference",
                 "DocumentSnapshot",
                 "ExponentialBackoff",
                 "FieldPath",
                 "FieldPath$1",
-                "FieldPath$2",
                 "FirebaseCredentialsProvider",
-                "Firestore",
-                "Firestore$1",
+                "FirebaseFirestore",
+                "FirebaseFirestore$1",
                 "FirestoreError",
                 "GeoPoint",
                 "JsonProtoSerializer",
@@ -3793,23 +3753,25 @@
                 "QueryEndAtConstraint",
                 "QueryImpl",
                 "ResourcePath",
-                "SerializableFieldValue",
                 "Timestamp",
                 "User",
                 "UserDataReader",
-                "UserDataWriter"
+                "UserDataWriter",
+                "_BaseFieldPath",
+                "_DocumentKeyReference",
+                "_SerializableFieldValue"
             ],
             "variables": []
         },
-        "sizeInBytes": 54029
+        "sizeInBytes": 53487
     },
     "endBefore": {
         "dependencies": {
             "functions": [
                 "argToString",
                 "binaryStringFromUint8Array",
-                "cast",
                 "createError",
+                "debugCast",
                 "decodeBase64",
                 "encodeBase64",
                 "endBefore",
@@ -3888,7 +3850,6 @@
             "classes": [
                 "AsyncQueue",
                 "AutoId",
-                "BaseFieldPath",
                 "BasePath",
                 "Bound",
                 "ByteString",
@@ -3899,16 +3860,14 @@
                 "Deferred",
                 "DelayedOperation",
                 "DocumentKey",
-                "DocumentKeyReference",
                 "DocumentReference",
                 "DocumentSnapshot",
                 "ExponentialBackoff",
                 "FieldPath",
                 "FieldPath$1",
-                "FieldPath$2",
                 "FirebaseCredentialsProvider",
-                "Firestore",
-                "Firestore$1",
+                "FirebaseFirestore",
+                "FirebaseFirestore$1",
                 "FirestoreError",
                 "GeoPoint",
                 "JsonProtoSerializer",
@@ -3921,20 +3880,21 @@
                 "QueryEndAtConstraint",
                 "QueryImpl",
                 "ResourcePath",
-                "SerializableFieldValue",
                 "Timestamp",
                 "User",
                 "UserDataReader",
-                "UserDataWriter"
+                "UserDataWriter",
+                "_BaseFieldPath",
+                "_DocumentKeyReference",
+                "_SerializableFieldValue"
             ],
             "variables": []
         },
-        "sizeInBytes": 54040
+        "sizeInBytes": 53498
     },
     "getDoc": {
         "dependencies": {
             "functions": [
-                "addNetworkStatusChangedHandler",
                 "allocateTarget",
                 "applyArrayRemoveTransformOperation",
                 "applyArrayUnionTransformOperation",
@@ -4208,7 +4168,6 @@
                 "AsyncObserver",
                 "AsyncQueue",
                 "AutoId",
-                "BaseFieldPath",
                 "BasePath",
                 "Bound",
                 "ByteString",
@@ -4224,7 +4183,6 @@
                 "Document",
                 "DocumentChangeSet",
                 "DocumentKey",
-                "DocumentKeyReference",
                 "DocumentReference",
                 "DocumentSet",
                 "DocumentSnapshot",
@@ -4236,10 +4194,9 @@
                 "ExponentialBackoff",
                 "FieldPath",
                 "FieldPath$1",
-                "FieldPath$2",
                 "FirebaseCredentialsProvider",
-                "Firestore",
-                "Firestore$1",
+                "FirebaseFirestore",
+                "FirebaseFirestore$1",
                 "FirestoreError",
                 "GeoPoint",
                 "GrpcConnection",
@@ -4319,11 +4276,13 @@
                 "View",
                 "ViewSnapshot",
                 "WatchChangeAggregator",
-                "WatchTargetChange"
+                "WatchTargetChange",
+                "_BaseFieldPath",
+                "_DocumentKeyReference"
             ],
             "variables": []
         },
-        "sizeInBytes": 202965
+        "sizeInBytes": 202567
     },
     "getDocFromCache": {
         "dependencies": {
@@ -4493,7 +4452,6 @@
                 "ArrayUnionTransformOperation",
                 "AsyncQueue",
                 "AutoId",
-                "BaseFieldPath",
                 "BasePath",
                 "Bound",
                 "ByteString",
@@ -4506,17 +4464,15 @@
                 "DocReference",
                 "Document",
                 "DocumentKey",
-                "DocumentKeyReference",
                 "DocumentReference",
                 "DocumentSnapshot",
                 "DocumentSnapshot$1",
                 "ExponentialBackoff",
                 "FieldPath",
                 "FieldPath$1",
-                "FieldPath$2",
                 "FirebaseCredentialsProvider",
-                "Firestore",
-                "Firestore$1",
+                "FirebaseFirestore",
+                "FirebaseFirestore$1",
                 "FirestoreError",
                 "GeoPoint",
                 "IndexFreeQueryEngine",
@@ -4572,16 +4528,17 @@
                 "TransformOperation",
                 "UnknownDocument",
                 "User",
-                "UserDataWriter"
+                "UserDataWriter",
+                "_BaseFieldPath",
+                "_DocumentKeyReference"
             ],
             "variables": []
         },
-        "sizeInBytes": 121579
+        "sizeInBytes": 121349
     },
     "getDocFromServer": {
         "dependencies": {
             "functions": [
-                "addNetworkStatusChangedHandler",
                 "allocateTarget",
                 "applyArrayRemoveTransformOperation",
                 "applyArrayUnionTransformOperation",
@@ -4855,7 +4812,6 @@
                 "AsyncObserver",
                 "AsyncQueue",
                 "AutoId",
-                "BaseFieldPath",
                 "BasePath",
                 "Bound",
                 "ByteString",
@@ -4871,7 +4827,6 @@
                 "Document",
                 "DocumentChangeSet",
                 "DocumentKey",
-                "DocumentKeyReference",
                 "DocumentReference",
                 "DocumentSet",
                 "DocumentSnapshot",
@@ -4883,10 +4838,9 @@
                 "ExponentialBackoff",
                 "FieldPath",
                 "FieldPath$1",
-                "FieldPath$2",
                 "FirebaseCredentialsProvider",
-                "Firestore",
-                "Firestore$1",
+                "FirebaseFirestore",
+                "FirebaseFirestore$1",
                 "FirestoreError",
                 "GeoPoint",
                 "GrpcConnection",
@@ -4966,16 +4920,17 @@
                 "View",
                 "ViewSnapshot",
                 "WatchChangeAggregator",
-                "WatchTargetChange"
+                "WatchTargetChange",
+                "_BaseFieldPath",
+                "_DocumentKeyReference"
             ],
             "variables": []
         },
-        "sizeInBytes": 202984
+        "sizeInBytes": 202586
     },
     "getDocs": {
         "dependencies": {
             "functions": [
-                "addNetworkStatusChangedHandler",
                 "allocateTarget",
                 "applyArrayRemoveTransformOperation",
                 "applyArrayUnionTransformOperation",
@@ -5251,7 +5206,6 @@
                 "AsyncObserver",
                 "AsyncQueue",
                 "AutoId",
-                "BaseFieldPath",
                 "BasePath",
                 "Bound",
                 "ByteString",
@@ -5267,7 +5221,6 @@
                 "Document",
                 "DocumentChangeSet",
                 "DocumentKey",
-                "DocumentKeyReference",
                 "DocumentReference",
                 "DocumentSet",
                 "DocumentSnapshot",
@@ -5279,10 +5232,9 @@
                 "ExponentialBackoff",
                 "FieldPath",
                 "FieldPath$1",
-                "FieldPath$2",
                 "FirebaseCredentialsProvider",
-                "Firestore",
-                "Firestore$1",
+                "FirebaseFirestore",
+                "FirebaseFirestore$1",
                 "FirestoreError",
                 "GeoPoint",
                 "GrpcConnection",
@@ -5363,11 +5315,13 @@
                 "View",
                 "ViewSnapshot",
                 "WatchChangeAggregator",
-                "WatchTargetChange"
+                "WatchTargetChange",
+                "_BaseFieldPath",
+                "_DocumentKeyReference"
             ],
             "variables": []
         },
-        "sizeInBytes": 205291
+        "sizeInBytes": 204857
     },
     "getDocsFromCache": {
         "dependencies": {
@@ -5543,7 +5497,6 @@
                 "ArrayUnionTransformOperation",
                 "AsyncQueue",
                 "AutoId",
-                "BaseFieldPath",
                 "BasePath",
                 "Bound",
                 "ByteString",
@@ -5557,7 +5510,6 @@
                 "Document",
                 "DocumentChangeSet",
                 "DocumentKey",
-                "DocumentKeyReference",
                 "DocumentReference",
                 "DocumentSet",
                 "DocumentSnapshot",
@@ -5565,10 +5517,9 @@
                 "ExponentialBackoff",
                 "FieldPath",
                 "FieldPath$1",
-                "FieldPath$2",
                 "FirebaseCredentialsProvider",
-                "Firestore",
-                "Firestore$1",
+                "FirebaseFirestore",
+                "FirebaseFirestore$1",
                 "FirestoreError",
                 "GeoPoint",
                 "IndexFreeQueryEngine",
@@ -5628,16 +5579,17 @@
                 "User",
                 "UserDataWriter",
                 "View",
-                "ViewSnapshot"
+                "ViewSnapshot",
+                "_BaseFieldPath",
+                "_DocumentKeyReference"
             ],
             "variables": []
         },
-        "sizeInBytes": 134538
+        "sizeInBytes": 134274
     },
     "getDocsFromServer": {
         "dependencies": {
             "functions": [
-                "addNetworkStatusChangedHandler",
                 "allocateTarget",
                 "applyArrayRemoveTransformOperation",
                 "applyArrayUnionTransformOperation",
@@ -5912,7 +5864,6 @@
                 "AsyncObserver",
                 "AsyncQueue",
                 "AutoId",
-                "BaseFieldPath",
                 "BasePath",
                 "Bound",
                 "ByteString",
@@ -5928,7 +5879,6 @@
                 "Document",
                 "DocumentChangeSet",
                 "DocumentKey",
-                "DocumentKeyReference",
                 "DocumentReference",
                 "DocumentSet",
                 "DocumentSnapshot",
@@ -5940,10 +5890,9 @@
                 "ExponentialBackoff",
                 "FieldPath",
                 "FieldPath$1",
-                "FieldPath$2",
                 "FirebaseCredentialsProvider",
-                "Firestore",
-                "Firestore$1",
+                "FirebaseFirestore",
+                "FirebaseFirestore$1",
                 "FirestoreError",
                 "GeoPoint",
                 "GrpcConnection",
@@ -6024,11 +5973,13 @@
                 "View",
                 "ViewSnapshot",
                 "WatchChangeAggregator",
-                "WatchTargetChange"
+                "WatchTargetChange",
+                "_BaseFieldPath",
+                "_DocumentKeyReference"
             ],
             "variables": []
         },
-        "sizeInBytes": 205011
+        "sizeInBytes": 204585
     },
     "getFirestore": {
         "dependencies": {
@@ -6058,15 +6009,15 @@
                 "DelayedOperation",
                 "ExponentialBackoff",
                 "FirebaseCredentialsProvider",
-                "Firestore",
-                "Firestore$1",
+                "FirebaseFirestore",
+                "FirebaseFirestore$1",
                 "FirestoreError",
                 "OAuthToken",
                 "User"
             ],
             "variables": []
         },
-        "sizeInBytes": 16794
+        "sizeInBytes": 16834
     },
     "increment": {
         "dependencies": {
@@ -6104,19 +6055,19 @@
                 "FieldValue",
                 "FieldValueDelegate",
                 "FirebaseCredentialsProvider",
-                "Firestore",
-                "Firestore$1",
+                "FirebaseFirestore",
+                "FirebaseFirestore$1",
                 "FirestoreError",
                 "NumericIncrementFieldValueImpl",
                 "NumericIncrementTransformOperation",
                 "OAuthToken",
-                "SerializableFieldValue",
                 "TransformOperation",
-                "User"
+                "User",
+                "_SerializableFieldValue"
             ],
             "variables": []
         },
-        "sizeInBytes": 18640
+        "sizeInBytes": 18683
     },
     "initializeFirestore": {
         "dependencies": {
@@ -6146,8 +6097,8 @@
                 "DelayedOperation",
                 "ExponentialBackoff",
                 "FirebaseCredentialsProvider",
-                "Firestore",
-                "Firestore$1",
+                "FirebaseFirestore",
+                "FirebaseFirestore$1",
                 "FirestoreError",
                 "LruParams",
                 "OAuthToken",
@@ -6155,7 +6106,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 18098
+        "sizeInBytes": 18138
     },
     "limit": {
         "dependencies": {
@@ -6188,8 +6139,8 @@
                 "DelayedOperation",
                 "ExponentialBackoff",
                 "FirebaseCredentialsProvider",
-                "Firestore",
-                "Firestore$1",
+                "FirebaseFirestore",
+                "FirebaseFirestore$1",
                 "FirestoreError",
                 "OAuthToken",
                 "Query",
@@ -6200,7 +6151,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 18270
+        "sizeInBytes": 18311
     },
     "limitToLast": {
         "dependencies": {
@@ -6233,8 +6184,8 @@
                 "DelayedOperation",
                 "ExponentialBackoff",
                 "FirebaseCredentialsProvider",
-                "Firestore",
-                "Firestore$1",
+                "FirebaseFirestore",
+                "FirebaseFirestore$1",
                 "FirestoreError",
                 "OAuthToken",
                 "Query",
@@ -6245,12 +6196,11 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 18294
+        "sizeInBytes": 18335
     },
     "onSnapshot": {
         "dependencies": {
             "functions": [
-                "addNetworkStatusChangedHandler",
                 "allocateTarget",
                 "applyArrayRemoveTransformOperation",
                 "applyArrayUnionTransformOperation",
@@ -6528,7 +6478,6 @@
                 "AsyncObserver",
                 "AsyncQueue",
                 "AutoId",
-                "BaseFieldPath",
                 "BasePath",
                 "Bound",
                 "ByteString",
@@ -6544,7 +6493,6 @@
                 "Document",
                 "DocumentChangeSet",
                 "DocumentKey",
-                "DocumentKeyReference",
                 "DocumentReference",
                 "DocumentSet",
                 "DocumentSnapshot",
@@ -6556,10 +6504,9 @@
                 "ExponentialBackoff",
                 "FieldPath",
                 "FieldPath$1",
-                "FieldPath$2",
                 "FirebaseCredentialsProvider",
-                "Firestore",
-                "Firestore$1",
+                "FirebaseFirestore",
+                "FirebaseFirestore$1",
                 "FirestoreError",
                 "GeoPoint",
                 "GrpcConnection",
@@ -6640,16 +6587,17 @@
                 "View",
                 "ViewSnapshot",
                 "WatchChangeAggregator",
-                "WatchTargetChange"
+                "WatchTargetChange",
+                "_BaseFieldPath",
+                "_DocumentKeyReference"
             ],
             "variables": []
         },
-        "sizeInBytes": 206315
+        "sizeInBytes": 205915
     },
     "onSnapshotsInSync": {
         "dependencies": {
             "functions": [
-                "addNetworkStatusChangedHandler",
                 "addSnapshotsInSyncListener",
                 "allocateTarget",
                 "applyArrayRemoveTransformOperation",
@@ -6693,7 +6641,6 @@
                 "canonifyTarget",
                 "canonifyTimestamp",
                 "canonifyValue",
-                "cast",
                 "cleanUpWatchStreamState",
                 "coercedFieldValuesArray",
                 "compareArrays",
@@ -6925,8 +6872,8 @@
                 "ExponentialBackoff",
                 "FieldPath",
                 "FirebaseCredentialsProvider",
-                "Firestore",
-                "Firestore$1",
+                "FirebaseFirestore",
+                "FirebaseFirestore$1",
                 "FirestoreError",
                 "GrpcConnection",
                 "IndexFreeQueryEngine",
@@ -7002,13 +6949,12 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 184712
+        "sizeInBytes": 184102
     },
     "orderBy": {
         "dependencies": {
             "functions": [
                 "argToString",
-                "cast",
                 "createError",
                 "errorMessage",
                 "fail",
@@ -7047,7 +6993,6 @@
             "classes": [
                 "AsyncQueue",
                 "AutoId",
-                "BaseFieldPath",
                 "BasePath",
                 "DatabaseId",
                 "DatabaseInfo",
@@ -7056,10 +7001,9 @@
                 "ExponentialBackoff",
                 "FieldPath",
                 "FieldPath$1",
-                "FieldPath$2",
                 "FirebaseCredentialsProvider",
-                "Firestore",
-                "Firestore$1",
+                "FirebaseFirestore",
+                "FirebaseFirestore$1",
                 "FirestoreError",
                 "OAuthToken",
                 "OrderBy",
@@ -7067,17 +7011,17 @@
                 "QueryConstraint",
                 "QueryImpl",
                 "QueryOrderByConstraint",
-                "User"
+                "User",
+                "_BaseFieldPath"
             ],
             "variables": []
         },
-        "sizeInBytes": 28159
+        "sizeInBytes": 27568
     },
     "query": {
         "dependencies": {
             "functions": [
                 "argToString",
-                "cast",
                 "fail",
                 "formatJSON",
                 "getMessageOrStack",
@@ -7102,16 +7046,15 @@
                 "DelayedOperation",
                 "ExponentialBackoff",
                 "FirebaseCredentialsProvider",
-                "Firestore",
-                "Firestore$1",
+                "FirebaseFirestore",
+                "FirebaseFirestore$1",
                 "FirestoreError",
                 "OAuthToken",
-                "Query",
                 "User"
             ],
             "variables": []
         },
-        "sizeInBytes": 17492
+        "sizeInBytes": 16859
     },
     "queryEqual": {
         "dependencies": {
@@ -7121,7 +7064,7 @@
                 "binaryStringFromUint8Array",
                 "blobEquals",
                 "boundEquals",
-                "cast",
+                "debugCast",
                 "decodeBase64",
                 "encodeBase64",
                 "fail",
@@ -7175,20 +7118,19 @@
                 "ExponentialBackoff",
                 "FieldPath",
                 "FirebaseCredentialsProvider",
-                "Firestore",
-                "Firestore$1",
+                "FirebaseFirestore",
+                "FirebaseFirestore$1",
                 "FirestoreError",
                 "OAuthToken",
                 "OrderBy",
                 "Query",
-                "QueryImpl",
                 "TargetImpl",
                 "Timestamp",
                 "User"
             ],
             "variables": []
         },
-        "sizeInBytes": 32730
+        "sizeInBytes": 31988
     },
     "refEqual": {
         "dependencies": {
@@ -7223,22 +7165,22 @@
                 "Deferred",
                 "DelayedOperation",
                 "DocumentKey",
-                "DocumentKeyReference",
                 "DocumentReference",
                 "ExponentialBackoff",
                 "FirebaseCredentialsProvider",
-                "Firestore",
-                "Firestore$1",
+                "FirebaseFirestore",
+                "FirebaseFirestore$1",
                 "FirestoreError",
                 "OAuthToken",
                 "Query",
                 "QueryImpl",
                 "ResourcePath",
-                "User"
+                "User",
+                "_DocumentKeyReference"
             ],
             "variables": []
         },
-        "sizeInBytes": 23070
+        "sizeInBytes": 23112
     },
     "runTransaction": {
         "dependencies": {
@@ -7249,7 +7191,6 @@
                 "assertPresent",
                 "binaryStringFromUint8Array",
                 "blobEquals",
-                "cast",
                 "createError",
                 "createMetadata",
                 "debugCast",
@@ -7363,7 +7304,6 @@
                 "ArrayUnionTransformOperation",
                 "AsyncQueue",
                 "AutoId",
-                "BaseFieldPath",
                 "BasePath",
                 "ByteString",
                 "Bytes",
@@ -7378,7 +7318,6 @@
                 "DeleteMutation",
                 "Document",
                 "DocumentKey",
-                "DocumentKeyReference",
                 "DocumentReference",
                 "DocumentSnapshot",
                 "DocumentSnapshot$1",
@@ -7388,8 +7327,8 @@
                 "FieldPath$1",
                 "FieldPath$2",
                 "FirebaseCredentialsProvider",
-                "Firestore",
-                "Firestore$1",
+                "FirebaseFirestore",
+                "FirebaseFirestore$1",
                 "FirestoreError",
                 "GeoPoint",
                 "GrpcConnection",
@@ -7411,7 +7350,6 @@
                 "QueryDocumentSnapshot$1",
                 "QueryImpl",
                 "ResourcePath",
-                "SerializableFieldValue",
                 "ServerTimestampTransform",
                 "SetMutation",
                 "SnapshotMetadata",
@@ -7427,11 +7365,14 @@
                 "User",
                 "UserDataReader",
                 "UserDataWriter",
-                "VerifyMutation"
+                "VerifyMutation",
+                "_BaseFieldPath",
+                "_DocumentKeyReference",
+                "_SerializableFieldValue"
             ],
             "variables": []
         },
-        "sizeInBytes": 84452
+        "sizeInBytes": 83913
     },
     "serverTimestamp": {
         "dependencies": {
@@ -7464,26 +7405,25 @@
                 "FieldValue",
                 "FieldValueDelegate",
                 "FirebaseCredentialsProvider",
-                "Firestore",
-                "Firestore$1",
+                "FirebaseFirestore",
+                "FirebaseFirestore$1",
                 "FirestoreError",
                 "OAuthToken",
-                "SerializableFieldValue",
                 "ServerTimestampFieldValueImpl",
                 "ServerTimestampTransform",
                 "TransformOperation",
-                "User"
+                "User",
+                "_SerializableFieldValue"
             ],
             "variables": []
         },
-        "sizeInBytes": 17786
+        "sizeInBytes": 17829
     },
     "setDoc": {
         "dependencies": {
             "functions": [
                 "acknowledgeBatch",
                 "addMutationCallback",
-                "addNetworkStatusChangedHandler",
                 "addToWritePipeline",
                 "applyArrayRemoveTransformOperation",
                 "applyArrayUnionTransformOperation",
@@ -7629,7 +7569,6 @@
                 "newLocalStore",
                 "newPersistentWriteStream",
                 "newQueryComparator",
-                "newQueryForPath",
                 "newRemoteStore",
                 "newSerializer",
                 "newSyncEngine",
@@ -7720,11 +7659,8 @@
                 "typeOrder",
                 "uint8ArrayFromBinaryString",
                 "validateArgType",
-                "validateCollectionPath",
-                "validateDocumentPath",
                 "validateExactNumberOfArgs",
                 "validateNamedArrayAtLeastNumberOfElements",
-                "validateNonEmptyArgument",
                 "validatePlainObject",
                 "validateType",
                 "valueCompare",
@@ -7737,12 +7673,10 @@
                 "ArrayUnionTransformOperation",
                 "AsyncQueue",
                 "AutoId",
-                "BaseFieldPath",
                 "BasePath",
                 "Bound",
                 "ByteString",
                 "Bytes",
-                "CollectionReference",
                 "DatabaseId",
                 "DatabaseInfo",
                 "Datastore",
@@ -7753,16 +7687,14 @@
                 "DocReference",
                 "Document",
                 "DocumentKey",
-                "DocumentKeyReference",
-                "DocumentReference",
                 "EventManagerImpl",
                 "ExponentialBackoff",
                 "FieldMask",
                 "FieldPath",
                 "FieldPath$1",
                 "FirebaseCredentialsProvider",
-                "Firestore",
-                "Firestore$1",
+                "FirebaseFirestore",
+                "FirebaseFirestore$1",
                 "FirestoreError",
                 "GeoPoint",
                 "GrpcConnection",
@@ -7808,13 +7740,11 @@
                 "PersistentStream",
                 "PersistentWriteStream",
                 "Precondition",
-                "Query",
                 "QueryImpl",
                 "ReferenceSet",
                 "RemoteDocumentChangeBuffer",
                 "RemoteStoreImpl",
                 "ResourcePath",
-                "SerializableFieldValue",
                 "ServerTimestampTransform",
                 "SetMutation",
                 "SnapshotVersion",
@@ -7832,11 +7762,14 @@
                 "UnknownDocument",
                 "User",
                 "UserDataReader",
-                "VerifyMutation"
+                "VerifyMutation",
+                "_BaseFieldPath",
+                "_DocumentKeyReference",
+                "_SerializableFieldValue"
             ],
             "variables": []
         },
-        "sizeInBytes": 167454
+        "sizeInBytes": 164700
     },
     "setLogLevel": {
         "dependencies": {
@@ -7866,15 +7799,15 @@
                 "DelayedOperation",
                 "ExponentialBackoff",
                 "FirebaseCredentialsProvider",
-                "Firestore",
-                "Firestore$1",
+                "FirebaseFirestore",
+                "FirebaseFirestore$1",
                 "FirestoreError",
                 "OAuthToken",
                 "User"
             ],
             "variables": []
         },
-        "sizeInBytes": 16760
+        "sizeInBytes": 16800
     },
     "snapshotEqual": {
         "dependencies": {
@@ -7884,9 +7817,9 @@
                 "binaryStringFromUint8Array",
                 "blobEquals",
                 "boundEquals",
-                "cast",
                 "changesFromSnapshot",
                 "createError",
+                "debugCast",
                 "decodeBase64",
                 "encodeBase64",
                 "errorMessage",
@@ -7953,7 +7886,6 @@
             "classes": [
                 "AsyncQueue",
                 "AutoId",
-                "BaseFieldPath",
                 "BasePath",
                 "Bound",
                 "ByteString",
@@ -7964,17 +7896,15 @@
                 "Deferred",
                 "DelayedOperation",
                 "DocumentKey",
-                "DocumentKeyReference",
                 "DocumentReference",
                 "DocumentSnapshot",
                 "DocumentSnapshot$1",
                 "ExponentialBackoff",
                 "FieldPath",
                 "FieldPath$1",
-                "FieldPath$2",
                 "FirebaseCredentialsProvider",
-                "Firestore",
-                "Firestore$1",
+                "FirebaseFirestore",
+                "FirebaseFirestore$1",
                 "FirestoreError",
                 "GeoPoint",
                 "OAuthToken",
@@ -7989,19 +7919,21 @@
                 "TargetImpl",
                 "Timestamp",
                 "User",
-                "UserDataWriter"
+                "UserDataWriter",
+                "_BaseFieldPath",
+                "_DocumentKeyReference"
             ],
             "variables": []
         },
-        "sizeInBytes": 51794
+        "sizeInBytes": 51223
     },
     "startAfter": {
         "dependencies": {
             "functions": [
                 "argToString",
                 "binaryStringFromUint8Array",
-                "cast",
                 "createError",
+                "debugCast",
                 "decodeBase64",
                 "encodeBase64",
                 "errorMessage",
@@ -8080,7 +8012,6 @@
             "classes": [
                 "AsyncQueue",
                 "AutoId",
-                "BaseFieldPath",
                 "BasePath",
                 "Bound",
                 "ByteString",
@@ -8091,16 +8022,14 @@
                 "Deferred",
                 "DelayedOperation",
                 "DocumentKey",
-                "DocumentKeyReference",
                 "DocumentReference",
                 "DocumentSnapshot",
                 "ExponentialBackoff",
                 "FieldPath",
                 "FieldPath$1",
-                "FieldPath$2",
                 "FirebaseCredentialsProvider",
-                "Firestore",
-                "Firestore$1",
+                "FirebaseFirestore",
+                "FirebaseFirestore$1",
                 "FirestoreError",
                 "GeoPoint",
                 "JsonProtoSerializer",
@@ -8113,23 +8042,25 @@
                 "QueryImpl",
                 "QueryStartAtConstraint",
                 "ResourcePath",
-                "SerializableFieldValue",
                 "Timestamp",
                 "User",
                 "UserDataReader",
-                "UserDataWriter"
+                "UserDataWriter",
+                "_BaseFieldPath",
+                "_DocumentKeyReference",
+                "_SerializableFieldValue"
             ],
             "variables": []
         },
-        "sizeInBytes": 54050
+        "sizeInBytes": 53508
     },
     "startAt": {
         "dependencies": {
             "functions": [
                 "argToString",
                 "binaryStringFromUint8Array",
-                "cast",
                 "createError",
+                "debugCast",
                 "decodeBase64",
                 "encodeBase64",
                 "errorMessage",
@@ -8208,7 +8139,6 @@
             "classes": [
                 "AsyncQueue",
                 "AutoId",
-                "BaseFieldPath",
                 "BasePath",
                 "Bound",
                 "ByteString",
@@ -8219,16 +8149,14 @@
                 "Deferred",
                 "DelayedOperation",
                 "DocumentKey",
-                "DocumentKeyReference",
                 "DocumentReference",
                 "DocumentSnapshot",
                 "ExponentialBackoff",
                 "FieldPath",
                 "FieldPath$1",
-                "FieldPath$2",
                 "FirebaseCredentialsProvider",
-                "Firestore",
-                "Firestore$1",
+                "FirebaseFirestore",
+                "FirebaseFirestore$1",
                 "FirestoreError",
                 "GeoPoint",
                 "JsonProtoSerializer",
@@ -8241,21 +8169,22 @@
                 "QueryImpl",
                 "QueryStartAtConstraint",
                 "ResourcePath",
-                "SerializableFieldValue",
                 "Timestamp",
                 "User",
                 "UserDataReader",
-                "UserDataWriter"
+                "UserDataWriter",
+                "_BaseFieldPath",
+                "_DocumentKeyReference",
+                "_SerializableFieldValue"
             ],
             "variables": []
         },
-        "sizeInBytes": 54040
+        "sizeInBytes": 53498
     },
     "terminate": {
         "dependencies": {
             "functions": [
                 "argToString",
-                "cast",
                 "fail",
                 "formatJSON",
                 "getMessageOrStack",
@@ -8280,22 +8209,21 @@
                 "DelayedOperation",
                 "ExponentialBackoff",
                 "FirebaseCredentialsProvider",
-                "Firestore",
-                "Firestore$1",
+                "FirebaseFirestore",
+                "FirebaseFirestore$1",
                 "FirestoreError",
                 "OAuthToken",
                 "User"
             ],
             "variables": []
         },
-        "sizeInBytes": 17291
+        "sizeInBytes": 16869
     },
     "updateDoc": {
         "dependencies": {
             "functions": [
                 "acknowledgeBatch",
                 "addMutationCallback",
-                "addNetworkStatusChangedHandler",
                 "addToWritePipeline",
                 "applyArrayRemoveTransformOperation",
                 "applyArrayUnionTransformOperation",
@@ -8441,7 +8369,6 @@
                 "newLocalStore",
                 "newPersistentWriteStream",
                 "newQueryComparator",
-                "newQueryForPath",
                 "newRemoteStore",
                 "newSerializer",
                 "newSyncEngine",
@@ -8533,11 +8460,8 @@
                 "uint8ArrayFromBinaryString",
                 "updateDoc",
                 "validateArgType",
-                "validateCollectionPath",
-                "validateDocumentPath",
                 "validateExactNumberOfArgs",
                 "validateNamedArrayAtLeastNumberOfElements",
-                "validateNonEmptyArgument",
                 "validatePlainObject",
                 "validateType",
                 "valueCompare",
@@ -8550,12 +8474,10 @@
                 "ArrayUnionTransformOperation",
                 "AsyncQueue",
                 "AutoId",
-                "BaseFieldPath",
                 "BasePath",
                 "Bound",
                 "ByteString",
                 "Bytes",
-                "CollectionReference",
                 "DatabaseId",
                 "DatabaseInfo",
                 "Datastore",
@@ -8567,8 +8489,6 @@
                 "DocReference",
                 "Document",
                 "DocumentKey",
-                "DocumentKeyReference",
-                "DocumentReference",
                 "EventManagerImpl",
                 "ExponentialBackoff",
                 "FieldMask",
@@ -8576,8 +8496,8 @@
                 "FieldPath$1",
                 "FieldPath$2",
                 "FirebaseCredentialsProvider",
-                "Firestore",
-                "Firestore$1",
+                "FirebaseFirestore",
+                "FirebaseFirestore$1",
                 "FirestoreError",
                 "GeoPoint",
                 "GrpcConnection",
@@ -8623,13 +8543,11 @@
                 "PersistentStream",
                 "PersistentWriteStream",
                 "Precondition",
-                "Query",
                 "QueryImpl",
                 "ReferenceSet",
                 "RemoteDocumentChangeBuffer",
                 "RemoteStoreImpl",
                 "ResourcePath",
-                "SerializableFieldValue",
                 "ServerTimestampTransform",
                 "SetMutation",
                 "SnapshotVersion",
@@ -8647,11 +8565,14 @@
                 "UnknownDocument",
                 "User",
                 "UserDataReader",
-                "VerifyMutation"
+                "VerifyMutation",
+                "_BaseFieldPath",
+                "_DocumentKeyReference",
+                "_SerializableFieldValue"
             ],
             "variables": []
         },
-        "sizeInBytes": 168953
+        "sizeInBytes": 166163
     },
     "waitForPendingWrites": {
         "dependencies": {
@@ -8693,7 +8614,6 @@
                 "canonifyTarget",
                 "canonifyTimestamp",
                 "canonifyValue",
-                "cast",
                 "coercedFieldValuesArray",
                 "compareArrays",
                 "compareBlobs",
@@ -8846,8 +8766,8 @@
                 "ExponentialBackoff",
                 "FieldPath",
                 "FirebaseCredentialsProvider",
-                "Firestore",
-                "Firestore$1",
+                "FirebaseFirestore",
+                "FirebaseFirestore$1",
                 "FirestoreError",
                 "GrpcConnection",
                 "IndexFreeQueryEngine",
@@ -8910,7 +8830,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 127742
+        "sizeInBytes": 127302
     },
     "where": {
         "dependencies": {
@@ -8920,7 +8840,6 @@
                 "arrayValueContains",
                 "binaryStringFromUint8Array",
                 "blobEquals",
-                "cast",
                 "compareArrays",
                 "compareBlobs",
                 "compareGeoPoints",
@@ -9017,7 +8936,6 @@
                 "ArrayContainsFilter",
                 "AsyncQueue",
                 "AutoId",
-                "BaseFieldPath",
                 "BasePath",
                 "ByteString",
                 "Bytes",
@@ -9026,16 +8944,14 @@
                 "Deferred",
                 "DelayedOperation",
                 "DocumentKey",
-                "DocumentKeyReference",
                 "ExponentialBackoff",
                 "FieldFilter",
                 "FieldPath",
                 "FieldPath$1",
-                "FieldPath$2",
                 "Filter",
                 "FirebaseCredentialsProvider",
-                "Firestore",
-                "Firestore$1",
+                "FirebaseFirestore",
+                "FirebaseFirestore$1",
                 "FirestoreError",
                 "GeoPoint",
                 "InFilter",
@@ -9051,21 +8967,22 @@
                 "QueryFilterConstraint",
                 "QueryImpl",
                 "ResourcePath",
-                "SerializableFieldValue",
                 "Timestamp",
                 "User",
-                "UserDataReader"
+                "UserDataReader",
+                "_BaseFieldPath",
+                "_DocumentKeyReference",
+                "_SerializableFieldValue"
             ],
             "variables": []
         },
-        "sizeInBytes": 58527
+        "sizeInBytes": 57943
     },
     "writeBatch": {
         "dependencies": {
             "functions": [
                 "acknowledgeBatch",
                 "addMutationCallback",
-                "addNetworkStatusChangedHandler",
                 "addToWritePipeline",
                 "applyArrayRemoveTransformOperation",
                 "applyArrayUnionTransformOperation",
@@ -9108,7 +9025,6 @@
                 "canonifyTarget",
                 "canonifyTimestamp",
                 "canonifyValue",
-                "cast",
                 "coercedFieldValuesArray",
                 "compareArrays",
                 "compareBlobs",
@@ -9212,7 +9128,6 @@
                 "newLocalStore",
                 "newPersistentWriteStream",
                 "newQueryComparator",
-                "newQueryForPath",
                 "newRemoteStore",
                 "newSerializer",
                 "newSyncEngine",
@@ -9304,11 +9219,8 @@
                 "typeOrder",
                 "uint8ArrayFromBinaryString",
                 "validateArgType",
-                "validateCollectionPath",
-                "validateDocumentPath",
                 "validateExactNumberOfArgs",
                 "validateNamedArrayAtLeastNumberOfElements",
-                "validateNonEmptyArgument",
                 "validatePlainObject",
                 "validateReference",
                 "validateType",
@@ -9323,12 +9235,10 @@
                 "ArrayUnionTransformOperation",
                 "AsyncQueue",
                 "AutoId",
-                "BaseFieldPath",
                 "BasePath",
                 "Bound",
                 "ByteString",
                 "Bytes",
-                "CollectionReference",
                 "DatabaseId",
                 "DatabaseInfo",
                 "Datastore",
@@ -9340,8 +9250,6 @@
                 "DocReference",
                 "Document",
                 "DocumentKey",
-                "DocumentKeyReference",
-                "DocumentReference",
                 "EventManagerImpl",
                 "ExponentialBackoff",
                 "FieldMask",
@@ -9349,8 +9257,8 @@
                 "FieldPath$1",
                 "FieldPath$2",
                 "FirebaseCredentialsProvider",
-                "Firestore",
-                "Firestore$1",
+                "FirebaseFirestore",
+                "FirebaseFirestore$1",
                 "FirestoreError",
                 "GeoPoint",
                 "GrpcConnection",
@@ -9397,13 +9305,11 @@
                 "PersistentStream",
                 "PersistentWriteStream",
                 "Precondition",
-                "Query",
                 "QueryImpl",
                 "ReferenceSet",
                 "RemoteDocumentChangeBuffer",
                 "RemoteStoreImpl",
                 "ResourcePath",
-                "SerializableFieldValue",
                 "ServerTimestampTransform",
                 "SetMutation",
                 "SnapshotVersion",
@@ -9422,10 +9328,13 @@
                 "User",
                 "UserDataReader",
                 "VerifyMutation",
-                "WriteBatch"
+                "WriteBatch",
+                "_BaseFieldPath",
+                "_DocumentKeyReference",
+                "_SerializableFieldValue"
             ],
             "variables": []
         },
-        "sizeInBytes": 172600
+        "sizeInBytes": 169339
     }
 }

--- a/packages/firestore/exp/index.ts
+++ b/packages/firestore/exp/index.ts
@@ -22,7 +22,7 @@ registerFirestore();
 export { FieldPath, documentId } from '../lite/src/api/field_path';
 
 export {
-  Firestore as FirebaseFirestore,
+  FirebaseFirestore,
   initializeFirestore,
   getFirestore,
   enableIndexedDbPersistence,
@@ -31,14 +31,19 @@ export {
   waitForPendingWrites,
   disableNetwork,
   enableNetwork,
-  terminate
+  terminate,
+  Settings
 } from './src/api/database';
 
 export {
+  DocumentChange,
   DocumentSnapshot,
   QueryDocumentSnapshot,
   QuerySnapshot,
-  snapshotEqual
+  snapshotEqual,
+  SnapshotOptions,
+  FirestoreDataConverter,
+  DocumentChangeType
 } from './src/api/snapshot';
 
 export { SnapshotMetadata } from '../src/api/database';
@@ -59,7 +64,12 @@ export {
   limit,
   limitToLast,
   where,
-  orderBy
+  orderBy,
+  SetOptions,
+  QueryConstraintType,
+  DocumentData,
+  UpdateData,
+  OrderByDirection
 } from '../lite/src/api/reference';
 
 export { runTransaction, Transaction } from './src/api/transaction';
@@ -88,7 +98,7 @@ export {
   serverTimestamp
 } from '../lite/src/api/field_value';
 
-export { setLogLevel } from '../src/util/log';
+export { setLogLevel, LogLevel } from '../src/util/log';
 
 export { Bytes } from '../lite/src/api/bytes';
 
@@ -101,3 +111,9 @@ export { GeoPoint } from '../src/api/geo_point';
 export { Timestamp } from '../src/api/timestamp';
 
 export { refEqual, queryEqual } from '../lite/src/api/reference';
+
+export { SnapshotListenOptions } from './src/api/reference';
+
+export { CACHE_SIZE_UNLIMITED } from '../src/api/database';
+
+export { FirestoreErrorCode, FirestoreError } from '../src/util/error';

--- a/packages/firestore/exp/register.ts
+++ b/packages/firestore/exp/register.ts
@@ -18,7 +18,7 @@
 import { _registerComponent, registerVersion } from '@firebase/app-exp';
 import { Component, ComponentType } from '@firebase/component';
 
-import { Firestore } from './src/api/database';
+import { FirebaseFirestore } from './src/api/database';
 import { version } from '../package.json';
 
 export function registerFirestore(): void {
@@ -27,7 +27,7 @@ export function registerFirestore(): void {
       'firestore-exp',
       container => {
         const app = container.getProvider('app-exp').getImmediate()!;
-        return ((app, auth) => new Firestore(app, auth))(
+        return ((app, auth) => new FirebaseFirestore(app, auth))(
           app,
           container.getProvider('auth-internal')
         );

--- a/packages/firestore/exp/src/api/components.ts
+++ b/packages/firestore/exp/src/api/components.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { Firestore } from './database';
+import { FirebaseFirestore } from './database';
 import { PersistenceSettings } from '../../../src/core/firestore_client';
 import {
   MemoryOfflineComponentProvider,
@@ -45,16 +45,16 @@ export const LOG_TAG = 'ComponentProvider';
 // Instance maps that ensure that only one component provider exists per
 // Firestore instance.
 const offlineComponentProviders = new Map<
-  Firestore,
+  FirebaseFirestore,
   Promise<OfflineComponentProvider>
 >();
 const onlineComponentProviders = new Map<
-  Firestore,
+  FirebaseFirestore,
   Promise<OnlineComponentProvider>
 >();
 
 export async function setOfflineComponentProvider(
-  firestore: Firestore,
+  firestore: FirebaseFirestore,
   persistenceSettings: PersistenceSettings,
   offlineComponentProvider: OfflineComponentProvider
 ): Promise<void> {
@@ -83,7 +83,7 @@ export async function setOfflineComponentProvider(
 }
 
 export async function setOnlineComponentProvider(
-  firestore: Firestore,
+  firestore: FirebaseFirestore,
   onlineComponentProvider: OnlineComponentProvider
 ): Promise<void> {
   const onlineDeferred = new Deferred<OnlineComponentProvider>();
@@ -112,7 +112,7 @@ export async function setOnlineComponentProvider(
 }
 
 function getOfflineComponentProvider(
-  firestore: Firestore
+  firestore: FirebaseFirestore
 ): Promise<OfflineComponentProvider> {
   firestore._queue.verifyOperationInProgress();
 
@@ -129,7 +129,7 @@ function getOfflineComponentProvider(
 }
 
 function getOnlineComponentProvider(
-  firestore: Firestore
+  firestore: FirebaseFirestore
 ): Promise<OnlineComponentProvider> {
   firestore._queue.verifyOperationInProgress();
 
@@ -144,19 +144,25 @@ function getOnlineComponentProvider(
 // Note: These functions cannot be `async` since we want to throw an exception
 // when Firestore is terminated (via `getOnlineComponentProvider()`).
 
-export function getSyncEngine(firestore: Firestore): Promise<SyncEngine> {
+export function getSyncEngine(
+  firestore: FirebaseFirestore
+): Promise<SyncEngine> {
   return getOnlineComponentProvider(firestore).then(
     components => components.syncEngine
   );
 }
 
-export function getRemoteStore(firestore: Firestore): Promise<RemoteStore> {
+export function getRemoteStore(
+  firestore: FirebaseFirestore
+): Promise<RemoteStore> {
   return getOnlineComponentProvider(firestore).then(
     components => components.remoteStore
   );
 }
 
-export function getEventManager(firestore: Firestore): Promise<EventManager> {
+export function getEventManager(
+  firestore: FirebaseFirestore
+): Promise<EventManager> {
   return getOnlineComponentProvider(firestore).then(components => {
     const eventManager = components.eventManager;
     eventManager.onListen = syncEngineListen.bind(null, components.syncEngine);
@@ -168,13 +174,17 @@ export function getEventManager(firestore: Firestore): Promise<EventManager> {
   });
 }
 
-export function getPersistence(firestore: Firestore): Promise<Persistence> {
+export function getPersistence(
+  firestore: FirebaseFirestore
+): Promise<Persistence> {
   return getOfflineComponentProvider(firestore).then(
     components => components.persistence
   );
 }
 
-export function getLocalStore(firestore: Firestore): Promise<LocalStore> {
+export function getLocalStore(
+  firestore: FirebaseFirestore
+): Promise<LocalStore> {
   return getOfflineComponentProvider(firestore).then(
     provider => provider.localStore
   );
@@ -184,7 +194,9 @@ export function getLocalStore(firestore: Firestore): Promise<LocalStore> {
  * Removes all components associated with the provided instance. Must be called
  * when the Firestore instance is terminated.
  */
-export async function removeComponents(firestore: Firestore): Promise<void> {
+export async function removeComponents(
+  firestore: FirebaseFirestore
+): Promise<void> {
   const onlineComponentProviderPromise = onlineComponentProviders.get(
     firestore
   );

--- a/packages/firestore/exp/src/api/reference.ts
+++ b/packages/firestore/exp/src/api/reference.ts
@@ -396,7 +396,7 @@ export function onSnapshot<T>(
   onCompletion?: () => void
 ): Unsubscribe;
 export function onSnapshot<T>(
-  ref: Query<T> | DocumentReference<T>,
+  reference: Query<T> | DocumentReference<T>,
   ...args: unknown[]
 ): Unsubscribe {
   let options: SnapshotListenOptions = {
@@ -423,15 +423,15 @@ export function onSnapshot<T>(
   let firestore: FirebaseFirestore;
   let internalQuery: InternalQuery;
 
-  if (ref instanceof DocumentReference) {
-    firestore = cast(ref.firestore, FirebaseFirestore);
-    internalQuery = newQueryForPath(ref._key.path);
+  if (reference instanceof DocumentReference) {
+    firestore = cast(reference.firestore, FirebaseFirestore);
+    internalQuery = newQueryForPath(reference._key.path);
 
     observer = {
       next: snapshot => {
         if (args[currArg]) {
           (args[currArg] as NextFn<DocumentSnapshot<T>>)(
-            convertToDocSnapshot(firestore, ref, snapshot)
+            convertToDocSnapshot(firestore, reference, snapshot)
           );
         }
       },
@@ -439,14 +439,14 @@ export function onSnapshot<T>(
       complete: args[currArg + 2] as CompleteFn
     };
   } else {
-    firestore = cast(ref.firestore, FirebaseFirestore);
-    internalQuery = ref._query;
+    firestore = cast(reference.firestore, FirebaseFirestore);
+    internalQuery = reference._query;
 
     observer = {
       next: snapshot => {
         if (args[currArg]) {
           (args[currArg] as NextFn<QuerySnapshot<T>>)(
-            new QuerySnapshot(firestore, ref, snapshot)
+            new QuerySnapshot(firestore, reference, snapshot)
           );
         }
       },
@@ -454,7 +454,7 @@ export function onSnapshot<T>(
       complete: args[currArg + 2] as CompleteFn
     };
 
-    validateHasExplicitOrderByForLimitToLast(ref._query);
+    validateHasExplicitOrderByForLimitToLast(reference._query);
   }
 
   firestore._verifyNotTerminated();

--- a/packages/firestore/exp/src/api/snapshot.ts
+++ b/packages/firestore/exp/src/api/snapshot.ts
@@ -26,7 +26,6 @@ import {
   fieldPathFromArgument
 } from '../../../lite/src/api/snapshot';
 import { FirebaseFirestore } from './database';
-import { cast } from '../../../lite/src/api/util';
 import {
   DocumentData,
   DocumentReference,
@@ -81,7 +80,7 @@ export class DocumentSnapshot<T = DocumentData> extends LiteDocumentSnapshot<
     converter: FirestoreDataConverter<T> | null
   ) {
     super(_firestore, key, document, converter);
-    this._firestoreImpl = cast(_firestore, FirebaseFirestore);
+    this._firestoreImpl = _firestore;
   }
 
   exists(): this is QueryDocumentSnapshot<T> {
@@ -119,8 +118,7 @@ export class DocumentSnapshot<T = DocumentData> extends LiteDocumentSnapshot<
     }
   }
 
-  // We are using `any` here, since `unknown` would require an explicit cast by
-  // our users.
+  // We are using `any` here to avoid an explicit cast by our users.
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   get(fieldPath: string | FieldPath, options: SnapshotOptions = {}): any {
     if (this._document) {

--- a/packages/firestore/exp/src/api/transaction.ts
+++ b/packages/firestore/exp/src/api/transaction.ts
@@ -15,36 +15,31 @@
  * limitations under the License.
  */
 
-import * as firestore from '../../../exp-types';
-
 import { Transaction as LiteTransaction } from '../../../lite/src/api/transaction';
 import { DocumentSnapshot } from './snapshot';
 import { TransactionRunner } from '../../../src/core/transaction_runner';
 import { AsyncQueue } from '../../../src/util/async_queue';
 import { cast } from '../../../lite/src/api/util';
-import { Firestore } from './database';
+import { FirebaseFirestore } from './database';
 import { Deferred } from '../../../src/util/promise';
 import { SnapshotMetadata } from '../../../src/api/database';
 import { Transaction as InternalTransaction } from '../../../src/core/transaction';
 import { validateReference } from '../../../lite/src/api/write_batch';
 import { getDatastore } from '../../../lite/src/api/components';
+import { DocumentReference } from '../../../lite/src/api/reference';
 
-export class Transaction
-  extends LiteTransaction
-  implements firestore.Transaction {
+export class Transaction extends LiteTransaction {
   // This class implements the same logic as the Transaction API in the Lite SDK
   // but is subclassed in order to return its own DocumentSnapshot types.
 
   constructor(
-    protected readonly _firestore: Firestore,
+    protected readonly _firestore: FirebaseFirestore,
     _transaction: InternalTransaction
   ) {
     super(_firestore, _transaction);
   }
 
-  get<T>(
-    documentRef: firestore.DocumentReference<T>
-  ): Promise<DocumentSnapshot<T>> {
+  get<T>(documentRef: DocumentReference<T>): Promise<DocumentSnapshot<T>> {
     const ref = validateReference<T>(documentRef, this._firestore);
     return super
       .get(documentRef)
@@ -65,10 +60,10 @@ export class Transaction
 }
 
 export function runTransaction<T>(
-  firestore: firestore.FirebaseFirestore,
-  updateFunction: (transaction: firestore.Transaction) => Promise<T>
+  firestore: FirebaseFirestore,
+  updateFunction: (transaction: Transaction) => Promise<T>
 ): Promise<T> {
-  const firestoreClient = cast(firestore, Firestore);
+  const firestoreClient = cast(firestore, FirebaseFirestore);
   firestoreClient._verifyNotTerminated();
 
   const deferred = new Deferred<T>();

--- a/packages/firestore/exp/src/api/write_batch.ts
+++ b/packages/firestore/exp/src/api/write_batch.ts
@@ -15,15 +15,13 @@
  * limitations under the License.
  */
 
-import { cast } from '../../../lite/src/api/util';
 import { WriteBatch } from '../../../lite/src/api/write_batch';
 import { FirebaseFirestore } from './database';
 import { executeWrite } from './reference';
 
 export function writeBatch(firestore: FirebaseFirestore): WriteBatch {
-  const firestoreImpl = cast(firestore, FirebaseFirestore);
-  firestoreImpl._verifyNotTerminated();
-  return new WriteBatch(firestoreImpl, mutations =>
-    executeWrite(firestoreImpl, mutations)
+  firestore._verifyNotTerminated();
+  return new WriteBatch(firestore, mutations =>
+    executeWrite(firestore, mutations)
   );
 }

--- a/packages/firestore/exp/src/api/write_batch.ts
+++ b/packages/firestore/exp/src/api/write_batch.ts
@@ -15,19 +15,13 @@
  * limitations under the License.
  */
 
-// See https://github.com/typescript-eslint/typescript-eslint/issues/363
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-import * as firestore from '../../../exp-types';
-
 import { cast } from '../../../lite/src/api/util';
 import { WriteBatch } from '../../../lite/src/api/write_batch';
-import { Firestore } from './database';
+import { FirebaseFirestore } from './database';
 import { executeWrite } from './reference';
 
-export function writeBatch(
-  firestore: firestore.FirebaseFirestore
-): firestore.WriteBatch {
-  const firestoreImpl = cast(firestore, Firestore);
+export function writeBatch(firestore: FirebaseFirestore): WriteBatch {
+  const firestoreImpl = cast(firestore, FirebaseFirestore);
   firestoreImpl._verifyNotTerminated();
   return new WriteBatch(firestoreImpl, mutations =>
     executeWrite(firestoreImpl, mutations)

--- a/packages/firestore/exp/test/shim.ts
+++ b/packages/firestore/exp/test/shim.ts
@@ -19,7 +19,7 @@ import { FirebaseApp as FirebaseAppLegacy } from '@firebase/app-types';
 import { FirebaseApp as FirebaseAppExp } from '@firebase/app-types-exp';
 import { deleteApp } from '@firebase/app-exp';
 import * as legacy from '@firebase/firestore-types';
-import * as exp from '../../exp-types';
+import * as exp from '../index';
 
 import {
   addDoc,
@@ -766,7 +766,10 @@ function wrap(value: any): any {
   } else if (value instanceof DocumentReferenceExp) {
     // TODO(mrschmidt): Ideally, we should use an existing instance of
     // FirebaseFirestore here rather than instantiating a new instance
-    return new DocumentReference(new FirebaseFirestore(value.firestore), value);
+    return new DocumentReference(
+      new FirebaseFirestore(value.firestore as exp.FirebaseFirestore),
+      value
+    );
   } else if (isPlainObject(value)) {
     const obj: any = {};
     for (const key in value) {

--- a/packages/firestore/lite/dependencies.json
+++ b/packages/firestore/lite/dependencies.json
@@ -21,14 +21,14 @@
                 "Bytes",
                 "DatabaseId",
                 "FirebaseCredentialsProvider",
-                "Firestore",
+                "FirebaseFirestore",
                 "FirestoreError",
                 "OAuthToken",
                 "User"
             ],
             "variables": []
         },
-        "sizeInBytes": 9277
+        "sizeInBytes": 9261
     },
     "CollectionReference": {
         "dependencies": {
@@ -54,20 +54,20 @@
                 "CollectionReference",
                 "DatabaseId",
                 "DocumentKey",
-                "DocumentKeyReference",
                 "DocumentReference",
                 "FirebaseCredentialsProvider",
-                "Firestore",
+                "FirebaseFirestore",
                 "FirestoreError",
                 "OAuthToken",
                 "Query",
                 "QueryImpl",
                 "ResourcePath",
-                "User"
+                "User",
+                "_DocumentKeyReference"
             ],
             "variables": []
         },
-        "sizeInBytes": 14009
+        "sizeInBytes": 13995
     },
     "DocumentReference": {
         "dependencies": {
@@ -93,27 +93,26 @@
                 "CollectionReference",
                 "DatabaseId",
                 "DocumentKey",
-                "DocumentKeyReference",
                 "DocumentReference",
                 "FirebaseCredentialsProvider",
-                "Firestore",
+                "FirebaseFirestore",
                 "FirestoreError",
                 "OAuthToken",
                 "Query",
                 "QueryImpl",
                 "ResourcePath",
-                "User"
+                "User",
+                "_DocumentKeyReference"
             ],
             "variables": []
         },
-        "sizeInBytes": 14007
+        "sizeInBytes": 13993
     },
     "DocumentSnapshot": {
         "dependencies": {
             "functions": [
                 "argToString",
                 "binaryStringFromUint8Array",
-                "cast",
                 "createError",
                 "decodeBase64",
                 "encodeBase64",
@@ -157,21 +156,18 @@
             ],
             "classes": [
                 "AutoId",
-                "BaseFieldPath",
                 "BasePath",
                 "ByteString",
                 "Bytes",
                 "CollectionReference",
                 "DatabaseId",
                 "DocumentKey",
-                "DocumentKeyReference",
                 "DocumentReference",
                 "DocumentSnapshot",
                 "FieldPath",
                 "FieldPath$1",
-                "FieldPath$2",
                 "FirebaseCredentialsProvider",
-                "Firestore",
+                "FirebaseFirestore",
                 "FirestoreError",
                 "GeoPoint",
                 "OAuthToken",
@@ -181,17 +177,18 @@
                 "ResourcePath",
                 "Timestamp",
                 "User",
-                "UserDataWriter"
+                "UserDataWriter",
+                "_BaseFieldPath",
+                "_DocumentKeyReference"
             ],
             "variables": []
         },
-        "sizeInBytes": 31606
+        "sizeInBytes": 30960
     },
     "FieldPath": {
         "dependencies": {
             "functions": [
                 "argToString",
-                "cast",
                 "fail",
                 "formatJSON",
                 "formatPlural",
@@ -210,20 +207,20 @@
                 "valueDescription"
             ],
             "classes": [
-                "BaseFieldPath",
                 "BasePath",
                 "DatabaseId",
                 "FieldPath",
                 "FieldPath$2",
                 "FirebaseCredentialsProvider",
-                "Firestore",
+                "FirebaseFirestore",
                 "FirestoreError",
                 "OAuthToken",
-                "User"
+                "User",
+                "_BaseFieldPath"
             ],
             "variables": []
         },
-        "sizeInBytes": 13900
+        "sizeInBytes": 13442
     },
     "FieldValue": {
         "dependencies": {
@@ -242,15 +239,15 @@
                 "DatabaseId",
                 "FieldValue",
                 "FirebaseCredentialsProvider",
-                "Firestore",
+                "FirebaseFirestore",
                 "FirestoreError",
                 "OAuthToken",
-                "SerializableFieldValue",
-                "User"
+                "User",
+                "_SerializableFieldValue"
             ],
             "variables": []
         },
-        "sizeInBytes": 7530
+        "sizeInBytes": 7516
     },
     "FirebaseFirestore": {
         "dependencies": {
@@ -268,14 +265,14 @@
             "classes": [
                 "DatabaseId",
                 "FirebaseCredentialsProvider",
-                "Firestore",
+                "FirebaseFirestore",
                 "FirestoreError",
                 "OAuthToken",
                 "User"
             ],
             "variables": []
         },
-        "sizeInBytes": 7437
+        "sizeInBytes": 7408
     },
     "GeoPoint": {
         "dependencies": {
@@ -301,7 +298,7 @@
             "classes": [
                 "DatabaseId",
                 "FirebaseCredentialsProvider",
-                "Firestore",
+                "FirebaseFirestore",
                 "FirestoreError",
                 "GeoPoint",
                 "OAuthToken",
@@ -309,7 +306,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 10348
+        "sizeInBytes": 10332
     },
     "Query": {
         "dependencies": {
@@ -327,7 +324,7 @@
             "classes": [
                 "DatabaseId",
                 "FirebaseCredentialsProvider",
-                "Firestore",
+                "FirebaseFirestore",
                 "FirestoreError",
                 "OAuthToken",
                 "Query",
@@ -335,7 +332,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 7632
+        "sizeInBytes": 7616
     },
     "QueryConstraint": {
         "dependencies": {
@@ -353,7 +350,7 @@
             "classes": [
                 "DatabaseId",
                 "FirebaseCredentialsProvider",
-                "Firestore",
+                "FirebaseFirestore",
                 "FirestoreError",
                 "OAuthToken",
                 "QueryConstraint",
@@ -361,14 +358,13 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 7445
+        "sizeInBytes": 7429
     },
     "QueryDocumentSnapshot": {
         "dependencies": {
             "functions": [
                 "argToString",
                 "binaryStringFromUint8Array",
-                "cast",
                 "createError",
                 "decodeBase64",
                 "encodeBase64",
@@ -412,21 +408,18 @@
             ],
             "classes": [
                 "AutoId",
-                "BaseFieldPath",
                 "BasePath",
                 "ByteString",
                 "Bytes",
                 "CollectionReference",
                 "DatabaseId",
                 "DocumentKey",
-                "DocumentKeyReference",
                 "DocumentReference",
                 "DocumentSnapshot",
                 "FieldPath",
                 "FieldPath$1",
-                "FieldPath$2",
                 "FirebaseCredentialsProvider",
-                "Firestore",
+                "FirebaseFirestore",
                 "FirestoreError",
                 "GeoPoint",
                 "OAuthToken",
@@ -436,11 +429,13 @@
                 "ResourcePath",
                 "Timestamp",
                 "User",
-                "UserDataWriter"
+                "UserDataWriter",
+                "_BaseFieldPath",
+                "_DocumentKeyReference"
             ],
             "variables": []
         },
-        "sizeInBytes": 31611
+        "sizeInBytes": 30965
     },
     "QuerySnapshot": {
         "dependencies": {
@@ -458,7 +453,7 @@
             "classes": [
                 "DatabaseId",
                 "FirebaseCredentialsProvider",
-                "Firestore",
+                "FirebaseFirestore",
                 "FirestoreError",
                 "OAuthToken",
                 "QuerySnapshot",
@@ -466,7 +461,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 7671
+        "sizeInBytes": 7655
     },
     "Timestamp": {
         "dependencies": {
@@ -484,7 +479,7 @@
             "classes": [
                 "DatabaseId",
                 "FirebaseCredentialsProvider",
-                "Firestore",
+                "FirebaseFirestore",
                 "FirestoreError",
                 "OAuthToken",
                 "Timestamp",
@@ -492,7 +487,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 9040
+        "sizeInBytes": 9024
     },
     "Transaction": {
         "dependencies": {
@@ -502,7 +497,6 @@
                 "arrayEquals",
                 "binaryStringFromUint8Array",
                 "blobEquals",
-                "cast",
                 "createError",
                 "decodeBase64",
                 "encodeBase64",
@@ -579,7 +573,6 @@
             ],
             "classes": [
                 "AutoId",
-                "BaseFieldPath",
                 "BasePath",
                 "ByteString",
                 "Bytes",
@@ -588,7 +581,6 @@
                 "DeleteFieldValueImpl",
                 "Document",
                 "DocumentKey",
-                "DocumentKeyReference",
                 "DocumentReference",
                 "DocumentSnapshot",
                 "FieldMask",
@@ -596,7 +588,7 @@
                 "FieldPath$1",
                 "FieldPath$2",
                 "FirebaseCredentialsProvider",
-                "Firestore",
+                "FirebaseFirestore",
                 "FirestoreError",
                 "GeoPoint",
                 "JsonProtoSerializer",
@@ -615,18 +607,20 @@
                 "QueryDocumentSnapshot",
                 "QueryImpl",
                 "ResourcePath",
-                "SerializableFieldValue",
                 "SetMutation",
                 "Timestamp",
                 "Transaction$1",
                 "TransformMutation",
                 "User",
                 "UserDataReader",
-                "UserDataWriter"
+                "UserDataWriter",
+                "_BaseFieldPath",
+                "_DocumentKeyReference",
+                "_SerializableFieldValue"
             ],
             "variables": []
         },
-        "sizeInBytes": 54538
+        "sizeInBytes": 54035
     },
     "WriteBatch": {
         "dependencies": {
@@ -636,7 +630,6 @@
                 "arrayEquals",
                 "binaryStringFromUint8Array",
                 "blobEquals",
-                "cast",
                 "createError",
                 "decodeBase64",
                 "encodeBase64",
@@ -664,7 +657,6 @@
                 "logDebug",
                 "logError",
                 "looksLikeJsonObject",
-                "newQueryForPath",
                 "newSerializer",
                 "newUserDataReader",
                 "normalizeByteString",
@@ -683,7 +675,6 @@
                 "parseUpdateData",
                 "parseUpdateVarargs",
                 "primitiveComparator",
-                "randomBytes",
                 "registerFirestore",
                 "removeComponents",
                 "timestampEquals",
@@ -697,11 +688,8 @@
                 "typeOrder",
                 "uint8ArrayFromBinaryString",
                 "validateArgType",
-                "validateCollectionPath",
-                "validateDocumentPath",
                 "validateExactNumberOfArgs",
                 "validateNamedArrayAtLeastNumberOfElements",
-                "validateNonEmptyArgument",
                 "validatePlainObject",
                 "validateReference",
                 "validateType",
@@ -709,24 +697,18 @@
                 "valueEquals"
             ],
             "classes": [
-                "AutoId",
-                "BaseFieldPath",
                 "BasePath",
                 "ByteString",
                 "Bytes",
-                "CollectionReference",
                 "DatabaseId",
                 "DeleteFieldValueImpl",
                 "DeleteMutation",
-                "DocumentKey",
-                "DocumentKeyReference",
-                "DocumentReference",
                 "FieldMask",
                 "FieldPath",
                 "FieldPath$1",
                 "FieldPath$2",
                 "FirebaseCredentialsProvider",
-                "Firestore",
+                "FirebaseFirestore",
                 "FirestoreError",
                 "GeoPoint",
                 "JsonProtoSerializer",
@@ -739,20 +721,20 @@
                 "ParsedUpdateData",
                 "PatchMutation",
                 "Precondition",
-                "Query",
-                "QueryImpl",
                 "ResourcePath",
-                "SerializableFieldValue",
                 "SetMutation",
                 "Timestamp",
                 "TransformMutation",
                 "User",
                 "UserDataReader",
-                "WriteBatch"
+                "WriteBatch",
+                "_BaseFieldPath",
+                "_DocumentKeyReference",
+                "_SerializableFieldValue"
             ],
             "variables": []
         },
-        "sizeInBytes": 49199
+        "sizeInBytes": 44542
     },
     "addDoc": {
         "dependencies": {
@@ -763,7 +745,6 @@
                 "arrayEquals",
                 "binaryStringFromUint8Array",
                 "blobEquals",
-                "cast",
                 "createError",
                 "createMetadata",
                 "debugCast",
@@ -854,7 +835,6 @@
                 "ArrayRemoveTransformOperation",
                 "ArrayUnionTransformOperation",
                 "AutoId",
-                "BaseFieldPath",
                 "BasePath",
                 "ByteString",
                 "Bytes",
@@ -866,13 +846,12 @@
                 "Deferred",
                 "DeleteMutation",
                 "DocumentKey",
-                "DocumentKeyReference",
                 "DocumentReference",
                 "FieldMask",
                 "FieldPath",
                 "FieldPath$1",
                 "FirebaseCredentialsProvider",
-                "Firestore",
+                "FirebaseFirestore",
                 "FirestoreError",
                 "GeoPoint",
                 "GrpcConnection",
@@ -888,7 +867,6 @@
                 "Query",
                 "QueryImpl",
                 "ResourcePath",
-                "SerializableFieldValue",
                 "ServerTimestampTransform",
                 "SetMutation",
                 "StreamBridge",
@@ -897,11 +875,14 @@
                 "TransformOperation",
                 "User",
                 "UserDataReader",
-                "VerifyMutation"
+                "VerifyMutation",
+                "_BaseFieldPath",
+                "_DocumentKeyReference",
+                "_SerializableFieldValue"
             ],
             "variables": []
         },
-        "sizeInBytes": 55080
+        "sizeInBytes": 54630
     },
     "arrayRemove": {
         "dependencies": {
@@ -958,25 +939,25 @@
                 "ByteString",
                 "Bytes",
                 "DatabaseId",
-                "DocumentKeyReference",
                 "FieldTransform",
                 "FieldValue",
                 "FieldValueDelegate",
                 "FirebaseCredentialsProvider",
-                "Firestore",
+                "FirebaseFirestore",
                 "FirestoreError",
                 "GeoPoint",
                 "OAuthToken",
                 "ParseContext",
                 "ResourcePath",
-                "SerializableFieldValue",
                 "Timestamp",
                 "TransformOperation",
-                "User"
+                "User",
+                "_DocumentKeyReference",
+                "_SerializableFieldValue"
             ],
             "variables": []
         },
-        "sizeInBytes": 26035
+        "sizeInBytes": 26027
     },
     "arrayUnion": {
         "dependencies": {
@@ -1033,25 +1014,25 @@
                 "ByteString",
                 "Bytes",
                 "DatabaseId",
-                "DocumentKeyReference",
                 "FieldTransform",
                 "FieldValue",
                 "FieldValueDelegate",
                 "FirebaseCredentialsProvider",
-                "Firestore",
+                "FirebaseFirestore",
                 "FirestoreError",
                 "GeoPoint",
                 "OAuthToken",
                 "ParseContext",
                 "ResourcePath",
-                "SerializableFieldValue",
                 "Timestamp",
                 "TransformOperation",
-                "User"
+                "User",
+                "_DocumentKeyReference",
+                "_SerializableFieldValue"
             ],
             "variables": []
         },
-        "sizeInBytes": 26027
+        "sizeInBytes": 26019
     },
     "collection": {
         "dependencies": {
@@ -1078,26 +1059,25 @@
                 "CollectionReference",
                 "DatabaseId",
                 "DocumentKey",
-                "DocumentKeyReference",
                 "DocumentReference",
                 "FirebaseCredentialsProvider",
-                "Firestore",
+                "FirebaseFirestore",
                 "FirestoreError",
                 "OAuthToken",
                 "Query",
                 "QueryImpl",
                 "ResourcePath",
-                "User"
+                "User",
+                "_DocumentKeyReference"
             ],
             "variables": []
         },
-        "sizeInBytes": 14742
+        "sizeInBytes": 14736
     },
     "collectionGroup": {
         "dependencies": {
             "functions": [
                 "argToString",
-                "cast",
                 "collectionGroup",
                 "fail",
                 "formatJSON",
@@ -1114,7 +1094,7 @@
                 "BasePath",
                 "DatabaseId",
                 "FirebaseCredentialsProvider",
-                "Firestore",
+                "FirebaseFirestore",
                 "FirestoreError",
                 "OAuthToken",
                 "Query",
@@ -1124,13 +1104,12 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 11488
+        "sizeInBytes": 11008
     },
     "deleteDoc": {
         "dependencies": {
             "functions": [
                 "argToString",
-                "cast",
                 "createMetadata",
                 "debugCast",
                 "deleteDoc",
@@ -1148,11 +1127,9 @@
                 "mapCodeFromRpcCode",
                 "newConnection",
                 "newDatastore",
-                "newQueryForPath",
                 "newSerializer",
                 "nodePromise",
                 "primitiveComparator",
-                "randomBytes",
                 "registerFirestore",
                 "removeComponents",
                 "toDocumentMask",
@@ -1163,28 +1140,20 @@
                 "toPrecondition",
                 "toResourceName",
                 "toTimestamp",
-                "toVersion",
-                "validateCollectionPath",
-                "validateDocumentPath",
-                "validateNonEmptyArgument"
+                "toVersion"
             ],
             "classes": [
                 "ArrayRemoveTransformOperation",
                 "ArrayUnionTransformOperation",
-                "AutoId",
                 "BasePath",
-                "CollectionReference",
                 "DatabaseId",
                 "DatabaseInfo",
                 "Datastore",
                 "DatastoreImpl",
                 "Deferred",
                 "DeleteMutation",
-                "DocumentKey",
-                "DocumentKeyReference",
-                "DocumentReference",
                 "FirebaseCredentialsProvider",
-                "Firestore",
+                "FirebaseFirestore",
                 "FirestoreError",
                 "GrpcConnection",
                 "JsonProtoSerializer",
@@ -1193,8 +1162,6 @@
                 "OAuthToken",
                 "PatchMutation",
                 "Precondition",
-                "Query",
-                "QueryImpl",
                 "ResourcePath",
                 "ServerTimestampTransform",
                 "SetMutation",
@@ -1206,7 +1173,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 28252
+        "sizeInBytes": 23467
     },
     "deleteField": {
         "dependencies": {
@@ -1228,15 +1195,15 @@
                 "FieldValue",
                 "FieldValueDelegate",
                 "FirebaseCredentialsProvider",
-                "Firestore",
+                "FirebaseFirestore",
                 "FirestoreError",
                 "OAuthToken",
-                "SerializableFieldValue",
-                "User"
+                "User",
+                "_SerializableFieldValue"
             ],
             "variables": []
         },
-        "sizeInBytes": 8496
+        "sizeInBytes": 8483
     },
     "doc": {
         "dependencies": {
@@ -1263,26 +1230,25 @@
                 "CollectionReference",
                 "DatabaseId",
                 "DocumentKey",
-                "DocumentKeyReference",
                 "DocumentReference",
                 "FirebaseCredentialsProvider",
-                "Firestore",
+                "FirebaseFirestore",
                 "FirestoreError",
                 "OAuthToken",
                 "Query",
                 "QueryImpl",
                 "ResourcePath",
-                "User"
+                "User",
+                "_DocumentKeyReference"
             ],
             "variables": []
         },
-        "sizeInBytes": 14797
+        "sizeInBytes": 14791
     },
     "documentId": {
         "dependencies": {
             "functions": [
                 "argToString",
-                "cast",
                 "documentId",
                 "fail",
                 "formatJSON",
@@ -1302,28 +1268,28 @@
                 "valueDescription"
             ],
             "classes": [
-                "BaseFieldPath",
                 "BasePath",
                 "DatabaseId",
                 "FieldPath",
                 "FieldPath$2",
                 "FirebaseCredentialsProvider",
-                "Firestore",
+                "FirebaseFirestore",
                 "FirestoreError",
                 "OAuthToken",
-                "User"
+                "User",
+                "_BaseFieldPath"
             ],
             "variables": []
         },
-        "sizeInBytes": 13950
+        "sizeInBytes": 13492
     },
     "endAt": {
         "dependencies": {
             "functions": [
                 "argToString",
                 "binaryStringFromUint8Array",
-                "cast",
                 "createError",
+                "debugCast",
                 "decodeBase64",
                 "encodeBase64",
                 "endAt",
@@ -1397,7 +1363,6 @@
             ],
             "classes": [
                 "AutoId",
-                "BaseFieldPath",
                 "BasePath",
                 "Bound",
                 "ByteString",
@@ -1405,14 +1370,12 @@
                 "CollectionReference",
                 "DatabaseId",
                 "DocumentKey",
-                "DocumentKeyReference",
                 "DocumentReference",
                 "DocumentSnapshot",
                 "FieldPath",
                 "FieldPath$1",
-                "FieldPath$2",
                 "FirebaseCredentialsProvider",
-                "Firestore",
+                "FirebaseFirestore",
                 "FirestoreError",
                 "GeoPoint",
                 "JsonProtoSerializer",
@@ -1425,23 +1388,25 @@
                 "QueryEndAtConstraint",
                 "QueryImpl",
                 "ResourcePath",
-                "SerializableFieldValue",
                 "Timestamp",
                 "User",
                 "UserDataReader",
-                "UserDataWriter"
+                "UserDataWriter",
+                "_BaseFieldPath",
+                "_DocumentKeyReference",
+                "_SerializableFieldValue"
             ],
             "variables": []
         },
-        "sizeInBytes": 45251
+        "sizeInBytes": 44653
     },
     "endBefore": {
         "dependencies": {
             "functions": [
                 "argToString",
                 "binaryStringFromUint8Array",
-                "cast",
                 "createError",
+                "debugCast",
                 "decodeBase64",
                 "encodeBase64",
                 "endBefore",
@@ -1515,7 +1480,6 @@
             ],
             "classes": [
                 "AutoId",
-                "BaseFieldPath",
                 "BasePath",
                 "Bound",
                 "ByteString",
@@ -1523,14 +1487,12 @@
                 "CollectionReference",
                 "DatabaseId",
                 "DocumentKey",
-                "DocumentKeyReference",
                 "DocumentReference",
                 "DocumentSnapshot",
                 "FieldPath",
                 "FieldPath$1",
-                "FieldPath$2",
                 "FirebaseCredentialsProvider",
-                "Firestore",
+                "FirebaseFirestore",
                 "FirestoreError",
                 "GeoPoint",
                 "JsonProtoSerializer",
@@ -1543,15 +1505,17 @@
                 "QueryEndAtConstraint",
                 "QueryImpl",
                 "ResourcePath",
-                "SerializableFieldValue",
                 "Timestamp",
                 "User",
                 "UserDataReader",
-                "UserDataWriter"
+                "UserDataWriter",
+                "_BaseFieldPath",
+                "_DocumentKeyReference",
+                "_SerializableFieldValue"
             ],
             "variables": []
         },
-        "sizeInBytes": 45262
+        "sizeInBytes": 44664
     },
     "getDoc": {
         "dependencies": {
@@ -1561,7 +1525,6 @@
                 "assertPresent",
                 "binaryStringFromUint8Array",
                 "blobEquals",
-                "cast",
                 "createError",
                 "createMetadata",
                 "debugCast",
@@ -1637,7 +1600,6 @@
             ],
             "classes": [
                 "AutoId",
-                "BaseFieldPath",
                 "BasePath",
                 "ByteString",
                 "Bytes",
@@ -1649,14 +1611,12 @@
                 "Deferred",
                 "Document",
                 "DocumentKey",
-                "DocumentKeyReference",
                 "DocumentReference",
                 "DocumentSnapshot",
                 "FieldPath",
                 "FieldPath$1",
-                "FieldPath$2",
                 "FirebaseCredentialsProvider",
-                "Firestore",
+                "FirebaseFirestore",
                 "FirestoreError",
                 "GeoPoint",
                 "GrpcConnection",
@@ -1673,11 +1633,13 @@
                 "StreamBridge",
                 "Timestamp",
                 "User",
-                "UserDataWriter"
+                "UserDataWriter",
+                "_BaseFieldPath",
+                "_DocumentKeyReference"
             ],
             "variables": []
         },
-        "sizeInBytes": 48208
+        "sizeInBytes": 47548
     },
     "getDocs": {
         "dependencies": {
@@ -1686,7 +1648,6 @@
                 "arrayEquals",
                 "binaryStringFromUint8Array",
                 "blobEquals",
-                "cast",
                 "createError",
                 "createMetadata",
                 "debugCast",
@@ -1779,7 +1740,6 @@
             ],
             "classes": [
                 "AutoId",
-                "BaseFieldPath",
                 "BasePath",
                 "Bound",
                 "ByteString",
@@ -1792,14 +1752,12 @@
                 "Deferred",
                 "Document",
                 "DocumentKey",
-                "DocumentKeyReference",
                 "DocumentReference",
                 "DocumentSnapshot",
                 "FieldPath",
                 "FieldPath$1",
-                "FieldPath$2",
                 "FirebaseCredentialsProvider",
-                "Firestore",
+                "FirebaseFirestore",
                 "FirestoreError",
                 "GeoPoint",
                 "GrpcConnection",
@@ -1818,11 +1776,13 @@
                 "TargetImpl",
                 "Timestamp",
                 "User",
-                "UserDataWriter"
+                "UserDataWriter",
+                "_BaseFieldPath",
+                "_DocumentKeyReference"
             ],
             "variables": []
         },
-        "sizeInBytes": 53099
+        "sizeInBytes": 52385
     },
     "getFirestore": {
         "dependencies": {
@@ -1841,14 +1801,14 @@
             "classes": [
                 "DatabaseId",
                 "FirebaseCredentialsProvider",
-                "Firestore",
+                "FirebaseFirestore",
                 "FirestoreError",
                 "OAuthToken",
                 "User"
             ],
             "variables": []
         },
-        "sizeInBytes": 7516
+        "sizeInBytes": 7500
     },
     "increment": {
         "dependencies": {
@@ -1875,18 +1835,18 @@
                 "FieldValue",
                 "FieldValueDelegate",
                 "FirebaseCredentialsProvider",
-                "Firestore",
+                "FirebaseFirestore",
                 "FirestoreError",
                 "NumericIncrementFieldValueImpl",
                 "NumericIncrementTransformOperation",
                 "OAuthToken",
-                "SerializableFieldValue",
                 "TransformOperation",
-                "User"
+                "User",
+                "_SerializableFieldValue"
             ],
             "variables": []
         },
-        "sizeInBytes": 9361
+        "sizeInBytes": 9348
     },
     "initializeFirestore": {
         "dependencies": {
@@ -1905,14 +1865,14 @@
             "classes": [
                 "DatabaseId",
                 "FirebaseCredentialsProvider",
-                "Firestore",
+                "FirebaseFirestore",
                 "FirestoreError",
                 "OAuthToken",
                 "User"
             ],
             "variables": []
         },
-        "sizeInBytes": 7602
+        "sizeInBytes": 7586
     },
     "limit": {
         "dependencies": {
@@ -1934,7 +1894,7 @@
             "classes": [
                 "DatabaseId",
                 "FirebaseCredentialsProvider",
-                "Firestore",
+                "FirebaseFirestore",
                 "FirestoreError",
                 "OAuthToken",
                 "Query",
@@ -1945,7 +1905,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 8991
+        "sizeInBytes": 8976
     },
     "limitToLast": {
         "dependencies": {
@@ -1967,7 +1927,7 @@
             "classes": [
                 "DatabaseId",
                 "FirebaseCredentialsProvider",
-                "Firestore",
+                "FirebaseFirestore",
                 "FirestoreError",
                 "OAuthToken",
                 "Query",
@@ -1978,13 +1938,12 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 9015
+        "sizeInBytes": 9000
     },
     "orderBy": {
         "dependencies": {
             "functions": [
                 "argToString",
-                "cast",
                 "createError",
                 "errorMessage",
                 "fail",
@@ -2016,14 +1975,12 @@
                 "valueDescription"
             ],
             "classes": [
-                "BaseFieldPath",
                 "BasePath",
                 "DatabaseId",
                 "FieldPath",
                 "FieldPath$1",
-                "FieldPath$2",
                 "FirebaseCredentialsProvider",
-                "Firestore",
+                "FirebaseFirestore",
                 "FirestoreError",
                 "OAuthToken",
                 "OrderBy",
@@ -2031,17 +1988,17 @@
                 "QueryConstraint",
                 "QueryImpl",
                 "QueryOrderByConstraint",
-                "User"
+                "User",
+                "_BaseFieldPath"
             ],
             "variables": []
         },
-        "sizeInBytes": 18880
+        "sizeInBytes": 18233
     },
     "query": {
         "dependencies": {
             "functions": [
                 "argToString",
-                "cast",
                 "fail",
                 "formatJSON",
                 "hardAssert",
@@ -2055,15 +2012,14 @@
             "classes": [
                 "DatabaseId",
                 "FirebaseCredentialsProvider",
-                "Firestore",
+                "FirebaseFirestore",
                 "FirestoreError",
                 "OAuthToken",
-                "Query",
                 "User"
             ],
             "variables": []
         },
-        "sizeInBytes": 8213
+        "sizeInBytes": 7524
     },
     "queryEqual": {
         "dependencies": {
@@ -2073,7 +2029,7 @@
                 "binaryStringFromUint8Array",
                 "blobEquals",
                 "boundEquals",
-                "cast",
+                "debugCast",
                 "decodeBase64",
                 "encodeBase64",
                 "fail",
@@ -2116,19 +2072,18 @@
                 "DatabaseId",
                 "FieldPath",
                 "FirebaseCredentialsProvider",
-                "Firestore",
+                "FirebaseFirestore",
                 "FirestoreError",
                 "OAuthToken",
                 "OrderBy",
                 "Query",
-                "QueryImpl",
                 "TargetImpl",
                 "Timestamp",
                 "User"
             ],
             "variables": []
         },
-        "sizeInBytes": 23451
+        "sizeInBytes": 22653
     },
     "refEqual": {
         "dependencies": {
@@ -2155,20 +2110,20 @@
                 "CollectionReference",
                 "DatabaseId",
                 "DocumentKey",
-                "DocumentKeyReference",
                 "DocumentReference",
                 "FirebaseCredentialsProvider",
-                "Firestore",
+                "FirebaseFirestore",
                 "FirestoreError",
                 "OAuthToken",
                 "Query",
                 "QueryImpl",
                 "ResourcePath",
-                "User"
+                "User",
+                "_DocumentKeyReference"
             ],
             "variables": []
         },
-        "sizeInBytes": 14292
+        "sizeInBytes": 14278
     },
     "runTransaction": {
         "dependencies": {
@@ -2179,7 +2134,6 @@
                 "assertPresent",
                 "binaryStringFromUint8Array",
                 "blobEquals",
-                "cast",
                 "createError",
                 "createMetadata",
                 "debugCast",
@@ -2291,7 +2245,6 @@
                 "ArrayUnionTransformOperation",
                 "AsyncQueue",
                 "AutoId",
-                "BaseFieldPath",
                 "BasePath",
                 "ByteString",
                 "Bytes",
@@ -2306,7 +2259,6 @@
                 "DeleteMutation",
                 "Document",
                 "DocumentKey",
-                "DocumentKeyReference",
                 "DocumentReference",
                 "DocumentSnapshot",
                 "ExponentialBackoff",
@@ -2315,7 +2267,7 @@
                 "FieldPath$1",
                 "FieldPath$2",
                 "FirebaseCredentialsProvider",
-                "Firestore",
+                "FirebaseFirestore",
                 "FirestoreError",
                 "GeoPoint",
                 "GrpcConnection",
@@ -2336,7 +2288,6 @@
                 "QueryDocumentSnapshot",
                 "QueryImpl",
                 "ResourcePath",
-                "SerializableFieldValue",
                 "ServerTimestampTransform",
                 "SetMutation",
                 "SnapshotVersion",
@@ -2350,11 +2301,14 @@
                 "User",
                 "UserDataReader",
                 "UserDataWriter",
-                "VerifyMutation"
+                "VerifyMutation",
+                "_BaseFieldPath",
+                "_DocumentKeyReference",
+                "_SerializableFieldValue"
             ],
             "variables": []
         },
-        "sizeInBytes": 79624
+        "sizeInBytes": 79061
     },
     "serverTimestamp": {
         "dependencies": {
@@ -2376,18 +2330,18 @@
                 "FieldValue",
                 "FieldValueDelegate",
                 "FirebaseCredentialsProvider",
-                "Firestore",
+                "FirebaseFirestore",
                 "FirestoreError",
                 "OAuthToken",
-                "SerializableFieldValue",
                 "ServerTimestampFieldValueImpl",
                 "ServerTimestampTransform",
                 "TransformOperation",
-                "User"
+                "User",
+                "_SerializableFieldValue"
             ],
             "variables": []
         },
-        "sizeInBytes": 8484
+        "sizeInBytes": 8471
     },
     "setDoc": {
         "dependencies": {
@@ -2397,7 +2351,6 @@
                 "arrayEquals",
                 "binaryStringFromUint8Array",
                 "blobEquals",
-                "cast",
                 "createError",
                 "createMetadata",
                 "debugCast",
@@ -2434,7 +2387,6 @@
                 "mapCodeFromRpcCode",
                 "newConnection",
                 "newDatastore",
-                "newQueryForPath",
                 "newSerializer",
                 "newUserDataReader",
                 "nodePromise",
@@ -2452,7 +2404,6 @@
                 "parseSentinelFieldValue",
                 "parseSetData",
                 "primitiveComparator",
-                "randomBytes",
                 "registerFirestore",
                 "removeComponents",
                 "setDoc",
@@ -2474,11 +2425,8 @@
                 "typeOrder",
                 "uint8ArrayFromBinaryString",
                 "validateArgType",
-                "validateCollectionPath",
-                "validateDocumentPath",
                 "validateExactNumberOfArgs",
                 "validateNamedArrayAtLeastNumberOfElements",
-                "validateNonEmptyArgument",
                 "validatePlainObject",
                 "validateType",
                 "valueDescription",
@@ -2487,26 +2435,20 @@
             "classes": [
                 "ArrayRemoveTransformOperation",
                 "ArrayUnionTransformOperation",
-                "AutoId",
-                "BaseFieldPath",
                 "BasePath",
                 "ByteString",
                 "Bytes",
-                "CollectionReference",
                 "DatabaseId",
                 "DatabaseInfo",
                 "Datastore",
                 "DatastoreImpl",
                 "Deferred",
                 "DeleteMutation",
-                "DocumentKey",
-                "DocumentKeyReference",
-                "DocumentReference",
                 "FieldMask",
                 "FieldPath",
                 "FieldPath$1",
                 "FirebaseCredentialsProvider",
-                "Firestore",
+                "FirebaseFirestore",
                 "FirestoreError",
                 "GeoPoint",
                 "GrpcConnection",
@@ -2519,10 +2461,7 @@
                 "ParsedSetData",
                 "PatchMutation",
                 "Precondition",
-                "Query",
-                "QueryImpl",
                 "ResourcePath",
-                "SerializableFieldValue",
                 "ServerTimestampTransform",
                 "SetMutation",
                 "StreamBridge",
@@ -2531,11 +2470,14 @@
                 "TransformOperation",
                 "User",
                 "UserDataReader",
-                "VerifyMutation"
+                "VerifyMutation",
+                "_BaseFieldPath",
+                "_DocumentKeyReference",
+                "_SerializableFieldValue"
             ],
             "variables": []
         },
-        "sizeInBytes": 54221
+        "sizeInBytes": 49609
     },
     "setLogLevel": {
         "dependencies": {
@@ -2554,14 +2496,14 @@
             "classes": [
                 "DatabaseId",
                 "FirebaseCredentialsProvider",
-                "Firestore",
+                "FirebaseFirestore",
                 "FirestoreError",
                 "OAuthToken",
                 "User"
             ],
             "variables": []
         },
-        "sizeInBytes": 7481
+        "sizeInBytes": 7465
     },
     "snapshotEqual": {
         "dependencies": {
@@ -2571,8 +2513,8 @@
                 "binaryStringFromUint8Array",
                 "blobEquals",
                 "boundEquals",
-                "cast",
                 "createError",
+                "debugCast",
                 "decodeBase64",
                 "encodeBase64",
                 "errorMessage",
@@ -2633,7 +2575,6 @@
             ],
             "classes": [
                 "AutoId",
-                "BaseFieldPath",
                 "BasePath",
                 "Bound",
                 "ByteString",
@@ -2641,14 +2582,12 @@
                 "CollectionReference",
                 "DatabaseId",
                 "DocumentKey",
-                "DocumentKeyReference",
                 "DocumentReference",
                 "DocumentSnapshot",
                 "FieldPath",
                 "FieldPath$1",
-                "FieldPath$2",
                 "FirebaseCredentialsProvider",
-                "Firestore",
+                "FirebaseFirestore",
                 "FirestoreError",
                 "GeoPoint",
                 "OAuthToken",
@@ -2661,19 +2600,21 @@
                 "TargetImpl",
                 "Timestamp",
                 "User",
-                "UserDataWriter"
+                "UserDataWriter",
+                "_BaseFieldPath",
+                "_DocumentKeyReference"
             ],
             "variables": []
         },
-        "sizeInBytes": 39087
+        "sizeInBytes": 38478
     },
     "startAfter": {
         "dependencies": {
             "functions": [
                 "argToString",
                 "binaryStringFromUint8Array",
-                "cast",
                 "createError",
+                "debugCast",
                 "decodeBase64",
                 "encodeBase64",
                 "errorMessage",
@@ -2747,7 +2688,6 @@
             ],
             "classes": [
                 "AutoId",
-                "BaseFieldPath",
                 "BasePath",
                 "Bound",
                 "ByteString",
@@ -2755,14 +2695,12 @@
                 "CollectionReference",
                 "DatabaseId",
                 "DocumentKey",
-                "DocumentKeyReference",
                 "DocumentReference",
                 "DocumentSnapshot",
                 "FieldPath",
                 "FieldPath$1",
-                "FieldPath$2",
                 "FirebaseCredentialsProvider",
-                "Firestore",
+                "FirebaseFirestore",
                 "FirestoreError",
                 "GeoPoint",
                 "JsonProtoSerializer",
@@ -2775,23 +2713,25 @@
                 "QueryImpl",
                 "QueryStartAtConstraint",
                 "ResourcePath",
-                "SerializableFieldValue",
                 "Timestamp",
                 "User",
                 "UserDataReader",
-                "UserDataWriter"
+                "UserDataWriter",
+                "_BaseFieldPath",
+                "_DocumentKeyReference",
+                "_SerializableFieldValue"
             ],
             "variables": []
         },
-        "sizeInBytes": 45272
+        "sizeInBytes": 44674
     },
     "startAt": {
         "dependencies": {
             "functions": [
                 "argToString",
                 "binaryStringFromUint8Array",
-                "cast",
                 "createError",
+                "debugCast",
                 "decodeBase64",
                 "encodeBase64",
                 "errorMessage",
@@ -2865,7 +2805,6 @@
             ],
             "classes": [
                 "AutoId",
-                "BaseFieldPath",
                 "BasePath",
                 "Bound",
                 "ByteString",
@@ -2873,14 +2812,12 @@
                 "CollectionReference",
                 "DatabaseId",
                 "DocumentKey",
-                "DocumentKeyReference",
                 "DocumentReference",
                 "DocumentSnapshot",
                 "FieldPath",
                 "FieldPath$1",
-                "FieldPath$2",
                 "FirebaseCredentialsProvider",
-                "Firestore",
+                "FirebaseFirestore",
                 "FirestoreError",
                 "GeoPoint",
                 "JsonProtoSerializer",
@@ -2893,21 +2830,22 @@
                 "QueryImpl",
                 "QueryStartAtConstraint",
                 "ResourcePath",
-                "SerializableFieldValue",
                 "Timestamp",
                 "User",
                 "UserDataReader",
-                "UserDataWriter"
+                "UserDataWriter",
+                "_BaseFieldPath",
+                "_DocumentKeyReference",
+                "_SerializableFieldValue"
             ],
             "variables": []
         },
-        "sizeInBytes": 45262
+        "sizeInBytes": 44664
     },
     "terminate": {
         "dependencies": {
             "functions": [
                 "argToString",
-                "cast",
                 "fail",
                 "formatJSON",
                 "hardAssert",
@@ -2921,14 +2859,14 @@
             "classes": [
                 "DatabaseId",
                 "FirebaseCredentialsProvider",
-                "Firestore",
+                "FirebaseFirestore",
                 "FirestoreError",
                 "OAuthToken",
                 "User"
             ],
             "variables": []
         },
-        "sizeInBytes": 8015
+        "sizeInBytes": 7535
     },
     "updateDoc": {
         "dependencies": {
@@ -2937,7 +2875,6 @@
                 "arrayEquals",
                 "binaryStringFromUint8Array",
                 "blobEquals",
-                "cast",
                 "createError",
                 "createMetadata",
                 "debugCast",
@@ -2975,7 +2912,6 @@
                 "mapCodeFromRpcCode",
                 "newConnection",
                 "newDatastore",
-                "newQueryForPath",
                 "newSerializer",
                 "newUserDataReader",
                 "nodePromise",
@@ -2994,7 +2930,6 @@
                 "parseUpdateData",
                 "parseUpdateVarargs",
                 "primitiveComparator",
-                "randomBytes",
                 "registerFirestore",
                 "removeComponents",
                 "timestampEquals",
@@ -3016,11 +2951,8 @@
                 "uint8ArrayFromBinaryString",
                 "updateDoc",
                 "validateArgType",
-                "validateCollectionPath",
-                "validateDocumentPath",
                 "validateExactNumberOfArgs",
                 "validateNamedArrayAtLeastNumberOfElements",
-                "validateNonEmptyArgument",
                 "validatePlainObject",
                 "validateType",
                 "valueDescription",
@@ -3029,12 +2961,9 @@
             "classes": [
                 "ArrayRemoveTransformOperation",
                 "ArrayUnionTransformOperation",
-                "AutoId",
-                "BaseFieldPath",
                 "BasePath",
                 "ByteString",
                 "Bytes",
-                "CollectionReference",
                 "DatabaseId",
                 "DatabaseInfo",
                 "Datastore",
@@ -3042,15 +2971,12 @@
                 "Deferred",
                 "DeleteFieldValueImpl",
                 "DeleteMutation",
-                "DocumentKey",
-                "DocumentKeyReference",
-                "DocumentReference",
                 "FieldMask",
                 "FieldPath",
                 "FieldPath$1",
                 "FieldPath$2",
                 "FirebaseCredentialsProvider",
-                "Firestore",
+                "FirebaseFirestore",
                 "FirestoreError",
                 "GeoPoint",
                 "GrpcConnection",
@@ -3064,10 +2990,7 @@
                 "ParsedUpdateData",
                 "PatchMutation",
                 "Precondition",
-                "Query",
-                "QueryImpl",
                 "ResourcePath",
-                "SerializableFieldValue",
                 "ServerTimestampTransform",
                 "SetMutation",
                 "StreamBridge",
@@ -3076,11 +2999,14 @@
                 "TransformOperation",
                 "User",
                 "UserDataReader",
-                "VerifyMutation"
+                "VerifyMutation",
+                "_BaseFieldPath",
+                "_DocumentKeyReference",
+                "_SerializableFieldValue"
             ],
             "variables": []
         },
-        "sizeInBytes": 57328
+        "sizeInBytes": 52680
     },
     "where": {
         "dependencies": {
@@ -3090,7 +3016,6 @@
                 "arrayValueContains",
                 "binaryStringFromUint8Array",
                 "blobEquals",
-                "cast",
                 "compareArrays",
                 "compareBlobs",
                 "compareGeoPoints",
@@ -3180,20 +3105,17 @@
             "classes": [
                 "ArrayContainsAnyFilter",
                 "ArrayContainsFilter",
-                "BaseFieldPath",
                 "BasePath",
                 "ByteString",
                 "Bytes",
                 "DatabaseId",
                 "DocumentKey",
-                "DocumentKeyReference",
                 "FieldFilter",
                 "FieldPath",
                 "FieldPath$1",
-                "FieldPath$2",
                 "Filter",
                 "FirebaseCredentialsProvider",
-                "Firestore",
+                "FirebaseFirestore",
                 "FirestoreError",
                 "GeoPoint",
                 "InFilter",
@@ -3209,14 +3131,16 @@
                 "QueryFilterConstraint",
                 "QueryImpl",
                 "ResourcePath",
-                "SerializableFieldValue",
                 "Timestamp",
                 "User",
-                "UserDataReader"
+                "UserDataReader",
+                "_BaseFieldPath",
+                "_DocumentKeyReference",
+                "_SerializableFieldValue"
             ],
             "variables": []
         },
-        "sizeInBytes": 49248
+        "sizeInBytes": 48608
     },
     "writeBatch": {
         "dependencies": {
@@ -3226,7 +3150,6 @@
                 "arrayEquals",
                 "binaryStringFromUint8Array",
                 "blobEquals",
-                "cast",
                 "createError",
                 "createMetadata",
                 "debugCast",
@@ -3264,7 +3187,6 @@
                 "mapCodeFromRpcCode",
                 "newConnection",
                 "newDatastore",
-                "newQueryForPath",
                 "newSerializer",
                 "newUserDataReader",
                 "nodePromise",
@@ -3284,7 +3206,6 @@
                 "parseUpdateData",
                 "parseUpdateVarargs",
                 "primitiveComparator",
-                "randomBytes",
                 "registerFirestore",
                 "removeComponents",
                 "timestampEquals",
@@ -3305,11 +3226,8 @@
                 "typeOrder",
                 "uint8ArrayFromBinaryString",
                 "validateArgType",
-                "validateCollectionPath",
-                "validateDocumentPath",
                 "validateExactNumberOfArgs",
                 "validateNamedArrayAtLeastNumberOfElements",
-                "validateNonEmptyArgument",
                 "validatePlainObject",
                 "validateReference",
                 "validateType",
@@ -3320,12 +3238,9 @@
             "classes": [
                 "ArrayRemoveTransformOperation",
                 "ArrayUnionTransformOperation",
-                "AutoId",
-                "BaseFieldPath",
                 "BasePath",
                 "ByteString",
                 "Bytes",
-                "CollectionReference",
                 "DatabaseId",
                 "DatabaseInfo",
                 "Datastore",
@@ -3333,15 +3248,12 @@
                 "Deferred",
                 "DeleteFieldValueImpl",
                 "DeleteMutation",
-                "DocumentKey",
-                "DocumentKeyReference",
-                "DocumentReference",
                 "FieldMask",
                 "FieldPath",
                 "FieldPath$1",
                 "FieldPath$2",
                 "FirebaseCredentialsProvider",
-                "Firestore",
+                "FirebaseFirestore",
                 "FirestoreError",
                 "GeoPoint",
                 "GrpcConnection",
@@ -3356,10 +3268,7 @@
                 "ParsedUpdateData",
                 "PatchMutation",
                 "Precondition",
-                "Query",
-                "QueryImpl",
                 "ResourcePath",
-                "SerializableFieldValue",
                 "ServerTimestampTransform",
                 "SetMutation",
                 "StreamBridge",
@@ -3369,10 +3278,13 @@
                 "User",
                 "UserDataReader",
                 "VerifyMutation",
-                "WriteBatch"
+                "WriteBatch",
+                "_BaseFieldPath",
+                "_DocumentKeyReference",
+                "_SerializableFieldValue"
             ],
             "variables": []
         },
-        "sizeInBytes": 61029
+        "sizeInBytes": 56318
     }
 }

--- a/packages/firestore/lite/index.ts
+++ b/packages/firestore/lite/index.ts
@@ -20,17 +20,24 @@ import { registerFirestore } from './register';
 registerFirestore();
 
 export {
-  Firestore as FirebaseFirestore,
+  Settings,
+  FirebaseFirestore,
   initializeFirestore,
   getFirestore,
   terminate
 } from './src/api/database';
 
 export {
+  SetOptions,
+  DocumentData,
+  UpdateData,
   DocumentReference,
   Query,
   QueryConstraint,
+  QueryConstraintType,
   CollectionReference,
+  OrderByDirection,
+  WhereFilterOp,
   collection,
   collectionGroup,
   doc,
@@ -67,6 +74,7 @@ export {
 } from './src/api/field_value';
 
 export {
+  FirestoreDataConverter,
   DocumentSnapshot,
   QueryDocumentSnapshot,
   QuerySnapshot,
@@ -77,10 +85,12 @@ export { WriteBatch, writeBatch } from './src/api/write_batch';
 
 export { Transaction, runTransaction } from './src/api/transaction';
 
-export { setLogLevel } from '../src/util/log';
+export { setLogLevel, LogLevel, LogLevelString } from '../src/util/log';
 
 export { Bytes } from './src/api/bytes';
 
 export { GeoPoint } from '../src/api/geo_point';
 
 export { Timestamp } from '../src/api/timestamp';
+
+export { FirestoreErrorCode, FirestoreError } from '../src/util/error';

--- a/packages/firestore/lite/register.ts
+++ b/packages/firestore/lite/register.ts
@@ -18,7 +18,7 @@
 import { _registerComponent, registerVersion } from '@firebase/app-exp';
 import { Component, ComponentType } from '@firebase/component';
 
-import { Firestore } from './src/api/database';
+import { FirebaseFirestore } from './src/api/database';
 import { version } from '../package.json';
 
 export function registerFirestore(): void {
@@ -27,7 +27,7 @@ export function registerFirestore(): void {
       'firestore/lite',
       container => {
         const app = container.getProvider('app-exp').getImmediate()!;
-        return ((app, auth) => new Firestore(app, auth))(
+        return ((app, auth) => new FirebaseFirestore(app, auth))(
           app,
           container.getProvider('auth-internal')
         );

--- a/packages/firestore/lite/src/api/components.ts
+++ b/packages/firestore/lite/src/api/components.ts
@@ -18,7 +18,7 @@
 import { Datastore, newDatastore } from '../../../src/remote/datastore';
 import { newConnection } from '../../../src/platform/connection';
 import { newSerializer } from '../../../src/platform/serializer';
-import { Firestore } from './database';
+import { FirebaseFirestore } from './database';
 import { DatabaseInfo } from '../../../src/core/database_info';
 import { logDebug } from '../../../src/util/log';
 import { Code, FirestoreError } from '../../../src/util/error';
@@ -37,14 +37,14 @@ export const DEFAULT_SSL = true;
  * An instance map that ensures only one Datastore exists per Firestore
  * instance.
  */
-const datastoreInstances = new Map<Firestore, Datastore>();
+const datastoreInstances = new Map<FirebaseFirestore, Datastore>();
 
 /**
  * Returns an initialized and started Datastore for the given Firestore
  * instance. Callers must invoke removeDatastore() when the Firestore
  * instance is terminated.
  */
-export function getDatastore(firestore: Firestore): Datastore {
+export function getDatastore(firestore: FirebaseFirestore): Datastore {
   if (firestore._terminated) {
     throw new FirestoreError(
       Code.FAILED_PRECONDITION,
@@ -79,7 +79,7 @@ export function getDatastore(firestore: Firestore): Datastore {
  * Removes all components associated with the provided instance. Must be called
  * when the Firestore instance is terminated.
  */
-export function removeComponents(firestore: Firestore): void {
+export function removeComponents(firestore: FirebaseFirestore): void {
   const datastore = datastoreInstances.get(firestore);
   if (datastore) {
     logDebug(LOG_TAG, 'Removing Datastore');

--- a/packages/firestore/lite/src/api/database.ts
+++ b/packages/firestore/lite/src/api/database.ts
@@ -15,8 +15,6 @@
  * limitations under the License.
  */
 
-import * as firestore from '../../../lite-types';
-
 import { _getProvider, _removeServiceInstance } from '@firebase/app-exp';
 import { FirebaseApp, _FirebaseService } from '@firebase/app-types-exp';
 import { Provider } from '@firebase/component';
@@ -31,17 +29,28 @@ import {
 import { cast } from './util';
 import { removeComponents } from './components';
 
+declare module '@firebase/component' {
+  interface NameServiceMapping {
+    'firestore/lite': FirebaseFirestore;
+  }
+}
+
+export interface Settings {
+  host?: string;
+  ssl?: boolean;
+  ignoreUndefinedProperties?: boolean;
+}
+
 /**
  * The root reference to the Firestore Lite database.
  */
-export class Firestore
-  implements firestore.FirebaseFirestore, _FirebaseService {
+export class FirebaseFirestore implements _FirebaseService {
   readonly _databaseId: DatabaseId;
   readonly _credentials: CredentialsProvider;
   readonly _persistenceKey: string = '(lite)';
 
   // Assigned via _configureClient()
-  protected _settings?: firestore.Settings;
+  protected _settings?: Settings;
   private _settingsFrozen = false;
 
   // A task that is assigned when the terminate() is invoked and resolved when
@@ -52,7 +61,7 @@ export class Firestore
     readonly app: FirebaseApp,
     authProvider: Provider<FirebaseAuthInternalName>
   ) {
-    this._databaseId = Firestore._databaseIdFromApp(app);
+    this._databaseId = FirebaseFirestore._databaseIdFromApp(app);
     this._credentials = new FirebaseCredentialsProvider(authProvider);
   }
 
@@ -64,7 +73,7 @@ export class Firestore
     return this._terminateTask !== undefined;
   }
 
-  _configureClient(settings: firestore.Settings): void {
+  _configureClient(settings: Settings): void {
     if (this._settingsFrozen) {
       throw new FirestoreError(
         Code.FAILED_PRECONDITION,
@@ -76,7 +85,7 @@ export class Firestore
     this._settings = settings;
   }
 
-  _getSettings(): firestore.Settings {
+  _getSettings(): Settings {
     if (!this._settings) {
       this._settings = {};
     }
@@ -117,24 +126,25 @@ export class Firestore
 
 export function initializeFirestore(
   app: FirebaseApp,
-  settings: firestore.Settings
-): Firestore {
+  settings: Settings
+): FirebaseFirestore {
   const firestore = _getProvider(
     app,
     'firestore/lite'
-  ).getImmediate() as Firestore;
+  ).getImmediate() as FirebaseFirestore;
   firestore._configureClient(settings);
   return firestore;
 }
 
-export function getFirestore(app: FirebaseApp): Firestore {
-  return _getProvider(app, 'firestore/lite').getImmediate() as Firestore;
+export function getFirestore(app: FirebaseApp): FirebaseFirestore {
+  return _getProvider(
+    app,
+    'firestore/lite'
+  ).getImmediate() as FirebaseFirestore;
 }
 
-export function terminate(
-  firestore: firestore.FirebaseFirestore
-): Promise<void> {
+export function terminate(firestore: FirebaseFirestore): Promise<void> {
   _removeServiceInstance(firestore.app, 'firestore/lite');
-  const firestoreClient = cast(firestore, Firestore);
+  const firestoreClient = cast(firestore, FirebaseFirestore);
   return firestoreClient._delete();
 }

--- a/packages/firestore/lite/src/api/database.ts
+++ b/packages/firestore/lite/src/api/database.ts
@@ -16,7 +16,7 @@
  */
 
 import { _getProvider, _removeServiceInstance } from '@firebase/app-exp';
-import { FirebaseApp, _FirebaseService } from '@firebase/app-types-exp';
+import { _FirebaseService, FirebaseApp } from '@firebase/app-types-exp';
 import { Provider } from '@firebase/component';
 
 import { Code, FirestoreError } from '../../../src/util/error';
@@ -26,7 +26,6 @@ import {
   CredentialsProvider,
   FirebaseCredentialsProvider
 } from '../../../src/api/credentials';
-import { cast } from './util';
 import { removeComponents } from './components';
 
 declare module '@firebase/component' {
@@ -145,6 +144,5 @@ export function getFirestore(app: FirebaseApp): FirebaseFirestore {
 
 export function terminate(firestore: FirebaseFirestore): Promise<void> {
   _removeServiceInstance(firestore.app, 'firestore/lite');
-  const firestoreClient = cast(firestore, FirebaseFirestore);
-  return firestoreClient._delete();
+  return firestore._delete();
 }

--- a/packages/firestore/lite/src/api/field_path.ts
+++ b/packages/firestore/lite/src/api/field_path.ts
@@ -16,7 +16,6 @@
  */
 
 import { _BaseFieldPath } from '../../../src/api/field_path';
-import { cast } from './util';
 import { DOCUMENT_KEY_NAME } from '../../../src/model/path';
 
 /**
@@ -42,8 +41,7 @@ export class FieldPath extends _BaseFieldPath {
   }
 
   isEqual(other: FieldPath): boolean {
-    const path = cast(other, FieldPath);
-    return this._internalPath.isEqual(path._internalPath);
+    return this._internalPath.isEqual(other._internalPath);
   }
 }
 

--- a/packages/firestore/lite/src/api/field_path.ts
+++ b/packages/firestore/lite/src/api/field_path.ts
@@ -15,9 +15,7 @@
  * limitations under the License.
  */
 
-import * as firestore from '../../../lite-types';
-
-import { BaseFieldPath } from '../../../src/api/field_path';
+import { _BaseFieldPath } from '../../../src/api/field_path';
 import { cast } from './util';
 import { DOCUMENT_KEY_NAME } from '../../../src/model/path';
 
@@ -26,7 +24,7 @@ import { DOCUMENT_KEY_NAME } from '../../../src/model/path';
  * field name (referring to a top-level field in the document), or a list of
  * field names (referring to a nested field in the document).
  */
-export class FieldPath extends BaseFieldPath implements firestore.FieldPath {
+export class FieldPath extends _BaseFieldPath {
   // Note: This class is stripped down a copy of the FieldPath class in the
   // legacy SDK. The changes are:
   // - The `documentId()` static method has been removed
@@ -43,12 +41,12 @@ export class FieldPath extends BaseFieldPath implements firestore.FieldPath {
     super(fieldNames);
   }
 
-  isEqual(other: firestore.FieldPath): boolean {
+  isEqual(other: FieldPath): boolean {
     const path = cast(other, FieldPath);
     return this._internalPath.isEqual(path._internalPath);
   }
 }
 
-export function documentId(): firestore.FieldPath {
+export function documentId(): FieldPath {
   return new FieldPath(DOCUMENT_KEY_NAME);
 }

--- a/packages/firestore/lite/src/api/field_value.ts
+++ b/packages/firestore/lite/src/api/field_value.ts
@@ -15,23 +15,20 @@
  * limitations under the License.
  */
 
-import * as firestore from '../../../lite-types';
-
 import { validateAtLeastNumberOfArgs } from '../../../src/util/input_validation';
 import {
   ArrayRemoveFieldValueImpl,
   ArrayUnionFieldValueImpl,
   DeleteFieldValueImpl,
   NumericIncrementFieldValueImpl,
-  SerializableFieldValue,
+  _SerializableFieldValue,
   ServerTimestampFieldValueImpl
 } from '../../../src/api/field_value';
 import { ParseContext } from '../../../src/api/user_data_reader';
 import { FieldTransform } from '../../../src/model/mutation';
 
 /** The public FieldValue class of the lite API. */
-export abstract class FieldValue extends SerializableFieldValue
-  implements firestore.FieldValue {}
+export abstract class FieldValue extends _SerializableFieldValue {}
 
 /**
  * A delegate class that allows the FieldValue implementations returned by
@@ -42,10 +39,10 @@ export abstract class FieldValue extends SerializableFieldValue
  * implementations as the base FieldValue class differs between the lite, full
  * and legacy SDK.
  */
-class FieldValueDelegate extends FieldValue implements firestore.FieldValue {
+class FieldValueDelegate extends FieldValue {
   readonly _methodName: string;
 
-  constructor(readonly _delegate: SerializableFieldValue) {
+  constructor(readonly _delegate: _SerializableFieldValue) {
     super();
     this._methodName = _delegate._methodName;
   }
@@ -54,7 +51,7 @@ class FieldValueDelegate extends FieldValue implements firestore.FieldValue {
     return this._delegate._toFieldTransform(context);
   }
 
-  isEqual(other: firestore.FieldValue): boolean {
+  isEqual(other: FieldValue): boolean {
     if (!(other instanceof FieldValueDelegate)) {
       return false;
     }
@@ -62,17 +59,17 @@ class FieldValueDelegate extends FieldValue implements firestore.FieldValue {
   }
 }
 
-export function deleteField(): firestore.FieldValue {
+export function deleteField(): FieldValue {
   return new FieldValueDelegate(new DeleteFieldValueImpl('deleteField'));
 }
 
-export function serverTimestamp(): firestore.FieldValue {
+export function serverTimestamp(): FieldValue {
   return new FieldValueDelegate(
     new ServerTimestampFieldValueImpl('serverTimestamp')
   );
 }
 
-export function arrayUnion(...elements: unknown[]): firestore.FieldValue {
+export function arrayUnion(...elements: unknown[]): FieldValue {
   validateAtLeastNumberOfArgs('arrayUnion()', arguments, 1);
   // NOTE: We don't actually parse the data until it's used in set() or
   // update() since we'd need the Firestore instance to do this.
@@ -81,7 +78,7 @@ export function arrayUnion(...elements: unknown[]): firestore.FieldValue {
   );
 }
 
-export function arrayRemove(...elements: unknown[]): firestore.FieldValue {
+export function arrayRemove(...elements: unknown[]): FieldValue {
   validateAtLeastNumberOfArgs('arrayRemove()', arguments, 1);
   // NOTE: We don't actually parse the data until it's used in set() or
   // update() since we'd need the Firestore instance to do this.
@@ -90,7 +87,7 @@ export function arrayRemove(...elements: unknown[]): firestore.FieldValue {
   );
 }
 
-export function increment(n: number): firestore.FieldValue {
+export function increment(n: number): FieldValue {
   return new FieldValueDelegate(
     new NumericIncrementFieldValueImpl('increment', n)
   );

--- a/packages/firestore/lite/src/api/snapshot.ts
+++ b/packages/firestore/lite/src/api/snapshot.ts
@@ -24,7 +24,6 @@ import {
   SetOptions
 } from './reference';
 import { FieldPath } from './field_path';
-import { cast } from './util';
 import { DocumentKey } from '../../../src/model/document_key';
 import { Document } from '../../../src/model/document';
 import { UserDataWriter } from '../../../src/api/user_data_writer';
@@ -101,8 +100,7 @@ export class DocumentSnapshot<T = DocumentData> {
     }
   }
 
-  // We are using `any` here, since `unknown` would require an explicit cast by
-  // our users.
+  // We are using `any` here to avoid an explicit cast by our users.
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   get(fieldPath: string | FieldPath): any {
     if (this._document) {
@@ -192,7 +190,6 @@ export function fieldPathFromArgument(
   if (typeof arg === 'string') {
     return fieldPathFromDotSeparatedString(methodName, arg);
   } else {
-    const path = cast(arg, FieldPath);
-    return path._internalPath;
+    return arg._internalPath;
   }
 }

--- a/packages/firestore/lite/src/api/transaction.ts
+++ b/packages/firestore/lite/src/api/transaction.ts
@@ -15,8 +15,6 @@
  * limitations under the License.
  */
 
-import * as firestore from '../../../lite-types';
-
 import {
   parseSetData,
   parseUpdateData,
@@ -32,13 +30,17 @@ import {
 import { fail } from '../../../src/util/assert';
 import { applyFirestoreDataConverter } from '../../../src/api/database';
 import { DocumentSnapshot } from './snapshot';
-import { Firestore } from './database';
+import { FirebaseFirestore } from './database';
 import { TransactionRunner } from '../../../src/core/transaction_runner';
 import { AsyncQueue } from '../../../src/util/async_queue';
 import { Deferred } from '../../../src/util/promise';
-import { FieldPath as ExternalFieldPath } from '../../../src/api/field_path';
 import { validateReference } from './write_batch';
-import { newUserDataReader } from './reference';
+import {
+  DocumentReference,
+  newUserDataReader,
+  SetOptions,
+  UpdateData
+} from './reference';
 import { FieldPath } from './field_path';
 import { cast } from './util';
 import { getDatastore } from './components';
@@ -54,15 +56,13 @@ export class Transaction {
   private readonly _dataReader: UserDataReader;
 
   constructor(
-    protected readonly _firestore: Firestore,
+    protected readonly _firestore: FirebaseFirestore,
     private readonly _transaction: InternalTransaction
   ) {
     this._dataReader = newUserDataReader(_firestore);
   }
 
-  get<T>(
-    documentRef: firestore.DocumentReference<T>
-  ): Promise<DocumentSnapshot<T>> {
+  get<T>(documentRef: DocumentReference<T>): Promise<DocumentSnapshot<T>> {
     const ref = validateReference(documentRef, this._firestore);
     return this._transaction
       .lookup([ref._key])
@@ -93,16 +93,16 @@ export class Transaction {
       });
   }
 
-  set<T>(documentRef: firestore.DocumentReference<T>, value: T): this;
+  set<T>(documentRef: DocumentReference<T>, value: T): this;
   set<T>(
-    documentRef: firestore.DocumentReference<T>,
+    documentRef: DocumentReference<T>,
     value: Partial<T>,
-    options: firestore.SetOptions
+    options: SetOptions
   ): this;
   set<T>(
-    documentRef: firestore.DocumentReference<T>,
+    documentRef: DocumentReference<T>,
     value: T,
-    options?: firestore.SetOptions
+    options?: SetOptions
   ): this {
     const ref = validateReference(documentRef, this._firestore);
     const convertedValue = applyFirestoreDataConverter(
@@ -122,19 +122,16 @@ export class Transaction {
     return this;
   }
 
+  update(documentRef: DocumentReference<unknown>, value: UpdateData): this;
   update(
-    documentRef: firestore.DocumentReference<unknown>,
-    value: firestore.UpdateData
-  ): this;
-  update(
-    documentRef: firestore.DocumentReference<unknown>,
-    field: string | ExternalFieldPath,
+    documentRef: DocumentReference<unknown>,
+    field: string | FieldPath,
     value: unknown,
     ...moreFieldsAndValues: unknown[]
   ): this;
   update(
-    documentRef: firestore.DocumentReference<unknown>,
-    fieldOrUpdateData: string | ExternalFieldPath | firestore.UpdateData,
+    documentRef: DocumentReference<unknown>,
+    fieldOrUpdateData: string | FieldPath | UpdateData,
     value?: unknown,
     ...moreFieldsAndValues: unknown[]
   ): this {
@@ -166,7 +163,7 @@ export class Transaction {
     return this;
   }
 
-  delete(documentRef: firestore.DocumentReference<unknown>): this {
+  delete(documentRef: DocumentReference<unknown>): this {
     const ref = validateReference(documentRef, this._firestore);
     this._transaction.delete(ref._key);
     return this;
@@ -174,10 +171,10 @@ export class Transaction {
 }
 
 export function runTransaction<T>(
-  firestore: firestore.FirebaseFirestore,
-  updateFunction: (transaction: firestore.Transaction) => Promise<T>
+  firestore: FirebaseFirestore,
+  updateFunction: (transaction: Transaction) => Promise<T>
 ): Promise<T> {
-  const firestoreClient = cast(firestore, Firestore);
+  const firestoreClient = cast(firestore, FirebaseFirestore);
   const datastore = getDatastore(firestoreClient);
   const deferred = new Deferred<T>();
   new TransactionRunner<T>(

--- a/packages/firestore/lite/src/api/transaction.ts
+++ b/packages/firestore/lite/src/api/transaction.ts
@@ -42,7 +42,6 @@ import {
   UpdateData
 } from './reference';
 import { FieldPath } from './field_path';
-import { cast } from './util';
 import { getDatastore } from './components';
 
 // TODO(mrschmidt) Consider using `BaseTransaction` as the base class in the
@@ -174,14 +173,13 @@ export function runTransaction<T>(
   firestore: FirebaseFirestore,
   updateFunction: (transaction: Transaction) => Promise<T>
 ): Promise<T> {
-  const firestoreClient = cast(firestore, FirebaseFirestore);
-  const datastore = getDatastore(firestoreClient);
+  const datastore = getDatastore(firestore);
   const deferred = new Deferred<T>();
   new TransactionRunner<T>(
     new AsyncQueue(),
     datastore,
     internalTransaction =>
-      updateFunction(new Transaction(firestoreClient, internalTransaction)),
+      updateFunction(new Transaction(firestore, internalTransaction)),
     deferred
   ).run();
   return deferred.promise;

--- a/packages/firestore/lite/src/api/util.ts
+++ b/packages/firestore/lite/src/api/util.ts
@@ -23,6 +23,8 @@ import { Code, FirestoreError } from '../../../src/util/error';
  * This cast is used in the Lite and Full SDK to verify instance types for
  * arguments passed to the public API.
  */
+// TODO(firestoreexp): We can probably remove this since we now use the classes
+// directly instead of an interface
 export function cast<T>(
   obj: object,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/firestore/lite/src/api/util.ts
+++ b/packages/firestore/lite/src/api/util.ts
@@ -23,8 +23,6 @@ import { Code, FirestoreError } from '../../../src/util/error';
  * This cast is used in the Lite and Full SDK to verify instance types for
  * arguments passed to the public API.
  */
-// TODO(firestoreexp): We can probably remove this since we now use the classes
-// directly instead of an interface
 export function cast<T>(
   obj: object,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -34,8 +32,8 @@ export function cast<T>(
     if (constructor.name === obj.constructor.name) {
       throw new FirestoreError(
         Code.INVALID_ARGUMENT,
-        'Type does not match the expected instance. Did you pass ' +
-          `'${constructor.name}' from a different Firestore SDK?`
+        'Type does not match the expected instance. Did you pass a ' +
+          `reference from a different Firestore SDK?`
       );
     } else {
       throw new FirestoreError(

--- a/packages/firestore/lite/src/api/write_batch.ts
+++ b/packages/firestore/lite/src/api/write_batch.ts
@@ -28,7 +28,6 @@ import {
   parseUpdateVarargs,
   UserDataReader
 } from '../../../src/api/user_data_reader';
-import { cast } from './util';
 import {
   DocumentReference,
   newUserDataReader,
@@ -176,14 +175,13 @@ export function validateReference<T>(
       'Provided document reference is from a different Firestore instance.'
     );
   } else {
-    return cast(documentRef, DocumentReference) as DocumentReference<T>;
+    return documentRef as DocumentReference<T>;
   }
 }
 
 export function writeBatch(firestore: FirebaseFirestore): WriteBatch {
-  const firestoreImpl = cast(firestore, FirebaseFirestore);
-  const datastore = getDatastore(firestoreImpl);
-  return new WriteBatch(firestoreImpl, writes =>
+  const datastore = getDatastore(firestore);
+  return new WriteBatch(firestore, writes =>
     invokeCommitRpc(datastore, writes)
   );
 }

--- a/packages/firestore/lite/src/api/write_batch.ts
+++ b/packages/firestore/lite/src/api/write_batch.ts
@@ -15,8 +15,6 @@
  * limitations under the License.
  */
 
-import * as firestore from '../../../lite-types';
-
 import {
   DeleteMutation,
   Mutation,
@@ -31,13 +29,18 @@ import {
   UserDataReader
 } from '../../../src/api/user_data_reader';
 import { cast } from './util';
-import { DocumentReference, newUserDataReader } from './reference';
-import { Firestore } from './database';
+import {
+  DocumentReference,
+  newUserDataReader,
+  SetOptions,
+  UpdateData
+} from './reference';
+import { FirebaseFirestore } from './database';
 import { invokeCommitRpc } from '../../../src/remote/datastore';
 import { FieldPath } from './field_path';
 import { getDatastore } from './components';
 
-export class WriteBatch implements firestore.WriteBatch {
+export class WriteBatch {
   // This is the lite version of the WriteBatch API used in the legacy SDK. The
   // class is a close copy but takes different input types.
 
@@ -46,22 +49,22 @@ export class WriteBatch implements firestore.WriteBatch {
   private _committed = false;
 
   constructor(
-    private readonly _firestore: Firestore,
+    private readonly _firestore: FirebaseFirestore,
     private readonly _commitHandler: (m: Mutation[]) => Promise<void>
   ) {
     this._dataReader = newUserDataReader(_firestore);
   }
 
-  set<T>(documentRef: firestore.DocumentReference<T>, value: T): WriteBatch;
+  set<T>(documentRef: DocumentReference<T>, value: T): WriteBatch;
   set<T>(
-    documentRef: firestore.DocumentReference<T>,
+    documentRef: DocumentReference<T>,
     value: Partial<T>,
-    options: firestore.SetOptions
+    options: SetOptions
   ): WriteBatch;
   set<T>(
-    documentRef: firestore.DocumentReference<T>,
+    documentRef: DocumentReference<T>,
     value: T,
-    options?: firestore.SetOptions
+    options?: SetOptions
   ): WriteBatch {
     this.verifyNotCommitted();
     const ref = validateReference(documentRef, this._firestore);
@@ -86,18 +89,18 @@ export class WriteBatch implements firestore.WriteBatch {
   }
 
   update(
-    documentRef: firestore.DocumentReference<unknown>,
-    value: firestore.UpdateData
+    documentRef: DocumentReference<unknown>,
+    value: UpdateData
   ): WriteBatch;
   update(
-    documentRef: firestore.DocumentReference<unknown>,
-    field: string | firestore.FieldPath,
+    documentRef: DocumentReference<unknown>,
+    field: string | FieldPath,
     value: unknown,
     ...moreFieldsAndValues: unknown[]
   ): WriteBatch;
   update(
-    documentRef: firestore.DocumentReference<unknown>,
-    fieldOrUpdateData: string | firestore.FieldPath | firestore.UpdateData,
+    documentRef: DocumentReference<unknown>,
+    fieldOrUpdateData: string | FieldPath | UpdateData,
     value?: unknown,
     ...moreFieldsAndValues: unknown[]
   ): WriteBatch {
@@ -133,7 +136,7 @@ export class WriteBatch implements firestore.WriteBatch {
     return this;
   }
 
-  delete(documentRef: firestore.DocumentReference<unknown>): WriteBatch {
+  delete(documentRef: DocumentReference<unknown>): WriteBatch {
     this.verifyNotCommitted();
     const ref = validateReference(documentRef, this._firestore);
     this._mutations = this._mutations.concat(
@@ -164,8 +167,8 @@ export class WriteBatch implements firestore.WriteBatch {
 }
 
 export function validateReference<T>(
-  documentRef: firestore.DocumentReference<T>,
-  firestore: Firestore
+  documentRef: DocumentReference<T>,
+  firestore: FirebaseFirestore
 ): DocumentReference<T> {
   if (documentRef.firestore !== firestore) {
     throw new FirestoreError(
@@ -177,10 +180,8 @@ export function validateReference<T>(
   }
 }
 
-export function writeBatch(
-  firestore: firestore.FirebaseFirestore
-): firestore.WriteBatch {
-  const firestoreImpl = cast(firestore, Firestore);
+export function writeBatch(firestore: FirebaseFirestore): WriteBatch {
+  const firestoreImpl = cast(firestore, FirebaseFirestore);
   const datastore = getDatastore(firestoreImpl);
   return new WriteBatch(firestoreImpl, writes =>
     invokeCommitRpc(datastore, writes)

--- a/packages/firestore/src/api/database.ts
+++ b/packages/firestore/src/api/database.ts
@@ -128,7 +128,7 @@ import {
   Unsubscribe
 } from './observer';
 import {
-  DocumentKeyReference,
+  _DocumentKeyReference,
   fieldPathFromArgument,
   parseQueryValue,
   parseSetData,
@@ -1021,7 +1021,7 @@ export class WriteBatch implements PublicWriteBatch {
  * A reference to a particular document in a collection in the database.
  */
 export class DocumentReference<T = DocumentData>
-  extends DocumentKeyReference<T>
+  extends _DocumentKeyReference<T>
   implements PublicDocumentReference<T> {
   private _firestoreClient: FirestoreClient;
 
@@ -1693,7 +1693,7 @@ function parseDocumentIdValue(
       );
     }
     return refValue(databaseId, new DocumentKey(path));
-  } else if (documentIdValue instanceof DocumentKeyReference) {
+  } else if (documentIdValue instanceof _DocumentKeyReference) {
     return refValue(databaseId, documentIdValue._key);
   } else {
     throw new FirestoreError(
@@ -2462,8 +2462,8 @@ function validateReference<T>(
   methodName: string,
   documentRef: PublicDocumentReference<T>,
   firestore: Firestore
-): DocumentKeyReference<T> {
-  if (!(documentRef instanceof DocumentKeyReference)) {
+): _DocumentKeyReference<T> {
+  if (!(documentRef instanceof _DocumentKeyReference)) {
     throw invalidClassError(methodName, 'DocumentReference', 1, documentRef);
   } else if (documentRef.firestore !== firestore) {
     throw new FirestoreError(

--- a/packages/firestore/src/api/field_path.ts
+++ b/packages/firestore/src/api/field_path.ts
@@ -33,7 +33,9 @@ import {
  * A field class base class that is shared by the lite, full and legacy SDK,
  * which supports shared code that deals with FieldPaths.
  */
-export abstract class BaseFieldPath {
+// Use underscore prefix to hide this class from our Public API.
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export abstract class _BaseFieldPath {
   /** Internal representation of a Firestore field path. */
   readonly _internalPath: InternalFieldPath;
 
@@ -65,7 +67,7 @@ export abstract class BaseFieldPath {
  * field name (referring to a top-level field in the document), or a list of
  * field names (referring to a nested field in the document).
  */
-export class FieldPath extends BaseFieldPath implements PublicFieldPath {
+export class FieldPath extends _BaseFieldPath implements PublicFieldPath {
   /**
    * Creates a FieldPath from the provided field names. If more than one field
    * name is provided, the path will point to a nested field in a document.

--- a/packages/firestore/src/api/field_value.ts
+++ b/packages/firestore/src/api/field_value.ts
@@ -37,19 +37,21 @@ import { toNumber } from '../remote/serializer';
  * An opaque base class for FieldValue sentinel objects in our public API that
  * is shared between the full, lite and legacy SDK.
  */
-export abstract class SerializableFieldValue {
+// Use underscore prefix to hide this class from our Public API.
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export abstract class _SerializableFieldValue {
   /** The public API endpoint that returns this class. */
   abstract readonly _methodName: string;
 
   /** A pointer to the implementing class. */
-  readonly _delegate: SerializableFieldValue = this;
+  readonly _delegate: _SerializableFieldValue = this;
 
   abstract _toFieldTransform(context: ParseContext): FieldTransform | null;
 
-  abstract isEqual(other: SerializableFieldValue): boolean;
+  abstract isEqual(other: _SerializableFieldValue): boolean;
 }
 
-export class DeleteFieldValueImpl extends SerializableFieldValue {
+export class DeleteFieldValueImpl extends _SerializableFieldValue {
   constructor(readonly _methodName: string) {
     super();
   }
@@ -101,7 +103,7 @@ export class DeleteFieldValueImpl extends SerializableFieldValue {
  * @param arrayElement Whether or not the FieldValue has an array.
  */
 function createSentinelChildContext(
-  fieldValue: SerializableFieldValue,
+  fieldValue: _SerializableFieldValue,
   context: ParseContext,
   arrayElement: boolean
 ): ParseContext {
@@ -118,7 +120,7 @@ function createSentinelChildContext(
   );
 }
 
-export class ServerTimestampFieldValueImpl extends SerializableFieldValue {
+export class ServerTimestampFieldValueImpl extends _SerializableFieldValue {
   constructor(readonly _methodName: string) {
     super();
   }
@@ -132,7 +134,7 @@ export class ServerTimestampFieldValueImpl extends SerializableFieldValue {
   }
 }
 
-export class ArrayUnionFieldValueImpl extends SerializableFieldValue {
+export class ArrayUnionFieldValueImpl extends _SerializableFieldValue {
   constructor(
     readonly _methodName: string,
     private readonly _elements: unknown[]
@@ -159,7 +161,7 @@ export class ArrayUnionFieldValueImpl extends SerializableFieldValue {
   }
 }
 
-export class ArrayRemoveFieldValueImpl extends SerializableFieldValue {
+export class ArrayRemoveFieldValueImpl extends _SerializableFieldValue {
   constructor(readonly _methodName: string, readonly _elements: unknown[]) {
     super();
   }
@@ -183,7 +185,7 @@ export class ArrayRemoveFieldValueImpl extends SerializableFieldValue {
   }
 }
 
-export class NumericIncrementFieldValueImpl extends SerializableFieldValue {
+export class NumericIncrementFieldValueImpl extends _SerializableFieldValue {
   constructor(readonly _methodName: string, private readonly _operand: number) {
     super();
   }
@@ -204,7 +206,7 @@ export class NumericIncrementFieldValueImpl extends SerializableFieldValue {
 
 /** The public FieldValue class of the lite API. */
 export abstract class FieldValue
-  extends SerializableFieldValue
+  extends _SerializableFieldValue
   implements PublicFieldValue {
   protected constructor() {
     super();
@@ -263,7 +265,7 @@ export abstract class FieldValue
 class FieldValueDelegate extends FieldValue implements PublicFieldValue {
   readonly _methodName: string;
 
-  constructor(readonly _delegate: SerializableFieldValue) {
+  constructor(readonly _delegate: _SerializableFieldValue) {
     super();
     this._methodName = _delegate._methodName;
   }

--- a/packages/firestore/src/api/user_data_reader.ts
+++ b/packages/firestore/src/api/user_data_reader.ts
@@ -46,8 +46,8 @@ import {
   toResourceName,
   toTimestamp
 } from '../remote/serializer';
-import { BaseFieldPath, fromDotSeparatedString } from './field_path';
-import { DeleteFieldValueImpl, SerializableFieldValue } from './field_value';
+import { _BaseFieldPath, fromDotSeparatedString } from './field_path';
+import { DeleteFieldValueImpl, _SerializableFieldValue } from './field_value';
 import { GeoPoint } from './geo_point';
 import { newSerializer } from '../platform/serializer';
 import { Bytes } from '../../lite/src/api/bytes';
@@ -70,7 +70,9 @@ export interface UntypedFirestoreDataConverter<T> {
  * This class serves as a common base class for the public DocumentReferences
  * exposed in the lite, full and legacy SDK.
  */
-export class DocumentKeyReference<T> {
+// Use underscore prefix to hide this class from our Public API.
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export class _DocumentKeyReference<T> {
   constructor(
     readonly _databaseId: DatabaseId,
     readonly _key: DocumentKey,
@@ -373,7 +375,7 @@ export function parseSetData(
     for (const stringOrFieldPath of options.mergeFields) {
       let fieldPath: FieldPath;
 
-      if (stringOrFieldPath instanceof BaseFieldPath) {
+      if (stringOrFieldPath instanceof _BaseFieldPath) {
         fieldPath = stringOrFieldPath._internalPath;
       } else if (typeof stringOrFieldPath === 'string') {
         fieldPath = fieldPathFromDotSeparatedString(
@@ -434,7 +436,7 @@ export function parseUpdateData(
 
     const childContext = context.childContextForFieldPath(path);
     if (
-      value instanceof SerializableFieldValue &&
+      value instanceof _SerializableFieldValue &&
       value._delegate instanceof DeleteFieldValueImpl
     ) {
       // Add it to the field mask, but don't add anything to updateData.
@@ -461,7 +463,7 @@ export function parseUpdateVarargs(
   userDataReader: UserDataReader,
   methodName: string,
   targetDoc: DocumentKey,
-  field: string | BaseFieldPath,
+  field: string | _BaseFieldPath,
   value: unknown,
   moreFieldsAndValues: unknown[]
 ): ParsedUpdateData {
@@ -485,7 +487,7 @@ export function parseUpdateVarargs(
     keys.push(
       fieldPathFromArgument(
         methodName,
-        moreFieldsAndValues[i] as string | BaseFieldPath
+        moreFieldsAndValues[i] as string | _BaseFieldPath
       )
     );
     values.push(moreFieldsAndValues[i + 1]);
@@ -502,7 +504,7 @@ export function parseUpdateVarargs(
       const value = values[i];
       const childContext = context.childContextForFieldPath(path);
       if (
-        value instanceof SerializableFieldValue &&
+        value instanceof _SerializableFieldValue &&
         value._delegate instanceof DeleteFieldValueImpl
       ) {
         // Add it to the field mask, but don't add anything to updateData.
@@ -567,7 +569,7 @@ export function parseData(
   if (looksLikeJsonObject(input)) {
     validatePlainObject('Unsupported field value:', context, input);
     return parseObject(input, context);
-  } else if (input instanceof SerializableFieldValue) {
+  } else if (input instanceof _SerializableFieldValue) {
     // FieldValues usually parse into transforms (except FieldValue.delete())
     // in which case we do not want to include this field in our parsed data
     // (as doing so will overwrite the field directly prior to the transform
@@ -650,7 +652,7 @@ function parseArray(array: unknown[], context: ParseContext): ProtoValue {
  * context.fieldTransforms.
  */
 function parseSentinelFieldValue(
-  value: SerializableFieldValue,
+  value: _SerializableFieldValue,
   context: ParseContext
 ): void {
   // Sentinels are only supported with writes, and not within arrays.
@@ -713,7 +715,7 @@ function parseScalarValue(
     };
   } else if (value instanceof Bytes) {
     return { bytesValue: toBytes(context.serializer, value._byteString) };
-  } else if (value instanceof DocumentKeyReference) {
+  } else if (value instanceof _DocumentKeyReference) {
     const thisDb = context.databaseId;
     const otherDb = value._databaseId;
     if (!otherDb.isEqual(thisDb)) {
@@ -754,8 +756,8 @@ function looksLikeJsonObject(input: unknown): boolean {
     !(input instanceof Timestamp) &&
     !(input instanceof GeoPoint) &&
     !(input instanceof Bytes) &&
-    !(input instanceof DocumentKeyReference) &&
-    !(input instanceof SerializableFieldValue)
+    !(input instanceof _DocumentKeyReference) &&
+    !(input instanceof _SerializableFieldValue)
   );
 }
 
@@ -780,10 +782,10 @@ function validatePlainObject(
  */
 export function fieldPathFromArgument(
   methodName: string,
-  path: string | BaseFieldPath,
+  path: string | _BaseFieldPath,
   targetDoc?: DocumentKey
 ): FieldPath {
-  if (path instanceof BaseFieldPath) {
+  if (path instanceof _BaseFieldPath) {
     return path._internalPath;
   } else if (typeof path === 'string') {
     return fieldPathFromDotSeparatedString(methodName, path);

--- a/packages/firestore/src/api/user_data_writer.ts
+++ b/packages/firestore/src/api/user_data_writer.ts
@@ -24,7 +24,7 @@ import {
   Timestamp as ProtoTimestamp,
   Value as ProtoValue
 } from '../protos/firestore_proto_api';
-import { DocumentKeyReference } from './user_data_reader';
+import { _DocumentKeyReference } from './user_data_reader';
 import { GeoPoint } from './geo_point';
 import { Timestamp } from './timestamp';
 import { DatabaseId } from '../core/database_info';
@@ -61,7 +61,7 @@ export class UserDataWriter {
     private readonly serverTimestampBehavior: ServerTimestampBehavior,
     private readonly referenceFactory: (
       key: DocumentKey
-    ) => DocumentKeyReference<DocumentData>,
+    ) => _DocumentKeyReference<DocumentData>,
     private readonly bytesFactory: (bytes: ByteString) => Bytes
   ) {}
 
@@ -141,7 +141,7 @@ export class UserDataWriter {
     }
   }
 
-  private convertReference(name: string): DocumentKeyReference<DocumentData> {
+  private convertReference(name: string): _DocumentKeyReference<DocumentData> {
     const resourcePath = ResourcePath.fromString(name);
     hardAssert(
       isValidResourceName(resourcePath),

--- a/packages/firestore/src/core/query.ts
+++ b/packages/firestore/src/core/query.ts
@@ -31,7 +31,7 @@ import {
   valueEquals
 } from '../model/values';
 import { FieldPath, ResourcePath } from '../model/path';
-import { debugAssert, fail } from '../util/assert';
+import { debugAssert, debugCast, fail } from '../util/assert';
 import { Code, FirestoreError } from '../util/error';
 import { isNullOrUndefined } from '../util/types';
 import {
@@ -41,7 +41,6 @@ import {
   Target,
   targetEquals
 } from './target';
-import { cast } from '../../lite/src/api/util';
 
 export const enum LimitType {
   First = 'F',
@@ -254,7 +253,7 @@ export function isCollectionGroupQuery(query: Query): boolean {
  * the SDK and backend always orders by `__name__`).
  */
 export function queryOrderBy(query: Query): OrderBy[] {
-  const queryImpl = cast(query, QueryImpl);
+  const queryImpl = debugCast(query, QueryImpl);
   if (queryImpl.memoizedOrderBy === null) {
     queryImpl.memoizedOrderBy = [];
 
@@ -305,7 +304,7 @@ export function queryOrderBy(query: Query): OrderBy[] {
  * Converts this `Query` instance to it's corresponding `Target` representation.
  */
 export function queryToTarget(query: Query): Target {
-  const queryImpl = cast(query, QueryImpl);
+  const queryImpl = debugCast(query, QueryImpl);
   if (!queryImpl.memoizedTarget) {
     if (queryImpl.limitType === LimitType.First) {
       queryImpl.memoizedTarget = newTarget(

--- a/packages/firestore/src/util/error.ts
+++ b/packages/firestore/src/util/error.ts
@@ -15,28 +15,41 @@
  * limitations under the License.
  */
 
-import {
-  FirestoreError as PublicFirestoreError,
-  FirestoreErrorCode as PublicFirestoreErrorCode
-} from '@firebase/firestore-types';
+export type FirestoreErrorCode =
+  | 'cancelled'
+  | 'unknown'
+  | 'invalid-argument'
+  | 'deadline-exceeded'
+  | 'not-found'
+  | 'already-exists'
+  | 'permission-denied'
+  | 'resource-exhausted'
+  | 'failed-precondition'
+  | 'aborted'
+  | 'out-of-range'
+  | 'unimplemented'
+  | 'internal'
+  | 'unavailable'
+  | 'data-loss'
+  | 'unauthenticated';
 
 /**
  * Error Codes describing the different ways Firestore can fail. These come
  * directly from GRPC.
  */
-export type Code = PublicFirestoreErrorCode;
+export type Code = FirestoreErrorCode;
 
 export const Code = {
   // Causes are copied from:
   // https://github.com/grpc/grpc/blob/bceec94ea4fc5f0085d81235d8e1c06798dc341a/include/grpc%2B%2B/impl/codegen/status_code_enum.h
   /** Not an error; returned on success. */
-  OK: 'ok' as Code,
+  OK: 'ok' as FirestoreErrorCode,
 
   /** The operation was cancelled (typically by the caller). */
-  CANCELLED: 'cancelled' as Code,
+  CANCELLED: 'cancelled' as FirestoreErrorCode,
 
   /** Unknown error or an error from a different error domain. */
-  UNKNOWN: 'unknown' as Code,
+  UNKNOWN: 'unknown' as FirestoreErrorCode,
 
   /**
    * Client specified an invalid argument. Note that this differs from
@@ -44,7 +57,7 @@ export const Code = {
    * problematic regardless of the state of the system (e.g., a malformed file
    * name).
    */
-  INVALID_ARGUMENT: 'invalid-argument' as Code,
+  INVALID_ARGUMENT: 'invalid-argument' as FirestoreErrorCode,
 
   /**
    * Deadline expired before operation could complete. For operations that
@@ -53,16 +66,16 @@ export const Code = {
    * from a server could have been delayed long enough for the deadline to
    * expire.
    */
-  DEADLINE_EXCEEDED: 'deadline-exceeded' as Code,
+  DEADLINE_EXCEEDED: 'deadline-exceeded' as FirestoreErrorCode,
 
   /** Some requested entity (e.g., file or directory) was not found. */
-  NOT_FOUND: 'not-found' as Code,
+  NOT_FOUND: 'not-found' as FirestoreErrorCode,
 
   /**
    * Some entity that we attempted to create (e.g., file or directory) already
    * exists.
    */
-  ALREADY_EXISTS: 'already-exists' as Code,
+  ALREADY_EXISTS: 'already-exists' as FirestoreErrorCode,
 
   /**
    * The caller does not have permission to execute the specified operation.
@@ -71,19 +84,19 @@ export const Code = {
    * PERMISSION_DENIED must not be used if the caller can not be identified
    * (use UNAUTHENTICATED instead for those errors).
    */
-  PERMISSION_DENIED: 'permission-denied' as Code,
+  PERMISSION_DENIED: 'permission-denied' as FirestoreErrorCode,
 
   /**
    * The request does not have valid authentication credentials for the
    * operation.
    */
-  UNAUTHENTICATED: 'unauthenticated' as Code,
+  UNAUTHENTICATED: 'unauthenticated' as FirestoreErrorCode,
 
   /**
    * Some resource has been exhausted, perhaps a per-user quota, or perhaps the
    * entire file system is out of space.
    */
-  RESOURCE_EXHAUSTED: 'resource-exhausted' as Code,
+  RESOURCE_EXHAUSTED: 'resource-exhausted' as FirestoreErrorCode,
 
   /**
    * Operation was rejected because the system is not in a state required for
@@ -105,7 +118,7 @@ export const Code = {
    *      server does not match the condition. E.g., conflicting
    *      read-modify-write on the same resource.
    */
-  FAILED_PRECONDITION: 'failed-precondition' as Code,
+  FAILED_PRECONDITION: 'failed-precondition' as FirestoreErrorCode,
 
   /**
    * The operation was aborted, typically due to a concurrency issue like
@@ -114,7 +127,7 @@ export const Code = {
    * See litmus test above for deciding between FAILED_PRECONDITION, ABORTED,
    * and UNAVAILABLE.
    */
-  ABORTED: 'aborted' as Code,
+  ABORTED: 'aborted' as FirestoreErrorCode,
 
   /**
    * Operation was attempted past the valid range. E.g., seeking or reading
@@ -131,16 +144,16 @@ export const Code = {
    * when it applies so that callers who are iterating through a space can
    * easily look for an OUT_OF_RANGE error to detect when they are done.
    */
-  OUT_OF_RANGE: 'out-of-range' as Code,
+  OUT_OF_RANGE: 'out-of-range' as FirestoreErrorCode,
 
   /** Operation is not implemented or not supported/enabled in this service. */
-  UNIMPLEMENTED: 'unimplemented' as Code,
+  UNIMPLEMENTED: 'unimplemented' as FirestoreErrorCode,
 
   /**
    * Internal errors. Means some invariants expected by underlying System has
    * been broken. If you see one of these errors, Something is very broken.
    */
-  INTERNAL: 'internal' as Code,
+  INTERNAL: 'internal' as FirestoreErrorCode,
 
   /**
    * The service is currently unavailable. This is a most likely a transient
@@ -149,10 +162,10 @@ export const Code = {
    * See litmus test above for deciding between FAILED_PRECONDITION, ABORTED,
    * and UNAVAILABLE.
    */
-  UNAVAILABLE: 'unavailable' as Code,
+  UNAVAILABLE: 'unavailable' as FirestoreErrorCode,
 
   /** Unrecoverable data loss or corruption. */
-  DATA_LOSS: 'data-loss' as Code
+  DATA_LOSS: 'data-loss' as FirestoreErrorCode
 };
 
 /**
@@ -161,11 +174,11 @@ export const Code = {
  * so we define our own compatible error class (with a `name` of 'FirebaseError'
  * and compatible `code` and `message` fields.)
  */
-export class FirestoreError extends Error implements PublicFirestoreError {
+export class FirestoreError extends Error {
   name = 'FirebaseError';
   stack?: string;
 
-  constructor(readonly code: Code, readonly message: string) {
+  constructor(readonly code: FirestoreErrorCode, readonly message: string) {
     super(message);
 
     // HACK: We write a toString property directly because Error is not a real

--- a/packages/firestore/src/util/log.ts
+++ b/packages/firestore/src/util/log.ts
@@ -19,7 +19,7 @@ import { Logger, LogLevel, LogLevelString } from '@firebase/logger';
 import { SDK_VERSION } from '../core/version';
 import { formatJSON } from '../platform/format_json';
 
-export { LogLevel };
+export { LogLevel, LogLevelString };
 
 const logClient = new Logger('@firebase/firestore');
 


### PR DESCRIPTION
This PR updates the firestore-exp and firestore/lite SDK so that we no longer have to maintain manual type definitions.

The first commit:
- removes the reliance on the types in the SDK code
- moves interface-only types into the SDK itself, which allows us to export them directly in the index.ts (this affects things such as Settings and FirestoreDataConverter)
- renames Firestore to FirebaseFirestore as that is the name in the public API
- renames some private classes (DocumentKeyReference, SerializeableFieldValue, ...) that leak into the public API (via inheritance) to use underscore prefixes, which allows us to hide the class from the auto-generated interfaces.

The second commit removes the now unnecessary `cast()` calls from the interface to the SDK type from most callsites. I maintained the cast to FirebaseFirestore in some instances as this allows me to share DocumentReference, CollectionReference and Query between the different SDKs (the firestore-exp SDK used the Lite classes, which are only typed to return LiteFirestore and not ExpFirebaseFirestore).

The third commit regenerates the dependency files.

There should be no logic changes.