### PR TITLE
Add a last sent date to heartbeat storage

### DIFF
--- a/.changeset/sweet-pumas-dance.md
+++ b/.changeset/sweet-pumas-dance.md
@@ -1,0 +1,5 @@
+---
+'@firebase/app': patch
+---
+
+Fix heartbeat controller to ensure not sending more than one a day.

--- a/packages/app/src/heartbeatService.test.ts
+++ b/packages/app/src/heartbeatService.test.ts
@@ -236,7 +236,6 @@ describe('HeartbeatServiceImpl', () => {
       }
     });
     it('getHeartbeatHeaders() gets stored heartbeats and clears heartbeats', async () => {
-
       const heartbeatHeaders = firebaseUtil.base64Decode(
         await heartbeatService.getHeartbeatsHeader()
       );

--- a/packages/app/src/heartbeatService.ts
+++ b/packages/app/src/heartbeatService.ts
@@ -119,7 +119,8 @@ export class HeartbeatServiceImpl implements HeartbeatService {
    * Returns a base64 encoded string which can be attached to the heartbeat-specific header directly.
    * It also clears all heartbeats from memory as well as in IndexedDB.
    *
-   * NOTE: It will read heartbeats from the heartbeatsCache, instead of from indexedDB to reduce latency
+   * NOTE: Consuming product SDKs should not send the header if this method
+   * returns an empty string.
    */
   async getHeartbeatsHeader(): Promise<string> {
     if (this._heartbeatsCache === null) {

--- a/packages/app/src/heartbeatService.ts
+++ b/packages/app/src/heartbeatService.ts
@@ -22,7 +22,6 @@ import {
   validateIndexedDBOpenable
 } from '@firebase/util';
 import {
-  deleteHeartbeatsFromIndexedDB,
   readHeartbeatsFromIndexedDB,
   writeHeartbeatsToIndexedDB
 } from './indexeddb';
@@ -30,6 +29,7 @@ import { FirebaseApp } from './public-types';
 import {
   HeartbeatsByUserAgent,
   HeartbeatService,
+  HeartbeatsInIndexedDB,
   HeartbeatStorage,
   SingleDateHeartbeat
 } from './types';
@@ -54,7 +54,7 @@ export class HeartbeatServiceImpl implements HeartbeatService {
    * be kept in sync with indexedDB.
    * Leave public for easier testing.
    */
-  _heartbeatsCache: SingleDateHeartbeat[] | null = null;
+  _heartbeatsCache: HeartbeatsInIndexedDB | null = null;
 
   /**
    * the initialization promise for populating heartbeatCache.
@@ -62,7 +62,7 @@ export class HeartbeatServiceImpl implements HeartbeatService {
    * (hearbeatsCache == null), it should wait for this promise
    * Leave public for easier testing.
    */
-  _heartbeatsCachePromise: Promise<SingleDateHeartbeat[]>;
+  _heartbeatsCachePromise: Promise<HeartbeatsInIndexedDB>;
   constructor(private readonly container: ComponentContainer) {
     const app = this.container.getProvider('app').getImmediate();
     this._storage = new HeartbeatStorageImpl(app);
@@ -91,19 +91,21 @@ export class HeartbeatServiceImpl implements HeartbeatService {
     if (this._heartbeatsCache === null) {
       this._heartbeatsCache = await this._heartbeatsCachePromise;
     }
+    // Do not store a heartbeat if one is already stored for this day
+    // or if a header has already been sent today.
     if (
-      this._heartbeatsCache.some(
+      this._heartbeatsCache.lastSentHeartbeatDate === date ||
+      this._heartbeatsCache.heartbeats.some(
         singleDateHeartbeat => singleDateHeartbeat.date === date
       )
     ) {
-      // Do not store a heartbeat if one is already stored for this day.
       return;
     } else {
       // There is no entry for this date. Create one.
-      this._heartbeatsCache.push({ date, userAgent });
+      this._heartbeatsCache.heartbeats.push({ date, userAgent });
     }
     // Remove entries older than 30 days.
-    this._heartbeatsCache = this._heartbeatsCache.filter(
+    this._heartbeatsCache.heartbeats = this._heartbeatsCache.heartbeats.filter(
       singleDateHeartbeat => {
         const hbTimestamp = new Date(singleDateHeartbeat.date).valueOf();
         const now = Date.now();
@@ -123,28 +125,34 @@ export class HeartbeatServiceImpl implements HeartbeatService {
     if (this._heartbeatsCache === null) {
       await this._heartbeatsCachePromise;
     }
-    // If it's still null, it's been cleared and has not been repopulated.
-    if (this._heartbeatsCache === null) {
+    // If it's still null or the array is empty, there is no data to send.
+    if (
+      this._heartbeatsCache === null ||
+      this._heartbeatsCache.heartbeats.length === 0
+    ) {
       return '';
     }
+    const date = getUTCDateString();
     // Extract as many heartbeats from the cache as will fit under the size limit.
     const { heartbeatsToSend, unsentEntries } = extractHeartbeatsForHeader(
-      this._heartbeatsCache
+      this._heartbeatsCache.heartbeats
     );
     const headerString = base64Encode(
       JSON.stringify({ version: 2, heartbeats: heartbeatsToSend })
     );
+    // Store last sent date to prevent another being logged/sent for the same day.
+    this._heartbeatsCache.lastSentHeartbeatDate = date;
     if (unsentEntries.length > 0) {
       // Store any unsent entries if they exist.
-      this._heartbeatsCache = unsentEntries;
-      // This seems more likely than deleteAll (below) to lead to some odd state
+      this._heartbeatsCache.heartbeats = unsentEntries;
+      // This seems more likely than emptying the array (below) to lead to some odd state
       // since the cache isn't empty and this will be called again on the next request,
       // and is probably safest if we await it.
       await this._storage.overwrite(this._heartbeatsCache);
     } else {
-      this._heartbeatsCache = null;
+      this._heartbeatsCache.heartbeats = [];
       // Do not wait for this, to reduce latency.
-      void this._storage.deleteAll();
+      void this._storage.overwrite(this._heartbeatsCache);
     }
     return headerString;
   }
@@ -221,57 +229,46 @@ export class HeartbeatStorageImpl implements HeartbeatStorage {
   /**
    * Read all heartbeats.
    */
-  async read(): Promise<SingleDateHeartbeat[]> {
+  async read(): Promise<HeartbeatsInIndexedDB> {
     const canUseIndexedDB = await this._canUseIndexedDBPromise;
     if (!canUseIndexedDB) {
-      return [];
+      return { heartbeats: [] };
     } else {
       const idbHeartbeatObject = await readHeartbeatsFromIndexedDB(this.app);
-      return idbHeartbeatObject?.heartbeats || [];
+      return idbHeartbeatObject || { heartbeats: [] };
     }
   }
   // overwrite the storage with the provided heartbeats
-  async overwrite(heartbeats: SingleDateHeartbeat[]): Promise<void> {
+  async overwrite(heartbeatsObject: HeartbeatsInIndexedDB): Promise<void> {
     const canUseIndexedDB = await this._canUseIndexedDBPromise;
     if (!canUseIndexedDB) {
       return;
     } else {
-      return writeHeartbeatsToIndexedDB(this.app, { heartbeats });
+      const existingHeartbeatsObject = await this.read();
+      return writeHeartbeatsToIndexedDB(this.app, {
+        lastSentHeartbeatDate:
+          heartbeatsObject.lastSentHeartbeatDate ??
+          existingHeartbeatsObject.lastSentHeartbeatDate,
+        heartbeats: heartbeatsObject.heartbeats
+      });
     }
   }
   // add heartbeats
-  async add(heartbeats: SingleDateHeartbeat[]): Promise<void> {
+  async add(heartbeatsObject: HeartbeatsInIndexedDB): Promise<void> {
     const canUseIndexedDB = await this._canUseIndexedDBPromise;
     if (!canUseIndexedDB) {
       return;
     } else {
-      const existingHeartbeats = await this.read();
+      const existingHeartbeatsObject = await this.read();
       return writeHeartbeatsToIndexedDB(this.app, {
-        heartbeats: [...existingHeartbeats, ...heartbeats]
+        lastSentHeartbeatDate:
+          heartbeatsObject.lastSentHeartbeatDate ??
+          existingHeartbeatsObject.lastSentHeartbeatDate,
+        heartbeats: [
+          ...existingHeartbeatsObject.heartbeats,
+          ...heartbeatsObject.heartbeats
+        ]
       });
-    }
-  }
-  // delete heartbeats
-  async delete(heartbeats: SingleDateHeartbeat[]): Promise<void> {
-    const canUseIndexedDB = await this._canUseIndexedDBPromise;
-    if (!canUseIndexedDB) {
-      return;
-    } else {
-      const existingHeartbeats = await this.read();
-      return writeHeartbeatsToIndexedDB(this.app, {
-        heartbeats: existingHeartbeats.filter(
-          existingHeartbeat => !heartbeats.includes(existingHeartbeat)
-        )
-      });
-    }
-  }
-  // delete all heartbeats
-  async deleteAll(): Promise<void> {
-    const canUseIndexedDB = await this._canUseIndexedDBPromise;
-    if (!canUseIndexedDB) {
-      return;
-    } else {
-      return deleteHeartbeatsFromIndexedDB(this.app);
     }
   }
 }

--- a/packages/app/src/indexeddb.ts
+++ b/packages/app/src/indexeddb.ts
@@ -78,21 +78,6 @@ export async function writeHeartbeatsToIndexedDB(
   }
 }
 
-export async function deleteHeartbeatsFromIndexedDB(
-  app: FirebaseApp
-): Promise<void> {
-  try {
-    const db = await getDbPromise();
-    const tx = db.transaction(STORE_NAME, 'readwrite');
-    await tx.objectStore(STORE_NAME).delete(computeKey(app));
-    return tx.complete;
-  } catch (e) {
-    throw ERROR_FACTORY.create(AppError.STORAGE_DELETE, {
-      originalErrorMessage: e.message
-    });
-  }
-}
-
 function computeKey(app: FirebaseApp): string {
   return `${app.name}!${app.options.appId}`;
 }

--- a/packages/app/src/types.ts
+++ b/packages/app/src/types.ts
@@ -42,12 +42,12 @@ export interface HeartbeatService {
 
 // Heartbeats grouped by the same user agent string
 export interface HeartbeatsByUserAgent {
-  userAgent: string;
+  agent: string;
   dates: string[];
 }
 
 export interface SingleDateHeartbeat {
-  userAgent: string;
+  agent: string;
   date: string;
 }
 

--- a/packages/app/src/types.ts
+++ b/packages/app/src/types.ts
@@ -53,17 +53,14 @@ export interface SingleDateHeartbeat {
 
 export interface HeartbeatStorage {
   // overwrite the storage with the provided heartbeats
-  overwrite(heartbeats: SingleDateHeartbeat[]): Promise<void>;
+  overwrite(heartbeats: HeartbeatsInIndexedDB): Promise<void>;
   // add heartbeats
-  add(heartbeats: SingleDateHeartbeat[]): Promise<void>;
-  // delete heartbeats
-  delete(heartbeats: SingleDateHeartbeat[]): Promise<void>;
-  // delete all heartbeats
-  deleteAll(): Promise<void>;
+  add(heartbeats: HeartbeatsInIndexedDB): Promise<void>;
   // read all heartbeats
-  read(): Promise<SingleDateHeartbeat[]>;
+  read(): Promise<HeartbeatsInIndexedDB>;
 }
 
 export interface HeartbeatsInIndexedDB {
+  lastSentHeartbeatDate?: string;
   heartbeats: SingleDateHeartbeat[];
 }


### PR DESCRIPTION
Persist date of last sent heartbeat header, to prevent adding any more entries for that date. This is done by adding a `lastSentHeartbeatDate` to the heartbeat object stored in IndexedDB (and retained in app memory as `this._heartbeatsCache`).