### PR TITLE
Make initializeAuth() idempotent

### DIFF
--- a/packages-exp/auth-exp/src/core/auth/initialize.test.ts
+++ b/packages-exp/auth-exp/src/core/auth/initialize.test.ts
@@ -32,7 +32,6 @@ import { isNode } from '@firebase/util';
 
 import { expect } from 'chai';
 import {
-  browserSessionPersistence,
   inMemoryPersistence
 } from '../../../internal';
 
@@ -222,13 +221,13 @@ describe('core/auth/initialize', () => {
     it('should not throw if called again with same params', () => {
       const auth = initializeAuth(fakeApp, {
         errorMap: prodErrorMap,
-        persistence: browserSessionPersistence,
+        persistence: fakeSessionPersistence,
         popupRedirectResolver: fakePopupRedirectResolver
       });
       expect(
         initializeAuth(fakeApp, {
           errorMap: prodErrorMap,
-          persistence: browserSessionPersistence,
+          persistence: fakeSessionPersistence,
           popupRedirectResolver: fakePopupRedirectResolver
         })
       ).to.equal(auth);

--- a/packages-exp/auth-exp/src/core/auth/initialize.test.ts
+++ b/packages-exp/auth-exp/src/core/auth/initialize.test.ts
@@ -31,7 +31,11 @@ import {
 import { isNode } from '@firebase/util';
 
 import { expect } from 'chai';
-import { browserLocalPersistence, browserSessionPersistence, inMemoryPersistence } from '../../../internal';
+import {
+  browserLocalPersistence,
+  browserSessionPersistence,
+  inMemoryPersistence
+} from '../../../internal';
 
 import { AuthInternal } from '../../model/auth';
 import {
@@ -128,7 +132,8 @@ describe('core/auth/initialize', () => {
     }
   }
 
-  const fakePopupRedirectResolver: PopupRedirectResolver = FakePopupRedirectResolver;
+  const fakePopupRedirectResolver: PopupRedirectResolver =
+    FakePopupRedirectResolver;
 
   before(() => {
     registerAuth(ClientPlatform.BROWSER);
@@ -204,7 +209,7 @@ describe('core/auth/initialize', () => {
       const auth = initializeAuth(fakeApp, {
         popupRedirectResolver: fakePopupRedirectResolver
       }) as AuthInternal;
-      await ((auth as unknown) as _FirebaseService)._delete();
+      await (auth as unknown as _FirebaseService)._delete();
       await auth._initializationPromise;
 
       expect(auth._isInitialized).to.be.false;
@@ -221,38 +226,46 @@ describe('core/auth/initialize', () => {
         persistence: browserSessionPersistence,
         popupRedirectResolver: fakePopupRedirectResolver
       });
-      expect(initializeAuth(fakeApp, {
-        errorMap: prodErrorMap,
-        persistence: browserSessionPersistence,
-        popupRedirectResolver: fakePopupRedirectResolver
-      })).to.equal(auth);
+      expect(
+        initializeAuth(fakeApp, {
+          errorMap: prodErrorMap,
+          persistence: browserSessionPersistence,
+          popupRedirectResolver: fakePopupRedirectResolver
+        })
+      ).to.equal(auth);
     });
 
     it('should throw if called again with different params (popupRedirectResolver)', () => {
       initializeAuth(fakeApp, {
         popupRedirectResolver: fakePopupRedirectResolver
       });
-      expect(() => initializeAuth(fakeApp, {
-        popupRedirectResolver: undefined
-      })).to.throw();
+      expect(() =>
+        initializeAuth(fakeApp, {
+          popupRedirectResolver: undefined
+        })
+      ).to.throw();
     });
 
     it('should throw if called again with different params (errorMap)', () => {
       initializeAuth(fakeApp, {
         errorMap: prodErrorMap
       });
-      expect(() => initializeAuth(fakeApp, {
-        errorMap: debugErrorMap
-      })).to.throw();
+      expect(() =>
+        initializeAuth(fakeApp, {
+          errorMap: debugErrorMap
+        })
+      ).to.throw();
     });
 
     it('should throw if called again with different params (persistence)', () => {
       initializeAuth(fakeApp, {
         persistence: [browserLocalPersistence, browserSessionPersistence]
       });
-      expect(() => initializeAuth(fakeApp, {
-        persistence: [browserSessionPersistence, browserLocalPersistence]
-      })).to.throw();
+      expect(() =>
+        initializeAuth(fakeApp, {
+          persistence: [browserSessionPersistence, browserLocalPersistence]
+        })
+      ).to.throw();
     });
   });
 });

--- a/packages-exp/auth-exp/src/core/auth/initialize.test.ts
+++ b/packages-exp/auth-exp/src/core/auth/initialize.test.ts
@@ -31,9 +31,7 @@ import {
 import { isNode } from '@firebase/util';
 
 import { expect } from 'chai';
-import {
-  inMemoryPersistence
-} from '../../../internal';
+import { inMemoryPersistence } from '../../../internal';
 
 import { AuthInternal } from '../../model/auth';
 import {

--- a/packages-exp/auth-exp/src/core/auth/initialize.test.ts
+++ b/packages-exp/auth-exp/src/core/auth/initialize.test.ts
@@ -32,7 +32,6 @@ import { isNode } from '@firebase/util';
 
 import { expect } from 'chai';
 import {
-  browserLocalPersistence,
   browserSessionPersistence,
   inMemoryPersistence
 } from '../../../internal';
@@ -259,11 +258,11 @@ describe('core/auth/initialize', () => {
 
     it('should throw if called again with different params (persistence)', () => {
       initializeAuth(fakeApp, {
-        persistence: [browserLocalPersistence, browserSessionPersistence]
+        persistence: [inMemoryPersistence, fakeSessionPersistence]
       });
       expect(() =>
         initializeAuth(fakeApp, {
-          persistence: [browserSessionPersistence, browserLocalPersistence]
+          persistence: [fakeSessionPersistence, inMemoryPersistence]
         })
       ).to.throw();
     });

--- a/packages-exp/auth-exp/src/core/auth/initialize.ts
+++ b/packages-exp/auth-exp/src/core/auth/initialize.ts
@@ -16,6 +16,7 @@
  */
 
 import { _getProvider, FirebaseApp } from '@firebase/app-exp';
+import { deepEqual } from '@firebase/util';
 import { Auth, Dependencies } from '../../model/public_types';
 
 import { AuthErrorCode } from '../errors';
@@ -54,7 +55,16 @@ export function initializeAuth(app: FirebaseApp, deps?: Dependencies): Auth {
 
   if (provider.isInitialized()) {
     const auth = provider.getImmediate() as AuthImpl;
-    _fail(auth, AuthErrorCode.ALREADY_INITIALIZED);
+    const initialOptions = provider.getOptions() as Dependencies;
+    if (
+      initialOptions.errorMap === deps?.errorMap &&
+      initialOptions.popupRedirectResolver === deps?.popupRedirectResolver &&
+      deepEqual(initialOptions.persistence as object, deps?.persistence as object)
+    ) {
+      return auth;
+    } else {
+      _fail(auth, AuthErrorCode.ALREADY_INITIALIZED);
+    }
   }
 
   const auth = provider.initialize({ options: deps }) as AuthImpl;
@@ -67,9 +77,8 @@ export function _initializeAuthInstance(
   deps?: Dependencies
 ): void {
   const persistence = deps?.persistence || [];
-  const hierarchy = (Array.isArray(persistence)
-    ? persistence
-    : [persistence]
+  const hierarchy = (
+    Array.isArray(persistence) ? persistence : [persistence]
   ).map<PersistenceInternal>(_getInstance);
   if (deps?.errorMap) {
     auth._updateErrorMap(deps.errorMap);

--- a/packages-exp/auth-exp/src/core/auth/initialize.ts
+++ b/packages-exp/auth-exp/src/core/auth/initialize.ts
@@ -59,7 +59,10 @@ export function initializeAuth(app: FirebaseApp, deps?: Dependencies): Auth {
     if (
       initialOptions.errorMap === deps?.errorMap &&
       initialOptions.popupRedirectResolver === deps?.popupRedirectResolver &&
-      deepEqual(initialOptions.persistence as object, deps?.persistence as object)
+      deepEqual(
+        initialOptions.persistence as object,
+        deps?.persistence as object
+      )
     ) {
       return auth;
     } else {

--- a/packages-exp/auth-exp/src/core/auth/initialize.ts
+++ b/packages-exp/auth-exp/src/core/auth/initialize.ts
@@ -56,14 +56,7 @@ export function initializeAuth(app: FirebaseApp, deps?: Dependencies): Auth {
   if (provider.isInitialized()) {
     const auth = provider.getImmediate() as AuthImpl;
     const initialOptions = provider.getOptions() as Dependencies;
-    if (
-      initialOptions.errorMap === deps?.errorMap &&
-      initialOptions.popupRedirectResolver === deps?.popupRedirectResolver &&
-      deepEqual(
-        initialOptions.persistence as object,
-        deps?.persistence as object
-      )
-    ) {
+    if (deepEqual(initialOptions, deps ?? {})) {
       return auth;
     } else {
       _fail(auth, AuthErrorCode.ALREADY_INITIALIZED);

--- a/packages-exp/auth-exp/src/core/errors.ts
+++ b/packages-exp/auth-exp/src/core/errors.ts
@@ -349,7 +349,10 @@ function _debugErrorMap(): ErrorMap<AuthErrorCode> {
     [AuthErrorCode.WEB_STORAGE_UNSUPPORTED]:
       'This browser is not supported or 3rd party cookies and data may be disabled.',
     [AuthErrorCode.ALREADY_INITIALIZED]:
-      'Auth can only be initialized once per app.'
+      'initializeAuth() has already been called with ' +
+      'different options. To avoid this error, call initializeAuth() with the ' +
+      'same options as when it was originally called, or call getAuth() to return the' +
+      ' already initialized instance.'
   };
 }
 


### PR DESCRIPTION
Making all product initialize() functions idempotent.
See https://github.com/firebase/firebase-js-sdk/pull/5272