### PR TITLE
[patch] Pre-process variables before adding into indexedDB

### DIFF
--- a/packages/firestore/src/local/simple_db.ts
+++ b/packages/firestore/src/local/simple_db.ts
@@ -589,6 +589,25 @@ export class SimpleDbStore<
     keyOrValue: KeyType | ValueType,
     value?: ValueType
   ): PersistencePromise<void> {
+    try {
+      keyOrValue =
+        keyOrValue != null
+          ? JSON.parse(JSON.stringify(keyOrValue))
+          : keyOrValue;
+    } catch {
+      console.warn(
+        'Could not process value before adding into indexedDB: ',
+        keyOrValue
+      );
+    }
+    try {
+      value = value != null ? JSON.parse(JSON.stringify(value)) : value;
+    } catch {
+      console.warn(
+        'Could not process value before adding into indexedDB:  ',
+        value
+      );
+    }
     let request;
     if (value !== undefined) {
       logDebug(LOG_TAG, 'PUT', this.store.name, keyOrValue, value);


### PR DESCRIPTION
Serialize and deserialize key-value pairs before adding them into indexedDB. This prevents invalid values (like functions) from being added into indexedDB, and fixes [Issue 6087](https://github.com/firebase/firebase-js-sdk/issues/6087).

You can test these changes live [here](https://firestore-db-persistence-error.pages.dev/) [[see code](https://github.com/Shanzid01/firestore-db-persistence-error)].
