### PR TITLE
Add custom token provider form to auth demo page

### DIFF
--- a/packages/auth-compat/demo/public/script.js
+++ b/packages/auth-compat/demo/public/script.js
@@ -447,6 +447,31 @@ function onSignInWithCustomToken(event) {
 }
 
 /**
+ * Sets a custom token provider that simply returns the custom token provided
+ * in the #user-custom-token-for-provider field.
+ * @param {DOMEvent} _event HTML DOM event returned by the listener.
+ */
+function onSetCustomTokenProvider(event) {
+  const nextRefreshToken = $('#user-custom-token-for-provider').val();
+  auth.setCustomTokenProvider({
+    async getCustomToken() {
+      return nextRefreshToken;
+    }
+  });
+  log(
+    `On next refresh, custom token provider will use token:\n${nextRefreshToken}`
+  );
+}
+
+/**
+ * Clears the custom token provider.
+ */
+function onClearCustomTokenProvider() {
+  auth.clearCustomTokenProvider();
+  log('Cleared custom token provider');
+}
+
+/**
  * Signs in anonymously.
  */
 function onSignInAnonymously() {
@@ -661,9 +686,8 @@ function onFinalizeEnrollWithPhoneMultiFactor() {
     verificationId,
     verificationCode
   );
-  var multiFactorAssertion = firebase.auth.PhoneMultiFactorGenerator.assertion(
-    credential
-  );
+  var multiFactorAssertion =
+    firebase.auth.PhoneMultiFactorGenerator.assertion(credential);
   var displayName = $('#enroll-mfa-phone-display-name').val() || undefined;
 
   activeUser()
@@ -1754,6 +1778,8 @@ function initApp() {
   $('#sign-up-with-email-and-password').click(onSignUp);
   $('#sign-in-with-email-and-password').click(onSignInWithEmailAndPassword);
   $('.sign-in-with-custom-token').click(onSignInWithCustomToken);
+  $('#set-custom-token-provider').click(onSetCustomTokenProvider);
+  $('#clear-custom-token-provider').click(onClearCustomTokenProvider);
   $('#sign-in-anonymously').click(onSignInAnonymously);
   $('#sign-in-with-generic-idp-credential').click(
     onSignInWithGenericIdPCredential

--- a/packages/auth-compat/demo/public/script.js
+++ b/packages/auth-compat/demo/public/script.js
@@ -452,14 +452,14 @@ function onSignInWithCustomToken(event) {
  * @param {DOMEvent} _event HTML DOM event returned by the listener.
  */
 function onSetCustomTokenProvider(event) {
-  const nextRefreshToken = $('#user-custom-token-for-provider').val();
+  const nextCustomToken = $('#user-custom-token-for-provider').val();
   auth.setCustomTokenProvider({
     async getCustomToken() {
-      return nextRefreshToken;
+      return nextCustomToken;
     }
   });
   log(
-    `On next refresh, custom token provider will use token:\n${nextRefreshToken}`
+    `On next refresh, custom token provider will use token:\n${nextCustomToken}`
   );
 }
 

--- a/packages/auth/cordova/demo/src/index.js
+++ b/packages/auth/cordova/demo/src/index.js
@@ -61,7 +61,9 @@ import {
   linkWithRedirect,
   reauthenticateWithRedirect,
   getRedirectResult,
-  cordovaPopupRedirectResolver
+  cordovaPopupRedirectResolver,
+  clearCustomTokenProvider,
+  setCustomTokenProvider
 } from '@firebase/auth/dist/cordova';
 
 import { config } from './config';
@@ -411,6 +413,29 @@ function onSignInWithCustomToken(_event) {
     onAuthUserCredentialSuccess,
     onAuthError
   );
+}
+
+/**
+ * Sets a custom token provider that simply returns the custom token provided
+ * in the #user-custom-token-for-provider field.
+ * @param {DOMEvent} _event HTML DOM event returned by the listener.
+ */
+ function onSetCustomTokenProvider(_event) {
+  const nextRefreshToken = $('#user-custom-token-for-provider').val();
+  setCustomTokenProvider(auth, {
+    async getCustomToken() {
+      return nextRefreshToken;
+    }
+  });
+  log(`On next refresh, custom token provider will use token:\n${nextRefreshToken}`)
+}
+
+/**
+ * Clears the custom token provider.
+ */
+function onClearCustomTokenProvider() {
+  clearCustomTokenProvider(auth);
+  log('Cleared custom token provider');
 }
 
 /**
@@ -1498,6 +1523,8 @@ function initApp() {
   $('#sign-up-with-email-and-password').click(onSignUp);
   $('#sign-in-with-email-and-password').click(onSignInWithEmailAndPassword);
   $('.sign-in-with-custom-token').click(onSignInWithCustomToken);
+  $('#set-custom-token-provider').click(onSetCustomTokenProvider);
+  $('#clear-custom-token-provider').click(onClearCustomTokenProvider);
   $('#sign-in-anonymously').click(onSignInAnonymously);
   $('#sign-in-with-generic-idp-credential').click(
     onSignInWithGenericIdPCredential

--- a/packages/auth/cordova/demo/src/index.js
+++ b/packages/auth/cordova/demo/src/index.js
@@ -421,13 +421,13 @@ function onSignInWithCustomToken(_event) {
  * @param {DOMEvent} _event HTML DOM event returned by the listener.
  */
  function onSetCustomTokenProvider(_event) {
-  const nextRefreshToken = $('#user-custom-token-for-provider').val();
+  const nextCustomToken = $('#user-custom-token-for-provider').val();
   setCustomTokenProvider(auth, {
     async getCustomToken() {
-      return nextRefreshToken;
+      return nextCustomToken;
     }
   });
-  log(`On next refresh, custom token provider will use token:\n${nextRefreshToken}`)
+  log(`On next refresh, custom token provider will use token:\n${nextCustomToken}`)
 }
 
 /**

--- a/packages/auth/cordova/demo/www/index.html
+++ b/packages/auth/cordova/demo/www/index.html
@@ -227,6 +227,18 @@
                   Sign In with Custom Token
                 </button>
               </form>
+              <form class="form form-bordered no-submit">
+                <input type="text" id="user-custom-token-for-provider" class="form-control"
+                       placeholder="Custom Authentication Token" />
+                <button id="set-custom-token-provider" class="btn btn-block btn-primary"
+                        data-expired=false>
+                  Set Custom Token Provider
+                </button>
+                <button id="clear-custom-token-provider" class="btn btn-block btn-primary"
+                        data-expired=false>
+                  Clear Custom Token Provider
+                </button>
+              </form>
               <button class="btn btn-block btn-primary"
                       id="sign-in-anonymously">
                 Sign In Anonymously

--- a/packages/auth/demo/public/index.html
+++ b/packages/auth/demo/public/index.html
@@ -261,6 +261,18 @@
                   Sign In with Custom Token
                 </button>
               </form>
+              <form class="form form-bordered no-submit">
+                <input type="text" id="user-custom-token-for-provider" class="form-control"
+                       placeholder="Custom Authentication Token" />
+                <button id="set-custom-token-provider" class="btn btn-block btn-primary"
+                        data-expired=false>
+                  Set Custom Token Provider
+                </button>
+                <button id="clear-custom-token-provider" class="btn btn-block btn-primary"
+                        data-expired=false>
+                  Clear Custom Token Provider
+                </button>
+              </form>
               <button class="btn btn-block btn-primary"
                       id="sign-in-anonymously">
                 Sign In Anonymously

--- a/packages/auth/demo/src/index.js
+++ b/packages/auth/demo/src/index.js
@@ -91,7 +91,6 @@ let multiFactorErrorResolver = null;
 let selectedMultiFactorHint = null;
 let recaptchaSize = 'normal';
 let webWorker = null;
-let customTokenProvider = null;
 
 // The corresponding Font Awesome icons for each provider.
 const providersIcons = {

--- a/packages/auth/demo/src/index.js
+++ b/packages/auth/demo/src/index.js
@@ -67,7 +67,9 @@ import {
   linkWithRedirect,
   reauthenticateWithRedirect,
   getRedirectResult,
-  browserPopupRedirectResolver
+  browserPopupRedirectResolver,
+  setCustomTokenProvider,
+  clearCustomTokenProvider
 } from '@firebase/auth';
 
 import { config } from './config';
@@ -89,6 +91,7 @@ let multiFactorErrorResolver = null;
 let selectedMultiFactorHint = null;
 let recaptchaSize = 'normal';
 let webWorker = null;
+let customTokenProvider = null;
 
 // The corresponding Font Awesome icons for each provider.
 const providersIcons = {
@@ -417,6 +420,29 @@ function onSignInWithCustomToken(_event) {
     onAuthUserCredentialSuccess,
     onAuthError
   );
+}
+
+/**
+ * Sets a custom token provider that simply returns the custom token provided
+ * in the #user-custom-token-for-provider field.
+ * @param {DOMEvent} _event HTML DOM event returned by the listener.
+ */
+function onSetCustomTokenProvider(_event) {
+  const nextRefreshToken = $('#user-custom-token-for-provider').val();
+  setCustomTokenProvider(auth, {
+    async getCustomToken() {
+      return nextRefreshToken;
+    }
+  });
+  log(`On next refresh, custom token provider will use token:\n${nextRefreshToken}`)
+}
+
+/**
+ * Clears the custom token provider.
+ */
+function onClearCustomTokenProvider() {
+  clearCustomTokenProvider(auth);
+  log('Cleared custom token provider');
 }
 
 /**
@@ -1822,6 +1848,8 @@ function initApp() {
   $('#sign-up-with-email-and-password').click(onSignUp);
   $('#sign-in-with-email-and-password').click(onSignInWithEmailAndPassword);
   $('.sign-in-with-custom-token').click(onSignInWithCustomToken);
+  $('#set-custom-token-provider').click(onSetCustomTokenProvider);
+  $('#clear-custom-token-provider').click(onClearCustomTokenProvider);
   $('#sign-in-anonymously').click(onSignInAnonymously);
   $('#sign-in-with-generic-idp-credential').click(
     onSignInWithGenericIdPCredential

--- a/packages/auth/demo/src/index.js
+++ b/packages/auth/demo/src/index.js
@@ -427,13 +427,13 @@ function onSignInWithCustomToken(_event) {
  * @param {DOMEvent} _event HTML DOM event returned by the listener.
  */
 function onSetCustomTokenProvider(_event) {
-  const nextRefreshToken = $('#user-custom-token-for-provider').val();
+  const nextCustomToken = $('#user-custom-token-for-provider').val();
   setCustomTokenProvider(auth, {
     async getCustomToken() {
-      return nextRefreshToken;
+      return nextCustomToken;
     }
   });
-  log(`On next refresh, custom token provider will use token:\n${nextRefreshToken}`)
+  log(`On next refresh, custom token provider will use token:\n${nextCustomToken}`)
 }
 
 /**


### PR DESCRIPTION
Added form for setting / clearing customTokenProvider. For simplicity, the provider set simply returns the custom token that is passed in.

Corresponding internal bug: b/192699639