### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/canary-deploy.yml
+++ b/.github/workflows/canary-deploy.yml
@@ -6,6 +6,9 @@ on:
       - master
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
     name: Canary Deploy

--- a/.github/workflows/check-changeset.yml
+++ b/.github/workflows/check-changeset.yml
@@ -6,8 +6,15 @@ env:
   GITHUB_PULL_REQUEST_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
   GITHUB_PULL_REQUEST_BASE_SHA: ${{ github.event.pull_request.base.sha }}
 
+permissions:
+  contents: read
+
 jobs:
   check_changeset:
+    permissions:
+      contents: read  # for actions/checkout to fetch code
+      issues: write  # for peter-evans/create-or-update-comment to create or update comment
+      pull-requests: write  # for peter-evans/create-or-update-comment to create or update comment
     name: Check changeset vs changed files
     runs-on: ubuntu-latest
 

--- a/.github/workflows/check-pkg-paths.yml
+++ b/.github/workflows/check-pkg-paths.yml
@@ -2,6 +2,9 @@ name: Test Package Paths
 
 on: pull_request
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Test Package Paths

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -5,6 +5,9 @@ on:
   repository_dispatch:
     types: [staging-tests]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Run E2E Smoke Tests

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -6,6 +6,9 @@ env:
   GITHUB_PULL_REQUEST_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
   GITHUB_PULL_REQUEST_BASE_SHA: ${{ github.event.pull_request.base.sha }}
 
+permissions:
+  contents: read
+
 jobs:
   format:
     name: Run license and prettier formatting tasks

--- a/.github/workflows/health-metrics-pull-request.yml
+++ b/.github/workflows/health-metrics-pull-request.yml
@@ -17,6 +17,9 @@ env:
   GITHUB_PULL_REQUEST_BASE_SHA: ${{ github.event.pull_request.base.sha }}
   NODE_OPTIONS: "--max-old-space-size=4096"
 
+permissions:
+  contents: read
+
 jobs:
   binary-size:
     name: Binary Size

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,6 +2,9 @@ name: Lint All Packages
 
 on: pull_request
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Lint

--- a/.github/workflows/prerelease-manual-deploy.yml
+++ b/.github/workflows/prerelease-manual-deploy.yml
@@ -9,6 +9,9 @@ on:
             npmTag:
                 description: 'The npm tag to publish to, as in npm install firebase@<npmTag>'
                 required: true
+permissions:
+  contents: read
+
 jobs:
     deploy:
         name: Prerelease Deploy

--- a/.github/workflows/release-log.yml
+++ b/.github/workflows/release-log.yml
@@ -6,6 +6,9 @@ on:
       - release
       - '*-releasebranch'
 
+permissions:
+  contents: read
+
 jobs:
   release:
     name: Send PR number to tracker endpoint

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -8,8 +8,14 @@ env:
   # make chromedriver detect installed Chrome version and download the corresponding driver
   DETECT_CHROMEDRIVER_VERSION: true
 
+permissions:
+  contents: read
+
 jobs:
   test:
+    permissions:
+      checks: write  # for coverallsapp/github-action to create new checks
+      contents: read  # for actions/checkout to fetch code
     name: Node.js and Browser (Chrome) Tests
     runs-on: ubuntu-latest
 

--- a/.github/workflows/test-changed-auth.yml
+++ b/.github/workflows/test-changed-auth.yml
@@ -6,6 +6,9 @@ env:
   # make chromedriver detect installed Chrome version and download the corresponding driver
   DETECT_CHROMEDRIVER_VERSION: true
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Test Auth If Changed

--- a/.github/workflows/test-changed-fcm-integration.yml
+++ b/.github/workflows/test-changed-fcm-integration.yml
@@ -6,6 +6,9 @@ env:
   # make chromedriver detect installed Chrome version and download the corresponding driver
   DETECT_CHROMEDRIVER_VERSION: true
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Test FCM integration If Changed

--- a/.github/workflows/test-changed-firestore-integration.yml
+++ b/.github/workflows/test-changed-firestore-integration.yml
@@ -2,6 +2,9 @@ name: Test Firestore Integration
 
 on: pull_request
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Test Firestore Integration If Changed

--- a/.github/workflows/test-changed-firestore.yml
+++ b/.github/workflows/test-changed-firestore.yml
@@ -2,6 +2,9 @@ name: Test Firestore
 
 on: pull_request
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Test Firestore If Changed

--- a/.github/workflows/test-changed-misc.yml
+++ b/.github/workflows/test-changed-misc.yml
@@ -2,6 +2,9 @@ name: Test @firebase/rules-unit-testing
 
 on: pull_request
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Test Misc Packages If Changed

--- a/.github/workflows/test-changed.yml
+++ b/.github/workflows/test-changed.yml
@@ -2,6 +2,9 @@ name: Test Modified Packages
 
 on: pull_request
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Test Packages With Changed Files

--- a/.github/workflows/test-firebase-integration.yml
+++ b/.github/workflows/test-firebase-integration.yml
@@ -2,6 +2,9 @@ name: Test Firebase Namespace
 
 on: pull_request
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Test Firebase Namespace


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: naveen <172697+naveensrinivasan@users.noreply.github.com>
