### PR TITLE
Remove describe.only

### DIFF
--- a/packages/util/test/object.test.ts
+++ b/packages/util/test/object.test.ts
@@ -18,8 +18,7 @@
 import { expect } from 'chai';
 import { deepEqual } from '../src/obj';
 
-// eslint-disable-next-line no-restricted-properties
-describe.only('deepEqual()', () => {
+describe('deepEqual()', () => {
   it('returns true for comparing empty objects', () => {
     expect(deepEqual({}, {})).to.be.true;
   });


### PR DESCRIPTION
Remove accidental `describe.only` in packages/util tests.