### PR TITLE
[Auth] Fix incorrectly-cased parameter in OOB request

### DIFF
--- a/.changeset/swift-items-prove.md
+++ b/.changeset/swift-items-prove.md
@@ -1,0 +1,5 @@
+---
+"@firebase/auth": patch
+---
+
+Fix incorrectly-cased parameter in out-of-band request that was causing incorrect behavior in some cases

--- a/packages/auth/src/api/authentication/email_and_password.ts
+++ b/packages/auth/src/api/authentication/email_and_password.ts
@@ -56,7 +56,7 @@ export async function signInWithPassword(
 export interface GetOobCodeRequest {
   email?: string; // Everything except VERIFY_AND_CHANGE_EMAIL
   continueUrl?: string;
-  iosBundleId?: string;
+  iOSBundleId?: string;
   iosAppStoreId?: string;
   androidPackageName?: string;
   androidInstallApp?: boolean;

--- a/packages/auth/src/core/strategies/action_code_settings.ts
+++ b/packages/auth/src/core/strategies/action_code_settings.ts
@@ -48,7 +48,7 @@ export function _setActionCodeSettingsOnRequest(
       auth,
       AuthErrorCode.MISSING_IOS_BUNDLE_ID
     );
-    request.iosBundleId = actionCodeSettings.iOS.bundleId;
+    request.iOSBundleId = actionCodeSettings.iOS.bundleId;
   }
 
   if (actionCodeSettings.android) {

--- a/packages/auth/src/core/strategies/email.test.ts
+++ b/packages/auth/src/core/strategies/email.test.ts
@@ -171,7 +171,7 @@ describe('core/strategies/sendEmailVerification', () => {
         continueUrl: 'my-url',
         dynamicLinkDomain: 'fdl-domain',
         canHandleCodeInApp: true,
-        iosBundleId: 'my-bundle'
+        iOSBundleId: 'my-bundle'
       });
     });
   });
@@ -280,7 +280,7 @@ describe('core/strategies/verifyBeforeUpdateEmail', () => {
         continueUrl: 'my-url',
         dynamicLinkDomain: 'fdl-domain',
         canHandleCodeInApp: true,
-        iosBundleId: 'my-bundle'
+        iOSBundleId: 'my-bundle'
       });
     });
   });

--- a/packages/auth/src/core/strategies/email_and_password.test.ts
+++ b/packages/auth/src/core/strategies/email_and_password.test.ts
@@ -104,7 +104,7 @@ describe('core/strategies/sendPasswordResetEmail', () => {
         continueUrl: 'my-url',
         dynamicLinkDomain: 'fdl-domain',
         canHandleCodeInApp: true,
-        iosBundleId: 'my-bundle'
+        iOSBundleId: 'my-bundle'
       });
     });
   });

--- a/packages/auth/src/core/strategies/email_link.test.ts
+++ b/packages/auth/src/core/strategies/email_link.test.ts
@@ -119,7 +119,7 @@ describe('core/strategies/sendSignInLinkToEmail', () => {
         continueUrl: 'my-url',
         dynamicLinkDomain: 'fdl-domain',
         canHandleCodeInApp: true,
-        iosBundleId: 'my-bundle'
+        iOSBundleId: 'my-bundle'
       });
     });
   });


### PR DESCRIPTION
Fixes https://github.com/firebase/firebase-js-sdk/issues/5541

We were sending `iosBundleId` instead of `iOSBundleId`, which was causing incorrect behavior.