### PR TITLE
[Auth] Fix an issue with the UI interop

### DIFF
--- a/packages-exp/auth-compat-exp/demo/rollup.config.js
+++ b/packages-exp/auth-compat-exp/demo/rollup.config.js
@@ -15,7 +15,6 @@
  * limitations under the License.
  */
 
-import commonjs from '@rollup/plugin-commonjs';
 import json from '@rollup/plugin-json';
 import resolveModule from '@rollup/plugin-node-resolve';
 import sourcemaps from 'rollup-plugin-sourcemaps';
@@ -30,7 +29,6 @@ const plugins = [
     include: ['../**/*.ts']
   }),
   json(),
-  commonjs()
 ];
 
 /**

--- a/packages-exp/auth-compat-exp/demo/rollup.config.js
+++ b/packages-exp/auth-compat-exp/demo/rollup.config.js
@@ -28,7 +28,7 @@ const plugins = [
     typescript,
     include: ['../**/*.ts']
   }),
-  json(),
+  json()
 ];
 
 /**

--- a/packages-exp/auth-exp/src/core/auth/auth_impl.test.ts
+++ b/packages-exp/auth-exp/src/core/auth/auth_impl.test.ts
@@ -85,11 +85,11 @@ describe('core/auth/auth_impl', () => {
 
     it('public version throws if the auth is mismatched', async () => {
       const auth2 = await testAuth();
-      Object.assign(auth2, { name: 'not-the-right-auth' });
+      Object.assign(auth2.config, { apiKey: 'not-the-right-auth' });
       const user = testUser(auth2, 'uid');
       await expect(auth.updateCurrentUser(user)).to.be.rejectedWith(
         FirebaseError,
-        'auth/argument-error'
+        'auth/invalid-user-token'
       );
     });
 

--- a/packages-exp/auth-exp/src/core/auth/auth_impl.ts
+++ b/packages-exp/auth-exp/src/core/auth/auth_impl.ts
@@ -296,15 +296,8 @@ export class AuthImpl implements AuthInternal, _FirebaseService {
   }
 
   async updateCurrentUser(userExtern: User | null): Promise<void> {
-    // The public updateCurrentUser method needs to make a copy of the user,
-    // and also needs to verify that the app matches
+    // The public updateCurrentUser method needs to make a copy of the user
     const user = userExtern as UserInternal | null;
-    _assert(
-      !user || user.auth.name === this.name,
-      this,
-      AuthErrorCode.ARGUMENT_ERROR
-    );
-
     return this._updateCurrentUser(user && user._clone());
   }
 

--- a/packages-exp/auth-exp/src/core/auth/auth_impl.ts
+++ b/packages-exp/auth-exp/src/core/auth/auth_impl.ts
@@ -300,7 +300,11 @@ export class AuthImpl implements AuthInternal, _FirebaseService {
     // and also check that the project matches
     const user = userExtern as UserInternal | null;
     if (user) {
-      _assert(user.auth.config.apiKey === this.config.apiKey, this, AuthErrorCode.INVALID_AUTH);
+      _assert(
+        user.auth.config.apiKey === this.config.apiKey,
+        this,
+        AuthErrorCode.INVALID_AUTH
+      );
     }
     return this._updateCurrentUser(user && user._clone(this));
   }

--- a/packages-exp/auth-exp/src/core/auth/auth_impl.ts
+++ b/packages-exp/auth-exp/src/core/auth/auth_impl.ts
@@ -296,9 +296,13 @@ export class AuthImpl implements AuthInternal, _FirebaseService {
   }
 
   async updateCurrentUser(userExtern: User | null): Promise<void> {
-    // The public updateCurrentUser method needs to make a copy of the user
+    // The public updateCurrentUser method needs to make a copy of the user,
+    // and also check that the project matches
     const user = userExtern as UserInternal | null;
-    return this._updateCurrentUser(user && user._clone());
+    if (user) {
+      _assert(user.auth.config.apiKey === this.config.apiKey, this, AuthErrorCode.INVALID_AUTH);
+    }
+    return this._updateCurrentUser(user && user._clone(this));
   }
 
   async _updateCurrentUser(user: User | null): Promise<void> {

--- a/packages-exp/auth-exp/src/core/user/user_impl.test.ts
+++ b/packages-exp/auth-exp/src/core/user/user_impl.test.ts
@@ -244,7 +244,7 @@ describe('core/user/user_impl', () => {
   });
 
   describe('_clone', () => {
-    it('copies the user to a new object', () => {
+    it('copies the user to a new object', async () => {
       const stsTokenManager = Object.assign(new StsTokenManager(), {
         accessToken: 'access-token',
         refreshToken: 'refresh-token',
@@ -263,10 +263,12 @@ describe('core/user/user_impl', () => {
         isAnonymous: true
       });
 
-      const copy = user._clone();
+      const newAuth = await testAuth();
+      const copy = user._clone(newAuth);
       expect(copy).not.to.eq(user);
       expect(copy.stsTokenManager).not.to.eq(user.stsTokenManager);
       expect(copy.toJSON()).to.eql(user.toJSON());
+      expect(copy.auth).to.eq(newAuth);
     });
   });
 });

--- a/packages-exp/auth-exp/src/core/user/user_impl.ts
+++ b/packages-exp/auth-exp/src/core/user/user_impl.ts
@@ -135,9 +135,10 @@ export class UserImpl implements UserInternal {
     this.stsTokenManager._assign(user.stsTokenManager);
   }
 
-  _clone(): UserInternal {
+  _clone(auth: AuthInternal): UserInternal {
     return new UserImpl({
       ...this,
+      auth,
       stsTokenManager: this.stsTokenManager._clone()
     });
   }

--- a/packages-exp/auth-exp/src/model/user.ts
+++ b/packages-exp/auth-exp/src/model/user.ts
@@ -75,7 +75,7 @@ export interface UserInternal extends User {
   ): Promise<void>;
 
   _assign(user: UserInternal): void;
-  _clone(): UserInternal;
+  _clone(auth: AuthInternal): UserInternal;
   _onReload: (cb: NextFn<APIUserInfo>) => void;
   _notifyReloadListener: NextFn<APIUserInfo>;
   _startProactiveRefresh: () => void;


### PR DESCRIPTION
The Closure SDK makes sure the user belongs to the project by checking the API key on the user and the auth object. We don't store the API key on the user in the new SDK so we were checking this using the app name. But it's a perfectly valid use case to pass users between apps on the same project, so this check was wrong.

This PR also removes an unused rollup plugin that was breaking the compat demo build.