### PR TITLE
Implement Index Scanning

### DIFF
--- a/packages/firestore/src/core/target.ts
+++ b/packages/firestore/src/core/target.ts
@@ -333,9 +333,8 @@ export function targetGetLowerBound(
           filterValue = MIN_VALUE;
           break;
         case Operator.NOT_IN:
-          const length = (fieldFilter.value.arrayValue!.values || []).length;
           filterValue = {
-            arrayValue: { values: new Array(length).fill(MIN_VALUE) }
+            arrayValue: { values: [MIN_VALUE] }
           };
           break;
         default:
@@ -418,9 +417,8 @@ export function targetGetUpperBound(
           filterValue = MAX_VALUE;
           break;
         case Operator.NOT_IN:
-          const length = (fieldFilter.value.arrayValue!.values || []).length;
           filterValue = {
-            arrayValue: { values: new Array(length).fill(MIN_VALUE) }
+            arrayValue: { values: [MAX_VALUE] }
           };
           break;
         default:

--- a/packages/firestore/src/core/target.ts
+++ b/packages/firestore/src/core/target.ts
@@ -440,7 +440,7 @@ export function targetGetUpperBound(
     }
 
     if (segmentValue === undefined) {
-      // No lower bound exists
+      // No upper bound exists
       return null;
     }
     values.push(segmentValue);

--- a/packages/firestore/src/core/target.ts
+++ b/packages/firestore/src/core/target.ts
@@ -259,7 +259,7 @@ export function targetGetNotInValues(
   target: Target,
   fieldIndex: FieldIndex
 ): ProtoValue[] | null {
-  const values: ProtoValue[] = [];
+  const values = new Map</* fieldPath = */ string, ProtoValue>();
 
   for (const segment of fieldIndexGetDirectionalSegments(fieldIndex)) {
     for (const fieldFilter of targetGetFieldFiltersForPath(
@@ -272,14 +272,14 @@ export function targetGetNotInValues(
           // Encode equality prefix, which is encoded in the index value before
           // the inequality (e.g. `a == 'a' && b != 'b'` is encoded to
           // `value != 'ab'`).
-          values.push(fieldFilter.value);
+          values.set(segment.fieldPath.canonicalString(), fieldFilter.value);
           break;
         case Operator.NOT_IN:
         case Operator.NOT_EQUAL:
           // NotIn/NotEqual is always a suffix. There cannot be any remaining
           // segments and hence we can return early here.
-          values.push(fieldFilter.value);
-          return values;
+          values.set(segment.fieldPath.canonicalString(), fieldFilter.value);
+          return Array.from(values.values());
         default:
         // Remaining filters cannot be used as notIn bounds.
       }
@@ -330,12 +330,8 @@ export function targetGetLowerBound(
           filterInclusive = false;
           break;
         case Operator.NOT_EQUAL:
-          filterValue = MIN_VALUE;
-          break;
         case Operator.NOT_IN:
-          filterValue = {
-            arrayValue: { values: [MIN_VALUE] }
-          };
+          filterValue = MIN_VALUE;
           break;
         default:
         // Remaining filters cannot be used as lower bounds.
@@ -414,12 +410,8 @@ export function targetGetUpperBound(
           filterInclusive = false;
           break;
         case Operator.NOT_EQUAL:
-          filterValue = MAX_VALUE;
-          break;
         case Operator.NOT_IN:
-          filterValue = {
-            arrayValue: { values: [MAX_VALUE] }
-          };
+          filterValue = MAX_VALUE;
           break;
         default:
         // Remaining filters cannot be used as upper bounds.

--- a/packages/firestore/src/index/index_entry.ts
+++ b/packages/firestore/src/index/index_entry.ts
@@ -25,6 +25,33 @@ export class IndexEntry {
     readonly arrayValue: Uint8Array,
     readonly directionalValue: Uint8Array
   ) {}
+
+  /**
+   * Returns an IndexEntry entry that sorts immediately after the current
+   * directional value.
+   */
+  successor(): IndexEntry {
+    const currentLength = this.directionalValue.length;
+    const newLength =
+      currentLength === 0 || this.directionalValue[currentLength - 1] === 255
+        ? currentLength + 1
+        : currentLength;
+
+    const successor = new Uint8Array(newLength);
+    successor.set(this.directionalValue, 0);
+    if (newLength !== currentLength) {
+      successor.set([0], this.directionalValue.length);
+    } else {
+      ++successor[successor.length - 1];
+    }
+
+    return new IndexEntry(
+      this.indexId,
+      this.documentKey,
+      this.arrayValue,
+      successor
+    );
+  }
 }
 
 export function indexEntryComparator(
@@ -36,17 +63,17 @@ export function indexEntryComparator(
     return cmp;
   }
 
-  cmp = DocumentKey.comparator(left.documentKey, right.documentKey);
-  if (cmp !== 0) {
-    return cmp;
-  }
-
   cmp = compareByteArrays(left.arrayValue, right.arrayValue);
   if (cmp !== 0) {
     return cmp;
   }
 
-  return compareByteArrays(left.directionalValue, right.directionalValue);
+  cmp = compareByteArrays(left.directionalValue, right.directionalValue);
+  if (cmp !== 0) {
+    return cmp;
+  }
+
+  return DocumentKey.comparator(left.documentKey, right.documentKey);
 }
 
 export function compareByteArrays(left: Uint8Array, right: Uint8Array): number {

--- a/packages/firestore/src/index/index_entry.ts
+++ b/packages/firestore/src/index/index_entry.ts
@@ -49,7 +49,7 @@ export function indexEntryComparator(
   return compareByteArrays(left.directionalValue, right.directionalValue);
 }
 
-function compareByteArrays(left: Uint8Array, right: Uint8Array): number {
+export function compareByteArrays(left: Uint8Array, right: Uint8Array): number {
   for (let i = 0; i < left.length && i < right.length; ++i) {
     const compare = left[i] - right[i];
     if (compare !== 0) {

--- a/packages/firestore/src/local/index_manager.ts
+++ b/packages/firestore/src/local/index_manager.ts
@@ -103,13 +103,12 @@ export interface IndexManager {
 
   /**
    * Returns the documents that match the given target based on the provided
-   * index.
+   * index or `null` if the target does not have a matching index.
    */
   getDocumentsMatchingTarget(
     transaction: PersistenceTransaction,
-    fieldIndex: FieldIndex,
     target: Target
-  ): PersistencePromise<DocumentKeySet>;
+  ): PersistencePromise<DocumentKeySet | null>;
 
   /**
    * Returns the next collection group to update. Returns `null` if no group

--- a/packages/firestore/src/local/indexeddb_index_manager.ts
+++ b/packages/firestore/src/local/indexeddb_index_manager.ts
@@ -860,29 +860,26 @@ export class IndexedDbIndexManager implements IndexManager {
       const lowerBound = new Uint8Array(indexRange.lower[3]);
       const upperBound = new Uint8Array(indexRange.upper[3]);
 
-      let lastLower = lowerBound;
-      let lowerOpen = indexRange.lowerOpen;
+      let lastBound = lowerBound;
+      let lastOpen = indexRange.lowerOpen;
 
-      const barriers = [...notInValues, upperBound];
-      for (const barrier of barriers) {
+      const bounds = [...notInValues, upperBound];
+      for (const currentBound of bounds) {
         // Verify that the range in the bound is sensible, as the bound may get
         // rejected otherwise
-        const sortsAfter = compareByteArrays(barrier, lastLower);
-        const sortsBefore = compareByteArrays(barrier, upperBound);
-        if (
-          (lowerOpen ? sortsAfter > 0 : sortsAfter >= 0) &&
-          sortsBefore <= 0
-        ) {
+        const sortsAfter = compareByteArrays(currentBound, lastBound);
+        const sortsBefore = compareByteArrays(currentBound, upperBound);
+        if ((lastOpen ? sortsAfter > 0 : sortsAfter >= 0) && sortsBefore <= 0) {
           ranges.push(
             IDBKeyRange.bound(
-              this.generateBound(indexRange.lower, lastLower),
-              this.generateBound(indexRange.lower, barrier),
-              lowerOpen,
-              /* upperOpen= */ false
+              this.generateBound(indexRange.lower, lastBound),
+              this.generateBound(indexRange.lower, currentBound),
+              lastOpen,
+              /* upperOpen= */ indexRange.upperOpen
             )
           );
-          lowerOpen = true;
-          lastLower = successor(barrier);
+          lastOpen = true;
+          lastBound = successor(currentBound);
         }
       }
     }

--- a/packages/firestore/src/local/indexeddb_index_manager.ts
+++ b/packages/firestore/src/local/indexeddb_index_manager.ts
@@ -873,18 +873,24 @@ export class IndexedDbIndexManager implements IndexManager {
     const bounds: IndexEntry[] = [];
     bounds.push(lower);
     for (const notInValue of notInValues) {
-      const sortsAfter = indexEntryComparator(notInValue, lower);
-      const sortsBefore = indexEntryComparator(notInValue, upper);
+      const cpmToLower = indexEntryComparator(notInValue, lower);
+      const cmpToUpper = indexEntryComparator(notInValue, upper);
 
-      if (sortsAfter > 0 && sortsBefore < 0) {
+      if (cpmToLower === 0) {
+        // `notInValue` is the lower bound. We therefore need to raise the bound
+        // to the next value.
+        bounds[0] = lower.successor();
+      } else if (cpmToLower > 0 && cmpToUpper < 0) {
+        // `notInValue` is in the middle of the range
         bounds.push(notInValue);
         bounds.push(notInValue.successor());
-      } else if (sortsAfter === 0) {
-        // The lowest value in the range is excluded
-        bounds[0] = lower.successor();
-      } else if (sortsBefore === 0) {
-        // The largest value in the range is excluded
+      } else if (cmpToUpper === 0) {
+        // `notInValue` is the upper value. We therefore need to exclude the
+        // upper bound.
         upperInclusive = false;
+      } else {
+        // `notInValue` (and all following values) are out of the range
+        break;
       }
     }
     bounds.push(upper);

--- a/packages/firestore/src/local/indexeddb_index_manager.ts
+++ b/packages/firestore/src/local/indexeddb_index_manager.ts
@@ -16,10 +16,25 @@
  */
 
 import { User } from '../auth/user';
-import { Target } from '../core/target';
+import {
+  Bound,
+  canonifyTarget,
+  FieldFilter,
+  Operator,
+  Target,
+  targetEquals,
+  targetGetArrayValues,
+  targetGetLowerBound,
+  targetGetNotInValues,
+  targetGetUpperBound
+} from '../core/target';
 import { FirestoreIndexValueWriter } from '../index/firestore_index_value_writer';
 import { IndexByteEncoder } from '../index/index_byte_encoder';
-import { IndexEntry, indexEntryComparator } from '../index/index_entry';
+import {
+  compareByteArrays,
+  IndexEntry,
+  indexEntryComparator
+} from '../index/index_entry';
 import {
   documentKeySet,
   DocumentKeySet,
@@ -31,15 +46,19 @@ import {
   FieldIndex,
   fieldIndexGetArraySegment,
   fieldIndexGetDirectionalSegments,
+  fieldIndexToString,
   IndexKind,
-  IndexOffset
+  IndexOffset,
+  IndexSegment
 } from '../model/field_index';
-import { ResourcePath } from '../model/path';
+import { FieldPath, ResourcePath } from '../model/path';
+import { TargetIndexMatcher } from '../model/target_index_matcher';
 import { isArray } from '../model/values';
 import { Value as ProtoValue } from '../protos/firestore_proto_api';
 import { debugAssert } from '../util/assert';
 import { logDebug } from '../util/log';
 import { immediateSuccessor } from '../util/misc';
+import { ObjectMap } from '../util/obj_map';
 import { diffSortedSets, SortedSet } from '../util/sorted_set';
 
 import {
@@ -70,6 +89,8 @@ import { SimpleDbStore } from './simple_db';
 
 const LOG_TAG = 'IndexedDbIndexManager';
 
+const EMPTY_VALUE = new Uint8Array(0);
+
 /**
  * A persisted implementation of IndexManager.
  *
@@ -87,6 +108,15 @@ export class IndexedDbIndexManager implements IndexManager {
   private collectionParentsCache = new MemoryCollectionParentIndex();
 
   private uid: string;
+
+  /**
+   * Maps from a target to its equivalent list of sub-targets. Each sub-target
+   * contains only one term from the target's disjunctive normal form (DNF).
+   */
+  private targetToDnfSubTargets = new ObjectMap<Target, Target[]>(
+    t => canonifyTarget(t),
+    (l, r) => targetEquals(l, r)
+  );
 
   constructor(private user: User) {
     this.uid = user.uid || '';
@@ -196,19 +226,211 @@ export class IndexedDbIndexManager implements IndexManager {
 
   getDocumentsMatchingTarget(
     transaction: PersistenceTransaction,
-    fieldIndex: FieldIndex,
     target: Target
-  ): PersistencePromise<DocumentKeySet> {
-    // TODO(indexing): Implement
-    return PersistencePromise.resolve(documentKeySet());
+  ): PersistencePromise<DocumentKeySet | null> {
+    const indexEntries = indexEntriesStore(transaction);
+
+    let canServeTarget = true;
+    const indexes = new Map<Target, FieldIndex | null>();
+
+    return PersistencePromise.forEach(
+      this.getSubTargets(target),
+      (subTarget: Target) => {
+        return this.getFieldIndex(transaction, subTarget).next(index => {
+          canServeTarget &&= !!index;
+          indexes.set(subTarget, index);
+        });
+      }
+    ).next(() => {
+      if (!canServeTarget) {
+        return PersistencePromise.resolve(null as DocumentKeySet | null);
+      } else {
+        let result = documentKeySet();
+        return PersistencePromise.forEach(indexes, (index, subTarget) => {
+          logDebug(
+            LOG_TAG,
+            `Using index ${fieldIndexToString(
+              index!
+            )} to execute ${canonifyTarget(target)}`
+          );
+
+          const arrayValues = targetGetArrayValues(subTarget, index!);
+          const notInValues = targetGetNotInValues(subTarget, index!);
+          const lowerBound = targetGetLowerBound(subTarget, index!);
+          const upperBound = targetGetUpperBound(subTarget, index!);
+
+          const lowerBoundEncoded = this.encodeBound(
+            index!,
+            subTarget,
+            lowerBound
+          );
+          const upperBoundEncoded = this.encodeBound(
+            index!,
+            subTarget,
+            upperBound
+          );
+          const notInEncoded = this.encodeValues(
+            index!,
+            subTarget,
+            notInValues
+          );
+
+          const indexRanges = this.generateIndexRanges(
+            index!.indexId,
+            arrayValues,
+            lowerBoundEncoded,
+            !!lowerBound && lowerBound.inclusive,
+            upperBoundEncoded,
+            !!upperBound && upperBound.inclusive,
+            notInEncoded
+          );
+          return PersistencePromise.forEach(
+            indexRanges,
+            (indexRange: IDBKeyRange) => {
+              return indexEntries
+                .loadFirst(indexRange, target.limit)
+                .next(entries => {
+                  entries.forEach(entry => {
+                    result = result.add(
+                      new DocumentKey(decodeResourcePath(entry.documentKey))
+                    );
+                  });
+                });
+            }
+          );
+        }).next(() => result as DocumentKeySet | null);
+      }
+    });
+  }
+
+  private getSubTargets(target: Target): Target[] {
+    let subTargets = this.targetToDnfSubTargets.get(target);
+    if (subTargets) {
+      return subTargets;
+    }
+    // TODO(orquery): Implement DNF transform
+    subTargets = [target];
+    this.targetToDnfSubTargets.set(target, subTargets);
+    return subTargets;
+  }
+
+  /**
+   * Constructs a key range query on `DbIndexEntry.store` that unions all
+   * bounds.
+   */
+  private generateIndexRanges(
+    indexId: number,
+    arrayValues: ProtoValue[] | null,
+    lowerBounds: Uint8Array[] | null,
+    lowerBoundInclusive: boolean,
+    upperBounds: Uint8Array[] | null,
+    upperBoundInclusive: boolean,
+    notInValues: Uint8Array[] | null
+  ): IDBKeyRange[] {
+    // The number of total index scans we union together. This is similar to a
+    // distributed normal form, but adapted for array values. We create a single
+    // index range per value in an ARRAY_CONTAINS or ARRAY_CONTAINS_ANY filter
+    // combined with the values from the query bounds.
+    const totalScans =
+      (arrayValues != null ? arrayValues.length : 1) *
+      Math.max(
+        lowerBounds != null ? lowerBounds.length : 1,
+        upperBounds != null ? upperBounds.length : 1
+      );
+    const scansPerArrayElement =
+      totalScans / (arrayValues != null ? arrayValues.length : 1);
+
+    const indexRanges: IDBKeyRange[] = [];
+    for (let i = 0; i < totalScans; ++i) {
+      const arrayValue = arrayValues
+        ? this.encodeSingleElement(arrayValues[i / scansPerArrayElement])
+        : EMPTY_VALUE;
+      indexRanges.push(
+        IDBKeyRange.bound(
+          lowerBounds
+            ? this.generateLowerBound(
+                indexId,
+                arrayValue,
+                lowerBounds[i % scansPerArrayElement],
+                lowerBoundInclusive
+              )
+            : this.generateEmptyBound(indexId),
+          upperBounds
+            ? this.generateUpperBound(
+                indexId,
+                arrayValue,
+                upperBounds[i % scansPerArrayElement],
+                upperBoundInclusive
+              )
+            : this.generateEmptyBound(indexId + 1),
+          /* lowerOpen= */ false,
+          /* upperOpen= */ true
+        )
+      );
+    }
+
+    return this.applyNotIn(indexRanges, notInValues);
+  }
+
+  /** Generates the lower bound for `arrayValue` and `directionalValue`. */
+  private generateLowerBound(
+    indexId: number,
+    arrayValue: Uint8Array,
+    directionalValue: Uint8Array,
+    inclusive: boolean
+  ): DbIndexEntryKey {
+    return [
+      indexId,
+      this.uid,
+      arrayValue,
+      inclusive ? directionalValue : successor(directionalValue),
+      ''
+    ];
+  }
+
+  /** Generates the upper bound for `arrayValue` and `directionalValue`. */
+  private generateUpperBound(
+    indexId: number,
+    arrayValue: Uint8Array,
+    directionalValue: Uint8Array,
+    inclusive: boolean
+  ): DbIndexEntryKey {
+    return [
+      indexId,
+      this.uid,
+      arrayValue,
+      inclusive ? successor(directionalValue) : directionalValue,
+      ''
+    ];
+  }
+
+  /**
+   * Generates an empty bound that scopes the index scan to the current index
+   * and user.
+   */
+  private generateEmptyBound(indexId: number): DbIndexEntryKey {
+    return [indexId, this.uid, EMPTY_VALUE, EMPTY_VALUE, ''];
   }
 
   getFieldIndex(
     transaction: PersistenceTransaction,
     target: Target
   ): PersistencePromise<FieldIndex | null> {
-    // TODO(indexing): Implement
-    return PersistencePromise.resolve<FieldIndex | null>(null);
+    const targetIndexMatcher = new TargetIndexMatcher(target);
+    const collectionGroup =
+      target.collectionGroup != null
+        ? target.collectionGroup
+        : target.path.lastSegment();
+
+    return this.getFieldIndexes(transaction, collectionGroup).next(indexes => {
+      const matchingIndexes = indexes.filter(i =>
+        targetIndexMatcher.servedByIndex(i)
+      );
+
+      // Return the index that matches the most number of segments.
+      matchingIndexes.sort((l, r) => r.fields.length - l.fields.length);
+      return matchingIndexes.length > 0 ? matchingIndexes[0] : null;
+    });
   }
 
   /**
@@ -243,6 +465,101 @@ export class IndexedDbIndexManager implements IndexManager {
       encoder.forKind(IndexKind.ASCENDING)
     );
     return encoder.encodedBytes();
+  }
+
+  /**
+   * Encodes the given field values according to the specification in `target`.
+   * For IN queries, a list of possible values is returned.
+   */
+  private encodeValues(
+    fieldIndex: FieldIndex,
+    target: Target,
+    bound: ProtoValue[] | null
+  ): Uint8Array[] | null {
+    if (bound == null) {
+      return null;
+    }
+
+    let encoders: IndexByteEncoder[] = [];
+    encoders.push(new IndexByteEncoder());
+
+    let boundIdx = 0;
+    for (const segment of fieldIndexGetDirectionalSegments(fieldIndex)) {
+      const value = bound[boundIdx++];
+      for (const encoder of encoders) {
+        if (this.isInFilter(target, segment.fieldPath) && isArray(value)) {
+          encoders = this.expandIndexValues(encoders, segment, value);
+        } else {
+          const directionalEncoder = encoder.forKind(segment.kind);
+          FirestoreIndexValueWriter.INSTANCE.writeIndexValue(
+            value,
+            directionalEncoder
+          );
+        }
+      }
+    }
+    return this.getEncodedBytes(encoders);
+  }
+
+  /**
+   * Encodes the given bounds according to the specification in `target`. For IN
+   * queries, a list of possible values is returned.
+   */
+  private encodeBound(
+    fieldIndex: FieldIndex,
+    target: Target,
+    bound: Bound | null
+  ): Uint8Array[] | null {
+    if (bound == null) {
+      return null;
+    }
+    return this.encodeValues(fieldIndex, target, bound.position);
+  }
+
+  /** Returns the byte representation for the provided encoders. */
+  private getEncodedBytes(encoders: IndexByteEncoder[]): Uint8Array[] {
+    const result: Uint8Array[] = [];
+    for (let i = 0; i < encoders.length; ++i) {
+      result[i] = encoders[i].encodedBytes();
+    }
+    return result;
+  }
+
+  /**
+   * Creates a separate encoder for each element of an array.
+   *
+   * The method appends each value to all existing encoders (e.g. filter("a",
+   * "==", "a1").filter("b", "in", ["b1", "b2"]) becomes ["a1,b1", "a1,b2"]). A
+   * list of new encoders is returned.
+   */
+  private expandIndexValues(
+    encoders: IndexByteEncoder[],
+    segment: IndexSegment,
+    value: ProtoValue
+  ): IndexByteEncoder[] {
+    const prefixes = [...encoders];
+    const results: IndexByteEncoder[] = [];
+    for (const arrayElement of value.arrayValue!.values || []) {
+      for (const prefix of prefixes) {
+        const clonedEncoder = new IndexByteEncoder();
+        clonedEncoder.seed(prefix.encodedBytes());
+        FirestoreIndexValueWriter.INSTANCE.writeIndexValue(
+          arrayElement,
+          clonedEncoder.forKind(segment.kind)
+        );
+        results.push(clonedEncoder);
+      }
+    }
+    return results;
+  }
+
+  private isInFilter(target: Target, fieldPath: FieldPath): boolean {
+    for (const filter of target.filters) {
+      if (filter instanceof FieldFilter && filter.field.isEqual(fieldPath)) {
+        return filter.op === Operator.IN || filter.op === Operator.NOT_IN;
+      }
+    }
+    return false;
   }
 
   getFieldIndexes(
@@ -459,7 +776,7 @@ export class IndexedDbIndexManager implements IndexManager {
         new IndexEntry(
           fieldIndex.indexId,
           document.key,
-          new Uint8Array(),
+          EMPTY_VALUE,
           directionalValue
         )
       );
@@ -516,6 +833,103 @@ export class IndexedDbIndexManager implements IndexManager {
       )
       .next(() => nextSequenceNumber);
   }
+
+  /**
+   * Applies notIn and != filters by taking the provided ranges and excluding
+   * any values that match the `notInValue` from these ranges. As an example,
+   * '[foo > 2 && foo != 3]` becomes  `[foo > 2 && < 3, foo > 3]`.
+   */
+  private applyNotIn(
+    indexRanges: IDBKeyRange[],
+    notInValues: Uint8Array[] | null
+  ): IDBKeyRange[] {
+    if (!notInValues) {
+      return indexRanges;
+    }
+
+    // The values need to be sorted so that we can return a sorted set of
+    // non-overlapping ranges.
+    notInValues.sort((l, r) => compareByteArrays(l, r));
+
+    const notInRanges: IDBKeyRange[] = [];
+    for (const indexRange of indexRanges) {
+      // Use the existing bounds and interleave the notIn values. This means
+      // that we would split an existing range into multiple ranges that exclude
+      // the values from any notIn filter.
+
+      // The first index range starts with the lower bound and ends at the
+      // first notIn value (exclusive).
+      notInRanges.push(
+        IDBKeyRange.bound(
+          indexRange.lower,
+          this.generateNotInBound(indexRange.lower, notInValues[0]),
+          indexRange.lowerOpen,
+          /* upperOpen= */ true
+        )
+      );
+
+      for (let i = 1; i < notInValues.length - 1; ++i) {
+        // Each index range that we need to scan starts at the last notIn value
+        // and ends at the next.
+        notInRanges.push(
+          IDBKeyRange.bound(
+            this.generateNotInBound(indexRange.lower, notInValues[i - 1]),
+            this.generateNotInBound(
+              indexRange.lower,
+              successor(notInValues[i])
+            ),
+            /* lowerOpen= */ false,
+            /* upperOpen= */ true
+          )
+        );
+      }
+
+      // The last index range starts at tha last notIn value (exclusive) and
+      // ends at the upper bound;
+      notInRanges.push(
+        IDBKeyRange.bound(
+          this.generateNotInBound(
+            indexRange.lower,
+            successor(notInValues[notInValues.length - 1])
+          ),
+          indexRange.upper,
+          /* lowerOpen= */ false,
+          indexRange.upperOpen
+        )
+      );
+    }
+    return notInRanges;
+  }
+
+  /**
+   * Generates the index entry that can be used to create the cutoff for `value`
+   * on the provided index range.
+   */
+  private generateNotInBound(
+    existingRange: DbIndexEntryKey,
+    value: Uint8Array
+  ): DbIndexEntryKey {
+    return [
+      /* indexId= */ existingRange[0],
+      /* userId= */ existingRange[1],
+      /* arrayValue= */ existingRange[2],
+      value,
+      /* documentKey= */ ''
+    ];
+  }
+}
+
+/** Creates a Uint8Array value that sorts immediately after `value`. */
+function successor(value: Uint8Array): Uint8Array {
+  if (value.length === 0 || value[value.length - 1] === 255) {
+    const successor = new Uint8Array(value.length + 1);
+    successor.set(value, 0);
+    successor.set([0], value.length);
+    return successor;
+  } else {
+    ++value[value.length - 1];
+  }
+  return value;
 }
 
 /**

--- a/packages/firestore/src/local/indexeddb_index_manager.ts
+++ b/packages/firestore/src/local/indexeddb_index_manager.ts
@@ -857,6 +857,10 @@ export class IndexedDbIndexManager implements IndexManager {
     // that we would split an existing range into multiple ranges that exclude
     // the values from any notIn filter.
     for (const indexRange of indexRanges) {
+      debugAssert(
+        indexRange.lower[0] === indexRange.upper[0],
+        'Index ID must match for index range'
+      );
       const lowerBound = new Uint8Array(indexRange.lower[3]);
       const upperBound = new Uint8Array(indexRange.upper[3]);
 
@@ -873,7 +877,7 @@ export class IndexedDbIndexManager implements IndexManager {
           ranges.push(
             IDBKeyRange.bound(
               this.generateBound(indexRange.lower, lastBound),
-              this.generateBound(indexRange.lower, currentBound),
+              this.generateBound(indexRange.upper, currentBound),
               lastOpen,
               /* upperOpen= */ indexRange.upperOpen
             )

--- a/packages/firestore/src/local/indexeddb_index_manager.ts
+++ b/packages/firestore/src/local/indexeddb_index_manager.ts
@@ -362,9 +362,7 @@ export class IndexedDbIndexManager implements IndexManager {
       indexRanges.push(
         ...this.createRange(
           lowerBound,
-          /* lowerInclusive= */ true,
           upperBound,
-          /* upperInclusive= */ false,
           notInValues.map(
             (
               notIn // make non-nullable
@@ -857,9 +855,7 @@ export class IndexedDbIndexManager implements IndexManager {
    */
   private createRange(
     lower: IndexEntry,
-    lowerInclusive: boolean,
     upper: IndexEntry,
-    upperInclusive: boolean,
     notInValues: IndexEntry[]
   ): IDBKeyRange[] {
     // The notIb values need to be sorted and unique so that we can return a
@@ -884,11 +880,7 @@ export class IndexedDbIndexManager implements IndexManager {
         // `notInValue` is in the middle of the range
         bounds.push(notInValue);
         bounds.push(notInValue.successor());
-      } else if (cmpToUpper === 0) {
-        // `notInValue` is the upper value. We therefore need to exclude the
-        // upper bound.
-        upperInclusive = false;
-      } else {
+      } else if (cmpToUpper > 0) {
         // `notInValue` (and all following values) are out of the range
         break;
       }
@@ -912,9 +904,7 @@ export class IndexedDbIndexManager implements IndexManager {
             bounds[i + 1].arrayValue,
             bounds[i + 1].directionalValue,
             ''
-          ],
-          !lowerInclusive,
-          !upperInclusive
+          ]
         )
       );
     }

--- a/packages/firestore/src/local/indexeddb_index_manager.ts
+++ b/packages/firestore/src/local/indexeddb_index_manager.ts
@@ -873,14 +873,14 @@ export class IndexedDbIndexManager implements IndexManager {
     const bounds: IndexEntry[] = [];
     bounds.push(lower);
     for (const notInValue of notInValues) {
-      const cpmToLower = indexEntryComparator(notInValue, lower);
+      const cmpToLower = indexEntryComparator(notInValue, lower);
       const cmpToUpper = indexEntryComparator(notInValue, upper);
 
-      if (cpmToLower === 0) {
+      if (cmpToLower === 0) {
         // `notInValue` is the lower bound. We therefore need to raise the bound
         // to the next value.
         bounds[0] = lower.successor();
-      } else if (cpmToLower > 0 && cmpToUpper < 0) {
+      } else if (cmpToLower > 0 && cmpToUpper < 0) {
         // `notInValue` is in the middle of the range
         bounds.push(notInValue);
         bounds.push(notInValue.successor());

--- a/packages/firestore/src/local/memory_index_manager.ts
+++ b/packages/firestore/src/local/memory_index_manager.ts
@@ -16,11 +16,7 @@
  */
 
 import { Target } from '../core/target';
-import {
-  documentKeySet,
-  DocumentKeySet,
-  DocumentMap
-} from '../model/collections';
+import { DocumentKeySet, DocumentMap } from '../model/collections';
 import { FieldIndex, IndexOffset } from '../model/field_index';
 import { ResourcePath } from '../model/path';
 import { debugAssert } from '../util/assert';
@@ -71,11 +67,10 @@ export class MemoryIndexManager implements IndexManager {
 
   getDocumentsMatchingTarget(
     transaction: PersistenceTransaction,
-    fieldIndex: FieldIndex,
     target: Target
-  ): PersistencePromise<DocumentKeySet> {
+  ): PersistencePromise<DocumentKeySet | null> {
     // Field indices are not supported with memory persistence.
-    return PersistencePromise.resolve(documentKeySet());
+    return PersistencePromise.resolve<DocumentKeySet | null>(null);
   }
 
   getFieldIndex(

--- a/packages/firestore/src/local/simple_db.ts
+++ b/packages/firestore/src/local/simple_db.ts
@@ -683,6 +683,24 @@ export class SimpleDbStore<
     }
   }
 
+  loadFirst(
+    range: IDBKeyRange,
+    count: number | null
+  ): PersistencePromise<ValueType[]> {
+    const request = this.store.getAll(
+      range,
+      count === null ? undefined : count
+    );
+    return new PersistencePromise((resolve, reject) => {
+      request.onerror = (event: Event) => {
+        reject((event.target as IDBRequest).error!);
+      };
+      request.onsuccess = (event: Event) => {
+        resolve((event.target as IDBRequest).result);
+      };
+    });
+  }
+
   deleteAll(): PersistencePromise<void>;
   deleteAll(range: IDBKeyRange): PersistencePromise<void>;
   deleteAll(index: string, range: IDBKeyRange): PersistencePromise<void>;

--- a/packages/firestore/src/local/simple_db.ts
+++ b/packages/firestore/src/local/simple_db.ts
@@ -652,8 +652,14 @@ export class SimpleDbStore<
     return wrapRequest<number>(request);
   }
 
+  /** Loads all elements from the object store. */
   loadAll(): PersistencePromise<ValueType[]>;
+  /** Loads all elements for the index range from the object store. */
   loadAll(range: IDBKeyRange): PersistencePromise<ValueType[]>;
+  /**
+   * Loads all elements from the object store that fall into the provided in the
+   * index range for the given index.
+   */
   loadAll(index: string, range: IDBKeyRange): PersistencePromise<ValueType[]>;
   loadAll(
     indexOrRange?: string | IDBKeyRange,
@@ -683,6 +689,10 @@ export class SimpleDbStore<
     }
   }
 
+  /**
+   * Loads the first `count` elements from the provided index range. Loads all
+   * elements if no limit is provided.
+   */
   loadFirst(
     range: IDBKeyRange,
     count: number | null

--- a/packages/firestore/src/model/field_index.ts
+++ b/packages/firestore/src/model/field_index.ts
@@ -101,6 +101,13 @@ export function fieldIndexSemanticComparator(
   return primitiveComparator(left.fields.length, right.fields.length);
 }
 
+/** Returns a debug representation of the field index */
+export function fieldIndexToString(fieldIndex: FieldIndex): string {
+  return `id=${fieldIndex.indexId}|cg=${
+    fieldIndex.collectionGroup
+  }|f=${fieldIndex.fields.map(f => `${f.fieldPath}:${f.kind}`).join(',')}`;
+}
+
 /** The type of the index, e.g. for which type of query it can be used. */
 export const enum IndexKind {
   // Note: The order of these values cannot be changed as the enum values are

--- a/packages/firestore/src/model/type_order.ts
+++ b/packages/firestore/src/model/type_order.ts
@@ -24,7 +24,7 @@
  */
 export const enum TypeOrder {
   // This order is based on the backend's ordering, but modified to support
-  // server timestamps.
+  // server timestamps and `MAX_VALUE`.
   NullValue = 0,
   BooleanValue = 1,
   NumberValue = 2,
@@ -35,5 +35,6 @@ export const enum TypeOrder {
   RefValue = 7,
   GeoPointValue = 8,
   ArrayValue = 9,
-  ObjectValue = 10
+  ObjectValue = 10,
+  MaxValue = 9007199254740991 // Number.MAX_SAFE_INTEGER
 }

--- a/packages/firestore/src/platform/node/base64.ts
+++ b/packages/firestore/src/platform/node/base64.ts
@@ -16,23 +16,16 @@
  */
 
 /** Converts a Base64 encoded string to a binary string. */
-import { Code, FirestoreError } from '../../util/error';
 
 export function decodeBase64(encoded: string): string {
-  // Node actually doesn't validate base64 strings.
-  // A quick sanity check that is not a fool-proof validation
-  if (/[^-A-Za-z0-9+/=]/.test(encoded)) {
-    throw new FirestoreError(
-      Code.INVALID_ARGUMENT,
-      'Not a valid Base64 string: ' + encoded
-    );
-  }
-  return new Buffer(encoded, 'base64').toString('binary');
+  // Note: We used to validate the base64 string here via a regular expression.
+  // This was removed to improve the performance of indexing.
+  return Buffer.from(encoded, 'base64').toString('binary');
 }
 
 /** Converts a binary string to a Base64 encoded string. */
 export function encodeBase64(raw: string): string {
-  return new Buffer(raw, 'binary').toString('base64');
+  return Buffer.from(raw, 'binary').toString('base64');
 }
 
 /** True if and only if the Base64 conversion functions are available. */

--- a/packages/firestore/src/util/byte_string.ts
+++ b/packages/firestore/src/util/byte_string.ts
@@ -39,6 +39,8 @@ export class ByteString {
   }
 
   static fromUint8Array(array: Uint8Array): ByteString {
+    // TODO(indexing); Remove the copy of the byte string here as this method
+    // is frequently called during indexing.
     const binaryString = binaryStringFromUint8Array(array);
     return new ByteString(binaryString);
   }

--- a/packages/firestore/test/unit/api/bytes.test.ts
+++ b/packages/firestore/test/unit/api/bytes.test.ts
@@ -47,12 +47,6 @@ describe('Bytes', () => {
     });
   });
 
-  it('throws on invalid Base64 strings', () => {
-    expect(() => Bytes.fromBase64String('not-base64!')).to.throw(
-      /Failed to construct data from Base64 string:/
-    );
-  });
-
   it('works with instanceof checks', () => {
     expect(Bytes.fromBase64String('') instanceof Bytes).to.equal(true);
   });

--- a/packages/firestore/test/unit/local/index_manager.test.ts
+++ b/packages/firestore/test/unit/local/index_manager.test.ts
@@ -365,6 +365,54 @@ describe('IndexedDbIndexManager', async () => {
       filter('count', '!=', 1)
     );
     await verifyResults(q);
+
+    q = queryWithAddedFilter(
+      queryWithAddedFilter(query('coll'), filter('count', '>', 2)),
+      filter('count', '!=', 2)
+    );
+    await verifyResults(q, 'coll/val3');
+
+    q = queryWithAddedFilter(
+      queryWithAddedFilter(query('coll'), filter('count', '>=', 2)),
+      filter('count', '!=', 2)
+    );
+    await verifyResults(q, 'coll/val3');
+
+    q = queryWithAddedFilter(
+      queryWithAddedFilter(query('coll'), filter('count', '<=', 2)),
+      filter('count', '!=', 2)
+    );
+    await verifyResults(q, 'coll/val1');
+
+    q = queryWithAddedFilter(
+      queryWithAddedFilter(query('coll'), filter('count', '<=', 2)),
+      filter('count', '!=', 1)
+    );
+    await verifyResults(q, 'coll/val2');
+
+    q = queryWithAddedFilter(
+      queryWithAddedFilter(query('coll'), filter('count', '<', 2)),
+      filter('count', '!=', 2)
+    );
+    await verifyResults(q, 'coll/val1');
+
+    q = queryWithAddedFilter(
+      queryWithAddedFilter(query('coll'), filter('count', '<', 2)),
+      filter('count', '!=', 1)
+    );
+    await verifyResults(q);
+
+    q = queryWithAddedFilter(
+      queryWithAddedFilter(query('coll'), filter('count', '>', 2)),
+      filter('count', 'not-in', [3])
+    );
+    await verifyResults(q);
+
+    q = queryWithAddedFilter(
+      queryWithAddedFilter(query('coll'), filter('count', '>', 2)),
+      filter('count', 'not-in', [2, 2])
+    );
+    await verifyResults(q, 'coll/val3');
   });
 
   it('applies less than filter', async () => {

--- a/packages/firestore/test/unit/local/index_manager.test.ts
+++ b/packages/firestore/test/unit/local/index_manager.test.ts
@@ -29,6 +29,7 @@ import {
   queryWithLimit,
   queryWithStartAt
 } from '../../../src/core/query';
+import { FieldFilter } from '../../../src/core/target';
 import { IndexedDbPersistence } from '../../../src/local/indexeddb_persistence';
 import { INDEXING_SCHEMA_VERSION } from '../../../src/local/indexeddb_schema';
 import { Persistence } from '../../../src/local/persistence';
@@ -58,7 +59,6 @@ import {
 
 import * as persistenceHelpers from './persistence_test_helpers';
 import { TestIndexManager } from './test_index_manager';
-import { FieldFilter } from '../../../src/core/target';
 
 describe('MemoryIndexManager', async () => {
   genericIndexManagerTests(persistenceHelpers.testMemoryEagerPersistence);

--- a/packages/firestore/test/unit/local/index_manager.test.ts
+++ b/packages/firestore/test/unit/local/index_manager.test.ts
@@ -446,6 +446,18 @@ describe('IndexedDbIndexManager', async () => {
     await verifyResults(q, 'coll/val2', 'coll/val3');
   });
 
+  it('applies startAt filter with notIn', async () => {
+    await setUpSingleValueFilter();
+    const q = queryWithStartAt(
+      queryWithAddedOrderBy(
+        queryWithAddedFilter(query('coll'), filter('count', '!=', 2)),
+        orderBy('count')
+      ),
+      bound([2], true)
+    );
+    await verifyResults(q, 'coll/val3');
+  });
+
   it('applies startAfter filter', async () => {
     await setUpSingleValueFilter();
     const q = queryWithStartAt(

--- a/packages/firestore/test/unit/local/index_manager.test.ts
+++ b/packages/firestore/test/unit/local/index_manager.test.ts
@@ -18,6 +18,17 @@
 import { expect } from 'chai';
 
 import { User } from '../../../src/auth/user';
+import {
+  LimitType,
+  newQueryForCollectionGroup,
+  Query,
+  queryToTarget,
+  queryWithAddedFilter,
+  queryWithAddedOrderBy,
+  queryWithEndAt,
+  queryWithLimit,
+  queryWithStartAt
+} from '../../../src/core/query';
 import { IndexedDbPersistence } from '../../../src/local/indexeddb_persistence';
 import { INDEXING_SCHEMA_VERSION } from '../../../src/local/indexeddb_schema';
 import { Persistence } from '../../../src/local/persistence';
@@ -29,17 +40,30 @@ import {
   IndexState
 } from '../../../src/model/field_index';
 import { JsonObject } from '../../../src/model/object_value';
+import { canonicalId } from '../../../src/model/values';
 import { addEqualityMatcher } from '../../util/equality_matcher';
-import { doc, fieldIndex, key, path, version } from '../../util/helpers';
+import {
+  bound,
+  deletedDoc,
+  doc,
+  fieldIndex,
+  filter,
+  key,
+  orderBy,
+  path,
+  query,
+  version,
+  wrap
+} from '../../util/helpers';
 
 import * as persistenceHelpers from './persistence_test_helpers';
 import { TestIndexManager } from './test_index_manager';
 
-describe('MemoryIndexManager', () => {
+describe('MemoryIndexManager', async () => {
   genericIndexManagerTests(persistenceHelpers.testMemoryEagerPersistence);
 });
 
-describe('IndexedDbIndexManager', () => {
+describe('IndexedDbIndexManager', async () => {
   if (!IndexedDbPersistence.isAvailable()) {
     console.warn('No IndexedDB. Skipping IndexedDbIndexManager tests.');
     return;
@@ -171,6 +195,10 @@ describe('IndexedDbIndexManager', () => {
 
     nextCollectionGroup = await indexManager.getNextCollectionGroupToUpdate();
     expect(nextCollectionGroup).to.equal('coll2');
+
+    await indexManager.updateCollectionGroup('coll2', IndexOffset.min());
+    nextCollectionGroup = await indexManager.getNextCollectionGroupToUpdate();
+    expect(nextCollectionGroup).to.equal('coll1');
   });
 
   it('deleting field index removes entry from collection group', async () => {
@@ -208,6 +236,20 @@ describe('IndexedDbIndexManager', () => {
     expect(await indexManager.getNextCollectionGroupToUpdate()).to.equal(null);
   });
 
+  it('persist index offset', async () => {
+    await indexManager.addFieldIndex(
+      fieldIndex('coll1', { fields: [['value', IndexKind.ASCENDING]] })
+    );
+    const offset = new IndexOffset(version(20), key('coll/doc'), 42);
+    await indexManager.updateCollectionGroup('coll1', offset);
+
+    indexManager = await getIndexManager(User.UNAUTHENTICATED);
+
+    const indexes = await indexManager.getFieldIndexes('coll1');
+    expect(indexes).to.have.length(1);
+    expect(indexes[0].indexState.offset).to.deep.equal(offset);
+  });
+
   it('changes user', async () => {
     let indexManager = await getIndexManager(new User('user1'));
 
@@ -243,6 +285,863 @@ describe('IndexedDbIndexManager', () => {
     await addDoc('coll/doc2', {});
   });
 
+  it('applies orderBy', async () => {
+    await indexManager.addFieldIndex(
+      fieldIndex('coll', { fields: [['count', IndexKind.ASCENDING]] })
+    );
+    await addDoc('coll/val1', { 'count': 1 });
+    await addDoc('coll/val2', { 'not-count': 3 });
+    await addDoc('coll/val3', { 'count': 2 });
+    const q = queryWithAddedOrderBy(query('coll'), orderBy('count'));
+    await verifyResults(q, 'coll/val1', 'coll/val3');
+  });
+
+  it('applies equality filter', async () => {
+    await setUpSingleValueFilter();
+    const q = queryWithAddedFilter(query('coll'), filter('count', '==', 2));
+    await verifyResults(q, 'coll/val2');
+  });
+
+  it('applies nested field equality filter', async () => {
+    await indexManager.addFieldIndex(
+      fieldIndex('coll', { fields: [['a.b', IndexKind.ASCENDING]] })
+    );
+    await addDoc('coll/doc1', { 'a': { 'b': 1 } });
+    await addDoc('coll/doc2', { 'a': { 'b': 2 } });
+    const q = queryWithAddedFilter(query('coll'), filter('a.b', '==', 2));
+    await verifyResults(q, 'coll/doc2');
+  });
+
+  it('applies not equals filter', async () => {
+    await setUpSingleValueFilter();
+    const q = queryWithAddedFilter(query('coll'), filter('count', '!=', 2));
+    await verifyResults(q, 'coll/val1', 'coll/val3');
+  });
+
+  it('applies equals with not equals filter', async () => {
+    await indexManager.addFieldIndex(
+      fieldIndex('coll', {
+        fields: [
+          ['a', IndexKind.ASCENDING],
+          ['b', IndexKind.ASCENDING]
+        ]
+      })
+    );
+    await addDoc('coll/val1', { 'a': 1, 'b': 1 });
+    await addDoc('coll/val2', { 'a': 1, 'b': 2 });
+    await addDoc('coll/val3', { 'a': 2, 'b': 1 });
+    await addDoc('coll/val4', { 'a': 2, 'b': 2 });
+
+    // Verifies that we apply the filter in the order of the field index
+    let q = queryWithAddedFilter(
+      queryWithAddedFilter(query('coll'), filter('a', '==', 1)),
+      filter('b', '!=', 1)
+    );
+    await verifyResults(q, 'coll/val2');
+
+    q = queryWithAddedFilter(
+      queryWithAddedFilter(query('coll'), filter('b', '!=', 1)),
+      filter('a', '==', 1)
+    );
+    await verifyResults(q, 'coll/val2');
+  });
+
+  it('applies less than filter', async () => {
+    await setUpSingleValueFilter();
+    const q = queryWithAddedFilter(query('coll'), filter('count', '<', 2));
+    await verifyResults(q, 'coll/val1');
+  });
+
+  it('applies less than or equals filter', async () => {
+    await setUpSingleValueFilter();
+    const q = queryWithAddedFilter(query('coll'), filter('count', '<=', 2));
+    await verifyResults(q, 'coll/val1', 'coll/val2');
+  });
+
+  it('applies greater than or equals filter', async () => {
+    await setUpSingleValueFilter();
+    const q = queryWithAddedFilter(query('coll'), filter('count', '>=', 2));
+    await verifyResults(q, 'coll/val2', 'coll/val3');
+  });
+
+  it('applies greater than filter', async () => {
+    await setUpSingleValueFilter();
+    const q = queryWithAddedFilter(query('coll'), filter('count', '>', 2));
+    await verifyResults(q, 'coll/val3');
+  });
+
+  it('applies range filter', async () => {
+    await setUpSingleValueFilter();
+    const q = queryWithAddedFilter(
+      queryWithAddedFilter(query('coll'), filter('count', '>', 1)),
+      filter('count', '<', 3)
+    );
+    await verifyResults(q, 'coll/val2');
+  });
+
+  it('applies startAt filter', async () => {
+    await setUpSingleValueFilter();
+    const q = queryWithStartAt(
+      queryWithAddedOrderBy(query('coll'), orderBy('count')),
+      bound([2], true)
+    );
+    await verifyResults(q, 'coll/val2', 'coll/val3');
+  });
+
+  it('applies startAfter filter', async () => {
+    await setUpSingleValueFilter();
+    const q = queryWithStartAt(
+      queryWithAddedOrderBy(query('coll'), orderBy('count')),
+      bound([2], false)
+    );
+    await verifyResults(q, 'coll/val3');
+  });
+
+  it('applies endAt filter', async () => {
+    await setUpSingleValueFilter();
+    const q = queryWithEndAt(
+      queryWithAddedOrderBy(query('coll'), orderBy('count')),
+      bound([2], true)
+    );
+    await verifyResults(q, 'coll/val1', 'coll/val2');
+  });
+
+  it('applies endBefore filter', async () => {
+    await setUpSingleValueFilter();
+    const q = queryWithEndAt(
+      queryWithAddedOrderBy(query('coll'), orderBy('count')),
+      bound([2], false)
+    );
+    await verifyResults(q, 'coll/val1');
+  });
+
+  it('applies range with bound filter', async () => {
+    await setUpSingleValueFilter();
+    const startAt = queryWithEndAt(
+      queryWithStartAt(
+        queryWithAddedOrderBy(
+          queryWithAddedFilter(
+            queryWithAddedFilter(query('coll'), filter('count', '>=', 1)),
+            filter('count', '<=', 3)
+          ),
+          orderBy('count')
+        ),
+        bound([1], false)
+      ),
+      bound([2], true)
+    );
+    await verifyResults(startAt, 'coll/val2');
+  });
+
+  it('applies in filter', async () => {
+    await setUpSingleValueFilter();
+    const q = queryWithAddedFilter(
+      query('coll'),
+      filter('count', 'in', [1, 3])
+    );
+    await verifyResults(q, 'coll/val1', 'coll/val3');
+  });
+
+  it('applies notIn filter', async () => {
+    await setUpSingleValueFilter();
+    const q = queryWithAddedFilter(
+      query('coll'),
+      filter('count', 'not-in', [1, 2])
+    );
+    await verifyResults(q, 'coll/val3');
+  });
+
+  it('applies arrayContains filter', async () => {
+    await setUpArrayValueFilter();
+    const q = queryWithAddedFilter(
+      query('coll'),
+      filter('values', 'array-contains', 1)
+    );
+    await verifyResults(q, 'coll/arr1');
+  });
+
+  it('applies arrayContainsAny filter', async () => {
+    await setUpArrayValueFilter();
+    const q = queryWithAddedFilter(
+      query('coll'),
+      filter('values', 'array-contains-any', [1, 2, 4])
+    );
+    await verifyResults(q, 'coll/arr1', 'coll/arr2');
+  });
+
+  it('validates that array contains filter only matches array', async () => {
+    // Set up two field indexes. This causes two index entries to be written,
+    // but our query should only use one index.
+    await setUpArrayValueFilter();
+    await setUpSingleValueFilter();
+    await addDoc('coll/nonmatching', { 'values': 1 });
+    const q = queryWithAddedFilter(
+      query('coll'),
+      filter('values', 'array-contains-any', [1])
+    );
+    await verifyResults(q, 'coll/arr1');
+  });
+
+  it('returns empty result when no index exists', async () => {
+    await setUpSingleValueFilter();
+    const q = queryWithAddedFilter(
+      query('coll'),
+      filter('unknown', '==', true)
+    );
+    expect(await indexManager.getFieldIndex(queryToTarget(q))).to.be.null;
+    expect(await indexManager.getDocumentsMatchingTarget(queryToTarget(q))).to
+      .be.null;
+  });
+
+  it('returns empty results when no matching documents exists', async () => {
+    await setUpSingleValueFilter();
+    const q = queryWithAddedFilter(query('coll'), filter('count', '==', -1));
+    await verifyResults(q);
+  });
+
+  it('filters by field type', async () => {
+    await indexManager.addFieldIndex(
+      fieldIndex('coll', { fields: [['value', IndexKind.ASCENDING]] })
+    );
+    await addDoc('coll/boolean', { 'value': true });
+    await addDoc('coll/string', { 'value': 'true' });
+    await addDoc('coll/number', { 'value': 1 });
+    const q = queryWithAddedFilter(query('coll'), filter('value', '==', true));
+    await verifyResults(q, 'coll/boolean');
+  });
+
+  it('supports collection group indexes', async () => {
+    await indexManager.addFieldIndex(
+      fieldIndex('coll1', { fields: [['value', IndexKind.ASCENDING]] })
+    );
+    await addDoc('coll1/doc1', { 'value': true });
+    await addDoc('coll2/doc2/coll1/doc1', { 'value': true });
+    await addDoc('coll2/doc2', { 'value': true });
+    const q = queryWithAddedFilter(
+      newQueryForCollectionGroup('coll1'),
+      filter('value', '==', true)
+    );
+    await verifyResults(q, 'coll1/doc1', 'coll2/doc2/coll1/doc1');
+  });
+
+  it('applies limit filter', async () => {
+    await indexManager.addFieldIndex(
+      fieldIndex('coll', { fields: [['value', IndexKind.ASCENDING]] })
+    );
+    await addDoc('coll/doc1', { 'value': 1 });
+    await addDoc('coll/doc2', { 'value': 1 });
+    await addDoc('coll/doc3', { 'value': 1 });
+    const q = queryWithLimit(
+      queryWithAddedFilter(query('coll'), filter('value', '==', 1)),
+      2,
+      LimitType.First
+    );
+    await verifyResults(q, 'coll/doc1', 'coll/doc2');
+  });
+
+  it('uses ordering for limit filter', async () => {
+    await indexManager.addFieldIndex(
+      fieldIndex('coll', {
+        fields: [
+          ['value', IndexKind.CONTAINS],
+          ['value', IndexKind.ASCENDING]
+        ]
+      })
+    );
+    await addDoc('coll/doc1', { 'value': [1, 'foo'] });
+    await addDoc('coll/doc2', { 'value': [3, 'foo'] });
+    await addDoc('coll/doc3', { 'value': [2, 'foo'] });
+    const q = queryWithLimit(
+      queryWithAddedOrderBy(
+        queryWithAddedFilter(
+          query('coll'),
+          filter('value', 'array-contains', 'foo')
+        ),
+        orderBy('value')
+      ),
+      2,
+      LimitType.First
+    );
+    await verifyResults(q, 'coll/doc1', 'coll/doc3');
+  });
+
+  it('updates index entries', async () => {
+    await indexManager.addFieldIndex(
+      fieldIndex('coll', { fields: [['value', IndexKind.ASCENDING]] })
+    );
+    const q = queryWithAddedOrderBy(query('coll'), orderBy('value'));
+
+    await addDoc('coll/doc1', { 'value': true });
+    await verifyResults(q, 'coll/doc1');
+
+    await addDocs(
+      doc('coll/doc1', 1, {}),
+      doc('coll/doc2', 1, { 'value': true })
+    );
+    await verifyResults(q, 'coll/doc2');
+  });
+
+  it('removes index entries', async () => {
+    await indexManager.addFieldIndex(
+      fieldIndex('coll', { fields: [['value', IndexKind.ASCENDING]] })
+    );
+    const q = queryWithAddedOrderBy(query('coll'), orderBy('value'));
+
+    await addDoc('coll/doc1', { 'value': true });
+    await verifyResults(q, 'coll/doc1');
+
+    await addDocs(deletedDoc('coll/doc1', 1));
+    await verifyResults(q);
+  });
+
+  it('support advances queries', async () => {
+    // This test compares local query results with those received from the Java
+    // Server SDK.
+
+    await indexManager.addFieldIndex(
+      fieldIndex('coll', { fields: [['null', IndexKind.ASCENDING]] })
+    );
+    await indexManager.addFieldIndex(
+      fieldIndex('coll', { fields: [['int', IndexKind.ASCENDING]] })
+    );
+    await indexManager.addFieldIndex(
+      fieldIndex('coll', { fields: [['float', IndexKind.ASCENDING]] })
+    );
+    await indexManager.addFieldIndex(
+      fieldIndex('coll', { fields: [['string', IndexKind.ASCENDING]] })
+    );
+    await indexManager.addFieldIndex(
+      fieldIndex('coll', { fields: [['multi', IndexKind.ASCENDING]] })
+    );
+    await indexManager.addFieldIndex(
+      fieldIndex('coll', { fields: [['array', IndexKind.ASCENDING]] })
+    );
+    await indexManager.addFieldIndex(
+      fieldIndex('coll', { fields: [['array', IndexKind.DESCENDING]] })
+    );
+    await indexManager.addFieldIndex(
+      fieldIndex('coll', { fields: [['array', IndexKind.CONTAINS]] })
+    );
+    await indexManager.addFieldIndex(
+      fieldIndex('coll', { fields: [['map', IndexKind.ASCENDING]] })
+    );
+    await indexManager.addFieldIndex(
+      fieldIndex('coll', { fields: [['map.field', IndexKind.ASCENDING]] })
+    );
+    await indexManager.addFieldIndex(
+      fieldIndex('coll', { fields: [['prefix', IndexKind.ASCENDING]] })
+    );
+    await indexManager.addFieldIndex(
+      fieldIndex('coll', {
+        fields: [
+          ['prefix', IndexKind.ASCENDING],
+          ['suffix', IndexKind.ASCENDING]
+        ]
+      })
+    );
+    await indexManager.addFieldIndex(
+      fieldIndex('coll', { fields: [['a', IndexKind.ASCENDING]] })
+    );
+    await indexManager.addFieldIndex(
+      fieldIndex('coll', {
+        fields: [
+          ['a', IndexKind.ASCENDING],
+          ['b', IndexKind.ASCENDING]
+        ]
+      })
+    );
+    await indexManager.addFieldIndex(
+      fieldIndex('coll', {
+        fields: [
+          ['a', IndexKind.DESCENDING],
+          ['b', IndexKind.ASCENDING]
+        ]
+      })
+    );
+    await indexManager.addFieldIndex(
+      fieldIndex('coll', {
+        fields: [
+          ['a', IndexKind.ASCENDING],
+          ['b', IndexKind.DESCENDING]
+        ]
+      })
+    );
+    await indexManager.addFieldIndex(
+      fieldIndex('coll', {
+        fields: [
+          ['a', IndexKind.DESCENDING],
+          ['b', IndexKind.DESCENDING]
+        ]
+      })
+    );
+    await indexManager.addFieldIndex(
+      fieldIndex('coll', {
+        fields: [
+          ['b', IndexKind.ASCENDING],
+          ['a', IndexKind.ASCENDING]
+        ]
+      })
+    );
+
+    const docs = [
+      {},
+      { 'int': 1, 'array': [1, 'foo'] },
+      { 'array': [2, 'foo'] },
+      { 'int': 3, 'array': [3, 'foo'] },
+      { 'array': 'foo' },
+      { 'array': [1] },
+      { 'float': -0.0, 'string': 'a' },
+      { 'float': 0, 'string': 'ab' },
+      { 'float': 0.0, 'string': 'b' },
+      { 'float': NaN },
+      { 'multi': true },
+      { 'multi': 1 },
+      { 'multi': 'string' },
+      { 'multi': [] },
+      { 'null': null },
+      { 'prefix': [1, 2], 'suffix': null },
+      { 'prefix': [1], 'suffix': 2 },
+      { 'map': {} },
+      { 'map': { 'field': true } },
+      { 'map': { 'field': false } },
+      { 'a': 0, 'b': 0 },
+      { 'a': 0, 'b': 1 },
+      { 'a': 1, 'b': 0 },
+      { 'a': 1, 'b': 1 },
+      { 'a': 2, 'b': 0 },
+      { 'a': 2, 'b': 1 }
+    ];
+
+    for (const doc of docs) {
+      await addDoc('coll/' + canonicalId(wrap(doc)), doc);
+    }
+
+    const q = query('coll');
+
+    await verifyResults(
+      queryWithAddedOrderBy(q, orderBy('int')),
+      'coll/{array:[1,foo],int:1}',
+      'coll/{array:[3,foo],int:3}'
+    );
+    await verifyResults(
+      queryWithAddedFilter(q, filter('float', '==', NaN)),
+      'coll/{float:NaN}'
+    );
+    await verifyResults(
+      queryWithAddedFilter(q, filter('float', '==', -0.0)),
+      'coll/{float:-0,string:a}',
+      'coll/{float:0,string:ab}',
+      'coll/{float:0,string:b}'
+    );
+    await verifyResults(
+      queryWithAddedFilter(q, filter('float', '==', 0)),
+      'coll/{float:-0,string:a}',
+      'coll/{float:0,string:ab}',
+      'coll/{float:0,string:b}'
+    );
+    await verifyResults(
+      queryWithAddedFilter(q, filter('float', '==', 0.0)),
+      'coll/{float:-0,string:a}',
+      'coll/{float:0,string:ab}',
+      'coll/{float:0,string:b}'
+    );
+    await verifyResults(
+      queryWithAddedFilter(q, filter('string', '==', 'a')),
+      'coll/{float:-0,string:a}'
+    );
+    await verifyResults(
+      queryWithAddedFilter(q, filter('string', '>', 'a')),
+      'coll/{float:0,string:ab}',
+      'coll/{float:0,string:b}'
+    );
+    await verifyResults(
+      queryWithAddedFilter(q, filter('string', '>=', 'a')),
+      'coll/{float:-0,string:a}',
+      'coll/{float:0,string:ab}',
+      'coll/{float:0,string:b}'
+    );
+    await verifyResults(
+      queryWithAddedFilter(q, filter('string', '<', 'b')),
+      'coll/{float:-0,string:a}',
+      'coll/{float:0,string:ab}'
+    );
+    await verifyResults(
+      queryWithAddedFilter(q, filter('string', '<', 'coll')),
+      'coll/{float:-0,string:a}',
+      'coll/{float:0,string:ab}',
+      'coll/{float:0,string:b}'
+    );
+    await verifyResults(
+      queryWithAddedFilter(
+        queryWithAddedFilter(q, filter('string', '>', 'a')),
+        filter('string', '<', 'b')
+      ),
+      'coll/{float:0,string:ab}'
+    );
+    await verifyResults(
+      queryWithAddedFilter(q, filter('array', 'array-contains', 'foo')),
+      'coll/{array:[1,foo],int:1}',
+      'coll/{array:[2,foo]}',
+      'coll/{array:[3,foo],int:3}'
+    );
+    await verifyResults(
+      queryWithAddedFilter(
+        q,
+        filter('array', 'array-contains-any', [1, 'foo'])
+      ),
+      'coll/{array:[1,foo],int:1}',
+      'coll/{array:[2,foo]}',
+      'coll/{array:[3,foo],int:3}',
+      'coll/{array:[1]}'
+    );
+    await verifyResults(
+      queryWithAddedFilter(q, filter('multi', '>=', true)),
+      'coll/{multi:true}'
+    );
+    await verifyResults(
+      queryWithAddedFilter(q, filter('multi', '>=', 0)),
+      'coll/{multi:1}'
+    );
+    await verifyResults(
+      queryWithAddedFilter(q, filter('multi', '>=', '')),
+      'coll/{multi:string}'
+    );
+    await verifyResults(
+      queryWithAddedFilter(q, filter('multi', '>=', [])),
+      'coll/{multi:[]}'
+    );
+    await verifyResults(
+      queryWithAddedFilter(q, filter('multi', '!=', true)),
+      'coll/{multi:1}',
+      'coll/{multi:string}',
+      'coll/{multi:[]}'
+    );
+    await verifyResults(
+      queryWithAddedFilter(q, filter('multi', 'in', [true, 1])),
+      'coll/{multi:true}',
+      'coll/{multi:1}'
+    );
+    await verifyResults(
+      queryWithAddedFilter(q, filter('multi', 'not-in', [true, 1])),
+      'coll/{multi:string}',
+      'coll/{multi:[]}'
+    );
+    await verifyResults(
+      queryWithStartAt(
+        queryWithAddedOrderBy(q, orderBy('array')),
+        bound([[2]], true)
+      ),
+      'coll/{array:[2,foo]}',
+      'coll/{array:[3,foo],int:3}'
+    );
+    await verifyResults(
+      queryWithStartAt(
+        queryWithAddedOrderBy(q, orderBy('array', 'desc')),
+        bound([[2]], true)
+      ),
+      'coll/{array:[1,foo],int:1}',
+      'coll/{array:foo}',
+      'coll/{array:[1]}'
+    );
+    await verifyResults(
+      queryWithLimit(
+        queryWithStartAt(
+          queryWithAddedOrderBy(q, orderBy('array', 'desc')),
+          bound([[2]], true)
+        ),
+        2,
+        LimitType.First
+      ),
+      'coll/{array:[1,foo],int:1}',
+      'coll/{array:[1]}'
+    );
+    await verifyResults(
+      queryWithStartAt(
+        queryWithAddedOrderBy(q, orderBy('array')),
+        bound([[2]], false)
+      ),
+      'coll/{array:[2,foo]}',
+      'coll/{array:[3,foo],int:3}'
+    );
+    await verifyResults(
+      queryWithStartAt(
+        queryWithAddedOrderBy(q, orderBy('array', 'desc')),
+        bound([[2]], false)
+      ),
+      'coll/{array:[1,foo],int:1}',
+      'coll/{array:foo}',
+      'coll/{array:[1]}'
+    );
+    await verifyResults(
+      queryWithLimit(
+        queryWithStartAt(
+          queryWithAddedOrderBy(q, orderBy('array', 'desc')),
+          bound([[2]], true)
+        ),
+        2,
+        LimitType.First
+      ),
+      'coll/{array:[1,foo],int:1}',
+      'coll/{array:[1]}'
+    );
+    await verifyResults(
+      queryWithStartAt(
+        queryWithAddedOrderBy(q, orderBy('array')),
+        bound([[2, 'foo']], false)
+      ),
+      'coll/{array:[3,foo],int:3}'
+    );
+    await verifyResults(
+      queryWithStartAt(
+        queryWithAddedOrderBy(q, orderBy('array', 'desc')),
+        bound([[2, 'foo']], false)
+      ),
+      'coll/{array:[1,foo],int:1}',
+      'coll/{array:foo}',
+      'coll/{array:[1]}'
+    );
+    await verifyResults(
+      queryWithLimit(
+        queryWithStartAt(
+          queryWithAddedOrderBy(q, orderBy('array', 'desc')),
+          bound([[2, 'foo']], false)
+        ),
+        2,
+        LimitType.First
+      ),
+      'coll/{array:[1,foo],int:1}',
+      'coll/{array:[1]}'
+    );
+    await verifyResults(
+      queryWithEndAt(
+        queryWithAddedOrderBy(q, orderBy('array')),
+        bound([[2]], true)
+      ),
+      'coll/{array:[1,foo],int:1}',
+      'coll/{array:foo}',
+      'coll/{array:[1]}'
+    );
+    await verifyResults(
+      queryWithEndAt(
+        queryWithAddedOrderBy(q, orderBy('array', 'desc')),
+        bound([[2]], true)
+      ),
+      'coll/{array:[2,foo]}',
+      'coll/{array:[3,foo],int:3}'
+    );
+    await verifyResults(
+      queryWithEndAt(
+        queryWithAddedOrderBy(q, orderBy('array')),
+        bound([[2]], false)
+      ),
+      'coll/{array:[1,foo],int:1}',
+      'coll/{array:foo}',
+      'coll/{array:[1]}'
+    );
+    await verifyResults(
+      queryWithLimit(
+        queryWithEndAt(
+          queryWithAddedOrderBy(q, orderBy('array')),
+          bound([[2]], false)
+        ),
+        2,
+        LimitType.First
+      ),
+      'coll/{array:foo}',
+      'coll/{array:[1]}'
+    );
+    await verifyResults(
+      queryWithEndAt(
+        queryWithAddedOrderBy(q, orderBy('array', 'desc')),
+        bound([[2]], false)
+      ),
+      'coll/{array:[2,foo]}',
+      'coll/{array:[3,foo],int:3}'
+    );
+    await verifyResults(
+      queryWithEndAt(
+        queryWithAddedOrderBy(q, orderBy('array')),
+        bound([[2, 'foo']], false)
+      ),
+      'coll/{array:[1,foo],int:1}',
+      'coll/{array:foo}',
+      'coll/{array:[1]}'
+    );
+    await verifyResults(
+      queryWithLimit(
+        queryWithEndAt(
+          queryWithAddedOrderBy(q, orderBy('array')),
+          bound([[2, 'foo']], false)
+        ),
+        2,
+        LimitType.First
+      ),
+      'coll/{array:foo}',
+      'coll/{array:[1]}'
+    );
+    await verifyResults(
+      queryWithEndAt(
+        queryWithAddedOrderBy(q, orderBy('array', 'desc')),
+        bound([[2, 'foo']], false)
+      ),
+      'coll/{array:[3,foo],int:3}'
+    );
+    await verifyResults(
+      queryWithLimit(
+        queryWithAddedOrderBy(
+          queryWithAddedOrderBy(q, orderBy('a')),
+          orderBy('b')
+        ),
+        1,
+        LimitType.First
+      ),
+      'coll/{a:0,b:0}'
+    );
+    await verifyResults(
+      queryWithLimit(
+        queryWithAddedOrderBy(
+          queryWithAddedOrderBy(q, orderBy('a', 'desc')),
+          orderBy('b')
+        ),
+        1,
+        LimitType.First
+      ),
+      'coll/{a:2,b:0}'
+    );
+    await verifyResults(
+      queryWithLimit(
+        queryWithAddedOrderBy(
+          queryWithAddedOrderBy(q, orderBy('a')),
+          orderBy('b', 'desc')
+        ),
+        1,
+        LimitType.First
+      ),
+      'coll/{a:0,b:1}'
+    );
+    await verifyResults(
+      queryWithLimit(
+        queryWithAddedOrderBy(
+          queryWithAddedOrderBy(q, orderBy('a', 'desc')),
+          orderBy('b', 'desc')
+        ),
+        1,
+        LimitType.First
+      ),
+      'coll/{a:2,b:1}'
+    );
+    await verifyResults(
+      queryWithAddedFilter(
+        queryWithAddedFilter(q, filter('a', '>', 0)),
+        filter('b', '==', 1)
+      ),
+      'coll/{a:1,b:1}',
+      'coll/{a:2,b:1}'
+    );
+    await verifyResults(
+      queryWithAddedFilter(
+        queryWithAddedFilter(q, filter('a', '==', 1)),
+        filter('b', '==', 1)
+      ),
+      'coll/{a:1,b:1}'
+    );
+    await verifyResults(
+      queryWithAddedFilter(
+        queryWithAddedFilter(q, filter('a', '!=', 0)),
+        filter('b', '==', 1)
+      ),
+      'coll/{a:1,b:1}',
+      'coll/{a:2,b:1}'
+    );
+    await verifyResults(
+      queryWithAddedFilter(
+        queryWithAddedFilter(q, filter('b', '==', 1)),
+        filter('a', '!=', 0)
+      ),
+      'coll/{a:1,b:1}',
+      'coll/{a:2,b:1}'
+    );
+    await verifyResults(
+      queryWithAddedFilter(q, filter('a', 'not-in', [0, 1])),
+      'coll/{a:2,b:0}',
+      'coll/{a:2,b:1}'
+    );
+    await verifyResults(
+      queryWithAddedFilter(
+        queryWithAddedFilter(q, filter('a', 'not-in', [0, 1])),
+        filter('b', '==', 1)
+      ),
+      'coll/{a:2,b:1}'
+    );
+    await verifyResults(
+      queryWithAddedFilter(
+        queryWithAddedFilter(q, filter('b', '==', 1)),
+        filter('a', 'not-in', [0, 1])
+      ),
+      'coll/{a:2,b:1}'
+    );
+    await verifyResults(
+      queryWithAddedFilter(q, filter('null', '==', null)),
+      'coll/{null:null}'
+    );
+    await verifyResults(
+      queryWithAddedOrderBy(q, orderBy('null')),
+      'coll/{null:null}'
+    );
+    await verifyResults(
+      queryWithAddedFilter(q, filter('prefix', '==', [1, 2])),
+      'coll/{prefix:[1,2],suffix:null}'
+    );
+    await verifyResults(
+      queryWithAddedFilter(
+        queryWithAddedFilter(q, filter('prefix', '==', [1])),
+        filter('suffix', '==', 2)
+      ),
+      'coll/{prefix:[1],suffix:2}'
+    );
+    await verifyResults(
+      queryWithAddedFilter(q, filter('map', '==', {})),
+      'coll/{map:{}}'
+    );
+    await verifyResults(
+      queryWithAddedFilter(q, filter('map', '==', { 'field': true })),
+      'coll/{map:{field:true}}'
+    );
+    await verifyResults(
+      queryWithAddedFilter(q, filter('map.field', '==', true)),
+      'coll/{map:{field:true}}'
+    );
+    await verifyResults(
+      queryWithAddedOrderBy(q, orderBy('map')),
+      'coll/{map:{}}',
+      'coll/{map:{field:true}}',
+      'coll/{map:{field:false}}'
+    );
+    await verifyResults(
+      queryWithAddedOrderBy(q, orderBy('map.field')),
+      'coll/{map:{field:true}}',
+      'coll/{map:{field:false}}'
+    );
+  });
+
+  async function setUpSingleValueFilter(): Promise<void> {
+    await indexManager.addFieldIndex(
+      fieldIndex('coll', { fields: [['count', IndexKind.ASCENDING]] })
+    );
+    await addDoc('coll/val1', { 'count': 1 });
+    await addDoc('coll/val2', { 'count': 2 });
+    await addDoc('coll/val3', { 'count': 3 });
+  }
+
+  async function setUpArrayValueFilter(): Promise<void> {
+    await indexManager.addFieldIndex(
+      fieldIndex('coll', { fields: [['values', IndexKind.CONTAINS]] })
+    );
+    await addDoc('coll/arr1', { 'values': [1, 2, 3] });
+    await addDoc('coll/arr2', { 'values': [4, 5, 6] });
+    await addDoc('coll/arr3', { 'values': [7, 8, 9] });
+  }
+
   function addDocs(...docs: Document[]): Promise<void> {
     let data = documentMap();
     for (const doc of docs) {
@@ -253,6 +1152,15 @@ describe('IndexedDbIndexManager', () => {
 
   function addDoc(key: string, data: JsonObject<unknown>): Promise<void> {
     return addDocs(doc(key, 1, data));
+  }
+
+  async function verifyResults(query: Query, ...keys: string[]): Promise<void> {
+    const target = queryToTarget(query);
+    const actualResults = await indexManager.getDocumentsMatchingTarget(target);
+    expect(actualResults).to.not.equal(null, 'Expected successful query');
+    const actualKeys: string[] = [];
+    actualResults!.forEach(v => actualKeys.push(v.path.toString()));
+    expect(actualKeys).to.have.members(keys);
   }
 });
 

--- a/packages/firestore/test/unit/local/index_manager.test.ts
+++ b/packages/firestore/test/unit/local/index_manager.test.ts
@@ -346,6 +346,27 @@ describe('IndexedDbIndexManager', async () => {
     await verifyResults(q, 'coll/val2');
   });
 
+  it('applies equals with not equals filter on same field', async () => {
+    await setUpSingleValueFilter();
+    let q = queryWithAddedFilter(
+      queryWithAddedFilter(query('coll'), filter('count', '>', 1)),
+      filter('count', '!=', 2)
+    );
+    await verifyResults(q, 'coll/val3');
+
+    q = queryWithAddedFilter(
+      queryWithAddedFilter(query('coll'), filter('count', '==', 1)),
+      filter('count', '!=', 2)
+    );
+    await verifyResults(q, 'coll/val1');
+
+    q = queryWithAddedFilter(
+      queryWithAddedFilter(query('coll'), filter('count', '==', 1)),
+      filter('count', '!=', 1)
+    );
+    await verifyResults(q);
+  });
+
   it('applies less than filter', async () => {
     await setUpSingleValueFilter();
     const q = queryWithAddedFilter(query('coll'), filter('count', '<', 2));
@@ -442,7 +463,7 @@ describe('IndexedDbIndexManager', async () => {
     await verifyResults(q, 'coll/val1', 'coll/val3');
   });
 
-  it('applies notIn filter', async () => {
+  it('applies not in filter', async () => {
     await setUpSingleValueFilter();
     const q = queryWithAddedFilter(
       query('coll'),
@@ -451,7 +472,25 @@ describe('IndexedDbIndexManager', async () => {
     await verifyResults(q, 'coll/val3');
   });
 
-  it('applies arrayContains filter', async () => {
+  it('applies not in filter with greater than filter', async () => {
+    await setUpSingleValueFilter();
+    const q = queryWithAddedFilter(
+      queryWithAddedFilter(query('coll'), filter('count', '>', 1)),
+      filter('count', 'not-in', [2])
+    );
+    await verifyResults(q, 'coll/val3');
+  });
+
+  it('applies not in filter with out of bounds greater than filter', async () => {
+    await setUpSingleValueFilter();
+    const q = queryWithAddedFilter(
+      queryWithAddedFilter(query('coll'), filter('count', '>', 2)),
+      filter('count', 'not-in', [1])
+    );
+    await verifyResults(q, 'coll/val3');
+  });
+
+  it('applies array contains filter', async () => {
     await setUpArrayValueFilter();
     const q = queryWithAddedFilter(
       query('coll'),
@@ -460,7 +499,7 @@ describe('IndexedDbIndexManager', async () => {
     await verifyResults(q, 'coll/arr1');
   });
 
-  it('applies arrayContainsAny filter', async () => {
+  it('applies array contains any filter', async () => {
     await setUpArrayValueFilter();
     const q = queryWithAddedFilter(
       query('coll'),

--- a/packages/firestore/test/unit/local/simple_db.test.ts
+++ b/packages/firestore/test/unit/local/simple_db.test.ts
@@ -242,14 +242,14 @@ describe('SimpleDb', () => {
     await runTransaction(store => {
       return store.loadAll(range).next(users => {
         const expected = testData.filter(user => user.id >= 3 && user.id <= 5);
-        expect(users.length).to.deep.equal(expected.length);
+        expect(users.length).to.equal(expected.length);
         expect(users).to.deep.equal(expected);
       });
     });
     await runTransaction(store => {
       return store.loadAll().next(users => {
         const expected = testData;
-        expect(users.length).to.deep.equal(expected.length);
+        expect(users.length).to.equal(expected.length);
         expect(users).to.deep.equal(expected);
       });
     });
@@ -257,7 +257,7 @@ describe('SimpleDb', () => {
     await runTransaction(store => {
       return store.loadAll('age-name', indexRange).next(users => {
         const expected = testData.filter(user => user.id >= 3 && user.id <= 6);
-        expect(users.length).to.deep.equal(expected.length);
+        expect(users.length).to.equal(expected.length);
         expect(users).to.deep.equal(expected);
       });
     });
@@ -270,7 +270,7 @@ describe('SimpleDb', () => {
         const expected = testData
           .filter(user => user.id >= 3 && user.id <= 5)
           .slice(0, 2);
-        expect(users.length).to.deep.equal(expected.length);
+        expect(users.length).to.equal(expected.length);
         expect(users).to.deep.equal(expected);
       });
     });
@@ -299,7 +299,7 @@ describe('SimpleDb', () => {
         })
         .next(users => {
           const expected = testData.filter(user => user.id < 3 || user.id > 5);
-          expect(users.length).to.deep.equal(expected.length);
+          expect(users.length).to.equal(expected.length);
           expect(users).to.deep.equal(expected);
         });
     });
@@ -315,7 +315,7 @@ describe('SimpleDb', () => {
         })
         .next(users => {
           const expected = testData.filter(user => user.id < 3 || user.id > 6);
-          expect(users.length).to.deep.equal(expected.length);
+          expect(users.length).to.equal(expected.length);
           expect(users).to.deep.equal(expected);
         });
     });

--- a/packages/firestore/test/unit/local/simple_db.test.ts
+++ b/packages/firestore/test/unit/local/simple_db.test.ts
@@ -263,6 +263,19 @@ describe('SimpleDb', () => {
     });
   });
 
+  it('loadFirst', async () => {
+    const range = IDBKeyRange.bound(3, 8);
+    await runTransaction(store => {
+      return store.loadFirst(range, 2).next(users => {
+        const expected = testData
+          .filter(user => user.id >= 3 && user.id <= 5)
+          .slice(0, 2);
+        expect(users.length).to.deep.equal(expected.length);
+        expect(users).to.deep.equal(expected);
+      });
+    });
+  });
+
   it('deleteAll', async () => {
     await runTransaction(store => {
       return store

--- a/packages/firestore/test/unit/local/test_index_manager.ts
+++ b/packages/firestore/test/unit/local/test_index_manager.ts
@@ -76,15 +76,11 @@ export class TestIndexManager {
     );
   }
 
-  getDocumentsMatchingTarget(
-    fieldIndex: FieldIndex,
-    target: Target
-  ): Promise<DocumentKeySet> {
+  getDocumentsMatchingTarget(target: Target): Promise<DocumentKeySet | null> {
     return this.persistence.runTransaction(
       'getDocumentsMatchingTarget',
       'readonly',
-      txn =>
-        this.indexManager.getDocumentsMatchingTarget(txn, fieldIndex, target)
+      txn => this.indexManager.getDocumentsMatchingTarget(txn, target)
     );
   }
 


### PR DESCRIPTION
This adds all index evaluation logic to the Web SDK and ports all tests from Android. The query logic is mostly the same as Android, with the exception of notIn/notEquals queries which are executed by doing scans across split ranges.

Example:

```
Query q = coll.where("a", ">", 2).where("a", "!=", 3);

Android: SELECT * FROM (SELECT * FROM coll WHERE a > 2) WHERE a != 3

Web: Scan [a>2, a<3] && [a>3, ∞]
```
