### PR TITLE
Make App Check initialization explicit

### DIFF
--- a/.changeset/fair-garlics-smoke.md
+++ b/.changeset/fair-garlics-smoke.md
@@ -1,0 +1,6 @@
+---
+'@firebase/app': patch
+'@firebase/app-check': patch
+---
+
+Make App Check initialization explicit, to prevent unexpected errors for users who do not intend to use App Check.

--- a/packages-exp/app-compat/src/firebaseApp.ts
+++ b/packages-exp/app-compat/src/firebaseApp.ts
@@ -20,6 +20,7 @@ import {
   Component,
   ComponentContainer,
   ComponentType,
+  InstantiationMode,
   Name
 } from '@firebase/component';
 import {
@@ -121,8 +122,17 @@ export class FirebaseAppImpl implements Compat<_FirebaseAppExp>, _FirebaseApp {
   ): _FirebaseService {
     this._delegate.checkDestroyed();
 
+    // Initialize instance if InstatiationMode is `EXPLICIT`.
+    const provider = this._delegate.container.getProvider(name as Name);
+    if (
+      !provider.isInitialized() &&
+      provider.getComponent()?.instantiationMode === InstantiationMode.EXPLICIT
+    ) {
+      provider.initialize();
+    }
+
     // getImmediate will always succeed because _getService is only called for registered components.
-    return (this._delegate.container.getProvider(name as Name).getImmediate({
+    return (provider.getImmediate({
       identifier: instanceIdentifier
     }) as unknown) as _FirebaseService;
   }

--- a/packages/app/src/firebaseApp.ts
+++ b/packages/app/src/firebaseApp.ts
@@ -29,7 +29,8 @@ import {
   ComponentContainer,
   Component,
   ComponentType,
-  Name
+  Name,
+  InstantiationMode
 } from '@firebase/component';
 import { AppError, ERROR_FACTORY } from './errors';
 import { DEFAULT_ENTRY_NAME } from './constants';
@@ -122,8 +123,17 @@ export class FirebaseAppImpl implements FirebaseApp {
   ): FirebaseService {
     this.checkDestroyed_();
 
+    // Initialize instance if InstatiationMode is `EXPLICIT`.
+    const provider = this.container.getProvider(name as Name);
+    if (
+      !provider.isInitialized() &&
+      provider.getComponent()?.instantiationMode === InstantiationMode.EXPLICIT
+    ) {
+      provider.initialize();
+    }
+
     // getImmediate will always succeed because _getService is only called for registered components.
-    return (this.container.getProvider(name as Name).getImmediate({
+    return (provider.getImmediate({
       identifier: instanceIdentifier
     }) as unknown) as FirebaseService;
   }

--- a/packages/app/test/clientLogger.test.ts
+++ b/packages/app/test/clientLogger.test.ts
@@ -16,7 +16,10 @@
  */
 
 import { FirebaseNamespace, VersionService } from '@firebase/app-types';
-import { _FirebaseNamespace } from '@firebase/app-types/private';
+import {
+  _FirebaseNamespace,
+  FirebaseService
+} from '@firebase/app-types/private';
 import { createFirebaseNamespace } from '../src/firebaseNamespace';
 import { expect } from 'chai';
 import { spy as Spy } from 'sinon';
@@ -29,7 +32,7 @@ declare module '@firebase/component' {
   interface NameServiceMapping {
     'vs1': VersionService;
     'vs2': VersionService;
-    'test-shell': Promise<void>;
+    'test-shell': FirebaseService;
   }
 }
 

--- a/packages/app/test/clientLogger.test.ts
+++ b/packages/app/test/clientLogger.test.ts
@@ -54,7 +54,7 @@ describe('User Log Methods', () => {
       (firebase as _FirebaseNamespace).INTERNAL.registerComponent(
         new Component(
           'test-shell',
-          async () => {
+          () => {
             const logger = new Logger('@firebase/logger-test');
             logger.warn('hello');
             expect(warnSpy.called).to.be.true;
@@ -70,6 +70,7 @@ describe('User Log Methods', () => {
             expect(infoSpy.called).to.be.true;
             logger.log('hi');
             expect(logSpy.called).to.be.true;
+            return {} as FirebaseService;
           },
           ComponentType.PUBLIC
         )
@@ -84,7 +85,7 @@ describe('User Log Methods', () => {
       (firebase as _FirebaseNamespace).INTERNAL.registerComponent(
         new Component(
           'test-shell',
-          async () => {
+          () => {
             const logger = new Logger('@firebase/logger-test');
             (firebase as _FirebaseNamespace).onLog(logData => {
               result = logData;
@@ -95,6 +96,7 @@ describe('User Log Methods', () => {
             expect(result.args).to.deep.equal(['hi']);
             expect(result.type).to.equal('@firebase/logger-test');
             expect(infoSpy.called).to.be.true;
+            return {} as FirebaseService;
           },
           ComponentType.PUBLIC
         )

--- a/packages/app/test/firebaseApp.test.ts
+++ b/packages/app/test/firebaseApp.test.ts
@@ -84,7 +84,7 @@ function executeFirebaseTests(): void {
       expect(service).to.eq((firebase as any).test());
     });
 
-    it('does not instantiate explicit components unless called explicitly', done => {
+    it('does not instantiate explicit components unless called explicitly', () => {
       firebase.initializeApp({});
       (firebase as _FirebaseNamespace).INTERNAL.registerComponent(
         createTestComponent('test').setInstantiationMode(
@@ -92,16 +92,17 @@ function executeFirebaseTests(): void {
         )
       );
 
+      let explicitService;
+
       // Expect getImmediate in a consuming component to return null.
       const consumerComponent = new Component(
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         'consumer' as any,
         container => {
-          const testService = container
+          explicitService = container
             .getProvider('test' as any)
             .getImmediate({ optional: true });
-          expect(testService).to.be.null;
-          done();
+          return new TestService(container.getProvider('app').getImmediate());
         },
         ComponentType.PUBLIC
       );
@@ -110,9 +111,10 @@ function executeFirebaseTests(): void {
       );
 
       (firebase as any).consumer();
+      expect(explicitService).to.be.null;
     });
 
-    it('does instantiate explicit components when called explicitly', done => {
+    it('does instantiate explicit components when called explicitly', () => {
       firebase.initializeApp({});
       (firebase as _FirebaseNamespace).INTERNAL.registerComponent(
         createTestComponent('test').setInstantiationMode(
@@ -120,16 +122,17 @@ function executeFirebaseTests(): void {
         )
       );
 
+      let explicitService;
+
       // Expect getImmediate in a consuming component to return the service.
       const consumerComponent = new Component(
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         'consumer' as any,
         container => {
-          const testService = container
+          explicitService = container
             .getProvider('test' as any)
             .getImmediate({ optional: true });
-          expect(testService).to.not.be.null;
-          done();
+          return new TestService(container.getProvider('app').getImmediate());
         },
         ComponentType.PUBLIC
       );
@@ -139,6 +142,7 @@ function executeFirebaseTests(): void {
 
       (firebase as any).test();
       (firebase as any).consumer();
+      expect(explicitService).to.not.be.null;
     });
 
     it(`creates a new instance of a service after removing the existing instance`, () => {

--- a/packages/app/test/firebaseApp.test.ts
+++ b/packages/app/test/firebaseApp.test.ts
@@ -29,7 +29,11 @@ import { createFirebaseNamespace } from '../src/firebaseNamespace';
 import { createFirebaseNamespaceLite } from '../src/lite/firebaseNamespaceLite';
 import { expect } from 'chai';
 import { stub } from 'sinon';
-import { Component, ComponentType } from '@firebase/component';
+import {
+  Component,
+  ComponentType,
+  InstantiationMode
+} from '@firebase/component';
 import './setup';
 
 executeFirebaseTests();
@@ -78,6 +82,63 @@ function executeFirebaseTests(): void {
       const service = (firebase as any).test();
 
       expect(service).to.eq((firebase as any).test());
+    });
+
+    it('does not instantiate explicit components unless called explicitly', done => {
+      firebase.initializeApp({});
+      (firebase as _FirebaseNamespace).INTERNAL.registerComponent(
+        createTestComponent('test').setInstantiationMode(
+          InstantiationMode.EXPLICIT
+        )
+      );
+
+      // Expect getImmediate in a consuming component to return null.
+      const consumerComponent = new Component(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        'consumer' as any,
+        container => {
+          const testService = container
+            .getProvider('test' as any)
+            .getImmediate({ optional: true });
+          expect(testService).to.be.null;
+          done();
+        },
+        ComponentType.PUBLIC
+      );
+      (firebase as _FirebaseNamespace).INTERNAL.registerComponent(
+        consumerComponent
+      );
+
+      (firebase as any).consumer();
+    });
+
+    it('does instantiate explicit components when called explicitly', done => {
+      firebase.initializeApp({});
+      (firebase as _FirebaseNamespace).INTERNAL.registerComponent(
+        createTestComponent('test').setInstantiationMode(
+          InstantiationMode.EXPLICIT
+        )
+      );
+
+      // Expect getImmediate in a consuming component to return the service.
+      const consumerComponent = new Component(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        'consumer' as any,
+        container => {
+          const testService = container
+            .getProvider('test' as any)
+            .getImmediate({ optional: true });
+          expect(testService).to.not.be.null;
+          done();
+        },
+        ComponentType.PUBLIC
+      );
+      (firebase as _FirebaseNamespace).INTERNAL.registerComponent(
+        consumerComponent
+      );
+
+      (firebase as any).test();
+      (firebase as any).consumer();
     });
 
     it(`creates a new instance of a service after removing the existing instance`, () => {

--- a/packages/app/test/platformLogger.test.ts
+++ b/packages/app/test/platformLogger.test.ts
@@ -16,7 +16,10 @@
  */
 
 import { FirebaseNamespace, VersionService } from '@firebase/app-types';
-import { _FirebaseNamespace } from '@firebase/app-types/private';
+import {
+  FirebaseService,
+  _FirebaseNamespace
+} from '@firebase/app-types/private';
 import { createFirebaseNamespace } from '../src/firebaseNamespace';
 import { expect } from 'chai';
 import './setup';
@@ -33,7 +36,7 @@ declare module '@firebase/component' {
   interface NameServiceMapping {
     'vs1': VersionService;
     'vs2': VersionService;
-    'test-shell': Promise<void>;
+    'test-shell': FirebaseService;
   }
 }
 

--- a/packages/app/test/platformLogger.test.ts
+++ b/packages/app/test/platformLogger.test.ts
@@ -78,14 +78,15 @@ describe('Platform Logger Service', () => {
       (firebase as _FirebaseNamespace).INTERNAL.registerComponent(
         new Component(
           'test-shell',
-          async (container: ComponentContainer) => {
+          (container: ComponentContainer) => {
             const platformLoggerProvider = container.getProvider(
               'platform-logger'
             );
-            const platformLogger = (await platformLoggerProvider.get()) as PlatformLoggerService;
+            const platformLogger = platformLoggerProvider.getImmediate() as PlatformLoggerService;
             const platformInfoString = platformLogger.getPlatformInfoString();
             expect(platformInfoString).to.include(`fire-core/${appVersion}`);
             expect(platformInfoString).to.include('fire-js/');
+            return {} as FirebaseService;
           },
           ComponentType.PUBLIC
         )
@@ -99,16 +100,17 @@ describe('Platform Logger Service', () => {
       (firebase as _FirebaseNamespace).INTERNAL.registerComponent(
         new Component(
           'test-shell',
-          async (container: ComponentContainer) => {
+          (container: ComponentContainer) => {
             const platformLoggerProvider = container.getProvider(
               'platform-logger'
             );
-            const platformLogger = (await platformLoggerProvider.get()) as PlatformLoggerService;
+            const platformLogger = platformLoggerProvider.getImmediate() as PlatformLoggerService;
             const platformInfoString = platformLogger.getPlatformInfoString();
             expect(platformInfoString).to.include(
               `fire-core-node/${appVersion}`
             );
             expect(platformInfoString).to.include('fire-js/');
+            return {} as FirebaseService;
           },
           ComponentType.PUBLIC
         )
@@ -126,14 +128,15 @@ describe('Platform Logger Service', () => {
       (firebase as _FirebaseNamespace).INTERNAL.registerComponent(
         new Component(
           'test-shell',
-          async (container: ComponentContainer) => {
+          (container: ComponentContainer) => {
             const platformLoggerProvider = container.getProvider(
               'platform-logger'
             );
-            const platformLogger = (await platformLoggerProvider.get()) as PlatformLoggerService;
+            const platformLogger = platformLoggerProvider.getImmediate() as PlatformLoggerService;
             const platformInfoString = platformLogger.getPlatformInfoString();
             expect(platformInfoString).to.include('fire-analytics/1.2.3');
             expect(platformInfoString).to.include('fire-js/');
+            return {} as FirebaseService;
           },
           ComponentType.PUBLIC
         )


### PR DESCRIPTION
Make AppCheck initialization explicit, so users not intending to use app-check won't get errors in storage, functions, etc. Modify _getService to initialize component if it hasn't been.