### PR TITLE
Make initializePerformance() idempotent

### DIFF
--- a/packages-exp/performance-exp/src/index.test.ts
+++ b/packages-exp/performance-exp/src/index.test.ts
@@ -31,10 +31,6 @@ const fakeFirebaseConfig = {
   appId: '1:111:web:a1234'
 };
 
-// const fakeFirebaseApp = ({
-//   options: fakeFirebaseConfig
-// } as unknown) as firebase.FirebaseApp;
-
 describe('Firebase Performance > initializePerformance()', () => {
   let app: FirebaseApp;
   beforeEach(() => {

--- a/packages-exp/performance-exp/src/index.test.ts
+++ b/packages-exp/performance-exp/src/index.test.ts
@@ -16,12 +16,10 @@
  */
 
 import { expect } from 'chai';
-import { stub } from 'sinon';
 import { initializePerformance } from './index';
 import { ERROR_FACTORY, ErrorCode } from './utils/errors';
-import * as firebase from '@firebase/app-exp';
-import { Provider } from '@firebase/component';
 import '../test/setup';
+import { deleteApp, FirebaseApp, initializeApp } from '@firebase/app-exp';
 
 const fakeFirebaseConfig = {
   apiKey: 'api-key',
@@ -33,17 +31,44 @@ const fakeFirebaseConfig = {
   appId: '1:111:web:a1234'
 };
 
-const fakeFirebaseApp = ({
-  options: fakeFirebaseConfig
-} as unknown) as firebase.FirebaseApp;
+// const fakeFirebaseApp = ({
+//   options: fakeFirebaseConfig
+// } as unknown) as firebase.FirebaseApp;
 
 describe('Firebase Performance > initializePerformance()', () => {
-  it('throws if a perf instance has already been created', () => {
-    stub(firebase, '_getProvider').returns(({
-      isInitialized: () => true
-    } as unknown) as Provider<'performance-exp'>);
+  let app: FirebaseApp;
+  beforeEach(() => {
+    app = initializeApp(fakeFirebaseConfig);
+  });
+  afterEach(() => {
+    return deleteApp(app);
+  });
+  it('returns same instance if given same (no) params a second time', () => {
+    const performanceInstance = initializePerformance(app);
+    expect(initializePerformance(app)).to.equal(performanceInstance);
+  });
+  it('returns same instance if given same params a second time', () => {
+    const performanceInstance = initializePerformance(app, { dataCollectionEnabled: false });
+    expect(initializePerformance(app, { dataCollectionEnabled: false })).to.equal(performanceInstance);
+  });
+  it('throws if called with params after being called with no params', () => {
+    initializePerformance(app);
     const expectedError = ERROR_FACTORY.create(ErrorCode.ALREADY_INITIALIZED);
-    expect(() => initializePerformance(fakeFirebaseApp)).to.throw(
+    expect(() => initializePerformance(app, { dataCollectionEnabled: false })).to.throw(
+      expectedError.message
+    );
+  });
+  it('throws if called with no params after being called with params', () => {
+    initializePerformance(app, { instrumentationEnabled: false });
+    const expectedError = ERROR_FACTORY.create(ErrorCode.ALREADY_INITIALIZED);
+    expect(() => initializePerformance(app)).to.throw(
+      expectedError.message
+    );
+  });
+  it('throws if called a second time with different params', () => {
+    initializePerformance(app, { instrumentationEnabled: true });
+    const expectedError = ERROR_FACTORY.create(ErrorCode.ALREADY_INITIALIZED);
+    expect(() => initializePerformance(app, { instrumentationEnabled: false })).to.throw(
       expectedError.message
     );
   });

--- a/packages-exp/performance-exp/src/index.test.ts
+++ b/packages-exp/performance-exp/src/index.test.ts
@@ -48,28 +48,30 @@ describe('Firebase Performance > initializePerformance()', () => {
     expect(initializePerformance(app)).to.equal(performanceInstance);
   });
   it('returns same instance if given same params a second time', () => {
-    const performanceInstance = initializePerformance(app, { dataCollectionEnabled: false });
-    expect(initializePerformance(app, { dataCollectionEnabled: false })).to.equal(performanceInstance);
+    const performanceInstance = initializePerformance(app, {
+      dataCollectionEnabled: false
+    });
+    expect(
+      initializePerformance(app, { dataCollectionEnabled: false })
+    ).to.equal(performanceInstance);
   });
   it('throws if called with params after being called with no params', () => {
     initializePerformance(app);
     const expectedError = ERROR_FACTORY.create(ErrorCode.ALREADY_INITIALIZED);
-    expect(() => initializePerformance(app, { dataCollectionEnabled: false })).to.throw(
-      expectedError.message
-    );
+    expect(() =>
+      initializePerformance(app, { dataCollectionEnabled: false })
+    ).to.throw(expectedError.message);
   });
   it('throws if called with no params after being called with params', () => {
     initializePerformance(app, { instrumentationEnabled: false });
     const expectedError = ERROR_FACTORY.create(ErrorCode.ALREADY_INITIALIZED);
-    expect(() => initializePerformance(app)).to.throw(
-      expectedError.message
-    );
+    expect(() => initializePerformance(app)).to.throw(expectedError.message);
   });
   it('throws if called a second time with different params', () => {
     initializePerformance(app, { instrumentationEnabled: true });
     const expectedError = ERROR_FACTORY.create(ErrorCode.ALREADY_INITIALIZED);
-    expect(() => initializePerformance(app, { instrumentationEnabled: false })).to.throw(
-      expectedError.message
-    );
+    expect(() =>
+      initializePerformance(app, { instrumentationEnabled: false })
+    ).to.throw(expectedError.message);
   });
 });

--- a/packages-exp/performance-exp/src/index.ts
+++ b/packages-exp/performance-exp/src/index.ts
@@ -79,7 +79,16 @@ export function initializePerformance(
   // throw if an instance was already created.
   // It could happen if initializePerformance() is called more than once, or getPerformance() is called first.
   if (provider.isInitialized()) {
-    throw ERROR_FACTORY.create(ErrorCode.ALREADY_INITIALIZED);
+    const existingInstance = provider.getImmediate();
+    const initialSettings = provider.getOptions() as PerformanceSettings;
+    if (
+      settings?.dataCollectionEnabled === initialSettings?.dataCollectionEnabled && 
+      settings?.instrumentationEnabled === initialSettings?.instrumentationEnabled
+    ) {
+      return existingInstance;
+    } else {
+      throw ERROR_FACTORY.create(ErrorCode.ALREADY_INITIALIZED);
+    }
   }
 
   const perfInstance = provider.initialize({

--- a/packages-exp/performance-exp/src/index.ts
+++ b/packages-exp/performance-exp/src/index.ts
@@ -45,7 +45,7 @@ import {
 import { name, version } from '../package.json';
 import { Trace } from './resources/trace';
 import '@firebase/installations-exp';
-import { getModularInstance } from '@firebase/util';
+import { deepEqual, getModularInstance } from '@firebase/util';
 
 const DEFAULT_ENTRY_NAME = '[DEFAULT]';
 
@@ -81,12 +81,7 @@ export function initializePerformance(
   if (provider.isInitialized()) {
     const existingInstance = provider.getImmediate();
     const initialSettings = provider.getOptions() as PerformanceSettings;
-    if (
-      settings?.dataCollectionEnabled ===
-        initialSettings?.dataCollectionEnabled &&
-      settings?.instrumentationEnabled ===
-        initialSettings?.instrumentationEnabled
-    ) {
+    if (deepEqual(initialSettings, settings ?? {})) {
       return existingInstance;
     } else {
       throw ERROR_FACTORY.create(ErrorCode.ALREADY_INITIALIZED);

--- a/packages-exp/performance-exp/src/index.ts
+++ b/packages-exp/performance-exp/src/index.ts
@@ -82,8 +82,10 @@ export function initializePerformance(
     const existingInstance = provider.getImmediate();
     const initialSettings = provider.getOptions() as PerformanceSettings;
     if (
-      settings?.dataCollectionEnabled === initialSettings?.dataCollectionEnabled && 
-      settings?.instrumentationEnabled === initialSettings?.instrumentationEnabled
+      settings?.dataCollectionEnabled ===
+        initialSettings?.dataCollectionEnabled &&
+      settings?.instrumentationEnabled ===
+        initialSettings?.instrumentationEnabled
     ) {
       return existingInstance;
     } else {

--- a/packages-exp/performance-exp/src/utils/errors.ts
+++ b/packages-exp/performance-exp/src/utils/errors.ts
@@ -60,7 +60,11 @@ const ERROR_DESCRIPTION_MAP: { readonly [key in ErrorCode]: string } = {
     'Custom metric name {$customMetricName} is invalid',
   [ErrorCode.INVALID_STRING_MERGER_PARAMETER]:
     'Input for String merger is invalid, contact support team to resolve.',
-  [ErrorCode.ALREADY_INITIALIZED]: 'Performance can only be initialized once.'
+  [ErrorCode.ALREADY_INITIALIZED]: 
+  'initializePerformance() has already been called with ' +
+  'different options. To avoid this error, call initializePerformance() with the ' +
+  'same options as when it was originally called, or call getPerformance() to return the' +
+  ' already initialized instance.'
 };
 
 interface ErrorParams {

--- a/packages-exp/performance-exp/src/utils/errors.ts
+++ b/packages-exp/performance-exp/src/utils/errors.ts
@@ -60,11 +60,11 @@ const ERROR_DESCRIPTION_MAP: { readonly [key in ErrorCode]: string } = {
     'Custom metric name {$customMetricName} is invalid',
   [ErrorCode.INVALID_STRING_MERGER_PARAMETER]:
     'Input for String merger is invalid, contact support team to resolve.',
-  [ErrorCode.ALREADY_INITIALIZED]: 
-  'initializePerformance() has already been called with ' +
-  'different options. To avoid this error, call initializePerformance() with the ' +
-  'same options as when it was originally called, or call getPerformance() to return the' +
-  ' already initialized instance.'
+  [ErrorCode.ALREADY_INITIALIZED]:
+    'initializePerformance() has already been called with ' +
+    'different options. To avoid this error, call initializePerformance() with the ' +
+    'same options as when it was originally called, or call getPerformance() to return the' +
+    ' already initialized instance.'
 };
 
 interface ErrorParams {

--- a/tools/gitHooks/prettier.js
+++ b/tools/gitHooks/prettier.js
@@ -101,7 +101,7 @@ async function doPrettier(changedFiles) {
   }
 
   const gitSpinner = ora(' Git staging prettier formatting changes.').start();
-  await exec('git add -u .', {stdio: 'inherit'});
+  await exec('git add -u .', { stdio: 'inherit' });
   gitSpinner.stopAndPersist({
     symbol: '▶️'
   });

--- a/tools/gitHooks/prettier.js
+++ b/tools/gitHooks/prettier.js
@@ -16,7 +16,7 @@
  */
 
 const { resolve } = require('path');
-const { exec, spawn } = require('child-process-promise');
+const { spawn } = require('child-process-promise');
 const fs = require('mz/fs');
 const glob = require('glob');
 const simpleGit = require('simple-git/promise');
@@ -101,7 +101,7 @@ async function doPrettier(changedFiles) {
   }
 
   const gitSpinner = ora(' Git staging prettier formatting changes.').start();
-  await exec('git add -u .', { stdio: 'inherit' });
+  await git.add(targetFiles);
   gitSpinner.stopAndPersist({
     symbol: '▶️'
   });

--- a/tools/gitHooks/prettier.js
+++ b/tools/gitHooks/prettier.js
@@ -16,7 +16,7 @@
  */
 
 const { resolve } = require('path');
-const { spawn } = require('child-process-promise');
+const { exec, spawn } = require('child-process-promise');
 const fs = require('mz/fs');
 const glob = require('glob');
 const simpleGit = require('simple-git/promise');
@@ -101,7 +101,7 @@ async function doPrettier(changedFiles) {
   }
 
   const gitSpinner = ora(' Git staging prettier formatting changes.').start();
-  await git.add(targetFiles);
+  await exec('git add -u .', {stdio: 'inherit'});
   gitSpinner.stopAndPersist({
     symbol: '▶️'
   });


### PR DESCRIPTION
Making all product initialize() functions idempotent.
See https://github.com/firebase/firebase-js-sdk/pull/5272