### PR TITLE
Fix remote-config-exp installations import

### DIFF
--- a/packages-exp/remote-config-exp/src/index.ts
+++ b/packages-exp/remote-config-exp/src/index.ts
@@ -15,7 +15,6 @@
  * limitations under the License.
  */
 
-import '@firebase/installations-exp';
 import { registerRemoteConfig } from './register';
 
 // Facilitates debugging by enabling settings changes without rebuilding asset.

--- a/packages-exp/remote-config-exp/src/register.ts
+++ b/packages-exp/remote-config-exp/src/register.ts
@@ -36,6 +36,9 @@ import { ErrorCode, ERROR_FACTORY } from './errors';
 import { RemoteConfig as RemoteConfigImpl } from './remote_config';
 import { Storage } from './storage/storage';
 import { StorageCache } from './storage/storage_cache';
+// This needs to be in the same file that calls `getProvider()` on the component
+// or it will get tree-shaken out.
+import '@firebase/installations-exp';
 
 export function registerRemoteConfig(): void {
   _registerComponent(


### PR DESCRIPTION
If this import is not in the same file that uses the code (that has the `getProvider()` call), this import gets tree-shaken out during the rollup build and installations fails to register. (The error won't happen if there's another library, like performance, bringing in installations.)