### PR TITLE
Generate v8 docs with correct project paths

### DIFF
--- a/packages/auth/api-extractor.json
+++ b/packages/auth/api-extractor.json
@@ -1,6 +1,6 @@
 {
     "extends": "../../config/api-extractor.json",
-    "mainEntryPointFilePath": "<projectFolder>/dist/esm5/index.d.ts",
+    "mainEntryPointFilePath": "<projectFolder>/dist/esm5/index.doc.d.ts",
     "dtsRollup": {
         "enabled": true,
         "untrimmedFilePath": "<projectFolder>/dist/<unscopedPackageName>.d.ts",

--- a/packages/auth/api-extractor.json
+++ b/packages/auth/api-extractor.json
@@ -1,6 +1,6 @@
 {
     "extends": "../../config/api-extractor.json",
-    "mainEntryPointFilePath": "<projectFolder>/dist/esm5/index.doc.d.ts",
+    "mainEntryPointFilePath": "<projectFolder>/dist/esm5/index.d.ts",
     "dtsRollup": {
         "enabled": true,
         "untrimmedFilePath": "<projectFolder>/dist/<unscopedPackageName>.d.ts",

--- a/scripts/docgen-compat/generate-docs.js
+++ b/scripts/docgen-compat/generate-docs.js
@@ -293,7 +293,7 @@ async function setProjectYamlPath(api) {
   const projectFilePath = PROJECT_FILE_PATH[api];
   console.log('replacing', projectFilePath);
   const replacedText = defaultTemplateText.replace(
-    /(<meta name="project_path" value=")[a-z\/_\.]+(" \/>)/,
+    /(<meta name="project_path" value=")[a-zA-Z0-9\/_\.]+(" \/>)/,
     `$1${projectFilePath}$2`
   );
   await fs.writeFile(defaultTemplatePath, replacedText);

--- a/scripts/docgen-compat/generate-docs.js
+++ b/scripts/docgen-compat/generate-docs.js
@@ -281,6 +281,24 @@ function fixAllLinks(htmlFiles) {
   return Promise.all(writePromises);
 }
 
+const PROJECT_FILE_PATH = {
+  'js': '/docs/reference/js/v8/_project.yaml',
+  'node': '/docs/reference/node/_project.yaml'
+};
+async function setProjectYamlPath(api) {
+  const defaultTemplatePath = path.resolve(
+    `${__dirname}/theme/layouts/default.hbs`
+  );
+  const defaultTemplateText = await fs.readFile(defaultTemplatePath, 'utf8');
+  const projectFilePath = PROJECT_FILE_PATH[api];
+  console.log('replacing', projectFilePath);
+  const replacedText = defaultTemplateText.replace(
+    /(<meta name="project_path" value=")[a-z\/_\.]+(" \/>)/,
+    `$1${projectFilePath}$2`
+  );
+  await fs.writeFile(defaultTemplatePath, replacedText);
+}
+
 /**
  * Generate an temporary abridged version of index.d.ts used to create
  * Node docs.
@@ -356,6 +374,9 @@ Promise.all([
     if (apiType === 'node') {
       return generateNodeSource();
     }
+  })
+  .then(() => {
+    setProjectYamlPath(apiType);
   })
   // Run main Typedoc process (uses index.d.ts and generated temp file above).
   .then(runTypedoc)

--- a/scripts/docgen-compat/theme/layouts/default.hbs
+++ b/scripts/docgen-compat/theme/layouts/default.hbs
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="hide_page_heading" value="true" />
-    <meta name="project_path" value="/docs/reference/js/v8/_project.yaml" />
+    <meta name="project_path" value="/docs/reference/node/_project.yaml" />
     <meta name="book_path" value="/docs/reference/_book.yaml" />
     <meta name="translation" value="disabled" />
     <meta name="page_type" value="reference" />

--- a/scripts/docgen-compat/theme/layouts/default.hbs
+++ b/scripts/docgen-compat/theme/layouts/default.hbs
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="hide_page_heading" value="true" />
-    <meta name="project_path" value="/docs/reference/js/_project.yaml" />
+    <meta name="project_path" value="/docs/reference/js/v8/_project.yaml" />
     <meta name="book_path" value="/docs/reference/_book.yaml" />
     <meta name="translation" value="disabled" />
     <meta name="page_type" value="reference" />


### PR DESCRIPTION
Changed v8 docgen script so that depending on if "node" or "js" is specified as the script is called, the script will modify theme/layouts/default.hbs to point to the correct _project.yaml.

Sample of the generated files:

First 7 lines of firebase.app.App.html for js/v8:
```
<!DOCTYPE html>
<html devsite class="default no-js">
<head>
	<meta charset="utf-8">
	<meta http-equiv="X-UA-Compatible" content="IE=edge">
	<meta name="hide_page_heading" value="true" />
	<meta name="project_path" value="/docs/reference/js/v8/_project.yaml" />
```
First 7 lines of firebase.app.App.html for node:
```
<!DOCTYPE html>
<html devsite class="default no-js">
<head>
	<meta charset="utf-8">
	<meta http-equiv="X-UA-Compatible" content="IE=edge">
	<meta name="hide_page_heading" value="true" />
	<meta name="project_path" value="/docs/reference/node/_project.yaml" />
```