### PR TITLE
Auth middleware (beforeAuthStateChanged)

### DIFF
--- a/common/api-review/auth.api.md
+++ b/common/api-review/auth.api.md
@@ -81,6 +81,7 @@ export function applyActionCode(auth: Auth, oobCode: string): Promise<void>;
 // @public
 export interface Auth {
     readonly app: FirebaseApp;
+    beforeAuthStateChanged(callback: (user: User | null) => void | Promise<void>): Unsubscribe;
     readonly config: Config;
     readonly currentUser: User | null;
     readonly emulatorConfig: EmulatorConfig | null;

--- a/packages/auth/src/core/auth/auth_impl.ts
+++ b/packages/auth/src/core/auth/auth_impl.ts
@@ -78,6 +78,7 @@ export class AuthImpl implements AuthInternal, _FirebaseService {
   private redirectPersistenceManager?: PersistenceUserManager;
   private authStateSubscription = new Subscription<User>(this);
   private idTokenSubscription = new Subscription<User>(this);
+  private beforeStateSubscription = new Subscription<User>(this);
   private redirectUser: UserInternal | null = null;
   private isProactiveRefreshEnabled = false;
 
@@ -366,6 +367,17 @@ export class AuthImpl implements AuthInternal, _FirebaseService {
     return this.registerStateListener(
       this.authStateSubscription,
       nextOrObserver,
+      error,
+      completed
+    );
+  }
+
+  beforeAuthStateChanged(
+    next: NextFn<User | null>,
+  ): Unsubscribe {
+    return this.registerStateListener(
+      this.beforeStateSubscription,
+      next,
       error,
       completed
     );

--- a/packages/auth/src/core/auth/auth_impl.ts
+++ b/packages/auth/src/core/auth/auth_impl.ts
@@ -227,7 +227,11 @@ export class AuthImpl implements AuthInternal, _FirebaseService {
 
     // At this point in the flow, this is a redirect user. Run blocking
     // middleware callbacks before setting the user.
-    await this._runBeforeStateCallbacks(storedUser);
+    try {
+      await this._runBeforeStateCallbacks(storedUser);
+    } catch(e) {
+      return;
+    }
 
     // If the redirect user's event ID matches the current user's event ID,
     // DO NOT reload the current user, otherwise they'll be cleared from storage.

--- a/packages/auth/src/core/auth/auth_impl.ts
+++ b/packages/auth/src/core/auth/auth_impl.ts
@@ -528,6 +528,7 @@ export class AuthImpl implements AuthInternal, _FirebaseService {
    * should only be called from within a queued callback. This is necessary
    * because the queue shouldn't rely on another queued callback.
    */
+  // TODO: Find where this is called and see if we can run the middleware before it
   private async directlySetCurrentUser(
     user: UserInternal | null
   ): Promise<void> {

--- a/packages/auth/src/core/errors.ts
+++ b/packages/auth/src/core/errors.ts
@@ -75,6 +75,7 @@ export const enum AuthErrorCode {
   INVALID_SENDER = 'invalid-sender',
   INVALID_SESSION_INFO = 'invalid-verification-id',
   INVALID_TENANT_ID = 'invalid-tenant-id',
+  LOGIN_BLOCKED = 'login-blocked',
   MFA_INFO_NOT_FOUND = 'multi-factor-info-not-found',
   MFA_REQUIRED = 'multi-factor-auth-required',
   MISSING_ANDROID_PACKAGE_NAME = 'missing-android-pkg-name',
@@ -245,6 +246,7 @@ function _debugErrorMap(): ErrorMap<AuthErrorCode> {
       'The verification ID used to create the phone auth credential is invalid.',
     [AuthErrorCode.INVALID_TENANT_ID]:
       "The Auth instance's tenant ID is invalid.",
+    [AuthErrorCode.LOGIN_BLOCKED]: "Login blocked by user-provided method.",
     [AuthErrorCode.MISSING_ANDROID_PACKAGE_NAME]:
       'An Android Package Name must be provided if the Android App is required to be installed.',
     [AuthErrorCode.MISSING_AUTH_DOMAIN]:
@@ -414,9 +416,10 @@ type GenericAuthErrorParams = {
     | AuthErrorCode.NO_AUTH_EVENT
     | AuthErrorCode.OPERATION_NOT_SUPPORTED
   >]: {
-    appName: AppName;
+    appName?: AppName;
     email?: string;
     phoneNumber?: string;
+    message?: string;
   };
 };
 
@@ -427,6 +430,7 @@ export interface AuthErrorParams extends GenericAuthErrorParams {
   [AuthErrorCode.ARGUMENT_ERROR]: { appName?: AppName };
   [AuthErrorCode.DEPENDENT_SDK_INIT_BEFORE_AUTH]: { appName?: AppName };
   [AuthErrorCode.INTERNAL_ERROR]: { appName?: AppName };
+  [AuthErrorCode.LOGIN_BLOCKED]: { message?: string };
   [AuthErrorCode.OPERATION_NOT_SUPPORTED]: { appName?: AppName };
   [AuthErrorCode.NO_AUTH_EVENT]: { appName?: AppName };
   [AuthErrorCode.MFA_REQUIRED]: {

--- a/packages/auth/src/core/errors.ts
+++ b/packages/auth/src/core/errors.ts
@@ -246,7 +246,7 @@ function _debugErrorMap(): ErrorMap<AuthErrorCode> {
       'The verification ID used to create the phone auth credential is invalid.',
     [AuthErrorCode.INVALID_TENANT_ID]:
       "The Auth instance's tenant ID is invalid.",
-    [AuthErrorCode.LOGIN_BLOCKED]: "Login blocked by user-provided method.",
+    [AuthErrorCode.LOGIN_BLOCKED]: "Login blocked by user-provided method: {$originalMessage}",
     [AuthErrorCode.MISSING_ANDROID_PACKAGE_NAME]:
       'An Android Package Name must be provided if the Android App is required to be installed.',
     [AuthErrorCode.MISSING_AUTH_DOMAIN]:
@@ -430,7 +430,7 @@ export interface AuthErrorParams extends GenericAuthErrorParams {
   [AuthErrorCode.ARGUMENT_ERROR]: { appName?: AppName };
   [AuthErrorCode.DEPENDENT_SDK_INIT_BEFORE_AUTH]: { appName?: AppName };
   [AuthErrorCode.INTERNAL_ERROR]: { appName?: AppName };
-  [AuthErrorCode.LOGIN_BLOCKED]: { message?: string };
+  [AuthErrorCode.LOGIN_BLOCKED]: { appName?: AppName, originalMessage?: string };
   [AuthErrorCode.OPERATION_NOT_SUPPORTED]: { appName?: AppName };
   [AuthErrorCode.NO_AUTH_EVENT]: { appName?: AppName };
   [AuthErrorCode.MFA_REQUIRED]: {

--- a/packages/auth/src/model/public_types.ts
+++ b/packages/auth/src/model/public_types.ts
@@ -255,6 +255,16 @@ export interface Auth {
     completed?: CompleteFn
   ): Unsubscribe;
   /**
+   * Adds a blocking callback that runs before an auth state change
+   * sets a new user.
+   *
+   * @param callback - callback triggered before new user value is set.
+   *   If this throws, it will block the user from being set.
+   */
+  beforeAuthStateChanged(
+    callback: (user: User | null) => void | Promise<void>
+  ): Unsubscribe;
+  /**
    * Adds an observer for changes to the signed-in user's ID token.
    *
    * @remarks


### PR DESCRIPTION
Create `beforeAuthStateChanged()` method per internal design doc [go/firebase-auth-middleware](https://goto.google.com/firebase-auth-middleware).

TODO in a separate PR: implement `onAbort()`.