### PR TITLE
Fix AuthError incoherent structure.

### DIFF
--- a/packages/auth/src/model/public_types.ts
+++ b/packages/auth/src/model/public_types.ts
@@ -117,7 +117,8 @@ export type NextOrObserver<T> = NextFn<T | null> | Observer<T | null>;
 
 /**
  * Interface for an `Auth` error.
- * 
+ *
+ *
  * @public
  */
 export declare interface AuthError extends FirebaseError {
@@ -138,7 +139,8 @@ export declare interface AuthError extends FirebaseError {
      * after redirection.
      */
     readonly tenantId?: string;
-  };}
+  };
+}
 
 /**
  * Interface representing an {@link Auth} instance's settings.


### PR DESCRIPTION
Add a AuthErrorData interface for customData in `FirebaseError`
Change tenantid to tenantId, other tenantId are formatted like this, better than smallcase since ID is a "word"

### Discussion

this closes #5599  

### More TODOs

- [ ] Update [this offical document page](https://firebase.google.com/docs/reference/js/auth.autherror)

### Testing

I don't know how to test for this specific issue.

### API Changes

NONE
