### PR TITLE
Always send our auth token on Node, and always send an appcheck token if we have one.

### DIFF
--- a/.changeset/silent-seals-approve.md
+++ b/.changeset/silent-seals-approve.md
@@ -2,4 +2,4 @@
 '@firebase/database': patch
 ---
 
-On node, always send auth and appcheck tokens when they are available.
+On Node, always send Auth and AppCheck tokens when they are available.

--- a/.changeset/silent-seals-approve.md
+++ b/.changeset/silent-seals-approve.md
@@ -1,0 +1,5 @@
+---
+'@firebase/database': patch
+---
+
+On node, always send auth and appcheck tokens when they are available.

--- a/packages/database/src/realtime/WebSocketConnection.ts
+++ b/packages/database/src/realtime/WebSocketConnection.ts
@@ -167,16 +167,15 @@ export class WebSocketConnection implements Transport {
         };
 
         // If using Node with admin creds, AppCheck-related checks are unnecessary.
-        // It will send the authorization token.
-        if (this.nodeAdmin) {
-          options.headers['Authorization'] = this.authToken || '';
-        } else {
-          // If using Node without admin creds (which includes all uses of the
-          // client-side Node SDK), it will send an AppCheck token if available.
-          // Any other auth credentials will eventually be sent after the connection
-          // is established, but aren't needed here as they don't effect the initial
-          // request to establish a connection.
-          options.headers['X-Firebase-AppCheck'] = this.appCheckToken || '';
+        // Note that we send the credentials here even if they aren't admin credentials, which is
+        // not a problem.
+        // Note that this header is just used to bypass appcheck, and the token should still be sent
+        // through the websocket connection once it is established.
+        if (this.authToken) {
+          options.headers['Authorization'] = this.authToken;
+        }
+        if (this.appCheckToken) {
+          options.headers['X-Firebase-AppCheck'] = this.appCheckToken;
         }
 
         // Plumb appropriate http_proxy environment variable into faye-websocket if it exists.
@@ -239,7 +238,7 @@ export class WebSocketConnection implements Transport {
   /**
    * No-op for websockets, we don't need to do anything once the connection is confirmed as open
    */
-  start() {}
+  start() { }
 
   static forceDisallow_: boolean;
 


### PR DESCRIPTION
`this.nodeAdmin` does not always appear to be set when it should be, which is breaking the admin SDK for users with appcheck enforced. This should be more robust, since we always send whatever credentials the client has.

Hey there! So you want to contribute to a Firebase SDK? 
Before you file this pull request, please read these guidelines:

### Discussion

  * Read the contribution guidelines (CONTRIBUTING.md).
  * If this has been discussed in an issue, make sure to link to the issue here. 
    If not, go file an issue about this **before creating a pull request** to discuss.

### Testing

  * Make sure all existing tests in the repository pass after your change.
  * If you fixed a bug or added a feature, add a new test to cover your code.

### API Changes

  * At this time we cannot accept changes that affect the public API.  If you'd like to help 
    us make Firebase APIs better, please propose your change in an issue so that we 
    can discuss it together.
