### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/packages/auth/src/core/auth/emulator.ts
+++ b/packages/auth/src/core/auth/emulator.ts
@@ -82,7 +82,7 @@ export function connectAuthEmulator(
 
 function extractProtocol(url: string): string {
   const protocolEnd = url.indexOf(':');
-  return protocolEnd < 0 ? '' : url.substr(0, protocolEnd + 1);
+  return protocolEnd < 0 ? '' : url.slice(0, protocolEnd + 1);
 }
 
 function extractHostAndPort(url: string): {
@@ -90,7 +90,7 @@ function extractHostAndPort(url: string): {
   port: number | null;
 } {
   const protocol = extractProtocol(url);
-  const authority = /(\/\/)?([^?#/]+)/.exec(url.substr(protocol.length)); // Between // and /, ? or #.
+  const authority = /(\/\/)?([^?#/]+)/.exec(url.slice(protocol.length)); // Between // and /, ? or #.
   if (!authority) {
     return { host: '', port: null };
   }
@@ -98,7 +98,7 @@ function extractHostAndPort(url: string): {
   const bracketedIPv6 = /^(\[[^\]]+\])(:|$)/.exec(hostAndPort);
   if (bracketedIPv6) {
     const host = bracketedIPv6[1];
-    return { host, port: parsePort(hostAndPort.substr(host.length + 1)) };
+    return { host, port: parsePort(hostAndPort.slice(host.length + 1)) };
   } else {
     const [host, port] = hostAndPort.split(':');
     return { host, port: parsePort(port) };

--- a/packages/database/src/core/RepoInfo.ts
+++ b/packages/database/src/core/RepoInfo.ts
@@ -48,13 +48,13 @@ export class RepoInfo {
     public readonly includeNamespaceInQueryParams: boolean = false
   ) {
     this._host = host.toLowerCase();
-    this._domain = this._host.substr(this._host.indexOf('.') + 1);
+    this._domain = this._host.slice(this._host.indexOf('.') + 1);
     this.internalHost =
       (PersistentStorage.get('host:' + host) as string) || this._host;
   }
 
   isCacheableHost(): boolean {
-    return this.internalHost.substr(0, 2) === 's-';
+    return this.internalHost.slice(0, 2) === 's-';
   }
 
   isCustomHost() {

--- a/packages/database/src/core/SyncTree.ts
+++ b/packages/database/src/core/SyncTree.ts
@@ -841,8 +841,8 @@ function syncTreeParseQueryKey_(queryKey: string): {
     'Bad queryKey.'
   );
   return {
-    queryId: queryKey.substr(splitIndex + 1),
-    path: new Path(queryKey.substr(0, splitIndex))
+    queryId: queryKey.slice(splitIndex + 1),
+    path: new Path(queryKey.slice(0, splitIndex))
   };
 }
 

--- a/packages/database/src/core/util/util.ts
+++ b/packages/database/src/core/util/util.ts
@@ -437,7 +437,7 @@ export const doubleToIEEE754String = function (v: number): string {
   // Return the data as a hex string. --MJL
   let hexByteString = '';
   for (i = 0; i < 64; i += 8) {
-    let hexByte = parseInt(str.substr(i, 8), 2).toString(16);
+    let hexByte = parseInt(str.slice(i, i + 8), 2).toString(16);
     if (hexByte.length === 1) {
       hexByte = '0' + hexByte;
     }

--- a/packages/database/src/realtime/BrowserPollConnection.ts
+++ b/packages/database/src/realtime/BrowserPollConnection.ts
@@ -467,7 +467,7 @@ export class FirebaseIFrameScriptHolder {
       // for ie9, but ie8 needs to do it again in the document itself.
       if (
         this.myIFrame.src &&
-        this.myIFrame.src.substr(0, 'javascript:'.length) === 'javascript:'
+        this.myIFrame.src.slice(0, 'javascript:'.length) === 'javascript:'
       ) {
         const currentDomain = document.domain;
         script = '<script>document.domain="' + currentDomain + '";</script>';

--- a/packages/firestore/src/model/normalize.ts
+++ b/packages/firestore/src/model/normalize.ts
@@ -48,7 +48,7 @@ export function normalizeTimestamp(date: Timestamp): {
     if (fraction[1]) {
       // Pad the fraction out to 9 digits (nanos).
       let nanoStr = fraction[1];
-      nanoStr = (nanoStr + '000000000').substr(0, 9);
+      nanoStr = (nanoStr + '000000000').slice(0, 9);
       nanos = Number(nanoStr);
     }
 

--- a/packages/firestore/test/unit/index/ordered_code_writer.test.ts
+++ b/packages/firestore/test/unit/index/ordered_code_writer.test.ts
@@ -221,7 +221,7 @@ describe('Ordered Code Writer', () => {
 function fromHex(hexString: string): Uint8Array {
   const bytes = new Uint8Array(hexString.length / 2);
   for (let i = 0; i < hexString.length; i += 2) {
-    bytes[i / 2] = parseInt(hexString.substr(i, 2), 16);
+    bytes[i / 2] = parseInt(hexString.slice(i, i + 2), 16);
   }
   return bytes;
 }

--- a/packages/installations/src/helpers/generate-fid.ts
+++ b/packages/installations/src/helpers/generate-fid.ts
@@ -51,5 +51,5 @@ function encode(fidByteArray: Uint8Array): string {
 
   // Remove the 23rd character that was added because of the extra 4 bits at the
   // end of our 17 byte array, and the '=' padding.
-  return b64String.substr(0, 22);
+  return b64String.slice(0, 22);
 }

--- a/repo-scripts/api-documenter/src/utils/IndentedWriter.ts
+++ b/repo-scripts/api-documenter/src/utils/IndentedWriter.ts
@@ -147,7 +147,7 @@ export class IndentedWriter {
    */
   public peekLastCharacter(): string {
     if (this._latestChunk !== undefined) {
-      return this._latestChunk.substr(-1, 1);
+      return this._latestChunk.slice(-1);
     }
     return '';
   }
@@ -159,10 +159,10 @@ export class IndentedWriter {
   public peekSecondLastCharacter(): string {
     if (this._latestChunk !== undefined) {
       if (this._latestChunk.length > 1) {
-        return this._latestChunk.substr(-2, 1);
+        return this._latestChunk.slice(-2, -1);
       }
       if (this._previousChunk !== undefined) {
-        return this._previousChunk.substr(-1, 1);
+        return this._previousChunk.slice(-1);
       }
     }
     return '';


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.
