### PR TITLE
Disable Origin Trial code in WebChannel to reduce JS bundle size.

### DIFF
--- a/packages/webchannel-wrapper/gulpfile.js
+++ b/packages/webchannel-wrapper/gulpfile.js
@@ -52,7 +52,9 @@ const closureDefines = [
   // Disables IE8-specific event fallback code (saves 523 bytes).
   'goog.events.CAPTURE_SIMULATION_MODE=0',
   // Disable IE-Specific ActiveX fallback for XHRs (saves 524 bytes).
-  'goog.net.XmlHttpDefines.ASSUME_NATIVE_XHR=true'
+  'goog.net.XmlHttpDefines.ASSUME_NATIVE_XHR=true',
+  // Disable Origin Trials code for WebChannel (saves 1786 bytes).
+  'goog.net.webChannel.ALLOW_ORIGIN_TRIAL_FEATURES=false',
 ];
 
 /**


### PR DESCRIPTION
The new `ALLOW_ORIGIN_TRIAL_FEATURES` option was added to Closure in [this commit](https://github.com/google/closure-library/commit/23314e6077b4b7fb25bd9600a66480529e0ead1f).

Having this flag will save ~1.74 KB in the webchannel wrapper JS bundle compared with not having it (with the next Closure release).