### PR TITLE
firebase/analytics => added setCookieFlags method

### DIFF
--- a/packages/analytics-types/index.d.ts
+++ b/packages/analytics-types/index.d.ts
@@ -73,6 +73,11 @@ export interface FirebaseAnalytics {
    * window['ga-disable-analyticsId'] = true;
    */
   setAnalyticsCollectionEnabled(enabled: boolean): void;
+
+  /**
+   * Sets cookie flags on gtag
+   * */
+  setCookieFlags(flags: string, options?: AnalyticsCallOptions): void;
 }
 
 /**

--- a/packages/analytics/src/constants.ts
+++ b/packages/analytics/src/constants.ts
@@ -18,6 +18,7 @@
 // Key to attach FID to in gtag params.
 export const GA_FID_KEY = 'firebase_id';
 export const ORIGIN_KEY = 'origin';
+export const COOKIE_FLAGS = 'cookie_flags';
 
 export const FETCH_TIMEOUT_MILLIS = 60 * 1000;
 

--- a/packages/analytics/src/factory.ts
+++ b/packages/analytics/src/factory.ts
@@ -27,7 +27,8 @@ import {
   setCurrentScreen,
   setUserId,
   setUserProperties,
-  setAnalyticsCollectionEnabled
+  setAnalyticsCollectionEnabled,
+  setCookieFlags
 } from './functions';
 import {
   insertScriptTag,
@@ -270,6 +271,14 @@ export function factory(
       setAnalyticsCollectionEnabled(
         initializationPromisesMap[appId],
         enabled
+      ).catch(e => logger.error(e));
+    },
+    setCookieFlags: (flags: string, options) => {
+      setCookieFlags(
+        wrappedGtagFunction,
+        initializationPromisesMap[appId],
+        flags,
+        options
       ).catch(e => logger.error(e));
     },
     INTERNAL: {

--- a/packages/analytics/src/functions.test.ts
+++ b/packages/analytics/src/functions.test.ts
@@ -23,9 +23,10 @@ import {
   logEvent,
   setUserId,
   setUserProperties,
-  setAnalyticsCollectionEnabled
+  setAnalyticsCollectionEnabled,
+  setCookieFlags
 } from './functions';
-import { GtagCommand, EventName } from './constants';
+import { GtagCommand, EventName, COOKIE_FLAGS } from './constants';
 
 const fakeMeasurementId = 'abcd-efgh-ijkl';
 const fakeInitializationPromise = Promise.resolve(fakeMeasurementId);
@@ -172,6 +173,34 @@ describe('FirebaseAnalytics methods', () => {
     expect(gtagStub).to.be.calledWith(GtagCommand.SET, {
       'user_properties.currency': 'USD',
       'user_properties.language': 'en'
+    });
+  });
+
+  it('setCookieFlags() calls gtag correctly (instance)', async () => {
+    await setCookieFlags(
+      gtagStub,
+      fakeInitializationPromise,
+      'SameSite=None; Secure'
+    );
+    expect(gtagStub).to.have.been.calledWith(
+      GtagCommand.CONFIG,
+      fakeMeasurementId,
+      {
+        [COOKIE_FLAGS]: 'SameSite=None; Secure',
+        update: true
+      }
+    );
+  });
+
+  it('setCookieFlags() calls gtag correctly (global)', async () => {
+    await setCookieFlags(
+      gtagStub,
+      fakeInitializationPromise,
+      'SameSite=None; Secure',
+      { global: true }
+    );
+    expect(gtagStub).to.be.calledWith(GtagCommand.SET, {
+      [COOKIE_FLAGS]: 'SameSite=None; Secure'
     });
   });
 

--- a/packages/analytics/src/functions.ts
+++ b/packages/analytics/src/functions.ts
@@ -22,7 +22,7 @@ import {
   ControlParams,
   EventParams
 } from '@firebase/analytics-types';
-import { GtagCommand } from './constants';
+import { COOKIE_FLAGS, GtagCommand } from './constants';
 /**
  * Logs an analytics event through the Firebase SDK.
  *
@@ -94,6 +94,24 @@ export async function setUserId(
     gtagFunction(GtagCommand.CONFIG, measurementId, {
       update: true,
       'user_id': id
+    });
+  }
+}
+
+export async function setCookieFlags(
+  gtagFunction: Gtag,
+  initializationPromise: Promise<string>,
+  flags: string | null,
+  options?: AnalyticsCallOptions
+): Promise<void> {
+  if (options && options.global) {
+    gtagFunction(GtagCommand.SET, { [COOKIE_FLAGS]: flags });
+    return Promise.resolve();
+  } else {
+    const measurementId = await initializationPromise;
+    gtagFunction(GtagCommand.CONFIG, measurementId, {
+      update: true,
+      [COOKIE_FLAGS]: flags
     });
   }
 }


### PR DESCRIPTION
Hey there! So you want to contribute to a Firebase SDK? 
Before you file this pull request, please read these guidelines:

### Discussion

  * Read the contribution guidelines (CONTRIBUTING.md).
  * If this has been discussed in an issue, make sure to link to the issue here. 
    If not, go file an issue about this **before creating a pull request** to discuss.

Related: #2284
Related: #3504

### Testing

  * Make sure all existing tests in the repository pass after your change.
  * If you fixed a bug or added a feature, add a new test to cover your code.

Added a single method and a test to it.

### API Changes

  * At this time we cannot accept changes that affect the public API.  If you'd like to help 
    us make Firebase APIs better, please propose your change in an issue so that we 
    can discuss it together.

**There are no breaking changes.**

With the addition you are able to pass the `cookie_flags` to gtag. This is especially helpful when you need to use analytics inside an iframe (third party) and need the cookies to be set properly.
Without this method the cookies cannot be set (see screenshot below)

See [here](https://developers.google.com/analytics/devguides/collection/gtagjs/cookies-user-id#cookie_flags) for more information about the `cookie_flags`.

![gtag](https://user-images.githubusercontent.com/22191877/94143770-96527500-fe70-11ea-8fe6-837a66f1d0aa.png)



