### PR TITLE
Tree-shake SparseSnapshotTree

### DIFF
--- a/packages/database/src/core/SparseSnapshotTree.ts
+++ b/packages/database/src/core/SparseSnapshotTree.ts
@@ -22,7 +22,7 @@ import { Node } from './snap/Node';
 /**
  * Helper class to store a sparse set of snapshots.
  */
-interface SparseSnapshotTree {
+export interface SparseSnapshotTree {
   value: Node | null;
   readonly children: Map<string, SparseSnapshotTree>;
 }

--- a/packages/database/src/core/SparseSnapshotTree.ts
+++ b/packages/database/src/core/SparseSnapshotTree.ts
@@ -22,129 +22,157 @@ import { Node } from './snap/Node';
 /**
  * Helper class to store a sparse set of snapshots.
  */
-export class SparseSnapshotTree {
-  private value: Node | null = null;
+export interface SparseSnapshotTree {
+  value: Node | null;
+  readonly children: Map<string, SparseSnapshotTree>;
+}
 
-  private readonly children: Map<string, SparseSnapshotTree> = new Map();
+export function newSparseSnapshotTree(): SparseSnapshotTree {
+  return {
+    value: null,
+    children: new Map()
+  };
+}
 
-  /**
-   * Gets the node stored at the given path if one exists.
-   *
-   * @param path Path to look up snapshot for.
-   * @return The retrieved node, or null.
-   */
-  find(path: Path): Node | null {
-    if (this.value != null) {
-      return this.value.getChild(path);
-    } else if (!pathIsEmpty(path) && this.children.size > 0) {
-      const childKey = pathGetFront(path);
-      path = pathPopFront(path);
-      if (this.children.has(childKey)) {
-        const childTree = this.children.get(childKey);
-        return childTree.find(path);
-      } else {
-        return null;
-      }
+/**
+ * Gets the node stored at the given path if one exists.
+ * Only seems to be used in tests.
+ *
+ * @param path Path to look up snapshot for.
+ * @return The retrieved node, or null.
+ */
+export function sparseSnapshotTreeFind(
+  sparseSnapshotTree: SparseSnapshotTree,
+  path: Path
+): Node | null {
+  if (sparseSnapshotTree.value != null) {
+    return sparseSnapshotTree.value.getChild(path);
+  } else if (!pathIsEmpty(path) && sparseSnapshotTree.children.size > 0) {
+    const childKey = pathGetFront(path);
+    path = pathPopFront(path);
+    if (sparseSnapshotTree.children.has(childKey)) {
+      const childTree = sparseSnapshotTree.children.get(childKey);
+      return sparseSnapshotTreeFind(childTree, path);
     } else {
       return null;
     }
+  } else {
+    return null;
   }
+}
 
-  /**
-   * Stores the given node at the specified path. If there is already a node
-   * at a shallower path, it merges the new data into that snapshot node.
-   *
-   * @param path Path to look up snapshot for.
-   * @param data The new data, or null.
-   */
-  remember(path: Path, data: Node) {
-    if (pathIsEmpty(path)) {
-      this.value = data;
-      this.children.clear();
-    } else if (this.value !== null) {
-      this.value = this.value.updateChild(path, data);
-    } else {
-      const childKey = pathGetFront(path);
-      if (!this.children.has(childKey)) {
-        this.children.set(childKey, new SparseSnapshotTree());
-      }
-
-      const child = this.children.get(childKey);
-      path = pathPopFront(path);
-      child.remember(path, data);
+/**
+ * Stores the given node at the specified path. If there is already a node
+ * at a shallower path, it merges the new data into that snapshot node.
+ *
+ * @param path Path to look up snapshot for.
+ * @param data The new data, or null.
+ */
+export function sparseSnapshotTreeRemember(
+  sparseSnapshotTree: SparseSnapshotTree,
+  path: Path,
+  data: Node
+) {
+  if (pathIsEmpty(path)) {
+    sparseSnapshotTree.value = data;
+    sparseSnapshotTree.children.clear();
+  } else if (sparseSnapshotTree.value !== null) {
+    sparseSnapshotTree.value = sparseSnapshotTree.value.updateChild(path, data);
+  } else {
+    const childKey = pathGetFront(path);
+    if (!sparseSnapshotTree.children.has(childKey)) {
+      sparseSnapshotTree.children.set(childKey, newSparseSnapshotTree());
     }
+
+    const child = sparseSnapshotTree.children.get(childKey);
+    path = pathPopFront(path);
+    sparseSnapshotTreeRemember(child, path, data);
   }
+}
 
-  /**
-   * Purge the data at path from the cache.
-   *
-   * @param path Path to look up snapshot for.
-   * @return True if this node should now be removed.
-   */
-  forget(path: Path): boolean {
-    if (pathIsEmpty(path)) {
-      this.value = null;
-      this.children.clear();
-      return true;
-    } else {
-      if (this.value !== null) {
-        if (this.value.isLeafNode()) {
-          // We're trying to forget a node that doesn't exist
-          return false;
-        } else {
-          const value = this.value;
-          this.value = null;
-
-          const self = this;
-          value.forEachChild(PRIORITY_INDEX, (key, tree) => {
-            self.remember(new Path(key), tree);
-          });
-
-          return this.forget(path);
-        }
-      } else if (this.children.size > 0) {
-        const childKey = pathGetFront(path);
-        path = pathPopFront(path);
-        if (this.children.has(childKey)) {
-          const safeToRemove = this.children.get(childKey).forget(path);
-          if (safeToRemove) {
-            this.children.delete(childKey);
-          }
-        }
-
-        return this.children.size === 0;
+/**
+ * Purge the data at path from the cache.
+ *
+ * @param path Path to look up snapshot for.
+ * @return True if this node should now be removed.
+ */
+export function sparseSnapshotTreeForget(
+  sparseSnapshotTree: SparseSnapshotTree,
+  path: Path
+): boolean {
+  if (pathIsEmpty(path)) {
+    sparseSnapshotTree.value = null;
+    sparseSnapshotTree.children.clear();
+    return true;
+  } else {
+    if (sparseSnapshotTree.value !== null) {
+      if (sparseSnapshotTree.value.isLeafNode()) {
+        // We're trying to forget a node that doesn't exist
+        return false;
       } else {
-        return true;
+        const value = sparseSnapshotTree.value;
+        sparseSnapshotTree.value = null;
+
+        const self = this;
+        value.forEachChild(PRIORITY_INDEX, (key, tree) => {
+          self.remember(new Path(key), tree);
+        });
+
+        return sparseSnapshotTreeForget(sparseSnapshotTree, path);
       }
-    }
-  }
+    } else if (sparseSnapshotTree.children.size > 0) {
+      const childKey = pathGetFront(path);
+      path = pathPopFront(path);
+      if (sparseSnapshotTree.children.has(childKey)) {
+        const safeToRemove = sparseSnapshotTreeForget(
+          sparseSnapshotTree.children.get(childKey),
+          path
+        );
+        if (safeToRemove) {
+          sparseSnapshotTree.children.delete(childKey);
+        }
+      }
 
-  /**
-   * Recursively iterates through all of the stored tree and calls the
-   * callback on each one.
-   *
-   * @param prefixPath Path to look up node for.
-   * @param func The function to invoke for each tree.
-   */
-  forEachTree(prefixPath: Path, func: (a: Path, b: Node) => unknown) {
-    if (this.value !== null) {
-      func(prefixPath, this.value);
+      return sparseSnapshotTree.children.size === 0;
     } else {
-      this.forEachChild((key, tree) => {
-        const path = new Path(prefixPath.toString() + '/' + key);
-        tree.forEachTree(path, func);
-      });
+      return true;
     }
   }
+}
 
-  /**
-   * Iterates through each immediate child and triggers the callback.
-   *
-   * @param func The function to invoke for each child.
-   */
-  forEachChild(func: (a: string, b: SparseSnapshotTree) => void) {
-    this.children.forEach((tree, key) => {
-      func(key, tree);
+/**
+ * Recursively iterates through all of the stored tree and calls the
+ * callback on each one.
+ *
+ * @param prefixPath Path to look up node for.
+ * @param func The function to invoke for each tree.
+ */
+export function sparseSnapshotTreeForEachTree(
+  sparseSnapshotTree: SparseSnapshotTree,
+  prefixPath: Path,
+  func: (a: Path, b: Node) => unknown
+) {
+  if (sparseSnapshotTree.value !== null) {
+    func(prefixPath, sparseSnapshotTree.value);
+  } else {
+    sparseSnapshotTreeForEachChild(sparseSnapshotTree, (key, tree) => {
+      const path = new Path(prefixPath.toString() + '/' + key);
+      sparseSnapshotTreeForEachTree(tree, path, func);
     });
   }
+}
+
+/**
+ * Iterates through each immediate child and triggers the callback.
+ * Only seems to be used in tests.
+ *
+ * @param func The function to invoke for each child.
+ */
+export function sparseSnapshotTreeForEachChild(
+  sparseSnapshotTree: SparseSnapshotTree,
+  func: (a: string, b: SparseSnapshotTree) => void
+) {
+  sparseSnapshotTree.children.forEach((tree, key) => {
+    func(key, tree);
+  });
 }

--- a/packages/database/src/core/SparseSnapshotTree.ts
+++ b/packages/database/src/core/SparseSnapshotTree.ts
@@ -72,7 +72,7 @@ export function sparseSnapshotTreeRemember(
   sparseSnapshotTree: SparseSnapshotTree,
   path: Path,
   data: Node
-) {
+): void {
   if (pathIsEmpty(path)) {
     sparseSnapshotTree.value = data;
     sparseSnapshotTree.children.clear();
@@ -150,7 +150,7 @@ export function sparseSnapshotTreeForEachTree(
   sparseSnapshotTree: SparseSnapshotTree,
   prefixPath: Path,
   func: (a: Path, b: Node) => unknown
-) {
+): void {
   if (sparseSnapshotTree.value !== null) {
     func(prefixPath, sparseSnapshotTree.value);
   } else {
@@ -170,7 +170,7 @@ export function sparseSnapshotTreeForEachTree(
 export function sparseSnapshotTreeForEachChild(
   sparseSnapshotTree: SparseSnapshotTree,
   func: (a: string, b: SparseSnapshotTree) => void
-) {
+): void {
   sparseSnapshotTree.children.forEach((tree, key) => {
     func(key, tree);
   });

--- a/packages/database/src/core/SparseSnapshotTree.ts
+++ b/packages/database/src/core/SparseSnapshotTree.ts
@@ -22,7 +22,7 @@ import { Node } from './snap/Node';
 /**
  * Helper class to store a sparse set of snapshots.
  */
-export interface SparseSnapshotTree {
+interface SparseSnapshotTree {
   value: Node | null;
   readonly children: Map<string, SparseSnapshotTree>;
 }
@@ -113,9 +113,8 @@ export function sparseSnapshotTreeForget(
         const value = sparseSnapshotTree.value;
         sparseSnapshotTree.value = null;
 
-        const self = this;
         value.forEachChild(PRIORITY_INDEX, (key, tree) => {
-          self.remember(new Path(key), tree);
+          sparseSnapshotTreeRemember(sparseSnapshotTree, new Path(key), tree);
         });
 
         return sparseSnapshotTreeForget(sparseSnapshotTree, path);

--- a/packages/database/test/sparsesnapshottree.test.ts
+++ b/packages/database/test/sparsesnapshottree.test.ts
@@ -16,111 +16,161 @@
  */
 
 import { expect } from 'chai';
-import { SparseSnapshotTree } from '../src/core/SparseSnapshotTree';
+import {
+  newSparseSnapshotTree,
+  sparseSnapshotTreeFind,
+  sparseSnapshotTreeForEachChild,
+  sparseSnapshotTreeForEachTree,
+  sparseSnapshotTreeForget,
+  sparseSnapshotTreeRemember
+} from '../src/core/SparseSnapshotTree';
 import { newEmptyPath, Path } from '../src/core/util/Path';
 import { nodeFromJSON } from '../src/core/snap/nodeFromJSON';
 import { ChildrenNode } from '../src/core/snap/ChildrenNode';
 
 describe('SparseSnapshotTree Tests', () => {
   it('Basic remember and find.', () => {
-    const st = new SparseSnapshotTree();
+    const st = newSparseSnapshotTree();
     const path = new Path('a/b');
     const node = nodeFromJSON('sdfsd');
 
-    st.remember(path, node);
-    expect(st.find(new Path('a/b')).isEmpty()).to.equal(false);
-    expect(st.find(new Path('a'))).to.equal(null);
+    sparseSnapshotTreeRemember(st, path, node);
+    expect(sparseSnapshotTreeFind(st, new Path('a/b')).isEmpty()).to.equal(
+      false
+    );
+    expect(sparseSnapshotTreeFind(st, new Path('a'))).to.equal(null);
   });
 
   it('Find inside an existing snapshot', () => {
-    const st = new SparseSnapshotTree();
+    const st = newSparseSnapshotTree();
     const path = new Path('t/tt');
     let node = nodeFromJSON({ a: 'sdfsd', x: 5, '999i': true });
     node = node.updateImmediateChild('apples', nodeFromJSON({ goats: 88 }));
-    st.remember(path, node);
+    sparseSnapshotTreeRemember(st, path, node);
 
-    expect(st.find(new Path('t/tt')).isEmpty()).to.equal(false);
-    expect(st.find(new Path('t/tt/a')).val()).to.equal('sdfsd');
-    expect(st.find(new Path('t/tt/999i')).val()).to.equal(true);
-    expect(st.find(new Path('t/tt/apples')).isEmpty()).to.equal(false);
-    expect(st.find(new Path('t/tt/apples/goats')).val()).to.equal(88);
+    expect(sparseSnapshotTreeFind(st, new Path('t/tt')).isEmpty()).to.equal(
+      false
+    );
+    expect(sparseSnapshotTreeFind(st, new Path('t/tt/a')).val()).to.equal(
+      'sdfsd'
+    );
+    expect(sparseSnapshotTreeFind(st, new Path('t/tt/999i')).val()).to.equal(
+      true
+    );
+    expect(
+      sparseSnapshotTreeFind(st, new Path('t/tt/apples')).isEmpty()
+    ).to.equal(false);
+    expect(
+      sparseSnapshotTreeFind(st, new Path('t/tt/apples/goats')).val()
+    ).to.equal(88);
   });
 
   it('Write a snapshot inside a snapshot.', () => {
-    const st = new SparseSnapshotTree();
-    st.remember(new Path('t'), nodeFromJSON({ a: { b: 'v' } }));
-    st.remember(new Path('t/a/rr'), nodeFromJSON(19));
-    expect(st.find(new Path('t/a/b')).val()).to.equal('v');
-    expect(st.find(new Path('t/a/rr')).val()).to.equal(19);
+    const st = newSparseSnapshotTree();
+    sparseSnapshotTreeRemember(
+      st,
+      new Path('t'),
+      nodeFromJSON({ a: { b: 'v' } })
+    );
+    sparseSnapshotTreeRemember(st, new Path('t/a/rr'), nodeFromJSON(19));
+    expect(sparseSnapshotTreeFind(st, new Path('t/a/b')).val()).to.equal('v');
+    expect(sparseSnapshotTreeFind(st, new Path('t/a/rr')).val()).to.equal(19);
   });
 
   it('Write a null value and confirm it is remembered.', () => {
-    const st = new SparseSnapshotTree();
-    st.remember(new Path('awq/fff'), nodeFromJSON(null));
-    expect(st.find(new Path('awq/fff'))).to.equal(ChildrenNode.EMPTY_NODE);
-    expect(st.find(new Path('awq/sdf'))).to.equal(null);
-    expect(st.find(new Path('awq/fff/jjj'))).to.equal(ChildrenNode.EMPTY_NODE);
-    expect(st.find(new Path('awq/sdf/sdf/q'))).to.equal(null);
+    const st = newSparseSnapshotTree();
+    sparseSnapshotTreeRemember(st, new Path('awq/fff'), nodeFromJSON(null));
+    expect(sparseSnapshotTreeFind(st, new Path('awq/fff'))).to.equal(
+      ChildrenNode.EMPTY_NODE
+    );
+    expect(sparseSnapshotTreeFind(st, new Path('awq/sdf'))).to.equal(null);
+    expect(sparseSnapshotTreeFind(st, new Path('awq/fff/jjj'))).to.equal(
+      ChildrenNode.EMPTY_NODE
+    );
+    expect(sparseSnapshotTreeFind(st, new Path('awq/sdf/sdf/q'))).to.equal(
+      null
+    );
   });
 
   it('Overwrite with null and confirm it is remembered.', () => {
-    const st = new SparseSnapshotTree();
-    st.remember(new Path('t'), nodeFromJSON({ a: { b: 'v' } }));
-    expect(st.find(new Path('t')).isEmpty()).to.equal(false);
-    st.remember(new Path('t'), ChildrenNode.EMPTY_NODE);
-    expect(st.find(new Path('t')).isEmpty()).to.equal(true);
+    const st = newSparseSnapshotTree();
+    sparseSnapshotTreeRemember(
+      st,
+      new Path('t'),
+      nodeFromJSON({ a: { b: 'v' } })
+    );
+    expect(sparseSnapshotTreeFind(st, new Path('t')).isEmpty()).to.equal(false);
+    sparseSnapshotTreeRemember(st, new Path('t'), ChildrenNode.EMPTY_NODE);
+    expect(sparseSnapshotTreeFind(st, new Path('t')).isEmpty()).to.equal(true);
   });
 
   it('Simple remember and forget.', () => {
-    const st = new SparseSnapshotTree();
-    st.remember(new Path('t'), nodeFromJSON({ a: { b: 'v' } }));
-    expect(st.find(new Path('t')).isEmpty()).to.equal(false);
-    st.forget(new Path('t'));
-    expect(st.find(new Path('t'))).to.equal(null);
+    const st = newSparseSnapshotTree();
+    sparseSnapshotTreeRemember(
+      st,
+      new Path('t'),
+      nodeFromJSON({ a: { b: 'v' } })
+    );
+    expect(sparseSnapshotTreeFind(st, new Path('t')).isEmpty()).to.equal(false);
+    sparseSnapshotTreeForget(st, new Path('t'));
+    expect(sparseSnapshotTreeFind(st, new Path('t'))).to.equal(null);
   });
 
   it('Forget the root.', () => {
-    const st = new SparseSnapshotTree();
-    st.remember(new Path('t'), nodeFromJSON({ a: { b: 'v' } }));
-    expect(st.find(new Path('t')).isEmpty()).to.equal(false);
-    st.forget(newEmptyPath());
-    expect(st.find(new Path('t'))).to.equal(null);
+    const st = newSparseSnapshotTree();
+    sparseSnapshotTreeRemember(
+      st,
+      new Path('t'),
+      nodeFromJSON({ a: { b: 'v' } })
+    );
+    expect(sparseSnapshotTreeFind(st, new Path('t')).isEmpty()).to.equal(false);
+    sparseSnapshotTreeForget(st, newEmptyPath());
+    expect(sparseSnapshotTreeFind(st, new Path('t'))).to.equal(null);
   });
 
   it('Forget snapshot inside snapshot.', () => {
-    const st = new SparseSnapshotTree();
-    st.remember(
+    const st = newSparseSnapshotTree();
+    sparseSnapshotTreeRemember(
+      st,
       new Path('t'),
       nodeFromJSON({ a: { b: 'v', c: 9, art: false } })
     );
-    expect(st.find(new Path('t/a/c')).isEmpty()).to.equal(false);
-    expect(st.find(new Path('t')).isEmpty()).to.equal(false);
+    expect(sparseSnapshotTreeFind(st, new Path('t/a/c')).isEmpty()).to.equal(
+      false
+    );
+    expect(sparseSnapshotTreeFind(st, new Path('t')).isEmpty()).to.equal(false);
 
-    st.forget(new Path('t/a/c'));
-    expect(st.find(new Path('t'))).to.equal(null);
-    expect(st.find(new Path('t/a'))).to.equal(null);
-    expect(st.find(new Path('t/a/b')).val()).to.equal('v');
-    expect(st.find(new Path('t/a/c'))).to.equal(null);
-    expect(st.find(new Path('t/a/art')).val()).to.equal(false);
+    sparseSnapshotTreeForget(st, new Path('t/a/c'));
+    expect(sparseSnapshotTreeFind(st, new Path('t'))).to.equal(null);
+    expect(sparseSnapshotTreeFind(st, new Path('t/a'))).to.equal(null);
+    expect(sparseSnapshotTreeFind(st, new Path('t/a/b')).val()).to.equal('v');
+    expect(sparseSnapshotTreeFind(st, new Path('t/a/c'))).to.equal(null);
+    expect(sparseSnapshotTreeFind(st, new Path('t/a/art')).val()).to.equal(
+      false
+    );
   });
 
   it('Forget path shallower than snapshots.', () => {
-    const st = new SparseSnapshotTree();
-    st.remember(new Path('t/x1'), nodeFromJSON(false));
-    st.remember(new Path('t/x2'), nodeFromJSON(true));
-    st.forget(new Path('t'));
-    expect(st.find(new Path('t'))).to.equal(null);
+    const st = newSparseSnapshotTree();
+    sparseSnapshotTreeRemember(st, new Path('t/x1'), nodeFromJSON(false));
+    sparseSnapshotTreeRemember(st, new Path('t/x2'), nodeFromJSON(true));
+    sparseSnapshotTreeForget(st, new Path('t'));
+    expect(sparseSnapshotTreeFind(st, new Path('t'))).to.equal(null);
   });
 
   it('Iterate children.', () => {
-    const st = new SparseSnapshotTree();
-    st.remember(new Path('t'), nodeFromJSON({ b: 'v', c: 9, art: false }));
-    st.remember(new Path('q'), ChildrenNode.EMPTY_NODE);
+    const st = newSparseSnapshotTree();
+    sparseSnapshotTreeRemember(
+      st,
+      new Path('t'),
+      nodeFromJSON({ b: 'v', c: 9, art: false })
+    );
+    sparseSnapshotTreeRemember(st, new Path('q'), ChildrenNode.EMPTY_NODE);
 
     let num = 0,
       gotT = false,
       gotQ = false;
-    st.forEachChild((key, child) => {
+    sparseSnapshotTreeForEachChild(st, (key, child) => {
       num += 1;
       if (key === 't') {
         gotT = true;
@@ -137,25 +187,25 @@ describe('SparseSnapshotTree Tests', () => {
   });
 
   it('Iterate trees.', () => {
-    const st = new SparseSnapshotTree();
+    const st = newSparseSnapshotTree();
 
     let count = 0;
-    st.forEachTree(newEmptyPath(), (path, tree) => {
+    sparseSnapshotTreeForEachTree(st, newEmptyPath(), (path, tree) => {
       count += 1;
     });
     expect(count).to.equal(0);
 
-    st.remember(new Path('t'), nodeFromJSON(1));
-    st.remember(new Path('a/b'), nodeFromJSON(2));
-    st.remember(new Path('a/x/g'), nodeFromJSON(3));
-    st.remember(new Path('a/x/null'), nodeFromJSON(null));
+    sparseSnapshotTreeRemember(st, new Path('t'), nodeFromJSON(1));
+    sparseSnapshotTreeRemember(st, new Path('a/b'), nodeFromJSON(2));
+    sparseSnapshotTreeRemember(st, new Path('a/x/g'), nodeFromJSON(3));
+    sparseSnapshotTreeRemember(st, new Path('a/x/null'), nodeFromJSON(null));
 
     let num = 0,
       got1 = false,
       got2 = false,
       got3 = false,
       got4 = false;
-    st.forEachTree(new Path('q'), (path, node) => {
+    sparseSnapshotTreeForEachTree(st, new Path('q'), (path, node) => {
       num += 1;
       const pathString = path.toString();
       if (pathString === '/q/t') {
@@ -183,10 +233,10 @@ describe('SparseSnapshotTree Tests', () => {
   });
 
   it('Set leaf, then forget deeper path', () => {
-    const st = new SparseSnapshotTree();
+    const st = newSparseSnapshotTree();
 
-    st.remember(new Path('foo'), nodeFromJSON('bar'));
-    const safeToRemove = st.forget(new Path('foo/baz'));
+    sparseSnapshotTreeRemember(st, new Path('foo'), nodeFromJSON('bar'));
+    const safeToRemove = sparseSnapshotTreeForget(st, new Path('foo/baz'));
     // it's not safe to remove this node
     expect(safeToRemove).to.equal(false);
   });


### PR DESCRIPTION
Changed from class to interface, replaced the constructor with `newSparseSnapshotTree`?

Two methods are only used in the unit tests (`find` and `forEachChild`), but now that they've been extracted they shouldn't make it into the bundle, so they probably don't need to be moved into the test file.