### PR TITLE
Fix app release again

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,9 @@ jobs:
         run: yarn
 
       - name: Add a changeset for @firebase/app
-        run: yarn ts-node-script scripts/ci/add_changeset.ts
+        run: |
+          git pull -f origin master:master
+          yarn ts-node-script scripts/ci/add_changeset.ts
 
       - name: Create Release Pull Request
         uses: changesets/action@master

--- a/scripts/ci/add_changeset.ts
+++ b/scripts/ci/add_changeset.ts
@@ -41,9 +41,7 @@ async function addChangeSet() {
   try {
     // The way actions/checkout works, there is no local `master` branch, but it
     // has access to the remote origin/master.
-    const { stdout } = await exec(
-      'yarn changeset status'
-    );
+    const { stdout } = await exec('yarn changeset status');
     // only add a changeset for @firebase/app if
     // 1. we are publishing a new firebase version. and
     // 2. @firebase/app is not already being published

--- a/scripts/ci/add_changeset.ts
+++ b/scripts/ci/add_changeset.ts
@@ -42,7 +42,7 @@ async function addChangeSet() {
     // The way actions/checkout works, there is no local `master` branch, but it
     // has access to the remote origin/master.
     const { stdout } = await exec(
-      'yarn changeset status --since origin/master'
+      'yarn changeset status'
     );
     // only add a changeset for @firebase/app if
     // 1. we are publishing a new firebase version. and


### PR DESCRIPTION
I did it wrong. --since does not do what I expected. We need to explicitly pull master and use the regular `yarn changeset status` command.

https://github.com/atlassian/changesets/issues/517