### PR TITLE
Add `initializeAnalytics()` to analytics-exp

### DIFF
--- a/common/api-review/analytics-exp.api.md
+++ b/common/api-review/analytics-exp.api.md
@@ -18,7 +18,7 @@ export interface AnalyticsCallOptions {
 
 // @public
 export interface AnalyticsOptions {
-    config: GtagConfigParams | EventParams;
+    config?: GtagConfigParams | EventParams;
 }
 
 // @public

--- a/common/api-review/analytics-exp.api.md
+++ b/common/api-review/analytics-exp.api.md
@@ -18,7 +18,6 @@ export interface AnalyticsCallOptions {
 
 // @public
 export interface AnalyticsOptions {
-    // (undocumented)
     config: GtagConfigParams | EventParams;
 }
 
@@ -120,37 +119,23 @@ export function getAnalytics(app?: FirebaseApp): Analytics;
 
 // @public
 export interface GtagConfigParams {
-    // (undocumented)
     'allow_google_signals?': boolean;
     // (undocumented)
     [key: string]: unknown;
-    // (undocumented)
     'allow_ad_personalization_signals'?: boolean;
-    // (undocumented)
     'anonymize_ip'?: boolean;
-    // (undocumented)
     'cookie_domain'?: string;
-    // (undocumented)
     'cookie_expires'?: number;
-    // (undocumented)
     'cookie_flags'?: string;
-    // (undocumented)
     'cookie_prefix'?: string;
-    // (undocumented)
     'cookie_update'?: boolean;
-    // (undocumented)
     'custom_map'?: {
         [key: string]: unknown;
     };
-    // (undocumented)
     'link_attribution'?: boolean;
-    // (undocumented)
     'page_location'?: string;
-    // (undocumented)
     'page_path'?: string;
-    // (undocumented)
     'page_title'?: string;
-    // (undocumented)
     'send_page_view'?: boolean;
 }
 

--- a/common/api-review/analytics-exp.api.md
+++ b/common/api-review/analytics-exp.api.md
@@ -17,6 +17,12 @@ export interface AnalyticsCallOptions {
 }
 
 // @public
+export interface AnalyticsOptions {
+    // (undocumented)
+    config: GtagConfigParams | EventParams;
+}
+
+// @public
 export interface ControlParams {
     // (undocumented)
     event_callback?: () => void;
@@ -45,6 +51,8 @@ export type EventNameString = 'add_payment_info' | 'add_shipping_info' | 'add_to
 
 // @public
 export interface EventParams {
+    // (undocumented)
+    [key: string]: unknown;
     // (undocumented)
     affiliation?: string;
     // (undocumented)
@@ -109,6 +117,45 @@ export interface EventParams {
 
 // @public
 export function getAnalytics(app?: FirebaseApp): Analytics;
+
+// @public
+export interface GtagConfigParams {
+    // (undocumented)
+    'allow_google_signals?': boolean;
+    // (undocumented)
+    [key: string]: unknown;
+    // (undocumented)
+    'allow_ad_personalization_signals'?: boolean;
+    // (undocumented)
+    'anonymize_ip'?: boolean;
+    // (undocumented)
+    'cookie_domain'?: string;
+    // (undocumented)
+    'cookie_expires'?: number;
+    // (undocumented)
+    'cookie_flags'?: string;
+    // (undocumented)
+    'cookie_prefix'?: string;
+    // (undocumented)
+    'cookie_update'?: boolean;
+    // (undocumented)
+    'custom_map'?: {
+        [key: string]: unknown;
+    };
+    // (undocumented)
+    'link_attribution'?: boolean;
+    // (undocumented)
+    'page_location'?: string;
+    // (undocumented)
+    'page_path'?: string;
+    // (undocumented)
+    'page_title'?: string;
+    // (undocumented)
+    'send_page_view'?: boolean;
+}
+
+// @public
+export function initializeAnalytics(app: FirebaseApp, options?: AnalyticsOptions): Analytics;
 
 // @public
 export function isSupported(): Promise<boolean>;

--- a/packages-exp/analytics-exp/src/api.ts
+++ b/packages-exp/analytics-exp/src/api.ts
@@ -38,7 +38,6 @@ import { ANALYTICS_TYPE } from './constants';
 import {
   AnalyticsService,
   initializationPromisesMap,
-  _initializeAnalyticsForApp,
   wrappedGtagFunction
 } from './factory';
 import { logger } from './logger';
@@ -90,7 +89,7 @@ export function getAnalytics(app: FirebaseApp = getApp()): Analytics {
  */
 export function initializeAnalytics(
   app: FirebaseApp,
-  options?: AnalyticsOptions
+  options: AnalyticsOptions = {}
 ): Analytics {
   // Dependencies
   const analyticsProvider: Provider<'analytics-exp'> = _getProvider(
@@ -100,13 +99,7 @@ export function initializeAnalytics(
   if (analyticsProvider.isInitialized()) {
     throw ERROR_FACTORY.create(AnalyticsError.ALREADY_INITIALIZED);
   }
-  const analyticsInstance = analyticsProvider.getImmediate();
-  // do init settings stuff here
-  const installations = _getProvider(
-    app,
-    'installations-exp-internal'
-  ).getImmediate();
-  _initializeAnalyticsForApp(app, installations, options);
+  const analyticsInstance = analyticsProvider.initialize({ options });
   return analyticsInstance;
 }
 

--- a/packages-exp/analytics-exp/src/api.ts
+++ b/packages-exp/analytics-exp/src/api.ts
@@ -49,6 +49,7 @@ import {
   setUserProperties as internalSetUserProperties,
   setAnalyticsCollectionEnabled as internalSetAnalyticsCollectionEnabled
 } from './functions';
+import { ERROR_FACTORY, AnalyticsError } from './errors';
 
 export { settings } from './factory';
 
@@ -97,9 +98,7 @@ export function initializeAnalytics(
     ANALYTICS_TYPE
   );
   if (analyticsProvider.isInitialized()) {
-    return analyticsProvider.getImmediate();
-    // TODO: Throw an analytics specific error.
-    // _fail(analyticsInstance, AuthErrorCode.ALREADY_INITIALIZED);
+    throw ERROR_FACTORY.create(AnalyticsError.ALREADY_INITIALIZED);
   }
   const analyticsInstance = analyticsProvider.getImmediate();
   // do init settings stuff here

--- a/packages-exp/analytics-exp/src/errors.ts
+++ b/packages-exp/analytics-exp/src/errors.ts
@@ -20,6 +20,7 @@ import { ErrorFactory, ErrorMap } from '@firebase/util';
 export const enum AnalyticsError {
   ALREADY_EXISTS = 'already-exists',
   ALREADY_INITIALIZED = 'already-initialized',
+  ALREADY_INITIALIZED_SETTINGS = 'already-initialized-settings',
   INTEROP_COMPONENT_REG_FAILED = 'interop-component-reg-failed',
   INVALID_ANALYTICS_CONTEXT = 'invalid-analytics-context',
   INDEXEDDB_UNAVAILABLE = 'indexeddb-unavailable',
@@ -35,6 +36,10 @@ const ERRORS: ErrorMap<AnalyticsError> = {
     ' already exists. ' +
     'Only one Firebase Analytics instance can be created for each appId.',
   [AnalyticsError.ALREADY_INITIALIZED]:
+    'Firebase Analytics has already been initialized. ' +
+    'initializeAnalytics() must only be called once. getAnalytics() can be used ' +
+    'to get a reference to the already-intialized instance.',
+  [AnalyticsError.ALREADY_INITIALIZED_SETTINGS]:
     'Firebase Analytics has already been initialized.' +
     'settings() must be called before initializing any Analytics instance' +
     'or it will have no effect.',

--- a/packages-exp/analytics-exp/src/factory.ts
+++ b/packages-exp/analytics-exp/src/factory.ts
@@ -136,7 +136,7 @@ export function getGlobalVars(): {
  */
 export function settings(options: SettingsOptions): void {
   if (globalInitDone) {
-    throw ERROR_FACTORY.create(AnalyticsError.ALREADY_INITIALIZED);
+    throw ERROR_FACTORY.create(AnalyticsError.ALREADY_INITIALIZED_SETTINGS);
   }
   if (options.dataLayerName) {
     dataLayerName = options.dataLayerName;

--- a/packages-exp/analytics-exp/src/index.test.ts
+++ b/packages-exp/analytics-exp/src/index.test.ts
@@ -34,7 +34,8 @@ import {
   AnalyticsService,
   getGlobalVars,
   resetGlobalVars,
-  factory as analyticsFactory
+  factory as analyticsFactory,
+  _initializeAnalyticsForApp
 } from './factory';
 import { _FirebaseInstallationsInternal } from '@firebase/installations-exp';
 
@@ -89,15 +90,11 @@ describe('FirebaseAnalytics instance tests', () => {
 
     it('Throws if no appId in config', () => {
       const app = getFakeApp({ apiKey: fakeAppParams.apiKey });
-      expect(() => analyticsFactory(app, fakeInstallations)).to.throw(
-        AnalyticsError.NO_APP_ID
-      );
+      expect(() => analyticsFactory(app)).to.throw(AnalyticsError.NO_APP_ID);
     });
     it('Throws if no apiKey or measurementId in config', () => {
       const app = getFakeApp({ appId: fakeAppParams.appId });
-      expect(() => analyticsFactory(app, fakeInstallations)).to.throw(
-        AnalyticsError.NO_API_KEY
-      );
+      expect(() => analyticsFactory(app)).to.throw(AnalyticsError.NO_API_KEY);
     });
     it('Warns if config has no apiKey but does have a measurementId', async () => {
       // Since this is a warning and doesn't block the rest of initialization
@@ -110,7 +107,8 @@ describe('FirebaseAnalytics instance tests', () => {
         measurementId: fakeMeasurementId
       });
       stubIdbOpen();
-      analyticsFactory(app, fakeInstallations);
+      analyticsFactory(app);
+      _initializeAnalyticsForApp(app, fakeInstallations);
       // Successfully resolves fake IDB open request.
       fakeRequest.onsuccess();
       // Lets async IDB validation process complete.
@@ -128,7 +126,7 @@ describe('FirebaseAnalytics instance tests', () => {
     it('Throws if creating an instance with already-used appId', () => {
       const app = getFakeApp(fakeAppParams);
       resetGlobalVars(false, { [fakeAppParams.appId]: Promise.resolve() });
-      expect(() => analyticsFactory(app, fakeInstallations)).to.throw(
+      expect(() => analyticsFactory(app)).to.throw(
         AnalyticsError.ALREADY_EXISTS
       );
     });
@@ -149,7 +147,8 @@ describe('FirebaseAnalytics instance tests', () => {
       window['dataLayer'] = [];
       stubFetch(200, { measurementId: fakeMeasurementId });
       stubIdbOpen();
-      analyticsInstance = analyticsFactory(app, fakeInstallations);
+      analyticsInstance = analyticsFactory(app);
+      _initializeAnalyticsForApp(app, fakeInstallations);
       // Successfully resolves fake IDB open request.
       fakeRequest.onsuccess();
     });
@@ -223,7 +222,8 @@ describe('FirebaseAnalytics instance tests', () => {
     });
     it('Warns on initialization if cookies not available', async () => {
       cookieStub = stub(navigator, 'cookieEnabled').value(false);
-      analyticsInstance = analyticsFactory(app, fakeInstallations);
+      analyticsInstance = analyticsFactory(app);
+      _initializeAnalyticsForApp(app, fakeInstallations);
       // Successfully resolves fake IDB open request.
       fakeRequest.onsuccess();
       expect(warnStub.args[0][1]).to.include(
@@ -234,7 +234,8 @@ describe('FirebaseAnalytics instance tests', () => {
     });
     it('Warns on initialization if in browser extension', async () => {
       window.chrome = { runtime: { id: 'blah' } };
-      analyticsInstance = analyticsFactory(app, fakeInstallations);
+      analyticsInstance = analyticsFactory(app);
+      _initializeAnalyticsForApp(app, fakeInstallations);
       // Successfully resolves fake IDB open request.
       fakeRequest.onsuccess();
       expect(warnStub.args[0][1]).to.include(
@@ -245,7 +246,8 @@ describe('FirebaseAnalytics instance tests', () => {
     });
     it('Warns on logEvent if indexedDB API not available', async () => {
       const idbStub = stub(window, 'indexedDB').value(undefined);
-      analyticsInstance = analyticsFactory(app, fakeInstallations);
+      analyticsInstance = analyticsFactory(app);
+      _initializeAnalyticsForApp(app, fakeInstallations);
       logEvent(analyticsInstance, 'add_payment_info', {
         currency: 'USD'
       });
@@ -265,7 +267,8 @@ describe('FirebaseAnalytics instance tests', () => {
     it('Warns on logEvent if indexedDB.open() not allowed', async () => {
       idbOpenStub.restore();
       idbOpenStub = stub(indexedDB, 'open').throws('idb open error test');
-      analyticsInstance = analyticsFactory(app, fakeInstallations);
+      analyticsInstance = analyticsFactory(app);
+      _initializeAnalyticsForApp(app, fakeInstallations);
       logEvent(analyticsInstance, 'add_payment_info', {
         currency: 'USD'
       });
@@ -303,7 +306,8 @@ describe('FirebaseAnalytics instance tests', () => {
       });
       stubIdbOpen();
       stubFetch(200, { measurementId: fakeMeasurementId });
-      analyticsInstance = analyticsFactory(app, fakeInstallations);
+      analyticsInstance = analyticsFactory(app);
+      _initializeAnalyticsForApp(app, fakeInstallations);
       // Successfully resolves fake IDB open request.
       fakeRequest.onsuccess();
     });
@@ -349,7 +353,8 @@ describe('FirebaseAnalytics instance tests', () => {
       fakeInstallations = getFakeInstallations();
       stubFetch(200, {});
       stubIdbOpen();
-      analyticsInstance = analyticsFactory(app, fakeInstallations);
+      analyticsInstance = analyticsFactory(app);
+      _initializeAnalyticsForApp(app, fakeInstallations);
 
       const { initializationPromisesMap } = getGlobalVars();
       // Successfully resolves fake IDB open request.

--- a/packages-exp/analytics-exp/src/index.test.ts
+++ b/packages-exp/analytics-exp/src/index.test.ts
@@ -34,8 +34,7 @@ import {
   AnalyticsService,
   getGlobalVars,
   resetGlobalVars,
-  factory as analyticsFactory,
-  _initializeAnalyticsForApp
+  factory as analyticsFactory
 } from './factory';
 import { _FirebaseInstallationsInternal } from '@firebase/installations-exp';
 
@@ -90,11 +89,15 @@ describe('FirebaseAnalytics instance tests', () => {
 
     it('Throws if no appId in config', () => {
       const app = getFakeApp({ apiKey: fakeAppParams.apiKey });
-      expect(() => analyticsFactory(app)).to.throw(AnalyticsError.NO_APP_ID);
+      expect(() => analyticsFactory(app, fakeInstallations)).to.throw(
+        AnalyticsError.NO_APP_ID
+      );
     });
     it('Throws if no apiKey or measurementId in config', () => {
       const app = getFakeApp({ appId: fakeAppParams.appId });
-      expect(() => analyticsFactory(app)).to.throw(AnalyticsError.NO_API_KEY);
+      expect(() => analyticsFactory(app, fakeInstallations)).to.throw(
+        AnalyticsError.NO_API_KEY
+      );
     });
     it('Warns if config has no apiKey but does have a measurementId', async () => {
       // Since this is a warning and doesn't block the rest of initialization
@@ -107,8 +110,7 @@ describe('FirebaseAnalytics instance tests', () => {
         measurementId: fakeMeasurementId
       });
       stubIdbOpen();
-      analyticsFactory(app);
-      _initializeAnalyticsForApp(app, fakeInstallations);
+      analyticsFactory(app, fakeInstallations);
       // Successfully resolves fake IDB open request.
       fakeRequest.onsuccess();
       // Lets async IDB validation process complete.
@@ -126,7 +128,7 @@ describe('FirebaseAnalytics instance tests', () => {
     it('Throws if creating an instance with already-used appId', () => {
       const app = getFakeApp(fakeAppParams);
       resetGlobalVars(false, { [fakeAppParams.appId]: Promise.resolve() });
-      expect(() => analyticsFactory(app)).to.throw(
+      expect(() => analyticsFactory(app, fakeInstallations)).to.throw(
         AnalyticsError.ALREADY_EXISTS
       );
     });
@@ -147,8 +149,7 @@ describe('FirebaseAnalytics instance tests', () => {
       window['dataLayer'] = [];
       stubFetch(200, { measurementId: fakeMeasurementId });
       stubIdbOpen();
-      analyticsInstance = analyticsFactory(app);
-      _initializeAnalyticsForApp(app, fakeInstallations);
+      analyticsInstance = analyticsFactory(app, fakeInstallations);
       // Successfully resolves fake IDB open request.
       fakeRequest.onsuccess();
     });
@@ -222,8 +223,7 @@ describe('FirebaseAnalytics instance tests', () => {
     });
     it('Warns on initialization if cookies not available', async () => {
       cookieStub = stub(navigator, 'cookieEnabled').value(false);
-      analyticsInstance = analyticsFactory(app);
-      _initializeAnalyticsForApp(app, fakeInstallations);
+      analyticsInstance = analyticsFactory(app, fakeInstallations);
       // Successfully resolves fake IDB open request.
       fakeRequest.onsuccess();
       expect(warnStub.args[0][1]).to.include(
@@ -234,8 +234,7 @@ describe('FirebaseAnalytics instance tests', () => {
     });
     it('Warns on initialization if in browser extension', async () => {
       window.chrome = { runtime: { id: 'blah' } };
-      analyticsInstance = analyticsFactory(app);
-      _initializeAnalyticsForApp(app, fakeInstallations);
+      analyticsInstance = analyticsFactory(app, fakeInstallations);
       // Successfully resolves fake IDB open request.
       fakeRequest.onsuccess();
       expect(warnStub.args[0][1]).to.include(
@@ -246,8 +245,7 @@ describe('FirebaseAnalytics instance tests', () => {
     });
     it('Warns on logEvent if indexedDB API not available', async () => {
       const idbStub = stub(window, 'indexedDB').value(undefined);
-      analyticsInstance = analyticsFactory(app);
-      _initializeAnalyticsForApp(app, fakeInstallations);
+      analyticsInstance = analyticsFactory(app, fakeInstallations);
       logEvent(analyticsInstance, 'add_payment_info', {
         currency: 'USD'
       });
@@ -267,8 +265,7 @@ describe('FirebaseAnalytics instance tests', () => {
     it('Warns on logEvent if indexedDB.open() not allowed', async () => {
       idbOpenStub.restore();
       idbOpenStub = stub(indexedDB, 'open').throws('idb open error test');
-      analyticsInstance = analyticsFactory(app);
-      _initializeAnalyticsForApp(app, fakeInstallations);
+      analyticsInstance = analyticsFactory(app, fakeInstallations);
       logEvent(analyticsInstance, 'add_payment_info', {
         currency: 'USD'
       });
@@ -306,8 +303,7 @@ describe('FirebaseAnalytics instance tests', () => {
       });
       stubIdbOpen();
       stubFetch(200, { measurementId: fakeMeasurementId });
-      analyticsInstance = analyticsFactory(app);
-      _initializeAnalyticsForApp(app, fakeInstallations);
+      analyticsInstance = analyticsFactory(app, fakeInstallations);
       // Successfully resolves fake IDB open request.
       fakeRequest.onsuccess();
     });
@@ -353,8 +349,7 @@ describe('FirebaseAnalytics instance tests', () => {
       fakeInstallations = getFakeInstallations();
       stubFetch(200, {});
       stubIdbOpen();
-      analyticsInstance = analyticsFactory(app);
-      _initializeAnalyticsForApp(app, fakeInstallations);
+      analyticsInstance = analyticsFactory(app, fakeInstallations);
 
       const { initializationPromisesMap } = getGlobalVars();
       // Successfully resolves fake IDB open request.

--- a/packages-exp/analytics-exp/src/index.ts
+++ b/packages-exp/analytics-exp/src/index.ts
@@ -49,11 +49,8 @@ function registerAnalytics(): void {
       container => {
         // getImmediate for FirebaseApp will always succeed
         const app = container.getProvider('app-exp').getImmediate();
-        const installations = container
-          .getProvider('installations-exp-internal')
-          .getImmediate();
 
-        return factory(app, installations);
+        return factory(app);
       },
       ComponentType.PUBLIC
     )
@@ -68,6 +65,8 @@ function registerAnalytics(): void {
   function internalFactory(
     container: ComponentContainer
   ): FirebaseAnalyticsInternal {
+    //TODO: initialization fetches aren't in factory anymore so it might need to be
+    // called here.
     try {
       const analytics = container.getProvider(ANALYTICS_TYPE).getImmediate();
       return {

--- a/packages-exp/analytics-exp/src/index.ts
+++ b/packages-exp/analytics-exp/src/index.ts
@@ -28,7 +28,8 @@ import { ANALYTICS_TYPE } from './constants';
 import {
   Component,
   ComponentType,
-  ComponentContainer
+  ComponentContainer,
+  InstanceFactoryOptions
 } from '@firebase/component';
 import { ERROR_FACTORY, AnalyticsError } from './errors';
 import { logEvent } from './api';
@@ -46,11 +47,14 @@ function registerAnalytics(): void {
   _registerComponent(
     new Component(
       ANALYTICS_TYPE,
-      container => {
+      (container, { options: analyticsOptions }: InstanceFactoryOptions) => {
         // getImmediate for FirebaseApp will always succeed
         const app = container.getProvider('app-exp').getImmediate();
+        const installations = container
+          .getProvider('installations-exp-internal')
+          .getImmediate();
 
-        return factory(app);
+        return factory(app, installations, analyticsOptions);
       },
       ComponentType.PUBLIC
     )
@@ -65,8 +69,6 @@ function registerAnalytics(): void {
   function internalFactory(
     container: ComponentContainer
   ): FirebaseAnalyticsInternal {
-    //TODO: initialization fetches aren't in factory anymore so it might need to be
-    // called here.
     try {
       const analytics = container.getProvider(ANALYTICS_TYPE).getImmediate();
       return {

--- a/packages-exp/analytics-exp/src/initialize-analytics.test.ts
+++ b/packages-exp/analytics-exp/src/initialize-analytics.test.ts
@@ -18,7 +18,7 @@
 import { expect } from 'chai';
 import { SinonStub, stub } from 'sinon';
 import '../testing/setup';
-import { initializeAnalytics } from './initialize-analytics';
+import { _initializeAnalytics } from './initialize-analytics';
 import {
   getFakeApp,
   getFakeInstallations
@@ -65,7 +65,7 @@ describe('initializeIds()', () => {
   });
   it('gets FID and measurement ID and calls gtag config with them', async () => {
     stubFetch();
-    await initializeAnalytics(
+    await _initializeAnalytics(
       app,
       dynamicPromisesList,
       measurementIdToAppId,
@@ -81,7 +81,7 @@ describe('initializeIds()', () => {
   });
   it('puts dynamic fetch promise into dynamic promises list', async () => {
     stubFetch();
-    await initializeAnalytics(
+    await _initializeAnalytics(
       app,
       dynamicPromisesList,
       measurementIdToAppId,
@@ -95,7 +95,7 @@ describe('initializeIds()', () => {
   });
   it('puts dynamically fetched measurementId into lookup table', async () => {
     stubFetch();
-    await initializeAnalytics(
+    await _initializeAnalytics(
       app,
       dynamicPromisesList,
       measurementIdToAppId,
@@ -108,7 +108,7 @@ describe('initializeIds()', () => {
   it('warns on local/fetched measurement ID mismatch', async () => {
     stubFetch();
     const consoleStub = stub(console, 'warn');
-    await initializeAnalytics(
+    await _initializeAnalytics(
       getFakeApp({ ...fakeAppParams, measurementId: 'old-measurement-id' }),
       dynamicPromisesList,
       measurementIdToAppId,

--- a/packages-exp/analytics-exp/src/initialize-analytics.test.ts
+++ b/packages-exp/analytics-exp/src/initialize-analytics.test.ts
@@ -18,7 +18,7 @@
 import { expect } from 'chai';
 import { SinonStub, stub } from 'sinon';
 import '../testing/setup';
-import { _initializeAnalytics } from './initialize-analytics';
+import { initializeAnalytics } from './initialize-analytics';
 import {
   getFakeApp,
   getFakeInstallations
@@ -65,7 +65,7 @@ describe('initializeIds()', () => {
   });
   it('gets FID and measurement ID and calls gtag config with them', async () => {
     stubFetch();
-    await _initializeAnalytics(
+    await initializeAnalytics(
       app,
       dynamicPromisesList,
       measurementIdToAppId,
@@ -81,7 +81,7 @@ describe('initializeIds()', () => {
   });
   it('puts dynamic fetch promise into dynamic promises list', async () => {
     stubFetch();
-    await _initializeAnalytics(
+    await initializeAnalytics(
       app,
       dynamicPromisesList,
       measurementIdToAppId,
@@ -95,7 +95,7 @@ describe('initializeIds()', () => {
   });
   it('puts dynamically fetched measurementId into lookup table', async () => {
     stubFetch();
-    await _initializeAnalytics(
+    await initializeAnalytics(
       app,
       dynamicPromisesList,
       measurementIdToAppId,
@@ -108,7 +108,7 @@ describe('initializeIds()', () => {
   it('warns on local/fetched measurement ID mismatch', async () => {
     stubFetch();
     const consoleStub = stub(console, 'warn');
-    await _initializeAnalytics(
+    await initializeAnalytics(
       getFakeApp({ ...fakeAppParams, measurementId: 'old-measurement-id' }),
       dynamicPromisesList,
       measurementIdToAppId,

--- a/packages-exp/analytics-exp/src/initialize-analytics.test.ts
+++ b/packages-exp/analytics-exp/src/initialize-analytics.test.ts
@@ -48,7 +48,7 @@ function stubFetch(): void {
   fetchStub.returns(Promise.resolve(mockResponse));
 }
 
-describe('initializeIds()', () => {
+describe('initializeAnalytics()', () => {
   const gtagStub: SinonStub = stub();
   const dynamicPromisesList: Array<Promise<DynamicConfig>> = [];
   const measurementIdToAppId: { [key: string]: string } = {};
@@ -77,6 +77,24 @@ describe('initializeIds()', () => {
       'firebase_id': fakeFid,
       'origin': 'firebase',
       update: true
+    });
+  });
+  it('calls gtag config with options if provided', async () => {
+    stubFetch();
+    await initializeAnalytics(
+      app,
+      dynamicPromisesList,
+      measurementIdToAppId,
+      fakeInstallations,
+      gtagStub,
+      'dataLayer',
+      { config: { 'send_page_view': false } }
+    );
+    expect(gtagStub).to.be.calledWith(GtagCommand.CONFIG, fakeMeasurementId, {
+      'firebase_id': fakeFid,
+      'origin': 'firebase',
+      update: true,
+      'send_page_view': false
     });
   });
   it('puts dynamic fetch promise into dynamic promises list', async () => {

--- a/packages-exp/analytics-exp/src/initialize-analytics.ts
+++ b/packages-exp/analytics-exp/src/initialize-analytics.ts
@@ -65,7 +65,7 @@ async function validateIndexedDB(): Promise<boolean> {
  *
  * @returns Measurement ID.
  */
-export async function _initializeAnalytics(
+export async function initializeAnalytics(
   app: FirebaseApp,
   dynamicConfigPromisesList: Array<
     Promise<DynamicConfig | MinimalDynamicConfig>
@@ -123,7 +123,6 @@ export async function _initializeAnalytics(
   // We keep it together with other initialization logic for better code structure.
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   (gtagCore as any)('js', new Date());
-
   // User config added first. We don't want users to accidentally overwrite
   // base Firebase config properties.
   const configProperties: Record<string, unknown> = options?.config ?? {};

--- a/packages-exp/analytics-exp/src/public-types.ts
+++ b/packages-exp/analytics-exp/src/public-types.ts
@@ -106,7 +106,7 @@ export interface AnalyticsOptions {
   /**
    * Params to be passed in the initial gtag config call during analytics initialization.
    */
-  config: GtagConfigParams | EventParams;
+  config?: GtagConfigParams | EventParams;
 }
 
 /**

--- a/packages-exp/analytics-exp/src/public-types.ts
+++ b/packages-exp/analytics-exp/src/public-types.ts
@@ -23,19 +23,77 @@ import { FirebaseApp } from '@firebase/app-exp';
  * @public
  */
 export interface GtagConfigParams {
+  /**
+   * Whether or not a page view should be sent.
+   * If set to true (default), a page view is automatically sent upon initialization
+   * of analytics.
+   * See https://developers.google.com/analytics/devguides/collection/gtagjs/pages
+   */
   'send_page_view'?: boolean;
+  /**
+   * The title of the page.
+   * See https://developers.google.com/analytics/devguides/collection/gtagjs/pages
+   */
   'page_title'?: string;
+  /**
+   * The path to the page. If overridden, this value must start with a / character.
+   * See https://developers.google.com/analytics/devguides/collection/gtagjs/pages
+   */
   'page_path'?: string;
+  /**
+   * The URL of the page.
+   * See https://developers.google.com/analytics/devguides/collection/gtagjs/pages
+   */
   'page_location'?: string;
+  /**
+   * Defaults to `auto`.
+   * See https://developers.google.com/analytics/devguides/collection/gtagjs/cookies-user-id
+   */
   'cookie_domain'?: string;
+  /**
+   * Defaults to 63072000 (two years, in seconds).
+   * See https://developers.google.com/analytics/devguides/collection/gtagjs/cookies-user-id
+   */
   'cookie_expires'?: number;
+  /**
+   * Defaults to `_ga`.
+   * See https://developers.google.com/analytics/devguides/collection/gtagjs/cookies-user-id
+   */
   'cookie_prefix'?: string;
+  /**
+   * If set to true, will update cookies on each page load.
+   * Defaults to true.
+   * See https://developers.google.com/analytics/devguides/collection/gtagjs/cookies-user-id
+   */
   'cookie_update'?: boolean;
+  /**
+   * Appends additional flags to the cookie when set.
+   * See https://developers.google.com/analytics/devguides/collection/gtagjs/cookies-user-id
+   */
   'cookie_flags'?: string;
+  /**
+   * If set to false, disables all advertising features with gtag.js.
+   * See https://developers.google.com/analytics/devguides/collection/gtagjs/display-features
+   */
   'allow_google_signals?': boolean;
+  /**
+   * If set to false, disables all advertising personalization with gtag.js.
+   * See https://developers.google.com/analytics/devguides/collection/gtagjs/display-features
+   */
   'allow_ad_personalization_signals'?: boolean;
+  /**
+   * See https://developers.google.com/analytics/devguides/collection/gtagjs/enhanced-link-attribution
+   */
   'link_attribution'?: boolean;
+  /**
+   * If set to true, anonymizes IP addresses for all events.
+   * See https://developers.google.com/analytics/devguides/collection/gtagjs/ip-anonymization
+   */
   'anonymize_ip'?: boolean;
+  /**
+   * Custom dimensions and metrics.
+   * See https://developers.google.com/analytics/devguides/collection/gtagjs/custom-dims-mets
+   */
   'custom_map'?: { [key: string]: unknown };
   [key: string]: unknown;
 }
@@ -45,6 +103,9 @@ export interface GtagConfigParams {
  * @public
  */
 export interface AnalyticsOptions {
+  /**
+   * Params to be passed in the initial gtag config call during analytics initialization.
+   */
   config: GtagConfigParams | EventParams;
 }
 
@@ -91,6 +152,7 @@ export interface SettingsOptions {
 export interface CustomParams {
   [key: string]: unknown;
 }
+
 /**
  * Type for standard gtag.js event names. `logEvent` also accepts any
  * custom string and interprets it as a custom event name.
@@ -126,14 +188,14 @@ export type EventNameString =
   | 'view_search_results';
 
 /**
- * Currency field used by some Analytics events.
+ * Standard analytics currency type.
  * @public
  */
 export type Currency = string | number;
 
 /* eslint-disable camelcase */
 /**
- * Item field used by some Analytics events.
+ * Standard analytics `Item` type.
  * @public
  */
 export interface Item {

--- a/packages-exp/analytics-exp/src/public-types.ts
+++ b/packages-exp/analytics-exp/src/public-types.ts
@@ -18,6 +18,35 @@
 import { FirebaseApp } from '@firebase/app-exp';
 
 /**
+ * A set of common Analytics config settings recognized by
+ * gtag.
+ */
+export interface GtagConfigParams {
+  'send_page_view'?: boolean;
+  'page_title'?: string;
+  'page_path'?: string;
+  'page_location'?: string;
+  'cookie_domain'?: string;
+  'cookie_expires'?: number;
+  'cookie_prefix'?: string;
+  'cookie_update'?: boolean;
+  'cookie_flags'?: string;
+  'allow_google_signals?': boolean;
+  'allow_ad_personalization_signals'?: boolean;
+  'link_attribution'?: boolean;
+  'anonymize_ip'?: boolean;
+  'custom_map'?: { [key: string]: unknown };
+  [key: string]: unknown;
+}
+
+/**
+ * Analytics initialization options.
+ */
+export interface AnalyticsOptions {
+  config: GtagConfigParams | EventParams;
+}
+
+/**
  * Additional options that can be passed to Firebase Analytics method
  * calls such as `logEvent`, `setCurrentScreen`, etc.
  * @public
@@ -204,5 +233,6 @@ export interface EventParams {
   page_title?: string;
   page_location?: string;
   page_path?: string;
+  [key: string]: unknown;
 }
 /* eslint-enable camelcase */

--- a/packages-exp/analytics-exp/src/public-types.ts
+++ b/packages-exp/analytics-exp/src/public-types.ts
@@ -20,6 +20,7 @@ import { FirebaseApp } from '@firebase/app-exp';
 /**
  * A set of common Analytics config settings recognized by
  * gtag.
+ * @public
  */
 export interface GtagConfigParams {
   'send_page_view'?: boolean;
@@ -41,6 +42,7 @@ export interface GtagConfigParams {
 
 /**
  * Analytics initialization options.
+ * @public
  */
 export interface AnalyticsOptions {
   config: GtagConfigParams | EventParams;
@@ -60,8 +62,7 @@ export interface AnalyticsCallOptions {
 }
 
 /**
- * The Firebase Analytics service interface.
- *
+ * An instance of Firebase Analytics.
  * @public
  */
 export interface Analytics {

--- a/packages-exp/analytics-exp/src/public-types.ts
+++ b/packages-exp/analytics-exp/src/public-types.ts
@@ -128,7 +128,7 @@ export interface AnalyticsCallOptions {
  */
 export interface Analytics {
   /**
-   * The FirebaseApp this Functions instance is associated with.
+   * The FirebaseApp this Analytics instance is associated with.
    */
   app: FirebaseApp;
 }

--- a/packages-exp/analytics-exp/testing/integration-tests/integration.ts
+++ b/packages-exp/analytics-exp/testing/integration-tests/integration.ts
@@ -75,7 +75,7 @@ describe('FirebaseAnalytics Integration Smoke Tests', () => {
     it('logEvent() sends correct network request.', async () => {
       app = initializeApp(config);
       logEvent(initializeAnalytics(app), 'login', { method: 'email' });
-      async function checkForEventCalls(): Promise<number> {
+      async function checkForEventCalls(): Promise<PerformanceEntry[]> {
         await new Promise(resolve => setTimeout(resolve, RETRY_INTERVAL));
         const resources = performance.getEntriesByType('resource');
         const callsWithEvent = resources.filter(
@@ -86,11 +86,12 @@ describe('FirebaseAnalytics Integration Smoke Tests', () => {
         if (callsWithEvent.length === 0) {
           return checkForEventCalls();
         } else {
-          return callsWithEvent.length;
+          return callsWithEvent;
         }
       }
-      const eventCallCount = await checkForEventCalls();
-      expect(eventCallCount).to.equal(1);
+      const eventCalls = await checkForEventCalls();
+      expect(eventCalls.length).to.equal(1);
+      expect(eventCalls[0].name).to.include('method=email');
     });
     it('getAnalytics() does not throw if called after initializeAnalytics().', async () => {
       const analyticsInstance = getAnalytics(app);


### PR DESCRIPTION
Create an `initializeAnalytics()` method that can only be called once, which can take an `AnalyticsOptions` object with an initial config. Allows users to set useful custom gtag config parameters such as `send_page_view` on initialization of analytics.

Updated some documentation comments.

Design doc (internal link):
go/firebase-analytics-initial-config