### PR TITLE
Fix transaction interference in v9

### DIFF
--- a/packages/database/src/core/view/EventRegistration.ts
+++ b/packages/database/src/core/view/EventRegistration.ts
@@ -71,8 +71,10 @@ export class CallbackContext {
   matches(other: CallbackContext): boolean {
     return (
       this.snapshotCallback === other.snapshotCallback ||
-      (this.snapshotCallback.userCallback ===
-        other.snapshotCallback.userCallback &&
+      (this.snapshotCallback.userCallback !== undefined &&
+        this.snapshotCallback.userCallback ===
+          other.snapshotCallback.userCallback &&
+        this.snapshotCallback.context !== undefined &&
         this.snapshotCallback.context === other.snapshotCallback.context)
     );
   }

--- a/packages/database/src/core/view/EventRegistration.ts
+++ b/packages/database/src/core/view/EventRegistration.ts
@@ -74,7 +74,6 @@ export class CallbackContext {
       (this.snapshotCallback.userCallback !== undefined &&
         this.snapshotCallback.userCallback ===
           other.snapshotCallback.userCallback &&
-        this.snapshotCallback.context !== undefined &&
         this.snapshotCallback.context === other.snapshotCallback.context)
     );
   }

--- a/packages/database/test/exp/integration.test.ts
+++ b/packages/database/test/exp/integration.test.ts
@@ -17,6 +17,7 @@
 
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { initializeApp, deleteApp } from '@firebase/app-exp';
+import { Deferred } from '@firebase/util';
 import { expect } from 'chai';
 
 import {
@@ -32,7 +33,6 @@ import {
 import { onValue, set } from '../../src/exp/Reference_impl';
 import { EventAccumulatorFactory } from '../helpers/EventAccumulator';
 import { DATABASE_ADDRESS, DATABASE_URL } from '../helpers/util';
-import { Deferred } from '@firebase/util';
 
 export function createTestApp() {
   return initializeApp({ databaseURL: DATABASE_URL });


### PR DESCRIPTION
This fixes a bug in listener unregistration, which exists in both the user facing `unsubscribe` API as well as runTransaction() (since it uses listeners internally).

When we unregister a listener, we go through all existing listeners to find the one that matches. We do this by comparing the callbacks for equality.

In v8, we wrap all listeners, and hence, we have to unwrap the listener to get back to the original user function before checking for equality. Our listener looks as such:

```
const listener = () => { userCallback(); /*...*/ )
listener.userCallback = userCallback;
```

In v9, we have:

```
const listener = userCallback(); 
```

Unfortunately, the comparison function considered all v9 listeners the same since it either compared `listener` (which only matches for the exact listener) or `listener.userCallback` (which matched every listener since the property was never set).

Fixes https://github.com/firebase/firebase-js-sdk/issues/5195