### PR TITLE
Address negative zero lint validation

### DIFF
--- a/.changeset/moody-jobs-deliver.md
+++ b/.changeset/moody-jobs-deliver.md
@@ -1,0 +1,5 @@
+---
+"@firebase/firestore": patch
+---
+
+Fixes a "Comparison with -0" lint warning for customers that build from source.

--- a/packages/firestore/src/util/types.ts
+++ b/packages/firestore/src/util/types.ts
@@ -31,7 +31,7 @@ export function isNullOrUndefined(value: unknown): value is null | undefined {
 export function isNegativeZero(value: number): boolean {
   // Detect if the value is -0.0. Based on polyfill from
   // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/is
-  return value === -0 && 1 / value === 1 / -0;
+  return value === 0 && 1 / value === 1 / -0;
 }
 
 /**


### PR DESCRIPTION
It should not matter whether we check for "value === 0.0" or "value === -0.0" since JS treats them equal. This change should silence a lint error that is blocking one of our customers.

Fixes https://github.com/firebase/firebase-js-sdk/issues/3814