### PR TITLE
[Auth] Add tabindex=-1 to iframe to fix issue with aria-hidden

### DIFF
--- a/.changeset/witty-kids-buy.md
+++ b/.changeset/witty-kids-buy.md
@@ -1,0 +1,5 @@
+---
+"@firebase/auth": patch
+---
+
+Fix lighthouse issues related to the embedded iframe used to perform OAuth sign in.

--- a/packages/auth/src/platform_browser/iframe/iframe.test.ts
+++ b/packages/auth/src/platform_browser/iframe/iframe.test.ts
@@ -86,6 +86,7 @@ describe('platform_browser/iframe/iframe', () => {
         height: '1px'
       },
       'aria-hidden': 'true',
+      tabindex: '-1'
     });
     expect(iframeSettings.dontclear).to.be.true;
   });

--- a/packages/auth/src/platform_browser/iframe/iframe.ts
+++ b/packages/auth/src/platform_browser/iframe/iframe.ts
@@ -38,7 +38,8 @@ const IFRAME_ATTRIBUTES = {
     width: '1px',
     height: '1px'
   },
-  'aria-hidden': 'true'
+  'aria-hidden': 'true',
+  tabindex: '-1'
 };
 
 // Map from apiHost to endpoint ID for passing into iframe. In current SDK, apiHost can be set to


### PR DESCRIPTION
Fixes https://github.com/firebase/firebase-js-sdk/issues/5631

This is a follow-up to https://github.com/firebase/firebase-js-sdk/pull/5633/files. There was still an issue with lighthouse until we add tabindex=-1 to the iframe as well