### PR TITLE
Add missing Firestore comments

### DIFF
--- a/common/api-review/firestore-exp.api.md
+++ b/common/api-review/firestore-exp.api.md
@@ -46,16 +46,12 @@ export function collectionGroup(firestore: FirebaseFirestore, collectionId: stri
 
 // @public
 export class CollectionReference<T = DocumentData> extends Query<T> {
-    // (undocumented)
-    readonly firestore: FirebaseFirestore;
     get id(): string;
     get parent(): DocumentReference<DocumentData> | null;
     get path(): string;
-    // (undocumented)
     readonly type = "collection";
-    withConverter(converter: null): CollectionReference<DocumentData>;
-    // (undocumented)
     withConverter<U>(converter: FirestoreDataConverter<U>): CollectionReference<U>;
+    withConverter(converter: null): CollectionReference<DocumentData>;
 }
 
 // @public
@@ -89,7 +85,6 @@ export type DocumentChangeType = 'added' | 'removed' | 'modified';
 
 // @public
 export interface DocumentData {
-    // (undocumented)
     [field: string]: any;
 }
 
@@ -103,9 +98,8 @@ export class DocumentReference<T = DocumentData> {
     get parent(): CollectionReference<T>;
     get path(): string;
     readonly type = "document";
-    withConverter(converter: null): DocumentReference<DocumentData>;
-    // (undocumented)
     withConverter<U>(converter: FirestoreDataConverter<U>): DocumentReference<U>;
+    withConverter(converter: null): DocumentReference<DocumentData>;
 }
 
 // @public
@@ -114,10 +108,8 @@ export class DocumentSnapshot<T = DocumentData> {
     data(options?: SnapshotOptions): T | undefined;
     exists(): this is QueryDocumentSnapshot<T>;
     get(fieldPath: string | FieldPath, options?: SnapshotOptions): any;
-    // (undocumented)
     get id(): string;
     readonly metadata: SnapshotMetadata;
-    // (undocumented)
     get ref(): DocumentReference<T>;
 }
 
@@ -150,16 +142,12 @@ export class FieldPath {
 
 // @public
 export abstract class FieldValue {
-    constructor(_methodName: string);
-    // (undocumented)
     abstract isEqual(other: FieldValue): boolean;
 }
 
 // @public
 export class FirebaseFirestore {
-    // (undocumented)
     get app(): FirebaseApp;
-    // (undocumented)
     toJSON(): object;
 }
 
@@ -172,13 +160,9 @@ export interface FirestoreDataConverter<T> {
 
 // @public
 export class FirestoreError extends Error {
-    // (undocumented)
     readonly code: FirestoreErrorCode;
-    // (undocumented)
     readonly message: string;
-    // (undocumented)
     readonly name: string;
-    // (undocumented)
     readonly stack?: string;
 }
 
@@ -191,7 +175,6 @@ export class GeoPoint {
     isEqual(other: GeoPoint): boolean;
     get latitude(): number;
     get longitude(): number;
-    // (undocumented)
     toJSON(): {
         latitude: number;
         longitude: number;
@@ -311,9 +294,8 @@ export function orderBy(fieldPath: string | FieldPath, directionStr?: OrderByDir
 // @public
 export type OrderByDirection = 'desc' | 'asc';
 
-// @public (undocumented)
+// @public
 export interface PersistenceSettings {
-    // (undocumented)
     forceOwnership?: boolean;
 }
 
@@ -323,7 +305,6 @@ export class Query<T = DocumentData> {
     readonly firestore: FirebaseFirestore;
     readonly type: 'query' | 'collection';
     withConverter(converter: null): Query<DocumentData>;
-    // (undocumented)
     withConverter<U>(converter: FirestoreDataConverter<U>): Query<U>;
 }
 
@@ -383,19 +364,13 @@ export type SetOptions = {
     readonly mergeFields?: Array<string | FieldPath>;
 };
 
-// @public (undocumented)
+// @public
 export interface Settings {
-    // (undocumented)
     cacheSizeBytes?: number;
-    // (undocumented)
     experimentalAutoDetectLongPolling?: boolean;
-    // (undocumented)
     experimentalForceLongPolling?: boolean;
-    // (undocumented)
     host?: string;
-    // (undocumented)
     ignoreUndefinedProperties?: boolean;
-    // (undocumented)
     ssl?: boolean;
 }
 
@@ -439,51 +414,42 @@ export function terminate(firestore: FirebaseFirestore): Promise<void>;
 
 // @public
 export class Timestamp {
-    constructor(seconds: number, nanoseconds: number);
+    constructor(
+    seconds: number,
+    nanoseconds: number);
     static fromDate(date: Date): Timestamp;
     static fromMillis(milliseconds: number): Timestamp;
     isEqual(other: Timestamp): boolean;
-    // (undocumented)
     readonly nanoseconds: number;
     static now(): Timestamp;
-    // (undocumented)
     readonly seconds: number;
     toDate(): Date;
-    // (undocumented)
     toJSON(): {
         seconds: number;
         nanoseconds: number;
     };
     toMillis(): number;
-    // (undocumented)
     toString(): string;
     valueOf(): string;
 }
 
 // @public
 export class Transaction {
-    // (undocumented)
     delete(documentRef: DocumentReference<unknown>): this;
     get<T>(documentRef: DocumentReference<T>): Promise<DocumentSnapshot<T>>;
-    // (undocumented)
     set<T>(documentRef: DocumentReference<T>, data: T): this;
-    // (undocumented)
     set<T>(documentRef: DocumentReference<T>, data: Partial<T>, options: SetOptions): this;
-    // (undocumented)
     update(documentRef: DocumentReference<unknown>, data: UpdateData): this;
-    // (undocumented)
     update(documentRef: DocumentReference<unknown>, field: string | FieldPath, value: unknown, ...moreFieldsAndValues: unknown[]): this;
 }
 
-// @public (undocumented)
+// @public
 export interface Unsubscribe {
-    // (undocumented)
     (): void;
 }
 
 // @public
 export interface UpdateData {
-    // (undocumented)
     [fieldPath: string]: any;
 }
 

--- a/common/api-review/firestore-lite.api.md
+++ b/common/api-review/firestore-lite.api.md
@@ -40,16 +40,12 @@ export function collectionGroup(firestore: FirebaseFirestore, collectionId: stri
 
 // @public
 export class CollectionReference<T = DocumentData> extends Query<T> {
-    // (undocumented)
-    readonly firestore: FirebaseFirestore;
     get id(): string;
     get parent(): DocumentReference<DocumentData> | null;
     get path(): string;
-    // (undocumented)
     readonly type = "collection";
-    withConverter(converter: null): CollectionReference<DocumentData>;
-    // (undocumented)
     withConverter<U>(converter: FirestoreDataConverter<U>): CollectionReference<U>;
+    withConverter(converter: null): CollectionReference<DocumentData>;
 }
 
 // @public
@@ -69,7 +65,6 @@ export function doc(reference: DocumentReference<unknown>, path: string, ...path
 
 // @public
 export interface DocumentData {
-    // (undocumented)
     [field: string]: any;
 }
 
@@ -83,9 +78,8 @@ export class DocumentReference<T = DocumentData> {
     get parent(): CollectionReference<T>;
     get path(): string;
     readonly type = "document";
-    withConverter(converter: null): DocumentReference<DocumentData>;
-    // (undocumented)
     withConverter<U>(converter: FirestoreDataConverter<U>): DocumentReference<U>;
+    withConverter(converter: null): DocumentReference<DocumentData>;
 }
 
 // @public
@@ -118,15 +112,12 @@ export class FieldPath {
 
 // @public
 export abstract class FieldValue {
-    constructor(_methodName: string);
-    // (undocumented)
     abstract isEqual(other: FieldValue): boolean;
 }
 
 // @public
 export class FirebaseFirestore {
     get app(): FirebaseApp;
-    // (undocumented)
     toJSON(): object;
 }
 
@@ -139,13 +130,9 @@ export interface FirestoreDataConverter<T> {
 
 // @public
 export class FirestoreError extends Error {
-    // (undocumented)
     readonly code: FirestoreErrorCode;
-    // (undocumented)
     readonly message: string;
-    // (undocumented)
     readonly name: string;
-    // (undocumented)
     readonly stack?: string;
 }
 
@@ -158,7 +145,6 @@ export class GeoPoint {
     isEqual(other: GeoPoint): boolean;
     get latitude(): number;
     get longitude(): number;
-    // (undocumented)
     toJSON(): {
         latitude: number;
         longitude: number;
@@ -200,7 +186,6 @@ export class Query<T = DocumentData> {
     readonly firestore: FirebaseFirestore;
     readonly type: 'query' | 'collection';
     withConverter(converter: null): Query<DocumentData>;
-    // (undocumented)
     withConverter<U>(converter: FirestoreDataConverter<U>): Query<U>;
 }
 
@@ -258,19 +243,13 @@ export type SetOptions = {
     readonly mergeFields?: Array<string | FieldPath>;
 };
 
-// @public (undocumented)
+// @public
 export interface Settings {
-    // (undocumented)
     cacheSizeBytes?: number;
-    // (undocumented)
     experimentalAutoDetectLongPolling?: boolean;
-    // (undocumented)
     experimentalForceLongPolling?: boolean;
-    // (undocumented)
     host?: string;
-    // (undocumented)
     ignoreUndefinedProperties?: boolean;
-    // (undocumented)
     ssl?: boolean;
 }
 
@@ -294,23 +273,21 @@ export function terminate(firestore: FirebaseFirestore): Promise<void>;
 
 // @public
 export class Timestamp {
-    constructor(seconds: number, nanoseconds: number);
+    constructor(
+    seconds: number,
+    nanoseconds: number);
     static fromDate(date: Date): Timestamp;
     static fromMillis(milliseconds: number): Timestamp;
     isEqual(other: Timestamp): boolean;
-    // (undocumented)
     readonly nanoseconds: number;
     static now(): Timestamp;
-    // (undocumented)
     readonly seconds: number;
     toDate(): Date;
-    // (undocumented)
     toJSON(): {
         seconds: number;
         nanoseconds: number;
     };
     toMillis(): number;
-    // (undocumented)
     toString(): string;
     valueOf(): string;
 }
@@ -327,7 +304,6 @@ export class Transaction {
 
 // @public
 export interface UpdateData {
-    // (undocumented)
     [fieldPath: string]: any;
 }
 

--- a/common/api-review/firestore-lite.api.md
+++ b/common/api-review/firestore-lite.api.md
@@ -245,9 +245,6 @@ export type SetOptions = {
 
 // @public
 export interface Settings {
-    cacheSizeBytes?: number;
-    experimentalAutoDetectLongPolling?: boolean;
-    experimentalForceLongPolling?: boolean;
     host?: string;
     ignoreUndefinedProperties?: boolean;
     ssl?: boolean;

--- a/packages/firestore/src/exp/reference_impl.ts
+++ b/packages/firestore/src/exp/reference_impl.ts
@@ -418,7 +418,7 @@ export function addDoc<T>(
 }
 
 /**
- * A function returns by `onSnapshot() `that removes the listener when invoked.
+ * A function returned by `onSnapshot()` that removes the listener when invoked.
  */
 export interface Unsubscribe {
   /** Removes the listener when invoked. */

--- a/packages/firestore/src/exp/reference_impl.ts
+++ b/packages/firestore/src/exp/reference_impl.ts
@@ -417,7 +417,11 @@ export function addDoc<T>(
   return executeWrite(firestore, [mutation]).then(() => docRef);
 }
 
+/**
+ * A function returns by `onSnapshot() `that removes the listener when invoked.
+ */
 export interface Unsubscribe {
+  /** Removes the listener when invoked. */
   (): void;
 }
 

--- a/packages/firestore/src/exp/settings.ts
+++ b/packages/firestore/src/exp/settings.ts
@@ -20,7 +20,7 @@ import { Settings as LiteSettings } from '../lite/settings';
 export { DEFAULT_HOST } from '../lite/settings';
 
 /**
- * Settings that can be passed to Firestore.enablePersistence() to configure
+ * Settings that can be passed to `enableIndexedDbPersistence()` to configure
  * Firestore persistence.
  */
 export interface PersistenceSettings {
@@ -46,7 +46,33 @@ export interface Settings extends LiteSettings {
    * attempted.
    *
    * The default value is 40 MB. The threshold must be set to at least 1 MB, and
-   * can be set to CACHE_SIZE_UNLIMITED to disable garbage collection.
+   * can be set to `CACHE_SIZE_UNLIMITED` to disable garbage collection.
    */
   cacheSizeBytes?: number;
+
+  /**
+   * Forces the SDK’s underlying network transport (WebChannel) to use
+   * long-polling. Each response from the backend will be closed immediately
+   * after the backend sends data (by default responses are kept open in
+   * case the backend has more data to send). This avoids incompatibility
+   * issues with certain proxies, antivirus software, etc. that incorrectly
+   * buffer traffic indefinitely. Use of this option will cause some
+   * performance degradation though.
+   *
+   * This setting cannot be used with `experimentalAutoDetectLongPolling` and
+   * may be removed in a future release. If you find yourself using it to
+   * work around a specific network reliability issue, please tell us about
+   * it in https://github.com/firebase/firebase-js-sdk/issues/1674.
+   */
+  experimentalForceLongPolling?: boolean;
+
+  /**
+   * Configures the SDK's underlying transport (WebChannel) to automatically
+   * detect if long-polling should be used. This is very similar to
+   * `experimentalForceLongPolling`, but only uses long-polling if required.
+   *
+   * This setting will likely be enabled by default in future releases and
+   * cannot be combined with `experimentalForceLongPolling`.
+   */
+  experimentalAutoDetectLongPolling?: boolean;
 }

--- a/packages/firestore/src/exp/settings.ts
+++ b/packages/firestore/src/exp/settings.ts
@@ -19,10 +19,34 @@ import { Settings as LiteSettings } from '../lite/settings';
 
 export { DEFAULT_HOST } from '../lite/settings';
 
+/**
+ * Settings that can be passed to Firestore.enablePersistence() to configure
+ * Firestore persistence.
+ */
 export interface PersistenceSettings {
+  /**
+   * Whether to force enable persistence for the client. This cannot be used
+   * with multi-tab synchronization and is primarily intended for use with Web
+   * Workers. Setting this to `true` will enable persistence, but cause other
+   * tabs using persistence to fail.
+   */
   forceOwnership?: boolean;
 }
 
+/**
+ * Specifies custom configurations for your Cloud Firestore instance.
+ * You must set these before invoking any other methods.
+ */
 export interface Settings extends LiteSettings {
+  /**
+   * An approximate cache size threshold for the on-disk data. If the cache
+   * grows beyond this size, Firestore will start removing data that hasn't been
+   * recently used. The size is not a guarantee that the cache will stay below
+   * that size, only that if the cache exceeds the given size, cleanup will be
+   * attempted.
+   *
+   * The default value is 40 MB. The threshold must be set to at least 1 MB, and
+   * can be set to CACHE_SIZE_UNLIMITED to disable garbage collection.
+   */
   cacheSizeBytes?: number;
 }

--- a/packages/firestore/src/lite/database.ts
+++ b/packages/firestore/src/lite/database.ts
@@ -137,6 +137,7 @@ export class FirebaseFirestore implements FirestoreService {
     return this._terminateTask;
   }
 
+  /** Returns a JSON-serializable representation of this Firestore instance. */
   toJSON(): object {
     return {
       app: this._app,

--- a/packages/firestore/src/lite/field_value.ts
+++ b/packages/firestore/src/lite/field_value.ts
@@ -29,7 +29,7 @@ export abstract class FieldValue {
    */
   constructor(public _methodName: string) {}
 
-  /** Compares FieldValues for equality. */
+  /** Compares `FieldValue`s for equality. */
   abstract isEqual(other: FieldValue): boolean;
   abstract _toFieldTransform(context: ParseContext): FieldTransform | null;
 }

--- a/packages/firestore/src/lite/geo_point.ts
+++ b/packages/firestore/src/lite/geo_point.ts
@@ -79,6 +79,7 @@ export class GeoPoint {
     return this._lat === other._lat && this._long === other._long;
   }
 
+  /** Returns a JSON-serializable representation of this GeoPoint. */
   toJSON(): { latitude: number; longitude: number } {
     return { latitude: this._lat, longitude: this._long };
   }

--- a/packages/firestore/src/lite/reference.ts
+++ b/packages/firestore/src/lite/reference.ts
@@ -43,6 +43,7 @@ import { FirestoreDataConverter } from './snapshot';
  * values.
  */
 export interface DocumentData {
+  /** A mapping between a field and its value. */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   [field: string]: any;
 }
@@ -53,6 +54,7 @@ export interface DocumentData {
  * nested fields within the document.
  */
 export interface UpdateData {
+  /** A mapping between a dot-separated field path and its value. */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   [fieldPath: string]: any;
 }
@@ -139,15 +141,17 @@ export class DocumentReference<T = DocumentData> {
    * instance, the provided converter will convert between Firestore data and
    * your custom type `U`.
    *
-   * Passing in `null` as the converter parameter removes the current
-   * converter.
-   *
-   * @param converter - Converts objects to and from Firestore. Passing in
-   * `null` removes the current converter.
+   * @param converter - Converts objects to and from Firestore.
    * @returns A `DocumentReference<U>` that uses the provided converter.
    */
-  withConverter(converter: null): DocumentReference<DocumentData>;
   withConverter<U>(converter: FirestoreDataConverter<U>): DocumentReference<U>;
+  /**
+   * Removes the current converter.
+   *
+   * @param converter - `null'`removes the current converter.
+   * @returns A `DocumentReference<DocumentData>` that does not use a converter.
+   */
+  withConverter(converter: null): DocumentReference<DocumentData>;
   withConverter<U>(
     converter: FirestoreDataConverter<U> | null
   ): DocumentReference<U> {
@@ -181,6 +185,13 @@ export class Query<T = DocumentData> {
   }
 
   /**
+   * Removes the current converter.
+   *
+   * @param converter - `null'`removes the current converter.
+   * @returns A `Query<DocumentData>` that does not use a converter.
+   */
+  withConverter(converter: null): Query<DocumentData>;
+  /**
    * Applies a custom data converter to this query, allowing you to use your own
    * custom model objects with Firestore. When you call {@link getDocs} with
    * the returned query, the provided converter will convert between Firestore
@@ -189,7 +200,6 @@ export class Query<T = DocumentData> {
    * @param converter - Converts objects to and from Firestore.
    * @returns A `Query<U>` that uses the provided converter.
    */
-  withConverter(converter: null): Query<DocumentData>;
   withConverter<U>(converter: FirestoreDataConverter<U>): Query<U>;
   withConverter<U>(converter: FirestoreDataConverter<U> | null): Query<U> {
     return new Query<U>(this.firestore, converter, this._query);
@@ -201,11 +211,12 @@ export class Query<T = DocumentData> {
  * document references, and querying for documents (using {@link query}).
  */
 export class CollectionReference<T = DocumentData> extends Query<T> {
+  /** The type of this Firestore reference. */
   readonly type = 'collection';
 
   /** @hideconstructor */
   constructor(
-    readonly firestore: FirebaseFirestore,
+    firestore: FirebaseFirestore,
     converter: FirestoreDataConverter<T> | null,
     readonly _path: ResourcePath
   ) {
@@ -251,10 +262,17 @@ export class CollectionReference<T = DocumentData> extends Query<T> {
    * @param converter - Converts objects to and from Firestore.
    * @returns A `CollectionReference<U>` that uses the provided converter.
    */
-  withConverter(converter: null): CollectionReference<DocumentData>;
   withConverter<U>(
     converter: FirestoreDataConverter<U>
   ): CollectionReference<U>;
+  /**
+   * Removes the current converter.
+   *
+   * @param converter - `null'`removes the current converter.
+   * @returns A `CollectionReference<DocumentData>` that does not use a
+   * converter.
+   */
+  withConverter(converter: null): CollectionReference<DocumentData>;
   withConverter<U>(
     converter: FirestoreDataConverter<U> | null
   ): CollectionReference<U> {

--- a/packages/firestore/src/lite/reference.ts
+++ b/packages/firestore/src/lite/reference.ts
@@ -148,7 +148,7 @@ export class DocumentReference<T = DocumentData> {
   /**
    * Removes the current converter.
    *
-   * @param converter - `null'`removes the current converter.
+   * @param converter - `null` removes the current converter.
    * @returns A `DocumentReference<DocumentData>` that does not use a converter.
    */
   withConverter(converter: null): DocumentReference<DocumentData>;
@@ -187,7 +187,7 @@ export class Query<T = DocumentData> {
   /**
    * Removes the current converter.
    *
-   * @param converter - `null'`removes the current converter.
+   * @param converter - `null` removes the current converter.
    * @returns A `Query<DocumentData>` that does not use a converter.
    */
   withConverter(converter: null): Query<DocumentData>;
@@ -268,7 +268,7 @@ export class CollectionReference<T = DocumentData> extends Query<T> {
   /**
    * Removes the current converter.
    *
-   * @param converter - `null'`removes the current converter.
+   * @param converter - `null` removes the current converter.
    * @returns A `CollectionReference<DocumentData>` that does not use a
    * converter.
    */

--- a/packages/firestore/src/lite/settings.ts
+++ b/packages/firestore/src/lite/settings.ts
@@ -28,12 +28,61 @@ import { validateIsNotUsedTogether } from '../util/input_validation';
 export const DEFAULT_HOST = 'firestore.googleapis.com';
 export const DEFAULT_SSL = true;
 
+/**
+ * Specifies custom configurations for your Cloud Firestore instance.
+ * You must set these before invoking any other methods.
+ */
 export interface Settings {
+  /** The hostname to connect to. */
   host?: string;
+
+  /** Whether to use SSL when connecting. */
   ssl?: boolean;
+
+  /**
+   * Whether to skip nested properties that are set to `undefined` during
+   * object serialization. If set to `true`, these properties are skipped
+   * and not written to Firestore. If set to `false` or omitted, the SDK
+   * throws an exception when it encounters properties of type `undefined`.
+   */
   ignoreUndefinedProperties?: boolean;
+
+  /**
+   * An approximate cache size threshold for the on-disk data. If the cache
+   * grows beyond this size, Firestore will start removing data that hasn't been
+   * recently used. The size is not a guarantee that the cache will stay below
+   * that size, only that if the cache exceeds the given size, cleanup will be
+   * attempted.
+   *
+   * The default value is 40 MB. The threshold must be set to at least 1 MB, and
+   * can be set to CACHE_SIZE_UNLIMITED to disable garbage collection.
+   */
   cacheSizeBytes?: number;
+
+  /**
+   * Forces the SDK’s underlying network transport (WebChannel) to use
+   * long-polling. Each response from the backend will be closed immediately
+   * after the backend sends data (by default responses are kept open in
+   * case the backend has more data to send). This avoids incompatibility
+   * issues with certain proxies, antivirus software, etc. that incorrectly
+   * buffer traffic indefinitely. Use of this option will cause some
+   * performance degradation though.
+   *
+   * This setting cannot be used with `experimentalAutoDetectLongPolling` and
+   * may be removed in a future release. If you find yourself using it to
+   * work around a specific network reliability issue, please tell us about
+   * it in https://github.com/firebase/firebase-js-sdk/issues/1674.
+   */
   experimentalForceLongPolling?: boolean;
+
+  /**
+   * Configures the SDK's underlying transport (WebChannel) to automatically
+   * detect if long-polling should be used. This is very similar to
+   * `experimentalForceLongPolling`, but only uses long-polling if required.
+   *
+   * This setting will likely be enabled by default in future releases and
+   * cannot be combined with `experimentalForceLongPolling`.
+   */
   experimentalAutoDetectLongPolling?: boolean;
 }
 

--- a/packages/firestore/src/lite/settings.ts
+++ b/packages/firestore/src/lite/settings.ts
@@ -46,50 +46,18 @@ export interface Settings {
    * throws an exception when it encounters properties of type `undefined`.
    */
   ignoreUndefinedProperties?: boolean;
-
-  /**
-   * An approximate cache size threshold for the on-disk data. If the cache
-   * grows beyond this size, Firestore will start removing data that hasn't been
-   * recently used. The size is not a guarantee that the cache will stay below
-   * that size, only that if the cache exceeds the given size, cleanup will be
-   * attempted.
-   *
-   * The default value is 40 MB. The threshold must be set to at least 1 MB, and
-   * can be set to CACHE_SIZE_UNLIMITED to disable garbage collection.
-   */
-  cacheSizeBytes?: number;
-
-  /**
-   * Forces the SDK’s underlying network transport (WebChannel) to use
-   * long-polling. Each response from the backend will be closed immediately
-   * after the backend sends data (by default responses are kept open in
-   * case the backend has more data to send). This avoids incompatibility
-   * issues with certain proxies, antivirus software, etc. that incorrectly
-   * buffer traffic indefinitely. Use of this option will cause some
-   * performance degradation though.
-   *
-   * This setting cannot be used with `experimentalAutoDetectLongPolling` and
-   * may be removed in a future release. If you find yourself using it to
-   * work around a specific network reliability issue, please tell us about
-   * it in https://github.com/firebase/firebase-js-sdk/issues/1674.
-   */
-  experimentalForceLongPolling?: boolean;
-
-  /**
-   * Configures the SDK's underlying transport (WebChannel) to automatically
-   * detect if long-polling should be used. This is very similar to
-   * `experimentalForceLongPolling`, but only uses long-polling if required.
-   *
-   * This setting will likely be enabled by default in future releases and
-   * cannot be combined with `experimentalForceLongPolling`.
-   */
-  experimentalAutoDetectLongPolling?: boolean;
 }
 
 /** Undocumented, private additional settings not exposed in our public API. */
 export interface PrivateSettings extends Settings {
   // Can be a google-auth-library or gapi client.
   credentials?: CredentialsSettings;
+  // Used in firestore@exp
+  cacheSizeBytes?: number;
+  // Used in firestore@exp
+  experimentalForceLongPolling?: boolean;
+  // Used in firestore@exp
+  experimentalAutoDetectLongPolling?: boolean;
 }
 
 /**

--- a/packages/firestore/src/lite/timestamp.ts
+++ b/packages/firestore/src/lite/timestamp.ts
@@ -81,7 +81,16 @@ export class Timestamp {
    *     non-negative nanoseconds values that count forward in time. Must be
    *     from 0 to 999,999,999 inclusive.
    */
-  constructor(readonly seconds: number, readonly nanoseconds: number) {
+  constructor(
+    /**
+     * The number of seconds of UTC time since Unix epoch 1970-01-01T00:00:00Z.
+     */
+    readonly seconds: number,
+    /**
+     * The fractions of a second at nanosecond resolution.*
+     */
+    readonly nanoseconds: number
+  ) {
     if (nanoseconds < 0) {
       throw new FirestoreError(
         Code.INVALID_ARGUMENT,
@@ -110,8 +119,9 @@ export class Timestamp {
   }
 
   /**
-   * Converts a `Timestamp` to a JavaScript `Date` object. This conversion causes
-   * a loss of precision since `Date` objects only support millisecond precision.
+   * Converts a `Timestamp` to a JavaScript `Date` object. This conversion
+   * causes a loss of precision since `Date` objects only support millisecond
+   * precision.
    *
    * @returns JavaScript `Date` object representing the same point in time as
    *     this `Timestamp`, with millisecond precision.
@@ -150,6 +160,7 @@ export class Timestamp {
     );
   }
 
+  /** Returns a textual representation of this Timestamp. */
   toString(): string {
     return (
       'Timestamp(seconds=' +
@@ -160,23 +171,26 @@ export class Timestamp {
     );
   }
 
+  /** Returns a JSON-serializable representation of this Timestamp. */
   toJSON(): { seconds: number; nanoseconds: number } {
     return { seconds: this.seconds, nanoseconds: this.nanoseconds };
   }
 
   /**
-   * Converts this object to a primitive string, which allows Timestamp objects to be compared
-   * using the `>`, `<=`, `>=` and `>` operators.
+   * Converts this object to a primitive string, which allows Timestamp objects
+   * to be compared using the `>`, `<=`, `>=` and `>` operators.
    */
   valueOf(): string {
-    // This method returns a string of the form <seconds>.<nanoseconds> where <seconds> is
-    // translated to have a non-negative value and both <seconds> and <nanoseconds> are left-padded
-    // with zeroes to be a consistent length. Strings with this format then have a lexiographical
-    // ordering that matches the expected ordering. The <seconds> translation is done to avoid
-    // having a leading negative sign (i.e. a leading '-' character) in its string representation,
-    // which would affect its lexiographical ordering.
+    // This method returns a string of the form <seconds>.<nanoseconds> where
+    // <seconds> is translated to have a non-negative value and both <seconds>
+    // and <nanoseconds> are left-padded with zeroes to be a consistent length.
+    // Strings with this format then have a lexiographical ordering that matches
+    // the expected ordering. The <seconds> translation is done to avoid having
+    // a leading negative sign (i.e. a leading '-' character) in its string
+    // representation, which would affect its lexiographical ordering.
     const adjustedSeconds = this.seconds - MIN_SECONDS;
-    // Note: Up to 12 decimal digits are required to represent all valid 'seconds' values.
+    // Note: Up to 12 decimal digits are required to represent all valid
+    // 'seconds' values.
     const formattedSeconds = String(adjustedSeconds).padStart(12, '0');
     const formattedNanoseconds = String(this.nanoseconds).padStart(9, '0');
     return formattedSeconds + '.' + formattedNanoseconds;

--- a/packages/firestore/src/util/error.ts
+++ b/packages/firestore/src/util/error.ts
@@ -209,11 +209,23 @@ export const Code = {
 
 /** An error returned by a Firestore operation. */
 export class FirestoreError extends Error {
+  /** The custom name for all FirestoreErrors. */
   readonly name: string = 'FirebaseError';
+
+  /** The stack of the error. */
   readonly stack?: string;
 
   /** @hideconstructor */
-  constructor(readonly code: FirestoreErrorCode, readonly message: string) {
+  constructor(
+    /**
+     * The backend error code associated with this error.
+     */
+    readonly code: FirestoreErrorCode,
+    /**
+     * A custom error description.
+     */
+    readonly message: string
+  ) {
     super(message);
 
     // HACK: We write a toString property directly because Error is not a real

--- a/repo-scripts/prune-dts/tests/firestore.output.d.ts
+++ b/repo-scripts/prune-dts/tests/firestore.output.d.ts
@@ -445,7 +445,13 @@ export declare class DocumentSnapshot<T = DocumentData> {
    * field exists in the document.
    */
   get(fieldPath: string | FieldPath, options?: SnapshotOptions): any;
+  /**
+   * Property of the `DocumentSnapshot` that provides the document's ID.
+   */
   get id(): string;
+  /**
+   * The `DocumentReference` for the document included in the `DocumentSnapshot`.
+   */
   get ref(): DocumentReference<T>;
 }
 /**
@@ -595,6 +601,10 @@ export declare abstract class FieldValue {
  */
 export declare class FirebaseFirestore {
   private constructor();
+  /**
+   * The {@link FirebaseApp} associated with this `Firestore` service
+   * instance.
+   */
   get app(): FirebaseApp;
   toJSON(): object;
 }
@@ -1784,19 +1794,69 @@ export declare class Transaction {
    * @returns A `DocumentSnapshot` with the read data.
    */
   get<T>(documentRef: DocumentReference<T>): Promise<DocumentSnapshot<T>>;
+  /**
+   * Writes to the document referred to by the provided {@link
+   * DocumentReference}. If the document does not exist yet, it will be created.
+   *
+   * @param documentRef - A reference to the document to be set.
+   * @param data - An object of the fields and values for the document.
+   * @returns This `Transaction` instance. Used for chaining method calls.
+   */
   set<T>(documentRef: DocumentReference<T>, data: T): this;
+  /**
+   * Writes to the document referred to by the provided {@link
+   * DocumentReference}. If the document does not exist yet, it will be created.
+   * If you provide `merge` or `mergeFields`, the provided data can be merged
+   * into an existing document.
+   *
+   * @param documentRef - A reference to the document to be set.
+   * @param data - An object of the fields and values for the document.
+   * @param options - An object to configure the set behavior.
+   * @returns This `Transaction` instance. Used for chaining method calls.
+   */
   set<T>(
     documentRef: DocumentReference<T>,
     data: Partial<T>,
     options: SetOptions
   ): this;
+  /**
+     * Updates fields in the document referred to by the provided {@link
+     * DocumentReference}. The update will fail if applied to a document that does
+     * not exist.
+     * 
+     * @param documentRef - A reference to the document to be updated.
+     * @param data - An object containing the fields and values with which to
+update the document. Fields can contain dots to reference nested fields
+within the document.
+     * @returns This `Transaction` instance. Used for chaining method calls.
+     */
   update(documentRef: DocumentReference<unknown>, data: UpdateData): this;
+  /**
+   * Updates fields in the document referred to by the provided {@link
+   * DocumentReference}. The update will fail if applied to a document that does
+   * not exist.
+   *
+   * Nested fields can be updated by providing dot-separated field path
+   * strings or by providing `FieldPath` objects.
+   *
+   * @param documentRef - A reference to the document to be updated.
+   * @param field - The first field to update.
+   * @param value - The first value.
+   * @param moreFieldsAndValues - Additional key/value pairs.
+   * @returns This `Transaction` instance. Used for chaining method calls.
+   */
   update(
     documentRef: DocumentReference<unknown>,
     field: string | FieldPath,
     value: unknown,
     ...moreFieldsAndValues: unknown[]
   ): this;
+  /**
+   * Deletes the document referred to by the provided {@link DocumentReference}.
+   *
+   * @param documentRef - A reference to the document to be deleted.
+   * @returns This `Transaction` instance. Used for chaining method calls.
+   */
   delete(documentRef: DocumentReference<unknown>): this;
 }
 export declare interface Unsubscribe {

--- a/repo-scripts/prune-dts/tests/propagates-comments.input.d.ts
+++ b/repo-scripts/prune-dts/tests/propagates-comments.input.d.ts
@@ -15,21 +15,27 @@
  * limitations under the License.
  */
 
-import { ParseContext } from '../api/parse_context';
-import { FieldTransform } from '../model/mutation';
-
-/**
- * Sentinel values that can be used when writing document fields with `set()`
- * or `update()`.
- */
-export abstract class FieldValue {
+declare class A {
+  /** a */
+  a: string;
   /**
-   * @param _methodName - The public API endpoint that returns this class.
-   * @hideconstructor
+   * b1 first line
+   *
+   * b1 second line
+   *
+   * @param b1 b1 param
+   * @returns b1 return
    */
-  constructor(public _methodName: string) {}
-
-  /** Compares FieldValues for equality. */
-  abstract isEqual(other: FieldValue): boolean;
-  abstract _toFieldTransform(context: ParseContext): FieldTransform | null;
+  b(b1: string): string;
+  /**
+   * b2 first line
+   *
+   * b2 second line
+   *
+   * @param b2 b2 param
+   * @returns b2 return
+   */
+  b(b2: string): string;
 }
+export class B extends A {}
+export {};

--- a/repo-scripts/prune-dts/tests/propagates-comments.output.d.ts
+++ b/repo-scripts/prune-dts/tests/propagates-comments.output.d.ts
@@ -14,22 +14,28 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-import { ParseContext } from '../api/parse_context';
-import { FieldTransform } from '../model/mutation';
-
-/**
- * Sentinel values that can be used when writing document fields with `set()`
- * or `update()`.
- */
-export abstract class FieldValue {
+export class B {
   /**
-   * @param _methodName - The public API endpoint that returns this class.
-   * @hideconstructor
+   * a
    */
-  constructor(public _methodName: string) {}
-
-  /** Compares FieldValues for equality. */
-  abstract isEqual(other: FieldValue): boolean;
-  abstract _toFieldTransform(context: ParseContext): FieldTransform | null;
+  a: string;
+  /**
+   * b1 first line
+   *
+   * b1 second line
+   *
+   * @param b1 b1 param
+   * @returns b1 return
+   */
+  b(b1: string): string;
+  /**
+   * b2 first line
+   *
+   * b2 second line
+   *
+   * @param b2 b2 param
+   * @returns b2 return
+   */
+  b(b2: string): string;
 }
+export {};


### PR DESCRIPTION
Add missing comments for Firestore's Public API and modify the API generation script to pull JSDoc comments from a hidden superclass to the new location.