### PR TITLE
Show build output during release script

### DIFF
--- a/scripts/release/utils/yarn.ts
+++ b/scripts/release/utils/yarn.ts
@@ -32,7 +32,8 @@ export async function reinstallDeps() {
 export async function buildPackages() {
   const spinner = ora(' Building Packages').start();
   await spawn('yarn', ['build:release'], {
-    cwd: root
+    cwd: root,
+    stdio: 'inherit'
   });
   spinner.stopAndPersist({
     symbol: '✅'


### PR DESCRIPTION
Set stdio on `build:release` step so we can see build errors in the terminal.