### PR TITLE
Block on Auth user availabilty

### DIFF
--- a/packages/firestore/exp/register.ts
+++ b/packages/firestore/exp/register.ts
@@ -23,6 +23,7 @@ import {
 import { Component, ComponentType } from '@firebase/component';
 
 import { name, version } from '../package.json';
+import { FirebaseCredentialsProvider } from '../src/api/credentials';
 import { setSDKVersion } from '../src/core/version';
 import { Firestore } from '../src/exp/database';
 import { PrivateSettings } from '../src/lite/settings';
@@ -42,7 +43,9 @@ export function registerFirestore(variant?: string): void {
         const app = container.getProvider('app-exp').getImmediate()!;
         const firestoreInstance = new Firestore(
           app,
-          container.getProvider('auth-internal')
+          new FirebaseCredentialsProvider(
+            container.getProvider('auth-internal')
+          )
         );
         settings = { useFetchStreams: true, ...settings };
         firestoreInstance._setSettings(settings);

--- a/packages/firestore/index.console.ts
+++ b/packages/firestore/index.console.ts
@@ -18,6 +18,7 @@
 import { FirebaseAuthInternalName } from '@firebase/auth-interop-types';
 import { Provider } from '@firebase/component';
 
+import { EmptyCredentialsProvider } from './src/api/credentials';
 import {
   Firestore as FirestoreCompat,
   MemoryPersistenceProvider
@@ -53,7 +54,7 @@ export class Firestore extends FirestoreCompat {
       databaseIdFromFirestoreDatabase(firestoreDatabase),
       new FirestoreExp(
         databaseIdFromFirestoreDatabase(firestoreDatabase),
-        authProvider
+        new EmptyCredentialsProvider()
       ),
       new MemoryPersistenceProvider()
     );

--- a/packages/firestore/index.node.memory.ts
+++ b/packages/firestore/index.node.memory.ts
@@ -19,6 +19,7 @@ import firebase from '@firebase/app';
 import { FirebaseNamespace } from '@firebase/app-types';
 
 import { name, version } from './package.json';
+import { FirebaseCredentialsProvider } from './src/api/credentials';
 import { Firestore, MemoryPersistenceProvider } from './src/api/database';
 import { configureForFirebase } from './src/config';
 import { Firestore as ExpFirestore } from './src/exp/database';
@@ -35,7 +36,7 @@ export function registerFirestore(instance: FirebaseNamespace): void {
     (app, auth) =>
       new Firestore(
         app,
-        new ExpFirestore(app, auth),
+        new ExpFirestore(app, new FirebaseCredentialsProvider(auth)),
         new MemoryPersistenceProvider()
       )
   );

--- a/packages/firestore/index.node.ts
+++ b/packages/firestore/index.node.ts
@@ -18,6 +18,7 @@ import firebase from '@firebase/app';
 import { FirebaseNamespace } from '@firebase/app-types';
 
 import { name, version } from './package.json';
+import { FirebaseCredentialsProvider } from './src/api/credentials';
 import { Firestore, IndexedDbPersistenceProvider } from './src/api/database';
 import { configureForFirebase } from './src/config';
 import { Firestore as ExpFirestore } from './src/exp/database';
@@ -34,7 +35,7 @@ export function registerFirestore(instance: FirebaseNamespace): void {
     (app, auth) =>
       new Firestore(
         app,
-        new ExpFirestore(app, auth),
+        new ExpFirestore(app, new FirebaseCredentialsProvider(auth)),
         new IndexedDbPersistenceProvider()
       )
   );

--- a/packages/firestore/lite/register.ts
+++ b/packages/firestore/lite/register.ts
@@ -23,6 +23,7 @@ import {
 import { Component, ComponentType } from '@firebase/component';
 
 import { version } from '../package.json';
+import { LiteCredentialsProvider } from '../src/api/credentials';
 import { setSDKVersion } from '../src/core/version';
 import { Firestore } from '../src/lite/database';
 import { FirestoreSettings } from '../src/lite/settings';
@@ -42,7 +43,7 @@ export function registerFirestore(): void {
         const app = container.getProvider('app-exp').getImmediate()!;
         const firestoreInstance = new Firestore(
           app,
-          container.getProvider('auth-internal')
+          new LiteCredentialsProvider(container.getProvider('auth-internal'))
         );
         if (settings) {
           firestoreInstance._setSettings(settings);

--- a/packages/firestore/src/api/credentials.ts
+++ b/packages/firestore/src/api/credentials.ts
@@ -229,6 +229,11 @@ export class FirebaseCredentialsProvider implements CredentialsProvider {
   constructor(private authProvider: Provider<FirebaseAuthInternalName>) {}
 
   getToken(): Promise<Token | null> {
+    debugAssert(
+      this.tokenListener != null,
+      'FirebaseCredentialsProvider not started.'
+    );
+
     // Take note of the current value of the tokenCounter so that this method
     // can fail (with an ABORTED error) if there is a token change while the
     // request is outstanding.

--- a/packages/firestore/src/api/credentials.ts
+++ b/packages/firestore/src/api/credentials.ts
@@ -253,8 +253,8 @@ export class FirebaseCredentialsProvider implements CredentialsProvider {
     let lastTokenId = -1;
 
     // A change listener that prevents double-firing for the same token change.
-    const guardedChangeListener = (user: User) => {
-      if (this.tokenCounter != lastTokenId) {
+    const guardedChangeListener : (user: User) => Promise<void> = user => {
+      if (this.tokenCounter !== lastTokenId) {
         lastTokenId = this.tokenCounter;
         return changeListener(user);
       } else {

--- a/packages/firestore/src/api/credentials.ts
+++ b/packages/firestore/src/api/credentials.ts
@@ -169,13 +169,13 @@ export class EmulatorCredentialsProvider implements CredentialsProvider {
 export class LiteCredentialsProvider implements CredentialsProvider {
   private auth: FirebaseAuthInternal | null = null;
 
-  constructor(private authProvider: Provider<FirebaseAuthInternalName>) {}
+  constructor(authProvider: Provider<FirebaseAuthInternalName>) {
+    authProvider.onInit(auth => {
+      this.auth = auth;
+    });
+  }
 
   getToken(): Promise<Token | null> {
-    if (!this.auth) {
-      this.auth = this.authProvider.getImmediate({ optional: true });
-    }
-
     if (!this.auth) {
       return Promise.resolve(null);
     }

--- a/packages/firestore/src/api/credentials.ts
+++ b/packages/firestore/src/api/credentials.ts
@@ -97,19 +97,15 @@ export interface CredentialsProvider {
   invalidateToken(): void;
 
   /**
-   * Specifies a listener to be notified of credential changes
-   * (sign-in / sign-out, token changes). It is immediately called once with the
-   * initial user.
+   * Starts the credentials provider and specifies a listener to be notified of
+   * credential changes (sign-in / sign-out, token changes). It is immediately
+   * called once with the initial user.
    *
    * The change listener is invoked on the provided AsyncQueue.
    */
-  setChangeListener(
-    asyncQueue: AsyncQueue,
-    changeListener: CredentialChangeListener
-  ): void;
+  start(asyncQueue: AsyncQueue, changeListener: CredentialChangeListener): void;
 
-  /** Removes the previously-set change listener. */
-  removeChangeListener(): void;
+  shutdown(): void;
 }
 
 /** A CredentialsProvider that always yields an empty token. */
@@ -127,7 +123,7 @@ export class EmptyCredentialsProvider implements CredentialsProvider {
 
   invalidateToken(): void {}
 
-  setChangeListener(
+  start(
     asyncQueue: AsyncQueue,
     changeListener: CredentialChangeListener
   ): void {
@@ -140,7 +136,7 @@ export class EmptyCredentialsProvider implements CredentialsProvider {
     asyncQueue.enqueueRetryable(() => changeListener(User.UNAUTHENTICATED));
   }
 
-  removeChangeListener(): void {
+  shutdown(): void {
     this.changeListener = null;
   }
 }
@@ -165,7 +161,7 @@ export class EmulatorCredentialsProvider implements CredentialsProvider {
 
   invalidateToken(): void {}
 
-  setChangeListener(
+  start(
     asyncQueue: AsyncQueue,
     changeListener: CredentialChangeListener
   ): void {
@@ -178,7 +174,7 @@ export class EmulatorCredentialsProvider implements CredentialsProvider {
     asyncQueue.enqueueRetryable(() => changeListener(this.token.user));
   }
 
-  removeChangeListener(): void {
+  shutdown(): void {
     this.changeListener = null;
   }
 }
@@ -188,13 +184,10 @@ export class FirebaseCredentialsProvider implements CredentialsProvider {
    * The auth token listener registered with FirebaseApp, retained here so we
    * can unregister it.
    */
-  private tokenListener: () => void;
+  private tokenListener!: () => void;
 
   /** Tracks the current User. */
   private currentUser: User = User.UNAUTHENTICATED;
-
-  /** Promise that allows blocking on the initialization of Firebase Auth. */
-  private authDeferred = new Deferred();
 
   /**
    * Counter used to detect if the token changed while a getToken request was
@@ -202,51 +195,11 @@ export class FirebaseCredentialsProvider implements CredentialsProvider {
    */
   private tokenCounter = 0;
 
-  /** The listener registered with setChangeListener(). */
-  private changeListener?: CredentialChangeListener;
-
   private forceRefresh = false;
 
   private auth: FirebaseAuthInternal | null = null;
 
-  private asyncQueue: AsyncQueue | null = null;
-
-  constructor(authProvider: Provider<FirebaseAuthInternalName>) {
-    this.tokenListener = () => {
-      this.tokenCounter++;
-      this.currentUser = this.getUser();
-      this.authDeferred.resolve();
-      if (this.changeListener) {
-        this.asyncQueue!.enqueueRetryable(() =>
-          this.changeListener!(this.currentUser)
-        );
-      }
-    };
-
-    const registerAuth = (auth: FirebaseAuthInternal): void => {
-      logDebug('FirebaseCredentialsProvider', 'Auth detected');
-      this.auth = auth;
-      this.auth.addAuthTokenListener(this.tokenListener);
-    };
-
-    authProvider.onInit(auth => registerAuth(auth));
-
-    // Our users can initialize Auth right after Firestore, so we give it
-    // a chance to register itself with the component framework before we
-    // determine whether to start up in unauthenticated mode.
-    setTimeout(() => {
-      if (!this.auth) {
-        const auth = authProvider.getImmediate({ optional: true });
-        if (auth) {
-          registerAuth(auth);
-        } else {
-          // If auth is still not available, proceed with `null` user
-          logDebug('FirebaseCredentialsProvider', 'Auth not yet detected');
-          this.authDeferred.resolve();
-        }
-      }
-    }, 0);
-  }
+  constructor(private authProvider: Provider<FirebaseAuthInternalName>) {}
 
   getToken(): Promise<Token | null> {
     debugAssert(
@@ -293,26 +246,78 @@ export class FirebaseCredentialsProvider implements CredentialsProvider {
     this.forceRefresh = true;
   }
 
-  setChangeListener(
+  start(
     asyncQueue: AsyncQueue,
     changeListener: CredentialChangeListener
   ): void {
-    debugAssert(!this.asyncQueue, 'Can only call setChangeListener() once.');
-    this.asyncQueue = asyncQueue;
+    let lastTokenId = -1;
 
-    // Blocks the AsyncQueue until the next user is available.
-    this.asyncQueue!.enqueueRetryable(async () => {
-      await this.authDeferred.promise;
-      await changeListener(this.currentUser);
-      this.changeListener = changeListener;
+    // A change listener that prevents double-firing for the same token change.
+    const guardedChangeListener = (user: User) => {
+      if (this.tokenCounter != lastTokenId) {
+        lastTokenId = this.tokenCounter;
+        return changeListener(user);
+      } else {
+        return Promise.resolve();
+      }
+    };
+
+    // A promise that can be waited on to block on the next token change.
+    // This promise is re-created after each change.
+    let nextToken = new Deferred<void>();
+
+    this.tokenListener = () => {
+      this.tokenCounter++;
+      this.currentUser = this.getUser();
+      nextToken.resolve();
+      nextToken = new Deferred<void>();
+      asyncQueue.enqueueRetryable(() =>
+        guardedChangeListener(this.currentUser)
+      );
+    };
+
+    const registerAuth = (auth: FirebaseAuthInternal): void => {
+      asyncQueue.enqueueRetryable(async () => {
+        logDebug('FirebaseCredentialsProvider', 'Auth detected');
+        this.auth = auth;
+        this.auth.addAuthTokenListener(this.tokenListener);
+
+        // Call the change listener inline to block on the user change.
+        await nextToken.promise;
+        await guardedChangeListener(this.currentUser);
+      });
+    };
+
+    this.authProvider.onInit(auth => registerAuth(auth));
+
+    // Our users can initialize Auth right after Firestore, so we give it
+    // a chance to register itself with the component framework before we
+    // determine whether to start up in unauthenticated mode.
+    setTimeout(() => {
+      if (!this.auth) {
+        const auth = this.authProvider.getImmediate({ optional: true });
+        if (auth) {
+          registerAuth(auth);
+        } else {
+          // If auth is still not available, proceed with `null` user
+          logDebug('FirebaseCredentialsProvider', 'Auth not yet detected');
+          nextToken.resolve();
+          nextToken = new Deferred<void>();
+        }
+      }
+    }, 0);
+
+    asyncQueue.enqueueRetryable(async () => {
+      // Call the change listener inline to block on the user change.
+      await nextToken.promise;
+      await guardedChangeListener(this.currentUser);
     });
   }
 
-  removeChangeListener(): void {
+  shutdown(): void {
     if (this.auth) {
       this.auth.removeAuthTokenListener(this.tokenListener!);
     }
-    this.changeListener = () => Promise.resolve();
   }
 
   // Auth.getUid() can return null even with a user logged in. It is because
@@ -389,7 +394,7 @@ export class FirstPartyCredentialsProvider implements CredentialsProvider {
     );
   }
 
-  setChangeListener(
+  start(
     asyncQueue: AsyncQueue,
     changeListener: CredentialChangeListener
   ): void {
@@ -397,7 +402,7 @@ export class FirstPartyCredentialsProvider implements CredentialsProvider {
     asyncQueue.enqueueRetryable(() => changeListener(User.FIRST_PARTY));
   }
 
-  removeChangeListener(): void {}
+  shutdown(): void {}
 
   invalidateToken(): void {}
 }

--- a/packages/firestore/src/api/credentials.ts
+++ b/packages/firestore/src/api/credentials.ts
@@ -202,11 +202,6 @@ export class FirebaseCredentialsProvider implements CredentialsProvider {
   constructor(private authProvider: Provider<FirebaseAuthInternalName>) {}
 
   getToken(): Promise<Token | null> {
-    debugAssert(
-      this.tokenListener != null,
-      'getToken cannot be called after listener removed.'
-    );
-
     // Take note of the current value of the tokenCounter so that this method
     // can fail (with an ABORTED error) if there is a token change while the
     // request is outstanding.
@@ -253,7 +248,7 @@ export class FirebaseCredentialsProvider implements CredentialsProvider {
     let lastTokenId = -1;
 
     // A change listener that prevents double-firing for the same token change.
-    const guardedChangeListener : (user: User) => Promise<void> = user => {
+    const guardedChangeListener: (user: User) => Promise<void> = user => {
       if (this.tokenCounter !== lastTokenId) {
         lastTokenId = this.tokenCounter;
         return changeListener(user);

--- a/packages/firestore/src/core/firestore_client.ts
+++ b/packages/firestore/src/core/firestore_client.ts
@@ -116,7 +116,7 @@ export class FirestoreClient {
     public asyncQueue: AsyncQueue,
     private databaseInfo: DatabaseInfo
   ) {
-    this.credentials.setChangeListener(asyncQueue, async user => {
+    this.credentials.start(asyncQueue, async user => {
       logDebug(LOG_TAG, 'Received user=', user.uid);
       await this.credentialListener(user);
       this.user = user;
@@ -163,10 +163,10 @@ export class FirestoreClient {
           await this.offlineComponents.terminate();
         }
 
-        // `removeChangeListener` must be called after shutting down the
-        // RemoteStore as it will prevent the RemoteStore from retrieving
-        // auth tokens.
-        this.credentials.removeChangeListener();
+        // The credentials provider must be terminated after shutting down the
+        // RemoteStore as it will prevent the RemoteStore from retrieving auth
+        // tokens.
+        this.credentials.shutdown();
         deferred.resolve();
       } catch (e) {
         const firestoreError = wrapInUserErrorIfRecoverable(

--- a/packages/firestore/src/exp/database.ts
+++ b/packages/firestore/src/exp/database.ts
@@ -22,10 +22,9 @@ import {
   FirebaseApp,
   getApp
 } from '@firebase/app-exp';
-import { FirebaseAuthInternalName } from '@firebase/auth-interop-types';
-import { Provider } from '@firebase/component';
 import { deepEqual } from '@firebase/util';
 
+import { CredentialsProvider } from '../api/credentials';
 import {
   IndexedDbOfflineComponentProvider,
   MultiTabOfflineComponentProvider,
@@ -94,9 +93,9 @@ export class Firestore extends LiteFirestore {
   /** @hideconstructor */
   constructor(
     databaseIdOrApp: DatabaseId | FirebaseApp,
-    authProvider: Provider<FirebaseAuthInternalName>
+    credentials: CredentialsProvider
   ) {
-    super(databaseIdOrApp, authProvider);
+    super(databaseIdOrApp, credentials);
     this._persistenceKey =
       'name' in databaseIdOrApp ? databaseIdOrApp.name : '[DEFAULT]';
   }

--- a/packages/firestore/src/lite/database.ts
+++ b/packages/firestore/src/lite/database.ts
@@ -22,15 +22,11 @@ import {
   FirebaseApp,
   getApp
 } from '@firebase/app-exp';
-import { FirebaseAuthInternalName } from '@firebase/auth-interop-types';
-import { Provider } from '@firebase/component';
 import { createMockUserToken, EmulatorMockTokenOptions } from '@firebase/util';
 
 import {
   CredentialsProvider,
-  EmptyCredentialsProvider,
   EmulatorCredentialsProvider,
-  FirebaseCredentialsProvider,
   makeCredentialsProvider,
   OAuthToken
 } from '../api/credentials';
@@ -67,7 +63,6 @@ export class Firestore implements FirestoreService {
 
   readonly _databaseId: DatabaseId;
   readonly _persistenceKey: string = '(lite)';
-  _credentials: CredentialsProvider;
 
   private _settings = new FirestoreSettingsImpl({});
   private _settingsFrozen = false;
@@ -81,15 +76,13 @@ export class Firestore implements FirestoreService {
   /** @hideconstructor */
   constructor(
     databaseIdOrApp: DatabaseId | FirebaseApp,
-    authProvider: Provider<FirebaseAuthInternalName>
+    public _credentials: CredentialsProvider
   ) {
     if (databaseIdOrApp instanceof DatabaseId) {
       this._databaseId = databaseIdOrApp;
-      this._credentials = new EmptyCredentialsProvider();
     } else {
       this._app = databaseIdOrApp as FirebaseApp;
       this._databaseId = databaseIdFromApp(databaseIdOrApp as FirebaseApp);
-      this._credentials = new FirebaseCredentialsProvider(authProvider);
     }
   }
 

--- a/packages/firestore/test/integration/util/internal_helpers.ts
+++ b/packages/firestore/test/integration/util/internal_helpers.ts
@@ -73,11 +73,8 @@ export class MockCredentialsProvider extends EmptyCredentialsProvider {
     this.asyncQueue!.enqueueRetryable(async () => this.listener!(newUser));
   }
 
-  setChangeListener(
-    asyncQueue: AsyncQueue,
-    listener: CredentialChangeListener
-  ): void {
-    super.setChangeListener(asyncQueue, listener);
+  start(asyncQueue: AsyncQueue, listener: CredentialChangeListener): void {
+    super.start(asyncQueue, listener);
     this.asyncQueue = asyncQueue;
     this.listener = listener;
   }

--- a/packages/firestore/test/util/api_helpers.ts
+++ b/packages/firestore/test/util/api_helpers.ts
@@ -18,8 +18,7 @@
 // Helpers here mock Firestore in order to unit-test API types. Do NOT use
 // these in any integration test, where we expect working Firestore object.
 
-import { Provider, ComponentContainer } from '@firebase/component';
-
+import { EmptyCredentialsProvider } from '../../src/api/credentials';
 import {
   CollectionReference,
   DocumentReference,
@@ -70,10 +69,7 @@ export function firestore(): Firestore {
 export function newTestFirestore(projectId = 'new-project'): Firestore {
   return new Firestore(
     new DatabaseId(projectId),
-    new ExpFirestore(
-      new DatabaseId(projectId),
-      new Provider('auth-internal', new ComponentContainer('default'))
-    ),
+    new ExpFirestore(new DatabaseId(projectId), new EmptyCredentialsProvider()),
     new IndexedDbPersistenceProvider()
   );
 }


### PR DESCRIPTION
This PR changes Firestore to block the AsyncQueue even if Auth is only available after startup. The queue is blocked from the moment that auth is detected until the SDK receives a user.