### PR TITLE
Fix to avoid false failures on changeset checker

### DIFF
--- a/.changeset/giant-pants-relax.md
+++ b/.changeset/giant-pants-relax.md
@@ -1,0 +1,5 @@
+---
+'@firebase/app-compat': patch
+---
+
+test

--- a/.changeset/giant-pants-relax.md
+++ b/.changeset/giant-pants-relax.md
@@ -1,5 +1,5 @@
 ---
-'@firebase/app-compat': patch
+'@firebase/app-compat: patch
 ---
 
 test

--- a/.changeset/giant-pants-relax.md
+++ b/.changeset/giant-pants-relax.md
@@ -1,5 +1,0 @@
----
-'@firebase/app-compat': patch
----
-
-test

--- a/.changeset/giant-pants-relax.md
+++ b/.changeset/giant-pants-relax.md
@@ -1,5 +1,5 @@
 ---
-'@firebase/app-compat: patch
+'@firebase/app-compat': patch
 ---
 
 test

--- a/.github/workflows/check-changeset.yml
+++ b/.github/workflows/check-changeset.yml
@@ -61,5 +61,5 @@ jobs:
           - No changeset formatting errors detected.
     # Don't want it to throw before editing the comment.
     - name: Fail if checker script logged a blocking failure
-      if: ${{steps.check-changeset.outputs.BLOCKING_FAILURE}}
+      if: ${{steps.check-changeset.outputs.BLOCKING_FAILURE == 'true'}}
       run: exit 1

--- a/.github/workflows/check-changeset.yml
+++ b/.github/workflows/check-changeset.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Run changeset script
       run: yarn ts-node-script scripts/check_changeset.ts
       id: check-changeset
-    - name: Print changeset checker output
+    - name: Print changeset checker outputx
       run: echo "${{steps.check-changeset.outputs.CHANGESET_ERROR_MESSAGE}}"
     - name: Find Comment
       uses: peter-evans/find-comment@v1

--- a/.github/workflows/check-changeset.yml
+++ b/.github/workflows/check-changeset.yml
@@ -22,8 +22,10 @@ jobs:
     - name: Run changeset script
       run: yarn ts-node-script scripts/check_changeset.ts
       id: check-changeset
-    - name: Print changeset checker outputx
+    - name: Print changeset checker output
       run: echo "${{steps.check-changeset.outputs.CHANGESET_ERROR_MESSAGE}}"
+    - name: Print blocking failure status
+      run: echo "${{steps.check-changeset.outputs.BLOCKING_FAILURE}}"
     - name: Find Comment
       uses: peter-evans/find-comment@v1
       id: fc

--- a/scripts/check_changeset.ts
+++ b/scripts/check_changeset.ts
@@ -87,6 +87,7 @@ async function main() {
   const errors = [];
   try {
     await exec('yarn changeset status');
+    console.log(`::set-output name=BLOCKING_FAILURE::false`);
   } catch (e) {
     const messageLines = e.message.replace(/🦋  error /g, '').split('\n');
     let formattedStatusError =


### PR DESCRIPTION
Initially set BLOCKING_FAILURE var to false, and also log the value to help diagnose any future issues.