### PR TITLE
Fix version name lookup for exp packages

### DIFF
--- a/packages-exp/app-exp/src/api.test.ts
+++ b/packages-exp/app-exp/src/api.test.ts
@@ -215,7 +215,7 @@ describe('API tests', () => {
       const warnStub = stub(console, 'warn');
       const initialSize = _components.size;
 
-      registerVersion('@firebase/analytics', '1.2.3');
+      registerVersion('@firebase/analytics-exp', '1.2.3');
       expect(_components.get('fire-analytics-version')).to.exist;
       expect(_components.size).to.equal(initialSize + 1);
 

--- a/packages-exp/app-exp/src/constants.ts
+++ b/packages-exp/app-exp/src/constants.ts
@@ -17,15 +17,18 @@
 
 import { name as appName } from '../package.json';
 import { name as appCompatName } from '../../app-compat/package.json';
-import { name as analyticsName } from '../../../packages/analytics/package.json';
-import { name as authName } from '../../../packages/auth/package.json';
+import { name as analyticsName } from '../../../packages-exp/analytics-exp/package.json';
+import { name as authName } from '../../../packages-exp/auth-exp/package.json';
+import { name as authCompatName } from '../../../packages-exp/auth-compat-exp/package.json';
 import { name as databaseName } from '../../../packages/database/package.json';
 import { name as functionsName } from '../../../packages-exp/functions-exp/package.json';
 import { name as functionsCompatName } from '../../../packages-exp/functions-compat/package.json';
-import { name as installationsName } from '../../../packages/installations/package.json';
-import { name as messagingName } from '../../../packages/messaging/package.json';
-import { name as performanceName } from '../../../packages/performance/package.json';
-import { name as remoteConfigName } from '../../../packages/remote-config/package.json';
+import { name as installationsName } from '../../../packages-exp/installations-exp/package.json';
+import { name as installationsCompatName } from '../../../packages-exp/installations-compat/package.json';
+import { name as messagingName } from '../../../packages-exp/messaging-exp/package.json';
+import { name as performanceName } from '../../../packages-exp/performance-exp/package.json';
+import { name as remoteConfigName } from '../../../packages-exp/remote-config-exp/package.json';
+import { name as remoteConfigCompatName } from '../../../packages-exp/remote-config-compat/package.json';
 import { name as storageName } from '../../../packages/storage/package.json';
 import { name as firestoreName } from '../../../packages/firestore/package.json';
 import { name as packageName } from '../../../packages-exp/firebase-exp/package.json';
@@ -42,13 +45,16 @@ export const PLATFORM_LOG_STRING = {
   [appCompatName]: 'fire-core-compat',
   [analyticsName]: 'fire-analytics',
   [authName]: 'fire-auth',
+  [authCompatName]: 'fire-auth-compat',
   [databaseName]: 'fire-rtdb',
   [functionsName]: 'fire-fn',
   [functionsCompatName]: 'fire-fn-compat',
   [installationsName]: 'fire-iid',
+  [installationsCompatName]: 'fire-iid-compat',
   [messagingName]: 'fire-fcm',
   [performanceName]: 'fire-perf',
   [remoteConfigName]: 'fire-rc',
+  [remoteConfigCompatName]: 'fire-rc-compat',
   [storageName]: 'fire-gcs',
   [firestoreName]: 'fire-fst',
   'fire-js': 'fire-js', // Platform identifier for JS SDK.


### PR DESCRIPTION
Incorrect paths causing `registerVersion` to not find the correct platform logging string and trying to register library using its raw name, which has illegal characters.

Console warnings look like:
```
[2021-02-09T18:37:57.903Z]  @firebase/app: Unable to register library "@firebase/installations-exp" with version "0.0.900": library name "@firebase/installations-exp" contains illegal characters (whitespace or "/")
defaultLogHandler @ logger.ts:115
logger.ts:115 [2021-02-09T18:37:57.906Z]  @firebase/app: Unable to register library "@firebase/performance-exp" with version "0.0.900": library name "@firebase/performance-exp" contains illegal characters (whitespace or "/")
defaultLogHandler @ logger.ts:115
logger.ts:115 [2021-02-09T18:37:57.907Z]  @firebase/app: Unable to register library "@firebase/remote-config-exp" with version "0.0.900": library name "@firebase/remote-config-exp" contains illegal characters (whitespace or "/")
defaultLogHandler @ logger.ts:115
logger.ts:115 [2021-02-09T18:37:57.908Z]  @firebase/app: Unable to register library "@firebase/analytics-exp" with version "0.0.900": library name "@firebase/analytics-exp" contains illegal characters (whitespace or "/")
```