### PR TITLE
Remove mentions of Bower from repo and docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,9 +39,6 @@ coverage
 # Grunt intermediate storage (http://gruntjs.com/creating-plugins#storing-task-files)
 .grunt
 
-# Bower dependency directory (https://bower.io/)
-bower_components
-
 # node-waf configuration
 .lock-wscript
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ applications using Firebase services. This SDK is distributed via:
 
 - [CDN](https://firebase.google.com/docs/web/setup/#add-sdks-initialize)
 - [npm package](https://www.npmjs.com/package/firebase)
-- [Bower package](https://github.com/firebase/firebase-bower)
 
 To get started using Firebase, see
 [Add Firebase to your JavaScript Project](https://firebase.google.com/docs/web/setup).

--- a/scripts/docgen-compat/content-sources/js/HOME.md
+++ b/scripts/docgen-compat/content-sources/js/HOME.md
@@ -4,7 +4,6 @@ applications using Firebase services. This SDK is distributed via:
 
 - [CDN](/docs/web/setup/#add-sdks-initialize)
 - [npm package](https://www.npmjs.com/package/firebase)
-- [Bower package](https://github.com/firebase/firebase-bower)
 
 To get started using Firebase, see
 [Add Firebase to your JavaScript Project](https://firebase.google.com/docs/web/setup).

--- a/scripts/docgen-compat/content-sources/node/HOME.md
+++ b/scripts/docgen-compat/content-sources/node/HOME.md
@@ -4,7 +4,6 @@ applications using Firebase services. This SDK is distributed via:
 
 - [CDN](/docs/web/setup/#add-sdks-initialize)
 - [npm package](https://www.npmjs.com/package/firebase)
-- [Bower package](https://github.com/firebase/firebase-bower)
 
 To get started using Firebase, see
 [Add Firebase to your JavaScript Project](https://firebase.google.com/docs/web/setup).


### PR DESCRIPTION
We have stopped publishing Bower versions of Firebase. Removing mentions of it from the repo.