### PR TITLE
Add cached token changes to v9 appcheck

### DIFF
--- a/packages-exp/app-check-exp/src/api.ts
+++ b/packages-exp/app-check-exp/src/api.ts
@@ -87,7 +87,7 @@ function _activate(
   const state = getState(app);
 
   const newState: AppCheckState = { ...state, activated: true };
-  newState.provider = provider;  // Read cached token from storage if it exists and store it in memory.
+  newState.provider = provider; // Read cached token from storage if it exists and store it in memory.
   newState.cachedTokenPromise = readTokenFromStorage(app).then(cachedToken => {
     if (cachedToken && isValid(cachedToken)) {
       setState(app, { ...getState(app), token: cachedToken });

--- a/packages-exp/app-check-exp/src/api.ts
+++ b/packages-exp/app-check-exp/src/api.ts
@@ -31,8 +31,10 @@ import { AppCheckProvider, ListenerType } from './types';
 import {
   getToken as getTokenInternal,
   addTokenListener,
-  removeTokenListener
+  removeTokenListener,
+  isValid
 } from './internal-api';
+import { readTokenFromStorage } from './storage';
 
 declare module '@firebase/component' {
   interface NameServiceMapping {
@@ -85,7 +87,13 @@ function _activate(
   const state = getState(app);
 
   const newState: AppCheckState = { ...state, activated: true };
-  newState.provider = provider;
+  newState.provider = provider;  // Read cached token from storage if it exists and store it in memory.
+  newState.cachedTokenPromise = readTokenFromStorage(app).then(cachedToken => {
+    if (cachedToken && isValid(cachedToken)) {
+      setState(app, { ...getState(app), token: cachedToken });
+    }
+    return cachedToken;
+  });
 
   // Use value of global `automaticDataCollectionEnabled` (which
   // itself defaults to false if not specified in config) if

--- a/packages-exp/app-check-exp/src/state.ts
+++ b/packages-exp/app-check-exp/src/state.ts
@@ -29,6 +29,7 @@ export interface AppCheckState {
   tokenObservers: AppCheckTokenObserver[];
   provider?: AppCheckProvider;
   token?: AppCheckTokenInternal;
+  cachedTokenPromise?: Promise<AppCheckTokenInternal | undefined>;
   tokenRefresher?: Refresher;
   reCAPTCHAState?: ReCAPTCHAState;
   isTokenAutoRefreshEnabled?: boolean;


### PR DESCRIPTION
Copy part of the v8 app check PR https://github.com/firebase/firebase-js-sdk/pull/4902 that involves checking for token in storage during initialization. (The rest of 4902 was already in v9.)