### PR TITLE
Fix changeset checker

### DIFF
--- a/.changeset/fair-cycles-rescue.md
+++ b/.changeset/fair-cycles-rescue.md
@@ -1,0 +1,5 @@
+---
+'@firebase/app': patch
+---
+
+test

--- a/.changeset/fair-cycles-rescue.md
+++ b/.changeset/fair-cycles-rescue.md
@@ -1,5 +1,0 @@
----
-'@firebase/app': patch
----
-
-test

--- a/.github/workflows/check-changeset.yml
+++ b/.github/workflows/check-changeset.yml
@@ -2,6 +2,10 @@ name: Check Changeset
 
 on: pull_request
 
+env:
+  GITHUB_PULL_REQUEST_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+  GITHUB_PULL_REQUEST_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+
 jobs:
   check_changeset:
     name: Check changeset vs changed files

--- a/scripts/check_changeset.ts
+++ b/scripts/check_changeset.ts
@@ -123,7 +123,9 @@ async function parseChangesetFile(changesetFile: string) {
 async function main() {
   const errors = [];
   try {
-    await exec('yarn changeset status');
+    await exec(
+      `yarn changeset status --since ${process.env.GITHUB_PULL_REQUEST_BASE_SHA}`
+    );
     console.log(`::set-output name=BLOCKING_FAILURE::false`);
   } catch (e) {
     if (e.message.match('No changesets present')) {

--- a/scripts/check_changeset.ts
+++ b/scripts/check_changeset.ts
@@ -65,7 +65,10 @@ async function getDiffData(): Promise<{
   changedPackages: Set<string>;
   changesetFile: string;
 } | null> {
-  const diff = await git.diff(['--name-only', 'origin/master...HEAD']);
+  const diff = await git.diff([
+    '--name-only',
+    `${process.env.GITHUB_PULL_REQUEST_BASE_SHA}...${process.env.GITHUB_PULL_REQUEST_HEAD_SHA}`
+  ]);
   const changedFiles = diff.split('\n');
   let changesetFile = '';
   const changedPackages = new Set<string>();
@@ -173,9 +176,8 @@ async function main() {
 
       // Check for packages with a minor or major bump where 'firebase' hasn't been
       // bumped high enough or at all.
-      const { highestBump, bumpText, bumpPackage } = getHighestBump(
-        changesetPackages
-      );
+      const { highestBump, bumpText, bumpPackage } =
+        getHighestBump(changesetPackages);
       if (highestBump > bumpRank.patch) {
         if (changesetPackages['firebase'] == null) {
           errors.push(


### PR DESCRIPTION
There is a bug in the latest changesets: https://github.com/atlassian/changesets/issues/517

Instead of letting it implicitly try to use `master`, use `--since` option to specify base SHA, obtained from Github Actions' env variables. Keep `master/HEAD` as a fallback option in case this script is run locally.