### PR TITLE
Implement ReCaptchaEnterprise for App Check

### DIFF
--- a/.changeset/ten-impalas-wink.md
+++ b/.changeset/ten-impalas-wink.md
@@ -1,0 +1,6 @@
+---
+'@firebase/app-check': minor
+'@firebase/app-check-compat': minor
+---
+
+Add ReCAPTCHA Enterprise as an attestation option for App Check.

--- a/.changeset/ten-impalas-wink.md
+++ b/.changeset/ten-impalas-wink.md
@@ -1,6 +1,7 @@
 ---
 '@firebase/app-check': minor
 '@firebase/app-check-compat': minor
+'firebase': minor
 ---
 
 Add ReCAPTCHA Enterprise as an attestation option for App Check.

--- a/common/api-review/app-check.api.md
+++ b/common/api-review/app-check.api.md
@@ -22,7 +22,7 @@ export type _AppCheckInternalComponentName = 'app-check-internal';
 // @public
 export interface AppCheckOptions {
     isTokenAutoRefreshEnabled?: boolean;
-    provider: CustomProvider | ReCaptchaV3Provider;
+    provider: CustomProvider | ReCaptchaV3Provider | ReCaptchaEnterpriseProvider;
 }
 
 // @public
@@ -73,6 +73,17 @@ export function onTokenChanged(appCheckInstance: AppCheck, observer: PartialObse
 export function onTokenChanged(appCheckInstance: AppCheck, onNext: (tokenResult: AppCheckTokenResult) => void, onError?: (error: Error) => void, onCompletion?: () => void): Unsubscribe;
 
 export { PartialObserver }
+
+// @public
+export class ReCaptchaEnterpriseProvider implements AppCheckProvider {
+    constructor(_siteKey: string);
+    // @internal
+    getToken(): Promise<AppCheckTokenInternal>;
+    // @internal (undocumented)
+    initialize(app: FirebaseApp): void;
+    // @internal (undocumented)
+    isEqual(otherProvider: unknown): boolean;
+    }
 
 // @public
 export class ReCaptchaV3Provider implements AppCheckProvider {

--- a/packages/app-check-compat/src/index.ts
+++ b/packages/app-check-compat/src/index.ts
@@ -28,7 +28,11 @@ import {
 } from '@firebase/component';
 import { AppCheckService } from './service';
 import { FirebaseAppCheck } from '@firebase/app-check-types';
-import { ReCaptchaV3Provider, CustomProvider } from '@firebase/app-check';
+import {
+  ReCaptchaV3Provider,
+  ReCaptchaEnterpriseProvider,
+  CustomProvider
+} from '@firebase/app-check';
 
 const factory: InstanceFactory<'appCheck-compat'> = (
   container: ComponentContainer
@@ -46,6 +50,7 @@ export function registerAppCheck(): void {
       factory,
       ComponentType.PUBLIC
     ).setServiceProps({
+      ReCaptchaEnterpriseProvider,
       ReCaptchaV3Provider,
       CustomProvider
     })

--- a/packages/app-check-compat/src/service.ts
+++ b/packages/app-check-compat/src/service.ts
@@ -26,6 +26,7 @@ import {
   CustomProvider,
   initializeAppCheck,
   ReCaptchaV3Provider,
+  ReCaptchaEnterpriseProvider,
   setTokenAutoRefreshEnabled as setTokenAutoRefreshEnabledExp,
   getToken as getTokenExp,
   onTokenChanged as onTokenChangedExp
@@ -43,10 +44,14 @@ export class AppCheckService
     siteKeyOrProvider: string | AppCheckProvider,
     isTokenAutoRefreshEnabled?: boolean
   ): void {
-    let provider: ReCaptchaV3Provider | CustomProvider;
+    let provider:
+      | ReCaptchaV3Provider
+      | CustomProvider
+      | ReCaptchaEnterpriseProvider;
     if (typeof siteKeyOrProvider === 'string') {
       provider = new ReCaptchaV3Provider(siteKeyOrProvider);
     } else if (
+      siteKeyOrProvider instanceof ReCaptchaEnterpriseProvider ||
       siteKeyOrProvider instanceof ReCaptchaV3Provider ||
       siteKeyOrProvider instanceof CustomProvider
     ) {

--- a/packages/app-check/src/api.test.ts
+++ b/packages/app-check/src/api.test.ts
@@ -41,7 +41,11 @@ import * as internalApi from './internal-api';
 import * as indexeddb from './indexeddb';
 import * as debug from './debug';
 import { deleteApp, FirebaseApp } from '@firebase/app';
-import { CustomProvider, ReCaptchaEnterpriseProvider, ReCaptchaV3Provider } from './providers';
+import {
+  CustomProvider,
+  ReCaptchaEnterpriseProvider,
+  ReCaptchaV3Provider
+} from './providers';
 import { AppCheckService } from './factory';
 import { AppCheckToken } from './public-types';
 import { getDebugToken } from './debug';

--- a/packages/app-check/src/api.test.ts
+++ b/packages/app-check/src/api.test.ts
@@ -41,7 +41,7 @@ import * as internalApi from './internal-api';
 import * as indexeddb from './indexeddb';
 import * as debug from './debug';
 import { deleteApp, FirebaseApp } from '@firebase/app';
-import { CustomProvider, ReCaptchaV3Provider } from './providers';
+import { CustomProvider, ReCaptchaEnterpriseProvider, ReCaptchaV3Provider } from './providers';
 import { AppCheckService } from './factory';
 import { AppCheckToken } from './public-types';
 import { getDebugToken } from './debug';
@@ -83,6 +83,16 @@ describe('api', () => {
         })
       ).to.throw(/appCheck\/already-initialized/);
     });
+    it('can only be called once (if given different ReCaptchaEnterpriseProviders)', () => {
+      initializeAppCheck(app, {
+        provider: new ReCaptchaEnterpriseProvider(FAKE_SITE_KEY)
+      });
+      expect(() =>
+        initializeAppCheck(app, {
+          provider: new ReCaptchaEnterpriseProvider(FAKE_SITE_KEY + 'X')
+        })
+      ).to.throw(/appCheck\/already-initialized/);
+    });
     it('can only be called once (if given different CustomProviders)', () => {
       initializeAppCheck(app, {
         provider: new CustomProvider({
@@ -104,6 +114,16 @@ describe('api', () => {
       expect(
         initializeAppCheck(app, {
           provider: new ReCaptchaV3Provider(FAKE_SITE_KEY)
+        })
+      ).to.equal(appCheckInstance);
+    });
+    it('can be called multiple times (if given equivalent ReCaptchaEnterpriseProviders)', () => {
+      const appCheckInstance = initializeAppCheck(app, {
+        provider: new ReCaptchaEnterpriseProvider(FAKE_SITE_KEY)
+      });
+      expect(
+        initializeAppCheck(app, {
+          provider: new ReCaptchaEnterpriseProvider(FAKE_SITE_KEY)
         })
       ).to.equal(appCheckInstance);
     });
@@ -175,6 +195,20 @@ describe('api', () => {
       expect(initReCAPTCHAStub).to.have.been.calledWithExactly(
         app,
         FAKE_SITE_KEY
+      );
+    });
+
+    it('initialize reCAPTCHA when a ReCaptchaEnterpriseProvider is provided', () => {
+      const initReCAPTCHAStub = stub(reCAPTCHA, 'initialize').returns(
+        Promise.resolve({} as any)
+      );
+      initializeAppCheck(app, {
+        provider: new ReCaptchaEnterpriseProvider(FAKE_SITE_KEY)
+      });
+      expect(initReCAPTCHAStub).to.have.been.calledWithExactly(
+        app,
+        FAKE_SITE_KEY,
+        true
       );
     });
 

--- a/packages/app-check/src/api.test.ts
+++ b/packages/app-check/src/api.test.ts
@@ -186,7 +186,7 @@ describe('api', () => {
     });
 
     it('initialize reCAPTCHA when a ReCaptchaV3Provider is provided', () => {
-      const initReCAPTCHAStub = stub(reCAPTCHA, 'initialize').returns(
+      const initReCAPTCHAStub = stub(reCAPTCHA, 'initializeV3').returns(
         Promise.resolve({} as any)
       );
       initializeAppCheck(app, {
@@ -199,7 +199,7 @@ describe('api', () => {
     });
 
     it('initialize reCAPTCHA when a ReCaptchaEnterpriseProvider is provided', () => {
-      const initReCAPTCHAStub = stub(reCAPTCHA, 'initialize').returns(
+      const initReCAPTCHAStub = stub(reCAPTCHA, 'initializeEnterprise').returns(
         Promise.resolve({} as any)
       );
       initializeAppCheck(app, {
@@ -207,8 +207,7 @@ describe('api', () => {
       });
       expect(initReCAPTCHAStub).to.have.been.calledWithExactly(
         app,
-        FAKE_SITE_KEY,
-        true
+        FAKE_SITE_KEY
       );
     });
 

--- a/packages/app-check/src/api.ts
+++ b/packages/app-check/src/api.ts
@@ -43,7 +43,11 @@ declare module '@firebase/component' {
   }
 }
 
-export { ReCaptchaV3Provider, CustomProvider } from './providers';
+export {
+  ReCaptchaV3Provider,
+  CustomProvider,
+  ReCaptchaEnterpriseProvider
+} from './providers';
 
 /**
  * Activate App Check for the given app. Can be called only once per app.

--- a/packages/app-check/src/client.test.ts
+++ b/packages/app-check/src/client.test.ts
@@ -20,7 +20,11 @@ import { expect } from 'chai';
 import { stub, SinonStub, useFakeTimers } from 'sinon';
 import { FirebaseApp } from '@firebase/app';
 import { getFakeApp, getFakePlatformLoggingProvider } from '../test/util';
-import { getExchangeRecaptchaV3TokenRequest, exchangeToken, getExchangeRecaptchaEnterpriseTokenRequest } from './client';
+import {
+  getExchangeRecaptchaV3TokenRequest,
+  exchangeToken,
+  getExchangeRecaptchaEnterpriseTokenRequest
+} from './client';
 import { FirebaseError } from '@firebase/util';
 import { ERROR_FACTORY, AppCheckError } from './errors';
 import { BASE_ENDPOINT } from './constants';

--- a/packages/app-check/src/client.test.ts
+++ b/packages/app-check/src/client.test.ts
@@ -60,7 +60,7 @@ describe('client', () => {
     const { projectId, appId, apiKey } = app.options;
 
     expect(request).to.deep.equal({
-      url: `${BASE_ENDPOINT}/projects/${projectId}/apps/${appId}:exchangeRecaptchaToken?key=${apiKey}`,
+      url: `${BASE_ENDPOINT}/projects/${projectId}/apps/${appId}:exchangeRecaptchaEnterpriseToken?key=${apiKey}`,
       body: {
         // eslint-disable-next-line camelcase
         recaptcha_enterprise_token: 'fake-recaptcha-token'

--- a/packages/app-check/src/client.test.ts
+++ b/packages/app-check/src/client.test.ts
@@ -20,7 +20,7 @@ import { expect } from 'chai';
 import { stub, SinonStub, useFakeTimers } from 'sinon';
 import { FirebaseApp } from '@firebase/app';
 import { getFakeApp, getFakePlatformLoggingProvider } from '../test/util';
-import { getExchangeRecaptchaTokenRequest, exchangeToken } from './client';
+import { getExchangeRecaptchaV3TokenRequest, exchangeToken, getExchangeRecaptchaEnterpriseTokenRequest } from './client';
 import { FirebaseError } from '@firebase/util';
 import { ERROR_FACTORY, AppCheckError } from './errors';
 import { BASE_ENDPOINT } from './constants';
@@ -36,7 +36,7 @@ describe('client', () => {
   });
 
   it('creates exchange recaptcha token request correctly', () => {
-    const request = getExchangeRecaptchaTokenRequest(
+    const request = getExchangeRecaptchaV3TokenRequest(
       app,
       'fake-recaptcha-token'
     );
@@ -52,10 +52,9 @@ describe('client', () => {
   });
 
   it('creates exchange recaptcha enterprise token request correctly', () => {
-    const request = getExchangeRecaptchaTokenRequest(
+    const request = getExchangeRecaptchaEnterpriseTokenRequest(
       app,
-      'fake-recaptcha-token',
-      true
+      'fake-recaptcha-token'
     );
     const { projectId, appId, apiKey } = app.options;
 
@@ -82,7 +81,7 @@ describe('client', () => {
     );
 
     const response = await exchangeToken(
-      getExchangeRecaptchaTokenRequest(app, 'fake-custom-token'),
+      getExchangeRecaptchaV3TokenRequest(app, 'fake-custom-token'),
       getFakePlatformLoggingProvider('a/1.2.3 fire-app-check/2.3.4')
     );
 
@@ -110,7 +109,7 @@ describe('client', () => {
 
     try {
       await exchangeToken(
-        getExchangeRecaptchaTokenRequest(app, 'fake-custom-token'),
+        getExchangeRecaptchaV3TokenRequest(app, 'fake-custom-token'),
         getFakePlatformLoggingProvider()
       );
     } catch (e) {
@@ -139,7 +138,7 @@ describe('client', () => {
 
     try {
       await exchangeToken(
-        getExchangeRecaptchaTokenRequest(app, 'fake-custom-token'),
+        getExchangeRecaptchaV3TokenRequest(app, 'fake-custom-token'),
         getFakePlatformLoggingProvider()
       );
     } catch (e) {
@@ -167,7 +166,7 @@ describe('client', () => {
 
     try {
       await exchangeToken(
-        getExchangeRecaptchaTokenRequest(app, 'fake-custom-token'),
+        getExchangeRecaptchaV3TokenRequest(app, 'fake-custom-token'),
         getFakePlatformLoggingProvider()
       );
     } catch (e) {
@@ -201,7 +200,7 @@ describe('client', () => {
 
     try {
       await exchangeToken(
-        getExchangeRecaptchaTokenRequest(app, 'fake-custom-token'),
+        getExchangeRecaptchaV3TokenRequest(app, 'fake-custom-token'),
         getFakePlatformLoggingProvider()
       );
     } catch (e) {

--- a/packages/app-check/src/client.test.ts
+++ b/packages/app-check/src/client.test.ts
@@ -51,6 +51,23 @@ describe('client', () => {
     });
   });
 
+  it('creates exchange recaptcha enterprise token request correctly', () => {
+    const request = getExchangeRecaptchaTokenRequest(
+      app,
+      'fake-recaptcha-token',
+      true
+    );
+    const { projectId, appId, apiKey } = app.options;
+
+    expect(request).to.deep.equal({
+      url: `${BASE_ENDPOINT}/projects/${projectId}/apps/${appId}:exchangeRecaptchaToken?key=${apiKey}`,
+      body: {
+        // eslint-disable-next-line camelcase
+        recaptcha_enterprise_token: 'fake-recaptcha-token'
+      }
+    });
+  });
+
   it('returns a AppCheck token', async () => {
     // To get a consistent expireTime/issuedAtTime.
     const clock = useFakeTimers();

--- a/packages/app-check/src/client.ts
+++ b/packages/app-check/src/client.ts
@@ -105,15 +105,16 @@ export async function exchangeToken(
 
 export function getExchangeRecaptchaTokenRequest(
   app: FirebaseApp,
-  reCAPTCHAToken: string
+  reCAPTCHAToken: string,
+  isEnterprise: boolean = false
 ): AppCheckRequest {
   const { projectId, appId, apiKey } = app.options;
+  const fieldName = isEnterprise ? 'recaptcha_enterprise_token' : 'recaptcha_token';
 
   return {
     url: `${BASE_ENDPOINT}/projects/${projectId}/apps/${appId}:${EXCHANGE_RECAPTCHA_TOKEN_METHOD}?key=${apiKey}`,
     body: {
-      // eslint-disable-next-line
-      recaptcha_token: reCAPTCHAToken
+      [fieldName]: reCAPTCHAToken
     }
   };
 }

--- a/packages/app-check/src/client.ts
+++ b/packages/app-check/src/client.ts
@@ -109,7 +109,9 @@ export function getExchangeRecaptchaTokenRequest(
   isEnterprise: boolean = false
 ): AppCheckRequest {
   const { projectId, appId, apiKey } = app.options;
-  const fieldName = isEnterprise ? 'recaptcha_enterprise_token' : 'recaptcha_token';
+  const fieldName = isEnterprise
+    ? 'recaptcha_enterprise_token'
+    : 'recaptcha_token';
 
   return {
     url: `${BASE_ENDPOINT}/projects/${projectId}/apps/${appId}:${EXCHANGE_RECAPTCHA_TOKEN_METHOD}?key=${apiKey}`,

--- a/packages/app-check/src/client.ts
+++ b/packages/app-check/src/client.ts
@@ -104,23 +104,30 @@ export async function exchangeToken(
   };
 }
 
-export function getExchangeRecaptchaTokenRequest(
+export function getExchangeRecaptchaV3TokenRequest(
   app: FirebaseApp,
-  reCAPTCHAToken: string,
-  isEnterprise: boolean = false
+  reCAPTCHAToken: string
 ): AppCheckRequest {
   const { projectId, appId, apiKey } = app.options;
-  const fieldName = isEnterprise
-    ? 'recaptcha_enterprise_token'
-    : 'recaptcha_token';
-  const exchangeMethod = isEnterprise
-    ? EXCHANGE_RECAPTCHA_ENTERPRISE_TOKEN_METHOD
-    : EXCHANGE_RECAPTCHA_TOKEN_METHOD;
 
   return {
-    url: `${BASE_ENDPOINT}/projects/${projectId}/apps/${appId}:${exchangeMethod}?key=${apiKey}`,
+    url: `${BASE_ENDPOINT}/projects/${projectId}/apps/${appId}:${EXCHANGE_RECAPTCHA_TOKEN_METHOD}?key=${apiKey}`,
     body: {
-      [fieldName]: reCAPTCHAToken
+      'recaptcha_token': reCAPTCHAToken
+    }
+  };
+}
+
+export function getExchangeRecaptchaEnterpriseTokenRequest(
+  app: FirebaseApp,
+  reCAPTCHAToken: string
+): AppCheckRequest {
+  const { projectId, appId, apiKey } = app.options;
+
+  return {
+    url: `${BASE_ENDPOINT}/projects/${projectId}/apps/${appId}:${EXCHANGE_RECAPTCHA_ENTERPRISE_TOKEN_METHOD}?key=${apiKey}`,
+    body: {
+      'recaptcha_enterprise_token': reCAPTCHAToken
     }
   };
 }

--- a/packages/app-check/src/client.ts
+++ b/packages/app-check/src/client.ts
@@ -18,6 +18,7 @@
 import {
   BASE_ENDPOINT,
   EXCHANGE_DEBUG_TOKEN_METHOD,
+  EXCHANGE_RECAPTCHA_ENTERPRISE_TOKEN_METHOD,
   EXCHANGE_RECAPTCHA_TOKEN_METHOD
 } from './constants';
 import { FirebaseApp } from '@firebase/app';
@@ -112,9 +113,12 @@ export function getExchangeRecaptchaTokenRequest(
   const fieldName = isEnterprise
     ? 'recaptcha_enterprise_token'
     : 'recaptcha_token';
+  const exchangeMethod = isEnterprise
+    ? EXCHANGE_RECAPTCHA_ENTERPRISE_TOKEN_METHOD
+    : EXCHANGE_RECAPTCHA_TOKEN_METHOD;
 
   return {
-    url: `${BASE_ENDPOINT}/projects/${projectId}/apps/${appId}:${EXCHANGE_RECAPTCHA_TOKEN_METHOD}?key=${apiKey}`,
+    url: `${BASE_ENDPOINT}/projects/${projectId}/apps/${appId}:${exchangeMethod}?key=${apiKey}`,
     body: {
       [fieldName]: reCAPTCHAToken
     }

--- a/packages/app-check/src/constants.ts
+++ b/packages/app-check/src/constants.ts
@@ -18,7 +18,8 @@ export const BASE_ENDPOINT =
   'https://content-firebaseappcheck.googleapis.com/v1beta';
 
 export const EXCHANGE_RECAPTCHA_TOKEN_METHOD = 'exchangeRecaptchaToken';
-export const EXCHANGE_RECAPTCHA_ENTERPRISE_TOKEN_METHOD = 'exchangeRecaptchaEnterpriseToken';
+export const EXCHANGE_RECAPTCHA_ENTERPRISE_TOKEN_METHOD =
+  'exchangeRecaptchaEnterpriseToken';
 export const EXCHANGE_DEBUG_TOKEN_METHOD = 'exchangeDebugToken';
 
 export const TOKEN_REFRESH_TIME = {

--- a/packages/app-check/src/constants.ts
+++ b/packages/app-check/src/constants.ts
@@ -18,6 +18,7 @@ export const BASE_ENDPOINT =
   'https://content-firebaseappcheck.googleapis.com/v1beta';
 
 export const EXCHANGE_RECAPTCHA_TOKEN_METHOD = 'exchangeRecaptchaToken';
+export const EXCHANGE_RECAPTCHA_ENTERPRISE_TOKEN_METHOD = 'exchangeRecaptchaEnterpriseToken';
 export const EXCHANGE_DEBUG_TOKEN_METHOD = 'exchangeDebugToken';
 
 export const TOKEN_REFRESH_TIME = {

--- a/packages/app-check/src/internal-api.test.ts
+++ b/packages/app-check/src/internal-api.test.ts
@@ -132,9 +132,9 @@ describe('internal api', () => {
 
       expect(reCAPTCHASpy).to.be.called;
 
-      expect(exchangeTokenStub.args[0][0].body['recaptcha_enterprise_token']).to.equal(
-        fakeRecaptchaToken
-      );
+      expect(
+        exchangeTokenStub.args[0][0].body['recaptcha_enterprise_token']
+      ).to.equal(fakeRecaptchaToken);
       expect(token).to.deep.equal({ token: fakeRecaptchaAppCheckToken.token });
     });
 

--- a/packages/app-check/src/internal-api.test.ts
+++ b/packages/app-check/src/internal-api.test.ts
@@ -41,7 +41,7 @@ import * as util from './util';
 import { getState, clearState, setState, getDebugState } from './state';
 import { AppCheckTokenListener } from './public-types';
 import { Deferred } from '@firebase/util';
-import { ReCaptchaV3Provider } from './providers';
+import { ReCaptchaEnterpriseProvider, ReCaptchaV3Provider } from './providers';
 import { AppCheckService } from './factory';
 import { ListenerType } from './types';
 
@@ -92,7 +92,7 @@ describe('internal api', () => {
       });
     });
 
-    it('uses reCAPTCHA token to exchange for AppCheck token', async () => {
+    it('uses reCAPTCHA (V3) token to exchange for AppCheck token', async () => {
       const appCheck = initializeAppCheck(app, {
         provider: new ReCaptchaV3Provider(FAKE_SITE_KEY)
       });
@@ -110,6 +110,29 @@ describe('internal api', () => {
       expect(reCAPTCHASpy).to.be.called;
 
       expect(exchangeTokenStub.args[0][0].body['recaptcha_token']).to.equal(
+        fakeRecaptchaToken
+      );
+      expect(token).to.deep.equal({ token: fakeRecaptchaAppCheckToken.token });
+    });
+
+    it('uses reCAPTCHA (Enterprise) token to exchange for AppCheck token', async () => {
+      const appCheck = initializeAppCheck(app, {
+        provider: new ReCaptchaEnterpriseProvider(FAKE_SITE_KEY)
+      });
+
+      const reCAPTCHASpy = stub(reCAPTCHA, 'getToken').returns(
+        Promise.resolve(fakeRecaptchaToken)
+      );
+      const exchangeTokenStub: SinonStub = stub(
+        client,
+        'exchangeToken'
+      ).returns(Promise.resolve(fakeRecaptchaAppCheckToken));
+
+      const token = await getToken(appCheck as AppCheckService);
+
+      expect(reCAPTCHASpy).to.be.called;
+
+      expect(exchangeTokenStub.args[0][0].body['recaptcha_enterprise_token']).to.equal(
         fakeRecaptchaToken
       );
       expect(token).to.deep.equal({ token: fakeRecaptchaAppCheckToken.token });

--- a/packages/app-check/src/providers.ts
+++ b/packages/app-check/src/providers.ts
@@ -99,8 +99,8 @@ export class ReCaptchaEnterpriseProvider implements AppCheckProvider {
   private _app?: FirebaseApp;
   private _platformLoggerProvider?: Provider<'platform-logger'>;
   /**
-   * Create a ReCaptchaV3Provider instance.
-   * @param siteKey - ReCAPTCHA V3 siteKey.
+   * Create a ReCaptchaEnterpriseProvider instance.
+   * @param siteKey - reCAPTCHA Enterprise score-based site key.
    */
   constructor(private _siteKey: string) {}
 

--- a/packages/app-check/src/providers.ts
+++ b/packages/app-check/src/providers.ts
@@ -18,7 +18,11 @@
 import { FirebaseApp, _getProvider } from '@firebase/app';
 import { Provider } from '@firebase/component';
 import { issuedAtTime } from '@firebase/util';
-import { exchangeToken, getExchangeRecaptchaEnterpriseTokenRequest, getExchangeRecaptchaV3TokenRequest } from './client';
+import {
+  exchangeToken,
+  getExchangeRecaptchaEnterpriseTokenRequest,
+  getExchangeRecaptchaV3TokenRequest
+} from './client';
 import { AppCheckError, ERROR_FACTORY } from './errors';
 import { CustomProviderOptions } from './public-types';
 import {
@@ -50,10 +54,12 @@ export class ReCaptchaV3Provider implements AppCheckProvider {
   async getToken(): Promise<AppCheckTokenInternal> {
     // Top-level `getToken()` has already checked that App Check is initialized
     // and therefore this._app and this._platformLoggerProvider are available.
-    const attestedClaimsToken = await getReCAPTCHAToken(this._app!).catch(_e => {
-      // reCaptcha.execute() throws null which is not very descriptive.
-      throw ERROR_FACTORY.create(AppCheckError.RECAPTCHA_ERROR);
-    });
+    const attestedClaimsToken = await getReCAPTCHAToken(this._app!).catch(
+      _e => {
+        // reCaptcha.execute() throws null which is not very descriptive.
+        throw ERROR_FACTORY.create(AppCheckError.RECAPTCHA_ERROR);
+      }
+    );
     return exchangeToken(
       getExchangeRecaptchaV3TokenRequest(this._app!, attestedClaimsToken),
       this._platformLoggerProvider!
@@ -105,12 +111,17 @@ export class ReCaptchaEnterpriseProvider implements AppCheckProvider {
   async getToken(): Promise<AppCheckTokenInternal> {
     // Top-level `getToken()` has already checked that App Check is initialized
     // and therefore this._app and this._platformLoggerProvider are available.
-    const attestedClaimsToken = await getReCAPTCHAToken(this._app!).catch(_e => {
-      // reCaptcha.execute() throws null which is not very descriptive.
-      throw ERROR_FACTORY.create(AppCheckError.RECAPTCHA_ERROR);
-    });
+    const attestedClaimsToken = await getReCAPTCHAToken(this._app!).catch(
+      _e => {
+        // reCaptcha.execute() throws null which is not very descriptive.
+        throw ERROR_FACTORY.create(AppCheckError.RECAPTCHA_ERROR);
+      }
+    );
     return exchangeToken(
-      getExchangeRecaptchaEnterpriseTokenRequest(this._app!, attestedClaimsToken),
+      getExchangeRecaptchaEnterpriseTokenRequest(
+        this._app!,
+        attestedClaimsToken
+      ),
       this._platformLoggerProvider!
     );
   }

--- a/packages/app-check/src/public-types.ts
+++ b/packages/app-check/src/public-types.ts
@@ -58,7 +58,7 @@ export type _AppCheckComponentName = 'app-check';
  */
 export interface AppCheckOptions {
   /**
-   * reCAPTCHA provider or custom provider.
+   * reCAPTCHA V3 provider, reCAPTCHA Enterprise provider,  or custom provider.
    */
   provider: CustomProvider | ReCaptchaV3Provider | ReCaptchaEnterpriseProvider;
   /**

--- a/packages/app-check/src/public-types.ts
+++ b/packages/app-check/src/public-types.ts
@@ -16,7 +16,11 @@
  */
 
 import { FirebaseApp } from '@firebase/app';
-import { CustomProvider, ReCaptchaV3Provider } from './providers';
+import {
+  CustomProvider,
+  ReCaptchaEnterpriseProvider,
+  ReCaptchaV3Provider
+} from './providers';
 export { Unsubscribe, PartialObserver } from '@firebase/util';
 
 /**
@@ -56,7 +60,7 @@ export interface AppCheckOptions {
   /**
    * reCAPTCHA provider or custom provider.
    */
-  provider: CustomProvider | ReCaptchaV3Provider;
+  provider: CustomProvider | ReCaptchaV3Provider | ReCaptchaEnterpriseProvider;
   /**
    * If set to true, enables automatic background refresh of App Check token.
    */

--- a/packages/app-check/src/public-types.ts
+++ b/packages/app-check/src/public-types.ts
@@ -58,7 +58,7 @@ export type _AppCheckComponentName = 'app-check';
  */
 export interface AppCheckOptions {
   /**
-   * reCAPTCHA V3 provider, reCAPTCHA Enterprise provider,  or custom provider.
+   * A reCAPTCHA V3 provider, reCAPTCHA Enterprise provider, or custom provider.
    */
   provider: CustomProvider | ReCaptchaV3Provider | ReCaptchaEnterpriseProvider;
   /**

--- a/packages/app-check/src/recaptcha.test.ts
+++ b/packages/app-check/src/recaptcha.test.ts
@@ -26,12 +26,12 @@ import {
   findgreCAPTCHAScriptsOnPage,
   FAKE_SITE_KEY
 } from '../test/util';
-import { initialize, getToken } from './recaptcha';
+import { initialize, getToken, GreCAPTCHATopLevel } from './recaptcha';
 import * as utils from './util';
 import { getState } from './state';
 import { Deferred } from '@firebase/util';
 import { initializeAppCheck } from './api';
-import { ReCaptchaV3Provider } from './providers';
+import { ReCaptchaEnterpriseProvider, ReCaptchaV3Provider } from './providers';
 
 describe('recaptcha', () => {
   let app: FirebaseApp;
@@ -45,9 +45,9 @@ describe('recaptcha', () => {
     return deleteApp(app);
   });
 
-  describe('initialize()', () => {
+  describe('initialize() - V3', () => {
     it('sets reCAPTCHAState', async () => {
-      self.grecaptcha = getFakeGreCAPTCHA();
+      self.grecaptcha = getFakeGreCAPTCHA() as GreCAPTCHATopLevel;
       expect(getState(app).reCAPTCHAState).to.equal(undefined);
       await initialize(app, FAKE_SITE_KEY);
       expect(getState(app).reCAPTCHAState?.initialized).to.be.instanceof(
@@ -75,7 +75,7 @@ describe('recaptcha', () => {
     it('creates invisible widget', async () => {
       const grecaptchaFake = getFakeGreCAPTCHA();
       const renderStub = stub(grecaptchaFake, 'render').callThrough();
-      self.grecaptcha = grecaptchaFake;
+      self.grecaptcha = grecaptchaFake as GreCAPTCHATopLevel;
 
       await initialize(app, FAKE_SITE_KEY);
 
@@ -88,7 +88,50 @@ describe('recaptcha', () => {
     });
   });
 
-  describe('getToken()', () => {
+  describe('initialize() - Enterprise', () => {
+    it('sets reCAPTCHAState', async () => {
+      self.grecaptcha = getFakeGreCAPTCHA() as GreCAPTCHATopLevel;
+      expect(getState(app).reCAPTCHAState).to.equal(undefined);
+      await initialize(app, FAKE_SITE_KEY, true);
+      expect(getState(app).reCAPTCHAState?.initialized).to.be.instanceof(
+        Deferred
+      );
+    });
+
+    it('loads reCAPTCHA script if it was not loaded already', async () => {
+      const fakeRecaptcha = getFakeGreCAPTCHA();
+      let count = 0;
+      stub(utils, 'getRecaptcha').callsFake(() => {
+        count++;
+        if (count === 1) {
+          return undefined;
+        }
+
+        return fakeRecaptcha;
+      });
+
+      expect(findgreCAPTCHAScriptsOnPage().length).to.equal(0);
+      await initialize(app, FAKE_SITE_KEY, true);
+      expect(findgreCAPTCHAScriptsOnPage().length).to.equal(1);
+    });
+
+    it('creates invisible widget', async () => {
+      const grecaptchaFake = getFakeGreCAPTCHA() as GreCAPTCHATopLevel;
+      const renderStub = stub(grecaptchaFake.enterprise, 'render').callThrough();
+      self.grecaptcha = grecaptchaFake;
+
+      await initialize(app, FAKE_SITE_KEY, true);
+
+      expect(renderStub).to.be.calledWith(`fire_app_check_${app.name}`, {
+        sitekey: FAKE_SITE_KEY,
+        size: 'invisible'
+      });
+
+      expect(getState(app).reCAPTCHAState?.widgetId).to.equal('fake_widget_1');
+    });
+  });
+
+  describe('getToken() - V3', () => {
     it('throws if AppCheck has not been activated yet', () => {
       return expect(getToken(app)).to.eventually.rejectedWith(
         /appCheck\/use-before-activation/
@@ -100,7 +143,7 @@ describe('recaptcha', () => {
       const executeStub = stub(grecaptchaFake, 'execute').returns(
         Promise.resolve('fake-recaptcha-token')
       );
-      self.grecaptcha = grecaptchaFake;
+      self.grecaptcha = grecaptchaFake as GreCAPTCHATopLevel;
       initializeAppCheck(app, {
         provider: new ReCaptchaV3Provider(FAKE_SITE_KEY)
       });
@@ -116,9 +159,41 @@ describe('recaptcha', () => {
       stub(grecaptchaFake, 'execute').returns(
         Promise.resolve('fake-recaptcha-token')
       );
-      self.grecaptcha = grecaptchaFake;
+      self.grecaptcha = grecaptchaFake as GreCAPTCHATopLevel;
       initializeAppCheck(app, {
         provider: new ReCaptchaV3Provider(FAKE_SITE_KEY)
+      });
+      const token = await getToken(app);
+
+      expect(token).to.equal('fake-recaptcha-token');
+    });
+  });
+
+  describe('getToken() - Enterprise', () => {
+    it('calls recaptcha.execute with correct widgetId', async () => {
+      const grecaptchaFake = getFakeGreCAPTCHA() as GreCAPTCHATopLevel;
+      const executeStub = stub(grecaptchaFake.enterprise, 'execute').returns(
+        Promise.resolve('fake-recaptcha-token')
+      );
+      self.grecaptcha = grecaptchaFake;
+      initializeAppCheck(app, {
+        provider: new ReCaptchaEnterpriseProvider(FAKE_SITE_KEY)
+      });
+      await getToken(app);
+
+      expect(executeStub).to.have.been.calledWith('fake_widget_1', {
+        action: 'fire_app_check'
+      });
+    });
+
+    it('resolves with token returned by recaptcha.execute', async () => {
+      const grecaptchaFake = getFakeGreCAPTCHA() as GreCAPTCHATopLevel;
+      stub(grecaptchaFake.enterprise, 'execute').returns(
+        Promise.resolve('fake-recaptcha-token')
+      );
+      self.grecaptcha = grecaptchaFake;
+      initializeAppCheck(app, {
+        provider: new ReCaptchaEnterpriseProvider(FAKE_SITE_KEY)
       });
       const token = await getToken(app);
 

--- a/packages/app-check/src/recaptcha.test.ts
+++ b/packages/app-check/src/recaptcha.test.ts
@@ -26,7 +26,12 @@ import {
   findgreCAPTCHAScriptsOnPage,
   FAKE_SITE_KEY
 } from '../test/util';
-import { initializeV3, initializeEnterprise, getToken, GreCAPTCHATopLevel } from './recaptcha';
+import {
+  initializeV3,
+  initializeEnterprise,
+  getToken,
+  GreCAPTCHATopLevel
+} from './recaptcha';
 import * as utils from './util';
 import { getState } from './state';
 import { Deferred } from '@firebase/util';

--- a/packages/app-check/src/recaptcha.test.ts
+++ b/packages/app-check/src/recaptcha.test.ts
@@ -26,7 +26,7 @@ import {
   findgreCAPTCHAScriptsOnPage,
   FAKE_SITE_KEY
 } from '../test/util';
-import { initialize, getToken, GreCAPTCHATopLevel } from './recaptcha';
+import { initializeV3, initializeEnterprise, getToken, GreCAPTCHATopLevel } from './recaptcha';
 import * as utils from './util';
 import { getState } from './state';
 import { Deferred } from '@firebase/util';
@@ -49,7 +49,7 @@ describe('recaptcha', () => {
     it('sets reCAPTCHAState', async () => {
       self.grecaptcha = getFakeGreCAPTCHA() as GreCAPTCHATopLevel;
       expect(getState(app).reCAPTCHAState).to.equal(undefined);
-      await initialize(app, FAKE_SITE_KEY);
+      await initializeV3(app, FAKE_SITE_KEY);
       expect(getState(app).reCAPTCHAState?.initialized).to.be.instanceof(
         Deferred
       );
@@ -68,7 +68,7 @@ describe('recaptcha', () => {
       });
 
       expect(findgreCAPTCHAScriptsOnPage().length).to.equal(0);
-      await initialize(app, FAKE_SITE_KEY);
+      await initializeV3(app, FAKE_SITE_KEY);
       expect(findgreCAPTCHAScriptsOnPage().length).to.equal(1);
     });
 
@@ -77,7 +77,7 @@ describe('recaptcha', () => {
       const renderStub = stub(grecaptchaFake, 'render').callThrough();
       self.grecaptcha = grecaptchaFake as GreCAPTCHATopLevel;
 
-      await initialize(app, FAKE_SITE_KEY);
+      await initializeV3(app, FAKE_SITE_KEY);
 
       expect(renderStub).to.be.calledWith(`fire_app_check_${app.name}`, {
         sitekey: FAKE_SITE_KEY,
@@ -92,7 +92,7 @@ describe('recaptcha', () => {
     it('sets reCAPTCHAState', async () => {
       self.grecaptcha = getFakeGreCAPTCHA() as GreCAPTCHATopLevel;
       expect(getState(app).reCAPTCHAState).to.equal(undefined);
-      await initialize(app, FAKE_SITE_KEY, true);
+      await initializeEnterprise(app, FAKE_SITE_KEY);
       expect(getState(app).reCAPTCHAState?.initialized).to.be.instanceof(
         Deferred
       );
@@ -111,7 +111,7 @@ describe('recaptcha', () => {
       });
 
       expect(findgreCAPTCHAScriptsOnPage().length).to.equal(0);
-      await initialize(app, FAKE_SITE_KEY, true);
+      await initializeEnterprise(app, FAKE_SITE_KEY);
       expect(findgreCAPTCHAScriptsOnPage().length).to.equal(1);
     });
 
@@ -123,7 +123,7 @@ describe('recaptcha', () => {
       ).callThrough();
       self.grecaptcha = grecaptchaFake;
 
-      await initialize(app, FAKE_SITE_KEY, true);
+      await initializeEnterprise(app, FAKE_SITE_KEY);
 
       expect(renderStub).to.be.calledWith(`fire_app_check_${app.name}`, {
         sitekey: FAKE_SITE_KEY,

--- a/packages/app-check/src/recaptcha.test.ts
+++ b/packages/app-check/src/recaptcha.test.ts
@@ -117,7 +117,10 @@ describe('recaptcha', () => {
 
     it('creates invisible widget', async () => {
       const grecaptchaFake = getFakeGreCAPTCHA() as GreCAPTCHATopLevel;
-      const renderStub = stub(grecaptchaFake.enterprise, 'render').callThrough();
+      const renderStub = stub(
+        grecaptchaFake.enterprise,
+        'render'
+      ).callThrough();
       self.grecaptcha = grecaptchaFake;
 
       await initialize(app, FAKE_SITE_KEY, true);

--- a/packages/app-check/src/recaptcha.ts
+++ b/packages/app-check/src/recaptcha.ts
@@ -24,46 +24,90 @@ export const RECAPTCHA_URL = 'https://www.google.com/recaptcha/api.js';
 export const RECAPTCHA_ENTERPRISE_URL =
   'https://www.google.com/recaptcha/enterprise.js';
 
-export function initialize(
+export function initializeV3(
   app: FirebaseApp,
-  siteKey: string,
-  isEnterprise: boolean = false
+  siteKey: string
 ): Promise<GreCAPTCHA> {
   const state = getState(app);
   const initialized = new Deferred<GreCAPTCHA>();
 
   setState(app, { ...state, reCAPTCHAState: { initialized } });
+  const divId = makeDiv(app);
 
-  const divId = `fire_app_check_${app.name}`;
-  const invisibleDiv = document.createElement('div');
-  invisibleDiv.id = divId;
-  invisibleDiv.style.display = 'none';
-
-  document.body.appendChild(invisibleDiv);
-
-  const grecaptcha = getRecaptcha(isEnterprise);
+  const grecaptcha = getRecaptcha(false);
   if (!grecaptcha) {
-    loadReCAPTCHAScript(() => {
-      const grecaptcha = getRecaptcha(isEnterprise);
+    loadReCAPTCHAV3Script(() => {
+      const grecaptcha = getRecaptcha(false);
 
       if (!grecaptcha) {
         // it shouldn't happen.
         throw new Error('no recaptcha');
       }
-      grecaptcha.ready(() => {
-        // Invisible widgets allow us to set a different siteKey for each widget, so we use them to support multiple apps
-        renderInvisibleWidget(app, siteKey, grecaptcha, divId);
-        initialized.resolve(grecaptcha);
-      });
-    }, isEnterprise);
-  } else {
-    grecaptcha.ready(() => {
-      renderInvisibleWidget(app, siteKey, grecaptcha, divId);
-      initialized.resolve(grecaptcha);
+      queueWidgetRender(app, siteKey, grecaptcha, divId, initialized);
     });
+  } else {
+    queueWidgetRender(app, siteKey, grecaptcha, divId, initialized);
   }
-
   return initialized.promise;
+}
+export function initializeEnterprise(
+  app: FirebaseApp,
+  siteKey: string
+): Promise<GreCAPTCHA> {
+  const state = getState(app);
+  const initialized = new Deferred<GreCAPTCHA>();
+
+  setState(app, { ...state, reCAPTCHAState: { initialized } });
+  const divId = makeDiv(app);
+
+  const grecaptcha = getRecaptcha(true);
+  if (!grecaptcha) {
+    loadReCAPTCHAEnterpriseScript(() => {
+      const grecaptcha = getRecaptcha(true);
+
+      if (!grecaptcha) {
+        // it shouldn't happen.
+        throw new Error('no recaptcha');
+      }
+      queueWidgetRender(app, siteKey, grecaptcha, divId, initialized);
+    });
+  } else {
+    queueWidgetRender(app, siteKey, grecaptcha, divId, initialized);
+  }
+  return initialized.promise;
+}
+
+/**
+ * Add listener to render the widget and resolve the promise when
+ * the grecaptcha.ready() event fires.
+ */
+function queueWidgetRender(
+  app: FirebaseApp,
+  siteKey: string,
+  grecaptcha: GreCAPTCHA,
+  container: string,
+  initialized: Deferred<GreCAPTCHA>): void {
+  grecaptcha.ready(() => {
+    // Invisible widgets allow us to set a different siteKey for each widget,
+    // so we use them to support multiple apps
+    renderInvisibleWidget(app, siteKey, grecaptcha, container);
+    initialized.resolve(grecaptcha);
+  });
+}
+
+/**
+ * Add invisible div to page.
+ */
+function makeDiv(
+  app: FirebaseApp): string {
+
+    const divId = `fire_app_check_${app.name}`;
+    const invisibleDiv = document.createElement('div');
+    invisibleDiv.id = divId;
+    invisibleDiv.style.display = 'none';
+  
+    document.body.appendChild(invisibleDiv);
+    return divId;
 }
 
 export async function getToken(app: FirebaseApp): Promise<string> {
@@ -114,12 +158,20 @@ function renderInvisibleWidget(
   });
 }
 
-function loadReCAPTCHAScript(
-  onload: () => void,
-  isEnterprise: boolean = false
+function loadReCAPTCHAV3Script(
+  onload: () => void
 ): void {
   const script = document.createElement('script');
-  script.src = isEnterprise ? RECAPTCHA_ENTERPRISE_URL : RECAPTCHA_URL;
+  script.src = RECAPTCHA_URL;
+  script.onload = onload;
+  document.head.appendChild(script);
+}
+
+function loadReCAPTCHAEnterpriseScript(
+  onload: () => void
+): void {
+  const script = document.createElement('script');
+  script.src = RECAPTCHA_ENTERPRISE_URL;
   script.onload = onload;
   document.head.appendChild(script);
 }

--- a/packages/app-check/src/recaptcha.ts
+++ b/packages/app-check/src/recaptcha.ts
@@ -24,7 +24,8 @@ export const RECAPTCHA_URL = 'https://www.google.com/recaptcha/api.js';
 
 export function initialize(
   app: FirebaseApp,
-  siteKey: string
+  siteKey: string,
+  isEnterprise: boolean = false
 ): Promise<GreCAPTCHA> {
   const state = getState(app);
   const initialized = new Deferred<GreCAPTCHA>();
@@ -38,10 +39,10 @@ export function initialize(
 
   document.body.appendChild(invisibleDiv);
 
-  const grecaptcha = getRecaptcha();
+  const grecaptcha = getRecaptcha(isEnterprise);
   if (!grecaptcha) {
     loadReCAPTCHAScript(() => {
-      const grecaptcha = getRecaptcha();
+      const grecaptcha = getRecaptcha(isEnterprise);
 
       if (!grecaptcha) {
         // it shouldn't happen.
@@ -120,8 +121,12 @@ function loadReCAPTCHAScript(onload: () => void): void {
 
 declare global {
   interface Window {
-    grecaptcha: GreCAPTCHA | undefined;
+    grecaptcha: GreCAPTCHATopLevel | undefined;
   }
+}
+
+export interface GreCAPTCHATopLevel extends GreCAPTCHA {
+  enterprise: GreCAPTCHA;
 }
 
 export interface GreCAPTCHA {

--- a/packages/app-check/src/recaptcha.ts
+++ b/packages/app-check/src/recaptcha.ts
@@ -21,6 +21,7 @@ import { Deferred } from '@firebase/util';
 import { getRecaptcha, ensureActivated } from './util';
 
 export const RECAPTCHA_URL = 'https://www.google.com/recaptcha/api.js';
+export const RECAPTCHA_ENTERPRISE_URL = 'https://www.google.com/recaptcha/enterprise.js';
 
 export function initialize(
   app: FirebaseApp,
@@ -53,7 +54,7 @@ export function initialize(
         renderInvisibleWidget(app, siteKey, grecaptcha, divId);
         initialized.resolve(grecaptcha);
       });
-    });
+    }, isEnterprise);
   } else {
     grecaptcha.ready(() => {
       renderInvisibleWidget(app, siteKey, grecaptcha, divId);
@@ -112,9 +113,9 @@ function renderInvisibleWidget(
   });
 }
 
-function loadReCAPTCHAScript(onload: () => void): void {
+function loadReCAPTCHAScript(onload: () => void, isEnterprise: boolean = false): void {
   const script = document.createElement('script');
-  script.src = `${RECAPTCHA_URL}`;
+  script.src = isEnterprise ? RECAPTCHA_ENTERPRISE_URL : RECAPTCHA_URL;
   script.onload = onload;
   document.head.appendChild(script);
 }

--- a/packages/app-check/src/recaptcha.ts
+++ b/packages/app-check/src/recaptcha.ts
@@ -21,7 +21,8 @@ import { Deferred } from '@firebase/util';
 import { getRecaptcha, ensureActivated } from './util';
 
 export const RECAPTCHA_URL = 'https://www.google.com/recaptcha/api.js';
-export const RECAPTCHA_ENTERPRISE_URL = 'https://www.google.com/recaptcha/enterprise.js';
+export const RECAPTCHA_ENTERPRISE_URL =
+  'https://www.google.com/recaptcha/enterprise.js';
 
 export function initialize(
   app: FirebaseApp,
@@ -113,7 +114,10 @@ function renderInvisibleWidget(
   });
 }
 
-function loadReCAPTCHAScript(onload: () => void, isEnterprise: boolean = false): void {
+function loadReCAPTCHAScript(
+  onload: () => void,
+  isEnterprise: boolean = false
+): void {
   const script = document.createElement('script');
   script.src = isEnterprise ? RECAPTCHA_ENTERPRISE_URL : RECAPTCHA_URL;
   script.onload = onload;

--- a/packages/app-check/src/recaptcha.ts
+++ b/packages/app-check/src/recaptcha.ts
@@ -86,7 +86,8 @@ function queueWidgetRender(
   siteKey: string,
   grecaptcha: GreCAPTCHA,
   container: string,
-  initialized: Deferred<GreCAPTCHA>): void {
+  initialized: Deferred<GreCAPTCHA>
+): void {
   grecaptcha.ready(() => {
     // Invisible widgets allow us to set a different siteKey for each widget,
     // so we use them to support multiple apps
@@ -98,16 +99,14 @@ function queueWidgetRender(
 /**
  * Add invisible div to page.
  */
-function makeDiv(
-  app: FirebaseApp): string {
+function makeDiv(app: FirebaseApp): string {
+  const divId = `fire_app_check_${app.name}`;
+  const invisibleDiv = document.createElement('div');
+  invisibleDiv.id = divId;
+  invisibleDiv.style.display = 'none';
 
-    const divId = `fire_app_check_${app.name}`;
-    const invisibleDiv = document.createElement('div');
-    invisibleDiv.id = divId;
-    invisibleDiv.style.display = 'none';
-  
-    document.body.appendChild(invisibleDiv);
-    return divId;
+  document.body.appendChild(invisibleDiv);
+  return divId;
 }
 
 export async function getToken(app: FirebaseApp): Promise<string> {
@@ -158,18 +157,14 @@ function renderInvisibleWidget(
   });
 }
 
-function loadReCAPTCHAV3Script(
-  onload: () => void
-): void {
+function loadReCAPTCHAV3Script(onload: () => void): void {
   const script = document.createElement('script');
   script.src = RECAPTCHA_URL;
   script.onload = onload;
   document.head.appendChild(script);
 }
 
-function loadReCAPTCHAEnterpriseScript(
-  onload: () => void
-): void {
+function loadReCAPTCHAEnterpriseScript(onload: () => void): void {
   const script = document.createElement('script');
   script.src = RECAPTCHA_ENTERPRISE_URL;
   script.onload = onload;

--- a/packages/app-check/src/util.ts
+++ b/packages/app-check/src/util.ts
@@ -20,7 +20,9 @@ import { getState } from './state';
 import { ERROR_FACTORY, AppCheckError } from './errors';
 import { FirebaseApp } from '@firebase/app';
 
-export function getRecaptcha(isEnterprise: boolean = false): GreCAPTCHA | undefined {
+export function getRecaptcha(
+  isEnterprise: boolean = false
+): GreCAPTCHA | undefined {
   if (isEnterprise) {
     return self.grecaptcha?.enterprise;
   }

--- a/packages/app-check/src/util.ts
+++ b/packages/app-check/src/util.ts
@@ -20,7 +20,10 @@ import { getState } from './state';
 import { ERROR_FACTORY, AppCheckError } from './errors';
 import { FirebaseApp } from '@firebase/app';
 
-export function getRecaptcha(): GreCAPTCHA | undefined {
+export function getRecaptcha(isEnterprise: boolean = false): GreCAPTCHA | undefined {
+  if (isEnterprise) {
+    return self.grecaptcha?.enterprise;
+  }
   return self.grecaptcha;
 }
 

--- a/packages/app-check/test/util.ts
+++ b/packages/app-check/test/util.ts
@@ -16,7 +16,11 @@
  */
 
 import { FirebaseApp, initializeApp, _registerComponent } from '@firebase/app';
-import { GreCAPTCHA, RECAPTCHA_URL } from '../src/recaptcha';
+import {
+  GreCAPTCHA,
+  GreCAPTCHATopLevel,
+  RECAPTCHA_URL
+} from '../src/recaptcha';
 import {
   Provider,
   ComponentContainer,
@@ -102,12 +106,19 @@ export function getFakePlatformLoggingProvider(
   return container.getProvider('platform-logger');
 }
 
-export function getFakeGreCAPTCHA(): GreCAPTCHA {
-  return {
+export function getFakeGreCAPTCHA(
+  isTopLevel: boolean = true
+): GreCAPTCHATopLevel | GreCAPTCHA {
+  const greCaptchaTopLevel: GreCAPTCHA = {
     ready: callback => callback(),
     render: (_container, _parameters) => 'fake_widget_1',
     execute: (_siteKey, _options) => Promise.resolve('fake_recaptcha_token')
   };
+  if (isTopLevel) {
+    (greCaptchaTopLevel as GreCAPTCHATopLevel).enterprise =
+      getFakeGreCAPTCHA(false);
+  }
+  return greCaptchaTopLevel;
 }
 
 /**

--- a/packages/app-check/test/util.ts
+++ b/packages/app-check/test/util.ts
@@ -19,6 +19,7 @@ import { FirebaseApp, initializeApp, _registerComponent } from '@firebase/app';
 import {
   GreCAPTCHA,
   GreCAPTCHATopLevel,
+  RECAPTCHA_ENTERPRISE_URL,
   RECAPTCHA_URL
 } from '../src/recaptcha';
 import {
@@ -130,7 +131,11 @@ export function findgreCAPTCHAScriptsOnPage(): HTMLScriptElement[] {
   const scriptTags = window.document.getElementsByTagName('script');
   const tags = [];
   for (const tag of Object.values(scriptTags)) {
-    if (tag.src && tag.src.includes(RECAPTCHA_URL)) {
+    if (
+      tag.src &&
+      (tag.src.includes(RECAPTCHA_URL) ||
+        tag.src.includes(RECAPTCHA_ENTERPRISE_URL))
+    ) {
       tags.push(tag);
     }
   }

--- a/packages/firebase/compat/index.d.ts
+++ b/packages/firebase/compat/index.d.ts
@@ -1543,20 +1543,20 @@ declare namespace firebase.appCheck {
     token: string;
   }
   /*
-   * ReCAPTCHA v3 token provider.
+   * reCAPTCHA v3 token provider.
    */
   class ReCaptchaV3Provider {
     /**
-     * @param siteKey - ReCAPTCHA v3 site key (public key).
+     * @param siteKey - reCAPTCHA v3 site key (public key).
      */
     constructor(siteKey: string);
   }
   /*
-   * ReCAPTCHA Enterprise token provider.
+   * reCAPTCHA Enterprise token provider.
    */
   class ReCaptchaEnterpriseProvider {
     /**
-     * @param keyId - ReCAPTCHA Enterprise key ID.
+     * @param keyId - reCAPTCHA Enterprise key ID.
      */
     constructor(keyId: string);
   }

--- a/packages/firebase/compat/index.d.ts
+++ b/packages/firebase/compat/index.d.ts
@@ -1552,6 +1552,15 @@ declare namespace firebase.appCheck {
     constructor(siteKey: string);
   }
   /*
+   * ReCAPTCHA Enterprise token provider.
+   */
+  class ReCaptchaEnterpriseProvider {
+    /**
+     * @param keyId - ReCAPTCHA Enterprise key ID.
+     */
+    constructor(keyId: string);
+  }
+  /*
    * Custom token provider.
    */
   class CustomProvider {
@@ -1581,8 +1590,8 @@ declare namespace firebase.appCheck {
     /**
      * Activate AppCheck
      * @param provider This can be a `ReCaptchaV3Provider` instance,
-     * a `CustomProvider` instance, an object with a custom `getToken()`
-     * method, or a reCAPTCHA site key.
+     * a `ReCaptchaEnterpriseProvider` instance, a `CustomProvider` instance,
+     * an object with a custom `getToken()` method, or a reCAPTCHA site key.
      * @param isTokenAutoRefreshEnabled If true, the SDK automatically
      * refreshes App Check tokens as needed. If undefined, defaults to the
      * value of `app.automaticDataCollectionEnabled`, which defaults to
@@ -1591,6 +1600,7 @@ declare namespace firebase.appCheck {
     activate(
       provider:
         | ReCaptchaV3Provider
+        | ReCaptchaEnterpriseProvider
         | CustomProvider
         | AppCheckProvider
         | { getToken: () => AppCheckToken }


### PR DESCRIPTION
Add `ReCaptchaEnterpriseProvider` and associated methods to `app-check` and `app-check-compat`.

E2E tests were successful.

We want to coordinate the release with iOS/Android, do not merge until the coordinated date (TBD).