### PR TITLE
Issue template for alpha

### DIFF
--- a/.github/ISSUE_TEMPLATE/alpha_bug_report.md
+++ b/.github/ISSUE_TEMPLATE/alpha_bug_report.md
@@ -1,16 +1,20 @@
+---
+name: 🧪 Alpha SDK bug report
+about: Have you found a bug in one of our pre-release or alpha SDKs? File it here.
+title: ""
+labels: "alpha"
+assignees: ""
+---
+
 <!-- Step 1 [READ THIS] -->
 <!--
 Are you in the right place?
   * For issues or feature requests related to __the code in this repository__
     file a Github issue.
-    * If this is a __feature request__ make sure the issue title starts with "FR:".
-  * For general technical questions, post a question on [StackOverflow](http://stackoverflow.com/)
-    with the firebase tag.
-  * For general Firebase discussion, use the [firebase-talk](https://groups.google.com/forum/#!forum/firebase-talk)
-    google group.
-  * For help troubleshooting your application that does not fall under one
-    of the above categories, reach out to the personalized
-    [Firebase support channel](https://firebase.google.com/support/).
+  * If you are not yet participating in our Alpha and would like to join, use this form:
+    https://forms.gle/bKBEm48W8EMPLaUp9
+  * For general Alpha discussion, use the google group:
+    https://groups.google.com/g/firebase-js-sdk-testers
 -->
 
 <!-- Step 2 -->

--- a/.github/ISSUE_TEMPLATE/alpha_bug_report.md
+++ b/.github/ISSUE_TEMPLATE/alpha_bug_report.md
@@ -37,12 +37,6 @@ Are you in the right place?
 -->
 #### Relevant Code:
 
-<!--
-  Reproduce the issue on StackBlitz and provide your forked URL
-  or give us some sample code below
--->
-https://stackblitz.com/fork/firebase-issue-sandbox
-
 ```javascript
 // TODO(you): code here to reproduce the problem
 ```

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,52 @@
+---
+name: 🐞 Bug report
+about: Found a bug in the JS SDK? File it here.
+title: ""
+labels: ""
+assignees: ""
+---
+
+<!-- Step 1 [READ THIS] -->
+<!--
+Are you in the right place?
+  * For issues or feature requests related to __the code in this repository__
+    file a Github issue.
+    * If this is a __feature request__ make sure the issue title starts with "FR:".
+  * For general technical questions, post a question on [StackOverflow](http://stackoverflow.com/)
+    with the firebase tag.
+  * For general Firebase discussion, use the [firebase-talk](https://groups.google.com/forum/#!forum/firebase-talk)
+    google group.
+  * For help troubleshooting your application that does not fall under one
+    of the above categories, reach out to the personalized
+    [Firebase support channel](https://firebase.google.com/support/).
+-->
+
+<!-- Step 2 -->
+
+### [REQUIRED] Describe your environment
+
+  * Operating System version: _____
+  * Browser version: _____
+  * Firebase SDK version: _____
+  * Firebase Product: _____ (auth, database, storage, etc)
+
+<!-- Step 3 -->
+
+### [REQUIRED] Describe the problem
+
+#### Steps to reproduce:
+<!--
+  What happened? How can we make the problem occur?
+  This could be a description, log/console output, etc.
+-->
+#### Relevant Code:
+
+<!--
+  Reproduce the issue on StackBlitz and provide your forked URL
+  or give us some sample code below
+-->
+https://stackblitz.com/fork/firebase-issue-sandbox
+
+```javascript
+// TODO(you): code here to reproduce the problem
+```

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -41,12 +41,6 @@ Are you in the right place?
 -->
 #### Relevant Code:
 
-<!--
-  Reproduce the issue on StackBlitz and provide your forked URL
-  or give us some sample code below
--->
-https://stackblitz.com/fork/firebase-issue-sandbox
-
 ```javascript
 // TODO(you): code here to reproduce the problem
 ```

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 🔥 Firebase Support
+    url: https://firebase.google.com/support/
+    about: If you have an urgent issue with your app in production, please contact support.


### PR DESCRIPTION
This PR makes a few changes to issue templates:

  1. Adds a separate issue template for Alpha bugs. It has a slightly different preamble and also auto-applies the `alpha` label.
  1. Adds a new "choice" screen to direct people to the right template and also offer a link to Support.

Hard to preview in a PR but here's how the iOS SDK chooser looks:
<img width="1414" alt="Screen Shot 2020-12-14 at 1 21 25 PM" src="https://user-images.githubusercontent.com/8466666/102086077-839f6a80-3de5-11eb-97e6-77c17335d5f7.png">
