### PR TITLE
Fix document change leads to time travel across multiple tabs

### DIFF
--- a/.changeset/nine-cherries-swim.md
+++ b/.changeset/nine-cherries-swim.md
@@ -1,0 +1,5 @@
+---
+'@firebase/firestore': patch
+---
+
+Fix a time travel issue across multiple tabs

--- a/packages/firestore/src/local/local_store_impl.ts
+++ b/packages/firestore/src/local/local_store_impl.ts
@@ -1273,7 +1273,9 @@ function setMaxReadTime(
   collectionGroup: string,
   changedDocs: SortedMap<DocumentKey, Document>
 ): void {
-  let readTime = SnapshotVersion.min();
+  let readTime =
+    localStoreImpl.collectionGroupReadTime.get(collectionGroup) ||
+    SnapshotVersion.min();
   changedDocs.forEach((_, doc) => {
     if (doc.readTime.compareTo(readTime) > 0) {
       readTime = doc.readTime;


### PR DESCRIPTION
Fix: https://github.com/firebase/firebase-js-sdk/issues/6511