### PR TITLE
Use API to bold

### DIFF
--- a/repo-scripts/api-documenter/package.json
+++ b/repo-scripts/api-documenter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@firebase/api-documenter",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Read JSON files from api-extractor, generate documentation pages",
   "repository": {
     "directory": "repo-scripts/documenter",

--- a/repo-scripts/api-documenter/src/documenters/MarkdownDocumenter.ts
+++ b/repo-scripts/api-documenter/src/documenters/MarkdownDocumenter.ts
@@ -975,13 +975,14 @@ page_type: reference
         // Header for each group of functions grouped by first param.
         // Doesn't make sense if there's only one group.
         const headerText = paramKey ? `function(${paramKey}...)` : 'function()';
-        const formattedHeaderText = `**${headerText}**`;
         if (sortedFunctionsFirstParamKeys.length > 1) {
           finalFunctionsTable.addRow(
             new DocTableRow({ configuration }, [
               new DocTableCell({ configuration }, [
                 new DocParagraph({ configuration }, [
-                  new DocPlainText({ configuration, text: formattedHeaderText })
+                  new DocEmphasisSpan({ configuration, bold: true }, [
+                    new DocPlainText({ configuration, text: headerText })
+                  ])
                 ])
               ])
             ])

--- a/repo-scripts/api-documenter/src/documenters/MarkdownDocumenter.ts
+++ b/repo-scripts/api-documenter/src/documenters/MarkdownDocumenter.ts
@@ -975,7 +975,7 @@ page_type: reference
         // Header for each group of functions grouped by first param.
         // Doesn't make sense if there's only one group.
         const headerText = paramKey ? `function(${paramKey}...)` : 'function()';
-        const formattedHeaderText = `<strong>${headerText}</strong>`;
+        const formattedHeaderText = `**${headerText}**`;
         if (sortedFunctionsFirstParamKeys.length > 1) {
           finalFunctionsTable.addRow(
             new DocTableRow({ configuration }, [

--- a/repo-scripts/api-documenter/src/documenters/MarkdownDocumenter.ts
+++ b/repo-scripts/api-documenter/src/documenters/MarkdownDocumenter.ts
@@ -979,9 +979,7 @@ page_type: reference
           finalFunctionsTable.addRow(
             new DocTableRow({ configuration }, [
               new DocTableCell({ configuration }, [
-                new DocParagraph({ configuration }, [
-                  new DocHeading({ configuration, title: headerText, level: 4 })
-                ])
+                new DocHeading({ configuration, title: headerText, level: 4 })
               ])
             ])
           );

--- a/repo-scripts/api-documenter/src/documenters/MarkdownDocumenter.ts
+++ b/repo-scripts/api-documenter/src/documenters/MarkdownDocumenter.ts
@@ -979,7 +979,11 @@ page_type: reference
           finalFunctionsTable.addRow(
             new DocTableRow({ configuration }, [
               new DocTableCell({ configuration }, [
-                new DocHeading({ configuration, title: headerText, level: 4 })
+                new DocParagraph({ configuration }, [
+                  new DocEmphasisSpan({ configuration, bold: true }, [
+                    new DocPlainText({ configuration, text: headerText })
+                  ])
+                ])
               ])
             ])
           );

--- a/repo-scripts/api-documenter/src/documenters/MarkdownDocumenter.ts
+++ b/repo-scripts/api-documenter/src/documenters/MarkdownDocumenter.ts
@@ -980,9 +980,7 @@ page_type: reference
             new DocTableRow({ configuration }, [
               new DocTableCell({ configuration }, [
                 new DocParagraph({ configuration }, [
-                  new DocEmphasisSpan({ configuration, bold: true }, [
-                    new DocPlainText({ configuration, text: headerText })
-                  ])
+                  new DocHeading({ configuration, title: headerText, level: 4 })
                 ])
               ])
             ])

--- a/repo-scripts/api-documenter/src/toc.ts
+++ b/repo-scripts/api-documenter/src/toc.ts
@@ -48,8 +48,7 @@ export function generateToc({
   if (jsSdk) {
     const firebaseToc: ITocItem = {
       title: 'firebase',
-      path: `${g3Path}/index`,
-      section: []
+      path: `${g3Path}/index`
     };
     toc.push(firebaseToc);
   }


### PR DESCRIPTION
API documenter's API doesn't seem to let you add arbitrary HTML or formatting so added bold using its API. Can't seem to do much more than that for now.

Also remove "section: []" from toc. Apparently devsite doesn't like it? But it used to?