### PR TITLE
Do not run check-changeset on release PR

### DIFF
--- a/.github/workflows/check-changeset.yml
+++ b/.github/workflows/check-changeset.yml
@@ -1,6 +1,9 @@
 name: Check Changeset
 
-on: pull_request
+on:
+  pull_request:
+    branches-ignore:
+      - release
 
 env:
   GITHUB_PULL_REQUEST_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
@@ -8,7 +11,6 @@ env:
 
 jobs:
   check_changeset:
-    if: github.event.pull_request.title != "Version Packages"
     name: Check changeset vs changed files
     runs-on: ubuntu-latest
 

--- a/.github/workflows/check-changeset.yml
+++ b/.github/workflows/check-changeset.yml
@@ -8,6 +8,7 @@ env:
 
 jobs:
   check_changeset:
+    if: github.event.pull_request.title != "Version Packages"
     name: Check changeset vs changed files
     runs-on: ubuntu-latest
 

--- a/.github/workflows/health-metrics-pull-request.yml
+++ b/.github/workflows/health-metrics-pull-request.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches: ['**']
   pull_request:
-    branches-ignore:
-      - release
 
 env:
   GITHUB_PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/health-metrics-pull-request.yml
+++ b/.github/workflows/health-metrics-pull-request.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches: ['**']
   pull_request:
+    branches-ignore:
+      - release
 
 env:
   GITHUB_PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
Skip running this workflow on the "Version Packages" release PR. It always leaves a confusing comment that no changesets were found because this PR removes all changesets, as it should, for the release.