### PR TITLE
Fix bug in rtdb query get test

### DIFF
--- a/packages/database/test/query.test.ts
+++ b/packages/database/test/query.test.ts
@@ -3131,7 +3131,7 @@ describe('Query Tests', () => {
   it('get returns the latest value', async () => {
     const node = getRandomNode() as Reference;
     await node.set({ foo: 'bar' });
-    expect(node.get()).to.eventually.equal({ foo: 'bar' });
+    expect((await node.get()).val()).to.deep.equal({ foo: 'bar' });
   });
 
   it('get reads from cache if database is not connected', async () => {


### PR DESCRIPTION
Before this test was trying to shallow-compare the promise object to `{foo: 'bar'}`.