### PR TITLE
Update mismatch in main index.d.ts

### DIFF
--- a/packages/firebase/index.d.ts
+++ b/packages/firebase/index.d.ts
@@ -6296,7 +6296,7 @@ declare namespace firebase.database {
     on(
       eventType: EventType,
       callback: (a: firebase.database.DataSnapshot, b?: string | null) => any,
-      cancelCallbackOrContext?: Object | null,
+      cancelCallbackOrContext?: ((a: Error) => any) | Object | null,
       context?: Object | null
     ): (a: firebase.database.DataSnapshot | null, b?: string | null) => any;
 


### PR DESCRIPTION
I think this got overlooked in an update to database-types (https://github.com/firebase/firebase-js-sdk/blob/master/packages/database-types/index.d.ts#L88)

See https://github.com/firebase/firebase-js-sdk/issues/4250.