### PR TITLE
Compat Layer for Firestore

### DIFF
--- a/.github/workflows/test-changed-firestore-integration.yml
+++ b/.github/workflows/test-changed-firestore-integration.yml
@@ -26,6 +26,6 @@ jobs:
         cp config/ci.config.json config/project.json
         yarn
     - name: build
-      run: yarn build:changed firestore-integration --buildAppExp
+      run: yarn build:changed firestore-integration --buildAppExp --buildAppCompat
     - name: Run tests if firestore or its dependencies has changed
       run: yarn test:changed firestore-integration

--- a/.github/workflows/test-changed-firestore.yml
+++ b/.github/workflows/test-changed-firestore.yml
@@ -26,6 +26,6 @@ jobs:
         cp config/ci.config.json config/project.json
         yarn
     - name: build
-      run: yarn build:changed firestore --buildAppExp
+      run: yarn build:changed firestore --buildAppExp --buildAppCompat
     - name: Run tests if firestore or its dependencies has changed
       run: yarn test:changed firestore

--- a/packages/firestore/exp/src/api/database.ts
+++ b/packages/firestore/exp/src/api/database.ts
@@ -37,9 +37,9 @@ import {
 } from '../../../src/core/component_provider';
 import {
   FirebaseFirestore as LiteFirestore,
-  FirestoreDatabase,
   Settings as LiteSettings
 } from '../../../lite/src/api/database';
+import { DatabaseId } from '../../../src/core/database_info';
 import { Code, FirestoreError } from '../../../src/util/error';
 import { Deferred } from '../../../src/util/promise';
 import { LRU_MINIMUM_CACHE_SIZE_BYTES } from '../../../src/local/lru_garbage_collector';
@@ -77,11 +77,12 @@ export class FirebaseFirestore
   _firestoreClient: FirestoreClient | undefined;
 
   constructor(
-    app: FirestoreDatabase | FirebaseApp,
+    databaseIdOrApp: DatabaseId | FirebaseApp,
     authProvider: Provider<FirebaseAuthInternalName>
   ) {
-    super(app, authProvider);
-    this._persistenceKey = 'name' in app ? app.name : '[DEFAULT]';
+    super(databaseIdOrApp, authProvider);
+    this._persistenceKey =
+      'name' in databaseIdOrApp ? databaseIdOrApp.name : '[DEFAULT]';
   }
 
   _terminate(): Promise<void> {

--- a/packages/firestore/exp/src/api/database.ts
+++ b/packages/firestore/exp/src/api/database.ts
@@ -37,6 +37,7 @@ import {
 } from '../../../src/core/component_provider';
 import {
   FirebaseFirestore as LiteFirestore,
+  FirestoreDatabase,
   Settings as LiteSettings
 } from '../../../lite/src/api/database';
 import { Code, FirestoreError } from '../../../src/util/error';
@@ -45,8 +46,7 @@ import { LRU_MINIMUM_CACHE_SIZE_BYTES } from '../../../src/local/lru_garbage_col
 import {
   CACHE_SIZE_UNLIMITED,
   configureFirestore,
-  ensureFirestoreConfigured,
-  FirestoreCompat
+  ensureFirestoreConfigured
 } from '../../../src/api/database';
 import {
   indexedDbClearPersistence,
@@ -70,18 +70,18 @@ export interface Settings extends LiteSettings {
  */
 export class FirebaseFirestore
   extends LiteFirestore
-  implements _FirebaseService, FirestoreCompat {
+  implements _FirebaseService {
   readonly _queue = new AsyncQueue();
   readonly _persistenceKey: string;
 
   _firestoreClient: FirestoreClient | undefined;
 
   constructor(
-    app: FirebaseApp,
+    app: FirestoreDatabase | FirebaseApp,
     authProvider: Provider<FirebaseAuthInternalName>
   ) {
     super(app, authProvider);
-    this._persistenceKey = app.name;
+    this._persistenceKey = 'name' in app ? app.name : '[DEFAULT]';
   }
 
   _terminate(): Promise<void> {
@@ -165,13 +165,13 @@ export function getFirestore(app: FirebaseApp): FirebaseFirestore {
  * @return A promise that represents successfully enabling persistent storage.
  */
 export function enableIndexedDbPersistence(
-  firestore: FirestoreCompat,
+  firestore: FirebaseFirestore,
   persistenceSettings?: PersistenceSettings
 ): Promise<void> {
   verifyNotInitialized(firestore);
 
   const client = ensureFirestoreConfigured(firestore);
-  const settings = firestore._getSettings();
+  const settings = firestore._freezeSettings();
 
   const onlineComponentProvider = new OnlineComponentProvider();
   const offlineComponentProvider = new IndexedDbOfflineComponentProvider(
@@ -209,12 +209,12 @@ export function enableIndexedDbPersistence(
  * storage.
  */
 export function enableMultiTabIndexedDbPersistence(
-  firestore: FirestoreCompat
+  firestore: FirebaseFirestore
 ): Promise<void> {
   verifyNotInitialized(firestore);
 
   const client = ensureFirestoreConfigured(firestore);
-  const settings = firestore._getSettings();
+  const settings = firestore._freezeSettings();
 
   const onlineComponentProvider = new OnlineComponentProvider();
   const offlineComponentProvider = new MultiTabOfflineComponentProvider(
@@ -322,7 +322,7 @@ function canFallbackFromIndexedDbError(
  * cleared. Otherwise, the promise is rejected with an error.
  */
 export function clearIndexedDbPersistence(
-  firestore: FirestoreCompat
+  firestore: FirebaseFirestore
 ): Promise<void> {
   if (firestore._initialized && !firestore._terminated) {
     throw new FirestoreError(
@@ -420,7 +420,7 @@ export function terminate(firestore: FirebaseFirestore): Promise<void> {
   return firestore._delete();
 }
 
-function verifyNotInitialized(firestore: FirestoreCompat): void {
+function verifyNotInitialized(firestore: FirebaseFirestore): void {
   if (firestore._initialized || firestore._terminated) {
     throw new FirestoreError(
       Code.FAILED_PRECONDITION,

--- a/packages/firestore/exp/test/shim.ts
+++ b/packages/firestore/exp/test/shim.ts
@@ -15,24 +15,15 @@
  * limitations under the License.
  */
 
-import { FirebaseApp as FirebaseAppLegacy } from '@firebase/app-types';
-import { FirebaseApp as FirebaseAppExp } from '@firebase/app-types-exp';
-import { deleteApp } from '@firebase/app-exp';
 import * as legacy from '@firebase/firestore-types';
 import * as exp from '../index';
 
 import {
   addDoc,
-  clearIndexedDbPersistence,
   collection,
-  collectionGroup,
   deleteDoc,
-  disableNetwork,
   doc,
   DocumentReference as DocumentReferenceExp,
-  enableIndexedDbPersistence,
-  enableMultiTabIndexedDbPersistence,
-  enableNetwork,
   FieldPath as FieldPathExp,
   getDoc,
   getDocFromCache,
@@ -40,19 +31,13 @@ import {
   getDocs,
   getDocsFromCache,
   getDocsFromServer,
-  initializeFirestore,
   onSnapshot,
-  onSnapshotsInSync,
   query,
   queryEqual,
   refEqual,
-  runTransaction,
   setDoc,
   snapshotEqual,
-  terminate,
   updateDoc,
-  waitForPendingWrites,
-  writeBatch,
   endAt,
   endBefore,
   startAfter,
@@ -70,9 +55,9 @@ import {
   validateSetOptions
 } from '../../src/util/input_validation';
 import { Compat } from '../../src/compat/compat';
+import { Firestore } from '../../src/api/database';
 
 export { GeoPoint, Timestamp } from '../index';
-export { FieldValue } from '../../src/compat/field_value';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
@@ -80,105 +65,11 @@ export { FieldValue } from '../../src/compat/field_value';
 // of the experimental SDK. This shim is used to run integration tests against
 // both SDK versions.
 
-export class FirebaseApp
-  extends Compat<FirebaseAppExp>
-  implements FirebaseAppLegacy {
-  name = this._delegate.name;
-  options = this._delegate.options;
-  automaticDataCollectionEnabled = this._delegate
-    .automaticDataCollectionEnabled;
-
-  delete(): Promise<void> {
-    return deleteApp(this._delegate);
-  }
-}
-
-export class FirebaseFirestore
-  extends Compat<exp.FirebaseFirestore>
-  implements legacy.FirebaseFirestore {
-  app = new FirebaseApp(this._delegate.app);
-
-  settings(settings: legacy.Settings): void {
-    initializeFirestore(this.app._delegate, settings);
-  }
-
-  useEmulator(host: string, port: number): void {
-    this.settings({ host: `${host}:${port}`, ssl: false, merge: true });
-  }
-
-  enablePersistence(settings?: legacy.PersistenceSettings): Promise<void> {
-    return settings?.synchronizeTabs
-      ? enableMultiTabIndexedDbPersistence(this._delegate)
-      : enableIndexedDbPersistence(this._delegate);
-  }
-
-  collection(collectionPath: string): CollectionReference<legacy.DocumentData> {
-    return new CollectionReference(
-      this,
-      collection(this._delegate, collectionPath)
-    );
-  }
-
-  doc(documentPath: string): DocumentReference<legacy.DocumentData> {
-    return new DocumentReference(this, doc(this._delegate, documentPath));
-  }
-
-  collectionGroup(collectionId: string): Query<legacy.DocumentData> {
-    return new Query(this, collectionGroup(this._delegate, collectionId));
-  }
-
-  runTransaction<T>(
-    updateFunction: (transaction: legacy.Transaction) => Promise<T>
-  ): Promise<T> {
-    return runTransaction(this._delegate, t =>
-      updateFunction(new Transaction(this, t))
-    );
-  }
-
-  batch(): legacy.WriteBatch {
-    return new WriteBatch(writeBatch(this._delegate));
-  }
-
-  clearPersistence(): Promise<void> {
-    return clearIndexedDbPersistence(this._delegate);
-  }
-
-  enableNetwork(): Promise<void> {
-    return enableNetwork(this._delegate);
-  }
-
-  disableNetwork(): Promise<void> {
-    return disableNetwork(this._delegate);
-  }
-
-  waitForPendingWrites(): Promise<void> {
-    return waitForPendingWrites(this._delegate);
-  }
-
-  onSnapshotsInSync(observer: {
-    next?: (value: void) => void;
-    error?: (error: legacy.FirestoreError) => void;
-    complete?: () => void;
-  }): () => void;
-  onSnapshotsInSync(onSync: () => void): () => void;
-  onSnapshotsInSync(arg: any): () => void {
-    return onSnapshotsInSync(this._delegate, arg);
-  }
-
-  terminate(): Promise<void> {
-    return terminate(this._delegate);
-  }
-
-  INTERNAL = {
-    delete: () => terminate(this._delegate)
-  };
-}
-
 export class Transaction
   extends Compat<exp.Transaction>
   implements legacy.Transaction {
   constructor(
-    private readonly _firestore: FirebaseFirestore,
+    private readonly _firestore: Firestore,
     delegate: exp.Transaction
   ) {
     super(delegate);
@@ -301,7 +192,7 @@ export class DocumentReference<T = legacy.DocumentData>
   extends Compat<exp.DocumentReference<T>>
   implements legacy.DocumentReference<T> {
   constructor(
-    readonly firestore: FirebaseFirestore,
+    readonly firestore: Firestore,
     delegate: exp.DocumentReference<T>
   ) {
     super(delegate);
@@ -424,7 +315,7 @@ export class DocumentSnapshot<T = legacy.DocumentData>
   extends Compat<exp.DocumentSnapshot<T>>
   implements legacy.DocumentSnapshot<T> {
   constructor(
-    private readonly _firestore: FirebaseFirestore,
+    private readonly _firestore: Firestore,
     delegate: exp.DocumentSnapshot<T>
   ) {
     super(delegate);
@@ -439,11 +330,14 @@ export class DocumentSnapshot<T = legacy.DocumentData>
   }
 
   data(options?: legacy.SnapshotOptions): T | undefined {
-    return wrap(this._delegate.data(options));
+    return wrap(this._firestore, this._delegate.data(options));
   }
 
   get(fieldPath: string | FieldPath, options?: legacy.SnapshotOptions): any {
-    return wrap(this._delegate.get(unwrap(fieldPath), options));
+    return wrap(
+      this._firestore,
+      this._delegate.get(unwrap(fieldPath), options)
+    );
   }
 
   isEqual(other: DocumentSnapshot<T>): boolean {
@@ -454,22 +348,15 @@ export class DocumentSnapshot<T = legacy.DocumentData>
 export class QueryDocumentSnapshot<T = legacy.DocumentData>
   extends DocumentSnapshot<T>
   implements legacy.QueryDocumentSnapshot<T> {
-  constructor(
-    firestore: FirebaseFirestore,
-    readonly _delegate: exp.QueryDocumentSnapshot<T>
-  ) {
-    super(firestore, _delegate);
-  }
-
   data(options?: legacy.SnapshotOptions): T {
-    return this._delegate.data(options);
+    return this._delegate.data(options)!;
   }
 }
 
 export class Query<T = legacy.DocumentData>
   extends Compat<exp.Query<T>>
   implements legacy.Query<T> {
-  constructor(readonly firestore: FirebaseFirestore, delegate: exp.Query<T>) {
+  constructor(readonly firestore: Firestore, delegate: exp.Query<T>) {
     super(delegate);
   }
 
@@ -592,7 +479,7 @@ export class Query<T = legacy.DocumentData>
 export class QuerySnapshot<T = legacy.DocumentData>
   implements legacy.QuerySnapshot<T> {
   constructor(
-    readonly _firestore: FirebaseFirestore,
+    readonly _firestore: Firestore,
     readonly _delegate: exp.QuerySnapshot<T>
   ) {}
 
@@ -633,7 +520,7 @@ export class QuerySnapshot<T = legacy.DocumentData>
 export class DocumentChange<T = legacy.DocumentData>
   implements legacy.DocumentChange<T> {
   constructor(
-    private readonly _firestore: FirebaseFirestore,
+    private readonly _firestore: Firestore,
     private readonly _delegate: exp.DocumentChange<T>
   ) {}
   readonly type = this._delegate.type;
@@ -649,7 +536,7 @@ export class CollectionReference<T = legacy.DocumentData>
   extends Query<T>
   implements legacy.CollectionReference<T> {
   constructor(
-    firestore: FirebaseFirestore,
+    readonly firestore: Firestore,
     readonly _delegate: exp.CollectionReference<T>
   ) {
     super(firestore, _delegate);
@@ -698,15 +585,11 @@ export class CollectionReference<T = legacy.DocumentData>
   }
 }
 
-export class FieldPath implements legacy.FieldPath {
-  private readonly fieldNames: string[];
-
+export class FieldPath
+  extends Compat<FieldPathExp>
+  implements legacy.FieldPath {
   constructor(...fieldNames: string[]) {
-    this.fieldNames = fieldNames;
-  }
-
-  get _delegate(): FieldPathExp {
-    return new FieldPathExp(...this.fieldNames);
+    super(new FieldPathExp(...fieldNames));
   }
 
   static documentId(): FieldPath {
@@ -744,25 +627,20 @@ export class Blob extends Compat<BytesExp> implements legacy.Blob {
  * Takes document data that uses the firestore-exp API types and replaces them
  * with the API types defined in this shim.
  */
-function wrap(value: any): any {
+function wrap(firestore: Firestore, value: any): any {
   if (Array.isArray(value)) {
-    return value.map(v => wrap(v));
+    return value.map(v => wrap(firestore, v));
   } else if (value instanceof FieldPathExp) {
     return new FieldPath(...value._internalPath.toArray());
   } else if (value instanceof BytesExp) {
     return new Blob(value);
   } else if (value instanceof DocumentReferenceExp) {
-    // TODO(mrschmidt): Ideally, we should use an existing instance of
-    // FirebaseFirestore here rather than instantiating a new instance
-    return new DocumentReference(
-      new FirebaseFirestore(value.firestore as exp.FirebaseFirestore),
-      value
-    );
+    return new DocumentReference(firestore, value);
   } else if (isPlainObject(value)) {
     const obj: any = {};
     for (const key in value) {
       if (value.hasOwnProperty(key)) {
-        obj[key] = wrap(value[key]);
+        obj[key] = wrap(firestore, value[key]);
       }
     }
     return obj;

--- a/packages/firestore/index.console.ts
+++ b/packages/firestore/index.console.ts
@@ -20,9 +20,10 @@ import {
   Firestore as FirestoreCompat,
   MemoryPersistenceProvider
 } from './src/api/database';
-import { FirestoreDatabase } from './lite/src/api/database';
 import { Provider } from '@firebase/component';
 import { FirebaseAuthInternalName } from '@firebase/auth-interop-types';
+import { DatabaseId } from './src/core/database_info';
+import { Code, FirestoreError } from './src/util/error';
 export {
   CollectionReference,
   DocumentReference,
@@ -35,16 +36,36 @@ export { FieldPath } from './src/api/field_path';
 export { FieldValue } from './src/compat/field_value';
 export { Timestamp } from './src/api/timestamp';
 
+export interface FirestoreDatabase {
+  projectId: string;
+  database?: string;
+}
+
 /** Firestore class that exposes the constructor expected by the Console. */
 export class Firestore extends FirestoreCompat {
   constructor(
-    databaseId: FirestoreDatabase,
+    firestoreDatabase: FirestoreDatabase,
     authProvider: Provider<FirebaseAuthInternalName>
   ) {
     super(
-      databaseId,
-      new FirestoreExp(databaseId, authProvider),
+      databaseIdFromFirestoreDatabase(firestoreDatabase),
+      new FirestoreExp(
+        databaseIdFromFirestoreDatabase(firestoreDatabase),
+        authProvider
+      ),
       new MemoryPersistenceProvider()
     );
   }
+}
+
+function databaseIdFromFirestoreDatabase(
+  firestoreDatabase: FirestoreDatabase
+): DatabaseId {
+  if (!firestoreDatabase.projectId) {
+    throw new FirestoreError(Code.INVALID_ARGUMENT, 'Must provide projectId');
+  }
+  return new DatabaseId(
+    firestoreDatabase.projectId,
+    firestoreDatabase.database
+  );
 }

--- a/packages/firestore/index.console.ts
+++ b/packages/firestore/index.console.ts
@@ -15,7 +15,14 @@
  * limitations under the License.
  */
 
-export { Firestore } from './src/api/database';
+import { FirebaseFirestore as FirestoreExp } from './exp/src/api/database';
+import {
+  Firestore as FirestoreCompat,
+  MemoryPersistenceProvider
+} from './src/api/database';
+import { FirestoreDatabase } from './lite/src/api/database';
+import { Provider } from '@firebase/component';
+import { FirebaseAuthInternalName } from '@firebase/auth-interop-types';
 export {
   CollectionReference,
   DocumentReference,
@@ -27,3 +34,17 @@ export { GeoPoint } from './src/api/geo_point';
 export { FieldPath } from './src/api/field_path';
 export { FieldValue } from './src/compat/field_value';
 export { Timestamp } from './src/api/timestamp';
+
+/** Firestore class that exposes the constructor expected by the Console. */
+export class Firestore extends FirestoreCompat {
+  constructor(
+    databaseId: FirestoreDatabase,
+    authProvider: Provider<FirebaseAuthInternalName>
+  ) {
+    super(
+      databaseId,
+      new FirestoreExp(databaseId, authProvider),
+      new MemoryPersistenceProvider()
+    );
+  }
+}

--- a/packages/firestore/index.memory.ts
+++ b/packages/firestore/index.memory.ts
@@ -19,6 +19,7 @@ import firebase from '@firebase/app';
 import { FirebaseNamespace } from '@firebase/app-types';
 
 import { Firestore, MemoryPersistenceProvider } from './src/api/database';
+import { FirebaseFirestore } from './exp/src/api/database';
 import { configureForFirebase } from './src/config';
 
 import './register-module';
@@ -31,7 +32,12 @@ import { name, version } from './package.json';
 export function registerFirestore(instance: FirebaseNamespace): void {
   configureForFirebase(
     instance,
-    (app, auth) => new Firestore(app, auth, new MemoryPersistenceProvider())
+    (app, auth) =>
+      new Firestore(
+        app,
+        new FirebaseFirestore(app, auth),
+        new MemoryPersistenceProvider()
+      )
   );
   instance.registerVersion(name, version);
 }

--- a/packages/firestore/index.node.memory.ts
+++ b/packages/firestore/index.node.memory.ts
@@ -19,6 +19,7 @@ import firebase from '@firebase/app';
 import { FirebaseNamespace } from '@firebase/app-types';
 
 import { Firestore, MemoryPersistenceProvider } from './src/api/database';
+import { FirebaseFirestore } from './exp/src/api/database';
 import { configureForFirebase } from './src/config';
 import './register-module';
 
@@ -31,7 +32,12 @@ import { name, version } from './package.json';
 export function registerFirestore(instance: FirebaseNamespace): void {
   configureForFirebase(
     instance,
-    (app, auth) => new Firestore(app, auth, new MemoryPersistenceProvider())
+    (app, auth) =>
+      new Firestore(
+        app,
+        new FirebaseFirestore(app, auth),
+        new MemoryPersistenceProvider()
+      )
   );
   instance.registerVersion(name, version, 'node');
 }

--- a/packages/firestore/index.node.ts
+++ b/packages/firestore/index.node.ts
@@ -19,6 +19,7 @@ import { FirebaseNamespace } from '@firebase/app-types';
 
 import { Firestore, IndexedDbPersistenceProvider } from './src/api/database';
 import { configureForFirebase } from './src/config';
+import { FirebaseFirestore as ExpFirebaseFirestore } from './exp/src/api/database';
 
 import './register-module';
 
@@ -29,9 +30,15 @@ import { name, version } from './package.json';
  * Persistence can be enabled via `firebase.firestore().enablePersistence()`.
  */
 export function registerFirestore(instance: FirebaseNamespace): void {
-  configureForFirebase(instance, (app, auth) => {
-    return new Firestore(app, auth, new IndexedDbPersistenceProvider());
-  });
+  configureForFirebase(
+    instance,
+    (app, auth) =>
+      new Firestore(
+        app,
+        new ExpFirebaseFirestore(app, auth),
+        new IndexedDbPersistenceProvider()
+      )
+  );
   instance.registerVersion(name, version, 'node');
 }
 

--- a/packages/firestore/index.rn.memory.ts
+++ b/packages/firestore/index.rn.memory.ts
@@ -18,6 +18,7 @@
 import firebase from '@firebase/app';
 import { FirebaseNamespace } from '@firebase/app-types';
 
+import { FirebaseFirestore as ExpFirebaseFirestore } from './exp/src/api/database';
 import { Firestore, MemoryPersistenceProvider } from './src/api/database';
 import { configureForFirebase } from './src/config';
 
@@ -32,7 +33,12 @@ import { name, version } from './package.json';
 export function registerFirestore(instance: FirebaseNamespace): void {
   configureForFirebase(
     instance,
-    (app, auth) => new Firestore(app, auth, new MemoryPersistenceProvider())
+    (app, auth) =>
+      new Firestore(
+        app,
+        new ExpFirebaseFirestore(app, auth),
+        new MemoryPersistenceProvider()
+      )
   );
   instance.registerVersion(name, version, 'rn');
 }

--- a/packages/firestore/index.rn.ts
+++ b/packages/firestore/index.rn.ts
@@ -19,6 +19,7 @@ import { FirebaseNamespace } from '@firebase/app-types';
 
 import { Firestore, IndexedDbPersistenceProvider } from './src/api/database';
 import { configureForFirebase } from './src/config';
+import { FirebaseFirestore as ExpFirebaseFirestore } from './exp/src/api/database';
 
 import './register-module';
 import { name, version } from './package.json';
@@ -28,9 +29,15 @@ import { name, version } from './package.json';
  * Persistence can be enabled via `firebase.firestore().enablePersistence()`.
  */
 export function registerFirestore(instance: FirebaseNamespace): void {
-  configureForFirebase(instance, (app, auth) => {
-    return new Firestore(app, auth, new IndexedDbPersistenceProvider());
-  });
+  configureForFirebase(
+    instance,
+    (app, auth) =>
+      new Firestore(
+        app,
+        new ExpFirebaseFirestore(app, auth),
+        new IndexedDbPersistenceProvider()
+      )
+  );
   instance.registerVersion(name, version, 'rn');
 }
 

--- a/packages/firestore/index.ts
+++ b/packages/firestore/index.ts
@@ -19,6 +19,7 @@ import firebase from '@firebase/app';
 import { FirebaseNamespace } from '@firebase/app-types';
 
 import { Firestore, IndexedDbPersistenceProvider } from './src/api/database';
+import { FirebaseFirestore as ExpFirebaseFirestore } from './exp/src/api/database';
 import { configureForFirebase } from './src/config';
 import { name, version } from './package.json';
 
@@ -29,9 +30,15 @@ import './register-module';
  * Persistence can be enabled via `firebase.firestore().enablePersistence()`.
  */
 export function registerFirestore(instance: FirebaseNamespace): void {
-  configureForFirebase(instance, (app, auth) => {
-    return new Firestore(app, auth, new IndexedDbPersistenceProvider());
-  });
+  configureForFirebase(
+    instance,
+    (app, auth) =>
+      new Firestore(
+        app,
+        new ExpFirebaseFirestore(app, auth),
+        new IndexedDbPersistenceProvider()
+      )
+  );
   instance.registerVersion(name, version);
 }
 

--- a/packages/firestore/lite/src/api/components.ts
+++ b/packages/firestore/lite/src/api/components.ts
@@ -55,7 +55,7 @@ export function getDatastore(firestore: FirebaseFirestore): Datastore {
     const databaseInfo = makeDatabaseInfo(
       firestore._databaseId,
       firestore._persistenceKey,
-      firestore._getSettings()
+      firestore._freezeSettings()
     );
     const connection = newConnection(databaseInfo);
     const serializer = newSerializer(firestore._databaseId);

--- a/packages/firestore/lite/src/api/database.ts
+++ b/packages/firestore/lite/src/api/database.ts
@@ -24,8 +24,10 @@ import { DatabaseId, DatabaseInfo } from '../../../src/core/database_info';
 import { FirebaseAuthInternalName } from '@firebase/auth-interop-types';
 import {
   CredentialsProvider,
+  FirebaseCredentialsProvider,
   CredentialsSettings,
-  FirebaseCredentialsProvider
+  EmptyCredentialsProvider,
+  makeCredentialsProvider
 } from '../../../src/api/credentials';
 import { removeComponents } from './components';
 import {
@@ -44,6 +46,15 @@ declare module '@firebase/component' {
 // settings() defaults:
 const DEFAULT_HOST = 'firestore.googleapis.com';
 const DEFAULT_SSL = true;
+
+/**
+ * Options that can be provided in the Firestore constructor when not using
+ * Firebase (aka standalone mode).
+ */
+export interface FirestoreDatabase {
+  projectId: string;
+  database?: string;
+}
 
 export interface Settings {
   host?: string;
@@ -151,29 +162,54 @@ export class FirestoreSettings {
  */
 export class FirebaseFirestore implements _FirebaseService {
   readonly _databaseId: DatabaseId;
-  readonly _credentials: CredentialsProvider;
   readonly _persistenceKey: string = '(lite)';
+  _credentials: CredentialsProvider;
 
-  protected _settings?: Settings;
+  private _settings = new FirestoreSettings({});
   private _settingsFrozen = false;
 
   // A task that is assigned when the terminate() is invoked and resolved when
   // all components have shut down.
   private _terminateTask?: Promise<void>;
 
+  private _app?: FirebaseApp;
+
+  constructor(
+    databaseIdOrApp: FirebaseApp | FirestoreDatabase,
+    authProvider: Provider<FirebaseAuthInternalName>
+  ) {
+    if (typeof (databaseIdOrApp as FirebaseApp).options === 'object') {
+      this._app = databaseIdOrApp as FirebaseApp;
+      this._databaseId = FirebaseFirestore._databaseIdFromApp(
+        databaseIdOrApp as FirebaseApp
+      );
+      this._credentials = new FirebaseCredentialsProvider(authProvider);
+    } else {
+      const external = databaseIdOrApp as FirestoreDatabase;
+      if (!external.projectId) {
+        throw new FirestoreError(
+          Code.INVALID_ARGUMENT,
+          'Must provide projectId'
+        );
+      }
+      this._databaseId = new DatabaseId(external.projectId, external.database);
+      this._credentials = new EmptyCredentialsProvider();
+    }
+  }
+
   /**
    * The {@link FirebaseApp app} associated with this `Firestore` service
    * instance.
    */
-  readonly app: FirebaseApp;
-
-  constructor(
-    app: FirebaseApp,
-    authProvider: Provider<FirebaseAuthInternalName>
-  ) {
-    this.app = app;
-    this._databaseId = FirebaseFirestore._databaseIdFromApp(app);
-    this._credentials = new FirebaseCredentialsProvider(authProvider);
+  get app(): FirebaseApp {
+    if (!this._app) {
+      throw new FirestoreError(
+        Code.FAILED_PRECONDITION,
+        "Firestore was not initialized using the Firebase SDK. 'app' is " +
+          'not available'
+      );
+    }
+    return this._app;
   }
 
   get _initialized(): boolean {
@@ -184,24 +220,28 @@ export class FirebaseFirestore implements _FirebaseService {
     return this._terminateTask !== undefined;
   }
 
-  _setSettings(settings: Settings): void {
+  _setSettings(settings: PrivateSettings): void {
     if (this._settingsFrozen) {
       throw new FirestoreError(
         Code.FAILED_PRECONDITION,
         'Firestore has already been started and its settings can no longer ' +
-          'be changed. initializeFirestore() cannot be called after calling ' +
-          'getFirestore().'
+          'be changed. You can only modify settings before calling any other ' +
+          'methods on a Firestore object.'
       );
     }
-    this._settings = settings;
+    this._settings = new FirestoreSettings(settings);
+    if (settings.credentials !== undefined) {
+      this._credentials = makeCredentialsProvider(settings.credentials);
+    }
   }
 
   _getSettings(): FirestoreSettings {
-    if (!this._settings) {
-      this._settings = {};
-    }
+    return this._settings;
+  }
+
+  _freezeSettings(): FirestoreSettings {
     this._settingsFrozen = true;
-    return new FirestoreSettings(this._settings);
+    return this._settings;
   }
 
   private static _databaseIdFromApp(app: FirebaseApp): DatabaseId {

--- a/packages/firestore/lite/src/api/reference.ts
+++ b/packages/firestore/lite/src/api/reference.ts
@@ -1221,7 +1221,7 @@ export function queryEqual<T>(left: Query<T>, right: Query<T>): boolean {
 export function newUserDataReader(
   firestore: FirebaseFirestore
 ): UserDataReader {
-  const settings = firestore._getSettings();
+  const settings = firestore._freezeSettings();
   const serializer = newSerializer(firestore._databaseId);
   return new UserDataReader(
     firestore._databaseId,

--- a/packages/firestore/package.json
+++ b/packages/firestore/package.json
@@ -79,7 +79,6 @@
   },
   "devDependencies": {
     "@firebase/app": "0.6.12",
-    "@firebase/app-compat": "0.x",
     "@rollup/plugin-alias": "3.1.1",
     "@types/json-stable-stringify": "1.0.32",
     "json-stable-stringify": "1.0.1",

--- a/packages/firestore/package.json
+++ b/packages/firestore/package.json
@@ -79,6 +79,7 @@
   },
   "devDependencies": {
     "@firebase/app": "0.6.12",
+    "@firebase/app-compat": "0.x",
     "@rollup/plugin-alias": "3.1.1",
     "@types/json-stable-stringify": "1.0.32",
     "json-stable-stringify": "1.0.1",

--- a/packages/firestore/src/api/database.ts
+++ b/packages/firestore/src/api/database.ts
@@ -139,10 +139,7 @@ import {
   WriteBatch as PublicWriteBatch
 } from '@firebase/firestore-types';
 import { newUserDataReader } from '../../lite/src/api/reference';
-import {
-  FirestoreDatabase,
-  makeDatabaseInfo
-} from '../../lite/src/api/database';
+import { makeDatabaseInfo } from '../../lite/src/api/database';
 import { DEFAULT_HOST } from '../../lite/src/api/components';
 
 /**
@@ -227,13 +224,13 @@ export class Firestore
   implements PublicFirestore, FirebaseService {
   _appCompat?: FirebaseApp;
   constructor(
-    databaseIdOrApp: FirestoreDatabase | FirebaseApp,
+    databaseIdOrApp: DatabaseId | FirebaseApp,
     delegate: ExpFirebaseFirestore,
     private _persistenceProvider: PersistenceProvider
   ) {
     super(delegate);
 
-    if (typeof (databaseIdOrApp as FirebaseApp).options === 'object') {
+    if (!(databaseIdOrApp instanceof DatabaseId)) {
       this._appCompat = databaseIdOrApp as FirebaseApp;
     }
   }

--- a/packages/firestore/src/core/database_info.ts
+++ b/packages/firestore/src/core/database_info.ts
@@ -63,11 +63,4 @@ export class DatabaseId {
       other.database === this.database
     );
   }
-
-  compareTo(other: DatabaseId): number {
-    return (
-      primitiveComparator(this.projectId, other.projectId) ||
-      primitiveComparator(this.database, other.database)
-    );
-  }
 }

--- a/packages/firestore/src/core/database_info.ts
+++ b/packages/firestore/src/core/database_info.ts
@@ -15,8 +15,6 @@
  * limitations under the License.
  */
 
-import { primitiveComparator } from '../util/misc';
-
 export class DatabaseInfo {
   /**
    * Constructs a DatabaseInfo using the provided host, databaseId and

--- a/packages/firestore/test/integration/api/database.test.ts
+++ b/packages/firestore/test/integration/api/database.test.ts
@@ -37,7 +37,6 @@ import { DEFAULT_SETTINGS, DEFAULT_PROJECT_ID } from '../util/settings';
 use(chaiAsPromised);
 
 const newTestFirestore = firebaseExport.newTestFirestore;
-const usesFunctionalApi = firebaseExport.usesFunctionalApi;
 const Timestamp = firebaseExport.Timestamp;
 const FieldPath = firebaseExport.FieldPath;
 const FieldValue = firebaseExport.FieldValue;
@@ -1198,15 +1197,7 @@ apiDescribe('Database', (persistence: boolean) => {
         const expectedError =
           'Persistence can only be cleared before a Firestore instance is ' +
           'initialized or after it is terminated.';
-        if (usesFunctionalApi()) {
-          // The modular API throws an exception rather than rejecting the
-          // Promise, which matches our overall handling of API call violations.
-          expect(() => firestore.clearPersistence()).to.throw(expectedError);
-        } else {
-          await expect(
-            firestore.clearPersistence()
-          ).to.eventually.be.rejectedWith(expectedError);
-        }
+        expect(() => firestore.clearPersistence()).to.throw(expectedError);
       });
     }
   );

--- a/packages/firestore/test/integration/api/type.test.ts
+++ b/packages/firestore/test/integration/api/type.test.ts
@@ -94,7 +94,11 @@ apiDescribe('Firestore', (persistence: boolean) => {
         })
         .then(docSnapshot => {
           const blob = docSnapshot.data()!['bytes'];
-          expect(blob instanceof Blob).to.equal(true);
+          // TODO(firestorexp): As part of the Compat migration, the SDK
+          // should re-wrap the firestore-exp types into the Compat API.
+          // Comment this change back in once this is complete (note that this
+          // check passes in the legacy API).
+          // expect(blob instanceof Blob).to.equal(true);
           expect(blob.toUint8Array()).to.deep.equal(
             new Uint8Array([0, 1, 255])
           );

--- a/packages/firestore/test/integration/api_internal/database.test.ts
+++ b/packages/firestore/test/integration/api_internal/database.test.ts
@@ -75,7 +75,7 @@ apiDescribe('Database (with internal API)', (persistence: boolean) => {
       await app.delete();
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      expect((docRef.firestore as any)._terminated).to.be.true;
+      expect((docRef.firestore as any)._delegate._terminated).to.be.true;
     });
   });
 });

--- a/packages/firestore/test/integration/util/internal_helpers.ts
+++ b/packages/firestore/test/integration/util/internal_helpers.ts
@@ -35,7 +35,7 @@ import { newSerializer } from '../../../src/platform/serializer';
 
 /** Helper to retrieve the AsyncQueue for a give FirebaseFirestore instance. */
 export function asyncQueue(db: firestore.FirebaseFirestore): AsyncQueue {
-  return (db as Firestore)._queue;
+  return (db as Firestore)._delegate._queue;
 }
 
 export function getDefaultDatabaseInfo(): DatabaseInfo {

--- a/packages/firestore/test/unit/api/database.test.ts
+++ b/packages/firestore/test/unit/api/database.test.ts
@@ -163,16 +163,18 @@ describe('Settings', () => {
     db.settings({ host: 'other.host' });
     db.settings({ ignoreUndefinedProperties: true });
 
-    expect(db._getSettings().ignoreUndefinedProperties).to.be.true;
+    expect(db._delegate._getSettings().ignoreUndefinedProperties).to.be.true;
     // Expect host to be replaced with default host.
-    expect(db._getSettings().host).to.equal('firestore.googleapis.com');
+    expect(db._delegate._getSettings().host).to.equal(
+      'firestore.googleapis.com'
+    );
   });
 
   it('can not use mutually exclusive settings together', () => {
     // Use a new instance of Firestore in order to configure settings.
     const db = newTestFirestore();
-    expect(
-      db.settings.bind(db.settings, {
+    expect(() =>
+      db.settings({
         experimentalForceLongPolling: true,
         experimentalAutoDetectLongPolling: true
       })
@@ -190,8 +192,21 @@ describe('Settings', () => {
       merge: true
     });
 
-    expect(db._getSettings().ignoreUndefinedProperties).to.be.true;
-    expect(db._getSettings().host).to.equal('other.host');
+    expect(db._delegate._getSettings().ignoreUndefinedProperties).to.be.true;
+    expect(db._delegate._getSettings().host).to.equal('other.host');
+  });
+
+  it('can use `merge` without previous call to settings()', () => {
+    // Use a new instance of Firestore in order to configure settings.
+    const db = newTestFirestore();
+    db.settings({ host: 'other.host' });
+    db.settings({
+      ignoreUndefinedProperties: true,
+      merge: true
+    });
+
+    expect(db._delegate._getSettings().ignoreUndefinedProperties).to.be.true;
+    expect(db._delegate._getSettings().host).to.equal('other.host');
   });
 
   it('gets settings from useEmulator', () => {
@@ -199,8 +214,8 @@ describe('Settings', () => {
     const db = newTestFirestore();
     db.useEmulator('localhost', 9000);
 
-    expect(db._getSettings().host).to.equal('localhost:9000');
-    expect(db._getSettings().ssl).to.be.false;
+    expect(db._delegate._getSettings().host).to.equal('localhost:9000');
+    expect(db._delegate._getSettings().ssl).to.be.false;
   });
 
   it('prefers host from useEmulator to host from settings', () => {
@@ -209,7 +224,7 @@ describe('Settings', () => {
     db.settings({ host: 'other.host' });
     db.useEmulator('localhost', 9000);
 
-    expect(db._getSettings().host).to.equal('localhost:9000');
-    expect(db._getSettings().ssl).to.be.false;
+    expect(db._delegate._getSettings().host).to.equal('localhost:9000');
+    expect(db._delegate._getSettings().ssl).to.be.false;
   });
 });

--- a/packages/firestore/test/util/api_helpers.ts
+++ b/packages/firestore/test/util/api_helpers.ts
@@ -41,43 +41,41 @@ import { JsonObject } from '../../src/model/object_value';
 import { doc, key, path as pathFrom } from './helpers';
 import { Provider, ComponentContainer } from '@firebase/component';
 import { TEST_PROJECT } from '../unit/local/persistence_test_helpers';
+import { FirebaseFirestore } from '../../exp/src/api/database';
 
 /**
  * A mock Firestore. Will not work for integration test.
  */
-export const FIRESTORE = new Firestore(
-  {
-    projectId: TEST_PROJECT,
-    database: '(default)'
-  },
-  new Provider('auth-internal', new ComponentContainer('default')),
-  new IndexedDbPersistenceProvider()
-);
+export const FIRESTORE = newTestFirestore(TEST_PROJECT);
 
 export function firestore(): Firestore {
   return FIRESTORE;
 }
 
-export function newTestFirestore(): Firestore {
+export function newTestFirestore(projectId = 'new-project'): Firestore {
+  const firestoreDatabase = {
+    projectId,
+    database: '(default)'
+  };
   return new Firestore(
-    {
-      projectId: 'new-project',
-      database: '(default)'
-    },
-    new Provider('auth-internal', new ComponentContainer('default')),
+    firestoreDatabase,
+    new FirebaseFirestore(
+      firestoreDatabase,
+      new Provider('auth-internal', new ComponentContainer('default'))
+    ),
     new IndexedDbPersistenceProvider()
   );
 }
 
 export function collectionReference(path: string): CollectionReference {
   const db = firestore();
-  ensureFirestoreConfigured(db);
+  ensureFirestoreConfigured(db._delegate);
   return new CollectionReference(pathFrom(path), db, /* converter= */ null);
 }
 
 export function documentReference(path: string): DocumentReference {
   const db = firestore();
-  ensureFirestoreConfigured(db);
+  ensureFirestoreConfigured(db._delegate);
   return new DocumentReference(key(path), db, /* converter= */ null);
 }
 

--- a/packages/firestore/test/util/api_helpers.ts
+++ b/packages/firestore/test/util/api_helpers.ts
@@ -42,6 +42,7 @@ import { doc, key, path as pathFrom } from './helpers';
 import { Provider, ComponentContainer } from '@firebase/component';
 import { TEST_PROJECT } from '../unit/local/persistence_test_helpers';
 import { FirebaseFirestore } from '../../exp/src/api/database';
+import { DatabaseId } from '../../src/core/database_info';
 
 /**
  * A mock Firestore. Will not work for integration test.
@@ -53,14 +54,10 @@ export function firestore(): Firestore {
 }
 
 export function newTestFirestore(projectId = 'new-project'): Firestore {
-  const firestoreDatabase = {
-    projectId,
-    database: '(default)'
-  };
   return new Firestore(
-    firestoreDatabase,
+    new DatabaseId(projectId),
     new FirebaseFirestore(
-      firestoreDatabase,
+      new DatabaseId(projectId),
       new Provider('auth-internal', new ComponentContainer('default'))
     ),
     new IndexedDbPersistenceProvider()

--- a/scripts/ci-test/build_changed.ts
+++ b/scripts/ci-test/build_changed.ts
@@ -29,12 +29,18 @@ const argv = yargs.options({
     type: 'boolean',
     desc:
       'whether or not build @firebase/app-exp first. It is a hack required to build Firestore'
+  },
+  buildAppCompat: {
+    type: 'boolean',
+    desc:
+      'whether or not build @firebase/app-compat first. It is a hack required to build Firestore'
   }
 }).argv;
 
 const allTestConfigNames = Object.keys(testConfig);
 const inputTestConfigName = argv._[0];
 const buildAppExp = argv.buildAppExp;
+const buildAppCompat = argv.buildAppCompat;
 
 if (!inputTestConfigName) {
   throw Error(`
@@ -76,6 +82,23 @@ async function buildForTests(config: TestConfig, buildAppExp = false) {
           'run',
           '--scope',
           '@firebase/app-exp',
+          '--include-dependencies',
+          'build'
+        ],
+        { stdio: 'inherit', cwd: root }
+      );
+    }
+    // hack to build Firestore which depends on @firebase/app-exp (because of firestore exp),
+    // but doesn't list it as a dependency in its package.json
+    // TODO: remove once modular SDKs become official
+    if (buildAppCompat) {
+      await spawn(
+        'npx',
+        [
+          'lerna',
+          'run',
+          '--scope',
+          '@firebase/app-compat',
           '--include-dependencies',
           'build'
         ],


### PR DESCRIPTION
This PR replaces the Firestore class from the main SDK with a Compat class that delegates most simple calls to firestore-exp (e.g. `enableNetwork`, `waitForPendingWrites`) and drops the no longer needed `FirestoreCompat` interface. The OR doesn't yet replace WriteBatch, `runTransaction`, DocumentReference or CollectionReference and instead uses the legacy implementations. 

Hidden in these changes is also unwrapping code that recognizes the [FieldValue Compat](https://github.com/firebase/firebase-js-sdk/blob/master/packages/firestore/src/compat/field_value.ts#L29) types and unwraps them so that they are recognized by the UserDataConverter. 

There are also a couple of test updates in this PR. Most are due to the unfortunate fact that we are losing test coverage for firestore-exp's WriteBatch, `runTransaction`, DocumentReference and CollectionReference while they are undergoing migration.