### PR TITLE
Fix CI release tracker script errors

### DIFF
--- a/scripts/ci/log-changesets.js
+++ b/scripts/ci/log-changesets.js
@@ -70,7 +70,7 @@ async function logChangesets() {
 
     req.on('error', error => reject(error));
 
-    req.write(data);
+    req.write(data, err => reject(err));
     req.end();
   });
 }

--- a/scripts/ci/notify-test-result.js
+++ b/scripts/ci/notify-test-result.js
@@ -75,7 +75,8 @@ async function notifyTestResults() {
     req.write(
       JSON.stringify({
         text: message
-      })
+      }),
+      err => reject(err)
     );
     req.end();
   });
@@ -101,10 +102,13 @@ async function notifyTestResults() {
 
     req.on('error', error => reject(error));
 
-    req.write({
-      testStatus,
-      testUrl: workflowUrl
-    });
+    req.write(
+      JSON.stringify({
+        testStatus,
+        testUrl: workflowUrl
+      }),
+      err => reject(err)
+    );
     req.end();
   });
 


### PR DESCRIPTION
Error in script that logs E2E test status to the release tracker.

Added proper error handling to all `req.write` calls in CI scripts (all related to logging release status info to the release tracker functions backend).