### PR TITLE
Fix caching errors during Firestore build

### DIFF
--- a/packages/firestore/rollup.config.js
+++ b/packages/firestore/rollup.config.js
@@ -84,7 +84,6 @@ const browserPlugins = function () {
         }
       },
       cacheDir: tmp.dirSync(),
-      clean: true,
       abortOnError: false,
       transformers: [util.removeAssertAndPrefixInternalTransformer]
     }),

--- a/packages/firestore/test/unit/specs/describe_spec.ts
+++ b/packages/firestore/test/unit/specs/describe_spec.ts
@@ -252,7 +252,7 @@ export function describeSpec(
     // Note: We use json-stable-stringify instead of JSON.stringify() to ensure
     // that the generated JSON does not produce diffs merely due to the order
     // of the keys in an object changing.
-    const output = stringify(specsInThisTest, {
+    const output = stringify.default(specsInThisTest, {
       space: 2,
       cmp: stringifyComparator
     });

--- a/packages/firestore/test/unit/specs/describe_spec.ts
+++ b/packages/firestore/test/unit/specs/describe_spec.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import * as stringify from 'json-stable-stringify';
+import stringify from 'json-stable-stringify';
 import { ExclusiveTestFunction, PendingTestFunction } from 'mocha';
 
 import { queryEquals, QueryImpl } from '../../../src/core/query';
@@ -252,7 +252,7 @@ export function describeSpec(
     // Note: We use json-stable-stringify instead of JSON.stringify() to ensure
     // that the generated JSON does not produce diffs merely due to the order
     // of the keys in an object changing.
-    const output = stringify.default(specsInThisTest, {
+    const output = stringify(specsInThisTest, {
       space: 2,
       cmp: stringifyComparator
     });


### PR DESCRIPTION
This fixes the endless saga of 

```
[!] (plugin rpt2) Error: ENOENT: no such file or directory, open '/Users/mrschmidt/GitHub/firebase/firebase-js-sdk/packages/firestore/node_modules/.cache/rollup-plugin-typescript2/rpt2_7887a05285f2ead33e6e00d96643596dbe46f0d0/code/cache_/1e43392417c9b6c95b07e7f45d8c498c15e959c1'

```

for me. We don't need to clean the cache since each build has its own directory.