### PR TITLE
Allow publishing from any branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,12 +1,10 @@
 name: Release
 
-on:
-  push:
-    branches:
-      - release
+on: push
 
 jobs:
   release:
+    if: github.ref == 'release' || contains(github.ref, '-release')
     name: Release
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on: push
 
 jobs:
   release:
-    if: github.ref == 'release' || contains(github.ref, '-release')
+    if: github.ref == 'refs/heads/release' || endsWith(github.ref, '-releasebranch')
     name: Release
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This works in tandem with a change to the internal `release-cli` script (that branch is currently named `custombranch`).

The change to that script is, if publishing from `master`, the release branch is named `release`. If publishing from any other branch, the release branch is named `[branch name]-releasebranch`. I was going to make the suffix `-release` but I did a search and it's not uncommon to end dev branches with `-release` if we're working on the release process. So trying to make something more unique.