### PR TITLE
Add integration tests, fix reload and setCustomTokenProvider

### DIFF
--- a/packages/auth/src/core/strategies/custom_token.test.ts
+++ b/packages/auth/src/core/strategies/custom_token.test.ts
@@ -35,6 +35,7 @@ import {
   signInWithCustomToken
 } from './custom_token';
 import { FirebaseError } from '@firebase/util';
+import { makeJWT } from '../../../test/helpers/jwt';
 
 use(sinonChai);
 use(chaiAsPromised);
@@ -52,7 +53,7 @@ describe('core/strategies/signInWithCustomToken', () => {
   };
 
   const idTokenResponse: IdTokenResponse = {
-    idToken: 'my-id-token',
+    idToken: makeJWT({ sub: 'local-id' }),
     refreshToken: 'my-refresh-token',
     expiresIn: '1234',
     localId: serverUser.localId!,
@@ -135,7 +136,7 @@ describe('core/strategies/signInWithCustomToken', () => {
         token: 'custom-token',
         returnSecureToken: true
       });
-      expect(token).to.eq('my-id-token');
+      expect(token).to.eq(idTokenResponse.idToken);
       expect(
         user.stsTokenManager.updateFromServerResponse
       ).to.have.been.calledWith(idTokenResponse);

--- a/packages/auth/src/core/strategies/custom_token.ts
+++ b/packages/auth/src/core/strategies/custom_token.ts
@@ -29,6 +29,7 @@ import { OperationType } from '../../model/enums';
 import { _assert } from '../util/assert';
 import { AuthErrorCode } from '../errors';
 import { UserInternal } from '../../model/user';
+import { _parseToken } from '../user/id_token_result';
 
 /**
  * Asynchronously signs in using a custom token.
@@ -96,8 +97,9 @@ export function setCustomTokenProvider(
       token,
       returnSecureToken: true
     });
+    const responseToken = _parseToken(response.idToken!);
     _assert(
-      response.localId === authInternal.currentUser?.uid,
+      responseToken && responseToken.sub === authInternal.currentUser?.uid,
       AuthErrorCode.INTERNAL_ERROR
     );
     const user = authInternal.currentUser as UserInternal;

--- a/packages/auth/src/core/strategies/custom_token.ts
+++ b/packages/auth/src/core/strategies/custom_token.ts
@@ -99,7 +99,7 @@ export function setCustomTokenProvider(
     });
     const responseToken = _parseToken(response.idToken!);
     _assert(
-      responseToken && responseToken.sub === authInternal.currentUser?.uid,
+      responseToken?.sub === authInternal.currentUser?.uid,
       AuthErrorCode.INTERNAL_ERROR
     );
     const user = authInternal.currentUser as UserInternal;

--- a/packages/auth/src/core/user/reload.test.ts
+++ b/packages/auth/src/core/user/reload.test.ts
@@ -34,6 +34,7 @@ import {
 import { _reloadWithoutSaving, reload } from './reload';
 import { UserMetadata } from './user_metadata';
 import { UserInternal } from '../../model/user';
+import { makeJWT } from '../../../test/helpers/jwt';
 
 use(chaiAsPromised);
 use(sinonChai);
@@ -172,11 +173,12 @@ describe('core/user/reload', () => {
   it('nulls out properties in passthrough mode', async () => {
     const user = testUser(auth, 'abc', '');
     user.stsTokenManager.isPassthroughMode = true;
-    const getIdTokenSpy = sinon.spy(user, 'getIdToken');
+    user.stsTokenManager.expirationTime = Date.now() + 300_000;
+    user.stsTokenManager.accessToken = makeJWT({ sub: 'uid' });
 
     await _reloadWithoutSaving(user);
 
-    expect(user.uid).to.eq('abc');
+    expect(user.uid).to.eq('uid');
     expect(user.displayName).to.be.null;
     expect(user.photoURL).to.be.null;
     expect(user.email).to.be.null;
@@ -188,7 +190,6 @@ describe('core/user/reload', () => {
       createdAt: undefined,
       lastLoginAt: undefined
     });
-    expect(getIdTokenSpy).not.to.have.been.called;
   });
 
   context('anonymous carryover', () => {

--- a/packages/auth/src/core/user/reload.ts
+++ b/packages/auth/src/core/user/reload.ts
@@ -28,6 +28,7 @@ import { _assert } from '../util/assert';
 import { _logoutIfInvalidated } from './invalidation';
 import { UserMetadata } from './user_metadata';
 import { getModularInstance } from '@firebase/util';
+import { _parseToken } from './id_token_result';
 
 export async function _reloadWithoutSaving(user: UserInternal): Promise<void> {
   const auth = user.auth;
@@ -35,7 +36,9 @@ export async function _reloadWithoutSaving(user: UserInternal): Promise<void> {
 
   if (user.stsTokenManager.isPassthroughMode) {
     // The uid === localId === id token's `sub` claim
-    coreAccount.localId = user.uid;
+    const idToken = await user.getIdToken();
+    const parsedToken = _parseToken(idToken);
+    coreAccount.localId = parsedToken?.sub;
   } else {
     const idToken = await user.getIdToken();
     const response = await _logoutIfInvalidated(

--- a/packages/auth/test/helpers/integration/emulator_rest_helpers.ts
+++ b/packages/auth/test/helpers/integration/emulator_rest_helpers.ts
@@ -39,6 +39,15 @@ interface OobCodesResponse {
   oobCodes: OobCodeSession[];
 }
 
+interface SignInConfig {
+  allowDuplicateEmails?: boolean;
+}
+
+export interface EmulatorProjectsConfig {
+  signIn?: SignInConfig;
+  usageMode?: 'USAGE_MODE_UNSPECIFIED' | 'DEFAULT' | 'PASSTHROUGH';
+}
+
 export async function getPhoneVerificationCodes(): Promise<
   Record<string, VerificationSession>
 > {
@@ -78,6 +87,20 @@ export async function createAnonAccount(): Promise<{
   return response;
 }
 
+export async function updateEmulatorProjectConfig(
+  body: string
+): Promise<EmulatorProjectsConfig> {
+  const url = buildEmulatorUrlForPath('config');
+  const response: EmulatorProjectsConfig = await (
+    await doFetch(url, {
+      method: 'PATCH',
+      body,
+      headers: { 'Content-Type': 'application/json' }
+    })
+  ).json();
+  return response;
+}
+
 function buildEmulatorUrlForPath(endpoint: string): string {
   const emulatorBaseUrl = getEmulatorUrl();
   const projectId = getAppConfig().projectId;
@@ -89,8 +112,8 @@ function doFetch(url: string, request?: RequestInit): ReturnType<typeof fetch> {
     return fetch(url, request);
   }
 
-  return (fetchImpl.default(
+  return fetchImpl.default(
     url,
     request as fetchImpl.RequestInit
-  ) as unknown) as ReturnType<typeof fetch>;
+  ) as unknown as ReturnType<typeof fetch>;
 }

--- a/packages/auth/test/integration/flows/custom.local.test.ts
+++ b/packages/auth/test/integration/flows/custom.local.test.ts
@@ -24,6 +24,7 @@ import {
   linkWithCredential,
   OperationType,
   reload,
+  setCustomTokenProvider,
   signInAnonymously,
   signInWithCustomToken,
   signInWithEmailAndPassword,
@@ -34,11 +35,14 @@ import {
 import { FirebaseError } from '@firebase/util';
 import { expect, use } from 'chai';
 import * as chaiAsPromised from 'chai-as-promised';
+import { updateEmulatorProjectConfig } from '../../helpers/integration/emulator_rest_helpers';
 import {
   cleanUpTestInstance,
   getTestInstance,
   randomEmail
 } from '../../helpers/integration/helpers';
+
+declare const xit: typeof it;
 
 use(chaiAsPromised);
 
@@ -144,6 +148,62 @@ describe('Integration test: custom auth', () => {
     const { user: customUser } = await signInWithCustomToken(auth, customToken);
     expect(auth.currentUser).to.eql(customUser);
     expect(customUser.uid).not.to.eql(anonUser.uid);
+  });
+
+  context('in passthrough mode', () => {
+    beforeEach(async () => {
+      const updatedConfig = await updateEmulatorProjectConfig(
+        JSON.stringify({
+          usageMode: 'PASSTHROUGH'
+        })
+      );
+      expect(updatedConfig).to.eql({
+        signIn: { allowDuplicateEmails: false },
+        usageMode: 'PASSTHROUGH'
+      });
+    });
+
+    afterEach(async () => {
+      await updateEmulatorProjectConfig(
+        JSON.stringify({
+          usageMode: 'DEFAULT'
+        })
+      );
+    });
+
+    xit('signs in with custom token in passthrough mode', async () => {
+      const cred = await signInWithCustomToken(auth, customToken);
+      expect(auth.currentUser).to.eq(cred.user);
+      expect(cred.operationType).to.eq(OperationType.SIGN_IN);
+
+      const { user } = cred;
+      expect(user.isAnonymous).to.be.false;
+      expect(user.uid).to.eq(uid);
+      expect((await user.getIdTokenResult(false)).claims.customClaim).to.eq(
+        'some-claim'
+      );
+      expect(user.providerId).to.eq('firebase');
+      const additionalUserInfo = await getAdditionalUserInfo(cred)!;
+      expect(additionalUserInfo.providerId).to.be.null;
+      expect(additionalUserInfo.isNewUser).to.be.false;
+    });
+
+    xit('token can be refreshed in passthrough mode', async () => {
+      setCustomTokenProvider(auth, {
+        async getCustomToken(): Promise<string> {
+          return JSON.stringify({
+            uid,
+            claims: {
+              customClaim: 'some-claim'
+            }
+          });
+        }
+      });
+      const { user } = await signInWithCustomToken(auth, customToken);
+      const origToken = await user.getIdToken();
+      await new Promise(resolve => setTimeout(resolve, 1000));
+      expect(await user.getIdToken(true)).not.to.eq(origToken);
+    });
   });
 
   context('email/password interaction', () => {

--- a/packages/auth/test/integration/flows/custom.local.test.ts
+++ b/packages/auth/test/integration/flows/custom.local.test.ts
@@ -194,7 +194,7 @@ describe('Integration test: custom auth', () => {
           return JSON.stringify({
             uid,
             claims: {
-              customClaim: 'some-claim'
+              customClaim: 'other-claim'
             }
           });
         }
@@ -203,6 +203,9 @@ describe('Integration test: custom auth', () => {
       const origToken = await user.getIdToken();
       await new Promise(resolve => setTimeout(resolve, 1000));
       expect(await user.getIdToken(true)).not.to.eq(origToken);
+      expect((await user.getIdTokenResult(false)).claims.customClaim).to.eq(
+        'other-claim'
+      );
     });
   });
 


### PR DESCRIPTION
Added integration tests for passthrough, namely,
- for the initial call to signInWithCustomToken
- for a force refresh with a customTokenProvider

Noticed a couple bugs in the process and addressed it here too:
- `user.uid` is not set until a call to `_reloadWithoutSaving()`. The previous logic in `_reloadWithoutSaving()` did not correctly set the `uid` and is now updated to parse the access token for the `sub` claim
- The REST API for [`signInWithCustomToken`](https://cloud.google.com/identity-platform/docs/reference/rest/v1/accounts/signInWithCustomToken) does not include the `localId` in the response, so the assertion in `setCustomTokenProvider()` was also updated to parse the id token 

`xit` is used in place of `it` since passthrough emulator changes have not been merged into main, but will be updated to the latter once it's merged

Corresponding internal bug: b/192699639

### Testing

  * `yarn test` passes
  * With the passthrough emulator changes (i.e. checking out https://github.com/firebase/firebase-tools/commits/lj-passthrough and running `npm run build` in firebase-tools) and changing `xit`'s to `it`'s, `firebase emulators:exec --project p --only auth "yarn test:browser:integration:local"` passes

### API Changes

N/A
