### PR TITLE
Compat and @exp class for DataSnapshot

### DIFF
--- a/packages/database/src/api/DataSnapshot.ts
+++ b/packages/database/src/api/DataSnapshot.ts
@@ -17,28 +17,20 @@
 
 import { validateArgCount, validateCallback } from '@firebase/util';
 import { validatePathString } from '../core/util/validation';
-import { Path } from '../core/util/Path';
-import { PRIORITY_INDEX } from '../core/snap/indexes/PriorityIndex';
-import { Node } from '../core/snap/Node';
 import { Reference } from './Reference';
-import { Index } from '../core/snap/indexes/Index';
-import { ChildrenNode } from '../core/snap/ChildrenNode';
+import { DataSnapshot as ExpDataSnapshot } from '../exp/DataSnapshot';
+
+// TODO(databaseexp): Import Compat from @firebase/util
+export interface Compat<T> {
+  readonly _delegate: T;
+}
 
 /**
  * Class representing a firebase data snapshot.  It wraps a SnapshotNode and
  * surfaces the public methods (val, forEach, etc.) we want to expose.
  */
-export class DataSnapshot {
-  /**
-   * @param node_ A SnapshotNode to wrap.
-   * @param ref_ The ref of the location this snapshot came from.
-   * @param index_ The iteration order for this snapshot
-   */
-  constructor(
-    private readonly node_: Node,
-    private readonly ref_: Reference,
-    private readonly index_: Index
-  ) {}
+export class DataSnapshot implements Compat<ExpDataSnapshot> {
+  constructor(readonly _delegate: ExpDataSnapshot) {}
 
   /**
    * Retrieves the snapshot contents as JSON.  Returns null if the snapshot is
@@ -48,7 +40,7 @@ export class DataSnapshot {
    */
   val(): unknown {
     validateArgCount('DataSnapshot.val', 0, 0, arguments.length);
-    return this.node_.val();
+    return this._delegate.val();
   }
 
   /**
@@ -58,7 +50,7 @@ export class DataSnapshot {
    */
   exportVal(): unknown {
     validateArgCount('DataSnapshot.exportVal', 0, 0, arguments.length);
-    return this.node_.val(true);
+    return this._delegate.exportVal();
   }
 
   // Do not create public documentation. This is intended to make JSON serialization work but is otherwise unnecessary
@@ -66,7 +58,7 @@ export class DataSnapshot {
   toJSON(): unknown {
     // Optional spacer argument is unnecessary because we're depending on recursion rather than stringifying the content
     validateArgCount('DataSnapshot.toJSON', 0, 1, arguments.length);
-    return this.exportVal();
+    return this._delegate.toJSON();
   }
 
   /**
@@ -76,7 +68,7 @@ export class DataSnapshot {
    */
   exists(): boolean {
     validateArgCount('DataSnapshot.exists', 0, 0, arguments.length);
-    return !this.node_.isEmpty();
+    return this._delegate.exists();
   }
 
   /**
@@ -90,14 +82,7 @@ export class DataSnapshot {
     // Ensure the childPath is a string (can be a number)
     childPathString = String(childPathString);
     validatePathString('DataSnapshot.child', 1, childPathString, false);
-
-    const childPath = new Path(childPathString);
-    const childRef = this.ref_.child(childPath);
-    return new DataSnapshot(
-      this.node_.getChild(childPath),
-      childRef,
-      PRIORITY_INDEX
-    );
+    return new DataSnapshot(this._delegate.child(childPathString));
   }
 
   /**
@@ -109,9 +94,7 @@ export class DataSnapshot {
   hasChild(childPathString: string): boolean {
     validateArgCount('DataSnapshot.hasChild', 1, 1, arguments.length);
     validatePathString('DataSnapshot.hasChild', 1, childPathString, false);
-
-    const childPath = new Path(childPathString);
-    return !this.node_.getChild(childPath).isEmpty();
+    return this._delegate.hasChild(childPathString);
   }
 
   /**
@@ -121,9 +104,7 @@ export class DataSnapshot {
    */
   getPriority(): string | number | null {
     validateArgCount('DataSnapshot.getPriority', 0, 0, arguments.length);
-
-    // typecast here because we never return deferred values or internal priorities (MAX_PRIORITY)
-    return this.node_.getPriority().val() as string | number | null;
+    return this._delegate.priority;
   }
 
   /**
@@ -134,21 +115,12 @@ export class DataSnapshot {
    * @return True if forEach was canceled by action returning true for
    * one of the child nodes.
    */
-  forEach(action: (d: DataSnapshot) => boolean | void): boolean {
+  forEach(action: (snapshot: DataSnapshot) => boolean | void): boolean {
     validateArgCount('DataSnapshot.forEach', 1, 1, arguments.length);
     validateCallback('DataSnapshot.forEach', 1, action, false);
-
-    if (this.node_.isLeafNode()) {
-      return false;
-    }
-
-    const childrenNode = this.node_ as ChildrenNode;
-    // Sanitize the return value to a boolean. ChildrenNode.forEachChild has a weird return type...
-    return !!childrenNode.forEachChild(this.index_, (key, node) => {
-      return action(
-        new DataSnapshot(node, this.ref_.child(key), PRIORITY_INDEX)
-      );
-    });
+    return this._delegate.forEach(expDataSnapshot =>
+      action(new DataSnapshot(expDataSnapshot))
+    );
   }
 
   /**
@@ -157,16 +129,11 @@ export class DataSnapshot {
    */
   hasChildren(): boolean {
     validateArgCount('DataSnapshot.hasChildren', 0, 0, arguments.length);
-
-    if (this.node_.isLeafNode()) {
-      return false;
-    } else {
-      return !this.node_.isEmpty();
-    }
+    return this._delegate.hasChildren();
   }
 
   get key() {
-    return this.ref_.getKey();
+    return this._delegate.key;
   }
 
   /**
@@ -175,8 +142,7 @@ export class DataSnapshot {
    */
   numChildren(): number {
     validateArgCount('DataSnapshot.numChildren', 0, 0, arguments.length);
-
-    return this.node_.numChildren();
+    return this._delegate.size;
   }
 
   /**
@@ -185,8 +151,7 @@ export class DataSnapshot {
    */
   getRef(): Reference {
     validateArgCount('DataSnapshot.ref', 0, 0, arguments.length);
-
-    return this.ref_;
+    return new Reference(this._delegate.ref._repo, this._delegate.ref._path);
   }
 
   get ref() {

--- a/packages/database/src/core/view/Event.ts
+++ b/packages/database/src/core/view/Event.ts
@@ -18,7 +18,7 @@
 import { stringify } from '@firebase/util';
 import { Path } from '../util/Path';
 import { EventRegistration } from './EventRegistration';
-import { DataSnapshot } from '../../api/DataSnapshot';
+import { DataSnapshot as ExpDataSnapshot } from '../../exp/DataSnapshot';
 
 /**
  * Encapsulates the data needed to raise an event
@@ -54,7 +54,7 @@ export class DataEvent implements Event {
   constructor(
     public eventType: EventType,
     public eventRegistration: EventRegistration,
-    public snapshot: DataSnapshot,
+    public snapshot: ExpDataSnapshot,
     public prevName?: string | null
   ) {}
 
@@ -62,11 +62,11 @@ export class DataEvent implements Event {
    * @inheritDoc
    */
   getPath(): Path {
-    const ref = this.snapshot.getRef();
+    const ref = this.snapshot.ref;
     if (this.eventType === 'value') {
-      return ref.path;
+      return ref._path;
     } else {
-      return ref.getParent().path;
+      return ref.parent._path;
     }
   }
 

--- a/packages/database/src/exp/DataSnapshot.ts
+++ b/packages/database/src/exp/DataSnapshot.ts
@@ -17,7 +17,7 @@
 
 import { child, Reference } from './Reference';
 import { Node } from '../core/snap/Node';
-import { Index } from '../core/snap/indexes';
+import { Index } from '../core/snap/indexes/Index';
 import { Path } from '../core/util/Path';
 import { PRIORITY_INDEX } from '../core/snap/indexes/PriorityIndex';
 import { ChildrenNode } from '../core/snap/ChildrenNode';

--- a/packages/database/src/exp/DataSnapshot.ts
+++ b/packages/database/src/exp/DataSnapshot.ts
@@ -15,54 +15,90 @@
  * limitations under the License.
  */
 
-import { Reference } from './Reference';
+import { child, Reference } from './Reference';
+import { Node } from '../core/snap/Node';
+import { Index } from '../core/snap/indexes';
+import { Path } from '../core/util/Path';
+import { PRIORITY_INDEX } from '../core/snap/indexes/PriorityIndex';
+import { ChildrenNode } from '../core/snap/ChildrenNode';
 
 export class DataSnapshot {
-  private constructor() {}
-  priority: string | number | null;
-  size: number;
-  key: string | null;
-  ref: Reference;
+  /**
+   * @param _node A SnapshotNode to wrap.
+   * @param ref The ref of the location this snapshot came from.
+   * @param _index The iteration order for this snapshot
+   */
+  constructor(
+    readonly _node: Node,
+    readonly ref: Reference,
+    readonly _index: Index
+  ) {}
+
+  get priority(): string | number | null {
+    // typecast here because we never return deferred values or internal priorities (MAX_PRIORITY)
+    return this._node.getPriority().val() as string | number | null;
+  }
+
+  get key(): string | null {
+    return this.ref.key;
+  }
+
+  get size(): number {
+    return this._node.numChildren();
+  }
 
   child(path: string): DataSnapshot {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    return {} as any;
+    const childPath = new Path(path);
+    const childRef = child(this.ref, path);
+    return new DataSnapshot(
+      this._node.getChild(childPath),
+      childRef,
+      PRIORITY_INDEX
+    );
   }
 
   exists(): boolean {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    return {} as any;
+    return !this._node.isEmpty();
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   exportVal(): any {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    return {} as any;
+    return this._node.val(true);
   }
 
   forEach(action: (child: DataSnapshot) => boolean | void): boolean {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    return {} as any;
+    if (this._node.isLeafNode()) {
+      return false;
+    }
+
+    const childrenNode = this._node as ChildrenNode;
+    // Sanitize the return value to a boolean. ChildrenNode.forEachChild has a weird return type...
+    return !!childrenNode.forEachChild(this._index, (key, node) => {
+      return action(
+        new DataSnapshot(node, child(this.ref, key), PRIORITY_INDEX)
+      );
+    });
   }
 
   hasChild(path: string): boolean {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    return {} as any;
+    const childPath = new Path(path);
+    return !this._node.getChild(childPath).isEmpty();
   }
 
   hasChildren(): boolean {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    return {} as any;
+    if (this._node.isLeafNode()) {
+      return false;
+    } else {
+      return !this._node.isEmpty();
+    }
   }
 
   toJSON(): object | null {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    return {} as any;
+    return this.exportVal();
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   val(): any {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    return {} as any;
+    return this._node.val();
   }
 }

--- a/packages/database/src/exp/Reference.ts
+++ b/packages/database/src/exp/Reference.ts
@@ -16,15 +16,34 @@
  */
 
 import { Query } from './Query';
+import { Repo } from '../core/Repo';
+import {
+  Path,
+  pathChild,
+  pathGetBack,
+  pathIsEmpty,
+  pathParent
+} from '../core/util/Path';
 
 export class Reference extends Query {
-  private constructor() {
+  root: Reference;
+
+  constructor(readonly _repo: Repo, readonly _path: Path) {
     super();
   }
 
-  key: string | null;
-  parent: Reference | null;
-  root: Reference;
+  get key(): string | null {
+    if (pathIsEmpty(this._path)) {
+      return null;
+    } else {
+      return pathGetBack(this._path);
+    }
+  }
+
+  get parent(): Reference | null {
+    const parentPath = pathParent(this._path);
+    return parentPath === null ? null : new Reference(this._repo, parentPath);
+  }
 }
 
 export interface OnDisconnect {
@@ -43,8 +62,7 @@ export interface ThenableReference
     Pick<Promise<Reference>, 'then' | 'catch'> {}
 
 export function child(ref: Reference, path: string): Reference {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  return {} as any;
+  return new Reference(ref._repo, pathChild(ref._path, path));
 }
 
 export function onDisconnect(ref: Reference): OnDisconnect {

--- a/packages/database/src/exp/Reference.ts
+++ b/packages/database/src/exp/Reference.ts
@@ -62,6 +62,7 @@ export interface ThenableReference
     Pick<Promise<Reference>, 'then' | 'catch'> {}
 
 export function child(ref: Reference, path: string): Reference {
+  // TODO: Accept Compat class
   return new Reference(ref._repo, pathChild(ref._path, path));
 }
 

--- a/packages/database/test/datasnapshot.test.ts
+++ b/packages/database/test/datasnapshot.test.ts
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+import { DataSnapshot as ExpDataSnapshot } from '../src/exp/DataSnapshot';
+import { Reference as ExpReference } from '../src/exp/Reference';
 import { expect } from 'chai';
 import { nodeFromJSON } from '../src/core/snap/nodeFromJSON';
 import { PRIORITY_INDEX } from '../src/core/snap/indexes/PriorityIndex';
@@ -26,7 +28,13 @@ describe('DataSnapshot Tests', () => {
   /** @return {!DataSnapshot} */
   const snapshotForJSON = function (json) {
     const dummyRef = getRandomNode() as Reference;
-    return new DataSnapshot(nodeFromJSON(json), dummyRef, PRIORITY_INDEX);
+    return new DataSnapshot(
+      new ExpDataSnapshot(
+        nodeFromJSON(json),
+        new ExpReference(dummyRef.repo, dummyRef.path),
+        PRIORITY_INDEX
+      )
+    );
   };
 
   it('DataSnapshot.hasChildren() works.', () => {


### PR DESCRIPTION
This PR creates the Compat class for DataSnapshot, and also adds the `@exp` class at the same time (mostly by moving code). 

There are a bunch of seemingly unrelated changes, but most of them are meant to remove internal references to the old legacy DataSnapshot from `/core`.

The next step would be to do this same change for Reference, since I only converted the code paths that I needed for the conversion.

One extra thing: The current SDK accepts numbers and string in some places for child keys, but this is not documented. I dropped accepting numbers for now.