### PR TITLE
Fix TOC path for v9 docs

### DIFF
--- a/scripts/docgen/docgen.ts
+++ b/scripts/docgen/docgen.ts
@@ -89,7 +89,7 @@ async function generateToc() {
       '--input',
       'temp',
       '-p',
-      'docs/reference/js/v9',
+      'docs/reference/js',
       '-j'
     ],
     { stdio: 'inherit' }


### PR DESCRIPTION
TOC paths should not have "v9" in them.