### PR TITLE
Skip IndexedDB cleanup on Safari 14

### DIFF
--- a/.changeset/nine-needles-compare.md
+++ b/.changeset/nine-needles-compare.md
@@ -1,0 +1,5 @@
+---
+"@firebase/firestore": patch
+---
+
+The SDK no longer accesses IndexedDB during a page unload event on Safari 14. This aims to reduce the occurrence of an IndexedDB bug in Safari (https://bugs.webkit.org/show_bug.cgi?id=226547).

--- a/packages/firestore/src/util/async_queue.ts
+++ b/packages/firestore/src/util/async_queue.ts
@@ -223,8 +223,13 @@ export interface AsyncQueue {
    * Initialize the shutdown of this queue. Once this method is called, the
    * only possible way to request running an operation is through
    * `enqueueEvenWhileRestricted()`.
+   *
+   * @param purgeExistingTasks Whether already enqueued tasked should be
+   * rejected (unless enqueued wih `enqueueEvenWhileRestricted()`). Defaults
+   * to false.
    */
-  enterRestrictedMode(): void;
+  enterRestrictedMode(purgeExistingTasks?: boolean): void;
+
   /**
    * Adds a new operation to the queue. Returns a promise that will be resolved
    * when the promise returned by the new operation is (with its value).

--- a/packages/firestore/test/unit/util/async_queue.test.ts
+++ b/packages/firestore/test/unit/util/async_queue.test.ts
@@ -87,7 +87,7 @@ describe('AsyncQueue', () => {
 
   it('handles failures', () => {
     const queue = newAsyncQueue() as AsyncQueueImpl;
-    const expected = new Error('Firit cestore Test Simulated Error');
+    const expected = new Error('Firestore Test Simulated Error');
 
     // Disable logging for this test to avoid the assertion being logged
     const oldLogLevel = getLogLevel();
@@ -142,7 +142,7 @@ describe('AsyncQueue', () => {
       }).to.throw(/already failed:.*Simulated Error/);
 
       // Finally, restore log level.
-      setLogLevel((oldLogLevel as unknown) as LogLevelString);
+      setLogLevel(oldLogLevel as unknown as LogLevelString);
     });
   });
 
@@ -416,6 +416,21 @@ describe('AsyncQueue', () => {
 
     await queue.drain();
     expect(completedSteps).to.deep.equal([1, 2, 4]);
+  });
+
+  it('Does not run existing operations if opted out', async () => {
+    const queue = newAsyncQueue() as AsyncQueueImpl;
+    const completedSteps: number[] = [];
+    const doStep = (n: number): Promise<void> =>
+      defer(() => {
+        completedSteps.push(n);
+      });
+
+    queue.enqueueAndForget(() => doStep(1));
+    queue.enterRestrictedMode(/* purgeExistingTasks =*/ true);
+
+    await queue.drain();
+    expect(completedSteps).to.deep.equal([]);
   });
 });
 

--- a/packages/firestore/test/unit/util/async_queue.test.ts
+++ b/packages/firestore/test/unit/util/async_queue.test.ts
@@ -427,10 +427,11 @@ describe('AsyncQueue', () => {
       });
 
     queue.enqueueAndForget(() => doStep(1));
+    queue.enqueueAndForgetEvenWhileRestricted(() => doStep(2));
     queue.enterRestrictedMode(/* purgeExistingTasks =*/ true);
 
     await queue.drain();
-    expect(completedSteps).to.deep.equal([]);
+    expect(completedSteps).to.deep.equal([2]);
   });
 });
 


### PR DESCRIPTION
This PR changes our IndexedDB shutdown to skip all remaining work items on Safari 14. It is believed that writing to IndexedDB during unload can trigger a bug on Safari that prevents IndexedDB from loading during the next page load.

Fixes https://github.com/firebase/firebase-js-sdk/issues/4076