### PR TITLE
Use collectionGroupReadTimeIndex for multi-tab synchronization

### DIFF
--- a/packages/firestore/src/core/bundle.ts
+++ b/packages/firestore/src/core/bundle.ts
@@ -43,11 +43,10 @@ export interface BundledDocument {
  */
 export type BundledDocuments = BundledDocument[];
 
-export class BundleLoadResult {
-  constructor(
-    readonly progress: LoadBundleTaskProgress,
-    readonly changedDocs: DocumentMap
-  ) {}
+export interface BundleLoadResult {
+  readonly progress: LoadBundleTaskProgress;
+  readonly changedCollectionGroups: Set<string>;
+  readonly changedDocs: DocumentMap;
 }
 
 /**

--- a/packages/firestore/src/core/component_provider.ts
+++ b/packages/firestore/src/core/component_provider.ts
@@ -22,10 +22,7 @@ import {
   IndexedDbPersistence
 } from '../local/indexeddb_persistence';
 import { LocalStore } from '../local/local_store';
-import {
-  newLocalStore,
-  localStoreSynchronizeLastDocumentChangeReadTime
-} from '../local/local_store_impl';
+import { newLocalStore } from '../local/local_store_impl';
 import { LruParams } from '../local/lru_garbage_collector';
 import { LruScheduler } from '../local/lru_garbage_collector_impl';
 import {
@@ -174,7 +171,6 @@ export class IndexedDbOfflineComponentProvider extends MemoryOfflineComponentPro
 
   async initialize(cfg: ComponentConfiguration): Promise<void> {
     await super.initialize(cfg);
-    await localStoreSynchronizeLastDocumentChangeReadTime(this.localStore);
 
     await this.onlineComponentProvider.initialize(this, cfg);
 

--- a/packages/firestore/src/core/query.ts
+++ b/packages/firestore/src/core/query.ts
@@ -527,6 +527,21 @@ function queryMatchesBounds(query: Query, doc: Document): boolean {
 }
 
 /**
+ * Returns the collection group that this query targets.
+ *
+ * PORTING NOTE: This is only used in the Web SDK to facilitate multi-tab
+ * synchronization for query results.
+ */
+export function queryCollectionGroup(query: Query): string {
+  return (
+    query.collectionGroup ||
+    (query.path.length % 2 === 1
+      ? query.path.lastSegment()
+      : query.path.get(query.path.length - 2))
+  );
+}
+
+/**
  * Returns a new comparator function that can be used to compare two documents
  * based on the Query's ordering constraint.
  */

--- a/packages/firestore/src/local/indexeddb_schema_converter.ts
+++ b/packages/firestore/src/local/indexeddb_schema_converter.ts
@@ -93,8 +93,6 @@ import {
   DbRemoteDocumentGlobalStore,
   DbRemoteDocumentKey,
   DbRemoteDocumentKeyPath,
-  DbRemoteDocumentReadTimeIndex,
-  DbRemoteDocumentReadTimeIndexPath,
   DbRemoteDocumentStore,
   DbTargetDocumentDocumentTargetsIndex,
   DbTargetDocumentDocumentTargetsKeyPath,
@@ -531,11 +529,6 @@ function createRemoteDocumentCache(db: IDBDatabase): void {
   remoteDocumentStore.createIndex(
     DbRemoteDocumentDocumentKeyIndex,
     DbRemoteDocumentDocumentKeyIndexPath
-  );
-  remoteDocumentStore.createIndex(
-    DbRemoteDocumentReadTimeIndex,
-    DbRemoteDocumentReadTimeIndexPath,
-    { unique: false }
   );
   remoteDocumentStore.createIndex(
     DbRemoteDocumentCollectionGroupIndex,

--- a/packages/firestore/src/local/indexeddb_sentinels.ts
+++ b/packages/firestore/src/local/indexeddb_sentinels.ts
@@ -148,17 +148,6 @@ export const DbRemoteDocumentKeyPath = [
   'documentId'
 ];
 
-/**
- * An index that provides access to all entries sorted by read time (which
- * corresponds to the last modification time of each row).
- *
- * This index is used to provide a changelog for Multi-Tab.
- */
-export const DbRemoteDocumentReadTimeIndex = 'readTimeIndex';
-
-// TODO(indexing): Consider re-working Multi-Tab to use the collectionGroupIndex
-export const DbRemoteDocumentReadTimeIndexPath = 'readTime';
-
 /** An index that provides access to documents by key. */
 export const DbRemoteDocumentDocumentKeyIndex = 'documentKeyIndex';
 

--- a/packages/firestore/src/local/shared_client_state_schema.ts
+++ b/packages/firestore/src/local/shared_client_state_schema.ts
@@ -119,8 +119,9 @@ export function createWebStorageOnlineStateKey(persistenceKey: string): string {
 // The WebStorage prefix that plays as a event to indicate the remote documents
 // might have changed due to some secondary tabs loading a bundle.
 // format of the key is:
-//     firestore_bundle_loaded_<persistenceKey>
-export const BUNDLE_LOADED_KEY_PREFIX = 'firestore_bundle_loaded';
+//     firestore_bundle_loaded_v2_<persistenceKey>
+// The version ending with "v2" stores the list of modified collection groups.
+export const BUNDLE_LOADED_KEY_PREFIX = 'firestore_bundle_loaded_v2';
 export function createBundleLoadedKey(persistenceKey: string): string {
   return `${BUNDLE_LOADED_KEY_PREFIX}_${persistenceKey}`;
 }

--- a/packages/firestore/src/local/shared_client_state_syncer.ts
+++ b/packages/firestore/src/local/shared_client_state_syncer.ts
@@ -55,5 +55,5 @@ export interface SharedClientStateSyncer {
    * Retrieves newly changed documents from remote document cache and raises
    * snapshots if needed.
    */
-  synchronizeWithChangedDocuments(): Promise<void>;
+  synchronizeWithChangedDocuments(collectionGroup: string): Promise<void>;
 }

--- a/packages/firestore/test/unit/core/query.test.ts
+++ b/packages/firestore/test/unit/core/query.test.ts
@@ -34,7 +34,9 @@ import {
   queryToTarget,
   QueryImpl,
   queryEquals,
-  matchesAllDocuments
+  matchesAllDocuments,
+  queryCollectionGroup,
+  newQueryForCollectionGroup
 } from '../../../src/core/query';
 import {
   Bound,
@@ -88,6 +90,14 @@ describe('Bound', () => {
 
 describe('Query', () => {
   addEqualityMatcher({ equalsFn: queryEquals, forType: QueryImpl });
+
+  it('can get collection group', () => {
+    expect(queryCollectionGroup(query('foo'))).to.equal('foo');
+    expect(queryCollectionGroup(query('foo/bar'))).to.equal('foo');
+    expect(queryCollectionGroup(newQueryForCollectionGroup('foo'))).to.equal(
+      'foo'
+    );
+  });
 
   it('matches based on document key', () => {
     const queryKey = new ResourcePath(['rooms', 'eros', 'messages', '1']);

--- a/packages/firestore/test/unit/local/indexeddb_persistence.test.ts
+++ b/packages/firestore/test/unit/local/indexeddb_persistence.test.ts
@@ -61,7 +61,6 @@ import {
   DbRemoteDocumentGlobalKey,
   DbRemoteDocumentGlobalStore,
   DbRemoteDocumentKey,
-  DbRemoteDocumentReadTimeIndex,
   DbRemoteDocumentStore,
   DbTargetDocumentKey,
   DbTargetDocumentStore,
@@ -1022,41 +1021,6 @@ describe('IndexedDbSchema: createOrUpgradeDb', () => {
                   'projects/test-project/databases/(default)/documents/coll/doc4'
                 ]);
               });
-            })
-          );
-        }
-      );
-    });
-  });
-
-  it('can get recent document changes', async function (this: Context) {
-    const oldDocPaths = ['coll1/old', 'coll2/old'];
-    const newDocPaths = ['coll1/new', 'coll2/new'];
-
-    await withDb(13, db => {
-      return db.runTransaction(
-        this.test!.fullTitle(),
-        'readwrite',
-        V13_STORES,
-        txn => {
-          return addDocs(txn, oldDocPaths, /* version= */ 1).next(() =>
-            addDocs(txn, newDocPaths, /* version= */ 2).next(() => {
-              const remoteDocumentStore = txn.store<
-                DbRemoteDocumentKey,
-                DbRemoteDocument
-              >(DbRemoteDocumentStore);
-
-              const lastReadTime = toDbTimestampKey(version(1));
-              const range = IDBKeyRange.lowerBound(lastReadTime, true);
-              return remoteDocumentStore
-                .loadAll(DbRemoteDocumentReadTimeIndex, range)
-                .next(docsRead => {
-                  const keys = docsRead.map(dbDoc => dbDoc.document!.name);
-                  expect(keys).to.have.members([
-                    'projects/test-project/databases/(default)/documents/coll1/new',
-                    'projects/test-project/databases/(default)/documents/coll2/new'
-                  ]);
-                });
             })
           );
         }

--- a/packages/firestore/test/unit/local/local_store.test.ts
+++ b/packages/firestore/test/unit/local/local_store.test.ts
@@ -51,7 +51,6 @@ import {
   localStoreReleaseTarget,
   localStoreSaveBundle,
   localStoreSaveNamedQuery,
-  localStoreSynchronizeLastDocumentChangeReadTime,
   newLocalStore
 } from '../../../src/local/local_store_impl';
 import { LocalViewChanges } from '../../../src/local/local_view_changes';
@@ -579,7 +578,6 @@ describe('LocalStore w/ IndexedDB Persistence', () => {
       User.UNAUTHENTICATED,
       JSON_SERIALIZER
     );
-    await localStoreSynchronizeLastDocumentChangeReadTime(localStore);
     return { queryEngine, persistence, localStore };
   }
 

--- a/packages/firestore/test/unit/local/remote_document_cache.test.ts
+++ b/packages/firestore/test/unit/local/remote_document_cache.test.ts
@@ -154,7 +154,7 @@ describe('IndexedDbRemoteDocumentCache', () => {
     assertMatches([doc('a/2', 2, DOC_DATA), doc('a/3', 3, DOC_DATA)], results);
   });
 
-  it('cen get next documents from collection group with document key offset', async () => {
+  it('can get next documents from collection group with document key offset', async () => {
     await cache.addEntries([
       doc('a/1', 1, DOC_DATA),
       doc('a/2', 1, DOC_DATA),
@@ -193,7 +193,7 @@ describe('IndexedDbRemoteDocumentCache', () => {
     assertMatches([doc('a/1', 1, DOC_DATA), doc('a/2', 2, DOC_DATA)], results);
   });
 
-  it('cen get next documents from collection group with limit', async () => {
+  it('can get next documents from collection group with limit', async () => {
     await cache.addEntries([
       doc('a/1', 1, DOC_DATA),
       doc('b/2/a/2', 2, DOC_DATA),
@@ -211,7 +211,7 @@ describe('IndexedDbRemoteDocumentCache', () => {
     );
   });
 
-  it('cen get next documents from collection group with read time offset', async () => {
+  it('can get next documents from collection group with read time offset', async () => {
     await cache.addEntries([
       doc('a/1', 1, DOC_DATA),
       doc('a/2', 2, DOC_DATA),
@@ -226,7 +226,7 @@ describe('IndexedDbRemoteDocumentCache', () => {
     assertMatches([doc('a/2', 2, DOC_DATA), doc('a/3', 3, DOC_DATA)], results);
   });
 
-  it('cen get next documents from collection group with document key offset', async () => {
+  it('can get next documents from collection group with document key offset', async () => {
     await cache.addEntries([
       doc('a/1', 1, DOC_DATA),
       doc('a/2', 1, DOC_DATA),

--- a/packages/firestore/test/unit/local/remote_document_cache.test.ts
+++ b/packages/firestore/test/unit/local/remote_document_cache.test.ts
@@ -121,7 +121,7 @@ describe('IndexedDbRemoteDocumentCache', () => {
     assertMatches([doc('a/1', 1, DOC_DATA), doc('a/2', 2, DOC_DATA)], results);
   });
 
-  it('cen get next documents from collection group with limit', async () => {
+  it('can get next documents from collection group with limit', async () => {
     await cache.addEntries([
       doc('a/1', 1, DOC_DATA),
       doc('b/2/a/2', 2, DOC_DATA),
@@ -139,7 +139,7 @@ describe('IndexedDbRemoteDocumentCache', () => {
     );
   });
 
-  it('cen get next documents from collection group with read time offset', async () => {
+  it('can get next documents from collection group with read time offset', async () => {
     await cache.addEntries([
       doc('a/1', 1, DOC_DATA),
       doc('a/2', 2, DOC_DATA),

--- a/packages/firestore/test/unit/local/remote_document_cache.test.ts
+++ b/packages/firestore/test/unit/local/remote_document_cache.test.ts
@@ -18,9 +18,7 @@
 import { expect } from 'chai';
 
 import { User } from '../../../src/auth/user';
-import { SnapshotVersion } from '../../../src/core/snapshot_version';
 import { IndexedDbPersistence } from '../../../src/local/indexeddb_persistence';
-import { remoteDocumentCacheGetLastReadTime } from '../../../src/local/indexeddb_remote_document_cache';
 import { documentKeySet, DocumentMap } from '../../../src/model/collections';
 import { MutableDocument, Document } from '../../../src/model/document';
 import {
@@ -36,7 +34,6 @@ import {
   field,
   key,
   path,
-  removedDoc,
   version,
   wrap
 } from '../../util/helpers';
@@ -109,79 +106,76 @@ describe('IndexedDbRemoteDocumentCache', () => {
     await persistenceHelpers.clearTestPersistence();
   });
 
-  function getLastReadTime(): Promise<SnapshotVersion> {
-    return persistence.runTransaction('getLastReadTime', 'readonly', txn => {
-      return remoteDocumentCacheGetLastReadTime(txn);
-    });
-  }
-
-  it('skips previous changes', async () => {
-    // Add a document to simulate a previous run.
-    await cache.addEntries([doc('a/1', 1, DOC_DATA).setReadTime(version(1))]);
-    await persistence.shutdown();
-
-    // Start a new run of the persistence layer
-    persistence = await persistenceHelpers.testIndexedDbPersistence({
-      synchronizeTabs: true,
-      dontPurgeData: true
-    });
-    cache = new TestRemoteDocumentCache(persistence);
-    const readTime = await getLastReadTime();
-    const { changedDocs } = await cache.getNewDocumentChanges(readTime);
-    assertMatches([], changedDocs);
-  });
-
-  it('can get changes', async () => {
+  it('can get next documents from collection group', async () => {
     await cache.addEntries([
       doc('a/1', 1, DOC_DATA),
-      doc('b/1', 2, DOC_DATA),
-      doc('b/2', 2, DOC_DATA),
-      doc('a/1', 3, DOC_DATA)
+      doc('a/2', 2, DOC_DATA),
+      doc('b/1', 3, DOC_DATA)
     ]);
 
-    let { changedDocs, readTime } = await cache.getNewDocumentChanges(
-      SnapshotVersion.min()
+    const results = await cache.getAllFromCollectionGroup(
+      'a',
+      IndexOffset.min(),
+      Number.MAX_SAFE_INTEGER
+    );
+    assertMatches([doc('a/1', 1, DOC_DATA), doc('a/2', 2, DOC_DATA)], results);
+  });
+
+  it('cen get next documents from collection group with limit', async () => {
+    await cache.addEntries([
+      doc('a/1', 1, DOC_DATA),
+      doc('b/2/a/2', 2, DOC_DATA),
+      doc('a/3', 3, DOC_DATA)
+    ]);
+
+    const results = await cache.getAllFromCollectionGroup(
+      'a',
+      IndexOffset.min(),
+      2
     );
     assertMatches(
-      [
-        doc('a/1', 3, DOC_DATA),
-        doc('b/1', 2, DOC_DATA),
-        doc('b/2', 2, DOC_DATA)
-      ],
-      changedDocs
+      [doc('a/1', 1, DOC_DATA), doc('b/2/a/2', 2, DOC_DATA)],
+      results
     );
-
-    await cache.addEntry(doc('c/1', 4, DOC_DATA));
-    changedDocs = (await cache.getNewDocumentChanges(readTime)).changedDocs;
-    assertMatches([doc('c/1', 4, DOC_DATA)], changedDocs);
   });
 
-  it('can get empty changes', async () => {
-    const { changedDocs } = await cache.getNewDocumentChanges(
-      SnapshotVersion.min()
-    );
-    assertMatches([], changedDocs);
-  });
-
-  it('can get missing documents in changes', async () => {
+  it('cen get next documents from collection group with read time offset', async () => {
     await cache.addEntries([
       doc('a/1', 1, DOC_DATA),
       doc('a/2', 2, DOC_DATA),
       doc('a/3', 3, DOC_DATA)
     ]);
-    await cache.removeEntry(key('a/2'), version(4));
 
-    const { changedDocs } = await cache.getNewDocumentChanges(
-      SnapshotVersion.min()
+    const results = await cache.getAllFromCollectionGroup(
+      'a',
+      newIndexOffsetSuccessorFromReadTime(version(1), INITIAL_LARGEST_BATCH_ID),
+      2
     );
-    assertMatches(
-      [
-        doc('a/1', 1, DOC_DATA),
-        removedDoc('a/2').setReadTime(version(4)),
-        doc('a/3', 3, DOC_DATA)
-      ],
-      changedDocs
+    assertMatches([doc('a/2', 2, DOC_DATA), doc('a/3', 3, DOC_DATA)], results);
+  });
+
+  it('cen get next documents from collection group with document key offset', async () => {
+    await cache.addEntries([
+      doc('a/1', 1, DOC_DATA),
+      doc('a/2', 1, DOC_DATA),
+      doc('a/3', 1, DOC_DATA)
+    ]);
+
+    const results = await cache.getAllFromCollectionGroup(
+      'a',
+      newIndexOffsetFromDocument(doc('a/1', 1, DOC_DATA)),
+      Number.MAX_SAFE_INTEGER
     );
+    assertMatches([doc('a/2', 1, DOC_DATA), doc('a/3', 1, DOC_DATA)], results);
+  });
+
+  it('can get next documents from non-existing collection group', async () => {
+    const results = await cache.getAllFromCollectionGroup(
+      'a',
+      IndexOffset.min(),
+      Number.MAX_SAFE_INTEGER
+    );
+    assertMatches([], results);
   });
 
   it('can get next documents from collection group', async () => {


### PR DESCRIPTION
This drops one index created by https://github.com/firebase/firebase-js-sdk/pull/5988 and changes the multi-tab synchronization to use the collection group read time index. This works pretty well for normal query execution, but needs some adjusting to bundle loading as we don't know the collection groups of the bundles. As such, this PR adds functionality to the bundle loader to persist the names of the affected collection groups in LocalStoragel