### PR TITLE
[Auth] Make the persistences default to inMemory for node

### DIFF
--- a/.changeset/swift-shirts-appear.md
+++ b/.changeset/swift-shirts-appear.md
@@ -1,5 +1,5 @@
 ---
-"@firebase/auth": patch
+"@firebase/auth": minor
 ---
 
 Update all persistences to map to `inMemoryPersistence` in Node, to avoid errors with server-side rendering

--- a/.changeset/swift-shirts-appear.md
+++ b/.changeset/swift-shirts-appear.md
@@ -1,0 +1,5 @@
+---
+"@firebase/auth": patch
+---
+
+Update all persistences to map to `inMemoryPersistence` in Node, to avoid errors with server-side rendering

--- a/packages/auth/src/platform_node/index.ts
+++ b/packages/auth/src/platform_node/index.ts
@@ -21,7 +21,7 @@ import { _createError } from '../core/util/assert';
 import { FirebaseApp, getApp, _getProvider } from '@firebase/app';
 import { Auth } from '../model/public_types';
 
-import { initializeAuth } from '..';
+import { initializeAuth, inMemoryPersistence } from '..';
 import { registerAuth } from '../core/auth/register';
 import { ClientPlatform } from '../core/util/version';
 import { AuthImpl } from '../core/auth/auth_impl';
@@ -76,9 +76,9 @@ class FailClass {
   }
 }
 
-export const browserLocalPersistence = NOT_AVAILABLE_ERROR;
-export const browserSessionPersistence = NOT_AVAILABLE_ERROR;
-export const indexedDBLocalPersistence = NOT_AVAILABLE_ERROR;
+export const browserLocalPersistence = inMemoryPersistence;
+export const browserSessionPersistence = inMemoryPersistence;
+export const indexedDBLocalPersistence = inMemoryPersistence;
 export const browserPopupRedirectResolver = NOT_AVAILABLE_ERROR;
 export const PhoneAuthProvider = FailClass;
 export const signInWithPhoneNumber = fail;


### PR DESCRIPTION
Fixes https://github.com/firebase/firebase-js-sdk/issues/5475

In node, all persistence types now map to inMemory instead of the not-available error