### PR TITLE
Don't log token parse error for missing token

### DIFF
--- a/.changeset/gold-jobs-invent.md
+++ b/.changeset/gold-jobs-invent.md
@@ -1,0 +1,5 @@
+---
+"@firebase/util": patch
+---
+
+Suppresses an error message when parsing non-admin Auth tokens.

--- a/packages/util/src/jwt.ts
+++ b/packages/util/src/jwt.ts
@@ -44,8 +44,8 @@ export const decode = function (token: string): DecodedToken {
 
   try {
     const parts = token.split('.');
-    header = jsonEval(base64Decode(parts[0]) || '') as object;
-    claims = jsonEval(base64Decode(parts[1]) || '') as Claims;
+    header = (parts[0] ? jsonEval(base64Decode(parts[0]) || '') : {}) as object;
+    claims = (parts[1] ? jsonEval(base64Decode(parts[1]) || '') : {}) as Claims;
     signature = parts[2];
     data = claims['d'] || {};
     delete claims['d'];


### PR DESCRIPTION
This should fix an error we print to the console during RTDB startup:

base64Decode failed:  TypeError: Cannot read property 'length' of undefined
    at Object.decodeStringToByteArray (firebase-database.js:formatted:290)
    at Object.decodeString (firebase-database.js:formatted:286)
    at a (firebase-database.js:formatted:220)
    at k (firebase-database.js:formatted:415)
    at D (firebase-database.js:formatted:428)
    at Function.fi.connectionURL_ (firebase-database.js:formatted:5499)
    at new fi (firebase-database.js:formatted:5664)
    at vi.start_ (firebase-database.js:formatted:5719)
    at new vi (firebase-database.js:formatted:5992)
    at bi.<anonymous> (firebase-database.js:formatted:6390)


This is logged when we verify whether a token is an admin token when it is not.