### PR TITLE
Fill out storage bucket url param

### DIFF
--- a/common/api-review/storage.api.md
+++ b/common/api-review/storage.api.md
@@ -4,7 +4,7 @@
 
 ```ts
 
-import { FirebaseApp } from '@firebase/app';
+import { FirebaseApp } from '@firebase/app-types';
 import { FirebaseStorageError } from '@firebase/storage-types/exp';
 import { FullMetadata } from '@firebase/storage-types/exp';
 import { ListOptions } from '@firebase/storage-types/exp';
@@ -33,7 +33,7 @@ export function getDownloadURL(ref: StorageReference): Promise<string>;
 export function getMetadata(ref: StorageReference): Promise<FullMetadata>;
 
 // @public
-export function getStorage(app: FirebaseApp, url?: string): StorageService;
+export function getStorage(app: FirebaseApp, bucketUrl?: string): StorageService;
 
 // @public
 export function list(ref: StorageReference, options?: ListOptions): Promise<ListResult>;

--- a/packages/storage/exp/index.ts
+++ b/packages/storage/exp/index.ts
@@ -294,15 +294,22 @@ const STORAGE_TYPE = 'storage-exp';
  * Gets a Firebase StorageService instance for the given Firebase app.
  * @public
  * @param app - Firebase app to get Storage instance for.
+ * @param bucketUrl - The gs:// url to your Firebase Storage Bucket.
+ * If not passed, uses the app's default Storage Bucket.
  * @returns A Firebase StorageService instance.
  */
-export function getStorage(app: FirebaseApp, url?: string): StorageService {
+export function getStorage(
+  app: FirebaseApp,
+  bucketUrl?: string
+): StorageService {
   // Dependencies
   const storageProvider: Provider<'storage-exp'> = _getProvider(
     app,
     STORAGE_TYPE
   );
-  const storageInstance = storageProvider.getImmediate({ identifier: url });
+  const storageInstance = storageProvider.getImmediate({
+    identifier: bucketUrl
+  });
   return storageInstance;
 }
 


### PR DESCRIPTION
Add jsdoc description and change name from `url` to `bucketUrl` to make it more clear. (FYI the param name in the original API is `url`).

Fixes https://github.com/firebase/firebase-js-sdk/issues/4407