### PR TITLE
fix renovate config to group non major updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,10 +7,8 @@
   },
   "packageRules": [
     {
-      "minor": {
-        "groupName": "all non-major dependencies",
-        "groupSlug": "all-minor-patch"
-      },
+      "matchUpdateTypes": ["patch", "minor"],
+      "groupName": "all non-major dependencies",
       "excludePackageNames": ["typescript"]
     }
   ],


### PR DESCRIPTION
The old config stopped working for unknown reasons, and renovate is sending individual PRs for every dependency.