### PR TITLE
Fix message id parsing

### DIFF
--- a/.changeset/unlucky-bottles-wait.md
+++ b/.changeset/unlucky-bottles-wait.md
@@ -1,0 +1,5 @@
+---
+"@firebase/messaging": patch
+---
+
+Fix message id parsing.

--- a/packages/messaging/src/helpers/externalizePayload.test.ts
+++ b/packages/messaging/src/helpers/externalizePayload.test.ts
@@ -32,7 +32,7 @@ describe('externalizePayload', () => {
       // eslint-disable-next-line camelcase
       collapse_key: 'collapse',
       // eslint-disable-next-line camelcase
-      fcm_message_id: 'mid'
+      fcmMessageId: 'mid'
     };
 
     const payload: MessagePayload = {
@@ -55,7 +55,7 @@ describe('externalizePayload', () => {
       // eslint-disable-next-line camelcase
       collapse_key: 'collapse',
       // eslint-disable-next-line camelcase
-      fcm_message_id: 'mid'
+      fcmMessageId: 'mid'
     };
 
     const payload: MessagePayload = {
@@ -88,7 +88,7 @@ describe('externalizePayload', () => {
       // eslint-disable-next-line camelcase
       collapse_key: 'collapse',
       // eslint-disable-next-line camelcase
-      fcm_message_id: 'mid'
+      fcmMessageId: 'mid'
     };
 
     const payload: MessagePayload = {

--- a/packages/messaging/src/helpers/externalizePayload.ts
+++ b/packages/messaging/src/helpers/externalizePayload.ts
@@ -26,7 +26,7 @@ export function externalizePayload(
     // eslint-disable-next-line camelcase
     collapseKey: internalPayload.collapse_key,
     // eslint-disable-next-line camelcase
-    messageId: internalPayload.fcm_message_id
+    messageId: internalPayload.fcmMessageId
   } as MessagePayload;
 
   propagateNotificationPayload(payload, internalPayload);

--- a/packages/messaging/src/helpers/logToFirelog.ts
+++ b/packages/messaging/src/helpers/logToFirelog.ts
@@ -177,8 +177,8 @@ function createFcmEvent(
     fcmEvent.project_number = internalPayload.from;
   }
 
-  if (!!internalPayload.fcm_message_id) {
-    fcmEvent.message_id = internalPayload.fcm_message_id;
+  if (!!internalPayload.fcmMessageId) {
+    fcmEvent.message_id = internalPayload.fcmMessageId;
   }
 
   fcmEvent.instance_id = fid;

--- a/packages/messaging/src/interfaces/internal-message-payload.ts
+++ b/packages/messaging/src/interfaces/internal-message-payload.ts
@@ -27,10 +27,9 @@ export interface MessagePayloadInternal {
   messageType?: MessageType;
   isFirebaseMessaging?: boolean;
   from: string;
+  fcmMessageId: string;
   // eslint-disable-next-line camelcase
   collapse_key: string;
-  // eslint-disable-next-line camelcase
-  fcm_message_id: string;
 }
 
 export interface NotificationPayloadInternal extends NotificationOptions {

--- a/packages/messaging/src/listeners/sw-listeners.test.ts
+++ b/packages/messaging/src/listeners/sw-listeners.test.ts
@@ -76,7 +76,7 @@ const DISPLAY_MESSAGE: MessagePayloadInternal = {
   // eslint-disable-next-line camelcase
   collapse_key: 'collapse',
   // eslint-disable-next-line camelcase
-  fcm_message_id: 'mid'
+  fcmMessageId: 'mid'
 };
 
 describe('SwController', () => {


### PR DESCRIPTION
Message Id  is passed down to the SDK as camel case as opposed to snake case.

The previous implementation resulted `mid=null` for all messages.  