### PR TITLE
Update recaptchaVerifier docs

### DIFF
--- a/packages/auth/src/platform_browser/recaptcha/recaptcha_verifier.ts
+++ b/packages/auth/src/platform_browser/recaptcha/recaptcha_verifier.ts
@@ -85,10 +85,6 @@ export class RecaptchaVerifier implements ApplicationVerifierInternal {
    * 'invisible'.
    *
    * @param authExtern - The corresponding Firebase {@link Auth} instance.
-   *
-   * @remarks
-   * If none is provided, the default Firebase {@link Auth} instance is used. A Firebase {@link Auth} instance
-   * must be initialized with an API key, otherwise an error will be thrown.
    */
   constructor(
     containerOrId: HTMLElement | string,


### PR DESCRIPTION
Remove note about auto-populating auth if it's not present