### PR TITLE
Update type of ParsedToken to include unknown

### DIFF
--- a/.changeset/spotty-pillows-applaud.md
+++ b/.changeset/spotty-pillows-applaud.md
@@ -2,4 +2,4 @@
 "@firebase/auth": patch
 ---
 
-Update custom claim type of `ParsedToken` to be `unknown`
+Update custom claim type of `ParsedToken` to be `any`

--- a/.changeset/spotty-pillows-applaud.md
+++ b/.changeset/spotty-pillows-applaud.md
@@ -1,0 +1,5 @@
+---
+"@firebase/auth": patch
+---
+
+Update custom claim type of `ParsedToken` to be `unknown`

--- a/common/api-review/auth.api.md
+++ b/common/api-review/auth.api.md
@@ -538,7 +538,7 @@ export function parseActionCodeURL(link: string): ActionCodeURL | null;
 
 // @public
 export interface ParsedToken {
-    [key: string]: string | object | undefined | unknown;
+    [key: string]: unknown;
     'auth_time'?: string;
     'exp'?: string;
     'firebase'?: {

--- a/common/api-review/auth.api.md
+++ b/common/api-review/auth.api.md
@@ -538,7 +538,7 @@ export function parseActionCodeURL(link: string): ActionCodeURL | null;
 
 // @public
 export interface ParsedToken {
-    [key: string]: unknown;
+    [key: string]: any;
     'auth_time'?: string;
     'exp'?: string;
     'firebase'?: {

--- a/common/api-review/auth.api.md
+++ b/common/api-review/auth.api.md
@@ -538,7 +538,7 @@ export function parseActionCodeURL(link: string): ActionCodeURL | null;
 
 // @public
 export interface ParsedToken {
-    [key: string]: string | object | undefined;
+    [key: string]: string | object | undefined | unknown;
     'auth_time'?: string;
     'exp'?: string;
     'firebase'?: {

--- a/packages/auth/src/model/public_types.ts
+++ b/packages/auth/src/model/public_types.ts
@@ -104,7 +104,7 @@ export interface ParsedToken {
     'identities'?: Record<string, string>;
   };
   /** Map of any additional custom claims. */
-  [key: string]: string | object | undefined;
+  [key: string]: string | object | undefined | unknown;
 }
 
 /**

--- a/packages/auth/src/model/public_types.ts
+++ b/packages/auth/src/model/public_types.ts
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
 import { FirebaseApp } from '@firebase/app';
 import {
   CompleteFn,
@@ -104,7 +106,7 @@ export interface ParsedToken {
     'identities'?: Record<string, string>;
   };
   /** Map of any additional custom claims. */
-  [key: string]: unknown;
+  [key: string]: any;
 }
 
 /**

--- a/packages/auth/src/model/public_types.ts
+++ b/packages/auth/src/model/public_types.ts
@@ -104,7 +104,7 @@ export interface ParsedToken {
     'identities'?: Record<string, string>;
   };
   /** Map of any additional custom claims. */
-  [key: string]: string | object | undefined | unknown;
+  [key: string]: unknown;
 }
 
 /**


### PR DESCRIPTION
This change updates the type of the custom claim field in the `ParsedToken` interface to be `any`. This more accurately reflects that a JWT may contain any valid JSON object.

While using the `unknown` type would have been more type-safe (and use of `any` is generally frowned-upon), it unfortunately makes this change backwards-incompatible.

Fixes https://github.com/firebase/firebase-js-sdk/issues/6553