### PR TITLE
Fix workflow that automatically publishes @firebase/app

### DIFF
--- a/.changeset/bump-sdk-version.md
+++ b/.changeset/bump-sdk-version.md
@@ -1,6 +1,0 @@
-
----
-'@firebase/app': patch
----
-
-Update SDK_VERSION.

--- a/.changeset/bump-sdk-version.md
+++ b/.changeset/bump-sdk-version.md
@@ -1,0 +1,6 @@
+
+---
+'@firebase/app': patch
+---
+
+Update SDK_VERSION.

--- a/scripts/ci/add_changeset.ts
+++ b/scripts/ci/add_changeset.ts
@@ -39,7 +39,9 @@ const FILE_PATH = `${projectRoot}/.changeset/bump-sdk-version.md`;
 async function addChangeSet() {
   // check if a few firebase version is being released
   try {
-    const { stdout } = await exec('yarn changeset status');
+    // The way actions/checkout works, there is no local `master` branch, but it
+    // has access to the remote origin/master.
+    const { stdout } = await exec('yarn changeset status --since origin/master');
     // only add a changeset for @firebase/app if
     // 1. we are publishing a new firebase version. and
     // 2. @firebase/app is not already being published

--- a/scripts/ci/add_changeset.ts
+++ b/scripts/ci/add_changeset.ts
@@ -41,7 +41,9 @@ async function addChangeSet() {
   try {
     // The way actions/checkout works, there is no local `master` branch, but it
     // has access to the remote origin/master.
-    const { stdout } = await exec('yarn changeset status --since origin/master');
+    const { stdout } = await exec(
+      'yarn changeset status --since origin/master'
+    );
     // only add a changeset for @firebase/app if
     // 1. we are publishing a new firebase version. and
     // 2. @firebase/app is not already being published


### PR DESCRIPTION
`@firebase/app` should be published on every release. The script to automatically do this was failing because `yarn changesets status` couldn't find the `master` branch locally, because actions/checkout doesn't check it out locally. After reproducing locally, it does seem to be able to access `origin/master`, so changed it to that.