### PR TITLE
Create storage-exp packaging scripts

### DIFF
--- a/packages-exp/firebase-exp/package.json
+++ b/packages-exp/firebase-exp/package.json
@@ -41,6 +41,7 @@
     "@firebase/auth-exp": "0.0.900",
     "@firebase/functions-exp": "0.0.900",
     "@firebase/firestore": "2.1.2",
+    "@firebase/storage": "0.4.2",
     "@firebase/performance-exp": "0.0.900",
     "@firebase/remote-config-exp": "0.0.900",
     "@firebase/messaging-exp": "0.0.900"

--- a/packages-exp/firebase-exp/package.json
+++ b/packages-exp/firebase-exp/package.json
@@ -65,6 +65,7 @@
     "functions",
     "firestore",
     "firestore/lite",
+    "storage",
     "performance",
     "remote-config",
     "messaging"

--- a/packages-exp/firebase-exp/storage/index.ts
+++ b/packages-exp/firebase-exp/storage/index.ts
@@ -1,0 +1,18 @@
+/**
+ * @license
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export * from '@firebase/storage';

--- a/packages-exp/firebase-exp/storage/package.json
+++ b/packages-exp/firebase-exp/storage/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "firebase-exp/storage",
+  "main": "dist/index.cjs.js",
+  "browser": "dist/index.esm.js",
+  "module": "dist/index.esm.js",
+  "typings": "dist/storage/index.d.ts"
+}

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -5,6 +5,7 @@
   "author": "Firebase <firebase-support@google.com> (https://firebase.google.com/)",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
+  "browser": "dist/index.esm.js",
   "esm2017": "dist/index.esm2017.js",
   "files": [
     "dist",

--- a/scripts/exp/prepare-firestore-for-exp-release.ts
+++ b/scripts/exp/prepare-firestore-for-exp-release.ts
@@ -22,7 +22,6 @@ import { promisify } from 'util';
 const writeFile = promisify(_writeFile);
 const packagePath = `${projectRoot}/packages/firestore`;
 
-//
 /**
  * Transform package.json in @firebase/firestore so that we can use scripts/exp/release.ts to release Firestore exp.
  * It does following things:

--- a/scripts/exp/prepare-storage-for-exp-release.ts
+++ b/scripts/exp/prepare-storage-for-exp-release.ts
@@ -45,15 +45,15 @@ export async function prepare() {
     '@firebase/app-types-exp': '0.x'
   };
 
-  packageJson.main = expPackageJson.main.replace('../', './exp');
-  packageJson.module = expPackageJson.module.replace('../', './exp');
-  packageJson.browser = expPackageJson.browser.replace('../', './exp');
+  packageJson.main = expPackageJson.main.replace('./', 'exp/');
+  packageJson.module = expPackageJson.module.replace('./', 'exp/');
+  packageJson.browser = expPackageJson.browser.replace('./', 'exp/');
   delete packageJson['esm2017'];
 
-  packageJson.typings = expPackageJson.typings.replace('../', './exp');
+  packageJson.typings = expPackageJson.typings.replace('./', 'exp/');
 
   // include files to be published
-  packageJson.files = [...packageJson.files, packageJson.typings];
+  packageJson.files = ['exp/dist'];
 
   // update package.json files
   await writeFile(

--- a/scripts/exp/prepare-storage-for-exp-release.ts
+++ b/scripts/exp/prepare-storage-for-exp-release.ts
@@ -22,7 +22,6 @@ import { promisify } from 'util';
 const writeFile = promisify(_writeFile);
 const packagePath = `${projectRoot}/packages/storage`;
 
-//
 /**
  * Transform package.json in @firebase/storage so that we can use scripts/exp/release.ts to release storage exp.
  * It does following things:

--- a/scripts/exp/prepare-storage-for-exp-release.ts
+++ b/scripts/exp/prepare-storage-for-exp-release.ts
@@ -20,11 +20,11 @@ import { writeFile as _writeFile, readFile as _readFile } from 'fs';
 import { promisify } from 'util';
 
 const writeFile = promisify(_writeFile);
-const packagePath = `${projectRoot}/packages/firestore`;
+const packagePath = `${projectRoot}/packages/storage`;
 
 //
 /**
- * Transform package.json in @firebase/firestore so that we can use scripts/exp/release.ts to release Firestore exp.
+ * Transform package.json in @firebase/storage so that we can use scripts/exp/release.ts to release storage exp.
  * It does following things:
  * 1. Update package.json to point to exp binaries
  * 2. Update version to '0.0.900', the version number we choose for releasing exp packages
@@ -38,7 +38,6 @@ export async function prepare() {
   // Update package.json
   const packageJson = await readPackageJson(packagePath);
   const expPackageJson = await readPackageJson(`${packagePath}/exp`);
-  const litePackageJson = await readPackageJson(`${packagePath}/lite`);
   packageJson.version = '0.0.900';
 
   packageJson.peerDependencies = {
@@ -46,25 +45,15 @@ export async function prepare() {
     '@firebase/app-types-exp': '0.x'
   };
 
-  packageJson.main = expPackageJson.main.replace('../', '');
-  packageJson.module = expPackageJson.module.replace('../', '');
-  packageJson.browser = expPackageJson.browser.replace('../', '');
-  packageJson['react-native'] = expPackageJson['react-native'].replace(
-    '../',
-    ''
-  );
-  delete packageJson['main-esm2017'];
+  packageJson.main = expPackageJson.main.replace('../', './exp');
+  packageJson.module = expPackageJson.module.replace('../', './exp');
+  packageJson.browser = expPackageJson.browser.replace('../', './exp');
   delete packageJson['esm2017'];
 
-  packageJson.typings = expPackageJson.typings.replace('../', '');
+  packageJson.typings = expPackageJson.typings.replace('../', './exp');
 
   // include files to be published
-  packageJson.files = [
-    ...packageJson.files,
-    packageJson.typings,
-    'lite/package.json',
-    litePackageJson.typings.replace('../', '')
-  ];
+  packageJson.files = [...packageJson.files, packageJson.typings];
 
   // update package.json files
   await writeFile(

--- a/scripts/exp/release.ts
+++ b/scripts/exp/release.ts
@@ -29,6 +29,7 @@ import { promisify } from 'util';
 import chalk from 'chalk';
 import Listr from 'listr';
 import { prepare as prepareFirestoreForRelease } from './prepare-firestore-for-exp-release';
+import { prepare as prepareStorageForRelease } from './prepare-storage-for-exp-release';
 import * as yargs from 'yargs';
 
 const prompt = createPromptModule();
@@ -58,6 +59,7 @@ async function publishExpPackages({ dryRun }: { dryRun: boolean }) {
      * Update fields in package.json and stuff
      */
     await prepareFirestoreForRelease();
+    await prepareStorageForRelease();
 
     /**
      * build packages
@@ -70,6 +72,7 @@ async function publishExpPackages({ dryRun }: { dryRun: boolean }) {
     ]);
 
     packagePaths.push(`${projectRoot}/packages/firestore`);
+    packagePaths.push(`${projectRoot}/packages/storage`);
 
     /**
      * It does 2 things:
@@ -239,6 +242,16 @@ async function buildPackages() {
   await spawn(
     'yarn',
     ['lerna', 'run', '--scope', '@firebase/firestore', 'build:exp:release'],
+    {
+      cwd: projectRoot,
+      stdio: 'inherit'
+    }
+  );
+
+  // Storage
+  await spawn(
+    'yarn',
+    ['lerna', 'run', '--scope', '@firebase/storage', 'build:exp'],
     {
       cwd: projectRoot,
       stdio: 'inherit'


### PR DESCRIPTION
Set up scripts to publish storage-exp, similar to Firestore's.

I have a question:
I set up the script based on Firestore's pattern. Based on this, the `typings` field in `packages-exp/firebase-exp/storage/package.json` points to "dist/storage/index.d.ts". If I look at that generated file, it contains one line `export * from '@firebase/storage';`. The same thing happens in Firestore, with `firestore` instead of `storage` of course. Is that right? I get a little confused about the firebase-exp entry points.