### PR TITLE
Update toc.yaml files for v8 doc generation

### DIFF
--- a/scripts/docgen/content-sources/js/toc.yaml
+++ b/scripts/docgen/content-sources/js/toc.yaml
@@ -4,6 +4,8 @@ toc:
   section:
   - title: "FirebaseError"
     path: /docs/reference/js/firebase.FirebaseError
+  - title: "FirebaseIdToken"
+    path: /docs/reference/js/firebase.FirebaseIdToken
 
 - title: "firebase.app"
   path: /docs/reference/js/firebase.app
@@ -20,6 +22,14 @@ toc:
     path: /docs/reference/js/firebase.appcheck.AppCheckProvider
   - title: "AppCheckToken"
     path: /docs/reference/js/firebase.appcheck.AppCheckToken
+  - title: "AppCheckTokenResult"
+    path: /docs/reference/js/firebase.appcheck.AppCheckTokenResult
+  - title: "CustomProvider"
+    path: /docs/reference/js/firebase.appcheck.CustomProvider
+  - title: "CustomProviderOptions"
+    path: /docs/reference/js/firebase.appcheck.CustomProviderOptions
+  - title: "ReCaptchaV3Provider"
+    path: /docs/reference/js/firebase.appcheck.ReCaptchaV3Provider
 
 - title: "firebase.analytics"
   path: /docs/reference/js/firebase.analytics

--- a/scripts/docgen/content-sources/node/toc.yaml
+++ b/scripts/docgen/content-sources/node/toc.yaml
@@ -4,6 +4,8 @@ toc:
   section:
   - title: "FirebaseError"
     path: /docs/reference/node/firebase.FirebaseError
+  - title: "FirebaseIdToken"
+    path: /docs/reference/node/firebase.FirebaseIdToken
 
 - title: "firebase.app"
   path: /docs/reference/node/firebase.app


### PR DESCRIPTION
Recent changes added some top level doc pages which were not added to the toc.yaml files, so they won't appear in the reference docs.