### PR TITLE
[Auth] Fix persistence issue when manually setting/using session storage

### DIFF
--- a/packages-exp/auth-compat-exp/src/auth.test.ts
+++ b/packages-exp/auth-compat-exp/src/auth.test.ts
@@ -65,7 +65,7 @@ describe('auth compat', () => {
         providerStub.getImmediate.returns(underlyingAuth);
         const authCompat = new Auth(
           app,
-          (providerStub as unknown) as Provider<'auth-exp'>
+          providerStub as unknown as Provider<'auth-exp'>
         );
         // eslint-disable-next-line @typescript-eslint/no-floating-promises
         await authCompat.signInWithRedirect(new exp.GoogleAuthProvider());
@@ -83,7 +83,7 @@ describe('auth compat', () => {
         );
         providerStub.isInitialized.returns(false);
         providerStub.initialize.returns(underlyingAuth);
-        new Auth(app, (providerStub as unknown) as Provider<'auth-exp'>);
+        new Auth(app, providerStub as unknown as Provider<'auth-exp'>);
         // eslint-disable-next-line @typescript-eslint/no-floating-promises
         expect(providerStub.initialize).to.have.been.calledWith({
           options: {

--- a/packages-exp/auth-compat-exp/src/auth.test.ts
+++ b/packages-exp/auth-compat-exp/src/auth.test.ts
@@ -91,7 +91,8 @@ describe('auth compat', () => {
             persistence: [
               exp.inMemoryPersistence,
               exp.indexedDBLocalPersistence,
-              exp.browserLocalPersistence
+              exp.browserLocalPersistence,
+              exp.browserSessionPersistence
             ]
           }
         });

--- a/packages-exp/auth-compat-exp/src/auth.ts
+++ b/packages-exp/auth-compat-exp/src/auth.ts
@@ -68,7 +68,7 @@ export class Auth
       for (const persistence of [
         exp.indexedDBLocalPersistence,
         exp.browserLocalPersistence,
-        exp.browserSessionPersistence,
+        exp.browserSessionPersistence
       ]) {
         if (!persistences.includes(persistence)) {
           persistences.push(persistence);

--- a/packages-exp/auth-compat-exp/src/auth.ts
+++ b/packages-exp/auth-compat-exp/src/auth.ts
@@ -67,7 +67,8 @@ export class Auth
 
       for (const persistence of [
         exp.indexedDBLocalPersistence,
-        exp.browserLocalPersistence
+        exp.browserLocalPersistence,
+        exp.browserSessionPersistence,
       ]) {
         if (!persistences.includes(persistence)) {
           persistences.push(persistence);

--- a/packages-exp/auth-exp/index.ts
+++ b/packages-exp/auth-exp/index.ts
@@ -137,7 +137,11 @@ export function getAuth(app: FirebaseApp = getApp()): Auth {
 
   return initializeAuth(app, {
     popupRedirectResolver: browserPopupRedirectResolver,
-    persistence: [indexedDBLocalPersistence, browserLocalPersistence, browserSessionPersistence]
+    persistence: [
+      indexedDBLocalPersistence,
+      browserLocalPersistence,
+      browserSessionPersistence
+    ]
   });
 }
 

--- a/packages-exp/auth-exp/index.ts
+++ b/packages-exp/auth-exp/index.ts
@@ -27,6 +27,7 @@ import { initializeAuth } from './src';
 import { registerAuth } from './src/core/auth/register';
 import { ClientPlatform } from './src/core/util/version';
 import { browserLocalPersistence } from './src/platform_browser/persistence/local_storage';
+import { browserSessionPersistence } from './src/platform_browser/persistence/session_storage';
 import { indexedDBLocalPersistence } from './src/platform_browser/persistence/indexed_db';
 import { browserPopupRedirectResolver } from './src/platform_browser/popup_redirect';
 import { Auth } from './src/model/public_types';
@@ -136,7 +137,7 @@ export function getAuth(app: FirebaseApp = getApp()): Auth {
 
   return initializeAuth(app, {
     popupRedirectResolver: browserPopupRedirectResolver,
-    persistence: [indexedDBLocalPersistence, browserLocalPersistence]
+    persistence: [indexedDBLocalPersistence, browserLocalPersistence, browserSessionPersistence]
   });
 }
 

--- a/packages-exp/auth-exp/src/core/persistence/index.ts
+++ b/packages-exp/auth-exp/src/core/persistence/index.ts
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { AuthInternal } from '../../model/auth';
 import { Persistence } from '../../model/public_types';
 
 export const enum PersistenceType {
@@ -44,4 +45,6 @@ export interface PersistenceInternal extends Persistence {
   _remove(key: string): Promise<void>;
   _addListener(key: string, listener: StorageEventListener): void;
   _removeListener(key: string, listener: StorageEventListener): void;
+  // Should this persistence allow migration up the chosen hierarchy?
+  _shouldAllowMigration?: boolean;
 }

--- a/packages-exp/auth-exp/src/core/persistence/index.ts
+++ b/packages-exp/auth-exp/src/core/persistence/index.ts
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { AuthInternal } from '../../model/auth';
 import { Persistence } from '../../model/public_types';
 
 export const enum PersistenceType {

--- a/packages-exp/auth-exp/src/core/persistence/persistence_user_manager.test.ts
+++ b/packages-exp/auth-exp/src/core/persistence/persistence_user_manager.test.ts
@@ -36,7 +36,7 @@ chai.use(sinonChai);
 
 function makePersistence(
   type = PersistenceType.NONE,
-  shouldAllowMigration = false,
+  shouldAllowMigration = false
 ): {
   persistence: PersistenceInternal;
   stub: sinon.SinonStubbedInstance<PersistenceInternal>;
@@ -51,7 +51,7 @@ function makePersistence(
     _remove: async () => {},
     _addListener(_key: string, _listener: StorageEventListener) {},
     _removeListener(_key: string, _listener: StorageEventListener) {},
-    _shouldAllowMigration: shouldAllowMigration,
+    _shouldAllowMigration: shouldAllowMigration
   };
 
   const stub = sinon.stub(persistence);
@@ -261,10 +261,8 @@ describe('core/persistence/persistence_user_manager', () => {
       });
 
       it('removes current user & sets it in the new persistene', async () => {
-        const {
-          persistence: nextPersistence,
-          stub: nextStub
-        } = makePersistence();
+        const { persistence: nextPersistence, stub: nextStub } =
+          makePersistence();
         const auth = await testAuth();
         const user = testUser(auth, 'uid');
         persistenceStub._get.returns(Promise.resolve(user.toJSON()));
@@ -285,10 +283,8 @@ describe('core/persistence/persistence_user_manager', () => {
         const user = testUser(auth, 'uid');
         stub._get.returns(Promise.resolve(user.toJSON()));
 
-        const {
-          persistence: nextPersistence,
-          stub: nextStub
-        } = makePersistence(PersistenceType.LOCAL);
+        const { persistence: nextPersistence, stub: nextStub } =
+          makePersistence(PersistenceType.LOCAL);
 
         // This should migrate the user even if both has type LOCAL. For example, developer may want
         // to switch from localStorage to indexedDB (both type LOCAL) and we should honor that.

--- a/packages-exp/auth-exp/src/core/persistence/persistence_user_manager.test.ts
+++ b/packages-exp/auth-exp/src/core/persistence/persistence_user_manager.test.ts
@@ -35,7 +35,8 @@ import { KeyName, PersistenceUserManager } from './persistence_user_manager';
 chai.use(sinonChai);
 
 function makePersistence(
-  type = PersistenceType.NONE
+  type = PersistenceType.NONE,
+  shouldAllowMigration = false,
 ): {
   persistence: PersistenceInternal;
   stub: sinon.SinonStubbedInstance<PersistenceInternal>;
@@ -49,7 +50,8 @@ function makePersistence(
     },
     _remove: async () => {},
     _addListener(_key: string, _listener: StorageEventListener) {},
-    _removeListener(_key: string, _listener: StorageEventListener) {}
+    _removeListener(_key: string, _listener: StorageEventListener) {},
+    _shouldAllowMigration: shouldAllowMigration,
   };
 
   const stub = sinon.stub(persistence);
@@ -69,7 +71,7 @@ describe('core/persistence/persistence_user_manager', () => {
       expect(manager.persistence).to.eq(_getInstance(inMemoryPersistence));
     });
 
-    it('chooses the first one available', async () => {
+    it('chooses the first one with a user', async () => {
       const a = makePersistence();
       const b = makePersistence();
       const c = makePersistence();
@@ -78,11 +80,31 @@ describe('core/persistence/persistence_user_manager', () => {
       a.stub._isAvailable.resolves(false);
       a.stub._get.onFirstCall().resolves(testUser(auth, 'uid').toJSON());
       b.stub._isAvailable.resolves(true);
+      a.stub._get.onFirstCall().resolves(testUser(auth, 'uid-b').toJSON());
 
       const out = await PersistenceUserManager.create(auth, search);
       expect(a.stub._isAvailable).to.have.been.calledOnce;
       expect(b.stub._isAvailable).to.have.been.calledOnce;
-      expect(c.stub._isAvailable).to.not.have.been.called;
+      expect(c.stub._isAvailable).to.have.been.calledOnce;
+
+      // a should not be chosen since it is not available (despite having a user).
+      expect(out.persistence).to.eq(b.persistence);
+    });
+
+    it('defaults to first available persistence if no user', async () => {
+      const a = makePersistence();
+      const b = makePersistence();
+      const c = makePersistence();
+      const search = [a.persistence, b.persistence, c.persistence];
+      const auth = await testAuth();
+      a.stub._isAvailable.resolves(false);
+      b.stub._isAvailable.resolves(true);
+      c.stub._isAvailable.resolves(true);
+
+      const out = await PersistenceUserManager.create(auth, search);
+      expect(a.stub._isAvailable).to.have.been.calledOnce;
+      expect(b.stub._isAvailable).to.have.been.calledOnce;
+      expect(c.stub._isAvailable).to.have.been.calledOnce;
 
       // a should not be chosen since it is not available (despite having a user).
       expect(out.persistence).to.eq(b.persistence);
@@ -108,14 +130,16 @@ describe('core/persistence/persistence_user_manager', () => {
       expect((await out.getCurrentUser())!.uid).to.eq(user.uid);
     });
 
-    it('migrate found user to the selected persistence and clear others', async () => {
-      const a = makePersistence();
-      const b = makePersistence();
-      const c = makePersistence();
+    it('migrate found user to higher order persistence, if applicable', async () => {
+      const a = makePersistence(PersistenceType.NONE, true);
+      const b = makePersistence(PersistenceType.NONE, true);
+      const c = makePersistence(PersistenceType.NONE, true);
       const search = [a.persistence, b.persistence, c.persistence];
       const auth = await testAuth();
       const user = testUser(auth, 'uid');
       a.stub._isAvailable.resolves(true);
+      b.stub._isAvailable.resolves(true);
+      c.stub._isAvailable.resolves(true);
       b.stub._get.resolves(user.toJSON());
       c.stub._get.resolves(testUser(auth, 'wrong-uid').toJSON());
 
@@ -145,6 +169,7 @@ describe('core/persistence/persistence_user_manager', () => {
 
     it('uses default user key if none provided', async () => {
       const { stub, persistence } = makePersistence();
+      stub._isAvailable.resolves(true);
       await PersistenceUserManager.create(auth, [persistence]);
       expect(stub._get).to.have.been.calledWith(
         'firebase:authUser:test-api-key:test-app'
@@ -153,6 +178,7 @@ describe('core/persistence/persistence_user_manager', () => {
 
     it('uses user key if provided', async () => {
       const { stub, persistence } = makePersistence();
+      stub._isAvailable.resolves(true);
       await PersistenceUserManager.create(
         auth,
         [persistence],
@@ -174,9 +200,9 @@ describe('core/persistence/persistence_user_manager', () => {
 
       const out = await PersistenceUserManager.create(auth, search);
       expect(out.persistence).to.eq(_getInstance(inMemoryPersistence));
-      expect(a.stub._get).to.have.been.calledOnce;
-      expect(b.stub._get).to.have.been.calledOnce;
-      expect(c.stub._get).to.have.been.called;
+      expect(a.stub._get).not.to.have.been.called;
+      expect(b.stub._get).not.to.have.been.called;
+      expect(c.stub._get).not.to.have.been.called;
     });
   });
 

--- a/packages-exp/auth-exp/src/core/persistence/persistence_user_manager.test.ts
+++ b/packages-exp/auth-exp/src/core/persistence/persistence_user_manager.test.ts
@@ -177,14 +177,14 @@ describe('core/persistence/persistence_user_manager', () => {
       a.stub._isAvailable.resolves(false); // Important
       b.stub._isAvailable.resolves(true);
       c.stub._isAvailable.resolves(true);
-      b.stub._get.resolves(user.toJSON());
+      a.stub._get.resolves(user.toJSON());
       c.stub._get.resolves(testUser(auth, 'wrong-uid').toJSON());
 
-      let persistedUserInA: PersistenceValue | null = null;
+      let persistedUserInB: PersistenceValue | null = null;
       b.stub._set.callsFake(async (_, value) => {
-        persistedUserInA = value;
+        persistedUserInB = value;
       });
-      a.stub._get.callsFake(async () => persistedUserInA);
+      b.stub._get.callsFake(async () => persistedUserInB);
 
       const out = await PersistenceUserManager.create(auth, search);
       expect(b.stub._set).to.have.been.calledOnceWith(

--- a/packages-exp/auth-exp/src/core/persistence/persistence_user_manager.test.ts
+++ b/packages-exp/auth-exp/src/core/persistence/persistence_user_manager.test.ts
@@ -174,7 +174,7 @@ describe('core/persistence/persistence_user_manager', () => {
       const search = [a.persistence, b.persistence, c.persistence];
       const auth = await testAuth();
       const user = testUser(auth, 'uid');
-      a.stub._isAvailable.resolves(false);  // Important
+      a.stub._isAvailable.resolves(false); // Important
       b.stub._isAvailable.resolves(true);
       c.stub._isAvailable.resolves(true);
       b.stub._get.resolves(user.toJSON());

--- a/packages-exp/auth-exp/src/core/persistence/persistence_user_manager.ts
+++ b/packages-exp/auth-exp/src/core/persistence/persistence_user_manager.ts
@@ -127,7 +127,8 @@ export class PersistenceUserManager {
 
     // Fall back to the first persistence listed, or in memory if none available
     let selectedPersistence =
-      availablePersistences[0] || _getInstance<PersistenceInternal>(inMemoryPersistence);
+      availablePersistences[0] ||
+      _getInstance<PersistenceInternal>(inMemoryPersistence);
 
     const key = _persistenceKeyName(userKey, auth.config.apiKey, auth.name);
 
@@ -158,7 +159,10 @@ export class PersistenceUserManager {
     );
 
     // If the persistence does _not_ allow migration, just finish off here
-    if (!selectedPersistence._shouldAllowMigration || !migrationHierarchy.length) {
+    if (
+      !selectedPersistence._shouldAllowMigration ||
+      !migrationHierarchy.length
+    ) {
       return new PersistenceUserManager(selectedPersistence, auth, userKey);
     }
 

--- a/packages-exp/auth-exp/src/core/persistence/persistence_user_manager.ts
+++ b/packages-exp/auth-exp/src/core/persistence/persistence_user_manager.ts
@@ -131,6 +131,8 @@ export class PersistenceUserManager {
 
     const key = _persistenceKeyName(userKey, auth.config.apiKey, auth.name);
 
+    // Pull out the existing user, setting the chosen persistence to that
+    // persistence if the user exists.
     let userToMigrate: UserInternal | null = null;
     for (const persistence of persistences) {
       try {
@@ -144,11 +146,13 @@ export class PersistenceUserManager {
       } catch {}
     }
 
+    // If the persistence does _not_ allow migration, just finish off here
     if (!chosenPersistence._shouldAllowMigration) {
       return new PersistenceUserManager(chosenPersistence, auth, userKey);
     }
 
-    // Migrate up the chain
+    // If we find the user in a persistence that does support migration, use
+    // that migration path (of only persistences that support migration)
     const migrationHierarchy = persistences.filter(
       p => p._shouldAllowMigration
     );

--- a/packages-exp/auth-exp/src/core/persistence/persistence_user_manager.ts
+++ b/packages-exp/auth-exp/src/core/persistence/persistence_user_manager.ts
@@ -112,19 +112,22 @@ export class PersistenceUserManager {
         userKey
       );
     }
-    
+
     // Eliminate any persistences that are not available
-    const persistences = (await Promise.all(persistenceHierarchy.map(async persistence => {
-      if (await persistence._isAvailable()) {
-        return persistence;
-      }
-      return undefined;
-    }))).filter(persistence => persistence) as PersistenceInternal[];
+    const persistences = (
+      await Promise.all(
+        persistenceHierarchy.map(async persistence => {
+          if (await persistence._isAvailable()) {
+            return persistence;
+          }
+          return undefined;
+        })
+      )
+    ).filter(persistence => persistence) as PersistenceInternal[];
 
     // Fall back to the first persistence listed, or in memory if none available
-    let chosenPersistence = persistences[0] || _getInstance<PersistenceInternal>(
-      inMemoryPersistence
-    );
+    let chosenPersistence =
+      persistences[0] || _getInstance<PersistenceInternal>(inMemoryPersistence);
 
     const key = _persistenceKeyName(userKey, auth.config.apiKey, auth.name);
 
@@ -146,7 +149,9 @@ export class PersistenceUserManager {
     }
 
     // Migrate up the chain
-    const migrationHierarchy = persistences.filter(p => p._shouldAllowMigration);
+    const migrationHierarchy = persistences.filter(
+      p => p._shouldAllowMigration
+    );
     chosenPersistence = migrationHierarchy[0];
     if (userToMigrate) {
       // This normally shouldn't throw since chosenPersistence.isAvailable() is true, but if it does

--- a/packages-exp/auth-exp/src/platform_browser/auth.test.ts
+++ b/packages-exp/auth-exp/src/platform_browser/auth.test.ts
@@ -324,6 +324,7 @@ describe('core/auth/initializeAuth', () => {
         const stub = sinon.stub(
           _getInstance<PersistenceInternal>(browserSessionPersistence)
         );
+        stub._isAvailable.returns(Promise.resolve(true));
         stub._remove.returns(Promise.resolve());
         completeRedirectFnStub.returns(Promise.reject(new Error('no')));
 

--- a/packages-exp/auth-exp/src/platform_browser/persistence/indexed_db.ts
+++ b/packages-exp/auth-exp/src/platform_browser/persistence/indexed_db.ts
@@ -158,6 +158,7 @@ class IndexedDBLocalPersistence implements InternalPersistence {
 
   type = PersistenceType.LOCAL;
   db?: IDBDatabase;
+  readonly _shouldAllowMigration = true;
 
   private readonly listeners: Record<string, Set<StorageEventListener>> = {};
   private readonly localCache: Record<string, PersistenceValue | null> = {};

--- a/packages-exp/auth-exp/src/platform_browser/persistence/local_storage.ts
+++ b/packages-exp/auth-exp/src/platform_browser/persistence/local_storage.ts
@@ -46,7 +46,8 @@ const IE10_LOCAL_STORAGE_SYNC_DELAY = 10;
 
 class BrowserLocalPersistence
   extends BrowserPersistenceClass
-  implements InternalPersistence {
+  implements InternalPersistence
+{
   static type: 'LOCAL' = 'LOCAL';
 
   constructor() {

--- a/packages-exp/auth-exp/src/platform_browser/persistence/local_storage.ts
+++ b/packages-exp/auth-exp/src/platform_browser/persistence/local_storage.ts
@@ -69,6 +69,7 @@ class BrowserLocalPersistence
     _iframeCannotSyncWebStorage() && _isIframe();
   // Whether to use polling instead of depending on window events
   private readonly fallbackToPolling = _isMobileBrowser();
+  readonly _shouldAllowMigration = true;
 
   private forAllChangedKeys(
     cb: (key: string, oldValue: string | null, newValue: string | null) => void

--- a/packages-exp/auth-exp/test/integration/webdriver/persistence.test.ts
+++ b/packages-exp/auth-exp/test/integration/webdriver/persistence.test.ts
@@ -131,11 +131,11 @@ browserDescribe('WebDriver persistence test', (driver, browser) => {
       expect(await driver.getUserSnapshot()).to.contain({ uid });
     });
 
-    it('fall back to in-memory if neither indexedDB or localStorage is present', async () => {
+    it('fall back to in-memory if neither indexedDB or browser storage is present', async () => {
       await driver.webDriver.navigate().refresh();
       // Simulate browsers that do not support indexedDB or localStorage.
       await driver.webDriver.executeScript(
-        'delete window.indexedDB; delete window.localStorage;'
+        'delete window.indexedDB; delete window.localStorage; delete window.sessionStorage'
       );
       await driver.injectConfigAndInitAuth();
       await driver.waitForAuthInit();
@@ -182,34 +182,8 @@ browserDescribe('WebDriver persistence test', (driver, browser) => {
       );
     });
 
-    it('migrate stored user to localStorage if indexedDB is readonly', async () => {
-      // Sign in first, which gets persisted in indexedDB.
-      const cred: UserCredential = await driver.call(
-        AnonFunction.SIGN_IN_ANONYMOUSLY
-      );
-      const uid = cred.user.uid;
-
-      await driver.webDriver.navigate().refresh();
-      await driver.call(PersistenceFunction.MAKE_INDEXED_DB_READONLY);
-      await driver.injectConfigAndInitAuth();
-      await driver.waitForAuthInit();
-
-      // User from indexedDB should be picked up.
-      const user = await driver.getUserSnapshot();
-      expect(user.uid).eql(uid);
-
-      // User should be migrated to localStorage, and the key in indexedDB should be deleted.
-      const snap = await driver.call(PersistenceFunction.LOCAL_STORAGE_SNAP);
-      expect(snap).to.have.property(fullPersistenceKey).that.contains({ uid });
-      expect(await driver.call(PersistenceFunction.INDEXED_DB_SNAP)).to.eql({});
-    });
-
     it('use in-memory and clear all persistences if indexedDB and localStorage are both broken', async () => {
-      const persistedUser = await testPersistedUser();
       await driver.webDriver.navigate().refresh();
-      await driver.call(PersistenceFunction.LOCAL_STORAGE_SET, {
-        [fullPersistenceKey]: persistedUser
-      });
       // Simulate browsers that do not support indexedDB.
       await driver.webDriver.executeScript('delete window.indexedDB;');
       // Simulate browsers denying writes to localStorage (e.g. Safari private browsing).
@@ -219,9 +193,10 @@ browserDescribe('WebDriver persistence test', (driver, browser) => {
       await driver.injectConfigAndInitAuth();
       await driver.waitForAuthInit();
 
-      // User from localStorage should be picked up.
+      // User should exist in memory storage only
+      await driver.call(AnonFunction.SIGN_IN_ANONYMOUSLY);
       const user = await driver.getUserSnapshot();
-      expect(user.uid).eql(persistedUser.uid);
+      expect(user.uid).to.be.a('string');
 
       // Both storage should be cleared.
       expect(await driver.call(PersistenceFunction.LOCAL_STORAGE_SNAP)).to.eql(
@@ -267,16 +242,20 @@ browserDescribe('WebDriver persistence test', (driver, browser) => {
       const snapshotAfter = await driver.getUserSnapshot();
       expect(snapshotAfter.uid).to.eql(user.uid);
       expect(await driver.call(PersistenceFunction.INDEXED_DB_SNAP)).to.eql({});
-      const snap = await driver.call(PersistenceFunction.SESSION_STORAGE_SNAP);
+      let snap = await driver.call(PersistenceFunction.SESSION_STORAGE_SNAP);
       expect(snap)
         .to.have.property(fullPersistenceKey)
         .that.contains({ uid: user.uid });
 
-      // User will be gone (a.k.a. logged out) after refresh.
+      // User will be in session storage after refresh
       await driver.webDriver.navigate().refresh();
       await driver.injectConfigAndInitAuth();
       await driver.waitForAuthInit();
-      expect(await driver.getUserSnapshot()).to.equal(null);
+      expect(await driver.getUserSnapshot()).to.eql(snapshotAfter);
+      snap = await driver.call(PersistenceFunction.SESSION_STORAGE_SNAP);
+      expect(snap)
+        .to.have.property(fullPersistenceKey)
+        .that.contains({ uid: user.uid });
     });
 
     it('migrates user when switching from indexedDB to localStorage', async () => {


### PR DESCRIPTION
Fixes https://github.com/firebase/firebase-js-sdk/issues/5171

`browserSession` persistence is now added to the escalation path of `getAuth()` to match v8. We also now only "upgrade" the persistence if the persistence deems itself "upgradeable" (which only applies to `indexedDB` and `localStorage`)