### PR TITLE
Use ObjectMap instead of Map with proper comparator.

### DIFF
--- a/packages/firestore/src/local/document_overlay_cache.ts
+++ b/packages/firestore/src/local/document_overlay_cache.ts
@@ -15,9 +15,12 @@
  * limitations under the License.
  */
 
-import { DocumentKeySet } from '../model/collections';
+import {
+  DocumentKeySet,
+  DocumentKeyToMutationMap,
+  DocumentKeyToOverlayMap
+} from '../model/collections';
 import { DocumentKey } from '../model/document_key';
-import { Mutation } from '../model/mutation';
 import { Overlay } from '../model/overlay';
 import { ResourcePath } from '../model/path';
 
@@ -51,7 +54,7 @@ export interface DocumentOverlayCache {
   saveOverlays(
     transaction: PersistenceTransaction,
     largestBatchId: number,
-    overlays: Map<DocumentKey, Mutation>
+    overlays: DocumentKeyToMutationMap
   ): PersistencePromise<void>;
 
   /** Removes overlays for the given document keys and batch ID. */
@@ -74,7 +77,7 @@ export interface DocumentOverlayCache {
     transaction: PersistenceTransaction,
     collection: ResourcePath,
     sinceBatchId: number
-  ): PersistencePromise<Map<DocumentKey, Overlay>>;
+  ): PersistencePromise<DocumentKeyToOverlayMap>;
 
   /**
    * Returns `count` overlays with a batch ID higher than `sinceBatchId` for the
@@ -95,5 +98,5 @@ export interface DocumentOverlayCache {
     collectionGroup: string,
     sinceBatchId: number,
     count: number
-  ): PersistencePromise<Map<DocumentKey, Overlay>>;
+  ): PersistencePromise<DocumentKeyToOverlayMap>;
 }

--- a/packages/firestore/src/model/collections.ts
+++ b/packages/firestore/src/model/collections.ts
@@ -18,11 +18,14 @@
 import { SnapshotVersion } from '../core/snapshot_version';
 import { TargetId } from '../core/types';
 import { primitiveComparator } from '../util/misc';
+import { ObjectMap } from '../util/obj_map';
 import { SortedMap } from '../util/sorted_map';
 import { SortedSet } from '../util/sorted_set';
 
 import { Document, MutableDocument } from './document';
 import { DocumentKey } from './document_key';
+import { Mutation } from './mutation';
+import { Overlay } from './overlay';
 
 /** Miscellaneous collection types / constants. */
 
@@ -45,6 +48,22 @@ const EMPTY_DOCUMENT_MAP = new SortedMap<DocumentKey, Document>(
 );
 export function documentMap(): DocumentMap {
   return EMPTY_DOCUMENT_MAP;
+}
+
+export type DocumentKeyToOverlayMap = ObjectMap<DocumentKey, Overlay>;
+export function newDocumentKeyToOverlayMap(): DocumentKeyToOverlayMap {
+  return new ObjectMap<DocumentKey, Overlay>(
+    key => key.toString(),
+    (l, r) => l.isEqual(r)
+  );
+}
+
+export type DocumentKeyToMutationMap = ObjectMap<DocumentKey, Mutation>;
+export function newDocumentKeyToMutationMap(): DocumentKeyToMutationMap {
+  return new ObjectMap<DocumentKey, Mutation>(
+    key => key.toString(),
+    (l, r) => l.isEqual(r)
+  );
 }
 
 export type DocumentVersionMap = SortedMap<DocumentKey, SnapshotVersion>;

--- a/packages/firestore/src/util/obj_map.ts
+++ b/packages/firestore/src/util/obj_map.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { forEach, isEmpty } from './obj';
+import { forEach, isEmpty, objectSize } from './obj';
 
 type Entry<K, V> = [K, V];
 
@@ -109,5 +109,9 @@ export class ObjectMap<KeyType, ValueType> {
 
   isEmpty(): boolean {
     return isEmpty(this.inner);
+  }
+
+  size(): number {
+    return objectSize(this.inner);
   }
 }

--- a/packages/firestore/test/unit/local/test_document_overlay_cache.ts
+++ b/packages/firestore/test/unit/local/test_document_overlay_cache.ts
@@ -17,7 +17,11 @@
 
 import { DocumentOverlayCache } from '../../../src/local/document_overlay_cache';
 import { Persistence } from '../../../src/local/persistence';
-import { DocumentKeySet } from '../../../src/model/collections';
+import {
+  DocumentKeySet,
+  DocumentKeyToMutationMap,
+  DocumentKeyToOverlayMap
+} from '../../../src/model/collections';
 import { DocumentKey } from '../../../src/model/document_key';
 import { Mutation } from '../../../src/model/mutation';
 import { Overlay } from '../../../src/model/overlay';
@@ -36,7 +40,7 @@ export class TestDocumentOverlayCache {
 
   saveOverlays(
     largestBatch: number,
-    data: Map<DocumentKey, Mutation>
+    data: DocumentKeyToMutationMap
   ): Promise<void> {
     return this.persistence.runTransaction('saveOverlays', 'readwrite', txn => {
       return this.cache.saveOverlays(txn, largestBatch, data);
@@ -61,7 +65,7 @@ export class TestDocumentOverlayCache {
   getOverlaysForCollection(
     path: ResourcePath,
     sinceBatchId: number
-  ): Promise<Map<DocumentKey, Overlay>> {
+  ): Promise<DocumentKeyToOverlayMap> {
     return this.persistence.runTransaction(
       'getOverlaysForCollection',
       'readonly',
@@ -75,7 +79,7 @@ export class TestDocumentOverlayCache {
     collectionGroup: string,
     sinceBatchId: number,
     count: number
-  ): Promise<Map<DocumentKey, Overlay>> {
+  ): Promise<DocumentKeyToOverlayMap> {
     return this.persistence.runTransaction(
       'getOverlaysForCollectionGroup',
       'readonly',


### PR DESCRIPTION
I used `Map` and `Set` in PR #5969, but these data structures use reference comparison for the keys instead of using the object's comparator function. This PR fixes this by using `ObjectMap` and `SortedSet`.