### PR TITLE
Remove peer deps from auth-interop-types

### DIFF
--- a/.changeset/heavy-mirrors-drum.md
+++ b/.changeset/heavy-mirrors-drum.md
@@ -1,0 +1,5 @@
+---
+'@firebase/auth-interop-types': patch
+---
+
+Remove unused peerDependencies.

--- a/packages/auth-interop-types/package.json
+++ b/packages/auth-interop-types/package.json
@@ -11,10 +11,6 @@
   "files": [
     "index.d.ts"
   ],
-  "peerDependencies": {
-    "@firebase/app-types": "0.x",
-    "@firebase/util": "1.x"
-  },
   "repository": {
     "directory": "packages/auth-types",
     "type": "git",


### PR DESCRIPTION
`auth-interop-types` doesn't have any dependencies or imports and it's likely the `peerDependencies` only appears in its package.json because of a copy-paste mistake when the package was created.

Likely causing warnings as described in `firebase-admin`: https://github.com/firebase/firebase-admin-node/issues/973