### PR TITLE
Add getReactNativePersistence to docs

### DIFF
--- a/packages/auth/index.doc.ts
+++ b/packages/auth/index.doc.ts
@@ -28,4 +28,4 @@
 export * from './index';
 
 export { cordovaPopupRedirectResolver } from './index.cordova';
-export { reactNativeLocalPersistence } from './index.rn';
+export { reactNativeLocalPersistence, getReactNativePersistence } from './index.rn';

--- a/packages/auth/src/model/public_types.ts
+++ b/packages/auth/src/model/public_types.ts
@@ -631,6 +631,7 @@ export interface MultiFactorInfo {
 /**
  * The subclass of the {@link MultiFactorInfo} interface for phone number
  * second factors. The factorId of this second factor is {@link FactorId.PHONE}.
+ * @public
  */
 export interface PhoneMultiFactorInfo extends MultiFactorInfo {
   /** The phone number associated with the current second factor. */


### PR DESCRIPTION
Add `getReactNativePersistence` to the special index file we use only for generating docs (which includes methods from environments that shouldn't go together in one bundle).

Also add `@public` tag to MultiFactorPhoneInfo, this just gets rid of a warning as the api-extractor seems to default to public anyway.