### PR TITLE
Fix App Check typings

### DIFF
--- a/packages/app-check/src/types.ts
+++ b/packages/app-check/src/types.ts
@@ -61,8 +61,12 @@ export interface AppCheckTokenInternal extends AppCheckToken {
 export interface AppCheckProvider {
   /**
    * Returns an App Check token.
+   * @internal
    */
   getToken: () => Promise<AppCheckTokenInternal>;
+  /**
+   * @internal
+   */
   initialize(app: FirebaseApp): void;
 }
 


### PR DESCRIPTION
Fixes https://github.com/firebase/firebase-js-sdk/issues/5569

The two public facing providers (Custom and RecaptchaV3) implement an internal interface `AppCheckProvider` but they hide some of their public methods, causing them to be inconsistent with the internal interface.

If I tag `AppCheckProvider` `@internal`, the "implements AppCheckProvider" is still there on the two public types and there's an error because it can't find it.

I don't want to get rid of the "implements" because it is a helpful check in the internal code.