### PR TITLE
Add leading slash to toc path

### DIFF
--- a/scripts/docgen/docgen.ts
+++ b/scripts/docgen/docgen.ts
@@ -89,7 +89,7 @@ async function generateToc() {
       '--input',
       'temp',
       '-p',
-      'docs/reference/js',
+      '/docs/reference/js',
       '-j'
     ],
     { stdio: 'inherit' }


### PR DESCRIPTION
Add a leading slash to keep the toc contents consistent with what's already on devsite.