### PR TITLE
Fix documentation

### DIFF
--- a/packages/auth/src/model/public_types.ts
+++ b/packages/auth/src/model/public_types.ts
@@ -630,7 +630,7 @@ export interface MultiFactorInfo {
 
 /**
  * The subclass of the {@link MultiFactorInfo} interface for phone number
- * second factors. The factorId of this second factor is {@link FactorId.PHONE}.
+ * second factors. The `factorId` of this second factor is `{@link FactorId}.PHONE`.
  * @public
  */
 export interface PhoneMultiFactorInfo extends MultiFactorInfo {
@@ -863,7 +863,7 @@ export interface PhoneMultiFactorEnrollInfoOptions {
   session: MultiFactorSession;
 }
 /**
- * Options used for signing-in with a second factor.
+ * Options used for signing in with a second factor.
  *
  * @public
  */

--- a/packages/auth/src/model/public_types.ts
+++ b/packages/auth/src/model/public_types.ts
@@ -630,7 +630,7 @@ export interface MultiFactorInfo {
 
 /**
  * The subclass of the {@link MultiFactorInfo} interface for phone number
- * second factors. The `factorId` of this second factor is `{@link FactorId}.PHONE`.
+ * second factors. The `factorId` of this second factor is {@link FactorId}.PHONE.
  * @public
  */
 export interface PhoneMultiFactorInfo extends MultiFactorInfo {

--- a/packages/auth/src/platform_react_native/persistence/react_native.ts
+++ b/packages/auth/src/platform_react_native/persistence/react_native.ts
@@ -26,7 +26,7 @@ import {
 } from '../../core/persistence';
 
 /**
- * Returns a persistence object that wraps AsyncStorage imported from
+ * Returns a persistence object that wraps `AsyncStorage` imported from
  * `react-native` or `@react-native-community/async-storage`, and can
  * be used in the persistence dependency field in {@link initializeAuth}.
  * 


### PR DESCRIPTION
Errors caught in review when generating new docs pages. See internal cl/425742150

api-documenter doesn't allow referencing members of an enum, causing there to just be a blank space in the documentation text where `{@link FactorId.PHONE}` should be, so I moved the `.PHONE` out of the link.