### PR TITLE
Implement App Check auto refresh timing and opt out flag

### DIFF
--- a/packages/app-check-types/index.d.ts
+++ b/packages/app-check-types/index.d.ts
@@ -18,9 +18,17 @@
 export interface FirebaseAppCheck {
   /**
    * Activate AppCheck
-   * @param siteKeyOrOrovider - reCAPTCHA sitekey or custom token provider
+   * @param siteKeyOrProvider - reCAPTCHA sitekey or custom token provider
+   * @param isTokenAutoRefreshEnabled - If true, enables SDK to automatically
+   * refresh AppCheck token as needed. If undefined, the value will default
+   * to the value of `app.automaticDataCollectionEnabled`. That property
+   * defaults to false and can be set in the app config.
    */
-  activate(siteKeyOrProvider: string | AppCheckProvider): void;
+  activate(
+    siteKeyOrProvider: string | AppCheckProvider,
+    isTokenAutoRefreshEnabled?: boolean
+  ): void;
+  setTokenAutoRefreshEnabled(isTokenAutoRefreshEnabled: boolean): void;
 }
 
 interface AppCheckProvider {

--- a/packages/app-check/src/api.test.ts
+++ b/packages/app-check/src/api.test.ts
@@ -17,7 +17,7 @@
 import '../test/setup';
 import { expect } from 'chai';
 import { stub } from 'sinon';
-import { activate } from './api';
+import { activate, setTokenAutoRefreshEnabled } from './api';
 import {
   FAKE_SITE_KEY,
   getFakeApp,
@@ -39,6 +39,18 @@ describe('api', () => {
       expect(getState(app).activated).to.equal(false);
       activate(app, FAKE_SITE_KEY);
       expect(getState(app).activated).to.equal(true);
+    });
+
+    it('isTokenAutoRefreshEnabled value defaults to global setting', () => {
+      app = getFakeApp({ automaticDataCollectionEnabled: false });
+      activate(app, FAKE_SITE_KEY);
+      expect(getState(app).isTokenAutoRefreshEnabled).to.equal(false);
+    });
+
+    it('sets isTokenAutoRefreshEnabled correctly, overriding global setting', () => {
+      app = getFakeApp({ automaticDataCollectionEnabled: false });
+      activate(app, FAKE_SITE_KEY, true);
+      expect(getState(app).isTokenAutoRefreshEnabled).to.equal(true);
     });
 
     it('can only be called once', () => {
@@ -65,6 +77,13 @@ describe('api', () => {
       activate(app, fakeCustomTokenProvider);
       expect(getState(app).customProvider).to.equal(fakeCustomTokenProvider);
       expect(initReCAPTCHAStub).to.have.not.been.called;
+    });
+  });
+  describe('setTokenAutoRefreshEnabled()', () => {
+    it('sets isTokenAutoRefreshEnabled correctly', () => {
+      const app = getFakeApp({ automaticDataCollectionEnabled: false });
+      setTokenAutoRefreshEnabled(app, true);
+      expect(getState(app).isTokenAutoRefreshEnabled).to.equal(true);
     });
   });
 });

--- a/packages/app-check/src/client.test.ts
+++ b/packages/app-check/src/client.test.ts
@@ -74,7 +74,8 @@ describe('client', () => {
 
     expect(response).to.deep.equal({
       token: 'fake-appcheck-token',
-      expireTimeMillis: 3600
+      expireTimeMillis: 3600,
+      issuedAtTimeMillis: 0
     });
   });
 

--- a/packages/app-check/src/client.ts
+++ b/packages/app-check/src/client.ts
@@ -22,8 +22,8 @@ import {
 } from './constants';
 import { FirebaseApp } from '@firebase/app-types';
 import { ERROR_FACTORY, AppCheckError } from './errors';
-import { AppCheckToken } from '@firebase/app-check-types';
 import { Provider } from '@firebase/component';
+import { AppCheckTokenInternal } from './state';
 
 /**
  * Response JSON returned from AppCheck server endpoint.
@@ -42,7 +42,7 @@ interface AppCheckRequest {
 export async function exchangeToken(
   { url, body }: AppCheckRequest,
   platformLoggerProvider: Provider<'platform-logger'>
-): Promise<AppCheckToken> {
+): Promise<AppCheckTokenInternal> {
   const headers: HeadersInit = {
     'Content-Type': 'application/json'
   };
@@ -95,9 +95,11 @@ export async function exchangeToken(
   }
   const timeToLiveAsNumber = Number(match[1]) * 1000;
 
+  const now = Date.now();
   return {
     token: responseBody.attestationToken,
-    expireTimeMillis: Date.now() + timeToLiveAsNumber
+    expireTimeMillis: now + timeToLiveAsNumber,
+    issuedAtTimeMillis: now
   };
 }
 

--- a/packages/app-check/src/factory.ts
+++ b/packages/app-check/src/factory.ts
@@ -16,7 +16,7 @@
  */
 
 import { FirebaseAppCheck, AppCheckProvider } from '@firebase/app-check-types';
-import { activate } from './api';
+import { activate, setTokenAutoRefreshEnabled } from './api';
 import { FirebaseApp } from '@firebase/app-types';
 import { FirebaseAppCheckInternal } from '@firebase/app-check-interop-types';
 import {
@@ -28,8 +28,12 @@ import { Provider } from '@firebase/component';
 
 export function factory(app: FirebaseApp): FirebaseAppCheck {
   return {
-    activate: (siteKeyOrProvider: string | AppCheckProvider) =>
-      activate(app, siteKeyOrProvider)
+    activate: (
+      siteKeyOrProvider: string | AppCheckProvider,
+      isTokenAutoRefreshEnabled?: boolean
+    ) => activate(app, siteKeyOrProvider, isTokenAutoRefreshEnabled),
+    setTokenAutoRefreshEnabled: (isTokenAutoRefreshEnabled: boolean) =>
+      setTokenAutoRefreshEnabled(app, isTokenAutoRefreshEnabled)
   };
 }
 

--- a/packages/app-check/src/indexeddb.ts
+++ b/packages/app-check/src/indexeddb.ts
@@ -15,9 +15,9 @@
  * limitations under the License.
  */
 
-import { AppCheckToken } from '@firebase/app-check-types';
 import { FirebaseApp } from '@firebase/app-types';
 import { ERROR_FACTORY, AppCheckError } from './errors';
+import { AppCheckTokenInternal } from './state';
 const DB_NAME = 'firebase-app-check-database';
 const DB_VERSION = 1;
 const STORE_NAME = 'firebase-app-check-store';
@@ -74,13 +74,13 @@ function getDBPromise(): Promise<IDBDatabase> {
 
 export function readTokenFromIndexedDB(
   app: FirebaseApp
-): Promise<AppCheckToken | undefined> {
-  return read(computeKey(app)) as Promise<AppCheckToken | undefined>;
+): Promise<AppCheckTokenInternal | undefined> {
+  return read(computeKey(app)) as Promise<AppCheckTokenInternal | undefined>;
 }
 
 export function writeTokenToIndexedDB(
   app: FirebaseApp,
-  token: AppCheckToken
+  token: AppCheckTokenInternal
 ): Promise<void> {
   return write(computeKey(app), token);
 }

--- a/packages/app-check/src/internal-api.test.ts
+++ b/packages/app-check/src/internal-api.test.ts
@@ -59,12 +59,14 @@ describe('internal api', () => {
     const fakeRecaptchaToken = 'fake-recaptcha-token';
     const fakeRecaptchaAppCheckToken = {
       token: 'fake-recaptcha-app-check-token',
-      expireTimeMillis: 123
+      expireTimeMillis: 123,
+      issuedAtTimeMillis: 0
     };
 
     const fakeCachedAppCheckToken = {
       token: 'fake-cached-app-check-token',
-      expireTimeMillis: 123
+      expireTimeMillis: 123,
+      issuedAtTimeMillis: 0
     };
 
     it('uses customTokenProvider to get an AppCheck token', async () => {
@@ -318,7 +320,8 @@ describe('internal api', () => {
         ...getState(app),
         token: {
           token: `fake-memory-app-check-token`,
-          expireTimeMillis: 123
+          expireTimeMillis: 123,
+          issuedAtTimeMillis: 0
         }
       });
 
@@ -331,7 +334,8 @@ describe('internal api', () => {
       stub(storage, 'readTokenFromStorage').returns(
         Promise.resolve({
           token: `fake-cached-app-check-token`,
-          expireTimeMillis: 123
+          expireTimeMillis: 123,
+          issuedAtTimeMillis: 0
         })
       );
 

--- a/packages/app-check/src/internal-api.test.ts
+++ b/packages/app-check/src/internal-api.test.ts
@@ -295,6 +295,7 @@ describe('internal api', () => {
 
     it('starts proactively refreshing token after adding the first listener', () => {
       const listener = (): void => {};
+      setState(app, { ...getState(app), isTokenAutoRefreshEnabled: true });
       expect(getState(app).tokenListeners.length).to.equal(0);
       expect(getState(app).tokenRefresher).to.equal(undefined);
 
@@ -389,6 +390,7 @@ describe('internal api', () => {
 
     it('should stop proactively refreshing token after deleting the last listener', () => {
       const listener = (): void => {};
+      setState(app, { ...getState(app), isTokenAutoRefreshEnabled: true });
 
       addTokenListener(app, fakePlatformLoggingProvider, listener);
       expect(getState(app).tokenListeners.length).to.equal(1);

--- a/packages/app-check/src/internal-api.ts
+++ b/packages/app-check/src/internal-api.ts
@@ -264,11 +264,18 @@ function createTokenRefresher(
 
       if (state.token) {
         // issuedAtTime + (50% * total TTL) + 5 minutes
-        const nextRefreshTimeMillis =
+        let nextRefreshTimeMillis =
           state.token.issuedAtTimeMillis +
           (state.token.expireTimeMillis - state.token.issuedAtTimeMillis) *
             0.5 +
           5 * 60 * 1000;
+        // Do not allow refresh time to be past (expireTime - 5 minutes)
+        const latestAllowableRefresh =
+          state.token.expireTimeMillis - 5 * 60 * 1000;
+        nextRefreshTimeMillis = Math.min(
+          nextRefreshTimeMillis,
+          latestAllowableRefresh
+        );
         return Math.max(0, nextRefreshTimeMillis - Date.now());
       } else {
         return 0;

--- a/packages/app-check/src/internal-api.ts
+++ b/packages/app-check/src/internal-api.ts
@@ -183,7 +183,12 @@ export function addTokenListener(
       newState.tokenRefresher = tokenRefresher;
     }
 
-    if (!newState.tokenRefresher.isRunning()) {
+    // Create the refresher but don't start it if `isTokenAutoRefreshEnabled`
+    // is not true.
+    if (
+      !newState.tokenRefresher.isRunning() &&
+      state.isTokenAutoRefreshEnabled === true
+    ) {
       newState.tokenRefresher.start();
     }
 

--- a/packages/app-check/src/state.ts
+++ b/packages/app-check/src/state.ts
@@ -29,6 +29,7 @@ export interface AppCheckState {
   token?: AppCheckToken;
   tokenRefresher?: Refresher;
   reCAPTCHAState?: ReCAPTCHAState;
+  isTokenAutoRefreshEnabled?: boolean;
 }
 
 export interface ReCAPTCHAState {

--- a/packages/app-check/src/state.ts
+++ b/packages/app-check/src/state.ts
@@ -21,12 +21,16 @@ import { AppCheckTokenListener } from '@firebase/app-check-interop-types';
 import { Refresher } from './proactive-refresh';
 import { Deferred } from '@firebase/util';
 import { GreCAPTCHA } from './recaptcha';
+
+export interface AppCheckTokenInternal extends AppCheckToken {
+  issuedAtTimeMillis: number;
+}
 export interface AppCheckState {
   activated: boolean;
   tokenListeners: AppCheckTokenListener[];
   customProvider?: AppCheckProvider;
   siteKey?: string;
-  token?: AppCheckToken;
+  token?: AppCheckTokenInternal;
   tokenRefresher?: Refresher;
   reCAPTCHAState?: ReCAPTCHAState;
   isTokenAutoRefreshEnabled?: boolean;

--- a/packages/app-check/src/storage.test.ts
+++ b/packages/app-check/src/storage.test.ts
@@ -28,7 +28,8 @@ describe('Storage', () => {
   const app = getFakeApp();
   const fakeToken = {
     token: 'fake-app-check-token',
-    expireTimeMillis: 345
+    expireTimeMillis: 345,
+    issuedAtTimeMillis: 0
   };
 
   it('sets and gets appCheck token to indexeddb', async () => {

--- a/packages/app-check/src/storage.ts
+++ b/packages/app-check/src/storage.ts
@@ -15,7 +15,6 @@
  * limitations under the License.
  */
 
-import { AppCheckToken } from '@firebase/app-check-types';
 import { uuidv4 } from './util';
 import { FirebaseApp } from '@firebase/app-types';
 import { isIndexedDBAvailable } from '@firebase/util';
@@ -26,13 +25,14 @@ import {
   writeTokenToIndexedDB
 } from './indexeddb';
 import { logger } from './logger';
+import { AppCheckTokenInternal } from './state';
 
 /**
  * Always resolves. In case of an error reading from indexeddb, resolve with undefined
  */
 export async function readTokenFromStorage(
   app: FirebaseApp
-): Promise<AppCheckToken | undefined> {
+): Promise<AppCheckTokenInternal | undefined> {
   if (isIndexedDBAvailable()) {
     let token = undefined;
     try {
@@ -52,7 +52,7 @@ export async function readTokenFromStorage(
  */
 export function writeTokenToStorage(
   app: FirebaseApp,
-  token: AppCheckToken
+  token: AppCheckTokenInternal
 ): Promise<void> {
   if (isIndexedDBAvailable()) {
     return writeTokenToIndexedDB(app, token).catch(e => {

--- a/packages/app-check/test/util.ts
+++ b/packages/app-check/test/util.ts
@@ -27,7 +27,7 @@ import {
 
 export const FAKE_SITE_KEY = 'fake-site-key';
 
-export function getFakeApp(): FirebaseApp {
+export function getFakeApp(overrides: Record<string, any> = {}): FirebaseApp {
   return {
     name: 'appName',
     options: {
@@ -43,7 +43,8 @@ export function getFakeApp(): FirebaseApp {
     delete: async () => {},
     // This won't be used in tests.
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    appCheck: null as any
+    appCheck: null as any,
+    ...overrides
   };
 }
 


### PR DESCRIPTION
- Implement global opt-out. API proposal is here: https://docs.google.com/document/d/17RZDbKMRtgHoRGcyAR_KIAHPStr2aFnJmFsffO50pRI/edit?hl=en&forcehl=1#

- Implement auto-refresh timing. Formula is `issuedAtTime + (50% * TTL) + 5 minutes` from here: https://docs.google.com/document/d/1fi4xUsARCs3Uc8c46KvNiIf2rQeWnjxvODW-h0coSmo/edit?resourcekey=0-IK3tvAt8BxEmzoOHbbRfcg&disco=AAAAIUhr8kE

The second required an additional `AppCheckTokenInternal` type to be created that extends `AppCheckToken` with a `issuedAtTimeMillis` field, which is needed to calculate the auto refresh time. This info can also be extracted from the token, but I am following Android's example of adding this data to an internal token type using the local client's clock to avoid clock skew (the issued-at-time in the token is server time).