### PR TITLE
Bump Node memory limit for all test CI

### DIFF
--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -17,6 +17,8 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install google-chrome-stable
+    - name: Bump Node memory limit
+      run: echo "NODE_OPTIONS=--max_old_space_size=4096" >> $GITHUB_ENV
     - name: Test setup and yarn install
       run: |
         cp config/ci.config.json config/project.json

--- a/.github/workflows/test-changed-auth.yml
+++ b/.github/workflows/test-changed-auth.yml
@@ -21,6 +21,8 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install google-chrome-stable
+    - name: Bump Node memory limit
+      run: echo "NODE_OPTIONS=--max_old_space_size=4096" >> $GITHUB_ENV
     - name: Test setup and yarn install
       run: |
         cp config/ci.config.json config/project.json

--- a/.github/workflows/test-changed-fcm-integration.yml
+++ b/.github/workflows/test-changed-fcm-integration.yml
@@ -21,6 +21,8 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install google-chrome-stable
+    - name: Bump Node memory limit
+      run: echo "NODE_OPTIONS=--max_old_space_size=4096" >> $GITHUB_ENV
     - name: Test setup and yarn install
       run: |
         cp config/ci.config.json config/project.json

--- a/.github/workflows/test-changed-firestore-integration.yml
+++ b/.github/workflows/test-changed-firestore-integration.yml
@@ -21,6 +21,8 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install google-chrome-stable
+    - name: Bump Node memory limit
+      run: echo "NODE_OPTIONS=--max_old_space_size=4096" >> $GITHUB_ENV
     - name: Test setup and yarn install
       run: |
         cp config/ci.config.json config/project.json

--- a/.github/workflows/test-changed-firestore.yml
+++ b/.github/workflows/test-changed-firestore.yml
@@ -21,6 +21,8 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install google-chrome-stable
+    - name: Bump Node memory limit
+      run: echo "NODE_OPTIONS=--max_old_space_size=4096" >> $GITHUB_ENV
     - name: Test setup and yarn install
       run: |
         cp config/ci.config.json config/project.json

--- a/.github/workflows/test-changed-misc.yml
+++ b/.github/workflows/test-changed-misc.yml
@@ -21,6 +21,8 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install google-chrome-stable
+    - name: Bump Node memory limit
+      run: echo "NODE_OPTIONS=--max_old_space_size=4096" >> $GITHUB_ENV
     - name: Test setup and yarn install
       run: |
         cp config/ci.config.json config/project.json

--- a/.github/workflows/test-changed.yml
+++ b/.github/workflows/test-changed.yml
@@ -21,6 +21,8 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install google-chrome-stable
+    - name: Bump Node memory limit
+      run: echo "NODE_OPTIONS=--max_old_space_size=4096" >> $GITHUB_ENV
     - name: Test setup and yarn install
       run: |
         cp config/ci.config.json config/project.json

--- a/.github/workflows/test-firebase-integration.yml
+++ b/.github/workflows/test-firebase-integration.yml
@@ -21,6 +21,8 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install google-chrome-stable
+    - name: Bump Node memory limit
+      run: echo "NODE_OPTIONS=--max_old_space_size=4096" >> $GITHUB_ENV
     - name: Test setup and yarn install
       run: |
         cp config/ci.config.json config/project.json


### PR DESCRIPTION
auth-exp tests were causing memory to run out in CI (but not locally) as part of `test-changed.yml`. It's possible it could happen in the future to other large test suites like Firestore so might as well consistently bump for all test workflows.