### PR TITLE
Fix FirestoreDataConverter.fromFirestore() being called with QueryDocumentSnapshot from exp

### DIFF
--- a/.changeset/neat-yaks-kneel.md
+++ b/.changeset/neat-yaks-kneel.md
@@ -1,0 +1,5 @@
+---
+'@firebase/firestore': patch
+---
+
+Fixes FirestoreDataConverter.fromFirestore() being called with an incorrect "snapshot" object.

--- a/integration/firestore/firebase_export.ts
+++ b/integration/firestore/firebase_export.ts
@@ -50,11 +50,22 @@ export function usesFunctionalApi(): false {
   return false;
 }
 
-const Firestore = firebase.firestore.Firestore;
-const FieldPath = firebase.firestore.FieldPath;
-const Timestamp = firebase.firestore.Timestamp;
-const GeoPoint = firebase.firestore.GeoPoint;
-const FieldValue = firebase.firestore.FieldValue;
 const Blob = firebase.firestore.Blob;
+const DocumentReference = firebase.firestore.DocumentReference;
+const FieldPath = firebase.firestore.FieldPath;
+const FieldValue = firebase.firestore.FieldValue;
+const Firestore = firebase.firestore.Firestore;
+const GeoPoint = firebase.firestore.GeoPoint;
+const QueryDocumentSnapshot = firebase.firestore.QueryDocumentSnapshot;
+const Timestamp = firebase.firestore.Timestamp;
 
-export { Firestore, FieldValue, FieldPath, Timestamp, Blob, GeoPoint };
+export {
+  Blob,
+  DocumentReference,
+  FieldPath,
+  FieldValue,
+  Firestore,
+  GeoPoint,
+  QueryDocumentSnapshot,
+  Timestamp
+};

--- a/integration/firestore/firebase_export_memory.ts
+++ b/integration/firestore/firebase_export_memory.ts
@@ -50,11 +50,22 @@ export function usesFunctionalApi(): false {
   return false;
 }
 
-const Firestore = firebase.firestore.Firestore;
-const FieldPath = firebase.firestore.FieldPath;
-const Timestamp = firebase.firestore.Timestamp;
-const GeoPoint = firebase.firestore.GeoPoint;
-const FieldValue = firebase.firestore.FieldValue;
 const Blob = firebase.firestore.Blob;
+const DocumentReference = firebase.firestore.DocumentReference;
+const FieldPath = firebase.firestore.FieldPath;
+const FieldValue = firebase.firestore.FieldValue;
+const Firestore = firebase.firestore.Firestore;
+const GeoPoint = firebase.firestore.GeoPoint;
+const QueryDocumentSnapshot = firebase.firestore.QueryDocumentSnapshot;
+const Timestamp = firebase.firestore.Timestamp;
 
-export { Firestore, FieldValue, FieldPath, Timestamp, Blob, GeoPoint };
+export {
+  Blob,
+  DocumentReference,
+  FieldPath,
+  FieldValue,
+  Firestore,
+  GeoPoint,
+  QueryDocumentSnapshot,
+  Timestamp
+};

--- a/packages/firestore/src/api/database.ts
+++ b/packages/firestore/src/api/database.ts
@@ -553,18 +553,34 @@ export class WriteBatch
   }
 }
 
-class PublicFirestoreDataConverterAdapter<U> implements UntypedFirestoreDataConverter<U> {
-  constructor(readonly firestore: Firestore, readonly delegate: PublicFirestoreDataConverter<U>) {}
+class PublicFirestoreDataConverterAdapter<U>
+  implements UntypedFirestoreDataConverter<U> {
+  constructor(
+    readonly firestore: Firestore,
+    readonly delegate: PublicFirestoreDataConverter<U>
+  ) {}
 
   fromFirestore(snapshot: unknown, options?: unknown): U {
     const expSnapshot = snapshot as ExpQueryDocumentSnapshot<U>;
-    const querySnapshot = new QueryDocumentSnapshot<U>(this.firestore, expSnapshot);
-    return this.delegate.fromFirestore(querySnapshot, options as PublicSnapshotOptions);
+    const querySnapshot = new QueryDocumentSnapshot<U>(
+      this.firestore,
+      expSnapshot
+    );
+    return this.delegate.fromFirestore(
+      querySnapshot,
+      options as PublicSnapshotOptions
+    );
   }
 
   toFirestore(modelObject: U): PublicDocumentData;
-  toFirestore(modelObject: Partial<U>, options: PublicSetOptions): PublicDocumentData;
-  toFirestore(modelObject: U | Partial<U>, options?: PublicSetOptions): PublicDocumentData {
+  toFirestore(
+    modelObject: Partial<U>,
+    options: PublicSetOptions
+  ): PublicDocumentData;
+  toFirestore(
+    modelObject: U | Partial<U>,
+    options?: PublicSetOptions
+  ): PublicDocumentData {
     if (options === undefined) {
       return this.delegate.toFirestore(modelObject as U);
     } else {
@@ -773,7 +789,9 @@ export class DocumentReference<T = PublicDocumentData>
   ): PublicDocumentReference<U> {
     return new DocumentReference<U>(
       this.firestore,
-      this._delegate.withConverter(new PublicFirestoreDataConverterAdapter(this.firestore, converter)),
+      this._delegate.withConverter(
+        new PublicFirestoreDataConverterAdapter(this.firestore, converter)
+      )
     );
   }
 }
@@ -1080,7 +1098,9 @@ export class Query<T = PublicDocumentData>
   withConverter<U>(converter: PublicFirestoreDataConverter<U>): Query<U> {
     return new Query<U>(
       this.firestore,
-      this._delegate.withConverter(new PublicFirestoreDataConverterAdapter(this.firestore, converter)),
+      this._delegate.withConverter(
+        new PublicFirestoreDataConverterAdapter(this.firestore, converter)
+      )
     );
   }
 }
@@ -1222,7 +1242,9 @@ export class CollectionReference<T = PublicDocumentData>
   ): CollectionReference<U> {
     return new CollectionReference<U>(
       this.firestore,
-      this._delegate.withConverter(new PublicFirestoreDataConverterAdapter(this.firestore, converter)),
+      this._delegate.withConverter(
+        new PublicFirestoreDataConverterAdapter(this.firestore, converter)
+      )
     );
   }
 }

--- a/packages/firestore/src/api/database.ts
+++ b/packages/firestore/src/api/database.ts
@@ -575,18 +575,16 @@ class FirestoreDataConverter<U>
     snapshot: ExpQueryDocumentSnapshot,
     options?: PublicSnapshotOptions
   ): U {
+    const expSnapshot = new ExpQueryDocumentSnapshot(
+      this._firestore._delegate,
+      this._userDataWriter,
+      snapshot._key,
+      snapshot._document,
+      snapshot.metadata,
+      /* converter= */ null
+    );
     return this._delegate.fromFirestore(
-      new QueryDocumentSnapshot<U>(
-        this._firestore,
-        new ExpQueryDocumentSnapshot<U>(
-          this._firestore._delegate,
-          this._userDataWriter,
-          snapshot._key,
-          snapshot._document,
-          snapshot.metadata,
-          /* converter= */ null
-        )
-      ),
+      new QueryDocumentSnapshot(this._firestore, expSnapshot),
       options ?? {}
     );
   }

--- a/packages/firestore/src/api/database.ts
+++ b/packages/firestore/src/api/database.ts
@@ -559,7 +559,7 @@ class UntypedFirestoreDataConverterAdapter<U>
   private static readonly INSTANCES = new WeakMap();
 
   private constructor(
-    private readonly firestore: Firestore,
+    private readonly _firestore: Firestore,
     delegate: PublicFirestoreDataConverter<U>
   ) {
     super(delegate);
@@ -568,7 +568,7 @@ class UntypedFirestoreDataConverterAdapter<U>
   fromFirestore(snapshot: unknown, options?: unknown): U {
     return this._delegate.fromFirestore(
       new QueryDocumentSnapshot<U>(
-        this.firestore,
+        this._firestore,
         snapshot as ExpQueryDocumentSnapshot<U>
       ),
       options as PublicSnapshotOptions

--- a/packages/firestore/src/api/database.ts
+++ b/packages/firestore/src/api/database.ts
@@ -591,6 +591,9 @@ class UntypedFirestoreDataConverterAdapter<U>
     }
   }
 
+  // Use the same instance of UntypedFirestoreDataConverterAdapter for a given
+  // instance of PublicFirestoreDataConverter so that isEqual() will compare
+  // equal for two objects created with the same converter instance.
   static getInstance<U>(
     firestore: Firestore,
     converter: PublicFirestoreDataConverter<U>

--- a/packages/firestore/src/api/database.ts
+++ b/packages/firestore/src/api/database.ts
@@ -556,7 +556,6 @@ export class WriteBatch
 class UntypedFirestoreDataConverterAdapter<U>
   extends Compat<PublicFirestoreDataConverter<U>>
   implements UntypedFirestoreDataConverter<U> {
-
   private static readonly INSTANCES = new WeakMap();
 
   private constructor(
@@ -567,7 +566,13 @@ class UntypedFirestoreDataConverterAdapter<U>
   }
 
   fromFirestore(snapshot: unknown, options?: unknown): U {
-    return this._delegate.fromFirestore(new QueryDocumentSnapshot<U>(this.firestore, snapshot as ExpQueryDocumentSnapshot<U>), options as PublicSnapshotOptions);
+    return this._delegate.fromFirestore(
+      new QueryDocumentSnapshot<U>(
+        this.firestore,
+        snapshot as ExpQueryDocumentSnapshot<U>
+      ),
+      options as PublicSnapshotOptions
+    );
   }
 
   toFirestore(modelObject: U): PublicDocumentData;
@@ -586,18 +591,19 @@ class UntypedFirestoreDataConverterAdapter<U>
     }
   }
 
-  static getInstance<U>(firestore: Firestore, converter: PublicFirestoreDataConverter<U>): UntypedFirestoreDataConverterAdapter<U> {
+  static getInstance<U>(
+    firestore: Firestore,
+    converter: PublicFirestoreDataConverter<U>
+  ): UntypedFirestoreDataConverterAdapter<U> {
     const map = UntypedFirestoreDataConverterAdapter.INSTANCES;
     let instance = map.get(converter);
-    if (! instance) {
+    if (!instance) {
       instance = new UntypedFirestoreDataConverterAdapter(firestore, converter);
       map.set(converter, instance);
     }
     return instance;
   }
 }
-
-
 
 /**
  * A reference to a particular document in a collection in the database.
@@ -797,7 +803,15 @@ export class DocumentReference<T = PublicDocumentData>
   withConverter<U>(
     converter: PublicFirestoreDataConverter<U>
   ): PublicDocumentReference<U> {
-    return new DocumentReference<U>(this.firestore, this._delegate.withConverter(UntypedFirestoreDataConverterAdapter.getInstance(this.firestore, converter)));
+    return new DocumentReference<U>(
+      this.firestore,
+      this._delegate.withConverter(
+        UntypedFirestoreDataConverterAdapter.getInstance(
+          this.firestore,
+          converter
+        )
+      )
+    );
   }
 }
 
@@ -1101,7 +1115,15 @@ export class Query<T = PublicDocumentData>
   }
 
   withConverter<U>(converter: PublicFirestoreDataConverter<U>): Query<U> {
-    return new Query<U>(this.firestore, this._delegate.withConverter(UntypedFirestoreDataConverterAdapter.getInstance(this.firestore, converter)));
+    return new Query<U>(
+      this.firestore,
+      this._delegate.withConverter(
+        UntypedFirestoreDataConverterAdapter.getInstance(
+          this.firestore,
+          converter
+        )
+      )
+    );
   }
 }
 
@@ -1240,7 +1262,15 @@ export class CollectionReference<T = PublicDocumentData>
   withConverter<U>(
     converter: PublicFirestoreDataConverter<U>
   ): CollectionReference<U> {
-    return new CollectionReference<U>(this.firestore, this._delegate.withConverter(UntypedFirestoreDataConverterAdapter.getInstance(this.firestore, converter)));
+    return new CollectionReference<U>(
+      this.firestore,
+      this._delegate.withConverter(
+        UntypedFirestoreDataConverterAdapter.getInstance(
+          this.firestore,
+          converter
+        )
+      )
+    );
   }
 }
 

--- a/packages/firestore/src/api/database.ts
+++ b/packages/firestore/src/api/database.ts
@@ -553,7 +553,7 @@ export class WriteBatch
   }
 }
 
-class PublicFirestoreDataConverterAdapter<U>
+class UntypedFirestoreDataConverterAdapter<U>
   implements UntypedFirestoreDataConverter<U> {
   constructor(
     readonly firestore: Firestore,
@@ -561,10 +561,9 @@ class PublicFirestoreDataConverterAdapter<U>
   ) {}
 
   fromFirestore(snapshot: unknown, options?: unknown): U {
-    const expSnapshot = snapshot as ExpQueryDocumentSnapshot<U>;
     const querySnapshot = new QueryDocumentSnapshot<U>(
       this.firestore,
-      expSnapshot
+      snapshot as ExpQueryDocumentSnapshot<U>
     );
     return this.delegate.fromFirestore(
       querySnapshot,
@@ -790,7 +789,7 @@ export class DocumentReference<T = PublicDocumentData>
     return new DocumentReference<U>(
       this.firestore,
       this._delegate.withConverter(
-        new PublicFirestoreDataConverterAdapter(this.firestore, converter)
+        new UntypedFirestoreDataConverterAdapter(this.firestore, converter)
       )
     );
   }
@@ -1099,7 +1098,7 @@ export class Query<T = PublicDocumentData>
     return new Query<U>(
       this.firestore,
       this._delegate.withConverter(
-        new PublicFirestoreDataConverterAdapter(this.firestore, converter)
+        new UntypedFirestoreDataConverterAdapter(this.firestore, converter)
       )
     );
   }
@@ -1243,7 +1242,7 @@ export class CollectionReference<T = PublicDocumentData>
     return new CollectionReference<U>(
       this.firestore,
       this._delegate.withConverter(
-        new PublicFirestoreDataConverterAdapter(this.firestore, converter)
+        new UntypedFirestoreDataConverterAdapter(this.firestore, converter)
       )
     );
   }

--- a/packages/firestore/src/api/database.ts
+++ b/packages/firestore/src/api/database.ts
@@ -558,8 +558,9 @@ export class WriteBatch
  * experimental SDK into corresponding types from the Classic SDK before passing
  * them to the wrapped converter.
  */
-class FirestoreDataConverter<U> extends Compat<PublicFirestoreDataConverter<U>> implements UntypedFirestoreDataConverter<U> {
-
+class FirestoreDataConverter<U>
+  extends Compat<PublicFirestoreDataConverter<U>>
+  implements UntypedFirestoreDataConverter<U> {
   private static readonly INSTANCES = new WeakMap();
 
   private constructor(
@@ -570,8 +571,24 @@ class FirestoreDataConverter<U> extends Compat<PublicFirestoreDataConverter<U>> 
     super(delegate);
   }
 
-  fromFirestore(snapshot: ExpQueryDocumentSnapshot, options?: PublicSnapshotOptions): U {
-    return this._delegate.fromFirestore(new QueryDocumentSnapshot<U>(this._firestore, new ExpQueryDocumentSnapshot<U>(this._firestore._delegate, this._userDataWriter, snapshot._key, snapshot._document, snapshot.metadata,/* converter= */ null)), options ?? {});
+  fromFirestore(
+    snapshot: ExpQueryDocumentSnapshot,
+    options?: PublicSnapshotOptions
+  ): U {
+    return this._delegate.fromFirestore(
+      new QueryDocumentSnapshot<U>(
+        this._firestore,
+        new ExpQueryDocumentSnapshot<U>(
+          this._firestore._delegate,
+          this._userDataWriter,
+          snapshot._key,
+          snapshot._document,
+          snapshot.metadata,
+          /* converter= */ null
+        )
+      ),
+      options ?? {}
+    );
   }
 
   toFirestore(modelObject: U): PublicDocumentData;
@@ -593,7 +610,10 @@ class FirestoreDataConverter<U> extends Compat<PublicFirestoreDataConverter<U>> 
   // Use the same instance of `FirestoreDataConverter` for the given instances
   // of `Firestore` and `PublicFirestoreDataConverter` so that isEqual() will
   // compare equal for two objects created with the same converter instance.
-  static getInstance<U>(firestore: Firestore, converter: PublicFirestoreDataConverter<U>): FirestoreDataConverter<U> {
+  static getInstance<U>(
+    firestore: Firestore,
+    converter: PublicFirestoreDataConverter<U>
+  ): FirestoreDataConverter<U> {
     const converterMapByFirestore = FirestoreDataConverter.INSTANCES;
     let untypedConverterByConverter = converterMapByFirestore.get(firestore);
     if (!untypedConverterByConverter) {
@@ -603,7 +623,11 @@ class FirestoreDataConverter<U> extends Compat<PublicFirestoreDataConverter<U>> 
 
     let instance = untypedConverterByConverter.get(converter);
     if (!instance) {
-      instance = new FirestoreDataConverter(firestore, new UserDataWriter(firestore), converter);
+      instance = new FirestoreDataConverter(
+        firestore,
+        new UserDataWriter(firestore),
+        converter
+      );
       untypedConverterByConverter.set(converter, instance);
     }
 
@@ -809,7 +833,12 @@ export class DocumentReference<T = PublicDocumentData>
   withConverter<U>(
     converter: PublicFirestoreDataConverter<U>
   ): PublicDocumentReference<U> {
-    return new DocumentReference<U>(this.firestore, this._delegate.withConverter(FirestoreDataConverter.getInstance(this.firestore, converter)));
+    return new DocumentReference<U>(
+      this.firestore,
+      this._delegate.withConverter(
+        FirestoreDataConverter.getInstance(this.firestore, converter)
+      )
+    );
   }
 }
 
@@ -1113,7 +1142,12 @@ export class Query<T = PublicDocumentData>
   }
 
   withConverter<U>(converter: PublicFirestoreDataConverter<U>): Query<U> {
-    return new Query<U>(this.firestore, this._delegate.withConverter(FirestoreDataConverter.getInstance(this.firestore, converter)));
+    return new Query<U>(
+      this.firestore,
+      this._delegate.withConverter(
+        FirestoreDataConverter.getInstance(this.firestore, converter)
+      )
+    );
   }
 }
 
@@ -1252,7 +1286,12 @@ export class CollectionReference<T = PublicDocumentData>
   withConverter<U>(
     converter: PublicFirestoreDataConverter<U>
   ): CollectionReference<U> {
-    return new CollectionReference<U>(this.firestore, this._delegate.withConverter(FirestoreDataConverter.getInstance(this.firestore, converter)));
+    return new CollectionReference<U>(
+      this.firestore,
+      this._delegate.withConverter(
+        FirestoreDataConverter.getInstance(this.firestore, converter)
+      )
+    );
   }
 }
 

--- a/packages/firestore/test/integration/api/database.test.ts
+++ b/packages/firestore/test/integration/api/database.test.ts
@@ -1377,11 +1377,12 @@ apiDescribe('Database', (persistence: boolean) => {
       constructor(readonly ref: firestore.DocumentReference<ModelWithRef>) {}
     }
 
-    const omitSingle = (key: any, { [key]: _, ...obj }) => obj;
-
     const modelWithRefConverter = {
       toFirestore(model: ModelWithRef): firestore.DocumentData {
-        return omitSingle('ref', model);
+        // Remove the "ref" attribute, since it's not meant to be stored in
+        // the Firestore database.
+        const { ['ref']: _, ...rest } = model;
+        return rest;
       },
       fromFirestore(
         snapshot: firestore.QueryDocumentSnapshot<ModelWithRef>,

--- a/packages/firestore/test/integration/api/database.test.ts
+++ b/packages/firestore/test/integration/api/database.test.ts
@@ -1601,31 +1601,33 @@ apiDescribe('Database', (persistence: boolean) => {
 
         const modelConverter = {
           toFirestore: function (model: MyModel) {
-            return omitSingle("ref", model);
+            return omitSingle('ref', model);
           },
           fromFirestore: function (
             snapshot: firestore.QueryDocumentSnapshot
           ): MyModel {
             return new MyModel(snapshot.ref);
           },
-          denver: function() {
-            console.log("denver");
+          denver: function () {
+            console.log('denver');
           }
         };
 
         const docRef = db
-          .collection("/models")
-          .doc("some_id")
+          .collection('/models')
+          .doc('some_id')
           .withConverter(modelConverter);
 
         await docRef.set(new MyModel(docRef));
 
-        const accumulator = new EventsAccumulator<firestore.DocumentSnapshot<MyModel>>();
+        const accumulator = new EventsAccumulator<
+          firestore.DocumentSnapshot<MyModel>
+        >();
         const unsubscribe = docRef.onSnapshot(accumulator.storeEvent);
 
         await accumulator
           .awaitEvent()
-          .then(docSnapshot => docSnapshot.data()!.ref.collection("/sub"));
+          .then(docSnapshot => docSnapshot.data()!.ref.collection('/sub'));
 
         unsubscribe();
       });

--- a/packages/firestore/test/integration/api/database.test.ts
+++ b/packages/firestore/test/integration/api/database.test.ts
@@ -39,6 +39,8 @@ const newTestFirestore = firebaseExport.newTestFirestore;
 const Timestamp = firebaseExport.Timestamp;
 const FieldPath = firebaseExport.FieldPath;
 const FieldValue = firebaseExport.FieldValue;
+const DocumentReference = firebaseExport.DocumentReference;
+const QueryDocumentSnapshot = firebaseExport.QueryDocumentSnapshot;
 
 const MEMORY_ONLY_BUILD =
   typeof process !== 'undefined' &&
@@ -1344,6 +1346,7 @@ apiDescribe('Database', (persistence: boolean) => {
         snapshot: firestore.QueryDocumentSnapshot,
         options: firestore.SnapshotOptions
       ): Post {
+        expect(snapshot).to.be.an.instanceof(QueryDocumentSnapshot);
         const data = snapshot.data(options);
         return new Post(data.title, data.author, snapshot.ref);
       }
@@ -1602,7 +1605,7 @@ apiDescribe('Database', (persistence: boolean) => {
         await docRef.set(new Post('post', 'author'));
         const docSnapshot = await docRef.get();
         const ref = docSnapshot.data()!.ref!;
-        //expect(ref).to.be.an.instanceof(firestore.DocumentReference);
+        expect(ref).to.be.an.instanceof(DocumentReference);
         expect(untypedDocRef.isEqual(ref)).to.be.true;
       });
     });
@@ -1619,7 +1622,7 @@ apiDescribe('Database', (persistence: boolean) => {
         const querySnapshot = await collection.get();
         expect(querySnapshot.size).to.equal(1);
         const ref = querySnapshot.docs[0].data().ref!;
-        //expect(ref).to.be.an.instanceof(firestore.DocumentReference);
+        expect(ref).to.be.an.instanceof(DocumentReference);
         const untypedDocRef = untypedCollection.doc(docRef.id);
         expect(untypedDocRef.isEqual(ref)).to.be.true;
       });
@@ -1637,7 +1640,7 @@ apiDescribe('Database', (persistence: boolean) => {
         const querySnapshot = await query.get();
         expect(querySnapshot.size).to.equal(1);
         const ref = querySnapshot.docs[0].data().ref!;
-        //expect(ref).to.be.an.instanceof(firestore.DocumentReference);
+        expect(ref).to.be.an.instanceof(DocumentReference);
         expect(untypedDocRef.isEqual(ref)).to.be.true;
       });
     });

--- a/packages/firestore/test/integration/api/database.test.ts
+++ b/packages/firestore/test/integration/api/database.test.ts
@@ -1389,9 +1389,6 @@ apiDescribe('Database', (persistence: boolean) => {
       ): ModelWithRef {
         return new ModelWithRef(snapshot.ref);
       },
-      denver: function () {
-        console.log('denver');
-      }
     };
 
     it('for DocumentReference.withConverter()', () => {
@@ -1612,36 +1609,39 @@ apiDescribe('Database', (persistence: boolean) => {
       });
     });
 
-    it('github Correct snapshot specified to fromFirestore() when registered with DocumentReference', () => {
+    it('Correct snapshot specified to fromFirestore() when registered with DocumentReference', () => {
       return withTestDb(persistence, async db => {
-        const docRef = db.collection('/models').doc().withConverter(modelWithRefConverter);
+        const untypedDocRef = db.collection('/models').doc();
+        const docRef = untypedDocRef.withConverter(modelWithRefConverter);
         await docRef.set(new ModelWithRef(docRef));
         const docSnapshot = await docRef.get();
-        expect(docRef.isEqual(docSnapshot.data()!.ref)).to.be.true;
+        expect(untypedDocRef.isEqual(docSnapshot.data()!.ref)).to.be.true;
       });
     });
 
-    it('github Correct snapshot specified to fromFirestore() when registered with CollectionReference', () => {
+    it('Correct snapshot specified to fromFirestore() when registered with CollectionReference', () => {
       return withTestDb(persistence, async db => {
-        const collection = db.collection('/models').doc().collection("sub").withConverter(modelWithRefConverter);
+        const untypedCollection = db.collection('/models').doc().collection("sub");
+        const collection = untypedCollection.withConverter(modelWithRefConverter);
         const docRef = collection.doc();
         await docRef.set(new ModelWithRef(docRef));
         const querySnapshot = await collection.get();
         expect(querySnapshot.size).to.equal(1);
-        expect(docRef.isEqual(querySnapshot.docs[0].data().ref)).to.be.true;
+        const untypedDocRef = untypedCollection.doc(docRef.id);
+        expect(untypedDocRef.isEqual(querySnapshot.docs[0].data().ref)).to.be.true;
       });
     });
 
-    it('github Correct snapshot specified to fromFirestore() when registered with Query', () => {
+    it('Correct snapshot specified to fromFirestore() when registered with Query', () => {
       return withTestDb(persistence, async db => {
-        const collection = db.collection('/models');
-        const docRef = collection.doc();
-        const docRefWithConverter = docRef.withConverter(modelWithRefConverter);
-        await docRefWithConverter.set(new ModelWithRef(docRefWithConverter));
-        const query = collection.where(FieldPath.documentId(), '==', docRef.id).withConverter(modelWithRefConverter);
+        const untypedCollection = db.collection('/models');
+        const untypedDocRef = untypedCollection.doc();
+        const docRef = untypedDocRef.withConverter(modelWithRefConverter);
+        await docRef.set(new ModelWithRef(docRef));
+        const query = untypedCollection.where(FieldPath.documentId(), '==', docRef.id).withConverter(modelWithRefConverter);
         const querySnapshot = await query.get();
         expect(querySnapshot.size).to.equal(1);
-        expect(docRef.isEqual(querySnapshot.docs[0].data().ref)).to.be.true;
+        expect(untypedDocRef.isEqual(querySnapshot.docs[0].data().ref)).to.be.true;
       });
     });
   });

--- a/packages/firestore/test/integration/api/database.test.ts
+++ b/packages/firestore/test/integration/api/database.test.ts
@@ -1326,7 +1326,11 @@ apiDescribe('Database', (persistence: boolean) => {
   // only to web.
   apiDescribe('withConverter() support', (persistence: boolean) => {
     class Post {
-      constructor(readonly title: string, readonly author: string, readonly ref: firestore.DocumentReference | null = null) {}
+      constructor(
+        readonly title: string,
+        readonly author: string,
+        readonly ref: firestore.DocumentReference | null = null
+      ) {}
       byline(): string {
         return this.title + ', by ' + this.author;
       }

--- a/packages/firestore/test/integration/api/database.test.ts
+++ b/packages/firestore/test/integration/api/database.test.ts
@@ -1388,7 +1388,7 @@ apiDescribe('Database', (persistence: boolean) => {
         options: firestore.SnapshotOptions
       ): ModelWithRef {
         return new ModelWithRef(snapshot.ref);
-      },
+      }
     };
 
     it('for DocumentReference.withConverter()', () => {
@@ -1621,14 +1621,20 @@ apiDescribe('Database', (persistence: boolean) => {
 
     it('Correct snapshot specified to fromFirestore() when registered with CollectionReference', () => {
       return withTestDb(persistence, async db => {
-        const untypedCollection = db.collection('/models').doc().collection("sub");
-        const collection = untypedCollection.withConverter(modelWithRefConverter);
+        const untypedCollection = db
+          .collection('/models')
+          .doc()
+          .collection('sub');
+        const collection = untypedCollection.withConverter(
+          modelWithRefConverter
+        );
         const docRef = collection.doc();
         await docRef.set(new ModelWithRef(docRef));
         const querySnapshot = await collection.get();
         expect(querySnapshot.size).to.equal(1);
         const untypedDocRef = untypedCollection.doc(docRef.id);
-        expect(untypedDocRef.isEqual(querySnapshot.docs[0].data().ref)).to.be.true;
+        expect(untypedDocRef.isEqual(querySnapshot.docs[0].data().ref)).to.be
+          .true;
       });
     });
 
@@ -1638,10 +1644,13 @@ apiDescribe('Database', (persistence: boolean) => {
         const untypedDocRef = untypedCollection.doc();
         const docRef = untypedDocRef.withConverter(modelWithRefConverter);
         await docRef.set(new ModelWithRef(docRef));
-        const query = untypedCollection.where(FieldPath.documentId(), '==', docRef.id).withConverter(modelWithRefConverter);
+        const query = untypedCollection
+          .where(FieldPath.documentId(), '==', docRef.id)
+          .withConverter(modelWithRefConverter);
         const querySnapshot = await query.get();
         expect(querySnapshot.size).to.equal(1);
-        expect(untypedDocRef.isEqual(querySnapshot.docs[0].data().ref)).to.be.true;
+        expect(untypedDocRef.isEqual(querySnapshot.docs[0].data().ref)).to.be
+          .true;
       });
     });
   });

--- a/packages/firestore/test/integration/util/firebase_export.ts
+++ b/packages/firestore/test/integration/util/firebase_export.ts
@@ -25,7 +25,11 @@ import { FirebaseApp } from '@firebase/app-types';
 import * as firestore from '@firebase/firestore-types';
 
 import { Blob } from '../../../src/api/blob';
-import { Firestore } from '../../../src/api/database';
+import {
+  Firestore,
+  DocumentReference,
+  QueryDocumentSnapshot
+} from '../../../src/api/database';
 import { FieldPath } from '../../../src/api/field_path';
 import { FieldValue } from '../../../src/api/field_value';
 import { GeoPoint } from '../../../src/api/geo_point';
@@ -68,4 +72,13 @@ export function newTestFirestore(
   return firestore;
 }
 
-export { Firestore, FieldValue, FieldPath, Timestamp, Blob, GeoPoint };
+export {
+  Firestore,
+  FieldValue,
+  FieldPath,
+  Timestamp,
+  Blob,
+  GeoPoint,
+  DocumentReference,
+  QueryDocumentSnapshot
+};


### PR DESCRIPTION
`FirestoreDataConverter.fromFirestore()` was being invoked with an instance of `QueryDocumentSnapshot` from the experimental SDK; however, it was expected to be invoked with an instance of `QueryDocumentSnapshot` from the Classic SDK. This worked okay, except that the object was lacking attributes like `ref`, which are only provided by the Classic SDK.

The root cause is that the `FirestoreDataConverter` provided by the user was registered directly with the `QueryDocumentSnapshot` from the experimental SDK, and therefore was invoked with types from the experimental SDK. The fix is to instead register a "wrapper" data converter with the `QueryDocumentSnapshot` that calls the underlying data converter with the equivalent objects from the Classic SDK.

There was, however, a side effect of this change that caused `isEqual()` methods (e.g. `DocumentReference.isEqual()`) to incorrectly return `false` if compared with another `DocumentReference` created with the same converter instance. This is because the implementation of `isEqual()` compares the converters using the `===` operator. The wrapper instances that wrapped the same converters were distinct objects, and thus did not compare equal using `===`. The fix was to store each converter in a `WeakMap` mapping it to its wrapper instance so that the same wrapper instance can be used for each given converter, causing `isEqual()` to compare correctly.

Fixes #4278