### PR TITLE
Add `Provider.initialize()`

### DIFF
--- a/.changeset/clever-apricots-look.md
+++ b/.changeset/clever-apricots-look.md
@@ -1,0 +1,10 @@
+---
+"@firebase/component": minor
+"@firebase/database": patch
+"@firebase/firestore": patch
+"@firebase/functions": patch
+"@firebase/remote-config": patch
+"@firebase/storage": patch
+---
+
+Component facotry now takes an options object. And added `Provider.initialize()` that can be used to pass an options object to the component factory.

--- a/packages-exp/analytics-compat/src/index.ts
+++ b/packages-exp/analytics-compat/src/index.ts
@@ -41,16 +41,13 @@ declare module '@firebase/component' {
 }
 
 const factory: InstanceFactory<'analytics-compat'> = (
-  container: ComponentContainer,
-  regionOrCustomDomain?: string
+  container: ComponentContainer
 ) => {
   // Dependencies
   const app = container.getProvider('app-compat').getImmediate();
   const analyticsServiceExp = container
     .getProvider('analytics-exp')
-    .getImmediate({
-      identifier: regionOrCustomDomain
-    });
+    .getImmediate();
 
   return new AnalyticsService(app as FirebaseApp, analyticsServiceExp);
 };

--- a/packages-exp/auth-exp/src/core/auth/initialize.ts
+++ b/packages-exp/auth-exp/src/core/auth/initialize.ts
@@ -34,8 +34,7 @@ export function initializeAuth(app: FirebaseApp, deps?: Dependencies): Auth {
     _fail(auth, AuthErrorCode.ALREADY_INITIALIZED);
   }
 
-  const auth = provider.getImmediate() as AuthImpl;
-  _initializeAuthInstance(auth, deps);
+  const auth = provider.initialize({ options: deps }) as AuthImpl;
 
   return auth;
 }

--- a/packages-exp/auth-exp/src/core/auth/register.ts
+++ b/packages-exp/auth-exp/src/core/auth/register.ts
@@ -25,6 +25,8 @@ import { _assert } from '../util/assert';
 import { _getClientVersion, ClientPlatform } from '../util/version';
 import { _castAuth, AuthImpl, DefaultConfig } from './auth_impl';
 import { AuthInterop } from './firebase_internal';
+import { Dependencies } from '../../model/auth';
+import { _initializeAuthInstance } from './initialize';
 
 export const enum _ComponentName {
   AUTH = 'auth-exp',
@@ -53,7 +55,7 @@ export function registerAuth(clientPlatform: ClientPlatform): void {
   _registerComponent(
     new Component(
       _ComponentName.AUTH,
-      container => {
+      (container, { options: deps }: { options?: Dependencies }) => {
         const app = container.getProvider('app-exp').getImmediate()!;
         const { apiKey, authDomain } = app.options;
         return (app => {
@@ -66,7 +68,11 @@ export function registerAuth(clientPlatform: ClientPlatform): void {
             apiScheme: DefaultConfig.API_SCHEME,
             sdkClientVersion: _getClientVersion(clientPlatform)
           };
-          return new AuthImpl(app, config);
+
+          const authInstance = new AuthImpl(app, config);
+          _initializeAuthInstance(authInstance, deps);
+
+          return authInstance;
         })(app);
       },
       ComponentType.PUBLIC

--- a/packages-exp/functions-exp/src/config.ts
+++ b/packages-exp/functions-exp/src/config.ts
@@ -30,7 +30,7 @@ export const DEFAULT_REGION = 'us-central1';
 export function registerFunctions(fetchImpl: typeof fetch): void {
   const factory: InstanceFactory<'functions'> = (
     container: ComponentContainer,
-    regionOrCustomDomain?: string
+    { instanceIdentifier: regionOrCustomDomain }
   ) => {
     // Dependencies
     const app = container.getProvider('app-exp').getImmediate();

--- a/packages-exp/performance-exp/src/index.ts
+++ b/packages-exp/performance-exp/src/index.ts
@@ -70,8 +70,9 @@ export function initializePerformance(
     throw ERROR_FACTORY.create(ErrorCode.ALREADY_INITIALIZED);
   }
 
-  const perfInstance = provider.getImmediate() as PerformanceController;
-  perfInstance._init(settings);
+  const perfInstance = provider.initialize({
+    options: settings
+  }) as PerformanceController;
   return perfInstance;
 }
 
@@ -89,7 +90,8 @@ export function trace(
 }
 
 const factory: InstanceFactory<'performance-exp'> = (
-  container: ComponentContainer
+  container: ComponentContainer,
+  { options: settings }: { options?: PerformanceSettings }
 ) => {
   // Dependencies
   const app = container.getProvider('app-exp').getImmediate();
@@ -104,7 +106,10 @@ const factory: InstanceFactory<'performance-exp'> = (
     throw ERROR_FACTORY.create(ErrorCode.NO_WINDOW);
   }
   setupApi(window);
-  return new PerformanceController(app, installations);
+  const perfInstance = new PerformanceController(app, installations);
+  perfInstance._init(settings);
+
+  return perfInstance;
 };
 
 function registerPerformance(): void {

--- a/packages-exp/remote-config-compat/src/index.ts
+++ b/packages-exp/remote-config-compat/src/index.ts
@@ -19,7 +19,8 @@ import firebase, { _FirebaseNamespace } from '@firebase/app-compat';
 import {
   Component,
   ComponentContainer,
-  ComponentType
+  ComponentType,
+  InstanceFactoryOptions
 } from '@firebase/component';
 import { RemoteConfigCompatImpl } from './remoteConfig';
 import { name as packageName, version } from '../package.json';
@@ -48,7 +49,7 @@ function registerRemoteConfigCompat(
 
 function remoteConfigFactory(
   container: ComponentContainer,
-  namespace?: string
+  { instanceIdentifier: namespace }: InstanceFactoryOptions
 ): RemoteConfigCompatImpl {
   const app = container.getProvider('app-compat').getImmediate();
   // The following call will always succeed because rc `import {...} from '@firebase/remote-config-exp'`

--- a/packages-exp/remote-config-exp/src/register.ts
+++ b/packages-exp/remote-config-exp/src/register.ts
@@ -22,7 +22,8 @@ import {
 import {
   Component,
   ComponentType,
-  ComponentContainer
+  ComponentContainer,
+  InstanceFactoryOptions
 } from '@firebase/component';
 import { Logger, LogLevel as FirebaseLogLevel } from '@firebase/logger';
 import { RemoteConfig } from './public_types';
@@ -53,7 +54,7 @@ export function registerRemoteConfig(): void {
 
   function remoteConfigFactory(
     container: ComponentContainer,
-    namespace?: string
+    { instanceIdentifier: namespace }: InstanceFactoryOptions
   ): RemoteConfig {
     /* Dependencies */
     // getImmediate for FirebaseApp will always succeed

--- a/packages/component/index.ts
+++ b/packages/component/index.ts
@@ -23,5 +23,6 @@ export {
   InstanceFactory,
   InstantiationMode,
   NameServiceMapping,
-  Name
+  Name,
+  InstanceFactoryOptions
 } from './src/types';

--- a/packages/component/src/provider.test.ts
+++ b/packages/component/src/provider.test.ts
@@ -101,6 +101,34 @@ describe('Provider', () => {
     expect(() => provider.setComponent(component)).to.not.throw();
   });
 
+  describe('initialize()', () => {
+    it('throws if the provider is already initialized', () => {
+      provider.setComponent(getFakeComponent('test', () => ({})));
+      provider.initialize();
+
+      expect(() => provider.initialize()).to.throw();
+    });
+
+    it('throws if the component has not been registered', () => {
+      expect(() => provider.initialize()).to.throw();
+    });
+
+    it('accepts an options parameter and passes it to the instance factory', () => {
+      const options = {
+        configurable: true,
+        test: true
+      };
+      provider.setComponent(
+        getFakeComponent('test', (_container, opts) => ({
+          options: opts.options
+        }))
+      );
+      const instance = provider.initialize({ options });
+
+      expect((instance as any).options).to.deep.equal(options);
+    });
+  });
+
   describe('Provider (multipleInstances = false)', () => {
     describe('getImmediate()', () => {
       it('throws if the service is not available', () => {
@@ -155,7 +183,7 @@ describe('Provider', () => {
       });
     });
 
-    describe('provideFactory()', () => {
+    describe('setComponent()', () => {
       it('instantiates the service if there is a pending promise and the service is eager', () => {
         // create a pending promise
         // eslint-disable-next-line @typescript-eslint/no-floating-promises
@@ -320,7 +348,7 @@ describe('Provider', () => {
       });
     });
 
-    describe('provideFactory()', () => {
+    describe('setComponent()', () => {
       it('instantiates services for the pending promises for all instance identifiers', async () => {
         /* eslint-disable @typescript-eslint/no-floating-promises */
         // create 3 promises for 3 different identifiers

--- a/packages/component/src/provider.ts
+++ b/packages/component/src/provider.ts
@@ -195,10 +195,9 @@ export class Provider<T extends Name> {
   ): NameServiceMapping[T] | null {
     let instance = this.instances.get(identifier);
     if (!instance && this.component) {
-      instance = this.component.instanceFactory(
-        this.container,
-        normalizeIdentifierForFactory(identifier)
-      ) as NameServiceMapping[T];
+      instance = this.component.instanceFactory(this.container, {
+        instanceIdentifier: normalizeIdentifierForFactory(identifier)
+      }) as NameServiceMapping[T];
       this.instances.set(identifier, instance);
     }
 

--- a/packages/component/src/provider.ts
+++ b/packages/component/src/provider.ts
@@ -18,7 +18,12 @@
 import { Deferred } from '@firebase/util';
 import { ComponentContainer } from './component_container';
 import { DEFAULT_ENTRY_NAME } from './constants';
-import { InstantiationMode, Name, NameServiceMapping } from './types';
+import {
+  InitializeOptions,
+  InstantiationMode,
+  Name,
+  NameServiceMapping
+} from './types';
 import { Component } from './component';
 
 /**
@@ -51,7 +56,9 @@ export class Provider<T extends Name> {
       this.instancesDeferred.set(normalizedIdentifier, deferred);
       // If the service instance is available, resolve the promise with it immediately
       try {
-        const instance = this.getOrInitializeService(normalizedIdentifier);
+        const instance = this.getOrInitializeService({
+          instanceIdentifier: normalizedIdentifier
+        });
         if (instance) {
           deferred.resolve(instance);
         }
@@ -92,7 +99,9 @@ export class Provider<T extends Name> {
     // if multipleInstances is not supported, use the default name
     const normalizedIdentifier = this.normalizeInstanceIdentifier(identifier);
     try {
-      const instance = this.getOrInitializeService(normalizedIdentifier);
+      const instance = this.getOrInitializeService({
+        instanceIdentifier: normalizedIdentifier
+      });
 
       if (!instance) {
         if (optional) {
@@ -129,7 +138,7 @@ export class Provider<T extends Name> {
     // if the service is eager, initialize the default instance
     if (isComponentEager(component)) {
       try {
-        this.getOrInitializeService(DEFAULT_ENTRY_NAME);
+        this.getOrInitializeService({ instanceIdentifier: DEFAULT_ENTRY_NAME });
       } catch (e) {
         // when the instance factory for an eager Component throws an exception during the eager
         // initialization, it should not cause a fatal error.
@@ -151,7 +160,9 @@ export class Provider<T extends Name> {
 
       try {
         // `getOrInitializeService()` should always return a valid instance since a component is guaranteed. use ! to make typescript happy.
-        const instance = this.getOrInitializeService(normalizedIdentifier)!;
+        const instance = this.getOrInitializeService({
+          instanceIdentifier: normalizedIdentifier
+        })!;
         instanceDeferred.resolve(instance);
       } catch (e) {
         // when the instance factory throws an exception, it should not cause
@@ -190,15 +201,41 @@ export class Provider<T extends Name> {
     return this.instances.has(identifier);
   }
 
-  private getOrInitializeService(
-    identifier: string
-  ): NameServiceMapping[T] | null {
-    let instance = this.instances.get(identifier);
+  initialize(opts: InitializeOptions = {}): NameServiceMapping[T] {
+    const { instanceIdentifier = DEFAULT_ENTRY_NAME, options = {} } = opts;
+    const normalizedIdentifier = this.normalizeInstanceIdentifier(
+      instanceIdentifier
+    );
+    if (this.isInitialized(normalizedIdentifier)) {
+      throw Error(
+        `${this.name}(${normalizedIdentifier}) has already been initialized`
+      );
+    }
+
+    if (!this.isComponentSet()) {
+      throw Error(`Component ${this.name} has not been registered yet`);
+    }
+
+    return this.getOrInitializeService({
+      instanceIdentifier: normalizedIdentifier,
+      options
+    })!;
+  }
+
+  private getOrInitializeService({
+    instanceIdentifier,
+    options = {}
+  }: {
+    instanceIdentifier: string;
+    options?: Record<string, unknown>;
+  }): NameServiceMapping[T] | null {
+    let instance = this.instances.get(instanceIdentifier);
     if (!instance && this.component) {
       instance = this.component.instanceFactory(this.container, {
-        instanceIdentifier: normalizeIdentifierForFactory(identifier)
-      }) as NameServiceMapping[T];
-      this.instances.set(identifier, instance);
+        instanceIdentifier: normalizeIdentifierForFactory(instanceIdentifier),
+        options
+      });
+      this.instances.set(instanceIdentifier, instance);
     }
 
     return instance || null;

--- a/packages/component/src/types.ts
+++ b/packages/component/src/types.ts
@@ -38,7 +38,7 @@ export const enum ComponentType {
 
 export interface InstanceFactoryOptions {
   instanceIdentifier?: string;
-  options?: Record<string, unknown>;
+  options?: {};
 }
 
 export type InitializeOptions = InstanceFactoryOptions;

--- a/packages/component/src/types.ts
+++ b/packages/component/src/types.ts
@@ -36,6 +36,11 @@ export const enum ComponentType {
   VERSION = 'VERSION'
 }
 
+export interface InstanceFactoryOptions {
+  instanceIdentifier?: string;
+  options?: Record<string, unknown>;
+}
+
 /**
  * Factory to create an instance of type T, given a ComponentContainer.
  * ComponentContainer is the IOC container that provides {@link Provider}
@@ -46,7 +51,7 @@ export const enum ComponentType {
  */
 export type InstanceFactory<T extends Name> = (
   container: ComponentContainer,
-  instanceIdentifier?: string
+  options: InstanceFactoryOptions
 ) => NameServiceMapping[T];
 
 export interface Dictionary {

--- a/packages/component/src/types.ts
+++ b/packages/component/src/types.ts
@@ -41,6 +41,8 @@ export interface InstanceFactoryOptions {
   options?: Record<string, unknown>;
 }
 
+export type InitializeOptions = InstanceFactoryOptions;
+
 /**
  * Factory to create an instance of type T, given a ComponentContainer.
  * ComponentContainer is the IOC container that provides {@link Provider}

--- a/packages/database/exp/index.ts
+++ b/packages/database/exp/index.ts
@@ -35,7 +35,7 @@ function registerDatabase(): void {
   _registerComponent(
     new Component(
       'database-exp',
-      (container, url) => {
+      (container, { instanceIdentifier: url }) => {
         const app = container.getProvider('app-exp').getImmediate()!;
         const authProvider = container.getProvider('auth-internal');
         return new FirebaseDatabase(app, authProvider, url);

--- a/packages/database/index.node.ts
+++ b/packages/database/index.node.ts
@@ -84,7 +84,7 @@ export function registerDatabase(instance: FirebaseNamespace) {
   const namespace = (instance as _FirebaseNamespace).INTERNAL.registerComponent(
     new Component(
       'database',
-      (container, url) => {
+      (container, { instanceIdentifier: url }) => {
         /* Dependencies */
         // getImmediate for FirebaseApp will always succeed
         const app = container.getProvider('app').getImmediate();

--- a/packages/database/index.ts
+++ b/packages/database/index.ts
@@ -44,7 +44,7 @@ export function registerDatabase(instance: FirebaseNamespace) {
   const namespace = (instance as _FirebaseNamespace).INTERNAL.registerComponent(
     new Component(
       'database',
-      (container, url) => {
+      (container, { instanceIdentifier: url }) => {
         /* Dependencies */
         // getImmediate for FirebaseApp will always succeed
         const app = container.getProvider('app').getImmediate();

--- a/packages/firestore/exp/register.ts
+++ b/packages/firestore/exp/register.ts
@@ -20,6 +20,7 @@ import { Component, ComponentType } from '@firebase/component';
 
 import { version } from '../package.json';
 import { FirebaseFirestore } from '../src/exp/database';
+import { Settings } from '../src/exp/settings';
 
 declare module '@firebase/component' {
   interface NameServiceMapping {
@@ -31,12 +32,16 @@ export function registerFirestore(): void {
   _registerComponent(
     new Component(
       'firestore-exp',
-      container => {
+      (container, { options: settings }: { options?: Settings }) => {
         const app = container.getProvider('app-exp').getImmediate()!;
-        return ((app, auth) => new FirebaseFirestore(app, auth))(
+        const firestoreInstance = new FirebaseFirestore(
           app,
           container.getProvider('auth-internal')
         );
+        if (settings) {
+          firestoreInstance._setSettings(settings);
+        }
+        return firestoreInstance;
       },
       ComponentType.PUBLIC
     )

--- a/packages/firestore/lite/register.ts
+++ b/packages/firestore/lite/register.ts
@@ -20,6 +20,7 @@ import { Component, ComponentType } from '@firebase/component';
 
 import { version } from '../package.json';
 import { FirebaseFirestore } from '../src/lite/database';
+import { Settings } from '../src/lite/settings';
 
 declare module '@firebase/component' {
   interface NameServiceMapping {
@@ -31,12 +32,16 @@ export function registerFirestore(): void {
   _registerComponent(
     new Component(
       'firestore/lite',
-      container => {
+      (container, { options: settings }: { options?: Settings }) => {
         const app = container.getProvider('app-exp').getImmediate()!;
-        return ((app, auth) => new FirebaseFirestore(app, auth))(
+        const firestoreInstance = new FirebaseFirestore(
           app,
           container.getProvider('auth-internal')
         );
+        if (settings) {
+          firestoreInstance._setSettings(settings);
+        }
+        return firestoreInstance;
       },
       ComponentType.PUBLIC
     )

--- a/packages/firestore/src/exp/database.ts
+++ b/packages/firestore/src/exp/database.ts
@@ -128,10 +128,6 @@ export function initializeFirestore(
     );
   }
 
-  /**
-   * create a firestore instance with the default settings
-   */
-  const firestore = provider.getImmediate() as FirebaseFirestore;
   if (
     settings.cacheSizeBytes !== undefined &&
     settings.cacheSizeBytes !== CACHE_SIZE_UNLIMITED &&
@@ -143,11 +139,7 @@ export function initializeFirestore(
     );
   }
 
-  /**
-   * update settings with the user supplied values on the firestore instance
-   */
-  firestore._setSettings(settings);
-  return firestore;
+  return provider.initialize({ options: settings });
 }
 
 /**

--- a/packages/firestore/src/exp/database.ts
+++ b/packages/firestore/src/exp/database.ts
@@ -128,6 +128,9 @@ export function initializeFirestore(
     );
   }
 
+  /**
+   * create a firestore instance with the default settings
+   */
   const firestore = provider.getImmediate() as FirebaseFirestore;
   if (
     settings.cacheSizeBytes !== undefined &&
@@ -140,6 +143,9 @@ export function initializeFirestore(
     );
   }
 
+  /**
+   * update settings with the user supplied values on the firestore instance
+   */
   firestore._setSettings(settings);
   return firestore;
 }

--- a/packages/firestore/src/lite/database.ts
+++ b/packages/firestore/src/lite/database.ts
@@ -193,9 +193,7 @@ export function initializeFirestore(
     );
   }
 
-  const firestore = provider.getImmediate() as FirebaseFirestore;
-  firestore._setSettings(settings);
-  return firestore;
+  return provider.initialize({ options: settings });
 }
 
 /**

--- a/packages/functions/src/config.ts
+++ b/packages/functions/src/config.ts
@@ -19,7 +19,8 @@ import { Service } from './api/service';
 import {
   Component,
   ComponentType,
-  ComponentContainer
+  ComponentContainer,
+  InstanceFactoryOptions
 } from '@firebase/component';
 import { _FirebaseNamespace } from '@firebase/app-types/private';
 
@@ -39,7 +40,7 @@ export function registerFunctions(
 
   function factory(
     container: ComponentContainer,
-    regionOrCustomDomain?: string
+    { instanceIdentifier: regionOrCustomDomain }: InstanceFactoryOptions
   ): Service {
     // Dependencies
     const app = container.getProvider('app').getImmediate();

--- a/packages/remote-config/index.ts
+++ b/packages/remote-config/index.ts
@@ -31,7 +31,8 @@ import { name as packageName, version } from './package.json';
 import {
   Component,
   ComponentType,
-  ComponentContainer
+  ComponentContainer,
+  InstanceFactoryOptions
 } from '@firebase/component';
 
 // Facilitates debugging by enabling settings changes without rebuilding asset.
@@ -59,7 +60,7 @@ export function registerRemoteConfig(
 
   function remoteConfigFactory(
     container: ComponentContainer,
-    namespace?: string
+    { instanceIdentifier: namespace }: InstanceFactoryOptions
   ): RemoteConfig {
     /* Dependencies */
     // getImmediate for FirebaseApp will always succeed

--- a/packages/storage/compat/index.ts
+++ b/packages/storage/compat/index.ts
@@ -28,7 +28,8 @@ import * as types from '@firebase/storage-types';
 import {
   Component,
   ComponentType,
-  ComponentContainer
+  ComponentContainer,
+  InstanceFactoryOptions
 } from '@firebase/component';
 
 import { name, version } from '../package.json';
@@ -40,7 +41,7 @@ const STORAGE_TYPE = 'storage';
 
 function factory(
   container: ComponentContainer,
-  url?: string
+  { instanceIdentifier: url }: InstanceFactoryOptions
 ): types.FirebaseStorage {
   // Dependencies
   // TODO: This should eventually be 'app-compat'

--- a/packages/storage/exp/index.ts
+++ b/packages/storage/exp/index.ts
@@ -33,7 +33,8 @@ import {
   Component,
   ComponentType,
   ComponentContainer,
-  Provider
+  Provider,
+  InstanceFactoryOptions
 } from '@firebase/component';
 
 import { name, version } from '../package.json';
@@ -295,7 +296,10 @@ export function getStorage(
   return storageInstance;
 }
 
-function factory(container: ComponentContainer, url?: string): StorageService {
+function factory(
+  container: ComponentContainer,
+  { instanceIdentifier: url }: InstanceFactoryOptions
+): StorageService {
   const app = container.getProvider('app-exp').getImmediate();
   const authProvider = container.getProvider('auth-internal');
 


### PR DESCRIPTION
Currently component factory doesn't take an options parameter. This leads to a 2 steps initialization pattern in `initializeAuth()`, `initializeFirestore()`, `initializePerformance()` and `initializeAnalytics()`:

Step 1: The component framework creates a service instance using default options
Step 2: Set user supplied options on the service instance returned from Step 1.


This PR removes the need of the second step by allowing you to pass an options to the component framework 
using the new `Provider.initialize()` method.

2 steps initialization is also problematic for certain use cases. See this [doc](https://docs.google.com/document/d/1wv2yxkMhp01Sp6uaQgyzUIWGIP4TV80j8ggJi8TatFM/edit?resourcekey=0-qQljqbBcfnxMdyOjrjovyw#heading=h.141ziqg4ofg6) for more details.

## Changes

**Component factory can take an options parameter now:**
```typescript
// Now it accepts an options parameter
Type InstanceFactory<T extends Name> = (container: ComponentContainer, options: InstanceFactoryOptions) => NameServiceMapping[T];

interface InstanceFactoryOptions {
    instanceIdentifier?: string;
    options?: Record<string, unknown>;
}
```

**Use `initialize()` to initialize with options. Taking `initializePerformance()` as an example:**
```typescript
export function initializePerformance(
 app: FirebaseApp,
 settings?: PerformanceSettings
): FirebasePerformance {
 const provider = _getProvider(app, 'performance-exp');

 if (provider.isInitialized()) {
   throw ERROR_FACTORY.create(ErrorCode.ALREADY_INITIALIZED);
 }
 
 // initialize a performance service instance with custom settings
 const perfInstance = provider.initialize(settings) as PerformanceController;
 
 // 2 steps process previously
 // const perfInstance = provider.getImmediate() as PerformanceController;
 // perfInstance._init(settings);

 return perfInstance;
}

```
