### PR TITLE
Use generics for some firestore types

### DIFF
--- a/packages/firebase/index.d.ts
+++ b/packages/firebase/index.d.ts
@@ -8168,7 +8168,9 @@ declare namespace firebase.firestore {
      * @param collectionPath A slash-separated path to a collection.
      * @return The `CollectionReference` instance.
      */
-    collection(collectionPath: string): CollectionReference<DocumentData>;
+    collection<T = DocumentData>(
+      collectionPath: string
+    ): CollectionReference<T>;
 
     /**
      * Gets a `DocumentReference` instance that refers to the document at the
@@ -8177,7 +8179,7 @@ declare namespace firebase.firestore {
      * @param documentPath A slash-separated path to a document.
      * @return The `DocumentReference` instance.
      */
-    doc(documentPath: string): DocumentReference<DocumentData>;
+    doc<T = DocumentData>(documentPath: string): DocumentReference<T>;
 
     /**
      * Creates and returns a new Query that includes all documents in the
@@ -8189,7 +8191,7 @@ declare namespace firebase.firestore {
      * will be included. Cannot contain a slash.
      * @return The created Query.
      */
-    collectionGroup(collectionId: string): Query<DocumentData>;
+    collectionGroup<T = DocumentData>(collectionId: string): Query<T>;
 
     /**
      * Executes the given `updateFunction` and then attempts to commit the changes

--- a/packages/firestore-types/index.d.ts
+++ b/packages/firestore-types/index.d.ts
@@ -65,11 +65,11 @@ export class FirebaseFirestore {
 
   enablePersistence(settings?: PersistenceSettings): Promise<void>;
 
-  collection(collectionPath: string): CollectionReference<DocumentData>;
+  collection<T = DocumentData>(collectionPath: string): CollectionReference<T>;
 
-  doc(documentPath: string): DocumentReference<DocumentData>;
+  doc<T = DocumentData>(documentPath: string): DocumentReference<T>;
 
-  collectionGroup(collectionId: string): Query<DocumentData>;
+  collectionGroup<T = DocumentData>(collectionId: string): Query<T>;
 
   runTransaction<T>(
     updateFunction: (transaction: Transaction) => Promise<T>
@@ -243,7 +243,7 @@ export class DocumentReference<T = DocumentData> {
   readonly parent: CollectionReference<T>;
   readonly path: string;
 
-  collection(collectionPath: string): CollectionReference<DocumentData>;
+  collection(collectionPath: string): CollectionReference<T>;
 
   isEqual(other: DocumentReference<T>): boolean;
 


### PR DESCRIPTION
All use of generic types on Firebase functions `collection`, `doc`, and `collectionGroup`.

Closes #4646 