### PR TITLE
Updated typings for database methods

### DIFF
--- a/.changeset/eighty-coats-hide.md
+++ b/.changeset/eighty-coats-hide.md
@@ -1,0 +1,5 @@
+---
+'@firebase/database-types': patch
+---
+
+Updated typings for Reference methods

--- a/packages/database-compat/src/api/Reference.ts
+++ b/packages/database-compat/src/api/Reference.ts
@@ -601,7 +601,7 @@ export class Reference extends Query implements Compat<ModularReference> {
   set(
     newVal: unknown,
     onComplete?: (error: Error | null) => void
-  ): Promise<unknown> {
+  ): Promise<void> {
     validateArgCount('Reference.set', 1, 2, arguments.length);
     validateCallback('Reference.set', 'onComplete', onComplete, true);
     const result = set(this._delegate, newVal);
@@ -617,7 +617,7 @@ export class Reference extends Query implements Compat<ModularReference> {
   update(
     values: object,
     onComplete?: (a: Error | null) => void
-  ): Promise<unknown> {
+  ): Promise<void> {
     validateArgCount('Reference.update', 1, 2, arguments.length);
 
     if (Array.isArray(values)) {
@@ -650,7 +650,7 @@ export class Reference extends Query implements Compat<ModularReference> {
     newVal: unknown,
     newPriority: string | number | null,
     onComplete?: (a: Error | null) => void
-  ): Promise<unknown> {
+  ): Promise<void> {
     validateArgCount('Reference.setWithPriority', 2, 3, arguments.length);
     validateCallback(
       'Reference.setWithPriority',
@@ -669,7 +669,7 @@ export class Reference extends Query implements Compat<ModularReference> {
     return result;
   }
 
-  remove(onComplete?: (a: Error | null) => void): Promise<unknown> {
+  remove(onComplete?: (a: Error | null) => void): Promise<void> {
     validateArgCount('Reference.remove', 0, 1, arguments.length);
     validateCallback('Reference.remove', 'onComplete', onComplete, true);
 
@@ -733,7 +733,7 @@ export class Reference extends Query implements Compat<ModularReference> {
   setPriority(
     priority: string | number | null,
     onComplete?: (a: Error | null) => void
-  ): Promise<unknown> {
+  ): Promise<void> {
     validateArgCount('Reference.setPriority', 1, 2, arguments.length);
     validateCallback('Reference.setPriority', 'onComplete', onComplete, true);
 

--- a/packages/database-types/index.d.ts
+++ b/packages/database-types/index.d.ts
@@ -125,29 +125,34 @@ export interface Reference extends Query {
   onDisconnect(): OnDisconnect;
   parent: Reference | null;
   push(value?: any, onComplete?: (a: Error | null) => any): ThenableReference;
-  remove(onComplete?: (a: Error | null) => any): Promise<any>;
+  remove(onComplete?: (a: Error | null) => void): Promise<void>;
   root: Reference;
-  set(value: any, onComplete?: (a: Error | null) => any): Promise<any>;
+  set(value: any, onComplete?: (a: Error | null) => void): Promise<void>;
   setPriority(
     priority: string | number | null,
-    onComplete: (a: Error | null) => any
-  ): Promise<any>;
+    onComplete: (a: Error | null) => void
+  ): Promise<void>;
   setWithPriority(
     newVal: any,
     newPriority: string | number | null,
-    onComplete?: (a: Error | null) => any
-  ): Promise<any>;
+    onComplete?: (a: Error | null) => void
+  ): Promise<void>;
   transaction(
     transactionUpdate: (a: any) => any,
-    onComplete?: (a: Error | null, b: boolean, c: DataSnapshot | null) => any,
+    onComplete?: (a: Error | null, b: boolean, c: DataSnapshot | null) => void,
     applyLocally?: boolean
-  ): Promise<any>;
-  update(values: Object, onComplete?: (a: Error | null) => any): Promise<any>;
+  ): Promise<TransactionResult>;
+  update(values: Object, onComplete?: (a: Error | null) => void): Promise<void>;
 }
 
 export interface ServerValue {
   TIMESTAMP: Object;
   increment(delta: number): Object;
+}
+
+export interface TransactionResult {
+  committed: boolean;
+  snapshot: DataSnapshot;
 }
 
 export interface ThenableReference

--- a/packages/firebase/compat/index.d.ts
+++ b/packages/firebase/compat/index.d.ts
@@ -7082,7 +7082,7 @@ declare namespace firebase.database {
      *   complete.
      * @return Resolves when remove on server is complete.
      */
-    remove(onComplete?: (a: Error | null) => any): Promise<any>;
+    remove(onComplete?: (a: Error | null) => void): Promise<void>;
     /**
      * The root `Reference` of the Database.
      *
@@ -7160,7 +7160,7 @@ declare namespace firebase.database {
      *   complete.
      * @return Resolves when write to server is complete.
      */
-    set(value: any, onComplete?: (a: Error | null) => any): Promise<any>;
+    set(value: any, onComplete?: (a: Error | null) => void): Promise<void>;
     /**
      * Sets a priority for the data at this Database location.
      *
@@ -7172,8 +7172,8 @@ declare namespace firebase.database {
      */
     setPriority(
       priority: string | number | null,
-      onComplete: (a: Error | null) => any
-    ): Promise<any>;
+      onComplete: (a: Error | null) => void
+    ): Promise<void>;
     /**
      * Writes data the Database location. Like `set()` but also specifies the
      * priority for that data.
@@ -7187,8 +7187,8 @@ declare namespace firebase.database {
     setWithPriority(
       newVal: any,
       newPriority: string | number | null,
-      onComplete?: (a: Error | null) => any
-    ): Promise<any>;
+      onComplete?: (a: Error | null) => void
+    ): Promise<void>;
     /**
      * Atomically modifies the data at this location.
      *
@@ -7280,9 +7280,9 @@ declare namespace firebase.database {
         a: Error | null,
         b: boolean,
         c: firebase.database.DataSnapshot | null
-      ) => any,
+      ) => void,
       applyLocally?: boolean
-    ): Promise<any>;
+    ): Promise<TransactionResult>;
     /**
      * Writes multiple values to the Database at once.
      *
@@ -7329,7 +7329,21 @@ declare namespace firebase.database {
      *   complete.
      * @return Resolves when update on server is complete.
      */
-    update(values: Object, onComplete?: (a: Error | null) => any): Promise<any>;
+    update(
+      values: Object,
+      onComplete?: (a: Error | null) => void
+    ): Promise<void>;
+  }
+
+  interface TransactionResult {
+    /**
+     * Whether the transaction was successfully committed.
+     */
+    committed: boolean;
+    /**
+     * The resulting data snapshot.
+     */
+    snapshot: DataSnapshot;
   }
 
   interface ThenableReference


### PR DESCRIPTION
Fixes #6071. I've also update the return type for the `onComplete` handler that the methods also accept.

I've copied the comments for the `TransactionResult` interface from the corresponding `@firebase/database` package:

https://github.com/firebase/firebase-js-sdk/blob/14ccbadd034e1a702f7d91e70ec14856d445764f/packages/database/src/api/Transaction.ts#L42-L49