### PR TITLE
Fix changeset checker to stop using since option

### DIFF
--- a/.github/workflows/check-changeset.yml
+++ b/.github/workflows/check-changeset.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Run changeset script
       # pull master so changeset can diff against it
       run: |
-        git pull -f origin master:master
+        git pull -f --ff-only origin master:master
         yarn ts-node-script scripts/ci/check_changeset.ts
       id: check-changeset
     - name: Print changeset checker output

--- a/.github/workflows/check-changeset.yml
+++ b/.github/workflows/check-changeset.yml
@@ -24,7 +24,10 @@ jobs:
     - name: Yarn install
       run: yarn
     - name: Run changeset script
-      run: yarn ts-node-script scripts/ci/check_changeset.ts
+      # pull master so changeset can diff against it
+      run: |
+        git pull -f origin master:master
+        yarn ts-node-script scripts/ci/check_changeset.ts
       id: check-changeset
     - name: Print changeset checker output
       run: echo "${{steps.check-changeset.outputs.CHANGESET_ERROR_MESSAGE}}"

--- a/.github/workflows/check-changeset.yml
+++ b/.github/workflows/check-changeset.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Run changeset script
       # pull master so changeset can diff against it
       run: |
-        git pull -f --ff-only origin master:master
+        git pull -f --no-rebase origin master:master
         yarn ts-node-script scripts/ci/check_changeset.ts
       id: check-changeset
     - name: Print changeset checker output

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,7 @@ jobs:
         run: yarn
 
       - name: Add a changeset for @firebase/app
+        # pull master so changeset can diff against it
         run: |
           git pull -f origin master:master
           yarn ts-node-script scripts/ci/add_changeset.ts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Add a changeset for @firebase/app
         # pull master so changeset can diff against it
         run: |
-          git pull -f origin master:master
+          git pull -f --ff-only origin master:master
           yarn ts-node-script scripts/ci/add_changeset.ts
 
       - name: Create Release Pull Request

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Add a changeset for @firebase/app
         # pull master so changeset can diff against it
         run: |
-          git pull -f --ff-only origin master:master
+          git pull -f --no-rebase origin master:master
           yarn ts-node-script scripts/ci/add_changeset.ts
 
       - name: Create Release Pull Request

--- a/scripts/ci/check_changeset.ts
+++ b/scripts/ci/check_changeset.ts
@@ -123,7 +123,7 @@ async function parseChangesetFile(changesetFile: string) {
 async function main() {
   const errors = [];
   try {
-    await exec(`yarn changeset status --since ${baseRef}`);
+    await exec(`yarn changeset status`);
     console.log(`::set-output name=BLOCKING_FAILURE::false`);
   } catch (e) {
     if (e.message.match('No changesets present')) {


### PR DESCRIPTION
The option doesn't do what I thought it did, it should be calling the normal `changeset status` command. It just needs to explicitly pull master first so that the command doesn't fail.

`--no-rebase` avoids the warning message of not specifying a default merge strategy while selecting what would have been the default anyway.