### PR TITLE
Remove json path and fix process check

### DIFF
--- a/.changeset/strong-squids-dress.md
+++ b/.changeset/strong-squids-dress.md
@@ -1,0 +1,5 @@
+---
+'@firebase/util': patch
+---
+
+Remove `__FIREBASE_DEFAULTS_PATH__` option for now, as the current implementation causes Webpack warnings. Also fix `process.env` check to work in environments where `process` exists but `process.env` does not.

--- a/packages/util/src/defaults.ts
+++ b/packages/util/src/defaults.ts
@@ -57,32 +57,12 @@ const getDefaultsFromGlobal = (): FirebaseDefaults | undefined =>
  * process.env.__FIREBASE_DEFAULTS_PATH__
  */
 const getDefaultsFromEnvVariable = (): FirebaseDefaults | undefined => {
-  if (typeof process === 'undefined') {
+  if (typeof process === 'undefined' || typeof process.env === 'undefined') {
     return;
   }
   const defaultsJsonString = process.env.__FIREBASE_DEFAULTS__;
-  const defaultsJsonPath = process.env.__FIREBASE_DEFAULTS_PATH__;
   if (defaultsJsonString) {
-    if (defaultsJsonPath) {
-      console.warn(
-        `Values were provided for both __FIREBASE_DEFAULTS__ ` +
-          `and __FIREBASE_DEFAULTS_PATH__. __FIREBASE_DEFAULTS_PATH__ ` +
-          `will be ignored.`
-      );
-    }
     return JSON.parse(defaultsJsonString);
-  }
-  if (defaultsJsonPath && typeof require !== 'undefined') {
-    try {
-      // eslint-disable-next-line @typescript-eslint/no-require-imports
-      const json = require(defaultsJsonPath);
-      return json;
-    } catch (e) {
-      console.warn(
-        `Unable to read defaults from file provided to ` +
-          `__FIREBASE_DEFAULTS_PATH__: ${defaultsJsonPath}`
-      );
-    }
   }
 };
 


### PR DESCRIPTION
Fix bugs introduced in https://github.com/firebase/firebase-js-sdk/pull/6526:

1) Remove `__FIREBASE_DEFAULTS_PATH__` option to point to a JSON file path for modular autoinit defaults. This causes webpack warnings about dynamic `require()`s although the code is only meant to take that path in a Node environment. (See https://github.com/firebase/firebase-js-sdk/issues/6660). If we can figure out a way around this, we can add the functionality back.

2) Fix the `process` check to be more robust and handle environments that have `process` but do not have `process.env`. This incorporates the fix in PR https://github.com/firebase/firebase-js-sdk/pull/6663

Fixes https://github.com/firebase/firebase-js-sdk/issues/6660
Fixes https://github.com/firebase/firebase-js-sdk/issues/6662