### PR TITLE
Expose only public types from Auth exp

### DIFF
--- a/packages-exp/auth-exp/api-extractor.json
+++ b/packages-exp/auth-exp/api-extractor.json
@@ -1,5 +1,10 @@
 {
     "extends": "../../config/api-extractor.json",
     // Point it to your entry point d.ts file. 
-    "mainEntryPointFilePath": "<projectFolder>/dist/index.d.ts"
+    "mainEntryPointFilePath": "<projectFolder>/dist/esm5/index.d.ts",
+    "dtsRollup": {
+        "enabled": true,
+        "untrimmedFilePath": "<projectFolder>/dist/<unscopedPackageName>.d.ts",
+        "publicTrimmedFilePath": "<projectFolder>/dist/<unscopedPackageName>-public.d.ts"
+    }
 }

--- a/packages-exp/auth-exp/package.json
+++ b/packages-exp/auth-exp/package.json
@@ -17,7 +17,7 @@
     "lint:fix": "eslint --fix -c .eslintrc.js '**/*.ts' --ignore-path '../../.gitignore'",
     "build": "rollup -c && yarn api-report",
     "build:deps": "lerna run --scope @firebase/auth-exp --include-dependencies build",
-    "build:release": "rollup -c rollup.config.release.js",
+    "build:release": "rollup -c rollup.config.release.js && yarn api-report && yarn typings:public",
     "dev": "rollup -c -w",
     "test": "run-p lint test:all",
     "test:all": "run-p test:browser test:node",
@@ -31,7 +31,8 @@
     "api-report": "api-extractor run --local --verbose",
     "predoc": "node ../../scripts/exp/remove-exp.js temp",
     "doc": "api-documenter markdown --input temp --output docs",
-    "build:doc": "yarn build && yarn doc"
+    "build:doc": "yarn build && yarn doc",
+    "typings:public": "node ../../scripts/exp/use_typings.js ./dist/auth-exp-public.d.ts"
   },
   "peerDependencies": {
     "@firebase/app-exp": "0.x",

--- a/packages-exp/auth-exp/src/core/action_code_url.ts
+++ b/packages-exp/auth-exp/src/core/action_code_url.ts
@@ -23,7 +23,6 @@ import { _assert } from './util/assert';
  * Enums for fields in URL query string.
  *
  * @enum {string}
- * @internal
  */
 const enum QueryField {
   API_KEY = 'apiKey',
@@ -38,7 +37,6 @@ const enum QueryField {
  * Maps the mode string in action code URL to Action Code Info operation.
  *
  * @param mode
- * @internal
  */
 function parseMode(mode: string | null): externs.ActionCodeOperation | null {
   switch (mode) {
@@ -63,7 +61,6 @@ function parseMode(mode: string | null): externs.ActionCodeOperation | null {
  * Helper to parse FDL links
  *
  * @param url
- * @internal
  */
 function parseDeepLink(url: string): string {
   const uri = new URL(url);

--- a/packages-exp/auth-exp/src/core/credentials/oauth.ts
+++ b/packages-exp/auth-exp/src/core/credentials/oauth.ts
@@ -30,9 +30,6 @@ import { AuthCredential } from './auth_credential';
 
 const IDP_REQUEST_URI = 'http://localhost';
 
-/**
- * @internal
- */
 export interface OAuthCredentialParams {
   // OAuth 2 uses either id token or access token
   idToken?: string | null;

--- a/packages-exp/auth-exp/src/core/credentials/phone.ts
+++ b/packages-exp/auth-exp/src/core/credentials/phone.ts
@@ -28,7 +28,6 @@ import { Auth } from '../../model/auth';
 import { IdTokenResponse } from '../../model/id_token';
 import { AuthCredential } from './auth_credential';
 
-/** @internal */
 export interface PhoneAuthCredentialParameters {
   verificationId?: string;
   verificationCode?: string;

--- a/packages-exp/auth-exp/src/core/strategies/credential.ts
+++ b/packages-exp/auth-exp/src/core/strategies/credential.ts
@@ -27,7 +27,6 @@ import { _reauthenticate } from '../user/reauthenticate';
 import { UserCredentialImpl } from '../user/user_credential_impl';
 import { _castAuth } from '../auth/auth_impl';
 
-/** @internal */
 export async function _signInWithCredential(
   auth: Auth,
   credential: AuthCredential,

--- a/packages-exp/auth-exp/src/core/strategies/idp.ts
+++ b/packages-exp/auth-exp/src/core/strategies/idp.ts
@@ -31,7 +31,6 @@ import { _assert } from '../util/assert';
 import { _signInWithCredential } from './credential';
 import { AuthErrorCode } from '../errors';
 
-/** @internal */
 export interface IdpTaskParams {
   auth: Auth;
   requestUri: string;
@@ -43,10 +42,8 @@ export interface IdpTaskParams {
   bypassAuthState?: boolean;
 }
 
-/** @internal */
 export type IdpTask = (params: IdpTaskParams) => Promise<UserCredential>;
 
-/** @internal */
 class IdpCredential extends AuthCredential {
   constructor(readonly params: IdpTaskParams) {
     super(externs.ProviderId.CUSTOM, externs.ProviderId.CUSTOM);
@@ -82,7 +79,6 @@ class IdpCredential extends AuthCredential {
   }
 }
 
-/** @internal */
 export function _signIn(params: IdpTaskParams): Promise<UserCredential> {
   return _signInWithCredential(
     params.auth,
@@ -91,7 +87,6 @@ export function _signIn(params: IdpTaskParams): Promise<UserCredential> {
   ) as Promise<UserCredential>;
 }
 
-/** @internal */
 export function _reauth(params: IdpTaskParams): Promise<UserCredential> {
   const { auth, user } = params;
   _assert(user, auth, AuthErrorCode.INTERNAL_ERROR);
@@ -102,7 +97,6 @@ export function _reauth(params: IdpTaskParams): Promise<UserCredential> {
   );
 }
 
-/** @internal */
 export async function _link(params: IdpTaskParams): Promise<UserCredential> {
   const { auth, user } = params;
   _assert(user, auth, AuthErrorCode.INTERNAL_ERROR);

--- a/packages-exp/auth-exp/src/core/user/account_info.ts
+++ b/packages-exp/auth-exp/src/core/user/account_info.ts
@@ -117,7 +117,6 @@ export function updatePassword(
   return updateEmailOrPassword(user as User, null, newPassword);
 }
 
-/** @internal */
 async function updateEmailOrPassword(
   user: User,
   email: string | null,

--- a/packages-exp/auth-exp/src/core/user/additional_user_info.ts
+++ b/packages-exp/auth-exp/src/core/user/additional_user_info.ts
@@ -23,7 +23,6 @@ import { UserCredential } from '../../model/user';
 /**
  * Parse the `AdditionalUserInfo` from the ID token response.
  *
- * @internal
  */
 export function _fromIdTokenResponse(
   idTokenResponse?: IdTokenResponse

--- a/packages-exp/auth-exp/src/core/user/id_token_result.ts
+++ b/packages-exp/auth-exp/src/core/user/id_token_result.ts
@@ -94,7 +94,6 @@ function secondsStringToMilliseconds(seconds: string): number {
   return Number(seconds) * 1000;
 }
 
-/** @internal */
 export function _parseToken(token: string): externs.ParsedToken | null {
   const [algorithm, payload, signature] = token.split('.');
   if (
@@ -121,8 +120,6 @@ export function _parseToken(token: string): externs.ParsedToken | null {
 
 /**
  * Extract expiresIn TTL from a token by subtracting the expiration from the issuance.
- *
- * @internal
  */
 export function _tokenExpiresIn(token: string): number {
   const parsedToken = _parseToken(token);

--- a/packages-exp/auth-exp/src/core/user/link_unlink.ts
+++ b/packages-exp/auth-exp/src/core/user/link_unlink.ts
@@ -59,7 +59,6 @@ export async function unlink(
   return user;
 }
 
-/** @internal */
 export async function _link(
   user: User,
   credential: AuthCredential,
@@ -77,7 +76,6 @@ export async function _link(
   );
 }
 
-/** @internal */
 export async function _assertLinkedStatus(
   expected: boolean,
   user: User,

--- a/packages-exp/auth-exp/src/core/user/token_manager.ts
+++ b/packages-exp/auth-exp/src/core/user/token_manager.ts
@@ -27,8 +27,6 @@ import { _tokenExpiresIn } from './id_token_result';
 /**
  * The number of milliseconds before the official expiration time of a token
  * to refresh that token, to provide a buffer for RPCs to complete.
- *
- * @internal
  */
 export const enum Buffer {
   TOKEN_REFRESH = 30_000

--- a/packages-exp/auth-exp/src/core/util/resolver.ts
+++ b/packages-exp/auth-exp/src/core/util/resolver.ts
@@ -26,8 +26,6 @@ import { _getInstance } from './instantiator';
  * Chooses a popup/redirect resolver to use. This prefers the override (which
  * is directly passed in), and falls back to the property set on the auth
  * object. If neither are available, this function errors w/ an argument error.
- *
- * @internal
  */
 export function _withDefaultResolver(
   auth: Auth,

--- a/packages-exp/auth-exp/src/model/application_verifier.ts
+++ b/packages-exp/auth-exp/src/model/application_verifier.ts
@@ -17,8 +17,9 @@
 
 import * as externs from '@firebase/auth-types-exp';
 
-/** @internal */
 export interface ApplicationVerifier extends externs.ApplicationVerifier {
-  /** @internal */
+  /**
+   * @internal
+   */
   _reset(): void;
 }

--- a/packages-exp/auth-exp/src/model/auth.ts
+++ b/packages-exp/auth-exp/src/model/auth.ts
@@ -22,17 +22,12 @@ import { AuthErrorCode, AuthErrorParams } from '../core/errors';
 import { PopupRedirectResolver } from './popup_redirect';
 import { User } from './user';
 
-/** @internal */
 export type AppName = string;
-/** @internal */
 export type ApiKey = string;
-/** @internal */
 export type AuthDomain = string;
 
-/** @internal */
 export interface ConfigInternal extends externs.Config {
   /**
-   * @internal
    * @readonly
    */
   emulator?: {
@@ -40,58 +35,36 @@ export interface ConfigInternal extends externs.Config {
   };
 }
 
-/** @internal */
 export interface Auth extends externs.Auth {
-  /** @internal */
   currentUser: externs.User | null;
-  /** @internal */
   _canInitEmulator: boolean;
-  /** @internal */
   _isInitialized: boolean;
-  /** @internal */
   _initializationPromise: Promise<void> | null;
-  /** @internal */
   _updateCurrentUser(user: User | null): Promise<void>;
 
-  /** @internal */
   _onStorageEvent(): void;
 
-  /** @internal */
   _notifyListenersIfCurrent(user: User): void;
-  /** @internal */
   _persistUserIfCurrent(user: User): Promise<void>;
-  /** @internal */
   _setRedirectUser(
     user: User | null,
     popupRedirectResolver?: externs.PopupRedirectResolver
   ): Promise<void>;
-  /** @internal */
   _redirectUserForId(id: string): Promise<User | null>;
-  /** @internal */
   _popupRedirectResolver: PopupRedirectResolver | null;
-  /** @internal */
   _key(): string;
-  /** @internal */
   _startProactiveRefresh(): void;
-  /** @internal */
   _stopProactiveRefresh(): void;
   _getPersistence(): string;
 
-  /** @internal */
   readonly name: AppName;
-  /** @internal */
   readonly config: ConfigInternal;
-  /** @internal */
   languageCode: string | null;
-  /** @internal */
   tenantId: string | null;
-  /** @internal */
   readonly settings: externs.AuthSettings;
   _errorFactory: ErrorFactory<AuthErrorCode, AuthErrorParams>;
 
-  /** @internal */
   useDeviceLanguage(): void;
-  /** @internal */
   signOut(): Promise<void>;
 }
 

--- a/packages-exp/auth-exp/src/model/id_token.ts
+++ b/packages-exp/auth-exp/src/model/id_token.ts
@@ -22,14 +22,12 @@ import { PhoneOrOauthTokenResponse } from '../api/authentication/mfa';
 /**
  * Raw encoded JWT
  *
- * @internal
  */
 export type IdToken = string;
 
 /**
  * Raw parsed JWT
  *
- * @internal
  */
 export interface ParsedIdToken {
   iss: string;
@@ -51,7 +49,6 @@ export interface ParsedIdToken {
 /**
  * IdToken as returned by the API
  *
- * @internal
  */
 export interface IdTokenResponse {
   localId: string;
@@ -72,7 +69,6 @@ export interface IdTokenResponse {
 /**
  * The possible types of the `IdTokenResponse`
  *
- * @internal
  */
 export const enum IdTokenResponseKind {
   CreateAuthUri = 'identitytoolkit#CreateAuthUriResponse',
@@ -91,9 +87,6 @@ export const enum IdTokenResponseKind {
   VerifyPassword = 'identitytoolkit#VerifyPasswordResponse'
 }
 
-/**
- * @internal
- */
 export interface TaggedWithTokenResponse {
   _tokenResponse?: PhoneOrOauthTokenResponse;
 }

--- a/packages-exp/auth-exp/src/model/popup_redirect.ts
+++ b/packages-exp/auth-exp/src/model/popup_redirect.ts
@@ -21,24 +21,20 @@ import { FirebaseError } from '@firebase/util';
 import { AuthPopup } from '../platform_browser/util/popup';
 import { Auth } from './auth';
 
-/** @internal */
 export const enum EventFilter {
   POPUP,
   REDIRECT
 }
 
-/** @internal */
 export const enum GapiOutcome {
   ACK = 'ACK',
   ERROR = 'ERROR'
 }
 
-/** @internal */
 export interface GapiAuthEvent extends gapi.iframes.Message {
   authEvent: AuthEvent;
 }
 
-/** @internal */
 export const enum AuthEventType {
   LINK_VIA_POPUP = 'linkViaPopup',
   LINK_VIA_REDIRECT = 'linkViaRedirect',
@@ -50,13 +46,11 @@ export const enum AuthEventType {
   VERIFY_APP = 'verifyApp'
 }
 
-/** @internal */
 export interface AuthEventError extends Error {
   code: string; // in the form of auth/${AuthErrorCode}
   message: string;
 }
 
-/** @internal */
 export interface AuthEvent {
   type: AuthEventType;
   eventId: string | null;
@@ -67,7 +61,6 @@ export interface AuthEvent {
   error?: AuthEventError;
 }
 
-/** @internal */
 export interface AuthEventConsumer {
   readonly filter: AuthEventType[];
   eventId: string | null;
@@ -75,31 +68,25 @@ export interface AuthEventConsumer {
   onError(error: FirebaseError): unknown;
 }
 
-/** @internal */
 export interface EventManager {
   registerConsumer(authEventConsumer: AuthEventConsumer): void;
   unregisterConsumer(authEventConsumer: AuthEventConsumer): void;
 }
 
-/** @internal */
 export interface PopupRedirectResolver extends externs.PopupRedirectResolver {
-  /** @internal */
   _initialize(auth: Auth): Promise<EventManager>;
-  /** @internal */
   _openPopup(
     auth: Auth,
     provider: externs.AuthProvider,
     authType: AuthEventType,
     eventId?: string
   ): Promise<AuthPopup>;
-  /** @internal */
   _openRedirect(
     auth: Auth,
     provider: externs.AuthProvider,
     authType: AuthEventType,
     eventId?: string
   ): Promise<never>;
-  /** @internal */
   _isIframeWebStorageSupported(
     auth: Auth,
     cb: (support: boolean) => unknown

--- a/packages-exp/auth-exp/src/model/user.ts
+++ b/packages-exp/auth-exp/src/model/user.ts
@@ -25,12 +25,10 @@ import { UserMetadata } from '../core/user/user_metadata';
 import { Auth } from './auth';
 import { IdTokenResponse, TaggedWithTokenResponse } from './id_token';
 
-/** @internal */
 export type MutableUserInfo = {
   -readonly [K in keyof externs.UserInfo]: externs.UserInfo[K];
 };
 
-/** @internal */
 export interface UserParameters {
   uid: string;
   auth: Auth;
@@ -48,72 +46,44 @@ export interface UserParameters {
   lastLoginAt?: string | null;
 }
 
-/** @internal */
 export interface User extends externs.User {
-  /** @internal */
   displayName: string | null;
-  /** @internal */
   email: string | null;
-  /** @internal */
   phoneNumber: string | null;
-  /** @internal */
   photoURL: string | null;
 
-  /** @internal */
   auth: Auth;
-  /** @internal  */
   providerId: externs.ProviderId.FIREBASE;
-  /** @internal */
   refreshToken: string;
-  /** @internal */
   emailVerified: boolean;
-  /** @internal */
   tenantId: string | null;
-  /** @internal */
   providerData: MutableUserInfo[];
-  /** @internal */
   metadata: UserMetadata;
 
-  /** @internal */
   stsTokenManager: StsTokenManager;
-  /** @internal */
   _redirectEventId?: string;
 
-  /** @internal */
   _updateTokensIfNecessary(
     response: IdTokenResponse | FinalizeMfaResponse,
     reload?: boolean
   ): Promise<void>;
 
-  /** @internal */
   _assign(user: User): void;
-  /** @internal */
   _clone(): User;
-  /** @internal */
   _onReload: (cb: NextFn<APIUserInfo>) => void;
-  /** @internal */
   _notifyReloadListener: NextFn<APIUserInfo>;
-  /** @internal */
   _startProactiveRefresh: () => void;
-  /** @internal */
   _stopProactiveRefresh: () => void;
 
-  /** @internal */
   getIdToken(forceRefresh?: boolean): Promise<string>;
-  /** @internal */
   getIdTokenResult(forceRefresh?: boolean): Promise<externs.IdTokenResult>;
-  /** @internal */
   reload(): Promise<void>;
-  /** @internal */
   delete(): Promise<void>;
-  /** @internal */
   toJSON(): PersistedBlob;
 }
 
-/** @internal */
 export interface UserCredential
   extends externs.UserCredential,
     TaggedWithTokenResponse {
-  /** @internal */
   user: User;
 }

--- a/packages-exp/auth-exp/src/platform_browser/messagechannel/receiver.ts
+++ b/packages-exp/auth-exp/src/platform_browser/messagechannel/receiver.ts
@@ -28,7 +28,6 @@ import { _allSettled } from './promise';
 /**
  * Interface class for receiving messages.
  *
- * @internal
  */
 export class Receiver {
   private static readonly receivers: Receiver[] = [];
@@ -78,7 +77,6 @@ export class Receiver {
    *
    * @param event - The MessageEvent.
    *
-   * @internal
    */
   private async handleEvent<
     T extends _ReceiverResponse,
@@ -118,7 +116,6 @@ export class Receiver {
    * @param eventType - Event name to subscribe to.
    * @param eventHandler - The event handler which should receive the events.
    *
-   * @internal
    */
   _subscribe<T extends _ReceiverResponse, S extends _SenderRequest>(
     eventType: _EventType,
@@ -141,7 +138,6 @@ export class Receiver {
    * @param eventType - Event name to unsubscribe from.
    * @param eventHandler - Optinoal event handler, if none provided, unsubscribe all handlers on this event.
    *
-   * @internal
    */
   _unsubscribe<T extends _ReceiverResponse, S extends _SenderRequest>(
     eventType: _EventType,

--- a/packages-exp/auth-exp/src/platform_browser/messagechannel/sender.ts
+++ b/packages-exp/auth-exp/src/platform_browser/messagechannel/sender.ts
@@ -39,7 +39,6 @@ function generateEventId(prefix = '', digits = 20): string {
 /**
  * Interface for sending messages and waiting for a completion response.
  *
- * @internal
  */
 export class Sender {
   private readonly handlers = new Set<MessageHandler>();

--- a/packages-exp/auth-exp/src/platform_browser/persistence/indexed_db.ts
+++ b/packages-exp/auth-exp/src/platform_browser/persistence/indexed_db.ts
@@ -56,7 +56,6 @@ interface DBObject {
  *
  * Unfortunately we can't cleanly extend Promise<T> since promises are not callable in ES6
  *
- * @internal
  */
 class DBPromise<T> {
   constructor(private readonly request: IDBRequest) {}
@@ -79,19 +78,16 @@ function getObjectStore(db: IDBDatabase, isReadWrite: boolean): IDBObjectStore {
     .objectStore(DB_OBJECTSTORE_NAME);
 }
 
-/** @internal */
 export async function _clearDatabase(db: IDBDatabase): Promise<void> {
   const objectStore = getObjectStore(db, true);
   return new DBPromise<void>(objectStore.clear()).toPromise();
 }
 
-/** @internal */
 export function _deleteDatabase(): Promise<void> {
   const request = indexedDB.deleteDatabase(DB_NAME);
   return new DBPromise<void>(request).toPromise();
 }
 
-/** @internal */
 export function _openDatabase(): Promise<IDBDatabase> {
   const request = indexedDB.open(DB_NAME, DB_VERSION);
   return new Promise((resolve, reject) => {
@@ -126,7 +122,6 @@ export function _openDatabase(): Promise<IDBDatabase> {
   });
 }
 
-/** @internal */
 export async function _putObject(
   db: IDBDatabase,
   key: string,
@@ -162,9 +157,7 @@ function deleteObject(db: IDBDatabase, key: string): Promise<void> {
   return new DBPromise<void>(request).toPromise();
 }
 
-/** @internal */
 export const _POLLING_INTERVAL_MS = 800;
-/** @internal */
 export const _TRANSACTION_RETRY_COUNT = 3;
 
 class IndexedDBLocalPersistence implements Persistence {

--- a/packages-exp/auth-exp/src/platform_browser/popup_redirect.ts
+++ b/packages-exp/auth-exp/src/platform_browser/popup_redirect.ts
@@ -44,21 +44,18 @@ import { _getRedirectResult } from './strategies/redirect';
 /**
  * URL for Authentication widget which will initiate the OAuth handshake
  *
- * @internal
  */
 const WIDGET_PATH = '__/auth/handler';
 
 /**
  * URL for emulated environment
  *
- * @internal
  */
 const EMULATOR_WIDGET_PATH = 'emulator/auth/handler';
 
 /**
  * The special web storage event
  *
- * @internal
  */
 const WEB_STORAGE_SUPPORT_KEY = 'webStorageSupport';
 

--- a/packages-exp/auth-exp/src/platform_browser/strategies/phone.ts
+++ b/packages-exp/auth-exp/src/platform_browser/strategies/phone.ts
@@ -156,7 +156,6 @@ export async function reauthenticateWithPhoneNumber(
 /**
  * Returns a verification ID to be used in conjunction with the SMS code that is sent.
  *
- * @internal
  */
 export async function _verifyPhoneNumber(
   auth: Auth,

--- a/packages-exp/auth-exp/src/platform_browser/strategies/popup.ts
+++ b/packages-exp/auth-exp/src/platform_browser/strategies/popup.ts
@@ -35,7 +35,6 @@ import { AbstractPopupRedirectOperation } from './abstract_popup_redirect_operat
 
 /*
  * The event timeout is the same on mobile and desktop, no need for Delay.
- * @internal
  */
 export const enum _Timeout {
   AUTH_EVENT = 2000
@@ -193,7 +192,6 @@ export async function linkWithPopup(
  * Popup event manager. Handles the popup's entire lifecycle; listens to auth
  * events
  *
- * @internal
  */
 class PopupOperation extends AbstractPopupRedirectOperation {
   // Only one popup is ever shown at once. The lifecycle of the current popup

--- a/packages-exp/auth-exp/src/platform_browser/strategies/redirect.ts
+++ b/packages-exp/auth-exp/src/platform_browser/strategies/redirect.ts
@@ -259,7 +259,6 @@ export async function _getRedirectResult(
   return result;
 }
 
-/** @internal */
 async function prepareUserForRedirect(user: User): Promise<string> {
   const eventId = _generateEventId(`${user.uid}:::`);
   user._redirectEventId = eventId;
@@ -342,7 +341,6 @@ class RedirectAction extends AbstractPopupRedirectOperation {
   cleanUp(): void {}
 }
 
-/** @internal */
 export function _clearOutcomes(): void {
   redirectOutcomeMap.clear();
 }


### PR DESCRIPTION
1. Create a rollup d.ts file that only contains public types. Fixes https://github.com/firebase/firebase-js-sdk/issues/4392
2. Remove unnecessary `@internal` annotations. `@internal` is only needed to hide members of public API, e.g. to hide internal methods of a public class. If something is not part of the API, there is no need to annotate it.