### PR TITLE
Set up auth to use a separate d.ts file for docgen

### DIFF
--- a/common/api-review/auth.api.md
+++ b/common/api-review/auth.api.md
@@ -101,14 +101,14 @@ export class AuthCredential {
     protected constructor(
     providerId: string,
     signInMethod: string);
-    // Warning: (ae-forgotten-export) The symbol "AuthInternal" needs to be exported by the entry point index.doc.d.ts
-    // Warning: (ae-forgotten-export) The symbol "PhoneOrOauthTokenResponse" needs to be exported by the entry point index.doc.d.ts
+    // Warning: (ae-forgotten-export) The symbol "AuthInternal" needs to be exported by the entry point index.d.ts
+    // Warning: (ae-forgotten-export) The symbol "PhoneOrOauthTokenResponse" needs to be exported by the entry point index.d.ts
     //
     // @internal (undocumented)
     _getIdTokenResponse(_auth: AuthInternal): Promise<PhoneOrOauthTokenResponse>;
     // @internal (undocumented)
     _getReauthenticationResolver(_auth: AuthInternal): Promise<IdTokenResponse>;
-    // Warning: (ae-forgotten-export) The symbol "IdTokenResponse" needs to be exported by the entry point index.doc.d.ts
+    // Warning: (ae-forgotten-export) The symbol "IdTokenResponse" needs to be exported by the entry point index.d.ts
     //
     // @internal (undocumented)
     _linkToIdToken(_auth: AuthInternal, _idToken: string): Promise<IdTokenResponse>;
@@ -277,9 +277,6 @@ export function connectAuthEmulator(auth: Auth, url: string, options?: {
 }): void;
 
 // @public
-export const cordovaPopupRedirectResolver: PopupRedirectResolver;
-
-// @public
 export function createUserWithEmailAndPassword(auth: Auth, email: string, password: string): Promise<UserCredential>;
 
 // @public
@@ -342,7 +339,7 @@ export interface EmulatorConfig {
 
 export { ErrorFn }
 
-// Warning: (ae-forgotten-export) The symbol "BaseOAuthProvider" needs to be exported by the entry point index.doc.d.ts
+// Warning: (ae-forgotten-export) The symbol "BaseOAuthProvider" needs to be exported by the entry point index.d.ts
 //
 // @public
 export class FacebookAuthProvider extends BaseOAuthProvider {
@@ -484,7 +481,7 @@ export type NextOrObserver<T> = NextFn<T | null> | Observer<T | null>;
 export class OAuthCredential extends AuthCredential {
     accessToken?: string;
     static fromJSON(json: string | object): OAuthCredential | null;
-    // Warning: (ae-forgotten-export) The symbol "OAuthCredentialParams" needs to be exported by the entry point index.doc.d.ts
+    // Warning: (ae-forgotten-export) The symbol "OAuthCredentialParams" needs to be exported by the entry point index.d.ts
     //
     // @internal (undocumented)
     static _fromParams(params: OAuthCredentialParams): OAuthCredential;
@@ -563,7 +560,7 @@ export class PhoneAuthCredential extends AuthCredential {
     _getReauthenticationResolver(auth: AuthInternal): Promise<IdTokenResponse>;
     // @internal (undocumented)
     _linkToIdToken(auth: AuthInternal, idToken: string): Promise<IdTokenResponse>;
-    // Warning: (ae-forgotten-export) The symbol "SignInWithPhoneNumberRequest" needs to be exported by the entry point index.doc.d.ts
+    // Warning: (ae-forgotten-export) The symbol "SignInWithPhoneNumberRequest" needs to be exported by the entry point index.d.ts
     //
     // @internal (undocumented)
     _makeVerificationRequest(): SignInWithPhoneNumberRequest;
@@ -637,9 +634,6 @@ export interface ReactNativeAsyncStorage {
 }
 
 // @public
-export const reactNativeLocalPersistence: Persistence;
-
-// @public
 export function reauthenticateWithCredential(user: User, credential: AuthCredential): Promise<UserCredential>;
 
 // @public
@@ -657,13 +651,13 @@ export interface RecaptchaParameters {
     [key: string]: any;
 }
 
-// Warning: (ae-forgotten-export) The symbol "ApplicationVerifierInternal" needs to be exported by the entry point index.doc.d.ts
+// Warning: (ae-forgotten-export) The symbol "ApplicationVerifierInternal" needs to be exported by the entry point index.d.ts
 //
 // @public
 export class RecaptchaVerifier implements ApplicationVerifierInternal {
     constructor(containerOrId: HTMLElement | string, parameters: RecaptchaParameters, authExtern: Auth);
     clear(): void;
-    // Warning: (ae-forgotten-export) The symbol "ReCaptchaLoader" needs to be exported by the entry point index.doc.d.ts
+    // Warning: (ae-forgotten-export) The symbol "ReCaptchaLoader" needs to be exported by the entry point index.d.ts
     //
     // @internal (undocumented)
     readonly _recaptchaLoader: ReCaptchaLoader;
@@ -677,7 +671,7 @@ export class RecaptchaVerifier implements ApplicationVerifierInternal {
 // @public
 export function reload(user: User): Promise<void>;
 
-// Warning: (ae-forgotten-export) The symbol "FederatedAuthProvider" needs to be exported by the entry point index.doc.d.ts
+// Warning: (ae-forgotten-export) The symbol "FederatedAuthProvider" needs to be exported by the entry point index.d.ts
 //
 // @public
 export class SAMLAuthProvider extends FederatedAuthProvider {

--- a/packages/auth/api-extractor.json
+++ b/packages/auth/api-extractor.json
@@ -1,7 +1,8 @@
 {
     "extends": "../../config/api-extractor.json",
-    // Point it to your entry point d.ts file. 
-    "mainEntryPointFilePath": "<projectFolder>/dist/esm5/index.doc.d.ts",
+    // If this path ever changes, make sure to change scripts/exp/docgen.ts
+    // accordingly.
+    "mainEntryPointFilePath": "<projectFolder>/dist/esm5/index.d.ts",
     "dtsRollup": {
         "enabled": true,
         "untrimmedFilePath": "<projectFolder>/dist/<unscopedPackageName>.d.ts",

--- a/scripts/exp/docgen.ts
+++ b/scripts/exp/docgen.ts
@@ -38,6 +38,20 @@ async function generateDocs(forDevsite: boolean = false) {
   const outputFolder = forDevsite ? 'docs-devsite' : 'docs-exp';
   const command = forDevsite ? 'api-documenter-devsite' : 'api-documenter';
 
+  // Use a special d.ts file for auth for doc gen only.
+  const authApiConfigOriginal = fs.readFileSync(
+    `${projectRoot}/packages/auth/api-extractor.json`,
+    'utf8'
+  );
+  const authApiConfigModified = authApiConfigOriginal.replace(
+    `"mainEntryPointFilePath": "<projectFolder>/dist/esm5/index.d.ts"`,
+    `"mainEntryPointFilePath": "<projectFolder>/dist/esm5/index.doc.d.ts"`
+  );
+  fs.writeFileSync(
+    `${projectRoot}/packages/auth/api-extractor.json`,
+    authApiConfigModified
+  );
+
   await spawn('yarn', ['build'], {
     stdio: 'inherit'
   });
@@ -46,15 +60,19 @@ async function generateDocs(forDevsite: boolean = false) {
     stdio: 'inherit'
   });
 
+  // Restore original auth api-extractor.json contents.
+  fs.writeFileSync(
+    `${projectRoot}/packages/auth/api-extractor.json`,
+    authApiConfigOriginal
+  );
+
   if (!fs.existsSync(tmpDir)) {
     fs.mkdirSync(tmpDir);
   }
 
   // TODO: Throw error if path doesn't exist once all packages add markdown support.
   const apiJsonDirectories = (
-    await mapWorkspaceToPackages([
-      `${projectRoot}/packages/*`
-    ])
+    await mapWorkspaceToPackages([`${projectRoot}/packages/*`])
   )
     .map(path => `${path}/temp`)
     .filter(path => fs.existsSync(path));


### PR DESCRIPTION
Hack to ensure auth uses `index.doc.d.ts` for doc gen only - and not during the actual build.