### PR TITLE
Cache emulator between runs

### DIFF
--- a/scripts/emulator-testing/emulators/database-emulator.ts
+++ b/scripts/emulator-testing/emulators/database-emulator.ts
@@ -24,7 +24,7 @@ export class DatabaseEmulator extends Emulator {
 
   constructor(port = 8088, namespace = 'test-emulator') {
     super(
-      'database-emulator.jar',
+      'firebase-database-emulator-v4.4.1.jar',
       // Use locked version of emulator for test to be deterministic.
       // The latest version can be found from database emulator doc:
       // https://firebase.google.com/docs/database/security/test-rules-emulator

--- a/scripts/emulator-testing/emulators/firestore-emulator.ts
+++ b/scripts/emulator-testing/emulators/firestore-emulator.ts
@@ -22,7 +22,7 @@ export class FirestoreEmulator extends Emulator {
 
   constructor(port: number, projectId = 'test-emulator') {
     super(
-      'firestore-emulator.jar',
+      'cloud-firestore-emulator-v1.11.7.jar',
       // Use locked version of emulator for test to be deterministic.
       // The latest version can be found from firestore emulator doc:
       // https://firebase.google.com/docs/firestore/security/test-rules-emulator


### PR DESCRIPTION
### Discussion

When running unit tests locally the emulator is downloaded every time.  This is 30-60MB depending on the service and on my slow home WiFi this makes test startup much slower than it needs to be.

### Testing

Here are the database unit tests, run twice.

First run:
```
$ yarn test:emulator
yarn run v1.22.4
$ ts-node --compiler-options='{"module":"commonjs"}' ../../scripts/emulator-testing/database-test-runner.ts
Created temporary directory at [/var/folders/xl/6lkrzp7j07581mw8_4dlt3b000643s/T/tmp-88560-ch7akdXEY5Iy].
Downloading emulator from [https://storage.googleapis.com/firebase-preview-drop/emulator/firebase-database-emulator-v4.4.1.jar] ...
Saved emulator binary file to [/var/folders/xl/6lkrzp7j07581mw8_4dlt3b000643s/T/tmp-88560-ch7akdXEY5Iy/firebase-database-emulator-v4.4.1.jar].
Changed emulator file permissions to 'rwxr-xr-x'.
Cached emulator at /Users/samstern/.cache/firebase-js-sdk/firebase-database-emulator-v4.4.1.jar
Waiting for emulator to start up ...
WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by io.netty.util.internal.ReflectionUtil (file:/private/var/folders/xl/6lkrzp7j07581mw8_4dlt3b000643s/T/tmp-88560-ch7akdXEY5Iy/firebase-database-emulator-v4.4.1.jar) to field sun.nio.ch.SelectorImpl.selectedKeys
WARNING: Please consider reporting this to the maintainers of io.netty.util.internal.ReflectionUtil
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release
Ping emulator at [http://localhost:8088] ...
13:02:35.700 [NamespaceSystem-akka.actor.default-dispatcher-5] INFO akka.event.slf4j.Slf4jLogger - Slf4jLogger started
Ping emulator at [http://localhost:8088] ...
13:02:35.892 [main] INFO com.firebase.server.forge.App$ - Listening at localhost:8088
Ping emulator at [http://localhost:8088] ...
Emulator has started up after 3.019s!
```

Second run:
```
$ yarn test:emulator
yarn run v1.22.4
$ ts-node --compiler-options='{"module":"commonjs"}' ../../scripts/emulator-testing/database-test-runner.ts
Emulator found in cache: /Users/samstern/.cache/firebase-js-sdk/firebase-database-emulator-v4.4.1.jar
Waiting for emulator to start up ...
WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by io.netty.util.internal.ReflectionUtil (file:/Users/samstern/.cache/firebase-js-sdk/firebase-database-emulator-v4.4.1.jar) to field sun.nio.ch.SelectorImpl.selectedKeys
WARNING: Please consider reporting this to the maintainers of io.netty.util.internal.ReflectionUtil
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release
Ping emulator at [http://localhost:8088] ...
13:02:55.876 [NamespaceSystem-akka.actor.default-dispatcher-5] INFO akka.event.slf4j.Slf4jLogger - Slf4jLogger started
13:02:56.061 [main] INFO com.firebase.server.forge.App$ - Listening at localhost:8088
Ping emulator at [http://localhost:8088] ...
Emulator has started up after 2.027s!
```

### API Changes

N/A