### PR TITLE
Fix assertFails not recognising database permission denied error

### DIFF
--- a/.changeset/early-dots-peel.md
+++ b/.changeset/early-dots-peel.md
@@ -1,0 +1,5 @@
+---
+"@firebase/rules-unit-testing": patch
+---
+
+Fix assertFails not recognising database permission denied error

--- a/packages/rules-unit-testing/src/api/index.ts
+++ b/packages/rules-unit-testing/src/api/index.ts
@@ -454,9 +454,14 @@ export function assertFails(pr: Promise<any>): any {
       );
     },
     (err: any) => {
+      const errCode = (err && err.code && err.code.toLowerCase()) || '';
+      const errMessage =
+        (err && err.message && err.message.toLowerCase()) || '';
       const isPermissionDenied =
-        (err && err.message && err.message.indexOf('PERMISSION_DENIED') >= 0) ||
-        (err && err.code === 'permission-denied');
+        errCode === 'permission-denied' ||
+        errCode === 'permission_denied' ||
+        errMessage.indexOf('permission_denied') >= 0;
+
       if (!isPermissionDenied) {
         return Promise.reject(
           new Error(

--- a/packages/rules-unit-testing/test/database.test.ts
+++ b/packages/rules-unit-testing/test/database.test.ts
@@ -103,6 +103,31 @@ describe('Testing Module Tests', function () {
       .catch(() => {});
   });
 
+  it('assertFails() if code is PERMISSION_DENIED', async function () {
+    const success = Promise.resolve('success');
+    const permissionDenied = Promise.reject({
+      code: 'PERMISSION_DENIED'
+    });
+    const otherFailure = Promise.reject('failure');
+    await firebase
+      .assertFails(success)
+      .then(() => {
+        throw new Error('Expected success to fail.');
+      })
+      .catch(() => {});
+
+    await firebase.assertFails(permissionDenied).catch(() => {
+      throw new Error('Expected permissionDenied to succeed.');
+    });
+
+    await firebase
+      .assertFails(otherFailure)
+      .then(() => {
+        throw new Error('Expected otherFailure to fail.');
+      })
+      .catch(() => {});
+  });
+
   it('initializeTestApp() with auth=null does not set access token', async function () {
     const app = firebase.initializeTestApp({
       projectId: 'foo',


### PR DESCRIPTION
```assertFails``` does not recognise the permission denied error from database ```once('value')```

example
```
const app = firebase.initializeTestApp({
  databaseName,
  auth: { uid: 'alice' },
})
app
  .database()
  .ref('secrets/bob/id')
  .once('value')
  .then((snapshot) => {
    console.log('read succeeded')
  })
  .catch((err) => {
    console.log('read failed')
    // current implementation of isPermissionDenied 
    // https://github.com/firebase/firebase-js-sdk/blob/d934f74d6750dc31cca480e126757d53935cefcd/packages/rules-unit-testing/src/api/index.ts#L457
    const isPermissionDenied =
      (err && err.message && err.message.indexOf('PERMISSION_DENIED') >= 0) ||
      (err && err.code === 'permission-denied')
    console.log(`isPermissionDenied ${isPermissionDenied}`)
    console.log(JSON.stringify({ message: err.message, ...err }, null, 2))
  })
```
output:
```
read failed
isPermissionDenied false
{
  "message": "permission_denied at /secrets/bob/id: Client doesn't have permission to access the desired data.",
  "code": "PERMISSION_DENIED"
}
```