### PR TITLE
Update error handling for TS v4.4 unknown variables

### DIFF
--- a/packages/functions/src/callable.test.ts
+++ b/packages/functions/src/callable.test.ts
@@ -35,6 +35,7 @@ import {
 import { makeFakeApp, createTestService } from '../test/utils';
 import { httpsCallable } from './service';
 import { FUNCTIONS_TYPE } from './constants';
+import {FunctionsError} from './error';
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 export const TEST_PROJECT = require('../../../config/project.json');
@@ -52,9 +53,10 @@ async function expectError(
     await promise;
   } catch (e) {
     failed = true;
-    expect(e.code).to.equal(`${FUNCTIONS_TYPE}/${code}`);
-    expect(e.message).to.equal(message);
-    expect(e.details).to.deep.equal(details);
+    const error = e as FunctionsError;
+    expect(error.code).to.equal(`${FUNCTIONS_TYPE}/${code}`);
+    expect(error.message).to.equal(message);
+    expect(error.details).to.deep.equal(details);
   }
   if (!failed) {
     expect(false, 'Promise should have failed.').to.be.true;

--- a/packages/functions/src/callable.test.ts
+++ b/packages/functions/src/callable.test.ts
@@ -35,7 +35,7 @@ import {
 import { makeFakeApp, createTestService } from '../test/utils';
 import { httpsCallable } from './service';
 import { FUNCTIONS_TYPE } from './constants';
-import {FunctionsError} from './error';
+import { FunctionsError } from './error';
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 export const TEST_PROJECT = require('../../../config/project.json');

--- a/packages/remote-config/src/api.ts
+++ b/packages/remote-config/src/api.ts
@@ -123,7 +123,7 @@ export async function fetchConfig(remoteConfig: RemoteConfig): Promise<void> {
 
     await rc._storageCache.setLastFetchStatus('success');
   } catch (e) {
-    const lastFetchStatus = hasErrorCode(e, ErrorCode.FETCH_THROTTLE)
+    const lastFetchStatus = hasErrorCode(e as Error, ErrorCode.FETCH_THROTTLE)
       ? 'throttle'
       : 'failure';
     await rc._storageCache.setLastFetchStatus(lastFetchStatus);

--- a/packages/storage/src/platform/node/connection.ts
+++ b/packages/storage/src/platform/node/connection.ts
@@ -69,7 +69,7 @@ abstract class FetchConnection<T extends ConnectionType>
       this.errorCode_ = ErrorCode.NO_ERROR;
       this.body_ = await response.arrayBuffer();
     } catch (e) {
-      this.errorText_ = e.message;
+      this.errorText_ = (e as Error)?.message;
       // emulate XHR which sets status to 0 when encountering a network error
       this.statusCode_ = 0;
       this.errorCode_ = ErrorCode.NETWORK_ERROR;
@@ -171,7 +171,7 @@ export class FetchStreamConnection extends FetchConnection<NodeJS.ReadableStream
       this.errorCode_ = ErrorCode.NO_ERROR;
       this.stream_ = response.body;
     } catch (e) {
-      this.errorText_ = e.message;
+      this.errorText_ = (e as Error)?.message;
       // emulate XHR which sets status to 0 when encountering a network error
       this.statusCode_ = 0;
       this.errorCode_ = ErrorCode.NETWORK_ERROR;

--- a/packages/storage/src/task.ts
+++ b/packages/storage/src/task.ts
@@ -275,7 +275,7 @@ export class UploadTask {
           this._makeProgressCallback()
         );
       } catch (e) {
-        this._error = e;
+        this._error = e as StorageError;
         this._transition(InternalTaskState.ERROR);
         return;
       }

--- a/packages/storage/test/browser/blob.test.ts
+++ b/packages/storage/test/browser/blob.test.ts
@@ -114,7 +114,7 @@ describe('Firebase Storage > Blob', () => {
       await getBlob(reference);
       expect.fail();
     } catch (e) {
-      expect(e.message).to.satisfy((v: string) =>
+      expect((e as Error)?.message).to.satisfy((v: string) =>
         v.match(/Object 'public\/exp-bytes-missing' does not exist/)
       );
     }

--- a/packages/storage/test/integration/integration.test.ts
+++ b/packages/storage/test/integration/integration.test.ts
@@ -103,7 +103,7 @@ describe('FirebaseStorage Exp', () => {
       await getBytes(reference);
       expect.fail();
     } catch (e) {
-      expect(e.message).to.satisfy((v: string) =>
+      expect((e as Error)?.message).to.satisfy((v: string) =>
         v.match(/Object 'public\/exp-bytes-missing' does not exist/)
       );
     }
@@ -130,7 +130,7 @@ describe('FirebaseStorage Exp', () => {
       await uploadString(reference, 'foo');
       expect.fail();
     } catch (e) {
-      expect(e.message).to.satisfy((v: string) =>
+      expect((e as Error)?.message).to.satisfy((v: string) =>
         v.match(
           /The operation 'uploadString' cannot be performed on a root reference/
         )

--- a/packages/storage/test/node/stream.test.ts
+++ b/packages/storage/test/node/stream.test.ts
@@ -68,7 +68,7 @@ describe('Firebase Storage > getStream', () => {
       await readData(stream);
       expect.fail();
     } catch (e) {
-      expect(e.message).to.satisfy((v: string) =>
+      expect((e as Error)?.message).to.satisfy((v: string) =>
         v.match(/Object 'public\/exp-bytes-missing' does not exist/)
       );
     }

--- a/packages/storage/test/unit/testshared.ts
+++ b/packages/storage/test/unit/testshared.ts
@@ -156,7 +156,7 @@ export function assertThrows(f: () => void, code: string): StorageError {
     try {
       f();
     } catch (e) {
-      captured = e;
+      captured = e as StorageError;
       throw e;
     }
   }).to.throw();


### PR DESCRIPTION
Updating error handling in select packages to account for a future TypeScript package upgrade. For more information, see the below blog comment about TypeScript v4.4 errors.

"""
In JavaScript, any type of value can be thrown with throw and caught in a catch clause. Because of this, TypeScript historically typed catch clause variables as any, and would not allow any other type annotation:

Once TypeScript added the unknown type, it became clear that unknown was a better choice than any in catch clause variables for users who want the highest degree of correctness and type-safety, since it narrows better and forces us to test against arbitrary values. Eventually TypeScript 4.0 allowed users to specify an explicit type annotation of unknown (or any) on each catch clause variable so that we could opt into stricter types on a case-by-case basis; however, for some, manually specifying : unknown on every catch clause was a chore.
"""
per https://devblogs.microsoft.com/typescript/announcing-typescript-4-4/#use-unknown-catch-variables