### PR TITLE
better meta url polyfill

### DIFF
--- a/.changeset/quick-experts-shave.md
+++ b/.changeset/quick-experts-shave.md
@@ -1,0 +1,5 @@
+---
+"@firebase/firestore": patch
+---
+
+better meta url polyfill

--- a/packages/firestore/rollup.config.js
+++ b/packages/firestore/rollup.config.js
@@ -38,7 +38,7 @@ function importMetaUrlPolyfillPlugin() {
     resolveImportMeta(property, { moduleId }) {
       if (property === 'url') {
         // copied from rollup output
-        return `new (require('u' + 'rl').URL)('file:' + __filename).href`;
+        return `new (require('url').URL)('file:' + __filename).href`;
       }
       return null;
     }

--- a/packages/firestore/rollup.config.js
+++ b/packages/firestore/rollup.config.js
@@ -29,6 +29,22 @@ import { generateBuildTargetReplaceConfig } from '../../scripts/build/rollup_rep
 
 const util = require('./rollup.shared');
 
+// Customize how import.meta.url is polyfilled in cjs nodejs build. We use it to be able to use require() in esm.
+// It only generates the nodejs version of the polyfill, as opposed to the default polyfill which
+// supports both browser and nodejs. The browser support is unnecessary and doesn't work well with Jest. See https://github.com/firebase/firebase-js-sdk/issues/5687
+function importMetaUrlPolyfillPlugin() {
+  return {
+    name: 'import-meta-url-current-module',
+    resolveImportMeta(property, { moduleId }) {
+      if (property === 'url') {
+        // copied from rollup output
+        return `new (require('u' + 'rl').URL)('file:' + __filename).href`;
+      }
+      return null;
+    }
+  };
+}
+
 const nodePlugins = function () {
   return [
     typescriptPlugin({
@@ -105,7 +121,8 @@ const allBuilds = [
     },
     plugins: [
       ...util.es2017ToEs5Plugins(/* mangled= */ false),
-      replace(generateBuildTargetReplaceConfig('cjs', 2017))
+      replace(generateBuildTargetReplaceConfig('cjs', 2017)),
+      importMetaUrlPolyfillPlugin()
     ],
     external: util.resolveNodeExterns,
     treeshake: {


### PR DESCRIPTION
Generate polyfill for Nodejs only.
Partially fixes https://github.com/firebase/firebase-js-sdk/issues/5687 (or rather just hide the problem that Jest will load Nodejs bundles as if it is testing in browser)