### PR TITLE
Update comments for v9 reference docs

### DIFF
--- a/packages-exp/app-check-exp/src/index.ts
+++ b/packages-exp/app-check-exp/src/index.ts
@@ -1,4 +1,10 @@
 /**
+ * Firebase App Check
+ *
+ * @packageDocumentation
+ */
+
+/**
  * @license
  * Copyright 2017 Google LLC
  *

--- a/packages-exp/app-check-exp/src/index.ts
+++ b/packages-exp/app-check-exp/src/index.ts
@@ -6,7 +6,7 @@
 
 /**
  * @license
- * Copyright 2017 Google LLC
+ * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages-exp/auth-exp/src/core/auth/emulator.ts
+++ b/packages-exp/auth-exp/src/core/auth/emulator.ts
@@ -25,7 +25,7 @@ import { _castAuth } from './auth_impl';
  *
  * @remarks
  * This must be called synchronously immediately following the first call to
- * {@link @firebase/auth#initializeAuth}.  Do not use with production credentials as emulator
+ * {@link initializeAuth}.  Do not use with production credentials as emulator
  * traffic is not encrypted.
  *
  *
@@ -82,9 +82,10 @@ function extractProtocol(url: string): string {
   return protocolEnd < 0 ? '' : url.substr(0, protocolEnd + 1);
 }
 
-function extractHostAndPort(
-  url: string
-): { host: string; port: number | null } {
+function extractHostAndPort(url: string): {
+  host: string;
+  port: number | null;
+} {
   const protocol = extractProtocol(url);
   const authority = /(\/\/)?([^?#/]+)/.exec(url.substr(protocol.length)); // Between // and /, ? or #.
   if (!authority) {

--- a/packages-exp/auth-exp/src/core/credentials/auth_credential.ts
+++ b/packages-exp/auth-exp/src/core/credentials/auth_credential.ts
@@ -42,8 +42,8 @@ export class AuthCredential {
      * The authentication sign in method for the credential.
      *
      * @remarks
-     * For example, {@link  SignInMethod.EMAIL_PASSWORD}, or
-     * {@link  SignInMethod.EMAIL_LINK}. This corresponds to the sign-in method
+     * For example, {@link SignInMethod}.EMAIL_PASSWORD, or
+     * {@link SignInMethod}.EMAIL_LINK. This corresponds to the sign-in method
      * identifier as returned in {@link fetchSignInMethodsForEmail}.
      */
     readonly signInMethod: string

--- a/packages-exp/auth-exp/src/core/credentials/email.ts
+++ b/packages-exp/auth-exp/src/core/credentials/email.ts
@@ -31,11 +31,11 @@ import { AuthCredential } from './auth_credential';
 
 /**
  * Interface that represents the credentials returned by {@link EmailAuthProvider} for
- * {@link ProviderId.PASSWORD}
+ * {@link ProviderId}.PASSWORD
  *
  * @remarks
- * Covers both {@link SignInMethod.EMAIL_PASSWORD} and
- * {@link SignInMethod.EMAIL_LINK}.
+ * Covers both {@link SignInMethod}.EMAIL_PASSWORD and
+ * {@link SignInMethod}.EMAIL_LINK.
  *
  * @public
  */

--- a/packages-exp/auth-exp/src/core/providers/email.ts
+++ b/packages-exp/auth-exp/src/core/providers/email.ts
@@ -33,19 +33,19 @@ import { _assert } from '../util/assert';
  */
 export class EmailAuthProvider implements AuthProvider {
   /**
-   * Always set to {@link ProviderId.PASSWORD}, even for email link.
+   * Always set to {@link ProviderId}.PASSWORD, even for email link.
    */
   static readonly PROVIDER_ID = ProviderId.PASSWORD;
   /**
-   * Always set to {@link SignInMethod.EMAIL_PASSWORD}.
+   * Always set to {@link SignInMethod}.EMAIL_PASSWORD.
    */
   static readonly EMAIL_PASSWORD_SIGN_IN_METHOD = SignInMethod.EMAIL_PASSWORD;
   /**
-   * Always set to {@link SignInMethod.EMAIL_LINK}.
+   * Always set to {@link SignInMethod}.EMAIL_LINK.
    */
   static readonly EMAIL_LINK_SIGN_IN_METHOD = SignInMethod.EMAIL_LINK;
   /**
-   * Always set to {@link ProviderId.PASSWORD}, even for email link.
+   * Always set to {@link ProviderId}.PASSWORD, even for email link.
    */
   readonly providerId = EmailAuthProvider.PROVIDER_ID;
 

--- a/packages-exp/auth-exp/src/core/providers/facebook.ts
+++ b/packages-exp/auth-exp/src/core/providers/facebook.ts
@@ -28,7 +28,7 @@ import { OAuthCredential } from '../credentials/oauth';
 import { BaseOAuthProvider } from './oauth';
 
 /**
- * Provider for generating an {@link OAuthCredential} for {@link ProviderId.FACEBOOK}.
+ * Provider for generating an {@link OAuthCredential} for {@link ProviderId}.FACEBOOK.
  *
  * @example
  * ```javascript
@@ -67,9 +67,9 @@ import { BaseOAuthProvider } from './oauth';
  * @public
  */
 export class FacebookAuthProvider extends BaseOAuthProvider {
-  /** Always set to {@link SignInMethod.FACEBOOK}. */
+  /** Always set to {@link SignInMethod}.FACEBOOK. */
   static readonly FACEBOOK_SIGN_IN_METHOD = SignInMethod.FACEBOOK;
-  /** Always set to {@link ProviderId.FACEBOOK}. */
+  /** Always set to {@link ProviderId}.FACEBOOK. */
   static readonly PROVIDER_ID = ProviderId.FACEBOOK;
 
   constructor() {

--- a/packages-exp/auth-exp/src/core/providers/github.ts
+++ b/packages-exp/auth-exp/src/core/providers/github.ts
@@ -28,7 +28,7 @@ import { OAuthCredential } from '../credentials/oauth';
 import { BaseOAuthProvider } from './oauth';
 
 /**
- * Provider for generating an {@link OAuthCredential} for {@link ProviderId.GITHUB}.
+ * Provider for generating an {@link OAuthCredential} for {@link ProviderId}.GITHUB.
  *
  * @remarks
  * GitHub requires an OAuth 2.0 redirect, so you can either handle the redirect directly, or use
@@ -70,9 +70,9 @@ import { BaseOAuthProvider } from './oauth';
  * @public
  */
 export class GithubAuthProvider extends BaseOAuthProvider {
-  /** Always set to {@link SignInMethod.GITHUB}. */
+  /** Always set to {@link SignInMethod}.GITHUB. */
   static readonly GITHUB_SIGN_IN_METHOD = SignInMethod.GITHUB;
-  /** Always set to {@link ProviderId.GITHUB}. */
+  /** Always set to {@link ProviderId}.GITHUB. */
   static readonly PROVIDER_ID = ProviderId.GITHUB;
 
   constructor() {

--- a/packages-exp/auth-exp/src/core/providers/google.ts
+++ b/packages-exp/auth-exp/src/core/providers/google.ts
@@ -29,7 +29,7 @@ import { OAuthCredential } from '../credentials/oauth';
 import { BaseOAuthProvider } from './oauth';
 
 /**
- * Provider for generating an an {@link OAuthCredential} for {@link ProviderId.GOOGLE}.
+ * Provider for generating an an {@link OAuthCredential} for {@link ProviderId}.GOOGLE.
  *
  * @example
  * ```javascript
@@ -70,9 +70,9 @@ import { BaseOAuthProvider } from './oauth';
  * @public
  */
 export class GoogleAuthProvider extends BaseOAuthProvider {
-  /** Always set to {@link SignInMethod.GOOGLE}. */
+  /** Always set to {@link SignInMethod}.GOOGLE. */
   static readonly GOOGLE_SIGN_IN_METHOD = SignInMethod.GOOGLE;
-  /** Always set to {@link ProviderId.GOOGLE}. */
+  /** Always set to {@link ProviderId}.GOOGLE. */
   static readonly PROVIDER_ID = ProviderId.GOOGLE;
 
   constructor() {
@@ -136,10 +136,8 @@ export class GoogleAuthProvider extends BaseOAuthProvider {
       return null;
     }
 
-    const {
-      oauthIdToken,
-      oauthAccessToken
-    } = tokenResponse as SignInWithIdpResponse;
+    const { oauthIdToken, oauthAccessToken } =
+      tokenResponse as SignInWithIdpResponse;
     if (!oauthIdToken && !oauthAccessToken) {
       // This could be an oauth 1 credential or a phone credential
       return null;

--- a/packages-exp/auth-exp/src/core/providers/twitter.ts
+++ b/packages-exp/auth-exp/src/core/providers/twitter.ts
@@ -46,7 +46,7 @@ import { OAuthCredential } from '../credentials/oauth';
 import { BaseOAuthProvider } from './oauth';
 
 /**
- * Provider for generating an {@link OAuthCredential} for {@link ProviderId.TWITTER}.
+ * Provider for generating an {@link OAuthCredential} for {@link ProviderId}.TWITTER.
  *
  * @example
  * ```javascript
@@ -85,9 +85,9 @@ import { BaseOAuthProvider } from './oauth';
  * @public
  */
 export class TwitterAuthProvider extends BaseOAuthProvider {
-  /** Always set to {@link SignInMethod.TWITTER}. */
+  /** Always set to {@link SignInMethod}.TWITTER. */
   static readonly TWITTER_SIGN_IN_METHOD = SignInMethod.TWITTER;
-  /** Always set to {@link ProviderId.TWITTER}. */
+  /** Always set to {@link ProviderId}.TWITTER. */
   static readonly PROVIDER_ID = ProviderId.TWITTER;
 
   constructor() {
@@ -140,10 +140,8 @@ export class TwitterAuthProvider extends BaseOAuthProvider {
     if (!tokenResponse) {
       return null;
     }
-    const {
-      oauthAccessToken,
-      oauthTokenSecret
-    } = tokenResponse as SignInWithIdpResponse;
+    const { oauthAccessToken, oauthTokenSecret } =
+      tokenResponse as SignInWithIdpResponse;
     if (!oauthAccessToken || !oauthTokenSecret) {
       return null;
     }

--- a/packages-exp/auth-exp/src/core/strategies/email.ts
+++ b/packages-exp/auth-exp/src/core/strategies/email.ts
@@ -38,8 +38,8 @@ import { getModularInstance } from '@firebase/util';
  * @remarks
  * This is useful to differentiate methods of sign-in for the same provider, eg.
  * {@link EmailAuthProvider} which has 2 methods of sign-in,
- * {@link SignInMethod.EMAIL_PASSWORD} and
- * {@link SignInMethod.EMAIL_LINK} .
+ * {@link SignInMethod}.EMAIL_PASSWORD and
+ * {@link SignInMethod}.EMAIL_LINK.
  *
  * @param auth - The Auth instance.
  * @param email - The user's email address.

--- a/packages-exp/auth-exp/src/model/public_types.ts
+++ b/packages-exp/auth-exp/src/model/public_types.ts
@@ -177,7 +177,7 @@ export interface AuthError extends FirebaseError {
    * The tenant ID being used for sign-in/linking.
    *
    * @remarks
-   * If you use {@link @firebase/auth#signInWithRedirect} to sign in,
+   * If you use {@link signInWithRedirect} to sign in,
    * you have to set the tenant ID on {@link Auth} instance again as the tenant ID is not persisted
    * after redirection.
    */
@@ -401,7 +401,7 @@ export interface IdTokenResult {
 }
 
 /**
- * A response from {@link @firebase/auth#checkActionCode}.
+ * A response from {@link checkActionCode}.
  *
  * @public
  */
@@ -410,21 +410,21 @@ export interface ActionCodeInfo {
    * The data associated with the action code.
    *
    * @remarks
-   * For the {@link ActionCodeOperation.PASSWORD_RESET}, {@link ActionCodeOperation.VERIFY_EMAIL}, and
-   * {@link ActionCodeOperation.RECOVER_EMAIL} actions, this object contains an email field with the address
+   * For the {@link ActionCodeOperation}.PASSWORD_RESET, {@link ActionCodeOperation}.VERIFY_EMAIL, and
+   * {@link ActionCodeOperation}.RECOVER_EMAIL actions, this object contains an email field with the address
    * the email was sent to.
    *
-   * For the {@link ActionCodeOperation.RECOVER_EMAIL} action, which allows a user to undo an email address
+   * For the {@link ActionCodeOperation}.RECOVER_EMAIL action, which allows a user to undo an email address
    * change, this object also contains a `previousEmail` field with the user account's current
    * email address. After the action completes, the user's email address will revert to the value
    * in the `email` field from the value in `previousEmail` field.
    *
-   * For the {@link ActionCodeOperation.VERIFY_AND_CHANGE_EMAIL} action, which allows a user to verify the
+   * For the {@link ActionCodeOperation}.VERIFY_AND_CHANGE_EMAIL action, which allows a user to verify the
    * email before updating it, this object contains a `previousEmail` field with the user account's
    * email address before updating. After the action completes, the user's email address will be
    * updated to the value in the `email` field from the value in `previousEmail` field.
    *
-   * For the {@link ActionCodeOperation.REVERT_SECOND_FACTOR_ADDITION} action, which allows a user to
+   * For the {@link ActionCodeOperation}.REVERT_SECOND_FACTOR_ADDITION action, which allows a user to
    * unenroll a newly added second factor, this object contains a `multiFactorInfo` field with
    * the information about the second factor. For phone second factor, the `multiFactorInfo`
    * is a {@link MultiFactorInfo} object, which contains the phone number.
@@ -530,7 +530,7 @@ export interface ActionCodeSettings {
  * A verifier for domain verification and abuse prevention.
  *
  * @remarks
- * Currently, the only implementation is {@link @firebase/auth#RecaptchaVerifier}.
+ * Currently, the only implementation is {@link RecaptchaVerifier}.
  *
  * @public
  */
@@ -951,7 +951,7 @@ export interface User extends UserInfo {
    */
   readonly emailVerified: boolean;
   /**
-   * Whether the user is authenticated using the {@link ProviderId.ANONYMOUS} provider.
+   * Whether the user is authenticated using the {@link ProviderId}.ANONYMOUS provider.
    */
   readonly isAnonymous: boolean;
   /**
@@ -992,7 +992,7 @@ export interface User extends UserInfo {
    * @remarks
    * Important: this is a security-sensitive operation that requires the user to have recently
    * signed in. If this requirement isn't met, ask the user to authenticate again and then call
-   * one of the reauthentication methods like {@link @firebase/auth#reauthenticateWithCredential}.
+   * one of the reauthentication methods like {@link reauthenticateWithCredential}.
    */
   delete(): Promise<void>;
   /**
@@ -1032,8 +1032,8 @@ export interface User extends UserInfo {
  * and any additional user information that was returned from the identity provider.
  *
  * @remarks
- * `operationType` could be {@link OperationType.SIGN_IN} for a sign-in operation,
- * {@link OperationType.LINK} for a linking operation and {@link OperationType.REAUTHENTICATE} for
+ * `operationType` could be {@link OperationType}.SIGN_IN for a sign-in operation,
+ * {@link OperationType}.LINK for a linking operation and {@link OperationType}.REAUTHENTICATE for
  * a reauthentication operation.
  *
  * @public
@@ -1133,8 +1133,8 @@ export interface AdditionalUserInfo {
 export type UserProfile = Record<string, unknown>;
 
 /**
- * A resolver used for handling DOM specific operations like {@link @firebase/auth#signInWithPopup}
- * or {@link @firebase/auth#signInWithRedirect}.
+ * A resolver used for handling DOM specific operations like {@link signInWithPopup}
+ * or {@link signInWithRedirect}.
  *
  * @public
  */

--- a/packages-exp/auth-exp/src/platform_browser/providers/phone.ts
+++ b/packages-exp/auth-exp/src/platform_browser/providers/phone.ts
@@ -52,12 +52,12 @@ import { TaggedWithTokenResponse } from '../../model/id_token';
  * @public
  */
 export class PhoneAuthProvider {
-  /** Always set to {@link ProviderId.PHONE}. */
+  /** Always set to {@link ProviderId}.PHONE. */
   static readonly PROVIDER_ID = ProviderId.PHONE;
-  /** Always set to {@link SignInMethod.PHONE}. */
+  /** Always set to {@link SignInMethod}.PHONE. */
   static readonly PHONE_SIGN_IN_METHOD = SignInMethod.PHONE;
 
-  /** Always set to {@link ProviderId.PHONE}. */
+  /** Always set to {@link ProviderId}.PHONE. */
   readonly providerId = PhoneAuthProvider.PROVIDER_ID;
   private readonly auth: AuthInternal;
 
@@ -203,10 +203,8 @@ export class PhoneAuthProvider {
     if (!tokenResponse) {
       return null;
     }
-    const {
-      phoneNumber,
-      temporaryProof
-    } = tokenResponse as SignInWithPhoneNumberResponse;
+    const { phoneNumber, temporaryProof } =
+      tokenResponse as SignInWithPhoneNumberResponse;
     if (phoneNumber && temporaryProof) {
       return PhoneAuthCredential._fromTokenResponse(
         phoneNumber,


### PR DESCRIPTION
- Add package description for AppCheck
- Update links in Auth comments. It's not possible to link to a property of a variable, so we just link to the variable.
- Remove unnecessary package specifiers in links