### PR TITLE
Return Firestore-Compat types from QuerySnapshot.docs

### DIFF
--- a/.changeset/calm-shrimps-press.md
+++ b/.changeset/calm-shrimps-press.md
@@ -1,0 +1,5 @@
+---
+"@firebase/firestore": patch
+---
+
+Fixes an issue that returned invalid `DocumentReference`s in `QuerySnapshot`s.

--- a/packages/firestore/test/util/equality_matcher.ts
+++ b/packages/firestore/test/util/equality_matcher.ts
@@ -62,11 +62,11 @@ function customDeepEqual(
     // compared with API types from Firestore classic. We do want to
     // differentiate between these types in our tests to ensure that the we do
     // not return firestore-exp types in the classic SDK.
+    let leftObj = left as Record<string, unknown>;
+    let rightObj = right as Record<string, unknown>;
     if (
-      (left as Record<string, unknown>).constructor.name ===
-        (right as Record<string, unknown>).constructor.name &&
-      (left as Record<string, unknown>).constructor !==
-        (right as Record<string, unknown>).constructor
+      leftObj.constructor.name === rightObj.constructor.name &&
+      leftObj.constructor !== rightObj.constructor
     ) {
       return false;
     }

--- a/packages/firestore/test/util/equality_matcher.ts
+++ b/packages/firestore/test/util/equality_matcher.ts
@@ -62,8 +62,8 @@ function customDeepEqual(
     // compared with API types from Firestore classic. We do want to
     // differentiate between these types in our tests to ensure that the we do
     // not return firestore-exp types in the classic SDK.
-    let leftObj = left as Record<string, unknown>;
-    let rightObj = right as Record<string, unknown>;
+    const leftObj = left as Record<string, unknown>;
+    const rightObj = right as Record<string, unknown>;
     if (
       leftObj.constructor.name === rightObj.constructor.name &&
       leftObj.constructor !== rightObj.constructor

--- a/packages/firestore/test/util/equality_matcher.ts
+++ b/packages/firestore/test/util/equality_matcher.ts
@@ -16,7 +16,6 @@
  */
 
 import { use } from 'chai';
-import { Indexable } from '../../src/util/misc';
 
 /**
  * Duck-typed interface for objects that have an isEqual() method.
@@ -64,9 +63,10 @@ function customDeepEqual(
     // differentiate between these types in our tests to ensure that the we do
     // not return firestore-exp types in the classic SDK.
     if (
-      (left as Indexable).constructor.name ===
-        (right as Indexable).constructor.name &&
-      (left as Indexable).constructor !== (right as Indexable).constructor
+      (left as Record<string, unknown>).constructor.name ===
+        (right as Record<string, unknown>).constructor.name &&
+      (left as Record<string, unknown>).constructor !==
+        (right as Record<string, unknown>).constructor
     ) {
       return false;
     }

--- a/packages/firestore/test/util/equality_matcher.ts
+++ b/packages/firestore/test/util/equality_matcher.ts
@@ -16,6 +16,7 @@
  */
 
 import { use } from 'chai';
+import { Indexable } from '../../src/util/misc';
 
 /**
  * Duck-typed interface for objects that have an isEqual() method.
@@ -55,6 +56,19 @@ function customDeepEqual(
       right instanceof customMatcher.forType
     ) {
       return customMatcher.equalsFn(left, right);
+    }
+  }
+  if (left && typeof left === 'object' && right && typeof right === 'object') {
+    // The `isEqual` check below returns true if firestore-exp types are
+    // compared with API types from Firestore classic. We do want to
+    // differentiate between these types in our tests to ensure that the we do
+    // not return firestore-exp types in the classic SDK.
+    if (
+      (left as Indexable).constructor.name ===
+        (right as Indexable).constructor.name &&
+      (left as Indexable).constructor !== (right as Indexable).constructor
+    ) {
+      return false;
     }
   }
   if (typeof left === 'object' && left && 'isEqual' in left) {


### PR DESCRIPTION
This fixes a bug where the Firestore Classic SDK leaks the firestore-exp types in QuerySnapshots. We need to use the Firestore Classic's UserDataWriter (similar to what we already do in `DoucmentSnapshot.get()`).

Fixes https://github.com/firebase/firebase-js-sdk/issues/4125, https://github.com/firebase/firebase-js-sdk/issues/4134