### PR TITLE
Change functions bump to minor

### DIFF
--- a/.changeset/new-bugs-think.md
+++ b/.changeset/new-bugs-think.md
@@ -3,4 +3,4 @@
 "@firebase/functions": minor
 ---
 
-Add `httpsCallableFromURL()`.
+Add `httpsCallableFromURL()`, which calls a callable function using its url.

--- a/.changeset/new-bugs-think.md
+++ b/.changeset/new-bugs-think.md
@@ -1,6 +1,6 @@
 ---
-"@firebase/functions-compat": patch
-"@firebase/functions": patch
+"@firebase/functions-compat": minor
+"@firebase/functions": minor
 ---
 
-Add httpsCallableFromURL
+Add `httpsCallableFromURL()`.


### PR DESCRIPTION
Amend https://github.com/firebase/firebase-js-sdk/pull/6162 to change version bumps to minor since we're adding a new method and changing the API. My bad for not noticing this when PR was approved.