### PR TITLE
Load Protos from JSON

### DIFF
--- a/.changeset/selfish-pots-fetch.md
+++ b/.changeset/selfish-pots-fetch.md
@@ -2,4 +2,4 @@
 "@firebase/firestore": patch
 ---
 
-The Node SDK now uses JSON to load its internal Protobuf definition, which allows the Node SDK to work bundlers such as Rollup and Webpack.
+The Node SDK now uses JSON to load its internal Protobuf definition, which allows the Node SDK to work with bundlers such as Rollup and Webpack.

--- a/.changeset/selfish-pots-fetch.md
+++ b/.changeset/selfish-pots-fetch.md
@@ -1,0 +1,5 @@
+---
+"@firebase/firestore": patch
+---
+
+The Node SDK now uses JSON to load its internal Protobuf definition, which allows the Node SDK to work bundlers such as Rollup and Webpack.

--- a/packages/firestore/rollup.config.lite.js
+++ b/packages/firestore/rollup.config.lite.js
@@ -22,7 +22,6 @@ import alias from '@rollup/plugin-alias';
 import typescriptPlugin from 'rollup-plugin-typescript2';
 import typescript from 'typescript';
 import sourcemaps from 'rollup-plugin-sourcemaps';
-import copy from 'rollup-plugin-copy';
 import replace from 'rollup-plugin-replace';
 import { terser } from 'rollup-plugin-terser';
 
@@ -44,18 +43,7 @@ const nodePlugins = function () {
       abortOnError: false,
       transformers: [util.removeAssertTransformer]
     }),
-    json({ preferConst: true }),
-    copy({
-      targets: [
-        {
-          src: 'src/protos',
-          dest: 'dist/lite/src'
-        }
-      ]
-    }),
-    replace({
-      'process.env.FIRESTORE_PROTO_ROOT': JSON.stringify('src/protos')
-    })
+    json({ preferConst: true })
   ];
 };
 

--- a/packages/firestore/src/platform/node/load_protos.ts
+++ b/packages/firestore/src/platform/node/load_protos.ts
@@ -15,19 +15,15 @@
  * limitations under the License.
  */
 
-import { join, resolve, isAbsolute, dirname } from 'path';
-import { fileURLToPath } from 'url';
-
-// __filename and __dirname globals are unavailable in ES modules
-// @ts-ignore To avoid using `--module es2020` flag.
-const __filenameInESM = fileURLToPath(import.meta.url);
-const __dirnameInESM = dirname(__filenameInESM);
+import { join, resolve, isAbsolute } from 'path';
 
 import { loadPackageDefinition, GrpcObject } from '@grpc/grpc-js';
-import { loadSync } from '@grpc/proto-loader';
+import { fromJSON } from '@grpc/proto-loader';
 // only used in tests
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { IConversionOptions, Root } from 'protobufjs';
+
+import * as protos from '../../protos/protos.json';
 
 /** Used by tests so we can match @grpc/proto-loader behavior. */
 export const protoLoaderOptions: IConversionOptions = {
@@ -43,17 +39,7 @@ export const protoLoaderOptions: IConversionOptions = {
  * @returns The GrpcObject representing our protos.
  */
 export function loadProtos(): GrpcObject {
-  const root = resolve(
-    __dirnameInESM,
-    process.env.FIRESTORE_PROTO_ROOT || '../../protos'
-  );
-  const firestoreProtoFile = join(root, 'google/firestore/v1/firestore.proto');
-
-  const packageDefinition = loadSync(firestoreProtoFile, {
-    ...protoLoaderOptions,
-    includeDirs: [root]
-  });
-
+  const packageDefinition = fromJSON(protos, protoLoaderOptions);
   return loadPackageDefinition(packageDefinition);
 }
 

--- a/packages/firestore/src/protos/google/api/annotations.proto
+++ b/packages/firestore/src/protos/google/api/annotations.proto
@@ -1,4 +1,4 @@
-// Copyright (c) 2015, Google Inc.
+// Copyright 2015 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/firestore/src/protos/google/api/http.proto
+++ b/packages/firestore/src/protos/google/api/http.proto
@@ -1,4 +1,4 @@
-// Copyright 2018 Google LLC.
+// Copyright 2015 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,7 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
 
 syntax = "proto3";
 
@@ -24,7 +23,6 @@ option java_outer_classname = "HttpProto";
 option java_package = "com.google.api";
 option objc_class_prefix = "GAPI";
 
-
 // Defines the HTTP configuration for an API service. It contains a list of
 // [HttpRule][google.api.HttpRule], each specifying the mapping of an RPC method
 // to one or more HTTP REST API methods.
@@ -34,7 +32,7 @@ message Http {
   // **NOTE:** All service configuration rules follow "last one wins" order.
   repeated HttpRule rules = 1;
 
-  // When set to true, URL path parmeters will be fully URI-decoded except in
+  // When set to true, URL path parameters will be fully URI-decoded except in
   // cases of single segment matches in reserved expansion, where "%2F" will be
   // left encoded.
   //
@@ -112,7 +110,9 @@ message Http {
 //
 // HTTP | gRPC
 // -----|-----
-// `GET /v1/messages/123456?revision=2&sub.subfield=foo` | `GetMessage(message_id: "123456" revision: 2 sub: SubMessage(subfield: "foo"))`
+// `GET /v1/messages/123456?revision=2&sub.subfield=foo` |
+// `GetMessage(message_id: "123456" revision: 2 sub: SubMessage(subfield:
+// "foo"))`
 //
 // Note that fields which are mapped to URL query parameters must have a
 // primitive type or a repeated primitive type or a non-repeated message type.
@@ -144,7 +144,8 @@ message Http {
 //
 // HTTP | gRPC
 // -----|-----
-// `PATCH /v1/messages/123456 { "text": "Hi!" }` | `UpdateMessage(message_id: "123456" message { text: "Hi!" })`
+// `PATCH /v1/messages/123456 { "text": "Hi!" }` | `UpdateMessage(message_id:
+// "123456" message { text: "Hi!" })`
 //
 // The special name `*` can be used in the body mapping to define that
 // every field not bound by the path template should be mapped to the
@@ -169,7 +170,8 @@ message Http {
 //
 // HTTP | gRPC
 // -----|-----
-// `PATCH /v1/messages/123456 { "text": "Hi!" }` | `UpdateMessage(message_id: "123456" text: "Hi!")`
+// `PATCH /v1/messages/123456 { "text": "Hi!" }` | `UpdateMessage(message_id:
+// "123456" text: "Hi!")`
 //
 // Note that when using `*` in the body mapping, it is not possible to
 // have HTTP parameters, as all fields not bound by the path end in
@@ -200,7 +202,8 @@ message Http {
 // HTTP | gRPC
 // -----|-----
 // `GET /v1/messages/123456` | `GetMessage(message_id: "123456")`
-// `GET /v1/users/me/messages/123456` | `GetMessage(user_id: "me" message_id: "123456")`
+// `GET /v1/users/me/messages/123456` | `GetMessage(user_id: "me" message_id:
+// "123456")`
 //
 // ## Rules for HTTP mapping
 //
@@ -244,16 +247,18 @@ message Http {
 // `"{var=*}"`, when such a variable is expanded into a URL path on the client
 // side, all characters except `[-_.~0-9a-zA-Z]` are percent-encoded. The
 // server side does the reverse decoding. Such variables show up in the
-// [Discovery Document](https://developers.google.com/discovery/v1/reference/apis)
-// as `{var}`.
+// [Discovery
+// Document](https://developers.google.com/discovery/v1/reference/apis) as
+// `{var}`.
 //
 // If a variable contains multiple path segments, such as `"{var=foo/*}"`
 // or `"{var=**}"`, when such a variable is expanded into a URL path on the
 // client side, all characters except `[-_.~/0-9a-zA-Z]` are percent-encoded.
 // The server side does the reverse decoding, except "%2F" and "%2f" are left
 // unchanged. Such variables show up in the
-// [Discovery Document](https://developers.google.com/discovery/v1/reference/apis)
-// as `{+var}`.
+// [Discovery
+// Document](https://developers.google.com/discovery/v1/reference/apis) as
+// `{+var}`.
 //
 // ## Using gRPC API Service Configuration
 //

--- a/packages/firestore/src/protos/google/firestore/v1/common.proto
+++ b/packages/firestore/src/protos/google/firestore/v1/common.proto
@@ -1,4 +1,4 @@
-// Copyright 2018 Google LLC.
+// Copyright 2021 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,14 +11,13 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
 
 syntax = "proto3";
 
 package google.firestore.v1;
 
-import "google/api/annotations.proto";
 import "google/protobuf/timestamp.proto";
+import "google/api/annotations.proto";
 
 option csharp_namespace = "Google.Cloud.Firestore.V1";
 option go_package = "google.golang.org/genproto/googleapis/firestore/v1;firestore";
@@ -27,7 +26,7 @@ option java_outer_classname = "CommonProto";
 option java_package = "com.google.firestore.v1";
 option objc_class_prefix = "GCFS";
 option php_namespace = "Google\\Cloud\\Firestore\\V1";
-
+option ruby_package = "Google::Cloud::Firestore::V1";
 
 // A set of field paths on a document.
 // Used to restrict a get or update operation on a document to a subset of its

--- a/packages/firestore/src/protos/google/firestore/v1/document.proto
+++ b/packages/firestore/src/protos/google/firestore/v1/document.proto
@@ -1,4 +1,4 @@
-// Copyright 2018 Google LLC.
+// Copyright 2021 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,16 +11,15 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
 
 syntax = "proto3";
 
 package google.firestore.v1;
 
-import "google/api/annotations.proto";
 import "google/protobuf/struct.proto";
 import "google/protobuf/timestamp.proto";
 import "google/type/latlng.proto";
+import "google/api/annotations.proto";
 
 option csharp_namespace = "Google.Cloud.Firestore.V1";
 option go_package = "google.golang.org/genproto/googleapis/firestore/v1;firestore";
@@ -29,7 +28,7 @@ option java_outer_classname = "DocumentProto";
 option java_package = "com.google.firestore.v1";
 option objc_class_prefix = "GCFS";
 option php_namespace = "Google\\Cloud\\Firestore\\V1";
-
+option ruby_package = "Google::Cloud::Firestore::V1";
 
 // A Firestore document.
 //

--- a/packages/firestore/src/protos/google/firestore/v1/firestore.proto
+++ b/packages/firestore/src/protos/google/firestore/v1/firestore.proto
@@ -1,4 +1,4 @@
-// Copyright 2018 Google LLC.
+// Copyright 2021 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,13 +11,14 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
 
 syntax = "proto3";
 
 package google.firestore.v1;
 
 import "google/api/annotations.proto";
+import "google/api/client.proto";
+import "google/api/field_behavior.proto";
 import "google/firestore/v1/common.proto";
 import "google/firestore/v1/document.proto";
 import "google/firestore/v1/query.proto";
@@ -33,25 +34,24 @@ option java_outer_classname = "FirestoreProto";
 option java_package = "com.google.firestore.v1";
 option objc_class_prefix = "GCFS";
 option php_namespace = "Google\\Cloud\\Firestore\\V1";
+option ruby_package = "Google::Cloud::Firestore::V1";
+
 // Specification of the Firestore API.
 
 // The Cloud Firestore service.
 //
-// This service exposes several types of comparable timestamps:
-//
-// *    `create_time` - The time at which a document was created. Changes only
-//      when a document is deleted, then re-created. Increases in a strict
-//       monotonic fashion.
-// *    `update_time` - The time at which a document was last updated. Changes
-//      every time a document is modified. Does not change when a write results
-//      in no modifications. Increases in a strict monotonic fashion.
-// *    `read_time` - The time at which a particular state was observed. Used
-//      to denote a consistent snapshot of the database or the time at which a
-//      Document was observed to not exist.
-// *    `commit_time` - The time at which the writes in a transaction were
-//      committed. Any read with an equal or greater `read_time` is guaranteed
-//      to see the effects of the transaction.
+// Cloud Firestore is a fast, fully managed, serverless, cloud-native NoSQL
+// document database that simplifies storing, syncing, and querying data for
+// your mobile, web, and IoT apps at global scale. Its client libraries provide
+// live synchronization and offline support, while its security features and
+// integrations with Firebase and Google Cloud Platform (GCP) accelerate
+// building truly serverless apps.
 service Firestore {
+  option (google.api.default_host) = "firestore.googleapis.com";
+  option (google.api.oauth_scopes) =
+      "https://www.googleapis.com/auth/cloud-platform,"
+      "https://www.googleapis.com/auth/datastore";
+
   // Gets a single document.
   rpc GetDocument(GetDocumentRequest) returns (Document) {
     option (google.api.http) = {
@@ -66,20 +66,13 @@ service Firestore {
     };
   }
 
-  // Creates a new document.
-  rpc CreateDocument(CreateDocumentRequest) returns (Document) {
-    option (google.api.http) = {
-      post: "/v1/{parent=projects/*/databases/*/documents/**}/{collection_id}"
-      body: "document"
-    };
-  }
-
   // Updates or inserts a document.
   rpc UpdateDocument(UpdateDocumentRequest) returns (Document) {
     option (google.api.http) = {
       patch: "/v1/{document.name=projects/*/databases/*/documents/*/**}"
       body: "document"
     };
+    option (google.api.method_signature) = "document,update_mask";
   }
 
   // Deletes a document.
@@ -87,6 +80,7 @@ service Firestore {
     option (google.api.http) = {
       delete: "/v1/{name=projects/*/databases/*/documents/*/**}"
     };
+    option (google.api.method_signature) = "name";
   }
 
   // Gets multiple documents.
@@ -106,6 +100,7 @@ service Firestore {
       post: "/v1/{database=projects/*/databases/*}/documents:beginTransaction"
       body: "*"
     };
+    option (google.api.method_signature) = "database";
   }
 
   // Commits a transaction, while optionally updating documents.
@@ -114,6 +109,7 @@ service Firestore {
       post: "/v1/{database=projects/*/databases/*}/documents:commit"
       body: "*"
     };
+    option (google.api.method_signature) = "database,writes";
   }
 
   // Rolls back a transaction.
@@ -122,6 +118,7 @@ service Firestore {
       post: "/v1/{database=projects/*/databases/*}/documents:rollback"
       body: "*"
     };
+    option (google.api.method_signature) = "database,transaction";
   }
 
   // Runs a query.
@@ -131,6 +128,20 @@ service Firestore {
       body: "*"
       additional_bindings {
         post: "/v1/{parent=projects/*/databases/*/documents/*/**}:runQuery"
+        body: "*"
+      }
+    };
+  }
+
+  // Partitions a query by returning partition cursors that can be used to run
+  // the query in parallel. The returned partition cursors are split points that
+  // can be used by RunQuery as starting/end points for the query results.
+  rpc PartitionQuery(PartitionQueryRequest) returns (PartitionQueryResponse) {
+    option (google.api.http) = {
+      post: "/v1/{parent=projects/*/databases/*/documents}:partitionQuery"
+      body: "*"
+      additional_bindings {
+        post: "/v1/{parent=projects/*/databases/*/documents/*/**}:partitionQuery"
         body: "*"
       }
     };
@@ -162,14 +173,39 @@ service Firestore {
         body: "*"
       }
     };
+    option (google.api.method_signature) = "parent";
+  }
+
+  // Applies a batch of write operations.
+  //
+  // The BatchWrite method does not apply the write operations atomically
+  // and can apply them out of order. Method does not allow more than one write
+  // per document. Each write succeeds or fails independently. See the
+  // [BatchWriteResponse][google.firestore.v1.BatchWriteResponse] for the success status of each write.
+  //
+  // If you require an atomically applied set of writes, use
+  // [Commit][google.firestore.v1.Firestore.Commit] instead.
+  rpc BatchWrite(BatchWriteRequest) returns (BatchWriteResponse) {
+    option (google.api.http) = {
+      post: "/v1/{database=projects/*/databases/*}/documents:batchWrite"
+      body: "*"
+    };
+  }
+
+  // Creates a new document.
+  rpc CreateDocument(CreateDocumentRequest) returns (Document) {
+    option (google.api.http) = {
+      post: "/v1/{parent=projects/*/databases/*/documents/**}/{collection_id}"
+      body: "document"
+    };
   }
 }
 
 // The request for [Firestore.GetDocument][google.firestore.v1.Firestore.GetDocument].
 message GetDocumentRequest {
-  // The resource name of the Document to get. In the format:
+  // Required. The resource name of the Document to get. In the format:
   // `projects/{project_id}/databases/{database_id}/documents/{document_path}`.
-  string name = 1;
+  string name = 1 [(google.api.field_behavior) = REQUIRED];
 
   // The fields to return. If not set, returns all fields.
   //
@@ -184,24 +220,24 @@ message GetDocumentRequest {
     bytes transaction = 3;
 
     // Reads the version of the document at the given time.
-    // This may not be older than 60 seconds.
+    // This may not be older than 270 seconds.
     google.protobuf.Timestamp read_time = 5;
   }
 }
 
 // The request for [Firestore.ListDocuments][google.firestore.v1.Firestore.ListDocuments].
 message ListDocumentsRequest {
-  // The parent resource name. In the format:
+  // Required. The parent resource name. In the format:
   // `projects/{project_id}/databases/{database_id}/documents` or
   // `projects/{project_id}/databases/{database_id}/documents/{document_path}`.
   // For example:
   // `projects/my-project/databases/my-database/documents` or
   // `projects/my-project/databases/my-database/documents/chatrooms/my-chatroom`
-  string parent = 1;
+  string parent = 1 [(google.api.field_behavior) = REQUIRED];
 
-  // The collection ID, relative to `parent`, to list. For example: `chatrooms`
+  // Required. The collection ID, relative to `parent`, to list. For example: `chatrooms`
   // or `messages`.
-  string collection_id = 2;
+  string collection_id = 2 [(google.api.field_behavior) = REQUIRED];
 
   // The maximum number of documents to return.
   int32 page_size = 3;
@@ -225,7 +261,7 @@ message ListDocumentsRequest {
     bytes transaction = 8;
 
     // Reads documents as they were at the given time.
-    // This may not be older than 60 seconds.
+    // This may not be older than 270 seconds.
     google.protobuf.Timestamp read_time = 10;
   }
 
@@ -250,21 +286,21 @@ message ListDocumentsResponse {
 
 // The request for [Firestore.CreateDocument][google.firestore.v1.Firestore.CreateDocument].
 message CreateDocumentRequest {
-  // The parent resource. For example:
+  // Required. The parent resource. For example:
   // `projects/{project_id}/databases/{database_id}/documents` or
   // `projects/{project_id}/databases/{database_id}/documents/chatrooms/{chatroom_id}`
-  string parent = 1;
+  string parent = 1 [(google.api.field_behavior) = REQUIRED];
 
-  // The collection ID, relative to `parent`, to list. For example: `chatrooms`.
-  string collection_id = 2;
+  // Required. The collection ID, relative to `parent`, to list. For example: `chatrooms`.
+  string collection_id = 2 [(google.api.field_behavior) = REQUIRED];
 
   // The client-assigned document ID to use for this document.
   //
   // Optional. If not specified, an ID will be assigned by the service.
   string document_id = 3;
 
-  // The document to create. `name` must not be set.
-  Document document = 4;
+  // Required. The document to create. `name` must not be set.
+  Document document = 4 [(google.api.field_behavior) = REQUIRED];
 
   // The fields to return. If not set, returns all fields.
   //
@@ -275,9 +311,9 @@ message CreateDocumentRequest {
 
 // The request for [Firestore.UpdateDocument][google.firestore.v1.Firestore.UpdateDocument].
 message UpdateDocumentRequest {
-  // The updated document.
+  // Required. The updated document.
   // Creates the document if it does not already exist.
-  Document document = 1;
+  Document document = 1 [(google.api.field_behavior) = REQUIRED];
 
   // The fields to update.
   // None of the field paths in the mask may contain a reserved name.
@@ -301,9 +337,9 @@ message UpdateDocumentRequest {
 
 // The request for [Firestore.DeleteDocument][google.firestore.v1.Firestore.DeleteDocument].
 message DeleteDocumentRequest {
-  // The resource name of the Document to delete. In the format:
+  // Required. The resource name of the Document to delete. In the format:
   // `projects/{project_id}/databases/{database_id}/documents/{document_path}`.
-  string name = 1;
+  string name = 1 [(google.api.field_behavior) = REQUIRED];
 
   // An optional precondition on the document.
   // The request will fail if this is set and not met by the target document.
@@ -312,9 +348,9 @@ message DeleteDocumentRequest {
 
 // The request for [Firestore.BatchGetDocuments][google.firestore.v1.Firestore.BatchGetDocuments].
 message BatchGetDocumentsRequest {
-  // The database name. In the format:
+  // Required. The database name. In the format:
   // `projects/{project_id}/databases/{database_id}`.
-  string database = 1;
+  string database = 1 [(google.api.field_behavior) = REQUIRED];
 
   // The names of the documents to retrieve. In the format:
   // `projects/{project_id}/databases/{database_id}/documents/{document_path}`.
@@ -341,7 +377,7 @@ message BatchGetDocumentsRequest {
     TransactionOptions new_transaction = 5;
 
     // Reads documents as they were at the given time.
-    // This may not be older than 60 seconds.
+    // This may not be older than 270 seconds.
     google.protobuf.Timestamp read_time = 7;
   }
 }
@@ -373,9 +409,9 @@ message BatchGetDocumentsResponse {
 
 // The request for [Firestore.BeginTransaction][google.firestore.v1.Firestore.BeginTransaction].
 message BeginTransactionRequest {
-  // The database name. In the format:
+  // Required. The database name. In the format:
   // `projects/{project_id}/databases/{database_id}`.
-  string database = 1;
+  string database = 1 [(google.api.field_behavior) = REQUIRED];
 
   // The options for the transaction.
   // Defaults to a read-write transaction.
@@ -390,9 +426,9 @@ message BeginTransactionResponse {
 
 // The request for [Firestore.Commit][google.firestore.v1.Firestore.Commit].
 message CommitRequest {
-  // The database name. In the format:
+  // Required. The database name. In the format:
   // `projects/{project_id}/databases/{database_id}`.
-  string database = 1;
+  string database = 1 [(google.api.field_behavior) = REQUIRED];
 
   // The writes to apply.
   //
@@ -411,29 +447,30 @@ message CommitResponse {
   // request.
   repeated WriteResult write_results = 1;
 
-  // The time at which the commit occurred.
+  // The time at which the commit occurred. Any read with an equal or greater
+  // `read_time` is guaranteed to see the effects of the commit.
   google.protobuf.Timestamp commit_time = 2;
 }
 
 // The request for [Firestore.Rollback][google.firestore.v1.Firestore.Rollback].
 message RollbackRequest {
-  // The database name. In the format:
+  // Required. The database name. In the format:
   // `projects/{project_id}/databases/{database_id}`.
-  string database = 1;
+  string database = 1 [(google.api.field_behavior) = REQUIRED];
 
-  // The transaction to roll back.
-  bytes transaction = 2;
+  // Required. The transaction to roll back.
+  bytes transaction = 2 [(google.api.field_behavior) = REQUIRED];
 }
 
 // The request for [Firestore.RunQuery][google.firestore.v1.Firestore.RunQuery].
 message RunQueryRequest {
-  // The parent resource name. In the format:
+  // Required. The parent resource name. In the format:
   // `projects/{project_id}/databases/{database_id}/documents` or
   // `projects/{project_id}/databases/{database_id}/documents/{document_path}`.
   // For example:
   // `projects/my-project/databases/my-database/documents` or
   // `projects/my-project/databases/my-database/documents/chatrooms/my-chatroom`
-  string parent = 1;
+  string parent = 1 [(google.api.field_behavior) = REQUIRED];
 
   // The query to run.
   oneof query_type {
@@ -454,7 +491,7 @@ message RunQueryRequest {
     TransactionOptions new_transaction = 6;
 
     // Reads documents as they were at the given time.
-    // This may not be older than 60 seconds.
+    // This may not be older than 270 seconds.
     google.protobuf.Timestamp read_time = 7;
   }
 }
@@ -485,6 +522,85 @@ message RunQueryResponse {
   int32 skipped_results = 4;
 }
 
+// The request for [Firestore.PartitionQuery][google.firestore.v1.Firestore.PartitionQuery].
+message PartitionQueryRequest {
+  // Required. The parent resource name. In the format:
+  // `projects/{project_id}/databases/{database_id}/documents`.
+  // Document resource names are not supported; only database resource names
+  // can be specified.
+  string parent = 1 [(google.api.field_behavior) = REQUIRED];
+
+  // The query to partition.
+  oneof query_type {
+    // A structured query.
+    // Query must specify collection with all descendants and be ordered by name
+    // ascending. Other filters, order bys, limits, offsets, and start/end
+    // cursors are not supported.
+    StructuredQuery structured_query = 2;
+  }
+
+  // The desired maximum number of partition points.
+  // The partitions may be returned across multiple pages of results.
+  // The number must be positive. The actual number of partitions
+  // returned may be fewer.
+  //
+  // For example, this may be set to one fewer than the number of parallel
+  // queries to be run, or in running a data pipeline job, one fewer than the
+  // number of workers or compute instances available.
+  int64 partition_count = 3;
+
+  // The `next_page_token` value returned from a previous call to
+  // PartitionQuery that may be used to get an additional set of results.
+  // There are no ordering guarantees between sets of results. Thus, using
+  // multiple sets of results will require merging the different result sets.
+  //
+  // For example, two subsequent calls using a page_token may return:
+  //
+  //  * cursor B, cursor M, cursor Q
+  //  * cursor A, cursor U, cursor W
+  //
+  // To obtain a complete result set ordered with respect to the results of the
+  // query supplied to PartitionQuery, the results sets should be merged:
+  // cursor A, cursor B, cursor M, cursor Q, cursor U, cursor W
+  string page_token = 4;
+
+  // The maximum number of partitions to return in this call, subject to
+  // `partition_count`.
+  //
+  // For example, if `partition_count` = 10 and `page_size` = 8, the first call
+  // to PartitionQuery will return up to 8 partitions and a `next_page_token`
+  // if more results exist. A second call to PartitionQuery will return up to
+  // 2 partitions, to complete the total of 10 specified in `partition_count`.
+  int32 page_size = 5;
+}
+
+// The response for [Firestore.PartitionQuery][google.firestore.v1.Firestore.PartitionQuery].
+message PartitionQueryResponse {
+  // Partition results.
+  // Each partition is a split point that can be used by RunQuery as a starting
+  // or end point for the query results. The RunQuery requests must be made with
+  // the same query supplied to this PartitionQuery request. The partition
+  // cursors will be ordered according to same ordering as the results of the
+  // query supplied to PartitionQuery.
+  //
+  // For example, if a PartitionQuery request returns partition cursors A and B,
+  // running the following three queries will return the entire result set of
+  // the original query:
+  //
+  //  * query, end_at A
+  //  * query, start_at A, end_at B
+  //  * query, start_at B
+  //
+  // An empty result may indicate that the query has too few results to be
+  // partitioned.
+  repeated Cursor partitions = 1;
+
+  // A page token that may be used to request an additional set of results, up
+  // to the number specified by `partition_count` in the PartitionQuery request.
+  // If blank, there are no more results.
+  string next_page_token = 2;
+}
+
 // The request for [Firestore.Write][google.firestore.v1.Firestore.Write].
 //
 // The first request creates a stream, or resumes an existing one from a token.
@@ -496,10 +612,10 @@ message RunQueryResponse {
 // given token, then a response containing only an up-to-date token, to use in
 // the next request.
 message WriteRequest {
-  // The database name. In the format:
+  // Required. The database name. In the format:
   // `projects/{project_id}/databases/{database_id}`.
   // This is only required in the first message.
-  string database = 1;
+  string database = 1 [(google.api.field_behavior) = REQUIRED];
 
   // The ID of the write stream to resume.
   // This may only be set in the first message. When left empty, a new write
@@ -552,15 +668,16 @@ message WriteResponse {
   // request.
   repeated WriteResult write_results = 3;
 
-  // The time at which the commit occurred.
+  // The time at which the commit occurred. Any read with an equal or greater
+  // `read_time` is guaranteed to see the effects of the write.
   google.protobuf.Timestamp commit_time = 4;
 }
 
 // A request for [Firestore.Listen][google.firestore.v1.Firestore.Listen]
 message ListenRequest {
-  // The database name. In the format:
+  // Required. The database name. In the format:
   // `projects/{project_id}/databases/{database_id}`.
-  string database = 1;
+  string database = 1 [(google.api.field_behavior) = REQUIRED];
 
   // The supported target changes.
   oneof target_change {
@@ -654,14 +771,8 @@ message Target {
     google.protobuf.Timestamp read_time = 11;
   }
 
-  // A client provided target ID.
-  //
-  // If not set, the server will assign an ID for the target.
-  //
-  // Used for resuming a target without changing IDs. The IDs can either be
-  // client-assigned or be server-assigned in a previous stream. All targets
-  // with client provided IDs must be added before adding a target that needs
-  // a server-assigned id.
+  // The target ID that identifies the target on the stream. Must be a positive
+  // number and non-zero.
   int32 target_id = 5;
 
   // If the target should be removed once it is current and consistent.
@@ -706,11 +817,7 @@ message TargetChange {
   //
   // If empty, the change applies to all targets.
   //
-  // For `target_change_type=ADD`, the order of the target IDs matches the order
-  // of the requests to add the targets. This allows clients to unambiguously
-  // associate server-assigned target IDs with added targets.
-  //
-  // For other states, the order of the target IDs is not defined.
+  // The order of the target IDs is not defined.
   repeated int32 target_ids = 2;
 
   // The error that resulted in this change, if applicable.
@@ -737,11 +844,11 @@ message TargetChange {
 
 // The request for [Firestore.ListCollectionIds][google.firestore.v1.Firestore.ListCollectionIds].
 message ListCollectionIdsRequest {
-  // The parent document. In the format:
+  // Required. The parent document. In the format:
   // `projects/{project_id}/databases/{database_id}/documents/{document_path}`.
   // For example:
   // `projects/my-project/databases/my-database/documents/chatrooms/my-chatroom`
-  string parent = 1;
+  string parent = 1 [(google.api.field_behavior) = REQUIRED];
 
   // The maximum number of results to return.
   int32 page_size = 2;
@@ -758,4 +865,36 @@ message ListCollectionIdsResponse {
 
   // A page token that may be used to continue the list.
   string next_page_token = 2;
+}
+
+// The request for [Firestore.BatchWrite][google.firestore.v1.Firestore.BatchWrite].
+message BatchWriteRequest {
+  // Required. The database name. In the format:
+  // `projects/{project_id}/databases/{database_id}`.
+  string database = 1 [(google.api.field_behavior) = REQUIRED];
+
+  // The writes to apply.
+  //
+  // Method does not apply writes atomically and does not guarantee ordering.
+  // Each write succeeds or fails independently. You cannot write to the same
+  // document more than once per request.
+  repeated Write writes = 2;
+
+  // Labels associated with this batch write.
+  map<string, string> labels = 3;
+}
+
+// The response from [Firestore.BatchWrite][google.firestore.v1.Firestore.BatchWrite].
+message BatchWriteResponse {
+  // The result of applying the writes.
+  //
+  // This i-th write result corresponds to the i-th write in the
+  // request.
+  repeated WriteResult write_results = 1;
+
+  // The status of applying the writes.
+  //
+  // This i-th write status corresponds to the i-th write in the
+  // request.
+  repeated google.rpc.Status status = 2;
 }

--- a/packages/firestore/src/protos/google/firestore/v1/query.proto
+++ b/packages/firestore/src/protos/google/firestore/v1/query.proto
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC.
+// Copyright 2021 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,15 +11,14 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
 
 syntax = "proto3";
 
 package google.firestore.v1;
 
-import "google/api/annotations.proto";
 import "google/firestore/v1/document.proto";
 import "google/protobuf/wrappers.proto";
+import "google/api/annotations.proto";
 
 option csharp_namespace = "Google.Cloud.Firestore.V1";
 option go_package = "google.golang.org/genproto/googleapis/firestore/v1;firestore";
@@ -28,7 +27,7 @@ option java_outer_classname = "QueryProto";
 option java_package = "com.google.firestore.v1";
 option objc_class_prefix = "GCFS";
 option php_namespace = "Google\\Cloud\\Firestore\\V1";
-
+option ruby_package = "Google::Cloud::Firestore::V1";
 
 // A Firestore query.
 message StructuredQuery {
@@ -113,7 +112,7 @@ message StructuredQuery {
       // * That `field` come first in `order_by`.
       GREATER_THAN_OR_EQUAL = 4;
 
-      // The given `field` is equal to the given `value`..
+      // The given `field` is equal to the given `value`.
       EQUAL = 5;
 
       // The given `field` is not equal to the given `value`.
@@ -132,7 +131,7 @@ message StructuredQuery {
       // Requires:
       //
       // * That `value` is a non-empty `ArrayValue` with at most 10 values.
-      // * No other `IN` or `ARRAY_CONTAINS_ANY`. (-- or `NOT_IN` --)
+      // * No other `IN` or `ARRAY_CONTAINS_ANY` or `NOT_IN`.
       IN = 8;
 
       // The given `field` is an array that contains any of the values in the
@@ -141,7 +140,7 @@ message StructuredQuery {
       // Requires:
       //
       // * That `value` is a non-empty `ArrayValue` with at most 10 values.
-      // * No other `IN` or `ARRAY_CONTAINS_ANY`. (-- or `NOT_IN` --)
+      // * No other `IN` or `ARRAY_CONTAINS_ANY` or `NOT_IN`.
       ARRAY_CONTAINS_ANY = 9;
 
       // The value of the `field` is not in the given array.

--- a/packages/firestore/src/protos/google/firestore/v1/write.proto
+++ b/packages/firestore/src/protos/google/firestore/v1/write.proto
@@ -1,4 +1,4 @@
-// Copyright 2018 Google LLC.
+// Copyright 2021 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,16 +11,15 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
 
 syntax = "proto3";
 
 package google.firestore.v1;
 
-import "google/api/annotations.proto";
 import "google/firestore/v1/common.proto";
 import "google/firestore/v1/document.proto";
 import "google/protobuf/timestamp.proto";
+import "google/api/annotations.proto";
 
 option csharp_namespace = "Google.Cloud.Firestore.V1";
 option go_package = "google.golang.org/genproto/googleapis/firestore/v1;firestore";
@@ -29,7 +28,7 @@ option java_outer_classname = "WriteProto";
 option java_package = "com.google.firestore.v1";
 option objc_class_prefix = "GCFS";
 option php_namespace = "Google\\Cloud\\Firestore\\V1";
-
+option ruby_package = "Google::Cloud::Firestore::V1";
 
 // A write on a document.
 message Write {
@@ -86,7 +85,8 @@ message DocumentTransform {
       SERVER_VALUE_UNSPECIFIED = 0;
 
       // The time at which the server processed the request, with millisecond
-      // precision.
+      // precision. If used on multiple fields (same or different documents) in
+      // a transaction, all the fields will get the same server timestamp.
       REQUEST_TIME = 1;
     }
 

--- a/packages/firestore/src/protos/google/rpc/status.proto
+++ b/packages/firestore/src/protos/google/rpc/status.proto
@@ -1,4 +1,4 @@
-// Copyright 2017 Google Inc.
+// Copyright 2020 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,65 +18,20 @@ package google.rpc;
 
 import "google/protobuf/any.proto";
 
+option cc_enable_arenas = true;
 option go_package = "google.golang.org/genproto/googleapis/rpc/status;status";
 option java_multiple_files = true;
 option java_outer_classname = "StatusProto";
 option java_package = "com.google.rpc";
 option objc_class_prefix = "RPC";
 
-
-// The `Status` type defines a logical error model that is suitable for different
-// programming environments, including REST APIs and RPC APIs. It is used by
-// [gRPC](https://github.com/grpc). The error model is designed to be:
+// The `Status` type defines a logical error model that is suitable for
+// different programming environments, including REST APIs and RPC APIs. It is
+// used by [gRPC](https://github.com/grpc). Each `Status` message contains
+// three pieces of data: error code, error message, and error details.
 //
-// - Simple to use and understand for most users
-// - Flexible enough to meet unexpected needs
-//
-// # Overview
-//
-// The `Status` message contains three pieces of data: error code, error message,
-// and error details. The error code should be an enum value of
-// [google.rpc.Code][google.rpc.Code], but it may accept additional error codes if needed.  The
-// error message should be a developer-facing English message that helps
-// developers *understand* and *resolve* the error. If a localized user-facing
-// error message is needed, put the localized message in the error details or
-// localize it in the client. The optional error details may contain arbitrary
-// information about the error. There is a predefined set of error detail types
-// in the package `google.rpc` that can be used for common error conditions.
-//
-// # Language mapping
-//
-// The `Status` message is the logical representation of the error model, but it
-// is not necessarily the actual wire format. When the `Status` message is
-// exposed in different client libraries and different wire protocols, it can be
-// mapped differently. For example, it will likely be mapped to some exceptions
-// in Java, but more likely mapped to some error codes in C.
-//
-// # Other uses
-//
-// The error model and the `Status` message can be used in a variety of
-// environments, either with or without APIs, to provide a
-// consistent developer experience across different environments.
-//
-// Example uses of this error model include:
-//
-// - Partial errors. If a service needs to return partial errors to the client,
-//     it may embed the `Status` in the normal response to indicate the partial
-//     errors.
-//
-// - Workflow errors. A typical workflow has multiple steps. Each step may
-//     have a `Status` message for error reporting.
-//
-// - Batch operations. If a client uses batch request and batch response, the
-//     `Status` message should be used directly inside batch response, one for
-//     each error sub-response.
-//
-// - Asynchronous operations. If an API call embeds asynchronous operation
-//     results in its response, the status of those operations should be
-//     represented directly using the `Status` message.
-//
-// - Logging. If some API errors are stored in logs, the message `Status` could
-//     be used directly after any stripping needed for security/privacy reasons.
+// You can find out more about this error model and how to work with it in the
+// [API Design Guide](https://cloud.google.com/apis/design/errors).
 message Status {
   // The status code, which should be an enum value of [google.rpc.Code][google.rpc.Code].
   int32 code = 1;

--- a/packages/firestore/src/protos/google/type/latlng.proto
+++ b/packages/firestore/src/protos/google/type/latlng.proto
@@ -1,4 +1,4 @@
-// Copyright 2016 Google Inc.
+// Copyright 2021 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,52 +16,18 @@ syntax = "proto3";
 
 package google.type;
 
+option cc_enable_arenas = true;
 option go_package = "google.golang.org/genproto/googleapis/type/latlng;latlng";
 option java_multiple_files = true;
 option java_outer_classname = "LatLngProto";
 option java_package = "com.google.type";
 option objc_class_prefix = "GTP";
 
-
-// An object representing a latitude/longitude pair. This is expressed as a pair
-// of doubles representing degrees latitude and degrees longitude. Unless
+// An object that represents a latitude/longitude pair. This is expressed as a
+// pair of doubles to represent degrees latitude and degrees longitude. Unless
 // specified otherwise, this must conform to the
 // <a href="http://www.unoosa.org/pdf/icg/2012/template/WGS_84.pdf">WGS84
 // standard</a>. Values must be within normalized ranges.
-//
-// Example of normalization code in Python:
-//
-//     def NormalizeLongitude(longitude):
-//       """Wraps decimal degrees longitude to [-180.0, 180.0]."""
-//       q, r = divmod(longitude, 360.0)
-//       if r > 180.0 or (r == 180.0 and q <= -1.0):
-//         return r - 360.0
-//       return r
-//
-//     def NormalizeLatLng(latitude, longitude):
-//       """Wraps decimal degrees latitude and longitude to
-//       [-90.0, 90.0] and [-180.0, 180.0], respectively."""
-//       r = latitude % 360.0
-//       if r <= 90.0:
-//         return r, NormalizeLongitude(longitude)
-//       elif r >= 270.0:
-//         return r - 360, NormalizeLongitude(longitude)
-//       else:
-//         return 180 - r, NormalizeLongitude(longitude + 180.0)
-//
-//     assert 180.0 == NormalizeLongitude(180.0)
-//     assert -180.0 == NormalizeLongitude(-180.0)
-//     assert -179.0 == NormalizeLongitude(181.0)
-//     assert (0.0, 0.0) == NormalizeLatLng(360.0, 0.0)
-//     assert (0.0, 0.0) == NormalizeLatLng(-360.0, 0.0)
-//     assert (85.0, 180.0) == NormalizeLatLng(95.0, 0.0)
-//     assert (-85.0, -170.0) == NormalizeLatLng(-95.0, 10.0)
-//     assert (90.0, 10.0) == NormalizeLatLng(90.0, 10.0)
-//     assert (-90.0, -10.0) == NormalizeLatLng(-90.0, -10.0)
-//     assert (0.0, -170.0) == NormalizeLatLng(-180.0, 10.0)
-//     assert (0.0, -170.0) == NormalizeLatLng(180.0, 10.0)
-//     assert (-90.0, 10.0) == NormalizeLatLng(270.0, 10.0)
-//     assert (90.0, 10.0) == NormalizeLatLng(-270.0, 10.0)
 message LatLng {
   // The latitude in degrees. It must be in the range [-90.0, +90.0].
   double latitude = 1;

--- a/packages/firestore/src/protos/protos.json
+++ b/packages/firestore/src/protos/protos.json
@@ -1,0 +1,2650 @@
+{
+  "nested": {
+    "google": {
+      "nested": {
+        "protobuf": {
+          "options": {
+            "csharp_namespace": "Google.Protobuf.WellKnownTypes",
+            "go_package": "github.com/golang/protobuf/ptypes/wrappers",
+            "java_package": "com.google.protobuf",
+            "java_outer_classname": "WrappersProto",
+            "java_multiple_files": true,
+            "objc_class_prefix": "GPB",
+            "cc_enable_arenas": true,
+            "optimize_for": "SPEED"
+          },
+          "nested": {
+            "Timestamp": {
+              "fields": {
+                "seconds": {
+                  "type": "int64",
+                  "id": 1
+                },
+                "nanos": {
+                  "type": "int32",
+                  "id": 2
+                }
+              }
+            },
+            "FileDescriptorSet": {
+              "fields": {
+                "file": {
+                  "rule": "repeated",
+                  "type": "FileDescriptorProto",
+                  "id": 1
+                }
+              }
+            },
+            "FileDescriptorProto": {
+              "fields": {
+                "name": {
+                  "type": "string",
+                  "id": 1
+                },
+                "package": {
+                  "type": "string",
+                  "id": 2
+                },
+                "dependency": {
+                  "rule": "repeated",
+                  "type": "string",
+                  "id": 3
+                },
+                "publicDependency": {
+                  "rule": "repeated",
+                  "type": "int32",
+                  "id": 10,
+                  "options": {
+                    "packed": false
+                  }
+                },
+                "weakDependency": {
+                  "rule": "repeated",
+                  "type": "int32",
+                  "id": 11,
+                  "options": {
+                    "packed": false
+                  }
+                },
+                "messageType": {
+                  "rule": "repeated",
+                  "type": "DescriptorProto",
+                  "id": 4
+                },
+                "enumType": {
+                  "rule": "repeated",
+                  "type": "EnumDescriptorProto",
+                  "id": 5
+                },
+                "service": {
+                  "rule": "repeated",
+                  "type": "ServiceDescriptorProto",
+                  "id": 6
+                },
+                "extension": {
+                  "rule": "repeated",
+                  "type": "FieldDescriptorProto",
+                  "id": 7
+                },
+                "options": {
+                  "type": "FileOptions",
+                  "id": 8
+                },
+                "sourceCodeInfo": {
+                  "type": "SourceCodeInfo",
+                  "id": 9
+                },
+                "syntax": {
+                  "type": "string",
+                  "id": 12
+                }
+              }
+            },
+            "DescriptorProto": {
+              "fields": {
+                "name": {
+                  "type": "string",
+                  "id": 1
+                },
+                "field": {
+                  "rule": "repeated",
+                  "type": "FieldDescriptorProto",
+                  "id": 2
+                },
+                "extension": {
+                  "rule": "repeated",
+                  "type": "FieldDescriptorProto",
+                  "id": 6
+                },
+                "nestedType": {
+                  "rule": "repeated",
+                  "type": "DescriptorProto",
+                  "id": 3
+                },
+                "enumType": {
+                  "rule": "repeated",
+                  "type": "EnumDescriptorProto",
+                  "id": 4
+                },
+                "extensionRange": {
+                  "rule": "repeated",
+                  "type": "ExtensionRange",
+                  "id": 5
+                },
+                "oneofDecl": {
+                  "rule": "repeated",
+                  "type": "OneofDescriptorProto",
+                  "id": 8
+                },
+                "options": {
+                  "type": "MessageOptions",
+                  "id": 7
+                },
+                "reservedRange": {
+                  "rule": "repeated",
+                  "type": "ReservedRange",
+                  "id": 9
+                },
+                "reservedName": {
+                  "rule": "repeated",
+                  "type": "string",
+                  "id": 10
+                }
+              },
+              "nested": {
+                "ExtensionRange": {
+                  "fields": {
+                    "start": {
+                      "type": "int32",
+                      "id": 1
+                    },
+                    "end": {
+                      "type": "int32",
+                      "id": 2
+                    }
+                  }
+                },
+                "ReservedRange": {
+                  "fields": {
+                    "start": {
+                      "type": "int32",
+                      "id": 1
+                    },
+                    "end": {
+                      "type": "int32",
+                      "id": 2
+                    }
+                  }
+                }
+              }
+            },
+            "FieldDescriptorProto": {
+              "fields": {
+                "name": {
+                  "type": "string",
+                  "id": 1
+                },
+                "number": {
+                  "type": "int32",
+                  "id": 3
+                },
+                "label": {
+                  "type": "Label",
+                  "id": 4
+                },
+                "type": {
+                  "type": "Type",
+                  "id": 5
+                },
+                "typeName": {
+                  "type": "string",
+                  "id": 6
+                },
+                "extendee": {
+                  "type": "string",
+                  "id": 2
+                },
+                "defaultValue": {
+                  "type": "string",
+                  "id": 7
+                },
+                "oneofIndex": {
+                  "type": "int32",
+                  "id": 9
+                },
+                "jsonName": {
+                  "type": "string",
+                  "id": 10
+                },
+                "options": {
+                  "type": "FieldOptions",
+                  "id": 8
+                }
+              },
+              "nested": {
+                "Type": {
+                  "values": {
+                    "TYPE_DOUBLE": 1,
+                    "TYPE_FLOAT": 2,
+                    "TYPE_INT64": 3,
+                    "TYPE_UINT64": 4,
+                    "TYPE_INT32": 5,
+                    "TYPE_FIXED64": 6,
+                    "TYPE_FIXED32": 7,
+                    "TYPE_BOOL": 8,
+                    "TYPE_STRING": 9,
+                    "TYPE_GROUP": 10,
+                    "TYPE_MESSAGE": 11,
+                    "TYPE_BYTES": 12,
+                    "TYPE_UINT32": 13,
+                    "TYPE_ENUM": 14,
+                    "TYPE_SFIXED32": 15,
+                    "TYPE_SFIXED64": 16,
+                    "TYPE_SINT32": 17,
+                    "TYPE_SINT64": 18
+                  }
+                },
+                "Label": {
+                  "values": {
+                    "LABEL_OPTIONAL": 1,
+                    "LABEL_REQUIRED": 2,
+                    "LABEL_REPEATED": 3
+                  }
+                }
+              }
+            },
+            "OneofDescriptorProto": {
+              "fields": {
+                "name": {
+                  "type": "string",
+                  "id": 1
+                },
+                "options": {
+                  "type": "OneofOptions",
+                  "id": 2
+                }
+              }
+            },
+            "EnumDescriptorProto": {
+              "fields": {
+                "name": {
+                  "type": "string",
+                  "id": 1
+                },
+                "value": {
+                  "rule": "repeated",
+                  "type": "EnumValueDescriptorProto",
+                  "id": 2
+                },
+                "options": {
+                  "type": "EnumOptions",
+                  "id": 3
+                }
+              }
+            },
+            "EnumValueDescriptorProto": {
+              "fields": {
+                "name": {
+                  "type": "string",
+                  "id": 1
+                },
+                "number": {
+                  "type": "int32",
+                  "id": 2
+                },
+                "options": {
+                  "type": "EnumValueOptions",
+                  "id": 3
+                }
+              }
+            },
+            "ServiceDescriptorProto": {
+              "fields": {
+                "name": {
+                  "type": "string",
+                  "id": 1
+                },
+                "method": {
+                  "rule": "repeated",
+                  "type": "MethodDescriptorProto",
+                  "id": 2
+                },
+                "options": {
+                  "type": "ServiceOptions",
+                  "id": 3
+                }
+              }
+            },
+            "MethodDescriptorProto": {
+              "fields": {
+                "name": {
+                  "type": "string",
+                  "id": 1
+                },
+                "inputType": {
+                  "type": "string",
+                  "id": 2
+                },
+                "outputType": {
+                  "type": "string",
+                  "id": 3
+                },
+                "options": {
+                  "type": "MethodOptions",
+                  "id": 4
+                },
+                "clientStreaming": {
+                  "type": "bool",
+                  "id": 5
+                },
+                "serverStreaming": {
+                  "type": "bool",
+                  "id": 6
+                }
+              }
+            },
+            "FileOptions": {
+              "fields": {
+                "javaPackage": {
+                  "type": "string",
+                  "id": 1
+                },
+                "javaOuterClassname": {
+                  "type": "string",
+                  "id": 8
+                },
+                "javaMultipleFiles": {
+                  "type": "bool",
+                  "id": 10
+                },
+                "javaGenerateEqualsAndHash": {
+                  "type": "bool",
+                  "id": 20,
+                  "options": {
+                    "deprecated": true
+                  }
+                },
+                "javaStringCheckUtf8": {
+                  "type": "bool",
+                  "id": 27
+                },
+                "optimizeFor": {
+                  "type": "OptimizeMode",
+                  "id": 9,
+                  "options": {
+                    "default": "SPEED"
+                  }
+                },
+                "goPackage": {
+                  "type": "string",
+                  "id": 11
+                },
+                "ccGenericServices": {
+                  "type": "bool",
+                  "id": 16
+                },
+                "javaGenericServices": {
+                  "type": "bool",
+                  "id": 17
+                },
+                "pyGenericServices": {
+                  "type": "bool",
+                  "id": 18
+                },
+                "deprecated": {
+                  "type": "bool",
+                  "id": 23
+                },
+                "ccEnableArenas": {
+                  "type": "bool",
+                  "id": 31
+                },
+                "objcClassPrefix": {
+                  "type": "string",
+                  "id": 36
+                },
+                "csharpNamespace": {
+                  "type": "string",
+                  "id": 37
+                },
+                "uninterpretedOption": {
+                  "rule": "repeated",
+                  "type": "UninterpretedOption",
+                  "id": 999
+                }
+              },
+              "extensions": [
+                [
+                  1000,
+                  536870911
+                ]
+              ],
+              "reserved": [
+                [
+                  38,
+                  38
+                ]
+              ],
+              "nested": {
+                "OptimizeMode": {
+                  "values": {
+                    "SPEED": 1,
+                    "CODE_SIZE": 2,
+                    "LITE_RUNTIME": 3
+                  }
+                }
+              }
+            },
+            "MessageOptions": {
+              "fields": {
+                "messageSetWireFormat": {
+                  "type": "bool",
+                  "id": 1
+                },
+                "noStandardDescriptorAccessor": {
+                  "type": "bool",
+                  "id": 2
+                },
+                "deprecated": {
+                  "type": "bool",
+                  "id": 3
+                },
+                "mapEntry": {
+                  "type": "bool",
+                  "id": 7
+                },
+                "uninterpretedOption": {
+                  "rule": "repeated",
+                  "type": "UninterpretedOption",
+                  "id": 999
+                }
+              },
+              "extensions": [
+                [
+                  1000,
+                  536870911
+                ]
+              ],
+              "reserved": [
+                [
+                  8,
+                  8
+                ]
+              ]
+            },
+            "FieldOptions": {
+              "fields": {
+                "ctype": {
+                  "type": "CType",
+                  "id": 1,
+                  "options": {
+                    "default": "STRING"
+                  }
+                },
+                "packed": {
+                  "type": "bool",
+                  "id": 2
+                },
+                "jstype": {
+                  "type": "JSType",
+                  "id": 6,
+                  "options": {
+                    "default": "JS_NORMAL"
+                  }
+                },
+                "lazy": {
+                  "type": "bool",
+                  "id": 5
+                },
+                "deprecated": {
+                  "type": "bool",
+                  "id": 3
+                },
+                "weak": {
+                  "type": "bool",
+                  "id": 10
+                },
+                "uninterpretedOption": {
+                  "rule": "repeated",
+                  "type": "UninterpretedOption",
+                  "id": 999
+                }
+              },
+              "extensions": [
+                [
+                  1000,
+                  536870911
+                ]
+              ],
+              "reserved": [
+                [
+                  4,
+                  4
+                ]
+              ],
+              "nested": {
+                "CType": {
+                  "values": {
+                    "STRING": 0,
+                    "CORD": 1,
+                    "STRING_PIECE": 2
+                  }
+                },
+                "JSType": {
+                  "values": {
+                    "JS_NORMAL": 0,
+                    "JS_STRING": 1,
+                    "JS_NUMBER": 2
+                  }
+                }
+              }
+            },
+            "OneofOptions": {
+              "fields": {
+                "uninterpretedOption": {
+                  "rule": "repeated",
+                  "type": "UninterpretedOption",
+                  "id": 999
+                }
+              },
+              "extensions": [
+                [
+                  1000,
+                  536870911
+                ]
+              ]
+            },
+            "EnumOptions": {
+              "fields": {
+                "allowAlias": {
+                  "type": "bool",
+                  "id": 2
+                },
+                "deprecated": {
+                  "type": "bool",
+                  "id": 3
+                },
+                "uninterpretedOption": {
+                  "rule": "repeated",
+                  "type": "UninterpretedOption",
+                  "id": 999
+                }
+              },
+              "extensions": [
+                [
+                  1000,
+                  536870911
+                ]
+              ]
+            },
+            "EnumValueOptions": {
+              "fields": {
+                "deprecated": {
+                  "type": "bool",
+                  "id": 1
+                },
+                "uninterpretedOption": {
+                  "rule": "repeated",
+                  "type": "UninterpretedOption",
+                  "id": 999
+                }
+              },
+              "extensions": [
+                [
+                  1000,
+                  536870911
+                ]
+              ]
+            },
+            "ServiceOptions": {
+              "fields": {
+                "deprecated": {
+                  "type": "bool",
+                  "id": 33
+                },
+                "uninterpretedOption": {
+                  "rule": "repeated",
+                  "type": "UninterpretedOption",
+                  "id": 999
+                }
+              },
+              "extensions": [
+                [
+                  1000,
+                  536870911
+                ]
+              ]
+            },
+            "MethodOptions": {
+              "fields": {
+                "deprecated": {
+                  "type": "bool",
+                  "id": 33
+                },
+                "uninterpretedOption": {
+                  "rule": "repeated",
+                  "type": "UninterpretedOption",
+                  "id": 999
+                }
+              },
+              "extensions": [
+                [
+                  1000,
+                  536870911
+                ]
+              ]
+            },
+            "UninterpretedOption": {
+              "fields": {
+                "name": {
+                  "rule": "repeated",
+                  "type": "NamePart",
+                  "id": 2
+                },
+                "identifierValue": {
+                  "type": "string",
+                  "id": 3
+                },
+                "positiveIntValue": {
+                  "type": "uint64",
+                  "id": 4
+                },
+                "negativeIntValue": {
+                  "type": "int64",
+                  "id": 5
+                },
+                "doubleValue": {
+                  "type": "double",
+                  "id": 6
+                },
+                "stringValue": {
+                  "type": "bytes",
+                  "id": 7
+                },
+                "aggregateValue": {
+                  "type": "string",
+                  "id": 8
+                }
+              },
+              "nested": {
+                "NamePart": {
+                  "fields": {
+                    "namePart": {
+                      "rule": "required",
+                      "type": "string",
+                      "id": 1
+                    },
+                    "isExtension": {
+                      "rule": "required",
+                      "type": "bool",
+                      "id": 2
+                    }
+                  }
+                }
+              }
+            },
+            "SourceCodeInfo": {
+              "fields": {
+                "location": {
+                  "rule": "repeated",
+                  "type": "Location",
+                  "id": 1
+                }
+              },
+              "nested": {
+                "Location": {
+                  "fields": {
+                    "path": {
+                      "rule": "repeated",
+                      "type": "int32",
+                      "id": 1
+                    },
+                    "span": {
+                      "rule": "repeated",
+                      "type": "int32",
+                      "id": 2
+                    },
+                    "leadingComments": {
+                      "type": "string",
+                      "id": 3
+                    },
+                    "trailingComments": {
+                      "type": "string",
+                      "id": 4
+                    },
+                    "leadingDetachedComments": {
+                      "rule": "repeated",
+                      "type": "string",
+                      "id": 6
+                    }
+                  }
+                }
+              }
+            },
+            "GeneratedCodeInfo": {
+              "fields": {
+                "annotation": {
+                  "rule": "repeated",
+                  "type": "Annotation",
+                  "id": 1
+                }
+              },
+              "nested": {
+                "Annotation": {
+                  "fields": {
+                    "path": {
+                      "rule": "repeated",
+                      "type": "int32",
+                      "id": 1
+                    },
+                    "sourceFile": {
+                      "type": "string",
+                      "id": 2
+                    },
+                    "begin": {
+                      "type": "int32",
+                      "id": 3
+                    },
+                    "end": {
+                      "type": "int32",
+                      "id": 4
+                    }
+                  }
+                }
+              }
+            },
+            "Struct": {
+              "fields": {
+                "fields": {
+                  "keyType": "string",
+                  "type": "Value",
+                  "id": 1
+                }
+              }
+            },
+            "Value": {
+              "oneofs": {
+                "kind": {
+                  "oneof": [
+                    "nullValue",
+                    "numberValue",
+                    "stringValue",
+                    "boolValue",
+                    "structValue",
+                    "listValue"
+                  ]
+                }
+              },
+              "fields": {
+                "nullValue": {
+                  "type": "NullValue",
+                  "id": 1
+                },
+                "numberValue": {
+                  "type": "double",
+                  "id": 2
+                },
+                "stringValue": {
+                  "type": "string",
+                  "id": 3
+                },
+                "boolValue": {
+                  "type": "bool",
+                  "id": 4
+                },
+                "structValue": {
+                  "type": "Struct",
+                  "id": 5
+                },
+                "listValue": {
+                  "type": "ListValue",
+                  "id": 6
+                }
+              }
+            },
+            "NullValue": {
+              "values": {
+                "NULL_VALUE": 0
+              }
+            },
+            "ListValue": {
+              "fields": {
+                "values": {
+                  "rule": "repeated",
+                  "type": "Value",
+                  "id": 1
+                }
+              }
+            },
+            "Empty": {
+              "fields": {}
+            },
+            "DoubleValue": {
+              "fields": {
+                "value": {
+                  "type": "double",
+                  "id": 1
+                }
+              }
+            },
+            "FloatValue": {
+              "fields": {
+                "value": {
+                  "type": "float",
+                  "id": 1
+                }
+              }
+            },
+            "Int64Value": {
+              "fields": {
+                "value": {
+                  "type": "int64",
+                  "id": 1
+                }
+              }
+            },
+            "UInt64Value": {
+              "fields": {
+                "value": {
+                  "type": "uint64",
+                  "id": 1
+                }
+              }
+            },
+            "Int32Value": {
+              "fields": {
+                "value": {
+                  "type": "int32",
+                  "id": 1
+                }
+              }
+            },
+            "UInt32Value": {
+              "fields": {
+                "value": {
+                  "type": "uint32",
+                  "id": 1
+                }
+              }
+            },
+            "BoolValue": {
+              "fields": {
+                "value": {
+                  "type": "bool",
+                  "id": 1
+                }
+              }
+            },
+            "StringValue": {
+              "fields": {
+                "value": {
+                  "type": "string",
+                  "id": 1
+                }
+              }
+            },
+            "BytesValue": {
+              "fields": {
+                "value": {
+                  "type": "bytes",
+                  "id": 1
+                }
+              }
+            },
+            "Any": {
+              "fields": {
+                "typeUrl": {
+                  "type": "string",
+                  "id": 1
+                },
+                "value": {
+                  "type": "bytes",
+                  "id": 2
+                }
+              }
+            }
+          }
+        },
+        "firestore": {
+          "nested": {
+            "v1": {
+              "options": {
+                "csharp_namespace": "Google.Cloud.Firestore.V1",
+                "go_package": "google.golang.org/genproto/googleapis/firestore/v1;firestore",
+                "java_multiple_files": true,
+                "java_outer_classname": "WriteProto",
+                "java_package": "com.google.firestore.v1",
+                "objc_class_prefix": "GCFS",
+                "php_namespace": "Google\\Cloud\\Firestore\\V1",
+                "ruby_package": "Google::Cloud::Firestore::V1"
+              },
+              "nested": {
+                "DocumentMask": {
+                  "fields": {
+                    "fieldPaths": {
+                      "rule": "repeated",
+                      "type": "string",
+                      "id": 1
+                    }
+                  }
+                },
+                "Precondition": {
+                  "oneofs": {
+                    "conditionType": {
+                      "oneof": [
+                        "exists",
+                        "updateTime"
+                      ]
+                    }
+                  },
+                  "fields": {
+                    "exists": {
+                      "type": "bool",
+                      "id": 1
+                    },
+                    "updateTime": {
+                      "type": "google.protobuf.Timestamp",
+                      "id": 2
+                    }
+                  }
+                },
+                "TransactionOptions": {
+                  "oneofs": {
+                    "mode": {
+                      "oneof": [
+                        "readOnly",
+                        "readWrite"
+                      ]
+                    }
+                  },
+                  "fields": {
+                    "readOnly": {
+                      "type": "ReadOnly",
+                      "id": 2
+                    },
+                    "readWrite": {
+                      "type": "ReadWrite",
+                      "id": 3
+                    }
+                  },
+                  "nested": {
+                    "ReadWrite": {
+                      "fields": {
+                        "retryTransaction": {
+                          "type": "bytes",
+                          "id": 1
+                        }
+                      }
+                    },
+                    "ReadOnly": {
+                      "oneofs": {
+                        "consistencySelector": {
+                          "oneof": [
+                            "readTime"
+                          ]
+                        }
+                      },
+                      "fields": {
+                        "readTime": {
+                          "type": "google.protobuf.Timestamp",
+                          "id": 2
+                        }
+                      }
+                    }
+                  }
+                },
+                "Document": {
+                  "fields": {
+                    "name": {
+                      "type": "string",
+                      "id": 1
+                    },
+                    "fields": {
+                      "keyType": "string",
+                      "type": "Value",
+                      "id": 2
+                    },
+                    "createTime": {
+                      "type": "google.protobuf.Timestamp",
+                      "id": 3
+                    },
+                    "updateTime": {
+                      "type": "google.protobuf.Timestamp",
+                      "id": 4
+                    }
+                  }
+                },
+                "Value": {
+                  "oneofs": {
+                    "valueType": {
+                      "oneof": [
+                        "nullValue",
+                        "booleanValue",
+                        "integerValue",
+                        "doubleValue",
+                        "timestampValue",
+                        "stringValue",
+                        "bytesValue",
+                        "referenceValue",
+                        "geoPointValue",
+                        "arrayValue",
+                        "mapValue"
+                      ]
+                    }
+                  },
+                  "fields": {
+                    "nullValue": {
+                      "type": "google.protobuf.NullValue",
+                      "id": 11
+                    },
+                    "booleanValue": {
+                      "type": "bool",
+                      "id": 1
+                    },
+                    "integerValue": {
+                      "type": "int64",
+                      "id": 2
+                    },
+                    "doubleValue": {
+                      "type": "double",
+                      "id": 3
+                    },
+                    "timestampValue": {
+                      "type": "google.protobuf.Timestamp",
+                      "id": 10
+                    },
+                    "stringValue": {
+                      "type": "string",
+                      "id": 17
+                    },
+                    "bytesValue": {
+                      "type": "bytes",
+                      "id": 18
+                    },
+                    "referenceValue": {
+                      "type": "string",
+                      "id": 5
+                    },
+                    "geoPointValue": {
+                      "type": "google.type.LatLng",
+                      "id": 8
+                    },
+                    "arrayValue": {
+                      "type": "ArrayValue",
+                      "id": 9
+                    },
+                    "mapValue": {
+                      "type": "MapValue",
+                      "id": 6
+                    }
+                  }
+                },
+                "ArrayValue": {
+                  "fields": {
+                    "values": {
+                      "rule": "repeated",
+                      "type": "Value",
+                      "id": 1
+                    }
+                  }
+                },
+                "MapValue": {
+                  "fields": {
+                    "fields": {
+                      "keyType": "string",
+                      "type": "Value",
+                      "id": 1
+                    }
+                  }
+                },
+                "Firestore": {
+                  "options": {
+                    "(google.api.default_host)": "firestore.googleapis.com",
+                    "(google.api.oauth_scopes)": "https://www.googleapis.com/auth/cloud-platform,https://www.googleapis.com/auth/datastore"
+                  },
+                  "methods": {
+                    "GetDocument": {
+                      "requestType": "GetDocumentRequest",
+                      "responseType": "Document",
+                      "options": {
+                        "(google.api.http).get": "/v1/{name=projects/*/databases/*/documents/*/**}"
+                      },
+                      "parsedOptions": [
+                        {
+                          "(google.api.http)": {
+                            "get": "/v1/{name=projects/*/databases/*/documents/*/**}"
+                          }
+                        }
+                      ]
+                    },
+                    "ListDocuments": {
+                      "requestType": "ListDocumentsRequest",
+                      "responseType": "ListDocumentsResponse",
+                      "options": {
+                        "(google.api.http).get": "/v1/{parent=projects/*/databases/*/documents/*/**}/{collection_id}"
+                      },
+                      "parsedOptions": [
+                        {
+                          "(google.api.http)": {
+                            "get": "/v1/{parent=projects/*/databases/*/documents/*/**}/{collection_id}"
+                          }
+                        }
+                      ]
+                    },
+                    "UpdateDocument": {
+                      "requestType": "UpdateDocumentRequest",
+                      "responseType": "Document",
+                      "options": {
+                        "(google.api.http).patch": "/v1/{document.name=projects/*/databases/*/documents/*/**}",
+                        "(google.api.http).body": "document",
+                        "(google.api.method_signature)": "document,update_mask"
+                      },
+                      "parsedOptions": [
+                        {
+                          "(google.api.http)": {
+                            "patch": "/v1/{document.name=projects/*/databases/*/documents/*/**}",
+                            "body": "document"
+                          }
+                        },
+                        {
+                          "(google.api.method_signature)": "document,update_mask"
+                        }
+                      ]
+                    },
+                    "DeleteDocument": {
+                      "requestType": "DeleteDocumentRequest",
+                      "responseType": "google.protobuf.Empty",
+                      "options": {
+                        "(google.api.http).delete": "/v1/{name=projects/*/databases/*/documents/*/**}",
+                        "(google.api.method_signature)": "name"
+                      },
+                      "parsedOptions": [
+                        {
+                          "(google.api.http)": {
+                            "delete": "/v1/{name=projects/*/databases/*/documents/*/**}"
+                          }
+                        },
+                        {
+                          "(google.api.method_signature)": "name"
+                        }
+                      ]
+                    },
+                    "BatchGetDocuments": {
+                      "requestType": "BatchGetDocumentsRequest",
+                      "responseType": "BatchGetDocumentsResponse",
+                      "responseStream": true,
+                      "options": {
+                        "(google.api.http).post": "/v1/{database=projects/*/databases/*}/documents:batchGet",
+                        "(google.api.http).body": "*"
+                      },
+                      "parsedOptions": [
+                        {
+                          "(google.api.http)": {
+                            "post": "/v1/{database=projects/*/databases/*}/documents:batchGet",
+                            "body": "*"
+                          }
+                        }
+                      ]
+                    },
+                    "BeginTransaction": {
+                      "requestType": "BeginTransactionRequest",
+                      "responseType": "BeginTransactionResponse",
+                      "options": {
+                        "(google.api.http).post": "/v1/{database=projects/*/databases/*}/documents:beginTransaction",
+                        "(google.api.http).body": "*",
+                        "(google.api.method_signature)": "database"
+                      },
+                      "parsedOptions": [
+                        {
+                          "(google.api.http)": {
+                            "post": "/v1/{database=projects/*/databases/*}/documents:beginTransaction",
+                            "body": "*"
+                          }
+                        },
+                        {
+                          "(google.api.method_signature)": "database"
+                        }
+                      ]
+                    },
+                    "Commit": {
+                      "requestType": "CommitRequest",
+                      "responseType": "CommitResponse",
+                      "options": {
+                        "(google.api.http).post": "/v1/{database=projects/*/databases/*}/documents:commit",
+                        "(google.api.http).body": "*",
+                        "(google.api.method_signature)": "database,writes"
+                      },
+                      "parsedOptions": [
+                        {
+                          "(google.api.http)": {
+                            "post": "/v1/{database=projects/*/databases/*}/documents:commit",
+                            "body": "*"
+                          }
+                        },
+                        {
+                          "(google.api.method_signature)": "database,writes"
+                        }
+                      ]
+                    },
+                    "Rollback": {
+                      "requestType": "RollbackRequest",
+                      "responseType": "google.protobuf.Empty",
+                      "options": {
+                        "(google.api.http).post": "/v1/{database=projects/*/databases/*}/documents:rollback",
+                        "(google.api.http).body": "*",
+                        "(google.api.method_signature)": "database,transaction"
+                      },
+                      "parsedOptions": [
+                        {
+                          "(google.api.http)": {
+                            "post": "/v1/{database=projects/*/databases/*}/documents:rollback",
+                            "body": "*"
+                          }
+                        },
+                        {
+                          "(google.api.method_signature)": "database,transaction"
+                        }
+                      ]
+                    },
+                    "RunQuery": {
+                      "requestType": "RunQueryRequest",
+                      "responseType": "RunQueryResponse",
+                      "responseStream": true,
+                      "options": {
+                        "(google.api.http).post": "/v1/{parent=projects/*/databases/*/documents}:runQuery",
+                        "(google.api.http).body": "*",
+                        "(google.api.http).additional_bindings.post": "/v1/{parent=projects/*/databases/*/documents/*/**}:runQuery",
+                        "(google.api.http).additional_bindings.body": "*"
+                      },
+                      "parsedOptions": [
+                        {
+                          "(google.api.http)": {
+                            "post": "/v1/{parent=projects/*/databases/*/documents}:runQuery",
+                            "body": "*",
+                            "additional_bindings": {
+                              "post": "/v1/{parent=projects/*/databases/*/documents/*/**}:runQuery",
+                              "body": "*"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "PartitionQuery": {
+                      "requestType": "PartitionQueryRequest",
+                      "responseType": "PartitionQueryResponse",
+                      "options": {
+                        "(google.api.http).post": "/v1/{parent=projects/*/databases/*/documents}:partitionQuery",
+                        "(google.api.http).body": "*",
+                        "(google.api.http).additional_bindings.post": "/v1/{parent=projects/*/databases/*/documents/*/**}:partitionQuery",
+                        "(google.api.http).additional_bindings.body": "*"
+                      },
+                      "parsedOptions": [
+                        {
+                          "(google.api.http)": {
+                            "post": "/v1/{parent=projects/*/databases/*/documents}:partitionQuery",
+                            "body": "*",
+                            "additional_bindings": {
+                              "post": "/v1/{parent=projects/*/databases/*/documents/*/**}:partitionQuery",
+                              "body": "*"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "Write": {
+                      "requestType": "WriteRequest",
+                      "requestStream": true,
+                      "responseType": "WriteResponse",
+                      "responseStream": true,
+                      "options": {
+                        "(google.api.http).post": "/v1/{database=projects/*/databases/*}/documents:write",
+                        "(google.api.http).body": "*"
+                      },
+                      "parsedOptions": [
+                        {
+                          "(google.api.http)": {
+                            "post": "/v1/{database=projects/*/databases/*}/documents:write",
+                            "body": "*"
+                          }
+                        }
+                      ]
+                    },
+                    "Listen": {
+                      "requestType": "ListenRequest",
+                      "requestStream": true,
+                      "responseType": "ListenResponse",
+                      "responseStream": true,
+                      "options": {
+                        "(google.api.http).post": "/v1/{database=projects/*/databases/*}/documents:listen",
+                        "(google.api.http).body": "*"
+                      },
+                      "parsedOptions": [
+                        {
+                          "(google.api.http)": {
+                            "post": "/v1/{database=projects/*/databases/*}/documents:listen",
+                            "body": "*"
+                          }
+                        }
+                      ]
+                    },
+                    "ListCollectionIds": {
+                      "requestType": "ListCollectionIdsRequest",
+                      "responseType": "ListCollectionIdsResponse",
+                      "options": {
+                        "(google.api.http).post": "/v1/{parent=projects/*/databases/*/documents}:listCollectionIds",
+                        "(google.api.http).body": "*",
+                        "(google.api.http).additional_bindings.post": "/v1/{parent=projects/*/databases/*/documents/*/**}:listCollectionIds",
+                        "(google.api.http).additional_bindings.body": "*",
+                        "(google.api.method_signature)": "parent"
+                      },
+                      "parsedOptions": [
+                        {
+                          "(google.api.http)": {
+                            "post": "/v1/{parent=projects/*/databases/*/documents}:listCollectionIds",
+                            "body": "*",
+                            "additional_bindings": {
+                              "post": "/v1/{parent=projects/*/databases/*/documents/*/**}:listCollectionIds",
+                              "body": "*"
+                            }
+                          }
+                        },
+                        {
+                          "(google.api.method_signature)": "parent"
+                        }
+                      ]
+                    },
+                    "BatchWrite": {
+                      "requestType": "BatchWriteRequest",
+                      "responseType": "BatchWriteResponse",
+                      "options": {
+                        "(google.api.http).post": "/v1/{database=projects/*/databases/*}/documents:batchWrite",
+                        "(google.api.http).body": "*"
+                      },
+                      "parsedOptions": [
+                        {
+                          "(google.api.http)": {
+                            "post": "/v1/{database=projects/*/databases/*}/documents:batchWrite",
+                            "body": "*"
+                          }
+                        }
+                      ]
+                    },
+                    "CreateDocument": {
+                      "requestType": "CreateDocumentRequest",
+                      "responseType": "Document",
+                      "options": {
+                        "(google.api.http).post": "/v1/{parent=projects/*/databases/*/documents/**}/{collection_id}",
+                        "(google.api.http).body": "document"
+                      },
+                      "parsedOptions": [
+                        {
+                          "(google.api.http)": {
+                            "post": "/v1/{parent=projects/*/databases/*/documents/**}/{collection_id}",
+                            "body": "document"
+                          }
+                        }
+                      ]
+                    }
+                  }
+                },
+                "GetDocumentRequest": {
+                  "oneofs": {
+                    "consistencySelector": {
+                      "oneof": [
+                        "transaction",
+                        "readTime"
+                      ]
+                    }
+                  },
+                  "fields": {
+                    "name": {
+                      "type": "string",
+                      "id": 1,
+                      "options": {
+                        "(google.api.field_behavior)": "REQUIRED"
+                      }
+                    },
+                    "mask": {
+                      "type": "DocumentMask",
+                      "id": 2
+                    },
+                    "transaction": {
+                      "type": "bytes",
+                      "id": 3
+                    },
+                    "readTime": {
+                      "type": "google.protobuf.Timestamp",
+                      "id": 5
+                    }
+                  }
+                },
+                "ListDocumentsRequest": {
+                  "oneofs": {
+                    "consistencySelector": {
+                      "oneof": [
+                        "transaction",
+                        "readTime"
+                      ]
+                    }
+                  },
+                  "fields": {
+                    "parent": {
+                      "type": "string",
+                      "id": 1,
+                      "options": {
+                        "(google.api.field_behavior)": "REQUIRED"
+                      }
+                    },
+                    "collectionId": {
+                      "type": "string",
+                      "id": 2,
+                      "options": {
+                        "(google.api.field_behavior)": "REQUIRED"
+                      }
+                    },
+                    "pageSize": {
+                      "type": "int32",
+                      "id": 3
+                    },
+                    "pageToken": {
+                      "type": "string",
+                      "id": 4
+                    },
+                    "orderBy": {
+                      "type": "string",
+                      "id": 6
+                    },
+                    "mask": {
+                      "type": "DocumentMask",
+                      "id": 7
+                    },
+                    "transaction": {
+                      "type": "bytes",
+                      "id": 8
+                    },
+                    "readTime": {
+                      "type": "google.protobuf.Timestamp",
+                      "id": 10
+                    },
+                    "showMissing": {
+                      "type": "bool",
+                      "id": 12
+                    }
+                  }
+                },
+                "ListDocumentsResponse": {
+                  "fields": {
+                    "documents": {
+                      "rule": "repeated",
+                      "type": "Document",
+                      "id": 1
+                    },
+                    "nextPageToken": {
+                      "type": "string",
+                      "id": 2
+                    }
+                  }
+                },
+                "CreateDocumentRequest": {
+                  "fields": {
+                    "parent": {
+                      "type": "string",
+                      "id": 1,
+                      "options": {
+                        "(google.api.field_behavior)": "REQUIRED"
+                      }
+                    },
+                    "collectionId": {
+                      "type": "string",
+                      "id": 2,
+                      "options": {
+                        "(google.api.field_behavior)": "REQUIRED"
+                      }
+                    },
+                    "documentId": {
+                      "type": "string",
+                      "id": 3
+                    },
+                    "document": {
+                      "type": "Document",
+                      "id": 4,
+                      "options": {
+                        "(google.api.field_behavior)": "REQUIRED"
+                      }
+                    },
+                    "mask": {
+                      "type": "DocumentMask",
+                      "id": 5
+                    }
+                  }
+                },
+                "UpdateDocumentRequest": {
+                  "fields": {
+                    "document": {
+                      "type": "Document",
+                      "id": 1,
+                      "options": {
+                        "(google.api.field_behavior)": "REQUIRED"
+                      }
+                    },
+                    "updateMask": {
+                      "type": "DocumentMask",
+                      "id": 2
+                    },
+                    "mask": {
+                      "type": "DocumentMask",
+                      "id": 3
+                    },
+                    "currentDocument": {
+                      "type": "Precondition",
+                      "id": 4
+                    }
+                  }
+                },
+                "DeleteDocumentRequest": {
+                  "fields": {
+                    "name": {
+                      "type": "string",
+                      "id": 1,
+                      "options": {
+                        "(google.api.field_behavior)": "REQUIRED"
+                      }
+                    },
+                    "currentDocument": {
+                      "type": "Precondition",
+                      "id": 2
+                    }
+                  }
+                },
+                "BatchGetDocumentsRequest": {
+                  "oneofs": {
+                    "consistencySelector": {
+                      "oneof": [
+                        "transaction",
+                        "newTransaction",
+                        "readTime"
+                      ]
+                    }
+                  },
+                  "fields": {
+                    "database": {
+                      "type": "string",
+                      "id": 1,
+                      "options": {
+                        "(google.api.field_behavior)": "REQUIRED"
+                      }
+                    },
+                    "documents": {
+                      "rule": "repeated",
+                      "type": "string",
+                      "id": 2
+                    },
+                    "mask": {
+                      "type": "DocumentMask",
+                      "id": 3
+                    },
+                    "transaction": {
+                      "type": "bytes",
+                      "id": 4
+                    },
+                    "newTransaction": {
+                      "type": "TransactionOptions",
+                      "id": 5
+                    },
+                    "readTime": {
+                      "type": "google.protobuf.Timestamp",
+                      "id": 7
+                    }
+                  }
+                },
+                "BatchGetDocumentsResponse": {
+                  "oneofs": {
+                    "result": {
+                      "oneof": [
+                        "found",
+                        "missing"
+                      ]
+                    }
+                  },
+                  "fields": {
+                    "found": {
+                      "type": "Document",
+                      "id": 1
+                    },
+                    "missing": {
+                      "type": "string",
+                      "id": 2
+                    },
+                    "transaction": {
+                      "type": "bytes",
+                      "id": 3
+                    },
+                    "readTime": {
+                      "type": "google.protobuf.Timestamp",
+                      "id": 4
+                    }
+                  }
+                },
+                "BeginTransactionRequest": {
+                  "fields": {
+                    "database": {
+                      "type": "string",
+                      "id": 1,
+                      "options": {
+                        "(google.api.field_behavior)": "REQUIRED"
+                      }
+                    },
+                    "options": {
+                      "type": "TransactionOptions",
+                      "id": 2
+                    }
+                  }
+                },
+                "BeginTransactionResponse": {
+                  "fields": {
+                    "transaction": {
+                      "type": "bytes",
+                      "id": 1
+                    }
+                  }
+                },
+                "CommitRequest": {
+                  "fields": {
+                    "database": {
+                      "type": "string",
+                      "id": 1,
+                      "options": {
+                        "(google.api.field_behavior)": "REQUIRED"
+                      }
+                    },
+                    "writes": {
+                      "rule": "repeated",
+                      "type": "Write",
+                      "id": 2
+                    },
+                    "transaction": {
+                      "type": "bytes",
+                      "id": 3
+                    }
+                  }
+                },
+                "CommitResponse": {
+                  "fields": {
+                    "writeResults": {
+                      "rule": "repeated",
+                      "type": "WriteResult",
+                      "id": 1
+                    },
+                    "commitTime": {
+                      "type": "google.protobuf.Timestamp",
+                      "id": 2
+                    }
+                  }
+                },
+                "RollbackRequest": {
+                  "fields": {
+                    "database": {
+                      "type": "string",
+                      "id": 1,
+                      "options": {
+                        "(google.api.field_behavior)": "REQUIRED"
+                      }
+                    },
+                    "transaction": {
+                      "type": "bytes",
+                      "id": 2,
+                      "options": {
+                        "(google.api.field_behavior)": "REQUIRED"
+                      }
+                    }
+                  }
+                },
+                "RunQueryRequest": {
+                  "oneofs": {
+                    "queryType": {
+                      "oneof": [
+                        "structuredQuery"
+                      ]
+                    },
+                    "consistencySelector": {
+                      "oneof": [
+                        "transaction",
+                        "newTransaction",
+                        "readTime"
+                      ]
+                    }
+                  },
+                  "fields": {
+                    "parent": {
+                      "type": "string",
+                      "id": 1,
+                      "options": {
+                        "(google.api.field_behavior)": "REQUIRED"
+                      }
+                    },
+                    "structuredQuery": {
+                      "type": "StructuredQuery",
+                      "id": 2
+                    },
+                    "transaction": {
+                      "type": "bytes",
+                      "id": 5
+                    },
+                    "newTransaction": {
+                      "type": "TransactionOptions",
+                      "id": 6
+                    },
+                    "readTime": {
+                      "type": "google.protobuf.Timestamp",
+                      "id": 7
+                    }
+                  }
+                },
+                "RunQueryResponse": {
+                  "fields": {
+                    "transaction": {
+                      "type": "bytes",
+                      "id": 2
+                    },
+                    "document": {
+                      "type": "Document",
+                      "id": 1
+                    },
+                    "readTime": {
+                      "type": "google.protobuf.Timestamp",
+                      "id": 3
+                    },
+                    "skippedResults": {
+                      "type": "int32",
+                      "id": 4
+                    }
+                  }
+                },
+                "PartitionQueryRequest": {
+                  "oneofs": {
+                    "queryType": {
+                      "oneof": [
+                        "structuredQuery"
+                      ]
+                    }
+                  },
+                  "fields": {
+                    "parent": {
+                      "type": "string",
+                      "id": 1,
+                      "options": {
+                        "(google.api.field_behavior)": "REQUIRED"
+                      }
+                    },
+                    "structuredQuery": {
+                      "type": "StructuredQuery",
+                      "id": 2
+                    },
+                    "partitionCount": {
+                      "type": "int64",
+                      "id": 3
+                    },
+                    "pageToken": {
+                      "type": "string",
+                      "id": 4
+                    },
+                    "pageSize": {
+                      "type": "int32",
+                      "id": 5
+                    }
+                  }
+                },
+                "PartitionQueryResponse": {
+                  "fields": {
+                    "partitions": {
+                      "rule": "repeated",
+                      "type": "Cursor",
+                      "id": 1
+                    },
+                    "nextPageToken": {
+                      "type": "string",
+                      "id": 2
+                    }
+                  }
+                },
+                "WriteRequest": {
+                  "fields": {
+                    "database": {
+                      "type": "string",
+                      "id": 1,
+                      "options": {
+                        "(google.api.field_behavior)": "REQUIRED"
+                      }
+                    },
+                    "streamId": {
+                      "type": "string",
+                      "id": 2
+                    },
+                    "writes": {
+                      "rule": "repeated",
+                      "type": "Write",
+                      "id": 3
+                    },
+                    "streamToken": {
+                      "type": "bytes",
+                      "id": 4
+                    },
+                    "labels": {
+                      "keyType": "string",
+                      "type": "string",
+                      "id": 5
+                    }
+                  }
+                },
+                "WriteResponse": {
+                  "fields": {
+                    "streamId": {
+                      "type": "string",
+                      "id": 1
+                    },
+                    "streamToken": {
+                      "type": "bytes",
+                      "id": 2
+                    },
+                    "writeResults": {
+                      "rule": "repeated",
+                      "type": "WriteResult",
+                      "id": 3
+                    },
+                    "commitTime": {
+                      "type": "google.protobuf.Timestamp",
+                      "id": 4
+                    }
+                  }
+                },
+                "ListenRequest": {
+                  "oneofs": {
+                    "targetChange": {
+                      "oneof": [
+                        "addTarget",
+                        "removeTarget"
+                      ]
+                    }
+                  },
+                  "fields": {
+                    "database": {
+                      "type": "string",
+                      "id": 1,
+                      "options": {
+                        "(google.api.field_behavior)": "REQUIRED"
+                      }
+                    },
+                    "addTarget": {
+                      "type": "Target",
+                      "id": 2
+                    },
+                    "removeTarget": {
+                      "type": "int32",
+                      "id": 3
+                    },
+                    "labels": {
+                      "keyType": "string",
+                      "type": "string",
+                      "id": 4
+                    }
+                  }
+                },
+                "ListenResponse": {
+                  "oneofs": {
+                    "responseType": {
+                      "oneof": [
+                        "targetChange",
+                        "documentChange",
+                        "documentDelete",
+                        "documentRemove",
+                        "filter"
+                      ]
+                    }
+                  },
+                  "fields": {
+                    "targetChange": {
+                      "type": "TargetChange",
+                      "id": 2
+                    },
+                    "documentChange": {
+                      "type": "DocumentChange",
+                      "id": 3
+                    },
+                    "documentDelete": {
+                      "type": "DocumentDelete",
+                      "id": 4
+                    },
+                    "documentRemove": {
+                      "type": "DocumentRemove",
+                      "id": 6
+                    },
+                    "filter": {
+                      "type": "ExistenceFilter",
+                      "id": 5
+                    }
+                  }
+                },
+                "Target": {
+                  "oneofs": {
+                    "targetType": {
+                      "oneof": [
+                        "query",
+                        "documents"
+                      ]
+                    },
+                    "resumeType": {
+                      "oneof": [
+                        "resumeToken",
+                        "readTime"
+                      ]
+                    }
+                  },
+                  "fields": {
+                    "query": {
+                      "type": "QueryTarget",
+                      "id": 2
+                    },
+                    "documents": {
+                      "type": "DocumentsTarget",
+                      "id": 3
+                    },
+                    "resumeToken": {
+                      "type": "bytes",
+                      "id": 4
+                    },
+                    "readTime": {
+                      "type": "google.protobuf.Timestamp",
+                      "id": 11
+                    },
+                    "targetId": {
+                      "type": "int32",
+                      "id": 5
+                    },
+                    "once": {
+                      "type": "bool",
+                      "id": 6
+                    }
+                  },
+                  "nested": {
+                    "DocumentsTarget": {
+                      "fields": {
+                        "documents": {
+                          "rule": "repeated",
+                          "type": "string",
+                          "id": 2
+                        }
+                      }
+                    },
+                    "QueryTarget": {
+                      "oneofs": {
+                        "queryType": {
+                          "oneof": [
+                            "structuredQuery"
+                          ]
+                        }
+                      },
+                      "fields": {
+                        "parent": {
+                          "type": "string",
+                          "id": 1
+                        },
+                        "structuredQuery": {
+                          "type": "StructuredQuery",
+                          "id": 2
+                        }
+                      }
+                    }
+                  }
+                },
+                "TargetChange": {
+                  "fields": {
+                    "targetChangeType": {
+                      "type": "TargetChangeType",
+                      "id": 1
+                    },
+                    "targetIds": {
+                      "rule": "repeated",
+                      "type": "int32",
+                      "id": 2
+                    },
+                    "cause": {
+                      "type": "google.rpc.Status",
+                      "id": 3
+                    },
+                    "resumeToken": {
+                      "type": "bytes",
+                      "id": 4
+                    },
+                    "readTime": {
+                      "type": "google.protobuf.Timestamp",
+                      "id": 6
+                    }
+                  },
+                  "nested": {
+                    "TargetChangeType": {
+                      "values": {
+                        "NO_CHANGE": 0,
+                        "ADD": 1,
+                        "REMOVE": 2,
+                        "CURRENT": 3,
+                        "RESET": 4
+                      }
+                    }
+                  }
+                },
+                "ListCollectionIdsRequest": {
+                  "fields": {
+                    "parent": {
+                      "type": "string",
+                      "id": 1,
+                      "options": {
+                        "(google.api.field_behavior)": "REQUIRED"
+                      }
+                    },
+                    "pageSize": {
+                      "type": "int32",
+                      "id": 2
+                    },
+                    "pageToken": {
+                      "type": "string",
+                      "id": 3
+                    }
+                  }
+                },
+                "ListCollectionIdsResponse": {
+                  "fields": {
+                    "collectionIds": {
+                      "rule": "repeated",
+                      "type": "string",
+                      "id": 1
+                    },
+                    "nextPageToken": {
+                      "type": "string",
+                      "id": 2
+                    }
+                  }
+                },
+                "BatchWriteRequest": {
+                  "fields": {
+                    "database": {
+                      "type": "string",
+                      "id": 1,
+                      "options": {
+                        "(google.api.field_behavior)": "REQUIRED"
+                      }
+                    },
+                    "writes": {
+                      "rule": "repeated",
+                      "type": "Write",
+                      "id": 2
+                    },
+                    "labels": {
+                      "keyType": "string",
+                      "type": "string",
+                      "id": 3
+                    }
+                  }
+                },
+                "BatchWriteResponse": {
+                  "fields": {
+                    "writeResults": {
+                      "rule": "repeated",
+                      "type": "WriteResult",
+                      "id": 1
+                    },
+                    "status": {
+                      "rule": "repeated",
+                      "type": "google.rpc.Status",
+                      "id": 2
+                    }
+                  }
+                },
+                "StructuredQuery": {
+                  "fields": {
+                    "select": {
+                      "type": "Projection",
+                      "id": 1
+                    },
+                    "from": {
+                      "rule": "repeated",
+                      "type": "CollectionSelector",
+                      "id": 2
+                    },
+                    "where": {
+                      "type": "Filter",
+                      "id": 3
+                    },
+                    "orderBy": {
+                      "rule": "repeated",
+                      "type": "Order",
+                      "id": 4
+                    },
+                    "startAt": {
+                      "type": "Cursor",
+                      "id": 7
+                    },
+                    "endAt": {
+                      "type": "Cursor",
+                      "id": 8
+                    },
+                    "offset": {
+                      "type": "int32",
+                      "id": 6
+                    },
+                    "limit": {
+                      "type": "google.protobuf.Int32Value",
+                      "id": 5
+                    }
+                  },
+                  "nested": {
+                    "CollectionSelector": {
+                      "fields": {
+                        "collectionId": {
+                          "type": "string",
+                          "id": 2
+                        },
+                        "allDescendants": {
+                          "type": "bool",
+                          "id": 3
+                        }
+                      }
+                    },
+                    "Filter": {
+                      "oneofs": {
+                        "filterType": {
+                          "oneof": [
+                            "compositeFilter",
+                            "fieldFilter",
+                            "unaryFilter"
+                          ]
+                        }
+                      },
+                      "fields": {
+                        "compositeFilter": {
+                          "type": "CompositeFilter",
+                          "id": 1
+                        },
+                        "fieldFilter": {
+                          "type": "FieldFilter",
+                          "id": 2
+                        },
+                        "unaryFilter": {
+                          "type": "UnaryFilter",
+                          "id": 3
+                        }
+                      }
+                    },
+                    "CompositeFilter": {
+                      "fields": {
+                        "op": {
+                          "type": "Operator",
+                          "id": 1
+                        },
+                        "filters": {
+                          "rule": "repeated",
+                          "type": "Filter",
+                          "id": 2
+                        }
+                      },
+                      "nested": {
+                        "Operator": {
+                          "values": {
+                            "OPERATOR_UNSPECIFIED": 0,
+                            "AND": 1
+                          }
+                        }
+                      }
+                    },
+                    "FieldFilter": {
+                      "fields": {
+                        "field": {
+                          "type": "FieldReference",
+                          "id": 1
+                        },
+                        "op": {
+                          "type": "Operator",
+                          "id": 2
+                        },
+                        "value": {
+                          "type": "Value",
+                          "id": 3
+                        }
+                      },
+                      "nested": {
+                        "Operator": {
+                          "values": {
+                            "OPERATOR_UNSPECIFIED": 0,
+                            "LESS_THAN": 1,
+                            "LESS_THAN_OR_EQUAL": 2,
+                            "GREATER_THAN": 3,
+                            "GREATER_THAN_OR_EQUAL": 4,
+                            "EQUAL": 5,
+                            "NOT_EQUAL": 6,
+                            "ARRAY_CONTAINS": 7,
+                            "IN": 8,
+                            "ARRAY_CONTAINS_ANY": 9,
+                            "NOT_IN": 10
+                          }
+                        }
+                      }
+                    },
+                    "UnaryFilter": {
+                      "oneofs": {
+                        "operandType": {
+                          "oneof": [
+                            "field"
+                          ]
+                        }
+                      },
+                      "fields": {
+                        "op": {
+                          "type": "Operator",
+                          "id": 1
+                        },
+                        "field": {
+                          "type": "FieldReference",
+                          "id": 2
+                        }
+                      },
+                      "nested": {
+                        "Operator": {
+                          "values": {
+                            "OPERATOR_UNSPECIFIED": 0,
+                            "IS_NAN": 2,
+                            "IS_NULL": 3,
+                            "IS_NOT_NAN": 4,
+                            "IS_NOT_NULL": 5
+                          }
+                        }
+                      }
+                    },
+                    "Order": {
+                      "fields": {
+                        "field": {
+                          "type": "FieldReference",
+                          "id": 1
+                        },
+                        "direction": {
+                          "type": "Direction",
+                          "id": 2
+                        }
+                      }
+                    },
+                    "FieldReference": {
+                      "fields": {
+                        "fieldPath": {
+                          "type": "string",
+                          "id": 2
+                        }
+                      }
+                    },
+                    "Projection": {
+                      "fields": {
+                        "fields": {
+                          "rule": "repeated",
+                          "type": "FieldReference",
+                          "id": 2
+                        }
+                      }
+                    },
+                    "Direction": {
+                      "values": {
+                        "DIRECTION_UNSPECIFIED": 0,
+                        "ASCENDING": 1,
+                        "DESCENDING": 2
+                      }
+                    }
+                  }
+                },
+                "Cursor": {
+                  "fields": {
+                    "values": {
+                      "rule": "repeated",
+                      "type": "Value",
+                      "id": 1
+                    },
+                    "before": {
+                      "type": "bool",
+                      "id": 2
+                    }
+                  }
+                },
+                "Write": {
+                  "oneofs": {
+                    "operation": {
+                      "oneof": [
+                        "update",
+                        "delete",
+                        "verify",
+                        "transform"
+                      ]
+                    }
+                  },
+                  "fields": {
+                    "update": {
+                      "type": "Document",
+                      "id": 1
+                    },
+                    "delete": {
+                      "type": "string",
+                      "id": 2
+                    },
+                    "verify": {
+                      "type": "string",
+                      "id": 5
+                    },
+                    "transform": {
+                      "type": "DocumentTransform",
+                      "id": 6
+                    },
+                    "updateMask": {
+                      "type": "DocumentMask",
+                      "id": 3
+                    },
+                    "updateTransforms": {
+                      "rule": "repeated",
+                      "type": "DocumentTransform.FieldTransform",
+                      "id": 7
+                    },
+                    "currentDocument": {
+                      "type": "Precondition",
+                      "id": 4
+                    }
+                  }
+                },
+                "DocumentTransform": {
+                  "fields": {
+                    "document": {
+                      "type": "string",
+                      "id": 1
+                    },
+                    "fieldTransforms": {
+                      "rule": "repeated",
+                      "type": "FieldTransform",
+                      "id": 2
+                    }
+                  },
+                  "nested": {
+                    "FieldTransform": {
+                      "oneofs": {
+                        "transformType": {
+                          "oneof": [
+                            "setToServerValue",
+                            "increment",
+                            "maximum",
+                            "minimum",
+                            "appendMissingElements",
+                            "removeAllFromArray"
+                          ]
+                        }
+                      },
+                      "fields": {
+                        "fieldPath": {
+                          "type": "string",
+                          "id": 1
+                        },
+                        "setToServerValue": {
+                          "type": "ServerValue",
+                          "id": 2
+                        },
+                        "increment": {
+                          "type": "Value",
+                          "id": 3
+                        },
+                        "maximum": {
+                          "type": "Value",
+                          "id": 4
+                        },
+                        "minimum": {
+                          "type": "Value",
+                          "id": 5
+                        },
+                        "appendMissingElements": {
+                          "type": "ArrayValue",
+                          "id": 6
+                        },
+                        "removeAllFromArray": {
+                          "type": "ArrayValue",
+                          "id": 7
+                        }
+                      },
+                      "nested": {
+                        "ServerValue": {
+                          "values": {
+                            "SERVER_VALUE_UNSPECIFIED": 0,
+                            "REQUEST_TIME": 1
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "WriteResult": {
+                  "fields": {
+                    "updateTime": {
+                      "type": "google.protobuf.Timestamp",
+                      "id": 1
+                    },
+                    "transformResults": {
+                      "rule": "repeated",
+                      "type": "Value",
+                      "id": 2
+                    }
+                  }
+                },
+                "DocumentChange": {
+                  "fields": {
+                    "document": {
+                      "type": "Document",
+                      "id": 1
+                    },
+                    "targetIds": {
+                      "rule": "repeated",
+                      "type": "int32",
+                      "id": 5
+                    },
+                    "removedTargetIds": {
+                      "rule": "repeated",
+                      "type": "int32",
+                      "id": 6
+                    }
+                  }
+                },
+                "DocumentDelete": {
+                  "fields": {
+                    "document": {
+                      "type": "string",
+                      "id": 1
+                    },
+                    "removedTargetIds": {
+                      "rule": "repeated",
+                      "type": "int32",
+                      "id": 6
+                    },
+                    "readTime": {
+                      "type": "google.protobuf.Timestamp",
+                      "id": 4
+                    }
+                  }
+                },
+                "DocumentRemove": {
+                  "fields": {
+                    "document": {
+                      "type": "string",
+                      "id": 1
+                    },
+                    "removedTargetIds": {
+                      "rule": "repeated",
+                      "type": "int32",
+                      "id": 2
+                    },
+                    "readTime": {
+                      "type": "google.protobuf.Timestamp",
+                      "id": 4
+                    }
+                  }
+                },
+                "ExistenceFilter": {
+                  "fields": {
+                    "targetId": {
+                      "type": "int32",
+                      "id": 1
+                    },
+                    "count": {
+                      "type": "int32",
+                      "id": 2
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "api": {
+          "options": {
+            "go_package": "google.golang.org/genproto/googleapis/api/annotations;annotations",
+            "java_multiple_files": true,
+            "java_outer_classname": "HttpProto",
+            "java_package": "com.google.api",
+            "objc_class_prefix": "GAPI",
+            "cc_enable_arenas": true
+          },
+          "nested": {
+            "http": {
+              "type": "HttpRule",
+              "id": 72295728,
+              "extend": "google.protobuf.MethodOptions"
+            },
+            "Http": {
+              "fields": {
+                "rules": {
+                  "rule": "repeated",
+                  "type": "HttpRule",
+                  "id": 1
+                }
+              }
+            },
+            "HttpRule": {
+              "oneofs": {
+                "pattern": {
+                  "oneof": [
+                    "get",
+                    "put",
+                    "post",
+                    "delete",
+                    "patch",
+                    "custom"
+                  ]
+                }
+              },
+              "fields": {
+                "get": {
+                  "type": "string",
+                  "id": 2
+                },
+                "put": {
+                  "type": "string",
+                  "id": 3
+                },
+                "post": {
+                  "type": "string",
+                  "id": 4
+                },
+                "delete": {
+                  "type": "string",
+                  "id": 5
+                },
+                "patch": {
+                  "type": "string",
+                  "id": 6
+                },
+                "custom": {
+                  "type": "CustomHttpPattern",
+                  "id": 8
+                },
+                "selector": {
+                  "type": "string",
+                  "id": 1
+                },
+                "body": {
+                  "type": "string",
+                  "id": 7
+                },
+                "additionalBindings": {
+                  "rule": "repeated",
+                  "type": "HttpRule",
+                  "id": 11
+                }
+              }
+            },
+            "CustomHttpPattern": {
+              "fields": {
+                "kind": {
+                  "type": "string",
+                  "id": 1
+                },
+                "path": {
+                  "type": "string",
+                  "id": 2
+                }
+              }
+            }
+          }
+        },
+        "type": {
+          "options": {
+            "cc_enable_arenas": true,
+            "go_package": "google.golang.org/genproto/googleapis/type/latlng;latlng",
+            "java_multiple_files": true,
+            "java_outer_classname": "LatLngProto",
+            "java_package": "com.google.type",
+            "objc_class_prefix": "GTP"
+          },
+          "nested": {
+            "LatLng": {
+              "fields": {
+                "latitude": {
+                  "type": "double",
+                  "id": 1
+                },
+                "longitude": {
+                  "type": "double",
+                  "id": 2
+                }
+              }
+            }
+          }
+        },
+        "rpc": {
+          "options": {
+            "cc_enable_arenas": true,
+            "go_package": "google.golang.org/genproto/googleapis/rpc/status;status",
+            "java_multiple_files": true,
+            "java_outer_classname": "StatusProto",
+            "java_package": "com.google.rpc",
+            "objc_class_prefix": "RPC"
+          },
+          "nested": {
+            "Status": {
+              "fields": {
+                "code": {
+                  "type": "int32",
+                  "id": 1
+                },
+                "message": {
+                  "type": "string",
+                  "id": 2
+                },
+                "details": {
+                  "rule": "repeated",
+                  "type": "google.protobuf.Any",
+                  "id": 3
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This changes the Firestore SDK to load protos from JSON, which gets bundled directly into the source file. This should fix a bunch of problems with JS environments that use Node sources + Bundlers.