### PR TITLE
isSupported fixes

### DIFF
--- a/.changeset/angry-moons-change.md
+++ b/.changeset/angry-moons-change.md
@@ -1,0 +1,6 @@
+---
+'@firebase/app-check': patch
+'@firebase/app-check-compat': patch
+---
+
+AppCheck could encounter runtime errors when initialized in Node

--- a/.changeset/lazy-bulldogs-tickle.md
+++ b/.changeset/lazy-bulldogs-tickle.md
@@ -1,0 +1,6 @@
+---
+'@firebase/performance': patch
+'@firebase/performance-compat': patch
+---
+
+Performance could encounter runtime errors when initialized in certain environments

--- a/.changeset/ninety-lions-report.md
+++ b/.changeset/ninety-lions-report.md
@@ -1,10 +1,8 @@
 ---
 '@firebase/messaging': patch
-'@firebase/performance': patch
 '@firebase/analytics': patch
 '@firebase/messaging-compat': patch
-'@firebase/performance-compat': patch
 '@firebase/analytics-compat': patch
 ---
 
-checking isSupported led to runtime failures in certain environments
+checking isSupported led to runtime errors in certain environments

--- a/.changeset/ninety-lions-report.md
+++ b/.changeset/ninety-lions-report.md
@@ -1,0 +1,7 @@
+---
+'@firebase/messaging': patch
+'@firebase/performance': patch
+'@firebase/analytics': patch
+---
+
+checking isSupported led to runtime failures in certain environments

--- a/.changeset/ninety-lions-report.md
+++ b/.changeset/ninety-lions-report.md
@@ -2,6 +2,9 @@
 '@firebase/messaging': patch
 '@firebase/performance': patch
 '@firebase/analytics': patch
+'@firebase/messaging-compat': patch
+'@firebase/performance-compat': patch
+'@firebase/analytics-compat': patch
 ---
 
 checking isSupported led to runtime failures in certain environments

--- a/.changeset/sixty-flowers-melt.md
+++ b/.changeset/sixty-flowers-melt.md
@@ -1,0 +1,5 @@
+---
+'@firebase/util': patch
+---
+
+areCookiesEnabled could encounter runtime errors in certain enviornments

--- a/packages/firestore/src/local/simple_db.ts
+++ b/packages/firestore/src/local/simple_db.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { getUA } from '@firebase/util';
+import { getUA, isIndexedDBAvailable } from '@firebase/util';
 
 import { debugAssert } from '../util/assert';
 import { Code, FirestoreError } from '../util/error';
@@ -158,7 +158,7 @@ export class SimpleDb {
 
   /** Returns true if IndexedDB is available in the current environment. */
   static isAvailable(): boolean {
-    if (typeof indexedDB === 'undefined') {
+    if (!isIndexedDBAvailable()) {
       return false;
     }
 

--- a/packages/firestore/test/integration/util/helpers.ts
+++ b/packages/firestore/test/integration/util/helpers.ts
@@ -16,6 +16,7 @@
  */
 
 import * as firestore from '@firebase/firestore-types';
+import { isIndexedDBAvailable } from '@firebase/util';
 
 import * as firebaseExport from './firebase_export';
 import {
@@ -44,7 +45,7 @@ function isIeOrEdge(): boolean {
 export function isPersistenceAvailable(): boolean {
   return (
     typeof window === 'object' &&
-    typeof window.indexedDB === 'object' &&
+    isIndexedDBAvailable() &&
     !isIeOrEdge() &&
     (typeof process === 'undefined' ||
       process.env?.INCLUDE_FIRESTORE_PERSISTENCE !== 'false')

--- a/packages/messaging-compat/src/messaging-compat.ts
+++ b/packages/messaging-compat/src/messaging-compat.ts
@@ -68,6 +68,7 @@ export function isSupported(): boolean {
  */
 function isWindowSupported(): boolean {
   return (
+    typeof window !== 'undefined' &&
     isIndexedDBAvailable() &&
     areCookiesEnabled() &&
     'serviceWorker' in navigator &&

--- a/packages/messaging-compat/src/messaging-compat.ts
+++ b/packages/messaging-compat/src/messaging-compat.ts
@@ -26,7 +26,13 @@ import {
   getToken,
   onMessage
 } from '@firebase/messaging';
-import { NextFn, Observer, Unsubscribe } from '@firebase/util';
+import {
+  areCookiesEnabled,
+  isIndexedDBAvailable,
+  NextFn,
+  Observer,
+  Unsubscribe
+} from '@firebase/util';
 
 import { onBackgroundMessage } from '@firebase/messaging/sw';
 
@@ -62,9 +68,8 @@ export function isSupported(): boolean {
  */
 function isWindowSupported(): boolean {
   return (
-    'indexedDB' in window &&
-    indexedDB !== null &&
-    navigator.cookieEnabled &&
+    isIndexedDBAvailable() &&
+    areCookiesEnabled() &&
     'serviceWorker' in navigator &&
     'PushManager' in window &&
     'Notification' in window &&
@@ -79,8 +84,7 @@ function isWindowSupported(): boolean {
  */
 function isSwSupported(): boolean {
   return (
-    'indexedDB' in self &&
-    indexedDB !== null &&
+    isIndexedDBAvailable() &&
     'PushManager' in self &&
     'Notification' in self &&
     ServiceWorkerRegistration.prototype.hasOwnProperty('showNotification') &&

--- a/packages/messaging/src/api/isSupported.ts
+++ b/packages/messaging/src/api/isSupported.ts
@@ -28,9 +28,9 @@ export async function isWindowSupported(): Promise<boolean> {
   // might be prohibited to run. In these contexts, an error would be thrown during the messaging
   // instantiating phase, informing the developers to import/call isSupported for special handling.
   return (
+    typeof window !== 'undefined' &&
+    typeof indexedDB !== 'undefined' &&
     (await validateIndexedDBOpenable()) &&
-    'indexedDB' in window &&
-    indexedDB !== null &&
     navigator.cookieEnabled &&
     'serviceWorker' in navigator &&
     'PushManager' in window &&

--- a/packages/messaging/src/api/isSupported.ts
+++ b/packages/messaging/src/api/isSupported.ts
@@ -15,7 +15,10 @@
  * limitations under the License.
  */
 
-import { validateIndexedDBOpenable } from '@firebase/util';
+import {
+  isIndexedDBAvailable,
+  validateIndexedDBOpenable
+} from '@firebase/util';
 
 /**
  * Checks if all required APIs exist in the browser.
@@ -29,7 +32,7 @@ export async function isWindowSupported(): Promise<boolean> {
   // instantiating phase, informing the developers to import/call isSupported for special handling.
   return (
     typeof window !== 'undefined' &&
-    typeof indexedDB !== 'undefined' &&
+    isIndexedDBAvailable() &&
     (await validateIndexedDBOpenable()) &&
     navigator.cookieEnabled &&
     'serviceWorker' in navigator &&
@@ -52,9 +55,8 @@ export async function isSwSupported(): Promise<boolean> {
   // might be prohibited to run. In these contexts, an error would be thrown during the messaging
   // instantiating phase, informing the developers to import/call isSupported for special handling.
   return (
+    isIndexedDBAvailable() &&
     (await validateIndexedDBOpenable()) &&
-    'indexedDB' in self &&
-    indexedDB !== null &&
     'PushManager' in self &&
     'Notification' in self &&
     ServiceWorkerRegistration.prototype.hasOwnProperty('showNotification') &&

--- a/packages/messaging/src/api/isSupported.ts
+++ b/packages/messaging/src/api/isSupported.ts
@@ -16,6 +16,7 @@
  */
 
 import {
+  areCookiesEnabled,
   isIndexedDBAvailable,
   validateIndexedDBOpenable
 } from '@firebase/util';
@@ -34,7 +35,7 @@ export async function isWindowSupported(): Promise<boolean> {
     typeof window !== 'undefined' &&
     isIndexedDBAvailable() &&
     (await validateIndexedDBOpenable()) &&
-    navigator.cookieEnabled &&
+    areCookiesEnabled() &&
     'serviceWorker' in navigator &&
     'PushManager' in window &&
     'Notification' in window &&

--- a/packages/performance/src/services/api_service.ts
+++ b/packages/performance/src/services/api_service.ts
@@ -16,7 +16,7 @@
  */
 
 import { ERROR_FACTORY, ErrorCode } from '../utils/errors';
-import { isIndexedDBAvailable } from '@firebase/util';
+import { isIndexedDBAvailable, areCookiesEnabled } from '@firebase/util';
 import { consoleLogger } from '../utils/console_logger';
 
 declare global {
@@ -112,12 +112,7 @@ export class Api {
   }
 
   requiredApisAvailable(): boolean {
-    if (
-      !fetch ||
-      !Promise ||
-      !this.navigator ||
-      !this.navigator.cookieEnabled
-    ) {
+    if (!fetch || !Promise || !areCookiesEnabled()) {
       consoleLogger.info(
         'Firebase Performance cannot start if browser does not support fetch and Promise or cookie is disabled.'
       );

--- a/packages/util/src/environment.ts
+++ b/packages/util/src/environment.ts
@@ -184,7 +184,7 @@ export function validateIndexedDBOpenable(): Promise<boolean> {
  * @return true if cookie is enabled within current browser
  */
 export function areCookiesEnabled(): boolean {
-  if (!navigator || !navigator.cookieEnabled) {
+  if (typeof navigator === 'undefined' || !navigator.cookieEnabled) {
     return false;
   }
   return true;

--- a/packages/util/src/environment.ts
+++ b/packages/util/src/environment.ts
@@ -140,7 +140,7 @@ export function isSafari(): boolean {
  * @return true if indexedDB is supported by current browser/service worker context
  */
 export function isIndexedDBAvailable(): boolean {
-  return 'indexedDB' in self && indexedDB != null;
+  return typeof indexedDB === 'object';
 }
 
 /**


### PR DESCRIPTION
`isSupported()` had bugs in messaging, performance, and analytics.

* in messaging, isSupported was not checking for the existence of window or indexedDB before validating that indexedDB is openable
* in performance and analytics, navigator was not being checked for correctly `!navigator` should be `typeof navigator !== 'undefined` since it's a global. This led to runtime failures.
* further I dry'd up performance and messaging to use the same `areCookiesEnabled` test

Further, the indexedDb check was not working correctly in AppCheck due to checking for it on `self` (which isn't available in all environments). I addressed this and dry'd up our `typeof indexedDb` checks to all use `isIndexedDBAvailable()`.