### PR TITLE
Functions: Bind passed fetch function

### DIFF
--- a/.changeset/dirty-rings-cry.md
+++ b/.changeset/dirty-rings-cry.md
@@ -1,0 +1,6 @@
+---
+'@firebase/functions-exp': patch
+'@firebase/functions': patch
+---
+
+Fixes a bug introduced in #3782 that causes callable functions to throw an error in browser extensions.

--- a/.changeset/dirty-rings-cry.md
+++ b/.changeset/dirty-rings-cry.md
@@ -1,5 +1,4 @@
 ---
-'@firebase/functions-exp': patch
 '@firebase/functions': patch
 ---
 

--- a/packages-exp/functions-exp/src/index.ts
+++ b/packages-exp/functions-exp/src/index.ts
@@ -21,5 +21,5 @@ import { name, version } from '../package.json';
 
 export * from './api';
 
-registerFunctions(window.fetch.bind(window));
+registerFunctions(fetch.bind(self));
 registerVersion(name, version);

--- a/packages-exp/functions-exp/src/index.ts
+++ b/packages-exp/functions-exp/src/index.ts
@@ -21,5 +21,5 @@ import { name, version } from '../package.json';
 
 export * from './api';
 
-registerFunctions(fetch);
+registerFunctions(window.fetch.bind(window));
 registerVersion(name, version);

--- a/packages/functions/index.ts
+++ b/packages/functions/index.ts
@@ -21,7 +21,7 @@ import { registerFunctions } from './src/config';
 
 import { name, version } from './package.json';
 
-registerFunctions(firebase as _FirebaseNamespace, window.fetch.bind(window));
+registerFunctions(firebase as _FirebaseNamespace, fetch.bind(self));
 firebase.registerVersion(name, version);
 
 declare module '@firebase/app-types' {

--- a/packages/functions/index.ts
+++ b/packages/functions/index.ts
@@ -21,7 +21,7 @@ import { registerFunctions } from './src/config';
 
 import { name, version } from './package.json';
 
-registerFunctions(firebase as _FirebaseNamespace, fetch);
+registerFunctions(firebase as _FirebaseNamespace, window.fetch.bind(window));
 firebase.registerVersion(name, version);
 
 declare module '@firebase/app-types' {


### PR DESCRIPTION
Fix a bug caused by PR https://github.com/firebase/firebase-js-sdk/pull/3782 to replace isomorphic-fetch dependency in functions. Bug occurs in Chrome extensions and possibly other environments. When passing `fetch` function as an argument it loses `window` context. Binding `self` so that it will work in service workers as well.

See https://stackoverflow.com/questions/44720448/fetch-typeerror-failed-to-execute-fetch-on-window-illegal-invocation for a similar issue.

Fixes https://github.com/firebase/firebase-js-sdk/issues/3849