### PR TITLE
use raw api-report rollup d.ts

### DIFF
--- a/.changeset/dirty-balloons-unite.md
+++ b/.changeset/dirty-balloons-unite.md
@@ -1,0 +1,5 @@
+---
+"@firebase/auth": patch
+---
+
+Fix typings where the constructor of `OAuthProvider` was missing.

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -41,7 +41,7 @@
     "test:node:integration": "ts-node -O '{\"module\": \"commonjs\", \"target\": \"es6\"}' scripts/run_node_tests.ts --integration",
     "test:node:integration:local": "ts-node -O '{\"module\": \"commonjs\", \"target\": \"es6\"}' scripts/run_node_tests.ts --integration --local",
     "test:webdriver": "rollup -c test/integration/webdriver/static/rollup.config.js && ts-node -O '{\"module\": \"commonjs\", \"target\": \"es6\"}' scripts/run_node_tests.ts --webdriver",
-    "api-report": "api-extractor run --local --verbose && ts-node-script ../../repo-scripts/prune-dts/prune-dts.ts --input dist/auth-public.d.ts --output dist/auth-public.d.ts",
+    "api-report": "api-extractor run --local --verbose",
     "doc": "api-documenter markdown --input temp --output docs",
     "build:doc": "yarn build && yarn doc",
     "typings:public": "node ../../scripts/exp/use_typings.js ./dist/auth-public.d.ts"


### PR DESCRIPTION
Fixes https://github.com/firebase/firebase-js-sdk/issues/5392

`repo-scripts/prune-dts/prune-dts.ts` removes inherited constructors, which makes the typings of classes incorrect.
This is a temporary fix, and will expose some internal types to developers. We should fix the `prune-dts.ts` to handle constructors correctly.

@schmidt-sebastian fyi