### PR TITLE
Make _delete() idempotent

### DIFF
--- a/packages/database/src/exp/Database.ts
+++ b/packages/database/src/exp/Database.ts
@@ -263,6 +263,12 @@ export class FirebaseDatabase implements _FirebaseService {
     }
     return Promise.resolve();
   }
+
+  _checkNotDeleted(apiName: string) {
+    if (this._rootInternal === null) {
+      fatal('Cannot call ' + apiName + ' on a deleted database.');
+    }
+  }
 }
 
 /**

--- a/packages/database/src/exp/Database.ts
+++ b/packages/database/src/exp/Database.ts
@@ -256,17 +256,12 @@ export class FirebaseDatabase implements _FirebaseService {
   }
 
   _delete(): Promise<void> {
-    this._checkNotDeleted('delete');
-    repoManagerDeleteRepo(this._repo, this.app.name);
-    this._repoInternal = null;
-    this._rootInternal = null;
-    return Promise.resolve();
-  }
-
-  _checkNotDeleted(apiName: string) {
-    if (this._rootInternal === null) {
-      fatal('Cannot call ' + apiName + ' on a deleted database.');
+    if (this._rootInternal !== null) {
+      repoManagerDeleteRepo(this._repo, this.app.name);
+      this._repoInternal = null;
+      this._rootInternal = null;
     }
+    return Promise.resolve();
   }
 }
 

--- a/packages/storage/compat/service.ts
+++ b/packages/storage/compat/service.ts
@@ -33,17 +33,9 @@ import { Compat } from '@firebase/util';
  * @param opt_url gs:// url to a custom Storage Bucket
  */
 export class StorageServiceCompat
-  implements types.FirebaseStorage, Compat<StorageService> {
+  implements types.FirebaseStorage, Compat<StorageService>
+{
   constructor(public app: FirebaseApp, readonly _delegate: StorageService) {}
-
-  INTERNAL = {
-    /**
-     * Called when the associated app is deleted.
-     */
-    delete: () => {
-      return this._delegate._delete();
-    }
-  };
 
   get maxOperationRetryTime(): number {
     return this._delegate.maxOperationRetryTime;

--- a/packages/storage/src/service.ts
+++ b/packages/storage/src/service.ts
@@ -269,9 +269,11 @@ export class StorageService implements _FirebaseService {
    * Stop running requests and prevent more from being created.
    */
   _delete(): Promise<void> {
-    this._deleted = true;
-    this._requests.forEach(request => request.cancel());
-    this._requests.clear();
+    if (!this._deleted) {
+      this._deleted = true;
+      this._requests.forEach(request => request.cancel());
+      this._requests.clear();
+    }
     return Promise.resolve();
   }
 

--- a/packages/storage/test/unit/service.compat.test.ts
+++ b/packages/storage/test/unit/service.compat.test.ts
@@ -333,13 +333,13 @@ GOOG4-RSA-SHA256`
       const ref = service.refFromURL('gs://mybucket/image.jpg');
       const metadataPromise = ref.getMetadata();
       // eslint-disable-next-line @typescript-eslint/no-floating-promises
-      service.INTERNAL.delete();
+      service._delegate._delete();
       await expect(metadataPromise).to.be.rejectedWith('storage/app-deleted');
     });
     it('Requests fail when started after the service is deleted', async () => {
       const ref = service.refFromURL('gs://mybucket/image.jpg');
       // eslint-disable-next-line @typescript-eslint/no-floating-promises
-      service.INTERNAL.delete();
+      service._delegate._delete();
 
       await expect(ref.getMetadata()).to.be.rejectedWith('storage/app-deleted');
     });
@@ -360,7 +360,7 @@ GOOG4-RSA-SHA256`
           }
         );
         // eslint-disable-next-line @typescript-eslint/no-floating-promises
-        service.INTERNAL.delete();
+        service._delegate._delete();
       });
       return toReturn;
     });


### PR DESCRIPTION
`_delete()` should be idempotent - it should just be a noop if the service has already been deleted. This prevents errors trying to delete an already deleted service.

Also firestore-compat and database-compat can't have their INTERNAL.delete() method removed easily because it's in a class shared by v8, exp, and compat. But storage-compat has it in a compat-only file, where it's not needed, so removed it.