### PR TITLE
Fix isWindowSupported() check

### DIFF
--- a/.changeset/tame-apes-tie.md
+++ b/.changeset/tame-apes-tie.md
@@ -1,0 +1,5 @@
+---
+'@firebase/messaging': patch
+---
+
+Fix uncaught rejection in `isSupported()` if environment does not support IndexedDB's `open()` method.

--- a/packages/messaging-compat/src/messaging-compat.ts
+++ b/packages/messaging-compat/src/messaging-compat.ts
@@ -65,6 +65,8 @@ export function isSupported(): boolean {
 
 /**
  * Checks to see if the required APIs exist.
+ * Unlike the modular version, it does not check if IndexedDB.open() is allowed
+ * in order to keep isSupported() synchronous and maintain v8 compatibility.
  */
 function isWindowSupported(): boolean {
   return (

--- a/packages/messaging/src/api/isSupported.ts
+++ b/packages/messaging/src/api/isSupported.ts
@@ -28,13 +28,19 @@ import {
  * @public
  */
 export async function isWindowSupported(): Promise<boolean> {
+  try {
+    // This throws if open() is unsupported, so adding it to the conditional
+    // statement below can cause an uncaught error.
+    await validateIndexedDBOpenable();
+  } catch(e) {
+    return false;
+  }
   // firebase-js-sdk/issues/2393 reveals that idb#open in Safari iframe and Firefox private browsing
   // might be prohibited to run. In these contexts, an error would be thrown during the messaging
   // instantiating phase, informing the developers to import/call isSupported for special handling.
   return (
     typeof window !== 'undefined' &&
     isIndexedDBAvailable() &&
-    (await validateIndexedDBOpenable()) &&
     areCookiesEnabled() &&
     'serviceWorker' in navigator &&
     'PushManager' in window &&

--- a/packages/messaging/src/api/isSupported.ts
+++ b/packages/messaging/src/api/isSupported.ts
@@ -32,7 +32,7 @@ export async function isWindowSupported(): Promise<boolean> {
     // This throws if open() is unsupported, so adding it to the conditional
     // statement below can cause an uncaught error.
     await validateIndexedDBOpenable();
-  } catch(e) {
+  } catch (e) {
     return false;
   }
   // firebase-js-sdk/issues/2393 reveals that idb#open in Safari iframe and Firefox private browsing


### PR DESCRIPTION
Wrap `validateIndexedDBOpenable()` in a try/catch. Add a comment to the equivalent function in messaging-compat to remind us of why we can't add this check there.

Fixes https://github.com/firebase/firebase-js-sdk/issues/5868