### PR TITLE
Improve typing for options.auth

### DIFF
--- a/.changeset/chilled-ways-promise.md
+++ b/.changeset/chilled-ways-promise.md
@@ -1,0 +1,5 @@
+---
+'@firebase/rules-unit-testing': patch
+---
+
+Add stronger types to the 'options.auth' option for initializeTestApp

--- a/packages/rules-unit-testing/test/database.test.ts
+++ b/packages/rules-unit-testing/test/database.test.ts
@@ -129,7 +129,6 @@ describe('Testing Module Tests', function () {
       auth_time: 0,
       sub: 'alice',
       user_id: 'alice',
-      provider_id: 'custom',
       firebase: {
         sign_in_provider: 'custom',
         identities: {}

--- a/packages/rules-unit-testing/test/database.test.ts
+++ b/packages/rules-unit-testing/test/database.test.ts
@@ -121,7 +121,20 @@ describe('Testing Module Tests', function () {
       base64.decodeString(token!.accessToken.split('.')[1], /*webSafe=*/ false)
     );
     // We add an 'iat' field.
-    expect(claims).to.deep.equal({ uid: auth.uid, iat: 0, sub: auth.uid });
+    expect(claims).to.deep.equal({
+      iss: 'https://securetoken.google.com/foo',
+      aud: 'foo',
+      iat: 0,
+      exp: 3600,
+      auth_time: 0,
+      sub: 'alice',
+      user_id: 'alice',
+      provider_id: 'custom',
+      firebase: {
+        sign_in_provider: 'custom',
+        identities: {}
+      }
+    });
   });
 
   it('initializeAdminApp() has admin access', async function () {


### PR DESCRIPTION
### Discussion

This is a non-breaking change to improve the typing for `options.auth` in `initializeTestApp`.  Note that this removes the `uid` property of the token which should never have been there in the first place (`sub` is the canonical `uid` field).

Related issues: 
  - https://github.com/firebase/quickstart-testing/issues/2
  - https://github.com/firebase/firebase-tools/issues/2405
  - http://b/153398707 (internal)

### Testing

Improved existing unit tests

### API Changes

N/A