### PR TITLE
Fix Firestore failing to return empty results from the local cache

### DIFF
--- a/packages/firestore/src/core/event_manager.ts
+++ b/packages/firestore/src/core/event_manager.ts
@@ -307,7 +307,8 @@ export class QueryListener {
         snap.mutatedKeys,
         snap.fromCache,
         snap.syncStateChanged,
-        /* excludesMetadataChanges= */ true
+        /* excludesMetadataChanges= */ true,
+        snap.resumeToken
       );
     }
     let raisedEvent = false;
@@ -371,8 +372,9 @@ export class QueryListener {
       return false;
     }
 
-    // Raise data from cache if we have any documents or we are offline
-    return !snap.docs.isEmpty() || onlineState === OnlineState.Offline;
+    // Raise data from cache if we have previously executed the query and have
+    // cached data or we are offline
+    return snap.resumeToken.approximateByteSize() > 0 || onlineState === OnlineState.Offline;
   }
 
   private shouldRaiseEvent(snap: ViewSnapshot): boolean {
@@ -405,7 +407,8 @@ export class QueryListener {
       snap.query,
       snap.docs,
       snap.mutatedKeys,
-      snap.fromCache
+      snap.fromCache,
+      snap.resumeToken
     );
     this.raisedInitialEvent = true;
     this.queryObserver.next(snap);

--- a/packages/firestore/src/core/view_snapshot.ts
+++ b/packages/firestore/src/core/view_snapshot.ts
@@ -23,6 +23,7 @@ import { fail } from '../util/assert';
 import { SortedMap } from '../util/sorted_map';
 
 import { Query, queryEquals } from './query';
+import {ByteString} from '../util/byte_string';
 
 export const enum ChangeType {
   Added,
@@ -146,15 +147,19 @@ export class ViewSnapshot {
     readonly mutatedKeys: DocumentKeySet,
     readonly fromCache: boolean,
     readonly syncStateChanged: boolean,
-    readonly excludesMetadataChanges: boolean
-  ) {}
+    readonly excludesMetadataChanges: boolean,
+    readonly resumeToken: ByteString
+  ) {
+    1 == 1;
+  }
 
   /** Returns a view snapshot as if all documents in the snapshot were added. */
   static fromInitialDocuments(
     query: Query,
     documents: DocumentSet,
     mutatedKeys: DocumentKeySet,
-    fromCache: boolean
+    fromCache: boolean,
+    resumeToken: ByteString
   ): ViewSnapshot {
     const changes: DocumentViewChange[] = [];
     documents.forEach(doc => {
@@ -169,7 +174,8 @@ export class ViewSnapshot {
       mutatedKeys,
       fromCache,
       /* syncStateChanged= */ true,
-      /* excludesMetadataChanges= */ false
+      /* excludesMetadataChanges= */ false,
+      resumeToken
     );
   }
 
@@ -184,7 +190,8 @@ export class ViewSnapshot {
       !this.mutatedKeys.isEqual(other.mutatedKeys) ||
       !queryEquals(this.query, other.query) ||
       !this.docs.isEqual(other.docs) ||
-      !this.oldDocs.isEqual(other.oldDocs)
+      !this.oldDocs.isEqual(other.oldDocs) ||
+      this.resumeToken !== other.resumeToken
     ) {
       return false;
     }

--- a/packages/firestore/src/remote/remote_event.ts
+++ b/packages/firestore/src/remote/remote_event.ts
@@ -67,14 +67,16 @@ export class RemoteEvent {
   // PORTING NOTE: Multi-tab only
   static createSynthesizedRemoteEventForCurrentChange(
     targetId: TargetId,
-    current: boolean
+    current: boolean,
+    resumeToken: ByteString
   ): RemoteEvent {
     const targetChanges = new Map<TargetId, TargetChange>();
     targetChanges.set(
       targetId,
       TargetChange.createSynthesizedTargetChangeForCurrentChange(
         targetId,
-        current
+        current,
+        resumeToken
       )
     );
     return new RemoteEvent(
@@ -134,10 +136,11 @@ export class TargetChange {
    */
   static createSynthesizedTargetChangeForCurrentChange(
     targetId: TargetId,
-    current: boolean
+    current: boolean,
+    resumeToken: ByteString
   ): TargetChange {
     return new TargetChange(
-      ByteString.EMPTY_BYTE_STRING,
+      resumeToken,
       current,
       documentKeySet(),
       documentKeySet(),

--- a/packages/firestore/test/integration/api/query.test.ts
+++ b/packages/firestore/test/integration/api/query.test.ts
@@ -1290,7 +1290,7 @@ apiDescribe('Queries', (persistence: boolean) => {
   });
 
   // eslint-disable-next-line no-restricted-properties
-  (persistence ? it.only : it.skip)('empty query results are cached', () => {
+  (persistence ? it : it.skip)('empty query results are cached', () => {
     // Reproduces https://github.com/firebase/firebase-js-sdk/issues/5873
     return withTestCollection(persistence, {}, async coll => {
       const snapshot1 = await coll.get(); // Populate the cache

--- a/packages/firestore/test/integration/api/query.test.ts
+++ b/packages/firestore/test/integration/api/query.test.ts
@@ -1288,6 +1288,25 @@ apiDescribe('Queries', (persistence: boolean) => {
       expect(toDataArray(snapshot)).to.deep.equal([{ map: { nested: 'foo' } }]);
     });
   });
+
+  // eslint-disable-next-line no-restricted-properties
+  (persistence ? it.only : it.skip)('empty query results are cached', () => {
+    // Reproduces https://github.com/firebase/firebase-js-sdk/issues/5873
+    return withTestCollection(persistence, {}, async coll => {
+      const snapshot1 = await coll.get(); // Populate the cache
+      expect(snapshot1.metadata.fromCache).to.be.false;
+      expect(toDataArray(snapshot1)).to.deep.equal([]); // Precondition check
+
+      // Add a snapshot listener whose first event should be raised from cache.
+      const storeEvent = new EventsAccumulator<firestore.QuerySnapshot>();
+      coll.onSnapshot(storeEvent.storeEvent);
+      const snapshot2 = await storeEvent.awaitEvent();
+
+      expect(snapshot2.metadata.fromCache).to.be.true;
+      expect(toDataArray(snapshot2)).to.deep.equal([]);
+    });
+  });
+
 });
 
 function verifyDocumentChange<T>(

--- a/packages/firestore/test/util/api_helpers.ts
+++ b/packages/firestore/test/util/api_helpers.ts
@@ -46,6 +46,7 @@ import { JsonObject } from '../../src/model/object_value';
 import { TEST_PROJECT } from '../unit/local/persistence_test_helpers';
 
 import { doc, key, path as pathFrom } from './helpers';
+import {ByteString} from '../../src/util/byte_string';
 
 /**
  * A mock Firestore. Will not work for integration test.
@@ -122,6 +123,7 @@ export function query(path: string): Query {
  * @param mutatedKeys - The list of document with pending writes.
  * @param fromCache - Whether the query snapshot is cache result.
  * @param syncStateChanged - Whether the sync state has changed.
+ * @param resumeToken - The resume token associated with the query.
  * @returns A query snapshot that consists of both sets of documents.
  */
 export function querySnapshot(
@@ -130,7 +132,8 @@ export function querySnapshot(
   docsToAdd: { [key: string]: JsonObject<unknown> },
   mutatedKeys: DocumentKeySet,
   fromCache: boolean,
-  syncStateChanged: boolean
+  syncStateChanged: boolean,
+  resumeToken: ByteString
 ): QuerySnapshot {
   const query: InternalQuery = newQueryForPath(pathFrom(path));
   let oldDocuments: DocumentSet = new DocumentSet();
@@ -152,7 +155,8 @@ export function querySnapshot(
     mutatedKeys,
     fromCache,
     syncStateChanged,
-    false
+    false,
+    resumeToken
   );
   const db = firestore();
   return new QuerySnapshot(


### PR DESCRIPTION
Fix a bug where Firestore fails to return results from the local cache if the result set was empty.

This bug is due to the following logic in `event_manager.ts`:

https://github.com/firebase/firebase-js-sdk/blob/4ddf5566ca52b1f9ef776dd647c7d514e3b3f9f5/packages/firestore/src/core/event_manager.ts#L374-L375 where it 

which assumes that if the result set from the local cache is empty that there is no cached result; however, if the result set of the query is indeed empty then it should be returning that empty result set from the cache.

This fix improves the logic to use the presence of a resume token for the query to indicate that the empty result set is cached data and should be raised to the client.

Fixed #5873