### PR TITLE
Fix messaging delete bug

### DIFF
--- a/packages-exp/messaging-exp/src/messaging-service.ts
+++ b/packages-exp/messaging-exp/src/messaging-service.ts
@@ -27,7 +27,7 @@ import { extractAppConfig } from './helpers/extract-app-config';
 export class MessagingService implements _FirebaseService {
   readonly app!: FirebaseApp;
   readonly firebaseDependencies!: FirebaseInternalDependencies;
-  deleteService!: () => Promise<void>;
+  deleteService: () => Promise<void> = () => Promise.resolve();
 
   swRegistration?: ServiceWorkerRegistration;
   vapidKey?: string;

--- a/packages-exp/messaging-exp/src/messaging-service.ts
+++ b/packages-exp/messaging-exp/src/messaging-service.ts
@@ -27,7 +27,6 @@ import { extractAppConfig } from './helpers/extract-app-config';
 export class MessagingService implements _FirebaseService {
   readonly app!: FirebaseApp;
   readonly firebaseDependencies!: FirebaseInternalDependencies;
-  deleteService: () => Promise<void> = () => Promise.resolve();
 
   swRegistration?: ServiceWorkerRegistration;
   vapidKey?: string;
@@ -58,6 +57,6 @@ export class MessagingService implements _FirebaseService {
   }
 
   _delete(): Promise<void> {
-    return this.deleteService();
+    return Promise.resolve();
   }
 }


### PR DESCRIPTION
`deleteService()` wasn't populated with a value so when `_delete()` tries to call it, there's an error. I think this pattern was copied from functions-exp where the constructor assigns a value to `deleteService()`. But it never gets assigned here, so just inlining the Promise.resolve().