### PR TITLE
Make rules-unit-testing depend on @firebase/component directly

### DIFF
--- a/.changeset/thick-ties-hang.md
+++ b/.changeset/thick-ties-hang.md
@@ -1,0 +1,5 @@
+---
+'@firebase/rules-unit-testing': patch
+---
+
+Depend on @firebase/component directly to fix the use with Yarn Plug'n'Play

--- a/packages/rules-unit-testing/package.json
+++ b/packages/rules-unit-testing/package.json
@@ -21,6 +21,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "firebase": "8.3.2",
+    "@firebase/component": "0.3.1",
     "@firebase/logger": "0.2.6",
     "@firebase/util": "0.4.1",
     "request": "2.88.2"


### PR DESCRIPTION
Bug fix: Make @firebase/rules-unit-testing depend on @firebase/component directly so that @firebase/rules-unit-testing works correctly with Yarn Plug'n'Play (https://yarnpkg.com/advanced/rulebook#packages-should-only-ever-require-what-they-formally-list-in-their-dependencies).

Closes #4716.