### PR TITLE
Fix storage compat task bug

### DIFF
--- a/packages/storage/compat/task.ts
+++ b/packages/storage/compat/task.ts
@@ -31,20 +31,17 @@ import { ReferenceCompat } from './reference';
 import { FirebaseStorageError } from '../src/implementation/error';
 
 export class UploadTaskCompat implements types.UploadTask {
-  private readonly _snapshot: UploadTaskSnapshotCompat;
   constructor(
     private readonly _delegate: UploadTask,
     private readonly _ref: ReferenceCompat
-  ) {
-    this._snapshot = new UploadTaskSnapshotCompat(
+  ) {}
+
+  get snapshot(): UploadTaskSnapshotCompat {
+    return new UploadTaskSnapshotCompat(
       this._delegate.snapshot,
       this,
       this._ref
     );
-  }
-
-  get snapshot(): UploadTaskSnapshotCompat {
-    return this._snapshot;
   }
 
   cancel = this._delegate.cancel.bind(this._delegate);


### PR DESCRIPTION
`UploadTaskCompat` was using a static _snapshot generated in the constructor but it won't update the state. The original `UploadTask` has a `snapshot()` getter that actually inserts the current state whenever it is called, so I'm changing the compat version to call its delegate's getter to get one with an updated state, and then wrap it in a Compat snapshot.

Fixes https://github.com/firebase/firebase-js-sdk/issues/4158 I think.