### PR TITLE
Replace deprecated set-output commands

### DIFF
--- a/.github/workflows/merge-release-branch.yml
+++ b/.github/workflows/merge-release-branch.yml
@@ -18,7 +18,7 @@ jobs:
         run: |
           export VERSION_SCRIPT="const pkg = require('./packages/firebase/package.json'); console.log(pkg.version);"
           export VERSION=`node -e "${VERSION_SCRIPT}"`
-          echo "::set-output name=RELEASE_VERSION::$VERSION"
+          echo "RELEASE_VERSION=$VERSION" >> $GITHUB_OUTPUT
       - name: Echo version in shell
         run: |
           echo "Merging release ${{ steps.get-version.outputs.RELEASE_VERSION }}"

--- a/.github/workflows/release-prod.yml
+++ b/.github/workflows/release-prod.yml
@@ -95,7 +95,7 @@ jobs:
       run: |
         VERSION_SCRIPT="const pkg = require('./packages/firebase/package.json'); console.log(pkg.version);"
         VERSION=`node -e "${VERSION_SCRIPT}"`
-        echo "::set-output name=BASE_VERSION::$VERSION"
+        echo "BASE_VERSION=$VERSION" >> $GITHUB_OUTPUT
     - name: Echo version in shell
       run: |
         echo "Base version: ${{ steps.get-version.outputs.BASE_VERSION }}"

--- a/.github/workflows/release-staging.yml
+++ b/.github/workflows/release-staging.yml
@@ -114,9 +114,9 @@ jobs:
       run: |
         VERSION_SCRIPT="const pkg = require('./packages/firebase/package.json'); console.log(pkg.version);"
         VERSION=`node -e "${VERSION_SCRIPT}"`
-        echo "::set-output name=STAGING_VERSION::$VERSION"
+        echo "STAGING_VERSION=$VERSION" >> $GITHUB_OUTPUT
         BASE_VERSION=$(echo $VERSION | cut -d "-" -f 1)
-        echo "::set-output name=BASE_VERSION::$BASE_VERSION"
+        echo "BASE_VERSION=$BASE_VERSION" >> $GITHUB_OUTPUT
     - name: Echo versions in shell
       run: |
         echo "Staging release ${{ steps.get-version.outputs.STAGING_VERSION }}"

--- a/scripts/ci/check_changeset.ts
+++ b/scripts/ci/check_changeset.ts
@@ -124,11 +124,11 @@ async function main() {
   const errors = [];
   try {
     await exec(`yarn changeset status`);
-    console.log(`::set-output name=BLOCKING_FAILURE::false`);
+    console.log(`"BLOCKING_FAILURE=false" >> $GITHUB_STATE`);
   } catch (e) {
     const error = e as Error;
     if (error.message.match('No changesets present')) {
-      console.log(`::set-output name=BLOCKING_FAILURE::false`);
+      console.log(`"BLOCKING_FAILURE=false" >> $GITHUB_STATE`);
     } else {
       const messageLines = error.message.replace(/🦋  error /g, '').split('\n');
       let formattedStatusError =
@@ -149,7 +149,7 @@ async function main() {
        * step. See:
        * https://github.com/actions/toolkit/blob/master/docs/commands.md#set-outputs
        */
-      console.log(`::set-output name=BLOCKING_FAILURE::true`);
+      console.log(`"BLOCKING_FAILURE=true" >> $GITHUB_STATE`);
     }
   }
 
@@ -183,15 +183,15 @@ async function main() {
         if (changesetPackages['firebase'] == null) {
           errors.push(
             `- Package ${bumpPackage} has a ${bumpText} bump which requires an ` +
-              `additional line to bump the main "firebase" package to ${bumpText}.`
+            `additional line to bump the main "firebase" package to ${bumpText}.`
           );
-          console.log(`::set-output name=BLOCKING_FAILURE::true`);
+          console.log(`"BLOCKING_FAILURE=true" >> $GITHUB_STATE`);
         } else if (bumpRank[changesetPackages['firebase']] < highestBump) {
           errors.push(
             `- Package ${bumpPackage} has a ${bumpText} bump. ` +
-              `Increase the bump for the main "firebase" package to ${bumpText}.`
+            `Increase the bump for the main "firebase" package to ${bumpText}.`
           );
-          console.log(`::set-output name=BLOCKING_FAILURE::true`);
+          console.log(`"BLOCKING_FAILURE=true" >> $GITHUB_STATE`);
         }
       }
     }
@@ -206,9 +206,7 @@ async function main() {
    * https://github.com/actions/toolkit/blob/master/docs/commands.md#set-outputs
    */
   if (errors.length > 0)
-    console.log(
-      `::set-output name=CHANGESET_ERROR_MESSAGE::${errors.join('%0A')}`
-    );
+    console.log(`"CHANGESET_ERROR_MESSAGE=${errors.join('%0A')}" >> $GITHUB_STATE`);
   process.exit();
 }
 

--- a/scripts/ci/check_changeset.ts
+++ b/scripts/ci/check_changeset.ts
@@ -183,13 +183,13 @@ async function main() {
         if (changesetPackages['firebase'] == null) {
           errors.push(
             `- Package ${bumpPackage} has a ${bumpText} bump which requires an ` +
-            `additional line to bump the main "firebase" package to ${bumpText}.`
+              `additional line to bump the main "firebase" package to ${bumpText}.`
           );
           console.log(`"BLOCKING_FAILURE=true" >> $GITHUB_STATE`);
         } else if (bumpRank[changesetPackages['firebase']] < highestBump) {
           errors.push(
             `- Package ${bumpPackage} has a ${bumpText} bump. ` +
-            `Increase the bump for the main "firebase" package to ${bumpText}.`
+              `Increase the bump for the main "firebase" package to ${bumpText}.`
           );
           console.log(`"BLOCKING_FAILURE=true" >> $GITHUB_STATE`);
         }
@@ -206,7 +206,9 @@ async function main() {
    * https://github.com/actions/toolkit/blob/master/docs/commands.md#set-outputs
    */
   if (errors.length > 0)
-    console.log(`"CHANGESET_ERROR_MESSAGE=${errors.join('%0A')}" >> $GITHUB_STATE`);
+    console.log(
+      `"CHANGESET_ERROR_MESSAGE=${errors.join('%0A')}" >> $GITHUB_STATE`
+    );
   process.exit();
 }
 

--- a/scripts/ci/detect-doc-changes.ts
+++ b/scripts/ci/detect-doc-changes.ts
@@ -83,9 +83,9 @@ async function runInCI() {
   }
 
   if (await docChanged(mergeBaseSha, headSha)) {
-    console.log(`::set-output name=DOC_CHANGED::true`);
+    console.log(`"DOC_CHANGED=true" >> $GITHUB_STATE`);
   } else {
-    console.log(`::set-output name=DOC_CHANGED::false`);
+    console.log(`"DOC_CHANGED=false" >> $GITHUB_STATE`);
   }
 }
 


### PR DESCRIPTION
The `set-output` command for Github Actions has been deprecated and should be replaced with writing to `$GITHUB_OUTPUT` as described here: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

This will get rid of warnings in Github workflow logs.