### PR TITLE
Add app-check-types as a dependency for app-check-compat

### DIFF
--- a/.changeset/fluffy-tools-thank.md
+++ b/.changeset/fluffy-tools-thank.md
@@ -1,0 +1,5 @@
+---
+'@firebase/app-check-compat': patch
+---
+
+Added `app-check-types` dependency to `app-check-compat` package.json.

--- a/packages/app-check-compat/package.json
+++ b/packages/app-check-compat/package.json
@@ -35,6 +35,7 @@
   },
   "dependencies": {
     "@firebase/app-check": "0.5.4",
+    "@firebase/app-check-types": "0.4.0",
     "@firebase/logger": "0.3.2",
     "@firebase/util": "1.5.0",
     "@firebase/component": "0.5.11",


### PR DESCRIPTION
This was overlooked when app-check-compat was created.