### PR TITLE
Normalize line endings for markdown files checked into git

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,5 @@
+# Source files
+# ============
+*.md       text eol=lf
+
 *.json  linguist-language=JSON-with-Comments


### PR DESCRIPTION
Use https://git-scm.com/docs/gitattributes to normalize line endings for markdown files checked into git. We had issues in the past where files with different line endings would be checked in and the diff would show the entire file as changed. This will use the line endings specified for all markdown files checked in.