### PR TITLE
Update types for js-yaml

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "@types/sinon-chai": "3.2.5",
     "@types/tmp": "0.2.1",
     "@types/yargs": "17.0.3",
-    "@types/js-yaml": "4.0.3",
+    "@types/js-yaml": "4.0.5",
     "@types/request": "2.48.7",
     "@typescript-eslint/eslint-plugin": "4.31.2",
     "@typescript-eslint/eslint-plugin-tslint": "4.31.2",

--- a/repo-scripts/api-documenter/package.json
+++ b/repo-scripts/api-documenter/package.json
@@ -31,7 +31,7 @@
     "js-yaml": "4.1.0"
   },
   "devDependencies": {
-    "@types/js-yaml": "4.0.3",
+    "@types/js-yaml": "4.0.5",
     "@types/resolve": "1.20.1",
     "mocha-chai-jest-snapshot": "1.1.3"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3097,10 +3097,10 @@
   dependencies:
     "@types/istanbul-lib-report" "*"
 
-"@types/js-yaml@4.0.3":
-  version "4.0.3"
-  resolved "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.3.tgz#9f33cd6fbf0d5ec575dc8c8fc69c7fec1b4eb200"
-  integrity sha512-5t9BhoORasuF5uCPr+d5/hdB++zRFUTMIZOzbNkr+jZh3yQht4HYbRDyj9fY8n2TZT30iW9huzav73x4NikqWg==
+"@types/js-yaml@4.0.5":
+  version "4.0.5"
+  resolved "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.5.tgz#738dd390a6ecc5442f35e7f03fa1431353f7e138"
+  integrity sha512-FhpRzf927MNQdRZP0J5DLIdTXhjLYzeUTmLAu69mnVksLH9CJY3IuSeEgbKUki7GQZm0WqDkGzyxju2EZGD2wA==
 
 "@types/json-schema@*", "@types/json-schema@^7.0.5", "@types/json-schema@^7.0.6", "@types/json-schema@^7.0.7", "@types/json-schema@^7.0.8":
   version "7.0.9"


### PR DESCRIPTION
Updating types for js-yaml as mentioned in [pull request 5566](https://github.com/firebase/firebase-js-sdk/pull/5566/files#) for all non-major dependencies.