### PR TITLE
[Auth] Add custom error factory for custom messages; add special handling for instanceof checks

### DIFF
--- a/packages/auth/src/api/index.test.ts
+++ b/packages/auth/src/api/index.test.ts
@@ -220,13 +220,8 @@ describe('api/_performApiRequest', () => {
         Endpoint.SIGN_UP,
         request
       );
-      let error: FirebaseError;
-      try {
-        await promise;
-      } catch (e) {
-        error = e;
-      }
-      expect(error!.customData!.message).to.eql('Text text text');
+      await expect(promise)
+        .to.be.rejectedWith(FirebaseError, 'Text text text');
     });
 
     it('should handle unknown server errors', async () => {

--- a/packages/auth/src/api/index.ts
+++ b/packages/auth/src/api/index.ts
@@ -18,7 +18,7 @@
 import { FirebaseError, querystring } from '@firebase/util';
 
 import { AuthErrorCode, NamedErrorParams } from '../core/errors';
-import { _createError, _fail } from '../core/util/assert';
+import { _createError, _errorWithCustomMessage, _fail } from '../core/util/assert';
 import { Delay } from '../core/util/delay';
 import { _emulatorUrl } from '../core/util/emulator';
 import { FetchProvider } from '../core/util/fetch_provider';
@@ -168,7 +168,7 @@ export async function _performFetchWithErrorHandling<V>(
           .toLowerCase()
           .replace(/[_\s]+/g, '-') as unknown) as AuthErrorCode);
       if (serverErrorMessage) {
-        _fail(auth, authError, {message: serverErrorMessage});
+        throw _errorWithCustomMessage(auth, authError, serverErrorMessage);
       } else {
         _fail(auth, authError);
       }

--- a/packages/auth/src/core/errors.ts
+++ b/packages/auth/src/core/errors.ts
@@ -359,7 +359,7 @@ export interface ErrorMapRetriever extends AuthErrorMap {
   (): ErrorMap<AuthErrorCode>;
 }
 
-export function _prodErrorMap(): ErrorMap<AuthErrorCode> {
+function _prodErrorMap(): ErrorMap<AuthErrorCode> {
   // We will include this one message in the prod error map since by the very
   // nature of this error, developers will never be able to see the message
   // using the debugErrorMap (which is installed during auth initialization).

--- a/packages/auth/src/core/errors.ts
+++ b/packages/auth/src/core/errors.ts
@@ -359,7 +359,7 @@ export interface ErrorMapRetriever extends AuthErrorMap {
   (): ErrorMap<AuthErrorCode>;
 }
 
-function _prodErrorMap(): ErrorMap<AuthErrorCode> {
+export function _prodErrorMap(): ErrorMap<AuthErrorCode> {
   // We will include this one message in the prod error map since by the very
   // nature of this error, developers will never be able to see the message
   // using the debugErrorMap (which is installed during auth initialization).

--- a/packages/auth/src/core/util/assert.ts
+++ b/packages/auth/src/core/util/assert.ts
@@ -16,12 +16,13 @@
  */
 
 import { Auth } from '../../model/public_types';
-import { FirebaseError } from '@firebase/util';
+import { ErrorFactory, FirebaseError } from '@firebase/util';
 import { AuthInternal } from '../../model/auth';
 import {
   _DEFAULT_AUTH_ERROR_FACTORY,
   AuthErrorCode,
-  AuthErrorParams
+  AuthErrorParams,
+  _prodErrorMap
 } from '../errors';
 import { _logError } from './log';
 
@@ -79,6 +80,31 @@ export function _createError<K extends AuthErrorCode>(
   ...rest: unknown[]
 ): FirebaseError {
   return createErrorInternal(authOrCode, ...rest);
+}
+
+export function _errorWithCustomMessage(auth: Auth, code: AuthErrorCode, message: string): FirebaseError {
+  const errorMap = {..._prodErrorMap(), [code]: message};
+  const factory = new ErrorFactory<AuthErrorCode, AuthErrorParams>(
+    'auth',
+    'Firebase',
+    errorMap
+  );
+  return factory.create(code, {
+    appName: auth.name,
+  });
+}
+
+export function _assertInstanceOf(auth: Auth, object: object, instance: unknown): void {
+  const constructorInstance =  (instance as { new (...args: unknown[]): unknown });
+  if (!(object instanceof constructorInstance)) {
+    if (constructorInstance.name !== object.constructor.name) {
+      _fail(auth, AuthErrorCode.ARGUMENT_ERROR);
+    }
+
+    throw _errorWithCustomMessage(auth, AuthErrorCode.ARGUMENT_ERROR,
+      `Type of ${object.constructor.name} does not match expected instance.` +
+      `Did you pass a reference from a different Auth SDK?`);
+  }
 }
 
 function createErrorInternal<K extends AuthErrorCode>(
@@ -244,3 +270,4 @@ export function debugAssert(
     debugFail(message);
   }
 }
+

--- a/packages/auth/src/core/util/assert.ts
+++ b/packages/auth/src/core/util/assert.ts
@@ -22,7 +22,8 @@ import {
   _DEFAULT_AUTH_ERROR_FACTORY,
   AuthErrorCode,
   AuthErrorParams,
-  _prodErrorMap
+  prodErrorMap,
+  ErrorMapRetriever
 } from '../errors';
 import { _logError } from './log';
 
@@ -83,7 +84,7 @@ export function _createError<K extends AuthErrorCode>(
 }
 
 export function _errorWithCustomMessage(auth: Auth, code: AuthErrorCode, message: string): FirebaseError {
-  const errorMap = {..._prodErrorMap(), [code]: message};
+  const errorMap = {...(prodErrorMap as ErrorMapRetriever)(), [code]: message};
   const factory = new ErrorFactory<AuthErrorCode, AuthErrorParams>(
     'auth',
     'Firebase',

--- a/packages/auth/src/platform_browser/strategies/popup.ts
+++ b/packages/auth/src/platform_browser/strategies/popup.ts
@@ -25,7 +25,7 @@ import {
 
 import { _castAuth } from '../../core/auth/auth_impl';
 import { AuthErrorCode } from '../../core/errors';
-import { _assert, debugAssert, _createError } from '../../core/util/assert';
+import { _assert, debugAssert, _createError, _assertInstanceOf } from '../../core/util/assert';
 import { Delay } from '../../core/util/delay';
 import { _generateEventId } from '../../core/util/event_id';
 import { AuthInternal } from '../../model/auth';
@@ -83,12 +83,7 @@ export async function signInWithPopup(
   resolver?: PopupRedirectResolver
 ): Promise<UserCredential> {
   const authInternal = _castAuth(auth);
-  _assert(
-    provider instanceof FederatedAuthProvider,
-    auth,
-    AuthErrorCode.ARGUMENT_ERROR
-  );
-
+  _assertInstanceOf(auth, provider, FederatedAuthProvider);
   const resolverInternal = _withDefaultResolver(authInternal, resolver);
   const action = new PopupOperation(
     authInternal,
@@ -130,12 +125,7 @@ export async function reauthenticateWithPopup(
   resolver?: PopupRedirectResolver
 ): Promise<UserCredential> {
   const userInternal = getModularInstance(user) as UserInternal;
-  _assert(
-    provider instanceof FederatedAuthProvider,
-    userInternal.auth,
-    AuthErrorCode.ARGUMENT_ERROR
-  );
-
+  _assertInstanceOf(userInternal.auth, provider, FederatedAuthProvider);
   const resolverInternal = _withDefaultResolver(userInternal.auth, resolver);
   const action = new PopupOperation(
     userInternal.auth,
@@ -177,12 +167,7 @@ export async function linkWithPopup(
   resolver?: PopupRedirectResolver
 ): Promise<UserCredential> {
   const userInternal = getModularInstance(user) as UserInternal;
-  _assert(
-    provider instanceof FederatedAuthProvider,
-    userInternal.auth,
-    AuthErrorCode.ARGUMENT_ERROR
-  );
-
+  _assertInstanceOf(userInternal.auth, provider, FederatedAuthProvider);
   const resolverInternal = _withDefaultResolver(userInternal.auth, resolver);
 
   const action = new PopupOperation(

--- a/packages/auth/src/platform_browser/strategies/redirect.ts
+++ b/packages/auth/src/platform_browser/strategies/redirect.ts
@@ -24,9 +24,8 @@ import {
 } from '../../model/public_types';
 
 import { _castAuth } from '../../core/auth/auth_impl';
-import { AuthErrorCode } from '../../core/errors';
 import { _assertLinkedStatus } from '../../core/user/link_unlink';
-import { _assert } from '../../core/util/assert';
+import { _assertInstanceOf } from '../../core/util/assert';
 import { _generateEventId } from '../../core/util/event_id';
 import { AuthEventType } from '../../model/popup_redirect';
 import { UserInternal } from '../../model/user';
@@ -91,12 +90,7 @@ export async function _signInWithRedirect(
   resolver?: PopupRedirectResolver
 ): Promise<void | never> {
   const authInternal = _castAuth(auth);
-  _assert(
-    provider instanceof FederatedAuthProvider,
-    auth,
-    AuthErrorCode.ARGUMENT_ERROR
-  );
-
+  _assertInstanceOf(auth, provider, FederatedAuthProvider);
   const resolverInternal = _withDefaultResolver(authInternal, resolver);
   await _setPendingRedirectStatus(resolverInternal, authInternal);
 
@@ -152,12 +146,7 @@ export async function _reauthenticateWithRedirect(
   resolver?: PopupRedirectResolver
 ): Promise<void | never> {
   const userInternal = getModularInstance(user) as UserInternal;
-  _assert(
-    provider instanceof FederatedAuthProvider,
-    userInternal.auth,
-    AuthErrorCode.ARGUMENT_ERROR
-  );
-
+  _assertInstanceOf(userInternal.auth, provider, FederatedAuthProvider);
   // Allow the resolver to error before persisting the redirect user
   const resolverInternal = _withDefaultResolver(userInternal.auth, resolver);
   await _setPendingRedirectStatus(resolverInternal, userInternal.auth);
@@ -209,12 +198,7 @@ export async function _linkWithRedirect(
   resolver?: PopupRedirectResolver
 ): Promise<void | never> {
   const userInternal = getModularInstance(user) as UserInternal;
-  _assert(
-    provider instanceof FederatedAuthProvider,
-    userInternal.auth,
-    AuthErrorCode.ARGUMENT_ERROR
-  );
-
+  _assertInstanceOf(userInternal.auth, provider, FederatedAuthProvider);
   // Allow the resolver to error before persisting the redirect user
   const resolverInternal = _withDefaultResolver(userInternal.auth, resolver);
   await _assertLinkedStatus(false, userInternal, provider.providerId);


### PR DESCRIPTION
Fixes https://github.com/firebase/firebase-js-sdk/issues/5420

We now provide better messaging in cases where auth is imported from multiple entry points, leading to mismatched types. Also small update for https://github.com/firebase/firebase-js-sdk/pull/5423; we now incorporate the message onto the error itself (as it should have been originally, thanks @lisajian for pointing that out)