### PR TITLE
Correct Firebase spelling for issue #6393

### DIFF
--- a/packages/app/src/public-types.ts
+++ b/packages/app/src/public-types.ts
@@ -107,7 +107,7 @@ export interface FirebaseOptions {
   storageBucket?: string;
   /**
    * Unique numerical value used to identify each sender that can send
-   * Firebse Cloud Messaging messages to client apps.
+   * Firebase Cloud Messaging messages to client apps.
    */
   messagingSenderId?: string;
   /**


### PR DESCRIPTION
This change corrects a misspelling of Firebase in a documentation comment. Issue #6393 