### PR TITLE
Cater for shapes where keys are not all strings in AddPrefixToKeys interface definition

### DIFF
--- a/common/api-review/firestore-lite.api.md
+++ b/common/api-review/firestore-lite.api.md
@@ -14,7 +14,7 @@ export function addDoc<T>(reference: CollectionReference<T>, data: WithFieldValu
 
 // @public
 export type AddPrefixToKeys<Prefix extends string, T extends Record<string, unknown>> = {
-    [K in keyof T & string as `${Prefix}.${K}`]+?: T[K];
+    [K in keyof T as K extends string ? `${Prefix}.${K}`: K]+?: T[K]
 };
 
 // @public

--- a/common/api-review/firestore.api.md
+++ b/common/api-review/firestore.api.md
@@ -14,7 +14,7 @@ export function addDoc<T>(reference: CollectionReference<T>, data: WithFieldValu
 
 // @public
 export type AddPrefixToKeys<Prefix extends string, T extends Record<string, unknown>> = {
-    [K in keyof T & string as `${Prefix}.${K}`]+?: T[K];
+    [K in keyof T as K extends string ? `${Prefix}.${K}`: K]+?: T[K]
 };
 
 // @public

--- a/packages/firestore/src/lite-api/types.ts
+++ b/packages/firestore/src/lite-api/types.ts
@@ -66,7 +66,7 @@ export type AddPrefixToKeys<
   T extends Record<string, unknown>
 > =
   // Remap K => Prefix.K. See https://www.typescriptlang.org/docs/handbook/2/mapped-types.html#key-remapping-via-as
-  { [K in keyof T & string as `${Prefix}.${K}`]+?: T[K] };
+  { [K in keyof T as K extends string ? `${Prefix}.${K}`: K]+?: T[K] };
 
 /**
  * Given a union type `U = T1 | T2 | ...`, returns an intersected type


### PR DESCRIPTION
### Summary

Fixes #6105 

The issue comes from `AddPrefixToKeys` interface, shown below, in use cases where nested interfaces are defined as `Record<string, Model>` or `{[key: string]: Model}` - it looks like Typescript has a challenge inferring such shape as it considers `K` to be of type `string|number|symbol`.

```ts
export declare type AddPrefixToKeys<Prefix extends string, T extends Record<string, unknown>> = {
  [K in keyof T & string as`${Prefix}.${K}`]+?: T[K];
};
```

To sole this, we have to tell Typescript to infer the type or use a conditional statement to determine the type as shown below. Now, typescript can infer K and know its shape n-levels deep. 
```ts
export declare type AddPrefixToKeys<Prefix extends string, T extends Record<string, unknown>> = {
  [K in keyof T as K extends string ? `${Prefix}.${K}`: K]+?: T[K];
};
```

This [Typescript playground](https://www.typescriptlang.org/play?#code/KYDwDg9gTgLgBAE2AYwDYEMrDjAnmbABSgEsBbEmEgN2wF44BnGUgOwHM4AfOVgVzIAjYFG5xBECKmDpWYvqyQAzEq2AIx-VKgDcAWABQh0JFiIUGLDnzYAqqxIRWAFQgBJVjBGMUVJwB5bAD44BgAKWzhQL0VGOAUAa1YIAHc5AH44MISALjhbAEpQkOoIEg08tVooIujgWKzcuFUlETg3IroSso1MtzhK4Gr9IwMTaHgkNExsPAI4AEEEBGJgFRBXAGlgXEZ-VfWokBiEOOY2dgAaOGcjk7iAJRRoBH9z1Sv41iTU1iCQhgAb0McDgAHowXAANqbZpyBI7CBKG5wABkTBYHzg6DiAAMACSAg4kEAAXwAdITNqTcQBdADU6TyzhhtJGoJhcLgCNwSJROLgsLqDXeHDgmQJRKw6wpVJpeU2DKZN1ZI1JI2M4Am5mmVjm2AAwgALEioBC2MAIdBeABiJGAZr2QuO9VOGIu1wAagC4J67q7Hs8oK9RZ9Esk0iFMksVtKSVsdk7rharV4ACLW9D+b0hQbDQya0yTCwzazzABywGY6hT1uAdodp38t2FbqeyBeb0xHGu4d+-1C+QcTlcHi8UB8yD8rH8wIMoI5sNU3MRyNu6NDtLyxtN5stdYbjv8m2uLMVQUMpKhPL56-dH1pQQ1Yy1ZimllmNny+-TmebPpbF0GmIchKBobBMluZl-QaQFSXFOA5wXaEl3hVcblpZVa1-GAszPR81TROBK2rPdU3re0j2cXM4EITAqHQVB-2ffUbhkMhByQ+IfCgPIuI5PhyjyTc+JBZC4CgKRgDyABydAEAoVgZLEGSyGAIQRBk64xOQ5hrT4RhZPQKdwOUngZNUYyqFoGSdLgUlLjE0lLwLAwO1YZg4AARzybDgAzXDm3Yn1ARkgyRHJQSEHJPSYAMmSjJMmznIMIA) shows what's happening - all interface definitions come from the current version of firebase-js-sdk (firebase v9.7.0). I've commented the current logic for the fix. Switch between the 2 to see how the fix solves the issue

cc @ehsannas