### PR TITLE
trim all d.ts files in dist folder

### DIFF
--- a/repo-scripts/prune-dts/tsconfig.eslint.json
+++ b/repo-scripts/prune-dts/tsconfig.eslint.json
@@ -1,4 +1,4 @@
 {
   "extends": "../../config/tsconfig.base.json",
-  "include": ["../../packages/*/dist/**/index.d.ts"]
+  "include": ["../../packages/*/dist/**/*.d.ts"]
 }

--- a/repo-scripts/prune-dts/tsconfig.json
+++ b/repo-scripts/prune-dts/tsconfig.json
@@ -5,7 +5,7 @@
     "module": "commonjs",
     "moduleResolution": "node",
     "resolveJsonModule": true,
-    "target": "es5",
+    "target": "es2017",
     "esModuleInterop": true,
     "declaration": true,
     "strict": true


### PR DESCRIPTION
Relaxing the pattern to match all d.ts files to allow them to be trimmed. The original pattern was too specific and didn't match the typings file `public.d.ts` in `@firebase/database`, so it was not trimmed.