### PR TITLE
Set Messaging to use only CJS bundles if Node

### DIFF
--- a/.changeset/happy-tools-wonder.md
+++ b/.changeset/happy-tools-wonder.md
@@ -1,0 +1,6 @@
+---
+'@firebase/messaging': patch
+'@firebase/messaging-compat': patch
+---
+
+Changed messaging `exports` paths to always point to cjs bundles when in a Node.js context.

--- a/packages/messaging-compat/package.json
+++ b/packages/messaging-compat/package.json
@@ -10,7 +10,7 @@
   "esm5": "dist/esm/index.esm.js",
   "exports": {
     ".": {
-      "require": "./dist/index.cjs.js",
+      "node": "./dist/index.cjs.js",
       "esm5": "./dist/esm/index.esm.js",
       "default": "./dist/esm/index.esm2017.js"
     },

--- a/packages/messaging/package.json
+++ b/packages/messaging/package.json
@@ -17,8 +17,7 @@
       "default": "./dist/index.cjs.js"
     },
     "./sw": {
-      "require": "./dist/index.sw.cjs",
-      "import": "./dist/index.sw.esm2017.js",
+      "node": "./dist/index.sw.cjs",
       "default": "./dist/index.sw.esm2017.js"
     },
     "./package.json": "./package.json"

--- a/packages/messaging/package.json
+++ b/packages/messaging/package.json
@@ -11,6 +11,7 @@
   "esm5": "dist/esm/index.esm.js",
   "exports": {
     ".": {
+      "node": "./dist/index.cjs.js",
       "browser": "./dist/esm/index.esm2017.js",
       "module": "./dist/esm/index.esm2017.js",
       "esm5": "./dist/esm/index.esm.js",


### PR DESCRIPTION
This change will direct all Node consumers of messaging, messaging-compat, and messaging/sw to the respective CJS bundles, regardless of whether they are using `require` or `import`. We cannot currently provide ESM Node bundles for messaging until we are able to upgrade our `idb` dependency, so we need to point all Node applications to the CJS bundles.

Once we are unblocked on upgrading `idb` (which entails officially dropping IE support, PR https://github.com/firebase/firebase-js-sdk/pull/5857), we can create Node ESM bundles for messaging and separate the `exports.node` entry point into `exports.node.require` (cjs) and `exports.node.import` (mjs) entry points.

See issue https://github.com/firebase/firebase-js-sdk/issues/5839.