### PR TITLE
Expose 'icon' field from the Firebase Messaging SDK

### DIFF
--- a/.changeset/lovely-swans-shake.md
+++ b/.changeset/lovely-swans-shake.md
@@ -1,0 +1,5 @@
+---
+'@firebase/messaging': minor
+---
+
+Expose 'icon' field from the Firebase Messaging SDK as part of the 'notification' payload.

--- a/.changeset/lovely-swans-shake.md
+++ b/.changeset/lovely-swans-shake.md
@@ -2,4 +2,4 @@
 '@firebase/messaging': minor
 ---
 
-Expose 'icon' field from the Firebase Messaging SDK as part of the 'notification' payload.
+Expose 'icon' field from the Firebase Messaging SDK as part of the 'notification' payload

--- a/common/api-review/messaging-sw.api.md
+++ b/common/api-review/messaging-sw.api.md
@@ -52,6 +52,7 @@ export { NextFn }
 // @public
 export interface NotificationPayload {
     body?: string;
+    icon?: string;
     image?: string;
     title?: string;
 }

--- a/common/api-review/messaging.api.md
+++ b/common/api-review/messaging.api.md
@@ -55,6 +55,7 @@ export { NextFn }
 // @public
 export interface NotificationPayload {
     body?: string;
+    icon?: string;
     image?: string;
     title?: string;
 }

--- a/packages/messaging/src/helpers/externalizePayload.test.ts
+++ b/packages/messaging/src/helpers/externalizePayload.test.ts
@@ -39,7 +39,12 @@ describe('externalizePayload', () => {
     };
 
     const payload: MessagePayload = {
-      notification: { title: 'title', body: 'body', image: 'image', icon: 'icon' },
+      notification: {
+        title: 'title',
+        body: 'body',
+        image: 'image',
+        icon: 'icon'
+      },
       from: 'from',
       collapseKey: 'collapse',
       messageId: 'mid',

--- a/packages/messaging/src/helpers/externalizePayload.test.ts
+++ b/packages/messaging/src/helpers/externalizePayload.test.ts
@@ -27,6 +27,7 @@ describe('externalizePayload', () => {
         title: 'title',
         body: 'body',
         image: 'image',
+        icon: 'icon',
         // eslint-disable-next-line camelcase
         click_action: 'https://www.self_orgin.com'
       },
@@ -38,7 +39,7 @@ describe('externalizePayload', () => {
     };
 
     const payload: MessagePayload = {
-      notification: { title: 'title', body: 'body', image: 'image' },
+      notification: { title: 'title', body: 'body', image: 'image', icon: 'icon' },
       from: 'from',
       collapseKey: 'collapse',
       messageId: 'mid',
@@ -77,7 +78,8 @@ describe('externalizePayload', () => {
       notification: {
         title: 'title',
         body: 'body',
-        image: 'image'
+        image: 'image',
+        icon: 'icon'
       },
       data: {
         foo: 'foo',
@@ -100,7 +102,8 @@ describe('externalizePayload', () => {
       notification: {
         title: 'title',
         body: 'body',
-        image: 'image'
+        image: 'image',
+        icon: 'icon'
       },
       data: {
         foo: 'foo',

--- a/packages/messaging/src/helpers/externalizePayload.ts
+++ b/packages/messaging/src/helpers/externalizePayload.ts
@@ -60,6 +60,11 @@ function propagateNotificationPayload(
   if (!!image) {
     payload.notification!.image = image;
   }
+
+  const icon = messagePayloadInternal.notification!.icon;
+  if (!!icon) {
+    payload.notification!.icon = icon;
+  }
 }
 
 function propagateDataPayload(

--- a/packages/messaging/src/interfaces/internal-message-payload.ts
+++ b/packages/messaging/src/interfaces/internal-message-payload.ts
@@ -38,6 +38,7 @@ export interface NotificationPayloadInternal extends NotificationOptions {
   // See:https://firebase.google.com/docs/cloud-messaging/xmpp-server-ref.
   // eslint-disable-next-line camelcase
   click_action?: string;
+  icon?: string;
 }
 
 // Defined in

--- a/packages/messaging/src/interfaces/public-types.ts
+++ b/packages/messaging/src/interfaces/public-types.ts
@@ -38,6 +38,12 @@ export interface NotificationPayload {
    * The URL of an image that is downloaded on the device and displayed in the notification.
    */
   image?: string;
+
+  /**
+   * The URL to use for the notification's icon. If you don't send this key in the request, 
+   * FCM displays the launcher icon specified in your app manifest.
+   */
+  icon?: string;
 }
 
 /**

--- a/packages/messaging/src/interfaces/public-types.ts
+++ b/packages/messaging/src/interfaces/public-types.ts
@@ -40,7 +40,7 @@ export interface NotificationPayload {
   image?: string;
 
   /**
-   * The URL to use for the notification's icon. If you don't send this key in the request, 
+   * The URL to use for the notification's icon. If you don't send this key in the request,
    * FCM displays the launcher icon specified in your app manifest.
    */
   icon?: string;


### PR DESCRIPTION
Fixes for b/241885017.

Would patch https://github.com/firebase/firebase-js-sdk/issues/6466
