### PR TITLE
Add recaptcha enterprise verifier

### DIFF
--- a/packages/auth/src/platform_browser/auth_window.ts
+++ b/packages/auth/src/platform_browser/auth_window.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { Recaptcha } from './recaptcha/recaptcha';
+import { Recaptcha, GreCAPTCHATopLevel } from './recaptcha/recaptcha';
 
 /**
  * A specialized window type that melds the normal window type plus the
@@ -27,7 +27,7 @@ export type AuthWindow = {
   [T in keyof Window]: Window[T];
 } & {
   // Any known / named properties we want to add
-  grecaptcha?: Recaptcha;
+  grecaptcha?: Recaptcha | GreCAPTCHATopLevel;
   /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
   ___jsl?: Record<string, any>;
   gapi?: typeof gapi;

--- a/packages/auth/src/platform_browser/recaptcha/recaptcha.test.ts
+++ b/packages/auth/src/platform_browser/recaptcha/recaptcha.test.ts
@@ -1,0 +1,60 @@
+/**
+ * @license
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+ import { expect, use } from 'chai';
+ import chaiAsPromised from 'chai-as-promised';
+ import sinonChai from 'sinon-chai';
+  
+ import { testAuth, TestAuth } from '../../../test/helpers/mock_auth';
+
+ import { MockReCaptcha, MockGreCAPTCHATopLevel, MockGreCAPTCHA } from './recaptcha_mock';
+
+ import {isV2, isEnterprise} from "./recaptcha";
+ 
+ use(chaiAsPromised);
+ use(sinonChai);
+ 
+ describe('platform_browser/recaptcha/recaptcha', () => {  
+  let auth: TestAuth;
+  let recaptchaV2: MockReCaptcha;
+  let recaptchaV3: MockGreCAPTCHA;
+  let recaptchaEnterprise: MockGreCAPTCHATopLevel;
+
+  context('#verify', () => {
+    beforeEach(async () => {
+      auth = await testAuth();
+       recaptchaV2 = new MockReCaptcha(auth);
+       recaptchaV3 = new MockGreCAPTCHA();
+       recaptchaEnterprise = new MockGreCAPTCHATopLevel();
+    });
+ 
+     it('isV2', async () => {
+      expect(isV2(undefined)).to.be.false;
+      expect(isV2(recaptchaV2)).to.be.true;
+      expect(isV2(recaptchaV3)).to.be.false;
+      expect(isV2(recaptchaEnterprise)).to.be.false;
+    });
+
+     it('isEnterprise', async () => {
+      expect(isEnterprise(undefined)).to.be.false;
+      expect(isEnterprise(recaptchaV2)).to.be.false;
+      expect(isEnterprise(recaptchaV3)).to.be.false;
+      expect(isEnterprise(recaptchaEnterprise)).to.be.true;
+    });
+   });
+ });
+ 

--- a/packages/auth/src/platform_browser/recaptcha/recaptcha.ts
+++ b/packages/auth/src/platform_browser/recaptcha/recaptcha.ts
@@ -17,9 +17,38 @@
 
 import { RecaptchaParameters } from '../../model/public_types';
 
+// reCAPTCHA v2 interface
 export interface Recaptcha {
   render: (container: HTMLElement, parameters: RecaptchaParameters) => number;
   getResponse: (id: number) => string;
   execute: (id: number) => unknown;
   reset: (id: number) => unknown;
+}
+
+export function isV2(grecaptcha: Recaptcha | GreCAPTCHATopLevel | undefined): grecaptcha is Recaptcha {
+  return grecaptcha !== undefined && (grecaptcha as Recaptcha).getResponse !== undefined;
+}
+
+// reCAPTCHA Enterprise & v3 shared interface
+ export interface GreCAPTCHATopLevel extends GreCAPTCHA {
+   enterprise: GreCAPTCHA;
+ }
+ 
+ // reCAPTCHA Enterprise interface
+ export interface GreCAPTCHA {
+   ready: (callback: () => void) => void;
+   execute: (siteKey: string, options: { action: string }) => Promise<string>;
+   render: (
+     container: string | HTMLElement,
+     parameters: GreCAPTCHARenderOption
+   ) => string;
+ }
+ 
+ export interface GreCAPTCHARenderOption {
+   sitekey: string;
+   size: 'invisible';
+ }
+
+ export function isEnterprise(grecaptcha: Recaptcha | GreCAPTCHATopLevel | undefined): grecaptcha is GreCAPTCHATopLevel {
+  return grecaptcha !== undefined && (grecaptcha as GreCAPTCHATopLevel).enterprise !== undefined;
 }

--- a/packages/auth/src/platform_browser/recaptcha/recaptcha.ts
+++ b/packages/auth/src/platform_browser/recaptcha/recaptcha.ts
@@ -25,7 +25,7 @@ export interface Recaptcha {
   reset: (id: number) => unknown;
 }
 
-export function isV2(grecaptcha: Recaptcha | GreCAPTCHATopLevel | undefined): grecaptcha is Recaptcha {
+export function isV2(grecaptcha: Recaptcha | GreCAPTCHA | undefined): grecaptcha is Recaptcha {
   return grecaptcha !== undefined && (grecaptcha as Recaptcha).getResponse !== undefined;
 }
 
@@ -49,6 +49,6 @@ export function isV2(grecaptcha: Recaptcha | GreCAPTCHATopLevel | undefined): gr
    size: 'invisible';
  }
 
- export function isEnterprise(grecaptcha: Recaptcha | GreCAPTCHATopLevel | undefined): grecaptcha is GreCAPTCHATopLevel {
+ export function isEnterprise(grecaptcha: Recaptcha | GreCAPTCHA | undefined): grecaptcha is GreCAPTCHATopLevel {
   return grecaptcha !== undefined && (grecaptcha as GreCAPTCHATopLevel).enterprise !== undefined;
 }

--- a/packages/auth/src/platform_browser/recaptcha/recaptcha_enterprise_verifier.test.ts
+++ b/packages/auth/src/platform_browser/recaptcha/recaptcha_enterprise_verifier.test.ts
@@ -1,0 +1,61 @@
+/**
+ * @license
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+ import { expect, use } from 'chai';
+ import chaiAsPromised from 'chai-as-promised';
+ import * as sinon from 'sinon';
+ import sinonChai from 'sinon-chai';
+  
+ import { testAuth, TestAuth } from '../../../test/helpers/mock_auth';
+ import * as fetch from '../../../test/helpers/mock_fetch';
+ import { _window } from '../auth_window';
+
+ import { MockGreCAPTCHATopLevel } from './recaptcha_mock';
+ import { RecaptchaEnterpriseVerifier } from './recaptcha_enterprise_verifier';
+ 
+ use(chaiAsPromised);
+ use(sinonChai);
+ 
+ describe('platform_browser/recaptcha/recaptcha_enterprise_verifier', () => {
+   let auth: TestAuth;
+   let verifier: RecaptchaEnterpriseVerifier;
+ 
+   beforeEach(async () => {
+     fetch.setUp();
+     auth = await testAuth();
+     verifier = new RecaptchaEnterpriseVerifier(auth);
+   });
+ 
+   afterEach(() => {
+     sinon.restore();
+     fetch.tearDown();
+   });
+ 
+   context('#verify', () => {
+     let recaptcha: MockGreCAPTCHATopLevel;
+     beforeEach(() => {
+        recaptcha = new MockGreCAPTCHATopLevel();
+        _window().grecaptcha = recaptcha;
+    });
+ 
+     it('returns if response is available', async () => {
+       sinon.stub(recaptcha.enterprise, 'execute').returns(Promise.resolve('recaptcha-response'));
+       expect(await verifier.verify()).to.eq('recaptcha-response');
+     });
+   });
+ });
+ 

--- a/packages/auth/src/platform_browser/recaptcha/recaptcha_enterprise_verifier.test.ts
+++ b/packages/auth/src/platform_browser/recaptcha/recaptcha_enterprise_verifier.test.ts
@@ -21,7 +21,6 @@
  import sinonChai from 'sinon-chai';
   
  import { testAuth, TestAuth } from '../../../test/helpers/mock_auth';
- import * as fetch from '../../../test/helpers/mock_fetch';
  import { _window } from '../auth_window';
 
  import { MockGreCAPTCHATopLevel } from './recaptcha_mock';
@@ -35,14 +34,12 @@
    let verifier: RecaptchaEnterpriseVerifier;
  
    beforeEach(async () => {
-     fetch.setUp();
      auth = await testAuth();
      verifier = new RecaptchaEnterpriseVerifier(auth);
    });
  
    afterEach(() => {
      sinon.restore();
-     fetch.tearDown();
    });
  
    context('#verify', () => {
@@ -56,6 +53,11 @@
        sinon.stub(recaptcha.enterprise, 'execute').returns(Promise.resolve('recaptcha-response'));
        expect(await verifier.verify()).to.eq('recaptcha-response');
      });
+
+     it('reject if error is thrown', async () => {
+      sinon.stub(recaptcha.enterprise, 'execute').returns(Promise.reject(Error('recaptcha-error')));
+      await expect(verifier.verify()).to.be.rejectedWith(Error, 'recaptcha-error');
+    });
    });
  });
  

--- a/packages/auth/src/platform_browser/recaptcha/recaptcha_enterprise_verifier.ts
+++ b/packages/auth/src/platform_browser/recaptcha/recaptcha_enterprise_verifier.ts
@@ -17,7 +17,7 @@
  */
 
  import { _window } from '../auth_window';
- import { GreCAPTCHATopLevel, isEnterprise } from './recaptcha';
+ import { isEnterprise } from './recaptcha';
 
  import {
    Auth

--- a/packages/auth/src/platform_browser/recaptcha/recaptcha_enterprise_verifier.ts
+++ b/packages/auth/src/platform_browser/recaptcha/recaptcha_enterprise_verifier.ts
@@ -1,0 +1,106 @@
+/* eslint-disable @typescript-eslint/no-require-imports */
+/**
+ * @license
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+ import { _window } from '../auth_window';
+ import { GreCAPTCHATopLevel, isEnterprise } from './recaptcha';
+
+ import {
+   Auth
+ } from '../../model/public_types';
+ import {
+   AuthInternal
+ } from '../../model/auth';
+ import { _castAuth } from '../../core/auth/auth_impl';
+
+ const RECAPTCHA_ENTERPRISE_URL = 'https://www.google.com/recaptcha/enterprise.js?render=';
+  
+ export const RECAPTCHA_ENTERPRISE_VERIFIER_TYPE = 'recaptcha-enterprise';
+ 
+ export class RecaptchaEnterpriseVerifier {
+   /**
+    * Identifies the type of application verifier (e.g. "recaptcha-enterprise").
+    */
+   readonly type = RECAPTCHA_ENTERPRISE_VERIFIER_TYPE;
+ 
+   /**
+    * Stores the recaptcha site key per tenant.
+    */
+   static siteKeys: [string: string];
+ 
+   private readonly auth: AuthInternal;
+ 
+   /**
+    *
+    * @param authExtern - The corresponding Firebase {@link Auth} instance.
+    *
+    */
+   constructor(
+     authExtern: Auth
+   ) {
+     this.auth = _castAuth(authExtern);
+   }
+ 
+   /**
+    * Executes the verification process.
+    *
+    * @returns A Promise for a token that can be used to assert the validity of a request.
+    */
+   async verify(): Promise<string> {
+     // TODO(b/217382327): load and manage recaptcha config
+     const siteKey = '6LfyHwgeAAAAAKhL1Ujy7K1fBgX-l6bYdJpYJb_K';
+ 
+     const grecaptcha = _window().grecaptcha;
+     if (isEnterprise(grecaptcha)) {
+        grecaptcha.enterprise.ready(() => {
+            grecaptcha.enterprise.execute(siteKey, { action: 'login' })
+            .then((token) => {
+                return Promise.resolve(token);
+            })
+            .catch((error) => {
+                return Promise.reject(error);
+            });
+          });
+     }
+     
+     return new Promise<string>((resolve, reject) => {
+       loadReCAPTCHAEnterpriseScript(siteKey, () => {
+        const grecaptcha = _window().grecaptcha as GreCAPTCHATopLevel;
+         if (!grecaptcha) {
+           throw new Error('no recaptcha script loaded');
+         } else {
+           grecaptcha.enterprise.ready(() => {
+             grecaptcha.enterprise.execute(siteKey, { action: 'login' })
+             .then((token) => {
+               resolve(token);
+             })
+             .catch((error) => {
+               reject(error);
+             });
+           });
+         }
+       });
+     });
+   }
+ }
+ 
+ function loadReCAPTCHAEnterpriseScript(siteKey: string, onload: () => void): void {
+   const script = document.createElement('script');
+   script.src = RECAPTCHA_ENTERPRISE_URL + siteKey;
+   script.onload = onload;
+   document.head.appendChild(script);
+ }

--- a/packages/auth/src/platform_browser/recaptcha/recaptcha_enterprise_verifier.ts
+++ b/packages/auth/src/platform_browser/recaptcha/recaptcha_enterprise_verifier.ts
@@ -62,7 +62,7 @@
     * @returns A Promise for a token that can be used to assert the validity of a request.
     */
    async verify(): Promise<string> {
-     // TODO(b/217382327): load and manage recaptcha config
+     // TODO(b/217382327):load and manage recaptcha config
      const siteKey = '';
 
     function retrieveRecaptchaToken(resolve: (value: string | PromiseLike<string>) => void, reject: (reason?: unknown) => void): void {

--- a/packages/auth/src/platform_browser/recaptcha/recaptcha_enterprise_verifier.ts
+++ b/packages/auth/src/platform_browser/recaptcha/recaptcha_enterprise_verifier.ts
@@ -62,7 +62,7 @@
     * @returns A Promise for a token that can be used to assert the validity of a request.
     */
    async verify(): Promise<string> {
-     // TODO(b/217382327):load and manage recaptcha config
+     // TODO(b/217382327): load and manage recaptcha config
      const siteKey = '';
 
     function retrieveRecaptchaToken(resolve: (value: string | PromiseLike<string>) => void, reject: (reason?: unknown) => void): void {

--- a/packages/auth/src/platform_browser/recaptcha/recaptcha_loader.ts
+++ b/packages/auth/src/platform_browser/recaptcha/recaptcha_loader.ts
@@ -23,7 +23,7 @@ import { Delay } from '../../core/util/delay';
 import { AuthInternal } from '../../model/auth';
 import { _window } from '../auth_window';
 import * as jsHelpers from '../load_js';
-import { Recaptcha } from './recaptcha';
+import { Recaptcha, isV2 } from './recaptcha';
 import { MockReCaptcha } from './recaptcha_mock';
 
 // ReCaptcha will load using the same callback, so the callback function needs
@@ -54,8 +54,8 @@ export class ReCaptchaLoaderImpl implements ReCaptchaLoader {
   load(auth: AuthInternal, hl = ''): Promise<Recaptcha> {
     _assert(isHostLanguageValid(hl), auth, AuthErrorCode.ARGUMENT_ERROR);
 
-    if (this.shouldResolveImmediately(hl)) {
-      return Promise.resolve(_window().grecaptcha!);
+    if (this.shouldResolveImmediately(hl) && isV2(_window().grecaptcha)) {
+      return Promise.resolve(_window().grecaptcha! as Recaptcha);
     }
     return new Promise<Recaptcha>((resolve, reject) => {
       const networkTimeout = _window().setTimeout(() => {
@@ -66,9 +66,9 @@ export class ReCaptchaLoaderImpl implements ReCaptchaLoader {
         _window().clearTimeout(networkTimeout);
         delete _window()[_JSLOAD_CALLBACK];
 
-        const recaptcha = _window().grecaptcha;
+        const recaptcha = _window().grecaptcha as Recaptcha;
 
-        if (!recaptcha) {
+        if (!recaptcha || !isV2(recaptcha)) {
           reject(_createError(auth, AuthErrorCode.INTERNAL_ERROR));
           return;
         }

--- a/packages/auth/src/platform_browser/recaptcha/recaptcha_mock.ts
+++ b/packages/auth/src/platform_browser/recaptcha/recaptcha_mock.ts
@@ -19,7 +19,7 @@ import { AuthErrorCode } from '../../core/errors';
 import { _assert } from '../../core/util/assert';
 import { AuthInternal } from '../../model/auth';
 import { RecaptchaParameters } from '../../model/public_types';
-import { Recaptcha } from './recaptcha';
+import { Recaptcha, GreCAPTCHATopLevel, GreCAPTCHARenderOption, GreCAPTCHA } from './recaptcha';
 
 export const _SOLVE_TIME_MS = 500;
 export const _EXPIRATION_TIME_MS = 60_000;
@@ -66,6 +66,43 @@ export class MockReCaptcha implements Recaptcha {
     void this._widgets.get(id)?.execute();
     return '';
   }
+}
+
+export class MockGreCAPTCHATopLevel implements GreCAPTCHATopLevel {
+  enterprise: GreCAPTCHA = new MockGreCAPTCHA();
+  ready(callback: () => void): void {
+    callback();
+  }
+   
+  execute(
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    siteKey: string, options: { action: string }): Promise<string> {
+      return Promise.resolve('token');
+   }
+   render(
+     // eslint-disable-next-line @typescript-eslint/no-unused-vars
+     container: string | HTMLElement, parameters: GreCAPTCHARenderOption
+   ): string {
+    return '';
+   }
+}
+
+export class MockGreCAPTCHA implements GreCAPTCHA {
+  ready(callback: () => void): void {
+    callback();
+  }
+   
+  execute(
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    siteKey: string, options: { action: string }): Promise<string> {
+      return Promise.resolve('token');
+   }
+   render(
+     // eslint-disable-next-line @typescript-eslint/no-unused-vars
+     container: string | HTMLElement, parameters: GreCAPTCHARenderOption
+   ): string {
+    return '';
+   }
 }
 
 export class MockWidget {


### PR DESCRIPTION
This PR implements the new recaptcha enterprise verifier.
Not that it resolves the conflicts with existing recaptcha v2 and recaptcha v3 & enterprise from App check.

### Development progress
Base apis and types update
- https://github.com/firebase/firebase-js-sdk/pull/5942
- https://github.com/firebase/firebase-js-sdk/pull/5943
- New backend error types

Core logic
- Implement getRecaptchaConfig API
- This PR - https://github.com/firebase/firebase-js-sdk/pull/5964
- Wire recaptcha enterprise verifier to email auth flows