### PR TITLE
Don't use namespace imports

### DIFF
--- a/packages/firestore/src/core/bundle.ts
+++ b/packages/firestore/src/core/bundle.ts
@@ -23,7 +23,11 @@ import {
   fromVersion,
   JsonProtoSerializer
 } from '../remote/serializer';
-import { NamedQuery as ProtoNamedQuery, BundleMetadata as ProtoBundleMetadata, BundledDocumentMetadata as ProtoBundledDocumentMetadata} from '../protos/firestore_bundle_proto';
+import {
+  NamedQuery as ProtoNamedQuery,
+  BundleMetadata as ProtoBundleMetadata,
+  BundledDocumentMetadata as ProtoBundledDocumentMetadata
+} from '../protos/firestore_bundle_proto';
 import * as api from '../protos/firestore_proto_api';
 import { DocumentKey } from '../model/document_key';
 import { MaybeDocument, NoDocument } from '../model/document';

--- a/packages/firestore/src/core/bundle.ts
+++ b/packages/firestore/src/core/bundle.ts
@@ -23,7 +23,7 @@ import {
   fromVersion,
   JsonProtoSerializer
 } from '../remote/serializer';
-import * as bundleProto from '../protos/firestore_bundle_proto';
+import { NamedQuery as ProtoNamedQuery, BundleMetadata as ProtoBundleMetadata, BundledDocumentMetadata as ProtoBundledDocumentMetadata} from '../protos/firestore_bundle_proto';
 import { BundleMetadata } from '../protos/firestore_bundle_proto';
 import * as api from '../protos/firestore_proto_api';
 import { DocumentKey } from '../model/document_key';
@@ -70,7 +70,7 @@ export interface NamedQuery {
  * itself, if it exists.
  */
 interface BundledDocument {
-  metadata: bundleProto.BundledDocumentMetadata;
+  metadata: ProtoBundledDocumentMetadata;
   document?: api.Document;
 }
 
@@ -159,12 +159,12 @@ export class BundleLoader {
   /** The current progress of loading */
   private progress: ApiLoadBundleTaskProgress;
   /** Batched queries to be saved into storage */
-  private queries: bundleProto.NamedQuery[] = [];
+  private queries: ProtoNamedQuery[] = [];
   /** Batched documents to be saved into storage */
   private documents: BundledDocuments = [];
 
   constructor(
-    private bundleMetadata: bundleProto.BundleMetadata,
+    private bundleMetadata: ProtoBundleMetadata,
     private localStore: LocalStore,
     private serializer: JsonProtoSerializer
   ) {

--- a/packages/firestore/src/core/bundle.ts
+++ b/packages/firestore/src/core/bundle.ts
@@ -24,7 +24,6 @@ import {
   JsonProtoSerializer
 } from '../remote/serializer';
 import { NamedQuery as ProtoNamedQuery, BundleMetadata as ProtoBundleMetadata, BundledDocumentMetadata as ProtoBundledDocumentMetadata} from '../protos/firestore_bundle_proto';
-import { BundleMetadata } from '../protos/firestore_bundle_proto';
 import * as api from '../protos/firestore_proto_api';
 import { DocumentKey } from '../model/document_key';
 import { MaybeDocument, NoDocument } from '../model/document';
@@ -117,7 +116,7 @@ export class BundleConverter {
  * loading a bundle.
  */
 export function bundleInitialProgress(
-  metadata: BundleMetadata
+  metadata: ProtoBundleMetadata
 ): ApiLoadBundleTaskProgress {
   return {
     taskState: 'Running',
@@ -133,7 +132,7 @@ export function bundleInitialProgress(
  * has succeeded.
  */
 export function bundleSuccessProgress(
-  metadata: BundleMetadata
+  metadata: ProtoBundleMetadata
 ): ApiLoadBundleTaskProgress {
   return {
     taskState: 'Success',

--- a/packages/firestore/src/local/bundle_cache.ts
+++ b/packages/firestore/src/local/bundle_cache.ts
@@ -17,7 +17,7 @@
 
 import { PersistenceTransaction } from './persistence';
 import { PersistencePromise } from './persistence_promise';
-import * as bundleProto from '../protos/firestore_bundle_proto';
+import { NamedQuery as ProtoNamedQuery, BundleMetadata as ProtoBundleMetadata} from '../protos/firestore_bundle_proto';
 import { Bundle, NamedQuery } from '../core/bundle';
 
 /**
@@ -39,7 +39,7 @@ export interface BundleCache {
    */
   saveBundleMetadata(
     transaction: PersistenceTransaction,
-    metadata: bundleProto.BundleMetadata
+    metadata: ProtoBundleMetadata
   ): PersistencePromise<void>;
 
   /**
@@ -56,6 +56,6 @@ export interface BundleCache {
    */
   saveNamedQuery(
     transaction: PersistenceTransaction,
-    query: bundleProto.NamedQuery
+    query: ProtoNamedQuery
   ): PersistencePromise<void>;
 }

--- a/packages/firestore/src/local/bundle_cache.ts
+++ b/packages/firestore/src/local/bundle_cache.ts
@@ -17,7 +17,10 @@
 
 import { PersistenceTransaction } from './persistence';
 import { PersistencePromise } from './persistence_promise';
-import { NamedQuery as ProtoNamedQuery, BundleMetadata as ProtoBundleMetadata} from '../protos/firestore_bundle_proto';
+import {
+  NamedQuery as ProtoNamedQuery,
+  BundleMetadata as ProtoBundleMetadata
+} from '../protos/firestore_bundle_proto';
 import { Bundle, NamedQuery } from '../core/bundle';
 
 /**

--- a/packages/firestore/src/local/indexeddb_bundle_cache.ts
+++ b/packages/firestore/src/local/indexeddb_bundle_cache.ts
@@ -17,7 +17,7 @@
 
 import { PersistenceTransaction } from './persistence';
 import { PersistencePromise } from './persistence_promise';
-import * as bundleProto from '../protos/firestore_bundle_proto';
+import { NamedQuery as ProtoNamedQuery, BundleMetadata as ProtoBundleMetadata} from '../protos/firestore_bundle_proto';
 import { BundleCache } from './bundle_cache';
 import {
   DbBundle,
@@ -55,7 +55,7 @@ export class IndexedDbBundleCache implements BundleCache {
 
   saveBundleMetadata(
     transaction: PersistenceTransaction,
-    bundleMetadata: bundleProto.BundleMetadata
+    bundleMetadata: ProtoBundleMetadata
   ): PersistencePromise<void> {
     return bundlesStore(transaction).put(toDbBundle(bundleMetadata));
   }
@@ -76,7 +76,7 @@ export class IndexedDbBundleCache implements BundleCache {
 
   saveNamedQuery(
     transaction: PersistenceTransaction,
-    query: bundleProto.NamedQuery
+    query: ProtoNamedQuery
   ): PersistencePromise<void> {
     return namedQueriesStore(transaction).put(toDbNamedQuery(query));
   }

--- a/packages/firestore/src/local/indexeddb_bundle_cache.ts
+++ b/packages/firestore/src/local/indexeddb_bundle_cache.ts
@@ -17,7 +17,10 @@
 
 import { PersistenceTransaction } from './persistence';
 import { PersistencePromise } from './persistence_promise';
-import { NamedQuery as ProtoNamedQuery, BundleMetadata as ProtoBundleMetadata} from '../protos/firestore_bundle_proto';
+import {
+  NamedQuery as ProtoNamedQuery,
+  BundleMetadata as ProtoBundleMetadata
+} from '../protos/firestore_bundle_proto';
 import { BundleCache } from './bundle_cache';
 import {
   DbBundle,

--- a/packages/firestore/src/local/local_serializer.ts
+++ b/packages/firestore/src/local/local_serializer.ts
@@ -57,7 +57,7 @@ import {
 import { TargetData, TargetPurpose } from './target_data';
 import { Bundle, NamedQuery } from '../core/bundle';
 import { LimitType, Query, queryWithLimit } from '../core/query';
-import { BundleMetadata as ProtoBundleMetadata} from '../protos/firestore_bundle_proto';
+import { BundleMetadata as ProtoBundleMetadata } from '../protos/firestore_bundle_proto';
 
 /** Serializer for values stored in the LocalStore. */
 export class LocalSerializer {

--- a/packages/firestore/src/local/local_serializer.ts
+++ b/packages/firestore/src/local/local_serializer.ts
@@ -57,7 +57,11 @@ import {
 import { TargetData, TargetPurpose } from './target_data';
 import { Bundle, NamedQuery } from '../core/bundle';
 import { LimitType, Query, queryWithLimit } from '../core/query';
-import { BundleMetadata as ProtoBundleMetadata } from '../protos/firestore_bundle_proto';
+import {
+  BundleMetadata as ProtoBundleMetadata,
+  NamedQuery as ProtoNamedQuery,
+  BundledQuery as ProtoBundledQuery
+} from '../protos/firestore_bundle_proto';
 
 /** Serializer for values stored in the LocalStore. */
 export class LocalSerializer {
@@ -307,7 +311,7 @@ export function fromDbNamedQuery(dbNamedQuery: DbNamedQuery): NamedQuery {
 }
 
 /** Encodes a NamedQuery from a bundle proto to a DbNamedQuery. */
-export function toDbNamedQuery(query: bundleProto.NamedQuery): DbNamedQuery {
+export function toDbNamedQuery(query: ProtoNamedQuery): DbNamedQuery {
   return {
     name: query.name!,
     readTime: toDbTimestamp(fromVersion(query.readTime!)),
@@ -321,9 +325,7 @@ export function toDbNamedQuery(query: bundleProto.NamedQuery): DbNamedQuery {
  * This reconstructs the original query used to build the bundle being loaded,
  * including features exists only in SDKs (for example: limit-to-last).
  */
-export function fromBundledQuery(
-  bundledQuery: bundleProto.BundledQuery
-): Query {
+export function fromBundledQuery(bundledQuery: ProtoBundledQuery): Query {
   const query = convertQueryTargetToQuery({
     parent: bundledQuery.parent!,
     structuredQuery: bundledQuery.structuredQuery!
@@ -339,9 +341,7 @@ export function fromBundledQuery(
 }
 
 /** Encodes a NamedQuery proto object to a NamedQuery model object. */
-export function fromProtoNamedQuery(
-  namedQuery: bundleProto.NamedQuery
-): NamedQuery {
+export function fromProtoNamedQuery(namedQuery: ProtoNamedQuery): NamedQuery {
   return {
     name: namedQuery.name!,
     query: fromBundledQuery(namedQuery.bundledQuery!),
@@ -350,9 +350,7 @@ export function fromProtoNamedQuery(
 }
 
 /** Encodes a BundleMetadata proto object to a Bundle model object. */
-export function fromBundleMetadata(
-  metadata: bundleProto.BundleMetadata
-): Bundle {
+export function fromBundleMetadata(metadata: ProtoBundleMetadata): Bundle {
   return {
     id: metadata.id!,
     version: metadata.version!,

--- a/packages/firestore/src/local/local_serializer.ts
+++ b/packages/firestore/src/local/local_serializer.ts
@@ -57,7 +57,7 @@ import {
 import { TargetData, TargetPurpose } from './target_data';
 import { Bundle, NamedQuery } from '../core/bundle';
 import { LimitType, Query, queryWithLimit } from '../core/query';
-import * as bundleProto from '../protos/firestore_bundle_proto';
+import { BundleMetadata as ProtoBundleMetadata} from '../protos/firestore_bundle_proto';
 
 /** Serializer for values stored in the LocalStore. */
 export class LocalSerializer {
@@ -289,7 +289,7 @@ export function fromDbBundle(dbBundle: DbBundle): Bundle {
 }
 
 /** Encodes a BundleMetadata to a DbBundle. */
-export function toDbBundle(metadata: bundleProto.BundleMetadata): DbBundle {
+export function toDbBundle(metadata: ProtoBundleMetadata): DbBundle {
   return {
     bundleId: metadata.id!,
     createTime: toDbTimestamp(fromVersion(metadata.createTime!)),

--- a/packages/firestore/src/local/local_store.ts
+++ b/packages/firestore/src/local/local_store.ts
@@ -76,7 +76,7 @@ import {
 import { IndexedDbTargetCache } from './indexeddb_target_cache';
 import { extractFieldMask } from '../model/object_value';
 import { isIndexedDbTransactionError } from './simple_db';
-import * as bundleProto from '../protos/firestore_bundle_proto';
+import { NamedQuery as ProtoNamedQuery, BundleMetadata as ProtoBundleMetadata} from '../protos/firestore_bundle_proto';
 import { BundleConverter, BundledDocuments, NamedQuery } from '../core/bundle';
 import { BundleCache } from './bundle_cache';
 import { fromVersion, JsonProtoSerializer } from '../remote/serializer';
@@ -1370,7 +1370,7 @@ export async function applyBundleDocuments(
  */
 export function hasNewerBundle(
   localStore: LocalStore,
-  bundleMetadata: bundleProto.BundleMetadata
+  bundleMetadata: ProtoBundleMetadata
 ): Promise<boolean> {
   const localStoreImpl = debugCast(localStore, LocalStoreImpl);
   const bundleConverter = new BundleConverter(localStoreImpl.serializer);
@@ -1395,7 +1395,7 @@ export function hasNewerBundle(
  */
 export function saveBundle(
   localStore: LocalStore,
-  bundleMetadata: bundleProto.BundleMetadata
+  bundleMetadata: ProtoBundleMetadata
 ): Promise<void> {
   const localStoreImpl = debugCast(localStore, LocalStoreImpl);
   return localStoreImpl.persistence.runTransaction(
@@ -1432,7 +1432,7 @@ export function getNamedQuery(
  */
 export async function saveNamedQuery(
   localStore: LocalStore,
-  query: bundleProto.NamedQuery,
+  query: ProtoNamedQuery,
   documents: DocumentKeySet = documentKeySet()
 ): Promise<void> {
   // Allocate a target for the named query such that it can be resumed

--- a/packages/firestore/src/local/local_store.ts
+++ b/packages/firestore/src/local/local_store.ts
@@ -76,7 +76,10 @@ import {
 import { IndexedDbTargetCache } from './indexeddb_target_cache';
 import { extractFieldMask } from '../model/object_value';
 import { isIndexedDbTransactionError } from './simple_db';
-import { NamedQuery as ProtoNamedQuery, BundleMetadata as ProtoBundleMetadata} from '../protos/firestore_bundle_proto';
+import {
+  NamedQuery as ProtoNamedQuery,
+  BundleMetadata as ProtoBundleMetadata
+} from '../protos/firestore_bundle_proto';
 import { BundleConverter, BundledDocuments, NamedQuery } from '../core/bundle';
 import { BundleCache } from './bundle_cache';
 import { fromVersion, JsonProtoSerializer } from '../remote/serializer';

--- a/packages/firestore/src/local/memory_bundle_cache.ts
+++ b/packages/firestore/src/local/memory_bundle_cache.ts
@@ -17,7 +17,7 @@
 
 import { PersistenceTransaction } from './persistence';
 import { PersistencePromise } from './persistence_promise';
-import * as bundleProto from '../protos/firestore_bundle_proto';
+import { NamedQuery as ProtoNamedQuery, BundleMetadata as ProtoBundleMetadata} from '../protos/firestore_bundle_proto';
 import { BundleCache } from './bundle_cache';
 import { Bundle, NamedQuery } from '../core/bundle';
 import {
@@ -41,7 +41,7 @@ export class MemoryBundleCache implements BundleCache {
 
   saveBundleMetadata(
     transaction: PersistenceTransaction,
-    bundleMetadata: bundleProto.BundleMetadata
+    bundleMetadata: ProtoBundleMetadata
   ): PersistencePromise<void> {
     this.bundles.set(bundleMetadata.id!, fromBundleMetadata(bundleMetadata));
     return PersistencePromise.resolve();
@@ -56,7 +56,7 @@ export class MemoryBundleCache implements BundleCache {
 
   saveNamedQuery(
     transaction: PersistenceTransaction,
-    query: bundleProto.NamedQuery
+    query: ProtoNamedQuery
   ): PersistencePromise<void> {
     this.namedQueries.set(query.name!, fromProtoNamedQuery(query));
     return PersistencePromise.resolve();

--- a/packages/firestore/src/local/memory_bundle_cache.ts
+++ b/packages/firestore/src/local/memory_bundle_cache.ts
@@ -17,7 +17,10 @@
 
 import { PersistenceTransaction } from './persistence';
 import { PersistencePromise } from './persistence_promise';
-import { NamedQuery as ProtoNamedQuery, BundleMetadata as ProtoBundleMetadata} from '../protos/firestore_bundle_proto';
+import {
+  NamedQuery as ProtoNamedQuery,
+  BundleMetadata as ProtoBundleMetadata
+} from '../protos/firestore_bundle_proto';
 import { BundleCache } from './bundle_cache';
 import { Bundle, NamedQuery } from '../core/bundle';
 import {

--- a/packages/firestore/test/unit/local/local_store.test.ts
+++ b/packages/firestore/test/unit/local/local_store.test.ts
@@ -115,7 +115,7 @@ import * as persistenceHelpers from './persistence_test_helpers';
 import { JSON_SERIALIZER } from './persistence_test_helpers';
 import { ByteString } from '../../../src/util/byte_string';
 import { BundledDocuments, NamedQuery } from '../../../src/core/bundle';
-import { BundleMetadata as ProtoBundleMetadata} from '../../../src/protos/firestore_bundle_proto';
+import { BundleMetadata as ProtoBundleMetadata } from '../../../src/protos/firestore_bundle_proto';
 
 export interface LocalStoreComponents {
   queryEngine: CountingQueryEngine;

--- a/packages/firestore/test/unit/local/local_store.test.ts
+++ b/packages/firestore/test/unit/local/local_store.test.ts
@@ -115,7 +115,7 @@ import * as persistenceHelpers from './persistence_test_helpers';
 import { JSON_SERIALIZER } from './persistence_test_helpers';
 import { ByteString } from '../../../src/util/byte_string';
 import { BundledDocuments, NamedQuery } from '../../../src/core/bundle';
-import * as bundleProto from '../../../src/protos/firestore_bundle_proto';
+import { BundleMetadata as ProtoBundleMetadata} from '../../../src/protos/firestore_bundle_proto';
 
 export interface LocalStoreComponents {
   queryEngine: CountingQueryEngine;
@@ -473,7 +473,7 @@ class LocalStoreTester {
   }
 
   toHaveNewerBundle(
-    metadata: bundleProto.BundleMetadata,
+    metadata: ProtoBundleMetadata,
     expected: boolean
   ): LocalStoreTester {
     this.promiseChain = this.promiseChain.then(() => {
@@ -496,7 +496,7 @@ class LocalStoreTester {
     return this;
   }
 
-  afterSavingBundle(metadata: bundleProto.BundleMetadata): LocalStoreTester {
+  afterSavingBundle(metadata: ProtoBundleMetadata): LocalStoreTester {
     this.promiseChain = this.promiseChain.then(() =>
       saveBundle(this.localStore, metadata)
     );

--- a/packages/firestore/test/unit/local/test_bundle_cache.ts
+++ b/packages/firestore/test/unit/local/test_bundle_cache.ts
@@ -18,7 +18,10 @@
 import { Persistence } from '../../../src/local/persistence';
 import { BundleCache } from '../../../src/local/bundle_cache';
 import { Bundle, NamedQuery } from '../../../src/core/bundle';
-import { NamedQuery as ProtoNamedQuery, BundleMetadata as ProtoBundleMetadata} from '../../../src/protos/firestore_bundle_proto';
+import {
+  NamedQuery as ProtoNamedQuery,
+  BundleMetadata as ProtoBundleMetadata
+} from '../../../src/protos/firestore_bundle_proto';
 
 /**
  * A wrapper around a BundleCache that automatically creates a

--- a/packages/firestore/test/unit/local/test_bundle_cache.ts
+++ b/packages/firestore/test/unit/local/test_bundle_cache.ts
@@ -18,7 +18,7 @@
 import { Persistence } from '../../../src/local/persistence';
 import { BundleCache } from '../../../src/local/bundle_cache';
 import { Bundle, NamedQuery } from '../../../src/core/bundle';
-import * as bundleProto from '../../../src/protos/firestore_bundle_proto';
+import { NamedQuery as ProtoNamedQuery, BundleMetadata as ProtoBundleMetadata} from '../../../src/protos/firestore_bundle_proto';
 
 /**
  * A wrapper around a BundleCache that automatically creates a
@@ -41,7 +41,7 @@ export class TestBundleCache {
     );
   }
 
-  saveBundleMetadata(metadata: bundleProto.BundleMetadata): Promise<void> {
+  saveBundleMetadata(metadata: ProtoBundleMetadata): Promise<void> {
     return this.persistence.runTransaction(
       'saveBundleMetadata',
       'readwrite',
@@ -61,7 +61,7 @@ export class TestBundleCache {
     );
   }
 
-  setNamedQuery(query: bundleProto.NamedQuery): Promise<void> {
+  setNamedQuery(query: ProtoNamedQuery): Promise<void> {
     return this.persistence.runTransaction(
       'setNamedQuery',
       'readwrite',

--- a/packages/firestore/test/util/helpers.ts
+++ b/packages/firestore/test/util/helpers.ts
@@ -112,7 +112,7 @@ import {
   TEST_DATABASE_ID
 } from '../unit/local/persistence_test_helpers';
 import { BundledDocuments } from '../../src/core/bundle';
-import * as bundleProto from '../../src/protos/firestore_bundle_proto';
+import { NamedQuery as ProtoNamedQuery, BundleMetadata as ProtoBundleMetadata, LimitType as ProtoLimitType} from '../../src/protos/firestore_bundle_proto';
 
 /* eslint-disable no-restricted-globals */
 
@@ -456,7 +456,7 @@ export function bundledDocuments(
 
 export class TestNamedQuery {
   constructor(
-    public namedQuery: bundleProto.NamedQuery,
+    public namedQuery: ProtoNamedQuery,
     public matchingDocuments: DocumentKeySet
   ) {}
 }
@@ -464,7 +464,7 @@ export class TestNamedQuery {
 export function namedQuery(
   name: string,
   query: Query,
-  limitType: bundleProto.LimitType,
+  limitType: ProtoLimitType,
   readTime: SnapshotVersion,
   matchingDocuments: DocumentKeySet = documentKeySet()
 ): TestNamedQuery {
@@ -489,7 +489,7 @@ export function bundleMetadata(
   version = 1,
   totalDocuments = 1,
   totalBytes = 1000
-): bundleProto.BundleMetadata {
+): ProtoBundleMetadata {
   return {
     id,
     createTime: { seconds: createTime, nanos: 0 },

--- a/packages/firestore/test/util/helpers.ts
+++ b/packages/firestore/test/util/helpers.ts
@@ -112,7 +112,11 @@ import {
   TEST_DATABASE_ID
 } from '../unit/local/persistence_test_helpers';
 import { BundledDocuments } from '../../src/core/bundle';
-import { NamedQuery as ProtoNamedQuery, BundleMetadata as ProtoBundleMetadata, LimitType as ProtoLimitType} from '../../src/protos/firestore_bundle_proto';
+import {
+  NamedQuery as ProtoNamedQuery,
+  BundleMetadata as ProtoBundleMetadata,
+  LimitType as ProtoLimitType
+} from '../../src/protos/firestore_bundle_proto';
 
 /* eslint-disable no-restricted-globals */
 


### PR DESCRIPTION
The namespace imports don't work well with APIExtractor, which we want to use to generate API docs
