### PR TITLE
[Auth] Add missing initializer for providerData to UserImpl

### DIFF
--- a/.changeset/curvy-brooms-clean.md
+++ b/.changeset/curvy-brooms-clean.md
@@ -1,0 +1,5 @@
+---
+"@firebase/auth": patch
+---
+
+Fix bug where `user.providerData` field was being improperly initialized

--- a/packages/auth/src/core/user/user_impl.test.ts
+++ b/packages/auth/src/core/user/user_impl.test.ts
@@ -264,6 +264,14 @@ describe('core/user/user_impl', () => {
         photoURL: 'photo',
         emailVerified: false,
         isAnonymous: true,
+        providerData: [{
+          providerId: 'password',
+          displayName: null,
+          photoURL: null,
+          email: 'test@foo.test',
+          phoneNumber: null,
+          uid: 'i-am-uid'
+        }],
         tenantId: 'tenant-id'
       });
 
@@ -274,6 +282,14 @@ describe('core/user/user_impl', () => {
       expect(copy.toJSON()).to.eql(user.toJSON());
       expect(copy.auth).to.eq(newAuth);
       expect(copy.tenantId).to.eq('tenant-id');
+      expect(copy.providerData).to.eql([{
+        providerId: 'password',
+        displayName: null,
+        photoURL: null,
+        email: 'test@foo.test',
+        phoneNumber: null,
+        uid: 'i-am-uid'
+      }]);
     });
   });
 });

--- a/packages/auth/src/core/user/user_impl.ts
+++ b/packages/auth/src/core/user/user_impl.ts
@@ -61,11 +61,11 @@ export class UserImpl implements UserInternal {
 
   uid: string;
   auth: AuthInternal;
-  emailVerified = false;
-  isAnonymous = false;
-  tenantId: string | null = null;
+  emailVerified: boolean;
+  isAnonymous: boolean;
+  tenantId: string | null;
   readonly metadata: UserMetadata;
-  providerData: MutableUserInfo[] = [];
+  providerData: MutableUserInfo[];
 
   // Optional fields from UserInfo
   displayName: string | null;
@@ -88,6 +88,7 @@ export class UserImpl implements UserInternal {
     this.photoURL = opt.photoURL || null;
     this.isAnonymous = opt.isAnonymous || false;
     this.tenantId = opt.tenantId || null;
+    this.providerData = opt.providerData ? [...opt.providerData] : [];
     this.metadata = new UserMetadata(
       opt.createdAt || undefined,
       opt.lastLoginAt || undefined

--- a/packages/auth/src/model/user.ts
+++ b/packages/auth/src/model/user.ts
@@ -42,6 +42,7 @@ export interface UserParameters {
   isAnonymous?: boolean | null;
   emailVerified?: boolean | null;
   tenantId?: string | null;
+  providerData?: MutableUserInfo[] | null;
 
   createdAt?: string | null;
   lastLoginAt?: string | null;


### PR DESCRIPTION
Fixes https://github.com/firebase/firebaseui-web/issues/917.

I also updated all the fields on `UserImpl` to not have a default constructor, so in future we'll get type errors if one of the fields isn't properly initialized by the parameters. (We also ran into this issue with tenantId).