### PR TITLE
Handle IPv6 addresses in emulator autoinit.

### DIFF
--- a/.changeset/shy-dragons-fly.md
+++ b/.changeset/shy-dragons-fly.md
@@ -1,0 +1,9 @@
+---
+"@firebase/database": patch
+"@firebase/firestore": patch
+"@firebase/functions": patch
+"@firebase/storage": patch
+"@firebase/util": patch
+---
+
+Handle IPv6 addresses in emulator autoinit.

--- a/common/api-review/util.api.md
+++ b/common/api-review/util.api.md
@@ -219,6 +219,9 @@ export const getDefaultAppConfig: () => Record<string, string> | undefined;
 export const getDefaultEmulatorHost: (productName: string) => string | undefined;
 
 // @public
+export const getDefaultEmulatorHostnameAndPort: (productName: string) => [hostname: string, port: number] | undefined;
+
+// @public
 export const getExperimentalSetting: <T extends ExperimentalKey>(name: T) => FirebaseDefaults[`_${T}`];
 
 // Warning: (ae-missing-release-tag) "getGlobal" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)

--- a/packages/database/src/api/Database.ts
+++ b/packages/database/src/api/Database.ts
@@ -321,7 +321,7 @@ export function getDatabase(
     identifier: url
   }) as Database;
   const emulator = getDefaultEmulatorHostnameAndPort('database');
-  if (emulator)
+  if (emulator) {
     connectDatabaseEmulator(db, ...emulator);
   }
   return db;

--- a/packages/database/src/api/Database.ts
+++ b/packages/database/src/api/Database.ts
@@ -28,7 +28,7 @@ import {
   getModularInstance,
   createMockUserToken,
   EmulatorMockTokenOptions,
-  getDefaultEmulatorHost
+  getDefaultEmulatorHostnameAndPort
 } from '@firebase/util';
 
 import { AppCheckTokenProvider } from '../core/AppCheckTokenProvider';
@@ -320,10 +320,9 @@ export function getDatabase(
   const db = _getProvider(app, 'database').getImmediate({
     identifier: url
   }) as Database;
-  const databaseEmulatorHost = getDefaultEmulatorHost('database');
-  if (databaseEmulatorHost) {
-    const [host, port] = databaseEmulatorHost.split(':');
-    connectDatabaseEmulator(db, host, parseInt(port, 10));
+  const emulator = getDefaultEmulatorHostnameAndPort('database');
+  if (emulator)
+    connectDatabaseEmulator(db, ...emulator);
   }
   return db;
 }

--- a/packages/firestore/src/api/database.ts
+++ b/packages/firestore/src/api/database.ts
@@ -21,7 +21,7 @@ import {
   FirebaseApp,
   getApp
 } from '@firebase/app';
-import { deepEqual, getDefaultEmulatorHost } from '@firebase/util';
+import { deepEqual, getDefaultEmulatorHostnameAndPort } from '@firebase/util';
 
 import { User } from '../auth/user';
 import {
@@ -242,10 +242,9 @@ export function getFirestore(
     identifier: databaseId
   }) as Firestore;
   if (!db._initialized) {
-    const firestoreEmulatorHost = getDefaultEmulatorHost('firestore');
-    if (firestoreEmulatorHost) {
-      const [host, port] = firestoreEmulatorHost.split(':');
-      connectFirestoreEmulator(db, host, parseInt(port, 10));
+    const emulator = getDefaultEmulatorHostnameAndPort('firestore');
+    if (emulator) {
+      connectFirestoreEmulator(db, ...emulator);
     }
   }
   return db;

--- a/packages/firestore/src/lite-api/database.ts
+++ b/packages/firestore/src/lite-api/database.ts
@@ -25,7 +25,7 @@ import {
 import {
   createMockUserToken,
   EmulatorMockTokenOptions,
-  getDefaultEmulatorHost
+  getDefaultEmulatorHostnameAndPort
 } from '@firebase/util';
 
 import {
@@ -270,10 +270,9 @@ export function getFirestore(
     identifier: databaseId
   }) as Firestore;
   if (!db._initialized) {
-    const firestoreEmulatorHost = getDefaultEmulatorHost('firestore');
-    if (firestoreEmulatorHost) {
-      const [host, port] = firestoreEmulatorHost.split(':');
-      connectFirestoreEmulator(db, host, parseInt(port, 10));
+    const emulator = getDefaultEmulatorHostnameAndPort('firestore');
+    if (emulator) {
+      connectFirestoreEmulator(db, ...emulator);
     }
   }
   return db;

--- a/packages/functions/src/api.ts
+++ b/packages/functions/src/api.ts
@@ -27,7 +27,10 @@ import {
   httpsCallable as _httpsCallable,
   httpsCallableFromURL as _httpsCallableFromURL
 } from './service';
-import { getModularInstance, getDefaultEmulatorHost } from '@firebase/util';
+import {
+  getModularInstance,
+  getDefaultEmulatorHostnameAndPort
+} from '@firebase/util';
 
 export * from './public-types';
 
@@ -51,11 +54,9 @@ export function getFunctions(
   const functionsInstance = functionsProvider.getImmediate({
     identifier: regionOrCustomDomain
   });
-  const functionsEmulatorHost = getDefaultEmulatorHost('functions');
-  if (functionsEmulatorHost) {
-    const [host, port] = functionsEmulatorHost.split(':');
-    // eslint-disable-next-line no-restricted-globals
-    connectFunctionsEmulator(functionsInstance, host, parseInt(port, 10));
+  const emulator = getDefaultEmulatorHostnameAndPort('functions');
+  if (emulator) {
+    connectFunctionsEmulator(functionsInstance, ...emulator);
   }
   return functionsInstance;
 }

--- a/packages/storage/src/api.ts
+++ b/packages/storage/src/api.ts
@@ -53,7 +53,7 @@ import { STORAGE_TYPE } from './constants';
 import {
   EmulatorMockTokenOptions,
   getModularInstance,
-  getDefaultEmulatorHost
+  getDefaultEmulatorHostnameAndPort
 } from '@firebase/util';
 import { StringFormat } from './implementation/string';
 
@@ -334,11 +334,9 @@ export function getStorage(
   const storageInstance = storageProvider.getImmediate({
     identifier: bucketUrl
   });
-  const storageEmulatorHost = getDefaultEmulatorHost('storage');
-  if (storageEmulatorHost) {
-    const [host, port] = storageEmulatorHost.split(':');
-    // eslint-disable-next-line no-restricted-globals
-    connectStorageEmulator(storageInstance, host, parseInt(port, 10));
+  const emulator = getDefaultEmulatorHostnameAndPort('storage');
+  if () {
+    connectStorageEmulator(storageInstance, ...emulator);
   }
   return storageInstance;
 }

--- a/packages/storage/src/api.ts
+++ b/packages/storage/src/api.ts
@@ -335,7 +335,7 @@ export function getStorage(
     identifier: bucketUrl
   });
   const emulator = getDefaultEmulatorHostnameAndPort('storage');
-  if () {
+  if (emulator) {
     connectStorageEmulator(storageInstance, ...emulator);
   }
   return storageInstance;

--- a/packages/util/test/defaults.test.ts
+++ b/packages/util/test/defaults.test.ts
@@ -28,7 +28,7 @@ describe('getDefaultEmulatorHost', () => {
 
   context('with no config', () => {
     it('returns undefined', () => {
-      expect(getDefaultEmulatorHost('firestore')).to.equal(undefined);
+      expect(getDefaultEmulatorHost('firestore')).to.be.undefined;
     });
   });
 
@@ -43,7 +43,7 @@ describe('getDefaultEmulatorHost', () => {
     });
 
     it('returns undefined', () => {
-      expect(getDefaultEmulatorHost('firestore')).to.equal(undefined);
+      expect(getDefaultEmulatorHost('firestore')).to.be.undefined;
     });
   });
 
@@ -83,9 +83,7 @@ describe('getDefaultEmulatorHostnameAndPort', () => {
 
   context('with no config', () => {
     it('returns undefined', () => {
-      expect(getDefaultEmulatorHostnameAndPort('firestore')).to.equal(
-        undefined
-      );
+      expect(getDefaultEmulatorHostnameAndPort('firestore')).to.be.undefined;
     });
   });
 
@@ -100,9 +98,7 @@ describe('getDefaultEmulatorHostnameAndPort', () => {
     });
 
     it('returns undefined', () => {
-      expect(getDefaultEmulatorHostnameAndPort('firestore')).to.equal(
-        undefined
-      );
+      expect(getDefaultEmulatorHostnameAndPort('firestore')).to.be.undefined;
     });
   });
 
@@ -116,7 +112,7 @@ describe('getDefaultEmulatorHostnameAndPort', () => {
     });
 
     it('returns hostname and port splitted', () => {
-      expect(getDefaultEmulatorHostnameAndPort('firestore')).to.equal([
+      expect(getDefaultEmulatorHostnameAndPort('firestore')).to.eql([
         '127.0.0.1',
         8080
       ]);
@@ -133,7 +129,7 @@ describe('getDefaultEmulatorHostnameAndPort', () => {
     });
 
     it('returns unquoted hostname and port splitted', () => {
-      expect(getDefaultEmulatorHostnameAndPort('firestore')).to.equal([
+      expect(getDefaultEmulatorHostnameAndPort('firestore')).to.eql([
         '::1',
         8080
       ]);

--- a/packages/util/test/defaults.test.ts
+++ b/packages/util/test/defaults.test.ts
@@ -1,0 +1,142 @@
+/**
+ * @license
+ * Copyright 2017 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { expect } from 'chai';
+import {
+  getDefaultEmulatorHost,
+  getDefaultEmulatorHostnameAndPort
+} from '../src/defaults';
+import { getGlobal } from '../src/environment';
+
+describe('getDefaultEmulatorHost', () => {
+  after(() => {
+    delete getGlobal().__FIREBASE_DEFAULTS__;
+  });
+
+  context('with no config', () => {
+    it('returns undefined', () => {
+      expect(getDefaultEmulatorHost('firestore')).to.equal(undefined);
+    });
+  });
+
+  context('with global config not listing the emulator', () => {
+    before(() => {
+      getGlobal().__FIREBASE_DEFAULTS__ = {
+        emulatorHosts: {
+          /* no firestore */
+          database: '127.0.0.1:8080'
+        }
+      };
+    });
+
+    it('returns undefined', () => {
+      expect(getDefaultEmulatorHost('firestore')).to.equal(undefined);
+    });
+  });
+
+  context('with IPv4 hostname in global config', () => {
+    before(() => {
+      getGlobal().__FIREBASE_DEFAULTS__ = {
+        emulatorHosts: {
+          firestore: '127.0.0.1:8080'
+        }
+      };
+    });
+
+    it('returns host', () => {
+      expect(getDefaultEmulatorHost('firestore')).to.equal('127.0.0.1:8080');
+    });
+  });
+
+  context('with quoted IPv6 hostname in global config', () => {
+    before(() => {
+      getGlobal().__FIREBASE_DEFAULTS__ = {
+        emulatorHosts: {
+          firestore: '[::1]:8080'
+        }
+      };
+    });
+
+    it('returns host', () => {
+      expect(getDefaultEmulatorHost('firestore')).to.equal('[::1]:8080');
+    });
+  });
+});
+
+describe('getDefaultEmulatorHostnameAndPort', () => {
+  after(() => {
+    delete getGlobal().__FIREBASE_DEFAULTS__;
+  });
+
+  context('with no config', () => {
+    it('returns undefined', () => {
+      expect(getDefaultEmulatorHostnameAndPort('firestore')).to.equal(
+        undefined
+      );
+    });
+  });
+
+  context('with global config not listing the emulator', () => {
+    before(() => {
+      getGlobal().__FIREBASE_DEFAULTS__ = {
+        emulatorHosts: {
+          /* no firestore */
+          database: '127.0.0.1:8080'
+        }
+      };
+    });
+
+    it('returns undefined', () => {
+      expect(getDefaultEmulatorHostnameAndPort('firestore')).to.equal(
+        undefined
+      );
+    });
+  });
+
+  context('with IPv4 hostname in global config', () => {
+    before(() => {
+      getGlobal().__FIREBASE_DEFAULTS__ = {
+        emulatorHosts: {
+          firestore: '127.0.0.1:8080'
+        }
+      };
+    });
+
+    it('returns hostname and port splitted', () => {
+      expect(getDefaultEmulatorHostnameAndPort('firestore')).to.equal([
+        '127.0.0.1',
+        8080
+      ]);
+    });
+  });
+
+  context('with quoted IPv6 hostname in global config', () => {
+    before(() => {
+      getGlobal().__FIREBASE_DEFAULTS__ = {
+        emulatorHosts: {
+          firestore: '[::1]:8080'
+        }
+      };
+    });
+
+    it('returns unquoted hostname and port splitted', () => {
+      expect(getDefaultEmulatorHostnameAndPort('firestore')).to.equal([
+        '::1',
+        8080
+      ]);
+    });
+  });
+});


### PR DESCRIPTION
Fixes IPv6 addresses not parsed correctly in #6526. See tests added