### PR TITLE
Update prune-dts to allow beta APIs

### DIFF
--- a/common/api-review/firestore.api.md
+++ b/common/api-review/firestore.api.md
@@ -236,6 +236,30 @@ export function getFirestore(app: FirebaseApp): Firestore;
 // @public
 export function increment(n: number): FieldValue;
 
+// @beta
+export interface Index {
+    // (undocumented)
+    [key: string]: unknown;
+    readonly collectionGroup: string;
+    readonly fields?: IndexField[];
+}
+
+// @beta
+export interface IndexConfiguration {
+    // (undocumented)
+    [key: string]: unknown;
+    readonly indexes?: Index[];
+}
+
+// @beta
+export interface IndexField {
+    // (undocumented)
+    [key: string]: unknown;
+    readonly arrayConfig?: 'CONTAINS';
+    readonly fieldPath: string;
+    readonly order?: 'ASCENDING' | 'DESCENDING';
+}
+
 // @public
 export function initializeFirestore(app: FirebaseApp, settings: FirestoreSettings, databaseId?: string): Firestore;
 
@@ -398,6 +422,12 @@ export function setDoc<T>(reference: DocumentReference<T>, data: WithFieldValue<
 
 // @public
 export function setDoc<T>(reference: DocumentReference<T>, data: PartialWithFieldValue<T>, options: SetOptions): Promise<void>;
+
+// @beta
+export function setIndexConfiguration(firestore: Firestore, configuration: IndexConfiguration): Promise<void>;
+
+// @beta
+export function setIndexConfiguration(firestore: Firestore, json: string): Promise<void>;
 
 // @public
 export function setLogLevel(logLevel: LogLevel): void;

--- a/packages/firestore/src/api/database.ts
+++ b/packages/firestore/src/api/database.ts
@@ -88,7 +88,7 @@ export const CACHE_SIZE_UNLIMITED = LRU_COLLECTION_DISABLED;
 /**
  * The Cloud Firestore service interface.
  *
- * Do not call this constructor directly. Instead, use {@link getFirestore}.
+ * Do not call this constructor directly. Instead, use {@link (getFirestore:1)}.
  */
 export class Firestore extends LiteFirestore {
   /**
@@ -130,8 +130,8 @@ export class Firestore extends LiteFirestore {
 /**
  * Initializes a new instance of {@link Firestore} with the provided settings.
  * Can only be called before any other function, including
- * {@link getFirestore}. If the custom settings are empty, this function is
- * equivalent to calling {@link getFirestore}.
+ * {@link (getFirestore:1)}. If the custom settings are empty, this function is
+ * equivalent to calling {@link (getFirestore:1)}.
  *
  * @param app - The {@link @firebase/app#FirebaseApp} with which the {@link Firestore} instance will
  * be associated.
@@ -280,7 +280,7 @@ export function configureFirestore(firestore: Firestore): void {
  * Attempts to enable persistent storage, if possible.
  *
  * Must be called before any other functions (other than
- * {@link initializeFirestore}, {@link getFirestore} or
+ * {@link initializeFirestore}, {@link (getFirestore:1)} or
  * {@link clearIndexedDbPersistence}.
  *
  * If this fails, `enableIndexedDbPersistence()` will reject the promise it
@@ -444,7 +444,7 @@ function canFallbackFromIndexedDbError(
  * Must be called while the {@link Firestore} instance is not started (after the app is
  * terminated or when the app is first initialized). On startup, this function
  * must be called before other functions (other than {@link
- * initializeFirestore} or {@link getFirestore})). If the {@link Firestore}
+ * initializeFirestore} or {@link (getFirestore:1)})). If the {@link Firestore}
  * instance is still running, the promise will be rejected with the error code
  * of `failed-precondition`.
  *
@@ -537,7 +537,7 @@ export function disableNetwork(firestore: Firestore): Promise<void> {
  * may be used. Any other function will throw a `FirestoreError`.
  *
  * To restart after termination, create a new instance of FirebaseFirestore with
- * {@link getFirestore}.
+ * {@link (getFirestore:1)}.
  *
  * Termination does not cancel any pending writes, and any promises that are
  * awaiting a response from the server will not be resolved. If you have

--- a/packages/firestore/src/lite-api/database.ts
+++ b/packages/firestore/src/lite-api/database.ts
@@ -53,7 +53,7 @@ declare module '@firebase/component' {
 /**
  * The Cloud Firestore service interface.
  *
- * Do not call this constructor directly. Instead, use {@link getFirestore}.
+ * Do not call this constructor directly. Instead, use {@link (getFirestore:1)}.
  */
 export class Firestore implements FirestoreService {
   /**
@@ -157,8 +157,8 @@ export class Firestore implements FirestoreService {
 /**
  * Initializes a new instance of Cloud Firestore with the provided settings.
  * Can only be called before any other functions, including
- * {@link getFirestore}. If the custom settings are empty, this function is
- * equivalent to calling {@link getFirestore}.
+ * {@link (getFirestore:1)}. If the custom settings are empty, this function is
+ * equivalent to calling {@link (getFirestore:1)}.
  *
  * @param app - The {@link @firebase/app#FirebaseApp} with which the `Firestore` instance will
  * be associated.
@@ -172,8 +172,8 @@ export function initializeFirestore(
 /**
  * Initializes a new instance of Cloud Firestore with the provided settings.
  * Can only be called before any other functions, including
- * {@link getFirestore}. If the custom settings are empty, this function is
- * equivalent to calling {@link getFirestore}.
+ * {@link (getFirestore:1)}. If the custom settings are empty, this function is
+ * equivalent to calling {@link (getFirestore:1)}.
  *
  * @param app - The {@link @firebase/app#FirebaseApp} with which the `Firestore` instance will
  * be associated.
@@ -341,7 +341,7 @@ export function connectFirestoreEmulator(
  * response from the server will not be resolved.
  *
  * To restart after termination, create a new instance of `Firestore` with
- * {@link getFirestore}.
+ * {@link (getFirestore:1)}.
  *
  * Note: Under normal circumstances, calling `terminate()` is not required. This
  * function is useful only when you want to force this instance to release all of

--- a/repo-scripts/prune-dts/extract-public-api.ts
+++ b/repo-scripts/prune-dts/extract-public-api.ts
@@ -77,7 +77,12 @@ function loadApiExtractorConfig(
     mainEntryPointFilePath: typescriptDtsPath,
     'dtsRollup': {
       'enabled': dtsRollupEnabled,
-      publicTrimmedFilePath: rollupDtsPath,
+      /**
+       * Include beta APIs in documentation and typings. api-extractor/documenter
+       * seems to work this way by default but this intermediate step
+       * seems to restrict it to public tagged APIs.
+       */
+      betaTrimmedFilePath: rollupDtsPath,
       untrimmedFilePath: untrimmedRollupDtsPath
     },
     'tsdocMetadata': {


### PR DESCRIPTION
Update prune-dts (only used by Firestore I think) to allow beta APIs to get through (this seems to be the default behavior when using api-documenter). I think this is because api-documenter uses the *.api.json files and prune-dts filters out beta APIs before they even get into the json, whereas api-extractor puts everything in the json, and only filters what it puts into the public *.d.ts file.

Also an overload was recently added to `getFirestore()` which causes `{@link getFirestore}` to no longer work, leaving only a blank space in its place in reference docs. Fixed this by specifying the overload.

Also regenerated the firestore.api.md file after these changes.