### PR TITLE
DO NOT MERGE: Upgrade idb version from 3.2.0 to 7.0.0

### DIFF
--- a/.changeset/quiet-years-sleep.md
+++ b/.changeset/quiet-years-sleep.md
@@ -1,0 +1,7 @@
+---
+'@firebase/installations': patch
+'@firebase/installations-compat': patch
+'@firebase/messaging': patch
+---
+
+Update `idb` dependency from 3.0.2 to 7.0.0.

--- a/packages/installations-compat/package.json
+++ b/packages/installations-compat/package.json
@@ -61,7 +61,7 @@
     "@firebase/installations-types": "0.4.0",
     "@firebase/util": "1.4.3",
     "@firebase/component": "0.5.10",
-    "idb": "3.0.2",
+    "idb": "7.0.0",
     "tslib": "^2.1.0"
   }
 }

--- a/packages/installations/package.json
+++ b/packages/installations/package.json
@@ -64,7 +64,7 @@
   "dependencies": {
     "@firebase/util": "1.4.3",
     "@firebase/component": "0.5.10",
-    "idb": "3.0.2",
+    "idb": "7.0.0",
     "tslib": "^2.1.0"
   }
 }

--- a/packages/installations/src/helpers/idb-manager.ts
+++ b/packages/installations/src/helpers/idb-manager.ts
@@ -28,17 +28,19 @@ const OBJECT_STORE_NAME = 'firebase-installations-store';
 let dbPromise: Promise<IDBPDatabase> | null = null;
 function getDbPromise(): Promise<IDBPDatabase> {
   if (!dbPromise) {
-    dbPromise = openDB(DATABASE_NAME, DATABASE_VERSION, {upgrade: (db, oldVersion) => {
-      // We don't use 'break' in this switch statement, the fall-through
-      // behavior is what we want, because if there are multiple versions between
-      // the old version and the current version, we want ALL the migrations
-      // that correspond to those versions to run, not only the last one.
-      // eslint-disable-next-line default-case
-      switch (oldVersion) {
-        case 0:
-          db.createObjectStore(OBJECT_STORE_NAME);
+    dbPromise = openDB(DATABASE_NAME, DATABASE_VERSION, {
+      upgrade: (db, oldVersion) => {
+        // We don't use 'break' in this switch statement, the fall-through
+        // behavior is what we want, because if there are multiple versions between
+        // the old version and the current version, we want ALL the migrations
+        // that correspond to those versions to run, not only the last one.
+        // eslint-disable-next-line default-case
+        switch (oldVersion) {
+          case 0:
+            db.createObjectStore(OBJECT_STORE_NAME);
+        }
       }
-    }});
+    });
   }
   return dbPromise;
 }

--- a/packages/messaging/package.json
+++ b/packages/messaging/package.json
@@ -51,7 +51,7 @@
     "@firebase/messaging-interop-types": "0.1.0",
     "@firebase/util": "1.4.3",
     "@firebase/component": "0.5.10",
-    "idb": "3.0.2",
+    "idb": "7.0.0",
     "tslib": "^2.1.0"
   },
   "devDependencies": {

--- a/packages/messaging/src/helpers/migrate-old-database.test.ts
+++ b/packages/messaging/src/helpers/migrate-old-database.test.ts
@@ -28,7 +28,7 @@ import { FakePushSubscription } from '../testing/fakes/service-worker';
 import { base64ToArray } from './array-base64-translator';
 import { expect } from 'chai';
 import { getFakeTokenDetails } from '../testing/fakes/token-details';
-import { openDb } from 'idb';
+import { openDB } from 'idb';
 
 describe('migrateOldDb', () => {
   it("does nothing if old DB didn't exist", async () => {
@@ -179,25 +179,27 @@ describe('migrateOldDb', () => {
 });
 
 async function put(version: number, value: object): Promise<void> {
-  const db = await openDb('fcm_token_details_db', version, upgradeDb => {
-    if (upgradeDb.oldVersion === 0) {
-      const objectStore = upgradeDb.createObjectStore(
-        'fcm_token_object_Store',
-        {
-          keyPath: 'swScope'
-        }
-      );
-      objectStore.createIndex('fcmSenderId', 'fcmSenderId', {
-        unique: false
-      });
-      objectStore.createIndex('fcmToken', 'fcmToken', { unique: true });
+  const db = await openDB('fcm_token_details_db', version, {
+    upgrade: (upgradeDb, oldVersion) => {
+      if (oldVersion === 0) {
+        const objectStore = upgradeDb.createObjectStore(
+          'fcm_token_object_Store',
+          {
+            keyPath: 'swScope'
+          }
+        );
+        objectStore.createIndex('fcmSenderId', 'fcmSenderId', {
+          unique: false
+        });
+        objectStore.createIndex('fcmToken', 'fcmToken', { unique: true });
+      }
     }
   });
 
   try {
     const tx = db.transaction('fcm_token_object_Store', 'readwrite');
     await tx.objectStore('fcm_token_object_Store').put(value);
-    await tx.complete;
+    await tx.done;
   } finally {
     db.close();
   }

--- a/packages/messaging/src/helpers/migrate-old-database.ts
+++ b/packages/messaging/src/helpers/migrate-old-database.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { deleteDb, openDb } from 'idb';
+import { deleteDB, openDB } from 'idb';
 
 import { TokenDetails } from '../interfaces/token-details';
 import { arrayToBase64 } from './array-base64-translator';
@@ -88,83 +88,85 @@ export async function migrateOldDatabase(
 
   let tokenDetails: TokenDetails | null = null;
 
-  const db = await openDb(OLD_DB_NAME, OLD_DB_VERSION, async db => {
-    if (db.oldVersion < 2) {
-      // Database too old, skip migration.
-      return;
-    }
-
-    if (!db.objectStoreNames.contains(OLD_OBJECT_STORE_NAME)) {
-      // Database did not exist. Nothing to do.
-      return;
-    }
-
-    const objectStore = db.transaction.objectStore(OLD_OBJECT_STORE_NAME);
-    const value = await objectStore.index('fcmSenderId').get(senderId);
-    await objectStore.clear();
-
-    if (!value) {
-      // No entry in the database, nothing to migrate.
-      return;
-    }
-
-    if (db.oldVersion === 2) {
-      const oldDetails = value as V2TokenDetails;
-
-      if (!oldDetails.auth || !oldDetails.p256dh || !oldDetails.endpoint) {
+  const db = await openDB(OLD_DB_NAME, OLD_DB_VERSION, {
+    upgrade: async (db, oldVersion, _newVersion, transaction) => {
+      if (oldVersion < 2) {
+        // Database too old, skip migration.
         return;
       }
 
-      tokenDetails = {
-        token: oldDetails.fcmToken,
-        createTime: oldDetails.createTime ?? Date.now(),
-        subscriptionOptions: {
-          auth: oldDetails.auth,
-          p256dh: oldDetails.p256dh,
-          endpoint: oldDetails.endpoint,
-          swScope: oldDetails.swScope,
-          vapidKey:
-            typeof oldDetails.vapidKey === 'string'
-              ? oldDetails.vapidKey
-              : arrayToBase64(oldDetails.vapidKey)
-        }
-      };
-    } else if (db.oldVersion === 3) {
-      const oldDetails = value as V3TokenDetails;
+      if (!db.objectStoreNames.contains(OLD_OBJECT_STORE_NAME)) {
+        // Database did not exist. Nothing to do.
+        return;
+      }
 
-      tokenDetails = {
-        token: oldDetails.fcmToken,
-        createTime: oldDetails.createTime,
-        subscriptionOptions: {
-          auth: arrayToBase64(oldDetails.auth),
-          p256dh: arrayToBase64(oldDetails.p256dh),
-          endpoint: oldDetails.endpoint,
-          swScope: oldDetails.swScope,
-          vapidKey: arrayToBase64(oldDetails.vapidKey)
-        }
-      };
-    } else if (db.oldVersion === 4) {
-      const oldDetails = value as V4TokenDetails;
+      const objectStore = transaction.objectStore(OLD_OBJECT_STORE_NAME);
+      const value = await objectStore.index('fcmSenderId').get(senderId);
+      await objectStore.clear();
 
-      tokenDetails = {
-        token: oldDetails.fcmToken,
-        createTime: oldDetails.createTime,
-        subscriptionOptions: {
-          auth: arrayToBase64(oldDetails.auth),
-          p256dh: arrayToBase64(oldDetails.p256dh),
-          endpoint: oldDetails.endpoint,
-          swScope: oldDetails.swScope,
-          vapidKey: arrayToBase64(oldDetails.vapidKey)
+      if (!value) {
+        // No entry in the database, nothing to migrate.
+        return;
+      }
+
+      if (oldVersion === 2) {
+        const oldDetails = value as V2TokenDetails;
+
+        if (!oldDetails.auth || !oldDetails.p256dh || !oldDetails.endpoint) {
+          return;
         }
-      };
+
+        tokenDetails = {
+          token: oldDetails.fcmToken,
+          createTime: oldDetails.createTime ?? Date.now(),
+          subscriptionOptions: {
+            auth: oldDetails.auth,
+            p256dh: oldDetails.p256dh,
+            endpoint: oldDetails.endpoint,
+            swScope: oldDetails.swScope,
+            vapidKey:
+              typeof oldDetails.vapidKey === 'string'
+                ? oldDetails.vapidKey
+                : arrayToBase64(oldDetails.vapidKey)
+          }
+        };
+      } else if (oldVersion === 3) {
+        const oldDetails = value as V3TokenDetails;
+
+        tokenDetails = {
+          token: oldDetails.fcmToken,
+          createTime: oldDetails.createTime,
+          subscriptionOptions: {
+            auth: arrayToBase64(oldDetails.auth),
+            p256dh: arrayToBase64(oldDetails.p256dh),
+            endpoint: oldDetails.endpoint,
+            swScope: oldDetails.swScope,
+            vapidKey: arrayToBase64(oldDetails.vapidKey)
+          }
+        };
+      } else if (oldVersion === 4) {
+        const oldDetails = value as V4TokenDetails;
+
+        tokenDetails = {
+          token: oldDetails.fcmToken,
+          createTime: oldDetails.createTime,
+          subscriptionOptions: {
+            auth: arrayToBase64(oldDetails.auth),
+            p256dh: arrayToBase64(oldDetails.p256dh),
+            endpoint: oldDetails.endpoint,
+            swScope: oldDetails.swScope,
+            vapidKey: arrayToBase64(oldDetails.vapidKey)
+          }
+        };
+      }
     }
   });
   db.close();
 
   // Delete all old databases.
-  await deleteDb(OLD_DB_NAME);
-  await deleteDb('fcm_vapid_details_db');
-  await deleteDb('undefined');
+  await deleteDB(OLD_DB_NAME);
+  await deleteDB('fcm_vapid_details_db');
+  await deleteDB('undefined');
 
   return checkTokenDetails(tokenDetails) ? tokenDetails : null;
 }

--- a/packages/messaging/src/internals/idb-manager.ts
+++ b/packages/messaging/src/internals/idb-manager.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { DB, deleteDb, openDb } from 'idb';
+import { IDBPDatabase, deleteDB, openDB } from 'idb';
 
 import { FirebaseInternalDependencies } from '../interfaces/internal-dependencies';
 import { TokenDetails } from '../interfaces/token-details';
@@ -26,17 +26,19 @@ export const DATABASE_NAME = 'firebase-messaging-database';
 const DATABASE_VERSION = 1;
 const OBJECT_STORE_NAME = 'firebase-messaging-store';
 
-let dbPromise: Promise<DB> | null = null;
-function getDbPromise(): Promise<DB> {
+let dbPromise: Promise<IDBPDatabase> | null = null;
+function getDbPromise(): Promise<IDBPDatabase> {
   if (!dbPromise) {
-    dbPromise = openDb(DATABASE_NAME, DATABASE_VERSION, upgradeDb => {
-      // We don't use 'break' in this switch statement, the fall-through behavior is what we want,
-      // because if there are multiple versions between the old version and the current version, we
-      // want ALL the migrations that correspond to those versions to run, not only the last one.
-      // eslint-disable-next-line default-case
-      switch (upgradeDb.oldVersion) {
-        case 0:
-          upgradeDb.createObjectStore(OBJECT_STORE_NAME);
+    dbPromise = openDB(DATABASE_NAME, DATABASE_VERSION, {
+      upgrade: (upgradeDb, oldVersion) => {
+        // We don't use 'break' in this switch statement, the fall-through behavior is what we want,
+        // because if there are multiple versions between the old version and the current version, we
+        // want ALL the migrations that correspond to those versions to run, not only the last one.
+        // eslint-disable-next-line default-case
+        switch (oldVersion) {
+          case 0:
+            upgradeDb.createObjectStore(OBJECT_STORE_NAME);
+        }
       }
     });
   }
@@ -77,7 +79,7 @@ export async function dbSet(
   const db = await getDbPromise();
   const tx = db.transaction(OBJECT_STORE_NAME, 'readwrite');
   await tx.objectStore(OBJECT_STORE_NAME).put(tokenDetails, key);
-  await tx.complete;
+  await tx.done;
   return tokenDetails;
 }
 
@@ -89,14 +91,14 @@ export async function dbRemove(
   const db = await getDbPromise();
   const tx = db.transaction(OBJECT_STORE_NAME, 'readwrite');
   await tx.objectStore(OBJECT_STORE_NAME).delete(key);
-  await tx.complete;
+  await tx.done;
 }
 
 /** Deletes the DB. Useful for tests. */
 export async function dbDelete(): Promise<void> {
   if (dbPromise) {
     (await dbPromise).close();
-    await deleteDb(DATABASE_NAME);
+    await deleteDB(DATABASE_NAME);
     dbPromise = null;
   }
 }

--- a/packages/messaging/src/testing/setup.ts
+++ b/packages/messaging/src/testing/setup.ts
@@ -19,7 +19,7 @@ import chaiAsPromised from 'chai-as-promised';
 import sinonChai from 'sinon-chai';
 
 import { dbDelete } from '../internals/idb-manager';
-import { deleteDb } from 'idb';
+import { deleteDB } from 'idb';
 import { restore } from 'sinon';
 import { use } from 'chai';
 
@@ -29,5 +29,5 @@ use(sinonChai);
 afterEach(async () => {
   restore();
   await dbDelete();
-  await deleteDb('fcm_token_details_db');
+  await deleteDB('fcm_token_details_db');
 });

--- a/renovate.json
+++ b/renovate.json
@@ -17,7 +17,6 @@
     "protractor",
     "long",
     "rollup-plugin-copy-assets",
-    "idb",
     "whatwg-fetch",
     "typedoc",
     "@microsoft/tsdoc"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8972,10 +8972,10 @@ iconv-lite@0.6.3, iconv-lite@^0.6.2:
   dependencies:
     safer-buffer ">= 2.1.2 < 3.0.0"
 
-idb@3.0.2:
-  version "3.0.2"
-  resolved "https://registry.npmjs.org/idb/-/idb-3.0.2.tgz#c8e9122d5ddd40f13b60ae665e4862f8b13fa384"
-  integrity sha512-+FLa/0sTXqyux0o6C+i2lOR0VoS60LU/jzUo5xjfY6+7sEEgy4Gz1O7yFBXvjd7N0NyIGWIRg8DcQSLEG+VSPw==
+idb@7.0.0:
+  version "7.0.0"
+  resolved "https://registry.npmjs.org/idb/-/idb-7.0.0.tgz#f349b418c128f625961147a7d6b0e4b526fd34ed"
+  integrity sha512-jSx0WOY9Nj+QzP6wX5e7g64jqh8ExtDs/IAuOrOEZCD/h6+0HqyrKsDMfdJc0hqhSvh0LsrwqrkDn+EtjjzSRA==
 
 ieee754@^1.1.13, ieee754@^1.1.4:
   version "1.2.1"


### PR DESCRIPTION
We had locked our [idb](https://github.com/jakearchibald/idb) dependency version to 3.2.0 because it was the last version to support IE. Since we no longer support IE, we can now upgrade to the most recent version which is now 7.0.0. In addition to being good practice in general, this allows us to provide ES Module versions of installations and messaging which may solve some other packaging problems for users of various frameworks.

The API has changed slightly between 3.2.0 and 7.0.0 and I've made the corresponding changes to installations/messaging code.

Also removed idb from the Renovate ignore list so we will now get Renovate PRs whenever idb is updated.

Problem about incompatibility with Node ESM mentioned in https://github.com/firebase/firebase-js-sdk/pull/5646 should be resolved in 7.0.0 (see https://github.com/jakearchibald/idb/pull/235#issuecomment-957589722). This should enable us to offer a Node ESM export in messaging, which will address https://github.com/firebase/firebase-js-sdk/issues/5839.