### PR TITLE
Fix Vercel build

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -11,6 +11,8 @@ assignees: ''
 <!-- Step 1 [READ THIS] -->
 <!--
 
+**Thank you for submitting your issue. We are operating at reduced capacity from Dec 20 2021 to Jan 4 2022. While we are monitoring issues for major breakages and emergencies, there may be delayed responses. For more urgent requests please reach us via our support channels https://firebase.google.com/support**
+
 Are you in the right place?
   * For issues or feature requests related to __the code in this repository__
     file a Github issue.

--- a/packages/firestore/rollup.config.js
+++ b/packages/firestore/rollup.config.js
@@ -43,10 +43,12 @@ function importMetaUrlPolyfillPlugin(filename) {
     resolveImportMeta(property, { moduleId }) {
       if (property === 'url') {
         // copied from rollup output
-        return "(typeof document === 'undefined' ? new (require('url').URL)"
-          + "('file:' + __filename).href : (document.currentScript && "
-          + `document.currentScript.src || new URL('${filename}', `
-          + "document.baseURI).href))";
+        return (
+          "(typeof document === 'undefined' ? new (require('url').URL)" +
+          "('file:' + __filename).href : (document.currentScript && " +
+          `document.currentScript.src || new URL('${filename}', ` +
+          'document.baseURI).href))'
+        );
       }
       return null;
     }


### PR DESCRIPTION
This changes the manual replacement code to produce the exact output I got in 9.2:

```
url.fileURLToPath((typeof document === 'undefined' ? new (require('url').URL)('file:' + __filename).href : (document.currentScript && document.currentScript.src || new URL('index.node.cjs.js', document.baseURI).href)));
```

Fixes https://github.com/firebase/firebase-js-sdk/issues/5823