### PR TITLE
Create staging release workflow

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -2,12 +2,8 @@ name: E2E Smoke Tests
 
 # Allows REST trigger. Currently triggered by release-cli script during a staging run.
 on:
-  workflow_dispatch:
-    inputs:
-      versionOrTag:
-        description: 'release version or tag'
-        required: true
-        default: 'next'
+  repository_dispatch:
+    types: [staging-tests]
 
 jobs:
   test:
@@ -39,8 +35,8 @@ jobs:
           echo "export const config = $PROJECT_CONFIG; export const testAccount = $TEST_ACCOUNT" > firebase-config.js
       - name: Yarn install
         run: |
-          echo "Installing firebase@${{ github.event.inputs.versionOrTag }}"
-          yarn add firebase@${{ github.event.inputs.versionOrTag }}
+          echo "Installing firebase@${{ github.event.client_payload.versionOrTag }}"
+          yarn add firebase@${{ github.event.client_payload.versionOrTag }}
           yarn
       - name: Deploy "callTest" cloud function
         run: |

--- a/.github/workflows/release-staging.yml
+++ b/.github/workflows/release-staging.yml
@@ -1,0 +1,131 @@
+name: Staging Release
+
+on:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    name: Staging Release
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Set up Node (14)
+      uses: actions/setup-node@v2
+      with:
+        node-version: 14.x
+    - name: Merge master into release
+      uses: actions/github-script@v6
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        script: |
+          github.repos.merge({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            base: 'release',
+            head: 'master'
+          })
+    - name: Checkout release branch (with history)
+      uses: actions/checkout@master
+      with:
+        # Release script requires git history and tags.
+        fetch-depth: 0
+        ref: release
+    - name: Yarn install
+      run: yarn
+    # Ensures a new @firebase/app is published with every release.
+    # This keeps the SDK_VERSION variable up to date.
+    - name: Add a changeset for @firebase/app
+      # pull master so changeset can diff against it
+      run: |
+        git pull -f --no-rebase origin master:master
+        yarn ts-node-script scripts/ci/add_changeset.ts
+    - name: Create Release Pull Request
+      uses: changesets/action@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.OSS_BOT_GITHUB_TOKEN }}
+    - name: Get release version
+      id: get-version
+      # STAGING_VERSION = version with staging hash, e.g. 1.2.3-20430523
+      # BASE_VERSION = version without staging hash, e.g. 1.2.3
+      run: |
+        VERSION_SCRIPT="const pkg = require('./packages/firebase/package.json'); console.log(pkg.version);"
+        VERSION=`node -e "${VERSION_SCRIPT}"`
+        echo "::set-output name=STAGING_VERSION::$VERSION"
+        BASE_VERSION=$(echo ${{ steps.get-version.outputs.STAGING_VERSION }} | cut -d "-" -f 1)
+        echo "::set-output name=BASE_VERSION::$BASE_VERSION"
+    - name: Echo version in shell
+      run: |
+        echo "Staging release ${{ steps.get-version.outputs.STAGING_VERSION }}"
+    - name: Publish to NPM
+      run: yarn release --releaseType staging
+      env:
+        NPM_TOKEN_ANALYTICS: ${{secrets.NPM_TOKEN_ANALYTICS}}
+        NPM_TOKEN_ANALYTICS_INTEROP_TYPES: ${{secrets.NPM_TOKEN_ANALYTICS_INTEROP_TYPES}}
+        NPM_TOKEN_ANALYTICS_TYPES: ${{secrets.NPM_TOKEN_ANALYTICS_TYPES}}
+        NPM_TOKEN_APP: ${{secrets.NPM_TOKEN_APP}}
+        NPM_TOKEN_APP_TYPES: ${{secrets.NPM_TOKEN_APP_TYPES}}
+        NPM_TOKEN_APP_CHECK: ${{secrets.NPM_TOKEN_APP_CHECK}}
+        NPM_TOKEN_APP_CHECK_INTEROP_TYPES: ${{secrets.NPM_TOKEN_APP_CHECK_INTEROP_TYPES}}
+        NPM_TOKEN_APP_CHECK_TYPES: ${{secrets.NPM_TOKEN_APP_CHECK_TYPES}}
+        NPM_TOKEN_AUTH: ${{secrets.NPM_TOKEN_AUTH}}
+        NPM_TOKEN_AUTH_INTEROP_TYPES: ${{secrets.NPM_TOKEN_AUTH_INTEROP_TYPES}}
+        NPM_TOKEN_AUTH_TYPES: ${{secrets.NPM_TOKEN_AUTH_TYPES}}
+        NPM_TOKEN_COMPONENT: ${{secrets.NPM_TOKEN_COMPONENT}}
+        NPM_TOKEN_DATABASE: ${{secrets.NPM_TOKEN_DATABASE}}
+        NPM_TOKEN_DATABASE_TYPES: ${{secrets.NPM_TOKEN_DATABASE_TYPES}}
+        NPM_TOKEN_FIRESTORE: ${{secrets.NPM_TOKEN_FIRESTORE}}
+        NPM_TOKEN_FIRESTORE_TYPES: ${{secrets.NPM_TOKEN_FIRESTORE_TYPES}}
+        NPM_TOKEN_FUNCTIONS: ${{secrets.NPM_TOKEN_FUNCTIONS}}
+        NPM_TOKEN_FUNCTIONS_TYPES: ${{secrets.NPM_TOKEN_FUNCTIONS_TYPES}}
+        NPM_TOKEN_INSTALLATIONS: ${{secrets.NPM_TOKEN_INSTALLATIONS}}
+        NPM_TOKEN_INSTALLATIONS_TYPES: ${{secrets.NPM_TOKEN_INSTALLATIONS_TYPES}}
+        NPM_TOKEN_LOGGER: ${{secrets.NPM_TOKEN_LOGGER}}
+        NPM_TOKEN_MESSAGING: ${{secrets.NPM_TOKEN_MESSAGING}}
+        NPM_TOKEN_MESSAGING_TYPES: ${{secrets.NPM_TOKEN_MESSAGING_TYPES}}
+        NPM_TOKEN_PERFORMANCE: ${{secrets.NPM_TOKEN_PERFORMANCE}}
+        NPM_TOKEN_PERFORMANCE_TYPES: ${{secrets.NPM_TOKEN_PERFORMANCE_TYPES}}
+        NPM_TOKEN_POLYFILL: ${{secrets.NPM_TOKEN_POLYFILL}}
+        NPM_TOKEN_REMOTE_CONFIG: ${{secrets.NPM_TOKEN_REMOTE_CONFIG}}
+        NPM_TOKEN_REMOTE_CONFIG_TYPES: ${{secrets.NPM_TOKEN_REMOTE_CONFIG_TYPES}}
+        NPM_TOKEN_RULES_UNIT_TESTING: ${{secrets.NPM_TOKEN_RULES_UNIT_TESTING}}
+        NPM_TOKEN_STORAGE: ${{secrets.NPM_TOKEN_STORAGE}}
+        NPM_TOKEN_STORAGE_TYPES: ${{secrets.NPM_TOKEN_STORAGE_TYPES}}
+        NPM_TOKEN_TESTING: ${{secrets.NPM_TOKEN_TESTING}}
+        NPM_TOKEN_UTIL: ${{secrets.NPM_TOKEN_UTIL}}
+        NPM_TOKEN_WEBCHANNEL_WRAPPER: ${{secrets.NPM_TOKEN_WEBCHANNEL_WRAPPER}}
+        NPM_TOKEN_FIREBASE: ${{secrets.NPM_TOKEN_FIREBASE}}
+        NPM_TOKEN_APP_COMPAT: ${{ secrets.NPM_TOKEN_APP_COMPAT }}
+        NPM_TOKEN_INSTALLATIONS_COMPAT: ${{ secrets.NPM_TOKEN_INSTALLATIONS_COMPAT }}
+        NPM_TOKEN_ANALYTICS_COMPAT: ${{ secrets.NPM_TOKEN_ANALYTICS_COMPAT }}
+        NPM_TOKEN_AUTH_COMPAT: ${{ secrets.NPM_TOKEN_AUTH_COMPAT }}
+        NPM_TOKEN_MESSAGING_INTEROP_TYPES: ${{ secrets.NPM_TOKEN_MESSAGING_INTEROP_TYPES }}
+        NPM_TOKEN_FUNCTIONS_COMPAT: ${{ secrets.NPM_TOKEN_FUNCTIONS_COMPAT }}
+        NPM_TOKEN_MESSAGING_COMPAT: ${{ secrets.NPM_TOKEN_MESSAGING_COMPAT }}
+        NPM_TOKEN_PERFORMANCE_COMPAT: ${{ secrets.NPM_TOKEN_PERFORMANCE_COMPAT }}
+        NPM_TOKEN_REMOTE_CONFIG_COMPAT: ${{ secrets.NPM_TOKEN_REMOTE_CONFIG_COMPAT }}
+        NPM_TOKEN_DATABASE_COMPAT: ${{ secrets.NPM_TOKEN_DATABASE_COMPAT }}
+        NPM_TOKEN_FIRESTORE_COMPAT: ${{ secrets.NPM_TOKEN_FIRESTORE_COMPAT }}
+        NPM_TOKEN_STORAGE_COMPAT: ${{ secrets.NPM_TOKEN_STORAGE_COMPAT }}
+        NPM_TOKEN_APP_CHECK_COMPAT: ${{ secrets.NPM_TOKEN_APP_CHECK_COMPAT }}
+        NPM_TOKEN_API_DOCUMENTER: ${{ secrets.NPM_TOKEN_API_DOCUMENTER }}
+        CI: true
+    - name: Launch E2E tests workflow
+      uses: peter-evans/repository-dispatch@v2
+      with:
+        token: ${{ secrets.OSS_BOT_GITHUB_TOKEN }}
+        repository: firebase/firebase-js-sdk
+        event-type: staging-tests
+        client-payload: '{"versionOrTag": "${{ steps.get-version.outputs.STAGING_VERSION }}"}'
+    - name: Log to release tracker
+      # Sends release information to cloud functions endpoint of release tracker.
+      run: |
+        DATE=$(date +'%m/%d/%Y')
+        BASE_VERSION=${{ steps.get-version.outputs.BASE_VERSION }}
+        STAGING_VERSION=${{ steps.get-version.outputs.STAGING_VERSION }}
+        OPERATOR=${{ github.actor }}
+        curl -X POST -H "Content-Type:application/json" \
+        -d "{\"version\":\"$BASE_VERSION\",\"tag\":\"$STAGING_VERSION\",\"date\":\"$DATE\",\"operator\":\"$OPERATOR\"}" \
+        https://us-central1-feature-tracker-8ca2b.cloudfunctions.net/logStaging

--- a/.github/workflows/release-staging.yml
+++ b/.github/workflows/release-staging.yml
@@ -60,7 +60,12 @@ jobs:
       run: |
         echo "Staging release ${{ steps.get-version.outputs.STAGING_VERSION }}"
     - name: Publish to NPM
-      run: yarn release --releaseType staging
+      # --skipTests No need to run tests
+      # --skipReinstall Yarn install has already been run
+      # --ignoreUnstaged Adding the @firebase/app changeset file means
+      # there's unstaged changes. Ignore.
+      # TODO: Make these flags defaults in the release script.
+      run: yarn release --releaseType staging --skipTests --skipReinstall --ignoreUnstaged
       env:
         NPM_TOKEN_ANALYTICS: ${{secrets.NPM_TOKEN_ANALYTICS}}
         NPM_TOKEN_ANALYTICS_INTEROP_TYPES: ${{secrets.NPM_TOKEN_ANALYTICS_INTEROP_TYPES}}

--- a/.github/workflows/release-staging.yml
+++ b/.github/workflows/release-staging.yml
@@ -113,12 +113,16 @@ jobs:
         NPM_TOKEN_API_DOCUMENTER: ${{ secrets.NPM_TOKEN_API_DOCUMENTER }}
         CI: true
     - name: Launch E2E tests workflow
-      uses: peter-evans/repository-dispatch@v2
-      with:
-        token: ${{ secrets.OSS_BOT_GITHUB_TOKEN }}
-        repository: firebase/firebase-js-sdk
-        event-type: staging-tests
-        client-payload: '{"versionOrTag": "${{ steps.get-version.outputs.STAGING_VERSION }}"}'
+      # Trigger e2e-test.yml
+      run: |
+        OSS_BOT_GITHUB_TOKEN=${{ secrets.OSS_BOT_GITHUB_TOKEN }}
+        VERSION_OR_TAG=${{ steps.get-version.outputs.STAGING_VERSION }}
+        curl -X POST \
+        -H "Content-Type:application/json" \
+        -H "Accept:application/vnd.github.v3+json" \
+        -H "Authorization:Bearer $OSS_BOT_GITHUB_TOKEN" \
+        -d "{\"event_type\":\"staging-tests\", \"client_payload\":{\"versionOrTag\":\"$VERSION_OR_TAG\"}}" \
+        https://api.github.com/repos/firebase/firebase-js-sdk/dispatches
     - name: Log to release tracker
       # Sends release information to cloud functions endpoint of release tracker.
       run: |

--- a/.github/workflows/release-staging.yml
+++ b/.github/workflows/release-staging.yml
@@ -126,6 +126,7 @@ jobs:
         BASE_VERSION=${{ steps.get-version.outputs.BASE_VERSION }}
         STAGING_VERSION=${{ steps.get-version.outputs.STAGING_VERSION }}
         OPERATOR=${{ github.actor }}
+        RELEASE_TRACKER_URL=${{ secrets.RELEASE_TRACKER_URL }}
         curl -X POST -H "Content-Type:application/json" \
         -d "{\"version\":\"$BASE_VERSION\",\"tag\":\"$STAGING_VERSION\",\"date\":\"$DATE\",\"operator\":\"$OPERATOR\"}" \
-        https://us-central1-feature-tracker-8ca2b.cloudfunctions.net/logStaging
+        $RELEASE_TRACKER_URL/logStaging


### PR DESCRIPTION
Moving as many release tasks as possible out of local script and into Github Actions.

Try creating a workflow for staging first. If all works well, make one for production in a future PR.

- Merge master into release
- Check out release branch
- yarn install
- Add changeset for @firebase/app to ensure that package is always published (this keeps the SDK_VERSION variable current)
- Create release PR (the "Version Changes" PR - use changesets Github action to automatically do this)
- Publish to NPM using wombat-dressing-room tokens
- Launch E2E tests workflow (changed e2e-test.yml workflow to use a `repository_dispatch` trigger to make it easier to call from here)
- Log staging info to Firebase release tracker (call a cloud function) - we should probably add some kind of auth check before launching this

CDN steps will be run separately and manually in google3 after the NPM publish is done.