### PR TITLE
Fix issue with auto-redirect signin in auth-exp

### DIFF
--- a/packages-exp/auth-exp/src/core/auth/auth_impl.ts
+++ b/packages-exp/auth-exp/src/core/auth/auth_impl.ts
@@ -171,7 +171,7 @@ export class AuthImpl implements Auth, _FirebaseService {
   ): Promise<void> {
     // First check to see if we have a pending redirect event.
     let storedUser = (await this.assertedPersistence.getCurrentUser()) as User | null;
-    if (popupRedirectResolver) {
+    if (popupRedirectResolver && this.config.authDomain) {
       await this.getOrInitRedirectPersistenceManager();
       const redirectUserEventId = this.redirectUser?._redirectEventId;
       const storedUserEventId = storedUser?._redirectEventId;

--- a/packages-exp/auth-exp/src/platform_browser/auth.test.ts
+++ b/packages-exp/auth-exp/src/platform_browser/auth.test.ts
@@ -118,14 +118,15 @@ describe('core/auth/initializeAuth', () => {
 
     async function initAndWait(
       persistence: externs.Persistence | externs.Persistence[],
-      popupRedirectResolver?: externs.PopupRedirectResolver
+      popupRedirectResolver?: externs.PopupRedirectResolver,
+      authDomain = FAKE_APP.options.authDomain,
     ): Promise<externs.Auth> {
       const auth = new AuthImpl(FAKE_APP, {
         apiKey: FAKE_APP.options.apiKey!,
         apiHost: DefaultConfig.API_HOST,
         apiScheme: DefaultConfig.API_SCHEME,
         tokenApiHost: DefaultConfig.TOKEN_API_HOST,
-        authDomain: FAKE_APP.options.authDomain,
+        authDomain,
         sdkClientVersion: _getClientVersion(ClientPlatform.BROWSER)
       });
 
@@ -277,6 +278,11 @@ describe('core/auth/initializeAuth', () => {
 
         await initAndWait([inMemoryPersistence], browserPopupRedirectResolver);
         expect(stub._remove).to.have.been.called;
+      });
+
+      it('does not run redirect sign in attempt if authDomain not set', async () => {
+        await initAndWait([inMemoryPersistence], browserPopupRedirectResolver, '');
+        expect(completeRedirectFnStub).not.to.have.been.called;
       });
 
       it('signs in the redirect user if found', async () => {

--- a/packages-exp/auth-exp/src/platform_browser/auth.test.ts
+++ b/packages-exp/auth-exp/src/platform_browser/auth.test.ts
@@ -119,7 +119,7 @@ describe('core/auth/initializeAuth', () => {
     async function initAndWait(
       persistence: externs.Persistence | externs.Persistence[],
       popupRedirectResolver?: externs.PopupRedirectResolver,
-      authDomain = FAKE_APP.options.authDomain,
+      authDomain = FAKE_APP.options.authDomain
     ): Promise<externs.Auth> {
       const auth = new AuthImpl(FAKE_APP, {
         apiKey: FAKE_APP.options.apiKey!,
@@ -281,7 +281,11 @@ describe('core/auth/initializeAuth', () => {
       });
 
       it('does not run redirect sign in attempt if authDomain not set', async () => {
-        await initAndWait([inMemoryPersistence], browserPopupRedirectResolver, '');
+        await initAndWait(
+          [inMemoryPersistence],
+          browserPopupRedirectResolver,
+          ''
+        );
         expect(completeRedirectFnStub).not.to.have.been.called;
       });
 

--- a/packages-exp/auth-exp/src/platform_browser/iframe/iframe.ts
+++ b/packages-exp/auth-exp/src/platform_browser/iframe/iframe.ts
@@ -41,9 +41,10 @@ const IFRAME_ATTRIBUTES = {
 
 function getIframeUrl(auth: Auth): string {
   const config = auth.config;
+  _assert(config.authDomain, auth, AuthErrorCode.MISSING_AUTH_DOMAIN);
   const url = config.emulator
     ? _emulatorUrl(config, EMULATED_IFRAME_PATH)
-    : `https://${auth.config.authDomain!}/${IFRAME_PATH}`;
+    : `https://${auth.config.authDomain}/${IFRAME_PATH}`;
 
   const params = {
     apiKey: config.apiKey,


### PR DESCRIPTION
`getRedirectResult()` was hanging previously if `config.authDomain` wasn't set. This PR makes `getRedirectResult()` error if `config.authDomain` isn't available, and also skips the eager redirect path entirely if authDomain isn't available at initialization 