### PR TITLE
Remove isomorphic-fetch dependency

### DIFF
--- a/packages-exp/functions-exp/package.json
+++ b/packages-exp/functions-exp/package.json
@@ -54,8 +54,9 @@
     "@firebase/functions-types-exp": "0.0.800",
     "@firebase/messaging-types": "0.5.0",
     "@firebase/util": "0.3.2",
-    "isomorphic-fetch": "2.2.1",
-    "tslib": "^1.11.1"
+    "node-fetch": "2.6.1",
+    "tslib": "^1.11.1",
+    "whatwg-fetch": "3.4.1"
   },
   "nyc": {
     "extension": [

--- a/packages-exp/functions-exp/package.json
+++ b/packages-exp/functions-exp/package.json
@@ -55,8 +55,7 @@
     "@firebase/messaging-types": "0.5.0",
     "@firebase/util": "0.3.2",
     "node-fetch": "2.6.1",
-    "tslib": "^1.11.1",
-    "whatwg-fetch": "3.4.1"
+    "tslib": "^1.11.1"
   },
   "nyc": {
     "extension": [

--- a/packages-exp/functions-exp/src/config.ts
+++ b/packages-exp/functions-exp/src/config.ts
@@ -27,23 +27,29 @@ import { FUNCTIONS_TYPE } from './constants';
 
 export const DEFAULT_REGION = 'us-central1';
 
-const factory: InstanceFactory<'functions'> = (
-  container: ComponentContainer,
-  region?: string
-) => {
-  // Dependencies
-  const app = container.getProvider('app-exp').getImmediate();
-  const authProvider = container.getProvider('auth-internal');
-  const messagingProvider = container.getProvider('messaging');
-
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  return new FunctionsService(app, authProvider, messagingProvider, region);
-};
-
-export function registerFunctions(): void {
+export function registerFunctions(fetchImpl: typeof fetch): void {
   const namespaceExports = {
     // no-inline
     Functions: FunctionsService
+  };
+
+  const factory: InstanceFactory<'functions'> = (
+    container: ComponentContainer,
+    region?: string
+  ) => {
+    // Dependencies
+    const app = container.getProvider('app-exp').getImmediate();
+    const authProvider = container.getProvider('auth-internal');
+    const messagingProvider = container.getProvider('messaging');
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return new FunctionsService(
+      app,
+      authProvider,
+      messagingProvider,
+      region,
+      fetchImpl
+    );
   };
 
   _registerComponent(

--- a/packages-exp/functions-exp/src/config.ts
+++ b/packages-exp/functions-exp/src/config.ts
@@ -28,11 +28,6 @@ import { FUNCTIONS_TYPE } from './constants';
 export const DEFAULT_REGION = 'us-central1';
 
 export function registerFunctions(fetchImpl: typeof fetch): void {
-  const namespaceExports = {
-    // no-inline
-    Functions: FunctionsService
-  };
-
   const factory: InstanceFactory<'functions'> = (
     container: ComponentContainer,
     region?: string
@@ -53,8 +48,10 @@ export function registerFunctions(fetchImpl: typeof fetch): void {
   };
 
   _registerComponent(
-    new Component(FUNCTIONS_TYPE, factory, ComponentType.PUBLIC)
-      .setServiceProps(namespaceExports)
-      .setMultipleInstances(true)
+    new Component(
+      FUNCTIONS_TYPE,
+      factory,
+      ComponentType.PUBLIC
+    ).setMultipleInstances(true)
   );
 }

--- a/packages-exp/functions-exp/src/index.node.ts
+++ b/packages-exp/functions-exp/src/index.node.ts
@@ -23,7 +23,7 @@ import { name, version } from '../package.json';
 
 /**
  * Patch global object with node-fetch. whatwg-fetch polyfill patches other global
- * fetch objects such as Headers. Then we override the implemenation of `fetch()`
+ * fetch types such as Headers. Then we override the implemenation of `fetch()`
  * itself with node-fetch.
  * https://github.com/node-fetch/node-fetch#loading-and-configuring-the-module
  * node-fetch type deviates somewhat from fetch spec:

--- a/packages-exp/functions-exp/src/index.node.ts
+++ b/packages-exp/functions-exp/src/index.node.ts
@@ -16,23 +16,12 @@
  */
 import { registerVersion } from '@firebase/app-exp';
 import { registerFunctions } from './config';
-import 'whatwg-fetch';
 import nodeFetch from 'node-fetch';
 
 import { name, version } from '../package.json';
 
-/**
- * Patch global object with node-fetch. whatwg-fetch polyfill patches other global
- * fetch types such as Headers. Then we override the implemenation of `fetch()`
- * itself with node-fetch.
- * https://github.com/node-fetch/node-fetch#loading-and-configuring-the-module
- * node-fetch type deviates somewhat from fetch spec:
- * https://github.com/apollographql/apollo-link/issues/513#issuecomment-548219023
- */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-(global as any).fetch = (nodeFetch as unknown) as typeof fetch;
-
 export * from './api';
 
-registerFunctions();
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+registerFunctions(nodeFetch as any);
 registerVersion(name, version, 'node');

--- a/packages-exp/functions-exp/src/index.node.ts
+++ b/packages-exp/functions-exp/src/index.node.ts
@@ -16,9 +16,20 @@
  */
 import { registerVersion } from '@firebase/app-exp';
 import { registerFunctions } from './config';
-import 'isomorphic-fetch';
+import 'whatwg-fetch';
+import nodeFetch from 'node-fetch';
 
 import { name, version } from '../package.json';
+
+/**
+ * Patch global object with node-fetch. whatwg-fetch polyfill patches other global
+ * fetch objects such as Headers. Then we override the implemenation of `fetch()`
+ * itself with node-fetch.
+ * https://github.com/node-fetch/node-fetch#loading-and-configuring-the-module
+ * node-fetch type deviates somewhat from fetch spec:
+ * https://github.com/apollographql/apollo-link/issues/513#issuecomment-548219023
+ */
+globalThis.fetch = (nodeFetch as unknown) as typeof fetch;
 
 export * from './api';
 

--- a/packages-exp/functions-exp/src/index.node.ts
+++ b/packages-exp/functions-exp/src/index.node.ts
@@ -29,7 +29,8 @@ import { name, version } from '../package.json';
  * node-fetch type deviates somewhat from fetch spec:
  * https://github.com/apollographql/apollo-link/issues/513#issuecomment-548219023
  */
-globalThis.fetch = (nodeFetch as unknown) as typeof fetch;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(global as any).fetch = (nodeFetch as unknown) as typeof fetch;
 
 export * from './api';
 

--- a/packages-exp/functions-exp/src/index.ts
+++ b/packages-exp/functions-exp/src/index.ts
@@ -21,5 +21,5 @@ import { name, version } from '../package.json';
 
 export * from './api';
 
-registerFunctions();
+registerFunctions(fetch);
 registerVersion(name, version);

--- a/packages-exp/functions-exp/test/utils.ts
+++ b/packages-exp/functions-exp/test/utils.ts
@@ -21,6 +21,7 @@ import { FirebaseAuthInternalName } from '@firebase/auth-interop-types';
 import { FirebaseMessagingName } from '@firebase/messaging-types';
 import { FunctionsService } from '../src/service';
 import { useFunctionsEmulator } from '../src/api';
+import nodeFetch from 'node-fetch';
 
 export function makeFakeApp(options: FirebaseOptions = {}): FirebaseApp {
   options = {
@@ -52,11 +53,14 @@ export function createTestService(
     new ComponentContainer('test')
   )
 ): FunctionsService {
+  const fetchImpl: typeof fetch =
+    typeof window !== 'undefined' ? fetch.bind(window) : (nodeFetch as any);
   const functions = new FunctionsService(
     app,
     authProvider,
     messagingProvider,
-    region
+    region,
+    fetchImpl
   );
   const useEmulator = !!process.env.FIREBASE_FUNCTIONS_EMULATOR_ORIGIN;
   if (useEmulator) {

--- a/packages/functions/index.node.ts
+++ b/packages/functions/index.node.ts
@@ -30,7 +30,8 @@ import { name, version } from './package.json';
  * node-fetch type deviates somewhat from fetch spec:
  * https://github.com/apollographql/apollo-link/issues/513#issuecomment-548219023
  */
-globalThis.fetch = (nodeFetch as unknown) as typeof fetch;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(global as any).fetch = (nodeFetch as unknown) as typeof fetch;
 
 registerFunctions(firebase as _FirebaseNamespace);
 firebase.registerVersion(name, version, 'node');

--- a/packages/functions/index.node.ts
+++ b/packages/functions/index.node.ts
@@ -24,7 +24,7 @@ import { name, version } from './package.json';
 
 /**
  * Patch global object with node-fetch. whatwg-fetch polyfill patches other global
- * fetch objects such as Headers. Then we override the implemenation of `fetch()`
+ * fetch types such as Headers. Then we override the implemenation of `fetch()`
  * itself with node-fetch.
  * https://github.com/node-fetch/node-fetch#loading-and-configuring-the-module
  * node-fetch type deviates somewhat from fetch spec:

--- a/packages/functions/index.node.ts
+++ b/packages/functions/index.node.ts
@@ -17,21 +17,10 @@
 import firebase from '@firebase/app';
 import { _FirebaseNamespace } from '@firebase/app-types/private';
 import { registerFunctions } from './src/config';
-import 'whatwg-fetch';
 import nodeFetch from 'node-fetch';
 
 import { name, version } from './package.json';
 
-/**
- * Patch global object with node-fetch. whatwg-fetch polyfill patches other global
- * fetch types such as Headers. Then we override the implemenation of `fetch()`
- * itself with node-fetch.
- * https://github.com/node-fetch/node-fetch#loading-and-configuring-the-module
- * node-fetch type deviates somewhat from fetch spec:
- * https://github.com/apollographql/apollo-link/issues/513#issuecomment-548219023
- */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-(global as any).fetch = (nodeFetch as unknown) as typeof fetch;
-
-registerFunctions(firebase as _FirebaseNamespace);
+registerFunctions(firebase as _FirebaseNamespace, nodeFetch as any);
 firebase.registerVersion(name, version, 'node');

--- a/packages/functions/index.node.ts
+++ b/packages/functions/index.node.ts
@@ -17,9 +17,20 @@
 import firebase from '@firebase/app';
 import { _FirebaseNamespace } from '@firebase/app-types/private';
 import { registerFunctions } from './src/config';
-import 'isomorphic-fetch';
+import 'whatwg-fetch';
+import nodeFetch from 'node-fetch';
 
 import { name, version } from './package.json';
+
+/**
+ * Patch global object with node-fetch. whatwg-fetch polyfill patches other global
+ * fetch objects such as Headers. Then we override the implemenation of `fetch()`
+ * itself with node-fetch.
+ * https://github.com/node-fetch/node-fetch#loading-and-configuring-the-module
+ * node-fetch type deviates somewhat from fetch spec:
+ * https://github.com/apollographql/apollo-link/issues/513#issuecomment-548219023
+ */
+globalThis.fetch = (nodeFetch as unknown) as typeof fetch;
 
 registerFunctions(firebase as _FirebaseNamespace);
 firebase.registerVersion(name, version, 'node');

--- a/packages/functions/index.ts
+++ b/packages/functions/index.ts
@@ -21,7 +21,7 @@ import { registerFunctions } from './src/config';
 
 import { name, version } from './package.json';
 
-registerFunctions(firebase as _FirebaseNamespace);
+registerFunctions(firebase as _FirebaseNamespace, fetch);
 firebase.registerVersion(name, version);
 
 declare module '@firebase/app-types' {

--- a/packages/functions/package.json
+++ b/packages/functions/package.json
@@ -7,7 +7,9 @@
   "browser": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
   "esm2017": "dist/index.esm2017.js",
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "lint": "eslint -c .eslintrc.js '**/*.ts' --ignore-path '../../.gitignore'",
     "lint:fix": "eslint --fix -c .eslintrc.js '**/*.ts' --ignore-path '../../.gitignore'",
@@ -45,11 +47,12 @@
   },
   "typings": "dist/index.d.ts",
   "dependencies": {
+    "@firebase/component": "0.1.19",
     "@firebase/functions-types": "0.3.17",
     "@firebase/messaging-types": "0.5.0",
-    "@firebase/component": "0.1.19",
-    "isomorphic-fetch": "2.2.1",
-    "tslib": "^1.11.1"
+    "node-fetch": "2.6.1",
+    "tslib": "^1.11.1",
+    "whatwg-fetch": "3.4.1"
   },
   "nyc": {
     "extension": [

--- a/packages/functions/package.json
+++ b/packages/functions/package.json
@@ -51,8 +51,7 @@
     "@firebase/functions-types": "0.3.17",
     "@firebase/messaging-types": "0.5.0",
     "node-fetch": "2.6.1",
-    "tslib": "^1.11.1",
-    "whatwg-fetch": "3.4.1"
+    "tslib": "^1.11.1"
   },
   "nyc": {
     "extension": [

--- a/packages/functions/src/api/service.ts
+++ b/packages/functions/src/api/service.ts
@@ -96,7 +96,8 @@ export class Service implements FirebaseFunctions, FirebaseService {
     private app_: FirebaseApp,
     authProvider: Provider<FirebaseAuthInternalName>,
     messagingProvider: Provider<FirebaseMessagingName>,
-    private region_: string = 'us-central1'
+    private region_: string = 'us-central1',
+    readonly fetchImpl: typeof fetch
   ) {
     this.contextProvider = new ContextProvider(authProvider, messagingProvider);
     // Cancels all ongoing requests when resolved.
@@ -162,13 +163,13 @@ export class Service implements FirebaseFunctions, FirebaseService {
   private async postJSON(
     url: string,
     body: {},
-    headers: Headers
+    headers: { [key: string]: string }
   ): Promise<HttpResponse> {
-    headers.append('Content-Type', 'application/json');
+    headers['Content-Type'] = 'application/json';
 
     let response: Response;
     try {
-      response = await fetch(url, {
+      response = await this.fetchImpl(url, {
         method: 'POST',
         body: JSON.stringify(body),
         headers
@@ -212,13 +213,13 @@ export class Service implements FirebaseFunctions, FirebaseService {
     const body = { data };
 
     // Add a header for the authToken.
-    const headers = new Headers();
+    const headers: { [key: string]: string } = {};
     const context = await this.contextProvider.getContext();
     if (context.authToken) {
-      headers.append('Authorization', 'Bearer ' + context.authToken);
+      headers['Authorization'] = 'Bearer ' + context.authToken;
     }
     if (context.instanceIdToken) {
-      headers.append('Firebase-Instance-ID-Token', context.instanceIdToken);
+      headers['Firebase-Instance-ID-Token'] = context.instanceIdToken;
     }
 
     // Default timeout to 70s, but let the options override it.

--- a/packages/functions/src/config.ts
+++ b/packages/functions/src/config.ts
@@ -28,21 +28,24 @@ import { _FirebaseNamespace } from '@firebase/app-types/private';
  */
 const FUNCTIONS_TYPE = 'functions';
 
-function factory(container: ComponentContainer, region?: string): Service {
-  // Dependencies
-  const app = container.getProvider('app').getImmediate();
-  const authProvider = container.getProvider('auth-internal');
-  const messagingProvider = container.getProvider('messaging');
-
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  return new Service(app, authProvider, messagingProvider, region);
-}
-
-export function registerFunctions(instance: _FirebaseNamespace): void {
+export function registerFunctions(
+  instance: _FirebaseNamespace,
+  fetchImpl: typeof fetch
+): void {
   const namespaceExports = {
     // no-inline
     Functions: Service
   };
+
+  function factory(container: ComponentContainer, region?: string): Service {
+    // Dependencies
+    const app = container.getProvider('app').getImmediate();
+    const authProvider = container.getProvider('auth-internal');
+    const messagingProvider = container.getProvider('messaging');
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return new Service(app, authProvider, messagingProvider, region, fetchImpl);
+  }
   instance.INTERNAL.registerComponent(
     new Component(FUNCTIONS_TYPE, factory, ComponentType.PUBLIC)
       .setServiceProps(namespaceExports)

--- a/packages/functions/test/utils.ts
+++ b/packages/functions/test/utils.ts
@@ -20,6 +20,7 @@ import { Provider, ComponentContainer } from '@firebase/component';
 import { FirebaseAuthInternalName } from '@firebase/auth-interop-types';
 import { FirebaseMessagingName } from '@firebase/messaging-types';
 import { Service } from '../src/api/service';
+import nodeFetch from 'node-fetch';
 
 export function makeFakeApp(options: FirebaseOptions = {}): FirebaseApp {
   options = {
@@ -52,7 +53,15 @@ export function createTestService(
     new ComponentContainer('test')
   )
 ): Service {
-  const functions = new Service(app, authProvider, messagingProvider, region);
+  const fetchImpl: typeof fetch =
+    typeof window !== 'undefined' ? fetch.bind(window) : (nodeFetch as any);
+  const functions = new Service(
+    app,
+    authProvider,
+    messagingProvider,
+    region,
+    fetchImpl
+  );
   const useEmulator = !!process.env.FIREBASE_FUNCTIONS_EMULATOR_ORIGIN;
   if (useEmulator) {
     functions.useFunctionsEmulator(

--- a/yarn.lock
+++ b/yarn.lock
@@ -8934,7 +8934,7 @@ is-stream-ended@^0.1.4:
   resolved "https://registry.npmjs.org/is-stream-ended/-/is-stream-ended-0.1.4.tgz#f50224e95e06bce0e356d440a4827cd35b267eda"
   integrity sha512-xj0XPvmr7bQFTvirqnFr50o0hQIh6ZItDqloxt5aJrR4NQsYeSsyFQERYGCAzfindAcnKjINnwEEgLx4IqVzQw==
 
-is-stream@^1.0.0, is-stream@^1.0.1, is-stream@^1.1.0:
+is-stream@^1.0.0, is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
   integrity sha1-EtSj3U5o4Lec6428hBc66A2RykQ=
@@ -9074,14 +9074,6 @@ isobject@^3.0.0, isobject@^3.0.1:
   version "3.0.1"
   resolved "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
   integrity sha1-TkMekrEalzFjaqH5yNHMvP2reN8=
-
-isomorphic-fetch@2.2.1:
-  version "2.2.1"
-  resolved "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz#611ae1acf14f5e81f729507472819fe9733558a9"
-  integrity sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=
-  dependencies:
-    node-fetch "^1.0.1"
-    whatwg-fetch ">=0.10.0"
 
 isstream@~0.1.2:
   version "0.1.2"
@@ -11099,14 +11091,6 @@ node-fetch@2.6.1, node-fetch@^2.2.0, node-fetch@^2.3.0, node-fetch@^2.5.0, node-
   version "2.6.1"
   resolved "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
   integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
-
-node-fetch@^1.0.1:
-  version "1.7.3"
-  resolved "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz#980f6f72d85211a5347c6b2bc18c5b84c3eb47ef"
-  integrity sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==
-  dependencies:
-    encoding "^0.1.11"
-    is-stream "^1.0.1"
 
 node-forge@^0.10.0:
   version "0.10.0"
@@ -14361,7 +14345,6 @@ symbol-observable@^1.1.0:
 
 "sync-promise@git+https://github.com/brettz9/sync-promise.git#full-sync-missing-promise-features":
   version "1.0.1"
-  uid "25845a49a00aa2d2c985a5149b97c86a1fcdc75a"
   resolved "git+https://github.com/brettz9/sync-promise.git#25845a49a00aa2d2c985a5149b97c86a1fcdc75a"
 
 table@^5.2.3:
@@ -15670,7 +15653,6 @@ websocket-extensions@>=0.1.1:
 
 "websql@git+https://github.com/brettz9/node-websql.git#configurable-secure2":
   version "1.0.0"
-  uid "5149bc0763376ca757fc32dc74345ada0467bfbb"
   resolved "git+https://github.com/brettz9/node-websql.git#5149bc0763376ca757fc32dc74345ada0467bfbb"
   dependencies:
     argsarray "^0.0.1"
@@ -15684,7 +15666,7 @@ whatwg-fetch@2.0.4:
   resolved "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz#dde6a5df315f9d39991aa17621853d720b85566f"
   integrity sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng==
 
-whatwg-fetch@>=0.10.0:
+whatwg-fetch@3.4.1:
   version "3.4.1"
   resolved "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.4.1.tgz#e5f871572d6879663fa5674c8f833f15a8425ab3"
   integrity sha512-sofZVzE1wKwO+EYPbWfiwzaKovWiZXf4coEzjGP9b2GBVgQRLQUZ2QcuPpQExGDAW5GItpEm6Tl4OU5mywnAoQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -15666,11 +15666,6 @@ whatwg-fetch@2.0.4:
   resolved "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz#dde6a5df315f9d39991aa17621853d720b85566f"
   integrity sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng==
 
-whatwg-fetch@3.4.1:
-  version "3.4.1"
-  resolved "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.4.1.tgz#e5f871572d6879663fa5674c8f833f15a8425ab3"
-  integrity sha512-sofZVzE1wKwO+EYPbWfiwzaKovWiZXf4coEzjGP9b2GBVgQRLQUZ2QcuPpQExGDAW5GItpEm6Tl4OU5mywnAoQ==
-
 whatwg-mimetype@^2.3.0:
   version "2.3.0"
   resolved "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz#3d4b1e0312d2079879f826aff18dbeeca5960fbf"


### PR DESCRIPTION
The `isomorphic-fetch` dependency has not been updated in years and depends on an older version of `node-fetch` which has now been discovered to have security issues. Removing isomorphic-fetch and consuming node-fetch directly.

I tried another approach that involved passing the node-fetch implementation directly into the functions service, but it involved passing through many layers, and since it is passed into the Service constructor, the `createTestService` test util function needs to detect the environment and pass the correct fetch implementation as well which seems like a lot of places. This seems like the simplest approach and only touches the `index.node.ts` file.

Fixes https://github.com/firebase/firebase-js-sdk/issues/3768