### PR TITLE
Update auth compat polyfill to use composition instead of inheritance

### DIFF
--- a/common/api-review/auth-exp.api.md
+++ b/common/api-review/auth-exp.api.md
@@ -10,6 +10,7 @@ import { ErrorFn } from '@firebase/util';
 import * as externs from '@firebase/auth-types-exp';
 import { FirebaseApp } from '@firebase/app-types-exp';
 import { FirebaseError } from '@firebase/util';
+import { NextFn } from '@firebase/util';
 import { ProviderId } from '@firebase/auth-types-exp';
 import { Unsubscribe } from '@firebase/util';
 import { UserCredential } from '@firebase/auth-types-exp';
@@ -39,17 +40,17 @@ export function applyActionCode(auth: externs.Auth, oobCode: string): Promise<vo
 // @public (undocumented)
 export class AuthCredential {
     protected constructor(providerId: string, signInMethod: string);
-    // Warning: (ae-forgotten-export) The symbol "AuthCore" needs to be exported by the entry point index.d.ts
+    // Warning: (ae-forgotten-export) The symbol "Auth" needs to be exported by the entry point index.d.ts
     // Warning: (ae-forgotten-export) The symbol "PhoneOrOauthTokenResponse" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)
-    _getIdTokenResponse(_auth: AuthCore): Promise<PhoneOrOauthTokenResponse>;
+    _getIdTokenResponse(_auth: Auth_2): Promise<PhoneOrOauthTokenResponse>;
     // (undocumented)
-    _getReauthenticationResolver(_auth: AuthCore): Promise<IdTokenResponse>;
+    _getReauthenticationResolver(_auth: Auth_2): Promise<IdTokenResponse>;
     // Warning: (ae-forgotten-export) The symbol "IdTokenResponse" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)
-    _linkToIdToken(_auth: AuthCore, _idToken: string): Promise<IdTokenResponse>;
+    _linkToIdToken(_auth: Auth_2, _idToken: string): Promise<IdTokenResponse>;
     // (undocumented)
     readonly providerId: string;
     // (undocumented)
@@ -90,11 +91,11 @@ export class EmailAuthCredential extends AuthCredential implements externs.AuthC
     // (undocumented)
     static fromJSON(json: object | string): EmailAuthCredential | null;
     // (undocumented)
-    _getIdTokenResponse(auth: AuthCore): Promise<IdTokenResponse>;
+    _getIdTokenResponse(auth: Auth_2): Promise<IdTokenResponse>;
     // (undocumented)
-    _getReauthenticationResolver(auth: AuthCore): Promise<IdTokenResponse>;
+    _getReauthenticationResolver(auth: Auth_2): Promise<IdTokenResponse>;
     // (undocumented)
-    _linkToIdToken(auth: AuthCore, idToken: string): Promise<IdTokenResponse>;
+    _linkToIdToken(auth: Auth_2, idToken: string): Promise<IdTokenResponse>;
     // (undocumented)
     readonly password: string;
     // (undocumented)
@@ -154,7 +155,7 @@ export function getIdTokenResult(externUser: externs.User, forceRefresh?: boolea
 export function getMultiFactorResolver(auth: externs.Auth, errorExtern: externs.MultiFactorError): externs.MultiFactorResolver;
 
 // @public (undocumented)
-export function getRedirectResult(authExtern: externs.Auth, resolverExtern: externs.PopupRedirectResolver): Promise<externs.UserCredential | null>;
+export function getRedirectResult(authExtern: externs.Auth, resolverExtern?: externs.PopupRedirectResolver): Promise<externs.UserCredential | null>;
 
 // @public (undocumented)
 export class GithubAuthProvider extends OAuthProvider {
@@ -209,10 +210,10 @@ export function linkWithCredential(userExtern: externs.User, credentialExtern: e
 export function linkWithPhoneNumber(userExtern: externs.User, phoneNumber: string, appVerifier: externs.ApplicationVerifier): Promise<externs.ConfirmationResult>;
 
 // @public (undocumented)
-export function linkWithPopup(userExtern: externs.User, provider: externs.AuthProvider, resolverExtern: externs.PopupRedirectResolver): Promise<externs.UserCredential>;
+export function linkWithPopup(userExtern: externs.User, provider: externs.AuthProvider, resolverExtern?: externs.PopupRedirectResolver): Promise<externs.UserCredential>;
 
 // @public (undocumented)
-export function linkWithRedirect(userExtern: externs.User, provider: externs.AuthProvider, resolverExtern: externs.PopupRedirectResolver): Promise<never>;
+export function linkWithRedirect(userExtern: externs.User, provider: externs.AuthProvider, resolverExtern?: externs.PopupRedirectResolver): Promise<never>;
 
 // @public (undocumented)
 export function multiFactor(user: externs.User): externs.MultiFactorUser;
@@ -228,13 +229,13 @@ export class OAuthCredential extends AuthCredential implements externs.OAuthCred
     // (undocumented)
     static _fromParams(params: OAuthCredentialParams): OAuthCredential;
     // (undocumented)
-    _getIdTokenResponse(auth: AuthCore): Promise<IdTokenResponse>;
+    _getIdTokenResponse(auth: Auth_2): Promise<IdTokenResponse>;
     // (undocumented)
-    _getReauthenticationResolver(auth: AuthCore): Promise<IdTokenResponse>;
+    _getReauthenticationResolver(auth: Auth_2): Promise<IdTokenResponse>;
     // (undocumented)
     idToken?: string;
     // (undocumented)
-    _linkToIdToken(auth: AuthCore, idToken: string): Promise<IdTokenResponse>;
+    _linkToIdToken(auth: Auth_2, idToken: string): Promise<IdTokenResponse>;
     // (undocumented)
     nonce?: string;
     // (undocumented)
@@ -288,11 +289,11 @@ export class PhoneAuthCredential extends AuthCredential implements externs.Phone
     // (undocumented)
     static _fromVerification(verificationId: string, verificationCode: string): PhoneAuthCredential;
     // (undocumented)
-    _getIdTokenResponse(auth: AuthCore): Promise<PhoneOrOauthTokenResponse>;
+    _getIdTokenResponse(auth: Auth_2): Promise<PhoneOrOauthTokenResponse>;
     // (undocumented)
-    _getReauthenticationResolver(auth: AuthCore): Promise<IdTokenResponse>;
+    _getReauthenticationResolver(auth: Auth_2): Promise<IdTokenResponse>;
     // (undocumented)
-    _linkToIdToken(auth: AuthCore, idToken: string): Promise<IdTokenResponse>;
+    _linkToIdToken(auth: Auth_2, idToken: string): Promise<IdTokenResponse>;
     // Warning: (ae-forgotten-export) The symbol "SignInWithPhoneNumberRequest" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)
@@ -303,7 +304,7 @@ export class PhoneAuthCredential extends AuthCredential implements externs.Phone
 
 // @public (undocumented)
 export class PhoneAuthProvider implements externs.PhoneAuthProvider {
-    constructor(auth: AuthCore);
+    constructor(auth: Auth_2);
     // (undocumented)
     static credential(verificationId: string, verificationCode: string): PhoneAuthCredential;
     // (undocumented)
@@ -331,17 +332,17 @@ export function reauthenticateWithCredential(userExtern: externs.User, credentia
 export function reauthenticateWithPhoneNumber(userExtern: externs.User, phoneNumber: string, appVerifier: externs.ApplicationVerifier): Promise<externs.ConfirmationResult>;
 
 // @public (undocumented)
-export function reauthenticateWithPopup(userExtern: externs.User, provider: externs.AuthProvider, resolverExtern: externs.PopupRedirectResolver): Promise<externs.UserCredential>;
+export function reauthenticateWithPopup(userExtern: externs.User, provider: externs.AuthProvider, resolverExtern?: externs.PopupRedirectResolver): Promise<externs.UserCredential>;
 
 // @public (undocumented)
-export function reauthenticateWithRedirect(userExtern: externs.User, provider: externs.AuthProvider, resolverExtern: externs.PopupRedirectResolver): Promise<never>;
+export function reauthenticateWithRedirect(userExtern: externs.User, provider: externs.AuthProvider, resolverExtern?: externs.PopupRedirectResolver): Promise<never>;
 
 // Warning: (ae-forgotten-export) The symbol "ApplicationVerifier" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
 export class RecaptchaVerifier implements externs.RecaptchaVerifier, ApplicationVerifier {
     // Warning: (ae-forgotten-export) The symbol "Parameters" needs to be exported by the entry point index.d.ts
-    constructor(containerOrId: HTMLElement | string, parameters: Parameters_2, auth: AuthCore);
+    constructor(containerOrId: HTMLElement | string, parameters: Parameters_2, authExtern: externs.Auth);
     // (undocumented)
     clear(): void;
     // Warning: (ae-forgotten-export) The symbol "ReCaptchaLoader" needs to be exported by the entry point index.d.ts
@@ -392,10 +393,10 @@ export function signInWithEmailLink(auth: externs.Auth, email: string, emailLink
 export function signInWithPhoneNumber(auth: externs.Auth, phoneNumber: string, appVerifier: externs.ApplicationVerifier): Promise<externs.ConfirmationResult>;
 
 // @public (undocumented)
-export function signInWithPopup(auth: externs.Auth, provider: externs.AuthProvider, resolverExtern: externs.PopupRedirectResolver): Promise<externs.UserCredential>;
+export function signInWithPopup(authExtern: externs.Auth, provider: externs.AuthProvider, resolverExtern?: externs.PopupRedirectResolver): Promise<externs.UserCredential>;
 
 // @public (undocumented)
-export function signInWithRedirect(auth: externs.Auth, provider: externs.AuthProvider, resolverExtern: externs.PopupRedirectResolver): Promise<never>;
+export function signInWithRedirect(authExtern: externs.Auth, provider: externs.AuthProvider, resolverExtern?: externs.PopupRedirectResolver): Promise<never>;
 
 // @public (undocumented)
 export function signOut(auth: externs.Auth): Promise<void>;

--- a/common/api-review/auth-exp.api.md
+++ b/common/api-review/auth-exp.api.md
@@ -304,7 +304,7 @@ export class PhoneAuthCredential extends AuthCredential implements externs.Phone
 
 // @public (undocumented)
 export class PhoneAuthProvider implements externs.PhoneAuthProvider {
-    constructor(auth: Auth_2);
+    constructor(auth: externs.Auth);
     // (undocumented)
     static credential(verificationId: string, verificationCode: string): PhoneAuthCredential;
     // (undocumented)

--- a/packages-exp/app-compat/src/firebaseNamespaceCore.ts
+++ b/packages-exp/app-compat/src/firebaseNamespaceCore.ts
@@ -26,15 +26,7 @@ import {
   FirebaseService,
   FirebaseServiceNamespace
 } from '@firebase/app-types/private';
-import {
-  SDK_VERSION,
-  initializeApp,
-  registerVersion,
-  onLog,
-  setLogLevel,
-  _registerComponent,
-  _DEFAULT_ENTRY_NAME
-} from '@firebase/app-exp';
+import * as modularAPIs from '@firebase/app-exp';
 import { _FirebaseAppInternal } from '@firebase/app-types-exp';
 import { Component, ComponentType } from '@firebase/component';
 
@@ -66,16 +58,17 @@ export function createFirebaseNamespaceCore(
     initializeApp: initializeAppCompat,
     // @ts-ignore
     app,
-    registerVersion,
-    setLogLevel,
-    onLog,
+    registerVersion: modularAPIs.registerVersion,
+    setLogLevel: modularAPIs.setLogLevel,
+    onLog: modularAPIs.onLog,
     // @ts-ignore
     apps: null,
-    SDK_VERSION,
+    SDK_VERSION: modularAPIs.SDK_VERSION,
     INTERNAL: {
       registerComponent: registerComponentCompat,
       removeApp,
-      useAsService
+      useAsService,
+      modularAPIs
     }
   };
 
@@ -109,7 +102,7 @@ export function createFirebaseNamespaceCore(
    * Get the App object for a given name (or DEFAULT).
    */
   function app(name?: string): FirebaseApp {
-    name = name || _DEFAULT_ENTRY_NAME;
+    name = name || modularAPIs._DEFAULT_ENTRY_NAME;
     if (!contains(apps, name)) {
       throw ERROR_FACTORY.create(AppError.NO_APP, { appName: name });
     }
@@ -126,7 +119,10 @@ export function createFirebaseNamespaceCore(
     options: FirebaseOptions,
     rawConfig = {}
   ): FirebaseApp {
-    const app = initializeApp(options, rawConfig) as _FirebaseAppInternal;
+    const app = modularAPIs.initializeApp(
+      options,
+      rawConfig
+    ) as _FirebaseAppInternal;
     const appCompat = new firebaseAppImpl(app, namespace as _FirebaseNamespace);
     apps[app.name] = appCompat;
     return appCompat;
@@ -145,7 +141,7 @@ export function createFirebaseNamespaceCore(
   ): FirebaseServiceNamespace<FirebaseService> | null {
     const componentName = component.name;
     if (
-      _registerComponent(component) &&
+      modularAPIs._registerComponent(component) &&
       component.type === ComponentType.PUBLIC
     ) {
       // create service namespace for public components

--- a/packages-exp/auth-compat-exp/demo/package.json
+++ b/packages-exp/auth-compat-exp/demo/package.json
@@ -10,11 +10,11 @@
     "lint:fix": "eslint --fix -c .eslintrc.js '**/*.ts' --ignore-path '../../../.gitignore'",
     "demo": "rollup -c && firebase serve",
     "build": "rollup -c",
-    "build:deps": "lerna run --scope @firebase/'{app-exp,auth-compat-exp}' --include-dependencies build",
+    "build:deps": "lerna run --scope @firebase/'{app-compat,app-exp,auth-compat-exp}' --include-dependencies build",
     "dev": "rollup -c -w"
   },
   "peerDependencies": {
-    "@firebase/app": "0.x",
+    "@firebase/app-compat": "0.x",
     "@firebase/auth-types": "0.x",
     "@firebase/auth-exp": "0.x"
   },

--- a/packages-exp/auth-compat-exp/demo/rollup.config.js
+++ b/packages-exp/auth-compat-exp/demo/rollup.config.js
@@ -59,7 +59,8 @@ const umdBuilds = [
       extend: true,
       name: 'firebase',
       globals: {
-        '@firebase/app-compat': 'firebase'
+        '@firebase/app-compat': 'firebase',
+        '@firebase/app-exp': 'firebase.INTERNAL.modularAPIs'
       },
       /**
        * use iife to avoid below error in the old Safari browser
@@ -81,7 +82,7 @@ const umdBuilds = [
           }`
     },
     plugins: [...plugins],
-    external: ['@firebase/app-compat']
+    external: ['@firebase/app-compat', '@firebase/app-exp']
   }
 ];
 

--- a/packages-exp/auth-compat-exp/demo/rollup.config.js
+++ b/packages-exp/auth-compat-exp/demo/rollup.config.js
@@ -41,7 +41,7 @@ const umdBuilds = [
    * App UMD Builds
    */
   {
-    input: '../../../packages/firebase/app/index.ts',
+    input: '../../firebase-exp/compat/app/index.ts',
     output: {
       file: 'public/dist/firebase-app.js',
       sourcemap: true,
@@ -59,7 +59,7 @@ const umdBuilds = [
       extend: true,
       name: 'firebase',
       globals: {
-        '@firebase/app': 'firebase'
+        '@firebase/app-compat': 'firebase'
       },
       /**
        * use iife to avoid below error in the old Safari browser
@@ -81,7 +81,7 @@ const umdBuilds = [
           }`
     },
     plugins: [...plugins],
-    external: ['@firebase/app']
+    external: ['@firebase/app-compat']
   }
 ];
 

--- a/packages-exp/auth-compat-exp/index.ts
+++ b/packages-exp/auth-compat-exp/index.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import firebase from '@firebase/app';
+import firebase from '@firebase/app-compat';
 import { _FirebaseNamespace } from '@firebase/app-types/private';
 import * as impl from '@firebase/auth-exp/internal';
 import * as externs from '@firebase/auth-types-exp';
@@ -28,20 +28,22 @@ import {
 import { version } from './package.json';
 import { Auth } from './src/auth';
 import { Persistence } from './src/persistence';
+import { _getClientPlatform } from './src/platform';
 import { RecaptchaVerifier } from './src/recaptcha_verifier';
 
 const AUTH_TYPE = 'auth';
 
 // Create auth components to register with firebase.
 // Provides Auth public APIs.
-function registerAuth(instance: _FirebaseNamespace): void {
+function registerAuthCompat(instance: _FirebaseNamespace): void {
   instance.INTERNAL.registerComponent(
     new Component(
       AUTH_TYPE,
       container => {
         // getImmediate for FirebaseApp will always succeed
         const app = container.getProvider('app').getImmediate();
-        return new Auth(app);
+        const auth = container.getProvider('auth-exp').getImmediate();
+        return new Auth(app, auth as impl.AuthImpl);
       },
       ComponentType.PUBLIC
     )
@@ -80,4 +82,5 @@ function registerAuth(instance: _FirebaseNamespace): void {
   instance.registerVersion('auth', version);
 }
 
-registerAuth(firebase as _FirebaseNamespace);
+impl.registerAuth(_getClientPlatform());
+registerAuthCompat(firebase as _FirebaseNamespace);

--- a/packages-exp/auth-compat-exp/index.ts
+++ b/packages-exp/auth-compat-exp/index.ts
@@ -42,8 +42,7 @@ function registerAuthCompat(instance: _FirebaseNamespace): void {
       container => {
         // getImmediate for FirebaseApp will always succeed
         const app = container.getProvider('app').getImmediate();
-        const auth = container.getProvider('auth-exp').getImmediate();
-        return new Auth(app, auth as impl.AuthImpl);
+        return new Auth(app);
       },
       ComponentType.PUBLIC
     )
@@ -82,5 +81,4 @@ function registerAuthCompat(instance: _FirebaseNamespace): void {
   instance.registerVersion('auth', version);
 }
 
-impl.registerAuth(_getClientPlatform());
 registerAuthCompat(firebase as _FirebaseNamespace);

--- a/packages-exp/auth-compat-exp/index.ts
+++ b/packages-exp/auth-compat-exp/index.ts
@@ -28,6 +28,7 @@ import {
 import { version } from './package.json';
 import { Auth } from './src/auth';
 import { Persistence } from './src/persistence';
+import { PhoneAuthProvider } from './src/phone_auth_provider';
 import { _getClientPlatform } from './src/platform';
 import { RecaptchaVerifier } from './src/recaptcha_verifier';
 
@@ -64,7 +65,7 @@ function registerAuthCompat(instance: _FirebaseNamespace): void {
         GoogleAuthProvider: impl.GoogleAuthProvider,
         OAuthProvider: impl.OAuthProvider,
         //   SAMLAuthProvider,
-        PhoneAuthProvider: impl.PhoneAuthProvider,
+        PhoneAuthProvider: PhoneAuthProvider,
         PhoneMultiFactorGenerator: impl.PhoneMultiFactorGenerator,
         RecaptchaVerifier,
         TwitterAuthProvider: impl.TwitterAuthProvider,

--- a/packages-exp/auth-compat-exp/index.ts
+++ b/packages-exp/auth-compat-exp/index.ts
@@ -65,7 +65,7 @@ function registerAuthCompat(instance: _FirebaseNamespace): void {
         GoogleAuthProvider: impl.GoogleAuthProvider,
         OAuthProvider: impl.OAuthProvider,
         //   SAMLAuthProvider,
-        PhoneAuthProvider: PhoneAuthProvider,
+        PhoneAuthProvider,
         PhoneMultiFactorGenerator: impl.PhoneMultiFactorGenerator,
         RecaptchaVerifier,
         TwitterAuthProvider: impl.TwitterAuthProvider,

--- a/packages-exp/auth-compat-exp/index.ts
+++ b/packages-exp/auth-compat-exp/index.ts
@@ -43,7 +43,8 @@ function registerAuthCompat(instance: _FirebaseNamespace): void {
       container => {
         // getImmediate for FirebaseApp will always succeed
         const app = container.getProvider('app').getImmediate();
-        return new Auth(app);
+        const auth = container.getProvider('auth-exp').getImmediate();
+        return new Auth(app, auth as impl.AuthImpl);
       },
       ComponentType.PUBLIC
     )
@@ -82,4 +83,5 @@ function registerAuthCompat(instance: _FirebaseNamespace): void {
   instance.registerVersion('auth', version);
 }
 
+impl.registerAuth(_getClientPlatform());
 registerAuthCompat(firebase as _FirebaseNamespace);

--- a/packages-exp/auth-compat-exp/package.json
+++ b/packages-exp/auth-compat-exp/package.json
@@ -38,7 +38,7 @@
   },
   "license": "Apache-2.0",
   "devDependencies": {
-    "@firebase/app": "0.6.11",
+    "@firebase/app-compat": "0.x",
     "rollup": "2.29.0",
     "rollup-plugin-json": "4.0.0",
     "rollup-plugin-replace": "2.2.0",

--- a/packages-exp/auth-compat-exp/package.json
+++ b/packages-exp/auth-compat-exp/package.json
@@ -25,7 +25,7 @@
     "prepare": "yarn build"
   },
   "peerDependencies": {
-    "@firebase/app-exp": "0.x",
+    "@firebase/app-compat": "0.x",
     "@firebase/app-types": "0.x"
   },
   "dependencies": {

--- a/packages-exp/auth-compat-exp/package.json
+++ b/packages-exp/auth-compat-exp/package.json
@@ -25,7 +25,7 @@
     "prepare": "yarn build"
   },
   "peerDependencies": {
-    "@firebase/app": "0.x",
+    "@firebase/app-exp": "0.x",
     "@firebase/app-types": "0.x"
   },
   "dependencies": {

--- a/packages-exp/auth-compat-exp/rollup.config.js
+++ b/packages-exp/auth-compat-exp/rollup.config.js
@@ -73,7 +73,7 @@ const es5Builds = [
       extend: true,
       name: 'firebase',
       globals: {
-        '@firebase/app': 'firebase'
+        '@firebase/app-compat': 'firebase'
       },
       /**
        * use iife to avoid below error in the old Safari browser
@@ -95,7 +95,7 @@ const es5Builds = [
           }`
     },
     plugins: [...es5BuildPlugins, uglify()],
-    external: ['@firebase/app']
+    external: ['@firebase/app-compat']
   }
 ];
 

--- a/packages-exp/auth-compat-exp/src/auth.ts
+++ b/packages-exp/auth-compat-exp/src/auth.ts
@@ -312,7 +312,7 @@ function wrapObservers(
   // We know 'next' is now a function
   const oldNext = next as (a: compat.User | null) => unknown;
 
-  const newNext = (user: externs.User | null) =>
+  const newNext = (user: externs.User | null): unknown =>
     oldNext(user && User.getOrCreate(user as externs.User));
   return {
     next: newNext,

--- a/packages-exp/auth-compat-exp/src/auth.ts
+++ b/packages-exp/auth-compat-exp/src/auth.ts
@@ -82,10 +82,10 @@ export class Auth implements compat.FirebaseAuth, Wrapper<externs.Auth> {
   }
   get settings(): compat.AuthSettings {
     return this.auth.settings;
-  };
+  }
   get tenantId(): string | null {
     return this.auth.tenantId;
-  };
+  }
   useDeviceLanguage(): void {
     this.auth.useDeviceLanguage();
   }
@@ -146,34 +146,30 @@ export class Auth implements compat.FirebaseAuth, Wrapper<externs.Auth> {
     errorFn?: (error: compat.Error) => unknown,
     completed?: Unsubscribe
   ): Unsubscribe {
-    const {next, error, complete} = wrapObservers(nextOrObserver, errorFn, completed);
-    return this.auth.onAuthStateChanged(
-      next!,
-      error,
-      complete
+    const { next, error, complete } = wrapObservers(
+      nextOrObserver,
+      errorFn,
+      completed
     );
+    return this.auth.onAuthStateChanged(next!, error, complete);
   }
   onIdTokenChanged(
     nextOrObserver: Observer<unknown> | ((a: compat.User | null) => unknown),
     errorFn?: (error: compat.Error) => unknown,
     completed?: Unsubscribe
   ): Unsubscribe {
-    const {next, error, complete} = wrapObservers(nextOrObserver, errorFn, completed);
-    return this.auth.onIdTokenChanged(
-      next!,
-      error,
-      complete
+    const { next, error, complete } = wrapObservers(
+      nextOrObserver,
+      errorFn,
+      completed
     );
+    return this.auth.onIdTokenChanged(next!, error, complete);
   }
   sendSignInLinkToEmail(
     email: string,
     actionCodeSettings: compat.ActionCodeSettings
   ): Promise<void> {
-    return impl.sendSignInLinkToEmail(
-      this.auth,
-      email,
-      actionCodeSettings
-    );
+    return impl.sendSignInLinkToEmail(this.auth, email, actionCodeSettings);
   }
   sendPasswordResetEmail(
     email: string,
@@ -207,9 +203,7 @@ export class Auth implements compat.FirebaseAuth, Wrapper<externs.Auth> {
       }
     }
 
-    return this.auth.setPersistence(
-      convertPersistence(this.auth, persistence)
-    );
+    return this.auth.setPersistence(convertPersistence(this.auth, persistence));
   }
 
   signInAndRetrieveDataWithCredential(
@@ -218,20 +212,14 @@ export class Auth implements compat.FirebaseAuth, Wrapper<externs.Auth> {
     return this.signInWithCredential(credential);
   }
   signInAnonymously(): Promise<compat.UserCredential> {
-    return convertCredential(
-      this.auth,
-      impl.signInAnonymously(this.auth)
-    );
+    return convertCredential(this.auth, impl.signInAnonymously(this.auth));
   }
   signInWithCredential(
     credential: compat.AuthCredential
   ): Promise<compat.UserCredential> {
     return convertCredential(
       this.auth,
-      impl.signInWithCredential(
-        this.auth,
-        credential as externs.AuthCredential
-      )
+      impl.signInWithCredential(this.auth, credential as externs.AuthCredential)
     );
   }
   signInWithCustomToken(token: string): Promise<compat.UserCredential> {
@@ -311,19 +299,24 @@ export class Auth implements compat.FirebaseAuth, Wrapper<externs.Auth> {
   }
 }
 
-function wrapObservers(nextOrObserver: Observer<unknown> | ((a: compat.User|null) => unknown),
-error?: (error: compat.Error) => unknown,
-complete?: Unsubscribe): Partial<Observer<externs.User|null>> {
+function wrapObservers(
+  nextOrObserver: Observer<unknown> | ((a: compat.User | null) => unknown),
+  error?: (error: compat.Error) => unknown,
+  complete?: Unsubscribe
+): Partial<Observer<externs.User | null>> {
   let next = nextOrObserver;
   if (typeof nextOrObserver !== 'function') {
-    ({next, error, complete} = nextOrObserver);
+    ({ next, error, complete } = nextOrObserver);
   }
 
   // We know 'next' is now a function
-  const oldNext = next as ((a: compat.User|null) => unknown);
+  const oldNext = next as (a: compat.User | null) => unknown;
 
-  const newNext = (user: externs.User|null) => oldNext(user && User.getOrCreate(user as externs.User));
+  const newNext = (user: externs.User | null) =>
+    oldNext(user && User.getOrCreate(user as externs.User));
   return {
-    next: newNext, error: error as ErrorFn, complete
+    next: newNext,
+    error: error as ErrorFn,
+    complete
   };
 }

--- a/packages-exp/auth-compat-exp/src/auth.ts
+++ b/packages-exp/auth-compat-exp/src/auth.ts
@@ -36,9 +36,9 @@ import {
 import { unwrap, Wrapper } from './wrap';
 
 export class Auth implements compat.FirebaseAuth, Wrapper<externs.Auth> {
-  private readonly auth: impl.AuthImpl;
+  // private readonly auth: impl.AuthImpl;
 
-  constructor(readonly app: FirebaseApp) {
+  constructor(readonly app: FirebaseApp, private readonly auth: impl.AuthImpl) {
     const { apiKey, authDomain } = app.options;
 
     // TODO(avolkovi): Implement proper persistence fallback
@@ -59,7 +59,7 @@ export class Auth implements compat.FirebaseAuth, Wrapper<externs.Auth> {
       sdkClientVersion: impl._getClientVersion(_getClientPlatform())
     };
 
-    this.auth = new impl.AuthImpl(app, config);
+    // this.auth = new impl.AuthImpl(app, config);
 
     // This promise is intended to float; auth initialization happens in the
     // background, meanwhile the auth object may be used by the app.

--- a/packages-exp/auth-compat-exp/src/auth.ts
+++ b/packages-exp/auth-compat-exp/src/auth.ts
@@ -39,7 +39,7 @@ export class Auth implements compat.FirebaseAuth, Wrapper<externs.Auth> {
   // private readonly auth: impl.AuthImpl;
 
   constructor(readonly app: FirebaseApp, private readonly auth: impl.AuthImpl) {
-    const { apiKey, authDomain } = app.options;
+    const { apiKey } = app.options;
 
     // TODO(avolkovi): Implement proper persistence fallback
     const hierarchy = [impl.indexedDBLocalPersistence].map<impl.Persistence>(
@@ -50,16 +50,6 @@ export class Auth implements compat.FirebaseAuth, Wrapper<externs.Auth> {
     impl.assertFn(apiKey, impl.AuthErrorCode.INVALID_API_KEY, {
       appName: app.name
     });
-    const config: externs.Config = {
-      apiKey,
-      authDomain,
-      apiHost: impl.DEFAULT_API_HOST,
-      tokenApiHost: impl.DEFAULT_TOKEN_API_HOST,
-      apiScheme: impl.DEFAULT_API_SCHEME,
-      sdkClientVersion: impl._getClientVersion(_getClientPlatform())
-    };
-
-    // this.auth = new impl.AuthImpl(app, config);
 
     // This promise is intended to float; auth initialization happens in the
     // background, meanwhile the auth object may be used by the app.

--- a/packages-exp/auth-compat-exp/src/auth.ts
+++ b/packages-exp/auth-compat-exp/src/auth.ts
@@ -33,13 +33,12 @@ import {
   convertConfirmationResult,
   convertCredential
 } from './user_credential';
+import { unwrap, Wrapper } from './wrap';
 
-export class Auth
-  extends impl.AuthImplCompat<User>
-  implements compat.FirebaseAuth {
-  readonly app: FirebaseApp;
+export class Auth implements compat.FirebaseAuth, Wrapper<externs.Auth> {
+  private readonly auth: impl.AuthImpl;
 
-  constructor(app: FirebaseApp) {
+  constructor(readonly app: FirebaseApp) {
     const { apiKey, authDomain } = app.options;
 
     // TODO(avolkovi): Implement proper persistence fallback
@@ -60,34 +59,50 @@ export class Auth
       sdkClientVersion: impl._getClientVersion(_getClientPlatform())
     };
 
-    super(app, config, User);
-    this.app = app;
+    this.auth = new impl.AuthImpl(app, config);
 
     // This promise is intended to float; auth initialization happens in the
     // background, meanwhile the auth object may be used by the app.
     // eslint-disable-next-line @typescript-eslint/no-floating-promises
-    this._initializeWithPersistence(
+    this.auth._initializeWithPersistence(
       hierarchy,
       impl.browserPopupRedirectResolver
     );
   }
 
-  _asExtern(): externs.Auth {
-    // We need this unsafe cast before calling impl.* methods since our implementation of
-    // setPersistence, onAuthStateChanged and onIdTokenChanged has a different signature
-    return (this as unknown) as externs.Auth;
+  get currentUser(): compat.User | null {
+    if (!this.auth.currentUser) {
+      return null;
+    }
+
+    return User.getOrCreate(this.auth.currentUser);
+  }
+  get languageCode(): string | null {
+    return this.auth.languageCode;
+  }
+  get settings(): compat.AuthSettings {
+    return this.auth.settings;
+  };
+  get tenantId(): string | null {
+    return this.auth.tenantId;
+  };
+  useDeviceLanguage(): void {
+    this.auth.useDeviceLanguage();
+  }
+  signOut(): Promise<void> {
+    return this.auth.signOut();
   }
 
   applyActionCode(code: string): Promise<void> {
-    return impl.applyActionCode(this._asExtern(), code);
+    return impl.applyActionCode(this.auth, code);
   }
 
   checkActionCode(code: string): Promise<compat.ActionCodeInfo> {
-    return impl.checkActionCode(this._asExtern(), code);
+    return impl.checkActionCode(this.auth, code);
   }
 
   confirmPasswordReset(code: string, newPassword: string): Promise<void> {
-    return impl.confirmPasswordReset(this._asExtern(), code, newPassword);
+    return impl.confirmPasswordReset(this.auth, code, newPassword);
   }
 
   async createUserWithEmailAndPassword(
@@ -95,18 +110,18 @@ export class Auth
     password: string
   ): Promise<compat.UserCredential> {
     return convertCredential(
-      this._asExtern(),
-      impl.createUserWithEmailAndPassword(this._asExtern(), email, password)
+      this.auth,
+      impl.createUserWithEmailAndPassword(this.auth, email, password)
     );
   }
   fetchProvidersForEmail(email: string): Promise<string[]> {
     return this.fetchSignInMethodsForEmail(email);
   }
   fetchSignInMethodsForEmail(email: string): Promise<string[]> {
-    return impl.fetchSignInMethodsForEmail(this._asExtern(), email);
+    return impl.fetchSignInMethodsForEmail(this.auth, email);
   }
   isSignInWithEmailLink(emailLink: string): boolean {
-    return impl.isSignInWithEmailLink(this._asExtern(), emailLink);
+    return impl.isSignInWithEmailLink(this.auth, emailLink);
   }
   async getRedirectResult(): Promise<compat.UserCredential> {
     impl.assertFn(
@@ -115,7 +130,7 @@ export class Auth
       { appName: this.app.name }
     );
     const credential = await impl.getRedirectResult(
-      this._asExtern(),
+      this.auth,
       impl.browserPopupRedirectResolver
     );
     if (!credential) {
@@ -124,28 +139,30 @@ export class Auth
         user: null
       };
     }
-    return convertCredential(this._asExtern(), Promise.resolve(credential));
+    return convertCredential(this.auth, Promise.resolve(credential));
   }
   onAuthStateChanged(
     nextOrObserver: Observer<unknown> | ((a: compat.User | null) => unknown),
-    error?: (error: compat.Error) => unknown,
+    errorFn?: (error: compat.Error) => unknown,
     completed?: Unsubscribe
   ): Unsubscribe {
-    return super._onAuthStateChanged(
-      nextOrObserver as externs.NextOrObserver<externs.User | null>,
-      error as ErrorFn,
-      completed
+    const {next, error, complete} = wrapObservers(nextOrObserver, errorFn, completed);
+    return this.auth.onAuthStateChanged(
+      next!,
+      error,
+      complete
     );
   }
   onIdTokenChanged(
     nextOrObserver: Observer<unknown> | ((a: compat.User | null) => unknown),
-    error?: (error: compat.Error) => unknown,
+    errorFn?: (error: compat.Error) => unknown,
     completed?: Unsubscribe
   ): Unsubscribe {
-    return super._onIdTokenChanged(
-      nextOrObserver as externs.NextOrObserver<externs.User | null>,
-      error as ErrorFn,
-      completed
+    const {next, error, complete} = wrapObservers(nextOrObserver, errorFn, completed);
+    return this.auth.onIdTokenChanged(
+      next!,
+      error,
+      complete
     );
   }
   sendSignInLinkToEmail(
@@ -153,7 +170,7 @@ export class Auth
     actionCodeSettings: compat.ActionCodeSettings
   ): Promise<void> {
     return impl.sendSignInLinkToEmail(
-      this._asExtern(),
+      this.auth,
       email,
       actionCodeSettings
     );
@@ -163,7 +180,7 @@ export class Auth
     actionCodeSettings?: compat.ActionCodeSettings | null
   ): Promise<void> {
     return impl.sendPasswordResetEmail(
-      this._asExtern(),
+      this.auth,
       email,
       actionCodeSettings || undefined
     );
@@ -190,8 +207,8 @@ export class Auth
       }
     }
 
-    return super._setPersistence(
-      convertPersistence(this._asExtern(), persistence)
+    return this.auth.setPersistence(
+      convertPersistence(this.auth, persistence)
     );
   }
 
@@ -202,25 +219,25 @@ export class Auth
   }
   signInAnonymously(): Promise<compat.UserCredential> {
     return convertCredential(
-      this._asExtern(),
-      impl.signInAnonymously(this._asExtern())
+      this.auth,
+      impl.signInAnonymously(this.auth)
     );
   }
   signInWithCredential(
     credential: compat.AuthCredential
   ): Promise<compat.UserCredential> {
     return convertCredential(
-      this._asExtern(),
+      this.auth,
       impl.signInWithCredential(
-        this._asExtern(),
+        this.auth,
         credential as externs.AuthCredential
       )
     );
   }
   signInWithCustomToken(token: string): Promise<compat.UserCredential> {
     return convertCredential(
-      this._asExtern(),
-      impl.signInWithCustomToken(this._asExtern(), token)
+      this.auth,
+      impl.signInWithCustomToken(this.auth, token)
     );
   }
   signInWithEmailAndPassword(
@@ -228,8 +245,8 @@ export class Auth
     password: string
   ): Promise<compat.UserCredential> {
     return convertCredential(
-      this._asExtern(),
-      impl.signInWithEmailAndPassword(this._asExtern(), email, password)
+      this.auth,
+      impl.signInWithEmailAndPassword(this.auth, email, password)
     );
   }
   signInWithEmailLink(
@@ -237,8 +254,8 @@ export class Auth
     emailLink?: string
   ): Promise<compat.UserCredential> {
     return convertCredential(
-      this._asExtern(),
-      impl.signInWithEmailLink(this._asExtern(), email, emailLink)
+      this.auth,
+      impl.signInWithEmailLink(this.auth, email, emailLink)
     );
   }
   signInWithPhoneNumber(
@@ -246,11 +263,11 @@ export class Auth
     applicationVerifier: compat.ApplicationVerifier
   ): Promise<compat.ConfirmationResult> {
     return convertConfirmationResult(
-      this._asExtern(),
+      this.auth,
       impl.signInWithPhoneNumber(
-        this._asExtern(),
+        this.auth,
         phoneNumber,
-        applicationVerifier
+        unwrap(applicationVerifier)
       )
     );
   }
@@ -263,9 +280,9 @@ export class Auth
       { appName: this.app.name }
     );
     return convertCredential(
-      this._asExtern(),
+      this.auth,
       impl.signInWithPopup(
-        this._asExtern(),
+        this.auth,
         provider as externs.AuthProvider,
         impl.browserPopupRedirectResolver
       )
@@ -278,15 +295,35 @@ export class Auth
       { appName: this.app.name }
     );
     return impl.signInWithRedirect(
-      this._asExtern(),
+      this.auth,
       provider as externs.AuthProvider,
       impl.browserPopupRedirectResolver
     );
   }
-  updateCurrentUser(user: User | null): Promise<void> {
-    return super.updateCurrentUser(user);
+  updateCurrentUser(user: compat.User | null): Promise<void> {
+    return this.auth.updateCurrentUser(unwrap(user));
   }
   verifyPasswordResetCode(code: string): Promise<string> {
-    return impl.verifyPasswordResetCode(this._asExtern(), code);
+    return impl.verifyPasswordResetCode(this.auth, code);
   }
+  unwrap(): externs.Auth {
+    return this.auth;
+  }
+}
+
+function wrapObservers(nextOrObserver: Observer<unknown> | ((a: compat.User|null) => unknown),
+error?: (error: compat.Error) => unknown,
+complete?: Unsubscribe): Partial<Observer<externs.User|null>> {
+  let next = nextOrObserver;
+  if (typeof nextOrObserver !== 'function') {
+    ({next, error, complete} = nextOrObserver);
+  }
+
+  // We know 'next' is now a function
+  const oldNext = next as ((a: compat.User|null) => unknown);
+
+  const newNext = (user: externs.User|null) => oldNext(user && User.getOrCreate(user as externs.User));
+  return {
+    next: newNext, error: error as ErrorFn, complete
+  };
 }

--- a/packages-exp/auth-compat-exp/src/phone_auth_provider.ts
+++ b/packages-exp/auth-compat-exp/src/phone_auth_provider.ts
@@ -1,0 +1,31 @@
+import * as impl from '@firebase/auth-exp/internal';
+import * as compat from '@firebase/auth-types';
+import * as externs from '@firebase/auth-types-exp';
+import firebase from '@firebase/app-compat';
+import { unwrap, Wrapper } from './wrap';
+
+export class PhoneAuthProvider implements compat.PhoneAuthProvider, Wrapper<externs.PhoneAuthProvider> {
+  providerId = 'phone';
+  private readonly phoneProvider: impl.PhoneAuthProvider;
+
+  static PHONE_SIGN_IN_METHOD = impl.PhoneAuthProvider.PHONE_SIGN_IN_METHOD;
+  static PROVIDER_ID = impl.PhoneAuthProvider.PROVIDER_ID;
+
+  static credential ( verificationId :  string ,  verificationCode :  string ) : compat.AuthCredential {
+    return impl.PhoneAuthProvider.credential(verificationId, verificationCode);
+  }
+
+  constructor() {
+    this.phoneProvider = new impl.PhoneAuthProvider(unwrap(firebase.auth!()));
+  }
+
+  verifyPhoneNumber(phoneInfoOptions: string | compat.PhoneSingleFactorInfoOptions | compat.PhoneMultiFactorEnrollInfoOptions | compat.PhoneMultiFactorSignInInfoOptions, applicationVerifier: compat.ApplicationVerifier): Promise<string> {
+    // The implementation matches but the types are subtly incompatible
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return this.phoneProvider.verifyPhoneNumber(phoneInfoOptions as any, unwrap(applicationVerifier));
+  }
+
+  unwrap(): externs.PhoneAuthProvider {
+    return this.phoneProvider;
+  }
+}

--- a/packages-exp/auth-compat-exp/src/phone_auth_provider.ts
+++ b/packages-exp/auth-compat-exp/src/phone_auth_provider.ts
@@ -48,9 +48,9 @@ export class PhoneAuthProvider
       | compat.PhoneMultiFactorSignInInfoOptions,
     applicationVerifier: compat.ApplicationVerifier
   ): Promise<string> {
-    // The implementation matches but the types are subtly incompatible
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     return this.phoneProvider.verifyPhoneNumber(
+      // The implementation matches but the types are subtly incompatible
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       phoneInfoOptions as any,
       unwrap(applicationVerifier)
     );

--- a/packages-exp/auth-compat-exp/src/phone_auth_provider.ts
+++ b/packages-exp/auth-compat-exp/src/phone_auth_provider.ts
@@ -1,17 +1,38 @@
+/**
+ * @license
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import * as impl from '@firebase/auth-exp/internal';
 import * as compat from '@firebase/auth-types';
 import * as externs from '@firebase/auth-types-exp';
 import firebase from '@firebase/app-compat';
 import { unwrap, Wrapper } from './wrap';
 
-export class PhoneAuthProvider implements compat.PhoneAuthProvider, Wrapper<externs.PhoneAuthProvider> {
+export class PhoneAuthProvider
+  implements compat.PhoneAuthProvider, Wrapper<externs.PhoneAuthProvider> {
   providerId = 'phone';
   private readonly phoneProvider: impl.PhoneAuthProvider;
 
   static PHONE_SIGN_IN_METHOD = impl.PhoneAuthProvider.PHONE_SIGN_IN_METHOD;
   static PROVIDER_ID = impl.PhoneAuthProvider.PROVIDER_ID;
 
-  static credential ( verificationId :  string ,  verificationCode :  string ) : compat.AuthCredential {
+  static credential(
+    verificationId: string,
+    verificationCode: string
+  ): compat.AuthCredential {
     return impl.PhoneAuthProvider.credential(verificationId, verificationCode);
   }
 
@@ -19,10 +40,20 @@ export class PhoneAuthProvider implements compat.PhoneAuthProvider, Wrapper<exte
     this.phoneProvider = new impl.PhoneAuthProvider(unwrap(firebase.auth!()));
   }
 
-  verifyPhoneNumber(phoneInfoOptions: string | compat.PhoneSingleFactorInfoOptions | compat.PhoneMultiFactorEnrollInfoOptions | compat.PhoneMultiFactorSignInInfoOptions, applicationVerifier: compat.ApplicationVerifier): Promise<string> {
+  verifyPhoneNumber(
+    phoneInfoOptions:
+      | string
+      | compat.PhoneSingleFactorInfoOptions
+      | compat.PhoneMultiFactorEnrollInfoOptions
+      | compat.PhoneMultiFactorSignInInfoOptions,
+    applicationVerifier: compat.ApplicationVerifier
+  ): Promise<string> {
     // The implementation matches but the types are subtly incompatible
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    return this.phoneProvider.verifyPhoneNumber(phoneInfoOptions as any, unwrap(applicationVerifier));
+    return this.phoneProvider.verifyPhoneNumber(
+      phoneInfoOptions as any,
+      unwrap(applicationVerifier)
+    );
   }
 
   unwrap(): externs.PhoneAuthProvider {

--- a/packages-exp/auth-compat-exp/src/recaptcha_verifier.ts
+++ b/packages-exp/auth-compat-exp/src/recaptcha_verifier.ts
@@ -40,7 +40,8 @@ export class RecaptchaVerifier
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       parameters as any,
 
-      unwrap(app.auth!()));
+      unwrap(app.auth!())
+    );
     this.type = this.verifier.type;
   }
   clear(): void {

--- a/packages-exp/auth-compat-exp/src/recaptcha_verifier.ts
+++ b/packages-exp/auth-compat-exp/src/recaptcha_verifier.ts
@@ -15,15 +15,17 @@
  * limitations under the License.
  */
 
-import firebase from '@firebase/app';
+import firebase from '@firebase/app-compat';
 import { FirebaseApp } from '@firebase/app-types';
 import * as impl from '@firebase/auth-exp/internal';
 import * as compat from '@firebase/auth-types';
 import * as externs from '@firebase/auth-types-exp';
+import { unwrap, Wrapper } from './wrap';
 
 export class RecaptchaVerifier
-  extends impl.RecaptchaVerifier
-  implements compat.RecaptchaVerifier {
+  implements compat.RecaptchaVerifier, Wrapper<externs.ApplicationVerifier> {
+  readonly verifier: externs.RecaptchaVerifier;
+  type: string;
   constructor(
     container: HTMLElement | string,
     parameters?: object | null,
@@ -33,11 +35,24 @@ export class RecaptchaVerifier
     impl.assertFn(app.options?.apiKey, impl.AuthErrorCode.INVALID_API_KEY, {
       appName: app.name
     });
-    super(
+    this.verifier = new impl.RecaptchaVerifier(
       container,
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       parameters as any,
-      (app.auth!() as unknown) as externs.Auth
-    );
+
+      unwrap(app.auth!()));
+    this.type = this.verifier.type;
+  }
+  clear(): void {
+    this.verifier.clear();
+  }
+  render(): Promise<number> {
+    return this.verifier.render();
+  }
+  verify(): Promise<string> {
+    return this.verifier.verify();
+  }
+  unwrap(): externs.ApplicationVerifier {
+    return this.verifier;
   }
 }

--- a/packages-exp/auth-compat-exp/src/user.ts
+++ b/packages-exp/auth-compat-exp/src/user.ts
@@ -77,7 +77,11 @@ export class User implements compat.User, Wrapper<externs.User> {
   ): Promise<compat.ConfirmationResult> {
     return convertConfirmationResult(
       this.auth,
-      impl.linkWithPhoneNumber(this.user, phoneNumber, unwrap(applicationVerifier))
+      impl.linkWithPhoneNumber(
+        this.user,
+        phoneNumber,
+        unwrap(applicationVerifier)
+      )
     );
   }
   async linkWithPopup(
@@ -121,7 +125,11 @@ export class User implements compat.User, Wrapper<externs.User> {
   ): Promise<compat.ConfirmationResult> {
     return convertConfirmationResult(
       this.auth,
-      impl.reauthenticateWithPhoneNumber(this.user, phoneNumber, unwrap(applicationVerifier))
+      impl.reauthenticateWithPhoneNumber(
+        this.user,
+        phoneNumber,
+        unwrap(applicationVerifier)
+      )
     );
   }
   reauthenticateWithPopup(
@@ -174,7 +182,11 @@ export class User implements compat.User, Wrapper<externs.User> {
     newEmail: string,
     actionCodeSettings?: compat.ActionCodeSettings | null
   ): Promise<void> {
-    return impl.verifyBeforeUpdateEmail(this.user, newEmail, actionCodeSettings);
+    return impl.verifyBeforeUpdateEmail(
+      this.user,
+      newEmail,
+      actionCodeSettings
+    );
   }
   unwrap(): externs.User {
     return this.user;
@@ -216,6 +228,6 @@ export class User implements compat.User, Wrapper<externs.User> {
     return this.user.uid;
   }
   private get auth(): externs.Auth {
-    return (this.user as impl.UserImpl).auth as unknown as externs.Auth;
+    return ((this.user as impl.UserImpl).auth as unknown) as externs.Auth;
   }
 }

--- a/packages-exp/auth-compat-exp/src/user.ts
+++ b/packages-exp/auth-compat-exp/src/user.ts
@@ -49,7 +49,7 @@ export class User implements compat.User, Wrapper<externs.User> {
   reload(): Promise<void> {
     return this.user.reload();
   }
-  toJSON(): Object {
+  toJSON(): object {
     return this.user.toJSON();
   }
   getIdTokenResult(forceRefresh?: boolean): Promise<compat.IdTokenResult> {
@@ -203,7 +203,7 @@ export class User implements compat.User, Wrapper<externs.User> {
   get phoneNumber(): string | null {
     return this.user.phoneNumber;
   }
-  get providerData(): (compat.UserInfo | null)[] {
+  get providerData(): Array<compat.UserInfo | null> {
     return this.user.providerData;
   }
   get refreshToken(): string {

--- a/packages-exp/auth-compat-exp/src/user.ts
+++ b/packages-exp/auth-compat-exp/src/user.ts
@@ -27,7 +27,7 @@ import { unwrap, Wrapper } from './wrap';
 export class User implements compat.User, Wrapper<externs.User> {
   // Maintain a map so that there's always a 1:1 mapping between new User and
   // legacy compat users
-  private static readonly USER_MAP = new Map<externs.User, User>();
+  private static readonly USER_MAP = new WeakMap<externs.User, User>();
 
   readonly multiFactor: compat.MultiFactorUser;
 

--- a/packages-exp/auth-compat-exp/src/user_credential.ts
+++ b/packages-exp/auth-compat-exp/src/user_credential.ts
@@ -108,7 +108,7 @@ export async function convertCredential(
     additionalUserInfo: impl.getAdditionalUserInfo(
       credential as impl.UserCredential
     ),
-    user: user as User
+    user: User.getOrCreate(user)
   };
 }
 

--- a/packages-exp/auth-compat-exp/src/wrap.ts
+++ b/packages-exp/auth-compat-exp/src/wrap.ts
@@ -1,0 +1,7 @@
+export interface Wrapper<T> {
+  unwrap(): T;
+}
+
+export function unwrap<T>(object: unknown): T {
+  return (object as Wrapper<T>).unwrap();
+}

--- a/packages-exp/auth-compat-exp/src/wrap.ts
+++ b/packages-exp/auth-compat-exp/src/wrap.ts
@@ -1,3 +1,20 @@
+/**
+ * @license
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 export interface Wrapper<T> {
   unwrap(): T;
 }

--- a/packages-exp/auth-exp/internal/index.ts
+++ b/packages-exp/auth-exp/internal/index.ts
@@ -28,6 +28,7 @@ export { Persistence } from '../src/core/persistence';
 export { UserImpl } from '../src/core/user/user_impl';
 export { _getInstance } from '../src/core/util/instantiator';
 export { UserCredential, UserParameters } from '../src/model/user';
+export { registerAuth } from '../src/core/auth/register';
 export {
   DEFAULT_API_HOST,
   DEFAULT_API_SCHEME,

--- a/packages-exp/auth-exp/internal/index.ts
+++ b/packages-exp/auth-exp/internal/index.ts
@@ -29,10 +29,10 @@ export { UserImpl } from '../src/core/user/user_impl';
 export { _getInstance } from '../src/core/util/instantiator';
 export { UserCredential, UserParameters } from '../src/model/user';
 export {
-  AuthImplCompat,
   DEFAULT_API_HOST,
   DEFAULT_API_SCHEME,
-  DEFAULT_TOKEN_API_HOST
+  DEFAULT_TOKEN_API_HOST,
+  AuthImpl
 } from '../src/core/auth/auth_impl';
 
 export { ClientPlatform, _getClientVersion } from '../src/core/util/version';

--- a/packages-exp/auth-exp/src/api/account_management/account.ts
+++ b/packages-exp/auth-exp/src/api/account_management/account.ts
@@ -17,14 +17,14 @@
 
 import { Endpoint, HttpMethod, _performApiRequest } from '../';
 import { MfaEnrollment } from './mfa';
-import { AuthCore } from '../../model/auth';
+import { Auth } from '@firebase/auth-types-exp';
 
 export interface DeleteAccountRequest {
   idToken: string;
 }
 
 export async function deleteAccount(
-  auth: AuthCore,
+  auth: Auth,
   request: DeleteAccountRequest
 ): Promise<void> {
   return _performApiRequest<DeleteAccountRequest, void>(
@@ -54,7 +54,7 @@ export interface DeleteLinkedAccountsResponse {
 }
 
 export async function deleteLinkedAccounts(
-  auth: AuthCore,
+  auth: Auth,
   request: DeleteLinkedAccountsRequest
 ): Promise<DeleteLinkedAccountsResponse> {
   return _performApiRequest<
@@ -87,7 +87,7 @@ export interface GetAccountInfoResponse {
 }
 
 export async function getAccountInfo(
-  auth: AuthCore,
+  auth: Auth,
   request: GetAccountInfoRequest
 ): Promise<GetAccountInfoResponse> {
   return _performApiRequest<GetAccountInfoRequest, GetAccountInfoResponse>(

--- a/packages-exp/auth-exp/src/api/account_management/email_and_password.ts
+++ b/packages-exp/auth-exp/src/api/account_management/email_and_password.ts
@@ -15,12 +15,11 @@
  * limitations under the License.
  */
 
-import { Operation } from '@firebase/auth-types-exp';
+import { Operation, Auth } from '@firebase/auth-types-exp';
 
 import { Endpoint, HttpMethod, _performApiRequest } from '..';
 import { IdTokenResponse } from '../../model/id_token';
 import { MfaEnrollment } from './mfa';
-import { AuthCore } from '../../model/auth';
 
 export interface ResetPasswordRequest {
   oobCode: string;
@@ -35,7 +34,7 @@ export interface ResetPasswordResponse {
 }
 
 export async function resetPassword(
-  auth: AuthCore,
+  auth: Auth,
   request: ResetPasswordRequest
 ): Promise<ResetPasswordResponse> {
   return _performApiRequest<ResetPasswordRequest, ResetPasswordResponse>(
@@ -55,7 +54,7 @@ export interface UpdateEmailPasswordRequest {
 export interface UpdateEmailPasswordResponse extends IdTokenResponse {}
 
 export async function updateEmailPassword(
-  auth: AuthCore,
+  auth: Auth,
   request: UpdateEmailPasswordRequest
 ): Promise<UpdateEmailPasswordResponse> {
   return _performApiRequest<
@@ -71,7 +70,7 @@ export interface ApplyActionCodeRequest {
 export interface ApplyActionCodeResponse {}
 
 export async function applyActionCode(
-  auth: AuthCore,
+  auth: Auth,
   request: ApplyActionCodeRequest
 ): Promise<ApplyActionCodeResponse> {
   return _performApiRequest<ApplyActionCodeRequest, ApplyActionCodeResponse>(

--- a/packages-exp/auth-exp/src/api/account_management/mfa.ts
+++ b/packages-exp/auth-exp/src/api/account_management/mfa.ts
@@ -18,7 +18,7 @@
 import { Endpoint, HttpMethod, _performApiRequest } from '..';
 import { SignInWithPhoneNumberRequest } from '../authentication/sms';
 import { FinalizeMfaResponse } from '../authentication/mfa';
-import {Auth} from '../../model/auth';
+import { Auth } from '../../model/auth';
 
 /**
  * MFA Info as returned by the API

--- a/packages-exp/auth-exp/src/api/account_management/mfa.ts
+++ b/packages-exp/auth-exp/src/api/account_management/mfa.ts
@@ -18,7 +18,7 @@
 import { Endpoint, HttpMethod, _performApiRequest } from '..';
 import { SignInWithPhoneNumberRequest } from '../authentication/sms';
 import { FinalizeMfaResponse } from '../authentication/mfa';
-import { AuthCore } from '../../model/auth';
+import {Auth} from '../../model/auth';
 
 /**
  * MFA Info as returned by the API
@@ -57,7 +57,7 @@ export interface StartPhoneMfaEnrollmentResponse {
 }
 
 export function startEnrollPhoneMfa(
-  auth: AuthCore,
+  auth: Auth,
   request: Omit<StartPhoneMfaEnrollmentRequest, 'tenantId'>
 ): Promise<StartPhoneMfaEnrollmentResponse> {
   return _performApiRequest<
@@ -80,7 +80,7 @@ export interface FinalizePhoneMfaEnrollmentResponse
   extends FinalizeMfaResponse {}
 
 export function finalizeEnrollPhoneMfa(
-  auth: AuthCore,
+  auth: Auth,
   request: Omit<FinalizePhoneMfaEnrollmentRequest, 'tenantId'>
 ): Promise<FinalizePhoneMfaEnrollmentResponse> {
   return _performApiRequest<
@@ -101,7 +101,7 @@ export interface WithdrawMfaRequest {
 export interface WithdrawMfaResponse extends FinalizeMfaResponse {}
 
 export function withdrawMfa(
-  auth: AuthCore,
+  auth: Auth,
   request: Omit<WithdrawMfaRequest, 'tenantId'>
 ): Promise<WithdrawMfaResponse> {
   return _performApiRequest<WithdrawMfaRequest, WithdrawMfaResponse>(

--- a/packages-exp/auth-exp/src/api/account_management/profile.ts
+++ b/packages-exp/auth-exp/src/api/account_management/profile.ts
@@ -17,7 +17,7 @@
 
 import { Endpoint, HttpMethod, _performApiRequest } from '..';
 import { IdTokenResponse } from '../../model/id_token';
-import { AuthCore } from '../../model/auth';
+import { Auth } from '@firebase/auth-types-exp';
 
 export interface UpdateProfileRequest {
   idToken: string;
@@ -31,7 +31,7 @@ export interface UpdateProfileResponse extends IdTokenResponse {
 }
 
 export async function updateProfile(
-  auth: AuthCore,
+  auth: Auth,
   request: UpdateProfileRequest
 ): Promise<UpdateProfileResponse> {
   return _performApiRequest<UpdateProfileRequest, UpdateProfileResponse>(

--- a/packages-exp/auth-exp/src/api/authentication/create_auth_uri.ts
+++ b/packages-exp/auth-exp/src/api/authentication/create_auth_uri.ts
@@ -16,7 +16,7 @@
  */
 
 import { Endpoint, HttpMethod, _performApiRequest } from '..';
-import { AuthCore } from '../../model/auth';
+import { Auth } from '@firebase/auth-types-exp';
 
 export interface CreateAuthUriRequest {
   identifier: string;
@@ -28,7 +28,7 @@ export interface CreateAuthUriResponse {
 }
 
 export async function createAuthUri(
-  auth: AuthCore,
+  auth: Auth,
   request: CreateAuthUriRequest
 ): Promise<CreateAuthUriResponse> {
   return _performApiRequest<CreateAuthUriRequest, CreateAuthUriResponse>(

--- a/packages-exp/auth-exp/src/api/authentication/custom_token.ts
+++ b/packages-exp/auth-exp/src/api/authentication/custom_token.ts
@@ -17,7 +17,7 @@
 
 import { Endpoint, HttpMethod, _performSignInRequest } from '..';
 import { IdTokenResponse } from '../../model/id_token';
-import { AuthCore } from '../../model/auth';
+import { Auth } from '@firebase/auth-types-exp';
 
 export interface SignInWithCustomTokenRequest {
   token: string;
@@ -26,7 +26,7 @@ export interface SignInWithCustomTokenRequest {
 export interface SignInWithCustomTokenResponse extends IdTokenResponse {}
 
 export async function signInWithCustomToken(
-  auth: AuthCore,
+  auth: Auth,
   request: SignInWithCustomTokenRequest
 ): Promise<SignInWithCustomTokenResponse> {
   return _performSignInRequest<

--- a/packages-exp/auth-exp/src/api/authentication/email_and_password.ts
+++ b/packages-exp/auth-exp/src/api/authentication/email_and_password.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { Operation } from '@firebase/auth-types-exp';
+import { Operation, Auth } from '@firebase/auth-types-exp';
 
 import {
   Endpoint,
@@ -24,7 +24,6 @@ import {
   _performSignInRequest
 } from '..';
 import { IdToken, IdTokenResponse } from '../../model/id_token';
-import { AuthCore } from '../../model/auth';
 
 export interface SignInWithPasswordRequest {
   returnSecureToken?: boolean;
@@ -38,7 +37,7 @@ export interface SignInWithPasswordResponse extends IdTokenResponse {
 }
 
 export async function signInWithPassword(
-  auth: AuthCore,
+  auth: Auth,
   request: SignInWithPasswordRequest
 ): Promise<SignInWithPasswordResponse> {
   return _performSignInRequest<
@@ -94,7 +93,7 @@ export interface EmailSignInResponse extends GetOobCodeResponse {}
 export interface VerifyAndChangeEmailResponse extends GetOobCodeRequest {}
 
 async function sendOobCode(
-  auth: AuthCore,
+  auth: Auth,
   request: GetOobCodeRequest
 ): Promise<GetOobCodeResponse> {
   return _performApiRequest<GetOobCodeRequest, GetOobCodeResponse>(
@@ -106,28 +105,28 @@ async function sendOobCode(
 }
 
 export async function sendEmailVerification(
-  auth: AuthCore,
+  auth: Auth,
   request: VerifyEmailRequest
 ): Promise<VerifyEmailResponse> {
   return sendOobCode(auth, request);
 }
 
 export async function sendPasswordResetEmail(
-  auth: AuthCore,
+  auth: Auth,
   request: PasswordResetRequest
 ): Promise<PasswordResetResponse> {
   return sendOobCode(auth, request);
 }
 
 export async function sendSignInLinkToEmail(
-  auth: AuthCore,
+  auth: Auth,
   request: EmailSignInRequest
 ): Promise<EmailSignInResponse> {
   return sendOobCode(auth, request);
 }
 
 export async function verifyAndChangeEmail(
-  auth: AuthCore,
+  auth: Auth,
   request: VerifyAndChangeEmailRequest
 ): Promise<VerifyAndChangeEmailResponse> {
   return sendOobCode(auth, request);

--- a/packages-exp/auth-exp/src/api/authentication/email_link.ts
+++ b/packages-exp/auth-exp/src/api/authentication/email_link.ts
@@ -17,7 +17,7 @@
 
 import { _performSignInRequest, Endpoint, HttpMethod } from '../';
 import { IdTokenResponse } from '../../model/id_token';
-import { AuthCore } from '../../model/auth';
+import { Auth } from '@firebase/auth-types-exp';
 
 export interface SignInWithEmailLinkRequest {
   email: string;
@@ -30,7 +30,7 @@ export interface SignInWithEmailLinkResponse extends IdTokenResponse {
 }
 
 export async function signInWithEmailLink(
-  auth: AuthCore,
+  auth: Auth,
   request: SignInWithEmailLinkRequest
 ): Promise<SignInWithEmailLinkResponse> {
   return _performSignInRequest<
@@ -45,7 +45,7 @@ export interface SignInWithEmailLinkForLinkingRequest
 }
 
 export async function signInWithEmailLinkForLinking(
-  auth: AuthCore,
+  auth: Auth,
   request: SignInWithEmailLinkForLinkingRequest
 ): Promise<SignInWithEmailLinkResponse> {
   return _performSignInRequest<

--- a/packages-exp/auth-exp/src/api/authentication/idp.ts
+++ b/packages-exp/auth-exp/src/api/authentication/idp.ts
@@ -17,7 +17,7 @@
 
 import { Endpoint, HttpMethod, _performSignInRequest } from '..';
 import { IdToken, IdTokenResponse } from '../../model/id_token';
-import { AuthCore } from '../../model/auth';
+import { Auth } from '@firebase/auth-types-exp';
 
 export interface SignInWithIdpRequest {
   requestUri: string;
@@ -39,7 +39,7 @@ export interface SignInWithIdpResponse extends IdTokenResponse {
 }
 
 export async function signInWithIdp(
-  auth: AuthCore,
+  auth: Auth,
   request: SignInWithIdpRequest
 ): Promise<SignInWithIdpResponse> {
   return _performSignInRequest<SignInWithIdpRequest, SignInWithIdpResponse>(

--- a/packages-exp/auth-exp/src/api/authentication/mfa.ts
+++ b/packages-exp/auth-exp/src/api/authentication/mfa.ts
@@ -16,7 +16,7 @@
  */
 
 import { _performApiRequest, Endpoint, HttpMethod } from '../';
-import { AuthCore } from '../../model/auth';
+import { Auth } from '@firebase/auth-types-exp';
 import { IdTokenResponse } from '../../model/id_token';
 import { MfaEnrollment } from '../account_management/mfa';
 import { SignInWithIdpResponse } from './idp';
@@ -51,7 +51,7 @@ export interface StartPhoneMfaSignInResponse {
 }
 
 export function startSignInPhoneMfa(
-  auth: AuthCore,
+  auth: Auth,
   request: Omit<StartPhoneMfaSignInRequest, 'tenantId'>
 ): Promise<StartPhoneMfaSignInResponse> {
   return _performApiRequest<
@@ -72,7 +72,7 @@ export interface FinalizePhoneMfaSignInRequest {
 export interface FinalizePhoneMfaSignInResponse extends FinalizeMfaResponse {}
 
 export function finalizeSignInPhoneMfa(
-  auth: AuthCore,
+  auth: Auth,
   request: Omit<FinalizePhoneMfaSignInRequest, 'tenantId'>
 ): Promise<FinalizePhoneMfaSignInResponse> {
   return _performApiRequest<

--- a/packages-exp/auth-exp/src/api/authentication/recaptcha.ts
+++ b/packages-exp/auth-exp/src/api/authentication/recaptcha.ts
@@ -16,13 +16,13 @@
  */
 
 import { Endpoint, HttpMethod, _performApiRequest } from '..';
-import { AuthCore } from '../../model/auth';
+import { Auth } from '@firebase/auth-types-exp';
 
 interface GetRecaptchaParamResponse {
   recaptchaSiteKey?: string;
 }
 
-export async function getRecaptchaParams(auth: AuthCore): Promise<string> {
+export async function getRecaptchaParams(auth: Auth): Promise<string> {
   return (
     (
       await _performApiRequest<void, GetRecaptchaParamResponse>(

--- a/packages-exp/auth-exp/src/api/authentication/sign_up.ts
+++ b/packages-exp/auth-exp/src/api/authentication/sign_up.ts
@@ -17,7 +17,7 @@
 
 import { Endpoint, HttpMethod, _performSignInRequest } from '..';
 import { IdTokenResponse } from '../../model/id_token';
-import { AuthCore } from '../../model/auth';
+import { Auth } from '@firebase/auth-types-exp';
 
 export interface SignUpRequest {
   returnSecureToken?: boolean;
@@ -31,7 +31,7 @@ export interface SignUpResponse extends IdTokenResponse {
 }
 
 export async function signUp(
-  auth: AuthCore,
+  auth: Auth,
   request: SignUpRequest
 ): Promise<SignUpResponse> {
   return _performSignInRequest<SignUpRequest, SignUpResponse>(

--- a/packages-exp/auth-exp/src/api/authentication/sms.ts
+++ b/packages-exp/auth-exp/src/api/authentication/sms.ts
@@ -24,7 +24,7 @@ import {
 import { AuthErrorCode } from '../../core/errors';
 import { IdTokenResponse } from '../../model/id_token';
 import { ServerError, ServerErrorMap } from '../errors';
-import { AuthCore } from '../../model/auth';
+import { Auth } from '@firebase/auth-types-exp';
 
 export interface SendPhoneVerificationCodeRequest {
   phoneNumber: string;
@@ -36,7 +36,7 @@ export interface SendPhoneVerificationCodeResponse {
 }
 
 export async function sendPhoneVerificationCode(
-  auth: AuthCore,
+  auth: Auth,
   request: SendPhoneVerificationCodeRequest
 ): Promise<SendPhoneVerificationCodeResponse> {
   return _performApiRequest<
@@ -63,7 +63,7 @@ export interface SignInWithPhoneNumberResponse extends IdTokenResponse {
 }
 
 export async function signInWithPhoneNumber(
-  auth: AuthCore,
+  auth: Auth,
   request: SignInWithPhoneNumberRequest
 ): Promise<SignInWithPhoneNumberResponse> {
   return _performSignInRequest<
@@ -73,7 +73,7 @@ export async function signInWithPhoneNumber(
 }
 
 export async function linkWithPhoneNumber(
-  auth: AuthCore,
+  auth: Auth,
   request: LinkWithPhoneNumberRequest
 ): Promise<SignInWithPhoneNumberResponse> {
   return _performSignInRequest<
@@ -94,7 +94,7 @@ const VERIFY_PHONE_NUMBER_FOR_EXISTING_ERROR_MAP_: Partial<ServerErrorMap<
 };
 
 export async function verifyPhoneNumberForExisting(
-  auth: AuthCore,
+  auth: Auth,
   request: SignInWithPhoneNumberRequest
 ): Promise<SignInWithPhoneNumberResponse> {
   const apiRequest: VerifyPhoneNumberForExistingRequest = {

--- a/packages-exp/auth-exp/src/api/authentication/token.ts
+++ b/packages-exp/auth-exp/src/api/authentication/token.ts
@@ -25,7 +25,7 @@ import {
   HttpMethod
 } from '../';
 import { FetchProvider } from '../../core/util/fetch_provider';
-import { AuthCore } from '../../model/auth';
+import { Auth } from '@firebase/auth-types-exp';
 
 export const _ENDPOINT = '/v1/token';
 const GRANT_TYPE = 'refresh_token';
@@ -44,7 +44,7 @@ export interface RequestStsTokenResponse {
 }
 
 export async function requestStsToken(
-  auth: AuthCore,
+  auth: Auth,
   refreshToken: string
 ): Promise<RequestStsTokenResponse> {
   const response = await _performFetchWithErrorHandling<

--- a/packages-exp/auth-exp/src/api/project_config/get_project_config.ts
+++ b/packages-exp/auth-exp/src/api/project_config/get_project_config.ts
@@ -16,7 +16,7 @@
  */
 
 import { _performApiRequest, Endpoint, HttpMethod } from '../';
-import { AuthCore } from '../../model/auth';
+import { Auth } from '@firebase/auth-types-exp';
 
 export interface GetProjectConfigRequest {}
 
@@ -25,7 +25,7 @@ export interface GetProjectConfigResponse {
 }
 
 export async function _getProjectConfig(
-  auth: AuthCore
+  auth: Auth
 ): Promise<GetProjectConfigResponse> {
   return _performApiRequest<GetProjectConfigRequest, GetProjectConfigResponse>(
     auth,

--- a/packages-exp/auth-exp/src/core/auth/auth_impl.test.ts
+++ b/packages-exp/auth-exp/src/core/auth/auth_impl.test.ts
@@ -144,7 +144,7 @@ describe('core/auth/auth_impl', () => {
       const user = testUser(auth, 'uid');
       auth.currentUser = user;
       auth._isInitialized = true;
-      auth._onAuthStateChanged(user => {
+      auth.onAuthStateChanged(user => {
         expect(user).to.eq(user);
         done();
       });
@@ -154,7 +154,7 @@ describe('core/auth/auth_impl', () => {
       const user = testUser(auth, 'uid');
       auth.currentUser = user;
       auth._isInitialized = false;
-      auth._onAuthStateChanged(user => {
+      auth.onAuthStateChanged(user => {
         expect(user).to.eq(user);
         done();
       });
@@ -164,7 +164,7 @@ describe('core/auth/auth_impl', () => {
       const user = testUser(auth, 'uid');
       auth.currentUser = user;
       auth._isInitialized = true;
-      auth._onIdTokenChanged(user => {
+      auth.onIdTokenChanged(user => {
         expect(user).to.eq(user);
         done();
       });
@@ -174,7 +174,7 @@ describe('core/auth/auth_impl', () => {
       const user = testUser(auth, 'uid');
       auth.currentUser = user;
       auth._isInitialized = false;
-      auth._onIdTokenChanged(user => {
+      auth.onIdTokenChanged(user => {
         expect(user).to.eq(user);
         done();
       });
@@ -183,7 +183,7 @@ describe('core/auth/auth_impl', () => {
     it('immediate callback is done async', () => {
       auth._isInitialized = true;
       let callbackCalled = false;
-      auth._onIdTokenChanged(() => {
+      auth.onIdTokenChanged(() => {
         callbackCalled = true;
       });
 
@@ -203,8 +203,8 @@ describe('core/auth/auth_impl', () => {
 
       context('initially currentUser is null', () => {
         beforeEach(async () => {
-          auth._onAuthStateChanged(authStateCallback);
-          auth._onIdTokenChanged(idTokenCallback);
+          auth.onAuthStateChanged(authStateCallback);
+          auth.onIdTokenChanged(idTokenCallback);
           await auth.updateCurrentUser(null);
           authStateCallback.resetHistory();
           idTokenCallback.resetHistory();
@@ -223,8 +223,8 @@ describe('core/auth/auth_impl', () => {
 
       context('initially currentUser is user', () => {
         beforeEach(async () => {
-          auth._onAuthStateChanged(authStateCallback);
-          auth._onIdTokenChanged(idTokenCallback);
+          auth.onAuthStateChanged(authStateCallback);
+          auth.onIdTokenChanged(idTokenCallback);
           await auth.updateCurrentUser(user);
           authStateCallback.resetHistory();
           idTokenCallback.resetHistory();
@@ -262,8 +262,8 @@ describe('core/auth/auth_impl', () => {
       it('onAuthStateChange works for multiple listeners', async () => {
         const cb1 = sinon.spy();
         const cb2 = sinon.spy();
-        auth._onAuthStateChanged(cb1);
-        auth._onAuthStateChanged(cb2);
+        auth.onAuthStateChanged(cb1);
+        auth.onAuthStateChanged(cb2);
         await auth.updateCurrentUser(null);
         cb1.resetHistory();
         cb2.resetHistory();
@@ -276,8 +276,8 @@ describe('core/auth/auth_impl', () => {
       it('onIdTokenChange works for multiple listeners', async () => {
         const cb1 = sinon.spy();
         const cb2 = sinon.spy();
-        auth._onIdTokenChanged(cb1);
-        auth._onIdTokenChanged(cb2);
+        auth.onIdTokenChanged(cb1);
+        auth.onIdTokenChanged(cb2);
         await auth.updateCurrentUser(null);
         cb1.resetHistory();
         cb2.resetHistory();
@@ -296,8 +296,8 @@ describe('core/auth/auth_impl', () => {
     beforeEach(async () => {
       authStateCallback = sinon.spy();
       idTokenCallback = sinon.spy();
-      auth._onAuthStateChanged(authStateCallback);
-      auth._onIdTokenChanged(idTokenCallback);
+      auth.onAuthStateChanged(authStateCallback);
+      auth.onIdTokenChanged(idTokenCallback);
       await auth.updateCurrentUser(null); // force event handlers to clear out
       authStateCallback.resetHistory();
       idTokenCallback.resetHistory();
@@ -388,7 +388,7 @@ describe('core/auth/auth_impl', () => {
           await auth._onStorageEvent();
 
           expect(auth.currentUser?.uid).to.eq(user.uid);
-          expect(auth.currentUser?.stsTokenManager.accessToken).to.eq(
+          expect((auth.currentUser as User)?.stsTokenManager.accessToken).to.eq(
             'new-access-token'
           );
           expect(authStateCallback).not.to.have.been.called;

--- a/packages-exp/auth-exp/src/core/auth/auth_impl.ts
+++ b/packages-exp/auth-exp/src/core/auth/auth_impl.ts
@@ -77,7 +77,7 @@ export class AuthImpl implements Auth, _FirebaseService {
 
   constructor(
     public readonly app: FirebaseApp,
-    public readonly config: ConfigInternal,
+    public readonly config: ConfigInternal
   ) {
     this.name = app.name;
   }
@@ -276,7 +276,7 @@ export class AuthImpl implements Auth, _FirebaseService {
         [_getInstance(resolver._redirectPersistence)],
         _REDIRECT_USER_KEY_NAME
       );
-      this.redirectUser = (await this.redirectPersistenceManager.getCurrentUser());
+      this.redirectUser = await this.redirectPersistenceManager.getCurrentUser();
     }
 
     return this.redirectPersistenceManager;

--- a/packages-exp/auth-exp/src/core/auth/auth_impl.ts
+++ b/packages-exp/auth-exp/src/core/auth/auth_impl.ts
@@ -27,9 +27,9 @@ import {
   Unsubscribe
 } from '@firebase/util';
 
-import { Auth, AuthCore, ConfigInternal } from '../../model/auth';
+import { Auth, ConfigInternal } from '../../model/auth';
 import { PopupRedirectResolver } from '../../model/popup_redirect';
-import { User, UserParameters } from '../../model/user';
+import { User } from '../../model/user';
 import { AuthErrorCode } from '../errors';
 import { Persistence } from '../persistence';
 import {
@@ -37,7 +37,6 @@ import {
   PersistenceUserManager
 } from '../persistence/persistence_user_manager';
 import { _reloadWithoutSaving } from '../user/reload';
-import { UserImpl } from '../user/user_impl';
 import { assert } from '../util/assert';
 import { _getInstance } from '../util/instantiator';
 import { _getUserLanguage } from '../util/navigator';
@@ -46,22 +45,18 @@ interface AsyncAction {
   (): Promise<void>;
 }
 
-export interface UserProvider<T extends User> {
-  new (params: UserParameters): T;
-}
-
 export const DEFAULT_TOKEN_API_HOST = 'securetoken.googleapis.com';
 export const DEFAULT_API_HOST = 'identitytoolkit.googleapis.com';
 export const DEFAULT_API_SCHEME = 'https';
 
-export class AuthImplCompat<T extends User> implements Auth, _FirebaseService {
-  currentUser: T | null = null;
+export class AuthImpl implements Auth, _FirebaseService {
+  currentUser: externs.User | null = null;
   private operations = Promise.resolve();
   private persistenceManager?: PersistenceUserManager;
   private redirectPersistenceManager?: PersistenceUserManager;
-  private authStateSubscription = new Subscription<T>(this);
-  private idTokenSubscription = new Subscription<T>(this);
-  private redirectUser: T | null = null;
+  private authStateSubscription = new Subscription<externs.User>(this);
+  private idTokenSubscription = new Subscription<externs.User>(this);
+  private redirectUser: User | null = null;
   private isProactiveRefreshEnabled = false;
 
   // Any network calls will set this to true and prevent subsequent emulator
@@ -83,7 +78,6 @@ export class AuthImplCompat<T extends User> implements Auth, _FirebaseService {
   constructor(
     public readonly app: FirebaseApp,
     public readonly config: ConfigInternal,
-    private readonly _userProvider: UserProvider<T>
   ) {
     this.name = app.name;
   }
@@ -125,7 +119,7 @@ export class AuthImplCompat<T extends User> implements Auth, _FirebaseService {
     // If the same user is to be synchronized.
     if (this.currentUser && user && this.currentUser.uid === user.uid) {
       // Data update, simply copy data changes.
-      this.currentUser._copy(user);
+      this._currentUser._copy(user);
       // If tokens changed from previous user tokens, this will trigger
       // notifyAuthListeners_.
       await this.currentUser.getIdToken();
@@ -138,12 +132,8 @@ export class AuthImplCompat<T extends User> implements Auth, _FirebaseService {
     this.notifyAuthListeners();
   }
 
-  _createUser(params: UserParameters): T {
-    return new this._userProvider(params);
-  }
-
   private async initializeCurrentUser(): Promise<void> {
-    const storedUser = (await this.assertedPersistence.getCurrentUser()) as T | null;
+    const storedUser = (await this.assertedPersistence.getCurrentUser()) as User | null;
     if (!storedUser) {
       return this.directlySetCurrentUser(storedUser);
     }
@@ -171,7 +161,7 @@ export class AuthImplCompat<T extends User> implements Auth, _FirebaseService {
     return this.reloadAndSetCurrentUserOrClear(storedUser);
   }
 
-  private async reloadAndSetCurrentUserOrClear(user: T): Promise<void> {
+  private async reloadAndSetCurrentUserOrClear(user: User): Promise<void> {
     try {
       await _reloadWithoutSaving(user);
     } catch (e) {
@@ -215,7 +205,7 @@ export class AuthImplCompat<T extends User> implements Auth, _FirebaseService {
       );
     }
     return this.queue(async () => {
-      await this.directlySetCurrentUser(user as T | null);
+      await this.directlySetCurrentUser(user as User | null);
       this.notifyAuthListeners();
     });
   }
@@ -229,14 +219,14 @@ export class AuthImplCompat<T extends User> implements Auth, _FirebaseService {
     return this.updateCurrentUser(null);
   }
 
-  _setPersistence(persistence: externs.Persistence): Promise<void> {
+  setPersistence(persistence: externs.Persistence): Promise<void> {
     return this.queue(async () => {
       await this.assertedPersistence.setPersistence(_getInstance(persistence));
     });
   }
 
-  _onAuthStateChanged(
-    nextOrObserver: externs.NextOrObserver<T>,
+  onAuthStateChanged(
+    nextOrObserver: externs.NextOrObserver<externs.User>,
     error?: ErrorFn,
     completed?: CompleteFn
   ): Unsubscribe {
@@ -248,8 +238,8 @@ export class AuthImplCompat<T extends User> implements Auth, _FirebaseService {
     );
   }
 
-  _onIdTokenChanged(
-    nextOrObserver: externs.NextOrObserver<T>,
+  onIdTokenChanged(
+    nextOrObserver: externs.NextOrObserver<externs.User>,
     error?: ErrorFn,
     completed?: CompleteFn
   ): Unsubscribe {
@@ -262,7 +252,7 @@ export class AuthImplCompat<T extends User> implements Auth, _FirebaseService {
   }
 
   async _setRedirectUser(
-    user: T | null,
+    user: User | null,
     popupRedirectResolver?: externs.PopupRedirectResolver
   ): Promise<void> {
     const redirectManager = await this.getOrInitRedirectPersistenceManager(
@@ -286,18 +276,18 @@ export class AuthImplCompat<T extends User> implements Auth, _FirebaseService {
         [_getInstance(resolver._redirectPersistence)],
         _REDIRECT_USER_KEY_NAME
       );
-      this.redirectUser = (await this.redirectPersistenceManager.getCurrentUser()) as T;
+      this.redirectUser = (await this.redirectPersistenceManager.getCurrentUser());
     }
 
     return this.redirectPersistenceManager;
   }
 
-  async _redirectUserForId(id: string): Promise<T | null> {
+  async _redirectUserForId(id: string): Promise<User | null> {
     // Make sure we've cleared any pending ppersistence actions
     await this.queue(async () => {});
 
-    if (this.currentUser?._redirectEventId === id) {
-      return this.currentUser;
+    if (this._currentUser?._redirectEventId === id) {
+      return this._currentUser;
     }
 
     if (this.redirectUser?._redirectEventId === id) {
@@ -307,14 +297,14 @@ export class AuthImplCompat<T extends User> implements Auth, _FirebaseService {
     return null;
   }
 
-  async _persistUserIfCurrent(user: T): Promise<void> {
+  async _persistUserIfCurrent(user: User): Promise<void> {
     if (user === this.currentUser) {
       return this.queue(async () => this.directlySetCurrentUser(user));
     }
   }
 
   /** Notifies listeners only if the user is current */
-  _notifyListenersIfCurrent(user: T): void {
+  _notifyListenersIfCurrent(user: User): void {
     if (user === this.currentUser) {
       this.notifyAuthListeners();
     }
@@ -327,15 +317,20 @@ export class AuthImplCompat<T extends User> implements Auth, _FirebaseService {
   _startProactiveRefresh(): void {
     this.isProactiveRefreshEnabled = true;
     if (this.currentUser) {
-      this.currentUser._startProactiveRefresh();
+      this._currentUser._startProactiveRefresh();
     }
   }
 
   _stopProactiveRefresh(): void {
     this.isProactiveRefreshEnabled = false;
     if (this.currentUser) {
-      this.currentUser._stopProactiveRefresh();
+      this._currentUser._stopProactiveRefresh();
     }
+  }
+
+  /** Returns the current user cast as the internal type */
+  get _currentUser(): User {
+    return this.currentUser as User;
   }
 
   private notifyAuthListeners(): void {
@@ -352,8 +347,8 @@ export class AuthImplCompat<T extends User> implements Auth, _FirebaseService {
   }
 
   private registerStateListener(
-    subscription: Subscription<T>,
-    nextOrObserver: externs.NextOrObserver<T>,
+    subscription: Subscription<externs.User>,
+    nextOrObserver: externs.NextOrObserver<externs.User>,
     error?: ErrorFn,
     completed?: CompleteFn
   ): Unsubscribe {
@@ -382,9 +377,9 @@ export class AuthImplCompat<T extends User> implements Auth, _FirebaseService {
    * should only be called from within a queued callback. This is necessary
    * because the queue shouldn't rely on another queued callback.
    */
-  private async directlySetCurrentUser(user: T | null): Promise<void> {
+  private async directlySetCurrentUser(user: User | null): Promise<void> {
     if (this.currentUser && this.currentUser !== user) {
-      this.currentUser._stopProactiveRefresh();
+      this._currentUser._stopProactiveRefresh();
       if (user && this.isProactiveRefreshEnabled) {
         user._startProactiveRefresh();
       }
@@ -415,37 +410,6 @@ export class AuthImplCompat<T extends User> implements Auth, _FirebaseService {
 }
 
 /**
- * This is the implementation we make public in the new SDK, note the changed interface on these methods
- *
- * Don't instantiate this class directly, use initializeAuth()
- */
-export class AuthImpl extends AuthImplCompat<UserImpl> implements externs.Auth {
-  constructor(app: FirebaseApp, config: externs.Config) {
-    super(app, config, UserImpl);
-  }
-
-  onAuthStateChanged(
-    nextOrObserver: externs.NextOrObserver<externs.User>,
-    error?: ErrorFn,
-    completed?: CompleteFn
-  ): Unsubscribe {
-    return super._onAuthStateChanged(nextOrObserver, error, completed);
-  }
-
-  onIdTokenChanged(
-    nextOrObserver: externs.NextOrObserver<externs.User>,
-    error?: ErrorFn,
-    completed?: CompleteFn
-  ): Unsubscribe {
-    return super._onIdTokenChanged(nextOrObserver, error, completed);
-  }
-
-  setPersistence(persistence: externs.Persistence): Promise<void> {
-    return super._setPersistence(persistence);
-  }
-}
-
-/**
  * Method to be used to cast down to our private implmentation of Auth
  *
  * @param auth Auth object passed in from developer
@@ -461,7 +425,7 @@ class Subscription<T> {
     observer => (this.observer = observer)
   );
 
-  constructor(readonly auth: AuthCore) {}
+  constructor(readonly auth: Auth) {}
 
   get next(): NextFn<T | null> {
     assert(this.observer, AuthErrorCode.INTERNAL_ERROR, {

--- a/packages-exp/auth-exp/src/core/auth/firebase_internal.ts
+++ b/packages-exp/auth-exp/src/core/auth/firebase_internal.ts
@@ -60,7 +60,7 @@ export class AuthInternal {
     }
 
     const unsubscribe = this.auth.onIdTokenChanged(user => {
-      listener((user as User|null)?.stsTokenManager.accessToken || null);
+      listener((user as User | null)?.stsTokenManager.accessToken || null);
     });
     this.internalListeners.set(listener, unsubscribe);
     this.updateProactiveRefresh();

--- a/packages-exp/auth-exp/src/core/auth/firebase_internal.ts
+++ b/packages-exp/auth-exp/src/core/auth/firebase_internal.ts
@@ -18,6 +18,7 @@
 import { Unsubscribe } from '@firebase/util';
 
 import { Auth } from '../../model/auth';
+import { User } from '../../model/user';
 
 declare module '@firebase/component' {
   interface NameServiceMapping {
@@ -58,8 +59,8 @@ export class AuthInternal {
       return;
     }
 
-    const unsubscribe = this.auth._onIdTokenChanged(user => {
-      listener(user?.stsTokenManager.accessToken || null);
+    const unsubscribe = this.auth.onIdTokenChanged(user => {
+      listener((user as User|null)?.stsTokenManager.accessToken || null);
     });
     this.internalListeners.set(listener, unsubscribe);
     this.updateProactiveRefresh();

--- a/packages-exp/auth-exp/src/core/credentials/auth_credential.ts
+++ b/packages-exp/auth-exp/src/core/credentials/auth_credential.ts
@@ -16,7 +16,7 @@
  */
 
 import { PhoneOrOauthTokenResponse } from '../../api/authentication/mfa';
-import { AuthCore } from '../../model/auth';
+import { Auth } from '../../model/auth';
 import { IdTokenResponse } from '../../model/id_token';
 import { debugFail } from '../util/assert';
 
@@ -30,13 +30,13 @@ export class AuthCredential {
     return debugFail('not implemented');
   }
 
-  _getIdTokenResponse(_auth: AuthCore): Promise<PhoneOrOauthTokenResponse> {
+  _getIdTokenResponse(_auth: Auth): Promise<PhoneOrOauthTokenResponse> {
     return debugFail('not implemented');
   }
-  _linkToIdToken(_auth: AuthCore, _idToken: string): Promise<IdTokenResponse> {
+  _linkToIdToken(_auth: Auth, _idToken: string): Promise<IdTokenResponse> {
     return debugFail('not implemented');
   }
-  _getReauthenticationResolver(_auth: AuthCore): Promise<IdTokenResponse> {
+  _getReauthenticationResolver(_auth: Auth): Promise<IdTokenResponse> {
     return debugFail('not implemented');
   }
 }

--- a/packages-exp/auth-exp/src/core/credentials/email.ts
+++ b/packages-exp/auth-exp/src/core/credentials/email.ts
@@ -104,10 +104,7 @@ export class EmailAuthCredential
     }
   }
 
-  async _linkToIdToken(
-    auth: Auth,
-    idToken: string
-  ): Promise<IdTokenResponse> {
+  async _linkToIdToken(auth: Auth, idToken: string): Promise<IdTokenResponse> {
     switch (this.signInMethod) {
       case externs.SignInMethod.EMAIL_PASSWORD:
         return updateEmailPassword(auth, {

--- a/packages-exp/auth-exp/src/core/credentials/email.ts
+++ b/packages-exp/auth-exp/src/core/credentials/email.ts
@@ -23,7 +23,7 @@ import {
   signInWithEmailLink,
   signInWithEmailLinkForLinking
 } from '../../api/authentication/email_link';
-import { AuthCore } from '../../model/auth';
+import { Auth } from '../../model/auth';
 import { IdTokenResponse } from '../../model/id_token';
 import { AuthErrorCode } from '../errors';
 import { fail } from '../util/assert';
@@ -86,7 +86,7 @@ export class EmailAuthCredential
     return null;
   }
 
-  async _getIdTokenResponse(auth: AuthCore): Promise<IdTokenResponse> {
+  async _getIdTokenResponse(auth: Auth): Promise<IdTokenResponse> {
     switch (this.signInMethod) {
       case externs.SignInMethod.EMAIL_PASSWORD:
         return signInWithPassword(auth, {
@@ -105,7 +105,7 @@ export class EmailAuthCredential
   }
 
   async _linkToIdToken(
-    auth: AuthCore,
+    auth: Auth,
     idToken: string
   ): Promise<IdTokenResponse> {
     switch (this.signInMethod) {
@@ -127,7 +127,7 @@ export class EmailAuthCredential
     }
   }
 
-  _getReauthenticationResolver(auth: AuthCore): Promise<IdTokenResponse> {
+  _getReauthenticationResolver(auth: Auth): Promise<IdTokenResponse> {
     return this._getIdTokenResponse(auth);
   }
 }

--- a/packages-exp/auth-exp/src/core/credentials/oauth.ts
+++ b/packages-exp/auth-exp/src/core/credentials/oauth.ts
@@ -22,7 +22,7 @@ import {
   signInWithIdp,
   SignInWithIdpRequest
 } from '../../api/authentication/idp';
-import { AuthCore } from '../../model/auth';
+import { Auth } from '../../model/auth';
 import { IdTokenResponse } from '../../model/id_token';
 import { AuthErrorCode } from '../errors';
 import { fail } from '../util/assert';
@@ -114,18 +114,18 @@ export class OAuthCredential
     return cred;
   }
 
-  _getIdTokenResponse(auth: AuthCore): Promise<IdTokenResponse> {
+  _getIdTokenResponse(auth: Auth): Promise<IdTokenResponse> {
     const request = this.buildRequest();
     return signInWithIdp(auth, request);
   }
 
-  _linkToIdToken(auth: AuthCore, idToken: string): Promise<IdTokenResponse> {
+  _linkToIdToken(auth: Auth, idToken: string): Promise<IdTokenResponse> {
     const request = this.buildRequest();
     request.idToken = idToken;
     return signInWithIdp(auth, request);
   }
 
-  _getReauthenticationResolver(auth: AuthCore): Promise<IdTokenResponse> {
+  _getReauthenticationResolver(auth: Auth): Promise<IdTokenResponse> {
     const request = this.buildRequest();
     request.autoCreate = false;
     return signInWithIdp(auth, request);

--- a/packages-exp/auth-exp/src/core/credentials/phone.ts
+++ b/packages-exp/auth-exp/src/core/credentials/phone.ts
@@ -24,7 +24,7 @@ import {
   SignInWithPhoneNumberRequest,
   verifyPhoneNumberForExisting
 } from '../../api/authentication/sms';
-import { AuthCore } from '../../model/auth';
+import { Auth } from '../../model/auth';
 import { IdTokenResponse } from '../../model/id_token';
 import { AuthCredential } from './auth_credential';
 
@@ -56,18 +56,18 @@ export class PhoneAuthCredential
     return new PhoneAuthCredential({ phoneNumber, temporaryProof });
   }
 
-  _getIdTokenResponse(auth: AuthCore): Promise<PhoneOrOauthTokenResponse> {
+  _getIdTokenResponse(auth: Auth): Promise<PhoneOrOauthTokenResponse> {
     return signInWithPhoneNumber(auth, this._makeVerificationRequest());
   }
 
-  _linkToIdToken(auth: AuthCore, idToken: string): Promise<IdTokenResponse> {
+  _linkToIdToken(auth: Auth, idToken: string): Promise<IdTokenResponse> {
     return linkWithPhoneNumber(auth, {
       idToken,
       ...this._makeVerificationRequest()
     });
   }
 
-  _getReauthenticationResolver(auth: AuthCore): Promise<IdTokenResponse> {
+  _getReauthenticationResolver(auth: Auth): Promise<IdTokenResponse> {
     return verifyPhoneNumberForExisting(auth, this._makeVerificationRequest());
   }
 

--- a/packages-exp/auth-exp/src/core/strategies/email_and_password.ts
+++ b/packages-exp/auth-exp/src/core/strategies/email_and_password.ts
@@ -101,7 +101,7 @@ export async function checkActionCode(
   let multiFactorInfo: MultiFactorInfo | null = null;
   if (response.mfaInfo) {
     multiFactorInfo = MultiFactorInfo._fromServerResponse(
-      auth,
+      _castAuth(auth),
       response.mfaInfo
     );
   }

--- a/packages-exp/auth-exp/src/core/strategies/idp.ts
+++ b/packages-exp/auth-exp/src/core/strategies/idp.ts
@@ -21,7 +21,7 @@ import {
   SignInWithIdpRequest
 } from '../../api/authentication/idp';
 import { PhoneOrOauthTokenResponse } from '../../api/authentication/mfa';
-import { Auth, AuthCore } from '../../model/auth';
+import { Auth } from '../../model/auth';
 import { IdTokenResponse } from '../../model/id_token';
 import { User, UserCredential } from '../../model/user';
 import { AuthCredential } from '../credentials';
@@ -51,15 +51,15 @@ class IdpCredential extends AuthCredential {
     super(externs.ProviderId.CUSTOM, externs.ProviderId.CUSTOM);
   }
 
-  _getIdTokenResponse(auth: AuthCore): Promise<PhoneOrOauthTokenResponse> {
+  _getIdTokenResponse(auth: Auth): Promise<PhoneOrOauthTokenResponse> {
     return signInWithIdp(auth, this._buildIdpRequest());
   }
 
-  _linkToIdToken(auth: AuthCore, idToken: string): Promise<IdTokenResponse> {
+  _linkToIdToken(auth: Auth, idToken: string): Promise<IdTokenResponse> {
     return signInWithIdp(auth, this._buildIdpRequest(idToken));
   }
 
-  _getReauthenticationResolver(auth: AuthCore): Promise<IdTokenResponse> {
+  _getReauthenticationResolver(auth: Auth): Promise<IdTokenResponse> {
     return signInWithIdp(auth, this._buildIdpRequest());
   }
 

--- a/packages-exp/auth-exp/src/core/user/reload.test.ts
+++ b/packages-exp/auth-exp/src/core/user/reload.test.ts
@@ -160,7 +160,7 @@ describe('core/user/reload', () => {
     user.auth.currentUser = user;
 
     const cb = sinon.stub();
-    user.auth._onIdTokenChanged(cb);
+    user.auth.onIdTokenChanged(cb);
 
     await reload(user);
     expect(cb).to.have.been.calledWith(user);

--- a/packages-exp/auth-exp/src/core/user/token_manager.ts
+++ b/packages-exp/auth-exp/src/core/user/token_manager.ts
@@ -17,7 +17,7 @@
 
 import { FinalizeMfaResponse } from '../../api/authentication/mfa';
 import { requestStsToken } from '../../api/authentication/token';
-import { AuthCore } from '../../model/auth';
+import { Auth } from '../../model/auth';
 import { IdTokenResponse } from '../../model/id_token';
 import { AuthErrorCode } from '../errors';
 import { PersistedBlob } from '../persistence';
@@ -51,7 +51,7 @@ export class StsTokenManager {
     );
   }
 
-  async getToken(auth: AuthCore, forceRefresh = false): Promise<string | null> {
+  async getToken(auth: Auth, forceRefresh = false): Promise<string | null> {
     if (!forceRefresh && this.accessToken && !this.isExpired) {
       return this.accessToken;
     }
@@ -71,7 +71,7 @@ export class StsTokenManager {
     this.refreshToken = null;
   }
 
-  private async refresh(auth: AuthCore, oldToken: string): Promise<void> {
+  private async refresh(auth: Auth, oldToken: string): Promise<void> {
     const { accessToken, refreshToken, expiresIn } = await requestStsToken(
       auth,
       oldToken

--- a/packages-exp/auth-exp/src/core/user/user_impl.ts
+++ b/packages-exp/auth-exp/src/core/user/user_impl.ts
@@ -261,7 +261,7 @@ export class UserImpl implements User {
     assertStringOrUndefined(_redirectEventId, auth.name);
     assertStringOrUndefined(createdAt, auth.name);
     assertStringOrUndefined(lastLoginAt, auth.name);
-    const user = auth._createUser({
+    const user = new UserImpl({
       uid,
       auth,
       email,
@@ -301,7 +301,7 @@ export class UserImpl implements User {
     stsTokenManager.updateFromServerResponse(idTokenResponse);
 
     // Initialize the Firebase Auth user.
-    const user = auth._createUser({
+    const user = new UserImpl({
       uid: idTokenResponse.localId,
       auth,
       stsTokenManager,

--- a/packages-exp/auth-exp/src/mfa/assertions/index.ts
+++ b/packages-exp/auth-exp/src/mfa/assertions/index.ts
@@ -18,14 +18,14 @@ import * as externs from '@firebase/auth-types-exp';
 import { debugFail } from '../../core/util/assert';
 import { MultiFactorSession, MultiFactorSessionType } from '../mfa_session';
 import { FinalizeMfaResponse } from '../../api/authentication/mfa';
-import { AuthCore } from '../../model/auth';
+import { Auth } from '../../model/auth';
 
 export abstract class MultiFactorAssertion
   implements externs.MultiFactorAssertion {
   protected constructor(readonly factorId: string) {}
 
   _process(
-    auth: AuthCore,
+    auth: Auth,
     session: MultiFactorSession,
     displayName?: string | null
   ): Promise<FinalizeMfaResponse> {
@@ -40,12 +40,12 @@ export abstract class MultiFactorAssertion
   }
 
   abstract _finalizeEnroll(
-    auth: AuthCore,
+    auth: Auth,
     idToken: string,
     displayName?: string | null
   ): Promise<FinalizeMfaResponse>;
   abstract _finalizeSignIn(
-    auth: AuthCore,
+    auth: Auth,
     mfaPendingCredential: string
   ): Promise<FinalizeMfaResponse>;
 }

--- a/packages-exp/auth-exp/src/mfa/mfa_error.ts
+++ b/packages-exp/auth-exp/src/mfa/mfa_error.ts
@@ -17,7 +17,7 @@
 
 import * as externs from '@firebase/auth-types-exp';
 import { FirebaseError } from '@firebase/util';
-import { AuthCore } from '../model/auth';
+import { Auth } from '../model/auth';
 import { IdTokenResponse } from '../model/id_token';
 import { AuthErrorCode } from '../core/errors';
 import { User } from '../model/user';
@@ -35,7 +35,7 @@ export class MultiFactorError
   readonly tenantId?: string;
 
   private constructor(
-    auth: AuthCore,
+    auth: Auth,
     error: FirebaseError,
     readonly operationType: externs.OperationType,
     readonly credential: AuthCredential,
@@ -51,7 +51,7 @@ export class MultiFactorError
   }
 
   static _fromErrorAndCredential(
-    auth: AuthCore,
+    auth: Auth,
     error: FirebaseError,
     operationType: externs.OperationType,
     credential: AuthCredential,
@@ -62,7 +62,7 @@ export class MultiFactorError
 }
 
 export function _processCredentialSavingMfaContextIfNecessary(
-  auth: AuthCore,
+  auth: Auth,
   operationType: externs.OperationType,
   credential: AuthCredential,
   user?: User

--- a/packages-exp/auth-exp/src/mfa/mfa_info.ts
+++ b/packages-exp/auth-exp/src/mfa/mfa_info.ts
@@ -22,7 +22,7 @@ import {
 } from '../api/account_management/mfa';
 import { AuthErrorCode } from '../core/errors';
 import { fail } from '../core/util/assert';
-import { AuthCore } from '../model/auth';
+import { Auth } from '../model/auth';
 
 export abstract class MultiFactorInfo implements externs.MultiFactorInfo {
   readonly uid: string;
@@ -39,7 +39,7 @@ export abstract class MultiFactorInfo implements externs.MultiFactorInfo {
   }
 
   static _fromServerResponse(
-    auth: AuthCore,
+    auth: Auth,
     enrollment: MfaEnrollment
   ): MultiFactorInfo {
     if ('phoneInfo' in enrollment) {
@@ -58,7 +58,7 @@ export class PhoneMultiFactorInfo extends MultiFactorInfo {
   }
 
   static _fromServerResponse(
-    _auth: AuthCore,
+    _auth: Auth,
     enrollment: MfaEnrollment
   ): PhoneMultiFactorInfo {
     return new PhoneMultiFactorInfo(enrollment);

--- a/packages-exp/auth-exp/src/mfa/mfa_resolver.ts
+++ b/packages-exp/auth-exp/src/mfa/mfa_resolver.ts
@@ -41,7 +41,7 @@ export class MultiFactorResolver implements externs.MultiFactorResolver {
     error: MultiFactorError
   ): MultiFactorResolver {
     const hints = (error.serverResponse.mfaInfo || []).map(enrollment =>
-      MultiFactorInfo._fromServerResponse(auth, enrollment)
+      MultiFactorInfo._fromServerResponse(_castAuth(auth), enrollment)
     );
 
     assert(
@@ -57,7 +57,7 @@ export class MultiFactorResolver implements externs.MultiFactorResolver {
       session,
       hints,
       async (assertion: MultiFactorAssertion): Promise<UserCredential> => {
-        const mfaResponse = await assertion._process(auth, session);
+        const mfaResponse = await assertion._process(_castAuth(auth), session);
         // Clear out the unneeded fields from the old login response
         delete error.serverResponse.mfaInfo;
         delete error.serverResponse.mfaPendingCredential;

--- a/packages-exp/auth-exp/src/mfa/mfa_user.test.ts
+++ b/packages-exp/auth-exp/src/mfa/mfa_user.test.ts
@@ -32,7 +32,7 @@ import { MultiFactorInfo } from './mfa_info';
 import { MultiFactorSession, MultiFactorSessionType } from './mfa_session';
 import { multiFactor, MultiFactorUser } from './mfa_user';
 import { MultiFactorAssertion } from './assertions';
-import { AuthCore } from '../model/auth';
+import { Auth } from '../model/auth';
 
 use(chaiAsPromised);
 
@@ -42,14 +42,14 @@ class MockMultiFactorAssertion extends MultiFactorAssertion {
   }
 
   async _finalizeEnroll(
-    _auth: AuthCore,
+    _auth: Auth,
     _idToken: string,
     _displayName?: string | null
   ): Promise<FinalizeMfaResponse> {
     return this.response;
   }
   async _finalizeSignIn(
-    _auth: AuthCore,
+    _auth: Auth,
     _mfaPendingCredential: string
   ): Promise<FinalizeMfaResponse> {
     return this.response;

--- a/packages-exp/auth-exp/src/model/auth.ts
+++ b/packages-exp/auth-exp/src/model/auth.ts
@@ -16,10 +16,9 @@
  */
 
 import * as externs from '@firebase/auth-types-exp';
-import { CompleteFn, ErrorFn, Unsubscribe } from '@firebase/util';
 
 import { PopupRedirectResolver } from './popup_redirect';
-import { User, UserParameters } from './user';
+import { User } from './user';
 
 export type AppName = string;
 export type ApiKey = string;
@@ -32,41 +31,15 @@ export interface ConfigInternal extends externs.Config {
   };
 }
 
-/**
- * Core implementation of the Auth object, the signatures here should match across both legacy
- * and modern implementations
- */
-export interface AuthCore {
-  readonly name: AppName;
-  readonly config: ConfigInternal;
-  languageCode: string | null;
-  tenantId: string | null;
-  readonly settings: externs.AuthSettings;
-
-  useDeviceLanguage(): void;
-  signOut(): Promise<void>;
-}
-
-export interface Auth extends AuthCore {
-  currentUser: User | null;
+export interface Auth extends externs.Auth {
+  currentUser: externs.User | null;
   _canInitEmulator: boolean;
   _isInitialized: boolean;
   _initializationPromise: Promise<void> | null;
   updateCurrentUser(user: User | null): Promise<void>;
 
   _onStorageEvent(): void;
-  _createUser(params: UserParameters): User;
-  _setPersistence(persistence: externs.Persistence): void;
-  _onAuthStateChanged(
-    nextOrObserver: externs.NextOrObserver<User>,
-    error?: ErrorFn,
-    completed?: CompleteFn
-  ): Unsubscribe;
-  _onIdTokenChanged(
-    nextOrObserver: externs.NextOrObserver<User>,
-    error?: ErrorFn,
-    completed?: CompleteFn
-  ): Unsubscribe;
+
   _notifyListenersIfCurrent(user: User): void;
   _persistUserIfCurrent(user: User): Promise<void>;
   _setRedirectUser(
@@ -78,6 +51,15 @@ export interface Auth extends AuthCore {
   _key(): string;
   _startProactiveRefresh(): void;
   _stopProactiveRefresh(): void;
+
+  readonly name: AppName;
+  readonly config: ConfigInternal;
+  languageCode: string | null;
+  tenantId: string | null;
+  readonly settings: externs.AuthSettings;
+
+  useDeviceLanguage(): void;
+  signOut(): Promise<void>;
 }
 
 export interface Dependencies {

--- a/packages-exp/auth-exp/src/model/popup_redirect.ts
+++ b/packages-exp/auth-exp/src/model/popup_redirect.ts
@@ -19,7 +19,7 @@ import * as externs from '@firebase/auth-types-exp';
 import { FirebaseError } from '@firebase/util';
 
 import { AuthPopup } from '../platform_browser/util/popup';
-import { AuthCore } from './auth';
+import { Auth } from './auth';
 
 export const enum EventFilter {
   POPUP,
@@ -74,21 +74,21 @@ export interface EventManager {
 }
 
 export interface PopupRedirectResolver extends externs.PopupRedirectResolver {
-  _initialize(auth: AuthCore): Promise<EventManager>;
+  _initialize(auth: Auth): Promise<EventManager>;
   _openPopup(
-    auth: AuthCore,
+    auth: Auth,
     provider: externs.AuthProvider,
     authType: AuthEventType,
     eventId?: string
   ): Promise<AuthPopup>;
   _openRedirect(
-    auth: AuthCore,
+    auth: Auth,
     provider: externs.AuthProvider,
     authType: AuthEventType,
     eventId?: string
   ): Promise<never>;
   _isIframeWebStorageSupported(
-    auth: AuthCore,
+    auth: Auth,
     cb: (support: boolean) => unknown
   ): void;
   _redirectPersistence: externs.Persistence;

--- a/packages-exp/auth-exp/src/platform_browser/auth.test.ts
+++ b/packages-exp/auth-exp/src/platform_browser/auth.test.ts
@@ -84,7 +84,7 @@ describe('core/auth/auth_impl', () => {
         Promise.resolve(testUser(auth, 'test').toJSON())
       );
 
-      await auth._setPersistence(newPersistence);
+      await auth.setPersistence(newPersistence);
       expect(persistenceStub._get).to.have.been.called;
       expect(persistenceStub._remove).to.have.been.called;
       expect(newStub._set).to.have.been.calledWith(

--- a/packages-exp/auth-exp/src/platform_browser/iframe/gapi.ts
+++ b/packages-exp/auth-exp/src/platform_browser/iframe/gapi.ts
@@ -17,7 +17,7 @@
 
 import { AUTH_ERROR_FACTORY, AuthErrorCode } from '../../core/errors';
 import { Delay } from '../../core/util/delay';
-import { AuthCore } from '../../model/auth';
+import { Auth } from '../../model/auth';
 import { _window } from '../auth_window';
 import * as js from '../load_js';
 
@@ -54,7 +54,7 @@ function resetUnloadedGapiModules(): void {
   }
 }
 
-function loadGapi(auth: AuthCore): Promise<gapi.iframes.Context> {
+function loadGapi(auth: Auth): Promise<gapi.iframes.Context> {
   return new Promise<gapi.iframes.Context>((resolve, reject) => {
     // Function to run when gapi.load is ready.
     function loadGapiIframe(): void {
@@ -121,7 +121,7 @@ function loadGapi(auth: AuthCore): Promise<gapi.iframes.Context> {
 }
 
 let cachedGApiLoader: Promise<gapi.iframes.Context> | null = null;
-export function _loadGapi(auth: AuthCore): Promise<gapi.iframes.Context> {
+export function _loadGapi(auth: Auth): Promise<gapi.iframes.Context> {
   cachedGApiLoader = cachedGApiLoader || loadGapi(auth);
   return cachedGApiLoader;
 }

--- a/packages-exp/auth-exp/src/platform_browser/iframe/iframe.ts
+++ b/packages-exp/auth-exp/src/platform_browser/iframe/iframe.ts
@@ -22,7 +22,7 @@ import { AUTH_ERROR_FACTORY, AuthErrorCode } from '../../core/errors';
 import { assert } from '../../core/util/assert';
 import { Delay } from '../../core/util/delay';
 import { _emulatorUrl } from '../../core/util/emulator';
-import { AuthCore } from '../../model/auth';
+import { Auth } from '../../model/auth';
 import { _window } from '../auth_window';
 import * as gapiLoader from './gapi';
 
@@ -39,7 +39,7 @@ const IFRAME_ATTRIBUTES = {
   }
 };
 
-function getIframeUrl(auth: AuthCore): string {
+function getIframeUrl(auth: Auth): string {
   const config = auth.config;
   const url = config.emulator
     ? _emulatorUrl(config, EMULATED_IFRAME_PATH)
@@ -57,7 +57,7 @@ function getIframeUrl(auth: AuthCore): string {
 }
 
 export async function _openIframe(
-  auth: AuthCore
+  auth: Auth
 ): Promise<gapi.iframes.Iframe> {
   const context = await gapiLoader._loadGapi(auth);
   const gapi = _window().gapi;

--- a/packages-exp/auth-exp/src/platform_browser/iframe/iframe.ts
+++ b/packages-exp/auth-exp/src/platform_browser/iframe/iframe.ts
@@ -56,9 +56,7 @@ function getIframeUrl(auth: Auth): string {
   return `${url}?${querystring(params).slice(1)}`;
 }
 
-export async function _openIframe(
-  auth: Auth
-): Promise<gapi.iframes.Iframe> {
+export async function _openIframe(auth: Auth): Promise<gapi.iframes.Iframe> {
   const context = await gapiLoader._loadGapi(auth);
   const gapi = _window().gapi;
   assert(gapi, AuthErrorCode.INTERNAL_ERROR, { appName: auth.name });

--- a/packages-exp/auth-exp/src/platform_browser/mfa/assertions/phone.ts
+++ b/packages-exp/auth-exp/src/platform_browser/mfa/assertions/phone.ts
@@ -17,7 +17,7 @@
 import * as externs from '@firebase/auth-types-exp';
 
 import { MultiFactorAssertion } from '../../../mfa/assertions';
-import { AuthCore } from '../../../model/auth';
+import { Auth } from '../../../model/auth';
 import { finalizeEnrollPhoneMfa } from '../../../api/account_management/mfa';
 import { PhoneAuthCredential } from '../../../core/credentials/phone';
 import {
@@ -39,7 +39,7 @@ export class PhoneMultiFactorAssertion
   }
 
   _finalizeEnroll(
-    auth: AuthCore,
+    auth: Auth,
     idToken: string,
     displayName?: string | null
   ): Promise<FinalizeMfaResponse> {
@@ -51,7 +51,7 @@ export class PhoneMultiFactorAssertion
   }
 
   _finalizeSignIn(
-    auth: AuthCore,
+    auth: Auth,
     mfaPendingCredential: string
   ): Promise<FinalizeMfaResponse> {
     return finalizeSignInPhoneMfa(auth, {

--- a/packages-exp/auth-exp/src/platform_browser/providers/phone.ts
+++ b/packages-exp/auth-exp/src/platform_browser/providers/phone.ts
@@ -19,20 +19,24 @@ import * as externs from '@firebase/auth-types-exp';
 
 import { SignInWithPhoneNumberResponse } from '../../api/authentication/sms';
 import { ApplicationVerifier } from '../../model/application_verifier';
-import { AuthCore } from '../../model/auth';
+import { Auth } from '../../model/auth';
 import { UserCredential } from '../../model/user';
 import { PhoneAuthCredential } from '../../core/credentials/phone';
 import { AuthErrorCode } from '../../core/errors';
 import { _verifyPhoneNumber } from '../strategies/phone';
 import { assert, fail } from '../../core/util/assert';
+import { _castAuth } from '../../core/auth/auth_impl';
 
 export class PhoneAuthProvider implements externs.PhoneAuthProvider {
   static readonly PROVIDER_ID = externs.ProviderId.PHONE;
   static readonly PHONE_SIGN_IN_METHOD = externs.SignInMethod.PHONE;
 
   readonly providerId = PhoneAuthProvider.PROVIDER_ID;
+  private readonly auth: Auth;
 
-  constructor(private readonly auth: AuthCore) {}
+  constructor(auth: externs.Auth) {
+    this.auth = _castAuth(auth);
+  }
 
   verifyPhoneNumber(
     phoneOptions: externs.PhoneInfoOptions | string,

--- a/packages-exp/auth-exp/src/platform_browser/recaptcha/recaptcha_loader.ts
+++ b/packages-exp/auth-exp/src/platform_browser/recaptcha/recaptcha_loader.ts
@@ -20,7 +20,7 @@ import { querystring } from '@firebase/util';
 import { AUTH_ERROR_FACTORY, AuthErrorCode } from '../../core/errors';
 import { assert } from '../../core/util/assert';
 import { Delay } from '../../core/util/delay';
-import { Auth, AuthCore } from '../../model/auth';
+import { Auth } from '../../model/auth';
 import { _window } from '../auth_window';
 import * as jsHelpers from '../load_js';
 import { Recaptcha } from './recaptcha';
@@ -33,7 +33,7 @@ const NETWORK_TIMEOUT_DELAY = new Delay(30000, 60000);
 const RECAPTCHA_BASE = 'https://www.google.com/recaptcha/api.js?';
 
 export interface ReCaptchaLoader {
-  load(auth: AuthCore, hl?: string): Promise<Recaptcha>;
+  load(auth: Auth, hl?: string): Promise<Recaptcha>;
   clearedOneInstance(): void;
 }
 
@@ -45,7 +45,7 @@ export class ReCaptchaLoaderImpl implements ReCaptchaLoader {
   private counter = 0;
   private readonly librarySeparatelyLoaded = !!_window().grecaptcha;
 
-  load(auth: AuthCore, hl = ''): Promise<Recaptcha> {
+  load(auth: Auth, hl = ''): Promise<Recaptcha> {
     assert(isHostLanguageValid(hl), AuthErrorCode.ARGUMENT_ERROR, {
       appName: auth.name
     });

--- a/packages-exp/auth-exp/src/platform_browser/recaptcha/recaptcha_verifier.ts
+++ b/packages-exp/auth-exp/src/platform_browser/recaptcha/recaptcha_verifier.ts
@@ -17,11 +17,12 @@
 
 import * as externs from '@firebase/auth-types-exp';
 import { getRecaptchaParams } from '../../api/authentication/recaptcha';
+import { _castAuth } from '../../core/auth/auth_impl';
 import { AuthErrorCode } from '../../core/errors';
 import { assert } from '../../core/util/assert';
 import { _isHttpOrHttps } from '../../core/util/location';
 import { ApplicationVerifier } from '../../model/application_verifier';
-import { AuthCore } from '../../model/auth';
+import { Auth } from '../../model/auth';
 import { _window } from '../auth_window';
 import { Parameters, Recaptcha } from './recaptcha';
 import {
@@ -49,6 +50,7 @@ export class RecaptchaVerifier
   private readonly isInvisible: boolean;
   private readonly tokenChangeListeners = new Set<TokenCallback>();
   private renderPromise: Promise<number> | null = null;
+  private readonly auth: Auth;
 
   readonly _recaptchaLoader: ReCaptchaLoader;
   private recaptcha: Recaptcha | null = null;
@@ -58,8 +60,9 @@ export class RecaptchaVerifier
     private readonly parameters: Parameters = {
       ...DEFAULT_PARAMS
     },
-    private readonly auth: AuthCore
+    authExtern: externs.Auth
   ) {
+    this.auth = _castAuth(authExtern);
     this.appName = this.auth.name;
     this.isInvisible = this.parameters.size === 'invisible';
     assert(

--- a/packages-exp/auth-exp/src/platform_browser/strategies/phone.ts
+++ b/packages-exp/auth-exp/src/platform_browser/strategies/phone.ts
@@ -21,11 +21,11 @@ import { startEnrollPhoneMfa } from '../../api/account_management/mfa';
 import { startSignInPhoneMfa } from '../../api/authentication/mfa';
 import { sendPhoneVerificationCode } from '../../api/authentication/sms';
 import { ApplicationVerifier } from '../../model/application_verifier';
-import { AuthCore } from '../../model/auth';
 import { PhoneAuthCredential } from '../../core/credentials/phone';
 import { AuthErrorCode } from '../../core/errors';
 import { _assertLinkedStatus, _link } from '../../core/user/link_unlink';
 import { assert } from '../../core/util/assert';
+import { Auth } from '../../model/auth';
 import {
   linkWithCredential,
   reauthenticateWithCredential,
@@ -37,6 +37,7 @@ import {
 } from '../../mfa/mfa_session';
 import { User } from '../../model/user';
 import { RECAPTCHA_VERIFIER_TYPE } from '../recaptcha/recaptcha_verifier';
+import { _castAuth } from '../../core/auth/auth_impl';
 
 interface OnConfirmationCallback {
   (credential: PhoneAuthCredential): Promise<externs.UserCredential>;
@@ -63,7 +64,7 @@ export async function signInWithPhoneNumber(
   appVerifier: externs.ApplicationVerifier
 ): Promise<externs.ConfirmationResult> {
   const verificationId = await _verifyPhoneNumber(
-    auth,
+    _castAuth(auth),
     phoneNumber,
     appVerifier as ApplicationVerifier
   );
@@ -110,7 +111,7 @@ export async function reauthenticateWithPhoneNumber(
  *  is sent.
  */
 export async function _verifyPhoneNumber(
-  auth: AuthCore,
+  auth: Auth,
   options: externs.PhoneInfoOptions | string,
   verifier: ApplicationVerifier
 ): Promise<string> {

--- a/packages-exp/auth-exp/src/platform_browser/strategies/redirect.test.ts
+++ b/packages-exp/auth-exp/src/platform_browser/strategies/redirect.test.ts
@@ -411,7 +411,7 @@ describe('src/core/strategies/redirect', () => {
       sinon.spy(redirectPersistence, '_remove');
 
       const cred = new UserCredentialImpl({
-        user: auth.currentUser!,
+        user: auth._currentUser!,
         providerId: externs.ProviderId.GOOGLE,
         operationType: externs.OperationType.LINK
       });
@@ -422,7 +422,7 @@ describe('src/core/strategies/redirect', () => {
       });
       expect(await promise).to.eq(cred);
       expect(redirectPersistence._remove).to.have.been.called;
-      expect(auth.currentUser?._redirectEventId).to.be.undefined;
+      expect(auth._currentUser?._redirectEventId).to.be.undefined;
       expect(auth.persistenceLayer.lastObjectSet?._redirectEventId).to.be
         .undefined;
     });


### PR DESCRIPTION
Big change to switch to composition over inheritance.

The changes in `auth-exp` are mostly just cleaning up the complexity that was required for inheritance. The important bits are in the `auth-compat-exp` folder.

Also switched `auth-compat-exp` to depend on `app-compat` instead of `app`