### PR TITLE
Update the assertSucceed reference doc to the public doc

### DIFF
--- a/packages/rules-unit-testing/src/util.ts
+++ b/packages/rules-unit-testing/src/util.ts
@@ -162,7 +162,7 @@ export function assertFails(pr: Promise<any>): Promise<any> {
 }
 
 /**
- * Assert the promise to be successful with no Security Rules error.
+ * Assert the promise to be successful.
  *
  * This is a no-op function returning the passed promise as-is, but can be used for documentational
  * purposes in test code to emphasize that a certain request should succeed (e.g. allowed by rules).

--- a/packages/rules-unit-testing/src/util.ts
+++ b/packages/rules-unit-testing/src/util.ts
@@ -162,7 +162,7 @@ export function assertFails(pr: Promise<any>): Promise<any> {
 }
 
 /**
- * Assert the promise to be rejected with a "permission denied" error.
+ * Assert the promise to be successful with no Security Rules error.
  *
  * This is a no-op function returning the passed promise as-is, but can be used for documentational
  * purposes in test code to emphasize that a certain request should succeed (e.g. allowed by rules).


### PR DESCRIPTION
Update the reference doc for assertSucceed and align it to the public doc.

per:  https://firebase.google.com/docs/rules/unit-tests#rut-v2-common-methods

> The function asserts that the supplied Promise wrapping an emulator operation will be resolved with no Security Rules violations.

Proposed fix for #6306
