### PR TITLE
Fix the import of node-fetch polyfill

### DIFF
--- a/.changeset/twelve-items-wonder.md
+++ b/.changeset/twelve-items-wonder.md
@@ -1,0 +1,6 @@
+---
+'@firebase/firestore': patch
+'@firebase/storage': patch
+---
+
+Addressed incorrect use of the `node-fetch` polyfill

--- a/packages/firestore/src/platform/node_lite/connection.ts
+++ b/packages/firestore/src/platform/node_lite/connection.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import * as nodeFetch from 'node-fetch';
+import nodeFetch from 'node-fetch';
 
 import { DatabaseInfo } from '../../core/database_info';
 import { Connection } from '../../remote/connection';

--- a/packages/storage/src/platform/node/connection.ts
+++ b/packages/storage/src/platform/node/connection.ts
@@ -17,7 +17,7 @@
 
 import { ErrorCode, Connection } from '../../implementation/connection';
 import { internalError } from '../../implementation/error';
-import * as nodeFetch from 'node-fetch';
+import nodeFetch from 'node-fetch';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const fetch: typeof window.fetch = nodeFetch as any;


### PR DESCRIPTION
Storage and FirestoreLite were importing node-fetch as a namespace, rather than pulling the default fetch function and using that.

```ts
// import * as nodeFetch from 'node-fetch';
Object [Module] {
  default: [Getter],
  Headers: [Getter],
  Request: [Getter],
  Response: [Getter],
  FetchError: [Getter]
}
```

```ts
// import nodeFetch from 'node-fetch';
[Function: fetch] {
  isRedirect: [Function (anonymous)],
  Promise: [Function: ZoneAwarePromise] {
    toString: [Function (anonymous)],
    resolve: [Function (anonymous)],
    reject: [Function (anonymous)],
    race: [Function (anonymous)],
    all: [Function (anonymous)],
    allSettled: [Function (anonymous)],
    allWithCallback: [Function (anonymous)],
    __zone_symbol__uncaughtPromiseErrors: []
  }
}
```

This was leading to timeouts in Storage node and uncaught exceptions in Firestore Lite `@firebase/firestore: Firestore (9.0.0_lite): RPC_ERROR HTTP error has no status` diving in and setting a breakpoint I found this underlying error `TypeError: this.fetchImpl is not a function`