### PR TITLE
Correct typo in Remote Config reference docs

### DIFF
--- a/docs-exp/remote-config.remoteconfig.defaultconfig.md
+++ b/docs-exp/remote-config.remoteconfig.defaultconfig.md
@@ -4,7 +4,7 @@
 
 ## RemoteConfig.defaultConfig property
 
-Object containing default values for conigs.
+Object containing default values for configs.
 
 <b>Signature:</b>
 

--- a/docs-exp/remote-config.remoteconfig.md
+++ b/docs-exp/remote-config.remoteconfig.md
@@ -16,7 +16,7 @@ export interface RemoteConfig
 
 |  Property | Type | Description |
 |  --- | --- | --- |
-|  [defaultConfig](./remote-config.remoteconfig.defaultconfig.md) | { \[key: string\]: string \| number \| boolean; } | Object containing default values for conigs. |
+|  [defaultConfig](./remote-config.remoteconfig.defaultconfig.md) | { \[key: string\]: string \| number \| boolean; } | Object containing default values for configs. |
 |  [fetchTimeMillis](./remote-config.remoteconfig.fetchtimemillis.md) | number | The Unix timestamp in milliseconds of the last <i>successful</i> fetch, or negative one if the [RemoteConfig](./remote-config.remoteconfig.md) instance either hasn't fetched or initialization is incomplete. |
 |  [lastFetchStatus](./remote-config.remoteconfig.lastfetchstatus.md) | [FetchStatus](./remote-config.fetchstatus.md) | The status of the last fetch <i>attempt</i>. |
 |  [settings](./remote-config.remoteconfig.settings.md) | [Settings](./remote-config.settings.md) | Defines configuration for the Remote Config SDK. |

--- a/packages-exp/firebase-exp/compat/index.d.ts
+++ b/packages-exp/firebase-exp/compat/index.d.ts
@@ -1673,7 +1673,7 @@ declare namespace firebase.remoteConfig {
     settings: Settings;
 
     /**
-     * Object containing default values for conigs.
+     * Object containing default values for configs.
      */
     defaultConfig: { [key: string]: string | number | boolean };
 

--- a/packages-exp/remote-config-exp/src/public_types.ts
+++ b/packages-exp/remote-config-exp/src/public_types.ts
@@ -27,7 +27,7 @@ export interface RemoteConfig {
   settings: Settings;
 
   /**
-   * Object containing default values for conigs.
+   * Object containing default values for configs.
    */
   defaultConfig: { [key: string]: string | number | boolean };
 

--- a/packages/firebase/index.d.ts
+++ b/packages/firebase/index.d.ts
@@ -1659,7 +1659,7 @@ declare namespace firebase.remoteConfig {
     settings: Settings;
 
     /**
-     * Object containing default values for conigs.
+     * Object containing default values for configs.
      */
     defaultConfig: { [key: string]: string | number | boolean };
 

--- a/packages/remote-config-types/index.d.ts
+++ b/packages/remote-config-types/index.d.ts
@@ -22,7 +22,7 @@ export interface RemoteConfig {
   settings: Settings;
 
   /**
-   * Object containing default values for conigs.
+   * Object containing default values for configs.
    */
   defaultConfig: { [key: string]: string | number | boolean };
 


### PR DESCRIPTION
Replace "conig" with "config"