### PR TITLE
Change techwriter alias to individual account

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -82,11 +82,11 @@ packages/remote-config @erikeldridge @firebase/jssdk-global-approvers
 packages/remote-config-types @erikeldridge @firebase/jssdk-global-approvers
 
 # Documentation Changes
-packages/firebase/index.d.ts @firebase/firebase-techwriters @firebase/jssdk-global-approvers
-scripts/docgen/content-sources/ @firebase/firebase-techwriters @firebase/jssdk-global-approvers
+packages/firebase/index.d.ts @egilmorez @firebase/jssdk-global-approvers
+scripts/docgen/content-sources/ @egilmorez @firebase/jssdk-global-approvers
 
 # Changeset
-.changeset @firebase/firebase-techwriters @firebase/jssdk-changeset-approvers @firebase/firestore-js-team @firebase/jssdk-global-approvers
+.changeset @egilmorez @firebase/jssdk-changeset-approvers @firebase/firestore-js-team @firebase/jssdk-global-approvers
 
 # Auth-Exp Code
 packages-exp/auth-exp  @avolkovi @sam-gc @yuchenshi @firebase/jssdk-global-approvers


### PR DESCRIPTION
It doesn't seem like the techwriters alias is working for triggering a suggested reviewer or assignee, change to individual account for now (@egilmorez) and see if it works better.