### PR TITLE
[Auth] Remove background error throwing in initialization

### DIFF
--- a/packages-exp/auth-exp/src/core/auth/auth_impl.ts
+++ b/packages-exp/auth-exp/src/core/auth/auth_impl.ts
@@ -79,7 +79,6 @@ export class AuthImpl implements AuthInternal, _FirebaseService {
   private idTokenSubscription = new Subscription<User>(this);
   private redirectUser: UserInternal | null = null;
   private isProactiveRefreshEnabled = false;
-  private redirectInitializerError: Error | null = null;
 
   // Any network calls will set this to true and prevent subsequent emulator
   // initialization
@@ -150,12 +149,7 @@ export class AuthImpl implements AuthInternal, _FirebaseService {
       this._isInitialized = true;
     });
 
-    // After initialization completes, throw any error caused by redirect flow
-    return this._initializationPromise.then(() => {
-      if (this.redirectInitializerError) {
-        throw this.redirectInitializerError;
-      }
-    });
+    return this._initializationPromise;
   }
 
   /**
@@ -267,7 +261,8 @@ export class AuthImpl implements AuthInternal, _FirebaseService {
         true
       );
     } catch (e) {
-      this.redirectInitializerError = e;
+      // Swallow any errors here; the code can retrieve them in
+      // getRedirectResult().
       await this._setRedirectUser(null);
     }
 

--- a/packages-exp/auth-exp/src/core/auth/auth_impl.ts
+++ b/packages-exp/auth-exp/src/core/auth/auth_impl.ts
@@ -87,10 +87,8 @@ export class AuthImpl implements AuthInternal, _FirebaseService {
   _deleted = false;
   _initializationPromise: Promise<void> | null = null;
   _popupRedirectResolver: PopupRedirectResolverInternal | null = null;
-  _errorFactory: ErrorFactory<
-    AuthErrorCode,
-    AuthErrorParams
-  > = _DEFAULT_AUTH_ERROR_FACTORY;
+  _errorFactory: ErrorFactory<AuthErrorCode, AuthErrorParams> =
+    _DEFAULT_AUTH_ERROR_FACTORY;
   readonly name: string;
 
   // Tracks the last notified UID for state change listeners to prevent
@@ -185,7 +183,8 @@ export class AuthImpl implements AuthInternal, _FirebaseService {
     popupRedirectResolver?: PopupRedirectResolver
   ): Promise<void> {
     // First check to see if we have a pending redirect event.
-    let storedUser = (await this.assertedPersistence.getCurrentUser()) as UserInternal | null;
+    let storedUser =
+      (await this.assertedPersistence.getCurrentUser()) as UserInternal | null;
     if (popupRedirectResolver && this.config.authDomain) {
       await this.getOrInitRedirectPersistenceManager();
       const redirectUserEventId = this.redirectUser?._redirectEventId;
@@ -414,7 +413,8 @@ export class AuthImpl implements AuthInternal, _FirebaseService {
         [_getInstance(resolver._redirectPersistence)],
         KeyName.REDIRECT_USER
       );
-      this.redirectUser = await this.redirectPersistenceManager.getCurrentUser();
+      this.redirectUser =
+        await this.redirectPersistenceManager.getCurrentUser();
     }
 
     return this.redirectPersistenceManager;

--- a/packages-exp/auth-exp/src/platform_browser/auth.test.ts
+++ b/packages-exp/auth-exp/src/platform_browser/auth.test.ts
@@ -328,6 +328,19 @@ describe('core/auth/initializeAuth', () => {
         stub._remove.returns(Promise.resolve());
         completeRedirectFnStub.returns(Promise.reject(new Error('no')));
 
+        // Manually initialize auth to make sure no error is thrown,
+        // since the _initializeAuthInstance function floats
+        const auth = new AuthImpl(FAKE_APP, {
+          apiKey: FAKE_APP.options.apiKey!,
+          apiHost: DefaultConfig.API_HOST,
+          apiScheme: DefaultConfig.API_SCHEME,
+          tokenApiHost: DefaultConfig.TOKEN_API_HOST,
+          authDomain: FAKE_APP.options.authDomain,
+          clientPlatform: ClientPlatform.BROWSER,
+          sdkClientVersion: _getClientVersion(ClientPlatform.BROWSER)
+        });
+        await expect(auth._initializeWithPersistence([_getInstance(inMemoryPersistence)], browserPopupRedirectResolver)).to.not.be.rejected;
+
         await initAndWait([inMemoryPersistence], browserPopupRedirectResolver);
         expect(stub._remove).to.have.been.called;
       });

--- a/packages-exp/auth-exp/src/platform_browser/auth.test.ts
+++ b/packages-exp/auth-exp/src/platform_browser/auth.test.ts
@@ -339,7 +339,12 @@ describe('core/auth/initializeAuth', () => {
           clientPlatform: ClientPlatform.BROWSER,
           sdkClientVersion: _getClientVersion(ClientPlatform.BROWSER)
         });
-        await expect(auth._initializeWithPersistence([_getInstance(inMemoryPersistence)], browserPopupRedirectResolver)).to.not.be.rejected;
+        await expect(
+          auth._initializeWithPersistence(
+            [_getInstance(inMemoryPersistence)],
+            browserPopupRedirectResolver
+          )
+        ).to.not.be.rejected;
 
         await initAndWait([inMemoryPersistence], browserPopupRedirectResolver);
         expect(stub._remove).to.have.been.called;


### PR DESCRIPTION
Fixes https://github.com/firebase/firebase-js-sdk/issues/5304

We were holding on to any redirect error and throwing it after initialization completed. Unfortunately since init is totally async, there was no way this was actionable for developers. The error can instead be gotten by calling `getRedirectResult()`, while initialization simply swallows any errors in the redirect flow. This matches v8 behavior.