### PR TITLE
Fix cancelCallback for child_added events

### DIFF
--- a/.changeset/fluffy-oranges-cross.md
+++ b/.changeset/fluffy-oranges-cross.md
@@ -1,0 +1,5 @@
+---
+"@firebase/database": patch
+---
+
+Fixes an issue that prevented the SDK from firing cancel events for Rules violations.


### PR DESCRIPTION
Fixes https://github.com/firebase/firebase-js-sdk/issues/4818

This simplifies the code in ChildEventRegistration. The class is meant to support multiple callbacks, but only one cancel callback. This broke in our refactor. Luckily, the class is never used for more than callback, so I was able to simplify the code and also fix the bug (which was due to the fact that the cancel callback was never registered under 'cancel').