### PR TITLE
`lerna` field is deprecated since v3

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,4 @@
 {
-  "lerna": "3.10.5",
   "version": "independent",
   "npmClient": "yarn",
   "packages": [


### PR DESCRIPTION
Remove deprecated field. Anyway, currenly project uses learna v3.22.1, not 3.10.x

