### PR TITLE
Remove cyclic references in RemoteDocumentCache

### DIFF
--- a/packages/firestore/exp/dependencies.json
+++ b/packages/firestore/exp/dependencies.json
@@ -86,7 +86,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 21610
+        "sizeInBytes": 21609
     },
     "DocumentReference": {
         "dependencies": {
@@ -132,7 +132,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 21608
+        "sizeInBytes": 21607
     },
     "DocumentSnapshot": {
         "dependencies": {
@@ -218,7 +218,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 40022
+        "sizeInBytes": 40021
     },
     "FieldPath": {
         "dependencies": {
@@ -550,7 +550,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 40032
+        "sizeInBytes": 40031
     },
     "QuerySnapshot": {
         "dependencies": {
@@ -640,7 +640,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 42664
+        "sizeInBytes": 42663
     },
     "SnapshotMetadata": {
         "dependencies": {
@@ -861,7 +861,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 63766
+        "sizeInBytes": 63765
     },
     "WriteBatch": {
         "dependencies": {
@@ -988,7 +988,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 54010
+        "sizeInBytes": 54009
     },
     "addDoc": {
         "dependencies": {
@@ -1348,7 +1348,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 167503
+        "sizeInBytes": 167169
     },
     "arrayRemove": {
         "dependencies": {
@@ -1434,7 +1434,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 35085
+        "sizeInBytes": 35084
     },
     "arrayUnion": {
         "dependencies": {
@@ -1520,7 +1520,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 35077
+        "sizeInBytes": 35076
     },
     "clearIndexedDbPersistence": {
         "dependencies": {
@@ -1617,7 +1617,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 22829
+        "sizeInBytes": 22828
     },
     "collectionGroup": {
         "dependencies": {
@@ -1661,7 +1661,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 20418
+        "sizeInBytes": 20417
     },
     "deleteDoc": {
         "dependencies": {
@@ -1975,7 +1975,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 149140
+        "sizeInBytes": 148806
     },
     "deleteField": {
         "dependencies": {
@@ -2273,7 +2273,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 126697
+        "sizeInBytes": 126383
     },
     "doc": {
         "dependencies": {
@@ -2322,7 +2322,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 22873
+        "sizeInBytes": 22872
     },
     "documentId": {
         "dependencies": {
@@ -2819,7 +2819,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 237109
+        "sizeInBytes": 235442
     },
     "enableMultiTabIndexedDbPersistence": {
         "dependencies": {
@@ -3355,7 +3355,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 304802
+        "sizeInBytes": 303115
     },
     "enableNetwork": {
         "dependencies": {
@@ -3613,7 +3613,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 126639
+        "sizeInBytes": 126325
     },
     "endAt": {
         "dependencies": {
@@ -3738,7 +3738,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 52361
+        "sizeInBytes": 52360
     },
     "endBefore": {
         "dependencies": {
@@ -3863,7 +3863,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 52372
+        "sizeInBytes": 52371
     },
     "getDoc": {
         "dependencies": {
@@ -4252,7 +4252,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 201347
+        "sizeInBytes": 201013
     },
     "getDocFromCache": {
         "dependencies": {
@@ -4501,7 +4501,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 120129
+        "sizeInBytes": 119815
     },
     "getDocFromServer": {
         "dependencies": {
@@ -4890,7 +4890,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 201366
+        "sizeInBytes": 201032
     },
     "getDocs": {
         "dependencies": {
@@ -5282,7 +5282,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 203638
+        "sizeInBytes": 203304
     },
     "getDocsFromCache": {
         "dependencies": {
@@ -5543,7 +5543,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 133055
+        "sizeInBytes": 132741
     },
     "getDocsFromServer": {
         "dependencies": {
@@ -5934,7 +5934,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 203366
+        "sizeInBytes": 203032
     },
     "getFirestore": {
         "dependencies": {
@@ -6543,7 +6543,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 204750
+        "sizeInBytes": 204416
     },
     "onSnapshotsInSync": {
         "dependencies": {
@@ -6899,7 +6899,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 184173
+        "sizeInBytes": 183839
     },
     "orderBy": {
         "dependencies": {
@@ -7127,7 +7127,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 21895
+        "sizeInBytes": 21894
     },
     "runTransaction": {
         "dependencies": {
@@ -7317,7 +7317,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 82755
+        "sizeInBytes": 82754
     },
     "serverTimestamp": {
         "dependencies": {
@@ -7713,7 +7713,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 164864
+        "sizeInBytes": 164530
     },
     "setLogLevel": {
         "dependencies": {
@@ -7866,7 +7866,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 50006
+        "sizeInBytes": 50005
     },
     "startAfter": {
         "dependencies": {
@@ -7991,7 +7991,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 52382
+        "sizeInBytes": 52381
     },
     "startAt": {
         "dependencies": {
@@ -8116,7 +8116,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 52372
+        "sizeInBytes": 52371
     },
     "terminate": {
         "dependencies": {
@@ -8510,7 +8510,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 166296
+        "sizeInBytes": 165962
     },
     "waitForPendingWrites": {
         "dependencies": {
@@ -8768,7 +8768,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 127373
+        "sizeInBytes": 127059
     },
     "where": {
         "dependencies": {
@@ -8915,7 +8915,7 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 58214
+        "sizeInBytes": 58213
     },
     "writeBatch": {
         "dependencies": {
@@ -9275,6 +9275,6 @@
             ],
             "variables": []
         },
-        "sizeInBytes": 169472
+        "sizeInBytes": 169138
     }
 }

--- a/packages/firestore/lite/src/api/transaction.ts
+++ b/packages/firestore/lite/src/api/transaction.ts
@@ -123,9 +123,14 @@ export class Transaction {
    *
    * @param documentRef A reference to the document to be set.
    * @param data An object of the fields and values for the document.
+   * @param options An object to configure the set behavior.
    * @return This `Transaction` instance. Used for chaining method calls.
    */
-  set<T>(documentRef: DocumentReference<T>, data: Partial<T>): this;
+  set<T>(
+    documentRef: DocumentReference<T>,
+    data: Partial<T>,
+    options: SetOptions
+  ): this;
   set<T>(
     documentRef: DocumentReference<T>,
     value: T,

--- a/packages/firestore/src/local/indexeddb_persistence.ts
+++ b/packages/firestore/src/local/indexeddb_persistence.ts
@@ -35,7 +35,10 @@ import {
   IndexedDbMutationQueue,
   mutationQueuesContainKey
 } from './indexeddb_mutation_queue';
-import { newIndexedDbRemoteDocumentCache } from './indexeddb_remote_document_cache';
+import {
+  IndexedDbRemoteDocumentCache,
+  newIndexedDbRemoteDocumentCache
+} from './indexeddb_remote_document_cache';
 import {
   ALL_STORES,
   DbClientMetadata,

--- a/packages/firestore/src/local/indexeddb_persistence.ts
+++ b/packages/firestore/src/local/indexeddb_persistence.ts
@@ -35,7 +35,7 @@ import {
   IndexedDbMutationQueue,
   mutationQueuesContainKey
 } from './indexeddb_mutation_queue';
-import { IndexedDbRemoteDocumentCache } from './indexeddb_remote_document_cache';
+import { newIndexedDbRemoteDocumentCache } from './indexeddb_remote_document_cache';
 import {
   ALL_STORES,
   DbClientMetadata,
@@ -266,7 +266,7 @@ export class IndexedDbPersistence implements Persistence {
       this.serializer
     );
     this.indexManager = new IndexedDbIndexManager();
-    this.remoteDocumentCache = new IndexedDbRemoteDocumentCache(
+    this.remoteDocumentCache = newIndexedDbRemoteDocumentCache(
       this.serializer,
       this.indexManager
     );

--- a/packages/firestore/src/local/indexeddb_remote_document_cache.ts
+++ b/packages/firestore/src/local/indexeddb_remote_document_cache.ts
@@ -35,7 +35,7 @@ import { SortedMap } from '../util/sorted_map';
 import { SortedSet } from '../util/sorted_set';
 
 import { SnapshotVersion } from '../core/snapshot_version';
-import { debugAssert, fail, hardAssert } from '../util/assert';
+import { debugAssert, debugCast, fail, hardAssert } from '../util/assert';
 import { IndexManager } from './index_manager';
 import { IndexedDbPersistence } from './indexeddb_persistence';
 import {
@@ -58,14 +58,23 @@ import { RemoteDocumentChangeBuffer } from './remote_document_change_buffer';
 import { IterateOptions, SimpleDbStore } from './simple_db';
 import { ObjectMap } from '../util/obj_map';
 
-export class IndexedDbRemoteDocumentCache implements RemoteDocumentCache {
+export interface IndexedDbRemoteDocumentCache extends RemoteDocumentCache {
+  // The IndexedDbRemoteDocumentCache doesn't implement any methods on top
+  // of RemoteDocumentCache. This class exists for consistency.
+}
+
+/**
+ * The RemoteDocumentCache for IndexedDb. To construct, invoke
+ * `newIndexedDbRemoteDocumentCache()`.
+ */
+export class IndexedDbRemoteDocumentCacheImpl implements RemoteDocumentCache {
   /**
-   * @param {LocalSerializer} serializer The document serializer.
-   * @param {IndexManager} indexManager The query indexes that need to be maintained.
+   * @param serializer The document serializer.
+   * @param indexManager The query indexes that need to be maintained.
    */
   constructor(
     readonly serializer: LocalSerializer,
-    private readonly indexManager: IndexManager
+    readonly indexManager: IndexManager
   ) {}
 
   /**
@@ -74,7 +83,7 @@ export class IndexedDbRemoteDocumentCache implements RemoteDocumentCache {
    * All calls of `addEntry` are required to go through the RemoteDocumentChangeBuffer
    * returned by `newChangeBuffer()` to ensure proper accounting of metadata.
    */
-  private addEntry(
+  addEntry(
     transaction: PersistenceTransaction,
     key: DocumentKey,
     doc: DbRemoteDocument
@@ -89,7 +98,7 @@ export class IndexedDbRemoteDocumentCache implements RemoteDocumentCache {
    * All calls of `removeEntry`  are required to go through the RemoteDocumentChangeBuffer
    * returned by `newChangeBuffer()` to ensure proper accounting of metadata.
    */
-  private removeEntry(
+  removeEntry(
     transaction: PersistenceTransaction,
     documentKey: DocumentKey
   ): PersistencePromise<void> {
@@ -104,7 +113,7 @@ export class IndexedDbRemoteDocumentCache implements RemoteDocumentCache {
    * Callers to `addEntry()` and `removeEntry()` *must* call this afterwards to update the
    * cache's metadata.
    */
-  private updateMetadata(
+  updateMetadata(
     transaction: PersistenceTransaction,
     sizeDelta: number
   ): PersistencePromise<void> {
@@ -300,73 +309,10 @@ export class IndexedDbRemoteDocumentCache implements RemoteDocumentCache {
       .next(() => results);
   }
 
-  /**
-   * Returns the set of documents that have changed since the specified read
-   * time.
-   */
-  // PORTING NOTE: This is only used for multi-tab synchronization.
-  getNewDocumentChanges(
-    transaction: PersistenceTransaction,
-    sinceReadTime: SnapshotVersion
-  ): PersistencePromise<{
-    changedDocs: MaybeDocumentMap;
-    readTime: SnapshotVersion;
-  }> {
-    let changedDocs = maybeDocumentMap();
-
-    let lastReadTime = toDbTimestampKey(sinceReadTime);
-
-    const documentsStore = remoteDocumentsStore(transaction);
-    const range = IDBKeyRange.lowerBound(lastReadTime, true);
-    return documentsStore
-      .iterate(
-        { index: DbRemoteDocument.readTimeIndex, range },
-        (_, dbRemoteDoc) => {
-          // Unlike `getEntry()` and others, `getNewDocumentChanges()` parses
-          // the documents directly since we want to keep sentinel deletes.
-          const doc = fromDbRemoteDocument(this.serializer, dbRemoteDoc);
-          changedDocs = changedDocs.insert(doc.key, doc);
-          lastReadTime = dbRemoteDoc.readTime!;
-        }
-      )
-      .next(() => {
-        return {
-          changedDocs,
-          readTime: fromDbTimestampKey(lastReadTime)
-        };
-      });
-  }
-
-  /**
-   * Returns the read time of the most recently read document in the cache, or
-   * SnapshotVersion.min() if not available.
-   */
-  // PORTING NOTE: This is only used for multi-tab synchronization.
-  getLastReadTime(
-    transaction: PersistenceTransaction
-  ): PersistencePromise<SnapshotVersion> {
-    const documentsStore = remoteDocumentsStore(transaction);
-
-    // If there are no existing entries, we return SnapshotVersion.min().
-    let readTime = SnapshotVersion.min();
-
-    return documentsStore
-      .iterate(
-        { index: DbRemoteDocument.readTimeIndex, reverse: true },
-        (key, dbRemoteDoc, control) => {
-          if (dbRemoteDoc.readTime) {
-            readTime = fromDbTimestampKey(dbRemoteDoc.readTime);
-          }
-          control.done();
-        }
-      )
-      .next(() => readTime);
-  }
-
   newChangeBuffer(options?: {
     trackRemovals: boolean;
   }): RemoteDocumentChangeBuffer {
-    return new IndexedDbRemoteDocumentCache.RemoteDocumentChangeBuffer(
+    return new IndexedDbRemoteDocumentChangeBuffer(
       this,
       !!options && options.trackRemovals
     );
@@ -416,137 +362,221 @@ export class IndexedDbRemoteDocumentCache implements RemoteDocumentCache {
     }
     return null;
   }
+}
+
+/**
+ * Creates a new IndexedDbRemoteDocumentCache.
+ *
+ * @param serializer The document serializer.
+ * @param indexManager The query indexes that need to be maintained.
+ */
+export function newIndexedDbRemoteDocumentCache(
+  serializer: LocalSerializer,
+  indexManager: IndexManager
+): IndexedDbRemoteDocumentCache {
+  return new IndexedDbRemoteDocumentCacheImpl(serializer, indexManager);
+}
+
+/**
+ * Returns the set of documents that have changed since the specified read
+ * time.
+ */
+// PORTING NOTE: This is only used for multi-tab synchronization.
+export function remoteDocumentCacheGetNewDocumentChanges(
+  remoteDocumentCache: IndexedDbRemoteDocumentCache,
+  transaction: PersistenceTransaction,
+  sinceReadTime: SnapshotVersion
+): PersistencePromise<{
+  changedDocs: MaybeDocumentMap;
+  readTime: SnapshotVersion;
+}> {
+  const remoteDocumentCacheImpl = debugCast(
+    remoteDocumentCache,
+    IndexedDbRemoteDocumentCacheImpl // We only support IndexedDb in multi-tab mode.
+  );
+  let changedDocs = maybeDocumentMap();
+
+  let lastReadTime = toDbTimestampKey(sinceReadTime);
+
+  const documentsStore = remoteDocumentsStore(transaction);
+  const range = IDBKeyRange.lowerBound(lastReadTime, true);
+  return documentsStore
+    .iterate(
+      { index: DbRemoteDocument.readTimeIndex, range },
+      (_, dbRemoteDoc) => {
+        // Unlike `getEntry()` and others, `getNewDocumentChanges()` parses
+        // the documents directly since we want to keep sentinel deletes.
+        const doc = fromDbRemoteDocument(
+          remoteDocumentCacheImpl.serializer,
+          dbRemoteDoc
+        );
+        changedDocs = changedDocs.insert(doc.key, doc);
+        lastReadTime = dbRemoteDoc.readTime!;
+      }
+    )
+    .next(() => {
+      return {
+        changedDocs,
+        readTime: fromDbTimestampKey(lastReadTime)
+      };
+    });
+}
+
+/**
+ * Returns the read time of the most recently read document in the cache, or
+ * SnapshotVersion.min() if not available.
+ */
+// PORTING NOTE: This is only used for multi-tab synchronization.
+export function remoteDocumentCacheGetLastReadTime(
+  transaction: PersistenceTransaction
+): PersistencePromise<SnapshotVersion> {
+  const documentsStore = remoteDocumentsStore(transaction);
+
+  // If there are no existing entries, we return SnapshotVersion.min().
+  let readTime = SnapshotVersion.min();
+
+  return documentsStore
+    .iterate(
+      { index: DbRemoteDocument.readTimeIndex, reverse: true },
+      (key, dbRemoteDoc, control) => {
+        if (dbRemoteDoc.readTime) {
+          readTime = fromDbTimestampKey(dbRemoteDoc.readTime);
+        }
+        control.done();
+      }
+    )
+    .next(() => readTime);
+}
+
+/**
+ * Handles the details of adding and updating documents in the IndexedDbRemoteDocumentCache.
+ *
+ * Unlike the MemoryRemoteDocumentChangeBuffer, the IndexedDb implementation computes the size
+ * delta for all submitted changes. This avoids having to re-read all documents from IndexedDb
+ * when we apply the changes.
+ */
+class IndexedDbRemoteDocumentChangeBuffer extends RemoteDocumentChangeBuffer {
+  // A map of document sizes prior to applying the changes in this buffer.
+  protected documentSizes: ObjectMap<DocumentKey, number> = new ObjectMap(
+    key => key.toString(),
+    (l, r) => l.isEqual(r)
+  );
 
   /**
-   * Handles the details of adding and updating documents in the IndexedDbRemoteDocumentCache.
-   *
-   * Unlike the MemoryRemoteDocumentChangeBuffer, the IndexedDb implementation computes the size
-   * delta for all submitted changes. This avoids having to re-read all documents from IndexedDb
-   * when we apply the changes.
+   * @param documentCache The IndexedDbRemoteDocumentCache to apply the changes to.
+   * @param trackRemovals Whether to create sentinel deletes that can be tracked by
+   * `getNewDocumentChanges()`.
    */
-  private static RemoteDocumentChangeBuffer = class extends RemoteDocumentChangeBuffer {
-    // A map of document sizes prior to applying the changes in this buffer.
-    protected documentSizes: ObjectMap<DocumentKey, number> = new ObjectMap(
-      key => key.toString(),
-      (l, r) => l.isEqual(r)
+  constructor(
+    private readonly documentCache: IndexedDbRemoteDocumentCacheImpl,
+    private readonly trackRemovals: boolean
+  ) {
+    super();
+  }
+
+  protected applyChanges(
+    transaction: PersistenceTransaction
+  ): PersistencePromise<void> {
+    const promises: Array<PersistencePromise<void>> = [];
+
+    let sizeDelta = 0;
+
+    let collectionParents = new SortedSet<ResourcePath>((l, r) =>
+      primitiveComparator(l.canonicalString(), r.canonicalString())
     );
 
-    /**
-     * @param documentCache The IndexedDbRemoteDocumentCache to apply the changes to.
-     * @param trackRemovals Whether to create sentinel deletes that can be tracked by
-     * `getNewDocumentChanges()`.
-     */
-    constructor(
-      private readonly documentCache: IndexedDbRemoteDocumentCache,
-      private readonly trackRemovals: boolean
-    ) {
-      super();
-    }
-
-    protected applyChanges(
-      transaction: PersistenceTransaction
-    ): PersistencePromise<void> {
-      const promises: Array<PersistencePromise<void>> = [];
-
-      let sizeDelta = 0;
-
-      let collectionParents = new SortedSet<ResourcePath>((l, r) =>
-        primitiveComparator(l.canonicalString(), r.canonicalString())
+    this.changes.forEach((key, maybeDocument) => {
+      const previousSize = this.documentSizes.get(key);
+      debugAssert(
+        previousSize !== undefined,
+        `Cannot modify a document that wasn't read (for ${key})`
       );
-
-      this.changes.forEach((key, maybeDocument) => {
-        const previousSize = this.documentSizes.get(key);
+      if (maybeDocument) {
         debugAssert(
-          previousSize !== undefined,
-          `Cannot modify a document that wasn't read (for ${key})`
+          !this.readTime.isEqual(SnapshotVersion.min()),
+          'Cannot add a document with a read time of zero'
         );
-        if (maybeDocument) {
-          debugAssert(
-            !this.readTime.isEqual(SnapshotVersion.min()),
-            'Cannot add a document with a read time of zero'
-          );
-          const doc = toDbRemoteDocument(
+        const doc = toDbRemoteDocument(
+          this.documentCache.serializer,
+          maybeDocument,
+          this.readTime
+        );
+        collectionParents = collectionParents.add(key.path.popLast());
+
+        const size = dbDocumentSize(doc);
+        sizeDelta += size - previousSize!;
+        promises.push(this.documentCache.addEntry(transaction, key, doc));
+      } else {
+        sizeDelta -= previousSize!;
+        if (this.trackRemovals) {
+          // In order to track removals, we store a "sentinel delete" in the
+          // RemoteDocumentCache. This entry is represented by a NoDocument
+          // with a version of 0 and ignored by `maybeDecodeDocument()` but
+          // preserved in `getNewDocumentChanges()`.
+          const deletedDoc = toDbRemoteDocument(
             this.documentCache.serializer,
-            maybeDocument,
+            new NoDocument(key, SnapshotVersion.min()),
             this.readTime
           );
-          collectionParents = collectionParents.add(key.path.popLast());
-
-          const size = dbDocumentSize(doc);
-          sizeDelta += size - previousSize!;
-          promises.push(this.documentCache.addEntry(transaction, key, doc));
+          promises.push(
+            this.documentCache.addEntry(transaction, key, deletedDoc)
+          );
         } else {
-          sizeDelta -= previousSize!;
-          if (this.trackRemovals) {
-            // In order to track removals, we store a "sentinel delete" in the
-            // RemoteDocumentCache. This entry is represented by a NoDocument
-            // with a version of 0 and ignored by `maybeDecodeDocument()` but
-            // preserved in `getNewDocumentChanges()`.
-            const deletedDoc = toDbRemoteDocument(
-              this.documentCache.serializer,
-              new NoDocument(key, SnapshotVersion.min()),
-              this.readTime
-            );
-            promises.push(
-              this.documentCache.addEntry(transaction, key, deletedDoc)
-            );
-          } else {
-            promises.push(this.documentCache.removeEntry(transaction, key));
-          }
+          promises.push(this.documentCache.removeEntry(transaction, key));
+        }
+      }
+    });
+
+    collectionParents.forEach(parent => {
+      promises.push(
+        this.documentCache.indexManager.addToCollectionParentIndex(
+          transaction,
+          parent
+        )
+      );
+    });
+
+    promises.push(this.documentCache.updateMetadata(transaction, sizeDelta));
+
+    return PersistencePromise.waitFor(promises);
+  }
+
+  protected getFromCache(
+    transaction: PersistenceTransaction,
+    documentKey: DocumentKey
+  ): PersistencePromise<MaybeDocument | null> {
+    // Record the size of everything we load from the cache so we can compute a delta later.
+    return this.documentCache
+      .getSizedEntry(transaction, documentKey)
+      .next(getResult => {
+        if (getResult === null) {
+          this.documentSizes.set(documentKey, 0);
+          return null;
+        } else {
+          this.documentSizes.set(documentKey, getResult.size);
+          return getResult.maybeDocument;
         }
       });
+  }
 
-      collectionParents.forEach(parent => {
-        promises.push(
-          this.documentCache.indexManager.addToCollectionParentIndex(
-            transaction,
-            parent
-          )
-        );
+  protected getAllFromCache(
+    transaction: PersistenceTransaction,
+    documentKeys: DocumentKeySet
+  ): PersistencePromise<NullableMaybeDocumentMap> {
+    // Record the size of everything we load from the cache so we can compute
+    // a delta later.
+    return this.documentCache
+      .getSizedEntries(transaction, documentKeys)
+      .next(({ maybeDocuments, sizeMap }) => {
+        // Note: `getAllFromCache` returns two maps instead of a single map from
+        // keys to `DocumentSizeEntry`s. This is to allow returning the
+        // `NullableMaybeDocumentMap` directly, without a conversion.
+        sizeMap.forEach((documentKey, size) => {
+          this.documentSizes.set(documentKey, size);
+        });
+        return maybeDocuments;
       });
-
-      promises.push(this.documentCache.updateMetadata(transaction, sizeDelta));
-
-      return PersistencePromise.waitFor(promises);
-    }
-
-    protected getFromCache(
-      transaction: PersistenceTransaction,
-      documentKey: DocumentKey
-    ): PersistencePromise<MaybeDocument | null> {
-      // Record the size of everything we load from the cache so we can compute a delta later.
-      return this.documentCache
-        .getSizedEntry(transaction, documentKey)
-        .next(getResult => {
-          if (getResult === null) {
-            this.documentSizes.set(documentKey, 0);
-            return null;
-          } else {
-            this.documentSizes.set(documentKey, getResult.size);
-            return getResult.maybeDocument;
-          }
-        });
-    }
-
-    protected getAllFromCache(
-      transaction: PersistenceTransaction,
-      documentKeys: DocumentKeySet
-    ): PersistencePromise<NullableMaybeDocumentMap> {
-      // Record the size of everything we load from the cache so we can compute
-      // a delta later.
-      return this.documentCache
-        .getSizedEntries(transaction, documentKeys)
-        .next(({ maybeDocuments, sizeMap }) => {
-          // Note: `getAllFromCache` returns two maps instead of a single map from
-          // keys to `DocumentSizeEntry`s. This is to allow returning the
-          // `NullableMaybeDocumentMap` directly, without a conversion.
-          sizeMap.forEach((documentKey, size) => {
-            this.documentSizes.set(documentKey, size);
-          });
-          return maybeDocuments;
-        });
-    }
-  };
+  }
 }
 
 function documentGlobalStore(

--- a/packages/firestore/src/local/indexeddb_remote_document_cache.ts
+++ b/packages/firestore/src/local/indexeddb_remote_document_cache.ts
@@ -67,7 +67,7 @@ export interface IndexedDbRemoteDocumentCache extends RemoteDocumentCache {
  * The RemoteDocumentCache for IndexedDb. To construct, invoke
  * `newIndexedDbRemoteDocumentCache()`.
  */
-export class IndexedDbRemoteDocumentCacheImpl implements RemoteDocumentCache {
+class IndexedDbRemoteDocumentCacheImpl implements IndexedDbRemoteDocumentCache {
   /**
    * @param serializer The document serializer.
    * @param indexManager The query indexes that need to be maintained.

--- a/packages/firestore/src/local/local_store.ts
+++ b/packages/firestore/src/local/local_store.ts
@@ -67,7 +67,10 @@ import { ClientId } from './shared_client_state';
 import { TargetData, TargetPurpose } from './target_data';
 import { IndexedDbPersistence } from './indexeddb_persistence';
 import { IndexedDbMutationQueue } from './indexeddb_mutation_queue';
-import { IndexedDbRemoteDocumentCache } from './indexeddb_remote_document_cache';
+import {
+  remoteDocumentCacheGetLastReadTime,
+  remoteDocumentCacheGetNewDocumentChanges
+} from './indexeddb_remote_document_cache';
 import { IndexedDbTargetCache } from './indexeddb_target_cache';
 import { extractFieldMask } from '../model/object_value';
 import { isIndexedDbTransactionError } from './simple_db';
@@ -1158,13 +1161,10 @@ export function getNewDocumentChanges(
   localStore: LocalStore
 ): Promise<MaybeDocumentMap> {
   const localStoreImpl = debugCast(localStore, LocalStoreImpl);
-  const remoteDocumentCacheImpl = debugCast(
-    localStoreImpl.remoteDocuments,
-    IndexedDbRemoteDocumentCache // We only support IndexedDb in multi-tab mode.
-  );
   return localStoreImpl.persistence
     .runTransaction('Get new document changes', 'readonly', txn =>
-      remoteDocumentCacheImpl.getNewDocumentChanges(
+      remoteDocumentCacheGetNewDocumentChanges(
+        localStoreImpl.remoteDocuments,
         txn,
         localStoreImpl.lastDocumentChangeReadTime
       )
@@ -1185,15 +1185,11 @@ export async function synchronizeLastDocumentChangeReadTime(
   localStore: LocalStore
 ): Promise<void> {
   const localStoreImpl = debugCast(localStore, LocalStoreImpl);
-  const remoteDocumentCacheImpl = debugCast(
-    localStoreImpl.remoteDocuments,
-    IndexedDbRemoteDocumentCache // We only support IndexedDb in multi-tab mode.
-  );
   return localStoreImpl.persistence
     .runTransaction(
       'Synchronize last document change read time',
       'readonly',
-      txn => remoteDocumentCacheImpl.getLastReadTime(txn)
+      txn => remoteDocumentCacheGetLastReadTime(txn)
     )
     .then(readTime => {
       localStoreImpl.lastDocumentChangeReadTime = readTime;

--- a/packages/firestore/src/local/memory_persistence.ts
+++ b/packages/firestore/src/local/memory_persistence.ts
@@ -33,7 +33,10 @@ import { ListenSequenceNumber, TargetId } from '../core/types';
 import { estimateByteSize } from '../model/values';
 import { MemoryIndexManager } from './memory_index_manager';
 import { MemoryMutationQueue } from './memory_mutation_queue';
-import { MemoryRemoteDocumentCache } from './memory_remote_document_cache';
+import {
+  MemoryRemoteDocumentCache,
+  newMemoryRemoteDocumentCache
+} from './memory_remote_document_cache';
 import { MemoryTargetCache } from './memory_target_cache';
 import { MutationQueue } from './mutation_queue';
 import {
@@ -84,7 +87,7 @@ export class MemoryPersistence implements Persistence {
     const sizer = (doc: MaybeDocument): number =>
       this.referenceDelegate.documentSize(doc);
     this.indexManager = new MemoryIndexManager();
-    this.remoteDocumentCache = new MemoryRemoteDocumentCache(
+    this.remoteDocumentCache = newMemoryRemoteDocumentCache(
       this.indexManager,
       sizer
     );

--- a/packages/firestore/src/local/memory_remote_document_cache.ts
+++ b/packages/firestore/src/local/memory_remote_document_cache.ts
@@ -50,7 +50,18 @@ function documentEntryMap(): DocumentEntryMap {
   );
 }
 
-export class MemoryRemoteDocumentCache implements RemoteDocumentCache {
+export interface MemoryRemoteDocumentCache extends RemoteDocumentCache {
+  forEachDocumentKey(
+    transaction: PersistenceTransaction,
+    f: (key: DocumentKey) => PersistencePromise<void>
+  ): PersistencePromise<void>;
+}
+
+/**
+ * The memory-only RemoteDocumentCache for IndexedDb. To construct, invoke
+ * `newMemoryRemoteDocumentCache()`.
+ */
+class MemoryRemoteDocumentCacheImpl implements RemoteDocumentCache {
   /** Underlying cache of documents and their read times. */
   private docs = documentEntryMap();
 
@@ -72,7 +83,7 @@ export class MemoryRemoteDocumentCache implements RemoteDocumentCache {
    * All calls of `addEntry`  are required to go through the RemoteDocumentChangeBuffer
    * returned by `newChangeBuffer()`.
    */
-  private addEntry(
+  addEntry(
     transaction: PersistenceTransaction,
     doc: MaybeDocument,
     readTime: SnapshotVersion
@@ -107,7 +118,7 @@ export class MemoryRemoteDocumentCache implements RemoteDocumentCache {
    * All calls of `removeEntry` are required to go through the RemoteDocumentChangeBuffer
    * returned by `newChangeBuffer()`.
    */
-  private removeEntry(documentKey: DocumentKey): void {
+  removeEntry(documentKey: DocumentKey): void {
     const entry = this.docs.get(documentKey);
     if (entry) {
       this.docs = this.docs.remove(documentKey);
@@ -183,49 +194,63 @@ export class MemoryRemoteDocumentCache implements RemoteDocumentCache {
   }): RemoteDocumentChangeBuffer {
     // `trackRemovals` is ignores since the MemoryRemoteDocumentCache keeps
     // a separate changelog and does not need special handling for removals.
-    return new MemoryRemoteDocumentCache.RemoteDocumentChangeBuffer(this);
+    return new MemoryRemoteDocumentChangeBuffer(this);
   }
 
   getSize(txn: PersistenceTransaction): PersistencePromise<number> {
     return PersistencePromise.resolve(this.size);
   }
+}
 
-  /**
-   * Handles the details of adding and updating documents in the MemoryRemoteDocumentCache.
-   */
-  private static RemoteDocumentChangeBuffer = class extends RemoteDocumentChangeBuffer {
-    constructor(private readonly documentCache: MemoryRemoteDocumentCache) {
-      super();
-    }
+/**
+ * Creates a new memory-only RemoteDocumentCache.
+ *
+ * @param indexManager A class that manages collection group indices.
+ * @param sizer Used to assess the size of a document. For eager GC, this is expected to just
+ * return 0 to avoid unnecessarily doing the work of calculating the size.
+ */
+export function newMemoryRemoteDocumentCache(
+  indexManager: IndexManager,
+  sizer: DocumentSizer
+): MemoryRemoteDocumentCache {
+  return new MemoryRemoteDocumentCacheImpl(indexManager, sizer);
+}
 
-    protected applyChanges(
-      transaction: PersistenceTransaction
-    ): PersistencePromise<void> {
-      const promises: Array<PersistencePromise<void>> = [];
-      this.changes.forEach((key, doc) => {
-        if (doc) {
-          promises.push(
-            this.documentCache.addEntry(transaction, doc, this.readTime)
-          );
-        } else {
-          this.documentCache.removeEntry(key);
-        }
-      });
-      return PersistencePromise.waitFor(promises);
-    }
+/**
+ * Handles the details of adding and updating documents in the MemoryRemoteDocumentCache.
+ */
+class MemoryRemoteDocumentChangeBuffer extends RemoteDocumentChangeBuffer {
+  constructor(private readonly documentCache: MemoryRemoteDocumentCacheImpl) {
+    super();
+  }
 
-    protected getFromCache(
-      transaction: PersistenceTransaction,
-      documentKey: DocumentKey
-    ): PersistencePromise<MaybeDocument | null> {
-      return this.documentCache.getEntry(transaction, documentKey);
-    }
+  protected applyChanges(
+    transaction: PersistenceTransaction
+  ): PersistencePromise<void> {
+    const promises: Array<PersistencePromise<void>> = [];
+    this.changes.forEach((key, doc) => {
+      if (doc) {
+        promises.push(
+          this.documentCache.addEntry(transaction, doc, this.readTime)
+        );
+      } else {
+        this.documentCache.removeEntry(key);
+      }
+    });
+    return PersistencePromise.waitFor(promises);
+  }
 
-    protected getAllFromCache(
-      transaction: PersistenceTransaction,
-      documentKeys: DocumentKeySet
-    ): PersistencePromise<NullableMaybeDocumentMap> {
-      return this.documentCache.getEntries(transaction, documentKeys);
-    }
-  };
+  protected getFromCache(
+    transaction: PersistenceTransaction,
+    documentKey: DocumentKey
+  ): PersistencePromise<MaybeDocument | null> {
+    return this.documentCache.getEntry(transaction, documentKey);
+  }
+
+  protected getAllFromCache(
+    transaction: PersistenceTransaction,
+    documentKeys: DocumentKeySet
+  ): PersistencePromise<NullableMaybeDocumentMap> {
+    return this.documentCache.getEntries(transaction, documentKeys);
+  }
 }

--- a/packages/firestore/src/local/memory_remote_document_cache.ts
+++ b/packages/firestore/src/local/memory_remote_document_cache.ts
@@ -61,7 +61,7 @@ export interface MemoryRemoteDocumentCache extends RemoteDocumentCache {
  * The memory-only RemoteDocumentCache for IndexedDb. To construct, invoke
  * `newMemoryRemoteDocumentCache()`.
  */
-class MemoryRemoteDocumentCacheImpl implements RemoteDocumentCache {
+class MemoryRemoteDocumentCacheImpl implements MemoryRemoteDocumentCache {
   /** Underlying cache of documents and their read times. */
   private docs = documentEntryMap();
 

--- a/packages/firestore/test/unit/local/remote_document_cache.test.ts
+++ b/packages/firestore/test/unit/local/remote_document_cache.test.ts
@@ -34,6 +34,7 @@ import {
 } from '../../../src/model/collections';
 import * as persistenceHelpers from './persistence_test_helpers';
 import { TestRemoteDocumentCache } from './test_remote_document_cache';
+import { remoteDocumentCacheGetLastReadTime } from '../../../src/local/indexeddb_remote_document_cache';
 
 // Helpers for use throughout tests.
 const DOC_PATH = 'a/b';
@@ -91,8 +92,7 @@ describe('IndexedDbRemoteDocumentCache', () => {
 
   function getLastReadTime(): Promise<SnapshotVersion> {
     return persistence.runTransaction('getLastReadTime', 'readonly', txn => {
-      const remoteDocuments = persistence.getRemoteDocumentCache();
-      return remoteDocuments.getLastReadTime(txn);
+      return remoteDocumentCacheGetLastReadTime(txn);
     });
   }
 

--- a/packages/firestore/test/unit/local/test_remote_document_cache.ts
+++ b/packages/firestore/test/unit/local/test_remote_document_cache.ts
@@ -20,10 +20,7 @@ import { SnapshotVersion } from '../../../src/core/snapshot_version';
 import { Persistence } from '../../../src/local/persistence';
 import { PersistencePromise } from '../../../src/local/persistence_promise';
 import { RemoteDocumentCache } from '../../../src/local/remote_document_cache';
-import {
-  IndexedDbRemoteDocumentCache,
-  remoteDocumentCacheGetNewDocumentChanges
-} from '../../../src/local/indexeddb_remote_document_cache';
+import { remoteDocumentCacheGetNewDocumentChanges } from '../../../src/local/indexeddb_remote_document_cache';
 import { RemoteDocumentChangeBuffer } from '../../../src/local/remote_document_change_buffer';
 import {
   DocumentKeySet,
@@ -33,7 +30,6 @@ import {
 } from '../../../src/model/collections';
 import { MaybeDocument } from '../../../src/model/document';
 import { DocumentKey } from '../../../src/model/document_key';
-import { debugAssert } from '../../../src/util/assert';
 
 /**
  * A wrapper around a RemoteDocumentCache that automatically creates a

--- a/packages/firestore/test/unit/local/test_remote_document_cache.ts
+++ b/packages/firestore/test/unit/local/test_remote_document_cache.ts
@@ -20,7 +20,10 @@ import { SnapshotVersion } from '../../../src/core/snapshot_version';
 import { Persistence } from '../../../src/local/persistence';
 import { PersistencePromise } from '../../../src/local/persistence_promise';
 import { RemoteDocumentCache } from '../../../src/local/remote_document_cache';
-import { IndexedDbRemoteDocumentCache } from '../../../src/local/indexeddb_remote_document_cache';
+import {
+  IndexedDbRemoteDocumentCache,
+  remoteDocumentCacheGetNewDocumentChanges
+} from '../../../src/local/indexeddb_remote_document_cache';
 import { RemoteDocumentChangeBuffer } from '../../../src/local/remote_document_change_buffer';
 import {
   DocumentKeySet,
@@ -132,11 +135,11 @@ export class TestRemoteDocumentCache {
       'getNewDocumentChanges',
       'readonly',
       txn => {
-        debugAssert(
-          this.cache instanceof IndexedDbRemoteDocumentCache,
-          'getNewDocumentChanges() requires IndexedDB'
+        return remoteDocumentCacheGetNewDocumentChanges(
+          this.cache,
+          txn,
+          sinceReadTime
         );
-        return this.cache.getNewDocumentChanges(txn, sinceReadTime);
       }
     );
   }


### PR DESCRIPTION
This PR removes a static inheritance that WebPack cannot tree-shake. 

Before, our RemoteDocumentCaches would look like this:

```
class XYZRemoteDocumentCache {
static class XYZRemoteDocumentChangeBuffer extends RemoteDocumentChangeBuffer {...}
}
```

This patterns breaks code optimization in Webpack (as per @Feiyang1's research), but it does allow us to access "private" members within the enclosing class while also extending from another class. To address the Webpack issue while keeping some of the encapsulation, I:

- Extracted the XYZRemoteDocumentChangeBuffers into top-level classes.
- Changed XYZRemoteDocumentCaches to XYZRemoteDocumentCacheImpls
- Made XYZRemoteDocumentCacheImpls methods public, so they can be used by the newly extracted types

The rest of the repo still refers to the old types, which are now interfaces and hide the new public methods. This is the same pattern that I applied in lots of other places already (see LocalStore), and it also allowed me to make two functions tree-shakeable that are only used in Multi-Tab (`getNewDocumentChanges()` and `getReadTime()`).

There are no logic changes.