### PR TITLE
Specify readonly as the default indexeddb transaction mode

### DIFF
--- a/.changeset/hungry-owls-hide.md
+++ b/.changeset/hungry-owls-hide.md
@@ -1,0 +1,5 @@
+---
+'@firebase/util': patch
+---
+
+Default indexeddb transaction mode to readonly for IE11 compatibility

--- a/packages/util/src/indexeddb.ts
+++ b/packages/util/src/indexeddb.ts
@@ -42,7 +42,7 @@ export class DBWrapper {
   }
   transaction(
     storeNames: string[] | string,
-    mode?: IDBTransactionMode
+    mode: IDBTransactionMode = 'readonly'
   ): TransactionWrapper {
     return new TransactionWrapper(
       this._db.transaction.call(this._db, storeNames, mode)


### PR DESCRIPTION
While the mode parameter is optional, the wrapper method will pass `undefined` into the native method if it is not passed into the wrapper. IE11 interprets this as a mode instead of ignoring it and throws an InvalidAccessError.

Specifying `readonly` as the default (which is the default if the parameter is omitted) prevents IE11 from crashing during initialization.

This PR fixes #6121.
