### PR TITLE
Add Node debug token support

### DIFF
--- a/packages/app-check/src/internal-api.test.ts
+++ b/packages/app-check/src/internal-api.test.ts
@@ -48,7 +48,6 @@ describe('internal api', () => {
   });
 
   afterEach(() => {
-    console.log('afterEach');
     clearState();
     removegreCAPTCHAScriptsOnPage();
   });
@@ -234,7 +233,6 @@ describe('internal api', () => {
     });
 
     it('returns the valid token in memory without making network request', async () => {
-      console.log('start returns the valid');
       const clock = useFakeTimers();
       activate(app, FAKE_SITE_KEY);
       setState(app, { ...getState(app), token: fakeRecaptchaAppCheckToken });
@@ -246,11 +244,9 @@ describe('internal api', () => {
       expect(clientStub).to.not.have.been.called;
 
       clock.restore();
-      console.log('end returns the valid');
     });
 
     it('force to get new token when forceRefresh is true', async () => {
-      console.log('start force to get new token');
       activate(app, FAKE_SITE_KEY);
       setState(app, { ...getState(app), token: fakeRecaptchaAppCheckToken });
 
@@ -262,11 +258,9 @@ describe('internal api', () => {
       expect(await getToken(app, true)).to.deep.equal({
         token: fakeRecaptchaAppCheckToken.token
       });
-      console.log('end force to get new token');
     });
 
     it('exchanges debug token if in debug mode', async () => {
-      console.log('start exchanges debug token');
       const exchangeTokenStub: SinonStub = stub(
         client,
         'exchangeToken'
@@ -282,7 +276,6 @@ describe('internal api', () => {
         'my-debug-token'
       );
       expect(token).to.deep.equal({ token: fakeRecaptchaAppCheckToken.token });
-      console.log('end exchanges debug token');
     });
   });
 
@@ -312,9 +305,6 @@ describe('internal api', () => {
           token: `fake-memory-app-check-token`
         });
         clock.restore();
-        console.log(
-          'done() in notifies the listener with the valid token in memory immediately'
-        );
         done();
       };
 
@@ -344,9 +334,6 @@ describe('internal api', () => {
           token: `fake-cached-app-check-token`
         });
         clock.restore();
-        console.log(
-          'done() in notifies the listener with the valid token in storage'
-        );
         done();
       };
 
@@ -359,9 +346,6 @@ describe('internal api', () => {
         expect(token).to.deep.equal({
           token: `my-debug-token`
         });
-        console.log(
-          'done() in notifies the listener with the debug token immediately'
-        );
         done();
       };
 

--- a/packages/app-check/src/internal-api.test.ts
+++ b/packages/app-check/src/internal-api.test.ts
@@ -48,6 +48,7 @@ describe('internal api', () => {
   });
 
   afterEach(() => {
+    console.log('afterEach');
     clearState();
     removegreCAPTCHAScriptsOnPage();
   });
@@ -305,6 +306,9 @@ describe('internal api', () => {
           token: `fake-memory-app-check-token`
         });
         clock.restore();
+        console.log(
+          'done() in notifies the listener with the valid token in memory immediately'
+        );
         done();
       };
 
@@ -334,6 +338,9 @@ describe('internal api', () => {
           token: `fake-cached-app-check-token`
         });
         clock.restore();
+        console.log(
+          'done() in notifies the listener with the valid token in storage'
+        );
         done();
       };
 
@@ -346,6 +353,9 @@ describe('internal api', () => {
         expect(token).to.deep.equal({
           token: `my-debug-token`
         });
+        console.log(
+          'done() in notifies the listener with the debug token immediately'
+        );
         done();
       };
 

--- a/packages/app-check/src/internal-api.test.ts
+++ b/packages/app-check/src/internal-api.test.ts
@@ -234,6 +234,7 @@ describe('internal api', () => {
     });
 
     it('returns the valid token in memory without making network request', async () => {
+      console.log('start returns the valid');
       const clock = useFakeTimers();
       activate(app, FAKE_SITE_KEY);
       setState(app, { ...getState(app), token: fakeRecaptchaAppCheckToken });
@@ -245,9 +246,11 @@ describe('internal api', () => {
       expect(clientStub).to.not.have.been.called;
 
       clock.restore();
+      console.log('end returns the valid');
     });
 
     it('force to get new token when forceRefresh is true', async () => {
+      console.log('start force to get new token');
       activate(app, FAKE_SITE_KEY);
       setState(app, { ...getState(app), token: fakeRecaptchaAppCheckToken });
 
@@ -259,9 +262,11 @@ describe('internal api', () => {
       expect(await getToken(app, true)).to.deep.equal({
         token: fakeRecaptchaAppCheckToken.token
       });
+      console.log('end force to get new token');
     });
 
     it('exchanges debug token if in debug mode', async () => {
+      console.log('start exchanges debug token');
       const exchangeTokenStub: SinonStub = stub(
         client,
         'exchangeToken'
@@ -277,6 +282,7 @@ describe('internal api', () => {
         'my-debug-token'
       );
       expect(token).to.deep.equal({ token: fakeRecaptchaAppCheckToken.token });
+      console.log('end exchanges debug token');
     });
   });
 

--- a/packages/database/src/realtime/WebSocketConnection.ts
+++ b/packages/database/src/realtime/WebSocketConnection.ts
@@ -166,10 +166,16 @@ export class WebSocketConnection implements Transport {
           }
         };
 
-        // Adding a comment to ask questions
+        // If using Node with admin creds, AppCheck-related checks are unnecessary.
+        // It will send the authorization token.
         if (this.nodeAdmin) {
           options.headers['Authorization'] = this.authToken || '';
         } else {
+          // If using Node without admin creds (which includes all uses of the
+          // client-side Node SDK), it will send an AppCheck token if available.
+          // Any other auth credentials will eventually be sent after the connection
+          // is established, but aren't needed here as they don't effect the initial
+          // request to establish a connection.
           options.headers['X-Firebase-AppCheck'] = this.appCheckToken || '';
         }
 

--- a/packages/database/src/realtime/WebSocketConnection.ts
+++ b/packages/database/src/realtime/WebSocketConnection.ts
@@ -166,6 +166,7 @@ export class WebSocketConnection implements Transport {
           }
         };
 
+        // Adding a comment to ask questions
         if (this.nodeAdmin) {
           options.headers['Authorization'] = this.authToken || '';
         } else {

--- a/packages/util/src/environment.ts
+++ b/packages/util/src/environment.ts
@@ -189,3 +189,20 @@ export function areCookiesEnabled(): boolean {
   }
   return true;
 }
+
+/**
+ * Polyfill for `globalThis` object.
+ * @returns the `globalThis` object for the given environment.
+ */
+export function getGlobal(): typeof globalThis {
+  if (typeof self !== 'undefined') {
+    return self;
+  }
+  if (typeof window !== 'undefined') {
+    return window;
+  }
+  if (typeof global !== 'undefined') {
+    return global;
+  }
+  throw new Error('Unable to locate global object.');
+}


### PR DESCRIPTION
Add ability for App Check to use debug token in Node by using `globalThis`.

In `app-check/src/util.ts`, `self` is also used in `self.grecaptcha` and I left that alone because Node can't use `grecaptcha` anyway.

See question about headers.