### PR TITLE
Add reduced capacity note to issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,8 +7,12 @@ assignees: ''
 
 ---
 
+
 <!-- Step 1 [READ THIS] -->
 <!--
+
+**Thank you for submitting your issue. We are operating at reduced capacity from Dec 18 2020 to Jan 4 2021. Please expect delayed responses. For more urgent requests please reach us via our support channels https://firebase.google.com/support**
+
 Are you in the right place?
   * For issues or feature requests related to __the code in this repository__
     file a Github issue.
@@ -20,6 +24,7 @@ Are you in the right place?
   * For help troubleshooting your application that does not fall under one
     of the above categories, reach out to the personalized
     [Firebase support channel](https://firebase.google.com/support/).
+    
 -->
 
 <!-- Step 2 -->


### PR DESCRIPTION
Adding a note about reduced capacity during the holiday. Also adding some line breaks makes the commented-out text format better in the Github editor.