### PR TITLE
Update firestore types to allow specifying DocumentData type

### DIFF
--- a/packages/firestore-types/index.d.ts
+++ b/packages/firestore-types/index.d.ts
@@ -65,11 +65,11 @@ export class FirebaseFirestore {
 
   enablePersistence(settings?: PersistenceSettings): Promise<void>;
 
-  collection(collectionPath: string): CollectionReference<DocumentData>;
+  collection<T = DocumentData>(collectionPath: string): CollectionReference<T>;
 
-  doc(documentPath: string): DocumentReference<DocumentData>;
+  doc<T = DocumentData>(documentPath: string): DocumentReference<T>;
 
-  collectionGroup(collectionId: string): Query<DocumentData>;
+  collectionGroup<T = DocumentData>(collectionId: string): Query<T>;
 
   runTransaction<T>(
     updateFunction: (transaction: Transaction) => Promise<T>
@@ -210,7 +210,7 @@ export class DocumentReference<T = DocumentData> {
   readonly parent: CollectionReference<T>;
   readonly path: string;
 
-  collection(collectionPath: string): CollectionReference<DocumentData>;
+  collection<T = DocumentData>(collectionPath: string): CollectionReference<T>;
 
   isEqual(other: DocumentReference<T>): boolean;
 
@@ -396,11 +396,11 @@ export interface DocumentChange<T = DocumentData> {
   readonly newIndex: number;
 }
 
-export class CollectionReference<T = DocumentData> extends Query<T> {
+export class CollectionReference<T = DocumentData, P = DocumentData> extends Query<T> {
   private constructor();
 
   readonly id: string;
-  readonly parent: DocumentReference<DocumentData> | null;
+  readonly parent: DocumentReference<P> | null;
   readonly path: string;
 
   doc(documentPath?: string): DocumentReference<T>;


### PR DESCRIPTION
I thought this would be more helpful than an issue. Not 100% certain that this is correct, but it seems to work for me :) Thanks!

Before these changes, I was unable to specify the type of `.collection('id').get()`.