### PR TITLE
[Remote Config] add `connectRemoteConfigEmulator` to Remote Config

### DIFF
--- a/common/api-review/remote-config.api.md
+++ b/common/api-review/remote-config.api.md
@@ -10,6 +10,9 @@ import { FirebaseApp } from '@firebase/app';
 export function activate(remoteConfig: RemoteConfig): Promise<boolean>;
 
 // @public
+export function connectRemoteConfigEmulator(remoteConfig: RemoteConfig, url: string): void;
+
+// @public
 export function ensureInitialized(remoteConfig: RemoteConfig): Promise<void>;
 
 // @public

--- a/packages/remote-config/src/errors.ts
+++ b/packages/remote-config/src/errors.ts
@@ -31,7 +31,8 @@ export const enum ErrorCode {
   FETCH_THROTTLE = 'fetch-throttle',
   FETCH_PARSE = 'fetch-client-parse',
   FETCH_STATUS = 'fetch-status',
-  INDEXED_DB_UNAVAILABLE = 'indexed-db-unavailable'
+  INDEXED_DB_UNAVAILABLE = 'indexed-db-unavailable',
+  ALREADY_FETCHED = 'already-fetched'
 }
 
 const ERROR_DESCRIPTION_MAP: { readonly [key in ErrorCode]: string } = {
@@ -67,7 +68,9 @@ const ERROR_DESCRIPTION_MAP: { readonly [key in ErrorCode]: string } = {
   [ErrorCode.FETCH_STATUS]:
     'Fetch server returned an HTTP error status. HTTP status: {$httpStatus}.',
   [ErrorCode.INDEXED_DB_UNAVAILABLE]:
-    'Indexed DB is not supported by current browser'
+    'Indexed DB is not supported by current browser',
+  [ErrorCode.ALREADY_FETCHED]:
+    'Cannot connect to emulator after a fetch has been made.'
 };
 
 // Note this is effectively a type system binding a code to params. This approach overlaps with the


### PR DESCRIPTION
Add the `connectRemoteConfigEmulator` function to allow Remote Config Emulator usage. It changes `FIREBASE_REMOTE_CONFIG_URL_BASE` to point to the emulator. This is similar to the `useEmulator` implementations in other SDKs (https://github.com/firebase/firebase-android-sdk/pull/3806).

Testing with these (not-yet-merged) CLI branches:

CLI: https://github.com/Firebase/firebase-tools/tree/kroikie-rc-emulator
Emulator UI: https://github.com/Firebase/firebase-tools-ui/tree/jhuleatt-rc-emulator
