### PR TITLE
[Auth] Restrict the ':' character in API key

### DIFF
--- a/packages-exp/auth-exp/src/core/auth/register.ts
+++ b/packages-exp/auth-exp/src/core/auth/register.ts
@@ -64,6 +64,8 @@ export function registerAuth(clientPlatform: ClientPlatform): void {
             AuthErrorCode.INVALID_API_KEY,
             { appName: app.name }
           );
+          // Auth domain is optional if IdP sign in isn't being used
+          _assert(!(authDomain?.includes(':')), AuthErrorCode.ARGUMENT_ERROR, {appName: app.name});
           const config: ConfigInternal = {
             apiKey,
             authDomain,

--- a/packages-exp/auth-exp/src/core/auth/register.ts
+++ b/packages-exp/auth-exp/src/core/auth/register.ts
@@ -65,7 +65,9 @@ export function registerAuth(clientPlatform: ClientPlatform): void {
             { appName: app.name }
           );
           // Auth domain is optional if IdP sign in isn't being used
-          _assert(!(authDomain?.includes(':')), AuthErrorCode.ARGUMENT_ERROR, {appName: app.name});
+          _assert(!authDomain?.includes(':'), AuthErrorCode.ARGUMENT_ERROR, {
+            appName: app.name
+          });
           const config: ConfigInternal = {
             apiKey,
             authDomain,

--- a/packages-exp/auth-exp/src/core/auth/register.ts
+++ b/packages-exp/auth-exp/src/core/auth/register.ts
@@ -59,7 +59,11 @@ export function registerAuth(clientPlatform: ClientPlatform): void {
         const app = container.getProvider('app-exp').getImmediate()!;
         const { apiKey, authDomain } = app.options;
         return (app => {
-          _assert(apiKey && !apiKey.includes(':'), AuthErrorCode.INVALID_API_KEY, { appName: app.name });
+          _assert(
+            apiKey && !apiKey.includes(':'),
+            AuthErrorCode.INVALID_API_KEY,
+            { appName: app.name }
+          );
           const config: ConfigInternal = {
             apiKey,
             authDomain,

--- a/packages-exp/auth-exp/src/core/auth/register.ts
+++ b/packages-exp/auth-exp/src/core/auth/register.ts
@@ -59,7 +59,7 @@ export function registerAuth(clientPlatform: ClientPlatform): void {
         const app = container.getProvider('app-exp').getImmediate()!;
         const { apiKey, authDomain } = app.options;
         return (app => {
-          _assert(apiKey, AuthErrorCode.INVALID_API_KEY, { appName: app.name });
+          _assert(apiKey && !apiKey.includes(':'), AuthErrorCode.INVALID_API_KEY, { appName: app.name });
           const config: ConfigInternal = {
             apiKey,
             authDomain,


### PR DESCRIPTION
This is to prevent potential collisions with app name in the persistence layer (as `:` is used as the separator). In practice this will only ever apply when using fake API key / app against the emulator as no actual API key has `:`.