### PR TITLE
Fix more issues related to admin auth and appcheck.

### DIFF
--- a/.changeset/wet-pets-travel.md
+++ b/.changeset/wet-pets-travel.md
@@ -1,0 +1,5 @@
+---
+'@firebase/database': patch
+---
+
+Fix sending of auth tokens on node.

--- a/packages/database/src/realtime/Connection.ts
+++ b/packages/database/src/realtime/Connection.ts
@@ -123,6 +123,7 @@ export class Connection {
       this.applicationId_,
       this.appCheckToken_,
       this.authToken_,
+      null,
       this.lastSessionId
     );
 

--- a/packages/database/src/realtime/Connection.ts
+++ b/packages/database/src/realtime/Connection.ts
@@ -122,6 +122,7 @@ export class Connection {
       this.repoInfo_,
       this.applicationId_,
       this.appCheckToken_,
+      this.authToken_,
       this.lastSessionId
     );
 

--- a/packages/database/src/realtime/WebSocketConnection.ts
+++ b/packages/database/src/realtime/WebSocketConnection.ts
@@ -172,7 +172,7 @@ export class WebSocketConnection implements Transport {
         // Note that this header is just used to bypass appcheck, and the token should still be sent
         // through the websocket connection once it is established.
         if (this.authToken) {
-          options.headers['Authorization'] = this.authToken;
+          options.headers['Authorization'] = `Bearer ${this.authToken}`;
         }
         if (this.appCheckToken) {
           options.headers['X-Firebase-AppCheck'] = this.appCheckToken;
@@ -238,7 +238,7 @@ export class WebSocketConnection implements Transport {
   /**
    * No-op for websockets, we don't need to do anything once the connection is confirmed as open
    */
-  start() { }
+  start() {}
 
   static forceDisallow_: boolean;
 


### PR DESCRIPTION
This fixed two more problems with using admin credentials on node with appcheck enforced:
 1. We now pass the auth token to the transport constructor, and
 2. We set the header value to `Bearer: <token>`

Hey there! So you want to contribute to a Firebase SDK? 
Before you file this pull request, please read these guidelines:

### Discussion

  * Read the contribution guidelines (CONTRIBUTING.md).
  * If this has been discussed in an issue, make sure to link to the issue here. 
    If not, go file an issue about this **before creating a pull request** to discuss.

### Testing

  * Make sure all existing tests in the repository pass after your change.
  * If you fixed a bug or added a feature, add a new test to cover your code.

### API Changes

  * At this time we cannot accept changes that affect the public API.  If you'd like to help 
    us make Firebase APIs better, please propose your change in an issue so that we 
    can discuss it together.
