### PR TITLE
Make COUNT queries available to the Firestore Console

### DIFF
--- a/.changeset/metal-goats-unite.md
+++ b/.changeset/metal-goats-unite.md
@@ -1,0 +1,8 @@
+---
+'@firebase/firestore': minor
+'@firebase/firestore-compat': minor
+'@firebase/webchannel-wrapper': minor
+'firebase': minor
+---
+
+Set withCredentials=true when making requests via non-streaming RPCs, like is done for streaming RPCs.

--- a/packages/firestore-compat/src/index.console.ts
+++ b/packages/firestore-compat/src/index.console.ts
@@ -22,8 +22,11 @@ import {
   Firestore as FirestoreExp,
   FirestoreError,
   _EmptyAuthCredentialsProvider,
-  _EmptyAppCheckTokenProvider
+  _EmptyAppCheckTokenProvider,
+  Query as ExpQuery,
+  getCountFromServer
 } from '@firebase/firestore';
+import { Compat } from '@firebase/util';
 
 import {
   Firestore as FirestoreCompat,
@@ -98,6 +101,15 @@ export class Firestore extends FirestoreCompat {
       new MemoryPersistenceProvider()
     );
   }
+
+  INTERNAL = {
+    delete: () => this.terminate(),
+    count: (query: Compat<ExpQuery<unknown>>) => {
+      return getCountFromServer(query._delegate).then(response => {
+        return response.data().count;
+      });
+    }
+  };
 }
 
 function databaseIdFromFirestoreDatabase(

--- a/packages/firestore/src/platform/browser/webchannel_connection.ts
+++ b/packages/firestore/src/platform/browser/webchannel_connection.ts
@@ -72,6 +72,7 @@ export class WebChannelConnection extends RestConnection {
   ): Promise<Resp> {
     return new Promise((resolve: Resolver<Resp>, reject: Rejecter) => {
       const xhr = new XhrIo();
+      xhr.setWithCredentials(true);
       xhr.listenOnce(EventType.COMPLETE, () => {
         try {
           switch (xhr.getLastErrorCode()) {

--- a/packages/webchannel-wrapper/src/index.d.ts
+++ b/packages/webchannel-wrapper/src/index.d.ts
@@ -74,6 +74,8 @@ export class XhrIo {
   getResponseJson(): WebChannelError | object;
 
   listenOnce(type: string, cb: (param: unknown) => void): void;
+
+  setWithCredentials(withCredentials: boolean): void;
 }
 
 export interface WebChannelOptions {

--- a/packages/webchannel-wrapper/src/index.js
+++ b/packages/webchannel-wrapper/src/index.js
@@ -75,7 +75,8 @@ goog.net.XhrIo.prototype['getResponseJson'] =
 goog.net.XhrIo.prototype['getResponseText'] =
   goog.net.XhrIo.prototype.getResponseText;
 goog.net.XhrIo.prototype['send'] = goog.net.XhrIo.prototype.send;
-goog.net.XhrIo.prototype['setWithCredentials'] = goog.net.XhrIo.prototype.setWithCredentials;
+goog.net.XhrIo.prototype['setWithCredentials'] =
+  goog.net.XhrIo.prototype.setWithCredentials;
 
 module['exports']['createWebChannelTransport'] =
   goog.net.createWebChannelTransport;

--- a/packages/webchannel-wrapper/src/index.js
+++ b/packages/webchannel-wrapper/src/index.js
@@ -75,6 +75,7 @@ goog.net.XhrIo.prototype['getResponseJson'] =
 goog.net.XhrIo.prototype['getResponseText'] =
   goog.net.XhrIo.prototype.getResponseText;
 goog.net.XhrIo.prototype['send'] = goog.net.XhrIo.prototype.send;
+goog.net.XhrIo.prototype['setWithCredentials'] = goog.net.XhrIo.prototype.setWithCredentials;
 
 module['exports']['createWebChannelTransport'] =
   goog.net.createWebChannelTransport;


### PR DESCRIPTION
There are two notable changes in this PR:
1. Add a call to `XhrIo.setWithCredentials(true)` when invoking the `RunAggregationQuery` RPC.
2. Add a hook in firestore-compat to call `getCountFromServer()` in the `INTERNAL` object.

The `XhrIo.setWithCredentials(true)` change is required so that the Firestore Console's authentication cookie will be included in the HTTP request headers. Without it, the requests fail with HTTP 401 errors. This problem is unique to the Firestore Console because they use 1st-party authentication. This change should have no effect on any other users. Moreover, the "Listen" and "Write" streams have been invoking `XhrIo.setWithCredentials(true)` indirectly since the dawn of time by specifying `supportsCrossDomainXhr: true` in the `WebChannelOptions`: https://github.com/firebase/firebase-js-sdk/blob/34ad43cc2a9863f7ac326c314d9539fcbc1f0913/packages/firestore/src/platform/browser/webchannel_connection.ts#L179 which trickles down to call `XhrIo.setWithCredentials(true)` here: https://github.com/google/closure-library/blob/e439bfd5ff09e0efd85693fc5adf23462d5a39d4/closure/goog/labs/net/webchannel/webchannelbase.js#L2601

The change to the firestore-compat library is done because the Firestore Console is stuck using the compat SDK for now, and we don't want to add a new public API surface to the firestore-compat library.

Googlers see b/250662155 for more info.