### PR TITLE
Updated base64 error to be more descriptive

### DIFF
--- a/.changeset/long-shirts-explode.md
+++ b/.changeset/long-shirts-explode.md
@@ -1,0 +1,5 @@
+---
+"@firebase/storage": patch
+---
+
+Fixed issue where if btoa wasn't supported in the environment, then the user would get a generic message.

--- a/packages/storage/src/implementation/error.ts
+++ b/packages/storage/src/implementation/error.ts
@@ -261,6 +261,13 @@ export function noDownloadURL(): StorageError {
   );
 }
 
+export function missingPolyFill(polyFill: string): StorageError {
+  return new StorageError(
+    StorageErrorCode.UNSUPPORTED_ENVIRONMENT,
+    `${polyFill} is missing. Please install the right polyfills. Visit https://firebase.google.com/docs/web/environments-js-sdk#polyfills for more information.`
+  );
+}
+
 /**
  * @internal
  */

--- a/packages/storage/src/implementation/error.ts
+++ b/packages/storage/src/implementation/error.ts
@@ -264,7 +264,7 @@ export function noDownloadURL(): StorageError {
 export function missingPolyFill(polyFill: string): StorageError {
   return new StorageError(
     StorageErrorCode.UNSUPPORTED_ENVIRONMENT,
-    `${polyFill} is missing. Please install the right polyfills. Visit https://firebase.google.com/docs/web/environments-js-sdk#polyfills for more information.`
+    `${polyFill} is missing. Make sure to install the required polyfills. See https://firebase.google.com/docs/web/environments-js-sdk#polyfills for more information.`
   );
 }
 

--- a/packages/storage/src/implementation/string.ts
+++ b/packages/storage/src/implementation/string.ts
@@ -187,7 +187,6 @@ export function base64Bytes_(format: StringFormat, value: string): Uint8Array {
     if ((e as Error).message.includes('polyfill')) {
       throw e;
     }
-    console.log(e);
     throw invalidFormat(format, 'Invalid character found');
   }
   const array = new Uint8Array(bytes.length);

--- a/packages/storage/src/implementation/string.ts
+++ b/packages/storage/src/implementation/string.ts
@@ -184,7 +184,7 @@ export function base64Bytes_(format: StringFormat, value: string): Uint8Array {
   try {
     bytes = decodeBase64(value);
   } catch (e) {
-    if(e instanceof StorageError) {
+    if (e instanceof StorageError) {
       throw e;
     }
     console.log(e);

--- a/packages/storage/src/implementation/string.ts
+++ b/packages/storage/src/implementation/string.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { unknown, invalidFormat } from './error';
+import { unknown, invalidFormat, StorageError } from './error';
 import { decodeBase64 } from '../platform/base64';
 
 /**
@@ -184,6 +184,10 @@ export function base64Bytes_(format: StringFormat, value: string): Uint8Array {
   try {
     bytes = decodeBase64(value);
   } catch (e) {
+    if(e instanceof StorageError) {
+      throw e;
+    }
+    console.log(e);
     throw invalidFormat(format, 'Invalid character found');
   }
   const array = new Uint8Array(bytes.length);

--- a/packages/storage/src/implementation/string.ts
+++ b/packages/storage/src/implementation/string.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { unknown, invalidFormat, StorageError } from './error';
+import { unknown, invalidFormat } from './error';
 import { decodeBase64 } from '../platform/base64';
 
 /**
@@ -184,7 +184,7 @@ export function base64Bytes_(format: StringFormat, value: string): Uint8Array {
   try {
     bytes = decodeBase64(value);
   } catch (e) {
-    if (e instanceof StorageError) {
+    if ((e as Error).message.includes('polyfill')) {
       throw e;
     }
     console.log(e);

--- a/packages/storage/src/platform/browser/base64.ts
+++ b/packages/storage/src/platform/browser/base64.ts
@@ -19,7 +19,7 @@ import { missingPolyFill } from '../../implementation/error';
 
 /** Converts a Base64 encoded string to a binary string. */
 export function decodeBase64(encoded: string): string {
-  if ((typeof atob === 'undefined')) {
+  if (typeof atob === 'undefined') {
     throw missingPolyFill('base-64');
   }
   return atob(encoded);

--- a/packages/storage/src/platform/browser/base64.ts
+++ b/packages/storage/src/platform/browser/base64.ts
@@ -15,8 +15,13 @@
  * limitations under the License.
  */
 
+import { missingPolyFill } from "../../implementation/error";
+
 /** Converts a Base64 encoded string to a binary string. */
 export function decodeBase64(encoded: string): string {
+  if(!(typeof atob !== 'undefined')) {
+    throw missingPolyFill('base-64');
+  }
   return atob(encoded);
 }
 

--- a/packages/storage/src/platform/browser/base64.ts
+++ b/packages/storage/src/platform/browser/base64.ts
@@ -15,11 +15,11 @@
  * limitations under the License.
  */
 
-import { missingPolyFill } from "../../implementation/error";
+import { missingPolyFill } from '../../implementation/error';
 
 /** Converts a Base64 encoded string to a binary string. */
 export function decodeBase64(encoded: string): string {
-  if(!(typeof atob !== 'undefined')) {
+  if (!(typeof atob !== 'undefined')) {
     throw missingPolyFill('base-64');
   }
   return atob(encoded);

--- a/packages/storage/src/platform/browser/base64.ts
+++ b/packages/storage/src/platform/browser/base64.ts
@@ -19,7 +19,7 @@ import { missingPolyFill } from '../../implementation/error';
 
 /** Converts a Base64 encoded string to a binary string. */
 export function decodeBase64(encoded: string): string {
-  if (!(typeof atob !== 'undefined')) {
+  if ((typeof atob === 'undefined')) {
     throw missingPolyFill('base-64');
   }
   return atob(encoded);

--- a/packages/storage/test/browser/string.browser.test.ts
+++ b/packages/storage/test/browser/string.browser.test.ts
@@ -1,0 +1,19 @@
+import { expect } from "chai";
+import { missingPolyFill } from "../../src/implementation/error";
+import { dataFromString, StringFormat } from "../../src/implementation/string";
+import { assertThrows } from "../unit/testshared";
+
+describe.only('String browser tests', () => {
+    it('should reject if atob is undefined', () => {
+        const originalAToB = global.atob;
+        // @ts-ignore
+        global.atob = undefined;
+        const str = 'CpYlM1-XsGxTd1n6izHMU_yY3Bw=';
+
+        const error = assertThrows(() => {
+          dataFromString(StringFormat.BASE64URL, str);
+        }, 'storage/unsupported-environment');
+        expect(error.message).to.equal(missingPolyFill('base-64').message);
+        global.atob = originalAToB;
+    });
+});

--- a/packages/storage/test/browser/string.browser.test.ts
+++ b/packages/storage/test/browser/string.browser.test.ts
@@ -1,19 +1,36 @@
-import { expect } from "chai";
-import { missingPolyFill } from "../../src/implementation/error";
-import { dataFromString, StringFormat } from "../../src/implementation/string";
-import { assertThrows } from "../unit/testshared";
+/**
+ * @license
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { expect } from 'chai';
+import { missingPolyFill } from '../../src/implementation/error';
+import { dataFromString, StringFormat } from '../../src/implementation/string';
+import { assertThrows } from '../unit/testshared';
 
 describe.only('String browser tests', () => {
-    it('should reject if atob is undefined', () => {
-        const originalAToB = global.atob;
-        // @ts-ignore
-        global.atob = undefined;
-        const str = 'CpYlM1-XsGxTd1n6izHMU_yY3Bw=';
+  it('should reject if atob is undefined', () => {
+    const originalAToB = global.atob;
+    // @ts-ignore
+    global.atob = undefined;
+    const str = 'CpYlM1-XsGxTd1n6izHMU_yY3Bw=';
 
-        const error = assertThrows(() => {
-          dataFromString(StringFormat.BASE64URL, str);
-        }, 'storage/unsupported-environment');
-        expect(error.message).to.equal(missingPolyFill('base-64').message);
-        global.atob = originalAToB;
-    });
+    const error = assertThrows(() => {
+      dataFromString(StringFormat.BASE64URL, str);
+    }, 'storage/unsupported-environment');
+    expect(error.message).to.equal(missingPolyFill('base-64').message);
+    global.atob = originalAToB;
+  });
 });

--- a/packages/storage/test/browser/string.browser.test.ts
+++ b/packages/storage/test/browser/string.browser.test.ts
@@ -20,7 +20,7 @@ import { missingPolyFill } from '../../src/implementation/error';
 import { dataFromString, StringFormat } from '../../src/implementation/string';
 import { assertThrows } from '../unit/testshared';
 
-describe.only('String browser tests', () => {
+describe('String browser tests', () => {
   it('should reject if atob is undefined', () => {
     const originalAToB = global.atob;
     // @ts-ignore


### PR DESCRIPTION
When users of Expo and other similar environments don't support `atob` or `btoa`, polyfills are required, but the SDK doesn't provide this information to the user. 

This PR checks whether `atob` is available and throws an error if it is not.