### PR TITLE
Make initializeFirestore() idempotent

### DIFF
--- a/packages/firestore/src/exp/database.ts
+++ b/packages/firestore/src/exp/database.ts
@@ -150,7 +150,10 @@ export function initializeFirestore(
     } else {
       throw new FirestoreError(
         Code.FAILED_PRECONDITION,
-        'Firestore can only be initialized once per app.'
+        'initializeFirestore() has already been called with ' +
+          'different options. To avoid this error, call initializeFirestore() with the ' +
+          'same options as when it was originally called, or call getFirestore() to return the' +
+          ' already initialized instance.'
       );
     }
   }

--- a/packages/firestore/src/exp/database.ts
+++ b/packages/firestore/src/exp/database.ts
@@ -24,8 +24,8 @@ import {
 } from '@firebase/app-exp';
 import { FirebaseAuthInternalName } from '@firebase/auth-interop-types';
 import { Provider } from '@firebase/component';
+import { deepEqual } from '@firebase/util';
 
-import { deepEqual } from '../../../util/dist';
 import {
   IndexedDbOfflineComponentProvider,
   MultiTabOfflineComponentProvider,

--- a/packages/firestore/src/exp/database.ts
+++ b/packages/firestore/src/exp/database.ts
@@ -24,8 +24,8 @@ import {
 } from '@firebase/app-exp';
 import { FirebaseAuthInternalName } from '@firebase/auth-interop-types';
 import { Provider } from '@firebase/component';
-import { deepEqual } from '../../../util/dist';
 
+import { deepEqual } from '../../../util/dist';
 import {
   IndexedDbOfflineComponentProvider,
   MultiTabOfflineComponentProvider,

--- a/packages/firestore/src/exp/database.ts
+++ b/packages/firestore/src/exp/database.ts
@@ -24,6 +24,7 @@ import {
 } from '@firebase/app-exp';
 import { FirebaseAuthInternalName } from '@firebase/auth-interop-types';
 import { Provider } from '@firebase/component';
+import { deepEqual } from '../../../util/dist';
 
 import {
   IndexedDbOfflineComponentProvider,
@@ -129,23 +130,8 @@ export function initializeFirestore(
 
   if (provider.isInitialized()) {
     const existingInstance = provider.getImmediate();
-    const initialOptions = provider.getOptions() as FirestoreSettings;
-    // Every option can currently be compared shallowly.
-    // We could currently do a deepEqual() on `settings` but if we add
-    // a new option to `FirestoreSettings` that needs a custom
-    // comparison, it should be coded separately. This makes it less
-    // likely to be missed.
-    const shallowOptionsKeys: Array<keyof FirestoreSettings> = [
-      'cacheSizeBytes',
-      'experimentalAutoDetectLongPolling',
-      'experimentalForceLongPolling',
-      'host',
-      'ignoreUndefinedProperties',
-      'ssl'
-    ];
-    if (
-      shallowOptionsKeys.every(key => initialOptions[key] === settings[key])
-    ) {
+    const initialSettings = provider.getOptions() as FirestoreSettings;
+    if (deepEqual(initialSettings, settings)) {
       return existingInstance;
     } else {
       throw new FirestoreError(


### PR DESCRIPTION
Making all product initialize() functions idempotent.
See #5272

I don't see any existing tests for `initializeFirestore()` or `getFirestore()` and I'm a little unsure of how to set up a new test in this structure.