### PR TITLE
Apply functional-style naming pattern to mutation.ts

### DIFF
--- a/packages/firestore/src/local/local_documents_view.ts
+++ b/packages/firestore/src/local/local_documents_view.ts
@@ -32,7 +32,7 @@ import {
 } from '../model/collections';
 import { Document, MutableDocument } from '../model/document';
 import { DocumentKey } from '../model/document_key';
-import { applyMutationToLocalView, PatchMutation } from '../model/mutation';
+import { mutationApplyToLocalView, PatchMutation } from '../model/mutation';
 import { MutationBatch } from '../model/mutation_batch';
 import { ResourcePath } from '../model/path';
 import { debugAssert } from '../util/assert';
@@ -251,7 +251,7 @@ export class LocalDocumentsView {
                 document = MutableDocument.newInvalidDocument(key);
                 results = results.insert(key, document);
               }
-              applyMutationToLocalView(
+              mutationApplyToLocalView(
                 mutation,
                 document,
                 batch.localWriteTime

--- a/packages/firestore/src/local/local_store_impl.ts
+++ b/packages/firestore/src/local/local_store_impl.ts
@@ -34,7 +34,7 @@ import {
 import { Document } from '../model/document';
 import { DocumentKey } from '../model/document_key';
 import {
-  extractMutationBaseValue,
+  mutationExtractBaseValue,
   Mutation,
   PatchMutation,
   Precondition
@@ -318,7 +318,7 @@ export function localStoreWriteLocally(
           const baseMutations: Mutation[] = [];
 
           for (const mutation of mutations) {
-            const baseValue = extractMutationBaseValue(
+            const baseValue = mutationExtractBaseValue(
               mutation,
               existingDocs.get(mutation.key)!
             );

--- a/packages/firestore/src/model/mutation.ts
+++ b/packages/firestore/src/model/mutation.ts
@@ -204,7 +204,7 @@ export function preconditionIsValidForDocument(
  *
  * Every type of mutation needs to implement its own applyToRemoteDocument() and
  * applyToLocalView() to implement the actual behavior of applying the mutation
- * to some source document (see `applySetMutationToRemoteDocument()` for an
+ * to some source document (see `setMutationApplyToRemoteDocument()` for an
  * example).
  */
 export abstract class Mutation {
@@ -226,22 +226,22 @@ export abstract class Mutation {
  *     of the document.
  * @param mutationResult - The result of applying the mutation from the backend.
  */
-export function applyMutationToRemoteDocument(
+export function mutationApplyToRemoteDocument(
   mutation: Mutation,
   document: MutableDocument,
   mutationResult: MutationResult
 ): void {
-  verifyMutationKeyMatches(mutation, document);
+  mutationVerifyKeyMatches(mutation, document);
   if (mutation instanceof SetMutation) {
-    applySetMutationToRemoteDocument(mutation, document, mutationResult);
+    setMutationApplyToRemoteDocument(mutation, document, mutationResult);
   } else if (mutation instanceof PatchMutation) {
-    applyPatchMutationToRemoteDocument(mutation, document, mutationResult);
+    patchMutationApplyToRemoteDocument(mutation, document, mutationResult);
   } else {
     debugAssert(
       mutation instanceof DeleteMutation,
       'Unexpected mutation type: ' + mutation
     );
-    applyDeleteMutationToRemoteDocument(mutation, document, mutationResult);
+    deleteMutationApplyToRemoteDocument(mutation, document, mutationResult);
   }
 }
 
@@ -257,23 +257,23 @@ export function applyMutationToRemoteDocument(
  * @param localWriteTime - A timestamp indicating the local write time of the
  *     batch this mutation is a part of.
  */
-export function applyMutationToLocalView(
+export function mutationApplyToLocalView(
   mutation: Mutation,
   document: MutableDocument,
   localWriteTime: Timestamp
 ): void {
-  verifyMutationKeyMatches(mutation, document);
+  mutationVerifyKeyMatches(mutation, document);
 
   if (mutation instanceof SetMutation) {
-    applySetMutationToLocalView(mutation, document, localWriteTime);
+    setMutationApplyToLocalView(mutation, document, localWriteTime);
   } else if (mutation instanceof PatchMutation) {
-    applyPatchMutationToLocalView(mutation, document, localWriteTime);
+    patchMutationApplyToLocalView(mutation, document, localWriteTime);
   } else {
     debugAssert(
       mutation instanceof DeleteMutation,
       'Unexpected mutation type: ' + mutation
     );
-    applyDeleteMutationToLocalView(mutation, document);
+    deleteMutationApplyToLocalView(mutation, document);
   }
 }
 
@@ -293,7 +293,7 @@ export function applyMutationToLocalView(
  * @returns a base value to store along with the mutation, or null for
  * idempotent mutations.
  */
-export function extractMutationBaseValue(
+export function mutationExtractBaseValue(
   mutation: Mutation,
   document: Document
 ): ObjectValue | null {
@@ -348,7 +348,7 @@ export function mutationEquals(left: Mutation, right: Mutation): boolean {
   return true;
 }
 
-function verifyMutationKeyMatches(
+function mutationVerifyKeyMatches(
   mutation: Mutation,
   document: MutableDocument
 ): void {
@@ -385,12 +385,12 @@ export class SetMutation extends Mutation {
   readonly type: MutationType = MutationType.Set;
 }
 
-function applySetMutationToRemoteDocument(
+function setMutationApplyToRemoteDocument(
   mutation: SetMutation,
   document: MutableDocument,
   mutationResult: MutationResult
 ): void {
-  // Unlike applySetMutationToLocalView, if we're applying a mutation to a
+  // Unlike setMutationApplyToLocalView, if we're applying a mutation to a
   // remote document the server has accepted the mutation so the precondition
   // must have held.
   const newData = mutation.value.clone();
@@ -405,7 +405,7 @@ function applySetMutationToRemoteDocument(
     .setHasCommittedMutations();
 }
 
-function applySetMutationToLocalView(
+function setMutationApplyToLocalView(
   mutation: SetMutation,
   document: MutableDocument,
   localWriteTime: Timestamp
@@ -455,7 +455,7 @@ export class PatchMutation extends Mutation {
   readonly type: MutationType = MutationType.Patch;
 }
 
-function applyPatchMutationToRemoteDocument(
+function patchMutationApplyToRemoteDocument(
   mutation: PatchMutation,
   document: MutableDocument,
   mutationResult: MutationResult
@@ -482,7 +482,7 @@ function applyPatchMutationToRemoteDocument(
     .setHasCommittedMutations();
 }
 
-function applyPatchMutationToLocalView(
+function patchMutationApplyToLocalView(
   mutation: PatchMutation,
   document: MutableDocument,
   localWriteTime: Timestamp
@@ -601,7 +601,7 @@ export class DeleteMutation extends Mutation {
   readonly fieldTransforms: FieldTransform[] = [];
 }
 
-function applyDeleteMutationToRemoteDocument(
+function deleteMutationApplyToRemoteDocument(
   mutation: DeleteMutation,
   document: MutableDocument,
   mutationResult: MutationResult
@@ -619,7 +619,7 @@ function applyDeleteMutationToRemoteDocument(
     .setHasCommittedMutations();
 }
 
-function applyDeleteMutationToLocalView(
+function deleteMutationApplyToLocalView(
   mutation: DeleteMutation,
   document: MutableDocument
 ): void {

--- a/packages/firestore/src/model/mutation_batch.ts
+++ b/packages/firestore/src/model/mutation_batch.ts
@@ -30,9 +30,9 @@ import {
 } from './collections';
 import { MutableDocument } from './document';
 import {
+  Mutation,
   mutationApplyToLocalView,
   mutationApplyToRemoteDocument,
-  Mutation,
   mutationEquals,
   MutationResult
 } from './mutation';

--- a/packages/firestore/src/model/mutation_batch.ts
+++ b/packages/firestore/src/model/mutation_batch.ts
@@ -30,8 +30,8 @@ import {
 } from './collections';
 import { MutableDocument } from './document';
 import {
-  applyMutationToLocalView,
-  applyMutationToRemoteDocument,
+  mutationApplyToLocalView,
+  mutationApplyToRemoteDocument,
   Mutation,
   mutationEquals,
   MutationResult
@@ -85,7 +85,7 @@ export class MutationBatch {
       const mutation = this.mutations[i];
       if (mutation.key.isEqual(document.key)) {
         const mutationResult = mutationResults[i];
-        applyMutationToRemoteDocument(mutation, document, mutationResult);
+        mutationApplyToRemoteDocument(mutation, document, mutationResult);
       }
     }
   }
@@ -101,14 +101,14 @@ export class MutationBatch {
     // transform against a consistent set of values.
     for (const mutation of this.baseMutations) {
       if (mutation.key.isEqual(document.key)) {
-        applyMutationToLocalView(mutation, document, this.localWriteTime);
+        mutationApplyToLocalView(mutation, document, this.localWriteTime);
       }
     }
 
     // Second, apply all user-provided mutations.
     for (const mutation of this.mutations) {
       if (mutation.key.isEqual(document.key)) {
-        applyMutationToLocalView(mutation, document, this.localWriteTime);
+        mutationApplyToLocalView(mutation, document, this.localWriteTime);
       }
     }
   }

--- a/packages/firestore/test/unit/model/mutation.test.ts
+++ b/packages/firestore/test/unit/model/mutation.test.ts
@@ -21,9 +21,9 @@ import { FieldValue } from '../../../src/api/field_value';
 import { Timestamp } from '../../../src/api/timestamp';
 import { MutableDocument } from '../../../src/model/document';
 import {
-  applyMutationToLocalView,
-  applyMutationToRemoteDocument,
-  extractMutationBaseValue,
+  mutationApplyToLocalView,
+  mutationApplyToRemoteDocument,
+  mutationExtractBaseValue,
   Mutation,
   MutationResult,
   Precondition
@@ -61,7 +61,7 @@ describe('Mutation', () => {
     const document = doc('collection/key', 0, docData);
 
     const set = setMutation('collection/key', { bar: 'bar-value' });
-    applyMutationToLocalView(set, document, timestamp);
+    mutationApplyToLocalView(set, document, timestamp);
     expect(document).to.deep.equal(
       doc('collection/key', 0, { bar: 'bar-value' }).setHasLocalMutations()
     );
@@ -75,7 +75,7 @@ describe('Mutation', () => {
       'foo.bar': 'new-bar-value'
     });
 
-    applyMutationToLocalView(patch, document, timestamp);
+    mutationApplyToLocalView(patch, document, timestamp);
     expect(document).to.deep.equal(
       doc('collection/key', 0, {
         foo: { bar: 'new-bar-value' },
@@ -94,7 +94,7 @@ describe('Mutation', () => {
       Precondition.none()
     );
 
-    applyMutationToLocalView(patch, document, timestamp);
+    mutationApplyToLocalView(patch, document, timestamp);
     expect(document).to.deep.equal(
       doc('collection/key', 0, {
         foo: { bar: 'new-bar-value' }
@@ -112,7 +112,7 @@ describe('Mutation', () => {
       Precondition.none()
     );
 
-    applyMutationToLocalView(patch, document, timestamp);
+    mutationApplyToLocalView(patch, document, timestamp);
     expect(document).to.deep.equal(
       doc('collection/key', 0, {
         foo: { bar: 'new-bar-value' }
@@ -128,7 +128,7 @@ describe('Mutation', () => {
       'foo.bar': FieldValue.delete()
     });
 
-    applyMutationToLocalView(patch, document, timestamp);
+    mutationApplyToLocalView(patch, document, timestamp);
     expect(document).to.deep.equal(
       doc('collection/key', 0, {
         foo: { baz: 'baz-value' }
@@ -145,7 +145,7 @@ describe('Mutation', () => {
       'foo.bar': 'new-bar-value'
     });
 
-    applyMutationToLocalView(patch, document, timestamp);
+    mutationApplyToLocalView(patch, document, timestamp);
     expect(document).to.deep.equal(
       doc('collection/key', 0, {
         foo: { bar: 'new-bar-value' },
@@ -157,7 +157,7 @@ describe('Mutation', () => {
   it('patching a NoDocument yields a NoDocument', () => {
     const document = deletedDoc('collection/key', 0);
     const patch = patchMutation('collection/key', { foo: 'bar' });
-    applyMutationToLocalView(patch, document, timestamp);
+    mutationApplyToLocalView(patch, document, timestamp);
     expect(document).to.deep.equal(deletedDoc('collection/key', 0));
   });
 
@@ -169,7 +169,7 @@ describe('Mutation', () => {
       'foo.bar': FieldValue.serverTimestamp()
     });
 
-    applyMutationToLocalView(transform, document, timestamp);
+    mutationApplyToLocalView(transform, document, timestamp);
 
     // Server timestamps aren't parsed, so we manually insert it.
     const data = wrapObject({
@@ -334,7 +334,7 @@ describe('Mutation', () => {
 
     for (const transformData of transforms) {
       const transform = patchMutation('collection/key', transformData);
-      applyMutationToLocalView(transform, document, timestamp);
+      mutationApplyToLocalView(transform, document, timestamp);
     }
 
     const expectedDoc = doc(
@@ -361,7 +361,7 @@ describe('Mutation', () => {
         }
       }
     ]);
-    applyMutationToRemoteDocument(transform, document, mutationResult);
+    mutationApplyToRemoteDocument(transform, document, mutationResult);
 
     expect(document).to.deep.equal(
       doc('collection/key', 1, {
@@ -381,7 +381,7 @@ describe('Mutation', () => {
 
     // Server just sends null transform results for array operations.
     const mutationResult = new MutationResult(version(1), [null, null]);
-    applyMutationToRemoteDocument(transform, document, mutationResult);
+    mutationApplyToRemoteDocument(transform, document, mutationResult);
 
     expect(document).to.deep.equal(
       doc('collection/key', 1, {
@@ -462,7 +462,7 @@ describe('Mutation', () => {
     const mutationResult = new MutationResult(version(1), [
       { integerValue: 3 }
     ]);
-    applyMutationToRemoteDocument(transform, document, mutationResult);
+    mutationApplyToRemoteDocument(transform, document, mutationResult);
 
     expect(document).to.deep.equal(
       doc('collection/key', 1, { sum: 3 }).setHasCommittedMutations()
@@ -473,7 +473,7 @@ describe('Mutation', () => {
     const document = doc('collection/key', 0, { foo: 'bar' });
 
     const mutation = deleteMutation('collection/key');
-    applyMutationToLocalView(mutation, document, Timestamp.now());
+    mutationApplyToLocalView(mutation, document, Timestamp.now());
     expect(document).to.deep.equal(deletedDoc('collection/key', 0));
   });
 
@@ -482,7 +482,7 @@ describe('Mutation', () => {
 
     const docSet = setMutation('collection/key', { foo: 'new-bar' });
     const setResult = mutationResult(4);
-    applyMutationToRemoteDocument(docSet, document, setResult);
+    mutationApplyToRemoteDocument(docSet, document, setResult);
     expect(document).to.deep.equal(
       doc('collection/key', 4, { foo: 'new-bar' }).setHasCommittedMutations()
     );
@@ -493,7 +493,7 @@ describe('Mutation', () => {
 
     const mutation = patchMutation('collection/key', { foo: 'new-bar' });
     const result = mutationResult(5);
-    applyMutationToRemoteDocument(mutation, document, result);
+    mutationApplyToRemoteDocument(mutation, document, result);
     expect(document).to.deep.equal(
       doc('collection/key', 5, { foo: 'new-bar' }).setHasCommittedMutations()
     );
@@ -506,7 +506,7 @@ describe('Mutation', () => {
     expected: MutableDocument
   ): void {
     const documentCopy = base.clone();
-    applyMutationToRemoteDocument(mutation, documentCopy, mutationResult);
+    mutationApplyToRemoteDocument(mutation, documentCopy, mutationResult);
     expect(documentCopy).to.deep.equal(expected);
   }
 
@@ -552,13 +552,13 @@ describe('Mutation', () => {
     const baseDoc = doc('collection/key', 0, data);
 
     const set = setMutation('collection/key', { foo: 'bar' });
-    expect(extractMutationBaseValue(set, baseDoc)).to.be.null;
+    expect(mutationExtractBaseValue(set, baseDoc)).to.be.null;
 
     const patch = patchMutation('collection/key', { foo: 'bar' });
-    expect(extractMutationBaseValue(patch, baseDoc)).to.be.null;
+    expect(mutationExtractBaseValue(patch, baseDoc)).to.be.null;
 
     const deleter = deleteMutation('collection/key');
-    expect(extractMutationBaseValue(deleter, baseDoc)).to.be.null;
+    expect(mutationExtractBaseValue(deleter, baseDoc)).to.be.null;
   });
 
   it('extracts null base value for ServerTimestamp', () => {
@@ -572,7 +572,7 @@ describe('Mutation', () => {
 
     // Server timestamps are idempotent and don't have base values.
     const transform = patchMutation('collection/key', allTransforms);
-    expect(extractMutationBaseValue(transform, baseDoc)).to.be.null;
+    expect(mutationExtractBaseValue(transform, baseDoc)).to.be.null;
   });
 
   it('extracts base value for increment', () => {
@@ -610,7 +610,7 @@ describe('Mutation', () => {
       missing: 0,
       nested: { double: 42.0, long: 42, text: 0, map: 0, missing: 0 }
     });
-    const actualBaseValue = extractMutationBaseValue(transform, baseDoc);
+    const actualBaseValue = mutationExtractBaseValue(transform, baseDoc);
 
     expect(expectedBaseValue.isEqual(actualBaseValue!)).to.be.true;
   });
@@ -621,8 +621,8 @@ describe('Mutation', () => {
     const increment = { sum: FieldValue.increment(1) };
     const transform = setMutation('collection/key', increment);
 
-    applyMutationToLocalView(transform, document, Timestamp.now());
-    applyMutationToLocalView(transform, document, Timestamp.now());
+    mutationApplyToLocalView(transform, document, Timestamp.now());
+    mutationApplyToLocalView(transform, document, Timestamp.now());
 
     expect(document.isFoundDocument()).to.be.true;
     expect(document.data.field(field('sum'))).to.deep.equal(wrap(2));


### PR DESCRIPTION
The mutation file never followed the functional style naming convention we came up with during the firestore-exp migration. This PR changes the function names to follow the className+methodName pattern.
