### PR TITLE
Typo on changelog-generator

### DIFF
--- a/repo-scripts/changelog-generator/index.ts
+++ b/repo-scripts/changelog-generator/index.ts
@@ -50,11 +50,11 @@ const changelogFunctions: ChangelogFunctions = {
       .filter(_ => _)
       .join(', ')}]:`;
 
-    const updatedDepenenciesList = dependenciesUpdated.map(
+    const updatedDependenciesList = dependenciesUpdated.map(
       dependency => `  - ${dependency.name}@${dependency.newVersion}`
     );
 
-    return [changesetLink, ...updatedDepenenciesList].join('\n');
+    return [changesetLink, ...updatedDependenciesList].join('\n');
   },
   getReleaseLine: async (changeset, type, options) => {
     if (!options || !options.repo) {


### PR DESCRIPTION
In this pr, fixed a typo in a variable name. It is a really very small change that does not affect any functionality or process.
