### PR TITLE
Fix App Check state setting and promise clearing

### DIFF
--- a/.changeset/spicy-bags-sparkle.md
+++ b/.changeset/spicy-bags-sparkle.md
@@ -1,0 +1,5 @@
+---
+'@firebase/app-check': patch
+---
+
+Clear App Check exchange promise correctly after request succeeds.

--- a/packages/app-check/src/api.ts
+++ b/packages/app-check/src/api.ts
@@ -23,7 +23,7 @@ import {
   PartialObserver
 } from './public-types';
 import { ERROR_FACTORY, AppCheckError } from './errors';
-import { getState, setState, AppCheckState, getDebugState } from './state';
+import { getState, setState, AppCheckState, getDebugState, setStateProperty } from './state';
 import { FirebaseApp, getApp, _getProvider } from '@firebase/app';
 import { getModularInstance, ErrorFn, NextFn } from '@firebase/util';
 import { AppCheckService } from './factory';
@@ -134,7 +134,7 @@ function _activate(
   newState.provider = provider; // Read cached token from storage if it exists and store it in memory.
   newState.cachedTokenPromise = readTokenFromStorage(app).then(cachedToken => {
     if (cachedToken && isValid(cachedToken)) {
-      setState(app, { ...getState(app), token: cachedToken });
+      setStateProperty(app, 'token', cachedToken);
       // notify all listeners with the cached token
       notifyTokenListeners(app, { token: cachedToken.token });
     }
@@ -178,7 +178,7 @@ export function setTokenAutoRefreshEnabled(
       state.tokenRefresher.stop();
     }
   }
-  setState(app, { ...state, isTokenAutoRefreshEnabled });
+  setStateProperty(app, 'isTokenAutoRefreshEnabled', isTokenAutoRefreshEnabled);
 }
 /**
  * Get the current App Check token. Attaches to the most recent

--- a/packages/app-check/src/api.ts
+++ b/packages/app-check/src/api.ts
@@ -23,7 +23,13 @@ import {
   PartialObserver
 } from './public-types';
 import { ERROR_FACTORY, AppCheckError } from './errors';
-import { getState, setState, AppCheckState, getDebugState, setStateProperty } from './state';
+import {
+  getState,
+  setState,
+  AppCheckState,
+  getDebugState,
+  setStateProperty
+} from './state';
 import { FirebaseApp, getApp, _getProvider } from '@firebase/app';
 import { getModularInstance, ErrorFn, NextFn } from '@firebase/util';
 import { AppCheckService } from './factory';

--- a/packages/app-check/src/internal-api.test.ts
+++ b/packages/app-check/src/internal-api.test.ts
@@ -390,9 +390,7 @@ describe('internal api', () => {
 
       const getTokenPromise = getToken(appCheck as AppCheckService, true);
 
-      expect(getState(app).exchangeTokenPromise).to.be.instanceOf(
-        Promise
-      );
+      expect(getState(app).exchangeTokenPromise).to.be.instanceOf(Promise);
 
       await getTokenPromise;
 
@@ -625,7 +623,7 @@ describe('internal api', () => {
     afterEach(async () => {
       clearState();
     });
-  
+
     it('adds token listeners', async () => {
       const clock = useFakeTimers();
       const listener = (): void => {};

--- a/packages/app-check/src/internal-api.ts
+++ b/packages/app-check/src/internal-api.ts
@@ -129,7 +129,7 @@ export async function getToken(
       shouldCallListeners = true;
     }
     const tokenFromDebugExchange: AppCheckTokenInternal =
-    // This was checked for above and assigned via setStateProperty()
+      // This was checked for above and assigned via setStateProperty()
       await state.exchangeTokenPromise!;
     // Write debug token to indexedDB.
     await writeTokenToStorage(app, tokenFromDebugExchange);
@@ -221,7 +221,10 @@ export function addTokenListener(
     error: onError,
     type
   };
-  setStateProperty(app, 'tokenObservers', [...state.tokenObservers, tokenObserver]);
+  setStateProperty(app, 'tokenObservers', [
+    ...state.tokenObservers,
+    tokenObserver
+  ]);
 
   // Invoke the listener async immediately if there is a valid token
   // in memory.

--- a/packages/app-check/src/recaptcha.ts
+++ b/packages/app-check/src/recaptcha.ts
@@ -16,7 +16,7 @@
  */
 
 import { FirebaseApp } from '@firebase/app';
-import { getState, setState } from './state';
+import { getState, setStateProperty } from './state';
 import { Deferred } from '@firebase/util';
 import { getRecaptcha, ensureActivated } from './util';
 
@@ -28,10 +28,9 @@ export function initializeV3(
   app: FirebaseApp,
   siteKey: string
 ): Promise<GreCAPTCHA> {
-  const state = getState(app);
   const initialized = new Deferred<GreCAPTCHA>();
 
-  setState(app, { ...state, reCAPTCHAState: { initialized } });
+  setStateProperty(app, 'reCAPTCHAState', { initialized });
   const divId = makeDiv(app);
 
   const grecaptcha = getRecaptcha(false);
@@ -54,10 +53,9 @@ export function initializeEnterprise(
   app: FirebaseApp,
   siteKey: string
 ): Promise<GreCAPTCHA> {
-  const state = getState(app);
   const initialized = new Deferred<GreCAPTCHA>();
 
-  setState(app, { ...state, reCAPTCHAState: { initialized } });
+  setStateProperty(app, 'reCAPTCHAState', { initialized });
   const divId = makeDiv(app);
 
   const grecaptcha = getRecaptcha(true);
@@ -148,12 +146,9 @@ function renderInvisibleWidget(
 
   const state = getState(app);
 
-  setState(app, {
-    ...state,
-    reCAPTCHAState: {
-      ...state.reCAPTCHAState!, // state.reCAPTCHAState is set in the initialize()
-      widgetId
-    }
+  setStateProperty(app, 'reCAPTCHAState', {
+    ...state.reCAPTCHAState!, // state.reCAPTCHAState is set in the initialize()
+    widgetId
   });
 }
 

--- a/packages/app-check/src/state.ts
+++ b/packages/app-check/src/state.ts
@@ -71,8 +71,7 @@ export function setStateProperty<T extends keyof AppCheckState>(
   property: T,
   value: AppCheckState[T]
 ): void {
-  console.log('setStateProperty', property);
-  const newState = getState(app);
+  const newState = {...getState(app)};
   newState[property] = value;
   setState(app, newState);
 }

--- a/packages/app-check/src/state.ts
+++ b/packages/app-check/src/state.ts
@@ -71,7 +71,7 @@ export function setStateProperty<T extends keyof AppCheckState>(
   property: T,
   value: AppCheckState[T]
 ): void {
-  const newState = {...getState(app)};
+  const newState = { ...getState(app) };
   newState[property] = value;
   setState(app, newState);
 }

--- a/packages/app-check/src/state.ts
+++ b/packages/app-check/src/state.ts
@@ -66,6 +66,17 @@ export function setState(app: FirebaseApp, state: AppCheckState): void {
   APP_CHECK_STATES.set(app, state);
 }
 
+export function setStateProperty<T extends keyof AppCheckState>(
+  app: FirebaseApp,
+  property: T,
+  value: AppCheckState[T]
+): void {
+  console.log('setStateProperty', property);
+  const newState = getState(app);
+  newState[property] = value;
+  setState(app, newState);
+}
+
 // for testing only
 export function clearState(): void {
   APP_CHECK_STATES.clear();


### PR DESCRIPTION
Fixes https://github.com/firebase/firebase-js-sdk/issues/6734 (probably)?

Based on solution suggested in https://github.com/firebase/firebase-js-sdk/pull/6735

`setState()` and `state` usage is already pretty inconsistent throughout the App Check codebase (sometimes immutable, sometimes mutated) and I don't think the best answer is mixing in more mutation. Additionally, the way `setState()` is used depends on extending a temporary version of `state` that, due to a lot of async code, may be stale by the time it `setState()` is called.

Added a method called `setStateProperty()` which starts with a fresh `getState()` clone, directly sets a property on the clone (which ensures `undefined` will override any previous set values, unlike an assign/extend), then uses setState to put the entire new state object back in the `APP_CHECK_STATES` Map.

Replaced `setState` with this new method in the problem areas causing this bug, as well as everywhere else it is appropriate.