### PR TITLE
Updated type of action parameter for DataSnapshot#forEach

### DIFF
--- a/.changeset/orange-doors-swim.md
+++ b/.changeset/orange-doors-swim.md
@@ -1,7 +1,0 @@
----
-"@firebase/database-compat": patch
-"@firebase/database-types": patch
-"@firebase/database": patch
----
-
-Revert "Updated type of action parameter for DataSnapshot#forEach"

--- a/.changeset/silly-eagles-unite.md
+++ b/.changeset/silly-eagles-unite.md
@@ -1,0 +1,7 @@
+---
+"@firebase/database-compat": major
+"@firebase/database-types": major
+"@firebase/database": major
+---
+
+Updated type of action parameter for DataSnapshot#forEach

--- a/common/api-review/database.api.md
+++ b/common/api-review/database.api.md
@@ -33,7 +33,9 @@ export class DataSnapshot {
     child(path: string): DataSnapshot;
     exists(): boolean;
     exportVal(): any;
-    forEach(action: (child: DataSnapshot) => boolean | void): boolean;
+    forEach(action: (child: DataSnapshot & {
+        key: string;
+    }) => boolean | void): boolean;
     hasChild(path: string): boolean;
     hasChildren(): boolean;
     get key(): string | null;

--- a/common/api-review/database.api.md
+++ b/common/api-review/database.api.md
@@ -33,9 +33,7 @@ export class DataSnapshot {
     child(path: string): DataSnapshot;
     exists(): boolean;
     exportVal(): any;
-    forEach(action: (child: DataSnapshot & {
-        key: string;
-    }) => boolean | void): boolean;
+    forEach(action: (child: IteratedDataSnapshot) => boolean | void): boolean;
     hasChild(path: string): boolean;
     hasChildren(): boolean;
     get key(): string | null;
@@ -86,6 +84,12 @@ export function goOnline(db: Database): void;
 
 // @public
 export function increment(delta: number): object;
+
+// @public
+export interface IteratedDataSnapshot extends DataSnapshot {
+    // (undocumented)
+    key: string;
+}
 
 // @public
 export function limitToFirst(limit: number): QueryConstraint;

--- a/common/api-review/database.api.md
+++ b/common/api-review/database.api.md
@@ -6,6 +6,7 @@
 
 import { EmulatorMockTokenOptions } from '@firebase/util';
 import { FirebaseApp } from '@firebase/app';
+import { _FirebaseService } from '@firebase/app';
 
 // @public
 export function child(parent: DatabaseReference, path: string): DatabaseReference;
@@ -16,7 +17,7 @@ export function connectDatabaseEmulator(db: Database, host: string, port: number
 }): void;
 
 // @public
-export class Database {
+export class Database implements _FirebaseService {
     readonly app: FirebaseApp;
     readonly 'type' = "database";
 }

--- a/common/api-review/database.api.md
+++ b/common/api-review/database.api.md
@@ -6,7 +6,6 @@
 
 import { EmulatorMockTokenOptions } from '@firebase/util';
 import { FirebaseApp } from '@firebase/app';
-import { _FirebaseService } from '@firebase/app';
 
 // @public
 export function child(parent: DatabaseReference, path: string): DatabaseReference;
@@ -17,7 +16,7 @@ export function connectDatabaseEmulator(db: Database, host: string, port: number
 }): void;
 
 // @public
-export class Database implements _FirebaseService {
+export class Database {
     readonly app: FirebaseApp;
     readonly 'type' = "database";
 }

--- a/packages/database-compat/src/api/Reference.ts
+++ b/packages/database-compat/src/api/Reference.ts
@@ -164,7 +164,9 @@ export class DataSnapshot implements Compat<ModularDataSnapshot> {
    * @returns True if forEach was canceled by action returning true for
    * one of the child nodes.
    */
-  forEach(action: (snapshot: DataSnapshot) => boolean | void): boolean {
+  forEach(
+    action: (snapshot: DataSnapshot & { key: string }) => boolean | void
+  ): boolean {
     validateArgCount('DataSnapshot.forEach', 1, 1, arguments.length);
     validateCallback('DataSnapshot.forEach', 'action', action, false);
     return this._delegate.forEach(expDataSnapshot =>

--- a/packages/database-compat/src/api/Reference.ts
+++ b/packages/database-compat/src/api/Reference.ts
@@ -156,8 +156,6 @@ export class DataSnapshot implements Compat<ModularDataSnapshot> {
     return this._delegate.priority;
   }
 
-  
-
   /**
    * Iterates through child nodes and calls the specified action for each one.
    *
@@ -166,9 +164,7 @@ export class DataSnapshot implements Compat<ModularDataSnapshot> {
    * @returns True if forEach was canceled by action returning true for
    * one of the child nodes.
    */
-  forEach(
-    action: (snapshot: IteratedDataSnapshot) => boolean | void
-  ): boolean {
+  forEach(action: (snapshot: IteratedDataSnapshot) => boolean | void): boolean {
     validateArgCount('DataSnapshot.forEach', 1, 1, arguments.length);
     validateCallback('DataSnapshot.forEach', 'action', action, false);
     return this._delegate.forEach(expDataSnapshot =>

--- a/packages/database-compat/src/api/Reference.ts
+++ b/packages/database-compat/src/api/Reference.ts
@@ -208,8 +208,11 @@ export class DataSnapshot implements Compat<ModularDataSnapshot> {
   }
 }
 
+/**
+ * Represents a child snapshot of a `Reference` that is being iterated over. The key will never be undefined.
+ */
 export interface IteratedDataSnapshot extends DataSnapshot {
-  key: string;
+  key: string; // key of the location of this snapshot.
 }
 
 export interface SnapshotCallback {

--- a/packages/database-compat/src/api/Reference.ts
+++ b/packages/database-compat/src/api/Reference.ts
@@ -156,6 +156,8 @@ export class DataSnapshot implements Compat<ModularDataSnapshot> {
     return this._delegate.priority;
   }
 
+  
+
   /**
    * Iterates through child nodes and calls the specified action for each one.
    *
@@ -165,7 +167,7 @@ export class DataSnapshot implements Compat<ModularDataSnapshot> {
    * one of the child nodes.
    */
   forEach(
-    action: (snapshot: DataSnapshot & { key: string }) => boolean | void
+    action: (snapshot: IteratedDataSnapshot) => boolean | void
   ): boolean {
     validateArgCount('DataSnapshot.forEach', 1, 1, arguments.length);
     validateCallback('DataSnapshot.forEach', 'action', action, false);
@@ -208,6 +210,10 @@ export class DataSnapshot implements Compat<ModularDataSnapshot> {
   get ref(): Reference {
     return this.getRef();
   }
+}
+
+export interface IteratedDataSnapshot extends DataSnapshot {
+  key: string;
 }
 
 export interface SnapshotCallback {

--- a/packages/database-types/index.d.ts
+++ b/packages/database-types/index.d.ts
@@ -22,7 +22,9 @@ export interface DataSnapshot {
   child(path: string): DataSnapshot;
   exists(): boolean;
   exportVal(): any;
-  forEach(action: (a: DataSnapshot) => boolean | void): boolean;
+  forEach(
+    action: (a: DataSnapshot & { key: string }) => boolean | void
+  ): boolean;
   getPriority(): string | number | null;
   hasChild(path: string): boolean;
   hasChildren(): boolean;

--- a/packages/database-types/index.d.ts
+++ b/packages/database-types/index.d.ts
@@ -18,12 +18,19 @@
 import { FirebaseApp } from '@firebase/app-types';
 import { EmulatorMockTokenOptions } from '@firebase/util';
 
+/**
+ * Represents a child snapshot of an iterated `Reference`. The key will never be undefined.
+ */
+export interface IteratedDataSnapshot extends DataSnapshot {
+  key: string;
+}
+
 export interface DataSnapshot {
   child(path: string): DataSnapshot;
   exists(): boolean;
   exportVal(): any;
   forEach(
-    action: (a: DataSnapshot & { key: string }) => boolean | void
+    action: (a: IteratedDataSnapshot) => boolean | void
   ): boolean;
   getPriority(): string | number | null;
   hasChild(path: string): boolean;

--- a/packages/database-types/index.d.ts
+++ b/packages/database-types/index.d.ts
@@ -19,10 +19,10 @@ import { FirebaseApp } from '@firebase/app-types';
 import { EmulatorMockTokenOptions } from '@firebase/util';
 
 /**
- * Represents a child snapshot of an iterated `Reference`. The key will never be undefined.
+ * Represents a child snapshot of a `Reference` that is being iterated over. The key will never be undefined.
  */
 export interface IteratedDataSnapshot extends DataSnapshot {
-  key: string;
+  key: string; // key of the location of this snapshot.
 }
 
 export interface DataSnapshot {

--- a/packages/database-types/index.d.ts
+++ b/packages/database-types/index.d.ts
@@ -29,9 +29,7 @@ export interface DataSnapshot {
   child(path: string): DataSnapshot;
   exists(): boolean;
   exportVal(): any;
-  forEach(
-    action: (a: IteratedDataSnapshot) => boolean | void
-  ): boolean;
+  forEach(action: (a: IteratedDataSnapshot) => boolean | void): boolean;
   getPriority(): string | number | null;
   hasChild(path: string): boolean;
   hasChildren(): boolean;

--- a/packages/database/src/api.standalone.ts
+++ b/packages/database/src/api.standalone.ts
@@ -37,6 +37,7 @@ export { OnDisconnect } from './api/OnDisconnect';
 export {
   DataSnapshot,
   EventType,
+  IteratedDataSnapshot,
   QueryConstraint,
   QueryConstraintType,
   endAt,

--- a/packages/database/src/api/Reference_impl.ts
+++ b/packages/database/src/api/Reference_impl.ts
@@ -376,7 +376,7 @@ export class DataSnapshot {
   }
 
   /**
-   * Enumerates the top-level children in the `DataSnapshot`.
+   * Enumerates the top-level children in the `IteratorDataSnapshot`.
    *
    * Because of the way JavaScript objects work, the ordering of data in the
    * JavaScript object returned by `val()` is not guaranteed to match the
@@ -394,7 +394,7 @@ export class DataSnapshot {
    * true.
    */
   forEach(
-    action: (child: DataSnapshot & { key: string }) => boolean | void
+    action: (child: IteratedDataSnapshot) => boolean | void
   ): boolean {
     if (this._node.isLeafNode()) {
       return false;
@@ -463,6 +463,13 @@ export class DataSnapshot {
   val(): any {
     return this._node.val();
   }
+}
+
+/**
+ * Represents a child snapshot of an iterated `Reference`. The key will never be undefined.
+ */
+export interface IteratedDataSnapshot extends DataSnapshot {
+  key: string;
 }
 
 /**

--- a/packages/database/src/api/Reference_impl.ts
+++ b/packages/database/src/api/Reference_impl.ts
@@ -393,7 +393,9 @@ export class DataSnapshot {
    * @returns true if enumeration was canceled due to your callback returning
    * true.
    */
-  forEach(action: (child: DataSnapshot) => boolean | void): boolean {
+  forEach(
+    action: (child: DataSnapshot & { key: string }) => boolean | void
+  ): boolean {
     if (this._node.isLeafNode()) {
       return false;
     }

--- a/packages/database/src/api/Reference_impl.ts
+++ b/packages/database/src/api/Reference_impl.ts
@@ -393,9 +393,7 @@ export class DataSnapshot {
    * @returns true if enumeration was canceled due to your callback returning
    * true.
    */
-  forEach(
-    action: (child: IteratedDataSnapshot) => boolean | void
-  ): boolean {
+  forEach(action: (child: IteratedDataSnapshot) => boolean | void): boolean {
     if (this._node.isLeafNode()) {
       return false;
     }

--- a/packages/database/src/api/Reference_impl.ts
+++ b/packages/database/src/api/Reference_impl.ts
@@ -376,7 +376,7 @@ export class DataSnapshot {
   }
 
   /**
-   * Enumerates the top-level children in the `IteratorDataSnapshot`.
+   * Enumerates the top-level children in the `IteratedDataSnapshot`.
    *
    * Because of the way JavaScript objects work, the ordering of data in the
    * JavaScript object returned by `val()` is not guaranteed to match the
@@ -464,10 +464,10 @@ export class DataSnapshot {
 }
 
 /**
- * Represents a child snapshot of an iterated `Reference`. The key will never be undefined.
+ * Represents a child snapshot of a `Reference` that is being iterated over. The key will never be undefined.
  */
 export interface IteratedDataSnapshot extends DataSnapshot {
-  key: string;
+  key: string; // key of the location of this snapshot.
 }
 
 /**

--- a/packages/firebase/compat/index.d.ts
+++ b/packages/firebase/compat/index.d.ts
@@ -5819,7 +5819,9 @@ declare namespace firebase.database {
      *   returning true.
      */
     forEach(
-      action: (a: firebase.database.DataSnapshot) => boolean | void
+      action: (
+        a: firebase.database.DataSnapshot & { key: string }
+      ) => boolean | void
     ): boolean;
     /**
      * Gets the priority value of the data in this `DataSnapshot`.

--- a/packages/firebase/compat/index.d.ts
+++ b/packages/firebase/compat/index.d.ts
@@ -5820,7 +5820,7 @@ declare namespace firebase.database {
      */
     forEach(
       action: (
-        a: firebase.database.DataSnapshot & { key: string }
+        a: firebase.database.IteratorDataSnapshot
       ) => boolean | void
     ): boolean;
     /**

--- a/packages/firebase/compat/index.d.ts
+++ b/packages/firebase/compat/index.d.ts
@@ -5819,9 +5819,7 @@ declare namespace firebase.database {
      *   returning true.
      */
     forEach(
-      action: (
-        a: firebase.database.IteratorDataSnapshot
-      ) => boolean | void
+      action: (a: firebase.database.IteratorDataSnapshot) => boolean | void
     ): boolean;
     /**
      * Gets the priority value of the data in this `DataSnapshot`.


### PR DESCRIPTION
Restores original change that required the `key` parameter in the `forEach` callback.

As this is a potentially breaking change for extensions, we will wait for a major release for this to be available to users.