### PR TITLE
Use interfaces for IndexedDB

### DIFF
--- a/packages/firestore/src/local/indexeddb_bundle_cache.ts
+++ b/packages/firestore/src/local/indexeddb_bundle_cache.ts
@@ -22,12 +22,13 @@ import {
 } from '../protos/firestore_bundle_proto';
 
 import { BundleCache } from './bundle_cache';
+import { DbBundle, DbNamedQuery } from './indexeddb_schema';
 import {
-  DbBundle,
   DbBundlesKey,
+  DbBundleStore,
   DbNamedQueriesKey,
-  DbNamedQuery
-} from './indexeddb_schema';
+  DbNamedQueryStore
+} from './indexeddb_sentinels';
 import { getStore } from './indexeddb_transaction';
 import {
   fromDbBundle,
@@ -89,7 +90,7 @@ export class IndexedDbBundleCache implements BundleCache {
 function bundlesStore(
   txn: PersistenceTransaction
 ): SimpleDbStore<DbBundlesKey, DbBundle> {
-  return getStore<DbBundlesKey, DbBundle>(txn, DbBundle.store);
+  return getStore<DbBundlesKey, DbBundle>(txn, DbBundleStore);
 }
 
 /**
@@ -98,5 +99,5 @@ function bundlesStore(
 function namedQueriesStore(
   txn: PersistenceTransaction
 ): SimpleDbStore<DbNamedQueriesKey, DbNamedQuery> {
-  return getStore<DbNamedQueriesKey, DbNamedQuery>(txn, DbNamedQuery.store);
+  return getStore<DbNamedQueriesKey, DbNamedQuery>(txn, DbNamedQueryStore);
 }

--- a/packages/firestore/src/local/indexeddb_document_overlay_cache.ts
+++ b/packages/firestore/src/local/indexeddb_document_overlay_cache.ts
@@ -24,7 +24,13 @@ import { ResourcePath } from '../model/path';
 
 import { DocumentOverlayCache } from './document_overlay_cache';
 import { encodeResourcePath } from './encoded_resource_path';
-import { DbDocumentOverlay, DbDocumentOverlayKey } from './indexeddb_schema';
+import { DbDocumentOverlay } from './indexeddb_schema';
+import {
+  DbDocumentOverlayCollectionGroupOverlayIndex,
+  DbDocumentOverlayCollectionPathOverlayIndex,
+  DbDocumentOverlayKey,
+  DbDocumentOverlayStore
+} from './indexeddb_sentinels';
 import { getStore } from './indexeddb_transaction';
 import {
   fromDbDocumentOverlay,
@@ -106,7 +112,7 @@ export class IndexedDbDocumentOverlayCache implements DocumentOverlayCache {
       );
       promises.push(
         documentOverlayStore(transaction).deleteAll(
-          DbDocumentOverlay.collectionPathOverlayIndex,
+          DbDocumentOverlayCollectionPathOverlayIndex,
           range
         )
       );
@@ -129,7 +135,7 @@ export class IndexedDbDocumentOverlayCache implements DocumentOverlayCache {
       /*lowerOpen=*/ true
     );
     return documentOverlayStore(transaction)
-      .loadAll(DbDocumentOverlay.collectionPathOverlayIndex, range)
+      .loadAll(DbDocumentOverlayCollectionPathOverlayIndex, range)
       .next(dbOverlays => {
         for (const dbOverlay of dbOverlays) {
           const overlay = fromDbDocumentOverlay(this.serializer, dbOverlay);
@@ -157,7 +163,7 @@ export class IndexedDbDocumentOverlayCache implements DocumentOverlayCache {
     return documentOverlayStore(transaction)
       .iterate(
         {
-          index: DbDocumentOverlay.collectionGroupOverlayIndex,
+          index: DbDocumentOverlayCollectionGroupOverlayIndex,
           range
         },
         (_, dbOverlay, control) => {
@@ -198,6 +204,6 @@ function documentOverlayStore(
 ): SimpleDbStore<DbDocumentOverlayKey, DbDocumentOverlay> {
   return getStore<DbDocumentOverlayKey, DbDocumentOverlay>(
     txn,
-    DbDocumentOverlay.store
+    DbDocumentOverlayStore
   );
 }

--- a/packages/firestore/src/local/indexeddb_index_manager.ts
+++ b/packages/firestore/src/local/indexeddb_index_manager.ts
@@ -64,14 +64,23 @@ import {
 import { IndexManager } from './index_manager';
 import {
   DbCollectionParent,
-  DbCollectionParentKey,
   DbIndexConfiguration,
-  DbIndexConfigurationKey,
   DbIndexEntry,
-  DbIndexEntryKey,
-  DbIndexState,
-  DbIndexStateKey
+  DbIndexState
 } from './indexeddb_schema';
+import {
+  DbCollectionParentKey,
+  DbCollectionParentStore,
+  DbIndexConfigurationCollectionGroupIndex,
+  DbIndexConfigurationKey,
+  DbIndexConfigurationStore,
+  DbIndexEntryDocumentKeyIndex,
+  DbIndexEntryKey,
+  DbIndexEntryStore,
+  DbIndexStateKey,
+  DbIndexStateSequenceNumberIndex,
+  DbIndexStateStore
+} from './indexeddb_sentinels';
 import { getStore } from './indexeddb_transaction';
 import {
   fromDbIndexConfiguration,
@@ -311,7 +320,7 @@ export class IndexedDbIndexManager implements IndexManager {
   }
 
   /**
-   * Constructs a key range query on `DbIndexEntry.store` that unions all
+   * Constructs a key range query on `DbIndexEntryStore` that unions all
    * bounds.
    */
   private generateIndexRanges(
@@ -586,7 +595,7 @@ export class IndexedDbIndexManager implements IndexManager {
     return (
       collectionGroup
         ? indexes.loadAll(
-            DbIndexConfiguration.collectionGroupIndex,
+            DbIndexConfigurationCollectionGroupIndex,
             IDBKeyRange.bound(collectionGroup, collectionGroup)
           )
         : indexes.loadAll()
@@ -629,7 +638,7 @@ export class IndexedDbIndexManager implements IndexManager {
     return this.getNextSequenceNumber(transaction).next(nextSequenceNumber =>
       indexes
         .loadAll(
-          DbIndexConfiguration.collectionGroupIndex,
+          DbIndexConfigurationCollectionGroupIndex,
           IDBKeyRange.bound(collectionGroup, collectionGroup)
         )
         .next(configs =>
@@ -698,15 +707,13 @@ export class IndexedDbIndexManager implements IndexManager {
     indexEntry: IndexEntry
   ): PersistencePromise<void> {
     const indexEntries = indexEntriesStore(transaction);
-    return indexEntries.put(
-      new DbIndexEntry(
-        indexEntry.indexId,
-        this.uid,
-        indexEntry.arrayValue,
-        indexEntry.directionalValue,
-        encodeResourcePath(document.key.path)
-      )
-    );
+    return indexEntries.put({
+      indexId: indexEntry.indexId,
+      uid: this.uid,
+      arrayValue: indexEntry.arrayValue,
+      directionalValue: indexEntry.directionalValue,
+      documentKey: encodeResourcePath(document.key.path)
+    });
   }
 
   private deleteIndexEntry(
@@ -734,7 +741,7 @@ export class IndexedDbIndexManager implements IndexManager {
     return indexEntries
       .iterate(
         {
-          index: DbIndexEntry.documentKeyIndex,
+          index: DbIndexEntryDocumentKeyIndex,
           range: IDBKeyRange.only([
             fieldIndex.indexId,
             this.uid,
@@ -836,7 +843,7 @@ export class IndexedDbIndexManager implements IndexManager {
     return states
       .iterate(
         {
-          index: DbIndexState.sequenceNumberIndex,
+          index: DbIndexStateSequenceNumberIndex,
           reverse: true,
           range: IDBKeyRange.upperBound([this.uid, Number.MAX_SAFE_INTEGER])
         },
@@ -921,7 +928,7 @@ function collectionParentsStore(
 ): SimpleDbStore<DbCollectionParentKey, DbCollectionParent> {
   return getStore<DbCollectionParentKey, DbCollectionParent>(
     txn,
-    DbCollectionParent.store
+    DbCollectionParentStore
   );
 }
 
@@ -931,7 +938,7 @@ function collectionParentsStore(
 function indexEntriesStore(
   txn: PersistenceTransaction
 ): SimpleDbStore<DbIndexEntryKey, DbIndexEntry> {
-  return getStore<DbIndexEntryKey, DbIndexEntry>(txn, DbIndexEntry.store);
+  return getStore<DbIndexEntryKey, DbIndexEntry>(txn, DbIndexEntryStore);
 }
 
 /**
@@ -942,7 +949,7 @@ function indexConfigurationStore(
 ): SimpleDbStore<DbIndexConfigurationKey, DbIndexConfiguration> {
   return getStore<DbIndexConfigurationKey, DbIndexConfiguration>(
     txn,
-    DbIndexConfiguration.store
+    DbIndexConfigurationStore
   );
 }
 
@@ -952,5 +959,5 @@ function indexConfigurationStore(
 function indexStateStore(
   txn: PersistenceTransaction
 ): SimpleDbStore<DbIndexStateKey, DbIndexState> {
-  return getStore<DbIndexStateKey, DbIndexState>(txn, DbIndexState.store);
+  return getStore<DbIndexStateKey, DbIndexState>(txn, DbIndexStateStore);
 }

--- a/packages/firestore/src/local/indexeddb_lru_delegate_impl.ts
+++ b/packages/firestore/src/local/indexeddb_lru_delegate_impl.ts
@@ -28,6 +28,7 @@ import {
 import { IndexedDbLruDelegate } from './indexeddb_lru_delegate';
 import { mutationQueuesContainKey } from './indexeddb_mutation_queue';
 import { DbTargetDocument } from './indexeddb_schema';
+import { DbTargetDocumentDocumentTargetsIndex } from './indexeddb_sentinels';
 import {
   documentTargetStore,
   IndexedDbTargetCache
@@ -201,7 +202,7 @@ export class IndexedDbLruDelegateImpl implements IndexedDbLruDelegate {
     return store
       .iterate(
         {
-          index: DbTargetDocument.documentTargetsIndex
+          index: DbTargetDocumentDocumentTargetsIndex
         },
         ([targetId, docKey], { path, sequenceNumber }) => {
           if (targetId === 0) {
@@ -250,7 +251,7 @@ function sentinelRow(
   key: DocumentKey,
   sequenceNumber: ListenSequenceNumber
 ): DbTargetDocument {
-  return new DbTargetDocument(0, encodeResourcePath(key.path), sequenceNumber);
+  return { targetId: 0, path: encodeResourcePath(key.path), sequenceNumber };
 }
 
 function writeSentinelKey(

--- a/packages/firestore/src/local/indexeddb_mutation_batch_impl.ts
+++ b/packages/firestore/src/local/indexeddb_mutation_batch_impl.ts
@@ -20,11 +20,16 @@ import { fail, hardAssert } from '../util/assert';
 
 import {
   DbDocumentMutation,
-  DbDocumentMutationKey,
   DbMutationBatch,
-  DbMutationBatchKey,
   DbRemoteDocument
 } from './indexeddb_schema';
+import {
+  DbDocumentMutationKey,
+  DbDocumentMutationStore,
+  DbMutationBatchKey,
+  DbMutationBatchStore,
+  newDbDocumentMutationKey
+} from './indexeddb_sentinels';
 import { PersistencePromise } from './persistence_promise';
 import { SimpleDbTransaction } from './simple_db';
 
@@ -38,10 +43,10 @@ export function removeMutationBatch(
   batch: { batchId: number; mutations: Array<{ key: DocumentKey }> }
 ): PersistencePromise<DocumentKey[]> {
   const mutationStore = txn.store<DbMutationBatchKey, DbMutationBatch>(
-    DbMutationBatch.store
+    DbMutationBatchStore
   );
   const indexTxn = txn.store<DbDocumentMutationKey, DbDocumentMutation>(
-    DbDocumentMutation.store
+    DbDocumentMutationStore
   );
   const promises: Array<PersistencePromise<void>> = [];
 
@@ -65,7 +70,7 @@ export function removeMutationBatch(
   );
   const removedDocuments: DocumentKey[] = [];
   for (const mutation of batch.mutations) {
-    const indexKey = DbDocumentMutation.key(
+    const indexKey = newDbDocumentMutationKey(
       userId,
       mutation.key.path,
       batch.batchId

--- a/packages/firestore/src/local/indexeddb_sentinels.ts
+++ b/packages/firestore/src/local/indexeddb_sentinels.ts
@@ -1,0 +1,395 @@
+/**
+ * @license
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { BatchId, TargetId } from '../core/types';
+import { ResourcePath } from '../model/path';
+import { fail } from '../util/assert';
+
+import {
+  EncodedResourcePath,
+  encodeResourcePath
+} from './encoded_resource_path';
+import { DbDocumentMutation } from './indexeddb_schema';
+
+// This file contains static constants and helper functions for IndexedDB.
+// It is split from indexeddb_schema to allow for minification.
+
+/** A timestamp type that can be used in IndexedDb keys. */
+export type DbTimestampKey = [/* seconds */ number, /* nanos */ number];
+
+// The key for the singleton object in the DbPrimaryClient is a single string.
+export type DbPrimaryClientKey = typeof DbPrimaryClientKey;
+
+/**
+ * Name of the IndexedDb object store.
+ *
+ * Note that the name 'owner' is chosen to ensure backwards compatibility with
+ * older clients that only supported single locked access to the persistence
+ * layer.
+ */
+export const DbPrimaryClientStore = 'owner';
+
+/**
+ * The key string used for the single object that exists in the
+ * DbPrimaryClient store.
+ */
+
+export const DbPrimaryClientKey = 'owner';
+
+/** Object keys in the 'mutationQueues' store are userId strings. */
+export type DbMutationQueueKey = string;
+
+/** Name of the IndexedDb object store.  */
+export const DbMutationQueueStore = 'mutationQueues';
+
+/** Keys are automatically assigned via the userId property. */
+export const DbMutationQueueKeyPath = 'userId';
+
+/** The 'mutations' store  is keyed by batch ID. */
+export type DbMutationBatchKey = BatchId;
+
+/** Name of the IndexedDb object store.  */
+export const DbMutationBatchStore = 'mutations';
+
+/** Keys are automatically assigned via the userId, batchId properties. */
+export const DbMutationBatchKeyPath = 'batchId';
+
+/** The index name for lookup of mutations by user. */
+
+export const DbMutationBatchUserMutationsIndex = 'userMutationsIndex';
+
+/** The user mutations index is keyed by [userId, batchId] pairs. */
+export const DbMutationBatchUserMutationsKeyPath = ['userId', 'batchId'];
+
+/**
+ * The key for a db document mutation, which is made up of a userID, path, and
+ * batchId. Note that the path must be serialized into a form that indexedDB can
+ * sort.
+ */
+export type DbDocumentMutationKey = [string, EncodedResourcePath, BatchId];
+
+/**
+ * Creates a [userId] key for use in the DbDocumentMutations index to iterate
+ * over all of a user's document mutations.
+ */
+export function newDbDocumentMutationPrefixForUser(userId: string): [string] {
+  return [userId];
+}
+
+/**
+ * Creates a [userId, encodedPath] key for use in the DbDocumentMutations
+ * index to iterate over all at document mutations for a given path or lower.
+ */
+export function newDbDocumentMutationPrefixForPath(
+  userId: string,
+  path: ResourcePath
+): [string, EncodedResourcePath] {
+  return [userId, encodeResourcePath(path)];
+}
+
+/**
+ * Creates a full index key of [userId, encodedPath, batchId] for inserting
+ * and deleting into the DbDocumentMutations index.
+ */
+export function newDbDocumentMutationKey(
+  userId: string,
+  path: ResourcePath,
+  batchId: BatchId
+): DbDocumentMutationKey {
+  return [userId, encodeResourcePath(path), batchId];
+}
+
+/**
+ * Because we store all the useful information for this store in the key,
+ * there is no useful information to store as the value. The raw (unencoded)
+ * path cannot be stored because IndexedDb doesn't store prototype
+ * information.
+ */
+export const DbDocumentMutationPlaceholder: DbDocumentMutation = {};
+
+export const DbDocumentMutationStore = 'documentMutations';
+
+export const DbRemoteDocumentStore = 'remoteDocuments';
+
+/**
+ * An index that provides access to all entries sorted by read time (which
+ * corresponds to the last modification time of each row).
+ *
+ * This index is used to provide a changelog for Multi-Tab.
+ */
+export const DbRemoteDocumentReadTimeIndex = 'readTimeIndex';
+
+export const DbRemoteDocumentReadTimeIndexPath = 'readTime';
+
+/**
+ * An index that provides access to documents in a collection sorted by read
+ * time.
+ *
+ * This index is used to allow the RemoteDocumentCache to fetch newly changed
+ * documents in a collection.
+ */
+export const DbRemoteDocumentCollectionReadTimeIndex =
+  'collectionReadTimeIndex';
+
+export const DbRemoteDocumentCollectionReadTimeIndexPath = [
+  'parentPath',
+  'readTime'
+];
+
+export const DbRemoteDocumentGlobalStore = 'remoteDocumentGlobal';
+
+export const DbRemoteDocumentGlobalKey = 'remoteDocumentGlobalKey';
+
+export type DbRemoteDocumentGlobalKey = typeof DbRemoteDocumentGlobalKey;
+
+/**
+ * A key in the 'targets' object store is a targetId of the query.
+ */
+export type DbTargetKey = TargetId;
+
+export const DbTargetStore = 'targets';
+
+/** Keys are automatically assigned via the targetId property. */
+export const DbTargetKeyPath = 'targetId';
+
+/** The name of the queryTargets index. */
+export const DbTargetQueryTargetsIndexName = 'queryTargetsIndex';
+
+/**
+ * The index of all canonicalIds to the targets that they match. This is not
+ * a unique mapping because canonicalId does not promise a unique name for all
+ * possible queries, so we append the targetId to make the mapping unique.
+ */
+export const DbTargetQueryTargetsKeyPath = ['canonicalId', 'targetId'];
+
+/**
+ * The key for a DbTargetDocument, containing a targetId and an encoded resource
+ * path.
+ */
+export type DbTargetDocumentKey = [TargetId, EncodedResourcePath];
+
+/** Name of the IndexedDb object store.  */
+export const DbTargetDocumentStore = 'targetDocuments';
+
+/** Keys are automatically assigned via the targetId, path properties. */
+export const DbTargetDocumentKeyPath = ['targetId', 'path'];
+
+/** The index name for the reverse index. */
+export const DbTargetDocumentDocumentTargetsIndex = 'documentTargetsIndex';
+
+/** We also need to create the reverse index for these properties. */
+export const DbTargetDocumentDocumentTargetsKeyPath = ['path', 'targetId'];
+
+/**
+ * The type to represent the single allowed key for the DbTargetGlobal store.
+ */
+export type DbTargetGlobalKey = typeof DbTargetGlobalKey;
+/**
+ * The key string used for the single object that exists in the
+ * DbTargetGlobal store.
+ */
+export const DbTargetGlobalKey = 'targetGlobalKey';
+
+export const DbTargetGlobalStore = 'targetGlobal';
+
+/**
+ * The key for a DbCollectionParent entry, containing the collection ID
+ * and the parent path that contains it. Note that the parent path will be an
+ * empty path in the case of root-level collections.
+ */
+export type DbCollectionParentKey = [string, EncodedResourcePath];
+
+/** Name of the IndexedDb object store. */
+export const DbCollectionParentStore = 'collectionParents';
+
+/** Keys are automatically assigned via the collectionId, parent properties. */
+export const DbCollectionParentKeyPath = ['collectionId', 'parent'];
+
+/** Name of the IndexedDb object store. */
+export const DbClientMetadataStore = 'clientMetadata';
+
+/** Keys are automatically assigned via the clientId properties. */
+export const DbClientMetadataKeyPath = 'clientId';
+
+/** Object keys in the 'clientMetadata' store are clientId strings. */
+export type DbClientMetadataKey = string;
+
+export type DbBundlesKey = string;
+
+/** Name of the IndexedDb object store. */
+export const DbBundleStore = 'bundles';
+
+export const DbBundleKeyPath = 'bundleId';
+
+export type DbNamedQueriesKey = string;
+
+/** Name of the IndexedDb object store. */
+export const DbNamedQueryStore = 'namedQueries';
+
+export const DbNamedQueryKeyPath = 'name';
+
+/** The key for each index consisting of just the index id. */
+export type DbIndexConfigurationKey = number;
+
+/** Name of the IndexedDb object store. */
+export const DbIndexConfigurationStore = 'indexConfiguration';
+
+export const DbIndexConfigurationKeyPath = 'indexId';
+
+/**
+ * An index that provides access to the index configurations by collection
+ * group.
+ *
+ * PORTING NOTE: iOS and Android maintain this index in-memory, but this is
+ * not possible here as the Web client supports concurrent access to
+ * persistence via multi-tab.
+ */
+export const DbIndexConfigurationCollectionGroupIndex = 'collectionGroupIndex';
+
+export const DbIndexConfigurationCollectionGroupIndexPath = 'collectionGroup';
+
+/** The key for each index state consisting of the index id and its user id. */
+export type DbIndexStateKey = [number, string];
+
+/** Name of the IndexedDb object store. */
+export const DbIndexStateStore = 'indexState';
+
+export const DbIndexStateKeyPath = ['indexId', 'uid'];
+
+/**
+ * An index that provides access to documents in a collection sorted by last
+ * update time. Used by the backfiller.
+ *
+ * PORTING NOTE: iOS and Android maintain this index in-memory, but this is
+ * not possible here as the Web client supports concurrent access to
+ * persistence via multi-tab.
+ */
+export const DbIndexStateSequenceNumberIndex = 'sequenceNumberIndex';
+
+export const DbIndexStateSequenceNumberIndexPath = ['uid', 'sequenceNumber'];
+
+/**
+ * The key for each index entry consists of the index id and its user id,
+ * the encoded array and directional value for the indexed fields as well as
+ * the encoded document path for the indexed document.
+ */
+export type DbIndexEntryKey = [number, string, Uint8Array, Uint8Array, string];
+
+/** Name of the IndexedDb object store. */
+export const DbIndexEntryStore = 'indexEntries';
+
+export const DbIndexEntryKeyPath = [
+  'indexId',
+  'uid',
+  'arrayValue',
+  'directionalValue',
+  'documentKey'
+];
+
+export const DbIndexEntryDocumentKeyIndex = 'documentKeyIndex';
+
+export const DbIndexEntryDocumentKeyIndexPath = [
+  'indexId',
+  'uid',
+  'documentKey'
+];
+
+export type DbDocumentOverlayKey = [
+  /* userId */ string,
+  /* collectionPath */ string,
+  /* documentId */ string
+];
+
+/** Name of the IndexedDb object store. */
+export const DbDocumentOverlayStore = 'documentOverlays';
+
+export const DbDocumentOverlayKeyPath = [
+  'userId',
+  'collectionPath',
+  'documentId'
+];
+
+export const DbDocumentOverlayCollectionPathOverlayIndex =
+  'collectionPathOverlayIndex';
+
+export const DbDocumentOverlayCollectionPathOverlayIndexPath = [
+  'userId',
+  'collectionPath',
+  'largestBatchId'
+];
+
+export const DbDocumentOverlayCollectionGroupOverlayIndex =
+  'collectionGroupOverlayIndex';
+
+export const DbDocumentOverlayCollectionGroupOverlayIndexPath = [
+  'userId',
+  'collectionGroup',
+  'largestBatchId'
+];
+
+// Visible for testing
+export const V1_STORES = [
+  DbMutationQueueStore,
+  DbMutationBatchStore,
+  DbDocumentMutationStore,
+  DbRemoteDocumentStore,
+  DbTargetStore,
+  DbPrimaryClientStore,
+  DbTargetGlobalStore,
+  DbTargetDocumentStore
+];
+
+// Visible for testing
+export const V3_STORES = V1_STORES;
+// Note: DbRemoteDocumentChanges is no longer used and dropped with v9.
+export const V4_STORES = [...V3_STORES, DbClientMetadataStore];
+export const V6_STORES = [...V4_STORES, DbRemoteDocumentGlobalStore];
+export const V8_STORES = [...V6_STORES, DbCollectionParentStore];
+export const V11_STORES = [...V8_STORES, DbBundleStore, DbNamedQueryStore];
+export const V12_STORES = [...V11_STORES, DbDocumentOverlayStore];
+export const V13_STORES = [
+  ...V12_STORES,
+  DbIndexConfigurationStore,
+  DbIndexStateStore,
+  DbIndexEntryStore
+];
+
+/**
+ * The list of all default IndexedDB stores used throughout the SDK. This is
+ * used when creating transactions so that access across all stores is done
+ * atomically.
+ */
+export const ALL_STORES = V12_STORES;
+
+/** Returns the object stores for the provided schema. */
+export function getObjectStores(schemaVersion: number): string[] {
+  if (schemaVersion === 13) {
+    return V13_STORES;
+  } else if (schemaVersion === 12) {
+    return V12_STORES;
+  } else if (schemaVersion === 11) {
+    return V11_STORES;
+  } else {
+    fail('Only schema version 11 and 12 and 13 are supported');
+  }
+}
+
+/**
+ * A key in the 'remoteDocuments' object store is a string array containing the
+ * segments that make up the path.
+ */
+export type DbRemoteDocumentKey = string[];

--- a/packages/firestore/test/unit/local/indexeddb_persistence.test.ts
+++ b/packages/firestore/test/unit/local/indexeddb_persistence.test.ts
@@ -86,9 +86,7 @@ import { ClientId } from '../../../src/local/shared_client_state';
 import { SimpleDb, SimpleDbTransaction } from '../../../src/local/simple_db';
 import { TargetData, TargetPurpose } from '../../../src/local/target_data';
 import { getWindow } from '../../../src/platform/dom';
-import {
-  firestoreV1ApiClientInterfaces
-} from '../../../src/protos/firestore_proto_api';
+import { firestoreV1ApiClientInterfaces } from '../../../src/protos/firestore_proto_api';
 import { JsonProtoSerializer } from '../../../src/remote/serializer';
 import { AsyncQueue, TimerId } from '../../../src/util/async_queue';
 import {

--- a/packages/firestore/test/unit/local/indexeddb_persistence.test.ts
+++ b/packages/firestore/test/unit/local/indexeddb_persistence.test.ts
@@ -29,27 +29,43 @@ import {
 import { IndexedDbPersistence } from '../../../src/local/indexeddb_persistence';
 import {
   DbCollectionParent,
-  DbCollectionParentKey,
   DbDocumentMutation,
-  DbDocumentMutationKey,
   DbMutationBatch,
-  DbMutationBatchKey,
   DbMutationQueue,
-  DbMutationQueueKey,
   DbPrimaryClient,
-  DbPrimaryClientKey,
   DbRemoteDocument,
   DbRemoteDocumentGlobal,
-  DbRemoteDocumentGlobalKey,
-  DbRemoteDocumentKey,
   DbTarget,
   DbTargetDocument,
-  DbTargetDocumentKey,
   DbTargetGlobal,
+  SCHEMA_VERSION
+} from '../../../src/local/indexeddb_schema';
+import { SchemaConverter } from '../../../src/local/indexeddb_schema_converter';
+import {
+  DbCollectionParentKey,
+  DbCollectionParentStore,
+  DbDocumentMutationKey,
+  DbDocumentMutationPlaceholder,
+  DbDocumentMutationStore,
+  DbMutationBatchKey,
+  DbMutationBatchStore,
+  DbMutationQueueKey,
+  DbMutationQueueStore,
+  DbPrimaryClientKey,
+  DbPrimaryClientStore,
+  DbRemoteDocumentCollectionReadTimeIndex,
+  DbRemoteDocumentGlobalKey,
+  DbRemoteDocumentGlobalStore,
+  DbRemoteDocumentKey,
+  DbRemoteDocumentReadTimeIndex,
+  DbRemoteDocumentStore,
+  DbTargetDocumentKey,
+  DbTargetDocumentStore,
   DbTargetGlobalKey,
+  DbTargetGlobalStore,
   DbTargetKey,
-  DbTimestamp,
-  SCHEMA_VERSION,
+  DbTargetStore,
+  newDbDocumentMutationKey,
   V12_STORES,
   V13_STORES,
   V1_STORES,
@@ -57,8 +73,7 @@ import {
   V4_STORES,
   V6_STORES,
   V8_STORES
-} from '../../../src/local/indexeddb_schema';
-import { SchemaConverter } from '../../../src/local/indexeddb_schema_converter';
+} from '../../../src/local/indexeddb_sentinels';
 import {
   fromDbTarget,
   toDbRemoteDocument,
@@ -71,7 +86,9 @@ import { ClientId } from '../../../src/local/shared_client_state';
 import { SimpleDb, SimpleDbTransaction } from '../../../src/local/simple_db';
 import { TargetData, TargetPurpose } from '../../../src/local/target_data';
 import { getWindow } from '../../../src/platform/dom';
-import { firestoreV1ApiClientInterfaces } from '../../../src/protos/firestore_proto_api';
+import {
+  firestoreV1ApiClientInterfaces
+} from '../../../src/protos/firestore_proto_api';
 import { JsonProtoSerializer } from '../../../src/remote/serializer';
 import { AsyncQueue, TimerId } from '../../../src/util/async_queue';
 import {
@@ -218,7 +235,7 @@ function addDocs(
   version: number
 ): PersistencePromise<void> {
   const remoteDocumentStore = txn.store<DbRemoteDocumentKey, DbRemoteDocument>(
-    DbRemoteDocument.store
+    DbRemoteDocumentStore
   );
   return PersistencePromise.forEach(keys, (key: string) => {
     const remoteDoc = doc(key, version, { data: 'foo' });
@@ -250,32 +267,37 @@ describe('IndexedDbSchema: createOrUpgradeDb', () => {
     const batchId = 1;
     const targetId = 2;
 
-    const expectedMutation = new DbMutationBatch(userId, batchId, 1000, [], []);
-    const dummyTargetGlobal = new DbTargetGlobal(
-      /*highestTargetId=*/ 1,
-      /*highestListenSequencNumber=*/ 1,
-      /*lastRemoteSnapshotVersion=*/ new DbTimestamp(1, 1),
-      /*targetCount=*/ 1
-    );
-    const resetTargetGlobal = new DbTargetGlobal(
-      /*highestTargetId=*/ 0,
-      /*highestListenSequencNumber=*/ 0,
-      /*lastRemoteSnapshotVersion=*/ SnapshotVersion.min().toTimestamp(),
-      /*targetCount=*/ 0
-    );
+    const expectedMutation: DbMutationBatch = {
+      userId,
+      batchId,
+      localWriteTimeMs: 1000,
+      mutations: []
+    };
+    const dummyTargetGlobal: DbTargetGlobal = {
+      highestTargetId: 1,
+      highestListenSequenceNumber: 1,
+      lastRemoteSnapshotVersion: { seconds: 1, nanoseconds: 1 },
+      targetCount: 1
+    };
+    const resetTargetGlobal: DbTargetGlobal = {
+      highestTargetId: 0,
+      highestListenSequenceNumber: 0,
+      lastRemoteSnapshotVersion: SnapshotVersion.min().toTimestamp(),
+      targetCount: 0
+    };
 
     return withDb(2, db => {
       return db.runTransaction(
         this.test!.fullTitle(),
         'readwrite',
-        [DbTarget.store, DbTargetGlobal.store, DbMutationBatch.store],
+        [DbTargetStore, DbTargetGlobalStore, DbMutationBatchStore],
         txn => {
-          const targets = txn.store<DbTargetKey, DbTarget>(DbTarget.store);
+          const targets = txn.store<DbTargetKey, DbTarget>(DbTargetStore);
           const targetGlobal = txn.store<DbTargetGlobalKey, DbTargetGlobal>(
-            DbTargetGlobal.store
+            DbTargetGlobalStore
           );
           const mutations = txn.store<DbMutationBatchKey, DbMutationBatch>(
-            DbMutationBatch.store
+            DbMutationBatchStore
           );
 
           return (
@@ -283,7 +305,7 @@ describe('IndexedDbSchema: createOrUpgradeDb', () => {
               // eslint-disable-next-line @typescript-eslint/no-explicit-any
               .put({ targetId, canonicalId: 'foo' } as any)
               .next(() =>
-                targetGlobal.put(DbTargetGlobal.key, dummyTargetGlobal)
+                targetGlobal.put(DbTargetGlobalKey, dummyTargetGlobal)
               )
               .next(() => mutations.put(expectedMutation))
           );
@@ -297,14 +319,14 @@ describe('IndexedDbSchema: createOrUpgradeDb', () => {
         return db.runTransaction(
           this.test!.fullTitle(),
           'readwrite',
-          [DbTarget.store, DbTargetGlobal.store, DbMutationBatch.store],
+          [DbTargetStore, DbTargetGlobalStore, DbMutationBatchStore],
           txn => {
-            const targets = txn.store<DbTargetKey, DbTarget>(DbTarget.store);
+            const targets = txn.store<DbTargetKey, DbTarget>(DbTargetStore);
             const targetGlobal = txn.store<DbTargetGlobalKey, DbTargetGlobal>(
-              DbTargetGlobal.store
+              DbTargetGlobalStore
             );
             const mutations = txn.store<DbMutationBatchKey, DbMutationBatch>(
-              DbMutationBatch.store
+              DbMutationBatchStore
             );
 
             return targets
@@ -313,7 +335,7 @@ describe('IndexedDbSchema: createOrUpgradeDb', () => {
                 // The target should have been dropped
                 expect(target).to.be.null;
               })
-              .next(() => targetGlobal.get(DbTargetGlobal.key))
+              .next(() => targetGlobal.get(DbTargetGlobalKey))
               .next(targetGlobalEntry => {
                 // Target Global should exist but be cleared.
                 // HACK: round-trip through JSON to clear types, like IndexedDb
@@ -363,9 +385,9 @@ describe('IndexedDbSchema: createOrUpgradeDb', () => {
       return db.runTransaction(
         this.test!.fullTitle(),
         'readwrite',
-        [DbMutationBatch.store],
+        [DbMutationBatchStore],
         txn => {
-          const store = txn.store(DbMutationBatch.store);
+          const store = txn.store(DbMutationBatchStore);
           return PersistencePromise.forEach(
             testMutations,
             (testMutation: DbMutationBatch) => store.put(testMutation)
@@ -379,10 +401,10 @@ describe('IndexedDbSchema: createOrUpgradeDb', () => {
         return db.runTransaction(
           this.test!.fullTitle(),
           'readwrite',
-          [DbMutationBatch.store],
+          [DbMutationBatchStore],
           txn => {
             const store = txn.store<DbMutationBatchKey, DbMutationBatch>(
-              DbMutationBatch.store
+              DbMutationBatchStore
             );
             let p = PersistencePromise.forEach(
               testMutations,
@@ -480,15 +502,15 @@ describe('IndexedDbSchema: createOrUpgradeDb', () => {
           const mutationBatchStore = txn.store<
             DbMutationBatchKey,
             DbMutationBatch
-          >(DbMutationBatch.store);
+          >(DbMutationBatchStore);
           const documentMutationStore = txn.store<
             DbDocumentMutationKey,
             DbDocumentMutation
-          >(DbDocumentMutation.store);
+          >(DbDocumentMutationStore);
           const mutationQueuesStore = txn.store<
             DbMutationQueueKey,
             DbMutationQueue
-          >(DbMutationQueue.store);
+          >(DbMutationQueueStore);
           // Manually populate the mutation queue and create all indicies.
           return PersistencePromise.forEach(
             testMutations,
@@ -497,14 +519,14 @@ describe('IndexedDbSchema: createOrUpgradeDb', () => {
                 return PersistencePromise.forEach(
                   testMutation.mutations,
                   (write: firestoreV1ApiClientInterfaces.Write) => {
-                    const indexKey = DbDocumentMutation.key(
+                    const indexKey = newDbDocumentMutationKey(
                       testMutation.userId,
                       path(write.update!.name!, 5),
                       testMutation.batchId
                     );
                     return documentMutationStore.put(
                       indexKey,
-                      DbDocumentMutation.PLACEHOLDER
+                      DbDocumentMutationPlaceholder
                     );
                   }
                 );
@@ -513,9 +535,21 @@ describe('IndexedDbSchema: createOrUpgradeDb', () => {
           ).next(() =>
             // Populate the mutation queues' metadata
             PersistencePromise.waitFor([
-              mutationQueuesStore.put(new DbMutationQueue('foo', 2, '')),
-              mutationQueuesStore.put(new DbMutationQueue('bar', 3, '')),
-              mutationQueuesStore.put(new DbMutationQueue('empty', -1, ''))
+              mutationQueuesStore.put({
+                userId: 'foo',
+                lastAcknowledgedBatchId: 2,
+                lastStreamToken: ''
+              }),
+              mutationQueuesStore.put({
+                userId: 'bar',
+                lastAcknowledgedBatchId: 3,
+                lastStreamToken: ''
+              }),
+              mutationQueuesStore.put({
+                userId: 'empty',
+                lastAcknowledgedBatchId: -1,
+                lastStreamToken: ''
+              })
             ])
           );
         }
@@ -533,15 +567,15 @@ describe('IndexedDbSchema: createOrUpgradeDb', () => {
             const mutationBatchStore = txn.store<
               DbMutationBatchKey,
               DbMutationBatch
-            >(DbMutationBatch.store);
+            >(DbMutationBatchStore);
             const documentMutationStore = txn.store<
               DbDocumentMutationKey,
               DbDocumentMutation
-            >(DbDocumentMutation.store);
+            >(DbDocumentMutationStore);
             const mutationQueuesStore = txn.store<
               DbMutationQueueKey,
               DbMutationQueue
-            >(DbMutationQueue.store);
+            >(DbMutationQueueStore);
 
             // Verify that all but the two pending mutations have been cleared
             // by the migration.
@@ -587,7 +621,7 @@ describe('IndexedDbSchema: createOrUpgradeDb', () => {
         V4_STORES,
         txn => {
           const store = txn.store<DbRemoteDocumentKey, DbRemoteDocument>(
-            DbRemoteDocument.store
+            DbRemoteDocumentStore
           );
           return PersistencePromise.forEach(
             dbRemoteDocs,
@@ -606,8 +640,8 @@ describe('IndexedDbSchema: createOrUpgradeDb', () => {
           const store = txn.store<
             DbRemoteDocumentGlobalKey,
             DbRemoteDocumentGlobal
-          >(DbRemoteDocumentGlobal.store);
-          return store.get(DbRemoteDocumentGlobal.key).next(metadata => {
+          >(DbRemoteDocumentGlobalStore);
+          return store.get(DbRemoteDocumentGlobalKey).next(metadata => {
             // We don't really care what the size is, just that it's greater than 0.
             // Our sizing algorithm may change at some point.
             expect(metadata!.byteSize).to.be.greaterThan(0);
@@ -632,21 +666,21 @@ describe('IndexedDbSchema: createOrUpgradeDb', () => {
           const targetGlobalStore = txn.store<
             DbTargetGlobalKey,
             DbTargetGlobal
-          >(DbTargetGlobal.store);
+          >(DbTargetGlobalStore);
           const remoteDocumentStore = txn.store<
             DbRemoteDocumentKey,
             DbRemoteDocument
-          >(DbRemoteDocument.store);
+          >(DbRemoteDocumentStore);
           const targetDocumentStore = txn.store<
             DbTargetDocumentKey,
             DbTargetDocument
-          >(DbTargetDocument.store);
+          >(DbTargetDocumentStore);
           return targetGlobalStore
-            .get(DbTargetGlobal.key)
+            .get(DbTargetGlobalKey)
             .next(metadata => {
               expect(metadata).to.not.be.null;
               metadata!.highestListenSequenceNumber = newSequenceNumber;
-              return targetGlobalStore.put(DbTargetGlobal.key, metadata!);
+              return targetGlobalStore.put(DbTargetGlobalKey, metadata!);
             })
             .next(() => {
               // Set up some documents (we only need the keys)
@@ -662,13 +696,11 @@ describe('IndexedDbSchema: createOrUpgradeDb', () => {
                 );
                 if (i % 2 === 1) {
                   promises.push(
-                    targetDocumentStore.put(
-                      new DbTargetDocument(
-                        0,
-                        encodeResourcePath(document.key.path),
-                        oldSequenceNumber
-                      )
-                    )
+                    targetDocumentStore.put({
+                      targetId: 0,
+                      path: encodeResourcePath(document.key.path),
+                      sequenceNumber: oldSequenceNumber
+                    })
                   );
                 }
               }
@@ -688,7 +720,7 @@ describe('IndexedDbSchema: createOrUpgradeDb', () => {
           const targetDocumentStore = txn.store<
             DbTargetDocumentKey,
             DbTargetDocument
-          >(DbTargetDocument.store);
+          >(DbTargetDocumentStore);
           const range = IDBKeyRange.bound(
             [0],
             [1],
@@ -743,22 +775,22 @@ describe('IndexedDbSchema: createOrUpgradeDb', () => {
           const remoteDocumentStore = txn.store<
             DbRemoteDocumentKey,
             DbRemoteDocument
-          >(DbRemoteDocument.store);
+          >(DbRemoteDocumentStore);
           const documentMutationStore = txn.store<
             DbDocumentMutationKey,
             DbDocumentMutation
-          >(DbDocumentMutation.store);
+          >(DbDocumentMutationStore);
           // We "cheat" and only write the DbDocumentMutation index entries, since that's
           // all the migration uses.
           return PersistencePromise.forEach(writePaths, (writePath: string) => {
-            const indexKey = DbDocumentMutation.key(
+            const indexKey = newDbDocumentMutationKey(
               'dummy-uid',
               path(writePath),
               /*dummy batchId=*/ 123
             );
             return documentMutationStore.put(
               indexKey,
-              DbDocumentMutation.PLACEHOLDER
+              DbDocumentMutationPlaceholder
             );
           }).next(() => {
             // Write the remote document entries.
@@ -787,7 +819,7 @@ describe('IndexedDbSchema: createOrUpgradeDb', () => {
           const collectionParentsStore = txn.store<
             DbCollectionParentKey,
             DbCollectionParent
-          >(DbCollectionParent.store);
+          >(DbCollectionParentStore);
           // We use iterate() as loadAll() does not seem to guarantee ordering
           // with our IndexedDB shim.
           const actualParents: { [key: string]: string[] } = {};
@@ -815,7 +847,7 @@ describe('IndexedDbSchema: createOrUpgradeDb', () => {
         'readwrite',
         V8_STORES,
         txn => {
-          const targetsStore = txn.store<DbTargetKey, DbTarget>(DbTarget.store);
+          const targetsStore = txn.store<DbTargetKey, DbTarget>(DbTargetStore);
 
           const filteredQuery = query('collection', filter('foo', '==', 'bar'));
           const initialTargetData = new TargetData(
@@ -841,7 +873,7 @@ describe('IndexedDbSchema: createOrUpgradeDb', () => {
         'readwrite',
         V8_STORES,
         txn => {
-          const targetsStore = txn.store<DbTargetKey, DbTarget>(DbTarget.store);
+          const targetsStore = txn.store<DbTargetKey, DbTarget>(DbTargetStore);
           return targetsStore.iterate((key, value) => {
             const targetData = fromDbTarget(value).target;
             const expectedCanonicalId = canonifyTarget(targetData);
@@ -881,7 +913,7 @@ describe('IndexedDbSchema: createOrUpgradeDb', () => {
           const remoteDocumentStore = txn.store<
             DbRemoteDocumentKey,
             DbRemoteDocument
-          >(DbRemoteDocument.store);
+          >(DbRemoteDocumentStore);
 
           // Write the remote document entries.
           return PersistencePromise.forEach(
@@ -917,7 +949,7 @@ describe('IndexedDbSchema: createOrUpgradeDb', () => {
           const remoteDocumentStore = txn.store<
             DbRemoteDocumentKey,
             DbRemoteDocument
-          >(DbRemoteDocument.store);
+          >(DbRemoteDocumentStore);
 
           // Verify the existing remote document entries.
           return remoteDocumentStore
@@ -941,7 +973,7 @@ describe('IndexedDbSchema: createOrUpgradeDb', () => {
                 true
               );
               return remoteDocumentStore
-                .loadAll(DbRemoteDocument.collectionReadTimeIndex, range)
+                .loadAll(DbRemoteDocumentCollectionReadTimeIndex, range)
                 .next(docsRead => {
                   const keys = docsRead.map(dbDoc => dbDoc.document!.name);
                   expect(keys).to.have.members([
@@ -970,7 +1002,7 @@ describe('IndexedDbSchema: createOrUpgradeDb', () => {
               const remoteDocumentStore = txn.store<
                 DbRemoteDocumentKey,
                 DbRemoteDocument
-              >(DbRemoteDocument.store);
+              >(DbRemoteDocumentStore);
 
               const lastReadTime = toDbTimestampKey(version(1));
               const range = IDBKeyRange.lowerBound(
@@ -978,7 +1010,7 @@ describe('IndexedDbSchema: createOrUpgradeDb', () => {
                 true
               );
               return remoteDocumentStore
-                .loadAll(DbRemoteDocument.collectionReadTimeIndex, range)
+                .loadAll(DbRemoteDocumentCollectionReadTimeIndex, range)
                 .next(docsRead => {
                   const keys = docsRead.map(dbDoc => dbDoc.document!.name);
                   expect(keys).to.have.members([
@@ -1008,12 +1040,12 @@ describe('IndexedDbSchema: createOrUpgradeDb', () => {
               const remoteDocumentStore = txn.store<
                 DbRemoteDocumentKey,
                 DbRemoteDocument
-              >(DbRemoteDocument.store);
+              >(DbRemoteDocumentStore);
 
               const lastReadTime = toDbTimestampKey(version(1));
               const range = IDBKeyRange.lowerBound(lastReadTime, true);
               return remoteDocumentStore
-                .loadAll(DbRemoteDocument.readTimeIndex, range)
+                .loadAll(DbRemoteDocumentReadTimeIndex, range)
                 .next(docsRead => {
                   const keys = docsRead.map(dbDoc => dbDoc.document!.name);
                   expect(keys).to.have.members([
@@ -1085,12 +1117,12 @@ describe('IndexedDb: canActAsPrimary', () => {
     await simpleDb.runTransaction(
       'clearPrimaryLease',
       'readwrite',
-      [DbPrimaryClient.store],
+      [DbPrimaryClientStore],
       txn => {
         const primaryStore = txn.store<DbPrimaryClientKey, DbPrimaryClient>(
-          DbPrimaryClient.store
+          DbPrimaryClientStore
         );
-        return primaryStore.delete(DbPrimaryClient.key);
+        return primaryStore.delete(DbPrimaryClientKey);
       }
     );
     simpleDb.close();
@@ -1105,13 +1137,13 @@ describe('IndexedDb: canActAsPrimary', () => {
     const leaseOwner = await simpleDb.runTransaction(
       'getCurrentLeaseOwner',
       'readonly',
-      [DbPrimaryClient.store],
+      [DbPrimaryClientStore],
       txn => {
         const primaryStore = txn.store<DbPrimaryClientKey, DbPrimaryClient>(
-          DbPrimaryClient.store
+          DbPrimaryClientStore
         );
         return primaryStore
-          .get(DbPrimaryClient.key)
+          .get(DbPrimaryClientKey)
           .next(owner => (owner ? owner.ownerId : null));
       }
     );

--- a/packages/firestore/test/unit/local/local_serializer.test.ts
+++ b/packages/firestore/test/unit/local/local_serializer.test.ts
@@ -106,13 +106,12 @@ describe('Local Serializer', () => {
   };
 
   it('SetMutation + TransformMutation (legacy) are squashed', () => {
-    const dbMutationBatch = new DbMutationBatch(
+    const dbMutationBatch: DbMutationBatch = {
       userId,
       batchId,
-      1000,
-      [],
-      [setMutationWrite, transformMutationWrite]
-    );
+      localWriteTimeMs: 1000,
+      mutations: [setMutationWrite, transformMutationWrite]
+    };
     const mutationBatch = fromDbMutationBatch(localSerializer, dbMutationBatch);
     expect(mutationBatch.mutations).to.have.lengthOf(1);
     expect(mutationBatch.mutations[0] instanceof SetMutation).to.be.true;
@@ -124,13 +123,12 @@ describe('Local Serializer', () => {
   });
 
   it('PatchMutation + TransformMutation (legacy) are squashed', () => {
-    const dbMutationBatch = new DbMutationBatch(
+    const dbMutationBatch: DbMutationBatch = {
       userId,
       batchId,
-      1000,
-      [],
-      [patchMutationWrite, transformMutationWrite]
-    );
+      localWriteTimeMs: 1000,
+      mutations: [patchMutationWrite, transformMutationWrite]
+    };
     const mutationBatch = fromDbMutationBatch(localSerializer, dbMutationBatch);
     expect(mutationBatch.mutations).to.have.lengthOf(1);
     expect(mutationBatch.mutations[0] instanceof PatchMutation).to.be.true;
@@ -142,13 +140,12 @@ describe('Local Serializer', () => {
   });
 
   it('TransformMutation (legacy) + TransformMutation (legacy) throw assertion', () => {
-    const dbMutationBatch = new DbMutationBatch(
+    const dbMutationBatch: DbMutationBatch = {
       userId,
       batchId,
-      1000,
-      [],
-      [transformMutationWrite, transformMutationWrite]
-    );
+      localWriteTimeMs: 1000,
+      mutations: [transformMutationWrite, transformMutationWrite]
+    };
     expect(() =>
       fromDbMutationBatch(localSerializer, dbMutationBatch)
     ).to.throw(
@@ -157,13 +154,12 @@ describe('Local Serializer', () => {
   });
 
   it('DeleteMutation + TransformMutation (legacy) on its own throws assertion', () => {
-    const dbMutationBatch = new DbMutationBatch(
+    const dbMutationBatch: DbMutationBatch = {
       userId,
       batchId,
-      1000,
-      [],
-      [deleteMutationWrite, transformMutationWrite]
-    );
+      localWriteTimeMs: 1000,
+      mutations: [deleteMutationWrite, transformMutationWrite]
+    };
     expect(() =>
       fromDbMutationBatch(localSerializer, dbMutationBatch)
     ).to.throw(
@@ -177,12 +173,11 @@ describe('Local Serializer', () => {
     // DeleteMutation -> PatchMutation -> TransformMutation -> PatchMutation
     // OUTPUT (squashed):
     // SetMutation -> SetMutation -> DeleteMutation -> PatchMutation -> PatchMutation
-    const dbMutationBatch = new DbMutationBatch(
+    const dbMutationBatch: DbMutationBatch = {
       userId,
       batchId,
-      1000,
-      [],
-      [
+      localWriteTimeMs: 1000,
+      mutations: [
         setMutationWrite,
         setMutationWrite,
         transformMutationWrite,
@@ -191,7 +186,7 @@ describe('Local Serializer', () => {
         transformMutationWrite,
         patchMutationWrite
       ]
-    );
+    };
     const expected = [
       setMutationWrite,
       { ...setMutationWrite, ...updateTransforms },

--- a/packages/firestore/test/unit/local/persistence_transaction.test.ts
+++ b/packages/firestore/test/unit/local/persistence_transaction.test.ts
@@ -19,7 +19,10 @@ import { expect } from 'chai';
 
 import { TargetId } from '../../../src/core/types';
 import { IndexedDbPersistence } from '../../../src/local/indexeddb_persistence';
-import { DbTarget, DbTargetKey } from '../../../src/local/indexeddb_schema';
+import {
+  DbTargetKey,
+  DbTargetStore
+} from '../../../src/local/indexeddb_sentinels';
 import { getStore } from '../../../src/local/indexeddb_transaction';
 import { Persistence } from '../../../src/local/persistence';
 import { PersistencePromise } from '../../../src/local/persistence_promise';
@@ -60,7 +63,7 @@ describe('IndexedDbTransaction', () => {
     await persistence.runTransaction('onCommitted', 'readwrite', txn => {
       const targetsStore = getStore<DbTargetKey, { targetId: TargetId }>(
         txn,
-        DbTarget.store
+        DbTargetStore
       );
 
       txn.addOnCommittedListener(() => {

--- a/packages/firestore/test/unit/specs/spec_test_runner.ts
+++ b/packages/firestore/test/unit/specs/spec_test_runner.ts
@@ -64,10 +64,13 @@ import {
 import { IndexedDbPersistence } from '../../../src/local/indexeddb_persistence';
 import {
   DbPrimaryClient,
-  DbPrimaryClientKey,
   SCHEMA_VERSION
 } from '../../../src/local/indexeddb_schema';
 import { SchemaConverter } from '../../../src/local/indexeddb_schema_converter';
+import {
+  DbPrimaryClientKey,
+  DbPrimaryClientStore
+} from '../../../src/local/indexeddb_sentinels';
 import { LocalStore } from '../../../src/local/local_store';
 import {
   ClientId,
@@ -1642,12 +1645,12 @@ async function clearCurrentPrimaryLease(): Promise<void> {
   await db.runTransaction(
     'clearCurrentPrimaryLease',
     'readwrite',
-    [DbPrimaryClient.store],
+    [DbPrimaryClientStore],
     txn => {
       const primaryClientStore = txn.store<DbPrimaryClientKey, DbPrimaryClient>(
-        DbPrimaryClient.store
+        DbPrimaryClientStore
       );
-      return primaryClientStore.delete(DbPrimaryClient.key);
+      return primaryClientStore.delete(DbPrimaryClientKey);
     }
   );
   db.close();


### PR DESCRIPTION
We use classes for IndexedDB, but really our entries are just plain JSON. This PR changes the code to treat them as JSON, which reduces the overhead of JS classes. This PR is merely meant to reduce SDK size, as we are adding a lot of bytes for indexing.