### PR TITLE
Tag some internal auth types with @internal tag

### DIFF
--- a/packages/auth/src/model/id_token.ts
+++ b/packages/auth/src/model/id_token.ts
@@ -87,6 +87,9 @@ export const enum IdTokenResponseKind {
   VerifyPassword = 'identitytoolkit#VerifyPasswordResponse'
 }
 
+/**
+ * @internal
+ */
 export interface TaggedWithTokenResponse {
   _tokenResponse?: PhoneOrOauthTokenResponse;
 }

--- a/packages/auth/src/model/user.ts
+++ b/packages/auth/src/model/user.ts
@@ -90,6 +90,9 @@ export interface UserInternal extends User {
   toJSON(): PersistedBlob;
 }
 
+/**
+ * @internal
+ */
 export interface UserCredentialInternal
   extends UserCredential,
     TaggedWithTokenResponse {


### PR DESCRIPTION
Somehow https://github.com/firebase/firebase-js-sdk/pull/6151 caused api-extractor to write these types to the public d.ts when it hadn't previously. Explicitly tagging them as `@internal`.

Fixes https://github.com/firebase/firebase-js-sdk/issues/6246