### PR TITLE
Fix platform logging for exp packages

### DIFF
--- a/packages-exp/app-exp/src/constants.ts
+++ b/packages-exp/app-exp/src/constants.ts
@@ -21,17 +21,21 @@ import { name as analyticsCompatName } from '../../../packages-exp/analytics-com
 import { name as analyticsName } from '../../../packages-exp/analytics-exp/package.json';
 import { name as authName } from '../../../packages-exp/auth-exp/package.json';
 import { name as authCompatName } from '../../../packages-exp/auth-compat-exp/package.json';
-import { name as databaseName } from '../../../packages/database/package.json';
+import { name as databaseName } from '../../../packages/database/exp/package.json';
 import { name as functionsName } from '../../../packages-exp/functions-exp/package.json';
 import { name as functionsCompatName } from '../../../packages-exp/functions-compat/package.json';
 import { name as installationsName } from '../../../packages-exp/installations-exp/package.json';
 import { name as installationsCompatName } from '../../../packages-exp/installations-compat/package.json';
 import { name as messagingName } from '../../../packages-exp/messaging-exp/package.json';
+import { name as messagingCompatName } from '../../../packages-exp/messaging-compat/package.json';
 import { name as performanceName } from '../../../packages-exp/performance-exp/package.json';
+import { name as performanceCompatName } from '../../../packages-exp/performance-compat/package.json';
 import { name as remoteConfigName } from '../../../packages-exp/remote-config-exp/package.json';
 import { name as remoteConfigCompatName } from '../../../packages-exp/remote-config-compat/package.json';
 import { name as storageName } from '../../../packages/storage/package.json';
-import { name as firestoreName } from '../../../packages/firestore/package.json';
+import { name as storageCompatName } from '../../../packages/storage/compat/package.json';
+import { name as firestoreName } from '../../../packages/firestore/exp/package.json';
+import { name as firestoreCompatName } from '../../../packages/firestore/compat/package.json';
 import { name as packageName } from '../../../packages-exp/firebase-exp/package.json';
 
 /**
@@ -54,11 +58,15 @@ export const PLATFORM_LOG_STRING = {
   [installationsName]: 'fire-iid',
   [installationsCompatName]: 'fire-iid-compat',
   [messagingName]: 'fire-fcm',
+  [messagingCompatName]: 'fire-fcm-compat',
   [performanceName]: 'fire-perf',
+  [performanceCompatName]: 'fire-perf-compat',
   [remoteConfigName]: 'fire-rc',
   [remoteConfigCompatName]: 'fire-rc-compat',
   [storageName]: 'fire-gcs',
+  [storageCompatName]: 'fire-gcs-compat',
   [firestoreName]: 'fire-fst',
+  [firestoreCompatName]: 'fire-fst-compat',
   'fire-js': 'fire-js', // Platform identifier for JS SDK.
   [packageName]: 'fire-js-all'
 } as const;

--- a/packages-exp/auth-compat-exp/index.ts
+++ b/packages-exp/auth-compat-exp/index.ts
@@ -27,7 +27,7 @@ import {
 } from '@firebase/component';
 
 import * as types from '@firebase/auth-types';
-import { version } from './package.json';
+import { name, version } from './package.json';
 import { Auth } from './src/auth';
 import { Persistence } from './src/persistence';
 import { PhoneAuthProvider as CompatAuthProvider } from './src/phone_auth_provider';
@@ -117,7 +117,7 @@ function registerAuthCompat(instance: _FirebaseNamespace): void {
       .setMultipleInstances(false)
   );
 
-  instance.registerVersion('auth-compat', version);
+  instance.registerVersion(name, version);
 }
 
 registerAuthCompat(firebase as _FirebaseNamespace);

--- a/packages-exp/auth-exp/src/core/auth/register.ts
+++ b/packages-exp/auth-exp/src/core/auth/register.ts
@@ -18,7 +18,7 @@
 import { _registerComponent, registerVersion } from '@firebase/app-exp';
 import { Component, ComponentType } from '@firebase/component';
 
-import { version } from '../../../package.json';
+import { name, version } from '../../../package.json';
 import { AuthErrorCode } from '../errors';
 import { _assert } from '../util/assert';
 import { _getClientVersion, ClientPlatform } from '../util/version';
@@ -101,9 +101,5 @@ export function registerAuth(clientPlatform: ClientPlatform): void {
     )
   );
 
-  registerVersion(
-    _ComponentName.AUTH,
-    version,
-    getVersionForPlatform(clientPlatform)
-  );
+  registerVersion(name, version, getVersionForPlatform(clientPlatform));
 }

--- a/packages/database/exp/index.node.ts
+++ b/packages/database/exp/index.node.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2020 Google LLC
+ * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,8 +15,9 @@
  * limitations under the License.
  */
 
-import { registerFirestore } from './register';
+import { registerDatabase } from './register';
 
-registerFirestore();
+export { getDatabase, ServerValue } from '../src/exp/Database';
+export { enableLogging } from '../src/core/util/util';
 
-export * from './api';
+registerDatabase('node');

--- a/packages/database/exp/index.ts
+++ b/packages/database/exp/index.ts
@@ -15,35 +15,9 @@
  * limitations under the License.
  */
 
-// eslint-disable-next-line import/no-extraneous-dependencies
-import { _registerComponent, registerVersion } from '@firebase/app-exp';
-import { Component, ComponentType } from '@firebase/component';
-
-import { version } from '../package.json';
-import { FirebaseDatabase } from '../src/exp/Database';
+import { registerDatabase } from './register';
 
 export { getDatabase, ServerValue } from '../src/exp/Database';
 export { enableLogging } from '../src/core/util/util';
-
-declare module '@firebase/component' {
-  interface NameServiceMapping {
-    'database-exp': FirebaseDatabase;
-  }
-}
-
-function registerDatabase(): void {
-  _registerComponent(
-    new Component(
-      'database-exp',
-      (container, { instanceIdentifier: url }) => {
-        const app = container.getProvider('app-exp').getImmediate()!;
-        const authProvider = container.getProvider('auth-internal');
-        return new FirebaseDatabase(app, authProvider, url);
-      },
-      ComponentType.PUBLIC
-    ).setMultipleInstances(true)
-  );
-  registerVersion('database-exp', version, 'node');
-}
 
 registerDatabase();

--- a/packages/database/exp/package.json
+++ b/packages/database/exp/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@firebase/database-exp",
-  "version": "0.0.900",
   "description": "A version of the Realtime Database SDK that is compatible with the tree-shakeable Firebase SDK",
   "main": "../dist/exp/index.node.cjs.js",
   "browser": "../dist/exp/index.esm.js",

--- a/packages/database/exp/package.json
+++ b/packages/database/exp/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@firebase/database-exp",
+  "version": "0.0.900",
   "description": "A version of the Realtime Database SDK that is compatible with the tree-shakeable Firebase SDK",
   "main": "../dist/exp/index.node.cjs.js",
   "browser": "../dist/exp/index.esm.js",

--- a/packages/database/exp/register.ts
+++ b/packages/database/exp/register.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2020 Google LLC
+ * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,37 +15,34 @@
  * limitations under the License.
  */
 
+// eslint-disable-next-line import/no-extraneous-dependencies
 import { _registerComponent, registerVersion } from '@firebase/app-exp';
 import { Component, ComponentType } from '@firebase/component';
 
-import { FirebaseFirestore } from '../src/exp/database';
-import { Settings } from '../src/exp/settings';
+import { FirebaseDatabase } from '../src/exp/Database';
+
+export { getDatabase, ServerValue } from '../src/exp/Database';
+export { enableLogging } from '../src/core/util/util';
 
 import { name, version } from './package.json';
 
 declare module '@firebase/component' {
   interface NameServiceMapping {
-    'firestore-exp': FirebaseFirestore;
+    'database-exp': FirebaseDatabase;
   }
 }
 
-export function registerFirestore(variant?: string): void {
+export function registerDatabase(variant?: string): void {
   _registerComponent(
     new Component(
-      'firestore-exp',
-      (container, { options: settings }: { options?: Settings }) => {
+      'database-exp',
+      (container, { instanceIdentifier: url }) => {
         const app = container.getProvider('app-exp').getImmediate()!;
-        const firestoreInstance = new FirebaseFirestore(
-          app,
-          container.getProvider('auth-internal')
-        );
-        if (settings) {
-          firestoreInstance._setSettings(settings);
-        }
-        return firestoreInstance;
+        const authProvider = container.getProvider('auth-internal');
+        return new FirebaseDatabase(app, authProvider, url);
       },
       ComponentType.PUBLIC
-    )
+    ).setMultipleInstances(true)
   );
   registerVersion(name, version, variant);
 }

--- a/packages/database/exp/register.ts
+++ b/packages/database/exp/register.ts
@@ -19,12 +19,11 @@
 import { _registerComponent, registerVersion } from '@firebase/app-exp';
 import { Component, ComponentType } from '@firebase/component';
 
+import { name, version } from '../package.json';
 import { FirebaseDatabase } from '../src/exp/Database';
 
 export { getDatabase, ServerValue } from '../src/exp/Database';
 export { enableLogging } from '../src/core/util/util';
-
-import { name, version } from './package.json';
 
 declare module '@firebase/component' {
   interface NameServiceMapping {

--- a/packages/database/rollup.config.exp.js
+++ b/packages/database/rollup.config.exp.js
@@ -53,7 +53,7 @@ const es5Builds = [
    * Node.js Build
    */
   {
-    input: 'exp/index.ts',
+    input: 'exp/index.node.ts',
     output: [
       { file: path.resolve('exp', expPkg.main), format: 'cjs', sourcemap: true }
     ],

--- a/packages/firestore/compat/index.node.ts
+++ b/packages/firestore/compat/index.node.ts
@@ -19,11 +19,11 @@
 import firebase from '@firebase/app-compat';
 import { FirebaseNamespace } from '@firebase/app-types';
 
-import { name, version } from '../package.json';
 import { Firestore, IndexedDbPersistenceProvider } from '../src/api/database';
 
 import { registerBundle } from './bundle';
 import { configureForFirebase } from './config';
+import { name, version } from './package.json';
 
 /**
  * Registers the main Firestore Node build with the components framework.

--- a/packages/firestore/compat/index.rn.ts
+++ b/packages/firestore/compat/index.rn.ts
@@ -19,11 +19,11 @@
 import firebase from '@firebase/app-compat';
 import { FirebaseNamespace } from '@firebase/app-types';
 
-import { name, version } from '../package.json';
 import { Firestore, IndexedDbPersistenceProvider } from '../src/api/database';
 
 import { registerBundle } from './bundle';
 import { configureForFirebase } from './config';
+import { name, version } from './package.json';
 
 /**
  * Registers the main Firestore ReactNative build with the components framework.

--- a/packages/firestore/compat/index.ts
+++ b/packages/firestore/compat/index.ts
@@ -20,11 +20,11 @@ import firebase from '@firebase/app-compat';
 import { FirebaseNamespace } from '@firebase/app-types';
 import * as types from '@firebase/firestore-types';
 
-import { name, version } from '../package.json';
 import { Firestore, IndexedDbPersistenceProvider } from '../src/api/database';
 
 import { registerBundle } from './bundle';
 import { configureForFirebase } from './config';
+import { name, version } from './package.json';
 
 import '../register-module';
 

--- a/packages/firestore/exp/api.ts
+++ b/packages/firestore/exp/api.ts
@@ -1,0 +1,131 @@
+/**
+ * @license
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export { FieldPath, documentId } from '../src/exp/field_path';
+
+export {
+  FirebaseFirestore,
+  initializeFirestore,
+  getFirestore,
+  enableIndexedDbPersistence,
+  enableMultiTabIndexedDbPersistence,
+  clearIndexedDbPersistence,
+  waitForPendingWrites,
+  disableNetwork,
+  enableNetwork,
+  terminate,
+  useFirestoreEmulator,
+  loadBundle,
+  namedQuery,
+  ensureFirestoreConfigured
+} from '../src/exp/database';
+
+export {
+  LoadBundleTask,
+  LoadBundleTaskProgress,
+  TaskState
+} from '../src/exp/bundle';
+
+export { Settings, PersistenceSettings } from '../src/exp/settings';
+
+export {
+  DocumentChange,
+  DocumentSnapshot,
+  QueryDocumentSnapshot,
+  QuerySnapshot,
+  snapshotEqual,
+  SnapshotOptions,
+  FirestoreDataConverter,
+  DocumentChangeType,
+  SnapshotMetadata
+} from '../src/exp/snapshot';
+
+export {
+  DocumentReference,
+  CollectionReference,
+  Query,
+  doc,
+  collection,
+  collectionGroup,
+  SetOptions,
+  DocumentData,
+  UpdateData,
+  refEqual,
+  queryEqual
+} from '../src/exp/reference';
+
+export {
+  endAt,
+  endBefore,
+  startAt,
+  startAfter,
+  limit,
+  limitToLast,
+  where,
+  orderBy,
+  query,
+  QueryConstraint,
+  QueryConstraintType,
+  OrderByDirection,
+  WhereFilterOp
+} from '../src/exp/query';
+
+export { Unsubscribe, SnapshotListenOptions } from '../src/exp/reference_impl';
+
+export { runTransaction, Transaction } from '../src/exp/transaction';
+
+export {
+  getDoc,
+  getDocFromCache,
+  getDocFromServer,
+  getDocs,
+  getDocsFromCache,
+  getDocsFromServer,
+  onSnapshot,
+  onSnapshotsInSync,
+  setDoc,
+  updateDoc,
+  deleteDoc,
+  addDoc,
+  executeWrite
+} from '../src/exp/reference_impl';
+
+export { FieldValue } from '../src/exp/field_value';
+
+export {
+  increment,
+  arrayRemove,
+  arrayUnion,
+  serverTimestamp,
+  deleteField
+} from '../src/exp/field_value_impl';
+
+export { setLogLevel, LogLevelString as LogLevel } from '../src/util/log';
+
+export { Bytes } from '../src/exp/bytes';
+
+export { WriteBatch, writeBatch } from '../src/exp/write_batch';
+
+export { GeoPoint } from '../src/exp/geo_point';
+
+export { Timestamp } from '../src/exp/timestamp';
+
+export { CACHE_SIZE_UNLIMITED } from '../src/exp/database';
+
+export { FirestoreErrorCode, FirestoreError } from '../src/util/error';
+
+export { AbstractUserDataWriter } from '../src/lite/user_data_writer';

--- a/packages/firestore/exp/index.node.ts
+++ b/packages/firestore/exp/index.node.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2020 Google LLC
+ * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,6 @@
 
 import { registerFirestore } from './register';
 
-registerFirestore();
+registerFirestore('node');
 
 export * from './api';

--- a/packages/firestore/exp/index.rn.ts
+++ b/packages/firestore/exp/index.rn.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2020 Google LLC
+ * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,6 @@
 
 import { registerFirestore } from './register';
 
-registerFirestore();
+registerFirestore('rn');
 
 export * from './api';

--- a/packages/firestore/exp/package.json
+++ b/packages/firestore/exp/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@firebase/firestore-exp",
+  "version": "0.0.900",
   "description": "A tree-shakeable version of the Firestore SDK",
   "main": "../dist/exp/index.node.umd.js",
   "main-esm": "../dist/exp/index.node.esm2017.js",

--- a/packages/firestore/exp/package.json
+++ b/packages/firestore/exp/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@firebase/firestore-exp",
-  "version": "0.0.900",
   "description": "A tree-shakeable version of the Firestore SDK",
   "main": "../dist/exp/index.node.umd.js",
   "main-esm": "../dist/exp/index.node.esm2017.js",

--- a/packages/firestore/exp/register.ts
+++ b/packages/firestore/exp/register.ts
@@ -18,10 +18,9 @@
 import { _registerComponent, registerVersion } from '@firebase/app-exp';
 import { Component, ComponentType } from '@firebase/component';
 
+import { name, version } from '../package.json';
 import { FirebaseFirestore } from '../src/exp/database';
 import { Settings } from '../src/exp/settings';
-
-import { name, version } from './package.json';
 
 declare module '@firebase/component' {
   interface NameServiceMapping {

--- a/packages/firestore/rollup.config.exp.js
+++ b/packages/firestore/rollup.config.exp.js
@@ -84,7 +84,7 @@ const browserPlugins = function () {
 const allBuilds = [
   // Node ESM build
   {
-    input: './exp/index.ts',
+    input: './exp/index.node.ts',
     output: {
       file: path.resolve('./exp', pkg['main-esm']),
       format: 'es',
@@ -128,7 +128,7 @@ const allBuilds = [
   },
   // RN build
   {
-    input: './exp/index.ts',
+    input: './exp/index.rn.ts',
     output: {
       file: path.resolve('./exp', pkg['react-native']),
       format: 'es',

--- a/packages/storage/compat/index.ts
+++ b/packages/storage/compat/index.ts
@@ -31,7 +31,7 @@ import {
   InstanceFactoryOptions
 } from '@firebase/component';
 
-import { name, version } from '../package.json';
+import { name, version } from './package.json';
 
 /**
  * Type constant for Firebase Storage.

--- a/packages/storage/compat/package.json
+++ b/packages/storage/compat/package.json
@@ -3,7 +3,7 @@
     "version": "0.0.900",
     "description": "The Cloud Storage component of the Firebase JS SDK.",
     "author": "Firebase <firebase-support@google.com> (https://firebase.google.com/)",
-    "main": "../dist/compat/node-cjs/index.js",
+    "main": "../dist/compat/cjs/index.js",
     "browser": "../dist/compat/esm5/index.js",
     "module": "../dist/compat/esm5/index.js",
     "esm2017": "../dist/compat/esm2017/index.js",

--- a/packages/storage/exp/index.ts
+++ b/packages/storage/exp/index.ts
@@ -31,7 +31,7 @@ import {
   InstanceFactoryOptions
 } from '@firebase/component';
 
-import { name, version } from './package.json';
+import { name, version } from '../package.json';
 
 import { StorageService } from './public-types';
 import { STORAGE_TYPE } from './constants';

--- a/packages/storage/exp/index.ts
+++ b/packages/storage/exp/index.ts
@@ -31,7 +31,7 @@ import {
   InstanceFactoryOptions
 } from '@firebase/component';
 
-import { name, version } from '../package.json';
+import { name, version } from './package.json';
 
 import { StorageService } from './public-types';
 import { STORAGE_TYPE } from './constants';

--- a/packages/storage/exp/package.json
+++ b/packages/storage/exp/package.json
@@ -1,5 +1,6 @@
 {
-  "name": "@firebase/storage/exp",
+  "name": "@firebase/storage-exp",
+  "version": "0.0.900",
   "description": "A tree-shakeable version of the Storage SDK",
   "main": "./dist/index.browser.cjs.js",
   "module": "./dist/index.browser.esm2017.js",

--- a/packages/storage/exp/package.json
+++ b/packages/storage/exp/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@firebase/storage-exp",
-  "version": "0.0.900",
   "description": "A tree-shakeable version of the Storage SDK",
   "main": "./dist/index.browser.cjs.js",
   "module": "./dist/index.browser.esm2017.js",


### PR DESCRIPTION
Update files as needed for platform logging to work with exp packages.

Part of this requires keeping track of the versions of firestore, storage, and database exp in their respective /exp/package.json files. These files aren't used in publishing the release so we need to add something to the release script to make sure they stay updated the same way as any other subpackage once we move out of alpha.