### PR TITLE
auto-init auth-internal after initializing auth

### DIFF
--- a/.changeset/sixty-masks-wash.md
+++ b/.changeset/sixty-masks-wash.md
@@ -1,0 +1,6 @@
+---
+"@firebase/auth": patch
+"@firebase/component": patch
+---
+
+Auto initialize `auth-internal` after `auth` has been initialized.

--- a/packages/auth/src/exports_auth.js
+++ b/packages/auth/src/exports_auth.js
@@ -761,7 +761,16 @@ fireauth.exportlib.exportFunction(
       'multipleInstances': false,
       'serviceProps': namespace,
       'instantiationMode': 'LAZY',
-      'type':  'PUBLIC'
+      'type':  'PUBLIC',
+      /**
+       * Initialize auth-internal after auth is initialized to make auth available to other firebase products.
+       */
+      'onInstanceCreated': function (container, _instanceIdentifier, _instance) {
+          const authInternalProvider = container['getProvider'](
+            'auth-internal'
+          );
+          authInternalProvider['initialize']();
+        }
     };
   
     // Provides Auth internal APIs.

--- a/packages/component/src/provider.ts
+++ b/packages/component/src/provider.ts
@@ -251,8 +251,6 @@ export class Provider<T extends Name> {
       }
     }
 
-    this.invokeOnInitCallbacks(instance, normalizedIdentifier);
-
     return instance;
   }
 
@@ -317,6 +315,13 @@ export class Provider<T extends Name> {
         options
       });
       this.instances.set(instanceIdentifier, instance);
+
+      /**
+       * Invoke onInit listeners.
+       * Note this.component.onInstanceCreated is different, which is used by the component creator,
+       * while onInit listeners are registered by consumers of the provider.
+       */
+      this.invokeOnInitCallbacks(instance, instanceIdentifier);
 
       /**
        * Order is important


### PR DESCRIPTION
Fixes https://github.com/firebase/firebase-js-sdk/issues/4932

Since Firestore doesn't call `authProvider.get()` to work with asynchronously loaded Auth anymore (changed to use `authProvider.onInit()` in v9 which is shared with v8), `auth-interal` needs to be proactively initialized after Auth has been initialized.

Note that it only affects v8, `auth-internal` is already initialized proactively in v9.