### PR TITLE
Update backend apis

### DIFF
--- a/packages/auth/src/api/authentication/email_and_password.test.ts
+++ b/packages/auth/src/api/authentication/email_and_password.test.ts
@@ -21,7 +21,7 @@ import chaiAsPromised from 'chai-as-promised';
 import { ActionCodeOperation } from '../../model/public_types';
 import { FirebaseError } from '@firebase/util';
 
-import { Endpoint, HttpHeader } from '../';
+import { Endpoint, HttpHeader, RecaptchaClientType, RecaptchaVersion } from '../';
 import { mockEndpoint } from '../../../test/helpers/api/helper';
 import { testAuth, TestAuth } from '../../../test/helpers/mock_auth';
 import * as mockFetch from '../../../test/helpers/mock_fetch';
@@ -44,7 +44,10 @@ describe('api/authentication/signInWithPassword', () => {
   const request = {
     returnSecureToken: true,
     email: 'test@foo.com',
-    password: 'my-password'
+    password: 'my-password',
+    captchaResponse: 'recaptcha-token',
+    clientType: RecaptchaClientType.WEB,
+    recaptchaVersion: RecaptchaVersion.ENTERPRISE,
   };
 
   let auth: TestAuth;
@@ -162,8 +165,11 @@ describe('api/authentication/sendEmailVerification', () => {
 describe('api/authentication/sendPasswordResetEmail', () => {
   const request: PasswordResetRequest = {
     requestType: ActionCodeOperation.PASSWORD_RESET,
-    email: 'test@foo.com'
-  };
+    email: 'test@foo.com',
+    captchaResp: 'recaptcha-token',
+    clientType: RecaptchaClientType.WEB,
+    recaptchaVersion: RecaptchaVersion.ENTERPRISE,
+};
 
   let auth: TestAuth;
 
@@ -220,7 +226,10 @@ describe('api/authentication/sendPasswordResetEmail', () => {
 describe('api/authentication/sendSignInLinkToEmail', () => {
   const request: EmailSignInRequest = {
     requestType: ActionCodeOperation.EMAIL_SIGNIN,
-    email: 'test@foo.com'
+    email: 'test@foo.com',
+    captchaResp: 'recaptcha-token',
+    clientType: RecaptchaClientType.WEB,
+    recaptchaVersion: RecaptchaVersion.ENTERPRISE,
   };
 
   let auth: TestAuth;

--- a/packages/auth/src/api/authentication/email_and_password.ts
+++ b/packages/auth/src/api/authentication/email_and_password.ts
@@ -20,6 +20,8 @@ import { ActionCodeOperation, Auth } from '../../model/public_types';
 import {
   Endpoint,
   HttpMethod,
+  RecaptchaClientType,
+  RecaptchaVersion,
   _addTidIfNecessary,
   _performApiRequest,
   _performSignInRequest
@@ -31,6 +33,9 @@ export interface SignInWithPasswordRequest {
   email: string;
   password: string;
   tenantId?: string;
+  captchaResponse?: string;
+  clientType?: RecaptchaClientType;
+  recaptchaVersion?: RecaptchaVersion;
 }
 
 export interface SignInWithPasswordResponse extends IdTokenResponse {
@@ -76,11 +81,16 @@ export interface PasswordResetRequest extends GetOobCodeRequest {
   requestType: ActionCodeOperation.PASSWORD_RESET;
   email: string;
   captchaResp?: string;
+  clientType?: RecaptchaClientType;
+  recaptchaVersion?: RecaptchaVersion;
 }
 
 export interface EmailSignInRequest extends GetOobCodeRequest {
   requestType: ActionCodeOperation.EMAIL_SIGNIN;
   email: string;
+  captchaResp?: string;
+  clientType?: RecaptchaClientType;
+  recaptchaVersion?: RecaptchaVersion;
 }
 
 export interface VerifyAndChangeEmailRequest extends GetOobCodeRequest {

--- a/packages/auth/src/api/authentication/sign_up.test.ts
+++ b/packages/auth/src/api/authentication/sign_up.test.ts
@@ -20,7 +20,7 @@ import chaiAsPromised from 'chai-as-promised';
 
 import { FirebaseError } from '@firebase/util';
 
-import { Endpoint, HttpHeader } from '../';
+import { Endpoint, HttpHeader, RecaptchaClientType, RecaptchaVersion } from '../';
 import { mockEndpoint } from '../../../test/helpers/api/helper';
 import { testAuth, TestAuth } from '../../../test/helpers/mock_auth';
 import * as mockFetch from '../../../test/helpers/mock_fetch';
@@ -33,8 +33,11 @@ describe('api/authentication/signUp', () => {
   const request = {
     returnSecureToken: true,
     email: 'test@foo.com',
-    password: 'my-password'
-  };
+    password: 'my-password',
+    captchaResponse: 'recaptcha-token',
+    clientType: RecaptchaClientType.WEB,
+    recaptchaVersion: RecaptchaVersion.ENTERPRISE,
+};
 
   let auth: TestAuth;
 

--- a/packages/auth/src/api/authentication/sign_up.ts
+++ b/packages/auth/src/api/authentication/sign_up.ts
@@ -18,6 +18,8 @@
 import {
   Endpoint,
   HttpMethod,
+  RecaptchaClientType,
+  RecaptchaVersion,
   _addTidIfNecessary,
   _performSignInRequest
 } from '../index';
@@ -29,6 +31,9 @@ export interface SignUpRequest {
   email?: string;
   password?: string;
   tenantId?: string;
+  captchaResponse?: string;
+  clientType?: RecaptchaClientType;
+  recaptchaVersion?: RecaptchaVersion;
 }
 
 export interface SignUpResponse extends IdTokenResponse {

--- a/packages/auth/src/api/index.ts
+++ b/packages/auth/src/api/index.ts
@@ -60,7 +60,15 @@ export const enum Endpoint {
   START_PHONE_MFA_SIGN_IN = '/v2/accounts/mfaSignIn:start',
   FINALIZE_PHONE_MFA_SIGN_IN = '/v2/accounts/mfaSignIn:finalize',
   WITHDRAW_MFA = '/v2/accounts/mfaEnrollment:withdraw',
-  GET_PROJECT_CONFIG = '/v1/projects'
+
+export const enum RecaptchaClientType {
+  WEB = 1,
+  ANDROID = 2,
+  IOS = 3,
+}
+
+export const enum RecaptchaVersion {
+  ENTERPRISE = 1,
 }
 
 export const DEFAULT_API_TIMEOUT_MS = new Delay(30_000, 60_000);

--- a/packages/auth/src/api/index.ts
+++ b/packages/auth/src/api/index.ts
@@ -60,6 +60,8 @@ export const enum Endpoint {
   START_PHONE_MFA_SIGN_IN = '/v2/accounts/mfaSignIn:start',
   FINALIZE_PHONE_MFA_SIGN_IN = '/v2/accounts/mfaSignIn:finalize',
   WITHDRAW_MFA = '/v2/accounts/mfaEnrollment:withdraw',
+  GET_PROJECT_CONFIG = '/v1/projects'
+}
 
 export const enum RecaptchaClientType {
   WEB = 1,


### PR DESCRIPTION
This PR updates the 4 email auth apis (sign in, sign up, password reset, email link sign in) to support recaptcha enterprise.

### Development progress
Base apis and types update
- Backend API updates - https://github.com/firebase/firebase-js-sdk/pull/5942
- Public API and internal support types
- New backend error types

Core logic
- Implement getRecaptchaConfig API
- Implement recaptcha enterprise verifier
- Wire recaptcha enterprise verifier to email auth flows
