### PR TITLE
Upload release tags on behalf of google-oss-bot.

### DIFF
--- a/.github/workflows/health-metrics-pull-request.yml
+++ b/.github/workflows/health-metrics-pull-request.yml
@@ -1,6 +1,9 @@
 name: Health Metrics
 
-on: [push, pull_request]
+on:
+  push:
+    branches: ['**']
+  pull_request:
 
 env:
   GITHUB_PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/release-prod.yml
+++ b/.github/workflows/release-prod.yml
@@ -21,6 +21,7 @@ jobs:
         # Release script requires git history and tags.
         fetch-depth: 0
         ref: release
+        token: ${{ secrets.OSS_BOT_GITHUB_TOKEN }}
     - name: Yarn install
       run: yarn
     - name: Publish to NPM
@@ -31,7 +32,6 @@ jobs:
       # TODO: Make these flags defaults in the release script.
       run: yarn release --releaseType Production --ci --skipTests --skipReinstall --ignoreUnstaged
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         NPM_TOKEN_ANALYTICS: ${{secrets.NPM_TOKEN_ANALYTICS}}
         NPM_TOKEN_ANALYTICS_INTEROP_TYPES: ${{secrets.NPM_TOKEN_ANALYTICS_INTEROP_TYPES}}
         NPM_TOKEN_ANALYTICS_TYPES: ${{secrets.NPM_TOKEN_ANALYTICS_TYPES}}

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -1,6 +1,9 @@
 name: Test All Packages
 
-on: push
+on:
+  push:
+    branches: ['**']
+
 env:
   # make chromedriver detect installed Chrome version and download the corresponding driver
   DETECT_CHROMEDRIVER_VERSION: true


### PR DESCRIPTION
There is another workflow [1] that listens to tag push events.

However, this workflow is not being triggered by new tags
currently, due to the fact that tag push commands
(`git push <tag-name>`) initiated by GitHub Actions bot do not
trigger other workflows [2].

Switching to a personal GitHub account (in our case the
`google-oss-bot`) should fix the problem.

[1] https://github.com/firebase/firebase-js-sdk/blob/master/.github/workflows/health-metrics-release.yml
[2] https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow