### PR TITLE
Migrates Listeners Registration from `getMessaging` to Messaging's Factory Methods 🏭

### DIFF
--- a/common/api-review/messaging-exp.api.md
+++ b/common/api-review/messaging-exp.api.md
@@ -59,11 +59,6 @@ export interface NotificationPayload {
 
 export { Observer }
 
-// Warning: (ae-internal-missing-underscore) The name "onBackgroundMessage" should be prefixed with an underscore because the declaration is marked as @internal
-//
-// @internal
-export function onBackgroundMessage(messaging: FirebaseMessaging, nextOrObserver: NextFn<MessagePayload> | Observer<MessagePayload>): Unsubscribe;
-
 // @public
 export function onMessage(messaging: FirebaseMessaging, nextOrObserver: NextFn<MessagePayload> | Observer<MessagePayload>): Unsubscribe;
 

--- a/common/api-review/messaging-exp.api.md
+++ b/common/api-review/messaging-exp.api.md
@@ -67,9 +67,6 @@ export function onBackgroundMessage(messaging: FirebaseMessaging, nextOrObserver
 // @public
 export function onMessage(messaging: FirebaseMessaging, nextOrObserver: NextFn<MessagePayload> | Observer<MessagePayload>): Unsubscribe;
 
-// @internal
-export function _registerListeners(messaging: FirebaseMessaging): void;
-
 export { Unsubscribe }
 
 

--- a/common/api-review/messaging-exp.api.md
+++ b/common/api-review/messaging-exp.api.md
@@ -67,6 +67,9 @@ export function onBackgroundMessage(messaging: FirebaseMessaging, nextOrObserver
 // @public
 export function onMessage(messaging: FirebaseMessaging, nextOrObserver: NextFn<MessagePayload> | Observer<MessagePayload>): Unsubscribe;
 
+// @internal
+export function _registerListeners(messaging: FirebaseMessaging): void;
+
 export { Unsubscribe }
 
 

--- a/packages-exp/messaging-compat/src/messaging-compat.ts
+++ b/packages-exp/messaging-compat/src/messaging-compat.ts
@@ -24,10 +24,11 @@ import {
   MessagePayload,
   deleteToken,
   getToken,
-  onBackgroundMessage,
   onMessage
 } from '@firebase/messaging-exp';
 import { NextFn, Observer, Unsubscribe } from '@firebase/util';
+
+import { onBackgroundMessage } from '@firebase/messaging-exp/sw';
 
 export interface MessagingCompat {
   getToken(options?: {

--- a/packages-exp/messaging-compat/src/messaging-compat.ts
+++ b/packages-exp/messaging-compat/src/messaging-compat.ts
@@ -22,7 +22,6 @@ import {
 import {
   FirebaseMessaging,
   MessagePayload,
-  _registerListeners,
   deleteToken,
   getToken,
   onBackgroundMessage,
@@ -92,8 +91,6 @@ export class MessagingCompatImpl implements MessagingCompat, _FirebaseService {
   constructor(readonly app: AppCompat, readonly _delegate: FirebaseMessaging) {
     this.app = app;
     this._delegate = _delegate;
-
-    _registerListeners(_delegate);
   }
 
   async getToken(options?: {

--- a/packages-exp/messaging-compat/src/messaging-compat.ts
+++ b/packages-exp/messaging-compat/src/messaging-compat.ts
@@ -22,6 +22,7 @@ import {
 import {
   FirebaseMessaging,
   MessagePayload,
+  _registerListeners,
   deleteToken,
   getToken,
   onBackgroundMessage,
@@ -88,22 +89,11 @@ function isSwSupported(): boolean {
 }
 
 export class MessagingCompatImpl implements MessagingCompat, _FirebaseService {
-  swRegistration?: ServiceWorkerRegistration;
-  vapidKey?: string;
-
-  onBackgroundMessageHandler:
-    | NextFn<MessagePayload>
-    | Observer<MessagePayload>
-    | null = null;
-
-  onMessageHandler:
-    | NextFn<MessagePayload>
-    | Observer<MessagePayload>
-    | null = null;
-
   constructor(readonly app: AppCompat, readonly _delegate: FirebaseMessaging) {
     this.app = app;
     this._delegate = _delegate;
+
+    _registerListeners(_delegate);
   }
 
   async getToken(options?: {

--- a/packages-exp/messaging-compat/src/registerMessagingCompat.ts
+++ b/packages-exp/messaging-compat/src/registerMessagingCompat.ts
@@ -22,6 +22,7 @@ import {
   InstanceFactory
 } from '@firebase/component';
 import firebase, { _FirebaseNamespace } from '@firebase/app-compat';
+
 import { MessagingCompatImpl } from './messaging-compat';
 
 declare module '@firebase/component' {
@@ -33,10 +34,19 @@ declare module '@firebase/component' {
 const messagingCompatFactory: InstanceFactory<'messaging-compat'> = (
   container: ComponentContainer
 ) => {
-  return new MessagingCompatImpl(
-    container.getProvider('app-compat').getImmediate(),
-    container.getProvider('messaging-exp').getImmediate()
-  );
+  if (!!navigator) {
+    // in window
+    return new MessagingCompatImpl(
+      container.getProvider('app-compat').getImmediate(),
+      container.getProvider('messaging-exp').getImmediate()
+    );
+  } else {
+    // in sw
+    return new MessagingCompatImpl(
+      container.getProvider('app-compat').getImmediate(),
+      container.getProvider('messaging-sw-exp').getImmediate()
+    );
+  }
 };
 
 export function registerMessagingCompat(): void {

--- a/packages-exp/messaging-compat/test/messaging-compat.test.ts
+++ b/packages-exp/messaging-compat/test/messaging-compat.test.ts
@@ -16,6 +16,7 @@
  */
 
 import * as messagingModule from '@firebase/messaging-exp';
+import * as messagingModuleInSw from '@firebase/messaging-exp/sw';
 
 import { getFakeApp, getFakeModularMessaging } from './fakes';
 
@@ -33,7 +34,10 @@ describe('messagingCompat', () => {
   const getTokenStub = stub(messagingModule, 'getToken');
   const deleteTokenStub = stub(messagingModule, 'deleteToken');
   const onMessageStub = stub(messagingModule, 'onMessage');
-  const onBackgroundMessageStub = stub(messagingModule, 'onBackgroundMessage');
+  const onBackgroundMessageStub = stub(
+    messagingModuleInSw,
+    'onBackgroundMessage'
+  );
 
   it('routes messagingCompat.getToken to modular SDK', () => {
     void messagingCompat.getToken();

--- a/packages-exp/messaging-exp/src/api.ts
+++ b/packages-exp/messaging-exp/src/api.ts
@@ -141,6 +141,8 @@ export function onMessage(
  * message is received and the app is currently in the background.
  *
  * @returns To stop listening for messages execute this returned function
+ *
+ * @public
  */
 export function onBackgroundMessage(
   messaging: FirebaseMessaging,

--- a/packages-exp/messaging-exp/src/api.ts
+++ b/packages-exp/messaging-exp/src/api.ts
@@ -23,20 +23,12 @@ import {
   Unsubscribe,
   getModularInstance
 } from '@firebase/util';
-import {
-  onNotificationClick,
-  onPush,
-  onSubChange
-} from './listeners/sw-listeners';
 
 import { MessagingService } from './messaging-service';
-import { Provider } from '@firebase/component';
-import { ServiceWorkerGlobalScope } from './util/sw-types';
 import { deleteToken as _deleteToken } from './api/deleteToken';
 import { getToken as _getToken } from './api/getToken';
 import { onBackgroundMessage as _onBackgroundMessage } from './api/onBackgroundMessage';
 import { onMessage as _onMessage } from './api/onMessage';
-import { messageEventListener } from './listeners/window-listener';
 
 /**
  * Retrieves a Firebase Cloud Messaging instance.
@@ -45,48 +37,8 @@ import { messageEventListener } from './listeners/window-listener';
  *
  * @public
  */
-export function getMessagingInWindow(
-  app: FirebaseApp = getApp()
-): FirebaseMessaging {
-  app = getModularInstance(app);
-  const messagingProvider: Provider<'messaging-exp'> = _getProvider(
-    app,
-    'messaging-exp'
-  );
-  const messaging = messagingProvider.getImmediate();
-
-  navigator.serviceWorker.addEventListener('message', e =>
-    messageEventListener(messaging as MessagingService, e)
-  );
-
-  return messaging;
-}
-
-/**
- * Retrieves a firebase messaging instance.
- *
- * @returns the firebase messaging instance associated with the provided firebase app.
- *
- */
-declare const self: ServiceWorkerGlobalScope;
-export function getMessagingInSw(app: FirebaseApp): FirebaseMessaging {
-  const messagingProvider: Provider<'messaging-exp'> = _getProvider(
-    app,
-    'messaging-exp'
-  );
-  const messaging = messagingProvider.getImmediate();
-
-  self.addEventListener('push', e => {
-    e.waitUntil(onPush(e, messaging as MessagingService));
-  });
-  self.addEventListener('pushsubscriptionchange', e => {
-    e.waitUntil(onSubChange(e, messaging as MessagingService));
-  });
-  self.addEventListener('notificationclick', e => {
-    e.waitUntil(onNotificationClick(e));
-  });
-
-  return messagingProvider.getImmediate();
+export function getMessaging(app: FirebaseApp = getApp()): FirebaseMessaging {
+  return _getProvider(getModularInstance(app), 'messaging-exp').getImmediate();
 }
 
 /**

--- a/packages-exp/messaging-exp/src/api.ts
+++ b/packages-exp/messaging-exp/src/api.ts
@@ -141,9 +141,6 @@ export function onMessage(
  * message is received and the app is currently in the background.
  *
  * @returns To stop listening for messages execute this returned function
- *
- * make it internal to hide it from the browser entry point.
- * @internal
  */
 export function onBackgroundMessage(
   messaging: FirebaseMessaging,

--- a/packages-exp/messaging-exp/src/api.ts
+++ b/packages-exp/messaging-exp/src/api.ts
@@ -37,8 +37,26 @@ import { onMessage as _onMessage } from './api/onMessage';
  *
  * @public
  */
-export function getMessaging(app: FirebaseApp = getApp()): FirebaseMessaging {
+export function getMessagingInWindow(
+  app: FirebaseApp = getApp()
+): FirebaseMessaging {
   return _getProvider(getModularInstance(app), 'messaging-exp').getImmediate();
+}
+
+/**
+ * Retrieves a Firebase Cloud Messaging instance.
+ *
+ * @returns The Firebase Cloud Messaging instance associated with the provided firebase app.
+ *
+ * @public
+ */
+export function getMessagingInSw(
+  app: FirebaseApp = getApp()
+): FirebaseMessaging {
+  return _getProvider(
+    getModularInstance(app),
+    'messaging-sw-exp'
+  ).getImmediate();
 }
 
 /**

--- a/packages-exp/messaging-exp/src/helpers/register.ts
+++ b/packages-exp/messaging-exp/src/helpers/register.ts
@@ -52,11 +52,15 @@ const WindowMessagingFactory: InstanceFactory<'messaging-exp'> = (
       throw ERROR_FACTORY.create(ErrorCode.INDEXED_DB_UNSUPPORTED);
     });
 
-  return new MessagingService(
+  const messaging = new MessagingService(
     container.getProvider('app-exp').getImmediate(),
     container.getProvider('installations-exp-internal').getImmediate(),
     container.getProvider('analytics-internal')
   );
+
+  registerListeners(messaging);
+
+  return messaging;
 };
 
 const SwMessagingFactory: InstanceFactory<'messaging-exp'> = (
@@ -76,11 +80,15 @@ const SwMessagingFactory: InstanceFactory<'messaging-exp'> = (
       throw ERROR_FACTORY.create(ErrorCode.INDEXED_DB_UNSUPPORTED);
     });
 
-  return new MessagingService(
+  const messaging = new MessagingService(
     container.getProvider('app-exp').getImmediate(),
     container.getProvider('installations-exp-internal').getImmediate(),
     container.getProvider('analytics-internal')
   );
+
+  registerListeners(messaging);
+
+  return messaging;
 };
 
 export function registerMessagingInWindow(): void {
@@ -96,15 +104,7 @@ export function registerMessagingInSw(): void {
 }
 
 declare const self: ServiceWorkerGlobalScope;
-/**
- * Conditionally registers the listeners. Theses registrations are done in `getMessagingInSw` and
- * `getMessagingInWindow` for the v9 SDK. This method exists for `messaging-compat` because the
- * injected messaging instance to `messaging-compat` isn't created through the `getMessaging`
- * method. Thus the main package of v9 needs to export this method to support `messaging-compat`.
- *
- * @internal
- */
-export function _registerListeners(messaging: FirebaseMessaging): void {
+function registerListeners(messaging: FirebaseMessaging): void {
   if (!!navigator) {
     // in window
     navigator.serviceWorker.addEventListener('message', e =>

--- a/packages-exp/messaging-exp/src/index.sw.ts
+++ b/packages-exp/messaging-exp/src/index.sw.ts
@@ -20,7 +20,7 @@ import '@firebase/installations-exp';
 import { FirebaseMessaging } from './interfaces/public-types';
 import { registerMessagingInSw } from './helpers/register';
 
-export { onBackgroundMessage, getMessagingInSw as getMessaging } from './api';
+export { onBackgroundMessage, getMessaging } from './api';
 export { isSwSupported as isSupported } from './api/isSupported';
 
 declare module '@firebase/component' {

--- a/packages-exp/messaging-exp/src/index.sw.ts
+++ b/packages-exp/messaging-exp/src/index.sw.ts
@@ -20,12 +20,12 @@ import '@firebase/installations-exp';
 import { FirebaseMessaging } from './interfaces/public-types';
 import { registerMessagingInSw } from './helpers/register';
 
-export { onBackgroundMessage, getMessaging } from './api';
+export { onBackgroundMessage, getMessagingInSw as getMessaging } from './api';
 export { isSwSupported as isSupported } from './api/isSupported';
 
 declare module '@firebase/component' {
   interface NameServiceMapping {
-    'messaging-exp': FirebaseMessaging;
+    'messaging-sw-exp': FirebaseMessaging;
   }
 }
 

--- a/packages-exp/messaging-exp/src/index.ts
+++ b/packages-exp/messaging-exp/src/index.ts
@@ -30,8 +30,7 @@ export {
   getToken,
   deleteToken,
   onMessage,
-  getMessagingInWindow as getMessaging,
-  onBackgroundMessage
+  getMessagingInWindow as getMessaging
 } from './api';
 export { isWindowSupported as isSupported } from './api/isSupported';
 export * from './interfaces/public-types';

--- a/packages-exp/messaging-exp/src/index.ts
+++ b/packages-exp/messaging-exp/src/index.ts
@@ -33,6 +33,7 @@ export {
   getMessagingInWindow as getMessaging,
   onBackgroundMessage
 } from './api';
+export { _registerListeners } from './helpers/register';
 export { isWindowSupported as isSupported } from './api/isSupported';
 export * from './interfaces/public-types';
 

--- a/packages-exp/messaging-exp/src/index.ts
+++ b/packages-exp/messaging-exp/src/index.ts
@@ -30,10 +30,9 @@ export {
   getToken,
   deleteToken,
   onMessage,
-  getMessagingInWindow as getMessaging,
+  getMessaging,
   onBackgroundMessage
 } from './api';
-export { _registerListeners } from './helpers/register';
 export { isWindowSupported as isSupported } from './api/isSupported';
 export * from './interfaces/public-types';
 

--- a/packages-exp/messaging-exp/src/index.ts
+++ b/packages-exp/messaging-exp/src/index.ts
@@ -30,7 +30,7 @@ export {
   getToken,
   deleteToken,
   onMessage,
-  getMessaging,
+  getMessagingInWindow as getMessaging,
   onBackgroundMessage
 } from './api';
 export { isWindowSupported as isSupported } from './api/isSupported';


### PR DESCRIPTION
`messaging-compat` is a compatibility layer that bridges the v8 and v9(modular) JS API. It's created through wrapping the v9 SDK to recreate the v8 API surface. The objective is to allow developer to gradually migrate to v9 without having to migrate the entire codebase. 

Now the v9 SDK registers its listeners (`onPush`, `onSubChange`, `onMessage`) in `getMessagingInWindow` and `getMessagaingInSw` which is not called in the `messaging-compat`. Without these listeners, the compat SDK can only `getToken` and not get callbacks in `onMessage` and `onBackgroundMessage` 


- PR moves the  listeners registration to factory methods.    
- PR also removes unused variables in `messaging-compat`.
- PR registers 2 components since they will both be called in `messaging-compat` as `messaging-exp` and `messaging-sw-exp`

b/188418727 for tracking