### PR TITLE
Remove storage-types/exp

### DIFF
--- a/common/api-review/storage.api.md
+++ b/common/api-review/storage.api.md
@@ -4,27 +4,34 @@
 
 ```ts
 
-import { FirebaseApp } from '@firebase/app-types';
-import { FirebaseStorageError } from '@firebase/storage-types/exp';
-import { FullMetadata } from '@firebase/storage-types/exp';
-import { ListOptions } from '@firebase/storage-types/exp';
-import { ListResult } from '@firebase/storage-types/exp';
-import { SettableMetadata } from '@firebase/storage-types/exp';
-import { StorageObserver } from '@firebase/storage-types/exp';
-import { StorageReference } from '@firebase/storage-types/exp';
-import { StorageService } from '@firebase/storage-types/exp';
-import { TaskEvent } from '@firebase/storage-types/exp';
-import { TaskState } from '@firebase/storage-types/exp';
-import { UploadMetadata } from '@firebase/storage-types/exp';
-import { UploadResult } from '@firebase/storage-types/exp';
-import { UploadTask } from '@firebase/storage-types/exp';
+import { CompleteFn } from '@firebase/util';
+import { FirebaseApp } from '@firebase/app';
+import { FirebaseError } from '@firebase/util';
+import { NextFn } from '@firebase/util';
+import { Subscribe } from '@firebase/util';
+import { Unsubscribe } from '@firebase/util';
 
 // @public
 export function deleteObject(ref: StorageReference): Promise<void>;
 
-export { FirebaseStorageError }
+// @public
+export interface FirebaseStorageError extends FirebaseError {
+    serverResponse: string | null;
+}
 
-export { FullMetadata }
+// @public
+export interface FullMetadata extends UploadMetadata {
+    bucket: string;
+    downloadTokens: string[] | undefined;
+    fullPath: string;
+    generation: string;
+    metageneration: string;
+    name: string;
+    ref?: StorageReference | undefined;
+    size: number;
+    timeCreated: string;
+    updated: string;
+}
 
 // @public
 export function getDownloadURL(ref: StorageReference): Promise<string>;
@@ -41,9 +48,18 @@ export function list(ref: StorageReference, options?: ListOptions): Promise<List
 // @public
 export function listAll(ref: StorageReference): Promise<ListResult>;
 
-export { ListOptions }
+// @public
+export interface ListOptions {
+    maxResults?: number | null;
+    pageToken?: string | null;
+}
 
-export { ListResult }
+// @public
+export interface ListResult {
+    items: StorageReference[];
+    nextPageToken?: string;
+    prefixes: StorageReference[];
+}
 
 // @public
 export function ref(storage: StorageService, url?: string): StorageReference;
@@ -51,13 +67,45 @@ export function ref(storage: StorageService, url?: string): StorageReference;
 // @public
 export function ref(storageOrRef: StorageService | StorageReference, path?: string): StorageReference;
 
-export { SettableMetadata }
+// @public
+export interface SettableMetadata {
+    cacheControl?: string | undefined;
+    contentDisposition?: string | undefined;
+    contentEncoding?: string | undefined;
+    contentLanguage?: string | undefined;
+    contentType?: string | undefined;
+    customMetadata?: {
+        [key: string]: string;
+    } | undefined;
+}
 
-export { StorageObserver }
+// @public
+export interface StorageObserver<T> {
+    // (undocumented)
+    complete?: CompleteFn | null;
+    // (undocumented)
+    error?: (error: FirebaseStorageError) => void | null;
+    // (undocumented)
+    next?: NextFn<T> | null;
+}
 
-export { StorageReference }
+// @public
+export interface StorageReference {
+    bucket: string;
+    fullPath: string;
+    name: string;
+    parent: StorageReference | null;
+    root: StorageReference;
+    storage: StorageService;
+    toString(): string;
+}
 
-export { StorageService }
+// @public
+export interface StorageService {
+    readonly app: FirebaseApp;
+    maxOperationRetryTime: number;
+    maxUploadRetryTime: number;
+}
 
 // @public
 export type StringFormat = string;
@@ -70,9 +118,11 @@ export const StringFormat: {
     DATA_URL: string;
 };
 
-export { TaskEvent }
+// @public
+export type TaskEvent = 'state_changed';
 
-export { TaskState }
+// @public
+export type TaskState = 'running' | 'paused' | 'success' | 'canceled' | 'error';
 
 // @public
 export function updateMetadata(ref: StorageReference, metadata: SettableMetadata): Promise<FullMetadata>;
@@ -83,14 +133,40 @@ export function uploadBytes(ref: StorageReference, data: Blob | Uint8Array | Arr
 // @public
 export function uploadBytesResumable(ref: StorageReference, data: Blob | Uint8Array | ArrayBuffer, metadata?: UploadMetadata): UploadTask;
 
-export { UploadMetadata }
+// @public
+export interface UploadMetadata extends SettableMetadata {
+    md5Hash?: string | undefined;
+}
 
-export { UploadResult }
+// @public
+export interface UploadResult {
+    readonly metadata: FullMetadata;
+    readonly ref: StorageReference;
+}
 
 // @public
 export function uploadString(ref: StorageReference, value: string, format?: string, metadata?: UploadMetadata): Promise<UploadResult>;
 
-export { UploadTask }
+// @public
+export interface UploadTask {
+    cancel(): boolean;
+    catch(onRejected: (error: FirebaseStorageError) => unknown): Promise<unknown>;
+    on(event: TaskEvent, nextOrObserver?: StorageObserver<UploadTaskSnapshot> | null | ((snapshot: UploadTaskSnapshot) => unknown), error?: ((a: FirebaseStorageError) => unknown) | null, complete?: Unsubscribe | null): Unsubscribe | Subscribe<UploadTaskSnapshot>;
+    pause(): boolean;
+    resume(): boolean;
+    snapshot: UploadTaskSnapshot;
+    then(onFulfilled?: ((snapshot: UploadTaskSnapshot) => unknown) | null, onRejected?: ((error: FirebaseStorageError) => unknown) | null): Promise<unknown>;
+}
+
+// @public
+export interface UploadTaskSnapshot {
+    bytesTransferred: number;
+    metadata: FullMetadata;
+    ref: StorageReference;
+    state: TaskState;
+    task: UploadTask;
+    totalBytes: number;
+}
 
 
 // (No @packageDocumentation comment for this package)

--- a/packages/storage/exp/index.ts
+++ b/packages/storage/exp/index.ts
@@ -52,7 +52,7 @@ import {
   SettableMetadata,
   UploadMetadata,
   FullMetadata
-} from '@firebase/storage-types/exp';
+} from './public-types';
 import { Metadata as MetadataInternal } from '../src/metadata';
 import {
   uploadBytes as uploadBytesInternal,

--- a/packages/storage/exp/index.ts
+++ b/packages/storage/exp/index.ts
@@ -51,7 +51,8 @@ import {
   StorageObserver,
   SettableMetadata,
   UploadMetadata,
-  FullMetadata
+  FullMetadata,
+  UploadTaskSnapshot
 } from './public-types';
 import { Metadata as MetadataInternal } from '../src/metadata';
 import {
@@ -83,7 +84,8 @@ export {
   FirebaseStorageError,
   TaskEvent,
   TaskState,
-  StorageObserver
+  StorageObserver,
+  UploadTaskSnapshot
 };
 
 /**

--- a/packages/storage/exp/index.ts
+++ b/packages/storage/exp/index.ts
@@ -45,14 +45,9 @@ import {
   ListOptions,
   ListResult,
   UploadTask,
-  FirebaseStorageError,
-  TaskEvent,
-  TaskState,
-  StorageObserver,
   SettableMetadata,
   UploadMetadata,
-  FullMetadata,
-  UploadTaskSnapshot
+  FullMetadata
 } from './public-types';
 import { Metadata as MetadataInternal } from '../src/metadata';
 import {
@@ -71,22 +66,7 @@ import {
 /**
  * Public types.
  */
-export {
-  StorageReference,
-  StorageService,
-  UploadMetadata,
-  SettableMetadata,
-  FullMetadata,
-  UploadResult,
-  ListOptions,
-  ListResult,
-  UploadTask,
-  FirebaseStorageError,
-  TaskEvent,
-  TaskState,
-  StorageObserver,
-  UploadTaskSnapshot
-};
+export * from './public-types';
 
 /**
  * Uploads data to this object's location.

--- a/packages/storage/exp/public-types.ts
+++ b/packages/storage/exp/public-types.ts
@@ -15,8 +15,15 @@
  * limitations under the License.
  */
 
-import { FirebaseApp, _FirebaseService } from '@firebase/app-types-exp';
-import { CompleteFn, FirebaseError, NextFn, Unsubscribe } from '@firebase/util';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { FirebaseApp } from '@firebase/app-exp';
+import {
+  CompleteFn,
+  FirebaseError,
+  NextFn,
+  Subscribe,
+  Unsubscribe
+} from '@firebase/util';
 
 /**
  * A Firebase Storage instance.
@@ -245,7 +252,7 @@ export type TaskState = 'running' | 'paused' | 'success' | 'canceled' | 'error';
  * An error returned by the Firebase Storage SDK.
  * @public
  */
-interface FirebaseStorageError extends FirebaseError {
+export interface FirebaseStorageError extends FirebaseError {
   /**
    * A server response message for the error, if applicable.
    */
@@ -276,7 +283,7 @@ export interface UploadTask {
   /**
    * Equivalent to calling `then(null, onRejected)`.
    */
-  catch(onRejected: (error: FirebaseStorageError) => any): Promise<any>;
+  catch(onRejected: (error: FirebaseStorageError) => unknown): Promise<unknown>;
   /**
    * Listens for events on this task.
    *
@@ -391,10 +398,10 @@ export interface UploadTask {
     nextOrObserver?:
       | StorageObserver<UploadTaskSnapshot>
       | null
-      | ((snapshot: UploadTaskSnapshot) => any),
-    error?: ((a: FirebaseStorageError) => any) | null,
+      | ((snapshot: UploadTaskSnapshot) => unknown),
+    error?: ((a: FirebaseStorageError) => unknown) | null,
     complete?: Unsubscribe | null
-  ): Function;
+  ): Unsubscribe | Subscribe<UploadTaskSnapshot>;
 
   /**
    * Pauses a currently running task. Has no effect on a paused or failed task.
@@ -419,9 +426,9 @@ export interface UploadTask {
    * @param onRejected - The rejection callback.
    */
   then(
-    onFulfilled?: ((snapshot: UploadTaskSnapshot) => any) | null,
-    onRejected?: ((error: FirebaseStorageError) => any) | null
-  ): Promise<any>;
+    onFulfilled?: ((snapshot: UploadTaskSnapshot) => unknown) | null,
+    onRejected?: ((error: FirebaseStorageError) => unknown) | null
+  ): Promise<unknown>;
 }
 
 /**

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -15,7 +15,7 @@
     "lint": "eslint -c .eslintrc.js '**/*.ts' --ignore-path '../../.gitignore'",
     "lint:fix": "eslint --fix -c .eslintrc.js '**/*.ts' --ignore-path '../../.gitignore'",
     "build": "rollup -c rollup.config.compat.js && yarn build:exp",
-    "build:exp": "rollup -c rollup.config.exp.js ; yarn api-report",
+    "build:exp": "rollup -c rollup.config.exp.js && yarn api-report",
     "build:deps": "lerna run --scope @firebase/storage --include-dependencies build",
     "dev": "rollup -c -w",
     "test": "run-p test:browser lint",

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -15,7 +15,7 @@
     "lint": "eslint -c .eslintrc.js '**/*.ts' --ignore-path '../../.gitignore'",
     "lint:fix": "eslint --fix -c .eslintrc.js '**/*.ts' --ignore-path '../../.gitignore'",
     "build": "rollup -c rollup.config.compat.js && yarn build:exp",
-    "build:exp": "rollup -c rollup.config.exp.js && yarn api-report",
+    "build:exp": "rollup -c rollup.config.exp.js ; yarn api-report",
     "build:deps": "lerna run --scope @firebase/storage --include-dependencies build",
     "dev": "rollup -c -w",
     "test": "run-p test:browser lint",

--- a/packages/storage/src/metadata.ts
+++ b/packages/storage/src/metadata.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { FullMetadata } from '@firebase/storage-types/exp';
+import { FullMetadata } from '../exp/public-types';
 
 /**
  * @fileoverview Documentation for the metadata format.

--- a/packages/storage/src/reference.ts
+++ b/packages/storage/src/reference.ts
@@ -31,7 +31,7 @@ import {
   deleteObject as requestsDeleteObject,
   multipartUpload
 } from './implementation/requests';
-import { ListOptions } from '@firebase/storage-types/exp';
+import { ListOptions } from '../exp/public-types';
 import { StringFormat, dataFromString } from './implementation/string';
 import { Metadata } from './metadata';
 import { StorageService } from './service';

--- a/packages/storage/test/integration/integration.exp.test.ts
+++ b/packages/storage/test/integration/integration.exp.test.ts
@@ -34,7 +34,7 @@ import {
 
 import { use, expect } from 'chai';
 import * as chaiAsPromised from 'chai-as-promised';
-import * as types from '@firebase/storage-types/exp';
+import * as types from '../../exp/public-types';
 
 use(chaiAsPromised);
 

--- a/scripts/exp/prepare-storage-for-exp-release.ts
+++ b/scripts/exp/prepare-storage-for-exp-release.ts
@@ -37,10 +37,7 @@ export async function prepare() {
   // Update package.json
   const packageJson = await readPackageJson(packagePath);
   const expPackageJson = await readPackageJson(`${packagePath}/exp`);
-  const typesPackageJson = await readPackageJson(`${packagePath}-types`);
   packageJson.version = '0.0.900';
-  typesPackageJson.version = '0.0.900';
-  typesPackageJson.files = `['exp/index.d.ts']`;
 
   packageJson.peerDependencies = {
     '@firebase/app-exp': '0.x'
@@ -60,11 +57,6 @@ export async function prepare() {
   await writeFile(
     `${packagePath}/package.json`,
     `${JSON.stringify(packageJson, null, 2)}\n`,
-    { encoding: 'utf-8' }
-  );
-  await writeFile(
-    `${packagePath}-types/package.json`,
-    `${JSON.stringify(typesPackageJson, null, 2)}\n`,
     { encoding: 'utf-8' }
   );
 }

--- a/scripts/exp/release.ts
+++ b/scripts/exp/release.ts
@@ -75,7 +75,6 @@ async function publishExpPackages({ dryRun }: { dryRun: boolean }) {
 
     packagePaths.push(`${projectRoot}/packages/firestore`);
     packagePaths.push(`${projectRoot}/packages/storage`);
-    packagePaths.push(`${projectRoot}/packages/storage-types`);
     packagePaths.push(`${projectRoot}/packages/database`);
 
     /**


### PR DESCRIPTION
Remove exp types for storage as part of the effort to remove all -types packages from the exp SDK.