### PR TITLE
Fill documentation gaps in analytics and functions exp

### DIFF
--- a/common/api-review/analytics-exp.api.md
+++ b/common/api-review/analytics-exp.api.md
@@ -6,7 +6,7 @@
 
 import { FirebaseApp } from '@firebase/app-exp';
 
-// @public (undocumented)
+// @public
 export interface Analytics {
     app: FirebaseApp;
 }
@@ -28,7 +28,7 @@ export interface ControlParams {
     send_to?: string | string[];
 }
 
-// @public (undocumented)
+// @public
 export type Currency = string | number;
 
 // @public
@@ -108,12 +108,12 @@ export interface EventParams {
 }
 
 // @public
-export function getAnalytics(app: FirebaseApp): Analytics;
+export function getAnalytics(app?: FirebaseApp): Analytics;
 
 // @public
 export function isSupported(): Promise<boolean>;
 
-// @public (undocumented)
+// @public
 export interface Item {
     // (undocumented)
     affiliation?: string;
@@ -351,7 +351,7 @@ export function logEvent<T extends string>(analyticsInstance: Analytics, eventNa
     [key: string]: any;
 }, options?: AnalyticsCallOptions): void;
 
-// @public @deprecated (undocumented)
+// @public @deprecated
 export interface Promotion {
     // (undocumented)
     creative_name?: string;

--- a/common/api-review/functions-exp.api.md
+++ b/common/api-review/functions-exp.api.md
@@ -24,26 +24,21 @@ export interface FunctionsError extends FirebaseError {
 export type FunctionsErrorCode = 'ok' | 'cancelled' | 'unknown' | 'invalid-argument' | 'deadline-exceeded' | 'not-found' | 'already-exists' | 'permission-denied' | 'resource-exhausted' | 'failed-precondition' | 'aborted' | 'out-of-range' | 'unimplemented' | 'internal' | 'unavailable' | 'data-loss' | 'unauthenticated';
 
 // @public
-export function getFunctions(app: FirebaseApp, regionOrCustomDomain?: string): Functions;
+export function getFunctions(app?: FirebaseApp, regionOrCustomDomain?: string): Functions;
 
 // @public
-export interface HttpsCallable<RequestData = unknown, ResponseData = unknown> {
-    // (undocumented)
-    (data?: RequestData | null): Promise<HttpsCallableResult<ResponseData>>;
-}
+export type HttpsCallable<RequestData = unknown, ResponseData = unknown> = (data?: RequestData | null) => Promise<HttpsCallableResult<ResponseData>>;
 
 // @public
 export function httpsCallable<RequestData = unknown, ResponseData = unknown>(functionsInstance: Functions, name: string, options?: HttpsCallableOptions): HttpsCallable<RequestData, ResponseData>;
 
 // @public
 export interface HttpsCallableOptions {
-    // (undocumented)
     timeout?: number;
 }
 
 // @public
 export interface HttpsCallableResult<ResponseData = unknown> {
-    // (undocumented)
     readonly data: ResponseData;
 }
 

--- a/packages-exp/analytics-exp/src/public-types.ts
+++ b/packages-exp/analytics-exp/src/public-types.ts
@@ -20,6 +20,7 @@ import { FirebaseApp } from '@firebase/app-exp';
 /**
  * Additional options that can be passed to Firebase Analytics method
  * calls such as `logEvent`, `setCurrentScreen`, etc.
+ * @public
  */
 export interface AnalyticsCallOptions {
   /**
@@ -29,6 +30,11 @@ export interface AnalyticsCallOptions {
   global: boolean;
 }
 
+/**
+ * The Firebase Analytics service interface.
+ *
+ * @public
+ */
 export interface Analytics {
   /**
    * The FirebaseApp this Functions instance is associated with.
@@ -39,6 +45,7 @@ export interface Analytics {
 /**
  * Specifies custom options for your Firebase Analytics instance.
  * You must set these before initializing `firebase.analytics()`.
+ * @public
  */
 export interface SettingsOptions {
   /** Sets custom name for `gtag` function. */
@@ -49,6 +56,7 @@ export interface SettingsOptions {
 
 /**
  * Any custom params the user may pass to gtag.js.
+ * @public
  */
 export interface CustomParams {
   [key: string]: unknown;
@@ -56,6 +64,7 @@ export interface CustomParams {
 /**
  * Type for standard gtag.js event names. `logEvent` also accepts any
  * custom string and interprets it as a custom event name.
+ * @public
  */
 export type EventNameString =
   | 'add_payment_info'
@@ -86,9 +95,17 @@ export type EventNameString =
   | 'view_promotion'
   | 'view_search_results';
 
+/**
+ * Currency field used by some Analytics events.
+ * @public
+ */
 export type Currency = string | number;
 
 /* eslint-disable camelcase */
+/**
+ * Item field used by some Analytics events.
+ * @public
+ */
 export interface Item {
   item_id?: string;
   item_name?: string;
@@ -122,7 +139,11 @@ export interface Item {
   name?: string;
 }
 
-/** @deprecated Use Item instead. */
+/**
+ * Field previously used by some Analytics events.
+ * @deprecated Use Item instead.
+ * @public
+ */
 export interface Promotion {
   creative_name?: string;
   creative_slot?: string;
@@ -135,6 +156,7 @@ export interface Promotion {
  * For more information, see
  * {@link https://developers.google.com/gtagjs/reference/parameter
  * | the gtag.js documentation on parameters}.
+ * @public
  */
 export interface ControlParams {
   groups?: string | string[];
@@ -148,6 +170,7 @@ export interface ControlParams {
  * For more information, see
  * {@link https://developers.google.com/gtagjs/reference/parameter
  * | the gtag.js documentation on parameters}.
+ * @public
  */
 export interface EventParams {
   checkout_option?: string;

--- a/packages-exp/functions-exp/src/public-types.ts
+++ b/packages-exp/functions-exp/src/public-types.ts
@@ -22,24 +22,32 @@ import { FirebaseError } from '@firebase/util';
  * @public
  */
 export interface HttpsCallableResult<ResponseData = unknown> {
+  /**
+   * Data returned from callable function.
+   */
   readonly data: ResponseData;
 }
 
 /**
  * An HttpsCallable is a reference to a "callable" http trigger in
  * Google Cloud Functions.
+ * @param data - Data to be passed to callable function.
  * @public
  */
-export interface HttpsCallable<RequestData = unknown, ResponseData = unknown> {
-  (data?: RequestData | null): Promise<HttpsCallableResult<ResponseData>>;
-}
+export type HttpsCallable<RequestData = unknown, ResponseData = unknown> = (
+  data?: RequestData | null
+) => Promise<HttpsCallableResult<ResponseData>>;
 
 /**
  * HttpsCallableOptions specify metadata about how calls should be executed.
  * @public
  */
 export interface HttpsCallableOptions {
-  timeout?: number; // in millis
+  /**
+   * Time in milliseconds after which to cancel if there is no response.
+   * Default is 70000.
+   */
+  timeout?: number;
 }
 
 /**


### PR DESCRIPTION
I decided not to document every property of analytics param types like Item, I'm sure Analytics users can find those in the general Google Analytics docs, and that documentation will be better maintained.