### PR TITLE
[Auth] Fix OAuth credential issue with nonce fields

### DIFF
--- a/.changeset/itchy-snails-give.md
+++ b/.changeset/itchy-snails-give.md
@@ -1,0 +1,5 @@
+---
+"@firebase/auth": patch
+---
+
+Fix bug in the `OAuthProvider.prototype.credential` method that was preventing the `rawNonce` field from being populated in the returned `OAuthCredential`.

--- a/common/api-review/auth.api.md
+++ b/common/api-review/auth.api.md
@@ -493,8 +493,6 @@ export class OAuthCredential extends AuthCredential {
     idToken?: string;
     // @internal (undocumented)
     _linkToIdToken(auth: AuthInternal, idToken: string): Promise<IdTokenResponse>;
-    // @internal (undocumented)
-    nonce?: string;
     secret?: string;
     toJSON(): object;
 }

--- a/packages/auth/src/core/credentials/oauth.test.ts
+++ b/packages/auth/src/core/credentials/oauth.test.ts
@@ -69,7 +69,7 @@ describe('core/credentials/oauth', () => {
         nonce: 'nonce'
       });
 
-      expect(cred.nonce).to.eq('nonce');
+      expect((cred.toJSON() as {nonce: string}).nonce).to.eq('nonce');
     });
 
     it('ignores the nonce if pendingToken set', () => {
@@ -81,7 +81,7 @@ describe('core/credentials/oauth', () => {
         pendingToken: 'pending-token'
       });
 
-      expect(cred.nonce).to.be.undefined;
+      expect((cred.toJSON() as {nonce?: string}).nonce).to.be.undefined;
     });
 
     it('handles oauth1 and oauth with token secret', () => {

--- a/packages/auth/src/core/credentials/oauth.ts
+++ b/packages/auth/src/core/credentials/oauth.ts
@@ -75,8 +75,8 @@ export class OAuthCredential extends AuthCredential {
    * @readonly
    */
   secret?: string;
-  /** @internal */
-  nonce?: string;
+  
+  private nonce?: string;
   private pendingToken: string | null = null;
 
   /** @internal */
@@ -136,13 +136,17 @@ export class OAuthCredential extends AuthCredential {
    */
   static fromJSON(json: string | object): OAuthCredential | null {
     const obj = typeof json === 'string' ? JSON.parse(json) : json;
-    const { providerId, signInMethod, ...rest }: Partial<OAuthCredential> = obj;
+    const { providerId, signInMethod, ...rest }: OAuthCredentialParams = obj;
     if (!providerId || !signInMethod) {
       return null;
     }
 
     const cred = new OAuthCredential(providerId, signInMethod);
-    Object.assign(cred, rest);
+    cred.idToken = rest.idToken || undefined;
+    cred.accessToken = rest.accessToken || undefined;
+    cred.secret = rest.secret;
+    cred.nonce = rest.nonce;
+    cred.pendingToken = rest.pendingToken || null;
     return cred;
   }
 

--- a/packages/auth/src/core/providers/oauth.test.ts
+++ b/packages/auth/src/core/providers/oauth.test.ts
@@ -117,4 +117,16 @@ describe('core/providers/oauth', () => {
     expect(cred.providerId).to.eq(ProviderId.FACEBOOK);
     expect(cred.signInMethod).to.eq(SignInMethod.FACEBOOK);
   });
+
+  it('credential generates the cred with the correct fields', () => {
+    const provider = new OAuthProvider('foo.test');
+    const cred = provider.credential({
+      idToken: 'foo',
+      rawNonce: 'i-am-a-nonce',
+    });
+    expect(cred.idToken).to.eq('foo');
+    expect(cred.providerId).to.eq('foo.test');
+    expect(cred.signInMethod).to.eq('foo.test');
+    expect((cred.toJSON() as {nonce: string}).nonce).to.eq('i-am-a-nonce');
+  });
 });

--- a/packages/auth/src/core/providers/oauth.ts
+++ b/packages/auth/src/core/providers/oauth.ts
@@ -164,12 +164,12 @@ export class OAuthProvider extends BaseOAuthProvider {
    * or the ID token string.
    */
   credential(params: OAuthCredentialOptions): OAuthCredential {
-    return this._credential(params);
+    return this._credential({...params, nonce: params.rawNonce});
   }
 
   /** An internal credential method that accepts more permissive options */
   private _credential(
-    params: OAuthCredentialOptions | OAuthCredentialParams
+    params: Omit<OAuthCredentialParams, 'signInMethod' | 'providerId'>
   ): OAuthCredential {
     _assert(params.idToken || params.accessToken, AuthErrorCode.ARGUMENT_ERROR);
     // For OAuthCredential, sign in method is same as providerId.
@@ -236,7 +236,7 @@ export class OAuthProvider extends BaseOAuthProvider {
       return new OAuthProvider(providerId)._credential({
         idToken: oauthIdToken,
         accessToken: oauthAccessToken,
-        rawNonce: nonce,
+        nonce,
         pendingToken
       });
     } catch (e) {


### PR DESCRIPTION
Fixes https://github.com/firebase/firebase-js-sdk/issues/5553

The field wasn't being carried through to the final object properly. This change also makes the `nonce` field in the OAuthCredential object fully private---it is not documented or exposed in any of the other SDKs