### PR TITLE
use esm2017 builds by default

### DIFF
--- a/.changeset/heavy-books-mate.md
+++ b/.changeset/heavy-books-mate.md
@@ -1,0 +1,7 @@
+---
+"@firebase/logger": minor
+"@firebase/util": minor
+"@firebase/webchannel-wrapper": minor
+---
+
+Use esm2017 builds by default

--- a/.changeset/wet-queens-tell.md
+++ b/.changeset/wet-queens-tell.md
@@ -2,4 +2,4 @@
 "@firebase/firestore": patch
 ---
 
-use `constructor.name` for Object name
+use `constructor.name` for Object type

--- a/.changeset/wet-queens-tell.md
+++ b/.changeset/wet-queens-tell.md
@@ -1,0 +1,5 @@
+---
+"@firebase/firestore": patch
+---
+
+use `constructor.name` for Object name

--- a/config/webpack.test.js
+++ b/config/webpack.test.js
@@ -38,7 +38,7 @@ module.exports = {
           options: {
             compilerOptions: {
               module: 'commonjs',
-              target: 'es5',
+              target: 'es2017',
               downlevelIteration: true,
               resolveJsonModule: true
             }

--- a/packages/firestore/src/util/input_validation.ts
+++ b/packages/firestore/src/util/input_validation.ts
@@ -132,14 +132,10 @@ export function valueDescription(input: unknown): string {
   }
 }
 
-/** Hacky method to try to get the constructor name for an object. */
+/** try to get the constructor name for an object. */
 export function tryGetCustomObjectType(input: object): string | null {
   if (input.constructor) {
-    const funcNameRegex = /function\s+([^\s(]+)\s*\(/;
-    const results = funcNameRegex.exec(input.constructor.toString());
-    if (results && results.length > 1) {
-      return results[1];
-    }
+    return input.constructor.name;
   }
   return null;
 }

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -4,8 +4,8 @@
   "description": "A logger package for use in the Firebase JS SDK",
   "author": "Firebase <firebase-support@google.com> (https://firebase.google.com/)",
   "main": "dist/index.cjs.js",
-  "module": "dist/index.esm.js",
-  "esm2017": "dist/index.esm2017.js",
+  "module": "dist/index.esm2017.js",
+  "esm5": "dist/index.esm5.js",
   "files": ["dist"],
   "scripts": {
     "lint": "eslint -c .eslintrc.js '**/*.ts' --ignore-path '../../.gitignore'",

--- a/packages/logger/rollup.config.js
+++ b/packages/logger/rollup.config.js
@@ -37,7 +37,7 @@ const es5Builds = [
     input: 'index.ts',
     output: [
       { file: pkg.main, format: 'cjs', sourcemap: true },
-      { file: pkg.module, format: 'es', sourcemap: true }
+      { file: pkg.esm5, format: 'es', sourcemap: true }
     ],
     plugins: es5BuildPlugins,
     external: id => deps.some(dep => id === dep || id.startsWith(`${dep}/`))
@@ -62,7 +62,7 @@ const es2017Builds = [
   {
     input: 'index.ts',
     output: {
-      file: pkg.esm2017,
+      file: pkg.module,
       format: 'es',
       sourcemap: true
     },

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -4,9 +4,9 @@
   "description": "",
   "author": "Firebase <firebase-support@google.com> (https://firebase.google.com/)",
   "main": "dist/index.node.cjs.js",
-  "browser": "dist/index.esm.js",
-  "module": "dist/index.esm.js",
-  "esm2017": "dist/index.esm2017.js",
+  "browser": "dist/index.esm2017.js",
+  "module": "dist/index.esm2017.js",
+  "esm5": "dist/index.esm5.js",
   "files": [
     "dist"
   ],

--- a/packages/util/rollup.config.js
+++ b/packages/util/rollup.config.js
@@ -39,7 +39,7 @@ const es5Builds = [
    */
   {
     input: 'index.ts',
-    output: [{ file: pkg.module, format: 'es', sourcemap: true }],
+    output: [{ file: pkg.esm5, format: 'es', sourcemap: true }],
     plugins: es5BuildPlugins,
     external: id => deps.some(dep => id === dep || id.startsWith(`${dep}/`))
   },
@@ -72,7 +72,7 @@ const es2017Builds = [
   {
     input: 'index.ts',
     output: {
-      file: pkg.esm2017,
+      file: pkg.module,
       format: 'es',
       sourcemap: true
     },

--- a/packages/webchannel-wrapper/package.json
+++ b/packages/webchannel-wrapper/package.json
@@ -4,8 +4,8 @@
   "description": "A wrapper of the webchannel packages from closure-library for use outside of a closure compiled application",
   "author": "Firebase <firebase-support@google.com> (https://firebase.google.com/)",
   "main": "dist/index.js",
-  "module": "dist/index.esm.js",
-  "esm2017": "dist/index.esm2017.js",
+  "module": "dist/index.esm2017.js",
+  "esm5": "dist/index.esm.js",
   "files": [
     "dist"
   ],


### PR DESCRIPTION
Esm2017 is the default build for v9 libraries. Changing util libraries to use esm2017 by default.