### PR TITLE
Fix refFromUrl when used with emulator

### DIFF
--- a/.changeset/clever-kangaroos-hug.md
+++ b/.changeset/clever-kangaroos-hug.md
@@ -1,0 +1,5 @@
+---
+"@firebase/database": patch
+---
+
+Fixes an issue that caused `refFromUrl()` to reject production database URLs when `useEmulator()` was used.

--- a/packages/database/src/api/Database.ts
+++ b/packages/database/src/api/Database.ts
@@ -156,7 +156,7 @@ export class Database implements FirebaseService {
 
     const repoInfo = parsedURL.repoInfo;
     if (
-      !repoInfo.isCustomHost() &&
+      !this.repo_.repoInfo_.isCustomHost() &&
       repoInfo.host !== this.repo_.repoInfo_.host
     ) {
       fatal(

--- a/packages/database/test/database.test.ts
+++ b/packages/database/test/database.test.ts
@@ -246,12 +246,12 @@ describe('Database Tests', () => {
   });
 
   it('refFromURL() validates domain', () => {
-    const db = (firebase as any).database();
-    expect(() => {
-      const ref = db.refFromURL(
-        'https://thisisnotarealfirebase.firebaseio.com/path/to/data'
-      );
-    }).to.throw(/does not match.*database/i);
+    const db = (firebase as any)
+      .app()
+      .database('https://thisisreal.firebaseio.com');
+    expect(() =>
+      db.refFromURL('https://thisisnotreal.firebaseio.com/path/to/data')
+    ).to.throw(/does not match.*database/i);
   });
 
   it('refFromURL() validates argument', () => {


### PR DESCRIPTION
The unit test `refFromURL returns an emulated ref with useEmulator` fails for me locally. I think that we don't want to enforce the host check when the database URL is emulated.

Note that this test probably passes on CI since `localhost` gets used as the default host.