### PR TITLE
Update doc string to reflect V9 changes

### DIFF
--- a/packages/auth/src/platform_browser/strategies/redirect.ts
+++ b/packages/auth/src/platform_browser/strategies/redirect.ts
@@ -218,8 +218,7 @@ export async function _linkWithRedirect(
  *
  * @remarks
  * If sign-in succeeded, returns the signed in user. If sign-in was unsuccessful, fails with an
- * error. If no redirect operation was called, returns a {@link UserCredential}
- * with a null `user`.
+ * error. If no redirect operation was called, returns `null`.
  *
  * @example
  * ```javascript

--- a/packages/firebase/compat/index.d.ts
+++ b/packages/firebase/compat/index.d.ts
@@ -2613,8 +2613,7 @@ declare namespace firebase.auth {
      * Returns a UserCredential from the redirect-based sign-in flow.
      *
      * If sign-in succeeded, returns the signed in user. If sign-in was
-     * unsuccessful, fails with an error. If no redirect operation was called,
-     * returns a UserCredential with a null User.
+     * unsuccessful, fails with an error. If no redirect operation was called, returns `null`.
      *
      * <h4>Error Codes</h4>
      * <dl>


### PR DESCRIPTION
In v8, getRedirectResult returned a UserCredential with a null user if no redirect operation was called. In v9, it now returns null. Change docs to reflect this change

https://github.com/firebase/firebase-js-sdk/issues/6616