### PR TITLE
Storage: Do not throw for path containing ".."

### DIFF
--- a/.changeset/big-lobsters-tell.md
+++ b/.changeset/big-lobsters-tell.md
@@ -1,0 +1,5 @@
+---
+'@firebase/storage': patch
+---
+
+Change `ref()` to not throw if given a path with '..' in it.

--- a/packages/storage/src/service.ts
+++ b/packages/storage/src/service.ts
@@ -74,9 +74,6 @@ function refFromPath(
   } else {
     // ref is a Reference
     if (path !== undefined) {
-      if (path.includes('..')) {
-        throw invalidArgument('`path` param cannot contain ".."');
-      }
       return _getChild(ref, path);
     } else {
       return ref;

--- a/packages/storage/test/unit/service.exp.test.ts
+++ b/packages/storage/test/unit/service.exp.test.ts
@@ -372,12 +372,6 @@ GOOG4-RSA-SHA256`
       const newRef = ref(reference);
       expect(newRef.toString()).to.equal('gs://bucket/object');
     });
-    it('Throws calling ref(reference, path) if path contains ".."', () => {
-      const error = testShared.assertThrows(() => {
-        ref(reference, `../child/path`);
-      }, 'storage/invalid-argument');
-      expect(error.message).to.match(/"\.\."/);
-    });
   });
 
   describe('Deletion', () => {


### PR DESCRIPTION
Based on the only reference to ".." in the Android repo (a test), it seems we do not try to parse ".." as a parent shortcut on the client side and just pass it directly to the server. (https://github.com/firebase/firebase-android-sdk/blob/d7017614307c4497f5b91da3c59b6de2102a17b7/firebase-storage/src/test/java/com/google/firebase/storage/PathingTest.java#L162)

So we will just remove the error and the test for it, and server errors should enable developers to debug if they pass an invalid path.

Fixes https://github.com/firebase/firebase-js-sdk/issues/5180