### PR TITLE
Firestore: Fix FAILED_PRECONDITION when writing to a deleted document in a transaction

### DIFF
--- a/.changeset/smart-plants-sparkle.md
+++ b/.changeset/smart-plants-sparkle.md
@@ -1,0 +1,5 @@
+---
+'@firebase/firestore': patch
+---
+
+Fix FAILED_PRECONDITION when writing to a deleted document in a transaction (#5871)

--- a/packages/firestore/src/core/transaction.ts
+++ b/packages/firestore/src/core/transaction.ts
@@ -34,6 +34,19 @@ import { Code, FirestoreError } from '../util/error';
 
 import { SnapshotVersion } from './snapshot_version';
 
+function nullableSnapshotVersionsEqual(
+  v1: SnapshotVersion | null,
+  v2: SnapshotVersion | null
+): boolean {
+  if (v1 === v2) {
+    return true;
+  } else if (v1 === null || v2 === null) {
+    return false;
+  } else {
+    return v1.isEqual(v2);
+  }
+}
+
 /**
  * Internal transaction object responsible for accumulating the mutations to
  * perform and the base versions for any documents read.
@@ -127,12 +140,8 @@ export class Transaction {
     }
 
     const existingVersion = this.readVersions.get(doc.key.toString());
-    if (existingVersion !== undefined && existingVersion !== docVersion) {
-      if (
-        docVersion == null ||
-        existingVersion == null ||
-        !docVersion.isEqual(existingVersion)
-      ) {
+    if (existingVersion !== undefined) {
+      if (!nullableSnapshotVersionsEqual(existingVersion, docVersion)) {
         // This transaction will fail no matter what.
         throw new FirestoreError(
           Code.ABORTED,

--- a/packages/firestore/test/integration/api/transactions.test.ts
+++ b/packages/firestore/test/integration/api/transactions.test.ts
@@ -23,6 +23,7 @@ import {
   QueryDocumentSnapshot,
   Transaction,
   collection,
+  deleteDoc,
   doc,
   DocumentReference,
   DocumentSnapshot,
@@ -87,6 +88,16 @@ apiDescribe('Database transactions', (persistence: boolean) => {
     await transaction.get(docRef);
   }
 
+  enum FromDocumentType {
+    // The operation will be performed on a document that exists.
+    EXISTING = 'existing',
+    // The operation will be performed on a document that has never existed.
+    NON_EXISTENT = 'non_existent',
+    // The operation will be performed on a document that existed, but was
+    // deleted.
+    DELETED = 'deleted'
+  }
+
   /**
    * Used for testing that all possible combinations of executing transactions
    * result in the desired document value or error.
@@ -101,16 +112,21 @@ apiDescribe('Database transactions', (persistence: boolean) => {
     constructor(readonly db: Firestore) {}
 
     private docRef!: DocumentReference;
-    private fromExistingDoc: boolean = false;
+    private fromDocumentType: FromDocumentType = FromDocumentType.NON_EXISTENT;
     private stages: TransactionStage[] = [];
 
     withExistingDoc(): this {
-      this.fromExistingDoc = true;
+      this.fromDocumentType = FromDocumentType.EXISTING;
       return this;
     }
 
     withNonexistentDoc(): this {
-      this.fromExistingDoc = false;
+      this.fromDocumentType = FromDocumentType.NON_EXISTENT;
+      return this;
+    }
+
+    withDeletedDoc(): this {
+      this.fromDocumentType = FromDocumentType.DELETED;
       return this;
     }
 
@@ -176,8 +192,17 @@ apiDescribe('Database transactions', (persistence: boolean) => {
 
     private async prepareDoc(): Promise<void> {
       this.docRef = doc(collection(this.db, 'tester-docref'));
-      if (this.fromExistingDoc) {
-        await setDoc(this.docRef, { foo: 'bar0' });
+      switch (this.fromDocumentType) {
+        case FromDocumentType.EXISTING:
+          await setDoc(this.docRef, { foo: 'bar0' });
+          break;
+        case FromDocumentType.NON_EXISTENT:
+          // Nothing to do; document does not exist.
+          break;
+        case FromDocumentType.DELETED:
+          await setDoc(this.docRef, { foo: 'bar0' });
+          await deleteDoc(this.docRef);
+          break;
       }
     }
 
@@ -286,6 +311,42 @@ apiDescribe('Database transactions', (persistence: boolean) => {
         .withNonexistentDoc()
         .run(get, set1, set2)
         .expectDoc({ foo: 'bar2' });
+    });
+  });
+
+  it('runs transactions after getting a deleted document', async () => {
+    return withTestDb(persistence, async db => {
+      const tt = new TransactionTester(db);
+
+      await tt.withDeletedDoc().run(get, delete1, delete1).expectNoDoc();
+      await tt
+        .withDeletedDoc()
+        .run(get, delete1, update2)
+        .expectError('invalid-argument');
+      await tt
+        .withDeletedDoc()
+        .run(get, delete1, set2)
+        .expectDoc({ foo: 'bar2' });
+
+      await tt
+        .withDeletedDoc()
+        .run(get, update1, delete1)
+        .expectError('invalid-argument');
+      await tt
+        .withDeletedDoc()
+        .run(get, update1, update2)
+        .expectError('invalid-argument');
+      await tt
+        .withDeletedDoc()
+        .run(get, update1, set1)
+        .expectError('invalid-argument');
+
+      await tt.withDeletedDoc().run(get, set1, delete1).expectNoDoc();
+      await tt
+        .withDeletedDoc()
+        .run(get, set1, update2)
+        .expectDoc({ foo: 'bar2' });
+      await tt.withDeletedDoc().run(get, set1, set2).expectDoc({ foo: 'bar2' });
     });
   });
 

--- a/packages/firestore/test/integration/api/transactions.test.ts
+++ b/packages/firestore/test/integration/api/transactions.test.ts
@@ -316,6 +316,11 @@ apiDescribe('Database transactions', (persistence: boolean) => {
     });
   });
 
+  // This test is identical to the test above, except that withNonexistentDoc()
+  // is replaced by withDeletedDoc(), to guard against regression of
+  // https://github.com/firebase/firebase-js-sdk/issues/5871, where transactions
+  // would incorrectly fail with FAILED_PRECONDITION when operations were
+  // performed on a deleted document (rather than a non-existent document).
   it('runs transactions after getting a deleted document', async () => {
     return withTestDb(persistence, async db => {
       const tt = new TransactionTester(db);

--- a/packages/firestore/test/integration/api/transactions.test.ts
+++ b/packages/firestore/test/integration/api/transactions.test.ts
@@ -203,6 +203,8 @@ apiDescribe('Database transactions', (persistence: boolean) => {
           await setDoc(this.docRef, { foo: 'bar0' });
           await deleteDoc(this.docRef);
           break;
+        default:
+          throw new Error(`invalid fromDocumentType: ${this.fromDocumentType}`);
       }
     }
 

--- a/packages/firestore/test/lite/integration.test.ts
+++ b/packages/firestore/test/lite/integration.test.ts
@@ -524,6 +524,19 @@ describe('Transaction', () => {
     });
   });
 
+  it('can read deleted doc then write', () => {
+    return withTestDocAndInitialData({ counter: 1 }, async doc => {
+      await deleteDoc(doc);
+      await runTransaction(doc.firestore, async transaction => {
+        const snap = await transaction.get(doc);
+        expect(snap.exists()).to.be.false;
+        transaction.set(doc, { counter: 1 });
+      });
+      const result = await getDoc(doc);
+      expect(result.get('counter')).to.equal(1);
+    });
+  });
+
   it('retries when document is modified', () => {
     return withTestDoc(async doc => {
       let retryCounter = 0;

--- a/packages/firestore/test/lite/integration.test.ts
+++ b/packages/firestore/test/lite/integration.test.ts
@@ -524,6 +524,11 @@ describe('Transaction', () => {
     });
   });
 
+  // This test is identical to the test above, except that a non-existent
+  // document is replaced by a deleted document, to guard against regression of
+  // https://github.com/firebase/firebase-js-sdk/issues/5871, where transactions
+  // would incorrectly fail with FAILED_PRECONDITION when operations were
+  // performed on a deleted document (rather than a non-existent document).
   it('can read deleted doc then write', () => {
     return withTestDocAndInitialData({ counter: 1 }, async doc => {
       await deleteDoc(doc);


### PR DESCRIPTION
Note: This fix needs to be ported to android and ios.

Fixes #5871