### PR TITLE
RxFire Firestore observables should emit metadata changes

### DIFF
--- a/packages/rxfire/firestore/document/index.ts
+++ b/packages/rxfire/firestore/document/index.ts
@@ -24,7 +24,7 @@ type DocumentReference = firebase.firestore.DocumentReference;
 type DocumentSnapshot = firebase.firestore.DocumentSnapshot;
 
 export function doc(ref: DocumentReference): Observable<DocumentSnapshot> {
-  return fromDocRef(ref);
+  return fromDocRef(ref, { includeMetadataChanges: true });
 }
 
 /**


### PR DESCRIPTION
The built in observables for Firestore should include the metadata changes by default & allow the developer to filter them out if unneeded. This is a blocker to my utilizing RxFire in EmberFire and AngularFire.

Oddly enough, `docChanges({ includeMetadataChanges: true })` doesn't seem to work... so I went ahead and created the metadata changes manually like I have in AngularFire.

Perhaps is a bug in Firestore?