### PR TITLE
Update api-documenter to add extra new lines

### DIFF
--- a/repo-scripts/api-documenter/src/documenters/MarkdownDocumenter.ts
+++ b/repo-scripts/api-documenter/src/documenters/MarkdownDocumenter.ts
@@ -171,6 +171,7 @@ export class MarkdownDocumenter {
       `Project: /docs/reference/${this._projectName}/_project.yaml
 Book: /docs/reference/_book.yaml
 page_type: reference
+
 `
     );
 


### PR DESCRIPTION
Added an empty line between the top matter and the heading (in addition to the new line between the heading and the first sentence).