### PR TITLE
Preserve user input in initializeTestApp

### DIFF
--- a/.changeset/ninety-kings-agree.md
+++ b/.changeset/ninety-kings-agree.md
@@ -1,0 +1,5 @@
+---
+'@firebase/rules-unit-testing': patch
+---
+
+Do not delete uid property from user auth object in initializeTestApp()

--- a/packages/rules-unit-testing/src/api/index.ts
+++ b/packages/rules-unit-testing/src/api/index.ts
@@ -127,9 +127,6 @@ function createUnsecuredJwt(token: TokenOptions, projectId?: string): string {
     throw new Error("Auth must contain 'sub', 'uid', or 'user_id' field!");
   }
 
-  // Remove the uid option since it's not actually part of the token spec
-  delete token.uid;
-
   const payload: FirebaseIdToken = {
     // Set all required fields to decent defaults
     iss: `https://securetoken.google.com/${project}`,
@@ -147,6 +144,11 @@ function createUnsecuredJwt(token: TokenOptions, projectId?: string): string {
     // Override with user options
     ...token
   };
+
+  // Remove the uid option since it's not actually part of the token spec.
+  if (payload.uid) {
+    delete payload.uid;
+  }
 
   // Unsecured JWTs use the empty string as a signature.
   const signature = '';

--- a/packages/rules-unit-testing/test/database.test.ts
+++ b/packages/rules-unit-testing/test/database.test.ts
@@ -245,7 +245,21 @@ describe('Testing Module Tests', function () {
       wrongClaim.firestore().doc('test/test').set({ hello: 'test' })
     );
   });
-  
+
+  it('initializeTestApp() does not destroy user input', function () {
+    const options = {
+      projectId: 'fakeproject',
+      auth: {
+        uid: 'sam',
+        email: 'sam@sam.com'
+      }
+    };
+    const optionsCopy = Object.assign({}, options);
+
+    firebase.initializeTestApp(options);
+    expect(options).to.deep.equal(optionsCopy);
+  });
+
   it('loadDatabaseRules() throws if no databaseName or rules', async function () {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     await expect((firebase as any).loadDatabaseRules.bind(null, {})).to.throw(


### PR DESCRIPTION
### Discussion

Fixes #3920

Previous to this change we would delete the `uid` property from the object before copying it, which is destructive if the user is re-using the object.

### Testing

  * Added unit test.

### API Changes

  * None
