### PR TITLE
fix broken typings for the non modular RTDB package

### DIFF
--- a/common/api-review/database.api.md
+++ b/common/api-review/database.api.md
@@ -7,7 +7,7 @@
 import { EmulatorMockTokenOptions } from '@firebase/util';
 import { FirebaseApp } from '@firebase/app';
 
-// @public
+// @public (undocumented)
 export function child(parent: Reference, path: string): Reference;
 
 // @public

--- a/common/api-review/database.api.md
+++ b/common/api-review/database.api.md
@@ -7,7 +7,7 @@
 import { EmulatorMockTokenOptions } from '@firebase/util';
 import { FirebaseApp } from '@firebase/app';
 
-// @public (undocumented)
+// @public
 export function child(parent: Reference, path: string): Reference;
 
 // @public

--- a/packages/database/index.ts
+++ b/packages/database/index.ts
@@ -28,9 +28,9 @@ import { Database } from './src/api/Database';
 import * as INTERNAL from './src/api/internal';
 import { DataSnapshot, Query, Reference } from './src/api/Reference';
 import * as TEST_ACCESS from './src/api/test_access';
+import { enableLogging } from './src/core/util/util';
 import { setSDKVersion } from './src/core/version';
 import { repoManagerDatabaseFromApp } from './src/exp/Database';
-import { enableLogging } from './src/core/util/util';
 
 const ServerValue = Database.ServerValue;
 

--- a/packages/database/index.ts
+++ b/packages/database/index.ts
@@ -29,7 +29,8 @@ import * as INTERNAL from './src/api/internal';
 import { DataSnapshot, Query, Reference } from './src/api/Reference';
 import * as TEST_ACCESS from './src/api/test_access';
 import { setSDKVersion } from './src/core/version';
-import { enableLogging, repoManagerDatabaseFromApp } from './src/exp/Database';
+import { repoManagerDatabaseFromApp } from './src/exp/Database';
+import { enableLogging } from './src/core/util/util';
 
 const ServerValue = Database.ServerValue;
 

--- a/packages/database/src/api/Database.ts
+++ b/packages/database/src/api/Database.ts
@@ -41,6 +41,7 @@ import { Reference } from './Reference';
  * This is a workaround for an issue in the no-modular '@firebase/database' where its typings
  * reference types from `@firebase/app-exp`.
  */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 type ExpDatabase = any;
 
 /**

--- a/packages/database/src/api/Database.ts
+++ b/packages/database/src/api/Database.ts
@@ -25,7 +25,6 @@ import {
 } from '@firebase/util';
 
 import {
-  FirebaseDatabase as ExpDatabase,
   goOnline,
   useDatabaseEmulator,
   goOffline,
@@ -36,6 +35,13 @@ import {
 } from '../../exp/index'; // import from the exp public API
 
 import { Reference } from './Reference';
+
+// TODO: revert to import {FirebaseDatabase as ExpDatabase} from '@firebase/database' once modular SDK goes GA
+/**
+ * This is a workaround for an issue in the no-modular '@firebase/database' where its typings
+ * reference types from `@firebase/app-exp`.
+ */
+type ExpDatabase = any;
 
 /**
  * Class representing a firebase database.

--- a/packages/database/src/api/Reference.ts
+++ b/packages/database/src/api/Reference.ts
@@ -78,9 +78,12 @@ import { TransactionResult } from './TransactionResult';
  * This is part of a workaround for an issue in the no-modular '@firebase/database' where its typings
  * reference types from `@firebase/app-exp`.
  */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
 type ExpDataSnapshot = any;
 type ExpQuery = any;
 type ExpReference = any;
+/* eslint-enable @typescript-eslint/no-explicit-any */
 
 /**
  * Class representing a firebase data snapshot.  It wraps a SnapshotNode and

--- a/packages/database/src/api/Reference.ts
+++ b/packages/database/src/api/Reference.ts
@@ -26,7 +26,6 @@ import {
 
 import {
   OnDisconnect as ExpOnDisconnect,
-  DataSnapshot as ExpDataSnapshot,
   off,
   onChildAdded,
   onChildChanged,
@@ -54,8 +53,6 @@ import {
   setPriority,
   push,
   runTransaction,
-  Query as ExpQuery,
-  Reference as ExpReference,
   _QueryImpl,
   _ReferenceImpl,
   child
@@ -74,6 +71,16 @@ import { ThenableReferenceImpl } from '../exp/Reference_impl';
 import { Database } from './Database';
 import { OnDisconnect } from './onDisconnect';
 import { TransactionResult } from './TransactionResult';
+
+// TODO: revert to import {  DataSnapshot as ExpDataSnapshot, Query as ExpQuery,
+// Reference as ExpReference,} from '../../exp/index'; once the modular SDK goes GA
+/**
+ * This is part of a workaround for an issue in the no-modular '@firebase/database' where its typings
+ * reference types from `@firebase/app-exp`.
+ */
+type ExpDataSnapshot = any;
+type ExpQuery = any;
+type ExpReference = any;
 
 /**
  * Class representing a firebase data snapshot.  It wraps a SnapshotNode and

--- a/packages/database/src/api/onDisconnect.ts
+++ b/packages/database/src/api/onDisconnect.ts
@@ -25,6 +25,7 @@ import { warn } from '../core/util/util';
  * This is a workaround for an issue in the no-modular '@firebase/database' where its typings
  * reference types from `@firebase/app-exp`.
  */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 type ExpOnDisconnect = any;
 
 export class OnDisconnect implements Compat<ExpOnDisconnect> {

--- a/packages/database/src/api/onDisconnect.ts
+++ b/packages/database/src/api/onDisconnect.ts
@@ -17,9 +17,15 @@
 
 import { validateArgCount, validateCallback, Compat } from '@firebase/util';
 
-import { OnDisconnect as ExpOnDisconnect } from '../../exp/index';
 import { Indexable } from '../core/util/misc';
 import { warn } from '../core/util/util';
+
+// TODO: revert to import { OnDisconnect as ExpOnDisconnect } from '../../exp/index'; once the modular SDK goes GA
+/**
+ * This is a workaround for an issue in the no-modular '@firebase/database' where its typings
+ * reference types from `@firebase/app-exp`.
+ */
+type ExpOnDisconnect = any;
 
 export class OnDisconnect implements Compat<ExpOnDisconnect> {
   constructor(readonly _delegate: ExpOnDisconnect) {}

--- a/packages/database/src/core/util/util.ts
+++ b/packages/database/src/core/util/util.ts
@@ -26,8 +26,13 @@ import {
 } from '@firebase/util';
 
 import { SessionStorage } from '../storage/storage';
-import { QueryContext } from '../view/EventRegistration';
 
+// TODO: revert to import { QueryContext } from '../view/EventRegistration'; once the modular SDK goes GA
+/**
+ * This is part of a workaround for an issue in the no-modular '@firebase/database' where its typings
+ * reference types from `@firebase/app-exp`.
+ */
+type QueryContext = any;
 declare const window: Window;
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 declare const Windows: any;

--- a/packages/database/src/core/util/util.ts
+++ b/packages/database/src/core/util/util.ts
@@ -32,6 +32,7 @@ import { SessionStorage } from '../storage/storage';
  * This is part of a workaround for an issue in the no-modular '@firebase/database' where its typings
  * reference types from `@firebase/app-exp`.
  */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 type QueryContext = any;
 declare const window: Window;
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/repo-scripts/prune-dts/extract-public-api.ts
+++ b/repo-scripts/prune-dts/extract-public-api.ts
@@ -21,7 +21,7 @@ import * as path from 'path';
 import { Extractor, ExtractorConfig } from 'api-extractor-me';
 import * as tmp from 'tmp';
 
-import { pruneDts, removeUnusedImports } from './prune-dts';
+import { addBlankLines, pruneDts, removeUnusedImports } from './prune-dts';
 import * as yargs from 'yargs';
 
 /* eslint-disable no-console */
@@ -154,6 +154,8 @@ export async function generateApi(
   console.log('Generated rollup DTS');
   pruneDts(rollupDtsPath, publicDtsPath);
   console.log('Pruned DTS file');
+  await addBlankLines(publicDtsPath);
+  console.log('Added blank lines after imports');
   await removeUnusedImports(publicDtsPath);
   console.log('Removed unused imports');
 


### PR DESCRIPTION
Admin SDK couldn't upgrade to the latest version because our typings are broken. They reference typings from `@firebase/app-exp`. This ugly workaround fixes it.

These changes are internal, so no public types are affected.