### PR TITLE
Forgot to add firebase version bumps for analytics

### DIFF
--- a/.changeset/shiny-bats-reflect.md
+++ b/.changeset/shiny-bats-reflect.md
@@ -1,5 +1,6 @@
 ---
 '@firebase/analytics': minor
+'firebase': minor
 ---
 
 Add function `setConsent()` to set the applicable end user "consent" state.

--- a/.changeset/silly-panthers-mix.md
+++ b/.changeset/silly-panthers-mix.md
@@ -1,5 +1,6 @@
 ---
 '@firebase/analytics': minor
+'firebase': minor
 ---
 
 Add function `setDefaultEventParameters()` to set data that will be logged on every Analytics SDK event


### PR DESCRIPTION
Forgot to add `firebase` to minor version bumps for Analytics. We need to manually add it because changesets won't automatically do a minor bump for the main package when dependent packages get a minor bump.