### PR TITLE
Export public types from functions-exp

### DIFF
--- a/common/api-review/functions-exp.api.md
+++ b/common/api-review/functions-exp.api.md
@@ -19,6 +19,8 @@ export function httpsCallable(functionsInstance: Functions, name: string, option
 export function useFunctionsEmulator(functionsInstance: Functions, host: string, port: number): void;
 
 
+export * from "@firebase/functions-types-exp";
+
 // (No @packageDocumentation comment for this package)
 
 ```

--- a/common/api-review/functions-exp.api.md
+++ b/common/api-review/functions-exp.api.md
@@ -6,20 +6,33 @@
 
 import { FirebaseApp } from '@firebase/app-types-exp';
 import { Functions } from '@firebase/functions-types-exp';
+import { FunctionsError } from '@firebase/functions-types-exp';
+import { FunctionsErrorCode } from '@firebase/functions-types-exp';
 import { HttpsCallable } from '@firebase/functions-types-exp';
 import { HttpsCallableOptions } from '@firebase/functions-types-exp';
+import { HttpsCallableResult } from '@firebase/functions-types-exp';
+
+export { Functions }
+
+export { FunctionsError }
+
+export { FunctionsErrorCode }
 
 // @public
 export function getFunctions(app: FirebaseApp, regionOrCustomDomain?: string): Functions;
 
+export { HttpsCallable }
+
 // @public
 export function httpsCallable(functionsInstance: Functions, name: string, options?: HttpsCallableOptions): HttpsCallable;
+
+export { HttpsCallableOptions }
+
+export { HttpsCallableResult }
 
 // @public
 export function useFunctionsEmulator(functionsInstance: Functions, host: string, port: number): void;
 
-
-export * from "@firebase/functions-types-exp";
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages-exp/functions-exp/src/api.ts
+++ b/packages-exp/functions-exp/src/api.ts
@@ -23,7 +23,10 @@ import { Provider } from '@firebase/component';
 import {
   Functions,
   HttpsCallableOptions,
-  HttpsCallable
+  HttpsCallable,
+  HttpsCallableResult,
+  FunctionsError,
+  FunctionsErrorCode
 } from '@firebase/functions-types-exp';
 import {
   FunctionsService,
@@ -32,7 +35,14 @@ import {
   httpsCallable as _httpsCallable
 } from './service';
 
-export * from '@firebase/functions-types-exp';
+export {
+  Functions,
+  HttpsCallableOptions,
+  HttpsCallable,
+  HttpsCallableResult,
+  FunctionsError,
+  FunctionsErrorCode
+};
 
 /**
  * Returns a Functions instance for the given app.

--- a/packages-exp/functions-exp/src/api.ts
+++ b/packages-exp/functions-exp/src/api.ts
@@ -32,6 +32,8 @@ import {
   httpsCallable as _httpsCallable
 } from './service';
 
+export * from '@firebase/functions-types-exp';
+
 /**
  * Returns a Functions instance for the given app.
  * @param app - The FirebaseApp to use.


### PR DESCRIPTION
Export public types. Reviewed functions-types and seems like they all should be public.