### PR TITLE
Support descending queries

### DIFF
--- a/packages/firestore/src/core/target.ts
+++ b/packages/firestore/src/core/target.ts
@@ -20,7 +20,9 @@ import { DocumentKey } from '../model/document_key';
 import {
   FieldIndex,
   fieldIndexGetArraySegment,
-  fieldIndexGetDirectionalSegments
+  fieldIndexGetDirectionalSegments,
+  IndexKind,
+  IndexSegment
 } from '../model/field_index';
 import { FieldPath, ResourcePath } from '../model/path';
 import {
@@ -304,70 +306,21 @@ export function targetGetLowerBound(
   // For each segment, retrieve a lower bound if there is a suitable filter or
   // startAt.
   for (const segment of fieldIndexGetDirectionalSegments(fieldIndex)) {
-    let segmentValue: ProtoValue | undefined = undefined;
-    let segmentInclusive = true;
+    const segmentBound =
+      segment.kind === IndexKind.ASCENDING
+        ? targetGetAscendingBound(target, segment, target.startAt)
+        : targetGetDescendingBound(target, segment, target.startAt);
 
-    // Process all filters to find a value for the current field segment
-    for (const fieldFilter of targetGetFieldFiltersForPath(
-      target,
-      segment.fieldPath
-    )) {
-      let filterValue: ProtoValue | undefined = undefined;
-      let filterInclusive = true;
-
-      switch (fieldFilter.op) {
-        case Operator.LESS_THAN:
-        case Operator.LESS_THAN_OR_EQUAL:
-          filterValue = valuesGetLowerBound(fieldFilter.value);
-          break;
-        case Operator.EQUAL:
-        case Operator.IN:
-        case Operator.GREATER_THAN_OR_EQUAL:
-          filterValue = fieldFilter.value;
-          break;
-        case Operator.GREATER_THAN:
-          filterValue = fieldFilter.value;
-          filterInclusive = false;
-          break;
-        case Operator.NOT_EQUAL:
-        case Operator.NOT_IN:
-          filterValue = MIN_VALUE;
-          break;
-        default:
-        // Remaining filters cannot be used as lower bounds.
-      }
-
-      if (valuesMax(segmentValue, filterValue) === filterValue) {
-        segmentValue = filterValue;
-        segmentInclusive = filterInclusive;
-      }
-    }
-
-    // If there is a startAt bound, compare the values against the existing
-    // boundary to see if we can narrow the scope.
-    if (target.startAt !== null) {
-      for (let i = 0; i < target.orderBy.length; ++i) {
-        const orderBy = target.orderBy[i];
-        if (orderBy.field.isEqual(segment.fieldPath)) {
-          const cursorValue = target.startAt.position[i];
-          if (valuesMax(segmentValue, cursorValue) === cursorValue) {
-            segmentValue = cursorValue;
-            segmentInclusive = target.startAt.inclusive;
-          }
-          break;
-        }
-      }
-    }
-
-    if (segmentValue === undefined) {
+    if (!segmentBound.value) {
       // No lower bound exists
       return null;
     }
-    values.push(segmentValue);
-    inclusive &&= segmentInclusive;
+    values.push(segmentBound.value);
+    inclusive &&= segmentBound.inclusive;
   }
   return new Bound(values, inclusive);
 }
+
 /**
  * Returns an upper bound of field values that can be used as an ending point
  * when scanning the index defined by `fieldIndex`. Returns `null` if no
@@ -383,71 +336,147 @@ export function targetGetUpperBound(
   // For each segment, retrieve an upper bound if there is a suitable filter or
   // endAt.
   for (const segment of fieldIndexGetDirectionalSegments(fieldIndex)) {
-    let segmentValue: ProtoValue | undefined = undefined;
-    let segmentInclusive = true;
+    const segmentBound =
+      segment.kind === IndexKind.ASCENDING
+        ? targetGetDescendingBound(target, segment, target.endAt)
+        : targetGetAscendingBound(target, segment, target.endAt);
 
-    // Process all filters to find a value for the current field segment
-    for (const fieldFilter of targetGetFieldFiltersForPath(
-      target,
-      segment.fieldPath
-    )) {
-      let filterValue: ProtoValue | undefined = undefined;
-      let filterInclusive = true;
-
-      switch (fieldFilter.op) {
-        case Operator.GREATER_THAN_OR_EQUAL:
-        case Operator.GREATER_THAN:
-          filterValue = valuesGetUpperBound(fieldFilter.value);
-          filterInclusive = false;
-          break;
-        case Operator.EQUAL:
-        case Operator.IN:
-        case Operator.LESS_THAN_OR_EQUAL:
-          filterValue = fieldFilter.value;
-          break;
-        case Operator.LESS_THAN:
-          filterValue = fieldFilter.value;
-          filterInclusive = false;
-          break;
-        case Operator.NOT_EQUAL:
-        case Operator.NOT_IN:
-          filterValue = MAX_VALUE;
-          break;
-        default:
-        // Remaining filters cannot be used as upper bounds.
-      }
-
-      if (valuesMin(segmentValue, filterValue) === filterValue) {
-        segmentValue = filterValue;
-        segmentInclusive = filterInclusive;
-      }
-    }
-
-    // If there is a endAt bound, compare the values against the existing
-    // boundary to see if we can narrow the scope.
-    if (target.endAt !== null) {
-      for (let i = 0; i < target.orderBy.length; ++i) {
-        const orderBy = target.orderBy[i];
-        if (orderBy.field.isEqual(segment.fieldPath)) {
-          const cursorValue = target.endAt.position[i];
-          if (valuesMin(segmentValue, cursorValue) === cursorValue) {
-            segmentValue = cursorValue;
-            segmentInclusive = target.endAt.inclusive;
-          }
-          break;
-        }
-      }
-    }
-
-    if (segmentValue === undefined) {
+    if (!segmentBound.value) {
       // No upper bound exists
       return null;
     }
-    values.push(segmentValue);
-    inclusive &&= segmentInclusive;
+    values.push(segmentBound.value);
+    inclusive &&= segmentBound.inclusive;
   }
 
   return new Bound(values, inclusive);
+}
+
+function targetGetAscendingBound(
+  target: Target,
+  segment: IndexSegment,
+  bound: Bound | null
+): { value: ProtoValue | undefined; inclusive: boolean } {
+  let value: ProtoValue | undefined = undefined;
+  let inclusive = true;
+
+  // Process all filters to find a value for the current field segment
+  for (const fieldFilter of targetGetFieldFiltersForPath(
+    target,
+    segment.fieldPath
+  )) {
+    let filterValue: ProtoValue | undefined = undefined;
+    let filterInclusive = true;
+
+    switch (fieldFilter.op) {
+      case Operator.LESS_THAN:
+      case Operator.LESS_THAN_OR_EQUAL:
+        filterValue = valuesGetLowerBound(fieldFilter.value);
+        break;
+      case Operator.EQUAL:
+      case Operator.IN:
+      case Operator.GREATER_THAN_OR_EQUAL:
+        filterValue = fieldFilter.value;
+        break;
+      case Operator.GREATER_THAN:
+        filterValue = fieldFilter.value;
+        filterInclusive = false;
+        break;
+      case Operator.NOT_EQUAL:
+      case Operator.NOT_IN:
+        filterValue = MIN_VALUE;
+        break;
+      default:
+      // Remaining filters cannot be used as lower bounds.
+    }
+
+    if (valuesMax(value, filterValue) === filterValue) {
+      value = filterValue;
+      inclusive = filterInclusive;
+    }
+  }
+
+  // If there is an additional bound, compare the values against the existing
+  // range to see if we can narrow the scope.
+  if (bound !== null) {
+    for (let i = 0; i < target.orderBy.length; ++i) {
+      const orderBy = target.orderBy[i];
+      if (orderBy.field.isEqual(segment.fieldPath)) {
+        const cursorValue = bound.position[i];
+        if (valuesMax(value, cursorValue) === cursorValue) {
+          value = cursorValue;
+          inclusive = bound.inclusive;
+        }
+        break;
+      }
+    }
+  }
+
+  return { value, inclusive };
+}
+
+function targetGetDescendingBound(
+  target: Target,
+  segment: IndexSegment,
+  bound: Bound | null
+): { value: ProtoValue | undefined; inclusive: boolean } {
+  let value: ProtoValue | undefined = undefined;
+  let inclusive = true;
+
+  // Process all filters to find a value for the current field segment
+  for (const fieldFilter of targetGetFieldFiltersForPath(
+    target,
+    segment.fieldPath
+  )) {
+    let filterValue: ProtoValue | undefined = undefined;
+    let filterInclusive = true;
+
+    switch (fieldFilter.op) {
+      case Operator.GREATER_THAN_OR_EQUAL:
+      case Operator.GREATER_THAN:
+        filterValue = valuesGetUpperBound(fieldFilter.value);
+        filterInclusive = false;
+        break;
+      case Operator.EQUAL:
+      case Operator.IN:
+      case Operator.LESS_THAN_OR_EQUAL:
+        filterValue = fieldFilter.value;
+        break;
+      case Operator.LESS_THAN:
+        filterValue = fieldFilter.value;
+        filterInclusive = false;
+        break;
+      case Operator.NOT_EQUAL:
+      case Operator.NOT_IN:
+        filterValue = MAX_VALUE;
+        break;
+      default:
+      // Remaining filters cannot be used as upper bounds.
+    }
+
+    if (valuesMin(value, filterValue) === filterValue) {
+      value = filterValue;
+      inclusive = filterInclusive;
+    }
+  }
+
+  // If there is an additional bound, compare the values against the existing
+  // range to see if we can narrow the scope.
+  if (bound !== null) {
+    for (let i = 0; i < target.orderBy.length; ++i) {
+      const orderBy = target.orderBy[i];
+      if (orderBy.field.isEqual(segment.fieldPath)) {
+        const cursorValue = bound.position[i];
+        if (valuesMin(value, cursorValue) === cursorValue) {
+          value = cursorValue;
+          inclusive = bound.inclusive;
+        }
+        break;
+      }
+    }
+  }
+
+  return { value, inclusive };
 }
 
 export abstract class Filter {

--- a/packages/firestore/src/local/index_manager.ts
+++ b/packages/firestore/src/local/index_manager.ts
@@ -16,7 +16,8 @@
  */
 
 import { Target } from '../core/target';
-import { DocumentKeySet, DocumentMap } from '../model/collections';
+import { DocumentMap } from '../model/collections';
+import { DocumentKey } from '../model/document_key';
 import { FieldIndex, IndexOffset } from '../model/field_index';
 import { ResourcePath } from '../model/path';
 
@@ -108,7 +109,7 @@ export interface IndexManager {
   getDocumentsMatchingTarget(
     transaction: PersistenceTransaction,
     target: Target
-  ): PersistencePromise<DocumentKeySet | null>;
+  ): PersistencePromise<DocumentKey[] | null>;
 
   /**
    * Returns the next collection group to update. Returns `null` if no group

--- a/packages/firestore/src/local/indexeddb_index_manager.ts
+++ b/packages/firestore/src/local/indexeddb_index_manager.ts
@@ -295,8 +295,8 @@ export class IndexedDbIndexManager implements IndexManager {
                 .loadFirst(indexRange, target.limit)
                 .next(entries => {
                   entries.forEach(entry => {
-                    const documentKey = new DocumentKey(
-                      decodeResourcePath(entry.documentKey)
+                    const documentKey = DocumentKey.fromSegments(
+                      entry.documentKey
                     );
                     if (!existingKeys.has(documentKey)) {
                       existingKeys = existingKeys.add(documentKey);
@@ -737,7 +737,7 @@ export class IndexedDbIndexManager implements IndexManager {
       arrayValue: indexEntry.arrayValue,
       directionalValue: indexEntry.directionalValue,
       orderedDocumentKey: this.encodeDirectionalKey(fieldIndex, document.key),
-      documentKey: encodeResourcePath(document.key.path)
+      documentKey: document.key.path.toArray()
     });
   }
 
@@ -754,7 +754,7 @@ export class IndexedDbIndexManager implements IndexManager {
       indexEntry.arrayValue,
       indexEntry.directionalValue,
       this.encodeDirectionalKey(fieldIndex, document.key),
-      encodeResourcePath(document.key.path)
+      document.key.path.toArray()
     ]);
   }
 
@@ -935,16 +935,16 @@ export class IndexedDbIndexManager implements IndexManager {
             this.uid,
             bounds[i].arrayValue,
             bounds[i].directionalValue,
-            new Uint8Array(),
-            ''
+            EMPTY_VALUE,
+            []
           ] as DbIndexEntryKey,
           [
             bounds[i + 1].indexId,
             this.uid,
             bounds[i + 1].arrayValue,
             bounds[i + 1].directionalValue,
-            new Uint8Array(),
-            ''
+            EMPTY_VALUE,
+            []
           ] as DbIndexEntryKey
         )
       );

--- a/packages/firestore/src/local/indexeddb_index_manager.ts
+++ b/packages/firestore/src/local/indexeddb_index_manager.ts
@@ -16,6 +16,7 @@
  */
 
 import { User } from '../auth/user';
+import { DatabaseId } from '../core/database_info';
 import {
   Bound,
   canonifyTarget,
@@ -31,17 +32,14 @@ import {
 import { FirestoreIndexValueWriter } from '../index/firestore_index_value_writer';
 import { IndexByteEncoder } from '../index/index_byte_encoder';
 import { IndexEntry, indexEntryComparator } from '../index/index_entry';
-import {
-  documentKeySet,
-  DocumentKeySet,
-  DocumentMap
-} from '../model/collections';
+import { documentKeySet, DocumentMap } from '../model/collections';
 import { Document } from '../model/document';
 import { DocumentKey } from '../model/document_key';
 import {
   FieldIndex,
   fieldIndexGetArraySegment,
   fieldIndexGetDirectionalSegments,
+  fieldIndexGetKeyOrder,
   fieldIndexToString,
   IndexKind,
   IndexOffset,
@@ -49,7 +47,7 @@ import {
 } from '../model/field_index';
 import { FieldPath, ResourcePath } from '../model/path';
 import { TargetIndexMatcher } from '../model/target_index_matcher';
-import { isArray } from '../model/values';
+import { isArray, refValue } from '../model/values';
 import { Value as ProtoValue } from '../protos/firestore_proto_api';
 import { debugAssert } from '../util/assert';
 import { logDebug } from '../util/log';
@@ -123,7 +121,7 @@ export class IndexedDbIndexManager implements IndexManager {
     (l, r) => targetEquals(l, r)
   );
 
-  constructor(private user: User) {
+  constructor(private user: User, private readonly databaseId: DatabaseId) {
     this.uid = user.uid || '';
   }
 
@@ -232,7 +230,7 @@ export class IndexedDbIndexManager implements IndexManager {
   getDocumentsMatchingTarget(
     transaction: PersistenceTransaction,
     target: Target
-  ): PersistencePromise<DocumentKeySet | null> {
+  ): PersistencePromise<DocumentKey[] | null> {
     const indexEntries = indexEntriesStore(transaction);
 
     let canServeTarget = true;
@@ -248,9 +246,10 @@ export class IndexedDbIndexManager implements IndexManager {
       }
     ).next(() => {
       if (!canServeTarget) {
-        return PersistencePromise.resolve(null as DocumentKeySet | null);
+        return PersistencePromise.resolve(null as DocumentKey[] | null);
       } else {
-        let result = documentKeySet();
+        let existingKeys = documentKeySet();
+        const result: DocumentKey[] = [];
         return PersistencePromise.forEach(indexes, (index, subTarget) => {
           logDebug(
             LOG_TAG,
@@ -296,14 +295,18 @@ export class IndexedDbIndexManager implements IndexManager {
                 .loadFirst(indexRange, target.limit)
                 .next(entries => {
                   entries.forEach(entry => {
-                    result = result.add(
-                      new DocumentKey(decodeResourcePath(entry.documentKey))
+                    const documentKey = new DocumentKey(
+                      decodeResourcePath(entry.documentKey)
                     );
+                    if (!existingKeys.has(documentKey)) {
+                      existingKeys = existingKeys.add(documentKey);
+                      result.push(documentKey);
+                    }
                   });
                 });
             }
           );
-        }).next(() => result as DocumentKeySet | null);
+        }).next(() => result as DocumentKey[] | null);
       }
     });
   }
@@ -486,6 +489,22 @@ export class IndexedDbIndexManager implements IndexManager {
     FirestoreIndexValueWriter.INSTANCE.writeIndexValue(
       value,
       encoder.forKind(IndexKind.ASCENDING)
+    );
+    return encoder.encodedBytes();
+  }
+
+  /**
+   * Returns an encoded form of the document key that sorts based on the key
+   * ordering of the field index.
+   */
+  private encodeDirectionalKey(
+    fieldIndex: FieldIndex,
+    documentKey: DocumentKey
+  ): Uint8Array {
+    const encoder = new IndexByteEncoder();
+    FirestoreIndexValueWriter.INSTANCE.writeIndexValue(
+      refValue(this.databaseId, documentKey),
+      encoder.forKind(fieldIndexGetKeyOrder(fieldIndex))
     );
     return encoder.encodedBytes();
   }
@@ -692,6 +711,7 @@ export class IndexedDbIndexManager implements IndexManager {
                 return this.updateEntries(
                   transaction,
                   doc,
+                  fieldIndex,
                   existingEntries,
                   newEntries
                 );
@@ -707,6 +727,7 @@ export class IndexedDbIndexManager implements IndexManager {
   private addIndexEntry(
     transaction: PersistenceTransaction,
     document: Document,
+    fieldIndex: FieldIndex,
     indexEntry: IndexEntry
   ): PersistencePromise<void> {
     const indexEntries = indexEntriesStore(transaction);
@@ -715,6 +736,7 @@ export class IndexedDbIndexManager implements IndexManager {
       uid: this.uid,
       arrayValue: indexEntry.arrayValue,
       directionalValue: indexEntry.directionalValue,
+      orderedDocumentKey: this.encodeDirectionalKey(fieldIndex, document.key),
       documentKey: encodeResourcePath(document.key.path)
     });
   }
@@ -722,6 +744,7 @@ export class IndexedDbIndexManager implements IndexManager {
   private deleteIndexEntry(
     transaction: PersistenceTransaction,
     document: Document,
+    fieldIndex: FieldIndex,
     indexEntry: IndexEntry
   ): PersistencePromise<void> {
     const indexEntries = indexEntriesStore(transaction);
@@ -730,6 +753,7 @@ export class IndexedDbIndexManager implements IndexManager {
       this.uid,
       indexEntry.arrayValue,
       indexEntry.directionalValue,
+      this.encodeDirectionalKey(fieldIndex, document.key),
       encodeResourcePath(document.key.path)
     ]);
   }
@@ -748,7 +772,7 @@ export class IndexedDbIndexManager implements IndexManager {
           range: IDBKeyRange.only([
             fieldIndex.indexId,
             this.uid,
-            encodeResourcePath(documentKey.path)
+            this.encodeDirectionalKey(fieldIndex, documentKey)
           ])
         },
         (_, entry) => {
@@ -817,6 +841,7 @@ export class IndexedDbIndexManager implements IndexManager {
   private updateEntries(
     transaction: PersistenceTransaction,
     document: Document,
+    fieldIndex: FieldIndex,
     existingEntries: SortedSet<IndexEntry>,
     newEntries: SortedSet<IndexEntry>
   ): PersistencePromise<void> {
@@ -828,10 +853,14 @@ export class IndexedDbIndexManager implements IndexManager {
       newEntries,
       indexEntryComparator,
       /* onAdd= */ entry => {
-        promises.push(this.addIndexEntry(transaction, document, entry));
+        promises.push(
+          this.addIndexEntry(transaction, document, fieldIndex, entry)
+        );
       },
       /* onRemove= */ entry => {
-        promises.push(this.deleteIndexEntry(transaction, document, entry));
+        promises.push(
+          this.deleteIndexEntry(transaction, document, fieldIndex, entry)
+        );
       }
     );
 
@@ -906,15 +935,17 @@ export class IndexedDbIndexManager implements IndexManager {
             this.uid,
             bounds[i].arrayValue,
             bounds[i].directionalValue,
+            new Uint8Array(),
             ''
-          ],
+          ] as DbIndexEntryKey,
           [
             bounds[i + 1].indexId,
             this.uid,
             bounds[i + 1].arrayValue,
             bounds[i + 1].directionalValue,
+            new Uint8Array(),
             ''
-          ]
+          ] as DbIndexEntryKey
         )
       );
     }

--- a/packages/firestore/src/local/indexeddb_persistence.ts
+++ b/packages/firestore/src/local/indexeddb_persistence.ts
@@ -745,7 +745,10 @@ export class IndexedDbPersistence implements Persistence {
       this.started,
       'Cannot initialize IndexManager before persistence is started.'
     );
-    return new IndexedDbIndexManager(user);
+    return new IndexedDbIndexManager(
+      user,
+      this.serializer.remoteSerializer.databaseId
+    );
   }
 
   getDocumentOverlayCache(user: User): DocumentOverlayCache {

--- a/packages/firestore/src/local/indexeddb_schema.ts
+++ b/packages/firestore/src/local/indexeddb_schema.ts
@@ -502,6 +502,10 @@ export interface DbIndexState {
 
 /** An object that stores the encoded entries for all documents and fields. */
 export interface DbIndexEntry {
+  // TODO(indexing): Consider just storing `orderedDocumentKey` and decoding
+  // the ordered key into a document key. This would reduce storage space on
+  // disk but require us to port parts of OrderedCodeReader.
+
   /** The index id for this entry. */
   indexId: number;
   /** The user id for this entry. */
@@ -510,6 +514,11 @@ export interface DbIndexEntry {
   arrayValue: Uint8Array;
   /** The encoded directional value for equality and inequality filters. */
   directionalValue: Uint8Array;
+  /**
+   * The document key this entry points to. This entry is encoded by an ordered
+   * encoder to match the key order of the index.
+   */
+  orderedDocumentKey: Uint8Array;
   /** The document key this entry points to. */
   documentKey: EncodedResourcePath;
 }

--- a/packages/firestore/src/local/indexeddb_schema.ts
+++ b/packages/firestore/src/local/indexeddb_schema.ts
@@ -519,8 +519,8 @@ export interface DbIndexEntry {
    * encoder to match the key order of the index.
    */
   orderedDocumentKey: Uint8Array;
-  /** The document key this entry points to. */
-  documentKey: EncodedResourcePath;
+  /** The segments of the document key this entry points to. */
+  documentKey: string[];
 }
 
 /**

--- a/packages/firestore/src/local/indexeddb_sentinels.ts
+++ b/packages/firestore/src/local/indexeddb_sentinels.ts
@@ -285,9 +285,16 @@ export const DbIndexStateSequenceNumberIndexPath = ['uid', 'sequenceNumber'];
 /**
  * The key for each index entry consists of the index id and its user id,
  * the encoded array and directional value for the indexed fields as well as
- * the encoded document path for the indexed document.
+ * an ordered and an encoded document path for the indexed document.
  */
-export type DbIndexEntryKey = [number, string, Uint8Array, Uint8Array, string];
+export type DbIndexEntryKey = [
+  number,
+  string,
+  Uint8Array,
+  Uint8Array,
+  Uint8Array,
+  string
+];
 
 /** Name of the IndexedDb object store. */
 export const DbIndexEntryStore = 'indexEntries';
@@ -297,6 +304,7 @@ export const DbIndexEntryKeyPath = [
   'uid',
   'arrayValue',
   'directionalValue',
+  'orderedDocumentKey',
   'documentKey'
 ];
 

--- a/packages/firestore/src/local/indexeddb_sentinels.ts
+++ b/packages/firestore/src/local/indexeddb_sentinels.ts
@@ -293,7 +293,7 @@ export type DbIndexEntryKey = [
   Uint8Array,
   Uint8Array,
   Uint8Array,
-  string
+  string[]
 ];
 
 /** Name of the IndexedDb object store. */
@@ -313,7 +313,7 @@ export const DbIndexEntryDocumentKeyIndex = 'documentKeyIndex';
 export const DbIndexEntryDocumentKeyIndexPath = [
   'indexId',
   'uid',
-  'documentKey'
+  'orderedDocumentKey'
 ];
 
 export type DbDocumentOverlayKey = [

--- a/packages/firestore/src/local/memory_index_manager.ts
+++ b/packages/firestore/src/local/memory_index_manager.ts
@@ -16,7 +16,8 @@
  */
 
 import { Target } from '../core/target';
-import { DocumentKeySet, DocumentMap } from '../model/collections';
+import { DocumentMap } from '../model/collections';
+import { DocumentKey } from '../model/document_key';
 import { FieldIndex, IndexOffset } from '../model/field_index';
 import { ResourcePath } from '../model/path';
 import { debugAssert } from '../util/assert';
@@ -68,9 +69,9 @@ export class MemoryIndexManager implements IndexManager {
   getDocumentsMatchingTarget(
     transaction: PersistenceTransaction,
     target: Target
-  ): PersistencePromise<DocumentKeySet | null> {
+  ): PersistencePromise<DocumentKey[] | null> {
     // Field indices are not supported with memory persistence.
-    return PersistencePromise.resolve<DocumentKeySet | null>(null);
+    return PersistencePromise.resolve<DocumentKey[] | null>(null);
   }
 
   getFieldIndex(

--- a/packages/firestore/src/model/field_index.ts
+++ b/packages/firestore/src/model/field_index.ts
@@ -80,6 +80,18 @@ export function fieldIndexGetDirectionalSegments(
 }
 
 /**
+ * Returns the order of the document key component.
+ *
+ * PORTING NOTE: This is only used in the Web IndexedDb implementation.
+ */
+export function fieldIndexGetKeyOrder(fieldIndex: FieldIndex): IndexKind {
+  const directionalSegments = fieldIndexGetDirectionalSegments(fieldIndex);
+  return directionalSegments.length === 0
+    ? IndexKind.ASCENDING
+    : directionalSegments[directionalSegments.length - 1].kind;
+}
+
+/**
  * Compares indexes by collection group and segments. Ignores update time and
  * index ID.
  */

--- a/packages/firestore/src/model/field_index.ts
+++ b/packages/firestore/src/model/field_index.ts
@@ -80,7 +80,7 @@ export function fieldIndexGetDirectionalSegments(
 }
 
 /**
- * Returns the order of the document key component.
+ * Returns the order of the document key component for the given index.
  *
  * PORTING NOTE: This is only used in the Web IndexedDb implementation.
  */

--- a/packages/firestore/test/unit/local/index_manager.test.ts
+++ b/packages/firestore/test/unit/local/index_manager.test.ts
@@ -737,6 +737,152 @@ describe('IndexedDbIndexManager', async () => {
     await verifyResults(q);
   });
 
+  it('supports order by key', async () => {
+    await indexManager.addFieldIndex(
+      fieldIndex('coll', { fields: [['count', IndexKind.ASCENDING]] })
+    );
+    await indexManager.addFieldIndex(
+      fieldIndex('coll', { fields: [['count', IndexKind.DESCENDING]] })
+    );
+    await addDoc('coll/val1a', { 'count': 1 });
+    await addDoc('coll/val1b', { 'count': 1 });
+    await addDoc('coll/val2', { 'count': 2 });
+
+    let q = queryWithAddedOrderBy(query('coll'), orderBy('count'));
+    await verifyResults(q, 'coll/val1a', 'coll/val1b', 'coll/val2');
+
+    q = queryWithAddedOrderBy(query('coll'), orderBy('count', 'desc'));
+    await verifyResults(q, 'coll/val2', 'coll/val1b', 'coll/val1a');
+  });
+
+  it('supports ascending order with greater than filter', async () => {
+    await setUpMultipleOrderBys();
+
+    const originalQuery = queryWithAddedOrderBy(
+      queryWithAddedFilter(
+        queryWithAddedFilter(
+          queryWithAddedFilter(query('coll'), filter('a', '==', 2)),
+          filter('b', '==', 2)
+        ),
+        filter('c', '<', 5)
+      ),
+      orderBy('c', 'asc')
+    );
+    const queryWithNonRestrictedBound = queryWithEndAt(
+      queryWithStartAt(originalQuery, bound([1], /* inclusive= */ false)),
+      bound([6], /* inclusive= */ false)
+    );
+    const queryWithRestrictedBound = queryWithEndAt(
+      queryWithStartAt(originalQuery, bound([2], /* inclusive= */ false)),
+      bound([4], /* inclusive= */ false)
+    );
+
+    await verifyResults(originalQuery, 'coll/val2', 'coll/val3', 'coll/val4');
+    await verifyResults(
+      queryWithNonRestrictedBound,
+      'coll/val2',
+      'coll/val3',
+      'coll/val4'
+    );
+    await verifyResults(queryWithRestrictedBound, 'coll/val3');
+  });
+
+  it('supports descending order with less than filter', async () => {
+    await setUpMultipleOrderBys();
+
+    const originalQuery = queryWithAddedOrderBy(
+      queryWithAddedFilter(
+        queryWithAddedFilter(
+          queryWithAddedFilter(query('coll'), filter('a', '==', 2)),
+          filter('b', '==', 2)
+        ),
+        filter('c', '<', 5)
+      ),
+      orderBy('c', 'desc')
+    );
+    const queryWithNonRestrictedBound = queryWithEndAt(
+      queryWithStartAt(originalQuery, bound([6], /* inclusive= */ false)),
+      bound([1], /* inclusive= */ false)
+    );
+    const queryWithRestrictedBound = queryWithEndAt(
+      queryWithStartAt(originalQuery, bound([4], /* inclusive= */ false)),
+      bound([2], /* inclusive= */ false)
+    );
+
+    await verifyResults(originalQuery, 'coll/val4', 'coll/val3', 'coll/val2');
+    await verifyResults(
+      queryWithNonRestrictedBound,
+      'coll/val4',
+      'coll/val3',
+      'coll/val2'
+    );
+    await verifyResults(queryWithRestrictedBound, 'coll/val3');
+  });
+
+  it('supports ascending order with greater than filter', async () => {
+    await setUpMultipleOrderBys();
+
+    const originalQuery = queryWithAddedOrderBy(
+      queryWithAddedFilter(
+        queryWithAddedFilter(
+          queryWithAddedFilter(query('coll'), filter('a', '==', 2)),
+          filter('b', '==', 2)
+        ),
+        filter('c', '>', 2)
+      ),
+      orderBy('c', 'asc')
+    );
+    const queryWithNonRestrictedBound = queryWithEndAt(
+      queryWithStartAt(originalQuery, bound([2], /* inclusive= */ false)),
+      bound([6], /* inclusive= */ false)
+    );
+    const queryWithRestrictedBound = queryWithEndAt(
+      queryWithStartAt(originalQuery, bound([3], /* inclusive= */ false)),
+      bound([5], /* inclusive= */ false)
+    );
+
+    await verifyResults(originalQuery, 'coll/val3', 'coll/val4', 'coll/val5');
+    await verifyResults(
+      queryWithNonRestrictedBound,
+      'coll/val3',
+      'coll/val4',
+      'coll/val5'
+    );
+    await verifyResults(queryWithRestrictedBound, 'coll/val4');
+  });
+
+  it('supports descending order with greater than filter', async () => {
+    await setUpMultipleOrderBys();
+
+    const originalQuery = queryWithAddedOrderBy(
+      queryWithAddedFilter(
+        queryWithAddedFilter(
+          queryWithAddedFilter(query('coll'), filter('a', '==', 2)),
+          filter('b', '==', 2)
+        ),
+        filter('c', '>', 2)
+      ),
+      orderBy('c', 'desc')
+    );
+    const queryWithNonRestrictedBound = queryWithEndAt(
+      queryWithStartAt(originalQuery, bound([6], /* inclusive= */ false)),
+      bound([2], /* inclusive= */ false)
+    );
+    const queryWithRestrictedBound = queryWithEndAt(
+      queryWithStartAt(originalQuery, bound([5], /* inclusive= */ false)),
+      bound([3], /* inclusive= */ false)
+    );
+
+    await verifyResults(originalQuery, 'coll/val5', 'coll/val4', 'coll/val3');
+    await verifyResults(
+      queryWithNonRestrictedBound,
+      'coll/val5',
+      'coll/val4',
+      'coll/val3'
+    );
+    await verifyResults(queryWithRestrictedBound, 'coll/val4');
+  });
+
   it('support advances queries', async () => {
     // This test compares local query results with those received from the Java
     // Server SDK.
@@ -892,6 +1038,7 @@ describe('IndexedDbIndexManager', async () => {
       queryWithAddedFilter(q, filter('string', '==', 'a')),
       'coll/{float:-0,string:a}'
     );
+
     await verifyResults(
       queryWithAddedFilter(q, filter('string', '>', 'a')),
       'coll/{float:0,string:ab}',
@@ -933,9 +1080,9 @@ describe('IndexedDbIndexManager', async () => {
         filter('array', 'array-contains-any', [1, 'foo'])
       ),
       'coll/{array:[1,foo],int:1}',
+      'coll/{array:[1]}',
       'coll/{array:[2,foo]}',
-      'coll/{array:[3,foo],int:3}',
-      'coll/{array:[1]}'
+      'coll/{array:[3,foo],int:3}'
     );
     await verifyResults(
       queryWithAddedFilter(q, filter('multi', '>=', true)),
@@ -983,8 +1130,8 @@ describe('IndexedDbIndexManager', async () => {
         bound([[2]], true)
       ),
       'coll/{array:[1,foo],int:1}',
-      'coll/{array:foo}',
-      'coll/{array:[1]}'
+      'coll/{array:[1]}',
+      'coll/{array:foo}'
     );
     await verifyResults(
       queryWithLimit(
@@ -1012,8 +1159,8 @@ describe('IndexedDbIndexManager', async () => {
         bound([[2]], false)
       ),
       'coll/{array:[1,foo],int:1}',
-      'coll/{array:foo}',
-      'coll/{array:[1]}'
+      'coll/{array:[1]}',
+      'coll/{array:foo}'
     );
     await verifyResults(
       queryWithLimit(
@@ -1040,8 +1187,8 @@ describe('IndexedDbIndexManager', async () => {
         bound([[2, 'foo']], false)
       ),
       'coll/{array:[1,foo],int:1}',
-      'coll/{array:foo}',
-      'coll/{array:[1]}'
+      'coll/{array:[1]}',
+      'coll/{array:foo}'
     );
     await verifyResults(
       queryWithLimit(
@@ -1060,26 +1207,26 @@ describe('IndexedDbIndexManager', async () => {
         queryWithAddedOrderBy(q, orderBy('array')),
         bound([[2]], true)
       ),
-      'coll/{array:[1,foo],int:1}',
       'coll/{array:foo}',
-      'coll/{array:[1]}'
+      'coll/{array:[1]}',
+      'coll/{array:[1,foo],int:1}'
     );
     await verifyResults(
       queryWithEndAt(
         queryWithAddedOrderBy(q, orderBy('array', 'desc')),
         bound([[2]], true)
       ),
-      'coll/{array:[2,foo]}',
-      'coll/{array:[3,foo],int:3}'
+      'coll/{array:[3,foo],int:3}',
+      'coll/{array:[2,foo]}'
     );
     await verifyResults(
       queryWithEndAt(
         queryWithAddedOrderBy(q, orderBy('array')),
         bound([[2]], false)
       ),
-      'coll/{array:[1,foo],int:1}',
       'coll/{array:foo}',
-      'coll/{array:[1]}'
+      'coll/{array:[1]}',
+      'coll/{array:[1,foo],int:1}'
     );
     await verifyResults(
       queryWithLimit(
@@ -1093,22 +1240,23 @@ describe('IndexedDbIndexManager', async () => {
       'coll/{array:foo}',
       'coll/{array:[1]}'
     );
+
     await verifyResults(
       queryWithEndAt(
         queryWithAddedOrderBy(q, orderBy('array', 'desc')),
         bound([[2]], false)
       ),
-      'coll/{array:[2,foo]}',
-      'coll/{array:[3,foo],int:3}'
+      'coll/{array:[3,foo],int:3}',
+      'coll/{array:[2,foo]}'
     );
     await verifyResults(
       queryWithEndAt(
         queryWithAddedOrderBy(q, orderBy('array')),
         bound([[2, 'foo']], false)
       ),
-      'coll/{array:[1,foo],int:1}',
       'coll/{array:foo}',
-      'coll/{array:[1]}'
+      'coll/{array:[1]}',
+      'coll/{array:[1,foo],int:1}'
     );
     await verifyResults(
       queryWithLimit(
@@ -1140,6 +1288,7 @@ describe('IndexedDbIndexManager', async () => {
       ),
       'coll/{a:0,b:0}'
     );
+
     await verifyResults(
       queryWithLimit(
         queryWithAddedOrderBy(
@@ -1257,13 +1406,13 @@ describe('IndexedDbIndexManager', async () => {
     await verifyResults(
       queryWithAddedOrderBy(q, orderBy('map')),
       'coll/{map:{}}',
-      'coll/{map:{field:true}}',
-      'coll/{map:{field:false}}'
+      'coll/{map:{field:false}}',
+      'coll/{map:{field:true}}'
     );
     await verifyResults(
       queryWithAddedOrderBy(q, orderBy('map.field')),
-      'coll/{map:{field:true}}',
-      'coll/{map:{field:false}}'
+      'coll/{map:{field:false}}',
+      'coll/{map:{field:true}}'
     );
   });
 
@@ -1285,6 +1434,33 @@ describe('IndexedDbIndexManager', async () => {
     await addDoc('coll/arr3', { 'values': [7, 8, 9] });
   }
 
+  async function setUpMultipleOrderBys(): Promise<void> {
+    await indexManager.addFieldIndex(
+      fieldIndex('coll', {
+        fields: [
+          ['a', IndexKind.ASCENDING],
+          ['b', IndexKind.DESCENDING],
+          ['c', IndexKind.ASCENDING]
+        ]
+      })
+    );
+    await indexManager.addFieldIndex(
+      fieldIndex('coll', {
+        fields: [
+          ['a', IndexKind.DESCENDING],
+          ['b', IndexKind.ASCENDING],
+          ['c', IndexKind.DESCENDING]
+        ]
+      })
+    );
+    await addDoc('coll/val1', { 'a': 1, 'b': 1, 'c': 3 });
+    await addDoc('coll/val2', { 'a': 2, 'b': 2, 'c': 2 });
+    await addDoc('coll/val3', { 'a': 2, 'b': 2, 'c': 3 });
+    await addDoc('coll/val4', { 'a': 2, 'b': 2, 'c': 4 });
+    await addDoc('coll/val5', { 'a': 2, 'b': 2, 'c': 5 });
+    await addDoc('coll/val6', { 'a': 3, 'b': 3, 'c': 6 });
+  }
+
   function addDocs(...docs: Document[]): Promise<void> {
     let data = documentMap();
     for (const doc of docs) {
@@ -1303,7 +1479,7 @@ describe('IndexedDbIndexManager', async () => {
     expect(actualResults).to.not.equal(null, 'Expected successful query');
     const actualKeys: string[] = [];
     actualResults!.forEach(v => actualKeys.push(v.path.toString()));
-    expect(actualKeys).to.have.members(keys);
+    expect(actualKeys).to.have.ordered.members(keys);
   }
 });
 

--- a/packages/firestore/test/unit/local/test_index_manager.ts
+++ b/packages/firestore/test/unit/local/test_index_manager.ts
@@ -18,7 +18,8 @@
 import { Target } from '../../../src/core/target';
 import { IndexManager } from '../../../src/local/index_manager';
 import { Persistence } from '../../../src/local/persistence';
-import { DocumentKeySet, DocumentMap } from '../../../src/model/collections';
+import { DocumentMap } from '../../../src/model/collections';
+import { DocumentKey } from '../../../src/model/document_key';
 import { FieldIndex, IndexOffset } from '../../../src/model/field_index';
 import { ResourcePath } from '../../../src/model/path';
 
@@ -76,7 +77,7 @@ export class TestIndexManager {
     );
   }
 
-  getDocumentsMatchingTarget(target: Target): Promise<DocumentKeySet | null> {
+  getDocumentsMatchingTarget(target: Target): Promise<DocumentKey[] | null> {
     return this.persistence.runTransaction(
       'getDocumentsMatchingTarget',
       'readonly',

--- a/packages/firestore/test/unit/model/target.test.ts
+++ b/packages/firestore/test/unit/model/target.test.ts
@@ -41,6 +41,9 @@ import {
 } from '../../util/helpers';
 
 describe('Target Bounds', () => {
+  // TODO(indexing): Consider adding more test helpers to reduce the boilerplate
+  // in these tests.
+
   it('empty query', () => {
     const target = queryToTarget(query('c'));
     const index = fieldIndex('c');
@@ -52,7 +55,7 @@ describe('Target Bounds', () => {
     verifyBound(upperBound, true);
   });
 
-  it('equals query', () => {
+  it('equals query with ascending index', () => {
     const target = queryToTarget(query('c', filter('foo', '==', 'bar')));
     const index = fieldIndex('c', { fields: [['foo', IndexKind.ASCENDING]] });
 
@@ -63,9 +66,20 @@ describe('Target Bounds', () => {
     verifyBound(upperBound, true, 'bar');
   });
 
-  it('less than query', () => {
-    const target = queryToTarget(query('c', filter('foo', '<', 'bar')));
+  it('equals query with descending index', () => {
+    const target = queryToTarget(query('c', filter('foo', '==', 'bar')));
     const index = fieldIndex('c', { fields: [['foo', IndexKind.DESCENDING]] });
+
+    const lowerBound = targetGetLowerBound(target, index);
+    verifyBound(lowerBound, true, 'bar');
+
+    const upperBound = targetGetUpperBound(target, index);
+    verifyBound(upperBound, true, 'bar');
+  });
+
+  it('less than query with ascending index', () => {
+    const target = queryToTarget(query('c', filter('foo', '<', 'bar')));
+    const index = fieldIndex('c', { fields: [['foo', IndexKind.ASCENDING]] });
 
     const lowerBound = targetGetLowerBound(target, index);
     verifyBound(lowerBound, true, '');
@@ -74,7 +88,18 @@ describe('Target Bounds', () => {
     verifyBound(upperBound, false, 'bar');
   });
 
-  it('less than or equals query', () => {
+  it('less than query with descending index', () => {
+    const target = queryToTarget(query('c', filter('foo', '<', 'bar')));
+    const index = fieldIndex('c', { fields: [['foo', IndexKind.DESCENDING]] });
+
+    const lowerBound = targetGetLowerBound(target, index);
+    verifyBound(lowerBound, false, 'bar');
+
+    const upperBound = targetGetUpperBound(target, index);
+    verifyBound(upperBound, true, '');
+  });
+
+  it('less than or equals query with ascending index', () => {
     const target = queryToTarget(query('c', filter('foo', '<=', 'bar')));
     const index = fieldIndex('c', { fields: [['foo', IndexKind.ASCENDING]] });
 
@@ -85,7 +110,18 @@ describe('Target Bounds', () => {
     verifyBound(upperBound, true, 'bar');
   });
 
-  it('greater than query', () => {
+  it('less than or equals query with descending index', () => {
+    const target = queryToTarget(query('c', filter('foo', '<=', 'bar')));
+    const index = fieldIndex('c', { fields: [['foo', IndexKind.DESCENDING]] });
+
+    const lowerBound = targetGetLowerBound(target, index);
+    verifyBound(lowerBound, true, 'bar');
+
+    const upperBound = targetGetUpperBound(target, index);
+    verifyBound(upperBound, true, '');
+  });
+
+  it('greater than query with ascending index', () => {
     const target = queryToTarget(query('c', filter('foo', '>', 'bar')));
     const index = fieldIndex('c', { fields: [['foo', IndexKind.ASCENDING]] });
 
@@ -96,15 +132,37 @@ describe('Target Bounds', () => {
     verifyBound(upperBound, false, blob());
   });
 
-  it('greater than or equals query', () => {
-    const target = queryToTarget(query('c', filter('foo', '>=', 'bar')));
+  it('greater than query with descending index', () => {
+    const target = queryToTarget(query('c', filter('foo', '>', 'bar')));
     const index = fieldIndex('c', { fields: [['foo', IndexKind.DESCENDING]] });
+
+    const lowerBound = targetGetLowerBound(target, index);
+    verifyBound(lowerBound, false, blob());
+
+    const upperBound = targetGetUpperBound(target, index);
+    verifyBound(upperBound, false, 'bar');
+  });
+
+  it('greater than or equals query with ascending index', () => {
+    const target = queryToTarget(query('c', filter('foo', '>=', 'bar')));
+    const index = fieldIndex('c', { fields: [['foo', IndexKind.ASCENDING]] });
 
     const lowerBound = targetGetLowerBound(target, index);
     verifyBound(lowerBound, true, 'bar');
 
     const upperBound = targetGetUpperBound(target, index);
     verifyBound(upperBound, false, blob());
+  });
+
+  it('greater than or equals query with descending index', () => {
+    const target = queryToTarget(query('c', filter('foo', '>=', 'bar')));
+    const index = fieldIndex('c', { fields: [['foo', IndexKind.DESCENDING]] });
+
+    const lowerBound = targetGetLowerBound(target, index);
+    verifyBound(lowerBound, false, blob());
+
+    const upperBound = targetGetUpperBound(target, index);
+    verifyBound(upperBound, true, 'bar');
   });
 
   it('arrayContains query', () => {


### PR DESCRIPTION
This adds code to order all query results by document key, which is needed to return the correct result for limit queries.

Port of https://github.com/firebase/firebase-android-sdk/pull/3499