### PR TITLE
update SDK_VERSION to the latest value in `firebase/app`

### DIFF
--- a/.changeset/twenty-scissors-exist.md
+++ b/.changeset/twenty-scissors-exist.md
@@ -1,0 +1,5 @@
+---
+"firebase": patch
+---
+
+set firebase.SDK_VERSION to the latest value

--- a/packages/firebase/app/index.ts
+++ b/packages/firebase/app/index.ts
@@ -19,5 +19,6 @@ import firebase from '@firebase/app';
 import { name, version } from '../package.json';
 
 firebase.registerVersion(name, version, 'app');
+firebase.SDK_VERSION = version;
 
 export default firebase;


### PR DESCRIPTION
Fixes https://github.com/firebase/firebase-js-sdk/issues/4235

`firebase.SDK_VERSION` may not be up to date because the value is set at compile time in `@firebase/app`, which is not necessarily published with every release. This change updates `firebase.SDK_VERSION` to the latest version of `firebase` package.

Note that the solution will NOT work if you import scoped packages.
You should import using the umbrella package:

```
import firebase from 'firebase/app';
firebase.SDK_VERSION; // the latest version

// DON'T do it if you want the latest SDK VERSION
// import firebase from '@firebase/app';
// firebase.SDK_VERSION; // might be a stale version
```

To fix the issue for the scoped package, we will need to publish `@firebase/app` with every release to make sure SDK_VERSION is up to date. We need to create a process to automatically add a changeset for `@firebase/app` for every release.

Since using the umbrella package to import firebase is the recommended way of doing things and all our guides and snippets use the umbrella package, this fix should be sufficient for now and will work for the majority of our users.