### PR TITLE
Convert Date to ISO string in functions

### DIFF
--- a/.changeset/brown-snails-pull.md
+++ b/.changeset/brown-snails-pull.md
@@ -1,0 +1,5 @@
+---
+'@firebase/functions': patch
+---
+
+Fix functions to convert Date objects to an ISO string instead of an empty object.

--- a/packages-exp/functions-exp/src/serializer.test.ts
+++ b/packages-exp/functions-exp/src/serializer.test.ts
@@ -82,6 +82,18 @@ describe('Serializer', () => {
     expect(decode('hello')).to.equal('hello');
   });
 
+  it('encodes date to ISO string', () => {
+    expect(encode(new Date(1620666095891))).to.equal(
+      '2021-05-10T17:01:35.891Z'
+    );
+  });
+
+  it('decodes date string without modifying it', () => {
+    expect(decode('2021-05-10T17:01:35.891Z')).to.equal(
+      '2021-05-10T17:01:35.891Z'
+    );
+  });
+
   // TODO(klimt): Make this test more interesting once we have a complex type
   // that can be created in JavaScript.
   it('encodes array', () => {
@@ -111,12 +123,14 @@ describe('Serializer', () => {
       encode({
         foo: 1,
         bar: 'hello',
-        baz: [1, 2, 3]
+        baz: [1, 2, 3],
+        date: new Date(1620666095891)
       })
     ).to.deep.equal({
       foo: 1,
       bar: 'hello',
-      baz: [1, 2, 3]
+      baz: [1, 2, 3],
+      date: '2021-05-10T17:01:35.891Z'
     });
   });
 
@@ -132,12 +146,14 @@ describe('Serializer', () => {
             value: '1099511627776',
             '@type': 'type.googleapis.com/google.protobuf.Int64Value'
           }
-        ]
+        ],
+        date: '2021-05-10T17:01:35.891Z'
       })
     ).to.deep.equal({
       foo: 1,
       bar: 'hello',
-      baz: [1, 2, 1099511627776]
+      baz: [1, 2, 1099511627776],
+      date: '2021-05-10T17:01:35.891Z'
     });
   });
 

--- a/packages-exp/functions-exp/src/serializer.ts
+++ b/packages-exp/functions-exp/src/serializer.ts
@@ -56,6 +56,9 @@ export function encode(data: unknown): unknown {
   if (Object.prototype.toString.call(data) === '[object String]') {
     return data;
   }
+  if (data instanceof Date) {
+    return data.toISOString();
+  }
   if (Array.isArray(data)) {
     return data.map(x => encode(x));
   }

--- a/packages/functions/src/serializer.ts
+++ b/packages/functions/src/serializer.ts
@@ -54,6 +54,9 @@ export class Serializer {
     if (Object.prototype.toString.call(data) === '[object String]') {
       return data;
     }
+    if (data instanceof Date) {
+      return data.toISOString();
+    }
     if (Array.isArray(data)) {
       return data.map(x => this.encode(x));
     }

--- a/packages/functions/test/serializer.test.ts
+++ b/packages/functions/test/serializer.test.ts
@@ -88,6 +88,18 @@ describe('Serializer', () => {
     expect(serializer.decode('hello')).to.equal('hello');
   });
 
+  it('encodes date to ISO string', () => {
+    expect(serializer.encode(new Date(1620666095891))).to.equal(
+      '2021-05-10T17:01:35.891Z'
+    );
+  });
+
+  it('decodes date string without modifying it', () => {
+    expect(serializer.decode('2021-05-10T17:01:35.891Z')).to.equal(
+      '2021-05-10T17:01:35.891Z'
+    );
+  });
+
   // TODO(klimt): Make this test more interesting once we have a complex type
   // that can be created in JavaScript.
   it('encodes array', () => {
@@ -117,12 +129,14 @@ describe('Serializer', () => {
       serializer.encode({
         foo: 1,
         bar: 'hello',
-        baz: [1, 2, 3]
+        baz: [1, 2, 3],
+        date: new Date(1620666095891)
       })
     ).to.deep.equal({
       foo: 1,
       bar: 'hello',
-      baz: [1, 2, 3]
+      baz: [1, 2, 3],
+      date: '2021-05-10T17:01:35.891Z'
     });
   });
 
@@ -138,12 +152,14 @@ describe('Serializer', () => {
             value: '1099511627776',
             '@type': 'type.googleapis.com/google.protobuf.Int64Value'
           }
-        ]
+        ],
+        date: '2021-05-10T17:01:35.891Z'
       })
     ).to.deep.equal({
       foo: 1,
       bar: 'hello',
-      baz: [1, 2, 1099511627776]
+      baz: [1, 2, 1099511627776],
+      date: '2021-05-10T17:01:35.891Z'
     });
   });
 


### PR DESCRIPTION
Fixes https://github.com/firebase/firebase-js-sdk/issues/683
Also see https://github.com/firebase/firebase-js-sdk/pull/4450

Currently httpsCallable functions serialize any `Date` objects passed to them to an empty object (`{}`). In the absence of a comprehensive Date type shared across all the SDK client platforms plus the functions backend, which may or may not happen, we should at least convert it to an ISO string.

We are not automatically deserializing ISO strings because the developer may intentionally be passing that string down from the cloud function.