### PR TITLE
Fix some incorrect typings / missing pieces in the new auth SDK

### DIFF
--- a/common/api-review/auth-exp.api.md
+++ b/common/api-review/auth-exp.api.md
@@ -247,8 +247,10 @@ export class OAuthProvider implements externs.AuthProvider {
     constructor(providerId: string);
     addScope(scope: string): externs.AuthProvider;
     credential(params: OAuthCredentialOptions): externs.OAuthCredential;
+    static credentialFromError(error: FirebaseError): externs.OAuthCredential | null;
     // (undocumented)
     static credentialFromJSON(json: object | string): externs.OAuthCredential;
+    static credentialFromResult(userCredential: externs.UserCredential): externs.OAuthCredential | null;
     // @internal (undocumented)
     defaultLanguageCode: string | null;
     getCustomParameters(): CustomParameters;
@@ -363,7 +365,7 @@ export function sendPasswordResetEmail(auth: externs.Auth, email: string, action
 export function sendSignInLinkToEmail(auth: externs.Auth, email: string, actionCodeSettings?: externs.ActionCodeSettings): Promise<void>;
 
 // @public
-export function setPersistence(auth: externs.Auth, persistence: externs.Persistence): void;
+export function setPersistence(auth: externs.Auth, persistence: externs.Persistence): Promise<void>;
 
 // @public
 export function signInAnonymously(auth: externs.Auth): Promise<externs.UserCredential>;

--- a/common/api-review/auth-exp.api.md
+++ b/common/api-review/auth-exp.api.md
@@ -146,7 +146,7 @@ export function fetchSignInMethodsForEmail(auth: externs.Auth, email: string): P
 export function getAdditionalUserInfo(userCredential: externs.UserCredential): externs.AdditionalUserInfo | null;
 
 // @public
-export function getAuth(app?: FirebaseApp): Auth;
+export function getAuth(app: FirebaseApp): Auth;
 
 // @public
 export function getIdToken(user: externs.User, forceRefresh?: boolean): Promise<string>;
@@ -186,7 +186,7 @@ export const indexedDBLocalPersistence: externs.Persistence;
 // Warning: (ae-forgotten-export) The symbol "Dependencies" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
-export function initializeAuth(app?: FirebaseApp, deps?: Dependencies): externs.Auth;
+export function initializeAuth(app: FirebaseApp, deps?: Dependencies): externs.Auth;
 
 // @public
 export const inMemoryPersistence: externs.Persistence;

--- a/packages-exp/auth-exp/index.node.ts
+++ b/packages-exp/auth-exp/index.node.ts
@@ -42,7 +42,7 @@ FetchProvider.initialize(
 // Core functionality shared by all clients
 export * from './src';
 
-export function getAuth(app?: FirebaseApp): Auth {
+export function getAuth(app: FirebaseApp): Auth {
   return initializeAuth(app);
 }
 

--- a/packages-exp/auth-exp/index.rn.ts
+++ b/packages-exp/auth-exp/index.rn.ts
@@ -39,7 +39,7 @@ export const reactNativeLocalPersistence = getReactNativePersistence(
   AsyncStorage
 );
 
-export function getAuth(app?: FirebaseApp): Auth {
+export function getAuth(app: FirebaseApp): Auth {
   return initializeAuth(app, {
     persistence: reactNativeLocalPersistence
   });

--- a/packages-exp/auth-exp/index.ts
+++ b/packages-exp/auth-exp/index.ts
@@ -70,7 +70,7 @@ export { PhoneMultiFactorGenerator } from './src/platform_browser/mfa/assertions
  *
  * @public
  */
-export function getAuth(app?: FirebaseApp): Auth {
+export function getAuth(app: FirebaseApp): Auth {
   return initializeAuth(app, {
     popupRedirectResolver: browserPopupRedirectResolver,
     persistence: [indexedDBLocalPersistence, browserLocalPersistence]

--- a/packages-exp/auth-exp/index.webworker.ts
+++ b/packages-exp/auth-exp/index.webworker.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { _getProvider, getApp } from '@firebase/app-exp';
+import { _getProvider } from '@firebase/app-exp';
 import { FirebaseApp } from '@firebase/app-types-exp';
 import { Auth } from '@firebase/auth-types-exp';
 

--- a/packages-exp/auth-exp/index.webworker.ts
+++ b/packages-exp/auth-exp/index.webworker.ts
@@ -16,6 +16,7 @@
  */
 
 import { _getProvider, getApp } from '@firebase/app-exp';
+import { FirebaseApp } from '@firebase/app-types-exp';
 import { Auth } from '@firebase/auth-types-exp';
 
 import { AuthImpl } from './src/core/auth/auth_impl';
@@ -34,7 +35,7 @@ export { indexedDBLocalPersistence } from './src/platform_browser/persistence/in
 
 registerAuth(ClientPlatform.WORKER);
 
-export function getAuth(app = getApp()): Auth {
+export function getAuth(app: FirebaseApp): Auth {
   // Unlike the other environments, we need to explicitly check if indexedDb is
   // available. That means doing the whole rigamarole
   const auth = _getProvider(

--- a/packages-exp/auth-exp/src/core/auth/initialize.ts
+++ b/packages-exp/auth-exp/src/core/auth/initialize.ts
@@ -26,7 +26,7 @@ import { AuthImpl } from './auth_impl';
 
 /** @public */
 export function initializeAuth(
-  app: FirebaseApp = getApp(),
+  app: FirebaseApp,
   deps?: Dependencies
 ): externs.Auth {
   const auth = _getProvider(app, 'auth-exp').getImmediate() as AuthImpl;

--- a/packages-exp/auth-exp/src/core/auth/initialize.ts
+++ b/packages-exp/auth-exp/src/core/auth/initialize.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { _getProvider, getApp } from '@firebase/app-exp';
+import { _getProvider } from '@firebase/app-exp';
 import { FirebaseApp } from '@firebase/app-types-exp';
 import * as externs from '@firebase/auth-types-exp';
 

--- a/packages-exp/auth-exp/src/core/index.ts
+++ b/packages-exp/auth-exp/src/core/index.ts
@@ -38,14 +38,15 @@ export { debugErrorMap, prodErrorMap } from './errors';
  *
  * @param auth - The Auth instance.
  * @param persistence - The {@link @firebase/auth-types#Persistence} to use.
+ * @returns A promise that resolves once the persistence change has completed
  *
  * @public
  */
 export function setPersistence(
   auth: externs.Auth,
   persistence: externs.Persistence
-): void {
-  auth.setPersistence(persistence);
+): Promise<void> {
+  return auth.setPersistence(persistence);
 }
 /**
  * Adds an observer for changes to the signed-in user's ID token, which includes sign-in,

--- a/packages-exp/auth-exp/src/core/providers/oauth.test.ts
+++ b/packages-exp/auth-exp/src/core/providers/oauth.test.ts
@@ -35,7 +35,7 @@ describe('core/providers/oauth', () => {
   it('generates the correct type of oauth credential', () => {
     const cred = new OAuthProvider('google.com').credential({
       idToken: 'id-token',
-      accessToken: 'access-token',
+      accessToken: 'access-token'
     });
     expect(cred.accessToken).to.eq('access-token');
     expect(cred.idToken).to.eq('id-token');
@@ -52,7 +52,7 @@ describe('core/providers/oauth', () => {
         ...TEST_ID_TOKEN_RESPONSE,
         oauthAccessToken: 'access-token',
         oauthIdToken: 'id-token',
-        providerId: ProviderId.FACEBOOK,
+        providerId: ProviderId.FACEBOOK
       },
       operationType: OperationType.SIGN_IN
     });
@@ -71,7 +71,7 @@ describe('core/providers/oauth', () => {
       _tokenResponse: {
         ...TEST_ID_TOKEN_RESPONSE,
         oauthAccessToken: 'access-token',
-        oauthIdToken: 'id-token',
+        oauthIdToken: 'id-token'
       },
       operationType: OperationType.SIGN_IN
     });

--- a/packages-exp/auth-exp/src/core/providers/oauth.test.ts
+++ b/packages-exp/auth-exp/src/core/providers/oauth.test.ts
@@ -1,0 +1,98 @@
+/**
+ * @license
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { expect } from 'chai';
+
+import {
+  OperationType,
+  ProviderId,
+  SignInMethod
+} from '@firebase/auth-types-exp';
+
+import { TEST_ID_TOKEN_RESPONSE } from '../../../test/helpers/id_token_response';
+import { testUser, testAuth } from '../../../test/helpers/mock_auth';
+import { TaggedWithTokenResponse } from '../../model/id_token';
+import { AuthErrorCode } from '../errors';
+import { UserCredentialImpl } from '../user/user_credential_impl';
+import { _createError } from '../util/assert';
+import { OAuthProvider } from './oauth';
+
+describe('core/providers/oauth', () => {
+  it('generates the correct type of oauth credential', () => {
+    const cred = new OAuthProvider('google.com').credential({
+      idToken: 'id-token',
+      accessToken: 'access-token',
+    });
+    expect(cred.accessToken).to.eq('access-token');
+    expect(cred.idToken).to.eq('id-token');
+    expect(cred.providerId).to.eq(ProviderId.GOOGLE);
+    expect(cred.signInMethod).to.eq(SignInMethod.GOOGLE);
+  });
+
+  it('credentialFromResult creates the cred from a tagged result', async () => {
+    const auth = await testAuth();
+    const userCred = new UserCredentialImpl({
+      user: testUser(auth, 'uid'),
+      providerId: ProviderId.GOOGLE,
+      _tokenResponse: {
+        ...TEST_ID_TOKEN_RESPONSE,
+        oauthAccessToken: 'access-token',
+        oauthIdToken: 'id-token',
+        providerId: ProviderId.FACEBOOK,
+      },
+      operationType: OperationType.SIGN_IN
+    });
+    const cred = OAuthProvider.credentialFromResult(userCred)!;
+    expect(cred.accessToken).to.eq('access-token');
+    expect(cred.idToken).to.eq('id-token');
+    expect(cred.providerId).to.eq(ProviderId.FACEBOOK);
+    expect(cred.signInMethod).to.eq(SignInMethod.FACEBOOK);
+  });
+
+  it('credentialFromResult returns null if provider ID not specified', async () => {
+    const auth = await testAuth();
+    const userCred = new UserCredentialImpl({
+      user: testUser(auth, 'uid'),
+      providerId: ProviderId.GOOGLE,
+      _tokenResponse: {
+        ...TEST_ID_TOKEN_RESPONSE,
+        oauthAccessToken: 'access-token',
+        oauthIdToken: 'id-token',
+      },
+      operationType: OperationType.SIGN_IN
+    });
+    expect(OAuthProvider.credentialFromResult(userCred)).to.be.null;
+  });
+
+  it('credentialFromError creates the cred from a tagged error', () => {
+    const error = _createError(AuthErrorCode.NEED_CONFIRMATION, {
+      appName: 'foo'
+    });
+    (error.customData! as TaggedWithTokenResponse)._tokenResponse = {
+      ...TEST_ID_TOKEN_RESPONSE,
+      oauthAccessToken: 'access-token',
+      oauthIdToken: 'id-token',
+      providerId: ProviderId.FACEBOOK
+    };
+
+    const cred = OAuthProvider.credentialFromError(error)!;
+    expect(cred.accessToken).to.eq('access-token');
+    expect(cred.idToken).to.eq('id-token');
+    expect(cred.providerId).to.eq(ProviderId.FACEBOOK);
+    expect(cred.signInMethod).to.eq(SignInMethod.FACEBOOK);
+  });
+});

--- a/packages-exp/auth-types-exp/index.d.ts
+++ b/packages-exp/auth-types-exp/index.d.ts
@@ -215,7 +215,7 @@ export interface Auth {
    *
    * @param persistence - The {@link Persistence} to use.
    */
-  setPersistence(persistence: Persistence): void;
+  setPersistence(persistence: Persistence): Promise<void>;
   /**
    * The Auth instance's language code.
    *


### PR DESCRIPTION
Specifically, this PR:
  * Fixes the return type of `setPersistence` to be the correct value (`Promise<void>`) in the typings package
  * Adds `OAuthProvider.credentialFromResult()` and `OAuthProvider.credentialFromError()`