### PR TITLE
Support getAuth() after getDatabase()

### DIFF
--- a/packages/database/src/core/AppCheckTokenProvider.ts
+++ b/packages/database/src/core/AppCheckTokenProvider.ts
@@ -36,7 +36,7 @@ export class AppCheckTokenProvider {
   ) {
     this.appCheck = appCheckProvider?.getImmediate({ optional: true });
     if (!this.appCheck) {
-      appCheckProvider?.onInit(appCheck => (this.appCheck = appCheck));
+      appCheckProvider?.get().then(appCheck => (this.appCheck = appCheck));
     }
   }
 

--- a/packages/database/src/core/AuthTokenProvider.ts
+++ b/packages/database/src/core/AuthTokenProvider.ts
@@ -36,6 +36,7 @@ export interface AuthTokenProvider {
  */
 export class FirebaseAuthTokenProvider implements AuthTokenProvider {
   private auth_: FirebaseAuthInternal | null = null;
+
   constructor(
     private appName_: string,
     private firebaseOptions_: object,
@@ -43,13 +44,25 @@ export class FirebaseAuthTokenProvider implements AuthTokenProvider {
   ) {
     this.auth_ = authProvider_.getImmediate({ optional: true });
     if (!this.auth_) {
-      authProvider_.get().then(auth => (this.auth_ = auth));
+      authProvider_.onInit(auth => (this.auth_ = auth));
     }
   }
 
   getToken(forceRefresh: boolean): Promise<FirebaseAuthTokenData> {
     if (!this.auth_) {
-      return Promise.resolve(null);
+      return new Promise<FirebaseAuthTokenData>((resolve, reject) => {
+        // Support delayed initialization of FirebaseAuth. This allows our
+        // customers to initialize the RTDB SDK before initializing Firebase
+        // Auth and ensures that all requests are authenticated if a token
+        // becomes available before the timoeout below expires.
+        setTimeout(() => {
+          if (this.auth_) {
+            this.getToken(forceRefresh).then(resolve, reject);
+          } else {
+            resolve(null);
+          }
+        }, 0);
+      });
     }
 
     return this.auth_.getToken(forceRefresh).catch(error => {
@@ -70,7 +83,6 @@ export class FirebaseAuthTokenProvider implements AuthTokenProvider {
     if (this.auth_) {
       this.auth_.addAuthTokenListener(listener);
     } else {
-      setTimeout(() => listener(null), 0);
       this.authProvider_
         .get()
         .then(auth => auth.addAuthTokenListener(listener));

--- a/packages/database/src/core/PersistentConnection.ts
+++ b/packages/database/src/core/PersistentConnection.ts
@@ -243,6 +243,7 @@ export class PersistentConnection extends ServerActions {
 
     return deferred.promise;
   }
+
   listen(
     query: QueryContext,
     currentHashFn: () => string,
@@ -348,6 +349,7 @@ export class PersistentConnection extends ServerActions {
       }
     }
   }
+
   refreshAuthToken(token: string) {
     this.authToken_ = token;
     this.log_('Auth token refreshed');
@@ -485,6 +487,7 @@ export class PersistentConnection extends ServerActions {
 
     this.sendRequest(action, req);
   }
+
   onDisconnectPut(
     pathString: string,
     data: unknown,
@@ -501,6 +504,7 @@ export class PersistentConnection extends ServerActions {
       });
     }
   }
+
   onDisconnectMerge(
     pathString: string,
     data: unknown,
@@ -517,6 +521,7 @@ export class PersistentConnection extends ServerActions {
       });
     }
   }
+
   onDisconnectCancel(
     pathString: string,
     onComplete?: (a: string, b: string) => void
@@ -552,6 +557,7 @@ export class PersistentConnection extends ServerActions {
       }
     });
   }
+
   put(
     pathString: string,
     data: unknown,
@@ -560,6 +566,7 @@ export class PersistentConnection extends ServerActions {
   ) {
     this.putInternal('p', pathString, data, onComplete, hash);
   }
+
   merge(
     pathString: string,
     data: unknown,
@@ -627,6 +634,7 @@ export class PersistentConnection extends ServerActions {
       }
     });
   }
+
   reportStats(stats: { [k: string]: unknown }) {
     // If we're not connected, we just drop the stats.
     if (this.connected_) {


### PR DESCRIPTION
This changes the RTDB SDK to allow getAuth() to be called after getDatabase(). Unlike Firestore, it does not go back into blocking mode if Auth is initialized after startup. This would require us to rewrite the entire networking layer to be asynchronous and I suspect that this simple change is enough to cover most use cases.

The simple fix here works because the initial connection attempt in the networking layer is asynchronous. Only was `this.connected` is set to true do we flip to a synchronous behavior and send all requests immediately.