### PR TITLE
Dequeue limbo resolutions when their respective queries are stopped

### DIFF
--- a/.changeset/eight-bananas-nail.md
+++ b/.changeset/eight-bananas-nail.md
@@ -2,4 +2,4 @@
 '@firebase/firestore': patch
 ---
 
-Fix a bug where local cache inconsistencies were unnecessarily being resolved.
+Fixes a bug where local cache inconsistencies were unnecessarily being resolved.

--- a/.changeset/eight-bananas-nail.md
+++ b/.changeset/eight-bananas-nail.md
@@ -1,0 +1,5 @@
+---
+'@firebase/firestore': patch
+---
+
+Fix a bug where local cache inconsistencies were unnecessarily being resolved.

--- a/packages/firestore/src/core/sync_engine_impl.ts
+++ b/packages/firestore/src/core/sync_engine_impl.ts
@@ -51,6 +51,7 @@ import { MaybeDocument, NoDocument } from '../model/document';
 import { DocumentKey } from '../model/document_key';
 import { Mutation } from '../model/mutation';
 import { MutationBatchResult } from '../model/mutation_batch';
+import { ResourcePath } from '../model/path';
 import { RemoteEvent, TargetChange } from '../remote/remote_event';
 import {
   canUseNetwork,
@@ -113,7 +114,6 @@ import {
   ViewChange
 } from './view';
 import { ViewSnapshot } from './view_snapshot';
-import { ResourcePath } from '../model/path';
 
 const LOG_TAG = 'SyncEngine';
 

--- a/packages/firestore/src/core/sync_engine_impl.ts
+++ b/packages/firestore/src/core/sync_engine_impl.ts
@@ -211,6 +211,10 @@ class SyncEngineImpl implements SyncEngine {
    * The keys of documents that are in limbo for which we haven't yet started a
    * limbo resolution query. The strings in this set are the result of calling
    * `key.path.canonicalString()` where `key` is a `DocumentKey` object.
+   *
+   * The `Set` type was chosen because it provides efficient lookup and removal
+   * of arbitrary elements and it also maintains insertion order, providing the
+   * desired queue-like FIFO semantics.
    */
   enqueuedLimboResolutions = new Set<string>();
   /**

--- a/packages/firestore/src/core/sync_engine_impl.ts
+++ b/packages/firestore/src/core/sync_engine_impl.ts
@@ -929,9 +929,13 @@ function trackLimboChange(
   limboChange: AddedLimboDocument
 ): void {
   const key = limboChange.key;
-  if (!syncEngineImpl.activeLimboTargetsByKey.get(key)) {
+  const keyString = key.path.canonicalString();
+  if (
+    !syncEngineImpl.activeLimboTargetsByKey.get(key) &&
+    !syncEngineImpl.enqueuedLimboResolutions.has(keyString)
+  ) {
     logDebug(LOG_TAG, 'New document in limbo: ' + key);
-    syncEngineImpl.enqueuedLimboResolutions.add(key.path.canonicalString());
+    syncEngineImpl.enqueuedLimboResolutions.add(keyString);
     pumpEnqueuedLimboResolutions(syncEngineImpl);
   }
 }

--- a/packages/firestore/test/unit/specs/limbo_spec.test.ts
+++ b/packages/firestore/test/unit/specs/limbo_spec.test.ts
@@ -924,72 +924,11 @@ describeSpec('Limbo Documents:', [], () => {
   );
 
   specTest(
-    'A limbo resolution for a document should be removed from the queue when the last query listen stops',
-    [],
-    () => {
-      const doc1 = doc('collection1/doc', 1000, { key: 1 });
-      const query1 = query('collection1');
-      const filteredQuery1 = query('collection1', filter('key', '==', 1));
-
-      const doc2 = doc('collection2/doc', 1000, { key: 2 });
-      const query2 = query('collection2');
-      const filteredQuery2 = query('collection2', filter('key', '==', 2));
-      const filteredQuery3 = query('collection2', filter('key', '>=', 2));
-
-      return (
-        spec()
-          .withGCEnabled(false)
-          .withMaxConcurrentLimboResolutions(1)
-
-          // Max out the number of active limbo resolutions.
-          .userListens(query1)
-          .watchAcksFull(query1, 1000, doc1)
-          .expectEvents(query1, { added: [doc1] })
-          .userUnlistens(query1)
-          .userListens(filteredQuery1)
-          .expectEvents(filteredQuery1, { added: [doc1], fromCache: true })
-          .watchAcksFull(filteredQuery1, 1001)
-          .expectLimboDocs(doc1.key)
-
-          // Enqueue a limbo resolution for doc2.
-          .userListens(query2)
-          .watchAcksFull(query2, 1002, doc2)
-          .expectEvents(query2, { added: [doc2] })
-          .userUnlistens(query2)
-          .userListens(filteredQuery2)
-          .expectEvents(filteredQuery2, { added: [doc2], fromCache: true })
-          .watchAcksFull(filteredQuery2, 1003)
-          .expectLimboDocs(doc1.key)
-          .expectEnqueuedLimboDocs(doc2.key)
-
-          // Start another query that puts doc2 into limbo again.
-          .userListens(filteredQuery3)
-          .expectEvents(filteredQuery3, { added: [doc2], fromCache: true })
-          .watchAcksFull(filteredQuery3, 1004)
-          .expectLimboDocs(doc1.key)
-          .expectEnqueuedLimboDocs(doc2.key)
-
-          // Stop one of the queries that enqueued a limbo resolution for doc2;
-          // verify that doc2 is not removed from the limbo resolution queue.
-          .userUnlistens(filteredQuery3)
-          .expectLimboDocs(doc1.key)
-          .expectEnqueuedLimboDocs(doc2.key)
-
-          // Stop the other query that enqueued a limbo resolution for doc2;
-          // verify that doc2 *is* removed from the limbo resolution queue.
-          .userUnlistens(filteredQuery2)
-          .expectLimboDocs(doc1.key)
-          .expectEnqueuedLimboDocs()
-      );
-    }
-  );
-
-  specTest(
     'A limbo resolution for a document should not be started if one is already active',
     [],
     () => {
       const doc1 = doc('collection/doc', 1000, { key: 1 });
-      const query1 = query('collection');
+      const fullQuery = query('collection');
       const filteredQuery1 = query('collection', filter('key', '==', 1));
       const filteredQuery2 = query('collection', filter('key', '>=', 1));
 
@@ -998,10 +937,10 @@ describeSpec('Limbo Documents:', [], () => {
           .withGCEnabled(false)
 
           // Start a limbo resolution listen for a document (doc1).
-          .userListens(query1)
-          .watchAcksFull(query1, 1000, doc1)
-          .expectEvents(query1, { added: [doc1] })
-          .userUnlistens(query1)
+          .userListens(fullQuery)
+          .watchAcksFull(fullQuery, 1000, doc1)
+          .expectEvents(fullQuery, { added: [doc1] })
+          .userUnlistens(fullQuery)
           .userListens(filteredQuery1)
           .expectEvents(filteredQuery1, { added: [doc1], fromCache: true })
           .watchAcksFull(filteredQuery1, 1001)
@@ -1024,12 +963,12 @@ describeSpec('Limbo Documents:', [], () => {
     [],
     () => {
       const doc1 = doc('collection1/doc1', 1000, { key: 1 });
-      const query1 = query('collection1');
+      const fullQuery1 = query('collection1');
       const filteredQuery1 = query('collection1', filter('key', '==', 1));
       const doc2 = doc('collection2/doc2', 1000, { key: 2 });
-      const query2 = query('collection2');
-      const filteredQuery2 = query('collection2', filter('key', '==', 2));
-      const filteredQuery3 = query('collection2', filter('key', '>=', 2));
+      const fullQuery2 = query('collection2');
+      const filteredQuery2a = query('collection2', filter('key', '==', 2));
+      const filteredQuery2b = query('collection2', filter('key', '>=', 2));
 
       return (
         spec()
@@ -1037,33 +976,94 @@ describeSpec('Limbo Documents:', [], () => {
           .withMaxConcurrentLimboResolutions(1)
 
           // Max out the number of active limbo resolutions.
-          .userListens(query1)
-          .watchAcksFull(query1, 1000, doc1)
-          .expectEvents(query1, { added: [doc1] })
-          .userUnlistens(query1)
+          .userListens(fullQuery1)
+          .watchAcksFull(fullQuery1, 1000, doc1)
+          .expectEvents(fullQuery1, { added: [doc1] })
+          .userUnlistens(fullQuery1)
           .userListens(filteredQuery1)
           .expectEvents(filteredQuery1, { added: [doc1], fromCache: true })
           .watchAcksFull(filteredQuery1, 1001)
           .expectLimboDocs(doc1.key)
 
           // Start a limbo resolution listen for a different document (doc2).
-          .userListens(query2)
-          .watchAcksFull(query2, 1002, doc2)
-          .expectEvents(query2, { added: [doc2] })
-          .userUnlistens(query2)
-          .userListens(filteredQuery2)
-          .expectEvents(filteredQuery2, { added: [doc2], fromCache: true })
-          .watchAcksFull(filteredQuery2, 1003)
+          .userListens(fullQuery2)
+          .watchAcksFull(fullQuery2, 1002, doc2)
+          .expectEvents(fullQuery2, { added: [doc2] })
+          .userUnlistens(fullQuery2)
+          .userListens(filteredQuery2a)
+          .expectEvents(filteredQuery2a, { added: [doc2], fromCache: true })
+          .watchAcksFull(filteredQuery2a, 1003)
           .expectLimboDocs(doc1.key)
           .expectEnqueuedLimboDocs(doc2.key)
 
           // Put doc2 into limbo in a different query and verify that it's not
           // added to the limbo resolution queue again.
-          .userListens(filteredQuery3)
-          .expectEvents(filteredQuery3, { added: [doc2], fromCache: true })
-          .watchAcksFull(filteredQuery3, 1004)
+          .userListens(filteredQuery2b)
+          .expectEvents(filteredQuery2b, { added: [doc2], fromCache: true })
+          .watchAcksFull(filteredQuery2b, 1004)
           .expectLimboDocs(doc1.key)
           .expectEnqueuedLimboDocs(doc2.key)
+      );
+    }
+  );
+
+  specTest(
+    'A limbo resolution for a document should be removed from the queue when the last query listen stops',
+    [],
+    () => {
+      const doc1 = doc('collection1/doc', 1000, { key: 1 });
+      const fullQuery1 = query('collection1');
+      const filteredQuery1 = query('collection1', filter('key', '==', 1));
+
+      const doc2 = doc('collection2/doc', 1000, { key: 2 });
+      const fullQuery2 = query('collection2');
+      const filteredQuery2a = query('collection2', filter('key', '==', 2));
+      const filteredQuery2b = query('collection2', filter('key', '>=', 2));
+
+      return (
+        spec()
+          .withGCEnabled(false)
+          .withMaxConcurrentLimboResolutions(1)
+
+          // Max out the number of active limbo resolutions.
+          .userListens(fullQuery1)
+          .watchAcksFull(fullQuery1, 1000, doc1)
+          .expectEvents(fullQuery1, { added: [doc1] })
+          .userUnlistens(fullQuery1)
+          .userListens(filteredQuery1)
+          .expectEvents(filteredQuery1, { added: [doc1], fromCache: true })
+          .watchAcksFull(filteredQuery1, 1001)
+          .expectLimboDocs(doc1.key)
+
+          // Enqueue a limbo resolution for doc2.
+          .userListens(fullQuery2)
+          .watchAcksFull(fullQuery2, 1002, doc2)
+          .expectEvents(fullQuery2, { added: [doc2] })
+          .userUnlistens(fullQuery2)
+          .userListens(filteredQuery2a)
+          .expectEvents(filteredQuery2a, { added: [doc2], fromCache: true })
+          .watchAcksFull(filteredQuery2a, 1003)
+          .expectLimboDocs(doc1.key)
+          .expectEnqueuedLimboDocs(doc2.key)
+
+          // Start another query that puts doc2 into limbo again.
+          .userListens(filteredQuery2b)
+          .expectEvents(filteredQuery2b, { added: [doc2], fromCache: true })
+          .watchAcksFull(filteredQuery2b, 1004)
+          .expectLimboDocs(doc1.key)
+          .expectEnqueuedLimboDocs(doc2.key)
+
+          // Stop one of the queries that enqueued a limbo resolution for doc2;
+          // verify that doc2 is not removed from the limbo resolution queue.
+          .userUnlistens(filteredQuery2b)
+          .expectLimboDocs(doc1.key)
+          .expectEnqueuedLimboDocs(doc2.key)
+
+          // Stop the other query that enqueued a limbo resolution for doc2;
+          // verify that doc2 *is* removed from the limbo resolution queue.
+          .userUnlistens(filteredQuery2a)
+          .expectLimboDocs(doc1.key)
+          .expectEnqueuedLimboDocs()
       );
     }
   );

--- a/packages/firestore/test/unit/specs/limbo_spec.test.ts
+++ b/packages/firestore/test/unit/specs/limbo_spec.test.ts
@@ -997,7 +997,7 @@ describeSpec('Limbo Documents:', [], () => {
         spec()
           .withGCEnabled(false)
 
-          // Start a limbo resolution listen for a document.
+          // Start a limbo resolution listen for a document (doc1).
           .userListens(query1)
           .watchAcksFull(query1, 1000, doc1)
           .expectEvents(query1, { added: [doc1] })
@@ -1008,7 +1008,8 @@ describeSpec('Limbo Documents:', [], () => {
           .expectLimboDocs(doc1.key)
           .expectEnqueuedLimboDocs()
 
-          // Put the same document into limbo in a different query.
+          // Put doc1 into limbo in a different query; verify that another limbo
+          // resolution is neither started nor enqueued.
           .userListens(filteredQuery2)
           .expectEvents(filteredQuery2, { added: [doc1], fromCache: true })
           .watchAcksFull(filteredQuery2, 1002)
@@ -1045,7 +1046,7 @@ describeSpec('Limbo Documents:', [], () => {
           .watchAcksFull(filteredQuery1, 1001)
           .expectLimboDocs(doc1.key)
 
-          // Start a limbo resolution listen for a different document.
+          // Start a limbo resolution listen for a different document (doc2).
           .userListens(query2)
           .watchAcksFull(query2, 1002, doc2)
           .expectEvents(query2, { added: [doc2] })
@@ -1056,9 +1057,8 @@ describeSpec('Limbo Documents:', [], () => {
           .expectLimboDocs(doc1.key)
           .expectEnqueuedLimboDocs(doc2.key)
 
-          // Put the the "different" document into limbo in a different query
-          // and verify that it's not added to the limbo resolution queue a
-          // second time.
+          // Put doc2 into limbo in a different query and verify that it's not
+          // added to the limbo resolution queue again.
           .userListens(filteredQuery3)
           .expectEvents(filteredQuery3, { added: [doc2], fromCache: true })
           .watchAcksFull(filteredQuery3, 1004)

--- a/packages/firestore/test/unit/specs/spec_test_runner.ts
+++ b/packages/firestore/test/unit/specs/spec_test_runner.ts
@@ -1008,31 +1008,13 @@ abstract class TestRunner {
   }
 
   private validateEnqueuedLimboDocs(): void {
-    let actualLimboDocs = new SortedSet<DocumentKey>(DocumentKey.comparator);
-    syncEngineGetEnqueuedLimboDocumentResolutions(this.syncEngine).forEach(
-      key => {
-        actualLimboDocs = actualLimboDocs.add(key);
-      }
-    );
-    let expectedLimboDocs = new SortedSet<DocumentKey>(DocumentKey.comparator);
-    this.expectedEnqueuedLimboDocs.forEach(key => {
-      expectedLimboDocs = expectedLimboDocs.add(key);
-    });
-    actualLimboDocs.forEach(key => {
-      expect(expectedLimboDocs.has(key)).to.equal(
-        true,
-        `Found enqueued limbo doc ${key.toString()}, but it was not in ` +
-          `the set of expected enqueued limbo documents ` +
-          `(${expectedLimboDocs.toString()})`
-      );
-    });
-    expectedLimboDocs.forEach(key => {
-      expect(actualLimboDocs.has(key)).to.equal(
-        true,
-        `Expected doc ${key.toString()} to be enqueued for limbo resolution, ` +
-          `but it was not in the queue (${actualLimboDocs.toString()})`
-      );
-    });
+    const actualLimboDocs = Array.from(
+      syncEngineGetEnqueuedLimboDocumentResolutions(this.syncEngine)
+    ).sort();
+    const expectedLimboDocs = Array.from(this.expectedEnqueuedLimboDocs, key =>
+      key.path.canonicalString()
+    ).sort();
+    expect(actualLimboDocs).to.deep.equal(expectedLimboDocs);
   }
 
   private async validateActiveTargets(): Promise<void> {

--- a/packages/firestore/test/unit/specs/spec_test_runner.ts
+++ b/packages/firestore/test/unit/specs/spec_test_runner.ts
@@ -1009,11 +1009,14 @@ abstract class TestRunner {
   private validateEnqueuedLimboDocs(): void {
     const actualLimboDocs = Array.from(
       syncEngineGetEnqueuedLimboDocumentResolutions(this.syncEngine)
-    ).sort();
+    );
     const expectedLimboDocs = Array.from(this.expectedEnqueuedLimboDocs, key =>
       key.path.canonicalString()
-    ).sort();
-    expect(actualLimboDocs).to.deep.equal(expectedLimboDocs);
+    );
+    expect(actualLimboDocs).to.have.members(
+      expectedLimboDocs,
+      'The set of enqueued limbo documents is incorrect'
+    );
   }
 
   private async validateActiveTargets(): Promise<void> {

--- a/packages/firestore/test/unit/specs/spec_test_runner.ts
+++ b/packages/firestore/test/unit/specs/spec_test_runner.ts
@@ -118,7 +118,6 @@ import { primitiveComparator } from '../../../src/util/misc';
 import { forEach, objectSize } from '../../../src/util/obj';
 import { ObjectMap } from '../../../src/util/obj_map';
 import { Deferred, sequence } from '../../../src/util/promise';
-import { SortedSet } from '../../../src/util/sorted_set';
 import {
   byteStringFromString,
   deletedDoc,


### PR DESCRIPTION
Fix a bug where enqueued limbo resolutions are left in the queue even after all targets that care about their resolutions are stopped. This erroneous behavior was found in and reported against the Android SDK (https://github.com/firebase/firebase-android-sdk/issues/2311) but also applies to the Web and iOS SDKs. This fix will be ported to those other SDKs. This bug was introduced when limbo resolution throttling was implemented almost a year ago (https://github.com/firebase/firebase-js-sdk/pull/2790).