### PR TITLE
FirestoreClient cleanup

### DIFF
--- a/packages/firestore/src/core/firestore_client.ts
+++ b/packages/firestore/src/core/firestore_client.ts
@@ -485,7 +485,7 @@ export function firestoreClientTransaction<T>(
   return deferred.promise;
 }
 
-export async function readDocumentFromCache(
+async function readDocumentFromCache(
   localStore: LocalStore,
   docKey: DocumentKey,
   result: Deferred<Document | null>
@@ -520,7 +520,7 @@ export async function readDocumentFromCache(
  * Retrieves a latency-compensated document from the backend via a
  * SnapshotListener.
  */
-export function readDocumentViaSnapshotListener(
+function readDocumentViaSnapshotListener(
   eventManager: EventManager,
   asyncQueue: AsyncQueue,
   key: DocumentKey,
@@ -587,7 +587,7 @@ export function readDocumentViaSnapshotListener(
   return eventManagerListen(eventManager, listener);
 }
 
-export async function executeQueryFromCache(
+async function executeQueryFromCache(
   localStore: LocalStore,
   query: Query,
   result: Deferred<ViewSnapshot>
@@ -618,7 +618,7 @@ export async function executeQueryFromCache(
  * Retrieves a latency-compensated query snapshot from the backend via a
  * SnapshotListener.
  */
-export function executeQueryViaSnapshotListener(
+function executeQueryViaSnapshotListener(
   eventManager: EventManager,
   asyncQueue: AsyncQueue,
   query: Query,


### PR DESCRIPTION
This replaces a bunch of duplicate logic in firestore-exp with the FirestoreClient functions
