### PR TITLE
Modify auth-exp related packages in changeset ignore

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -13,7 +13,7 @@
     "@firebase/app-exp",
     "@firebase/app-types-exp",
     "@firebase/auth-exp",
-    "@firebase/auth-compat-exp",
+    "@firebase/auth-compat",
     "@firebase/auth-types-exp",
     "@firebase/functions-exp",
     "@firebase/functions-types-exp",


### PR DESCRIPTION
Ran into the following error with #3898. When I removed `auth-compat-exp`, it complained about adding back `auth-compat`. I then added `auth-compat` back, which resulted the changeset working.
```
🦋  error { ValidationError: Some errors occurred when validating the changesets config:
🦋  error The package "@firebase/auth-compat-exp" is specified in the `ignore` option but it is not found in the project. You may have misspelled the package name.
🦋  error     at parse (/Users/chenbrian/dev/firebase-js-sdk/node_modules/@changesets/config/dist/config.cjs.dev.js:173:11)
🦋  error     at Object.read (/Users/chenbrian/dev/firebase-js-sdk/node_modules/@changesets/config/dist/config.cjs.dev.js:64:10)
🦋  error   name: 'ValidationError',
🦋  error   _error:
🦋  error    Error
🦋  error        at new ExtendableError (/Users/chenbrian/dev/firebase-js-sdk/node_modules/extendable-error/bld/index.js:23:24)
🦋  error        at new ValidationError (/Users/chenbrian/dev/firebase-js-sdk/node_modules/@changesets/errors/dist/errors.cjs.dev.js:16:1)
🦋  error        at parse (/Users/chenbrian/dev/firebase-js-sdk/node_modules/@changesets/config/dist/config.cjs.dev.js:173:11)
🦋  error        at Object.read (/Users/chenbrian/dev/firebase-js-sdk/node_modules/@changesets/config/dist/config.cjs.dev.js:64:10) }
error Command failed with exit code 1.
```