### PR TITLE
Fix firestore/lite paths

### DIFF
--- a/packages/firestore/package.json
+++ b/packages/firestore/package.json
@@ -61,9 +61,9 @@
         "require": "./dist/lite/index.node.cjs.js",
         "import": "./dist/lite/index.node.mjs"
       },
-      "react-native": "./dist/index.rn.js",
-      "esm5": "./dist/index.esm5.js",
-      "default": "./dist/index.esm2017.js"
+      "react-native": "./dist/lite/index.rn.esm2017.js",
+      "esm5": "./dist/lite/index.browser.esm5.js",
+      "default": "./dist/lite/index.browser.esm2017.js"
     },
     "./package.json": "./package.json"
   },


### PR DESCRIPTION
Fix incorrect Node ESM exports paths for firestore/lite. They should match https://github.com/firebase/firebase-js-sdk/blob/master/packages/firestore/lite/package.json