### PR TITLE
Compat class for FieldPath

### DIFF
--- a/packages/firestore/src/api/database.ts
+++ b/packages/firestore/src/api/database.ts
@@ -77,7 +77,7 @@ import {
 } from '../util/input_validation';
 import { logWarn, setLogLevel as setClientLogLevel } from '../util/log';
 import { AutoId } from '../util/misc';
-import { _BaseFieldPath, FieldPath as ExternalFieldPath } from './field_path';
+import { FieldPath as ExpFieldPath } from '../../lite/src/api/field_path';
 import {
   CompleteFn,
   ErrorFn,
@@ -119,6 +119,7 @@ import {
   DocumentData as PublicDocumentData,
   DocumentReference as PublicDocumentReference,
   DocumentSnapshot as PublicDocumentSnapshot,
+  FieldPath as PublicFieldPath,
   FirebaseFirestore as PublicFirestore,
   FirestoreDataConverter as PublicFirestoreDataConverter,
   GetOptions as PublicGetOptions,
@@ -518,28 +519,33 @@ export class Transaction implements PublicTransaction {
   ): Transaction;
   update(
     documentRef: PublicDocumentReference<unknown>,
-    field: string | ExternalFieldPath,
+    field: string | PublicFieldPath,
     value: unknown,
     ...moreFieldsAndValues: unknown[]
   ): Transaction;
   update(
     documentRef: PublicDocumentReference<unknown>,
-    fieldOrUpdateData: string | ExternalFieldPath | PublicUpdateData,
+    fieldOrUpdateData: string | PublicFieldPath | PublicUpdateData,
     value?: unknown,
     ...moreFieldsAndValues: unknown[]
   ): Transaction {
-    let ref;
-    let parsed;
+    const ref = validateReference(
+      'Transaction.update',
+      documentRef,
+      this._firestore
+    );
 
+    // For Compat types, we have to "extract" the underlying types before
+    // performing validation.
+    if (fieldOrUpdateData instanceof Compat) {
+      fieldOrUpdateData = (fieldOrUpdateData as Compat<ExpFieldPath>)._delegate;
+    }
+
+    let parsed;
     if (
       typeof fieldOrUpdateData === 'string' ||
-      fieldOrUpdateData instanceof ExternalFieldPath
+      fieldOrUpdateData instanceof ExpFieldPath
     ) {
-      ref = validateReference(
-        'Transaction.update',
-        documentRef,
-        this._firestore
-      );
       parsed = parseUpdateVarargs(
         this._dataReader,
         'Transaction.update',
@@ -549,11 +555,6 @@ export class Transaction implements PublicTransaction {
         moreFieldsAndValues
       );
     } else {
-      ref = validateReference(
-        'Transaction.update',
-        documentRef,
-        this._firestore
-      );
       parsed = parseUpdateData(
         this._dataReader,
         'Transaction.update',
@@ -629,30 +630,34 @@ export class WriteBatch implements PublicWriteBatch {
   ): WriteBatch;
   update(
     documentRef: PublicDocumentReference<unknown>,
-    field: string | ExternalFieldPath,
+    field: string | PublicFieldPath,
     value: unknown,
     ...moreFieldsAndValues: unknown[]
   ): WriteBatch;
   update(
     documentRef: PublicDocumentReference<unknown>,
-    fieldOrUpdateData: string | ExternalFieldPath | PublicUpdateData,
+    fieldOrUpdateData: string | PublicFieldPath | PublicUpdateData,
     value?: unknown,
     ...moreFieldsAndValues: unknown[]
   ): WriteBatch {
     this.verifyNotCommitted();
+    const ref = validateReference(
+      'WriteBatch.update',
+      documentRef,
+      this._firestore
+    );
 
-    let ref;
+    // For Compat types, we have to "extract" the underlying types before
+    // performing validation.
+    if (fieldOrUpdateData instanceof Compat) {
+      fieldOrUpdateData = (fieldOrUpdateData as Compat<ExpFieldPath>)._delegate;
+    }
+
     let parsed;
-
     if (
       typeof fieldOrUpdateData === 'string' ||
-      fieldOrUpdateData instanceof ExternalFieldPath
+      fieldOrUpdateData instanceof ExpFieldPath
     ) {
-      ref = validateReference(
-        'WriteBatch.update',
-        documentRef,
-        this._firestore
-      );
       parsed = parseUpdateVarargs(
         this._dataReader,
         'WriteBatch.update',
@@ -662,11 +667,6 @@ export class WriteBatch implements PublicWriteBatch {
         moreFieldsAndValues
       );
     } else {
-      ref = validateReference(
-        'WriteBatch.update',
-        documentRef,
-        this._firestore
-      );
       parsed = parseUpdateData(
         this._dataReader,
         'WriteBatch.update',
@@ -825,26 +825,25 @@ export class DocumentReference<T = PublicDocumentData>
 
   update(value: PublicUpdateData): Promise<void>;
   update(
-    field: string | ExternalFieldPath,
+    field: string | PublicFieldPath,
     value: unknown,
     ...moreFieldsAndValues: unknown[]
   ): Promise<void>;
   update(
-    fieldOrUpdateData: string | ExternalFieldPath | PublicUpdateData,
+    fieldOrUpdateData: string | PublicFieldPath | PublicUpdateData,
     value?: unknown,
     ...moreFieldsAndValues: unknown[]
   ): Promise<void> {
     // For Compat types, we have to "extract" the underlying types before
     // performing validation.
     if (fieldOrUpdateData instanceof Compat) {
-      fieldOrUpdateData = (fieldOrUpdateData as Compat<_BaseFieldPath>)
-        ._delegate;
+      fieldOrUpdateData = (fieldOrUpdateData as Compat<ExpFieldPath>)._delegate;
     }
 
     let parsed;
     if (
       typeof fieldOrUpdateData === 'string' ||
-      fieldOrUpdateData instanceof _BaseFieldPath
+      fieldOrUpdateData instanceof ExpFieldPath
     ) {
       parsed = parseUpdateVarargs(
         this._dataReader,
@@ -1080,7 +1079,7 @@ export class DocumentSnapshot<T = PublicDocumentData>
   }
 
   get(
-    fieldPath: string | ExternalFieldPath,
+    fieldPath: string | PublicFieldPath,
     options: PublicSnapshotOptions = {}
   ): unknown {
     if (this._document) {
@@ -1556,7 +1555,7 @@ export class Query<T = PublicDocumentData> implements PublicQuery<T> {
   }
 
   where(
-    field: string | ExternalFieldPath,
+    field: string | PublicFieldPath,
     opStr: PublicWhereFilterOp,
     value: unknown
   ): PublicQuery<T> {
@@ -1578,7 +1577,7 @@ export class Query<T = PublicDocumentData> implements PublicQuery<T> {
   }
 
   orderBy(
-    field: string | ExternalFieldPath,
+    field: string | PublicFieldPath,
     directionStr?: PublicOrderByDirection
   ): PublicQuery<T> {
     let direction: Direction;

--- a/packages/firestore/test/integration/util/firebase_export.ts
+++ b/packages/firestore/test/integration/util/firebase_export.ts
@@ -34,6 +34,7 @@ import firebaseAppCompat from '@firebase/app-compat';
 
 import * as exp from '../../../exp/test/shim';
 import { FieldValue } from '../../../src/compat/field_value';
+import { FieldPath } from '../../../src/api/field_path';
 import { FirebaseApp } from '@firebase/app-types';
 import {
   Firestore,
@@ -115,9 +116,6 @@ export function newTestFirestore(
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const legacyNamespace = (firebase as any).firestore;
 
-const FieldPath = usesFunctionalApi()
-  ? exp.FieldPath
-  : legacyNamespace.FieldPath;
 const Timestamp = usesFunctionalApi()
   ? exp.Timestamp
   : legacyNamespace.Timestamp;

--- a/packages/firestore/test/util/helpers.ts
+++ b/packages/firestore/test/util/helpers.ts
@@ -22,7 +22,6 @@ import * as api from '../../src/protos/firestore_proto_api';
 import { expect } from 'chai';
 
 import { Blob } from '../../src/api/blob';
-import { fromDotSeparatedString } from '../../src/api/field_path';
 import { UserDataWriter } from '../../src/api/user_data_writer';
 import {
   parseQueryValue,
@@ -203,7 +202,7 @@ export function path(path: string, offset?: number): ResourcePath {
 }
 
 export function field(path: string): FieldPath {
-  return fromDotSeparatedString(path)._internalPath;
+  return new FieldPath(path.split('.'));
 }
 
 export function mask(...paths: string[]): FieldMask {


### PR DESCRIPTION
This PR removes the FieldPath class in the legacy class in favor of a Compat class that delegates to firestore-exp. It changes all callsites to accept either the Compat class or the firestore-exp FieldPath.