### PR TITLE
Properly escape field paths

### DIFF
--- a/.changeset/afraid-socks-shop.md
+++ b/.changeset/afraid-socks-shop.md
@@ -1,0 +1,5 @@
+---
+"@firebase/firestore": patch
+---
+
+Fixed a bug that prevented usage of FieldPaths with multiple special characters.

--- a/packages/firestore/src/model/path.ts
+++ b/packages/firestore/src/model/path.ts
@@ -265,7 +265,7 @@ export class FieldPath extends BasePath<FieldPath> {
   canonicalString(): string {
     return this.toArray()
       .map(str => {
-        str = str.replace('\\', '\\\\').replace('`', '\\`');
+        str = str.replace(/\\/g, '\\\\').replace(/`/g, '\\`');
         if (!FieldPath.isValidIdentifier(str)) {
           str = '`' + str + '`';
         }

--- a/packages/firestore/src/remote/rpc_error.ts
+++ b/packages/firestore/src/remote/rpc_error.ts
@@ -314,7 +314,7 @@ export function mapCodeFromHttpStatus(status?: number): Code {
  *     Code.UNKNOWN.
  */
 export function mapCodeFromHttpResponseErrorStatus(status: string): Code {
-  const serverError = status.toLowerCase().replace('_', '-');
+  const serverError = status.toLowerCase().replace(/_/g, '-');
   return Object.values(Code).indexOf(serverError as Code) >= 0
     ? (serverError as Code)
     : Code.UNKNOWN;

--- a/packages/firestore/test/unit/model/path.test.ts
+++ b/packages/firestore/test/unit/model/path.test.ts
@@ -160,6 +160,11 @@ describe('Path', () => {
     expect(abc.isPrefixOf(ba)).to.equal(false);
   });
 
+  it('escaped FieldPath with segments', () => {
+    const path = new FieldPath(['foo.`bar`']);
+    expect(path.canonicalString()).to.equal('`foo.\\`bar\\``');
+  });
+
   it('can be constructed from field path.', () => {
     const path = FieldPath.fromServerFormat('foo\\..bar\\\\.baz');
     expect(path.toArray()).to.deep.equal(['foo.', 'bar\\', 'baz']);

--- a/packages/firestore/test/unit/model/path.test.ts
+++ b/packages/firestore/test/unit/model/path.test.ts
@@ -160,9 +160,9 @@ describe('Path', () => {
     expect(abc.isPrefixOf(ba)).to.equal(false);
   });
 
-  it('escaped FieldPath with segments', () => {
-    const path = new FieldPath(['foo.`bar`']);
-    expect(path.canonicalString()).to.equal('`foo.\\`bar\\``');
+  it('escapes FieldPath with segments', () => {
+    const path = new FieldPath(['\\foo\\.`bar`']);
+    expect(path.canonicalString()).to.equal('`\\\\foo\\\\.\\`bar\\``');
   });
 
   it('can be constructed from field path.', () => {


### PR DESCRIPTION
JavaScript's `replace()` by default only replaces the first occurrence of a string, which breaks our field path escaping.