### PR TITLE
Catch getDefaults() errors and do not throw

### DIFF
--- a/.changeset/grumpy-suits-pump.md
+++ b/.changeset/grumpy-suits-pump.md
@@ -1,0 +1,5 @@
+---
+'@firebase/util': patch
+---
+
+Catch errors when the SDK checks for `__FIREBASE_DEFAULTS__` and do not block other app functionality.

--- a/packages/util/test/defaults.test.ts
+++ b/packages/util/test/defaults.test.ts
@@ -43,8 +43,9 @@ describe('getDefaultEmulatorHost', () => {
     after(() => {
       restore();
     });
-    it('returns undefined', () => {
+    it('returns undefined and does not throw', () => {
       expect(getDefaultEmulatorHost('firestore')).to.be.undefined;
+      expect(getDefaultEmulatorHost('firestore')).to.not.throw;
     });
   });
 
@@ -58,8 +59,9 @@ describe('getDefaultEmulatorHost', () => {
     after(() => {
       restore();
     });
-    it('returns undefined and calls console.info', () => {
+    it('returns undefined and does not throw', () => {
       expect(getDefaultEmulatorHost('firestore')).to.be.undefined;
+      expect(getDefaultEmulatorHost('firestore')).to.not.throw;
     });
   });
 


### PR DESCRIPTION
Due to various frameworks and environments, we have been encountering a lot of special cases not accounted for in `getDefaults()` (such as `process` existing but `process.env` not existing in Nuxt 3, or `document` existing but `document.cookie` throwing in Angular Universal).

Adding an overall try/catch block to `getDefaults()` so that if it runs into any errors we haven't thought of, it won't block execution of the rest of Firebase. It will log a console.info so we can find out about these cases and account for them.

Also added a separate catch specifically for the Angular Universal case. Yes, this would be caught by the overall try/catch already, but I'd like to put in the specific cases as we find them so we know the specifics of the various environments we're dealing with, as this knowledge will help us with SSR support going forward.

Fixes https://github.com/firebase/firebase-js-sdk/issues/6677