### PR TITLE
Fix a couple of parity issues for auth-exp

### DIFF
--- a/packages-exp/auth-exp/src/core/auth/auth_impl.test.ts
+++ b/packages-exp/auth-exp/src/core/auth/auth_impl.test.ts
@@ -150,10 +150,30 @@ describe('core/auth/auth_impl', () => {
       });
     });
 
+    it('waits for initialization for authStateChange', done => {
+      const user = testUser(auth, 'uid');
+      auth.currentUser = user;
+      auth._isInitialized = false;
+      auth._onAuthStateChanged(user => {
+        expect(user).to.eq(user);
+        done();
+      });
+    });
+
     it('immediately calls idTokenChange if initialization finished', done => {
       const user = testUser(auth, 'uid');
       auth.currentUser = user;
       auth._isInitialized = true;
+      auth._onIdTokenChanged(user => {
+        expect(user).to.eq(user);
+        done();
+      });
+    });
+
+    it('waits for initialization for idTokenChanged', done => {
+      const user = testUser(auth, 'uid');
+      auth.currentUser = user;
+      auth._isInitialized = false;
       auth._onIdTokenChanged(user => {
         expect(user).to.eq(user);
         done();

--- a/packages-exp/auth-exp/src/core/auth/auth_impl.ts
+++ b/packages-exp/auth-exp/src/core/auth/auth_impl.ts
@@ -358,12 +358,14 @@ export class AuthImplCompat<T extends User> implements Auth, _FirebaseService {
     completed?: CompleteFn
   ): Unsubscribe {
     const cb =
-        typeof nextOrObserver === 'function'
-          ? nextOrObserver
-          : nextOrObserver.next;
-    
-    const promise = this._isInitialized ? Promise.resolve() : this._initializationPromise;
-    assert(promise, AuthErrorCode.INTERNAL_ERROR, {appName: this.name});
+      typeof nextOrObserver === 'function'
+        ? nextOrObserver
+        : nextOrObserver.next;
+
+    const promise = this._isInitialized
+      ? Promise.resolve()
+      : this._initializationPromise;
+    assert(promise, AuthErrorCode.INTERNAL_ERROR, { appName: this.name });
     // The callback needs to be called asynchronously per the spec.
     // eslint-disable-next-line @typescript-eslint/no-floating-promises
     promise.then(() => cb(this.currentUser));

--- a/packages-exp/auth-exp/src/core/auth/auth_impl.ts
+++ b/packages-exp/auth-exp/src/core/auth/auth_impl.ts
@@ -357,15 +357,16 @@ export class AuthImplCompat<T extends User> implements Auth, _FirebaseService {
     error?: ErrorFn,
     completed?: CompleteFn
   ): Unsubscribe {
-    if (this._isInitialized) {
-      const cb =
+    const cb =
         typeof nextOrObserver === 'function'
           ? nextOrObserver
           : nextOrObserver.next;
-      // The callback needs to be called asynchronously per the spec.
-      // eslint-disable-next-line @typescript-eslint/no-floating-promises
-      Promise.resolve().then(() => cb(this.currentUser));
-    }
+    
+    const promise = this._isInitialized ? Promise.resolve() : this._initializationPromise;
+    assert(promise, AuthErrorCode.INTERNAL_ERROR, {appName: this.name});
+    // The callback needs to be called asynchronously per the spec.
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
+    promise.then(() => cb(this.currentUser));
 
     if (typeof nextOrObserver === 'function') {
       return subscription.addObserver(nextOrObserver, error, completed);

--- a/packages-exp/auth-exp/src/core/user/user_impl.ts
+++ b/packages-exp/auth-exp/src/core/user/user_impl.ts
@@ -219,20 +219,20 @@ export class UserImpl implements User {
   }
 
   static _fromJSON(auth: Auth, object: PersistedBlob): User {
+    const displayName = object.displayName ?? undefined;
+    const email = object.email ?? undefined;
+    const phoneNumber = object.phoneNumber ?? undefined;
+    const photoURL = object.photoURL ?? undefined;
+    const tenantId = object.tenantId ?? undefined;
+    const _redirectEventId = object._redirectEventId ?? undefined;
+    const createdAt = object.createdAt ?? undefined;
+    const lastLoginAt = object.lastLoginAt ?? undefined;
     const {
       uid,
-      email,
       emailVerified,
-      displayName,
       isAnonymous,
-      photoURL,
-      phoneNumber,
-      tenantId,
       providerData,
       stsTokenManager: plainObjectTokenManager,
-      _redirectEventId,
-      createdAt,
-      lastLoginAt
     } = object;
 
     assert(uid && plainObjectTokenManager, AuthErrorCode.INTERNAL_ERROR, {

--- a/packages-exp/auth-exp/src/core/user/user_impl.ts
+++ b/packages-exp/auth-exp/src/core/user/user_impl.ts
@@ -232,7 +232,7 @@ export class UserImpl implements User {
       emailVerified,
       isAnonymous,
       providerData,
-      stsTokenManager: plainObjectTokenManager,
+      stsTokenManager: plainObjectTokenManager
     } = object;
 
     assert(uid && plainObjectTokenManager, AuthErrorCode.INTERNAL_ERROR, {


### PR DESCRIPTION
 * State change listeners before initialization completes now fire after initialization is done
 * Deserializing user objects now does not care if the a value is null or undefined

b/169870894  
b/169870246