### PR TITLE
Send Analytics measurement ID with script tag request

### DIFF
--- a/packages/analytics/index.test.ts
+++ b/packages/analytics/index.test.ts
@@ -93,7 +93,12 @@ describe('FirebaseAnalytics instance tests', () => {
       );
     });
     it('Warns if config has no apiKey but does have a measurementId', () => {
+      // Since this is a warning and doesn't block the rest of initialization
+      // all the async stuff needs to be stubbed and cleaned up.
       const warnStub = stub(console, 'warn');
+      const docStub = stub(document, 'createElement');
+      stubFetch(200, { measurementId: fakeMeasurementId });
+      stubIdbOpen();
       const app = getFakeApp({
         appId: fakeAppParams.appId,
         measurementId: fakeMeasurementId
@@ -104,6 +109,11 @@ describe('FirebaseAnalytics instance tests', () => {
         `Falling back to the measurement ID ${fakeMeasurementId}`
       );
       warnStub.restore();
+      docStub.restore();
+      fetchStub.restore();
+      idbOpenStub.restore();
+      delete window['gtag'];
+      delete window['dataLayer'];
     });
     it('Throws if creating an instance with already-used appId', () => {
       const app = getFakeApp(fakeAppParams);
@@ -210,6 +220,7 @@ describe('FirebaseAnalytics instance tests', () => {
     afterEach(() => {
       delete window['gtag'];
       delete window['dataLayer'];
+      removeGtagScript();
       fetchStub.restore();
       clock.restore();
       warnStub.restore();

--- a/packages/analytics/src/factory.ts
+++ b/packages/analytics/src/factory.ts
@@ -29,12 +29,7 @@ import {
   setUserProperties,
   setAnalyticsCollectionEnabled
 } from './functions';
-import {
-  insertScriptTag,
-  getOrCreateDataLayer,
-  wrapOrCreateGtag,
-  findGtagScriptOnPage
-} from './helpers';
+import { getOrCreateDataLayer, wrapOrCreateGtag } from './helpers';
 import { AnalyticsError, ERROR_FACTORY } from './errors';
 import { FirebaseApp } from '@firebase/app-types';
 import { FirebaseInstallations } from '@firebase/installations-types';
@@ -61,9 +56,9 @@ let initializationPromisesMap: {
  * wait on all these to be complete in order to determine if it can selectively
  * wait for only certain initialization (FID) promises or if it must wait for all.
  */
-let dynamicConfigPromisesList: Array<Promise<
-  DynamicConfig | MinimalDynamicConfig
->> = [];
+let dynamicConfigPromisesList: Array<
+  Promise<DynamicConfig | MinimalDynamicConfig>
+> = [];
 
 /**
  * Maps fetched measurementIds to appId. Populated when the app's dynamic config
@@ -202,10 +197,6 @@ export function factory(
     // Steps here should only be done once per page: creation or wrapping
     // of dataLayer and global gtag function.
 
-    // Detect if user has already put the gtag <script> tag on this page.
-    if (!findGtagScriptOnPage()) {
-      insertScriptTag(dataLayerName);
-    }
     getOrCreateDataLayer(dataLayerName);
 
     const { wrappedGtag, gtagCore } = wrapOrCreateGtag(
@@ -227,7 +218,8 @@ export function factory(
     dynamicConfigPromisesList,
     measurementIdToAppId,
     installations,
-    gtagCoreFunction
+    gtagCoreFunction,
+    dataLayerName
   );
 
   const analyticsInstance: FirebaseAnalyticsInternal = {

--- a/packages/analytics/src/helpers.test.ts
+++ b/packages/analytics/src/helpers.test.ts
@@ -56,10 +56,11 @@ describe('Gtag wrapping functions', () => {
 
   it('insertScriptIfNeeded inserts script tag', () => {
     expect(findGtagScriptOnPage()).to.be.null;
-    insertScriptTag('customDataLayerName');
+    insertScriptTag('customDataLayerName', fakeMeasurementId);
     const scriptTag = findGtagScriptOnPage();
     expect(scriptTag).to.not.be.null;
     expect(scriptTag!.src).to.contain(`l=customDataLayerName`);
+    expect(scriptTag!.src).to.contain(`id=${fakeMeasurementId}`);
   });
 
   describe('wrapOrCreateGtag() when user has not previously inserted a gtag script tag on this page', () => {

--- a/packages/analytics/src/helpers.ts
+++ b/packages/analytics/src/helpers.ts
@@ -31,11 +31,12 @@ import { logger } from './logger';
  * Inserts gtag script tag into the page to asynchronously download gtag.
  * @param dataLayerName Name of datalayer (most often the default, "_dataLayer").
  */
-export function insertScriptTag(dataLayerName: string): void {
+export function insertScriptTag(
+  dataLayerName: string,
+  measurementId: string
+): void {
   const script = document.createElement('script');
-  // We are not providing an analyticsId in the URL because it would trigger a `page_view`
-  // without fid. We will initialize ga-id using gtag (config) command together with fid.
-  script.src = `${GTAG_URL}?l=${dataLayerName}`;
+  script.src = `${GTAG_URL}?l=${dataLayerName}&id=${measurementId}`;
   script.async = true;
   document.head.appendChild(script);
 }

--- a/packages/analytics/src/initialize-ids.test.ts
+++ b/packages/analytics/src/initialize-ids.test.ts
@@ -28,6 +28,7 @@ import { DynamicConfig } from '@firebase/analytics-types';
 import { FirebaseInstallations } from '@firebase/installations-types';
 import { FirebaseApp } from '@firebase/app-types';
 import { Deferred } from '@firebase/util';
+import { removeGtagScript } from '../testing/gtag-script-util';
 
 const fakeMeasurementId = 'abcd-efgh-ijkl';
 const fakeFid = 'fid-1234-zyxw';
@@ -60,6 +61,7 @@ describe('initializeIds()', () => {
   });
   afterEach(() => {
     fetchStub.restore();
+    removeGtagScript();
   });
   it('gets FID and measurement ID and calls gtag config with them', async () => {
     stubFetch();
@@ -68,7 +70,8 @@ describe('initializeIds()', () => {
       dynamicPromisesList,
       measurementIdToAppId,
       installations,
-      gtagStub
+      gtagStub,
+      'dataLayer'
     );
     expect(gtagStub).to.be.calledWith(GtagCommand.CONFIG, fakeMeasurementId, {
       'firebase_id': fakeFid,
@@ -83,7 +86,8 @@ describe('initializeIds()', () => {
       dynamicPromisesList,
       measurementIdToAppId,
       installations,
-      gtagStub
+      gtagStub,
+      'dataLayer'
     );
     const dynamicPromiseResult = await dynamicPromisesList[0];
     expect(dynamicPromiseResult.measurementId).to.equal(fakeMeasurementId);
@@ -96,7 +100,8 @@ describe('initializeIds()', () => {
       dynamicPromisesList,
       measurementIdToAppId,
       installations,
-      gtagStub
+      gtagStub,
+      'dataLayer'
     );
     expect(measurementIdToAppId[fakeMeasurementId]).to.equal(fakeAppId);
   });
@@ -108,7 +113,8 @@ describe('initializeIds()', () => {
       dynamicPromisesList,
       measurementIdToAppId,
       installations,
-      gtagStub
+      gtagStub,
+      'dataLayer'
     );
     expect(consoleStub.args[0][1]).to.include(fakeMeasurementId);
     expect(consoleStub.args[0][1]).to.include('old-measurement-id');


### PR DESCRIPTION
Confirmed with gtag team that including measurementId in initial script tag request does not trigger a page_view event. page_view is in fact triggered on first config call. Tested this out as well.

We now wait for measurementID to be fetched from the dynamic config endpoint, then insert the script tag.  All events sent with firebase.analytics() are still queued until after all initialization requests complete, so the delay shouldn't cause any problems?

This should prevent 2 downloads of gtag reported by users here: https://github.com/firebase/firebase-js-sdk/issues/2628 which causes a cluttered and confusing log when using the Google Analytics Debugger chrome extension.

I'm still not sure if the double download causes any functionality issues (I don't think so) but it seems to make it distracting and confusing when diagnosing other analytics problems.

(Observed results: There are 2 events sent, one is `user_engagement`, and one is `page_view`, they both seem to be sent properly with FID and are viewable in the Firebase console dashboard.)

I will make a separate PR for exp if this approach is good.