### PR TITLE
Update typing for new TS versions

### DIFF
--- a/packages/analytics/src/get-config.ts
+++ b/packages/analytics/src/get-config.ts
@@ -188,7 +188,9 @@ async function attemptFetchDynamicConfigWithRetry(
       logger.warn(
         `Timed out fetching this Firebase app's measurement ID from the server.` +
           ` Falling back to the measurement ID ${measurementId}` +
-          ` provided in the "measurementId" field in the local Firebase config. [${e.message}]`
+          ` provided in the "measurementId" field in the local Firebase config. [${
+            (e as Error)?.message
+          }]`
       );
       return { appId, measurementId };
     }
@@ -203,13 +205,14 @@ async function attemptFetchDynamicConfigWithRetry(
 
     return response;
   } catch (e) {
-    if (!isRetriableError(e)) {
+    const error = e as Error;
+    if (!isRetriableError(error)) {
       retryData.deleteThrottleMetadata(appId);
       if (measurementId) {
         logger.warn(
           `Failed to fetch this Firebase app's measurement ID from the server.` +
             ` Falling back to the measurement ID ${measurementId}` +
-            ` provided in the "measurementId" field in the local Firebase config. [${e.message}]`
+            ` provided in the "measurementId" field in the local Firebase config. [${error?.message}]`
         );
         return { appId, measurementId };
       } else {
@@ -218,7 +221,7 @@ async function attemptFetchDynamicConfigWithRetry(
     }
 
     const backoffMillis =
-      Number(e.customData.httpStatus) === 503
+      Number(error?.customData?.httpStatus) === 503
         ? calculateBackoffMillis(
             backoffCount,
             retryData.intervalMillis,

--- a/packages/messaging/src/internals/requests.ts
+++ b/packages/messaging/src/internals/requests.ts
@@ -141,7 +141,7 @@ export async function requestDeleteToken(
     }
   } catch (err) {
     throw ERROR_FACTORY.create(ErrorCode.TOKEN_UNSUBSCRIBE_FAILED, {
-      errorInfo: err
+      errorInfo: (err as Error)?.toString()
     });
   }
 }

--- a/repo-scripts/size-analysis/analyze-all-bundles.ts
+++ b/repo-scripts/size-analysis/analyze-all-bundles.ts
@@ -61,7 +61,7 @@ export async function generateReportForBundles(
       input: version ? `${outputDir}/${bundle}` : `${definitionDir}/${bundle}`,
       bundler: Bundler.Rollup,
       mode: version ? Mode.Npm : Mode.Local,
-      output: output,
+      output,
       debug: true
     };
     console.log(`Running for bundle "${bundle}" with mode "${option.mode}".`);
@@ -78,7 +78,7 @@ function overwriteVersion(
   bundle: string,
   temp: string,
   version: string
-) {
+): void {
   const definitions = JSON.parse(
     fs.readFileSync(`${definitionDir}/${bundle}`, { encoding: 'utf-8' })
   );
@@ -93,7 +93,7 @@ function overwriteVersion(
   });
 }
 
-function parseAnalysisOutput(product: string, output: string) {
+function parseAnalysisOutput(product: string, output: string): Report[] {
   const analyses = JSON.parse(fs.readFileSync(output, { encoding: 'utf-8' }));
   const results: Report[] = [];
   for (const analysis of analyses) {

--- a/repo-scripts/size-analysis/test/size-analysis.test.ts
+++ b/repo-scripts/size-analysis/test/size-analysis.test.ts
@@ -196,7 +196,7 @@ describe('extractExports', () => {
 describe('extractAllTopLevelSymbols', () => {
   let subsetExportsBundleFile: string;
   let extractedDeclarations: MemberList;
-  before(function () {
+  before(() => {
     const start = Date.now();
     subsetExportsBundleFile = getSubsetExportsBundleFilePath();
     extractedDeclarations = extractAllTopLevelSymbols(subsetExportsBundleFile);


### PR DESCRIPTION
Update codebase to conform to later typescript versions. TS version > 4.4 gave TS errors for the lack of return type and not using arrow functions as a callback. TS version 4.4  requires updating catch variables as unknown. See additional information below.

"""
In JavaScript, any type of value can be thrown with throw and caught in a catch clause. Because of this, TypeScript historically typed catch clause variables as any, and would not allow any other type annotation:

Once TypeScript added the unknown type, it became clear that unknown was a better choice than any in catch clause variables for users who want the highest degree of correctness and type-safety, since it narrows better and forces us to test against arbitrary values. Eventually TypeScript 4.0 allowed users to specify an explicit type annotation of unknown (or any) on each catch clause variable so that we could opt into stricter types on a case-by-case basis; however, for some, manually specifying : unknown on every catch clause was a chore.
"""
per https://devblogs.microsoft.com/typescript/announcing-typescript-4-4/#use-unknown-catch-variables