### PR TITLE
[Auth] Add onAbort and refactor middleware

### DIFF
--- a/common/api-review/auth.api.md
+++ b/common/api-review/auth.api.md
@@ -81,7 +81,7 @@ export function applyActionCode(auth: Auth, oobCode: string): Promise<void>;
 // @public
 export interface Auth {
     readonly app: FirebaseApp;
-    beforeAuthStateChanged(callback: (user: User | null) => void | Promise<void>): Unsubscribe;
+    beforeAuthStateChanged(callback: (user: User | null) => void | Promise<void>, onAbort?: () => void): Unsubscribe;
     readonly config: Config;
     readonly currentUser: User | null;
     readonly emulatorConfig: EmulatorConfig | null;

--- a/common/api-review/auth.api.md
+++ b/common/api-review/auth.api.md
@@ -243,6 +243,9 @@ export interface AuthSettings {
 }
 
 // @public
+export function beforeAuthStateChanged(auth: Auth, callback: (user: User | null) => void | Promise<void>, onAbort?: () => void): Unsubscribe;
+
+// @public
 export const browserLocalPersistence: Persistence;
 
 // @public

--- a/packages/auth/src/core/auth/middleware.test.ts
+++ b/packages/auth/src/core/auth/middleware.test.ts
@@ -1,0 +1,132 @@
+import { expect, use } from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import * as sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import { testAuth, testUser } from '../../../test/helpers/mock_auth';
+import { AuthInternal } from '../../model/auth';
+import { User } from '../../model/public_types';
+import { AuthMiddlewareQueue } from './middleware';
+
+use(chaiAsPromised);
+use(sinonChai);
+
+describe('Auth middleware', () => {
+  let middlewareQueue: AuthMiddlewareQueue;
+  let user: User;
+  let auth: AuthInternal;
+
+  beforeEach(async () => {
+    auth = await testAuth();
+    user = testUser(auth, 'uid');
+    middlewareQueue = new AuthMiddlewareQueue(auth);
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('calls middleware in order', async () => {
+    const calls: number[] = [];
+
+    middlewareQueue.pushCallback(() => {calls.push(1);});
+    middlewareQueue.pushCallback(() => {calls.push(2);});
+    middlewareQueue.pushCallback(() => {calls.push(3);});
+
+    await middlewareQueue.runMiddleware(user);
+
+    expect(calls).to.eql([1, 2, 3]);
+  });
+
+  it('rejects on error', async () => {
+    middlewareQueue.pushCallback(() => {
+      throw new Error('no');
+    });
+    await expect(middlewareQueue.runMiddleware(user)).to.be.rejectedWith('auth/login-blocked');
+  });
+
+  it('rejects on promise rejection', async () => {
+    middlewareQueue.pushCallback(() => Promise.reject('no'));
+    await expect(middlewareQueue.runMiddleware(user)).to.be.rejectedWith('auth/login-blocked');
+  });
+
+  it('awaits middleware completion before calling next', async () => {
+    const firstCb = sinon.spy();
+    const secondCb = sinon.spy();
+
+    middlewareQueue.pushCallback(() => {
+      // Force the first one to run one tick later
+      return new Promise(resolve => {
+        setTimeout(() => {
+          firstCb();
+          resolve();
+        }, 1);
+      });
+    });
+    middlewareQueue.pushCallback(secondCb);
+
+    await middlewareQueue.runMiddleware(user);
+    expect(secondCb).to.have.been.calledAfter(firstCb);
+  });
+
+  it('subsequent middleware not run after rejection', async () => {
+    const spy = sinon.spy();
+
+    middlewareQueue.pushCallback(() => {
+      throw new Error('no');
+    });
+    middlewareQueue.pushCallback(spy);
+
+    await expect(middlewareQueue.runMiddleware(user)).to.be.rejectedWith('auth/login-blocked');
+    expect(spy).not.to.have.been.called;
+  });
+
+  it('calls onAbort if provided but only for earlier runs', async () => {
+    const firstOnAbort = sinon.spy();
+    const secondOnAbort = sinon.spy();
+
+    middlewareQueue.pushCallback(() => {}, firstOnAbort);
+    middlewareQueue.pushCallback(() => {
+      throw new Error('no');
+    }, secondOnAbort);
+
+    await expect(middlewareQueue.runMiddleware(user)).to.be.rejectedWith('auth/login-blocked');
+    expect(firstOnAbort).to.have.been.called;
+    expect(secondOnAbort).not.to.have.been.called;
+  });
+
+  it('calls onAbort in order', async () => {
+    const calls: number[] = [];
+
+    middlewareQueue.pushCallback(() => {}, () => {calls.push(1);});
+    middlewareQueue.pushCallback(() => {}, () => {calls.push(2);});
+    middlewareQueue.pushCallback(() => {}, () => {calls.push(3);});
+    middlewareQueue.pushCallback(() => {
+      throw new Error('no');
+    });
+
+    await expect(middlewareQueue.runMiddleware(user)).to.be.rejectedWith('auth/login-blocked');
+    expect(calls).to.eql([3, 2, 1]);
+  });
+
+  it('does not call any middleware if user matches null', async () => {
+    const spy = sinon.spy();
+
+    middlewareQueue.pushCallback(spy);
+    await middlewareQueue.runMiddleware(null);
+
+    expect(spy).not.to.have.been.called;
+  });
+
+  it('does not call any middleware if user matches object', async () => {
+    const spy = sinon.spy();
+
+    // Directly set it manually since the public function creates a
+    // copy of the user.
+    auth.currentUser = user;
+
+    middlewareQueue.pushCallback(spy);
+    await middlewareQueue.runMiddleware(user);
+
+    expect(spy).not.to.have.been.called;
+  });
+});

--- a/packages/auth/src/core/auth/middleware.test.ts
+++ b/packages/auth/src/core/auth/middleware.test.ts
@@ -94,7 +94,7 @@ describe('Auth middleware', () => {
     expect(secondOnAbort).not.to.have.been.called;
   });
 
-  it('calls onAbort in order', async () => {
+  it('calls onAbort in reverse order', async () => {
     const calls: number[] = [];
 
     middlewareQueue.pushCallback(() => {}, () => {calls.push(1);});

--- a/packages/auth/src/core/auth/middleware.ts
+++ b/packages/auth/src/core/auth/middleware.ts
@@ -1,0 +1,76 @@
+import { AuthInternal } from '../../model/auth';
+import { Unsubscribe, User } from '../../model/public_types';
+import { AuthErrorCode } from '../errors';
+
+interface MiddlewareEntry {
+  (user: User | null): Promise<void>;
+  onAbort?: () => void;
+}
+
+export class AuthMiddlewareQueue {
+  private readonly queue: MiddlewareEntry[] = [];
+
+  constructor(private readonly auth: AuthInternal) {}
+
+  pushCallback(
+      callback: (user: User | null) => void | Promise<void>,
+      onAbort?: () => void): Unsubscribe {
+    // The callback could be sync or async. Wrap it into a
+    // function that is always async.
+    const wrappedCallback: MiddlewareEntry =
+      (user: User | null): Promise<void> => new Promise((resolve, reject) => {
+        try {
+          const result = callback(user);
+          // Either resolve with existing promise or wrap a non-promise
+          // return value into a promise.
+          resolve(result);
+        } catch (e) {
+          // Sync callback throws.
+          reject(e);
+        }
+      });
+    // Attach the onAbort if present
+    wrappedCallback.onAbort = onAbort;
+    this.queue.push(wrappedCallback);
+
+    const index = this.queue.length - 1;
+    return () => {
+      // Unsubscribe. Replace with no-op. Do not remove from array, or it will disturb
+      // indexing of other elements.
+      this.queue[index] = () => Promise.resolve();
+    };
+  }
+
+  async runMiddleware(nextUser: User | null): Promise<void> {
+    if (this.auth.currentUser === nextUser) {
+      return;
+    }
+
+    // While running the middleware, build a temporary stack of onAbort
+    // callbacks to call if one middleware callback rejects.
+
+    const onAbortStack: Array<() => void> = [];
+    try {
+      for (const beforeStateCallback of this.queue) {
+        await beforeStateCallback(nextUser);
+
+        // Only push the onAbort if the callback succeeds
+        if (beforeStateCallback.onAbort) {
+          onAbortStack.push(beforeStateCallback.onAbort);
+        }
+      }
+    } catch (e) {
+      // Run all onAbort, with separate try/catch to ignore any errors and
+      // continue
+      onAbortStack.reverse();
+      for (const onAbort of onAbortStack) {
+        try {
+          onAbort();
+        } catch (_) { /* swallow error */}
+      }
+
+      throw this.auth._errorFactory.create(
+        AuthErrorCode.LOGIN_BLOCKED, { originalMessage: e.message });
+    }
+  }
+}

--- a/packages/auth/src/core/index.ts
+++ b/packages/auth/src/core/index.ts
@@ -84,6 +84,26 @@ export function onIdTokenChanged(
   );
 }
 /**
+ * Adds a blocking callback that runs before an auth state change
+ * sets a new user.
+ *
+ * @param auth - The {@link Auth} instance.
+ * @param callback - callback triggered before new user value is set.
+ *   If this throws, it will block the user from being set.
+ * @param onAbort - callback triggered if a later before state changed
+ *   callback throws, allowing you to undo any side effects.
+ */
+ export function beforeAuthStateChanged(
+  auth: Auth,
+  callback: (user: User|null) => void | Promise<void>,
+  onAbort?: () => void,
+): Unsubscribe {
+  return getModularInstance(auth).beforeAuthStateChanged(
+    callback,
+    onAbort
+  );
+}
+/**
  * Adds an observer for changes to the user's sign-in state.
  *
  * @remarks

--- a/packages/auth/src/core/index.ts
+++ b/packages/auth/src/core/index.ts
@@ -89,8 +89,8 @@ export function onIdTokenChanged(
  *
  * @param auth - The {@link Auth} instance.
  * @param callback - callback triggered before new user value is set.
- *   If this throws, it will block the user from being set.
- * @param onAbort - callback triggered if a later before state changed
+ *   If this throws, it blocks the user from being set.
+ * @param onAbort - callback triggered if a later `beforeAuthStateChanged()`
  *   callback throws, allowing you to undo any side effects.
  */
  export function beforeAuthStateChanged(

--- a/packages/auth/src/model/public_types.ts
+++ b/packages/auth/src/model/public_types.ts
@@ -260,9 +260,12 @@ export interface Auth {
    *
    * @param callback - callback triggered before new user value is set.
    *   If this throws, it blocks the user from being set.
+   * @param onAbort - callback triggered if a later before state changed
+   *   callback throws, allowing you to undo any side effects.
    */
   beforeAuthStateChanged(
-    callback: (user: User | null) => void | Promise<void>
+    callback: (user: User | null) => void | Promise<void>,
+    onAbort?: () => void,
   ): Unsubscribe;
   /**
    * Adds an observer for changes to the signed-in user's ID token.

--- a/packages/auth/src/model/public_types.ts
+++ b/packages/auth/src/model/public_types.ts
@@ -260,7 +260,7 @@ export interface Auth {
    *
    * @param callback - callback triggered before new user value is set.
    *   If this throws, it blocks the user from being set.
-   * @param onAbort - callback triggered if a later before state changed
+   * @param onAbort - callback triggered if a later `beforeAuthStateChanged()`
    *   callback throws, allowing you to undo any side effects.
    */
   beforeAuthStateChanged(


### PR DESCRIPTION
I've refactored the middleware code to its own class since it got sufficiently complicated with the `onAbort()` callbacks. 