### PR TITLE
Implemented exponential backoff with query

### DIFF
--- a/common/api-review/storage.api.md
+++ b/common/api-review/storage.api.md
@@ -325,8 +325,7 @@ export class _UploadTask {
     _metadata: Metadata | null;
     // Warning: (ae-forgotten-export) The symbol "Unsubscribe" needs to be exported by the entry point index.d.ts
     // Warning: (ae-forgotten-export) The symbol "Subscribe" needs to be exported by the entry point index.d.ts
-    on(type: _TaskEvent, // Note: This isn't being used. Its type is also incorrect.
-    nextOrObserver?: StorageObserver<UploadTaskSnapshot> | null | ((snapshot: UploadTaskSnapshot) => unknown), error?: ((a: StorageError_2) => unknown) | null, completed?: CompleteFn | null): Unsubscribe_2 | Subscribe_2<UploadTaskSnapshot>;
+    on(type: _TaskEvent, nextOrObserver?: StorageObserver<UploadTaskSnapshot> | null | ((snapshot: UploadTaskSnapshot) => unknown), error?: ((a: StorageError_2) => unknown) | null, completed?: CompleteFn | null): Unsubscribe_2 | Subscribe_2<UploadTaskSnapshot>;
     pause(): boolean;
     resume(): boolean;
     get snapshot(): UploadTaskSnapshot;

--- a/packages/storage/src/implementation/backoff.ts
+++ b/packages/storage/src/implementation/backoff.ts
@@ -24,15 +24,24 @@ type id = (p1: boolean) => void;
 export { id };
 
 /**
- * @param f May be invoked
- *     before the function returns.
- * @param callback Get all the arguments passed to the function
- *     passed to f, including the initial boolean.
+ * Accepts a callback for an action to perform (`doRequest`),
+ * and then a callback for when the backoff has completed (`backoffCompleteCb`).
+ * The callback sent to start requires an argument to call (`onRequestComplete`)
+ * When `start` calls `doRequest`, it passes a callback for when the request has
+ * completed, `onRequestComplete`. Based on this, the backoff continues, with
+ * another call to `doRequest` and the above loop continues until the timeout
+ * is hit, or a successful response occurs.
+ * @description
+ * @param doRequest Callback to perform request
+ * @param backoffCompleteCb Callback to call when backoff has been completed
  */
 export function start(
-  f: (p1: (success: boolean) => void, canceled: boolean) => void,
+  doRequest: (
+    onRequestComplete: (success: boolean) => void,
+    canceled: boolean
+  ) => void,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  callback: (...args: any[]) => unknown,
+  backoffCompleteCb: (...args: any[]) => unknown,
   timeout: number
 ): id {
   // TODO(andysoto): make this code cleaner (probably refactor into an actual
@@ -55,14 +64,14 @@ export function start(
   function triggerCallback(...args: any[]): void {
     if (!triggeredCallback) {
       triggeredCallback = true;
-      callback.apply(null, args);
+      backoffCompleteCb.apply(null, args);
     }
   }
 
   function callWithDelay(millis: number): void {
     retryTimeoutId = setTimeout(() => {
       retryTimeoutId = null;
-      f(handler, canceled());
+      doRequest(responseHandler, canceled());
     }, millis);
   }
 
@@ -72,7 +81,7 @@ export function start(
     }
   }
 
-  function handler(success: boolean, ...args: any[]): void {
+  function responseHandler(success: boolean, ...args: any[]): void {
     if (triggeredCallback) {
       clearGlobalTimeout();
       return;

--- a/packages/storage/src/implementation/backoff.ts
+++ b/packages/storage/src/implementation/backoff.ts
@@ -26,7 +26,7 @@ export { id };
 /**
  * Accepts a callback for an action to perform (`doRequest`),
  * and then a callback for when the backoff has completed (`backoffCompleteCb`).
- * The callback sent to start requires an argument to call (`onRequestComplete`)
+ * The callback sent to start requires an argument to call (`onRequestComplete`).
  * When `start` calls `doRequest`, it passes a callback for when the request has
  * completed, `onRequestComplete`. Based on this, the backoff continues, with
  * another call to `doRequest` and the above loop continues until the timeout

--- a/packages/storage/src/implementation/constants.ts
+++ b/packages/storage/src/implementation/constants.ts
@@ -45,7 +45,7 @@ export const DEFAULT_MAX_UPLOAD_RETRY_TIME = 10 * 60 * 1000;
 /**
  * 1 second
  */
-export const DEFAULT_MIN_SLEEP_TIME = 1000;
+export const DEFAULT_MIN_SLEEP_TIME_MILLIS = 1000;
 
 /**
  * This is the value of Number.MIN_SAFE_INTEGER, which is not well supported

--- a/packages/storage/src/implementation/constants.ts
+++ b/packages/storage/src/implementation/constants.ts
@@ -43,6 +43,11 @@ export const DEFAULT_MAX_OPERATION_RETRY_TIME = 2 * 60 * 1000;
 export const DEFAULT_MAX_UPLOAD_RETRY_TIME = 10 * 60 * 1000;
 
 /**
+ * 1 second
+ */
+export const DEFAULT_MIN_SLEEP_TIME = 1000;
+
+/**
  * This is the value of Number.MIN_SAFE_INTEGER, which is not well supported
  * enough for us to use it directly.
  */

--- a/packages/storage/src/implementation/error.ts
+++ b/packages/storage/src/implementation/error.ts
@@ -34,6 +34,7 @@ export class StorageError extends FirebaseError {
    * @param code - A StorageErrorCode string to be prefixed with 'storage/' and
    *  added to the end of the message.
    * @param message  - Error message.
+   * @param status_ - Corresponding HTTP Status Code
    */
   constructor(code: StorageErrorCode, message: string, private status_ = 0) {
     super(

--- a/packages/storage/src/implementation/error.ts
+++ b/packages/storage/src/implementation/error.ts
@@ -35,7 +35,7 @@ export class StorageError extends FirebaseError {
    *  added to the end of the message.
    * @param message  - Error message.
    */
-  constructor(code: StorageErrorCode, message: string) {
+  constructor(code: StorageErrorCode, message: string, private status_ = 0) {
     super(
       prependCode(code),
       `Firebase Storage: ${message} (${prependCode(code)})`
@@ -44,6 +44,14 @@ export class StorageError extends FirebaseError {
     // Without this, `instanceof StorageError`, in tests for example,
     // returns false.
     Object.setPrototypeOf(this, StorageError.prototype);
+  }
+
+  get status(): number {
+    return this.status_;
+  }
+
+  set status(status: number) {
+    this.status_ = status;
   }
 
   /**

--- a/packages/storage/src/implementation/request.ts
+++ b/packages/storage/src/implementation/request.ts
@@ -26,7 +26,7 @@ import { ErrorHandler, RequestHandler, RequestInfo } from './requestinfo';
 import { isJustDef } from './type';
 import { makeQueryString } from './url';
 import { Connection, ErrorCode, Headers, ConnectionType } from './connection';
-import { isRetryStatusCode_ } from './utils';
+import { isRetryStatusCode } from './utils';
 
 export interface Request<T> {
   getPromise(): Promise<T>;
@@ -121,7 +121,7 @@ class NetworkRequest<I extends ConnectionType, O> implements Request<O> {
           const status = connection.getStatus();
           if (
             (!hitServer ||
-              isRetryStatusCode_(status, this.additionalRetryCodes_)) &&
+              isRetryStatusCode(status, this.additionalRetryCodes_)) &&
             this.retry
           ) {
             const wasCanceled = connection.getErrorCode() === ErrorCode.ABORT;
@@ -181,14 +181,6 @@ class NetworkRequest<I extends ConnectionType, O> implements Request<O> {
     if (this.canceled_) {
       backoffDone(false, new RequestEndStatus(false, null, true));
     } else {
-      /**
-       * start accepts a callback for an action to perform (`doTheRequest`),
-       * and then a callback for when the backoff has completed (`backoffDone`).
-       * The callback sent to start requires an argument to call (`backoffCallback`)
-       * when operation has completed, and based on this, the backoff continues, with
-       * another call to `doTheRequest` and the above loop continues until the timeout
-       * is hit, or a successful response occurs.
-       */
       this.backoffId_ = start(doTheRequest, backoffDone, this.timeout_);
     }
   }

--- a/packages/storage/src/implementation/request.ts
+++ b/packages/storage/src/implementation/request.ts
@@ -181,6 +181,14 @@ class NetworkRequest<I extends ConnectionType, O> implements Request<O> {
     if (this.canceled_) {
       backoffDone(false, new RequestEndStatus(false, null, true));
     } else {
+      /**
+       * start accepts a callback for an action to perform (`doTheRequest`),
+       * and then a callback for when the backoff has completed (`backoffDone`).
+       * The callback sent to start requires an argument to call (`backoffCallback`)
+       * when operation has completed, and based on this, the backoff continues, with
+       * another call to `doTheRequest` and the above loop continues until the timeout
+       * is hit, or a successful response occurs.
+       */
       this.backoffId_ = start(doTheRequest, backoffDone, this.timeout_);
     }
   }

--- a/packages/storage/src/implementation/request.ts
+++ b/packages/storage/src/implementation/request.ts
@@ -26,6 +26,7 @@ import { ErrorHandler, RequestHandler, RequestInfo } from './requestinfo';
 import { isJustDef } from './type';
 import { makeQueryString } from './url';
 import { Connection, ErrorCode, Headers, ConnectionType } from './connection';
+import { isRetryStatusCode_ } from './utils';
 
 export interface Request<T> {
   getPromise(): Promise<T>;
@@ -69,7 +70,8 @@ class NetworkRequest<I extends ConnectionType, O> implements Request<O> {
     private errorCallback_: ErrorHandler | null,
     private timeout_: number,
     private progressCallback_: ((p1: number, p2: number) => void) | null,
-    private connectionFactory_: () => Connection<I>
+    private connectionFactory_: () => Connection<I>,
+    private retry = true
   ) {
     this.promise_ = new Promise((resolve, reject) => {
       this.resolve_ = resolve as (value?: O | PromiseLike<O>) => void;
@@ -93,16 +95,15 @@ class NetworkRequest<I extends ConnectionType, O> implements Request<O> {
       const connection = this.connectionFactory_();
       this.pendingConnection_ = connection;
 
-      const progressListener: (progressEvent: ProgressEvent) => void =
-        progressEvent => {
-          const loaded = progressEvent.loaded;
-          const total = progressEvent.lengthComputable
-            ? progressEvent.total
-            : -1;
-          if (this.progressCallback_ !== null) {
-            this.progressCallback_(loaded, total);
-          }
-        };
+      const progressListener: (
+        progressEvent: ProgressEvent
+      ) => void = progressEvent => {
+        const loaded = progressEvent.loaded;
+        const total = progressEvent.lengthComputable ? progressEvent.total : -1;
+        if (this.progressCallback_ !== null) {
+          this.progressCallback_(loaded, total);
+        }
+      };
       if (this.progressCallback_ !== null) {
         connection.addUploadProgressListener(progressListener);
       }
@@ -118,7 +119,11 @@ class NetworkRequest<I extends ConnectionType, O> implements Request<O> {
           this.pendingConnection_ = null;
           const hitServer = connection.getErrorCode() === ErrorCode.NO_ERROR;
           const status = connection.getStatus();
-          if (!hitServer || this.isRetryStatusCode_(status)) {
+          if (
+            (!hitServer ||
+              isRetryStatusCode_(status, this.additionalRetryCodes_)) &&
+            this.retry
+          ) {
             const wasCanceled = connection.getErrorCode() === ErrorCode.ABORT;
             backoffCallback(
               false,
@@ -196,22 +201,6 @@ class NetworkRequest<I extends ConnectionType, O> implements Request<O> {
       this.pendingConnection_.abort();
     }
   }
-
-  private isRetryStatusCode_(status: number): boolean {
-    // The codes for which to retry came from this page:
-    // https://cloud.google.com/storage/docs/exponential-backoff
-    const isFiveHundredCode = status >= 500 && status < 600;
-    const extraRetryCodes = [
-      // Request Timeout: web server didn't receive full request in time.
-      408,
-      // Too Many Requests: you're getting rate-limited, basically.
-      429
-    ];
-    const isExtraRetryCode = extraRetryCodes.indexOf(status) !== -1;
-    const isRequestSpecificRetryCode =
-      this.additionalRetryCodes_.indexOf(status) !== -1;
-    return isFiveHundredCode || isExtraRetryCode || isRequestSpecificRetryCode;
-  }
 }
 
 /**
@@ -271,7 +260,8 @@ export function makeRequest<I extends ConnectionType, O>(
   authToken: string | null,
   appCheckToken: string | null,
   requestFactory: () => Connection<I>,
-  firebaseVersion?: string
+  firebaseVersion?: string,
+  retry = true
 ): Request<O> {
   const queryPart = makeQueryString(requestInfo.urlParams);
   const url = requestInfo.url + queryPart;
@@ -291,6 +281,7 @@ export function makeRequest<I extends ConnectionType, O>(
     requestInfo.errorHandler,
     requestInfo.timeout,
     requestInfo.progressCallback,
-    requestFactory
+    requestFactory,
+    retry
   );
 }

--- a/packages/storage/src/implementation/requests.ts
+++ b/packages/storage/src/implementation/requests.ts
@@ -52,7 +52,6 @@ import { FirebaseStorageImpl } from '../service';
  */
 export function handlerCheck(cndn: boolean): void {
   if (!cndn) {
-    console.log('HERE');
     throw unknown();
   }
 }

--- a/packages/storage/src/implementation/requests.ts
+++ b/packages/storage/src/implementation/requests.ts
@@ -104,7 +104,7 @@ export function sharedErrorHandler(
     xhr: Connection<ConnectionType>,
     err: StorageError
   ): StorageError {
-    let newErr;
+    let newErr: StorageError;
     if (xhr.getStatus() === 401) {
       if (
         // This exact message string is the only consistent part of the
@@ -126,6 +126,7 @@ export function sharedErrorHandler(
         }
       }
     }
+    newErr.status = xhr.getStatus();
     newErr.serverResponse = err.serverResponse;
     return newErr;
   }
@@ -534,8 +535,15 @@ export function continueResumableUpload(
   }
   const startByte = status_.current;
   const endByte = startByte + bytesToUpload;
-  const uploadCommand =
-    bytesToUpload === bytesLeft ? 'upload, finalize' : 'upload';
+  let uploadCommand = '';
+  if (bytesToUpload === 0) {
+    // TODO(mtewani): Maybe we should extract this out.
+    uploadCommand = 'finalize';
+  } else if (bytesLeft === bytesToUpload) {
+    uploadCommand = 'upload, finalize';
+  } else {
+    uploadCommand = 'upload';
+  }
   const headers = {
     'X-Goog-Upload-Command': uploadCommand,
     'X-Goog-Upload-Offset': `${status_.current}`

--- a/packages/storage/src/implementation/requests.ts
+++ b/packages/storage/src/implementation/requests.ts
@@ -52,6 +52,7 @@ import { FirebaseStorageImpl } from '../service';
  */
 export function handlerCheck(cndn: boolean): void {
   if (!cndn) {
+    console.log('HERE');
     throw unknown();
   }
 }

--- a/packages/storage/src/implementation/requests.ts
+++ b/packages/storage/src/implementation/requests.ts
@@ -537,7 +537,6 @@ export function continueResumableUpload(
   const endByte = startByte + bytesToUpload;
   let uploadCommand = '';
   if (bytesToUpload === 0) {
-    // TODO(mtewani): Maybe we should extract this out.
     uploadCommand = 'finalize';
   } else if (bytesLeft === bytesToUpload) {
     uploadCommand = 'upload, finalize';

--- a/packages/storage/src/implementation/string.ts
+++ b/packages/storage/src/implementation/string.ts
@@ -92,7 +92,6 @@ export function dataFromString(
     // do nothing
   }
 
-  console.log('here');
   // assert(false);
   throw unknown();
 }

--- a/packages/storage/src/implementation/string.ts
+++ b/packages/storage/src/implementation/string.ts
@@ -92,6 +92,7 @@ export function dataFromString(
     // do nothing
   }
 
+  console.log('here');
   // assert(false);
   throw unknown();
 }

--- a/packages/storage/src/implementation/utils.ts
+++ b/packages/storage/src/implementation/utils.ts
@@ -1,0 +1,35 @@
+/**
+ * @license
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export function isRetryStatusCode_(
+  status: number,
+  additionalRetryCodes: number[]
+): boolean {
+  // The codes for which to retry came from this page:
+  // https://cloud.google.com/storage/docs/exponential-backoff
+  const isFiveHundredCode = status >= 500 && status < 600;
+  const extraRetryCodes = [
+    // Request Timeout: web server didn't receive full request in time.
+    408,
+    // Too Many Requests: you're getting rate-limited, basically.
+    429
+  ];
+  const isExtraRetryCode = extraRetryCodes.indexOf(status) !== -1;
+  const isRequestSpecificRetryCode =
+    additionalRetryCodes.indexOf(status) !== -1;
+  return isFiveHundredCode || isExtraRetryCode || isRequestSpecificRetryCode;
+}

--- a/packages/storage/src/implementation/utils.ts
+++ b/packages/storage/src/implementation/utils.ts
@@ -15,7 +15,13 @@
  * limitations under the License.
  */
 
-export function isRetryStatusCode_(
+/**
+ * Checks the status code to see if the action should be retried.
+ *
+ * @param status Current HTTP status code returned by server.
+ * @param additionalRetryCodes additional retry codes to check against
+ */
+export function isRetryStatusCode(
   status: number,
   additionalRetryCodes: number[]
 ): boolean {
@@ -29,7 +35,6 @@ export function isRetryStatusCode_(
     429
   ];
   const isExtraRetryCode = extraRetryCodes.indexOf(status) !== -1;
-  const isRequestSpecificRetryCode =
-    additionalRetryCodes.indexOf(status) !== -1;
-  return isFiveHundredCode || isExtraRetryCode || isRequestSpecificRetryCode;
+  const isAdditionalRetryCode = additionalRetryCodes.indexOf(status) !== -1;
+  return isFiveHundredCode || isExtraRetryCode || isAdditionalRetryCode;
 }

--- a/packages/storage/src/service.ts
+++ b/packages/storage/src/service.ts
@@ -302,7 +302,8 @@ export class FirebaseStorageImpl implements FirebaseStorage {
     requestInfo: RequestInfo<I, O>,
     requestFactory: () => Connection<I>,
     authToken: string | null,
-    appCheckToken: string | null
+    appCheckToken: string | null,
+    retry = true
   ): Request<O> {
     if (!this._deleted) {
       const request = makeRequest(
@@ -311,7 +312,8 @@ export class FirebaseStorageImpl implements FirebaseStorage {
         authToken,
         appCheckToken,
         requestFactory,
-        this._firebaseVersion
+        this._firebaseVersion,
+        retry
       );
       this._requests.add(request);
       // Request removes itself from set when complete.

--- a/packages/storage/src/task.ts
+++ b/packages/storage/src/task.ts
@@ -56,7 +56,7 @@ import { Reference } from './reference';
 import { newTextConnection } from './platform/connection';
 import { isRetryStatusCode } from './implementation/utils';
 import { CompleteFn } from '@firebase/util';
-import { DEFAULT_MIN_SLEEP_TIME } from './implementation/constants';
+import { DEFAULT_MIN_SLEEP_TIME_MILLIS } from './implementation/constants';
 
 /**
  * Represents a blob being uploaded. Can be used to pause/resume/cancel the
@@ -130,7 +130,7 @@ export class UploadTask {
           } else {
             this.sleepTime = Math.max(
               this.sleepTime * 2,
-              DEFAULT_MIN_SLEEP_TIME
+              DEFAULT_MIN_SLEEP_TIME_MILLIS
             );
             this._needToFetchStatus = true;
             this.completeTransitions_();
@@ -191,7 +191,7 @@ export class UploadTask {
             // Happens if we miss the metadata on upload completion.
             this._fetchMetadata();
           } else {
-            console.log('sleeping for', this.sleepTime);
+            // console.trace('sleeping for', this.sleepTime);
             setTimeout(() => {
               this._continueUpload();
             }, this.sleepTime);
@@ -336,7 +336,7 @@ export class UploadTask {
     const currentSize = RESUMABLE_UPLOAD_CHUNK_SIZE * this._chunkMultiplier;
 
     // Max chunk size is 32M.
-    if (currentSize < 32 * 1024 * 1024) {
+    if (currentSize * 2 < 32 * 1024 * 1024) {
       this._chunkMultiplier *= 2;
     }
   }

--- a/packages/storage/src/task.ts
+++ b/packages/storage/src/task.ts
@@ -191,7 +191,6 @@ export class UploadTask {
             // Happens if we miss the metadata on upload completion.
             this._fetchMetadata();
           } else {
-            // console.trace('sleeping for', this.sleepTime);
             setTimeout(() => {
               this._continueUpload();
             }, this.sleepTime);

--- a/packages/storage/src/task.ts
+++ b/packages/storage/src/task.ts
@@ -376,8 +376,7 @@ export class UploadTask {
         requestInfo,
         newTextConnection,
         authToken,
-        appCheckToken,
-        /*retry=*/ false
+        appCheckToken
       );
       this._request = multipartRequest;
       multipartRequest.getPromise().then(metadata => {

--- a/packages/storage/src/task.ts
+++ b/packages/storage/src/task.ts
@@ -516,7 +516,7 @@ export class UploadTask {
    *     callbacks.
    */
   on(
-    type: TaskEvent, // Note: This isn't being used. Its type is also incorrect.
+    type: TaskEvent,
     nextOrObserver?:
       | StorageObserver<UploadTaskSnapshot>
       | null
@@ -524,6 +524,7 @@ export class UploadTask {
     error?: ((a: StorageError) => unknown) | null,
     completed?: CompleteFn | null
   ): Unsubscribe | Subscribe<UploadTaskSnapshot> {
+    // Note: `type` isn't being used. Its type is also incorrect. TaskEvent should not be a string.
     const observer = new Observer(
       (nextOrObserver as
         | StorageObserverInternal<UploadTaskSnapshot>

--- a/packages/storage/src/task.ts
+++ b/packages/storage/src/task.ts
@@ -22,7 +22,8 @@ import { FbsBlob } from './implementation/blob';
 import {
   canceled,
   StorageErrorCode,
-  StorageError
+  StorageError,
+  retryLimitExceeded
 } from './implementation/error';
 import {
   InternalTaskState,
@@ -53,6 +54,7 @@ import {
 } from './implementation/requests';
 import { Reference } from './reference';
 import { newTextConnection } from './platform/connection';
+import { isRetryStatusCode_ } from './implementation/utils';
 
 /**
  * Represents a blob being uploaded. Can be used to pause/resume/cancel the
@@ -92,6 +94,15 @@ export class UploadTask {
   private _reject?: (p1: StorageError) => void = undefined;
   private _promise: Promise<UploadTaskSnapshot>;
 
+  // TODO(mtewani): Update these to use predefined constants
+  private sleepTime = 0;
+
+  private maxSleepTime = 10000;
+
+  isExponentialBackoffExpired(): boolean {
+    return this.sleepTime > this.maxSleepTime;
+  }
+
   /**
    * @param ref - The firebaseStorage.Reference object this task came
    *     from, untyped to avoid cyclic dependencies.
@@ -111,6 +122,17 @@ export class UploadTask {
         this._needToFetchStatus = true;
         this.completeTransitions_();
       } else {
+        const backoffExpired = this.isExponentialBackoffExpired();
+        if (isRetryStatusCode_(error.status, [])) {
+          if (backoffExpired) {
+            error = retryLimitExceeded();
+          } else {
+            this.sleepTime = Math.max(this.sleepTime * 2, 1000);
+            this._needToFetchStatus = true;
+            this.completeTransitions_();
+            return;
+          }
+        }
         this._error = error;
         this._transition(InternalTaskState.ERROR);
       }
@@ -163,7 +185,9 @@ export class UploadTask {
             // Happens if we miss the metadata on upload completion.
             this._fetchMetadata();
           } else {
-            this._continueUpload();
+            setTimeout(() => {
+              this._continueUpload();
+            }, this.sleepTime);
           }
         }
       }
@@ -283,7 +307,8 @@ export class UploadTask {
         requestInfo,
         newTextConnection,
         authToken,
-        appCheckToken
+        appCheckToken,
+        false
       );
       this._request = uploadRequest;
       uploadRequest.getPromise().then((newStatus: ResumableUploadStatus) => {
@@ -344,7 +369,8 @@ export class UploadTask {
         requestInfo,
         newTextConnection,
         authToken,
-        appCheckToken
+        appCheckToken,
+        false
       );
       this._request = multipartRequest;
       multipartRequest.getPromise().then(metadata => {

--- a/packages/storage/test/unit/requests.test.ts
+++ b/packages/storage/test/unit/requests.test.ts
@@ -632,6 +632,74 @@ describe('Firebase Storage > Requests', () => {
 
     return assertBodyEquals(requestInfo.body, smallBlobString);
   });
+  it('populates requestInfo with the upload command when more chunks are left', () => {
+    const url =
+      'https://this.is.totally.a.real.url.com/hello/upload?whatsgoingon';
+    const requestInfo = continueResumableUpload(
+      locationNormal,
+      storageService,
+      url,
+      bigBlob,
+      RESUMABLE_UPLOAD_CHUNK_SIZE,
+      mappings
+    );
+    assertObjectIncludes(
+      {
+        url,
+        method: 'POST',
+        urlParams: {},
+        headers: {
+          'X-Goog-Upload-Command': 'upload',
+          'X-Goog-Upload-Offset': '0'
+        }
+      },
+      requestInfo
+    );
+
+    assert.deepEqual(
+      requestInfo.body,
+      bigBlob.slice(0, RESUMABLE_UPLOAD_CHUNK_SIZE)!.uploadData()
+    );
+  });
+  it('populates requestInfo with just the finalize command command when no more data needs to be uploaded', () => {
+    const url =
+      'https://this.is.totally.a.real.url.com/hello/upload?whatsgoingon';
+    const blobSize = bigBlob.size();
+    const requestInfo = continueResumableUpload(
+      locationNormal,
+      storageService,
+      url,
+      bigBlob,
+      RESUMABLE_UPLOAD_CHUNK_SIZE,
+      mappings,
+      {
+        current: blobSize,
+        total: blobSize,
+        finalized: false,
+        metadata: null
+      }
+    );
+    assertObjectIncludes(
+      {
+        url,
+        method: 'POST',
+        urlParams: {},
+        headers: {
+          'X-Goog-Upload-Command': 'finalize',
+          'X-Goog-Upload-Offset': blobSize.toString()
+        }
+      },
+      requestInfo
+    );
+
+    assert.deepEqual(
+      requestInfo.body,
+      bigBlob.slice(blobSize, blobSize)!.uploadData()
+    );
+  });
+  /**
+   * TODO(mtewani): Test exponential backoff
+   */
   it('continueResumableUpload handler', () => {
     const url =
       'https://this.is.totally.a.real.url.com/hello/upload?whatsgoingon';

--- a/packages/storage/test/unit/requests.test.ts
+++ b/packages/storage/test/unit/requests.test.ts
@@ -697,9 +697,6 @@ describe('Firebase Storage > Requests', () => {
       bigBlob.slice(blobSize, blobSize)!.uploadData()
     );
   });
-  /**
-   * TODO(mtewani): Test exponential backoff
-   */
   it('continueResumableUpload handler', () => {
     const url =
       'https://this.is.totally.a.real.url.com/hello/upload?whatsgoingon';

--- a/packages/storage/test/unit/task.test.ts
+++ b/packages/storage/test/unit/task.test.ts
@@ -14,22 +14,32 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { assert } from 'chai';
+import { assert, expect } from 'chai';
 import { FbsBlob } from '../../src/implementation/blob';
 import { Location } from '../../src/implementation/location';
 import { Unsubscribe } from '../../src/implementation/observer';
 import { TaskEvent, TaskState } from '../../src/implementation/taskenums';
 import { Reference } from '../../src/reference';
 import { UploadTask } from '../../src/task';
-import { fakeServerHandler, storageServiceWithHandler } from './testshared';
+import {
+  fake503ServerHandler,
+  fakeServerHandler,
+  storageServiceWithHandler
+} from './testshared';
 import { injectTestConnection } from '../../src/platform/connection';
+import { Deferred } from '@firebase/util';
+import { retryLimitExceeded } from '../../src/implementation/error';
+import { SinonFakeTimers, useFakeTimers } from 'sinon';
 
 const testLocation = new Location('bucket', 'object');
 const smallBlob = new FbsBlob(new Uint8Array([97]));
 const bigBlob = new FbsBlob(new ArrayBuffer(1024 * 1024));
 
 describe('Firebase Storage > Upload Task', () => {
-  after(() => injectTestConnection(null));
+  let clock: SinonFakeTimers;
+  after(() => {
+    injectTestConnection(null);
+  });
 
   it('Works for a small upload w/ an observer', done => {
     const storageService = storageServiceWithHandler(fakeServerHandler());
@@ -151,6 +161,12 @@ describe('Firebase Storage > Upload Task', () => {
     });
   });
 
+  /**
+   * Takes a blob, uploads the blob, and tracks the events in the `events` array. It asserts in the `onComplete` callback itself.
+   *
+   * @param blob Blob to upload
+   * @returns resolved/rejected promise
+   */
   function runNormalUploadTest(blob: FbsBlob): Promise<void> {
     const storageService = storageServiceWithHandler(fakeServerHandler());
     const task = new UploadTask(
@@ -272,6 +288,7 @@ describe('Firebase Storage > Upload Task', () => {
       fixedAssertTrue(allTotalsTheSame);
       fixedAssertTrue(lastIsAll);
 
+      // serves as the cancellation task. It will cancel immediately and upon completion, will check that an error occurred
       const task2 = new UploadTask(
         new Reference(storageService, testLocation),
         blob
@@ -284,6 +301,7 @@ describe('Firebase Storage > Upload Task', () => {
           TaskEvent.STATE_CHANGED,
           snapshot => {
             const state = snapshot.state;
+            // TODO: This status update should probably be extracted out in a helper function.
             if (
               lastState !== TaskState.RUNNING &&
               state === TaskState.RUNNING
@@ -297,10 +315,13 @@ describe('Firebase Storage > Upload Task', () => {
             }
             lastState = state;
           },
-          () => {
+          e => {
+            console.error(e);
+            // TODO: These assertions should be moved down. Adding them here makes it unclear what the assertions are.
             events2.push('failure');
             fixedAssertEquals(events2.length, 2);
             fixedAssertEquals(events2[0], 'resume');
+            // This is not enough. Simply asserting that there was some failure doesn't validate that the *right* error was thrown.
             fixedAssertEquals(events2[1], 'failure');
             resolve(null);
           },
@@ -316,11 +337,115 @@ describe('Firebase Storage > Upload Task', () => {
 
     return promise;
   }
+  enum StateType {
+    RESUME = 'resume',
+    PAUSE = 'pause',
+    ERROR = 'error',
+    COMPLETE = 'complete'
+  }
+  interface State {
+    type: StateType;
+    data?: Error;
+  }
+  interface Progress {
+    bytesTransferred: number;
+    totalBytes: number;
+  }
+  interface TotalState {
+    events: State[];
+    progress: Progress[];
+  }
+  function run500UploadTest(blob: FbsBlob): Promise<TotalState> {
+    const storageService = storageServiceWithHandler(fake503ServerHandler());
+    const task = new UploadTask(
+      new Reference(storageService, testLocation),
+      blob
+    );
+
+    const deferred = new Deferred<TotalState>();
+    let lastState: TaskState;
+
+    const events: State[] = [];
+    const progress: Progress[] = [];
+
+    task.on(
+      TaskEvent.STATE_CHANGED,
+      snapshot => {
+        const { state } = snapshot;
+        if (lastState !== TaskState.RUNNING && state === TaskState.RUNNING) {
+          events.push({ type: StateType.RESUME });
+        } else if (
+          lastState !== TaskState.PAUSED &&
+          state === TaskState.PAUSED
+        ) {
+          events.push({ type: StateType.PAUSE });
+        }
+        const p = {
+          bytesTransferred: snapshot.bytesTransferred,
+          totalBytes: snapshot.totalBytes
+        };
+        progress.push(p);
+
+        lastState = state;
+      },
+      function onError(e) {
+        events.push({ type: StateType.ERROR, data: e });
+        deferred.resolve({
+          events,
+          progress
+        });
+      },
+      function onComplete() {
+        events.push({ type: StateType.COMPLETE });
+        deferred.resolve({
+          events,
+          progress
+        });
+      }
+    );
+
+    return deferred.promise;
+  }
 
   it('Calls callback sequences for small uploads correctly', () => {
     return runNormalUploadTest(smallBlob);
   });
   it('Calls callback sequences for big uploads correctly', () => {
     return runNormalUploadTest(bigBlob);
+  });
+  it('test callback sequences for big uploads correctly', async () => {
+    clock = useFakeTimers();
+    // Kick off upload
+    const promise = run500UploadTest(bigBlob);
+    // Run all timers
+    await clock.runAllAsync();
+    const { events, progress } = await promise;
+    expect(events.length).to.equal(2);
+    expect(events[0]).to.deep.equal({ type: 'resume' });
+    expect(events[1].type).to.deep.equal('error');
+    const retryLimitError = retryLimitExceeded();
+    expect(events[1].data!.name).to.deep.equal(retryLimitError.name);
+    expect(events[1].data!.message).to.deep.equal(retryLimitError.message);
+    const blobSize = bigBlob.size();
+    expect(progress.length).to.equal(4);
+    expect(progress[0]).to.deep.equal({
+      bytesTransferred: 0,
+      totalBytes: blobSize
+    });
+    expect(progress[1]).to.deep.equal({
+      bytesTransferred: 262144,
+      totalBytes: blobSize
+    });
+    // Upon continueUpload the multiplier becomes * 2, so chunkSize becomes 2 * DEFAULT_CHUNK_SIZE(256 * 1024)
+    expect(progress[2]).to.deep.equal({
+      bytesTransferred: 786432,
+      totalBytes: blobSize
+    });
+    // Chunk size is smaller here since there are less bytes left to upload than the chunkSize.
+    expect(progress[3]).to.deep.equal({
+      bytesTransferred: 1048576,
+      totalBytes: blobSize
+    });
+    clock.restore();
   });
 });

--- a/packages/storage/test/unit/testshared.ts
+++ b/packages/storage/test/unit/testshared.ts
@@ -197,7 +197,7 @@ interface Response {
   body: string;
   headers: Headers;
 }
-type RequestHandler = (
+export type RequestHandler = (
   url: string,
   method: string,
   body?: ArrayBufferView | Blob | string | null,
@@ -355,10 +355,11 @@ export function fakeServerHandler(
 }
 
 /**
- * Simulate when upload, finalize returns a 503 each time, and then query returns a 200. Expect the result to be a timeout
+ * Responds with a 503 for finalize.
+ * @param fakeMetadata metadata to respond with for query
+ * @returns a handler for requests
  */
-
-export function fake503ServerHandler(
+export function fake503ForFinalizeServerHandler(
   fakeMetadata: Partial<Metadata> = defaultFakeMetadata
 ): RequestHandler {
   const stats: {
@@ -398,7 +399,6 @@ export function fake503ServerHandler(
         currentSize: 0,
         finalSize: +headers['X-Goog-Upload-Header-Content-Length']
       };
-      console.log('returning url');
 
       return {
         status: 200,
@@ -411,7 +411,6 @@ export function fake503ServerHandler(
 
     const matches = url.match(/^http:\/\/example\.com\?([0-9]+)$/);
     if (matches === null) {
-      console.log(url);
       return { status: 400, body: '', headers: {} };
     }
 
@@ -448,6 +447,105 @@ export function fake503ServerHandler(
         status: 200,
         body: JSON.stringify(fakeMetadata),
         headers: statusHeaders('active')
+      };
+    }
+  }
+  return handler;
+}
+
+/**
+ * Responds with a 503 for upload.
+ * @param fakeMetadata metadata to respond with for query
+ * @returns a handler for requests
+ */
+export function fake503ForUploadServerHandler(
+  fakeMetadata: Partial<Metadata> = defaultFakeMetadata
+): RequestHandler {
+  const stats: {
+    [num: number]: {
+      currentSize: number;
+      finalSize: number;
+    };
+  } = {};
+
+  let nextId: number = 0;
+
+  function statusHeaders(status: string, existing?: Headers): Headers {
+    if (existing) {
+      existing['X-Goog-Upload-Status'] = status;
+      return existing;
+    } else {
+      return { 'X-Goog-Upload-Status': status };
+    }
+  }
+
+  function handler(
+    url: string,
+    method: string,
+    content?: ArrayBufferView | Blob | string | null,
+    headers?: Headers
+  ): Response {
+    method = method || 'GET';
+    content = content || '';
+    headers = headers || {};
+
+    // const contentLength =
+    // (content as Blob).size || (content as string).length || 0;
+    if (headers['X-Goog-Upload-Protocol'] === 'resumable') {
+      const thisId = nextId;
+      nextId++;
+      stats[thisId] = {
+        currentSize: 0,
+        finalSize: +headers['X-Goog-Upload-Header-Content-Length']
+      };
+
+      return {
+        status: 200,
+        body: '',
+        headers: statusHeaders('active', {
+          'X-Goog-Upload-URL': 'http://example.com?' + thisId
+        })
+      };
+    }
+
+    const matches = url.match(/^http:\/\/example\.com\?([0-9]+)$/);
+    if (matches === null) {
+      return { status: 400, body: '', headers: {} };
+    }
+
+    const id = +matches[1];
+    if (!stats[id]) {
+      return { status: 400, body: 'Invalid upload id', headers: {} };
+    }
+
+    if (headers['X-Goog-Upload-Command'] === 'query') {
+      return {
+        status: 200,
+        body: '',
+        headers: statusHeaders('active', {
+          'X-Goog-Upload-Size-Received': stats[id].currentSize.toString()
+        })
+      };
+    }
+
+    const commands = (headers['X-Goog-Upload-Command'] as string)
+      .split(',')
+      .map(str => {
+        return str.trim();
+      });
+    const isUpload = commands.indexOf('upload') !== -1;
+
+    if (isUpload) {
+      return {
+        status: 503,
+        body: JSON.stringify(fakeMetadata),
+        headers: statusHeaders('active')
+      };
+    } else {
+      return {
+        status: 200,
+        body: JSON.stringify(fakeMetadata),
+        headers: statusHeaders('final')
       };
     }
   }

--- a/packages/storage/test/unit/testshared.ts
+++ b/packages/storage/test/unit/testshared.ts
@@ -398,6 +398,7 @@ export function fake503ServerHandler(
         currentSize: 0,
         finalSize: +headers['X-Goog-Upload-Header-Content-Length']
       };
+      console.log('returning url');
 
       return {
         status: 200,
@@ -410,6 +411,7 @@ export function fake503ServerHandler(
 
     const matches = url.match(/^http:\/\/example\.com\?([0-9]+)$/);
     if (matches === null) {
+      console.log(url);
       return { status: 400, body: '', headers: {} };
     }
 
@@ -448,6 +450,37 @@ export function fake503ServerHandler(
         headers: statusHeaders('active')
       };
     }
+  }
+  return handler;
+}
+
+export function fakeOneShot503ServerHandler(
+  fakeMetadata: Partial<Metadata> = defaultFakeMetadata
+): RequestHandler {
+  function statusHeaders(status: string, existing?: Headers): Headers {
+    if (existing) {
+      existing['X-Goog-Upload-Status'] = status;
+      return existing;
+    } else {
+      return { 'X-Goog-Upload-Status': status };
+    }
+  }
+
+  function handler(
+    url: string,
+    method: string,
+    content?: ArrayBufferView | Blob | string | null,
+    headers?: Headers
+  ): Response {
+    method = method || 'GET';
+    content = content || '';
+    headers = headers || {};
+
+    return {
+      status: 503,
+      body: JSON.stringify(fakeMetadata),
+      headers: statusHeaders('final')
+    };
   }
   return handler;
 }

--- a/packages/storage/test/unit/utils.test.ts
+++ b/packages/storage/test/unit/utils.test.ts
@@ -1,0 +1,40 @@
+/**
+ * @license
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { expect } from 'chai';
+import { isRetryStatusCode } from '../../src/implementation/utils';
+
+describe('Storage Utils', () => {
+  it('does not deem 400 as a retry status code', () => {
+    const isRetry = isRetryStatusCode(400, []);
+    expect(isRetry).to.be.false;
+  });
+  it('deems extra retry codes as retryable ', () => {
+    let isRetry = isRetryStatusCode(408, []);
+    expect(isRetry).to.be.true;
+    isRetry = isRetryStatusCode(429, []);
+    expect(isRetry).to.be.true;
+  });
+  it('deems error codes beyond 500 as retryable', () => {
+    const isRetry = isRetryStatusCode(503, []);
+    expect(isRetry).to.be.true;
+  });
+  it('deems additional error codes as retryable', () => {
+    const isRetry = isRetryStatusCode(400, [400]);
+    expect(isRetry).to.be.true;
+  });
+});


### PR DESCRIPTION
When upload requests respond with a 503, there is a situation where the bytes were uploaded, yet finalize did not occur. This can result in an incorrect offset being sent to the server. We should make a request that checks the status of the upload, and updating our offset based on that.

This PR implements that, along with a backoff feature, exponentially increasing the time between different requests being issued.