### PR TITLE
Use google-closure-deps instead of depswriter.py.

### DIFF
--- a/packages/auth/buildtools/generate_test_files.sh
+++ b/packages/auth/buildtools/generate_test_files.sh
@@ -25,9 +25,13 @@ cd "$(dirname $(dirname "$0"))"
 mkdir -p generated
 
 echo "Generating dependency file..."
-python ../../node_modules/google-closure-library/closure/bin/build/depswriter.py \
-    --root_with_prefix="test ../../../../test" \
-    --root_with_prefix="src ../../../../src" \
+node $(npm bin)/closure-make-deps \
+    --closure-path="node_modules/google-closure-library/closure/goog" \
+    --file="node_modules/google-closure-library/closure/goog/deps.js" \
+    --root="test" \
+    --root="src" \
+    --exclude="src/debug.js" \
+    --exclude="src/externs.js" \
     > generated/deps.js
 
 echo "Generating test HTML files..."

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -26,6 +26,7 @@
   "devDependencies": {
     "firebase-tools": "9.1.0",
     "google-closure-compiler": "20200112.0.0",
+    "google-closure-deps": "^20210406.0.0",
     "google-closure-library": "20200830.0.0",
     "gulp": "4.0.2",
     "gulp-sourcemaps": "3.0.0"


### PR DESCRIPTION
In [Closure Library](https://github.com/google/closure-library), we will be removing `depswriter.py` and other Python-based build scripts soon. `depswriter.py` is superceded by [`google-closure-deps`](https://www.npmjs.com/package/google-closure-deps), a similar tool we maintain that is implemented in Node.js.

Here, I've substituted the `depswriter.py` command with a corresponding command from `google-closure-deps`; the CLI flags are similar. The difference in output is minimal (see below).

Explanation of "extra" flags:
* `--closure-path="node_modules/google-closure-library/closure/goog"` Path to Closure (now required)
* `--file="node_modules/google-closure-library/closure/goog/deps.js"` Use the deps.js file bundled with Closure as part of deps calculation
* `--exclude=...` Not strictly necessary, but prevents these files from being written to `deps.js` as trivial, 0-dependency entries

For reference, the diff of the resulting `deps.js` from running `npm run generate-test-files` (with lines sorted and formatted for diff clarity) is here (TODO).

Fixes #4848