### PR TITLE
Add externs annotation to firebase-externs

### DIFF
--- a/packages/firebase/externs/firebase-externs.js
+++ b/packages/firebase/externs/firebase-externs.js
@@ -1,3 +1,5 @@
+/** @externs */
+
 /**
  * @license Copyright 2017 Google Inc.
  *


### PR DESCRIPTION
An internal change was requested (see cl/356656077), this makes it permanent and prevents that change from being overwritten next time the firebase library is imported to google3.