### PR TITLE
fix: add missing 'apple.com' `ProviderId` to enum

### DIFF
--- a/.changeset/odd-cherries-try.md
+++ b/.changeset/odd-cherries-try.md
@@ -1,0 +1,5 @@
+---
+'@firebase/auth-types': patch
+---
+
+fix: add missing ProviderId type

--- a/packages/auth/src/model/enums.ts
+++ b/packages/auth/src/model/enums.ts
@@ -22,6 +22,8 @@
 export const enum ProviderId {
   /** @internal */
   ANONYMOUS = 'anonymous',
+  /** Apple provider ID */
+  APPLE = 'apple.com',
   /** @internal */
   CUSTOM = 'custom',
   /** Facebook provider ID */


### PR DESCRIPTION
I have the provider ID typed in my spec of my database like so:

```ts
import { ProviderId } from 'firebase/auth'

export type PROVIDER_ID = typeof ProviderId[keyof typeof ProviderId]
```
only to my surprise, it seems you forgot about apple.com. Let's get it typed correctly with this PR! ;)

Hey there! So you want to contribute to a Firebase SDK? 
Before you file this pull request, please read these guidelines:

### Discussion

  * Read the contribution guidelines (CONTRIBUTING.md).
  * If this has been discussed in an issue, make sure to link to the issue here. 
    If not, go file an issue about this **before creating a pull request** to discuss.

### Testing

  * Make sure all existing tests in the repository pass after your change.
  * If you fixed a bug or added a feature, add a new test to cover your code.

### API Changes

  * At this time we cannot accept changes that affect the public API.  If you'd like to help 
    us make Firebase APIs better, please propose your change in an issue so that we 
    can discuss it together.
