### PR TITLE
updated error message for invalid first argument in doc()

### DIFF
--- a/packages/firestore/src/lite-api/reference.ts
+++ b/packages/firestore/src/lite-api/reference.ts
@@ -517,7 +517,7 @@ export function doc<T>(
     ) {
       throw new FirestoreError(
         Code.INVALID_ARGUMENT,
-        'Expected first argument to collection() to be a CollectionReference, ' +
+        'Expected first argument to doc() to be a CollectionReference, ' +
           'a DocumentReference or FirebaseFirestore'
       );
     }


### PR DESCRIPTION
If an invalid first argument is passed to `doc()`, the error still says: 
```
FirebaseError: Expected first argument to collection() to be a CollectionReference, a DocumentReference or FirebaseFirestore
```
I changed it to:
```
Expected first argument to doc() ....
```