### PR TITLE
Fix path typo in npm script

### DIFF
--- a/packages/app-compat/package.json
+++ b/packages/app-compat/package.json
@@ -24,7 +24,7 @@
     "test:browser:debug": "karma start --browsers Chrome --auto-watch",
     "test:node": "TS_NODE_FILES=true TS_NODE_CACHE=NO TS_NODE_COMPILER_OPTIONS='{\"module\":\"commonjs\"}' nyc --reporter lcovonly -- mocha test/**/*.test.* src/**/*.test.ts --config ../../config/mocharc.node.js",
     "api-report": "api-extractor run --local --verbose",
-    "typings:public": "node ../../scripts/exp/use_typings.js ./dist/app-compat-public.d.ts"
+    "typings:public": "node ../../scripts/build/use_typings.js ./dist/app-compat-public.d.ts"
   },
   "license": "Apache-2.0",
   "dependencies": {


### PR DESCRIPTION
This must have been overlooked somehow when cleaning out the scripts/exp directory and all references to it.