### PR TITLE
Remove RepoManager

### DIFF
--- a/packages/database/index.node.ts
+++ b/packages/database/index.node.ts
@@ -15,14 +15,14 @@
  * limitations under the License.
  */
 
-import { FirebaseNamespace, FirebaseApp } from '@firebase/app-types';
+import { FirebaseApp, FirebaseNamespace } from '@firebase/app-types';
 import { _FirebaseNamespace } from '@firebase/app-types/private';
 import { Database } from './src/api/Database';
 import { DataSnapshot } from './src/api/DataSnapshot';
 import { Query } from './src/api/Query';
 import { Reference } from './src/api/Reference';
 import { enableLogging } from './src/core/util/util';
-import { RepoManager } from './src/core/RepoManager';
+import { repoManagerDatabaseFromApp } from './src/core/RepoManager';
 import * as INTERNAL from './src/api/internal';
 import * as TEST_ACCESS from './src/api/test_access';
 import * as types from '@firebase/database-types';
@@ -90,11 +90,7 @@ export function registerDatabase(instance: FirebaseNamespace) {
         const app = container.getProvider('app').getImmediate();
         const authProvider = container.getProvider('auth-internal');
 
-        return RepoManager.getInstance().databaseFromApp(
-          app,
-          authProvider,
-          url
-        );
+        return repoManagerDatabaseFromApp(app, authProvider, url, undefined);
       },
       ComponentType.PUBLIC
     )

--- a/packages/database/index.ts
+++ b/packages/database/index.ts
@@ -24,7 +24,7 @@ import { DataSnapshot } from './src/api/DataSnapshot';
 import { Query } from './src/api/Query';
 import { Reference } from './src/api/Reference';
 import { enableLogging } from './src/core/util/util';
-import { RepoManager } from './src/core/RepoManager';
+import { repoManagerDatabaseFromApp } from './src/core/RepoManager';
 import * as INTERNAL from './src/api/internal';
 import * as TEST_ACCESS from './src/api/test_access';
 import { isNodeSdk } from '@firebase/util';
@@ -50,11 +50,7 @@ export function registerDatabase(instance: FirebaseNamespace) {
         const app = container.getProvider('app').getImmediate();
         const authProvider = container.getProvider('auth-internal');
 
-        return RepoManager.getInstance().databaseFromApp(
-          app,
-          authProvider,
-          url
-        );
+        return repoManagerDatabaseFromApp(app, authProvider, url, undefined);
       },
       ComponentType.PUBLIC
     )

--- a/packages/database/src/api/Database.ts
+++ b/packages/database/src/api/Database.ts
@@ -20,7 +20,10 @@ import { parseRepoInfo } from '../core/util/libs/parser';
 import { newEmptyPath } from '../core/util/Path';
 import { Reference } from './Reference';
 import { Repo, repoInterrupt, repoResume, repoStart } from '../core/Repo';
-import { RepoManager } from '../core/RepoManager';
+import {
+  repoManagerApplyEmulatorSettings,
+  repoManagerDeleteRepo
+} from '../core/RepoManager';
 import { validateArgCount } from '@firebase/util';
 import { validateUrl } from '../core/util/validation';
 import { FirebaseApp } from '@firebase/app-types';
@@ -63,7 +66,7 @@ export class Database implements FirebaseService {
   INTERNAL = {
     delete: async () => {
       this.checkDeleted_('delete');
-      RepoManager.getInstance().deleteRepo(this.repo_);
+      repoManagerDeleteRepo(this.repo_);
       this.repoInternal_ = null;
       this.rootInternal_ = null;
     }
@@ -107,11 +110,7 @@ export class Database implements FirebaseService {
     }
 
     // Modify the repo to apply emulator settings
-    RepoManager.getInstance().applyEmulatorSettings(
-      this.repoInternal_,
-      host,
-      port
-    );
+    repoManagerApplyEmulatorSettings(this.repoInternal_, host, port);
   }
 
   /**

--- a/packages/database/src/api/internal.ts
+++ b/packages/database/src/api/internal.ts
@@ -18,7 +18,7 @@
 import { WebSocketConnection } from '../realtime/WebSocketConnection';
 import { BrowserPollConnection } from '../realtime/BrowserPollConnection';
 import { Reference } from './Reference';
-import { RepoManager } from '../core/RepoManager';
+import { repoManagerDatabaseFromApp } from '../core/RepoManager';
 import { setSDKVersion } from '../core/version';
 import { FirebaseApp } from '@firebase/app-types';
 import {
@@ -27,10 +27,10 @@ import {
 } from '@firebase/auth-interop-types';
 import * as types from '@firebase/database-types';
 import {
-  Provider,
-  ComponentContainer,
   Component,
-  ComponentType
+  ComponentContainer,
+  ComponentType,
+  Provider
 } from '@firebase/component';
 import {
   repoInterceptServerData,
@@ -127,7 +127,7 @@ export function initStandalone<T>({
   );
 
   return {
-    instance: RepoManager.getInstance().databaseFromApp(
+    instance: repoManagerDatabaseFromApp(
       app,
       authProvider,
       url,

--- a/packages/database/src/api/test_access.ts
+++ b/packages/database/src/api/test_access.ts
@@ -17,7 +17,7 @@
 
 import { RepoInfo } from '../core/RepoInfo';
 import { PersistentConnection } from '../core/PersistentConnection';
-import { RepoManager } from '../core/RepoManager';
+import { repoManagerForceRestClient } from '../core/RepoManager';
 import { Connection } from '../realtime/Connection';
 import { Query } from './Query';
 
@@ -70,5 +70,5 @@ export const queryIdentifier = function (query: Query) {
  * Forces the RepoManager to create Repos that use ReadonlyRestClient instead of PersistentConnection.
  */
 export const forceRestClient = function (forceRestClient: boolean) {
-  RepoManager.getInstance().forceRestClient(forceRestClient);
+  repoManagerForceRestClient(forceRestClient);
 };

--- a/packages/database/src/core/RepoManager.ts
+++ b/packages/database/src/core/RepoManager.ts
@@ -19,7 +19,7 @@ import { FirebaseApp } from '@firebase/app-types';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { FirebaseApp as FirebaseAppExp } from '@firebase/app-exp';
 import { safeGet } from '@firebase/util';
-import { Repo, repoGetDatabase, repoInterrupt, repoResume } from './Repo';
+import { Repo, repoGetDatabase, repoInterrupt } from './Repo';
 import { fatal, log } from './util/util';
 import { parseRepoInfo } from './util/libs/parser';
 import { validateUrl } from './util/validation';
@@ -44,8 +44,6 @@ import { pathIsEmpty } from './util/Path';
  */
 const FIREBASE_DATABASE_EMULATOR_HOST_VAR = 'FIREBASE_DATABASE_EMULATOR_HOST';
 
-let _staticInstance: RepoManager;
-
 /**
  * Intersection type that allows the SDK to be used from firebase-exp and
  * firebase v8.
@@ -55,171 +53,149 @@ export type FirebaseAppLike = FirebaseApp | FirebaseAppExp;
 /**
  * Creates and caches Repo instances.
  */
-export class RepoManager {
-  private repos_: {
-    [appName: string]: {
-      [dbUrl: string]: Repo;
-    };
-  } = {};
+const repos: {
+  [appName: string]: {
+    [dbUrl: string]: Repo;
+  };
+} = {};
 
-  /**
-   * If true, new Repos will be created to use ReadonlyRestClient (for testing purposes).
-   */
-  private useRestClient_: boolean = false;
+/**
+ * If true, new Repos will be created to use ReadonlyRestClient (for testing purposes).
+ */
+let useRestClient = false;
 
-  static getInstance(): RepoManager {
-    if (!_staticInstance) {
-      _staticInstance = new RepoManager();
+/**
+ * Update an existing repo in place to point to a new host/port.
+ */
+export function repoManagerApplyEmulatorSettings(
+  repo: Repo,
+  host: string,
+  port: number
+): void {
+  repo.repoInfo_ = new RepoInfo(
+    `${host}:${port}`,
+    /* secure= */ false,
+    repo.repoInfo_.namespace,
+    repo.repoInfo_.webSocketOnly,
+    repo.repoInfo_.nodeAdmin,
+    repo.repoInfo_.persistenceKey,
+    repo.repoInfo_.includeNamespaceInQueryParams
+  );
+
+  if (repo.repoInfo_.nodeAdmin) {
+    repo.authTokenProvider_ = new EmulatorAdminTokenProvider();
+  }
+}
+
+/**
+ * This function should only ever be called to CREATE a new database instance.
+ */
+export function repoManagerDatabaseFromApp(
+  app: FirebaseAppLike,
+  authProvider: Provider<FirebaseAuthInternalName>,
+  url?: string,
+  nodeAdmin?: boolean
+): Database {
+  let dbUrl: string | undefined = url || app.options.databaseURL;
+  if (dbUrl === undefined) {
+    if (!app.options.projectId) {
+      fatal(
+        "Can't determine Firebase Database URL. Be sure to include " +
+          ' a Project ID when calling firebase.initializeApp().'
+      );
     }
-    return _staticInstance;
+
+    log('Using default host for project ', app.options.projectId);
+    dbUrl = `${app.options.projectId}-default-rtdb.firebaseio.com`;
   }
 
-  // TODO(koss): Remove these functions unless used in tests?
-  interrupt() {
-    for (const appName of Object.keys(this.repos_)) {
-      for (const dbUrl of Object.keys(this.repos_[appName])) {
-        repoInterrupt(this.repos_[appName][dbUrl]);
-      }
-    }
+  let parsedUrl = parseRepoInfo(dbUrl, nodeAdmin);
+  let repoInfo = parsedUrl.repoInfo;
+
+  let isEmulator: boolean;
+
+  let dbEmulatorHost: string | undefined = undefined;
+  if (typeof process !== 'undefined') {
+    dbEmulatorHost = process.env[FIREBASE_DATABASE_EMULATOR_HOST_VAR];
   }
 
-  resume() {
-    for (const appName of Object.keys(this.repos_)) {
-      for (const dbUrl of Object.keys(this.repos_[appName])) {
-        repoResume(this.repos_[appName][dbUrl]);
-      }
-    }
+  if (dbEmulatorHost) {
+    isEmulator = true;
+    dbUrl = `http://${dbEmulatorHost}?ns=${repoInfo.namespace}`;
+    parsedUrl = parseRepoInfo(dbUrl, nodeAdmin);
+    repoInfo = parsedUrl.repoInfo;
+  } else {
+    isEmulator = !parsedUrl.repoInfo.secure;
   }
 
-  /**
-   * Update an existing repo in place to point to a new host/port.
-   */
-  applyEmulatorSettings(repo: Repo, host: string, port: number): void {
-    repo.repoInfo_ = new RepoInfo(
-      `${host}:${port}`,
-      /* secure= */ false,
-      repo.repoInfo_.namespace,
-      repo.repoInfo_.webSocketOnly,
-      repo.repoInfo_.nodeAdmin,
-      repo.repoInfo_.persistenceKey,
-      repo.repoInfo_.includeNamespaceInQueryParams
+  const authTokenProvider =
+    nodeAdmin && isEmulator
+      ? new EmulatorAdminTokenProvider()
+      : new FirebaseAuthTokenProvider(app, authProvider);
+
+  validateUrl('Invalid Firebase Database URL', 1, parsedUrl);
+  if (!pathIsEmpty(parsedUrl.path)) {
+    fatal(
+      'Database URL must point to the root of a Firebase Database ' +
+        '(not including a child path).'
     );
-
-    if (repo.repoInfo_.nodeAdmin) {
-      repo.authTokenProvider_ = new EmulatorAdminTokenProvider();
-    }
   }
 
-  /**
-   * This function should only ever be called to CREATE a new database instance.
-   */
-  databaseFromApp(
-    app: FirebaseAppLike,
-    authProvider: Provider<FirebaseAuthInternalName>,
-    url?: string,
-    nodeAdmin?: boolean
-  ): Database {
-    let dbUrl: string | undefined = url || app.options.databaseURL;
-    if (dbUrl === undefined) {
-      if (!app.options.projectId) {
-        fatal(
-          "Can't determine Firebase Database URL. Be sure to include " +
-            ' a Project ID when calling firebase.initializeApp().'
-        );
-      }
+  const repo = repoManagerCreateRepo(repoInfo, app, authTokenProvider);
 
-      log('Using default host for project ', app.options.projectId);
-      dbUrl = `${app.options.projectId}-default-rtdb.firebaseio.com`;
-    }
+  return repoGetDatabase(repo);
+}
 
-    let parsedUrl = parseRepoInfo(dbUrl, nodeAdmin);
-    let repoInfo = parsedUrl.repoInfo;
+/**
+ * Remove the repo and make sure it is disconnected.
+ *
+ */
+export function repoManagerDeleteRepo(repo: Repo): void {
+  const appRepos = safeGet(repos, repo.app.name);
+  // This should never happen...
+  if (!appRepos || safeGet(appRepos, repo.key) !== repo) {
+    fatal(
+      `Database ${repo.app.name}(${repo.repoInfo_}) has already been deleted.`
+    );
+  }
+  repoInterrupt(repo);
+  delete appRepos[repo.key];
+}
 
-    let isEmulator: boolean;
+/**
+ * Ensures a repo doesn't already exist and then creates one using the
+ * provided app.
+ *
+ * @param repoInfo The metadata about the Repo
+ * @return The Repo object for the specified server / repoName.
+ */
+export function repoManagerCreateRepo(
+  repoInfo: RepoInfo,
+  app: FirebaseAppLike,
+  authTokenProvider: AuthTokenProvider
+): Repo {
+  let appRepos = safeGet(repos, app.name);
 
-    let dbEmulatorHost: string | undefined = undefined;
-    if (typeof process !== 'undefined') {
-      dbEmulatorHost = process.env[FIREBASE_DATABASE_EMULATOR_HOST_VAR];
-    }
-
-    if (dbEmulatorHost) {
-      isEmulator = true;
-      dbUrl = `http://${dbEmulatorHost}?ns=${repoInfo.namespace}`;
-      parsedUrl = parseRepoInfo(dbUrl, nodeAdmin);
-      repoInfo = parsedUrl.repoInfo;
-    } else {
-      isEmulator = !parsedUrl.repoInfo.secure;
-    }
-
-    const authTokenProvider =
-      nodeAdmin && isEmulator
-        ? new EmulatorAdminTokenProvider()
-        : new FirebaseAuthTokenProvider(app, authProvider);
-
-    validateUrl('Invalid Firebase Database URL', 1, parsedUrl);
-    if (!pathIsEmpty(parsedUrl.path)) {
-      fatal(
-        'Database URL must point to the root of a Firebase Database ' +
-          '(not including a child path).'
-      );
-    }
-
-    const repo = this.createRepo(repoInfo, app, authTokenProvider);
-
-    return repoGetDatabase(repo);
+  if (!appRepos) {
+    appRepos = {};
+    repos[app.name] = appRepos;
   }
 
-  /**
-   * Remove the repo and make sure it is disconnected.
-   *
-   */
-  deleteRepo(repo: Repo) {
-    const appRepos = safeGet(this.repos_, repo.app.name);
-    // This should never happen...
-    if (!appRepos || safeGet(appRepos, repo.key) !== repo) {
-      fatal(
-        `Database ${repo.app.name}(${repo.repoInfo_}) has already been deleted.`
-      );
-    }
-    repoInterrupt(repo);
-    delete appRepos[repo.key];
+  let repo = safeGet(appRepos, repoInfo.toURLString());
+  if (repo) {
+    fatal(
+      'Database initialized multiple times. Please make sure the format of the database URL matches with each database() call.'
+    );
   }
+  repo = new Repo(repoInfo, useRestClient, app, authTokenProvider);
+  appRepos[repoInfo.toURLString()] = repo;
 
-  /**
-   * Ensures a repo doesn't already exist and then creates one using the
-   * provided app.
-   *
-   * @param repoInfo The metadata about the Repo
-   * @return The Repo object for the specified server / repoName.
-   */
-  createRepo(
-    repoInfo: RepoInfo,
-    app: FirebaseAppLike,
-    authTokenProvider: AuthTokenProvider
-  ): Repo {
-    let appRepos = safeGet(this.repos_, app.name);
+  return repo;
+}
 
-    if (!appRepos) {
-      appRepos = {};
-      this.repos_[app.name] = appRepos;
-    }
-
-    let repo = safeGet(appRepos, repoInfo.toURLString());
-    if (repo) {
-      fatal(
-        'Database initialized multiple times. Please make sure the format of the database URL matches with each database() call.'
-      );
-    }
-    repo = new Repo(repoInfo, this.useRestClient_, app, authTokenProvider);
-    appRepos[repoInfo.toURLString()] = repo;
-
-    return repo;
-  }
-
-  /**
-   * Forces us to use ReadonlyRestClient instead of PersistentConnection for new Repos.
-   */
-  forceRestClient(forceRestClient: boolean) {
-    this.useRestClient_ = forceRestClient;
-  }
+/**
+ * Forces us to use ReadonlyRestClient instead of PersistentConnection for new Repos.
+ */
+export function repoManagerForceRestClient(forceRestClient: boolean): void {
+  useRestClient = forceRestClient;
 }

--- a/packages/database/src/exp/Database.ts
+++ b/packages/database/src/exp/Database.ts
@@ -16,9 +16,9 @@
  */
 
 // eslint-disable-next-line import/no-extraneous-dependencies
-import { _getProvider, FirebaseApp, _FirebaseService } from '@firebase/app-exp';
+import { _FirebaseService, _getProvider, FirebaseApp } from '@firebase/app-exp';
 import { Reference } from '../api/Reference';
-import { RepoManager } from '../core/RepoManager';
+import { repoManagerDatabaseFromApp } from '../core/RepoManager';
 import { FirebaseAuthInternalName } from '@firebase/auth-interop-types';
 import { Database } from '../api/Database';
 import { Provider } from '@firebase/component';
@@ -36,10 +36,11 @@ export class FirebaseDatabase implements _FirebaseService {
     authProvider: Provider<FirebaseAuthInternalName>,
     databaseUrl?: string
   ) {
-    this._delegate = RepoManager.getInstance().databaseFromApp(
+    this._delegate = repoManagerDatabaseFromApp(
       this.app,
       authProvider,
-      databaseUrl
+      databaseUrl,
+      undefined
     );
   }
 


### PR DESCRIPTION
Removes the RepManager, which was only used as a singleton. It is replaced with two const variables. All functions are moved to be tree-shakeable (interrupt() and resume() were removed since they are not used).