### PR TITLE
Fix RUTv2 not setting RTDB namespace by default.

### DIFF
--- a/.changeset/fast-brooms-tie.md
+++ b/.changeset/fast-brooms-tie.md
@@ -1,0 +1,5 @@
+---
+"@firebase/rules-unit-testing": patch
+---
+
+Fix typing issues where Database/Firestore/Storage compat instances returned by RulesTestContext are not compatible with v9 modular APIs.

--- a/.changeset/little-foxes-own.md
+++ b/.changeset/little-foxes-own.md
@@ -1,0 +1,5 @@
+---
+"@firebase/rules-unit-testing": patch
+---
+
+Set RTDB namespace to be same as projectId by default instead of `${projectId}-default-rtdb`. This fixes rules not being applied and other issues related to namespace mismatch.

--- a/packages/rules-unit-testing/src/impl/test_environment.ts
+++ b/packages/rules-unit-testing/src/impl/test_environment.ts
@@ -192,6 +192,14 @@ class RulesTestContextImpl implements RulesTestContext {
   }
   database(databaseURL?: string): firebase.database.Database {
     assertEmulatorRunning(this.emulators, 'database');
+    if (!databaseURL) {
+      const url = makeUrl(this.emulators.database, '');
+      // Make sure to set the namespace equal to projectId -- otherwise the RTDB SDK will by default
+      // use `${projectId}-default-rtdb`, which is treated as a different DB by the RTDB emulator
+      // (and thus WON'T apply any rules set for the `projectId` DB during initialization).
+      url.searchParams.append('ns', this.projectId);
+      databaseURL = url.toString();
+    }
     const database = this.getApp().database(databaseURL);
     database.useEmulator(
       this.emulators.database.host,

--- a/packages/rules-unit-testing/src/public_types/index.ts
+++ b/packages/rules-unit-testing/src/public_types/index.ts
@@ -18,6 +18,12 @@
 import { FirebaseSignInProvider } from '@firebase/util';
 import firebase from 'firebase/compat/app';
 
+// These import statements allow v9 compat instances (created by RulesTestContext) to be used in v9
+// modular APIs, e.g. `doc(context.firestore(), 'a/b')` in developer code. (a.k.a. "interop mode".)
+import 'firebase/compat/database';
+import 'firebase/compat/firestore';
+import 'firebase/compat/storage';
+
 /**
  * More options for the mock user token to be used for testing, including developer-specfied custom
  * claims or optional overrides for Firebase Auth token payloads.


### PR DESCRIPTION
See changeset and comment for context.