### PR TITLE
[Auth] Fix tenantId field when setting user via updateCurrentUser

### DIFF
--- a/.changeset/twelve-scissors-wink.md
+++ b/.changeset/twelve-scissors-wink.md
@@ -1,0 +1,5 @@
+---
+"@firebase/auth": patch
+---
+
+Fix bug where `user.tenantId` wasn't being carried over in `updateCurrentUser` function

--- a/packages/auth/src/core/user/user_impl.test.ts
+++ b/packages/auth/src/core/user/user_impl.test.ts
@@ -263,7 +263,8 @@ describe('core/user/user_impl', () => {
         phoneNumber: 'number',
         photoURL: 'photo',
         emailVerified: false,
-        isAnonymous: true
+        isAnonymous: true,
+        tenantId: 'tenant-id'
       });
 
       const newAuth = await testAuth();
@@ -272,6 +273,7 @@ describe('core/user/user_impl', () => {
       expect(copy.stsTokenManager).not.to.eq(user.stsTokenManager);
       expect(copy.toJSON()).to.eql(user.toJSON());
       expect(copy.auth).to.eq(newAuth);
+      expect(copy.tenantId).to.eq('tenant-id');
     });
   });
 });

--- a/packages/auth/src/core/user/user_impl.ts
+++ b/packages/auth/src/core/user/user_impl.ts
@@ -87,6 +87,7 @@ export class UserImpl implements UserInternal {
     this.phoneNumber = opt.phoneNumber || null;
     this.photoURL = opt.photoURL || null;
     this.isAnonymous = opt.isAnonymous || false;
+    this.tenantId = opt.tenantId || null;
     this.metadata = new UserMetadata(
       opt.createdAt || undefined,
       opt.lastLoginAt || undefined


### PR DESCRIPTION
There was a bug in the `user._clone()` method where the tenantId wasn't getting carried over to the new object.