### PR TITLE
Fix auth popup positioning

### DIFF
--- a/.changeset/hot-bats-notice.md
+++ b/.changeset/hot-bats-notice.md
@@ -1,0 +1,5 @@
+---
+'@firebase/auth-exp': patch
+---
+
+Fix authentication popup positioning.

--- a/packages-exp/auth-exp/src/platform_browser/util/popup.test.ts
+++ b/packages-exp/auth-exp/src/platform_browser/util/popup.test.ts
@@ -138,7 +138,7 @@ describe('platform_browser/util/popup', () => {
       width: '500',
       height: '600',
       top: '0',
-      left: '0'
+      left: '150'
     });
 
     /* eslint-disable-next-line @typescript-eslint/no-explicit-any */

--- a/packages-exp/auth-exp/src/platform_browser/util/popup.ts
+++ b/packages-exp/auth-exp/src/platform_browser/util/popup.ts
@@ -60,8 +60,8 @@ export function _open(
   width = DEFAULT_WIDTH,
   height = DEFAULT_HEIGHT
 ): AuthPopup {
-  const top = Math.min((window.screen.availHeight - height) / 2, 0).toString();
-  const left = Math.min((window.screen.availWidth - width) / 2, 0).toString();
+  const top = Math.max((window.screen.availHeight - height) / 2, 0).toString();
+  const left = Math.max((window.screen.availWidth - width) / 2, 0).toString();
   let target = '';
 
   const options: { [key: string]: string } = {


### PR DESCRIPTION
The goal is to center the popup on the screen, but due to a mix-up of Math.min vs Math.max it always ends up at (0, 0) instead.