### PR TITLE
Add GHA workflow for submitting tags to metric service.

### DIFF
--- a/.github/workflows/health-metrics-presubmit.yml
+++ b/.github/workflows/health-metrics-presubmit.yml
@@ -3,6 +3,10 @@ name: Health Metrics
 on: [push, pull_request]
 
 env:
+<<<<<<< HEAD:.github/workflows/health-metrics-test.yml
+=======
+  METRICS_SERVICE_URL: "https://api.firebase-sdk-health-metrics.com"
+>>>>>>> 7b37f3376 (Add GHA workflow for submitting tags to metric service.):.github/workflows/health-metrics-presubmit.yml
   GITHUB_PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
   # TODO(yifany): parse from git commit history directly
   #   Reason: actions/checkout@v2 does not always honor ${{ github.event.pull_request.base.sha }},

--- a/.github/workflows/health-metrics-pull-request.yml
+++ b/.github/workflows/health-metrics-pull-request.yml
@@ -3,10 +3,6 @@ name: Health Metrics
 on: [push, pull_request]
 
 env:
-<<<<<<< HEAD:.github/workflows/health-metrics-test.yml
-=======
-  METRICS_SERVICE_URL: "https://api.firebase-sdk-health-metrics.com"
->>>>>>> 7b37f3376 (Add GHA workflow for submitting tags to metric service.):.github/workflows/health-metrics-presubmit.yml
   GITHUB_PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
   # TODO(yifany): parse from git commit history directly
   #   Reason: actions/checkout@v2 does not always honor ${{ github.event.pull_request.base.sha }},

--- a/.github/workflows/health-metrics-release.yml
+++ b/.github/workflows/health-metrics-release.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: google-github-actions/setup-gcloud@master
         with:
           service_account_key: ${{ secrets.GCP_SA_KEY }}
-      - uses: yifanyang/github-actions/health-metrics/release-diffing@master
+      - uses: FirebaseExtended/github-actions/health-metrics/release-diffing@master
         with:
           repo: ${{ github.repository }}
           ref: ${{ github.ref }}

--- a/.github/workflows/health-metrics-release.yml
+++ b/.github/workflows/health-metrics-release.yml
@@ -1,0 +1,19 @@
+name: Health Metrics
+
+on:
+  push:
+    tags: ['**']
+
+jobs:
+  release-diffing:
+    name: Release Diffing
+    runs-on: ubuntu-latest
+    steps:
+      - uses: google-github-actions/setup-gcloud@master
+        with:
+          service_account_key: ${{ secrets.GCP_SA_KEY }}
+      - uses: yifanyang/github-actions/health-metrics/release-diffing@master
+        with:
+          repo: ${{ github.repository }}
+          ref: ${{ github.ref }}
+          commit: ${{ github.sha }}


### PR DESCRIPTION
Add a GitHub Actions workflow file for submitting the tags information (name, commit sha1) to the SDK metric service.

- [x] ~The custom action `yifanyang/github-actions/health-metrics/release-diffing` is defined [here](https://github.com/yifanyang/github-actions/pull/1/files). I intend to have it reused across all Android/Apple/Web SDK repositories. For now, I'm putting it in my personal repository `yifanyang/github-actions`, but will figure out later where the best location for the code is.~ 
 The action is open sourced at https://github.com/FirebaseExtended/github-actions/tree/master/health-metrics/release-diffing.
- [x] ~At the moment, on the metric service end, only the logic of persisting tag information is implemented. Upon submission of this PR, we will be start to see tags stored in the database. I will send out the bundle definitions for you folks to review soon, so that we can associate releases/tags with meaningful metric data.~
 The bundle definitions are to be added in #5706.