### PR TITLE
Export the compat implementation for FieldPath and FieldValue

### DIFF
--- a/packages/firestore/compat/config.ts
+++ b/packages/firestore/compat/config.ts
@@ -40,7 +40,6 @@ import {
   WriteBatch,
   setLogLevel
 } from '../src/api/database';
-
 import { FieldPath } from '../src/api/field_path';
 import { FieldValue } from '../src/api/field_value';
 

--- a/packages/firestore/compat/config.ts
+++ b/packages/firestore/compat/config.ts
@@ -24,10 +24,8 @@ import { Component, ComponentType } from '@firebase/component';
 import {
   FirebaseFirestore,
   CACHE_SIZE_UNLIMITED,
-  FieldPath,
   GeoPoint,
-  Timestamp,
-  FieldValue
+  Timestamp
 } from '../exp/index'; // import from the exp public API
 import { Blob } from '../src/api/blob';
 import {
@@ -42,6 +40,9 @@ import {
   WriteBatch,
   setLogLevel
 } from '../src/api/database';
+
+import { FieldPath } from '../src/api/field_path';
+import { FieldValue } from '../src/api/field_value';
 
 const firestoreNamespace = {
   Firestore,

--- a/packages/firestore/exp/index.ts
+++ b/packages/firestore/exp/index.ts
@@ -133,3 +133,5 @@ export { CACHE_SIZE_UNLIMITED } from '../src/exp/database';
 export { FirestoreErrorCode, FirestoreError } from '../src/util/error';
 
 export { AbstractUserDataWriter } from '../src/lite/user_data_writer';
+
+export { Compat } from '../src/lite/compat';

--- a/packages/firestore/src/api/blob.ts
+++ b/packages/firestore/src/api/blob.ts
@@ -15,11 +15,9 @@
  * limitations under the License.
  */
 
-import { Bytes } from '../../exp/index';
+import { Bytes, Compat } from '../../exp/index';
 import { isBase64Available } from '../platform/base64';
 import { Code, FirestoreError } from '../util/error';
-
-import { Compat } from './compat';
 
 /** Helper function to assert Uint8Array is available at runtime. */
 function assertUint8ArrayAvailable(): void {

--- a/packages/firestore/src/api/database.ts
+++ b/packages/firestore/src/api/database.ts
@@ -98,7 +98,8 @@ import {
   runTransaction,
   Transaction as ExpTransaction,
   WriteBatch as ExpWriteBatch,
-  AbstractUserDataWriter
+  AbstractUserDataWriter,
+  Compat
 } from '../../exp/index'; // import from the exp public API
 import { DatabaseId } from '../core/database_info';
 import { UntypedFirestoreDataConverter } from '../lite/user_data_reader';
@@ -115,7 +116,6 @@ import {
 import { setLogLevel as setClientLogLevel } from '../util/log';
 
 import { Blob } from './blob';
-import { Compat } from './compat';
 import {
   CompleteFn,
   ErrorFn,

--- a/packages/firestore/src/api/field_path.ts
+++ b/packages/firestore/src/api/field_path.ts
@@ -17,10 +17,8 @@
 
 import { FieldPath as PublicFieldPath } from '@firebase/firestore-types';
 
-import { FieldPath as ExpFieldPath } from '../../exp/index';
+import { FieldPath as ExpFieldPath, Compat } from '../../exp/index';
 import { FieldPath as InternalFieldPath } from '../model/path';
-
-import { Compat } from './compat';
 
 // The objects that are a part of this API are exposed to third-parties as
 // compiled javascript so we want to flag our private members with a leading

--- a/packages/firestore/src/api/field_value.ts
+++ b/packages/firestore/src/api/field_value.ts
@@ -23,10 +23,9 @@ import {
   deleteField,
   FieldValue as FieldValue1,
   increment,
-  serverTimestamp
+  serverTimestamp,
+  Compat
 } from '../../exp/index';
-
-import { Compat } from './compat';
 
 export class FieldValue
   extends Compat<FieldValue1>

--- a/packages/firestore/src/exp/reference_impl.ts
+++ b/packages/firestore/src/exp/reference_impl.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { Compat } from '../api/compat';
+import { Compat } from '../lite/compat';
 import {
   CompleteFn,
   ErrorFn,

--- a/packages/firestore/src/exp/reference_impl.ts
+++ b/packages/firestore/src/exp/reference_impl.ts
@@ -15,7 +15,6 @@
  * limitations under the License.
  */
 
-import { Compat } from '../lite/compat';
 import {
   CompleteFn,
   ErrorFn,
@@ -35,6 +34,7 @@ import {
 import { newQueryForPath, Query as InternalQuery } from '../core/query';
 import { ViewSnapshot } from '../core/view_snapshot';
 import { Bytes } from '../lite/bytes';
+import { Compat } from '../lite/compat';
 import { FieldPath } from '../lite/field_path';
 import { validateHasExplicitOrderByForLimitToLast } from '../lite/query';
 import {

--- a/packages/firestore/src/lite/compat.ts
+++ b/packages/firestore/src/lite/compat.ts
@@ -20,6 +20,8 @@
  * contains a reference to the API type in the firestore-exp API. All internal
  * code unwraps these references, which allows us to only use firestore-exp
  * types in the SDK.
+ *
+ * @internal
  */
 export abstract class Compat<T> {
   constructor(readonly _delegate: T) {}

--- a/packages/firestore/src/lite/query.ts
+++ b/packages/firestore/src/lite/query.ts
@@ -15,7 +15,6 @@
  * limitations under the License.
  */
 
-import { Compat } from './compat';
 import { DatabaseId } from '../core/database_info';
 import {
   findFilterOperator,
@@ -53,6 +52,7 @@ import {
   valueDescription
 } from '../util/input_validation';
 
+import { Compat } from './compat';
 import { FieldPath } from './field_path';
 import { DocumentReference, Query } from './reference';
 import { DocumentSnapshot, fieldPathFromArgument } from './snapshot';

--- a/packages/firestore/src/lite/query.ts
+++ b/packages/firestore/src/lite/query.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { Compat } from '../api/compat';
+import { Compat } from './compat';
 import { DatabaseId } from '../core/database_info';
 import {
   findFilterOperator,

--- a/packages/firestore/src/lite/reference.ts
+++ b/packages/firestore/src/lite/reference.ts
@@ -15,7 +15,6 @@
  * limitations under the License.
  */
 
-import { Compat } from './compat';
 import {
   newQueryForCollectionGroup,
   newQueryForPath,
@@ -33,6 +32,7 @@ import {
 } from '../util/input_validation';
 import { AutoId } from '../util/misc';
 
+import { Compat } from './compat';
 import { FirebaseFirestore } from './database';
 import { FieldPath } from './field_path';
 import { FirestoreDataConverter } from './snapshot';

--- a/packages/firestore/src/lite/reference.ts
+++ b/packages/firestore/src/lite/reference.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { Compat } from '../api/compat';
+import { Compat } from './compat';
 import {
   newQueryForCollectionGroup,
   newQueryForPath,

--- a/packages/firestore/src/lite/reference_impl.ts
+++ b/packages/firestore/src/lite/reference_impl.ts
@@ -20,7 +20,7 @@ import {
   SetOptions as PublicSetOptions
 } from '@firebase/firestore-types';
 
-import { Compat } from '../api/compat';
+import { Compat } from './compat';
 import { hasLimitToLast } from '../core/query';
 import { Document } from '../model/document';
 import { DeleteMutation, Precondition } from '../model/mutation';

--- a/packages/firestore/src/lite/reference_impl.ts
+++ b/packages/firestore/src/lite/reference_impl.ts
@@ -20,7 +20,6 @@ import {
   SetOptions as PublicSetOptions
 } from '@firebase/firestore-types';
 
-import { Compat } from './compat';
 import { hasLimitToLast } from '../core/query';
 import { Document } from '../model/document';
 import { DeleteMutation, Precondition } from '../model/mutation';
@@ -34,6 +33,7 @@ import { ByteString } from '../util/byte_string';
 import { cast } from '../util/input_validation';
 
 import { Bytes } from './bytes';
+import { Compat } from './compat';
 import { getDatastore } from './components';
 import { FirebaseFirestore } from './database';
 import { FieldPath } from './field_path';

--- a/packages/firestore/src/lite/snapshot.ts
+++ b/packages/firestore/src/lite/snapshot.ts
@@ -15,12 +15,12 @@
  * limitations under the License.
  */
 
-import { Compat } from './compat';
 import { Document } from '../model/document';
 import { DocumentKey } from '../model/document_key';
 import { FieldPath as InternalFieldPath } from '../model/path';
 import { arrayEquals } from '../util/misc';
 
+import { Compat } from './compat';
 import { FirebaseFirestore } from './database';
 import { FieldPath } from './field_path';
 import {

--- a/packages/firestore/src/lite/snapshot.ts
+++ b/packages/firestore/src/lite/snapshot.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { Compat } from '../api/compat';
+import { Compat } from './compat';
 import { Document } from '../model/document';
 import { DocumentKey } from '../model/document_key';
 import { FieldPath as InternalFieldPath } from '../model/path';

--- a/packages/firestore/src/lite/transaction.ts
+++ b/packages/firestore/src/lite/transaction.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { Compat } from '../api/compat';
+import { Compat } from './compat';
 import { Transaction as InternalTransaction } from '../core/transaction';
 import { TransactionRunner } from '../core/transaction_runner';
 import { Document, MaybeDocument, NoDocument } from '../model/document';

--- a/packages/firestore/src/lite/transaction.ts
+++ b/packages/firestore/src/lite/transaction.ts
@@ -15,7 +15,6 @@
  * limitations under the License.
  */
 
-import { Compat } from './compat';
 import { Transaction as InternalTransaction } from '../core/transaction';
 import { TransactionRunner } from '../core/transaction_runner';
 import { Document, MaybeDocument, NoDocument } from '../model/document';
@@ -24,6 +23,7 @@ import { newAsyncQueue } from '../util/async_queue_impl';
 import { cast } from '../util/input_validation';
 import { Deferred } from '../util/promise';
 
+import { Compat } from './compat';
 import { getDatastore } from './components';
 import { FirebaseFirestore } from './database';
 import { FieldPath } from './field_path';

--- a/packages/firestore/src/lite/user_data_reader.ts
+++ b/packages/firestore/src/lite/user_data_reader.ts
@@ -21,7 +21,6 @@ import {
   SetOptions
 } from '@firebase/firestore-types';
 
-import { Compat } from './compat';
 import { ParseContext } from '../api/parse_context';
 import { DatabaseId } from '../core/database_info';
 import { DocumentKey } from '../model/document_key';
@@ -59,6 +58,7 @@ import { isPlainObject, valueDescription } from '../util/input_validation';
 import { Dict, forEach, isEmpty } from '../util/obj';
 
 import { Bytes } from './bytes';
+import { Compat } from './compat';
 import { FirebaseFirestore } from './database';
 import { FieldPath } from './field_path';
 import { FieldValue } from './field_value';

--- a/packages/firestore/src/lite/user_data_reader.ts
+++ b/packages/firestore/src/lite/user_data_reader.ts
@@ -21,7 +21,7 @@ import {
   SetOptions
 } from '@firebase/firestore-types';
 
-import { Compat } from '../api/compat';
+import { Compat } from './compat';
 import { ParseContext } from '../api/parse_context';
 import { DatabaseId } from '../core/database_info';
 import { DocumentKey } from '../model/document_key';

--- a/packages/firestore/src/lite/write_batch.ts
+++ b/packages/firestore/src/lite/write_batch.ts
@@ -15,12 +15,12 @@
  * limitations under the License.
  */
 
-import { Compat } from './compat';
 import { DeleteMutation, Mutation, Precondition } from '../model/mutation';
 import { invokeCommitRpc } from '../remote/datastore';
 import { Code, FirestoreError } from '../util/error';
 import { cast } from '../util/input_validation';
 
+import { Compat } from './compat';
 import { getDatastore } from './components';
 import { FirebaseFirestore } from './database';
 import { FieldPath } from './field_path';

--- a/packages/firestore/src/lite/write_batch.ts
+++ b/packages/firestore/src/lite/write_batch.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { Compat } from '../api/compat';
+import { Compat } from './compat';
 import { DeleteMutation, Mutation, Precondition } from '../model/mutation';
 import { invokeCommitRpc } from '../remote/datastore';
 import { Code, FirestoreError } from '../util/error';


### PR DESCRIPTION
Changes:

- export compat FieldValue and FieldPath from firestore-compat
- export `Compat` from exp, so `instanceof` works correctly across packages
  - This is a stopgap solution till we implement the interop proposal for all packages. 