### PR TITLE
[Do not submit] Add compat changes for passthrough APIs

### DIFF
--- a/packages-exp/auth-compat-exp/src/auth.ts
+++ b/packages-exp/auth-compat-exp/src/auth.ts
@@ -279,6 +279,12 @@ export class Auth
       exp.signInWithCustomToken(this._delegate, token)
     );
   }
+  setCustomTokenProvider(provider: compat.CustomTokenProvider): void {
+    exp.setCustomTokenProvider(this._delegate, provider);
+  }
+  clearCustomTokenProvider(): void {
+    exp.clearCustomTokenProvider(this._delegate);
+  }
   signInWithEmailAndPassword(
     email: string,
     password: string

--- a/packages/auth-types/index.d.ts
+++ b/packages/auth-types/index.d.ts
@@ -398,6 +398,10 @@ export interface EmulatorConfig {
   };
 }
 
+export interface CustomTokenProvider {
+  getCustomToken(): Promise<string>;
+}
+
 export class FirebaseAuth {
   private constructor();
 
@@ -447,6 +451,8 @@ export class FirebaseAuth {
   signInAnonymously(): Promise<UserCredential>;
   signInWithCredential(credential: AuthCredential): Promise<UserCredential>;
   signInWithCustomToken(token: string): Promise<UserCredential>;
+  setCustomTokenProvider(provider: CustomTokenProvider): void;
+  clearCustomTokenProvider(): void;
   signInWithEmailAndPassword(
     email: string,
     password: string


### PR DESCRIPTION
This contains the `compat` changes that correspond with https://github.com/firebase/firebase-js-sdk/pull/5300. Holding off on this PR for now as discussed offline w/ Sam - making this as a placeholder for compat changes

Corresponding internal bug: b/192699639

### Testing

  * Ran `yarn test` in `packages-exp/auth-compat-exp` and passed

### API Changes

  * Changes correspond to [go/custom-auth-passthrough-sdk#heading=h.t4hz4i7fojar](http://go/custom-auth-passthrough-sdk#heading=h.t4hz4i7fojar)
