### PR TITLE
Update public api signature for setUserId to reflect internal functions

### DIFF
--- a/.changeset/moody-icons-repeat.md
+++ b/.changeset/moody-icons-repeat.md
@@ -1,0 +1,5 @@
+---
+'@firebase/analytics': patch
+---
+
+Correct `id` type in `setUserId`

--- a/common/api-review/analytics.api.md
+++ b/common/api-review/analytics.api.md
@@ -421,7 +421,7 @@ export interface SettingsOptions {
 }
 
 // @public
-export function setUserId(analyticsInstance: Analytics, id: string, options?: AnalyticsCallOptions): void;
+export function setUserId(analyticsInstance: Analytics, id: string | null, options?: AnalyticsCallOptions): void;
 
 // @public
 export function setUserProperties(analyticsInstance: Analytics, properties: CustomParams, options?: AnalyticsCallOptions): void;

--- a/packages/analytics/src/api.ts
+++ b/packages/analytics/src/api.ts
@@ -177,7 +177,7 @@ export function setCurrentScreen(
  */
 export function setUserId(
   analyticsInstance: Analytics,
-  id: string,
+  id: string | null,
   options?: AnalyticsCallOptions
 ): void {
   analyticsInstance = getModularInstance(analyticsInstance);

--- a/packages/analytics/src/functions.test.ts
+++ b/packages/analytics/src/functions.test.ts
@@ -116,6 +116,18 @@ describe('FirebaseAnalytics methods', () => {
     });
   });
 
+  it('setUserId() with null (user) id calls gtag correctly (instance)', async () => {
+    await setUserId(gtagStub, fakeInitializationPromise, null);
+    expect(gtagStub).to.have.been.calledWith(
+      GtagCommand.CONFIG,
+      fakeMeasurementId,
+      {
+        'user_id': null,
+        update: true
+      }
+    );
+  });
+
   it('setUserId() calls gtag correctly (instance)', async () => {
     await setUserId(gtagStub, fakeInitializationPromise, 'user123');
     expect(gtagStub).to.have.been.calledWith(
@@ -134,6 +146,15 @@ describe('FirebaseAnalytics methods', () => {
     });
     expect(gtagStub).to.be.calledWith(GtagCommand.SET, {
       'user_id': 'user123'
+    });
+  });
+
+  it('setUserId() with null (user) id calls gtag correctly (global)', async () => {
+    await setUserId(gtagStub, fakeInitializationPromise, null, {
+      global: true
+    });
+    expect(gtagStub).to.be.calledWith(GtagCommand.SET, {
+      'user_id': null
     });
   });
 


### PR DESCRIPTION
Allow users to pass in `null` value to public `setUserId` per internal implementations 

https://github.com/firebase/firebase-js-sdk/issues/6592