### PR TITLE
Move Messaging env checks to public methods

### DIFF
--- a/packages/messaging/src/api.ts
+++ b/packages/messaging/src/api.ts
@@ -51,14 +51,12 @@ export function getMessagingInWindow(app: FirebaseApp = getApp()): Messaging {
   // special handling.
   isWindowSupported()
     .then(isSupported => {
+      // If `isWindowSupported()` resolved, but returned false.
       if (!isSupported) {
         throw ERROR_FACTORY.create(ErrorCode.UNSUPPORTED_BROWSER);
       }
-    })
-    .catch((e: Error) => {
-      if (e.message.includes(ErrorCode.UNSUPPORTED_BROWSER)) {
-        throw e;
-      }
+    }, _ => {
+      // If `isWindowSupported()` rejected.
       throw ERROR_FACTORY.create(ErrorCode.INDEXED_DB_UNSUPPORTED);
     });
   return _getProvider(getModularInstance(app), 'messaging').getImmediate();
@@ -77,17 +75,15 @@ export function getMessagingInSw(app: FirebaseApp = getApp()): Messaging {
   // developer's information. Developers can then choose to import and call `isSupported` for
   // special handling.
   isSwSupported()
-    .then(isSupported => {
-      if (!isSupported) {
-        throw ERROR_FACTORY.create(ErrorCode.UNSUPPORTED_BROWSER);
-      }
-    })
-    .catch((e: Error) => {
-      if (e.message.includes(ErrorCode.UNSUPPORTED_BROWSER)) {
-        throw e;
-      }
-      throw ERROR_FACTORY.create(ErrorCode.INDEXED_DB_UNSUPPORTED);
-    });
+  .then(isSupported => {
+    // If `isSwSupported()` resolved, but returned false.
+    if (!isSupported) {
+      throw ERROR_FACTORY.create(ErrorCode.UNSUPPORTED_BROWSER);
+    }
+  }, _ => {
+    // If `isSwSupported()` rejected.
+    throw ERROR_FACTORY.create(ErrorCode.INDEXED_DB_UNSUPPORTED);
+  });
   return _getProvider(getModularInstance(app), 'messaging-sw').getImmediate();
 }
 

--- a/packages/messaging/src/api.ts
+++ b/packages/messaging/src/api.ts
@@ -49,16 +49,18 @@ export function getMessagingInWindow(app: FirebaseApp = getApp()): Messaging {
   // initialization phase for performance consideration. An error would be thrown latter for
   // developer's information. Developers can then choose to import and call `isSupported` for
   // special handling.
-  isWindowSupported()
-    .then(isSupported => {
+  isWindowSupported().then(
+    isSupported => {
       // If `isWindowSupported()` resolved, but returned false.
       if (!isSupported) {
         throw ERROR_FACTORY.create(ErrorCode.UNSUPPORTED_BROWSER);
       }
-    }, _ => {
+    },
+    _ => {
       // If `isWindowSupported()` rejected.
       throw ERROR_FACTORY.create(ErrorCode.INDEXED_DB_UNSUPPORTED);
-    });
+    }
+  );
   return _getProvider(getModularInstance(app), 'messaging').getImmediate();
 }
 
@@ -74,16 +76,18 @@ export function getMessagingInSw(app: FirebaseApp = getApp()): Messaging {
   // initialization phase for performance consideration. An error would be thrown latter for
   // developer's information. Developers can then choose to import and call `isSupported` for
   // special handling.
-  isSwSupported()
-  .then(isSupported => {
-    // If `isSwSupported()` resolved, but returned false.
-    if (!isSupported) {
-      throw ERROR_FACTORY.create(ErrorCode.UNSUPPORTED_BROWSER);
+  isSwSupported().then(
+    isSupported => {
+      // If `isSwSupported()` resolved, but returned false.
+      if (!isSupported) {
+        throw ERROR_FACTORY.create(ErrorCode.UNSUPPORTED_BROWSER);
+      }
+    },
+    _ => {
+      // If `isSwSupported()` rejected.
+      throw ERROR_FACTORY.create(ErrorCode.INDEXED_DB_UNSUPPORTED);
     }
-  }, _ => {
-    // If `isSwSupported()` rejected.
-    throw ERROR_FACTORY.create(ErrorCode.INDEXED_DB_UNSUPPORTED);
-  });
+  );
   return _getProvider(getModularInstance(app), 'messaging-sw').getImmediate();
 }
 

--- a/packages/messaging/src/helpers/register.ts
+++ b/packages/messaging/src/helpers/register.ts
@@ -21,8 +21,6 @@ import {
   ComponentType,
   InstanceFactory
 } from '@firebase/component';
-import { ERROR_FACTORY, ErrorCode } from '../util/errors';
-import { isSwSupported, isWindowSupported } from '../api/isSupported';
 import {
   onNotificationClick,
   onPush,
@@ -40,8 +38,6 @@ import { messageEventListener } from '../listeners/window-listener';
 const WindowMessagingFactory: InstanceFactory<'messaging'> = (
   container: ComponentContainer
 ) => {
-  maybeThrowWindowError();
-
   const messaging = new MessagingService(
     container.getProvider('app').getImmediate(),
     container.getProvider('installations-internal').getImmediate(),
@@ -58,8 +54,6 @@ const WindowMessagingFactory: InstanceFactory<'messaging'> = (
 const WindowMessagingInternalFactory: InstanceFactory<'messaging-internal'> = (
   container: ComponentContainer
 ) => {
-  maybeThrowWindowError();
-
   const messaging = container
     .getProvider('messaging')
     .getImmediate() as MessagingService;
@@ -71,40 +65,10 @@ const WindowMessagingInternalFactory: InstanceFactory<'messaging-internal'> = (
   return messagingInternal;
 };
 
-function maybeThrowWindowError(): void {
-  // Conscious decision to make this async check non-blocking during the messaging instance
-  // initialization phase for performance consideration. An error would be thrown latter for
-  // developer's information. Developers can then choose to import and call `isSupported` for
-  // special handling.
-  isWindowSupported()
-    .then(isSupported => {
-      if (!isSupported) {
-        throw ERROR_FACTORY.create(ErrorCode.UNSUPPORTED_BROWSER);
-      }
-    })
-    .catch(_ => {
-      throw ERROR_FACTORY.create(ErrorCode.INDEXED_DB_UNSUPPORTED);
-    });
-}
-
 declare const self: ServiceWorkerGlobalScope;
 const SwMessagingFactory: InstanceFactory<'messaging'> = (
   container: ComponentContainer
 ) => {
-  // Conscious decision to make this async check non-blocking during the messaging instance
-  // initialization phase for performance consideration. An error would be thrown latter for
-  // developer's information. Developers can then choose to import and call `isSupported` for
-  // special handling.
-  isSwSupported()
-    .then(isSupported => {
-      if (!isSupported) {
-        throw ERROR_FACTORY.create(ErrorCode.UNSUPPORTED_BROWSER);
-      }
-    })
-    .catch(_ => {
-      throw ERROR_FACTORY.create(ErrorCode.INDEXED_DB_UNSUPPORTED);
-    });
-
   const messaging = new MessagingService(
     container.getProvider('app').getImmediate(),
     container.getProvider('installations-internal').getImmediate(),


### PR DESCRIPTION
Ensure messaging env checks are only called when the user explicitly initializes messaging. If messaging is initialized by an internal API (Functions specifically) in an unsupported environment, it will leave ugly warnings that aren't catchable because the check is async and leaves a hanging promise. Since the user did not call messaging, the user can't do anything about it, and the warning is not helpful.

Also in Node 16, it actually exits and blocks further execution.