### PR TITLE
made backticks more consistent

### DIFF
--- a/packages/firestore/src/api/snapshot.ts
+++ b/packages/firestore/src/api/snapshot.ts
@@ -218,7 +218,7 @@ export interface DocumentChange<T = DocumentData> {
    * The index of the changed document in the result set immediately after
    * this `DocumentChange` (i.e. supposing that all prior `DocumentChange`
    * objects and the current `DocumentChange` object have been applied).
-   * Is -1 for 'removed' events.
+   * Is `-1` for 'removed' events.
    */
   readonly newIndex: number;
 }


### PR DESCRIPTION
This is a simple comment change to make the description of the `newIndex` property more consistent with the description of the `oldIndex` property in the `DocumentChange` interface.