### PR TITLE
Fix out-of-order execution for enqueueRetryable

### DIFF
--- a/.changeset/long-hornets-scream.md
+++ b/.changeset/long-hornets-scream.md
@@ -1,0 +1,5 @@
+---
+"@firebase/firestore": patch
+---
+
+Fixed a potential issue in our internal queue that could have allowed API calls to be executed out of order.

--- a/packages/firestore/src/util/async_queue.ts
+++ b/packages/firestore/src/util/async_queue.ts
@@ -321,8 +321,10 @@ export class AsyncQueue {
    * operations were retried successfully.
    */
   enqueueRetryable(op: () => Promise<void>): void {
-    this.retryableOps.push(op);
-    this.enqueueAndForget(() => this.retryNextOp());
+    this.enqueueAndForget(() => {
+      this.retryableOps.push(op);
+      return this.retryNextOp();
+    });
   }
 
   /**


### PR DESCRIPTION
We currently do follow the global order of AsyncQueue operations when we insert items into the retryable queue. This seems to allow operations that inserted into the retryable queue to skip ahead of items that are inserted into the regular queue. This PR ties the insertion of new items to the retryable queue to the order in which all items are enqueue.

I still am not able to reproduce the original failure in a unit test (tried various delays, various order of operations, scheduling operations while other operations are running), but this code change addresses the consistent Integration tests failures in a follow-up PR.