### PR TITLE
Copy the auth user on updateCurrentUser(), also assert the app name matches

### DIFF
--- a/common/api-review/auth-exp.api.md
+++ b/common/api-review/auth-exp.api.md
@@ -76,7 +76,7 @@ export function checkActionCode(auth: externs.Auth, oobCode: string): Promise<ex
 export function confirmPasswordReset(auth: externs.Auth, oobCode: string, newPassword: string): Promise<void>;
 
 // @public (undocumented)
-export function createUserWithEmailAndPassword(auth: externs.Auth, email: string, password: string): Promise<externs.UserCredential>;
+export function createUserWithEmailAndPassword(authExtern: externs.Auth, email: string, password: string): Promise<externs.UserCredential>;
 
 // @public (undocumented)
 export function deleteUser(user: externs.User): Promise<void>;
@@ -376,7 +376,7 @@ export function sendSignInLinkToEmail(auth: externs.Auth, email: string, actionC
 export function setPersistence(auth: externs.Auth, persistence: externs.Persistence): void;
 
 // @public (undocumented)
-export function signInAnonymously(auth: externs.Auth): Promise<externs.UserCredential>;
+export function signInAnonymously(authExtern: externs.Auth): Promise<externs.UserCredential>;
 
 // @public (undocumented)
 export function signInWithCredential(auth: externs.Auth, credential: externs.AuthCredential): Promise<externs.UserCredential>;

--- a/common/api-review/auth-exp.api.md
+++ b/common/api-review/auth-exp.api.md
@@ -76,7 +76,7 @@ export function checkActionCode(auth: externs.Auth, oobCode: string): Promise<ex
 export function confirmPasswordReset(auth: externs.Auth, oobCode: string, newPassword: string): Promise<void>;
 
 // @public (undocumented)
-export function createUserWithEmailAndPassword(authExtern: externs.Auth, email: string, password: string): Promise<externs.UserCredential>;
+export function createUserWithEmailAndPassword(auth: externs.Auth, email: string, password: string): Promise<externs.UserCredential>;
 
 // @public (undocumented)
 export function deleteUser(user: externs.User): Promise<void>;
@@ -376,7 +376,7 @@ export function sendSignInLinkToEmail(auth: externs.Auth, email: string, actionC
 export function setPersistence(auth: externs.Auth, persistence: externs.Persistence): void;
 
 // @public (undocumented)
-export function signInAnonymously(authExtern: externs.Auth): Promise<externs.UserCredential>;
+export function signInAnonymously(auth: externs.Auth): Promise<externs.UserCredential>;
 
 // @public (undocumented)
 export function signInWithCredential(auth: externs.Auth, credential: externs.AuthCredential): Promise<externs.UserCredential>;

--- a/packages-exp/auth-exp/src/core/auth/auth_impl.test.ts
+++ b/packages-exp/auth-exp/src/core/auth/auth_impl.test.ts
@@ -94,9 +94,12 @@ describe('core/auth/auth_impl', () => {
 
     it('public version throws if the auth is mismatched', async () => {
       const auth2 = await testAuth();
-      Object.assign(auth2, {name: 'not-the-right-auth'});
+      Object.assign(auth2, { name: 'not-the-right-auth' });
       const user = testUser(auth2, 'uid');
-      await expect(auth.updateCurrentUser(user)).to.be.rejectedWith(FirebaseError, 'auth/argument-error');
+      await expect(auth.updateCurrentUser(user)).to.be.rejectedWith(
+        FirebaseError,
+        'auth/argument-error'
+      );
     });
 
     it('orders async operations correctly', async () => {

--- a/packages-exp/auth-exp/src/core/auth/auth_impl.ts
+++ b/packages-exp/auth-exp/src/core/auth/auth_impl.ts
@@ -214,10 +214,14 @@ export class AuthImpl implements Auth, _FirebaseService {
   async updateCurrentUser(userExtern: externs.User | null): Promise<void> {
     // The public updateCurrentUser method needs to make a copy of the user,
     // and also needs to verify that the app matches
-    const user = userExtern as User|null;
-    assert(!user || user.auth.name === this.name, AuthErrorCode.ARGUMENT_ERROR, {
-      appName: this.name
-    });
+    const user = userExtern as User | null;
+    assert(
+      !user || user.auth.name === this.name,
+      AuthErrorCode.ARGUMENT_ERROR,
+      {
+        appName: this.name
+      }
+    );
 
     return this._updateCurrentUser(user && user._clone());
   }

--- a/packages-exp/auth-exp/src/core/auth/auth_impl.ts
+++ b/packages-exp/auth-exp/src/core/auth/auth_impl.ts
@@ -138,7 +138,7 @@ export class AuthImpl implements Auth, _FirebaseService {
     // If the same user is to be synchronized.
     if (this.currentUser && user && this.currentUser.uid === user.uid) {
       // Data update, simply copy data changes.
-      this._currentUser._copy(user);
+      this._currentUser._assign(user);
       // If tokens changed from previous user tokens, this will trigger
       // notifyAuthListeners_.
       await this.currentUser.getIdToken();
@@ -146,7 +146,7 @@ export class AuthImpl implements Auth, _FirebaseService {
     }
 
     // Update current Auth state. Either a new login or logout.
-    await this.updateCurrentUser(user);
+    await this._updateCurrentUser(user);
     // Notify external Auth changes of Auth change event.
     this.notifyAuthListeners();
   }
@@ -211,7 +211,18 @@ export class AuthImpl implements Auth, _FirebaseService {
     this._deleted = true;
   }
 
-  async updateCurrentUser(user: externs.User | null): Promise<void> {
+  async updateCurrentUser(userExtern: externs.User | null): Promise<void> {
+    // The public updateCurrentUser method needs to make a copy of the user,
+    // and also needs to verify that the app matches
+    const user = userExtern as User|null;
+    assert(!user || user.auth.name === this.name, AuthErrorCode.ARGUMENT_ERROR, {
+      appName: this.name
+    });
+
+    return this._updateCurrentUser(user && user._clone());
+  }
+
+  async _updateCurrentUser(user: externs.User | null): Promise<void> {
     if (this._deleted) {
       return;
     }
@@ -234,7 +245,7 @@ export class AuthImpl implements Auth, _FirebaseService {
       await this._setRedirectUser(null);
     }
 
-    return this.updateCurrentUser(null);
+    return this._updateCurrentUser(null);
   }
 
   setPersistence(persistence: externs.Persistence): Promise<void> {

--- a/packages-exp/auth-exp/src/core/auth/firebase_internal.test.ts
+++ b/packages-exp/auth-exp/src/core/auth/firebase_internal.test.ts
@@ -42,7 +42,7 @@ describe('src/core/auth/firebase_internal', () => {
 
     it('returns the uid of the user if set', async () => {
       const user = testUser(auth, 'uid');
-      await auth.updateCurrentUser(user);
+      await auth._updateCurrentUser(user);
       expect(authInternal.getUid()).to.eq('uid');
     });
   });
@@ -54,7 +54,7 @@ describe('src/core/auth/firebase_internal', () => {
 
     it('returns the id token of the current user correctly', async () => {
       const user = testUser(auth, 'uid');
-      await auth.updateCurrentUser(user);
+      await auth._updateCurrentUser(user);
       user.stsTokenManager.accessToken = 'access-token';
       user.stsTokenManager.expirationTime = Date.now() + 1000 * 60 * 60 * 24;
       expect(await authInternal.getToken()).to.eql({
@@ -69,7 +69,7 @@ describe('src/core/auth/firebase_internal', () => {
 
     beforeEach(async () => {
       user = testUser(auth, 'uid', undefined, true);
-      await auth.updateCurrentUser(user);
+      await auth._updateCurrentUser(user);
       let i = 0;
       sinon.stub(user.stsTokenManager, 'getToken').callsFake(async () => {
         i += 1;

--- a/packages-exp/auth-exp/src/core/strategies/anonymous.test.ts
+++ b/packages-exp/auth-exp/src/core/strategies/anonymous.test.ts
@@ -70,7 +70,7 @@ describe('core/strategies/anonymous', () => {
     context('already signed in with a non-anonymous account', () => {
       it('should sign in as a new user user', async () => {
         const fakeUser = testUser(auth, 'other-uid');
-        await auth.updateCurrentUser(fakeUser);
+        await auth._updateCurrentUser(fakeUser);
         expect(fakeUser.isAnonymous).to.be.false;
 
         const { user, operationType } = await signInAnonymously(auth);

--- a/packages-exp/auth-exp/src/core/strategies/anonymous.ts
+++ b/packages-exp/auth-exp/src/core/strategies/anonymous.ts
@@ -22,26 +22,26 @@ import { UserCredentialImpl } from '../user/user_credential_impl';
 import { _castAuth } from '../auth/auth_impl';
 
 export async function signInAnonymously(
-  authExtern: externs.Auth
+  auth: externs.Auth
 ): Promise<externs.UserCredential> {
-  const auth = _castAuth(authExtern);
-  if (auth.currentUser?.isAnonymous) {
+  const authInternal = _castAuth(auth);
+  if (authInternal.currentUser?.isAnonymous) {
     // If an anonymous user is already signed in, no need to sign them in again.
     return new UserCredentialImpl({
-      user: auth.currentUser as User,
+      user: authInternal.currentUser as User,
       providerId: null,
       operationType: externs.OperationType.SIGN_IN
     });
   }
-  const response = await signUp(auth, {
+  const response = await signUp(authInternal, {
     returnSecureToken: true
   });
   const userCredential = await UserCredentialImpl._fromIdTokenResponse(
-    auth,
+    authInternal,
     externs.OperationType.SIGN_IN,
     response,
     true
   );
-  await auth._updateCurrentUser(userCredential.user);
+  await authInternal._updateCurrentUser(userCredential.user);
   return userCredential;
 }

--- a/packages-exp/auth-exp/src/core/strategies/anonymous.ts
+++ b/packages-exp/auth-exp/src/core/strategies/anonymous.ts
@@ -22,8 +22,9 @@ import { UserCredentialImpl } from '../user/user_credential_impl';
 import { _castAuth } from '../auth/auth_impl';
 
 export async function signInAnonymously(
-  auth: externs.Auth
+  authExtern: externs.Auth
 ): Promise<externs.UserCredential> {
+  const auth = _castAuth(authExtern);
   if (auth.currentUser?.isAnonymous) {
     // If an anonymous user is already signed in, no need to sign them in again.
     return new UserCredentialImpl({
@@ -36,11 +37,11 @@ export async function signInAnonymously(
     returnSecureToken: true
   });
   const userCredential = await UserCredentialImpl._fromIdTokenResponse(
-    _castAuth(auth),
+    auth,
     externs.OperationType.SIGN_IN,
     response,
     true
   );
-  await auth.updateCurrentUser(userCredential.user);
+  await auth._updateCurrentUser(userCredential.user);
   return userCredential;
 }

--- a/packages-exp/auth-exp/src/core/strategies/credential.ts
+++ b/packages-exp/auth-exp/src/core/strategies/credential.ts
@@ -42,7 +42,7 @@ export async function _signInWithCredential(
     operationType,
     response
   );
-  await auth.updateCurrentUser(userCredential.user);
+  await auth._updateCurrentUser(userCredential.user);
   return userCredential;
 }
 

--- a/packages-exp/auth-exp/src/core/strategies/custom_token.ts
+++ b/packages-exp/auth-exp/src/core/strategies/custom_token.ts
@@ -35,6 +35,6 @@ export async function signInWithCustomToken(
     externs.OperationType.SIGN_IN,
     response
   );
-  await auth.updateCurrentUser(cred.user);
+  await auth._updateCurrentUser(cred.user);
   return cred;
 }

--- a/packages-exp/auth-exp/src/core/strategies/email_and_password.ts
+++ b/packages-exp/auth-exp/src/core/strategies/email_and_password.ts
@@ -132,10 +132,11 @@ export async function verifyPasswordResetCode(
 }
 
 export async function createUserWithEmailAndPassword(
-  auth: externs.Auth,
+  authExtern: externs.Auth,
   email: string,
   password: string
 ): Promise<externs.UserCredential> {
+  const auth = _castAuth(authExtern);
   const response = await signUp(auth, {
     returnSecureToken: true,
     email,
@@ -143,11 +144,11 @@ export async function createUserWithEmailAndPassword(
   });
 
   const userCredential = await UserCredentialImpl._fromIdTokenResponse(
-    _castAuth(auth),
+    auth,
     externs.OperationType.SIGN_IN,
     response
   );
-  await auth.updateCurrentUser(userCredential.user);
+  await auth._updateCurrentUser(userCredential.user);
 
   return userCredential;
 }

--- a/packages-exp/auth-exp/src/core/strategies/email_and_password.ts
+++ b/packages-exp/auth-exp/src/core/strategies/email_and_password.ts
@@ -132,11 +132,11 @@ export async function verifyPasswordResetCode(
 }
 
 export async function createUserWithEmailAndPassword(
-  authExtern: externs.Auth,
+  auth: externs.Auth,
   email: string,
   password: string
 ): Promise<externs.UserCredential> {
-  const auth = _castAuth(authExtern);
+  const authInternal = _castAuth(auth);
   const response = await signUp(auth, {
     returnSecureToken: true,
     email,
@@ -144,11 +144,11 @@ export async function createUserWithEmailAndPassword(
   });
 
   const userCredential = await UserCredentialImpl._fromIdTokenResponse(
-    auth,
+    authInternal,
     externs.OperationType.SIGN_IN,
     response
   );
-  await auth._updateCurrentUser(userCredential.user);
+  await authInternal._updateCurrentUser(userCredential.user);
 
   return userCredential;
 }

--- a/packages-exp/auth-exp/src/core/user/account_info.test.ts
+++ b/packages-exp/auth-exp/src/core/user/account_info.test.ts
@@ -150,7 +150,7 @@ describe('core/user/profile', () => {
       auth.onIdTokenChanged(idTokenChange);
 
       // Flush token change promises which are floating
-      await auth.updateCurrentUser(user);
+      await auth._updateCurrentUser(user);
       auth._isInitialized = true;
       idTokenChange.resetHistory();
     });

--- a/packages-exp/auth-exp/src/core/user/invalidation.test.ts
+++ b/packages-exp/auth-exp/src/core/user/invalidation.test.ts
@@ -35,7 +35,7 @@ describe('src/core/user/invalidation', () => {
   beforeEach(async () => {
     auth = await testAuth();
     user = testUser(auth, 'uid');
-    await auth.updateCurrentUser(user);
+    await auth._updateCurrentUser(user);
   });
 
   function makeError(code: AuthErrorCode): FirebaseError {
@@ -76,7 +76,7 @@ describe('src/core/user/invalidation', () => {
 
     beforeEach(async () => {
       user2 = testUser(auth, 'uid2');
-      await auth.updateCurrentUser(user2);
+      await auth._updateCurrentUser(user2);
     });
 
     it('does not log out user2 if the error is user_disabled', async () => {

--- a/packages-exp/auth-exp/src/core/user/link_unlink.test.ts
+++ b/packages-exp/auth-exp/src/core/user/link_unlink.test.ts
@@ -39,7 +39,7 @@ describe('core/user/link_unlink', () => {
   beforeEach(async () => {
     auth = await testAuth();
     user = testUser(auth, 'uid', '', true);
-    await auth.updateCurrentUser(user);
+    await auth._updateCurrentUser(user);
     fetch.setUp();
   });
 

--- a/packages-exp/auth-exp/src/core/user/token_manager.test.ts
+++ b/packages-exp/auth-exp/src/core/user/token_manager.test.ts
@@ -158,6 +158,20 @@ describe('core/user/token_manager', () => {
     });
   });
 
+  describe('#_clone', () => {
+    it('copies the manager to a new object', () => {
+      Object.assign(stsTokenManager, {
+        accessToken: 'token',
+        refreshToken: 'refresh',
+        expirationTime: now,
+      });
+
+      const copy = stsTokenManager._clone();
+      expect(copy).not.to.eq(stsTokenManager);
+      expect(copy.toJSON()).to.eql(stsTokenManager.toJSON());
+    });
+  });
+
   describe('.fromJSON', () => {
     const errorString =
       'Firebase: An internal AuthError has occurred. (auth/internal-error).';

--- a/packages-exp/auth-exp/src/core/user/token_manager.test.ts
+++ b/packages-exp/auth-exp/src/core/user/token_manager.test.ts
@@ -163,7 +163,7 @@ describe('core/user/token_manager', () => {
       Object.assign(stsTokenManager, {
         accessToken: 'token',
         refreshToken: 'refresh',
-        expirationTime: now,
+        expirationTime: now
       });
 
       const copy = stsTokenManager._clone();

--- a/packages-exp/auth-exp/src/core/user/token_manager.ts
+++ b/packages-exp/auth-exp/src/core/user/token_manager.ts
@@ -124,10 +124,14 @@ export class StsTokenManager {
     };
   }
 
-  _copy(stsTokenManager: StsTokenManager): void {
+  _assign(stsTokenManager: StsTokenManager): void {
     this.accessToken = stsTokenManager.accessToken;
     this.refreshToken = stsTokenManager.refreshToken;
     this.expirationTime = stsTokenManager.expirationTime;
+  }
+
+  _clone(): StsTokenManager {
+    return Object.assign(new StsTokenManager(), this.toJSON());
   }
 
   _performRefresh(): never {

--- a/packages-exp/auth-exp/src/core/user/user_credential_impl.test.ts
+++ b/packages-exp/auth-exp/src/core/user/user_credential_impl.test.ts
@@ -83,7 +83,7 @@ describe('core/user/user_credential_impl', () => {
     it('should not trigger callbacks', async () => {
       const cb = sinon.spy();
       auth.onAuthStateChanged(cb);
-      await auth.updateCurrentUser(null);
+      await auth._updateCurrentUser(null);
       cb.resetHistory();
 
       await UserCredentialImpl._fromIdTokenResponse(
@@ -100,7 +100,7 @@ describe('core/user/user_credential_impl', () => {
 
     beforeEach(async () => {
       user = testUser(auth, 'uid', 'email', true);
-      await auth.updateCurrentUser(user);
+      await auth._updateCurrentUser(user);
     });
 
     it('gets a credential based on the response', async () => {

--- a/packages-exp/auth-exp/src/core/user/user_impl.test.ts
+++ b/packages-exp/auth-exp/src/core/user/user_impl.test.ts
@@ -245,12 +245,12 @@ describe('core/user/user_impl', () => {
 
   describe('_clone', () => {
     it('copies the user to a new object', () => {
-      const stsTokenManager = Object.assign(new StsTokenManager(),  {
+      const stsTokenManager = Object.assign(new StsTokenManager(), {
         accessToken: 'access-token',
         refreshToken: 'refresh-token',
         expirationTime: 3
       });
-      
+
       const user = new UserImpl({
         auth,
         uid: 'uid',

--- a/packages-exp/auth-exp/src/core/user/user_impl.test.ts
+++ b/packages-exp/auth-exp/src/core/user/user_impl.test.ts
@@ -235,11 +235,38 @@ describe('core/user/user_impl', () => {
     it('should not trigger additional callbacks', async () => {
       const cb = sinon.spy();
       auth.onAuthStateChanged(cb);
-      await auth.updateCurrentUser(null);
+      await auth._updateCurrentUser(null);
       cb.resetHistory();
 
       await UserImpl._fromIdTokenResponse(auth, idTokenResponse);
       expect(cb).not.to.have.been.called;
+    });
+  });
+
+  describe('_clone', () => {
+    it('copies the user to a new object', () => {
+      const stsTokenManager = Object.assign(new StsTokenManager(),  {
+        accessToken: 'access-token',
+        refreshToken: 'refresh-token',
+        expirationTime: 3
+      });
+      
+      const user = new UserImpl({
+        auth,
+        uid: 'uid',
+        stsTokenManager,
+        displayName: 'name',
+        email: 'email',
+        phoneNumber: 'number',
+        photoURL: 'photo',
+        emailVerified: false,
+        isAnonymous: true
+      });
+
+      const copy = user._clone();
+      expect(copy).not.to.eq(user);
+      expect(copy.stsTokenManager).not.to.eq(user.stsTokenManager);
+      expect(copy.toJSON()).to.eql(user.toJSON());
     });
   });
 });

--- a/packages-exp/auth-exp/src/core/user/user_impl.ts
+++ b/packages-exp/auth-exp/src/core/user/user_impl.ts
@@ -81,7 +81,7 @@ export class UserImpl implements User {
     this.phoneNumber = opt.phoneNumber || null;
     this.photoURL = opt.photoURL || null;
     this.isAnonymous = opt.isAnonymous || false;
-    this.metadata = new UserMetadata(opt.createdAt, opt.lastLoginAt);
+    this.metadata = new UserMetadata(opt.createdAt || undefined, opt.lastLoginAt || undefined);
   }
 
   async getIdToken(forceRefresh?: boolean): Promise<string> {
@@ -113,7 +113,7 @@ export class UserImpl implements User {
   private reloadUserInfo: APIUserInfo | null = null;
   private reloadListener: NextFn<APIUserInfo> | null = null;
 
-  _copy(user: User): void {
+  _assign(user: User): void {
     if (this === user) {
       return;
     }
@@ -129,7 +129,11 @@ export class UserImpl implements User {
     this.tenantId = user.tenantId;
     this.providerData = user.providerData.map(userInfo => ({ ...userInfo }));
     this.metadata._copy(user.metadata);
-    this.stsTokenManager._copy(user.stsTokenManager);
+    this.stsTokenManager._assign(user.stsTokenManager);
+  }
+
+  _clone(): User {
+    return new UserImpl({...this, stsTokenManager: this.stsTokenManager._clone()});
   }
 
   _onReload(callback: NextFn<APIUserInfo>): void {

--- a/packages-exp/auth-exp/src/core/user/user_impl.ts
+++ b/packages-exp/auth-exp/src/core/user/user_impl.ts
@@ -81,7 +81,10 @@ export class UserImpl implements User {
     this.phoneNumber = opt.phoneNumber || null;
     this.photoURL = opt.photoURL || null;
     this.isAnonymous = opt.isAnonymous || false;
-    this.metadata = new UserMetadata(opt.createdAt || undefined, opt.lastLoginAt || undefined);
+    this.metadata = new UserMetadata(
+      opt.createdAt || undefined,
+      opt.lastLoginAt || undefined
+    );
   }
 
   async getIdToken(forceRefresh?: boolean): Promise<string> {
@@ -133,7 +136,10 @@ export class UserImpl implements User {
   }
 
   _clone(): User {
-    return new UserImpl({...this, stsTokenManager: this.stsTokenManager._clone()});
+    return new UserImpl({
+      ...this,
+      stsTokenManager: this.stsTokenManager._clone()
+    });
   }
 
   _onReload(callback: NextFn<APIUserInfo>): void {

--- a/packages-exp/auth-exp/src/model/auth.ts
+++ b/packages-exp/auth-exp/src/model/auth.ts
@@ -35,7 +35,7 @@ export interface Auth extends externs.Auth {
   _canInitEmulator: boolean;
   _isInitialized: boolean;
   _initializationPromise: Promise<void> | null;
-  updateCurrentUser(user: User | null): Promise<void>;
+  _updateCurrentUser(user: User | null): Promise<void>;
 
   _onStorageEvent(): void;
 

--- a/packages-exp/auth-exp/src/model/user.ts
+++ b/packages-exp/auth-exp/src/model/user.ts
@@ -34,16 +34,16 @@ export interface UserParameters {
   auth: Auth;
   stsTokenManager: StsTokenManager;
 
-  displayName?: string|null;
-  email?: string|null;
-  phoneNumber?: string|null;
-  photoURL?: string|null;
-  isAnonymous?: boolean|null;
-  emailVerified?: boolean|null;
-  tenantId?: string|null;
+  displayName?: string | null;
+  email?: string | null;
+  phoneNumber?: string | null;
+  photoURL?: string | null;
+  isAnonymous?: boolean | null;
+  emailVerified?: boolean | null;
+  tenantId?: string | null;
 
-  createdAt?: string|null;
-  lastLoginAt?: string|null;
+  createdAt?: string | null;
+  lastLoginAt?: string | null;
 }
 
 export interface User extends externs.User {

--- a/packages-exp/auth-exp/src/model/user.ts
+++ b/packages-exp/auth-exp/src/model/user.ts
@@ -34,16 +34,16 @@ export interface UserParameters {
   auth: Auth;
   stsTokenManager: StsTokenManager;
 
-  displayName?: string;
-  email?: string;
-  phoneNumber?: string;
-  photoURL?: string;
-  isAnonymous?: boolean;
-  emailVerified?: boolean;
-  tenantId?: string;
+  displayName?: string|null;
+  email?: string|null;
+  phoneNumber?: string|null;
+  photoURL?: string|null;
+  isAnonymous?: boolean|null;
+  emailVerified?: boolean|null;
+  tenantId?: string|null;
 
-  createdAt?: string;
-  lastLoginAt?: string;
+  createdAt?: string|null;
+  lastLoginAt?: string|null;
 }
 
 export interface User extends externs.User {
@@ -68,7 +68,8 @@ export interface User extends externs.User {
     reload?: boolean
   ): Promise<void>;
 
-  _copy(user: User): void;
+  _assign(user: User): void;
+  _clone(): User;
   _onReload: (cb: NextFn<APIUserInfo>) => void;
   _notifyReloadListener: NextFn<APIUserInfo>;
   _startProactiveRefresh: () => void;

--- a/packages-exp/auth-exp/src/platform_browser/strategies/redirect.test.ts
+++ b/packages-exp/auth-exp/src/platform_browser/strategies/redirect.test.ts
@@ -127,7 +127,7 @@ describe('src/core/strategies/redirect', () => {
 
     beforeEach(async () => {
       user = testUser(auth, 'uid', 'email', true);
-      await auth.updateCurrentUser(user);
+      await auth._updateCurrentUser(user);
       sinon.stub(link, '_assertLinkedStatus').returns(Promise.resolve());
     });
 
@@ -185,7 +185,7 @@ describe('src/core/strategies/redirect', () => {
     });
 
     it('persists the redirect user but not current user if diff currentUser', async () => {
-      await auth.updateCurrentUser(testUser(auth, 'not-uid', 'email', true));
+      await auth._updateCurrentUser(testUser(auth, 'not-uid', 'email', true));
       const redirectPersistence: Persistence = _getInstance(
         RedirectPersistence
       );
@@ -207,7 +207,7 @@ describe('src/core/strategies/redirect', () => {
 
     beforeEach(async () => {
       user = testUser(auth, 'uid', 'email', true);
-      await auth.updateCurrentUser(user);
+      await auth._updateCurrentUser(user);
     });
 
     it('redirects the window', async () => {
@@ -263,7 +263,7 @@ describe('src/core/strategies/redirect', () => {
     });
 
     it('persists the redirect user but not current user if diff currentUser', async () => {
-      await auth.updateCurrentUser(testUser(auth, 'not-uid', 'email', true));
+      await auth._updateCurrentUser(testUser(auth, 'not-uid', 'email', true));
       const redirectPersistence: Persistence = _getInstance(
         RedirectPersistence
       );


### PR DESCRIPTION
This PR creates a differentiation between the public `updateCurrentUser()` and the internal `_updateCurrentUser()`. The latter does not make a copy because it is called by the SDK itself when the SDK signs someone in or updates something.

b/170886559,
b/170854629