### PR TITLE
Fix formatting for auth files.

### DIFF
--- a/packages/auth/karma.conf.js
+++ b/packages/auth/karma.conf.js
@@ -54,10 +54,10 @@ function getTestFiles(argv) {
 }
 
 function getTestBrowsers(argv) {
-  let browsers = ["ChromeHeadless"]; 
+  let browsers = ['ChromeHeadless'];
   if (process.env?.BROWSERS && argv.unit) {
     browsers = process.env?.BROWSERS?.split(',');
-  } 
+  }
   return browsers;
 }
 

--- a/packages/auth/src/core/util/version.test.ts
+++ b/packages/auth/src/core/util/version.test.ts
@@ -42,7 +42,9 @@ describe('core/util/_getClientVersion', () => {
     context('worker', () => {
       it('should set the correct version', () => {
         expect(_getClientVersion(ClientPlatform.WORKER)).to.eq(
-          `${_getBrowserName(getUA())}-Worker/JsCore/${SDK_VERSION}/FirebaseCore-web`
+          `${_getBrowserName(
+            getUA()
+          )}-Worker/JsCore/${SDK_VERSION}/FirebaseCore-web`
         );
       });
     });

--- a/packages/auth/src/platform_browser/persistence/session_storage.test.ts
+++ b/packages/auth/src/platform_browser/persistence/session_storage.test.ts
@@ -66,8 +66,8 @@ describe('platform_browser/persistence/session_storage', () => {
       afterEach(() => sinon.restore());
 
       it('should emit false if sessionStorage setItem throws', async () => {
-      sinon.stub(Storage.prototype, 'setItem').throws(new Error('nope'));
-      expect(await persistence._isAvailable()).to.be.false;
+        sinon.stub(Storage.prototype, 'setItem').throws(new Error('nope'));
+        expect(await persistence._isAvailable()).to.be.false;
       });
 
       it('should emit false if sessionStorage removeItem throws', async () => {

--- a/packages/auth/src/platform_cordova/popup_redirect/events.test.ts
+++ b/packages/auth/src/platform_cordova/popup_redirect/events.test.ts
@@ -73,8 +73,10 @@ describe('platform_cordova/popup_redirect/events', () => {
       const spy = sinon.spy(Storage.prototype, 'setItem');
       const event = _generateNewEvent(auth, AuthEventType.REAUTH_VIA_REDIRECT);
       await _savePartialEvent(auth, event);
-      expect(spy).to.have.been.calledWith('firebase:authEvent:test-api-key:test-app',
-      JSON.stringify(event));
+      expect(spy).to.have.been.calledWith(
+        'firebase:authEvent:test-api-key:test-app',
+        JSON.stringify(event)
+      );
     });
   });
 


### PR DESCRIPTION
These currently show up in the diff when running `yarn format`. Sending a separate PR so they are not showing up as unrelated changes in other PRs.
