### PR TITLE
Have Renovate ignore auth demo projects

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -21,6 +21,11 @@
     "typedoc",
     "@microsoft/tsdoc"
   ],
+  "ignorePaths": [
+    "auth/demo",
+    "auth/cordova/demo",
+    "auth-compat/demo"
+  ],
   "assignees": [
     "@hsubox76"
   ],


### PR DESCRIPTION
Use https://docs.renovatebot.com/configuration-options/#ignorepaths to have Renovate ignore auth demo projects. If these need to be regularly updated, we should add a process to do it on release. If they only need to be updated whenever someone decides to use them, they can be updated then. We don't do Renovate updates on a regular schedule so it's a solution that doesn't really fit either case.