### PR TITLE
Add a Node ESM build to RUT

### DIFF
--- a/.changeset/nervous-starfishes-crash.md
+++ b/.changeset/nervous-starfishes-crash.md
@@ -1,0 +1,5 @@
+---
+'@firebase/rules-unit-testing': patch
+---
+
+Add Node ESM build to rules-unit-testing.

--- a/packages/rules-unit-testing/package.json
+++ b/packages/rules-unit-testing/package.json
@@ -4,6 +4,17 @@
   "description": "",
   "author": "Firebase <firebase-support@google.com> (https://firebase.google.com/)",
   "main": "dist/index.cjs.js",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "node": {
+        "import": "./dist/esm/index.esm.js",
+        "require": "./dist/index.cjs.js"
+      },
+      "default": "./dist/index.cjs.js"
+    },
+    "./package.json": "./package.json"
+  },
   "engines": {
     "node": ">=10.10.0"
   },

--- a/packages/rules-unit-testing/rollup.config.js
+++ b/packages/rules-unit-testing/rollup.config.js
@@ -18,6 +18,7 @@
 import typescriptPlugin from 'rollup-plugin-typescript2';
 import pkg from './package.json';
 import typescript from 'typescript';
+import { emitModulePackageFile } from '../../scripts/build/rollup_emit_module_package_file';
 
 const plugins = [
   typescriptPlugin({
@@ -25,13 +26,34 @@ const plugins = [
   })
 ];
 
+const es2017BuildPlugins = [
+  typescriptPlugin({
+    typescript,
+    tsconfigOverride: {
+      compilerOptions: {
+        target: 'es2017'
+      }
+    }
+  })
+];
+
 const deps = Object.keys(
   Object.assign({}, pkg.peerDependencies, pkg.dependencies)
 );
 
-export default {
-  input: 'index.ts',
-  output: [{ file: pkg.main, format: 'cjs', sourcemap: true }],
-  plugins: [...plugins],
-  external: id => deps.some(dep => id === dep || id.startsWith(`${dep}/`))
-};
+export default [
+  {
+    input: 'index.ts',
+    output: [{ file: pkg.main, format: 'cjs', sourcemap: true }],
+    plugins: [...plugins],
+    external: id => deps.some(dep => id === dep || id.startsWith(`${dep}/`))
+  },
+  {
+    input: 'index.ts',
+    output: [
+      { file: pkg.exports['.'].node.import, format: 'es', sourcemap: true }
+    ],
+    plugins: [...es2017BuildPlugins, emitModulePackageFile()],
+    external: id => deps.some(dep => id === dep || id.startsWith(`${dep}/`))
+  }
+];


### PR DESCRIPTION
Rules-unit-testing only had a CJS build for Node. This causes it to load the CJS build of Firestore, while the user may load methods from an Node ESM build of Firestore, if their project uses ES modules. This causes there to be two copies of Firestore instances that don't match.

Tested on repro: https://github.com/MarkDuckworth/firebase-js-sdk-issues-6080 and it fixes the issue.

Fixes https://github.com/firebase/firebase-js-sdk/issues/6080