### PR TITLE
Implement and type auth.emulatorConfig.

### DIFF
--- a/.changeset/itchy-grapes-drum.md
+++ b/.changeset/itchy-grapes-drum.md
@@ -1,0 +1,5 @@
+---
+"@firebase/auth-types": patch
+---
+
+Add emulator methods to auth-types.

--- a/packages-exp/auth-compat-exp/src/auth.ts
+++ b/packages-exp/auth-compat-exp/src/auth.ts
@@ -75,6 +75,11 @@ export class Auth
     );
   }
 
+  get emulatorConfig(): compat.EmulatorConfig | null {
+    // TODO
+    return null;
+  }
+
   get currentUser(): compat.User | null {
     if (!this.auth.currentUser) {
       return null;

--- a/packages-exp/auth-compat-exp/src/auth.ts
+++ b/packages-exp/auth-compat-exp/src/auth.ts
@@ -76,8 +76,7 @@ export class Auth
   }
 
   get emulatorConfig(): compat.EmulatorConfig | null {
-    // TODO
-    return null;
+    return this.auth.emulatorConfig;
   }
 
   get currentUser(): compat.User | null {

--- a/packages-exp/auth-exp/src/api/index.test.ts
+++ b/packages-exp/auth-exp/src/api/index.test.ts
@@ -383,7 +383,7 @@ describe('api/_performApiRequest', () => {
 
     it('works properly with an emulated environment', () => {
       (auth.config as ConfigInternal).emulator = {
-        url: 'http://localhost:5000'
+        url: 'http://localhost:5000/'
       };
       expect(_getFinalTarget(auth, 'host', '/path', 'query=test')).to.eq(
         'http://localhost:5000/host/path?query=test'

--- a/packages-exp/auth-exp/src/core/auth/auth_impl.ts
+++ b/packages-exp/auth-exp/src/core/auth/auth_impl.ts
@@ -59,6 +59,7 @@ export const enum DefaultConfig {
 
 export class AuthImpl implements Auth, _FirebaseService {
   currentUser: externs.User | null = null;
+  emulatorConfig: externs.EmulatorConfig | null = null;
   private operations = Promise.resolve();
   private persistenceManager?: PersistenceUserManager;
   private redirectPersistenceManager?: PersistenceUserManager;

--- a/packages-exp/auth-exp/src/core/auth/emulator.test.ts
+++ b/packages-exp/auth-exp/src/core/auth/emulator.test.ts
@@ -83,6 +83,13 @@ describe('core/auth/emulator', () => {
       expect(emulatorEndpoint.calls.length).to.eq(1);
     });
 
+    it('updates the endpoint appropriately with trailing slash', async () => {
+      useAuthEmulator(auth, 'http://localhost:2020/');
+      await user.delete();
+      expect(normalEndpoint.calls.length).to.eq(0);
+      expect(emulatorEndpoint.calls.length).to.eq(1);
+    });
+
     it('checks the scheme properly', () => {
       expect(() => useAuthEmulator(auth, 'http://localhost:2020')).not.to.throw;
       delete auth.config.emulator;
@@ -133,6 +140,36 @@ describe('core/auth/emulator', () => {
       if (typeof document !== 'undefined') {
         expect(document.querySelector('.firebase-emulator-warning')).to.be.null;
       }
+    });
+
+    it('sets emulatorConfig on the Auth object', async () => {
+      useAuthEmulator(auth, 'http://localhost:2020');
+      expect(auth.emulatorConfig).to.eql({
+        protocol: 'http',
+        host: 'localhost',
+        port: 2020,
+        options: { disableWarnings: false }
+      });
+    });
+
+    it('sets disableWarnings in emulatorConfig accordingly', async () => {
+      useAuthEmulator(auth, 'https://127.0.0.1', { disableWarnings: true });
+      expect(auth.emulatorConfig).to.eql({
+        protocol: 'https',
+        host: '127.0.0.1',
+        port: null,
+        options: { disableWarnings: true }
+      });
+    });
+
+    it('quotes IPv6 address in emulatorConfig', async () => {
+      useAuthEmulator(auth, 'http://[::1]:2020/');
+      expect(auth.emulatorConfig).to.eql({
+        protocol: 'http',
+        host: '[::1]',
+        port: 2020,
+        options: { disableWarnings: false }
+      });
     });
   });
 

--- a/packages-exp/auth-exp/src/core/auth/emulator.ts
+++ b/packages-exp/auth-exp/src/core/auth/emulator.ts
@@ -58,9 +58,20 @@ export function useAuthEmulator(
     AuthErrorCode.INVALID_EMULATOR_SCHEME
   );
 
-  authInternal.config.emulator = { url };
+  const parsedUrl = new URL(url);
+  const disableWarnings = !!options?.disableWarnings;
+
+  // Store the normalized URL whose path is always nonempty (i.e. containing at least a single '/').
+  authInternal.config.emulator = { url: parsedUrl.toString() };
   authInternal.settings.appVerificationDisabledForTesting = true;
-  emitEmulatorWarning(!!options?.disableWarnings);
+  authInternal.emulatorConfig = Object.freeze({
+    host: parsedUrl.hostname,
+    port: parsedUrl.port ? Number(parsedUrl.port) : null,
+    protocol: parsedUrl.protocol.replace(':', ''),
+    options: Object.freeze({ disableWarnings })
+  });
+
+  emitEmulatorWarning(disableWarnings);
 }
 
 function emitEmulatorWarning(disableBanner: boolean): void {

--- a/packages-exp/auth-exp/src/core/util/emulator.test.ts
+++ b/packages-exp/auth-exp/src/core/util/emulator.test.ts
@@ -23,7 +23,7 @@ import { _emulatorUrl } from './emulator';
 describe('core/util/emulator', () => {
   const config: ConfigInternal = {
     emulator: {
-      url: 'http://localhost:4000'
+      url: 'http://localhost:4000/'
     }
   } as ConfigInternal;
 

--- a/packages-exp/auth-exp/src/core/util/emulator.ts
+++ b/packages-exp/auth-exp/src/core/util/emulator.ts
@@ -21,11 +21,10 @@ import { debugAssert } from './assert';
 export function _emulatorUrl(config: ConfigInternal, path?: string): string {
   debugAssert(config.emulator, 'Emulator should always be set here');
   const { url } = config.emulator;
-  const emulatorHost = new URL(url).toString();
 
   if (!path) {
-    return emulatorHost;
+    return url;
   }
 
-  return `${emulatorHost}${path.startsWith('/') ? path.slice(1) : path}`;
+  return `${url}${path.startsWith('/') ? path.slice(1) : path}`;
 }

--- a/packages-exp/auth-exp/src/model/auth.ts
+++ b/packages-exp/auth-exp/src/model/auth.ts
@@ -37,6 +37,7 @@ export interface ConfigInternal extends externs.Config {
 
 export interface Auth extends externs.Auth {
   currentUser: externs.User | null;
+  emulatorConfig: externs.EmulatorConfig | null;
   _canInitEmulator: boolean;
   _isInitialized: boolean;
   _initializationPromise: Promise<void> | null;

--- a/packages-exp/auth-types-exp/index.d.ts
+++ b/packages-exp/auth-types-exp/index.d.ts
@@ -288,6 +288,8 @@ export interface Auth {
   ): Unsubscribe;
   /** The currently signed-in user (or null). */
   readonly currentUser: User | null;
+  /** The current emulator configuration (or null). */
+  readonly emulatorConfig: EmulatorConfig | null;
   /**
    * Asynchronously sets the provided user as {@link Auth.currentUser} on the {@link Auth} instance.
    *
@@ -1509,6 +1511,34 @@ declare module '@firebase/component' {
   interface NameServiceMapping {
     'auth-exp': Auth;
   }
+}
+
+/**
+ * Configuration of Firebase Authentication Emulator.
+ */
+export interface EmulatorConfig {
+  /**
+   * The protocol used to communicate with the emulator ("http"/"https").
+   */
+  readonly protocol: string;
+  /**
+   * The hostname of the emulator, which may be a domain ("localhost"), IPv4 address ("127.0.0.1")
+   * or quoted IPv6 address ("[::1]").
+   */
+  readonly host: string;
+  /**
+   * The port of the emulator, or null if port isn't specified (i.e. protocol default).
+   */
+  readonly port: number | null;
+  /**
+   * The emulator-specific options.
+   */
+  readonly options: {
+    /**
+     * Whether the warning banner attached to the DOM was disabled.
+     */
+    readonly disableWarnings: boolean;
+  };
 }
 
 /**

--- a/packages/auth-types/index.d.ts
+++ b/packages/auth-types/index.d.ts
@@ -389,6 +389,15 @@ export class PhoneMultiFactorGenerator {
   ): PhoneMultiFactorAssertion;
 }
 
+export interface EmulatorConfig {
+  protocol: string;
+  host: string;
+  port: number | null;
+  options: {
+    disableWarnings: boolean;
+  };
+}
+
 export class FirebaseAuth {
   private constructor();
 
@@ -407,6 +416,7 @@ export class FirebaseAuth {
     password: string
   ): Promise<UserCredential>;
   currentUser: User | null;
+  readonly emulatorConfig: EmulatorConfig | null;
   fetchSignInMethodsForEmail(email: string): Promise<Array<string>>;
   isSignInWithEmailLink(emailLink: string): boolean;
   getRedirectResult(): Promise<UserCredential>;
@@ -455,6 +465,7 @@ export class FirebaseAuth {
   tenantId: string | null;
   updateCurrentUser(user: User | null): Promise<void>;
   useDeviceLanguage(): void;
+  useEmulator(url: string, options?: { disableWarnings?: boolean }): void;
   verifyPasswordResetCode(code: string): Promise<string>;
 }
 

--- a/packages/auth-types/index.d.ts
+++ b/packages/auth-types/index.d.ts
@@ -390,11 +390,11 @@ export class PhoneMultiFactorGenerator {
 }
 
 export interface EmulatorConfig {
-  protocol: string;
-  host: string;
-  port: number | null;
-  options: {
-    disableWarnings: boolean;
+  readonly protocol: string;
+  readonly host: string;
+  readonly port: number | null;
+  readonly options: {
+    readonly disableWarnings: boolean;
   };
 }
 


### PR DESCRIPTION
This PR implements the approved `auth.emulatorConfig` API in `auth-exp`, in parity with existing `auth` SDK.

Somehow `auth.emulatorConfig` and also `useEmulator` were never added to the existing `auth-types`. This PR also fixes that (and replaces #4354).