### PR TITLE
Update yargs calls to match dep update

### DIFF
--- a/scripts/ci-test/build_changed.ts
+++ b/scripts/ci-test/build_changed.ts
@@ -38,7 +38,7 @@ const argv = yargs.options({
 }).argv;
 
 const allTestConfigNames = Object.keys(testConfig);
-const inputTestConfigName = argv._[0];
+const inputTestConfigName = argv._[0].toString();
 const { buildAppExp, buildAppCompat } = argv;
 
 if (!inputTestConfigName) {

--- a/scripts/ci-test/test_changed.ts
+++ b/scripts/ci-test/test_changed.ts
@@ -23,7 +23,7 @@ import { argv } from 'yargs';
 import { TestConfig, testConfig } from './testConfig';
 const root = resolve(__dirname, '../..');
 
-const inputTestConfigName = argv._[0];
+const inputTestConfigName = argv._[0].toString();
 const testCommand = 'test:ci';
 
 const allTestConfigNames = Object.keys(testConfig);


### PR DESCRIPTION
Change needed to allow dep update: https://github.com/firebase/firebase-js-sdk/pull/4097 to work.

The `@types/yargs` update changes the type of `argv._` to `Array<string|number>` instead of `Array<string>` which requires some updates to a couple of our CI scripts.