### PR TITLE
Firestore: missing generics for `doc`, `collection`, `collectionGroup`, and `withConverter`

### DIFF
--- a/common/api-review/firestore-lite.api.md
+++ b/common/api-review/firestore-lite.api.md
@@ -66,16 +66,16 @@ export class Bytes {
 export type ChildUpdateFields<K extends string, V> = V extends Record<string, unknown> ? AddPrefixToKeys<K, UpdateData<V>> : never;
 
 // @public
-export function collection(firestore: Firestore, path: string, ...pathSegments: string[]): CollectionReference<DocumentData>;
+export function collection<T = DocumentData>(firestore: Firestore, path: string, ...pathSegments: string[]): CollectionReference<T>;
 
 // @public
-export function collection(reference: CollectionReference<unknown>, path: string, ...pathSegments: string[]): CollectionReference<DocumentData>;
+export function collection<T = DocumentData>(reference: CollectionReference<unknown>, path: string, ...pathSegments: string[]): CollectionReference<T>;
 
 // @public
-export function collection(reference: DocumentReference, path: string, ...pathSegments: string[]): CollectionReference<DocumentData>;
+export function collection<T = DocumentData>(reference: DocumentReference, path: string, ...pathSegments: string[]): CollectionReference<T>;
 
 // @public
-export function collectionGroup(firestore: Firestore, collectionId: string): Query<DocumentData>;
+export function collectionGroup<T = DocumentData>(firestore: Firestore, collectionId: string): Query<T>;
 
 // @public
 export class CollectionReference<T = DocumentData> extends Query<T> {
@@ -84,7 +84,7 @@ export class CollectionReference<T = DocumentData> extends Query<T> {
     get path(): string;
     readonly type = "collection";
     withConverter<U>(converter: FirestoreDataConverter<U>): CollectionReference<U>;
-    withConverter(converter: null): CollectionReference<DocumentData>;
+    withConverter<U = DocumentData>(converter: null): CollectionReference<U>;
 }
 
 // @public
@@ -99,13 +99,13 @@ export function deleteDoc(reference: DocumentReference<unknown>): Promise<void>;
 export function deleteField(): FieldValue;
 
 // @public
-export function doc(firestore: Firestore, path: string, ...pathSegments: string[]): DocumentReference<DocumentData>;
+export function doc<T = DocumentData>(firestore: Firestore, path: string, ...pathSegments: string[]): DocumentReference<T>;
 
 // @public
 export function doc<T>(reference: CollectionReference<T>, path?: string, ...pathSegments: string[]): DocumentReference<T>;
 
 // @public
-export function doc(reference: DocumentReference<unknown>, path: string, ...pathSegments: string[]): DocumentReference<DocumentData>;
+export function doc<T = DocumentData>(reference: DocumentReference<unknown>, path: string, ...pathSegments: string[]): DocumentReference<T>;
 
 // @public
 export interface DocumentData {
@@ -124,7 +124,7 @@ export class DocumentReference<T = DocumentData> {
     get path(): string;
     readonly type = "document";
     withConverter<U>(converter: FirestoreDataConverter<U>): DocumentReference<U>;
-    withConverter(converter: null): DocumentReference<DocumentData>;
+    withConverter<U>(converter: null): DocumentReference<U>;
 }
 
 // @public
@@ -254,7 +254,7 @@ export class Query<T = DocumentData> {
     readonly converter: FirestoreDataConverter<T> | null;
     readonly firestore: Firestore;
     readonly type: 'query' | 'collection';
-    withConverter(converter: null): Query<DocumentData>;
+    withConverter<U = DocumentData>(converter: null): Query<U>;
     withConverter<U>(converter: FirestoreDataConverter<U>): Query<U>;
 }
 

--- a/common/api-review/firestore.api.md
+++ b/common/api-review/firestore.api.md
@@ -72,16 +72,16 @@ export type ChildUpdateFields<K extends string, V> = V extends Record<string, un
 export function clearIndexedDbPersistence(firestore: Firestore): Promise<void>;
 
 // @public
-export function collection(firestore: Firestore, path: string, ...pathSegments: string[]): CollectionReference<DocumentData>;
+export function collection<T = DocumentData>(firestore: Firestore, path: string, ...pathSegments: string[]): CollectionReference<T>;
 
 // @public
-export function collection(reference: CollectionReference<unknown>, path: string, ...pathSegments: string[]): CollectionReference<DocumentData>;
+export function collection<T = DocumentData>(reference: CollectionReference<unknown>, path: string, ...pathSegments: string[]): CollectionReference<T>;
 
 // @public
-export function collection(reference: DocumentReference, path: string, ...pathSegments: string[]): CollectionReference<DocumentData>;
+export function collection<T = DocumentData>(reference: DocumentReference, path: string, ...pathSegments: string[]): CollectionReference<T>;
 
 // @public
-export function collectionGroup(firestore: Firestore, collectionId: string): Query<DocumentData>;
+export function collectionGroup<T = DocumentData>(firestore: Firestore, collectionId: string): Query<T>;
 
 // @public
 export class CollectionReference<T = DocumentData> extends Query<T> {
@@ -90,7 +90,7 @@ export class CollectionReference<T = DocumentData> extends Query<T> {
     get path(): string;
     readonly type = "collection";
     withConverter<U>(converter: FirestoreDataConverter<U>): CollectionReference<U>;
-    withConverter(converter: null): CollectionReference<DocumentData>;
+    withConverter<U = DocumentData>(converter: null): CollectionReference<U>;
 }
 
 // @public
@@ -108,13 +108,13 @@ export function deleteField(): FieldValue;
 export function disableNetwork(firestore: Firestore): Promise<void>;
 
 // @public
-export function doc(firestore: Firestore, path: string, ...pathSegments: string[]): DocumentReference<DocumentData>;
+export function doc<T = DocumentData>(firestore: Firestore, path: string, ...pathSegments: string[]): DocumentReference<T>;
 
 // @public
 export function doc<T>(reference: CollectionReference<T>, path?: string, ...pathSegments: string[]): DocumentReference<T>;
 
 // @public
-export function doc(reference: DocumentReference<unknown>, path: string, ...pathSegments: string[]): DocumentReference<DocumentData>;
+export function doc<T = DocumentData>(reference: DocumentReference<unknown>, path: string, ...pathSegments: string[]): DocumentReference<T>;
 
 // @public
 export interface DocumentChange<T = DocumentData> {
@@ -144,7 +144,7 @@ export class DocumentReference<T = DocumentData> {
     get path(): string;
     readonly type = "document";
     withConverter<U>(converter: FirestoreDataConverter<U>): DocumentReference<U>;
-    withConverter(converter: null): DocumentReference<DocumentData>;
+    withConverter<U>(converter: null): DocumentReference<U>;
 }
 
 // @public
@@ -407,7 +407,7 @@ export class Query<T = DocumentData> {
     readonly converter: FirestoreDataConverter<T> | null;
     readonly firestore: Firestore;
     readonly type: 'query' | 'collection';
-    withConverter(converter: null): Query<DocumentData>;
+    withConverter<U = DocumentData>(converter: null): Query<U>;
     withConverter<U>(converter: FirestoreDataConverter<U>): Query<U>;
 }
 

--- a/packages/firestore/src/lite-api/reference.ts
+++ b/packages/firestore/src/lite-api/reference.ts
@@ -182,7 +182,7 @@ export class DocumentReference<T = DocumentData> {
    * @param converter - `null` removes the current converter.
    * @returns A `DocumentReference<DocumentData>` that does not use a converter.
    */
-  withConverter(converter: null): DocumentReference<DocumentData>;
+  withConverter<U>(converter: null): DocumentReference<U>;
   withConverter<U>(
     converter: FirestoreDataConverter<U> | null
   ): DocumentReference<U> {
@@ -222,9 +222,9 @@ export class Query<T = DocumentData> {
    * Removes the current converter.
    *
    * @param converter - `null` removes the current converter.
-   * @returns A `Query<DocumentData>` that does not use a converter.
+   * @returns A `Query<U>` that does not use a converter.
    */
-  withConverter(converter: null): Query<DocumentData>;
+  withConverter<U = DocumentData>(converter: null): Query<U>;
   /**
    * Applies a custom data converter to this query, allowing you to use your own
    * custom model objects with Firestore. When you call {@link getDocs} with
@@ -303,10 +303,10 @@ export class CollectionReference<T = DocumentData> extends Query<T> {
    * Removes the current converter.
    *
    * @param converter - `null` removes the current converter.
-   * @returns A `CollectionReference<DocumentData>` that does not use a
+   * @returns A `CollectionReference<U>` that does not use a
    * converter.
    */
-  withConverter(converter: null): CollectionReference<DocumentData>;
+  withConverter<U = DocumentData>(converter: null): CollectionReference<U>;
   withConverter<U>(
     converter: FirestoreDataConverter<U> | null
   ): CollectionReference<U> {
@@ -326,11 +326,11 @@ export class CollectionReference<T = DocumentData> extends Query<T> {
  * to a collection.
  * @returns The `CollectionReference` instance.
  */
-export function collection(
+export function collection<T = DocumentData>(
   firestore: Firestore,
   path: string,
   ...pathSegments: string[]
-): CollectionReference<DocumentData>;
+): CollectionReference<T>;
 /**
  * Gets a `CollectionReference` instance that refers to a subcollection of
  * `reference` at the the specified relative path.
@@ -343,11 +343,11 @@ export function collection(
  * to a collection.
  * @returns The `CollectionReference` instance.
  */
-export function collection(
+export function collection<T = DocumentData>(
   reference: CollectionReference<unknown>,
   path: string,
   ...pathSegments: string[]
-): CollectionReference<DocumentData>;
+): CollectionReference<T>;
 /**
  * Gets a `CollectionReference` instance that refers to a subcollection of
  * `reference` at the the specified relative path.
@@ -360,16 +360,16 @@ export function collection(
  * to a collection.
  * @returns The `CollectionReference` instance.
  */
-export function collection(
+export function collection<T = DocumentData>(
   reference: DocumentReference,
   path: string,
   ...pathSegments: string[]
-): CollectionReference<DocumentData>;
-export function collection(
+): CollectionReference<T>;
+export function collection<T = DocumentData>(
   parent: Firestore | DocumentReference<unknown> | CollectionReference<unknown>,
   path: string,
   ...pathSegments: string[]
-): CollectionReference<DocumentData> {
+): CollectionReference<T> {
   parent = getModularInstance(parent);
 
   validateNonEmptyArgument('collection', 'path', path);
@@ -414,10 +414,10 @@ export function collection(
  * will be included. Cannot contain a slash.
  * @returns The created `Query`.
  */
-export function collectionGroup(
+export function collectionGroup<T = DocumentData>(
   firestore: Firestore,
   collectionId: string
-): Query<DocumentData> {
+): Query<T> {
   firestore = cast(firestore, Firestore);
 
   validateNonEmptyArgument('collectionGroup', 'collection id', collectionId);
@@ -448,11 +448,11 @@ export function collectionGroup(
  * a document.
  * @returns The `DocumentReference` instance.
  */
-export function doc(
+export function doc<T = DocumentData>(
   firestore: Firestore,
   path: string,
   ...pathSegments: string[]
-): DocumentReference<DocumentData>;
+): DocumentReference<T>;
 /**
  * Gets a `DocumentReference` instance that refers to a document within
  * `reference` at the specified relative path. If no path is specified, an
@@ -485,11 +485,11 @@ export function doc<T>(
  * a document.
  * @returns The `DocumentReference` instance.
  */
-export function doc(
+export function doc<T = DocumentData>(
   reference: DocumentReference<unknown>,
   path: string,
   ...pathSegments: string[]
-): DocumentReference<DocumentData>;
+): DocumentReference<T>;
 export function doc<T>(
   parent: Firestore | CollectionReference<T> | DocumentReference<unknown>,
   path?: string,


### PR DESCRIPTION
### Discussion

#6961

### Testing

Only type changes. I am not super familiar with this repo. Are you doing automated type-tests?

I manually tested the following cases:


```typescript
// Type 'CollectionReference<DocumentData>' is not assignable to type 'CollectionReference<Country>
const collRef: CollectionReference<Country> = collection(firestore, 'countries');
// Type 'CollectionReference<DocumentData>' is not assignable to type 'CollectionReference<Country>
const collRef2: CollectionReference<Country> = collection(firestore, 'countries').withConverter(null);
// Type 'CollectionReference<DocumentData>' is not assignable to type 'CollectionReference<City>
const collRef3: CollectionReference<City> = collection(collRef, 'germany', 'cities');

// Type 'DocumentReference<DocumentData>' is not assignable to type 'DocumentReference<Country>
const docRef: DocumentReference<Country> = doc(firestore, "countries",  "germany");
// Type 'DocumentReference<DocumentData>' is not assignable to type 'DocumentReference<Country>
const docRef2: DocumentReference<Country> = docRef.withConverter(null);
// Type 'DocumentReference<DocumentData>' is not assignable to type 'DocumentReference<City>
const docRef3: DocumentReference<Country> = doc(docRef2, 'cities', 'berlin');

// Type 'Query<DocumentData>' is not assignable to type 'Query<City>
const query: Query<City> = collectionGroup(firestore, "cities");
```

Also, an internal code base of mine compiles with these new types

### API Changes

The public API changes. It should not be breaking because it only adds new generics. It doesn't remove existing functionality.