### PR TITLE
throw if initializeFirestore is called more than once

### DIFF
--- a/packages/firestore/src/exp/database.ts
+++ b/packages/firestore/src/exp/database.ts
@@ -120,7 +120,7 @@ export function initializeFirestore(
 
   if (provider.isInitialized()) {
     throw new FirestoreError(
-      Code.ALREADY_INITIALIZED,
+      Code.FAILED_PRECONDITION,
       'Firestore can only be initialized once per app.'
     );
   }

--- a/packages/firestore/src/exp/database.ts
+++ b/packages/firestore/src/exp/database.ts
@@ -116,11 +116,16 @@ export function initializeFirestore(
   app: FirebaseApp,
   settings: Settings
 ): FirebaseFirestore {
-  const firestore = _getProvider(
-    app,
-    'firestore-exp'
-  ).getImmediate() as FirebaseFirestore;
+  const provider = _getProvider(app, 'firestore-exp');
 
+  if (provider.isInitialized()) {
+    throw new FirestoreError(
+      Code.ALREADY_INITIALIZED,
+      'Firestore can only be initialized once per app.'
+    );
+  }
+
+  const firestore = provider.getImmediate() as FirebaseFirestore;
   if (
     settings.cacheSizeBytes !== undefined &&
     settings.cacheSizeBytes !== CACHE_SIZE_UNLIMITED &&

--- a/packages/firestore/src/lite/database.ts
+++ b/packages/firestore/src/lite/database.ts
@@ -181,11 +181,11 @@ export function initializeFirestore(
   app: FirebaseApp,
   settings: Settings
 ): FirebaseFirestore {
-  const provider = _getProvider(app, 'firestore-exp');
+  const provider = _getProvider(app, 'firestore/lite');
 
   if (provider.isInitialized()) {
     throw new FirestoreError(
-      Code.ALREADY_INITIALIZED,
+      Code.FAILED_PRECONDITION,
       'Firestore can only be initialized once per app.'
     );
   }

--- a/packages/firestore/src/lite/database.ts
+++ b/packages/firestore/src/lite/database.ts
@@ -181,10 +181,16 @@ export function initializeFirestore(
   app: FirebaseApp,
   settings: Settings
 ): FirebaseFirestore {
-  const firestore = _getProvider(
-    app,
-    'firestore/lite'
-  ).getImmediate() as FirebaseFirestore;
+  const provider = _getProvider(app, 'firestore-exp');
+
+  if (provider.isInitialized()) {
+    throw new FirestoreError(
+      Code.ALREADY_INITIALIZED,
+      'Firestore can only be initialized once per app.'
+    );
+  }
+
+  const firestore = provider.getImmediate() as FirebaseFirestore;
   firestore._setSettings(settings);
   return firestore;
 }

--- a/packages/firestore/src/util/error.ts
+++ b/packages/firestore/src/util/error.ts
@@ -117,6 +117,12 @@ export const Code = {
   ALREADY_EXISTS: 'already-exists' as FirestoreErrorCode,
 
   /**
+   * Calling initializeFirestore() after a Firestore instance has already been created for the app
+   * It can happen when initializeFirestore() is called more than once or after calling getFirestore().
+   */
+  ALREADY_INITIALIZED: 'already-initialized' as FirestoreErrorCode,
+
+  /**
    * The caller does not have permission to execute the specified operation.
    * PERMISSION_DENIED must not be used for rejections caused by exhausting
    * some resource (use RESOURCE_EXHAUSTED instead for those errors).

--- a/packages/firestore/src/util/error.ts
+++ b/packages/firestore/src/util/error.ts
@@ -117,12 +117,6 @@ export const Code = {
   ALREADY_EXISTS: 'already-exists' as FirestoreErrorCode,
 
   /**
-   * Calling initializeFirestore() after a Firestore instance has already been created for the app
-   * It can happen when initializeFirestore() is called more than once or after calling getFirestore().
-   */
-  ALREADY_INITIALIZED: 'already-initialized' as FirestoreErrorCode,
-
-  /**
    * The caller does not have permission to execute the specified operation.
    * PERMISSION_DENIED must not be used for rejections caused by exhausting
    * some resource (use RESOURCE_EXHAUSTED instead for those errors).

--- a/packages/firestore/test/lite/integration.test.ts
+++ b/packages/firestore/test/lite/integration.test.ts
@@ -115,16 +115,11 @@ describe('Firestore', () => {
       { apiKey: 'fake-api-key', projectId: 'test-project' },
       'test-app-initializeFirestore-twice'
     );
-    const db = initializeFirestore(app, {});
-
-    // Start the client.
-    writeBatch(db);
+    initializeFirestore(app, {});
 
     expect(() => {
       initializeFirestore(app, {});
-    }).to.throw(
-      'Firestore has already been started and its settings can no longer be changed.'
-    );
+    }).to.throw('Firestore can only be initialized once per app.');
   });
 
   it('cannot use once terminated', () => {


### PR DESCRIPTION
Throw if `initializeFirestore()` is called after a Firestore instance has already been created for the app. 