### PR TITLE
Block release PR flow if release merge

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -10,6 +10,7 @@ jobs:
   release:
     name: Create Release PR
     runs-on: ubuntu-latest
+    if: ${{ !startsWith(github.event.head_commit.message, 'Version Packages (#') }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@master


### PR DESCRIPTION
Prevent "Create Release PR" workflow from running on push to release, if the push came from the release operator merging the "Version Packages" PR into the release branch in preparation for the production release.