### PR TITLE
Add a workflow to send release tweet

### DIFF
--- a/.github/workflows/release-tweet.yml
+++ b/.github/workflows/release-tweet.yml
@@ -1,0 +1,35 @@
+name: Send Release Tweet
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version number'
+        type: string
+        required: true
+      force:
+        description: 'Force publish'
+        type: boolean
+        default: false
+        required: true
+
+jobs:
+  tweet:
+    name: Send Release Tweet
+    runs-on: ubuntu-latest
+    steps:
+      - name: Poll release notes page on devsite
+        run: node scripts/ci/poll_release_notes.js
+        env:
+          VERSION: ${{ github.event.inputs.version }}
+          FORCE_PUBLISH: ${{ github.event.inputs.force }}
+      - name: Post to Twitter
+        uses: firebase/firebase-admin-node/.github/actions/send-tweet
+        with:
+          status: >
+            v${{github.event.inputs.version}} of @Firebase JavaScript client for Web / Node.js is available.
+            Release notes: https://firebase.google.com/support/release-notes/js#${{github.event.inputs.version}}
+          consumer-key: ${{ secrets.TWITTER_CONSUMER_KEY }}
+          consumer-secret: ${{ secrets.TWITTER_CONSUMER_SECRET }}
+          access-token: ${{ secrets.TWITTER_ACCESS_TOKEN }}
+          access-token-secret: ${{ secrets.TWITTER_ACCESS_TOKEN_SECRET }}

--- a/scripts/ci/poll_release_notes.js
+++ b/scripts/ci/poll_release_notes.js
@@ -1,0 +1,75 @@
+/**
+ * @license
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const https = require('https');
+
+const MAX_ATTEMPTS = 10;
+const MINUTE = 60 * 1000;
+const RETRY_DELAY_MINUTES = 15;
+
+async function pollReleaseNotes() {
+  if (!process.env.VERSION) {
+    console.log(`Couldn't find version.`);
+    return;
+  }
+
+  const version = process.env.VERSION;
+
+  const options = {
+    method: 'GET'
+  };
+
+  const getData = () =>
+    new Promise((resolve, reject) => {
+      const req = https.request(
+        `https://firebase.google.com/support/release-notes/js`,
+        options,
+        res => {
+          let content = '';
+          res.on('data', d => (content += d));
+          res.on('end', () => resolve(content));
+        }
+      );
+
+      req.on('error', error => reject(error));
+      req.end();
+    });
+  let siteContent = '';
+  for (let i = 0; i < MAX_ATTEMPTS; i++) {
+    siteContent = await getData();
+    const matches = siteContent.match(/<a name="\d+\.\d+.\d+">/g);
+    if (matches[0] === version) {
+      return;
+    }
+    if (matches.includes(`<a name="${version}">`) && !process.env.FORCE) {
+      console.warn(`${version} was found but is not the latest version. ` + 
+      `Set the force option to true to publish anyway.`);
+      process.exit(1);
+    }
+    console.log(`Didn't find ${version} on release notes page.`);
+    if (i < MAX_ATTEMPTS - 1) {
+      console.log(`Trying again in ${RETRY_DELAY_MINUTES} minutes.`);
+      await new Promise(resolve =>
+        setTimeout(resolve, RETRY_DELAY_MINUTES * MINUTE)
+      );
+    }
+  }
+  console.log(`Was not able to find ${version}. Ending process.`);
+  process.exit(1);
+}
+
+pollReleaseNotes();

--- a/scripts/ci/poll_release_notes.js
+++ b/scripts/ci/poll_release_notes.js
@@ -56,8 +56,10 @@ async function pollReleaseNotes() {
       return;
     }
     if (matches.includes(`<a name="${version}">`) && !process.env.FORCE) {
-      console.warn(`${version} was found but is not the latest version. ` + 
-      `Set the force option to true to publish anyway.`);
+      console.warn(
+        `${version} was found but is not the latest version. ` +
+          `Set the force option to true to publish anyway.`
+      );
       process.exit(1);
     }
     console.log(`Didn't find ${version} on release notes page.`);


### PR DESCRIPTION
This is manually triggered for now. You have to enter the version number. It will poll devsite 10 times every 15 minutes until it finds the release notes have been published, and then should send the tweet. I haven't put the secrets into the repo yet, I'd like to test everything else works up to that step before doing so. This PR needs to be merged to test it though.