### PR TITLE
Update error handling for TS v4.4 unknown variables

### DIFF
--- a/packages/analytics/src/index.ts
+++ b/packages/analytics/src/index.ts
@@ -82,7 +82,7 @@ function registerAnalytics(): void {
       };
     } catch (e) {
       throw ERROR_FACTORY.create(AnalyticsError.INTEROP_COMPONENT_REG_FAILED, {
-        reason: e
+        reason: (e as Error)
       });
     }
   }

--- a/packages/auth/src/core/auth/middleware.ts
+++ b/packages/auth/src/core/auth/middleware.ts
@@ -87,7 +87,7 @@ export class AuthMiddlewareQueue {
       }
 
       throw this.auth._errorFactory.create(
-        AuthErrorCode.LOGIN_BLOCKED, { originalMessage: e.message });
+        AuthErrorCode.LOGIN_BLOCKED, { originalMessage: (e as Error)?.message });
     }
   }
 }

--- a/packages/auth/test/integration/flows/phone.test.ts
+++ b/packages/auth/test/integration/flows/phone.test.ts
@@ -294,7 +294,7 @@ describe('Integration test: phone auth', () => {
           )
         );
       } catch (e) {
-        error = e;
+        error = e as FirebaseError;
       }
 
       expect(error!.customData!.phoneNumber).to.eq(PHONE_A.phoneNumber);

--- a/packages/firestore-compat/src/api/database.ts
+++ b/packages/firestore-compat/src/api/database.ts
@@ -297,7 +297,7 @@ export class Firestore
         collection(this._delegate, pathString)
       );
     } catch (e) {
-      throw replaceFunctionName(e, 'collection()', 'Firestore.collection()');
+      throw replaceFunctionName(e as Error, 'collection()', 'Firestore.collection()');
     }
   }
 
@@ -305,7 +305,7 @@ export class Firestore
     try {
       return new DocumentReference(this, doc(this._delegate, pathString));
     } catch (e) {
-      throw replaceFunctionName(e, 'doc()', 'Firestore.doc()');
+      throw replaceFunctionName(e as Error, 'doc()', 'Firestore.doc()');
     }
   }
 
@@ -314,7 +314,7 @@ export class Firestore
       return new Query(this, collectionGroup(this._delegate, collectionId));
     } catch (e) {
       throw replaceFunctionName(
-        e,
+        e as Error,
         'collectionGroup()',
         'Firestore.collectionGroup()'
       );
@@ -687,7 +687,7 @@ export class DocumentReference<T = PublicDocumentData>
       );
     } catch (e) {
       throw replaceFunctionName(
-        e,
+        e as Error,
         'collection()',
         'DocumentReference.collection()'
       );
@@ -718,7 +718,7 @@ export class DocumentReference<T = PublicDocumentData>
         return setDoc(this._delegate, value as WithFieldValue<T>);
       }
     } catch (e) {
-      throw replaceFunctionName(e, 'setDoc()', 'DocumentReference.set()');
+      throw replaceFunctionName(e as Error, 'setDoc()', 'DocumentReference.set()');
     }
   }
 
@@ -745,7 +745,7 @@ export class DocumentReference<T = PublicDocumentData>
         );
       }
     } catch (e) {
-      throw replaceFunctionName(e, 'updateDoc()', 'DocumentReference.update()');
+      throw replaceFunctionName(e as Error, 'updateDoc()', 'DocumentReference.update()');
     }
   }
 
@@ -991,7 +991,7 @@ export class Query<T = PublicDocumentData>
         query(this._delegate, where(fieldPath as string, opStr, value))
       );
     } catch (e) {
-      throw replaceFunctionName(e, /(orderBy|where)\(\)/, 'Query.$1()');
+      throw replaceFunctionName(e as Error, /(orderBy|where)\(\)/, 'Query.$1()');
     }
   }
 
@@ -1008,7 +1008,7 @@ export class Query<T = PublicDocumentData>
         query(this._delegate, orderBy(fieldPath as string, directionStr))
       );
     } catch (e) {
-      throw replaceFunctionName(e, /(orderBy|where)\(\)/, 'Query.$1()');
+      throw replaceFunctionName(e as Error, /(orderBy|where)\(\)/, 'Query.$1()');
     }
   }
 
@@ -1016,7 +1016,7 @@ export class Query<T = PublicDocumentData>
     try {
       return new Query<T>(this.firestore, query(this._delegate, limit(n)));
     } catch (e) {
-      throw replaceFunctionName(e, 'limit()', 'Query.limit()');
+      throw replaceFunctionName(e as Error, 'limit()', 'Query.limit()');
     }
   }
 
@@ -1027,7 +1027,7 @@ export class Query<T = PublicDocumentData>
         query(this._delegate, limitToLast(n))
       );
     } catch (e) {
-      throw replaceFunctionName(e, 'limitToLast()', 'Query.limitToLast()');
+      throw replaceFunctionName(e as Error, 'limitToLast()', 'Query.limitToLast()');
     }
   }
 
@@ -1035,7 +1035,7 @@ export class Query<T = PublicDocumentData>
     try {
       return new Query(this.firestore, query(this._delegate, startAt(...args)));
     } catch (e) {
-      throw replaceFunctionName(e, 'startAt()', 'Query.startAt()');
+      throw replaceFunctionName(e as Error, 'startAt()', 'Query.startAt()');
     }
   }
 
@@ -1046,7 +1046,7 @@ export class Query<T = PublicDocumentData>
         query(this._delegate, startAfter(...args))
       );
     } catch (e) {
-      throw replaceFunctionName(e, 'startAfter()', 'Query.startAfter()');
+      throw replaceFunctionName(e as Error, 'startAfter()', 'Query.startAfter()');
     }
   }
 
@@ -1057,7 +1057,7 @@ export class Query<T = PublicDocumentData>
         query(this._delegate, endBefore(...args))
       );
     } catch (e) {
-      throw replaceFunctionName(e, 'endBefore()', 'Query.endBefore()');
+      throw replaceFunctionName(e as Error, 'endBefore()', 'Query.endBefore()');
     }
   }
 
@@ -1065,7 +1065,7 @@ export class Query<T = PublicDocumentData>
     try {
       return new Query(this.firestore, query(this._delegate, endAt(...args)));
     } catch (e) {
-      throw replaceFunctionName(e, 'endAt()', 'Query.endAt()');
+      throw replaceFunctionName(e as Error, 'endAt()', 'Query.endAt()');
     }
   }
 
@@ -1265,7 +1265,7 @@ export class CollectionReference<T = PublicDocumentData>
         );
       }
     } catch (e) {
-      throw replaceFunctionName(e, 'doc()', 'CollectionReference.doc()');
+      throw replaceFunctionName(e as Error, 'doc()', 'CollectionReference.doc()');
     }
   }
 

--- a/packages/functions/src/callable.test.ts
+++ b/packages/functions/src/callable.test.ts
@@ -35,6 +35,7 @@ import {
 import { makeFakeApp, createTestService } from '../test/utils';
 import { httpsCallable } from './service';
 import { FUNCTIONS_TYPE } from './constants';
+import {FunctionsError} from './error';
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 export const TEST_PROJECT = require('../../../config/project.json');
@@ -52,9 +53,10 @@ async function expectError(
     await promise;
   } catch (e) {
     failed = true;
-    expect(e.code).to.equal(`${FUNCTIONS_TYPE}/${code}`);
-    expect(e.message).to.equal(message);
-    expect(e.details).to.deep.equal(details);
+    const error = e as FunctionsError;
+    expect(error.code).to.equal(`${FUNCTIONS_TYPE}/${code}`);
+    expect(error.message).to.equal(message);
+    expect(error.details).to.deep.equal(details);
   }
   if (!failed) {
     expect(false, 'Promise should have failed.').to.be.true;

--- a/packages/functions/src/callable.test.ts
+++ b/packages/functions/src/callable.test.ts
@@ -35,7 +35,7 @@ import {
 import { makeFakeApp, createTestService } from '../test/utils';
 import { httpsCallable } from './service';
 import { FUNCTIONS_TYPE } from './constants';
-import {FunctionsError} from './error';
+import { FunctionsError } from './error';
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 export const TEST_PROJECT = require('../../../config/project.json');

--- a/packages/messaging/src/helpers/registerDefaultSw.ts
+++ b/packages/messaging/src/helpers/registerDefaultSw.ts
@@ -41,7 +41,7 @@ export async function registerDefaultSw(
     });
   } catch (e) {
     throw ERROR_FACTORY.create(ErrorCode.FAILED_DEFAULT_REGISTRATION, {
-      browserErrorMessage: e.message
+      browserErrorMessage: (e as Error)?.message
     });
   }
 }

--- a/packages/remote-config/src/api.ts
+++ b/packages/remote-config/src/api.ts
@@ -123,7 +123,7 @@ export async function fetchConfig(remoteConfig: RemoteConfig): Promise<void> {
 
     await rc._storageCache.setLastFetchStatus('success');
   } catch (e) {
-    const lastFetchStatus = hasErrorCode(e, ErrorCode.FETCH_THROTTLE)
+    const lastFetchStatus = hasErrorCode(e as Error, ErrorCode.FETCH_THROTTLE)
       ? 'throttle'
       : 'failure';
     await rc._storageCache.setLastFetchStatus(lastFetchStatus);

--- a/packages/storage/src/platform/node/connection.ts
+++ b/packages/storage/src/platform/node/connection.ts
@@ -69,7 +69,7 @@ abstract class FetchConnection<T extends ConnectionType>
       this.errorCode_ = ErrorCode.NO_ERROR;
       this.body_ = await response.arrayBuffer();
     } catch (e) {
-      this.errorText_ = e.message;
+      this.errorText_ = (e as Error)?.message;
       // emulate XHR which sets status to 0 when encountering a network error
       this.statusCode_ = 0;
       this.errorCode_ = ErrorCode.NETWORK_ERROR;
@@ -171,7 +171,7 @@ export class FetchStreamConnection extends FetchConnection<NodeJS.ReadableStream
       this.errorCode_ = ErrorCode.NO_ERROR;
       this.stream_ = response.body;
     } catch (e) {
-      this.errorText_ = e.message;
+      this.errorText_ = (e as Error)?.message;
       // emulate XHR which sets status to 0 when encountering a network error
       this.statusCode_ = 0;
       this.errorCode_ = ErrorCode.NETWORK_ERROR;

--- a/packages/storage/src/task.ts
+++ b/packages/storage/src/task.ts
@@ -275,7 +275,7 @@ export class UploadTask {
           this._makeProgressCallback()
         );
       } catch (e) {
-        this._error = e;
+        this._error = e as StorageError;
         this._transition(InternalTaskState.ERROR);
         return;
       }

--- a/packages/storage/test/browser/blob.test.ts
+++ b/packages/storage/test/browser/blob.test.ts
@@ -114,7 +114,7 @@ describe('Firebase Storage > Blob', () => {
       await getBlob(reference);
       expect.fail();
     } catch (e) {
-      expect(e.message).to.satisfy((v: string) =>
+      expect((e as Error)?.message).to.satisfy((v: string) =>
         v.match(/Object 'public\/exp-bytes-missing' does not exist/)
       );
     }

--- a/packages/storage/test/integration/integration.test.ts
+++ b/packages/storage/test/integration/integration.test.ts
@@ -103,7 +103,7 @@ describe('FirebaseStorage Exp', () => {
       await getBytes(reference);
       expect.fail();
     } catch (e) {
-      expect(e.message).to.satisfy((v: string) =>
+      expect((e as Error)?.message).to.satisfy((v: string) =>
         v.match(/Object 'public\/exp-bytes-missing' does not exist/)
       );
     }
@@ -130,7 +130,7 @@ describe('FirebaseStorage Exp', () => {
       await uploadString(reference, 'foo');
       expect.fail();
     } catch (e) {
-      expect(e.message).to.satisfy((v: string) =>
+      expect((e as Error)?.message).to.satisfy((v: string) =>
         v.match(
           /The operation 'uploadString' cannot be performed on a root reference/
         )

--- a/packages/storage/test/node/stream.test.ts
+++ b/packages/storage/test/node/stream.test.ts
@@ -68,7 +68,7 @@ describe('Firebase Storage > getStream', () => {
       await readData(stream);
       expect.fail();
     } catch (e) {
-      expect(e.message).to.satisfy((v: string) =>
+      expect((e as Error)?.message).to.satisfy((v: string) =>
         v.match(/Object 'public\/exp-bytes-missing' does not exist/)
       );
     }

--- a/packages/storage/test/unit/testshared.ts
+++ b/packages/storage/test/unit/testshared.ts
@@ -156,7 +156,7 @@ export function assertThrows(f: () => void, code: string): StorageError {
     try {
       f();
     } catch (e) {
-      captured = e;
+      captured = e as StorageError;
       throw e;
     }
   }).to.throw();

--- a/repo-scripts/api-documenter/src/plugin/PluginLoader.ts
+++ b/repo-scripts/api-documenter/src/plugin/PluginLoader.ts
@@ -124,7 +124,7 @@ export class PluginLoader {
               );
             } catch (e) {
               throw new Error(
-                `Failed to construct feature subclass:\n` + e.toString()
+                `Failed to construct feature subclass:\n` + (e as Error)?.toString()
               );
             }
             if (
@@ -140,7 +140,7 @@ export class PluginLoader {
             } catch (e) {
               throw new Error(
                 'Error occurred during the onInitialized() event: ' +
-                  e.toString()
+                  (e as Error)?.toString()
               );
             }
 
@@ -153,7 +153,7 @@ export class PluginLoader {
         }
       } catch (e) {
         throw new Error(
-          `Error loading plugin ${configPlugin.packageName}: ` + e.message
+          `Error loading plugin ${configPlugin.packageName}: ` + (e as Error)?.message
         );
       }
     }

--- a/scripts/ci/check_changeset.ts
+++ b/scripts/ci/check_changeset.ts
@@ -126,10 +126,11 @@ async function main() {
     await exec(`yarn changeset status`);
     console.log(`::set-output name=BLOCKING_FAILURE::false`);
   } catch (e) {
-    if (e.message.match('No changesets present')) {
+    const error = e as Error;
+    if (error.message.match('No changesets present')) {
       console.log(`::set-output name=BLOCKING_FAILURE::false`);
     } else {
-      const messageLines = e.message.replace(/🦋  error /g, '').split('\n');
+      const messageLines = error.message.replace(/🦋  error /g, '').split('\n');
       let formattedStatusError =
         '- Changeset formatting error in following file:%0A';
       formattedStatusError += '    ```%0A';


### PR DESCRIPTION
Updating error handling in select packages to account for a future TypeScript package upgrade. For more information, see the below blog comment about TypeScript v4.4 errors.

"""
In JavaScript, any type of value can be thrown with throw and caught in a catch clause. Because of this, TypeScript historically typed catch clause variables as any, and would not allow any other type annotation:

Once TypeScript added the unknown type, it became clear that unknown was a better choice than any in catch clause variables for users who want the highest degree of correctness and type-safety, since it narrows better and forces us to test against arbitrary values. Eventually TypeScript 4.0 allowed users to specify an explicit type annotation of unknown (or any) on each catch clause variable so that we could opt into stricter types on a case-by-case basis; however, for some, manually specifying : unknown on every catch clause was a chore.
"""
per https://devblogs.microsoft.com/typescript/announcing-typescript-4-4/#use-unknown-catch-variables