### PR TITLE
Implement useEmulator for Database

### DIFF
--- a/.changeset/bright-ducks-jump.md
+++ b/.changeset/bright-ducks-jump.md
@@ -1,5 +1,7 @@
 ---
+'firebase': minor
 '@firebase/database': minor
+'@firebase/database-types': minor
 ---
 
-Add a useEmulator(host, port) method
+Add a useEmulator(host, port) method to Realtime Database

--- a/.changeset/bright-ducks-jump.md
+++ b/.changeset/bright-ducks-jump.md
@@ -1,0 +1,5 @@
+---
+'@firebase/database': minor
+---
+
+Add a useEmulator(host, port) method

--- a/packages/database-types/index.d.ts
+++ b/packages/database-types/index.d.ts
@@ -34,6 +34,7 @@ export interface DataSnapshot {
 
 export interface Database {
   app: FirebaseApp;
+  useEmulator(host: string, port: number): void;
   goOffline(): void;
   goOnline(): void;
   ref(path?: string | Reference): Reference;
@@ -43,6 +44,7 @@ export interface Database {
 export class FirebaseDatabase implements Database {
   private constructor();
   app: FirebaseApp;
+  useEmulator(host: string, port: number): void;
   goOffline(): void;
   goOnline(): void;
   ref(path?: string | Reference): Reference;

--- a/packages/database/src/api/Database.ts
+++ b/packages/database/src/api/Database.ts
@@ -74,7 +74,10 @@ export class Database implements FirebaseService {
   };
 
   private get repo_(): Repo {
-    this.instanceStarted_ = true;
+    if (!this.instanceStarted_) {
+      this.repoInternal_.start();
+      this.instanceStarted_ = true;
+    }
     return this.repoInternal_;
   }
 

--- a/packages/database/src/api/Database.ts
+++ b/packages/database/src/api/Database.ts
@@ -16,7 +16,7 @@
  */
 
 import { fatal } from '../core/util/util';
-import { parseRepoInfo } from '../core/util/libs/parser';
+import { parseDatabaseURL, parseRepoInfo } from '../core/util/libs/parser';
 import { Path } from '../core/util/Path';
 import { Reference } from './Reference';
 import { Repo } from '../core/Repo';
@@ -156,16 +156,21 @@ export class Database implements FirebaseService {
     const parsedURL = parseRepoInfo(url, this.repo_.repoInfo_.nodeAdmin);
     validateUrl(apiName, 1, parsedURL);
 
-    const repoInfo = parsedURL.repoInfo;
-    const expectedHost = this.repo_.originalHost;
-    if (repoInfo.host !== expectedHost) {
+    const newHost = parsedURL.repoInfo.host;
+    const originalHost = parseDatabaseURL(this.repo_.productionUrl).host;
+    const currentHost = this.repo_.repoInfo_.host;
+    if (newHost !== originalHost && newHost !== currentHost) {
+      const expected = originalHost === currentHost
+          ? originalHost
+          : `${originalHost} or ${currentHost}`;
+      
       fatal(
         apiName +
           ': Host name does not match the current database: ' +
           '(found ' +
-          repoInfo.host +
+          newHost +
           ' but expected ' +
-          expectedHost +
+          expected +
           ')'
       );
     }

--- a/packages/database/src/api/Database.ts
+++ b/packages/database/src/api/Database.ts
@@ -102,6 +102,7 @@ export class Database implements FirebaseService {
    * @param port the emulator port (ex: 8080)
    */
   useEmulator(host: string, port: number): void {
+    this.checkDeleted_('useEmulator');
     if (this.instanceStarted_) {
       fatal(
         'Cannot call useEmulator() after instance has already been initialized.'
@@ -156,14 +157,15 @@ export class Database implements FirebaseService {
     validateUrl(apiName, 1, parsedURL);
 
     const repoInfo = parsedURL.repoInfo;
-    if (repoInfo.host !== this.repo_.repoInfo_.host) {
+    const expectedHost = this.repo_.originalHost;
+    if (repoInfo.host !== expectedHost) {
       fatal(
         apiName +
           ': Host name does not match the current database: ' +
           '(found ' +
           repoInfo.host +
           ' but expected ' +
-          (this.repo_.repoInfo_ as RepoInfo).host +
+          expectedHost +
           ')'
       );
     }
@@ -175,7 +177,7 @@ export class Database implements FirebaseService {
    * @param {string} apiName
    */
   private checkDeleted_(apiName: string) {
-    if (this.repo_ === null) {
+    if (this.repoInternal_ === null) {
       fatal('Cannot call ' + apiName + ' on a deleted database.');
     }
   }

--- a/packages/database/src/api/Database.ts
+++ b/packages/database/src/api/Database.ts
@@ -16,7 +16,7 @@
  */
 
 import { fatal } from '../core/util/util';
-import { parseDatabaseURL, parseRepoInfo } from '../core/util/libs/parser';
+import { parseRepoInfo } from '../core/util/libs/parser';
 import { Path } from '../core/util/Path';
 import { Reference } from './Reference';
 import { Repo } from '../core/Repo';
@@ -156,21 +156,16 @@ export class Database implements FirebaseService {
     const parsedURL = parseRepoInfo(url, this.repo_.repoInfo_.nodeAdmin);
     validateUrl(apiName, 1, parsedURL);
 
-    const newHost = parsedURL.repoInfo.host;
-    const originalHost = parseDatabaseURL(this.repo_.productionUrl).host;
-    const currentHost = this.repo_.repoInfo_.host;
-    if (newHost !== originalHost && newHost !== currentHost) {
-      const expected = originalHost === currentHost
-          ? originalHost
-          : `${originalHost} or ${currentHost}`;
-      
+    const repoInfo = parsedURL.repoInfo;
+    const expectedHost = this.repo_.originalHost;
+    if (repoInfo.host !== expectedHost) {
       fatal(
         apiName +
           ': Host name does not match the current database: ' +
           '(found ' +
-          newHost +
+          repoInfo.host +
           ' but expected ' +
-          expected +
+          expectedHost +
           ')'
       );
     }

--- a/packages/database/src/api/Database.ts
+++ b/packages/database/src/api/Database.ts
@@ -66,6 +66,7 @@ export class Database implements FirebaseService {
     }
     
     // We have to "reserve" the repo now so we can safely create it as-needed
+    // TOOD(samstern): Enabling this is a mess
     // RepoManager.getInstance().reserveRepo(repoInfo_, app);
     this.INTERNAL = new DatabaseInternals(this);
   }

--- a/packages/database/src/api/Database.ts
+++ b/packages/database/src/api/Database.ts
@@ -103,7 +103,7 @@ export class Database implements FirebaseService {
    * @param host the emulator host (ex: localhost)
    * @param port the emulator port (ex: 8080)
    */
-  useEmulator(host: string, port: number) {
+  useEmulator(host: string, port: number): void {
     if (this.instanceUsed_) {
       fatal(
         'Cannot call useEmulator() after instance has already been initialized.'

--- a/packages/database/src/api/Database.ts
+++ b/packages/database/src/api/Database.ts
@@ -157,15 +157,14 @@ export class Database implements FirebaseService {
     validateUrl(apiName, 1, parsedURL);
 
     const repoInfo = parsedURL.repoInfo;
-    const expectedHost = this.repo_.originalHost;
-    if (repoInfo.host !== expectedHost) {
+    if (!repoInfo.isCustomHost() && repoInfo.host !== this.repo_.repoInfo_.host) {
       fatal(
         apiName +
           ': Host name does not match the current database: ' +
           '(found ' +
           repoInfo.host +
           ' but expected ' +
-          expectedHost +
+          this.repo_.repoInfo_.host+
           ')'
       );
     }

--- a/packages/database/src/api/Reference.ts
+++ b/packages/database/src/api/Reference.ts
@@ -37,7 +37,6 @@ import { validateArgCount, validateCallback, Deferred } from '@firebase/util';
 import { SyncPoint } from '../core/SyncPoint';
 import { Database } from './Database';
 import { DataSnapshot } from './DataSnapshot';
-import * as types from '@firebase/database-types';
 
 export interface ReferenceConstructor {
   new (repo: Repo, path: Path): Reference;

--- a/packages/database/src/api/Reference.ts
+++ b/packages/database/src/api/Reference.ts
@@ -37,6 +37,7 @@ import { validateArgCount, validateCallback, Deferred } from '@firebase/util';
 import { SyncPoint } from '../core/SyncPoint';
 import { Database } from './Database';
 import { DataSnapshot } from './DataSnapshot';
+import * as types from '@firebase/database-types';
 
 export interface ReferenceConstructor {
   new (repo: Repo, path: Path): Reference;

--- a/packages/database/src/core/Repo.ts
+++ b/packages/database/src/core/Repo.ts
@@ -71,6 +71,7 @@ export class Repo {
   private interceptServerDataCallback_:
     | ((a: string, b: unknown) => void)
     | null = null;
+  private __database: Database;
 
   /** A list of data pieces and paths to be set when this client disconnects. */
   private onDisconnect_ = new SparseSnapshotTree();
@@ -82,8 +83,7 @@ export class Repo {
     public repoInfo_: RepoInfo,
     forceRestClient: boolean,
     public app: FirebaseApp,
-    public authTokenProvider: AuthTokenProvider,
-    public readonly database: Database,
+    public authTokenProvider: AuthTokenProvider
   ) {
     this.stats_ = StatsManager.getCollection(repoInfo_);
 
@@ -636,5 +636,9 @@ export class Repo {
         }
       });
     }
+  }
+
+  get database(): Database {
+    return this.__database || (this.__database = new Database(this));
   }
 }

--- a/packages/database/src/core/Repo.ts
+++ b/packages/database/src/core/Repo.ts
@@ -57,6 +57,9 @@ export class Repo {
   /** Key for uniquely identifying this repo, used in RepoManager */
   readonly key: string;
 
+  /** Record of the original host, which does not change even if useEmulator mutates the repo */
+  readonly originalHost: string;
+
   dataUpdateCount = 0;
   private infoSyncTree_: SyncTree;
   private serverSyncTree_: SyncTree;
@@ -90,6 +93,7 @@ export class Repo {
   ) {
     // This key is intentionally not updated if RepoInfo is later changed or replaced
     this.key = this.repoInfo_.toURLString();
+    this.originalHost = this.repoInfo_.host;
   }
 
   start(): void {

--- a/packages/database/src/core/Repo.ts
+++ b/packages/database/src/core/Repo.ts
@@ -84,23 +84,28 @@ export class Repo {
 
   constructor(
     public repoInfo_: RepoInfo,
-    forceRestClient: boolean,
+    private forceRestClient_: boolean,
     public app: FirebaseApp,
-    authTokenProvider: AuthTokenProvider
+    public authTokenProvider_: AuthTokenProvider
   ) {
-    this.stats_ = StatsManager.getCollection(repoInfo_);
+    // This key is intentionally not updated if RepoInfo is later changed or replaced
+    this.key = this.repoInfo_.toURLString();
+  }
 
-    if (forceRestClient || beingCrawled()) {
+  start(): void {
+    this.stats_ = StatsManager.getCollection(this.repoInfo_);
+
+    if (this.forceRestClient_ || beingCrawled()) {
       this.server_ = new ReadonlyRestClient(
         this.repoInfo_,
         this.onDataUpdate_.bind(this),
-        authTokenProvider
+        this.authTokenProvider_
       );
 
       // Minor hack: Fire onConnect immediately, since there's no actual connection.
       setTimeout(this.onConnectStatus_.bind(this, true), 0);
     } else {
-      const authOverride = app.options['databaseAuthVariableOverride'];
+      const authOverride = this.app.options['databaseAuthVariableOverride'];
       // Validate authOverride
       if (typeof authOverride !== 'undefined' && authOverride !== null) {
         if (typeof authOverride !== 'object') {
@@ -117,25 +122,25 @@ export class Repo {
 
       this.persistentConnection_ = new PersistentConnection(
         this.repoInfo_,
-        app.options.appId,
+        this.app.options.appId,
         this.onDataUpdate_.bind(this),
         this.onConnectStatus_.bind(this),
         this.onServerInfoUpdate_.bind(this),
-        authTokenProvider,
+        this.authTokenProvider_,
         authOverride
       );
 
       this.server_ = this.persistentConnection_;
     }
 
-    authTokenProvider.addTokenChangeListener(token => {
+    this.authTokenProvider_.addTokenChangeListener(token => {
       this.server_.refreshAuthToken(token);
     });
 
     // In the case of multiple Repos for the same repoInfo (i.e. there are multiple Firebase.Contexts being used),
     // we only want to create one StatsReporter.  As such, we'll report stats over the first Repo created.
     this.statsReporter_ = StatsManager.getOrCreateReporter(
-      repoInfo_,
+      this.repoInfo_,
       () => new StatsReporter(this.stats_, this.server_)
     );
 
@@ -177,9 +182,6 @@ export class Repo {
         this.server_.unlisten(query, tag);
       }
     });
-
-    // This key is intentionally not updated if RepoInfo is later changed or replaced
-    this.key = this.repoInfo_.toURLString();
   }
 
   /**

--- a/packages/database/src/core/Repo.ts
+++ b/packages/database/src/core/Repo.ts
@@ -86,7 +86,7 @@ export class Repo {
     public repoInfo_: RepoInfo,
     forceRestClient: boolean,
     public app: FirebaseApp,
-    public authTokenProvider: AuthTokenProvider
+    authTokenProvider: AuthTokenProvider
   ) {
     this.stats_ = StatsManager.getCollection(repoInfo_);
 

--- a/packages/database/src/core/Repo.ts
+++ b/packages/database/src/core/Repo.ts
@@ -54,11 +54,8 @@ const INTERRUPT_REASON = 'repo_interrupt';
  * A connection to a single data repository.
  */
 export class Repo {
-  /** Key for uniquely identifying this repo, used in RepoManager */
-  readonly key: string;
-
   /** Record of the original host, which does not change even if useEmulator mutates the repo */
-  readonly originalHost: string;
+  readonly productionUrl: string;
 
   dataUpdateCount = 0;
   private infoSyncTree_: SyncTree;
@@ -91,9 +88,7 @@ export class Repo {
     public app: FirebaseApp,
     public authTokenProvider_: AuthTokenProvider
   ) {
-    // This key is intentionally not updated if RepoInfo is later changed or replaced
-    this.key = this.repoInfo_.toURLString();
-    this.originalHost = this.repoInfo_.host;
+    this.productionUrl = this.repoInfo_.toURLString();
   }
 
   start(): void {

--- a/packages/database/src/core/Repo.ts
+++ b/packages/database/src/core/Repo.ts
@@ -54,8 +54,11 @@ const INTERRUPT_REASON = 'repo_interrupt';
  * A connection to a single data repository.
  */
 export class Repo {
+  /** Key for uniquely identifying this repo, used in RepoManager */
+  readonly key: string;
+
   /** Record of the original host, which does not change even if useEmulator mutates the repo */
-  readonly productionUrl: string;
+  readonly originalHost: string;
 
   dataUpdateCount = 0;
   private infoSyncTree_: SyncTree;
@@ -88,7 +91,9 @@ export class Repo {
     public app: FirebaseApp,
     public authTokenProvider_: AuthTokenProvider
   ) {
-    this.productionUrl = this.repoInfo_.toURLString();
+    // This key is intentionally not updated if RepoInfo is later changed or replaced
+    this.key = this.repoInfo_.toURLString();
+    this.originalHost = this.repoInfo_.host;
   }
 
   start(): void {

--- a/packages/database/src/core/Repo.ts
+++ b/packages/database/src/core/Repo.ts
@@ -57,9 +57,6 @@ export class Repo {
   /** Key for uniquely identifying this repo, used in RepoManager */
   readonly key: string;
 
-  /** Record of the original host, which does not change even if useEmulator mutates the repo */
-  readonly originalHost: string;
-
   dataUpdateCount = 0;
   private infoSyncTree_: SyncTree;
   private serverSyncTree_: SyncTree;
@@ -93,7 +90,6 @@ export class Repo {
   ) {
     // This key is intentionally not updated if RepoInfo is later changed or replaced
     this.key = this.repoInfo_.toURLString();
-    this.originalHost = this.repoInfo_.host;
   }
 
   start(): void {

--- a/packages/database/src/core/Repo.ts
+++ b/packages/database/src/core/Repo.ts
@@ -83,7 +83,7 @@ export class Repo {
     public repoInfo_: RepoInfo,
     forceRestClient: boolean,
     public app: FirebaseApp,
-    authTokenProvider: AuthTokenProvider
+    public authTokenProvider: AuthTokenProvider
   ) {
     this.stats_ = StatsManager.getCollection(repoInfo_);
 

--- a/packages/database/src/core/Repo.ts
+++ b/packages/database/src/core/Repo.ts
@@ -54,6 +54,9 @@ const INTERRUPT_REASON = 'repo_interrupt';
  * A connection to a single data repository.
  */
 export class Repo {
+  /** Key for uniquely identifying this repo, used in RepoManager */
+  readonly key: string;
+
   dataUpdateCount = 0;
   private infoSyncTree_: SyncTree;
   private serverSyncTree_: SyncTree;
@@ -174,6 +177,9 @@ export class Repo {
         this.server_.unlisten(query, tag);
       }
     });
+
+    // This key is intentionally not updated if RepoInfo is later changed or replaced
+    this.key = this.repoInfo_.toURLString();
   }
 
   /**

--- a/packages/database/src/core/Repo.ts
+++ b/packages/database/src/core/Repo.ts
@@ -71,7 +71,6 @@ export class Repo {
   private interceptServerDataCallback_:
     | ((a: string, b: unknown) => void)
     | null = null;
-  private __database: Database;
 
   /** A list of data pieces and paths to be set when this client disconnects. */
   private onDisconnect_ = new SparseSnapshotTree();
@@ -83,7 +82,8 @@ export class Repo {
     public repoInfo_: RepoInfo,
     forceRestClient: boolean,
     public app: FirebaseApp,
-    public authTokenProvider: AuthTokenProvider
+    public authTokenProvider: AuthTokenProvider,
+    public readonly database: Database,
   ) {
     this.stats_ = StatsManager.getCollection(repoInfo_);
 
@@ -636,9 +636,5 @@ export class Repo {
         }
       });
     }
-  }
-
-  get database(): Database {
-    return this.__database || (this.__database = new Database(this));
   }
 }

--- a/packages/database/src/core/RepoManager.ts
+++ b/packages/database/src/core/RepoManager.ts
@@ -176,13 +176,13 @@ export class RepoManager {
   deleteRepo(repo: Repo) {
     const appRepos = safeGet(this.repos_, repo.app.name);
     // This should never happen...
-    if (!appRepos || safeGet(appRepos, repo.key) !== repo) {
+    if (!appRepos || safeGet(appRepos, repo.productionUrl) !== repo) {
       fatal(
         `Database ${repo.app.name}(${repo.repoInfo_}) has already been deleted.`
       );
     }
     repo.interrupt();
-    delete appRepos[repo.key];
+    delete appRepos[repo.productionUrl];
   }
 
   /**

--- a/packages/database/src/core/RepoManager.ts
+++ b/packages/database/src/core/RepoManager.ts
@@ -176,13 +176,13 @@ export class RepoManager {
   deleteRepo(repo: Repo) {
     const appRepos = safeGet(this.repos_, repo.app.name);
     // This should never happen...
-    if (!appRepos || safeGet(appRepos, repo.productionUrl) !== repo) {
+    if (!appRepos || safeGet(appRepos, repo.key) !== repo) {
       fatal(
         `Database ${repo.app.name}(${repo.repoInfo_}) has already been deleted.`
       );
     }
     repo.interrupt();
-    delete appRepos[repo.productionUrl];
+    delete appRepos[repo.key];
   }
 
   /**

--- a/packages/database/src/core/RepoManager.ts
+++ b/packages/database/src/core/RepoManager.ts
@@ -92,7 +92,7 @@ export class RepoManager {
    */
   applyEmulatorSettings(repo: Repo, host: string, port: number): void {
     repo.repoInfo_ = new RepoInfo(
-      `${host}/${port}`,
+      `${host}:${port}`,
       /* secure= */ false,
       repo.repoInfo_.namespace,
       repo.repoInfo_.webSocketOnly,

--- a/packages/database/src/core/RepoManager.ts
+++ b/packages/database/src/core/RepoManager.ts
@@ -102,9 +102,7 @@ export class RepoManager {
     );
 
     if (repo.repoInfo_.nodeAdmin) {
-      // TODO(samtstern): We need to re-run the initialization of the
-      //  `authTokenProvider` related code in the RepoInfo constructor
-      repo.authTokenProvider = new EmulatorAdminTokenProvider();
+      repo.authTokenProvider_ = new EmulatorAdminTokenProvider();
     }
   }
 

--- a/packages/database/src/core/RepoManager.ts
+++ b/packages/database/src/core/RepoManager.ts
@@ -91,17 +91,21 @@ export class RepoManager {
    * Update an existing repo in place to point to a new host/port.
    */
   applyEmulatorSettings(repo: Repo, host: string, port: number): void {
-    const url = `http://${host}:${port}?ns=${repo.repoInfo_.namespace}`;
+    repo.repoInfo_ = new RepoInfo(
+      `${host}/${port}`,
+      /* secure= */ false,
+      repo.repoInfo_.namespace,
+      repo.repoInfo_.webSocketOnly,
+      repo.repoInfo_.nodeAdmin,
+      repo.repoInfo_.persistenceKey,
+      repo.repoInfo_.includeNamespaceInQueryParams
+    );
 
-    const nodeAdmin = repo.repoInfo_.nodeAdmin;
-    const authTokenProvider = nodeAdmin
-      ? new EmulatorAdminTokenProvider()
-      : repo.authTokenProvider;
-
-    // Update the repo in-place
-    const { repoInfo } = parseRepoInfo(url, nodeAdmin);
-    repo.repoInfo_ = repoInfo;
-    repo.authTokenProvider = authTokenProvider;
+    if (repo.repoInfo_.nodeAdmin) {
+      // TODO(samtstern): We need to re-run the initialization of the
+      //  `authTokenProvider` related code in the RepoInfo constructor
+      repo.authTokenProvider = new EmulatorAdminTokenProvider();
+    }
   }
 
   /**

--- a/packages/database/src/core/RepoManager.ts
+++ b/packages/database/src/core/RepoManager.ts
@@ -98,17 +98,10 @@ export class RepoManager {
       ? new EmulatorAdminTokenProvider()
       : repo.authTokenProvider;
 
-    // Before we modify the repo, get the key used in the repo manager
-    const oldRepoKey = repo.repoInfo_.toURLString();
-
     // Update the repo in-place
     const { repoInfo } = parseRepoInfo(url, nodeAdmin);
     repo.repoInfo_ = repoInfo;
     repo.authTokenProvider = authTokenProvider;
-
-    // Replace the repomanager cache entry
-    delete this.repos_[repo.app.name][oldRepoKey];
-    this.repos_[repo.app.name][repoInfo.toURLString()] = repo;
   }
 
   /**
@@ -181,13 +174,13 @@ export class RepoManager {
   deleteRepo(repo: Repo) {
     const appRepos = safeGet(this.repos_, repo.app.name);
     // This should never happen...
-    if (!appRepos || safeGet(appRepos, repo.repoInfo_.toURLString()) !== repo) {
+    if (!appRepos || safeGet(appRepos, repo.key) !== repo) {
       fatal(
         `Database ${repo.app.name}(${repo.repoInfo_}) has already been deleted.`
       );
     }
     repo.interrupt();
-    delete appRepos[repo.repoInfo_.toURLString()];
+    delete appRepos[repo.key];
   }
 
   /**

--- a/packages/database/src/core/RepoManager.ts
+++ b/packages/database/src/core/RepoManager.ts
@@ -88,6 +88,21 @@ export class RepoManager {
   }
 
   /**
+   * Create a new repo based on an old one but pointing to a particular host and port.
+   */
+  cloneRepoForEmulator(repo: Repo, host: string, port: number): Repo {
+    const nodeAdmin = repo.repoInfo_.nodeAdmin;
+    const url = `http://${host}:${port}?ns=${repo.repoInfo_.namespace}`;
+    const authTokenProvider = nodeAdmin
+      ? new EmulatorAdminTokenProvider()
+      : repo.authTokenProvider;
+
+    const parsedUrl = parseRepoInfo(url, nodeAdmin);
+
+    return this.createRepo(parsedUrl.repoInfo, repo.app, authTokenProvider);
+  }
+
+  /**
    * This function should only ever be called to CREATE a new database instance.
    *
    * @param {!FirebaseApp} app

--- a/packages/database/test/database.test.ts
+++ b/packages/database/test/database.test.ts
@@ -286,4 +286,12 @@ describe('Database Tests', () => {
     const ref = db.refFromURL(DATABASE_ADDRESS + '/path/to/data');
     expect(ref.toString()).to.equal(`http://localhost:1234/path/to/data`);
   });
+
+  it('refFromURL accepts an emulated ref with useEmulator', () => {
+    const db = (firebase as any).database();
+    db.useEmulator('localhost', 1234);
+
+    const ref = db.refFromURL('http://localhost:1234/path/to/data');
+    expect(ref.toString()).to.equal(`http://localhost:1234/path/to/data`);
+  });
 });

--- a/packages/database/test/database.test.ts
+++ b/packages/database/test/database.test.ts
@@ -286,12 +286,4 @@ describe('Database Tests', () => {
     const ref = db.refFromURL(DATABASE_ADDRESS + '/path/to/data');
     expect(ref.toString()).to.equal(`http://localhost:1234/path/to/data`);
   });
-
-  it('refFromURL accepts an emulated ref with useEmulator', () => {
-    const db = (firebase as any).database();
-    db.useEmulator('localhost', 1234);
-
-    const ref = db.refFromURL('http://localhost:1234/path/to/data');
-    expect(ref.toString()).to.equal(`http://localhost:1234/path/to/data`);
-  });
 });

--- a/packages/database/test/database.test.ts
+++ b/packages/database/test/database.test.ts
@@ -260,4 +260,22 @@ describe('Database Tests', () => {
       const ref = (db as any).refFromURL();
     }).to.throw(/Expects at least 1/);
   });
+
+  it('can call useEmulator before use', () => {
+    const db = (firebase as any).database();
+    db.useEmulator('localhost', 1234);
+    expect(db.ref().toString()).to.equal('http://localhost:1234/');
+  });
+
+  it('cannot call useEmulator after use', () => {
+    const db = (firebase as any).database();
+
+    db.ref().set({
+      hello: 'world'
+    });
+
+    expect(() => {
+      db.useEmulator('localhost', 1234);
+    }).to.throw(/Cannot call useEmulator/);
+  });
 });

--- a/packages/database/test/database.test.ts
+++ b/packages/database/test/database.test.ts
@@ -229,8 +229,8 @@ describe('Database Tests', () => {
   });
 
   it('ref() validates project', () => {
-    const db1 = defaultApp.database('http://bar.foo.com');
-    const db2 = defaultApp.database('http://foo.bar.com');
+    const db1 = defaultApp.database('http://bar.firebaseio.com');
+    const db2 = defaultApp.database('http://foo.firebaseio.com');
 
     const ref1 = db1.ref('child');
 

--- a/packages/database/test/database.test.ts
+++ b/packages/database/test/database.test.ts
@@ -278,4 +278,12 @@ describe('Database Tests', () => {
       db.useEmulator('localhost', 1234);
     }).to.throw(/Cannot call useEmulator/);
   });
+
+  it('refFromURL returns an emulated ref with useEmulator', () => {
+    const db = (firebase as any).database();
+    db.useEmulator('localhost', 1234);
+
+    const ref = db.refFromURL(DATABASE_ADDRESS + '/path/to/data');
+    expect(ref.toString()).to.equal(`http://localhost:1234/path/to/data`);
+  });
 });

--- a/packages/firebase/index.d.ts
+++ b/packages/firebase/index.d.ts
@@ -5648,6 +5648,15 @@ declare namespace firebase.database {
      */
     app: firebase.app.App;
     /**
+     * Modify this instance to communicate with the Realtime Database emulator.
+     *
+     * <p>Note: this must be called before this instance has been used to do any operations.
+     *
+     * @param host the emulator host (ex: localhost)
+     * @param port the emulator port (ex: 8080)
+     */
+    useEmulator(host: string, port: number): void;
+    /**
      * Disconnects from the server (all Database operations will be completed
      * offline).
      *


### PR DESCRIPTION
### Discussion

This PR is part of a group: #3904 #3906 #3909

In order for `useEmulator()` to work the `Repo` has to be changed or replaced.  In Android this was easier because the database instance lazily creates the `Repo` (via `ensureRepo()`) but in JS the `Repo` creates the database instance.

In this change I move the `repo_` and `root_` fields to have getters/setters so that we can track their usage and allow `useEmulator()` to replace the `Repo` only if no database operations have been performed yet.

Android implementation:
https://github.com/firebase/firebase-android-sdk/pull/1802

This follows Proposal 2 at:
http://go/firebase-emulator-connection-api

### Testing

  * Added new unit tests

### API Changes

  * Approved, see above