### PR TITLE
Remove downlevelIteration from firebaseApp

### DIFF
--- a/packages/app/src/firebaseApp.ts
+++ b/packages/app/src/firebaseApp.ts
@@ -60,9 +60,9 @@ export class FirebaseAppImpl implements FirebaseApp {
     // add itself to container
     this._addComponent(new Component('app', () => this, ComponentType.PUBLIC));
     // populate ComponentContainer with existing components
-    for (const component of this.firebase_.INTERNAL.components.values()) {
-      this._addComponent(component);
-    }
+    this.firebase_.INTERNAL.components.forEach(component =>
+      this._addComponent(component)
+    );
   }
 
   get automaticDataCollectionEnabled(): boolean {

--- a/packages/app/src/lite/firebaseAppLite.ts
+++ b/packages/app/src/lite/firebaseAppLite.ts
@@ -64,9 +64,9 @@ export class FirebaseAppLiteImpl implements FirebaseApp {
       new Component('app', () => this, ComponentType.PUBLIC)
     );
     // populate ComponentContainer with existing components
-    for (const component of this.firebase_.INTERNAL.components.values()) {
-      this.container.addComponent(component);
-    }
+    this.firebase_.INTERNAL.components.forEach(component =>
+      this.container.addComponent(component)
+    );
   }
 
   get automaticDataCollectionEnabled(): boolean {

--- a/packages/app/tsconfig.json
+++ b/packages/app/tsconfig.json
@@ -2,8 +2,7 @@
   "extends": "../../config/tsconfig.base.json",
   "compilerOptions": {
     "outDir": "dist",
-    "resolveJsonModule": true,
-    "downlevelIteration": true
+    "resolveJsonModule": true
   },
   "exclude": ["dist/**/*"]
 }


### PR DESCRIPTION
This shaves off a little bit of size. It was meant to fix #4207, but is no longer needed for it. It sill saves some bytes though.