### PR TITLE
Make Converter explicit

### DIFF
--- a/packages/firestore/src/api/database.ts
+++ b/packages/firestore/src/api/database.ts
@@ -409,7 +409,7 @@ export class Transaction implements PublicTransaction, Compat<ExpTransaction> {
               result._key,
               result._document,
               result.metadata,
-              ref._converter
+              ref.converter
             )
           )
       );
@@ -775,7 +775,7 @@ export class DocumentReference<T = PublicDocumentData>
             result._key,
             result._document,
             result.metadata,
-            this._delegate._converter
+            this._delegate.converter
           )
         )
     );
@@ -802,7 +802,7 @@ export class DocumentReference<T = PublicDocumentData>
             result._key,
             result._document,
             result.metadata,
-            this._delegate._converter as UntypedFirestoreDataConverter<T>
+            this._delegate.converter as UntypedFirestoreDataConverter<T>
           )
         )
     );

--- a/packages/firestore/src/exp/database.ts
+++ b/packages/firestore/src/exp/database.ts
@@ -80,6 +80,8 @@ export const CACHE_SIZE_UNLIMITED = LRU_COLLECTION_DISABLED;
  * Do not call this constructor directly. Instead, use {@link getFirestore}.
  */
 export class FirebaseFirestore extends LiteFirestore {
+  type: 'firestore-lite' | 'firestore' = 'firestore';
+
   readonly _queue: AsyncQueue = newAsyncQueue();
   readonly _persistenceKey: string;
 

--- a/packages/firestore/src/exp/reference_impl.ts
+++ b/packages/firestore/src/exp/reference_impl.ts
@@ -143,7 +143,7 @@ export function getDocFromCache<T>(
           doc !== null && doc.hasLocalMutations,
           /* fromCache= */ true
         ),
-        reference._converter
+        reference.converter
       )
   );
 }
@@ -270,7 +270,7 @@ export function setDoc<T>(
   const firestore = cast(reference.firestore, FirebaseFirestore);
 
   const convertedValue = applyFirestoreDataConverter(
-    reference._converter,
+    reference.converter,
     data,
     options
   );
@@ -280,7 +280,7 @@ export function setDoc<T>(
     'setDoc',
     reference._key,
     convertedValue,
-    reference._converter !== null,
+    reference.converter !== null,
     options
   );
 
@@ -398,10 +398,7 @@ export function addDoc<T>(
   const firestore = cast(reference.firestore, FirebaseFirestore);
 
   const docRef = doc(reference);
-  const convertedValue = applyFirestoreDataConverter(
-    reference._converter,
-    data
-  );
+  const convertedValue = applyFirestoreDataConverter(reference.converter, data);
 
   const dataReader = newUserDataReader(reference.firestore);
   const parsed = parseSetData(
@@ -409,7 +406,7 @@ export function addDoc<T>(
     'addDoc',
     docRef._key,
     convertedValue,
-    reference._converter !== null,
+    reference.converter !== null,
     {}
   );
 
@@ -794,6 +791,6 @@ function convertToDocSnapshot<T>(
     ref._key,
     doc,
     new SnapshotMetadata(snapshot.hasPendingWrites, snapshot.fromCache),
-    ref._converter
+    ref.converter
   );
 }

--- a/packages/firestore/src/exp/snapshot.ts
+++ b/packages/firestore/src/exp/snapshot.ts
@@ -427,7 +427,7 @@ export class QuerySnapshot<T = DocumentData> {
             this._snapshot.mutatedKeys.has(doc.key),
             this._snapshot.fromCache
           ),
-          this.query._converter
+          this.query.converter
         )
       );
     });
@@ -497,7 +497,7 @@ export function changesFromSnapshot<T>(
           querySnapshot._snapshot.mutatedKeys.has(change.doc.key),
           querySnapshot._snapshot.fromCache
         ),
-        querySnapshot.query._converter
+        querySnapshot.query.converter
       );
       lastDoc = change.doc;
       return {
@@ -525,7 +525,7 @@ export function changesFromSnapshot<T>(
             querySnapshot._snapshot.mutatedKeys.has(change.doc.key),
             querySnapshot._snapshot.fromCache
           ),
-          querySnapshot.query._converter
+          querySnapshot.query.converter
         );
         let oldIndex = -1;
         let newIndex = -1;

--- a/packages/firestore/src/exp/transaction.ts
+++ b/packages/firestore/src/exp/transaction.ts
@@ -66,7 +66,7 @@ export class Transaction extends LiteTransaction {
               /* hasPendingWrites= */ false,
               /* fromCache= */ false
             ),
-            ref._converter
+            ref.converter
           )
       );
   }

--- a/packages/firestore/src/lite/database.ts
+++ b/packages/firestore/src/lite/database.ts
@@ -56,6 +56,8 @@ declare module '@firebase/component' {
  * Do not call this constructor directly. Instead, use {@link getFirestore}.
  */
 export class FirebaseFirestore implements FirestoreService {
+  type: 'firestore-lite' | 'firestore' = 'firestore-lite';
+
   readonly _databaseId: DatabaseId;
   readonly _persistenceKey: string = '(lite)';
   _credentials: CredentialsProvider;

--- a/packages/firestore/src/lite/query.ts
+++ b/packages/firestore/src/lite/query.ts
@@ -147,7 +147,7 @@ class QueryFilterConstraint extends QueryConstraint {
     );
     return new Query(
       query.firestore,
-      query._converter,
+      query.converter,
       queryWithAddedFilter(query._query, filter)
     );
   }
@@ -205,7 +205,7 @@ class QueryOrderByConstraint extends QueryConstraint {
     const orderBy = newQueryOrderBy(query._query, this._field, this._direction);
     return new Query(
       query.firestore,
-      query._converter,
+      query.converter,
       queryWithAddedOrderBy(query._query, orderBy)
     );
   }
@@ -247,7 +247,7 @@ class QueryLimitConstraint extends QueryConstraint {
   _apply<T>(query: Query<T>): Query<T> {
     return new Query(
       query.firestore,
-      query._converter,
+      query.converter,
       queryWithLimit(query._query, this._limit, this._limitType)
     );
   }
@@ -296,7 +296,7 @@ class QueryStartAtConstraint extends QueryConstraint {
     );
     return new Query(
       query.firestore,
-      query._converter,
+      query.converter,
       queryWithStartAt(query._query, bound)
     );
   }
@@ -378,7 +378,7 @@ class QueryEndAtConstraint extends QueryConstraint {
     );
     return new Query(
       query.firestore,
-      query._converter,
+      query.converter,
       queryWithEndAt(query._query, bound)
     );
   }

--- a/packages/firestore/src/lite/reference.ts
+++ b/packages/firestore/src/lite/reference.ts
@@ -98,7 +98,10 @@ export class DocumentReference<T = DocumentData> {
   /** @hideconstructor */
   constructor(
     firestore: FirebaseFirestore,
-    readonly _converter: FirestoreDataConverter<T> | null,
+    /**
+     * If provided, the `FirestoreDataConverter` associated with this instance.
+     */
+    readonly converter: FirestoreDataConverter<T> | null,
     readonly _key: DocumentKey
   ) {
     this.firestore = firestore;
@@ -129,7 +132,7 @@ export class DocumentReference<T = DocumentData> {
   get parent(): CollectionReference<T> {
     return new CollectionReference<T>(
       this.firestore,
-      this._converter,
+      this.converter,
       this._key.path.popLast()
     );
   }
@@ -178,7 +181,10 @@ export class Query<T = DocumentData> {
   /** @hideconstructor protected */
   constructor(
     firestore: FirebaseFirestore,
-    readonly _converter: FirestoreDataConverter<T> | null,
+    /**
+     * If provided, the `FirestoreDataConverter` associated with this instance.
+     */
+    readonly converter: FirestoreDataConverter<T> | null,
     readonly _query: InternalQuery
   ) {
     this.firestore = firestore;
@@ -502,7 +508,7 @@ export function doc<T>(
     validateDocumentPath(absolutePath);
     return new DocumentReference(
       parent.firestore,
-      parent instanceof CollectionReference ? parent._converter : null,
+      parent instanceof CollectionReference ? parent.converter : null,
       new DocumentKey(absolutePath)
     );
   }
@@ -531,7 +537,7 @@ export function refEqual<T>(
     return (
       left.firestore === right.firestore &&
       left.path === right.path &&
-      left._converter === right._converter
+      left.converter === right.converter
     );
   }
   return false;
@@ -554,7 +560,7 @@ export function queryEqual<T>(left: Query<T>, right: Query<T>): boolean {
     return (
       left.firestore === right.firestore &&
       queryEquals(left._query, right._query) &&
-      left._converter === right._converter
+      left.converter === right.converter
     );
   }
   return false;

--- a/packages/firestore/src/lite/reference_impl.ts
+++ b/packages/firestore/src/lite/reference_impl.ts
@@ -134,7 +134,7 @@ export function getDoc<T>(
         userDataWriter,
         reference._key,
         document.isFoundDocument() ? document : null,
-        reference._converter
+        reference.converter
       );
     }
   );
@@ -166,7 +166,7 @@ export function getDocs<T>(query: Query<T>): Promise<QuerySnapshot<T>> {
           userDataWriter,
           doc.key,
           doc,
-          query._converter
+          query.converter
         )
     );
 
@@ -227,7 +227,7 @@ export function setDoc<T>(
 ): Promise<void> {
   reference = cast<DocumentReference<T>>(reference, DocumentReference);
   const convertedValue = applyFirestoreDataConverter(
-    reference._converter,
+    reference.converter,
     data,
     options
   );
@@ -237,7 +237,7 @@ export function setDoc<T>(
     'setDoc',
     reference._key,
     convertedValue,
-    reference._converter !== null,
+    reference.converter !== null,
     options
   );
 
@@ -378,10 +378,7 @@ export function addDoc<T>(
   reference = cast<CollectionReference<T>>(reference, CollectionReference);
   const docRef = doc(reference);
 
-  const convertedValue = applyFirestoreDataConverter(
-    reference._converter,
-    data
-  );
+  const convertedValue = applyFirestoreDataConverter(reference.converter, data);
 
   const dataReader = newUserDataReader(reference.firestore);
   const parsed = parseSetData(
@@ -389,7 +386,7 @@ export function addDoc<T>(
     'addDoc',
     docRef._key,
     convertedValue,
-    docRef._converter !== null,
+    docRef.converter !== null,
     {}
   );
 

--- a/packages/firestore/src/lite/transaction.ts
+++ b/packages/firestore/src/lite/transaction.ts
@@ -88,7 +88,7 @@ export class Transaction {
           userDataWriter,
           doc.key,
           doc,
-          ref._converter
+          ref.converter
         );
       } else if (doc.isNoDocument()) {
         return new DocumentSnapshot(
@@ -96,7 +96,7 @@ export class Transaction {
           userDataWriter,
           ref._key,
           null,
-          ref._converter
+          ref.converter
         );
       } else {
         throw fail(
@@ -138,7 +138,7 @@ export class Transaction {
   ): this {
     const ref = validateReference(documentRef, this._firestore);
     const convertedValue = applyFirestoreDataConverter(
-      ref._converter,
+      ref.converter,
       value,
       options
     );
@@ -147,7 +147,7 @@ export class Transaction {
       'Transaction.set',
       ref._key,
       convertedValue,
-      ref._converter !== null,
+      ref.converter !== null,
       options
     );
     this._transaction.set(ref._key, parsed);

--- a/packages/firestore/src/lite/write_batch.ts
+++ b/packages/firestore/src/lite/write_batch.ts
@@ -93,7 +93,7 @@ export class WriteBatch {
     const ref = validateReference(documentRef, this._firestore);
 
     const convertedValue = applyFirestoreDataConverter(
-      ref._converter,
+      ref.converter,
       data,
       options
     );
@@ -102,7 +102,7 @@ export class WriteBatch {
       'WriteBatch.set',
       ref._key,
       convertedValue,
-      ref._converter !== null,
+      ref.converter !== null,
       options
     );
     this._mutations.push(parsed.toMutation(ref._key, Precondition.none()));


### PR DESCRIPTION
Fixes: https://github.com/firebase/firebase-js-sdk/issues/4812

The current API does not retain the type of CollectionReference<T> and Query<T> since T is not referenced within these classes.

We also want to expose a type property on FirebaseFirestore. This is similar to the type property of FirebaseDatabase@exp  and helps TypeScript tell apart instances of Firestore, FirestorLite and RTDB.
