### PR TITLE
adds a root changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,4 +2,4 @@
 
 You can view the changelog for the packages within this monorepo in `packages/<package name>/CHANGELOG.md`. For example, you will find the changelog for the Firestore package at [`packages/firestore/CHANGELOG.md`](./packages/firestore/CHANGELOG.md).
 
-Additionally, you can view a changelog for the entire monorepo at the [firebase support page](https://firebase.google.com/support/release-notes/js).
+Additionally, you can view our official release notes for the entire monorepo at the [firebase support page](https://firebase.google.com/support/release-notes/js).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+You can view the changelog for the packages within this monorepo in `packages/<package name>/CHANGELOG.md`. For example, you will find the changelog for the Firestore package at [`packages/firestore/CHANGELOG.md`](./packages/firestore/CHANGELOG.md).
+
+Additionally, you can view a changelog for the entire monorepo at the [firebase support page](https://firebase.google.com/support/release-notes/js).


### PR DESCRIPTION
I noticed that the developer experience (especially for people not already familiar with lerna or how this repo is structured) to be able to see at least a hint about where the changelogs are.

Personally, when I see a `CHANGELOG.md` file (as is convention) that's the first place I look, and I'll bet I'm not alone on that.

Please feel completely free to change what I wrote to whatever you think is best.  The main idea here is just to have _something_ there that will quickly point people in the right direction.