### PR TITLE
fix dependencies

### DIFF
--- a/integration/compat-typings/package.json
+++ b/integration/compat-typings/package.json
@@ -7,7 +7,7 @@
     "test:ci": "node ../../scripts/run_tests_in_ci.js -s test"
   },
   "dependencies": {
-    "firebase-exp": "0.900.19"
+    "firebase-exp": "file:../../packages-exp/firebase-exp"
   },
   "devDependencies": {
     "typescript": "4.2.2"

--- a/packages-exp/auth-compat-exp/package.json
+++ b/packages-exp/auth-compat-exp/package.json
@@ -44,7 +44,7 @@
   "devDependencies": {
     "@firebase/app-compat": "0.x",
     "@rollup/plugin-json": "4.1.0",
-    "rollup": "^2.35.1",
+    "rollup": "2.35.1",
     "rollup-plugin-replace": "2.2.0",
     "rollup-plugin-typescript2": "0.29.0",
     "typescript": "4.2.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7471,6 +7471,27 @@ firebase-admin@9.4.2:
     "@google-cloud/firestore" "^4.5.0"
     "@google-cloud/storage" "^5.3.0"
 
+"firebase-exp@file:packages-exp/firebase-exp":
+  version "0.900.20"
+  dependencies:
+    "@firebase/analytics-compat" "0.0.900"
+    "@firebase/analytics-exp" "0.0.900"
+    "@firebase/app-compat" "0.0.900"
+    "@firebase/app-exp" "0.0.900"
+    "@firebase/auth-compat" "0.0.900"
+    "@firebase/auth-exp" "0.0.900"
+    "@firebase/database" "0.9.7"
+    "@firebase/firestore" "2.2.2"
+    "@firebase/functions-compat" "0.0.900"
+    "@firebase/functions-exp" "0.0.900"
+    "@firebase/messaging-compat" "0.0.900"
+    "@firebase/messaging-exp" "0.0.900"
+    "@firebase/performance-compat" "0.0.900"
+    "@firebase/performance-exp" "0.0.900"
+    "@firebase/remote-config-compat" "0.0.900"
+    "@firebase/remote-config-exp" "0.0.900"
+    "@firebase/storage" "0.4.6"
+
 firebase-functions@3.13.0:
   version "3.13.0"
   resolved "https://registry.npmjs.org/firebase-functions/-/firebase-functions-3.13.0.tgz#66278dbeb45f343a179814f2b1d95b383beec5e7"
@@ -15706,7 +15727,7 @@ tslib@^1.11.1, tslib@^1.13.0, tslib@^1.8.1, tslib@^1.9.0:
   resolved "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@^2.0.0:
+tslib@^2.0.0, tslib@^2.1.0:
   version "2.1.0"
   resolved "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz#da60860f1c2ecaa5703ab7d39bc05b6bf988b97a"
   integrity sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==


### PR DESCRIPTION
Point to `firebase-exp` using the project location for now because `firebase-exp` doesn't exist on npm and its version is not automatically bumped in dependencies as part of the exp release. Things will work again once it becomes `firebase`.