### PR TITLE
Update public_types.ts

### DIFF
--- a/packages/auth/src/model/public_types.ts
+++ b/packages/auth/src/model/public_types.ts
@@ -103,7 +103,7 @@ export interface ParsedToken {
     'sign_in_second_factor'?: string;
   };
   /** Map of any additional custom claims. */
-  [key: string]: string | object | undefined;
+  [key: string]: string | object | number | boolean | undefined;
 }
 
 /**


### PR DESCRIPTION
According to [RFC7519](https://datatracker.ietf.org/doc/html/rfc7519#section-2):
> Claim Value
      The value portion of a claim representation.  A Claim Value can be
      any JSON value.

I thought it might make more sense to include some additional JSON primitives. This would make checking claims like `{ admin: true }` more type safe.

---

In my specific use case, I am using this function from Reactfire:

```typescript
// pass in an object describing the custom claims a user must have
const {status, data: signInCheckResult} = useSignInCheck({requiredClaims: {admin: true}});
```
From: https://github.com/FirebaseExtended/reactfire/blob/a2d2f1c36450515e81e07bd50f539266f5d825dc/docs/reference/modules/auth.md#usesignincheck

Which types the `requiredClaims` option to the types affected by this pull request:

```typescript
import type { Auth, User, IdTokenResult } from 'firebase/auth';
type Claims = IdTokenResult['claims'];
```

From: https://github.com/FirebaseExtended/reactfire/blob/2b564029a1903ef6b3f16c555693c264982ae678/src/auth.tsx#L8-L9

Without these changes, the `useSignInCheck` code block from above would produce the following type error:
```
Type 'boolean' is not assignable to type 'string | object'.ts(2322)
auth-public.d.ts(2040, 5): The expected type comes from this index signature.
```
---

This could be a seen as a Reactfire issue, but unless I'm mistaken, I don't see the harm in adding these primitives to the custom claims type.