### PR TITLE
Fix custom trace event dispatch before initialization for Performance Monitoring

### DIFF
--- a/.changeset/fifty-snakes-shout.md
+++ b/.changeset/fifty-snakes-shout.md
@@ -1,0 +1,6 @@
+---
+'@firebase/performance': patch
+'firebase': patch
+---
+
+Moved `loggingEnabled` check to wait until performance initialization finishes, thus avoid dropping custom traces right after getting `performance` object.

--- a/packages-exp/performance-exp/src/services/perf_logger.test.ts
+++ b/packages-exp/performance-exp/src/services/perf_logger.test.ts
@@ -96,7 +96,7 @@ describe('Performance Monitoring > perf_logger', () => {
   });
 
   describe('logTrace', () => {
-    it('will not drop event before initialization finishes', async () => {
+    it('will not drop custom events sent before initialization finishes', async () => {
       getIidStub.returns(IID);
       stub(attributeUtils, 'getVisibilityState').returns(VISIBILITY_STATE);
       stub(initializationService, 'isPerfInitialized').returns(false);

--- a/packages-exp/performance-exp/src/services/perf_logger.test.ts
+++ b/packages-exp/performance-exp/src/services/perf_logger.test.ts
@@ -70,7 +70,6 @@ describe('Performance Monitoring > perf_logger', () => {
   }
 
   setupApi(self);
-
   const fakeFirebaseApp = ({
     options: { appId: APP_ID }
   } as unknown) as FirebaseApp;
@@ -87,7 +86,6 @@ describe('Performance Monitoring > perf_logger', () => {
     stub(transportService, 'transportHandler').callsFake(mockTransportHandler);
     stub(Api.prototype, 'getUrl').returns(PAGE_URL);
     stub(Api.prototype, 'getTimeOrigin').returns(TIME_ORIGIN);
-    stub(initializationService, 'isPerfInitialized').returns(true);
     stub(attributeUtils, 'getEffectiveConnectionType').returns(
       EFFECTIVE_CONNECTION_TYPE
     );
@@ -98,6 +96,29 @@ describe('Performance Monitoring > perf_logger', () => {
   });
 
   describe('logTrace', () => {
+    it('will not drop event before initialization finishes', async () => {
+      getIidStub.returns(IID);
+      stub(attributeUtils, 'getVisibilityState').returns(VISIBILITY_STATE);
+      stub(initializationService, 'isPerfInitialized').returns(false);
+
+      // Simulates logging being enabled after initialization completes.
+      const initializationPromise = Promise.resolve().then(() => {
+        SettingsService.getInstance().loggingEnabled = true;
+        SettingsService.getInstance().logTraceAfterSampling = true;
+      });
+      stub(initializationService, 'getInitializationPromise').returns(
+        initializationPromise
+      );
+
+      const trace = new Trace(performanceController, TRACE_NAME);
+      trace.record(START_TIME, DURATION);
+      await initializationPromise.then(() => {
+        clock.tick(1);
+      });
+
+      expect(addToQueueStub).to.be.called;
+    });
+
     it('creates, serializes and sends a trace to transport service', () => {
       const EXPECTED_TRACE_MESSAGE =
         `{` +
@@ -107,6 +128,7 @@ describe('Performance Monitoring > perf_logger', () => {
 "counters":{"counter1":3},"custom_attributes":{"attr":"val"}}}`;
       getIidStub.returns(IID);
       stub(attributeUtils, 'getVisibilityState').returns(VISIBILITY_STATE);
+      stub(initializationService, 'isPerfInitialized').returns(true);
       SettingsService.getInstance().loggingEnabled = true;
       SettingsService.getInstance().logTraceAfterSampling = true;
       const trace = new Trace(performanceController, TRACE_NAME);
@@ -124,6 +146,7 @@ describe('Performance Monitoring > perf_logger', () => {
     it('does not log an event if cookies are disabled in the browser', () => {
       stub(Api.prototype, 'requiredApisAvailable').returns(false);
       stub(attributeUtils, 'getVisibilityState').returns(VISIBILITY_STATE);
+      stub(initializationService, 'isPerfInitialized').returns(true);
       const trace = new Trace(performanceController, TRACE_NAME);
       trace.record(START_TIME, DURATION);
       clock.tick(1);
@@ -145,6 +168,7 @@ describe('Performance Monitoring > perf_logger', () => {
 "counter31":31,"counter32":32}}}`;
       getIidStub.returns(IID);
       stub(attributeUtils, 'getVisibilityState').returns(VISIBILITY_STATE);
+      stub(initializationService, 'isPerfInitialized').returns(true);
       SettingsService.getInstance().loggingEnabled = true;
       SettingsService.getInstance().logTraceAfterSampling = true;
       const trace = new Trace(performanceController, TRACE_NAME);
@@ -169,6 +193,7 @@ describe('Performance Monitoring > perf_logger', () => {
 "custom_attributes":{"attr1":"val1","attr2":"val2","attr3":"val3","attr4":"val4","attr5":"val5"}}}`;
       getIidStub.returns(IID);
       stub(attributeUtils, 'getVisibilityState').returns(VISIBILITY_STATE);
+      stub(initializationService, 'isPerfInitialized').returns(true);
       SettingsService.getInstance().loggingEnabled = true;
       SettingsService.getInstance().logTraceAfterSampling = true;
       const trace = new Trace(performanceController, TRACE_NAME);
@@ -198,6 +223,7 @@ describe('Performance Monitoring > perf_logger', () => {
 "client_start_time_us":${flooredStartTime},"duration_us":${DURATION * 1000},\
 "counters":{"domInteractive":10000,"domContentLoadedEventEnd":20000,"loadEventEnd":10000,\
 "_fp":40000,"_fcp":50000,"_fid":90000}}}`;
+      stub(initializationService, 'isPerfInitialized').returns(true);
       getIidStub.returns(IID);
       SettingsService.getInstance().loggingEnabled = true;
       SettingsService.getInstance().logTraceAfterSampling = true;
@@ -303,6 +329,7 @@ describe('Performance Monitoring > perf_logger', () => {
 "response_payload_bytes":${RESOURCE_PERFORMANCE_ENTRY.transferSize},\
 "client_start_time_us":${START_TIME},\
 "time_to_response_completed_us":${TIME_TO_RESPONSE_COMPLETED}}}`;
+      stub(initializationService, 'isPerfInitialized').returns(true);
       getIidStub.returns(IID);
       stub(attributeUtils, 'getVisibilityState').returns(VISIBILITY_STATE);
       SettingsService.getInstance().loggingEnabled = true;
@@ -347,6 +374,7 @@ describe('Performance Monitoring > perf_logger', () => {
         workerStart: 0,
         toJSON: () => {}
       };
+      stub(initializationService, 'isPerfInitialized').returns(true);
       getIidStub.returns(IID);
       SettingsService.getInstance().loggingEnabled = true;
       SettingsService.getInstance().logNetworkAfterSampling = true;
@@ -390,6 +418,7 @@ describe('Performance Monitoring > perf_logger', () => {
         workerStart: 0,
         toJSON: () => {}
       };
+      stub(initializationService, 'isPerfInitialized').returns(true);
       getIidStub.returns(IID);
       SettingsService.getInstance().loggingEnabled = true;
       SettingsService.getInstance().logNetworkAfterSampling = true;

--- a/packages-exp/performance-exp/src/services/perf_logger.ts
+++ b/packages-exp/performance-exp/src/services/perf_logger.ts
@@ -122,13 +122,6 @@ export function logTrace(trace: Trace): void {
     return;
   }
 
-  if (
-    !settingsService.loggingEnabled ||
-    !settingsService.logTraceAfterSampling
-  ) {
-    return;
-  }
-
   if (isPerfInitialized()) {
     sendTraceLog(trace);
   } else {
@@ -142,9 +135,19 @@ export function logTrace(trace: Trace): void {
 }
 
 function sendTraceLog(trace: Trace): void {
-  if (getIid()) {
-    setTimeout(() => sendLog(trace, ResourceType.Trace), 0);
+  if (!getIid()) {
+    return;
   }
+
+  const settingsService = SettingsService.getInstance();
+  if (
+    !settingsService.loggingEnabled ||
+    !settingsService.logTraceAfterSampling
+  ) {
+    return;
+  }
+
+  setTimeout(() => sendLog(trace, ResourceType.Trace), 0);
 }
 
 export function logNetworkRequest(networkRequest: NetworkRequest): void {

--- a/packages/performance/src/services/perf_logger.test.ts
+++ b/packages/performance/src/services/perf_logger.test.ts
@@ -89,6 +89,7 @@ describe('Performance Monitoring > perf_logger', () => {
 
   describe('logTrace', () => {
     it('will not drop event before initialization finishes', () => {
+      getIidStub.returns(IID);
       stub(attributeUtils, 'getVisibilityState').returns(VISIBILITY_STATE);
 
       stub(initializationService, 'isPerfInitialized').returns(false);
@@ -112,8 +113,6 @@ describe('Performance Monitoring > perf_logger', () => {
       process.nextTick;
 
       setTimeout(expect(addToQueueStub).to.be.called, 0);
-      // process.nextTick;
-      // clock.tick(10000);
     });
 
     it('creates, serializes and sends a trace to transport service', () => {

--- a/packages/performance/src/services/perf_logger.test.ts
+++ b/packages/performance/src/services/perf_logger.test.ts
@@ -97,7 +97,7 @@ describe('Performance Monitoring > perf_logger', () => {
         'getInitializationPromise'
       );
 
-      const resolvePerfInitialization = function () {
+      const resolvePerfInitialization = function (): Promise<void> {
         SettingsService.getInstance().loggingEnabled = true;
         SettingsService.getInstance().logTraceAfterSampling = true;
         return new Promise<void>(resolve => {

--- a/packages/performance/src/services/perf_logger.test.ts
+++ b/packages/performance/src/services/perf_logger.test.ts
@@ -90,12 +90,14 @@ describe('Performance Monitoring > perf_logger', () => {
   describe('logTrace', () => {
     it('will not drop event before initialization finishes', async () => {
       getIidStub.returns(IID);
-      SettingsService.getInstance().loggingEnabled = true;
-      SettingsService.getInstance().logTraceAfterSampling = true;
       stub(attributeUtils, 'getVisibilityState').returns(VISIBILITY_STATE);
       stub(initializationService, 'isPerfInitialized').returns(false);
 
-      const initializationPromise = Promise.resolve();
+      // Simulates logging being enabled after initialization completes.
+      const initializationPromise = Promise.resolve().then(() => {
+        SettingsService.getInstance().loggingEnabled = true;
+        SettingsService.getInstance().logTraceAfterSampling = true;
+      });
       stub(initializationService, 'getInitializationPromise').returns(
         initializationPromise
       );

--- a/packages/performance/src/services/perf_logger.test.ts
+++ b/packages/performance/src/services/perf_logger.test.ts
@@ -88,7 +88,7 @@ describe('Performance Monitoring > perf_logger', () => {
   });
 
   describe('logTrace', () => {
-    it('will not drop event before initialization finishes', async () => {
+    it('will not drop custom events sent before initialization finishes', async () => {
       getIidStub.returns(IID);
       stub(attributeUtils, 'getVisibilityState').returns(VISIBILITY_STATE);
       stub(initializationService, 'isPerfInitialized').returns(false);

--- a/packages/performance/src/services/perf_logger.test.ts
+++ b/packages/performance/src/services/perf_logger.test.ts
@@ -75,7 +75,6 @@ describe('Performance Monitoring > perf_logger', () => {
     stub(transportService, 'transportHandler').callsFake(mockTransportHandler);
     stub(Api.prototype, 'getUrl').returns(PAGE_URL);
     stub(Api.prototype, 'getTimeOrigin').returns(TIME_ORIGIN);
-    stub(initializationService, 'isPerfInitialized').returns(true);
     stub(attributeUtils, 'getEffectiveConnectionType').returns(
       EFFECTIVE_CONNECTION_TYPE
     );
@@ -89,6 +88,34 @@ describe('Performance Monitoring > perf_logger', () => {
   });
 
   describe('logTrace', () => {
+    it('will not drop event before initialization finishes', () => {
+      stub(attributeUtils, 'getVisibilityState').returns(VISIBILITY_STATE);
+
+      stub(initializationService, 'isPerfInitialized').returns(false);
+      const getInitializationPromiseStub = stub(
+        initializationService,
+        'getInitializationPromise'
+      );
+
+      const resolvePerfInitialization = function () {
+        SettingsService.getInstance().loggingEnabled = true;
+        SettingsService.getInstance().logTraceAfterSampling = true;
+        return new Promise<void>(resolve => {
+          resolve();
+        });
+      };
+      getInitializationPromiseStub.callsFake(resolvePerfInitialization);
+      // getInitializationPromiseStub.resolves();
+
+      const trace = new Trace(TRACE_NAME);
+      trace.record(START_TIME, DURATION);
+      process.nextTick;
+
+      setTimeout(expect(addToQueueStub).to.be.called, 0);
+      // process.nextTick;
+      // clock.tick(10000);
+    });
+
     it('creates, serializes and sends a trace to transport service', () => {
       const EXPECTED_TRACE_MESSAGE =
         `{` +
@@ -98,6 +125,7 @@ describe('Performance Monitoring > perf_logger', () => {
 "counters":{"counter1":3},"custom_attributes":{"attr":"val"}}}`;
       getIidStub.returns(IID);
       stub(attributeUtils, 'getVisibilityState').returns(VISIBILITY_STATE);
+      stub(initializationService, 'isPerfInitialized').returns(true);
       SettingsService.getInstance().loggingEnabled = true;
       SettingsService.getInstance().logTraceAfterSampling = true;
       const trace = new Trace(TRACE_NAME);
@@ -115,6 +143,7 @@ describe('Performance Monitoring > perf_logger', () => {
     it('does not log an event if cookies are disabled in the browser', () => {
       stub(Api.prototype, 'requiredApisAvailable').returns(false);
       stub(attributeUtils, 'getVisibilityState').returns(VISIBILITY_STATE);
+      stub(initializationService, 'isPerfInitialized').returns(true);
       const trace = new Trace(TRACE_NAME);
       trace.record(START_TIME, DURATION);
       clock.tick(1);
@@ -136,6 +165,7 @@ describe('Performance Monitoring > perf_logger', () => {
 "counter31":31,"counter32":32}}}`;
       getIidStub.returns(IID);
       stub(attributeUtils, 'getVisibilityState').returns(VISIBILITY_STATE);
+      stub(initializationService, 'isPerfInitialized').returns(true);
       SettingsService.getInstance().loggingEnabled = true;
       SettingsService.getInstance().logTraceAfterSampling = true;
       const trace = new Trace(TRACE_NAME);
@@ -160,6 +190,7 @@ describe('Performance Monitoring > perf_logger', () => {
 "custom_attributes":{"attr1":"val1","attr2":"val2","attr3":"val3","attr4":"val4","attr5":"val5"}}}`;
       getIidStub.returns(IID);
       stub(attributeUtils, 'getVisibilityState').returns(VISIBILITY_STATE);
+      stub(initializationService, 'isPerfInitialized').returns(true);
       SettingsService.getInstance().loggingEnabled = true;
       SettingsService.getInstance().logTraceAfterSampling = true;
       const trace = new Trace(TRACE_NAME);
@@ -189,6 +220,7 @@ describe('Performance Monitoring > perf_logger', () => {
 "client_start_time_us":${flooredStartTime},"duration_us":${DURATION * 1000},\
 "counters":{"domInteractive":10000,"domContentLoadedEventEnd":20000,"loadEventEnd":10000,\
 "_fp":40000,"_fcp":50000,"_fid":90000}}}`;
+      stub(initializationService, 'isPerfInitialized').returns(true);
       getIidStub.returns(IID);
       SettingsService.getInstance().loggingEnabled = true;
       SettingsService.getInstance().logTraceAfterSampling = true;
@@ -289,6 +321,7 @@ describe('Performance Monitoring > perf_logger', () => {
 "response_payload_bytes":${RESOURCE_PERFORMANCE_ENTRY.transferSize},\
 "client_start_time_us":${START_TIME},\
 "time_to_response_completed_us":${TIME_TO_RESPONSE_COMPLETED}}}`;
+      stub(initializationService, 'isPerfInitialized').returns(true);
       getIidStub.returns(IID);
       stub(attributeUtils, 'getVisibilityState').returns(VISIBILITY_STATE);
       SettingsService.getInstance().loggingEnabled = true;
@@ -330,6 +363,7 @@ describe('Performance Monitoring > perf_logger', () => {
         workerStart: 0,
         toJSON: () => {}
       };
+      stub(initializationService, 'isPerfInitialized').returns(true);
       getIidStub.returns(IID);
       SettingsService.getInstance().loggingEnabled = true;
       SettingsService.getInstance().logNetworkAfterSampling = true;
@@ -370,6 +404,7 @@ describe('Performance Monitoring > perf_logger', () => {
         workerStart: 0,
         toJSON: () => {}
       };
+      stub(initializationService, 'isPerfInitialized').returns(true);
       getIidStub.returns(IID);
       SettingsService.getInstance().loggingEnabled = true;
       SettingsService.getInstance().logNetworkAfterSampling = true;

--- a/packages/performance/src/services/perf_logger.ts
+++ b/packages/performance/src/services/perf_logger.ts
@@ -120,18 +120,12 @@ export function logTrace(trace: Trace): void {
     return;
   }
 
-  if (
-    !settingsService.loggingEnabled ||
-    !settingsService.logTraceAfterSampling
-  ) {
-    return;
-  }
-
   if (isPerfInitialized()) {
     sendTraceLog(trace);
   } else {
     // Custom traces can be used before the initialization but logging
     // should wait until after.
+
     getInitializationPromise().then(
       () => sendTraceLog(trace),
       () => sendTraceLog(trace)
@@ -140,9 +134,19 @@ export function logTrace(trace: Trace): void {
 }
 
 function sendTraceLog(trace: Trace): void {
-  if (getIid()) {
-    setTimeout(() => sendLog(trace, ResourceType.Trace), 0);
+  if (!getIid()) {
+    return;
   }
+
+  const settingsService = SettingsService.getInstance();
+  if (
+    !settingsService.loggingEnabled ||
+    !settingsService.logTraceAfterSampling
+  ) {
+    return;
+  }
+
+  setTimeout(() => sendLog(trace, ResourceType.Trace), 0);
 }
 
 export function logNetworkRequest(networkRequest: NetworkRequest): void {


### PR DESCRIPTION
Developer reported that `custom trace` right after initializing perf object was not able to be recorded. That is because initialization didn't finish, thus was not able to flip the bit of `SettingsService.loggingEnabled` from false to true. Therefore custom trace was discarded.

### Fix

Check `SettingsService.loggingEnabled` after initialization finishes, thus avoid dropping events before reading RemoteConfig value.

Internal tracking bug: b/169126072