### PR TITLE
Mark Auth error callbacks as deprecated

### DIFF
--- a/packages/auth/src/core/index.ts
+++ b/packages/auth/src/core/index.ts
@@ -61,8 +61,10 @@ export function setPersistence(
   return getModularInstance(auth).setPersistence(persistence);
 }
 /**
- * Adds an observer for changes to the signed-in user's ID token, which includes sign-in,
- * sign-out, and token refresh events.
+ * Adds an observer for changes to the signed-in user's ID token.
+ *
+ * @remarks
+ * This includes sign-in, sign-out, and token refresh events.
  *
  * @param auth - The {@link Auth} instance.
  * @param nextOrObserver - callback triggered on change.

--- a/packages/auth/src/core/index.ts
+++ b/packages/auth/src/core/index.ts
@@ -66,7 +66,9 @@ export function setPersistence(
  *
  * @param auth - The {@link Auth} instance.
  * @param nextOrObserver - callback triggered on change.
- * @param error - callback triggered on error.
+ * @param error - Deprecated. This callback is never triggered. Errors
+ * on signing in/out can be caught in promises returned from
+ * sign-in/sign-out functions.
  * @param completed - callback triggered when observer is removed.
  *
  * @public
@@ -111,7 +113,9 @@ export function onIdTokenChanged(
  *
  * @param auth - The {@link Auth} instance.
  * @param nextOrObserver - callback triggered on change.
- * @param error - callback triggered on error.
+ * @param error - Deprecated. This callback is never triggered. Errors
+ * on signing in/out can be caught in promises returned from
+ * sign-in/sign-out functions.
  * @param completed - callback triggered when observer is removed.
  *
  * @public

--- a/packages/auth/src/core/index.ts
+++ b/packages/auth/src/core/index.ts
@@ -71,7 +71,7 @@ export function setPersistence(
  * @param error - Deprecated. This callback is never triggered. Errors
  * on signing in/out can be caught in promises returned from
  * sign-in/sign-out functions.
- * @param completed - callback triggered when observer is removed.
+ * @param completed - Deprecated. This callback is never triggered.
  *
  * @public
  */
@@ -118,7 +118,7 @@ export function onIdTokenChanged(
  * @param error - Deprecated. This callback is never triggered. Errors
  * on signing in/out can be caught in promises returned from
  * sign-in/sign-out functions.
- * @param completed - callback triggered when observer is removed.
+ * @param completed - Deprecated. This callback is never triggered.
  *
  * @public
  */

--- a/packages/auth/src/model/public_types.ts
+++ b/packages/auth/src/model/public_types.ts
@@ -242,6 +242,7 @@ export interface Auth {
   /**
    * Adds an observer for changes to the user's sign-in state.
    *
+   * @remarks
    * To keep the old behavior, see {@link Auth.onIdTokenChanged}.
    *
    * @param nextOrObserver - callback triggered on change.

--- a/packages/auth/src/model/public_types.ts
+++ b/packages/auth/src/model/public_types.ts
@@ -242,11 +242,12 @@ export interface Auth {
   /**
    * Adds an observer for changes to the user's sign-in state.
    *
-   * @remarks
    * To keep the old behavior, see {@link Auth.onIdTokenChanged}.
    *
    * @param nextOrObserver - callback triggered on change.
-   * @param error - callback triggered on error.
+   * @param error - Deprecated. This callback is never triggered. Errors
+   * on signing in/out can be caught in promises returned from
+   * sign-in/sign-out functions.
    * @param completed - callback triggered when observer is removed.
    */
   onAuthStateChanged(
@@ -274,7 +275,9 @@ export interface Auth {
    * This includes sign-in, sign-out, and token refresh events.
    *
    * @param nextOrObserver - callback triggered on change.
-   * @param error - callback triggered on error.
+   * @param error - Deprecated. This callback is never triggered. Errors
+   * on signing in/out can be caught in promises returned from
+   * sign-in/sign-out functions.
    * @param completed - callback triggered when observer is removed.
    */
   onIdTokenChanged(

--- a/packages/auth/src/model/public_types.ts
+++ b/packages/auth/src/model/public_types.ts
@@ -249,7 +249,7 @@ export interface Auth {
    * @param error - Deprecated. This callback is never triggered. Errors
    * on signing in/out can be caught in promises returned from
    * sign-in/sign-out functions.
-   * @param completed - callback triggered when observer is removed.
+   * @param completed - Deprecated. This callback is never triggered.
    */
   onAuthStateChanged(
     nextOrObserver: NextOrObserver<User | null>,
@@ -279,7 +279,7 @@ export interface Auth {
    * @param error - Deprecated. This callback is never triggered. Errors
    * on signing in/out can be caught in promises returned from
    * sign-in/sign-out functions.
-   * @param completed - callback triggered when observer is removed.
+   * @param completed - Deprecated. This callback is never triggered.
    */
   onIdTokenChanged(
     nextOrObserver: NextOrObserver<User | null>,


### PR DESCRIPTION
`error` and `completed` callbacks in `onAuthStateChanged()` and `onIdTokenChanged()` have always been no-op, even since before v9. Changing the docs to reflect this and to mark them as deprecated in preparation for removing them in a future major bump.

- We can't use the actual `@deprecated` tag on a single param, only on an entire function or interface, so I just put the word "Deprecated" in the comment. That means we won't get the big red box that devsite puts on deprecated items: https://firebase.google.com/docs/reference/js/analytics.item I don't think there's a way around it, I don't think devsite can put that box around params either, considering the way params are formatted.
- `packages/auth/src/core/index.ts` is the actual source of truth for the docgen, so copied some comment formatting from the other file into here.
- The `@remarks` tag doesn't seem to have any effect on the actual body text in the reference doc: https://firebase.google.com/docs/reference/js/auth#onauthstatechanged However, in the table of contents at the top of that doc, it cuts off the part after the `@remarks` tag for brevity within the table.