### PR TITLE
Modify URL parsing for React Native compat.

### DIFF
--- a/packages-exp/auth-exp/src/core/util/handler.ts
+++ b/packages-exp/auth-exp/src/core/util/handler.ts
@@ -94,22 +94,16 @@ export function _getRedirectUrl(
     params.tid = auth.tenantId;
   }
 
-  for (const key of Object.keys(params)) {
-    if ((params as Record<string, unknown>)[key] === undefined) {
-      delete (params as Record<string, unknown>)[key];
-    }
-  }
-
   // TODO: maybe set eid as endipointId
   // TODO: maybe set fw as Frameworks.join(",")
 
-  const url = new URL(
-    `${getHandlerBase(auth)}?${querystring(
-      params as Record<string, string | number>
-    ).slice(1)}`
-  );
-
-  return url.toString();
+  const paramsDict = params as Record<string, string | number>;
+  for (const key of Object.keys(paramsDict)) {
+    if (paramsDict[key] === undefined) {
+      delete paramsDict[key];
+    }
+  }
+  return `${getHandlerBase(auth)}?${querystring(paramsDict).slice(1)}`;
 }
 
 function getHandlerBase({ config }: AuthInternal): string {

--- a/packages-exp/auth-exp/src/platform_react_native/persistence/react_native.ts
+++ b/packages-exp/auth-exp/src/platform_react_native/persistence/react_native.ts
@@ -74,11 +74,13 @@ export function getReactNativePersistence(
     }
 
     _addListener(_key: string, _listener: StorageEventListener): void {
-      debugFail('not implemented');
+      // Listeners are not supported for React Native storage.
+      return;
     }
 
     _removeListener(_key: string, _listener: StorageEventListener): void {
-      debugFail('not implemented');
+      // Listeners are not supported for React Native storage.
+      return;
     }
   };
 }

--- a/packages-exp/auth-exp/src/platform_react_native/persistence/react_native.ts
+++ b/packages-exp/auth-exp/src/platform_react_native/persistence/react_native.ts
@@ -24,7 +24,6 @@ import {
   STORAGE_AVAILABLE_KEY,
   StorageEventListener
 } from '../../core/persistence';
-import { debugFail } from '../../core/util/assert';
 
 /**
  * Returns a persistence class that wraps AsyncStorage imported from

--- a/packages/util/src/query.ts
+++ b/packages/util/src/query.ts
@@ -42,15 +42,30 @@ export function querystring(querystringParams: {
  * Decodes a querystring (e.g. ?arg=val&arg2=val2) into a params object
  * (e.g. {arg: 'val', arg2: 'val2'})
  */
-export function querystringDecode(querystring: string): object {
-  const obj: { [key: string]: unknown } = {};
+export function querystringDecode(querystring: string): Record<string, string> {
+  const obj: Record<string, string> = {};
   const tokens = querystring.replace(/^\?/, '').split('&');
 
   tokens.forEach(token => {
     if (token) {
-      const key = token.split('=');
-      obj[key[0]] = key[1];
+      const [key, value] = token.split('=');
+      obj[decodeURIComponent(key)] = decodeURIComponent(value);
     }
   });
   return obj;
+}
+
+/**
+ * Extract the query string part of a URL, including the leading question mark (if present).
+ */
+export function extractQuerystring(url: string): string {
+  const queryStart = url.indexOf('?');
+  if (!queryStart) {
+    return '';
+  }
+  const fragmentStart = url.indexOf('#', queryStart);
+  return url.substring(
+    queryStart,
+    fragmentStart > 0 ? fragmentStart : undefined
+  );
 }


### PR DESCRIPTION
I've tried to keep the regex short and to the point, but let's see.

Once this is merged, there should be no `new URL` or `new URLSearchParams` floating in `auth-exp`.