### PR TITLE
[Auth] Fix halted initialization when proactive popup resolver init fails

### DIFF
--- a/.changeset/red-actors-care.md
+++ b/.changeset/red-actors-care.md
@@ -1,0 +1,5 @@
+---
+"@firebase/auth": patch
+---
+
+Fix errors during Auth initialization when the network is unavailable

--- a/packages/auth/src/core/auth/auth_impl.ts
+++ b/packages/auth/src/core/auth/auth_impl.ts
@@ -135,7 +135,10 @@ export class AuthImpl implements AuthInternal, _FirebaseService {
       // Initialize the resolver early if necessary (only applicable to web:
       // this will cause the iframe to load immediately in certain cases)
       if (this._popupRedirectResolver?._shouldInitProactively) {
-        await this._popupRedirectResolver._initialize(this);
+        // If this fails, don't halt auth loading
+        try {
+          await this._popupRedirectResolver._initialize(this);
+        } catch (e) { /* Ignore the error */ }
       }
 
       await this.initializeCurrentUser(popupRedirectResolver);

--- a/packages/auth/src/platform_browser/auth.test.ts
+++ b/packages/auth/src/platform_browser/auth.test.ts
@@ -216,6 +216,16 @@ describe('core/auth/initializeAuth', () => {
       expect(resolverInternal._initialize).to.have.been.called;
     });
 
+    it('does not halt init if resolver fails', async () => {
+      const popupRedirectResolver = makeMockPopupRedirectResolver();
+      const resolverInternal: PopupRedirectResolverInternal = _getInstance(
+        popupRedirectResolver
+      );
+      sinon.stub(resolverInternal, '_shouldInitProactively').value(true);
+      sinon.stub(resolverInternal, '_initialize').rejects(new Error());
+      await expect(initAndWait(inMemoryPersistence, popupRedirectResolver)).not.to.be.rejected;
+    });
+
     it('reloads non-redirect users', async () => {
       sinon
         .stub(_getInstance<PersistenceInternal>(inMemoryPersistence), '_get')

--- a/packages/auth/src/platform_browser/iframe/gapi.test.ts
+++ b/packages/auth/src/platform_browser/iframe/gapi.test.ts
@@ -33,13 +33,14 @@ use(chaiAsPromised);
 describe('platform_browser/iframe/gapi', () => {
   let library: typeof gapi;
   let auth: TestAuth;
+  let loadJsStub: sinon.SinonStub;
   function onJsLoad(globalLoadFnName: string): void {
     _window().gapi = library as typeof gapi;
     _window()[globalLoadFnName]();
   }
 
   beforeEach(async () => {
-    sinon.stub(js, '_loadJS').callsFake(url => {
+    loadJsStub = sinon.stub(js, '_loadJS').callsFake(url => {
       onJsLoad(url.split('onload=')[1]);
       return Promise.resolve(new Event('load'));
     });
@@ -133,5 +134,11 @@ describe('platform_browser/iframe/gapi', () => {
       'auth/network-request-failed'
     );
     expect(_loadGapi(auth)).not.to.eq(firstAttempt);
+  });
+
+  it('rejects if gapi itself does not load', async () => {
+    const error = new Error();
+    loadJsStub.rejects(error);
+    await expect(_loadGapi(auth)).to.be.rejectedWith(error);
   });
 });

--- a/packages/auth/src/platform_browser/iframe/gapi.ts
+++ b/packages/auth/src/platform_browser/iframe/gapi.ts
@@ -103,7 +103,7 @@ function loadGapi(auth: AuthInternal): Promise<gapi.iframes.Context> {
         }
       };
       // Load GApi loader.
-      return js._loadJS(`https://apis.google.com/js/api.js?onload=${cbName}`);
+      return js._loadJS(`https://apis.google.com/js/api.js?onload=${cbName}`).catch(e => reject(e));
     }
   }).catch(error => {
     // Reset cached promise to allow for retrial.

--- a/packages/auth/src/platform_browser/popup_redirect.test.ts
+++ b/packages/auth/src/platform_browser/popup_redirect.test.ts
@@ -54,6 +54,7 @@ describe('platform_browser/popup_redirect', () => {
   let auth: TestAuth;
   let onIframeMessage: (event: GapiAuthEvent) => Promise<void>;
   let iframeSendStub: sinon.SinonStub;
+  let loadGapiStub: sinon.SinonStub;
 
   beforeEach(async () => {
     auth = await testAuth();
@@ -61,8 +62,18 @@ describe('platform_browser/popup_redirect', () => {
 
     sinon.stub(validateOrigin, '_validateOrigin').returns(Promise.resolve());
     iframeSendStub = sinon.stub();
+    loadGapiStub = sinon.stub(gapiLoader, '_loadGapi');
+    setGapiStub();
 
-    sinon.stub(gapiLoader, '_loadGapi').returns(
+    sinon.stub(authWindow._window(), 'gapi').value({
+      iframes: {
+        CROSS_ORIGIN_IFRAMES_FILTER: 'cross-origin-iframes-filter'
+      }
+    });
+  });
+
+  function setGapiStub() {
+    loadGapiStub.returns(
       Promise.resolve(({
         open: () =>
           Promise.resolve({
@@ -74,13 +85,7 @@ describe('platform_browser/popup_redirect', () => {
           })
       } as unknown) as gapi.iframes.Context)
     );
-
-    sinon.stub(authWindow._window(), 'gapi').value({
-      iframes: {
-        CROSS_ORIGIN_IFRAMES_FILTER: 'cross-origin-iframes-filter'
-      }
-    });
-  });
+  }
 
   afterEach(() => {
     sinon.restore();
@@ -239,6 +244,14 @@ describe('platform_browser/popup_redirect', () => {
       const secondPromise = resolver._initialize(secondAuth);
       expect(secondPromise).not.to.eq(promise);
       expect(resolver._initialize(secondAuth)).to.eq(secondPromise);
+    });
+
+    it('clears the cache if the initialize fails', async () => {
+      const error = new Error();
+      loadGapiStub.rejects(error);
+      await expect(resolver._initialize(auth)).to.be.rejectedWith(error);
+      setGapiStub();  // Reset the gapi load stub
+      await expect(resolver._initialize(auth)).not.to.be.rejected;
     });
 
     it('iframe event goes through to the manager', async () => {

--- a/packages/auth/src/platform_browser/popup_redirect.test.ts
+++ b/packages/auth/src/platform_browser/popup_redirect.test.ts
@@ -72,7 +72,7 @@ describe('platform_browser/popup_redirect', () => {
     });
   });
 
-  function setGapiStub() {
+  function setGapiStub(): void {
     loadGapiStub.returns(
       Promise.resolve(({
         open: () =>

--- a/packages/auth/src/platform_browser/popup_redirect.ts
+++ b/packages/auth/src/platform_browser/popup_redirect.ts
@@ -111,6 +111,13 @@ class BrowserPopupRedirectResolver implements PopupRedirectResolverInternal {
 
     const promise = this.initAndGetManager(auth);
     this.eventManagers[key] = { promise };
+
+    // If the promise is rejected, the key should be removed so that the
+    // operation can be retried later.
+    promise.catch(() => {
+      delete this.eventManagers[key];
+    });
+
     return promise;
   }
 


### PR DESCRIPTION
Fixes https://github.com/firebase/firebase-js-sdk/issues/5720

In proactive initialization for the popup/redirect resolver, Auth initialization should not fail if there's a network error (i.e. in the case of offline-mode).