### PR TITLE
Add yarn build:debug

### DIFF
--- a/packages/firestore/package.json
+++ b/packages/firestore/package.json
@@ -15,6 +15,7 @@
     "build:deps": "lerna run --scope @firebase/firestore --include-dependencies build",
     "build:main": "rollup -c rollup.config.js",
     "build:lite": "rollup -c rollup.config.lite.js",
+    "build:debug": "rollup -c rollup.config.debug.js",
     "predev": "yarn prebuild",
     "dev": "rollup -c -w",
     "lint": "eslint -c .eslintrc.js '**/*.ts' --ignore-path '../../.gitignore'",

--- a/packages/firestore/package.json
+++ b/packages/firestore/package.json
@@ -8,7 +8,7 @@
   "author": "Firebase <firebase-support@google.com> (https://firebase.google.com/)",
   "scripts": {
     "bundle": "rollup -c",
-    "prebuild": "tsc --emitDeclarationOnly --declaration -p tsconfig.json; yarn api-report",
+    "prebuild": "yarn test:prepare && tsc --emitDeclarationOnly --declaration -p tsconfig.json; yarn api-report",
     "build": "run-p build:lite build:main",
     "build:release": "yarn build && yarn typings:public",
     "build:scripts": "tsc -moduleResolution node --module commonjs scripts/*.ts && ls scripts/*.js | xargs -I % sh -c 'terser %  -o %'",

--- a/packages/firestore/rollup.config.debug.js
+++ b/packages/firestore/rollup.config.debug.js
@@ -47,13 +47,13 @@ const browserPlugins = function () {
 };
 
 const aliasConfig = {
-    entries: [
-      {
-        find: /^(.*)\/platform\/([^.\/]*)(\.ts)?$/,
-        replacement: `$1\/platform/browser/$2.ts`
-      }
-    ]
-  };
+  entries: [
+    {
+      find: /^(.*)\/platform\/([^.\/]*)(\.ts)?$/,
+      replacement: `$1\/platform/browser/$2.ts`
+    }
+  ]
+};
 
 const browserDeps = [
   ...Object.keys(Object.assign({}, pkg.peerDependencies, pkg.dependencies)),
@@ -64,16 +64,16 @@ export default [
   {
     input: './src/index.ts',
     output: {
-      file: pkg.esm5,
+      file: pkg.browser,
       format: 'es',
       sourcemap: true
     },
     plugins: [alias(aliasConfig), ...browserPlugins()],
-    external: (id) => {
-        return [...browserDeps, '@firebase/firestore'].some(
-          dep => id === dep || id.startsWith(`${dep}/`)
-        );
-      },
+    external: id => {
+      return [...browserDeps, '@firebase/firestore'].some(
+        dep => id === dep || id.startsWith(`${dep}/`)
+      );
+    },
     treeshake: {
       moduleSideEffects: false
     }

--- a/packages/firestore/rollup.config.debug.js
+++ b/packages/firestore/rollup.config.debug.js
@@ -1,0 +1,81 @@
+/**
+ * @license
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import tmp from 'tmp';
+import json from '@rollup/plugin-json';
+import alias from '@rollup/plugin-alias';
+import typescriptPlugin from 'rollup-plugin-typescript2';
+import typescript from 'typescript';
+
+import pkg from './package.json';
+
+// This rollup configuration creates a single non-minified build for browser
+// testing. You can test code changes by running `yarn build:debug`. This
+// creates the file "dist/index.esm2017.js" that you can use in your sample
+// app as a replacement for
+// "node_modules/@firebase/firestore/dist/index.esm2017.js".
+
+const browserPlugins = function () {
+  return [
+    typescriptPlugin({
+      typescript,
+      tsconfigOverride: {
+        compilerOptions: {
+          target: 'es2017'
+        }
+      },
+      cacheDir: tmp.dirSync(),
+      clean: true,
+      abortOnError: false
+    }),
+    json({ preferConst: true })
+  ];
+};
+
+const aliasConfig = {
+    entries: [
+      {
+        find: /^(.*)\/platform\/([^.\/]*)(\.ts)?$/,
+        replacement: `$1\/platform/browser/$2.ts`
+      }
+    ]
+  };
+
+const browserDeps = [
+  ...Object.keys(Object.assign({}, pkg.peerDependencies, pkg.dependencies)),
+  '@firebase/app'
+];
+
+export default [
+  {
+    input: './src/index.ts',
+    output: {
+      file: pkg.esm5,
+      format: 'es',
+      sourcemap: true
+    },
+    plugins: [alias(aliasConfig), ...browserPlugins()],
+    external: (id) => {
+        return [...browserDeps, '@firebase/firestore'].some(
+          dep => id === dep || id.startsWith(`${dep}/`)
+        );
+      },
+    treeshake: {
+      moduleSideEffects: false
+    }
+  }
+];


### PR DESCRIPTION
Adding a new build configuration to both simplify and speed up browser-based testing.
