### PR TITLE
Fix E2E reporting to release tracker

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -61,6 +61,7 @@ jobs:
         env:
           WEBHOOK_URL: ${{ secrets.JSCORE_CHAT_WEBHOOK_URL }}
           RELEASE_TRACKER_URL: ${{ secrets.RELEASE_TRACKER_URL }}
+          VERSION_OR_TAG: ${{ github.event.client_payload.versionOrTag }}
         # run in root
         working-directory: '.'
       - name: Tests failed
@@ -69,5 +70,6 @@ jobs:
         env:
           WEBHOOK_URL: ${{ secrets.JSCORE_CHAT_WEBHOOK_URL }}
           RELEASE_TRACKER_URL: ${{ secrets.RELEASE_TRACKER_URL }}
+          VERSION_OR_TAG: ${{ github.event.client_payload.versionOrTag }}
         # run in root
         working-directory: '.'

--- a/scripts/ci/notify-test-result.js
+++ b/scripts/ci/notify-test-result.js
@@ -37,22 +37,8 @@ async function notifyTestResults() {
     status = 'succeeded';
   }
 
-  let message = `E2E Tests ${status}`;
-  let versionOrTag;
-
-  // Add version if it can find it in the workflow_dispatch event data.
-  if (process.env.GITHUB_EVENT_PATH) {
-    const wrPayload = require(process.env.GITHUB_EVENT_PATH);
-    if (wrPayload.inputs && wrPayload.inputs.versionOrTag) {
-      message += ` for release ${wrPayload.inputs.versionOrTag}.`;
-      versionOrTag = wrPayload.inputs.versionOrTag;
-    } else {
-      console.log(`Couldn't find versionOrTag in event payload.`);
-    }
-  } else {
-    console.log(`Couldn't find event payload.`);
-  }
-  message += ` ${workflowUrl}`;
+  const versionOrTag = process.env.VERSION_OR_TAG;
+  const message = `E2E Tests ${status} for release ${versionOrTag}. ${workflowUrl}`;
 
   const chatPromise = new Promise((resolve, reject) => {
     console.log(`Sending message to chat: ${message}`);


### PR DESCRIPTION
E2E tests are running fine but there's an issue with the REST call to the release tracker to log the result.

The E2E workflow was recently changed from a `workflow_dispatch` trigger to a `repository_dispatch` trigger. This changes how it receives input from the calling REST request, so the old github env variables no longer work. The correct variable is now passed in to the Node script through env variables to the "Tests succeeded" and "Tests failed" steps.