### PR TITLE
Add a flag allowing api-documenter to sort functions by first param

### DIFF
--- a/.changeset/popular-beans-wonder.md
+++ b/.changeset/popular-beans-wonder.md
@@ -1,0 +1,5 @@
+---
+'@firebase/api-documenter': minor
+---
+
+Add an option to sort functions by first param. (--sort-functions)

--- a/repo-scripts/api-documenter/src/cli/MarkdownAction.ts
+++ b/repo-scripts/api-documenter/src/cli/MarkdownAction.ts
@@ -21,10 +21,10 @@
 import { ApiDocumenterCommandLine } from './ApiDocumenterCommandLine';
 import { BaseAction } from './BaseAction';
 import { MarkdownDocumenter } from '../documenters/MarkdownDocumenter';
-import { CommandLineFlagParameter } from '@rushstack/ts-command-line';
+import { CommandLineStringParameter } from '@rushstack/ts-command-line';
 
 export class MarkdownAction extends BaseAction {
-  private _shouldSortFunctions!: CommandLineFlagParameter;
+  private _sortFunctions!: CommandLineStringParameter;
   public constructor(parser: ApiDocumenterCommandLine) {
     super({
       actionName: 'markdown',
@@ -38,10 +38,13 @@ export class MarkdownAction extends BaseAction {
   protected onDefineParameters(): void {
     super.onDefineParameters();
 
-    this._shouldSortFunctions = this.defineFlagParameter({
+    this._sortFunctions = this.defineStringParameter({
       parameterLongName: '--sort-functions',
+      argumentName: 'PRIORITY_PARAMS',
       description:
-        `Sorts functions tables and listings by first parameter.`
+        `Sorts functions tables and listings by first parameter.` +
+        ` Provide comma-separated strings for preferred params to be ` +
+        `ordered first. Alphabetical otherwise.`
     });
   }
 
@@ -49,7 +52,7 @@ export class MarkdownAction extends BaseAction {
     // override
     const { apiModel, outputFolder, addFileNameSuffix, projectName } =
       this.buildApiModel();
-    const shouldSortFunctions: boolean = this._shouldSortFunctions.value;
+    const sortFunctions: string = this._sortFunctions.value || '';
 
     if (!projectName) {
       throw new Error('No project name provided. Use --project.');
@@ -61,7 +64,7 @@ export class MarkdownAction extends BaseAction {
       outputFolder,
       addFileNameSuffix,
       projectName,
-      shouldSortFunctions
+      sortFunctions
     });
     markdownDocumenter.generateFiles();
   }

--- a/repo-scripts/api-documenter/src/cli/MarkdownAction.ts
+++ b/repo-scripts/api-documenter/src/cli/MarkdownAction.ts
@@ -21,8 +21,10 @@
 import { ApiDocumenterCommandLine } from './ApiDocumenterCommandLine';
 import { BaseAction } from './BaseAction';
 import { MarkdownDocumenter } from '../documenters/MarkdownDocumenter';
+import { CommandLineFlagParameter } from '@rushstack/ts-command-line';
 
 export class MarkdownAction extends BaseAction {
+  private _shouldSortFunctions!: CommandLineFlagParameter;
   public constructor(parser: ApiDocumenterCommandLine) {
     super({
       actionName: 'markdown',
@@ -33,10 +35,21 @@ export class MarkdownAction extends BaseAction {
     });
   }
 
+  protected onDefineParameters(): void {
+    super.onDefineParameters();
+
+    this._shouldSortFunctions = this.defineFlagParameter({
+      parameterLongName: '--sort-functions',
+      description:
+        `Sorts functions tables and listings by first parameter.`
+    });
+  }
+
   protected async onExecute(): Promise<void> {
     // override
     const { apiModel, outputFolder, addFileNameSuffix, projectName } =
       this.buildApiModel();
+    const shouldSortFunctions: boolean = this._shouldSortFunctions.value;
 
     if (!projectName) {
       throw new Error('No project name provided. Use --project.');
@@ -47,7 +60,8 @@ export class MarkdownAction extends BaseAction {
       documenterConfig: undefined,
       outputFolder,
       addFileNameSuffix,
-      projectName
+      projectName,
+      shouldSortFunctions
     });
     markdownDocumenter.generateFiles();
   }

--- a/repo-scripts/api-documenter/src/cli/MarkdownAction.ts
+++ b/repo-scripts/api-documenter/src/cli/MarkdownAction.ts
@@ -42,8 +42,8 @@ export class MarkdownAction extends BaseAction {
       parameterLongName: '--sort-functions',
       argumentName: 'PRIORITY_PARAMS',
       description:
-        `Sorts functions tables and listings by first parameter.` +
-        ` Provide comma-separated strings for preferred params to be ` +
+        `Sorts functions tables and listings by first parameter. ` +
+        `Provide comma-separated strings for preferred params to be ` +
         `ordered first. Alphabetical otherwise.`
     });
   }

--- a/repo-scripts/api-documenter/src/documenters/MarkdownDocumenter.ts
+++ b/repo-scripts/api-documenter/src/documenters/MarkdownDocumenter.ts
@@ -961,7 +961,7 @@ page_type: reference
       const sortedFunctionsFirstParamKeys = Object.keys(functionsRowGroup).sort(
         (a, b) => {
           if (!a || !b) {
-            console.log(`Missing one. a:${a}, b:${b}`)
+            console.log(`Missing one. a:${a}, b:${b}`);
           }
           if (priorityParams.includes(a) && priorityParams.includes(b)) {
             return priorityParams.indexOf(a) - priorityParams.indexOf(b);

--- a/repo-scripts/api-documenter/src/documenters/MarkdownDocumenter.ts
+++ b/repo-scripts/api-documenter/src/documenters/MarkdownDocumenter.ts
@@ -975,12 +975,13 @@ page_type: reference
         // Header for each group of functions grouped by first param.
         // Doesn't make sense if there's only one group.
         const headerText = paramKey ? `function(${paramKey}...)` : 'function()';
+        const formattedHeaderText = `<strong>${headerText}</strong>`;
         if (sortedFunctionsFirstParamKeys.length > 1) {
           finalFunctionsTable.addRow(
             new DocTableRow({ configuration }, [
               new DocTableCell({ configuration }, [
                 new DocParagraph({ configuration }, [
-                  new DocPlainText({ configuration, text: headerText })
+                  new DocPlainText({ configuration, text: formattedHeaderText })
                 ])
               ])
             ])

--- a/repo-scripts/api-documenter/src/documenters/MarkdownDocumenter.ts
+++ b/repo-scripts/api-documenter/src/documenters/MarkdownDocumenter.ts
@@ -960,9 +960,6 @@ page_type: reference
       }
       const sortedFunctionsFirstParamKeys = Object.keys(functionsRowGroup).sort(
         (a, b) => {
-          if (!a || !b) {
-            console.log(`Missing one. a:${a}, b:${b}`);
-          }
           if (priorityParams.includes(a) && priorityParams.includes(b)) {
             return priorityParams.indexOf(a) - priorityParams.indexOf(b);
           } else if (priorityParams.includes(a)) {

--- a/scripts/docgen/docgen.ts
+++ b/scripts/docgen/docgen.ts
@@ -182,7 +182,8 @@ async function generateDocs(
       outputFolder,
       '--project',
       'js',
-      '--sort-functions'
+      '--sort-functions',
+      'app,appCheck,auth,analytics,database,firestore,functions,storage,installations,messaging,performance,remoteConfig'
     ],
     { stdio: 'inherit' }
   );

--- a/scripts/docgen/docgen.ts
+++ b/scripts/docgen/docgen.ts
@@ -181,7 +181,8 @@ async function generateDocs(
       '--output',
       outputFolder,
       '--project',
-      'js'
+      'js',
+      '--sort-functions'
     ],
     { stdio: 'inherit' }
   );

--- a/scripts/docgen/docgen.ts
+++ b/scripts/docgen/docgen.ts
@@ -39,6 +39,24 @@ https://github.com/firebase/firebase-js-sdk
 const tmpDir = `${projectRoot}/temp`;
 const EXCLUDED_PACKAGES = ['app-compat', 'util', 'rules-unit-testing'];
 
+/**
+ * When ordering functions, will prioritize these first params at
+ * the top, in order.
+ */
+const PREFERRED_PARAMS = [
+  'app',
+  'analyticsInstance',
+  'appCheckInstance',
+  'db',
+  'firestore',
+  'functionsInstance',
+  'installations',
+  'messaging',
+  'performance',
+  'remoteConfig',
+  'storage'
+];
+
 yargs
   .command(
     '$0',
@@ -183,7 +201,7 @@ async function generateDocs(
       '--project',
       'js',
       '--sort-functions',
-      'app,appCheck,auth,analytics,database,firestore,functions,storage,installations,messaging,performance,remoteConfig'
+      PREFERRED_PARAMS.join(',')
     ],
     { stdio: 'inherit' }
   );


### PR DESCRIPTION
Attempting to clean up pages with large groups of functions such as https://firebase.google.com/docs/reference/js/auth by grouping them by first param.

Will gate this behind a flag, `--sort-functions` so that the change will not be forced on other consumers of our api-documenter fork (functions and admin teams).