### PR TITLE
Loading the `iframe` lazily for improved performance 🚤 

### DIFF
--- a/packages/auth/src/platform_browser/iframe/iframe.ts
+++ b/packages/auth/src/platform_browser/iframe/iframe.ts
@@ -39,7 +39,8 @@ const IFRAME_ATTRIBUTES = {
     height: '1px'
   },
   'aria-hidden': 'true',
-  tabindex: '-1'
+  tabindex: '-1',
+  loading: 'lazy'
 };
 
 // Map from apiHost to endpoint ID for passing into iframe. In current SDK, apiHost can be set to


### PR DESCRIPTION
Loading the `iframe` lazily for improved performance. I thought this will inform browser to load the `iframe` in less priority because due to load of large number of scripts lighthouse score is getting low :(

_Extremely sorry if I made any mistakes :(_