### PR TITLE
Package storage-types/exp

### DIFF
--- a/packages/storage/exp/package.json
+++ b/packages/storage/exp/package.json
@@ -4,6 +4,6 @@
   "main": "./dist/index.browser.cjs.js",
   "module": "./dist/index.browser.esm2017.js",
   "browser": "./dist/index.browser.esm2017.js",
-  "typings": "./dist/storage.d.ts",
+  "typings": "./dist/storage-public.d.ts",
   "private": true
 }

--- a/scripts/exp/prepare-storage-for-exp-release.ts
+++ b/scripts/exp/prepare-storage-for-exp-release.ts
@@ -37,7 +37,10 @@ export async function prepare() {
   // Update package.json
   const packageJson = await readPackageJson(packagePath);
   const expPackageJson = await readPackageJson(`${packagePath}/exp`);
+  const typesPackageJson = await readPackageJson(`${packagePath}-types`);
   packageJson.version = '0.0.900';
+  typesPackageJson.version = '0.0.900';
+  typesPackageJson.files = `['exp/index.d.ts']`;
 
   packageJson.peerDependencies = {
     '@firebase/app-exp': '0.x',
@@ -58,6 +61,11 @@ export async function prepare() {
   await writeFile(
     `${packagePath}/package.json`,
     `${JSON.stringify(packageJson, null, 2)}\n`,
+    { encoding: 'utf-8' }
+  );
+  await writeFile(
+    `${packagePath}-types/package.json`,
+    `${JSON.stringify(typesPackageJson, null, 2)}\n`,
     { encoding: 'utf-8' }
   );
 }


### PR DESCRIPTION
- Ensure storage-exp typings pointing to public typings.
- Storage prep script modifies storage-types/package.json as well, to package `exp/index.d.ts`