### PR TITLE
Use Authorization header instead of access_token for Github call

### DIFF
--- a/repo-scripts/changelog-generator/index.ts
+++ b/repo-scripts/changelog-generator/index.ts
@@ -89,7 +89,8 @@ const changelogFunctions: ChangelogFunctions = {
   }
 };
 
-const fixedIssueRegex = /(close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved) [^\s]*(#|issues\/)([\d]+)/i;
+const fixedIssueRegex =
+  /(close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved) [^\s]*(#|issues\/)([\d]+)/i;
 async function getFixedIssueLink(
   prNumber: number,
   repo: string

--- a/repo-scripts/changelog-generator/index.ts
+++ b/repo-scripts/changelog-generator/index.ts
@@ -95,9 +95,12 @@ async function getFixedIssueLink(
   repo: string
 ): Promise<string> {
   const { body }: { body: string } = await fetch(
-    `https://api.github.com/repos/${repo}/pulls/${prNumber}?access_token=${process.env.GITHUB_TOKEN}`,
+    `https://api.github.com/repos/${repo}/pulls/${prNumber}`,
     {
-      method: 'GET'
+      method: 'GET',
+      headers: {
+        'Authorization': `Bearer ${process.env.GITHUB_TOKEN}`
+      }
     }
   ).then(data => data.json());
 


### PR DESCRIPTION
Github has been warning about deprecation of the `access_token` query param and asking users to use the `Authorization` header instead.