### PR TITLE
Add import of TextEncoder

### DIFF
--- a/packages/firestore/test/integration/api/bundle.test.ts
+++ b/packages/firestore/test/integration/api/bundle.test.ts
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+import { TextEncoder } from 'util';
+
 import * as firestore from '@firebase/firestore-types';
 import { expect } from 'chai';
 


### PR DESCRIPTION
Not having the import caused the integration tests to fail on my local machine.