### PR TITLE
Add pull_request trigger to lint workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,6 @@
 name: Lint All Packages
 
-on: push
+on: [push, pull_request]
 
 jobs:
   test:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,6 @@
 name: Lint All Packages
 
-on: [push, pull_request]
+on: pull_request
 
 jobs:
   test:


### PR DESCRIPTION
External contributors making PRs don't trigger the push trigger, but lint check is required for merge. I suggest running lint on both triggers and setting the PR version as the required check for merge.