### PR TITLE
Use RemoteDocumentCache.getAll()

### DIFF
--- a/packages/firestore/src/local/indexeddb_remote_document_cache.ts
+++ b/packages/firestore/src/local/indexeddb_remote_document_cache.ts
@@ -15,7 +15,6 @@
  * limitations under the License.
  */
 
-import { isCollectionGroupQuery, Query, queryMatches } from '../core/query';
 import { SnapshotVersion } from '../core/snapshot_version';
 import {
   DocumentKeySet,
@@ -246,30 +245,26 @@ class IndexedDbRemoteDocumentCacheImpl implements IndexedDbRemoteDocumentCache {
       });
   }
 
-  getDocumentsMatchingQuery(
+  getAll(
     transaction: PersistenceTransaction,
-    query: Query,
+    collection: ResourcePath,
     sinceReadTime: SnapshotVersion
   ): PersistencePromise<MutableDocumentMap> {
-    debugAssert(
-      !isCollectionGroupQuery(query),
-      'CollectionGroup queries should be handled in LocalDocumentsView'
-    );
     let results = mutableDocumentMap();
 
-    const immediateChildrenPathLength = query.path.length + 1;
+    const immediateChildrenPathLength = collection.length + 1;
 
     const iterationOptions: IterateOptions = {};
     if (sinceReadTime.isEqual(SnapshotVersion.min())) {
       // Documents are ordered by key, so we can use a prefix scan to narrow
       // down the documents we need to match the query against.
-      const startKey = query.path.toArray();
+      const startKey = collection.toArray();
       iterationOptions.range = IDBKeyRange.lowerBound(startKey);
     } else {
       // Execute an index-free query and filter by read time. This is safe
       // since all document changes to queries that have a
       // lastLimboFreeSnapshotVersion (`sinceReadTime`) have a read time set.
-      const collectionKey = query.path.toArray();
+      const collectionKey = collection.toArray();
       const readTimeKey = toDbTimestampKey(sinceReadTime);
       iterationOptions.range = IDBKeyRange.lowerBound(
         [collectionKey, readTimeKey],
@@ -293,10 +288,10 @@ class IndexedDbRemoteDocumentCacheImpl implements IndexedDbRemoteDocumentCache {
           DocumentKey.fromSegments(key),
           dbRemoteDoc
         );
-        if (!query.path.isPrefixOf(document.key.path)) {
-          control.done();
-        } else if (queryMatches(query, document)) {
+        if (collection.isPrefixOf(document.key.path)) {
           results = results.insert(document.key, document);
+        } else {
+          control.done();
         }
       })
       .next(() => results);

--- a/packages/firestore/src/local/memory_remote_document_cache.ts
+++ b/packages/firestore/src/local/memory_remote_document_cache.ts
@@ -15,7 +15,6 @@
  * limitations under the License.
  */
 
-import { isCollectionGroupQuery, Query, queryMatches } from '../core/query';
 import { SnapshotVersion } from '../core/snapshot_version';
 import {
   DocumentKeySet,
@@ -24,6 +23,7 @@ import {
 } from '../model/collections';
 import { Document, MutableDocument } from '../model/document';
 import { DocumentKey } from '../model/document_key';
+import { ResourcePath } from '../model/path';
 import { debugAssert } from '../util/assert';
 import { SortedMap } from '../util/sorted_map';
 
@@ -152,33 +152,30 @@ class MemoryRemoteDocumentCacheImpl implements MemoryRemoteDocumentCache {
     return PersistencePromise.resolve(results);
   }
 
-  getDocumentsMatchingQuery(
+  getAll(
     transaction: PersistenceTransaction,
-    query: Query,
+    collectionPath: ResourcePath,
     sinceReadTime: SnapshotVersion
   ): PersistencePromise<MutableDocumentMap> {
-    debugAssert(
-      !isCollectionGroupQuery(query),
-      'CollectionGroup queries should be handled in LocalDocumentsView'
-    );
     let results = mutableDocumentMap();
 
     // Documents are ordered by key, so we can use a prefix scan to narrow down
     // the documents we need to match the query against.
-    const prefix = new DocumentKey(query.path.child(''));
+    const prefix = new DocumentKey(collectionPath.child(''));
     const iterator = this.docs.getIteratorFrom(prefix);
     while (iterator.hasNext()) {
       const {
         key,
         value: { document }
       } = iterator.getNext();
-      if (!query.path.isPrefixOf(key.path)) {
+      if (!collectionPath.isPrefixOf(key.path)) {
         break;
       }
-      if (document.readTime.compareTo(sinceReadTime) <= 0) {
+      if (key.path.length > collectionPath.length + 1) {
+        // Exclude entries from subcollections.
         continue;
       }
-      if (!queryMatches(query, document)) {
+      if (document.readTime.compareTo(sinceReadTime) <= 0) {
         continue;
       }
       results = results.insert(document.key, document.mutableCopy());

--- a/packages/firestore/src/local/remote_document_cache.ts
+++ b/packages/firestore/src/local/remote_document_cache.ts
@@ -15,11 +15,11 @@
  * limitations under the License.
  */
 
-import { Query } from '../core/query';
 import { SnapshotVersion } from '../core/snapshot_version';
 import { DocumentKeySet, MutableDocumentMap } from '../model/collections';
 import { MutableDocument } from '../model/document';
 import { DocumentKey } from '../model/document_key';
+import { ResourcePath } from '../model/path';
 
 import { PersistencePromise } from './persistence_promise';
 import { PersistenceTransaction } from './persistence_transaction';
@@ -58,21 +58,16 @@ export interface RemoteDocumentCache {
   ): PersistencePromise<MutableDocumentMap>;
 
   /**
-   * Executes a query against the cached Document entries.
+   * Returns the documents from the provided collection.
    *
-   * Implementations may return extra documents if convenient. The results
-   * should be re-filtered by the consumer before presenting them to the user.
-   *
-   * Cached NoDocument entries have no bearing on query results.
-   *
-   * @param query - The query to match documents against.
+   * @param collection - The collection to read.
    * @param sinceReadTime - If not set to SnapshotVersion.min(), return only
    *     documents that have been read since this snapshot version (exclusive).
    * @returns The set of matching documents.
    */
-  getDocumentsMatchingQuery(
+  getAll(
     transaction: PersistenceTransaction,
-    query: Query,
+    collection: ResourcePath,
     sinceReadTime: SnapshotVersion
   ): PersistencePromise<MutableDocumentMap>;
 

--- a/packages/firestore/test/unit/local/counting_query_engine.ts
+++ b/packages/firestore/test/unit/local/counting_query_engine.ts
@@ -35,7 +35,7 @@ export class CountingQueryEngine extends QueryEngine {
    * `getAllMutationBatchesAffectingQuery()` API (since the last call to
    * `resetCounts()`)
    */
-  mutationsReadByQuery = 0;
+  mutationsReadByCollection = 0;
 
   /**
    * The number of mutations returned by the MutationQueue's
@@ -47,9 +47,9 @@ export class CountingQueryEngine extends QueryEngine {
 
   /**
    * The number of documents returned by the RemoteDocumentCache's
-   * `getDocumentsMatchingQuery()` API (since the last call to `resetCounts()`)
+   * `getAll()` API (since the last call to `resetCounts()`)
    */
-  documentsReadByQuery = 0;
+  documentsReadByCollection = 0;
 
   /**
    * The number of documents returned by the RemoteDocumentCache's `getEntry()`
@@ -58,9 +58,9 @@ export class CountingQueryEngine extends QueryEngine {
   documentsReadByKey = 0;
 
   resetCounts(): void {
-    this.mutationsReadByQuery = 0;
+    this.mutationsReadByCollection = 0;
     this.mutationsReadByKey = 0;
-    this.documentsReadByQuery = 0;
+    this.documentsReadByCollection = 0;
     this.documentsReadByKey = 0;
   }
 
@@ -92,11 +92,11 @@ export class CountingQueryEngine extends QueryEngine {
     subject: RemoteDocumentCache
   ): RemoteDocumentCache {
     return {
-      getDocumentsMatchingQuery: (transaction, query, sinceReadTime) => {
+      getAll: (transaction, collectionGroup, sinceReadTime) => {
         return subject
-          .getDocumentsMatchingQuery(transaction, query, sinceReadTime)
+          .getAll(transaction, collectionGroup, sinceReadTime)
           .next(result => {
-            this.documentsReadByQuery += result.size;
+            this.documentsReadByCollection += result.size;
             return result;
           });
       },
@@ -150,7 +150,7 @@ export class CountingQueryEngine extends QueryEngine {
         return subject
           .getAllMutationBatchesAffectingQuery(transaction, query)
           .next(result => {
-            this.mutationsReadByQuery += result.length;
+            this.mutationsReadByCollection += result.length;
             return result;
           });
       },

--- a/packages/firestore/test/unit/local/local_store.test.ts
+++ b/packages/firestore/test/unit/local/local_store.test.ts
@@ -330,25 +330,25 @@ class LocalStoreTester {
    * the MutationQueue and the RemoteDocumentCache.
    *
    * @param expectedCount.mutationsByQuery - The number of mutations read by
-   * executing a query against the MutationQueue.
+   * executing a collection scan against the MutationQueue.
    * @param expectedCount.mutationsByKey - The number of mutations read by
    * document key lookups.
    * @param expectedCount.documentsByQuery - The number of mutations read by
-   * executing a query against the RemoteDocumentCache.
+   * executing a collection scan against the RemoteDocumentCache.
    * @param expectedCount.documentsByKey - The number of documents read by
    * document key lookups.
    */
   toHaveRead(expectedCount: {
-    mutationsByQuery?: number;
+    mutationsByCollection?: number;
     mutationsByKey?: number;
-    documentsByQuery?: number;
+    documentsByCollection?: number;
     documentsByKey?: number;
   }): LocalStoreTester {
     this.promiseChain = this.promiseChain.then(() => {
-      if (expectedCount.mutationsByQuery !== undefined) {
-        expect(this.queryEngine.mutationsReadByQuery).to.be.eq(
-          expectedCount.mutationsByQuery,
-          'Mutations read (by query)'
+      if (expectedCount.mutationsByCollection !== undefined) {
+        expect(this.queryEngine.mutationsReadByCollection).to.be.eq(
+          expectedCount.mutationsByCollection,
+          'Mutations read (by collection)'
         );
       }
       if (expectedCount.mutationsByKey !== undefined) {
@@ -357,10 +357,10 @@ class LocalStoreTester {
           'Mutations read (by key)'
         );
       }
-      if (expectedCount.documentsByQuery !== undefined) {
-        expect(this.queryEngine.documentsReadByQuery).to.be.eq(
-          expectedCount.documentsByQuery,
-          'Remote documents read (by query)'
+      if (expectedCount.documentsByCollection !== undefined) {
+        expect(this.queryEngine.documentsReadByCollection).to.be.eq(
+          expectedCount.documentsByCollection,
+          'Remote documents read (by collection)'
         );
       }
       if (expectedCount.documentsByKey !== undefined) {
@@ -1209,7 +1209,7 @@ function genericLocalStoreTests(
         doc('foo/baz', 20, { matches: true }),
         doc('foo/bonk', 0, { matches: true }).setHasLocalMutations()
       )
-      .toHaveRead({ documentsByQuery: 2, mutationsByQuery: 1 })
+      .toHaveRead({ documentsByCollection: 2, mutationsByCollection: 1 })
       .finish();
   });
 
@@ -1806,7 +1806,7 @@ function genericLocalStoreTests(
         // Execute the query, but note that we read all existing documents
         // from the RemoteDocumentCache since we do not yet have target
         // mapping.
-        .toHaveRead({ documentsByQuery: 2 })
+        .toHaveRead({ documentsByCollection: 3 })
         .after(
           docAddedRemoteEvent(
             [
@@ -1826,7 +1826,7 @@ function genericLocalStoreTests(
         )
         .after(localViewChanges(2, /* fromCache= */ false, {}))
         .afterExecutingQuery(query1)
-        .toHaveRead({ documentsByKey: 2, documentsByQuery: 0 })
+        .toHaveRead({ documentsByKey: 2, documentsByCollection: 0 })
         .toReturnChanged(
           doc('foo/a', 10, { matches: true }),
           doc('foo/b', 10, { matches: true })
@@ -1935,7 +1935,7 @@ function genericLocalStoreTests(
           // Re-run the query as a collection scan
           .afterExecutingQuery(query1)
           .toReturnChanged(doc('foo/a', 10, { matches: true }))
-          .toHaveRead({ documentsByQuery: 1 })
+          .toHaveRead({ documentsByCollection: 1 })
           .finish()
       );
     }

--- a/packages/firestore/test/unit/local/test_remote_document_cache.ts
+++ b/packages/firestore/test/unit/local/test_remote_document_cache.ts
@@ -15,7 +15,6 @@
  * limitations under the License.
  */
 
-import { Query } from '../../../src/core/query';
 import { SnapshotVersion } from '../../../src/core/snapshot_version';
 import { remoteDocumentCacheGetNewDocumentChanges } from '../../../src/local/indexeddb_remote_document_cache';
 import { Persistence } from '../../../src/local/persistence';
@@ -28,6 +27,7 @@ import {
 } from '../../../src/model/collections';
 import { Document, MutableDocument } from '../../../src/model/document';
 import { DocumentKey } from '../../../src/model/document_key';
+import { ResourcePath } from '../../../src/model/path';
 
 /**
  * A wrapper around a RemoteDocumentCache that automatically creates a
@@ -104,16 +104,14 @@ export class TestRemoteDocumentCache {
     });
   }
 
-  getDocumentsMatchingQuery(
-    query: Query,
+  getAll(
+    collection: ResourcePath,
     sinceReadTime: SnapshotVersion
   ): Promise<MutableDocumentMap> {
     return this.persistence.runTransaction(
       'getDocumentsMatchingQuery',
       'readonly',
-      txn => {
-        return this.cache.getDocumentsMatchingQuery(txn, query, sinceReadTime);
-      }
+      txn => this.cache.getAll(txn, collection, sinceReadTime)
     );
   }
 


### PR DESCRIPTION
Port of https://github.com/firebase/firebase-android-sdk/pull/3201, which also includes the rationale behind this change.