### PR TITLE
Fixed issue where serverCache is incorrectly marked as not filtered

### DIFF
--- a/packages/database/src/core/view/ViewProcessor.ts
+++ b/packages/database/src/core/view/ViewProcessor.ts
@@ -184,7 +184,8 @@ export function viewProcessorApplyOperation(
       oldViewCache,
       operation.path,
       writesCache,
-      accumulator
+      accumulator,
+      operation.source.tagged
     );
   } else {
     throw assertionError('Unknown operation type: ' + operation.type);
@@ -752,14 +753,17 @@ function viewProcessorListenComplete(
   viewCache: ViewCache,
   path: Path,
   writesCache: WriteTreeRef,
-  accumulator: ChildChangeAccumulator
+  accumulator: ChildChangeAccumulator,
+  isTagged: boolean
 ): ViewCache {
   const oldServerNode = viewCache.serverCache;
   const newViewCache = viewCacheUpdateServerSnap(
     viewCache,
     oldServerNode.getNode(),
     oldServerNode.isFullyInitialized() || pathIsEmpty(path),
-    oldServerNode.isFiltered()
+    // If the query is tagged, it essentially means we are filtering it on the server.
+    // This is to fix the issue where if a tagged query doesn't have data, it's assumed that the data is not filtered on the server and therefore complete
+    oldServerNode.isFiltered() || isTagged
   );
   return viewProcessorGenerateEventCacheAfterServerEvent(
     viewProcessor,


### PR DESCRIPTION
When `serverCache` is initialized, we initialize the `filtered_` parameter as `false` and then when new data comes in, we set that parameter based on whether the update (merge vs overwrite) is tagged. However, in cases where no data is at that location for a tagged query, that set will never be called, causing the `serverCache` at that location to be assumed as complete for that child, leading to invalid merges.

This PR adds an extra step where we can change that value based on whether the completed listen was tagged or not. 