### PR TITLE
Fix issue with IDP sign in error handling

### DIFF
--- a/packages-exp/auth-exp/src/api/authentication/idp.ts
+++ b/packages-exp/auth-exp/src/api/authentication/idp.ts
@@ -25,6 +25,7 @@ export interface SignInWithIdpRequest {
   sessionId?: string;
   tenantId?: string;
   returnSecureToken: boolean;
+  returnIdpCredential?: boolean;
   idToken?: IdToken;
   autoCreate?: boolean;
   pendingToken?: string;

--- a/packages-exp/auth-exp/src/api/index.test.ts
+++ b/packages-exp/auth-exp/src/api/index.test.ts
@@ -123,23 +123,21 @@ describe('api/_performApiRequest', () => {
     it('should translate server success with errorMessage into auth error', async () => {
       const response = {
         errorMessage: ServerError.FEDERATED_USER_ID_ALREADY_LINKED,
-        idToken: 'foo-bar',
+        idToken: 'foo-bar'
       };
-      const mock = mockEndpoint(
-        Endpoint.SIGN_IN_WITH_IDP,
-        response,
-        200
-      );
+      const mock = mockEndpoint(Endpoint.SIGN_IN_WITH_IDP, response, 200);
       const promise = _performApiRequest<typeof request, typeof serverResponse>(
         auth,
         HttpMethod.POST,
         Endpoint.SIGN_IN_WITH_IDP,
         request
       );
-      await expect(promise).to.be.rejectedWith(
-        FirebaseError,
-        'auth/credential-already-in-use'
-      ).eventually.with.deep.property('customData', {appName: 'test-app', _tokenResponse: response});
+      await expect(promise)
+        .to.be.rejectedWith(FirebaseError, 'auth/credential-already-in-use')
+        .eventually.with.deep.property('customData', {
+          appName: 'test-app',
+          _tokenResponse: response
+        });
       expect(mock.calls[0].request).to.eql(request);
     });
 

--- a/packages-exp/auth-exp/src/api/index.test.ts
+++ b/packages-exp/auth-exp/src/api/index.test.ts
@@ -120,6 +120,29 @@ describe('api/_performApiRequest', () => {
       expect(mock.calls[0].request).to.eql(request);
     });
 
+    it('should translate server success with errorMessage into auth error', async () => {
+      const response = {
+        errorMessage: ServerError.FEDERATED_USER_ID_ALREADY_LINKED,
+        idToken: 'foo-bar',
+      };
+      const mock = mockEndpoint(
+        Endpoint.SIGN_IN_WITH_IDP,
+        response,
+        200
+      );
+      const promise = _performApiRequest<typeof request, typeof serverResponse>(
+        auth,
+        HttpMethod.POST,
+        Endpoint.SIGN_IN_WITH_IDP,
+        request
+      );
+      await expect(promise).to.be.rejectedWith(
+        FirebaseError,
+        'auth/credential-already-in-use'
+      ).eventually.with.deep.property('customData', {appName: 'test-app', _tokenResponse: response});
+      expect(mock.calls[0].request).to.eql(request);
+    });
+
     it('should translate complex server errors to auth errors', async () => {
       const mock = mockEndpoint(
         Endpoint.SIGN_UP,

--- a/packages-exp/auth-exp/src/api/index.ts
+++ b/packages-exp/auth-exp/src/api/index.ts
@@ -132,10 +132,11 @@ export async function _performFetchWithErrorHandling<V>(
       throw makeTaggedError(auth, AuthErrorCode.NEED_CONFIRMATION, json);
     }
 
-    if (response.ok) {
+    if (response.ok && !('errorMessage' in json)) {
       return json;
     } else {
-      const serverErrorCode = json.error.message.split(' : ')[0] as ServerError;
+      const errorMessage = response.ok ? json.errorMessage : json.error.message;
+      const serverErrorCode = errorMessage.split(' : ')[0] as ServerError;
       if (serverErrorCode === ServerError.FEDERATED_USER_ID_ALREADY_LINKED) {
         throw makeTaggedError(
           auth,

--- a/packages-exp/auth-exp/src/core/strategies/idp.test.ts
+++ b/packages-exp/auth-exp/src/core/strategies/idp.test.ts
@@ -83,7 +83,7 @@ describe('core/strategies/idb', () => {
         tenantId: 'tenant-id',
         pendingToken: 'pending-token',
         returnSecureToken: true,
-        returnIdpCredential: true,
+        returnIdpCredential: true
       });
     });
 
@@ -113,7 +113,7 @@ describe('core/strategies/idb', () => {
         tenantId: 'tenant-id',
         pendingToken: 'pending-token',
         postBody: 'post-body',
-        bypassAuthState: true,
+        bypassAuthState: true
       });
       expect(stub.getCall(0).lastArg).to.be.true;
     });
@@ -138,7 +138,7 @@ describe('core/strategies/idb', () => {
         tenantId: 'tenant-id',
         pendingToken: 'pending-token',
         returnSecureToken: true,
-        returnIdpCredential: true,
+        returnIdpCredential: true
       });
     });
 

--- a/packages-exp/auth-exp/src/core/strategies/idp.test.ts
+++ b/packages-exp/auth-exp/src/core/strategies/idp.test.ts
@@ -82,7 +82,8 @@ describe('core/strategies/idb', () => {
         postBody: 'post-body',
         tenantId: 'tenant-id',
         pendingToken: 'pending-token',
-        returnSecureToken: true
+        returnSecureToken: true,
+        returnIdpCredential: true,
       });
     });
 
@@ -112,7 +113,7 @@ describe('core/strategies/idb', () => {
         tenantId: 'tenant-id',
         pendingToken: 'pending-token',
         postBody: 'post-body',
-        bypassAuthState: true
+        bypassAuthState: true,
       });
       expect(stub.getCall(0).lastArg).to.be.true;
     });
@@ -136,7 +137,8 @@ describe('core/strategies/idb', () => {
         postBody: 'post-body',
         tenantId: 'tenant-id',
         pendingToken: 'pending-token',
-        returnSecureToken: true
+        returnSecureToken: true,
+        returnIdpCredential: true,
       });
     });
 
@@ -193,6 +195,7 @@ describe('core/strategies/idb', () => {
         tenantId: 'tenant-id',
         pendingToken: 'pending-token',
         returnSecureToken: true,
+        returnIdpCredential: true,
         idToken: idTokenBeforeLink
       });
     });

--- a/packages-exp/auth-exp/src/core/strategies/idp.ts
+++ b/packages-exp/auth-exp/src/core/strategies/idp.ts
@@ -71,7 +71,8 @@ class IdpCredential extends AuthCredential {
       postBody: this.params.postBody || null,
       tenantId: this.params.tenantId,
       pendingToken: this.params.pendingToken,
-      returnSecureToken: true
+      returnSecureToken: true,
+      returnIdpCredential: true,
     };
 
     if (idToken) {

--- a/packages-exp/auth-exp/src/core/strategies/idp.ts
+++ b/packages-exp/auth-exp/src/core/strategies/idp.ts
@@ -72,7 +72,7 @@ class IdpCredential extends AuthCredential {
       tenantId: this.params.tenantId,
       pendingToken: this.params.pendingToken,
       returnSecureToken: true,
-      returnIdpCredential: true,
+      returnIdpCredential: true
     };
 
     if (idToken) {


### PR DESCRIPTION
We weren't passing through one of the required flags in the request that allows the `Provider.credentialFromError()` flow to work.

Fixes https://github.com/firebase/firebase-js-sdk/issues/4389