### PR TITLE
updating database package dependency to add required peer dependency

### DIFF
--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -45,6 +45,7 @@
   "license": "Apache-2.0",
   "peerDependencies": {},
   "dependencies": {
+    "@firebase/app-types": "0.x",
     "@firebase/logger": "0.3.4",
     "@firebase/util": "1.7.3",
     "@firebase/component": "0.5.21",


### PR DESCRIPTION
Hi! I noticed this warning when using firebase-admin in our app.

I was going through the test set up and was almost complete, but then it asked me to switch to the "pay as you go" plan. I'm not sure I feel comfortable signing up for that as I'm pretty unfamiliar with firebase and mostly just want to clean up our dependency tree. I don't really want to pay money just to run this test suite. Please advise on how to continue.

This is the warning we got when running `yarn`:

```
➤ YN0000: ┌ Resolution step
➤ YN0002: │ @firebase/database@npm:0.13.10 doesn't provide @firebase/app-types (pc007b), requested by @firebase/auth-interop-types
```

and when I use `yarn link` to link this version of `@firebase/database` that warning goes away.