### PR TITLE
remove isBrowser method

### DIFF
--- a/.changeset/five-waves-applaud.md
+++ b/.changeset/five-waves-applaud.md
@@ -1,0 +1,6 @@
+---
+'@firebase/app-compat': minor
+'@firebase/util': minor
+---
+
+Remove standalone `isBrowser` utility function and inline the functionality in `app-compat`.

--- a/.changeset/flat-snakes-joke.md
+++ b/.changeset/flat-snakes-joke.md
@@ -1,6 +1,7 @@
 ---
-'@firebase/app-compat': minor
-'@firebase/util': minor
+'@firebase/app-compat': patch
+'@firebase/util': patch
+'firebase': patch
 ---
 
 Remove standalone `isBrowser` utility function and inline the functionality in `app-compat`.

--- a/common/api-review/util.api.md
+++ b/common/api-review/util.api.md
@@ -246,11 +246,6 @@ export function getUA(): string;
 // @public
 export const isAdmin: (token: string) => boolean;
 
-// Warning: (ae-missing-release-tag) "isBrowser" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public
-export function isBrowser(): boolean;
-
 // Warning: (ae-missing-release-tag) "isBrowserExtension" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)

--- a/packages/app-compat/src/index.ts
+++ b/packages/app-compat/src/index.ts
@@ -16,14 +16,13 @@
  */
 
 import { FirebaseNamespace } from './public-types';
-import { isBrowser } from '@firebase/util';
 import { firebase as firebaseNamespace } from './firebaseNamespace';
 import { logger } from './logger';
 import { registerCoreComponents } from './registerCoreComponents';
 
 // Firebase Lite detection
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-if (isBrowser() && (self as any).firebase !== undefined) {
+if (typeof self !== 'undefined' && (self as any).firebase !== undefined) {
   logger.warn(`
     Warning: Firebase is already defined in the global scope. Please make sure
     Firebase library is only loaded once.

--- a/packages/app-compat/src/index.ts
+++ b/packages/app-compat/src/index.ts
@@ -20,7 +20,7 @@ import { firebase as firebaseNamespace } from './firebaseNamespace';
 import { logger } from './logger';
 import { registerCoreComponents } from './registerCoreComponents';
 
-// Firebase Lite detection -
+// Firebase Lite detection
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 if (typeof self !== 'undefined' && (self as any).firebase !== undefined) {
   logger.warn(`

--- a/packages/app-compat/src/index.ts
+++ b/packages/app-compat/src/index.ts
@@ -20,7 +20,7 @@ import { firebase as firebaseNamespace } from './firebaseNamespace';
 import { logger } from './logger';
 import { registerCoreComponents } from './registerCoreComponents';
 
-// Firebase Lite detection
+// Firebase Lite detection -
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 if (typeof self !== 'undefined' && (self as any).firebase !== undefined) {
   logger.warn(`

--- a/packages/util/src/environment.ts
+++ b/packages/util/src/environment.ts
@@ -74,13 +74,6 @@ export function isNode(): boolean {
 }
 
 /**
- * Detect Browser Environment
- */
-export function isBrowser(): boolean {
-  return typeof self === 'object' && self.self === self;
-}
-
-/**
  * Detect browser extensions (Chrome and Firefox at least).
  */
 interface BrowserRuntime {


### PR DESCRIPTION
We believe `isBrowser` does not care about whether it's a browser environment or not. It simply verifies if "self" is defined. Our inclination is to remove isBrowser() and inline `typeof self !== 'undefined'`.