### PR TITLE
Enable COUNT integration tests, now that backend support has rolled out

### DIFF
--- a/packages/firestore/test/integration/api_internal/aggregation.test.ts
+++ b/packages/firestore/test/integration/api_internal/aggregation.test.ts
@@ -38,88 +38,85 @@ import {
   withTestDb
 } from '../util/helpers';
 
-apiDescribe(
-  'Count quries',
-  (persistence: boolean) => {
-    it('can run count query getCountFromServer', () => {
-      const testDocs = {
-        a: { author: 'authorA', title: 'titleA' },
-        b: { author: 'authorB', title: 'titleB' }
-      };
-      return withTestCollection(persistence, testDocs, async coll => {
-        const snapshot = await getCountFromServer(coll);
-        expect(snapshot.data().count).to.equal(2);
-      });
+apiDescribe('Count quries', (persistence: boolean) => {
+  it('can run count query getCountFromServer', () => {
+    const testDocs = {
+      a: { author: 'authorA', title: 'titleA' },
+      b: { author: 'authorB', title: 'titleB' }
+    };
+    return withTestCollection(persistence, testDocs, async coll => {
+      const snapshot = await getCountFromServer(coll);
+      expect(snapshot.data().count).to.equal(2);
     });
+  });
 
-    it("count query doesn't use converter", () => {
-      const testDocs = {
-        a: { author: 'authorA', title: 'titleA' },
-        b: { author: 'authorB', title: 'titleB' }
-      };
-      const throwingConverter = {
-        toFirestore(obj: never): DocumentData {
-          throw new Error('should never be called');
-        },
-        fromFirestore(snapshot: QueryDocumentSnapshot): never {
-          throw new Error('should never be called');
-        }
-      };
-      return withTestCollection(persistence, testDocs, async coll => {
-        const query_ = query(
-          coll,
-          where('author', '==', 'authorA')
-        ).withConverter(throwingConverter);
-        const snapshot = await getCountFromServer(query_);
-        expect(snapshot.data().count).to.equal(1);
-      });
+  it("count query doesn't use converter", () => {
+    const testDocs = {
+      a: { author: 'authorA', title: 'titleA' },
+      b: { author: 'authorB', title: 'titleB' }
+    };
+    const throwingConverter = {
+      toFirestore(obj: never): DocumentData {
+        throw new Error('should never be called');
+      },
+      fromFirestore(snapshot: QueryDocumentSnapshot): never {
+        throw new Error('should never be called');
+      }
+    };
+    return withTestCollection(persistence, testDocs, async coll => {
+      const query_ = query(
+        coll,
+        where('author', '==', 'authorA')
+      ).withConverter(throwingConverter);
+      const snapshot = await getCountFromServer(query_);
+      expect(snapshot.data().count).to.equal(1);
     });
+  });
 
-    it('count query supports collection groups', () => {
-      return withTestDb(persistence, async db => {
-        const collectionGroupId = doc(collection(db, 'aggregateQueryTest')).id;
-        const docPaths = [
-          `${collectionGroupId}/cg-doc1`,
-          `abc/123/${collectionGroupId}/cg-doc2`,
-          `zzz${collectionGroupId}/cg-doc3`,
-          `abc/123/zzz${collectionGroupId}/cg-doc4`,
-          `abc/123/zzz/${collectionGroupId}`
-        ];
-        const batch = writeBatch(db);
-        for (const docPath of docPaths) {
-          batch.set(doc(db, docPath), { x: 1 });
-        }
-        await batch.commit();
-        const snapshot = await getCountFromServer(
-          collectionGroup(db, collectionGroupId)
-        );
-        expect(snapshot.data().count).to.equal(2);
-      });
+  it('count query supports collection groups', () => {
+    return withTestDb(persistence, async db => {
+      const collectionGroupId = doc(collection(db, 'aggregateQueryTest')).id;
+      const docPaths = [
+        `${collectionGroupId}/cg-doc1`,
+        `abc/123/${collectionGroupId}/cg-doc2`,
+        `zzz${collectionGroupId}/cg-doc3`,
+        `abc/123/zzz${collectionGroupId}/cg-doc4`,
+        `abc/123/zzz/${collectionGroupId}`
+      ];
+      const batch = writeBatch(db);
+      for (const docPath of docPaths) {
+        batch.set(doc(db, docPath), { x: 1 });
+      }
+      await batch.commit();
+      const snapshot = await getCountFromServer(
+        collectionGroup(db, collectionGroupId)
+      );
+      expect(snapshot.data().count).to.equal(2);
     });
+  });
 
-    it('getCountFromServer fails if firestore is terminated', () => {
-      return withEmptyTestCollection(persistence, async (coll, firestore) => {
-        await terminate(firestore);
-        expect(() => getCountFromServer(coll)).to.throw(
-          'The client has already been terminated.'
-        );
-      });
+  it('getCountFromServer fails if firestore is terminated', () => {
+    return withEmptyTestCollection(persistence, async (coll, firestore) => {
+      await terminate(firestore);
+      expect(() => getCountFromServer(coll)).to.throw(
+        'The client has already been terminated.'
+      );
     });
+  });
 
-    it("terminate doesn't crash when there is count query in flight", () => {
-      return withEmptyTestCollection(persistence, async (coll, firestore) => {
-        void getCountFromServer(coll);
-        await terminate(firestore);
-      });
+  it("terminate doesn't crash when there is count query in flight", () => {
+    return withEmptyTestCollection(persistence, async (coll, firestore) => {
+      void getCountFromServer(coll);
+      await terminate(firestore);
     });
+  });
 
-    it('getCountFromServer fails if user is offline', () => {
-      return withEmptyTestCollection(persistence, async (coll, firestore) => {
-        await disableNetwork(firestore);
-        await expect(getCountFromServer(coll)).to.be.eventually.rejectedWith(
-          'Failed to get count result because the client is offline'
-        );
-      });
+  it('getCountFromServer fails if user is offline', () => {
+    return withEmptyTestCollection(persistence, async (coll, firestore) => {
+      await disableNetwork(firestore);
+      await expect(getCountFromServer(coll)).to.be.eventually.rejectedWith(
+        'Failed to get count result because the client is offline'
+      );
     });
-  }
-);
+  });
+});

--- a/packages/firestore/test/integration/api_internal/aggregation.test.ts
+++ b/packages/firestore/test/integration/api_internal/aggregation.test.ts
@@ -37,9 +37,8 @@ import {
   withTestCollection,
   withTestDb
 } from '../util/helpers';
-import { USE_EMULATOR } from '../util/settings';
 
-(USE_EMULATOR ? apiDescribe : apiDescribe.skip)(
+apiDescribe(
   'Count quries',
   (persistence: boolean) => {
     it('can run count query getCountFromServer', () => {

--- a/packages/firestore/test/lite/integration.test.ts
+++ b/packages/firestore/test/lite/integration.test.ts
@@ -2150,9 +2150,7 @@ describe('Count quries', () => {
   it('run count query fails on invalid collection reference', () => {
     return withTestDb(async db => {
       const queryForRejection = collection(db, '__badpath__');
-      await expect(getCount(queryForRejection)).to.eventually.be.rejectedWith(
-        'Request failed with error: Bad Request'
-      );
+      await expect(getCount(queryForRejection)).to.eventually.be.rejected;
     });
   });
 

--- a/packages/firestore/test/lite/integration.test.ts
+++ b/packages/firestore/test/lite/integration.test.ts
@@ -83,8 +83,7 @@ import { runTransaction } from '../../src/lite-api/transaction';
 import { writeBatch } from '../../src/lite-api/write_batch';
 import {
   DEFAULT_PROJECT_ID,
-  DEFAULT_SETTINGS,
-  USE_EMULATOR
+  DEFAULT_SETTINGS
 } from '../integration/util/settings';
 
 import {
@@ -2120,7 +2119,7 @@ describe('withConverter() support', () => {
 });
 
 // eslint-disable-next-line no-restricted-properties
-(USE_EMULATOR ? describe : describe.skip)('Count quries', () => {
+describe('Count quries', () => {
   it('AggregateQuerySnapshot inherits the original query', () => {
     return withTestCollection(async coll => {
       const query_ = query(coll);


### PR DESCRIPTION
Enable the integration tests for COUNT that were added in https://github.com/firebase/firebase-js-sdk/pull/6597 now that the RunAggregationQuery RPC has been fully rolled out.