### PR TITLE
Revert "Make != and NOT_IN publicly available (#3772)"

### DIFF
--- a/.changeset/shiny-forks-pull.md
+++ b/.changeset/shiny-forks-pull.md
@@ -1,7 +1,0 @@
----
-'firebase': minor
-'@firebase/firestore': minor
-'@firebase/firestore-types': minor
----
-
-[feature] Added `not-in` and `!=` query operators for use with `.where()`. `not-in` finds documents where a specified field’s value is not in a specified array. `!=` finds documents where a specified field's value does not equal the specified value. Neither query operator will match documents where the specified field is not present.

--- a/packages/firebase/index.d.ts
+++ b/packages/firebase/index.d.ts
@@ -9073,20 +9073,17 @@ declare namespace firebase.firestore {
 
   /**
    * Filter conditions in a `Query.where()` clause are specified using the
-   * strings '<', '<=', '==', '!=', '>=', '>', 'array-contains', 'in',
-   * 'array-contains-any', and 'not-in'.
+   * strings '<', '<=', '==', '>=', '>', 'array-contains', 'in', and 'array-contains-any'.
    */
   export type WhereFilterOp =
     | '<'
     | '<='
     | '=='
-    | '!='
     | '>='
     | '>'
     | 'array-contains'
     | 'in'
-    | 'array-contains-any'
-    | 'not-in';
+    | 'array-contains-any';
 
   /**
    * A `Query` refers to a Query which you can read or listen to. You can also

--- a/packages/firestore-types/index.d.ts
+++ b/packages/firestore-types/index.d.ts
@@ -294,13 +294,11 @@ export type WhereFilterOp =
   | '<'
   | '<='
   | '=='
-  | '!='
   | '>='
   | '>'
   | 'array-contains'
   | 'in'
-  | 'array-contains-any'
-  | 'not-in';
+  | 'array-contains-any';
 
 export class Query<T = DocumentData> {
   protected constructor();

--- a/packages/firestore/exp-types/index.d.ts
+++ b/packages/firestore/exp-types/index.d.ts
@@ -277,13 +277,11 @@ export type WhereFilterOp =
   | '<'
   | '<='
   | '=='
-  | '!='
   | '>='
   | '>'
   | 'array-contains'
   | 'in'
-  | 'array-contains-any'
-  | 'not-in';
+  | 'array-contains-any';
 
 export class Query<T = DocumentData> {
   protected constructor();

--- a/packages/firestore/lite-types/index.d.ts
+++ b/packages/firestore/lite-types/index.d.ts
@@ -227,13 +227,11 @@ export type WhereFilterOp =
   | '<'
   | '<='
   | '=='
-  | '!='
   | '>='
   | '>'
   | 'array-contains'
   | 'in'
-  | 'array-contains-any'
-  | 'not-in';
+  | 'array-contains-any';
 
 export class Query<T = DocumentData> {
   protected constructor();

--- a/packages/firestore/src/api/database.ts
+++ b/packages/firestore/src/api/database.ts
@@ -1882,20 +1882,24 @@ export class Query<T = DocumentData> implements PublicQuery<T> {
     validateExactNumberOfArgs('Query.where', arguments, 3);
     validateDefined('Query.where', 3, value);
 
-    // Enumerated from the WhereFilterOp type in index.d.ts.
-    const whereFilterOpEnums = [
-      Operator.LESS_THAN,
-      Operator.LESS_THAN_OR_EQUAL,
-      Operator.EQUAL,
-      Operator.NOT_EQUAL,
-      Operator.GREATER_THAN_OR_EQUAL,
-      Operator.GREATER_THAN,
-      Operator.ARRAY_CONTAINS,
-      Operator.IN,
-      Operator.ARRAY_CONTAINS_ANY,
-      Operator.NOT_IN
-    ];
-    const op = validateStringEnum('Query.where', whereFilterOpEnums, 2, opStr);
+    // TODO(ne-queries): Add 'not-in' and '!=' to validation.
+    let op: Operator;
+    if ((opStr as unknown) === 'not-in' || (opStr as unknown) === '!=') {
+      op = opStr as Operator;
+    } else {
+      // Enumerated from the WhereFilterOp type in index.d.ts.
+      const whereFilterOpEnums = [
+        Operator.LESS_THAN,
+        Operator.LESS_THAN_OR_EQUAL,
+        Operator.EQUAL,
+        Operator.GREATER_THAN_OR_EQUAL,
+        Operator.GREATER_THAN,
+        Operator.ARRAY_CONTAINS,
+        Operator.IN,
+        Operator.ARRAY_CONTAINS_ANY
+      ];
+      op = validateStringEnum('Query.where', whereFilterOpEnums, 2, opStr);
+    }
 
     const fieldPath = fieldPathFromArgument('Query.where', field);
     const filter = newQueryFilter(

--- a/packages/firestore/src/core/query.ts
+++ b/packages/firestore/src/core/query.ts
@@ -605,17 +605,19 @@ export class FieldFilter extends Filter {
       }
     } else if (isNullValue(value)) {
       if (op !== Operator.EQUAL && op !== Operator.NOT_EQUAL) {
+        // TODO(ne-queries): Update error message to include != comparison.
         throw new FirestoreError(
           Code.INVALID_ARGUMENT,
-          "Invalid query. Null only supports '==' and '!=' comparisons."
+          'Invalid query. Null supports only equality comparisons.'
         );
       }
       return new FieldFilter(field, op, value);
     } else if (isNanValue(value)) {
       if (op !== Operator.EQUAL && op !== Operator.NOT_EQUAL) {
+        // TODO(ne-queries): Update error message to include != comparison.
         throw new FirestoreError(
           Code.INVALID_ARGUMENT,
-          "Invalid query. NaN only supports '==' and '!=' comparisons."
+          'Invalid query. NaN supports only equality comparisons.'
         );
       }
       return new FieldFilter(field, op, value);
@@ -709,8 +711,7 @@ export class FieldFilter extends Filter {
         Operator.LESS_THAN_OR_EQUAL,
         Operator.GREATER_THAN,
         Operator.GREATER_THAN_OR_EQUAL,
-        Operator.NOT_EQUAL,
-        Operator.NOT_IN
+        Operator.NOT_EQUAL
       ].indexOf(this.op) >= 0
     );
   }

--- a/packages/firestore/test/integration/api/database.test.ts
+++ b/packages/firestore/test/integration/api/database.test.ts
@@ -25,6 +25,8 @@ import { EventsAccumulator } from '../util/events_accumulator';
 import * as firebaseExport from '../util/firebase_export';
 import {
   apiDescribe,
+  notEqualOp,
+  notInOp,
   withTestCollection,
   withTestDb,
   withTestDbs,
@@ -642,6 +644,14 @@ apiDescribe('Database', (persistence: boolean) => {
       });
     });
 
+    it('inequality and NOT_IN on different fields works', () => {
+      return withTestCollection(persistence, {}, async coll => {
+        expect(() =>
+          coll.where('x', '>=', 32).where('y', notInOp, [1, 2])
+        ).not.to.throw();
+      });
+    });
+
     it('inequality and array-contains-any on different fields works', () => {
       return withTestCollection(persistence, {}, async coll => {
         expect(() =>
@@ -659,8 +669,12 @@ apiDescribe('Database', (persistence: boolean) => {
 
     it('!= same as orderBy works.', () => {
       return withTestCollection(persistence, {}, async coll => {
-        expect(() => coll.where('x', '!=', 32).orderBy('x')).not.to.throw();
-        expect(() => coll.orderBy('x').where('x', '!=', 32)).not.to.throw();
+        expect(() =>
+          coll.where('x', notEqualOp, 32).orderBy('x')
+        ).not.to.throw();
+        expect(() =>
+          coll.orderBy('x').where('x', notEqualOp, 32)
+        ).not.to.throw();
       });
     });
 
@@ -678,10 +692,10 @@ apiDescribe('Database', (persistence: boolean) => {
     it('!= same as first orderBy works.', () => {
       return withTestCollection(persistence, {}, async coll => {
         expect(() =>
-          coll.where('x', '!=', 32).orderBy('x').orderBy('y')
+          coll.where('x', notEqualOp, 32).orderBy('x').orderBy('y')
         ).not.to.throw();
         expect(() =>
-          coll.orderBy('x').where('x', '!=', 32).orderBy('y')
+          coll.orderBy('x').where('x', notEqualOp, 32).orderBy('y')
         ).not.to.throw();
       });
     });
@@ -703,6 +717,14 @@ apiDescribe('Database', (persistence: boolean) => {
     it('IN different than orderBy works', () => {
       return withTestCollection(persistence, {}, async coll => {
         expect(() => coll.orderBy('x').where('y', 'in', [1, 2])).not.to.throw();
+      });
+    });
+
+    it('NOT_IN different than orderBy works', () => {
+      return withTestCollection(persistence, {}, async coll => {
+        expect(() =>
+          coll.orderBy('x').where('y', notInOp, [1, 2])
+        ).not.to.throw();
       });
     });
 

--- a/packages/firestore/test/integration/api/validation.test.ts
+++ b/packages/firestore/test/integration/api/validation.test.ts
@@ -24,7 +24,9 @@ import {
   apiDescribe,
   withAlternateTestDb,
   withTestCollection,
-  withTestDb
+  withTestDb,
+  notInOp,
+  notEqualOp
 } from '../util/helpers';
 import { ALT_PROJECT_ID, DEFAULT_PROJECT_ID } from '../util/settings';
 
@@ -939,7 +941,7 @@ apiDescribe('Validation:', (persistence: boolean) => {
         const collection = db.collection('test') as any;
         expect(() => collection.where('a', 'foo' as any, 'b')).to.throw(
           'Invalid value "foo" provided to function Query.where() for its second argument. ' +
-            'Acceptable values: <, <=, ==, !=, >=, >, array-contains, in, array-contains-any, not-in'
+            'Acceptable values: <, <=, ==, >=, >, array-contains, in, array-contains-any'
         );
       }
     );
@@ -950,15 +952,15 @@ apiDescribe('Validation:', (persistence: boolean) => {
       db => {
         const collection = db.collection('test');
         expect(() => collection.where('a', '>', null)).to.throw(
-          "Invalid query. Null only supports '==' and '!=' comparisons."
+          'Invalid query. Null supports only equality comparisons.'
         );
         expect(() => collection.where('a', 'array-contains', null)).to.throw(
-          "Invalid query. Null only supports '==' and '!=' comparisons."
+          'Invalid query. Null supports only equality comparisons.'
         );
         expect(() => collection.where('a', 'in', null)).to.throw(
           "Invalid Query. A non-empty array is required for 'in' filters."
         );
-        expect(() => collection.where('a', 'not-in', null)).to.throw(
+        expect(() => collection.where('a', notInOp, null)).to.throw(
           "Invalid Query. A non-empty array is required for 'not-in' filters."
         );
         expect(() =>
@@ -968,17 +970,15 @@ apiDescribe('Validation:', (persistence: boolean) => {
         );
 
         expect(() => collection.where('a', '>', Number.NaN)).to.throw(
-          "Invalid query. NaN only supports '==' and '!=' comparisons."
+          'Invalid query. NaN supports only equality comparisons.'
         );
         expect(() =>
           collection.where('a', 'array-contains', Number.NaN)
-        ).to.throw(
-          "Invalid query. NaN only supports '==' and '!=' comparisons."
-        );
+        ).to.throw('Invalid query. NaN supports only equality comparisons.');
         expect(() => collection.where('a', 'in', Number.NaN)).to.throw(
           "Invalid Query. A non-empty array is required for 'in' filters."
         );
-        expect(() => collection.where('a', 'not-in', Number.NaN)).to.throw(
+        expect(() => collection.where('a', notInOp, Number.NaN)).to.throw(
           "Invalid Query. A non-empty array is required for 'not-in' filters."
         );
         expect(() =>
@@ -1131,7 +1131,7 @@ apiDescribe('Validation:', (persistence: boolean) => {
     validationIt(persistence, 'with more than one != query fail', db => {
       const collection = db.collection('test');
       expect(() =>
-        collection.where('x', '!=', 32).where('x', '!=', 33)
+        collection.where('x', notEqualOp, 32).where('x', notEqualOp, 33)
       ).to.throw("Invalid query. You cannot use more than one '!=' filter.");
     });
 
@@ -1141,22 +1141,7 @@ apiDescribe('Validation:', (persistence: boolean) => {
       db => {
         const collection = db.collection('test');
         expect(() =>
-          collection.where('y', '>', 32).where('x', '!=', 33)
-        ).to.throw(
-          'Invalid query. All where filters with an ' +
-            'inequality (<, <=, >, or >=) must be on the same field.' +
-            ` But you have inequality filters on 'y' and 'x`
-        );
-      }
-    );
-
-    validationIt(
-      persistence,
-      'with != and inequality queries on different fields fail',
-      db => {
-        const collection = db.collection('test');
-        expect(() =>
-          collection.where('y', '>', 32).where('x', 'not-in', [33])
+          collection.where('y', '>', 32).where('x', notEqualOp, 33)
         ).to.throw(
           'Invalid query. All where filters with an ' +
             'inequality (<, <=, >, or >=) must be on the same field.' +
@@ -1187,9 +1172,9 @@ apiDescribe('Validation:', (persistence: boolean) => {
         expect(() =>
           collection.orderBy('y').orderBy('x').where('x', '>', 32)
         ).to.throw(reason);
-        expect(() => collection.where('x', '!=', 32).orderBy('y')).to.throw(
-          reason
-        );
+        expect(() =>
+          collection.where('x', notEqualOp, 32).orderBy('y')
+        ).to.throw(reason);
       }
     );
 
@@ -1226,7 +1211,7 @@ apiDescribe('Validation:', (persistence: boolean) => {
       expect(() =>
         db
           .collection('test')
-          .where('foo', 'not-in', [2, 3])
+          .where('foo', notInOp, [2, 3])
           .where('foo', 'array-contains', 1)
       ).to.throw(
         "Invalid query. You cannot use 'array-contains' filters with " +
@@ -1238,8 +1223,8 @@ apiDescribe('Validation:', (persistence: boolean) => {
       expect(() =>
         db
           .collection('test')
-          .where('foo', 'not-in', [2, 3])
-          .where('foo', '!=', 4)
+          .where('foo', notInOp, [2, 3])
+          .where('foo', notEqualOp, 4)
       ).to.throw(
         "Invalid query. You cannot use '!=' filters with 'not-in' filters."
       );
@@ -1247,8 +1232,8 @@ apiDescribe('Validation:', (persistence: boolean) => {
       expect(() =>
         db
           .collection('test')
-          .where('foo', '!=', 4)
-          .where('foo', 'not-in', [2, 3])
+          .where('foo', notEqualOp, 4)
+          .where('foo', notInOp, [2, 3])
       ).to.throw(
         "Invalid query. You cannot use 'not-in' filters with '!=' filters."
       );
@@ -1265,8 +1250,8 @@ apiDescribe('Validation:', (persistence: boolean) => {
       expect(() =>
         db
           .collection('test')
-          .where('foo', 'not-in', [1, 2])
-          .where('foo', 'not-in', [2, 3])
+          .where('foo', notInOp, [1, 2])
+          .where('foo', notInOp, [2, 3])
       ).to.throw(
         "Invalid query. You cannot use more than one 'not-in' filter."
       );
@@ -1304,7 +1289,7 @@ apiDescribe('Validation:', (persistence: boolean) => {
       expect(() =>
         db
           .collection('test')
-          .where('foo', 'not-in', [2, 3])
+          .where('foo', notInOp, [2, 3])
           .where('foo', 'array-contains-any', [2, 3])
       ).to.throw(
         "Invalid query. You cannot use 'array-contains-any' filters with " +
@@ -1315,7 +1300,7 @@ apiDescribe('Validation:', (persistence: boolean) => {
         db
           .collection('test')
           .where('foo', 'array-contains-any', [2, 3])
-          .where('foo', 'not-in', [2, 3])
+          .where('foo', notInOp, [2, 3])
       ).to.throw(
         "Invalid query. You cannot use 'not-in' filters with " +
           "'array-contains-any' filters."
@@ -1324,7 +1309,7 @@ apiDescribe('Validation:', (persistence: boolean) => {
       expect(() =>
         db
           .collection('test')
-          .where('foo', 'not-in', [2, 3])
+          .where('foo', notInOp, [2, 3])
           .where('foo', 'in', [2, 3])
       ).to.throw(
         "Invalid query. You cannot use 'in' filters with 'not-in' filters."
@@ -1334,7 +1319,7 @@ apiDescribe('Validation:', (persistence: boolean) => {
         db
           .collection('test')
           .where('foo', 'in', [2, 3])
-          .where('foo', 'not-in', [2, 3])
+          .where('foo', notInOp, [2, 3])
       ).to.throw(
         "Invalid query. You cannot use 'not-in' filters with 'in' filters."
       );
@@ -1365,7 +1350,7 @@ apiDescribe('Validation:', (persistence: boolean) => {
       expect(() =>
         db
           .collection('test')
-          .where('foo', 'not-in', [2, 3])
+          .where('foo', notInOp, [2, 3])
           .where('foo', 'array-contains', 2)
           .where('foo', 'array-contains-any', [2])
       ).to.throw(
@@ -1378,7 +1363,7 @@ apiDescribe('Validation:', (persistence: boolean) => {
           .collection('test')
           .where('foo', 'array-contains', 2)
           .where('foo', 'in', [2])
-          .where('foo', 'not-in', [2, 3])
+          .where('foo', notInOp, [2, 3])
       ).to.throw(
         "Invalid query. You cannot use 'not-in' filters with " +
           "'array-contains' filters."

--- a/packages/firestore/test/integration/util/helpers.ts
+++ b/packages/firestore/test/integration/util/helpers.ts
@@ -276,3 +276,13 @@ export function withTestCollectionSettings(
     }
   );
 }
+
+// TODO(ne-queries): This exists just so we don't have to do the cast
+// repeatedly. Once we expose '!=' publicly we can remove it and just use '!='
+// in all the tests.
+export const notEqualOp = '!=' as firestore.WhereFilterOp;
+
+// TODO(ne-queries): This exists just so we don't have to do the cast
+// repeatedly. Once we expose 'not-in' publicly we can remove it and just use 'in'
+// in all the tests.
+export const notInOp = 'not-in' as firestore.WhereFilterOp;

--- a/packages/firestore/test/unit/core/query.test.ts
+++ b/packages/firestore/test/unit/core/query.test.ts
@@ -677,7 +677,7 @@ describe('Query', () => {
     );
     assertCanonicalId(
       query('collection', filter('a', 'not-in', [1, 2, 3])),
-      'collection|f:anot-in[1,2,3]|ob:aasc,__name__asc'
+      'collection|f:anot-in[1,2,3]|ob:__name__asc'
     );
     assertCanonicalId(
       query('collection', filter('a', 'array-contains-any', [1, 2, 3])),


### PR DESCRIPTION
Reverting #3772 since the launch-cal for != queries won't get approved before the M80 release.

