### PR TITLE
Tagging all new OR Query API members as internal until server support

### DIFF
--- a/common/api-review/firestore-lite.api.md
+++ b/common/api-review/firestore-lite.api.md
@@ -18,9 +18,6 @@ export type AddPrefixToKeys<Prefix extends string, T extends Record<string, unkn
 };
 
 // @public
-export function and(...queryConstraints: QueryFilterConstraint[]): QueryCompositeFilterConstraint;
-
-// @public
 export function arrayRemove(...elements: unknown[]): FieldValue;
 
 // @public
@@ -204,9 +201,6 @@ export type NestedUpdateFields<T extends Record<string, unknown>> = UnionToInter
 }[keyof T & string]>;
 
 // @public
-export function or(...queryConstraints: QueryFilterConstraint[]): QueryCompositeFilterConstraint;
-
-// @public
 export function orderBy(fieldPath: string | FieldPath, directionStr?: OrderByDirection): QueryOrderByConstraint;
 
 // @public
@@ -231,15 +225,7 @@ export class Query<T = DocumentData> {
 }
 
 // @public
-export function query<T>(query: Query<T>, compositeFilter: QueryCompositeFilterConstraint, ...queryConstraints: QueryNonFilterConstraint[]): Query<T>;
-
-// @public
 export function query<T>(query: Query<T>, ...queryConstraints: QueryConstraint[]): Query<T>;
-
-// @public
-export class QueryCompositeFilterConstraint {
-    readonly type: 'or' | 'and';
-}
 
 // @public
 export abstract class QueryConstraint {
@@ -267,9 +253,6 @@ export function queryEqual<T>(left: Query<T>, right: Query<T>): boolean;
 export class QueryFieldFilterConstraint extends QueryConstraint {
     readonly type = "where";
 }
-
-// @public
-export type QueryFilterConstraint = QueryFieldFilterConstraint | QueryCompositeFilterConstraint;
 
 // @public
 export class QueryLimitConstraint extends QueryConstraint {

--- a/common/api-review/firestore.api.md
+++ b/common/api-review/firestore.api.md
@@ -18,9 +18,6 @@ export type AddPrefixToKeys<Prefix extends string, T extends Record<string, unkn
 };
 
 // @public
-export function and(...queryConstraints: QueryFilterConstraint[]): QueryCompositeFilterConstraint;
-
-// @public
 export function arrayRemove(...elements: unknown[]): FieldValue;
 
 // @public
@@ -328,9 +325,6 @@ export function onSnapshotsInSync(firestore: Firestore, observer: {
 export function onSnapshotsInSync(firestore: Firestore, onSync: () => void): Unsubscribe;
 
 // @public
-export function or(...queryConstraints: QueryFilterConstraint[]): QueryCompositeFilterConstraint;
-
-// @public
 export function orderBy(fieldPath: string | FieldPath, directionStr?: OrderByDirection): QueryOrderByConstraint;
 
 // @public
@@ -360,15 +354,7 @@ export class Query<T = DocumentData> {
 }
 
 // @public
-export function query<T>(query: Query<T>, compositeFilter: QueryCompositeFilterConstraint, ...queryConstraints: QueryNonFilterConstraint[]): Query<T>;
-
-// @public
 export function query<T>(query: Query<T>, ...queryConstraints: QueryConstraint[]): Query<T>;
-
-// @public
-export class QueryCompositeFilterConstraint {
-    readonly type: 'or' | 'and';
-}
 
 // @public
 export abstract class QueryConstraint {
@@ -396,9 +382,6 @@ export function queryEqual<T>(left: Query<T>, right: Query<T>): boolean;
 export class QueryFieldFilterConstraint extends QueryConstraint {
     readonly type = "where";
 }
-
-// @public
-export type QueryFilterConstraint = QueryFieldFilterConstraint | QueryCompositeFilterConstraint;
 
 // @public
 export class QueryLimitConstraint extends QueryConstraint {

--- a/packages/firestore/src/lite-api/query.ts
+++ b/packages/firestore/src/lite-api/query.ts
@@ -130,6 +130,7 @@ export abstract class QueryConstraint extends AppliableConstraint {
  * apply (e.g. {@link orderBy}, {@link limit}).
  * @throws if any of the provided query constraints cannot be combined with the
  * existing or new constraints.
+ * @internal TODO remove this internal tag with OR Query support in the server
  */
 export function query<T>(
   query: Query<T>,
@@ -280,6 +281,7 @@ export function where(
  * `QueryCompositeFilterConstraint`s are created by invoking {@link or} or
  * {@link and} and can then be passed to {@link query} to create a new query
  * instance that also contains the `QueryCompositeFilterConstraint`.
+ * @internal TODO remove this internal tag with OR Query support in the server
  */
 export class QueryCompositeFilterConstraint extends AppliableConstraint {
   /**
@@ -360,6 +362,7 @@ export type QueryNonFilterConstraint =
  * `QueryFilterConstraint`s are created by invoking {@link or} or {@link and}
  * and can then be passed to {@link query} to create a new query instance that
  * also contains the `QueryConstraint`.
+ * @internal TODO remove this internal tag with OR Query support in the server
  */
 export type QueryFilterConstraint =
   | QueryFieldFilterConstraint
@@ -373,6 +376,7 @@ export type QueryFilterConstraint =
  * for OR operation. These must be created with calls to {@link where},
  * {@link or}, or {@link and}.
  * @returns The created {@link QueryCompositeFilterConstraint}.
+ * @internal TODO remove this internal tag with OR Query support in the server
  */
 export function or(
   ...queryConstraints: QueryFilterConstraint[]
@@ -396,6 +400,7 @@ export function or(
  * for AND operation. These must be created with calls to {@link where},
  * {@link or}, or {@link and}.
  * @returns The created {@link QueryCompositeFilterConstraint}.
+ * @internal TODO remove this internal tag with OR Query support in the server
  */
 export function and(
   ...queryConstraints: QueryFilterConstraint[]


### PR DESCRIPTION
Tagging all new OR Query API members as internal until server support. This keeps the OR Query members out of public documentation, but does not keep changes to pre-existing API members out of public docs. For example, changes to `limit(...)` documentation and return types will still be in docs.