### PR TITLE
[Auth] Add phone factor ID to the PhoneMultiFactorGenerator object

### DIFF
--- a/.changeset/neat-pants-wonder.md
+++ b/.changeset/neat-pants-wonder.md
@@ -1,0 +1,5 @@
+---
+"@firebase/auth": patch
+---
+
+Add missing phone FACTOR_ID static property to the PhoneMultiFactorGenerator class

--- a/common/api-review/auth.api.md
+++ b/common/api-review/auth.api.md
@@ -596,6 +596,7 @@ export interface PhoneMultiFactorEnrollInfoOptions {
 // @public
 export class PhoneMultiFactorGenerator {
     static assertion(credential: PhoneAuthCredential): PhoneMultiFactorAssertion;
+    static FACTOR_ID: string;
 }
 
 // @public

--- a/packages/auth/src/platform_browser/mfa/assertions/phone.ts
+++ b/packages/auth/src/platform_browser/mfa/assertions/phone.ts
@@ -90,4 +90,9 @@ export class PhoneMultiFactorGenerator {
   static assertion(credential: PhoneAuthCredential): PhoneMultiFactorAssertion {
     return PhoneMultiFactorAssertionImpl._fromCredential(credential);
   }
+
+  /**
+   * The identifier of the phone second factor: `phone`.
+   */
+  static FACTOR_ID = 'phone';
 }


### PR DESCRIPTION
Fixes https://github.com/firebase/firebase-js-sdk/issues/5480
We were missing the static `FACTOR_ID` field that is [present in v8](https://firebase.google.com/docs/reference/js/v8/firebase.auth.PhoneMultiFactorGenerator#static-factor_id)