### PR TITLE
[Auth] set key in storage before redirect, check this key before checking for redirect events

### DIFF
--- a/packages-exp/auth-compat-exp/src/platform.ts
+++ b/packages-exp/auth-compat-exp/src/platform.ts
@@ -162,8 +162,13 @@ export function _getClientPlatform(): impl.ClientPlatform {
   return impl.ClientPlatform.BROWSER;
 }
 
+/** Quick check that indicates the platform *may* be Cordova */
+export function _isLikelyCordova(): boolean {
+  return _isAndroidOrIosCordovaScheme() && typeof document !== 'undefined';
+}
+
 export async function _isCordova(): Promise<boolean> {
-  if (!_isAndroidOrIosCordovaScheme() || typeof document === 'undefined') {
+  if (!_isLikelyCordova()) {
     return false;
   }
 

--- a/packages-exp/auth-compat-exp/src/popup_redirect.test.ts
+++ b/packages-exp/auth-compat-exp/src/popup_redirect.test.ts
@@ -126,11 +126,31 @@ describe('popup_redirect/CompatPopupRedirectResolver', () => {
       );
     });
   });
+
+  context('_shouldInitProactively', () => {
+    it('returns true if platform may be cordova', () => {
+      sinon.stub(platform, '_isLikelyCordova').returns(true);
+      expect(compatResolver._shouldInitProactively).to.be.true;
+    });
+
+    it('returns true if cordova is false but browser value is true', () => {
+      sinon.stub(exp._getInstance<exp.PopupRedirectResolverInternal>(exp.browserPopupRedirectResolver), '_shouldInitProactively').value(true);
+      sinon.stub(platform, '_isLikelyCordova').returns(false);
+      expect(compatResolver._shouldInitProactively).to.be.true;
+    });
+
+    it('returns false if not cordova and not browser early init', () => {
+      sinon.stub(exp._getInstance<exp.PopupRedirectResolverInternal>(exp.browserPopupRedirectResolver), '_shouldInitProactively').value(false);
+      sinon.stub(platform, '_isLikelyCordova').returns(false);
+      expect(compatResolver._shouldInitProactively).to.be.false;
+    });
+  });
 });
 
 class FakeResolver implements exp.PopupRedirectResolverInternal {
   _completeRedirectFn = async (): Promise<null> => null;
   _redirectPersistence = exp.inMemoryPersistence;
+  _shouldInitProactively = true;
 
   _initialize(): Promise<exp.EventManager> {
     throw new Error('Method not implemented.');

--- a/packages-exp/auth-compat-exp/src/popup_redirect.test.ts
+++ b/packages-exp/auth-compat-exp/src/popup_redirect.test.ts
@@ -134,13 +134,27 @@ describe('popup_redirect/CompatPopupRedirectResolver', () => {
     });
 
     it('returns true if cordova is false but browser value is true', () => {
-      sinon.stub(exp._getInstance<exp.PopupRedirectResolverInternal>(exp.browserPopupRedirectResolver), '_shouldInitProactively').value(true);
+      sinon
+        .stub(
+          exp._getInstance<exp.PopupRedirectResolverInternal>(
+            exp.browserPopupRedirectResolver
+          ),
+          '_shouldInitProactively'
+        )
+        .value(true);
       sinon.stub(platform, '_isLikelyCordova').returns(false);
       expect(compatResolver._shouldInitProactively).to.be.true;
     });
 
     it('returns false if not cordova and not browser early init', () => {
-      sinon.stub(exp._getInstance<exp.PopupRedirectResolverInternal>(exp.browserPopupRedirectResolver), '_shouldInitProactively').value(false);
+      sinon
+        .stub(
+          exp._getInstance<exp.PopupRedirectResolverInternal>(
+            exp.browserPopupRedirectResolver
+          ),
+          '_shouldInitProactively'
+        )
+        .value(false);
       sinon.stub(platform, '_isLikelyCordova').returns(false);
       expect(compatResolver._shouldInitProactively).to.be.false;
     });

--- a/packages-exp/auth-compat-exp/src/popup_redirect.ts
+++ b/packages-exp/auth-compat-exp/src/popup_redirect.ts
@@ -19,8 +19,12 @@ import * as exp from '@firebase/auth-exp/internal';
 import { _isCordova, _isLikelyCordova } from './platform';
 
 const _assert: typeof exp._assert = exp._assert;
-const BROWSER_RESOLVER: exp.PopupRedirectResolverInternal = exp._getInstance(exp.browserPopupRedirectResolver);
-const CORDOVA_RESOLVER: exp.PopupRedirectResolverInternal = exp._getInstance(exp.cordovaPopupRedirectResolver);
+const BROWSER_RESOLVER: exp.PopupRedirectResolverInternal = exp._getInstance(
+  exp.browserPopupRedirectResolver
+);
+const CORDOVA_RESOLVER: exp.PopupRedirectResolverInternal = exp._getInstance(
+  exp.cordovaPopupRedirectResolver
+);
 
 /** Platform-agnostic popup-redirect resolver */
 export class CompatPopupRedirectResolver

--- a/packages-exp/auth-compat-exp/src/popup_redirect.ts
+++ b/packages-exp/auth-compat-exp/src/popup_redirect.ts
@@ -16,9 +16,11 @@
  */
 
 import * as exp from '@firebase/auth-exp/internal';
-import { _isCordova } from './platform';
+import { _isCordova, _isLikelyCordova } from './platform';
 
 const _assert: typeof exp._assert = exp._assert;
+const BROWSER_RESOLVER: exp.PopupRedirectResolverInternal = exp._getInstance(exp.browserPopupRedirectResolver);
+const CORDOVA_RESOLVER: exp.PopupRedirectResolverInternal = exp._getInstance(exp.cordovaPopupRedirectResolver);
 
 /** Platform-agnostic popup-redirect resolver */
 export class CompatPopupRedirectResolver
@@ -40,11 +42,7 @@ export class CompatPopupRedirectResolver
     // We haven't yet determined whether or not we're in Cordova; go ahead
     // and determine that state now.
     const isCordova = await _isCordova();
-    this.underlyingResolver = exp._getInstance(
-      isCordova
-        ? exp.cordovaPopupRedirectResolver
-        : exp.browserPopupRedirectResolver
-    );
+    this.underlyingResolver = isCordova ? CORDOVA_RESOLVER : BROWSER_RESOLVER;
     return this.assertedUnderlyingResolver._initialize(auth);
   }
 
@@ -85,6 +83,10 @@ export class CompatPopupRedirectResolver
 
   _originValidation(auth: exp.Auth): Promise<void> {
     return this.assertedUnderlyingResolver._originValidation(auth);
+  }
+
+  get _shouldInitProactively(): boolean {
+    return _isLikelyCordova() || BROWSER_RESOLVER._shouldInitProactively;
   }
 
   private get assertedUnderlyingResolver(): exp.PopupRedirectResolverInternal {

--- a/packages-exp/auth-exp/src/core/auth/auth_impl.ts
+++ b/packages-exp/auth-exp/src/core/auth/auth_impl.ts
@@ -132,6 +132,12 @@ export class AuthImpl implements AuthInternal, _FirebaseService {
         return;
       }
 
+      // Initialize the resolver early if necessary (only applicable to web:
+      // this will cause the iframe to load immediately in certain cases)
+      if (this._popupRedirectResolver?._shouldInitProactively) {
+        await this._popupRedirectResolver._initialize(this);
+      }
+
       await this.initializeCurrentUser(popupRedirectResolver);
 
       if (this._deleted) {

--- a/packages-exp/auth-exp/src/core/auth/initialize.test.ts
+++ b/packages-exp/auth-exp/src/core/auth/initialize.test.ts
@@ -117,6 +117,7 @@ describe('core/auth/initialize', () => {
       cb(true);
     }
     async _originValidation(): Promise<void> {}
+    _shouldInitProactively = false;
     async _completeRedirectFn(
       _auth: Auth,
       _resolver: PopupRedirectResolver,

--- a/packages-exp/auth-exp/src/core/strategies/redirect.test.ts
+++ b/packages-exp/auth-exp/src/core/strategies/redirect.test.ts
@@ -22,7 +22,8 @@ import {
   ProviderId
 } from '../../model/public_types';
 import * as sinon from 'sinon';
-import { _getInstance } from '../util/instantiator';
+import * as sinonChai from 'sinon-chai';
+import { _clearInstanceMap, _getInstance } from '../util/instantiator';
 import {
   MockPersistenceLayer,
   TestAuth,
@@ -39,17 +40,16 @@ import {
   PopupRedirectResolverInternal
 } from '../../model/popup_redirect';
 import { BASE_AUTH_EVENT } from '../../../test/helpers/iframe_event';
-import { PersistenceInternal } from '../persistence';
-import { InMemoryPersistence } from '../persistence/in_memory';
 import { UserCredentialImpl } from '../user/user_credential_impl';
 import * as idpTasks from '../strategies/idp';
-import { expect } from 'chai';
+import { expect, use } from 'chai';
 import { AuthErrorCode } from '../errors';
+import { RedirectPersistence } from '../../../test/helpers/redirect_persistence';
+
+use(sinonChai);
 
 const MATCHING_EVENT_ID = 'matching-event-id';
 const OTHER_EVENT_ID = 'wrong-id';
-
-class RedirectPersistence extends InMemoryPersistence {}
 
 describe('core/strategies/redirect', () => {
   let auth: AuthInternal;
@@ -57,6 +57,7 @@ describe('core/strategies/redirect', () => {
   let eventManager: AuthEventManager;
   let resolver: PopupRedirectResolver;
   let idpStubs: sinon.SinonStubbedInstance<typeof idpTasks>;
+  let redirectPersistence: RedirectPersistence;
 
   beforeEach(async () => {
     eventManager = new AuthEventManager(({} as unknown) as TestAuth);
@@ -67,11 +68,16 @@ describe('core/strategies/redirect', () => {
     )._redirectPersistence = RedirectPersistence;
     auth = await testAuth();
     redirectAction = new RedirectAction(auth, _getInstance(resolver), false);
+    redirectPersistence = _getInstance(RedirectPersistence);
+
+    // Default to has redirect for most test
+    redirectPersistence.hasPendingRedirect = true;
   });
 
   afterEach(() => {
     sinon.restore();
     _clearRedirectOutcomes();
+    _clearInstanceMap();
   });
 
   function iframeEvent(event: Partial<AuthEvent>): void {
@@ -86,16 +92,11 @@ describe('core/strategies/redirect', () => {
   }
 
   async function reInitAuthWithRedirectUser(eventId: string): Promise<void> {
-    const redirectPersistence: PersistenceInternal = _getInstance(
-      RedirectPersistence
-    );
     const mainPersistence = new MockPersistenceLayer();
     const oldAuth = await testAuth();
     const user = testUser(oldAuth, 'uid');
     user._redirectEventId = eventId;
-    sinon
-      .stub(redirectPersistence, '_get')
-      .returns(Promise.resolve(user.toJSON()));
+    redirectPersistence.redirectUser = user.toJSON();
     sinon.stub(mainPersistence, '_get').returns(Promise.resolve(user.toJSON()));
 
     auth = await testAuth(resolver, mainPersistence);
@@ -193,5 +194,17 @@ describe('core/strategies/redirect', () => {
     });
     expect(await promise).to.eq(cred);
     expect(await redirectAction.execute()).to.eq(cred);
+  });
+
+  it('bypasses initialization if no key set', async () => {
+    await reInitAuthWithRedirectUser(MATCHING_EVENT_ID);
+    const resolverInstance = _getInstance<PopupRedirectResolverInternal>(resolver);
+
+    sinon.spy(resolverInstance, '_initialize');
+    redirectPersistence.hasPendingRedirect = false;
+   
+    expect(await redirectAction.execute()).to.eq(null);
+    expect(await redirectAction.execute()).to.eq(null);
+    expect(resolverInstance._initialize).not.to.have.been.called;
   });
 });

--- a/packages-exp/auth-exp/src/core/strategies/redirect.test.ts
+++ b/packages-exp/auth-exp/src/core/strategies/redirect.test.ts
@@ -198,11 +198,13 @@ describe('core/strategies/redirect', () => {
 
   it('bypasses initialization if no key set', async () => {
     await reInitAuthWithRedirectUser(MATCHING_EVENT_ID);
-    const resolverInstance = _getInstance<PopupRedirectResolverInternal>(resolver);
+    const resolverInstance = _getInstance<PopupRedirectResolverInternal>(
+      resolver
+    );
 
     sinon.spy(resolverInstance, '_initialize');
     redirectPersistence.hasPendingRedirect = false;
-   
+
     expect(await redirectAction.execute()).to.eq(null);
     expect(await redirectAction.execute()).to.eq(null);
     expect(resolverInstance._initialize).not.to.have.been.called;

--- a/packages-exp/auth-exp/src/core/strategies/redirect.ts
+++ b/packages-exp/auth-exp/src/core/strategies/redirect.ts
@@ -22,7 +22,12 @@ import {
   PopupRedirectResolverInternal
 } from '../../model/popup_redirect';
 import { UserCredentialInternal } from '../../model/user';
+import { PersistenceInternal } from '../persistence';
+import { _persistenceKeyName } from '../persistence/persistence_user_manager';
+import { _getInstance } from '../util/instantiator';
 import { AbstractPopupRedirectOperation } from './abstract_popup_redirect_operation';
+
+const PENDING_REDIRECT_KEY = 'pendingRedirect';
 
 // We only get one redirect outcome for any one auth, so just store it
 // in here.
@@ -61,7 +66,8 @@ export class RedirectAction extends AbstractPopupRedirectOperation {
     let readyOutcome = redirectOutcomeMap.get(this.auth._key());
     if (!readyOutcome) {
       try {
-        const result = await super.execute();
+        const hasPendingRedirect = await _getAndClearPendingRedirectStatus(this.resolver, this.auth);
+        const result = hasPendingRedirect ? await super.execute() : null;
         readyOutcome = () => Promise.resolve(result);
       } catch (e) {
         readyOutcome = () => Promise.reject(e);
@@ -98,6 +104,25 @@ export class RedirectAction extends AbstractPopupRedirectOperation {
   cleanUp(): void {}
 }
 
+export async function _getAndClearPendingRedirectStatus(resolver: PopupRedirectResolverInternal, auth: AuthInternal): Promise<boolean> {
+  const key = pendingRedirectKey(auth);
+  const hasPendingRedirect = await resolverPersistence(resolver)._get(key) === 'true';
+  await resolverPersistence(resolver)._remove(key);
+  return hasPendingRedirect;
+}
+
+export async function _setPendingRedirectStatus(resolver: PopupRedirectResolverInternal, auth: AuthInternal): Promise<void> {
+  return resolverPersistence(resolver)._set(pendingRedirectKey(auth), 'true');
+}
+
 export function _clearRedirectOutcomes(): void {
   redirectOutcomeMap.clear();
+}
+
+function resolverPersistence(resolver: PopupRedirectResolverInternal): PersistenceInternal {
+  return _getInstance(resolver._redirectPersistence);
+}
+
+function pendingRedirectKey(auth: AuthInternal): string {
+  return _persistenceKeyName(PENDING_REDIRECT_KEY, auth.config.apiKey, auth.name);
 }

--- a/packages-exp/auth-exp/src/core/strategies/redirect.ts
+++ b/packages-exp/auth-exp/src/core/strategies/redirect.ts
@@ -66,7 +66,10 @@ export class RedirectAction extends AbstractPopupRedirectOperation {
     let readyOutcome = redirectOutcomeMap.get(this.auth._key());
     if (!readyOutcome) {
       try {
-        const hasPendingRedirect = await _getAndClearPendingRedirectStatus(this.resolver, this.auth);
+        const hasPendingRedirect = await _getAndClearPendingRedirectStatus(
+          this.resolver,
+          this.auth
+        );
         const result = hasPendingRedirect ? await super.execute() : null;
         readyOutcome = () => Promise.resolve(result);
       } catch (e) {
@@ -104,14 +107,21 @@ export class RedirectAction extends AbstractPopupRedirectOperation {
   cleanUp(): void {}
 }
 
-export async function _getAndClearPendingRedirectStatus(resolver: PopupRedirectResolverInternal, auth: AuthInternal): Promise<boolean> {
+export async function _getAndClearPendingRedirectStatus(
+  resolver: PopupRedirectResolverInternal,
+  auth: AuthInternal
+): Promise<boolean> {
   const key = pendingRedirectKey(auth);
-  const hasPendingRedirect = await resolverPersistence(resolver)._get(key) === 'true';
+  const hasPendingRedirect =
+    (await resolverPersistence(resolver)._get(key)) === 'true';
   await resolverPersistence(resolver)._remove(key);
   return hasPendingRedirect;
 }
 
-export async function _setPendingRedirectStatus(resolver: PopupRedirectResolverInternal, auth: AuthInternal): Promise<void> {
+export async function _setPendingRedirectStatus(
+  resolver: PopupRedirectResolverInternal,
+  auth: AuthInternal
+): Promise<void> {
   return resolverPersistence(resolver)._set(pendingRedirectKey(auth), 'true');
 }
 
@@ -119,10 +129,16 @@ export function _clearRedirectOutcomes(): void {
   redirectOutcomeMap.clear();
 }
 
-function resolverPersistence(resolver: PopupRedirectResolverInternal): PersistenceInternal {
+function resolverPersistence(
+  resolver: PopupRedirectResolverInternal
+): PersistenceInternal {
   return _getInstance(resolver._redirectPersistence);
 }
 
 function pendingRedirectKey(auth: AuthInternal): string {
-  return _persistenceKeyName(PENDING_REDIRECT_KEY, auth.config.apiKey, auth.name);
+  return _persistenceKeyName(
+    PENDING_REDIRECT_KEY,
+    auth.config.apiKey,
+    auth.name
+  );
 }

--- a/packages-exp/auth-exp/src/core/util/browser.ts
+++ b/packages-exp/auth-exp/src/core/util/browser.ts
@@ -92,7 +92,7 @@ export function _isFirefox(ua = getUA()): boolean {
   return /firefox\//i.test(ua);
 }
 
-export function _isSafari(userAgent: string): boolean {
+export function _isSafari(userAgent = getUA()): boolean {
   const ua = userAgent.toLowerCase();
   return (
     ua.includes('safari/') &&

--- a/packages-exp/auth-exp/src/core/util/instantiator.ts
+++ b/packages-exp/auth-exp/src/core/util/instantiator.ts
@@ -46,3 +46,7 @@ export function _getInstance<T>(cls: unknown): T {
   instanceCache.set(cls, instance);
   return instance;
 }
+
+export function _clearInstanceMap(): void {
+  instanceCache.clear();
+}

--- a/packages-exp/auth-exp/src/model/popup_redirect.ts
+++ b/packages-exp/auth-exp/src/model/popup_redirect.ts
@@ -80,6 +80,9 @@ export interface EventManager {
 }
 
 export interface PopupRedirectResolverInternal extends PopupRedirectResolver {
+  // Whether or not to initialize the event manager early
+  _shouldInitProactively: boolean;
+
   _initialize(auth: AuthInternal): Promise<EventManager>;
   _openPopup(
     auth: AuthInternal,

--- a/packages-exp/auth-exp/src/platform_browser/auth.test.ts
+++ b/packages-exp/auth-exp/src/platform_browser/auth.test.ts
@@ -46,6 +46,7 @@ import { PopupRedirectResolverInternal } from '../model/popup_redirect';
 import { UserCredentialImpl } from '../core/user/user_credential_impl';
 import { UserInternal } from '../model/user';
 import { _createError } from '../core/util/assert';
+import { makeMockPopupRedirectResolver } from '../../test/helpers/mock_popup_redirect_resolver';
 
 use(sinonChai);
 use(chaiAsPromised);
@@ -189,6 +190,24 @@ describe('core/auth/initializeAuth', () => {
         .returns(Promise.resolve(user.toJSON()));
       await initAndWait(inMemoryPersistence);
       expect(reload._reloadWithoutSaving).not.to.have.been.called;
+    });
+
+    it('does not early-initialize the resolver', async () => {
+      const popupRedirectResolver = makeMockPopupRedirectResolver();
+      const resolverInternal: PopupRedirectResolverInternal = _getInstance(popupRedirectResolver);
+      sinon.stub(resolverInternal, '_shouldInitProactively').value(false);
+      sinon.spy(resolverInternal, '_initialize');
+      await initAndWait(inMemoryPersistence, popupRedirectResolver);
+      expect(resolverInternal._initialize).not.to.have.been.called;
+    });
+
+    it('does early-initialize the resolver', async () => {
+      const popupRedirectResolver = makeMockPopupRedirectResolver();
+      const resolverInternal: PopupRedirectResolverInternal = _getInstance(popupRedirectResolver);
+      sinon.stub(resolverInternal, '_shouldInitProactively').value(true);
+      sinon.spy(resolverInternal, '_initialize');
+      await initAndWait(inMemoryPersistence, popupRedirectResolver);
+      expect(resolverInternal._initialize).to.have.been.called;
     });
 
     it('reloads non-redirect users', async () => {

--- a/packages-exp/auth-exp/src/platform_browser/auth.test.ts
+++ b/packages-exp/auth-exp/src/platform_browser/auth.test.ts
@@ -194,7 +194,9 @@ describe('core/auth/initializeAuth', () => {
 
     it('does not early-initialize the resolver', async () => {
       const popupRedirectResolver = makeMockPopupRedirectResolver();
-      const resolverInternal: PopupRedirectResolverInternal = _getInstance(popupRedirectResolver);
+      const resolverInternal: PopupRedirectResolverInternal = _getInstance(
+        popupRedirectResolver
+      );
       sinon.stub(resolverInternal, '_shouldInitProactively').value(false);
       sinon.spy(resolverInternal, '_initialize');
       await initAndWait(inMemoryPersistence, popupRedirectResolver);
@@ -203,7 +205,9 @@ describe('core/auth/initializeAuth', () => {
 
     it('does early-initialize the resolver', async () => {
       const popupRedirectResolver = makeMockPopupRedirectResolver();
-      const resolverInternal: PopupRedirectResolverInternal = _getInstance(popupRedirectResolver);
+      const resolverInternal: PopupRedirectResolverInternal = _getInstance(
+        popupRedirectResolver
+      );
       sinon.stub(resolverInternal, '_shouldInitProactively').value(true);
       sinon.spy(resolverInternal, '_initialize');
       await initAndWait(inMemoryPersistence, popupRedirectResolver);

--- a/packages-exp/auth-exp/src/platform_browser/auth.test.ts
+++ b/packages-exp/auth-exp/src/platform_browser/auth.test.ts
@@ -203,7 +203,7 @@ describe('core/auth/initializeAuth', () => {
       expect(resolverInternal._initialize).not.to.have.been.called;
     });
 
-    it('does early-initialize the resolver', async () => {
+    it('early-initializes the resolver if _shouldInitProactively is true', async () => {
       const popupRedirectResolver = makeMockPopupRedirectResolver();
       const resolverInternal: PopupRedirectResolverInternal = _getInstance(
         popupRedirectResolver

--- a/packages-exp/auth-exp/src/platform_browser/auth.test.ts
+++ b/packages-exp/auth-exp/src/platform_browser/auth.test.ts
@@ -192,7 +192,7 @@ describe('core/auth/initializeAuth', () => {
       expect(reload._reloadWithoutSaving).not.to.have.been.called;
     });
 
-    it('does not early-initialize the resolver', async () => {
+    it('does not early-initialize the resolver if _shouldInitProactively is false', async () => {
       const popupRedirectResolver = makeMockPopupRedirectResolver();
       const resolverInternal: PopupRedirectResolverInternal = _getInstance(
         popupRedirectResolver

--- a/packages-exp/auth-exp/src/platform_browser/popup_redirect.ts
+++ b/packages-exp/auth-exp/src/platform_browser/popup_redirect.ts
@@ -37,6 +37,7 @@ import { browserSessionPersistence } from './persistence/session_storage';
 import { _open, AuthPopup } from './util/popup';
 import { _getRedirectResult } from './strategies/redirect';
 import { _getRedirectUrl } from '../core/util/handler';
+import { _isIOS, _isMobileBrowser, _isSafari } from '../core/util/browser';
 
 /**
  * The special web storage event
@@ -160,6 +161,11 @@ class BrowserPopupRedirectResolver implements PopupRedirectResolverInternal {
     }
 
     return this.originValidationPromises[key];
+  }
+
+  get _shouldInitProactively(): boolean {
+    // Mobile browsers and Safari need to optimistically initialize
+    return _isMobileBrowser() || _isSafari() || _isIOS();
   }
 
   _completeRedirectFn = _getRedirectResult;

--- a/packages-exp/auth-exp/src/platform_browser/strategies/redirect.test.ts
+++ b/packages-exp/auth-exp/src/platform_browser/strategies/redirect.test.ts
@@ -45,11 +45,10 @@ import { UserInternal } from '../../model/user';
 import { AuthEventManager } from '../../core/auth/auth_event_manager';
 import { AuthErrorCode } from '../../core/errors';
 import { PersistenceInternal } from '../../core/persistence';
-import { InMemoryPersistence } from '../../core/persistence/in_memory';
 import { OAuthProvider } from '../../core/providers/oauth';
 import * as link from '../../core/user/link_unlink';
 import { UserCredentialImpl } from '../../core/user/user_credential_impl';
-import { _getInstance } from '../../core/util/instantiator';
+import { _clearInstanceMap, _getInstance } from '../../core/util/instantiator';
 import * as idpTasks from '../../core/strategies/idp';
 import {
   getRedirectResult,
@@ -60,14 +59,13 @@ import {
 } from './redirect';
 import { FirebaseError } from '@firebase/util';
 import { _clearRedirectOutcomes } from '../../core/strategies/redirect';
+import { RedirectPersistence } from '../../../test/helpers/redirect_persistence';
 
 use(sinonChai);
 use(chaiAsPromised);
 
 const MATCHING_EVENT_ID = 'matching-event-id';
 const OTHER_EVENT_ID = 'wrong-id';
-
-class RedirectPersistence extends InMemoryPersistence {}
 
 describe('platform_browser/strategies/redirect', () => {
   let auth: TestAuth;
@@ -85,11 +83,13 @@ describe('platform_browser/strategies/redirect', () => {
     )._redirectPersistence = RedirectPersistence;
     auth = await testAuth(resolver);
     idpStubs = sinon.stub(idpTasks);
+    _getInstance<RedirectPersistence>(RedirectPersistence).hasPendingRedirect = true;
   });
 
   afterEach(() => {
     sinon.restore();
     _clearRedirectOutcomes();
+    _clearInstanceMap();
   });
 
   context('signInWithRedirect', () => {
@@ -299,16 +299,14 @@ describe('platform_browser/strategies/redirect', () => {
     }
 
     async function reInitAuthWithRedirectUser(eventId: string): Promise<void> {
-      const redirectPersistence: PersistenceInternal = _getInstance(
+      const redirectPersistence: RedirectPersistence = _getInstance(
         RedirectPersistence
       );
       const mainPersistence = new MockPersistenceLayer();
       const oldAuth = await testAuth();
       const user = testUser(oldAuth, 'uid');
       user._redirectEventId = eventId;
-      sinon
-        .stub(redirectPersistence, '_get')
-        .returns(Promise.resolve(user.toJSON()));
+      redirectPersistence.redirectUser = user.toJSON();
       sinon
         .stub(mainPersistence, '_get')
         .returns(Promise.resolve(user.toJSON()));
@@ -427,7 +425,7 @@ describe('platform_browser/strategies/redirect', () => {
         type: AuthEventType.LINK_VIA_REDIRECT
       });
       expect(await promise).to.eq(cred);
-      expect(redirectPersistence._remove).to.have.been.called;
+      expect(redirectPersistence._remove).to.have.been.calledWith('firebase:redirectUser:test-api-key:test-app');
       expect(auth._currentUser?._redirectEventId).to.be.undefined;
       expect(auth.persistenceLayer.lastObjectSet?._redirectEventId).to.be
         .undefined;
@@ -451,7 +449,7 @@ describe('platform_browser/strategies/redirect', () => {
         type: AuthEventType.LINK_VIA_REDIRECT
       });
       expect(await promise).to.eq(cred);
-      expect(redirectPersistence._remove).not.to.have.been.called;
+      expect(redirectPersistence._remove).not.to.have.been.calledWith('firebase:redirectUser:test-api-key:test-app');
       expect(auth._currentUser?._redirectEventId).not.to.be.undefined;
       expect(auth.persistenceLayer.lastObjectSet?._redirectEventId).not.to.be
         .undefined;

--- a/packages-exp/auth-exp/src/platform_browser/strategies/redirect.test.ts
+++ b/packages-exp/auth-exp/src/platform_browser/strategies/redirect.test.ts
@@ -83,7 +83,9 @@ describe('platform_browser/strategies/redirect', () => {
     )._redirectPersistence = RedirectPersistence;
     auth = await testAuth(resolver);
     idpStubs = sinon.stub(idpTasks);
-    _getInstance<RedirectPersistence>(RedirectPersistence).hasPendingRedirect = true;
+    _getInstance<RedirectPersistence>(
+      RedirectPersistence
+    ).hasPendingRedirect = true;
   });
 
   afterEach(() => {
@@ -425,7 +427,9 @@ describe('platform_browser/strategies/redirect', () => {
         type: AuthEventType.LINK_VIA_REDIRECT
       });
       expect(await promise).to.eq(cred);
-      expect(redirectPersistence._remove).to.have.been.calledWith('firebase:redirectUser:test-api-key:test-app');
+      expect(redirectPersistence._remove).to.have.been.calledWith(
+        'firebase:redirectUser:test-api-key:test-app'
+      );
       expect(auth._currentUser?._redirectEventId).to.be.undefined;
       expect(auth.persistenceLayer.lastObjectSet?._redirectEventId).to.be
         .undefined;
@@ -449,7 +453,9 @@ describe('platform_browser/strategies/redirect', () => {
         type: AuthEventType.LINK_VIA_REDIRECT
       });
       expect(await promise).to.eq(cred);
-      expect(redirectPersistence._remove).not.to.have.been.calledWith('firebase:redirectUser:test-api-key:test-app');
+      expect(redirectPersistence._remove).not.to.have.been.calledWith(
+        'firebase:redirectUser:test-api-key:test-app'
+      );
       expect(auth._currentUser?._redirectEventId).not.to.be.undefined;
       expect(auth.persistenceLayer.lastObjectSet?._redirectEventId).not.to.be
         .undefined;

--- a/packages-exp/auth-exp/src/platform_browser/strategies/redirect.ts
+++ b/packages-exp/auth-exp/src/platform_browser/strategies/redirect.ts
@@ -32,7 +32,7 @@ import { _generateEventId } from '../../core/util/event_id';
 import { AuthEventType } from '../../model/popup_redirect';
 import { UserInternal } from '../../model/user';
 import { _withDefaultResolver } from '../../core/util/resolver';
-import { RedirectAction } from '../../core/strategies/redirect';
+import { RedirectAction, _setPendingRedirectStatus } from '../../core/strategies/redirect';
 
 /**
  * Authenticates a Firebase client using a full-page redirect flow.
@@ -93,7 +93,10 @@ export async function _signInWithRedirect(
     AuthErrorCode.ARGUMENT_ERROR
   );
 
-  return _withDefaultResolver(authInternal, resolver)._openRedirect(
+  const resolverInternal = _withDefaultResolver(authInternal, resolver);
+  await _setPendingRedirectStatus(resolverInternal, authInternal);
+
+  return resolverInternal._openRedirect(
     authInternal,
     provider,
     AuthEventType.SIGN_IN_VIA_REDIRECT
@@ -153,6 +156,7 @@ export async function _reauthenticateWithRedirect(
 
   // Allow the resolver to error before persisting the redirect user
   const resolverInternal = _withDefaultResolver(userInternal.auth, resolver);
+  await _setPendingRedirectStatus(resolverInternal, userInternal.auth);
 
   const eventId = await prepareUserForRedirect(userInternal);
   return resolverInternal._openRedirect(
@@ -209,8 +213,9 @@ export async function _linkWithRedirect(
 
   // Allow the resolver to error before persisting the redirect user
   const resolverInternal = _withDefaultResolver(userInternal.auth, resolver);
-
   await _assertLinkedStatus(false, userInternal, provider.providerId);
+  await _setPendingRedirectStatus(resolverInternal, userInternal.auth);
+
   const eventId = await prepareUserForRedirect(userInternal);
   return resolverInternal._openRedirect(
     userInternal.auth,

--- a/packages-exp/auth-exp/src/platform_browser/strategies/redirect.ts
+++ b/packages-exp/auth-exp/src/platform_browser/strategies/redirect.ts
@@ -32,7 +32,10 @@ import { _generateEventId } from '../../core/util/event_id';
 import { AuthEventType } from '../../model/popup_redirect';
 import { UserInternal } from '../../model/user';
 import { _withDefaultResolver } from '../../core/util/resolver';
-import { RedirectAction, _setPendingRedirectStatus } from '../../core/strategies/redirect';
+import {
+  RedirectAction,
+  _setPendingRedirectStatus
+} from '../../core/strategies/redirect';
 
 /**
  * Authenticates a Firebase client using a full-page redirect flow.

--- a/packages-exp/auth-exp/src/platform_cordova/popup_redirect/popup_redirect.ts
+++ b/packages-exp/auth-exp/src/platform_cordova/popup_redirect/popup_redirect.ts
@@ -52,6 +52,7 @@ const INITIAL_EVENT_TIMEOUT_MS = 500;
 
 class CordovaPopupRedirectResolver implements PopupRedirectResolverInternal {
   readonly _redirectPersistence = browserSessionPersistence;
+  readonly _shouldInitProactively = true;  // This is lightweight for Cordova
   private readonly eventManagers = new Map<string, CordovaAuthEventManager>();
 
   _completeRedirectFn = _getRedirectResult;

--- a/packages-exp/auth-exp/src/platform_cordova/popup_redirect/popup_redirect.ts
+++ b/packages-exp/auth-exp/src/platform_cordova/popup_redirect/popup_redirect.ts
@@ -52,7 +52,7 @@ const INITIAL_EVENT_TIMEOUT_MS = 500;
 
 class CordovaPopupRedirectResolver implements PopupRedirectResolverInternal {
   readonly _redirectPersistence = browserSessionPersistence;
-  readonly _shouldInitProactively = true;  // This is lightweight for Cordova
+  readonly _shouldInitProactively = true; // This is lightweight for Cordova
   private readonly eventManagers = new Map<string, CordovaAuthEventManager>();
 
   _completeRedirectFn = _getRedirectResult;

--- a/packages-exp/auth-exp/test/helpers/mock_popup_redirect_resolver.ts
+++ b/packages-exp/auth-exp/test/helpers/mock_popup_redirect_resolver.ts
@@ -56,6 +56,8 @@ export function makeMockPopupRedirectResolver(
 
     _redirectPersistence?: Persistence;
 
+    _shouldInitProactively = false;
+
     async _completeRedirectFn(): Promise<void> {}
 
     async _originValidation(): Promise<void> {}

--- a/packages-exp/auth-exp/test/helpers/redirect_persistence.ts
+++ b/packages-exp/auth-exp/test/helpers/redirect_persistence.ts
@@ -26,8 +26,10 @@ export class RedirectPersistence extends InMemoryPersistence {
   async _get<T extends PersistenceValue>(key: string): Promise<T | null> {
     if (key.includes('pendingRedirect')) {
       return this.hasPendingRedirect.toString() as T;
+    } else if (key.includes('redirectUser')) {
+      return this.redirectUser as T | null;
     }
 
-    return this.redirectUser as T | null;
+    throw new Error(`Unexpected redirect persistence key requested: ${key}`);
   }
 }

--- a/packages-exp/auth-exp/test/helpers/redirect_persistence.ts
+++ b/packages-exp/auth-exp/test/helpers/redirect_persistence.ts
@@ -1,0 +1,16 @@
+import { PersistenceValue } from '../../src/core/persistence';
+import { InMemoryPersistence } from '../../src/core/persistence/in_memory';
+
+/** Helper class for handling redirect persistence */
+export class RedirectPersistence extends InMemoryPersistence {
+  hasPendingRedirect = false;
+  redirectUser: object|null = null;
+
+  async _get<T extends PersistenceValue>(key: string): Promise<T|null> {
+    if (key.includes('pendingRedirect')) {
+      return this.hasPendingRedirect.toString() as T;
+    }
+
+    return this.redirectUser as T | null;
+  }
+}

--- a/packages-exp/auth-exp/test/helpers/redirect_persistence.ts
+++ b/packages-exp/auth-exp/test/helpers/redirect_persistence.ts
@@ -1,12 +1,29 @@
+/**
+ * @license
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { PersistenceValue } from '../../src/core/persistence';
 import { InMemoryPersistence } from '../../src/core/persistence/in_memory';
 
 /** Helper class for handling redirect persistence */
 export class RedirectPersistence extends InMemoryPersistence {
   hasPendingRedirect = false;
-  redirectUser: object|null = null;
+  redirectUser: object | null = null;
 
-  async _get<T extends PersistenceValue>(key: string): Promise<T|null> {
+  async _get<T extends PersistenceValue>(key: string): Promise<T | null> {
     if (key.includes('pendingRedirect')) {
       return this.hasPendingRedirect.toString() as T;
     }


### PR DESCRIPTION
This change prevents checking for redirects unless a key is set in storage. This brings the new SDK closer in line with the old SDK.

This change also similarly adds a new field to the resolver called `_shouldInitProactively`. This field is true for specific environments where opening the iframe is costly or can break the popup flow (i.e. Safari).