### PR TITLE
Fix DocumentChange.newIndex

### DIFF
--- a/.changeset/curvy-planets-sneeze.md
+++ b/.changeset/curvy-planets-sneeze.md
@@ -1,0 +1,5 @@
+---
+"@firebase/firestore": patch
+---
+
+Fixes a regression introduced in v8.0.2 that returned invalid values for `DocumentChange.newIndex`.

--- a/packages/firestore/src/api/database.ts
+++ b/packages/firestore/src/api/database.ts
@@ -1136,7 +1136,7 @@ export class DocumentChange<T = PublicDocumentData>
   }
 
   get newIndex(): number {
-    return this._delegate.oldIndex;
+    return this._delegate.newIndex;
   }
 }
 


### PR DESCRIPTION
8.0.2 contains a bug in DocumentChange.newIndex, which returns the oldIndex.

Fixes https://github.com/firebase/firebase-js-sdk/issues/4071
Fixes https://github.com/firebase/firebase-js-sdk/issues/4079