### PR TITLE
Add remaining bits to support Cordova redirect sign in

### DIFF
--- a/packages-exp/auth-exp/index.cordova.ts
+++ b/packages-exp/auth-exp/index.cordova.ts
@@ -37,9 +37,10 @@ export * from './src';
 export { indexedDBLocalPersistence } from './src/platform_browser/persistence/indexed_db';
 export { browserLocalPersistence } from './src/platform_browser/persistence/local_storage';
 export { browserSessionPersistence } from './src/platform_browser/persistence/session_storage';
+export { getRedirectResult } from './src/platform_browser/strategies/redirect';
 
 export { cordovaPopupRedirectResolver } from './src/platform_cordova/popup_redirect/popup_redirect';
-export { signInWithRedirect } from './src/platform_cordova/strategies/redirect';
+export { signInWithRedirect, reauthenticateWithRedirect, linkWithRedirect } from './src/platform_cordova/strategies/redirect';
 
 import { cordovaPopupRedirectResolver } from './src/platform_cordova/popup_redirect/popup_redirect';
 

--- a/packages-exp/auth-exp/index.cordova.ts
+++ b/packages-exp/auth-exp/index.cordova.ts
@@ -40,7 +40,11 @@ export { browserSessionPersistence } from './src/platform_browser/persistence/se
 export { getRedirectResult } from './src/platform_browser/strategies/redirect';
 
 export { cordovaPopupRedirectResolver } from './src/platform_cordova/popup_redirect/popup_redirect';
-export { signInWithRedirect, reauthenticateWithRedirect, linkWithRedirect } from './src/platform_cordova/strategies/redirect';
+export {
+  signInWithRedirect,
+  reauthenticateWithRedirect,
+  linkWithRedirect
+} from './src/platform_cordova/strategies/redirect';
 
 import { cordovaPopupRedirectResolver } from './src/platform_cordova/popup_redirect/popup_redirect';
 

--- a/packages-exp/auth-exp/src/model/popup_redirect.ts
+++ b/packages-exp/auth-exp/src/model/popup_redirect.ts
@@ -86,7 +86,7 @@ export interface PopupRedirectResolver extends externs.PopupRedirectResolver {
     provider: externs.AuthProvider,
     authType: AuthEventType,
     eventId?: string
-  ): Promise<void|never>;
+  ): Promise<void | never>;
   _isIframeWebStorageSupported(
     auth: Auth,
     cb: (support: boolean) => unknown

--- a/packages-exp/auth-exp/src/model/popup_redirect.ts
+++ b/packages-exp/auth-exp/src/model/popup_redirect.ts
@@ -86,7 +86,7 @@ export interface PopupRedirectResolver extends externs.PopupRedirectResolver {
     provider: externs.AuthProvider,
     authType: AuthEventType,
     eventId?: string
-  ): Promise<unknown>;
+  ): Promise<void|never>;
   _isIframeWebStorageSupported(
     auth: Auth,
     cb: (support: boolean) => unknown

--- a/packages-exp/auth-exp/src/platform_browser/strategies/redirect.ts
+++ b/packages-exp/auth-exp/src/platform_browser/strategies/redirect.ts
@@ -78,7 +78,7 @@ export async function _signInWithRedirect(
   auth: externs.Auth,
   provider: externs.AuthProvider,
   resolver?: externs.PopupRedirectResolver
-): Promise<void|never> {
+): Promise<void | never> {
   const authInternal = _castAuth(auth);
   _assert(
     provider instanceof OAuthProvider,
@@ -126,13 +126,17 @@ export function reauthenticateWithRedirect(
   provider: externs.AuthProvider,
   resolver?: externs.PopupRedirectResolver
 ): Promise<never> {
-  return _reauthenticateWithRedirect(user, provider, resolver) as Promise<never>;
+  return _reauthenticateWithRedirect(
+    user,
+    provider,
+    resolver
+  ) as Promise<never>;
 }
 export async function _reauthenticateWithRedirect(
   user: externs.User,
   provider: externs.AuthProvider,
   resolver?: externs.PopupRedirectResolver
-): Promise<void|never> {
+): Promise<void | never> {
   const userInternal = user as User;
   _assert(
     provider instanceof OAuthProvider,
@@ -188,7 +192,7 @@ export async function _linkWithRedirect(
   user: externs.User,
   provider: externs.AuthProvider,
   resolver?: externs.PopupRedirectResolver
-): Promise<void|never> {
+): Promise<void | never> {
   const userInternal = user as User;
   _assert(
     provider instanceof OAuthProvider,
@@ -208,7 +212,6 @@ export async function _linkWithRedirect(
     eventId
   );
 }
-
 
 /**
  * Returns a {@link @firebase/auth-types#UserCredential} from the redirect-based sign-in flow.

--- a/packages-exp/auth-exp/src/platform_browser/strategies/redirect.ts
+++ b/packages-exp/auth-exp/src/platform_browser/strategies/redirect.ts
@@ -67,11 +67,18 @@ import { RedirectAction } from '../../core/strategies/redirect';
  *
  * @public
  */
-export async function signInWithRedirect(
+export function signInWithRedirect(
   auth: externs.Auth,
   provider: externs.AuthProvider,
   resolver?: externs.PopupRedirectResolver
 ): Promise<never> {
+  return _signInWithRedirect(auth, provider, resolver) as Promise<never>;
+}
+export async function _signInWithRedirect(
+  auth: externs.Auth,
+  provider: externs.AuthProvider,
+  resolver?: externs.PopupRedirectResolver
+): Promise<void|never> {
   const authInternal = _castAuth(auth);
   _assert(
     provider instanceof OAuthProvider,
@@ -83,7 +90,7 @@ export async function signInWithRedirect(
     authInternal,
     provider,
     AuthEventType.SIGN_IN_VIA_REDIRECT
-  ) as Promise<never>;
+  );
 }
 
 /**
@@ -114,11 +121,18 @@ export async function signInWithRedirect(
  *
  * @public
  */
-export async function reauthenticateWithRedirect(
+export function reauthenticateWithRedirect(
   user: externs.User,
   provider: externs.AuthProvider,
   resolver?: externs.PopupRedirectResolver
 ): Promise<never> {
+  return _reauthenticateWithRedirect(user, provider, resolver) as Promise<never>;
+}
+export async function _reauthenticateWithRedirect(
+  user: externs.User,
+  provider: externs.AuthProvider,
+  resolver?: externs.PopupRedirectResolver
+): Promise<void|never> {
   const userInternal = user as User;
   _assert(
     provider instanceof OAuthProvider,
@@ -135,7 +149,7 @@ export async function reauthenticateWithRedirect(
     provider,
     AuthEventType.REAUTH_VIA_REDIRECT,
     eventId
-  ) as Promise<never>;
+  );
 }
 
 /**
@@ -163,11 +177,18 @@ export async function reauthenticateWithRedirect(
  *
  * @public
  */
-export async function linkWithRedirect(
+export function linkWithRedirect(
   user: externs.User,
   provider: externs.AuthProvider,
   resolver?: externs.PopupRedirectResolver
 ): Promise<never> {
+  return _linkWithRedirect(user, provider, resolver) as Promise<never>;
+}
+export async function _linkWithRedirect(
+  user: externs.User,
+  provider: externs.AuthProvider,
+  resolver?: externs.PopupRedirectResolver
+): Promise<void|never> {
   const userInternal = user as User;
   _assert(
     provider instanceof OAuthProvider,
@@ -185,8 +206,9 @@ export async function linkWithRedirect(
     provider,
     AuthEventType.LINK_VIA_REDIRECT,
     eventId
-  ) as Promise<never>;
+  );
 }
+
 
 /**
  * Returns a {@link @firebase/auth-types#UserCredential} from the redirect-based sign-in flow.

--- a/packages-exp/auth-exp/src/platform_cordova/strategies/redirect.ts
+++ b/packages-exp/auth-exp/src/platform_cordova/strategies/redirect.ts
@@ -16,7 +16,11 @@
  */
 
 import * as externs from '@firebase/auth-types-exp';
-import { _linkWithRedirect, _reauthenticateWithRedirect, _signInWithRedirect } from '../../platform_browser/strategies/redirect';
+import {
+  _linkWithRedirect,
+  _reauthenticateWithRedirect,
+  _signInWithRedirect
+} from '../../platform_browser/strategies/redirect';
 
 export function signInWithRedirect(
   auth: externs.Auth,

--- a/packages-exp/auth-exp/src/platform_cordova/strategies/redirect.ts
+++ b/packages-exp/auth-exp/src/platform_cordova/strategies/redirect.ts
@@ -16,31 +16,28 @@
  */
 
 import * as externs from '@firebase/auth-types-exp';
-import { _castAuth } from '../../core/auth/auth_impl';
-import { AuthErrorCode } from '../../core/errors';
-import { OAuthProvider } from '../../core/providers/oauth';
-import { _assert } from '../../core/util/assert';
-import { _withDefaultResolver } from '../../core/util/resolver';
-import { AuthEventType } from '../../model/popup_redirect';
+import { _linkWithRedirect, _reauthenticateWithRedirect, _signInWithRedirect } from '../../platform_browser/strategies/redirect';
 
-// TODO: For now this code is largely a duplicate of platform_browser/strategies/redirect.
-//       It's likely we can just reuse that code
-
-export async function signInWithRedirect(
+export function signInWithRedirect(
   auth: externs.Auth,
   provider: externs.AuthProvider,
   resolver?: externs.PopupRedirectResolver
 ): Promise<void> {
-  const authInternal = _castAuth(auth);
-  _assert(
-    provider instanceof OAuthProvider,
-    auth,
-    AuthErrorCode.ARGUMENT_ERROR
-  );
+  return _signInWithRedirect(auth, provider, resolver) as Promise<void>;
+}
 
-  return _withDefaultResolver(authInternal, resolver)._openRedirect(
-    authInternal,
-    provider,
-    AuthEventType.SIGN_IN_VIA_REDIRECT
-  ) as Promise<void>;
+export function reauthenticateWithRedirect(
+  user: externs.User,
+  provider: externs.AuthProvider,
+  resolver?: externs.PopupRedirectResolver
+): Promise<void> {
+  return _reauthenticateWithRedirect(user, provider, resolver) as Promise<void>;
+}
+
+export function linkWithRedirect(
+  user: externs.User,
+  provider: externs.AuthProvider,
+  resolver?: externs.PopupRedirectResolver
+): Promise<void> {
+  return _linkWithRedirect(user, provider, resolver) as Promise<void>;
 }


### PR DESCRIPTION
Cordova can use the `platform_browser` redirect entry points entirely, we just need to add new functions that have a different return type (`Promise<void>` instead of `Promise<never>`)