### PR TITLE
Temporary hack to fix terser output

### DIFF
--- a/.changeset/spicy-moose-approve.md
+++ b/.changeset/spicy-moose-approve.md
@@ -1,0 +1,5 @@
+---
+'@firebase/firestore': patch
+---
+
+Temporary fix for a bug causing `initializeFirestore()` to not work with certain bundling pipelines.

--- a/packages/firestore/rollup.shared.js
+++ b/packages/firestore/rollup.shared.js
@@ -145,6 +145,12 @@ const manglePrivatePropertiesOptions = {
     beautify: true
   },
   mangle: {
+    // Temporary hack fix for an issue where mangled code causes some downstream
+    // bundlers (Babel?) to confuse the same variable name in different scopes.
+    // This can be removed if the problem in the downstream library is fixed
+    // or if terser's mangler provides an option to avoid mangling everything
+    // that isn't a property.
+    reserved: ['_getProvider'],
     properties: {
       regex: /^__PRIVATE_/,
       // All JS Keywords are reserved. Although this should be taken cared of by
@@ -284,7 +290,12 @@ exports.es2017ToEs5Plugins = function (mangled = false) {
           comments: 'all',
           beautify: true
         },
-        mangle: true
+        // See comment above `manglePrivatePropertiesOptions`. This build did
+        // not have the identical variable name issue but we should be
+        // consistent.
+        mangle: {
+          reserved: ['_getProvider']
+        }
       }),
       sourcemaps()
     ];

--- a/packages/firestore/rollup.shared.js
+++ b/packages/firestore/rollup.shared.js
@@ -150,6 +150,7 @@ const manglePrivatePropertiesOptions = {
     // This can be removed if the problem in the downstream library is fixed
     // or if terser's mangler provides an option to avoid mangling everything
     // that isn't a property.
+    // See issue: https://github.com/firebase/firebase-js-sdk/issues/5384
     reserved: ['_getProvider'],
     properties: {
       regex: /^__PRIVATE_/,


### PR DESCRIPTION
Mangled terser code is causing some problems seen in Create React App apps. This is a temporary fix that will avoid mangling the specific variable in question. Long term fix is to see if terser will provide an option to mangle properties without mangling anything else (currently not available), and/or find out what downstream build tool is causing this bug and get them to fix it.

Details:
The `initializeFirestore()` function, when mangled by terser, has two variables with the same name in different scopes (one is an import, one is a `const` in an `if` block). This seems to confuse one of the tools in the Create React App production default build pipeline (Babel?). The code is converted to ES5, which makes the `const` a `var`, which puts both variables sharing a name into the same scope. The build tool gets confused and does not convert the import to the correct symbol, thinking it is the same as the declared `var`. We should try to pinpoint what step of the build this happens in and report a bug to the appropriate library.

Fixes https://github.com/firebase/firebase-js-sdk/issues/5384