### PR TITLE
Put firebase/* entry point ESM files in their own subdirs with "type: module" package.json 

### DIFF
--- a/.changeset/eighty-ants-do.md
+++ b/.changeset/eighty-ants-do.md
@@ -1,0 +1,5 @@
+---
+'firebase': patch
+---
+
+Modify entry point ESM bundles to conform to Node ESM specs.

--- a/packages/firebase/analytics/package.json
+++ b/packages/firebase/analytics/package.json
@@ -1,7 +1,7 @@
 {
   "name": "firebase/analytics",
   "main": "dist/index.cjs.js",
-  "browser": "dist/index.esm.js",
-  "module": "dist/index.esm.js",
+  "browser": "dist/esm/index.esm.js",
+  "module": "dist/esm/index.esm.js",
   "typings": "dist/analytics/index.d.ts"
 }

--- a/packages/firebase/app-check/package.json
+++ b/packages/firebase/app-check/package.json
@@ -1,7 +1,7 @@
 {
   "name": "firebase/app-check",
   "main": "dist/index.cjs.js",
-  "browser": "dist/index.esm.js",
-  "module": "dist/index.esm.js",
+  "browser": "dist/esm/index.esm.js",
+  "module": "dist/esm/index.esm.js",
   "typings": "dist/app-check/index.d.ts"
 }

--- a/packages/firebase/app/package.json
+++ b/packages/firebase/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "firebase/app",
   "main": "dist/index.cjs.js",
-  "browser": "dist/index.esm.js",
-  "module": "dist/index.esm.js",
+  "browser": "dist/esm/index.esm.js",
+  "module": "dist/esm/index.esm.js",
   "typings": "dist/app/index.d.ts"
 }

--- a/packages/firebase/auth/cordova/package.json
+++ b/packages/firebase/auth/cordova/package.json
@@ -1,7 +1,7 @@
 {
   "name": "firebase/auth/cordova",
   "main": "dist/index.cjs.js",
-  "browser": "dist/index.esm.js",
-  "module": "dist/index.esm.js",
+  "browser": "dist/esm/index.esm.js",
+  "module": "dist/esm/index.esm.js",
   "typings": "dist/auth/cordova/index.d.ts"
 }

--- a/packages/firebase/auth/package.json
+++ b/packages/firebase/auth/package.json
@@ -1,7 +1,7 @@
 {
   "name": "firebase/auth",
   "main": "dist/index.cjs.js",
-  "browser": "dist/index.esm.js",
-  "module": "dist/index.esm.js",
+  "browser": "dist/esm/index.esm.js",
+  "module": "dist/esm/index.esm.js",
   "typings": "dist/auth/index.d.ts"
 }

--- a/packages/firebase/auth/react-native/package.json
+++ b/packages/firebase/auth/react-native/package.json
@@ -1,7 +1,7 @@
 {
   "name": "firebase/auth/react-native",
   "main": "dist/index.cjs.js",
-  "browser": "dist/index.esm.js",
-  "module": "dist/index.esm.js",
+  "browser": "dist/esm/index.esm.js",
+  "module": "dist/esm/index.esm.js",
   "typings": "dist/auth/react-native/index.d.ts"
 }

--- a/packages/firebase/compat/analytics/package.json
+++ b/packages/firebase/compat/analytics/package.json
@@ -1,7 +1,7 @@
 {
   "name": "firebase/compat/analytics",
   "main": "dist/index.cjs.js",
-  "browser": "dist/index.esm.js",
-  "module": "dist/index.esm.js",
+  "browser": "dist/esm/index.esm.js",
+  "module": "dist/esm/index.esm.js",
   "typings": "dist/compat/analytics/index.d.ts"
 }

--- a/packages/firebase/compat/app-check/package.json
+++ b/packages/firebase/compat/app-check/package.json
@@ -1,7 +1,7 @@
 {
   "name": "firebase/compat/app-check",
   "main": "dist/index.cjs.js",
-  "browser": "dist/index.esm.js",
-  "module": "dist/index.esm.js",
+  "browser": "dist/esm/index.esm.js",
+  "module": "dist/esm/index.esm.js",
   "typings": "dist/compat/app-check/index.d.ts"
 }

--- a/packages/firebase/compat/app/package.json
+++ b/packages/firebase/compat/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "firebase/compat/app",
   "main": "dist/index.cjs.js",
-  "browser": "dist/index.esm.js",
-  "module": "dist/index.esm.js",
+  "browser": "dist/esm/index.esm.js",
+  "module": "dist/esm/index.esm.js",
   "typings": "../index.d.ts"
 }

--- a/packages/firebase/compat/auth/package.json
+++ b/packages/firebase/compat/auth/package.json
@@ -1,7 +1,7 @@
 {
   "name": "firebase/compat/auth",
   "main": "dist/index.cjs.js",
-  "browser": "dist/index.esm.js",
-  "module": "dist/index.esm.js",
+  "browser": "dist/esm/index.esm.js",
+  "module": "dist/esm/index.esm.js",
   "typings": "dist/compat/auth/index.d.ts"
 }

--- a/packages/firebase/compat/database/package.json
+++ b/packages/firebase/compat/database/package.json
@@ -1,7 +1,7 @@
 {
   "name": "firebase/compat/database",
   "main": "dist/index.cjs.js",
-  "browser": "dist/index.esm.js",
-  "module": "dist/index.esm.js",
+  "browser": "dist/esm/index.esm.js",
+  "module": "dist/esm/index.esm.js",
   "typings": "dist/compat/database/index.d.ts"
 }

--- a/packages/firebase/compat/firestore/package.json
+++ b/packages/firebase/compat/firestore/package.json
@@ -1,7 +1,7 @@
 {
   "name": "firebase/compat/firestore",
   "main": "dist/index.cjs.js",
-  "browser": "dist/index.esm.js",
-  "module": "dist/index.esm.js",
+  "browser": "dist/esm/index.esm.js",
+  "module": "dist/esm/index.esm.js",
   "typings": "dist/compat/firestore/index.d.ts"
 }

--- a/packages/firebase/compat/functions/package.json
+++ b/packages/firebase/compat/functions/package.json
@@ -1,7 +1,7 @@
 {
   "name": "firebase/compat/functions",
   "main": "dist/index.cjs.js",
-  "browser": "dist/index.esm.js",
-  "module": "dist/index.esm.js",
+  "browser": "dist/esm/index.esm.js",
+  "module": "dist/esm/index.esm.js",
   "typings": "dist/compat/functions/index.d.ts"
 }

--- a/packages/firebase/compat/installations/package.json
+++ b/packages/firebase/compat/installations/package.json
@@ -1,7 +1,7 @@
 {
   "name": "firebase/compat/installations",
   "main": "dist/index.cjs.js",
-  "browser": "dist/index.esm.js",
-  "module": "dist/index.esm.js",
+  "browser": "dist/esm/index.esm.js",
+  "module": "dist/esm/index.esm.js",
   "typings": "dist/compat/installations/index.d.ts"
 }

--- a/packages/firebase/compat/messaging/package.json
+++ b/packages/firebase/compat/messaging/package.json
@@ -1,7 +1,7 @@
 {
   "name": "firebase/compat/messaging",
   "main": "dist/index.cjs.js",
-  "browser": "dist/index.esm.js",
-  "module": "dist/index.esm.js",
+  "browser": "dist/esm/index.esm.js",
+  "module": "dist/esm/index.esm.js",
   "typings": "dist/compat/messaging/index.d.ts"
 }

--- a/packages/firebase/compat/package.json
+++ b/packages/firebase/compat/package.json
@@ -1,8 +1,8 @@
 {
   "name": "firebase/compat",
   "main": "dist/index.node.cjs",
-  "browser": "dist/index.esm.js",
-  "module": "dist/index.esm.js",
+  "browser": "dist/esm/index.esm.js",
+  "module": "dist/esm/index.esm.js",
   "react-native": "dist/index.rn.cjs.js",
   "typings": "index.d.ts",
   "components": [

--- a/packages/firebase/compat/performance/package.json
+++ b/packages/firebase/compat/performance/package.json
@@ -1,7 +1,7 @@
 {
   "name": "firebase/compat/performance",
   "main": "dist/index.cjs.js",
-  "browser": "dist/index.esm.js",
-  "module": "dist/index.esm.js",
+  "browser": "dist/esm/index.esm.js",
+  "module": "dist/esm/index.esm.js",
   "typings": "dist/compat/performance/index.d.ts"
 }

--- a/packages/firebase/compat/remote-config/package.json
+++ b/packages/firebase/compat/remote-config/package.json
@@ -1,7 +1,7 @@
 {
   "name": "firebase/compat/remote-config",
   "main": "dist/index.cjs.js",
-  "browser": "dist/index.esm.js",
-  "module": "dist/index.esm.js",
+  "browser": "dist/esm/index.esm.js",
+  "module": "dist/esm/index.esm.js",
   "typings": "dist/compat/remote-config/index.d.ts"
 }

--- a/packages/firebase/compat/storage/package.json
+++ b/packages/firebase/compat/storage/package.json
@@ -1,7 +1,7 @@
 {
   "name": "firebase/compat/storage",
   "main": "dist/index.cjs.js",
-  "browser": "dist/index.esm.js",
-  "module": "dist/index.esm.js",
+  "browser": "dist/esm/index.esm.js",
+  "module": "dist/esm/index.esm.js",
   "typings": "dist/compat/storage/index.d.ts"
 }

--- a/packages/firebase/database/package.json
+++ b/packages/firebase/database/package.json
@@ -1,7 +1,7 @@
 {
   "name": "firebase/database",
   "main": "dist/index.cjs.js",
-  "browser": "dist/index.esm.js",
-  "module": "dist/index.esm.js",
+  "browser": "dist/esm/index.esm.js",
+  "module": "dist/esm/index.esm.js",
   "typings": "dist/database/index.d.ts"
 }

--- a/packages/firebase/firestore/lite/package.json
+++ b/packages/firebase/firestore/lite/package.json
@@ -1,7 +1,7 @@
 {
   "name": "firebase/firestore/lite",
   "main": "dist/index.cjs.js",
-  "browser": "dist/index.esm.js",
-  "module": "dist/index.esm.js",
+  "browser": "dist/esm/index.esm.js",
+  "module": "dist/esm/index.esm.js",
   "typings": "dist/firestore/lite/index.d.ts"
 }

--- a/packages/firebase/firestore/package.json
+++ b/packages/firebase/firestore/package.json
@@ -1,7 +1,7 @@
 {
   "name": "firebase/firestore",
   "main": "dist/index.cjs.js",
-  "browser": "dist/index.esm.js",
-  "module": "dist/index.esm.js",
+  "browser": "dist/esm/index.esm.js",
+  "module": "dist/esm/index.esm.js",
   "typings": "dist/firestore/index.d.ts"
 }

--- a/packages/firebase/functions/package.json
+++ b/packages/firebase/functions/package.json
@@ -1,7 +1,7 @@
 {
   "name": "firebase/functions",
   "main": "dist/index.cjs.js",
-  "browser": "dist/index.esm.js",
-  "module": "dist/index.esm.js",
+  "browser": "dist/esm/index.esm.js",
+  "module": "dist/esm/index.esm.js",
   "typings": "dist/functions/index.d.ts"
 }

--- a/packages/firebase/installations/package.json
+++ b/packages/firebase/installations/package.json
@@ -1,7 +1,7 @@
 {
   "name": "firebase/installations",
   "main": "dist/index.cjs.js",
-  "browser": "dist/index.esm.js",
-  "module": "dist/index.esm.js",
+  "browser": "dist/esm/index.esm.js",
+  "module": "dist/esm/index.esm.js",
   "typings": "dist/installations/index.d.ts"
 }

--- a/packages/firebase/messaging/package.json
+++ b/packages/firebase/messaging/package.json
@@ -1,7 +1,7 @@
 {
   "name": "firebase/messaging",
   "main": "dist/index.cjs.js",
-  "browser": "dist/index.esm.js",
-  "module": "dist/index.esm.js",
+  "browser": "dist/esm/index.esm.js",
+  "module": "dist/esm/index.esm.js",
   "typings": "dist/messaging/index.d.ts"
 }

--- a/packages/firebase/messaging/sw/package.json
+++ b/packages/firebase/messaging/sw/package.json
@@ -1,7 +1,7 @@
 {
   "name": "firebase/messaging/sw",
   "main": "dist/index.cjs.js",
-  "browser": "dist/index.esm.js",
-  "module": "dist/index.esm.js",
+  "browser": "dist/esm/index.esm.js",
+  "module": "dist/esm/index.esm.js",
   "typings": "dist/messaging/sw/index.d.ts"
 }

--- a/packages/firebase/package.json
+++ b/packages/firebase/package.json
@@ -29,7 +29,7 @@
         "require": "./analytics/dist/index.cjs.js",
         "import": "./analytics/dist/index.mjs"
       },
-      "default": "./analytics/dist/index.esm.js"
+      "default": "./analytics/dist/esm/index.esm.js"
     },
     "./app": {
       "types": "./app/dist/app/index.d.ts",
@@ -37,7 +37,7 @@
         "require": "./app/dist/index.cjs.js",
         "import": "./app/dist/index.mjs"
       },
-      "default": "./app/dist/index.esm.js"
+      "default": "./app/dist/esm/index.esm.js"
     },
     "./app-check": {
       "types": "./app-check/dist/app-check/index.d.ts",
@@ -45,7 +45,7 @@
         "require": "./app-check/dist/index.cjs.js",
         "import": "./app-check/dist/index.mjs"
       },
-      "default": "./app-check/dist/index.esm.js"
+      "default": "./app-check/dist/esm/index.esm.js"
     },
     "./auth": {
       "types": "./auth/dist/auth/index.d.ts",
@@ -53,7 +53,7 @@
         "require": "./auth/dist/index.cjs.js",
         "import": "./auth/dist/index.mjs"
       },
-      "default": "./auth/dist/index.esm.js"
+      "default": "./auth/dist/esm/index.esm.js"
     },
     "./auth/cordova": {
       "types": "./auth/cordova/dist/auth/cordova/index.d.ts",
@@ -61,7 +61,7 @@
         "require": "./auth/cordova/dist/index.cjs.js",
         "import": "./auth/cordova/dist/index.mjs"
       },
-      "default": "./auth/cordova/dist/index.esm.js"
+      "default": "./auth/cordova/dist/esm/index.esm.js"
     },
     "./auth/react-native": {
       "types": "./auth/react-native/dist/auth/react-native/index.d.ts",
@@ -69,7 +69,7 @@
         "require": "./auth/react-native/dist/index.cjs.js",
         "import": "./auth/react-native/dist/index.mjs"
       },
-      "default": "./auth/react-native/dist/index.esm.js"
+      "default": "./auth/react-native/dist/esm/index.esm.js"
     },
     "./database": {
       "types": "./database/dist/database/index.d.ts",
@@ -77,7 +77,7 @@
         "require": "./database/dist/index.cjs.js",
         "import": "./database/dist/index.mjs"
       },
-      "default": "./database/dist/index.esm.js"
+      "default": "./database/dist/esm/index.esm.js"
     },
     "./firestore": {
       "types": "./firestore/dist/firestore/index.d.ts",
@@ -85,7 +85,7 @@
         "require": "./firestore/dist/index.cjs.js",
         "import": "./firestore/dist/index.mjs"
       },
-      "default": "./firestore/dist/index.esm.js"
+      "default": "./firestore/dist/esm/index.esm.js"
     },
     "./firestore/lite": {
       "types": "./firestore/lite/dist/firestore/lite/index.d.ts",
@@ -93,7 +93,7 @@
         "require": "./firestore/lite/dist/index.cjs.js",
         "import": "./firestore/lite/dist/index.mjs"
       },
-      "default": "./firestore/lite/dist/index.esm.js"
+      "default": "./firestore/lite/dist/esm/index.esm.js"
     },
     "./functions": {
       "types": "./functions/dist/functions/index.d.ts",
@@ -101,7 +101,7 @@
         "require": "./functions/dist/index.cjs.js",
         "import": "./functions/dist/index.mjs"
       },
-      "default": "./functions/dist/index.esm.js"
+      "default": "./functions/dist/esm/index.esm.js"
     },
     "./installations": {
       "types": "./installations/dist/installations/index.d.ts",
@@ -109,7 +109,7 @@
         "require": "./installations/dist/index.cjs.js",
         "import": "./installations/dist/index.mjs"
       },
-      "default": "./installations/dist/index.esm.js"
+      "default": "./installations/dist/esm/index.esm.js"
     },
     "./messaging": {
       "types": "./messaging/dist/messaging/index.d.ts",
@@ -117,7 +117,7 @@
         "require": "./messaging/dist/index.cjs.js",
         "import": "./messaging/dist/index.mjs"
       },
-      "default": "./messaging/dist/index.esm.js"
+      "default": "./messaging/dist/esm/index.esm.js"
     },
     "./messaging/sw": {
       "types": "./messaging/sw/dist/messaging/sw/index.d.ts",
@@ -125,7 +125,7 @@
         "require": "./messaging/sw/dist/index.cjs.js",
         "import": "./messaging/sw/dist/index.mjs"
       },
-      "default": "./messaging/sw/dist/index.esm.js"
+      "default": "./messaging/sw/dist/esm/index.esm.js"
     },
     "./performance": {
       "types": "./performance/dist/performance/index.d.ts",
@@ -133,7 +133,7 @@
         "require": "./performance/dist/index.cjs.js",
         "import": "./performance/dist/index.mjs"
       },
-      "default": "./performance/dist/index.esm.js"
+      "default": "./performance/dist/esm/index.esm.js"
     },
     "./remote-config": {
       "types": "./remote-config/dist/remote-config/index.d.ts",
@@ -141,7 +141,7 @@
         "require": "./remote-config/dist/index.cjs.js",
         "import": "./remote-config/dist/index.mjs"
       },
-      "default": "./remote-config/dist/index.esm.js"
+      "default": "./remote-config/dist/esm/index.esm.js"
     },
     "./storage": {
       "types": "./storage/dist/storage/index.d.ts",
@@ -149,7 +149,7 @@
         "require": "./storage/dist/index.cjs.js",
         "import": "./storage/dist/index.mjs"
       },
-      "default": "./storage/dist/index.esm.js"
+      "default": "./storage/dist/esm/index.esm.js"
     },
     "./compat/analytics": {
       "types": "./compat/analytics/dist/compat/analytics/index.d.ts",
@@ -157,7 +157,7 @@
         "require": "./compat/analytics/dist/index.cjs.js",
         "import": "./compat/analytics/dist/index.mjs"
       },
-      "default": "./compat/analytics/dist/index.esm.js"
+      "default": "./compat/analytics/dist/esm/index.esm.js"
     },
     "./compat/app": {
       "types": "./compat/app/dist/compat/app/index.d.ts",
@@ -165,7 +165,7 @@
         "require": "./compat/app/dist/index.cjs.js",
         "import": "./compat/app/dist/index.mjs"
       },
-      "default": "./compat/app/dist/index.esm.js"
+      "default": "./compat/app/dist/esm/index.esm.js"
     },
     "./compat/app-check": {
       "types": "./compat/app-check/dist/compat/app-check/index.d.ts",
@@ -173,7 +173,7 @@
         "require": "./compat/app-check/dist/index.cjs.js",
         "import": "./compat/app-check/dist/index.mjs"
       },
-      "default": "./compat/app-check/dist/index.esm.js"
+      "default": "./compat/app-check/dist/esm/index.esm.js"
     },
     "./compat/auth": {
       "types": "./compat/auth/dist/compat/auth/index.d.ts",
@@ -181,7 +181,7 @@
         "require": "./compat/auth/dist/index.cjs.js",
         "import": "./compat/auth/dist/index.mjs"
       },
-      "default": "./compat/auth/dist/index.esm.js"
+      "default": "./compat/auth/dist/esm/index.esm.js"
     },
     "./compat/database": {
       "types": "./compat/database/dist/compat/database/index.d.ts",
@@ -189,7 +189,7 @@
         "require": "./compat/database/dist/index.cjs.js",
         "import": "./compat/database/dist/index.mjs"
       },
-      "default": "./compat/database/dist/index.esm.js"
+      "default": "./compat/database/dist/esm/index.esm.js"
     },
     "./compat/firestore": {
       "types": "./compat/firestore/dist/compat/firestore/index.d.ts",
@@ -197,7 +197,7 @@
         "require": "./compat/firestore/dist/index.cjs.js",
         "import": "./compat/firestore/dist/index.mjs"
       },
-      "default": "./compat/firestore/dist/index.esm.js"
+      "default": "./compat/firestore/dist/esm/index.esm.js"
     },
     "./compat/functions": {
       "types": "./compat/functions/dist/compat/functions/index.d.ts",
@@ -205,7 +205,7 @@
         "require": "./compat/functions/dist/index.cjs.js",
         "import": "./compat/functions/dist/index.mjs"
       },
-      "default": "./compat/functions/dist/index.esm.js"
+      "default": "./compat/functions/dist/esm/index.esm.js"
     },
     "./compat/installations": {
       "types": "./compat/installations/dist/compat/installations/index.d.ts",
@@ -213,7 +213,7 @@
         "require": "./compat/installations/dist/index.cjs.js",
         "import": "./compat/installations/dist/index.mjs"
       },
-      "default": "./compat/installations/dist/index.esm.js"
+      "default": "./compat/installations/dist/esm/index.esm.js"
     },
     "./compat/messaging": {
       "types": "./compat/messaging/dist/compat/messaging/index.d.ts",
@@ -221,7 +221,7 @@
         "require": "./compat/messaging/dist/index.cjs.js",
         "import": "./compat/messaging/dist/index.mjs"
       },
-      "default": "./compat/messaging/dist/index.esm.js"
+      "default": "./compat/messaging/dist/esm/index.esm.js"
     },
     "./compat/performance": {
       "types": "./compat/performance/dist/compat/performance/index.d.ts",
@@ -229,7 +229,7 @@
         "require": "./compat/performance/dist/index.cjs.js",
         "import": "./compat/performance/dist/index.mjs"
       },
-      "default": "./compat/performance/dist/index.esm.js"
+      "default": "./compat/performance/dist/esm/index.esm.js"
     },
     "./compat/remote-config": {
       "types": "./compat/remote-config/dist/compat/remote-config/index.d.ts",
@@ -237,7 +237,7 @@
         "require": "./compat/remote-config/dist/index.cjs.js",
         "import": "./compat/remote-config/dist/index.mjs"
       },
-      "default": "./compat/remote-config/dist/index.esm.js"
+      "default": "./compat/remote-config/dist/esm/index.esm.js"
     },
     "./compat/storage": {
       "types": "./compat/storage/dist/compat/storage/index.d.ts",
@@ -245,7 +245,7 @@
         "require": "./compat/storage/dist/index.cjs.js",
         "import": "./compat/storage/dist/index.mjs"
       },
-      "default": "./compat/storage/dist/index.esm.js"
+      "default": "./compat/storage/dist/esm/index.esm.js"
     },
     "./package.json": "./package.json"
   },

--- a/packages/firebase/performance/package.json
+++ b/packages/firebase/performance/package.json
@@ -1,7 +1,7 @@
 {
   "name": "firebase/performance",
   "main": "dist/index.cjs.js",
-  "browser": "dist/index.esm.js",
-  "module": "dist/index.esm.js",
+  "browser": "dist/esm/index.esm.js",
+  "module": "dist/esm/index.esm.js",
   "typings": "dist/performance/index.d.ts"
 }

--- a/packages/firebase/remote-config/package.json
+++ b/packages/firebase/remote-config/package.json
@@ -1,7 +1,7 @@
 {
   "name": "firebase/remote-config",
   "main": "dist/index.cjs.js",
-  "browser": "dist/index.esm.js",
-  "module": "dist/index.esm.js",
+  "browser": "dist/esm/index.esm.js",
+  "module": "dist/esm/index.esm.js",
   "typings": "dist/remote-config/index.d.ts"
 }

--- a/packages/firebase/rollup.config.js
+++ b/packages/firebase/rollup.config.js
@@ -25,6 +25,7 @@ import rollupTypescriptPlugin from 'rollup-plugin-typescript2';
 import sourcemaps from 'rollup-plugin-sourcemaps';
 import { terser } from 'rollup-plugin-terser';
 import typescript from 'typescript';
+import { emitModulePackageFile } from '../../scripts/build/rollup_emit_module_package_file';
 
 const external = Object.keys(pkg.dependencies || {});
 const plugins = [sourcemaps(), resolveModule(), json(), commonjs()];
@@ -47,7 +48,21 @@ const typescriptPluginCDN = rollupTypescriptPlugin({
  */
 const appBuilds = [
   /**
-   * App Browser Builds
+   * App ESM Build
+   * Uses "type:module" in package.json to signal this is ESM.
+   * Allows the extension to remain '.js' as some tools do not recognize
+   * '.mjs'.
+   */
+  {
+    input: 'app/index.ts',
+    output: [
+      { file: resolve('app', appPkg.browser), format: 'es', sourcemap: true }
+    ],
+    plugins: [...plugins, typescriptPlugin, emitModulePackageFile()],
+    external: id => external.some(dep => id === dep || id.startsWith(`${dep}/`))
+  },
+  /**
+   * App CJS/MJS builds
    */
   {
     input: 'app/index.ts',
@@ -57,8 +72,7 @@ const appBuilds = [
         file: resolve('app', appPkg.main.replace('.cjs.js', '.mjs')),
         format: 'es',
         sourcemap: true
-      },
-      { file: resolve('app', appPkg.browser), format: 'es', sourcemap: true }
+      }
     ],
     plugins: [...plugins, typescriptPlugin],
     external: id => external.some(dep => id === dep || id.startsWith(`${dep}/`))
@@ -71,6 +85,28 @@ const componentBuilds = pkg.components
   .map(component => {
     const pkg = require(`./${component}/package.json`);
     return [
+      /**
+       * Component ESM Build
+       * Uses "type:module" in package.json to signal this is ESM.
+       * Allows the extension to remain '.js' as some tools do not recognize
+       * '.mjs'.
+       */
+      {
+        input: `${component}/index.ts`,
+        output: [
+          {
+            file: resolve(component, pkg.browser),
+            format: 'es',
+            sourcemap: true
+          }
+        ],
+        plugins: [...plugins, typescriptPlugin, emitModulePackageFile()],
+        external: id =>
+          external.some(dep => id === dep || id.startsWith(`${dep}/`))
+      },
+      /**
+       * Component CJS/MJS builds
+       */
       {
         input: `${component}/index.ts`,
         output: [
@@ -81,11 +117,6 @@ const componentBuilds = pkg.components
           },
           {
             file: resolve(component, pkg.main.replace('.cjs.js', '.mjs')),
-            format: 'es',
-            sourcemap: true
-          },
-          {
-            file: resolve(component, pkg.browser),
             format: 'es',
             sourcemap: true
           }

--- a/packages/firebase/storage/package.json
+++ b/packages/firebase/storage/package.json
@@ -1,7 +1,7 @@
 {
   "name": "firebase/storage",
   "main": "dist/index.cjs.js",
-  "browser": "dist/index.esm.js",
-  "module": "dist/index.esm.js",
+  "browser": "dist/esm/index.esm.js",
+  "module": "dist/esm/index.esm.js",
   "typings": "dist/storage/index.d.ts"
 }

--- a/scripts/ci-test/check-paths.ts
+++ b/scripts/ci-test/check-paths.ts
@@ -17,7 +17,7 @@
 
 import glob from 'glob';
 import { existsSync } from 'fs';
-import { resolve } from 'path';
+import { resolve, parse } from 'path';
 import { projectRoot as root } from '../utils';
 
 /**
@@ -48,9 +48,9 @@ const results: Result[] = [];
  * Get paths to packages. Only check the ones we actually
  * publish (packages/*).
  */
-function getPaths(): Promise<string[]> {
+function getPkgJsonPaths(): Promise<string[]> {
   return new Promise((resolve, reject) => {
-    glob('packages/*', (err, paths) => {
+    glob('packages/**/package.json', (err, paths) => {
       if (err) reject(err);
       resolve(paths);
     });
@@ -91,12 +91,21 @@ function checkExports(
 }
 
 async function main() {
-  const paths = await getPaths();
+  const paths = await getPkgJsonPaths();
 
   for (const path of paths) {
-    const pkgRoot = `${root}/${path}`;
+    const { dir } = parse(path);
+    if (dir.includes('node_modules') || dir.includes('/demo')) {
+      continue;
+    }
+    const pkgRoot = resolve(root, dir);
     if (existsSync(`${pkgRoot}/package.json`)) {
       const pkg = require(`${pkgRoot}/package.json`);
+      if (!pkg.name) {
+        // Probably dummy package.json with 'type: module'
+        continue;
+      }
+      console.log(`Checking ${dir}/package.json`);
 
       /**
        * Check top level fields.


### PR DESCRIPTION
See https://github.com/firebase/firebase-js-sdk/issues/6747

More build tooling these days is requiring all ESM bundles conform to Node ESM rules, even if the bundles are mainly used in the browser (for example, many test frameworks run browser tests in Node and require all bundles to meet Node ESM rules when the tests are run). This may also affect SSR/SSG.

The rules are essentially that the extension must be `.mjs` OR the nearest package.json file must have a line that says `type: "module"`.

We avoid putting an mjs extension on browser bundles because some older build tools and environments don't know how to handle that extension. Instead, in the `@firebase/*` packages, we have put ESM files in their own subdirectory in `dist/` (`dist/esm/`) and used a rollup plugin put a one-line package.json file in there with them that says "type: module". This build step had not been applied to the `firebase/*` packages (the entry point packages that just redirect to the equivalent `@firebase/*` package).

It's possible that some tooling is happy enough with the end package (`@firebase/*`) having this setup (the way it is now), while other tooling requires the Node ESM indicators to be there at every step of resolution (explaining issues still being reported by some users).

I've added this step to the entry point `firebase/*` packages in this PR hoping this will fix it for those users.