### PR TITLE
[Auth] Fix promise rejection for failing when loading JS

### DIFF
--- a/packages-exp/auth-exp/src/platform_browser/load_js.ts
+++ b/packages-exp/auth-exp/src/platform_browser/load_js.ts
@@ -25,9 +25,12 @@ function getScriptParentElement(): HTMLDocument | HTMLHeadElement {
 export function _loadJS(url: string): Promise<Event> {
   // TODO: consider adding timeout support & cancellation
   return new Promise((resolve, reject) => {
-    function onError(e: Event|string): void {
+    function onError(e: Event | string): void {
       const errorEvent = e as ErrorEvent;
-      const error = typeof errorEvent !== 'string' && errorEvent.error ? errorEvent.error : _createError(AuthErrorCode.INTERNAL_ERROR);
+      const error =
+        typeof errorEvent !== 'string' && errorEvent.error
+          ? errorEvent.error
+          : _createError(AuthErrorCode.INTERNAL_ERROR);
       reject(error);
     }
     const el = document.createElement('script');

--- a/packages-exp/auth-exp/src/platform_browser/load_js.ts
+++ b/packages-exp/auth-exp/src/platform_browser/load_js.ts
@@ -25,10 +25,15 @@ function getScriptParentElement(): HTMLDocument | HTMLHeadElement {
 export function _loadJS(url: string): Promise<Event> {
   // TODO: consider adding timeout support & cancellation
   return new Promise((resolve, reject) => {
+    function onError(e: Event|string): void {
+      const errorEvent = e as ErrorEvent;
+      const error = typeof errorEvent !== 'string' && errorEvent.error ? errorEvent.error : _createError(AuthErrorCode.INTERNAL_ERROR);
+      reject(error);
+    }
     const el = document.createElement('script');
     el.setAttribute('src', url);
     el.onload = resolve;
-    el.onerror = () => reject(_createError(AuthErrorCode.INTERNAL_ERROR));
+    el.onerror = onError;
     el.type = 'text/javascript';
     el.charset = 'UTF-8';
     getScriptParentElement().appendChild(el);

--- a/packages-exp/auth-exp/src/platform_browser/load_js.ts
+++ b/packages-exp/auth-exp/src/platform_browser/load_js.ts
@@ -25,18 +25,14 @@ function getScriptParentElement(): HTMLDocument | HTMLHeadElement {
 export function _loadJS(url: string): Promise<Event> {
   // TODO: consider adding timeout support & cancellation
   return new Promise((resolve, reject) => {
-    function onError(e: Event | string): void {
-      const errorEvent = e as ErrorEvent;
-      const error =
-        typeof errorEvent !== 'string' && errorEvent.error
-          ? errorEvent.error
-          : _createError(AuthErrorCode.INTERNAL_ERROR);
-      reject(error);
-    }
     const el = document.createElement('script');
     el.setAttribute('src', url);
     el.onload = resolve;
-    el.onerror = onError;
+    el.onerror = e => {
+      const error = _createError(AuthErrorCode.INTERNAL_ERROR);
+      error.customData = e as unknown as Record<string, unknown>;
+      reject(error);
+    };
     el.type = 'text/javascript';
     el.charset = 'UTF-8';
     getScriptParentElement().appendChild(el);

--- a/packages-exp/auth-exp/src/platform_browser/load_js.ts
+++ b/packages-exp/auth-exp/src/platform_browser/load_js.ts
@@ -15,6 +15,9 @@
  * limitations under the License.
  */
 
+import { AuthErrorCode } from '../core/errors';
+import { _createError } from '../core/util/assert';
+
 function getScriptParentElement(): HTMLDocument | HTMLHeadElement {
   return document.getElementsByTagName('head')?.[0] ?? document;
 }
@@ -25,7 +28,7 @@ export function _loadJS(url: string): Promise<Event> {
     const el = document.createElement('script');
     el.setAttribute('src', url);
     el.onload = resolve;
-    el.onerror = reject;
+    el.onerror = () => reject(_createError(AuthErrorCode.INTERNAL_ERROR));
     el.type = 'text/javascript';
     el.charset = 'UTF-8';
     getScriptParentElement().appendChild(el);


### PR DESCRIPTION
Fixes https://github.com/firebase/firebase-js-sdk/issues/5141
Now the promise will reject with an error instead of the result of `onerror`.