### PR TITLE
Remove all public const enums; export maps instead (with typings to strings)

### DIFF
--- a/common/api-review/auth-exp.api.md
+++ b/common/api-review/auth-exp.api.md
@@ -25,12 +25,12 @@ export interface ActionCodeInfo {
 
 // @public
 export const ActionCodeOperation: {
-    EMAIL_SIGNIN: string;
-    PASSWORD_RESET: string;
-    RECOVER_EMAIL: string;
-    REVERT_SECOND_FACTOR_ADDITION: string;
-    VERIFY_AND_CHANGE_EMAIL: string;
-    VERIFY_EMAIL: string;
+    readonly EMAIL_SIGNIN: "EMAIL_SIGNIN";
+    readonly PASSWORD_RESET: "PASSWORD_RESET";
+    readonly RECOVER_EMAIL: "RECOVER_EMAIL";
+    readonly REVERT_SECOND_FACTOR_ADDITION: "REVERT_SECOND_FACTOR_ADDITION";
+    readonly VERIFY_AND_CHANGE_EMAIL: "VERIFY_AND_CHANGE_EMAIL";
+    readonly VERIFY_EMAIL: "VERIFY_EMAIL";
 };
 
 // @public
@@ -240,7 +240,7 @@ export class FacebookAuthProvider extends BaseOAuthProvider {
 
 // @public
 export const FactorId: {
-    PHONE: string;
+    readonly PHONE: "phone";
 };
 
 // @public
@@ -406,9 +406,9 @@ export function onIdTokenChanged(auth: Auth, nextOrObserver: NextOrObserver<User
 
 // @public
 export const OperationType: {
-    LINK: string;
-    REAUTHENTICATE: string;
-    SIGN_IN: string;
+    readonly LINK: "link";
+    readonly REAUTHENTICATE: "reauthenticate";
+    readonly SIGN_IN: "signIn";
 };
 
 // @public
@@ -503,12 +503,12 @@ export const prodErrorMap: AuthErrorMap;
 
 // @public
 export const ProviderId: {
-    FACEBOOK: string;
-    GITHUB: string;
-    GOOGLE: string;
-    PASSWORD: string;
-    PHONE: string;
-    TWITTER: string;
+    readonly FACEBOOK: "facebook.com";
+    readonly GITHUB: "github.com";
+    readonly GOOGLE: "google.com";
+    readonly PASSWORD: "password";
+    readonly PHONE: "phone";
+    readonly TWITTER: "twitter.com";
 };
 
 // @public
@@ -578,13 +578,13 @@ export function signInAnonymously(auth: Auth): Promise<UserCredential>;
 
 // @public
 export const SignInMethod: {
-    EMAIL_LINK: string;
-    EMAIL_PASSWORD: string;
-    FACEBOOK: string;
-    GITHUB: string;
-    GOOGLE: string;
-    PHONE: string;
-    TWITTER: string;
+    readonly EMAIL_LINK: "emailLink";
+    readonly EMAIL_PASSWORD: "password";
+    readonly FACEBOOK: "facebook.com";
+    readonly GITHUB: "github.com";
+    readonly GOOGLE: "google.com";
+    readonly PHONE: "phone";
+    readonly TWITTER: "twitter.com";
 };
 
 // @public

--- a/common/api-review/auth-exp.api.md
+++ b/common/api-review/auth-exp.api.md
@@ -503,10 +503,7 @@ export const prodErrorMap: AuthErrorMap;
 
 // @public
 export const ProviderId: {
-    ANONYMOUS: string;
-    CUSTOM: string;
     FACEBOOK: string;
-    FIREBASE: string;
     GITHUB: string;
     GOOGLE: string;
     PASSWORD: string;
@@ -581,7 +578,6 @@ export function signInAnonymously(auth: Auth): Promise<UserCredential>;
 
 // @public
 export const SignInMethod: {
-    ANONYMOUS: string;
     EMAIL_LINK: string;
     EMAIL_PASSWORD: string;
     FACEBOOK: string;

--- a/common/api-review/auth-exp.api.md
+++ b/common/api-review/auth-exp.api.md
@@ -20,7 +20,7 @@ export interface ActionCodeInfo {
         multiFactorInfo?: MultiFactorInfo | null;
         previousEmail?: string | null;
     };
-    operation: string;
+    operation: typeof ActionCodeOperation[keyof typeof ActionCodeOperation];
 }
 
 // @public
@@ -324,19 +324,19 @@ export function multiFactor(user: User): MultiFactorUser;
 
 // @public
 export interface MultiFactorAssertion {
-    readonly factorId: string;
+    readonly factorId: typeof FactorId[keyof typeof FactorId];
 }
 
 // @public
 export interface MultiFactorError extends AuthError {
-    readonly operationType: string;
+    readonly operationType: typeof OperationType[keyof typeof OperationType];
 }
 
 // @public
 export interface MultiFactorInfo {
     readonly displayName?: string | null;
     readonly enrollmentTime: string;
-    readonly factorId: string;
+    readonly factorId: typeof FactorId[keyof typeof FactorId];
     readonly uid: string;
 }
 
@@ -669,7 +669,7 @@ export interface User extends UserInfo {
 
 // @public
 export interface UserCredential {
-    operationType: string;
+    operationType: typeof OperationType[keyof typeof OperationType];
     providerId: string | null;
     user: User;
 }

--- a/common/api-review/auth-exp.api.md
+++ b/common/api-review/auth-exp.api.md
@@ -20,18 +20,18 @@ export interface ActionCodeInfo {
         multiFactorInfo?: MultiFactorInfo | null;
         previousEmail?: string | null;
     };
-    operation: ActionCodeOperation;
+    operation: string;
 }
 
 // @public
-export const enum ActionCodeOperation {
-    EMAIL_SIGNIN = "EMAIL_SIGNIN",
-    PASSWORD_RESET = "PASSWORD_RESET",
-    RECOVER_EMAIL = "RECOVER_EMAIL",
-    REVERT_SECOND_FACTOR_ADDITION = "REVERT_SECOND_FACTOR_ADDITION",
-    VERIFY_AND_CHANGE_EMAIL = "VERIFY_AND_CHANGE_EMAIL",
-    VERIFY_EMAIL = "VERIFY_EMAIL"
-}
+export const ActionCodeOperation: {
+    EMAIL_SIGNIN: string;
+    PASSWORD_RESET: string;
+    RECOVER_EMAIL: string;
+    REVERT_SECOND_FACTOR_ADDITION: string;
+    VERIFY_AND_CHANGE_EMAIL: string;
+    VERIFY_EMAIL: string;
+};
 
 // @public
 export interface ActionCodeSettings {
@@ -56,7 +56,7 @@ export class ActionCodeURL {
     readonly code: string;
     readonly continueUrl: string | null;
     readonly languageCode: string | null;
-    readonly operation: ActionCodeOperation;
+    readonly operation: string;
     static parseLink(link: string): ActionCodeURL | null;
     readonly tenantId: string | null;
 }
@@ -239,9 +239,9 @@ export class FacebookAuthProvider extends BaseOAuthProvider {
 }
 
 // @public
-export const enum FactorId {
-    PHONE = "phone"
-}
+export const FactorId: {
+    PHONE: string;
+};
 
 // @public
 export function fetchSignInMethodsForEmail(auth: Auth, email: string): Promise<string[]>;
@@ -324,19 +324,19 @@ export function multiFactor(user: User): MultiFactorUser;
 
 // @public
 export interface MultiFactorAssertion {
-    readonly factorId: FactorId;
+    readonly factorId: string;
 }
 
 // @public
 export interface MultiFactorError extends AuthError {
-    readonly operationType: OperationType;
+    readonly operationType: string;
 }
 
 // @public
 export interface MultiFactorInfo {
     readonly displayName?: string | null;
     readonly enrollmentTime: string;
-    readonly factorId: FactorId;
+    readonly factorId: string;
     readonly uid: string;
 }
 
@@ -405,11 +405,11 @@ export function onAuthStateChanged(auth: Auth, nextOrObserver: NextOrObserver<Us
 export function onIdTokenChanged(auth: Auth, nextOrObserver: NextOrObserver<User>, error?: ErrorFn, completed?: CompleteFn): Unsubscribe;
 
 // @public
-export const enum OperationType {
-    LINK = "link",
-    REAUTHENTICATE = "reauthenticate",
-    SIGN_IN = "signIn"
-}
+export const OperationType: {
+    LINK: string;
+    REAUTHENTICATE: string;
+    SIGN_IN: string;
+};
 
 // @public
 export function parseActionCodeURL(link: string): ActionCodeURL | null;
@@ -502,20 +502,17 @@ export interface PopupRedirectResolver {
 export const prodErrorMap: AuthErrorMap;
 
 // @public
-export const enum ProviderId {
-    // @internal (undocumented)
-    ANONYMOUS = "anonymous",
-    // @internal (undocumented)
-    CUSTOM = "custom",
-    FACEBOOK = "facebook.com",
-    // @internal (undocumented)
-    FIREBASE = "firebase",
-    GITHUB = "github.com",
-    GOOGLE = "google.com",
-    PASSWORD = "password",
-    PHONE = "phone",
-    TWITTER = "twitter.com"
-}
+export const ProviderId: {
+    ANONYMOUS: string;
+    CUSTOM: string;
+    FACEBOOK: string;
+    FIREBASE: string;
+    GITHUB: string;
+    GOOGLE: string;
+    PASSWORD: string;
+    PHONE: string;
+    TWITTER: string;
+};
 
 // @public
 export interface ReactNativeAsyncStorage {
@@ -583,17 +580,16 @@ export function setPersistence(auth: Auth, persistence: Persistence): Promise<vo
 export function signInAnonymously(auth: Auth): Promise<UserCredential>;
 
 // @public
-export const enum SignInMethod {
-    // @internal (undocumented)
-    ANONYMOUS = "anonymous",
-    EMAIL_LINK = "emailLink",
-    EMAIL_PASSWORD = "password",
-    FACEBOOK = "facebook.com",
-    GITHUB = "github.com",
-    GOOGLE = "google.com",
-    PHONE = "phone",
-    TWITTER = "twitter.com"
-}
+export const SignInMethod: {
+    ANONYMOUS: string;
+    EMAIL_LINK: string;
+    EMAIL_PASSWORD: string;
+    FACEBOOK: string;
+    GITHUB: string;
+    GOOGLE: string;
+    PHONE: string;
+    TWITTER: string;
+};
 
 // @public
 export function signInWithCredential(auth: Auth, credential: AuthCredential): Promise<UserCredential>;
@@ -630,7 +626,7 @@ export class TwitterAuthProvider extends BaseOAuthProvider {
 }
 
 // @public
-export function unlink(user: User, providerId: ProviderId): Promise<User>;
+export function unlink(user: User, providerId: string): Promise<User>;
 
 export { Unsubscribe }
 
@@ -677,7 +673,7 @@ export interface User extends UserInfo {
 
 // @public
 export interface UserCredential {
-    operationType: OperationType;
+    operationType: string;
     providerId: string | null;
     user: User;
 }

--- a/packages-exp/auth-compat-exp/src/user.ts
+++ b/packages-exp/auth-compat-exp/src/user.ts
@@ -158,7 +158,7 @@ export class User implements compat.User, Compat<exp.User> {
     return exp.sendEmailVerification(this._delegate, actionCodeSettings);
   }
   async unlink(providerId: string): Promise<compat.User> {
-    await exp.unlink(this._delegate, providerId as exp.ProviderId);
+    await exp.unlink(this._delegate, providerId);
     return this;
   }
   updateEmail(newEmail: string): Promise<void> {

--- a/packages-exp/auth-exp/index.node.ts
+++ b/packages-exp/auth-exp/index.node.ts
@@ -41,6 +41,7 @@ FetchProvider.initialize(
 
 // Core functionality shared by all clients
 export * from './src';
+export { FactorId, ProviderId, SignInMethod, OperationType, ActionCodeOperation } from './src/model/enum_maps';
 
 export function getAuth(app: FirebaseApp): Auth {
   const provider = _getProvider(app, 'auth-exp');

--- a/packages-exp/auth-exp/index.node.ts
+++ b/packages-exp/auth-exp/index.node.ts
@@ -41,7 +41,13 @@ FetchProvider.initialize(
 
 // Core functionality shared by all clients
 export * from './src';
-export { FactorId, ProviderId, SignInMethod, OperationType, ActionCodeOperation } from './src/model/enum_maps';
+export {
+  FactorId,
+  ProviderId,
+  SignInMethod,
+  OperationType,
+  ActionCodeOperation
+} from './src/model/enum_maps';
 
 export function getAuth(app: FirebaseApp): Auth {
   const provider = _getProvider(app, 'auth-exp');

--- a/packages-exp/auth-exp/index.ts
+++ b/packages-exp/auth-exp/index.ts
@@ -74,7 +74,13 @@ export {
 } from './src/model/public_types';
 
 // Helper maps (not used internally)
-export { FactorId, ProviderId, SignInMethod, OperationType, ActionCodeOperation } from './src/model/enum_maps';
+export {
+  FactorId,
+  ProviderId,
+  SignInMethod,
+  OperationType,
+  ActionCodeOperation
+} from './src/model/enum_maps';
 
 // Core functionality shared by all clients
 export * from './src';

--- a/packages-exp/auth-exp/index.ts
+++ b/packages-exp/auth-exp/index.ts
@@ -33,12 +33,6 @@ import { Auth } from './src/model/public_types';
 
 // Public types
 export {
-  // Enums
-  ActionCodeOperation,
-  FactorId,
-  OperationType,
-  ProviderId,
-  SignInMethod,
   // Interfaces
   ActionCodeInfo,
   ActionCodeSettings,
@@ -78,6 +72,9 @@ export {
   CompleteFn,
   Unsubscribe
 } from './src/model/public_types';
+
+// Helper maps (not used internally)
+export { FactorId, ProviderId, SignInMethod, OperationType, ActionCodeOperation } from './src/model/enum_maps';
 
 // Core functionality shared by all clients
 export * from './src';

--- a/packages-exp/auth-exp/src/core/action_code_url.ts
+++ b/packages-exp/auth-exp/src/core/action_code_url.ts
@@ -107,7 +107,7 @@ export class ActionCodeURL {
    * The action performed by the email action link. It returns from one of the types from
    * {@link ActionCodeInfo}
    */
-  readonly operation: ActionCodeOperation;
+  readonly operation: string;
   /**
    * The tenant ID of the email action link. Null if the email action is from the parent project.
    */

--- a/packages-exp/auth-exp/src/core/user/link_unlink.ts
+++ b/packages-exp/auth-exp/src/core/user/link_unlink.ts
@@ -36,10 +36,7 @@ import { getModularInstance } from '@firebase/util';
  *
  * @public
  */
-export async function unlink(
-  user: User,
-  providerId: string
-): Promise<User> {
+export async function unlink(user: User, providerId: string): Promise<User> {
   const userInternal = getModularInstance(user) as UserInternal;
   await _assertLinkedStatus(true, userInternal, providerId);
   const { providerUserInfo } = await deleteLinkedAccounts(userInternal.auth, {

--- a/packages-exp/auth-exp/src/core/user/link_unlink.ts
+++ b/packages-exp/auth-exp/src/core/user/link_unlink.ts
@@ -38,7 +38,7 @@ import { getModularInstance } from '@firebase/util';
  */
 export async function unlink(
   user: User,
-  providerId: ProviderId
+  providerId: string
 ): Promise<User> {
   const userInternal = getModularInstance(user) as UserInternal;
   await _assertLinkedStatus(true, userInternal, providerId);

--- a/packages-exp/auth-exp/src/model/enum_maps.ts
+++ b/packages-exp/auth-exp/src/model/enum_maps.ts
@@ -23,7 +23,7 @@
 export const FactorId = {
   /** Phone as second factor */
   PHONE: 'phone'
-};
+} as const;
 
 /**
  * Enumeration of supported providers.
@@ -43,7 +43,7 @@ export const ProviderId = {
   PHONE: 'phone',
   /** Twitter provider ID */
   TWITTER: 'twitter.com'
-};
+} as const;
 
 /**
  * Enumeration of supported sign-in methods.
@@ -65,7 +65,7 @@ export const SignInMethod = {
   PHONE: 'phone',
   /** Twitter sign in method */
   TWITTER: 'twitter.com'
-};
+} as const;
 
 /**
  * Enumeration of supported operation types.
@@ -79,7 +79,7 @@ export const OperationType = {
   REAUTHENTICATE: 'reauthenticate',
   /** Operation involving signing in a user. */
   SIGN_IN: 'signIn'
-};
+} as const;
 
 /**
  * An enumeration of the possible email action types.
@@ -99,4 +99,4 @@ export const ActionCodeOperation = {
   VERIFY_AND_CHANGE_EMAIL: 'VERIFY_AND_CHANGE_EMAIL',
   /** The email verification action. */
   VERIFY_EMAIL: 'VERIFY_EMAIL'
-};
+} as const;

--- a/packages-exp/auth-exp/src/model/enum_maps.ts
+++ b/packages-exp/auth-exp/src/model/enum_maps.ts
@@ -31,14 +31,8 @@ export const FactorId = {
  * @public
  */
 export const ProviderId = {
-  /** @internal */
-  ANONYMOUS: 'anonymous',
-  /** @internal */
-  CUSTOM: 'custom',
   /** Facebook provider ID */
   FACEBOOK: 'facebook.com',
-  /** @internal */
-  FIREBASE: 'firebase',
   /** GitHub provider ID */
   GITHUB: 'github.com',
   /** Google provider ID */
@@ -57,8 +51,6 @@ export const ProviderId = {
  * @public
  */
 export const SignInMethod = {
-  /** @internal */
-  ANONYMOUS: 'anonymous',
   /** Email link sign in method */
   EMAIL_LINK: 'emailLink',
   /** Email/password sign in method */

--- a/packages-exp/auth-exp/src/model/enum_maps.ts
+++ b/packages-exp/auth-exp/src/model/enum_maps.ts
@@ -1,0 +1,95 @@
+/**
+ * An enum of factors that may be used for multifactor authentication.
+ *
+ * @public
+ */
+ export const FactorId = {
+  /** Phone as second factor */
+  PHONE: 'phone'
+};
+
+/**
+ * Enumeration of supported providers.
+ *
+ * @public
+ */
+ export const ProviderId = {
+  /** @internal */
+  ANONYMOUS: 'anonymous',
+  /** @internal */
+  CUSTOM: 'custom',
+  /** Facebook provider ID */
+  FACEBOOK: 'facebook.com',
+  /** @internal */
+  FIREBASE: 'firebase',
+  /** GitHub provider ID */
+  GITHUB: 'github.com',
+  /** Google provider ID */
+  GOOGLE: 'google.com',
+  /** Password provider */
+  PASSWORD: 'password',
+  /** Phone provider */
+  PHONE: 'phone',
+  /** Twitter provider ID */
+  TWITTER: 'twitter.com'
+};
+
+
+/**
+ * Enumeration of supported sign-in methods.
+ *
+ * @public
+ */
+ export const SignInMethod = {
+  /** @internal */
+  ANONYMOUS: 'anonymous',
+  /** Email link sign in method */
+  EMAIL_LINK: 'emailLink',
+  /** Email/password sign in method */
+  EMAIL_PASSWORD: 'password',
+  /** Facebook sign in method */
+  FACEBOOK: 'facebook.com',
+  /** GitHub sign in method */
+  GITHUB: 'github.com',
+  /** Google sign in method */
+  GOOGLE: 'google.com',
+  /** Phone sign in method */
+  PHONE: 'phone',
+  /** Twitter sign in method */
+  TWITTER: 'twitter.com'
+};
+
+/**
+ * Enumeration of supported operation types.
+ *
+ * @public
+ */
+ export const OperationType = {
+  /** Operation involving linking an additional provider to an already signed-in user. */
+  LINK: 'link',
+  /** Operation involving using a provider to reauthenticate an already signed-in user. */
+  REAUTHENTICATE: 'reauthenticate',
+  /** Operation involving signing in a user. */
+  SIGN_IN: 'signIn'
+};
+
+
+/**
+ * An enumeration of the possible email action types.
+ *
+ * @public
+ */
+ export const ActionCodeOperation = {
+  /** The email link sign-in action. */
+  EMAIL_SIGNIN: 'EMAIL_SIGNIN',
+  /** The password reset action. */
+  PASSWORD_RESET: 'PASSWORD_RESET',
+  /** The email revocation action. */
+  RECOVER_EMAIL: 'RECOVER_EMAIL',
+  /** The revert second factor addition email action. */
+  REVERT_SECOND_FACTOR_ADDITION: 'REVERT_SECOND_FACTOR_ADDITION',
+  /** The revert second factor addition email action. */
+  VERIFY_AND_CHANGE_EMAIL: 'VERIFY_AND_CHANGE_EMAIL',
+  /** The email verification action. */
+  VERIFY_EMAIL: 'VERIFY_EMAIL'
+};

--- a/packages-exp/auth-exp/src/model/enum_maps.ts
+++ b/packages-exp/auth-exp/src/model/enum_maps.ts
@@ -1,9 +1,26 @@
 /**
+ * @license
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
  * An enum of factors that may be used for multifactor authentication.
  *
  * @public
  */
- export const FactorId = {
+export const FactorId = {
   /** Phone as second factor */
   PHONE: 'phone'
 };
@@ -13,7 +30,7 @@
  *
  * @public
  */
- export const ProviderId = {
+export const ProviderId = {
   /** @internal */
   ANONYMOUS: 'anonymous',
   /** @internal */
@@ -34,13 +51,12 @@
   TWITTER: 'twitter.com'
 };
 
-
 /**
  * Enumeration of supported sign-in methods.
  *
  * @public
  */
- export const SignInMethod = {
+export const SignInMethod = {
   /** @internal */
   ANONYMOUS: 'anonymous',
   /** Email link sign in method */
@@ -64,7 +80,7 @@
  *
  * @public
  */
- export const OperationType = {
+export const OperationType = {
   /** Operation involving linking an additional provider to an already signed-in user. */
   LINK: 'link',
   /** Operation involving using a provider to reauthenticate an already signed-in user. */
@@ -73,13 +89,12 @@
   SIGN_IN: 'signIn'
 };
 
-
 /**
  * An enumeration of the possible email action types.
  *
  * @public
  */
- export const ActionCodeOperation = {
+export const ActionCodeOperation = {
   /** The email link sign-in action. */
   EMAIL_SIGNIN: 'EMAIL_SIGNIN',
   /** The password reset action. */

--- a/packages-exp/auth-exp/src/model/public_types.ts
+++ b/packages-exp/auth-exp/src/model/public_types.ts
@@ -24,6 +24,12 @@ import {
   Unsubscribe
 } from '@firebase/util';
 
+import {
+  FactorId as FactorIdMap,
+  OperationType as OperationTypeMap,
+  ActionCodeOperation as ActionCodeOperationMap,
+} from './enum_maps';
+
 export { CompleteFn, ErrorFn, NextFn, Unsubscribe };
 /**
  * Enumeration of supported providers.
@@ -431,7 +437,7 @@ export interface ActionCodeInfo {
   /**
    * The type of operation that generated the action code.
    */
-  operation: string;
+  operation: typeof ActionCodeOperationMap[keyof typeof ActionCodeOperationMap];
 }
 
 /**
@@ -603,7 +609,7 @@ export interface ConfirmationResult {
  */
 export interface MultiFactorAssertion {
   /** The identifier of the second factor. */
-  readonly factorId: string;
+  readonly factorId: typeof FactorIdMap[keyof typeof FactorIdMap];
 }
 
 /**
@@ -641,7 +647,7 @@ export interface MultiFactorError extends AuthError {
   /**
    * The type of operation (e.g., sign-in, link, or reauthenticate) during which the error was raised.
    */
-  readonly operationType: string;
+   readonly operationType: typeof OperationTypeMap[keyof typeof OperationTypeMap];
 }
 
 /**
@@ -657,7 +663,7 @@ export interface MultiFactorInfo {
   /** The enrollment date of the second factor formatted as a UTC string. */
   readonly enrollmentTime: string;
   /** The identifier of the second factor. */
-  readonly factorId: string;
+  readonly factorId: typeof FactorIdMap[keyof typeof FactorIdMap];
 }
 
 /**
@@ -1044,7 +1050,7 @@ export interface UserCredential {
   /**
    * The type of operation which was used to authenticate the user (such as sign-in or link).
    */
-  operationType: string;
+  operationType: typeof OperationTypeMap[keyof typeof OperationTypeMap];
 }
 
 /**

--- a/packages-exp/auth-exp/src/model/public_types.ts
+++ b/packages-exp/auth-exp/src/model/public_types.ts
@@ -28,7 +28,7 @@ export { CompleteFn, ErrorFn, NextFn, Unsubscribe };
 /**
  * Enumeration of supported providers.
  *
- * @public
+ * @internal
  */
 export const enum ProviderId {
   /** @internal */
@@ -54,7 +54,7 @@ export const enum ProviderId {
 /**
  * Enumeration of supported sign-in methods.
  *
- * @public
+ * @private
  */
 export const enum SignInMethod {
   /** @internal */
@@ -78,7 +78,7 @@ export const enum SignInMethod {
 /**
  * Enumeration of supported operation types.
  *
- * @public
+ * @internal
  */
 export const enum OperationType {
   /** Operation involving linking an additional provider to an already signed-in user. */
@@ -431,13 +431,13 @@ export interface ActionCodeInfo {
   /**
    * The type of operation that generated the action code.
    */
-  operation: ActionCodeOperation;
+  operation: string;
 }
 
 /**
  * An enumeration of the possible email action types.
  *
- * @public
+ * @internal
  */
 export const enum ActionCodeOperation {
   /** The email link sign-in action. */
@@ -556,7 +556,7 @@ export interface AuthProvider {
 /**
  * An enum of factors that may be used for multifactor authentication.
  *
- * @public
+ * @internal
  */
 export const enum FactorId {
   /** Phone as second factor */
@@ -603,7 +603,7 @@ export interface ConfirmationResult {
  */
 export interface MultiFactorAssertion {
   /** The identifier of the second factor. */
-  readonly factorId: FactorId;
+  readonly factorId: string;
 }
 
 /**
@@ -641,7 +641,7 @@ export interface MultiFactorError extends AuthError {
   /**
    * The type of operation (e.g., sign-in, link, or reauthenticate) during which the error was raised.
    */
-  readonly operationType: OperationType;
+  readonly operationType: string;
 }
 
 /**
@@ -657,7 +657,7 @@ export interface MultiFactorInfo {
   /** The enrollment date of the second factor formatted as a UTC string. */
   readonly enrollmentTime: string;
   /** The identifier of the second factor. */
-  readonly factorId: FactorId;
+  readonly factorId: string;
 }
 
 /**
@@ -1044,7 +1044,7 @@ export interface UserCredential {
   /**
    * The type of operation which was used to authenticate the user (such as sign-in or link).
    */
-  operationType: OperationType;
+  operationType: string;
 }
 
 /**

--- a/packages-exp/auth-exp/src/model/public_types.ts
+++ b/packages-exp/auth-exp/src/model/public_types.ts
@@ -54,7 +54,7 @@ export const enum ProviderId {
 /**
  * Enumeration of supported sign-in methods.
  *
- * @private
+ * @internal
  */
 export const enum SignInMethod {
   /** @internal */

--- a/packages-exp/auth-exp/src/model/public_types.ts
+++ b/packages-exp/auth-exp/src/model/public_types.ts
@@ -27,7 +27,7 @@ import {
 import {
   FactorId as FactorIdMap,
   OperationType as OperationTypeMap,
-  ActionCodeOperation as ActionCodeOperationMap,
+  ActionCodeOperation as ActionCodeOperationMap
 } from './enum_maps';
 
 export { CompleteFn, ErrorFn, NextFn, Unsubscribe };
@@ -647,7 +647,7 @@ export interface MultiFactorError extends AuthError {
   /**
    * The type of operation (e.g., sign-in, link, or reauthenticate) during which the error was raised.
    */
-   readonly operationType: typeof OperationTypeMap[keyof typeof OperationTypeMap];
+  readonly operationType: typeof OperationTypeMap[keyof typeof OperationTypeMap];
 }
 
 /**


### PR DESCRIPTION
This PR removes public `const enum`s (which are inaccessible to JS anyway) and moves any (public) reference to those types to simply `string`. Instead, we export maps that can be used to reference acceptable values (but these are not used internally to aid tree shaking)

Fixes https://github.com/firebase/firebase-js-sdk/issues/5012