### PR TITLE
security(deps): node-fetch@2.6.7 (fix CVE-2022-0235)

### DIFF
--- a/integration/messaging/package.json
+++ b/integration/messaging/package.json
@@ -15,7 +15,7 @@
     "express": "4.17.1",
     "geckodriver": "2.0.4",
     "mocha": "9.1.1",
-    "node-fetch": "2.6.5",
+    "node-fetch": "2.6.7",
     "selenium-assistant": "6.1.0"
   }
 }

--- a/packages/auth-compat/package.json
+++ b/packages/auth-compat/package.json
@@ -47,7 +47,7 @@
     "@firebase/auth-types": "0.11.0",
     "@firebase/component": "0.5.10",
     "@firebase/util": "1.4.3",
-    "node-fetch": "2.6.5",
+    "node-fetch": "2.6.7",
     "selenium-webdriver": "^4.0.0-beta.2",
     "tslib": "^2.1.0"
   },

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -80,7 +80,7 @@
     "@firebase/component": "0.5.10",
     "@firebase/logger": "0.3.2",
     "@firebase/util": "1.4.3",
-    "node-fetch": "2.6.5",
+    "node-fetch": "2.6.7",
     "selenium-webdriver": "4.0.0-rc-1",
     "tslib": "^2.1.0"
   },

--- a/packages/firestore/package.json
+++ b/packages/firestore/package.json
@@ -83,7 +83,7 @@
     "@firebase/webchannel-wrapper": "0.6.1",
     "@grpc/grpc-js": "^1.3.2",
     "@grpc/proto-loader": "^0.6.0",
-    "node-fetch": "2.6.5",
+    "node-fetch": "2.6.7",
     "tslib": "^2.1.0"
   },
   "peerDependencies": {

--- a/packages/functions/package.json
+++ b/packages/functions/package.json
@@ -66,7 +66,7 @@
     "@firebase/auth-interop-types": "0.1.6",
     "@firebase/app-check-interop-types": "0.1.0",
     "@firebase/util": "1.4.3",
-    "node-fetch": "2.6.5",
+    "node-fetch": "2.6.7",
     "tslib": "^2.1.0"
   },
   "nyc": {

--- a/packages/rules-unit-testing/package.json
+++ b/packages/rules-unit-testing/package.json
@@ -39,6 +39,6 @@
     "url": "https://github.com/firebase/firebase-js-sdk/issues"
   },
   "dependencies": {
-    "node-fetch": "2.6.5"
+    "node-fetch": "2.6.7"
   }
 }

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -43,7 +43,7 @@
   "dependencies": {
     "@firebase/util": "1.4.3",
     "@firebase/component": "0.5.10",
-    "node-fetch": "2.6.5",
+    "node-fetch": "2.6.7",
     "tslib": "^2.1.0"
   },
   "peerDependencies": {

--- a/repo-scripts/changelog-generator/package.json
+++ b/repo-scripts/changelog-generator/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "@changesets/types": "3.3.0",
     "@changesets/get-github-info": "0.5.0",
-    "node-fetch": "2.6.5",
+    "node-fetch": "2.6.7",
     "@types/node-fetch": "2.5.12"
   },
   "license": "Apache-2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11918,10 +11918,10 @@ node-emoji@^1.4.1:
   dependencies:
     lodash "^4.17.21"
 
-node-fetch@2.6.5, node-fetch@^2.5.0, node-fetch@^2.6.1:
-  version "2.6.5"
-  resolved "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.5.tgz#42735537d7f080a7e5f78b6c549b7146be1742fd"
-  integrity sha512-mmlIVHJEu5rnIxgEgez6b9GgWXbkZj5YZ7fx+2r94a2E+Uirsp6HsPTPlomfdHtpt/B0cdKviwkoaM6pyvUOpQ==
+node-fetch@2.6.7, node-fetch@^2.5.0, node-fetch@^2.6.1:
+  version "2.6.7"
+  resolved "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
+  integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==
   dependencies:
     whatwg-url "^5.0.0"
 


### PR DESCRIPTION
no API breaking changes in v2.6.7.

closes #5928
closes #5919

there are still other audit failures in this repository coming from old versions of `firebase-tools`, `firebase-admin`, and `mocha`.
they seem to be devDeps, so consumers aren't affected. that being said, a library as big as `firebase` should probably be on top of that.