### PR TITLE
Fix typo in GtagConfigParams

### DIFF
--- a/common/api-review/analytics.api.md
+++ b/common/api-review/analytics.api.md
@@ -121,10 +121,10 @@ export function getAnalytics(app?: FirebaseApp): Analytics;
 
 // @public
 export interface GtagConfigParams {
-    'allow_google_signals?': boolean;
     // (undocumented)
     [key: string]: unknown;
     'allow_ad_personalization_signals'?: boolean;
+    'allow_google_signals'?: boolean;
     'cookie_domain'?: string;
     'cookie_expires'?: number;
     'cookie_flags'?: string;

--- a/packages/analytics/src/public-types.ts
+++ b/packages/analytics/src/public-types.ts
@@ -70,7 +70,7 @@ export interface GtagConfigParams {
    * If set to false, disables all advertising features with `gtag.js`.
    * See {@link https://developers.google.com/analytics/devguides/collection/ga4/display-features | Disable advertising features }
    */
-  'allow_google_signals?': boolean;
+  'allow_google_signals'?: boolean;
   /**
    * If set to false, disables all advertising personalization with `gtag.js`.
    * See {@link https://developers.google.com/analytics/devguides/collection/ga4/display-features | Disable advertising features }


### PR DESCRIPTION
Fix Typo in GtagConfigParams https://github.com/firebase/firebase-js-sdk/issues/6349