### PR TITLE
Port 3P token API to app-check-exp

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -15,7 +15,9 @@
     "firebase-messaging-integration-test",
     "firebase-compat-interop-test",
     "firebase-compat-typings-test",
+    "@firebase/app-compat",
     "@firebase/app-exp",
+    "@firebase/app-check-compat",
     "@firebase/app-check-exp",
     "@firebase/analytics-compat",
     "@firebase/analytics-exp",
@@ -32,7 +34,6 @@
     "@firebase/remote-config-exp",
     "@firebase/remote-config-compat",
     "firebase-exp",
-    "@firebase/app-compat",
     "@firebase/changelog-generator",
     "firebase-size-analysis"
   ],

--- a/common/api-review/app-check-exp.api.md
+++ b/common/api-review/app-check-exp.api.md
@@ -5,6 +5,8 @@
 ```ts
 
 import { FirebaseApp } from '@firebase/app-exp';
+import { PartialObserver } from '@firebase/util';
+import { Unsubscribe } from '@firebase/util';
 
 // @public
 export interface AppCheck {
@@ -30,6 +32,14 @@ export interface AppCheckToken {
     readonly token: string;
 }
 
+// @public
+export type AppCheckTokenListener = (token: AppCheckTokenResult) => void;
+
+// @public
+export interface AppCheckTokenResult {
+    readonly token: string;
+}
+
 // Warning: (ae-forgotten-export) The symbol "AppCheckProvider" needs to be exported by the entry point index.d.ts
 //
 // @public
@@ -49,7 +59,16 @@ export interface CustomProviderOptions {
 }
 
 // @public
+export function getToken(appCheckInstance: AppCheck, forceRefresh?: boolean): Promise<AppCheckTokenResult>;
+
+// @public
 export function initializeAppCheck(app: FirebaseApp | undefined, options: AppCheckOptions): AppCheck;
+
+// @public
+export function onTokenChanged(appCheckInstance: AppCheck, observer: PartialObserver<AppCheckTokenResult>): Unsubscribe;
+
+// @public
+export function onTokenChanged(appCheckInstance: AppCheck, onNext: (tokenResult: AppCheckTokenResult) => void, onError?: (error: Error) => void, onCompletion?: () => void): Unsubscribe;
 
 // @public
 export class ReCaptchaV3Provider implements AppCheckProvider {
@@ -61,7 +80,7 @@ export class ReCaptchaV3Provider implements AppCheckProvider {
     }
 
 // @public
-export function setTokenAutoRefreshEnabled(app: FirebaseApp, isTokenAutoRefreshEnabled: boolean): void;
+export function setTokenAutoRefreshEnabled(appCheckInstance: AppCheck, isTokenAutoRefreshEnabled: boolean): void;
 
 
 // (No @packageDocumentation comment for this package)

--- a/packages-exp/app-check-compat/.eslintrc.js
+++ b/packages-exp/app-check-compat/.eslintrc.js
@@ -1,0 +1,33 @@
+/**
+ * @license
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+const path = require('path');
+
+module.exports = {
+  'extends': '../../config/.eslintrc.js',
+  'parserOptions': {
+    'project': 'tsconfig.json',
+    'tsconfigRootDir': __dirname
+  },
+  rules: {
+    'import/no-extraneous-dependencies': [
+      'error',
+      {
+        'packageDir': [path.resolve(__dirname, '../../'), __dirname]
+      }
+    ]
+  }
+};

--- a/packages-exp/app-check-compat/README.md
+++ b/packages-exp/app-check-compat/README.md
@@ -1,0 +1,5 @@
+# @firebase/app-check-compat
+
+This is the Firebase App Check component (compat version) of the Firebase JS SDK.
+
+**This package is not intended for direct usage, and should only be used via the officially supported [`firebase`](https://www.npmjs.com/package/firebase) package.**

--- a/packages-exp/app-check-compat/karma.conf.js
+++ b/packages-exp/app-check-compat/karma.conf.js
@@ -1,0 +1,32 @@
+/**
+ * @license
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const karmaBase = require('../../config/karma.base');
+
+const files = [`**/*.test.ts`];
+
+module.exports = function (config) {
+  config.set({
+    ...karmaBase,
+    files,
+    preprocessors: { '**/*.ts': ['webpack', 'sourcemap'] },
+    frameworks: ['mocha']
+  });
+};
+
+module.exports.files = files;

--- a/packages-exp/app-check-compat/package.json
+++ b/packages-exp/app-check-compat/package.json
@@ -1,0 +1,60 @@
+{
+  "name": "@firebase/app-check-compat",
+  "version": "0.0.900",
+  "private": true,
+  "description": "A compat App Check package for new firebase packages",
+  "author": "Firebase <firebase-support@google.com> (https://firebase.google.com/)",
+  "main": "dist/index.cjs.js",
+  "browser": "dist/index.esm2017.js",
+  "module": "dist/index.esm2017.js",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "lint": "eslint -c .eslintrc.js '**/*.ts' --ignore-path '../../.gitignore'",
+    "lint:fix": "eslint --fix -c .eslintrc.js '**/*.ts' --ignore-path '../../.gitignore'",
+    "build": "rollup -c",
+    "build:release": "rollup -c rollup.config.release.js",
+    "build:deps": "lerna run --scope @firebase/app-check-compat --include-dependencies build",
+    "dev": "rollup -c -w",
+    "test": "run-p lint test:browser",
+    "test:ci": "node ../../scripts/run_tests_in_ci.js -s test:browser",
+    "test:browser": "karma start --single-run --nocache"
+  },
+  "peerDependencies": {
+    "@firebase/app-compat": "0.x"
+  },
+  "dependencies": {
+    "@firebase/app-check-exp": "0.0.900",
+    "@firebase/logger": "0.2.6",
+    "@firebase/util": "1.1.0",
+    "@firebase/component": "0.5.3",
+    "tslib": "^2.1.0"
+  },
+  "license": "Apache-2.0",
+  "devDependencies": {
+    "@firebase/app-compat": "0.0.900",
+    "rollup": "2.33.2",
+    "@rollup/plugin-commonjs": "17.1.0",
+    "@rollup/plugin-json": "4.1.0",
+    "@rollup/plugin-node-resolve": "11.2.0",
+    "rollup-plugin-typescript2": "0.29.0",
+    "typescript": "4.2.2"
+  },
+  "repository": {
+    "directory": "packages/app-check",
+    "type": "git",
+    "url": "https://github.com/firebase/firebase-js-sdk.git"
+  },
+  "bugs": {
+    "url": "https://github.com/firebase/firebase-js-sdk/issues"
+  },
+  "typings": "dist/src/index.d.ts",
+  "nyc": {
+    "extension": [
+      ".ts"
+    ],
+    "reportDir": "./coverage/node"
+  },
+  "esm5": "dist/index.esm.js"
+}

--- a/packages-exp/app-check-compat/rollup.config.js
+++ b/packages-exp/app-check-compat/rollup.config.js
@@ -1,0 +1,58 @@
+/**
+ * @license
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import json from '@rollup/plugin-json';
+import typescriptPlugin from 'rollup-plugin-typescript2';
+import typescript from 'typescript';
+import { es2017BuildsNoPlugin, es5BuildsNoPlugin } from './rollup.shared';
+
+/**
+ * ES5 Builds
+ */
+const es5BuildPlugins = [
+  typescriptPlugin({
+    typescript
+  }),
+  json()
+];
+
+const es5Builds = es5BuildsNoPlugin.map(build => ({
+  ...build,
+  plugins: es5BuildPlugins
+}));
+
+/**
+ * ES2017 Builds
+ */
+const es2017BuildPlugins = [
+  typescriptPlugin({
+    typescript,
+    tsconfigOverride: {
+      compilerOptions: {
+        target: 'es2017'
+      }
+    }
+  }),
+  json({ preferConst: true })
+];
+
+const es2017Builds = es2017BuildsNoPlugin.map(build => ({
+  ...build,
+  plugins: es2017BuildPlugins
+}));
+
+export default [...es5Builds, ...es2017Builds];

--- a/packages-exp/app-check-compat/rollup.config.release.js
+++ b/packages-exp/app-check-compat/rollup.config.release.js
@@ -1,0 +1,67 @@
+/**
+ * @license
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import typescriptPlugin from 'rollup-plugin-typescript2';
+import typescript from 'typescript';
+import json from '@rollup/plugin-json';
+import { importPathTransformer } from '../../scripts/exp/ts-transform-import-path';
+import { es2017BuildsNoPlugin, es5BuildsNoPlugin } from './rollup.shared';
+
+/**
+ * ES5 Builds
+ */
+const es5BuildPlugins = [
+  typescriptPlugin({
+    typescript,
+    clean: true,
+    abortOnError: false,
+    transformers: [importPathTransformer]
+  }),
+  json()
+];
+
+const es5Builds = es5BuildsNoPlugin.map(build => ({
+  ...build,
+  plugins: es5BuildPlugins
+}));
+
+/**
+ * ES2017 Builds
+ */
+const es2017BuildPlugins = [
+  typescriptPlugin({
+    typescript,
+    tsconfigOverride: {
+      compilerOptions: {
+        target: 'es2017'
+      }
+    },
+    abortOnError: false,
+    clean: true,
+    transformers: [importPathTransformer]
+  }),
+  json({
+    preferConst: true
+  })
+];
+
+const es2017Builds = es2017BuildsNoPlugin.map(build => ({
+  ...build,
+  plugins: es2017BuildPlugins
+}));
+
+export default [...es5Builds, ...es2017Builds];

--- a/packages-exp/app-check-compat/rollup.shared.js
+++ b/packages-exp/app-check-compat/rollup.shared.js
@@ -1,0 +1,54 @@
+/**
+ * @license
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import pkg from './package.json';
+
+const deps = [
+  ...Object.keys(Object.assign({}, pkg.peerDependencies, pkg.dependencies)),
+  '@firebase/app'
+];
+
+export const es5BuildsNoPlugin = [
+  /**
+   * Browser Builds
+   */
+  {
+    input: 'src/index.ts',
+    output: [
+      { file: pkg.main, format: 'cjs', sourcemap: true },
+      { file: pkg.esm5, format: 'es', sourcemap: true }
+    ],
+    external: id => deps.some(dep => id === dep || id.startsWith(`${dep}/`))
+  }
+];
+
+/**
+ * ES2017 Builds
+ */
+export const es2017BuildsNoPlugin = [
+  {
+    /**
+     * Browser Build
+     */
+    input: 'src/index.ts',
+    output: {
+      file: pkg.browser,
+      format: 'es',
+      sourcemap: true
+    },
+    external: id => deps.some(dep => id === dep || id.startsWith(`${dep}/`))
+  }
+];

--- a/packages-exp/app-check-compat/src/index.ts
+++ b/packages-exp/app-check-compat/src/index.ts
@@ -1,0 +1,69 @@
+/**
+ * @license
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import firebase, {
+  _FirebaseNamespace,
+  FirebaseApp
+} from '@firebase/app-compat';
+import { name, version } from '../package.json';
+import {
+  Component,
+  ComponentContainer,
+  ComponentType,
+  InstanceFactory
+} from '@firebase/component';
+import { AppCheckService } from './service';
+import { FirebaseAppCheck } from '../../../packages/app-check-types';
+
+declare module '@firebase/component' {
+  interface NameServiceMapping {
+    'appCheck-compat': AppCheckService;
+  }
+}
+
+const factory: InstanceFactory<'appCheck-compat'> = (
+  container: ComponentContainer
+) => {
+  // Dependencies
+  const app = container.getProvider('app-compat').getImmediate();
+  const appCheckServiceExp = container
+    .getProvider('app-check-exp')
+    .getImmediate();
+
+  return new AppCheckService(app as FirebaseApp, appCheckServiceExp);
+};
+
+export function registerAppCheck(): void {
+  (firebase as _FirebaseNamespace).INTERNAL.registerComponent(
+    new Component('appCheck-compat', factory, ComponentType.PUBLIC)
+  );
+}
+
+registerAppCheck();
+firebase.registerVersion(name, version);
+
+/**
+ * Define extension behavior of `registerAppCheck`
+ */
+declare module '@firebase/app-compat' {
+  interface FirebaseNamespace {
+    appCheck(app?: FirebaseApp): FirebaseAppCheck;
+  }
+  interface FirebaseApp {
+    appCheck(): FirebaseAppCheck;
+  }
+}

--- a/packages-exp/app-check-compat/src/service.test.ts
+++ b/packages-exp/app-check-compat/src/service.test.ts
@@ -1,0 +1,142 @@
+/**
+ * @license
+ * Copyright 2017 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { expect, use } from 'chai';
+import { AppCheckService } from './service';
+import { firebase, FirebaseApp } from '@firebase/app-compat';
+import * as appCheckExp from '@firebase/app-check-exp';
+import { stub, match, SinonStub } from 'sinon';
+import * as sinonChai from 'sinon-chai';
+import { CustomProvider, ReCaptchaV3Provider } from '@firebase/app-check-exp';
+import { AppCheckTokenResult } from '../../../packages/app-check-types';
+import { PartialObserver } from '../../../packages/util/dist';
+
+use(sinonChai);
+
+function createTestService(app: FirebaseApp): AppCheckService {
+  return new AppCheckService(
+    app,
+    appCheckExp.initializeAppCheck(app, {
+      provider: new ReCaptchaV3Provider('fake-site-key')
+    })
+  );
+}
+
+describe('Firebase App Check > Service', () => {
+  let app: FirebaseApp;
+  let service: AppCheckService;
+
+  beforeEach(() => {
+    app = firebase.initializeApp({
+      apiKey: '456_LETTERS_AND_1234NUMBERS',
+      appId: '123lettersand:numbers',
+      projectId: 'my-project',
+      messagingSenderId: 'messaging-sender-id'
+    });
+  });
+
+  afterEach(async () => {
+    await app.delete();
+  });
+
+  it(
+    'activate("string") calls modular initializeAppCheck() with a ' +
+      'ReCaptchaV3Provider',
+    () => {
+      const initializeAppCheckStub = stub(appCheckExp, 'initializeAppCheck');
+      service = new AppCheckService(app, {} as appCheckExp.AppCheck);
+      service.activate('my_site_key');
+      expect(initializeAppCheckStub).to.be.calledWith(app, {
+        provider: match.instanceOf(ReCaptchaV3Provider),
+        isTokenAutoRefreshEnabled: undefined
+      });
+      initializeAppCheckStub.restore();
+    }
+  );
+
+  it(
+    'activate(CustomProvider) calls modular initializeAppCheck() with' +
+      ' a CustomProvider',
+    () => {
+      const initializeAppCheckStub = stub(appCheckExp, 'initializeAppCheck');
+      service = new AppCheckService(app, {} as appCheckExp.AppCheck);
+      const customGetTokenStub = stub();
+      service.activate({
+        getToken: customGetTokenStub
+      });
+      expect(initializeAppCheckStub).to.be.calledWith(app, {
+        provider: match
+          .instanceOf(CustomProvider)
+          .and(
+            match.hasNested(
+              '_customProviderOptions.getToken',
+              customGetTokenStub
+            )
+          ),
+        isTokenAutoRefreshEnabled: undefined
+      });
+      initializeAppCheckStub.restore();
+    }
+  );
+
+  it('setTokenAutoRefreshEnabled() calls modular setTokenAutoRefreshEnabled()', () => {
+    const setTokenAutoRefreshEnabledStub: SinonStub = stub(
+      appCheckExp,
+      'setTokenAutoRefreshEnabled'
+    );
+    service = createTestService(app);
+    service.setTokenAutoRefreshEnabled(true);
+    expect(setTokenAutoRefreshEnabledStub).to.be.calledWith(
+      service._delegate,
+      true
+    );
+    setTokenAutoRefreshEnabledStub.restore();
+  });
+
+  it('getToken() calls modular getToken()', async () => {
+    service = createTestService(app);
+    const getTokenStub = stub(appCheckExp, 'getToken');
+    await service.getToken(true);
+    expect(getTokenStub).to.be.calledWith(service._delegate, true);
+    getTokenStub.restore();
+  });
+
+  it('onTokenChanged() calls modular onTokenChanged() with observer', () => {
+    const onTokenChangedStub = stub(appCheckExp, 'onTokenChanged');
+    service = createTestService(app);
+    const observer: PartialObserver<AppCheckTokenResult> = {
+      next: stub(),
+      error: stub()
+    };
+    service.onTokenChanged(observer);
+    expect(onTokenChangedStub).to.be.calledWith(service._delegate, observer);
+    onTokenChangedStub.restore();
+  });
+
+  it('onTokenChanged() calls modular onTokenChanged() with next/error fns', () => {
+    const onTokenChangedStub = stub(appCheckExp, 'onTokenChanged');
+    service = createTestService(app);
+    const nextFn = stub();
+    const errorFn = stub();
+    service.onTokenChanged(nextFn, errorFn);
+    expect(onTokenChangedStub).to.be.calledWith(
+      service._delegate,
+      nextFn,
+      errorFn
+    );
+    onTokenChangedStub.restore();
+  });
+});

--- a/packages-exp/app-check-compat/src/service.ts
+++ b/packages-exp/app-check-compat/src/service.ts
@@ -1,0 +1,79 @@
+/**
+ * @license
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  AppCheckProvider,
+  AppCheckTokenResult,
+  FirebaseAppCheck
+} from '@firebase/app-check-types';
+import { _FirebaseService, FirebaseApp } from '@firebase/app-compat';
+import {
+  AppCheck as AppCheckServiceExp,
+  CustomProvider,
+  initializeAppCheck,
+  ReCaptchaV3Provider,
+  setTokenAutoRefreshEnabled as setTokenAutoRefreshEnabledExp,
+  getToken as getTokenExp,
+  onTokenChanged as onTokenChangedExp
+} from '@firebase/app-check-exp';
+import { PartialObserver, Unsubscribe } from '@firebase/util';
+
+export class AppCheckService implements FirebaseAppCheck, _FirebaseService {
+  constructor(
+    public app: FirebaseApp,
+    readonly _delegate: AppCheckServiceExp
+  ) {}
+  activate(
+    siteKeyOrProvider: string | AppCheckProvider,
+    isTokenAutoRefreshEnabled?: boolean
+  ): void {
+    let provider: ReCaptchaV3Provider | CustomProvider;
+    if (typeof siteKeyOrProvider === 'string') {
+      provider = new ReCaptchaV3Provider(siteKeyOrProvider);
+    } else {
+      provider = new CustomProvider({ getToken: siteKeyOrProvider.getToken });
+    }
+    initializeAppCheck(this.app, {
+      provider,
+      isTokenAutoRefreshEnabled
+    });
+  }
+  setTokenAutoRefreshEnabled(isTokenAutoRefreshEnabled: boolean): void {
+    setTokenAutoRefreshEnabledExp(this._delegate, isTokenAutoRefreshEnabled);
+  }
+  getToken(forceRefresh?: boolean): Promise<AppCheckTokenResult> {
+    return getTokenExp(this._delegate, forceRefresh);
+  }
+  onTokenChanged(
+    onNextOrObserver:
+      | PartialObserver<AppCheckTokenResult>
+      | ((tokenResult: AppCheckTokenResult) => void),
+    onError?: (error: Error) => void,
+    onCompletion?: () => void
+  ): Unsubscribe {
+    return onTokenChangedExp(
+      this._delegate,
+      /**
+       * Exp onTokenChanged() will handle both overloads but we need
+       * to specify one to not confuse Typescript.
+       */
+      onNextOrObserver as (tokenResult: AppCheckTokenResult) => void,
+      onError,
+      onCompletion
+    );
+  }
+}

--- a/packages-exp/app-check-compat/tsconfig.json
+++ b/packages-exp/app-check-compat/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../config/tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "strict": true
+  },
+  "exclude": ["dist/**/*"]
+}

--- a/packages-exp/app-check-exp/src/api.test.ts
+++ b/packages-exp/app-check-exp/src/api.test.ts
@@ -16,11 +16,29 @@
  */
 import '../test/setup';
 import { expect } from 'chai';
-import { stub } from 'sinon';
-import { setTokenAutoRefreshEnabled, initializeAppCheck } from './api';
-import { FAKE_SITE_KEY, getFullApp, getFakeApp } from '../test/util';
-import { getState } from './state';
+import { match, spy, stub } from 'sinon';
+import {
+  setTokenAutoRefreshEnabled,
+  initializeAppCheck,
+  getToken,
+  onTokenChanged
+} from './api';
+import {
+  FAKE_SITE_KEY,
+  getFullApp,
+  getFakeApp,
+  getFakeGreCAPTCHA,
+  getFakeAppCheck,
+  getFakePlatformLoggingProvider,
+  removegreCAPTCHAScriptsOnPage
+} from '../test/util';
+import { clearState, getState } from './state';
 import * as reCAPTCHA from './recaptcha';
+import * as util from './util';
+import * as logger from './logger';
+import * as client from './client';
+import * as storage from './storage';
+import * as internalApi from './internal-api';
 import { deleteApp, FirebaseApp } from '@firebase/app-exp';
 import { ReCaptchaV3Provider } from './providers';
 
@@ -29,9 +47,12 @@ describe('api', () => {
 
   beforeEach(() => {
     app = getFullApp();
+    stub(util, 'getRecaptcha').returns(getFakeGreCAPTCHA());
   });
 
   afterEach(() => {
+    clearState();
+    removegreCAPTCHAScriptsOnPage();
     return deleteApp(app);
   });
 
@@ -88,8 +109,167 @@ describe('api', () => {
   describe('setTokenAutoRefreshEnabled()', () => {
     it('sets isTokenAutoRefreshEnabled correctly', () => {
       const app = getFakeApp({ automaticDataCollectionEnabled: false });
-      setTokenAutoRefreshEnabled(app, true);
+      const appCheck = getFakeAppCheck(app);
+      setTokenAutoRefreshEnabled(appCheck, true);
       expect(getState(app).isTokenAutoRefreshEnabled).to.equal(true);
+    });
+  });
+  describe('getToken()', () => {
+    it('getToken() calls the internal getToken() function', async () => {
+      const app = getFakeApp({ automaticDataCollectionEnabled: true });
+      const appCheck = getFakeAppCheck(app);
+      const internalGetToken = stub(internalApi, 'getToken').resolves({
+        token: 'a-token-string'
+      });
+      await getToken(appCheck, true);
+      expect(internalGetToken).to.be.calledWith(
+        appCheck.app,
+        match.any, // platformLoggerProvider
+        true
+      );
+    });
+    it('getToken() throws errors returned with token', async () => {
+      const app = getFakeApp({ automaticDataCollectionEnabled: true });
+      const appCheck = getFakeAppCheck(app);
+      // If getToken() errors, it returns a dummy token with an error field
+      // instead of throwing.
+      stub(internalApi, 'getToken').resolves({
+        token: 'a-dummy-token',
+        error: Error('there was an error')
+      });
+      await expect(getToken(appCheck, true)).to.be.rejectedWith(
+        'there was an error'
+      );
+    });
+  });
+  describe('onTokenChanged()', () => {
+    it('Listeners work when using top-level parameters pattern', async () => {
+      const appCheck = initializeAppCheck(app, {
+        provider: new ReCaptchaV3Provider(FAKE_SITE_KEY),
+        isTokenAutoRefreshEnabled: true
+      });
+      const fakeRecaptchaToken = 'fake-recaptcha-token';
+      const fakeRecaptchaAppCheckToken = {
+        token: 'fake-recaptcha-app-check-token',
+        expireTimeMillis: 123,
+        issuedAtTimeMillis: 0
+      };
+      stub(reCAPTCHA, 'getToken').returns(Promise.resolve(fakeRecaptchaToken));
+      stub(client, 'exchangeToken').returns(
+        Promise.resolve(fakeRecaptchaAppCheckToken)
+      );
+      stub(storage, 'writeTokenToStorage').returns(Promise.resolve(undefined));
+
+      const listener1 = (): void => {
+        throw new Error();
+      };
+      const listener2 = spy();
+
+      const errorFn1 = spy();
+      const errorFn2 = spy();
+
+      const unsubscribe1 = onTokenChanged(appCheck, listener1, errorFn1);
+      const unsubscribe2 = onTokenChanged(appCheck, listener2, errorFn2);
+
+      expect(getState(app).tokenObservers.length).to.equal(2);
+
+      await internalApi.getToken(
+        appCheck.app,
+        getFakePlatformLoggingProvider()
+      );
+
+      expect(listener2).to.be.calledWith({
+        token: fakeRecaptchaAppCheckToken.token
+      });
+      // onError should not be called on listener errors.
+      expect(errorFn1).to.not.be.called;
+      expect(errorFn2).to.not.be.called;
+      unsubscribe1();
+      unsubscribe2();
+      expect(getState(app).tokenObservers.length).to.equal(0);
+    });
+
+    it('Listeners work when using Observer pattern', async () => {
+      const appCheck = initializeAppCheck(app, {
+        provider: new ReCaptchaV3Provider(FAKE_SITE_KEY),
+        isTokenAutoRefreshEnabled: true
+      });
+      const fakePlatformLoggingProvider = getFakePlatformLoggingProvider();
+      const fakeRecaptchaToken = 'fake-recaptcha-token';
+      const fakeRecaptchaAppCheckToken = {
+        token: 'fake-recaptcha-app-check-token',
+        expireTimeMillis: 123,
+        issuedAtTimeMillis: 0
+      };
+      stub(reCAPTCHA, 'getToken').returns(Promise.resolve(fakeRecaptchaToken));
+      stub(client, 'exchangeToken').returns(
+        Promise.resolve(fakeRecaptchaAppCheckToken)
+      );
+      stub(storage, 'writeTokenToStorage').returns(Promise.resolve(undefined));
+
+      const listener1 = (): void => {
+        throw new Error();
+      };
+      const listener2 = spy();
+
+      const errorFn1 = spy();
+      const errorFn2 = spy();
+
+      /**
+       * Reverse the order of adding the failed and successful handler, for extra
+       * testing.
+       */
+      const unsubscribe2 = onTokenChanged(appCheck, {
+        next: listener2,
+        error: errorFn2
+      });
+      const unsubscribe1 = onTokenChanged(appCheck, {
+        next: listener1,
+        error: errorFn1
+      });
+
+      expect(getState(app).tokenObservers.length).to.equal(2);
+
+      await internalApi.getToken(appCheck.app, fakePlatformLoggingProvider);
+
+      expect(listener2).to.be.calledWith({
+        token: fakeRecaptchaAppCheckToken.token
+      });
+      // onError should not be called on listener errors.
+      expect(errorFn1).to.not.be.called;
+      expect(errorFn2).to.not.be.called;
+      unsubscribe1();
+      unsubscribe2();
+      expect(getState(app).tokenObservers.length).to.equal(0);
+    });
+
+    it('onError() catches token errors', async () => {
+      stub(logger.logger, 'error');
+      const appCheck = initializeAppCheck(app, {
+        provider: new ReCaptchaV3Provider(FAKE_SITE_KEY),
+        isTokenAutoRefreshEnabled: false
+      });
+      const fakePlatformLoggingProvider = getFakePlatformLoggingProvider();
+      const fakeRecaptchaToken = 'fake-recaptcha-token';
+      stub(reCAPTCHA, 'getToken').returns(Promise.resolve(fakeRecaptchaToken));
+      stub(client, 'exchangeToken').rejects('exchange error');
+      stub(storage, 'writeTokenToStorage').returns(Promise.resolve(undefined));
+
+      const listener1 = spy();
+
+      const errorFn1 = spy();
+
+      const unsubscribe1 = onTokenChanged(appCheck, listener1, errorFn1);
+
+      await internalApi.getToken(app, fakePlatformLoggingProvider);
+
+      expect(getState(app).tokenObservers.length).to.equal(1);
+
+      expect(errorFn1).to.be.calledOnce;
+      expect(errorFn1.args[0][0].name).to.include('exchange error');
+
+      unsubscribe1();
+      expect(getState(app).tokenObservers.length).to.equal(0);
     });
   });
 });

--- a/packages-exp/app-check-exp/src/api.ts
+++ b/packages-exp/app-check-exp/src/api.ts
@@ -27,7 +27,7 @@ import {
   Unsubscribe
 } from '@firebase/util';
 import { AppCheckService } from './factory';
-import { AppCheckProvider } from './types';
+import { AppCheckProvider, ListenerType } from './types';
 import {
   getToken as getTokenInternal,
   addTokenListener,
@@ -141,8 +141,7 @@ export async function getToken(
   forceRefresh?: boolean
 ): Promise<AppCheckTokenResult> {
   const result = await getTokenInternal(
-    appCheckInstance.app,
-    (appCheckInstance as AppCheckService).platformLoggerProvider,
+    appCheckInstance as AppCheckService,
     forceRefresh
   );
   if (result.error) {
@@ -231,8 +230,8 @@ export function onTokenChanged(
     errorFn = onError;
   }
   addTokenListener(
-    appCheckInstance.app,
-    (appCheckInstance as AppCheckService).platformLoggerProvider,
+    appCheckInstance as AppCheckService,
+    ListenerType['3P'],
     nextFn,
     errorFn
   );

--- a/packages-exp/app-check-exp/src/api.ts
+++ b/packages-exp/app-check-exp/src/api.ts
@@ -15,13 +15,24 @@
  * limitations under the License.
  */
 
-import { AppCheck, AppCheckOptions } from './public-types';
+import { AppCheck, AppCheckOptions, AppCheckTokenResult } from './public-types';
 import { ERROR_FACTORY, AppCheckError } from './errors';
 import { getState, setState, AppCheckState } from './state';
 import { FirebaseApp, getApp, _getProvider } from '@firebase/app-exp';
-import { getModularInstance } from '@firebase/util';
+import {
+  getModularInstance,
+  ErrorFn,
+  NextFn,
+  PartialObserver,
+  Unsubscribe
+} from '@firebase/util';
 import { AppCheckService } from './factory';
 import { AppCheckProvider } from './types';
+import {
+  getToken as getTokenInternal,
+  addTokenListener,
+  removeTokenListener
+} from './internal-api';
 
 declare module '@firebase/component' {
   interface NameServiceMapping {
@@ -92,15 +103,17 @@ function _activate(
 /**
  * Set whether App Check will automatically refresh tokens as needed.
  *
+ * @param appCheckInstance - The App Check service instance.
  * @param isTokenAutoRefreshEnabled - If true, the SDK automatically
  * refreshes App Check tokens as needed. This overrides any value set
  * during `initializeAppCheck()`.
  * @public
  */
 export function setTokenAutoRefreshEnabled(
-  app: FirebaseApp,
+  appCheckInstance: AppCheck,
   isTokenAutoRefreshEnabled: boolean
 ): void {
+  const app = appCheckInstance.app;
   const state = getState(app);
   // This will exist if any product libraries have called
   // `addTokenListener()`
@@ -112,4 +125,116 @@ export function setTokenAutoRefreshEnabled(
     }
   }
   setState(app, { ...state, isTokenAutoRefreshEnabled });
+}
+/**
+ * Get the current App Check token. Attaches to the most recent
+ * in-flight request if one is present. Returns null if no token
+ * is present and no token requests are in-flight.
+ *
+ * @param appCheckInstance - The App Check service instance.
+ * @param forceRefresh - If true, will always try to fetch a fresh token.
+ * If false, will use a cached token if found in storage.
+ * @public
+ */
+export async function getToken(
+  appCheckInstance: AppCheck,
+  forceRefresh?: boolean
+): Promise<AppCheckTokenResult> {
+  const result = await getTokenInternal(
+    appCheckInstance.app,
+    (appCheckInstance as AppCheckService).platformLoggerProvider,
+    forceRefresh
+  );
+  if (result.error) {
+    throw result.error;
+  }
+  return { token: result.token };
+}
+
+/**
+ * Registers a listener to changes in the token state. There can be more
+ * than one listener registered at the same time for one or more
+ * App Check instances. The listeners call back on the UI thread whenever
+ * the current token associated with this App Check instance changes.
+ *
+ * @param appCheckInstance - The App Check service instance.
+ * @param observer - An object with `next`, `error`, and `complete`
+ * properties. `next` is called with an
+ * {@link AppCheckTokenResult}
+ * whenever the token changes. `error` is optional and is called if an
+ * error is thrown by the listener (the `next` function). `complete`
+ * is unused, as the token stream is unending.
+ *
+ * @returns A function that unsubscribes this listener.
+ * @public
+ */
+export function onTokenChanged(
+  appCheckInstance: AppCheck,
+  observer: PartialObserver<AppCheckTokenResult>
+): Unsubscribe;
+/**
+ * Registers a listener to changes in the token state. There can be more
+ * than one listener registered at the same time for one or more
+ * App Check instances. The listeners call back on the UI thread whenever
+ * the current token associated with this App Check instance changes.
+ *
+ * @param appCheckInstance - The App Check service instance.
+ * @param onNext - When the token changes, this function is called with aa
+ * {@link AppCheckTokenResult}.
+ * @param onError - Optional. Called if there is an error thrown by the
+ * listener (the `onNext` function).
+ * @param onCompletion - Currently unused, as the token stream is unending.
+ * @returns A function that unsubscribes this listener.
+ * @public
+ */
+export function onTokenChanged(
+  appCheckInstance: AppCheck,
+  onNext: (tokenResult: AppCheckTokenResult) => void,
+  onError?: (error: Error) => void,
+  onCompletion?: () => void
+): Unsubscribe;
+/**
+ * Wraps addTokenListener/removeTokenListener methods in an Observer
+ * pattern for public use.
+ */
+export function onTokenChanged(
+  appCheckInstance: AppCheck,
+  onNextOrObserver:
+    | ((tokenResult: AppCheckTokenResult) => void)
+    | PartialObserver<AppCheckTokenResult>,
+  onError?: (error: Error) => void,
+  /**
+   * NOTE: Although an `onCompletion` callback can be provided, it will
+   * never be called because the token stream is never-ending.
+   * It is added only for API consistency with the observer pattern, which
+   * we follow in JS APIs.
+   */
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  onCompletion?: () => void
+): Unsubscribe {
+  let nextFn: NextFn<AppCheckTokenResult> = () => {};
+  let errorFn: ErrorFn = () => {};
+  if ((onNextOrObserver as PartialObserver<AppCheckTokenResult>).next != null) {
+    nextFn = (onNextOrObserver as PartialObserver<AppCheckTokenResult>).next!.bind(
+      onNextOrObserver
+    );
+  } else {
+    nextFn = onNextOrObserver as NextFn<AppCheckTokenResult>;
+  }
+  if (
+    (onNextOrObserver as PartialObserver<AppCheckTokenResult>).error != null
+  ) {
+    errorFn = (onNextOrObserver as PartialObserver<AppCheckTokenResult>).error!.bind(
+      onNextOrObserver
+    );
+  } else if (onError) {
+    errorFn = onError;
+  }
+  addTokenListener(
+    appCheckInstance.app,
+    (appCheckInstance as AppCheckService).platformLoggerProvider,
+    nextFn,
+    errorFn
+  );
+  return () => removeTokenListener(appCheckInstance.app, nextFn);
 }

--- a/packages-exp/app-check-exp/src/api.ts
+++ b/packages-exp/app-check-exp/src/api.ts
@@ -231,7 +231,7 @@ export function onTokenChanged(
   }
   addTokenListener(
     appCheckInstance as AppCheckService,
-    ListenerType['3P'],
+    ListenerType.EXTERNAL,
     nextFn,
     errorFn
   );

--- a/packages-exp/app-check-exp/src/factory.ts
+++ b/packages-exp/app-check-exp/src/factory.ts
@@ -16,7 +16,7 @@
  */
 
 import { AppCheck } from './public-types';
-import { FirebaseApp, _FirebaseService } from '@firebase/app-exp';
+import { FirebaseApp, _FirebaseService, _getProvider } from '@firebase/app-exp';
 import { FirebaseAppCheckInternal } from './types';
 import {
   getToken,
@@ -29,7 +29,11 @@ import { Provider } from '@firebase/component';
  * AppCheck Service class.
  */
 export class AppCheckService implements AppCheck, _FirebaseService {
-  constructor(public app: FirebaseApp) {}
+  platformLoggerProvider: Provider<'platform-logger'>;
+
+  constructor(public app: FirebaseApp) {
+    this.platformLoggerProvider = _getProvider(app, 'platform-logger');
+  }
   _delete(): Promise<void> {
     return Promise.resolve();
   }

--- a/packages-exp/app-check-exp/src/factory.ts
+++ b/packages-exp/app-check-exp/src/factory.ts
@@ -16,8 +16,8 @@
  */
 
 import { AppCheck } from './public-types';
-import { FirebaseApp, _FirebaseService, _getProvider } from '@firebase/app-exp';
-import { FirebaseAppCheckInternal } from './types';
+import { FirebaseApp, _FirebaseService } from '@firebase/app-exp';
+import { FirebaseAppCheckInternal, ListenerType } from './types';
 import {
   getToken,
   addTokenListener,
@@ -29,29 +29,29 @@ import { Provider } from '@firebase/component';
  * AppCheck Service class.
  */
 export class AppCheckService implements AppCheck, _FirebaseService {
-  platformLoggerProvider: Provider<'platform-logger'>;
-
-  constructor(public app: FirebaseApp) {
-    this.platformLoggerProvider = _getProvider(app, 'platform-logger');
-  }
+  constructor(
+    public app: FirebaseApp,
+    public platformLoggerProvider: Provider<'platform-logger'>
+  ) {}
   _delete(): Promise<void> {
     return Promise.resolve();
   }
 }
 
-export function factory(app: FirebaseApp): AppCheckService {
-  return new AppCheckService(app);
+export function factory(
+  app: FirebaseApp,
+  platformLoggerProvider: Provider<'platform-logger'>
+): AppCheckService {
+  return new AppCheckService(app, platformLoggerProvider);
 }
 
 export function internalFactory(
-  app: FirebaseApp,
-  platformLoggerProvider: Provider<'platform-logger'>
+  appCheck: AppCheckService
 ): FirebaseAppCheckInternal {
   return {
-    getToken: forceRefresh =>
-      getToken(app, platformLoggerProvider, forceRefresh),
+    getToken: forceRefresh => getToken(appCheck, forceRefresh),
     addTokenListener: listener =>
-      addTokenListener(app, platformLoggerProvider, listener),
-    removeTokenListener: listener => removeTokenListener(app, listener)
+      addTokenListener(appCheck, ListenerType['2P'], listener),
+    removeTokenListener: listener => removeTokenListener(appCheck.app, listener)
   };
 }

--- a/packages-exp/app-check-exp/src/factory.ts
+++ b/packages-exp/app-check-exp/src/factory.ts
@@ -51,7 +51,7 @@ export function internalFactory(
   return {
     getToken: forceRefresh => getToken(appCheck, forceRefresh),
     addTokenListener: listener =>
-      addTokenListener(appCheck, ListenerType['2P'], listener),
+      addTokenListener(appCheck, ListenerType.INTERNAL, listener),
     removeTokenListener: listener => removeTokenListener(appCheck.app, listener)
   };
 }

--- a/packages-exp/app-check-exp/src/index.ts
+++ b/packages-exp/app-check-exp/src/index.ts
@@ -39,7 +39,8 @@ function registerAppCheck(): void {
       container => {
         // getImmediate for FirebaseApp will always succeed
         const app = container.getProvider('app-exp').getImmediate();
-        return factory(app);
+        const platformLoggerProvider = container.getProvider('platform-logger');
+        return factory(app, platformLoggerProvider);
       },
       ComponentType.PUBLIC
     )
@@ -50,10 +51,8 @@ function registerAppCheck(): void {
     new Component(
       APP_CHECK_NAME_INTERNAL,
       container => {
-        // getImmediate for FirebaseApp will always succeed
-        const app = container.getProvider('app-exp').getImmediate();
-        const platformLoggerProvider = container.getProvider('platform-logger');
-        return internalFactory(app, platformLoggerProvider);
+        const appCheck = container.getProvider('app-check-exp').getImmediate();
+        return internalFactory(appCheck);
       },
       ComponentType.PUBLIC
     )

--- a/packages-exp/app-check-exp/src/internal-api.test.ts
+++ b/packages-exp/app-check-exp/src/internal-api.test.ts
@@ -23,7 +23,6 @@ import {
   FAKE_SITE_KEY,
   getFullApp,
   getFakeCustomTokenProvider,
-  getFakePlatformLoggingProvider,
   removegreCAPTCHAScriptsOnPage,
   getFakeGreCAPTCHA
 } from '../test/util';
@@ -43,8 +42,9 @@ import { getState, clearState, setState, getDebugState } from './state';
 import { AppCheckTokenListener } from './public-types';
 import { Deferred } from '@firebase/util';
 import { ReCaptchaV3Provider } from './providers';
+import { AppCheckService } from './factory';
+import { ListenerType } from './types';
 
-const fakePlatformLoggingProvider = getFakePlatformLoggingProvider();
 const fakeRecaptchaToken = 'fake-recaptcha-token';
 const fakeRecaptchaAppCheckToken = {
   token: 'fake-recaptcha-app-check-token',
@@ -81,8 +81,10 @@ describe('internal api', () => {
       const customTokenProvider = getFakeCustomTokenProvider();
       const customProviderSpy = spy(customTokenProvider, 'getToken');
 
-      initializeAppCheck(app, { provider: customTokenProvider });
-      const token = await getToken(app, fakePlatformLoggingProvider);
+      const appCheck = initializeAppCheck(app, {
+        provider: customTokenProvider
+      });
+      const token = await getToken(appCheck as AppCheckService);
 
       expect(customProviderSpy).to.be.called;
       expect(token).to.deep.equal({
@@ -91,7 +93,7 @@ describe('internal api', () => {
     });
 
     it('uses reCAPTCHA token to exchange for AppCheck token', async () => {
-      initializeAppCheck(app, {
+      const appCheck = initializeAppCheck(app, {
         provider: new ReCaptchaV3Provider(FAKE_SITE_KEY)
       });
 
@@ -103,7 +105,7 @@ describe('internal api', () => {
         'exchangeToken'
       ).returns(Promise.resolve(fakeRecaptchaAppCheckToken));
 
-      const token = await getToken(app, fakePlatformLoggingProvider);
+      const token = await getToken(appCheck as AppCheckService);
 
       expect(reCAPTCHASpy).to.be.called;
 
@@ -119,7 +121,7 @@ describe('internal api', () => {
 
     it('resolves with a dummy token and an error if failed to get a token', async () => {
       const errorStub = stub(console, 'error');
-      initializeAppCheck(app, {
+      const appCheck = initializeAppCheck(app, {
         provider: new ReCaptchaV3Provider(FAKE_SITE_KEY)
       });
 
@@ -130,7 +132,7 @@ describe('internal api', () => {
       const error = new Error('oops, something went wrong');
       stub(client, 'exchangeToken').returns(Promise.reject(error));
 
-      const token = await getToken(app, fakePlatformLoggingProvider);
+      const token = await getToken(appCheck as AppCheckService);
 
       expect(reCAPTCHASpy).to.be.called;
       expect(token).to.deep.equal({
@@ -144,7 +146,7 @@ describe('internal api', () => {
     });
 
     it('notifies listeners using cached token', async () => {
-      initializeAppCheck(app, {
+      const appCheck = initializeAppCheck(app, {
         provider: new ReCaptchaV3Provider(FAKE_SITE_KEY),
         isTokenAutoRefreshEnabled: true
       });
@@ -154,10 +156,18 @@ describe('internal api', () => {
 
       const listener1 = spy();
       const listener2 = spy();
-      addTokenListener(app, fakePlatformLoggingProvider, listener1);
-      addTokenListener(app, fakePlatformLoggingProvider, listener2);
+      addTokenListener(
+        appCheck as AppCheckService,
+        ListenerType['2P'],
+        listener1
+      );
+      addTokenListener(
+        appCheck as AppCheckService,
+        ListenerType['2P'],
+        listener2
+      );
 
-      await getToken(app, fakePlatformLoggingProvider);
+      await getToken(appCheck as AppCheckService);
 
       clock.tick(1);
 
@@ -172,7 +182,7 @@ describe('internal api', () => {
     });
 
     it('notifies listeners using new token', async () => {
-      initializeAppCheck(app, {
+      const appCheck = initializeAppCheck(app, {
         provider: new ReCaptchaV3Provider(FAKE_SITE_KEY),
         isTokenAutoRefreshEnabled: true
       });
@@ -184,10 +194,18 @@ describe('internal api', () => {
 
       const listener1 = spy();
       const listener2 = spy();
-      addTokenListener(app, fakePlatformLoggingProvider, listener1);
-      addTokenListener(app, fakePlatformLoggingProvider, listener2);
+      addTokenListener(
+        appCheck as AppCheckService,
+        ListenerType['2P'],
+        listener1
+      );
+      addTokenListener(
+        appCheck as AppCheckService,
+        ListenerType['2P'],
+        listener2
+      );
 
-      await getToken(app, fakePlatformLoggingProvider);
+      await getToken(appCheck as AppCheckService);
 
       expect(listener1).to.be.calledWith({
         token: fakeRecaptchaAppCheckToken.token
@@ -198,7 +216,7 @@ describe('internal api', () => {
     });
 
     it('calls optional error handler if there is an error getting a token', async () => {
-      initializeAppCheck(app, {
+      const appCheck = initializeAppCheck(app, {
         provider: new ReCaptchaV3Provider(FAKE_SITE_KEY),
         isTokenAutoRefreshEnabled: true
       });
@@ -207,16 +225,21 @@ describe('internal api', () => {
       const listener1 = spy();
       const errorFn1 = spy();
 
-      addTokenListener(app, fakePlatformLoggingProvider, listener1, errorFn1);
+      addTokenListener(
+        appCheck as AppCheckService,
+        ListenerType['2P'],
+        listener1,
+        errorFn1
+      );
 
-      await getToken(app, fakePlatformLoggingProvider);
+      await getToken(appCheck as AppCheckService);
 
       expect(errorFn1).to.be.calledOnce;
       expect(errorFn1.args[0][0].name).to.include('exchange error');
     });
 
     it('ignores listeners that throw', async () => {
-      initializeAppCheck(app, {
+      const appCheck = initializeAppCheck(app, {
         provider: new ReCaptchaV3Provider(FAKE_SITE_KEY),
         isTokenAutoRefreshEnabled: true
       });
@@ -229,10 +252,18 @@ describe('internal api', () => {
       };
       const listener2 = spy();
 
-      addTokenListener(app, fakePlatformLoggingProvider, listener1);
-      addTokenListener(app, fakePlatformLoggingProvider, listener2);
+      addTokenListener(
+        appCheck as AppCheckService,
+        ListenerType['2P'],
+        listener1
+      );
+      addTokenListener(
+        appCheck as AppCheckService,
+        ListenerType['2P'],
+        listener2
+      );
 
-      await getToken(app, fakePlatformLoggingProvider);
+      await getToken(appCheck as AppCheckService);
 
       expect(listener2).to.be.calledWith({
         token: fakeRecaptchaAppCheckToken.token
@@ -241,7 +272,7 @@ describe('internal api', () => {
 
     it('loads persisted token to memory and returns it', async () => {
       const clock = useFakeTimers();
-      initializeAppCheck(app, {
+      const appCheck = initializeAppCheck(app, {
         provider: new ReCaptchaV3Provider(FAKE_SITE_KEY)
       });
 
@@ -250,7 +281,7 @@ describe('internal api', () => {
       const clientStub = stub(client, 'exchangeToken');
 
       expect(getState(app).token).to.equal(undefined);
-      expect(await getToken(app, fakePlatformLoggingProvider)).to.deep.equal({
+      expect(await getToken(appCheck as AppCheckService)).to.deep.equal({
         token: fakeCachedAppCheckToken.token
       });
       expect(getState(app).token).to.equal(fakeCachedAppCheckToken);
@@ -260,7 +291,7 @@ describe('internal api', () => {
     });
 
     it('persists token to storage', async () => {
-      initializeAppCheck(app, {
+      const appCheck = initializeAppCheck(app, {
         provider: new ReCaptchaV3Provider(FAKE_SITE_KEY)
       });
 
@@ -269,7 +300,7 @@ describe('internal api', () => {
         Promise.resolve(fakeRecaptchaAppCheckToken)
       );
       storageWriteStub.resetHistory();
-      const result = await getToken(app, fakePlatformLoggingProvider);
+      const result = await getToken(appCheck as AppCheckService);
       expect(result).to.deep.equal({ token: fakeRecaptchaAppCheckToken.token });
       expect(storageWriteStub).has.been.calledWith(
         app,
@@ -279,13 +310,13 @@ describe('internal api', () => {
 
     it('returns the valid token in memory without making network request', async () => {
       const clock = useFakeTimers();
-      initializeAppCheck(app, {
+      const appCheck = initializeAppCheck(app, {
         provider: new ReCaptchaV3Provider(FAKE_SITE_KEY)
       });
       setState(app, { ...getState(app), token: fakeRecaptchaAppCheckToken });
 
       const clientStub = stub(client, 'exchangeToken');
-      expect(await getToken(app, fakePlatformLoggingProvider)).to.deep.equal({
+      expect(await getToken(appCheck as AppCheckService)).to.deep.equal({
         token: fakeRecaptchaAppCheckToken.token
       });
       expect(clientStub).to.not.have.been.called;
@@ -294,7 +325,7 @@ describe('internal api', () => {
     });
 
     it('force to get new token when forceRefresh is true', async () => {
-      initializeAppCheck(app, {
+      const appCheck = initializeAppCheck(app, {
         provider: new ReCaptchaV3Provider(FAKE_SITE_KEY)
       });
       setState(app, { ...getState(app), token: fakeRecaptchaAppCheckToken });
@@ -308,9 +339,7 @@ describe('internal api', () => {
         })
       );
 
-      expect(
-        await getToken(app, fakePlatformLoggingProvider, true)
-      ).to.deep.equal({
+      expect(await getToken(appCheck as AppCheckService, true)).to.deep.equal({
         token: 'new-recaptcha-app-check-token'
       });
     });
@@ -324,11 +353,11 @@ describe('internal api', () => {
       debugState.enabled = true;
       debugState.token = new Deferred();
       debugState.token.resolve('my-debug-token');
-      initializeAppCheck(app, {
+      const appCheck = initializeAppCheck(app, {
         provider: new ReCaptchaV3Provider(FAKE_SITE_KEY)
       });
 
-      const token = await getToken(app, fakePlatformLoggingProvider);
+      const token = await getToken(appCheck as AppCheckService);
       expect(exchangeTokenStub.args[0][0].body['debug_token']).to.equal(
         'my-debug-token'
       );
@@ -340,7 +369,11 @@ describe('internal api', () => {
     it('adds token listeners', () => {
       const listener = (): void => {};
 
-      addTokenListener(app, fakePlatformLoggingProvider, listener);
+      addTokenListener(
+        { app } as AppCheckService,
+        ListenerType['2P'],
+        listener
+      );
 
       expect(getState(app).tokenObservers[0].next).to.equal(listener);
     });
@@ -351,7 +384,11 @@ describe('internal api', () => {
       expect(getState(app).tokenObservers.length).to.equal(0);
       expect(getState(app).tokenRefresher).to.equal(undefined);
 
-      addTokenListener(app, fakePlatformLoggingProvider, listener);
+      addTokenListener(
+        { app } as AppCheckService,
+        ListenerType['2P'],
+        listener
+      );
 
       expect(getState(app).tokenRefresher?.isRunning()).to.be.true;
     });
@@ -375,12 +412,16 @@ describe('internal api', () => {
         }
       });
 
-      addTokenListener(app, fakePlatformLoggingProvider, fakeListener);
+      addTokenListener(
+        { app } as AppCheckService,
+        ListenerType['2P'],
+        fakeListener
+      );
     });
 
     it('notifies the listener with the valid token in storage', done => {
       const clock = useFakeTimers();
-      initializeAppCheck(app, {
+      const appCheck = initializeAppCheck(app, {
         provider: new ReCaptchaV3Provider(FAKE_SITE_KEY),
         isTokenAutoRefreshEnabled: true
       });
@@ -400,7 +441,11 @@ describe('internal api', () => {
         done();
       };
 
-      addTokenListener(app, fakePlatformLoggingProvider, fakeListener);
+      addTokenListener(
+        appCheck as AppCheckService,
+        ListenerType['2P'],
+        fakeListener
+      );
 
       clock.tick(1);
     });
@@ -418,10 +463,14 @@ describe('internal api', () => {
       debugState.token = new Deferred();
       debugState.token.resolve('my-debug-token');
 
-      initializeAppCheck(app, {
+      const appCheck = initializeAppCheck(app, {
         provider: new ReCaptchaV3Provider(FAKE_SITE_KEY)
       });
-      addTokenListener(app, fakePlatformLoggingProvider, fakeListener);
+      addTokenListener(
+        appCheck as AppCheckService,
+        ListenerType['2P'],
+        fakeListener
+      );
     });
 
     it('does NOT start token refresher in debug mode', () => {
@@ -430,10 +479,14 @@ describe('internal api', () => {
       debugState.token = new Deferred();
       debugState.token.resolve('my-debug-token');
 
-      initializeAppCheck(app, {
+      const appCheck = initializeAppCheck(app, {
         provider: new ReCaptchaV3Provider(FAKE_SITE_KEY)
       });
-      addTokenListener(app, fakePlatformLoggingProvider, () => {});
+      addTokenListener(
+        appCheck as AppCheckService,
+        ListenerType['2P'],
+        () => {}
+      );
 
       const state = getState(app);
       expect(state.tokenRefresher).is.undefined;
@@ -443,7 +496,11 @@ describe('internal api', () => {
   describe('removeTokenListener', () => {
     it('should remove token listeners', () => {
       const listener = (): void => {};
-      addTokenListener(app, fakePlatformLoggingProvider, listener);
+      addTokenListener(
+        { app } as AppCheckService,
+        ListenerType['2P'],
+        listener
+      );
       expect(getState(app).tokenObservers.length).to.equal(1);
 
       removeTokenListener(app, listener);
@@ -454,7 +511,11 @@ describe('internal api', () => {
       const listener = (): void => {};
       setState(app, { ...getState(app), isTokenAutoRefreshEnabled: true });
 
-      addTokenListener(app, fakePlatformLoggingProvider, listener);
+      addTokenListener(
+        { app } as AppCheckService,
+        ListenerType['2P'],
+        listener
+      );
       expect(getState(app).tokenObservers.length).to.equal(1);
       expect(getState(app).tokenRefresher?.isRunning()).to.be.true;
 

--- a/packages-exp/app-check-exp/src/internal-api.test.ts
+++ b/packages-exp/app-check-exp/src/internal-api.test.ts
@@ -158,12 +158,12 @@ describe('internal api', () => {
       const listener2 = spy();
       addTokenListener(
         appCheck as AppCheckService,
-        ListenerType['2P'],
+        ListenerType.INTERNAL,
         listener1
       );
       addTokenListener(
         appCheck as AppCheckService,
-        ListenerType['2P'],
+        ListenerType.INTERNAL,
         listener2
       );
 
@@ -196,12 +196,12 @@ describe('internal api', () => {
       const listener2 = spy();
       addTokenListener(
         appCheck as AppCheckService,
-        ListenerType['2P'],
+        ListenerType.INTERNAL,
         listener1
       );
       addTokenListener(
         appCheck as AppCheckService,
-        ListenerType['2P'],
+        ListenerType.INTERNAL,
         listener2
       );
 
@@ -227,7 +227,7 @@ describe('internal api', () => {
 
       addTokenListener(
         appCheck as AppCheckService,
-        ListenerType['3P'],
+        ListenerType.EXTERNAL,
         listener1,
         errorFn1
       );
@@ -254,12 +254,12 @@ describe('internal api', () => {
 
       addTokenListener(
         appCheck as AppCheckService,
-        ListenerType['2P'],
+        ListenerType.INTERNAL,
         listener1
       );
       addTokenListener(
         appCheck as AppCheckService,
-        ListenerType['2P'],
+        ListenerType.INTERNAL,
         listener2
       );
 
@@ -371,7 +371,7 @@ describe('internal api', () => {
 
       addTokenListener(
         { app } as AppCheckService,
-        ListenerType['2P'],
+        ListenerType.INTERNAL,
         listener
       );
 
@@ -386,7 +386,7 @@ describe('internal api', () => {
 
       addTokenListener(
         { app } as AppCheckService,
-        ListenerType['2P'],
+        ListenerType.INTERNAL,
         listener
       );
 
@@ -414,7 +414,7 @@ describe('internal api', () => {
 
       addTokenListener(
         { app } as AppCheckService,
-        ListenerType['2P'],
+        ListenerType.INTERNAL,
         fakeListener
       );
     });
@@ -443,7 +443,7 @@ describe('internal api', () => {
 
       addTokenListener(
         appCheck as AppCheckService,
-        ListenerType['2P'],
+        ListenerType.INTERNAL,
         fakeListener
       );
 
@@ -468,7 +468,7 @@ describe('internal api', () => {
       });
       addTokenListener(
         appCheck as AppCheckService,
-        ListenerType['2P'],
+        ListenerType.INTERNAL,
         fakeListener
       );
     });
@@ -484,7 +484,7 @@ describe('internal api', () => {
       });
       addTokenListener(
         appCheck as AppCheckService,
-        ListenerType['2P'],
+        ListenerType.INTERNAL,
         () => {}
       );
 
@@ -498,7 +498,7 @@ describe('internal api', () => {
       const listener = (): void => {};
       addTokenListener(
         { app } as AppCheckService,
-        ListenerType['2P'],
+        ListenerType.INTERNAL,
         listener
       );
       expect(getState(app).tokenObservers.length).to.equal(1);
@@ -513,7 +513,7 @@ describe('internal api', () => {
 
       addTokenListener(
         { app } as AppCheckService,
-        ListenerType['2P'],
+        ListenerType.INTERNAL,
         listener
       );
       expect(getState(app).tokenObservers.length).to.equal(1);

--- a/packages-exp/app-check-exp/src/internal-api.test.ts
+++ b/packages-exp/app-check-exp/src/internal-api.test.ts
@@ -215,7 +215,7 @@ describe('internal api', () => {
       });
     });
 
-    it('calls optional error handler if there is an error getting a token', async () => {
+    it('calls 3P error handler if there is an error getting a token', async () => {
       const appCheck = initializeAppCheck(app, {
         provider: new ReCaptchaV3Provider(FAKE_SITE_KEY),
         isTokenAutoRefreshEnabled: true
@@ -227,7 +227,7 @@ describe('internal api', () => {
 
       addTokenListener(
         appCheck as AppCheckService,
-        ListenerType['2P'],
+        ListenerType['3P'],
         listener1,
         errorFn1
       );

--- a/packages-exp/app-check-exp/src/internal-api.ts
+++ b/packages-exp/app-check-exp/src/internal-api.ts
@@ -284,7 +284,7 @@ function notifyTokenListeners(
 
   for (const observer of observers) {
     try {
-      if (observer.type === ListenerType['3P'] && token.error != null) {
+      if (observer.type === ListenerType.EXTERNAL && token.error != null) {
         // If this listener was added by a 3P call, send any token error to
         // the supplied error handler. A 3P observer always has an error
         // handler.

--- a/packages-exp/app-check-exp/src/internal-api.ts
+++ b/packages-exp/app-check-exp/src/internal-api.ts
@@ -284,24 +284,19 @@ function notifyTokenListeners(
 
   for (const observer of observers) {
     try {
-      if (observer.error) {
-        // If this listener has an error handler, handle errors differently
-        // from successes.
-        if (token.error) {
-          observer.error(token.error);
-        } else {
-          observer.next(token);
-        }
+      if (observer.type === ListenerType['3P'] && token.error != null) {
+        // If this listener was added by a 3P call, send any token error to
+        // the supplied error handler. A 3P observer always has an error
+        // handler.
+        observer.error!(token.error);
       } else {
+        // If the token has no error field, always return the token.
         // If this is a 2P listener, return the token, whether or not it
-        // has an error field. If it is a 3P listener with no error handler,
-        // ignore the error.
-        if (observer.type === ListenerType['2P']) {
-          observer.next(token);
-        }
+        // has an error field.
+        observer.next(token);
       }
     } catch (e) {
-      // If any handler fails, ignore and run next handler.
+      // Errors in the listener function itself are always ignored.
     }
   }
 }

--- a/packages-exp/app-check-exp/src/public-types.ts
+++ b/packages-exp/app-check-exp/src/public-types.ts
@@ -73,3 +73,20 @@ export interface CustomProviderOptions {
    */
   getToken: () => Promise<AppCheckToken>;
 }
+
+/**
+ * Result returned by `getToken()`.
+ * @public
+ */
+export interface AppCheckTokenResult {
+  /**
+   * The token string in JWT format.
+   */
+  readonly token: string;
+}
+
+/**
+ * A listener that is called whenever the App Check token changes.
+ * @public
+ */
+export type AppCheckTokenListener = (token: AppCheckTokenResult) => void;

--- a/packages-exp/app-check-exp/src/state.ts
+++ b/packages-exp/app-check-exp/src/state.ts
@@ -19,14 +19,14 @@ import { FirebaseApp } from '@firebase/app-exp';
 import {
   AppCheckProvider,
   AppCheckTokenInternal,
-  AppCheckTokenListener
+  AppCheckTokenObserver
 } from './types';
 import { Refresher } from './proactive-refresh';
 import { Deferred } from '@firebase/util';
 import { GreCAPTCHA } from './recaptcha';
 export interface AppCheckState {
   activated: boolean;
-  tokenListeners: AppCheckTokenListener[];
+  tokenObservers: AppCheckTokenObserver[];
   provider?: AppCheckProvider;
   token?: AppCheckTokenInternal;
   tokenRefresher?: Refresher;
@@ -47,7 +47,7 @@ export interface DebugState {
 const APP_CHECK_STATES = new Map<FirebaseApp, AppCheckState>();
 export const DEFAULT_STATE: AppCheckState = {
   activated: false,
-  tokenListeners: []
+  tokenObservers: []
 };
 
 const DEBUG_STATE: DebugState = {

--- a/packages-exp/app-check-exp/src/types.ts
+++ b/packages-exp/app-check-exp/src/types.ts
@@ -38,6 +38,12 @@ export interface AppCheckTokenObserver
   extends PartialObserver<AppCheckTokenResult> {
   // required
   next: AppCheckTokenListener;
+  type: ListenerType;
+}
+
+export enum ListenerType {
+  '2P' = '2P',
+  '3P' = '3P'
 }
 
 // If the error field is defined, the token field will be populated with a dummy token

--- a/packages-exp/app-check-exp/src/types.ts
+++ b/packages-exp/app-check-exp/src/types.ts
@@ -42,8 +42,10 @@ export interface AppCheckTokenObserver
 }
 
 export const enum ListenerType {
-  '2P' = '2P',
-  '3P' = '3P'
+  // Listener added by a 2P library.
+  'INTERNAL' = 'INTERNAL',
+  // Listener added by users using the public API.
+  'EXTERNAL' = 'EXTERNAL'
 }
 
 // If the error field is defined, the token field will be populated with a dummy token

--- a/packages-exp/app-check-exp/src/types.ts
+++ b/packages-exp/app-check-exp/src/types.ts
@@ -16,7 +16,8 @@
  */
 
 import { FirebaseApp } from '@firebase/app-exp';
-import { AppCheckToken } from './public-types';
+import { PartialObserver } from '@firebase/util';
+import { AppCheckToken, AppCheckTokenListener } from './public-types';
 
 export interface FirebaseAppCheckInternal {
   // Get the current AttestationToken. Attaches to the most recent in-flight request if one
@@ -33,7 +34,11 @@ export interface FirebaseAppCheckInternal {
   removeTokenListener(listener: AppCheckTokenListener): void;
 }
 
-export type AppCheckTokenListener = (token: AppCheckTokenResult) => void;
+export interface AppCheckTokenObserver
+  extends PartialObserver<AppCheckTokenResult> {
+  // required
+  next: AppCheckTokenListener;
+}
 
 // If the error field is defined, the token field will be populated with a dummy token
 export interface AppCheckTokenResult {

--- a/packages-exp/app-check-exp/src/types.ts
+++ b/packages-exp/app-check-exp/src/types.ts
@@ -41,7 +41,7 @@ export interface AppCheckTokenObserver
   type: ListenerType;
 }
 
-export enum ListenerType {
+export const enum ListenerType {
   '2P' = '2P',
   '3P' = '3P'
 }

--- a/packages-exp/app-check-exp/test/util.ts
+++ b/packages-exp/app-check-exp/test/util.ts
@@ -29,7 +29,7 @@ import {
 } from '@firebase/component';
 import { PlatformLoggerService } from '@firebase/app-exp/dist/packages-exp/app-exp/src/types';
 import { AppCheckService } from '../src/factory';
-import { CustomProvider } from '../src';
+import { AppCheck, CustomProvider } from '../src';
 
 export const FAKE_SITE_KEY = 'fake-site-key';
 
@@ -50,6 +50,13 @@ export function getFakeApp(overrides: Record<string, any> = {}): FirebaseApp {
     automaticDataCollectionEnabled: true,
     ...overrides
   };
+}
+
+export function getFakeAppCheck(app: FirebaseApp): AppCheck {
+  return {
+    app,
+    platformLoggerProvider: getFakePlatformLoggingProvider()
+  } as AppCheck;
 }
 
 export function getFullApp(): FirebaseApp {

--- a/packages-exp/app-check-exp/tsconfig.json
+++ b/packages-exp/app-check-exp/tsconfig.json
@@ -2,8 +2,7 @@
   "extends": "../../config/tsconfig.base.json",
   "compilerOptions": {
     "outDir": "dist",
-    "strict": true,
-    "preserveConstEnums": true
+    "strict": true
   },
   "exclude": ["dist/**/*"]
 }

--- a/packages-exp/app-check-exp/tsconfig.json
+++ b/packages-exp/app-check-exp/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../../config/tsconfig.base.json",
   "compilerOptions": {
     "outDir": "dist",
-    "strict": true
+    "strict": true,
+    "preserveConstEnums": true
   },
   "exclude": ["dist/**/*"]
 }


### PR DESCRIPTION
Porting 3P token APIs that were added to v8 (non-modular) API in https://github.com/firebase/firebase-js-sdk/pull/5033

Also added some test reliability improvements.