### PR TITLE
Return Firestore Classic types from Transaction API

### DIFF
--- a/.changeset/slimy-mugs-type.md
+++ b/.changeset/slimy-mugs-type.md
@@ -2,4 +2,4 @@
 "@firebase/firestore": patch
 ---
 
-Fixes an issue in the Transaction API that caused the SDK to return invalid DocumentReferences when returned from `DocumentSnapshot.data()`.
+Fixes an issue in the Transaction API that caused the SDK to return invalid DocumentReferences through `DocumentSnapshot.data()` calls.

--- a/.changeset/slimy-mugs-type.md
+++ b/.changeset/slimy-mugs-type.md
@@ -1,0 +1,5 @@
+---
+"@firebase/firestore": patch
+---
+
+Fixes an issue in the Transaction API that caused the SDK to return invalid DocumentReferences when returned from `DocumentSnapshot.data()`.

--- a/packages/firestore/test/integration/api/type.test.ts
+++ b/packages/firestore/test/integration/api/type.test.ts
@@ -44,7 +44,7 @@ apiDescribe('Firestore', (persistence: boolean) => {
 
     // Validate that the transaction API returns the same types
     await db.runTransaction(async transaction => {
-      let docSnapshot = await transaction.get(doc);
+      docSnapshot = await transaction.get(doc);
       expect(docSnapshot.data()).to.deep.equal(data);
     });
 

--- a/packages/firestore/test/integration/api/type.test.ts
+++ b/packages/firestore/test/integration/api/type.test.ts
@@ -42,6 +42,12 @@ apiDescribe('Firestore', (persistence: boolean) => {
     let docSnapshot = await doc.get();
     expect(docSnapshot.data()).to.deep.equal(data);
 
+    // Validate that the transaction API returns the same types
+    await db.runTransaction(async transaction => {
+      let docSnapshot = await transaction.get(doc);
+      expect(docSnapshot.data()).to.deep.equal(data);
+    });
+
     if (validateSnapshots) {
       let querySnapshot = await collection.get();
       docSnapshot = querySnapshot.docs[0];


### PR DESCRIPTION
We need to use the "classic" UserDataWriter in the old Transaction API, as only the classic UserDataWriter returns the old API types. This is the same fix as https://github.com/firebase/firebase-js-sdk/pull/4136 (and the last!)

Fixes https://github.com/firebase/firebase-js-sdk/issues/4226
