### PR TITLE
Installations heartbeat implementation

### DIFF
--- a/.changeset/proud-otters-tap.md
+++ b/.changeset/proud-otters-tap.md
@@ -1,0 +1,5 @@
+---
+'@firebase/installations': patch
+---
+
+Update platform logging code to send to new endpoint.

--- a/packages/installations/src/api/get-id.test.ts
+++ b/packages/installations/src/api/get-id.test.ts
@@ -26,17 +26,14 @@ import {
 import { getFakeInstallations } from '../testing/fake-generators';
 import '../testing/setup';
 import { getId } from './get-id';
-import {
-  FirebaseInstallationsImpl,
-  AppConfig
-} from '../interfaces/installation-impl';
+import { FirebaseInstallationsImpl } from '../interfaces/installation-impl';
 
 const FID = 'disciples-of-the-watch';
 
 describe('getId', () => {
   let installations: FirebaseInstallationsImpl;
   let getInstallationEntrySpy: SinonStub<
-    [AppConfig],
+    [FirebaseInstallationsImpl],
     Promise<getInstallationEntryModule.InstallationEntryWithRegistrationPromise>
   >;
 

--- a/packages/installations/src/api/get-id.ts
+++ b/packages/installations/src/api/get-id.ts
@@ -30,7 +30,7 @@ import { Installations } from '../interfaces/public-types';
 export async function getId(installations: Installations): Promise<string> {
   const installationsImpl = installations as FirebaseInstallationsImpl;
   const { installationEntry, registrationPromise } = await getInstallationEntry(
-    installationsImpl.appConfig
+    installationsImpl
   );
 
   if (registrationPromise) {

--- a/packages/installations/src/api/get-token.test.ts
+++ b/packages/installations/src/api/get-token.test.ts
@@ -175,7 +175,7 @@ const setupInstallationEntryMap: Map<
 describe('getToken', () => {
   let installations: FirebaseInstallationsImpl;
   let createInstallationRequestSpy: SinonStub<
-    [AppConfig, InProgressInstallationEntry],
+    [FirebaseInstallationsImpl, InProgressInstallationEntry],
     Promise<RegisteredInstallationEntry>
   >;
   let generateAuthTokenRequestSpy: SinonStub<

--- a/packages/installations/src/api/get-token.ts
+++ b/packages/installations/src/api/get-token.ts
@@ -18,8 +18,7 @@
 import { getInstallationEntry } from '../helpers/get-installation-entry';
 import { refreshAuthToken } from '../helpers/refresh-auth-token';
 import {
-  FirebaseInstallationsImpl,
-  AppConfig
+  FirebaseInstallationsImpl
 } from '../interfaces/installation-impl';
 import { Installations } from '../interfaces/public-types';
 
@@ -36,7 +35,7 @@ export async function getToken(
   forceRefresh = false
 ): Promise<string> {
   const installationsImpl = installations as FirebaseInstallationsImpl;
-  await completeInstallationRegistration(installationsImpl.appConfig);
+  await completeInstallationRegistration(installationsImpl);
 
   // At this point we either have a Registered Installation in the DB, or we've
   // already thrown an error.
@@ -45,9 +44,9 @@ export async function getToken(
 }
 
 async function completeInstallationRegistration(
-  appConfig: AppConfig
+  installations: FirebaseInstallationsImpl
 ): Promise<void> {
-  const { registrationPromise } = await getInstallationEntry(appConfig);
+  const { registrationPromise } = await getInstallationEntry(installations);
 
   if (registrationPromise) {
     // A createInstallation request is in progress. Wait until it finishes.

--- a/packages/installations/src/api/get-token.ts
+++ b/packages/installations/src/api/get-token.ts
@@ -17,9 +17,7 @@
 
 import { getInstallationEntry } from '../helpers/get-installation-entry';
 import { refreshAuthToken } from '../helpers/refresh-auth-token';
-import {
-  FirebaseInstallationsImpl
-} from '../interfaces/installation-impl';
+import { FirebaseInstallationsImpl } from '../interfaces/installation-impl';
 import { Installations } from '../interfaces/public-types';
 
 /**

--- a/packages/installations/src/api/on-id-change.ts
+++ b/packages/installations/src/api/on-id-change.ts
@@ -26,7 +26,7 @@ import { Installations } from '../interfaces/public-types';
  */
 export type IdChangeCallbackFn = (installationId: string) => void;
 /**
- * Unsubscribe a callback function previously added via {@link #IdChangeCallbackFn}.
+ * Unsubscribe a callback function previously added via {@link IdChangeCallbackFn}.
  *
  * @public
  */

--- a/packages/installations/src/functions/config.ts
+++ b/packages/installations/src/functions/config.ts
@@ -36,12 +36,12 @@ const publicFactory: InstanceFactory<'installations'> = (
   const app = container.getProvider('app').getImmediate();
   // Throws if app isn't configured properly.
   const appConfig = extractAppConfig(app);
-  const platformLoggerProvider = _getProvider(app, 'platform-logger');
+  const heartbeatServiceProvider = _getProvider(app, 'heartbeat');
 
   const installationsImpl: FirebaseInstallationsImpl = {
     app,
     appConfig,
-    platformLoggerProvider,
+    heartbeatServiceProvider,
     _delete: () => Promise.resolve()
   };
   return installationsImpl;

--- a/packages/installations/src/functions/create-installation-request.test.ts
+++ b/packages/installations/src/functions/create-installation-request.test.ts
@@ -19,9 +19,7 @@ import { FirebaseError } from '@firebase/util';
 import { expect } from 'chai';
 import { SinonStub, stub } from 'sinon';
 import { CreateInstallationResponse } from '../interfaces/api-response';
-import {
-  FirebaseInstallationsImpl
-} from '../interfaces/installation-impl';
+import { FirebaseInstallationsImpl } from '../interfaces/installation-impl';
 import {
   InProgressInstallationEntry,
   RequestStatus

--- a/packages/installations/src/functions/create-installation-request.test.ts
+++ b/packages/installations/src/functions/create-installation-request.test.ts
@@ -19,13 +19,15 @@ import { FirebaseError } from '@firebase/util';
 import { expect } from 'chai';
 import { SinonStub, stub } from 'sinon';
 import { CreateInstallationResponse } from '../interfaces/api-response';
-import { AppConfig } from '../interfaces/installation-impl';
+import {
+  FirebaseInstallationsImpl
+} from '../interfaces/installation-impl';
 import {
   InProgressInstallationEntry,
   RequestStatus
 } from '../interfaces/installation-entry';
 import { compareHeaders } from '../testing/compare-headers';
-import { getFakeAppConfig } from '../testing/fake-generators';
+import { getFakeInstallations } from '../testing/fake-generators';
 import '../testing/setup';
 import {
   INSTALLATIONS_API_URL,
@@ -38,13 +40,13 @@ import { createInstallationRequest } from './create-installation-request';
 const FID = 'defenders-of-the-faith';
 
 describe('createInstallationRequest', () => {
-  let appConfig: AppConfig;
+  let fakeInstallations: FirebaseInstallationsImpl;
   let fetchSpy: SinonStub<[RequestInfo, RequestInit?], Promise<Response>>;
   let inProgressInstallationEntry: InProgressInstallationEntry;
   let response: CreateInstallationResponse;
 
   beforeEach(() => {
-    appConfig = getFakeAppConfig();
+    fakeInstallations = getFakeInstallations();
 
     inProgressInstallationEntry = {
       fid: FID,
@@ -71,7 +73,7 @@ describe('createInstallationRequest', () => {
 
     it('registers a pending InstallationEntry', async () => {
       const registeredInstallationEntry = await createInstallationRequest(
-        appConfig,
+        fakeInstallations,
         inProgressInstallationEntry
       );
       expect(registeredInstallationEntry.registrationStatus).to.equal(
@@ -83,12 +85,13 @@ describe('createInstallationRequest', () => {
       const expectedHeaders = new Headers({
         'Content-Type': 'application/json',
         Accept: 'application/json',
-        'x-goog-api-key': 'apiKey'
+        'x-goog-api-key': 'apiKey',
+        'x-firebase-client': 'a/1.2.3 b/2.3.4'
       });
       const expectedBody = {
         fid: FID,
         authVersion: INTERNAL_AUTH_VERSION,
-        appId: appConfig.appId,
+        appId: fakeInstallations.appConfig.appId,
         sdkVersion: PACKAGE_VERSION
       };
       const expectedRequest: RequestInit = {
@@ -98,7 +101,10 @@ describe('createInstallationRequest', () => {
       };
       const expectedEndpoint = `${INSTALLATIONS_API_URL}/projects/projectId/installations`;
 
-      await createInstallationRequest(appConfig, inProgressInstallationEntry);
+      await createInstallationRequest(
+        fakeInstallations,
+        inProgressInstallationEntry
+      );
       expect(fetchSpy).to.be.calledOnceWith(expectedEndpoint, expectedRequest);
       const actualHeaders = fetchSpy.lastCall.lastArg.headers;
       compareHeaders(expectedHeaders, actualHeaders);
@@ -117,7 +123,7 @@ describe('createInstallationRequest', () => {
     fetchSpy.resolves(new Response(JSON.stringify(response)));
 
     const registeredInstallationEntry = await createInstallationRequest(
-      appConfig,
+      fakeInstallations,
       inProgressInstallationEntry
     );
     expect(registeredInstallationEntry.fid).to.equal(FID);
@@ -138,7 +144,10 @@ describe('createInstallationRequest', () => {
       );
 
       await expect(
-        createInstallationRequest(appConfig, inProgressInstallationEntry)
+        createInstallationRequest(
+          fakeInstallations,
+          inProgressInstallationEntry
+        )
       ).to.be.rejectedWith(FirebaseError);
     });
 
@@ -157,7 +166,10 @@ describe('createInstallationRequest', () => {
       fetchSpy.onCall(1).resolves(new Response(JSON.stringify(response)));
 
       await expect(
-        createInstallationRequest(appConfig, inProgressInstallationEntry)
+        createInstallationRequest(
+          fakeInstallations,
+          inProgressInstallationEntry
+        )
       ).to.be.fulfilled;
       expect(fetchSpy).to.be.calledTwice;
     });

--- a/packages/installations/src/functions/create-installation-request.ts
+++ b/packages/installations/src/functions/create-installation-request.ts
@@ -29,15 +29,25 @@ import {
   getInstallationsEndpoint,
   retryIfServerError
 } from './common';
-import { AppConfig } from '../interfaces/installation-impl';
+import { FirebaseInstallationsImpl } from '../interfaces/installation-impl';
 
 export async function createInstallationRequest(
-  appConfig: AppConfig,
+  { appConfig, heartbeatServiceProvider }: FirebaseInstallationsImpl,
   { fid }: InProgressInstallationEntry
 ): Promise<RegisteredInstallationEntry> {
   const endpoint = getInstallationsEndpoint(appConfig);
 
   const headers = getHeaders(appConfig);
+
+  // If heartbeat service exists, add the heartbeat string to the header.
+  const heartbeatService = heartbeatServiceProvider.getImmediate({
+    optional: true
+  });
+  if (heartbeatService) {
+    const heartbeatsHeader = await heartbeatService.getHeartbeatsHeader();
+    headers.append('x-firebase-client', heartbeatsHeader);
+  }
+
   const body = {
     fid,
     authVersion: INTERNAL_AUTH_VERSION,

--- a/packages/installations/src/functions/create-installation-request.ts
+++ b/packages/installations/src/functions/create-installation-request.ts
@@ -45,7 +45,9 @@ export async function createInstallationRequest(
   });
   if (heartbeatService) {
     const heartbeatsHeader = await heartbeatService.getHeartbeatsHeader();
-    headers.append('x-firebase-client', heartbeatsHeader);
+    if (heartbeatsHeader) {
+      headers.append('x-firebase-client', heartbeatsHeader);
+    }
   }
 
   const body = {

--- a/packages/installations/src/functions/generate-auth-token-request.test.ts
+++ b/packages/installations/src/functions/generate-auth-token-request.test.ts
@@ -91,7 +91,8 @@ describe('generateAuthTokenRequest', () => {
       });
       const expectedBody = {
         installation: {
-          sdkVersion: PACKAGE_VERSION
+          sdkVersion: PACKAGE_VERSION,
+          appId: installations.appConfig.appId
         }
       };
       const expectedRequest: RequestInit = {

--- a/packages/installations/src/functions/generate-auth-token-request.ts
+++ b/packages/installations/src/functions/generate-auth-token-request.ts
@@ -34,19 +34,20 @@ import {
 } from '../interfaces/installation-impl';
 
 export async function generateAuthTokenRequest(
-  { appConfig, platformLoggerProvider }: FirebaseInstallationsImpl,
+  { appConfig, heartbeatServiceProvider }: FirebaseInstallationsImpl,
   installationEntry: RegisteredInstallationEntry
 ): Promise<CompletedAuthToken> {
   const endpoint = getGenerateAuthTokenEndpoint(appConfig, installationEntry);
 
   const headers = getHeadersWithAuth(appConfig, installationEntry);
 
-  // If platform logger exists, add the platform info string to the header.
-  const platformLogger = platformLoggerProvider.getImmediate({
+  // If heartbeat service exists, add the heartbeat string to the header.
+  const heartbeatService = heartbeatServiceProvider.getImmediate({
     optional: true
   });
-  if (platformLogger) {
-    headers.append('x-firebase-client', platformLogger.getPlatformInfoString());
+  if (heartbeatService) {
+    const heartbeatsHeader = await heartbeatService.getHeartbeatsHeader();
+    headers.append('x-firebase-client', heartbeatsHeader);
   }
 
   const body = {

--- a/packages/installations/src/functions/generate-auth-token-request.ts
+++ b/packages/installations/src/functions/generate-auth-token-request.ts
@@ -52,7 +52,8 @@ export async function generateAuthTokenRequest(
 
   const body = {
     installation: {
-      sdkVersion: PACKAGE_VERSION
+      sdkVersion: PACKAGE_VERSION,
+      appId: appConfig.appId
     }
   };
 

--- a/packages/installations/src/functions/generate-auth-token-request.ts
+++ b/packages/installations/src/functions/generate-auth-token-request.ts
@@ -47,7 +47,9 @@ export async function generateAuthTokenRequest(
   });
   if (heartbeatService) {
     const heartbeatsHeader = await heartbeatService.getHeartbeatsHeader();
-    headers.append('x-firebase-client', heartbeatsHeader);
+    if (heartbeatsHeader) {
+      headers.append('x-firebase-client', heartbeatsHeader);
+    }
   }
 
   const body = {

--- a/packages/installations/src/helpers/get-installation-entry.test.ts
+++ b/packages/installations/src/helpers/get-installation-entry.test.ts
@@ -18,14 +18,14 @@
 import { AssertionError, expect } from 'chai';
 import { SinonFakeTimers, SinonStub, stub, useFakeTimers } from 'sinon';
 import * as createInstallationRequestModule from '../functions/create-installation-request';
-import { AppConfig } from '../interfaces/installation-impl';
+import { AppConfig, FirebaseInstallationsImpl } from '../interfaces/installation-impl';
 import {
   InProgressInstallationEntry,
   RegisteredInstallationEntry,
   RequestStatus,
   UnregisteredInstallationEntry
 } from '../interfaces/installation-entry';
-import { getFakeAppConfig } from '../testing/fake-generators';
+import { getFakeInstallations } from '../testing/fake-generators';
 import '../testing/setup';
 import { ERROR_FACTORY, ErrorCode } from '../util/errors';
 import { sleep } from '../util/sleep';
@@ -37,15 +37,17 @@ const FID = 'cry-of-the-black-birds';
 
 describe('getInstallationEntry', () => {
   let clock: SinonFakeTimers;
+  let fakeInstallations: FirebaseInstallationsImpl;
   let appConfig: AppConfig;
   let createInstallationRequestSpy: SinonStub<
-    [AppConfig, InProgressInstallationEntry],
+    [FirebaseInstallationsImpl, InProgressInstallationEntry],
     Promise<RegisteredInstallationEntry>
   >;
 
   beforeEach(() => {
     clock = useFakeTimers({ now: 1_000_000 });
-    appConfig = getFakeAppConfig();
+    fakeInstallations = getFakeInstallations();
+    appConfig = fakeInstallations.appConfig;
     createInstallationRequestSpy = stub(
       createInstallationRequestModule,
       'createInstallationRequest'
@@ -78,7 +80,7 @@ describe('getInstallationEntry', () => {
     const oldDbEntry = await get(appConfig);
     expect(oldDbEntry).to.be.undefined;
 
-    const { installationEntry } = await getInstallationEntry(appConfig);
+    const { installationEntry } = await getInstallationEntry(fakeInstallations);
 
     const newDbEntry = await get(appConfig);
     expect(newDbEntry).to.deep.equal(installationEntry);
@@ -90,7 +92,7 @@ describe('getInstallationEntry', () => {
     const oldDbEntry = await get(appConfig);
     expect(oldDbEntry).to.be.undefined;
 
-    const { installationEntry } = await getInstallationEntry(appConfig);
+    const { installationEntry } = await getInstallationEntry(fakeInstallations);
 
     const newDbEntry = await get(appConfig);
     expect(newDbEntry).to.deep.equal(installationEntry);
@@ -98,7 +100,7 @@ describe('getInstallationEntry', () => {
 
   it('saves the InstallationEntry in the database when registration completes', async () => {
     const { installationEntry, registrationPromise } =
-      await getInstallationEntry(appConfig);
+      await getInstallationEntry(fakeInstallations);
     expect(installationEntry.registrationStatus).to.equal(
       RequestStatus.IN_PROGRESS
     );
@@ -126,7 +128,7 @@ describe('getInstallationEntry', () => {
     });
 
     const { installationEntry, registrationPromise } =
-      await getInstallationEntry(appConfig);
+      await getInstallationEntry(fakeInstallations);
     expect(installationEntry.registrationStatus).to.equal(
       RequestStatus.IN_PROGRESS
     );
@@ -154,7 +156,7 @@ describe('getInstallationEntry', () => {
     });
 
     const { installationEntry, registrationPromise } =
-      await getInstallationEntry(appConfig);
+      await getInstallationEntry(fakeInstallations);
     expect(installationEntry.registrationStatus).to.equal(
       RequestStatus.IN_PROGRESS
     );
@@ -170,8 +172,8 @@ describe('getInstallationEntry', () => {
   });
 
   it('returns the same FID on subsequent calls', async () => {
-    const { installationEntry: entry1 } = await getInstallationEntry(appConfig);
-    const { installationEntry: entry2 } = await getInstallationEntry(appConfig);
+    const { installationEntry: entry1 } = await getInstallationEntry(fakeInstallations);
+    const { installationEntry: entry2 } = await getInstallationEntry(fakeInstallations);
     expect(entry1.fid).to.equal(entry2.fid);
   });
 
@@ -187,7 +189,7 @@ describe('getInstallationEntry', () => {
 
     it('returns a new pending InstallationEntry and triggers createInstallation', async () => {
       const { installationEntry, registrationPromise } =
-        await getInstallationEntry(appConfig);
+        await getInstallationEntry(fakeInstallations);
 
       if (installationEntry.registrationStatus !== RequestStatus.IN_PROGRESS) {
         throw new AssertionError('InstallationEntry is not IN_PROGRESS.');
@@ -208,7 +210,7 @@ describe('getInstallationEntry', () => {
     it('returns a new unregistered InstallationEntry if app is offline', async () => {
       stub(navigator, 'onLine').value(false);
 
-      const { installationEntry } = await getInstallationEntry(appConfig);
+      const { installationEntry } = await getInstallationEntry(fakeInstallations);
 
       expect(installationEntry).to.deep.equal({
         fid: FID,
@@ -219,18 +221,18 @@ describe('getInstallationEntry', () => {
     });
 
     it('does not trigger createInstallation REST call on subsequent calls', async () => {
-      await getInstallationEntry(appConfig);
-      await getInstallationEntry(appConfig);
+      await getInstallationEntry(fakeInstallations);
+      await getInstallationEntry(fakeInstallations);
 
       expect(createInstallationRequestSpy).to.be.calledOnce;
     });
 
     it('returns a registrationPromise on subsequent calls before initial promise resolves', async () => {
       const { registrationPromise: promise1 } = await getInstallationEntry(
-        appConfig
+        fakeInstallations
       );
       const { registrationPromise: promise2 } = await getInstallationEntry(
-        appConfig
+        fakeInstallations
       );
 
       expect(createInstallationRequestSpy).to.be.calledOnce;
@@ -240,7 +242,7 @@ describe('getInstallationEntry', () => {
 
     it('does not return a registrationPromise on subsequent calls after initial promise resolves', async () => {
       const { registrationPromise: promise1 } = await getInstallationEntry(
-        appConfig
+        fakeInstallations
       );
       expect(promise1).to.be.an.instanceOf(Promise);
 
@@ -248,7 +250,7 @@ describe('getInstallationEntry', () => {
       await expect(promise1).to.be.fulfilled;
 
       const { registrationPromise: promise2 } = await getInstallationEntry(
-        appConfig
+        fakeInstallations
       );
       expect(promise2).to.be.undefined;
 
@@ -266,7 +268,7 @@ describe('getInstallationEntry', () => {
       // FID generation fails.
       generateInstallationEntrySpy.returns(generateFidModule.INVALID_FID);
 
-      const getInstallationEntryPromise = getInstallationEntry(appConfig);
+      const getInstallationEntryPromise = getInstallationEntry(fakeInstallations);
 
       const { installationEntry, registrationPromise } =
         await getInstallationEntryPromise;
@@ -287,7 +289,7 @@ describe('getInstallationEntry', () => {
 
     it('returns a pending InstallationEntry and triggers createInstallation', async () => {
       const { installationEntry, registrationPromise } =
-        await getInstallationEntry(appConfig);
+        await getInstallationEntry(fakeInstallations);
 
       if (installationEntry.registrationStatus !== RequestStatus.IN_PROGRESS) {
         throw new AssertionError('InstallationEntry is not IN_PROGRESS.');
@@ -306,7 +308,7 @@ describe('getInstallationEntry', () => {
     it('returns the same InstallationEntry if the app is offline', async () => {
       stub(navigator, 'onLine').value(false);
 
-      const { installationEntry } = await getInstallationEntry(appConfig);
+      const { installationEntry } = await getInstallationEntry(fakeInstallations);
 
       expect(installationEntry).to.deep.equal({
         fid: FID,
@@ -329,7 +331,7 @@ describe('getInstallationEntry', () => {
     it("returns the same InstallationEntry if the request hasn't timed out", async () => {
       clock.now = 1_001_000; // One second after the request was initiated.
 
-      const { installationEntry } = await getInstallationEntry(appConfig);
+      const { installationEntry } = await getInstallationEntry(fakeInstallations);
 
       expect(installationEntry).to.deep.equal({
         fid: FID,
@@ -347,7 +349,7 @@ describe('getInstallationEntry', () => {
           true /* Needed to allow the createInstallation request to complete. */
       });
 
-      const installationEntryPromise = getInstallationEntry(appConfig);
+      const installationEntryPromise = getInstallationEntry(fakeInstallations);
 
       // The pending request fails after a while.
       clock.tick(3000);
@@ -389,7 +391,7 @@ describe('getInstallationEntry', () => {
           true /* Needed to allow the createInstallation request to complete. */
       });
 
-      const installationEntryPromise = getInstallationEntry(appConfig);
+      const installationEntryPromise = getInstallationEntry(fakeInstallations);
 
       // The pending request fails after a while.
       clock.tick(3000);
@@ -418,7 +420,7 @@ describe('getInstallationEntry', () => {
     it('returns a new pending InstallationEntry and triggers createInstallation if the request had already timed out', async () => {
       clock.now = 1_015_000; // Fifteen seconds after the request was initiated.
 
-      const { installationEntry } = await getInstallationEntry(appConfig);
+      const { installationEntry } = await getInstallationEntry(fakeInstallations);
 
       expect(installationEntry).to.deep.equal({
         fid: FID,
@@ -432,7 +434,7 @@ describe('getInstallationEntry', () => {
       stub(navigator, 'onLine').value(false);
       clock.now = 1_015_000; // Fifteen seconds after the request was initiated.
 
-      const { installationEntry } = await getInstallationEntry(appConfig);
+      const { installationEntry } = await getInstallationEntry(fakeInstallations);
 
       expect(installationEntry).to.deep.equal({
         fid: FID,
@@ -454,7 +456,7 @@ describe('getInstallationEntry', () => {
     });
 
     it('returns the InstallationEntry from the database', async () => {
-      const { installationEntry } = await getInstallationEntry(appConfig);
+      const { installationEntry } = await getInstallationEntry(fakeInstallations);
 
       expect(installationEntry).to.deep.equal({
         fid: FID,

--- a/packages/installations/src/helpers/get-installation-entry.test.ts
+++ b/packages/installations/src/helpers/get-installation-entry.test.ts
@@ -18,7 +18,10 @@
 import { AssertionError, expect } from 'chai';
 import { SinonFakeTimers, SinonStub, stub, useFakeTimers } from 'sinon';
 import * as createInstallationRequestModule from '../functions/create-installation-request';
-import { AppConfig, FirebaseInstallationsImpl } from '../interfaces/installation-impl';
+import {
+  AppConfig,
+  FirebaseInstallationsImpl
+} from '../interfaces/installation-impl';
 import {
   InProgressInstallationEntry,
   RegisteredInstallationEntry,
@@ -172,8 +175,12 @@ describe('getInstallationEntry', () => {
   });
 
   it('returns the same FID on subsequent calls', async () => {
-    const { installationEntry: entry1 } = await getInstallationEntry(fakeInstallations);
-    const { installationEntry: entry2 } = await getInstallationEntry(fakeInstallations);
+    const { installationEntry: entry1 } = await getInstallationEntry(
+      fakeInstallations
+    );
+    const { installationEntry: entry2 } = await getInstallationEntry(
+      fakeInstallations
+    );
     expect(entry1.fid).to.equal(entry2.fid);
   });
 
@@ -210,7 +217,9 @@ describe('getInstallationEntry', () => {
     it('returns a new unregistered InstallationEntry if app is offline', async () => {
       stub(navigator, 'onLine').value(false);
 
-      const { installationEntry } = await getInstallationEntry(fakeInstallations);
+      const { installationEntry } = await getInstallationEntry(
+        fakeInstallations
+      );
 
       expect(installationEntry).to.deep.equal({
         fid: FID,
@@ -268,7 +277,8 @@ describe('getInstallationEntry', () => {
       // FID generation fails.
       generateInstallationEntrySpy.returns(generateFidModule.INVALID_FID);
 
-      const getInstallationEntryPromise = getInstallationEntry(fakeInstallations);
+      const getInstallationEntryPromise =
+        getInstallationEntry(fakeInstallations);
 
       const { installationEntry, registrationPromise } =
         await getInstallationEntryPromise;
@@ -308,7 +318,9 @@ describe('getInstallationEntry', () => {
     it('returns the same InstallationEntry if the app is offline', async () => {
       stub(navigator, 'onLine').value(false);
 
-      const { installationEntry } = await getInstallationEntry(fakeInstallations);
+      const { installationEntry } = await getInstallationEntry(
+        fakeInstallations
+      );
 
       expect(installationEntry).to.deep.equal({
         fid: FID,
@@ -331,7 +343,9 @@ describe('getInstallationEntry', () => {
     it("returns the same InstallationEntry if the request hasn't timed out", async () => {
       clock.now = 1_001_000; // One second after the request was initiated.
 
-      const { installationEntry } = await getInstallationEntry(fakeInstallations);
+      const { installationEntry } = await getInstallationEntry(
+        fakeInstallations
+      );
 
       expect(installationEntry).to.deep.equal({
         fid: FID,
@@ -420,7 +434,9 @@ describe('getInstallationEntry', () => {
     it('returns a new pending InstallationEntry and triggers createInstallation if the request had already timed out', async () => {
       clock.now = 1_015_000; // Fifteen seconds after the request was initiated.
 
-      const { installationEntry } = await getInstallationEntry(fakeInstallations);
+      const { installationEntry } = await getInstallationEntry(
+        fakeInstallations
+      );
 
       expect(installationEntry).to.deep.equal({
         fid: FID,
@@ -434,7 +450,9 @@ describe('getInstallationEntry', () => {
       stub(navigator, 'onLine').value(false);
       clock.now = 1_015_000; // Fifteen seconds after the request was initiated.
 
-      const { installationEntry } = await getInstallationEntry(fakeInstallations);
+      const { installationEntry } = await getInstallationEntry(
+        fakeInstallations
+      );
 
       expect(installationEntry).to.deep.equal({
         fid: FID,
@@ -456,7 +474,9 @@ describe('getInstallationEntry', () => {
     });
 
     it('returns the InstallationEntry from the database', async () => {
-      const { installationEntry } = await getInstallationEntry(fakeInstallations);
+      const { installationEntry } = await getInstallationEntry(
+        fakeInstallations
+      );
 
       expect(installationEntry).to.deep.equal({
         fid: FID,

--- a/packages/installations/src/interfaces/installation-impl.ts
+++ b/packages/installations/src/interfaces/installation-impl.ts
@@ -23,7 +23,7 @@ export interface FirebaseInstallationsImpl
   extends Installations,
     _FirebaseService {
   readonly appConfig: AppConfig;
-  readonly platformLoggerProvider: Provider<'platform-logger'>;
+  readonly heartbeatServiceProvider: Provider<'heartbeat'>;
 }
 
 export interface AppConfig {

--- a/packages/installations/src/testing/fake-generators.ts
+++ b/packages/installations/src/testing/fake-generators.ts
@@ -53,8 +53,11 @@ export function getFakeInstallations(): FirebaseInstallationsImpl {
   const container = new ComponentContainer('test');
   container.addComponent(
     new Component(
-      'platform-logger',
-      () => ({ getPlatformInfoString: () => 'a/1.2.3 b/2.3.4' }),
+      'heartbeat',
+      () => ({
+        getHeartbeatsHeader: () => Promise.resolve('a/1.2.3 b/2.3.4'),
+        triggerHeartbeat: () => Promise.resolve()
+      }),
       ComponentType.PRIVATE
     )
   );
@@ -62,7 +65,7 @@ export function getFakeInstallations(): FirebaseInstallationsImpl {
   return {
     app: getFakeApp(),
     appConfig: getFakeAppConfig(),
-    platformLoggerProvider: container.getProvider('platform-logger'),
+    heartbeatServiceProvider: container.getProvider('heartbeat'),
     _delete: () => {
       return Promise.resolve();
     }


### PR DESCRIPTION
Replace sending v1 platform logging header with sending new heartbeats header.

Additionally:
- Sending the header to the "createInstallation" endpoint, which happens when an installations ID is registered. Previously it was only being sent to the "authTokens:generate" endpoint, which only happens on the auth token refresh, starting 7 days after registration.
- Adding app ID param to the body sent to the authTokens:generate endpoint.