### PR TITLE
Fix proactive refresh logic, add some tests

### DIFF
--- a/.changeset/happy-eels-confess.md
+++ b/.changeset/happy-eels-confess.md
@@ -1,0 +1,5 @@
+---
+"@firebase/auth": patch
+---
+
+Fix proactive refresh logic in Auth when RTDB/Firestore/Storage are in use

--- a/packages/auth/src/core/auth/auth_impl.ts
+++ b/packages/auth/src/core/auth/auth_impl.ts
@@ -581,9 +581,9 @@ export class AuthImpl implements AuthInternal, _FirebaseService {
   ): Promise<void> {
     if (this.currentUser && this.currentUser !== user) {
       this._currentUser._stopProactiveRefresh();
-      if (user && this.isProactiveRefreshEnabled) {
-        user._startProactiveRefresh();
-      }
+    }
+    if (user && this.isProactiveRefreshEnabled) {
+      user._startProactiveRefresh();
     }
 
     this.currentUser = user;


### PR DESCRIPTION
We noticed the logic in the proactive refresh code was not quite correct (it wasn't turning on for newly-signed-in users). Turns out we also never tested this. D'oh! I've added some tests and walked through the code with Maneesh and I think this puts us in a better spot.