### PR TITLE
Fix app-check-compat providers

### DIFF
--- a/.changeset/wild-vans-camp.md
+++ b/.changeset/wild-vans-camp.md
@@ -1,0 +1,6 @@
+---
+'@firebase/app-check-compat': patch
+'firebase': patch
+---
+
+Fixed App Check compat package to correctly export and handle `ReCaptchaV3Provider` and `CustomProvider` classes.

--- a/packages/app-check-compat/src/index.ts
+++ b/packages/app-check-compat/src/index.ts
@@ -28,6 +28,10 @@ import {
 } from '@firebase/component';
 import { AppCheckService } from './service';
 import { FirebaseAppCheck } from '@firebase/app-check-types';
+import {
+  ReCaptchaV3Provider,
+  CustomProvider
+} from '@firebase/app-check';
 
 const factory: InstanceFactory<'appCheck-compat'> = (
   container: ComponentContainer
@@ -40,7 +44,14 @@ const factory: InstanceFactory<'appCheck-compat'> = (
 
 export function registerAppCheck(): void {
   (firebase as _FirebaseNamespace).INTERNAL.registerComponent(
-    new Component('appCheck-compat', factory, ComponentType.PUBLIC)
+    new Component(
+      'appCheck-compat',
+      factory,
+      ComponentType.PUBLIC
+    ).setServiceProps({
+      ReCaptchaV3Provider,
+      CustomProvider
+    })
   );
 }
 

--- a/packages/app-check-compat/src/index.ts
+++ b/packages/app-check-compat/src/index.ts
@@ -28,10 +28,7 @@ import {
 } from '@firebase/component';
 import { AppCheckService } from './service';
 import { FirebaseAppCheck } from '@firebase/app-check-types';
-import {
-  ReCaptchaV3Provider,
-  CustomProvider
-} from '@firebase/app-check';
+import { ReCaptchaV3Provider, CustomProvider } from '@firebase/app-check';
 
 const factory: InstanceFactory<'appCheck-compat'> = (
   container: ComponentContainer

--- a/packages/app-check-compat/src/service.test.ts
+++ b/packages/app-check-compat/src/service.test.ts
@@ -79,7 +79,7 @@ describe('Firebase App Check > Service', () => {
   );
 
   it(
-    'activate(CustomProvider) calls modular initializeAppCheck() with' +
+    'activate({getToken: () => token}) calls modular initializeAppCheck() with' +
     ' a CustomProvider',
     () => {
       const initializeAppCheckStub = stub(appCheckExp, 'initializeAppCheck');
@@ -97,6 +97,37 @@ describe('Firebase App Check > Service', () => {
               customGetTokenStub
             )
           ),
+        isTokenAutoRefreshEnabled: undefined
+      });
+      initializeAppCheckStub.restore();
+    }
+  );
+
+  it(
+    'activate(new RecaptchaV3Provider(...)) calls modular initializeAppCheck() with' +
+    ' a RecaptchaV3Provider',
+    () => {
+      const initializeAppCheckStub = stub(appCheckExp, 'initializeAppCheck');
+      service = new AppCheckService(app);
+      service.activate(new ReCaptchaV3Provider('a-site-key'));
+      expect(initializeAppCheckStub).to.be.calledWith(app, {
+        provider: match.instanceOf(ReCaptchaV3Provider),
+        isTokenAutoRefreshEnabled: undefined
+      });
+      initializeAppCheckStub.restore();
+    }
+  );
+
+  it(
+    'activate(new CustomProvider(...)) calls modular initializeAppCheck() with' +
+    ' a CustomProvider',
+    () => {
+      const initializeAppCheckStub = stub(appCheckExp, 'initializeAppCheck');
+      service = new AppCheckService(app);
+      const customGetTokenStub = stub();
+      service.activate(new CustomProvider({ getToken: customGetTokenStub }));
+      expect(initializeAppCheckStub).to.be.calledWith(app, {
+        provider: match.instanceOf(CustomProvider),
         isTokenAutoRefreshEnabled: undefined
       });
       initializeAppCheckStub.restore();

--- a/packages/app-check-compat/src/service.test.ts
+++ b/packages/app-check-compat/src/service.test.ts
@@ -65,7 +65,7 @@ describe('Firebase App Check > Service', () => {
 
   it(
     'activate("string") calls modular initializeAppCheck() with a ' +
-    'ReCaptchaV3Provider',
+      'ReCaptchaV3Provider',
     () => {
       const initializeAppCheckStub = stub(appCheckExp, 'initializeAppCheck');
       service = new AppCheckService(app);
@@ -80,7 +80,7 @@ describe('Firebase App Check > Service', () => {
 
   it(
     'activate({getToken: () => token}) calls modular initializeAppCheck() with' +
-    ' a CustomProvider',
+      ' a CustomProvider',
     () => {
       const initializeAppCheckStub = stub(appCheckExp, 'initializeAppCheck');
       service = new AppCheckService(app);
@@ -105,7 +105,7 @@ describe('Firebase App Check > Service', () => {
 
   it(
     'activate(new RecaptchaV3Provider(...)) calls modular initializeAppCheck() with' +
-    ' a RecaptchaV3Provider',
+      ' a RecaptchaV3Provider',
     () => {
       const initializeAppCheckStub = stub(appCheckExp, 'initializeAppCheck');
       service = new AppCheckService(app);
@@ -120,7 +120,7 @@ describe('Firebase App Check > Service', () => {
 
   it(
     'activate(new CustomProvider(...)) calls modular initializeAppCheck() with' +
-    ' a CustomProvider',
+      ' a CustomProvider',
     () => {
       const initializeAppCheckStub = stub(appCheckExp, 'initializeAppCheck');
       service = new AppCheckService(app);
@@ -198,7 +198,7 @@ describe('Firebase App Check > Service', () => {
 
   it('onTokenChanged() throws if activate() has not been called', async () => {
     service = createTestService(app);
-    expect(() => service.onTokenChanged(() => { })).to.throw(
+    expect(() => service.onTokenChanged(() => {})).to.throw(
       AppCheckError.USE_BEFORE_ACTIVATION
     );
   });

--- a/packages/app-check-compat/src/service.ts
+++ b/packages/app-check-compat/src/service.ts
@@ -43,9 +43,16 @@ export class AppCheckService
     siteKeyOrProvider: string | AppCheckProvider,
     isTokenAutoRefreshEnabled?: boolean
   ): void {
-    let provider: ReCaptchaV3Provider | CustomProvider;
+    let provider:
+      | ReCaptchaV3Provider
+      | CustomProvider;
     if (typeof siteKeyOrProvider === 'string') {
       provider = new ReCaptchaV3Provider(siteKeyOrProvider);
+    } else if (
+      siteKeyOrProvider instanceof ReCaptchaV3Provider ||
+      siteKeyOrProvider instanceof CustomProvider
+    ) {
+      provider = siteKeyOrProvider;
     } else {
       provider = new CustomProvider({ getToken: siteKeyOrProvider.getToken });
     }

--- a/packages/app-check-compat/src/service.ts
+++ b/packages/app-check-compat/src/service.ts
@@ -43,9 +43,7 @@ export class AppCheckService
     siteKeyOrProvider: string | AppCheckProvider,
     isTokenAutoRefreshEnabled?: boolean
   ): void {
-    let provider:
-      | ReCaptchaV3Provider
-      | CustomProvider;
+    let provider: ReCaptchaV3Provider | CustomProvider;
     if (typeof siteKeyOrProvider === 'string') {
       provider = new ReCaptchaV3Provider(siteKeyOrProvider);
     } else if (

--- a/packages/firebase/compat/index.d.ts
+++ b/packages/firebase/compat/index.d.ts
@@ -1580,7 +1580,9 @@ declare namespace firebase.appCheck {
   export interface AppCheck {
     /**
      * Activate AppCheck
-     * @param provider reCAPTCHA provider, custom token provider, or reCAPTCHA site key.
+     * @param provider This can be a `ReCaptchaV3Provider` instance,
+     * a `CustomProvider` instance, an object with a custom `getToken()`
+     * method, or a reCAPTCHA site key.
      * @param isTokenAutoRefreshEnabled If true, the SDK automatically
      * refreshes App Check tokens as needed. If undefined, defaults to the
      * value of `app.automaticDataCollectionEnabled`, which defaults to
@@ -1591,6 +1593,7 @@ declare namespace firebase.appCheck {
         | ReCaptchaV3Provider
         | CustomProvider
         | AppCheckProvider
+        | { getToken: () => AppCheckToken }
         | string,
       isTokenAutoRefreshEnabled?: boolean
     ): void;


### PR DESCRIPTION
Not sure how this was overlooked but the special provider classes were not exported on the firebase.appcheck object and `activate` was not set up to process them.