### PR TITLE
Remove Auth internal types from the public typings

### DIFF
--- a/.changeset/slimy-penguins-itch.md
+++ b/.changeset/slimy-penguins-itch.md
@@ -1,0 +1,5 @@
+---
+"@firebase/auth": patch
+---
+
+Remove `const enum`s from the public typing file.

--- a/packages/auth/src/api/authentication/idp.ts
+++ b/packages/auth/src/api/authentication/idp.ts
@@ -36,6 +36,9 @@ export interface SignInWithIdpRequest {
   pendingToken?: string;
 }
 
+/**
+ * @internal
+ */
 export interface SignInWithIdpResponse extends IdTokenResponse {
   oauthAccessToken?: string;
   oauthTokenSecret?: string;

--- a/packages/auth/src/api/authentication/mfa.ts
+++ b/packages/auth/src/api/authentication/mfa.ts
@@ -30,6 +30,9 @@ export interface FinalizeMfaResponse {
   refreshToken: string;
 }
 
+/**
+ * @internal
+ */
 export interface IdTokenMfaResponse extends IdTokenResponse {
   mfaPendingCredential?: string;
   mfaInfo?: MfaEnrollment[];
@@ -84,6 +87,9 @@ export function finalizeSignInPhoneMfa(
   });
 }
 
+/**
+ * @internal
+ */
 export type PhoneOrOauthTokenResponse =
   | SignInWithPhoneNumberResponse
   | SignInWithIdpResponse

--- a/packages/auth/src/api/authentication/sms.ts
+++ b/packages/auth/src/api/authentication/sms.ts
@@ -53,6 +53,9 @@ export async function sendPhoneVerificationCode(
   );
 }
 
+/**
+ * @internal
+ */
 export interface SignInWithPhoneNumberRequest {
   temporaryProof?: string;
   phoneNumber?: string;
@@ -66,6 +69,9 @@ export interface LinkWithPhoneNumberRequest
   idToken: string;
 }
 
+/**
+ * @internal
+ */
 export interface SignInWithPhoneNumberResponse extends IdTokenResponse {
   temporaryProof?: string;
   phoneNumber?: string;

--- a/packages/auth/src/core/errors.ts
+++ b/packages/auth/src/core/errors.ts
@@ -24,6 +24,8 @@ import { AuthCredential } from './credentials';
 
 /**
  * Enumeration of Firebase Auth error codes.
+ * 
+ * @internal
  */
 export const enum AuthErrorCode {
   ADMIN_ONLY_OPERATION = 'admin-restricted-operation',
@@ -399,6 +401,9 @@ export interface NamedErrorParams {
   serverResponse?: object;
 }
 
+/**
+ * @internal
+ */
 type GenericAuthErrorParams = {
   [key in Exclude<
     AuthErrorCode,
@@ -415,6 +420,9 @@ type GenericAuthErrorParams = {
   };
 };
 
+/**
+ * @internal
+ */
 export interface AuthErrorParams extends GenericAuthErrorParams {
   [AuthErrorCode.ARGUMENT_ERROR]: { appName?: AppName };
   [AuthErrorCode.DEPENDENT_SDK_INIT_BEFORE_AUTH]: { appName?: AppName };

--- a/packages/auth/src/core/util/version.ts
+++ b/packages/auth/src/core/util/version.ts
@@ -23,6 +23,9 @@ export const enum ClientImplementation {
   CORE = 'JsCore'
 }
 
+/**
+ * @internal
+ */
 export const enum ClientPlatform {
   BROWSER = 'Browser',
   NODE = 'Node',

--- a/packages/auth/src/model/auth.ts
+++ b/packages/auth/src/model/auth.ts
@@ -34,6 +34,9 @@ export type AppName = string;
 export type ApiKey = string;
 export type AuthDomain = string;
 
+/**
+ * @internal
+ */
 export interface ConfigInternal extends Config {
   /**
    * @readonly

--- a/packages/auth/src/model/enums.ts
+++ b/packages/auth/src/model/enums.ts
@@ -17,7 +17,7 @@
 
 /**
  * Enumeration of supported providers.
- *
+ * @internal
  */
 export const enum ProviderId {
   /** @internal */
@@ -42,7 +42,7 @@ export const enum ProviderId {
 
 /**
  * Enumeration of supported sign-in methods.
- *
+ * @internal
  */
 export const enum SignInMethod {
   /** @internal */
@@ -65,7 +65,7 @@ export const enum SignInMethod {
 
 /**
  * Enumeration of supported operation types.
- *
+ * @internal
  */
 export const enum OperationType {
   /** Operation involving linking an additional provider to an already signed-in user. */

--- a/packages/auth/src/model/id_token.ts
+++ b/packages/auth/src/model/id_token.ts
@@ -47,6 +47,7 @@ export interface ParsedIdToken {
 /**
  * IdToken as returned by the API
  *
+ * @internal
  */
 export interface IdTokenResponse {
   localId: string;
@@ -67,6 +68,7 @@ export interface IdTokenResponse {
 /**
  * The possible types of the `IdTokenResponse`
  *
+ * @internal
  */
 export const enum IdTokenResponseKind {
   CreateAuthUri = 'identitytoolkit#CreateAuthUriResponse',

--- a/packages/auth/src/model/popup_redirect.ts
+++ b/packages/auth/src/model/popup_redirect.ts
@@ -41,6 +41,9 @@ export interface GapiAuthEvent extends gapi.iframes.Message {
   authEvent: AuthEvent;
 }
 
+/**
+ * @internal
+ */
 export const enum AuthEventType {
   LINK_VIA_POPUP = 'linkViaPopup',
   LINK_VIA_REDIRECT = 'linkViaRedirect',
@@ -57,6 +60,9 @@ export interface AuthEventError extends Error {
   message: string;
 }
 
+/**
+ * @internal
+ */
 export interface AuthEvent {
   type: AuthEventType;
   eventId: string | null;
@@ -67,6 +73,9 @@ export interface AuthEvent {
   error?: AuthEventError;
 }
 
+/**
+ * @internal
+ */
 export interface AuthEventConsumer {
   readonly filter: AuthEventType[];
   eventId: string | null;
@@ -74,6 +83,9 @@ export interface AuthEventConsumer {
   onError(error: FirebaseError): unknown;
 }
 
+/**
+ * @internal
+ */
 export interface EventManager {
   registerConsumer(authEventConsumer: AuthEventConsumer): void;
   unregisterConsumer(authEventConsumer: AuthEventConsumer): void;


### PR DESCRIPTION
Fixes https://github.com/firebase/firebase-js-sdk/issues/5451

Mark some internal types as `@internal` to prevent `const enum`s from accidentally showing up in the public typing file.