### PR TITLE
Fix e2e tests

### DIFF
--- a/e2e/karma.conf.js
+++ b/e2e/karma.conf.js
@@ -58,7 +58,9 @@ module.exports = function (config) {
           directories: ['./node_modules'],
           alias: {
             '@firebase/messaging/sw':
-              'node_modules/@firebase/messaging/dist/index.sw.esm2017.js'
+              'node_modules/@firebase/messaging/dist/index.sw.esm2017.js',
+            'idb':
+              'node_modules/idb/build/index.js'
           }
         },
         transforms: [
@@ -77,7 +79,14 @@ module.exports = function (config) {
         ]
       },
       compilerOptions: {
-        allowJs: true
+        allowJs: true,
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "resolveJsonModule": true,
+        "esModuleInterop": true,
+        "sourceMap": true,
+        "target": "es5",
+        "importHelpers": true,
       }
     },
     plugins: [

--- a/e2e/karma.conf.js
+++ b/e2e/karma.conf.js
@@ -59,8 +59,7 @@ module.exports = function (config) {
           alias: {
             '@firebase/messaging/sw':
               'node_modules/@firebase/messaging/dist/index.sw.esm2017.js',
-            'idb':
-              'node_modules/idb/build/index.js'
+            'idb': 'node_modules/idb/build/index.js'
           }
         },
         transforms: [
@@ -80,13 +79,13 @@ module.exports = function (config) {
       },
       compilerOptions: {
         allowJs: true,
-        "module": "commonjs",
-        "moduleResolution": "node",
-        "resolveJsonModule": true,
-        "esModuleInterop": true,
-        "sourceMap": true,
-        "target": "es5",
-        "importHelpers": true,
+        'module': 'commonjs',
+        'moduleResolution': 'node',
+        'resolveJsonModule': true,
+        'esModuleInterop': true,
+        'sourceMap': true,
+        'target': 'es5',
+        'importHelpers': true
       }
     },
     plugins: [

--- a/e2e/sample-apps/modular.js
+++ b/e2e/sample-apps/modular.js
@@ -23,7 +23,11 @@ import {
   logEvent
 } from 'firebase/analytics';
 import { initializeAppCheck, CustomProvider } from 'firebase/app-check';
-import { getFunctions, httpsCallable, httpsCallableFromURL } from 'firebase/functions';
+import {
+  getFunctions,
+  httpsCallable,
+  httpsCallableFromURL
+} from 'firebase/functions';
 import {
   getStorage,
   ref,

--- a/e2e/sample-apps/modular.js
+++ b/e2e/sample-apps/modular.js
@@ -23,7 +23,7 @@ import {
   logEvent
 } from 'firebase/analytics';
 import { initializeAppCheck, CustomProvider } from 'firebase/app-check';
-import { getFunctions, httpsCallable } from 'firebase/functions';
+import { getFunctions, httpsCallable, httpsCallableFromURL } from 'firebase/functions';
 import {
   getStorage,
   ref,
@@ -133,7 +133,7 @@ async function callFunctions(app) {
       throw e;
     }
   }
-  callTest = httpsCallableByUrl(
+  callTest = httpsCallableFromURL(
     functions,
     `https://us-central-${app.options.projectId}.cloudfunctions.net/callTest`
   );

--- a/e2e/webpack.config.js
+++ b/e2e/webpack.config.js
@@ -57,7 +57,7 @@ module.exports = [
     },
     devtool: 'source-map',
     devServer: {
-      contentBase: './build'
+      static: './build'
     }
   },
   {
@@ -96,7 +96,7 @@ module.exports = [
     },
     devtool: 'source-map',
     devServer: {
-      contentBase: './build'
+      static: './build'
     }
   }
 ];


### PR DESCRIPTION
I think the E2E tests were failing (https://github.com/firebase/firebase-js-sdk/actions/runs/2278640484) because karma-typescript was trying to grab the cjs module for idb and karma-typescript config doesn't allow specifying module fields preferences. This fixes it locally, will see how it runs on CI after merged.