### PR TITLE
Fix transaction.set() failure without retry on "already-exists" error

### DIFF
--- a/.changeset/young-knives-shake.md
+++ b/.changeset/young-knives-shake.md
@@ -1,0 +1,6 @@
+---
+'@firebase/firestore': patch
+'firebase': patch
+---
+
+Fix transaction.set() failure without retry on "already-exists" error.

--- a/packages/firestore/src/core/transaction_runner.ts
+++ b/packages/firestore/src/core/transaction_runner.ts
@@ -120,6 +120,7 @@ export class TransactionRunner<T> {
       return (
         code === 'aborted' ||
         code === 'failed-precondition' ||
+        code === 'already-exists' ||
         !isPermanentError(code)
       );
     }

--- a/packages/firestore/test/integration/api/transactions.test.ts
+++ b/packages/firestore/test/integration/api/transactions.test.ts
@@ -629,6 +629,30 @@ apiDescribe('Database transactions', (persistence: boolean) => {
     });
   });
 
+  it('retries when document already exists', () => {
+    return withTestDb(persistence, async db => {
+      let retryCounter = 0;
+      const docRef = doc(collection(db, 'nonexistent'));
+
+      await runTransaction(db, async transaction => {
+        ++retryCounter;
+        const snap1 = await transaction.get(docRef);
+
+        if (retryCounter === 1) {
+          expect(snap1.exists()).to.be.false;
+          // On the first attemp, create a doc before transaction.set(), so that
+          // the transaction fails with "already-exists" error, and retries.
+          await setDoc(docRef, { count: 1 });
+        }
+
+        transaction.set(docRef, { count: 2 });
+      });
+      expect(retryCounter).to.equal(2);
+      const result = await getDoc(docRef);
+      expect(result.get('count')).to.equal(2);
+    });
+  });
+
   it('are successful with no transaction operations', () => {
     return withTestDb(persistence, db => runTransaction(db, async () => {}));
   });

--- a/packages/firestore/test/integration/api/transactions.test.ts
+++ b/packages/firestore/test/integration/api/transactions.test.ts
@@ -636,11 +636,11 @@ apiDescribe('Database transactions', (persistence: boolean) => {
 
       await runTransaction(db, async transaction => {
         ++retryCounter;
-        const snap1 = await transaction.get(docRef);
+        const snap = await transaction.get(docRef);
 
         if (retryCounter === 1) {
-          expect(snap1.exists()).to.be.false;
-          // On the first attemp, create a doc before transaction.set(), so that
+          expect(snap.exists()).to.be.false;
+          // On the first attempt, create a doc before transaction.set(), so that
           // the transaction fails with "already-exists" error, and retries.
           await setDoc(docRef, { count: 1 });
         }
@@ -648,8 +648,8 @@ apiDescribe('Database transactions', (persistence: boolean) => {
         transaction.set(docRef, { count: 2 });
       });
       expect(retryCounter).to.equal(2);
-      const result = await getDoc(docRef);
-      expect(result.get('count')).to.equal(2);
+      const snap = await getDoc(docRef);
+      expect(snap.get('count')).to.equal(2);
     });
   });
 


### PR DESCRIPTION
#### Problem
Transaction.get(ref) followed by transaction.set(ref, {...}) is causing the transaction to fail with error 'Document already exists' if the document was created by another app between the get and set.

#### Cause
'already-exists' is considered to be a permanent error for transactions, therefore will not be retried.
https://github.com/firebase/firebase-js-sdk/blob/f86f7de090ae7f61b795d0dbbe9b3765590e0286/packages/firestore/src/core/transaction_runner.ts#L115


Fix Issue: https://github.com/firebase/firebase-js-sdk/issues/6659