### PR TITLE
handle ignoreUndefinedProperties in set(merge: true)

### DIFF
--- a/.changeset/silent-cars-burn.md
+++ b/.changeset/silent-cars-burn.md
@@ -1,0 +1,7 @@
+---
+'@firebase/firestore': patch
+---
+
+handle `ignoreUndefinedProperties` in `set({ merge: true })`. Previously this
+would behave as if the undefined value were `FieldValue.delete()`, which wasn't
+intended.

--- a/.changeset/silent-cars-burn.md
+++ b/.changeset/silent-cars-burn.md
@@ -2,6 +2,4 @@
 '@firebase/firestore': patch
 ---
 
-handle `ignoreUndefinedProperties` in `set({ merge: true })`. Previously this
-would behave as if the undefined value were `FieldValue.delete()`, which wasn't
-intended.
+handle `ignoreUndefinedProperties` in `set({ merge: true })`. Previously this would behave as if the undefined value were `FieldValue.delete()`, which wasn't intended.

--- a/packages/firestore/src/api/user_data_reader.ts
+++ b/packages/firestore/src/api/user_data_reader.ts
@@ -741,7 +741,11 @@ export function parseData(
   } else {
     // If context.path is null we are inside an array and we don't support
     // field mask paths more granular than the top-level array.
-    if (context.path) {
+    //
+    // If the input is undefined it can never participate in the fieldMask. With
+    // `ignoreUndefinedProperties` set to false, `parseScalarValue` will reject
+    // an undefined value.
+    if (context.path && input !== undefined) {
       context.fieldMask.push(context.path);
     }
 

--- a/packages/firestore/src/api/user_data_reader.ts
+++ b/packages/firestore/src/api/user_data_reader.ts
@@ -738,14 +738,15 @@ export function parseData(
     // context.fieldMask and we return null as our parsing result.
     parseSentinelFieldValue(input, context);
     return null;
+  } else if (input === undefined && context.ignoreUndefinedProperties) {
+    // If the input is undefined it can never participate in the fieldMask, so
+    // don't handle this below. If `ignoreUndefinedProperties` is false,
+    // `parseScalarValue` will reject an undefined value.
+    return null;
   } else {
     // If context.path is null we are inside an array and we don't support
     // field mask paths more granular than the top-level array.
-    //
-    // If the input is undefined it can never participate in the fieldMask. With
-    // `ignoreUndefinedProperties` set to false, `parseScalarValue` will reject
-    // an undefined value.
-    if (context.path && input !== undefined) {
+    if (context.path) {
       context.fieldMask.push(context.path);
     }
 
@@ -900,8 +901,6 @@ function parseScalarValue(
         value._key.path
       )
     };
-  } else if (value === undefined && context.ignoreUndefinedProperties) {
-    return null;
   } else {
     throw context.createError(
       `Unsupported field value: ${valueDescription(value)}`

--- a/packages/firestore/test/integration/api/fields.test.ts
+++ b/packages/firestore/test/integration/api/fields.test.ts
@@ -400,8 +400,8 @@ apiDescribe('`undefined` properties', (persistence: boolean) => {
 
   it('are ignored in set({ merge: true })', () => {
     return withTestDocAndSettings(persistence, settings, async doc => {
-      await doc.set({ foo: 'foo', 'bar': 'unchanged' });
-      await doc.set({ foo: 'foo', 'bar': undefined }, { merge: true });
+      await doc.set({ foo: 'foo', bar: 'unchanged' });
+      await doc.set({ foo: 'foo', bar: undefined }, { merge: true });
       const docSnap = await doc.get();
       expect(docSnap.data()).to.deep.equal({ foo: 'foo', bar: 'unchanged' });
     });

--- a/packages/firestore/test/integration/api/fields.test.ts
+++ b/packages/firestore/test/integration/api/fields.test.ts
@@ -398,6 +398,15 @@ apiDescribe('`undefined` properties', (persistence: boolean) => {
     });
   });
 
+  it('are ignored in set({ merge: true })', () => {
+    return withTestDocAndSettings(persistence, settings, async doc => {
+      await doc.set({ foo: 'foo', 'bar': 'unchanged' });
+      await doc.set({ foo: 'foo', 'bar': undefined }, { merge: true });
+      const docSnap = await doc.get();
+      expect(docSnap.data()).to.deep.equal({ foo: 'foo', bar: 'unchanged' });
+    });
+  });
+
   it('are ignored in update()', () => {
     return withTestDocAndSettings(persistence, settings, async doc => {
       await doc.set({});


### PR DESCRIPTION
Previously any field in the document would be propagated into the
FieldMask regardless of whether or not it had an undefined value, which
led to the client acting as if the user had passed FieldValue.delete(),
which wasn't intended.

Fixes googleapis/nodejs-firestore#1392 for the JS SDK.