### PR TITLE
Update Auth Firefox cross browser action to only run on changed auth files

### DIFF
--- a/.github/workflows/test-changed-auth.yml
+++ b/.github/workflows/test-changed-auth.yml
@@ -63,10 +63,6 @@ jobs:
       - name: build
         run: yarn build:changed auth
       - name: Run tests on auth changed packages
-        run: xvfb-run yarn --cwd packages/auth test:browser:unit
-        env:
-          BROWSERS: 'Firefox'
-      - name: Run tests on auth-compat changed packages
-        run: xvfb-run yarn --cwd packages/auth-compat test:browser:unit
+        run: xvfb-run yarn test:changed auth
         env:
           BROWSERS: 'Firefox'

--- a/packages/auth/src/api/errors.ts
+++ b/packages/auth/src/api/errors.ts
@@ -17,6 +17,7 @@
 
 import { AuthErrorCode } from '../core/errors';
 
+// Hmmm
 /**
  * Errors that can be returned by the backend
  */

--- a/packages/auth/src/api/errors.ts
+++ b/packages/auth/src/api/errors.ts
@@ -17,7 +17,6 @@
 
 import { AuthErrorCode } from '../core/errors';
 
-// Hmmm
 /**
  * Errors that can be returned by the backend
  */

--- a/scripts/run_tests_in_ci.js
+++ b/scripts/run_tests_in_ci.js
@@ -21,6 +21,8 @@ const { spawn } = require('child-process-promise');
 const { writeFileSync } = require('fs');
 
 const LOGDIR = process.env.CI ? process.env.HOME : '/tmp';
+// Maps the packages that have standalone cross browser testing to the necessary test script.
+// Note, the standalone tests are not covered by `test:changed core`
 const crossBrowserPackages = { 'packages/auth': 'test:browser:unit' };
 
 function writeLogs(status, name, logText) {

--- a/scripts/run_tests_in_ci.js
+++ b/scripts/run_tests_in_ci.js
@@ -21,8 +21,8 @@ const { spawn } = require('child-process-promise');
 const { writeFileSync } = require('fs');
 
 const LOGDIR = process.env.CI ? process.env.HOME : '/tmp';
-// Maps the packages that have standalone cross browser testing to the necessary test script.
-// Note, the standalone tests are not covered by `test:changed core`
+// Maps the packages where we should not run `test:all` and instead isolate the cross-browser tests.
+// TODO(dwyfrequency): Update object with `storage` and `firestore` packages.
 const crossBrowserPackages = { 'packages/auth': 'test:browser:unit' };
 
 function writeLogs(status, name, logText) {

--- a/scripts/run_tests_in_ci.js
+++ b/scripts/run_tests_in_ci.js
@@ -21,6 +21,7 @@ const { spawn } = require('child-process-promise');
 const { writeFileSync } = require('fs');
 
 const LOGDIR = process.env.CI ? process.env.HOME : '/tmp';
+const crossBrowserPackages = { 'packages/auth': 'test:browser:unit' };
 
 function writeLogs(status, name, logText) {
   const safeName = name.replace(/@/g, 'at_').replace(/\//g, '_');
@@ -49,13 +50,20 @@ const argv = yargs.options({
 
 (async () => {
   const myPath = argv.d;
-  const scriptName = argv.s;
+  let scriptName = argv.s;
   const dir = path.resolve(myPath);
   const { name } = require(`${dir}/package.json`);
 
   let stdout = '';
   let stderr = '';
   try {
+    if (process.env?.BROWSERS) {
+      for (const package in crossBrowserPackages) {
+        if (dir.endsWith(package)) {
+          scriptName = crossBrowserPackages[package];
+        }
+      }
+    }
     const testProcess = spawn('yarn', ['--cwd', dir, scriptName]);
 
     testProcess.childProcess.stdout.on('data', data => {


### PR DESCRIPTION
Update Auth Firefox cross browser action to only run on changed auth files. In the previous iteration, we ran the unit tests irrespective of changed auth files which is incongruent with the purpose of the github action