### PR TITLE
Use oss bot github token to label PRs

### DIFF
--- a/.github/workflows/label-doc-changes.yml
+++ b/.github/workflows/label-doc-changes.yml
@@ -33,4 +33,4 @@ jobs:
       if: ${{steps.check-doc-changes.outputs.DOC_CHANGED == 'true'}}
       with:
         labels: doc-changes
-        github_token: ${{ secrets.GITHUB_TOKEN }}
+        github_token: ${{ secrets.OSS_BOT_GITHUB_TOKEN }}


### PR DESCRIPTION
Actions made using the default `GITHUB_TOKEN` can't trigger additional workflow, so we switch to use the Firebase OSS bot's token.

see https://docs.github.com/en/actions/reference/events-that-trigger-workflows