### PR TITLE
Correctly add Storage to Node documentation

### DIFF
--- a/packages/firebase/index.d.ts
+++ b/packages/firebase/index.d.ts
@@ -1267,8 +1267,6 @@ declare namespace firebase {
    * {@link firebase.storage.Storage `Storage`} service associated with a
    * specific app.
    *
-   * @webonly
-   *
    * @example
    * ```javascript
    * // Get the Storage service for the default app
@@ -1465,8 +1463,6 @@ declare namespace firebase.app {
     /**
      * Gets the {@link firebase.storage.Storage `Storage`} service for the current
      * app, optionally initialized with a custom storage bucket.
-     *
-     * @webonly
      *
      * @example
      * ```javascript

--- a/scripts/docgen/content-sources/node/toc.yaml
+++ b/scripts/docgen/content-sources/node/toc.yaml
@@ -176,3 +176,29 @@ toc:
     path: /docs/reference/node/firebase.functions.HttpsCallableResult
   - title: "HttpsError"
     path: /docs/reference/node/firebase.functions.HttpsError
+
+- title: "firebase.storage"
+  path: /docs/reference/node/firebase.storage
+  section:
+  - title: "FirebaseStorageError"
+    path: /docs/reference/node/firebase.storage.FirebaseStorageError
+  - title: "FullMetadata"
+    path: /docs/reference/node/firebase.storage.FullMetadata
+  - title: "ListOptions"
+    path: /docs/reference/node/firebase.storage.ListOptions
+  - title: "ListResult"
+    path: /docs/reference/node/firebase.storage.ListResult
+  - title: "Reference"
+    path: /docs/reference/node/firebase.storage.Reference
+  - title: "SettableMetadata"
+    path: /docs/reference/node/firebase.storage.SettableMetadata
+  - title: "Storage"
+    path: /docs/reference/node/firebase.storage.Storage
+  - title: "StorageObserver"
+    path: /docs/reference/node/firebase.storage.StorageObserver
+  - title: "UploadMetadata"
+    path: /docs/reference/node/firebase.storage.UploadMetadata
+  - title: "UploadTask"
+    path: /docs/reference/node/firebase.storage.UploadTask
+  - title: "UploadTaskSnapshot"
+    path: /docs/reference/node/firebase.storage.UploadTaskSnapshot


### PR DESCRIPTION
Did not get everything in the last attempt. This should correctly lead to a Storage section being created in the Node reference docs.