### PR TITLE
Prod workflow: Fix logic for detecting published packages

### DIFF
--- a/scripts/release/release.ts
+++ b/scripts/release/release.ts
@@ -27,6 +27,7 @@ import { reinstallDeps, buildPackages } from './utils/yarn';
 import { runTests, setupTestDeps } from './utils/tests';
 import { bumpVersionForStaging } from './staging';
 import { ReleaseType } from './utils/enums';
+import { getAllPackages } from './utils/workspace';
 const prompt = createPromptModule();
 
 interface releaseOptions {
@@ -94,12 +95,11 @@ export async function runRelease({
     console.log(`Publishing ${inputReleaseType} release.`);
 
     let packagesToPublish = [];
-
-    /**
-     * Bump versions for staging release
-     * NOTE: For prod, versions are bumped in a PR which should be merged before running this script
-     */
     if (releaseType === ReleaseType.Staging) {
+      /**
+       * Bump versions for staging release
+       * NOTE: For prod, versions are bumped in a PR which should be merged before running this script
+       */
       const updatedPackages = await bumpVersionForStaging();
 
       if (!ci) {
@@ -117,6 +117,13 @@ export async function runRelease({
       for (const key of updatedPackages.keys()) {
         packagesToPublish.push(key);
       }
+    } else {
+      /**
+       * For production releases, pass all packages to publishToCI().
+       * It will only publish if it finds the local version is newer
+       * than NPM's.
+       */
+      packagesToPublish = await getAllPackages();
     }
 
     /**

--- a/scripts/release/utils/publish.ts
+++ b/scripts/release/utils/publish.ts
@@ -42,45 +42,47 @@ export async function publishInCI(
   npmTag: string,
   dryRun: boolean
 ) {
-  const taskArray = await Promise.all(
-    updatedPkgs.map(async pkg => {
-      const path = await mapPkgNameToPkgPath(pkg);
+  const taskArray = [];
+  for (const pkg of updatedPkgs) {
+    const path = await mapPkgNameToPkgPath(pkg);
 
-      /**
-       * Can't require here because we have a cached version of the required JSON
-       * in memory and it doesn't contain the updates
-       */
-      const { version, private: isPrivate } = JSON.parse(
-        await readFile(`${path}/package.json`, 'utf8')
-      );
+    /**
+     * Can't require here because we have a cached version of the required JSON
+     * in memory and it doesn't contain the updates
+     */
+    const { version, private: isPrivate } = JSON.parse(
+      await readFile(`${path}/package.json`, 'utf8')
+    );
 
-      /**
-       * Skip private packages
-       */
-      if (isPrivate) {
-        return {
-          title: `Skipping private package: ${pkg}.`,
-          task: () => {}
-        };
-      }
+    /**
+     * Skip private packages
+     */
+    if (isPrivate) {
+      console.log(`Skipping private package: ${pkg}.`);
+      continue;
+    }
 
-      /**
-       * Skip if this version has already been published.
-       */
-      const { stdout: npmVersion } = await exec('npm info firebase version');
+    /**
+     * Skip if this version has already been published.
+     */
+    try {
+      const { stdout: npmVersion } = await exec(`npm info ${pkg} version`);
       if (version === npmVersion.trim()) {
-        return {
-          title: `Skipping publish of ${pkg} - version ${version} is already published`,
-          task: () => {}
-        };
+        console.log(`Skipping publish of ${pkg} - version ${version} is already published`);
+        continue;
       }
+    } catch (e) {
+      // 404 from NPM indicates the package doesn't exist there.
+      console.log(`Skipping pkg: ${pkg} - it has never been published to NPM.`);
+      continue;
+    }
 
-      return {
-        title: `📦  ${pkg}@${version}`,
-        task: () => publishPackageInCI(pkg, npmTag, dryRun)
-      };
-    })
-  );
+    taskArray.push({
+      title: `📦  ${pkg}@${version}`,
+      task: () => publishPackageInCI(pkg, npmTag, dryRun)
+    });
+  }
+
   const tasks = new Listr(taskArray, {
     concurrent: false,
     exitOnError: false
@@ -117,8 +119,7 @@ async function publishPackageInCI(
 
     // Write proxy registry token for this package to .npmrc.
     await exec(
-      `echo "//wombat-dressing-room.appspot.com/:_authToken=${
-        process.env[getEnvTokenKey(pkg)]
+      `echo "//wombat-dressing-room.appspot.com/:_authToken=${process.env[getEnvTokenKey(pkg)]
       }" >> ~/.npmrc`
     );
 

--- a/scripts/release/utils/publish.ts
+++ b/scripts/release/utils/publish.ts
@@ -68,7 +68,9 @@ export async function publishInCI(
     try {
       const { stdout: npmVersion } = await exec(`npm info ${pkg} version`);
       if (version === npmVersion.trim()) {
-        console.log(`Skipping publish of ${pkg} - version ${version} is already published`);
+        console.log(
+          `Skipping publish of ${pkg} - version ${version} is already published`
+        );
         continue;
       }
     } catch (e) {
@@ -119,7 +121,8 @@ async function publishPackageInCI(
 
     // Write proxy registry token for this package to .npmrc.
     await exec(
-      `echo "//wombat-dressing-room.appspot.com/:_authToken=${process.env[getEnvTokenKey(pkg)]
+      `echo "//wombat-dressing-room.appspot.com/:_authToken=${
+        process.env[getEnvTokenKey(pkg)]
       }" >> ~/.npmrc`
     );
 


### PR DESCRIPTION
- If production release, pass all packages to publishToCI(), which will sort out which needs to be published.
- Fix logic in publishToCI() to detect this.

Was able to test run successfully with some modifications (used --dryRun flag, skipped release tracker step)