### PR TITLE
Exclude NodeJS.ReadableStream from compat overloads

### DIFF
--- a/.changeset/famous-houses-retire.md
+++ b/.changeset/famous-houses-retire.md
@@ -1,0 +1,6 @@
+---
+'@firebase/storage': patch
+'@firebase/storage-compat': patch
+---
+
+Fix typings for storage and storage-compat.

--- a/packages/storage/src/reference.ts
+++ b/packages/storage/src/reference.ts
@@ -167,7 +167,7 @@ export function getBytesInternal(
   );
   return ref.storage
     .makeRequestWithTokens(requestInfo, newBytesConnection)
-    .then((bytes) =>
+    .then(bytes =>
       maxDownloadSizeBytes !== undefined
         ? // GCS may not honor the Range header for small files
           (bytes as ArrayBuffer).slice(0, maxDownloadSizeBytes)

--- a/packages/storage/src/reference.ts
+++ b/packages/storage/src/reference.ts
@@ -167,11 +167,11 @@ export function getBytesInternal(
   );
   return ref.storage
     .makeRequestWithTokens(requestInfo, newBytesConnection)
-    .then(bytes =>
+    .then((bytes) =>
       maxDownloadSizeBytes !== undefined
         ? // GCS may not honor the Range header for small files
-          bytes.slice(0, maxDownloadSizeBytes)
-        : bytes
+          (bytes as ArrayBuffer).slice(0, maxDownloadSizeBytes)
+        : (bytes as ArrayBuffer)
     );
 }
 
@@ -194,8 +194,8 @@ export function getBlobInternal(
     .then(blob =>
       maxDownloadSizeBytes !== undefined
         ? // GCS may not honor the Range header for small files
-          blob.slice(0, maxDownloadSizeBytes)
-        : blob
+          (blob as Blob).slice(0, maxDownloadSizeBytes)
+        : (blob as Blob)
     );
 }
 
@@ -236,7 +236,7 @@ export function getStreamInternal(
 
   ref.storage
     .makeRequestWithTokens(requestInfo, newStreamConnection)
-    .then(stream => stream.pipe(result))
+    .then(stream => (stream as NodeJS.ReadableStream).pipe(result))
     .catch(e => result.destroy(e));
   return result;
 }

--- a/scripts/build/create-overloads.ts
+++ b/scripts/build/create-overloads.ts
@@ -278,7 +278,8 @@ const BUILTIN_TYPES = [
   'Blob',
   'ServiceWorkerRegistration',
   'Record',
-  'Error'
+  'Error',
+  'NodeJS.ReadableStream'
 ];
 
 // find all types (except for the built-ins and primitives) referenced in the function declaration


### PR DESCRIPTION
Add NodeJS.ReadableStream to excluded builtin types in the compat overloads script. Maybe there's a more robust way to address this, or can look into it later.

Also fix some type errors in storage.