### PR TITLE
Add storage.useEmulator to exp global typings

### DIFF
--- a/packages-exp/firebase-exp/compat/index.d.ts
+++ b/packages-exp/firebase-exp/compat/index.d.ts
@@ -7646,6 +7646,13 @@ declare namespace firebase.storage {
      * @see {@link firebase.storage.Storage.maxUploadRetryTime}
      */
     setMaxUploadRetryTime(time: number): any;
+    /**
+     * Modify this `Storage` instance to communicate with the Cloud Storage emulator.
+     *
+     * @param host - The emulator host (ex: localhost)
+     * @param port - The emulator port (ex: 5001)
+     */
+    useEmulator(host: string, port: number): void;
   }
 
   /**

--- a/packages/firebase/index.d.ts
+++ b/packages/firebase/index.d.ts
@@ -7618,7 +7618,7 @@ declare namespace firebase.storage {
      * @param host - The emulator host (ex: localhost)
      * @param port - The emulator port (ex: 5001)
      */
-    useEmulator(host: string, port: string): void;
+    useEmulator(host: string, port: number): void;
   }
 
   /**


### PR DESCRIPTION
Added to firebase/index.d.ts but forgot to add to firebase-exp/index.d.ts. Also the signature was wrong.