### PR TITLE
Add isSupported() to firebase/messaging/sw exports

### DIFF
--- a/packages-exp/firebase-exp/messaging/sw/index.ts
+++ b/packages-exp/firebase-exp/messaging/sw/index.ts
@@ -15,4 +15,8 @@
  * limitations under the License.
  */
 
-export { onBackgroundMessage, getMessaging } from '@firebase/messaging-exp/sw';
+export {
+  onBackgroundMessage,
+  getMessaging,
+  isSupported
+} from '@firebase/messaging-exp/sw';


### PR DESCRIPTION
Ensures that `isSupported()` function exported by `@firebase/messaging/sw` (https://github.com/firebase/firebase-js-sdk/pull/4665) is available from `firebase/messaging/sw`.

Fixes https://github.com/firebase/firebase-js-sdk/issues/5309