### PR TITLE
Add cordova and rn export paths to auth

### DIFF
--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -17,11 +17,13 @@
         "require": "./dist/node/index.js"
       },
       "react-native": "./dist/rn/index.js",
-      "cordova": "./dist/cordova/index.esm5.js",
+      "cordova": "./dist/cordova/index.js",
       "webworker": "./dist/index.webworker.esm5.js",
       "esm5": "./dist/esm5/index.js",
       "default": "./dist/esm2017/index.js"
     },
+    "./cordova": "./dist/cordova/index.js",
+    "./react-native": "./dist/rn/index.js",
     "./internal": {
       "node": {
         "import": "./dist/node-esm/internal.js",


### PR DESCRIPTION
Seems like it needs the exact file path in "exports". See the `firebase/messaging/sw` path for the same pattern:
https://github.com/firebase/firebase-js-sdk/blob/c5d8f6595e1344612dd84732d366912bd416d503/packages/messaging/package.json#L19

That one is split into 3 because it has a Node version.

Fixes https://github.com/firebase/firebase-js-sdk/issues/5878