### PR TITLE
Update error handling to account for TS v4.4 auto unknown variable in…

### DIFF
--- a/packages/app-check/src/client.test.ts
+++ b/packages/app-check/src/client.test.ts
@@ -107,7 +107,7 @@ describe('client', () => {
     const firebaseError = ERROR_FACTORY.create(
       AppCheckError.FETCH_NETWORK_ERROR,
       {
-        originalErrorMessage: originalError.message
+        originalErrorMessage: (originalError as Error)?.message
       }
     );
 
@@ -164,7 +164,7 @@ describe('client', () => {
     const firebaseError = ERROR_FACTORY.create(
       AppCheckError.FETCH_PARSE_ERROR,
       {
-        originalErrorMessage: originalError.message
+        originalErrorMessage: (originalError as Error)?.message
       }
     );
 
@@ -178,7 +178,7 @@ describe('client', () => {
       expect(e).has.property('message', firebaseError.message);
       expect(e).has.nested.property(
         'customData.originalErrorMessage',
-        originalError.message
+        (originalError as Error)?.message
       );
     }
   });

--- a/packages/app-check/src/client.ts
+++ b/packages/app-check/src/client.ts
@@ -67,7 +67,7 @@ export async function exchangeToken(
     response = await fetch(url, options);
   } catch (originalError) {
     throw ERROR_FACTORY.create(AppCheckError.FETCH_NETWORK_ERROR, {
-      originalErrorMessage: originalError.message
+      originalErrorMessage: (originalError as Error)?.message
     });
   }
 
@@ -83,7 +83,7 @@ export async function exchangeToken(
     responseBody = await response.json();
   } catch (originalError) {
     throw ERROR_FACTORY.create(AppCheckError.FETCH_PARSE_ERROR, {
-      originalErrorMessage: originalError.message
+      originalErrorMessage: (originalError as Error)?.message
     });
   }
 

--- a/packages/app-check/src/indexeddb.ts
+++ b/packages/app-check/src/indexeddb.ts
@@ -63,7 +63,7 @@ function getDBPromise(): Promise<IDBDatabase> {
     } catch (e) {
       reject(
         ERROR_FACTORY.create(AppCheckError.STORAGE_OPEN, {
-          originalErrorMessage: e.message
+          originalErrorMessage: (e as Error)?.message
         })
       );
     }

--- a/packages/app/src/indexeddb.ts
+++ b/packages/app/src/indexeddb.ts
@@ -66,7 +66,7 @@ export async function readHeartbeatsFromIndexedDB(
       .get(computeKey(app)) as Promise<HeartbeatsInIndexedDB | undefined>;
   } catch (e) {
     throw ERROR_FACTORY.create(AppError.STORAGE_GET, {
-      originalErrorMessage: e.message
+      originalErrorMessage: (e as Error)?.message
     });
   }
 }
@@ -83,7 +83,7 @@ export async function writeHeartbeatsToIndexedDB(
     return tx.done;
   } catch (e) {
     throw ERROR_FACTORY.create(AppError.STORAGE_WRITE, {
-      originalErrorMessage: e.message
+      originalErrorMessage: (e as Error)?.message
     });
   }
 }

--- a/packages/remote-config/src/client/rest_client.ts
+++ b/packages/remote-config/src/client/rest_client.ts
@@ -120,11 +120,11 @@ export class RestClient implements RemoteConfigFetchClient {
       response = await fetchPromise;
     } catch (originalError) {
       let errorCode = ErrorCode.FETCH_NETWORK;
-      if (originalError.name === 'AbortError') {
+      if ((originalError as Error)?.name === 'AbortError') {
         errorCode = ErrorCode.FETCH_TIMEOUT;
       }
       throw ERROR_FACTORY.create(errorCode, {
-        originalErrorMessage: originalError.message
+        originalErrorMessage: (originalError as Error)?.message
       });
     }
 
@@ -144,7 +144,7 @@ export class RestClient implements RemoteConfigFetchClient {
         responseBody = await response.json();
       } catch (originalError) {
         throw ERROR_FACTORY.create(ErrorCode.FETCH_PARSE, {
-          originalErrorMessage: originalError.message
+          originalErrorMessage: (originalError as Error)?.message
         });
       }
       config = responseBody['entries'];

--- a/packages/remote-config/src/client/retrying_client.ts
+++ b/packages/remote-config/src/client/retrying_client.ts
@@ -124,7 +124,7 @@ export class RetryingClient implements RemoteConfigFetchClient {
 
       return response;
     } catch (e) {
-      if (!isRetriableError(e)) {
+      if (!isRetriableError(e as Error)) {
         throw e;
       }
 

--- a/packages/remote-config/src/storage/storage.ts
+++ b/packages/remote-config/src/storage/storage.ts
@@ -29,7 +29,7 @@ import { FirebaseError } from '@firebase/util';
 function toFirebaseError(event: Event, errorCode: ErrorCode): FirebaseError {
   const originalError = (event.target as IDBRequest).error || undefined;
   return ERROR_FACTORY.create(errorCode, {
-    originalErrorMessage: originalError && originalError.message
+    originalErrorMessage: originalError && (originalError as Error)?.message
   });
 }
 
@@ -101,7 +101,7 @@ export function openDatabase(): Promise<IDBDatabase> {
     } catch (error) {
       reject(
         ERROR_FACTORY.create(ErrorCode.STORAGE_OPEN, {
-          originalErrorMessage: error
+          originalErrorMessage: (error as Error)?.message
         })
       );
     }
@@ -203,7 +203,7 @@ export class Storage {
       } catch (e) {
         reject(
           ERROR_FACTORY.create(ErrorCode.STORAGE_GET, {
-            originalErrorMessage: e && e.message
+            originalErrorMessage: (e as Error)?.message
           })
         );
       }
@@ -230,7 +230,7 @@ export class Storage {
       } catch (e) {
         reject(
           ERROR_FACTORY.create(ErrorCode.STORAGE_SET, {
-            originalErrorMessage: e && e.message
+            originalErrorMessage: (e as Error)?.message
           })
         );
       }
@@ -254,7 +254,7 @@ export class Storage {
       } catch (e) {
         reject(
           ERROR_FACTORY.create(ErrorCode.STORAGE_DELETE, {
-            originalErrorMessage: e && e.message
+            originalErrorMessage: (e as Error)?.message
           })
         );
       }

--- a/packages/remote-config/test/client/rest_client.test.ts
+++ b/packages/remote-config/test/client/rest_client.test.ts
@@ -128,7 +128,7 @@ describe('RestClient', () => {
       const fetchPromise = client.fetch(DEFAULT_REQUEST);
 
       const firebaseError = ERROR_FACTORY.create(ErrorCode.FETCH_NETWORK, {
-        originalErrorMessage: originalError.message
+        originalErrorMessage: (originalError as Error)?.message
       });
 
       await expect(fetchPromise)

--- a/packages/util/test/errors.test.ts
+++ b/packages/util/test/errors.test.ts
@@ -88,9 +88,9 @@ describe('FirebaseError', () => {
     try {
       throw e;
     } catch (error) {
-      assert.isDefined(error.stack);
+      assert.isDefined((error as Error).stack);
       // Multi-line match trick - .* does not match \n
-      assert.match(error.stack, /FirebaseError[\s\S]/);
+      assert.match((error as Error).stack!, /FirebaseError[\s\S]/);
     }
   });
 
@@ -100,7 +100,8 @@ describe('FirebaseError', () => {
       assert.ok(false);
     } catch (e) {
       assert.instanceOf(e, FirebaseError);
-      assert.match(e.stack, /dummy2[\s\S]*?dummy1/);
+      assert.isDefined((e as FirebaseError).stack);
+      assert.match((e as FirebaseError).stack!, /dummy2[\s\S]*?dummy1/);
     }
   });
 });


### PR DESCRIPTION
Updating error handling in select packages to account for a future TypeScript package upgrade. For more information, see the below blog comment about TypeScript v4.4 errors.

"""
In JavaScript, any type of value can be thrown with throw and caught in a catch clause. Because of this, TypeScript historically typed catch clause variables as any, and would not allow any other type annotation:

Once TypeScript added the unknown type, it became clear that unknown was a better choice than any in catch clause variables for users who want the highest degree of correctness and type-safety, since it narrows better and forces us to test against arbitrary values. Eventually TypeScript 4.0 allowed users to specify an explicit type annotation of unknown (or any) on each catch clause variable so that we could opt into stricter types on a case-by-case basis; however, for some, manually specifying : unknown on every catch clause was a chore.
"""
per https://devblogs.microsoft.com/typescript/announcing-typescript-4-4/#use-unknown-catch-variables