### PR TITLE
Group firestore-compat and auth-compat properly in test config

### DIFF
--- a/.github/workflows/test-changed.yml
+++ b/.github/workflows/test-changed.yml
@@ -1,9 +1,6 @@
 name: Test Modified Packages
 
 on: pull_request
-env:
-  # make chromedriver detect installed Chrome version and download the corresponding driver
-  DETECT_CHROMEDRIVER_VERSION: true
 
 jobs:
   test:

--- a/.github/workflows/test-changed.yml
+++ b/.github/workflows/test-changed.yml
@@ -1,6 +1,9 @@
 name: Test Modified Packages
 
 on: pull_request
+env:
+  # make chromedriver detect installed Chrome version and download the corresponding driver
+  DETECT_CHROMEDRIVER_VERSION: true
 
 jobs:
   test:

--- a/scripts/ci-test/testConfig.ts
+++ b/scripts/ci-test/testConfig.ts
@@ -34,12 +34,14 @@ export const testConfig: {
   'core': {
     'ignorePackages': [
       '@firebase/firestore',
+      '@firebase/firestore-compat',
       'firebase-firestore-integration-test',
       'firebase-messaging-integration-test',
       'firebase-namespace-integration-test',
       'firebase-compat-typings-test',
       '@firebase/rules-unit-testing',
       '@firebase/auth',
+      '@firebase/auth-compat',
       'firebase'
     ]
   },
@@ -59,6 +61,6 @@ export const testConfig: {
     'alwaysIncludePackages': ['firebase-namespace-integration-test']
   },
   'auth': {
-    'onlyIncludePackages': ['@firebase/auth']
+    'onlyIncludePackages': ['@firebase/auth', '@firebase/auth-compat']
   }
 };


### PR DESCRIPTION
firestore-compat belongs with firestore, auth-compat belongs with auth in the separated test configs for the "test-changed" script. Made sure to exclude them from the "core" config as well.