### PR TITLE
Fix db.useEmulator

### DIFF
--- a/.changeset/sweet-monkeys-warn.md
+++ b/.changeset/sweet-monkeys-warn.md
@@ -1,0 +1,5 @@
+---
+"@firebase/database": patch
+---
+
+Fixes a regression introduced with 8.4.1 that broke `useEmulator()`.

--- a/packages/database/src/core/PersistentConnection.ts
+++ b/packages/database/src/core/PersistentConnection.ts
@@ -773,7 +773,6 @@ export class PersistentConnection extends ServerActions {
       const onReady = this.onReady_.bind(this);
       const onDisconnect = this.onRealtimeDisconnect_.bind(this);
       const connId = this.id + ':' + PersistentConnection.nextConnectionId_++;
-      const self = this;
       const lastSessionId = this.lastSessionId;
       let canceled = false;
       let connection: Connection | null = null;
@@ -807,17 +806,17 @@ export class PersistentConnection extends ServerActions {
         .then(result => {
           if (!canceled) {
             log('getToken() completed. Creating connection.');
-            self.authToken_ = result && result.accessToken;
+            this.authToken_ = result && result.accessToken;
             connection = new Connection(
               connId,
-              self.repoInfo_,
-              self.applicationId_,
+              this.repoInfo_,
+              this.applicationId_,
               onDataMessage,
               onReady,
               onDisconnect,
               /* onKill= */ reason => {
-                warn(reason + ' (' + self.repoInfo_.toString() + ')');
-                self.interrupt(SERVER_KILL_INTERRUPT_REASON);
+                warn(reason + ' (' + this.repoInfo_.toString() + ')');
+                this.interrupt(SERVER_KILL_INTERRUPT_REASON);
               },
               lastSessionId
             );
@@ -826,7 +825,7 @@ export class PersistentConnection extends ServerActions {
           }
         })
         .then(null, error => {
-          self.log_('Failed to get token: ' + error);
+          this.log_('Failed to get token: ' + error);
           if (!canceled) {
             if (this.repoInfo_.nodeAdmin) {
               // This may be a critical error for the Admin Node.js SDK, so log a warning.

--- a/packages/database/src/exp/Database.ts
+++ b/packages/database/src/exp/Database.ts
@@ -217,7 +217,7 @@ export class FirebaseDatabase implements _FirebaseService {
 
   /** @hideconstructor */
   constructor(
-    private _repoInternal: Repo,
+    public _repoInternal: Repo,
     /** The FirebaseApp associated with this Realtime Database instance. */
     readonly app: FirebaseApp
   ) {}
@@ -300,7 +300,7 @@ export function useDatabaseEmulator(
     );
   }
   // Modify the repo to apply emulator settings
-  repoManagerApplyEmulatorSettings(db._repo, host, port);
+  repoManagerApplyEmulatorSettings(db._repoInternal, host, port);
 }
 
 /**


### PR DESCRIPTION
We need to invoke repoManagerApplyEmulatorSettings with db._repoInternal as db._repo starts the WebSocket connection if it hasn't yet been started and applies the production host.

Also random unrelated cleanup.

Fixes https://github.com/firebase/firebase-js-sdk/issues/4811