### PR TITLE
Support waitForPendingWrites in secondary tabs

### DIFF
--- a/.changeset/mean-queens-roll.md
+++ b/.changeset/mean-queens-roll.md
@@ -1,0 +1,5 @@
+---
+"@firebase/firestore": patch
+---
+
+Fixes an issue that prevent `waitForPendingWrites()` to resolve in background tabs when multi-tab is used.

--- a/.changeset/mean-queens-roll.md
+++ b/.changeset/mean-queens-roll.md
@@ -2,4 +2,4 @@
 "@firebase/firestore": patch
 ---
 
-Fixes an issue that prevents `waitForPendingWrites()` from resolving in background tabs when multi-tab is used.
+Fixes an issue that prevents `waitForPendingWrites()` from resolving in background tabs when multi-tab is used (https://github.com/firebase/firebase-js-sdk/issues/3816).

--- a/.changeset/mean-queens-roll.md
+++ b/.changeset/mean-queens-roll.md
@@ -2,4 +2,4 @@
 "@firebase/firestore": patch
 ---
 
-Fixes an issue that prevent `waitForPendingWrites()` to resolve in background tabs when multi-tab is used.
+Fixes an issue that prevents `waitForPendingWrites()` from resolving in background tabs when multi-tab is used.

--- a/packages/firestore/src/core/sync_engine.ts
+++ b/packages/firestore/src/core/sync_engine.ts
@@ -1185,6 +1185,7 @@ export async function applyBatchState(
     // NOTE: Both these methods are no-ops for batches that originated from
     // other clients.
     processUserCallback(syncEngineImpl, batchId, error ? error : null);
+    triggerPendingWritesCallbacks(syncEngineImpl, batchId);
     removeCachedMutationBatchMetadata(syncEngineImpl.localStore, batchId);
   } else {
     fail(`Unknown batchState: ${batchState}`);

--- a/packages/firestore/test/unit/specs/spec_builder.ts
+++ b/packages/firestore/test/unit/specs/spec_builder.ts
@@ -793,6 +793,14 @@ export class SpecBuilder {
     return this;
   }
 
+  waitForPendingWrites(): this {
+    this.nextStep();
+    this.currentStep = {
+      waitForPendingWrites: true
+    };
+    return this;
+  }
+
   expectUserCallbacks(docs: {
     acknowledged?: string[];
     rejected?: string[];
@@ -941,6 +949,13 @@ export class SpecBuilder {
     this.assertStep('Expectations require previous step');
     const currentStep = this.currentStep!;
     currentStep.expectedSnapshotsInSyncEvents = count;
+    return this;
+  }
+
+  expectWaitForPendingWritesEvent(count = 1): this {
+    this.assertStep('Expectations require previous step');
+    const currentStep = this.currentStep!;
+    currentStep.expectedWaitForPendingWritesEvents = count;
     return this;
   }
 

--- a/packages/firestore/test/unit/specs/write_spec.test.ts
+++ b/packages/firestore/test/unit/specs/write_spec.test.ts
@@ -1490,4 +1490,117 @@ describeSpec('Writes:', [], () => {
         .expectEvents(query1, { added: [docA, docB], fromCache: true });
     }
   );
+
+  specTest(
+    'Wait for pending writes resolves after write acknowledgment',
+    [],
+    () => {
+      return spec()
+        .userSets('collection/a', { k: 'a' })
+        .userSets('collection/b', { k: 'b' })
+        .waitForPendingWrites()
+        .writeAcks('collection/a', 1001)
+        .failWrite(
+          'collection/b',
+          new RpcError(Code.FAILED_PRECONDITION, 'Write error')
+        )
+        .expectWaitForPendingWritesEvent();
+    }
+  );
+
+  specTest('Wait for pending writes resolves with no writes', [], () => {
+    return spec().waitForPendingWrites().expectWaitForPendingWritesEvent();
+  });
+
+  specTest('Wait for pending writes resolves multiple times', [], () => {
+    return spec()
+      .userSets('collection/a', { k: 'a' })
+      .waitForPendingWrites()
+      .waitForPendingWrites()
+      .writeAcks('collection/a', 1001)
+      .expectWaitForPendingWritesEvent(2);
+  });
+
+  specTest(
+    'Wait for pending writes resolves if another write is issued',
+    [],
+    () => {
+      return spec()
+        .userSets('collection/a', { k: 'a' })
+        .waitForPendingWrites()
+        .userSets('collection/b', { k: 'b' })
+        .writeAcks('collection/a', 1001)
+        .expectWaitForPendingWritesEvent()
+        .writeAcks('collection/b', 1002);
+    }
+  );
+
+  specTest(
+    'Wait for pending writes waits after restart',
+    ['durable-persistence'],
+    () => {
+      return spec()
+        .userSets('collection/a', { k: 'a' })
+        .restart()
+        .waitForPendingWrites()
+        .writeAcks('collection/a', 1001, { expectUserCallback: false })
+        .expectWaitForPendingWritesEvent();
+    }
+  );
+
+  specTest(
+    'Wait for pending writes resolves for write in secondary tab',
+    ['multi-client'],
+    () => {
+      return client(0)
+        .expectPrimaryState(true)
+        .client(1)
+        .userSets('collection/a', { k: 'a' })
+        .waitForPendingWrites()
+        .client(0)
+        .writeAcks('collection/a', 1001, { expectUserCallback: false })
+        .client(1)
+        .expectUserCallbacks({ acknowledged: ['collection/a'] })
+        .expectWaitForPendingWritesEvent();
+    }
+  );
+
+  specTest(
+    'Wait for pending writes resolves independently for different tabs',
+    ['multi-client'],
+    () => {
+      return client(0)
+        .userSets('collection/a', { k: 'a' })
+        .waitForPendingWrites()
+        .client(1)
+        .userSets('collection/b', { k: 'b' })
+        .waitForPendingWrites()
+        .client(2)
+        .userSets('collection/c', { k: 'c' })
+        .waitForPendingWrites()
+        .client(0)
+        .writeAcks('collection/a', 1001)
+        .expectWaitForPendingWritesEvent(/* count= */ 1)
+        .client(1)
+        .expectWaitForPendingWritesEvent(/* count= */ 0)
+        .client(2)
+        .expectWaitForPendingWritesEvent(/* count= */ 0)
+        .client(0)
+        .writeAcks('collection/b', 1002, { expectUserCallback: false })
+        .expectWaitForPendingWritesEvent(/* count= */ 0)
+        .client(1)
+        .expectUserCallbacks({ acknowledged: ['collection/b'] })
+        .expectWaitForPendingWritesEvent(/* count= */ 1)
+        .client(2)
+        .expectWaitForPendingWritesEvent(/* count= */ 0)
+        .client(0)
+        .writeAcks('collection/c', 1003, { expectUserCallback: false })
+        .expectWaitForPendingWritesEvent(/* count= */ 0)
+        .client(1)
+        .expectWaitForPendingWritesEvent(/* count= */ 0)
+        .client(2)
+        .expectUserCallbacks({ acknowledged: ['collection/c'] })
+        .expectWaitForPendingWritesEvent(/* count= */ 1);
+    }
+  );
 });


### PR DESCRIPTION
A user noticed that `waitForPendingWrites` doesn't work in secondary tabs. This is a one line fix + spec tests.

Fixes https://github.com/firebase/firebase-js-sdk/issues/3816