### PR TITLE
Run prettier on Auth

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,5 +1,4 @@
 # This file is pre-built and need not be formatted
-packages/auth
 packages/firebase/firebase*
 packages/firestore/scripts
 dist

--- a/packages/auth/demo/src/index.js
+++ b/packages/auth/demo/src/index.js
@@ -82,7 +82,7 @@ import {
   logAtLevel_
 } from './logging';
 
-/** 
+/**
  * Constants that are used when connecting to the Auth Emulator.
  */
 const USE_AUTH_EMULATOR = false;
@@ -1658,7 +1658,6 @@ function initApp() {
   if (USE_AUTH_EMULATOR) {
     connectAuthEmulator(auth, AUTH_EMULATOR_URL);
   }
-  
 
   tempApp = initializeApp(
     {

--- a/packages/auth/demo/src/worker/service-worker.ts
+++ b/packages/auth/demo/src/worker/service-worker.ts
@@ -76,18 +76,16 @@ function getOriginFromUrl(url: string): string {
 
 self.addEventListener('install', (event: ExtendableEvent) => {
   // Perform install steps.
-  event.waitUntil(
-    async (): Promise<void> => {
-      const cache = await caches.open(CACHE_NAME);
-      // Add all URLs of resources we want to cache.
-      try {
-        await cache.addAll(urlsToCache);
-      } catch {
-        // Suppress error as some of the files may not be available for the
-        // current page.
-      }
+  event.waitUntil(async (): Promise<void> => {
+    const cache = await caches.open(CACHE_NAME);
+    // Add all URLs of resources we want to cache.
+    try {
+      await cache.addAll(urlsToCache);
+    } catch {
+      // Suppress error as some of the files may not be available for the
+      // current page.
     }
-  );
+  });
 });
 
 // As this is a test app, let's only return cached data when offline.
@@ -160,18 +158,16 @@ self.addEventListener('fetch', (event: FetchEvent) => {
 self.addEventListener('activate', (event: ExtendableEvent) => {
   // Update this list with all caches that need to remain cached.
   const cacheWhitelist = ['cache-v1'];
-  event.waitUntil(
-    async (): Promise<void> => {
-      const cacheNames = await caches.keys();
-      await Promise.all(
-        cacheNames.map(cacheName => {
-          // Check if cache is not whitelisted above.
-          if (cacheWhitelist.indexOf(cacheName) === -1) {
-            // If not whitelisted, delete it.
-            return caches.delete(cacheName);
-          }
-        })
-      );
-    }
-  );
+  event.waitUntil(async (): Promise<void> => {
+    const cacheNames = await caches.keys();
+    await Promise.all(
+      cacheNames.map(cacheName => {
+        // Check if cache is not whitelisted above.
+        if (cacheWhitelist.indexOf(cacheName) === -1) {
+          // If not whitelisted, delete it.
+          return caches.delete(cacheName);
+        }
+      })
+    );
+  });
 });

--- a/packages/auth/demo/src/worker/web-worker.ts
+++ b/packages/auth/demo/src/worker/web-worker.ts
@@ -105,9 +105,8 @@ async function runWorkerTests(googleIdToken: string): Promise<void> {
   if (!userCredential.user || !userCredential.user.uid) {
     throw new Error('signInWithCredential unexpectedly failed!');
   }
-  const googleCredential = GoogleAuthProvider.credentialFromResult(
-    userCredential
-  );
+  const googleCredential =
+    GoogleAuthProvider.credentialFromResult(userCredential);
   if (!googleCredential) {
     throw new Error('signInWithCredential unexpectedly failed!');
   }

--- a/packages/auth/index.doc.ts
+++ b/packages/auth/index.doc.ts
@@ -28,4 +28,7 @@
 export * from './index';
 
 export { cordovaPopupRedirectResolver } from './index.cordova';
-export { reactNativeLocalPersistence, getReactNativePersistence } from './index.rn';
+export {
+  reactNativeLocalPersistence,
+  getReactNativePersistence
+} from './index.rn';

--- a/packages/auth/index.rn.ts
+++ b/packages/auth/index.rn.ts
@@ -69,10 +69,10 @@ export const reactNativeLocalPersistence: Persistence =
     removeItem(...args) {
       // Called inline to avoid deprecation warnings on startup.
       return ReactNative.AsyncStorage.removeItem(...args);
-    },
+    }
   });
 
-export {getReactNativePersistence};
+export { getReactNativePersistence };
 
 export function getAuth(app: FirebaseApp = getApp()): Auth {
   const provider = _getProvider(app, 'auth');

--- a/packages/auth/rollup.config.js
+++ b/packages/auth/rollup.config.js
@@ -25,7 +25,9 @@ import { generateBuildTargetReplaceConfig } from '../../scripts/build/rollup_rep
 import { emitModulePackageFile } from '../../scripts/build/rollup_emit_module_package_file';
 import pkg from './package.json';
 
-const deps = Object.keys(Object.assign({}, pkg.peerDependencies, pkg.dependencies));
+const deps = Object.keys(
+  Object.assign({}, pkg.peerDependencies, pkg.dependencies)
+);
 
 /**
  * Node has the same entry point as browser, but browser-specific exports
@@ -34,150 +36,158 @@ const deps = Object.keys(Object.assign({}, pkg.peerDependencies, pkg.dependencie
  * only impacted file is the main index.ts
  */
 const nodeAliasPlugin = alias({
-    entries: [
-        {
-            find: /^\.\/src\/platform_browser(\/.*)?$/,
-            replacement: `./src/platform_node`
-        }
-    ]
+  entries: [
+    {
+      find: /^\.\/src\/platform_browser(\/.*)?$/,
+      replacement: `./src/platform_node`
+    }
+  ]
 });
 
 const es5BuildPlugins = [
-    json(),
-    strip({
-        functions: ['debugAssert.*']
-    }),
-    typescriptPlugin({
-        typescript
-    })
+  json(),
+  strip({
+    functions: ['debugAssert.*']
+  }),
+  typescriptPlugin({
+    typescript
+  })
 ];
 
 const es2017BuildPlugins = [
-    json(),
-    strip({
-        functions: ['debugAssert.*']
-    }),
-    typescriptPlugin({
-        typescript,
-        tsconfigOverride: {
-            compilerOptions: {
-                target: 'es2017'
-            }
-        }
-    })
+  json(),
+  strip({
+    functions: ['debugAssert.*']
+  }),
+  typescriptPlugin({
+    typescript,
+    tsconfigOverride: {
+      compilerOptions: {
+        target: 'es2017'
+      }
+    }
+  })
 ];
 
 const browserBuilds = [
-    {
-        input: {
-            index: 'index.ts',
-            internal: 'internal/index.ts'
-        },
-        output: [{ dir: 'dist/esm5', format: 'es', sourcemap: true }],
-        plugins: [...es5BuildPlugins, replace(generateBuildTargetReplaceConfig('esm', 5))],
-        external: id => deps.some(dep => id === dep || id.startsWith(`${dep}/`))
+  {
+    input: {
+      index: 'index.ts',
+      internal: 'internal/index.ts'
     },
-    {
-        input: {
-            index: 'index.ts',
-            internal: 'internal/index.ts'
-        },
-        output: {
-            dir: 'dist/esm2017',
-            format: 'es',
-            sourcemap: true
-        },
-        plugins: [
-            ...es2017BuildPlugins,
-            replace(generateBuildTargetReplaceConfig('esm', 2017))
-        ],
-        external: id => deps.some(dep => id === dep || id.startsWith(`${dep}/`))
-    }
+    output: [{ dir: 'dist/esm5', format: 'es', sourcemap: true }],
+    plugins: [
+      ...es5BuildPlugins,
+      replace(generateBuildTargetReplaceConfig('esm', 5))
+    ],
+    external: id => deps.some(dep => id === dep || id.startsWith(`${dep}/`))
+  },
+  {
+    input: {
+      index: 'index.ts',
+      internal: 'internal/index.ts'
+    },
+    output: {
+      dir: 'dist/esm2017',
+      format: 'es',
+      sourcemap: true
+    },
+    plugins: [
+      ...es2017BuildPlugins,
+      replace(generateBuildTargetReplaceConfig('esm', 2017))
+    ],
+    external: id => deps.some(dep => id === dep || id.startsWith(`${dep}/`))
+  }
 ];
 
 const nodeBuilds = [
-    {
-        input: {
-            index: 'index.node.ts',
-            internal: 'internal/index.ts'
-        },
-        output: [{ dir: 'dist/node', format: 'cjs', sourcemap: true }],
-        plugins: [
-            nodeAliasPlugin,
-            ...es5BuildPlugins,
-            replace(generateBuildTargetReplaceConfig('cjs', 5))
-        ],
-        external: id => deps.some(dep => id === dep || id.startsWith(`${dep}/`))
+  {
+    input: {
+      index: 'index.node.ts',
+      internal: 'internal/index.ts'
     },
-    {
-        input: {
-            index: 'index.node.ts',
-            internal: 'internal/index.ts'
-        },
-        output: [{ dir: 'dist/node-esm', format: 'es', sourcemap: true }],
-        plugins: [
-            nodeAliasPlugin,
-            ...es2017BuildPlugins,
-            replace(generateBuildTargetReplaceConfig('esm', 2017)),
-            emitModulePackageFile()
-        ],
-        external: id => deps.some(dep => id === dep || id.startsWith(`${dep}/`))
-    }
+    output: [{ dir: 'dist/node', format: 'cjs', sourcemap: true }],
+    plugins: [
+      nodeAliasPlugin,
+      ...es5BuildPlugins,
+      replace(generateBuildTargetReplaceConfig('cjs', 5))
+    ],
+    external: id => deps.some(dep => id === dep || id.startsWith(`${dep}/`))
+  },
+  {
+    input: {
+      index: 'index.node.ts',
+      internal: 'internal/index.ts'
+    },
+    output: [{ dir: 'dist/node-esm', format: 'es', sourcemap: true }],
+    plugins: [
+      nodeAliasPlugin,
+      ...es2017BuildPlugins,
+      replace(generateBuildTargetReplaceConfig('esm', 2017)),
+      emitModulePackageFile()
+    ],
+    external: id => deps.some(dep => id === dep || id.startsWith(`${dep}/`))
+  }
 ];
 
 const cordovaBuild = {
-    input: {
-        index: 'index.cordova.ts',
-        internal: 'internal/index.ts'
-    },
-    output: [{ dir: 'dist/cordova', format: 'es', sourcemap: true }],
-    plugins: [
-        ...es5BuildPlugins,
-        replace(generateBuildTargetReplaceConfig('esm', 5))
-    ],
-    external: id =>
-        [...deps, 'cordova'].some(dep => id === dep || id.startsWith(`${dep}/`))
+  input: {
+    index: 'index.cordova.ts',
+    internal: 'internal/index.ts'
+  },
+  output: [{ dir: 'dist/cordova', format: 'es', sourcemap: true }],
+  plugins: [
+    ...es5BuildPlugins,
+    replace(generateBuildTargetReplaceConfig('esm', 5))
+  ],
+  external: id =>
+    [...deps, 'cordova'].some(dep => id === dep || id.startsWith(`${dep}/`))
 };
 
 const rnBuild = {
-    input: {
-        index: 'index.rn.ts',
-        internal: 'internal/index.ts'
-    },
-    output: [{ dir: 'dist/rn', format: 'cjs', sourcemap: true }],
-    plugins: [
-        ...es5BuildPlugins,
-        replace(generateBuildTargetReplaceConfig('cjs', 5))
-    ],
-    external: id =>
-        [...deps, 'react-native'].some(
-            dep => id === dep || id.startsWith(`${dep}/`)
-        )
+  input: {
+    index: 'index.rn.ts',
+    internal: 'internal/index.ts'
+  },
+  output: [{ dir: 'dist/rn', format: 'cjs', sourcemap: true }],
+  plugins: [
+    ...es5BuildPlugins,
+    replace(generateBuildTargetReplaceConfig('cjs', 5))
+  ],
+  external: id =>
+    [...deps, 'react-native'].some(
+      dep => id === dep || id.startsWith(`${dep}/`)
+    )
 };
 
 const webWorkerBuild = {
-    input: 'index.webworker.ts',
-    output: [{ file: pkg.webworker, format: 'es', sourcemap: true }],
-    plugins: [
-        json(),
-        strip({
-            functions: ['debugAssert.*']
-        }),
-        typescriptPlugin({
-            typescript,
-            compilerOptions: {
-                lib: [
-                    // Remove dom after we figure out why navigator stuff doesn't exist
-                    'dom',
-                    'es2015',
-                    'webworker'
-                ]
-            }
-
-        }),
-        replace(generateBuildTargetReplaceConfig('esm', 5))
-    ],
-    external: id => deps.some(dep => id === dep || id.startsWith(`${dep}/`))
+  input: 'index.webworker.ts',
+  output: [{ file: pkg.webworker, format: 'es', sourcemap: true }],
+  plugins: [
+    json(),
+    strip({
+      functions: ['debugAssert.*']
+    }),
+    typescriptPlugin({
+      typescript,
+      compilerOptions: {
+        lib: [
+          // Remove dom after we figure out why navigator stuff doesn't exist
+          'dom',
+          'es2015',
+          'webworker'
+        ]
+      }
+    }),
+    replace(generateBuildTargetReplaceConfig('esm', 5))
+  ],
+  external: id => deps.some(dep => id === dep || id.startsWith(`${dep}/`))
 };
 
-export default [...browserBuilds, ...nodeBuilds, cordovaBuild, rnBuild, webWorkerBuild];
+export default [
+  ...browserBuilds,
+  ...nodeBuilds,
+  cordovaBuild,
+  rnBuild,
+  webWorkerBuild
+];

--- a/packages/auth/scripts/run_node_tests.ts
+++ b/packages/auth/scripts/run_node_tests.ts
@@ -20,17 +20,19 @@ import { resolve } from 'path';
 import { spawn } from 'child-process-promise';
 import * as yargs from 'yargs';
 
-const argv = yargs.options({
-  local: {
-    type: 'boolean'
-  },
-  integration: {
-    type: 'boolean'
-  },
-  webdriver: {
-    type: 'boolean'
-  }
-}).parseSync();
+const argv = yargs
+  .options({
+    local: {
+      type: 'boolean'
+    },
+    integration: {
+      type: 'boolean'
+    },
+    webdriver: {
+      type: 'boolean'
+    }
+  })
+  .parseSync();
 
 const nyc = resolve(__dirname, '../../../node_modules/.bin/nyc');
 const mocha = resolve(__dirname, '../../../node_modules/.bin/mocha');

--- a/packages/auth/src/api/account_management/mfa.ts
+++ b/packages/auth/src/api/account_management/mfa.ts
@@ -15,7 +15,12 @@
  * limitations under the License.
  */
 
-import { Endpoint, HttpMethod, _addTidIfNecessary, _performApiRequest } from '../index';
+import {
+  Endpoint,
+  HttpMethod,
+  _addTidIfNecessary,
+  _performApiRequest
+} from '../index';
 import { SignInWithPhoneNumberRequest } from '../authentication/sms';
 import { FinalizeMfaResponse } from '../authentication/mfa';
 import { AuthInternal } from '../../model/auth';
@@ -63,7 +68,12 @@ export function startEnrollPhoneMfa(
   return _performApiRequest<
     StartPhoneMfaEnrollmentRequest,
     StartPhoneMfaEnrollmentResponse
-  >(auth, HttpMethod.POST, Endpoint.START_PHONE_MFA_ENROLLMENT, _addTidIfNecessary(auth, request));
+  >(
+    auth,
+    HttpMethod.POST,
+    Endpoint.START_PHONE_MFA_ENROLLMENT,
+    _addTidIfNecessary(auth, request)
+  );
 }
 
 export interface FinalizePhoneMfaEnrollmentRequest {
@@ -83,7 +93,12 @@ export function finalizeEnrollPhoneMfa(
   return _performApiRequest<
     FinalizePhoneMfaEnrollmentRequest,
     FinalizePhoneMfaEnrollmentResponse
-  >(auth, HttpMethod.POST, Endpoint.FINALIZE_PHONE_MFA_ENROLLMENT, _addTidIfNecessary(auth, request));
+  >(
+    auth,
+    HttpMethod.POST,
+    Endpoint.FINALIZE_PHONE_MFA_ENROLLMENT,
+    _addTidIfNecessary(auth, request)
+  );
 }
 
 export interface WithdrawMfaRequest {

--- a/packages/auth/src/api/authentication/idp.test.ts
+++ b/packages/auth/src/api/authentication/idp.test.ts
@@ -89,31 +89,27 @@ describe('api/authentication/signInWithIdp', () => {
   });
   it('should handle user disabled errors and propagate email info', async () => {
     const response = {
-        email: "test123@gmail.com",
-        error: {
-          code: 400,
-          message: ServerError.USER_DISABLED,
-          errors: [
-            {
-              message: ServerError.USER_DISABLED
-            }
-          ]
-        }
+      email: 'test123@gmail.com',
+      error: {
+        code: 400,
+        message: ServerError.USER_DISABLED,
+        errors: [
+          {
+            message: ServerError.USER_DISABLED
+          }
+        ]
+      }
     };
 
-    const mock = mockEndpoint(
-      Endpoint.SIGN_IN_WITH_IDP,
-      response,
-      400
-    );
+    const mock = mockEndpoint(Endpoint.SIGN_IN_WITH_IDP, response, 400);
 
     await expect(signInWithIdp(auth, request))
-    .to.be.rejectedWith(FirebaseError, 'auth/user-disabled')
-    .eventually.with.deep.property('customData', {
-      appName: 'test-app',
-      _tokenResponse: response,
-      email: "test123@gmail.com"
-    });
+      .to.be.rejectedWith(FirebaseError, 'auth/user-disabled')
+      .eventually.with.deep.property('customData', {
+        appName: 'test-app',
+        _tokenResponse: response,
+        email: 'test123@gmail.com'
+      });
 
     expect(mock.calls[0].request).to.eql(request);
   });

--- a/packages/auth/src/api/authentication/mfa.ts
+++ b/packages/auth/src/api/authentication/mfa.ts
@@ -15,7 +15,12 @@
  * limitations under the License.
  */
 
-import { _performApiRequest, Endpoint, HttpMethod, _addTidIfNecessary } from '../index';
+import {
+  _performApiRequest,
+  Endpoint,
+  HttpMethod,
+  _addTidIfNecessary
+} from '../index';
 import { Auth } from '../../model/public_types';
 import { IdTokenResponse } from '../../model/id_token';
 import { MfaEnrollment } from '../account_management/mfa';
@@ -60,7 +65,12 @@ export function startSignInPhoneMfa(
   return _performApiRequest<
     StartPhoneMfaSignInRequest,
     StartPhoneMfaSignInResponse
-  >(auth, HttpMethod.POST, Endpoint.START_PHONE_MFA_SIGN_IN, _addTidIfNecessary(auth, request));
+  >(
+    auth,
+    HttpMethod.POST,
+    Endpoint.START_PHONE_MFA_SIGN_IN,
+    _addTidIfNecessary(auth, request)
+  );
 }
 
 export interface FinalizePhoneMfaSignInRequest {
@@ -73,12 +83,17 @@ export interface FinalizePhoneMfaSignInResponse extends FinalizeMfaResponse {}
 
 export function finalizeSignInPhoneMfa(
   auth: Auth,
-  request: FinalizePhoneMfaSignInRequest,
+  request: FinalizePhoneMfaSignInRequest
 ): Promise<FinalizePhoneMfaSignInResponse> {
   return _performApiRequest<
     FinalizePhoneMfaSignInRequest,
     FinalizePhoneMfaSignInResponse
-  >(auth, HttpMethod.POST, Endpoint.FINALIZE_PHONE_MFA_SIGN_IN, _addTidIfNecessary(auth, request));
+  >(
+    auth,
+    HttpMethod.POST,
+    Endpoint.FINALIZE_PHONE_MFA_SIGN_IN,
+    _addTidIfNecessary(auth, request)
+  );
 }
 
 /**

--- a/packages/auth/src/api/authentication/token.test.ts
+++ b/packages/auth/src/api/authentication/token.test.ts
@@ -95,10 +95,12 @@ describe('requestStsToken', () => {
   });
 
   it('should include whatever headers come from auth impl', async () => {
-    sinon.stub(auth, '_getAdditionalHeaders').returns(Promise.resolve({
-      'look-at-me-im-a-header': 'header-value',
-      'anotherheader': 'header-value-2',
-    }));
+    sinon.stub(auth, '_getAdditionalHeaders').returns(
+      Promise.resolve({
+        'look-at-me-im-a-header': 'header-value',
+        'anotherheader': 'header-value-2'
+      })
+    );
 
     const mock = fetch.mock(endpoint, {
       'access_token': 'new-access-token',
@@ -106,8 +108,10 @@ describe('requestStsToken', () => {
       'refresh_token': 'new-refresh-token'
     });
     await requestStsToken(auth, 'old-refresh-token');
-    
-    expect(mock.calls[0].headers.get('look-at-me-im-a-header')).to.eq('header-value');
+
+    expect(mock.calls[0].headers.get('look-at-me-im-a-header')).to.eq(
+      'header-value'
+    );
     expect(mock.calls[0].headers.get('anotherheader')).to.eq('header-value-2');
   });
 

--- a/packages/auth/src/api/authentication/token.ts
+++ b/packages/auth/src/api/authentication/token.ts
@@ -50,32 +50,33 @@ export async function requestStsToken(
   auth: Auth,
   refreshToken: string
 ): Promise<RequestStsTokenResponse> {
-  const response = await _performFetchWithErrorHandling<RequestStsTokenServerResponse>(
-    auth,
-    {},
-    async () => {
-      const body = querystring({
-        'grant_type': 'refresh_token',
-        'refresh_token': refreshToken
-      }).slice(1);
-      const { tokenApiHost, apiKey } = auth.config;
-      const url = _getFinalTarget(
-        auth,
-        tokenApiHost,
-        Endpoint.TOKEN,
-        `key=${apiKey}`
-      );
+  const response =
+    await _performFetchWithErrorHandling<RequestStsTokenServerResponse>(
+      auth,
+      {},
+      async () => {
+        const body = querystring({
+          'grant_type': 'refresh_token',
+          'refresh_token': refreshToken
+        }).slice(1);
+        const { tokenApiHost, apiKey } = auth.config;
+        const url = _getFinalTarget(
+          auth,
+          tokenApiHost,
+          Endpoint.TOKEN,
+          `key=${apiKey}`
+        );
 
-      const headers = await (auth as AuthInternal)._getAdditionalHeaders();
-      headers[HttpHeader.CONTENT_TYPE] = 'application/x-www-form-urlencoded';
+        const headers = await (auth as AuthInternal)._getAdditionalHeaders();
+        headers[HttpHeader.CONTENT_TYPE] = 'application/x-www-form-urlencoded';
 
-      return FetchProvider.fetch()(url, {
-        method: HttpMethod.POST,
-        headers,
-        body
-      });
-    }
-  );
+        return FetchProvider.fetch()(url, {
+          method: HttpMethod.POST,
+          headers,
+          body
+        });
+      }
+    );
 
   // The response comes back in snake_case. Convert to camel:
   return {

--- a/packages/auth/src/api/errors.ts
+++ b/packages/auth/src/api/errors.ts
@@ -203,5 +203,5 @@ export const SERVER_ERROR_MAP: Partial<ServerErrorMap<ServerError>> = {
     AuthErrorCode.SECOND_FACTOR_LIMIT_EXCEEDED,
 
   // Blocking functions related errors.
-  [ServerError.BLOCKING_FUNCTION_ERROR_RESPONSE]: AuthErrorCode.INTERNAL_ERROR,
+  [ServerError.BLOCKING_FUNCTION_ERROR_RESPONSE]: AuthErrorCode.INTERNAL_ERROR
 };

--- a/packages/auth/src/api/index.test.ts
+++ b/packages/auth/src/api/index.test.ts
@@ -95,18 +95,26 @@ describe('api/_performApiRequest', () => {
     });
 
     it('should include whatever headers the auth impl attaches', async () => {
-      sinon.stub(auth, '_getAdditionalHeaders').returns(Promise.resolve({
-        'look-at-me-im-a-header': 'header-value',
-        'anotherheader': 'header-value-2',
-      }));
+      sinon.stub(auth, '_getAdditionalHeaders').returns(
+        Promise.resolve({
+          'look-at-me-im-a-header': 'header-value',
+          'anotherheader': 'header-value-2'
+        })
+      );
 
       const mock = mockEndpoint(Endpoint.SIGN_UP, serverResponse);
-      await _performApiRequest<
-        typeof request,
-        typeof serverResponse
-      >(auth, HttpMethod.POST, Endpoint.SIGN_UP, request);
-      expect(mock.calls[0].headers.get('look-at-me-im-a-header')).to.eq('header-value');
-      expect(mock.calls[0].headers.get('anotherheader')).to.eq('header-value-2');
+      await _performApiRequest<typeof request, typeof serverResponse>(
+        auth,
+        HttpMethod.POST,
+        Endpoint.SIGN_UP,
+        request
+      );
+      expect(mock.calls[0].headers.get('look-at-me-im-a-header')).to.eq(
+        'header-value'
+      );
+      expect(mock.calls[0].headers.get('anotherheader')).to.eq(
+        'header-value-2'
+      );
     });
 
     it('should set the framework in clientVersion if logged', async () => {
@@ -235,8 +243,7 @@ describe('api/_performApiRequest', () => {
         Endpoint.SIGN_UP,
         request
       );
-      await expect(promise)
-        .to.be.rejectedWith(FirebaseError, 'Text text text');
+      await expect(promise).to.be.rejectedWith(FirebaseError, 'Text text text');
     });
 
     it('should handle unknown server errors', async () => {
@@ -316,7 +323,10 @@ describe('api/_performApiRequest', () => {
         request
       );
       clock.tick(DEFAULT_API_TIMEOUT_MS.get() + 1);
-      await expect(promise).to.be.rejectedWith(FirebaseError, 'auth/network-request-failed');
+      await expect(promise).to.be.rejectedWith(
+        FirebaseError,
+        'auth/network-request-failed'
+      );
       clock.restore();
     });
 
@@ -499,9 +509,7 @@ describe('api/_performApiRequest', () => {
 
     it('does not attach the tenant ID at all if not specified', () => {
       auth.tenantId = null;
-      expect(
-        _addTidIfNecessary<Record<string, string>>(auth, { foo: 'bar' })
-      )
+      expect(_addTidIfNecessary<Record<string, string>>(auth, { foo: 'bar' }))
         .to.eql({
           foo: 'bar'
         })

--- a/packages/auth/src/api/index.ts
+++ b/packages/auth/src/api/index.ts
@@ -18,7 +18,11 @@
 import { FirebaseError, querystring } from '@firebase/util';
 
 import { AuthErrorCode, NamedErrorParams } from '../core/errors';
-import { _createError, _errorWithCustomMessage, _fail } from '../core/util/assert';
+import {
+  _createError,
+  _errorWithCustomMessage,
+  _fail
+} from '../core/util/assert';
 import { Delay } from '../core/util/delay';
 import { _emulatorUrl } from '../core/util/emulator';
 import { FetchProvider } from '../core/util/fetch_provider';
@@ -38,7 +42,7 @@ export const enum HttpHeader {
   X_FIREBASE_LOCALE = 'X-Firebase-Locale',
   X_CLIENT_VERSION = 'X-Client-Version',
   X_FIREBASE_GMPID = 'X-Firebase-gmpid',
-  X_FIREBASE_CLIENT = 'X-Firebase-Client',
+  X_FIREBASE_CLIENT = 'X-Firebase-Client'
 }
 
 export const enum Endpoint {
@@ -164,9 +168,9 @@ export async function _performFetchWithErrorHandling<V>(
       }
       const authError =
         errorMap[serverErrorCode as ServerError] ||
-        ((serverErrorCode
+        (serverErrorCode
           .toLowerCase()
-          .replace(/[_\s]+/g, '-') as unknown) as AuthErrorCode);
+          .replace(/[_\s]+/g, '-') as unknown as AuthErrorCode);
       if (serverErrorMessage) {
         throw _errorWithCustomMessage(auth, authError, serverErrorMessage);
       } else {
@@ -226,7 +230,9 @@ class NetworkTimeout<T> {
   private timer: any | null = null;
   readonly promise = new Promise<T>((_, reject) => {
     this.timer = setTimeout(() => {
-      return reject(_createError(this.auth, AuthErrorCode.NETWORK_REQUEST_FAILED));
+      return reject(
+        _createError(this.auth, AuthErrorCode.NETWORK_REQUEST_FAILED)
+      );
     }, DEFAULT_API_TIMEOUT_MS.get());
   });
 

--- a/packages/auth/src/core/auth/auth_impl.test.ts
+++ b/packages/auth/src/core/auth/auth_impl.test.ts
@@ -23,7 +23,12 @@ import sinonChai from 'sinon-chai';
 import { FirebaseApp } from '@firebase/app';
 import { FirebaseError } from '@firebase/util';
 
-import { FAKE_HEARTBEAT_CONTROLLER, FAKE_HEARTBEAT_CONTROLLER_PROVIDER, testAuth, testUser } from '../../../test/helpers/mock_auth';
+import {
+  FAKE_HEARTBEAT_CONTROLLER,
+  FAKE_HEARTBEAT_CONTROLLER_PROVIDER,
+  testAuth,
+  testUser
+} from '../../../test/helpers/mock_auth';
 import { AuthInternal } from '../../model/auth';
 import { UserInternal } from '../../model/user';
 import { PersistenceInternal } from '../persistence';
@@ -54,14 +59,18 @@ describe('core/auth/auth_impl', () => {
 
   beforeEach(async () => {
     persistenceStub = sinon.stub(_getInstance(inMemoryPersistence));
-    const authImpl = new AuthImpl(FAKE_APP, FAKE_HEARTBEAT_CONTROLLER_PROVIDER, {
-      apiKey: FAKE_APP.options.apiKey!,
-      apiHost: DefaultConfig.API_HOST,
-      apiScheme: DefaultConfig.API_SCHEME,
-      tokenApiHost: DefaultConfig.TOKEN_API_HOST,
-      clientPlatform: ClientPlatform.BROWSER,
-      sdkClientVersion: 'v'
-    });
+    const authImpl = new AuthImpl(
+      FAKE_APP,
+      FAKE_HEARTBEAT_CONTROLLER_PROVIDER,
+      {
+        apiKey: FAKE_APP.options.apiKey!,
+        apiHost: DefaultConfig.API_HOST,
+        apiScheme: DefaultConfig.API_SCHEME,
+        tokenApiHost: DefaultConfig.TOKEN_API_HOST,
+        clientPlatform: ClientPlatform.BROWSER,
+        sdkClientVersion: 'v'
+      }
+    );
 
     _initializeAuthInstance(authImpl, { persistence: inMemoryPersistence });
     auth = authImpl;
@@ -142,7 +151,9 @@ describe('core/auth/auth_impl', () => {
     it('is blocked if a beforeAuthStateChanged callback throws', async () => {
       await auth._updateCurrentUser(testUser(auth, 'test'));
       auth.beforeAuthStateChanged(sinon.stub().throws());
-      await expect(auth.signOut()).to.be.rejectedWith(AuthErrorCode.LOGIN_BLOCKED);
+      await expect(auth.signOut()).to.be.rejectedWith(
+        AuthErrorCode.LOGIN_BLOCKED
+      );
     });
   });
 
@@ -344,7 +355,9 @@ describe('core/auth/auth_impl', () => {
         auth.beforeAuthStateChanged(cb1);
         auth.beforeAuthStateChanged(cb2);
 
-        await expect(auth._updateCurrentUser(user)).to.be.rejectedWith(AuthErrorCode.LOGIN_BLOCKED);
+        await expect(auth._updateCurrentUser(user)).to.be.rejectedWith(
+          AuthErrorCode.LOGIN_BLOCKED
+        );
         expect(cb2).not.to.be.called;
       });
 
@@ -355,7 +368,9 @@ describe('core/auth/auth_impl', () => {
         auth.beforeAuthStateChanged(cb1);
         auth.beforeAuthStateChanged(cb2);
 
-        await expect(auth._updateCurrentUser(user)).to.be.rejectedWith(AuthErrorCode.LOGIN_BLOCKED);
+        await expect(auth._updateCurrentUser(user)).to.be.rejectedWith(
+          AuthErrorCode.LOGIN_BLOCKED
+        );
         expect(cb2).not.to.be.called;
       });
     });
@@ -505,14 +520,18 @@ describe('core/auth/auth_impl', () => {
     });
 
     it('prevents initialization from completing', async () => {
-      const authImpl = new AuthImpl(FAKE_APP, FAKE_HEARTBEAT_CONTROLLER_PROVIDER, {
-        apiKey: FAKE_APP.options.apiKey!,
-        apiHost: DefaultConfig.API_HOST,
-        apiScheme: DefaultConfig.API_SCHEME,
-        tokenApiHost: DefaultConfig.TOKEN_API_HOST,
-        clientPlatform: ClientPlatform.BROWSER,
-        sdkClientVersion: 'v'
-      });
+      const authImpl = new AuthImpl(
+        FAKE_APP,
+        FAKE_HEARTBEAT_CONTROLLER_PROVIDER,
+        {
+          apiKey: FAKE_APP.options.apiKey!,
+          apiHost: DefaultConfig.API_HOST,
+          apiScheme: DefaultConfig.API_SCHEME,
+          tokenApiHost: DefaultConfig.TOKEN_API_HOST,
+          clientPlatform: ClientPlatform.BROWSER,
+          sdkClientVersion: 'v'
+        }
+      );
 
       persistenceStub._get.returns(
         Promise.resolve(testUser(auth, 'uid').toJSON())
@@ -538,7 +557,7 @@ describe('core/auth/auth_impl', () => {
   context('#_getAdditionalHeaders', () => {
     it('always adds the client version', async () => {
       expect(await auth._getAdditionalHeaders()).to.eql({
-        'X-Client-Version': 'v',
+        'X-Client-Version': 'v'
       });
     });
 
@@ -546,30 +565,36 @@ describe('core/auth/auth_impl', () => {
       auth.app.options.appId = 'app-id';
       expect(await auth._getAdditionalHeaders()).to.eql({
         'X-Client-Version': 'v',
-        'X-Firebase-gmpid': 'app-id',
+        'X-Firebase-gmpid': 'app-id'
       });
       delete auth.app.options.appId;
     });
 
     it('adds the heartbeat if available', async () => {
-      sinon.stub(FAKE_HEARTBEAT_CONTROLLER, 'getHeartbeatsHeader').returns(Promise.resolve('heartbeat'));
+      sinon
+        .stub(FAKE_HEARTBEAT_CONTROLLER, 'getHeartbeatsHeader')
+        .returns(Promise.resolve('heartbeat'));
       expect(await auth._getAdditionalHeaders()).to.eql({
         'X-Client-Version': 'v',
-        'X-Firebase-Client': 'heartbeat',
+        'X-Firebase-Client': 'heartbeat'
       });
     });
 
     it('does not add heartbeat if none returned', async () => {
-      sinon.stub(FAKE_HEARTBEAT_CONTROLLER, 'getHeartbeatsHeader').returns(Promise.resolve(''));
+      sinon
+        .stub(FAKE_HEARTBEAT_CONTROLLER, 'getHeartbeatsHeader')
+        .returns(Promise.resolve(''));
       expect(await auth._getAdditionalHeaders()).to.eql({
-        'X-Client-Version': 'v',
+        'X-Client-Version': 'v'
       });
     });
 
     it('does not add heartbeat if controller unavailable', async () => {
-      sinon.stub(FAKE_HEARTBEAT_CONTROLLER_PROVIDER, 'getImmediate').returns(undefined as any);
+      sinon
+        .stub(FAKE_HEARTBEAT_CONTROLLER_PROVIDER, 'getImmediate')
+        .returns(undefined as any);
       expect(await auth._getAdditionalHeaders()).to.eql({
-        'X-Client-Version': 'v',
+        'X-Client-Version': 'v'
       });
     });
   });

--- a/packages/auth/src/core/auth/auth_impl.ts
+++ b/packages/auth/src/core/auth/auth_impl.ts
@@ -144,7 +144,9 @@ export class AuthImpl implements AuthInternal, _FirebaseService {
         // If this fails, don't halt auth loading
         try {
           await this._popupRedirectResolver._initialize(this);
-        } catch (e) { /* Ignore the error */ }
+        } catch (e) {
+          /* Ignore the error */
+        }
       }
 
       await this.initializeCurrentUser(popupRedirectResolver);
@@ -228,14 +230,16 @@ export class AuthImpl implements AuthInternal, _FirebaseService {
       if (needsTocheckMiddleware) {
         try {
           await this.beforeStateQueue.runMiddleware(futureCurrentUser);
-        } catch(e) {
+        } catch (e) {
           futureCurrentUser = previouslyStoredUser;
           // We know this is available since the bit is only set when the
           // resolver is available
-          this._popupRedirectResolver!._overrideRedirectResult(this, () => Promise.reject(e));
+          this._popupRedirectResolver!._overrideRedirectResult(this, () =>
+            Promise.reject(e)
+          );
         }
       }
-  
+
       if (futureCurrentUser) {
         return this.reloadAndSetCurrentUserOrClear(futureCurrentUser);
       } else {
@@ -302,7 +306,10 @@ export class AuthImpl implements AuthInternal, _FirebaseService {
     try {
       await _reloadWithoutSaving(user);
     } catch (e) {
-      if ((e as FirebaseError)?.code !== `auth/${AuthErrorCode.NETWORK_REQUEST_FAILED}`) {
+      if (
+        (e as FirebaseError)?.code !==
+        `auth/${AuthErrorCode.NETWORK_REQUEST_FAILED}`
+      ) {
         // Something's wrong with the user's token. Log them out and remove
         // them from storage
         return this.directlySetCurrentUser(null);
@@ -336,7 +343,10 @@ export class AuthImpl implements AuthInternal, _FirebaseService {
     return this._updateCurrentUser(user && user._clone(this));
   }
 
-  async _updateCurrentUser(user: User | null, skipBeforeStateCallbacks: boolean = false): Promise<void> {
+  async _updateCurrentUser(
+    user: User | null,
+    skipBeforeStateCallbacks: boolean = false
+  ): Promise<void> {
     if (this._deleted) {
       return;
     }
@@ -404,7 +414,7 @@ export class AuthImpl implements AuthInternal, _FirebaseService {
 
   beforeAuthStateChanged(
     callback: (user: User | null) => void | Promise<void>,
-    onAbort?: () => void,
+    onAbort?: () => void
   ): Unsubscribe {
     return this.beforeStateQueue.pushCallback(callback, onAbort);
   }
@@ -467,7 +477,7 @@ export class AuthImpl implements AuthInternal, _FirebaseService {
     // Make sure we've cleared any pending persistence actions if we're not in
     // the initializer
     if (this._isInitialized) {
-      await this.queue(async () => { });
+      await this.queue(async () => {});
     }
 
     if (this._currentUser?._redirectEventId === id) {
@@ -538,7 +548,7 @@ export class AuthImpl implements AuthInternal, _FirebaseService {
     completed?: CompleteFn
   ): Unsubscribe {
     if (this._deleted) {
-      return () => { };
+      return () => {};
     }
 
     const cb =
@@ -619,7 +629,7 @@ export class AuthImpl implements AuthInternal, _FirebaseService {
   async _getAdditionalHeaders(): Promise<Record<string, string>> {
     // Additional headers on every request
     const headers: Record<string, string> = {
-      [HttpHeader.X_CLIENT_VERSION]: this.clientVersion,
+      [HttpHeader.X_CLIENT_VERSION]: this.clientVersion
     };
 
     if (this.app.options.appId) {
@@ -627,9 +637,11 @@ export class AuthImpl implements AuthInternal, _FirebaseService {
     }
 
     // If the heartbeat service exists, add the heartbeat string
-    const heartbeatsHeader = await this.heartbeatServiceProvider.getImmediate({
-      optional: true,
-    })?.getHeartbeatsHeader();
+    const heartbeatsHeader = await this.heartbeatServiceProvider
+      .getImmediate({
+        optional: true
+      })
+      ?.getHeartbeatsHeader();
     if (heartbeatsHeader) {
       headers[HttpHeader.X_FIREBASE_CLIENT] = heartbeatsHeader;
     }
@@ -654,7 +666,7 @@ class Subscription<T> {
     observer => (this.observer = observer)
   );
 
-  constructor(readonly auth: AuthInternal) { }
+  constructor(readonly auth: AuthInternal) {}
 
   get next(): NextFn<T | null> {
     _assert(this.observer, this.auth, AuthErrorCode.INTERNAL_ERROR);

--- a/packages/auth/src/core/auth/emulator.ts
+++ b/packages/auth/src/core/auth/emulator.ts
@@ -143,10 +143,7 @@ function emitEmulatorWarning(): void {
         ' production credentials.'
     );
   }
-  if (
-    typeof window !== 'undefined' &&
-    typeof document !== 'undefined'
-  ) {
+  if (typeof window !== 'undefined' && typeof document !== 'undefined') {
     if (document.readyState === 'loading') {
       window.addEventListener('DOMContentLoaded', attachBanner);
     } else {

--- a/packages/auth/src/core/auth/firebase_internal.test.ts
+++ b/packages/auth/src/core/auth/firebase_internal.test.ts
@@ -51,7 +51,7 @@ describe('core/auth/firebase_internal', () => {
     });
 
     it('errors if Auth is not initialized', () => {
-      delete ((auth as unknown) as Record<string, unknown>)[
+      delete (auth as unknown as Record<string, unknown>)[
         '_initializationPromise'
       ];
       expect(() => authInternal.getUid()).to.throw(
@@ -78,7 +78,7 @@ describe('core/auth/firebase_internal', () => {
     });
 
     it('errors if Auth is not initialized', async () => {
-      delete ((auth as unknown) as Record<string, unknown>)[
+      delete (auth as unknown as Record<string, unknown>)[
         '_initializationPromise'
       ];
       await expect(authInternal.getToken()).to.be.rejectedWith(
@@ -141,7 +141,7 @@ describe('core/auth/firebase_internal', () => {
       });
 
       it('errors if Auth is not initialized', () => {
-        delete ((auth as unknown) as Record<string, unknown>)[
+        delete (auth as unknown as Record<string, unknown>)[
           '_initializationPromise'
         ];
         expect(() => authInternal.addAuthTokenListener(() => {})).to.throw(
@@ -204,7 +204,7 @@ describe('core/auth/firebase_internal', () => {
       });
 
       it('errors if Auth is not initialized', () => {
-        delete ((auth as unknown) as Record<string, unknown>)[
+        delete (auth as unknown as Record<string, unknown>)[
           '_initializationPromise'
         ];
         expect(() => authInternal.removeAuthTokenListener(() => {})).to.throw(

--- a/packages/auth/src/core/auth/firebase_internal.ts
+++ b/packages/auth/src/core/auth/firebase_internal.ts
@@ -28,10 +28,8 @@ interface TokenListener {
 }
 
 export class AuthInterop implements FirebaseAuthInternal {
-  private readonly internalListeners: Map<
-    TokenListener,
-    Unsubscribe
-  > = new Map();
+  private readonly internalListeners: Map<TokenListener, Unsubscribe> =
+    new Map();
 
   constructor(private readonly auth: AuthInternal) {}
 

--- a/packages/auth/src/core/auth/initialize.test.ts
+++ b/packages/auth/src/core/auth/initialize.test.ts
@@ -126,8 +126,7 @@ describe('core/auth/initialize', () => {
     ): Promise<UserCredential | null> {
       return null;
     }
-    async _overrideRedirectResult(): Promise<void> {
-    }
+    async _overrideRedirectResult(): Promise<void> {}
   }
 
   const fakePopupRedirectResolver: PopupRedirectResolver =

--- a/packages/auth/src/core/auth/middleware.test.ts
+++ b/packages/auth/src/core/auth/middleware.test.ts
@@ -45,9 +45,15 @@ describe('Auth middleware', () => {
   it('calls middleware in order', async () => {
     const calls: number[] = [];
 
-    middlewareQueue.pushCallback(() => {calls.push(1);});
-    middlewareQueue.pushCallback(() => {calls.push(2);});
-    middlewareQueue.pushCallback(() => {calls.push(3);});
+    middlewareQueue.pushCallback(() => {
+      calls.push(1);
+    });
+    middlewareQueue.pushCallback(() => {
+      calls.push(2);
+    });
+    middlewareQueue.pushCallback(() => {
+      calls.push(3);
+    });
 
     await middlewareQueue.runMiddleware(user);
 
@@ -58,12 +64,16 @@ describe('Auth middleware', () => {
     middlewareQueue.pushCallback(() => {
       throw new Error('no');
     });
-    await expect(middlewareQueue.runMiddleware(user)).to.be.rejectedWith('auth/login-blocked');
+    await expect(middlewareQueue.runMiddleware(user)).to.be.rejectedWith(
+      'auth/login-blocked'
+    );
   });
 
   it('rejects on promise rejection', async () => {
     middlewareQueue.pushCallback(() => Promise.reject('no'));
-    await expect(middlewareQueue.runMiddleware(user)).to.be.rejectedWith('auth/login-blocked');
+    await expect(middlewareQueue.runMiddleware(user)).to.be.rejectedWith(
+      'auth/login-blocked'
+    );
   });
 
   it('awaits middleware completion before calling next', async () => {
@@ -93,7 +103,9 @@ describe('Auth middleware', () => {
     });
     middlewareQueue.pushCallback(spy);
 
-    await expect(middlewareQueue.runMiddleware(user)).to.be.rejectedWith('auth/login-blocked');
+    await expect(middlewareQueue.runMiddleware(user)).to.be.rejectedWith(
+      'auth/login-blocked'
+    );
     expect(spy).not.to.have.been.called;
   });
 
@@ -106,7 +118,9 @@ describe('Auth middleware', () => {
       throw new Error('no');
     }, secondOnAbort);
 
-    await expect(middlewareQueue.runMiddleware(user)).to.be.rejectedWith('auth/login-blocked');
+    await expect(middlewareQueue.runMiddleware(user)).to.be.rejectedWith(
+      'auth/login-blocked'
+    );
     expect(firstOnAbort).to.have.been.called;
     expect(secondOnAbort).not.to.have.been.called;
   });
@@ -114,14 +128,31 @@ describe('Auth middleware', () => {
   it('calls onAbort in reverse order', async () => {
     const calls: number[] = [];
 
-    middlewareQueue.pushCallback(() => {}, () => {calls.push(1);});
-    middlewareQueue.pushCallback(() => {}, () => {calls.push(2);});
-    middlewareQueue.pushCallback(() => {}, () => {calls.push(3);});
+    middlewareQueue.pushCallback(
+      () => {},
+      () => {
+        calls.push(1);
+      }
+    );
+    middlewareQueue.pushCallback(
+      () => {},
+      () => {
+        calls.push(2);
+      }
+    );
+    middlewareQueue.pushCallback(
+      () => {},
+      () => {
+        calls.push(3);
+      }
+    );
     middlewareQueue.pushCallback(() => {
       throw new Error('no');
     });
 
-    await expect(middlewareQueue.runMiddleware(user)).to.be.rejectedWith('auth/login-blocked');
+    await expect(middlewareQueue.runMiddleware(user)).to.be.rejectedWith(
+      'auth/login-blocked'
+    );
     expect(calls).to.eql([3, 2, 1]);
   });
 

--- a/packages/auth/src/core/auth/middleware.ts
+++ b/packages/auth/src/core/auth/middleware.ts
@@ -30,12 +30,15 @@ export class AuthMiddlewareQueue {
   constructor(private readonly auth: AuthInternal) {}
 
   pushCallback(
-      callback: (user: User | null) => void | Promise<void>,
-      onAbort?: () => void): Unsubscribe {
+    callback: (user: User | null) => void | Promise<void>,
+    onAbort?: () => void
+  ): Unsubscribe {
     // The callback could be sync or async. Wrap it into a
     // function that is always async.
-    const wrappedCallback: MiddlewareEntry =
-      (user: User | null): Promise<void> => new Promise((resolve, reject) => {
+    const wrappedCallback: MiddlewareEntry = (
+      user: User | null
+    ): Promise<void> =>
+      new Promise((resolve, reject) => {
         try {
           const result = callback(user);
           // Either resolve with existing promise or wrap a non-promise
@@ -83,11 +86,14 @@ export class AuthMiddlewareQueue {
       for (const onAbort of onAbortStack) {
         try {
           onAbort();
-        } catch (_) { /* swallow error */}
+        } catch (_) {
+          /* swallow error */
+        }
       }
 
-      throw this.auth._errorFactory.create(
-        AuthErrorCode.LOGIN_BLOCKED, { originalMessage: (e as Error)?.message });
+      throw this.auth._errorFactory.create(AuthErrorCode.LOGIN_BLOCKED, {
+        originalMessage: (e as Error)?.message
+      });
     }
   }
 }

--- a/packages/auth/src/core/auth/register.ts
+++ b/packages/auth/src/core/auth/register.ts
@@ -19,7 +19,7 @@ import { _registerComponent, registerVersion } from '@firebase/app';
 import {
   Component,
   ComponentType,
-  InstantiationMode,
+  InstantiationMode
 } from '@firebase/component';
 
 import { name, version } from '../../../package.json';
@@ -61,7 +61,8 @@ export function registerAuth(clientPlatform: ClientPlatform): void {
       _ComponentName.AUTH,
       (container, { options: deps }: { options?: Dependencies }) => {
         const app = container.getProvider('app').getImmediate()!;
-        const heartbeatServiceProvider = container.getProvider<'heartbeat'>('heartbeat');
+        const heartbeatServiceProvider =
+          container.getProvider<'heartbeat'>('heartbeat');
         const { apiKey, authDomain } = app.options;
         return ((app, heartbeatServiceProvider) => {
           _assert(
@@ -83,7 +84,11 @@ export function registerAuth(clientPlatform: ClientPlatform): void {
             sdkClientVersion: _getClientVersion(clientPlatform)
           };
 
-          const authInstance = new AuthImpl(app, heartbeatServiceProvider, config);
+          const authInstance = new AuthImpl(
+            app,
+            heartbeatServiceProvider,
+            config
+          );
           _initializeAuthInstance(authInstance, deps);
 
           return authInstance;

--- a/packages/auth/src/core/credentials/oauth.test.ts
+++ b/packages/auth/src/core/credentials/oauth.test.ts
@@ -69,7 +69,7 @@ describe('core/credentials/oauth', () => {
         nonce: 'nonce'
       });
 
-      expect((cred.toJSON() as {nonce: string}).nonce).to.eq('nonce');
+      expect((cred.toJSON() as { nonce: string }).nonce).to.eq('nonce');
     });
 
     it('ignores the nonce if pendingToken set', () => {
@@ -81,7 +81,7 @@ describe('core/credentials/oauth', () => {
         pendingToken: 'pending-token'
       });
 
-      expect((cred.toJSON() as {nonce?: string}).nonce).to.be.undefined;
+      expect((cred.toJSON() as { nonce?: string }).nonce).to.be.undefined;
     });
 
     it('handles oauth1 and oauth with token secret', () => {

--- a/packages/auth/src/core/credentials/oauth.ts
+++ b/packages/auth/src/core/credentials/oauth.ts
@@ -75,7 +75,7 @@ export class OAuthCredential extends AuthCredential {
    * @readonly
    */
   secret?: string;
-  
+
   private nonce?: string;
   private pendingToken: string | null = null;
 

--- a/packages/auth/src/core/credentials/saml.ts
+++ b/packages/auth/src/core/credentials/saml.ts
@@ -86,11 +86,8 @@ export class SAMLAuthCredential extends AuthCredential {
    */
   static fromJSON(json: string | object): SAMLAuthCredential | null {
     const obj = typeof json === 'string' ? JSON.parse(json) : json;
-    const {
-      providerId,
-      signInMethod,
-      pendingToken
-    }: Record<string, string> = obj;
+    const { providerId, signInMethod, pendingToken }: Record<string, string> =
+      obj;
     if (
       !providerId ||
       !signInMethod ||

--- a/packages/auth/src/core/errors.ts
+++ b/packages/auth/src/core/errors.ts
@@ -24,7 +24,7 @@ import { AuthCredential } from './credentials';
 
 /**
  * Enumeration of Firebase Auth error codes.
- * 
+ *
  * @internal
  */
 export const enum AuthErrorCode {
@@ -246,7 +246,8 @@ function _debugErrorMap(): ErrorMap<AuthErrorCode> {
       'The verification ID used to create the phone auth credential is invalid.',
     [AuthErrorCode.INVALID_TENANT_ID]:
       "The Auth instance's tenant ID is invalid.",
-    [AuthErrorCode.LOGIN_BLOCKED]: "Login blocked by user-provided method: {$originalMessage}",
+    [AuthErrorCode.LOGIN_BLOCKED]:
+      'Login blocked by user-provided method: {$originalMessage}',
     [AuthErrorCode.MISSING_ANDROID_PACKAGE_NAME]:
       'An Android Package Name must be provided if the Android App is required to be installed.',
     [AuthErrorCode.MISSING_AUTH_DOMAIN]:
@@ -430,7 +431,10 @@ export interface AuthErrorParams extends GenericAuthErrorParams {
   [AuthErrorCode.ARGUMENT_ERROR]: { appName?: AppName };
   [AuthErrorCode.DEPENDENT_SDK_INIT_BEFORE_AUTH]: { appName?: AppName };
   [AuthErrorCode.INTERNAL_ERROR]: { appName?: AppName };
-  [AuthErrorCode.LOGIN_BLOCKED]: { appName?: AppName, originalMessage?: string };
+  [AuthErrorCode.LOGIN_BLOCKED]: {
+    appName?: AppName;
+    originalMessage?: string;
+  };
   [AuthErrorCode.OPERATION_NOT_SUPPORTED]: { appName?: AppName };
   [AuthErrorCode.NO_AUTH_EVENT]: { appName?: AppName };
   [AuthErrorCode.MFA_REQUIRED]: {

--- a/packages/auth/src/core/index.ts
+++ b/packages/auth/src/core/index.ts
@@ -97,15 +97,12 @@ export function onIdTokenChanged(
  * @param onAbort - callback triggered if a later `beforeAuthStateChanged()`
  *   callback throws, allowing you to undo any side effects.
  */
- export function beforeAuthStateChanged(
+export function beforeAuthStateChanged(
   auth: Auth,
-  callback: (user: User|null) => void | Promise<void>,
-  onAbort?: () => void,
+  callback: (user: User | null) => void | Promise<void>,
+  onAbort?: () => void
 ): Unsubscribe {
-  return getModularInstance(auth).beforeAuthStateChanged(
-    callback,
-    onAbort
-  );
+  return getModularInstance(auth).beforeAuthStateChanged(callback, onAbort);
 }
 /**
  * Adds an observer for changes to the user's sign-in state.

--- a/packages/auth/src/core/providers/facebook.test.ts
+++ b/packages/auth/src/core/providers/facebook.test.ts
@@ -17,11 +17,7 @@
 
 import { expect } from 'chai';
 
-import {
-  OperationType,
-  ProviderId,
-  SignInMethod
-} from '../../model/enums';
+import { OperationType, ProviderId, SignInMethod } from '../../model/enums';
 
 import { TEST_ID_TOKEN_RESPONSE } from '../../../test/helpers/id_token_response';
 import { testUser, testAuth } from '../../../test/helpers/mock_auth';

--- a/packages/auth/src/core/providers/github.test.ts
+++ b/packages/auth/src/core/providers/github.test.ts
@@ -17,11 +17,7 @@
 
 import { expect } from 'chai';
 
-import {
-  OperationType,
-  ProviderId,
-  SignInMethod
-} from '../../model/enums';
+import { OperationType, ProviderId, SignInMethod } from '../../model/enums';
 
 import { TEST_ID_TOKEN_RESPONSE } from '../../../test/helpers/id_token_response';
 import { testUser, testAuth } from '../../../test/helpers/mock_auth';

--- a/packages/auth/src/core/providers/google.test.ts
+++ b/packages/auth/src/core/providers/google.test.ts
@@ -17,11 +17,7 @@
 
 import { expect } from 'chai';
 
-import {
-  OperationType,
-  ProviderId,
-  SignInMethod
-} from '../../model/enums';
+import { OperationType, ProviderId, SignInMethod } from '../../model/enums';
 
 import { TEST_ID_TOKEN_RESPONSE } from '../../../test/helpers/id_token_response';
 import { testUser, testAuth } from '../../../test/helpers/mock_auth';

--- a/packages/auth/src/core/providers/oauth.test.ts
+++ b/packages/auth/src/core/providers/oauth.test.ts
@@ -17,11 +17,7 @@
 
 import { expect } from 'chai';
 
-import {
-  OperationType,
-  ProviderId,
-  SignInMethod
-} from '../../model/enums';
+import { OperationType, ProviderId, SignInMethod } from '../../model/enums';
 
 import { TEST_ID_TOKEN_RESPONSE } from '../../../test/helpers/id_token_response';
 import { testUser, testAuth } from '../../../test/helpers/mock_auth';
@@ -122,11 +118,11 @@ describe('core/providers/oauth', () => {
     const provider = new OAuthProvider('foo.test');
     const cred = provider.credential({
       idToken: 'foo',
-      rawNonce: 'i-am-a-nonce',
+      rawNonce: 'i-am-a-nonce'
     });
     expect(cred.idToken).to.eq('foo');
     expect(cred.providerId).to.eq('foo.test');
     expect(cred.signInMethod).to.eq('foo.test');
-    expect((cred.toJSON() as {nonce: string}).nonce).to.eq('i-am-a-nonce');
+    expect((cred.toJSON() as { nonce: string }).nonce).to.eq('i-am-a-nonce');
   });
 });

--- a/packages/auth/src/core/providers/oauth.ts
+++ b/packages/auth/src/core/providers/oauth.ts
@@ -164,7 +164,7 @@ export class OAuthProvider extends BaseOAuthProvider {
    * or the ID token string.
    */
   credential(params: OAuthCredentialOptions): OAuthCredential {
-    return this._credential({...params, nonce: params.rawNonce});
+    return this._credential({ ...params, nonce: params.rawNonce });
   }
 
   /** An internal credential method that accepts more permissive options */

--- a/packages/auth/src/core/providers/twitter.test.ts
+++ b/packages/auth/src/core/providers/twitter.test.ts
@@ -34,11 +34,7 @@
 
 import { expect } from 'chai';
 
-import {
-  OperationType,
-  ProviderId,
-  SignInMethod
-} from '../../model/enums';
+import { OperationType, ProviderId, SignInMethod } from '../../model/enums';
 
 import { TEST_ID_TOKEN_RESPONSE } from '../../../test/helpers/id_token_response';
 import { testUser, testAuth } from '../../../test/helpers/mock_auth';

--- a/packages/auth/src/core/strategies/abstract_popup_redirect_operation.test.ts
+++ b/packages/auth/src/core/strategies/abstract_popup_redirect_operation.test.ts
@@ -175,7 +175,7 @@ describe('core/strategies/abstract_popup_redirect_operation', () => {
 
     context('idp tasks', () => {
       function updateFilter(type: AuthEventType): void {
-        ((operation as unknown) as Record<string, unknown>).filter = type;
+        (operation as unknown as Record<string, unknown>).filter = type;
       }
 
       function expectedIdpTaskParams(): idp.IdpTaskParams {

--- a/packages/auth/src/core/strategies/abstract_popup_redirect_operation.ts
+++ b/packages/auth/src/core/strategies/abstract_popup_redirect_operation.ts
@@ -46,7 +46,8 @@ interface PendingPromise {
  * events
  */
 export abstract class AbstractPopupRedirectOperation
-  implements AuthEventConsumer {
+  implements AuthEventConsumer
+{
   private pendingPromise: PendingPromise | null = null;
   private eventManager: EventManager | null = null;
   readonly filter: AuthEventType[];

--- a/packages/auth/src/core/strategies/credential.test.ts
+++ b/packages/auth/src/core/strategies/credential.test.ts
@@ -19,11 +19,7 @@ import { expect, use } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import { stub } from 'sinon';
 
-import {
-  OperationType,
-  ProviderId,
-  SignInMethod
-} from '../../model/enums';
+import { OperationType, ProviderId, SignInMethod } from '../../model/enums';
 import { FirebaseError } from '@firebase/util';
 
 import { mockEndpoint } from '../../../test/helpers/api/helper';

--- a/packages/auth/src/core/strategies/custom_token.test.ts
+++ b/packages/auth/src/core/strategies/custom_token.test.ts
@@ -68,14 +68,11 @@ describe('core/strategies/signInWithCustomToken', () => {
   afterEach(mockFetch.tearDown);
 
   it('should return a valid user credential', async () => {
-    const {
-      user,
-      operationType,
-      _tokenResponse
-    } = (await signInWithCustomToken(
-      auth,
-      'look-at-me-im-a-jwt'
-    )) as UserCredentialInternal;
+    const { user, operationType, _tokenResponse } =
+      (await signInWithCustomToken(
+        auth,
+        'look-at-me-im-a-jwt'
+      )) as UserCredentialInternal;
     expect(_tokenResponse).to.eql(idTokenResponse);
     expect(user.uid).to.eq('local-id');
     expect(user.displayName).to.eq('display-name');

--- a/packages/auth/src/core/strategies/email_and_password.test.ts
+++ b/packages/auth/src/core/strategies/email_and_password.test.ts
@@ -384,15 +384,12 @@ describe('core/strategies/email_and_password/createUserWithEmailAndPassword', ()
   afterEach(mockFetch.tearDown);
 
   it('should sign in the user', async () => {
-    const {
-      _tokenResponse,
-      user,
-      operationType
-    } = (await createUserWithEmailAndPassword(
-      auth,
-      'some-email',
-      'some-password'
-    )) as UserCredentialInternal;
+    const { _tokenResponse, user, operationType } =
+      (await createUserWithEmailAndPassword(
+        auth,
+        'some-email',
+        'some-password'
+      )) as UserCredentialInternal;
     expect(_tokenResponse).to.eql({
       idToken: 'id-token',
       refreshToken: 'refresh-token',
@@ -427,15 +424,12 @@ describe('core/strategies/email_and_password/signInWithEmailAndPassword', () => 
   afterEach(mockFetch.tearDown);
 
   it('should sign in the user', async () => {
-    const {
-      _tokenResponse,
-      user,
-      operationType
-    } = (await signInWithEmailAndPassword(
-      auth,
-      'some-email',
-      'some-password'
-    )) as UserCredentialInternal;
+    const { _tokenResponse, user, operationType } =
+      (await signInWithEmailAndPassword(
+        auth,
+        'some-email',
+        'some-password'
+      )) as UserCredentialInternal;
     expect(_tokenResponse).to.eql({
       idToken: 'id-token',
       refreshToken: 'refresh-token',

--- a/packages/auth/src/core/strategies/idp.test.ts
+++ b/packages/auth/src/core/strategies/idp.test.ts
@@ -104,7 +104,7 @@ describe('core/strategies/idb', () => {
     it('passes through the bypassAuthState flag', async () => {
       const stub = sinon
         .stub(credential, '_signInWithCredential')
-        .returns(Promise.resolve(({} as unknown) as UserCredentialImpl));
+        .returns(Promise.resolve({} as unknown as UserCredentialImpl));
       await idpTasks._signIn({
         auth,
         user,
@@ -160,7 +160,7 @@ describe('core/strategies/idb', () => {
     it('passes through the bypassAuthState flag', async () => {
       const stub = sinon
         .stub(reauthenticate, '_reauthenticate')
-        .returns(Promise.resolve(({} as unknown) as UserCredentialImpl));
+        .returns(Promise.resolve({} as unknown as UserCredentialImpl));
       await idpTasks._reauth({
         auth,
         user,
@@ -218,7 +218,7 @@ describe('core/strategies/idb', () => {
     it('passes through the bypassAuthState flag', async () => {
       const stub = sinon
         .stub(linkUnlink, '_link')
-        .returns(Promise.resolve(({} as unknown) as UserCredentialImpl));
+        .returns(Promise.resolve({} as unknown as UserCredentialImpl));
       await idpTasks._link({
         auth,
         user,

--- a/packages/auth/src/core/strategies/redirect.test.ts
+++ b/packages/auth/src/core/strategies/redirect.test.ts
@@ -33,7 +33,11 @@ import {
 import { makeMockPopupRedirectResolver } from '../../../test/helpers/mock_popup_redirect_resolver';
 import { AuthInternal } from '../../model/auth';
 import { AuthEventManager } from '../auth/auth_event_manager';
-import { RedirectAction, _clearRedirectOutcomes, _getAndClearPendingRedirectStatus } from './redirect';
+import {
+  RedirectAction,
+  _clearRedirectOutcomes,
+  _getAndClearPendingRedirectStatus
+} from './redirect';
 import {
   AuthEvent,
   AuthEventType,
@@ -61,12 +65,11 @@ describe('core/strategies/redirect', () => {
   let redirectPersistence: RedirectPersistence;
 
   beforeEach(async () => {
-    eventManager = new AuthEventManager(({} as unknown) as TestAuth);
+    eventManager = new AuthEventManager({} as unknown as TestAuth);
     idpStubs = sinon.stub(idpTasks);
     resolver = makeMockPopupRedirectResolver(eventManager);
-    _getInstance<PopupRedirectResolverInternal>(
-      resolver
-    )._redirectPersistence = RedirectPersistence;
+    _getInstance<PopupRedirectResolverInternal>(resolver)._redirectPersistence =
+      RedirectPersistence;
     auth = await testAuth();
     redirectAction = new RedirectAction(auth, _getInstance(resolver), false);
     redirectPersistence = _getInstance(RedirectPersistence);
@@ -201,9 +204,8 @@ describe('core/strategies/redirect', () => {
 
   it('bypasses initialization if no key set', async () => {
     await reInitAuthWithRedirectUser(MATCHING_EVENT_ID);
-    const resolverInstance = _getInstance<PopupRedirectResolverInternal>(
-      resolver
-    );
+    const resolverInstance =
+      _getInstance<PopupRedirectResolverInternal>(resolver);
 
     sinon.spy(resolverInstance, '_initialize');
     redirectPersistence.hasPendingRedirect = false;
@@ -221,17 +223,25 @@ describe('core/strategies/redirect', () => {
 
     it('returns false if the key is not set', async () => {
       redirectPersistence.hasPendingRedirect = false;
-      expect(await _getAndClearPendingRedirectStatus(_getInstance(resolver), auth)).to.be.false;
+      expect(
+        await _getAndClearPendingRedirectStatus(_getInstance(resolver), auth)
+      ).to.be.false;
     });
 
     it('returns true if the key is found', async () => {
       redirectPersistence.hasPendingRedirect = true;
-      expect(await _getAndClearPendingRedirectStatus(_getInstance(resolver), auth)).to.be.true;
+      expect(
+        await _getAndClearPendingRedirectStatus(_getInstance(resolver), auth)
+      ).to.be.true;
     });
 
     it('returns false if sessionStorage is permission denied', async () => {
-      _getInstance<PopupRedirectResolverInternal>(resolver)._redirectPersistence = ErroringUnavailablePersistence as unknown as Persistence;
-      expect(await _getAndClearPendingRedirectStatus(_getInstance(resolver), auth)).to.be.false;
+      _getInstance<PopupRedirectResolverInternal>(
+        resolver
+      )._redirectPersistence = ErroringUnavailablePersistence as unknown as Persistence;
+      expect(
+        await _getAndClearPendingRedirectStatus(_getInstance(resolver), auth)
+      ).to.be.false;
     });
   });
 });

--- a/packages/auth/src/core/strategies/redirect.ts
+++ b/packages/auth/src/core/strategies/redirect.ts
@@ -122,8 +122,7 @@ export async function _getAndClearPendingRedirectStatus(
   if (!(await persistence._isAvailable())) {
     return false;
   }
-  const hasPendingRedirect =
-    (await persistence._get(key)) === 'true';
+  const hasPendingRedirect = (await persistence._get(key)) === 'true';
   await persistence._remove(key);
   return hasPendingRedirect;
 }
@@ -139,7 +138,10 @@ export function _clearRedirectOutcomes(): void {
   redirectOutcomeMap.clear();
 }
 
-export function _overrideRedirectResult(auth: AuthInternal, result: () => Promise<UserCredentialInternal | null>): void {
+export function _overrideRedirectResult(
+  auth: AuthInternal,
+  result: () => Promise<UserCredentialInternal | null>
+): void {
   redirectOutcomeMap.set(auth._key(), result);
 }
 

--- a/packages/auth/src/core/user/additional_user_info.test.ts
+++ b/packages/auth/src/core/user/additional_user_info.test.ts
@@ -47,12 +47,8 @@ describe('core/user/additional_user_info', () => {
           providerId: ProviderId.FACEBOOK,
           rawUserInfo: rawUserInfoWithLogin
         });
-        const {
-          isNewUser,
-          providerId,
-          username,
-          profile
-        } = _fromIdTokenResponse(idResponse)!;
+        const { isNewUser, providerId, username, profile } =
+          _fromIdTokenResponse(idResponse)!;
         expect(isNewUser).to.be.false;
         expect(providerId).to.eq(ProviderId.FACEBOOK);
         expect(username).to.be.undefined;
@@ -64,12 +60,8 @@ describe('core/user/additional_user_info', () => {
           providerId: ProviderId.GITHUB,
           rawUserInfo: rawUserInfoWithLogin
         });
-        const {
-          isNewUser,
-          providerId,
-          username,
-          profile
-        } = _fromIdTokenResponse(idResponse)!;
+        const { isNewUser, providerId, username, profile } =
+          _fromIdTokenResponse(idResponse)!;
         expect(isNewUser).to.be.false;
         expect(providerId).to.eq(ProviderId.GITHUB);
         expect(username).to.eq('scott');
@@ -81,12 +73,8 @@ describe('core/user/additional_user_info', () => {
           providerId: ProviderId.GOOGLE,
           rawUserInfo: rawUserInfoWithLogin
         });
-        const {
-          isNewUser,
-          providerId,
-          username,
-          profile
-        } = _fromIdTokenResponse(idResponse)!;
+        const { isNewUser, providerId, username, profile } =
+          _fromIdTokenResponse(idResponse)!;
         expect(isNewUser).to.be.false;
         expect(providerId).to.eq(ProviderId.GOOGLE);
         expect(username).to.be.undefined;
@@ -99,12 +87,8 @@ describe('core/user/additional_user_info', () => {
           rawUserInfo: rawUserInfoNoLogin,
           screenName: 'scott'
         });
-        const {
-          isNewUser,
-          providerId,
-          username,
-          profile
-        } = _fromIdTokenResponse(idResponse)!;
+        const { isNewUser, providerId, username, profile } =
+          _fromIdTokenResponse(idResponse)!;
         expect(isNewUser).to.be.false;
         expect(providerId).to.eq(ProviderId.TWITTER);
         expect(username).to.eq('scott');
@@ -162,12 +146,8 @@ describe('core/user/additional_user_info', () => {
             }
           })
         });
-        const {
-          isNewUser,
-          providerId,
-          username,
-          profile
-        } = _fromIdTokenResponse(idResponse)!;
+        const { isNewUser, providerId, username, profile } =
+          _fromIdTokenResponse(idResponse)!;
         expect(isNewUser).to.be.false;
         expect(providerId).to.be.null;
         expect(username).to.be.undefined;
@@ -183,12 +163,8 @@ describe('core/user/additional_user_info', () => {
             }
           })
         });
-        const {
-          isNewUser,
-          providerId,
-          username,
-          profile
-        } = _fromIdTokenResponse(idResponse)!;
+        const { isNewUser, providerId, username, profile } =
+          _fromIdTokenResponse(idResponse)!;
         expect(isNewUser).to.be.false;
         expect(providerId).to.be.null;
         expect(username).to.be.undefined;
@@ -204,14 +180,10 @@ describe('core/user/additional_user_info', () => {
             })
           ) +
           '.signature';
-        const {
-          isNewUser,
-          providerId,
-          username,
-          profile
-        } = _fromIdTokenResponse(
-          idTokenResponse({ rawUserInfo: rawUserInfoWithLogin, idToken })
-        )!;
+        const { isNewUser, providerId, username, profile } =
+          _fromIdTokenResponse(
+            idTokenResponse({ rawUserInfo: rawUserInfoWithLogin, idToken })
+          )!;
         expect(isNewUser).to.be.false;
         expect(providerId).to.eq(ProviderId.FACEBOOK);
         expect(username).to.be.undefined;
@@ -246,12 +218,8 @@ describe('core/user/additional_user_info', () => {
         providerId: ProviderId.ANONYMOUS,
         rawUserInfo: rawUserInfoWithLogin
       });
-      const {
-        isNewUser,
-        providerId,
-        username,
-        profile
-      } = getAdditionalUserInfo(cred)!;
+      const { isNewUser, providerId, username, profile } =
+        getAdditionalUserInfo(cred)!;
       expect(isNewUser).to.be.false;
       expect(providerId).to.be.null;
       expect(username).to.be.undefined;
@@ -264,12 +232,8 @@ describe('core/user/additional_user_info', () => {
         rawUserInfo: rawUserInfoWithLogin,
         isNewUser: true
       });
-      const {
-        isNewUser,
-        providerId,
-        username,
-        profile
-      } = getAdditionalUserInfo(cred)!;
+      const { isNewUser, providerId, username, profile } =
+        getAdditionalUserInfo(cred)!;
       expect(isNewUser).to.be.true;
       expect(providerId).to.be.null;
       expect(username).to.be.undefined;
@@ -278,7 +242,7 @@ describe('core/user/additional_user_info', () => {
 
     it('returns bespoke info if existing anonymous user', () => {
       // Note that _tokenResponse is not set on cred
-      ((user as unknown) as Record<string, unknown>).isAnonymous = true;
+      (user as unknown as Record<string, unknown>).isAnonymous = true;
       const { isNewUser, providerId, profile } = getAdditionalUserInfo(cred)!;
       expect(isNewUser).to.be.false;
       expect(providerId).to.be.null;

--- a/packages/auth/src/core/user/id_token_result.ts
+++ b/packages/auth/src/core/user/id_token_result.ts
@@ -110,7 +110,10 @@ export function _parseToken(token: string): ParsedToken | null {
     }
     return JSON.parse(decoded);
   } catch (e) {
-    _logError('Caught error parsing JWT payload as JSON', (e as Error)?.toString());
+    _logError(
+      'Caught error parsing JWT payload as JSON',
+      (e as Error)?.toString()
+    );
     return null;
   }
 }

--- a/packages/auth/src/core/user/proactive_refresh.ts
+++ b/packages/auth/src/core/user/proactive_refresh.ts
@@ -93,7 +93,10 @@ export class ProactiveRefresh {
       await this.user.getIdToken(true);
     } catch (e) {
       // Only retry on network errors
-      if ((e as FirebaseError)?.code === `auth/${AuthErrorCode.NETWORK_REQUEST_FAILED}`) {
+      if (
+        (e as FirebaseError)?.code ===
+        `auth/${AuthErrorCode.NETWORK_REQUEST_FAILED}`
+      ) {
         this.schedule(/* wasError */ true);
       }
 

--- a/packages/auth/src/core/user/reauthenticate.test.ts
+++ b/packages/auth/src/core/user/reauthenticate.test.ts
@@ -19,11 +19,7 @@ import { expect, use } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import { stub } from 'sinon';
 
-import {
-  OperationType,
-  ProviderId,
-  SignInMethod
-} from '../../model/enums';
+import { OperationType, ProviderId, SignInMethod } from '../../model/enums';
 import { FirebaseError } from '@firebase/util';
 
 import { mockEndpoint } from '../../../test/helpers/api/helper';
@@ -63,10 +59,10 @@ describe('core/user/reauthenticate', () => {
 
   it('should error if the idToken is missing', async () => {
     stub(credential, '_getReauthenticationResolver').returns(
-      Promise.resolve(({
+      Promise.resolve({
         ...TEST_ID_TOKEN_RESPONSE,
         idToken: undefined
-      } as unknown) as IdTokenResponse)
+      } as unknown as IdTokenResponse)
     );
 
     await expect(_reauthenticate(user, credential)).to.be.rejectedWith(

--- a/packages/auth/src/core/user/reload.test.ts
+++ b/packages/auth/src/core/user/reload.test.ts
@@ -23,7 +23,6 @@ import sinonChai from 'sinon-chai';
 import { UserInfo } from '../../model/public_types';
 import { ProviderId } from '../../model/enums';
 
-
 import { mockEndpoint } from '../../../test/helpers/api/helper';
 import { testAuth, TestAuth, testUser } from '../../../test/helpers/mock_auth';
 import * as fetch from '../../../test/helpers/mock_fetch';
@@ -182,7 +181,7 @@ describe('core/user/reload', () => {
       providerData: Array<{ providerId: string }>
     ): void {
       // Get around readonly property
-      const mutUser = (user as unknown) as Record<string, unknown>;
+      const mutUser = user as unknown as Record<string, unknown>;
       mutUser.isAnonymous = isAnonStart;
       mutUser.email = emailStart;
 

--- a/packages/auth/src/core/user/user_impl.test.ts
+++ b/packages/auth/src/core/user/user_impl.test.ts
@@ -264,14 +264,16 @@ describe('core/user/user_impl', () => {
         photoURL: 'photo',
         emailVerified: false,
         isAnonymous: true,
-        providerData: [{
-          providerId: 'password',
-          displayName: null,
-          photoURL: null,
-          email: 'test@foo.test',
-          phoneNumber: null,
-          uid: 'i-am-uid'
-        }],
+        providerData: [
+          {
+            providerId: 'password',
+            displayName: null,
+            photoURL: null,
+            email: 'test@foo.test',
+            phoneNumber: null,
+            uid: 'i-am-uid'
+          }
+        ],
         tenantId: 'tenant-id'
       });
 
@@ -282,14 +284,16 @@ describe('core/user/user_impl', () => {
       expect(copy.toJSON()).to.eql(user.toJSON());
       expect(copy.auth).to.eq(newAuth);
       expect(copy.tenantId).to.eq('tenant-id');
-      expect(copy.providerData).to.eql([{
-        providerId: 'password',
-        displayName: null,
-        photoURL: null,
-        email: 'test@foo.test',
-        phoneNumber: null,
-        uid: 'i-am-uid'
-      }]);
+      expect(copy.providerData).to.eql([
+        {
+          providerId: 'password',
+          displayName: null,
+          photoURL: null,
+          email: 'test@foo.test',
+          phoneNumber: null,
+          uid: 'i-am-uid'
+        }
+      ]);
     });
   });
 });

--- a/packages/auth/src/core/util/assert.test.ts
+++ b/packages/auth/src/core/util/assert.test.ts
@@ -161,9 +161,9 @@ describe('_assertInstanceOf', () => {
   });
 
   function makeClass(): Constructable {
-    class Test {};
+    class Test {}
     return Test;
-  };
+  }
 
   class WrongClass {}
 

--- a/packages/auth/src/core/util/assert.ts
+++ b/packages/auth/src/core/util/assert.ts
@@ -83,28 +83,42 @@ export function _createError<K extends AuthErrorCode>(
   return createErrorInternal(authOrCode, ...rest);
 }
 
-export function _errorWithCustomMessage(auth: Auth, code: AuthErrorCode, message: string): FirebaseError {
-  const errorMap = {...(prodErrorMap as ErrorMapRetriever)(), [code]: message};
+export function _errorWithCustomMessage(
+  auth: Auth,
+  code: AuthErrorCode,
+  message: string
+): FirebaseError {
+  const errorMap = {
+    ...(prodErrorMap as ErrorMapRetriever)(),
+    [code]: message
+  };
   const factory = new ErrorFactory<AuthErrorCode, AuthErrorParams>(
     'auth',
     'Firebase',
     errorMap
   );
   return factory.create(code, {
-    appName: auth.name,
+    appName: auth.name
   });
 }
 
-export function _assertInstanceOf(auth: Auth, object: object, instance: unknown): void {
-  const constructorInstance =  (instance as { new (...args: unknown[]): unknown });
+export function _assertInstanceOf(
+  auth: Auth,
+  object: object,
+  instance: unknown
+): void {
+  const constructorInstance = instance as { new (...args: unknown[]): unknown };
   if (!(object instanceof constructorInstance)) {
     if (constructorInstance.name !== object.constructor.name) {
       _fail(auth, AuthErrorCode.ARGUMENT_ERROR);
     }
 
-    throw _errorWithCustomMessage(auth, AuthErrorCode.ARGUMENT_ERROR,
+    throw _errorWithCustomMessage(
+      auth,
+      AuthErrorCode.ARGUMENT_ERROR,
       `Type of ${object.constructor.name} does not match expected instance.` +
-      `Did you pass a reference from a different Auth SDK?`);
+        `Did you pass a reference from a different Auth SDK?`
+    );
   }
 }
 
@@ -271,4 +285,3 @@ export function debugAssert(
     debugFail(message);
   }
 }
-

--- a/packages/auth/src/core/util/browser.test.ts
+++ b/packages/auth/src/core/util/browser.test.ts
@@ -115,7 +115,7 @@ describe('core/util/browser', () => {
     it('should respond false for other mobile', () => {
       const userAgent =
         'Mozilla/5.0 (Linux; U; Android 4.0.3; ko-kr; LG-L160L Build/IML74K) AppleWebkit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Chrome/534.30';
-        expect(_isIOS(userAgent)).to.be.false;
+      expect(_isIOS(userAgent)).to.be.false;
     });
   });
 });

--- a/packages/auth/src/core/util/browser.ts
+++ b/packages/auth/src/core/util/browser.ts
@@ -123,8 +123,10 @@ export function _isWebOS(ua = getUA()): boolean {
 }
 
 export function _isIOS(ua = getUA()): boolean {
-  return /iphone|ipad|ipod/i.test(ua) ||
-      (/macintosh/i.test(ua) && /mobile/i.test(ua));
+  return (
+    /iphone|ipad|ipod/i.test(ua) ||
+    (/macintosh/i.test(ua) && /mobile/i.test(ua))
+  );
 }
 
 export function _isIOS7Or8(ua = getUA()): boolean {

--- a/packages/auth/src/mfa/mfa_error.ts
+++ b/packages/auth/src/mfa/mfa_error.ts
@@ -48,7 +48,7 @@ export class MultiFactorError
       appName: auth.name,
       tenantId: auth.tenantId ?? undefined,
       _serverResponse: error.customData!._serverResponse as IdTokenMfaResponse,
-      operationType,
+      operationType
     };
   }
 

--- a/packages/auth/src/mfa/mfa_info.ts
+++ b/packages/auth/src/mfa/mfa_info.ts
@@ -15,7 +15,11 @@
  * limitations under the License.
  */
 
-import { FactorId, MultiFactorInfo, PhoneMultiFactorInfo } from '../model/public_types';
+import {
+  FactorId,
+  MultiFactorInfo,
+  PhoneMultiFactorInfo
+} from '../model/public_types';
 import {
   PhoneMfaEnrollment,
   MfaEnrollment
@@ -46,7 +50,10 @@ export abstract class MultiFactorInfoImpl implements MultiFactorInfo {
   }
 }
 
-export class PhoneMultiFactorInfoImpl extends MultiFactorInfoImpl implements PhoneMultiFactorInfo {
+export class PhoneMultiFactorInfoImpl
+  extends MultiFactorInfoImpl
+  implements PhoneMultiFactorInfo
+{
   readonly phoneNumber: string;
 
   private constructor(response: PhoneMfaEnrollment) {

--- a/packages/auth/src/mfa/mfa_resolver.ts
+++ b/packages/auth/src/mfa/mfa_resolver.ts
@@ -130,7 +130,11 @@ export function getMultiFactorResolver(
 ): MultiFactorResolver {
   const authModular = getModularInstance(auth);
   const errorInternal = error as MultiFactorErrorInternal;
-  _assert(error.customData.operationType, authModular, AuthErrorCode.ARGUMENT_ERROR);
+  _assert(
+    error.customData.operationType,
+    authModular,
+    AuthErrorCode.ARGUMENT_ERROR
+  );
   _assert(
     errorInternal.customData._serverResponse?.mfaPendingCredential,
     authModular,

--- a/packages/auth/src/mfa/mfa_user.test.ts
+++ b/packages/auth/src/mfa/mfa_user.test.ts
@@ -188,7 +188,7 @@ describe('core/mfa/mfa_user/MultiFactorUser', () => {
 
       expect(withdrawMfaEnrollmentMock.calls[0].request).to.eql({
         idToken: 'access-token',
-        mfaEnrollmentId: mfaInfo.uid,
+        mfaEnrollmentId: mfaInfo.uid
       });
     });
 
@@ -203,7 +203,7 @@ describe('core/mfa/mfa_user/MultiFactorUser', () => {
 
       expect(withdrawMfaEnrollmentMock.calls[0].request).to.eql({
         idToken: 'access-token',
-        mfaEnrollmentId: mfaInfo.uid,
+        mfaEnrollmentId: mfaInfo.uid
       });
     });
 

--- a/packages/auth/src/mfa/mfa_user.ts
+++ b/packages/auth/src/mfa/mfa_user.ts
@@ -94,7 +94,9 @@ export class MultiFactorUserImpl implements MultiFactorUser {
     try {
       await this.user.reload();
     } catch (e) {
-      if ((e as FirebaseError)?.code !== `auth/${AuthErrorCode.TOKEN_EXPIRED}`) {
+      if (
+        (e as FirebaseError)?.code !== `auth/${AuthErrorCode.TOKEN_EXPIRED}`
+      ) {
         throw e;
       }
     }

--- a/packages/auth/src/model/popup_redirect.ts
+++ b/packages/auth/src/model/popup_redirect.ts
@@ -128,5 +128,8 @@ export interface PopupRedirectResolverInternal extends PopupRedirectResolver {
     resolver: PopupRedirectResolver,
     bypassAuthState: boolean
   ) => Promise<UserCredential | null>;
-  _overrideRedirectResult: (auth: AuthInternal, resultGetter: () => Promise<UserCredentialInternal|null>) => void;
+  _overrideRedirectResult: (
+    auth: AuthInternal,
+    resultGetter: () => Promise<UserCredentialInternal | null>
+  ) => void;
 }

--- a/packages/auth/src/model/public_types.ts
+++ b/packages/auth/src/model/public_types.ts
@@ -268,7 +268,7 @@ export interface Auth {
    */
   beforeAuthStateChanged(
     callback: (user: User | null) => void | Promise<void>,
-    onAbort?: () => void,
+    onAbort?: () => void
   ): Unsubscribe;
   /**
    * Adds an observer for changes to the signed-in user's ID token.
@@ -620,14 +620,14 @@ export interface MultiFactorAssertion {
  *
  * @public
  */
- export interface MultiFactorError extends AuthError {
-   /** Details about the MultiFactorError. */
+export interface MultiFactorError extends AuthError {
+  /** Details about the MultiFactorError. */
   readonly customData: AuthError['customData'] & {
     /**
      * The type of operation (sign-in, linking, or re-authentication) that raised the error.
      */
     readonly operationType: typeof OperationTypeMap[keyof typeof OperationTypeMap];
-  }
+  };
 }
 
 /**

--- a/packages/auth/src/platform_browser/auth.test.ts
+++ b/packages/auth/src/platform_browser/auth.test.ts
@@ -28,7 +28,11 @@ import {
 } from '../model/public_types';
 import { OperationType } from '../model/enums';
 
-import { FAKE_HEARTBEAT_CONTROLLER_PROVIDER, testAuth, testUser } from '../../test/helpers/mock_auth';
+import {
+  FAKE_HEARTBEAT_CONTROLLER_PROVIDER,
+  testAuth,
+  testUser
+} from '../../test/helpers/mock_auth';
 import { AuthImpl, DefaultConfig } from '../core/auth/auth_impl';
 import { _initializeAuthInstance } from '../core/auth/initialize';
 import { AuthErrorCode } from '../core/errors';
@@ -66,14 +70,18 @@ describe('core/auth/auth_impl', () => {
 
   beforeEach(async () => {
     persistenceStub = sinon.stub(_getInstance(inMemoryPersistence));
-    const authImpl = new AuthImpl(FAKE_APP, FAKE_HEARTBEAT_CONTROLLER_PROVIDER, {
-      apiKey: FAKE_APP.options.apiKey!,
-      apiHost: DefaultConfig.API_HOST,
-      apiScheme: DefaultConfig.API_SCHEME,
-      tokenApiHost: DefaultConfig.TOKEN_API_HOST,
-      clientPlatform: ClientPlatform.BROWSER,
-      sdkClientVersion: 'v'
-    });
+    const authImpl = new AuthImpl(
+      FAKE_APP,
+      FAKE_HEARTBEAT_CONTROLLER_PROVIDER,
+      {
+        apiKey: FAKE_APP.options.apiKey!,
+        apiHost: DefaultConfig.API_HOST,
+        apiScheme: DefaultConfig.API_SCHEME,
+        tokenApiHost: DefaultConfig.TOKEN_API_HOST,
+        clientPlatform: ClientPlatform.BROWSER,
+        sdkClientVersion: 'v'
+      }
+    );
 
     _initializeAuthInstance(authImpl, { persistence: inMemoryPersistence });
     auth = authImpl;
@@ -131,7 +139,7 @@ describe('core/auth/initializeAuth', () => {
       persistence: Persistence | Persistence[],
       popupRedirectResolver?: PopupRedirectResolver,
       authDomain = FAKE_APP.options.authDomain,
-      blockMiddleware = false,
+      blockMiddleware = false
     ): Promise<Auth> {
       const auth = new AuthImpl(FAKE_APP, FAKE_HEARTBEAT_CONTROLLER_PROVIDER, {
         apiKey: FAKE_APP.options.apiKey!,
@@ -230,7 +238,8 @@ describe('core/auth/initializeAuth', () => {
       );
       sinon.stub(resolverInternal, '_shouldInitProactively').value(true);
       sinon.stub(resolverInternal, '_initialize').rejects(new Error());
-      await expect(initAndWait(inMemoryPersistence, popupRedirectResolver)).not.to.be.rejected;
+      await expect(initAndWait(inMemoryPersistence, popupRedirectResolver)).not
+        .to.be.rejected;
     });
 
     it('reloads non-redirect users', async () => {
@@ -343,7 +352,7 @@ describe('core/auth/initializeAuth', () => {
       stub._get.returns(Promise.resolve(testUser(oldAuth, 'uid').toJSON()));
       let authStateChangeCalls = 0;
 
-      const auth = await initAndWait(inMemoryPersistence) as AuthInternal;
+      const auth = (await initAndWait(inMemoryPersistence)) as AuthInternal;
       auth.onAuthStateChanged(() => {
         authStateChangeCalls++;
       });
@@ -366,15 +375,19 @@ describe('core/auth/initializeAuth', () => {
 
         // Manually initialize auth to make sure no error is thrown,
         // since the _initializeAuthInstance function floats
-        const auth = new AuthImpl(FAKE_APP, FAKE_HEARTBEAT_CONTROLLER_PROVIDER, {
-          apiKey: FAKE_APP.options.apiKey!,
-          apiHost: DefaultConfig.API_HOST,
-          apiScheme: DefaultConfig.API_SCHEME,
-          tokenApiHost: DefaultConfig.TOKEN_API_HOST,
-          authDomain: FAKE_APP.options.authDomain,
-          clientPlatform: ClientPlatform.BROWSER,
-          sdkClientVersion: _getClientVersion(ClientPlatform.BROWSER)
-        });
+        const auth = new AuthImpl(
+          FAKE_APP,
+          FAKE_HEARTBEAT_CONTROLLER_PROVIDER,
+          {
+            apiKey: FAKE_APP.options.apiKey!,
+            apiHost: DefaultConfig.API_HOST,
+            apiScheme: DefaultConfig.API_SCHEME,
+            tokenApiHost: DefaultConfig.TOKEN_API_HOST,
+            authDomain: FAKE_APP.options.authDomain,
+            clientPlatform: ClientPlatform.BROWSER,
+            sdkClientVersion: _getClientVersion(ClientPlatform.BROWSER)
+          }
+        );
         await expect(
           auth._initializeWithPersistence(
             [_getInstance(inMemoryPersistence)],
@@ -422,7 +435,12 @@ describe('core/auth/initializeAuth', () => {
         );
         const oldUser = testUser(oldAuth, 'old-uid');
         stub._get.returns(Promise.resolve(oldUser.toJSON()));
-        const overrideSpy = sinon.spy(_getInstance<PopupRedirectResolverInternal>(browserPopupRedirectResolver), '_overrideRedirectResult');
+        const overrideSpy = sinon.spy(
+          _getInstance<PopupRedirectResolverInternal>(
+            browserPopupRedirectResolver
+          ),
+          '_overrideRedirectResult'
+        );
         const auth = await initAndWait(
           [inMemoryPersistence],
           browserPopupRedirectResolver,
@@ -441,7 +459,12 @@ describe('core/auth/initializeAuth', () => {
         );
         const oldUser = testUser(oldAuth, 'old-uid');
         stub._get.returns(Promise.resolve(oldUser.toJSON()));
-        const overrideSpy = sinon.spy(_getInstance<PopupRedirectResolverInternal>(browserPopupRedirectResolver), '_overrideRedirectResult');
+        const overrideSpy = sinon.spy(
+          _getInstance<PopupRedirectResolverInternal>(
+            browserPopupRedirectResolver
+          ),
+          '_overrideRedirectResult'
+        );
 
         let user: UserInternal | null = null;
         completeRedirectFnStub.callsFake((auth: AuthInternal) => {

--- a/packages/auth/src/platform_browser/auth_window.ts
+++ b/packages/auth/src/platform_browser/auth_window.ts
@@ -42,7 +42,7 @@ export type AuthWindow = {
  * we need to make sure not to mess with window unless we have to
  */
 export function _window(): AuthWindow {
-  return (window as unknown) as AuthWindow;
+  return window as unknown as AuthWindow;
 }
 
 export function _setWindowLocation(url: string): void {

--- a/packages/auth/src/platform_browser/iframe/gapi.test.ts
+++ b/packages/auth/src/platform_browser/iframe/gapi.test.ts
@@ -50,7 +50,7 @@ describe('platform_browser/iframe/gapi', () => {
 
   function makeGapi(result: unknown, timesout = false): typeof gapi {
     const callbackFn = timesout === false ? 'callback' : 'ontimeout';
-    return ({
+    return {
       load: sinon
         .stub()
         .callsFake((_name: string, params: Record<string, () => void>) =>
@@ -59,7 +59,7 @@ describe('platform_browser/iframe/gapi', () => {
       iframes: {
         getContext: () => result as gapi.iframes.Context
       }
-    } as unknown) as typeof gapi;
+    } as unknown as typeof gapi;
   }
 
   afterEach(() => {

--- a/packages/auth/src/platform_browser/iframe/gapi.ts
+++ b/packages/auth/src/platform_browser/iframe/gapi.ts
@@ -103,7 +103,9 @@ function loadGapi(auth: AuthInternal): Promise<gapi.iframes.Context> {
         }
       };
       // Load GApi loader.
-      return js._loadJS(`https://apis.google.com/js/api.js?onload=${cbName}`).catch(e => reject(e));
+      return js
+        ._loadJS(`https://apis.google.com/js/api.js?onload=${cbName}`)
+        .catch(e => reject(e));
     }
   }).catch(error => {
     // Reset cached promise to allow for retrial.

--- a/packages/auth/src/platform_browser/iframe/iframe.test.ts
+++ b/packages/auth/src/platform_browser/iframe/iframe.test.ts
@@ -45,15 +45,15 @@ describe('platform_browser/iframe/iframe', () => {
   let libraryLoadedCallback: IframesCallback;
 
   beforeEach(async () => {
-    _window().gapi = ({
+    _window().gapi = {
       iframes: {
         CROSS_ORIGIN_IFRAMES_FILTER: 'cross-origin-filter'
       }
-    } as unknown) as typeof gapi;
+    } as unknown as typeof gapi;
     auth = await testAuth();
 
     sinon.stub(gapiLoader, '_loadGapi').returns(
-      (Promise.resolve({
+      Promise.resolve({
         open: sinon
           .stub()
           .callsFake(
@@ -62,7 +62,7 @@ describe('platform_browser/iframe/iframe', () => {
               libraryLoadedCallback = cb;
             }
           )
-      }) as unknown) as Promise<gapi.iframes.Context>
+      }) as unknown as Promise<gapi.iframes.Context>
     );
   });
 
@@ -115,10 +115,10 @@ describe('platform_browser/iframe/iframe', () => {
     let clearTimeoutStub: sinon.SinonStub;
 
     beforeEach(() => {
-      iframe = sinon.stub(({
+      iframe = sinon.stub({
         restyle: () => {},
         ping: () => {}
-      } as unknown) as gapi.iframes.Iframe);
+      } as unknown as gapi.iframes.Iframe);
       clearTimeoutStub = sinon.stub(_window(), 'clearTimeout');
     });
 

--- a/packages/auth/src/platform_browser/messagechannel/receiver.test.ts
+++ b/packages/auth/src/platform_browser/messagechannel/receiver.test.ts
@@ -37,7 +37,7 @@ describe('platform_browser/messagechannel/receiver', () => {
   let messageChannel: MessageChannel;
 
   beforeEach(() => {
-    serviceWorker = (new FakeServiceWorker() as unknown) as ServiceWorker;
+    serviceWorker = new FakeServiceWorker() as unknown as ServiceWorker;
     receiver = Receiver._getInstance(serviceWorker);
     messageChannel = new MessageChannel();
   });

--- a/packages/auth/src/platform_browser/messagechannel/receiver.ts
+++ b/packages/auth/src/platform_browser/messagechannel/receiver.ts
@@ -85,9 +85,8 @@ export class Receiver {
     const messageEvent = event as MessageEvent<SenderMessageEvent<S>>;
     const { eventId, eventType, data } = messageEvent.data;
 
-    const handlers: Set<ReceiverHandler<T, S>> | undefined = this.handlersMap[
-      eventType
-    ];
+    const handlers: Set<ReceiverHandler<T, S>> | undefined =
+      this.handlersMap[eventType];
     if (!handlers?.size) {
       return;
     }

--- a/packages/auth/src/platform_browser/messagechannel/sender.test.ts
+++ b/packages/auth/src/platform_browser/messagechannel/sender.test.ts
@@ -45,7 +45,7 @@ describe('platform_browser/messagechannel/sender', () => {
     let pendingTimeouts: TimerMap;
 
     beforeEach(() => {
-      serviceWorker = (new FakeServiceWorker() as unknown) as ServiceWorker;
+      serviceWorker = new FakeServiceWorker() as unknown as ServiceWorker;
       sender = new Sender(serviceWorker);
       pendingTimeouts = stubTimeouts();
       sinon.stub(window, 'clearTimeout');

--- a/packages/auth/src/platform_browser/mfa/assertions/phone.ts
+++ b/packages/auth/src/platform_browser/mfa/assertions/phone.ts
@@ -35,7 +35,8 @@ import {
  */
 export class PhoneMultiFactorAssertionImpl
   extends MultiFactorAssertionImpl
-  implements PhoneMultiFactorAssertion {
+  implements PhoneMultiFactorAssertion
+{
   private constructor(private readonly credential: PhoneAuthCredential) {
     super(FactorId.PHONE);
   }

--- a/packages/auth/src/platform_browser/persistence/browser.test.ts
+++ b/packages/auth/src/platform_browser/persistence/browser.test.ts
@@ -15,19 +15,16 @@
  * limitations under the License.
  */
 
-
 import { expect } from 'chai';
-import {
-  PersistenceType
-} from '../../core/persistence';
+import { PersistenceType } from '../../core/persistence';
 import { BrowserPersistenceClass } from './browser';
 
 // Most tests for this class exist in the tests for the subclasses.
 
 class TestPersistence extends BrowserPersistenceClass {
   constructor(storageRetriever: () => Storage) {
-      super(storageRetriever, PersistenceType.NONE);
-    }
+    super(storageRetriever, PersistenceType.NONE);
+  }
 }
 
 describe('platform_browser/persistence/browser', () => {

--- a/packages/auth/src/platform_browser/persistence/indexed_db.test.ts
+++ b/packages/auth/src/platform_browser/persistence/indexed_db.test.ts
@@ -199,7 +199,7 @@ describe('platform_browser/persistence/indexed_db', () => {
     let persistence: TestPersistence;
 
     beforeEach(() => {
-      serviceWorker = (new FakeServiceWorker() as unknown) as ServiceWorker;
+      serviceWorker = new FakeServiceWorker() as unknown as ServiceWorker;
     });
 
     afterEach(() => {
@@ -214,7 +214,8 @@ describe('platform_browser/persistence/indexed_db', () => {
         sender = new Sender(serviceWorker);
         sinon.stub(workerUtil, '_isWorker').returns(true);
         sinon.stub(workerUtil, '_getWorkerGlobalScope').returns(serviceWorker);
-        persistence = new ((indexedDBLocalPersistence as unknown) as SingletonInstantiator<TestPersistence>)();
+        persistence =
+          new (indexedDBLocalPersistence as unknown as SingletonInstantiator<TestPersistence>)();
         db = await _openDatabase();
       });
 
@@ -288,7 +289,8 @@ describe('platform_browser/persistence/indexed_db', () => {
         sinon
           .stub(workerUtil, '_getServiceWorkerController')
           .returns(serviceWorker);
-        persistence = new ((indexedDBLocalPersistence as unknown) as SingletonInstantiator<TestPersistence>)();
+        persistence =
+          new (indexedDBLocalPersistence as unknown as SingletonInstantiator<TestPersistence>)();
       });
 
       it('should send a ping on init', async () => {
@@ -344,9 +346,11 @@ describe('platform_browser/persistence/indexed_db', () => {
   describe('closed IndexedDB connection', () => {
     it('should retry by reopening the connection', async () => {
       const closeDb = async (): Promise<void> => {
-        const db = await ((persistence as unknown) as {
-          _openDb(): Promise<IDBDatabase>;
-        })._openDb();
+        const db = await (
+          persistence as unknown as {
+            _openDb(): Promise<IDBDatabase>;
+          }
+        )._openDb();
         db.close();
       };
       const key = 'my-super-special-persistence-type';

--- a/packages/auth/src/platform_browser/persistence/local_storage.ts
+++ b/packages/auth/src/platform_browser/persistence/local_storage.ts
@@ -54,7 +54,10 @@ class BrowserLocalPersistence
     super(() => window.localStorage, PersistenceType.LOCAL);
   }
 
-  private readonly boundEventHandler = (event: StorageEvent, poll?: boolean): void => this.onStorageEvent(event, poll);
+  private readonly boundEventHandler = (
+    event: StorageEvent,
+    poll?: boolean
+  ): void => this.onStorageEvent(event, poll);
   private readonly listeners: Record<string, Set<StorageEventListener>> = {};
   private readonly localCache: Record<string, string | null> = {};
   // setTimeout return value is platform specific

--- a/packages/auth/src/platform_browser/popup_redirect.test.ts
+++ b/packages/auth/src/platform_browser/popup_redirect.test.ts
@@ -58,7 +58,8 @@ describe('platform_browser/popup_redirect', () => {
 
   beforeEach(async () => {
     auth = await testAuth();
-    resolver = new (browserPopupRedirectResolver as SingletonInstantiator<PopupRedirectResolverInternal>)();
+    resolver =
+      new (browserPopupRedirectResolver as SingletonInstantiator<PopupRedirectResolverInternal>)();
 
     sinon.stub(validateOrigin, '_validateOrigin').returns(Promise.resolve());
     iframeSendStub = sinon.stub();
@@ -74,7 +75,7 @@ describe('platform_browser/popup_redirect', () => {
 
   function setGapiStub(): void {
     loadGapiStub.returns(
-      Promise.resolve(({
+      Promise.resolve({
         open: () =>
           Promise.resolve({
             register: (
@@ -83,7 +84,7 @@ describe('platform_browser/popup_redirect', () => {
             ) => (onIframeMessage = cb),
             send: iframeSendStub
           })
-      } as unknown) as gapi.iframes.Context)
+      } as unknown as gapi.iframes.Context)
     );
   }
 
@@ -250,7 +251,7 @@ describe('platform_browser/popup_redirect', () => {
       const error = new Error();
       loadGapiStub.rejects(error);
       await expect(resolver._initialize(auth)).to.be.rejectedWith(error);
-      setGapiStub();  // Reset the gapi load stub
+      setGapiStub(); // Reset the gapi load stub
       await expect(resolver._initialize(auth)).not.to.be.rejected;
     });
 
@@ -277,7 +278,7 @@ describe('platform_browser/popup_redirect', () => {
       expect(() =>
         onIframeMessage({
           type: 'authEvent',
-          authEvent: (null as unknown) as AuthEvent
+          authEvent: null as unknown as AuthEvent
         })
       ).to.throw(FirebaseError, 'auth/invalid-auth-event');
     });
@@ -285,9 +286,10 @@ describe('platform_browser/popup_redirect', () => {
     it('errors with invalid event if everything is null', async () => {
       const manager = (await resolver._initialize(auth)) as AuthEventManager;
       sinon.stub(manager, 'onEvent').returns(true);
-      expect(() =>
-        onIframeMessage((null as unknown) as GapiAuthEvent)
-      ).to.throw(FirebaseError, 'auth/invalid-auth-event');
+      expect(() => onIframeMessage(null as unknown as GapiAuthEvent)).to.throw(
+        FirebaseError,
+        'auth/invalid-auth-event'
+      );
     });
 
     it('returns error to the iframe if the event was not handled', async () => {

--- a/packages/auth/src/platform_browser/popup_redirect.ts
+++ b/packages/auth/src/platform_browser/popup_redirect.ts
@@ -187,4 +187,5 @@ class BrowserPopupRedirectResolver implements PopupRedirectResolverInternal {
  *
  * @public
  */
-export const browserPopupRedirectResolver: PopupRedirectResolver = BrowserPopupRedirectResolver;
+export const browserPopupRedirectResolver: PopupRedirectResolver =
+  BrowserPopupRedirectResolver;

--- a/packages/auth/src/platform_browser/recaptcha/recaptcha_loader.test.ts
+++ b/packages/auth/src/platform_browser/recaptcha/recaptcha_loader.test.ts
@@ -67,9 +67,9 @@ describe('platform_browser/recaptcha/recaptcha_loader', () => {
       triggerNetworkTimeout = stubSingleTimeout(networkTimeoutId);
 
       sinon.stub(jsHelpers, '_loadJS').callsFake(() => {
-        return (new Promise<void>((resolve, reject) => {
+        return new Promise<void>((resolve, reject) => {
           jsLoader = { resolve, reject };
-        }) as unknown) as Promise<Event>;
+        }) as unknown as Promise<Event>;
       });
 
       loader = new ReCaptchaLoaderImpl();

--- a/packages/auth/src/platform_browser/recaptcha/recaptcha_mock.test.ts
+++ b/packages/auth/src/platform_browser/recaptcha/recaptcha_mock.test.ts
@@ -161,7 +161,7 @@ describe('platform_browser/recaptcha/recaptcha_mock', () => {
           'expired-callback': sinon.spy()
         };
         pendingTimers = stubTimeouts();
-        timeoutStub = (window.setTimeout as unknown) as sinon.SinonStub;
+        timeoutStub = window.setTimeout as unknown as sinon.SinonStub;
         widget = new MockWidget(container, auth.name, callbacks);
       });
 

--- a/packages/auth/src/platform_browser/recaptcha/recaptcha_verifier.test.ts
+++ b/packages/auth/src/platform_browser/recaptcha/recaptcha_verifier.test.ts
@@ -67,7 +67,7 @@ describe('platform_browser/recaptcha/recaptcha_verifier', () => {
   context('#render', () => {
     it('caches the promise if not completed and returns if called multiple times', () => {
       // This will force the loader to never return so the render promise never completes
-      sinon.stub(recaptchaLoader, 'load').returns(new Promise(() => { }));
+      sinon.stub(recaptchaLoader, 'load').returns(new Promise(() => {}));
       const renderPromise = verifier.render();
       expect(verifier.render()).to.eq(renderPromise);
     });

--- a/packages/auth/src/platform_browser/strategies/popup.ts
+++ b/packages/auth/src/platform_browser/strategies/popup.ts
@@ -25,7 +25,12 @@ import {
 
 import { _castAuth } from '../../core/auth/auth_impl';
 import { AuthErrorCode } from '../../core/errors';
-import { _assert, debugAssert, _createError, _assertInstanceOf } from '../../core/util/assert';
+import {
+  _assert,
+  debugAssert,
+  _createError,
+  _assertInstanceOf
+} from '../../core/util/assert';
 import { Delay } from '../../core/util/delay';
 import { _generateEventId } from '../../core/util/event_id';
 import { AuthInternal } from '../../model/auth';

--- a/packages/auth/src/platform_browser/strategies/redirect.test.ts
+++ b/packages/auth/src/platform_browser/strategies/redirect.test.ts
@@ -20,10 +20,7 @@ import chaiAsPromised from 'chai-as-promised';
 import * as sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 
-import {
-  AuthError,
-  PopupRedirectResolver
-} from '../../model/public_types';
+import { AuthError, PopupRedirectResolver } from '../../model/public_types';
 import { OperationType, ProviderId } from '../../model/enums';
 
 import { delay } from '../../../test/helpers/delay';
@@ -74,17 +71,15 @@ describe('platform_browser/strategies/redirect', () => {
   let idpStubs: sinon.SinonStubbedInstance<typeof idpTasks>;
 
   beforeEach(async () => {
-    eventManager = new AuthEventManager(({} as unknown) as TestAuth);
+    eventManager = new AuthEventManager({} as unknown as TestAuth);
     provider = new OAuthProvider(ProviderId.GOOGLE);
     resolver = makeMockPopupRedirectResolver(eventManager);
-    _getInstance<PopupRedirectResolverInternal>(
-      resolver
-    )._redirectPersistence = RedirectPersistence;
+    _getInstance<PopupRedirectResolverInternal>(resolver)._redirectPersistence =
+      RedirectPersistence;
     auth = await testAuth(resolver);
     idpStubs = sinon.stub(idpTasks);
-    _getInstance<RedirectPersistence>(
-      RedirectPersistence
-    ).hasPendingRedirect = true;
+    _getInstance<RedirectPersistence>(RedirectPersistence).hasPendingRedirect =
+      true;
   });
 
   afterEach(() => {
@@ -173,9 +168,8 @@ describe('platform_browser/strategies/redirect', () => {
     });
 
     it('persists the redirect user and current user', async () => {
-      const redirectPersistence: PersistenceInternal = _getInstance(
-        RedirectPersistence
-      );
+      const redirectPersistence: PersistenceInternal =
+        _getInstance(RedirectPersistence);
       sinon.spy(redirectPersistence, '_set');
       sinon.spy(auth.persistenceLayer, '_set');
 
@@ -193,9 +187,8 @@ describe('platform_browser/strategies/redirect', () => {
 
     it('persists the redirect user but not current user if diff currentUser', async () => {
       await auth._updateCurrentUser(testUser(auth, 'not-uid', 'email', true));
-      const redirectPersistence: PersistenceInternal = _getInstance(
-        RedirectPersistence
-      );
+      const redirectPersistence: PersistenceInternal =
+        _getInstance(RedirectPersistence);
       sinon.spy(redirectPersistence, '_set');
       sinon.spy(auth.persistenceLayer, '_set');
 
@@ -251,9 +244,8 @@ describe('platform_browser/strategies/redirect', () => {
     });
 
     it('persists the redirect user and current user', async () => {
-      const redirectPersistence: PersistenceInternal = _getInstance(
-        RedirectPersistence
-      );
+      const redirectPersistence: PersistenceInternal =
+        _getInstance(RedirectPersistence);
       sinon.spy(redirectPersistence, '_set');
       sinon.spy(auth.persistenceLayer, '_set');
 
@@ -271,9 +263,8 @@ describe('platform_browser/strategies/redirect', () => {
 
     it('persists the redirect user but not current user if diff currentUser', async () => {
       await auth._updateCurrentUser(testUser(auth, 'not-uid', 'email', true));
-      const redirectPersistence: PersistenceInternal = _getInstance(
-        RedirectPersistence
-      );
+      const redirectPersistence: PersistenceInternal =
+        _getInstance(RedirectPersistence);
       sinon.spy(redirectPersistence, '_set');
       sinon.spy(auth.persistenceLayer, '_set');
 
@@ -300,9 +291,8 @@ describe('platform_browser/strategies/redirect', () => {
     }
 
     async function reInitAuthWithRedirectUser(eventId: string): Promise<void> {
-      const redirectPersistence: RedirectPersistence = _getInstance(
-        RedirectPersistence
-      );
+      const redirectPersistence: RedirectPersistence =
+        _getInstance(RedirectPersistence);
       const mainPersistence = new MockPersistenceLayer();
       const oldAuth = await testAuth();
       const user = testUser(oldAuth, 'uid');
@@ -410,9 +400,8 @@ describe('platform_browser/strategies/redirect', () => {
 
     it('removes the redirect user and clears eventId from currentuser', async () => {
       await reInitAuthWithRedirectUser(MATCHING_EVENT_ID);
-      const redirectPersistence: PersistenceInternal = _getInstance(
-        RedirectPersistence
-      );
+      const redirectPersistence: PersistenceInternal =
+        _getInstance(RedirectPersistence);
       sinon.spy(redirectPersistence, '_remove');
 
       const cred = new UserCredentialImpl({
@@ -436,9 +425,8 @@ describe('platform_browser/strategies/redirect', () => {
 
     it('does not mutate authstate if bypassAuthState is true', async () => {
       await reInitAuthWithRedirectUser(MATCHING_EVENT_ID);
-      const redirectPersistence: PersistenceInternal = _getInstance(
-        RedirectPersistence
-      );
+      const redirectPersistence: PersistenceInternal =
+        _getInstance(RedirectPersistence);
       sinon.spy(redirectPersistence, '_remove');
 
       const cred = new UserCredentialImpl({

--- a/packages/auth/src/platform_browser/util/worker.ts
+++ b/packages/auth/src/platform_browser/util/worker.ts
@@ -41,5 +41,5 @@ export function _getServiceWorkerController(): ServiceWorker | null {
 }
 
 export function _getWorkerGlobalScope(): ServiceWorker | null {
-  return _isWorker() ? ((self as unknown) as ServiceWorker) : null;
+  return _isWorker() ? (self as unknown as ServiceWorker) : null;
 }

--- a/packages/auth/src/platform_cordova/plugins.ts
+++ b/packages/auth/src/platform_cordova/plugins.ts
@@ -50,5 +50,5 @@ export interface InAppBrowserRef {
 }
 
 export function _cordovaWindow(): CordovaWindow {
-  return (window as unknown) as CordovaWindow;
+  return window as unknown as CordovaWindow;
 }

--- a/packages/auth/src/platform_cordova/popup_redirect/events.ts
+++ b/packages/auth/src/platform_cordova/popup_redirect/events.ts
@@ -89,10 +89,7 @@ export function _savePartialEvent(
   auth: AuthInternal,
   event: AuthEvent
 ): Promise<void> {
-  return storage()._set(
-    persistenceKey(auth),
-    (event as object) as PersistedBlob
-  );
+  return storage()._set(persistenceKey(auth), event as object as PersistedBlob);
 }
 
 export async function _getAndRemoveEvent(

--- a/packages/auth/src/platform_cordova/popup_redirect/popup_redirect.ts
+++ b/packages/auth/src/platform_cordova/popup_redirect/popup_redirect.ts
@@ -42,7 +42,10 @@ import {
 } from './events';
 import { AuthEventManager } from '../../core/auth/auth_event_manager';
 import { _getRedirectResult } from '../../platform_browser/strategies/redirect';
-import { _clearRedirectOutcomes, _overrideRedirectResult } from '../../core/strategies/redirect';
+import {
+  _clearRedirectOutcomes,
+  _overrideRedirectResult
+} from '../../core/strategies/redirect';
 import { _cordovaWindow } from '../plugins';
 
 /**

--- a/packages/auth/src/platform_react_native/persistence/react_native.ts
+++ b/packages/auth/src/platform_react_native/persistence/react_native.ts
@@ -29,7 +29,7 @@ import {
  * Returns a persistence object that wraps `AsyncStorage` imported from
  * `react-native` or `@react-native-community/async-storage`, and can
  * be used in the persistence dependency field in {@link initializeAuth}.
- * 
+ *
  * @public
  */
 export function getReactNativePersistence(

--- a/packages/auth/test/helpers/erroring_unavailable_persistence.ts
+++ b/packages/auth/test/helpers/erroring_unavailable_persistence.ts
@@ -15,41 +15,47 @@
  * limitations under the License.
  */
 
- import { PersistenceInternal, PersistenceType, PersistenceValue } from '../../src/core/persistence';
+import {
+  PersistenceInternal,
+  PersistenceType,
+  PersistenceValue
+} from '../../src/core/persistence';
 
- const PERMISSION_ERROR = typeof window !== 'undefined' ? new DOMException(
-     'Failed to read this storage class from the Window; access is denied')
-     : new Error('This is Node.');
+const PERMISSION_ERROR =
+  typeof window !== 'undefined'
+    ? new DOMException(
+        'Failed to read this storage class from the Window; access is denied'
+      )
+    : new Error('This is Node.');
 
- /**
-  * Helper class for mocking completely broken persistence that errors when
-  * accessed.
-  * 
-  * When disabling cookies in Chrome entirely, for example, simply reading the
-  * "localStorage" field in "window" will throw an error, but this can't be
-  * checked for by calling `'localStorage' in window`. This class simulates a
-  * situation where _isAvailable works correctly but all other methods fail.
-  */
- export class ErroringUnavailablePersistence implements PersistenceInternal {
-   type = PersistenceType.NONE;
-   async _isAvailable(): Promise<boolean> {
-     return false;
-   }
-   async _set(): Promise<void> {
-     throw PERMISSION_ERROR;
-   }
-   async _get<T extends PersistenceValue>(): Promise<T | null> {
-     throw PERMISSION_ERROR;
-   }
-   async _remove(): Promise<void> {
-     throw PERMISSION_ERROR;
-   }
-   _addListener(): void {
-     throw PERMISSION_ERROR;
-   }
-   _removeListener(): void {
-     throw PERMISSION_ERROR;
-   }
-   _shouldAllowMigration = false;
- }
- 
+/**
+ * Helper class for mocking completely broken persistence that errors when
+ * accessed.
+ *
+ * When disabling cookies in Chrome entirely, for example, simply reading the
+ * "localStorage" field in "window" will throw an error, but this can't be
+ * checked for by calling `'localStorage' in window`. This class simulates a
+ * situation where _isAvailable works correctly but all other methods fail.
+ */
+export class ErroringUnavailablePersistence implements PersistenceInternal {
+  type = PersistenceType.NONE;
+  async _isAvailable(): Promise<boolean> {
+    return false;
+  }
+  async _set(): Promise<void> {
+    throw PERMISSION_ERROR;
+  }
+  async _get<T extends PersistenceValue>(): Promise<T | null> {
+    throw PERMISSION_ERROR;
+  }
+  async _remove(): Promise<void> {
+    throw PERMISSION_ERROR;
+  }
+  _addListener(): void {
+    throw PERMISSION_ERROR;
+  }
+  _removeListener(): void {
+    throw PERMISSION_ERROR;
+  }
+  _shouldAllowMigration = false;
+}

--- a/packages/auth/test/helpers/integration/emulator_rest_helpers.ts
+++ b/packages/auth/test/helpers/integration/emulator_rest_helpers.ts
@@ -89,8 +89,8 @@ function doFetch(url: string, request?: RequestInit): ReturnType<typeof fetch> {
     return fetch(url, request);
   }
 
-  return (fetchImpl.default(
+  return fetchImpl.default(
     url,
     request as fetchImpl.RequestInit
-  ) as unknown) as ReturnType<typeof fetch>;
+  ) as unknown as ReturnType<typeof fetch>;
 }

--- a/packages/auth/test/helpers/mock_auth.ts
+++ b/packages/auth/test/helpers/mock_auth.ts
@@ -46,7 +46,7 @@ const FAKE_APP: FirebaseApp = {
 };
 
 export const FAKE_HEARTBEAT_CONTROLLER = {
-  getHeartbeatsHeader: async () => '',
+  getHeartbeatsHeader: async () => ''
 };
 
 export const FAKE_HEARTBEAT_CONTROLLER_PROVIDER: Provider<'heartbeat'> = {
@@ -73,15 +73,19 @@ export async function testAuth(
   popupRedirectResolver?: PopupRedirectResolver,
   persistence = new MockPersistenceLayer()
 ): Promise<TestAuth> {
-  const auth: TestAuth = new AuthImpl(FAKE_APP, FAKE_HEARTBEAT_CONTROLLER_PROVIDER, {
-    apiKey: TEST_KEY,
-    authDomain: TEST_AUTH_DOMAIN,
-    apiHost: TEST_HOST,
-    apiScheme: TEST_SCHEME,
-    tokenApiHost: TEST_TOKEN_HOST,
-    clientPlatform: ClientPlatform.BROWSER,
-    sdkClientVersion: 'testSDK/0.0.0'
-  }) as TestAuth;
+  const auth: TestAuth = new AuthImpl(
+    FAKE_APP,
+    FAKE_HEARTBEAT_CONTROLLER_PROVIDER,
+    {
+      apiKey: TEST_KEY,
+      authDomain: TEST_AUTH_DOMAIN,
+      apiHost: TEST_HOST,
+      apiScheme: TEST_SCHEME,
+      tokenApiHost: TEST_TOKEN_HOST,
+      clientPlatform: ClientPlatform.BROWSER,
+      sdkClientVersion: 'testSDK/0.0.0'
+    }
+  ) as TestAuth;
   auth._updateErrorMap(debugErrorMap);
 
   await auth._initializeWithPersistence([persistence], popupRedirectResolver);

--- a/packages/auth/test/helpers/mock_popup_redirect_resolver.ts
+++ b/packages/auth/test/helpers/mock_popup_redirect_resolver.ts
@@ -37,7 +37,7 @@ export function makeMockPopupRedirectResolver(
   return class implements PopupRedirectResolver {
     async _initialize(): Promise<EventManager> {
       return (
-        eventManager || new AuthEventManager(({} as unknown) as AuthInternal)
+        eventManager || new AuthEventManager({} as unknown as AuthInternal)
       );
     }
 

--- a/packages/auth/test/integration/flows/anonymous.test.ts
+++ b/packages/auth/test/integration/flows/anonymous.test.ts
@@ -130,7 +130,10 @@ describe('Integration test: anonymous auth', () => {
     });
   });
 
-  generateMiddlewareTests(() => auth, () => {
-    return signInAnonymously(auth);
-  });
+  generateMiddlewareTests(
+    () => auth,
+    () => {
+      return signInAnonymously(auth);
+    }
+  );
 });

--- a/packages/auth/test/integration/flows/custom.local.test.ts
+++ b/packages/auth/test/integration/flows/custom.local.test.ts
@@ -227,7 +227,10 @@ describe('Integration test: custom auth', () => {
     });
   });
 
-  generateMiddlewareTests(() => auth, () => {
-    return signInWithCustomToken(auth, customToken);
-  });
+  generateMiddlewareTests(
+    () => auth,
+    () => {
+      return signInWithCustomToken(auth, customToken);
+    }
+  );
 });

--- a/packages/auth/test/integration/flows/email.test.ts
+++ b/packages/auth/test/integration/flows/email.test.ts
@@ -170,8 +170,11 @@ describe('Integration test: email/password auth', () => {
       expect(userA.uid).to.eq(userB.uid);
     });
 
-    generateMiddlewareTests(() => auth, () => {
-      return signInWithEmailAndPassword(auth, email, 'password');
-    });
+    generateMiddlewareTests(
+      () => auth,
+      () => {
+        return signInWithEmailAndPassword(auth, email, 'password');
+      }
+    );
   });
 });

--- a/packages/auth/test/integration/flows/idp.local.test.ts
+++ b/packages/auth/test/integration/flows/idp.local.test.ts
@@ -287,10 +287,13 @@ describe('Integration test: headless IdP', () => {
     ]);
   });
 
-  generateMiddlewareTests(() => auth, () => {
-    return signInWithCredential(
-      auth,
-      GoogleAuthProvider.credential(oauthIdToken)
-    );
-  });
+  generateMiddlewareTests(
+    () => auth,
+    () => {
+      return signInWithCredential(
+        auth,
+        GoogleAuthProvider.credential(oauthIdToken)
+      );
+    }
+  );
 });

--- a/packages/auth/test/integration/flows/middleware_test_generator.ts
+++ b/packages/auth/test/integration/flows/middleware_test_generator.ts
@@ -21,13 +21,16 @@ import * as sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 
 // eslint-disable-next-line import/no-extraneous-dependencies
-import {Auth, createUserWithEmailAndPassword, User} from '@firebase/auth';
+import { Auth, createUserWithEmailAndPassword, User } from '@firebase/auth';
 import { randomEmail } from '../../helpers/integration/helpers';
 
 use(chaiAsPromised);
 use(sinonChai);
 
-export function generateMiddlewareTests(authGetter: () => Auth, signIn: () => Promise<unknown>): void {
+export function generateMiddlewareTests(
+  authGetter: () => Auth,
+  signIn: () => Promise<unknown>
+): void {
   context('middleware', () => {
     let auth: Auth;
     let unsubscribes: Array<() => void>;
@@ -48,7 +51,10 @@ export function generateMiddlewareTests(authGetter: () => Auth, signIn: () => Pr
      * automatically unsubscribe after every test (since some tests may
      * perform cleanup after that would be affected by the middleware)
      */
-    function beforeAuthStateChanged(callback: (user: User | null) => void | Promise<void>, onAbort?: () => void): void {
+    function beforeAuthStateChanged(
+      callback: (user: User | null) => void | Promise<void>,
+      onAbort?: () => void
+    ): void {
       unsubscribes.push(auth.beforeAuthStateChanged(callback, onAbort));
     }
 
@@ -72,7 +78,11 @@ export function generateMiddlewareTests(authGetter: () => Auth, signIn: () => Pr
 
     it('keeps previously-logged in user if blocked', async () => {
       // Use a random email/password sign in for the base user
-      const {user: baseUser} = await createUserWithEmailAndPassword(auth, randomEmail(), 'password');
+      const { user: baseUser } = await createUserWithEmailAndPassword(
+        auth,
+        randomEmail(),
+        'password'
+      );
 
       beforeAuthStateChanged(() => {
         throw new Error('stop sign in');
@@ -102,7 +112,11 @@ export function generateMiddlewareTests(authGetter: () => Auth, signIn: () => Pr
 
     it('overrides previous user if allowed', async () => {
       // Use a random email/password sign in for the base user
-      const {user: baseUser} = await createUserWithEmailAndPassword(auth, randomEmail(), 'password');
+      const { user: baseUser } = await createUserWithEmailAndPassword(
+        auth,
+        randomEmail(),
+        'password'
+      );
 
       beforeAuthStateChanged(() => {
         // Pass
@@ -131,7 +145,11 @@ export function generateMiddlewareTests(authGetter: () => Auth, signIn: () => Pr
 
     it('keeps previously-logged in user if one rejects', async () => {
       // Use a random email/password sign in for the base user
-      const {user: baseUser} = await createUserWithEmailAndPassword(auth, randomEmail(), 'password');
+      const { user: baseUser } = await createUserWithEmailAndPassword(
+        auth,
+        randomEmail(),
+        'password'
+      );
 
       // Also check that the function is called multiple
       // times
@@ -151,7 +169,11 @@ export function generateMiddlewareTests(authGetter: () => Auth, signIn: () => Pr
 
     it('allows sign in with multiple callbacks all pass', async () => {
       // Use a random email/password sign in for the base user
-      const {user: baseUser} = await createUserWithEmailAndPassword(auth, randomEmail(), 'password');
+      const { user: baseUser } = await createUserWithEmailAndPassword(
+        auth,
+        randomEmail(),
+        'password'
+      );
 
       // Also check that the function is called multiple
       // times
@@ -184,7 +206,7 @@ export function generateMiddlewareTests(authGetter: () => Auth, signIn: () => Pr
     it('can prevent sign-out', async () => {
       await signIn();
       const user = auth.currentUser;
-      
+
       beforeAuthStateChanged(() => {
         throw new Error('block sign out');
       });

--- a/packages/auth/test/integration/flows/oob.local.test.ts
+++ b/packages/auth/test/integration/flows/oob.local.test.ts
@@ -269,13 +269,12 @@ describe('Integration test: oob codes', () => {
       ).to.be.rejectedWith(FirebaseError, 'auth/invalid-email');
     });
 
-    generateMiddlewareTests(() => auth, () => {
-      return signInWithEmailLink(
-        auth,
-        email,
-        oobSession.oobLink
-      );
-    });
+    generateMiddlewareTests(
+      () => auth,
+      () => {
+        return signInWithEmailLink(auth, email, oobSession.oobLink);
+      }
+    );
   });
 
   it('can be used to verify email', async () => {

--- a/packages/auth/test/integration/flows/phone.test.ts
+++ b/packages/auth/test/integration/flows/phone.test.ts
@@ -294,7 +294,7 @@ describe('Integration test: phone auth', () => {
           )
         );
       } catch (e) {
-         error = e as FirebaseError;
+        error = e as FirebaseError;
       }
 
       expect(error!.customData!.phoneNumber).to.eq(PHONE_A.phoneNumber);
@@ -308,8 +308,15 @@ describe('Integration test: phone auth', () => {
     });
   });
 
-  generateMiddlewareTests(() => auth, async () => {
-    const cr = await signInWithPhoneNumber(auth, PHONE_A.phoneNumber, verifier);
-    await cr.confirm(await code(cr, PHONE_A.code));
-  });
+  generateMiddlewareTests(
+    () => auth,
+    async () => {
+      const cr = await signInWithPhoneNumber(
+        auth,
+        PHONE_A.phoneNumber,
+        verifier
+      );
+      await cr.confirm(await code(cr, PHONE_A.code));
+    }
+  );
 });

--- a/packages/auth/test/integration/webdriver/compat/firebaseui.test.ts
+++ b/packages/auth/test/integration/webdriver/compat/firebaseui.test.ts
@@ -128,9 +128,9 @@ browserDescribe('WebDriver integration with FirebaseUI', driver => {
     await page.waitForCodeInputToBePresent();
 
     // Get the number from the emulator REST endpoint
-    const code = Object.values(
-      await getPhoneVerificationCodes()
-    ).find(session => session.phoneNumber.includes(phoneNumber))!.code;
+    const code = Object.values(await getPhoneVerificationCodes()).find(
+      session => session.phoneNumber.includes(phoneNumber)
+    )!.code;
     await page.enterPhoneCode(code);
     await page.clickSubmit();
 

--- a/packages/auth/test/integration/webdriver/persistence.test.ts
+++ b/packages/auth/test/integration/webdriver/persistence.test.ts
@@ -284,7 +284,7 @@ browserDescribe('WebDriver persistence test', (driver, browser) => {
         .that.contains({ uid: user.uid });
     });
 
-    it('migrates user when switching from indexedDB to localStorage', async function() {
+    it('migrates user when switching from indexedDB to localStorage', async function () {
       // This test only works in the modular SDK: the compat package does not
       // make the distinction between indexedDB and local storage (both are just
       // 'local').
@@ -462,7 +462,7 @@ browserDescribe('WebDriver persistence test', (driver, browser) => {
       expect(await driver.getUserSnapshot()).to.contain({ uid: uid2 });
     });
 
-    it('middleware does not block tab sync', async function() {
+    it('middleware does not block tab sync', async function () {
       if (driver.isCompatLayer()) {
         // Compat layer is skipped because it doesn't support middleware
         console.warn('Skipping middleware tabs in compat test');
@@ -473,9 +473,9 @@ browserDescribe('WebDriver persistence test', (driver, browser) => {
       await driver.call(MiddlewareFunction.ATTACH_BLOCKING_MIDDLEWARE);
 
       // Check that it blocks basic sign in
-      await expect(driver.call(
-        AnonFunction.SIGN_IN_ANONYMOUSLY
-      )).to.be.rejectedWith('auth/login-blocked');
+      await expect(
+        driver.call(AnonFunction.SIGN_IN_ANONYMOUSLY)
+      ).to.be.rejectedWith('auth/login-blocked');
       const userInPopup = await driver.getUserSnapshot();
       expect(userInPopup).to.be.null;
 

--- a/packages/auth/test/integration/webdriver/popup.test.ts
+++ b/packages/auth/test/integration/webdriver/popup.test.ts
@@ -85,9 +85,9 @@ browserDescribe('Popup IdP tests', driver => {
     await widget.clickSignIn();
 
     await driver.selectMainWindow();
-    await expect(driver.call(
-      PopupFunction.POPUP_RESULT
-    )).to.be.rejectedWith('auth/login-blocked');
+    await expect(driver.call(PopupFunction.POPUP_RESULT)).to.be.rejectedWith(
+      'auth/login-blocked'
+    );
     const currentUser = await driver.getUserSnapshot();
     expect(currentUser).to.be.null;
   });

--- a/packages/auth/test/integration/webdriver/redirect.test.ts
+++ b/packages/auth/test/integration/webdriver/redirect.test.ts
@@ -95,7 +95,9 @@ browserDescribe('WebDriver redirect IdP test', driver => {
     await driver.call(MiddlewareFunction.ATTACH_BLOCKING_MIDDLEWARE_ON_START);
 
     await driver.reinitOnRedirect();
-    await expect(driver.call(RedirectFunction.REDIRECT_RESULT)).to.be.rejectedWith('auth/login-blocked');
+    await expect(
+      driver.call(RedirectFunction.REDIRECT_RESULT)
+    ).to.be.rejectedWith('auth/login-blocked');
     expect(await driver.getUserSnapshot()).to.be.null;
   });
 

--- a/packages/auth/test/integration/webdriver/static/middleware.js
+++ b/packages/auth/test/integration/webdriver/static/middleware.js
@@ -29,5 +29,5 @@ export async function attachBlockingMiddlewareOnStart() {
   window.startAuth = async () => {
     oldStartAuth();
     await attachBlockingMiddleware();
-  }
+  };
 }

--- a/packages/auth/test/integration/webdriver/util/functions.ts
+++ b/packages/auth/test/integration/webdriver/util/functions.ts
@@ -79,7 +79,7 @@ export enum PersistenceFunction {
 
 export enum MiddlewareFunction {
   ATTACH_BLOCKING_MIDDLEWARE = 'middleware.attachBlockingMiddleware',
-  ATTACH_BLOCKING_MIDDLEWARE_ON_START = 'middleware.attachBlockingMiddlewareOnStart',
+  ATTACH_BLOCKING_MIDDLEWARE_ON_START = 'middleware.attachBlockingMiddlewareOnStart'
 }
 
 /** Available firebase UI functions (only for compat tests) */

--- a/packages/auth/test/integration/webdriver/util/test_runner.ts
+++ b/packages/auth/test/integration/webdriver/util/test_runner.ts
@@ -36,7 +36,7 @@ interface TempSuite {
 }
 
 /** The browsers that these tests will run in */
-const BROWSERS = ['chrome', /* 'firefox' */];  // TODO(b/198792664): Investigate Firefox timeout issues
+const BROWSERS = ['chrome' /* 'firefox' */]; // TODO(b/198792664): Investigate Firefox timeout issues
 
 /** One single AuthDriver instance to control everything */
 const DRIVER = new AuthDriver();


### PR DESCRIPTION
`packages/auth` was included in the `.prettierignore` file (should be the first file in this PR) ever since this SDK was ported to Github. I think it was because Auth was written in Closure at the time. Now that it's in Typescript like everything else, we should probably not be excluding it from prettier checks.

Obviously there is a bit of a backlog after not running it for so long, so there are 102 changed files (all formatting changes - whitespace, indents, splitting params onto multiple lines, etc.)