### PR TITLE
Don't send dummy App Check token to functions endpoint

### DIFF
--- a/packages/functions/src/context.ts
+++ b/packages/functions/src/context.ts
@@ -28,8 +28,6 @@ import {
   FirebaseAuthInternal,
   FirebaseAuthInternalName
 } from '@firebase/auth-interop-types';
-import { FunctionsError } from './error';
-import { logger } from './logger';
 
 /**
  * The metadata that should be supplied with function calls.

--- a/packages/functions/src/context.ts
+++ b/packages/functions/src/context.ts
@@ -28,6 +28,8 @@ import {
   FirebaseAuthInternal,
   FirebaseAuthInternalName
 } from '@firebase/auth-interop-types';
+import { FunctionsError } from './error';
+import { logger } from './logger';
 
 /**
  * The metadata that should be supplied with function calls.
@@ -122,10 +124,12 @@ export class ContextProvider {
   async getAppCheckToken(): Promise<string | null> {
     if (this.appCheck) {
       const result = await this.appCheck.getToken();
-      // If getToken() fails, it will still return a dummy token that also has
-      // an error field containing the error message. We will send any token
-      // provided here and show an error if/when it is rejected by the functions
-      // endpoint.
+      if (result.error) {
+        // Do not send the App Check header to the functions endpoint if
+        // there was an error from the App Check exchange endpoint. The App
+        // Check SDK will already have logged the error to console.
+        return null;
+      }
       return result.token;
     }
     return null;


### PR DESCRIPTION
See https://github.com/FirebaseExtended/flutterfire/issues/6794

This is a change being made across Android, iOS, and Web.