### PR TITLE
Fix version bump for api-documenter

### DIFF
--- a/.changeset/popular-beans-wonder.md
+++ b/.changeset/popular-beans-wonder.md
@@ -1,5 +1,0 @@
----
-'@firebase/api-documenter': minor
----
-
-Add an option to sort functions by first param. (--sort-functions)

--- a/.changeset/young-masks-pull.md
+++ b/.changeset/young-masks-pull.md
@@ -1,0 +1,5 @@
+---
+'@firebase/api-documenter': patch
+---
+
+Bold section separators in functions tables.

--- a/.changeset/young-masks-pull.md
+++ b/.changeset/young-masks-pull.md
@@ -1,5 +1,0 @@
----
-'@firebase/api-documenter': patch
----
-
-Bold section separators in functions tables.

--- a/repo-scripts/api-documenter/CHANGELOG.md
+++ b/repo-scripts/api-documenter/CHANGELOG.md
@@ -1,5 +1,8 @@
 # @firebase/api-documenter
+## 0.3.0
+### Minor Changes
 
+- [#6623](https://github.com/firebase/firebase-js-sdk/pull/6623) Add an option to sort functions by first param. (--sort-functions)
 ## 0.2.0
 ### Minor Changes
 

--- a/repo-scripts/api-documenter/package.json
+++ b/repo-scripts/api-documenter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@firebase/api-documenter",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Read JSON files from api-extractor, generate documentation pages",
   "repository": {
     "directory": "repo-scripts/documenter",

--- a/repo-scripts/api-documenter/package.json
+++ b/repo-scripts/api-documenter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@firebase/api-documenter",
-  "version": "0.2.1",
+  "version": "0.2.0",
   "description": "Read JSON files from api-extractor, generate documentation pages",
   "repository": {
     "directory": "repo-scripts/documenter",


### PR DESCRIPTION
`@firebase/api-documenter` is excluded from changesets so I guess we update it manually. There is a minor bump in #6623 and a patch bump in https://github.com/firebase/firebase-js-sdk/pull/6696 so that comes out to one minor combined.