### PR TITLE
Add missing entries to compat toc

### DIFF
--- a/scripts/docgen-compat/content-sources/js/toc.yaml
+++ b/scripts/docgen-compat/content-sources/js/toc.yaml
@@ -28,6 +28,8 @@ toc:
     path: /docs/reference/js/v8/firebase.appcheck.CustomProvider
   - title: "CustomProviderOptions"
     path: /docs/reference/js/v8/firebase.appcheck.CustomProviderOptions
+  - title: "ReCaptchaEnterpriseProvider"
+    path: /docs/reference/js/v8/firebase.appcheck.ReCaptchaEnterpriseProvider
   - title: "ReCaptchaV3Provider"
     path: /docs/reference/js/v8/firebase.appcheck.ReCaptchaV3Provider
 
@@ -154,6 +156,8 @@ toc:
     path: /docs/reference/js/v8/firebase.database.ServerValue
   - title: "ThenableReference"
     path: /docs/reference/js/v8/firebase.database.ThenableReference
+  - title: "TransactionResult"
+    path: /docs/reference/js/v8/firebase.database.TransactionResult
 
 - title: "firebase.firestore"
   path: /docs/reference/js/v8/firebase.firestore

--- a/scripts/docgen-compat/content-sources/node/toc.yaml
+++ b/scripts/docgen-compat/content-sources/node/toc.yaml
@@ -112,6 +112,8 @@ toc:
     path: /docs/reference/node/firebase.database.ServerValue
   - title: "ThenableReference"
     path: /docs/reference/node/firebase.database.ThenableReference
+  - title: "TransactionResult"
+    path: /docs/reference/node/firebase.database.TransactionResult
 
 - title: "firebase.firestore"
   path: /docs/reference/node/firebase.firestore


### PR DESCRIPTION
Overlooked adding new items to compat docs toc.yaml:

- Add `ReCaptchaEnterpriseProvider` to JS compat docs.
- Add `TransactionResult` to JS and Node compat docs.