### PR TITLE
Update disabled setenv command

### DIFF
--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -26,7 +26,7 @@ jobs:
     - name: yarn build
       run: yarn build
     - name: Set start timestamp env var
-      run: echo "::set-env name=FIREBASE_CI_TEST_START_TIME::$(date +%s)"
+      run: echo "FIREBASE_CI_TEST_START_TIME=$(date +%s)" >> $GITHUB_ENV
     - name: Run unit tests
       run: |
         xvfb-run yarn test:ci


### PR DESCRIPTION
Was causing error in CI:
```
Run echo "::set-env name=FIREBASE_CI_TEST_START_TIME::$(date +%s)"
Error: Unable to process command '::set-env name=FIREBASE_CI_TEST_START_TIME::1607107014' successfully.
Error: The `set-env` command is disabled. Please upgrade to using Environment Files or opt into unsecure command execution by setting the `ACTIONS_ALLOW_UNSECURE_COMMANDS` environment variable to `true`. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
```

See https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/