### PR TITLE
Add back browser CJS build as ./dist/index.browser.cjs.js.

### DIFF
--- a/.changeset/gorgeous-balloons-confess.md
+++ b/.changeset/gorgeous-balloons-confess.md
@@ -2,4 +2,4 @@
 "@firebase/storage": patch
 ---
 
-Add back browser CJS build as ./dist/index.browser.cjs.js.
+Adds a browser CJS build as ./dist/index.browser.cjs.js.

--- a/.changeset/gorgeous-balloons-confess.md
+++ b/.changeset/gorgeous-balloons-confess.md
@@ -1,0 +1,5 @@
+---
+"@firebase/storage": patch
+---
+
+Add back browser CJS build as ./dist/index.browser.cjs.js.

--- a/packages/storage/rollup.config.js
+++ b/packages/storage/rollup.config.js
@@ -42,7 +42,10 @@ const es5BuildPlugins = [
 const es5Builds = [
   {
     input: './index.ts',
-    output: { file: pkg.module, format: 'es', sourcemap: true },
+    output: [
+      { file: 'dist/index.browser.cjs.js', format: 'cjs', sourcemap: true },
+      { file: pkg.module, format: 'es', sourcemap: true }
+    ],
     plugins: [alias(generateAliasConfig('browser')), ...es5BuildPlugins],
     external: id => deps.some(dep => id === dep || id.startsWith(`${dep}/`)),
     treeshake: {


### PR DESCRIPTION
This adds back a browser CJS build, once removed by #5149 but still needed by Emulator UI. No changes to exports and package.json.