### PR TITLE
Skip IndexedDB cleanup on Safari 15

### DIFF
--- a/.changeset/lovely-bobcats-punch.md
+++ b/.changeset/lovely-bobcats-punch.md
@@ -1,0 +1,5 @@
+---
+"@firebase/firestore": patch
+---
+
+The SDK no longer accesses IndexedDB during a page unload event on Safari 15. This aims to reduce the occurrence of an IndexedDB bug in Safari (https://bugs.webkit.org/show_bug.cgi?id=226547).

--- a/packages/firestore/src/local/indexeddb_persistence.ts
+++ b/packages/firestore/src/local/indexeddb_persistence.ts
@@ -962,10 +962,10 @@ export class IndexedDbPersistence implements Persistence {
         // to make sure it gets a chance to run.
         this.markClientZombied();
 
-        if (isSafari() && navigator.appVersion.match(`Version/14`)) {
-          // On Safari 14, we do not run any cleanup actions as it might trigger
-          // a bug that prevents Safari from re-opening IndexedDB during the
-          // next page load.
+        if (isSafari() && navigator.appVersion.match(/Version\/1[45]/)) {
+          // On Safari 14 and 15, we do not run any cleanup actions as it might
+          // trigger a bug that prevents Safari from re-opening IndexedDB during
+          // the next page load.
           // See https://bugs.webkit.org/show_bug.cgi?id=226547
           this.queue.enterRestrictedMode(/* purgeExistingTasks= */ true);
         }


### PR DESCRIPTION
This PR changes our IndexedDB shutdown to skip all remaining work items on Safari 15. It is believed that writing to IndexedDB during unload can trigger a bug on Safari that prevents IndexedDB from loading during the next page load.

Fixes https://github.com/firebase/firebase-js-sdk/issues/5716 (Which is just extending https://github.com/firebase/firebase-js-sdk/issues/4076)

