### PR TITLE
Issue #462 fix : Add new method that returns the logged-in user as Promise : 

### DIFF
--- a/packages/auth/src/auth.js
+++ b/packages/auth/src/auth.js
@@ -1596,6 +1596,21 @@ fireauth.Auth.prototype.onAuthStateChanged = function(
       opt_completed);
 };
 
+/**
+ * @return {Promise} The fireauth.AuthUser if a user successfully logged in.
+ * Null if no user is logged in.
+ */
+fireauth.Auth.prototype.getSignedInUser = function() {
+  return new Promise((resolve, reject) => {
+    if (this.currentUser_()) {
+      resolve(this.currentUser_());
+    }
+    const unsubscribe = this.onAuthStateChanged(user => {
+      unsubscribe();
+      resolve(user);
+    }, reject);
+  });
+}
 
 /**
  * Returns an STS token. If the cached one is unexpired it is directly returned.


### PR DESCRIPTION
Issue https://github.com/firebase/firebase-js-sdk/issues/462
`onAuthStateChanged` has the following caveats that seem to be making it difficult for new-comers to get started with `firebase-auth` : 
- The method name doesn't clearly indicate a very common use-case: getting the current user info. Also, the method name implies that some state has to be changed in order for the callback to be triggered, but the callback is also triggered when auth is not pending (no user is logged in).
- Callbacks have caveats when compared to promises, which can be chained and utilized with the `async` keyword.

I was asked to tag @avolkovi and @bojeil-google.