### PR TITLE
Hardcode grpc-js version

### DIFF
--- a/packages/firestore/rollup.config.js
+++ b/packages/firestore/rollup.config.js
@@ -19,17 +19,33 @@ import { version as grpcVersion } from '@grpc/grpc-js/package.json';
 import alias from '@rollup/plugin-alias';
 import json from '@rollup/plugin-json';
 import copy from 'rollup-plugin-copy';
+import replace from 'rollup-plugin-replace';
 import { terser } from 'rollup-plugin-terser';
 import typescriptPlugin from 'rollup-plugin-typescript2';
 import tmp from 'tmp';
 import typescript from 'typescript';
-import replace from 'rollup-plugin-replace';
 
 import { generateBuildTargetReplaceConfig } from '../../scripts/build/rollup_replace_build_target';
 
 import pkg from './package.json';
 
 const util = require('./rollup.shared');
+
+// Customize how import.meta.url is polyfilled in cjs nodejs build. We use it to be able to use require() in esm.
+// It only generates the nodejs version of the polyfill, as opposed to the default polyfill which
+// supports both browser and nodejs. The browser support is unnecessary and doesn't work well with Jest. See https://github.com/firebase/firebase-js-sdk/issues/5687
+function importMetaUrlPolyfillPlugin() {
+  return {
+    name: 'import-meta-url-current-module',
+    resolveImportMeta(property, { moduleId }) {
+      if (property === 'url') {
+        // copied from rollup output
+        return `new (require('url').URL)('file:' + __filename).href`;
+      }
+      return null;
+    }
+  };
+}
 
 const nodePlugins = function () {
   return [
@@ -107,7 +123,8 @@ const allBuilds = [
     },
     plugins: [
       ...util.es2017ToEs5Plugins(/* mangled= */ false),
-      replace(generateBuildTargetReplaceConfig('cjs', 2017))
+      replace(generateBuildTargetReplaceConfig('cjs', 2017)),
+      importMetaUrlPolyfillPlugin()
     ],
     external: util.resolveNodeExterns,
     treeshake: {

--- a/packages/firestore/src/platform/node/grpc_connection.ts
+++ b/packages/firestore/src/platform/node/grpc_connection.ts
@@ -35,7 +35,7 @@ import { NodeCallback, nodePromise } from '../../util/node_api';
 import { Deferred } from '../../util/promise';
 
 // TODO: Fetch runtime version from grpc-js/package.json instead
-// when it becomes possible to use require() in Node ESM without hacks.
+// when there's a cleaner way to dynamic require in both Node ESM and CJS
 const grpcVersion = '__GRPC_VERSION__';
 
 const LOG_TAG = 'Connection';

--- a/packages/firestore/src/platform/node/grpc_connection.ts
+++ b/packages/firestore/src/platform/node/grpc_connection.ts
@@ -35,7 +35,7 @@ import { NodeCallback, nodePromise } from '../../util/node_api';
 import { Deferred } from '../../util/promise';
 
 // TODO: Fetch runtime version from grpc-js/package.json instead
-// when there's a cleaner way to dynamic require in both Node ESM and CJS
+// when there's a cleaner way to dynamic require JSON in both Node ESM and CJS
 const grpcVersion = '__GRPC_VERSION__';
 
 const LOG_TAG = 'Connection';

--- a/packages/firestore/src/platform/node/grpc_connection.ts
+++ b/packages/firestore/src/platform/node/grpc_connection.ts
@@ -15,10 +15,6 @@
  * limitations under the License.
  */
 
-// This is a hack fix for Node ES modules to use `require`.
-// @ts-ignore To avoid using `allowSyntheticDefaultImports` flag.
-import module from 'module';
-
 import {
   Metadata,
   GrpcObject,
@@ -38,11 +34,9 @@ import { logError, logDebug, logWarn } from '../../util/log';
 import { NodeCallback, nodePromise } from '../../util/node_api';
 import { Deferred } from '../../util/promise';
 
-// This is a hack fix for Node ES modules to use `require`.
-// @ts-ignore To avoid using `--module es2020` flag.
-const requireInESM = module.createRequire(import.meta.url);
-// eslint-disable-next-line @typescript-eslint/no-require-imports
-const { version: grpcVersion } = requireInESM('@grpc/grpc-js/package.json');
+// TODO: Fetch runtime version from grpc-js/package.json instead
+// when it becomes possible to use require() in Node ESM without hacks.
+const grpcVersion = '__GRPC_VERSION__';
 
 const LOG_TAG = 'Connection';
 const X_GOOG_API_CLIENT_VALUE = `gl-node/${process.versions.node} fire/${SDK_VERSION} grpc/${grpcVersion}`;


### PR DESCRIPTION
Hardcode the grpc-js version used for logging. This isn't ideal, as getting the version at runtime provides the most accurate version for metrics and debugging, but working around problems with import.meta.url in ESM Node builds while ensuring CJS Node builds still work is causing a lot of problems. Make a TODO to change back to getting runtime version when there is a better way to support it across CJS and ESM Node builds.

See issues:
https://github.com/firebase/firebase-js-sdk/issues/5752
https://github.com/firebase/firebase-js-sdk/issues/5687

And PR:
https://github.com/firebase/firebase-js-sdk/pull/5532