### PR TITLE
Fix links and update event typings

### DIFF
--- a/.changeset/wise-forks-poke.md
+++ b/.changeset/wise-forks-poke.md
@@ -1,0 +1,7 @@
+---
+'@firebase/analytics-interop-types': minor
+'@firebase/analytics-types': minor
+'firebase': minor
+---
+
+Fix formatting of links in comments and update some event typings to correctly match GA4 specs.

--- a/packages-exp/analytics-exp/src/api.ts
+++ b/packages-exp/analytics-exp/src/api.ts
@@ -221,8 +221,8 @@ export function setAnalyticsCollectionEnabled(
  * app instance on this device.
  * @public
  * List of recommended event parameters can be found in
- * {@link https://developers.google.com/gtagjs/reference/event
- * | the gtag.js reference documentation}.
+ * {@link https://developers.google.com/gtagjs/reference/ga4-events
+ * | the GA4 reference documentation}.
  */
 export function logEvent(
   analyticsInstance: Analytics,
@@ -244,8 +244,8 @@ export function logEvent(
  * app instance on this device.
  * @public
  * List of recommended event parameters can be found in
- * {@link https://developers.google.com/gtagjs/reference/event
- * | the gtag.js reference documentation}.
+ * {@link https://developers.google.com/gtagjs/reference/ga4-events
+ * | the GA4 reference documentation}.
  */
 export function logEvent(
   analyticsInstance: Analytics,
@@ -267,8 +267,8 @@ export function logEvent(
  * app instance on this device.
  * @public
  * List of recommended event parameters can be found in
- * {@link https://developers.google.com/gtagjs/reference/event
- * | the gtag.js reference documentation}.
+ * {@link https://developers.google.com/gtagjs/reference/ga4-events
+ * | the GA4 reference documentation}.
  */
 export function logEvent(
   analyticsInstance: Analytics,
@@ -288,8 +288,8 @@ export function logEvent(
  * app instance on this device.
  * @public
  * List of recommended event parameters can be found in
- * {@link https://developers.google.com/gtagjs/reference/event
- * | the gtag.js reference documentation}.
+ * {@link https://developers.google.com/gtagjs/reference/ga4-events
+ * | the GA4 reference documentation}.
  */
 export function logEvent(
   analyticsInstance: Analytics,
@@ -310,8 +310,8 @@ export function logEvent(
  * app instance on this device.
  * @public
  * List of recommended event parameters can be found in
- * {@link https://developers.google.com/gtagjs/reference/event
- * | the gtag.js reference documentation}.
+ * {@link https://developers.google.com/gtagjs/reference/ga4-events
+ * | the GA4 reference documentation}.
  */
 export function logEvent(
   analyticsInstance: Analytics,
@@ -333,9 +333,9 @@ export function logEvent(
  * automatically associates this logged event with this Firebase web
  * app instance on this device.
  * @public
- * List of recommended event parameters can be found in
- * {@link https://developers.google.com/gtagjs/reference/event
- * | the gtag.js reference documentation}.
+ * See
+ * {@link https://developers.google.com/analytics/devguides/collection/ga4/exceptions
+ * | Measure exceptions}.
  */
 export function logEvent(
   analyticsInstance: Analytics,
@@ -354,8 +354,8 @@ export function logEvent(
  * app instance on this device.
  * @public
  * List of recommended event parameters can be found in
- * {@link https://developers.google.com/gtagjs/reference/event
- * | the gtag.js reference documentation}.
+ * {@link https://developers.google.com/gtagjs/reference/ga4-events
+ * | the GA4 reference documentation}.
  */
 export function logEvent(
   analyticsInstance: Analytics,
@@ -363,7 +363,6 @@ export function logEvent(
   eventParams?: {
     value?: EventParams['value'];
     currency?: EventParams['currency'];
-    transaction_id?: EventParams['transaction_id'];
     [key: string]: any;
   },
   options?: AnalyticsCallOptions
@@ -375,8 +374,8 @@ export function logEvent(
  * app instance on this device.
  * @public
  * List of recommended event parameters can be found in
- * {@link https://developers.google.com/gtagjs/reference/event
- * | the gtag.js reference documentation}.
+ * {@link https://developers.google.com/gtagjs/reference/ga4-events
+ * | the GA4 reference documentation}.
  */
 export function logEvent(
   analyticsInstance: Analytics,
@@ -393,9 +392,9 @@ export function logEvent(
  * automatically associates this logged event with this Firebase web
  * app instance on this device.
  * @public
- * List of recommended event parameters can be found in
- * {@link https://developers.google.com/gtagjs/reference/event
- * | the gtag.js reference documentation}.
+ * See
+ * {@link https://developers.google.com/analytics/devguides/collection/ga4/page-view
+ * | Page views}.
  */
 export function logEvent(
   analyticsInstance: Analytics,
@@ -415,8 +414,8 @@ export function logEvent(
  * app instance on this device.
  * @public
  * List of recommended event parameters can be found in
- * {@link https://developers.google.com/gtagjs/reference/event
- * | the gtag.js reference documentation}.
+ * {@link https://developers.google.com/gtagjs/reference/ga4-events
+ * | the GA4 reference documentation}.
  */
 export function logEvent(
   analyticsInstance: Analytics,
@@ -440,9 +439,9 @@ export function logEvent(
  * automatically associates this logged event with this Firebase web
  * app instance on this device.
  * @public
- * List of recommended event parameters can be found in
- * {@link https://developers.google.com/gtagjs/reference/event
- * | the gtag.js reference documentation}.
+ * See
+ * {@link https://developers.google.com/analytics/devguides/collection/ga4/screen-view
+ * | Screen views}.
  */
 export function logEvent(
   analyticsInstance: Analytics,
@@ -466,8 +465,8 @@ export function logEvent(
  * app instance on this device.
  * @public
  * List of recommended event parameters can be found in
- * {@link https://developers.google.com/gtagjs/reference/event
- * | the gtag.js reference documentation}.
+ * {@link https://developers.google.com/gtagjs/reference/ga4-events
+ * | the GA4 reference documentation}.
  */
 export function logEvent(
   analyticsInstance: Analytics,
@@ -485,17 +484,15 @@ export function logEvent(
  * app instance on this device.
  * @public
  * List of recommended event parameters can be found in
- * {@link https://developers.google.com/gtagjs/reference/event
- * | the gtag.js reference documentation}.
+ * {@link https://developers.google.com/gtagjs/reference/ga4-events
+ * | the GA4 reference documentation}.
  */
 export function logEvent(
   analyticsInstance: Analytics,
   eventName: 'select_content',
   eventParams?: {
-    items?: EventParams['items'];
-    promotions?: EventParams['promotions'];
     content_type?: EventParams['content_type'];
-    content_id?: EventParams['content_id'];
+    item_id?: EventParams['item_id'];
     [key: string]: any;
   },
   options?: AnalyticsCallOptions
@@ -507,8 +504,8 @@ export function logEvent(
  * app instance on this device.
  * @public
  * List of recommended event parameters can be found in
- * {@link https://developers.google.com/gtagjs/reference/event
- * | the gtag.js reference documentation}.
+ * {@link https://developers.google.com/gtagjs/reference/ga4-events
+ * | the GA4 reference documentation}.
  */
 export function logEvent(
   analyticsInstance: Analytics,
@@ -528,8 +525,8 @@ export function logEvent(
  * app instance on this device.
  * @public
  * List of recommended event parameters can be found in
- * {@link https://developers.google.com/gtagjs/reference/event
- * | the gtag.js reference documentation}.
+ * {@link https://developers.google.com/gtagjs/reference/ga4-events
+ * | the GA4 reference documentation}.
  */
 export function logEvent(
   analyticsInstance: Analytics,
@@ -549,8 +546,8 @@ export function logEvent(
  * app instance on this device.
  * @public
  * List of recommended event parameters can be found in
- * {@link https://developers.google.com/gtagjs/reference/event
- * | the gtag.js reference documentation}.
+ * {@link https://developers.google.com/gtagjs/reference/ga4-events
+ * | the GA4 reference documentation}.
  */
 export function logEvent(
   analyticsInstance: Analytics,
@@ -569,8 +566,8 @@ export function logEvent(
  * app instance on this device.
  * @public
  * List of recommended event parameters can be found in
- * {@link https://developers.google.com/gtagjs/reference/event
- * | the gtag.js reference documentation}.
+ * {@link https://developers.google.com/gtagjs/reference/ga4-events
+ * | the GA4 reference documentation}.
  */
 export function logEvent(
   analyticsInstance: Analytics,
@@ -578,7 +575,7 @@ export function logEvent(
   eventParams?: {
     method?: EventParams['method'];
     content_type?: EventParams['content_type'];
-    content_id?: EventParams['content_id'];
+    item_id?: EventParams['item_id'];
     [key: string]: any;
   },
   options?: AnalyticsCallOptions
@@ -590,8 +587,8 @@ export function logEvent(
  * app instance on this device.
  * @public
  * List of recommended event parameters can be found in
- * {@link https://developers.google.com/gtagjs/reference/event
- * | the gtag.js reference documentation}.
+ * {@link https://developers.google.com/gtagjs/reference/ga4-events
+ * | the GA4 reference documentation}.
  */
 export function logEvent(
   analyticsInstance: Analytics,
@@ -609,8 +606,8 @@ export function logEvent(
  * app instance on this device.
  * @public
  * List of recommended event parameters can be found in
- * {@link https://developers.google.com/gtagjs/reference/event
- * | the gtag.js reference documentation}.
+ * {@link https://developers.google.com/gtagjs/reference/ga4-events
+ * | the GA4 reference documentation}.
  */
 export function logEvent(
   analyticsInstance: Analytics,
@@ -631,8 +628,8 @@ export function logEvent(
  * app instance on this device.
  * @public
  * List of recommended event parameters can be found in
- * {@link https://developers.google.com/gtagjs/reference/event
- * | the gtag.js reference documentation}.
+ * {@link https://developers.google.com/gtagjs/reference/ga4-events
+ * | the GA4 reference documentation}.
  */
 export function logEvent(
   analyticsInstance: Analytics,
@@ -652,8 +649,8 @@ export function logEvent(
  * app instance on this device.
  * @public
  * List of recommended event parameters can be found in
- * {@link https://developers.google.com/gtagjs/reference/event
- * | the gtag.js reference documentation}.
+ * {@link https://developers.google.com/gtagjs/reference/ga4-events
+ * | the GA4 reference documentation}.
  */
 export function logEvent(
   analyticsInstance: Analytics,
@@ -673,8 +670,8 @@ export function logEvent(
  * app instance on this device.
  * @public
  * List of recommended event parameters can be found in
- * {@link https://developers.google.com/gtagjs/reference/event
- * | the gtag.js reference documentation}.
+ * {@link https://developers.google.com/gtagjs/reference/ga4-events
+ * | the GA4 reference documentation}.
  */
 export function logEvent<T extends string>(
   analyticsInstance: Analytics,
@@ -689,8 +686,8 @@ export function logEvent<T extends string>(
  * app instance on this device.
  * List of official event parameters can be found in the gtag.js
  * reference documentation:
- * {@link https://developers.google.com/gtagjs/reference/event
- * | the gtag.js reference documentation}.
+ * {@link https://developers.google.com/gtagjs/reference/ga4-events
+ * | the GA4 reference documentation}.
  *
  * @public
  */

--- a/packages-exp/analytics-exp/src/api.ts
+++ b/packages-exp/analytics-exp/src/api.ts
@@ -439,21 +439,13 @@ export function logEvent(
  * automatically associates this logged event with this Firebase web
  * app instance on this device.
  * @public
- * See
- * {@link https://developers.google.com/analytics/devguides/collection/ga4/screen-view
- * | Screen views}.
  */
 export function logEvent(
   analyticsInstance: Analytics,
   eventName: 'screen_view',
   eventParams?: {
-    app_name: string;
-    screen_name: EventParams['screen_name'];
     firebase_screen: EventParams['firebase_screen'];
     firebase_screen_class: EventParams['firebase_screen_class'];
-    app_id?: string;
-    app_version?: string;
-    app_installer_id?: string;
     [key: string]: any;
   },
   options?: AnalyticsCallOptions

--- a/packages-exp/analytics-exp/src/api.ts
+++ b/packages-exp/analytics-exp/src/api.ts
@@ -439,6 +439,8 @@ export function logEvent(
  * automatically associates this logged event with this Firebase web
  * app instance on this device.
  * @public
+ * See {@link https://firebase.google.com/docs/analytics/screenviews
+ * | Track Screenviews}.
  */
 export function logEvent(
   analyticsInstance: Analytics,

--- a/packages-exp/analytics-exp/src/public-types.ts
+++ b/packages-exp/analytics-exp/src/public-types.ts
@@ -27,74 +27,55 @@ export interface GtagConfigParams {
    * Whether or not a page view should be sent.
    * If set to true (default), a page view is automatically sent upon initialization
    * of analytics.
-   * See https://developers.google.com/analytics/devguides/collection/gtagjs/pages
+   * See {@link https://developers.google.com/analytics/devguides/collection/ga4/page-view | Page views }
    */
   'send_page_view'?: boolean;
   /**
    * The title of the page.
-   * See https://developers.google.com/analytics/devguides/collection/gtagjs/pages
+   * See {@link https://developers.google.com/analytics/devguides/collection/ga4/page-view | Page views }
    */
   'page_title'?: string;
   /**
-   * The path to the page. If overridden, this value must start with a / character.
-   * See https://developers.google.com/analytics/devguides/collection/gtagjs/pages
-   */
-  'page_path'?: string;
-  /**
    * The URL of the page.
-   * See https://developers.google.com/analytics/devguides/collection/gtagjs/pages
+   * See {@link https://developers.google.com/analytics/devguides/collection/ga4/page-view | Page views }
    */
   'page_location'?: string;
   /**
    * Defaults to `auto`.
-   * See https://developers.google.com/analytics/devguides/collection/gtagjs/cookies-user-id
+   * See {@link https://developers.google.com/analytics/devguides/collection/ga4/cookies-user-id | Cookies and user identification }
    */
   'cookie_domain'?: string;
   /**
    * Defaults to 63072000 (two years, in seconds).
-   * See https://developers.google.com/analytics/devguides/collection/gtagjs/cookies-user-id
+   * See {@link https://developers.google.com/analytics/devguides/collection/ga4/cookies-user-id | Cookies and user identification }
    */
   'cookie_expires'?: number;
   /**
    * Defaults to `_ga`.
-   * See https://developers.google.com/analytics/devguides/collection/gtagjs/cookies-user-id
+   * See {@link https://developers.google.com/analytics/devguides/collection/ga4/cookies-user-id | Cookies and user identification }
    */
   'cookie_prefix'?: string;
   /**
    * If set to true, will update cookies on each page load.
    * Defaults to true.
-   * See https://developers.google.com/analytics/devguides/collection/gtagjs/cookies-user-id
+   * See {@link https://developers.google.com/analytics/devguides/collection/ga4/cookies-user-id | Cookies and user identification }
    */
   'cookie_update'?: boolean;
   /**
    * Appends additional flags to the cookie when set.
-   * See https://developers.google.com/analytics/devguides/collection/gtagjs/cookies-user-id
+   * See {@link https://developers.google.com/analytics/devguides/collection/ga4/cookies-user-id | Cookies and user identification }
    */
   'cookie_flags'?: string;
   /**
    * If set to false, disables all advertising features with gtag.js.
-   * See https://developers.google.com/analytics/devguides/collection/gtagjs/display-features
+   * See {@link https://developers.google.com/analytics/devguides/collection/ga4/display-features | Disable advertising features }
    */
   'allow_google_signals?': boolean;
   /**
    * If set to false, disables all advertising personalization with gtag.js.
-   * See https://developers.google.com/analytics/devguides/collection/gtagjs/display-features
+   * See {@link https://developers.google.com/analytics/devguides/collection/ga4/display-features | Disable advertising features }
    */
   'allow_ad_personalization_signals'?: boolean;
-  /**
-   * See https://developers.google.com/analytics/devguides/collection/gtagjs/enhanced-link-attribution
-   */
-  'link_attribution'?: boolean;
-  /**
-   * If set to true, anonymizes IP addresses for all events.
-   * See https://developers.google.com/analytics/devguides/collection/gtagjs/ip-anonymization
-   */
-  'anonymize_ip'?: boolean;
-  /**
-   * Custom dimensions and metrics.
-   * See https://developers.google.com/analytics/devguides/collection/gtagjs/custom-dims-mets
-   */
-  'custom_map'?: { [key: string]: unknown };
   [key: string]: unknown;
 }
 
@@ -246,8 +227,8 @@ export interface Promotion {
 /**
  * Standard gtag.js control parameters.
  * For more information, see
- * {@link https://developers.google.com/gtagjs/reference/parameter
- * | the gtag.js documentation on parameters}.
+ * {@link https://developers.google.com/gtagjs/reference/ga4-events
+ * the GA4 reference documentation}.
  * @public
  */
 export interface ControlParams {
@@ -260,14 +241,14 @@ export interface ControlParams {
 /**
  * Standard gtag.js event parameters.
  * For more information, see
- * {@link https://developers.google.com/gtagjs/reference/parameter
- * | the gtag.js documentation on parameters}.
+ * {@link https://developers.google.com/gtagjs/reference/ga4-events
+ * the GA4 reference documentation}.
  * @public
  */
 export interface EventParams {
   checkout_option?: string;
   checkout_step?: number;
-  content_id?: string;
+  item_id?: string;
   content_type?: string;
   coupon?: string;
   currency?: string;

--- a/packages-exp/firebase-exp/compat/index.d.ts
+++ b/packages-exp/firebase-exp/compat/index.d.ts
@@ -4887,18 +4887,14 @@ declare namespace firebase.analytics {
      * Sends analytics event with given `eventParams`. This method
      * automatically associates this logged event with this Firebase web
      * app instance on this device.
-     * See
-     * {@link https://developers.google.com/analytics/devguides/collection/ga4/screen-view
-     * | Screen views}.
+     * See {@link https://firebase.google.com/docs/analytics/screenviews
+     * | Track Screenviews}.
      */
     logEvent(
       eventName: 'screen_view',
       eventParams?: {
-        app_name: string;
-        screen_name: EventParams['screen_name'];
-        app_id?: string;
-        app_version?: string;
-        app_installer_id?: string;
+        firebase_screen: EventParams['firebase_screen'];
+        firebase_screen_class: EventParams['firebase_screen_class'];
         [key: string]: any;
       },
       options?: firebase.analytics.AnalyticsCallOptions
@@ -5197,6 +5193,14 @@ declare namespace firebase.analytics {
     currency?: string;
     description?: string;
     fatal?: boolean;
+    /**
+     * Firebase-specific. Use to log a `screen_name` to Firebase Analytics.
+     */
+    firebase_screen?: string;
+    /**
+     * Firebase-specific. Use to log a `screen_class` to Firebase Analytics.
+     */
+    firebase_screen_class?: string;
     items?: Item[];
     method?: string;
     number?: string;

--- a/packages-exp/firebase-exp/compat/index.d.ts
+++ b/packages-exp/firebase-exp/compat/index.d.ts
@@ -4689,8 +4689,8 @@ declare namespace firebase.analytics {
      * automatically associates this logged event with this Firebase web
      * app instance on this device.
      * List of recommended event parameters can be found in
-     * {@link https://developers.google.com/gtagjs/reference/event
-     * the gtag.js reference documentation}.
+     * {@link https://developers.google.com/gtagjs/reference/ga4-events
+     * | the GA4 reference documentation}.
      */
     logEvent(
       eventName: 'add_payment_info',
@@ -4710,8 +4710,8 @@ declare namespace firebase.analytics {
      * automatically associates this logged event with this Firebase web
      * app instance on this device.
      * List of recommended event parameters can be found in
-     * {@link https://developers.google.com/gtagjs/reference/event
-     * the gtag.js reference documentation}.
+     * {@link https://developers.google.com/gtagjs/reference/ga4-events
+     * | the GA4 reference documentation}.
      */
     logEvent(
       eventName: 'add_shipping_info',
@@ -4731,8 +4731,8 @@ declare namespace firebase.analytics {
      * automatically associates this logged event with this Firebase web
      * app instance on this device.
      * List of recommended event parameters can be found in
-     * {@link https://developers.google.com/gtagjs/reference/event
-     * the gtag.js reference documentation}.
+     * {@link https://developers.google.com/gtagjs/reference/ga4-events
+     * | the GA4 reference documentation}.
      */
     logEvent(
       eventName: 'add_to_cart' | 'add_to_wishlist' | 'remove_from_cart',
@@ -4750,8 +4750,8 @@ declare namespace firebase.analytics {
      * automatically associates this logged event with this Firebase web
      * app instance on this device.
      * List of recommended event parameters can be found in
-     * {@link https://developers.google.com/gtagjs/reference/event
-     * the gtag.js reference documentation}.
+     * {@link https://developers.google.com/gtagjs/reference/ga4-events
+     * | the GA4 reference documentation}.
      */
     logEvent(
       eventName: 'begin_checkout',
@@ -4770,8 +4770,8 @@ declare namespace firebase.analytics {
      * automatically associates this logged event with this Firebase web
      * app instance on this device.
      * List of recommended event parameters can be found in
-     * {@link https://developers.google.com/gtagjs/reference/event
-     * the gtag.js reference documentation}.
+     * {@link https://developers.google.com/gtagjs/reference/ga4-events
+     * | the GA4 reference documentation}.
      */
     logEvent(
       eventName: 'checkout_progress',
@@ -4791,9 +4791,9 @@ declare namespace firebase.analytics {
      * Sends analytics event with given `eventParams`. This method
      * automatically associates this logged event with this Firebase web
      * app instance on this device.
-     * List of recommended event parameters can be found in
-     * {@link https://developers.google.com/gtagjs/reference/event
-     * the gtag.js reference documentation}.
+     * See
+     * {@link https://developers.google.com/analytics/devguides/collection/ga4/exceptions
+     * | Measure exceptions}.
      */
     logEvent(
       eventName: 'exception',
@@ -4810,15 +4810,14 @@ declare namespace firebase.analytics {
      * automatically associates this logged event with this Firebase web
      * app instance on this device.
      * List of recommended event parameters can be found in
-     * {@link https://developers.google.com/gtagjs/reference/event
-     * the gtag.js reference documentation}.
+     * {@link https://developers.google.com/gtagjs/reference/ga4-events
+     * | the GA4 reference documentation}.
      */
     logEvent(
       eventName: 'generate_lead',
       eventParams?: {
         value?: EventParams['value'];
         currency?: EventParams['currency'];
-        transaction_id?: EventParams['transaction_id'];
         [key: string]: any;
       },
       options?: firebase.analytics.AnalyticsCallOptions
@@ -4829,8 +4828,8 @@ declare namespace firebase.analytics {
      * automatically associates this logged event with this Firebase web
      * app instance on this device.
      * List of recommended event parameters can be found in
-     * {@link https://developers.google.com/gtagjs/reference/event
-     * the gtag.js reference documentation}.
+     * {@link https://developers.google.com/gtagjs/reference/ga4-events
+     * | the GA4 reference documentation}.
      */
     logEvent(
       eventName: 'login',
@@ -4845,9 +4844,9 @@ declare namespace firebase.analytics {
      * Sends analytics event with given `eventParams`. This method
      * automatically associates this logged event with this Firebase web
      * app instance on this device.
-     * List of recommended event parameters can be found in
-     * {@link https://developers.google.com/gtagjs/reference/event
-     * the gtag.js reference documentation}.
+     * See
+     * {@link https://developers.google.com/analytics/devguides/collection/ga4/page-view
+     * | Page views}.
      */
     logEvent(
       eventName: 'page_view',
@@ -4865,8 +4864,8 @@ declare namespace firebase.analytics {
      * automatically associates this logged event with this Firebase web
      * app instance on this device.
      * List of recommended event parameters can be found in
-     * {@link https://developers.google.com/gtagjs/reference/event
-     * the gtag.js reference documentation}.
+     * {@link https://developers.google.com/gtagjs/reference/ga4-events
+     * | the GA4 reference documentation}.
      */
     logEvent(
       eventName: 'purchase' | 'refund',
@@ -4888,9 +4887,9 @@ declare namespace firebase.analytics {
      * Sends analytics event with given `eventParams`. This method
      * automatically associates this logged event with this Firebase web
      * app instance on this device.
-     * List of recommended event parameters can be found in
-     * {@link https://developers.google.com/gtagjs/reference/event
-     * the gtag.js reference documentation}.
+     * See
+     * {@link https://developers.google.com/analytics/devguides/collection/ga4/screen-view
+     * | Screen views}.
      */
     logEvent(
       eventName: 'screen_view',
@@ -4910,8 +4909,8 @@ declare namespace firebase.analytics {
      * automatically associates this logged event with this Firebase web
      * app instance on this device.
      * List of recommended event parameters can be found in
-     * {@link https://developers.google.com/gtagjs/reference/event
-     * the gtag.js reference documentation}.
+     * {@link https://developers.google.com/gtagjs/reference/ga4-events
+     * | the GA4 reference documentation}.
      */
     logEvent(
       eventName: 'search' | 'view_search_results',
@@ -4927,16 +4926,14 @@ declare namespace firebase.analytics {
      * automatically associates this logged event with this Firebase web
      * app instance on this device.
      * List of recommended event parameters can be found in
-     * {@link https://developers.google.com/gtagjs/reference/event
-     * the gtag.js reference documentation}.
+     * {@link https://developers.google.com/gtagjs/reference/ga4-events
+     * | the GA4 reference documentation}.
      */
     logEvent(
       eventName: 'select_content',
       eventParams?: {
-        items?: EventParams['items'];
-        promotions?: EventParams['promotions'];
         content_type?: EventParams['content_type'];
-        content_id?: EventParams['content_id'];
+        item_id?: EventParams['item_id'];
         [key: string]: any;
       },
       options?: firebase.analytics.AnalyticsCallOptions
@@ -4947,8 +4944,8 @@ declare namespace firebase.analytics {
      * automatically associates this logged event with this Firebase web
      * app instance on this device.
      * List of recommended event parameters can be found in
-     * {@link https://developers.google.com/gtagjs/reference/event
-     * the gtag.js reference documentation}.
+     * {@link https://developers.google.com/gtagjs/reference/ga4-events
+     * | the GA4 reference documentation}.
      */
     logEvent(
       eventName: 'select_item',
@@ -4966,8 +4963,8 @@ declare namespace firebase.analytics {
      * automatically associates this logged event with this Firebase web
      * app instance on this device.
      * List of recommended event parameters can be found in
-     * {@link https://developers.google.com/gtagjs/reference/event
-     * the gtag.js reference documentation}.
+     * {@link https://developers.google.com/gtagjs/reference/ga4-events
+     * | the GA4 reference documentation}.
      */
     logEvent(
       eventName: 'select_promotion' | 'view_promotion',
@@ -4985,8 +4982,8 @@ declare namespace firebase.analytics {
      * automatically associates this logged event with this Firebase web
      * app instance on this device.
      * List of recommended event parameters can be found in
-     * {@link https://developers.google.com/gtagjs/reference/event
-     * the gtag.js reference documentation}.
+     * {@link https://developers.google.com/gtagjs/reference/ga4-events
+     * | the GA4 reference documentation}.
      */
     logEvent(
       eventName: 'set_checkout_option',
@@ -5003,15 +5000,15 @@ declare namespace firebase.analytics {
      * automatically associates this logged event with this Firebase web
      * app instance on this device.
      * List of recommended event parameters can be found in
-     * {@link https://developers.google.com/gtagjs/reference/event
-     * the gtag.js reference documentation}.
+     * {@link https://developers.google.com/gtagjs/reference/ga4-events
+     * | the GA4 reference documentation}.
      */
     logEvent(
       eventName: 'share',
       eventParams?: {
         method?: EventParams['method'];
         content_type?: EventParams['content_type'];
-        content_id?: EventParams['content_id'];
+        item_id?: EventParams['item_id'];
         [key: string]: any;
       },
       options?: firebase.analytics.AnalyticsCallOptions
@@ -5022,8 +5019,8 @@ declare namespace firebase.analytics {
      * automatically associates this logged event with this Firebase web
      * app instance on this device.
      * List of recommended event parameters can be found in
-     * {@link https://developers.google.com/gtagjs/reference/event
-     * the gtag.js reference documentation}.
+     * {@link https://developers.google.com/gtagjs/reference/ga4-events
+     * | the GA4 reference documentation}.
      */
     logEvent(
       eventName: 'sign_up',
@@ -5039,8 +5036,8 @@ declare namespace firebase.analytics {
      * automatically associates this logged event with this Firebase web
      * app instance on this device.
      * List of recommended event parameters can be found in
-     * {@link https://developers.google.com/gtagjs/reference/event
-     * the gtag.js reference documentation}.
+     * {@link https://developers.google.com/gtagjs/reference/ga4-events
+     * | the GA4 reference documentation}.
      */
     logEvent(
       eventName: 'timing_complete',
@@ -5059,8 +5056,8 @@ declare namespace firebase.analytics {
      * automatically associates this logged event with this Firebase web
      * app instance on this device.
      * List of recommended event parameters can be found in
-     * {@link https://developers.google.com/gtagjs/reference/event
-     * the gtag.js reference documentation}.
+     * {@link https://developers.google.com/gtagjs/reference/ga4-events
+     * | the GA4 reference documentation}.
      */
     logEvent(
       eventName: 'view_cart' | 'view_item',
@@ -5078,8 +5075,8 @@ declare namespace firebase.analytics {
      * automatically associates this logged event with this Firebase web
      * app instance on this device.
      * List of recommended event parameters can be found in
-     * {@link https://developers.google.com/gtagjs/reference/event
-     * the gtag.js reference documentation}.
+     * {@link https://developers.google.com/gtagjs/reference/ga4-events
+     * | the GA4 reference documentation}.
      */
     logEvent(
       eventName: 'view_item_list',
@@ -5097,8 +5094,8 @@ declare namespace firebase.analytics {
      * automatically associates this logged event with this Firebase web
      * app instance on this device.
      * List of recommended event parameters can be found in
-     * {@link https://developers.google.com/gtagjs/reference/event
-     * the gtag.js reference documentation}.
+     * {@link https://developers.google.com/gtagjs/reference/ga4-events
+     * | the GA4 reference documentation}.
      */
     logEvent<T extends string>(
       eventName: CustomEventName<T>,
@@ -5194,7 +5191,7 @@ declare namespace firebase.analytics {
   export interface EventParams {
     checkout_option?: string;
     checkout_step?: number;
-    content_id?: string;
+    item_id?: string;
     content_type?: string;
     coupon?: string;
     currency?: string;

--- a/packages/analytics-interop-types/index.d.ts
+++ b/packages/analytics-interop-types/index.d.ts
@@ -21,8 +21,8 @@ export interface FirebaseAnalyticsInternal {
    * automatically associates this logged event with this Firebase web
    * app instance on this device.
    * List of official event parameters can be found in
-   * {@link https://developers.google.com/gtagjs/reference/event
-   * the gtag.js reference documentation}.
+   * {@link https://developers.google.com/gtagjs/reference/ga4-events
+   * the GA4 reference documentation}.
    */
   logEvent(
     eventName: string,

--- a/packages/analytics-types/index.d.ts
+++ b/packages/analytics-types/index.d.ts
@@ -41,8 +41,8 @@ export interface FirebaseAnalytics {
    * automatically associates this logged event with this Firebase web
    * app instance on this device.
    * List of recommended event parameters can be found in
-   * {@link https://developers.google.com/gtagjs/reference/event
-   * the gtag.js reference documentation}.
+   * {@link https://developers.google.com/gtagjs/reference/ga4-events
+   * | the GA4 reference documentation}.
    */
   logEvent(
     eventName: 'add_payment_info',
@@ -62,8 +62,8 @@ export interface FirebaseAnalytics {
    * automatically associates this logged event with this Firebase web
    * app instance on this device.
    * List of recommended event parameters can be found in
-   * {@link https://developers.google.com/gtagjs/reference/event
-   * the gtag.js reference documentation}.
+   * {@link https://developers.google.com/gtagjs/reference/ga4-events
+   * | the GA4 reference documentation}.
    */
   logEvent(
     eventName: 'add_shipping_info',
@@ -83,8 +83,8 @@ export interface FirebaseAnalytics {
    * automatically associates this logged event with this Firebase web
    * app instance on this device.
    * List of recommended event parameters can be found in
-   * {@link https://developers.google.com/gtagjs/reference/event
-   * the gtag.js reference documentation}.
+   * {@link https://developers.google.com/gtagjs/reference/ga4-events
+   * | the GA4 reference documentation}.
    */
   logEvent(
     eventName: 'add_to_cart' | 'add_to_wishlist' | 'remove_from_cart',
@@ -102,8 +102,8 @@ export interface FirebaseAnalytics {
    * automatically associates this logged event with this Firebase web
    * app instance on this device.
    * List of recommended event parameters can be found in
-   * {@link https://developers.google.com/gtagjs/reference/event
-   * the gtag.js reference documentation}.
+   * {@link https://developers.google.com/gtagjs/reference/ga4-events
+   * | the GA4 reference documentation}.
    */
   logEvent(
     eventName: 'begin_checkout',
@@ -122,8 +122,8 @@ export interface FirebaseAnalytics {
    * automatically associates this logged event with this Firebase web
    * app instance on this device.
    * List of recommended event parameters can be found in
-   * {@link https://developers.google.com/gtagjs/reference/event
-   * the gtag.js reference documentation}.
+   * {@link https://developers.google.com/gtagjs/reference/ga4-events
+   * | the GA4 reference documentation}.
    */
   logEvent(
     eventName: 'checkout_progress',
@@ -143,9 +143,9 @@ export interface FirebaseAnalytics {
    * Sends analytics event with given `eventParams`. This method
    * automatically associates this logged event with this Firebase web
    * app instance on this device.
-   * List of recommended event parameters can be found in
-   * {@link https://developers.google.com/gtagjs/reference/event
-   * the gtag.js reference documentation}.
+   * See
+   * {@link https://developers.google.com/analytics/devguides/collection/ga4/exceptions
+   * | Measure exceptions}.
    */
   logEvent(
     eventName: 'exception',
@@ -162,15 +162,14 @@ export interface FirebaseAnalytics {
    * automatically associates this logged event with this Firebase web
    * app instance on this device.
    * List of recommended event parameters can be found in
-   * {@link https://developers.google.com/gtagjs/reference/event
-   * the gtag.js reference documentation}.
+   * {@link https://developers.google.com/gtagjs/reference/ga4-events
+   * | the GA4 reference documentation}.
    */
   logEvent(
     eventName: 'generate_lead',
     eventParams?: {
       value?: EventParams['value'];
       currency?: EventParams['currency'];
-      transaction_id?: EventParams['transaction_id'];
       [key: string]: any;
     },
     options?: AnalyticsCallOptions
@@ -181,8 +180,8 @@ export interface FirebaseAnalytics {
    * automatically associates this logged event with this Firebase web
    * app instance on this device.
    * List of recommended event parameters can be found in
-   * {@link https://developers.google.com/gtagjs/reference/event
-   * the gtag.js reference documentation}.
+   * {@link https://developers.google.com/gtagjs/reference/ga4-events
+   * | the GA4 reference documentation}.
    */
   logEvent(
     eventName: 'login',
@@ -197,9 +196,9 @@ export interface FirebaseAnalytics {
    * Sends analytics event with given `eventParams`. This method
    * automatically associates this logged event with this Firebase web
    * app instance on this device.
-   * List of recommended event parameters can be found in
-   * {@link https://developers.google.com/gtagjs/reference/event
-   * the gtag.js reference documentation}.
+   * See
+   * {@link https://developers.google.com/analytics/devguides/collection/ga4/page-view
+   * | Page views}.
    */
   logEvent(
     eventName: 'page_view',
@@ -217,8 +216,8 @@ export interface FirebaseAnalytics {
    * automatically associates this logged event with this Firebase web
    * app instance on this device.
    * List of recommended event parameters can be found in
-   * {@link https://developers.google.com/gtagjs/reference/event
-   * the gtag.js reference documentation}.
+   * {@link https://developers.google.com/gtagjs/reference/ga4-events
+   * | the GA4 reference documentation}.
    */
   logEvent(
     eventName: 'purchase' | 'refund',
@@ -240,9 +239,9 @@ export interface FirebaseAnalytics {
    * Sends analytics event with given `eventParams`. This method
    * automatically associates this logged event with this Firebase web
    * app instance on this device.
-   * List of recommended event parameters can be found in
-   * {@link https://developers.google.com/gtagjs/reference/event
-   * the gtag.js reference documentation}.
+   * See
+   * {@link https://developers.google.com/analytics/devguides/collection/ga4/screen-view
+   * | Screen views}.
    */
   logEvent(
     eventName: 'screen_view',
@@ -264,8 +263,8 @@ export interface FirebaseAnalytics {
    * automatically associates this logged event with this Firebase web
    * app instance on this device.
    * List of recommended event parameters can be found in
-   * {@link https://developers.google.com/gtagjs/reference/event
-   * the gtag.js reference documentation}.
+   * {@link https://developers.google.com/gtagjs/reference/ga4-events
+   * | the GA4 reference documentation}.
    */
   logEvent(
     eventName: 'search' | 'view_search_results',
@@ -281,16 +280,14 @@ export interface FirebaseAnalytics {
    * automatically associates this logged event with this Firebase web
    * app instance on this device.
    * List of recommended event parameters can be found in
-   * {@link https://developers.google.com/gtagjs/reference/event
-   * the gtag.js reference documentation}.
+   * {@link https://developers.google.com/gtagjs/reference/ga4-events
+   * | the GA4 reference documentation}.
    */
   logEvent(
     eventName: 'select_content',
     eventParams?: {
-      items?: EventParams['items'];
-      promotions?: EventParams['promotions'];
       content_type?: EventParams['content_type'];
-      content_id?: EventParams['content_id'];
+      item_id?: EventParams['item_id'];
       [key: string]: any;
     },
     options?: AnalyticsCallOptions
@@ -301,8 +298,8 @@ export interface FirebaseAnalytics {
    * automatically associates this logged event with this Firebase web
    * app instance on this device.
    * List of recommended event parameters can be found in
-   * {@link https://developers.google.com/gtagjs/reference/event
-   * the gtag.js reference documentation}.
+   * {@link https://developers.google.com/gtagjs/reference/ga4-events
+   * | the GA4 reference documentation}.
    */
   logEvent(
     eventName: 'select_item',
@@ -320,8 +317,8 @@ export interface FirebaseAnalytics {
    * automatically associates this logged event with this Firebase web
    * app instance on this device.
    * List of recommended event parameters can be found in
-   * {@link https://developers.google.com/gtagjs/reference/event
-   * the gtag.js reference documentation}.
+   * {@link https://developers.google.com/gtagjs/reference/ga4-events
+   * | the GA4 reference documentation}.
    */
   logEvent(
     eventName: 'select_promotion' | 'view_promotion',
@@ -339,8 +336,8 @@ export interface FirebaseAnalytics {
    * automatically associates this logged event with this Firebase web
    * app instance on this device.
    * List of recommended event parameters can be found in
-   * {@link https://developers.google.com/gtagjs/reference/event
-   * the gtag.js reference documentation}.
+   * {@link https://developers.google.com/gtagjs/reference/ga4-events
+   * | the GA4 reference documentation}.
    */
   logEvent(
     eventName: 'set_checkout_option',
@@ -357,15 +354,15 @@ export interface FirebaseAnalytics {
    * automatically associates this logged event with this Firebase web
    * app instance on this device.
    * List of recommended event parameters can be found in
-   * {@link https://developers.google.com/gtagjs/reference/event
-   * the gtag.js reference documentation}.
+   * {@link https://developers.google.com/gtagjs/reference/ga4-events
+   * | the GA4 reference documentation}.
    */
   logEvent(
     eventName: 'share',
     eventParams?: {
       method?: EventParams['method'];
       content_type?: EventParams['content_type'];
-      content_id?: EventParams['content_id'];
+      item_id?: EventParams['item_id'];
       [key: string]: any;
     },
     options?: AnalyticsCallOptions
@@ -376,8 +373,8 @@ export interface FirebaseAnalytics {
    * automatically associates this logged event with this Firebase web
    * app instance on this device.
    * List of recommended event parameters can be found in
-   * {@link https://developers.google.com/gtagjs/reference/event
-   * the gtag.js reference documentation}.
+   * {@link https://developers.google.com/gtagjs/reference/ga4-events
+   * | the GA4 reference documentation}.
    */
   logEvent(
     eventName: 'sign_up',
@@ -393,8 +390,8 @@ export interface FirebaseAnalytics {
    * automatically associates this logged event with this Firebase web
    * app instance on this device.
    * List of recommended event parameters can be found in
-   * {@link https://developers.google.com/gtagjs/reference/event
-   * the gtag.js reference documentation}.
+   * {@link https://developers.google.com/gtagjs/reference/ga4-events
+   * | the GA4 reference documentation}.
    */
   logEvent(
     eventName: 'timing_complete',
@@ -413,8 +410,8 @@ export interface FirebaseAnalytics {
    * automatically associates this logged event with this Firebase web
    * app instance on this device.
    * List of recommended event parameters can be found in
-   * {@link https://developers.google.com/gtagjs/reference/event
-   * the gtag.js reference documentation}.
+   * {@link https://developers.google.com/gtagjs/reference/ga4-events
+   * | the GA4 reference documentation}.
    */
   logEvent(
     eventName: 'view_cart' | 'view_item',
@@ -432,8 +429,8 @@ export interface FirebaseAnalytics {
    * automatically associates this logged event with this Firebase web
    * app instance on this device.
    * List of recommended event parameters can be found in
-   * {@link https://developers.google.com/gtagjs/reference/event
-   * the gtag.js reference documentation}.
+   * {@link https://developers.google.com/gtagjs/reference/ga4-events
+   * | the GA4 reference documentation}.
    */
   logEvent(
     eventName: 'view_item_list',
@@ -451,8 +448,8 @@ export interface FirebaseAnalytics {
    * automatically associates this logged event with this Firebase web
    * app instance on this device.
    * List of recommended event parameters can be found in
-   * {@link https://developers.google.com/gtagjs/reference/event
-   * the gtag.js reference documentation}.
+   * {@link https://developers.google.com/gtagjs/reference/ga4-events
+   * | the GA4 reference documentation}.
    */
   logEvent<T extends string>(
     eventName: CustomEventName<T>,
@@ -537,7 +534,7 @@ export interface ControlParams {
 export interface EventParams {
   checkout_option?: string;
   checkout_step?: number;
-  content_id?: string;
+  item_id?: string;
   content_type?: string;
   coupon?: string;
   currency?: string;

--- a/packages/analytics-types/index.d.ts
+++ b/packages/analytics-types/index.d.ts
@@ -239,20 +239,14 @@ export interface FirebaseAnalytics {
    * Sends analytics event with given `eventParams`. This method
    * automatically associates this logged event with this Firebase web
    * app instance on this device.
-   * See
-   * {@link https://developers.google.com/analytics/devguides/collection/ga4/screen-view
-   * | Screen views}.
+   * See {@link https://firebase.google.com/docs/analytics/screenviews
+   * | Track Screenviews}.
    */
   logEvent(
     eventName: 'screen_view',
     eventParams?: {
-      app_name: string;
-      screen_name: EventParams['screen_name'];
       firebase_screen: EventParams['firebase_screen'];
       firebase_screen_class: EventParams['firebase_screen_class'];
-      app_id?: string;
-      app_version?: string;
-      app_installer_id?: string;
       [key: string]: any;
     },
     options?: AnalyticsCallOptions

--- a/packages/firebase/index.d.ts
+++ b/packages/firebase/index.d.ts
@@ -4849,20 +4849,14 @@ declare namespace firebase.analytics {
      * Sends analytics event with given `eventParams`. This method
      * automatically associates this logged event with this Firebase web
      * app instance on this device.
-     * See
-     * {@link https://developers.google.com/analytics/devguides/collection/ga4/screen-view
-     * | Screen views}.
+     * See {@link https://firebase.google.com/docs/analytics/screenviews
+     * | Track Screenviews}.
      */
     logEvent(
       eventName: 'screen_view',
       eventParams?: {
-        app_name: string;
-        screen_name: EventParams['screen_name'];
         firebase_screen: EventParams['firebase_screen'];
         firebase_screen_class: EventParams['firebase_screen_class'];
-        app_id?: string;
-        app_version?: string;
-        app_installer_id?: string;
         [key: string]: any;
       },
       options?: firebase.analytics.AnalyticsCallOptions

--- a/packages/firebase/index.d.ts
+++ b/packages/firebase/index.d.ts
@@ -4651,8 +4651,8 @@ declare namespace firebase.analytics {
      * automatically associates this logged event with this Firebase web
      * app instance on this device.
      * List of recommended event parameters can be found in
-     * {@link https://developers.google.com/gtagjs/reference/event
-     * the gtag.js reference documentation}.
+     * {@link https://developers.google.com/gtagjs/reference/ga4-events
+     * | the GA4 reference documentation}.
      */
     logEvent(
       eventName: 'add_payment_info',
@@ -4672,8 +4672,8 @@ declare namespace firebase.analytics {
      * automatically associates this logged event with this Firebase web
      * app instance on this device.
      * List of recommended event parameters can be found in
-     * {@link https://developers.google.com/gtagjs/reference/event
-     * the gtag.js reference documentation}.
+     * {@link https://developers.google.com/gtagjs/reference/ga4-events
+     * | the GA4 reference documentation}.
      */
     logEvent(
       eventName: 'add_shipping_info',
@@ -4693,8 +4693,8 @@ declare namespace firebase.analytics {
      * automatically associates this logged event with this Firebase web
      * app instance on this device.
      * List of recommended event parameters can be found in
-     * {@link https://developers.google.com/gtagjs/reference/event
-     * the gtag.js reference documentation}.
+     * {@link https://developers.google.com/gtagjs/reference/ga4-events
+     * | the GA4 reference documentation}.
      */
     logEvent(
       eventName: 'add_to_cart' | 'add_to_wishlist' | 'remove_from_cart',
@@ -4712,8 +4712,8 @@ declare namespace firebase.analytics {
      * automatically associates this logged event with this Firebase web
      * app instance on this device.
      * List of recommended event parameters can be found in
-     * {@link https://developers.google.com/gtagjs/reference/event
-     * the gtag.js reference documentation}.
+     * {@link https://developers.google.com/gtagjs/reference/ga4-events
+     * | the GA4 reference documentation}.
      */
     logEvent(
       eventName: 'begin_checkout',
@@ -4732,8 +4732,8 @@ declare namespace firebase.analytics {
      * automatically associates this logged event with this Firebase web
      * app instance on this device.
      * List of recommended event parameters can be found in
-     * {@link https://developers.google.com/gtagjs/reference/event
-     * the gtag.js reference documentation}.
+     * {@link https://developers.google.com/gtagjs/reference/ga4-events
+     * | the GA4 reference documentation}.
      */
     logEvent(
       eventName: 'checkout_progress',
@@ -4753,9 +4753,9 @@ declare namespace firebase.analytics {
      * Sends analytics event with given `eventParams`. This method
      * automatically associates this logged event with this Firebase web
      * app instance on this device.
-     * List of recommended event parameters can be found in
-     * {@link https://developers.google.com/gtagjs/reference/event
-     * the gtag.js reference documentation}.
+     * See
+     * {@link https://developers.google.com/analytics/devguides/collection/ga4/exceptions
+     * | Measure exceptions}.
      */
     logEvent(
       eventName: 'exception',
@@ -4772,15 +4772,14 @@ declare namespace firebase.analytics {
      * automatically associates this logged event with this Firebase web
      * app instance on this device.
      * List of recommended event parameters can be found in
-     * {@link https://developers.google.com/gtagjs/reference/event
-     * the gtag.js reference documentation}.
+     * {@link https://developers.google.com/gtagjs/reference/ga4-events
+     * | the GA4 reference documentation}.
      */
     logEvent(
       eventName: 'generate_lead',
       eventParams?: {
         value?: EventParams['value'];
         currency?: EventParams['currency'];
-        transaction_id?: EventParams['transaction_id'];
         [key: string]: any;
       },
       options?: firebase.analytics.AnalyticsCallOptions
@@ -4791,8 +4790,8 @@ declare namespace firebase.analytics {
      * automatically associates this logged event with this Firebase web
      * app instance on this device.
      * List of recommended event parameters can be found in
-     * {@link https://developers.google.com/gtagjs/reference/event
-     * the gtag.js reference documentation}.
+     * {@link https://developers.google.com/gtagjs/reference/ga4-events
+     * | the GA4 reference documentation}.
      */
     logEvent(
       eventName: 'login',
@@ -4807,9 +4806,9 @@ declare namespace firebase.analytics {
      * Sends analytics event with given `eventParams`. This method
      * automatically associates this logged event with this Firebase web
      * app instance on this device.
-     * List of recommended event parameters can be found in
-     * {@link https://developers.google.com/gtagjs/reference/event
-     * the gtag.js reference documentation}.
+     * See
+     * {@link https://developers.google.com/analytics/devguides/collection/ga4/page-view
+     * | Page views}.
      */
     logEvent(
       eventName: 'page_view',
@@ -4827,8 +4826,8 @@ declare namespace firebase.analytics {
      * automatically associates this logged event with this Firebase web
      * app instance on this device.
      * List of recommended event parameters can be found in
-     * {@link https://developers.google.com/gtagjs/reference/event
-     * the gtag.js reference documentation}.
+     * {@link https://developers.google.com/gtagjs/reference/ga4-events
+     * | the GA4 reference documentation}.
      */
     logEvent(
       eventName: 'purchase' | 'refund',
@@ -4850,9 +4849,9 @@ declare namespace firebase.analytics {
      * Sends analytics event with given `eventParams`. This method
      * automatically associates this logged event with this Firebase web
      * app instance on this device.
-     * List of recommended event parameters can be found in
-     * {@link https://developers.google.com/gtagjs/reference/event
-     * the gtag.js reference documentation}.
+     * See
+     * {@link https://developers.google.com/analytics/devguides/collection/ga4/screen-view
+     * | Screen views}.
      */
     logEvent(
       eventName: 'screen_view',
@@ -4874,8 +4873,8 @@ declare namespace firebase.analytics {
      * automatically associates this logged event with this Firebase web
      * app instance on this device.
      * List of recommended event parameters can be found in
-     * {@link https://developers.google.com/gtagjs/reference/event
-     * the gtag.js reference documentation}.
+     * {@link https://developers.google.com/gtagjs/reference/ga4-events
+     * | the GA4 reference documentation}.
      */
     logEvent(
       eventName: 'search' | 'view_search_results',
@@ -4891,16 +4890,14 @@ declare namespace firebase.analytics {
      * automatically associates this logged event with this Firebase web
      * app instance on this device.
      * List of recommended event parameters can be found in
-     * {@link https://developers.google.com/gtagjs/reference/event
-     * the gtag.js reference documentation}.
+     * {@link https://developers.google.com/gtagjs/reference/ga4-events
+     * | the GA4 reference documentation}.
      */
     logEvent(
       eventName: 'select_content',
       eventParams?: {
-        items?: EventParams['items'];
-        promotions?: EventParams['promotions'];
         content_type?: EventParams['content_type'];
-        content_id?: EventParams['content_id'];
+        item_id?: EventParams['item_id'];
         [key: string]: any;
       },
       options?: firebase.analytics.AnalyticsCallOptions
@@ -4911,8 +4908,8 @@ declare namespace firebase.analytics {
      * automatically associates this logged event with this Firebase web
      * app instance on this device.
      * List of recommended event parameters can be found in
-     * {@link https://developers.google.com/gtagjs/reference/event
-     * the gtag.js reference documentation}.
+     * {@link https://developers.google.com/gtagjs/reference/ga4-events
+     * | the GA4 reference documentation}.
      */
     logEvent(
       eventName: 'select_item',
@@ -4930,8 +4927,8 @@ declare namespace firebase.analytics {
      * automatically associates this logged event with this Firebase web
      * app instance on this device.
      * List of recommended event parameters can be found in
-     * {@link https://developers.google.com/gtagjs/reference/event
-     * the gtag.js reference documentation}.
+     * {@link https://developers.google.com/gtagjs/reference/ga4-events
+     * | the GA4 reference documentation}.
      */
     logEvent(
       eventName: 'select_promotion' | 'view_promotion',
@@ -4949,8 +4946,8 @@ declare namespace firebase.analytics {
      * automatically associates this logged event with this Firebase web
      * app instance on this device.
      * List of recommended event parameters can be found in
-     * {@link https://developers.google.com/gtagjs/reference/event
-     * the gtag.js reference documentation}.
+     * {@link https://developers.google.com/gtagjs/reference/ga4-events
+     * | the GA4 reference documentation}.
      */
     logEvent(
       eventName: 'set_checkout_option',
@@ -4967,15 +4964,15 @@ declare namespace firebase.analytics {
      * automatically associates this logged event with this Firebase web
      * app instance on this device.
      * List of recommended event parameters can be found in
-     * {@link https://developers.google.com/gtagjs/reference/event
-     * the gtag.js reference documentation}.
+     * {@link https://developers.google.com/gtagjs/reference/ga4-events
+     * | the GA4 reference documentation}.
      */
     logEvent(
       eventName: 'share',
       eventParams?: {
         method?: EventParams['method'];
         content_type?: EventParams['content_type'];
-        content_id?: EventParams['content_id'];
+        item_id?: EventParams['item_id'];
         [key: string]: any;
       },
       options?: firebase.analytics.AnalyticsCallOptions
@@ -4986,8 +4983,8 @@ declare namespace firebase.analytics {
      * automatically associates this logged event with this Firebase web
      * app instance on this device.
      * List of recommended event parameters can be found in
-     * {@link https://developers.google.com/gtagjs/reference/event
-     * the gtag.js reference documentation}.
+     * {@link https://developers.google.com/gtagjs/reference/ga4-events
+     * | the GA4 reference documentation}.
      */
     logEvent(
       eventName: 'sign_up',
@@ -5003,8 +5000,8 @@ declare namespace firebase.analytics {
      * automatically associates this logged event with this Firebase web
      * app instance on this device.
      * List of recommended event parameters can be found in
-     * {@link https://developers.google.com/gtagjs/reference/event
-     * the gtag.js reference documentation}.
+     * {@link https://developers.google.com/gtagjs/reference/ga4-events
+     * | the GA4 reference documentation}.
      */
     logEvent(
       eventName: 'timing_complete',
@@ -5023,8 +5020,8 @@ declare namespace firebase.analytics {
      * automatically associates this logged event with this Firebase web
      * app instance on this device.
      * List of recommended event parameters can be found in
-     * {@link https://developers.google.com/gtagjs/reference/event
-     * the gtag.js reference documentation}.
+     * {@link https://developers.google.com/gtagjs/reference/ga4-events
+     * | the GA4 reference documentation}.
      */
     logEvent(
       eventName: 'view_cart' | 'view_item',
@@ -5042,8 +5039,8 @@ declare namespace firebase.analytics {
      * automatically associates this logged event with this Firebase web
      * app instance on this device.
      * List of recommended event parameters can be found in
-     * {@link https://developers.google.com/gtagjs/reference/event
-     * the gtag.js reference documentation}.
+     * {@link https://developers.google.com/gtagjs/reference/ga4-events
+     * | the GA4 reference documentation}.
      */
     logEvent(
       eventName: 'view_item_list',
@@ -5061,8 +5058,8 @@ declare namespace firebase.analytics {
      * automatically associates this logged event with this Firebase web
      * app instance on this device.
      * List of recommended event parameters can be found in
-     * {@link https://developers.google.com/gtagjs/reference/event
-     * the gtag.js reference documentation}.
+     * {@link https://developers.google.com/gtagjs/reference/ga4-events
+     * | the GA4 reference documentation}.
      */
     logEvent<T extends string>(
       eventName: CustomEventName<T>,
@@ -5158,7 +5155,7 @@ declare namespace firebase.analytics {
   export interface EventParams {
     checkout_option?: string;
     checkout_step?: number;
-    content_id?: string;
+    item_id?: string;
     content_type?: string;
     coupon?: string;
     currency?: string;


### PR DESCRIPTION
Fixed some link formatting in comments, addressing https://github.com/firebase/firebase-js-sdk/issues/5116.

While doing that, discovered some of the links were for UA and not for GA4, meaning some of the event/config params were incorrect. Corrected them.

The link for screenviews (https://firebase.google.com/docs/analytics/screenviews) doesn't have the JS snippet yet, it can't be submitted until the typing changes in this PR have been released. It should be a short lag time though.