### PR TITLE
Remove innerHTML call and replace with textContent

### DIFF
--- a/.changeset/pretty-carrots-kneel.md
+++ b/.changeset/pretty-carrots-kneel.md
@@ -1,0 +1,5 @@
+---
+'@firebase/database': patch
+---
+
+Remove innerHTML call and replace it with textContent

--- a/.changeset/pretty-carrots-kneel.md
+++ b/.changeset/pretty-carrots-kneel.md
@@ -2,4 +2,4 @@
 '@firebase/database': patch
 ---
 
-Remove innerHTML call and replace it with textContent
+Replace `innerHTML` call with `textContent`.

--- a/packages/database/src/realtime/BrowserPollConnection.ts
+++ b/packages/database/src/realtime/BrowserPollConnection.ts
@@ -547,7 +547,7 @@ export class FirebaseIFrameScriptHolder {
     if (this.myIFrame) {
       //We have to actually remove all of the html inside this iframe before removing it from the
       //window, or IE will continue loading and executing the script tags we've already added, which
-      //can lead to some errors being thrown. Setting innerText seems to be the safest way to do this.
+      //can lead to some errors being thrown. Setting textContent seems to be the safest way to do this.
       this.myIFrame.doc.body.textContent = '';
       setTimeout(() => {
         if (this.myIFrame !== null) {

--- a/packages/database/src/realtime/BrowserPollConnection.ts
+++ b/packages/database/src/realtime/BrowserPollConnection.ts
@@ -548,7 +548,7 @@ export class FirebaseIFrameScriptHolder {
       //We have to actually remove all of the html inside this iframe before removing it from the
       //window, or IE will continue loading and executing the script tags we've already added, which
       //can lead to some errors being thrown. Setting innerText seems to be the safest way to do this.
-      this.myIFrame.doc.body.innerText = '';
+      this.myIFrame.doc.body.textContent = '';
       setTimeout(() => {
         if (this.myIFrame !== null) {
           document.body.removeChild(this.myIFrame);

--- a/packages/database/src/realtime/BrowserPollConnection.ts
+++ b/packages/database/src/realtime/BrowserPollConnection.ts
@@ -547,7 +547,7 @@ export class FirebaseIFrameScriptHolder {
     if (this.myIFrame) {
       //We have to actually remove all of the html inside this iframe before removing it from the
       //window, or IE will continue loading and executing the script tags we've already added, which
-      //can lead to some errors being thrown. Setting innerHTML seems to be the easiest way to do this.
+      //can lead to some errors being thrown. Setting innerText seems to be the safest way to do this.
       this.myIFrame.doc.body.innerText = '';
       setTimeout(() => {
         if (this.myIFrame !== null) {

--- a/packages/database/src/realtime/BrowserPollConnection.ts
+++ b/packages/database/src/realtime/BrowserPollConnection.ts
@@ -548,11 +548,7 @@ export class FirebaseIFrameScriptHolder {
       //We have to actually remove all of the html inside this iframe before removing it from the
       //window, or IE will continue loading and executing the script tags we've already added, which
       //can lead to some errors being thrown. Setting innerHTML seems to be the easiest way to do this.
-      // TODO() ^ see if there is another way to clear the iframe contents;; can also look at the closure function
-      // look at analytics function that removes the script tag
-      // make sure it can't be just removed entirely
-      // this.myIFrame.doc.body.innerHTML = '';
-      this.myIFrame.doc.write('');
+      this.myIFrame.doc.body.innerText = '';
       setTimeout(() => {
         if (this.myIFrame !== null) {
           document.body.removeChild(this.myIFrame);

--- a/packages/database/src/realtime/BrowserPollConnection.ts
+++ b/packages/database/src/realtime/BrowserPollConnection.ts
@@ -548,7 +548,11 @@ export class FirebaseIFrameScriptHolder {
       //We have to actually remove all of the html inside this iframe before removing it from the
       //window, or IE will continue loading and executing the script tags we've already added, which
       //can lead to some errors being thrown. Setting innerHTML seems to be the easiest way to do this.
-      this.myIFrame.doc.body.innerHTML = '';
+      // TODO() ^ see if there is another way to clear the iframe contents;; can also look at the closure function
+      // look at analytics function that removes the script tag
+      // make sure it can't be just removed entirely
+      // this.myIFrame.doc.body.innerHTML = '';
+      this.myIFrame.doc.write('');
       setTimeout(() => {
         if (this.myIFrame !== null) {
           document.body.removeChild(this.myIFrame);


### PR DESCRIPTION
Replacing innerHTML call with textContent. This is considered to be best practice and the safest option 