### PR TITLE
Publish workflow: Add git tags during publish

### DIFF
--- a/scripts/release/release.ts
+++ b/scripts/release/release.ts
@@ -180,12 +180,11 @@ export async function runRelease({
     }
 
     /**
-     * Changeset creates tags for staging releases as well,
-     * but we should only push tags to Github for prod releases
+     * Push tags to Github for prod releases only.
      */
     if (releaseType === ReleaseType.Production && !dryRun) {
       /**
-       * Push release tags created by changeset in publish() to Github
+       * Push release tags created by changeset or publishInCI() to Github
        */
       await pushReleaseTagsToGithub();
     }

--- a/scripts/release/utils/publish.ts
+++ b/scripts/release/utils/publish.ts
@@ -95,7 +95,7 @@ export async function publishInCI(
 
   console.log('\r\nPublishing Packages to NPM:');
   await tasks.run();
-  
+
   // Create git tags.
   for (const tag of tags) {
     await exec(`git tag ${tag}`);

--- a/scripts/release/utils/publish.ts
+++ b/scripts/release/utils/publish.ts
@@ -43,6 +43,7 @@ export async function publishInCI(
   dryRun: boolean
 ) {
   const taskArray = [];
+  const tags = [];
   for (const pkg of updatedPkgs) {
     const path = await mapPkgNameToPkgPath(pkg);
 
@@ -79,8 +80,10 @@ export async function publishInCI(
       continue;
     }
 
+    const tag = `${pkg}@${version}`;
+    tags.push(tag);
     taskArray.push({
-      title: `📦  ${pkg}@${version}`,
+      title: `📦  ${tag}`,
       task: () => publishPackageInCI(pkg, npmTag, dryRun)
     });
   }
@@ -91,7 +94,13 @@ export async function publishInCI(
   });
 
   console.log('\r\nPublishing Packages to NPM:');
-  return tasks.run();
+  await tasks.run();
+  
+  // Create git tags.
+  for (const tag of tags) {
+    await exec(`git tag ${tag}`);
+    console.log(`Added git tag ${tag}.`);
+  }
 }
 
 async function publishPackageInCI(


### PR DESCRIPTION
When not using changeset to publish, we need to add the git tags manually.