### PR TITLE
Fix breadcrumb margin problem in v8 docs

### DIFF
--- a/scripts/docgen/theme/assets/css/firebase.css
+++ b/scripts/docgen/theme/assets/css/firebase.css
@@ -39,6 +39,10 @@
     color: #333;
 }
 
+.firebase-docs .tsd-breadcrumb li {
+    margin-right: 0;
+}
+
 .firebase-docs .tsd-signature {
     border-bottom: 1px solid #eee;
 }


### PR DESCRIPTION
Not sure if we are going to regenerate v8 docs but if so, need to add this override of the default typedoc css to prevent breadcrumbs (e.g. "firebase.database.Database" title at top of page) from bunching together.