### PR TITLE
document_overlay_cache.test.ts: added a test for updating a document's overlay

### DIFF
--- a/packages/firestore/test/unit/local/document_overlay_cache.test.ts
+++ b/packages/firestore/test/unit/local/document_overlay_cache.test.ts
@@ -308,4 +308,22 @@ function genericDocumentOverlayCacheTests(): void {
     );
     verifyOverlayContains(overlays, 'coll/doc1', 'coll/doc2', 'coll/doc3');
   });
+
+  it.only('updating an overlay removes the old entry for that overlay', async () => {
+    const m1 = patchMutation('coll/doc', { 'foo': '1' });
+    const m2 = patchMutation('coll/doc', { 'foo': '2' });
+    await saveOverlaysForMutations(1, m1);
+    await saveOverlaysForMutations(2, m2);
+
+    // Verify that `getOverlay()` returns the updated mutation.
+    const overlay = await overlayCache.getOverlay(key('coll/doc'));
+    verifyEqualMutations(overlay!.mutation, m2);
+
+    // Verify that `removeOverlaysForBatchId()` removes the overlay completely.
+    await overlayCache.removeOverlaysForBatchId(
+      documentKeySet(key('coll/doc')),
+      2
+    );
+    expect(await overlayCache.getOverlay(key('coll/doc'))).to.equal(null);
+  });
 }

--- a/packages/firestore/test/unit/local/document_overlay_cache.test.ts
+++ b/packages/firestore/test/unit/local/document_overlay_cache.test.ts
@@ -309,7 +309,7 @@ function genericDocumentOverlayCacheTests(): void {
     verifyOverlayContains(overlays, 'coll/doc1', 'coll/doc2', 'coll/doc3');
   });
 
-  it.only('updating an overlay removes the old entry for that overlay', async () => {
+  it('updating an overlay removes the old entry for that overlay', async () => {
     const m1 = patchMutation('coll/doc', { 'foo': '1' });
     const m2 = patchMutation('coll/doc', { 'foo': '2' });
     await saveOverlaysForMutations(1, m1);


### PR DESCRIPTION
This test was ported from https://github.com/firebase/firebase-ios-sdk/commit/cf04e6740bd371738cd62bed71498838a259e3db, part of https://github.com/firebase/firebase-ios-sdk/pull/9345.