### PR TITLE
Fix AppCheck typings error

### DIFF
--- a/.changeset/four-taxis-fry.md
+++ b/.changeset/four-taxis-fry.md
@@ -1,0 +1,7 @@
+---
+'@firebase/app-check': patch
+'@firebase/app-check-types': patch
+'firebase': patch
+---
+
+Fixed argument typings for `activate()`.

--- a/packages/app-check-types/index.d.ts
+++ b/packages/app-check-types/index.d.ts
@@ -32,7 +32,11 @@ export interface FirebaseAppCheck {
    * defaults to false and can be set in the app config.
    */
   activate(
-    siteKeyOrProvider: string | AppCheckProvider,
+    siteKeyOrProvider:
+      | string
+      | AppCheckProvider
+      | CustomProvider
+      | ReCaptchaV3Provider,
     isTokenAutoRefreshEnabled?: boolean
   ): void;
 

--- a/packages/app-check/src/factory.ts
+++ b/packages/app-check/src/factory.ts
@@ -35,7 +35,10 @@ import {
   addTokenListener,
   removeTokenListener
 } from './internal-api';
-import { ReCaptchaV3Provider as ReCaptchaV3ProviderImpl, CustomProvider as CustomProviderImpl } from './providers';
+import {
+  ReCaptchaV3Provider as ReCaptchaV3ProviderImpl,
+  CustomProvider as CustomProviderImpl
+} from './providers';
 import { Provider } from '@firebase/component';
 import { PartialObserver } from '@firebase/util';
 
@@ -49,7 +52,11 @@ export function factory(
   return {
     app,
     activate: (
-      siteKeyOrProvider: ReCaptchaV3Provider | CustomProvider | AppCheckProvider | string,
+      siteKeyOrProvider:
+        | ReCaptchaV3Provider
+        | CustomProvider
+        | AppCheckProvider
+        | string,
       isTokenAutoRefreshEnabled?: boolean
     ) =>
       activate(
@@ -57,7 +64,11 @@ export function factory(
         // Public types of ReCaptchaV3Provider/CustomProvider don't
         // expose getToken() and aren't recognized as the internal
         // class version of themselves.
-        siteKeyOrProvider as (ReCaptchaV3ProviderImpl | CustomProviderImpl |AppCheckProvider | string),
+        siteKeyOrProvider as
+          | ReCaptchaV3ProviderImpl
+          | CustomProviderImpl
+          | AppCheckProvider
+          | string,
         platformLoggerProvider,
         isTokenAutoRefreshEnabled
       ),

--- a/packages/app-check/src/factory.ts
+++ b/packages/app-check/src/factory.ts
@@ -18,7 +18,9 @@
 import {
   FirebaseAppCheck,
   AppCheckProvider,
-  AppCheckTokenResult
+  AppCheckTokenResult,
+  ReCaptchaV3Provider,
+  CustomProvider
 } from '@firebase/app-check-types';
 import {
   activate,
@@ -33,6 +35,7 @@ import {
   addTokenListener,
   removeTokenListener
 } from './internal-api';
+import { ReCaptchaV3Provider as ReCaptchaV3ProviderImpl, CustomProvider as CustomProviderImpl } from './providers';
 import { Provider } from '@firebase/component';
 import { PartialObserver } from '@firebase/util';
 
@@ -46,12 +49,15 @@ export function factory(
   return {
     app,
     activate: (
-      siteKeyOrProvider: AppCheckProvider | string,
+      siteKeyOrProvider: ReCaptchaV3Provider | CustomProvider | AppCheckProvider | string,
       isTokenAutoRefreshEnabled?: boolean
     ) =>
       activate(
         app,
-        siteKeyOrProvider,
+        // Public types of ReCaptchaV3Provider/CustomProvider don't
+        // expose getToken() and aren't recognized as the internal
+        // class version of themselves.
+        siteKeyOrProvider as (ReCaptchaV3ProviderImpl | CustomProviderImpl |AppCheckProvider | string),
         platformLoggerProvider,
         isTokenAutoRefreshEnabled
       ),

--- a/packages/firebase/index.d.ts
+++ b/packages/firebase/index.d.ts
@@ -1580,14 +1580,18 @@ declare namespace firebase.appCheck {
   export interface AppCheck {
     /**
      * Activate AppCheck
-     * @param provider reCAPTCHA or custom token provider.
+     * @param provider reCAPTCHA provider, custom token provider, or reCAPTCHA site key.
      * @param isTokenAutoRefreshEnabled If true, the SDK automatically
      * refreshes App Check tokens as needed. If undefined, defaults to the
      * value of `app.automaticDataCollectionEnabled`, which defaults to
      * false and can be set in the app config.
      */
     activate(
-      provider: AppCheckProvider,
+      provider:
+        | ReCaptchaV3Provider
+        | CustomProvider
+        | AppCheckProvider
+        | string,
       isTokenAutoRefreshEnabled?: boolean
     ): void;
 


### PR DESCRIPTION
Incorrect typing of `activate()` params in `packages/firebase/index.d.ts` is causing users to get Typescript errors when using string or provider arguments.

Fixes https://github.com/firebase/firebase-js-sdk/issues/5258