### PR TITLE
change the instantiation mode to explicit for appcheck

### DIFF
--- a/packages-exp/app-check-exp/src/index.ts
+++ b/packages-exp/app-check-exp/src/index.ts
@@ -15,7 +15,11 @@
  * limitations under the License.
  */
 import { registerVersion, _registerComponent } from '@firebase/app-exp';
-import { Component, ComponentType } from '@firebase/component';
+import {
+  Component,
+  ComponentType,
+  InstantiationMode
+} from '@firebase/component';
 import { _AppCheckComponentName } from './public-types';
 import { factory, internalFactory } from './factory';
 import { initializeDebugMode } from './debug';
@@ -44,6 +48,16 @@ function registerAppCheck(): void {
       },
       ComponentType.PUBLIC
     )
+      .setInstantiationMode(InstantiationMode.EXPLICIT)
+      /**
+       * Initialize app-check-internal after app-check is initialized to make AppCheck available to
+       * other Firebase SDKs
+       */
+      .setInstanceCreatedCallback(
+        (container, _identifier, _appcheckService) => {
+          container.getProvider(APP_CHECK_NAME_INTERNAL).initialize();
+        }
+      )
   );
 
   // The internal interface used by other Firebase products
@@ -55,7 +69,7 @@ function registerAppCheck(): void {
         return internalFactory(appCheck);
       },
       ComponentType.PUBLIC
-    )
+    ).setInstantiationMode(InstantiationMode.EXPLICIT)
   );
 
   registerVersion(name, version);


### PR DESCRIPTION
AppCheck shouldn't be able to be instantiated by consumers by using `Provider.get()` or `Provider.getImmediate()`. Rather it should become available when it's explicitly initialized by developers by calling `initializeAppCheck()` and passing it an AppCheckProvider.