### PR TITLE
Fix the OAuth credential logic, and add support for OIDC

### DIFF
--- a/packages-exp/auth-exp/src/core/providers/oauth.test.ts
+++ b/packages-exp/auth-exp/src/core/providers/oauth.test.ts
@@ -87,7 +87,7 @@ describe('core/providers/oauth', () => {
         ...TEST_ID_TOKEN_RESPONSE,
         pendingToken: 'pending-token',
         oauthIdToken: 'id-token',
-        providerId: 'oidc.oidctest',
+        providerId: 'oidc.oidctest'
       },
       operationType: OperationType.SIGN_IN
     });
@@ -95,7 +95,9 @@ describe('core/providers/oauth', () => {
     expect(cred.idToken).to.eq('id-token');
     expect(cred.providerId).to.eq('oidc.oidctest');
     expect(cred.signInMethod).to.eq('oidc.oidctest');
-    expect((cred.toJSON() as Record<string, string>).pendingToken).to.eq('pending-token');
+    expect((cred.toJSON() as Record<string, string>).pendingToken).to.eq(
+      'pending-token'
+    );
   });
 
   it('credentialFromError creates the cred from a tagged error', () => {

--- a/packages-exp/auth-exp/src/core/providers/oauth.test.ts
+++ b/packages-exp/auth-exp/src/core/providers/oauth.test.ts
@@ -78,6 +78,26 @@ describe('core/providers/oauth', () => {
     expect(OAuthProvider.credentialFromResult(userCred)).to.be.null;
   });
 
+  it('credentialFromResult works for oidc', async () => {
+    const auth = await testAuth();
+    const userCred = new UserCredentialImpl({
+      user: testUser(auth, 'uid'),
+      providerId: ProviderId.GOOGLE,
+      _tokenResponse: {
+        ...TEST_ID_TOKEN_RESPONSE,
+        pendingToken: 'pending-token',
+        oauthIdToken: 'id-token',
+        providerId: 'oidc.oidctest',
+      },
+      operationType: OperationType.SIGN_IN
+    });
+    const cred = OAuthProvider.credentialFromResult(userCred)!;
+    expect(cred.idToken).to.eq('id-token');
+    expect(cred.providerId).to.eq('oidc.oidctest');
+    expect(cred.signInMethod).to.eq('oidc.oidctest');
+    expect((cred.toJSON() as Record<string, string>).pendingToken).to.eq('pending-token');
+  });
+
   it('credentialFromError creates the cred from a tagged error', () => {
     const error = _createError(AuthErrorCode.NEED_CONFIRMATION, {
       appName: 'foo'

--- a/packages-exp/auth-exp/src/core/providers/oauth.ts
+++ b/packages-exp/auth-exp/src/core/providers/oauth.ts
@@ -20,7 +20,7 @@ import { AuthProvider, UserCredential } from '../../model/public_types';
 import { _assert } from '../util/assert';
 import { AuthErrorCode } from '../errors';
 
-import { OAuthCredential } from '../credentials/oauth';
+import { OAuthCredential, OAuthCredentialParams } from '../credentials/oauth';
 import { UserCredentialInternal } from '../../model/user';
 import { FirebaseError } from '@firebase/util';
 import { TaggedWithTokenResponse } from '../../model/id_token';
@@ -146,12 +146,17 @@ export class OAuthProvider implements AuthProvider {
    * or the ID token string.
    */
   credential(params: OAuthCredentialOptions): OAuthCredential {
-    _assert(params.idToken && params.accessToken, AuthErrorCode.ARGUMENT_ERROR);
+    return this._credential(params);
+  }
+
+  /** An internal credential method that accepts more permissive options */
+  private _credential(params: OAuthCredentialOptions | OAuthCredentialParams): OAuthCredential {
+    _assert(params.idToken || params.accessToken, AuthErrorCode.ARGUMENT_ERROR);
     // For OAuthCredential, sign in method is same as providerId.
     return OAuthCredential._fromParams({
+      ...params,
       providerId: this.providerId,
       signInMethod: this.providerId,
-      ...params
     });
   }
 
@@ -261,10 +266,11 @@ export class OAuthProvider implements AuthProvider {
     }
 
     try {
-      return new OAuthProvider(providerId).credential({
+      return new OAuthProvider(providerId)._credential({
         idToken: oauthIdToken,
         accessToken: oauthAccessToken,
-        rawNonce: nonce
+        rawNonce: nonce,
+        pendingToken,
       });
     } catch (e) {
       return null;

--- a/packages-exp/auth-exp/src/core/providers/oauth.ts
+++ b/packages-exp/auth-exp/src/core/providers/oauth.ts
@@ -156,7 +156,7 @@ export class OAuthProvider implements AuthProvider {
     return OAuthCredential._fromParams({
       ...params,
       providerId: this.providerId,
-      signInMethod: this.providerId,
+      signInMethod: this.providerId
     });
   }
 
@@ -270,7 +270,7 @@ export class OAuthProvider implements AuthProvider {
         idToken: oauthIdToken,
         accessToken: oauthAccessToken,
         rawNonce: nonce,
-        pendingToken,
+        pendingToken
       });
     } catch (e) {
       return null;

--- a/packages-exp/auth-exp/src/core/providers/oauth.ts
+++ b/packages-exp/auth-exp/src/core/providers/oauth.ts
@@ -150,7 +150,9 @@ export class OAuthProvider implements AuthProvider {
   }
 
   /** An internal credential method that accepts more permissive options */
-  private _credential(params: OAuthCredentialOptions | OAuthCredentialParams): OAuthCredential {
+  private _credential(
+    params: OAuthCredentialOptions | OAuthCredentialParams
+  ): OAuthCredential {
     _assert(params.idToken || params.accessToken, AuthErrorCode.ARGUMENT_ERROR);
     // For OAuthCredential, sign in method is same as providerId.
     return OAuthCredential._fromParams({

--- a/packages-exp/auth-exp/src/core/user/additional_user_info.ts
+++ b/packages-exp/auth-exp/src/core/user/additional_user_info.ts
@@ -82,7 +82,7 @@ export function _fromIdTokenResponse(
 class GenericAdditionalUserInfo implements AdditionalUserInfo {
   constructor(
     readonly isNewUser: boolean,
-    readonly providerId: ProviderId | null,
+    readonly providerId: ProviderId | string | null,
     readonly profile: Record<string, unknown> = {}
   ) {}
 }

--- a/packages-exp/auth-exp/src/core/user/user_credential_impl.ts
+++ b/packages-exp/auth-exp/src/core/user/user_credential_impl.ts
@@ -25,7 +25,7 @@ import { AuthInternal } from '../../model/auth';
 
 interface UserCredentialParams {
   readonly user: UserInternal;
-  readonly providerId: ProviderId | null;
+  readonly providerId: ProviderId | string | null;
   readonly _tokenResponse?: PhoneOrOauthTokenResponse;
   readonly operationType: OperationType;
 }
@@ -33,7 +33,7 @@ interface UserCredentialParams {
 export class UserCredentialImpl
   implements UserCredentialInternal, UserCredentialParams {
   readonly user: UserInternal;
-  readonly providerId: ProviderId | null;
+  readonly providerId: ProviderId | string | null;
   readonly _tokenResponse: PhoneOrOauthTokenResponse | undefined;
   readonly operationType: OperationType;
 
@@ -81,7 +81,7 @@ export class UserCredentialImpl
   }
 }
 
-function providerIdForResponse(response: IdTokenResponse): ProviderId | null {
+function providerIdForResponse(response: IdTokenResponse): ProviderId | string | null {
   if (response.providerId) {
     return response.providerId;
   }

--- a/packages-exp/auth-exp/src/core/user/user_credential_impl.ts
+++ b/packages-exp/auth-exp/src/core/user/user_credential_impl.ts
@@ -81,7 +81,9 @@ export class UserCredentialImpl
   }
 }
 
-function providerIdForResponse(response: IdTokenResponse): ProviderId | string | null {
+function providerIdForResponse(
+  response: IdTokenResponse
+): ProviderId | string | null {
   if (response.providerId) {
     return response.providerId;
   }

--- a/packages-exp/auth-exp/src/model/id_token.ts
+++ b/packages-exp/auth-exp/src/model/id_token.ts
@@ -55,7 +55,7 @@ export interface IdTokenResponse {
   idToken?: IdToken;
   refreshToken?: string;
   expiresIn?: string;
-  providerId?: ProviderId|string;
+  providerId?: ProviderId | string;
 
   // Used in AdditionalUserInfo
   displayName?: string | null;

--- a/packages-exp/auth-exp/src/model/id_token.ts
+++ b/packages-exp/auth-exp/src/model/id_token.ts
@@ -55,7 +55,7 @@ export interface IdTokenResponse {
   idToken?: IdToken;
   refreshToken?: string;
   expiresIn?: string;
-  providerId?: ProviderId;
+  providerId?: ProviderId|string;
 
   // Used in AdditionalUserInfo
   displayName?: string | null;


### PR DESCRIPTION
The OIDC stuff was pretty much there already, but the type for several things internally needed to be changed from strictly `ProviderId` to `ProviderId | string` as OIDC provider IDs are arbitrary strings