### PR TITLE
Fix API call, add commit message

### DIFF
--- a/.github/workflows/merge-release-branch.yml
+++ b/.github/workflows/merge-release-branch.yml
@@ -1,6 +1,11 @@
 name: Merge Release Into Master
 
-on: workflow_dispatch
+on: 
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version'     
+        required: true
 
 jobs:
   merge_to_master:
@@ -14,9 +19,10 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            github.repos.merge({
+            github.rest.repos.merge({
               owner: context.repo.owner,
               repo: context.repo.repo,
               base: 'master',
-              head: 'release'
+              head: 'release',
+              commit_message: 'Release ${{ github.event.inputs.version }}'
             })

--- a/.github/workflows/merge-release-branch.yml
+++ b/.github/workflows/merge-release-branch.yml
@@ -21,16 +21,16 @@ jobs:
           echo "::set-output name=RELEASE_VERSION::$VERSION"
       - name: Echo version in shell
         run: |
-          echo "Merging release ${{ steps.get-version.outputs.RELEASE_VERSION }}"
-      - name: Merge to master
-        uses: actions/github-script@v6
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            github.rest.repos.merge({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              base: 'master',
-              head: 'release',
-              commit_message: 'Release ${{ steps.get-version.outputs.RELEASE_VERSION }}'
-            })
+          echo "Merging release $VERSION ${{ steps.get-version.outputs.RELEASE_VERSION }}"
+      # - name: Merge to master
+      #   uses: actions/github-script@v6
+      #   with:
+      #     github-token: ${{ secrets.GITHUB_TOKEN }}
+      #     script: |
+      #       github.rest.repos.merge({
+      #         owner: context.repo.owner,
+      #         repo: context.repo.repo,
+      #         base: 'master',
+      #         head: 'release',
+      #         commit_message: 'Release ${{ steps.get-version.outputs.RELEASE_VERSION }}'
+      #       })

--- a/.github/workflows/merge-release-branch.yml
+++ b/.github/workflows/merge-release-branch.yml
@@ -14,15 +14,28 @@ jobs:
     permissions:
       contents: write
     steps:
-      - name: Merge to master
-        uses: actions/github-script@v6
+      - name: Checkout Release Branch
+        uses: actions/checkout@master
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            github.rest.repos.merge({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              base: 'master',
-              head: 'release',
-              commit_message: 'Release ${{ github.event.inputs.version }}'
-            })
+          ref: release
+      - name: Get release version
+        id: get-version
+        run: |
+          export VERSION_SCRIPT="const pkg = require('./packages/firebase/package.json'); console.log(pkg.version);"
+          export VERSION=`node -e "${VERSION_SCRIPT}"`
+          echo "::set-output name=RELEASE_VERSION::$VERSION"
+      - name: Test
+        run: |
+          echo "${{ steps.get-version.outputs.RELEASE_VERSION }}"
+      # - name: Merge to master
+      #   uses: actions/github-script@v6
+      #   with:
+      #     github-token: ${{ secrets.GITHUB_TOKEN }}
+      #     script: |
+      #       github.rest.repos.merge({
+      #         owner: context.repo.owner,
+      #         repo: context.repo.repo,
+      #         base: 'master',
+      #         head: 'release',
+      #         commit_message: 'Release ${{ steps.get-version.outputs.RELEASE_VERSION }}'
+      #       })

--- a/.github/workflows/merge-release-branch.yml
+++ b/.github/workflows/merge-release-branch.yml
@@ -20,18 +20,18 @@ jobs:
           export VERSION_SCRIPT="const pkg = require('./packages/firebase/package.json'); console.log(pkg.version);"
           export VERSION=`node -e "${VERSION_SCRIPT}"`
           echo "::set-output name=RELEASE_VERSION::$VERSION"
-      - name: Test
+      - name: Echo version in shell
         run: |
-          echo "${{ steps.get-version.outputs.RELEASE_VERSION }}"
-      # - name: Merge to master
-      #   uses: actions/github-script@v6
-      #   with:
-      #     github-token: ${{ secrets.GITHUB_TOKEN }}
-      #     script: |
-      #       github.rest.repos.merge({
-      #         owner: context.repo.owner,
-      #         repo: context.repo.repo,
-      #         base: 'master',
-      #         head: 'release',
-      #         commit_message: 'Release ${{ steps.get-version.outputs.RELEASE_VERSION }}'
-      #       })
+          echo "Merging release ${{ steps.get-version.outputs.RELEASE_VERSION }}"
+      - name: Merge to master
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            github.rest.repos.merge({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              base: 'master',
+              head: 'release',
+              commit_message: 'Release ${{ steps.get-version.outputs.RELEASE_VERSION }}'
+            })

--- a/.github/workflows/merge-release-branch.yml
+++ b/.github/workflows/merge-release-branch.yml
@@ -1,11 +1,7 @@
 name: Merge Release Into Master
 
 on: 
-  workflow_dispatch:
-    inputs:
-      version:
-        description: 'Release version'     
-        required: true
+  workflow_dispatch
 
 jobs:
   merge_to_master:

--- a/.github/workflows/merge-release-branch.yml
+++ b/.github/workflows/merge-release-branch.yml
@@ -1,7 +1,6 @@
 name: Merge Release Into Master
 
-on: 
-  workflow_dispatch
+on: workflow_dispatch
 
 jobs:
   merge_to_master:

--- a/.github/workflows/merge-release-branch.yml
+++ b/.github/workflows/merge-release-branch.yml
@@ -21,16 +21,16 @@ jobs:
           echo "::set-output name=RELEASE_VERSION::$VERSION"
       - name: Echo version in shell
         run: |
-          echo "Merging release $VERSION ${{ steps.get-version.outputs.RELEASE_VERSION }}"
-      # - name: Merge to master
-      #   uses: actions/github-script@v6
-      #   with:
-      #     github-token: ${{ secrets.GITHUB_TOKEN }}
-      #     script: |
-      #       github.rest.repos.merge({
-      #         owner: context.repo.owner,
-      #         repo: context.repo.repo,
-      #         base: 'master',
-      #         head: 'release',
-      #         commit_message: 'Release ${{ steps.get-version.outputs.RELEASE_VERSION }}'
-      #       })
+          echo "Merging release ${{ steps.get-version.outputs.RELEASE_VERSION }}"
+      - name: Merge to master
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            github.rest.repos.merge({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              base: 'master',
+              head: 'release',
+              commit_message: 'Release ${{ steps.get-version.outputs.RELEASE_VERSION }}'
+            })


### PR DESCRIPTION
- github-script v6 needs REST APIs to be called with `github.rest` instead of `github`.
- Add an input field so we can put the version into the merge commit message (https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/)