### PR TITLE
Simplify ObjectValue

### DIFF
--- a/packages/firestore/src/exp/snapshot.ts
+++ b/packages/firestore/src/exp/snapshot.ts
@@ -278,7 +278,7 @@ export class DocumentSnapshot<
       return this._converter.fromFirestore(snapshot, options);
     } else {
       return this._userDataWriter.convertValue(
-        this._document.data.toProto(),
+        this._document.data.value,
         options.serverTimestamps
       ) as T;
     }

--- a/packages/firestore/src/lite/snapshot.ts
+++ b/packages/firestore/src/lite/snapshot.ts
@@ -174,9 +174,7 @@ export class DocumentSnapshot<T = DocumentData> {
       );
       return this._converter.fromFirestore(snapshot);
     } else {
-      return this._userDataWriter.convertValue(
-        this._document.data.toProto()
-      ) as T;
+      return this._userDataWriter.convertValue(this._document.data.value) as T;
     }
   }
 

--- a/packages/firestore/src/lite/user_data_writer.ts
+++ b/packages/firestore/src/lite/user_data_writer.ts
@@ -92,7 +92,7 @@ export abstract class AbstractUserDataWriter {
     serverTimestampBehavior: ServerTimestampBehavior
   ): DocumentData {
     const result: DocumentData = {};
-    forEach(mapValue.fields || {}, (key, value) => {
+    forEach(mapValue.fields, (key, value) => {
       result[key] = this.convertValue(value, serverTimestampBehavior);
     });
     return result;

--- a/packages/firestore/src/local/local_store_impl.ts
+++ b/packages/firestore/src/local/local_store_impl.ts
@@ -330,7 +330,7 @@ export function localStoreWriteLocally(
                 new PatchMutation(
                   mutation.key,
                   baseValue,
-                  extractFieldMask(baseValue.value.mapValue!),
+                  extractFieldMask(baseValue.value.mapValue),
                   Precondition.exists(true)
                 )
               );

--- a/packages/firestore/src/local/local_store_impl.ts
+++ b/packages/firestore/src/local/local_store_impl.ts
@@ -16,7 +16,7 @@
  */
 
 import { User } from '../auth/user';
-import { BundledDocuments, NamedQuery, BundleConverter } from '../core/bundle';
+import { BundleConverter, BundledDocuments, NamedQuery } from '../core/bundle';
 import { newQueryForPath, Query, queryToTarget } from '../core/query';
 import { SnapshotVersion } from '../core/snapshot_version';
 import { canonifyTarget, Target, targetEquals } from '../core/target';
@@ -330,7 +330,7 @@ export function localStoreWriteLocally(
                 new PatchMutation(
                   mutation.key,
                   baseValue,
-                  extractFieldMask(baseValue.toProto().mapValue!),
+                  extractFieldMask(baseValue.value.mapValue!),
                   Precondition.exists(true)
                 )
               );

--- a/packages/firestore/src/local/memory_persistence.ts
+++ b/packages/firestore/src/local/memory_persistence.ts
@@ -474,7 +474,7 @@ export class MemoryLruDelegate implements ReferenceDelegate, LruDelegate {
   documentSize(document: Document): number {
     let documentSize = document.key.toString().length;
     if (document.isFoundDocument()) {
-      documentSize += estimateByteSize(document.data.toProto());
+      documentSize += estimateByteSize(document.data.value);
     }
     return documentSize;
   }

--- a/packages/firestore/src/model/document.ts
+++ b/packages/firestore/src/model/document.ts
@@ -331,7 +331,7 @@ export class MutableDocument implements Document {
   toString(): string {
     return (
       `Document(${this.key}, ${this.version}, ${JSON.stringify(
-        this.data.toProto()
+        this.data.value
       )}, ` +
       `{documentType: ${this.documentType}}), ` +
       `{documentState: ${this.documentState}})`

--- a/packages/firestore/src/model/object_value.ts
+++ b/packages/firestore/src/model/object_value.ts
@@ -36,14 +36,11 @@ export interface JsonObject<T> {
  * ability to add and remove fields (via the ObjectValueBuilder).
  */
 export class ObjectValue {
-  private value: { mapValue: ProtoMapValue };
-
-  constructor(proto: { mapValue: ProtoMapValue }) {
+  constructor(private value: { mapValue: ProtoMapValue }) {
     debugAssert(
-      !isServerTimestamp(proto),
+      !isServerTimestamp(value),
       'ServerTimestamps should be converted to ServerTimestampValue'
     );
-    this.value = proto;
   }
 
   static empty(): ObjectValue {

--- a/packages/firestore/src/model/object_value.ts
+++ b/packages/firestore/src/model/object_value.ts
@@ -211,7 +211,7 @@ export class ObjectValue {
  */
 export function extractFieldMask(value: ProtoMapValue): FieldMask {
   const fields: FieldPath[] = [];
-  forEach(value!.fields || {}, (key, value) => {
+  forEach(value!.fields, (key, value) => {
     const currentPath = new FieldPath([key]);
     if (isMapValue(value)) {
       const nestedMask = extractFieldMask(value.mapValue!);

--- a/packages/firestore/src/model/object_value.ts
+++ b/packages/firestore/src/model/object_value.ts
@@ -22,11 +22,11 @@ import {
 } from '../protos/firestore_proto_api';
 import { debugAssert } from '../util/assert';
 import { forEach } from '../util/obj';
+
 import { FieldMask } from './field_mask';
 import { FieldPath } from './path';
 import { isServerTimestamp } from './server_timestamps';
 import { deepClone, isMapValue, valueEquals } from './values';
-import Value = firestoreV1ApiClientInterfaces.Value;
 
 export interface JsonObject<T> {
   [name: string]: T;

--- a/packages/firestore/src/model/object_value.ts
+++ b/packages/firestore/src/model/object_value.ts
@@ -16,7 +16,6 @@
  */
 
 import {
-  firestoreV1ApiClientInterfaces,
   MapValue as ProtoMapValue,
   Value as ProtoValue
 } from '../protos/firestore_proto_api';

--- a/packages/firestore/src/model/object_value.ts
+++ b/packages/firestore/src/model/object_value.ts
@@ -111,8 +111,8 @@ export class ObjectValue {
     data.forEach((value, path) => {
       if (!parent.isImmediateParentOf(path)) {
         // Insert the accumulated changes at this parent location
-        const parent_map = this.getParentMap(parent);
-        this.applyChanges(parent_map, upserts, deletes);
+        const parentMap = this.getParentMap(parent);
+        this.applyChanges(parentMap, upserts, deletes);
         upserts = {};
         deletes = [];
         parent = path.popLast();
@@ -160,22 +160,18 @@ export class ObjectValue {
     let parent = this.value;
 
     for (let i = 0; i < path.length; ++i) {
-      const currentSegment = path.get(i);
+      const segment = path.get(i);
 
       if (!parent.mapValue.fields) {
         parent.mapValue.fields = {};
       }
-      let currentValue = parent.mapValue.fields[currentSegment];
 
-      if (!currentValue || typeOrder(currentValue) !== TypeOrder.ObjectValue) {
-        // Since the element is not a map value, free all existing data and
+      if (!isMapValue(parent.mapValue.fields[segment])) {
+        // Since the element is not a map value, remove all existing data and
         // change it to a map type.
-        currentValue = { mapValue: {} };
-        parent.mapValue.fields[currentSegment] = currentValue;
+        parent.mapValue.fields[segment] = { mapValue: {} };
       }
-
-      parent.mapValue.fields[currentSegment] = currentValue;
-      parent = currentValue as { mapValue: ProtoMapValue };
+      parent = parent.mapValue.fields[segment] as { mapValue: ProtoMapValue };
     }
 
     return parent.mapValue;

--- a/packages/firestore/src/model/object_value.ts
+++ b/packages/firestore/src/model/object_value.ts
@@ -59,16 +59,12 @@ export class ObjectValue {
     } else {
       let currentLevel: ProtoValue = this.value;
       for (let i = 0; i < path.length - 1; ++i) {
-        if (!currentLevel.mapValue!.fields) {
-          return null;
-        }
-        currentLevel = currentLevel.mapValue!.fields[path.get(i)];
+        currentLevel = (currentLevel.mapValue!.fields || {})[path.get(i)];
         if (!isMapValue(currentLevel)) {
           return null;
         }
       }
-
-      currentLevel = (currentLevel.mapValue!.fields || {})[path.lastSegment()];
+      currentLevel = (currentLevel.mapValue!.fields! || {})[path.lastSegment()];
       return currentLevel || null;
     }
   }
@@ -153,8 +149,7 @@ export class ObjectValue {
     }
 
     for (let i = 0; i < path.length; ++i) {
-      let next =
-        current.mapValue!.fields && current.mapValue!.fields![path.get(i)];
+      let next = current.mapValue!.fields![path.get(i)];
       if (!isMapValue(next) || !next.mapValue.fields) {
         next = { mapValue: { fields: {} } };
         current.mapValue!.fields![path.get(i)] = next;

--- a/packages/firestore/src/model/object_value.ts
+++ b/packages/firestore/src/model/object_value.ts
@@ -80,7 +80,7 @@ export class ObjectValue {
       'Cannot set field for empty path on ObjectValue'
     );
     const fieldsMap = this.getFieldsMap(path.popLast());
-    fieldsMap[path.lastSegment()] = value;
+    fieldsMap[path.lastSegment()] = deepClone(value);
   }
 
   /**
@@ -105,7 +105,7 @@ export class ObjectValue {
       }
 
       if (value) {
-        upserts[path.lastSegment()] = value;
+        upserts[path.lastSegment()] = deepClone(value);
       } else {
         deletes.push(path.lastSegment());
       }

--- a/packages/firestore/src/model/object_value.ts
+++ b/packages/firestore/src/model/object_value.ts
@@ -160,7 +160,7 @@ export class ObjectValue {
   }
 
   /**
-   * Modifies `parent_map` by adding, replacing or deleting the specified
+   * Modifies `parentMap` by adding, replacing or deleting the specified
    * entries.
    */
   private applyChanges(

--- a/packages/firestore/src/model/object_value.ts
+++ b/packages/firestore/src/model/object_value.ts
@@ -160,7 +160,7 @@ export class ObjectValue {
   }
 
   /**
-   * Modifies `parentMap` by adding, replacing or deleting the specified
+   * Modifies `fieldsMap` by adding, replacing or deleting the specified
    * entries.
    */
   private applyChanges(

--- a/packages/firestore/src/model/values.ts
+++ b/packages/firestore/src/model/values.ts
@@ -479,7 +479,7 @@ export function estimateByteSize(value: Value): number {
 
 function estimateMapByteSize(mapValue: MapValue): number {
   let size = 0;
-  forEach(mapValue.fields || {}, (key, val) => {
+  forEach(mapValue.fields, (key, val) => {
     size += key.length + estimateByteSize(val);
   });
   return size;
@@ -564,7 +564,7 @@ export function deepClone(source: Value): Value {
   } else if (source.mapValue) {
     const target: Value = { mapValue: { fields: {} } };
     forEach(
-      source.mapValue.fields || {},
+      source.mapValue.fields,
       (key, val) => (target.mapValue!.fields![key] = deepClone(val))
     );
     return target;

--- a/packages/firestore/src/model/values.ts
+++ b/packages/firestore/src/model/values.ts
@@ -554,3 +554,27 @@ export function isMapValue(
 ): value is { mapValue: MapValue } {
   return !!value && 'mapValue' in value;
 }
+
+/** Creates a deep copy of `source`. */
+export function deepClone(source: Value): Value {
+  if (source.geoPointValue) {
+    return { geoPointValue: { ...source.geoPointValue } };
+  } else if (source.timestampValue) {
+    return { timestampValue: { ...normalizeTimestamp(source.timestampValue) } };
+  } else if (source.mapValue) {
+    const target: Value = { mapValue: { fields: {} } };
+    forEach(
+      source.mapValue.fields || {},
+      (key, val) => (target.mapValue!.fields![key] = deepClone(val))
+    );
+    return target;
+  } else if (source.arrayValue) {
+    const target: Value = { arrayValue: { values: [] } };
+    for (let i = 0; i < (source.arrayValue.values || []).length; ++i) {
+      target.arrayValue!.values![i] = deepClone(source.arrayValue.values![i]);
+    }
+    return target;
+  } else {
+    return { ...source };
+  }
+}

--- a/packages/firestore/src/remote/serializer.ts
+++ b/packages/firestore/src/remote/serializer.ts
@@ -379,7 +379,7 @@ export function toMutationDocument(
 ): ProtoDocument {
   return {
     name: toName(serializer, key),
-    fields: fields.toProto().mapValue.fields
+    fields: fields.value.mapValue.fields
   };
 }
 
@@ -393,7 +393,7 @@ export function toDocument(
   );
   return {
     name: toName(serializer, document.key),
-    fields: document.data.toProto().mapValue.fields,
+    fields: document.data.value.mapValue.fields,
     updateTime: toTimestamp(serializer, document.version.toTimestamp())
   };
 }

--- a/packages/firestore/src/util/obj.ts
+++ b/packages/firestore/src/util/obj.ts
@@ -32,7 +32,7 @@ export function objectSize(obj: object): number {
 }
 
 export function forEach<V>(
-  obj: Dict<V>,
+  obj: Dict<V> | undefined,
   fn: (key: string, val: V) => void
 ): void {
   for (const key in obj) {

--- a/packages/firestore/test/unit/model/document.test.ts
+++ b/packages/firestore/test/unit/model/document.test.ts
@@ -34,7 +34,7 @@ describe('Document', () => {
     const document = doc('rooms/Eros', 1, data);
 
     const value = document.data;
-    expect(value.toProto()).to.deep.equal(
+    expect(value.value).to.deep.equal(
       wrap({
         desc: 'Discuss all the project related stuff',
         owner: 'Jonny'

--- a/packages/firestore/test/unit/model/object_value.test.ts
+++ b/packages/firestore/test/unit/model/object_value.test.ts
@@ -170,7 +170,7 @@ describe('ObjectValue', () => {
       'map.nested.d',
       'emptymap'
     );
-    const actualMask = extractFieldMask(objValue.toProto().mapValue);
+    const actualMask = extractFieldMask(objValue.value.mapValue);
     expect(actualMask.isEqual(expectedMask)).to.be.true;
   });
 

--- a/packages/firestore/test/unit/remote/serializer.helper.ts
+++ b/packages/firestore/test/unit/remote/serializer.helper.ts
@@ -797,7 +797,7 @@ export function serializerTest(
       const d = doc('foo/bar', 42, { a: 5, b: 'b' });
       const proto = {
         name: toName(s, d.key),
-        fields: d.data.toProto().mapValue.fields,
+        fields: d.data.value.mapValue.fields,
         updateTime: toVersion(s, d.version)
       };
       const serialized = toDocument(s, d);

--- a/packages/firestore/test/unit/specs/bundle_spec.test.ts
+++ b/packages/firestore/test/unit/specs/bundle_spec.test.ts
@@ -22,8 +22,8 @@ import { LimitType } from '../../../src/protos/firestore_bundle_proto';
 import { toVersion } from '../../../src/remote/serializer';
 import {
   doc,
-  query,
   filter,
+  query,
   TestSnapshotVersion,
   version,
   wrapObject
@@ -76,7 +76,7 @@ function bundleWithDocumentAndQuery(
       testDoc.key,
       toVersion(JSON_SERIALIZER, version(testDoc.createTime)),
       toVersion(JSON_SERIALIZER, version(testDoc.updateTime!)),
-      wrapObject(testDoc.content!).toProto().mapValue.fields!
+      wrapObject(testDoc.content!).value.mapValue.fields!
     );
   }
   return builder.build(

--- a/packages/firestore/test/unit/specs/spec_builder.ts
+++ b/packages/firestore/test/unit/specs/spec_builder.ts
@@ -17,12 +17,12 @@
 
 import { UserDataWriter } from '../../../src/api/database';
 import {
+  hasLimitToFirst,
+  hasLimitToLast,
+  newQueryForPath,
   Query,
   queryEquals,
-  newQueryForPath,
-  queryToTarget,
-  hasLimitToLast,
-  hasLimitToFirst
+  queryToTarget
 } from '../../../src/core/query';
 import {
   canonifyTarget,
@@ -1044,7 +1044,7 @@ export class SpecBuilder {
         key: SpecBuilder.keyToSpec(doc.key),
         version: doc.version.toMicroseconds(),
         value: userDataWriter.convertValue(
-          doc.data.toProto()
+          doc.data.value
         ) as JsonObject<unknown>,
         options: {
           hasLocalMutations: doc.hasLocalMutations,

--- a/packages/firestore/test/util/spec_test_helpers.ts
+++ b/packages/firestore/test/util/spec_test_helpers.ts
@@ -56,7 +56,7 @@ export function encodeWatchChange(
         documentChange: {
           document: {
             name: toName(serializer, doc.key),
-            fields: doc?.data?.toProto().mapValue.fields,
+            fields: doc?.data.value.mapValue.fields,
             updateTime: toVersion(serializer, doc.version)
           },
           targetIds: watchChange.updatedTargetIds,


### PR DESCRIPTION
This is one of those "port of port" PRs. When I implemented iOS (https://github.com/firebase/firebase-ios-sdk/pull/8124) it became apparent that we do not need overlays anymore to implement mutable ObjectValues. There are only needed on Android, since Protobuf manipulations on Android are fairly expensive. On iOS and Web, we can directly edit the Protobuf object and can use a simpler version of ObjectValue.