### PR TITLE
Fix compat doc script

### DIFF
--- a/scripts/docgen-compat/generate-docs.js
+++ b/scripts/docgen-compat/generate-docs.js
@@ -39,11 +39,12 @@ const { api: apiType, source: sourceFile } = yargs
   .version(false)
   .help().argv;
 
-const docPath = path.resolve(`${__dirname}/html/${apiType}`);
+const destinationDir = apiType === 'js' ? 'js/v8' : apiType;
+const docPath = path.resolve(`${__dirname}/html/${destinationDir}`);
 const contentPath = path.resolve(`${__dirname}/content-sources/${apiType}`);
 const tempHomePath = path.resolve(`${contentPath}/HOME_TEMP.md`);
 const tempNodeSourcePath = path.resolve(`${__dirname}/index.node.d.ts`);
-const devsitePath = `/docs/reference/${apiType}/`;
+const devsitePath = `/docs/reference/${destinationDir}/`;
 
 /**
  * Strips path prefix and returns only filename.


### PR DESCRIPTION
Recently changed TOC to point to new devsite path js/v8. This causes some trouble for the file name checker as it checks against the TOC names. Could do some string search/replace in both directions, or could just put the files into a v8 subdirectory, which seems easier.

Also needs CL:
https://critique-ng.corp.google.com/cl/402381226