### PR TITLE
Fix App Check timer issues

### DIFF
--- a/.changeset/selfish-worms-glow.md
+++ b/.changeset/selfish-worms-glow.md
@@ -1,0 +1,5 @@
+---
+'@firebase/app-check': patch
+---
+
+Fix timer issues in App Check that caused the token to fail to refresh after the token expired, or caused rapid repeated requests attempting to do so.

--- a/packages/app-check/src/indexeddb.ts
+++ b/packages/app-check/src/indexeddb.ts
@@ -80,7 +80,7 @@ export function readTokenFromIndexedDB(
 
 export function writeTokenToIndexedDB(
   app: FirebaseApp,
-  token: AppCheckTokenInternal
+  token?: AppCheckTokenInternal
 ): Promise<void> {
   return write(computeKey(app), token);
 }

--- a/packages/app-check/src/internal-api.test.ts
+++ b/packages/app-check/src/internal-api.test.ts
@@ -373,7 +373,8 @@ describe('internal api', () => {
         provider: new ReCaptchaV3Provider(FAKE_SITE_KEY)
       });
       setState(app, {
-        ...getState(app), token: {
+        ...getState(app),
+        token: {
           token: 'something',
           expireTimeMillis: Date.now() - 1000,
           issuedAtTimeMillis: 0
@@ -428,25 +429,17 @@ describe('internal api', () => {
       };
 
       stub(reCAPTCHA, 'getToken').returns(Promise.resolve(fakeRecaptchaToken));
-      stub(client, 'exchangeToken').returns(
-        Promise.resolve(freshToken)
-      );
+      stub(client, 'exchangeToken').returns(Promise.resolve(freshToken));
 
       expect(await getToken(appCheck as AppCheckService)).to.deep.equal({
         token: 'new-recaptcha-app-check-token'
       });
 
       // When it wiped the invalid token.
-      expect(storageWriteStub).has.been.calledWith(
-        app,
-        undefined
-      );
+      expect(storageWriteStub).has.been.calledWith(app, undefined);
 
       // When it wrote the new token fetched from the exchange endpoint.
-      expect(storageWriteStub).has.been.calledWith(
-        app,
-        freshToken
-      );
+      expect(storageWriteStub).has.been.calledWith(app, freshToken);
     });
 
     it('returns the actual token and an internalError if a token is valid but the request fails', async () => {
@@ -539,7 +532,7 @@ describe('internal api', () => {
 
   describe('addTokenListener', () => {
     it('adds token listeners', () => {
-      const listener = (): void => { };
+      const listener = (): void => {};
       setState(app, {
         ...getState(app),
         cachedTokenPromise: Promise.resolve(undefined)
@@ -555,7 +548,7 @@ describe('internal api', () => {
     });
 
     it('starts proactively refreshing token after adding the first listener', async () => {
-      const listener = (): void => { };
+      const listener = (): void => {};
       setState(app, {
         ...getState(app),
         isTokenAutoRefreshEnabled: true,
@@ -638,7 +631,8 @@ describe('internal api', () => {
         isTokenAutoRefreshEnabled: true
       });
       setState(app, {
-        ...getState(app), token: {
+        ...getState(app),
+        token: {
           token: `fake-cached-app-check-token`,
           // within refresh window
           expireTimeMillis: 10000,
@@ -663,8 +657,12 @@ describe('internal api', () => {
       );
       // Tick 10s, make sure nothing is called repeatedly in that time.
       await clock.tickAsync(10000);
-      expect(fakeListener).to.be.calledWith({ token: 'fake-cached-app-check-token' });
-      expect(fakeListener).to.be.calledWith({ token: 'new-recaptcha-app-check-token' });
+      expect(fakeListener).to.be.calledWith({
+        token: 'fake-cached-app-check-token'
+      });
+      expect(fakeListener).to.be.calledWith({
+        token: 'new-recaptcha-app-check-token'
+      });
       expect(fakeExchange).to.be.calledOnce;
       clock.restore();
     });
@@ -677,7 +675,8 @@ describe('internal api', () => {
         isTokenAutoRefreshEnabled: true
       });
       setState(app, {
-        ...getState(app), token: {
+        ...getState(app),
+        token: {
           token: `fake-cached-app-check-token`,
           // not expired but within refresh window
           expireTimeMillis: 10000,
@@ -698,7 +697,9 @@ describe('internal api', () => {
       );
       // Tick 10s, make sure nothing is called repeatedly in that time.
       await clock.tickAsync(10000);
-      expect(fakeListener).to.be.calledWith({ token: 'fake-cached-app-check-token' });
+      expect(fakeListener).to.be.calledWith({
+        token: 'fake-cached-app-check-token'
+      });
       // once on init and once invoked directly in this test
       expect(fakeListener).to.be.calledTwice;
       expect(fakeExchange).to.be.calledOnce;
@@ -713,7 +714,8 @@ describe('internal api', () => {
         isTokenAutoRefreshEnabled: true
       });
       setState(app, {
-        ...getState(app), token: {
+        ...getState(app),
+        token: {
           token: `fake-cached-app-check-token`,
           // not expired but within refresh window
           expireTimeMillis: 10000,
@@ -749,7 +751,8 @@ describe('internal api', () => {
         isTokenAutoRefreshEnabled: true
       });
       setState(app, {
-        ...getState(app), token: {
+        ...getState(app),
+        token: {
           token: `fake-cached-app-check-token`,
           // expired
           expireTimeMillis: 0,
@@ -788,7 +791,8 @@ describe('internal api', () => {
         isTokenAutoRefreshEnabled: true
       });
       setState(app, {
-        ...getState(app), token: {
+        ...getState(app),
+        token: {
           token: `fake-cached-app-check-token`,
           // expired
           expireTimeMillis: 0,
@@ -822,7 +826,7 @@ describe('internal api', () => {
 
   describe('removeTokenListener', () => {
     it('should remove token listeners', () => {
-      const listener = (): void => { };
+      const listener = (): void => {};
       setState(app, {
         ...getState(app),
         cachedTokenPromise: Promise.resolve(undefined)
@@ -839,7 +843,7 @@ describe('internal api', () => {
     });
 
     it('should stop proactively refreshing token after deleting the last listener', async () => {
-      const listener = (): void => { };
+      const listener = (): void => {};
       setState(app, { ...getState(app), isTokenAutoRefreshEnabled: true });
       setState(app, {
         ...getState(app),

--- a/packages/app-check/src/internal-api.test.ts
+++ b/packages/app-check/src/internal-api.test.ts
@@ -368,6 +368,102 @@ describe('internal api', () => {
       });
     });
 
+    it('ignores in-memory token if it is invalid and continues to exchange request', async () => {
+      const appCheck = initializeAppCheck(app, {
+        provider: new ReCaptchaV3Provider(FAKE_SITE_KEY)
+      });
+      setState(app, {
+        ...getState(app), token: {
+          token: 'something',
+          expireTimeMillis: Date.now() - 1000,
+          issuedAtTimeMillis: 0
+        }
+      });
+
+      stub(reCAPTCHA, 'getToken').returns(Promise.resolve(fakeRecaptchaToken));
+      stub(client, 'exchangeToken').returns(
+        Promise.resolve({
+          token: 'new-recaptcha-app-check-token',
+          expireTimeMillis: Date.now() + 60000,
+          issuedAtTimeMillis: 0
+        })
+      );
+
+      expect(await getToken(appCheck as AppCheckService)).to.deep.equal({
+        token: 'new-recaptcha-app-check-token'
+      });
+    });
+
+    it('returns the valid token in storage without making a network request', async () => {
+      const clock = useFakeTimers();
+
+      storageReadStub.resolves(fakeCachedAppCheckToken);
+      const appCheck = initializeAppCheck(app, {
+        provider: new ReCaptchaV3Provider(FAKE_SITE_KEY)
+      });
+
+      const clientStub = stub(client, 'exchangeToken');
+      expect(await getToken(appCheck as AppCheckService)).to.deep.equal({
+        token: fakeCachedAppCheckToken.token
+      });
+      expect(clientStub).to.not.have.been.called;
+
+      clock.restore();
+    });
+
+    it('deletes cached token if it is invalid and continues to exchange request', async () => {
+      storageReadStub.resolves({
+        token: 'something',
+        expireTimeMillis: Date.now() - 1000,
+        issuedAtTimeMillis: 0
+      });
+      const appCheck = initializeAppCheck(app, {
+        provider: new ReCaptchaV3Provider(FAKE_SITE_KEY)
+      });
+
+      const freshToken = {
+        token: 'new-recaptcha-app-check-token',
+        expireTimeMillis: Date.now() + 60000,
+        issuedAtTimeMillis: 0
+      };
+
+      stub(reCAPTCHA, 'getToken').returns(Promise.resolve(fakeRecaptchaToken));
+      stub(client, 'exchangeToken').returns(
+        Promise.resolve(freshToken)
+      );
+
+      expect(await getToken(appCheck as AppCheckService)).to.deep.equal({
+        token: 'new-recaptcha-app-check-token'
+      });
+
+      // When it wiped the invalid token.
+      expect(storageWriteStub).has.been.calledWith(
+        app,
+        undefined
+      );
+
+      // When it wrote the new token fetched from the exchange endpoint.
+      expect(storageWriteStub).has.been.calledWith(
+        app,
+        freshToken
+      );
+    });
+
+    it('returns the actual token and an internalError if a token is valid but the request fails', async () => {
+      stub(logger, 'error');
+      const appCheck = initializeAppCheck(app, {
+        provider: new ReCaptchaV3Provider(FAKE_SITE_KEY)
+      });
+      setState(app, { ...getState(app), token: fakeRecaptchaAppCheckToken });
+
+      stub(reCAPTCHA, 'getToken').returns(Promise.resolve(fakeRecaptchaToken));
+      stub(client, 'exchangeToken').returns(Promise.reject(new Error('blah')));
+
+      const tokenResult = await getToken(appCheck as AppCheckService, true);
+      expect(tokenResult.internalError?.message).to.equal('blah');
+      expect(tokenResult.token).to.equal('fake-recaptcha-app-check-token');
+    });
+
     it('exchanges debug token if in debug mode and there is no cached token', async () => {
       const exchangeTokenStub: SinonStub = stub(
         client,
@@ -443,7 +539,7 @@ describe('internal api', () => {
 
   describe('addTokenListener', () => {
     it('adds token listeners', () => {
-      const listener = (): void => {};
+      const listener = (): void => { };
       setState(app, {
         ...getState(app),
         cachedTokenPromise: Promise.resolve(undefined)
@@ -459,7 +555,7 @@ describe('internal api', () => {
     });
 
     it('starts proactively refreshing token after adding the first listener', async () => {
-      const listener = (): void => {};
+      const listener = (): void => { };
       setState(app, {
         ...getState(app),
         isTokenAutoRefreshEnabled: true,
@@ -534,11 +630,199 @@ describe('internal api', () => {
         fakeListener
       );
     });
+
+    it('does not make rapid requests within proactive refresh window', async () => {
+      const clock = useFakeTimers();
+      const appCheck = initializeAppCheck(app, {
+        provider: new ReCaptchaV3Provider(FAKE_SITE_KEY),
+        isTokenAutoRefreshEnabled: true
+      });
+      setState(app, {
+        ...getState(app), token: {
+          token: `fake-cached-app-check-token`,
+          // within refresh window
+          expireTimeMillis: 10000,
+          issuedAtTimeMillis: 0
+        }
+      });
+
+      const fakeListener: AppCheckTokenListener = stub();
+
+      const fakeExchange = stub(client, 'exchangeToken').returns(
+        Promise.resolve({
+          token: 'new-recaptcha-app-check-token',
+          expireTimeMillis: 10 * 60 * 1000,
+          issuedAtTimeMillis: 0
+        })
+      );
+
+      addTokenListener(
+        appCheck as AppCheckService,
+        ListenerType.INTERNAL,
+        fakeListener
+      );
+      // Tick 10s, make sure nothing is called repeatedly in that time.
+      await clock.tickAsync(10000);
+      expect(fakeListener).to.be.calledWith({ token: 'fake-cached-app-check-token' });
+      expect(fakeListener).to.be.calledWith({ token: 'new-recaptcha-app-check-token' });
+      expect(fakeExchange).to.be.calledOnce;
+      clock.restore();
+    });
+
+    it('proactive refresh window test - exchange request fails - wait 10s', async () => {
+      stub(logger, 'error');
+      const clock = useFakeTimers();
+      const appCheck = initializeAppCheck(app, {
+        provider: new ReCaptchaV3Provider(FAKE_SITE_KEY),
+        isTokenAutoRefreshEnabled: true
+      });
+      setState(app, {
+        ...getState(app), token: {
+          token: `fake-cached-app-check-token`,
+          // not expired but within refresh window
+          expireTimeMillis: 10000,
+          issuedAtTimeMillis: 0
+        }
+      });
+
+      const fakeListener: AppCheckTokenListener = stub();
+
+      const fakeExchange = stub(client, 'exchangeToken').returns(
+        Promise.reject(new Error('fetch failed or something'))
+      );
+
+      addTokenListener(
+        appCheck as AppCheckService,
+        ListenerType.EXTERNAL,
+        fakeListener
+      );
+      // Tick 10s, make sure nothing is called repeatedly in that time.
+      await clock.tickAsync(10000);
+      expect(fakeListener).to.be.calledWith({ token: 'fake-cached-app-check-token' });
+      // once on init and once invoked directly in this test
+      expect(fakeListener).to.be.calledTwice;
+      expect(fakeExchange).to.be.calledOnce;
+      clock.restore();
+    });
+
+    it('proactive refresh window test - exchange request fails - wait 40s', async () => {
+      stub(logger, 'error');
+      const clock = useFakeTimers();
+      const appCheck = initializeAppCheck(app, {
+        provider: new ReCaptchaV3Provider(FAKE_SITE_KEY),
+        isTokenAutoRefreshEnabled: true
+      });
+      setState(app, {
+        ...getState(app), token: {
+          token: `fake-cached-app-check-token`,
+          // not expired but within refresh window
+          expireTimeMillis: 10000,
+          issuedAtTimeMillis: 0
+        }
+      });
+
+      const fakeListener: AppCheckTokenListener = stub();
+
+      const fakeExchange = stub(client, 'exchangeToken').returns(
+        Promise.reject(new Error('fetch failed or something'))
+      );
+
+      addTokenListener(
+        appCheck as AppCheckService,
+        ListenerType.EXTERNAL,
+        fakeListener
+      );
+      // Tick 40s, expect one initial exchange request and one retry.
+      // (First backoff is 30s).
+      await clock.tickAsync(40000);
+      expect(fakeListener).to.be.calledTwice;
+      expect(fakeExchange).to.be.calledTwice;
+      clock.restore();
+    });
+
+    it('expired token - exchange request fails - wait 10s', async () => {
+      stub(logger, 'error');
+      const clock = useFakeTimers();
+      clock.tick(1);
+      const appCheck = initializeAppCheck(app, {
+        provider: new ReCaptchaV3Provider(FAKE_SITE_KEY),
+        isTokenAutoRefreshEnabled: true
+      });
+      setState(app, {
+        ...getState(app), token: {
+          token: `fake-cached-app-check-token`,
+          // expired
+          expireTimeMillis: 0,
+          issuedAtTimeMillis: 0
+        }
+      });
+
+      const fakeListener = stub();
+      const errorHandler = stub();
+      const fakeNetworkError = new Error('fetch failed or something');
+
+      const fakeExchange = stub(client, 'exchangeToken').returns(
+        Promise.reject(fakeNetworkError)
+      );
+
+      addTokenListener(
+        appCheck as AppCheckService,
+        ListenerType.EXTERNAL,
+        fakeListener,
+        errorHandler
+      );
+      // Tick 10s, make sure nothing is called repeatedly in that time.
+      await clock.tickAsync(10000);
+      expect(fakeListener).not.to.be.called;
+      expect(fakeExchange).to.be.calledOnce;
+      expect(errorHandler).to.be.calledWith(fakeNetworkError);
+      clock.restore();
+    });
+
+    it('expired token - exchange request fails - wait 40s', async () => {
+      stub(logger, 'error');
+      const clock = useFakeTimers();
+      clock.tick(1);
+      const appCheck = initializeAppCheck(app, {
+        provider: new ReCaptchaV3Provider(FAKE_SITE_KEY),
+        isTokenAutoRefreshEnabled: true
+      });
+      setState(app, {
+        ...getState(app), token: {
+          token: `fake-cached-app-check-token`,
+          // expired
+          expireTimeMillis: 0,
+          issuedAtTimeMillis: 0
+        }
+      });
+
+      const fakeListener = stub();
+      const errorHandler = stub();
+      const fakeNetworkError = new Error('fetch failed or something');
+
+      const fakeExchange = stub(client, 'exchangeToken').returns(
+        Promise.reject(fakeNetworkError)
+      );
+
+      addTokenListener(
+        appCheck as AppCheckService,
+        ListenerType.EXTERNAL,
+        fakeListener,
+        errorHandler
+      );
+      // Tick 40s, expect one initial exchange request and one retry.
+      // (First backoff is 30s).
+      await clock.tickAsync(40000);
+      expect(fakeListener).not.to.be.called;
+      expect(fakeExchange).to.be.calledTwice;
+      expect(errorHandler).to.be.calledTwice;
+      clock.restore();
+    });
   });
 
   describe('removeTokenListener', () => {
     it('should remove token listeners', () => {
-      const listener = (): void => {};
+      const listener = (): void => { };
       setState(app, {
         ...getState(app),
         cachedTokenPromise: Promise.resolve(undefined)
@@ -555,7 +839,7 @@ describe('internal api', () => {
     });
 
     it('should stop proactively refreshing token after deleting the last listener', async () => {
-      const listener = (): void => {};
+      const listener = (): void => { };
       setState(app, { ...getState(app), isTokenAutoRefreshEnabled: true });
       setState(app, {
         ...getState(app),

--- a/packages/app-check/src/internal-api.ts
+++ b/packages/app-check/src/internal-api.ts
@@ -84,9 +84,9 @@ export async function getToken(
     }
   }
 
+  // If an invalid token was found in memory or indexedDB, clear token from
+  // memory and the local variable.
   if (token && !isValid(token)) {
-    // If an invalid token was found in memory or indexedDB, clear token from
-    // memory and the local variable.
     setState(app, { ...state, token: undefined });
     token = undefined;
   }
@@ -159,8 +159,11 @@ export async function getToken(
 
   let interopTokenResult: AppCheckTokenResult | undefined;
   if (!token || error) {
-    // if token is undefined, there must be an error.
-    // we return a dummy token along with the error
+    // If token is undefined, there must be an error.
+    // It's also possible a token exists, but there's also an error. (Such as
+    // if the token is almost expired, tries to refresh, and fails the
+    // exchange request.)
+    // In either case, return a dummy token along with the error.
     interopTokenResult = makeDummyTokenResult(error!);
   } else {
     interopTokenResult = {
@@ -297,7 +300,7 @@ function createTokenRefresher(appCheck: AppCheckService): Refresher {
         let nextRefreshTimeMillis =
           state.token.issuedAtTimeMillis +
           (state.token.expireTimeMillis - state.token.issuedAtTimeMillis) *
-          0.5 +
+            0.5 +
           5 * 60 * 1000;
         // Do not allow refresh time to be past (expireTime - 5 minutes)
         const latestAllowableRefresh =

--- a/packages/app-check/src/internal-api.ts
+++ b/packages/app-check/src/internal-api.ts
@@ -338,7 +338,7 @@ function createTokenRefresher(appCheck: AppCheckService): Refresher {
         let nextRefreshTimeMillis =
           state.token.issuedAtTimeMillis +
           (state.token.expireTimeMillis - state.token.issuedAtTimeMillis) *
-          0.5 +
+            0.5 +
           5 * 60 * 1000;
         // Do not allow refresh time to be past (expireTime - 5 minutes)
         const latestAllowableRefresh =

--- a/packages/app-check/src/internal-api.ts
+++ b/packages/app-check/src/internal-api.ts
@@ -128,7 +128,7 @@ export async function getToken(
       shouldCallListeners = true;
     }
     const tokenFromDebugExchange: AppCheckTokenInternal =
-      await state.exchangeTokenPromise!;
+      await state.exchangeTokenPromise;
     // Write debug token to indexedDB.
     await writeTokenToStorage(app, tokenFromDebugExchange);
     // Write debug token to state.
@@ -171,7 +171,7 @@ export async function getToken(
     // If token is undefined, there must be an error.
     // Return a dummy token along with the error.
     interopTokenResult = makeDummyTokenResult(error!);
-  } else if (error && isValid(token)) {
+  } else if (error) {
     if (isValid(token)) {
       // It's also possible a valid token exists, but there's also an error.
       // (Such as if the token is almost expired, tries to refresh, and

--- a/packages/app-check/src/storage.ts
+++ b/packages/app-check/src/storage.ts
@@ -51,7 +51,7 @@ export async function readTokenFromStorage(
  */
 export function writeTokenToStorage(
   app: FirebaseApp,
-  token: AppCheckTokenInternal
+  token?: AppCheckTokenInternal
 ): Promise<void> {
   if (isIndexedDBAvailable()) {
     return writeTokenToIndexedDB(app, token).catch(e => {

--- a/packages/app-check/src/types.ts
+++ b/packages/app-check/src/types.ts
@@ -52,6 +52,10 @@ export const enum ListenerType {
 export interface AppCheckTokenResult {
   readonly token: string;
   readonly error?: Error;
+  // Error that should not be propagated to 3P listeners, e.g. exchange
+  // request errors during proactive refresh period, while the token
+  // is still valid.
+  readonly internalError?: Error;
 }
 
 export interface AppCheckTokenInternal extends AppCheckToken {


### PR DESCRIPTION
Fixes https://github.com/firebase/firebase-js-sdk/issues/6373

## Causes
Found 2 causes of the problems:
1) `getToken()` needs to return an error result (a dummy token with an `error` property) whenever there is an error. It was assuming that if there was an error there would be no token. This is not always the case. If the token is about to expire, the proactive refresh attempt may run into an error at the exchange endpoint. Then there will be an existing valid token, but also en error.
2) When `getToken()` makes a request to the exchange endpoint, it stores the promise in `state.exchangeTokenPromise` and doesn't make another request if the promise is in flight, instead, any calls during that period await the existing promise. Once the promise is resolved, it clears `state.exchangeTokenPromise`, allowing future exchange requests to be made when needed. The mistake was that it only cleared this when the promise was resolved, and not when the promise was rejected, so that once an exchange request promise failed, another one wouldn't be made until memory was cleared. (This may be why users had to refresh the page.)

## Solutions
1) We need `getToken()` to return a token with a special error property, `internalError`. The reason this needs to be different from `error`, is that there's 2 different places that look for the `error` property on the result returned by `getToken()`. The first is the Refresher `operation` callback (defined inside `createTokenRefresher`), where we need it to find the `error` property (indicating there was an exchange request error) and throw, which will cause the Refresher to go into backoff retry mode. However, the other place that looks at `error` is `notifyTokenListeners` which calls the error callback for any 3P listeners if it finds `error`. If we have a valid token still, and it's just the proactive refresh attempt that's failing, we should just keep sending the token to 3P listeners as usual, it isn't an error from their point of view. That's why we use `internalError` for this case, so `notifyTokenListeners` can ignore it and the Refresher's operation callback can use it and throw, just as it does for `error`.
2) Replaced `then` with `finally`. The `return token` part of the `then` callback is no longer needed as the original promise already returns the token.

## Testing
Tested this using a 30 minute token and taking the tab offline using devtools, after initial token fetch. While offline, the app attempted to make requests to Firestore, and later App Check, after the App Check token had expired, but no more than 1 request per minute (and I think most were triggered by Firestore, which needs to get an App Check token when it tries to connect to the backend). After returning tab to online state, it immediately got a new token, and Firestore was able to write.