### PR TITLE
Using async functions in Component initialization

### DIFF
--- a/packages/firestore/exp/src/api/components.ts
+++ b/packages/firestore/exp/src/api/components.ts
@@ -105,6 +105,7 @@ export async function setOnlineComponentProvider(
       )
     )
   );
+
   onlineComponentProviders.set(firestore, onlineComponentProvider);
 }
 
@@ -121,6 +122,7 @@ async function getOfflineComponentProvider(
       new MemoryOfflineComponentProvider()
     );
   }
+
   return offlineComponentProviders.get(firestore)!;
 }
 
@@ -133,53 +135,52 @@ async function getOnlineComponentProvider(
     logDebug(LOG_TAG, 'Using default OnlineComponentProvider');
     await setOnlineComponentProvider(firestore, new OnlineComponentProvider());
   }
+
   return onlineComponentProviders.get(firestore)!;
 }
 
-export function getSyncEngine(
+export async function getSyncEngine(
   firestore: FirebaseFirestore
 ): Promise<SyncEngine> {
-  return getOnlineComponentProvider(firestore).then(
-    components => components.syncEngine
-  );
+  const onlineComponentProvider = await getOnlineComponentProvider(firestore);
+  return onlineComponentProvider.syncEngine;
 }
 
-export function getRemoteStore(
+export async function getRemoteStore(
   firestore: FirebaseFirestore
 ): Promise<RemoteStore> {
-  return getOnlineComponentProvider(firestore).then(
-    components => components.remoteStore
-  );
+  const onlineComponentProvider = await getOnlineComponentProvider(firestore);
+  return onlineComponentProvider.remoteStore;
 }
 
-export function getEventManager(
+export async function getEventManager(
   firestore: FirebaseFirestore
 ): Promise<EventManager> {
-  return getOnlineComponentProvider(firestore).then(components => {
-    const eventManager = components.eventManager;
-    eventManager.onListen = syncEngineListen.bind(null, components.syncEngine);
-    eventManager.onUnlisten = syncEngineUnlisten.bind(
-      null,
-      components.syncEngine
-    );
-    return eventManager;
-  });
+  const onlineComponentProvider = await getOnlineComponentProvider(firestore);
+  const eventManager = onlineComponentProvider.eventManager;
+  eventManager.onListen = syncEngineListen.bind(
+    null,
+    onlineComponentProvider.syncEngine
+  );
+  eventManager.onUnlisten = syncEngineUnlisten.bind(
+    null,
+    onlineComponentProvider.syncEngine
+  );
+  return eventManager;
 }
 
-export function getPersistence(
+export async function getPersistence(
   firestore: FirebaseFirestore
 ): Promise<Persistence> {
-  return getOfflineComponentProvider(firestore).then(
-    components => components.persistence
-  );
+  const offlineComponentProvider = await getOfflineComponentProvider(firestore);
+  return offlineComponentProvider.persistence;
 }
 
-export function getLocalStore(
+export async function getLocalStore(
   firestore: FirebaseFirestore
 ): Promise<LocalStore> {
-  return getOfflineComponentProvider(firestore).then(
-    provider => provider.localStore
-  );
+  const offlineComponentProvider = await getOfflineComponentProvider(firestore);
+  return offlineComponentProvider.localStore;
 }
 
 /**

--- a/packages/firestore/exp/src/api/components.ts
+++ b/packages/firestore/exp/src/api/components.ts
@@ -23,7 +23,6 @@ import {
   OnlineComponentProvider
 } from '../../../src/core/component_provider';
 import { handleUserChange, LocalStore } from '../../../src/local/local_store';
-import { Deferred } from '../../../src/util/promise';
 import { logDebug } from '../../../src/util/log';
 import {
   RemoteStore,
@@ -36,7 +35,8 @@ import {
 } from '../../../src/core/sync_engine';
 import { Persistence } from '../../../src/local/persistence';
 import { EventManager } from '../../../src/core/event_manager';
-export const LOG_TAG = 'ComponentProvider';
+
+const LOG_TAG = 'ComponentProvider';
 
 // The components module manages the lifetime of dependencies of the Firestore
 // client. Dependencies can be lazily constructed and only one exists per
@@ -46,11 +46,11 @@ export const LOG_TAG = 'ComponentProvider';
 // Firestore instance.
 const offlineComponentProviders = new Map<
   FirebaseFirestore,
-  Promise<OfflineComponentProvider>
+  OfflineComponentProvider
 >();
 const onlineComponentProviders = new Map<
   FirebaseFirestore,
-  Promise<OnlineComponentProvider>
+  OnlineComponentProvider
 >();
 
 export async function setOfflineComponentProvider(
@@ -58,13 +58,10 @@ export async function setOfflineComponentProvider(
   persistenceSettings: PersistenceSettings,
   offlineComponentProvider: OfflineComponentProvider
 ): Promise<void> {
-  const offlineDeferred = new Deferred<OfflineComponentProvider>();
-  offlineComponentProviders.set(firestore, offlineDeferred.promise);
-
+  logDebug(LOG_TAG, 'Initializing OfflineComponentProvider');
   const configuration = await firestore._getConfiguration();
   configuration.persistenceSettings = persistenceSettings;
 
-  logDebug(LOG_TAG, 'Initializing OfflineComponentProvider');
   await offlineComponentProvider.initialize(configuration);
   firestore._setCredentialChangeListener(user =>
     // TODO(firestorexp): This should be a retryable IndexedDB operation
@@ -79,15 +76,15 @@ export async function setOfflineComponentProvider(
   offlineComponentProvider.persistence.setDatabaseDeletedListener(() =>
     firestore._delete()
   );
-  offlineDeferred.resolve(offlineComponentProvider);
+
+  offlineComponentProviders.set(firestore, offlineComponentProvider);
 }
 
 export async function setOnlineComponentProvider(
   firestore: FirebaseFirestore,
   onlineComponentProvider: OnlineComponentProvider
 ): Promise<void> {
-  const onlineDeferred = new Deferred<OnlineComponentProvider>();
-  onlineComponentProviders.set(firestore, onlineDeferred.promise);
+  firestore._queue.verifyOperationInProgress();
 
   const configuration = await firestore._getConfiguration();
   const offlineComponentProvider = await getOfflineComponentProvider(firestore);
@@ -108,18 +105,17 @@ export async function setOnlineComponentProvider(
       )
     )
   );
-  onlineDeferred.resolve(onlineComponentProvider);
+  onlineComponentProviders.set(firestore, onlineComponentProvider);
 }
 
-function getOfflineComponentProvider(
+async function getOfflineComponentProvider(
   firestore: FirebaseFirestore
 ): Promise<OfflineComponentProvider> {
   firestore._queue.verifyOperationInProgress();
 
   if (!offlineComponentProviders.has(firestore)) {
     logDebug(LOG_TAG, 'Using default OfflineComponentProvider');
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
-    setOfflineComponentProvider(
+    await setOfflineComponentProvider(
       firestore,
       { durable: false },
       new MemoryOfflineComponentProvider()
@@ -128,21 +124,17 @@ function getOfflineComponentProvider(
   return offlineComponentProviders.get(firestore)!;
 }
 
-function getOnlineComponentProvider(
+async function getOnlineComponentProvider(
   firestore: FirebaseFirestore
 ): Promise<OnlineComponentProvider> {
   firestore._queue.verifyOperationInProgress();
 
   if (!onlineComponentProviders.has(firestore)) {
     logDebug(LOG_TAG, 'Using default OnlineComponentProvider');
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
-    setOnlineComponentProvider(firestore, new OnlineComponentProvider());
+    await setOnlineComponentProvider(firestore, new OnlineComponentProvider());
   }
   return onlineComponentProviders.get(firestore)!;
 }
-
-// Note: These functions cannot be `async` since we want to throw an exception
-// when Firestore is terminated (via `getOnlineComponentProvider()`).
 
 export function getSyncEngine(
   firestore: FirebaseFirestore


### PR DESCRIPTION
This is meant to make https://github.com/firebase/firebase-js-sdk/pull/390 smaller.

These function were not `async` before, but as of https://github.com/firebase/firebase-js-sdk/pull/3701 they can be. This is because now every function is executed on the `AsyncQueue` and we call `verifyNotTerminated()` before, which throws a JavaScript exception before we enqueue the new `async` functions.