### PR TITLE
Update parent path for check_changeset script

### DIFF
--- a/scripts/ci/check_changeset.ts
+++ b/scripts/ci/check_changeset.ts
@@ -22,7 +22,7 @@ import chalk from 'chalk';
 import simpleGit from 'simple-git';
 import fs from 'mz/fs';
 
-const root = resolve(__dirname, '..');
+const root = resolve(__dirname, '../..');
 const git = simpleGit(root);
 
 const baseRef = process.env.GITHUB_PULL_REQUEST_BASE_SHA || 'master';


### PR DESCRIPTION
This path seems to have not been updated when the script was moved inside a subdirectory in https://github.com/firebase/firebase-js-sdk/pull/5390