### PR TITLE
Warn instead of throw for idb errors in core app

### DIFF
--- a/.changeset/calm-pugs-leave.md
+++ b/.changeset/calm-pugs-leave.md
@@ -1,0 +1,5 @@
+---
+'@firebase/app': patch
+---
+
+Prevent core app from throwing if IndexedDB heartbeat functions throw.

--- a/packages/app/src/errors.ts
+++ b/packages/app/src/errors.ts
@@ -24,10 +24,10 @@ export const enum AppError {
   APP_DELETED = 'app-deleted',
   INVALID_APP_ARGUMENT = 'invalid-app-argument',
   INVALID_LOG_ARGUMENT = 'invalid-log-argument',
-  STORAGE_OPEN = 'storage-open',
-  STORAGE_GET = 'storage-get',
-  STORAGE_WRITE = 'storage-set',
-  STORAGE_DELETE = 'storage-delete'
+  IDB_OPEN = 'idb-open',
+  IDB_GET = 'idb-get',
+  IDB_WRITE = 'idb-set',
+  IDB_DELETE = 'idb-delete'
 }
 
 const ERRORS: ErrorMap<AppError> = {
@@ -43,14 +43,14 @@ const ERRORS: ErrorMap<AppError> = {
     'Firebase App instance.',
   [AppError.INVALID_LOG_ARGUMENT]:
     'First argument to `onLog` must be null or a function.',
-  [AppError.STORAGE_OPEN]:
-    'Error thrown when opening storage. Original error: {$originalErrorMessage}.',
-  [AppError.STORAGE_GET]:
-    'Error thrown when reading from storage. Original error: {$originalErrorMessage}.',
-  [AppError.STORAGE_WRITE]:
-    'Error thrown when writing to storage. Original error: {$originalErrorMessage}.',
-  [AppError.STORAGE_DELETE]:
-    'Error thrown when deleting from storage. Original error: {$originalErrorMessage}.'
+  [AppError.IDB_OPEN]:
+    'Error thrown when opening IndexedDB. Original error: {$originalErrorMessage}.',
+  [AppError.IDB_GET]:
+    'Error thrown when reading from IndexedDB. Original error: {$originalErrorMessage}.',
+  [AppError.IDB_WRITE]:
+    'Error thrown when writing to IndexedDB. Original error: {$originalErrorMessage}.',
+  [AppError.IDB_DELETE]:
+    'Error thrown when deleting from IndexedDB. Original error: {$originalErrorMessage}.'
 };
 
 interface ErrorParams {
@@ -59,10 +59,10 @@ interface ErrorParams {
   [AppError.DUPLICATE_APP]: { appName: string };
   [AppError.APP_DELETED]: { appName: string };
   [AppError.INVALID_APP_ARGUMENT]: { appName: string };
-  [AppError.STORAGE_OPEN]: { originalErrorMessage?: string };
-  [AppError.STORAGE_GET]: { originalErrorMessage?: string };
-  [AppError.STORAGE_WRITE]: { originalErrorMessage?: string };
-  [AppError.STORAGE_DELETE]: { originalErrorMessage?: string };
+  [AppError.IDB_OPEN]: { originalErrorMessage?: string };
+  [AppError.IDB_GET]: { originalErrorMessage?: string };
+  [AppError.IDB_WRITE]: { originalErrorMessage?: string };
+  [AppError.IDB_DELETE]: { originalErrorMessage?: string };
 }
 
 export const ERROR_FACTORY = new ErrorFactory<AppError, ErrorParams>(

--- a/packages/app/src/indexeddb.test.ts
+++ b/packages/app/src/indexeddb.test.ts
@@ -1,7 +1,27 @@
+/**
+ * @license
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { expect } from 'chai';
 import '../test/setup';
 import { match, stub } from 'sinon';
-import { readHeartbeatsFromIndexedDB, writeHeartbeatsToIndexedDB } from './indexeddb';
+import {
+  readHeartbeatsFromIndexedDB,
+  writeHeartbeatsToIndexedDB
+} from './indexeddb';
 import { FirebaseApp } from './public-types';
 import { AppError } from './errors';
 import { HeartbeatsInIndexedDB } from './types';
@@ -20,15 +40,13 @@ describe('IndexedDB functions', () => {
       await readHeartbeatsFromIndexedDB({
         name: 'testname',
         options: { appId: 'test-app-id' }
-      } as FirebaseApp
-      );
+      } as FirebaseApp);
       expect(warnStub).to.be.calledWith(match.any, match(AppError.IDB_GET));
     } else {
       await readHeartbeatsFromIndexedDB({
         name: 'testname',
         options: { appId: 'test-app-id' }
-      } as FirebaseApp
-      );
+      } as FirebaseApp);
       expect(warnStub).to.be.calledWith(match.any, match(AppError.IDB_GET));
     }
   });
@@ -37,18 +55,20 @@ describe('IndexedDB functions', () => {
     if (typeof window !== 'undefined') {
       // Ensure that indexedDB.open() fails in browser. It will always fail in Node.
       stub(window.indexedDB, 'open').throws(new Error('abcd'));
-      await writeHeartbeatsToIndexedDB({
-        name: 'testname',
-        options: { appId: 'test-app-id' }
-      } as FirebaseApp,
+      await writeHeartbeatsToIndexedDB(
+        {
+          name: 'testname',
+          options: { appId: 'test-app-id' }
+        } as FirebaseApp,
         {} as HeartbeatsInIndexedDB
       );
       expect(warnStub).to.be.calledWith(match.any, match(AppError.IDB_WRITE));
     } else {
-      await writeHeartbeatsToIndexedDB({
-        name: 'testname',
-        options: { appId: 'test-app-id' }
-      } as FirebaseApp,
+      await writeHeartbeatsToIndexedDB(
+        {
+          name: 'testname',
+          options: { appId: 'test-app-id' }
+        } as FirebaseApp,
         {} as HeartbeatsInIndexedDB
       );
       expect(warnStub).to.be.calledWith(match.any, match(AppError.IDB_WRITE));

--- a/packages/app/src/indexeddb.test.ts
+++ b/packages/app/src/indexeddb.test.ts
@@ -1,0 +1,57 @@
+import { expect } from 'chai';
+import '../test/setup';
+import { match, stub } from 'sinon';
+import { readHeartbeatsFromIndexedDB, writeHeartbeatsToIndexedDB } from './indexeddb';
+import { FirebaseApp } from './public-types';
+import { AppError } from './errors';
+import { HeartbeatsInIndexedDB } from './types';
+
+/**
+ * Mostly testing failure cases. heartbeatService.test.ts tests read-write
+ * more extensively.
+ */
+
+describe('IndexedDB functions', () => {
+  it('readHeartbeatsFromIndexedDB warns if IndexedDB.open() throws', async () => {
+    const warnStub = stub(console, 'warn');
+    if (typeof window !== 'undefined') {
+      // Ensure that indexedDB.open() fails in browser. It will always fail in Node.
+      stub(window.indexedDB, 'open').throws(new Error('abcd'));
+      await readHeartbeatsFromIndexedDB({
+        name: 'testname',
+        options: { appId: 'test-app-id' }
+      } as FirebaseApp
+      );
+      expect(warnStub).to.be.calledWith(match.any, match(AppError.IDB_GET));
+    } else {
+      await readHeartbeatsFromIndexedDB({
+        name: 'testname',
+        options: { appId: 'test-app-id' }
+      } as FirebaseApp
+      );
+      expect(warnStub).to.be.calledWith(match.any, match(AppError.IDB_GET));
+    }
+  });
+  it('writeHeartbeatsToIndexedDB warns if IndexedDB.open() throws', async () => {
+    const warnStub = stub(console, 'warn');
+    if (typeof window !== 'undefined') {
+      // Ensure that indexedDB.open() fails in browser. It will always fail in Node.
+      stub(window.indexedDB, 'open').throws(new Error('abcd'));
+      await writeHeartbeatsToIndexedDB({
+        name: 'testname',
+        options: { appId: 'test-app-id' }
+      } as FirebaseApp,
+        {} as HeartbeatsInIndexedDB
+      );
+      expect(warnStub).to.be.calledWith(match.any, match(AppError.IDB_WRITE));
+    } else {
+      await writeHeartbeatsToIndexedDB({
+        name: 'testname',
+        options: { appId: 'test-app-id' }
+      } as FirebaseApp,
+        {} as HeartbeatsInIndexedDB
+      );
+      expect(warnStub).to.be.calledWith(match.any, match(AppError.IDB_WRITE));
+    }
+  });
+});


### PR DESCRIPTION
IndexedDB is used in firebase/app for platform logging purposes. If there are any issues reading and writing to IDB, they should not throw and crash the rest of the app. Changed all caught failures to warn instead of throw.

Also renaming the error codes because they can be misleading and make it looks like the errors are related to Firebase Storage, the product.

Addresses "Error 1" listed in https://github.com/firebase/firebase-js-sdk/issues/6456