### PR TITLE
fix interface AuthError

### DIFF
--- a/packages/auth/src/model/public_types.ts
+++ b/packages/auth/src/model/public_types.ts
@@ -120,7 +120,7 @@ export type NextOrObserver<T> = NextFn<T | null> | Observer<T | null>;
  *
  * @public
  */
-export declare interface AuthError extends FirebaseError {
+export interface AuthError extends FirebaseError {
   /** The detailed Data of the Firebase Auth error.  */
   readonly customData: {
     /** The name of the Firebase App which triggered this error.  */


### PR DESCRIPTION
Extend interface `FirebaseError` to `AuthError` with correct customData
Change tenantid to tenantId, other tenantId are formatted like this, better than smallcase since ID is a "word"

### Discussion
moved from #5600 
this closes #5599

### More TODOs
- [ ] Update [this offical document page](https://firebase.google.com/docs/reference/js/auth.autherror)

### Testing
I don't know how to test for this specific issue.

### API Changes
NONE