### PR TITLE
Update App Check to v1 from v1beta

### DIFF
--- a/.changeset/new-gorillas-film.md
+++ b/.changeset/new-gorillas-film.md
@@ -2,4 +2,4 @@
 '@firebase/app-check': patch
 ---
 
-Update App Check to v1 from v1beta for both reCAPTCHA v3 and reCAPTCHA Enterprise
+Update App Check to use v1 endpoint instead of v1beta endpoint for both reCAPTCHA v3 and reCAPTCHA Enterprise

--- a/.changeset/new-gorillas-film.md
+++ b/.changeset/new-gorillas-film.md
@@ -1,0 +1,5 @@
+---
+'@firebase/app-check': patch
+---
+
+Update App Check to v1 from v1beta for both reCAPTCHA v3 and reCAPTCHA Enterprise

--- a/packages/app-check/src/client.test.ts
+++ b/packages/app-check/src/client.test.ts
@@ -47,7 +47,7 @@ describe('client', () => {
     const { projectId, appId, apiKey } = app.options;
 
     expect(request).to.deep.equal({
-      url: `${BASE_ENDPOINT}/projects/${projectId}/apps/${appId}:exchangeRecaptchaToken?key=${apiKey}`,
+      url: `${BASE_ENDPOINT}/projects/${projectId}/apps/${appId}:exchangeRecaptchaV3Token?key=${apiKey}`,
       body: {
         // eslint-disable-next-line camelcase
         recaptcha_token: 'fake-recaptcha-token'

--- a/packages/app-check/src/client.test.ts
+++ b/packages/app-check/src/client.test.ts
@@ -78,7 +78,7 @@ describe('client', () => {
       Promise.resolve({
         status: 200,
         json: async () => ({
-          attestationToken: 'fake-appcheck-token',
+          token: 'fake-appcheck-token',
           ttl: '3.600s'
         })
       } as Response)
@@ -189,7 +189,7 @@ describe('client', () => {
         status: 200,
         json: () =>
           Promise.resolve({
-            attestationToken: 'fake-appcheck-token',
+            token: 'fake-appcheck-token',
             ttl: 'NAN'
           })
       } as Response)

--- a/packages/app-check/src/client.test.ts
+++ b/packages/app-check/src/client.test.ts
@@ -50,7 +50,7 @@ describe('client', () => {
       url: `${BASE_ENDPOINT}/projects/${projectId}/apps/${appId}:exchangeRecaptchaV3Token?key=${apiKey}`,
       body: {
         // eslint-disable-next-line camelcase
-        recaptcha_token: 'fake-recaptcha-token'
+        recaptcha_v3_token: 'fake-recaptcha-token'
       }
     });
   });

--- a/packages/app-check/src/client.ts
+++ b/packages/app-check/src/client.ts
@@ -30,7 +30,7 @@ import { AppCheckTokenInternal } from './types';
  * Response JSON returned from AppCheck server endpoint.
  */
 interface AppCheckResponse {
-  attestationToken: string;
+  token: string;
   // timeToLive
   ttl: string;
 }
@@ -101,7 +101,7 @@ export async function exchangeToken(
 
   const now = Date.now();
   return {
-    token: responseBody.attestationToken,
+    token: responseBody.token,
     expireTimeMillis: now + timeToLiveAsNumber,
     issuedAtTimeMillis: now
   };

--- a/packages/app-check/src/client.ts
+++ b/packages/app-check/src/client.ts
@@ -116,7 +116,7 @@ export function getExchangeRecaptchaV3TokenRequest(
   return {
     url: `${BASE_ENDPOINT}/projects/${projectId}/apps/${appId}:${EXCHANGE_RECAPTCHA_TOKEN_METHOD}?key=${apiKey}`,
     body: {
-      'recaptcha_token': reCAPTCHAToken
+      'recaptcha_v3_token': reCAPTCHAToken
     }
   };
 }

--- a/packages/app-check/src/constants.ts
+++ b/packages/app-check/src/constants.ts
@@ -15,9 +15,9 @@
  * limitations under the License.
  */
 export const BASE_ENDPOINT =
-  'https://content-firebaseappcheck.googleapis.com/v1beta';
+  'https://content-firebaseappcheck.googleapis.com/v1';
 
-export const EXCHANGE_RECAPTCHA_TOKEN_METHOD = 'exchangeRecaptchaToken';
+export const EXCHANGE_RECAPTCHA_TOKEN_METHOD = 'exchangeRecaptchaV3Token';
 export const EXCHANGE_RECAPTCHA_ENTERPRISE_TOKEN_METHOD =
   'exchangeRecaptchaEnterpriseToken';
 export const EXCHANGE_DEBUG_TOKEN_METHOD = 'exchangeDebugToken';

--- a/packages/app-check/src/internal-api.test.ts
+++ b/packages/app-check/src/internal-api.test.ts
@@ -111,7 +111,7 @@ describe('internal api', () => {
 
       expect(reCAPTCHASpy).to.be.called;
 
-      expect(exchangeTokenStub.args[0][0].body['recaptcha_token']).to.equal(
+      expect(exchangeTokenStub.args[0][0].body['recaptcha_v3_token']).to.equal(
         fakeRecaptchaToken
       );
       expect(token).to.deep.equal({ token: fakeRecaptchaAppCheckToken.token });


### PR DESCRIPTION
For both reCAPTCHA v3 and reCAPTCHA Enterprise:

1. Updated URL to exchange for an App Check token
2. Updated the response JSON object containing the FAC token