### PR TITLE
Make AuthInternal implement the interface

### DIFF
--- a/common/api-review/functions-exp.api.md
+++ b/common/api-review/functions-exp.api.md
@@ -16,7 +16,7 @@ export function getFunctions(app: FirebaseApp, regionOrCustomDomain?: string): F
 export function httpsCallable(functionsInstance: Functions, name: string, options?: HttpsCallableOptions): HttpsCallable;
 
 // @public
-export function useFunctionsEmulator(functionsInstance: Functions, origin: string): void;
+export function useFunctionsEmulator(functionsInstance: Functions, host: string, port: number): void;
 
 
 // (No @packageDocumentation comment for this package)

--- a/packages-exp/auth-exp/src/core/auth/firebase_internal.ts
+++ b/packages-exp/auth-exp/src/core/auth/firebase_internal.ts
@@ -16,21 +16,16 @@
  */
 
 import { Unsubscribe } from '@firebase/util';
+import { FirebaseAuthInternal } from '@firebase/auth-interop-types';
 
 import { Auth } from '../../model/auth';
 import { User } from '../../model/user';
-
-declare module '@firebase/component' {
-  interface NameServiceMapping {
-    'auth-internal-exp': AuthInternal;
-  }
-}
 
 interface TokenListener {
   (tok: string | null): unknown;
 }
 
-export class AuthInternal {
+export class AuthInternal implements FirebaseAuthInternal {
   private readonly internalListeners: Map<
     TokenListener,
     Unsubscribe

--- a/packages-exp/auth-exp/src/core/auth/register.ts
+++ b/packages-exp/auth-exp/src/core/auth/register.ts
@@ -33,7 +33,7 @@ import {
 import { AuthInternal } from './firebase_internal';
 
 export const _AUTH_COMPONENT_NAME = 'auth-exp';
-export const _AUTH_INTERNAL_COMPONENT_NAME = 'auth-internal-exp';
+export const _AUTH_INTERNAL_COMPONENT_NAME = 'auth-internal';
 
 function getVersionForPlatform(
   clientPlatform: ClientPlatform


### PR DESCRIPTION
- Implement the interface from `@firebase/auth-interop-types`
- rename the internal component to `auth-internal`, so consumers don't need to change their existing code for exp. (It's also easier for the typings).

FYI, @schmidt-sebastian 