### PR TITLE
(de)serialize dates w/ ISO8601 (#683)

### DIFF
--- a/packages/functions/src/serializer.ts
+++ b/packages/functions/src/serializer.ts
@@ -51,6 +51,9 @@ export class Serializer {
     if (data === true || data === false) {
       return data;
     }
+    if (data instanceof Date) {
+      return data.toISOString();
+    }
     if (Object.prototype.toString.call(data) === '[object String]') {
       return data;
     }
@@ -94,6 +97,14 @@ export class Serializer {
     }
     if (typeof json === 'function' || typeof json === 'object') {
       return mapValues(json!, x => this.decode(x));
+    }
+    if (
+      typeof json === 'string' &&
+      /^(-?(?:[1-9][0-9]*)?[0-9]{4})-(1[0-2]|0[1-9])-(3[01]|0[1-9]|[12][0-9])T(2[0-3]|[01][0-9]):([0-5][0-9]):([0-5][0-9])(.[0-9]+)?(Z)?$/.test(
+        json
+      )
+    ) {
+      return new Date(json);
     }
     // Anything else is safe to return.
     return json;

--- a/packages/functions/test/serializer.test.ts
+++ b/packages/functions/test/serializer.test.ts
@@ -80,6 +80,18 @@ describe('Serializer', () => {
     expect(serializer.decode(1.2)).to.equal(1.2);
   });
 
+  it('encodes date', () => {
+    expect(serializer.encode(new Date('2021-02-10T13:26:37.977Z'))).to.equal(
+      '2021-02-10T13:26:37.977Z'
+    );
+  });
+
+  it('decodes date', () => {
+    expect(serializer.decode('2021-02-10T13:26:37.977Z')).to.deep.equal(
+      new Date('2021-02-10T13:26:37.977Z')
+    );
+  });
+
   it('encodes string', () => {
     expect(serializer.encode('hello')).to.equal('hello');
   });


### PR DESCRIPTION
There's been an issue (#683) open for a few years asking for serialization of dates for httpsCallables.
It seemed like something really easy to do, so I created this PR as a proposal for how we might consider doing it.


Encoding is done with `Date.toISOString`. JavaScript's `JSON.stringify` also uses `Date.toISOString` to encode Dates ([ref](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toJSON), [ref](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#description)). Decoding tests Strings against a RegEx that matches ISO 8601 strings.

It would be nice to support a more robust serialization that also supports Firestore data types (Timestamp, GeoPoint, Reference). Perhaps we could eventually use the same serialization format that the [Firestore REST API](https://firebase.google.com/docs/firestore/reference/rest/v1/Value) uses. I do think that would require more coordination efforts across both libs to deploy without breaking any compatibility.

Ideally, this change would be accompanied by a similar change on the `firebase-functions` repo.
However, it looks like the actual code for encoding/decoding `onCall` functions is actually private.
https://github.com/firebase/firebase-functions/blob/master/src/providers/https.ts#L377
https://github.com/firebase/firebase-functions/blob/master/src/providers/https.ts#L339
At least, that's what I understood from the comments on those functions.

For what it's worth, the existing implementation doesn't work with Date types at all. It converts them to `{ date: {} }`. I don't believe that merging this will break anything even if the `firebase-functions` isn't updated at the same time.