### PR TITLE
fix: assertFails for storage read/write requests (#5086)

### DIFF
--- a/packages/rules-unit-testing/src/api/index.ts
+++ b/packages/rules-unit-testing/src/api/index.ts
@@ -698,7 +698,9 @@ export function assertFails(pr: Promise<any>): any {
         errCode === 'permission-denied' ||
         errCode === 'permission_denied' ||
         errMessage.indexOf('permission_denied') >= 0 ||
-        errMessage.indexOf('permission denied') >= 0;
+        errMessage.indexOf('permission denied') >= 0 ||   
+        // Storage permission errors contain message: (storage/unauthorized)
+        errMessage.indexOf('unauthorized') >= 0;
 
       if (!isPermissionDenied) {
         return Promise.reject(

--- a/packages/rules-unit-testing/test/database.test.ts
+++ b/packages/rules-unit-testing/test/database.test.ts
@@ -153,6 +153,31 @@ describe('Testing Module Tests', function () {
       .catch(() => {});
   });
 
+  it('assertFails() if message contains unauthorized', async function () {
+    const success = Promise.resolve('success');
+    const permissionDenied = Promise.reject({
+      message: 'User does not have permission to access \'file\'. (storage/unauthorized)'
+    });
+    const otherFailure = Promise.reject('failure');
+    await firebase
+      .assertFails(success)
+      .then(() => {
+        throw new Error('Expected success to fail.');
+      })
+      .catch(() => {});
+
+    await firebase.assertFails(permissionDenied).catch(() => {
+      throw new Error('Expected permissionDenied to succeed.');
+    });
+
+    await firebase
+      .assertFails(otherFailure)
+      .then(() => {
+        throw new Error('Expected otherFailure to fail.');
+      })
+      .catch(() => {});
+  });
+
   it('discoverEmulators() finds all running emulators', async () => {
     const options = await firebase.discoverEmulators();
 


### PR DESCRIPTION
Fixes Issue 4 of #5086

### Discussion

https://github.com/firebase/firebase-js-sdk/issues/5086

This PR makes assertFails work properly with the storage emulator. 

Most storage permission errors throw errors with the message "(storage/unauthorized)", but assertFails only checks for the string "permission denied". This means that assertFails won't work properly for most storage unit tests. 

This fix is a small one that just adds another check if the message contains the string "unauthorized". A better fix would be to ensure that all firebase products throw consistent error message codes when permission is denied, but this solution will at least fix this bug in the unit testing library for storage for the time being.

### Testing

  * Added unit test to packages/rules-unit-testing/test/database.test.ts called `'assertFails() if message contains unauthorized'`
  
NOTE: It would be better if the rules-unit-testing library also contained tests for real-world usage (like actually spinning up the emulators and checking assertFails and assertSucceeds for basic actions like reading/writing from firestore, realtiime database, or storage). I think having just a few basic tests for usage would have caught this issue much quicker.