### PR TITLE
Update error handling for TS v4.4 unknown variables

### DIFF
--- a/packages/analytics/src/initialize-analytics.ts
+++ b/packages/analytics/src/initialize-analytics.ts
@@ -43,7 +43,7 @@ async function validateIndexedDB(): Promise<boolean> {
     } catch (e) {
       logger.warn(
         ERROR_FACTORY.create(AnalyticsError.INDEXEDDB_UNAVAILABLE, {
-          errorInfo: e
+          errorInfo: (e as Error)?.toString()
         }).message
       );
       return false;

--- a/packages/auth-compat/src/user_credential.ts
+++ b/packages/auth-compat/src/user_credential.ts
@@ -33,7 +33,7 @@ function attachExtraErrorFields(auth: exp.Auth, e: FirebaseError): void {
   // actually match the underlying type
   const response = (e.customData as exp.TaggedWithTokenResponse | undefined)
     ?._tokenResponse as unknown as Record<string, string>;
-  if (e.code === 'auth/multi-factor-auth-required') {
+  if ((e as FirebaseError)?.code === 'auth/multi-factor-auth-required') {
     const mfaErr = e as compat.MultiFactorError;
     mfaErr.resolver = new MultiFactorResolver(
       auth,

--- a/packages/auth/src/core/auth/auth_impl.ts
+++ b/packages/auth/src/core/auth/auth_impl.ts
@@ -35,6 +35,7 @@ import {
 import {
   createSubscribe,
   ErrorFactory,
+  FirebaseError,
   getModularInstance,
   Observer,
   Subscribe
@@ -301,7 +302,7 @@ export class AuthImpl implements AuthInternal, _FirebaseService {
     try {
       await _reloadWithoutSaving(user);
     } catch (e) {
-      if (e.code !== `auth/${AuthErrorCode.NETWORK_REQUEST_FAILED}`) {
+      if ((e as FirebaseError)?.code !== `auth/${AuthErrorCode.NETWORK_REQUEST_FAILED}`) {
         // Something's wrong with the user's token. Log them out and remove
         // them from storage
         return this.directlySetCurrentUser(null);

--- a/packages/auth/src/core/user/id_token_result.ts
+++ b/packages/auth/src/core/user/id_token_result.ts
@@ -110,7 +110,7 @@ export function _parseToken(token: string): ParsedToken | null {
     }
     return JSON.parse(decoded);
   } catch (e) {
-    _logError('Caught error parsing JWT payload as JSON', e);
+    _logError('Caught error parsing JWT payload as JSON', (e as Error)?.toString());
     return null;
   }
 }

--- a/packages/auth/src/core/user/proactive_refresh.ts
+++ b/packages/auth/src/core/user/proactive_refresh.ts
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+import { FirebaseError } from '@firebase/util';
 import { UserInternal } from '../../model/user';
 import { AuthErrorCode } from '../errors';
 
@@ -92,7 +93,7 @@ export class ProactiveRefresh {
       await this.user.getIdToken(true);
     } catch (e) {
       // Only retry on network errors
-      if (e.code === `auth/${AuthErrorCode.NETWORK_REQUEST_FAILED}`) {
+      if ((e as FirebaseError)?.code === `auth/${AuthErrorCode.NETWORK_REQUEST_FAILED}`) {
         this.schedule(/* wasError */ true);
       }
 

--- a/packages/auth/src/core/user/reauthenticate.ts
+++ b/packages/auth/src/core/user/reauthenticate.ts
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+import { FirebaseError } from '@firebase/util';
 import { _processCredentialSavingMfaContextIfNecessary } from '../../mfa/mfa_error';
 import { OperationType } from '../../model/enums';
 import { UserInternal } from '../../model/user';
@@ -54,7 +55,7 @@ export async function _reauthenticate(
     return UserCredentialImpl._forOperation(user, operationType, response);
   } catch (e) {
     // Convert user deleted error into user mismatch
-    if (e?.code === `auth/${AuthErrorCode.USER_DELETED}`) {
+    if ((e as FirebaseError)?.code === `auth/${AuthErrorCode.USER_DELETED}`) {
       _fail(auth, AuthErrorCode.USER_MISMATCH);
     }
     throw e;

--- a/packages/auth/src/mfa/mfa_user.ts
+++ b/packages/auth/src/mfa/mfa_user.ts
@@ -29,7 +29,7 @@ import { UserInternal } from '../model/user';
 import { MultiFactorAssertionImpl } from './mfa_assertion';
 import { MultiFactorInfoImpl } from './mfa_info';
 import { MultiFactorSessionImpl } from './mfa_session';
-import { getModularInstance } from '@firebase/util';
+import { FirebaseError, getModularInstance } from '@firebase/util';
 
 export class MultiFactorUserImpl implements MultiFactorUser {
   enrolledFactors: MultiFactorInfo[] = [];
@@ -94,7 +94,7 @@ export class MultiFactorUserImpl implements MultiFactorUser {
     try {
       await this.user.reload();
     } catch (e) {
-      if (e.code !== `auth/${AuthErrorCode.TOKEN_EXPIRED}`) {
+      if ((e as FirebaseError)?.code !== `auth/${AuthErrorCode.TOKEN_EXPIRED}`) {
         throw e;
       }
     }

--- a/packages/auth/src/platform_browser/providers/phone.ts
+++ b/packages/auth/src/platform_browser/providers/phone.ts
@@ -179,7 +179,7 @@ export class PhoneAuthProvider {
    *       auth.currentUser,
    *       PhoneAuthProvider.credential(verificationId, code));
    * } catch (e) {
-   *   if (e.code === 'auth/account-exists-with-different-credential') {
+   *   if ((e as FirebaseError)?.code === 'auth/account-exists-with-different-credential') {
    *     const cred = PhoneAuthProvider.credentialFromError(e);
    *     await linkWithCredential(auth.currentUser, cred);
    *   }

--- a/packages/remote-config/src/errors.ts
+++ b/packages/remote-config/src/errors.ts
@@ -96,8 +96,5 @@ export const ERROR_FACTORY = new ErrorFactory<ErrorCode, ErrorParams>(
 
 // Note how this is like typeof/instanceof, but for ErrorCode.
 export function hasErrorCode(e: Error, errorCode: ErrorCode): boolean {
-  return (
-    e instanceof FirebaseError &&
-    (e as FirebaseError)?.code.indexOf(errorCode) !== -1
-  );
+  return e instanceof FirebaseError && e.code.indexOf(errorCode) !== -1;
 }

--- a/packages/remote-config/src/errors.ts
+++ b/packages/remote-config/src/errors.ts
@@ -96,5 +96,8 @@ export const ERROR_FACTORY = new ErrorFactory<ErrorCode, ErrorParams>(
 
 // Note how this is like typeof/instanceof, but for ErrorCode.
 export function hasErrorCode(e: Error, errorCode: ErrorCode): boolean {
-  return e instanceof FirebaseError && e.code.indexOf(errorCode) !== -1;
+  return (
+    e instanceof FirebaseError &&
+    (e as FirebaseError)?.code.indexOf(errorCode) !== -1
+  );
 }

--- a/packages/util/src/errors.ts
+++ b/packages/util/src/errors.ts
@@ -49,7 +49,7 @@
  *
  *   catch (e) {
  *     assert(e.message === "Could not find file: foo.txt.");
- *     if (e.code === 'service/file-not-found') {
+ *     if ((e as FirebaseError)?.code === 'service/file-not-found') {
  *       console.log("Could not read file: " + e['file']);
  *     }
  *   }

--- a/packages/util/test/errors.test.ts
+++ b/packages/util/test/errors.test.ts
@@ -48,13 +48,13 @@ describe('FirebaseError', () => {
     const e = ERROR_FACTORY.create('generic-error');
     assert.instanceOf(e, Error);
     assert.instanceOf(e, FirebaseError);
-    assert.equal(e.code, 'fake/generic-error');
+    assert.equal((e as FirebaseError)?.code, 'fake/generic-error');
     assert.equal(e.message, 'Fake: Unknown error (fake/generic-error).');
   });
 
   it('replaces template values with data', () => {
     const e = ERROR_FACTORY.create('file-not-found', { file: 'foo.txt' });
-    assert.equal(e.code, 'fake/file-not-found');
+    assert.equal((e as FirebaseError)?.code, 'fake/file-not-found');
     assert.equal(
       e.message,
       "Fake: Could not find file: 'foo.txt' (fake/file-not-found)."
@@ -65,7 +65,7 @@ describe('FirebaseError', () => {
   it('uses "Error" as template when template is missing', () => {
     // Cast to avoid compile-time error.
     const e = ERROR_FACTORY.create('no-such-code' as any as ErrorCode);
-    assert.equal(e.code, 'fake/no-such-code');
+    assert.equal((e as FirebaseError)?.code, 'fake/no-such-code');
     assert.equal(e.message, 'Fake: Error (fake/no-such-code).');
   });
 
@@ -73,7 +73,7 @@ describe('FirebaseError', () => {
     const e = ERROR_FACTORY.create('file-not-found', {
       fileX: 'foo.txt'
     } as any);
-    assert.equal(e.code, 'fake/file-not-found');
+    assert.equal((e as FirebaseError)?.code, 'fake/file-not-found');
     assert.equal(
       e.message,
       "Fake: Could not find file: '<file?>' (fake/file-not-found)."


### PR DESCRIPTION
Updating error handling in select packages to account for a future TypeScript package upgrade. For more information, see the below blog comment about TypeScript v4.4 errors.

"""
In JavaScript, any type of value can be thrown with throw and caught in a catch clause. Because of this, TypeScript historically typed catch clause variables as any, and would not allow any other type annotation:

Once TypeScript added the unknown type, it became clear that unknown was a better choice than any in catch clause variables for users who want the highest degree of correctness and type-safety, since it narrows better and forces us to test against arbitrary values. Eventually TypeScript 4.0 allowed users to specify an explicit type annotation of unknown (or any) on each catch clause variable so that we could opt into stricter types on a case-by-case basis; however, for some, manually specifying : unknown on every catch clause was a chore.
"""
per https://devblogs.microsoft.com/typescript/announcing-typescript-4-4/#use-unknown-catch-variables