### PR TITLE
Add debug token caching to app-check-exp

### DIFF
--- a/packages-exp/app-check-exp/src/client.test.ts
+++ b/packages-exp/app-check-exp/src/client.test.ts
@@ -52,7 +52,8 @@ describe('client', () => {
   });
 
   it('returns a AppCheck token', async () => {
-    useFakeTimers();
+    // To get a consistent expireTime/issuedAtTime.
+    const clock = useFakeTimers();
     fetchStub.returns(
       Promise.resolve({
         status: 200,
@@ -77,6 +78,7 @@ describe('client', () => {
       expireTimeMillis: 3600,
       issuedAtTimeMillis: 0
     });
+    clock.restore();
   });
 
   it('throws when there is a network error', async () => {

--- a/packages-exp/app-check-exp/src/factory.ts
+++ b/packages-exp/app-check-exp/src/factory.ts
@@ -24,6 +24,7 @@ import {
   removeTokenListener
 } from './internal-api';
 import { Provider } from '@firebase/component';
+import { getState } from './state';
 
 /**
  * AppCheck Service class.
@@ -34,6 +35,10 @@ export class AppCheckService implements AppCheck, _FirebaseService {
     public platformLoggerProvider: Provider<'platform-logger'>
   ) {}
   _delete(): Promise<void> {
+    const { tokenObservers } = getState(this.app);
+    for (const tokenObserver of tokenObservers) {
+      removeTokenListener(this.app, tokenObserver.next);
+    }
     return Promise.resolve();
   }
 }

--- a/packages-exp/app-check-exp/src/internal-api.ts
+++ b/packages-exp/app-check-exp/src/internal-api.ts
@@ -173,7 +173,7 @@ export function addTokenListener(
   // is not true.
   if (
     !newState.tokenRefresher.isRunning() &&
-    state.isTokenAutoRefreshEnabled === true
+    state.isTokenAutoRefreshEnabled
   ) {
     newState.tokenRefresher.start();
   }

--- a/packages-exp/app-check-exp/src/internal-api.ts
+++ b/packages-exp/app-check-exp/src/internal-api.ts
@@ -23,7 +23,7 @@ import {
   ListenerType
 } from './types';
 import { AppCheckTokenListener } from './public-types';
-import { getDebugState, getState, setState } from './state';
+import { getState, setState } from './state';
 import { TOKEN_REFRESH_TIME } from './constants';
 import { Refresher } from './proactive-refresh';
 import { ensureActivated } from './util';
@@ -63,25 +63,17 @@ export async function getToken(
 ): Promise<AppCheckTokenResult> {
   const app = appCheck.app;
   ensureActivated(app);
-  /**
-   * DEBUG MODE
-   * return the debug token directly
-   */
-  if (isDebugMode()) {
-    const tokenFromDebugExchange: AppCheckTokenInternal = await exchangeToken(
-      getExchangeDebugTokenRequest(app, await getDebugToken()),
-      appCheck.platformLoggerProvider
-    );
-    return { token: tokenFromDebugExchange.token };
-  }
 
   const state = getState(app);
 
+  /**
+   * First check if there is a token in memory from a previous `getToken()` call.
+   */
   let token: AppCheckTokenInternal | undefined = state.token;
   let error: Error | undefined = undefined;
 
   /**
-   * try to load token from indexedDB if it's the first time this function is called
+   * If there is no token in memory, try to load token from indexedDB.
    */
   if (!token) {
     // readTokenFromStorage() always resolves. In case of an error, it resolves with `undefined`.
@@ -95,11 +87,28 @@ export async function getToken(
     }
   }
 
-  // return the cached token if it's valid
+  // Return the cached token (from either memory or indexedDB) if it's valid
   if (!forceRefresh && token && isValid(token)) {
     return {
       token: token.token
     };
+  }
+
+  /**
+   * DEBUG MODE
+   * If debug mode is set, and there is no cached token, fetch a new App
+   * Check token using the debug token, and return it directly.
+   */
+  if (isDebugMode()) {
+    const tokenFromDebugExchange: AppCheckTokenInternal = await exchangeToken(
+      getExchangeDebugTokenRequest(app, await getDebugToken()),
+      appCheck.platformLoggerProvider
+    );
+    // Write debug token to indexedDB.
+    await writeTokenToStorage(app, tokenFromDebugExchange);
+    // Write debug token to state.
+    setState(app, { ...state, token: tokenFromDebugExchange });
+    return { token: tokenFromDebugExchange.token };
   }
 
   /**
@@ -125,7 +134,7 @@ export async function getToken(
     interopTokenResult = {
       token: token.token
     };
-    // write the new token to the memory state as well ashe persistent storage.
+    // write the new token to the memory state as well as the persistent storage.
     // Only do it if we got a valid new token
     setState(app, { ...state, token });
     await writeTokenToStorage(app, token);
@@ -152,50 +161,31 @@ export function addTokenListener(
     ...state,
     tokenObservers: [...state.tokenObservers, tokenObserver]
   };
-
   /**
-   * DEBUG MODE
-   *
-   * invoke the listener once with the debug token.
+   * Invoke the listener with the valid token, then start the token refresher
    */
-  if (isDebugMode()) {
-    const debugState = getDebugState();
-    if (debugState.enabled && debugState.token) {
-      debugState.token.promise
-        .then(token => listener({ token }))
-        .catch(() => {
-          /* we don't care about exceptions thrown in listeners */
-        });
-    }
-  } else {
-    /**
-     * PROD MODE
-     *
-     * invoke the listener with the valid token, then start the token refresher
-     */
-    if (!newState.tokenRefresher) {
-      const tokenRefresher = createTokenRefresher(appCheck);
-      newState.tokenRefresher = tokenRefresher;
-    }
+  if (!newState.tokenRefresher) {
+    const tokenRefresher = createTokenRefresher(appCheck);
+    newState.tokenRefresher = tokenRefresher;
+  }
 
-    // Create the refresher but don't start it if `isTokenAutoRefreshEnabled`
-    // is not true.
-    if (
-      !newState.tokenRefresher.isRunning() &&
-      state.isTokenAutoRefreshEnabled === true
-    ) {
-      newState.tokenRefresher.start();
-    }
+  // Create the refresher but don't start it if `isTokenAutoRefreshEnabled`
+  // is not true.
+  if (
+    !newState.tokenRefresher.isRunning() &&
+    state.isTokenAutoRefreshEnabled === true
+  ) {
+    newState.tokenRefresher.start();
+  }
 
-    // invoke the listener async immediately if there is a valid token
-    if (state.token && isValid(state.token)) {
-      const validToken = state.token;
-      Promise.resolve()
-        .then(() => listener({ token: validToken.token }))
-        .catch(() => {
-          /* we don't care about exceptions thrown in listeners */
-        });
-    }
+  // invoke the listener async immediately if there is a valid token
+  if (state.token && isValid(state.token)) {
+    const validToken = state.token;
+    Promise.resolve()
+      .then(() => listener({ token: validToken.token }))
+      .catch(() => {
+        /* we don't care about exceptions thrown in listeners */
+      });
   }
 
   setState(app, newState);

--- a/packages/app-check/src/internal-api.test.ts
+++ b/packages/app-check/src/internal-api.test.ts
@@ -120,6 +120,7 @@ describe('internal api', () => {
     });
 
     it('resolves with a dummy token and an error if failed to get a token', async () => {
+      // getToken() errors are logged to console. Hide this during test.
       const errorStub = stub(console, 'error');
       activate(app, FAKE_SITE_KEY, true);
 

--- a/packages/app-check/src/internal-api.ts
+++ b/packages/app-check/src/internal-api.ts
@@ -202,10 +202,7 @@ export function addTokenListener(
 
   // Create the refresher but don't start it if `isTokenAutoRefreshEnabled`
   // is not true.
-  if (
-    !newState.tokenRefresher.isRunning() &&
-    state.isTokenAutoRefreshEnabled === true
-  ) {
+  if (!newState.tokenRefresher.isRunning() && state.isTokenAutoRefreshEnabled) {
     newState.tokenRefresher.start();
   }
 


### PR DESCRIPTION
Ported from v8: https://github.com/firebase/firebase-js-sdk/pull/5055
Also includes some of the test reliability fixes in 5055 that I missed porting over in an earlier PR.