### PR TITLE
Refactor QueryParams

### DIFF
--- a/packages/database/src/api/Query.ts
+++ b/packages/database/src/api/Query.ts
@@ -51,14 +51,14 @@ import {
 import { Repo } from '../core/Repo';
 import {
   QueryParams,
-  limitToFirst,
-  limitToLast,
-  startAfter,
-  startAt,
-  endAt,
-  endBefore,
-  getQueryObject,
-  orderBy
+  queryParamsLimitToFirst,
+  queryParamsLimitToLast,
+  queryParamsStartAfter,
+  queryParamsStartAt,
+  queryParamsEndAt,
+  queryParamsEndBefore,
+  queryParamsGetQueryObject,
+  queryParamsOrderBy
 } from '../core/view/QueryParams';
 import { Reference } from './Reference';
 import { DataSnapshot } from './DataSnapshot';
@@ -365,7 +365,7 @@ export class Query {
     return new Query(
       this.repo,
       this.path,
-      limitToFirst(this.queryParams_, limit),
+      queryParamsLimitToFirst(this.queryParams_, limit),
       this.orderByCalled_
     );
   }
@@ -394,7 +394,7 @@ export class Query {
     return new Query(
       this.repo,
       this.path,
-      limitToLast(this.queryParams_, limit),
+      queryParamsLimitToLast(this.queryParams_, limit),
       this.orderByCalled_
     );
   }
@@ -426,7 +426,7 @@ export class Query {
       );
     }
     const index = new PathIndex(parsedPath);
-    const newParams = orderBy(this.queryParams_, index);
+    const newParams = queryParamsOrderBy(this.queryParams_, index);
     Query.validateQueryEndpoints_(newParams);
 
     return new Query(this.repo, this.path, newParams, /*orderByCalled=*/ true);
@@ -438,7 +438,7 @@ export class Query {
   orderByKey(): Query {
     validateArgCount('Query.orderByKey', 0, 0, arguments.length);
     this.validateNoPreviousOrderByCall_('Query.orderByKey');
-    const newParams = orderBy(this.queryParams_, KEY_INDEX);
+    const newParams = queryParamsOrderBy(this.queryParams_, KEY_INDEX);
     Query.validateQueryEndpoints_(newParams);
     return new Query(this.repo, this.path, newParams, /*orderByCalled=*/ true);
   }
@@ -449,7 +449,7 @@ export class Query {
   orderByPriority(): Query {
     validateArgCount('Query.orderByPriority', 0, 0, arguments.length);
     this.validateNoPreviousOrderByCall_('Query.orderByPriority');
-    const newParams = orderBy(this.queryParams_, PRIORITY_INDEX);
+    const newParams = queryParamsOrderBy(this.queryParams_, PRIORITY_INDEX);
     Query.validateQueryEndpoints_(newParams);
     return new Query(this.repo, this.path, newParams, /*orderByCalled=*/ true);
   }
@@ -460,7 +460,7 @@ export class Query {
   orderByValue(): Query {
     validateArgCount('Query.orderByValue', 0, 0, arguments.length);
     this.validateNoPreviousOrderByCall_('Query.orderByValue');
-    const newParams = orderBy(this.queryParams_, VALUE_INDEX);
+    const newParams = queryParamsOrderBy(this.queryParams_, VALUE_INDEX);
     Query.validateQueryEndpoints_(newParams);
     return new Query(this.repo, this.path, newParams, /*orderByCalled=*/ true);
   }
@@ -473,7 +473,7 @@ export class Query {
     validateFirebaseDataArg('Query.startAt', 1, value, this.path, true);
     validateKey('Query.startAt', 2, name, true);
 
-    const newParams = startAt(this.queryParams_, value, name);
+    const newParams = queryParamsStartAt(this.queryParams_, value, name);
     Query.validateLimit_(newParams);
     Query.validateQueryEndpoints_(newParams);
     if (this.queryParams_.hasStart()) {
@@ -500,7 +500,7 @@ export class Query {
     validateFirebaseDataArg('Query.startAfter', 1, value, this.path, false);
     validateKey('Query.startAfter', 2, name, true);
 
-    const newParams = startAfter(this.queryParams_, value, name);
+    const newParams = queryParamsStartAfter(this.queryParams_, value, name);
     Query.validateLimit_(newParams);
     Query.validateQueryEndpoints_(newParams);
     if (this.queryParams_.hasStart()) {
@@ -521,7 +521,7 @@ export class Query {
     validateFirebaseDataArg('Query.endAt', 1, value, this.path, true);
     validateKey('Query.endAt', 2, name, true);
 
-    const newParams = endAt(this.queryParams_, value, name);
+    const newParams = queryParamsEndAt(this.queryParams_, value, name);
     Query.validateLimit_(newParams);
     Query.validateQueryEndpoints_(newParams);
     if (this.queryParams_.hasEnd()) {
@@ -542,7 +542,7 @@ export class Query {
     validateFirebaseDataArg('Query.endBefore', 1, value, this.path, false);
     validateKey('Query.endBefore', 2, name, true);
 
-    const newParams = endBefore(this.queryParams_, value, name);
+    const newParams = queryParamsEndBefore(this.queryParams_, value, name);
     Query.validateLimit_(newParams);
     Query.validateQueryEndpoints_(newParams);
     if (this.queryParams_.hasEnd()) {
@@ -599,7 +599,7 @@ export class Query {
    * An object representation of the query parameters used by this Query.
    */
   queryObject(): object {
-    return getQueryObject(this.queryParams_);
+    return queryParamsGetQueryObject(this.queryParams_);
   }
 
   queryIdentifier(): string {

--- a/packages/database/src/api/Query.ts
+++ b/packages/database/src/api/Query.ts
@@ -49,7 +49,17 @@ import {
 } from '../core/view/EventRegistration';
 
 import { Repo } from '../core/Repo';
-import { QueryParams } from '../core/view/QueryParams';
+import {
+  QueryParams,
+  limitToFirst,
+  limitToLast,
+  startAfter,
+  startAt,
+  endAt,
+  endBefore,
+  getQueryObject,
+  orderBy
+} from '../core/view/QueryParams';
 import { Reference } from './Reference';
 import { DataSnapshot } from './DataSnapshot';
 
@@ -355,7 +365,7 @@ export class Query {
     return new Query(
       this.repo,
       this.path,
-      this.queryParams_.limitToFirst(limit),
+      limitToFirst(this.queryParams_, limit),
       this.orderByCalled_
     );
   }
@@ -384,7 +394,7 @@ export class Query {
     return new Query(
       this.repo,
       this.path,
-      this.queryParams_.limitToLast(limit),
+      limitToLast(this.queryParams_, limit),
       this.orderByCalled_
     );
   }
@@ -416,7 +426,7 @@ export class Query {
       );
     }
     const index = new PathIndex(parsedPath);
-    const newParams = this.queryParams_.orderBy(index);
+    const newParams = orderBy(this.queryParams_, index);
     Query.validateQueryEndpoints_(newParams);
 
     return new Query(this.repo, this.path, newParams, /*orderByCalled=*/ true);
@@ -428,7 +438,7 @@ export class Query {
   orderByKey(): Query {
     validateArgCount('Query.orderByKey', 0, 0, arguments.length);
     this.validateNoPreviousOrderByCall_('Query.orderByKey');
-    const newParams = this.queryParams_.orderBy(KEY_INDEX);
+    const newParams = orderBy(this.queryParams_, KEY_INDEX);
     Query.validateQueryEndpoints_(newParams);
     return new Query(this.repo, this.path, newParams, /*orderByCalled=*/ true);
   }
@@ -439,7 +449,7 @@ export class Query {
   orderByPriority(): Query {
     validateArgCount('Query.orderByPriority', 0, 0, arguments.length);
     this.validateNoPreviousOrderByCall_('Query.orderByPriority');
-    const newParams = this.queryParams_.orderBy(PRIORITY_INDEX);
+    const newParams = orderBy(this.queryParams_, PRIORITY_INDEX);
     Query.validateQueryEndpoints_(newParams);
     return new Query(this.repo, this.path, newParams, /*orderByCalled=*/ true);
   }
@@ -450,7 +460,7 @@ export class Query {
   orderByValue(): Query {
     validateArgCount('Query.orderByValue', 0, 0, arguments.length);
     this.validateNoPreviousOrderByCall_('Query.orderByValue');
-    const newParams = this.queryParams_.orderBy(VALUE_INDEX);
+    const newParams = orderBy(this.queryParams_, VALUE_INDEX);
     Query.validateQueryEndpoints_(newParams);
     return new Query(this.repo, this.path, newParams, /*orderByCalled=*/ true);
   }
@@ -463,7 +473,7 @@ export class Query {
     validateFirebaseDataArg('Query.startAt', 1, value, this.path, true);
     validateKey('Query.startAt', 2, name, true);
 
-    const newParams = this.queryParams_.startAt(value, name);
+    const newParams = startAt(this.queryParams_, value, name);
     Query.validateLimit_(newParams);
     Query.validateQueryEndpoints_(newParams);
     if (this.queryParams_.hasStart()) {
@@ -490,7 +500,7 @@ export class Query {
     validateFirebaseDataArg('Query.startAfter', 1, value, this.path, false);
     validateKey('Query.startAfter', 2, name, true);
 
-    const newParams = this.queryParams_.startAfter(value, name);
+    const newParams = startAfter(this.queryParams_, value, name);
     Query.validateLimit_(newParams);
     Query.validateQueryEndpoints_(newParams);
     if (this.queryParams_.hasStart()) {
@@ -511,7 +521,7 @@ export class Query {
     validateFirebaseDataArg('Query.endAt', 1, value, this.path, true);
     validateKey('Query.endAt', 2, name, true);
 
-    const newParams = this.queryParams_.endAt(value, name);
+    const newParams = endAt(this.queryParams_, value, name);
     Query.validateLimit_(newParams);
     Query.validateQueryEndpoints_(newParams);
     if (this.queryParams_.hasEnd()) {
@@ -532,7 +542,7 @@ export class Query {
     validateFirebaseDataArg('Query.endBefore', 1, value, this.path, false);
     validateKey('Query.endBefore', 2, name, true);
 
-    const newParams = this.queryParams_.endBefore(value, name);
+    const newParams = endBefore(this.queryParams_, value, name);
     Query.validateLimit_(newParams);
     Query.validateQueryEndpoints_(newParams);
     if (this.queryParams_.hasEnd()) {
@@ -589,7 +599,7 @@ export class Query {
    * An object representation of the query parameters used by this Query.
    */
   queryObject(): object {
-    return this.queryParams_.getQueryObject();
+    return getQueryObject(this.queryParams_);
   }
 
   queryIdentifier(): string {

--- a/packages/database/src/core/ReadonlyRestClient.ts
+++ b/packages/database/src/core/ReadonlyRestClient.ts
@@ -28,6 +28,7 @@ import { ServerActions } from './ServerActions';
 import { RepoInfo } from './RepoInfo';
 import { AuthTokenProvider } from './AuthTokenProvider';
 import { Query } from '../api/Query';
+import { toRestQueryStringParameters } from './view/QueryParams';
 
 /**
  * An implementation of ServerActions that communicates with the server via REST requests.
@@ -94,9 +95,9 @@ export class ReadonlyRestClient extends ServerActions {
     const thisListen = {};
     this.listens_[listenId] = thisListen;
 
-    const queryStringParameters = query
-      .getQueryParams()
-      .toRestQueryStringParameters();
+    const queryStringParameters = toRestQueryStringParameters(
+      query.getQueryParams()
+    );
 
     this.restRequest_(
       pathString + '.json',
@@ -136,9 +137,9 @@ export class ReadonlyRestClient extends ServerActions {
   }
 
   get(query: Query): Promise<string> {
-    const queryStringParameters = query
-      .getQueryParams()
-      .toRestQueryStringParameters();
+    const queryStringParameters = toRestQueryStringParameters(
+      query.getQueryParams()
+    );
 
     const pathString = query.path.toString();
 

--- a/packages/database/src/core/ReadonlyRestClient.ts
+++ b/packages/database/src/core/ReadonlyRestClient.ts
@@ -28,7 +28,7 @@ import { ServerActions } from './ServerActions';
 import { RepoInfo } from './RepoInfo';
 import { AuthTokenProvider } from './AuthTokenProvider';
 import { Query } from '../api/Query';
-import { toRestQueryStringParameters } from './view/QueryParams';
+import { queryParamsToRestQueryStringParameters } from './view/QueryParams';
 
 /**
  * An implementation of ServerActions that communicates with the server via REST requests.
@@ -95,7 +95,7 @@ export class ReadonlyRestClient extends ServerActions {
     const thisListen = {};
     this.listens_[listenId] = thisListen;
 
-    const queryStringParameters = toRestQueryStringParameters(
+    const queryStringParameters = queryParamsToRestQueryStringParameters(
       query.getQueryParams()
     );
 
@@ -137,7 +137,7 @@ export class ReadonlyRestClient extends ServerActions {
   }
 
   get(query: Query): Promise<string> {
-    const queryStringParameters = toRestQueryStringParameters(
+    const queryStringParameters = queryParamsToRestQueryStringParameters(
       query.getQueryParams()
     );
 

--- a/packages/database/src/core/view/QueryParams.ts
+++ b/packages/database/src/core/view/QueryParams.ts
@@ -203,7 +203,7 @@ export class QueryParams {
   }
 }
 
-function getNodeFilter(queryParams: QueryParams): NodeFilter {
+export function getNodeFilter(queryParams: QueryParams): NodeFilter {
   if (queryParams.loadsAllData()) {
     return new IndexedFilter(queryParams.getIndex());
   } else if (queryParams.hasLimit()) {
@@ -333,7 +333,7 @@ export function endBefore(
   return params;
 }
 
-function orderBy(queryParams: QueryParams, index: Index): QueryParams {
+export function orderBy(queryParams: QueryParams, index: Index): QueryParams {
   const newParams = queryParams.copy();
   newParams.index_ = index;
   return newParams;
@@ -349,7 +349,7 @@ export function toRestQueryStringParameters(
 ): Record<string, string | number> {
   const qs: Record<string, string | number> = {};
 
-  if (this.isDefault()) {
+  if (queryParams.isDefault()) {
     return qs;
   }
 

--- a/packages/database/src/core/view/QueryParams.ts
+++ b/packages/database/src/core/view/QueryParams.ts
@@ -213,7 +213,7 @@ function getNodeFilter(queryParams: QueryParams): NodeFilter {
   }
 }
 
-function limit(queryParams: QueryParams, newLimit: number): QueryParams {
+export function limit(queryParams: QueryParams, newLimit: number): QueryParams {
   const newParams = queryParams.copy();
   newParams.limitSet_ = true;
   newParams.limit_ = newLimit;
@@ -221,7 +221,10 @@ function limit(queryParams: QueryParams, newLimit: number): QueryParams {
   return newParams;
 }
 
-function limitToFirst(queryParams: QueryParams, newLimit: number): QueryParams {
+export function limitToFirst(
+  queryParams: QueryParams,
+  newLimit: number
+): QueryParams {
   const newParams = queryParams.copy();
   newParams.limitSet_ = true;
   newParams.limit_ = newLimit;
@@ -229,7 +232,10 @@ function limitToFirst(queryParams: QueryParams, newLimit: number): QueryParams {
   return newParams;
 }
 
-function limitToLast(queryParams: QueryParams, newLimit: number): QueryParams {
+export function limitToLast(
+  queryParams: QueryParams,
+  newLimit: number
+): QueryParams {
   const newParams = queryParams.copy();
   newParams.limitSet_ = true;
   newParams.limit_ = newLimit;
@@ -237,7 +243,7 @@ function limitToLast(queryParams: QueryParams, newLimit: number): QueryParams {
   return newParams;
 }
 
-function startAt(
+export function startAt(
   queryParams: QueryParams,
   indexValue: unknown,
   key?: string | null
@@ -258,7 +264,7 @@ function startAt(
   return newParams;
 }
 
-function startAfter(
+export function startAfter(
   queryParams: QueryParams,
   indexValue: unknown,
   key?: string | null
@@ -282,7 +288,7 @@ function startAfter(
   return params;
 }
 
-function endAt(
+export function endAt(
   queryParams: QueryParams,
   indexValue: unknown,
   key?: string | null
@@ -303,7 +309,7 @@ function endAt(
   return newParams;
 }
 
-function endBefore(
+export function endBefore(
   queryParams: QueryParams,
   indexValue: unknown,
   key?: string | null
@@ -338,7 +344,7 @@ function orderBy(queryParams: QueryParams, index: Index): QueryParams {
  *
  * @return query string parameters
  */
-function toRestQueryStringParameters(
+export function toRestQueryStringParameters(
   queryParams: QueryParams
 ): Record<string, string | number> {
   const qs: Record<string, string | number> = {};
@@ -387,7 +393,9 @@ function toRestQueryStringParameters(
   return qs;
 }
 
-function getQueryObject(queryParams: QueryParams): Record<string, unknown> {
+export function getQueryObject(
+  queryParams: QueryParams
+): Record<string, unknown> {
   const obj: Record<string, unknown> = {};
   if (queryParams.startSet_) {
     obj[WIRE_PROTOCOL_CONSTANTS.INDEX_START_VALUE] =

--- a/packages/database/src/core/view/QueryParams.ts
+++ b/packages/database/src/core/view/QueryParams.ts
@@ -29,56 +29,54 @@ import { NodeFilter } from './filter/NodeFilter';
 import { Index } from '../snap/indexes/Index';
 
 /**
+ * Wire Protocol Constants
+ */
+const enum WIRE_PROTOCOL_CONSTANTS {
+  INDEX_START_VALUE = 'sp',
+  INDEX_START_NAME = 'sn',
+  INDEX_END_VALUE = 'ep',
+  INDEX_END_NAME = 'en',
+  LIMIT = 'l',
+  VIEW_FROM = 'vf',
+  VIEW_FROM_LEFT = 'l',
+  VIEW_FROM_RIGHT = 'r',
+  INDEX = 'i'
+}
+
+/**
+ * REST Query Constants
+ */
+const enum REST_QUERY_CONSTANTS {
+  ORDER_BY = 'orderBy',
+  PRIORITY_INDEX = '$priority',
+  VALUE_INDEX = '$value',
+  KEY_INDEX = '$key',
+  START_AT = 'startAt',
+  END_AT = 'endAt',
+  LIMIT_TO_FIRST = 'limitToFirst',
+  LIMIT_TO_LAST = 'limitToLast'
+}
+
+/**
  * This class is an immutable-from-the-public-api struct containing a set of query parameters defining a
  * range to be returned for a particular location. It is assumed that validation of parameters is done at the
  * user-facing API level, so it is not done here.
  */
 export class QueryParams {
-  private limitSet_ = false;
-  private startSet_ = false;
-  private startNameSet_ = false;
-  private startAfterSet_ = false;
-  private endSet_ = false;
-  private endNameSet_ = false;
-  private endBeforeSet_ = false;
-
-  private limit_ = 0;
-  private viewFrom_ = '';
-  private indexStartValue_: unknown | null = null;
-  private indexStartName_ = '';
-  private indexEndValue_: unknown | null = null;
-  private indexEndName_ = '';
-
-  private index_ = PRIORITY_INDEX;
-
-  /**
-   * Wire Protocol Constants
-   */
-  private static readonly WIRE_PROTOCOL_CONSTANTS_ = {
-    INDEX_START_VALUE: 'sp',
-    INDEX_START_NAME: 'sn',
-    INDEX_END_VALUE: 'ep',
-    INDEX_END_NAME: 'en',
-    LIMIT: 'l',
-    VIEW_FROM: 'vf',
-    VIEW_FROM_LEFT: 'l',
-    VIEW_FROM_RIGHT: 'r',
-    INDEX: 'i'
-  };
-
-  /**
-   * REST Query Constants
-   */
-  private static readonly REST_QUERY_CONSTANTS_ = {
-    ORDER_BY: 'orderBy',
-    PRIORITY_INDEX: '$priority',
-    VALUE_INDEX: '$value',
-    KEY_INDEX: '$key',
-    START_AT: 'startAt',
-    END_AT: 'endAt',
-    LIMIT_TO_FIRST: 'limitToFirst',
-    LIMIT_TO_LAST: 'limitToLast'
-  };
+  limitSet_ = false;
+  startSet_ = false;
+  startNameSet_ = false;
+  startAfterSet_ = false;
+  endSet_ = false;
+  endNameSet_ = false;
+  endBeforeSet_ = false;
+  limit_ = 0;
+  viewFrom_ = '';
+  indexStartValue_: unknown | null = null;
+  indexStartName_ = '';
+  indexEndValue_: unknown | null = null;
+  indexEndName_ = '';
+  index_ = PRIORITY_INDEX;
 
   hasStart(): boolean {
     return this.startSet_;
@@ -103,9 +101,7 @@ export class QueryParams {
       // anchor to the end.
       return this.startSet_;
     } else {
-      return (
-        this.viewFrom_ === QueryParams.WIRE_PROTOCOL_CONSTANTS_.VIEW_FROM_LEFT
-      );
+      return this.viewFrom_ === WIRE_PROTOCOL_CONSTANTS.VIEW_FROM_LEFT;
     }
   }
 
@@ -178,7 +174,18 @@ export class QueryParams {
     return this.index_;
   }
 
-  private copy_(): QueryParams {
+  loadsAllData(): boolean {
+    return !(this.startSet_ || this.endSet_ || this.limitSet_);
+  }
+
+  /**
+   * What does isDefault() mean?
+   */
+  isDefault(): boolean {
+    return this.loadsAllData() && this.index_ === PRIORITY_INDEX;
+  }
+
+  copy(): QueryParams {
     const copy = new QueryParams();
     copy.limitSet_ = this.limitSet_;
     copy.limit_ = this.limit_;
@@ -194,211 +201,223 @@ export class QueryParams {
     copy.viewFrom_ = this.viewFrom_;
     return copy;
   }
+}
 
-  limit(newLimit: number): QueryParams {
-    const newParams = this.copy_();
-    newParams.limitSet_ = true;
-    newParams.limit_ = newLimit;
-    newParams.viewFrom_ = '';
-    return newParams;
+function getNodeFilter(queryParams: QueryParams): NodeFilter {
+  if (queryParams.loadsAllData()) {
+    return new IndexedFilter(queryParams.getIndex());
+  } else if (queryParams.hasLimit()) {
+    return new LimitedFilter(queryParams);
+  } else {
+    return new RangedFilter(queryParams);
   }
+}
 
-  limitToFirst(newLimit: number): QueryParams {
-    const newParams = this.copy_();
-    newParams.limitSet_ = true;
-    newParams.limit_ = newLimit;
-    newParams.viewFrom_ = QueryParams.WIRE_PROTOCOL_CONSTANTS_.VIEW_FROM_LEFT;
-    return newParams;
+function limit(queryParams: QueryParams, newLimit: number): QueryParams {
+  const newParams = queryParams.copy();
+  newParams.limitSet_ = true;
+  newParams.limit_ = newLimit;
+  newParams.viewFrom_ = '';
+  return newParams;
+}
+
+function limitToFirst(queryParams: QueryParams, newLimit: number): QueryParams {
+  const newParams = queryParams.copy();
+  newParams.limitSet_ = true;
+  newParams.limit_ = newLimit;
+  newParams.viewFrom_ = WIRE_PROTOCOL_CONSTANTS.VIEW_FROM_LEFT;
+  return newParams;
+}
+
+function limitToLast(queryParams: QueryParams, newLimit: number): QueryParams {
+  const newParams = queryParams.copy();
+  newParams.limitSet_ = true;
+  newParams.limit_ = newLimit;
+  newParams.viewFrom_ = WIRE_PROTOCOL_CONSTANTS.VIEW_FROM_RIGHT;
+  return newParams;
+}
+
+function startAt(
+  queryParams: QueryParams,
+  indexValue: unknown,
+  key?: string | null
+): QueryParams {
+  const newParams = queryParams.copy();
+  newParams.startSet_ = true;
+  if (indexValue === undefined) {
+    indexValue = null;
   }
-
-  limitToLast(newLimit: number): QueryParams {
-    const newParams = this.copy_();
-    newParams.limitSet_ = true;
-    newParams.limit_ = newLimit;
-    newParams.viewFrom_ = QueryParams.WIRE_PROTOCOL_CONSTANTS_.VIEW_FROM_RIGHT;
-    return newParams;
+  newParams.indexStartValue_ = indexValue;
+  if (key != null) {
+    newParams.startNameSet_ = true;
+    newParams.indexStartName_ = key;
+  } else {
+    newParams.startNameSet_ = false;
+    newParams.indexStartName_ = '';
   }
+  return newParams;
+}
 
-  startAt(indexValue: unknown, key?: string | null): QueryParams {
-    const newParams = this.copy_();
-    newParams.startSet_ = true;
-    if (indexValue === undefined) {
-      indexValue = null;
+function startAfter(
+  queryParams: QueryParams,
+  indexValue: unknown,
+  key?: string | null
+): QueryParams {
+  let params: QueryParams;
+  if (queryParams.index_ === KEY_INDEX) {
+    if (typeof indexValue === 'string') {
+      indexValue = successor(indexValue as string);
     }
-    newParams.indexStartValue_ = indexValue;
-    if (key != null) {
-      newParams.startNameSet_ = true;
-      newParams.indexStartName_ = key;
-    } else {
-      newParams.startNameSet_ = false;
-      newParams.indexStartName_ = '';
-    }
-    return newParams;
-  }
-
-  startAfter(indexValue: unknown, key?: string | null): QueryParams {
-    let params: QueryParams;
-    if (this.index_ === KEY_INDEX) {
-      if (typeof indexValue === 'string') {
-        indexValue = successor(indexValue as string);
-      }
-      params = this.startAt(indexValue, key);
-    } else {
-      let childKey: string;
-      if (key == null) {
-        childKey = MAX_NAME;
-      } else {
-        childKey = successor(key);
-      }
-      params = this.startAt(indexValue, childKey);
-    }
-    params.startAfterSet_ = true;
-    return params;
-  }
-
-  endAt(indexValue: unknown, key?: string | null): QueryParams {
-    const newParams = this.copy_();
-    newParams.endSet_ = true;
-    if (indexValue === undefined) {
-      indexValue = null;
-    }
-    newParams.indexEndValue_ = indexValue;
-    if (key !== undefined) {
-      newParams.endNameSet_ = true;
-      newParams.indexEndName_ = key;
-    } else {
-      newParams.endNameSet_ = false;
-      newParams.indexEndName_ = '';
-    }
-    return newParams;
-  }
-
-  endBefore(indexValue: unknown, key?: string | null): QueryParams {
+    params = startAt(queryParams, indexValue, key);
+  } else {
     let childKey: string;
-    let params: QueryParams;
-    if (this.index_ === KEY_INDEX) {
-      if (typeof indexValue === 'string') {
-        indexValue = predecessor(indexValue as string);
-      }
-      params = this.endAt(indexValue, key);
+    if (key == null) {
+      childKey = MAX_NAME;
     } else {
-      if (key == null) {
-        childKey = MIN_NAME;
-      } else {
-        childKey = predecessor(key);
-      }
-      params = this.endAt(indexValue, childKey);
+      childKey = successor(key);
     }
-    params.endBeforeSet_ = true;
-    return params;
+    params = startAt(queryParams, indexValue, childKey);
   }
+  params.startAfterSet_ = true;
+  return params;
+}
 
-  orderBy(index: Index): QueryParams {
-    const newParams = this.copy_();
-    newParams.index_ = index;
-    return newParams;
+function endAt(
+  queryParams: QueryParams,
+  indexValue: unknown,
+  key?: string | null
+): QueryParams {
+  const newParams = queryParams.copy();
+  newParams.endSet_ = true;
+  if (indexValue === undefined) {
+    indexValue = null;
   }
+  newParams.indexEndValue_ = indexValue;
+  if (key !== undefined) {
+    newParams.endNameSet_ = true;
+    newParams.indexEndName_ = key;
+  } else {
+    newParams.endNameSet_ = false;
+    newParams.indexEndName_ = '';
+  }
+  return newParams;
+}
 
-  getQueryObject(): {} {
-    const WIRE_PROTOCOL_CONSTANTS = QueryParams.WIRE_PROTOCOL_CONSTANTS_;
-    const obj: { [k: string]: unknown } = {};
-    if (this.startSet_) {
-      obj[WIRE_PROTOCOL_CONSTANTS.INDEX_START_VALUE] = this.indexStartValue_;
-      if (this.startNameSet_) {
-        obj[WIRE_PROTOCOL_CONSTANTS.INDEX_START_NAME] = this.indexStartName_;
-      }
+function endBefore(
+  queryParams: QueryParams,
+  indexValue: unknown,
+  key?: string | null
+): QueryParams {
+  let childKey: string;
+  let params: QueryParams;
+  if (queryParams.index_ === KEY_INDEX) {
+    if (typeof indexValue === 'string') {
+      indexValue = predecessor(indexValue as string);
     }
-    if (this.endSet_) {
-      obj[WIRE_PROTOCOL_CONSTANTS.INDEX_END_VALUE] = this.indexEndValue_;
-      if (this.endNameSet_) {
-        obj[WIRE_PROTOCOL_CONSTANTS.INDEX_END_NAME] = this.indexEndName_;
-      }
-    }
-    if (this.limitSet_) {
-      obj[WIRE_PROTOCOL_CONSTANTS.LIMIT] = this.limit_;
-      let viewFrom = this.viewFrom_;
-      if (viewFrom === '') {
-        if (this.isViewFromLeft()) {
-          viewFrom = WIRE_PROTOCOL_CONSTANTS.VIEW_FROM_LEFT;
-        } else {
-          viewFrom = WIRE_PROTOCOL_CONSTANTS.VIEW_FROM_RIGHT;
-        }
-      }
-      obj[WIRE_PROTOCOL_CONSTANTS.VIEW_FROM] = viewFrom;
-    }
-    // For now, priority index is the default, so we only specify if it's some other index
-    if (this.index_ !== PRIORITY_INDEX) {
-      obj[WIRE_PROTOCOL_CONSTANTS.INDEX] = this.index_.toString();
-    }
-    return obj;
-  }
-
-  loadsAllData(): boolean {
-    return !(this.startSet_ || this.endSet_ || this.limitSet_);
-  }
-
-  isDefault(): boolean {
-    return this.loadsAllData() && this.index_ === PRIORITY_INDEX;
-  }
-
-  getNodeFilter(): NodeFilter {
-    if (this.loadsAllData()) {
-      return new IndexedFilter(this.getIndex());
-    } else if (this.hasLimit()) {
-      return new LimitedFilter(this);
+    params = endAt(queryParams, indexValue, key);
+  } else {
+    if (key == null) {
+      childKey = MIN_NAME;
     } else {
-      return new RangedFilter(this);
+      childKey = predecessor(key);
     }
+    params = endAt(queryParams, indexValue, childKey);
   }
+  params.endBeforeSet_ = true;
+  return params;
+}
 
-  /**
-   * Returns a set of REST query string parameters representing this query.
-   *
-   * @return query string parameters
-   */
-  toRestQueryStringParameters(): { [k: string]: string | number } {
-    const REST_CONSTANTS = QueryParams.REST_QUERY_CONSTANTS_;
-    const qs: { [k: string]: string | number } = {};
+function orderBy(queryParams: QueryParams, index: Index): QueryParams {
+  const newParams = queryParams.copy();
+  newParams.index_ = index;
+  return newParams;
+}
 
-    if (this.isDefault()) {
-      return qs;
-    }
+/**
+ * Returns a set of REST query string parameters representing this query.
+ *
+ * @return query string parameters
+ */
+function toRestQueryStringParameters(
+  queryParams: QueryParams
+): Record<string, string | number> {
+  const qs: Record<string, string | number> = {};
 
-    let orderBy;
-    if (this.index_ === PRIORITY_INDEX) {
-      orderBy = REST_CONSTANTS.PRIORITY_INDEX;
-    } else if (this.index_ === VALUE_INDEX) {
-      orderBy = REST_CONSTANTS.VALUE_INDEX;
-    } else if (this.index_ === KEY_INDEX) {
-      orderBy = REST_CONSTANTS.KEY_INDEX;
-    } else {
-      assert(this.index_ instanceof PathIndex, 'Unrecognized index type!');
-      orderBy = this.index_.toString();
-    }
-    qs[REST_CONSTANTS.ORDER_BY] = stringify(orderBy);
-
-    if (this.startSet_) {
-      qs[REST_CONSTANTS.START_AT] = stringify(this.indexStartValue_);
-      if (this.startNameSet_) {
-        qs[REST_CONSTANTS.START_AT] += ',' + stringify(this.indexStartName_);
-      }
-    }
-
-    if (this.endSet_) {
-      qs[REST_CONSTANTS.END_AT] = stringify(this.indexEndValue_);
-      if (this.endNameSet_) {
-        qs[REST_CONSTANTS.END_AT] += ',' + stringify(this.indexEndName_);
-      }
-    }
-
-    if (this.limitSet_) {
-      if (this.isViewFromLeft()) {
-        qs[REST_CONSTANTS.LIMIT_TO_FIRST] = this.limit_;
-      } else {
-        qs[REST_CONSTANTS.LIMIT_TO_LAST] = this.limit_;
-      }
-    }
-
+  if (this.isDefault()) {
     return qs;
   }
+
+  let orderBy;
+  if (queryParams.index_ === PRIORITY_INDEX) {
+    orderBy = REST_QUERY_CONSTANTS.PRIORITY_INDEX;
+  } else if (queryParams.index_ === VALUE_INDEX) {
+    orderBy = REST_QUERY_CONSTANTS.VALUE_INDEX;
+  } else if (queryParams.index_ === KEY_INDEX) {
+    orderBy = REST_QUERY_CONSTANTS.KEY_INDEX;
+  } else {
+    assert(queryParams.index_ instanceof PathIndex, 'Unrecognized index type!');
+    orderBy = queryParams.index_.toString();
+  }
+  qs[REST_QUERY_CONSTANTS.ORDER_BY] = stringify(orderBy);
+
+  if (queryParams.startSet_) {
+    qs[REST_QUERY_CONSTANTS.START_AT] = stringify(queryParams.indexStartValue_);
+    if (queryParams.startNameSet_) {
+      qs[REST_QUERY_CONSTANTS.START_AT] +=
+        ',' + stringify(queryParams.indexStartName_);
+    }
+  }
+
+  if (queryParams.endSet_) {
+    qs[REST_QUERY_CONSTANTS.END_AT] = stringify(queryParams.indexEndValue_);
+    if (queryParams.endNameSet_) {
+      qs[REST_QUERY_CONSTANTS.END_AT] +=
+        ',' + stringify(queryParams.indexEndName_);
+    }
+  }
+
+  if (queryParams.limitSet_) {
+    if (queryParams.isViewFromLeft()) {
+      qs[REST_QUERY_CONSTANTS.LIMIT_TO_FIRST] = queryParams.limit_;
+    } else {
+      qs[REST_QUERY_CONSTANTS.LIMIT_TO_LAST] = queryParams.limit_;
+    }
+  }
+
+  return qs;
+}
+
+function getQueryObject(queryParams: QueryParams): Record<string, unknown> {
+  const obj: Record<string, unknown> = {};
+  if (queryParams.startSet_) {
+    obj[WIRE_PROTOCOL_CONSTANTS.INDEX_START_VALUE] =
+      queryParams.indexStartValue_;
+    if (queryParams.startNameSet_) {
+      obj[WIRE_PROTOCOL_CONSTANTS.INDEX_START_NAME] =
+        queryParams.indexStartName_;
+    }
+  }
+  if (queryParams.endSet_) {
+    obj[WIRE_PROTOCOL_CONSTANTS.INDEX_END_VALUE] = queryParams.indexEndValue_;
+    if (queryParams.endNameSet_) {
+      obj[WIRE_PROTOCOL_CONSTANTS.INDEX_END_NAME] = queryParams.indexEndName_;
+    }
+  }
+  if (queryParams.limitSet_) {
+    obj[WIRE_PROTOCOL_CONSTANTS.LIMIT] = queryParams.limit_;
+    let viewFrom = queryParams.viewFrom_;
+    if (viewFrom === '') {
+      if (queryParams.isViewFromLeft()) {
+        viewFrom = WIRE_PROTOCOL_CONSTANTS.VIEW_FROM_LEFT;
+      } else {
+        viewFrom = WIRE_PROTOCOL_CONSTANTS.VIEW_FROM_RIGHT;
+      }
+    }
+    obj[WIRE_PROTOCOL_CONSTANTS.VIEW_FROM] = viewFrom;
+  }
+  // For now, priority index is the default, so we only specify if it's some other index
+  if (queryParams.index_ !== PRIORITY_INDEX) {
+    obj[WIRE_PROTOCOL_CONSTANTS.INDEX] = queryParams.index_.toString();
+  }
+  return obj;
 }

--- a/packages/database/src/core/view/QueryParams.ts
+++ b/packages/database/src/core/view/QueryParams.ts
@@ -178,9 +178,6 @@ export class QueryParams {
     return !(this.startSet_ || this.endSet_ || this.limitSet_);
   }
 
-  /**
-   * What does isDefault() mean?
-   */
   isDefault(): boolean {
     return this.loadsAllData() && this.index_ === PRIORITY_INDEX;
   }

--- a/packages/database/src/core/view/QueryParams.ts
+++ b/packages/database/src/core/view/QueryParams.ts
@@ -203,7 +203,7 @@ export class QueryParams {
   }
 }
 
-export function getNodeFilter(queryParams: QueryParams): NodeFilter {
+export function queryParamsGetNodeFilter(queryParams: QueryParams): NodeFilter {
   if (queryParams.loadsAllData()) {
     return new IndexedFilter(queryParams.getIndex());
   } else if (queryParams.hasLimit()) {
@@ -213,7 +213,10 @@ export function getNodeFilter(queryParams: QueryParams): NodeFilter {
   }
 }
 
-export function limit(queryParams: QueryParams, newLimit: number): QueryParams {
+export function queryParamsLimit(
+  queryParams: QueryParams,
+  newLimit: number
+): QueryParams {
   const newParams = queryParams.copy();
   newParams.limitSet_ = true;
   newParams.limit_ = newLimit;
@@ -221,7 +224,7 @@ export function limit(queryParams: QueryParams, newLimit: number): QueryParams {
   return newParams;
 }
 
-export function limitToFirst(
+export function queryParamsLimitToFirst(
   queryParams: QueryParams,
   newLimit: number
 ): QueryParams {
@@ -232,7 +235,7 @@ export function limitToFirst(
   return newParams;
 }
 
-export function limitToLast(
+export function queryParamsLimitToLast(
   queryParams: QueryParams,
   newLimit: number
 ): QueryParams {
@@ -243,7 +246,7 @@ export function limitToLast(
   return newParams;
 }
 
-export function startAt(
+export function queryParamsStartAt(
   queryParams: QueryParams,
   indexValue: unknown,
   key?: string | null
@@ -264,7 +267,7 @@ export function startAt(
   return newParams;
 }
 
-export function startAfter(
+export function queryParamsStartAfter(
   queryParams: QueryParams,
   indexValue: unknown,
   key?: string | null
@@ -274,7 +277,7 @@ export function startAfter(
     if (typeof indexValue === 'string') {
       indexValue = successor(indexValue as string);
     }
-    params = startAt(queryParams, indexValue, key);
+    params = queryParamsStartAt(queryParams, indexValue, key);
   } else {
     let childKey: string;
     if (key == null) {
@@ -282,13 +285,13 @@ export function startAfter(
     } else {
       childKey = successor(key);
     }
-    params = startAt(queryParams, indexValue, childKey);
+    params = queryParamsStartAt(queryParams, indexValue, childKey);
   }
   params.startAfterSet_ = true;
   return params;
 }
 
-export function endAt(
+export function queryParamsEndAt(
   queryParams: QueryParams,
   indexValue: unknown,
   key?: string | null
@@ -309,7 +312,7 @@ export function endAt(
   return newParams;
 }
 
-export function endBefore(
+export function queryParamsEndBefore(
   queryParams: QueryParams,
   indexValue: unknown,
   key?: string | null
@@ -320,20 +323,23 @@ export function endBefore(
     if (typeof indexValue === 'string') {
       indexValue = predecessor(indexValue as string);
     }
-    params = endAt(queryParams, indexValue, key);
+    params = queryParamsEndAt(queryParams, indexValue, key);
   } else {
     if (key == null) {
       childKey = MIN_NAME;
     } else {
       childKey = predecessor(key);
     }
-    params = endAt(queryParams, indexValue, childKey);
+    params = queryParamsEndAt(queryParams, indexValue, childKey);
   }
   params.endBeforeSet_ = true;
   return params;
 }
 
-export function orderBy(queryParams: QueryParams, index: Index): QueryParams {
+export function queryParamsOrderBy(
+  queryParams: QueryParams,
+  index: Index
+): QueryParams {
   const newParams = queryParams.copy();
   newParams.index_ = index;
   return newParams;
@@ -344,7 +350,7 @@ export function orderBy(queryParams: QueryParams, index: Index): QueryParams {
  *
  * @return query string parameters
  */
-export function toRestQueryStringParameters(
+export function queryParamsToRestQueryStringParameters(
   queryParams: QueryParams
 ): Record<string, string | number> {
   const qs: Record<string, string | number> = {};
@@ -393,7 +399,7 @@ export function toRestQueryStringParameters(
   return qs;
 }
 
-export function getQueryObject(
+export function queryParamsGetQueryObject(
   queryParams: QueryParams
 ): Record<string, unknown> {
   const obj: Record<string, unknown> = {};

--- a/packages/database/src/core/view/View.ts
+++ b/packages/database/src/core/view/View.ts
@@ -34,7 +34,7 @@ import { Node } from '../snap/Node';
 import { Path, pathGetFront, pathIsEmpty } from '../util/Path';
 import { WriteTreeRef } from '../WriteTree';
 import { CancelEvent, Event } from './Event';
-import { getNodeFilter } from './QueryParams';
+import { queryParamsGetNodeFilter } from './QueryParams';
 
 /**
  * A view represents a specific location and query that has 1 or more event registrations.
@@ -55,7 +55,7 @@ export class View {
     const params = this.query_.getQueryParams();
 
     const indexFilter = new IndexedFilter(params.getIndex());
-    const filter = getNodeFilter(params);
+    const filter = queryParamsGetNodeFilter(params);
 
     this.processor_ = new ViewProcessor(filter);
 

--- a/packages/database/src/core/view/View.ts
+++ b/packages/database/src/core/view/View.ts
@@ -34,6 +34,7 @@ import { Node } from '../snap/Node';
 import { Path, pathGetFront, pathIsEmpty } from '../util/Path';
 import { WriteTreeRef } from '../WriteTree';
 import { CancelEvent, Event } from './Event';
+import { getNodeFilter } from './QueryParams';
 
 /**
  * A view represents a specific location and query that has 1 or more event registrations.
@@ -54,7 +55,7 @@ export class View {
     const params = this.query_.getQueryParams();
 
     const indexFilter = new IndexedFilter(params.getIndex());
-    const filter = params.getNodeFilter();
+    const filter = getNodeFilter(params);
 
     this.processor_ = new ViewProcessor(filter);
 


### PR DESCRIPTION
I kept simple getters and `copy()` within the class. Other methods are changed to functions.