### PR TITLE
docs(WhereFilterOp): avoid html encode

### DIFF
--- a/packages/firestore/src/lite-api/query.ts
+++ b/packages/firestore/src/lite-api/query.ts
@@ -155,7 +155,7 @@ class QueryFilterConstraint extends QueryConstraint {
 
 /**
  * Filter conditions in a {@link where} clause are specified using the
- * strings '&lt;', '&lt;=', '==', '!=', '&gt;=', '&gt;', 'array-contains', 'in',
+ * strings `<`, `<=`, `==`, `!=`, `>=`, `>`, `array-contains`, `in`,
  * 'array-contains-any', and 'not-in'.
  */
 export type WhereFilterOp =
@@ -176,8 +176,8 @@ export type WhereFilterOp =
  * provided.
  *
  * @param fieldPath - The path to compare
- * @param opStr - The operation string (e.g "&lt;", "&lt;=", "==", "&lt;",
- *   "&lt;=", "!=").
+ * @param opStr - The operation string (e.g `"<"`, `"<="`, `"=="`, `">"`,
+ *   `">="`, `"!="`).
  * @param value - The value for comparison
  * @returns The created {@link Query}.
  */


### PR DESCRIPTION
in https://firebase.google.com/docs/reference/js/firestore_.md#wherefilterop the text seems to be used verbatim, and also there's a typo in them, as < is listed twice instead of > once
