### PR TITLE
Fix app externs type

### DIFF
--- a/packages/firebase/externs/firebase-app-internal-externs.js
+++ b/packages/firebase/externs/firebase-app-internal-externs.js
@@ -20,7 +20,7 @@
  */
 
 /**
- * @param {!firebase.FirebaseComponent}
+ * @param {!Object} component
  */
 firebase.INTERNAL.registerComponent = function (component) {};
 


### PR DESCRIPTION
FirebaseComponent doesn't seem to be defined and for the purposes of app-internal-externs, it probably doesn't need to be. Also got an error on Blaze build for not naming the param. This change mirrors a change I already made in the third_party repo. (internal link: cl/332960756)