### PR TITLE
Fix Firefox CI issue

### DIFF
--- a/.github/workflows/test-changed-auth.yml
+++ b/.github/workflows/test-changed-auth.yml
@@ -38,7 +38,10 @@ jobs:
         run: xvfb-run yarn test:changed auth
   test-firefox:
     name: Test Auth on Firefox If Changed
-    runs-on: ubuntu-latest
+    # Whatever version of Firefox comes with 22.04 is causing Firefox
+    # startup to hang when launched by karma. Need to look further into
+    # why.
+    runs-on: ubuntu-20.04
 
     steps:
       - name: install Firefox stable

--- a/.github/workflows/test-changed-firestore.yml
+++ b/.github/workflows/test-changed-firestore.yml
@@ -34,16 +34,13 @@ jobs:
 
   test-firefox:
     name: Test Firestore on Firefox If Changed
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - name: install Firefox stable
-        # run: |
-        #   sudo apt-get update
-        #   sudo apt-get install firefox
         run: |
           sudo apt-get update
-          apt-cache show firefox | grep Version
+          sudo apt-get install firefox
       - name: Checkout Repo
         uses: actions/checkout@master
         with:

--- a/.github/workflows/test-changed-firestore.yml
+++ b/.github/workflows/test-changed-firestore.yml
@@ -41,7 +41,9 @@ jobs:
         # run: |
         #   sudo apt-get update
         #   sudo apt-get install firefox
-        run: apt-cache show firefox | grep Version
+        run: |
+          sudo apt-get update
+          apt-cache show firefox | grep Version
       - name: Checkout Repo
         uses: actions/checkout@master
         with:

--- a/.github/workflows/test-changed-firestore.yml
+++ b/.github/workflows/test-changed-firestore.yml
@@ -40,7 +40,7 @@ jobs:
       - name: install Firefox stable
         run: |
           sudo apt-get update
-          sudo apt-get install firefox
+          sudo apt-get install firefox=106.0.5
       - name: Checkout Repo
         uses: actions/checkout@master
         with:
@@ -61,4 +61,4 @@ jobs:
       - name: Run tests if firestore or its dependencies has changed
         run: xvfb-run yarn test:changed firestore
         env:
-          BROWSERS: 'FirefoxHeadless'
+          BROWSERS: 'Firefox'

--- a/.github/workflows/test-changed-firestore.yml
+++ b/.github/workflows/test-changed-firestore.yml
@@ -38,9 +38,10 @@ jobs:
 
     steps:
       - name: install Firefox stable
-        run: |
-          sudo apt-get update
-          sudo apt-get install firefox=106.0.5
+        # run: |
+        #   sudo apt-get update
+        #   sudo apt-get install firefox
+        run: apt-cache show firefox | grep Version
       - name: Checkout Repo
         uses: actions/checkout@master
         with:

--- a/.github/workflows/test-changed-firestore.yml
+++ b/.github/workflows/test-changed-firestore.yml
@@ -34,6 +34,9 @@ jobs:
 
   test-firefox:
     name: Test Firestore on Firefox If Changed
+    # Whatever version of Firefox comes with 22.04 is causing Firefox
+    # startup to hang when launched by karma. Need to look further into
+    # why.
     runs-on: ubuntu-20.04
 
     steps:

--- a/.github/workflows/test-changed-firestore.yml
+++ b/.github/workflows/test-changed-firestore.yml
@@ -61,4 +61,4 @@ jobs:
       - name: Run tests if firestore or its dependencies has changed
         run: xvfb-run yarn test:changed firestore
         env:
-          BROWSERS: 'Firefox'
+          BROWSERS: 'FirefoxHeadless'

--- a/.github/workflows/test-changed.yml
+++ b/.github/workflows/test-changed.yml
@@ -34,7 +34,10 @@ jobs:
 
   test-firefox:
     name: Test Packages With Changed Files in Firefox
-    runs-on: ubuntu-latest
+    # Whatever version of Firefox comes with 22.04 is causing Firefox
+    # startup to hang when launched by karma. Need to look further into
+    # why.
+    runs-on: ubuntu-20.04
 
     steps:
       - name: Checkout Repo

--- a/packages/firestore/src/index/directional_index_byte_encoder.ts
+++ b/packages/firestore/src/index/directional_index_byte_encoder.ts
@@ -17,8 +17,6 @@
 
 import { ByteString } from '../util/byte_string';
 
-// Trigger Firestore CI tests
-
 /** An index value encoder.  */
 export interface DirectionalIndexByteEncoder {
   // Note: This code is copied from the backend. Code that is not used by

--- a/packages/firestore/src/index/directional_index_byte_encoder.ts
+++ b/packages/firestore/src/index/directional_index_byte_encoder.ts
@@ -17,7 +17,6 @@
 
 import { ByteString } from '../util/byte_string';
 
-
 // Trigger Firestore CI tests
 
 /** An index value encoder.  */

--- a/packages/firestore/src/index/directional_index_byte_encoder.ts
+++ b/packages/firestore/src/index/directional_index_byte_encoder.ts
@@ -17,6 +17,9 @@
 
 import { ByteString } from '../util/byte_string';
 
+
+// Trigger Firestore CI tests
+
 /** An index value encoder.  */
 export interface DirectionalIndexByteEncoder {
   // Note: This code is copied from the backend. Code that is not used by


### PR DESCRIPTION
Github's latest image for ubuntu is ubuntu-22.04 which seems to come with a version of Firefox that causes the karma launcher to hang and eventually give up when trying to launch Firefox. Other users have reported the Firefox bin isn't there at all, which is not exactly the same issue, but could be related. Locking it to ubuntu-20.04 until we can figure out why (hopefully it isn't that current and future versions of Firefox don't work with karma-firefox-launcher).