### PR TITLE
[Deprecated] Allows retrieval of `messageId` from `MessagePayload`

### DIFF
--- a/.changeset/bright-clouds-pretend.md
+++ b/.changeset/bright-clouds-pretend.md
@@ -1,0 +1,5 @@
+---
+'@firebase/messaging': minor
+---
+
+Allows retrieval of `messageId` from `MessagePayload`.

--- a/.changeset/quiet-moles-grab.md
+++ b/.changeset/quiet-moles-grab.md
@@ -1,0 +1,5 @@
+---
+'@firebase/messaging-exp': minor
+---
+
+Allows retrieval of `messageId` from `MessagePayload`.

--- a/common/api-review/messaging-exp.api.md
+++ b/common/api-review/messaging-exp.api.md
@@ -22,9 +22,6 @@ export interface FcmOptions {
 export interface FirebaseMessaging {
 }
 
-// @internal (undocumented)
-export type _FirebaseMessagingName = 'messaging';
-
 // @public
 export function getMessaging(app?: FirebaseApp): FirebaseMessaging;
 
@@ -48,6 +45,7 @@ export interface MessagePayload {
     };
     fcmOptions?: FcmOptions;
     from: string;
+    messageId: string;
     notification?: NotificationPayload;
 }
 

--- a/packages-exp/messaging-exp/src/helpers/externalizePayload.test.ts
+++ b/packages-exp/messaging-exp/src/helpers/externalizePayload.test.ts
@@ -30,13 +30,16 @@ describe('externalizePayload', () => {
       },
       from: 'from',
       // eslint-disable-next-line camelcase
-      collapse_key: 'collapse'
+      collapse_key: 'collapse',
+      // eslint-disable-next-line camelcase
+      exposed_message_id: 'mid'
     };
 
     const payload: MessagePayload = {
       notification: { title: 'title', body: 'body', image: 'image' },
       from: 'from',
-      collapseKey: 'collapse'
+      collapseKey: 'collapse',
+      messageId: 'mid'
     };
     expect(externalizePayload(internalPayload)).to.deep.equal(payload);
   });
@@ -50,13 +53,16 @@ describe('externalizePayload', () => {
       },
       from: 'from',
       // eslint-disable-next-line camelcase
-      collapse_key: 'collapse'
+      collapse_key: 'collapse',
+      // eslint-disable-next-line camelcase
+      exposed_message_id: 'mid'
     };
 
     const payload: MessagePayload = {
       data: { foo: 'foo', bar: 'bar', baz: 'baz' },
       from: 'from',
-      collapseKey: 'collapse'
+      collapseKey: 'collapse',
+      messageId: 'mid'
     };
     expect(externalizePayload(internalPayload)).to.deep.equal(payload);
   });
@@ -80,7 +86,9 @@ describe('externalizePayload', () => {
       },
       from: 'from',
       // eslint-disable-next-line camelcase
-      collapse_key: 'collapse'
+      collapse_key: 'collapse',
+      // eslint-disable-next-line camelcase
+      exposed_message_id: 'mid'
     };
 
     const payload: MessagePayload = {
@@ -99,7 +107,8 @@ describe('externalizePayload', () => {
         analyticsLabel: 'label'
       },
       from: 'from',
-      collapseKey: 'collapse'
+      collapseKey: 'collapse',
+      messageId: 'mid'
     };
     expect(externalizePayload(internalPayload)).to.deep.equal(payload);
   });

--- a/packages-exp/messaging-exp/src/helpers/externalizePayload.ts
+++ b/packages-exp/messaging-exp/src/helpers/externalizePayload.ts
@@ -24,7 +24,9 @@ export function externalizePayload(
   const payload: MessagePayload = {
     from: internalPayload.from,
     // eslint-disable-next-line camelcase
-    collapseKey: internalPayload.collapse_key
+    collapseKey: internalPayload.collapse_key,
+    // eslint-disable-next-line camelcase
+    messageId: internalPayload.exposed_message_id
   } as MessagePayload;
 
   propagateNotificationPayload(payload, internalPayload);

--- a/packages-exp/messaging-exp/src/interfaces/internal-message-payload.ts
+++ b/packages-exp/messaging-exp/src/interfaces/internal-message-payload.ts
@@ -29,6 +29,8 @@ export interface MessagePayloadInternal {
   from: string;
   // eslint-disable-next-line camelcase
   collapse_key: string;
+  // eslint-disable-next-line camelcase
+  exposed_message_id: string;
 }
 
 export interface NotificationPayloadInternal extends NotificationOptions {

--- a/packages-exp/messaging-exp/src/interfaces/public-types.ts
+++ b/packages-exp/messaging-exp/src/interfaces/public-types.ts
@@ -91,6 +91,11 @@ export interface MessagePayload {
    * {@link https://firebase.google.com/docs/cloud-messaging/concept-options#collapsible_and_non-collapsible_messages | Non-collapsible and collapsible messages}
    */
   collapseKey: string;
+
+  /**
+   * The message id of a message.
+   */
+  messageId: string;
 }
 
 /**

--- a/packages-exp/messaging-exp/src/listeners/sw-listeners.test.ts
+++ b/packages-exp/messaging-exp/src/listeners/sw-listeners.test.ts
@@ -74,7 +74,9 @@ const DISPLAY_MESSAGE: MessagePayloadInternal = {
   },
   from: 'from',
   // eslint-disable-next-line camelcase
-  collapse_key: 'collapse'
+  collapse_key: 'collapse',
+  // eslint-disable-next-line camelcase
+  exposed_message_id: 'mid'
 };
 
 describe('SwController', () => {

--- a/packages/messaging-types/index.d.ts
+++ b/packages/messaging-types/index.d.ts
@@ -44,6 +44,7 @@ export interface MessagePayload {
   fcmOptions?: FcmOptions;
   from: string;
   collapseKey: string;
+  messageId: string;
 }
 
 export interface FirebaseMessaging {

--- a/packages/messaging/src/controllers/sw-controller.test.ts
+++ b/packages/messaging/src/controllers/sw-controller.test.ts
@@ -67,7 +67,9 @@ const DISPLAY_MESSAGE: MessagePayloadInternal = {
   },
   from: 'from',
   // eslint-disable-next-line camelcase
-  collapse_key: 'collapse'
+  collapse_key: 'collapse',
+  // eslint-disable-next-line camelcase
+  exposed_message_id: 'mid'
 };
 
 // internal message payload (parsed directly from the push event) that contains and only contains
@@ -78,7 +80,9 @@ const DATA_MESSAGE: MessagePayloadInternal = {
   },
   from: 'from',
   // eslint-disable-next-line camelcase
-  collapse_key: 'collapse'
+  collapse_key: 'collapse',
+  // eslint-disable-next-line camelcase
+  exposed_message_id: 'mid'
 };
 
 describe('SwController', () => {

--- a/packages/messaging/src/controllers/window-controller.test.ts
+++ b/packages/messaging/src/controllers/window-controller.test.ts
@@ -55,7 +55,9 @@ describe('WindowController', () => {
   let getTokenStub: Stub<typeof tokenManagementModule.getToken>;
   let deleteTokenStub: Stub<typeof tokenManagementModule.deleteToken>;
   let registerStub: Stub<typeof navigator.serviceWorker.register>;
-  let addEventListenerStub: Stub<typeof navigator.serviceWorker.addEventListener>;
+  let addEventListenerStub: Stub<
+    typeof navigator.serviceWorker.addEventListener
+  >;
 
   /** The event listener that WindowController adds to the message event. */
   let messageEventListener: MessageEventListener;
@@ -380,7 +382,9 @@ describe('WindowController', () => {
         isFirebaseMessaging: true,
         from: 'from',
         // eslint-disable-next-line camelcase
-        collapse_key: 'collapse'
+        collapse_key: 'collapse',
+        // eslint-disable-next-line camelcase
+        exposed_message_id: 'mid'
       };
 
       await messageEventListener(
@@ -404,7 +408,9 @@ describe('WindowController', () => {
         isFirebaseMessaging: true,
         from: 'from',
         // eslint-disable-next-line camelcase
-        collapse_key: 'collapse'
+        collapse_key: 'collapse',
+        // eslint-disable-next-line camelcase
+        exposed_message_id: 'mid'
       };
 
       await messageEventListener(
@@ -425,7 +431,9 @@ describe('WindowController', () => {
         isFirebaseMessaging: true,
         from: 'from',
         // eslint-disable-next-line camelcase
-        collapse_key: 'collapse'
+        collapse_key: 'collapse',
+        // eslint-disable-next-line camelcase
+        exposed_message_id: 'mid'
       };
 
       await messageEventListener(
@@ -519,7 +527,9 @@ describe('WindowController', () => {
         isFirebaseMessaging: true,
         from: 'from',
         // eslint-disable-next-line camelcase
-        collapse_key: 'collapse'
+        collapse_key: 'collapse',
+        // eslint-disable-next-line camelcase
+        exposed_message_id: 'mid'
       };
 
       await messageEventListener(
@@ -530,7 +540,9 @@ describe('WindowController', () => {
         notification: { title: 'hello', body: 'world' },
         from: 'from',
         // eslint-disable-next-line camelcase
-        collapse_key: 'collapse'
+        collapse_key: 'collapse',
+        // eslint-disable-next-line camelcase
+        exposed_message_id: 'mid'
       });
       expect(logEventSpy).not.to.have.been.called;
     });
@@ -542,7 +554,9 @@ describe('WindowController', () => {
         isFirebaseMessaging: true,
         from: 'from',
         // eslint-disable-next-line camelcase
-        collapse_key: 'collapse'
+        collapse_key: 'collapse',
+        // eslint-disable-next-line camelcase
+        exposed_message_id: 'mid'
       };
 
       await messageEventListener(
@@ -566,7 +580,9 @@ describe('WindowController', () => {
         isFirebaseMessaging: true,
         from: 'from',
         // eslint-disable-next-line camelcase
-        collapse_key: 'collapse'
+        collapse_key: 'collapse',
+        // eslint-disable-next-line camelcase
+        exposed_message_id: 'mid'
       };
 
       await messageEventListener(
@@ -583,7 +599,9 @@ describe('WindowController', () => {
         },
         from: 'from',
         // eslint-disable-next-line camelcase
-        collapse_key: 'collapse'
+        collapse_key: 'collapse',
+        // eslint-disable-next-line camelcase
+        exposed_message_id: 'mid'
       });
       expect(logEventSpy).to.have.been.calledOnceWith(
         'notification_foreground',
@@ -611,7 +629,9 @@ describe('WindowController', () => {
         isFirebaseMessaging: true,
         from: 'from',
         // eslint-disable-next-line camelcase
-        collapse_key: 'collapse'
+        collapse_key: 'collapse',
+        // eslint-disable-next-line camelcase
+        exposed_message_id: 'mid'
       };
 
       await messageEventListener(

--- a/packages/messaging/src/helpers/externalizePayload.test.ts
+++ b/packages/messaging/src/helpers/externalizePayload.test.ts
@@ -30,15 +30,18 @@ describe('externalizePayload', () => {
       },
       from: 'from',
       // eslint-disable-next-line camelcase
-      collapse_key: 'collapse'
+      collapse_key: 'collapse',
+      // eslint-disable-next-line camelcase
+      exposed_message_id: 'mid'
     };
 
-    const payload: MessagePayload = {
+    const expected: MessagePayload = {
       notification: { title: 'title', body: 'body', image: 'image' },
       from: 'from',
-      collapseKey: 'collapse'
+      collapseKey: 'collapse',
+      messageId: 'mid'
     };
-    expect(externalizePayload(internalPayload)).to.deep.equal(payload);
+    expect(externalizePayload(internalPayload)).to.deep.equal(expected);
   });
 
   it('externalizes internalMessage with only data payload', () => {
@@ -50,15 +53,18 @@ describe('externalizePayload', () => {
       },
       from: 'from',
       // eslint-disable-next-line camelcase
-      collapse_key: 'collapse'
+      collapse_key: 'collapse',
+      // eslint-disable-next-line camelcase
+      exposed_message_id: 'mid'
     };
 
-    const payload: MessagePayload = {
+    const expected: MessagePayload = {
       data: { foo: 'foo', bar: 'bar', baz: 'baz' },
       from: 'from',
-      collapseKey: 'collapse'
+      collapseKey: 'collapse',
+      messageId: 'mid'
     };
-    expect(externalizePayload(internalPayload)).to.deep.equal(payload);
+    expect(externalizePayload(internalPayload)).to.deep.equal(expected);
   });
 
   it('externalizes internalMessage with all three payloads', () => {
@@ -80,10 +86,12 @@ describe('externalizePayload', () => {
       },
       from: 'from',
       // eslint-disable-next-line camelcase
-      collapse_key: 'collapse'
+      collapse_key: 'collapse',
+      // eslint-disable-next-line camelcase
+      exposed_message_id: 'mid'
     };
 
-    const payload: MessagePayload = {
+    const expected: MessagePayload = {
       notification: {
         title: 'title',
         body: 'body',
@@ -99,8 +107,9 @@ describe('externalizePayload', () => {
         analyticsLabel: 'label'
       },
       from: 'from',
-      collapseKey: 'collapse'
+      collapseKey: 'collapse',
+      messageId: 'mid'
     };
-    expect(externalizePayload(internalPayload)).to.deep.equal(payload);
+    expect(externalizePayload(internalPayload)).to.deep.equal(expected);
   });
 });

--- a/packages/messaging/src/helpers/externalizePayload.ts
+++ b/packages/messaging/src/helpers/externalizePayload.ts
@@ -24,7 +24,9 @@ export function externalizePayload(
   const payload: MessagePayload = {
     from: internalPayload.from,
     // eslint-disable-next-line camelcase
-    collapseKey: internalPayload.collapse_key
+    collapseKey: internalPayload.collapse_key,
+    // eslint-disable-next-line camelcase
+    messageId: internalPayload.exposed_message_id
   } as MessagePayload;
 
   propagateNotificationPayload(payload, internalPayload);

--- a/packages/messaging/src/interfaces/internal-message-payload.ts
+++ b/packages/messaging/src/interfaces/internal-message-payload.ts
@@ -29,6 +29,8 @@ export interface MessagePayloadInternal {
   from: string;
   // eslint-disable-next-line camelcase
   collapse_key: string;
+  // eslint-disable-next-line camelcase
+  exposed_message_id: string;
 }
 
 export interface NotificationPayloadInternal extends NotificationOptions {

--- a/packages/messaging/src/testing/fakes/service-worker.ts
+++ b/packages/messaging/src/testing/fakes/service-worker.ts
@@ -18,7 +18,7 @@
 import { Writable } from 'ts-essentials';
 
 // Add fake SW types.
-declare const self: Window & Writable<ServiceWorkerGlobalScope>;
+declare const self: Window & Writable<ServiceWorkerGlobalScopeForTesting>;
 
 // When trying to stub self.clients self.registration, Sinon complains that these properties do not
 // exist. This is because we're not actually running these tests in a service worker context.

--- a/packages/messaging/src/util/sw-types.ts
+++ b/packages/messaging/src/util/sw-types.ts
@@ -42,6 +42,23 @@ interface ServiceWorkerGlobalScope {
   ): void;
 }
 
+// Only makes `clients` and `registration` optional because in tests, we reset them by calling
+// `delete` and TS2790 enforces The operand of a `delete'` operator must be optional.
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+interface ServiceWorkerGlobalScopeForTesting {
+  readonly location: WorkerLocation;
+  readonly clients?: Clients;
+  readonly registration?: ServiceWorkerRegistration;
+  addEventListener<K extends keyof ServiceWorkerGlobalScopeEventMap>(
+    type: K,
+    listener: (
+      this: ServiceWorkerGlobalScope,
+      ev: ServiceWorkerGlobalScopeEventMap[K]
+    ) => any,
+    options?: boolean | AddEventListenerOptions
+  ): void;
+}
+
 // Same as the previous interface
 interface ServiceWorkerGlobalScopeEventMap {
   notificationclick: NotificationEvent;


### PR DESCRIPTION
Exposes the `messageId` to developers. This message id has the same value as the one returned from the send request. 

Developers now have a way to monitor message delivery status on individual message.  Submit  after cl/378075755  is rolled out.

links: 
- b/174697445
- go/fm-js-sdk-mid-and-beyond