### PR TITLE
Fix app-check-compat initialization

### DIFF
--- a/packages-exp/app-check-compat/package.json
+++ b/packages-exp/app-check-compat/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@firebase/app-check-compat",
-  "version": "0.0.900-exp.f229f736f",
-  "private": false,
+  "version": "0.0.900",
+  "private": true,
   "description": "A compat App Check package for new firebase packages",
   "author": "Firebase <firebase-support@google.com> (https://firebase.google.com/)",
   "main": "dist/index.cjs.js",

--- a/packages-exp/app-check-compat/package.json
+++ b/packages-exp/app-check-compat/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@firebase/app-check-compat",
-  "version": "0.0.900",
-  "private": true,
+  "version": "0.0.900-exp.f229f736f",
+  "private": false,
   "description": "A compat App Check package for new firebase packages",
   "author": "Firebase <firebase-support@google.com> (https://firebase.google.com/)",
   "main": "dist/index.cjs.js",

--- a/packages-exp/app-check-compat/src/errors.ts
+++ b/packages-exp/app-check-compat/src/errors.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2020 Google LLC
+ * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages-exp/app-check-compat/src/errors.ts
+++ b/packages-exp/app-check-compat/src/errors.ts
@@ -23,8 +23,8 @@ export const enum AppCheckError {
 
 const ERRORS: ErrorMap<AppCheckError> = {
   [AppCheckError.USE_BEFORE_ACTIVATION]:
-    'App Check is being used before initializeAppCheck() is called for FirebaseApp {$appName}. ' +
-    'Call initializeAppCheck() before instantiating other Firebase services.'
+    'App Check is being used before activate() is called for FirebaseApp {$appName}. ' +
+    'Call activate() before instantiating other Firebase services.'
 };
 
 interface ErrorParams {

--- a/packages-exp/app-check-compat/src/errors.ts
+++ b/packages-exp/app-check-compat/src/errors.ts
@@ -1,0 +1,38 @@
+/**
+ * @license
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ErrorFactory, ErrorMap } from '@firebase/util';
+
+export const enum AppCheckError {
+  USE_BEFORE_ACTIVATION = 'use-before-activation'
+}
+
+const ERRORS: ErrorMap<AppCheckError> = {
+  [AppCheckError.USE_BEFORE_ACTIVATION]:
+    'App Check is being used before initializeAppCheck() is called for FirebaseApp {$appName}. ' +
+    'Call initializeAppCheck() before instantiating other Firebase services.'
+};
+
+interface ErrorParams {
+  [AppCheckError.USE_BEFORE_ACTIVATION]: { appName: string };
+}
+
+export const ERROR_FACTORY = new ErrorFactory<AppCheckError, ErrorParams>(
+  'appCheck',
+  'AppCheck',
+  ERRORS
+);

--- a/packages-exp/app-check-compat/src/index.ts
+++ b/packages-exp/app-check-compat/src/index.ts
@@ -27,7 +27,7 @@ import {
   InstanceFactory
 } from '@firebase/component';
 import { AppCheckService } from './service';
-import { FirebaseAppCheck } from '../../../packages/app-check-types';
+import { FirebaseAppCheck } from '@firebase/app-check-types';
 
 declare module '@firebase/component' {
   interface NameServiceMapping {
@@ -40,11 +40,8 @@ const factory: InstanceFactory<'appCheck-compat'> = (
 ) => {
   // Dependencies
   const app = container.getProvider('app-compat').getImmediate();
-  const appCheckServiceExp = container
-    .getProvider('app-check-exp')
-    .getImmediate();
 
-  return new AppCheckService(app as FirebaseApp, appCheckServiceExp);
+  return new AppCheckService(app as FirebaseApp);
 };
 
 export function registerAppCheck(): void {


### PR DESCRIPTION
Try to fix app-check-compat's activate() incorrectly throwing an error that app check has already been initialized. This happens because app-check-compat's factory initializes app-check-exp, which means when the compat activate() calls exp's initializeAppCheck() it is too late, it has already been initialized.

This approach avoids initializing app-check-exp until activate() is called. This means the AppCheck compat service's _delegate is going to be empty at initialization. That should be fine because all the other app check compat methods can throw an error asking the user to call activate() first. I think app check compat should have its own error anyway. If they hit the error in the called exp function, it asks you to "call initializeAppCheck() first" which doesn't exist in compat.