### PR TITLE
return non zero code on error in size analysis workflow

### DIFF
--- a/scripts/size_report/report_binary_size.ts
+++ b/scripts/size_report/report_binary_size.ts
@@ -177,6 +177,11 @@ async function generateSizeReport(): Promise<BinarySizeRequestBody> {
   };
 }
 
-generateSizeReport().then(report => {
-  upload(report, RequestEndpoint.BINARY_SIZE);
-});
+generateSizeReport()
+  .then(report => {
+    upload(report, RequestEndpoint.BINARY_SIZE);
+  })
+  .catch(err => {
+    console.error(err);
+    process.exit(1);
+  });

--- a/scripts/size_report/report_modular_export_binary_size.ts
+++ b/scripts/size_report/report_modular_export_binary_size.ts
@@ -53,8 +53,13 @@ async function generateReport(): Promise<ModularExportBinarySizeRequestBody> {
 }
 
 async function main(): Promise<void> {
-  const reports: ModularExportBinarySizeRequestBody = await generateReport();
-  console.log(JSON.stringify(reports, null, 4));
-  upload(reports, RequestEndpoint.MODULAR_EXPORT_BINARY_SIZE);
+  try {
+    const reports: ModularExportBinarySizeRequestBody = await generateReport();
+    console.log(JSON.stringify(reports, null, 4));
+    upload(reports, RequestEndpoint.MODULAR_EXPORT_BINARY_SIZE);
+  } catch (e) {
+    console.error(e);
+    process.exit(1);
+  }
 }
 main();


### PR DESCRIPTION
It will make the workflow fail instead of passing, so we know if something went wrong.