### PR TITLE
Clean up compat docgen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@ dist
 .awcache
 .cache
 /config/project.json
-scripts/docgen/html
+scripts/docgen-compat/html
 
 # OS Specific Files
 .DS_Store

--- a/scripts/docgen-compat/content-sources/js/toc.yaml
+++ b/scripts/docgen-compat/content-sources/js/toc.yaml
@@ -72,10 +72,14 @@ toc:
     path: /docs/reference/js/firebase.auth.AuthProvider
   - title: "AuthSettings"
     path: /docs/reference/js/firebase.auth.AuthSettings
+  - title: "Config"
+    path: /docs/reference/js/firebase.auth.Config
   - title: "ConfirmationResult"
     path: /docs/reference/js/firebase.auth.ConfirmationResult
   - title: "EmailAuthProvider"
     path: /docs/reference/js/firebase.auth.EmailAuthProvider
+  - title: "EmulatorConfig"
+    path: /docs/reference/js/firebase.auth.EmulatorConfig
   - title: "Error"
     path: /docs/reference/js/firebase.auth.Error
   - title: "FacebookAuthProvider"

--- a/scripts/docgen-compat/content-sources/node/toc.yaml
+++ b/scripts/docgen-compat/content-sources/node/toc.yaml
@@ -32,10 +32,14 @@ toc:
     path: /docs/reference/node/firebase.auth.AuthProvider
   - title: "AuthSettings"
     path: /docs/reference/node/firebase.auth.AuthSettings
+  - title: "Config"
+    path: /docs/reference/node/firebase.auth.Config
   - title: "ConfirmationResult"
     path: /docs/reference/node/firebase.auth.ConfirmationResult
   - title: "EmailAuthProvider"
     path: /docs/reference/node/firebase.auth.EmailAuthProvider
+  - title: "EmulatorConfig"
+    path: /docs/reference/node/firebase.auth.EmulatorConfig
   - title: "Error"
     path: /docs/reference/node/firebase.auth.Error
   - title: "FacebookAuthProvider"

--- a/scripts/docgen-compat/generate-docs.js
+++ b/scripts/docgen-compat/generate-docs.js
@@ -62,7 +62,7 @@ function stripPath(path) {
 function runTypedoc() {
   const typeSource = apiType === 'node' ? tempNodeSourcePath : sourceFile;
   const command = `${repoPath}/node_modules/.bin/typedoc ${typeSource} \
-  --tsconfig ${repoPath}/scripts/docgen/tsconfig.json \
+  --tsconfig ${__dirname}/tsconfig.json \
   --out ${docPath} \
   --readme ${tempHomePath} \
   --options ${__dirname}/typedoc.js \


### PR DESCRIPTION
Small path fixes and add 2 pages to the TOC that were missing. These additions were before the v9 release but we had not updated the TOC. Will also update and re-run the g3 script after this is checked in.