### PR TITLE
Fixes to allow auth and remote config exp releases

### DIFF
--- a/packages-exp/auth-compat-exp/package.json
+++ b/packages-exp/auth-compat-exp/package.json
@@ -20,7 +20,7 @@
     "test:ci": "node ../../scripts/run_tests_in_ci.js -s test:all",
     "test:browser": "karma start --single-run",
     "test:node": "TS_NODE_COMPILER_OPTIONS='{\"module\":\"commonjs\"}' nyc --reporter lcovonly -- mocha src/**/*.test.* --config ../../config/mocharc.node.js",
-    "prepare": "yarn build"
+    "prepare": "yarn build:release"
   },
   "peerDependencies": {
     "@firebase/app-compat": "0.x",

--- a/packages-exp/remote-config-exp/package.json
+++ b/packages-exp/remote-config-exp/package.json
@@ -21,7 +21,7 @@
     "test:browser": "karma start --single-run",
     "test:debug": "karma start --browsers=Chrome --auto-watch",
     "prettier": "prettier --write '{src,test}/**/*.{js,ts}'",
-    "prepare": "yarn build",
+    "prepare": "yarn build:release",
     "api-report": "api-extractor run --local --verbose",
     "predoc": "node ../../scripts/exp/remove-exp.js temp",
     "doc": "api-documenter markdown --input temp --output docs",

--- a/scripts/exp/release.ts
+++ b/scripts/exp/release.ts
@@ -66,9 +66,6 @@ async function publishExpPackages({ dryRun }: { dryRun: boolean }) {
       `${projectRoot}/packages-exp/*`
     ]);
 
-    // exclude auth packages until we are ready to release
-    packagePaths = packagePaths.filter(path => !path.includes('auth'));
-
     packagePaths.push(`${projectRoot}/packages/firestore`);
 
     /**


### PR DESCRIPTION
Remove line blocking auth-exp release. Change 2 `prepare` scripts to call `build:release`.