### PR TITLE
Allow selecting a custom release branch

### DIFF
--- a/.github/workflows/release-prod.yml
+++ b/.github/workflows/release-prod.yml
@@ -1,6 +1,13 @@
 name: Production Release
 
-on: workflow_dispatch
+on:
+  workflow_dispatch:
+    inputs:
+      release-branch:
+        description: 'Release branch'
+        type: string
+        default: 'release'
+        required: true
 
 jobs:
   deploy:
@@ -20,7 +27,7 @@ jobs:
       with:
         # Release script requires git history and tags.
         fetch-depth: 0
-        ref: release
+        ref: ${{ github.event.inputs.release-branch }}
         token: ${{ secrets.OSS_BOT_GITHUB_TOKEN }}
     - name: Yarn install
       run: yarn


### PR DESCRIPTION
Last TODO in the new release process: allow the release-prod.yml workflow to take a custom release branch name. This should only be needed in very rare cases but we need to add this functionality for the migration to officially be complete.