### PR TITLE
fix: add type definitions to exports field

### DIFF
--- a/packages/analytics-compat/package.json
+++ b/packages/analytics-compat/package.json
@@ -11,7 +11,8 @@
     ".": {
       "require": "./dist/index.cjs.js",
       "esm5": "./dist/esm/index.esm.js",
-      "default": "./dist/esm/index.esm2017.js"
+      "default": "./dist/esm/index.esm2017.js",
+      "types": "./dist/src/index.d.ts"
     },
     "./package.json": "./package.json"
   },

--- a/packages/analytics/package.json
+++ b/packages/analytics/package.json
@@ -11,7 +11,8 @@
     ".": {
       "require": "./dist/index.cjs.js",
       "esm5": "./dist/esm/index.esm.js",
-      "default": "./dist/esm/index.esm2017.js"
+      "default": "./dist/esm/index.esm2017.js",
+      "types": "./dist/analytics-public.d.ts"
     },
     "./package.json": "./package.json"
   },

--- a/packages/app-check-compat/package.json
+++ b/packages/app-check-compat/package.json
@@ -11,7 +11,8 @@
     ".": {
       "require": "./dist/index.cjs.js",
       "esm5": "./dist/esm/index.esm.js",
-      "default": "./dist/esm/index.esm2017.js"
+      "default": "./dist/esm/index.esm2017.js",
+      "types": "./dist/src/index.d.ts"
     },
     "./package.json": "./package.json"
   },

--- a/packages/app-check/package.json
+++ b/packages/app-check/package.json
@@ -11,7 +11,8 @@
     ".": {
       "require": "./dist/index.cjs.js",
       "esm5": "./dist/esm/index.esm.js",
-      "default": "./dist/esm/index.esm2017.js"
+      "default": "./dist/esm/index.esm2017.js",
+      "types": "./dist/app-check-public.d.ts"
     },
     "./package.json": "./package.json"
   },

--- a/packages/app-compat/package.json
+++ b/packages/app-compat/package.json
@@ -15,7 +15,8 @@
       "esm5": "./dist/esm/index.esm5.js",
       "lite": "./dist/index.lite.js",
       "liteesm5": "./dist/index.lite.esm5.js",
-      "default": "./dist/esm/index.esm2017.js"
+      "default": "./dist/esm/index.esm2017.js",
+      "types": "./dist/app-compat-public.d.ts"
     },
     "./package.json": "./package.json"
   },

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -11,7 +11,8 @@
     ".": {
       "require": "./dist/index.cjs.js",
       "esm5": "./dist/esm/index.esm5.js",
-      "default": "./dist/esm/index.esm2017.js"
+      "default": "./dist/esm/index.esm2017.js",
+      "types": "./dist/app-public.d.ts"
     },
     "./package.json": "./package.json"
   },

--- a/packages/auth-compat/package.json
+++ b/packages/auth-compat/package.json
@@ -11,10 +11,12 @@
     ".": {
       "node": {
         "import": "./dist/esm/index.node.esm.js",
-        "require": "./dist/index.node.cjs.js"
+        "require": "./dist/index.node.cjs.js",
+        "types": "./dist/auth-compat/index.node.d.ts"
       },
       "esm5": "./dist/index.esm.js",
-      "default": "./dist/index.esm2017.js"
+      "default": "./dist/index.esm2017.js",
+      "types": "./dist/auth-compat/index.d.ts"
     },
     "./package.json": "./package.json"
   },

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -14,25 +14,50 @@
     ".": {
       "node": {
         "import": "./dist/node-esm/index.js",
-        "require": "./dist/node/index.js"
+        "require": "./dist/node/index.js",
+        "types": "./dist/node/index.d.ts"
       },
-      "react-native": "./dist/rn/index.js",
-      "cordova": "./dist/cordova/index.js",
-      "webworker": "./dist/index.webworker.esm5.js",
+      "react-native": {
+        "default": "./dist/rn/index.js",
+        "types": "./dist/rn/index.rn.d.ts"
+      },
+      "cordova": {
+        "default": "./dist/cordova/index.js",
+        "types": "./dist/cordova/index.cordova.d.ts"
+      },
+      "webworker": {
+        "default": "./dist/index.webworker.esm5.js",
+        "types": "./dist/index.webworker.d.ts"
+      },
       "esm5": "./dist/esm5/index.js",
-      "default": "./dist/esm2017/index.js"
+      "default": "./dist/esm2017/index.js",
+      "types": "./dist/auth-public.d.ts"
     },
-    "./cordova": "./dist/cordova/index.js",
-    "./react-native": "./dist/rn/index.js",
+    "./cordova": {
+      "default": "./dist/cordova/index.js",
+      "types": "./dist/cordova/index.cordova.d.ts"
+    },
+    "./react-native": {
+      "default": "./dist/rn/index.js",
+      "types": "./dist/rn/index.rn.d.ts"
+    },
     "./internal": {
       "node": {
         "import": "./dist/node-esm/internal.js",
-        "require": "./dist/node/internal.js"
+        "require": "./dist/node/internal.js",
+        "types": "./dist/node/internal/index.d.ts"
       },
-      "react-native": "./dist/rn/internal.js",
-      "cordova": "./dist/cordova/internal.js",
+      "react-native": {
+        "default": "./dist/rn/internal.js",
+        "types": "./dist/rn/internal/index.d.ts"
+      },
+      "cordova": {
+        "default": "./dist/cordova/internal.js",
+        "types": "./dist/cordova/internal/index.d.ts"
+      },
       "esm5": "./dist/esm5/internal.js",
-      "default": "./dist/esm2017/internal.js"
+      "default": "./dist/esm2017/internal.js",
+      "types": "./dist/internal/index.d.ts"
     },
     "./package.json": "./package.json"
   },

--- a/packages/component/package.json
+++ b/packages/component/package.json
@@ -11,7 +11,8 @@
     ".": {
       "require": "./dist/index.cjs.js",
       "esm5": "./dist/esm/index.esm5.js",
-      "default": "./dist/esm/index.esm2017.js"
+      "default": "./dist/esm/index.esm2017.js",
+      "types": "./dist/index.d.ts"
     },
     "./package.json": "./package.json"
   },

--- a/packages/database-compat/package.json
+++ b/packages/database-compat/package.json
@@ -17,13 +17,16 @@
     ".": {
       "node": {
         "import": "./dist/node-esm/index.js",
-        "require": "./dist/index.js"
+        "require": "./dist/index.js",
+        "types": "./dist/database-compat/src/index.node.d.ts"
       },
       "esm5": "./dist/index.esm5.js",
-      "default": "./dist/index.esm2017.js"
+      "default": "./dist/index.esm2017.js",
+      "types": "./dist/database-compat/src/index.d.ts"
     },
     "./standalone": {
-      "node": "./dist/index.standalone.js"
+      "node": "./dist/index.standalone.js",
+      "types": "./dist/database-compat/src/index.standalone.d.ts"
     },
     "./package.json": "./package.json"
   },

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -16,7 +16,8 @@
       },
       "esm5": "./dist/index.esm5.js",
       "standalone": "./dist/index.standalone.js",
-      "default": "./dist/index.esm2017.js"
+      "default": "./dist/index.esm2017.js",
+      "types": "./dist/public.d.ts"
     },
     "./package.json": "./package.json"
   },

--- a/packages/firebase/package.json
+++ b/packages/firebase/package.json
@@ -28,182 +28,208 @@
         "require": "./analytics/dist/index.cjs.js",
         "import": "./analytics/dist/index.mjs"
       },
-      "default": "./analytics/dist/index.esm.js"
+      "default": "./analytics/dist/index.esm.js",
+      "types": "./analytics/dist/analytics/index.d.ts"
     },
     "./app": {
       "node": {
         "require": "./app/dist/index.cjs.js",
         "import": "./app/dist/index.mjs"
       },
-      "default": "./app/dist/index.esm.js"
+      "default": "./app/dist/index.esm.js",
+      "types": "./app/dist/app/index.d.ts"
     },
     "./app-check": {
       "node": {
         "require": "./app-check/dist/index.cjs.js",
         "import": "./app-check/dist/index.mjs"
       },
-      "default": "./app-check/dist/index.esm.js"
+      "default": "./app-check/dist/index.esm.js",
+      "types": "./app-check/dist/app-check/index.d.ts"
     },
     "./auth": {
       "node": {
         "require": "./auth/dist/index.cjs.js",
         "import": "./auth/dist/index.mjs"
       },
-      "default": "./auth/dist/index.esm.js"
+      "default": "./auth/dist/index.esm.js",
+      "types": "./auth/dist/auth/index.d.ts"
     },
     "./auth/cordova": {
       "node": {
         "require": "./auth/cordova/dist/index.cjs.js",
         "import": "./auth/cordova/dist/index.mjs"
       },
-      "default": "./auth/cordova/dist/index.esm.js"
+      "default": "./auth/cordova/dist/index.esm.js",
+      "types": "./auth/cordova/dist/auth/cordova/index.d.ts"
     },
     "./auth/react-native": {
       "node": {
         "require": "./auth/react-native/dist/index.cjs.js",
         "import": "./auth/react-native/dist/index.mjs"
       },
-      "default": "./auth/react-native/dist/index.esm.js"
+      "default": "./auth/react-native/dist/index.esm.js",
+      "types": "./auth/react-native/dist/auth/react-native/index.d.ts"
     },
     "./database": {
       "node": {
         "require": "./database/dist/index.cjs.js",
         "import": "./database/dist/index.mjs"
       },
-      "default": "./database/dist/index.esm.js"
+      "default": "./database/dist/index.esm.js",
+      "types": "./database/dist/database/index.d.ts"
     },
     "./firestore": {
       "node": {
         "require": "./firestore/dist/index.cjs.js",
         "import": "./firestore/dist/index.mjs"
       },
-      "default": "./firestore/dist/index.esm.js"
+      "default": "./firestore/dist/index.esm.js",
+      "types": "./firestore/dist/firestore/index.d.ts"
     },
     "./firestore/lite": {
       "node": {
         "require": "./firestore/lite/dist/index.cjs.js",
         "import": "./firestore/lite/dist/index.mjs"
       },
-      "default": "./firestore/lite/dist/index.esm.js"
+      "default": "./firestore/lite/dist/index.esm.js",
+      "types": "./firestore/lite/dist/firestore/lite/index.d.ts"
     },
     "./functions": {
       "node": {
         "require": "./functions/dist/index.cjs.js",
         "import": "./functions/dist/index.mjs"
       },
-      "default": "./functions/dist/index.esm.js"
+      "default": "./functions/dist/index.esm.js",
+      "types": "./functions/dist/functions/index.d.ts"
     },
     "./messaging": {
       "node": {
         "require": "./messaging/dist/index.cjs.js",
         "import": "./messaging/dist/index.mjs"
       },
-      "default": "./messaging/dist/index.esm.js"
+      "default": "./messaging/dist/index.esm.js",
+      "types": "./messaging/dist/messaging/index.d.ts"
     },
     "./messaging/sw": {
       "node": {
         "require": "./messaging/sw/dist/index.cjs.js",
         "import": "./messaging/sw/dist/index.mjs"
       },
-      "default": "./messaging/sw/dist/index.esm.js"
+      "default": "./messaging/sw/dist/index.esm.js",
+      "types": "./messaging/sw/dist/messaging/sw/index.d.ts"
     },
     "./performance": {
       "node": {
         "require": "./performance/dist/index.cjs.js",
         "import": "./performance/dist/index.mjs"
       },
-      "default": "./performance/dist/index.esm.js"
+      "default": "./performance/dist/index.esm.js",
+      "types": "./performance/dist/performance/index.d.ts"
     },
     "./remote-config": {
       "node": {
         "require": "./remote-config/dist/index.cjs.js",
         "import": "./remote-config/dist/index.mjs"
       },
-      "default": "./remote-config/dist/index.esm.js"
+      "default": "./remote-config/dist/index.esm.js",
+      "types": "./remote-config/dist/remote-config/index.d.ts"
     },
     "./storage": {
       "node": {
         "require": "./storage/dist/index.cjs.js",
         "import": "./storage/dist/index.mjs"
       },
-      "default": "./storage/dist/index.esm.js"
+      "default": "./storage/dist/index.esm.js",
+      "types": "./storage/dist/storage/index.d.ts"
     },
     "./compat/analytics": {
       "node": {
         "require": "./compat/analytics/dist/index.cjs.js",
         "import": "./compat/analytics/dist/index.mjs"
       },
-      "default": "./compat/analytics/dist/index.esm.js"
+      "default": "./compat/analytics/dist/index.esm.js",
+      "types": "./compat/analytics/dist/compat/analytics/index.d.ts"
     },
     "./compat/app": {
       "node": {
         "require": "./compat/app/dist/index.cjs.js",
         "import": "./compat/app/dist/index.mjs"
       },
-      "default": "./compat/app/dist/index.esm.js"
+      "default": "./compat/app/dist/index.esm.js",
+      "types": "./compat/app/dist/compat/app/index.d.ts"
     },
     "./compat/app-check": {
       "node": {
         "require": "./compat/app-check/dist/index.cjs.js",
         "import": "./compat/app-check/dist/index.mjs"
       },
-      "default": "./compat/app-check/dist/index.esm.js"
+      "default": "./compat/app-check/dist/index.esm.js",
+      "types": "./compat/app-check/dist/compat/app-check/index.d.ts"
     },
     "./compat/auth": {
       "node": {
         "require": "./compat/auth/dist/index.cjs.js",
         "import": "./compat/auth/dist/index.mjs"
       },
-      "default": "./compat/auth/dist/index.esm.js"
+      "default": "./compat/auth/dist/index.esm.js",
+      "types": "./compat/auth/dist/compat/auth/index.d.ts"
     },
     "./compat/database": {
       "node": {
         "require": "./compat/database/dist/index.cjs.js",
         "import": "./compat/database/dist/index.mjs"
       },
-      "default": "./compat/database/dist/index.esm.js"
+      "default": "./compat/database/dist/index.esm.js",
+      "types": "./compat/database/dist/compat/database/index.d.ts"
     },
     "./compat/firestore": {
       "node": {
         "require": "./compat/firestore/dist/index.cjs.js",
         "import": "./compat/firestore/dist/index.mjs"
       },
-      "default": "./compat/firestore/dist/index.esm.js"
+      "default": "./compat/firestore/dist/index.esm.js",
+      "types": "./compat/firestore/dist/compat/firestore/index.d.ts"
     },
     "./compat/functions": {
       "node": {
         "require": "./compat/functions/dist/index.cjs.js",
         "import": "./compat/functions/dist/index.mjs"
       },
-      "default": "./compat/functions/dist/index.esm.js"
+      "default": "./compat/functions/dist/index.esm.js",
+      "types": "./compat/functions/dist/compat/functions/index.d.ts"
     },
     "./compat/messaging": {
       "node": {
         "require": "./compat/messaging/dist/index.cjs.js",
         "import": "./compat/messaging/dist/index.mjs"
       },
-      "default": "./compat/messaging/dist/index.esm.js"
+      "default": "./compat/messaging/dist/index.esm.js",
+      "types": "./compat/messaging/dist/compat/messaging/index.d.ts"
     },
     "./compat/performance": {
       "node": {
         "require": "./compat/performance/dist/index.cjs.js",
         "import": "./compat/performance/dist/index.mjs"
       },
-      "default": "./compat/performance/dist/index.esm.js"
+      "default": "./compat/performance/dist/index.esm.js",
+      "types": "./compat/performance/dist/compat/performance/index.d.ts"
     },
     "./compat/remote-config": {
       "node": {
         "require": "./compat/remote-config/dist/index.cjs.js",
         "import": "./compat/remote-config/dist/index.mjs"
       },
-      "default": "./compat/remote-config/dist/index.esm.js"
+      "default": "./compat/remote-config/dist/index.esm.js",
+      "types": "./compat/remote-config/dist/compat/remote-config/index.d.ts"
     },
     "./compat/storage": {
       "node": {
         "require": "./compat/storage/dist/index.cjs.js",
         "import": "./compat/storage/dist/index.mjs"
       },
-      "default": "./compat/storage/dist/index.esm.js"
+      "default": "./compat/storage/dist/index.esm.js",
+      "types": "./compat/storage/dist/compat/storage/index.d.ts"
     },
     "./package.json": "./package.json"
   },

--- a/packages/firestore-compat/package.json
+++ b/packages/firestore-compat/package.json
@@ -16,7 +16,8 @@
       },
       "react-native": "./dist/index.rn.js",
       "esm5": "./dist/index.esm5.js",
-      "default": "./dist/index.esm2017.js"
+      "default": "./dist/index.esm2017.js",
+      "types": "./dist/src/index.d.ts"
     },
     "./package.json": "./package.json"
   },

--- a/packages/firestore/package.json
+++ b/packages/firestore/package.json
@@ -52,7 +52,8 @@
       },
       "react-native": "./dist/index.rn.js",
       "esm5": "./dist/index.esm5.js",
-      "default": "./dist/index.esm2017.js"
+      "default": "./dist/index.esm2017.js",
+      "types": "./dist/index.d.ts"
     },
     "./lite": {
       "node": {
@@ -61,7 +62,8 @@
       },
       "react-native": "./dist/lite/index.rn.esm2017.js",
       "esm5": "./dist/lite/index.browser.esm5.js",
-      "default": "./dist/lite/index.browser.esm2017.js"
+      "default": "./dist/lite/index.browser.esm2017.js",
+      "types": "./dist/lite/index.d.ts"
     },
     "./package.json": "./package.json"
   },

--- a/packages/functions-compat/package.json
+++ b/packages/functions-compat/package.json
@@ -14,7 +14,8 @@
         "require": "./dist/index.node.cjs.js"
       },
       "esm5": "./dist/index.esm5.js",
-      "default": "./dist/index.esm2017.js"
+      "default": "./dist/index.esm2017.js",
+      "types": "./dist/src/index.d.ts"
     },
     "./package.json": "./package.json"
   },

--- a/packages/functions/package.json
+++ b/packages/functions/package.json
@@ -14,7 +14,8 @@
         "require": "./dist/index.node.cjs.js"
       },
       "esm5": "./dist/index.esm.js",
-      "default": "./dist/index.esm2017.js"
+      "default": "./dist/index.esm2017.js",
+      "types": "./dist/functions-public.d.ts"
     },
     "./package.json": "./package.json"
   },

--- a/packages/installations-compat/package.json
+++ b/packages/installations-compat/package.json
@@ -10,7 +10,8 @@
     ".": {
       "require": "./dist/index.cjs.js",
       "esm5": "./dist/esm/index.esm.js",
-      "default": "./dist/esm/index.esm2017.js"
+      "default": "./dist/esm/index.esm2017.js",
+      "types": "./dist/installations-compat.d.ts"
     },
     "./package.json": "./package.json"
   },

--- a/packages/installations/package.json
+++ b/packages/installations/package.json
@@ -10,7 +10,8 @@
     ".": {
       "require": "./dist/index.cjs.js",
       "esm5": "./dist/esm/index.esm.js",
-      "default": "./dist/esm/index.esm2017.js"
+      "default": "./dist/esm/index.esm2017.js",
+      "types": "./dist/installations-public.d.ts"
     },
     "./package.json": "./package.json"
   },

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -10,7 +10,8 @@
     ".": {
       "require": "./dist/index.cjs.js",
       "esm5": "./dist/esm/index.esm5.js",
-      "default": "./dist/esm/index.esm2017.js"
+      "default": "./dist/esm/index.esm2017.js",
+      "types": "./dist/index.d.ts"
     },
     "./package.json": "./package.json"
   },

--- a/packages/messaging-compat/package.json
+++ b/packages/messaging-compat/package.json
@@ -12,7 +12,8 @@
     ".": {
       "node": "./dist/index.cjs.js",
       "esm5": "./dist/esm/index.esm.js",
-      "default": "./dist/esm/index.esm2017.js"
+      "default": "./dist/esm/index.esm2017.js",
+      "types": "./dist/src/index.d.ts"
     },
     "./package.json": "./package.json"
   },

--- a/packages/messaging/package.json
+++ b/packages/messaging/package.json
@@ -15,11 +15,13 @@
       "browser": "./dist/esm/index.esm2017.js",
       "module": "./dist/esm/index.esm2017.js",
       "esm5": "./dist/esm/index.esm.js",
-      "default": "./dist/index.cjs.js"
+      "default": "./dist/index.cjs.js",
+      "types": "./dist/index-public.d.ts"
     },
     "./sw": {
       "node": "./dist/index.sw.cjs",
-      "default": "./dist/index.sw.esm2017.js"
+      "default": "./dist/index.sw.esm2017.js",
+      "types": "./dist/sw/index-public.d.ts"
     },
     "./package.json": "./package.json"
   },

--- a/packages/performance-compat/package.json
+++ b/packages/performance-compat/package.json
@@ -11,7 +11,8 @@
     ".": {
       "require": "./dist/index.cjs.js",
       "esm5": "./dist/esm/index.esm5.js",
-      "default": "./dist/esm/index.esm2017.js"
+      "default": "./dist/esm/index.esm2017.js",
+      "types": "./dist/src/index.d.ts"
     },
     "./package.json": "./package.json"
   },

--- a/packages/performance/package.json
+++ b/packages/performance/package.json
@@ -11,7 +11,8 @@
     ".": {
       "require": "./dist/index.cjs.js",
       "esm5": "./dist/esm/index.esm.js",
-      "default": "./dist/esm/index.esm2017.js"
+      "default": "./dist/esm/index.esm2017.js",
+      "types": "./dist/src/index.d.ts"
     },
     "./package.json": "./package.json"
   },

--- a/packages/remote-config-compat/package.json
+++ b/packages/remote-config-compat/package.json
@@ -11,7 +11,8 @@
     ".": {
       "require": "./dist/index.cjs.js",
       "esm5": "./dist/esm/index.esm5.js",
-      "default": "./dist/esm/index.esm2017.js"
+      "default": "./dist/esm/index.esm2017.js",
+      "types": "./dist/src/index.d.ts"
     },
     "./package.json": "./package.json"
   },

--- a/packages/remote-config/package.json
+++ b/packages/remote-config/package.json
@@ -11,7 +11,8 @@
     ".": {
       "require": "./dist/index.cjs.js",
       "esm5": "./dist/esm/index.esm.js",
-      "default": "./dist/esm/index.esm2017.js"
+      "default": "./dist/esm/index.esm2017.js",
+      "types": "./dist/remote-config-public.d.ts"
     },
     "./package.json": "./package.json"
   },

--- a/packages/storage-compat/package.json
+++ b/packages/storage-compat/package.json
@@ -11,7 +11,8 @@
     ".": {
       "require": "./dist/index.cjs.js",
       "esm5": "./dist/esm/index.esm5.js",
-      "default": "./dist/esm/index.esm2017.js"
+      "default": "./dist/esm/index.esm2017.js",
+      "types": "./dist/src/index.d.ts"
     },
     "./package.json": "./package.json"
   },

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -14,7 +14,8 @@
         "default": "./dist/index.node.cjs.js"
       },
       "esm5": "./dist/index.esm5.js",
-      "default": "./dist/index.esm2017.js"
+      "default": "./dist/index.esm2017.js",
+      "types": "./dist/storage-public.d.ts"
     },
     "./package.json": "./package.json"
   },

--- a/packages/template/package.json
+++ b/packages/template/package.json
@@ -15,7 +15,8 @@
         "require": "./dist/index.node.cjs.js"
       },
       "esm5": "./dist/index.esm5.js",
-      "default": "./dist/index.esm2017.js"
+      "default": "./dist/index.esm2017.js",
+      "types": "./dist/index.d.ts"
     },
     "./package.json": "./package.json"
   },

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -14,7 +14,8 @@
         "require": "./dist/index.node.cjs.js"
       },
       "esm5": "./dist/index.esm5.js",
-      "default": "./dist/index.esm2017.js"
+      "default": "./dist/index.esm2017.js",
+      "types": "./dist/util-public.d.ts"
     },
     "./package.json": "./package.json"
   },

--- a/packages/webchannel-wrapper/package.json
+++ b/packages/webchannel-wrapper/package.json
@@ -10,7 +10,8 @@
     ".": {
       "require": "./dist/index.js",
       "esm5": "./dist/index.esm.js",
-      "default": "./dist/index.esm2017.js"
+      "default": "./dist/index.esm2017.js",
+      "types": "./src/index.d.ts"
     },
     "./package.json": "./package.json"
   },


### PR DESCRIPTION
Adds paths of type definitions to each package.json's `exports`

I am the least confident about the changes to `@firebase/auth` due to the many different exports. I hope I got it right.

### Discussion

closes #6300

### Testing

I am not quite sure how to test these paths. Ideally, all paths within the `exports` fields should be tested to avoid referencing a missing file. Maybe a new global test that checks all packages could do the job?

