### PR TITLE
Update package.json

### DIFF
--- a/packages-exp/firebase-exp/package.json
+++ b/packages-exp/firebase-exp/package.json
@@ -24,6 +24,10 @@
     "compat/index.d.ts"
   ],
   "exports": {
+    ".": {
+      "node": "./app/dist/index.cjs.js",
+      "default": "./app/dist/index.esm.js"
+    },
     "./analytics": {
       "node": {
         "require": "./analytics/dist/index.cjs",


### PR DESCRIPTION
Required for Vite as per https://github.com/vitejs/vite/issues/1505

#4725 added the exports as needed but this one was missing and did not allow projects such as those using SvelteKit to build.
