### PR TITLE
Add getAuth() default arg to all entry points

### DIFF
--- a/packages-exp/auth-exp/index.cordova.ts
+++ b/packages-exp/auth-exp/index.cordova.ts
@@ -22,7 +22,7 @@
  * just use index.ts
  */
 
-import { FirebaseApp, _getProvider } from '@firebase/app-exp';
+import { FirebaseApp, getApp, _getProvider } from '@firebase/app-exp';
 import { Auth } from './src/model/public_types';
 import { indexedDBLocalPersistence } from './src/platform_browser/persistence/indexed_db';
 
@@ -48,7 +48,7 @@ export {
 
 import { cordovaPopupRedirectResolver } from './src/platform_cordova/popup_redirect/popup_redirect';
 
-export function getAuth(app: FirebaseApp): Auth {
+export function getAuth(app: FirebaseApp = getApp()): Auth {
   const provider = _getProvider(app, 'auth-exp');
 
   if (provider.isInitialized()) {

--- a/packages-exp/auth-exp/index.node.ts
+++ b/packages-exp/auth-exp/index.node.ts
@@ -24,7 +24,7 @@
 
 import * as fetchImpl from 'node-fetch';
 
-import { FirebaseApp, _getProvider } from '@firebase/app-exp';
+import { FirebaseApp, getApp, _getProvider } from '@firebase/app-exp';
 import { Auth } from './src/model/public_types';
 
 import { initializeAuth } from './src';
@@ -49,7 +49,7 @@ export {
   ActionCodeOperation
 } from './src/model/enum_maps';
 
-export function getAuth(app: FirebaseApp): Auth {
+export function getAuth(app: FirebaseApp = getApp()): Auth {
   const provider = _getProvider(app, 'auth-exp');
 
   if (provider.isInitialized()) {

--- a/packages-exp/auth-exp/index.rn.ts
+++ b/packages-exp/auth-exp/index.rn.ts
@@ -24,7 +24,7 @@
 
 import { AsyncStorage } from 'react-native';
 
-import { FirebaseApp, _getProvider } from '@firebase/app-exp';
+import { FirebaseApp, getApp, _getProvider } from '@firebase/app-exp';
 import { Auth } from './src/model/public_types';
 
 import { initializeAuth } from './src';
@@ -39,7 +39,7 @@ export const reactNativeLocalPersistence = getReactNativePersistence(
   AsyncStorage
 );
 
-export function getAuth(app: FirebaseApp): Auth {
+export function getAuth(app: FirebaseApp = getApp()): Auth {
   const provider = _getProvider(app, 'auth-exp');
 
   if (provider.isInitialized()) {

--- a/packages-exp/auth-exp/index.webworker.ts
+++ b/packages-exp/auth-exp/index.webworker.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { _getProvider, FirebaseApp } from '@firebase/app-exp';
+import { _getProvider, FirebaseApp, getApp } from '@firebase/app-exp';
 import { Auth } from './src/model/public_types';
 
 import { AuthImpl } from './src/core/auth/auth_impl';
@@ -34,7 +34,7 @@ export { indexedDBLocalPersistence } from './src/platform_browser/persistence/in
 
 registerAuth(ClientPlatform.WORKER);
 
-export function getAuth(app: FirebaseApp): Auth {
+export function getAuth(app: FirebaseApp = getApp()): Auth {
   // Unlike the other environments, we need to explicitly check if indexedDb is
   // available. That means doing the whole rigamarole
   const auth = _getProvider(


### PR DESCRIPTION
`getAuth()` is implemented separately in each auth entry point file. https://github.com/firebase/firebase-js-sdk/pull/4702 added a default app param value in only the browser `index.ts` entry point. Adding to the other entry points for consistency.

Fixes https://github.com/firebase/firebase-js-sdk/issues/4949