### PR TITLE
Allow type T in WithFieldValue<T>

### DIFF
--- a/.changeset/dry-toes-hammer.md
+++ b/.changeset/dry-toes-hammer.md
@@ -1,6 +1,6 @@
 ---
 "@firebase/auth-compat": minor
-"@firebase/auth": minor,
+"@firebase/auth": minor
 "firebase": minor
 ---
 

--- a/.changeset/short-mice-itch.md
+++ b/.changeset/short-mice-itch.md
@@ -2,4 +2,4 @@
 '@firebase/firestore': minor
 ---
 
-Expanded `Firestore.WithFieldValue<T>` to include `T`. This allows developers to delegate `WithFieldValue<T>` inside a wrappers of type `T` to avoid exposing Firebase types beyond Firebase-specific logic.
+Expanded `Firestore.WithFieldValue<T>` to include `T`. This allows developers to delegate `WithFieldValue<T>` inside wrappers of type `T` to avoid exposing Firebase types beyond Firebase-specific logic.

--- a/.changeset/short-mice-itch.md
+++ b/.changeset/short-mice-itch.md
@@ -1,0 +1,5 @@
+---
+'@firebase/firestore': minor
+---
+
+Expanded `Firestore.WithFieldValue<T>` to include `T`. This allows developers to delegate `WithFieldValue<T>` inside a wrappers of type `T` to avoid exposing Firebase types beyond Firebase-specific logic.

--- a/common/api-review/firestore-lite.api.md
+++ b/common/api-review/firestore-lite.api.md
@@ -204,9 +204,7 @@ export function orderBy(fieldPath: string | FieldPath, directionStr?: OrderByDir
 export type OrderByDirection = 'desc' | 'asc';
 
 // @public
-export type PartialWithFieldValue<T> = T extends Primitive ? T : T extends {} ? {
-    [K in keyof T]?: PartialWithFieldValue<T[K]> | FieldValue;
-} : Partial<T>;
+export type PartialWithFieldValue<T> = Partial<WithFieldValue<T>>;
 
 // @public
 export type Primitive = string | number | boolean | undefined | null;
@@ -352,9 +350,9 @@ export function where(fieldPath: string | FieldPath, opStr: WhereFilterOp, value
 export type WhereFilterOp = '<' | '<=' | '==' | '!=' | '>=' | '>' | 'array-contains' | 'in' | 'array-contains-any' | 'not-in';
 
 // @public
-export type WithFieldValue<T> = T extends Primitive ? T : T extends {} ? {
+export type WithFieldValue<T> = T | (T extends Primitive ? T : T extends {} ? {
     [K in keyof T]: WithFieldValue<T[K]> | FieldValue;
-} : Partial<T>;
+} : Partial<T>);
 
 // @public
 export class WriteBatch {

--- a/common/api-review/firestore-lite.api.md
+++ b/common/api-review/firestore-lite.api.md
@@ -204,7 +204,9 @@ export function orderBy(fieldPath: string | FieldPath, directionStr?: OrderByDir
 export type OrderByDirection = 'desc' | 'asc';
 
 // @public
-export type PartialWithFieldValue<T> = Partial<WithFieldValue<T>>;
+export type PartialWithFieldValue<T> = Partial<T> | (T extends Primitive ? T : T extends {} ? {
+    [K in keyof T]?: PartialWithFieldValue<T[K]> | FieldValue;
+} : never);
 
 // @public
 export type Primitive = string | number | boolean | undefined | null;
@@ -352,7 +354,7 @@ export type WhereFilterOp = '<' | '<=' | '==' | '!=' | '>=' | '>' | 'array-conta
 // @public
 export type WithFieldValue<T> = T | (T extends Primitive ? T : T extends {} ? {
     [K in keyof T]: WithFieldValue<T[K]> | FieldValue;
-} : Partial<T>);
+} : never);
 
 // @public
 export class WriteBatch {

--- a/common/api-review/firestore.api.md
+++ b/common/api-review/firestore.api.md
@@ -328,7 +328,9 @@ export function orderBy(fieldPath: string | FieldPath, directionStr?: OrderByDir
 export type OrderByDirection = 'desc' | 'asc';
 
 // @public
-export type PartialWithFieldValue<T> = Partial<WithFieldValue<T>>;
+export type PartialWithFieldValue<T> = Partial<T> | (T extends Primitive ? T : T extends {} ? {
+    [K in keyof T]?: PartialWithFieldValue<T[K]> | FieldValue;
+} : never);
 
 // @public
 export interface PersistenceSettings {
@@ -504,7 +506,7 @@ export type WhereFilterOp = '<' | '<=' | '==' | '!=' | '>=' | '>' | 'array-conta
 // @public
 export type WithFieldValue<T> = T | (T extends Primitive ? T : T extends {} ? {
     [K in keyof T]: WithFieldValue<T[K]> | FieldValue;
-} : Partial<T>);
+} : never);
 
 // @public
 export class WriteBatch {

--- a/common/api-review/firestore.api.md
+++ b/common/api-review/firestore.api.md
@@ -328,9 +328,7 @@ export function orderBy(fieldPath: string | FieldPath, directionStr?: OrderByDir
 export type OrderByDirection = 'desc' | 'asc';
 
 // @public
-export type PartialWithFieldValue<T> = T extends Primitive ? T : T extends {} ? {
-    [K in keyof T]?: PartialWithFieldValue<T[K]> | FieldValue;
-} : Partial<T>;
+export type PartialWithFieldValue<T> = Partial<WithFieldValue<T>>;
 
 // @public
 export interface PersistenceSettings {
@@ -504,9 +502,9 @@ export function where(fieldPath: string | FieldPath, opStr: WhereFilterOp, value
 export type WhereFilterOp = '<' | '<=' | '==' | '!=' | '>=' | '>' | 'array-contains' | 'in' | 'array-contains-any' | 'not-in';
 
 // @public
-export type WithFieldValue<T> = T extends Primitive ? T : T extends {} ? {
+export type WithFieldValue<T> = T | (T extends Primitive ? T : T extends {} ? {
     [K in keyof T]: WithFieldValue<T[K]> | FieldValue;
-} : Partial<T>;
+} : Partial<T>);
 
 // @public
 export class WriteBatch {

--- a/packages/firestore/src/lite-api/reference.ts
+++ b/packages/firestore/src/lite-api/reference.ts
@@ -54,22 +54,19 @@ export interface DocumentData {
  * Similar to Typescript's `Partial<T>`, but allows nested fields to be
  * omitted and FieldValues to be passed in as property values.
  */
-export type PartialWithFieldValue<T> = T extends Primitive
-  ? T
-  : T extends {}
-  ? { [K in keyof T]?: PartialWithFieldValue<T[K]> | FieldValue }
-  : Partial<T>;
+export type PartialWithFieldValue<T> = Partial<WithFieldValue<T>>;
 
 /**
  * Allows FieldValues to be passed in as a property value while maintaining
  * type safety.
  */
-export type WithFieldValue<T> = T extends Primitive
-  ? T
-  : T extends {}
-  ? { [K in keyof T]: WithFieldValue<T[K]> | FieldValue }
-  : Partial<T>;
-
+export type WithFieldValue<T> =
+  | T
+  | (T extends Primitive
+      ? T
+      : T extends {}
+      ? { [K in keyof T]: WithFieldValue<T[K]> | FieldValue }
+      : Partial<T>);
 /**
  * Update data (for use with {@link (updateDoc:1)}) that consists of field paths
  * (e.g. 'foo' or 'foo.baz') mapped to values. Fields that contain dots

--- a/packages/firestore/src/lite-api/reference.ts
+++ b/packages/firestore/src/lite-api/reference.ts
@@ -54,7 +54,13 @@ export interface DocumentData {
  * Similar to Typescript's `Partial<T>`, but allows nested fields to be
  * omitted and FieldValues to be passed in as property values.
  */
-export type PartialWithFieldValue<T> = Partial<WithFieldValue<T>>;
+export type PartialWithFieldValue<T> =
+  | Partial<T>
+  | (T extends Primitive
+      ? T
+      : T extends {}
+      ? { [K in keyof T]?: PartialWithFieldValue<T[K]> | FieldValue }
+      : never);
 
 /**
  * Allows FieldValues to be passed in as a property value while maintaining
@@ -66,7 +72,8 @@ export type WithFieldValue<T> =
       ? T
       : T extends {}
       ? { [K in keyof T]: WithFieldValue<T[K]> | FieldValue }
-      : Partial<T>);
+      : never);
+
 /**
  * Update data (for use with {@link (updateDoc:1)}) that consists of field paths
  * (e.g. 'foo' or 'foo.baz') mapped to values. Fields that contain dots

--- a/packages/firestore/test/lite/integration.test.ts
+++ b/packages/firestore/test/lite/integration.test.ts
@@ -1286,7 +1286,7 @@ describe('withConverter() support', () => {
       }
     };
 
-    describe('NestedPartial', () => {
+    describe('nested partial support', () => {
       const testConverterMerge = {
         toFirestore(
           testObj: PartialWithFieldValue<TestObject>,
@@ -1494,6 +1494,51 @@ describe('withConverter() support', () => {
               timestamp: serverTimestamp()
             }
           });
+        });
+      });
+
+      describe('used as a type', () => {
+        class ObjectWrapper<T> {
+          withFieldValueT(value: WithFieldValue<T>): void {
+            // eslint-disable-next-line no-console
+            console.log(value);
+          }
+
+          withPartialFieldValueT(value: PartialWithFieldValue<T>): void {
+            // eslint-disable-next-line no-console
+            console.log(value);
+          }
+
+          // Wrapper to avoid having Firebase types in non-Firebase code.
+          withT(value: T): void {
+            this.withFieldValueT(value);
+          }
+
+          // Wrapper to avoid having Firebase types in non-Firebase code.
+          withPartialT(value: Partial<T>): void {
+            this.withPartialFieldValueT(value);
+          }
+        }
+
+        it('supports passing in the object as `T`', () => {
+          interface Foo {
+            id: string;
+            foo: number;
+          }
+          const foo = new ObjectWrapper<Foo>();
+          foo.withFieldValueT({ id: '', foo: increment(1) });
+          foo.withPartialFieldValueT({ foo: increment(1) });
+          foo.withT({ id: '', foo: 1 });
+          foo.withPartialT({ foo: 1 });
+        });
+
+        it('does not allow primitive types to use FieldValue', () => {
+          type Bar = number;
+          const bar = new ObjectWrapper<Bar>();
+          // @ts-expect-error
+          bar.withFieldValueT(increment(1));
+          // @ts-expect-error
+          bar.withPartialFieldValueT(increment(1));
         });
       });
     });

--- a/packages/firestore/test/lite/integration.test.ts
+++ b/packages/firestore/test/lite/integration.test.ts
@@ -1553,13 +1553,17 @@ describe('withConverter() support', () => {
         });
       });
 
-      it('allows certain types but not others (prevent breaking changes)', () => {
+      it('allows certain types but not others', () => {
         const withTryCatch = async (fn: () => Promise<void>): Promise<void> => {
           try {
             await fn();
           } catch {}
         };
 
+        // These tests exist to establish which object types are allowed to be
+        // passed in by default when `T = DocumentData`. Some objects extend
+        // the Javascript `{}`, which is why they're allowed whereas others
+        // throw an error.
         return withTestDoc(async doc => {
           // @ts-expect-error
           await withTryCatch(() => setDoc(doc, 1));


### PR DESCRIPTION
Fixes #5661. Thanks @gustavohenke for proactively bringing up the fix!

This change allows developers to pass an object of type `T` into `WithFieldValue<T>`.