### PR TITLE
Compat class for Reference

### DIFF
--- a/packages/database/exp/index.ts
+++ b/packages/database/exp/index.ts
@@ -67,7 +67,11 @@ export {
   refFromURL
 } from '../src/exp/Reference_impl';
 export { increment, serverTimestamp } from '../src/exp/ServerValue';
-export { runTransaction, TransactionOptions } from '../src/exp/Transaction';
+export {
+  runTransaction,
+  TransactionOptions,
+  TransactionResult
+} from '../src/exp/Transaction';
 
 declare module '@firebase/component' {
   interface NameServiceMapping {

--- a/packages/database/src/api/Database.ts
+++ b/packages/database/src/api/Database.ts
@@ -84,10 +84,10 @@ export class Database implements FirebaseService, Compat<ExpDatabase> {
     validateArgCount('database.ref', 0, 1, arguments.length);
     if (path instanceof Reference) {
       const childRef = refFromURL(this._delegate, path.toString());
-      return new Reference(this, childRef._path);
+      return new Reference(this, childRef);
     } else {
       const childRef = ref(this._delegate, path);
-      return new Reference(this, childRef._path);
+      return new Reference(this, childRef);
     }
   }
 
@@ -101,7 +101,7 @@ export class Database implements FirebaseService, Compat<ExpDatabase> {
     const apiName = 'database.refFromURL';
     validateArgCount(apiName, 1, 1, arguments.length);
     const childRef = refFromURL(this._delegate, url);
-    return new Reference(this, childRef._path);
+    return new Reference(this, childRef);
   }
 
   // Make individual repo go offline.

--- a/packages/database/src/exp/Database.ts
+++ b/packages/database/src/exp/Database.ts
@@ -33,7 +33,6 @@ import { newEmptyPath, pathIsEmpty } from '../core/util/Path';
 import { fatal, log } from '../core/util/util';
 import { validateUrl } from '../core/util/validation';
 
-import { Reference } from './Reference';
 import { ReferenceImpl } from './Reference_impl';
 
 /**
@@ -203,7 +202,7 @@ export class FirebaseDatabase implements _FirebaseService {
   _instanceStarted: boolean = false;
 
   /** Backing state for root_ */
-  private _rootInternal?: Reference;
+  private _rootInternal?: ReferenceImpl;
 
   constructor(private _repoInternal: Repo, readonly app: FirebaseApp) {}
 
@@ -219,7 +218,7 @@ export class FirebaseDatabase implements _FirebaseService {
     return this._repoInternal;
   }
 
-  get _root(): Reference {
+  get _root(): ReferenceImpl {
     if (!this._rootInternal) {
       this._rootInternal = new ReferenceImpl(this._repo, newEmptyPath());
     }

--- a/packages/database/test/helpers/util.ts
+++ b/packages/database/test/helpers/util.ts
@@ -25,6 +25,7 @@ import { Component, ComponentType } from '@firebase/component';
 
 import { Query, Reference } from '../../src/api/Reference';
 import { ConnectionTarget } from '../../src/api/test_access';
+import { Path } from '../../src/core/util/Path';
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 export const TEST_PROJECT = require('../../../../config/project.json');
@@ -140,13 +141,13 @@ export function shuffle(arr, randFn = Math.random) {
 let freshRepoId = 1;
 const activeFreshApps = [];
 
-export function getFreshRepo(path) {
+export function getFreshRepo(path: Path) {
   const app = firebase.initializeApp(
     { databaseURL: DATABASE_URL },
     'ISOLATED_REPO_' + freshRepoId++
   );
   activeFreshApps.push(app);
-  return (app as any).database().ref(path);
+  return (app as any).database().ref(path.toString());
 }
 
 export function getFreshRepoFromReference(ref) {

--- a/packages/database/test/query.test.ts
+++ b/packages/database/test/query.test.ts
@@ -767,6 +767,16 @@ describe('Query Tests', () => {
     expect(expected).to.equal(10);
   });
 
+  it('Raises snapshots synchronously', () => {
+    const node = getRandomNode() as Reference;
+    let newValue;
+    node.on('value', v => {
+      newValue = v.val();
+    });
+    node.set('foo');
+    expect(newValue).to.equal('foo');
+  });
+
   it('Set a limit of 5, add a bunch of nodes, ensure only last 5 items are sent from server.', async () => {
     const node = getRandomNode() as Reference;
     await node.set({});

--- a/packages/database/test/transaction.test.ts
+++ b/packages/database/test/transaction.test.ts
@@ -381,13 +381,16 @@ describe('Transaction Tests', () => {
     node.child('foo').set(0);
 
     expect(firstDone).to.equal(false);
+
+    // Wait for the `onComplete` callbacks to be invoked. This is no longer
+    // happening synchronously, as the underlying database@exp implementation
+    // uses promises.
+    await ea.promise;
+
     expect(secondDone).to.equal(true);
     expect(thirdRunCount).to.equal(2);
     // Note that the set actually raises two events, one overlaid on top of the original transaction value, and a
     // second one with the re-run value from the third transaction
-
-    await ea.promise;
-
     expect(nodeSnap.val()).to.deep.equal({ foo: 0, bar: 'second' });
   });
 

--- a/packages/database/test/transaction.test.ts
+++ b/packages/database/test/transaction.test.ts
@@ -16,6 +16,7 @@
  */
 
 import firebase from '@firebase/app';
+import { Deferred } from '@firebase/util';
 import { expect } from 'chai';
 
 import { Reference } from '../src/api/Reference';
@@ -34,7 +35,6 @@ import {
 } from './helpers/util';
 
 import '../index';
-import { Deferred } from '@firebase/util';
 
 describe('Transaction Tests', () => {
   // Tests that use hijackHash() should set restoreHash to the restore function
@@ -554,7 +554,7 @@ describe('Transaction Tests', () => {
 
   it('Update should not cancel unrelated transactions', async () => {
     const node = getRandomNode() as Reference;
-    let fooTransactionDone = false;
+    const fooTransactionDone = false;
     let barTransactionDone = false;
     restoreHash = hijackHash(() => {
       return 'foobar';

--- a/packages/database/test/transaction.test.ts
+++ b/packages/database/test/transaction.test.ts
@@ -34,6 +34,7 @@ import {
 } from './helpers/util';
 
 import '../index';
+import { Deferred } from '@firebase/util';
 
 describe('Transaction Tests', () => {
   // Tests that use hijackHash() should set restoreHash to the restore function
@@ -561,6 +562,8 @@ describe('Transaction Tests', () => {
 
     await node.child('foo').set(5);
 
+    const deferred = new Deferred<void>();
+
     // 'foo' gets overwritten in the update so the transaction gets cancelled.
     node.child('foo').transaction(
       old => {
@@ -569,7 +572,7 @@ describe('Transaction Tests', () => {
       (error, committed, snapshot) => {
         expect(error.message).to.equal('set');
         expect(committed).to.equal(false);
-        fooTransactionDone = true;
+        deferred.resolve();
       }
     );
 
@@ -595,7 +598,7 @@ describe('Transaction Tests', () => {
       }
     });
 
-    expect(fooTransactionDone).to.equal(true);
+    await deferred.promise;
     expect(barTransactionDone).to.equal(false);
     restoreHash();
     restoreHash = null;


### PR DESCRIPTION
One breaking change: The `onComplete` callback of a transaction is no longer invoked synchronously when transactions are aborted. I think this is such a subtle change that it won't break our users - they would have to rely on the timing of a write that takes place outside of the `runTransaction` function and the transaction callback.

OnDisconnect is still missing and is next.