### PR TITLE
Fix Firestore exports for Node

### DIFF
--- a/packages/firestore/lite/package.json
+++ b/packages/firestore/lite/package.json
@@ -2,7 +2,7 @@
   "name": "@firebase/firestore-lite",
   "description": "A lite version of the Firestore SDK",
   "main": "../dist/lite/index.node.cjs.js",
-  "main-esm": "../dist/lite/index.node.esm2017.js",
+  "main-esm": "../dist/lite/index.node.mjs",
   "module": "../dist/lite/index.browser.esm2017.js",
   "browser": "../dist/lite/index.browser.esm2017.js",
   "react-native": "../dist/lite/index.rn.esm2017.js",

--- a/packages/firestore/package.json
+++ b/packages/firestore/package.json
@@ -49,16 +49,22 @@
   },
   "exports": {
     ".": {
-      "node": "./dist/index.node.cjs.js",
+      "node": {
+        "require": "./dist/index.node.cjs.js",
+        "import": "./dist/index.node.mjs"
+      },
       "default": "./dist/index.esm2017.js"
     },
     "./lite": {
-      "node": "./dist/lite/index.node.cjs.js",
+      "node": {
+        "require": "./dist/lite/index.node.cjs.js",
+        "import": "./dist/lite/index.node.esm2017.js"
+      },
       "default": "./dist/lite/index.browser.esm2017.js"
     }
   },
   "main": "dist/index.node.cjs.js",
-  "main-esm": "dist/index.node.cjs.esm2017.js",
+  "main-esm": "dist/index.node.mjs",
   "react-native": "dist/index.rn.js",
   "browser": "dist/index.esm2017.js",
   "module": "dist/index.esm2017.js",


### PR DESCRIPTION
Create `require` and `import` subfields for `node` exports where the latter points to `mjs` ESM builds for Node. Rename `main-esm` fields so rollup builds ESM node bundles with `mjs` extension.

Fixes https://github.com/firebase/firebase-js-sdk/issues/5499