### PR TITLE
Add custom auth integration tests (against emulator only)

### DIFF
--- a/packages-exp/auth-exp/karma.conf.js
+++ b/packages-exp/auth-exp/karma.conf.js
@@ -36,7 +36,9 @@ function getTestFiles(argv) {
   if (argv.unit) {
     return ['src/**/*.test.ts', 'test/helpers/**/*.test.ts'];
   } else if (argv.integration) {
-    return argv.local ? ['test/integration/**/*.test.ts'] : ['test/integration/**/*!(local).test.ts'];
+    return argv.local
+      ? ['test/integration/**/*.test.ts']
+      : ['test/integration/**/*!(local).test.ts'];
   } else if (argv.cordova) {
     return ['src/platform_cordova/**/*.test.ts'];
   } else {

--- a/packages-exp/auth-exp/karma.conf.js
+++ b/packages-exp/auth-exp/karma.conf.js
@@ -36,7 +36,7 @@ function getTestFiles(argv) {
   if (argv.unit) {
     return ['src/**/*.test.ts', 'test/helpers/**/*.test.ts'];
   } else if (argv.integration) {
-    return ['test/integration/**/*.test.ts'];
+    return argv.local ? ['test/integration/**/*.test.ts'] : ['test/integration/**/*!(local).test.ts'];
   } else if (argv.cordova) {
     return ['src/platform_cordova/**/*.test.ts'];
   } else {

--- a/packages-exp/auth-exp/scripts/run-node-tests.js
+++ b/packages-exp/auth-exp/scripts/run-node-tests.js
@@ -1,3 +1,4 @@
+"use strict";
 /**
  * @license
  * Copyright 2020 Google LLC
@@ -13,57 +14,4 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- */
-
-'use strict';
-var __spreadArrays =
-  (this && this.__spreadArrays) ||
-  function () {
-    for (var s = 0, i = 0, il = arguments.length; i < il; i++)
-      s += arguments[i].length;
-    for (var r = Array(s), k = 0, i = 0; i < il; i++)
-      for (var a = arguments[i], j = 0, jl = a.length; j < jl; j++, k++)
-        r[k] = a[j];
-    return r;
-  };
-exports.__esModule = true;
-var path_1 = require('path');
-var child_process_promise_1 = require('child-process-promise');
-var yargs = require('yargs');
-var argv = yargs.options({
-  local: { type: 'boolean' },
-  integration: { type: 'boolean' }
-}).argv;
-var nyc = path_1.resolve(__dirname, '../../../node_modules/.bin/nyc');
-var mocha = path_1.resolve(__dirname, '../../../node_modules/.bin/mocha');
-process.env.TS_NODE_COMPILER_OPTIONS = '{"module":"commonjs"}';
-var testConfig = [
-  'src/!(platform_browser|platform_react_native|platform_cordova)/**/*.test.ts',
-  '--file',
-  'index.node.ts'
-];
-if (argv.integration) {
-  testConfig = ['test/integration/flows/{email,anonymous}.test.ts'];
-}
-var args = __spreadArrays(['--reporter', 'lcovonly', mocha], testConfig, [
-  '--config',
-  '../../config/mocharc.node.js'
-]);
-if (argv.local) {
-  process.env.AUTH_EMULATOR_PORT = '9099';
-  process.env.AUTH_EMULATOR_PROJECT_ID = 'test-emulator';
-}
-args = args.concat(argv._);
-var childProcess = child_process_promise_1.spawn(nyc, args, {
-  stdio: 'inherit',
-  cwd: process.cwd()
-}).childProcess;
-process.once('exit', function () {
-  return childProcess.kill();
-});
-process.once('SIGINT', function () {
-  return childProcess.kill('SIGINT');
-});
-process.once('SIGTERM', function () {
-  return childProcess.kill('SIGTERM');
-});
+ */var __spreadArrays=this&&this.__spreadArrays||function(){for(var s=0,i=0,il=arguments.length;i<il;i++)s+=arguments[i].length;for(var r=Array(s),k=0,i=0;i<il;i++)for(var a=arguments[i],j=0,jl=a.length;j<jl;j++,k++)r[k]=a[j];return r};exports.__esModule=true;var path_1=require("path");var child_process_promise_1=require("child-process-promise");var yargs=require("yargs");var argv=yargs.options({local:{type:"boolean"},integration:{type:"boolean"}}).argv;var nyc=path_1.resolve(__dirname,"../../../node_modules/.bin/nyc");var mocha=path_1.resolve(__dirname,"../../../node_modules/.bin/mocha");process.env.TS_NODE_COMPILER_OPTIONS='{"module":"commonjs"}';var testConfig=["src/!(platform_browser|platform_react_native|platform_cordova)/**/*.test.ts","--file","index.node.ts"];if(argv.integration){testConfig=["test/integration/flows/{email,anonymous}.test.ts"];if(argv.local){testConfig.push("test/integration/flows/*.local.test.ts")}}var args=__spreadArrays(["--reporter","lcovonly",mocha],testConfig,["--config","../../config/mocharc.node.js"]);if(argv.local){process.env.AUTH_EMULATOR_PORT="9099";process.env.AUTH_EMULATOR_PROJECT_ID="test-emulator"}args=args.concat(argv._);var childProcess=child_process_promise_1.spawn(nyc,args,{stdio:"inherit",cwd:process.cwd()}).childProcess;process.once("exit",(function(){return childProcess.kill()}));process.once("SIGINT",(function(){return childProcess.kill("SIGINT")}));process.once("SIGTERM",(function(){return childProcess.kill("SIGTERM")}));

--- a/packages-exp/auth-exp/scripts/run-node-tests.js
+++ b/packages-exp/auth-exp/scripts/run-node-tests.js
@@ -1,4 +1,4 @@
-"use strict";
+'use strict';
 /**
  * @license
  * Copyright 2020 Google LLC
@@ -14,4 +14,57 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- */var __spreadArrays=this&&this.__spreadArrays||function(){for(var s=0,i=0,il=arguments.length;i<il;i++)s+=arguments[i].length;for(var r=Array(s),k=0,i=0;i<il;i++)for(var a=arguments[i],j=0,jl=a.length;j<jl;j++,k++)r[k]=a[j];return r};exports.__esModule=true;var path_1=require("path");var child_process_promise_1=require("child-process-promise");var yargs=require("yargs");var argv=yargs.options({local:{type:"boolean"},integration:{type:"boolean"}}).argv;var nyc=path_1.resolve(__dirname,"../../../node_modules/.bin/nyc");var mocha=path_1.resolve(__dirname,"../../../node_modules/.bin/mocha");process.env.TS_NODE_COMPILER_OPTIONS='{"module":"commonjs"}';var testConfig=["src/!(platform_browser|platform_react_native|platform_cordova)/**/*.test.ts","--file","index.node.ts"];if(argv.integration){testConfig=["test/integration/flows/{email,anonymous}.test.ts"];if(argv.local){testConfig.push("test/integration/flows/*.local.test.ts")}}var args=__spreadArrays(["--reporter","lcovonly",mocha],testConfig,["--config","../../config/mocharc.node.js"]);if(argv.local){process.env.AUTH_EMULATOR_PORT="9099";process.env.AUTH_EMULATOR_PROJECT_ID="test-emulator"}args=args.concat(argv._);var childProcess=child_process_promise_1.spawn(nyc,args,{stdio:"inherit",cwd:process.cwd()}).childProcess;process.once("exit",(function(){return childProcess.kill()}));process.once("SIGINT",(function(){return childProcess.kill("SIGINT")}));process.once("SIGTERM",(function(){return childProcess.kill("SIGTERM")}));
+ */ var __spreadArrays =
+  (this && this.__spreadArrays) ||
+  function () {
+    for (var s = 0, i = 0, il = arguments.length; i < il; i++)
+      s += arguments[i].length;
+    for (var r = Array(s), k = 0, i = 0; i < il; i++)
+      for (var a = arguments[i], j = 0, jl = a.length; j < jl; j++, k++)
+        r[k] = a[j];
+    return r;
+  };
+exports.__esModule = true;
+var path_1 = require('path');
+var child_process_promise_1 = require('child-process-promise');
+var yargs = require('yargs');
+var argv = yargs.options({
+  local: { type: 'boolean' },
+  integration: { type: 'boolean' }
+}).argv;
+var nyc = path_1.resolve(__dirname, '../../../node_modules/.bin/nyc');
+var mocha = path_1.resolve(__dirname, '../../../node_modules/.bin/mocha');
+process.env.TS_NODE_COMPILER_OPTIONS = '{"module":"commonjs"}';
+var testConfig = [
+  'src/!(platform_browser|platform_react_native|platform_cordova)/**/*.test.ts',
+  '--file',
+  'index.node.ts'
+];
+if (argv.integration) {
+  testConfig = ['test/integration/flows/{email,anonymous}.test.ts'];
+  if (argv.local) {
+    testConfig.push('test/integration/flows/*.local.test.ts');
+  }
+}
+var args = __spreadArrays(['--reporter', 'lcovonly', mocha], testConfig, [
+  '--config',
+  '../../config/mocharc.node.js'
+]);
+if (argv.local) {
+  process.env.AUTH_EMULATOR_PORT = '9099';
+  process.env.AUTH_EMULATOR_PROJECT_ID = 'test-emulator';
+}
+args = args.concat(argv._);
+var childProcess = child_process_promise_1.spawn(nyc, args, {
+  stdio: 'inherit',
+  cwd: process.cwd()
+}).childProcess;
+process.once('exit', function () {
+  return childProcess.kill();
+});
+process.once('SIGINT', function () {
+  return childProcess.kill('SIGINT');
+});
+process.once('SIGTERM', function () {
+  return childProcess.kill('SIGTERM');
+});

--- a/packages-exp/auth-exp/scripts/run-node-tests.ts
+++ b/packages-exp/auth-exp/scripts/run-node-tests.ts
@@ -42,6 +42,9 @@ let testConfig = [
 
 if (argv.integration) {
   testConfig = ['test/integration/flows/{email,anonymous}.test.ts'];
+  if (argv.local) {
+    testConfig.push('test/integration/flows/*.local.test.ts');
+  }
 }
 
 let args = [

--- a/packages-exp/auth-exp/test/helpers/integration/helpers.ts
+++ b/packages-exp/auth-exp/test/helpers/integration/helpers.ts
@@ -75,7 +75,11 @@ export async function cleanUpTestInstance(auth: Auth): Promise<void> {
 function stubConsoleToSilenceEmulatorWarnings(): sinon.SinonStub {
   const originalConsoleInfo = console.info.bind(console);
   return sinon.stub(console, 'info').callsFake((...args: unknown[]) => {
-    if (!JSON.stringify(args[0]).includes('WARNING: You are using the Auth Emulator')) {
+    if (
+      !JSON.stringify(args[0]).includes(
+        'WARNING: You are using the Auth Emulator'
+      )
+    ) {
       originalConsoleInfo(...args);
     }
   });

--- a/packages-exp/auth-exp/test/helpers/integration/helpers.ts
+++ b/packages-exp/auth-exp/test/helpers/integration/helpers.ts
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+import * as sinon from 'sinon';
 import { deleteApp, initializeApp } from '@firebase/app-exp';
 import { Auth, User } from '../../../src/model/public_types';
 
@@ -39,7 +40,9 @@ export function getTestInstance(): Auth {
   const emulatorUrl = getEmulatorUrl();
 
   if (emulatorUrl) {
+    const stub = stubConsoleToSilenceEmulatorWarnings();
     useAuthEmulator(auth, emulatorUrl, { disableWarnings: true });
+    stub.restore();
   }
 
   auth.onAuthStateChanged(user => {
@@ -67,4 +70,13 @@ export function getTestInstance(): Auth {
 export async function cleanUpTestInstance(auth: Auth): Promise<void> {
   await auth.signOut();
   await (auth as IntegrationTestAuth).cleanUp();
+}
+
+function stubConsoleToSilenceEmulatorWarnings(): sinon.SinonStub {
+  const originalConsoleInfo = console.info.bind(console);
+  return sinon.stub(console, 'info').callsFake((...args: unknown[]) => {
+    if (!JSON.stringify(args[0]).includes('WARNING: You are using the Auth Emulator')) {
+      originalConsoleInfo(...args);
+    }
+  });
 }

--- a/packages-exp/auth-exp/test/integration/flows/custom.local.test.ts
+++ b/packages-exp/auth-exp/test/integration/flows/custom.local.test.ts
@@ -1,0 +1,120 @@
+import {Auth, createUserWithEmailAndPassword, EmailAuthProvider, linkWithCredential, OperationType, signInAnonymously, signInWithCustomToken, signInWithEmailAndPassword, updateEmail, updatePassword} from '@firebase/auth-exp';
+import { FirebaseError } from '@firebase/util';
+import { expect, use } from 'chai';
+import * as chaiAsPromised from 'chai-as-promised';
+import { cleanUpTestInstance, getTestInstance, randomEmail } from '../../helpers/integration/helpers';
+
+use(chaiAsPromised);
+
+describe('Integration test: custom auth', () => {
+  let auth: Auth;
+
+  beforeEach(() => {
+    auth = getTestInstance();
+
+    if (!auth.emulatorConfig) {
+      throw new Error('Test can only be run against the emulator!');
+    }
+  });
+
+  afterEach(async () => {
+    await cleanUpTestInstance(auth);
+  });
+
+  it('signs in with custom token', async () => {
+    const cred = await signInWithCustomToken(auth, JSON.stringify({
+      uid: 'custom-uid-yay',
+      claims: {customClaim: 'some-claim'},
+    }));
+    expect(auth.currentUser).to.eq(cred.user);
+    expect(cred.operationType).to.eq(OperationType.SIGN_IN);
+
+    const {user} = cred;
+    expect(user.isAnonymous).to.be.false;
+    expect(user.uid).to.eq('custom-uid-yay');
+    expect((await user.getIdTokenResult(false)).claims.customClaim).to.eq('some-claim');
+    expect(user.providerId).to.eq('firebase');
+  });
+
+  it('uid will overwrite existing user, joining accounts', async () => {
+    const {user: anonUser} = await signInAnonymously(auth);
+    const customCred = await signInWithCustomToken(auth, JSON.stringify({
+      uid: anonUser.uid,
+    }));
+
+    expect(auth.currentUser).to.eq(customCred.user);
+    expect(customCred.user.uid).to.eq(anonUser.uid);
+    expect(customCred.user.isAnonymous).to.be.false;
+  });
+
+  context('email/password interaction', () => {
+    let email: string;
+    let customToken: string;
+
+    beforeEach(() => {
+      email = randomEmail();
+      customToken = JSON.stringify({
+        uid: email,
+      });
+    });
+
+    it('custom / email-password accounts remain independent', async () => {
+      let customCred = await signInWithCustomToken(auth, customToken);
+      const emailCred = await createUserWithEmailAndPassword(
+        auth,
+        email,
+        'password'
+      );
+      expect(emailCred.user.uid).not.to.eql(customCred.user.uid);
+
+      await auth.signOut();
+      customCred = await signInWithCustomToken(auth, customToken);
+      const emailSignIn = await signInWithEmailAndPassword(
+        auth,
+        email,
+        'password'
+      );
+      expect(emailCred.user.uid).to.eql(emailSignIn.user.uid);
+      expect(emailSignIn.user.uid).not.to.eql(customCred.user.uid);
+    });
+
+    it('account can have email / password attached', async () => {
+      const { user: customUser } = await signInWithCustomToken(auth, customToken);
+      await updateEmail(customUser, email);
+      await updatePassword(customUser, 'password');
+
+      await auth.signOut();
+
+      const { user: emailPassUser } = await signInWithEmailAndPassword(
+        auth,
+        email,
+        'password'
+      );
+      expect(emailPassUser.uid).to.eq(customUser.uid);
+    });
+
+    it('account can be linked using email and password', async () => {
+      const { user: customUser } = await signInWithCustomToken(auth, customToken);
+      const cred = EmailAuthProvider.credential(email, 'password');
+      await linkWithCredential(customUser, cred);
+      await auth.signOut();
+
+      const { user: emailPassUser } = await signInWithEmailAndPassword(
+        auth,
+        email,
+        'password'
+      );
+      expect(emailPassUser.uid).to.eq(customUser.uid);
+    });
+
+    it('account cannot be linked with existing email/password', async () => {
+      await createUserWithEmailAndPassword(auth, email, 'password');
+      const { user: customUser } = await signInWithCustomToken(auth, customToken);
+      const cred = EmailAuthProvider.credential(email, 'password');
+      await expect(linkWithCredential(customUser, cred)).to.be.rejectedWith(
+        FirebaseError,
+        'auth/email-already-in-use'
+      );
+    });
+  });
+});

--- a/packages-exp/auth-exp/test/integration/flows/custom.local.test.ts
+++ b/packages-exp/auth-exp/test/integration/flows/custom.local.test.ts
@@ -1,8 +1,40 @@
-import {Auth, createUserWithEmailAndPassword, EmailAuthProvider, linkWithCredential, OperationType, signInAnonymously, signInWithCustomToken, signInWithEmailAndPassword, updateEmail, updatePassword} from '@firebase/auth-exp';
+/**
+ * @license
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  Auth,
+  createUserWithEmailAndPassword,
+  EmailAuthProvider,
+  linkWithCredential,
+  OperationType,
+  signInAnonymously,
+  signInWithCustomToken,
+  signInWithEmailAndPassword,
+  updateEmail,
+  updatePassword
+} from '@firebase/auth-exp';
 import { FirebaseError } from '@firebase/util';
 import { expect, use } from 'chai';
 import * as chaiAsPromised from 'chai-as-promised';
-import { cleanUpTestInstance, getTestInstance, randomEmail } from '../../helpers/integration/helpers';
+import {
+  cleanUpTestInstance,
+  getTestInstance,
+  randomEmail
+} from '../../helpers/integration/helpers';
 
 use(chaiAsPromised);
 
@@ -22,25 +54,33 @@ describe('Integration test: custom auth', () => {
   });
 
   it('signs in with custom token', async () => {
-    const cred = await signInWithCustomToken(auth, JSON.stringify({
-      uid: 'custom-uid-yay',
-      claims: {customClaim: 'some-claim'},
-    }));
+    const cred = await signInWithCustomToken(
+      auth,
+      JSON.stringify({
+        uid: 'custom-uid-yay',
+        claims: { customClaim: 'some-claim' }
+      })
+    );
     expect(auth.currentUser).to.eq(cred.user);
     expect(cred.operationType).to.eq(OperationType.SIGN_IN);
 
-    const {user} = cred;
+    const { user } = cred;
     expect(user.isAnonymous).to.be.false;
     expect(user.uid).to.eq('custom-uid-yay');
-    expect((await user.getIdTokenResult(false)).claims.customClaim).to.eq('some-claim');
+    expect((await user.getIdTokenResult(false)).claims.customClaim).to.eq(
+      'some-claim'
+    );
     expect(user.providerId).to.eq('firebase');
   });
 
   it('uid will overwrite existing user, joining accounts', async () => {
-    const {user: anonUser} = await signInAnonymously(auth);
-    const customCred = await signInWithCustomToken(auth, JSON.stringify({
-      uid: anonUser.uid,
-    }));
+    const { user: anonUser } = await signInAnonymously(auth);
+    const customCred = await signInWithCustomToken(
+      auth,
+      JSON.stringify({
+        uid: anonUser.uid
+      })
+    );
 
     expect(auth.currentUser).to.eq(customCred.user);
     expect(customCred.user.uid).to.eq(anonUser.uid);
@@ -54,7 +94,7 @@ describe('Integration test: custom auth', () => {
     beforeEach(() => {
       email = randomEmail();
       customToken = JSON.stringify({
-        uid: email,
+        uid: email
       });
     });
 
@@ -79,7 +119,10 @@ describe('Integration test: custom auth', () => {
     });
 
     it('account can have email / password attached', async () => {
-      const { user: customUser } = await signInWithCustomToken(auth, customToken);
+      const { user: customUser } = await signInWithCustomToken(
+        auth,
+        customToken
+      );
       await updateEmail(customUser, email);
       await updatePassword(customUser, 'password');
 
@@ -94,7 +137,10 @@ describe('Integration test: custom auth', () => {
     });
 
     it('account can be linked using email and password', async () => {
-      const { user: customUser } = await signInWithCustomToken(auth, customToken);
+      const { user: customUser } = await signInWithCustomToken(
+        auth,
+        customToken
+      );
       const cred = EmailAuthProvider.credential(email, 'password');
       await linkWithCredential(customUser, cred);
       await auth.signOut();
@@ -109,7 +155,10 @@ describe('Integration test: custom auth', () => {
 
     it('account cannot be linked with existing email/password', async () => {
       await createUserWithEmailAndPassword(auth, email, 'password');
-      const { user: customUser } = await signInWithCustomToken(auth, customToken);
+      const { user: customUser } = await signInWithCustomToken(
+        auth,
+        customToken
+      );
       const cred = EmailAuthProvider.credential(email, 'password');
       await expect(linkWithCredential(customUser, cred)).to.be.rejectedWith(
         FirebaseError,

--- a/packages-exp/auth-exp/test/integration/flows/custom.local.test.ts
+++ b/packages-exp/auth-exp/test/integration/flows/custom.local.test.ts
@@ -26,6 +26,7 @@ import {
   signInWithEmailAndPassword,
   updateEmail,
   updatePassword
+// eslint-disable-next-line import/no-extraneous-dependencies
 } from '@firebase/auth-exp';
 import { FirebaseError } from '@firebase/util';
 import { expect, use } from 'chai';

--- a/packages-exp/auth-exp/test/integration/flows/custom.local.test.ts
+++ b/packages-exp/auth-exp/test/integration/flows/custom.local.test.ts
@@ -27,8 +27,8 @@ import {
   signInWithEmailAndPassword,
   updateEmail,
   updatePassword,
-  updateProfile,
-// eslint-disable-next-line import/no-extraneous-dependencies
+  updateProfile
+  // eslint-disable-next-line import/no-extraneous-dependencies
 } from '@firebase/auth-exp';
 import { FirebaseError } from '@firebase/util';
 import { expect, use } from 'chai';
@@ -52,7 +52,7 @@ describe('Integration test: custom auth', () => {
     customToken = JSON.stringify({
       uid,
       claims: {
-        customClaim: 'some-claim',
+        customClaim: 'some-claim'
       }
     });
 
@@ -66,10 +66,7 @@ describe('Integration test: custom auth', () => {
   });
 
   it('signs in with custom token', async () => {
-    const cred = await signInWithCustomToken(
-      auth,
-      customToken
-    );
+    const cred = await signInWithCustomToken(auth, customToken);
     expect(auth.currentUser).to.eq(cred.user);
     expect(cred.operationType).to.eq(OperationType.SIGN_IN);
 
@@ -97,11 +94,8 @@ describe('Integration test: custom auth', () => {
   });
 
   it('allows the user to delete the account', async () => {
-    let { user } = await signInWithCustomToken(
-      auth,
-      customToken
-    );
-    await updateProfile(user, {displayName: 'Display Name'});
+    let { user } = await signInWithCustomToken(auth, customToken);
+    await updateProfile(user, { displayName: 'Display Name' });
     expect(user.displayName).to.eq('Display Name');
 
     await user.delete();
@@ -111,20 +105,14 @@ describe('Integration test: custom auth', () => {
     );
     expect(auth.currentUser).to.be.null;
 
-    ({user} = await signInWithCustomToken(auth, customToken));
+    ({ user } = await signInWithCustomToken(auth, customToken));
     // New user in the system: the display name should be missing
     expect(user.displayName).to.be.null;
   });
 
   it('sign in can be called twice successively', async () => {
-    const { user: userA } = await signInWithCustomToken(
-      auth,
-      customToken
-    );
-    const { user: userB } = await signInWithCustomToken(
-      auth,
-      customToken
-    );
+    const { user: userA } = await signInWithCustomToken(auth, customToken);
+    const { user: userB } = await signInWithCustomToken(auth, customToken);
     expect(userA.uid).to.eq(userB.uid);
   });
 


### PR DESCRIPTION
This change also introduces a standard of marking a test as `.local.test.ts` if it can only be run against the emulator.