### PR TITLE
Change FirestoreError to extend FirebaseError

### DIFF
--- a/.changeset/big-otters-reply.md
+++ b/.changeset/big-otters-reply.md
@@ -1,0 +1,7 @@
+---
+"@firebase/firestore": patch
+"@firebase/storage": patch
+"@firebase/util": patch
+---
+
+FirestoreError and StorageError now extend FirebaseError

--- a/common/api-review/firestore-lite.api.md
+++ b/common/api-review/firestore-lite.api.md
@@ -149,10 +149,8 @@ export interface FirestoreDataConverter<T> {
 // @public
 export class FirestoreError {
     readonly code: FirestoreErrorCode;
-    // (undocumented)
     customData?: Record<string, unknown>;
     readonly message: string;
-    // (undocumented)
     name: 'FirebaseError';
     readonly stack?: string;
 }

--- a/common/api-review/firestore-lite.api.md
+++ b/common/api-review/firestore-lite.api.md
@@ -6,6 +6,7 @@
 
 import { EmulatorMockTokenOptions } from '@firebase/util';
 import { FirebaseApp } from '@firebase/app';
+import { FirebaseError } from '@firebase/util';
 import { LogLevelString as LogLevel } from '@firebase/logger';
 
 // @public
@@ -147,11 +148,9 @@ export interface FirestoreDataConverter<T> {
 }
 
 // @public
-export class FirestoreError {
+export class FirestoreError extends FirebaseError {
     readonly code: FirestoreErrorCode;
-    customData?: Record<string, unknown>;
     readonly message: string;
-    name: 'FirebaseError';
     readonly stack?: string;
 }
 

--- a/common/api-review/firestore.api.md
+++ b/common/api-review/firestore.api.md
@@ -6,6 +6,7 @@
 
 import { EmulatorMockTokenOptions } from '@firebase/util';
 import { FirebaseApp } from '@firebase/app';
+import { FirebaseError } from '@firebase/util';
 import { LogLevelString as LogLevel } from '@firebase/logger';
 
 // @public
@@ -177,11 +178,9 @@ export interface FirestoreDataConverter<T> {
 }
 
 // @public
-export class FirestoreError {
+export class FirestoreError extends FirebaseError {
     readonly code: FirestoreErrorCode;
-    customData?: Record<string, unknown>;
     readonly message: string;
-    name: 'FirebaseError';
     readonly stack?: string;
 }
 

--- a/common/api-review/firestore.api.md
+++ b/common/api-review/firestore.api.md
@@ -179,10 +179,8 @@ export interface FirestoreDataConverter<T> {
 // @public
 export class FirestoreError {
     readonly code: FirestoreErrorCode;
-    // (undocumented)
     customData?: Record<string, unknown>;
     readonly message: string;
-    // (undocumented)
     name: 'FirebaseError';
     readonly stack?: string;
 }

--- a/common/api-review/storage.api.md
+++ b/common/api-review/storage.api.md
@@ -10,6 +10,7 @@ import { EmulatorMockTokenOptions } from '@firebase/util';
 import { FirebaseApp } from '@firebase/app';
 import { FirebaseAuthInternalName } from '@firebase/auth-interop-types';
 import { FirebaseError } from '@firebase/util';
+import { FirebaseError as FirebaseError_2 } from '@firebase/app';
 import { _FirebaseService } from '@firebase/app';
 import { NextFn } from '@firebase/util';
 import { Provider } from '@firebase/component';

--- a/common/api-review/storage.api.md
+++ b/common/api-review/storage.api.md
@@ -10,7 +10,6 @@ import { EmulatorMockTokenOptions } from '@firebase/util';
 import { FirebaseApp } from '@firebase/app';
 import { FirebaseAuthInternalName } from '@firebase/auth-interop-types';
 import { FirebaseError } from '@firebase/util';
-import { FirebaseError as FirebaseError_2 } from '@firebase/app';
 import { _FirebaseService } from '@firebase/app';
 import { NextFn } from '@firebase/util';
 import { Provider } from '@firebase/component';

--- a/packages/firestore/src/util/error.ts
+++ b/packages/firestore/src/util/error.ts
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+import { FirebaseError } from '@firebase/app';
+
 /**
  * The set of Firestore status codes. The codes are the same at the ones
  * exposed by gRPC here:
@@ -208,10 +210,7 @@ export const Code = {
 };
 
 /** An error returned by a Firestore operation. */
-export class FirestoreError extends Error {
-  /** The custom name for all FirestoreErrors. */
-  readonly name: string = 'FirebaseError';
-
+export class FirestoreError extends FirebaseError {
   /** The stack of the error. */
   readonly stack?: string;
 
@@ -226,7 +225,7 @@ export class FirestoreError extends Error {
      */
     readonly message: string
   ) {
-    super(message);
+    super(code, message);
 
     // HACK: We write a toString property directly because Error is not a real
     // class and so inheritance does not work correctly. We could alternatively

--- a/packages/firestore/src/util/error.ts
+++ b/packages/firestore/src/util/error.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { FirebaseError } from '@firebase/app';
+import { FirebaseError } from '@firebase/util';
 
 /**
  * The set of Firestore status codes. The codes are the same at the ones

--- a/packages/storage/src/implementation/error.ts
+++ b/packages/storage/src/implementation/error.ts
@@ -1,4 +1,5 @@
-import { FirebaseError } from '@firebase/util';
+import { FirebaseError } from '@firebase/app';
+
 /**
  * @license
  * Copyright 2017 Google LLC

--- a/packages/storage/src/implementation/error.ts
+++ b/packages/storage/src/implementation/error.ts
@@ -1,4 +1,4 @@
-import { FirebaseError } from '@firebase/app';
+import { FirebaseError } from '@firebase/util';
 
 /**
  * @license

--- a/packages/util/src/errors.ts
+++ b/packages/util/src/errors.ts
@@ -72,11 +72,14 @@ export interface ErrorData {
 // Based on code from:
 // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error#Custom_Error_Types
 export class FirebaseError extends Error {
+  /** The custom name for all FirebaseErrors. */
   readonly name = ERROR_NAME;
 
   constructor(
+    /** The error code for this error. */
     readonly code: string,
     message: string,
+    /** Custom data for this error. */
     public customData?: Record<string, unknown>
   ) {
     super(message);

--- a/repo-scripts/prune-dts/.run/AllTests.run.xml
+++ b/repo-scripts/prune-dts/.run/AllTests.run.xml
@@ -1,0 +1,19 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="All Tests" type="mocha-javascript-test-runner">
+    <node-interpreter>project</node-interpreter>
+    <node-options />
+    <mocha-package>$PROJECT_DIR$/../../node_modules/mocha</mocha-package>
+    <working-directory>$PROJECT_DIR$</working-directory>
+    <pass-parent-env>true</pass-parent-env>
+    <envs>
+      <env name="TS_NODE_COMPILER_OPTIONS" value="{&quot;module&quot;:&quot;commonjs&quot;}" />
+      <env name="TS_NODE_FILES" value="true" />
+      <env name="TS_NODE_CACHE" value="NO" />
+    </envs>
+    <ui>bdd</ui>
+    <extra-mocha-options>--require ts-node/register/type-check</extra-mocha-options>
+    <test-kind>PATTERN</test-kind>
+    <test-pattern>*.test.ts</test-pattern>
+    <method v="2" />
+  </configuration>
+</component>

--- a/repo-scripts/prune-dts/extract-public-api.ts
+++ b/repo-scripts/prune-dts/extract-public-api.ts
@@ -138,7 +138,7 @@ export async function generateApi(
   untrimmedRollupDtsPath: string,
   publicDtsPath: string
 ): Promise<void> {
-  console.log(`Configuring API Extractor for #{packageName}`);
+  console.log(`Configuring API Extractor for ${packageName}`);
   writeTypescriptConfig(packageRoot);
   writePackageJson(packageName);
 

--- a/repo-scripts/prune-dts/prune-dts.ts
+++ b/repo-scripts/prune-dts/prune-dts.ts
@@ -119,11 +119,15 @@ function isExported(
   sourceFile: ts.SourceFile,
   name: ts.Identifier
 ): boolean {
+  const declarations =
+    typeChecker.getSymbolAtLocation(name)?.declarations ?? [];
+
   // Check is this is a public symbol (e.g. part of the DOM library)
-  const sourceFileNames = typeChecker
-    .getSymbolAtLocation(name)
-    ?.declarations?.map(d => d.getSourceFile().fileName);
-  if (sourceFileNames?.find(s => s.indexOf('typescript/lib') != -1)) {
+  const isTypescriptType = declarations.find(
+    d => d.getSourceFile().fileName.indexOf('typescript/lib') != -1
+  );
+  const isImported = declarations.find(d => ts.isImportSpecifier(d));
+  if (isTypescriptType || isImported) {
     return true;
   }
 

--- a/repo-scripts/prune-dts/tests/error.input.d.ts
+++ b/repo-scripts/prune-dts/tests/error.input.d.ts
@@ -1,0 +1,7 @@
+import { FirebaseError } from '@firebase/util';
+
+export declare interface StorageError extends FirebaseError {
+  serverResponse: string | null;
+}
+
+export {};

--- a/repo-scripts/prune-dts/tests/error.input.d.ts
+++ b/repo-scripts/prune-dts/tests/error.input.d.ts
@@ -1,3 +1,19 @@
+/**
+ * @license
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 import { FirebaseError } from '@firebase/util';
 
 export declare interface StorageError extends FirebaseError {

--- a/repo-scripts/prune-dts/tests/error.output.d.ts
+++ b/repo-scripts/prune-dts/tests/error.output.d.ts
@@ -1,0 +1,5 @@
+import { FirebaseError } from '@firebase/util';
+export declare interface StorageError extends FirebaseError {
+  serverResponse: string | null;
+}
+export {};

--- a/repo-scripts/prune-dts/tests/error.output.d.ts
+++ b/repo-scripts/prune-dts/tests/error.output.d.ts
@@ -1,3 +1,19 @@
+/**
+ * @license
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 import { FirebaseError } from '@firebase/util';
 export declare interface StorageError extends FirebaseError {
   serverResponse: string | null;


### PR DESCRIPTION
This changes FirestoreError to extend FirebaseError and updates the "Prune DTS" script to not remove this change again.

As part of this, I added a new test to "Prune DTS" and added a test runner for IntelliJ/WebStorm.

Fixes https://github.com/firebase/firebase-js-sdk/issues/5754