### PR TITLE
Included experimental support for Deno

### DIFF
--- a/.changeset/good-bears-obey.md
+++ b/.changeset/good-bears-obey.md
@@ -1,0 +1,5 @@
+---
+"@firebase/database": patch
+---
+
+Included experimental support for Deno

--- a/packages/database/src/core/util/util.ts
+++ b/packages/database/src/core/util/util.ts
@@ -618,10 +618,20 @@ export const setTimeoutNonBlocking = function (
   time: number
 ): number | object {
   const timeout: number | object = setTimeout(fn, time);
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  if (typeof timeout === 'object' && (timeout as any)['unref']) {
+  // @ts-ignore Deno and unrefTimer are only defined in Deno environments.
+  // Note: at the time of this comment, unrefTimer is under the unstable set of APIs. Run with --unstable to enable the API.
+  if (
+    typeof timeout === 'number' &&
+    typeof Deno !== 'undefined' &&
+    Deno['unrefTimer']
+  ) {
+    // @ts-ignore Deno and unrefTimer are only defined in Deno environments.
+    Deno.unrefTimer(timeout);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } else if (typeof timeout === 'object' && (timeout as any)['unref']) {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (timeout as any)['unref']();
   }
+
   return timeout;
 };

--- a/packages/database/src/core/util/util.ts
+++ b/packages/database/src/core/util/util.ts
@@ -618,11 +618,12 @@ export const setTimeoutNonBlocking = function (
   time: number
 ): number | object {
   const timeout: number | object = setTimeout(fn, time);
-  // @ts-ignore Deno and unrefTimer are only defined in Deno environments.
   // Note: at the time of this comment, unrefTimer is under the unstable set of APIs. Run with --unstable to enable the API.
   if (
     typeof timeout === 'number' &&
+    // @ts-ignore Is only defined in Deno environments.
     typeof Deno !== 'undefined' &&
+    // @ts-ignore Deno and unrefTimer are only defined in Deno environments.
     Deno['unrefTimer']
   ) {
     // @ts-ignore Deno and unrefTimer are only defined in Deno environments.

--- a/packages/database/test/deno.test.ts
+++ b/packages/database/test/deno.test.ts
@@ -1,0 +1,35 @@
+import { expect, use } from 'chai';
+import * as sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+
+import { setTimeoutNonBlocking } from '../src/core/util/util';
+use(sinonChai);
+describe('Deno tests', () => {
+    let oldSetTimeout;
+    beforeEach(() => {
+        oldSetTimeout = globalThis.setTimeout;
+    });
+    afterEach(() => {
+        globalThis.setTimeout = oldSetTimeout;
+    });
+    it('should call the deno unrefTimer() if in Deno', () => {
+        // @ts-ignore override nodejs behavior
+        global.Deno = {
+            unrefTimer: sinon.spy()
+        };
+        // @ts-ignore override nodejs behavior
+        global.setTimeout = () => 1;
+        setTimeoutNonBlocking(() => {}, 0);
+        expect(globalThis.Deno.unrefTimer).to.have.been.called;
+    });
+    it('should not call the deno unrefTimer() if not in Deno', () => {
+        // @ts-ignore override nodejs behavior
+        global.Deno2 = {
+            unrefTimer: sinon.spy()
+        };
+        // @ts-ignore override node.js behavior
+        global.setTimeout = () => 1;
+        setTimeoutNonBlocking(() => {}, 0);
+        expect(globalThis.Deno2.unrefTimer).to.not.have.been.called;
+    });
+});

--- a/packages/database/test/deno.test.ts
+++ b/packages/database/test/deno.test.ts
@@ -1,3 +1,20 @@
+/**
+ * @license
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { expect, use } from 'chai';
 import * as sinon from 'sinon';
 import sinonChai from 'sinon-chai';
@@ -5,31 +22,31 @@ import sinonChai from 'sinon-chai';
 import { setTimeoutNonBlocking } from '../src/core/util/util';
 use(sinonChai);
 describe('Deno tests', () => {
-    let oldSetTimeout;
-    beforeEach(() => {
-        oldSetTimeout = globalThis.setTimeout;
-    });
-    afterEach(() => {
-        globalThis.setTimeout = oldSetTimeout;
-    });
-    it('should call the deno unrefTimer() if in Deno', () => {
-        // @ts-ignore override nodejs behavior
-        global.Deno = {
-            unrefTimer: sinon.spy()
-        };
-        // @ts-ignore override nodejs behavior
-        global.setTimeout = () => 1;
-        setTimeoutNonBlocking(() => {}, 0);
-        expect(globalThis.Deno.unrefTimer).to.have.been.called;
-    });
-    it('should not call the deno unrefTimer() if not in Deno', () => {
-        // @ts-ignore override nodejs behavior
-        global.Deno2 = {
-            unrefTimer: sinon.spy()
-        };
-        // @ts-ignore override node.js behavior
-        global.setTimeout = () => 1;
-        setTimeoutNonBlocking(() => {}, 0);
-        expect(globalThis.Deno2.unrefTimer).to.not.have.been.called;
-    });
+  let oldSetTimeout;
+  beforeEach(() => {
+    oldSetTimeout = globalThis.setTimeout;
+  });
+  afterEach(() => {
+    globalThis.setTimeout = oldSetTimeout;
+  });
+  it('should call the deno unrefTimer() if in Deno', () => {
+    // @ts-ignore override nodejs behavior
+    global.Deno = {
+      unrefTimer: sinon.spy()
+    };
+    // @ts-ignore override nodejs behavior
+    global.setTimeout = () => 1;
+    setTimeoutNonBlocking(() => {}, 0);
+    expect(globalThis.Deno.unrefTimer).to.have.been.called;
+  });
+  it('should not call the deno unrefTimer() if not in Deno', () => {
+    // @ts-ignore override nodejs behavior
+    global.Deno2 = {
+      unrefTimer: sinon.spy()
+    };
+    // @ts-ignore override node.js behavior
+    global.setTimeout = () => 1;
+    setTimeoutNonBlocking(() => {}, 0);
+    expect(globalThis.Deno2.unrefTimer).to.not.have.been.called;
+  });
 });

--- a/scripts/emulator-testing/emulators/database-emulator.ts
+++ b/scripts/emulator-testing/emulators/database-emulator.ts
@@ -19,7 +19,7 @@ import * as request from 'request';
 
 import { Emulator } from './emulator';
 
-import * as rulesJSON from '../../../config/database.rules.json';
+import rulesJSON from '../../../config/database.rules.json';
 
 export class DatabaseEmulator extends Emulator {
   namespace: string;


### PR DESCRIPTION
Fixes the issue where the database hangs when all actions are completed and `setTimeout` fails to terminate via `unref` #5783

Deno has the experimental `Deno.unrefTimer` as an alternative to Node.JS's `timer.unref` in the unstable API version of Deno. With the `--unstable` argument, you can use `unrefTimer` in the same way as `unref` 