### PR TITLE
Rename Bundle metadata type to BundleMetadata

### DIFF
--- a/packages/firestore/src/core/bundle.ts
+++ b/packages/firestore/src/core/bundle.ts
@@ -53,7 +53,7 @@ export class BundleLoadResult {
 /**
  * Represents a Firestore bundle saved by the SDK in its local storage.
  */
-export interface Bundle {
+export interface BundleMetadata {
   /**
    * Id of the bundle. It is used together with `createTime` to determine if a
    * bundle has been loaded by the SDK.

--- a/packages/firestore/src/local/bundle_cache.ts
+++ b/packages/firestore/src/local/bundle_cache.ts
@@ -29,8 +29,8 @@ import { PersistenceTransaction } from './persistence_transaction';
  */
 export interface BundleCache {
   /**
-   * Gets a saved `Bundle` for a given `bundleId`, returns undefined if
-   * no bundles are found under the given id.
+   * Gets the saved `BundleMetadata` for a given `bundleId`, returns undefined
+   * if no bundle metadata is found under the given id.
    */
   getBundleMetadata(
     transaction: PersistenceTransaction,

--- a/packages/firestore/src/local/bundle_cache.ts
+++ b/packages/firestore/src/local/bundle_cache.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { Bundle, NamedQuery } from '../core/bundle';
+import { BundleMetadata, NamedQuery } from '../core/bundle';
 import {
   NamedQuery as ProtoNamedQuery,
   BundleMetadata as ProtoBundleMetadata
@@ -35,7 +35,7 @@ export interface BundleCache {
   getBundleMetadata(
     transaction: PersistenceTransaction,
     bundleId: string
-  ): PersistencePromise<Bundle | undefined>;
+  ): PersistencePromise<BundleMetadata | undefined>;
 
   /**
    * Saves a `BundleMetadata` from a bundle into local storage, using its id as

--- a/packages/firestore/src/local/indexeddb_bundle_cache.ts
+++ b/packages/firestore/src/local/indexeddb_bundle_cache.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { Bundle, NamedQuery } from '../core/bundle';
+import { BundleMetadata, NamedQuery } from '../core/bundle';
 import {
   BundleMetadata as ProtoBundleMetadata,
   NamedQuery as ProtoNamedQuery
@@ -43,7 +43,7 @@ export class IndexedDbBundleCache implements BundleCache {
   getBundleMetadata(
     transaction: PersistenceTransaction,
     bundleId: string
-  ): PersistencePromise<Bundle | undefined> {
+  ): PersistencePromise<BundleMetadata | undefined> {
     return bundlesStore(transaction)
       .get(bundleId)
       .next(bundle => {

--- a/packages/firestore/src/local/local_serializer.ts
+++ b/packages/firestore/src/local/local_serializer.ts
@@ -306,7 +306,7 @@ function isDocumentQuery(dbQuery: DbQuery): dbQuery is PublicDocumentsTarget {
   return (dbQuery as PublicDocumentsTarget).documents !== undefined;
 }
 
-/** Encodes a DbBundle to a Bundle. */
+/** Encodes a DbBundle to a BundleMetadata object. */
 export function fromDbBundle(dbBundle: DbBundle): BundleMetadata {
   return {
     id: dbBundle.bundleId,
@@ -372,7 +372,7 @@ export function fromProtoNamedQuery(namedQuery: ProtoNamedQuery): NamedQuery {
   };
 }
 
-/** Encodes a BundleMetadata proto object to a Bundle model object. */
+/** Decodes a BundleMetadata proto into a BundleMetadata object. */
 export function fromBundleMetadata(
   metadata: ProtoBundleMetadata
 ): BundleMetadata {

--- a/packages/firestore/src/local/local_serializer.ts
+++ b/packages/firestore/src/local/local_serializer.ts
@@ -16,7 +16,7 @@
  */
 
 import { Timestamp } from '../api/timestamp';
-import { Bundle, NamedQuery } from '../core/bundle';
+import { BundleMetadata, NamedQuery } from '../core/bundle';
 import { LimitType, Query, queryWithLimit } from '../core/query';
 import { SnapshotVersion } from '../core/snapshot_version';
 import { canonifyTarget, isDocumentTarget, Target } from '../core/target';
@@ -307,7 +307,7 @@ function isDocumentQuery(dbQuery: DbQuery): dbQuery is PublicDocumentsTarget {
 }
 
 /** Encodes a DbBundle to a Bundle. */
-export function fromDbBundle(dbBundle: DbBundle): Bundle {
+export function fromDbBundle(dbBundle: DbBundle): BundleMetadata {
   return {
     id: dbBundle.bundleId,
     createTime: fromDbTimestamp(dbBundle.createTime),
@@ -373,7 +373,9 @@ export function fromProtoNamedQuery(namedQuery: ProtoNamedQuery): NamedQuery {
 }
 
 /** Encodes a BundleMetadata proto object to a Bundle model object. */
-export function fromBundleMetadata(metadata: ProtoBundleMetadata): Bundle {
+export function fromBundleMetadata(
+  metadata: ProtoBundleMetadata
+): BundleMetadata {
   return {
     id: metadata.id!,
     version: metadata.version!,

--- a/packages/firestore/src/local/memory_bundle_cache.ts
+++ b/packages/firestore/src/local/memory_bundle_cache.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { Bundle, NamedQuery } from '../core/bundle';
+import { BundleMetadata, NamedQuery } from '../core/bundle';
 import {
   NamedQuery as ProtoNamedQuery,
   BundleMetadata as ProtoBundleMetadata
@@ -31,7 +31,7 @@ import { PersistencePromise } from './persistence_promise';
 import { PersistenceTransaction } from './persistence_transaction';
 
 export class MemoryBundleCache implements BundleCache {
-  private bundles = new Map<string, Bundle>();
+  private bundles = new Map<string, BundleMetadata>();
   private namedQueries = new Map<string, NamedQuery>();
 
   constructor(private serializer: LocalSerializer) {}
@@ -39,7 +39,7 @@ export class MemoryBundleCache implements BundleCache {
   getBundleMetadata(
     transaction: PersistenceTransaction,
     bundleId: string
-  ): PersistencePromise<Bundle | undefined> {
+  ): PersistencePromise<BundleMetadata | undefined> {
     return PersistencePromise.resolve(this.bundles.get(bundleId));
   }
 

--- a/packages/firestore/test/unit/local/bundle_cache.test.ts
+++ b/packages/firestore/test/unit/local/bundle_cache.test.ts
@@ -102,7 +102,7 @@ function genericBundleCacheTests(cacheFn: () => TestBundleCache): void {
   }
 
   it('returns undefined when bundle id is not found', async () => {
-    expect(await cache.getBundle('bundle-1')).to.be.undefined;
+    expect(await cache.getBundleMetadata('bundle-1')).to.be.undefined;
   });
 
   it('returns saved bundle', async () => {
@@ -111,7 +111,7 @@ function genericBundleCacheTests(cacheFn: () => TestBundleCache): void {
       version: 1,
       createTime: { seconds: 1, nanos: 9999 }
     });
-    expect(await cache.getBundle('bundle-1')).to.deep.equal({
+    expect(await cache.getBundleMetadata('bundle-1')).to.deep.equal({
       id: 'bundle-1',
       version: 1,
       createTime: SnapshotVersion.fromTimestamp(new Timestamp(1, 9999))
@@ -123,7 +123,7 @@ function genericBundleCacheTests(cacheFn: () => TestBundleCache): void {
       version: 2,
       createTime: { seconds: 2, nanos: 1111 }
     });
-    expect(await cache.getBundle('bundle-1')).to.deep.equal({
+    expect(await cache.getBundleMetadata('bundle-1')).to.deep.equal({
       id: 'bundle-1',
       version: 2,
       createTime: SnapshotVersion.fromTimestamp(new Timestamp(2, 1111))

--- a/packages/firestore/test/unit/local/test_bundle_cache.ts
+++ b/packages/firestore/test/unit/local/test_bundle_cache.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { Bundle, NamedQuery } from '../../../src/core/bundle';
+import { BundleMetadata, NamedQuery } from '../../../src/core/bundle';
 import { BundleCache } from '../../../src/local/bundle_cache';
 import { Persistence } from '../../../src/local/persistence';
 import {
@@ -34,9 +34,9 @@ export class TestBundleCache {
     this.cache = persistence.getBundleCache();
   }
 
-  getBundle(bundleId: string): Promise<Bundle | undefined> {
+  getBundleMetadata(bundleId: string): Promise<BundleMetadata | undefined> {
     return this.persistence.runTransaction(
-      'getBundle',
+      'getBundleMetadata',
       'readonly',
       transaction => {
         return this.cache.getBundleMetadata(transaction, bundleId);


### PR DESCRIPTION
Rename to match API names in the BundleCache.