### PR TITLE
Add firebase-specific screen_view params to Analytics

### DIFF
--- a/.changeset/nasty-hats-hope.md
+++ b/.changeset/nasty-hats-hope.md
@@ -1,0 +1,6 @@
+---
+'@firebase/analytics-types': minor
+'firebase': minor
+---
+
+Add `firebase_screen` and `firebase_screen_class` to `logEvent()` overload for `screen_view` events.

--- a/common/api-review/analytics-exp.api.md
+++ b/common/api-review/analytics-exp.api.md
@@ -74,6 +74,8 @@ export interface EventParams {
     event_label?: string;
     // (undocumented)
     fatal?: boolean;
+    firebase_screen?: string;
+    firebase_screen_class?: string;
     // (undocumented)
     item_list_id?: string;
     // (undocumented)
@@ -295,6 +297,8 @@ export function logEvent(analyticsInstance: Analytics, eventName: 'purchase' | '
 export function logEvent(analyticsInstance: Analytics, eventName: 'screen_view', eventParams?: {
     app_name: string;
     screen_name: EventParams['screen_name'];
+    firebase_screen: EventParams['firebase_screen'];
+    firebase_screen_class: EventParams['firebase_screen_class'];
     app_id?: string;
     app_version?: string;
     app_installer_id?: string;

--- a/packages-exp/analytics-exp/src/api.ts
+++ b/packages-exp/analytics-exp/src/api.ts
@@ -450,6 +450,8 @@ export function logEvent(
   eventParams?: {
     app_name: string;
     screen_name: EventParams['screen_name'];
+    firebase_screen: EventParams['firebase_screen'];
+    firebase_screen_class: EventParams['firebase_screen_class'];
     app_id?: string;
     app_version?: string;
     app_installer_id?: string;

--- a/packages-exp/analytics-exp/src/public-types.ts
+++ b/packages-exp/analytics-exp/src/public-types.ts
@@ -280,11 +280,11 @@ export interface EventParams {
   promotions?: Promotion[];
   screen_name?: string;
   /**
-   * Firebase-specific. Use to log a screen_name to Firebase Analytics.
+   * Firebase-specific. Use to log a `screen_name` to Firebase Analytics.
    */
   firebase_screen?: string;
   /**
-   * Firebase-specific. Use to log a screen_class to Firebase Analytics.
+   * Firebase-specific. Use to log a `screen_class` to Firebase Analytics.
    */
   firebase_screen_class?: string;
   search_term?: string;

--- a/packages-exp/analytics-exp/src/public-types.ts
+++ b/packages-exp/analytics-exp/src/public-types.ts
@@ -279,6 +279,14 @@ export interface EventParams {
   number?: string;
   promotions?: Promotion[];
   screen_name?: string;
+  /**
+   * Firebase-specific. Use to log a screen_name to Firebase Analytics.
+   */
+  firebase_screen?: string;
+  /**
+   * Firebase-specific. Use to log a screen_class to Firebase Analytics.
+   */
+  firebase_screen_class?: string;
   search_term?: string;
   shipping?: Currency;
   tax?: Currency;

--- a/packages/analytics-types/index.d.ts
+++ b/packages/analytics-types/index.d.ts
@@ -549,11 +549,11 @@ export interface EventParams {
   promotions?: Promotion[];
   screen_name?: string;
   /**
-   * Firebase-specific. Use to log a screen_name to Firebase Analytics.
+   * Firebase-specific. Use to log a `screen_name` to Firebase Analytics.
    */
   firebase_screen?: string;
   /**
-   * Firebase-specific. Use to log a screen_class to Firebase Analytics.
+   * Firebase-specific. Use to log a `screen_class` to Firebase Analytics.
    */
   firebase_screen_class?: string;
   search_term?: string;

--- a/packages/analytics-types/index.d.ts
+++ b/packages/analytics-types/index.d.ts
@@ -249,6 +249,8 @@ export interface FirebaseAnalytics {
     eventParams?: {
       app_name: string;
       screen_name: EventParams['screen_name'];
+      firebase_screen: EventParams['firebase_screen'];
+      firebase_screen_class: EventParams['firebase_screen_class'];
       app_id?: string;
       app_version?: string;
       app_installer_id?: string;
@@ -546,6 +548,14 @@ export interface EventParams {
   number?: string;
   promotions?: Promotion[];
   screen_name?: string;
+  /**
+   * Firebase-specific. Use to log a screen_name to Firebase Analytics.
+   */
+  firebase_screen?: string;
+  /**
+   * Firebase-specific. Use to log a screen_class to Firebase Analytics.
+   */
+  firebase_screen_class?: string;
   search_term?: string;
   shipping?: Currency;
   tax?: Currency;

--- a/packages/firebase/index.d.ts
+++ b/packages/firebase/index.d.ts
@@ -4858,6 +4858,8 @@ declare namespace firebase.analytics {
       eventParams?: {
         app_name: string;
         screen_name: EventParams['screen_name'];
+        firebase_screen: EventParams['firebase_screen'];
+        firebase_screen_class: EventParams['firebase_screen_class'];
         app_id?: string;
         app_version?: string;
         app_installer_id?: string;
@@ -5166,6 +5168,14 @@ declare namespace firebase.analytics {
     number?: string;
     promotions?: Promotion[];
     screen_name?: string;
+    /**
+     * Firebase-specific. Use to log a screen_name to Firebase Analytics.
+     */
+    firebase_screen?: string;
+    /**
+     * Firebase-specific. Use to log a screen_class to Firebase Analytics.
+     */
+    firebase_screen_class?: string;
     search_term?: string;
     shipping?: Currency;
     tax?: Currency;

--- a/packages/firebase/index.d.ts
+++ b/packages/firebase/index.d.ts
@@ -5169,11 +5169,11 @@ declare namespace firebase.analytics {
     promotions?: Promotion[];
     screen_name?: string;
     /**
-     * Firebase-specific. Use to log a screen_name to Firebase Analytics.
+     * Firebase-specific. Use to log a `screen_name` to Firebase Analytics.
      */
     firebase_screen?: string;
     /**
-     * Firebase-specific. Use to log a screen_class to Firebase Analytics.
+     * Firebase-specific. Use to log a `screen_class` to Firebase Analytics.
      */
     firebase_screen_class?: string;
     search_term?: string;


### PR DESCRIPTION
Add `firebase_screen` and `firebase_screen_class` to `EventParams` type and put them in the `logEvent('screen_view', ...)` overload. This should only affect autocomplete and type checking. Adding this to the "guides" in the docs site is also in progress.

This change is for both exp and non-modular.

API proposal: go/firebase-js-screen-view