### PR TITLE
Allow storage processes to exit before timeout in node

### DIFF
--- a/packages/storage/src/implementation/backoff.ts
+++ b/packages/storage/src/implementation/backoff.ts
@@ -42,6 +42,7 @@ export function start(
   // TODO: find a way to exclude Node type definition for storage because storage only works in browser
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let timeoutId: any = null;
+  let hitTimeoutId: any = null;
   let hitTimeout = false;
   let cancelState = 0;
 
@@ -69,6 +70,9 @@ export function start(
       return;
     }
     if (success) {
+      if (hitTimeoutId !== null) {
+        clearTimeout(hitTimeoutId);
+      }
       triggerCallback.call(null, success, ...args);
       return;
     }
@@ -113,7 +117,8 @@ export function start(
     }
   }
   callWithDelay(0);
-  setTimeout(() => {
+  hitTimeoutId = setTimeout(function () {
+    hitTimeoutId = null;
     hitTimeout = true;
     stop(true);
   }, timeout);


### PR DESCRIPTION
Currently the storage API is unsupported for node (see #18). This means storage rules are unavailable from a node environment (even using the admin interface). This can be resolved with some very minor updates to the storage package (for later versions of node at least):

- [x] Resolve any ongoing processes (in this case uncleared timeouts) to allow node to exit as expected once a script is complete
- [ ] Include an XHR polyfill (via dynamic import or node-specific build) ... successfully tested with [xmlhttprequest-ssl](https://www.npmjs.com/package/xmlhttprequest-ssl)

This PR does half the work. It clears a timeout that keeps a storage process running for a minimum 10mins in node (waiting on the 600,000ms function timeout to complete). This fix should also be useful in other environments as it clears up resources.

This PR doesn't include the XHR polyfill as that seems like a fairly opinionated piece of work. The `firebase/app` package actually already includes an XHR polyfill (incompatible here), but gives some direction for implementation.

That said, given the current changes in place, users needing storage functionality in node can easily install the XHR module in their project directly and patch the compiled storage script `@firebase/storage/dist/index.cjs.js` for a workable (if not full) level of functionality.