### PR TITLE
Revert "Revert to use Xhr in Firestore"

### DIFF
--- a/packages/firestore/exp/register.ts
+++ b/packages/firestore/exp/register.ts
@@ -44,7 +44,7 @@ export function registerFirestore(variant?: string): void {
           app,
           container.getProvider('auth-internal')
         );
-        settings = { useFetchStreams: false, ...settings };
+        settings = { useFetchStreams: true, ...settings };
         firestoreInstance._setSettings(settings);
         return firestoreInstance;
       },


### PR DESCRIPTION
Reverts firebase/firebase-js-sdk#5046. Fetch streams should now work (see https://github.com/firebase/firebase-js-sdk/issues/5074#issuecomment-889532005)

Addresses https://github.com/firebase/firebase-js-sdk/issues/5074