### PR TITLE
Fix postBody parameter for Auth sign in

### DIFF
--- a/packages-exp/auth-exp/src/api/authentication/idp.test.ts
+++ b/packages-exp/auth-exp/src/api/authentication/idp.test.ts
@@ -33,7 +33,6 @@ describe('api/authentication/signInWithIdp', () => {
   const request = {
     returnSecureToken: true,
     requestUri: 'request-uri',
-    postBody: null
   };
 
   let auth: TestAuth;

--- a/packages-exp/auth-exp/src/api/authentication/idp.test.ts
+++ b/packages-exp/auth-exp/src/api/authentication/idp.test.ts
@@ -32,7 +32,7 @@ use(chaiAsPromised);
 describe('api/authentication/signInWithIdp', () => {
   const request = {
     returnSecureToken: true,
-    requestUri: 'request-uri',
+    requestUri: 'request-uri'
   };
 
   let auth: TestAuth;

--- a/packages-exp/auth-exp/src/api/authentication/idp.ts
+++ b/packages-exp/auth-exp/src/api/authentication/idp.ts
@@ -21,7 +21,7 @@ import { Auth } from '../../model/public_types';
 
 export interface SignInWithIdpRequest {
   requestUri: string;
-  postBody: string | null;
+  postBody?: string;
   sessionId?: string;
   tenantId?: string;
   returnSecureToken: boolean;

--- a/packages-exp/auth-exp/src/core/credentials/oauth.test.ts
+++ b/packages-exp/auth-exp/src/core/credentials/oauth.test.ts
@@ -165,7 +165,7 @@ describe('core/credentials/oauth', () => {
       expect(request.requestUri).to.eq('http://localhost');
       expect(request.returnSecureToken).to.be.true;
       expect(request.pendingToken).to.eq('pending-token');
-      expect(request.postBody).to.be.null;
+      expect(request.postBody).to.be.undefined;
     });
   });
 

--- a/packages-exp/auth-exp/src/core/credentials/oauth.ts
+++ b/packages-exp/auth-exp/src/core/credentials/oauth.ts
@@ -172,7 +172,7 @@ export class OAuthCredential extends AuthCredential {
   private buildRequest(): SignInWithIdpRequest {
     const request: SignInWithIdpRequest = {
       requestUri: IDP_REQUEST_URI,
-      returnSecureToken: true,
+      returnSecureToken: true
     };
 
     if (this.pendingToken) {

--- a/packages-exp/auth-exp/src/core/credentials/oauth.ts
+++ b/packages-exp/auth-exp/src/core/credentials/oauth.ts
@@ -173,7 +173,6 @@ export class OAuthCredential extends AuthCredential {
     const request: SignInWithIdpRequest = {
       requestUri: IDP_REQUEST_URI,
       returnSecureToken: true,
-      postBody: null
     };
 
     if (this.pendingToken) {

--- a/packages-exp/auth-exp/src/core/strategies/idp.ts
+++ b/packages-exp/auth-exp/src/core/strategies/idp.ts
@@ -70,7 +70,7 @@ class IdpCredential extends AuthCredential {
     const request: SignInWithIdpRequest = {
       requestUri: this.params.requestUri,
       sessionId: this.params.sessionId,
-      postBody: this.params.postBody || null,
+      postBody: this.params.postBody,
       tenantId: this.params.tenantId,
       pendingToken: this.params.pendingToken,
       returnSecureToken: true,


### PR DESCRIPTION
We had typed it as `string|null` where it should actually be omitted if it's not set.