### PR TITLE
Add passthrough compat integration tests

### DIFF
--- a/packages/auth-compat/test/integration/flows/custom.test.ts
+++ b/packages/auth-compat/test/integration/flows/custom.test.ts
@@ -161,23 +161,25 @@ describe('Integration test: custom auth', () => {
       );
     });
 
+    // TODO(b/210009586): Enable integration tests once passthrough mode launches
     xit('signs in with custom token in passthrough mode', async () => {
       const cred = await firebase.auth().signInWithCustomToken(customToken);
       expect(firebase.auth().currentUser).to.eq(cred.user);
       expect(cred.operationType).to.eq('signIn');
 
-      const { user } = cred;
-      expect(user!.isAnonymous).to.be.false;
-      expect(user!.uid).to.eq(uid);
-      expect((await user!.getIdTokenResult(false)).claims.customClaim).to.eq(
+      const user = cred.user!;
+      expect(user.isAnonymous).to.be.false;
+      expect(user.uid).to.eq(uid);
+      expect((await user.getIdTokenResult(false)).claims.customClaim).to.eq(
         'some-claim'
       );
-      expect(user!.providerId).to.eq('firebase');
+      expect(user.providerId).to.eq('firebase');
       const additionalUserInfo = cred.additionalUserInfo!;
       expect(additionalUserInfo.providerId).to.be.null;
       expect(additionalUserInfo.isNewUser).to.be.false;
     });
 
+    // TODO(b/210009586): Enable integration tests once passthrough mode launches
     xit('token can be refreshed in passthrough mode', async () => {
       firebase.auth().setCustomTokenProvider({
         async getCustomToken(): Promise<string> {
@@ -189,11 +191,12 @@ describe('Integration test: custom auth', () => {
           });
         }
       });
-      const { user } = await firebase.auth().signInWithCustomToken(customToken);
-      const origToken = await user!.getIdToken();
-      await new Promise(resolve => setTimeout(resolve, 1000));
-      expect(await user!.getIdToken(true)).not.to.eq(origToken);
-      expect((await user!.getIdTokenResult(false)).claims.customClaim).to.eq(
+
+      const cred = await firebase.auth().signInWithCustomToken(customToken);
+      const user = cred.user!;
+      const origToken = await user.getIdToken();
+      expect(await user.getIdToken(true)).not.to.eq(origToken);
+      expect((await user.getIdTokenResult(false)).claims.customClaim).to.eq(
         'other-claim'
       );
     });

--- a/packages/auth/test/integration/flows/custom.local.test.ts
+++ b/packages/auth/test/integration/flows/custom.local.test.ts
@@ -171,6 +171,7 @@ describe('Integration test: custom auth', () => {
       );
     });
 
+    // TODO(b/210009586): Enable integration tests once passthrough mode launches
     xit('signs in with custom token in passthrough mode', async () => {
       const cred = await signInWithCustomToken(auth, customToken);
       expect(auth.currentUser).to.eq(cred.user);
@@ -188,6 +189,7 @@ describe('Integration test: custom auth', () => {
       expect(additionalUserInfo.isNewUser).to.be.false;
     });
 
+    // TODO(b/210009586): Enable integration tests once passthrough mode launches
     xit('token can be refreshed in passthrough mode', async () => {
       setCustomTokenProvider(auth, {
         async getCustomToken(): Promise<string> {
@@ -201,7 +203,6 @@ describe('Integration test: custom auth', () => {
       });
       const { user } = await signInWithCustomToken(auth, customToken);
       const origToken = await user.getIdToken();
-      await new Promise(resolve => setTimeout(resolve, 1000));
       expect(await user.getIdToken(true)).not.to.eq(origToken);
       expect((await user.getIdTokenResult(false)).claims.customClaim).to.eq(
         'other-claim'


### PR DESCRIPTION
### Discussion

Copied over integration passthrough integration tests (from https://github.com/firebase/firebase-js-sdk/pull/5361) over to compat layer. Additional changes include:

* Adding TODO's to enable tests once passthrough launches
* Remove unneeded timeout from all integ tests

Corresponding internal bug: b/192699639

### Testing

To test `auth-compat/`:
* Built emulator suite locally `npm run build` from `firebase-tools/`
* Change `xit` to `it`
* From `packages/auth-compat/` ran `node /Users/lisajian/dev/firebase-tools/lib/bin/firebase emulators:exec --project demo-emulatedproject --only auth "yarn run-s test:browser:integration test:node:integration test:webdriver"` (was having a little trouble with `yarn test:integration` b/c it wasn't picking up my local emulator build)

To test `auth/`:
* Same first two steps as above
* From `packages/auth/` ran `firebase emulators:exec --project p --only auth "yarn test:browser:integration:local"`

### API Changes

N/A
