### PR TITLE
lower storage bump to minor

### DIFF
--- a/.changeset/tiny-hounds-rest.md
+++ b/.changeset/tiny-hounds-rest.md
@@ -1,6 +1,6 @@
 ---
 "firebase": major
-"@firebase/storage": major
+"@firebase/storage": minor
 ---
 
 This releases removes all input validation. Please use our TypeScript types to validate API usage. 


### PR DESCRIPTION
Since storage is not GA, we should only bump minor.