### PR TITLE
Mila/count add tests

### DIFF
--- a/packages/firestore/test/lite/integration.test.ts
+++ b/packages/firestore/test/lite/integration.test.ts
@@ -2047,11 +2047,13 @@ describe('withConverter() support', () => {
 
 describe('countQuery()', () => {
   const testDocs = [
-    { author: 'authorA', title: 'titleA' },
-    { author: 'authorA', title: 'titleB' },
-    { author: 'authorB', title: 'titleC' },
-    { author: 'authorB', title: 'titleD' },
-    { author: 'authorB', title: 'titleE' }
+    { id: 3 ,author: 'authorA', title: 'titleA'},
+    { id: 4, author: 'authorA', title: 'titleB'},
+    { id: 2 ,author: 'authorB', title: 'titleC'},
+    { id: null,author: 'authorB', title: 'titleD'},
+    { id: 1, author: 'authorB'},
+    { id: 5, author: null, title: 'titleE'},
+
   ];
 
   it('AggregateQuery and AggregateQuerySnapshot inherits the original query', () => {
@@ -2073,11 +2075,11 @@ describe('countQuery()', () => {
     });
   });
 
-  it('test collection count with 5 docs', () => {
+  it('test collection count with 7 docs', () => {
     return withTestCollectionAndInitialData(testDocs, async collection => {
       const countQuery_ = countQuery(query(collection));
       const snapshot = await getAggregateFromServerDirect(countQuery_);
-      expect(snapshot.getCount()).to.equal(5);
+      expect(snapshot.getCount()).to.equal(7);
     });
   });
 
@@ -2113,6 +2115,100 @@ describe('countQuery()', () => {
       const countQuery_ = countQuery(query_);
       const snapshot = await getAggregateFromServerDirect(countQuery_);
       expect(snapshot.getCount()).to.equal(2);
+    });
+  });
+
+  
+  it.only('count with filter and order by in different fields', () => {
+    return withTestCollectionAndInitialData(testDocs, async collection => {
+      const query1 = query(
+        collection,
+        where('author', '==', 'authorB'),
+        orderBy('id')
+      );
+      const query2 = query(
+        collection,
+        where('author', '==', 'authorB'),
+        orderBy('title')
+      );
+      const countQuery1 = countQuery(query1);
+      const countQuery2 = countQuery(query2);
+      const snapshot1 = await getAggregateFromServerDirect(countQuery1);
+      const snapshot2 = await getAggregateFromServerDirect(countQuery2);
+
+      expect(snapshot1.getCount()).to.equal(3);
+      expect(snapshot2.getCount()).to.equal(2);
+      //this is not correct
+      // expect(snapshot1.getCount()).to.equal(snapshot2.getCount());
+    });
+  });
+
+  it.only('count with filter and order by nullable field', () => {
+    return withTestCollectionAndInitialData(testDocs, async collection => {
+      const query_ = query(
+        collection,
+        where('id', '<=', 2),
+        orderBy('id'),
+      );
+      const countQuery_ = countQuery(query_);
+      const snapshot = await getAggregateFromServerDirect(countQuery_);
+      expect(snapshot.getCount()).to.equal(2);
+    });
+  });
+
+  it.only('count with filter and order by no value field', () => {
+    return withTestCollectionAndInitialData(testDocs, async collection => {
+      const query_ = query(
+        collection,
+        where('id', '<=', 2),
+        orderBy('id'),
+        orderBy('title')
+      );
+      const countQuery_ = countQuery(query_);
+      const snapshot = await getAggregateFromServerDirect(countQuery_);
+      expect(snapshot.getCount()).to.equal(2);
+    });
+  });
+
+  it.only('count with order by and startAt, startAfter', () => {
+    return withTestCollectionAndInitialData(testDocs, async collection => {
+      const query1 = query(
+        collection,
+        orderBy('id'),
+        startAt(2)
+      );
+      const query2 = query(
+        collection,
+        orderBy('id'),
+        startAfter(2)
+      );
+      const countQuery1 = countQuery(query1);
+      const countQuery2 = countQuery(query2);
+      const snapshot1 = await getAggregateFromServerDirect(countQuery1);
+      const snapshot2 = await getAggregateFromServerDirect(countQuery2);
+      expect(snapshot1.getCount()).to.equal(4);
+      expect(snapshot2.getCount()).to.equal(3);
+    });
+  });
+
+  it.only('count with order by and endAt, endBefore', () => {
+    return withTestCollectionAndInitialData(testDocs, async collection => {
+      const query1 = query(
+        collection,
+        orderBy('id'),
+        endAt(2)
+      );
+      const query2 = query(
+        collection,
+        orderBy('id'),
+        endBefore(2)
+      );
+      const countQuery1 = countQuery(query1);
+      const countQuery2 = countQuery(query2);
+      const snapshot1 = await getAggregateFromServerDirect(countQuery1);
+      const snapshot2 = await getAggregateFromServerDirect(countQuery2);
+      expect(snapshot1.getCount()).to.equal(3);
+      expect(snapshot2.getCount()).to.equal(2);
     });
   });
 

--- a/packages/firestore/test/lite/integration.test.ts
+++ b/packages/firestore/test/lite/integration.test.ts
@@ -2328,16 +2328,16 @@ describe('countQuery()', () => {
       const countQuery_ = countQuery(query(collection));
 
       //This will pass
-      // const snapshot = getAggregateFromServerDirect(countQuery_)
+      // const promise = getAggregateFromServerDirect(countQuery_)
       // await terminate(collection.firestore)
-      // expect((await snapshot).getCount()).to.equal(3);
+      // expect((await promise).getCount()).to.equal(3);
 
       //this will pass
-      // const [snapshot,voidResult] = await Promise.all([
+      // const [promise,voidResult] = await Promise.all([
       //   getAggregateFromServerDirect(countQuery_),
       //   terminate(collection.firestore),
       // ])
-      // expect(snapshot.getCount()).to.equal(3);
+      // expect(promise.getCount()).to.equal(3);
 
       //if terminate comes first, it will throw error
       // expect(() => Promise.all([
@@ -2348,13 +2348,14 @@ describe('countQuery()', () => {
       // );
 
       // not sure why, this is not getting to the "then" block
+      // and therefore it is not checking the "expect" at all
       Promise.all([
         getAggregateFromServerDirect(countQuery_),
         terminate(collection.firestore)
       ])
-        .then(([snapshot, voidResult]) => {
-          console.log('snapshot', snapshot);
-          expect(snapshot.getCount()).to.equal(100);
+        .then(([promise, voidResult]) => {
+          console.log('snapshot', promise);
+          expect(promise.getCount()).to.equal(100);
         })
         .catch(e => {
           expect((e as Error)?.message).to.equal(

--- a/packages/firestore/test/lite/integration.test.ts
+++ b/packages/firestore/test/lite/integration.test.ts
@@ -2047,12 +2047,12 @@ describe('withConverter() support', () => {
 
 describe('countQuery()', () => {
   const testDocs = [
-    { id: 3 ,author: 'authorA', title: 'titleA'},
-    { id: 4, author: 'authorA', title: 'titleB'},
-    { id: 2 ,author: 'authorB', title: 'titleC'},
-    { id: null,author: 'authorB', title: 'titleD'},
-    { id: 1, author: 'authorB'},
-    { id: 5, author: null, title: 'titleE'},
+    { id: 3, author: 'authorA', title: 'titleA' },
+    { id: 4, author: 'authorA', title: 'titleB' },
+    { id: 2, author: 'authorB', title: 'titleC' },
+    { id: null, author: 'authorB', title: 'titleD' },
+    { id: 1, author: 'authorB' },
+    { id: 5, author: null, title: 'titleE' }
   ];
 
   it('AggregateQuery and AggregateQuerySnapshot inherits the original query', () => {
@@ -2117,7 +2117,6 @@ describe('countQuery()', () => {
     });
   });
 
-  
   it('count with filter and order by', () => {
     return withTestCollectionAndInitialData(testDocs, async collection => {
       const query1 = query(
@@ -2133,16 +2132,8 @@ describe('countQuery()', () => {
 
   it('count with order by and startAt, startAfter', () => {
     return withTestCollectionAndInitialData(testDocs, async collection => {
-      const query1 = query(
-        collection,
-        orderBy('id'),
-        startAt(2)
-      );
-      const query2 = query(
-        collection,
-        orderBy('id'),
-        startAfter(2)
-      );
+      const query1 = query(collection, orderBy('id'), startAt(2));
+      const query2 = query(collection, orderBy('id'), startAfter(2));
       const countQuery1 = countQuery(query1);
       const countQuery2 = countQuery(query2);
       const snapshot1 = await getAggregateFromServerDirect(countQuery1);
@@ -2154,18 +2145,8 @@ describe('countQuery()', () => {
 
   it('count with order by and endAt, endBefore', () => {
     return withTestCollectionAndInitialData(testDocs, async collection => {
-      const query1 = query(
-        collection,
-        orderBy('id'),
-        startAt(1),
-        endAt(2)
-      );
-      const query2 = query(
-        collection,
-        orderBy('id'),
-        startAt(1),
-        endBefore(2)
-      );
+      const query1 = query(collection, orderBy('id'), startAt(1), endAt(2));
+      const query2 = query(collection, orderBy('id'), startAt(1), endBefore(2));
       const countQuery1 = countQuery(query1);
       const countQuery2 = countQuery(query2);
       const snapshot1 = await getAggregateFromServerDirect(countQuery1);
@@ -2195,7 +2176,7 @@ describe('countQuery()', () => {
         `abc/123/${collectionGroupId}/cg-doc1`,
         `invalid${collectionGroupId}/cg-doc4`,
         `abc/123/invalid${collectionGroupId}/cg-doc2`,
-        `abc/123/invalid/${collectionGroupId}`,
+        `abc/123/invalid/${collectionGroupId}`
       ];
       const batch = writeBatch(db);
       for (const docPath of docPaths) {
@@ -2203,10 +2184,9 @@ describe('countQuery()', () => {
       }
       await batch.commit();
 
-      const countQuery_ = countQuery(collectionGroup(db, collectionGroupId))
+      const countQuery_ = countQuery(collectionGroup(db, collectionGroupId));
       const snapshot = await getAggregateFromServerDirect(countQuery_);
       expect(snapshot.getCount()).to.equal(2);
-      ;
     });
   });
 

--- a/packages/firestore/test/lite/integration.test.ts
+++ b/packages/firestore/test/lite/integration.test.ts
@@ -2046,21 +2046,12 @@ describe('withConverter() support', () => {
 });
 
 describe('countQuery()', () => {
-  const testDocs = [
-    { id: 3, author: 'authorA', title: 'titleA' },
-    { id: 4, author: 'authorA', title: 'titleB' },
-    { id: 2, author: 'authorB', title: 'titleC' },
-    { id: null, author: 'authorB', title: 'titleD' },
-    { id: 1, author: 'authorB' },
-    { id: 5, author: null, title: 'titleE' }
-  ];
-
   it('AggregateQuery and AggregateQuerySnapshot inherits the original query', () => {
     return withTestCollection(async coll => {
       const query_ = query(coll);
       const countQuery_ = countQuery(query_);
-      expect(countQuery_.query).to.equal(query_);
       const snapshot = await getAggregateFromServerDirect(countQuery_);
+      expect(countQuery_.query).to.equal(query_);
       expect(snapshot.query).to.equal(countQuery_);
       expect(snapshot.query.query).to.equal(query_);
     });
@@ -2074,15 +2065,25 @@ describe('countQuery()', () => {
     });
   });
 
-  it('test collection count with 6 docs', () => {
+  it('test collection count with 3 docs', () => {
+    const testDocs = [
+      { author: 'authorA', title: 'titleA' },
+      { author: 'authorA', title: 'titleB' },
+      { author: 'authorB', title: 'titleC' }
+    ];
     return withTestCollectionAndInitialData(testDocs, async collection => {
       const countQuery_ = countQuery(query(collection));
       const snapshot = await getAggregateFromServerDirect(countQuery_);
-      expect(snapshot.getCount()).to.equal(6);
+      expect(snapshot.getCount()).to.equal(3);
     });
   });
 
   it('test collection count with filter', () => {
+    const testDocs = [
+      { author: 'authorA', title: 'titleA' },
+      { author: 'authorA', title: 'titleB' },
+      { author: 'authorB', title: 'titleC' }
+    ];
     return withTestCollectionAndInitialData(testDocs, async collection => {
       const query_ = query(collection, where('author', '==', 'authorA'));
       const countQuery_ = countQuery(query_);
@@ -2092,6 +2093,11 @@ describe('countQuery()', () => {
   });
 
   it('test collection count with filter and a small limit size', () => {
+    const testDocs = [
+      { author: 'authorA', title: 'titleA' },
+      { author: 'authorA', title: 'titleB' },
+      { author: 'authorB', title: 'titleC' }
+    ];
     return withTestCollectionAndInitialData(testDocs, async collection => {
       const query_ = query(
         collection,
@@ -2105,6 +2111,11 @@ describe('countQuery()', () => {
   });
 
   it('test collection count with filter and a large limit size', () => {
+    const testDocs = [
+      { author: 'authorA', title: 'titleA' },
+      { author: 'authorA', title: 'titleB' },
+      { author: 'authorB', title: 'titleC' }
+    ];
     return withTestCollectionAndInitialData(testDocs, async collection => {
       const query_ = query(
         collection,
@@ -2117,46 +2128,87 @@ describe('countQuery()', () => {
     });
   });
 
-  it('count with filter and order by', () => {
+  it('count with order by', () => {
+    const testDocs = [
+      { author: 'authorA', title: 'titleA' },
+      { author: 'authorA', title: 'titleB' },
+      { author: 'authorB', title: null },
+      { author: 'authorB' }
+    ];
     return withTestCollectionAndInitialData(testDocs, async collection => {
-      const query1 = query(
-        collection,
-        where('author', '==', 'authorB'),
-        orderBy('title')
-      );
-      const countQuery_ = countQuery(query1);
+      const query_ = query(collection, orderBy('title'));
+      const countQuery_ = countQuery(query_);
+      const snapshot = await getAggregateFromServerDirect(countQuery_);
+      expect(snapshot.getCount()).to.equal(3);
+    });
+  });
+
+  it('count with order by and startAt', () => {
+    const testDocs = [
+      { id: 3, author: 'authorA', title: 'titleA' },
+      { id: 1, author: 'authorA', title: 'titleB' },
+      { id: 2, author: 'authorB', title: 'titleC' },
+      { id: null, author: 'authorB', title: 'titleD' }
+    ];
+    return withTestCollectionAndInitialData(testDocs, async collection => {
+      const query_ = query(collection, orderBy('id'), startAt(2));
+      const countQuery_ = countQuery(query_);
       const snapshot = await getAggregateFromServerDirect(countQuery_);
       expect(snapshot.getCount()).to.equal(2);
     });
   });
 
-  it('count with order by and startAt, startAfter', () => {
+  it('count with order by and startAfter', () => {
+    const testDocs = [
+      { id: 3, author: 'authorA', title: 'titleA' },
+      { id: 1, author: 'authorA', title: 'titleB' },
+      { id: 2, author: 'authorB', title: 'titleC' },
+      { id: null, author: 'authorB', title: 'titleD' }
+    ];
     return withTestCollectionAndInitialData(testDocs, async collection => {
-      const query1 = query(collection, orderBy('id'), startAt(2));
-      const query2 = query(collection, orderBy('id'), startAfter(2));
-      const countQuery1 = countQuery(query1);
-      const countQuery2 = countQuery(query2);
-      const snapshot1 = await getAggregateFromServerDirect(countQuery1);
-      const snapshot2 = await getAggregateFromServerDirect(countQuery2);
-      expect(snapshot1.getCount()).to.equal(4);
-      expect(snapshot2.getCount()).to.equal(3);
+      const query_ = query(collection, orderBy('id'), startAfter(2));
+      const countQuery_ = countQuery(query_);
+      const snapshot = await getAggregateFromServerDirect(countQuery_);
+      expect(snapshot.getCount()).to.equal(1);
     });
   });
 
-  it('count with order by and endAt, endBefore', () => {
+  it('count with order by and endAt', () => {
+    const testDocs = [
+      { id: 3, author: 'authorA', title: 'titleA' },
+      { id: 1, author: 'authorA', title: 'titleB' },
+      { id: 2, author: 'authorB', title: 'titleC' },
+      { id: null, author: 'authorB', title: 'titleD' }
+    ];
     return withTestCollectionAndInitialData(testDocs, async collection => {
-      const query1 = query(collection, orderBy('id'), startAt(1), endAt(2));
-      const query2 = query(collection, orderBy('id'), startAt(1), endBefore(2));
-      const countQuery1 = countQuery(query1);
-      const countQuery2 = countQuery(query2);
-      const snapshot1 = await getAggregateFromServerDirect(countQuery1);
-      const snapshot2 = await getAggregateFromServerDirect(countQuery2);
-      expect(snapshot1.getCount()).to.equal(2);
-      expect(snapshot2.getCount()).to.equal(1);
+      const query_ = query(collection, orderBy('id'), startAt(1), endAt(2));
+      const countQuery_ = countQuery(query_);
+      const snapshot = await getAggregateFromServerDirect(countQuery_);
+      expect(snapshot.getCount()).to.equal(2);
+    });
+  });
+
+  it('count with order by and endBefore', () => {
+    const testDocs = [
+      { id: 3, author: 'authorA', title: 'titleA' },
+      { id: 1, author: 'authorA', title: 'titleB' },
+      { id: 2, author: 'authorB', title: 'titleC' },
+      { id: null, author: 'authorB', title: 'titleD' }
+    ];
+    return withTestCollectionAndInitialData(testDocs, async collection => {
+      const query_ = query(collection, orderBy('id'), startAt(1), endBefore(2));
+      const countQuery_ = countQuery(query_);
+      const snapshot = await getAggregateFromServerDirect(countQuery_);
+      expect(snapshot.getCount()).to.equal(1);
     });
   });
 
   it('test collection count with converter on query', () => {
+    const testDocs = [
+      { author: 'authorA', title: 'titleA' },
+      { author: 'authorA', title: 'titleB' },
+      { author: 'authorB', title: 'titleC' }
+    ];
     return withTestCollectionAndInitialData(testDocs, async collection => {
       const query_ = query(
         collection,
@@ -2174,16 +2226,15 @@ describe('countQuery()', () => {
       const docPaths = [
         `${collectionGroupId}/cg-doc1`,
         `abc/123/${collectionGroupId}/cg-doc2`,
-        `invalid${collectionGroupId}/cg-doc3`,
-        `abc/123/invalid${collectionGroupId}/cg-doc4`,
-        `abc/123/invalid/${collectionGroupId}`
+        `zzz${collectionGroupId}/cg-doc3`,
+        `abc/123/zzz${collectionGroupId}/cg-doc4`,
+        `abc/123/zzz/${collectionGroupId}`
       ];
       const batch = writeBatch(db);
       for (const docPath of docPaths) {
         batch.set(doc(db, docPath), { x: 1 });
       }
       await batch.commit();
-
       const countQuery_ = countQuery(collectionGroup(db, collectionGroupId));
       const snapshot = await getAggregateFromServerDirect(countQuery_);
       expect(snapshot.getCount()).to.equal(2);
@@ -2191,6 +2242,11 @@ describe('countQuery()', () => {
   });
 
   it('aggregateQueryEqual on same queries', () => {
+    const testDocs = [
+      { author: 'authorA', title: 'titleA' },
+      { author: 'authorA', title: 'titleB' },
+      { author: 'authorB', title: 'titleC' }
+    ];
     return withTestCollectionAndInitialData(testDocs, async collection => {
       const query1 = query(collection, where('author', '==', 'authorA'));
       const query2 = query(collection, where('author', '==', 'authorA'));
@@ -2201,6 +2257,11 @@ describe('countQuery()', () => {
   });
 
   it('aggregateQueryEqual on different queries', () => {
+    const testDocs = [
+      { author: 'authorA', title: 'titleA' },
+      { author: 'authorA', title: 'titleB' },
+      { author: 'authorB', title: 'titleC' }
+    ];
     return withTestCollectionAndInitialData(testDocs, async collection => {
       const query1 = query(collection, where('author', '==', 'authorA'));
       const query2 = query(collection, where('author', '==', 'authorB'));
@@ -2211,6 +2272,11 @@ describe('countQuery()', () => {
   });
 
   it('aggregateQuerySnapshotEqual on same queries', () => {
+    const testDocs = [
+      { author: 'authorA', title: 'titleA' },
+      { author: 'authorA', title: 'titleB' },
+      { author: 'authorB', title: 'titleC' }
+    ];
     return withTestCollectionAndInitialData(testDocs, async collection => {
       const query1 = query(collection, where('author', '==', 'authorA'));
       const query2 = query(collection, where('author', '==', 'authorA'));
@@ -2226,6 +2292,11 @@ describe('countQuery()', () => {
   });
 
   it('aggregateQuerySnapshotEqual on different queries', () => {
+    const testDocs = [
+      { author: 'authorA', title: 'titleA' },
+      { author: 'authorA', title: 'titleB' },
+      { author: 'authorB', title: 'titleC' }
+    ];
     return withTestCollectionAndInitialData(testDocs, async collection => {
       const query1 = query(collection, where('author', '==', 'authorA'));
       const query2 = query(collection, where('author', '==', 'authorB'));

--- a/packages/firestore/test/lite/integration.test.ts
+++ b/packages/firestore/test/lite/integration.test.ts
@@ -2173,9 +2173,9 @@ describe('countQuery()', () => {
       const collectionGroupId = doc(collection(db, 'countTest')).id;
       const docPaths = [
         `${collectionGroupId}/cg-doc1`,
-        `abc/123/${collectionGroupId}/cg-doc1`,
-        `invalid${collectionGroupId}/cg-doc4`,
-        `abc/123/invalid${collectionGroupId}/cg-doc2`,
+        `abc/123/${collectionGroupId}/cg-doc2`,
+        `invalid${collectionGroupId}/cg-doc3`,
+        `abc/123/invalid${collectionGroupId}/cg-doc4`,
         `abc/123/invalid/${collectionGroupId}`
       ];
       const batch = writeBatch(db);

--- a/packages/firestore/test/lite/integration.test.ts
+++ b/packages/firestore/test/lite/integration.test.ts
@@ -2236,4 +2236,14 @@ describe('countQuery()', () => {
       expect(aggregateQuerySnapshotEqual(snapshot1, snapshot2)).to.be.false;
     });
   });
+
+  it('count query on a terminated Firestore', () => {
+    return withTestCollection(async collection => {
+      await terminate(collection.firestore);
+      const countQuery_ = countQuery(query(collection));
+      expect(() => getAggregateFromServerDirect(countQuery_)).to.throw(
+        'The client has already been terminated'
+      );
+    });
+  });
 });

--- a/packages/firestore/test/lite/integration.test.ts
+++ b/packages/firestore/test/lite/integration.test.ts
@@ -2318,7 +2318,7 @@ describe('countQuery()', () => {
     });
   });
 
-  it.only('terminate Firestore while calling count query', () => {
+  it('terminate Firestore while calling count query', () => {
     const testDocs = [
       { author: 'authorA', title: 'titleA' },
       { author: 'authorA', title: 'titleB' },
@@ -2326,42 +2326,10 @@ describe('countQuery()', () => {
     ];
     return withTestCollectionAndInitialData(testDocs, async collection => {
       const countQuery_ = countQuery(query(collection));
-
-      //This will pass
-      // const promise = getAggregateFromServerDirect(countQuery_)
-      // await terminate(collection.firestore)
-      // expect((await promise).getCount()).to.equal(3);
-
-      //this will pass
-      // const [promise,voidResult] = await Promise.all([
-      //   getAggregateFromServerDirect(countQuery_),
-      //   terminate(collection.firestore),
-      // ])
-      // expect(promise.getCount()).to.equal(3);
-
-      //if terminate comes first, it will throw error
-      // expect(() => Promise.all([
-      //   terminate(collection.firestore),
-      //   getAggregateFromServerDirect(countQuery_),
-      // ])).to.throw(
-      //   'The client has already been terminated.'
-      // );
-
-      // not sure why, this is not getting to the "then" block
-      // and therefore it is not checking the "expect" at all
-      Promise.all([
-        getAggregateFromServerDirect(countQuery_),
-        terminate(collection.firestore)
-      ])
-        .then(([promise, voidResult]) => {
-          console.log('snapshot', promise);
-          expect(promise.getCount()).to.equal(100);
-        })
-        .catch(e => {
-          expect((e as Error)?.message).to.equal(
-            'The client has already been terminated.'
-          );
-        });
+      const promise = getAggregateFromServerDirect(countQuery_);
+      await terminate(collection.firestore);
+      const snapshot = await promise;
+      expect(snapshot.getCount()).to.equal(3);
     });
   });
 });


### PR DESCRIPTION
# tasks:

- [x] add test case for orderBy
- [x] add test case for startAt, startAfter
- [x] add test case for endAt, endBefore
- [x] add test case for collection group
- [x] add test case for running count query on terminated firestore instance
