### PR TITLE
Add @firebase/logger as dependency to app-types

### DIFF
--- a/.changeset/short-lies-sing.md
+++ b/.changeset/short-lies-sing.md
@@ -1,0 +1,5 @@
+---
+'@firebase/app-types': patch
+---
+
+Add @firebase/logger as a dependency to @firebase/app-types to ensure that it can be resolved when compiling the package in a strict yarn PnP environment.

--- a/packages/app-types/package.json
+++ b/packages/app-types/package.json
@@ -20,10 +20,10 @@
   "bugs": {
     "url": "https://github.com/firebase/firebase-js-sdk/issues"
   },
+  "dependency": {
+    "@firebase/logger": "0.2.6"
+  },
   "devDependencies": {
     "typescript": "4.2.2"
-  },
-  "peerDependency": {
-    "@firebase/logger": "0.x"
   }
 }

--- a/packages/app-types/package.json
+++ b/packages/app-types/package.json
@@ -21,6 +21,7 @@
     "url": "https://github.com/firebase/firebase-js-sdk/issues"
   },
   "devDependencies": {
-    "typescript": "4.2.2"
+    "typescript": "4.2.2",
+    "@firebase/logger": "0.x"
   }
 }

--- a/packages/app-types/package.json
+++ b/packages/app-types/package.json
@@ -21,7 +21,9 @@
     "url": "https://github.com/firebase/firebase-js-sdk/issues"
   },
   "devDependencies": {
-    "typescript": "4.2.2",
+    "typescript": "4.2.2"
+  },
+  "peerDependency": {
     "@firebase/logger": "0.x"
   }
 }


### PR DESCRIPTION
Hey everyone, 

i ran into an issue with the `app-types` module where the typescript compilation of a module that defined `firebase-admin` as a dependency failed with the following error:
```
.yarn/cache/@firebase-app-types-npm-0.6.2-936c84268d-243af1c06f.zip/node_modules/@firebase/app-types/index.d.ts:17:57 - error TS2307: Cannot find module '@firebase/logger' or its corresponding type declarations.
``` 
The project uses yarn2 with a 'strict' PnP mode. 

I have created a small codesandbox that demonstrates this issue: https://codesandbox.io/s/gallant-satoshi-fycm1 
Run `yarn compile` to see the issue in action. 

Looking forward to your review!
