### PR TITLE
Fix auth compat import

### DIFF
--- a/packages-exp/auth-compat-exp/index.ts
+++ b/packages-exp/auth-compat-exp/index.ts
@@ -19,7 +19,6 @@
 
 import firebase, { _FirebaseNamespace } from '@firebase/app-compat';
 import * as impl from '@firebase/auth-exp/internal';
-import * as externs from '@firebase/auth-exp';
 import {
   Component,
   ComponentType,
@@ -87,14 +86,14 @@ function registerAuthCompat(instance: _FirebaseNamespace): void {
       .setServiceProps({
         ActionCodeInfo: {
           Operation: {
-            EMAIL_SIGNIN: externs.ActionCodeOperation.EMAIL_SIGNIN,
-            PASSWORD_RESET: externs.ActionCodeOperation.PASSWORD_RESET,
-            RECOVER_EMAIL: externs.ActionCodeOperation.RECOVER_EMAIL,
+            EMAIL_SIGNIN: impl.ActionCodeOperation.EMAIL_SIGNIN,
+            PASSWORD_RESET: impl.ActionCodeOperation.PASSWORD_RESET,
+            RECOVER_EMAIL: impl.ActionCodeOperation.RECOVER_EMAIL,
             REVERT_SECOND_FACTOR_ADDITION:
-              externs.ActionCodeOperation.REVERT_SECOND_FACTOR_ADDITION,
+              impl.ActionCodeOperation.REVERT_SECOND_FACTOR_ADDITION,
             VERIFY_AND_CHANGE_EMAIL:
-              externs.ActionCodeOperation.VERIFY_AND_CHANGE_EMAIL,
-            VERIFY_EMAIL: externs.ActionCodeOperation.VERIFY_EMAIL
+              impl.ActionCodeOperation.VERIFY_AND_CHANGE_EMAIL,
+            VERIFY_EMAIL: impl.ActionCodeOperation.VERIFY_EMAIL
           }
         },
         EmailAuthProvider: impl.EmailAuthProvider,

--- a/packages-exp/auth-compat-exp/index.ts
+++ b/packages-exp/auth-compat-exp/index.ts
@@ -19,6 +19,7 @@
 
 import firebase, { _FirebaseNamespace } from '@firebase/app-compat';
 import * as impl from '@firebase/auth-exp/internal';
+import * as externs from '@firebase/auth-exp';
 import {
   Component,
   ComponentType,
@@ -93,7 +94,7 @@ function registerAuthCompat(instance: _FirebaseNamespace): void {
               impl.ActionCodeOperation.REVERT_SECOND_FACTOR_ADDITION,
             VERIFY_AND_CHANGE_EMAIL:
               impl.ActionCodeOperation.VERIFY_AND_CHANGE_EMAIL,
-            VERIFY_EMAIL: impl.ActionCodeOperation.VERIFY_EMAIL
+            VERIFY_EMAIL: externs.ActionCodeOperation.VERIFY_EMAIL
           }
         },
         EmailAuthProvider: impl.EmailAuthProvider,

--- a/packages-exp/auth-compat-exp/index.ts
+++ b/packages-exp/auth-compat-exp/index.ts
@@ -19,7 +19,6 @@
 
 import firebase, { _FirebaseNamespace } from '@firebase/app-compat';
 import * as impl from '@firebase/auth-exp/internal';
-import * as externs from '@firebase/auth-exp';
 import {
   Component,
   ComponentType,
@@ -94,7 +93,7 @@ function registerAuthCompat(instance: _FirebaseNamespace): void {
               impl.ActionCodeOperation.REVERT_SECOND_FACTOR_ADDITION,
             VERIFY_AND_CHANGE_EMAIL:
               impl.ActionCodeOperation.VERIFY_AND_CHANGE_EMAIL,
-            VERIFY_EMAIL: externs.ActionCodeOperation.VERIFY_EMAIL
+            VERIFY_EMAIL: impl.ActionCodeOperation.VERIFY_EMAIL
           }
         },
         EmailAuthProvider: impl.EmailAuthProvider,

--- a/packages-exp/auth-compat-exp/rollup.config.shared.js
+++ b/packages-exp/auth-compat-exp/rollup.config.shared.js
@@ -147,7 +147,7 @@ export function getEs2017Builds(additionalTypescriptPlugins = {}) {
 
 export function getAllBuilds(additionalTypescriptPlugins = {}) {
   return [
-    // ...getEs5Builds(additionalTypescriptPlugins),
+    ...getEs5Builds(additionalTypescriptPlugins),
     ...getEs2017Builds(additionalTypescriptPlugins)
   ];
 }

--- a/packages-exp/auth-compat-exp/rollup.config.shared.js
+++ b/packages-exp/auth-compat-exp/rollup.config.shared.js
@@ -147,7 +147,7 @@ export function getEs2017Builds(additionalTypescriptPlugins = {}) {
 
 export function getAllBuilds(additionalTypescriptPlugins = {}) {
   return [
-    ...getEs5Builds(additionalTypescriptPlugins),
+    // ...getEs5Builds(additionalTypescriptPlugins),
     ...getEs2017Builds(additionalTypescriptPlugins)
   ];
 }

--- a/packages/database/rollup.config.compat.js
+++ b/packages/database/rollup.config.compat.js
@@ -47,7 +47,7 @@ const es5BuildPlugins = [
     transformers: [
       getImportPathTransformer({
         // ../../exp/index
-        pattern: /^.*exp\/index$/g,
+        pattern: /^.*exp\/index$/,
         template: ['@firebase/database']
       })
     ]
@@ -111,7 +111,7 @@ const es2017BuildPlugins = [
     transformers: [
       getImportPathTransformer({
         // ../../exp/index
-        pattern: /^.*exp\/index$/g,
+        pattern: /^.*exp\/index$/,
         template: ['@firebase/database']
       })
     ]

--- a/packages/firestore/rollup.config.browser.compat.js
+++ b/packages/firestore/rollup.config.browser.compat.js
@@ -37,7 +37,7 @@ export default [
         'browser',
         getImportPathTransformer({
           // ../../exp/index
-          pattern: /^.*exp\/index$/g,
+          pattern: /^.*exp\/index$/,
           template: ['@firebase/firestore']
         }),
         /* mangled= */ false

--- a/packages/firestore/rollup.config.node.compat.js
+++ b/packages/firestore/rollup.config.node.compat.js
@@ -38,7 +38,7 @@ export default [
         'node',
         getImportPathTransformer({
           // ../../exp/index
-          pattern: /^.*exp\/index$/g,
+          pattern: /^.*exp\/index$/,
           template: ['@firebase/firestore']
         })
       ),

--- a/packages/firestore/rollup.config.rn.compat.js
+++ b/packages/firestore/rollup.config.rn.compat.js
@@ -34,7 +34,7 @@ export default [
         'rn',
         getImportPathTransformer({
           // ../../exp/index
-          pattern: /^.*exp\/index$/g,
+          pattern: /^.*exp\/index$/,
           template: ['@firebase/firestore']
         }),
         /* mangled= */ false

--- a/packages/storage/rollup.config.compat.js
+++ b/packages/storage/rollup.config.compat.js
@@ -39,7 +39,7 @@ const es5BuildPlugins = [
     transformers: [
       getImportPathTransformer({
         // ../exp/index
-        pattern: /^.*exp\/api$/g,
+        pattern: /^.*exp\/api$/,
         template: ['@firebase/storage']
       })
     ]
@@ -80,7 +80,7 @@ const es2017BuildPlugins = [
     transformers: [
       getImportPathTransformer({
         // ../exp/index
-        pattern: /^.*exp\/api$/g,
+        pattern: /^.*exp\/api$/,
         template: ['@firebase/storage']
       })
     ],

--- a/scripts/exp/ts-transform-import-path.js
+++ b/scripts/exp/ts-transform-import-path.js
@@ -34,14 +34,14 @@ export function getImportPathTransformer({ pattern, template }) {
 export const importPathTransformer = () => ({
   before: [
     transformImportPath({
-      pattern: /^(@firebase.*)-exp(.*)$/g,
+      pattern: /^(@firebase.*)-exp(.*)$/,
       template: [1, 2]
     })
   ],
   after: [],
   afterDeclarations: [
     transformImportPath({
-      pattern: /^(@firebase.*)-exp(.*)$/g,
+      pattern: /^(@firebase.*)-exp(.*)$/,
       template: [1, 2]
     })
   ]
@@ -75,7 +75,6 @@ function visitNode(node, { pattern, template }) {
     );
 
     const captures = pattern.exec(importPath);
-
     if (captures) {
       const newNameFragments = [];
       for (const fragment of template) {


### PR DESCRIPTION
For some reason, our build doesn't remove the `-exp` in `auth-exp` correctly, so auth-compat is broken in 9.0.0-beta.5. 
We should use `ActionCodeOperation` as an implementation anyway since it has been changed from const enum to an object map.