### PR TITLE
Fix analytics type export

### DIFF
--- a/packages-exp/analytics-exp/src/index.ts
+++ b/packages-exp/analytics-exp/src/index.ts
@@ -82,7 +82,7 @@ registerAnalytics();
 
 export * from './api';
 
-export {
+export type {
   Analytics,
   AnalyticsCallOptions,
   SettingsOptions,


### PR DESCRIPTION
Add `type` to exclude from being included in js bundle.