### PR TITLE
[Auth] Update compat layer credential interception; add webdriver tests

### DIFF
--- a/packages-exp/auth-compat-exp/package.json
+++ b/packages-exp/auth-compat-exp/package.json
@@ -25,7 +25,8 @@
     "test:browser:integration": "karma start --single-run --integration",
     "test:node": "ts-node -O '{\"module\": \"commonjs\", \"target\": \"es6\"}' scripts/run_node_tests.ts",
     "test:node:integration": "ts-node -O '{\"module\": \"commonjs\", \"target\": \"es6\"}' scripts/run_node_tests.ts --integration",
-    "test:integration": "run-s test:browser:integration test:node:integration"
+    "test:webdriver": "rollup -c test/integration/webdriver/static/rollup.config.js && ts-node -O '{\"module\": \"commonjs\", \"target\": \"es6\"}' scripts/run_node_tests.ts --webdriver",
+    "test:integration": "run-s test:browser:integration test:node:integration test:webdriver"
   },
   "peerDependencies": {
     "@firebase/app-compat": "0.x"
@@ -41,8 +42,8 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "@firebase/app-compat": "0.x",
-    "rollup": "2.35.1",
     "@rollup/plugin-json": "4.1.0",
+    "rollup": "^2.35.1",
     "rollup-plugin-replace": "2.2.0",
     "rollup-plugin-typescript2": "0.29.0",
     "typescript": "4.2.2"

--- a/packages-exp/auth-compat-exp/scripts/run_node_tests.ts
+++ b/packages-exp/auth-compat-exp/scripts/run_node_tests.ts
@@ -33,13 +33,14 @@ const nyc = resolve(__dirname, '../../../node_modules/.bin/nyc');
 const mocha = resolve(__dirname, '../../../node_modules/.bin/mocha');
 
 process.env.TS_NODE_COMPILER_OPTIONS = '{"module":"commonjs", "target": "es6"}';
+process.env.COMPAT_LAYER = 'true';
 
 let testConfig = ['src/**/*.test.ts'];
 
 if (argv.integration) {
   testConfig = ['test/integration/flows/**.test.ts'];
 } else if (argv.webdriver) {
-  testConfig = ['../auth-exp/test/integration/webdriver/anonymous.test.ts', '--delay'];
+  testConfig = ['../auth-exp/test/integration/webdriver/*.test.ts', '--delay'];
 }
 
 let args = [

--- a/packages-exp/auth-compat-exp/scripts/run_node_tests.ts
+++ b/packages-exp/auth-compat-exp/scripts/run_node_tests.ts
@@ -39,7 +39,7 @@ let testConfig = ['src/**/*.test.ts'];
 if (argv.integration) {
   testConfig = ['test/integration/flows/**.test.ts'];
 } else if (argv.webdriver) {
-  testConfig = ['test/integration/webdriver/**.test.ts', '--delay'];
+  testConfig = ['../auth-exp/test/integration/webdriver/anonymous.test.ts', '--delay'];
 }
 
 let args = [

--- a/packages-exp/auth-compat-exp/src/auth.ts
+++ b/packages-exp/auth-compat-exp/src/auth.ts
@@ -34,7 +34,7 @@ import {
   convertConfirmationResult,
   convertCredential
 } from './user_credential';
-import { unwrap, Wrapper } from './wrap';
+import { ReverseWrapper, unwrap, Wrapper } from './wrap';
 
 const _assert: typeof exp._assert = exp._assert;
 
@@ -45,6 +45,7 @@ export class Auth
   constructor(readonly app: FirebaseApp, provider: Provider<'auth-exp'>) {
     if (provider.isInitialized()) {
       this.auth = provider.getImmediate() as exp.AuthImpl;
+      this.linkUnderlyingAuth();
       return;
     }
 
@@ -89,6 +90,7 @@ export class Auth
     }) as exp.AuthImpl;
 
     this.auth._updateErrorMap(exp.debugErrorMap);
+    this.linkUnderlyingAuth();
   }
 
   get emulatorConfig(): compat.EmulatorConfig | null {
@@ -329,6 +331,9 @@ export class Auth
   }
   _delete(): Promise<void> {
     return this.auth._delete();
+  }
+  private linkUnderlyingAuth(): void {
+    (this.auth as unknown as ReverseWrapper<Auth>).wrapped = () => this;
   }
 }
 

--- a/packages-exp/auth-compat-exp/src/auth.ts
+++ b/packages-exp/auth-compat-exp/src/auth.ts
@@ -219,7 +219,9 @@ export class Auth
         break;
       case Persistence.LOCAL:
         // Not using isIndexedDBAvailable() since it only checks if indexedDB is defined.
-        const isIndexedDBFullySupported = await exp._getInstance<exp.PersistenceInternal>(exp.indexedDBLocalPersistence)._isAvailable();
+        const isIndexedDBFullySupported = await exp
+          ._getInstance<exp.PersistenceInternal>(exp.indexedDBLocalPersistence)
+          ._isAvailable();
         converted = isIndexedDBFullySupported
           ? exp.indexedDBLocalPersistence
           : exp.browserLocalPersistence;
@@ -333,7 +335,7 @@ export class Auth
     return this.auth._delete();
   }
   private linkUnderlyingAuth(): void {
-    (this.auth as unknown as ReverseWrapper<Auth>).wrapped = () => this;
+    ((this.auth as unknown) as ReverseWrapper<Auth>).wrapped = () => this;
   }
 }
 

--- a/packages-exp/auth-compat-exp/src/auth.ts
+++ b/packages-exp/auth-compat-exp/src/auth.ts
@@ -219,7 +219,7 @@ export class Auth
         break;
       case Persistence.LOCAL:
         // Not using isIndexedDBAvailable() since it only checks if indexedDB is defined.
-        const isIndexedDBFullySupported = await (exp.indexedDBLocalPersistence as exp.PersistenceInternal)._isAvailable();
+        const isIndexedDBFullySupported = await exp._getInstance<exp.PersistenceInternal>(exp.indexedDBLocalPersistence)._isAvailable();
         converted = isIndexedDBFullySupported
           ? exp.indexedDBLocalPersistence
           : exp.browserLocalPersistence;

--- a/packages-exp/auth-compat-exp/src/user_credential.ts
+++ b/packages-exp/auth-compat-exp/src/user_credential.ts
@@ -78,7 +78,10 @@ function credentialFromObject(
     return null;
   }
 
-  let provider: Pick<typeof exp.OAuthProvider, 'credentialFromResult' | 'credentialFromError'>;
+  let provider: Pick<
+    typeof exp.OAuthProvider,
+    'credentialFromResult' | 'credentialFromError'
+  >;
   switch (providerId) {
     case exp.ProviderId.GOOGLE:
       provider = exp.GoogleAuthProvider;
@@ -130,7 +133,9 @@ function credentialFromObject(
       });
   }
 
-  return object instanceof FirebaseError ? provider.credentialFromError(object) : provider.credentialFromResult(object);
+  return object instanceof FirebaseError
+    ? provider.credentialFromError(object)
+    : provider.credentialFromResult(object);
 }
 
 export async function convertCredential(

--- a/packages-exp/auth-compat-exp/src/user_credential.ts
+++ b/packages-exp/auth-compat-exp/src/user_credential.ts
@@ -42,7 +42,7 @@ function modifyError(auth: exp.Auth, e: FirebaseError): void {
     const mfaErr = e as compat.MultiFactorError;
     mfaErr.resolver = new MultiFactorResolver(
       auth,
-      exp.getMultiFactorResolver(auth, e as any)
+      exp.getMultiFactorResolver(auth, e as exp.MultiFactorError)
     );
   } else if (response) {
     const credential = credentialFromObject(e);
@@ -120,7 +120,7 @@ function credentialFromObject(
       }
       // TODO(avolkovi): uncomment this and get it working with SAML & OIDC
       if (pendingToken) {
-        if (providerId.indexOf('saml.') == 0) {
+        if (providerId.startsWith('saml.')) {
           return exp.SAMLAuthCredential._create(providerId, pendingToken);
         } else {
           // OIDC and non-default providers excluding Twitter.

--- a/packages-exp/auth-compat-exp/src/wrap.ts
+++ b/packages-exp/auth-compat-exp/src/wrap.ts
@@ -15,10 +15,20 @@
  * limitations under the License.
  */
 
+/** Forward direction wrapper from Compat --unwrap-> Exp */
 export interface Wrapper<T> {
   unwrap(): T;
 }
 
+/** Reverse direction wrapper from Exp --wrapped--> Compat */
+export interface ReverseWrapper<T> {
+  wrapped(): T;
+}
+
 export function unwrap<T>(object: unknown): T {
   return (object as Wrapper<T>).unwrap();
+}
+
+export function wrapped<T>(object: unknown): T {
+  return (object as ReverseWrapper<T>).wrapped();
 }

--- a/packages-exp/auth-compat-exp/test/integration/webdriver/static/anonymous.js
+++ b/packages-exp/auth-compat-exp/test/integration/webdriver/static/anonymous.js
@@ -16,6 +16,5 @@
  */
 
 export async function anonymousSignIn() {
-  console.error('hi');
-  return firebase.auth().signInAnonymously();
+  return compat.auth().signInAnonymously();
 }

--- a/packages-exp/auth-compat-exp/test/integration/webdriver/static/anonymous.js
+++ b/packages-exp/auth-compat-exp/test/integration/webdriver/static/anonymous.js
@@ -1,0 +1,21 @@
+/**
+ * @license
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export async function anonymousSignIn() {
+  console.error('hi');
+  return firebase.auth().signInAnonymously();
+}

--- a/packages-exp/auth-compat-exp/test/integration/webdriver/static/core.js
+++ b/packages-exp/auth-compat-exp/test/integration/webdriver/static/core.js
@@ -1,0 +1,43 @@
+/**
+ * @license
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { clearPersistence } from './persistence';
+
+export function reset() {
+  return clearPersistence();
+}
+
+export function authInit() {
+  return new Promise(resolve => {
+    firebase.auth().onAuthStateChanged(user => {
+      console.error('Init resolution', user);
+      resolve();
+    });
+  });
+}
+
+export async function userSnap() {
+  console.error('User snap', firebase.auth().currentUser);
+  return firebase.auth().currentUser;
+}
+
+export async function authSnap() {
+  return firebase.auth();
+}
+
+export function signOut() {
+  return firebase.auth().signOut();
+}

--- a/packages-exp/auth-compat-exp/test/integration/webdriver/static/core.js
+++ b/packages-exp/auth-compat-exp/test/integration/webdriver/static/core.js
@@ -22,22 +22,30 @@ export function reset() {
 
 export function authInit() {
   return new Promise(resolve => {
-    firebase.auth().onAuthStateChanged(user => {
-      console.error('Init resolution', user);
+    compat.auth().onAuthStateChanged(user => {
       resolve();
     });
   });
 }
 
+export function legacyAuthInit() {
+  return new Promise(resolve => {
+    legacyAuth.onAuthStateChanged(() => resolve());
+  });
+}
+
 export async function userSnap() {
-  console.error('User snap', firebase.auth().currentUser);
-  return firebase.auth().currentUser;
+  return compat.auth().currentUser;
+}
+
+export async function legacyUserSnap() {
+  return legacyAuth.currentUser;
 }
 
 export async function authSnap() {
-  return firebase.auth();
+  return compat.auth();
 }
 
 export function signOut() {
-  return firebase.auth().signOut();
+  return compat.auth().signOut();
 }

--- a/packages-exp/auth-compat-exp/test/integration/webdriver/static/email.js
+++ b/packages-exp/auth-compat-exp/test/integration/webdriver/static/email.js
@@ -1,0 +1,22 @@
+/**
+ * @license
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const TEST_PASSWORD = 'password';
+
+export function createUser(email) {
+  return firebase.auth().createUserWithEmailAndPassword(email, TEST_PASSWORD);
+}

--- a/packages-exp/auth-compat-exp/test/integration/webdriver/static/email.js
+++ b/packages-exp/auth-compat-exp/test/integration/webdriver/static/email.js
@@ -18,5 +18,5 @@
 const TEST_PASSWORD = 'password';
 
 export function createUser(email) {
-  return firebase.auth().createUserWithEmailAndPassword(email, TEST_PASSWORD);
+  return compat.auth().createUserWithEmailAndPassword(email, TEST_PASSWORD);
 }

--- a/packages-exp/auth-compat-exp/test/integration/webdriver/static/index.html
+++ b/packages-exp/auth-compat-exp/test/integration/webdriver/static/index.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<!--
+  type=module makes browers treat it as an ES6 module and enforces strict mode. This helps catch
+  some errors in the test (e.g. extending frozen objects or accidentally creating global variables).
+-->
+<script type="module" src="dist/bundle.js"></script>
+<h1>Compatibility layer tests</h1>

--- a/packages-exp/auth-compat-exp/test/integration/webdriver/static/index.js
+++ b/packages-exp/auth-compat-exp/test/integration/webdriver/static/index.js
@@ -15,31 +15,63 @@
  * limitations under the License.
  */
 
-// import * as redirect from './redirect';
+import * as redirect from './redirect';
 import firebase from '@firebase/app-compat';
 import '@firebase/auth-compat';
 import * as anonymous from './anonymous';
 import * as core from './core';
-// import * as popup from './popup';
+import * as popup from './popup';
 import * as email from './email';
-// import * as persistence from './persistence';
-// import { initializeApp } from '@firebase/app-exp';
-// import { getAuth, useAuthEmulator } from '@firebase/auth-exp';
+import * as persistence from './persistence';
 
 window.core = core;
 window.anonymous = anonymous;
-// window.redirect = redirect;
-// window.popup = popup;
+window.redirect = redirect;
+window.popup = popup;
 window.email = email;
-// window.persistence = persistence;
+window.persistence = persistence;
 
-// window.auth = null;
+window.compat = null;
+window.legacyAuth = null;
 
 // The config and emulator URL are injected by the test. The test framework
 // calls this function after that injection.
 window.startAuth = async () => {
-  console.warn('Starting auth...');
+  // Make sure we haven't confused our firebase with the old firebase
+  if (!firebase.SDK_VERSION.startsWith('0.9')) {
+    throw new Error('Using legacy SDK version instead of compat version ' + firebase.SDK_VERSION);
+  }
   firebase.initializeApp(firebaseConfig);
   firebase.auth().useEmulator(emulatorUrl);
-  window.firebase = firebase;
+  window.compat = firebase;
 };
+
+
+window.startLegacySDK = async persistence => {
+  return new Promise((resolve, reject) => {
+    const appScript = document.createElement('script');
+    // TODO: Find some way to make the tests work without Internet.
+    appScript.src = 'https://www.gstatic.com/firebasejs/8.3.0/firebase-app.js';
+    appScript.onerror = reject;
+    document.head.appendChild(appScript);
+
+    const authScript = document.createElement('script');
+    authScript.src =
+      'https://www.gstatic.com/firebasejs/8.3.0/firebase-auth.js';
+    authScript.onerror = reject;
+    authScript.onload = function () {
+      window.firebase.initializeApp(firebaseConfig);
+      // Make sure the firebase variable here is the legacy SDK
+      if (window.firebase.SDK_VERSION !== '8.3.0') {
+        reject(new Error('Not using correct legacy version; using ' + window.firebase.SDK_VERSION));
+      }
+      const legacyAuth = window.firebase.auth();
+      legacyAuth.useEmulator(emulatorUrl);
+      legacyAuth.setPersistence(persistence.toLowerCase());
+      window.legacyAuth = legacyAuth;
+      resolve();
+    };
+    document.head.appendChild(authScript);
+  });
+};
+

--- a/packages-exp/auth-compat-exp/test/integration/webdriver/static/index.js
+++ b/packages-exp/auth-compat-exp/test/integration/webdriver/static/index.js
@@ -1,0 +1,45 @@
+/**
+ * @license
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// import * as redirect from './redirect';
+import firebase from '@firebase/app-compat';
+import '@firebase/auth-compat';
+import * as anonymous from './anonymous';
+import * as core from './core';
+// import * as popup from './popup';
+import * as email from './email';
+// import * as persistence from './persistence';
+// import { initializeApp } from '@firebase/app-exp';
+// import { getAuth, useAuthEmulator } from '@firebase/auth-exp';
+
+window.core = core;
+window.anonymous = anonymous;
+// window.redirect = redirect;
+// window.popup = popup;
+window.email = email;
+// window.persistence = persistence;
+
+// window.auth = null;
+
+// The config and emulator URL are injected by the test. The test framework
+// calls this function after that injection.
+window.startAuth = async () => {
+  console.warn('Starting auth...');
+  firebase.initializeApp(firebaseConfig);
+  firebase.auth().useEmulator(emulatorUrl);
+  window.firebase = firebase;
+};

--- a/packages-exp/auth-compat-exp/test/integration/webdriver/static/index.js
+++ b/packages-exp/auth-compat-exp/test/integration/webdriver/static/index.js
@@ -39,13 +39,15 @@ window.legacyAuth = null;
 window.startAuth = async () => {
   // Make sure we haven't confused our firebase with the old firebase
   if (!firebase.SDK_VERSION.startsWith('0.9')) {
-    throw new Error('Using legacy SDK version instead of compat version ' + firebase.SDK_VERSION);
+    throw new Error(
+      'Using legacy SDK version instead of compat version ' +
+        firebase.SDK_VERSION
+    );
   }
   firebase.initializeApp(firebaseConfig);
   firebase.auth().useEmulator(emulatorUrl);
   window.compat = firebase;
 };
-
 
 window.startLegacySDK = async persistence => {
   return new Promise((resolve, reject) => {
@@ -63,7 +65,12 @@ window.startLegacySDK = async persistence => {
       window.firebase.initializeApp(firebaseConfig);
       // Make sure the firebase variable here is the legacy SDK
       if (window.firebase.SDK_VERSION !== '8.3.0') {
-        reject(new Error('Not using correct legacy version; using ' + window.firebase.SDK_VERSION));
+        reject(
+          new Error(
+            'Not using correct legacy version; using ' +
+              window.firebase.SDK_VERSION
+          )
+        );
       }
       const legacyAuth = window.firebase.auth();
       legacyAuth.useEmulator(emulatorUrl);
@@ -74,4 +81,3 @@ window.startLegacySDK = async persistence => {
     document.head.appendChild(authScript);
   });
 };
-

--- a/packages-exp/auth-compat-exp/test/integration/webdriver/static/persistence.js
+++ b/packages-exp/auth-compat-exp/test/integration/webdriver/static/persistence.js
@@ -25,9 +25,14 @@ const sessionStorage = window.sessionStorage;
 export async function clearPersistence() {
   sessionStorage.clear();
   localStorage.clear();
-  return dbPromise(indexedDB.deleteDatabase(INDEXED_DB_NAME)).catch(
-    () => undefined
-  );
+  // HACK: Deleting databases in Firefox sometimes take a few seconds. Let's just return early.
+  return withTimeout(
+    1000,
+    dbPromise(indexedDB.deleteDatabase(INDEXED_DB_NAME))
+  ).catch(e => {
+    console.error(e);
+    return;
+  });
 }
 
 export async function localStorageSnap() {
@@ -62,6 +67,22 @@ export async function indexedDBSnap() {
     result[key] = value;
   }
   return result;
+}
+
+export async function setPersistenceMemory() {
+  return compat.auth().setPersistence('none');
+}
+
+export async function setPersistenceSession() {
+  return compat.auth().setPersistence('session');
+}
+
+export async function setPersistenceLocalStorage() {
+  return compat.auth().setPersistence('local');
+}
+
+export async function setPersistenceIndexedDB() {
+  return compat.auth().setPersistence('local');
 }
 
 // Mock functions for testing edge cases
@@ -110,4 +131,13 @@ function dbPromise(dbRequest) {
       reject(dbRequest.error || 'blocked');
     });
   });
+}
+
+function withTimeout(ms, promise) {
+  return Promise.race([
+    new Promise((_, reject) =>
+      setTimeout(() => reject(new Error('operation timed out')), ms)
+    ),
+    promise
+  ]);
 }

--- a/packages-exp/auth-compat-exp/test/integration/webdriver/static/persistence.js
+++ b/packages-exp/auth-compat-exp/test/integration/webdriver/static/persistence.js
@@ -1,0 +1,113 @@
+/**
+ * @license
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const INDEXED_DB_NAME = 'firebaseLocalStorageDb';
+
+// Save these variables for test utils use below, since some tests may delete them.
+const indexedDB = window.indexedDB;
+const localStorage = window.localStorage;
+const sessionStorage = window.sessionStorage;
+
+export async function clearPersistence() {
+  sessionStorage.clear();
+  localStorage.clear();
+  return dbPromise(indexedDB.deleteDatabase(INDEXED_DB_NAME)).catch(
+    () => undefined
+  );
+}
+
+export async function localStorageSnap() {
+  return dumpStorage(localStorage);
+}
+export async function localStorageSet(dict) {
+  setInStorage(localStorage, dict);
+}
+export async function sessionStorageSnap() {
+  return dumpStorage(sessionStorage);
+}
+export async function sessionStorageSet(dict) {
+  setInStorage(sessionStorage, dict);
+}
+
+const DB_OBJECTSTORE_NAME = 'firebaseLocalStorage';
+
+export async function indexedDBSnap() {
+  const db = await dbPromise(indexedDB.open(INDEXED_DB_NAME));
+  let entries;
+  try {
+    const store = db
+      .transaction([DB_OBJECTSTORE_NAME], 'readonly')
+      .objectStore(DB_OBJECTSTORE_NAME);
+    entries = await dbPromise(store.getAll());
+  } catch {
+    // May throw if DB_OBJECTSTORE_NAME is never created -- this is normal.
+    return {};
+  }
+  const result = {};
+  for (const { fbase_key: key, value } of entries) {
+    result[key] = value;
+  }
+  return result;
+}
+
+// Mock functions for testing edge cases
+export async function makeIndexedDBReadonly() {
+  IDBObjectStore.prototype.add = IDBObjectStore.prototype.put = () => {
+    return {
+      error: 'add/put is disabled for test purposes',
+      readyState: 'done',
+      addEventListener(event, listener) {
+        if (event === 'error') {
+          void Promise.resolve({}).then(listener);
+        }
+      }
+    };
+  };
+}
+
+function dumpStorage(storage) {
+  const result = {};
+  for (let i = 0; i < storage.length; i++) {
+    const key = storage.key(i);
+    result[key] = JSON.parse(storage.getItem(key));
+  }
+  return result;
+}
+
+function setInStorage(storage, dict) {
+  for (const [key, value] of Object.entries(dict)) {
+    if (value === undefined) {
+      storage.removeItem(key);
+    } else {
+      storage.setItem(key, JSON.stringify(value));
+    }
+  }
+}
+
+function dbPromise(dbRequest) {
+  return new Promise((resolve, reject) => {
+    dbRequest.addEventListener('success', () => {
+      resolve(dbRequest.result);
+    });
+    dbRequest.addEventListener('error', () => {
+      reject(dbRequest.error);
+    });
+    dbRequest.addEventListener('blocked', () => {
+      reject(dbRequest.error || 'blocked');
+    });
+  });
+}

--- a/packages-exp/auth-compat-exp/test/integration/webdriver/static/popup.js
+++ b/packages-exp/auth-compat-exp/test/integration/webdriver/static/popup.js
@@ -1,0 +1,85 @@
+/**
+ * @license
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// These functions are a little funky: WebDriver relies on callbacks to
+// pass data back to the main Node process. Because of that setup, we can't
+// return the popup tasks as pending promises as they won't resolve until
+// the WebDriver is allowed to do other stuff. Instead, we'll store the
+// promises in variables and provide a way to retrieve them later, unblocking
+// the WebDriver process.
+let popupPromise = null;
+let popupCred = null;
+let errorCred = null;
+
+export function idpPopup(optProvider) {
+  const provider = optProvider
+    ? new compat.auth.OAuthProvider(optProvider)
+    : new compat.auth.GoogleAuthProvider();
+  popupPromise = compat.auth().signInWithPopup(provider);
+}
+
+export function idpReauthPopup() {
+  popupPromise = compat.auth().currentUser.reauthenticateWithPopup(
+    new compat.auth.GoogleAuthProvider()
+  );
+}
+
+export function idpLinkPopup() {
+  popupPromise = compat.auth().currentUser.linkWithPopup(new compat.auth.GoogleAuthProvider());
+}
+
+export function popupResult() {
+  return popupPromise;
+}
+
+export async function generateCredentialFromResult() {
+  const result = await popupPromise;
+  popupCred = result.credential;
+  return popupCred;
+}
+
+export async function signInWithPopupCredential() {
+  return compat.auth().signInWithCredential(popupCred);
+}
+
+export async function linkWithErrorCredential() {
+  await compat.auth().currentUser.linkWithCredential(errorCred);
+}
+
+// These below are not technically popup functions but they're helpers for
+// the popup tests.
+
+export function createFakeGoogleUser(email) {
+  return compat.auth().signInWithCredential(
+    compat.auth.GoogleAuthProvider.credential(
+      `{"sub": "__${email}__", "email": "${email}", "email_verified": true}`
+    )
+  );
+}
+
+export async function tryToSignInUnverified(email) {
+  try {
+    await compat.auth().signInWithCredential(
+      compat.auth.FacebookAuthProvider.credential(
+        `{"sub": "$$${email}$$", "email": "${email}", "email_verified": false}`
+      )
+    );
+  } catch (e) {
+    errorCred = e.credential;
+    throw e;
+  }
+}

--- a/packages-exp/auth-compat-exp/test/integration/webdriver/static/popup.js
+++ b/packages-exp/auth-compat-exp/test/integration/webdriver/static/popup.js
@@ -33,13 +33,15 @@ export function idpPopup(optProvider) {
 }
 
 export function idpReauthPopup() {
-  popupPromise = compat.auth().currentUser.reauthenticateWithPopup(
-    new compat.auth.GoogleAuthProvider()
-  );
+  popupPromise = compat
+    .auth()
+    .currentUser.reauthenticateWithPopup(new compat.auth.GoogleAuthProvider());
 }
 
 export function idpLinkPopup() {
-  popupPromise = compat.auth().currentUser.linkWithPopup(new compat.auth.GoogleAuthProvider());
+  popupPromise = compat
+    .auth()
+    .currentUser.linkWithPopup(new compat.auth.GoogleAuthProvider());
 }
 
 export function popupResult() {
@@ -64,20 +66,24 @@ export async function linkWithErrorCredential() {
 // the popup tests.
 
 export function createFakeGoogleUser(email) {
-  return compat.auth().signInWithCredential(
-    compat.auth.GoogleAuthProvider.credential(
-      `{"sub": "__${email}__", "email": "${email}", "email_verified": true}`
-    )
-  );
+  return compat
+    .auth()
+    .signInWithCredential(
+      compat.auth.GoogleAuthProvider.credential(
+        `{"sub": "__${email}__", "email": "${email}", "email_verified": true}`
+      )
+    );
 }
 
 export async function tryToSignInUnverified(email) {
   try {
-    await compat.auth().signInWithCredential(
-      compat.auth.FacebookAuthProvider.credential(
-        `{"sub": "$$${email}$$", "email": "${email}", "email_verified": false}`
-      )
-    );
+    await compat
+      .auth()
+      .signInWithCredential(
+        compat.auth.FacebookAuthProvider.credential(
+          `{"sub": "$$${email}$$", "email": "${email}", "email_verified": false}`
+        )
+      );
   } catch (e) {
     errorCred = e.credential;
     throw e;

--- a/packages-exp/auth-compat-exp/test/integration/webdriver/static/redirect.js
+++ b/packages-exp/auth-compat-exp/test/integration/webdriver/static/redirect.js
@@ -26,11 +26,17 @@ export function idpRedirect(optProvider) {
 }
 
 export function idpReauthRedirect() {
-  compat.auth().currentUser.reauthenticateWithRedirect(new compat.auth.GoogleAuthProvider());
+  compat
+    .auth()
+    .currentUser.reauthenticateWithRedirect(
+      new compat.auth.GoogleAuthProvider()
+    );
 }
 
 export function idpLinkRedirect() {
-  compat.auth().currentUser.linkWithRedirect(new compat.auth.GoogleAuthProvider());
+  compat
+    .auth()
+    .currentUser.linkWithRedirect(new compat.auth.GoogleAuthProvider());
 }
 
 export function redirectResult() {
@@ -55,20 +61,24 @@ export async function linkWithErrorCredential() {
 // the redirect tests.
 
 export function createFakeGoogleUser(email) {
-  return compat.auth().signInWithCredential(
-    compat.auth.GoogleAuthProvider.credential(
-      `{"sub": "__${email}__", "email": "${email}", "email_verified": true}`
-    )
-  );
+  return compat
+    .auth()
+    .signInWithCredential(
+      compat.auth.GoogleAuthProvider.credential(
+        `{"sub": "__${email}__", "email": "${email}", "email_verified": true}`
+      )
+    );
 }
 
 export async function tryToSignInUnverified(email) {
   try {
-    await compat.auth().signInWithCredential(
-      compat.auth.FacebookAuthProvider.credential(
-        `{"sub": "$$${email}$$", "email": "${email}", "email_verified": false}`
-      )
-    );
+    await compat
+      .auth()
+      .signInWithCredential(
+        compat.auth.FacebookAuthProvider.credential(
+          `{"sub": "$$${email}$$", "email": "${email}", "email_verified": false}`
+        )
+      );
   } catch (e) {
     errorCred = e.credential;
     throw e;

--- a/packages-exp/auth-compat-exp/test/integration/webdriver/static/redirect.js
+++ b/packages-exp/auth-compat-exp/test/integration/webdriver/static/redirect.js
@@ -1,0 +1,76 @@
+/**
+ * @license
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+let redirectCred = null;
+let errorCred = null;
+
+export function idpRedirect(optProvider) {
+  const provider = optProvider
+    ? new compat.auth.OAuthProvider(optProvider)
+    : new compat.auth.GoogleAuthProvider();
+  compat.auth().signInWithRedirect(provider);
+}
+
+export function idpReauthRedirect() {
+  compat.auth().currentUser.reauthenticateWithRedirect(new compat.auth.GoogleAuthProvider());
+}
+
+export function idpLinkRedirect() {
+  compat.auth().currentUser.linkWithRedirect(new compat.auth.GoogleAuthProvider());
+}
+
+export function redirectResult() {
+  return compat.auth().getRedirectResult();
+}
+
+export async function generateCredentialFromRedirectResultAndStore() {
+  const result = await compat.auth().getRedirectResult();
+  redirectCred = result.credential;
+  return redirectCred;
+}
+
+export async function signInWithRedirectCredential() {
+  return compat.auth().signInWithCredential(redirectCred);
+}
+
+export async function linkWithErrorCredential() {
+  await compat.auth().currentUser.linkWithCredential(errorCred);
+}
+
+// These below are not technically redirect functions but they're helpers for
+// the redirect tests.
+
+export function createFakeGoogleUser(email) {
+  return compat.auth().signInWithCredential(
+    compat.auth.GoogleAuthProvider.credential(
+      `{"sub": "__${email}__", "email": "${email}", "email_verified": true}`
+    )
+  );
+}
+
+export async function tryToSignInUnverified(email) {
+  try {
+    await compat.auth().signInWithCredential(
+      compat.auth.FacebookAuthProvider.credential(
+        `{"sub": "$$${email}$$", "email": "${email}", "email_verified": false}`
+      )
+    );
+  } catch (e) {
+    errorCred = e.credential;
+    throw e;
+  }
+}

--- a/packages-exp/auth-compat-exp/test/integration/webdriver/static/rollup.config.js
+++ b/packages-exp/auth-compat-exp/test/integration/webdriver/static/rollup.config.js
@@ -1,0 +1,28 @@
+/**
+ * @license
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { nodeResolve } from '@rollup/plugin-node-resolve';
+
+// This is run from the auth-exp package.json
+export default {
+  input: ['test/integration/webdriver/static/index.js'],
+  output: {
+    file: 'test/integration/webdriver/static/dist/bundle.js',
+    format: 'esm'
+  },
+  plugins: [nodeResolve()]
+};

--- a/packages-exp/auth-exp/internal/index.ts
+++ b/packages-exp/auth-exp/internal/index.ts
@@ -38,7 +38,7 @@ export { DefaultConfig, AuthImpl, _castAuth } from '../src/core/auth/auth_impl';
 export { ClientPlatform, _getClientVersion } from '../src/core/util/version';
 
 export { _generateEventId } from '../src/core/util/event_id';
-export { TaggedWithTokenResponse} from '../src/model/id_token';
+export { TaggedWithTokenResponse } from '../src/model/id_token';
 export { _fail, _assert } from '../src/core/util/assert';
 export { AuthPopup } from '../src/platform_browser/util/popup';
 export { _getRedirectResult } from '../src/platform_browser/strategies/redirect';

--- a/packages-exp/auth-exp/internal/index.ts
+++ b/packages-exp/auth-exp/internal/index.ts
@@ -44,3 +44,4 @@ export { AuthPopup } from '../src/platform_browser/util/popup';
 export { _getRedirectResult } from '../src/platform_browser/strategies/redirect';
 export { cordovaPopupRedirectResolver } from '../src/platform_cordova/popup_redirect/popup_redirect';
 export { FetchProvider } from '../src/core/util/fetch_provider';
+export { SAMLAuthCredential } from '../src/core/credentials/saml';

--- a/packages-exp/auth-exp/internal/index.ts
+++ b/packages-exp/auth-exp/internal/index.ts
@@ -38,7 +38,7 @@ export { DefaultConfig, AuthImpl, _castAuth } from '../src/core/auth/auth_impl';
 export { ClientPlatform, _getClientVersion } from '../src/core/util/version';
 
 export { _generateEventId } from '../src/core/util/event_id';
-
+export { TaggedWithTokenResponse} from '../src/model/id_token';
 export { _fail, _assert } from '../src/core/util/assert';
 export { AuthPopup } from '../src/platform_browser/util/popup';
 export { _getRedirectResult } from '../src/platform_browser/strategies/redirect';

--- a/packages-exp/auth-exp/src/mfa/mfa_resolver.ts
+++ b/packages-exp/auth-exp/src/mfa/mfa_resolver.ts
@@ -19,7 +19,8 @@ import {
   Auth,
   MultiFactorResolver,
   OperationType,
-  UserCredential
+  UserCredential,
+  MultiFactorError
 } from '../model/public_types';
 
 import { _castAuth } from '../core/auth/auth_impl';
@@ -28,7 +29,7 @@ import { UserCredentialImpl } from '../core/user/user_credential_impl';
 import { _assert, _fail } from '../core/util/assert';
 import { UserCredentialInternal } from '../model/user';
 import { MultiFactorAssertionImpl } from './mfa_assertion';
-import { MultiFactorError } from './mfa_error';
+import { MultiFactorError as MultiFactorErrorInternal } from './mfa_error';
 import { MultiFactorInfoImpl } from './mfa_info';
 import { MultiFactorSessionImpl } from './mfa_session';
 
@@ -44,7 +45,7 @@ export class MultiFactorResolverImpl implements MultiFactorResolver {
   /** @internal */
   static _fromError(
     authExtern: Auth,
-    error: MultiFactorError
+    error: MultiFactorErrorInternal
   ): MultiFactorResolverImpl {
     const auth = _castAuth(authExtern);
     const hints = (error.serverResponse.mfaInfo || []).map(enrollment =>
@@ -124,7 +125,7 @@ export function getMultiFactorResolver(
   auth: Auth,
   error: MultiFactorError
 ): MultiFactorResolver {
-  const errorInternal = error as MultiFactorError;
+  const errorInternal = error as MultiFactorErrorInternal;
   _assert(error.operationType, auth, AuthErrorCode.ARGUMENT_ERROR);
   _assert(
     errorInternal.serverResponse?.mfaPendingCredential,

--- a/packages-exp/auth-exp/test/integration/webdriver/persistence.test.ts
+++ b/packages-exp/auth-exp/test/integration/webdriver/persistence.test.ts
@@ -129,7 +129,7 @@ browserDescribe('WebDriver persistence test', driver => {
       expect(await driver.getUserSnapshot()).to.contain({ uid });
     });
 
-    it.only('fall back to in-memory if neither indexedDB or localStorage is present', async () => {
+    it('fall back to in-memory if neither indexedDB or localStorage is present', async () => {
       await driver.webDriver.navigate().refresh();
       // Simulate browsers that do not support indexedDB or localStorage.
       await driver.webDriver.executeScript(

--- a/packages-exp/auth-exp/test/integration/webdriver/persistence.test.ts
+++ b/packages-exp/auth-exp/test/integration/webdriver/persistence.test.ts
@@ -129,7 +129,7 @@ browserDescribe('WebDriver persistence test', driver => {
       expect(await driver.getUserSnapshot()).to.contain({ uid });
     });
 
-    it('fall back to in-memory if neither indexedDB or localStorage is present', async () => {
+    it.only('fall back to in-memory if neither indexedDB or localStorage is present', async () => {
       await driver.webDriver.navigate().refresh();
       // Simulate browsers that do not support indexedDB or localStorage.
       await driver.webDriver.executeScript(
@@ -137,7 +137,6 @@ browserDescribe('WebDriver persistence test', driver => {
       );
       await driver.injectConfigAndInitAuth();
       await driver.waitForAuthInit();
-
       const cred: UserCredential = await driver.call(
         AnonFunction.SIGN_IN_ANONYMOUSLY
       );
@@ -279,6 +278,14 @@ browserDescribe('WebDriver persistence test', driver => {
     });
 
     it('migrates user when switching from indexedDB to localStorage', async () => {
+      // This test only works in the modular SDK: the compat package does not
+      // make the distinction between indexedDB and local storage (both are just
+      // 'local').
+      if (driver.isCompatLayer()) {
+        console.warn('Skipping indexedDB to local migration in compat test');
+        return;
+      }
+
       await driver.call(AnonFunction.SIGN_IN_ANONYMOUSLY);
       const user = await driver.getUserSnapshot();
 

--- a/packages-exp/auth-exp/test/integration/webdriver/util/auth_driver.ts
+++ b/packages-exp/auth-exp/test/integration/webdriver/util/auth_driver.ts
@@ -217,4 +217,8 @@ export class AuthDriver {
     await this.webDriver.close();
     return this.selectMainWindow();
   }
+
+  isCompatLayer(): boolean {
+    return process.env.COMPAT_LAYER === 'true';
+  }
 }


### PR DESCRIPTION
The compat layer uses the existing webdriver tests here; we swap out the JS source served to the browser to use the compat layer (keeping the same function names)