### PR TITLE
fix(AppCheck): Fixed getToken promise not being cleared

### DIFF
--- a/packages/app-check/src/state.ts
+++ b/packages/app-check/src/state.ts
@@ -30,7 +30,9 @@ export interface AppCheckState {
   provider?: AppCheckProvider;
   token?: AppCheckTokenInternal;
   cachedTokenPromise?: Promise<AppCheckTokenInternal | undefined>;
-  exchangeTokenPromise?: Promise<AppCheckTokenInternal>;
+  exchangeTokenFetcher: {
+    promise?: Promise<AppCheckTokenInternal>;
+  };
   tokenRefresher?: Refresher;
   reCAPTCHAState?: ReCAPTCHAState;
   isTokenAutoRefreshEnabled?: boolean;
@@ -50,7 +52,8 @@ export interface DebugState {
 const APP_CHECK_STATES = new Map<FirebaseApp, AppCheckState>();
 export const DEFAULT_STATE: AppCheckState = {
   activated: false,
-  tokenObservers: []
+  tokenObservers: [],
+  exchangeTokenFetcher: {}
 };
 
 const DEBUG_STATE: DebugState = {


### PR DESCRIPTION
Fix #6734

Immutable assignment by `setState` failed to clear the `exchangeTokenPromise` by assigning undefined to it.
https://github.com/firebase/firebase-js-sdk/blob/e2a90bf678eb6fa505f8b2f627e03cff622607b5/packages/app-check/src/internal-api.ts#L126

There may be a better way, but I wrapped the `exchangeTokenPromise` in an object to prevent it from deep copy due to spread assignments. 