### PR TITLE
Have user provide React Native AsyncStorage object

### DIFF
--- a/packages/app-types/index.d.ts
+++ b/packages/app-types/index.d.ts
@@ -112,6 +112,12 @@ export interface FirebaseNamespace {
   // Sets log handler for all Firebase components.
   onLog(logCallback: LogCallback, options?: LogOptions): void;
 
+  /**
+   * Provide React Native AsyncStorage object (needed if using Auth with React Native).
+   * @param asyncStorage - React Native AsyncStorage object.
+   */
+  useReactNativeAsyncStorage(asyncStorage: unknown): void;
+
   // The current SDK version.
   SDK_VERSION: string;
 }

--- a/packages/app/index.rn.ts
+++ b/packages/app/index.rn.ts
@@ -20,22 +20,6 @@ import { _FirebaseNamespace } from '@firebase/app-types/private';
 import { firebase as _firebase } from './src/firebaseNamespace';
 import { registerCoreComponents } from './src/registerCoreComponents';
 
-/**
- * To avoid having to include the @types/react-native package, which breaks
- * some of our tests because of duplicate symbols, we are using require syntax
- * here
- */
-// eslint-disable-next-line @typescript-eslint/no-require-imports
-const { AsyncStorage } = require('react-native');
-
-(_firebase as _FirebaseNamespace).INTERNAL.extendNamespace({
-  INTERNAL: {
-    reactNative: {
-      AsyncStorage
-    }
-  }
-});
-
 export const firebase = _firebase as FirebaseNamespace;
 
 registerCoreComponents(firebase, 'rn');

--- a/packages/app/index.rn.ts
+++ b/packages/app/index.rn.ts
@@ -20,6 +20,15 @@ import { _FirebaseNamespace } from '@firebase/app-types/private';
 import { firebase as _firebase } from './src/firebaseNamespace';
 import { registerCoreComponents } from './src/registerCoreComponents';
 
+(_firebase as _FirebaseNamespace).INTERNAL.extendNamespace({
+  INTERNAL: {
+    // Auth uses this to determine if it is in a React Native environment.
+    // User needs to use `firebase.useReactNativeAsyncStorage` to provide
+    // the AsyncStorage object.
+    reactNative: { asyncStorage: null }
+  }
+});
+
 export const firebase = _firebase as FirebaseNamespace;
 
 registerCoreComponents(firebase, 'rn');

--- a/packages/app/src/firebaseNamespaceCore.ts
+++ b/packages/app/src/firebaseNamespaceCore.ts
@@ -68,6 +68,7 @@ export function createFirebaseNamespaceCore(
     registerVersion,
     setLogLevel,
     onLog,
+    useReactNativeAsyncStorage,
     // @ts-ignore
     apps: null,
     SDK_VERSION: version,
@@ -292,6 +293,20 @@ export function createFirebaseNamespaceCore(
       });
     }
     setUserLogHandler(logCallback, options);
+  }
+
+  /**
+   * Provide React Native AsyncStorage object (needed if using Auth with React Native).
+   * @param asyncStorage - React Native AsyncStorage object.
+   */
+  function useReactNativeAsyncStorage(asyncStorage: unknown): void {
+    (namespace as _FirebaseNamespace).INTERNAL.extendNamespace({
+      INTERNAL: {
+        reactNative: {
+          AsyncStorage: asyncStorage
+        }
+      }
+    });
   }
 
   // Map the requested service to a registered service name

--- a/packages/firebase/index.d.ts
+++ b/packages/firebase/index.d.ts
@@ -148,6 +148,12 @@ declare namespace firebase {
   ): void;
 
   /**
+   * Provide React Native AsyncStorage object (needed if using Auth with React Native).
+   * @param asyncStorage - React Native AsyncStorage object.
+   */
+  function useReactNativeAsyncStorage(asyncStorage: unknown): void;
+
+  /**
    * @hidden
    */
   type Unsubscribe = () => void;


### PR DESCRIPTION
This is a breaking change.

Instead of importing the `AsyncStorage` bundled with 'react-native', which is now deprecated in favor of getting it from `@react-native-community/async-storage`, we let the user provide it with a required `firebase.useReactNativeAsyncStorage()` method which must be called before initializing auth if the user is using Firebase Auth and React Native.

We cannot move to importing the new one by default because it will break Expo users. We cannot conditionally import one way or the other because the React Native bundler doesn't support conditional `require`s and the `require` for the one that doesn't exist will break the build even if it's in a fork that isn't reached.

Tested manually on iOS, Android, and Expo. Will test further before release.