### PR TITLE
Fixed issue where WebSocketImpl was getting overridden by faye-websocket

### DIFF
--- a/packages/database/src/realtime/WebSocketConnection.ts
+++ b/packages/database/src/realtime/WebSocketConnection.ts
@@ -52,7 +52,9 @@ if (typeof MozWebSocket !== 'undefined') {
 }
 
 export function setWebSocketImpl(impl) {
-  WebSocketImpl = impl;
+  if (!WebSocketImpl) {
+    WebSocketImpl = impl;
+  }
 }
 
 /**


### PR DESCRIPTION
On RTDB, once the bundle is created, we check if `MozWebSocket` or `WebSocket` implementations are available. `index.node.ts` ends up overriding this with `faye-websocket`.

In Deno, `index.node.ts` ends up getting imported, but also has a default `WebSocket` implementation. So, first the native one is chosen, then overridden with `faye-websocket`. However, for whatever reason, `faye-websocket` doesn't properly connect in Deno environments, so we need to prevent the override, which is what this PR does.