### PR TITLE
Add CJS build for messaging/sw

### DIFF
--- a/.changeset/slow-bobcats-clap.md
+++ b/.changeset/slow-bobcats-clap.md
@@ -1,0 +1,5 @@
+---
+'@firebase/messaging': patch
+---
+
+Add a CJS bundle for messaging/sw. This enables some SSR frameworks to run their Node.js pipelines without erroring.

--- a/packages/messaging/package.json
+++ b/packages/messaging/package.json
@@ -7,6 +7,7 @@
   "browser": "dist/esm/index.esm2017.js",
   "module": "dist/esm/index.esm2017.js",
   "sw": "dist/index.sw.esm2017.js",
+  "sw-main": "dist/index.sw.cjs",
   "esm5": "dist/esm/index.esm.js",
   "exports": {
     ".": {
@@ -15,7 +16,11 @@
       "esm5": "./dist/esm/index.esm.js",
       "default": "./dist/index.cjs.js"
     },
-    "./sw": "./dist/index.sw.esm2017.js",
+    "./sw": {
+      "require": "./dist/index.sw.cjs",
+      "import": "./dist/index.sw.esm2017.js",
+      "default": "./dist/index.sw.esm2017.js"
+    },
     "./package.json": "./package.json"
   },
   "typings": "dist/src/index.d.ts",

--- a/packages/messaging/rollup.config.js
+++ b/packages/messaging/rollup.config.js
@@ -90,7 +90,11 @@ const cjsBuilds = [
     ],
     external: id => deps.some(dep => id === dep || id.startsWith(`${dep}/`))
   },
-  // sw builds
+  // sw build
+  // TODO: This may no longer be necessary when we can provide ESM Node
+  // builds (contingent on updating the `idb` dependency). When we add
+  // ESM Node builds, test with Nuxt and other SSR frameworks to see if
+  // this can then be removed.
   {
     input: 'src/index.sw.ts',
     output: { file: pkg['sw-main'], format: 'cjs', sourcemap: true },

--- a/packages/messaging/rollup.config.js
+++ b/packages/messaging/rollup.config.js
@@ -89,6 +89,16 @@ const cjsBuilds = [
       replace(generateBuildTargetReplaceConfig('cjs', 5))
     ],
     external: id => deps.some(dep => id === dep || id.startsWith(`${dep}/`))
+  },
+  // sw builds
+  {
+    input: 'src/index.sw.ts',
+    output: { file: pkg['sw-main'], format: 'cjs', sourcemap: true },
+    plugins: [
+      ...es5BuildPlugins,
+      replace(generateBuildTargetReplaceConfig('cjs', 5))
+    ],
+    external: id => deps.some(dep => id === dep || id.startsWith(`${dep}/`))
   }
 ];
 

--- a/packages/messaging/sw/package.json
+++ b/packages/messaging/sw/package.json
@@ -2,6 +2,7 @@
   "name": "@firebase/messaging-sw",
   "description": "",
   "author": "Firebase <firebase-support@google.com> (https://firebase.google.com/)",
+  "main": "../dist/index.sw.cjs",
   "module": "../dist/index.sw.esm2017.js",
   "typings": "../dist/src/index.sw.d.ts"
 }


### PR DESCRIPTION
Although the messaging SW shouldn't technically have a Node version as SW's don't run in Node, some SSR applications generate pages in Node to be later loaded in the browser, and these builds break when they can't find a CJS version. This can also be fixed by adding an ESM Node version, but that can't currently be done until we update the `idb` dependency (see https://github.com/firebase/firebase-js-sdk/issues/5839). Adding a CJS build for now.

See https://github.com/firebase/firebase-js-sdk/issues/5854