### PR TITLE
remove floating point rounding error in Timestamp.fromMillis()

### DIFF
--- a/.changeset/rich-olives-tease.md
+++ b/.changeset/rich-olives-tease.md
@@ -1,0 +1,5 @@
+---
+'@firebase/firestore': patch
+---
+
+Fixed a bug where decimal inputs to `Timestamp.fromMillis()` would throw an error

--- a/.changeset/rich-olives-tease.md
+++ b/.changeset/rich-olives-tease.md
@@ -2,4 +2,4 @@
 '@firebase/firestore': patch
 ---
 
-Fixed a bug where decimal inputs to `Timestamp.fromMillis()` would throw an error
+Fixed a bug where decimal inputs to `Timestamp.fromMillis()` calculated incorrectly due to floating point precision loss

--- a/packages/firestore/src/lite/timestamp.ts
+++ b/packages/firestore/src/lite/timestamp.ts
@@ -22,7 +22,7 @@ import { primitiveComparator } from '../util/misc';
 const MIN_SECONDS = -62135596800;
 
 // Number of nanoseconds in a millisecond.
-const MS_TO_NANOS = 1000000;
+const MS_TO_NANOS = 1e6;
 
 /**
  * A `Timestamp` represents a point in time independent of any time zone or
@@ -69,9 +69,7 @@ export class Timestamp {
    */
   static fromMillis(milliseconds: number): Timestamp {
     const seconds = Math.floor(milliseconds / 1000);
-    const nanos = Math.floor(
-      milliseconds * MS_TO_NANOS - seconds * 1000 * MS_TO_NANOS
-    );
+    const nanos = Math.floor((milliseconds - seconds * 1000) * MS_TO_NANOS);
     return new Timestamp(seconds, nanos);
   }
 
@@ -133,7 +131,7 @@ export class Timestamp {
    *     the number of milliseconds since Unix epoch 1970-01-01T00:00:00Z.
    */
   toMillis(): number {
-    return this.seconds * 1000 + this.nanoseconds / 1e6;
+    return this.seconds * 1000 + this.nanoseconds / MS_TO_NANOS;
   }
 
   _compareTo(other: Timestamp): number {

--- a/packages/firestore/src/lite/timestamp.ts
+++ b/packages/firestore/src/lite/timestamp.ts
@@ -21,6 +21,9 @@ import { primitiveComparator } from '../util/misc';
 // The earliest date supported by Firestore timestamps (0001-01-01T00:00:00Z).
 const MIN_SECONDS = -62135596800;
 
+// Number of nanoseconds in a millisecond.
+const MS_TO_NANOS = 1000000;
+
 /**
  * A `Timestamp` represents a point in time independent of any time zone or
  * calendar, represented as seconds and fractions of seconds at nanosecond
@@ -66,7 +69,9 @@ export class Timestamp {
    */
   static fromMillis(milliseconds: number): Timestamp {
     const seconds = Math.floor(milliseconds / 1000);
-    const nanos = (milliseconds - seconds * 1000) * 1e6;
+    const nanos = Math.floor(
+      milliseconds * MS_TO_NANOS - seconds * 1000 * MS_TO_NANOS
+    );
     return new Timestamp(seconds, nanos);
   }
 

--- a/packages/firestore/test/unit/api/timestamp.test.ts
+++ b/packages/firestore/test/unit/api/timestamp.test.ts
@@ -134,6 +134,12 @@ describe('Timestamp', () => {
     expect(t1 >= t2).to.be.false;
   });
 
+  it('handles decimal inputs in fromMillis()', () => {
+    const actual = Timestamp.fromMillis(1000.1);
+    const expected = new Timestamp(1, 100000);
+    expect(actual.isEqual(expected)).to.be.true;
+  });
+
   it('serializes to JSON', () => {
     expect(new Timestamp(123, 456).toJSON()).to.deep.equal({
       seconds: 123,


### PR DESCRIPTION
Porting over from [node](https://github.com/googleapis/nodejs-firestore/pull/1464).