### PR TITLE
[Auth] Fix error code thrown when the network errors out

### DIFF
--- a/.changeset/moody-ways-learn.md
+++ b/.changeset/moody-ways-learn.md
@@ -1,0 +1,5 @@
+---
+"@firebase/auth": patch
+---
+
+Fix error code thrown when the network times out

--- a/packages/auth/src/api/index.test.ts
+++ b/packages/auth/src/api/index.test.ts
@@ -316,7 +316,7 @@ describe('api/_performApiRequest', () => {
         request
       );
       clock.tick(DEFAULT_API_TIMEOUT_MS.get() + 1);
-      await expect(promise).to.be.rejectedWith(FirebaseError, 'auth/timeout');
+      await expect(promise).to.be.rejectedWith(FirebaseError, 'auth/network-request-failed');
       clock.restore();
     });
 

--- a/packages/auth/src/api/index.ts
+++ b/packages/auth/src/api/index.ts
@@ -223,7 +223,7 @@ class NetworkTimeout<T> {
   private timer: any | null = null;
   readonly promise = new Promise<T>((_, reject) => {
     this.timer = setTimeout(() => {
-      return reject(_createError(this.auth, AuthErrorCode.TIMEOUT));
+      return reject(_createError(this.auth, AuthErrorCode.NETWORK_REQUEST_FAILED));
     }, DEFAULT_API_TIMEOUT_MS.get());
   });
 


### PR DESCRIPTION
Fixes https://github.com/firebase/firebase-js-sdk/issues/5874

The error being thrown when the network timed out was not the correct one to use.