### PR TITLE
Deprecate analytics function setCurrentScreen

### DIFF
--- a/common/api-review/analytics.api.md
+++ b/common/api-review/analytics.api.md
@@ -388,7 +388,7 @@ export interface Promotion {
 // @public
 export function setAnalyticsCollectionEnabled(analyticsInstance: Analytics, enabled: boolean): void;
 
-// @public
+// @public @deprecated
 export function setCurrentScreen(analyticsInstance: Analytics, screenName: string, options?: AnalyticsCallOptions): void;
 
 // @public

--- a/packages/analytics-compat/src/service.test.ts
+++ b/packages/analytics-compat/src/service.test.ts
@@ -109,14 +109,14 @@ describe('Firebase Analytics > Service', () => {
     setUserIdStub.resetHistory();
   });
 
-  it('setCurrentScreen() calls modular setCurrentScreen()', () => {
+  it('setCurrentScreen() (deprecated) calls modular setCurrentScreen() (deprecated)', () => {
     service = createTestService(app);
     service.setCurrentScreen('some_screen');
     expect(setCurrentScreenStub).to.be.calledWith(match.any, 'some_screen');
     setCurrentScreenStub.resetHistory();
   });
 
-  it('setCurrentScreen() calls modular setCurrentScreen() with options if provided', () => {
+  it('setCurrentScreen() (deprecated) calls modular setCurrentScreen() (deprecated) with options if provided', () => {
     service = createTestService(app);
     service.setCurrentScreen('some_screen', { global: true });
     expect(setCurrentScreenStub).to.be.calledWith(match.any, 'some_screen', {

--- a/packages/analytics-compat/src/service.ts
+++ b/packages/analytics-compat/src/service.ts
@@ -45,6 +45,7 @@ export class AnalyticsService implements FirebaseAnalytics, _FirebaseService {
     logEventExp(this._delegate, eventName as '', eventParams, options);
   }
 
+  /** @deprecated Use logEvent with eventName as 'screen_view' and add relevant eventParams. */
   setCurrentScreen(screenName: string, options?: AnalyticsCallOptions): void {
     setCurrentScreenExp(this._delegate, screenName, options);
   }

--- a/packages/analytics-types/index.d.ts
+++ b/packages/analytics-types/index.d.ts
@@ -23,7 +23,7 @@ export type DataLayer = Array<IArguments>;
 
 /**
  * Additional options that can be passed to Firebase Analytics method
- * calls such as `logEvent`, `setCurrentScreen`, etc.
+ * calls such as `logEvent`, etc.
  */
 export interface AnalyticsCallOptions {
   /**
@@ -453,6 +453,8 @@ export interface FirebaseAnalytics {
 
   /**
    * Use gtag 'config' command to set 'screen_name'.
+   *
+   * @deprecated Use logEvent with eventName as 'screen_view' and add relevant eventParams.
    */
   setCurrentScreen(screenName: string, options?: AnalyticsCallOptions): void;
 

--- a/packages/analytics/src/api.ts
+++ b/packages/analytics/src/api.ts
@@ -144,6 +144,8 @@ export async function isSupported(): Promise<boolean> {
  *
  * @public
  *
+ * @deprecated Use logEvent with eventName as 'screen_view' and add relevant eventParams.
+ *
  * @param analyticsInstance - The {@link Analytics} instance.
  * @param screenName - Screen name to set.
  */

--- a/packages/analytics/src/functions.test.ts
+++ b/packages/analytics/src/functions.test.ts
@@ -90,7 +90,7 @@ describe('FirebaseAnalytics methods', () => {
     );
   });
 
-  it('setCurrentScreen() calls gtag correctly (instance)', async () => {
+  it('setCurrentScreen() (deprecated) calls gtag correctly (instance)', async () => {
     await setCurrentScreen(gtagStub, fakeInitializationPromise, 'home');
     expect(gtagStub).to.have.been.calledWith(
       GtagCommand.CONFIG,
@@ -102,7 +102,7 @@ describe('FirebaseAnalytics methods', () => {
     );
   });
 
-  it('setCurrentScreen() calls gtag correctly (global)', async () => {
+  it('setCurrentScreen() (deprecated) calls gtag correctly (global)', async () => {
     await setCurrentScreen(gtagStub, fakeInitializationPromise, 'home', {
       global: true
     });

--- a/packages/analytics/src/functions.ts
+++ b/packages/analytics/src/functions.ts
@@ -53,6 +53,8 @@ export async function logEvent(
 /**
  * Set screen_name parameter for this Google Analytics ID.
  *
+ * @deprecated Use logEvent with eventName as 'screen_view' and add relevant eventParams.
+ *
  * @param gtagFunction Wrapped gtag function that waits for fid to be set before sending an event
  * @param screenName Screen name string to set.
  */

--- a/packages/analytics/src/public-types.ts
+++ b/packages/analytics/src/public-types.ts
@@ -93,7 +93,7 @@ export interface AnalyticsSettings {
 
 /**
  * Additional options that can be passed to Analytics method
- * calls such as `logEvent`, `setCurrentScreen`, etc.
+ * calls such as `logEvent`, etc.
  * @public
  */
 export interface AnalyticsCallOptions {

--- a/packages/firebase/compat/index.d.ts
+++ b/packages/firebase/compat/index.d.ts
@@ -5215,6 +5215,8 @@ declare namespace firebase.analytics {
 
     /**
      * Use gtag 'config' command to set 'screen_name'.
+     *
+     * @deprecated Use logEvent with eventName as 'screen_view' and add relevant eventParams.
      */
     setCurrentScreen(
       screenName: string,


### PR DESCRIPTION
Mark setCurrentScreen function within analytics as deprecated. Users should utilize logEvent with eventName as 'screen_view' and add the relevant eventParams. For more information, see https://firebase.google.com/docs/analytics/screenviews#web-version-9