### PR TITLE
Fix Node ESM bundle to build from Node entry point.

### DIFF
--- a/.changeset/mean-seals-poke.md
+++ b/.changeset/mean-seals-poke.md
@@ -1,0 +1,5 @@
+---
+'@firebase/storage': patch
+---
+
+Fixed Node ESM bundle to build from Node entry point. (It was incorrectly using the browser entry point.)

--- a/packages/storage/rollup.config.js
+++ b/packages/storage/rollup.config.js
@@ -143,7 +143,7 @@ const nodeBuilds = [
     }
   },
   {
-    input: './src/index.ts',
+    input: './src/index.node.ts',
     output: {
       file: pkg.exports['.'].node.import,
       format: 'esm',


### PR DESCRIPTION
The Storage Node ESM bundle was incorrectly building from entry point `index.ts` instead of `index.node.ts`

Ran a build and the `index.node.esm.js` compiled bundle no longer contains "getStream() is only supported by NodeJS builds" error string.

Fixes https://github.com/firebase/firebase-js-sdk/issues/6343.