### PR TITLE
Update mismatching UID error code to USER_MISMATCH

### DIFF
--- a/packages/auth/src/core/strategies/custom_token.test.ts
+++ b/packages/auth/src/core/strategies/custom_token.test.ts
@@ -155,7 +155,7 @@ describe('core/strategies/signInWithCustomToken', () => {
       setCustomTokenProvider(auth, provider);
       await expect(auth._refreshWithCustomTokenProvider!()).to.be.rejectedWith(
         FirebaseError,
-        'Firebase: Error (auth/internal-error).'
+        'Firebase: The supplied credentials do not correspond to the previously signed in user. (auth/user-mismatch).'
       );
     });
   });

--- a/packages/auth/src/core/strategies/custom_token.ts
+++ b/packages/auth/src/core/strategies/custom_token.ts
@@ -99,8 +99,8 @@ export function setCustomTokenProvider(
     });
     const responseToken = _parseToken(response.idToken!);
     _assert(
-      responseToken?.sub === authInternal.currentUser?.uid,
-      AuthErrorCode.INTERNAL_ERROR
+      responseToken?.sub === authInternal.currentUser?.uid, auth,
+      AuthErrorCode.USER_MISMATCH
     );
     const user = authInternal.currentUser as UserInternal;
     user.stsTokenManager.updateFromServerResponse(response);


### PR DESCRIPTION
### Discussion

As the title implies - USER_MISMATCH is a more descriptive error code than INTERNAL_ERROR. This will also be reflected in iOS and Android.

Corresponding internal bug: b/192699639

### Testing

* `yarn test:browser:unit` passes
