### PR TITLE
Use esm2017 bundles in unit tests

### DIFF
--- a/config/webpack.test.js
+++ b/config/webpack.test.js
@@ -37,7 +37,7 @@ module.exports = {
           options: {
             compilerOptions: {
               module: 'commonjs',
-              target: 'es5',
+              target: 'es2015',
               downlevelIteration: true,
               resolveJsonModule: true
             }
@@ -95,7 +95,7 @@ module.exports = {
   },
   resolve: {
     modules: ['node_modules', path.resolve(__dirname, '../../node_modules')],
-    mainFields: ['browser', 'module', 'main'],
+    mainFields: ['esm2017', 'browser', 'module', 'main'],
     extensions: ['.js', '.ts'],
     symlinks: false
   },


### PR DESCRIPTION
Use our esm2017 bundles in unit tests, but this requires setting the webpack TS transpile target to at least `es2015` so there isn't a conflict between native classes and transpiled classes, see: https://stackoverflow.com/questions/51860043/javascript-es6-typeerror-class-constructor-client-cannot-be-invoked-without-ne

The esm2017 change is in https://github.com/firebase/firebase-js-sdk/pull/4168 and causes functions-exp tests to fail without the target change, when FunctionsError extends FirebaseError and calls super().

This will probably have to be changed if we begin rerunning cross-browser testing that includes IE.

Update:
Removed the mainFields change from https://github.com/firebase/firebase-js-sdk/pull/4168, we can discuss later. Looks like the issue occurs when `functions-exp` imports the `util` esm2017 bundle, it seems to not get transpiled by webpack or get transpiled wrong?