### PR TITLE
Hide converter from Public API

### DIFF
--- a/packages/firestore/exp/src/api/reference.ts
+++ b/packages/firestore/exp/src/api/reference.ts
@@ -317,7 +317,10 @@ export function addDoc<T>(
   firestore._verifyNotTerminated();
 
   const docRef = doc(reference);
-  const convertedValue = applyFirestoreDataConverter(reference.converter, data);
+  const convertedValue = applyFirestoreDataConverter(
+    reference._converter,
+    data
+  );
 
   const dataReader = newUserDataReader(reference.firestore);
   const parsed = parseSetData(
@@ -325,7 +328,7 @@ export function addDoc<T>(
     'addDoc',
     docRef._key,
     convertedValue,
-    reference.converter !== null,
+    reference._converter !== null,
     {}
   );
 

--- a/packages/firestore/exp/src/api/snapshot.ts
+++ b/packages/firestore/exp/src/api/snapshot.ts
@@ -232,7 +232,7 @@ export class QuerySnapshot<T = DocumentData> {
       doc.key,
       doc,
       new SnapshotMetadata(hasPendingWrites, fromCache),
-      this.query.converter
+      this.query._converter
     );
   }
 }

--- a/packages/firestore/lite/src/api/reference.ts
+++ b/packages/firestore/lite/src/api/reference.ts
@@ -108,10 +108,10 @@ export class DocumentReference<T = DocumentData> extends _DocumentKeyReference<
 
   constructor(
     readonly firestore: FirebaseFirestore,
-    readonly converter: FirestoreDataConverter<T> | null,
+    _converter: FirestoreDataConverter<T> | null,
     readonly _path: ResourcePath
   ) {
-    super(firestore._databaseId, new DocumentKey(_path), converter);
+    super(firestore._databaseId, new DocumentKey(_path), _converter);
   }
 
   get id(): string {
@@ -154,7 +154,7 @@ export class Query<T = DocumentData> {
   // This is the lite version of the Query class in the main SDK.
   constructor(
     readonly firestore: FirebaseFirestore,
-    readonly converter: FirestoreDataConverter<T> | null,
+    readonly _converter: FirestoreDataConverter<T> | null,
     readonly _query: InternalQuery
   ) {}
 
@@ -217,7 +217,7 @@ class QueryFilterConstraint extends QueryConstraint {
     );
     return new Query(
       query.firestore,
-      query.converter,
+      query._converter,
       queryWithAddedFilter(query._query, filter)
     );
   }
@@ -259,7 +259,7 @@ class QueryOrderByConstraint extends QueryConstraint {
     const orderBy = newQueryOrderBy(query._query, this._field, this._direction);
     return new Query(
       query.firestore,
-      query.converter,
+      query._converter,
       queryWithAddedOrderBy(query._query, orderBy)
     );
   }
@@ -290,7 +290,7 @@ class QueryLimitConstraint extends QueryConstraint {
   _apply<T>(query: Query<T>): Query<T> {
     return new Query(
       query.firestore,
-      query.converter,
+      query._converter,
       queryWithLimit(query._query, this._limit, this._limitType)
     );
   }
@@ -324,7 +324,7 @@ class QueryStartAtConstraint extends QueryConstraint {
     );
     return new Query(
       query.firestore,
-      query.converter,
+      query._converter,
       queryWithStartAt(query._query, bound)
     );
   }
@@ -364,7 +364,7 @@ class QueryEndAtConstraint extends QueryConstraint {
     );
     return new Query(
       query.firestore,
-      query.converter,
+      query._converter,
       queryWithEndAt(query._query, bound)
     );
   }
@@ -452,7 +452,7 @@ export class CollectionReference<T = DocumentData> extends Query<T> {
     validateNonEmptyArgument('CollectionReference.doc', 'path', path);
     const absolutePath = this._path.child(ResourcePath.fromString(path!));
     validateDocumentPath(absolutePath);
-    return new DocumentReference(this.firestore, this.converter, absolutePath);
+    return new DocumentReference(this.firestore, this._converter, absolutePath);
   }
 
   withConverter<U>(
@@ -578,7 +578,7 @@ export function doc<T>(
     validateDocumentPath(absolutePath);
     return new DocumentReference(
       parent.firestore,
-      parent instanceof CollectionReference ? parent.converter : null,
+      parent instanceof CollectionReference ? parent._converter : null,
       absolutePath
     );
   }
@@ -613,7 +613,7 @@ export function getDocs<T>(query: Query<T>): Promise<QuerySnapshot<T>> {
           query.firestore,
           doc.key,
           doc,
-          query.converter
+          query._converter
         )
     );
 
@@ -724,7 +724,10 @@ export function addDoc<T>(
 ): Promise<DocumentReference<T>> {
   const docRef = doc(reference);
 
-  const convertedValue = applyFirestoreDataConverter(reference.converter, data);
+  const convertedValue = applyFirestoreDataConverter(
+    reference._converter,
+    data
+  );
 
   const dataReader = newUserDataReader(reference.firestore);
   const parsed = parseSetData(
@@ -755,7 +758,7 @@ export function refEqual<T>(
     return (
       left.firestore === right.firestore &&
       left.path === right.path &&
-      left.converter === right.converter
+      left._converter === right._converter
     );
   }
   return false;
@@ -766,7 +769,7 @@ export function queryEqual<T>(left: Query<T>, right: Query<T>): boolean {
     return (
       left.firestore === right.firestore &&
       queryEquals(left._query, right._query) &&
-      left.converter === right.converter
+      left._converter === right._converter
     );
   }
   return false;


### PR DESCRIPTION
The converter property is currently not part of our public API, and as such it should be prefixed with an underscore

This is firestore-exp/lite only.