### PR TITLE
Add installations CDN build and "firebase" entry point

### DIFF
--- a/.changeset/late-ducks-invite.md
+++ b/.changeset/late-ducks-invite.md
@@ -1,0 +1,5 @@
+---
+'firebase': patch
+---
+
+Add installations CDN build and entry point.

--- a/packages/firebase/compat/installations/index.ts
+++ b/packages/firebase/compat/installations/index.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2021 Google LLC
+ * Copyright 2022 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/firebase/compat/installations/index.ts
+++ b/packages/firebase/compat/installations/index.ts
@@ -1,0 +1,18 @@
+/**
+ * @license
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import '@firebase/installations-compat';

--- a/packages/firebase/compat/installations/package.json
+++ b/packages/firebase/compat/installations/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "firebase/compat/installations",
+  "main": "dist/index.cjs.js",
+  "browser": "dist/index.esm.js",
+  "module": "dist/index.esm.js",
+  "typings": "dist/compat/installations/index.d.ts"
+}

--- a/packages/firebase/compat/package.json
+++ b/packages/firebase/compat/package.json
@@ -11,6 +11,7 @@
     "app-check",
     "auth",
     "functions",
+    "installations",
     "messaging",
     "performance",
     "remote-config",

--- a/packages/firebase/installations/index.ts
+++ b/packages/firebase/installations/index.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2020 Google LLC
+ * Copyright 2022 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/firebase/installations/index.ts
+++ b/packages/firebase/installations/index.ts
@@ -1,0 +1,18 @@
+/**
+ * @license
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export * from '@firebase/installations';

--- a/packages/firebase/installations/package.json
+++ b/packages/firebase/installations/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "firebase/installations",
+  "main": "dist/index.cjs.js",
+  "browser": "dist/index.esm.js",
+  "module": "dist/index.esm.js",
+  "typings": "dist/installations/index.d.ts"
+}

--- a/packages/firebase/package.json
+++ b/packages/firebase/package.json
@@ -103,6 +103,14 @@
       },
       "default": "./functions/dist/index.esm.js"
     },
+    "./installations": {
+      "types": "./installations/dist/installations/index.d.ts",
+      "node": {
+        "require": "./installations/dist/index.cjs.js",
+        "import": "./installations/dist/index.mjs"
+      },
+      "default": "./installations/dist/index.esm.js"
+    },
     "./messaging": {
       "types": "./messaging/dist/messaging/index.d.ts",
       "node": {
@@ -198,6 +206,14 @@
         "import": "./compat/functions/dist/index.mjs"
       },
       "default": "./compat/functions/dist/index.esm.js"
+    },
+    "./compat/installations": {
+      "types": "./compat/installations/dist/compat/installations/index.d.ts",
+      "node": {
+        "require": "./compat/installations/dist/index.cjs.js",
+        "import": "./compat/installations/dist/index.mjs"
+      },
+      "default": "./compat/installations/dist/index.esm.js"
     },
     "./compat/messaging": {
       "types": "./compat/messaging/dist/compat/messaging/index.d.ts",

--- a/packages/firebase/package.json
+++ b/packages/firebase/package.json
@@ -273,6 +273,7 @@
     "@firebase/functions": "0.8.3",
     "@firebase/functions-compat": "0.2.3",
     "@firebase/installations": "0.5.11",
+    "@firebase/installations-compat": "0.1.11",
     "@firebase/messaging": "0.9.15",
     "@firebase/messaging-compat": "0.1.15",
     "@firebase/polyfill": "0.3.36",

--- a/packages/firebase/package.json
+++ b/packages/firebase/package.json
@@ -295,6 +295,7 @@
     "functions",
     "firestore",
     "firestore/lite",
+    "installations",
     "storage",
     "performance",
     "remote-config",


### PR DESCRIPTION
These were not added in v9 because were under the impression that installations should not be a publicly exposed API but guide docs seem to indicate otherwise: https://firebase.google.com/docs/projects/manage-installations

This allows:
- importing `firebase/installations` and `firebase/compat/installations` - previously users could import `@firebase/installations` and `@firebase/installations-compat` directly, but they were not available on the `firebase` entry point (no `@`)
- usage of firebase-installations.js and firebase-installations-compat.js from the gstatic CDN