### PR TITLE
Do not throw from connection.send in Node.js

### DIFF
--- a/.changeset/curvy-peaches-deliver.md
+++ b/.changeset/curvy-peaches-deliver.md
@@ -1,0 +1,5 @@
+---
+"@firebase/storage": patch
+---
+
+Do not throw from `connection.send` to enable retries in Node.js.

--- a/packages/storage/src/implementation/connection.ts
+++ b/packages/storage/src/implementation/connection.ts
@@ -23,6 +23,10 @@ export type Headers = Record<string, string>;
  * goog.net.XhrIo-like interface.
  */
 export interface Connection {
+  /**
+   * This method should never reject. In case of encountering an error, set an error code internally which can be accessed
+   * by calling getErrorCode() by callers. 
+   */
   send(
     url: string,
     method: string,

--- a/packages/storage/src/implementation/request.ts
+++ b/packages/storage/src/implementation/request.ts
@@ -106,6 +106,7 @@ class NetworkRequest<T> implements Request<T> {
         connection.addUploadProgressListener(progressListener);
       }
 
+      // connection.send() never rejects, so we don't need to have a error handler or use catch on the returned promise.
       // eslint-disable-next-line @typescript-eslint/no-floating-promises
       connection
         .send(this.url_, this.method_, this.body_, this.headers_)

--- a/packages/storage/src/platform/node/connection.ts
+++ b/packages/storage/src/platform/node/connection.ts
@@ -19,9 +19,6 @@ import { ErrorCode, Connection } from '../../implementation/connection';
 import { internalError } from '../../implementation/error';
 import nodeFetch, { FetchError } from 'node-fetch';
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const fetch: typeof window.fetch = nodeFetch as any;
-
 /**
  * Network layer that works in Node.
  *
@@ -34,6 +31,8 @@ export class FetchConnection implements Connection {
   private body_: string | undefined;
   private headers_: Headers | undefined;
   private sent_: boolean = false;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private fetch_: typeof window.fetch = nodeFetch as any;
 
   constructor() {
     this.errorCode_ = ErrorCode.NO_ERROR;
@@ -50,7 +49,7 @@ export class FetchConnection implements Connection {
     }
     this.sent_ = true;
 
-    return fetch(url, {
+    return this.fetch_(url, {
       method,
       headers: headers || {},
       body

--- a/packages/storage/src/platform/node/connection.ts
+++ b/packages/storage/src/platform/node/connection.ts
@@ -17,7 +17,7 @@
 
 import { ErrorCode, Connection } from '../../implementation/connection';
 import { internalError } from '../../implementation/error';
-import nodeFetch from 'node-fetch';
+import nodeFetch, { FetchError } from 'node-fetch';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const fetch: typeof window.fetch = nodeFetch as any;
@@ -58,10 +58,13 @@ export class FetchConnection implements Connection {
       .then(resp => {
         this.headers_ = resp.headers;
         this.statusCode_ = resp.status;
-        return resp.text();
-      })
-      .then(body => {
-        this.body_ = body;
+        return resp.text().then(body => {
+          this.body_ = body;
+        });
+      }, (_err: FetchError) => {
+        this.errorCode_ = ErrorCode.NETWORK_ERROR;
+        // emulate XHR which sets status to 0 when encountering a network error
+        this.statusCode_ = 0;
       });
   }
 

--- a/packages/storage/test/browser/connection.test.ts
+++ b/packages/storage/test/browser/connection.test.ts
@@ -1,0 +1,17 @@
+import { expect } from "chai";
+import { SinonFakeXMLHttpRequest, useFakeXMLHttpRequest } from "sinon";
+import { ErrorCode } from "../../src/implementation/connection";
+import { XhrConnection } from "../../src/platform/browser/connection";
+
+describe('Connections', () => {
+    it('XhrConnection.send() should not reject on network errors', async () => {
+        const fakeXHR = useFakeXMLHttpRequest();
+        const connection = new XhrConnection();
+        const sendPromise = connection.send('testurl', 'GET');
+        // simulate an network error
+        ((connection as any).xhr_ as SinonFakeXMLHttpRequest).error();
+        await sendPromise;
+        expect(connection.getErrorCode()).to.equal(ErrorCode.NETWORK_ERROR);
+        fakeXHR.restore();
+    });
+});

--- a/packages/storage/test/browser/connection.test.ts
+++ b/packages/storage/test/browser/connection.test.ts
@@ -8,7 +8,7 @@ describe('Connections', () => {
         const fakeXHR = useFakeXMLHttpRequest();
         const connection = new XhrConnection();
         const sendPromise = connection.send('testurl', 'GET');
-        // simulate an network error
+        // simulate a network error
         ((connection as any).xhr_ as SinonFakeXMLHttpRequest).error();
         await sendPromise;
         expect(connection.getErrorCode()).to.equal(ErrorCode.NETWORK_ERROR);

--- a/packages/storage/test/unit/connection.test.ts
+++ b/packages/storage/test/unit/connection.test.ts
@@ -1,0 +1,15 @@
+import { stub } from 'sinon';
+import { expect } from 'chai';
+import { ErrorCode } from '../../src/implementation/connection';
+import { FetchConnection } from '../../src/platform/node/connection';
+
+describe('Connections', () => {
+    it('FetchConnection.send() should not reject on network errors', async () => {
+        const connection = new FetchConnection();
+
+        // need the casting here because fetch_ is a private member
+        stub(connection as any, 'fetch_').rejects();
+        await connection.send('testurl', 'GET');
+        expect(connection.getErrorCode()).to.equal(ErrorCode.NETWORK_ERROR);
+    });
+});


### PR DESCRIPTION
Fixes https://github.com/firebase/firebase-js-sdk/issues/5372
We should not throw from `connection.send` to enable retries.