### PR TITLE
Add CI script to check package paths

### DIFF
--- a/.changeset/old-lamps-nail.md
+++ b/.changeset/old-lamps-nail.md
@@ -1,0 +1,7 @@
+---
+'@firebase/auth': patch
+'@firebase/firestore': patch
+'@firebase/installations-compat': patch
+---
+
+Fix incorrect paths in package.json

--- a/.github/workflows/check-pkg-paths.yml
+++ b/.github/workflows/check-pkg-paths.yml
@@ -24,4 +24,4 @@ jobs:
     - name: Swap in public typings
       run: yarn release:prepare
     - name: Check paths
-      run: xvfb-run yarn test:changed core
+      run: yarn ts-node scripts/ci-test/check-paths.ts

--- a/.github/workflows/check-pkg-paths.yml
+++ b/.github/workflows/check-pkg-paths.yml
@@ -1,0 +1,27 @@
+name: Test Package Paths
+
+on: pull_request
+
+jobs:
+  test:
+    name: Test Package Paths
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@master
+      with:
+        # This makes Actions fetch all Git history so run-changed script can diff properly.
+        fetch-depth: 0
+    - name: Set up Node (14)
+      uses: actions/setup-node@v2
+      with:
+        node-version: 14.x
+    - name: Yarn install
+      run: yarn
+    - name: Yarn build
+      run: yarn build
+    - name: Swap in public typings
+      run: yarn release:prepare
+    - name: Check paths
+      run: xvfb-run yarn test:changed core

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -7,7 +7,7 @@
   "react-native": "dist/rn/index.js",
   "browser": "dist/esm2017/index.js",
   "module": "dist/esm2017/index.js",
-  "cordova": "dist/cordova/index.esm5.js",
+  "cordova": "dist/cordova/index.js",
   "webworker": "dist/index.webworker.esm5.js",
   "esm5": "dist/esm5/index.js",
   "exports": {

--- a/packages/firestore/package.json
+++ b/packages/firestore/package.json
@@ -59,9 +59,9 @@
         "require": "./dist/lite/index.node.cjs.js",
         "import": "./dist/lite/index.node.mjs"
       },
-      "react-native": "./dist/lite/index.rn.esm2017.js",
-      "esm5": "./dist/lite/index.browser.esm5.js",
-      "default": "./dist/lite/index.browser.esm2017.js"
+      "react-native": "./dist/index.rn.js",
+      "esm5": "./dist/index.esm5.js",
+      "default": "./dist/index.esm2017.js"
     },
     "./package.json": "./package.json"
   },

--- a/packages/installations-compat/package.json
+++ b/packages/installations-compat/package.json
@@ -14,7 +14,7 @@
     },
     "./package.json": "./package.json"
   },
-  "typings": "dist/installations-compat.d.ts",
+  "typings": "dist/src/index.d.ts",
   "license": "Apache-2.0",
   "files": [
     "dist"

--- a/scripts/ci-test/check-paths.ts
+++ b/scripts/ci-test/check-paths.ts
@@ -1,0 +1,97 @@
+import glob from 'glob';
+import { existsSync } from 'fs';
+import { resolve } from 'path';
+import { projectRoot as root } from '../utils';
+
+const TOP_LEVEL_FIELDS = [
+  'main',
+  'browser',
+  'module',
+  'typings',
+  'react-native',
+  'cordova',
+  'esm5',
+  'webworker',
+  'main-esm'
+];
+
+interface Result {
+  packageName: string;
+  found: boolean;
+  filePath: string;
+  fieldPath: string;
+}
+const results: Result[] = [];
+
+function getPaths(): Promise<string[]> {
+  return new Promise((resolve, reject) => {
+    glob('packages/*', (err, paths) => {
+      if (err) reject(err);
+      resolve(paths);
+    });
+  })
+}
+
+function checkExports(pkgName: string, pkgRoot: string, path: string = '', exports: Record<string, any>) {
+  for (const key in exports) {
+    if (typeof exports[key] === 'string') {
+      const filePath = resolve(pkgRoot, exports[key]);
+      const result = {
+        packageName: pkgName,
+        found: false,
+        filePath,
+        fieldPath: `exports${path}[${key}]`
+      };
+      if (existsSync(filePath)) {
+        result.found = true;
+      }
+      results.push(result);
+    } else {
+      checkExports(pkgName, pkgRoot, path ? `${path}[${key}]` : `[${key}]`, exports[key]);
+    }
+  }
+}
+
+async function main() {
+  const paths = await getPaths();
+  for (const path of paths) {
+    const pkgRoot = `${root}/${path}`;
+    if (existsSync(`${pkgRoot}/package.json`)) {
+      const pkg = require(`${pkgRoot}/package.json`);
+      for (const field of TOP_LEVEL_FIELDS) {
+        if (pkg[field]) {
+          const filePath = resolve(pkgRoot, pkg[field]);
+          const result = {
+            packageName: pkg.name,
+            found: false,
+            filePath,
+            fieldPath: field
+          };
+          if (existsSync(filePath)) {
+            result.found = true;
+          }
+          results.push(result);
+        }
+      }
+      if (pkg.exports) {
+        checkExports(pkg.name, pkgRoot, '', pkg.exports);
+      }
+    }
+  }
+
+  let missingPaths: boolean = false;
+
+  for (const result of results) {
+    if (!result.found) {
+      missingPaths = true;
+      console.log(`${result.packageName}: Field "${result.fieldPath}" ` +
+        `points to ${result.filePath} which is not found.`);
+    }
+  }
+
+  if (missingPaths) {
+    process.exit(1);
+  }
+}
+
+main();

--- a/scripts/ci-test/check-paths.ts
+++ b/scripts/ci-test/check-paths.ts
@@ -1,3 +1,20 @@
+/**
+ * @license
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import glob from 'glob';
 import { existsSync } from 'fs';
 import { resolve } from 'path';
@@ -29,10 +46,15 @@ function getPaths(): Promise<string[]> {
       if (err) reject(err);
       resolve(paths);
     });
-  })
+  });
 }
 
-function checkExports(pkgName: string, pkgRoot: string, path: string = '', exports: Record<string, any>) {
+function checkExports(
+  pkgName: string,
+  pkgRoot: string,
+  path: string = '',
+  exports: Record<string, any>
+) {
   for (const key in exports) {
     if (typeof exports[key] === 'string') {
       const filePath = resolve(pkgRoot, exports[key]);
@@ -47,7 +69,12 @@ function checkExports(pkgName: string, pkgRoot: string, path: string = '', expor
       }
       results.push(result);
     } else {
-      checkExports(pkgName, pkgRoot, path ? `${path}[${key}]` : `[${key}]`, exports[key]);
+      checkExports(
+        pkgName,
+        pkgRoot,
+        path ? `${path}[${key}]` : `[${key}]`,
+        exports[key]
+      );
     }
   }
 }
@@ -84,8 +111,10 @@ async function main() {
   for (const result of results) {
     if (!result.found) {
       missingPaths = true;
-      console.log(`${result.packageName}: Field "${result.fieldPath}" ` +
-        `points to ${result.filePath} which is not found.`);
+      console.log(
+        `${result.packageName}: Field "${result.fieldPath}" ` +
+          `points to ${result.filePath} which is not found.`
+      );
     }
   }
 


### PR DESCRIPTION
- Add a script to check all the paths to entry points and typings files in package.json and make sure the file they are pointing at exists.
- Add a workflow to run this in CI on pull_request.