### PR TITLE
Enforce POSIX-style newlines for API Extractor

### DIFF
--- a/config/api-extractor.json
+++ b/config/api-extractor.json
@@ -271,7 +271,7 @@
    *
    * DEFAULT VALUE: "crlf"
    */
-  // "newlineKind": "crlf",
+  "newlineKind": "lf",
 
   /**
    * Configures how API Extractor reports error and warning messages produced during analysis.


### PR DESCRIPTION
Update config file to use POSIX-style newlines to remove inconsistencies when various contributors push to Github. We were having issues where git thought every line in the md file was different instead of giving a useful diff report. 