### PR TITLE
API Extractor Doc fixes

### DIFF
--- a/packages/firestore/exp/src/api/database.ts
+++ b/packages/firestore/exp/src/api/database.ts
@@ -76,6 +76,7 @@ export class FirebaseFirestore
 
   _firestoreClient: FirestoreClient | undefined;
 
+  /** @hideconstructor */
   constructor(
     databaseIdOrApp: DatabaseId | FirebaseApp,
     authProvider: Provider<FirebaseAuthInternalName>
@@ -98,13 +99,13 @@ export class FirebaseFirestore
 /**
  * Initializes a new instance of Cloud Firestore with the provided settings.
  * Can only be called before any other function, including
- * {@link getFirestore()}. If the custom settings are empty, this function is
- * equivalent to calling {@link getFirestore()}.
+ * {@link getFirestore}. If the custom settings are empty, this function is
+ * equivalent to calling {@link getFirestore}.
  *
- * @param app The {@link FirebaseApp} with which the `Firestore` instance will
+ * @param app - The {@link FirebaseApp} with which the `Firestore` instance will
  * be associated.
- * @param settings A settings object to configure the `Firestore` instance.
- * @return A newly initialized `Firestore` instance.
+ * @param settings - A settings object to configure the `Firestore` instance.
+ * @returns A newly initialized `Firestore` instance.
  */
 export function initializeFirestore(
   app: FirebaseApp,
@@ -135,9 +136,9 @@ export function initializeFirestore(
  * provided {@link FirebaseApp}. If no instance exists, initializes a new
  * instance with default settings.
  *
- * @param app The {@link FirebaseApp} instance that the returned Firestore
+ * @param app - The {@link FirebaseApp} instance that the returned Firestore
  * instance is associated with.
- * @return The `Firestore` instance of the provided app.
+ * @returns The `Firestore` instance of the provided app.
  */
 export function getFirestore(app: FirebaseApp): FirebaseFirestore {
   return _getProvider(app, 'firestore-exp').getImmediate() as FirebaseFirestore;
@@ -147,8 +148,8 @@ export function getFirestore(app: FirebaseApp): FirebaseFirestore {
  * Attempts to enable persistent storage, if possible.
  *
  * Must be called before any other functions (other than
- * {@link initializeFirestore()}, {@link getFirestore()} or
- * {@link clearIndexedDbPersistence()}.
+ * {@link initializeFirestore}, {@link getFirestore} or
+ * {@link clearIndexedDbPersistence}.
  *
  * If this fails, `enableIndexedDbPersistence()` will reject the promise it
  * returns. Note that even after this failure, the `Firestore` instance will
@@ -161,9 +162,10 @@ export function getFirestore(app: FirebaseApp): FirebaseFirestore {
  *   * unimplemented: The browser is incompatible with the offline
  *     persistence implementation.
  *
- * @param firestore The `Firestore` instance to enable persistence for.
- * @param persistenceSettings Optional settings object to configure persistence.
- * @return A promise that represents successfully enabling persistent storage.
+ * @param firestore - The `Firestore` instance to enable persistence for.
+ * @param persistenceSettings - Optional settings object to configure
+ * persistence.
+ * @returns A promise that represents successfully enabling persistent storage.
  */
 export function enableIndexedDbPersistence(
   firestore: FirebaseFirestore,
@@ -205,8 +207,8 @@ export function enableIndexedDbPersistence(
  *   * unimplemented: The browser is incompatible with the offline
  *     persistence implementation.
  *
- * @param firestore The `Firestore` instance to enable persistence for.
- * @return A promise that represents successfully enabling persistent
+ * @param firestore - The `Firestore` instance to enable persistence for.
+ * @returns A promise that represents successfully enabling persistent
  * storage.
  */
 export function enableMultiTabIndexedDbPersistence(
@@ -307,7 +309,7 @@ function canFallbackFromIndexedDbError(
  * Must be called while the `Firestore` instance is not started (after the app is
  * terminated or when the app is first initialized). On startup, this function
  * must be called before other functions (other than {@link
- * initializeFirestore()} or {@link getFirestore()})). If the `Firestore`
+ * initializeFirestore} or {@link getFirestore})). If the `Firestore`
  * instance is still running, the promise will be rejected with the error code
  * of `failed-precondition`.
  *
@@ -318,8 +320,8 @@ function canFallbackFromIndexedDbError(
  * to the disclosure of cached data in between user sessions, we strongly
  * recommend not enabling persistence at all.
  *
- * @param firestore The `Firestore` instance to clear persistence for.
- * @return A promise that is resolved when the persistent storage is
+ * @param firestore - The `Firestore` instance to clear persistence for.
+ * @returns A promise that is resolved when the persistent storage is
  * cleared. Otherwise, the promise is rejected with an error.
  */
 export function clearIndexedDbPersistence(
@@ -360,7 +362,7 @@ export function clearIndexedDbPersistence(
  * Any outstanding `waitForPendingWrites()` Promises are rejected during user
  * changes.
  *
- * @return A Promise which resolves when all currently pending writes have been
+ * @returns A Promise which resolves when all currently pending writes have been
  * acknowledged by the backend.
  */
 export function waitForPendingWrites(
@@ -372,9 +374,9 @@ export function waitForPendingWrites(
 
 /**
  * Re-enables use of the network for this Firestore instance after a prior
- * call to {@link disableNetwork()}.
+ * call to {@link disableNetwork}.
  *
- * @return A promise that is resolved once the network has been enabled.
+ * @returns A promise that is resolved once the network has been enabled.
  */
 export function enableNetwork(firestore: FirebaseFirestore): Promise<void> {
   const client = ensureFirestoreConfigured(firestore);
@@ -383,11 +385,11 @@ export function enableNetwork(firestore: FirebaseFirestore): Promise<void> {
 
 /**
  * Disables network usage for this instance. It can be re-enabled via {@link
- * enableNetwork()}. While the network is disabled, any snapshot listeners,
+ * enableNetwork}. While the network is disabled, any snapshot listeners,
  * `getDoc()` or `getDocs()` calls will return results from cache, and any write
  * operations will be queued until the network is restored.
  *
- * @return A promise that is resolved once the network has been disabled.
+ * @returns A promise that is resolved once the network has been disabled.
  */
 export function disableNetwork(firestore: FirebaseFirestore): Promise<void> {
   const client = ensureFirestoreConfigured(firestore);
@@ -401,7 +403,7 @@ export function disableNetwork(firestore: FirebaseFirestore): Promise<void> {
  * may be used. Any other function will throw a `FirestoreError`.
  *
  * To restart after termination, create a new instance of FirebaseFirestore with
- * {@link getFirestore()}.
+ * {@link getFirestore}.
  *
  * Termination does not cancel any pending writes, and any promises that are
  * awaiting a response from the server will not be resolved. If you have
@@ -413,7 +415,7 @@ export function disableNetwork(firestore: FirebaseFirestore): Promise<void> {
  * of its resources or in combination with `clearIndexedDbPersistence()` to
  * ensure that all local state is destroyed between test runs.
  *
- * @return A promise that is resolved when the instance has been successfully
+ * @returns A promise that is resolved when the instance has been successfully
  * terminated.
  */
 export function terminate(firestore: FirebaseFirestore): Promise<void> {

--- a/packages/firestore/exp/src/api/reference.ts
+++ b/packages/firestore/exp/src/api/reference.ts
@@ -104,7 +104,7 @@ export {
 } from '../../../lite/src/api/reference';
 
 /**
- * An options object that can be passed to {@link onSnapshot()} and {@link
+ * An options object that can be passed to {@link onSnapshot} and {@link
  * QuerySnapshot#docChanges} to control which types of changes to include in the
  * result set.
  */
@@ -122,10 +122,10 @@ export interface SnapshotListenOptions {
  * Note: `getDoc()` attempts to provide up-to-date data when possible by waiting
  * for data from the server, but it may return cached data or fail if you are
  * offline and the server cannot be reached. To specify this behavior, invoke
- * {@link getDocFromCache()} or {@link getDocFromServer()}.
+ * {@link getDocFromCache} or {@link getDocFromServer}.
  *
- * @param reference The reference of the document to fetch.
- * @return A Promise resolved with a `DocumentSnapshot` containing the
+ * @param reference - The reference of the document to fetch.
+ * @returns A Promise resolved with a `DocumentSnapshot` containing the
  * current document contents.
  */
 export function getDoc<T>(
@@ -169,7 +169,7 @@ export class ExpUserDataWriter extends AbstractUserDataWriter {
  * Reads the document referred to by this `DocumentReference` from cache.
  * Returns an error if the document is not currently cached.
  *
- * @return A Promise resolved with a `DocumentSnapshot` containing the
+ * @returns A Promise resolved with a `DocumentSnapshot` containing the
  * current document contents.
  */
 export function getDocFromCache<T>(
@@ -204,7 +204,7 @@ export function getDocFromCache<T>(
  * Reads the document referred to by this `DocumentReference` from the server.
  * Returns an error if the network is not available.
  *
- * @return A Promise resolved with a `DocumentSnapshot` containing the
+ * @returns A Promise resolved with a `DocumentSnapshot` containing the
  * current document contents.
  */
 export function getDocFromServer<T>(
@@ -235,9 +235,9 @@ export function getDocFromServer<T>(
  * Note: `getDocs()` attempts to provide up-to-date data when possible by
  * waiting for data from the server, but it may return cached data or fail if
  * you are offline and the server cannot be reached. To specify this behavior,
- * invoke {@link getDocsFromCache()} or {@link getDocsFromServer()}.
+ * invoke {@link getDocsFromCache} or {@link getDocsFromServer}.
  *
- * @return A Promise that will be resolved with the results of the query.
+ * @returns A Promise that will be resolved with the results of the query.
  */
 export function getDocs<T>(query: Query<T>): Promise<QuerySnapshot<T>> {
   const firestore = cast(query.firestore, FirebaseFirestore);
@@ -266,7 +266,7 @@ export function getDocs<T>(query: Query<T>): Promise<QuerySnapshot<T>> {
  * Executes the query and returns the results as a `QuerySnapshot` from cache.
  * Returns an error if the document is not currently cached.
  *
- * @return A Promise that will be resolved with the results of the query.
+ * @returns A Promise that will be resolved with the results of the query.
  */
 export function getDocsFromCache<T>(
   query: Query<T>
@@ -289,7 +289,7 @@ export function getDocsFromCache<T>(
  * Executes the query and returns the results as a `QuerySnapshot` from the
  * server. Returns an error if the network is not available.
  *
- * @return A Promise that will be resolved with the results of the query.
+ * @returns A Promise that will be resolved with the results of the query.
  */
 export function getDocsFromServer<T>(
   query: Query<T>
@@ -318,9 +318,9 @@ export function getDocsFromServer<T>(
  * Writes to the document referred to by this `DocumentReference`. If the
  * document does not yet exist, it will be created.
  *
- * @param reference A reference to the document to write.
- * @param data A map of the fields and values for the document.
- * @return A Promise resolved once the data has been successfully written
+ * @param reference - A reference to the document to write.
+ * @param data - A map of the fields and values for the document.
+ * @returns A Promise resolved once the data has been successfully written
  * to the backend (note that it won't resolve while you're offline).
  */
 export function setDoc<T>(
@@ -332,10 +332,10 @@ export function setDoc<T>(
  * the document does not yet exist, it will be created. If you provide `merge`
  * or `mergeFields`, the provided data can be merged into an existing document.
  *
- * @param reference A reference to the document to write.
- * @param data A map of the fields and values for the document.
- * @param options An object to configure the set behavior.
- * @return A Promise resolved once the data has been successfully written
+ * @param reference - A reference to the document to write.
+ * @param data - A map of the fields and values for the document.
+ * @param options - An object to configure the set behavior.
+ * @returns A Promise resolved once the data has been successfully written
  * to the backend (note that it won't resolve while you're offline).
  */
 export function setDoc<T>(
@@ -374,11 +374,11 @@ export function setDoc<T>(
  * `DocumentReference`. The update will fail if applied to a document that does
  * not exist.
  *
- * @param reference A reference to the document to update.
- * @param data An object containing the fields and values with which to
+ * @param reference - A reference to the document to update.
+ * @param data - An object containing the fields and values with which to
  * update the document. Fields can contain dots to reference nested fields
  * within the document.
- * @return A Promise resolved once the data has been successfully written
+ * @returns A Promise resolved once the data has been successfully written
  * to the backend (note that it won't resolve while you're offline).
  */
 export function updateDoc(
@@ -393,11 +393,11 @@ export function updateDoc(
  * Nested fields can be updated by providing dot-separated field path
  * strings or by providing `FieldPath` objects.
  *
- * @param reference A reference to the document to update.
- * @param field The first field to update.
- * @param value The first value.
- * @param moreFieldsAndValues Additional key value pairs.
- * @return A Promise resolved once the data has been successfully written
+ * @param reference - A reference to the document to update.
+ * @param field - The first field to update.
+ * @param value - The first value.
+ * @param moreFieldsAndValues - Additional key value pairs.
+ * @returns A Promise resolved once the data has been successfully written
  * to the backend (note that it won't resolve while you're offline).
  */
 export function updateDoc(
@@ -454,8 +454,8 @@ export function updateDoc(
 /**
  * Deletes the document referred to by the specified `DocumentReference`.
  *
- * @param reference A reference to the document to delete.
- * @return A Promise resolved once the document has been successfully
+ * @param reference - A reference to the document to delete.
+ * @returns A Promise resolved once the document has been successfully
  * deleted from the backend (note that it won't resolve while you're offline).
  */
 export function deleteDoc(
@@ -470,9 +470,9 @@ export function deleteDoc(
  * Add a new document to specified `CollectionReference` with the given data,
  * assigning it a document ID automatically.
  *
- * @param reference A reference to the collection to add this document to.
- * @param data An Object containing the data for the new document.
- * @return A Promise resolved with a `DocumentReference` pointing to the
+ * @param reference - A reference to the collection to add this document to.
+ * @param data - An Object containing the data for the new document.
+ * @returns A Promise resolved with a `DocumentReference` pointing to the
  * newly created document after it has been written to the backend (Note that it
  * won't resolve while you're offline).
  */
@@ -513,9 +513,9 @@ export function addDoc<T>(
  * NOTE: Although an `onCompletion` callback can be provided, it will
  * never be called because the snapshot stream is never-ending.
  *
- * @param reference A reference to the document to listen to.
- * @param observer A single object containing `next` and `error` callbacks.
- * @return An unsubscribe function that can be called to cancel
+ * @param reference - A reference to the document to listen to.
+ * @param observer - A single object containing `next` and `error` callbacks.
+ * @returns An unsubscribe function that can be called to cancel
  * the snapshot listener.
  */
 export function onSnapshot<T>(
@@ -534,10 +534,10 @@ export function onSnapshot<T>(
  * NOTE: Although an `onCompletion` callback can be provided, it will
  * never be called because the snapshot stream is never-ending.
  *
- * @param reference A reference to the document to listen to.
- * @param options Options controlling the listen behavior.
- * @param observer A single object containing `next` and `error` callbacks.
- * @return An unsubscribe function that can be called to cancel
+ * @param reference - A reference to the document to listen to.
+ * @param options - Options controlling the listen behavior.
+ * @param observer - A single object containing `next` and `error` callbacks.
+ * @returns An unsubscribe function that can be called to cancel
  * the snapshot listener.
  */
 export function onSnapshot<T>(
@@ -557,14 +557,14 @@ export function onSnapshot<T>(
  * NOTE: Although an `onCompletion` callback can be provided, it will
  * never be called because the snapshot stream is never-ending.
  *
- * @param reference A reference to the document to listen to.
- * @param onNext A callback to be called every time a new `DocumentSnapshot`
+ * @param reference - A reference to the document to listen to.
+ * @param onNext - A callback to be called every time a new `DocumentSnapshot`
  * is available.
- * @param onError A callback to be called if the listen fails or is
+ * @param onError - A callback to be called if the listen fails or is
  * cancelled. No further callbacks will occur.
- * @param onCompletion Can be provided, but will not be called since streams are
+ * @param onCompletion - Can be provided, but will not be called since streams are
  * never ending.
- * @return An unsubscribe function that can be called to cancel
+ * @returns An unsubscribe function that can be called to cancel
  * the snapshot listener.
  */
 export function onSnapshot<T>(
@@ -581,15 +581,15 @@ export function onSnapshot<T>(
  * NOTE: Although an `onCompletion` callback can be provided, it will
  * never be called because the snapshot stream is never-ending.
  *
- * @param reference A reference to the document to listen to.
- * @param options Options controlling the listen behavior.
- * @param onNext A callback to be called every time a new `DocumentSnapshot`
+ * @param reference - A reference to the document to listen to.
+ * @param options - Options controlling the listen behavior.
+ * @param onNext - A callback to be called every time a new `DocumentSnapshot`
  * is available.
- * @param onError A callback to be called if the listen fails or is
+ * @param onError - A callback to be called if the listen fails or is
  * cancelled. No further callbacks will occur.
- * @param onCompletion Can be provided, but will not be called since streams are
+ * @param onCompletion - Can be provided, but will not be called since streams are
  * never ending.
- * @return An unsubscribe function that can be called to cancel
+ * @returns An unsubscribe function that can be called to cancel
  * the snapshot listener.
  */
 export function onSnapshot<T>(
@@ -608,9 +608,9 @@ export function onSnapshot<T>(
  * NOTE: Although an `onCompletion` callback can be provided, it will
  * never be called because the snapshot stream is never-ending.
  *
- * @param query The query to listen to.
- * @param observer A single object containing `next` and `error` callbacks.
- * @return An unsubscribe function that can be called to cancel
+ * @param query - The query to listen to.
+ * @param observer - A single object containing `next` and `error` callbacks.
+ * @returns An unsubscribe function that can be called to cancel
  * the snapshot listener.
  */
 export function onSnapshot<T>(
@@ -630,10 +630,10 @@ export function onSnapshot<T>(
  * NOTE: Although an `onCompletion` callback can be provided, it will
  * never be called because the snapshot stream is never-ending.
  *
- * @param query The query to listen to.
- * @param options Options controlling the listen behavior.
- * @param observer A single object containing `next` and `error` callbacks.
- * @return An unsubscribe function that can be called to cancel
+ * @param query - The query to listen to.
+ * @param options - Options controlling the listen behavior.
+ * @param observer - A single object containing `next` and `error` callbacks.
+ * @returns An unsubscribe function that can be called to cancel
  * the snapshot listener.
  */
 export function onSnapshot<T>(
@@ -654,14 +654,14 @@ export function onSnapshot<T>(
  * NOTE: Although an `onCompletion` callback can be provided, it will
  * never be called because the snapshot stream is never-ending.
  *
- * @param query The query to listen to.
- * @param onNext A callback to be called every time a new `QuerySnapshot`
+ * @param query - The query to listen to.
+ * @param onNext - A callback to be called every time a new `QuerySnapshot`
  * is available.
- * @param onCompletion Can be provided, but will not be called since streams are
+ * @param onCompletion - Can be provided, but will not be called since streams are
  * never ending.
- * @param onError A callback to be called if the listen fails or is
+ * @param onError - A callback to be called if the listen fails or is
  * cancelled. No further callbacks will occur.
- * @return An unsubscribe function that can be called to cancel
+ * @returns An unsubscribe function that can be called to cancel
  * the snapshot listener.
  */
 export function onSnapshot<T>(
@@ -679,15 +679,15 @@ export function onSnapshot<T>(
  * NOTE: Although an `onCompletion` callback can be provided, it will
  * never be called because the snapshot stream is never-ending.
  *
- * @param query The query to listen to.
- * @param options Options controlling the listen behavior.
- * @param onNext A callback to be called every time a new `QuerySnapshot`
+ * @param query - The query to listen to.
+ * @param options - Options controlling the listen behavior.
+ * @param onNext - A callback to be called every time a new `QuerySnapshot`
  * is available.
- * @param onCompletion Can be provided, but will not be called since streams are
+ * @param onCompletion - Can be provided, but will not be called since streams are
  * never ending.
- * @param onError A callback to be called if the listen fails or is
+ * @param onError - A callback to be called if the listen fails or is
  * cancelled. No further callbacks will occur.
- * @return An unsubscribe function that can be called to cancel
+ * @returns An unsubscribe function that can be called to cancel
  * the snapshot listener.
  */
 export function onSnapshot<T>(
@@ -795,9 +795,9 @@ export function onSnapshot<T>(
  * with the server. Use SnapshotMetadata in the individual listeners to
  * determine if a snapshot is from the cache or the server.
  *
- * @param firestore The instance of Firestore for synchronizing snapshots.
- * @param observer A single object containing `next` and `error` callbacks.
- * @return An unsubscribe function that can be called to cancel the snapshot
+ * @param firestore - The instance of Firestore for synchronizing snapshots.
+ * @param observer - A single object containing `next` and `error` callbacks.
+ * @returns An unsubscribe function that can be called to cancel the snapshot
  * listener.
  */
 export function onSnapshotsInSync(
@@ -818,10 +818,10 @@ export function onSnapshotsInSync(
  * with the server. Use SnapshotMetadata in the individual listeners to
  * determine if a snapshot is from the cache or the server.
  *
- * @param firestore The instance of Firestore for synchronizing snapshots.
- * @param onSync A callback to be called every time all snapshot listeners are
+ * @param firestore - The instance of Firestore for synchronizing snapshots.
+ * @param onSync - A callback to be called every time all snapshot listeners are
  * in sync with each other.
- * @return An unsubscribe function that can be called to cancel the snapshot
+ * @returns An unsubscribe function that can be called to cancel the snapshot
  * listener.
  */
 export function onSnapshotsInSync(

--- a/packages/firestore/exp/src/api/snapshot.ts
+++ b/packages/firestore/exp/src/api/snapshot.ts
@@ -83,7 +83,7 @@ import { newQueryComparator } from '../../../src/core/query';
 export interface FirestoreDataConverter<T> {
   /**
    * Called by the Firestore SDK to convert a custom model object of type `T`
-   * into a plain Javascript object (suitable for writing directly to the
+   * into a plain JavaScript object (suitable for writing directly to the
    * Firestore database). To use `set()` with `merge` and `mergeFields`,
    * `toFirestore()` must be defined with `Partial<T>`.
    */
@@ -91,7 +91,7 @@ export interface FirestoreDataConverter<T> {
 
   /**
    * Called by the Firestore SDK to convert a custom model object of type `T`
-   * into a plain Javascript object (suitable for writing directly to the
+   * into a plain JavaScript object (suitable for writing directly to the
    * Firestore database). Used with {@link setData}, {@link WriteBatch#set}
    * and {@link Transaction#set} with `merge:true` or `mergeFields`.
    */

--- a/packages/firestore/exp/src/api/snapshot.ts
+++ b/packages/firestore/exp/src/api/snapshot.ts
@@ -88,14 +88,21 @@ export interface FirestoreDataConverter<T> {
    * `toFirestore()` must be defined with `Partial<T>`.
    */
   toFirestore(modelObject: T): DocumentData;
+
+  /**
+   * Called by the Firestore SDK to convert a custom model object of type `T`
+   * into a plain Javascript object (suitable for writing directly to the
+   * Firestore database). Used with {@link setData}, {@link WriteBatch#set}
+   * and {@link Transaction#set} with `merge:true` or `mergeFields`.
+   */
   toFirestore(modelObject: Partial<T>, options: SetOptions): DocumentData;
 
   /**
    * Called by the Firestore SDK to convert Firestore data into an object of
    * type T. You can access your data by calling: `snapshot.data(options)`.
    *
-   * @param snapshot A `QueryDocumentSnapshot` containing your data and metadata.
-   * @param options The `SnapshotOptions` from the initial call to `data()`.
+   * @param snapshot - A `QueryDocumentSnapshot` containing your data and metadata.
+   * @param options - The `SnapshotOptions` from the initial call to `data()`.
    */
   fromFirestore(
     snapshot: QueryDocumentSnapshot<DocumentData>,
@@ -178,6 +185,7 @@ export class DocumentSnapshot<T = DocumentData> extends LiteDocumentSnapshot<
    */
   readonly metadata: SnapshotMetadata;
 
+  /** @hideconstructor protected */
   constructor(
     readonly _firestore: FirebaseFirestore,
     userDataWriter: AbstractUserDataWriter,
@@ -207,10 +215,10 @@ export class DocumentSnapshot<T = DocumentData> extends LiteDocumentSnapshot<
    * set to their final value will be returned as `null`. You can override
    * this by passing an options object.
    *
-   * @param options An options object to configure how data is retrieved from
+   * @param options - An options object to configure how data is retrieved from
    * the snapshot (for example the desired behavior for server timestamps that
    * have not yet been set to their final value).
-   * @return An `Object` containing all fields in the document or `undefined` if
+   * @returns An `Object` containing all fields in the document or `undefined` if
    * the document doesn't exist.
    */
   data(options: SnapshotOptions = {}): T | undefined {
@@ -244,12 +252,12 @@ export class DocumentSnapshot<T = DocumentData> extends LiteDocumentSnapshot<
    * its final value will be returned as `null`. You can override this by
    * passing an options object.
    *
-   * @param fieldPath The path (for example 'foo' or 'foo.bar') to a specific
+   * @param fieldPath - The path (for example 'foo' or 'foo.bar') to a specific
    * field.
-   * @param options An options object to configure how the field is retrieved
+   * @param options - An options object to configure how the field is retrieved
    * from the snapshot (for example the desired behavior for server timestamps
    * that have not yet been set to their final value).
-   * @return The data at the specified field location or undefined if no such
+   * @returns The data at the specified field location or undefined if no such
    * field exists in the document.
    */
   // We are using `any` here to avoid an explicit cast by our users.
@@ -292,10 +300,10 @@ export class QueryDocumentSnapshot<T = DocumentData> extends DocumentSnapshot<
    * this by passing an options object.
    *
    * @override
-   * @param options An options object to configure how data is retrieved from
+   * @param options - An options object to configure how data is retrieved from
    * the snapshot (for example the desired behavior for server timestamps that
    * have not yet been set to their final value).
-   * @return An `Object` containing all fields in the document.
+   * @returns An `Object` containing all fields in the document.
    */
   data(options: SnapshotOptions = {}): T {
     return super.data(options) as T;
@@ -325,6 +333,7 @@ export class QuerySnapshot<T = DocumentData> {
   private _cachedChanges?: Array<DocumentChange<T>>;
   private _cachedChangesIncludeMetadataChanges?: boolean;
 
+  /** @hideconstructor */
   constructor(
     readonly _firestore: FirebaseFirestore,
     readonly _userDataWriter: AbstractUserDataWriter,
@@ -358,9 +367,9 @@ export class QuerySnapshot<T = DocumentData> {
   /**
    * Enumerates all of the documents in the `QuerySnapshot`.
    *
-   * @param callback A callback to be called with a `QueryDocumentSnapshot` for
+   * @param callback - A callback to be called with a `QueryDocumentSnapshot` for
    * each document in the snapshot.
-   * @param thisArg The `this` binding for the callback.
+   * @param thisArg - The `this` binding for the callback.
    */
   forEach(
     callback: (result: QueryDocumentSnapshot<T>) => void,
@@ -389,7 +398,7 @@ export class QuerySnapshot<T = DocumentData> {
    * is the first snapshot, all documents will be in the list as 'added'
    * changes.
    *
-   * @param options `SnapshotListenOptions` that control whether metadata-only
+   * @param options - `SnapshotListenOptions` that control whether metadata-only
    * changes (i.e. only `DocumentSnapshot.metadata` changed) should trigger
    * snapshot events.
    */
@@ -518,9 +527,9 @@ export function resultChangeType(type: ChangeType): DocumentChangeType {
 /**
  * Returns true if the provided snapshots are equal.
  *
- * @param left A snapshot to compare.
- * @param right A snapshot to compare.
- * @return true if the snapshots are equal.
+ * @param left - A snapshot to compare.
+ * @param right - A snapshot to compare.
+ * @returns true if the snapshots are equal.
  */
 export function snapshotEqual<T>(
   left: DocumentSnapshot<T> | QuerySnapshot<T>,

--- a/packages/firestore/exp/src/api/transaction.ts
+++ b/packages/firestore/exp/src/api/transaction.ts
@@ -33,12 +33,13 @@ import { firestoreClientTransaction } from '../../../src/core/firestore_client';
  *
  * The `Transaction` object passed to a transaction's `updateFunction` provides
  * the methods to read and write data within the transaction context. See
- * {@link runTransaction()}.
+ * {@link runTransaction}.
  */
 export class Transaction extends LiteTransaction {
   // This class implements the same logic as the Transaction API in the Lite SDK
   // but is subclassed in order to return its own DocumentSnapshot types.
 
+  /** @hideconstructor */
   constructor(
     protected readonly _firestore: FirebaseFirestore,
     _transaction: InternalTransaction
@@ -49,8 +50,8 @@ export class Transaction extends LiteTransaction {
   /**
    * Reads the document referenced by the provided {@link DocumentReference}.
    *
-   * @param documentRef A reference to the document to be read.
-   * @return A `DocumentSnapshot` with the read data.
+   * @param documentRef - A reference to the document to be read.
+   * @returns A `DocumentSnapshot` with the read data.
    */
   get<T>(documentRef: DocumentReference<T>): Promise<DocumentSnapshot<T>> {
     const ref = validateReference<T>(documentRef, this._firestore);
@@ -82,10 +83,11 @@ export class Transaction extends LiteTransaction {
  *
  * The maximum number of writes allowed in a single transaction is 500.
  *
- * @param firestore A reference to the Firestore database to run this
+ * @param firestore - A reference to the Firestore database to run this
  * transaction against.
- * @param updateFunction The function to execute within the transaction context.
- * @return If the transaction completed successfully or was explicitly aborted
+ * @param updateFunction - The function to execute within the transaction
+ * context.
+ * @returns If the transaction completed successfully or was explicitly aborted
  * (the `updateFunction` returned a failed promise), the promise returned by the
  * `updateFunction `is returned here. Otherwise, if the transaction failed, a
  * rejected promise with the corresponding failure error is returned.

--- a/packages/firestore/exp/src/api/write_batch.ts
+++ b/packages/firestore/exp/src/api/write_batch.ts
@@ -30,7 +30,7 @@ export { WriteBatch };
  * Unlike transactions, write batches are persisted offline and therefore are
  * preferable when you don't need to condition your writes on read data.
  *
- * @return A `WriteBatch` that can be used to atomically execute multiple
+ * @returns A `WriteBatch` that can be used to atomically execute multiple
  * writes.
  */
 export function writeBatch(firestore: FirebaseFirestore): WriteBatch {

--- a/packages/firestore/lite/src/api/bytes.ts
+++ b/packages/firestore/lite/src/api/bytes.ts
@@ -24,6 +24,7 @@ import { ByteString } from '../../../src/util/byte_string';
 export class Bytes {
   _byteString: ByteString;
 
+  /** @hideconstructor */
   constructor(byteString: ByteString) {
     this._byteString = byteString;
   }
@@ -32,7 +33,7 @@ export class Bytes {
    * Creates a new `Bytes` object from the given Base64 string, converting it to
    * bytes.
    *
-   * @param base64 The Base64 string used to create the `Bytes` object.
+   * @param base64 - The Base64 string used to create the `Bytes` object.
    */
   static fromBase64String(base64: string): Bytes {
     try {
@@ -48,7 +49,7 @@ export class Bytes {
   /**
    * Creates a new `Bytes` object from the given Uint8Array.
    *
-   * @param array The Uint8Array used to create the `Bytes` object.
+   * @param array - The Uint8Array used to create the `Bytes` object.
    */
   static fromUint8Array(array: Uint8Array): Bytes {
     return new Bytes(ByteString.fromUint8Array(array));
@@ -57,7 +58,7 @@ export class Bytes {
   /**
    * Returns the underlying bytes as a Base64-encoded string.
    *
-   * @return The Base64-encoded string created from the `Bytes` object.
+   * @returns The Base64-encoded string created from the `Bytes` object.
    */
   toBase64(): string {
     return this._byteString.toBase64();
@@ -66,7 +67,7 @@ export class Bytes {
   /**
    * Returns the underlying bytes in a new `Uint8Array`.
    *
-   * @return The Uint8Array created from the `Bytes` object.
+   * @returns The Uint8Array created from the `Bytes` object.
    */
   toUint8Array(): Uint8Array {
     return this._byteString.toUint8Array();
@@ -75,7 +76,7 @@ export class Bytes {
   /**
    * Returns a string representation of the `Bytes` object.
    *
-   * @return A string representation of the `Bytes` object.
+   * @returns A string representation of the `Bytes` object.
    */
   toString(): string {
     return 'Bytes(base64: ' + this.toBase64() + ')';
@@ -84,8 +85,8 @@ export class Bytes {
   /**
    * Returns true if this `Bytes` object is equal to the provided one.
    *
-   * @param other The `Bytes` object to compare against.
-   * @return true if this `Bytes` object is equal to the provided one.
+   * @param other - The `Bytes` object to compare against.
+   * @returns true if this `Bytes` object is equal to the provided one.
    */
   isEqual(other: Bytes): boolean {
     return this._byteString.isEqual(other._byteString);

--- a/packages/firestore/lite/src/api/database.ts
+++ b/packages/firestore/lite/src/api/database.ts
@@ -149,7 +149,7 @@ export class FirestoreSettings {
 /**
  * The Cloud Firestore service interface.
  *
- * Do not call this constructor directly. Instead, use {@link getFirestore()}.
+ * Do not call this constructor directly. Instead, use {@link getFirestore}.
  */
 export class FirebaseFirestore implements _FirebaseService {
   readonly _databaseId: DatabaseId;
@@ -165,6 +165,7 @@ export class FirebaseFirestore implements _FirebaseService {
 
   private _app?: FirebaseApp;
 
+  /** @hideconstructor */
   constructor(
     databaseIdOrApp: DatabaseId | FirebaseApp,
     authProvider: Provider<FirebaseAuthInternalName>
@@ -180,7 +181,7 @@ export class FirebaseFirestore implements _FirebaseService {
   }
 
   /**
-   * The {@link FirebaseApp app} associated with this `Firestore` service
+   * The {@link FirebaseApp} associated with this `Firestore` service
    * instance.
    */
   get app(): FirebaseApp {
@@ -260,13 +261,13 @@ function databaseIdFromApp(app: FirebaseApp): DatabaseId {
 /**
  * Initializes a new instance of Cloud Firestore with the provided settings.
  * Can only be called before any other functions, including
- * {@link getFirestore()}. If the custom settings are empty, this function is
- * equivalent to calling {@link getFirestore()}.
+ * {@link getFirestore}. If the custom settings are empty, this function is
+ * equivalent to calling {@link getFirestore}.
  *
- * @param app The {@link FirebaseApp} with which the `Firestore` instance will be
- * associated.
- * @param settings A settings object to configure the `Firestore` instance.
- * @return A newly initialized Firestore instance.
+ * @param app - The {@link FirebaseApp} with which the `Firestore` instance will
+ * be associated.
+ * @param settings - A settings object to configure the `Firestore` instance.
+ * @returns A newly initialized Firestore instance.
  */
 export function initializeFirestore(
   app: FirebaseApp,
@@ -285,9 +286,9 @@ export function initializeFirestore(
  * provided {@link FirebaseApp}. If no instance exists, initializes a new
  * instance with default settings.
  *
- * @param app The {@link FirebaseApp} instance that the returned Firestore
+ * @param app - The {@link FirebaseApp} instance that the returned Firestore
  * instance is associated with.
- * @return The `Firestore` instance of the provided app.
+ * @returns The `Firestore` instance of the provided app.
  */
 export function getFirestore(app: FirebaseApp): FirebaseFirestore {
   return _getProvider(
@@ -305,14 +306,14 @@ export function getFirestore(app: FirebaseApp): FirebaseFirestore {
  * response from the server will not be resolved.
  *
  * To restart after termination, create a new instance of FirebaseFirestore with
- * {@link getFirestore()}.
+ * {@link getFirestore}.
  *
  * Note: Under normal circumstances, calling `terminate()` is not required. This
  * function is useful only when you want to force this instance to release all of
- * its resources or in combination with {@link clearIndexedDbPersistence()} to
+ * its resources or in combination with {@link clearIndexedDbPersistence} to
  * ensure that all local state is destroyed between test runs.
  *
- * @return A promise that is resolved when the instance has been successfully
+ * @returns A promise that is resolved when the instance has been successfully
  * terminated.
  */
 export function terminate(firestore: FirebaseFirestore): Promise<void> {

--- a/packages/firestore/lite/src/api/field_path.ts
+++ b/packages/firestore/lite/src/api/field_path.ts
@@ -37,7 +37,7 @@ export class FieldPath {
    * Creates a FieldPath from the provided field names. If more than one field
    * name is provided, the path will point to a nested field in a document.
    *
-   * @param fieldNames A list of field names.
+   * @param fieldNames - A list of field names.
    */
   constructor(...fieldNames: string[]) {
     for (let i = 0; i < fieldNames.length; ++i) {
@@ -56,8 +56,8 @@ export class FieldPath {
   /**
    * Returns true if this `FieldPath` is equal to the provided one.
    *
-   * @param other The `FieldPath` to compare against.
-   * @return true if this `FieldPath` is equal to the provided one.
+   * @param other - The `FieldPath` to compare against.
+   * @returns true if this `FieldPath` is equal to the provided one.
    */
   isEqual(other: FieldPath): boolean {
     return this._internalPath.isEqual(other._internalPath);

--- a/packages/firestore/lite/src/api/field_value.ts
+++ b/packages/firestore/lite/src/api/field_value.ts
@@ -31,7 +31,7 @@ import { FieldTransform } from '../../../src/model/mutation';
  */
 export abstract class FieldValue {
   /**
-   * @param _methodName The public API endpoint that returns this class.
+   * @param _methodName - The public API endpoint that returns this class.
    */
   constructor(public _methodName: string) {}
 
@@ -40,15 +40,15 @@ export abstract class FieldValue {
 }
 
 /**
- * Returns a sentinel for use with {@link updateDoc()} or
- * {@link setDoc `setDoc({}, { merge: true })`} to mark a field for deletion.
+ * Returns a sentinel for use with {@link updateDoc} or
+ * {@link setDoc} with `{merge: true}` to mark a field for deletion.
  */
 export function deleteField(): FieldValue {
   return new DeleteFieldValueImpl('deleteField');
 }
 
 /**
- * Returns a sentinel used with {@link setDoc()} or {@link updateDoc()} to
+ * Returns a sentinel used with {@link setDoc} or {@link updateDoc} to
  * include a server-generated timestamp in the written data.
  */
 export function serverTimestamp(): FieldValue {
@@ -56,15 +56,15 @@ export function serverTimestamp(): FieldValue {
 }
 
 /**
- * Returns a special value that can be used with {@link setDoc()} or {@link
- * updateDoc()} that tells the server to union the given elements with any array
+ * Returns a special value that can be used with {@link setDoc} or {@link
+ * updateDoc} that tells the server to union the given elements with any array
  * value that already exists on the server. Each specified element that doesn't
  * already exist in the array will be added to the end. If the field being
  * modified is not already an array it will be overwritten with an array
  * containing exactly the specified elements.
  *
- * @param elements The elements to union into the array.
- * @return The `FieldValue` sentinel for use in a call to `setDoc()` or
+ * @param elements - The elements to union into the array.
+ * @returns The `FieldValue` sentinel for use in a call to `setDoc()` or
  * `updateDoc()`.
  */
 export function arrayUnion(...elements: unknown[]): FieldValue {
@@ -74,14 +74,14 @@ export function arrayUnion(...elements: unknown[]): FieldValue {
 }
 
 /**
- * Returns a special value that can be used with {@link setDoc()} or {@link
- * updateDoc()} that tells the server to remove the given elements from any
+ * Returns a special value that can be used with {@link setDoc} or {@link
+ * updateDoc} that tells the server to remove the given elements from any
  * array value that already exists on the server. All instances of each element
  * specified will be removed from the array. If the field being modified is not
  * already an array it will be overwritten with an empty array.
  *
- * @param elements The elements to remove from the array.
- * @return The `FieldValue` sentinel for use in a call to `setDoc()` or
+ * @param elements - The elements to remove from the array.
+ * @returns The `FieldValue` sentinel for use in a call to `setDoc()` or
  * `updateDoc()`
  */
 export function arrayRemove(...elements: unknown[]): FieldValue {
@@ -91,8 +91,8 @@ export function arrayRemove(...elements: unknown[]): FieldValue {
 }
 
 /**
- * Returns a special value that can be used with {@link setDoc()} or {@link
- * updateDoc()} that tells the server to increment the field's current value by
+ * Returns a special value that can be used with {@link setDoc} or {@link
+ * updateDoc} that tells the server to increment the field's current value by
  * the given value.
  *
  * If either the operand or the current field value uses floating point
@@ -105,8 +105,8 @@ export function arrayRemove(...elements: unknown[]): FieldValue {
  * If the current field value is not of type `number`, or if the field does not
  * yet exist, the transformation sets the field to the given value.
  *
- * @param n The value to increment by.
- * @return The `FieldValue` sentinel for use in a call to `setDoc()` or
+ * @param n - The value to increment by.
+ * @returns The `FieldValue` sentinel for use in a call to `setDoc()` or
  * `updateDoc()`
  */
 export function increment(n: number): FieldValue {

--- a/packages/firestore/lite/src/api/reference.ts
+++ b/packages/firestore/lite/src/api/reference.ts
@@ -93,7 +93,7 @@ import { DocumentReference as ExpDocumentReference } from '../../../exp/src/api/
 import { isServerTimestamp } from '../../../src/model/server_timestamps';
 
 /**
- * Document data (for use with {@link setDoc()}) consists of fields mapped to
+ * Document data (for use with {@link setDoc}) consists of fields mapped to
  * values.
  */
 export interface DocumentData {
@@ -102,7 +102,7 @@ export interface DocumentData {
 }
 
 /**
- * Update data (for use with {@link updateDoc()}) consists of field paths (e.g.
+ * Update data (for use with {@link updateDoc}) consists of field paths (e.g.
  * 'foo' or 'foo.baz') mapped to values. Fields that contain dots reference
  * nested fields within the document.
  */
@@ -112,15 +112,15 @@ export interface UpdateData {
 }
 
 /**
- * An options object that configures the behavior of {@link setDoc()}, {@link
- * WriteBatch#set()} and {@link Transaction#set()} calls. These calls can be
+ * An options object that configures the behavior of {@link setDoc}, {@link
+ * WriteBatch#set} and {@link Transaction#set} calls. These calls can be
  * configured to perform granular merges instead of overwriting the target
  * documents in their entirety by providing a `SetOptions` with `merge: true`.
  *
- * @param merge Changes the behavior of a `setDoc()` call to only replace the
+ * @param merge - Changes the behavior of a `setDoc()` call to only replace the
  * values specified in its data argument. Fields omitted from the `setDoc()`
  * call remain untouched.
- * @param mergeFields Changes the behavior of `setDoc()` calls to only replace
+ * @param mergeFields - Changes the behavior of `setDoc()` calls to only replace
  * the specified field paths. Any field path that is not specified is ignored
  * and remains untouched.
  */
@@ -147,6 +147,7 @@ export class DocumentReference<T = DocumentData> {
    */
   readonly firestore: FirebaseFirestore;
 
+  /** @hideconstructor */
   constructor(
     firestore: FirebaseFirestore,
     readonly _converter: FirestoreDataConverter<T> | null,
@@ -188,12 +189,12 @@ export class DocumentReference<T = DocumentData> {
   /**
    * Applies a custom data converter to this `DocumentReference`, allowing you
    * to use your own custom model objects with Firestore. When you call {@link
-   * setDoc()}, {@link getDoc()}, etc. with the returned `DocumentReference`
+   * setDoc}, {@link getDoc}, etc. with the returned `DocumentReference`
    * instance, the provided converter will convert between Firestore data and
    * your custom type `U`.
    *
-   * @param converter Converts objects to and from Firestore.
-   * @return A `DocumentReference<U>` that uses the provided converter.
+   * @param converter - Converts objects to and from Firestore.
+   * @returns A `DocumentReference<U>` that uses the provided converter.
    */
   withConverter<U>(converter: FirestoreDataConverter<U>): DocumentReference<U> {
     return new DocumentReference<U>(this.firestore, converter, this._key);
@@ -215,6 +216,8 @@ export class Query<T = DocumentData> {
   readonly firestore: FirebaseFirestore;
 
   // This is the lite version of the Query class in the main SDK.
+
+  /** @hideconstructor protected */
   constructor(
     firestore: FirebaseFirestore,
     readonly _converter: FirestoreDataConverter<T> | null,
@@ -225,12 +228,12 @@ export class Query<T = DocumentData> {
 
   /**
    * Applies a custom data converter to this query, allowing you to use your own
-   * custom model objects with Firestore. When you call {@link getDocs()} with
+   * custom model objects with Firestore. When you call {@link getDocs} with
    * the returned query, the provided converter will convert between Firestore
    * data and your custom type `U`.
    *
-   * @param converter Converts objects to and from Firestore.
-   * @return A `Query<U>` that uses the provided converter.
+   * @param converter - Converts objects to and from Firestore.
+   * @returns A `Query<U>` that uses the provided converter.
    */
   withConverter<U>(converter: FirestoreDataConverter<U>): Query<U> {
     return new Query<U>(this.firestore, converter, this._query);
@@ -250,10 +253,10 @@ export type QueryConstraintType =
 
 /**
  * A `QueryConstraint` is used to narrow the set of documents returned by a
- * Firestore query. `QueryConstraint`s are created by invoking {@link where()},
- * {@link orderBy()}, {@link startAt()}, {@link startAfter()}, {@link
- * endBefore()}, {@link endAt()}, {@link limit()} or {@link limitToLast()} and
- * can then be passed to {@link query()} to create a new query instance that
+ * Firestore query. `QueryConstraint`s are created by invoking {@link where},
+ * {@link orderBy}, {@link startAt}, {@link startAfter}, {@link
+ * endBefore}, {@link endAt}, {@link limit} or {@link limitToLast} and
+ * can then be passed to {@link query} to create a new query instance that
  * also contains this `QueryConstraint`.
  */
 export abstract class QueryConstraint {
@@ -271,8 +274,8 @@ export abstract class QueryConstraint {
  * Creates a new immutable instance of `query` that is extended to also include
  * additional query constraints.
  *
- * @param query The query instance to use as a base for the new constraints.
- * @param queryConstraints The list of `QueryConstraint`s to apply.
+ * @param query - The query instance to use as a base for the new constraints.
+ * @param queryConstraints - The list of `QueryConstraint`s to apply.
  * @throws if any of the provided query constraints cannot be combined with the
  * existing or new constraints.
  */
@@ -317,8 +320,8 @@ class QueryFilterConstraint extends QueryConstraint {
 }
 
 /**
- * Filter conditions in a {@link where()} clause are specified using the
- * strings '<', '<=', '==', '!=', '>=', '>', 'array-contains', 'in',
+ * Filter conditions in a {@link where} clause are specified using the
+ * strings '&lt;', '&lt;=', '==', '!=', '&gt;=', '&gt;', 'array-contains', 'in',
  * 'array-contains-any', and 'not-in'.
  */
 export type WhereFilterOp =
@@ -338,10 +341,11 @@ export type WhereFilterOp =
  * specified field and that the value should satisfy the relation constraint
  * provided.
  *
- * @param fieldPath The path to compare
- * @param opStr The operation string (e.g "<", "<=", "==", ">", ">=", "!=").
- * @param value The value for comparison
- * @return The created `Query`.
+ * @param fieldPath - The path to compare
+ * @param opStr - The operation string (e.g "&lt;", "&lt;=", "==", "&lt;",
+ *   "&lt;=", "!=").
+ * @param value - The value for comparison
+ * @returns The created `Query`.
  */
 export function where(
   fieldPath: string | FieldPath,
@@ -374,7 +378,7 @@ class QueryOrderByConstraint extends QueryConstraint {
 }
 
 /**
- * The direction of a {@link orderBy()} clause is specified as 'desc' or 'asc'
+ * The direction of a {@link orderBy} clause is specified as 'desc' or 'asc'
  * (descending or ascending).
  */
 export type OrderByDirection = 'desc' | 'asc';
@@ -383,10 +387,10 @@ export type OrderByDirection = 'desc' | 'asc';
  * Creates a `QueryConstraint` that sorts the query result by the
  * specified field, optionally in descending order instead of ascending.
  *
- * @param fieldPath The field to sort by.
- * @param directionStr Optional direction to sort by ('asc' or 'desc'). If
+ * @param fieldPath - The field to sort by.
+ * @param directionStr - Optional direction to sort by ('asc' or 'desc'). If
  * not specified, order will be ascending.
- * @return The created `Query`.
+ * @returns The created `Query`.
  */
 export function orderBy(
   fieldPath: string | FieldPath,
@@ -418,8 +422,8 @@ class QueryLimitConstraint extends QueryConstraint {
 /**
  * Creates a `QueryConstraint` that only returns the first matching documents.
  *
- * @param limit The maximum number of items to return.
- * @return The created `Query`.
+ * @param limit - The maximum number of items to return.
+ * @returns The created `Query`.
  */
 export function limit(limit: number): QueryConstraint {
   validatePositiveNumber('limit', limit);
@@ -432,8 +436,8 @@ export function limit(limit: number): QueryConstraint {
  * You must specify at least one `orderBy` clause for `limitToLast` queries,
  * otherwise an exception will be thrown during execution.
  *
- * @param limit The maximum number of items to return.
- * @return The created `Query`.
+ * @param limit - The maximum number of items to return.
+ * @returns The created `Query`.
  */
 export function limitToLast(limit: number): QueryConstraint {
   validatePositiveNumber('limitToLast', limit);
@@ -470,8 +474,8 @@ class QueryStartAtConstraint extends QueryConstraint {
  * of the query. The document must contain all of the fields provided in the
  * `orderBy` of this query.
  *
- * @param snapshot The snapshot of the document to start at.
- * @return A `QueryConstraint` to pass to `query()`.
+ * @param snapshot - The snapshot of the document to start at.
+ * @returns A `QueryConstraint` to pass to `query()`.
  */
 export function startAt(snapshot: DocumentSnapshot<unknown>): QueryConstraint;
 /**
@@ -479,9 +483,9 @@ export function startAt(snapshot: DocumentSnapshot<unknown>): QueryConstraint;
  * provided fields relative to the order of the query. The order of the field
  * values must match the order of the order by clauses of the query.
  *
- * @param fieldValues The field values to start this query at, in order
+ * @param fieldValues - The field values to start this query at, in order
  * of the query's order by.
- * @return A `QueryConstraint` to pass to `query()`.
+ * @returns A `QueryConstraint` to pass to `query()`.
  */
 export function startAt(...fieldValues: unknown[]): QueryConstraint;
 export function startAt(
@@ -496,8 +500,8 @@ export function startAt(
  * of the query. The document must contain all of the fields provided in the
  * orderBy of the query.
  *
- * @param snapshot The snapshot of the document to start after.
- * @return A `QueryConstraint` to pass to `query()`
+ * @param snapshot - The snapshot of the document to start after.
+ * @returns A `QueryConstraint` to pass to `query()`
  */
 export function startAfter(
   snapshot: DocumentSnapshot<unknown>
@@ -507,9 +511,9 @@ export function startAfter(
  * provided fields relative to the order of the query. The order of the field
  * values must match the order of the order by clauses of the query.
  *
- * @param fieldValues The field values to start this query after, in order
+ * @param fieldValues - The field values to start this query after, in order
  * of the query's order by.
- * @return A `QueryConstraint` to pass to `query()`
+ * @returns A `QueryConstraint` to pass to `query()`
  */
 export function startAfter(...fieldValues: unknown[]): QueryConstraint;
 export function startAfter(
@@ -552,8 +556,8 @@ class QueryEndAtConstraint extends QueryConstraint {
  * the query. The document must contain all of the fields provided in the
  * orderBy of the query.
  *
- * @param snapshot The snapshot of the document to end before.
- * @return A `QueryConstraint` to pass to `query()`
+ * @param snapshot - The snapshot of the document to end before.
+ * @returns A `QueryConstraint` to pass to `query()`
  */
 export function endBefore(snapshot: DocumentSnapshot<unknown>): QueryConstraint;
 /**
@@ -561,9 +565,9 @@ export function endBefore(snapshot: DocumentSnapshot<unknown>): QueryConstraint;
  * provided fields relative to the order of the query. The order of the field
  * values must match the order of the order by clauses of the query.
  *
- * @param fieldValues The field values to end this query before, in order
+ * @param fieldValues - The field values to end this query before, in order
  * of the query's order by.
- * @return A `QueryConstraint` to pass to `query()`
+ * @returns A `QueryConstraint` to pass to `query()`
  */
 export function endBefore(...fieldValues: unknown[]): QueryConstraint;
 export function endBefore(
@@ -578,8 +582,8 @@ export function endBefore(
  * the query. The document must contain all of the fields provided in the
  * orderBy of the query.
  *
- * @param snapshot The snapshot of the document to end at.
- * @return A `QueryConstraint` to pass to `query()`
+ * @param snapshot - The snapshot of the document to end at.
+ * @returns A `QueryConstraint` to pass to `query()`
  */
 export function endAt(snapshot: DocumentSnapshot<unknown>): QueryConstraint;
 /**
@@ -587,9 +591,9 @@ export function endAt(snapshot: DocumentSnapshot<unknown>): QueryConstraint;
  * provided fields relative to the order of the query. The order of the field
  * values must match the order of the order by clauses of the query.
  *
- * @param fieldValues The field values to end this query at, in order
+ * @param fieldValues - The field values to end this query at, in order
  * of the query's order by.
- * @return A `QueryConstraint` to pass to `query()`
+ * @returns A `QueryConstraint` to pass to `query()`
  */
 export function endAt(...fieldValues: unknown[]): QueryConstraint;
 export function endAt(
@@ -1029,11 +1033,12 @@ export function validateHasExplicitOrderByForLimitToLast(
 
 /**
  * A `CollectionReference` object can be used for adding documents, getting
- * document references, and querying for documents (using {@link query()}`).
+ * document references, and querying for documents (using {@link query}).
  */
 export class CollectionReference<T = DocumentData> extends Query<T> {
   readonly type = 'collection';
 
+  /** @hideconstructor */
   constructor(
     readonly firestore: FirebaseFirestore,
     converter: FirestoreDataConverter<T> | null,
@@ -1075,11 +1080,11 @@ export class CollectionReference<T = DocumentData> extends Query<T> {
   /**
    * Applies a custom data converter to this CollectionReference, allowing you
    * to use your own custom model objects with Firestore. When you call {@link
-   * addDoc()} with the returned `CollectionReference` instance, the provided
+   * addDoc} with the returned `CollectionReference` instance, the provided
    * converter will convert between Firestore data and your custom type `U`.
    *
-   * @param converter Converts objects to and from Firestore.
-   * @return A `CollectionReference<U>` that uses the provided converter.
+   * @param converter - Converts objects to and from Firestore.
+   * @returns A `CollectionReference<U>` that uses the provided converter.
    */
   withConverter<U>(
     converter: FirestoreDataConverter<U>
@@ -1092,13 +1097,13 @@ export class CollectionReference<T = DocumentData> extends Query<T> {
  * Gets a `CollectionReference` instance that refers to the collection at
  * the specified absolute path.
  *
- * @param firestore A reference to the root Firestore instance.
- * @param path A slash-separated path to a collection.
- * @param pathSegments Additional path segments to apply relative to the first
+ * @param firestore - A reference to the root Firestore instance.
+ * @param path - A slash-separated path to a collection.
+ * @param pathSegments - Additional path segments to apply relative to the first
  * argument.
  * @throws If the final path has an even number of segments and does not point
  * to a collection.
- * @return The `CollectionReference` instance.
+ * @returns The `CollectionReference` instance.
  */
 export function collection(
   firestore: FirebaseFirestore,
@@ -1109,13 +1114,13 @@ export function collection(
  * Gets a `CollectionReference` instance that refers to a subcollection of
  * `reference` at the the specified relative path.
  *
- * @param reference A reference to a collection.
- * @param path A slash-separated path to a collection.
- * @param pathSegments Additional path segments to apply relative to the first
+ * @param reference - A reference to a collection.
+ * @param path - A slash-separated path to a collection.
+ * @param pathSegments - Additional path segments to apply relative to the first
  * argument.
  * @throws If the final path has an even number of segments and does not point
  * to a collection.
- * @return The `CollectionReference` instance.
+ * @returns The `CollectionReference` instance.
  */
 export function collection(
   reference: CollectionReference<unknown>,
@@ -1126,13 +1131,13 @@ export function collection(
  * Gets a `CollectionReference` instance that refers to a subcollection of
  * `reference` at the the specified relative path.
  *
- * @param reference A reference to a Firestore document.
- * @param path A slash-separated path to a collection.
- * @param pathSegments Additional path segments that will be applied relative
+ * @param reference - A reference to a Firestore document.
+ * @param path - A slash-separated path to a collection.
+ * @param pathSegments - Additional path segments that will be applied relative
  * to the first argument.
  * @throws If the final path has an even number of segments and does not point
  * to a collection.
- * @return The `CollectionReference` instance.
+ * @returns The `CollectionReference` instance.
  */
 export function collection(
   reference: DocumentReference,
@@ -1184,11 +1189,11 @@ export function collection(
  * database that are contained in a collection or subcollection with the
  * given `collectionId`.
  *
- * @param firestore A reference to the root Firestore instance.
- * @param collectionId Identifies the collections to query over. Every
+ * @param firestore - A reference to the root Firestore instance.
+ * @param collectionId - Identifies the collections to query over. Every
  * collection or subcollection with this ID as the last segment of its path
  * will be included. Cannot contain a slash.
- * @return The created `Query`.
+ * @returns The created `Query`.
  */
 export function collectionGroup(
   firestore: FirebaseFirestore,
@@ -1214,13 +1219,13 @@ export function collectionGroup(
  * Gets a `DocumentReference` instance that refers to the document at the
  * specified abosulute path.
  *
- * @param firestore A reference to the root Firestore instance.
- * @param path A slash-separated path to a document.
- * @param pathSegments Additional path segments that will be applied relative
+ * @param firestore - A reference to the root Firestore instance.
+ * @param path - A slash-separated path to a document.
+ * @param pathSegments - Additional path segments that will be applied relative
  * to the first argument.
  * @throws If the final path has an odd number of segments and does not point to
  * a document.
- * @return The `DocumentReference` instance.
+ * @returns The `DocumentReference` instance.
  */
 export function doc(
   firestore: FirebaseFirestore,
@@ -1233,14 +1238,14 @@ export function doc(
  * automatically-generated unique ID will be used for the returned
  * `DocumentReference`.
  *
- * @param reference A reference to a collection.
- * @param path A slash-separated path to a document. Has to be omitted to use
+ * @param reference - A reference to a collection.
+ * @param path - A slash-separated path to a document. Has to be omitted to use
  * auto-genrated IDs.
- * @param pathSegments Additional path segments that will be applied relative
+ * @param pathSegments - Additional path segments that will be applied relative
  * to the first argument.
  * @throws If the final path has an odd number of segments and does not point to
  * a document.
- * @return The `DocumentReference` instance.
+ * @returns The `DocumentReference` instance.
  */
 export function doc<T>(
   reference: CollectionReference<T>,
@@ -1251,13 +1256,13 @@ export function doc<T>(
  * Gets a `DocumentReference` instance that refers to a document within
  * `reference` at the specified relative path.
  *
- * @param reference A reference to a Firestore document.
- * @param path A slash-separated path to a document.
- * @param pathSegments Additional path segments that will be applied relative
+ * @param reference - A reference to a Firestore document.
+ * @param path - A slash-separated path to a document.
+ * @param pathSegments - Additional path segments that will be applied relative
  * to the first argument.
  * @throws If the final path has an odd number of segments and does not point to
  * a document.
- * @return The `DocumentReference` instance.
+ * @returns The `DocumentReference` instance.
  */
 export function doc(
   reference: DocumentReference<unknown>,
@@ -1334,8 +1339,8 @@ export class LiteUserDataWriter extends AbstractUserDataWriter {
  * backend. If the client is offline, the read fails. If you like to use
  * caching or see local modifications, please use the full Firestore SDK.
  *
- * @param reference The reference of the document to fetch.
- * @return A Promise resolved with a `DocumentSnapshot` containing the current
+ * @param reference - The reference of the document to fetch.
+ * @returns A Promise resolved with a `DocumentSnapshot` containing the current
  * document contents.
  */
 export function getDoc<T>(
@@ -1368,8 +1373,8 @@ export function getDoc<T>(
  * offline, the operation fails. To see previously cached result and local
  * modifications, use the full Firestore SDK.
  *
- * @param query The `Query` to execute.
- * @return A Promise that will be resolved with the results of the query.
+ * @param query - The `Query` to execute.
+ * @returns A Promise that will be resolved with the results of the query.
  */
 export function getDocs<T>(query: Query<T>): Promise<QuerySnapshot<T>> {
   validateHasExplicitOrderByForLimitToLast(query._query);
@@ -1408,9 +1413,9 @@ export function getDocs<T>(query: Query<T>): Promise<QuerySnapshot<T>> {
  * write fails. If you would like to see local modifications or buffer writes
  * until the client is online, use the full Firestore SDK.
  *
- * @param reference A reference to the document to write.
- * @param data A map of the fields and values for the document.
- * @return A Promise resolved once the data has been successfully written
+ * @param reference - A reference to the document to write.
+ * @param data - A map of the fields and values for the document.
+ * @returns A Promise resolved once the data has been successfully written
  * to the backend.
  */
 export function setDoc<T>(
@@ -1427,10 +1432,10 @@ export function setDoc<T>(
  * write fails. If you would like to see local modifications or buffer writes
  * until the client is online, use the full Firestore SDK.
  *
- * @param reference A reference to the document to write.
- * @param data A map of the fields and values for the document.
- * @param options An object to configure the set behavior.
- * @return A Promise resolved once the data has been successfully written
+ * @param reference - A reference to the document to write.
+ * @param data - A map of the fields and values for the document.
+ * @param options - An object to configure the set behavior.
+ * @returns A Promise resolved once the data has been successfully written
  * to the backend.
  */
 export function setDoc<T>(
@@ -1475,11 +1480,11 @@ export function setDoc<T>(
  * update fails. If you would like to see local modifications or buffer writes
  * until the client is online, use the full Firestore SDK.
  *
- * @param reference A reference to the document to update.
- * @param data An object containing the fields and values with which to
+ * @param reference - A reference to the document to update.
+ * @param data - An object containing the fields and values with which to
  * update the document. Fields can contain dots to reference nested fields
  * within the document.
- * @return A Promise resolved once the data has been successfully written
+ * @returns A Promise resolved once the data has been successfully written
  * to the backend.
  */
 export function updateDoc(
@@ -1499,11 +1504,11 @@ export function updateDoc(
  * update fails. If you would like to see local modifications or buffer writes
  * until the client is online, use the full Firestore SDK.
  *
- * @param reference A reference to the document to update.
- * @param field The first field to update.
- * @param value The first value.
- * @param moreFieldsAndValues Additional key value pairs.
- * @return A Promise resolved once the data has been successfully written
+ * @param reference - A reference to the document to update.
+ * @param field - The first field to update.
+ * @param value - The first value.
+ * @param moreFieldsAndValues - Additional key value pairs.
+ * @returns A Promise resolved once the data has been successfully written
  * to the backend.
  */
 export function updateDoc(
@@ -1563,8 +1568,8 @@ export function updateDoc(
  * delete fails. If you would like to see local modifications or buffer writes
  * until the client is online, use the full Firestore SDK.
  *
- * @param reference A reference to the document to delete.
- * @return A Promise resolved once the document has been successfully
+ * @param reference - A reference to the document to delete.
+ * @returns A Promise resolved once the document has been successfully
  * deleted from the backend.
  */
 export function deleteDoc(reference: DocumentReference): Promise<void> {
@@ -1583,9 +1588,9 @@ export function deleteDoc(reference: DocumentReference): Promise<void> {
  * write fails. If you would like to see local modifications or buffer writes
  * until the client is online, use the full Firestore SDK.
  *
- * @param reference A reference to the collection to add this document to.
- * @param data An Object containing the data for the new document.
- * @return A Promise resolved with a `DocumentReference` pointing to the
+ * @param reference - A reference to the collection to add this document to.
+ * @param data - An Object containing the data for the new document.
+ * @returns A Promise resolved with a `DocumentReference` pointing to the
  * newly created document after it has been written to the backend.
  */
 export function addDoc<T>(
@@ -1619,9 +1624,9 @@ export function addDoc<T>(
 /**
  * Returns true if the provided references are equal.
  *
- * @param left A reference to compare.
- * @param right A reference to compare.
- * @return true if the references point to the same location in the same
+ * @param left - A reference to compare.
+ * @param right - A reference to compare.
+ * @returns true if the references point to the same location in the same
  * Firestore database.
  */
 export function refEqual<T>(
@@ -1646,9 +1651,9 @@ export function refEqual<T>(
  * Returns true if the provided queries point to the same collection and apply
  * the same constraints.
  *
- * @param left A `Query` to compare.
- * @param right A Query` to compare.
- * @return true if the references point to the same location in the same
+ * @param left - A `Query` to compare.
+ * @param right - A `Query` to compare.
+ * @returns true if the references point to the same location in the same
  * Firestore database.
  */
 export function queryEqual<T>(left: Query<T>, right: Query<T>): boolean {

--- a/packages/firestore/lite/src/api/snapshot.ts
+++ b/packages/firestore/lite/src/api/snapshot.ts
@@ -78,16 +78,16 @@ export interface FirestoreDataConverter<T> {
   /**
    * Called by the Firestore SDK to convert a custom model object of type `T`
    * into a plain Javascript object (suitable for writing directly to the
-   * Firestore database). Used with {@link setData()}, {@link WriteBatch#set()}
-   * and {@link Transaction#set()}}.
+   * Firestore database). Used with {@link setData}, {@link WriteBatch#set}
+   * and {@link Transaction#set}.
    */
   toFirestore(modelObject: T): DocumentData;
 
   /**
    * Called by the Firestore SDK to convert a custom model object of type `T`
    * into a plain Javascript object (suitable for writing directly to the
-   * Firestore database). Used with {@link setData()}, {@link WriteBatch#set()}
-   * and {@link Transaction#set()}} with `merge:true` or `mergeFields`.
+   * Firestore database). Used with {@link setData}, {@link WriteBatch#set}
+   * and {@link Transaction#set} with `merge:true` or `mergeFields`.
    */
   toFirestore(modelObject: Partial<T>, options: SetOptions): DocumentData;
 
@@ -95,7 +95,7 @@ export interface FirestoreDataConverter<T> {
    * Called by the Firestore SDK to convert Firestore data into an object of
    * type T. You can access your data by calling: `snapshot.data()`.
    *
-   * @param snapshot A `QueryDocumentSnapshot` containing your data and
+   * @param snapshot - A `QueryDocumentSnapshot` containing your data and
    * metadata.
    */
   fromFirestore(snapshot: QueryDocumentSnapshot<DocumentData>): T;
@@ -116,6 +116,7 @@ export class DocumentSnapshot<T = DocumentData> {
   // - No support for SnapshotMetadata.
   // - No support for SnapshotOptions.
 
+  /** @hideconstructor protected */
   constructor(
     public _firestore: FirebaseFirestore,
     public _userDataWriter: AbstractUserDataWriter,
@@ -143,7 +144,7 @@ export class DocumentSnapshot<T = DocumentData> {
   /**
    * Signals whether or not the document at the snapshot's location exists.
    *
-   * @return true if the document exists.
+   * @returns true if the document exists.
    */
   exists(): this is QueryDocumentSnapshot<T> {
     return this._document !== null;
@@ -153,7 +154,7 @@ export class DocumentSnapshot<T = DocumentData> {
    * Retrieves all fields in the document as an `Object`. Returns `undefined` if
    * the document doesn't exist.
    *
-   * @return An `Object` containing all fields in the document or `undefined`
+   * @returns An `Object` containing all fields in the document or `undefined`
    * if the document doesn't exist.
    */
   data(): T | undefined {
@@ -179,9 +180,9 @@ export class DocumentSnapshot<T = DocumentData> {
    * Retrieves the field specified by `fieldPath`. Returns `undefined` if the
    * document or field doesn't exist.
    *
-   * @param fieldPath The path (for example 'foo' or 'foo.bar') to a specific
+   * @param fieldPath - The path (for example 'foo' or 'foo.bar') to a specific
    * field.
-   * @return The data at the specified field location or undefined if no such
+   * @returns The data at the specified field location or undefined if no such
    * field exists in the document.
    */
   // We are using `any` here to avoid an explicit cast by our users.
@@ -217,7 +218,7 @@ export class QueryDocumentSnapshot<T = DocumentData> extends DocumentSnapshot<
    * Retrieves all fields in the document as an `Object`.
    *
    * @override
-   * @return An `Object` containing all fields in the document.
+   * @returns An `Object` containing all fields in the document.
    */
   data(): T {
     return super.data() as T;
@@ -238,6 +239,7 @@ export class QuerySnapshot<T = DocumentData> {
    */
   readonly query: Query<T>;
 
+  /** @hideconstructor */
   constructor(
     _query: Query<T>,
     readonly _docs: Array<QueryDocumentSnapshot<T>>
@@ -263,9 +265,9 @@ export class QuerySnapshot<T = DocumentData> {
   /**
    * Enumerates all of the documents in the `QuerySnapshot`.
    *
-   * @param callback A callback to be called with a `QueryDocumentSnapshot` for
+   * @param callback - A callback to be called with a `QueryDocumentSnapshot` for
    * each document in the snapshot.
-   * @param thisArg The `this` binding for the callback.
+   * @param thisArg - The `this` binding for the callback.
    */
   forEach(
     callback: (result: QueryDocumentSnapshot<T>) => void,
@@ -278,9 +280,9 @@ export class QuerySnapshot<T = DocumentData> {
 /**
  * Returns true if the provided snapshots are equal.
  *
- * @param left A snapshot to compare.
- * @param right A snapshot to compare.
- * @return true if the snapshots are equal.
+ * @param left - A snapshot to compare.
+ * @param right - A snapshot to compare.
+ * @returns true if the snapshots are equal.
  */
 export function snapshotEqual<T>(
   left: DocumentSnapshot<T> | QuerySnapshot<T>,

--- a/packages/firestore/lite/src/api/transaction.ts
+++ b/packages/firestore/lite/src/api/transaction.ts
@@ -54,7 +54,7 @@ import { Compat } from '../../../src/compat/compat';
  *
  * The `Transaction` object passed to a transaction's `updateFunction` provides
  * the methods to read and write data within the transaction context. See
- * {@link runTransaction()}.
+ * {@link runTransaction}.
  */
 export class Transaction {
   // This is the tree-shakeable version of the Transaction class used in the
@@ -64,6 +64,7 @@ export class Transaction {
 
   private readonly _dataReader: UserDataReader;
 
+  /** @hideconstructor */
   constructor(
     protected readonly _firestore: FirebaseFirestore,
     private readonly _transaction: InternalTransaction
@@ -74,8 +75,8 @@ export class Transaction {
   /**
    * Reads the document referenced by the provided {@link DocumentReference}.
    *
-   * @param documentRef A reference to the document to be read.
-   * @return A `DocumentSnapshot` with the read data.
+   * @param documentRef - A reference to the document to be read.
+   * @returns A `DocumentSnapshot` with the read data.
    */
   get<T>(documentRef: DocumentReference<T>): Promise<DocumentSnapshot<T>> {
     const ref = validateReference(documentRef, this._firestore);
@@ -115,9 +116,9 @@ export class Transaction {
    * Writes to the document referred to by the provided {@link
    * DocumentReference}. If the document does not exist yet, it will be created.
    *
-   * @param documentRef A reference to the document to be set.
-   * @param data An object of the fields and values for the document.\
-   * @return This `Transaction` instance. Used for chaining method calls.
+   * @param documentRef - A reference to the document to be set.
+   * @param data - An object of the fields and values for the document.
+   * @returns This `Transaction` instance. Used for chaining method calls.
    */
   set<T>(documentRef: DocumentReference<T>, data: T): this;
   /**
@@ -126,10 +127,10 @@ export class Transaction {
    * If you provide `merge` or `mergeFields`, the provided data can be merged
    * into an existing document.
    *
-   * @param documentRef A reference to the document to be set.
-   * @param data An object of the fields and values for the document.
-   * @param options An object to configure the set behavior.
-   * @return This `Transaction` instance. Used for chaining method calls.
+   * @param documentRef - A reference to the document to be set.
+   * @param data - An object of the fields and values for the document.
+   * @param options - An object to configure the set behavior.
+   * @returns This `Transaction` instance. Used for chaining method calls.
    */
   set<T>(
     documentRef: DocumentReference<T>,
@@ -164,11 +165,11 @@ export class Transaction {
    * DocumentReference}. The update will fail if applied to a document that does
    * not exist.
    *
-   * @param documentRef A reference to the document to be updated.
-   * @param data An object containing the fields and values with which to
+   * @param documentRef - A reference to the document to be updated.
+   * @param data - An object containing the fields and values with which to
    * update the document. Fields can contain dots to reference nested fields
    * within the document.
-   * @return This `Transaction` instance. Used for chaining method calls.
+   * @returns This `Transaction` instance. Used for chaining method calls.
    */
   update(documentRef: DocumentReference<unknown>, data: UpdateData): this;
   /**
@@ -179,11 +180,11 @@ export class Transaction {
    * Nested fields can be updated by providing dot-separated field path
    * strings or by providing `FieldPath` objects.
    *
-   * @param documentRef A reference to the document to be updated.
-   * @param field The first field to update.
-   * @param value The first value.
-   * @param moreFieldsAndValues Additional key/value pairs.
-   * @return This `Transaction` instance. Used for chaining method calls.
+   * @param documentRef - A reference to the document to be updated.
+   * @param field - The first field to update.
+   * @param value - The first value.
+   * @param moreFieldsAndValues - Additional key/value pairs.
+   * @returns This `Transaction` instance. Used for chaining method calls.
    */
   update(
     documentRef: DocumentReference<unknown>,
@@ -234,8 +235,8 @@ export class Transaction {
   /**
    * Deletes the document referred to by the provided {@link DocumentReference}.
    *
-   * @param documentRef A reference to the document to be deleted.
-   * @return This `Transaction` instance. Used for chaining method calls.
+   * @param documentRef - A reference to the document to be deleted.
+   * @returns This `Transaction` instance. Used for chaining method calls.
    */
   delete(documentRef: DocumentReference<unknown>): this {
     const ref = validateReference(documentRef, this._firestore);
@@ -252,10 +253,11 @@ export class Transaction {
  *
  * The maximum number of writes allowed in a single transaction is 500.
  *
- * @param firestore A reference to the Firestore database to run this
+ * @param firestore - A reference to the Firestore database to run this
  * transaction against.
- * @param updateFunction The function to execute within the transaction context.
- * @return  If the transaction completed successfully or was explicitly aborted
+ * @param updateFunction - The function to execute within the transaction
+ * context.
+ * @returns If the transaction completed successfully or was explicitly aborted
  * (the `updateFunction` returned a failed promise), the promise returned by the
  * `updateFunction `is returned here. Otherwise, if the transaction failed, a
  * rejected promise with the corresponding failure error is returned.

--- a/packages/firestore/lite/src/api/write_batch.ts
+++ b/packages/firestore/lite/src/api/write_batch.ts
@@ -43,9 +43,9 @@ import { Compat } from '../../../src/compat/compat';
 /**
  * A write batch, used to perform multiple writes as a single atomic unit.
  *
- * A `WriteBatch` object can be acquired by calling {@link writeBatch()}. It
+ * A `WriteBatch` object can be acquired by calling {@link writeBatch}. It
  * provides methods for adding writes to the write batch. None of the writes
- * will be committed (or visible locally) until {@link WriteBatch#commit()} is
+ * will be committed (or visible locally) until {@link WriteBatch#commit} is
  * called.
  */
 export class WriteBatch {
@@ -56,6 +56,7 @@ export class WriteBatch {
   private _mutations = [] as Mutation[];
   private _committed = false;
 
+  /** @hideconstructor */
   constructor(
     private readonly _firestore: FirebaseFirestore,
     private readonly _commitHandler: (m: Mutation[]) => Promise<void>
@@ -67,9 +68,9 @@ export class WriteBatch {
    * Writes to the document referred to by the provided {@link
    * DocumentReference}. If the document does not exist yet, it will be created.
    *
-   * @param documentRef A reference to the document to be set.
-   * @param data An object of the fields and values for the document.
-   * @return This `WriteBatch` instance. Used for chaining method calls.
+   * @param documentRef - A reference to the document to be set.
+   * @param data - An object of the fields and values for the document.
+   * @returns This `WriteBatch` instance. Used for chaining method calls.
    */
   set<T>(documentRef: DocumentReference<T>, data: T): WriteBatch;
   /**
@@ -78,10 +79,10 @@ export class WriteBatch {
    * If you provide `merge` or `mergeFields`, the provided data can be merged
    * into an existing document.
    *
-   * @param documentRef A reference to the document to be set.
-   * @param data An object of the fields and values for the document.
-   * @param options An object to configure the set behavior.
-   * @return This `WriteBatch` instance. Used for chaining method calls.
+   * @param documentRef - A reference to the document to be set.
+   * @param data - An object of the fields and values for the document.
+   * @param options - An object to configure the set behavior.
+   * @returns This `WriteBatch` instance. Used for chaining method calls.
    */
   set<T>(
     documentRef: DocumentReference<T>,
@@ -120,11 +121,11 @@ export class WriteBatch {
    * DocumentReference}. The update will fail if applied to a document that does
    * not exist.
    *
-   * @param documentRef A reference to the document to be updated.
-   * @param data An object containing the fields and values with which to
+   * @param documentRef - A reference to the document to be updated.
+   * @param data - An object containing the fields and values with which to
    * update the document. Fields can contain dots to reference nested fields
    * within the document.
-   * @return This `WriteBatch` instance. Used for chaining method calls.
+   * @returns This `WriteBatch` instance. Used for chaining method calls.
    */
   update(documentRef: DocumentReference<unknown>, data: UpdateData): WriteBatch;
   /**
@@ -135,11 +136,11 @@ export class WriteBatch {
    * Nested fields can be update by providing dot-separated field path strings
    * or by providing `FieldPath` objects.
    *
-   * @param documentRef A reference to the document to be updated.
-   * @param field The first field to update.
-   * @param value The first value.
-   * @param moreFieldsAndValues Additional key value pairs.
-   * @return This `WriteBatch` instance. Used for chaining method calls.
+   * @param documentRef - A reference to the document to be updated.
+   * @param field - The first field to update.
+   * @param value - The first value.
+   * @param moreFieldsAndValues - Additional key value pairs.
+   * @returns This `WriteBatch` instance. Used for chaining method calls.
    */
   update(
     documentRef: DocumentReference<unknown>,
@@ -193,8 +194,8 @@ export class WriteBatch {
   /**
    * Deletes the document referred to by the provided {@link DocumentReference}.
    *
-   * @param documentRef A reference to the document to be deleted.
-   * @return This `WriteBatch` instance. Used for chaining method calls.
+   * @param documentRef - A reference to the document to be deleted.
+   * @returns This `WriteBatch` instance. Used for chaining method calls.
    */
   delete(documentRef: DocumentReference<unknown>): WriteBatch {
     this.verifyNotCommitted();
@@ -213,7 +214,7 @@ export class WriteBatch {
    * write fails. If you would like to see local modifications or buffer writes
    * until the client is online, use the full Firestore SDK.
    *
-   * @return A Promise resolved once all of the writes in the batch have been
+   * @returns A Promise resolved once all of the writes in the batch have been
    * successfully written to the backend as an atomic unit (note that it won't
    * resolve while you're offline).
    */
@@ -265,7 +266,7 @@ export function validateReference<T>(
  * write fails. If you would like to see local modifications or buffer writes
  * until the client is online, use the full Firestore SDK.
  *
- * @return A `WriteBatch` that can be used to atomically execute multiple
+ * @returns A `WriteBatch` that can be used to atomically execute multiple
  * writes.
  */
 export function writeBatch(firestore: FirebaseFirestore): WriteBatch {

--- a/packages/firestore/src/api/bundle.ts
+++ b/packages/firestore/src/api/bundle.ts
@@ -124,7 +124,7 @@ export class LoadBundleTask
 
   /**
    * Notifies a progress update of loading a bundle.
-   * @param progress The new progress.
+   * @param progress - The new progress.
    */
   _updateProgress(progress: ApiLoadBundleTaskProgress): void {
     debugAssert(

--- a/packages/firestore/src/api/database.ts
+++ b/packages/firestore/src/api/database.ts
@@ -819,8 +819,8 @@ export function extractSnapshotOptions(
  * observer converts all observed values into the format expected by the classic
  * SDK.
  *
- * @param args The list of arguments from an `onSnapshot` call.
- * @param wrapper The function that converts the firestore-exp type into the
+ * @param args - The list of arguments from an `onSnapshot` call.
+ * @param wrapper - The function that converts the firestore-exp type into the
  * type used by this shim.
  */
 export function wrapObserver<CompatType, ExpType>(
@@ -880,6 +880,7 @@ export class SnapshotMetadata implements PublicSnapshotMetadata {
    */
   readonly fromCache: boolean;
 
+  /** @hideconstructor */
   constructor(hasPendingWrites: boolean, fromCache: boolean) {
     this.hasPendingWrites = hasPendingWrites;
     this.fromCache = fromCache;
@@ -888,8 +889,8 @@ export class SnapshotMetadata implements PublicSnapshotMetadata {
   /**
    * Returns true if this `SnapshotMetadata` is equal to the provided one.
    *
-   * @param other The `SnapshotMetadata` to compare against.
-   * @return true if this `SnapshotMetadata` is equal to the provided one.
+   * @param other - The `SnapshotMetadata` to compare against.
+   * @returns true if this `SnapshotMetadata` is equal to the provided one.
    */
   isEqual(other: PublicSnapshotMetadata): boolean {
     return (

--- a/packages/firestore/src/api/field_path.ts
+++ b/packages/firestore/src/api/field_path.ts
@@ -35,7 +35,7 @@ export class FieldPath extends Compat<ExpFieldPath> implements PublicFieldPath {
    * Creates a FieldPath from the provided field names. If more than one field
    * name is provided, the path will point to a nested field in a document.
    *
-   * @param fieldNames A list of field names.
+   * @param fieldNames - A list of field names.
    */
   constructor(...fieldNames: string[]) {
     super(new ExpFieldPath(...fieldNames));

--- a/packages/firestore/src/api/field_value.ts
+++ b/packages/firestore/src/api/field_value.ts
@@ -69,10 +69,10 @@ export class DeleteFieldValueImpl extends FieldValue {
  * are not considered writes since they cannot contain any FieldValue sentinels,
  * etc.
  *
- * @param fieldValue The sentinel FieldValue for which to create a child
+ * @param fieldValue - The sentinel FieldValue for which to create a child
  *     context.
- * @param context The parent context.
- * @param arrayElement Whether or not the FieldValue has an array.
+ * @param context - The parent context.
+ * @param arrayElement - Whether or not the FieldValue has an array.
  */
 function createSentinelChildContext(
   fieldValue: FieldValue,

--- a/packages/firestore/src/api/geo_point.ts
+++ b/packages/firestore/src/api/geo_point.ts
@@ -34,8 +34,8 @@ export class GeoPoint {
   /**
    * Creates a new immutable `GeoPoint` object with the provided latitude and
    * longitude values.
-   * @param latitude The latitude as number between -90 and 90.
-   * @param longitude The longitude as number between -180 and 180.
+   * @param latitude - The latitude as number between -90 and 90.
+   * @param longitude - The longitude as number between -180 and 180.
    */
   constructor(latitude: number, longitude: number) {
     if (!isFinite(latitude) || latitude < -90 || latitude > 90) {
@@ -72,8 +72,8 @@ export class GeoPoint {
   /**
    * Returns true if this `GeoPoint` is equal to the provided one.
    *
-   * @param other The `GeoPoint` to compare against.
-   * @return true if this `GeoPoint` is equal to the provided one.
+   * @param other - The `GeoPoint` to compare against.
+   * @returns true if this `GeoPoint` is equal to the provided one.
    */
   isEqual(other: GeoPoint): boolean {
     return this._lat === other._lat && this._long === other._long;

--- a/packages/firestore/src/api/timestamp.ts
+++ b/packages/firestore/src/api/timestamp.ts
@@ -38,7 +38,7 @@ export class Timestamp {
   /**
    * Creates a new timestamp with the current date, with millisecond precision.
    *
-   * @return a new timestamp representing the current date.
+   * @returns a new timestamp representing the current date.
    */
   static now(): Timestamp {
     return Timestamp.fromMillis(Date.now());
@@ -47,8 +47,8 @@ export class Timestamp {
   /**
    * Creates a new timestamp from the given date.
    *
-   * @param date The date to initialize the `Timestamp` from.
-   * @return A new `Timestamp` representing the same point in time as the given
+   * @param date - The date to initialize the `Timestamp` from.
+   * @returns A new `Timestamp` representing the same point in time as the given
    *     date.
    */
   static fromDate(date: Date): Timestamp {
@@ -58,9 +58,9 @@ export class Timestamp {
   /**
    * Creates a new timestamp from the given number of milliseconds.
    *
-   * @param milliseconds Number of milliseconds since Unix epoch
+   * @param milliseconds - Number of milliseconds since Unix epoch
    *     1970-01-01T00:00:00Z.
-   * @return A new `Timestamp` representing the same point in time as the given
+   * @returns A new `Timestamp` representing the same point in time as the given
    *     number of milliseconds.
    */
   static fromMillis(milliseconds: number): Timestamp {
@@ -72,10 +72,10 @@ export class Timestamp {
   /**
    * Creates a new timestamp.
    *
-   * @param seconds The number of seconds of UTC time since Unix epoch
+   * @param seconds - The number of seconds of UTC time since Unix epoch
    *     1970-01-01T00:00:00Z. Must be from 0001-01-01T00:00:00Z to
    *     9999-12-31T23:59:59Z inclusive.
-   * @param nanoseconds The non-negative fractions of a second at nanosecond
+   * @param nanoseconds - The non-negative fractions of a second at nanosecond
    *     resolution. Negative second values with fractions must still have
    *     non-negative nanoseconds values that count forward in time. Must be
    *     from 0 to 999,999,999 inclusive.
@@ -112,7 +112,7 @@ export class Timestamp {
    * Converts a `Timestamp` to a JavaScript `Date` object. This conversion causes
    * a loss of precision since `Date` objects only support millisecond precision.
    *
-   * @return JavaScript `Date` object representing the same point in time as
+   * @returns JavaScript `Date` object representing the same point in time as
    *     this `Timestamp`, with millisecond precision.
    */
   toDate(): Date {
@@ -123,7 +123,7 @@ export class Timestamp {
    * Converts a `Timestamp` to a numeric timestamp (in milliseconds since
    * epoch). This operation causes a loss of precision.
    *
-   * @return The point in time corresponding to this timestamp, represented as
+   * @returns The point in time corresponding to this timestamp, represented as
    *     the number of milliseconds since Unix epoch 1970-01-01T00:00:00Z.
    */
   toMillis(): number {
@@ -140,8 +140,8 @@ export class Timestamp {
   /**
    * Returns true if this `Timestamp` is equal to the provided one.
    *
-   * @param other The `Timestamp` to compare against.
-   * @return true if this `Timestamp` is equal to the provided one.
+   * @param other - The `Timestamp` to compare against.
+   * @returns true if this `Timestamp` is equal to the provided one.
    */
   isEqual(other: Timestamp): boolean {
     return (

--- a/packages/firestore/src/api/user_data_reader.ts
+++ b/packages/firestore/src/api/user_data_reader.ts
@@ -183,15 +183,15 @@ export class ParseContext {
   /**
    * Initializes a ParseContext with the given source and path.
    *
-   * @param settings The settings for the parser.
-   * @param databaseId The database ID of the Firestore instance.
-   * @param serializer The serializer to use to generate the Value proto.
-   * @param ignoreUndefinedProperties Whether to ignore undefined properties
+   * @param settings - The settings for the parser.
+   * @param databaseId - The database ID of the Firestore instance.
+   * @param serializer - The serializer to use to generate the Value proto.
+   * @param ignoreUndefinedProperties - Whether to ignore undefined properties
    * rather than throw.
-   * @param fieldTransforms A mutable list of field transforms encountered while
-   *     parsing the data.
-   * @param fieldMask A mutable list of field paths encountered while parsing
-   *     the data.
+   * @param fieldTransforms - A mutable list of field transforms encountered
+   * while parsing the data.
+   * @param fieldMask - A mutable list of field paths encountered while parsing
+   * the data.
    *
    * TODO(b/34871131): We don't support array paths right now, so path can be
    * null to indicate the context represents any location within an array (in
@@ -520,7 +520,7 @@ export function parseUpdateVarargs(
  * Parse a "query value" (e.g. value in a where filter or a value in a cursor
  * bound).
  *
- * @param allowArrays Whether the query value is an array that may directly
+ * @param allowArrays - Whether the query value is an array that may directly
  * contain additional arrays (e.g. the operand of an `in` query).
  */
 export function parseQueryValue(
@@ -545,10 +545,10 @@ export function parseQueryValue(
 /**
  * Parses user data to Protobuf Values.
  *
- * @param input Data to be parsed.
- * @param context A context object representing the current path being parsed,
+ * @param input - Data to be parsed.
+ * @param context - A context object representing the current path being parsed,
  * the source of the data being parsed, etc.
- * @return The parsed value, or null if the value was a FieldValue sentinel
+ * @returns The parsed value, or null if the value was a FieldValue sentinel
  * that should not be included in the resulting parsed data.
  */
 export function parseData(
@@ -671,7 +671,7 @@ function parseSentinelFieldValue(
 /**
  * Helper to parse a scalar value (i.e. not an Object, Array, or FieldValue)
  *
- * @return The parsed value
+ * @returns The parsed value
  */
 function parseScalarValue(
   value: unknown,
@@ -814,10 +814,11 @@ const FIELD_PATH_RESERVED = new RegExp('[~\\*/\\[\\]]');
 /**
  * Wraps fromDotSeparatedString with an error message about the method that
  * was thrown.
- * @param methodName The publicly visible method name
- * @param path The dot-separated string form of a field path which will be split
- * on dots.
- * @param targetDoc The document against which the field path will be evaluated.
+ * @param methodName - The publicly visible method name
+ * @param path - The dot-separated string form of a field path which will be
+ * split on dots.
+ * @param targetDoc - The document against which the field path will be
+ * evaluated.
  */
 export function fieldPathFromDotSeparatedString(
   methodName: string,

--- a/packages/firestore/src/config.ts
+++ b/packages/firestore/src/config.ts
@@ -60,8 +60,8 @@ const firestoreNamespace = {
 /**
  * Configures Firestore as part of the Firebase SDK by calling registerService.
  *
- * @param firebase The FirebaseNamespace to register Firestore with
- * @param firestoreFactory A factory function that returns a new Firestore
+ * @param firebase - The FirebaseNamespace to register Firestore with
+ * @param firestoreFactory - A factory function that returns a new Firestore
  *    instance.
  */
 export function configureForFirebase(

--- a/packages/firestore/src/core/database_info.ts
+++ b/packages/firestore/src/core/database_info.ts
@@ -20,14 +20,14 @@ export class DatabaseInfo {
    * Constructs a DatabaseInfo using the provided host, databaseId and
    * persistenceKey.
    *
-   * @param databaseId The database to use.
-   * @param persistenceKey A unique identifier for this Firestore's local
+   * @param databaseId - The database to use.
+   * @param persistenceKey - A unique identifier for this Firestore's local
    * storage (used in conjunction with the databaseId).
-   * @param host The Firestore backend host to connect to.
-   * @param ssl Whether to use SSL when connecting.
-   * @param forceLongPolling Whether to use the forceLongPolling option
+   * @param host - The Firestore backend host to connect to.
+   * @param ssl - Whether to use SSL when connecting.
+   * @param forceLongPolling - Whether to use the forceLongPolling option
    * when using WebChannel as the network transport.
-   * @param autoDetectLongPolling Whether to use the detectBufferingProxy
+   * @param autoDetectLongPolling - Whether to use the detectBufferingProxy
    * option when using WebChannel as the network transport.
    */
   constructor(

--- a/packages/firestore/src/core/sync_engine.ts
+++ b/packages/firestore/src/core/sync_engine.ts
@@ -593,10 +593,10 @@ export function applyOnlineStateChange(
  * Rejects the listen for the given targetID. This can be triggered by the
  * backend for any active target.
  *
- * @param syncEngine The sync engine implementation.
- * @param targetId The targetID corresponds to one previously initiated by the
+ * @param syncEngine - The sync engine implementation.
+ * @param targetId - The targetID corresponds to one previously initiated by the
  * user as part of TargetData passed to listen() on RemoteStore.
- * @param err A description of the condition that has forced the rejection.
+ * @param err - A description of the condition that has forced the rejection.
  * Nearly always this will be an indication that the user is no longer
  * authorized to see the data matching the target.
  */
@@ -1298,9 +1298,9 @@ function resetLimboDocuments(syncEngine: SyncEngine): void {
  * persistence. Raises snapshots for any changes that affect the local
  * client and returns the updated state of all target's query data.
  *
- * @param syncEngine The sync engine implementation
- * @param targets the list of targets with views that need to be recomputed
- * @param transitionToPrimary `true` iff the tab transitions from a secondary
+ * @param syncEngine - The sync engine implementation
+ * @param targets - the list of targets with views that need to be recomputed
+ * @param transitionToPrimary - `true` iff the tab transitions from a secondary
  * tab to a primary tab
  */
 // PORTING NOTE: Multi-Tab only.
@@ -1537,8 +1537,8 @@ export function ensureWriteCallbacks(syncEngine: SyncEngine): SyncEngineImpl {
  * Loads a Firestore bundle into the SDK. The returned promise resolves when
  * the bundle finished loading.
  *
- * @param bundleReader Bundle to load into the SDK.
- * @param task LoadBundleTask used to update the loading progress to public API.
+ * @param bundleReader - Bundle to load into the SDK.
+ * @param task - LoadBundleTask used to update the loading progress to public API.
  */
 export function syncEngineLoadBundle(
   syncEngine: SyncEngine,

--- a/packages/firestore/src/core/view.ts
+++ b/packages/firestore/src/core/view.ts
@@ -115,10 +115,10 @@ export class View {
    * what the new results should be, what the changes were, and whether we may
    * need to go back to the local cache for more results. Does not make any
    * changes to the view.
-   * @param docChanges The doc changes to apply to this view.
-   * @param previousChanges If this is being called with a refill, then start
+   * @param docChanges - The doc changes to apply to this view.
+   * @param previousChanges - If this is being called with a refill, then start
    *        with this set of docs and changes instead of the current view.
-   * @return a new set of docs, changes, and refill flag.
+   * @returns a new set of docs, changes, and refill flag.
    */
   computeDocChanges(
     docChanges: MaybeDocumentMap,
@@ -284,12 +284,12 @@ export class View {
   /**
    * Updates the view with the given ViewDocumentChanges and optionally updates
    * limbo docs and sync state from the provided target change.
-   * @param docChanges The set of changes to make to the view's docs.
-   * @param updateLimboDocuments Whether to update limbo documents based on this
-   *        change.
-   * @param targetChange A target change to apply for computing limbo docs and
+   * @param docChanges - The set of changes to make to the view's docs.
+   * @param updateLimboDocuments - Whether to update limbo documents based on
+   *        this change.
+   * @param targetChange - A target change to apply for computing limbo docs and
    *        sync state.
-   * @return A new ViewChange with the given docs, changes, and sync state.
+   * @returns A new ViewChange with the given docs, changes, and sync state.
    */
   // PORTING NOTE: The iOS/Android clients always compute limbo document changes.
   applyChanges(
@@ -462,7 +462,7 @@ export class View {
    * @param queryResult.remoteKeys - The keys of the documents that match the
    * query according to the backend.
    *
-   * @return The ViewChange that resulted from this synchronization.
+   * @returns The ViewChange that resulted from this synchronization.
    */
   // PORTING NOTE: Multi-tab only.
   synchronizeWithPersistedState(queryResult: QueryResult): ViewChange {

--- a/packages/firestore/src/local/index_free_query_engine.ts
+++ b/packages/firestore/src/local/index_free_query_engine.ts
@@ -155,12 +155,12 @@ export class IndexFreeQueryEngine implements QueryEngine {
    * Determines if a limit query needs to be refilled from cache, making it
    * ineligible for index-free execution.
    *
-   * @param sortedPreviousResults The documents that matched the query when it
+   * @param sortedPreviousResults - The documents that matched the query when it
    * was last synchronized, sorted by the query's comparator.
-   * @param remoteKeys The document keys that matched the query at the last
+   * @param remoteKeys - The document keys that matched the query at the last
    * snapshot.
-   * @param limboFreeSnapshotVersion The version of the snapshot when the query
-   * was last synchronized.
+   * @param limboFreeSnapshotVersion - The version of the snapshot when the
+   * query was last synchronized.
    */
   private needsRefill(
     limitType: LimitType,

--- a/packages/firestore/src/local/index_manager.ts
+++ b/packages/firestore/src/local/index_manager.ts
@@ -22,7 +22,7 @@ import { PersistencePromise } from './persistence_promise';
 /**
  * Represents a set of indexes that are used to execute queries efficiently.
  *
- * Currently the only index is a [collection id] => [parent path] index, used
+ * Currently the only index is a [collection id] =&gt; [parent path] index, used
  * to execute Collection Group queries.
  */
 export interface IndexManager {

--- a/packages/firestore/src/local/indexeddb_mutation_queue.ts
+++ b/packages/firestore/src/local/indexeddb_mutation_queue.ts
@@ -81,8 +81,8 @@ export class IndexedDbMutationQueue implements MutationQueue {
 
   /**
    * Creates a new mutation queue for the given user.
-   * @param user The user for which to create a mutation queue.
-   * @param serializer The serializer to use when persisting to IndexedDb.
+   * @param user - The user for which to create a mutation queue.
+   * @param serializer - The serializer to use when persisting to IndexedDb.
    */
   static forUser(
     user: User,
@@ -574,7 +574,7 @@ export class IndexedDbMutationQueue implements MutationQueue {
 }
 
 /**
- * @return true if the mutation queue for the given user contains a pending
+ * @returns true if the mutation queue for the given user contains a pending
  *         mutation for the given key.
  */
 function mutationQueueContainsKey(
@@ -617,7 +617,7 @@ export function mutationQueuesContainKey(
 
 /**
  * Delete a mutation batch and the associated document mutations.
- * @return A PersistencePromise of the document mutations that were removed.
+ * @returns A PersistencePromise of the document mutations that were removed.
  */
 export function removeMutationBatch(
   txn: SimpleDbTransaction,

--- a/packages/firestore/src/local/indexeddb_persistence.ts
+++ b/packages/firestore/src/local/indexeddb_persistence.ts
@@ -292,7 +292,7 @@ export class IndexedDbPersistence implements Persistence {
   /**
    * Attempt to start IndexedDb persistence.
    *
-   * @return {Promise<void>} Whether persistence was enabled.
+   * @returns Whether persistence was enabled.
    */
   start(): Promise<void> {
     debugAssert(!this.started, 'IndexedDbPersistence double-started!');
@@ -1306,7 +1306,7 @@ function sentinelKey(key: DocumentKey): [TargetId, EncodedResourcePath] {
 }
 
 /**
- * @return A value suitable for writing a sentinel row in the target-document
+ * @returns A value suitable for writing a sentinel row in the target-document
  * store.
  */
 function sentinelRow(

--- a/packages/firestore/src/local/indexeddb_remote_document_cache.ts
+++ b/packages/firestore/src/local/indexeddb_remote_document_cache.ts
@@ -69,8 +69,8 @@ export interface IndexedDbRemoteDocumentCache extends RemoteDocumentCache {
  */
 class IndexedDbRemoteDocumentCacheImpl implements IndexedDbRemoteDocumentCache {
   /**
-   * @param serializer The document serializer.
-   * @param indexManager The query indexes that need to be maintained.
+   * @param serializer - The document serializer.
+   * @param indexManager - The query indexes that need to be maintained.
    */
   constructor(
     readonly serializer: LocalSerializer,
@@ -137,8 +137,9 @@ class IndexedDbRemoteDocumentCacheImpl implements IndexedDbRemoteDocumentCache {
   /**
    * Looks up an entry in the cache.
    *
-   * @param documentKey The key of the entry to look up.
-   * @return The cached MaybeDocument entry and its size, or null if we have nothing cached.
+   * @param documentKey - The key of the entry to look up.
+   * @returns The cached MaybeDocument entry and its size, or null if we have
+   * nothing cached.
    */
   getSizedEntry(
     transaction: PersistenceTransaction,
@@ -175,8 +176,8 @@ class IndexedDbRemoteDocumentCacheImpl implements IndexedDbRemoteDocumentCache {
   /**
    * Looks up several entries in the cache.
    *
-   * @param documentKeys The set of keys entries to look up.
-   * @return A map of MaybeDocuments indexed by key (if a document cannot be
+   * @param documentKeys - The set of keys entries to look up.
+   * @returns A map of MaybeDocuments indexed by key (if a document cannot be
    *     found, the key will be mapped to null) and a map of sizes indexed by
    *     key (zero if the key cannot be found).
    */
@@ -367,8 +368,8 @@ class IndexedDbRemoteDocumentCacheImpl implements IndexedDbRemoteDocumentCache {
 /**
  * Creates a new IndexedDbRemoteDocumentCache.
  *
- * @param serializer The document serializer.
- * @param indexManager The query indexes that need to be maintained.
+ * @param serializer - The document serializer.
+ * @param indexManager - The query indexes that need to be maintained.
  */
 export function newIndexedDbRemoteDocumentCache(
   serializer: LocalSerializer,
@@ -463,8 +464,8 @@ class IndexedDbRemoteDocumentChangeBuffer extends RemoteDocumentChangeBuffer {
   );
 
   /**
-   * @param documentCache The IndexedDbRemoteDocumentCache to apply the changes to.
-   * @param trackRemovals Whether to create sentinel deletes that can be tracked by
+   * @param documentCache - The IndexedDbRemoteDocumentCache to apply the changes to.
+   * @param trackRemovals - Whether to create sentinel deletes that can be tracked by
    * `getNewDocumentChanges()`.
    */
   constructor(

--- a/packages/firestore/src/local/indexeddb_schema.ts
+++ b/packages/firestore/src/local/indexeddb_schema.ts
@@ -737,8 +737,8 @@ export class DbRemoteDocumentGlobal {
   static key = 'remoteDocumentGlobalKey';
 
   /**
-   * @param byteSize Approximately the total size in bytes of all the documents in the document
-   * cache.
+   * @param byteSize - Approximately the total size in bytes of all the
+   * documents in the document cache.
    */
   constructor(public byteSize: number) {}
 }
@@ -1027,7 +1027,7 @@ function dropRemoteDocumentChangesStore(db: IDBDatabase): void {
 /**
  * Creates the target global singleton row.
  *
- * @param {IDBTransaction} txn The version upgrade transaction for indexeddb
+ * @param txn - The version upgrade transaction for indexeddb
  */
 function writeEmptyTargetGlobalEntry(
   txn: SimpleDbTransaction

--- a/packages/firestore/src/local/indexeddb_target_cache.ts
+++ b/packages/firestore/src/local/indexeddb_target_cache.ts
@@ -379,8 +379,8 @@ export class IndexedDbTargetCache implements TargetCache {
   /**
    * Looks up a TargetData entry by target ID.
    *
-   * @param targetId The target ID of the TargetData entry to look up.
-   * @return The cached TargetData entry, or null if the cache has no entry for
+   * @param targetId - The target ID of the TargetData entry to look up.
+   * @returns The cached TargetData entry, or null if the cache has no entry for
    * the target.
    */
   // PORTING NOTE: Multi-tab only.

--- a/packages/firestore/src/local/local_documents_view.ts
+++ b/packages/firestore/src/local/local_documents_view.ts
@@ -62,7 +62,7 @@ export class LocalDocumentsView {
   /**
    * Get the local view of the document identified by `key`.
    *
-   * @return Local view of the document or null if we don't have any cached
+   * @returns Local view of the document or null if we don't have any cached
    * state for it.
    */
   getDocument(
@@ -152,9 +152,9 @@ export class LocalDocumentsView {
   /**
    * Performs a query against the local view of all documents.
    *
-   * @param transaction The persistence transaction.
-   * @param query The query to match documents against.
-   * @param sinceReadTime If not set to SnapshotVersion.min(), return only
+   * @param transaction - The persistence transaction.
+   * @param query - The query to match documents against.
+   * @param sinceReadTime - If not set to SnapshotVersion.min(), return only
    *     documents that have been read since this snapshot version (exclusive).
    */
   getDocumentsMatchingQuery(

--- a/packages/firestore/src/local/local_store.ts
+++ b/packages/firestore/src/local/local_store.ts
@@ -652,13 +652,13 @@ export function applyRemoteEventToLocalCache(
  * Populates document change buffer with documents from backend or a bundle.
  * Returns the document changes resulting from applying those documents.
  *
- * @param txn Transaction to use to read existing documents from storage.
- * @param documentBuffer Document buffer to collect the resulted changes to be
+ * @param txn - Transaction to use to read existing documents from storage.
+ * @param documentBuffer - Document buffer to collect the resulted changes to be
  *        applied to storage.
- * @param documents Documents to be applied.
- * @param globalVersion A `SnapshotVersion` representing the read time if all
+ * @param documents - Documents to be applied.
+ * @param globalVersion - A `SnapshotVersion` representing the read time if all
  *        documents have the same read time.
- * @param documentVersions A DocumentKey-to-SnapshotVersion map if documents
+ * @param documentVersions - A DocumentKey-to-SnapshotVersion map if documents
  *        have their own read time.
  *
  * Note: this function will use `documentVersions` if it is defined;
@@ -849,7 +849,7 @@ export async function notifyLocalViewChanges(
 /**
  * Gets the mutation batch after the passed in batchId in the mutation queue
  * or null if empty.
- * @param afterBatchId If provided, the batch to search after.
+ * @param afterBatchId - If provided, the batch to search after.
  * @returns The next mutation or null if there wasn't one.
  */
 export function nextMutationBatch(
@@ -1034,7 +1034,7 @@ export async function releaseTarget(
  * potentially taking advantage of query data from previous executions (such
  * as the set of remote keys).
  *
- * @param usePreviousResults Whether results from previous executions can
+ * @param usePreviousResults - Whether results from previous executions can
  * be used to optimize this query execution.
  */
 export function executeQuery(
@@ -1256,8 +1256,8 @@ export async function synchronizeLastDocumentChangeReadTime(
  * `applyPrimaryLease` to propagate the primary state change). All other errors
  * are re-thrown.
  *
- * @param err An error returned by a LocalStore operation.
- * @return A Promise that resolves after we recovered, or the original error.
+ * @param err - An error returned by a LocalStore operation.
+ * @returns A Promise that resolves after we recovered, or the original error.
  */
 export async function ignoreIfPrimaryLeaseLoss(
   err: FirestoreError
@@ -1391,7 +1391,6 @@ export function hasNewerBundle(
 
 /**
  * Saves the given `BundleMetadata` to local persistence.
- * @param bundleMetadata
  */
 export function saveBundle(
   localStore: LocalStore,

--- a/packages/firestore/src/local/lru_garbage_collector.ts
+++ b/packages/firestore/src/local/lru_garbage_collector.ts
@@ -65,7 +65,7 @@ export interface LruDelegate {
    * Removes all targets that have a sequence number less than or equal to `upperBound`, and are not
    * present in the `activeTargetIds` set.
    *
-   * @return the number of targets removed.
+   * @returns the number of targets removed.
    */
   removeTargets(
     txn: PersistenceTransaction,
@@ -77,7 +77,7 @@ export interface LruDelegate {
    * Removes all unreferenced documents from the cache that have a sequence number less than or
    * equal to the given `upperBound`.
    *
-   * @return the number of documents removed.
+   * @returns the number of documents removed.
    */
   removeOrphanedDocuments(
     txn: PersistenceTransaction,

--- a/packages/firestore/src/local/memory_mutation_queue.ts
+++ b/packages/firestore/src/local/memory_mutation_queue.ts
@@ -290,8 +290,8 @@ export class MemoryMutationQueue implements MutationQueue {
    * Finds the index of the given batchId in the mutation queue and asserts that
    * the resulting index is within the bounds of the queue.
    *
-   * @param batchId The batchId to search for
-   * @param action A description of what the caller is doing, phrased in passive
+   * @param batchId - The batchId to search for
+   * @param action - A description of what the caller is doing, phrased in passive
    * form (e.g. "acknowledged" in a routine that acknowledges batches).
    */
   private indexOfExistingBatchId(batchId: BatchId, action: string): number {
@@ -307,7 +307,7 @@ export class MemoryMutationQueue implements MutationQueue {
    * Finds the index of the given batchId in the mutation queue. This operation
    * is O(1).
    *
-   * @return The computed index of the batch with the given batchId, based on
+   * @returns The computed index of the batch with the given batchId, based on
    * the state of the queue. Note this index can be negative if the requested
    * batchId has already been remvoed from the queue or past the end of the
    * queue if the batchId is larger than the last added batch.

--- a/packages/firestore/src/local/memory_remote_document_cache.ts
+++ b/packages/firestore/src/local/memory_remote_document_cache.ts
@@ -69,8 +69,9 @@ class MemoryRemoteDocumentCacheImpl implements MemoryRemoteDocumentCache {
   private size = 0;
 
   /**
-   * @param sizer Used to assess the size of a document. For eager GC, this is expected to just
-   * return 0 to avoid unnecessarily doing the work of calculating the size.
+   * @param sizer - Used to assess the size of a document. For eager GC, this is
+   * expected to just return 0 to avoid unnecessarily doing the work of
+   * calculating the size.
    */
   constructor(
     private readonly indexManager: IndexManager,
@@ -205,9 +206,10 @@ class MemoryRemoteDocumentCacheImpl implements MemoryRemoteDocumentCache {
 /**
  * Creates a new memory-only RemoteDocumentCache.
  *
- * @param indexManager A class that manages collection group indices.
- * @param sizer Used to assess the size of a document. For eager GC, this is expected to just
- * return 0 to avoid unnecessarily doing the work of calculating the size.
+ * @param indexManager - A class that manages collection group indices.
+ * @param sizer - Used to assess the size of a document. For eager GC, this is
+ * expected to just return 0 to avoid unnecessarily doing the work of
+ * calculating the size.
  */
 export function newMemoryRemoteDocumentCache(
   indexManager: IndexManager,

--- a/packages/firestore/src/local/mutation_queue.ts
+++ b/packages/firestore/src/local/mutation_queue.ts
@@ -34,12 +34,12 @@ export interface MutationQueue {
   /**
    * Creates a new mutation batch and adds it to this mutation queue.
    *
-   * @param transaction The transaction this operation is scoped to.
-   * @param localWriteTime The original write time of this mutation.
-   * @param baseMutations Mutations that are used to populate the base values
+   * @param transaction - The transaction this operation is scoped to.
+   * @param localWriteTime - The original write time of this mutation.
+   * @param baseMutations - Mutations that are used to populate the base values
    * when this mutation is applied locally. These mutations are used to locally
    * overwrite values that are persisted in the remote document cache.
-   * @param mutations The user-provided mutations in this mutation batch.
+   * @param mutations - The user-provided mutations in this mutation batch.
    */
   addMutationBatch(
     transaction: PersistenceTransaction,
@@ -60,10 +60,10 @@ export interface MutationQueue {
    * Gets the first unacknowledged mutation batch after the passed in batchId
    * in the mutation queue or null if empty.
    *
-   * @param batchId The batch to search after, or BATCHID_UNKNOWN for the first
-   * mutation in the queue.
+   * @param batchId - The batch to search after, or BATCHID_UNKNOWN for the
+   * first mutation in the queue.
    *
-   * @return the next mutation or null if there wasn't one.
+   * @returns the next mutation or null if there wasn't one.
    */
   getNextMutationBatchAfterBatchId(
     transaction: PersistenceTransaction,
@@ -71,10 +71,12 @@ export interface MutationQueue {
   ): PersistencePromise<MutationBatch | null>;
 
   /**
-   * Gets the largest (latest) batch id in mutation queue for the current user that is pending
-   * server response, returns `BATCHID_UNKNOWN` if the queue is empty.
+   * Gets the largest (latest) batch id in mutation queue for the current user
+   * that is pending server response, returns `BATCHID_UNKNOWN` if the queue is
+   * empty.
    *
-   * @return the largest batch id in the mutation queue that is not acknowledged.
+   * @returns the largest batch id in the mutation queue that is not
+   * acknowledged.
    */
   getHighestUnacknowledgedBatchId(
     transaction: PersistenceTransaction

--- a/packages/firestore/src/local/persistence.ts
+++ b/packages/firestore/src/local/persistence.ts
@@ -202,7 +202,7 @@ export interface Persistence {
    * this is called for a given user. In particular, the memory-backed
    * implementation does this to emulate the persisted implementation to the
    * extent possible (e.g. in the case of uid switching from
-   * sally=>jack=>sally, sally's mutation queue will be preserved).
+   * sally=&gt;jack=&gt;sally, sally's mutation queue will be preserved).
    */
   getMutationQueue(user: User): MutationQueue;
 
@@ -253,16 +253,16 @@ export interface Persistence {
    * the transaction will be committed and the Promise returned by this method
    * will resolve.
    *
-   * @param action A description of the action performed by this transaction,
+   * @param action - A description of the action performed by this transaction,
    * used for logging.
-   * @param mode The underlying mode of the IndexedDb transaction. Can be
-   * 'readonly`, 'readwrite' or 'readwrite-primary'. Transactions marked
+   * @param mode - The underlying mode of the IndexedDb transaction. Can be
+   * 'readonly', 'readwrite' or 'readwrite-primary'. Transactions marked
    * 'readwrite-primary' can only be executed by the primary client. In this
    * mode, the transactionOperation will not be run if the primary lease cannot
    * be acquired and the returned promise will be rejected with a
    * FAILED_PRECONDITION error.
-   * @param transactionOperation The operation to run inside a transaction.
-   * @return A promise that is resolved once the transaction completes.
+   * @param transactionOperation - The operation to run inside a transaction.
+   * @returns A promise that is resolved once the transaction completes.
    */
   runTransaction<T>(
     action: string,

--- a/packages/firestore/src/local/persistence_promise.ts
+++ b/packages/firestore/src/local/persistence_promise.ts
@@ -27,10 +27,10 @@ export type Resolver<T> = (value?: T) => void;
 export type Rejector = (error: Error) => void;
 
 /**
- * PersistencePromise<> is essentially a re-implementation of Promise<> except
+ * PersistencePromise is essentially a re-implementation of Promise except
  * it has a .next() method instead of .then() and .next() and .catch() callbacks
  * are executed synchronously when a PersistencePromise resolves rather than
- * asynchronously (Promise<> implementations use setImmediate() or similar).
+ * asynchronously (Promise implementations use setImmediate() or similar).
  *
  * This is necessary to interoperate with IndexedDB which will automatically
  * commit transactions if control is returned to the event loop without

--- a/packages/firestore/src/local/remote_document_cache.ts
+++ b/packages/firestore/src/local/remote_document_cache.ts
@@ -41,9 +41,9 @@ export interface RemoteDocumentCache {
   /**
    * Looks up an entry in the cache.
    *
-   * @param documentKey The key of the entry to look up.
-   * @return The cached Document or NoDocument entry, or null if we have nothing
-   * cached.
+   * @param documentKey - The key of the entry to look up.*
+   * @returns The cached Document or NoDocument entry, or null if we have
+   * nothing cached.
    */
   getEntry(
     transaction: PersistenceTransaction,
@@ -53,9 +53,9 @@ export interface RemoteDocumentCache {
   /**
    * Looks up a set of entries in the cache.
    *
-   * @param documentKeys The keys of the entries to look up.
-   * @return The cached Document or NoDocument entries indexed by key. If an entry is not cached,
-   *     the corresponding key will be mapped to a null value.
+   * @param documentKeys - The keys of the entries to look up.
+   * @returns The cached Document or NoDocument entries indexed by key. If an
+   * entry is not cached, the corresponding key will be mapped to a null value.
    */
   getEntries(
     transaction: PersistenceTransaction,
@@ -70,10 +70,10 @@ export interface RemoteDocumentCache {
    *
    * Cached NoDocument entries have no bearing on query results.
    *
-   * @param query The query to match documents against.
-   * @param sinceReadTime If not set to SnapshotVersion.min(), return only
+   * @param query - The query to match documents against.
+   * @param sinceReadTime - If not set to SnapshotVersion.min(), return only
    *     documents that have been read since this snapshot version (exclusive).
-   * @return The set of matching documents.
+   * @returns The set of matching documents.
    */
   getDocumentsMatchingQuery(
     transaction: PersistenceTransaction,
@@ -87,7 +87,7 @@ export interface RemoteDocumentCache {
    *
    * Multi-Tab Note: This should only be called by the primary client.
    *
-   * @param options.trackRemovals Whether to create sentinel entries for
+   * @param options - Specify `trackRemovals` to create sentinel entries for
    * removed documents, which allows removals to be tracked by
    * `getNewDocumentChanges()`.
    */

--- a/packages/firestore/src/local/remote_document_change_buffer.ts
+++ b/packages/firestore/src/local/remote_document_change_buffer.ts
@@ -115,11 +115,11 @@ export abstract class RemoteDocumentChangeBuffer {
    * and if no buffered change applies, this will forward to
    * `RemoteDocumentCache.getEntry()`.
    *
-   * @param transaction The transaction in which to perform any persistence
+   * @param transaction - The transaction in which to perform any persistence
    *     operations.
-   * @param documentKey The key of the entry to look up.
-   * @return The cached Document or NoDocument entry, or null if we have nothing
-   * cached.
+   * @param documentKey - The key of the entry to look up.
+   * @returns The cached Document or NoDocument entry, or null if we have
+   *     nothing cached.
    */
   getEntry(
     transaction: PersistenceTransaction,
@@ -140,12 +140,12 @@ export abstract class RemoteDocumentChangeBuffer {
    * Looks up several entries in the cache, forwarding to
    * `RemoteDocumentCache.getEntry()`.
    *
-   * @param transaction The transaction in which to perform any persistence
+   * @param transaction - The transaction in which to perform any persistence
    *     operations.
-   * @param documentKeys The keys of the entries to look up.
-   * @return A map of cached `Document`s or `NoDocument`s, indexed by key. If an
-   *     entry cannot be found, the corresponding key will be mapped to a null
-   *     value.
+   * @param documentKeys - The keys of the entries to look up.
+   * @returns A map of cached `Document`s or `NoDocument`s, indexed by key. If
+   *     an entry cannot be found, the corresponding key will be mapped to a
+   *     null value.
    */
   getEntries(
     transaction: PersistenceTransaction,

--- a/packages/firestore/src/local/simple_db.ts
+++ b/packages/firestore/src/local/simple_db.ts
@@ -553,9 +553,9 @@ export class SimpleDbStore<
   /**
    * Writes a value into the Object Store.
    *
-   * @param key Optional explicit key to use when writing the object, else the
+   * @param key - Optional explicit key to use when writing the object, else the
    * key will be auto-assigned (e.g. via the defined keyPath for the store).
-   * @param value The object to write.
+   * @param value - The object to write.
    */
   put(value: ValueType): PersistencePromise<void>;
   put(key: KeyType, value: ValueType): PersistencePromise<void>;
@@ -578,8 +578,8 @@ export class SimpleDbStore<
    * Adds a new value into an Object Store and returns the new key. Similar to
    * IndexedDb's `add()`, this method will fail on primary key collisions.
    *
-   * @param value The object to write.
-   * @return The key of the value to add.
+   * @param value - The object to write.
+   * @returns The key of the value to add.
    */
   add(value: ValueType): PersistencePromise<KeyType> {
     logDebug(LOG_TAG, 'ADD', this.store.name, value, value);
@@ -592,7 +592,7 @@ export class SimpleDbStore<
    * if no object exists with the specified key.
    *
    * @key The key of the object to get.
-   * @return The object with the specified key or null if no object exists.
+   * @returns The object with the specified key or null if no object exists.
    */
   get(key: KeyType): PersistencePromise<ValueType | null> {
     const request = this.store.get(key);
@@ -667,8 +667,9 @@ export class SimpleDbStore<
   /**
    * Iterates over keys and values in an object store.
    *
-   * @param options Options specifying how to iterate the objects in the store.
-   * @param callback will be called for each iterated object. Iteration can be
+   * @param options - Options specifying how to iterate the objects in the
+   * store.
+   * @param callback - will be called for each iterated object. Iteration can be
    * canceled at any point by calling the doneFn passed to the callback.
    * The callback can return a PersistencePromise if it performs async
    * operations but note that iteration will continue without waiting for them

--- a/packages/firestore/src/local/target_cache.ts
+++ b/packages/firestore/src/local/target_cache.ts
@@ -48,7 +48,7 @@ export interface TargetCache {
   ): PersistencePromise<SnapshotVersion>;
 
   /**
-   * @return The highest sequence number observed, including any that might be
+   * @returns The highest sequence number observed, including any that might be
    *         persisted on-disk.
    */
   getHighestSequenceNumber(
@@ -68,8 +68,8 @@ export interface TargetCache {
    * snapshot version of the last consistent snapshot received from the backend
    * (see getLastRemoteSnapshotVersion() for more details).
    *
-   * @param highestListenSequenceNumber The new maximum listen sequence number.
-   * @param lastRemoteSnapshotVersion The new snapshot version. Optional.
+   * @param highestListenSequenceNumber - The new maximum listen sequence number.
+   * @param lastRemoteSnapshotVersion - The new snapshot version. Optional.
    */
   setTargetsMetadata(
     transaction: PersistenceTransaction,
@@ -83,7 +83,7 @@ export interface TargetCache {
    * The cache key is extracted from `targetData.target`. The key must not already
    * exist in the cache.
    *
-   * @param targetData A TargetData instance to put in the cache.
+   * @param targetData - A TargetData instance to put in the cache.
    */
   addTargetData(
     transaction: PersistenceTransaction,
@@ -95,7 +95,7 @@ export interface TargetCache {
    *
    * The cache key is extracted from `targetData.target`. The entry must already
    * exist in the cache, and it will be replaced.
-   * @param {TargetData} targetData The TargetData to be replaced into the cache.
+   * @param targetData - The TargetData to be replaced into the cache.
    */
   updateTargetData(
     transaction: PersistenceTransaction,
@@ -124,8 +124,8 @@ export interface TargetCache {
   /**
    * Looks up a TargetData entry by target.
    *
-   * @param target The query target corresponding to the entry to look up.
-   * @return The cached TargetData entry, or null if the cache has no entry for
+   * @param target - The query target corresponding to the entry to look up.
+   * @returns The cached TargetData entry, or null if the cache has no entry for
    * the target.
    */
   getTargetData(

--- a/packages/firestore/src/model/document_key.ts
+++ b/packages/firestore/src/model/document_key.ts
@@ -65,8 +65,8 @@ export class DocumentKey {
   /**
    * Creates and returns a new document key with the given segments.
    *
-   * @param segments The segments of the path to the document
-   * @return A new instance of DocumentKey
+   * @param segments - The segments of the path to the document
+   * @returns A new instance of DocumentKey
    */
   static fromSegments(segments: string[]): DocumentKey {
     return new DocumentKey(new ResourcePath(segments.slice()));

--- a/packages/firestore/src/model/mutation.ts
+++ b/packages/firestore/src/model/mutation.ts
@@ -260,11 +260,11 @@ export abstract class Mutation {
  * expected state (e.g. it is null or outdated), an `UnknownDocument` can be
  * returned.
  *
- * @param mutation The mutation to apply.
- * @param maybeDoc The document to mutate. The input document can be null if
+ * @param mutation - The mutation to apply.
+ * @param maybeDoc - The document to mutate. The input document can be null if
  *     the client has no knowledge of the pre-mutation state of the document.
- * @param mutationResult The result of applying the mutation from the backend.
- * @return The mutated document. The returned document may be an
+ * @param mutationResult - The result of applying the mutation from the backend.
+ * @returns The mutated document. The returned document may be an
  *     UnknownDocument if the mutation could not be applied to the locally
  *     cached base document.
  */
@@ -306,15 +306,15 @@ export function applyMutationToRemoteDocument(
  * of computing the new local view of a document. Both the input and returned
  * documents can be null.
  *
- * @param mutation The mutation to apply.
- * @param maybeDoc The document to mutate. The input document can be null if
+ * @param mutation - The mutation to apply.
+ * @param maybeDoc - The document to mutate. The input document can be null if
  *     the client has no knowledge of the pre-mutation state of the document.
- * @param baseDoc The state of the document prior to this mutation batch. The
+ * @param baseDoc - The state of the document prior to this mutation batch. The
  *     input document can be null if the client has no knowledge of the
  *     pre-mutation state of the document.
- * @param localWriteTime A timestamp indicating the local write time of the
+ * @param localWriteTime - A timestamp indicating the local write time of the
  *     batch this mutation is a part of.
- * @return The mutated document. The returned document may be null, but only
+ * @returns The mutated document. The returned document may be null, but only
  *     if maybeDoc was null and the mutation would not create a new document.
  */
 export function applyMutationToLocalView(
@@ -358,7 +358,7 @@ export function applyMutationToLocalView(
  * mutation. The base value is null for idempotent mutations, as they can be
  * re-played even if the backend has already applied them.
  *
- * @return a base value to store along with the mutation, or null for
+ * @returns a base value to store along with the mutation, or null for
  * idempotent mutations.
  */
 export function extractMutationBaseValue(
@@ -717,10 +717,10 @@ function requireDocument(
  * representing the result of applying a transform) for use after a
  * TransformMutation has been acknowledged by the server.
  *
- * @param fieldTransforms The field transforms to apply the result to.
- * @param baseDoc The document prior to applying this mutation batch.
- * @param serverTransformResults The transform results received by the server.
- * @return The transform results list.
+ * @param fieldTransforms - The field transforms to apply the result to.
+ * @param baseDoc - The document prior to applying this mutation batch.
+ * @param serverTransformResults - The transform results received by the server.
+ * @returns The transform results list.
  */
 function serverTransformResults(
   fieldTransforms: FieldTransform[],
@@ -757,13 +757,13 @@ function serverTransformResults(
  * representing the result of applying a transform) for use when applying a
  * TransformMutation locally.
  *
- * @param fieldTransforms The field transforms to apply the result to.
- * @param localWriteTime The local time of the transform mutation (used to
+ * @param fieldTransforms - The field transforms to apply the result to.
+ * @param localWriteTime - The local time of the transform mutation (used to
  *     generate ServerTimestampValues).
- * @param maybeDoc The current state of the document after applying all
+ * @param maybeDoc - The current state of the document after applying all
  *     previous mutations.
- * @param baseDoc The document prior to applying this mutation batch.
- * @return The transform results list.
+ * @param baseDoc - The document prior to applying this mutation batch.
+ * @returns The transform results list.
  */
 function localTransformResults(
   fieldTransforms: FieldTransform[],

--- a/packages/firestore/src/model/mutation_batch.ts
+++ b/packages/firestore/src/model/mutation_batch.ts
@@ -44,13 +44,13 @@ export const BATCHID_UNKNOWN = -1;
  */
 export class MutationBatch {
   /**
-   * @param batchId The unique ID of this mutation batch.
-   * @param localWriteTime The original write time of this mutation.
-   * @param baseMutations Mutations that are used to populate the base
+   * @param batchId - The unique ID of this mutation batch.
+   * @param localWriteTime - The original write time of this mutation.
+   * @param baseMutations - Mutations that are used to populate the base
    * values when this mutation is applied locally. This can be used to locally
    * overwrite values that are persisted in the remote document cache. Base
    * mutations are never sent to the backend.
-   * @param mutations The user-provided mutations in this mutation batch.
+   * @param mutations - The user-provided mutations in this mutation batch.
    * User-provided mutations are applied both locally and remotely on the
    * backend.
    */
@@ -67,9 +67,9 @@ export class MutationBatch {
    * Applies all the mutations in this MutationBatch to the specified document
    * to create a new remote document
    *
-   * @param docKey The key of the document to apply mutations to.
-   * @param maybeDoc The document to apply mutations to.
-   * @param batchResult The result of applying the MutationBatch to the
+   * @param docKey - The key of the document to apply mutations to.
+   * @param maybeDoc - The document to apply mutations to.
+   * @param batchResult - The result of applying the MutationBatch to the
    * backend.
    */
   applyToRemoteDocument(
@@ -111,8 +111,8 @@ export class MutationBatch {
    * Computes the local view of a document given all the mutations in this
    * batch.
    *
-   * @param docKey The key of the document to apply mutations to.
-   * @param maybeDoc The document to apply mutations to.
+   * @param docKey - The key of the document to apply mutations to.
+   * @param maybeDoc - The document to apply mutations to.
    */
   applyToLocalView(
     docKey: DocumentKey,
@@ -212,7 +212,7 @@ export class MutationBatchResult {
   /**
    * Creates a new MutationBatchResult for the given batch and results. There
    * must be one result for each mutation in the batch. This static factory
-   * caches a document=>version mapping (docVersions).
+   * caches a document=&gt;version mapping (docVersions).
    */
   static from(
     batch: MutationBatch,

--- a/packages/firestore/src/model/object_value.ts
+++ b/packages/firestore/src/model/object_value.ts
@@ -66,8 +66,8 @@ export class ObjectValue {
   /**
    * Returns the value at the given path or null.
    *
-   * @param path the path to search
-   * @return The value at the path or if there it doesn't exist.
+   * @param path - the path to search
+   * @returns The value at the path or if there it doesn't exist.
    */
   field(path: FieldPath): ProtoValue | null {
     if (path.isEmpty()) {
@@ -110,16 +110,16 @@ export class ObjectValueBuilder {
   private overlayMap = new Map<string, Overlay>();
 
   /**
-   * @param baseObject The object to mutate.
+   * @param baseObject - The object to mutate.
    */
   constructor(private readonly baseObject: ObjectValue = ObjectValue.empty()) {}
 
   /**
    * Sets the field to the provided value.
    *
-   * @param path The field path to set.
-   * @param value The value to set.
-   * @return The current Builder instance.
+   * @param path - The field path to set.
+   * @param value - The value to set.
+   * @returns The current Builder instance.
    */
   set(path: FieldPath, value: ProtoValue): ObjectValueBuilder {
     debugAssert(
@@ -134,8 +134,8 @@ export class ObjectValueBuilder {
    * Removes the field at the specified path. If there is no field at the
    * specified path, nothing is changed.
    *
-   * @param path The field path to remove.
-   * @return The current Builder instance.
+   * @param path - The field path to remove.
+   * @returns The current Builder instance.
    */
   delete(path: FieldPath): ObjectValueBuilder {
     debugAssert(
@@ -199,11 +199,11 @@ export class ObjectValueBuilder {
    * and returns the merged data at `currentPath` (or null if there were no
    * changes).
    *
-   * @param currentPath The path at the current nesting level. Can be set to
+   * @param currentPath - The path at the current nesting level. Can be set to
    * FieldValue.emptyPath() to represent the root.
-   * @param currentOverlays The overlays at the current nesting level in the
+   * @param currentOverlays - The overlays at the current nesting level in the
    * same format as `overlayMap`.
-   * @return The merged data at `currentPath` or null if no modifications
+   * @returns The merged data at `currentPath` or null if no modifications
    * were applied.
    */
   private applyOverlay(

--- a/packages/firestore/src/model/transform_operation.ts
+++ b/packages/firestore/src/model/transform_operation.ts
@@ -101,7 +101,7 @@ export function applyTransformOperationToRemoteDocument(
  * idempotent transforms, as they can be re-played even if the backend has
  * already applied them.
  *
- * @return a base value to store along with the mutation, or null for
+ * @returns a base value to store along with the mutation, or null for
  * idempotent transforms.
  */
 export function computeTransformOperationBaseValue(

--- a/packages/firestore/src/platform/browser_lite/fetch_connection.ts
+++ b/packages/firestore/src/platform/browser_lite/fetch_connection.ts
@@ -29,8 +29,8 @@ import { DatabaseInfo } from '../../core/database_info';
  */
 export class FetchConnection extends RestConnection {
   /**
-   * @param databaseInfo The connection info.
-   * @param fetchImpl `fetch` or a Polyfill that implements the fetch API.
+   * @param databaseInfo - The connection info.
+   * @param fetchImpl - `fetch` or a Polyfill that implements the fetch API.
    */
   constructor(
     databaseInfo: DatabaseInfo,

--- a/packages/firestore/src/remote/connection.ts
+++ b/packages/firestore/src/remote/connection.ts
@@ -37,11 +37,11 @@ export interface Connection {
    * Invokes an RPC by name, given a request message as a JavaScript object
    * representing the JSON to send.
    *
-   * @param rpcName the name of the RPC to invoke
-   * @param path the path to invoke this RPC on
-   * @param request the Raw JSON object encoding of the request message
-   * @param token the Token to use for the RPC.
-   * @return a Promise containing the JSON object encoding of the response
+   * @param rpcName - the name of the RPC to invoke
+   * @param path - the path to invoke this RPC on
+   * @param request - the Raw JSON object encoding of the request message
+   * @param token - the Token to use for the RPC.
+   * @returns a Promise containing the JSON object encoding of the response
    */
   invokeRPC<Req, Resp>(
     rpcName: string,
@@ -55,11 +55,11 @@ export interface Connection {
    * object representing the JSON to send. The responses will be consumed to
    * completion and then returned as an array.
    *
-   * @param rpcName the name of the RPC to invoke
-   * @param path the path to invoke this RPC on
-   * @param request the Raw JSON object encoding of the request message
-   * @param token the Token to use for the RPC.
-   * @return a Promise containing an array with the JSON object encodings of the
+   * @param rpcName - the name of the RPC to invoke
+   * @param path - the path to invoke this RPC on
+   * @param request - the Raw JSON object encoding of the request message
+   * @param token - the Token to use for the RPC.
+   * @returns a Promise containing an array with the JSON object encodings of the
    * responses
    */
   invokeStreamingRPC<Req, Resp>(
@@ -72,8 +72,8 @@ export interface Connection {
   /**
    * Opens a stream to the given stream RPC endpoint. Returns a stream which
    * will try to open itself.
-   * @param rpcName the name of the RPC to open the stream on
-   * @param token the Token to use for the RPC.
+   * @param rpcName - the name of the RPC to open the stream on
+   * @param token - the Token to use for the RPC.
    */
   openStream<Req, Resp>(
     rpcName: string,

--- a/packages/firestore/src/remote/persistent_stream.ts
+++ b/packages/firestore/src/remote/persistent_stream.ts
@@ -321,8 +321,8 @@ export abstract class PersistentStream<
    *
    * A new stream can be opened by calling start().
    *
-   * @param finalState the intended state of the stream after closing.
-   * @param error the error the connection was closed with.
+   * @param finalState - the intended state of the stream after closing.
+   * @param error - the error the connection was closed with.
    */
   private async close(
     finalState: PersistentStreamState,
@@ -390,7 +390,7 @@ export abstract class PersistentStream<
   /**
    * Called after the stream has received a message. The function will be
    * called on the right queue and must return a Promise.
-   * @param message The message received from the stream.
+   * @param message - The message received from the stream.
    */
   protected abstract onMessage(message: ReceiveType): Promise<void>;
 

--- a/packages/firestore/src/remote/remote_syncer.ts
+++ b/packages/firestore/src/remote/remote_syncer.ts
@@ -38,9 +38,9 @@ export interface RemoteSyncer {
    * Rejects the listen for the given targetID. This can be triggered by the
    * backend for any active target.
    *
-   * @param targetId The targetID corresponds to one previously initiated by the
-   * user as part of TargetData passed to listen() on RemoteStore.
-   * @param error A description of the condition that has forced the rejection.
+   * @param targetId - The targetID corresponds to one previously initiated by
+   * the user as part of TargetData passed to listen() on RemoteStore.
+   * @param error - A description of the condition that has forced the rejection.
    * Nearly always this will be an indication that the user is no longer
    * authorized to see the data matching the target.
    */

--- a/packages/firestore/src/remote/rpc_error.ts
+++ b/packages/firestore/src/remote/rpc_error.ts
@@ -227,7 +227,7 @@ export function mapRpcCodeFromCode(code: Code | undefined): number {
 /**
  * Converts an HTTP Status Code to the equivalent error code.
  *
- * @param status An HTTP Status Code, like 200, 404, 503, etc.
+ * @param status - An HTTP Status Code, like 200, 404, 503, etc.
  * @returns The equivalent Code. Unknown status codes are mapped to
  *     Code.UNKNOWN.
  */
@@ -308,7 +308,7 @@ export function mapCodeFromHttpStatus(status?: number): Code {
 /**
  * Converts an HTTP response's error status to the equivalent error code.
  *
- * @param status An HTTP error response status ("FAILED_PRECONDITION",
+ * @param status - An HTTP error response status ("FAILED_PRECONDITION",
  * "UNKNOWN", etc.)
  * @returns The equivalent Code. Non-matching responses are mapped to
  *     Code.UNKNOWN.

--- a/packages/firestore/src/util/async_queue.ts
+++ b/packages/firestore/src/util/async_queue.ts
@@ -115,11 +115,11 @@ export class DelayedOperation<T extends unknown> implements PromiseLike<T> {
    * Creates and returns a DelayedOperation that has been scheduled to be
    * executed on the provided asyncQueue after the provided delayMs.
    *
-   * @param asyncQueue The queue to schedule the operation on.
-   * @param id A Timer ID identifying the type of operation this is.
-   * @param delayMs The delay (ms) before the operation should be scheduled.
-   * @param op The operation to run.
-   * @param removalCallback A callback to be called synchronously once the
+   * @param asyncQueue - The queue to schedule the operation on.
+   * @param id - A Timer ID identifying the type of operation this is.
+   * @param delayMs - The delay (ms) before the operation should be scheduled.
+   * @param op - The operation to run.
+   * @param removalCallback - A callback to be called synchronously once the
    *   operation is executed or canceled, notifying the AsyncQueue to remove it
    *   from its delayedOperations list.
    *   PORTING NOTE: This exists to prevent making removeDelayedOperation() and
@@ -471,8 +471,8 @@ export class AsyncQueue {
   /**
    * For Tests: Runs some or all delayed operations early.
    *
-   * @param lastTimerId Delayed operations up to and including this TimerId will
-   *  be drained. Pass TimerId.All to run all delayed operations.
+   * @param lastTimerId - Delayed operations up to and including this TimerId
+   * will be drained. Pass TimerId.All to run all delayed operations.
    * @returns a Promise that resolves once all operations have been run.
    */
   runAllDelayedOperationsUntil(lastTimerId: TimerId): Promise<void> {
@@ -527,7 +527,7 @@ export function wrapInUserErrorIfRecoverable(
 /**
  * Chrome includes Error.message in Error.stack. Other browsers do not.
  * This returns expected output of message + stack when available.
- * @param error Error or FirestoreError
+ * @param error - Error or FirestoreError
  */
 function getMessageOrStack(error: Error): string {
   let message = error.message || '';

--- a/packages/firestore/src/util/byte_stream.ts
+++ b/packages/firestore/src/util/byte_stream.ts
@@ -26,8 +26,8 @@ export const DEFAULT_BYTES_PER_READ = 10240;
 
 /**
  * Builds a `ByteStreamReader` from a UInt8Array.
- * @param source The data source to use.
- * @param bytesPerRead How many bytes each `read()` from the returned reader
+ * @param source - The data source to use.
+ * @param bytesPerRead - How many bytes each `read()` from the returned reader
  *        will read.
  */
 export function toByteStreamReaderHelper(

--- a/packages/firestore/src/util/error.ts
+++ b/packages/firestore/src/util/error.ts
@@ -212,6 +212,7 @@ export class FirestoreError extends Error {
   name = 'FirebaseError';
   stack?: string;
 
+  /** @hideconstructor */
   constructor(readonly code: FirestoreErrorCode, readonly message: string) {
     super(message);
 

--- a/packages/firestore/src/util/log.ts
+++ b/packages/firestore/src/util/log.ts
@@ -31,9 +31,8 @@ export function getLogLevel(): LogLevel {
 /**
  * Sets the verbosity of Cloud Firestore logs (debug, error, or silent).
  *
- * @param logLevel
- *   The verbosity you set for activity and error logging. Can be any of
- *   the following values:
+ * @param logLevel - The verbosity you set for activity and error logging. Can
+ *   be any of the following values:
  *
  *   <ul>
  *     <li>`debug` for the most verbose logging level, primarily for

--- a/packages/firestore/src/util/node_api.ts
+++ b/packages/firestore/src/util/node_api.ts
@@ -49,9 +49,9 @@
  *   fs.stat(path, callback);
  * });
  *
- * @param action a function that takes a node-style callback as an argument and
- *     then uses that callback to invoke some node-style API.
- * @return a new Promise which will be rejected if the callback is given the
+ * @param action - a function that takes a node-style callback as an argument
+ *     and then uses that callback to invoke some node-style API.
+ * @returns a new Promise which will be rejected if the callback is given the
  *     first Error parameter or will resolve to the value given otherwise.
  */
 export function nodePromise<R>(

--- a/packages/firestore/src/util/obj_map.ts
+++ b/packages/firestore/src/util/obj_map.ts
@@ -27,10 +27,10 @@ type Entry<K, V> = [K, V];
  */
 export class ObjectMap<KeyType, ValueType> {
   /**
-   * The inner map for a key -> value pair. Due to the possibility of
-   * collisions we keep a list of entries that we do a linear search through
-   * to find an actual match. Note that collisions should be rare, so we still
-   * expect near constant time lookups in practice.
+   * The inner map for a key/value pair. Due to the possibility of collisions we
+   * keep a list of entries that we do a linear search through to find an actual
+   * match. Note that collisions should be rare, so we still expect near
+   * constant time lookups in practice.
    */
   private inner: {
     [canonicalId: string]: Array<Entry<KeyType, ValueType>>;

--- a/packages/firestore/src/util/sorted_set.ts
+++ b/packages/firestore/src/util/sorted_set.ts
@@ -59,7 +59,7 @@ export class SortedSet<T> {
     });
   }
 
-  /** Iterates over `elem`s such that: range[0] <= elem < range[1]. */
+  /** Iterates over `elem`s such that: range[0] &lt;= elem &lt; range[1]. */
   forEachInRange(range: [T, T], cb: (elem: T) => void): void {
     const iter = this.data.getIteratorFrom(range[0]);
     while (iter.hasNext()) {
@@ -72,7 +72,7 @@ export class SortedSet<T> {
   }
 
   /**
-   * Iterates over `elem`s such that: start <= elem until false is returned.
+   * Iterates over `elem`s such that: start &lt;= elem until false is returned.
    */
   forEachWhile(cb: (elem: T) => boolean, start?: T): void {
     let iter: SortedMapIterator<T, boolean>;

--- a/packages/firestore/src/util/types.ts
+++ b/packages/firestore/src/util/types.ts
@@ -36,7 +36,7 @@ export function isNegativeZero(value: number): boolean {
 
 /**
  * Returns whether a value is an integer and in the safe integer range
- * @param value The value to test for being an integer and in the safe range
+ * @param value - The value to test for being an integer and in the safe range
  */
 export function isSafeInteger(value: unknown): boolean {
   return (

--- a/packages/firestore/test/unit/local/local_store.test.ts
+++ b/packages/firestore/test/unit/local/local_store.test.ts
@@ -316,13 +316,13 @@ class LocalStoreTester {
    * Asserts the expected number of mutations and documents read by
    * the MutationQueue and the RemoteDocumentCache.
    *
-   * @param expectedCount.mutationsByQuery The number of mutations read by
+   * @param expectedCount.mutationsByQuery - The number of mutations read by
    * executing a query against the MutationQueue.
-   * @param expectedCount.mutationsByKey The number of mutations read by
+   * @param expectedCount.mutationsByKey - The number of mutations read by
    * document key lookups.
-   * @param expectedCount.documentsByQuery The number of mutations read by
+   * @param expectedCount.documentsByQuery - The number of mutations read by
    * executing a query against the RemoteDocumentCache.
-   * @param expectedCount.documentsByKey The number of documents read by
+   * @param expectedCount.documentsByKey - The number of documents read by
    * document key lookups.
    */
   toHaveRead(expectedCount: {

--- a/packages/firestore/test/unit/local/mutation_queue.test.ts
+++ b/packages/firestore/test/unit/local/mutation_queue.test.ts
@@ -108,9 +108,9 @@ function genericMutationQueueTests(): void {
   /**
    * Removes the first n entries from the given batches and returns them.
    *
-   * @param n The number of batches to remove.
-   * @param batches The array to mutate, removing entries from it.
-   * @return A new array containing all the entries that were removed from
+   * @param n - The number of batches to remove.
+   * @param batches - The array to mutate, removing entries from it.
+   * @returns A new array containing all the entries that were removed from
    * batches.
    */
   async function removeFirstBatches(

--- a/packages/firestore/test/unit/specs/describe_spec.ts
+++ b/packages/firestore/test/unit/specs/describe_spec.ts
@@ -130,10 +130,10 @@ function getTestTimeout(tags: string[]): number | undefined {
 
 /**
  * Like it(), but for spec tests.
- * @param name A name to give the test.
- * @param tags Tags to apply to the test (e.g. 'exclusive' to only run
+ * @param name - A name to give the test.
+ * @param tags - Tags to apply to the test (e.g. 'exclusive' to only run
  *             individual tests)
- * @param builder A function that returns a spec.
+ * @param builder - A function that returns a spec.
  * If writeToJSONFile has been called, the spec will be stored in
  * `specsInThisTest`. Otherwise, it will be run, just as it() would run it.
  */
@@ -224,10 +224,10 @@ export function specTest(
 
 /**
  * Like describe, but for spec tests.
- * @param name A name to give the test.
- * @param tags Tags to apply to all tests in the spec (e.g. 'exclusive' to
+ * @param name - A name to give the test.
+ * @param tags - Tags to apply to all tests in the spec (e.g. 'exclusive' to
  *             only run individual tests)
- * @param builder A function that calls specTest for each test case.
+ * @param builder - A function that calls specTest for each test case.
  * If writeToJSONFile has been called, the specs will be stored in
  * that file. Otherwise, they will be run, just as describe would run.
  */

--- a/packages/firestore/test/unit/util/bundle.test.ts
+++ b/packages/firestore/test/unit/util/bundle.test.ts
@@ -49,8 +49,8 @@ const encoder = newTextEncoder();
 /**
  * Create a `ReadableStream` from a string.
  *
- * @param content: Bundle in string.
- * @param bytesPerRead: How many bytes to read from the underlying buffer from
+ * @param content - Bundle in string.
+ * @param bytesPerRead - How many bytes to read from the underlying buffer from
  * each read through the stream.
  */
 export function byteStreamReaderFromString(

--- a/packages/firestore/test/util/api_helpers.ts
+++ b/packages/firestore/test/util/api_helpers.ts
@@ -143,15 +143,17 @@ export function query(path: string): Query {
 /**
  * A convenience method for creating a particular query snapshot for tests.
  *
- * @param path To be used in constructing the query.
- * @param oldDocs Provides the prior set of documents in the QuerySnapshot. Each entry maps to a
- *     document, with the key being the document id, and the value being the document contents.
- * @param docsToAdd Specifies data to be added into the query snapshot as of now. Each entry maps
- *     to a document, with the key being the document id, and the value being the document contents.
- * @param mutatedKeys The list of document with pending writes.
- * @param fromCache Whether the query snapshot is cache result.
- * @param syncStateChanged Whether the sync state has changed.
- * @return A query snapshot that consists of both sets of documents.
+ * @param path - To be used in constructing the query.
+ * @param oldDocs - Provides the prior set of documents in the QuerySnapshot.
+ * Each entry maps to a document, with the key being the document id, and the
+ * value being the document contents.
+ * @param docsToAdd - Specifies data to be added into the query snapshot as of
+ * now. Each entry maps to a document, with the key being the document id, and
+ * the value being the document contents.
+ * @param mutatedKeys - The list of document with pending writes.
+ * @param fromCache - Whether the query snapshot is cache result.
+ * @param syncStateChanged - Whether the sync state has changed.
+ * @returns A query snapshot that consists of both sets of documents.
  */
 export function querySnapshot(
   path: string,

--- a/packages/firestore/test/util/node_persistence.ts
+++ b/packages/firestore/test/util/node_persistence.ts
@@ -30,7 +30,7 @@ import { FakeWindow, SharedFakeWebStorage } from './test_platform';
 // To use this code to run persistence-based tests in Node, include this module
 // and set the environment variable `USE_MOCK_PERSISTENCE` to `YES`.
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any,
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 const globalAny = global as any;
 
 const dbDir = fs.mkdtempSync(os.tmpdir() + '/firestore_tests');


### PR DESCRIPTION
API Extractor will be used to generate the reference documentation for firestore-exp. It currently throws some validation errors, and this fixes them by doing the following:

- Use `@returns` instead of `@return`
- Add "-" for `@param`
- HTML escape special characters
- Fix `@link` tags
- Add `@hideconstructor` for non-public (internal) constructors

I don't think this needs a thorough review, but a spot check would be nice.