### PR TITLE
Add more redirect tests so that almost all the main use cases are covered

### DIFF
--- a/packages-exp/auth-exp/test/integration/webdriver/anonymous.test.ts
+++ b/packages-exp/auth-exp/test/integration/webdriver/anonymous.test.ts
@@ -18,7 +18,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { OperationType, UserCredential } from '@firebase/auth-exp';
 import { expect } from 'chai';
-import { TestFunction } from './util/auth_driver';
+import { AnonFunction } from './util/functions';
 import { browserDescribe } from './util/test_runner';
 
 /**
@@ -29,7 +29,7 @@ import { browserDescribe } from './util/test_runner';
 browserDescribe('WebDriver anonymous auth test', driver => {
   it('basic sign in is possible', async () => {
     const cred: UserCredential = await driver.call(
-      TestFunction.SIGN_IN_ANONYMOUSLY
+      AnonFunction.SIGN_IN_ANONYMOUSLY
     );
     expect(cred).not.to.be.null;
     expect(cred.user.isAnonymous).to.be.true;
@@ -39,7 +39,7 @@ browserDescribe('WebDriver anonymous auth test', driver => {
 
   it('same user persists after refresh and sign in', async () => {
     const { user: before }: UserCredential = await driver.call(
-      TestFunction.SIGN_IN_ANONYMOUSLY
+      AnonFunction.SIGN_IN_ANONYMOUSLY
     );
     await driver.refresh();
 
@@ -48,7 +48,7 @@ browserDescribe('WebDriver anonymous auth test', driver => {
 
     // Then, sign in again and check
     const { user: after }: UserCredential = await driver.call(
-      TestFunction.SIGN_IN_ANONYMOUSLY
+      AnonFunction.SIGN_IN_ANONYMOUSLY
     );
     expect(after.uid).to.eq(before.uid);
   });

--- a/packages-exp/auth-exp/test/integration/webdriver/redirect.test.ts
+++ b/packages-exp/auth-exp/test/integration/webdriver/redirect.test.ts
@@ -16,16 +16,22 @@
  */
 
 // eslint-disable-next-line import/no-extraneous-dependencies
-import { OperationType, UserCredential } from '@firebase/auth-exp';
-import { expect } from 'chai';
-import { TestFunction } from './util/auth_driver';
+import { OperationType, UserCredential, User, OAuthCredential } from '@firebase/auth-exp';
+import { expect, use } from 'chai';
 import { IdPPage } from './util/idp_page';
+import * as chaiAsPromised from 'chai-as-promised';
 import { browserDescribe } from './util/test_runner';
+import { AnonFunction, CoreFunction, RedirectFunction } from './util/functions';
+
+use(chaiAsPromised);
 
 browserDescribe('WebDriver redirect IdP test', driver => {
-  it('allows users to sign in', async () => {
+  beforeEach(async () => {
     await driver.pause(200); // Race condition on auth init
-    await driver.callNoWait(TestFunction.IDP_REDIRECT);
+  });
+
+  it('allows users to sign in', async () => {
+    await driver.callNoWait(RedirectFunction.IDP_REDIRECT);
     const widget = new IdPPage(driver.webDriver);
 
     // We're now on the widget page; wait for load
@@ -38,16 +44,194 @@ browserDescribe('WebDriver redirect IdP test', driver => {
     await widget.clickSignIn();
 
     await driver.reinitOnRedirect();
-
     const currentUser = await driver.getUserSnapshot();
     expect(currentUser.email).to.eq('bob@bob.test');
     expect(currentUser.displayName).to.eq('Bob Test');
     expect(currentUser.photoURL).to.eq('http://bob.test/bob.png');
 
     const redirectResult: UserCredential = await driver.call(
-      TestFunction.REDIRECT_RESULT
+      RedirectFunction.REDIRECT_RESULT
     );
     expect(redirectResult.operationType).to.eq(OperationType.SIGN_IN);
     expect(redirectResult.user).to.eql(currentUser);
+  });
+
+
+  it('can link with another account account', async () => {
+    // First, sign in anonymously
+    const {user: anonUser}: UserCredential = await driver.call(AnonFunction.SIGN_IN_ANONYMOUSLY);
+
+    // Then, link with redirect
+    driver.callNoWait(RedirectFunction.IDP_LINK_REDIRECT);
+    const widget = new IdPPage(driver.webDriver);
+    await widget.pageLoad();
+    await widget.clickAddAccount();
+    await widget.fillEmail('bob@bob.test');
+    await widget.clickSignIn();
+
+    await driver.reinitOnRedirect();
+    // Back on page; check for the current user matching the anonymous account
+    // as well as the new IdP account
+    const user: User = await driver.getUserSnapshot();
+    expect(user.uid).to.eq(anonUser.uid);
+    expect(user.email).to.eq('bob@bob.test');
+  });
+
+  it('can be converted to a credential', async () => {
+    // Start with redirect
+    driver.callNoWait(RedirectFunction.IDP_REDIRECT);
+    const widget = new IdPPage(driver.webDriver);
+    await widget.pageLoad();
+    await widget.clickAddAccount();
+    await widget.fillEmail('bob@bob.test');
+    await widget.clickSignIn();
+
+    // Generate a credential, then store it on the window before logging out
+    await driver.reinitOnRedirect();
+    const first = await driver.getUserSnapshot();
+    const cred: OAuthCredential = await driver.call(RedirectFunction.GENERATE_CREDENTIAL_FROM_RESULT);
+    expect(cred.accessToken).to.be.a('string');
+    expect(cred.idToken).to.be.a('string');
+    expect(cred.signInMethod).to.eq('google.com');
+
+    // We've now generated that credential. Sign out and sign back in using it
+    await driver.call(CoreFunction.SIGN_OUT);
+    const {user: second}: UserCredential = await driver.call(RedirectFunction.SIGN_IN_WITH_REDIRECT_CREDENTIAL);
+    expect(second.uid).to.eq(first.uid);
+    expect(second.providerData).to.eql(first.providerData);
+  });
+
+  it('handles account exists different credential errors', async () => {
+    // Start with redirect and a verified account
+    driver.callNoWait(RedirectFunction.IDP_REDIRECT);
+    const widget = new IdPPage(driver.webDriver);
+    await widget.pageLoad();
+    await widget.clickAddAccount();
+    await widget.fillEmail('bob@bob.test');
+    await widget.clickSignIn();
+    await driver.reinitOnRedirect();
+
+    const original = await driver.getUserSnapshot();
+    expect(original.emailVerified).to.be.true;
+
+    // Try to sign in with an unverified Facebook account
+    // TODO: Convert this to the widget once unverified accounts work
+    // Come back and verify error / prepare for link
+    await expect(driver.call(RedirectFunction.TRY_TO_SIGN_IN_UNVERIFIED, '"bob@bob.test"')).to.be.rejected.and.eventually.have.property('code', 'auth/account-exists-with-different-credential');
+    
+    // Now do the link
+    await driver.call(RedirectFunction.LINK_WITH_ERROR_CREDENTIAL);
+    
+    // Check the user for both providers
+    const user = await driver.getUserSnapshot();
+    expect(user.uid).to.eq(original.uid);
+    expect(user.providerData.map(d => d.providerId)).to.have.members(['google.com', 'facebook.com']);
+  });
+
+  context('with existing user', () => {
+    let user1: User;
+    let user2: User;
+
+    beforeEach(async () => {
+      // Create a couple existing users
+      let cred: UserCredential = await driver.call(RedirectFunction.CREATE_FAKE_GOOGLE_USER, '"bob@bob.test"');
+      user1 = cred.user;
+      cred = await driver.call(RedirectFunction.CREATE_FAKE_GOOGLE_USER, '"sally@sally.test"');
+      user2 = cred.user;
+      await driver.call(CoreFunction.SIGN_OUT);
+    });
+
+    it('a user can sign in again', async () => {
+      // Sign in using pre-poulated user
+      await driver.callNoWait(RedirectFunction.IDP_REDIRECT);
+      
+      // This time, select an existing account
+      const widget = new IdPPage(driver.webDriver);
+      await widget.pageLoad();
+      await widget.selectExistingAccountByEmail(user1.email!);
+
+      // Double check the new sign in matches the old
+      await driver.reinitOnRedirect();
+      const user = await driver.getUserSnapshot();
+      expect(user.uid).to.eq(user1.uid);
+      expect(user.email).to.eq(user1.email);
+    });
+
+    it('reauthenticate works for the correct user', async() => {
+      // Sign in using pre-poulated user
+      await driver.callNoWait(RedirectFunction.IDP_REDIRECT);
+
+      const widget = new IdPPage(driver.webDriver);
+      await widget.pageLoad();
+      await widget.selectExistingAccountByEmail(user1.email!);
+
+      // Double check the new sign in matches the old
+      await driver.reinitOnRedirect();
+      let user = await driver.getUserSnapshot();
+      expect(user.uid).to.eq(user1.uid);
+      expect(user.email).to.eq(user1.email);
+
+      // Reauthenticate specifically
+      await driver.callNoWait(RedirectFunction.IDP_REAUTH_REDIRECT);
+      await widget.pageLoad();
+      await widget.selectExistingAccountByEmail(user1.email!);
+
+    await driver.reinitOnRedirect();
+      user = await driver.getUserSnapshot();
+      expect(user.uid).to.eq(user1.uid);
+      expect(user.email).to.eq(user1.email);
+    })
+    
+    it('reauthenticate throws for wrong user', async () => {
+      // Sign in using pre-poulated user
+      await driver.callNoWait(RedirectFunction.IDP_REDIRECT);
+
+      const widget = new IdPPage(driver.webDriver);
+      await widget.pageLoad();
+      await widget.selectExistingAccountByEmail(user1.email!);
+
+      // Immediately reauth but with the wrong user
+      await driver.reinitOnRedirect();
+      await driver.callNoWait(RedirectFunction.IDP_REAUTH_REDIRECT);
+      await widget.pageLoad();
+      await widget.selectExistingAccountByEmail(user2.email!);
+      
+      await driver.reinitOnRedirect();
+      await expect(driver.call(RedirectFunction.REDIRECT_RESULT)).to.be.rejected.and.eventually.have.property('code', 'auth/user-mismatch');
+    });
+
+    it('handles aborted sign ins', async () => {
+      await driver.callNoWait(RedirectFunction.IDP_REDIRECT);
+      const widget = new IdPPage(driver.webDriver);
+      
+      // Don't actually sign in; go back to the previous page
+      await widget.pageLoad();
+      await driver.goToTestPage();
+      await driver.reinitOnRedirect();
+      expect(await driver.getUserSnapshot()).to.be.null;
+
+      // Now do sign in
+      await driver.callNoWait(RedirectFunction.IDP_REDIRECT);
+      // Use user1
+      await widget.pageLoad();
+      await widget.selectExistingAccountByEmail(user1.email!);
+
+      // Ensure the user was signed in...
+      await driver.reinitOnRedirect();
+      let user = await driver.getUserSnapshot();
+      expect(user.uid).to.eq(user1.uid);
+      expect(user.email).to.eq(user1.email);
+
+      // Now open another sign in, but return
+      await driver.callNoWait(RedirectFunction.IDP_REAUTH_REDIRECT);
+      await widget.pageLoad();
+      await driver.goToTestPage();
+      await driver.reinitOnRedirect();
+
+      // Make sure state remained
+      user = await driver.getUserSnapshot();
+      expect(user.uid).to.eq(user1.uid);
+      expect(user.email).to.eq(user1.email);
+    });
   });
 });

--- a/packages-exp/auth-exp/test/integration/webdriver/redirect.test.ts
+++ b/packages-exp/auth-exp/test/integration/webdriver/redirect.test.ts
@@ -16,7 +16,12 @@
  */
 
 // eslint-disable-next-line import/no-extraneous-dependencies
-import { OperationType, UserCredential, User, OAuthCredential } from '@firebase/auth-exp';
+import {
+  OperationType,
+  UserCredential,
+  User,
+  OAuthCredential
+} from '@firebase/auth-exp';
 import { expect, use } from 'chai';
 import { IdPPage } from './util/idp_page';
 import * as chaiAsPromised from 'chai-as-promised';
@@ -56,10 +61,11 @@ browserDescribe('WebDriver redirect IdP test', driver => {
     expect(redirectResult.user).to.eql(currentUser);
   });
 
-
   it('can link with another account account', async () => {
     // First, sign in anonymously
-    const {user: anonUser}: UserCredential = await driver.call(AnonFunction.SIGN_IN_ANONYMOUSLY);
+    const { user: anonUser }: UserCredential = await driver.call(
+      AnonFunction.SIGN_IN_ANONYMOUSLY
+    );
 
     // Then, link with redirect
     driver.callNoWait(RedirectFunction.IDP_LINK_REDIRECT);
@@ -89,14 +95,18 @@ browserDescribe('WebDriver redirect IdP test', driver => {
     // Generate a credential, then store it on the window before logging out
     await driver.reinitOnRedirect();
     const first = await driver.getUserSnapshot();
-    const cred: OAuthCredential = await driver.call(RedirectFunction.GENERATE_CREDENTIAL_FROM_RESULT);
+    const cred: OAuthCredential = await driver.call(
+      RedirectFunction.GENERATE_CREDENTIAL_FROM_RESULT
+    );
     expect(cred.accessToken).to.be.a('string');
     expect(cred.idToken).to.be.a('string');
     expect(cred.signInMethod).to.eq('google.com');
 
     // We've now generated that credential. Sign out and sign back in using it
     await driver.call(CoreFunction.SIGN_OUT);
-    const {user: second}: UserCredential = await driver.call(RedirectFunction.SIGN_IN_WITH_REDIRECT_CREDENTIAL);
+    const { user: second }: UserCredential = await driver.call(
+      RedirectFunction.SIGN_IN_WITH_REDIRECT_CREDENTIAL
+    );
     expect(second.uid).to.eq(first.uid);
     expect(second.providerData).to.eql(first.providerData);
   });
@@ -117,15 +127,23 @@ browserDescribe('WebDriver redirect IdP test', driver => {
     // Try to sign in with an unverified Facebook account
     // TODO: Convert this to the widget once unverified accounts work
     // Come back and verify error / prepare for link
-    await expect(driver.call(RedirectFunction.TRY_TO_SIGN_IN_UNVERIFIED, '"bob@bob.test"')).to.be.rejected.and.eventually.have.property('code', 'auth/account-exists-with-different-credential');
-    
+    await expect(
+      driver.call(RedirectFunction.TRY_TO_SIGN_IN_UNVERIFIED, '"bob@bob.test"')
+    ).to.be.rejected.and.eventually.have.property(
+      'code',
+      'auth/account-exists-with-different-credential'
+    );
+
     // Now do the link
     await driver.call(RedirectFunction.LINK_WITH_ERROR_CREDENTIAL);
-    
+
     // Check the user for both providers
     const user = await driver.getUserSnapshot();
     expect(user.uid).to.eq(original.uid);
-    expect(user.providerData.map(d => d.providerId)).to.have.members(['google.com', 'facebook.com']);
+    expect(user.providerData.map(d => d.providerId)).to.have.members([
+      'google.com',
+      'facebook.com'
+    ]);
   });
 
   context('with existing user', () => {
@@ -134,9 +152,15 @@ browserDescribe('WebDriver redirect IdP test', driver => {
 
     beforeEach(async () => {
       // Create a couple existing users
-      let cred: UserCredential = await driver.call(RedirectFunction.CREATE_FAKE_GOOGLE_USER, '"bob@bob.test"');
+      let cred: UserCredential = await driver.call(
+        RedirectFunction.CREATE_FAKE_GOOGLE_USER,
+        '"bob@bob.test"'
+      );
       user1 = cred.user;
-      cred = await driver.call(RedirectFunction.CREATE_FAKE_GOOGLE_USER, '"sally@sally.test"');
+      cred = await driver.call(
+        RedirectFunction.CREATE_FAKE_GOOGLE_USER,
+        '"sally@sally.test"'
+      );
       user2 = cred.user;
       await driver.call(CoreFunction.SIGN_OUT);
     });
@@ -144,7 +168,7 @@ browserDescribe('WebDriver redirect IdP test', driver => {
     it('a user can sign in again', async () => {
       // Sign in using pre-poulated user
       await driver.callNoWait(RedirectFunction.IDP_REDIRECT);
-      
+
       // This time, select an existing account
       const widget = new IdPPage(driver.webDriver);
       await widget.pageLoad();
@@ -157,7 +181,7 @@ browserDescribe('WebDriver redirect IdP test', driver => {
       expect(user.email).to.eq(user1.email);
     });
 
-    it('reauthenticate works for the correct user', async() => {
+    it('reauthenticate works for the correct user', async () => {
       // Sign in using pre-poulated user
       await driver.callNoWait(RedirectFunction.IDP_REDIRECT);
 
@@ -176,12 +200,12 @@ browserDescribe('WebDriver redirect IdP test', driver => {
       await widget.pageLoad();
       await widget.selectExistingAccountByEmail(user1.email!);
 
-    await driver.reinitOnRedirect();
+      await driver.reinitOnRedirect();
       user = await driver.getUserSnapshot();
       expect(user.uid).to.eq(user1.uid);
       expect(user.email).to.eq(user1.email);
-    })
-    
+    });
+
     it('reauthenticate throws for wrong user', async () => {
       // Sign in using pre-poulated user
       await driver.callNoWait(RedirectFunction.IDP_REDIRECT);
@@ -195,15 +219,20 @@ browserDescribe('WebDriver redirect IdP test', driver => {
       await driver.callNoWait(RedirectFunction.IDP_REAUTH_REDIRECT);
       await widget.pageLoad();
       await widget.selectExistingAccountByEmail(user2.email!);
-      
+
       await driver.reinitOnRedirect();
-      await expect(driver.call(RedirectFunction.REDIRECT_RESULT)).to.be.rejected.and.eventually.have.property('code', 'auth/user-mismatch');
+      await expect(
+        driver.call(RedirectFunction.REDIRECT_RESULT)
+      ).to.be.rejected.and.eventually.have.property(
+        'code',
+        'auth/user-mismatch'
+      );
     });
 
     it('handles aborted sign ins', async () => {
       await driver.callNoWait(RedirectFunction.IDP_REDIRECT);
       const widget = new IdPPage(driver.webDriver);
-      
+
       // Don't actually sign in; go back to the previous page
       await widget.pageLoad();
       await driver.goToTestPage();

--- a/packages-exp/auth-exp/test/integration/webdriver/redirect.test.ts
+++ b/packages-exp/auth-exp/test/integration/webdriver/redirect.test.ts
@@ -128,7 +128,7 @@ browserDescribe('WebDriver redirect IdP test', driver => {
     // TODO: Convert this to the widget once unverified accounts work
     // Come back and verify error / prepare for link
     await expect(
-      driver.call(RedirectFunction.TRY_TO_SIGN_IN_UNVERIFIED, '"bob@bob.test"')
+      driver.call(RedirectFunction.TRY_TO_SIGN_IN_UNVERIFIED, 'bob@bob.test')
     ).to.be.rejected.and.eventually.have.property(
       'code',
       'auth/account-exists-with-different-credential'
@@ -154,12 +154,12 @@ browserDescribe('WebDriver redirect IdP test', driver => {
       // Create a couple existing users
       let cred: UserCredential = await driver.call(
         RedirectFunction.CREATE_FAKE_GOOGLE_USER,
-        '"bob@bob.test"'
+        'bob@bob.test'
       );
       user1 = cred.user;
       cred = await driver.call(
         RedirectFunction.CREATE_FAKE_GOOGLE_USER,
-        '"sally@sally.test"'
+        'sally@sally.test'
       );
       user2 = cred.user;
       await driver.call(CoreFunction.SIGN_OUT);

--- a/packages-exp/auth-exp/test/integration/webdriver/redirect.test.ts
+++ b/packages-exp/auth-exp/test/integration/webdriver/redirect.test.ts
@@ -15,12 +15,12 @@
  * limitations under the License.
  */
 
-// eslint-disable-next-line import/no-extraneous-dependencies
 import {
   OperationType,
   UserCredential,
   User,
   OAuthCredential
+  // eslint-disable-next-line import/no-extraneous-dependencies
 } from '@firebase/auth-exp';
 import { expect, use } from 'chai';
 import { IdPPage } from './util/idp_page';
@@ -68,7 +68,7 @@ browserDescribe('WebDriver redirect IdP test', driver => {
     );
 
     // Then, link with redirect
-    driver.callNoWait(RedirectFunction.IDP_LINK_REDIRECT);
+    await driver.callNoWait(RedirectFunction.IDP_LINK_REDIRECT);
     const widget = new IdPPage(driver.webDriver);
     await widget.pageLoad();
     await widget.clickAddAccount();
@@ -85,7 +85,7 @@ browserDescribe('WebDriver redirect IdP test', driver => {
 
   it('can be converted to a credential', async () => {
     // Start with redirect
-    driver.callNoWait(RedirectFunction.IDP_REDIRECT);
+    await driver.callNoWait(RedirectFunction.IDP_REDIRECT);
     const widget = new IdPPage(driver.webDriver);
     await widget.pageLoad();
     await widget.clickAddAccount();
@@ -113,7 +113,7 @@ browserDescribe('WebDriver redirect IdP test', driver => {
 
   it('handles account exists different credential errors', async () => {
     // Start with redirect and a verified account
-    driver.callNoWait(RedirectFunction.IDP_REDIRECT);
+    await driver.callNoWait(RedirectFunction.IDP_REDIRECT);
     const widget = new IdPPage(driver.webDriver);
     await widget.pageLoad();
     await widget.clickAddAccount();

--- a/packages-exp/auth-exp/test/integration/webdriver/static/anonymous.js
+++ b/packages-exp/auth-exp/test/integration/webdriver/static/anonymous.js
@@ -17,7 +17,7 @@
 
 import { signInAnonymously } from '@firebase/auth-exp';
 
-export async function anonymous() {
+export async function anonymousSignIn() {
   const userCred = await signInAnonymously(auth);
   return userCred;
 }

--- a/packages-exp/auth-exp/test/integration/webdriver/static/anonymous.js
+++ b/packages-exp/auth-exp/test/integration/webdriver/static/anonymous.js
@@ -1,0 +1,8 @@
+import {
+  signInAnonymously,
+} from '@firebase/auth-exp';
+
+export async function anonymous() {
+  const userCred = await signInAnonymously(auth);
+  return userCred;
+};

--- a/packages-exp/auth-exp/test/integration/webdriver/static/anonymous.js
+++ b/packages-exp/auth-exp/test/integration/webdriver/static/anonymous.js
@@ -1,8 +1,23 @@
-import {
-  signInAnonymously,
-} from '@firebase/auth-exp';
+/**
+ * @license
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { signInAnonymously } from '@firebase/auth-exp';
 
 export async function anonymous() {
   const userCred = await signInAnonymously(auth);
   return userCred;
-};
+}

--- a/packages-exp/auth-exp/test/integration/webdriver/static/core.js
+++ b/packages-exp/auth-exp/test/integration/webdriver/static/core.js
@@ -1,0 +1,29 @@
+export function reset() {
+  sessionStorage.clear();
+  localStorage.clear();
+  const del = indexedDB.deleteDatabase('firebaseLocalStorageDb');
+
+  return new Promise(resolve => {
+    del.addEventListener('success', () => resolve());
+    del.addEventListener('error', () => resolve());
+    del.addEventListener('blocked', () => resolve());
+  });
+};
+
+export function authInit() {
+  return new Promise(resolve => {
+    auth.onAuthStateChanged(() => resolve());
+  });
+};
+
+export async function userSnap() {
+  return auth.currentUser;
+}
+
+export async function authSnap() {
+  return auth;
+}
+
+export function signOut() {
+  return auth.signOut();
+}

--- a/packages-exp/auth-exp/test/integration/webdriver/static/core.js
+++ b/packages-exp/auth-exp/test/integration/webdriver/static/core.js
@@ -1,3 +1,20 @@
+/**
+ * @license
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 export function reset() {
   sessionStorage.clear();
   localStorage.clear();
@@ -8,13 +25,13 @@ export function reset() {
     del.addEventListener('error', () => resolve());
     del.addEventListener('blocked', () => resolve());
   });
-};
+}
 
 export function authInit() {
   return new Promise(resolve => {
     auth.onAuthStateChanged(() => resolve());
   });
-};
+}
 
 export async function userSnap() {
   return auth.currentUser;

--- a/packages-exp/auth-exp/test/integration/webdriver/static/index.js
+++ b/packages-exp/auth-exp/test/integration/webdriver/static/index.js
@@ -15,14 +15,11 @@
  * limitations under the License.
  */
 
-import * as redirect from './redirect'
+import * as redirect from './redirect';
 import * as anonymous from './anonymous';
 import * as core from './core';
 import { initializeApp } from '@firebase/app-exp';
-import {
-  getAuth,
-  useAuthEmulator
-} from '@firebase/auth-exp';
+import { getAuth, useAuthEmulator } from '@firebase/auth-exp';
 
 window.core = core;
 window.anonymous = anonymous;

--- a/packages-exp/auth-exp/test/integration/webdriver/static/index.js
+++ b/packages-exp/auth-exp/test/integration/webdriver/static/index.js
@@ -15,53 +15,18 @@
  * limitations under the License.
  */
 
+import * as redirect from './redirect'
+import * as anonymous from './anonymous';
+import * as core from './core';
 import { initializeApp } from '@firebase/app-exp';
 import {
   getAuth,
-  getRedirectResult,
-  GoogleAuthProvider,
-  signInAnonymously,
-  signInWithRedirect,
   useAuthEmulator
 } from '@firebase/auth-exp';
 
-let auth;
-
-// Helper functions for tests
-window.anonymous = async () => {
-  const userCred = await signInAnonymously(auth);
-  return userCred;
-};
-
-window.reset = () => {
-  sessionStorage.clear();
-  localStorage.clear();
-  const del = indexedDB.deleteDatabase('firebaseLocalStorageDb');
-
-  return new Promise(resolve => {
-    del.addEventListener('success', () => resolve());
-    del.addEventListener('error', () => resolve());
-    del.addEventListener('blocked', () => resolve());
-  });
-};
-
-window.authInit = () => {
-  return new Promise(resolve => {
-    auth.onAuthStateChanged(() => resolve());
-  });
-};
-
-window.userSnap = async () => auth.currentUser;
-
-window.authSnap = async () => auth;
-
-window.idpRedirect = () => {
-  signInWithRedirect(auth, new GoogleAuthProvider());
-};
-
-window.redirectResult = () => {
-  return getRedirectResult(auth);
-};
+window.core = core;
+window.anonymous = anonymous;
+window.redirect = redirect;
 
 // The config and emulator URL are injected by the test. The test framework
 // calls this function after that injection.

--- a/packages-exp/auth-exp/test/integration/webdriver/static/redirect.js
+++ b/packages-exp/auth-exp/test/integration/webdriver/static/redirect.js
@@ -1,3 +1,20 @@
+/**
+ * @license
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import {
   FacebookAuthProvider,
   getRedirectResult,
@@ -7,11 +24,13 @@ import {
   OAuthProvider,
   reauthenticateWithRedirect,
   signInWithCredential,
-  signInWithRedirect,
+  signInWithRedirect
 } from '@firebase/auth-exp';
 
 export function idpRedirect(optProvider) {
-  const provider = optProvider ? new OAuthProvider(optProvider) : new GoogleAuthProvider();
+  const provider = optProvider
+    ? new OAuthProvider(optProvider)
+    : new GoogleAuthProvider();
   signInWithRedirect(auth, provider);
 }
 
@@ -46,17 +65,21 @@ export async function linkWithErrorCredential() {
 
 export function createFakeGoogleUser(email) {
   return signInWithCredential(
-  auth,
-  GoogleAuthProvider.credential(
-    `{"sub": "__${email}__", "email": "${email}", "email_verified": true}`
-))
+    auth,
+    GoogleAuthProvider.credential(
+      `{"sub": "__${email}__", "email": "${email}", "email_verified": true}`
+    )
+  );
 }
 
-export async function tryToSignInUnverified(email) { 
+export async function tryToSignInUnverified(email) {
   try {
-    await signInWithCredential(auth, FacebookAuthProvider.credential(
-      `{"sub": "$$${email}$$", "email": "${email}", "email_verified": false}`
-    ));
+    await signInWithCredential(
+      auth,
+      FacebookAuthProvider.credential(
+        `{"sub": "$$${email}$$", "email": "${email}", "email_verified": false}`
+      )
+    );
   } catch (e) {
     window.errorCred = FacebookAuthProvider.credentialFromError(e);
     throw e;

--- a/packages-exp/auth-exp/test/integration/webdriver/static/redirect.js
+++ b/packages-exp/auth-exp/test/integration/webdriver/static/redirect.js
@@ -1,0 +1,64 @@
+import {
+  FacebookAuthProvider,
+  getRedirectResult,
+  GoogleAuthProvider,
+  linkWithCredential,
+  linkWithRedirect,
+  OAuthProvider,
+  reauthenticateWithRedirect,
+  signInWithCredential,
+  signInWithRedirect,
+} from '@firebase/auth-exp';
+
+export function idpRedirect(optProvider) {
+  const provider = optProvider ? new OAuthProvider(optProvider) : new GoogleAuthProvider();
+  signInWithRedirect(auth, provider);
+}
+
+export function idpReauthRedirect() {
+  reauthenticateWithRedirect(auth.currentUser, new GoogleAuthProvider());
+}
+
+export function idpLinkRedirect() {
+  linkWithRedirect(auth.currentUser, new GoogleAuthProvider());
+}
+
+export function redirectResult() {
+  return getRedirectResult(auth);
+}
+
+export async function generateCredentialFromRedirectResultAndStore() {
+  const result = await getRedirectResult(auth);
+  window.redirectCred = GoogleAuthProvider.credentialFromResult(result);
+  return window.redirectCred;
+}
+
+export async function signInWithRedirectCredential() {
+  return signInWithCredential(auth, window.redirectCred);
+}
+
+export async function linkWithErrorCredential() {
+  await linkWithCredential(auth.currentUser, window.errorCred);
+}
+
+// These below are not technically redirect functions but they're helpers for
+// the redirect tests.
+
+export function createFakeGoogleUser(email) {
+  return signInWithCredential(
+  auth,
+  GoogleAuthProvider.credential(
+    `{"sub": "__${email}__", "email": "${email}", "email_verified": true}`
+))
+}
+
+export async function tryToSignInUnverified(email) { 
+  try {
+    await signInWithCredential(auth, FacebookAuthProvider.credential(
+      `{"sub": "$$${email}$$", "email": "${email}", "email_verified": false}`
+    ));
+  } catch (e) {
+    window.errorCred = FacebookAuthProvider.credentialFromError(e);
+    throw e;
+  }
+}

--- a/packages-exp/auth-exp/test/integration/webdriver/util/auth_driver.ts
+++ b/packages-exp/auth-exp/test/integration/webdriver/util/auth_driver.ts
@@ -52,7 +52,8 @@ export class AuthDriver {
     // serialization which blows up the whole thing. It's okay though; this is
     // an integration test: we don't care about the internal (hidden) values of
     // these objects.
-    const {type, value}: {type: string, value: string} = await this.webDriver.executeAsyncScript(`
+    const { type, value }: { type: string; value: string } = await this
+      .webDriver.executeAsyncScript(`
       var callback = arguments[arguments.length - 1];
       ${fn}(${argString}).then(result => {
         callback({type: 'success', value: JSON.stringify(result)});

--- a/packages-exp/auth-exp/test/integration/webdriver/util/auth_driver.ts
+++ b/packages-exp/auth-exp/test/integration/webdriver/util/auth_driver.ts
@@ -29,6 +29,7 @@ import { JsLoadCondition } from './js_load_condition';
 import { authTestServer } from './test_server';
 
 const START_FUNCTION = 'startAuth';
+const PASSED_ARGS = '...Array.prototype.slice.call(arguments, 0, -1)';
 
 /** Helper wraper around the WebDriver object */
 export class AuthDriver {
@@ -60,7 +61,7 @@ export class AuthDriver {
     } = await this.webDriver.executeAsyncScript(
       `
       var callback = arguments[arguments.length - 1];
-      ${fn}(...arguments).then(result => {
+      ${fn}(${PASSED_ARGS}).then(result => {
         callback({type: 'success', value: JSON.stringify(result)});
       }).catch(e => {
         callback({type: 'error', value: JSON.stringify(e)});
@@ -80,7 +81,7 @@ export class AuthDriver {
   }
 
   async callNoWait(fn: string, ...args: unknown[]): Promise<void> {
-    return this.webDriver.executeScript(`${fn}(...arguments)`, ...args);
+    return this.webDriver.executeScript(`${fn}(${PASSED_ARGS})`, ...args);
   }
 
   async getAuthSnapshot(): Promise<Auth> {

--- a/packages-exp/auth-exp/test/integration/webdriver/util/auth_driver.ts
+++ b/packages-exp/auth-exp/test/integration/webdriver/util/auth_driver.ts
@@ -24,20 +24,11 @@ import {
   PROJECT_ID,
   USE_EMULATOR
 } from '../../../helpers/integration/settings';
+import { CoreFunction } from './functions';
 import { JsLoadCondition } from './js_load_condition';
 import { authTestServer } from './test_server';
 
-/** Available functions within the browser. See static/index.js */
-export enum TestFunction {
-  SIGN_IN_ANONYMOUSLY = 'anonymous',
-  RESET = 'reset',
-  AWAIT_AUTH_INIT = 'authInit',
-  USER_SNAPSHOT = 'userSnap',
-  AUTH_SNAPSHOT = 'authSnap',
-  START_AUTH = 'startAuth',
-  IDP_REDIRECT = 'idpRedirect',
-  REDIRECT_RESULT = 'redirectResult'
-}
+const START_FUNCTION = 'startAuth';
 
 /** Helper wraper around the WebDriver object */
 export class AuthDriver {
@@ -46,8 +37,7 @@ export class AuthDriver {
   async start(browser: string): Promise<void> {
     await authTestServer.start();
     this.webDriver = await new Builder().forBrowser(browser).build();
-    await this.webDriver.get(authTestServer.address!);
-    await this.injectConfigAndInitAuth();
+    await this.goToTestPage();
   }
 
   async stop(): Promise<void> {
@@ -55,48 +45,62 @@ export class AuthDriver {
     await this.webDriver.quit();
   }
 
-  async call<T>(fn: TestFunction): Promise<T> {
+  async call<T>(fn: string, ...args: unknown[]): Promise<T> {
+    const argString = args.length ? args.join(', ') : '';
     // When running on firefox we can't just return result immediately. For
     // some reason, the binding ends up causing a cycle dependency issue during
     // serialization which blows up the whole thing. It's okay though; this is
     // an integration test: we don't care about the internal (hidden) values of
     // these objects.
-    const result = await this.webDriver.executeAsyncScript(`
+    const {type, value}: {type: string, value: string} = await this.webDriver.executeAsyncScript(`
       var callback = arguments[arguments.length - 1];
-      ${fn}().then(result => {
-        callback(JSON.stringify(result));
+      ${fn}(${argString}).then(result => {
+        callback({type: 'success', value: JSON.stringify(result)});
+      }).catch(e => {
+        callback({type: 'error', value: JSON.stringify(e)});
       });
     `);
-    return JSON.parse(result as string) as T;
+
+    const parsed: object = JSON.parse(value);
+    if (type === 'success') {
+      return JSON.parse(value) as T;
+    } else {
+      const e = new Error('Test promise rejection');
+      Object.assign(e, parsed);
+      throw e;
+    }
   }
 
-  async callNoWait(fn: TestFunction): Promise<void> {
-    return this.webDriver.executeScript(`${fn}()`);
+  async callNoWait(fn: string, ...args: unknown[]): Promise<void> {
+    return this.webDriver.executeScript(`${fn}()`, ...args);
   }
 
   async getAuthSnapshot(): Promise<Auth> {
-    return this.call(TestFunction.AUTH_SNAPSHOT);
+    return this.call(CoreFunction.AUTH_SNAPSHOT);
   }
 
   async getUserSnapshot(): Promise<User> {
-    return this.call(TestFunction.USER_SNAPSHOT);
+    return this.call(CoreFunction.USER_SNAPSHOT);
   }
 
   async reset(): Promise<void> {
     await resetEmulator();
+    await this.goToTestPage();
+    return this.call(CoreFunction.RESET);
+  }
+
+  async goToTestPage(): Promise<void> {
     await this.webDriver.get(authTestServer.address!);
-    return this.call(TestFunction.RESET);
   }
 
   async waitForAuthInit(): Promise<void> {
-    return this.call(TestFunction.AWAIT_AUTH_INIT);
+    return this.call(CoreFunction.AWAIT_AUTH_INIT);
   }
 
   async reinitOnRedirect(): Promise<void> {
     // In this unique case we don't know when the page is back; check for the
-    // presence of the init function
-    // await this.webDriver.wait(this.webDriver.executeScript('typeof authInit !== "undefined"'));
-    await this.webDriver.wait(new JsLoadCondition(TestFunction.START_AUTH));
+    // presence of the core module
+    await this.webDriver.wait(new JsLoadCondition(START_FUNCTION));
     await this.injectConfigAndInitAuth();
     await this.waitForAuthInit();
   }
@@ -130,6 +134,6 @@ export class AuthDriver {
       };
       window.emulatorUrl = '${getEmulatorUrl()}';
     `);
-    await this.call(TestFunction.START_AUTH);
+    await this.call(START_FUNCTION);
   }
 }

--- a/packages-exp/auth-exp/test/integration/webdriver/util/auth_driver.ts
+++ b/packages-exp/auth-exp/test/integration/webdriver/util/auth_driver.ts
@@ -51,15 +51,23 @@ export class AuthDriver {
     // serialization which blows up the whole thing. It's okay though; this is
     // an integration test: we don't care about the internal (hidden) values of
     // these objects.
-    const { type, value }: { type: string; value: string } = await this
-      .webDriver.executeAsyncScript(`
+    const {
+      type,
+      value
+    }: {
+      type: string;
+      value: string;
+    } = await this.webDriver.executeAsyncScript(
+      `
       var callback = arguments[arguments.length - 1];
       ${fn}(...arguments).then(result => {
         callback({type: 'success', value: JSON.stringify(result)});
       }).catch(e => {
         callback({type: 'error', value: JSON.stringify(e)});
       });
-    `, ...args);
+    `,
+      ...args
+    );
 
     const parsed: object = JSON.parse(value);
     if (type === 'success') {

--- a/packages-exp/auth-exp/test/integration/webdriver/util/functions.ts
+++ b/packages-exp/auth-exp/test/integration/webdriver/util/functions.ts
@@ -1,7 +1,24 @@
+/**
+ * @license
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /** Available in the browser. See static/anonymous.js */
 export enum AnonFunction {
-  SIGN_IN_ANONYMOUSLY = 'anonymous.anonymous',
-};
+  SIGN_IN_ANONYMOUSLY = 'anonymous.anonymous'
+}
 
 /** Available redirect functions. See static/redirect.js */
 export enum RedirectFunction {
@@ -13,8 +30,8 @@ export enum RedirectFunction {
   SIGN_IN_WITH_REDIRECT_CREDENTIAL = 'redirect.signInWithRedirectCredential',
   LINK_WITH_ERROR_CREDENTIAL = 'redirect.linkWithErrorCredential',
   CREATE_FAKE_GOOGLE_USER = 'redirect.createFakeGoogleUser',
-  TRY_TO_SIGN_IN_UNVERIFIED = 'redirect.tryToSignInUnverified',
-};
+  TRY_TO_SIGN_IN_UNVERIFIED = 'redirect.tryToSignInUnverified'
+}
 
 /** Available core functions within the browser. See static/core.js */
 export enum CoreFunction {
@@ -22,5 +39,5 @@ export enum CoreFunction {
   AWAIT_AUTH_INIT = 'core.authInit',
   USER_SNAPSHOT = 'core.userSnap',
   AUTH_SNAPSHOT = 'core.authSnap',
-  SIGN_OUT = 'core.signOut',
+  SIGN_OUT = 'core.signOut'
 }

--- a/packages-exp/auth-exp/test/integration/webdriver/util/functions.ts
+++ b/packages-exp/auth-exp/test/integration/webdriver/util/functions.ts
@@ -17,7 +17,7 @@
 
 /** Available in the browser. See static/anonymous.js */
 export enum AnonFunction {
-  SIGN_IN_ANONYMOUSLY = 'anonymous.anonymous'
+  SIGN_IN_ANONYMOUSLY = 'anonymous.anonymousSignIn'
 }
 
 /** Available redirect functions. See static/redirect.js */

--- a/packages-exp/auth-exp/test/integration/webdriver/util/functions.ts
+++ b/packages-exp/auth-exp/test/integration/webdriver/util/functions.ts
@@ -1,0 +1,26 @@
+/** Available in the browser. See static/anonymous.js */
+export enum AnonFunction {
+  SIGN_IN_ANONYMOUSLY = 'anonymous.anonymous',
+};
+
+/** Available redirect functions. See static/redirect.js */
+export enum RedirectFunction {
+  IDP_REDIRECT = 'redirect.idpRedirect',
+  IDP_REAUTH_REDIRECT = 'redirect.idpReauthRedirect',
+  IDP_LINK_REDIRECT = 'redirect.idpLinkRedirect',
+  REDIRECT_RESULT = 'redirect.redirectResult',
+  GENERATE_CREDENTIAL_FROM_RESULT = 'redirect.generateCredentialFromRedirectResultAndStore',
+  SIGN_IN_WITH_REDIRECT_CREDENTIAL = 'redirect.signInWithRedirectCredential',
+  LINK_WITH_ERROR_CREDENTIAL = 'redirect.linkWithErrorCredential',
+  CREATE_FAKE_GOOGLE_USER = 'redirect.createFakeGoogleUser',
+  TRY_TO_SIGN_IN_UNVERIFIED = 'redirect.tryToSignInUnverified',
+};
+
+/** Available core functions within the browser. See static/core.js */
+export enum CoreFunction {
+  RESET = 'core.reset',
+  AWAIT_AUTH_INIT = 'core.authInit',
+  USER_SNAPSHOT = 'core.userSnap',
+  AUTH_SNAPSHOT = 'core.authSnap',
+  SIGN_OUT = 'core.signOut',
+}

--- a/packages-exp/auth-exp/test/integration/webdriver/util/idp_page.ts
+++ b/packages-exp/auth-exp/test/integration/webdriver/util/idp_page.ts
@@ -24,6 +24,7 @@ const EMAIL_INPUT = By.id('email-input');
 const DISPLAY_NAME_INPUT = By.id('display-name-input');
 const SCREEN_NAME_INPUT = By.id('screen-name-input');
 const PROFILE_PHOTO_INPUT = By.id('profile-photo-input');
+const ACCOUNT_LIST_ITEMS = By.css('#accounts-list li');
 
 export class IdPPage {
   static PAGE_TITLE = 'Auth Emulator IDP Login Widget';
@@ -45,6 +46,17 @@ export class IdPPage {
     const button = await this.driver.findElement(SIGN_IN_BUTTON);
     await this.driver.wait(until.elementIsEnabled(button));
     await button.click();
+  }
+
+  async selectExistingAccountByEmail(email: string): Promise<void> {
+    await this.driver.wait(until.elementLocated(ACCOUNT_LIST_ITEMS));
+    const accounts = await this.driver.findElements(ACCOUNT_LIST_ITEMS);
+    for (const account of accounts) {
+      if ((await account.getText()).includes(email)) {
+        await account.click();
+        return;
+      }
+    }
   }
 
   fillEmail(email: string): Promise<void> {


### PR DESCRIPTION
This change adds webdriver tests for redirect flows including error states as well as happy states. This change also reconfigures the static files directory so that test functions aren't all in one giant file.

This brings our total webdriver integration tests to 20