### PR TITLE
Fix instance deletion in the Console build

### DIFF
--- a/packages/firestore/src/api/database.ts
+++ b/packages/firestore/src/api/database.ts
@@ -277,8 +277,10 @@ export class Firestore
   }
 
   terminate(): Promise<void> {
-    (this.app as _FirebaseApp)._removeServiceInstance('firestore');
-    (this.app as _FirebaseApp)._removeServiceInstance('firestore-exp');
+    if (this._appCompat) {
+      (this._appCompat as _FirebaseApp)._removeServiceInstance('firestore');
+      (this._appCompat as _FirebaseApp)._removeServiceInstance('firestore-exp');
+    }
     return this._delegate._delete();
   }
 


### PR DESCRIPTION
The console build doesn't have FirebaseApp and fails the delete if this.app is accessed.
