### PR TITLE
Verify OIDC/SAML sign in against Auth Emulator

### DIFF
--- a/packages/auth/demo/src/index.js
+++ b/packages/auth/demo/src/index.js
@@ -56,6 +56,7 @@ import {
   verifyPasswordResetCode,
   getMultiFactorResolver,
   OAuthProvider,
+  SAMLAuthProvider,
   GoogleAuthProvider,
   FacebookAuthProvider,
   TwitterAuthProvider,
@@ -1188,6 +1189,7 @@ function onPopupRedirectAddCustomParam(_event) {
     e.preventDefault();
   });
   // Append constructed row to parameter list container.
+  // TODO: These parameters need to be passed into OAuth calls with provider.setCustomParameters()
   $('#popup-redirect-custom-parameters').append($node);
 }
 
@@ -1204,10 +1206,13 @@ function onPopupRedirectGenericProviderClick() {
  * Performs the corresponding popup/redirect action for a SAML provider.
  */
 function onPopupRedirectSamlProviderClick() {
-  alertNotImplemented();
-  // var providerId = $('#popup-redirect-saml-providerid').val();
-  // var provider = new SAMLAuthProvider(providerId);
-  // signInWithPopupRedirect(provider);
+  if (!USE_AUTH_EMULATOR) {
+    alertNotImplemented();
+    return;
+  }
+  var providerId = $('#popup-redirect-saml-providerid').val();
+  var provider = new SAMLAuthProvider(providerId);
+  signInWithPopupRedirect(provider);
 }
 
 /**


### PR DESCRIPTION
### Discussion

  * Add TODO for unused custom parameters
  * Uncommented logic for sign in with SAML providers

Corresponding internal bug: b/192387796

### Testing

Verified that OIDC/SAML happy cases work against head of Auth Emulator mainline. Followed instructions for running against emulator ([here](https://github.com/firebase/firebase-js-sdk/tree/master/packages/auth/demo#running-against-auth-emulator)). See videos of sign in flows:

* [go/firebase-jssdk-5776-oidc](http://go/firebase-jssdk-5776-oidc) - signs in with OIDC provider
* [go/firebase-jssdk-5776-saml](http://go/firebase-jssdk-5776-saml) - signs in with SAML provider

### API Changes

N/A
