### PR TITLE
Add exp deps and fix script bug

### DIFF
--- a/packages-exp/firebase-exp/package.json
+++ b/packages-exp/firebase-exp/package.json
@@ -36,9 +36,11 @@
     "test:ci": "echo 'No test suite for firebase wrapper'"
   },
   "dependencies": {
+    "@firebase/analytics-exp": "0.0.900",
     "@firebase/app-exp": "0.0.900",
     "@firebase/app-compat": "0.0.900",
     "@firebase/auth-exp": "0.0.900",
+    "@firebase/database": "0.8.3",
     "@firebase/functions-exp": "0.0.900",
     "@firebase/firestore": "2.1.2",
     "@firebase/storage": "0.4.2",

--- a/scripts/exp/release.ts
+++ b/scripts/exp/release.ts
@@ -146,7 +146,7 @@ async function publishExpPackages({ dryRun }: { dryRun: boolean }) {
      * Do not push to remote if it's a dryrun
      */
     if (!dryRun) {
-      const { commitAndPush } = await prompt([
+      const { shouldCommitAndPush } = await prompt([
         {
           type: 'confirm',
           name: 'commitAndPush',
@@ -158,7 +158,7 @@ async function publishExpPackages({ dryRun }: { dryRun: boolean }) {
       /**
        * push to github
        */
-      if (commitAndPush) {
+      if (shouldCommitAndPush) {
         await commitAndPush(versions);
       }
     }


### PR DESCRIPTION
- Add `analytics-exp` and `database` deps to `firebase-exp`.
- Fix a name collision bug in exp release script.