### PR TITLE
Include a reference to AuthInternal in MultiFactorSessionImpl.

### DIFF
--- a/.changeset/curly-mirrors-occur.md
+++ b/.changeset/curly-mirrors-occur.md
@@ -1,0 +1,5 @@
+---
+'@firebase/auth': patch
+---
+
+Included a reference to AuthInternal in MultiFactorSessionImpl.

--- a/packages/auth/src/mfa/mfa_session.ts
+++ b/packages/auth/src/mfa/mfa_session.ts
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { AuthInternal } from '../model/auth';
 import { MultiFactorSession } from '../model/public_types';
 
 export const enum MultiFactorSessionType {
@@ -31,11 +32,19 @@ interface SerializedMultiFactorSession {
 export class MultiFactorSessionImpl implements MultiFactorSession {
   private constructor(
     readonly type: MultiFactorSessionType,
-    readonly credential: string
+    readonly credential: string,
+    readonly auth?: AuthInternal
   ) {}
 
-  static _fromIdtoken(idToken: string): MultiFactorSessionImpl {
-    return new MultiFactorSessionImpl(MultiFactorSessionType.ENROLL, idToken);
+  static _fromIdtoken(
+    idToken: string,
+    auth?: AuthInternal
+  ): MultiFactorSessionImpl {
+    return new MultiFactorSessionImpl(
+      MultiFactorSessionType.ENROLL,
+      idToken,
+      auth
+    );
   }
 
   static _fromMfaPendingCredential(

--- a/packages/auth/src/mfa/mfa_user.test.ts
+++ b/packages/auth/src/mfa/mfa_user.test.ts
@@ -84,6 +84,12 @@ describe('core/mfa/mfa_user/MultiFactorUser', () => {
       expect(mfaSession.type).to.eq(MultiFactorSessionType.ENROLL);
       expect(mfaSession.credential).to.eq('access-token');
     });
+    it('should contain a reference to auth', async () => {
+      const mfaSession = (await mfaUser.getSession()) as MultiFactorSessionImpl;
+      expect(mfaSession.type).to.eq(MultiFactorSessionType.ENROLL);
+      expect(mfaSession.credential).to.eq('access-token');
+      expect(mfaSession.auth).to.eq(auth);
+    });
   });
 
   describe('enroll', () => {

--- a/packages/auth/src/mfa/mfa_user.ts
+++ b/packages/auth/src/mfa/mfa_user.ts
@@ -49,7 +49,10 @@ export class MultiFactorUserImpl implements MultiFactorUser {
   }
 
   async getSession(): Promise<MultiFactorSession> {
-    return MultiFactorSessionImpl._fromIdtoken(await this.user.getIdToken());
+    return MultiFactorSessionImpl._fromIdtoken(
+      await this.user.getIdToken(),
+      this.user.auth
+    );
   }
 
   async enroll(

--- a/packages/auth/src/platform_browser/mfa/assertions/phone.test.ts
+++ b/packages/auth/src/platform_browser/mfa/assertions/phone.test.ts
@@ -58,7 +58,10 @@ describe('platform_browser/mfa/phone', () => {
 
   describe('enroll', () => {
     beforeEach(() => {
-      session = MultiFactorSessionImpl._fromIdtoken('enrollment-id-token');
+      session = MultiFactorSessionImpl._fromIdtoken(
+        'enrollment-id-token',
+        auth
+      );
     });
 
     it('should finalize the MFA enrollment', async () => {
@@ -75,6 +78,7 @@ describe('platform_browser/mfa/phone', () => {
           sessionInfo: 'verification-id'
         }
       });
+      expect(session.auth).to.eql(auth);
     });
 
     context('with display name', () => {
@@ -97,6 +101,7 @@ describe('platform_browser/mfa/phone', () => {
             sessionInfo: 'verification-id'
           }
         });
+        expect(session.auth).to.eql(auth);
       });
     });
   });
@@ -119,6 +124,7 @@ describe('platform_browser/mfa/phone', () => {
           sessionInfo: 'verification-id'
         }
       });
+      expect(session.auth).to.eql(undefined);
     });
   });
 });


### PR DESCRIPTION
This is needed for TOTP support where the function to generate TOTP Secret (by invoking startEnrollment API) needs the Auth reference, but rather than pass in a parameter, we can derive it from the multiFactorSession that is already passed in as a param. This simplifies the TOTP enrollment API for the developer, by requiring one less parameter.

The usage for auth can be seen in this WIP change - https://github.com/firebase/firebase-js-sdk/compare/mfa-totp...mfa-totp-prameshj#diff-e9ae122839df9e758f95dd35db60444dd51b73a319b02a9ef36b747dc9889fbaR81

Hey there! So you want to contribute to a Firebase SDK? 
Before you file this pull request, please read these guidelines:

### Discussion

  * Read the contribution guidelines (CONTRIBUTING.md).
  * If this has been discussed in an issue, make sure to link to the issue here. 
    If not, go file an issue about this **before creating a pull request** to discuss.

### Testing

  * Make sure all existing tests in the repository pass after your change.
  * If you fixed a bug or added a feature, add a new test to cover your code.

Added new unit tests.


