### PR TITLE
Fix Firestore build

### DIFF
--- a/packages/firestore/src/local/indexeddb_remote_document_cache.ts
+++ b/packages/firestore/src/local/indexeddb_remote_document_cache.ts
@@ -20,7 +20,6 @@ import { SnapshotVersion } from '../core/snapshot_version';
 import {
   DocumentKeySet,
   DocumentSizeEntries,
-  DocumentSizeEntry,
   MutableDocumentMap,
   mutableDocumentMap
 } from '../model/collections';
@@ -54,6 +53,11 @@ import { PersistenceTransaction } from './persistence_transaction';
 import { RemoteDocumentCache } from './remote_document_cache';
 import { RemoteDocumentChangeBuffer } from './remote_document_change_buffer';
 import { IterateOptions, SimpleDbStore } from './simple_db';
+
+export interface DocumentSizeEntry {
+  document: MutableDocument;
+  size: number;
+}
 
 export interface IndexedDbRemoteDocumentCache extends RemoteDocumentCache {
   // The IndexedDbRemoteDocumentCache doesn't implement any methods on top

--- a/packages/firestore/src/local/memory_remote_document_cache.ts
+++ b/packages/firestore/src/local/memory_remote_document_cache.ts
@@ -19,7 +19,6 @@ import { isCollectionGroupQuery, Query, queryMatches } from '../core/query';
 import { SnapshotVersion } from '../core/snapshot_version';
 import {
   DocumentKeySet,
-  DocumentSizeEntry,
   MutableDocumentMap,
   mutableDocumentMap
 } from '../model/collections';
@@ -37,7 +36,9 @@ import { RemoteDocumentChangeBuffer } from './remote_document_change_buffer';
 export type DocumentSizer = (doc: Document) => number;
 
 /** Miscellaneous collection types / constants. */
-interface MemoryRemoteDocumentCacheEntry extends DocumentSizeEntry {
+interface MemoryRemoteDocumentCacheEntry {
+  document: Document;
+  size: number;
   readTime: SnapshotVersion;
 }
 

--- a/packages/firestore/src/model/collections.ts
+++ b/packages/firestore/src/model/collections.ts
@@ -25,10 +25,6 @@ import { Document, MutableDocument } from './document';
 import { DocumentKey } from './document_key';
 
 /** Miscellaneous collection types / constants. */
-export interface DocumentSizeEntry {
-  document: Document;
-  size: number;
-}
 
 export type MutableDocumentMap = SortedMap<DocumentKey, MutableDocument>;
 const EMPTY_MUTABLE_DOCUMENT_MAP = new SortedMap<DocumentKey, MutableDocument>(


### PR DESCRIPTION
This fixes an error in the JS build that has been showing up for me locally. It was introduced in https://github.com/firebase/firebase-js-sdk/pull/5808. Note that the error did not prevent the break the build - so that is a bit strange.

The main change here is that IndexedDbRemoteDocument cache goes back to the state before the PR and continues to use MutableDocuments.