### PR TITLE
fix: Add type check for `process.env`

### DIFF
--- a/packages/database/src/api/Database.ts
+++ b/packages/database/src/api/Database.ts
@@ -128,7 +128,7 @@ export function repoManagerDatabaseFromApp(
   let isEmulator: boolean;
 
   let dbEmulatorHost: string | undefined = undefined;
-  if (typeof process !== 'undefined') {
+  if (typeof process !== 'undefined' && process.env) {
     dbEmulatorHost = process.env[FIREBASE_DATABASE_EMULATOR_HOST_VAR];
   }
 


### PR DESCRIPTION
Fixes #5789 

This PR adds type checks for `process.env` to avoid `TypeError` when `process.env` is undefined although `process` is defined.