### PR TITLE
Using Compat-Layer for IndexedDB persistence

### DIFF
--- a/packages/firestore/src/util/async_queue.ts
+++ b/packages/firestore/src/util/async_queue.ts
@@ -240,8 +240,7 @@ export class AsyncQueue {
     if (document) {
       logDebug(
         LOG_TAG,
-        'Visibility state changed to  ',
-        document.visibilityState
+        'Visibility state changed to ' + document.visibilityState
       );
     }
     this.backoff.skipBackoff();

--- a/packages/firestore/test/integration/api_internal/database.test.ts
+++ b/packages/firestore/test/integration/api_internal/database.test.ts
@@ -75,7 +75,7 @@ apiDescribe('Database (with internal API)', (persistence: boolean) => {
       await app.delete();
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      expect((docRef.firestore as any)._isTerminated).to.be.true;
+      expect((docRef.firestore as any)._terminated).to.be.true;
     });
   });
 });


### PR DESCRIPTION
This PR pulls the Component Provider from firebase-exp into the legacy SDK. The main challenge is that some of the functionality in FirestoreClient now needs to live in FirebaseFirestore itself (the firestore-exp SDK doesn't use FirestoreClient since it is not tree-shakeable).

This PR passes all tests, but some of the changes here cannot be tested with our current test setup. I verified manually that persistence fallback works and that auth tokens are properly swapped as users sign in and out (by using two users in a web app and enforcing via security rules that each user can only write into their region of Firestore)