### PR TITLE
Fix documentation for getDocsFromCache.

### DIFF
--- a/.changeset/wild-frogs-play.md
+++ b/.changeset/wild-frogs-play.md
@@ -1,0 +1,5 @@
+---
+"@firebase/firestore": patch
+---
+
+Fix documentation for getDocsFromCache.

--- a/packages/firestore/src/api/reference_impl.ts
+++ b/packages/firestore/src/api/reference_impl.ts
@@ -196,7 +196,8 @@ export function getDocs<T>(query: Query<T>): Promise<QuerySnapshot<T>> {
 
 /**
  * Executes the query and returns the results as a `QuerySnapshot` from cache.
- * Returns an error if the document is not currently cached.
+ * Returns an empty result set if no documents matching the query are currently
+ * cached.
  *
  * @returns A `Promise` that will be resolved with the results of the query.
  */


### PR DESCRIPTION
Fix documentation for getDocsFromCache. Specifically this updates the line stating that the function will throw if documents are not cached, and instead states that the function will return an empty result set if documents are not cached. Fixes #6851