### PR TITLE
Support default app in the modular SDK

### DIFF
--- a/packages-exp/analytics-exp/src/api.ts
+++ b/packages-exp/analytics-exp/src/api.ts
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 
-import { _getProvider, FirebaseApp } from '@firebase/app-exp';
+import { _getProvider, FirebaseApp, getApp } from '@firebase/app-exp';
 import {
   Analytics,
   AnalyticsCallOptions,
@@ -63,7 +63,7 @@ declare module '@firebase/component' {
  *
  * @param app - The FirebaseApp to use.
  */
-export function getAnalytics(app: FirebaseApp): Analytics {
+export function getAnalytics(app: FirebaseApp = getApp()): Analytics {
   app = getModularInstance(app);
   // Dependencies
   const analyticsProvider: Provider<'analytics-exp'> = _getProvider(

--- a/packages-exp/auth-exp/index.ts
+++ b/packages-exp/auth-exp/index.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { FirebaseApp, _getProvider } from '@firebase/app-exp';
+import { FirebaseApp, getApp, _getProvider } from '@firebase/app-exp';
 
 import { initializeAuth } from './src';
 import { registerAuth } from './src/core/auth/register';
@@ -118,7 +118,7 @@ export { PhoneMultiFactorGenerator } from './src/platform_browser/mfa/assertions
  *
  * @public
  */
-export function getAuth(app: FirebaseApp): Auth {
+export function getAuth(app: FirebaseApp = getApp()): Auth {
   const provider = _getProvider(app, 'auth-exp');
 
   if (provider.isInitialized()) {

--- a/packages-exp/functions-exp/src/api.ts
+++ b/packages-exp/functions-exp/src/api.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { _getProvider, FirebaseApp } from '@firebase/app-exp';
+import { _getProvider, FirebaseApp, getApp } from '@firebase/app-exp';
 import { FUNCTIONS_TYPE } from './constants';
 
 import { Provider } from '@firebase/component';
@@ -39,7 +39,7 @@ export * from './public-types';
  * @public
  */
 export function getFunctions(
-  app: FirebaseApp,
+  app: FirebaseApp = getApp(),
   regionOrCustomDomain: string = DEFAULT_REGION
 ): Functions {
   // Dependencies

--- a/packages-exp/installations-exp/src/api/get-installations.ts
+++ b/packages-exp/installations-exp/src/api/get-installations.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { FirebaseApp, _getProvider } from '@firebase/app-exp';
+import { FirebaseApp, getApp, _getProvider } from '@firebase/app-exp';
 import { FirebaseInstallations } from '../interfaces/public-types';
 
 /**
@@ -23,7 +23,9 @@ import { FirebaseInstallations } from '../interfaces/public-types';
  *
  * @public
  */
-export function getInstallations(app: FirebaseApp): FirebaseInstallations {
+export function getInstallations(
+  app: FirebaseApp = getApp()
+): FirebaseInstallations {
   const installationsImpl = _getProvider(
     app,
     'installations-exp'

--- a/packages-exp/messaging-exp/src/api.ts
+++ b/packages-exp/messaging-exp/src/api.ts
@@ -26,7 +26,7 @@ import {
 import { MessagingService } from './messaging-service';
 import { Provider } from '@firebase/component';
 import { deleteToken as _deleteToken } from './api/deleteToken';
-import { _getProvider, FirebaseApp } from '@firebase/app-exp';
+import { _getProvider, FirebaseApp, getApp } from '@firebase/app-exp';
 import { getToken as _getToken } from './api/getToken';
 import { onBackgroundMessage as _onBackgroundMessage } from './api/onBackgroundMessage';
 import { onMessage as _onMessage } from './api/onMessage';
@@ -39,7 +39,7 @@ import { getModularInstance } from '@firebase/util';
  *
  * @public
  */
-export function getMessaging(app: FirebaseApp): FirebaseMessaging {
+export function getMessaging(app: FirebaseApp = getApp()): FirebaseMessaging {
   app = getModularInstance(app);
   const messagingProvider: Provider<'messaging-exp'> = _getProvider(
     app,

--- a/packages-exp/performance-exp/src/index.ts
+++ b/packages-exp/performance-exp/src/index.ts
@@ -27,7 +27,8 @@ import {
   _registerComponent,
   _getProvider,
   registerVersion,
-  FirebaseApp
+  FirebaseApp,
+  getApp
 } from '@firebase/app-exp';
 import {
   InstanceFactory,
@@ -47,7 +48,9 @@ const DEFAULT_ENTRY_NAME = '[DEFAULT]';
  * @param app - The FirebaseApp to use.
  * @public
  */
-export function getPerformance(app: FirebaseApp): FirebasePerformance {
+export function getPerformance(
+  app: FirebaseApp = getApp()
+): FirebasePerformance {
   app = getModularInstance(app);
   const provider = _getProvider(app, 'performance-exp');
   const perfInstance = provider.getImmediate() as PerformanceController;

--- a/packages-exp/remote-config-exp/src/api.ts
+++ b/packages-exp/remote-config-exp/src/api.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { _getProvider, FirebaseApp } from '@firebase/app-exp';
+import { _getProvider, FirebaseApp, getApp } from '@firebase/app-exp';
 import {
   LogLevel as RemoteConfigLogLevel,
   RemoteConfig,
@@ -36,7 +36,7 @@ import { getModularInstance } from '@firebase/util';
  *
  * @public
  */
-export function getRemoteConfig(app: FirebaseApp): RemoteConfig {
+export function getRemoteConfig(app: FirebaseApp = getApp()): RemoteConfig {
   app = getModularInstance(app);
   const rcProvider = _getProvider(app, RC_COMPONENT_NAME);
   return rcProvider.getImmediate();

--- a/packages/database/src/exp/Database.ts
+++ b/packages/database/src/exp/Database.ts
@@ -16,7 +16,12 @@
  */
 
 // eslint-disable-next-line import/no-extraneous-dependencies
-import { _FirebaseService, _getProvider, FirebaseApp } from '@firebase/app-exp';
+import {
+  _FirebaseService,
+  _getProvider,
+  FirebaseApp,
+  getApp
+} from '@firebase/app-exp';
 import { FirebaseAuthInternalName } from '@firebase/auth-interop-types';
 import { Provider } from '@firebase/component';
 
@@ -115,7 +120,10 @@ export { ServerValue };
  * provided, the SDK connects to the default instance of the Firebase App.
  * @returns The `FirebaseDatabase` instance of the provided app.
  */
-export function getDatabase(app: FirebaseApp, url?: string): FirebaseDatabase {
+export function getDatabase(
+  app: FirebaseApp = getApp(),
+  url?: string
+): FirebaseDatabase {
   return _getProvider(app, 'database-exp').getImmediate({
     identifier: url
   }) as FirebaseDatabase;

--- a/packages/database/src/exp/Database.ts
+++ b/packages/database/src/exp/Database.ts
@@ -15,12 +15,12 @@
  * limitations under the License.
  */
 
-// eslint-disable-next-line import/no-extraneous-dependencies
 import {
   _FirebaseService,
   _getProvider,
   FirebaseApp,
   getApp
+  // eslint-disable-next-line import/no-extraneous-dependencies
 } from '@firebase/app-exp';
 import { FirebaseAuthInternalName } from '@firebase/auth-interop-types';
 import { Provider } from '@firebase/component';

--- a/packages/firestore/src/exp/database.ts
+++ b/packages/firestore/src/exp/database.ts
@@ -18,7 +18,8 @@
 import {
   _getProvider,
   _removeServiceInstance,
-  FirebaseApp
+  FirebaseApp,
+  getApp
   // eslint-disable-next-line import/no-extraneous-dependencies
 } from '@firebase/app-exp';
 import { FirebaseAuthInternalName } from '@firebase/auth-interop-types';
@@ -151,7 +152,7 @@ export function initializeFirestore(
  * instance is associated with.
  * @returns The `Firestore` instance of the provided app.
  */
-export function getFirestore(app: FirebaseApp): FirebaseFirestore {
+export function getFirestore(app: FirebaseApp = getApp()): FirebaseFirestore {
   return _getProvider(app, 'firestore-exp').getImmediate() as FirebaseFirestore;
 }
 

--- a/packages/firestore/src/lite/database.ts
+++ b/packages/firestore/src/lite/database.ts
@@ -18,7 +18,8 @@
 import {
   _getProvider,
   _removeServiceInstance,
-  FirebaseApp
+  FirebaseApp,
+  getApp
   // eslint-disable-next-line import/no-extraneous-dependencies
 } from '@firebase/app-exp';
 import { FirebaseAuthInternalName } from '@firebase/auth-interop-types';
@@ -205,7 +206,7 @@ export function initializeFirestore(
  * instance is associated with.
  * @returns The `Firestore` instance of the provided app.
  */
-export function getFirestore(app: FirebaseApp): FirebaseFirestore {
+export function getFirestore(app: FirebaseApp = getApp()): FirebaseFirestore {
   return _getProvider(
     app,
     'firestore/lite'

--- a/packages/storage/exp/api.ts
+++ b/packages/storage/exp/api.ts
@@ -17,7 +17,8 @@
 
 import {
   _getProvider,
-  FirebaseApp
+  FirebaseApp,
+  getApp
   // eslint-disable-next-line import/no-extraneous-dependencies
 } from '@firebase/app-exp';
 
@@ -290,7 +291,7 @@ export { StringFormat } from '../src/implementation/string';
  * @returns A Firebase StorageService instance.
  */
 export function getStorage(
-  app: FirebaseApp,
+  app: FirebaseApp = getApp(),
   bucketUrl?: string
 ): StorageService {
   app = getModularInstance(app);


### PR DESCRIPTION
Make `app` optional in `getFoo()` functions.
Implements the [proposal](https://docs.google.com/document/d/1iNBpkCKfPCTxKmVOctobCe-ljMzAVxQ8ViOl5gj0xug/edit?ts=605a5961)