### PR TITLE
Add private field to analytics-exp

### DIFF
--- a/packages-exp/analytics-exp/package.json
+++ b/packages-exp/analytics-exp/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@firebase/analytics-exp",
   "version": "0.0.900",
+  "private": true,
   "description": "A analytics package for new firebase packages",
   "author": "Firebase <firebase-support@google.com> (https://firebase.google.com/)",
   "main": "dist/index.cjs.js",


### PR DESCRIPTION
This should fix the canary release workflow. All the other exp packages are set to private.