### PR TITLE
Update console.build.js to set a value on window

### DIFF
--- a/packages/firestore-compat/tools/console.build.js
+++ b/packages/firestore-compat/tools/console.build.js
@@ -57,11 +57,7 @@ const es5OutputOptions = {
   format: 'iife'
 };
 
-const PREFIX = `
-goog.module('firestore');
-exports = eval(`;
-
-const POSTFIX = ` + '${EXPORTNAME};');`;
+const POSTFIX = `window['${EXPORTNAME}']=${EXPORTNAME};`;
 
 async function build() {
   const es5Bundle = await rollup.rollup(es5InputOptions);
@@ -69,7 +65,7 @@ async function build() {
     output: [{ code }]
   } = await es5Bundle.generate(es5OutputOptions);
 
-  const output = `${PREFIX}${JSON.stringify(String(code))}${POSTFIX}`;
+  const output = `${String(code)}${POSTFIX}`;
 
   if (!fs.existsSync(OUTPUT_FOLDER)) {
     fs.mkdirSync(OUTPUT_FOLDER);


### PR DESCRIPTION
This change updates the console.build.js script that is used internally at Google to build the Firestore SDK.
Use of `eval` is removed and instead the code is exported using the global `window`.