### PR TITLE
Prefix all LocalStore functions with localStore

### DIFF
--- a/packages/firestore/src/core/bundle_impl.ts
+++ b/packages/firestore/src/core/bundle_impl.ts
@@ -19,8 +19,8 @@ import { LoadBundleTaskProgress } from '@firebase/firestore-types';
 
 import { LocalStore } from '../local/local_store';
 import {
-  applyBundleDocuments,
-  saveNamedQuery
+  localStoreApplyBundledDocuments,
+  localStoreSaveNamedQuery
 } from '../local/local_store_impl';
 import { documentKeySet, DocumentKeySet } from '../model/collections';
 import { MaybeDocument, NoDocument } from '../model/document';
@@ -173,7 +173,7 @@ export class BundleLoader {
     );
     debugAssert(!!this.bundleMetadata.id, 'Bundle ID must be set.');
 
-    const changedDocuments = await applyBundleDocuments(
+    const changedDocuments = await localStoreApplyBundledDocuments(
       this.localStore,
       new BundleConverterImpl(this.serializer),
       this.documents,
@@ -183,7 +183,11 @@ export class BundleLoader {
     const queryDocumentMap = this.getQueryDocumentMapping(this.documents);
 
     for (const q of this.queries) {
-      await saveNamedQuery(this.localStore, q, queryDocumentMap.get(q.name!));
+      await localStoreSaveNamedQuery(
+        this.localStore,
+        q,
+        queryDocumentMap.get(q.name!)
+      );
     }
 
     this.progress.taskState = 'Success';

--- a/packages/firestore/src/core/component_provider.ts
+++ b/packages/firestore/src/core/component_provider.ts
@@ -24,7 +24,7 @@ import {
 import { LocalStore } from '../local/local_store';
 import {
   newLocalStore,
-  synchronizeLastDocumentChangeReadTime
+  localStoreSynchronizeLastDocumentChangeReadTime
 } from '../local/local_store_impl';
 import { LruParams } from '../local/lru_garbage_collector';
 import { LruScheduler } from '../local/lru_garbage_collector_impl';
@@ -172,7 +172,7 @@ export class IndexedDbOfflineComponentProvider extends MemoryOfflineComponentPro
 
   async initialize(cfg: ComponentConfiguration): Promise<void> {
     await super.initialize(cfg);
-    await synchronizeLastDocumentChangeReadTime(this.localStore);
+    await localStoreSynchronizeLastDocumentChangeReadTime(this.localStore);
 
     await this.onlineComponentProvider.initialize(this, cfg);
 

--- a/packages/firestore/src/core/firestore_client.ts
+++ b/packages/firestore/src/core/firestore_client.ts
@@ -25,10 +25,10 @@ import {
 import { User } from '../auth/user';
 import { LocalStore } from '../local/local_store';
 import {
-  executeQuery,
-  getNamedQuery,
-  handleUserChange,
-  readLocalDocument
+  localStoreExecuteQuery,
+  localStoreGetNamedQuery,
+  localStoreHandleUserChange,
+  localStoreReadDocument
 } from '../local/local_store_impl';
 import { Persistence } from '../local/persistence';
 import { Document, NoDocument } from '../model/document';
@@ -201,7 +201,10 @@ export async function setOfflineComponentProvider(
 
   client.setCredentialChangeListener(user =>
     client.asyncQueue.enqueueRetryable(async () => {
-      await handleUserChange(offlineComponentProvider.localStore, user);
+      await localStoreHandleUserChange(
+        offlineComponentProvider.localStore,
+        user
+      );
     })
   );
 
@@ -493,7 +496,7 @@ async function readDocumentFromCache(
   result: Deferred<Document | null>
 ): Promise<void> {
   try {
-    const maybeDoc = await readLocalDocument(localStore, docKey);
+    const maybeDoc = await localStoreReadDocument(localStore, docKey);
     if (maybeDoc instanceof Document) {
       result.resolve(maybeDoc);
     } else if (maybeDoc instanceof NoDocument) {
@@ -595,7 +598,7 @@ async function executeQueryFromCache(
   result: Deferred<ViewSnapshot>
 ): Promise<void> {
   try {
-    const queryResult = await executeQuery(
+    const queryResult = await localStoreExecuteQuery(
       localStore,
       query,
       /* usePreviousResults= */ true
@@ -676,7 +679,7 @@ export function firestoreClientGetNamedQuery(
   queryName: string
 ): Promise<NamedQuery | undefined> {
   return client.asyncQueue.enqueue(async () =>
-    getNamedQuery(await getLocalStore(client), queryName)
+    localStoreGetNamedQuery(await getLocalStore(client), queryName)
   );
 }
 

--- a/packages/firestore/src/core/firestore_client.ts
+++ b/packages/firestore/src/core/firestore_client.ts
@@ -201,10 +201,12 @@ export async function setOfflineComponentProvider(
   client.setCredentialChangeListener(user => {
     if (!currentUser.isEqual(user)) {
       currentUser = user;
-      await localStoreHandleUserChange(
-        offlineComponentProvider.localStore,
-        user
-      );
+      client.asyncQueue.enqueueRetryable(async () => {
+        await localStoreHandleUserChange(
+          offlineComponentProvider.localStore,
+          user
+        );
+      });
     }
   });
 

--- a/packages/firestore/src/local/local_store.ts
+++ b/packages/firestore/src/local/local_store.ts
@@ -20,6 +20,7 @@ import { logDebug } from '../util/log';
 
 import { LruGarbageCollector, LruResults } from './lru_garbage_collector';
 import { PRIMARY_LEASE_LOST_ERROR_MSG } from './persistence_transaction';
+
 export interface LocalStore {
   collectGarbage(garbageCollector: LruGarbageCollector): Promise<LruResults>;
 }

--- a/packages/firestore/src/local/local_store_impl.ts
+++ b/packages/firestore/src/local/local_store_impl.ts
@@ -213,7 +213,7 @@ export function newLocalStore(
  */
 // PORTING NOTE: Android and iOS only return the documents affected by the
 // change.
-export async function handleUserChange(
+export async function localStoreHandleUserChange(
   localStore: LocalStore,
   user: User
 ): Promise<UserChangeResult> {
@@ -290,7 +290,7 @@ export async function handleUserChange(
 }
 
 /* Accepts locally generated Mutations and commit them to storage. */
-export function localWrite(
+export function localStoreWriteLocally(
   localStore: LocalStore,
   mutations: Mutation[]
 ): Promise<LocalWriteResult> {
@@ -365,7 +365,7 @@ export function localWrite(
  *
  * @returns The resulting (modified) documents.
  */
-export function acknowledgeBatch(
+export function localStoreAcknowledgeBatch(
   localStore: LocalStore,
   batchResult: MutationBatchResult
 ): Promise<MaybeDocumentMap> {
@@ -397,7 +397,7 @@ export function acknowledgeBatch(
  *
  * @returns The resulting modified documents.
  */
-export function rejectBatch(
+export function localStoreRejectBatch(
   localStore: LocalStore,
   batchId: BatchId
 ): Promise<MaybeDocumentMap> {
@@ -428,7 +428,7 @@ export function rejectBatch(
  *
  * Returns `BATCHID_UNKNOWN` if the queue is empty.
  */
-export function getHighestUnacknowledgedBatchId(
+export function localStoreGetHighestUnacknowledgedBatchId(
   localStore: LocalStore
 ): Promise<BatchId> {
   const localStoreImpl = debugCast(localStore, LocalStoreImpl);
@@ -443,7 +443,7 @@ export function getHighestUnacknowledgedBatchId(
  * Returns the last consistent snapshot processed (used by the RemoteStore to
  * determine whether to buffer incoming snapshots from the backend).
  */
-export function getLastRemoteSnapshotVersion(
+export function localStoreGetLastRemoteSnapshotVersion(
   localStore: LocalStore
 ): Promise<SnapshotVersion> {
   const localStoreImpl = debugCast(localStore, LocalStoreImpl);
@@ -462,7 +462,7 @@ export function getLastRemoteSnapshotVersion(
  * LocalDocuments are re-calculated if there are remaining mutations in the
  * queue.
  */
-export function applyRemoteEventToLocalCache(
+export function localStoreApplyRemoteEventToLocalCache(
   localStore: LocalStore,
   remoteEvent: RemoteEvent
 ): Promise<MaybeDocumentMap> {
@@ -714,7 +714,7 @@ function shouldPersistTargetData(
 /**
  * Notifies local store of the changed views to locally pin documents.
  */
-export async function notifyLocalViewChanges(
+export async function localStoreNotifyLocalViewChanges(
   localStore: LocalStore,
   viewChanges: LocalViewChanges[]
 ): Promise<void> {
@@ -791,7 +791,7 @@ export async function notifyLocalViewChanges(
  * @param afterBatchId - If provided, the batch to search after.
  * @returns The next mutation or null if there wasn't one.
  */
-export function nextMutationBatch(
+export function localStoreGetNextMutationBatch(
   localStore: LocalStore,
   afterBatchId?: BatchId
 ): Promise<MutationBatch | null> {
@@ -815,7 +815,7 @@ export function nextMutationBatch(
  * Reads the current value of a Document with a given key or null if not
  * found - used for testing.
  */
-export function readLocalDocument(
+export function localStoreReadDocument(
   localStore: LocalStore,
   key: DocumentKey
 ): Promise<MaybeDocument | null> {
@@ -835,7 +835,7 @@ export function readLocalDocument(
  * Allocating an already allocated `Target` will return the existing `TargetData`
  * for that `Target`.
  */
-export function allocateTarget(
+export function localStoreAllocateTarget(
   localStore: LocalStore,
   target: Target
 ): Promise<TargetData> {
@@ -895,7 +895,7 @@ export function allocateTarget(
  * have not yet been persisted to the TargetCache.
  */
 // Visible for testing.
-export function getLocalTargetData(
+export function localStoreGetTargetData(
   localStore: LocalStore,
   transaction: PersistenceTransaction,
   target: Target
@@ -919,7 +919,7 @@ export function getLocalTargetData(
  * Releasing a non-existing `Target` is a no-op.
  */
 // PORTING NOTE: `keepPersistedTargetData` is multi-tab only.
-export async function releaseTarget(
+export async function localStoreReleaseTarget(
   localStore: LocalStore,
   targetId: number,
   keepPersistedTargetData: boolean
@@ -976,7 +976,7 @@ export async function releaseTarget(
  * @param usePreviousResults - Whether results from previous executions can
  * be used to optimize this query execution.
  */
-export function executeQuery(
+export function localStoreExecuteQuery(
   localStore: LocalStore,
   query: Query,
   usePreviousResults: boolean
@@ -989,7 +989,7 @@ export function executeQuery(
     'Execute query',
     'readonly',
     txn => {
-      return getLocalTargetData(localStoreImpl, txn, queryToTarget(query))
+      return localStoreGetTargetData(localStoreImpl, txn, queryToTarget(query))
         .next(targetData => {
           if (targetData) {
             lastLimboFreeSnapshotVersion =
@@ -1066,7 +1066,7 @@ function applyWriteToRemoteDocuments(
 
 /** Returns the local view of the documents affected by a mutation batch. */
 // PORTING NOTE: Multi-Tab only.
-export function lookupMutationDocuments(
+export function localStoreLookupMutationDocuments(
   localStore: LocalStore,
   batchId: BatchId
 ): Promise<MaybeDocumentMap | null> {
@@ -1094,7 +1094,7 @@ export function lookupMutationDocuments(
 }
 
 // PORTING NOTE: Multi-Tab only.
-export function removeCachedMutationBatchMetadata(
+export function localStoreRemoveCachedMutationBatchMetadata(
   localStore: LocalStore,
   batchId: BatchId
 ): void {
@@ -1106,7 +1106,7 @@ export function removeCachedMutationBatchMetadata(
 }
 
 // PORTING NOTE: Multi-Tab only.
-export function getActiveClientsFromPersistence(
+export function localStoreGetActiveClients(
   localStore: LocalStore
 ): Promise<ClientId[]> {
   const persistenceImpl = debugCast(
@@ -1117,7 +1117,7 @@ export function getActiveClientsFromPersistence(
 }
 
 // PORTING NOTE: Multi-Tab only.
-export function getCachedTarget(
+export function localStoreGetCachedTarget(
   localStore: LocalStore,
   targetId: TargetId
 ): Promise<Target | null> {
@@ -1149,7 +1149,7 @@ export function getCachedTarget(
  * since the prior call.
  */
 // PORTING NOTE: Multi-Tab only.
-export function getNewDocumentChanges(
+export function localStoreGetNewDocumentChanges(
   localStore: LocalStore
 ): Promise<MaybeDocumentMap> {
   const localStoreImpl = debugCast(localStore, LocalStoreImpl);
@@ -1173,7 +1173,7 @@ export function getNewDocumentChanges(
  * only return changes that happened after client initialization.
  */
 // PORTING NOTE: Multi-Tab only.
-export async function synchronizeLastDocumentChangeReadTime(
+export async function localStoreSynchronizeLastDocumentChangeReadTime(
   localStore: LocalStore
 ): Promise<void> {
   const localStoreImpl = debugCast(localStore, LocalStoreImpl);
@@ -1209,7 +1209,7 @@ function umbrellaTarget(bundleName: string): Target {
  * LocalDocuments are re-calculated if there are remaining mutations in the
  * queue.
  */
-export async function applyBundleDocuments(
+export async function localStoreApplyBundledDocuments(
   localStore: LocalStore,
   bundleConverter: BundleConverter,
   documents: BundledDocuments,
@@ -1240,7 +1240,7 @@ export async function applyBundleDocuments(
 
   // Allocates a target to hold all document keys from the bundle, such that
   // they will not get garbage collected right away.
-  const umbrellaTargetData = await allocateTarget(
+  const umbrellaTargetData = await localStoreAllocateTarget(
     localStoreImpl,
     umbrellaTarget(bundleName)
   );
@@ -1284,7 +1284,7 @@ export async function applyBundleDocuments(
  * Returns a promise of a boolean to indicate if the given bundle has already
  * been loaded and the create time is newer than the current loading bundle.
  */
-export function hasNewerBundle(
+export function localStoreHasNewerBundle(
   localStore: LocalStore,
   bundleMetadata: BundleMetadata
 ): Promise<boolean> {
@@ -1305,7 +1305,7 @@ export function hasNewerBundle(
 /**
  * Saves the given `BundleMetadata` to local persistence.
  */
-export function saveBundle(
+export function localStoreSaveBundle(
   localStore: LocalStore,
   bundleMetadata: BundleMetadata
 ): Promise<void> {
@@ -1326,7 +1326,7 @@ export function saveBundle(
  * Returns a promise of a `NamedQuery` associated with given query name. Promise
  * resolves to undefined if no persisted data can be found.
  */
-export function getNamedQuery(
+export function localStoreGetNamedQuery(
   localStore: LocalStore,
   queryName: string
 ): Promise<NamedQuery | undefined> {
@@ -1342,7 +1342,7 @@ export function getNamedQuery(
 /**
  * Saves the given `NamedQuery` to local persistence.
  */
-export async function saveNamedQuery(
+export async function localStoreSaveNamedQuery(
   localStore: LocalStore,
   query: ProtoNamedQuery,
   documents: DocumentKeySet = documentKeySet()
@@ -1352,7 +1352,7 @@ export async function saveNamedQuery(
   // NOTE: this also means if no corresponding target exists, the new target
   // will remain active and will not get collected, unless users happen to
   // unlisten the query somehow.
-  const allocated = await allocateTarget(
+  const allocated = await localStoreAllocateTarget(
     localStore,
     queryToTarget(fromBundledQuery(query.bundledQuery!))
   );

--- a/packages/firestore/src/remote/remote_store.ts
+++ b/packages/firestore/src/remote/remote_store.ts
@@ -20,8 +20,8 @@ import { SnapshotVersion } from '../core/snapshot_version';
 import { OnlineState, TargetId } from '../core/types';
 import { LocalStore } from '../local/local_store';
 import {
-  getLastRemoteSnapshotVersion,
-  nextMutationBatch
+  localStoreGetLastRemoteSnapshotVersion,
+  localStoreGetNextMutationBatch
 } from '../local/local_store_impl';
 import { isIndexedDbTransactionError } from '../local/simple_db';
 import { TargetData, TargetPurpose } from '../local/target_data';
@@ -470,7 +470,7 @@ async function onWatchStreamChange(
 
   if (!snapshotVersion.isEqual(SnapshotVersion.min())) {
     try {
-      const lastRemoteSnapshotVersion = await getLastRemoteSnapshotVersion(
+      const lastRemoteSnapshotVersion = await localStoreGetLastRemoteSnapshotVersion(
         remoteStoreImpl.localStore
       );
       if (snapshotVersion.compareTo(lastRemoteSnapshotVersion) >= 0) {
@@ -514,7 +514,8 @@ async function disableNetworkUntilRecovery(
       // Use a simple read operation to determine if IndexedDB recovered.
       // Ideally, we would expose a health check directly on SimpleDb, but
       // RemoteStore only has access to persistence through LocalStore.
-      op = () => getLastRemoteSnapshotVersion(remoteStoreImpl.localStore);
+      op = () =>
+        localStoreGetLastRemoteSnapshotVersion(remoteStoreImpl.localStore);
     }
 
     // Probe IndexedDB periodically and re-enable network
@@ -659,7 +660,7 @@ export async function fillWritePipeline(
 
   while (canAddToWritePipeline(remoteStoreImpl)) {
     try {
-      const batch = await nextMutationBatch(
+      const batch = await localStoreGetNextMutationBatch(
         remoteStoreImpl.localStore,
         lastBatchIdRetrieved
       );

--- a/packages/firestore/test/unit/local/local_store.test.ts
+++ b/packages/firestore/test/unit/local/local_store.test.ts
@@ -46,14 +46,14 @@ import {
   localStoreHasNewerBundle,
   localStoreWriteLocally,
   LocalWriteResult,
-  newLocalStore,
   localStoreNotifyLocalViewChanges,
   localStoreReadDocument,
   localStoreRejectBatch,
   localStoreReleaseTarget,
   localStoreSaveBundle,
   localStoreSaveNamedQuery,
-  localStoreSynchronizeLastDocumentChangeReadTime
+  localStoreSynchronizeLastDocumentChangeReadTime,
+  newLocalStore
 } from '../../../src/local/local_store_impl';
 import { LocalViewChanges } from '../../../src/local/local_view_changes';
 import { Persistence } from '../../../src/local/persistence';

--- a/packages/firestore/test/unit/local/local_store.test.ts
+++ b/packages/firestore/test/unit/local/local_store.test.ts
@@ -35,25 +35,25 @@ import { BatchId, TargetId } from '../../../src/core/types';
 import { IndexedDbPersistence } from '../../../src/local/indexeddb_persistence';
 import { LocalStore } from '../../../src/local/local_store';
 import {
-  acknowledgeBatch,
-  allocateTarget,
-  applyBundleDocuments,
-  applyRemoteEventToLocalCache,
-  executeQuery,
-  getHighestUnacknowledgedBatchId,
-  getLocalTargetData,
-  getNamedQuery,
-  hasNewerBundle,
-  localWrite,
+  localStoreAcknowledgeBatch,
+  localStoreAllocateTarget,
+  localStoreApplyBundledDocuments,
+  localStoreApplyRemoteEventToLocalCache,
+  localStoreExecuteQuery,
+  localStoreGetHighestUnacknowledgedBatchId,
+  localStoreGetTargetData,
+  localStoreGetNamedQuery,
+  localStoreHasNewerBundle,
+  localStoreWriteLocally,
   LocalWriteResult,
   newLocalStore,
-  notifyLocalViewChanges,
-  readLocalDocument,
-  rejectBatch,
-  releaseTarget,
-  saveBundle,
-  saveNamedQuery,
-  synchronizeLastDocumentChangeReadTime
+  localStoreNotifyLocalViewChanges,
+  localStoreReadDocument,
+  localStoreRejectBatch,
+  localStoreReleaseTarget,
+  localStoreSaveBundle,
+  localStoreSaveNamedQuery,
+  localStoreSynchronizeLastDocumentChangeReadTime
 } from '../../../src/local/local_store_impl';
 import { LocalViewChanges } from '../../../src/local/local_view_changes';
 import { Persistence } from '../../../src/local/persistence';
@@ -172,7 +172,7 @@ class LocalStoreTester {
     this.prepareNextStep();
 
     this.promiseChain = this.promiseChain
-      .then(() => localWrite(this.localStore, mutations))
+      .then(() => localStoreWriteLocally(this.localStore, mutations))
       .then((result: LocalWriteResult) => {
         this.batches.push(
           new MutationBatch(result.batchId, Timestamp.now(), [], mutations)
@@ -186,7 +186,9 @@ class LocalStoreTester {
     this.prepareNextStep();
 
     this.promiseChain = this.promiseChain
-      .then(() => applyRemoteEventToLocalCache(this.localStore, remoteEvent))
+      .then(() =>
+        localStoreApplyRemoteEventToLocalCache(this.localStore, remoteEvent)
+      )
       .then((result: MaybeDocumentMap) => {
         this.lastChanges = result;
       });
@@ -201,7 +203,7 @@ class LocalStoreTester {
 
     this.promiseChain = this.promiseChain
       .then(() =>
-        applyBundleDocuments(
+        localStoreApplyBundledDocuments(
           this.localStore,
           this.bundleConverter,
           documents,
@@ -218,7 +220,7 @@ class LocalStoreTester {
     this.prepareNextStep();
 
     this.promiseChain = this.promiseChain.then(() =>
-      saveNamedQuery(
+      localStoreSaveNamedQuery(
         this.localStore,
         testQuery.namedQuery,
         testQuery.matchingDocuments
@@ -231,7 +233,7 @@ class LocalStoreTester {
     this.prepareNextStep();
 
     this.promiseChain = this.promiseChain.then(() =>
-      notifyLocalViewChanges(this.localStore, [viewChanges])
+      localStoreNotifyLocalViewChanges(this.localStore, [viewChanges])
     );
     return this;
   }
@@ -258,7 +260,7 @@ class LocalStoreTester {
         ];
         const write = MutationBatchResult.from(batch, ver, mutationResults);
 
-        return acknowledgeBatch(this.localStore, write);
+        return localStoreAcknowledgeBatch(this.localStore, write);
       })
       .then((changes: MaybeDocumentMap) => {
         this.lastChanges = changes;
@@ -270,7 +272,9 @@ class LocalStoreTester {
     this.prepareNextStep();
 
     this.promiseChain = this.promiseChain
-      .then(() => rejectBatch(this.localStore, this.batches.shift()!.batchId))
+      .then(() =>
+        localStoreRejectBatch(this.localStore, this.batches.shift()!.batchId)
+      )
       .then((changes: MaybeDocumentMap) => {
         this.lastChanges = changes;
       });
@@ -285,7 +289,7 @@ class LocalStoreTester {
     this.prepareNextStep();
 
     this.promiseChain = this.promiseChain.then(() =>
-      allocateTarget(this.localStore, target).then(result => {
+      localStoreAllocateTarget(this.localStore, target).then(result => {
         this.lastTargetId = result.targetId;
       })
     );
@@ -296,7 +300,7 @@ class LocalStoreTester {
     this.prepareNextStep();
 
     this.promiseChain = this.promiseChain.then(() =>
-      releaseTarget(
+      localStoreReleaseTarget(
         this.localStore,
         targetId,
         /*keepPersistedTargetData=*/ false
@@ -309,11 +313,13 @@ class LocalStoreTester {
     this.prepareNextStep();
 
     this.promiseChain = this.promiseChain.then(() =>
-      executeQuery(this.localStore, query, /* usePreviousResults= */ true).then(
-        ({ documents }) => {
-          this.lastChanges = documents;
-        }
-      )
+      localStoreExecuteQuery(
+        this.localStore,
+        query,
+        /* usePreviousResults= */ true
+      ).then(({ documents }) => {
+        this.lastChanges = documents;
+      })
     );
     return this;
   }
@@ -416,7 +422,7 @@ class LocalStoreTester {
 
   toContain(doc: MaybeDocument): LocalStoreTester {
     this.promiseChain = this.promiseChain.then(() => {
-      return readLocalDocument(this.localStore, doc.key).then(result => {
+      return localStoreReadDocument(this.localStore, doc.key).then(result => {
         expectEqual(
           result,
           doc,
@@ -431,7 +437,7 @@ class LocalStoreTester {
 
   toNotContain(keyStr: string): LocalStoreTester {
     this.promiseChain = this.promiseChain.then(() =>
-      readLocalDocument(this.localStore, key(keyStr)).then(result => {
+      localStoreReadDocument(this.localStore, key(keyStr)).then(result => {
         expect(result).to.be.null;
       })
     );
@@ -448,9 +454,11 @@ class LocalStoreTester {
 
   toReturnHighestUnacknowledgeBatchId(expectedId: BatchId): LocalStoreTester {
     this.promiseChain = this.promiseChain.then(() =>
-      getHighestUnacknowledgedBatchId(this.localStore).then(actual => {
-        expect(actual).to.equal(expectedId);
-      })
+      localStoreGetHighestUnacknowledgedBatchId(this.localStore).then(
+        actual => {
+          expect(actual).to.equal(expectedId);
+        }
+      )
     );
     return this;
   }
@@ -483,28 +491,32 @@ class LocalStoreTester {
     expected: boolean
   ): LocalStoreTester {
     this.promiseChain = this.promiseChain.then(() => {
-      return hasNewerBundle(this.localStore, metadata).then(actual => {
-        expect(actual).to.equal(expected);
-      });
+      return localStoreHasNewerBundle(this.localStore, metadata).then(
+        actual => {
+          expect(actual).to.equal(expected);
+        }
+      );
     });
     return this;
   }
 
   toHaveNamedQuery(namedQuery: NamedQuery): LocalStoreTester {
     this.promiseChain = this.promiseChain.then(() => {
-      return getNamedQuery(this.localStore, namedQuery.name).then(actual => {
-        expect(actual).to.exist;
-        expect(actual!.name).to.equal(namedQuery.name);
-        expect(namedQuery.readTime.isEqual(actual!.readTime)).to.be.true;
-        expect(queryEquals(actual!.query, namedQuery.query)).to.be.true;
-      });
+      return localStoreGetNamedQuery(this.localStore, namedQuery.name).then(
+        actual => {
+          expect(actual).to.exist;
+          expect(actual!.name).to.equal(namedQuery.name);
+          expect(namedQuery.readTime.isEqual(actual!.readTime)).to.be.true;
+          expect(queryEquals(actual!.query, namedQuery.query)).to.be.true;
+        }
+      );
     });
     return this;
   }
 
   afterSavingBundle(metadata: ProtoBundleMetadata): LocalStoreTester {
     this.promiseChain = this.promiseChain.then(() =>
-      saveBundle(this.localStore, metadata)
+      localStoreSaveBundle(this.localStore, metadata)
     );
     return this;
   }
@@ -548,7 +560,7 @@ describe('LocalStore w/ IndexedDB Persistence', () => {
       User.UNAUTHENTICATED,
       JSON_SERIALIZER
     );
-    await synchronizeLastDocumentChangeReadTime(localStore);
+    await localStoreSynchronizeLastDocumentChangeReadTime(localStore);
     return { queryEngine, persistence, localStore };
   }
 
@@ -1135,13 +1147,13 @@ function genericLocalStoreTests(
 
   it('can execute document queries', () => {
     const localStore = expectLocalStore().localStore;
-    return localWrite(localStore, [
+    return localStoreWriteLocally(localStore, [
       setMutation('foo/bar', { foo: 'bar' }),
       setMutation('foo/baz', { foo: 'baz' }),
       setMutation('foo/bar/Foo/Bar', { Foo: 'Bar' })
     ])
       .then(() => {
-        return executeQuery(
+        return localStoreExecuteQuery(
           localStore,
           query('foo/bar'),
           /* usePreviousResults= */ true
@@ -1155,7 +1167,7 @@ function genericLocalStoreTests(
 
   it('can execute collection queries', () => {
     const localStore = expectLocalStore().localStore;
-    return localWrite(localStore, [
+    return localStoreWriteLocally(localStore, [
       setMutation('fo/bar', { fo: 'bar' }),
       setMutation('foo/bar', { foo: 'bar' }),
       setMutation('foo/baz', { foo: 'baz' }),
@@ -1163,7 +1175,7 @@ function genericLocalStoreTests(
       setMutation('fooo/blah', { fooo: 'blah' })
     ])
       .then(() => {
-        return executeQuery(
+        return localStoreExecuteQuery(
           localStore,
           query('foo'),
           /* usePreviousResults= */ true
@@ -1178,18 +1190,23 @@ function genericLocalStoreTests(
 
   it('can execute mixed collection queries', async () => {
     const query1 = query('foo');
-    const targetData = await allocateTarget(localStore, queryToTarget(query1));
+    const targetData = await localStoreAllocateTarget(
+      localStore,
+      queryToTarget(query1)
+    );
     expect(targetData.targetId).to.equal(2);
-    await applyRemoteEventToLocalCache(
+    await localStoreApplyRemoteEventToLocalCache(
       localStore,
       docAddedRemoteEvent(doc('foo/baz', 10, { a: 'b' }), [2], [])
     );
-    await applyRemoteEventToLocalCache(
+    await localStoreApplyRemoteEventToLocalCache(
       localStore,
       docUpdateRemoteEvent(doc('foo/bar', 20, { a: 'b' }), [2], [])
     );
-    await localWrite(localStore, [setMutation('foo/bonk', { a: 'b' })]);
-    const { documents } = await executeQuery(
+    await localStoreWriteLocally(localStore, [
+      setMutation('foo/bonk', { a: 'b' })
+    ]);
+    const { documents } = await localStoreExecuteQuery(
       localStore,
       query1,
       /* usePreviousResults= */ true
@@ -1243,7 +1260,10 @@ function genericLocalStoreTests(
   // eslint-disable-next-line no-restricted-properties
   (gcIsEager ? it.skip : it)('persists resume tokens', async () => {
     const query1 = query('foo/bar');
-    const targetData = await allocateTarget(localStore, queryToTarget(query1));
+    const targetData = await localStoreAllocateTarget(
+      localStore,
+      queryToTarget(query1)
+    );
     const targetId = targetData.targetId;
     const resumeToken = byteStringFromString('abc');
     const watchChange = new WatchTargetChange(
@@ -1257,17 +1277,20 @@ function genericLocalStoreTests(
     });
     aggregator.handleTargetChange(watchChange);
     const remoteEvent = aggregator.createRemoteEvent(version(1000));
-    await applyRemoteEventToLocalCache(localStore, remoteEvent);
+    await localStoreApplyRemoteEventToLocalCache(localStore, remoteEvent);
 
     // Stop listening so that the query should become inactive (but persistent)
-    await releaseTarget(
+    await localStoreReleaseTarget(
       localStore,
       targetData.targetId,
       /*keepPersistedTargetData=*/ false
     );
 
     // Should come back with the same resume token
-    const targetData2 = await allocateTarget(localStore, queryToTarget(query1));
+    const targetData2 = await localStoreAllocateTarget(
+      localStore,
+      queryToTarget(query1)
+    );
     expect(targetData2.resumeToken).to.deep.equal(resumeToken);
   });
 
@@ -1276,7 +1299,7 @@ function genericLocalStoreTests(
     'does not replace resume token with empty resume token',
     async () => {
       const query1 = query('foo/bar');
-      const targetData = await allocateTarget(
+      const targetData = await localStoreAllocateTarget(
         localStore,
         queryToTarget(query1)
       );
@@ -1294,7 +1317,7 @@ function genericLocalStoreTests(
       });
       aggregator1.handleTargetChange(watchChange1);
       const remoteEvent1 = aggregator1.createRemoteEvent(version(1000));
-      await applyRemoteEventToLocalCache(localStore, remoteEvent1);
+      await localStoreApplyRemoteEventToLocalCache(localStore, remoteEvent1);
 
       const watchChange2 = new WatchTargetChange(
         WatchTargetChangeState.Current,
@@ -1307,17 +1330,17 @@ function genericLocalStoreTests(
       });
       aggregator2.handleTargetChange(watchChange2);
       const remoteEvent2 = aggregator2.createRemoteEvent(version(2000));
-      await applyRemoteEventToLocalCache(localStore, remoteEvent2);
+      await localStoreApplyRemoteEventToLocalCache(localStore, remoteEvent2);
 
       // Stop listening so that the query should become inactive (but persistent)
-      await releaseTarget(
+      await localStoreReleaseTarget(
         localStore,
         targetId,
         /*keepPersistedTargetData=*/ false
       );
 
       // Should come back with the same resume token
-      const targetData2 = await allocateTarget(
+      const targetData2 = await localStoreAllocateTarget(
         localStore,
         queryToTarget(query1)
       );
@@ -1922,10 +1945,10 @@ function genericLocalStoreTests(
 
     const target = queryToTarget(query('foo'));
 
-    const targetData = await allocateTarget(localStore, target);
+    const targetData = await localStoreAllocateTarget(localStore, target);
 
     // Advance the query snapshot
-    await applyRemoteEventToLocalCache(
+    await localStoreApplyRemoteEventToLocalCache(
       localStore,
       noChangeEvent(
         /* targetId= */ targetData.targetId,
@@ -1938,7 +1961,7 @@ function genericLocalStoreTests(
     let cachedTargetData = await persistence.runTransaction(
       'getTargetData',
       'readonly',
-      txn => getLocalTargetData(localStore, txn, target)
+      txn => localStoreGetTargetData(localStore, txn, target)
     );
     expect(
       cachedTargetData!.lastLimboFreeSnapshotVersion.isEqual(
@@ -1947,20 +1970,20 @@ function genericLocalStoreTests(
     ).to.be.true;
 
     // Mark the view synced, which updates the last limbo free snapshot version.
-    await notifyLocalViewChanges(localStore, [
+    await localStoreNotifyLocalViewChanges(localStore, [
       localViewChanges(2, /* fromCache= */ false, {})
     ]);
     cachedTargetData = await persistence.runTransaction(
       'getTargetData',
       'readonly',
-      txn => getLocalTargetData(localStore, txn, target)
+      txn => localStoreGetTargetData(localStore, txn, target)
     );
     expect(cachedTargetData!.lastLimboFreeSnapshotVersion.isEqual(version(10)))
       .to.be.true;
 
     // The last limbo free snapshot version is persisted even if we release the
     // query.
-    await releaseTarget(
+    await localStoreReleaseTarget(
       localStore,
       targetData.targetId,
       /* keepPersistedTargetData= */ false
@@ -1970,7 +1993,7 @@ function genericLocalStoreTests(
       cachedTargetData = await persistence.runTransaction(
         'getTargetData',
         'readonly',
-        txn => getLocalTargetData(localStore, txn, target)
+        txn => localStoreGetTargetData(localStore, txn, target)
       );
       expect(
         cachedTargetData!.lastLimboFreeSnapshotVersion.isEqual(version(10))


### PR DESCRIPTION
This addresses an outstanding cleanup from the firestore-exp work. In the later stages of the development, we decided to use consistent prefixes for all free-standing functions so that they we can continue to use the method names from other platforms. This first PR addresses LocalStore.

A class that already follows this pattern is FirestoreClient.