### PR TITLE
Change appcheck activate() to use provider pattern

### DIFF
--- a/.changeset/great-tigers-doubt.md
+++ b/.changeset/great-tigers-doubt.md
@@ -1,0 +1,7 @@
+---
+'@firebase/app-check': minor
+'@firebase/app-check-types': minor
+'firebase': minor
+---
+
+Add `RecaptchaV3Provider` and `CustomProvider` classes that can be supplied to `firebase.appCheck().activate()`.

--- a/packages/app-check-types/index.d.ts
+++ b/packages/app-check-types/index.d.ts
@@ -91,7 +91,7 @@ interface AppCheckProvider {
   getToken(): Promise<AppCheckToken>;
 }
 
-export class ReCAPTCHAV3Provider {
+export class ReCaptchaV3Provider {
   /**
    * @param siteKey - ReCAPTCHA v3 site key (public key).
    */

--- a/packages/app-check-types/index.d.ts
+++ b/packages/app-check-types/index.d.ts
@@ -90,6 +90,13 @@ interface AppCheckProvider {
   getToken(): Promise<AppCheckToken>;
 }
 
+interface ReCAPTCHAV3Provider {
+  /**
+   * @param siteKey - ReCAPTCHA v3 site key (public key).
+   */
+  constructor(siteKey: string): void;
+}
+
 /**
  * The token returned from an `AppCheckProvider`.
  */

--- a/packages/app-check-types/index.d.ts
+++ b/packages/app-check-types/index.d.ts
@@ -91,20 +91,20 @@ interface AppCheckProvider {
   getToken(): Promise<AppCheckToken>;
 }
 
-interface ReCAPTCHAV3Provider {
+export class ReCAPTCHAV3Provider {
   /**
    * @param siteKey - ReCAPTCHA v3 site key (public key).
    */
-  constructor(siteKey: string): void;
+  constructor(siteKey: string);
 }
 /*
  * Custom token provider.
  */
-interface CustomProvider {
+export class CustomProvider {
   /**
    * @param options - Options for creating the custom provider.
    */
-  constructor(options: CustomProviderOptions): void;
+  constructor(options: CustomProviderOptions);
 }
 interface CustomProviderOptions {
   /**

--- a/packages/app-check-types/index.d.ts
+++ b/packages/app-check-types/index.d.ts
@@ -17,6 +17,7 @@
 
 import { PartialObserver, Unsubscribe } from '@firebase/util';
 import { FirebaseApp } from '@firebase/app-types';
+import { Provider } from '@firebase/component';
 
 export interface FirebaseAppCheck {
   /** The `FirebaseApp` associated with this instance. */
@@ -95,6 +96,22 @@ interface ReCAPTCHAV3Provider {
    * @param siteKey - ReCAPTCHA v3 site key (public key).
    */
   constructor(siteKey: string): void;
+}
+/*
+ * Custom token provider.
+ */
+interface CustomProvider {
+  /**
+   * @param options - Options for creating the custom provider.
+   */
+  constructor(options: CustomProviderOptions): void;
+}
+interface CustomProviderOptions {
+  /**
+   * Function to get an App Check token through a custom provider
+   * service.
+   */
+  getToken: () => Promise<AppCheckToken>;
 }
 
 /**

--- a/packages/app-check/src/api.test.ts
+++ b/packages/app-check/src/api.test.ts
@@ -39,7 +39,7 @@ import * as client from './client';
 import * as storage from './storage';
 import * as logger from './logger';
 import * as util from './util';
-import { ReCAPTCHAV3Provider } from './providers';
+import { ReCaptchaV3Provider } from './providers';
 
 describe('api', () => {
   beforeEach(() => {
@@ -56,7 +56,7 @@ describe('api', () => {
       expect(getState(app).activated).to.equal(false);
       activate(
         app,
-        new ReCAPTCHAV3Provider(FAKE_SITE_KEY),
+        new ReCaptchaV3Provider(FAKE_SITE_KEY),
         getFakePlatformLoggingProvider()
       );
       expect(getState(app).activated).to.equal(true);
@@ -66,7 +66,7 @@ describe('api', () => {
       app = getFakeApp({ automaticDataCollectionEnabled: false });
       activate(
         app,
-        new ReCAPTCHAV3Provider(FAKE_SITE_KEY),
+        new ReCaptchaV3Provider(FAKE_SITE_KEY),
         getFakePlatformLoggingProvider()
       );
       expect(getState(app).isTokenAutoRefreshEnabled).to.equal(false);
@@ -76,7 +76,7 @@ describe('api', () => {
       app = getFakeApp({ automaticDataCollectionEnabled: false });
       activate(
         app,
-        new ReCAPTCHAV3Provider(FAKE_SITE_KEY),
+        new ReCaptchaV3Provider(FAKE_SITE_KEY),
         getFakePlatformLoggingProvider(),
         true
       );
@@ -86,25 +86,36 @@ describe('api', () => {
     it('can only be called once', () => {
       activate(
         app,
-        new ReCAPTCHAV3Provider(FAKE_SITE_KEY),
+        new ReCaptchaV3Provider(FAKE_SITE_KEY),
         getFakePlatformLoggingProvider()
       );
       expect(() =>
         activate(
           app,
-          new ReCAPTCHAV3Provider(FAKE_SITE_KEY),
+          new ReCaptchaV3Provider(FAKE_SITE_KEY),
           getFakePlatformLoggingProvider()
         )
       ).to.throw(/AppCheck can only be activated once/);
     });
 
-    it('initialize reCAPTCHA when a sitekey is provided', () => {
+    it('initialize reCAPTCHA when a sitekey string is provided', () => {
+      const initReCAPTCHAStub = stub(reCAPTCHA, 'initialize').returns(
+        Promise.resolve({} as any)
+      );
+      activate(app, FAKE_SITE_KEY, getFakePlatformLoggingProvider());
+      expect(initReCAPTCHAStub).to.have.been.calledWithExactly(
+        app,
+        FAKE_SITE_KEY
+      );
+    });
+
+    it('initialize reCAPTCHA when a ReCaptchaV3Provider instance is provided', () => {
       const initReCAPTCHAStub = stub(reCAPTCHA, 'initialize').returns(
         Promise.resolve({} as any)
       );
       activate(
         app,
-        new ReCAPTCHAV3Provider(FAKE_SITE_KEY),
+        new ReCaptchaV3Provider(FAKE_SITE_KEY),
         getFakePlatformLoggingProvider()
       );
       expect(initReCAPTCHAStub).to.have.been.calledWithExactly(
@@ -113,13 +124,22 @@ describe('api', () => {
       );
     });
 
-    it('does NOT initialize reCAPTCHA when a custom token provider is provided', () => {
-      const fakeCustomTokenProvider = getFakeCustomTokenProvider();
-      const initReCAPTCHAStub = stub(reCAPTCHA, 'initialize');
-      activate(app, fakeCustomTokenProvider, getFakePlatformLoggingProvider());
-      expect(getState(app).provider).to.equal(fakeCustomTokenProvider);
-      expect(initReCAPTCHAStub).to.have.not.been.called;
-    });
+    it(
+      'creates CustomProvider instance if user provides an object containing' +
+        ' a getToken() method',
+      async () => {
+        const fakeCustomTokenProvider = getFakeCustomTokenProvider();
+        const initReCAPTCHAStub = stub(reCAPTCHA, 'initialize');
+        activate(
+          app,
+          fakeCustomTokenProvider,
+          getFakePlatformLoggingProvider()
+        );
+        const result = await getState(app).provider?.getToken();
+        expect(result?.token).to.equal('fake-custom-app-check-token');
+        expect(initReCAPTCHAStub).to.have.not.been.called;
+      }
+    );
   });
   describe('setTokenAutoRefreshEnabled()', () => {
     it('sets isTokenAutoRefreshEnabled correctly', () => {
@@ -177,7 +197,7 @@ describe('api', () => {
       const app = getFakeApp();
       activate(
         app,
-        new ReCAPTCHAV3Provider(FAKE_SITE_KEY),
+        new ReCaptchaV3Provider(FAKE_SITE_KEY),
         fakePlatformLoggingProvider,
         false
       );
@@ -226,7 +246,7 @@ describe('api', () => {
       const app = getFakeApp();
       activate(
         app,
-        new ReCAPTCHAV3Provider(FAKE_SITE_KEY),
+        new ReCaptchaV3Provider(FAKE_SITE_KEY),
         fakePlatformLoggingProvider,
         false
       );
@@ -276,7 +296,7 @@ describe('api', () => {
       const app = getFakeApp();
       activate(
         app,
-        new ReCAPTCHAV3Provider(FAKE_SITE_KEY),
+        new ReCaptchaV3Provider(FAKE_SITE_KEY),
         fakePlatformLoggingProvider,
         false
       );

--- a/packages/app-check/src/api.test.ts
+++ b/packages/app-check/src/api.test.ts
@@ -39,7 +39,7 @@ import * as client from './client';
 import * as storage from './storage';
 import * as logger from './logger';
 import * as util from './util';
-import { ReCAPTCHAProvider } from './providers';
+import { ReCAPTCHAV3Provider } from './providers';
 
 describe('api', () => {
   beforeEach(() => {
@@ -56,7 +56,7 @@ describe('api', () => {
       expect(getState(app).activated).to.equal(false);
       activate(
         app,
-        new ReCAPTCHAProvider(FAKE_SITE_KEY),
+        new ReCAPTCHAV3Provider(FAKE_SITE_KEY),
         getFakePlatformLoggingProvider()
       );
       expect(getState(app).activated).to.equal(true);
@@ -66,7 +66,7 @@ describe('api', () => {
       app = getFakeApp({ automaticDataCollectionEnabled: false });
       activate(
         app,
-        new ReCAPTCHAProvider(FAKE_SITE_KEY),
+        new ReCAPTCHAV3Provider(FAKE_SITE_KEY),
         getFakePlatformLoggingProvider()
       );
       expect(getState(app).isTokenAutoRefreshEnabled).to.equal(false);
@@ -76,7 +76,7 @@ describe('api', () => {
       app = getFakeApp({ automaticDataCollectionEnabled: false });
       activate(
         app,
-        new ReCAPTCHAProvider(FAKE_SITE_KEY),
+        new ReCAPTCHAV3Provider(FAKE_SITE_KEY),
         getFakePlatformLoggingProvider(),
         true
       );
@@ -86,13 +86,13 @@ describe('api', () => {
     it('can only be called once', () => {
       activate(
         app,
-        new ReCAPTCHAProvider(FAKE_SITE_KEY),
+        new ReCAPTCHAV3Provider(FAKE_SITE_KEY),
         getFakePlatformLoggingProvider()
       );
       expect(() =>
         activate(
           app,
-          new ReCAPTCHAProvider(FAKE_SITE_KEY),
+          new ReCAPTCHAV3Provider(FAKE_SITE_KEY),
           getFakePlatformLoggingProvider()
         )
       ).to.throw(/AppCheck can only be activated once/);
@@ -104,7 +104,7 @@ describe('api', () => {
       );
       activate(
         app,
-        new ReCAPTCHAProvider(FAKE_SITE_KEY),
+        new ReCAPTCHAV3Provider(FAKE_SITE_KEY),
         getFakePlatformLoggingProvider()
       );
       expect(initReCAPTCHAStub).to.have.been.calledWithExactly(
@@ -175,7 +175,12 @@ describe('api', () => {
     });
     it('Listeners work when using top-level parameters pattern', async () => {
       const app = getFakeApp();
-      activate(app, new ReCAPTCHAProvider(FAKE_SITE_KEY), false);
+      activate(
+        app,
+        new ReCAPTCHAV3Provider(FAKE_SITE_KEY),
+        fakePlatformLoggingProvider,
+        false
+      );
       stub(reCAPTCHA, 'getToken').returns(Promise.resolve(fakeRecaptchaToken));
       stub(client, 'exchangeToken').returns(
         Promise.resolve(fakeRecaptchaAppCheckToken)
@@ -219,7 +224,12 @@ describe('api', () => {
 
     it('Listeners work when using Observer pattern', async () => {
       const app = getFakeApp();
-      activate(app, new ReCAPTCHAProvider(FAKE_SITE_KEY), false);
+      activate(
+        app,
+        new ReCAPTCHAV3Provider(FAKE_SITE_KEY),
+        fakePlatformLoggingProvider,
+        false
+      );
       stub(reCAPTCHA, 'getToken').returns(Promise.resolve(fakeRecaptchaToken));
       stub(client, 'exchangeToken').returns(
         Promise.resolve(fakeRecaptchaAppCheckToken)
@@ -264,7 +274,12 @@ describe('api', () => {
     it('onError() catches token errors', async () => {
       stub(logger.logger, 'error');
       const app = getFakeApp();
-      activate(app, new ReCAPTCHAProvider(FAKE_SITE_KEY), false);
+      activate(
+        app,
+        new ReCAPTCHAV3Provider(FAKE_SITE_KEY),
+        fakePlatformLoggingProvider,
+        false
+      );
       stub(reCAPTCHA, 'getToken').returns(Promise.resolve(fakeRecaptchaToken));
       stub(client, 'exchangeToken').rejects('exchange error');
 

--- a/packages/app-check/src/api.ts
+++ b/packages/app-check/src/api.ts
@@ -34,7 +34,7 @@ import { CustomProvider, ReCaptchaV3Provider } from './providers';
 /**
  *
  * @param app
- * @param provider - optional custom attestation provider
+ * @param siteKeyOrProvider - optional custom attestation provider
  * or reCAPTCHA provider
  * @param isTokenAutoRefreshEnabled - if true, enables auto refresh
  * of appCheck token.

--- a/packages/app-check/src/api.ts
+++ b/packages/app-check/src/api.ts
@@ -64,7 +64,7 @@ export function activate(
   // Read cached token from storage if it exists and store it in memory.
   newState.cachedTokenPromise = readTokenFromStorage(app).then(cachedToken => {
     if (cachedToken && isValid(cachedToken)) {
-      newState.token = cachedToken;
+      setState(app, { ...getState(app), token: cachedToken });
     }
     return cachedToken;
   });

--- a/packages/app-check/src/api.ts
+++ b/packages/app-check/src/api.ts
@@ -25,11 +25,13 @@ import { getState, setState, AppCheckState, ListenerType } from './state';
 import {
   getToken as getTokenInternal,
   addTokenListener,
-  removeTokenListener
+  removeTokenListener,
+  isValid
 } from './internal-api';
 import { Provider } from '@firebase/component';
 import { ErrorFn, NextFn, PartialObserver, Unsubscribe } from '@firebase/util';
 import { CustomProvider, ReCaptchaV3Provider } from './providers';
+import { readTokenFromStorage } from './storage';
 
 /**
  *
@@ -58,6 +60,14 @@ export function activate(
   }
 
   const newState: AppCheckState = { ...state, activated: true };
+
+  // Read cached token from storage if it exists and store it in memory.
+  newState.cachedTokenPromise = readTokenFromStorage(app).then(cachedToken => {
+    if (cachedToken && isValid(cachedToken)) {
+      newState.token = cachedToken;
+    }
+    return cachedToken;
+  });
 
   if (typeof siteKeyOrProvider === 'string') {
     newState.provider = new ReCaptchaV3Provider(siteKeyOrProvider);

--- a/packages/app-check/src/api.ts
+++ b/packages/app-check/src/api.ts
@@ -22,7 +22,7 @@ import {
 import { FirebaseApp } from '@firebase/app-types';
 import { Provider } from '@firebase/component';
 import { ERROR_FACTORY, AppCheckError } from './errors';
-import { ReCAPTCHAProvider, ReCAPTCHAProviderInternal } from './providers';
+import { ReCAPTCHAV3Provider, ReCAPTCHAV3ProviderInternal } from './providers';
 import { initialize as initializeRecaptcha } from './recaptcha';
 import { getState, setState, AppCheckState, ListenerType } from './state';
 import {
@@ -68,10 +68,10 @@ export function activate(
   setState(app, newState);
 
   // initialize reCAPTCHA if provider is a ReCAPTCHAProvider
-  if (newState.provider instanceof ReCAPTCHAProvider) {
+  if (newState.provider instanceof ReCAPTCHAV3Provider) {
     // Wrap public ReCAPTCHAProvider in an internal class that provides
     // platform logging and app.
-    const internalProvider = new ReCAPTCHAProviderInternal(
+    const internalProvider = new ReCAPTCHAV3ProviderInternal(
       app,
       newState.provider.siteKey,
       platformLoggerProvider

--- a/packages/app-check/src/factory.ts
+++ b/packages/app-check/src/factory.ts
@@ -46,9 +46,15 @@ export function factory(
   return {
     app,
     activate: (
-      siteKeyOrProvider: string | AppCheckProvider,
+      provider: AppCheckProvider,
       isTokenAutoRefreshEnabled?: boolean
-    ) => activate(app, siteKeyOrProvider, isTokenAutoRefreshEnabled),
+    ) =>
+      activate(
+        app,
+        provider,
+        platformLoggerProvider,
+        isTokenAutoRefreshEnabled
+      ),
     setTokenAutoRefreshEnabled: (isTokenAutoRefreshEnabled: boolean) =>
       setTokenAutoRefreshEnabled(app, isTokenAutoRefreshEnabled),
     getToken: forceRefresh =>

--- a/packages/app-check/src/factory.ts
+++ b/packages/app-check/src/factory.ts
@@ -46,12 +46,12 @@ export function factory(
   return {
     app,
     activate: (
-      provider: AppCheckProvider,
+      siteKeyOrProvider: AppCheckProvider | string,
       isTokenAutoRefreshEnabled?: boolean
     ) =>
       activate(
         app,
-        provider,
+        siteKeyOrProvider,
         platformLoggerProvider,
         isTokenAutoRefreshEnabled
       ),

--- a/packages/app-check/src/index.ts
+++ b/packages/app-check/src/index.ts
@@ -26,7 +26,7 @@ import {
   AppCheckComponentName
 } from '@firebase/app-check-types';
 import { factory, internalFactory } from './factory';
-import { ReCAPTCHAProvider } from './providers';
+import { ReCAPTCHAV3Provider } from './providers';
 import { initializeDebugMode } from './debug';
 import { AppCheckInternalComponentName } from '@firebase/app-check-interop-types';
 import { name, version } from '../package.json';
@@ -48,7 +48,7 @@ function registerAppCheck(firebase: _FirebaseNamespace): void {
       ComponentType.PUBLIC
     )
       .setServiceProps({
-        ReCAPTCHAProvider
+        ReCAPTCHAV3Provider
       })
       /**
        * AppCheck can only be initialized by explicitly calling firebase.appCheck()

--- a/packages/app-check/src/index.ts
+++ b/packages/app-check/src/index.ts
@@ -26,6 +26,7 @@ import {
   AppCheckComponentName
 } from '@firebase/app-check-types';
 import { factory, internalFactory } from './factory';
+import { ReCAPTCHAProvider } from './providers';
 import { initializeDebugMode } from './debug';
 import { AppCheckInternalComponentName } from '@firebase/app-check-interop-types';
 import { name, version } from '../package.json';
@@ -46,6 +47,9 @@ function registerAppCheck(firebase: _FirebaseNamespace): void {
       },
       ComponentType.PUBLIC
     )
+      .setServiceProps({
+        ReCAPTCHAProvider
+      })
       /**
        * AppCheck can only be initialized by explicitly calling firebase.appCheck()
        * We don't want firebase products that consume AppCheck to gate on AppCheck

--- a/packages/app-check/src/index.ts
+++ b/packages/app-check/src/index.ts
@@ -23,10 +23,15 @@ import {
 } from '@firebase/component';
 import {
   FirebaseAppCheck,
-  AppCheckComponentName
+  AppCheckComponentName,
+  ReCaptchaV3Provider,
+  CustomProvider
 } from '@firebase/app-check-types';
 import { factory, internalFactory } from './factory';
-import { ReCaptchaV3Provider, CustomProvider } from './providers';
+import {
+  ReCaptchaV3Provider as ReCaptchaV3ProviderImpl,
+  CustomProvider as CustomProviderImpl
+} from './providers';
 import { initializeDebugMode } from './debug';
 import { AppCheckInternalComponentName } from '@firebase/app-check-interop-types';
 import { name, version } from '../package.json';
@@ -48,8 +53,8 @@ function registerAppCheck(firebase: _FirebaseNamespace): void {
       ComponentType.PUBLIC
     )
       .setServiceProps({
-        ReCaptchaV3Provider,
-        CustomProvider
+        ReCaptchaV3Provider: ReCaptchaV3ProviderImpl,
+        CustomProvider: CustomProviderImpl
       })
       /**
        * AppCheck can only be initialized by explicitly calling firebase.appCheck()
@@ -99,8 +104,8 @@ initializeDebugMode();
 declare module '@firebase/app-types' {
   interface FirebaseNamespace {
     appCheck(app?: FirebaseApp): FirebaseAppCheck;
-    ReCaptchaV3Provider: typeof ReCaptchaV3Provider;
-    CustomProvider: typeof CustomProvider;
+    ReCaptchaV3Provider: ReCaptchaV3Provider;
+    CustomProvider: CustomProvider;
   }
   interface FirebaseApp {
     appCheck(): FirebaseAppCheck;

--- a/packages/app-check/src/index.ts
+++ b/packages/app-check/src/index.ts
@@ -104,8 +104,8 @@ initializeDebugMode();
 declare module '@firebase/app-types' {
   interface FirebaseNamespace {
     appCheck(app?: FirebaseApp): FirebaseAppCheck;
-    ReCaptchaV3Provider: ReCaptchaV3Provider;
-    CustomProvider: CustomProvider;
+    ReCaptchaV3Provider: typeof ReCaptchaV3Provider;
+    CustomProvider: typeof CustomProvider;
   }
   interface FirebaseApp {
     appCheck(): FirebaseAppCheck;

--- a/packages/app-check/src/index.ts
+++ b/packages/app-check/src/index.ts
@@ -99,6 +99,8 @@ initializeDebugMode();
 declare module '@firebase/app-types' {
   interface FirebaseNamespace {
     appCheck(app?: FirebaseApp): FirebaseAppCheck;
+    ReCaptchaV3Provider: typeof ReCaptchaV3Provider;
+    CustomProvider: typeof CustomProvider;
   }
   interface FirebaseApp {
     appCheck(): FirebaseAppCheck;

--- a/packages/app-check/src/index.ts
+++ b/packages/app-check/src/index.ts
@@ -26,7 +26,7 @@ import {
   AppCheckComponentName
 } from '@firebase/app-check-types';
 import { factory, internalFactory } from './factory';
-import { ReCAPTCHAV3Provider } from './providers';
+import { ReCaptchaV3Provider, CustomProvider } from './providers';
 import { initializeDebugMode } from './debug';
 import { AppCheckInternalComponentName } from '@firebase/app-check-interop-types';
 import { name, version } from '../package.json';
@@ -48,7 +48,8 @@ function registerAppCheck(firebase: _FirebaseNamespace): void {
       ComponentType.PUBLIC
     )
       .setServiceProps({
-        ReCAPTCHAV3Provider
+        ReCaptchaV3Provider,
+        CustomProvider
       })
       /**
        * AppCheck can only be initialized by explicitly calling firebase.appCheck()

--- a/packages/app-check/src/internal-api.test.ts
+++ b/packages/app-check/src/internal-api.test.ts
@@ -170,12 +170,12 @@ describe('internal api', () => {
     });
 
     it('notifies listeners using cached token', async () => {
+      storageReadStub.resolves(fakeCachedAppCheckToken);
       activate(
         app,
         new ReCaptchaV3Provider(FAKE_SITE_KEY),
         fakePlatformLoggingProvider
       );
-      storageReadStub.resolves(fakeCachedAppCheckToken);
 
       const listener1 = spy();
       const listener2 = spy();
@@ -299,13 +299,13 @@ describe('internal api', () => {
     });
 
     it('loads persisted token to memory and returns it', async () => {
+      storageReadStub.resolves(fakeCachedAppCheckToken);
+
       activate(
         app,
         new ReCaptchaV3Provider(FAKE_SITE_KEY),
         fakePlatformLoggingProvider
       );
-
-      storageReadStub.resolves(fakeCachedAppCheckToken);
 
       const clientStub = stub(client, 'exchangeToken');
 
@@ -402,6 +402,10 @@ describe('internal api', () => {
     it('adds token listeners', () => {
       const listener = (): void => {};
       stub(client, 'exchangeToken').resolves(fakeRecaptchaAppCheckToken);
+      setState(app, {
+        ...getState(app),
+        cachedTokenPromise: Promise.resolve(undefined)
+      });
 
       addTokenListener(
         app,
@@ -416,7 +420,11 @@ describe('internal api', () => {
     it('starts proactively refreshing token after adding the first listener', () => {
       const listener = (): void => {};
       stub(client, 'exchangeToken').resolves(fakeRecaptchaAppCheckToken);
-      setState(app, { ...getState(app), isTokenAutoRefreshEnabled: true });
+      setState(app, {
+        ...getState(app),
+        isTokenAutoRefreshEnabled: true,
+        cachedTokenPromise: Promise.resolve(undefined)
+      });
       expect(getState(app).tokenObservers.length).to.equal(0);
       expect(getState(app).tokenRefresher).to.equal(undefined);
 
@@ -461,16 +469,16 @@ describe('internal api', () => {
     it('notifies the listener with the valid token in storage', async () => {
       const clock = useFakeTimers();
       const listener = stub();
-      activate(
-        app,
-        new ReCaptchaV3Provider(FAKE_SITE_KEY),
-        fakePlatformLoggingProvider
-      );
       storageReadStub.resolves({
         token: `fake-cached-app-check-token`,
         expireTimeMillis: Date.now() + 60000,
         issuedAtTimeMillis: 0
       });
+      activate(
+        app,
+        new ReCaptchaV3Provider(FAKE_SITE_KEY),
+        fakePlatformLoggingProvider
+      );
 
       addTokenListener(
         app,
@@ -495,6 +503,10 @@ describe('internal api', () => {
     };
     it('should remove token listeners', () => {
       stub(client, 'exchangeToken').resolves(fakeRecaptchaAppCheckToken);
+      setState(app, {
+        ...getState(app),
+        cachedTokenPromise: Promise.resolve(undefined)
+      });
       const listener = (): void => {};
       addTokenListener(
         app,
@@ -510,6 +522,10 @@ describe('internal api', () => {
 
     it('should stop proactively refreshing token after deleting the last listener', () => {
       stub(client, 'exchangeToken').resolves(fakeRecaptchaAppCheckToken);
+      setState(app, {
+        ...getState(app),
+        cachedTokenPromise: Promise.resolve(undefined)
+      });
       const listener = (): void => {};
       setState(app, { ...getState(app), isTokenAutoRefreshEnabled: true });
 

--- a/packages/app-check/src/internal-api.test.ts
+++ b/packages/app-check/src/internal-api.test.ts
@@ -32,7 +32,6 @@ import {
   getToken,
   addTokenListener,
   removeTokenListener,
-  formatDummyToken,
   defaultTokenErrorData
 } from './internal-api';
 import * as reCAPTCHA from './recaptcha';
@@ -48,8 +47,9 @@ import {
   ListenerType
 } from './state';
 import { Deferred } from '@firebase/util';
-import { ReCAPTCHAProvider } from './providers';
 import { AppCheckTokenResult } from '../../app-check-types';
+import { ReCAPTCHAV3Provider } from './providers';
+import { formatDummyToken } from './util';
 
 const fakePlatformLoggingProvider = getFakePlatformLoggingProvider();
 
@@ -102,7 +102,7 @@ describe('internal api', () => {
     it('uses reCAPTCHA token to exchange for AppCheck token if ReCAPTCHAProvider is provided', async () => {
       activate(
         app,
-        new ReCAPTCHAProvider(FAKE_SITE_KEY),
+        new ReCAPTCHAV3Provider(FAKE_SITE_KEY),
         fakePlatformLoggingProvider
       );
 
@@ -128,7 +128,7 @@ describe('internal api', () => {
       const errorStub = stub(console, 'error');
       activate(
         app,
-        new ReCAPTCHAProvider(FAKE_SITE_KEY),
+        new ReCAPTCHAV3Provider(FAKE_SITE_KEY),
         fakePlatformLoggingProvider
       );
 
@@ -155,7 +155,7 @@ describe('internal api', () => {
     it('notifies listeners using cached token', async () => {
       activate(
         app,
-        new ReCAPTCHAProvider(FAKE_SITE_KEY),
+        new ReCAPTCHAV3Provider(FAKE_SITE_KEY),
         fakePlatformLoggingProvider
       );
       storageReadStub.resolves(fakeCachedAppCheckToken);
@@ -188,7 +188,7 @@ describe('internal api', () => {
     it('notifies listeners using new token', async () => {
       activate(
         app,
-        new ReCAPTCHAProvider(FAKE_SITE_KEY),
+        new ReCAPTCHAV3Provider(FAKE_SITE_KEY),
         fakePlatformLoggingProvider
       );
 
@@ -224,7 +224,7 @@ describe('internal api', () => {
       stub(logger.logger, 'error');
       activate(
         app,
-        new ReCAPTCHAProvider(FAKE_SITE_KEY),
+        new ReCAPTCHAV3Provider(FAKE_SITE_KEY),
         fakePlatformLoggingProvider
       );
       stub(reCAPTCHA, 'getToken').resolves(fakeRecaptchaToken);
@@ -250,7 +250,7 @@ describe('internal api', () => {
     it('ignores listeners that throw', async () => {
       activate(
         app,
-        new ReCAPTCHAProvider(FAKE_SITE_KEY),
+        new ReCAPTCHAV3Provider(FAKE_SITE_KEY),
         fakePlatformLoggingProvider
       );
       stub(reCAPTCHA, 'getToken').resolves(fakeRecaptchaToken);
@@ -284,7 +284,7 @@ describe('internal api', () => {
     it('loads persisted token to memory and returns it', async () => {
       activate(
         app,
-        new ReCAPTCHAProvider(FAKE_SITE_KEY),
+        new ReCAPTCHAV3Provider(FAKE_SITE_KEY),
         fakePlatformLoggingProvider
       );
 
@@ -304,7 +304,7 @@ describe('internal api', () => {
     it('persists token to storage', async () => {
       activate(
         app,
-        new ReCAPTCHAProvider(FAKE_SITE_KEY),
+        new ReCAPTCHAV3Provider(FAKE_SITE_KEY),
         fakePlatformLoggingProvider
       );
 
@@ -321,7 +321,7 @@ describe('internal api', () => {
     it('returns the valid token in memory without making network request', async () => {
       activate(
         app,
-        new ReCAPTCHAProvider(FAKE_SITE_KEY),
+        new ReCAPTCHAV3Provider(FAKE_SITE_KEY),
         fakePlatformLoggingProvider
       );
       setState(app, { ...getState(app), token: fakeRecaptchaAppCheckToken });
@@ -337,7 +337,7 @@ describe('internal api', () => {
     it('force to get new token when forceRefresh is true', async () => {
       activate(
         app,
-        new ReCAPTCHAProvider(FAKE_SITE_KEY),
+        new ReCAPTCHAV3Provider(FAKE_SITE_KEY),
         fakePlatformLoggingProvider
       );
       setState(app, { ...getState(app), token: fakeRecaptchaAppCheckToken });
@@ -363,7 +363,7 @@ describe('internal api', () => {
       debugState.token.resolve('my-debug-token');
       activate(
         app,
-        new ReCAPTCHAProvider(FAKE_SITE_KEY),
+        new ReCAPTCHAV3Provider(FAKE_SITE_KEY),
         fakePlatformLoggingProvider
       );
 
@@ -444,7 +444,7 @@ describe('internal api', () => {
     it('notifies the listener with the valid token in storage', done => {
       activate(
         app,
-        new ReCAPTCHAProvider(FAKE_SITE_KEY),
+        new ReCAPTCHAV3Provider(FAKE_SITE_KEY),
         fakePlatformLoggingProvider
       );
       storageReadStub.resolves({

--- a/packages/app-check/src/internal-api.ts
+++ b/packages/app-check/src/internal-api.ts
@@ -64,7 +64,7 @@ export async function getToken(
    * If there is no token in memory, try to load token from indexedDB.
    */
   if (!token) {
-    // readTokenFromStorage() always resolves. In case of an error, it resolves with `undefined`.
+    // cachedTokenPromise contains the token found in IndexedDB or undefined if not found.
     const cachedToken = await state.cachedTokenPromise;
     if (cachedToken && isValid(cachedToken)) {
       token = cachedToken;

--- a/packages/app-check/src/internal-api.ts
+++ b/packages/app-check/src/internal-api.ts
@@ -29,32 +29,18 @@ import {
 } from './state';
 import { TOKEN_REFRESH_TIME } from './constants';
 import { Refresher } from './proactive-refresh';
-import { ensureActivated } from './util';
+import { ensureActivated, formatDummyToken } from './util';
 import { exchangeToken, getExchangeDebugTokenRequest } from './client';
 import { writeTokenToStorage, readTokenFromStorage } from './storage';
 import { getDebugToken, isDebugMode } from './debug';
-import { base64, issuedAtTime } from '@firebase/util';
+import { issuedAtTime } from '@firebase/util';
 import { logger } from './logger';
 import { Provider } from '@firebase/component';
-import { ReCAPTCHAProviderInternal } from './providers';
+import { ReCAPTCHAV3ProviderInternal } from './providers';
 
 // Initial hardcoded value agreed upon across platforms for initial launch.
 // Format left open for possible dynamic error values and other fields in the future.
 export const defaultTokenErrorData = { error: 'UNKNOWN_ERROR' };
-
-/**
- * Stringify and base64 encode token error data.
- *
- * @param tokenError Error data, currently hardcoded.
- */
-export function formatDummyToken(
-  tokenErrorData: Record<string, string>
-): string {
-  return base64.encodeString(
-    JSON.stringify(tokenErrorData),
-    /* webSafe= */ false
-  );
-}
 
 /**
  * This function will always resolve.
@@ -122,7 +108,7 @@ export async function getToken(
     // ReCAPTCHAProvider is wrapped during activate().
     // ensureActivated() at the beginning of this function will prevent
     // getting here without activate() having been called.
-    if (state.provider instanceof ReCAPTCHAProviderInternal) {
+    if (state.provider instanceof ReCAPTCHAV3ProviderInternal) {
       token = await state.provider.getToken();
     } else if (state.provider) {
       // custom provider

--- a/packages/app-check/src/internal-api.ts
+++ b/packages/app-check/src/internal-api.ts
@@ -15,7 +15,6 @@
  * limitations under the License.
  */
 
-import { getToken as getReCAPTCHAToken } from './recaptcha';
 import { FirebaseApp } from '@firebase/app-types';
 import {
   AppCheckTokenListener,
@@ -31,17 +30,13 @@ import {
 import { TOKEN_REFRESH_TIME } from './constants';
 import { Refresher } from './proactive-refresh';
 import { ensureActivated } from './util';
-import {
-  exchangeToken,
-  getExchangeDebugTokenRequest,
-  getExchangeRecaptchaTokenRequest
-} from './client';
+import { exchangeToken, getExchangeDebugTokenRequest } from './client';
 import { writeTokenToStorage, readTokenFromStorage } from './storage';
 import { getDebugToken, isDebugMode } from './debug';
 import { base64, issuedAtTime } from '@firebase/util';
-import { ERROR_FACTORY, AppCheckError } from './errors';
 import { logger } from './logger';
 import { Provider } from '@firebase/component';
+import { ReCAPTCHAProviderInternal } from './providers';
 
 // Initial hardcoded value agreed upon across platforms for initial launch.
 // Format left open for possible dynamic error values and other fields in the future.
@@ -124,8 +119,14 @@ export async function getToken(
    * request a new token
    */
   try {
-    if (state.customProvider) {
-      const customToken = await state.customProvider.getToken();
+    // ReCAPTCHAProvider is wrapped during activate().
+    // ensureActivated() at the beginning of this function will prevent
+    // getting here without activate() having been called.
+    if (state.provider instanceof ReCAPTCHAProviderInternal) {
+      token = await state.provider.getToken();
+    } else if (state.provider) {
+      // custom provider
+      const customToken = await state.provider.getToken();
       // Try to extract IAT from custom token, in case this token is not
       // being newly issued. JWT timestamps are in seconds since epoch.
       const issuedAtTimeSeconds = issuedAtTime(customToken.token);
@@ -139,15 +140,6 @@ export async function getToken(
           : Date.now();
 
       token = { ...customToken, issuedAtTimeMillis };
-    } else {
-      const attestedClaimsToken = await getReCAPTCHAToken(app).catch(_e => {
-        // reCaptcha.execute() throws null which is not very descriptive.
-        throw ERROR_FACTORY.create(AppCheckError.RECAPTCHA_ERROR);
-      });
-      token = await exchangeToken(
-        getExchangeRecaptchaTokenRequest(app, attestedClaimsToken),
-        platformLoggerProvider
-      );
     }
   } catch (e) {
     // `getToken()` should never throw, but logging error text to console will aid debugging.

--- a/packages/app-check/src/internal-api.ts
+++ b/packages/app-check/src/internal-api.ts
@@ -177,7 +177,7 @@ export function addTokenListener(
     // Only check cache if there was no token. If the token was invalid,
     // skip this and rely on exchange endpoint.
     void state
-      .cachedTokenPromise!// Storage token promise. Always populated in `activate()`.
+      .cachedTokenPromise! // Storage token promise. Always populated in `activate()`.
       .then(cachedToken => {
         if (cachedToken && isValid(cachedToken)) {
           listener({ token: cachedToken.token });

--- a/packages/app-check/src/internal-api.ts
+++ b/packages/app-check/src/internal-api.ts
@@ -160,10 +160,7 @@ export function addTokenListener(
 
   // Create the refresher but don't start it if `isTokenAutoRefreshEnabled`
   // is not true.
-  if (
-    !newState.tokenRefresher.isRunning() &&
-    state.isTokenAutoRefreshEnabled === true
-  ) {
+  if (!newState.tokenRefresher.isRunning() && state.isTokenAutoRefreshEnabled) {
     newState.tokenRefresher.start();
   }
 

--- a/packages/app-check/src/providers.ts
+++ b/packages/app-check/src/providers.ts
@@ -20,11 +20,11 @@ import { FirebaseApp } from '@firebase/app-types';
 import { Provider } from '@firebase/component';
 import { exchangeToken, getExchangeRecaptchaTokenRequest } from './client';
 import { ERROR_FACTORY, AppCheckError } from './errors';
-import { formatDummyToken } from './internal-api';
+import { formatDummyToken } from './util';
 import { getToken as getReCAPTCHAToken } from './recaptcha';
 import { AppCheckTokenInternal } from './state';
 
-export class ReCAPTCHAProvider implements AppCheckProvider {
+export class ReCAPTCHAV3Provider implements AppCheckProvider {
   constructor(private _siteKey: string) {}
   async getToken(): Promise<AppCheckToken> {
     return Promise.resolve({
@@ -37,7 +37,7 @@ export class ReCAPTCHAProvider implements AppCheckProvider {
   }
 }
 
-export class ReCAPTCHAProviderInternal implements AppCheckProvider {
+export class ReCAPTCHAV3ProviderInternal implements AppCheckProvider {
   constructor(
     private _app: FirebaseApp,
     private _siteKey: string,

--- a/packages/app-check/src/providers.ts
+++ b/packages/app-check/src/providers.ts
@@ -1,0 +1,59 @@
+/**
+ * @license
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { AppCheckProvider, AppCheckToken } from '@firebase/app-check-types';
+import { FirebaseApp } from '@firebase/app-types';
+import { Provider } from '@firebase/component';
+import { exchangeToken, getExchangeRecaptchaTokenRequest } from './client';
+import { ERROR_FACTORY, AppCheckError } from './errors';
+import { formatDummyToken } from './internal-api';
+import { getToken as getReCAPTCHAToken } from './recaptcha';
+import { AppCheckTokenInternal } from './state';
+
+export class ReCAPTCHAProvider implements AppCheckProvider {
+  constructor(private _siteKey: string) {}
+  async getToken(): Promise<AppCheckToken> {
+    return Promise.resolve({
+      token: formatDummyToken({ error: 'NOT_ACTIVATED' }),
+      expireTimeMillis: Date.now()
+    });
+  }
+  get siteKey(): string {
+    return this._siteKey;
+  }
+}
+
+export class ReCAPTCHAProviderInternal implements AppCheckProvider {
+  constructor(
+    private _app: FirebaseApp,
+    private _siteKey: string,
+    private _platformLoggerProvider: Provider<'platform-logger'>
+  ) {}
+  async getToken(): Promise<AppCheckTokenInternal> {
+    const attestedClaimsToken = await getReCAPTCHAToken(this._app).catch(_e => {
+      // reCaptcha.execute() throws null which is not very descriptive.
+      throw ERROR_FACTORY.create(AppCheckError.RECAPTCHA_ERROR);
+    });
+    return exchangeToken(
+      getExchangeRecaptchaTokenRequest(this._app, attestedClaimsToken),
+      this._platformLoggerProvider
+    );
+  }
+  get siteKey(): string {
+    return this._siteKey;
+  }
+}

--- a/packages/app-check/src/providers.ts
+++ b/packages/app-check/src/providers.ts
@@ -15,35 +15,59 @@
  * limitations under the License.
  */
 
-import { AppCheckProvider, AppCheckToken } from '@firebase/app-check-types';
 import { FirebaseApp } from '@firebase/app-types';
 import { Provider } from '@firebase/component';
+import { issuedAtTime } from '@firebase/util';
+import { CustomProviderOptions } from '../../app-check-types';
 import { exchangeToken, getExchangeRecaptchaTokenRequest } from './client';
 import { ERROR_FACTORY, AppCheckError } from './errors';
-import { formatDummyToken } from './util';
-import { getToken as getReCAPTCHAToken } from './recaptcha';
+import {
+  getToken as getReCAPTCHAToken,
+  initialize as initializeRecaptcha
+} from './recaptcha';
 import { AppCheckTokenInternal } from './state';
 
-export class ReCAPTCHAV3Provider implements AppCheckProvider {
-  constructor(private _siteKey: string) {}
-  async getToken(): Promise<AppCheckToken> {
-    return Promise.resolve({
-      token: formatDummyToken({ error: 'NOT_ACTIVATED' }),
-      expireTimeMillis: Date.now()
-    });
-  }
-  get siteKey(): string {
-    return this._siteKey;
-  }
+export interface AppCheckProviderInternal {
+  /**
+   * Returns an AppCheck token.
+   */
+  getToken(): Promise<AppCheckTokenInternal>;
+  /**
+   * Initialize the class once app and platformLoggerProvider are available.
+   */
+  initialize(
+    app: FirebaseApp,
+    platformLoggerProvider: Provider<'platform-logger'>
+  ): void;
 }
 
-export class ReCAPTCHAV3ProviderInternal implements AppCheckProvider {
-  constructor(
-    private _app: FirebaseApp,
-    private _siteKey: string,
-    private _platformLoggerProvider: Provider<'platform-logger'>
-  ) {}
+/**
+ * App Check provider that can obtain a reCAPTCHA V3 token and exchange it
+ * for an App Check token.
+ *
+ * @public
+ */
+export class ReCaptchaV3Provider implements AppCheckProviderInternal {
+  private _app?: FirebaseApp;
+  private _platformLoggerProvider?: Provider<'platform-logger'>;
+  /**
+   * Create a ReCaptchaV3Provider instance.
+   * @param siteKey - ReCAPTCHA V3 siteKey.
+   */
+  constructor(private _siteKey: string) {}
+  /**
+   * Returns an App Check token.
+   * @internal
+   */
   async getToken(): Promise<AppCheckTokenInternal> {
+    if (!this._app || !this._platformLoggerProvider) {
+      // This should only occur if user has not called initializeAppCheck().
+      // We don't have an appName to provide if so.
+      // This should already be caught in the top level `getToken()` function.
+      throw ERROR_FACTORY.create(AppCheckError.USE_BEFORE_ACTIVATION, {
+        appName: ''
+      });
+    }
     const attestedClaimsToken = await getReCAPTCHAToken(this._app).catch(_e => {
       // reCaptcha.execute() throws null which is not very descriptive.
       throw ERROR_FACTORY.create(AppCheckError.RECAPTCHA_ERROR);
@@ -53,7 +77,64 @@ export class ReCAPTCHAV3ProviderInternal implements AppCheckProvider {
       this._platformLoggerProvider
     );
   }
-  get siteKey(): string {
-    return this._siteKey;
+
+  /**
+   * @internal
+   */
+  initialize(
+    app: FirebaseApp,
+    platformLoggerProvider: Provider<'platform-logger'>
+  ): void {
+    this._app = app;
+    this._platformLoggerProvider = platformLoggerProvider;
+    initializeRecaptcha(app, this._siteKey).catch(() => {
+      /* we don't care about the initialization result */
+    });
+  }
+}
+
+/**
+ * Custom provider class.
+ * @public
+ */
+export class CustomProvider implements AppCheckProviderInternal {
+  private _app?: FirebaseApp;
+
+  constructor(private _customProviderOptions: CustomProviderOptions) {}
+
+  /**
+   * @internal
+   */
+  async getToken(): Promise<AppCheckTokenInternal> {
+    if (!this._app) {
+      // This should only occur if user has not called initializeAppCheck().
+      // We don't have an appName to provide if so.
+      // This should already be caught in the top level `getToken()` function.
+      throw ERROR_FACTORY.create(AppCheckError.USE_BEFORE_ACTIVATION, {
+        appName: ''
+      });
+    }
+    // custom provider
+    const customToken = await this._customProviderOptions.getToken();
+    // Try to extract IAT from custom token, in case this token is not
+    // being newly issued. JWT timestamps are in seconds since epoch.
+    const issuedAtTimeSeconds = issuedAtTime(customToken.token);
+    // Very basic validation, use current timestamp as IAT if JWT
+    // has no `iat` field or value is out of bounds.
+    const issuedAtTimeMillis =
+      issuedAtTimeSeconds !== null &&
+      issuedAtTimeSeconds < Date.now() &&
+      issuedAtTimeSeconds > 0
+        ? issuedAtTimeSeconds * 1000
+        : Date.now();
+
+    return { ...customToken, issuedAtTimeMillis };
+  }
+
+  /**
+   * @internal
+   */
+  initialize(app: FirebaseApp): void {
+    this._app = app;
   }
 }

--- a/packages/app-check/src/providers.ts
+++ b/packages/app-check/src/providers.ts
@@ -44,8 +44,6 @@ export interface AppCheckProviderInternal {
 /**
  * App Check provider that can obtain a reCAPTCHA V3 token and exchange it
  * for an App Check token.
- *
- * @public
  */
 export class ReCaptchaV3Provider implements AppCheckProviderInternal {
   private _app?: FirebaseApp;
@@ -68,19 +66,19 @@ export class ReCaptchaV3Provider implements AppCheckProviderInternal {
         appName: ''
       });
     }
-    const attestedClaimsToken = await getReCAPTCHAToken(this._app).catch(_e => {
+    let attestedClaimsToken;
+    try {
+      attestedClaimsToken = await getReCAPTCHAToken(this._app);
+    } catch (e) {
       // reCaptcha.execute() throws null which is not very descriptive.
       throw ERROR_FACTORY.create(AppCheckError.RECAPTCHA_ERROR);
-    });
+    }
     return exchangeToken(
       getExchangeRecaptchaTokenRequest(this._app, attestedClaimsToken),
       this._platformLoggerProvider
     );
   }
 
-  /**
-   * @internal
-   */
   initialize(
     app: FirebaseApp,
     platformLoggerProvider: Provider<'platform-logger'>
@@ -95,7 +93,6 @@ export class ReCaptchaV3Provider implements AppCheckProviderInternal {
 
 /**
  * Custom provider class.
- * @public
  */
 export class CustomProvider implements AppCheckProviderInternal {
   private _app?: FirebaseApp;

--- a/packages/app-check/src/recaptcha.test.ts
+++ b/packages/app-check/src/recaptcha.test.ts
@@ -32,7 +32,7 @@ import * as utils from './util';
 import { getState } from './state';
 import { Deferred } from '@firebase/util';
 import { activate } from './api';
-import { ReCAPTCHAProvider } from './providers';
+import { ReCAPTCHAV3Provider } from './providers';
 
 describe('recaptcha', () => {
   let app: FirebaseApp;
@@ -103,7 +103,7 @@ describe('recaptcha', () => {
       self.grecaptcha = grecaptchaFake;
       activate(
         app,
-        new ReCAPTCHAProvider(FAKE_SITE_KEY),
+        new ReCAPTCHAV3Provider(FAKE_SITE_KEY),
         getFakePlatformLoggingProvider()
       );
       await getToken(app);
@@ -121,7 +121,7 @@ describe('recaptcha', () => {
       self.grecaptcha = grecaptchaFake;
       activate(
         app,
-        new ReCAPTCHAProvider(FAKE_SITE_KEY),
+        new ReCAPTCHAV3Provider(FAKE_SITE_KEY),
         getFakePlatformLoggingProvider()
       );
       const token = await getToken(app);

--- a/packages/app-check/src/recaptcha.test.ts
+++ b/packages/app-check/src/recaptcha.test.ts
@@ -24,13 +24,15 @@ import {
   getFakeGreCAPTCHA,
   removegreCAPTCHAScriptsOnPage,
   findgreCAPTCHAScriptsOnPage,
-  FAKE_SITE_KEY
+  FAKE_SITE_KEY,
+  getFakePlatformLoggingProvider
 } from '../test/util';
 import { initialize, getToken } from './recaptcha';
 import * as utils from './util';
 import { getState } from './state';
 import { Deferred } from '@firebase/util';
 import { activate } from './api';
+import { ReCAPTCHAProvider } from './providers';
 
 describe('recaptcha', () => {
   let app: FirebaseApp;
@@ -99,7 +101,11 @@ describe('recaptcha', () => {
         Promise.resolve('fake-recaptcha-token')
       );
       self.grecaptcha = grecaptchaFake;
-      activate(app, FAKE_SITE_KEY);
+      activate(
+        app,
+        new ReCAPTCHAProvider(FAKE_SITE_KEY),
+        getFakePlatformLoggingProvider()
+      );
       await getToken(app);
 
       expect(executeStub).to.have.been.calledWith('fake_widget_1', {
@@ -113,7 +119,11 @@ describe('recaptcha', () => {
         Promise.resolve('fake-recaptcha-token')
       );
       self.grecaptcha = grecaptchaFake;
-      activate(app, FAKE_SITE_KEY);
+      activate(
+        app,
+        new ReCAPTCHAProvider(FAKE_SITE_KEY),
+        getFakePlatformLoggingProvider()
+      );
       const token = await getToken(app);
 
       expect(token).to.equal('fake-recaptcha-token');

--- a/packages/app-check/src/recaptcha.test.ts
+++ b/packages/app-check/src/recaptcha.test.ts
@@ -32,7 +32,7 @@ import * as utils from './util';
 import { getState } from './state';
 import { Deferred } from '@firebase/util';
 import { activate } from './api';
-import { ReCAPTCHAV3Provider } from './providers';
+import { ReCaptchaV3Provider } from './providers';
 
 describe('recaptcha', () => {
   let app: FirebaseApp;
@@ -103,7 +103,7 @@ describe('recaptcha', () => {
       self.grecaptcha = grecaptchaFake;
       activate(
         app,
-        new ReCAPTCHAV3Provider(FAKE_SITE_KEY),
+        new ReCaptchaV3Provider(FAKE_SITE_KEY),
         getFakePlatformLoggingProvider()
       );
       await getToken(app);
@@ -121,7 +121,7 @@ describe('recaptcha', () => {
       self.grecaptcha = grecaptchaFake;
       activate(
         app,
-        new ReCAPTCHAV3Provider(FAKE_SITE_KEY),
+        new ReCaptchaV3Provider(FAKE_SITE_KEY),
         getFakePlatformLoggingProvider()
       );
       const token = await getToken(app);

--- a/packages/app-check/src/state.ts
+++ b/packages/app-check/src/state.ts
@@ -45,7 +45,7 @@ export const enum ListenerType {
 export interface AppCheckState {
   activated: boolean;
   tokenObservers: AppCheckTokenObserver[];
-  customProvider?: AppCheckProvider;
+  provider?: AppCheckProvider;
   siteKey?: string;
   token?: AppCheckTokenInternal;
   tokenRefresher?: Refresher;

--- a/packages/app-check/src/state.ts
+++ b/packages/app-check/src/state.ts
@@ -45,6 +45,7 @@ export interface AppCheckState {
   provider?: AppCheckProviderInternal;
   siteKey?: string;
   token?: AppCheckTokenInternal;
+  cachedTokenPromise?: Promise<AppCheckTokenInternal | undefined>;
   tokenRefresher?: Refresher;
   reCAPTCHAState?: ReCAPTCHAState;
   isTokenAutoRefreshEnabled?: boolean;

--- a/packages/app-check/src/state.ts
+++ b/packages/app-check/src/state.ts
@@ -16,15 +16,12 @@
  */
 
 import { FirebaseApp } from '@firebase/app-types';
-import {
-  AppCheckProvider,
-  AppCheckToken,
-  AppCheckTokenResult
-} from '@firebase/app-check-types';
+import { AppCheckToken, AppCheckTokenResult } from '@firebase/app-check-types';
 import { AppCheckTokenListener } from '@firebase/app-check-interop-types';
 import { Refresher } from './proactive-refresh';
 import { Deferred, PartialObserver } from '@firebase/util';
 import { GreCAPTCHA } from './recaptcha';
+import { AppCheckProviderInternal } from './providers';
 
 export interface AppCheckTokenInternal extends AppCheckToken {
   issuedAtTimeMillis: number;
@@ -45,7 +42,7 @@ export const enum ListenerType {
 export interface AppCheckState {
   activated: boolean;
   tokenObservers: AppCheckTokenObserver[];
-  provider?: AppCheckProvider;
+  provider?: AppCheckProviderInternal;
   siteKey?: string;
   token?: AppCheckTokenInternal;
   tokenRefresher?: Refresher;

--- a/packages/app-check/src/util.ts
+++ b/packages/app-check/src/util.ts
@@ -19,6 +19,7 @@ import { GreCAPTCHA } from './recaptcha';
 import { getState } from './state';
 import { ERROR_FACTORY, AppCheckError } from './errors';
 import { FirebaseApp } from '@firebase/app-types';
+import { base64 } from '@firebase/util';
 
 export function getRecaptcha(): GreCAPTCHA | undefined {
   return self.grecaptcha;
@@ -41,4 +42,18 @@ export function uuidv4(): string {
       v = c === 'x' ? r : (r & 0x3) | 0x8;
     return v.toString(16);
   });
+}
+
+/**
+ * Stringify and base64 encode token error data.
+ *
+ * @param tokenError Error data, currently hardcoded.
+ */
+export function formatDummyToken(
+  tokenErrorData: Record<string, string>
+): string {
+  return base64.encodeString(
+    JSON.stringify(tokenErrorData),
+    /* webSafe= */ false
+  );
 }

--- a/packages/app-check/test/util.ts
+++ b/packages/app-check/test/util.ts
@@ -39,7 +39,7 @@ export function getFakeApp(overrides: Record<string, any> = {}): FirebaseApp {
       storageBucket: 'storageBucket',
       appId: '1:777777777777:web:d93b5ca1475efe57'
     } as any,
-    automaticDataCollectionEnabled: true,
+    automaticDataCollectionEnabled: false,
     delete: async () => {},
     // This won't be used in tests.
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/firebase/index.d.ts
+++ b/packages/firebase/index.d.ts
@@ -1542,6 +1542,16 @@ declare namespace firebase.appCheck {
   interface AppCheckTokenResult {
     token: string;
   }
+  /*
+   * ReCAPTCHA v3 token provider.
+   */
+  class ReCAPTCHAV3Provider {
+    /**
+     * @param siteKey - ReCAPTCHA v3 site key (public key).
+     */
+    constructor(siteKey: string);
+  }
+
   /**
    * The Firebase AppCheck service interface.
    *
@@ -1551,15 +1561,14 @@ declare namespace firebase.appCheck {
   export interface AppCheck {
     /**
      * Activate AppCheck
-     * @param siteKeyOrProvider reCAPTCHA v3 site key (public key) or
-     * custom token provider.
+     * @param provider reCAPTCHA or custom token provider.
      * @param isTokenAutoRefreshEnabled If true, the SDK automatically
      * refreshes App Check tokens as needed. If undefined, defaults to the
      * value of `app.automaticDataCollectionEnabled`, which defaults to
      * false and can be set in the app config.
      */
     activate(
-      siteKeyOrProvider: string | AppCheckProvider,
+      provider: AppCheckProvider,
       isTokenAutoRefreshEnabled?: boolean
     ): void;
 

--- a/packages/firebase/index.d.ts
+++ b/packages/firebase/index.d.ts
@@ -1551,6 +1551,25 @@ declare namespace firebase.appCheck {
      */
     constructor(siteKey: string);
   }
+  /*
+   * Custom token provider.
+   */
+  class CustomProvider {
+    /**
+     * @param options - Options for creating the custom provider.
+     */
+    constructor(options: CustomProviderOptions);
+  }
+  /**
+   * Options when creating a CustomProvider.
+   */
+  interface CustomProviderOptions {
+    /**
+     * Function to get an App Check token through a custom provider
+     * service.
+     */
+    getToken: () => Promise<AppCheckToken>;
+  }
 
   /**
    * The Firebase AppCheck service interface.

--- a/packages/firebase/index.d.ts
+++ b/packages/firebase/index.d.ts
@@ -1545,7 +1545,7 @@ declare namespace firebase.appCheck {
   /*
    * ReCAPTCHA v3 token provider.
    */
-  class ReCAPTCHAV3Provider {
+  class ReCaptchaV3Provider {
     /**
      * @param siteKey - ReCAPTCHA v3 site key (public key).
      */


### PR DESCRIPTION
Create provider classes that users can use in `activate()`. To avoid breaking changes, `activate` still takes a string site key or our previous custom provider pattern, which is any object with a `getToken` property.

I also changed `addTokenListener` to check for existing tokens in both memory and storage because otherwise it will only check storage if `getToken()` is called, which only happens if the refresher starts, which only happens if automatic token refresh is enabled. I don't think fetching a token from local storage should be gated on that.

Note: API changes should also be propagated to v9 compat after this.

Edit: For docs review - only need to review `packages/firebase/index.d.ts`