### PR TITLE
Update @grpc/proto-loader dep to address protobufjs security issue

### DIFF
--- a/.changeset/cyan-buses-float.md
+++ b/.changeset/cyan-buses-float.md
@@ -1,0 +1,5 @@
+---
+'@firebase/firestore': patch
+---
+
+Update `@grpc/proto-loader` dependency to address `protobufjs` security issue.

--- a/packages/firestore/package.json
+++ b/packages/firestore/package.json
@@ -84,7 +84,7 @@
     "@firebase/util": "1.6.3",
     "@firebase/webchannel-wrapper": "0.6.2",
     "@grpc/grpc-js": "^1.3.2",
-    "@grpc/proto-loader": "^0.6.0",
+    "@grpc/proto-loader": "^0.6.13",
     "node-fetch": "2.6.7",
     "tslib": "^2.1.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1613,7 +1613,7 @@
   dependencies:
     "@types/node" ">=12.12.47"
 
-"@grpc/proto-loader@^0.6.0", "@grpc/proto-loader@^0.6.1":
+"@grpc/proto-loader@^0.6.1":
   version "0.6.5"
   resolved "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.6.5.tgz#f23c7cb3e7076a8702f40c2b6678f06fb9950a55"
   integrity sha512-GZdzyVQI1Bln/kCzIYgTKu+rQJ5dno0gVrfmLe4jqQu7T2e7svSwJzpCBqVU5hhBSJP3peuPjOMWsj5GR61YmQ==
@@ -1623,6 +1623,17 @@
     long "^4.0.0"
     protobufjs "^6.10.0"
     yargs "^16.1.1"
+
+"@grpc/proto-loader@^0.6.13":
+  version "0.6.13"
+  resolved "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.6.13.tgz#008f989b72a40c60c96cd4088522f09b05ac66bc"
+  integrity sha512-FjxPYDRTn6Ec3V0arm1FtSpmP6V50wuph2yILpyvTKzjc76oDdoihXqM1DzOW5ubvCC8GivfCnNtfaRE8myJ7g==
+  dependencies:
+    "@types/long" "^4.0.1"
+    lodash.camelcase "^4.3.0"
+    long "^4.0.0"
+    protobufjs "^6.11.3"
+    yargs "^16.2.0"
 
 "@gulp-sourcemaps/identity-map@^2.0.1":
   version "2.0.1"
@@ -13874,7 +13885,7 @@ protobufjs@6.11.2, protobufjs@^6.10.0:
     "@types/node" ">=13.7.0"
     long "^4.0.0"
 
-protobufjs@6.11.3:
+protobufjs@6.11.3, protobufjs@^6.11.3:
   version "6.11.3"
   resolved "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.3.tgz#637a527205a35caa4f3e2a9a4a13ddffe0e7af74"
   integrity sha512-xL96WDdCZYdU7Slin569tFX712BxsxslWwAfAhCYjQKGTq7dAU91Lomy6nLLhh/dyGhk/YH4TwTSRxTzhuHyZg==


### PR DESCRIPTION
There is a security issue with versions of the `protobufjs` dependency lower than 6.11.3: https://github.com/advisories/GHSA-g954-5hwp-pp24

Firestore has a direct dependency on `protobufjs` which was already previously updated to 6.11.3. However, Firestore also has a dependency on `@grpc/proto-loader` which had a dependency on an older version of `protobufjs`. Upgrading our `@grpc/proto-loader` dependency to the most recent version updates its `protobufjs` dependency to 6.11.3 as well.

Tested by `npm pack`ing this branch and installing it into a test project - no traces of `protobufjs` 6.11.3.

I do see some older versions of `protobufjs` that come from dependencies of `firebase-admin` and `firebase-tools`, but those are dev dependencies and won't make it into the published npm package and won't be delivered to end users.

Fixes https://github.com/firebase/firebase-js-sdk/issues/6438