### PR TITLE
Fix size analysis script issues

### DIFF
--- a/repo-scripts/size-analysis/analysis-helper.ts
+++ b/repo-scripts/size-analysis/analysis-helper.ts
@@ -225,7 +225,10 @@ export function extractDeclarations(
     } else if (ts.isVariableDeclaration(node)) {
       declarations.variables.push(node.name!.getText());
     } else if (ts.isEnumDeclaration(node)) {
+      // `const enum`s should not be analyzed. They do not add to bundle size and
+      // creating a file that imports them causes an error during the rollup step.
       if (
+        // Identifies if this enum had a "const" modifier attached.
         !node.modifiers?.some(mod => mod.kind === ts.SyntaxKind.ConstKeyword)
       ) {
         declarations.enums.push(node.name.escapedText.toString());

--- a/repo-scripts/size-analysis/analysis-helper.ts
+++ b/repo-scripts/size-analysis/analysis-helper.ts
@@ -96,7 +96,8 @@ export async function extractDependenciesAndSize(
   });
   const externalDepsNotResolvedBundle = await rollup.rollup({
     input,
-    external: id => id.startsWith('@firebase') // exclude all firebase dependencies
+    // exclude all firebase dependencies and tslib
+    external: id => id.startsWith('@firebase') || id === 'tslib'
   });
   await externalDepsNotResolvedBundle.write({
     file: externalDepsNotResolvedOutput,
@@ -224,7 +225,11 @@ export function extractDeclarations(
     } else if (ts.isVariableDeclaration(node)) {
       declarations.variables.push(node.name!.getText());
     } else if (ts.isEnumDeclaration(node)) {
-      declarations.enums.push(node.name.escapedText.toString());
+      if (
+        !node.modifiers?.some(mod => mod.kind === ts.SyntaxKind.ConstKeyword)
+      ) {
+        declarations.enums.push(node.name.escapedText.toString());
+      }
     } else if (ts.isVariableStatement(node)) {
       const variableDeclarations = node.declarationList.declarations;
 
@@ -238,9 +243,8 @@ export function extractDeclarations(
         }
         // Binding Pattern Example: export const {a, b} = {a: 1, b: 1};
         else {
-          const elements = variableDeclaration.name.elements as ts.NodeArray<
-            ts.BindingElement
-          >;
+          const elements = variableDeclaration.name
+            .elements as ts.NodeArray<ts.BindingElement>;
           elements.forEach((node: ts.BindingElement) => {
             declarations.variables.push(node.name.getText(sourceFile));
           });


### PR DESCRIPTION
Size analysis CI bugs started happening after we changed auth-exp to export const enum types from the main package.

I hope this is the most correct way to find and filter out const enums.
Also added 'tslib' as an external - otherwise rollup will do it anyway but give you a lot of warnings.