### PR TITLE
Initialize App Check debug mode in initializeAppCheck

### DIFF
--- a/packages/app-check/src/api.test.ts
+++ b/packages/app-check/src/api.test.ts
@@ -126,10 +126,7 @@ describe('api', () => {
         token = tokenToWrite;
         return Promise.resolve();
       };
-      stub(
-        indexeddb,
-        'writeDebugTokenToIndexedDB'
-      ).callsFake(fakeWrite);
+      stub(indexeddb, 'writeDebugTokenToIndexedDB').callsFake(fakeWrite);
       stub(indexeddb, 'readDebugTokenFromIndexedDB').resolves(token);
       const logStub = stub(logger.logger, 'warn');
       const consoleStub = stub(console, 'log');

--- a/packages/app-check/src/api.test.ts
+++ b/packages/app-check/src/api.test.ts
@@ -121,15 +121,14 @@ describe('api', () => {
       ).to.equal(appCheckInstance);
     });
     it('starts debug mode on first call', async () => {
-      const fakeWrite = ():Promise<void> => Promise.resolve();
+      const fakeWrite = (): Promise<void> => Promise.resolve();
       const writeToIndexedDBStub = stub(
         indexeddb,
         'writeDebugTokenToIndexedDB'
       ).callsFake(fakeWrite);
-      stub(
-        indexeddb,
-        'readDebugTokenFromIndexedDB'
-      ).callsFake(() => Promise.resolve(undefined));
+      stub(indexeddb, 'readDebugTokenFromIndexedDB').callsFake(() =>
+        Promise.resolve(undefined)
+      );
       const logStub = stub(logger.logger, 'warn');
       const consoleStub = stub(console, 'log');
       self.FIREBASE_APPCHECK_DEBUG_TOKEN = true;

--- a/packages/app-check/src/api.test.ts
+++ b/packages/app-check/src/api.test.ts
@@ -16,7 +16,7 @@
  */
 import '../test/setup';
 import { expect } from 'chai';
-import { match, spy, stub } from 'sinon';
+import { spy, stub } from 'sinon';
 import {
   setTokenAutoRefreshEnabled,
   initializeAppCheck,
@@ -128,7 +128,6 @@ describe('api', () => {
       };
       stub(indexeddb, 'writeDebugTokenToIndexedDB').callsFake(fakeWrite);
       stub(indexeddb, 'readDebugTokenFromIndexedDB').resolves(token);
-      const logStub = stub(logger.logger, 'warn');
       const consoleStub = stub(console, 'log');
       self.FIREBASE_APPCHECK_DEBUG_TOKEN = true;
       initializeAppCheck(app, {
@@ -139,13 +138,11 @@ describe('api', () => {
       // written to indexedDB.
       expect(await getDebugToken()).to.equal(token);
       expect(consoleStub.args[0][0]).to.include(token);
-      expect(logStub).to.be.calledWith(match('is in debug mode'));
-      expect(logStub).to.be.calledWith(match(token));
       self.FIREBASE_APPCHECK_DEBUG_TOKEN = undefined;
     });
     it('warns about debug mode on second call', async () => {
-      const logStub = stub(logger.logger, 'warn');
       self.FIREBASE_APPCHECK_DEBUG_TOKEN = 'abcdefg';
+      const consoleStub = stub(console, 'log');
       initializeAppCheck(app, {
         provider: new ReCaptchaV3Provider(FAKE_SITE_KEY)
       });
@@ -154,7 +151,7 @@ describe('api', () => {
       });
       const token = await getDebugToken();
       expect(token).to.equal('abcdefg');
-      expect(logStub).to.be.calledWith(match('abcdefg'));
+      expect(consoleStub.args[0][0]).to.include(token);
       self.FIREBASE_APPCHECK_DEBUG_TOKEN = undefined;
     });
 

--- a/packages/app-check/src/api.ts
+++ b/packages/app-check/src/api.ts
@@ -63,8 +63,8 @@ export function initializeAppCheck(
     initializeDebugMode();
   }
 
-  // Log a warning when `initializeAppCheck()` is called in debug mode,
-  // and show the token.
+  // Log a message containing the debug token when `initializeAppCheck()`
+  // is called in debug mode.
   if (isDebugMode()) {
     // Do not block initialization to get the token for the message.
     void getDebugToken().then(token =>

--- a/packages/app-check/src/api.ts
+++ b/packages/app-check/src/api.ts
@@ -36,7 +36,6 @@ import {
 } from './internal-api';
 import { readTokenFromStorage } from './storage';
 import { getDebugToken, initializeDebugMode, isDebugMode } from './debug';
-import { logger } from './logger';
 
 declare module '@firebase/component' {
   interface NameServiceMapping {
@@ -67,14 +66,13 @@ export function initializeAppCheck(
   // Log a warning when `initializeAppCheck()` is called in debug mode,
   // and show the token.
   if (isDebugMode()) {
-    logger.warn(
-      `App Check is in debug mode. To turn off debug mode, unset ` +
-        `the global variable FIREBASE_APPCHECK_DEBUG_TOKEN and ` +
-        `restart the app.`
+    // Do not block initialization to get the token for the message.
+    void getDebugToken().then(token =>
+      // Not using logger because I don't think we ever want this accidentally hidden.
+      console.log(
+        `App Check debug token: ${token}. You will need to add it to your app's App Check settings in the Firebase console for it to work.`
+      )
     );
-    // Make this a separate console statement so user will at least have the
-    // first message if the token promise doesn't resolve in time.
-    void getDebugToken().then(token => logger.warn(`Debug token is ${token}.`));
   }
 
   if (provider.isInitialized()) {

--- a/packages/app-check/src/api.ts
+++ b/packages/app-check/src/api.ts
@@ -74,9 +74,7 @@ export function initializeAppCheck(
     );
     // Make this a separate console statement so user will at least have the
     // first message if the token promise doesn't resolve in time.
-    void getDebugToken().then(token =>
-      logger.warn(`Debug token is ${token}.`)
-    );
+    void getDebugToken().then(token => logger.warn(`Debug token is ${token}.`));
   }
 
   if (provider.isInitialized()) {

--- a/packages/app-check/src/debug.ts
+++ b/packages/app-check/src/debug.ts
@@ -46,6 +46,11 @@ export async function getDebugToken(): Promise<string> {
 
 export function initializeDebugMode(): void {
   const globals = getGlobal();
+  const debugState = getDebugState();
+  // Set to true if this function has been called, whether or not
+  // it enabled debug mode.
+  debugState.initialized = true;
+
   if (
     typeof globals.FIREBASE_APPCHECK_DEBUG_TOKEN !== 'string' &&
     globals.FIREBASE_APPCHECK_DEBUG_TOKEN !== true
@@ -53,7 +58,6 @@ export function initializeDebugMode(): void {
     return;
   }
 
-  const debugState = getDebugState();
   debugState.enabled = true;
   const deferredToken = new Deferred<string>();
   debugState.token = deferredToken;

--- a/packages/app-check/src/index.ts
+++ b/packages/app-check/src/index.ts
@@ -28,7 +28,6 @@ import {
 } from '@firebase/component';
 import { _AppCheckComponentName } from './public-types';
 import { factory, internalFactory } from './factory';
-import { initializeDebugMode } from './debug';
 import { _AppCheckInternalComponentName } from './types';
 import { name, version } from '../package.json';
 
@@ -82,4 +81,3 @@ function registerAppCheck(): void {
 }
 
 registerAppCheck();
-initializeDebugMode();

--- a/packages/app-check/src/state.ts
+++ b/packages/app-check/src/state.ts
@@ -41,6 +41,7 @@ export interface ReCAPTCHAState {
 }
 
 export interface DebugState {
+  initialized: boolean;
   enabled: boolean;
   token?: Deferred<string>;
 }
@@ -52,6 +53,7 @@ export const DEFAULT_STATE: AppCheckState = {
 };
 
 const DEBUG_STATE: DebugState = {
+  initialized: false,
   enabled: false
 };
 

--- a/packages/app-check/src/state.ts
+++ b/packages/app-check/src/state.ts
@@ -70,6 +70,7 @@ export function clearState(): void {
   APP_CHECK_STATES.clear();
   DEBUG_STATE.enabled = false;
   DEBUG_STATE.token = undefined;
+  DEBUG_STATE.initialized = false;
 }
 
 export function getDebugState(): DebugState {

--- a/packages/app-check/src/storage.ts
+++ b/packages/app-check/src/storage.ts
@@ -87,10 +87,6 @@ export async function readOrCreateDebugTokenFromStorage(): Promise<string> {
     writeDebugTokenToIndexedDB(newToken).catch(e =>
       logger.warn(`Failed to persist debug token to IndexedDB. Error: ${e}`)
     );
-    // Not using logger because I don't think we ever want this accidentally hidden?
-    console.log(
-      `App Check debug token: ${newToken}. You will need to add it to your app's App Check settings in the Firebase console for it to work`
-    );
     return newToken;
   } else {
     return existingDebugToken;


### PR DESCRIPTION
Initialize debug mode for App Check (i.e., reading the global var) in the first call to `initializeAppCheck()` instead of when the app-check component is registered. This makes it easier for developers to set the variable in code.

Additionally, it logs a `console.warn` on subsequent calls to initializeAppCheck notifying the user they are still in debug mode, and logging the token (if they don't reload/quit before that token promise resolves). This may help HMR users who lose the initial token message.