### PR TITLE
Update firebase-functions version

### DIFF
--- a/.changeset/popular-bugs-draw.md
+++ b/.changeset/popular-bugs-draw.md
@@ -1,0 +1,5 @@
+---
+'@firebase/rules-unit-testing': patch
+---
+
+Update firebase-functions to a version compatible with firebase-admin.

--- a/config/functions/package.json
+++ b/config/functions/package.json
@@ -4,10 +4,10 @@
   "dependencies": {
     "cors": "2.8.5",
     "firebase-admin": "11.0.0",
-    "firebase-functions": "3.21.0"
+    "firebase-functions": "3.22.0"
   },
   "private": true,
   "engines": {
-    "node": "10"
+    "node": "16"
   }
 }

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "eslint-plugin-unused-imports": "2.0.0",
     "express": "4.18.1",
     "find-free-port": "2.0.0",
-    "firebase-functions": "3.21.0",
+    "firebase-functions": "3.22.0",
     "firebase-tools": "11.2.2",
     "glob": "7.2.0",
     "http-server": "14.1.0",

--- a/packages/auth-compat/demo/functions/package.json
+++ b/packages/auth-compat/demo/functions/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "firebase-admin": "11.0.0",
-    "firebase-functions": "3.21.0"
+    "firebase-functions": "3.22.0"
   },
   "private": true
 }

--- a/packages/auth/demo/functions/package.json
+++ b/packages/auth/demo/functions/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "firebase-admin": "11.0.0",
-    "firebase-functions": "3.21.0"
+    "firebase-functions": "3.22.0"
   },
   "private": true,
   "engines": {

--- a/packages/rules-unit-testing/functions/package.json
+++ b/packages/rules-unit-testing/functions/package.json
@@ -12,6 +12,6 @@
     "firebase-functions": "3.22.0"
   },
   "engines": {
-    "node": "10"
+    "node": "16"
   }
 }

--- a/packages/rules-unit-testing/functions/package.json
+++ b/packages/rules-unit-testing/functions/package.json
@@ -9,9 +9,9 @@
   "private": true,
   "dependencies": {
     "firebase-admin": "11.0.0",
-    "firebase-functions": "3.21.0"
+    "firebase-functions": "3.22.0"
   },
   "engines": {
-    "node": "16"
+    "node": "10"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8047,10 +8047,10 @@ firebase-frameworks@^0.4.2:
     semver "^7.3.7"
     tslib "^2.3.1"
 
-firebase-functions@3.21.0:
-  version "3.21.0"
-  resolved "https://registry.npmjs.org/firebase-functions/-/firebase-functions-3.21.0.tgz#46b4c771781891929408bd4424959fe552d6cd6c"
-  integrity sha512-Xl0EFV05+RSB9hJHlo12LguoRqAmpSXmBnpI0MANeNj07dGW0QCWPHtaAewxYEzRS3RfSCL8WH12rjvo0PPKGw==
+firebase-functions@3.22.0:
+  version "3.22.0"
+  resolved "https://registry.npmjs.org/firebase-functions/-/firebase-functions-3.22.0.tgz#d1b6c190551e29705d91819d8369a752ba5e061a"
+  integrity sha512-d1BxBpT95MhvVqXkpLWDvWbyuX7e2l69cFAiqG3U1XQDaMV88bM9S+Zg7H8i9pitEGFr+76ErjKgrY0n+g3ZDA==
   dependencies:
     "@types/cors" "^2.8.5"
     "@types/express" "4.17.3"


### PR DESCRIPTION
`firebase-functions` needs to be bumped to 3.22.0 to be compatible with `firebase-admin` version 11.0.0. Also might as well bump our testing functions to use Node 16 while we are at it.