### PR TITLE
Check for non-Enterprise recaptcha object

### DIFF
--- a/.changeset/smooth-readers-cough.md
+++ b/.changeset/smooth-readers-cough.md
@@ -1,0 +1,5 @@
+---
+'@firebase/auth': patch
+---
+
+Fix a bug causing ReCAPTCHA conflicts between Auth and App Check.

--- a/packages/auth/src/platform_browser/recaptcha/recaptcha_loader.ts
+++ b/packages/auth/src/platform_browser/recaptcha/recaptcha_loader.ts
@@ -49,7 +49,12 @@ export interface ReCaptchaLoader {
 export class ReCaptchaLoaderImpl implements ReCaptchaLoader {
   private hostLanguage = '';
   private counter = 0;
-  private readonly librarySeparatelyLoaded = !!_window().grecaptcha;
+  /**
+   * Check for `render()` method. `window.grecaptcha` will exist if the Enterprise
+   * version of the ReCAPTCHA script was loaded by someone else (e.g. App Check) but
+   * `window.grecaptcha.render()` will not. Another load will add it.
+   */
+  private readonly librarySeparatelyLoaded = !!_window().grecaptcha?.render;
 
   load(auth: AuthInternal, hl = ''): Promise<Recaptcha> {
     _assert(isHostLanguageValid(hl), auth, AuthErrorCode.ARGUMENT_ERROR);
@@ -112,7 +117,7 @@ export class ReCaptchaLoaderImpl implements ReCaptchaLoader {
     // In cases (2) and (3), we _can't_ reload as it would break the recaptchas
     // that are already in the page
     return (
-      !!_window().grecaptcha &&
+      !!_window().grecaptcha?.render &&
       (hl === this.hostLanguage ||
         this.counter > 0 ||
         this.librarySeparatelyLoaded)


### PR DESCRIPTION
Auth's `ReCaptchaLoaderImpl.load()` method checks for if the ReCAPTCHA script tag has already been loaded by itself or another library, and does not load it again if so. It does this by checking for the global object `window.grecaptcha`. Unfortunately, this object will exist if the ReCAPTCHA Enterprise version of the script has been loaded (which may be done by App Check if the user is using ReCAPTCHA Enterprise with App Check), BUT it will only contain the `enterprise` property, which is a nested version of the regular ReCAPTCHA object.

This change has the `load()` method check instead for the existence of `window.grecaptcha.render`. If it is not found, it will go ahead and load the non-Enterprise script tag, which seems to be able to co-exist with Enterprise and just adds the render/execute/etc methods onto the top level of the object without removing the `enterprise` property.

In the future, a more robust fix could be to extract a shared recaptcha loader to be used by Auth, App Check, and any other library that needs it.

One interesting note: the condition in `shouldResolveImmediately()` is kind of odd, in that it will always resolve if `window.grecaptcha.render` exists, regardless of the other 2 conditions, since `this.librarySeparatelyLoaded` is just also `!!window.grecaptcha.render`. But in the interest of a quick fix and breaking as little as possible, I will leave it be for now.

Fixes https://github.com/firebase/firebase-js-sdk/issues/6133