### PR TITLE
Various fixes for RxFire storage/fromTask

### DIFF
--- a/.changeset/spicy-garlics-switch.md
+++ b/.changeset/spicy-garlics-switch.md
@@ -1,0 +1,12 @@
+---
+"rxfire": patch
+---
+
+Addressing several bugs with `rxfire/storage` and cleaning up some poorly defined behavior:
+
+* `fromTask` should not cancel the task on unsubscribe
+* `fromTask` should immediately emit the current snapshot
+* `fromTask` should return a `success` snapshot before completion
+* `fromTask` should emit a `canceled` or `error` snapshot before erroring
+* `progress` should now correctly report 100% uploads as it uses `fromTask`
+* `put` and `putString` are now cold, only starting upload on subscription, will replay, and cancel the upload when all subscribers unsubscribe

--- a/packages/rxfire/storage/index.ts
+++ b/packages/rxfire/storage/index.ts
@@ -76,7 +76,10 @@ export function put(
   data: any,
   metadata?: UploadMetadata
 ): Observable<UploadTaskSnapshot> {
-  return fromTask(ref.put(data, metadata));
+  return new Observable(subscriber => {
+    const task = ref.put(data, metadata);
+    return fromTask(task).subscribe(subscriber).add(task.cancel);
+  });
 }
 
 export function putString(
@@ -85,7 +88,10 @@ export function putString(
   format?: StringFormat,
   metadata?: UploadMetadata
 ): Observable<UploadTaskSnapshot> {
-  return fromTask(ref.putString(data, format, metadata));
+  return new Observable(subscriber => {
+    const task = ref.putString(data, format, metadata);
+    return fromTask(task).subscribe(subscriber).add(task.cancel);
+  });
 }
 
 export function percentage(

--- a/packages/rxfire/storage/index.ts
+++ b/packages/rxfire/storage/index.ts
@@ -17,7 +17,7 @@
 
 import firebase from 'firebase/app';
 import { Observable, from } from 'rxjs';
-import { debounceTime, map } from 'rxjs/operators';
+import { debounceTime, map, shareReplay } from 'rxjs/operators';
 
 type UploadTaskSnapshot = firebase.storage.UploadTaskSnapshot;
 type Reference = firebase.storage.Reference;
@@ -76,10 +76,10 @@ export function put(
   data: any,
   metadata?: UploadMetadata
 ): Observable<UploadTaskSnapshot> {
-  return new Observable(subscriber => {
+  return new Observable<UploadTaskSnapshot>(subscriber => {
     const task = ref.put(data, metadata);
     return fromTask(task).subscribe(subscriber).add(task.cancel);
-  });
+  }).pipe(shareReplay({ bufferSize: 1, refCount: true }));
 }
 
 export function putString(
@@ -88,10 +88,10 @@ export function putString(
   format?: StringFormat,
   metadata?: UploadMetadata
 ): Observable<UploadTaskSnapshot> {
-  return new Observable(subscriber => {
+  return new Observable<UploadTaskSnapshot>(subscriber => {
     const task = ref.putString(data, format, metadata);
     return fromTask(task).subscribe(subscriber).add(task.cancel);
-  });
+  }).pipe(shareReplay({ bufferSize: 1, refCount: true }));
 }
 
 export function percentage(

--- a/packages/rxfire/storage/index.ts
+++ b/packages/rxfire/storage/index.ts
@@ -35,7 +35,7 @@ export function fromTask(
     // emit the current state of the task
     progress(task.snapshot);
     // emit progression of the task
-    const unsubscribe = task.on('state_changed', progress);
+    const unsubscribeFromOnStateChanged = task.on('state_changed', progress);
     // use the promise form of task, to get the last success snapshot
     task.then(
       snapshot => {
@@ -50,7 +50,7 @@ export function fromTask(
     // the unsubscribe method returns by storage isn't typed in the
     // way rxjs expects, Function vs () => void, so wrap it
     return function unsubscribe() {
-      unsubscribe();
+      unsubscribeFromOnStateChanged();
     };
   }).pipe(
     // since we're emitting first the current snapshot and then progression


### PR DESCRIPTION
Bringing in the storage fixes from AngularFire 6.1.4 into RxFire.

* Don't cancel the upload if the task is unsubscribed from, this is unexpected behavior #1659. `fromTask` is actually a hot-observable and the task controls it (having the cancel, pause, and resume functions) thus we should lean on the task to control itself to not surprise the developer
* As such `fromTask` should be idempotent and immediately emit the latest snapshot, as the task is effective a Subject
* Before completion `fromTask` was not emitting a `success` state, move to the promise form of the task to get that, as such `progress` was never reaching 100%
* After #4158 is addressed, `fromTask` should emit an `error` or `canceled` snapshot, before the observable errors out; making for easier handling of errors. `takeWhile(snap => snap.state !== 'canceled')` for instance.
* `put` and `putString` should be cold, replay, and cancel on unsubscribe however #1939 

FYI @jhuleatt 

TODO we really need some storage tests, I'll work on those.