### PR TITLE
Split staging release script into 2 parts

### DIFF
--- a/.github/workflows/release-log.yml
+++ b/.github/workflows/release-log.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches:
       - release
-      - v8-releasebranch
+      - '*-releasebranch'
 
 jobs:
   release:

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -1,0 +1,39 @@
+name: Create Release PR
+
+on:
+  push:
+    branches:
+      - release
+      - '*-releasebranch'
+
+jobs:
+  release:
+    name: Create Release PR
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@master
+        with:
+          # This makes Actions fetch all Git history so that Changesets can generate changelogs with the correct commits
+          fetch-depth: 0
+
+      - name: Setup Node.js 14.x
+        uses: actions/setup-node@master
+        with:
+          node-version: 14.x
+
+      - name: Install Dependencies
+        run: yarn
+
+      # Ensures a new @firebase/app is published with every release.
+      # This keeps the SDK_VERSION variable up to date.
+      - name: Add a changeset for @firebase/app
+        # pull master so changeset can diff against it
+        run: |
+          git pull -f --no-rebase origin master:master
+          yarn ts-node-script scripts/ci/add_changeset.ts
+
+      - name: Create Release Pull Request
+        uses: changesets/action@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.OSS_BOT_GITHUB_TOKEN }}

--- a/.github/workflows/release-staging.yml
+++ b/.github/workflows/release-staging.yml
@@ -37,12 +37,11 @@ jobs:
             base: branch,
             head: 'master'
           })
-    - name: Checkout release branch (with history)
+    - name: Checkout current branch (with history)
       uses: actions/checkout@master
       with:
         # Release script requires git history and tags.
         fetch-depth: 0
-        ref: release
     - name: Yarn install
       run: yarn
     - name: Publish to NPM

--- a/.github/workflows/release-staging.yml
+++ b/.github/workflows/release-staging.yml
@@ -30,10 +30,11 @@ jobs:
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         script: |
+          let branch = context.ref.replace("refs/heads/", "")
           await github.rest.repos.merge({
             owner: context.repo.owner,
             repo: context.repo.repo,
-            base: 'release',
+            base: branch,
             head: 'master'
           })
     - name: Checkout release branch (with history)
@@ -44,21 +45,6 @@ jobs:
         ref: release
     - name: Yarn install
       run: yarn
-    # Ensures a new @firebase/app is published with every release.
-    # This keeps the SDK_VERSION variable up to date.
-    - name: Add a changeset for @firebase/app
-      # pull master so changeset can diff against it
-      run: |
-        git pull -f --no-rebase origin master:master
-        yarn ts-node-script scripts/ci/add_changeset.ts
-    - name: Create Release Pull Request
-      uses: changesets/action@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.OSS_BOT_GITHUB_TOKEN }}
-    - name: Go back to release branch
-      # changesets/action created and checked out a new branch
-      # return to `release` branch.
-      run: git checkout release
     - name: Publish to NPM
       # --skipTests No need to run tests
       # --skipReinstall Yarn install has already been run


### PR DESCRIPTION
Separated out the part of the staging release workflow that uses changesets/action to generate the "Version Changes" PR because that action is dependent on github context to get the branch and SHA which is basically set when the workflow begins and can't be changed. The main staging workflow unfortunately makes some changes to the release branch before calling changesets/action, so it doesn't work there.

Basically, on step 2 of the Staging Release workflow ("Merge master into release"), the work will split into 2 branches running in parallel. One branch is the staging workflow continuing to its next steps (NPM publish mainly), and the second branch is the "Release PR" workflow beginning, triggered by the merge.