### PR TITLE
Meet peer dependency of @firebase/auth-interop-types

### DIFF
--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -30,12 +30,12 @@
     "@firebase/util": "0.3.4",
     "@firebase/component": "0.1.21",
     "@firebase/auth-interop-types": "0.1.5",
+    "@firebase/app-types": "0.6.1",
     "faye-websocket": "0.11.3",
     "tslib": "^1.11.1"
   },
   "devDependencies": {
     "@firebase/app": "0.6.13",
-    "@firebase/app-types": "0.6.1",
     "rollup": "2.33.2",
     "rollup-plugin-typescript2": "0.29.0",
     "typescript": "4.0.5"


### PR DESCRIPTION
`yarn` insists that any peer dependencies of packages you depend upon yourself, must also be included in your own dependencies. If not it will print warnings.

Currently the `@firebase/database` package depends upon `@firebase/auth-interop-types`, which has a peer dependency on `@firebase/app-types`. However `@firebase/app-types` is set as a dev dependency rather than a regular one resulting in a warning when installing `@firebase/database` or any package that depends upon it (since I know it's an internal package).
```
$ yarn add firebase-admin
yarn add v1.22.10
info No lockfile found.
[1/4] 🔍  Resolving packages...
[2/4] 🚚  Fetching packages...
[3/4] 🔗  Linking dependencies...
warning "firebase-admin > @firebase/database > @firebase/auth-interop-types@0.1.5" has unmet peer dependency "@firebase/app-types@0.x".
[4/4] 🔨  Building fresh packages...
```

This is quite annoying as projects that have a `firebase-admin` dependency get an unavoidable warning during installation (e.g. [taskline](https://github.com/perryrh0dan/taskline)) which can put users off.
<hr>

This has come up previously in regards to the `firebase` package (https://github.com/firebase/firebase-js-sdk/issues/1207 & https://github.com/firebase/firebase-js-sdk/issues/1794) and was fixed by @Feiyang1 in https://github.com/firebase/firebase-js-sdk/pull/1807. However, `firebase-admin` is still facing this issue. It was reported in the `firebase-admin` repo (https://github.com/firebase/firebase-admin-node/issues/973) but hasn't received any traction, possibly due to the fact the actual issue resides in this one.