### PR TITLE
Add App Check token to Auth requests

### DIFF
--- a/.changeset/brave-ducks-relax.md
+++ b/.changeset/brave-ducks-relax.md
@@ -1,0 +1,6 @@
+---
+'@firebase/auth': minor
+'@firebase/auth-compat': minor
+---
+
+App Check <> Auth integration

--- a/packages/auth-compat/src/auth.test.ts
+++ b/packages/auth-compat/src/auth.test.ts
@@ -24,7 +24,10 @@ import sinonChai from 'sinon-chai';
 import { Auth } from './auth';
 import { CompatPopupRedirectResolver } from './popup_redirect';
 import * as platform from './platform';
-import { FAKE_HEARTBEAT_CONTROLLER_PROVIDER } from '../test/helpers/helpers';
+import {
+  FAKE_APP_CHECK_CONTROLLER_PROVIDER,
+  FAKE_HEARTBEAT_CONTROLLER_PROVIDER
+} from '../test/helpers/helpers';
 
 use(sinonChai);
 
@@ -45,6 +48,7 @@ describe('auth compat', () => {
       underlyingAuth = new exp.AuthImpl(
         app,
         FAKE_HEARTBEAT_CONTROLLER_PROVIDER,
+        FAKE_APP_CHECK_CONTROLLER_PROVIDER,
         {
           apiKey: 'api-key'
         } as exp.ConfigInternal

--- a/packages/auth-compat/src/popup_redirect.test.ts
+++ b/packages/auth-compat/src/popup_redirect.test.ts
@@ -22,7 +22,10 @@ import * as exp from '@firebase/auth/internal';
 import * as platform from './platform';
 import { CompatPopupRedirectResolver } from './popup_redirect';
 import { FirebaseApp } from '@firebase/app-compat';
-import { FAKE_HEARTBEAT_CONTROLLER_PROVIDER } from '../test/helpers/helpers';
+import {
+  FAKE_APP_CHECK_CONTROLLER_PROVIDER,
+  FAKE_HEARTBEAT_CONTROLLER_PROVIDER
+} from '../test/helpers/helpers';
 
 use(sinonChai);
 
@@ -42,9 +45,14 @@ describe('popup_redirect/CompatPopupRedirectResolver', () => {
   beforeEach(() => {
     compatResolver = new CompatPopupRedirectResolver();
     const app = { options: { apiKey: 'api-key' } } as FirebaseApp;
-    auth = new exp.AuthImpl(app, FAKE_HEARTBEAT_CONTROLLER_PROVIDER, {
-      apiKey: 'api-key'
-    } as exp.ConfigInternal);
+    auth = new exp.AuthImpl(
+      app,
+      FAKE_HEARTBEAT_CONTROLLER_PROVIDER,
+      FAKE_APP_CHECK_CONTROLLER_PROVIDER,
+      {
+        apiKey: 'api-key'
+      } as exp.ConfigInternal
+    );
   });
 
   afterEach(() => {

--- a/packages/auth-compat/test/helpers/helpers.ts
+++ b/packages/auth-compat/test/helpers/helpers.ts
@@ -34,6 +34,13 @@ export const FAKE_HEARTBEAT_CONTROLLER_PROVIDER = {
   }
 } as unknown as Provider<'heartbeat'>;
 
+// App Check is fully tested in core auth impl
+export const FAKE_APP_CHECK_CONTROLLER_PROVIDER = {
+  getImmediate(): undefined {
+    return undefined;
+  }
+} as unknown as Provider<'app-check-internal'>;
+
 export function initializeTestInstance(): void {
   firebase.initializeApp(getAppConfig());
   const stub = stubConsoleToSilenceEmulatorWarnings();

--- a/packages/auth/src/api/index.ts
+++ b/packages/auth/src/api/index.ts
@@ -42,7 +42,8 @@ export const enum HttpHeader {
   X_FIREBASE_LOCALE = 'X-Firebase-Locale',
   X_CLIENT_VERSION = 'X-Client-Version',
   X_FIREBASE_GMPID = 'X-Firebase-gmpid',
-  X_FIREBASE_CLIENT = 'X-Firebase-Client'
+  X_FIREBASE_CLIENT = 'X-Firebase-Client',
+  X_FIREBASE_APP_CHECK = 'X-Firebase-AppCheck'
 }
 
 export const enum Endpoint {

--- a/packages/auth/src/core/auth/auth_impl.ts
+++ b/packages/auth/src/core/auth/auth_impl.ts
@@ -63,6 +63,7 @@ import { _getUserLanguage } from '../util/navigator';
 import { _getClientVersion } from '../util/version';
 import { HttpHeader } from '../../api';
 import { AuthMiddlewareQueue } from './middleware';
+import { _logWarn } from '../util/log';
 
 interface AsyncAction {
   (): Promise<void>;
@@ -650,11 +651,6 @@ export class AuthImpl implements AuthInternal, _FirebaseService {
 
     // If the App Check service exists, add the App Check token in the headers
     const appCheckToken = await this._getAppCheckToken();
-    // TODO: What do we want to do if there is an error getting the token?
-    // Context: appCheck.getToken() will never throw even if an error happened.
-    // In the error case, a dummy token will be returned along with an error field describing
-    // the error. In general, we shouldn't care about the error condition and just use
-    // the token (actual or dummy) to send requests.
     if (appCheckToken) {
       headers[HttpHeader.X_FIREBASE_APP_CHECK] = appCheckToken;
     }
@@ -665,6 +661,15 @@ export class AuthImpl implements AuthInternal, _FirebaseService {
     const appCheckTokenResult = await this.appCheckServiceProvider
       .getImmediate({ optional: true })
       ?.getToken();
+    if (appCheckTokenResult?.error) {
+      // Context: appCheck.getToken() will never throw even if an error happened.
+      // In the error case, a dummy token will be returned along with an error field describing
+      // the error. In general, we shouldn't care about the error condition and just use
+      // the token (actual or dummy) to send requests.
+      _logWarn(
+        `Error while retrieving App Check token: ${appCheckTokenResult.error}`
+      );
+    }
     return appCheckTokenResult?.token;
   }
 }

--- a/packages/auth/src/core/auth/auth_impl.ts
+++ b/packages/auth/src/core/auth/auth_impl.ts
@@ -649,19 +649,23 @@ export class AuthImpl implements AuthInternal, _FirebaseService {
     }
 
     // If the App Check service exists, add the App Check token in the headers
-    const appCheckTokenResult = await this.appCheckServiceProvider
-      .getImmediate({ optional: true })
-      ?.getToken();
+    const appCheckToken = await this._getAppCheckToken();
     // TODO: What do we want to do if there is an error getting the token?
     // Context: appCheck.getToken() will never throw even if an error happened.
     // In the error case, a dummy token will be returned along with an error field describing
     // the error. In general, we shouldn't care about the error condition and just use
     // the token (actual or dummy) to send requests.
-    if (appCheckTokenResult?.token) {
-      headers[HttpHeader.X_FIREBASE_APP_CHECK] = appCheckTokenResult.token;
+    if (appCheckToken) {
+      headers[HttpHeader.X_FIREBASE_APP_CHECK] = appCheckToken;
     }
 
     return headers;
+  }
+  async _getAppCheckToken(): Promise<string | undefined> {
+    const appCheckTokenResult = await this.appCheckServiceProvider
+      .getImmediate({ optional: true })
+      ?.getToken();
+    return appCheckTokenResult?.token;
   }
 }
 

--- a/packages/auth/src/core/auth/register.ts
+++ b/packages/auth/src/core/auth/register.ts
@@ -63,36 +63,38 @@ export function registerAuth(clientPlatform: ClientPlatform): void {
         const app = container.getProvider('app').getImmediate()!;
         const heartbeatServiceProvider =
           container.getProvider<'heartbeat'>('heartbeat');
+        const appCheckServiceProvider =
+          container.getProvider<'app-check-internal'>('app-check-internal');
         const { apiKey, authDomain } = app.options;
-        return ((app, heartbeatServiceProvider) => {
-          _assert(
-            apiKey && !apiKey.includes(':'),
-            AuthErrorCode.INVALID_API_KEY,
-            { appName: app.name }
-          );
-          // Auth domain is optional if IdP sign in isn't being used
-          _assert(!authDomain?.includes(':'), AuthErrorCode.ARGUMENT_ERROR, {
-            appName: app.name
-          });
-          const config: ConfigInternal = {
-            apiKey,
-            authDomain,
-            clientPlatform,
-            apiHost: DefaultConfig.API_HOST,
-            tokenApiHost: DefaultConfig.TOKEN_API_HOST,
-            apiScheme: DefaultConfig.API_SCHEME,
-            sdkClientVersion: _getClientVersion(clientPlatform)
-          };
 
-          const authInstance = new AuthImpl(
-            app,
-            heartbeatServiceProvider,
-            config
-          );
-          _initializeAuthInstance(authInstance, deps);
+        _assert(
+          apiKey && !apiKey.includes(':'),
+          AuthErrorCode.INVALID_API_KEY,
+          { appName: app.name }
+        );
+        // Auth domain is optional if IdP sign in isn't being used
+        _assert(!authDomain?.includes(':'), AuthErrorCode.ARGUMENT_ERROR, {
+          appName: app.name
+        });
+        const config: ConfigInternal = {
+          apiKey,
+          authDomain,
+          clientPlatform,
+          apiHost: DefaultConfig.API_HOST,
+          tokenApiHost: DefaultConfig.TOKEN_API_HOST,
+          apiScheme: DefaultConfig.API_SCHEME,
+          sdkClientVersion: _getClientVersion(clientPlatform)
+        };
 
-          return authInstance;
-        })(app, heartbeatServiceProvider);
+        const authInstance = new AuthImpl(
+          app,
+          heartbeatServiceProvider,
+          appCheckServiceProvider,
+          config
+        );
+        _initializeAuthInstance(authInstance, deps);
+
+        return authInstance;
       },
       ComponentType.PUBLIC
     )

--- a/packages/auth/src/core/util/handler.ts
+++ b/packages/auth/src/core/util/handler.ts
@@ -40,6 +40,13 @@ const WIDGET_PATH = '__/auth/handler';
  */
 const EMULATOR_WIDGET_PATH = 'emulator/auth/handler';
 
+/**
+ * Fragment name for the App Check token that gets passed to the widget
+ *
+ * @internal
+ */
+const FIREBASE_APP_CHECK_FRAGMENT_ID = 'fac';
+
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 type WidgetParams = {
   apiKey: ApiKey;
@@ -54,14 +61,14 @@ type WidgetParams = {
   tid?: string;
 } & { [key: string]: string | undefined };
 
-export function _getRedirectUrl(
+export async function _getRedirectUrl(
   auth: AuthInternal,
   provider: AuthProvider,
   authType: AuthEventType,
   redirectUrl?: string,
   eventId?: string,
   additionalParams?: Record<string, string>
-): string {
+): Promise<string> {
   _assert(auth.config.authDomain, auth, AuthErrorCode.MISSING_AUTH_DOMAIN);
   _assert(auth.config.apiKey, auth, AuthErrorCode.INVALID_API_KEY);
 
@@ -107,7 +114,18 @@ export function _getRedirectUrl(
       delete paramsDict[key];
     }
   }
-  return `${getHandlerBase(auth)}?${querystring(paramsDict).slice(1)}`;
+
+  // Sets the App Check token to pass to the widget
+  const appCheckToken = await auth._getAppCheckToken();
+  const appCheckTokenFragment = appCheckToken
+    ? encodeURIComponent(FIREBASE_APP_CHECK_FRAGMENT_ID) +
+      '=' +
+      encodeURIComponent(appCheckToken)
+    : '';
+
+  return `${getHandlerBase(auth)}?${querystring(paramsDict).slice(
+    1
+  )}#${appCheckTokenFragment}`;
 }
 
 function getHandlerBase({ config }: AuthInternal): string {

--- a/packages/auth/src/core/util/handler.ts
+++ b/packages/auth/src/core/util/handler.ts
@@ -121,6 +121,7 @@ export async function _getRedirectUrl(
     ? `${FIREBASE_APP_CHECK_FRAGMENT_ID}=${encodeURIComponent(appCheckToken)}`
     : '';
 
+  // Start at index 1 to skip the leading '&' in the query string
   return `${getHandlerBase(auth)}?${querystring(paramsDict).slice(
     1
   )}#${appCheckTokenFragment}`;

--- a/packages/auth/src/core/util/handler.ts
+++ b/packages/auth/src/core/util/handler.ts
@@ -45,7 +45,7 @@ const EMULATOR_WIDGET_PATH = 'emulator/auth/handler';
  *
  * @internal
  */
-const FIREBASE_APP_CHECK_FRAGMENT_ID = 'fac';
+const FIREBASE_APP_CHECK_FRAGMENT_ID = encodeURIComponent('fac');
 
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 type WidgetParams = {
@@ -118,9 +118,7 @@ export async function _getRedirectUrl(
   // Sets the App Check token to pass to the widget
   const appCheckToken = await auth._getAppCheckToken();
   const appCheckTokenFragment = appCheckToken
-    ? encodeURIComponent(FIREBASE_APP_CHECK_FRAGMENT_ID) +
-      '=' +
-      encodeURIComponent(appCheckToken)
+    ? `${FIREBASE_APP_CHECK_FRAGMENT_ID}=${encodeURIComponent(appCheckToken)}`
     : '';
 
   return `${getHandlerBase(auth)}?${querystring(paramsDict).slice(

--- a/packages/auth/src/core/util/handler.ts
+++ b/packages/auth/src/core/util/handler.ts
@@ -120,11 +120,12 @@ export async function _getRedirectUrl(
   const appCheckTokenFragment = appCheckToken
     ? `${FIREBASE_APP_CHECK_FRAGMENT_ID}=${encodeURIComponent(appCheckToken)}`
     : '';
+  const fragment = appCheckTokenFragment ? `#${appCheckTokenFragment}` : '';
 
   // Start at index 1 to skip the leading '&' in the query string
   return `${getHandlerBase(auth)}?${querystring(paramsDict).slice(
     1
-  )}#${appCheckTokenFragment}`;
+  )}${fragment}`;
 }
 
 function getHandlerBase({ config }: AuthInternal): string {

--- a/packages/auth/src/core/util/log.ts
+++ b/packages/auth/src/core/util/log.ts
@@ -37,6 +37,12 @@ export function _logDebug(msg: string, ...args: string[]): void {
   }
 }
 
+export function _logWarn(msg: string, ...args: string[]): void {
+  if (logClient.logLevel <= LogLevel.WARN) {
+    logClient.warn(`Auth (${SDK_VERSION}): ${msg}`, ...args);
+  }
+}
+
 export function _logError(msg: string, ...args: string[]): void {
   if (logClient.logLevel <= LogLevel.ERROR) {
     logClient.error(`Auth (${SDK_VERSION}): ${msg}`, ...args);

--- a/packages/auth/src/model/auth.ts
+++ b/packages/auth/src/model/auth.ts
@@ -82,6 +82,7 @@ export interface AuthInternal extends Auth {
   _logFramework(framework: string): void;
   _getFrameworks(): readonly string[];
   _getAdditionalHeaders(): Promise<Record<string, string>>;
+  _getAppCheckToken(): Promise<string | undefined>;
 
   readonly name: AppName;
   readonly config: ConfigInternal;

--- a/packages/auth/src/platform_browser/auth.test.ts
+++ b/packages/auth/src/platform_browser/auth.test.ts
@@ -29,6 +29,7 @@ import {
 import { OperationType } from '../model/enums';
 
 import {
+  FAKE_APP_CHECK_CONTROLLER_PROVIDER,
   FAKE_HEARTBEAT_CONTROLLER_PROVIDER,
   testAuth,
   testUser
@@ -73,6 +74,7 @@ describe('core/auth/auth_impl', () => {
     const authImpl = new AuthImpl(
       FAKE_APP,
       FAKE_HEARTBEAT_CONTROLLER_PROVIDER,
+      FAKE_APP_CHECK_CONTROLLER_PROVIDER,
       {
         apiKey: FAKE_APP.options.apiKey!,
         apiHost: DefaultConfig.API_HOST,
@@ -141,15 +143,20 @@ describe('core/auth/initializeAuth', () => {
       authDomain = FAKE_APP.options.authDomain,
       blockMiddleware = false
     ): Promise<Auth> {
-      const auth = new AuthImpl(FAKE_APP, FAKE_HEARTBEAT_CONTROLLER_PROVIDER, {
-        apiKey: FAKE_APP.options.apiKey!,
-        apiHost: DefaultConfig.API_HOST,
-        apiScheme: DefaultConfig.API_SCHEME,
-        tokenApiHost: DefaultConfig.TOKEN_API_HOST,
-        authDomain,
-        clientPlatform: ClientPlatform.BROWSER,
-        sdkClientVersion: _getClientVersion(ClientPlatform.BROWSER)
-      });
+      const auth = new AuthImpl(
+        FAKE_APP,
+        FAKE_HEARTBEAT_CONTROLLER_PROVIDER,
+        FAKE_APP_CHECK_CONTROLLER_PROVIDER,
+        {
+          apiKey: FAKE_APP.options.apiKey!,
+          apiHost: DefaultConfig.API_HOST,
+          apiScheme: DefaultConfig.API_SCHEME,
+          tokenApiHost: DefaultConfig.TOKEN_API_HOST,
+          authDomain,
+          clientPlatform: ClientPlatform.BROWSER,
+          sdkClientVersion: _getClientVersion(ClientPlatform.BROWSER)
+        }
+      );
 
       _initializeAuthInstance(auth, {
         persistence,
@@ -378,6 +385,7 @@ describe('core/auth/initializeAuth', () => {
         const auth = new AuthImpl(
           FAKE_APP,
           FAKE_HEARTBEAT_CONTROLLER_PROVIDER,
+          FAKE_APP_CHECK_CONTROLLER_PROVIDER,
           {
             apiKey: FAKE_APP.options.apiKey!,
             apiHost: DefaultConfig.API_HOST,

--- a/packages/auth/src/platform_browser/popup_redirect.test.ts
+++ b/packages/auth/src/platform_browser/popup_redirect.test.ts
@@ -30,7 +30,8 @@ import {
   TEST_AUTH_DOMAIN,
   TEST_KEY,
   testAuth,
-  TestAuth
+  TestAuth,
+  FAKE_APP_CHECK_CONTROLLER
 } from '../../test/helpers/mock_auth';
 import { AuthEventManager } from '../core/auth/auth_event_manager';
 import { OAuthProvider } from '../core/providers/oauth';
@@ -125,6 +126,48 @@ describe('platform_browser/popup_redirect', () => {
       );
     });
 
+    it('includes the App Check token in the url fragment if present', async () => {
+      await resolver._initialize(auth);
+      sinon
+        .stub(FAKE_APP_CHECK_CONTROLLER, 'getToken')
+        .returns(Promise.resolve({ token: 'fake-token' }));
+
+      await resolver._openPopup(auth, provider, event);
+
+      const matches = (popupUrl as string).match(/.*?#(.*)/);
+      expect(matches).not.to.be.null;
+      const fragment = matches![1];
+      expect(fragment).to.include('fac=fake-token');
+    });
+
+    it('does not add the App Check token in the url fragment if none returned', async () => {
+      await resolver._initialize(auth);
+      sinon
+        .stub(FAKE_APP_CHECK_CONTROLLER, 'getToken')
+        .returns(Promise.resolve({ token: '' }));
+
+      await resolver._openPopup(auth, provider, event);
+
+      const matches = (popupUrl as string).match(/.*?#(.*)/);
+      expect(matches).not.to.be.null;
+      const fragment = matches![1];
+      expect(fragment).not.to.include('fac');
+    });
+
+    it('does not add the App Check token in the url fragment if controller unavailable', async () => {
+      await resolver._initialize(auth);
+      sinon
+        .stub(FAKE_APP_CHECK_CONTROLLER, 'getToken')
+        .returns(undefined as any);
+
+      await resolver._openPopup(auth, provider, event);
+
+      const matches = (popupUrl as string).match(/.*?#(.*)/);
+      expect(matches).not.to.be.null;
+      const fragment = matches![1];
+      expect(fragment).not.to.include('fac');
+    });
+
     it('throws an error if apiKey is unspecified', async () => {
       delete (auth.config as Partial<Config>).apiKey;
       await resolver._initialize(auth);
@@ -157,8 +200,10 @@ describe('platform_browser/popup_redirect', () => {
       // eslint-disable-next-line @typescript-eslint/no-floating-promises
       resolver._openRedirect(auth, provider, event);
 
-      // Delay one tick
-      await Promise.resolve();
+      // Wait a bit so the _openRedirect() call completes
+      await new Promise((resolve): void => {
+        setTimeout(resolve, 100);
+      });
 
       expect(newWindowLocation).to.include(
         `https://${TEST_AUTH_DOMAIN}/__/auth/handler`
@@ -175,6 +220,66 @@ describe('platform_browser/popup_redirect', () => {
       expect(newWindowLocation).to.include(
         'customParameters=%7B%22foo%22%3A%22bar%22%7D'
       );
+    });
+
+    it('includes the App Check token in the url fragment if present', async () => {
+      sinon
+        .stub(FAKE_APP_CHECK_CONTROLLER, 'getToken')
+        .returns(Promise.resolve({ token: 'fake-token' }));
+
+      // This promise will never resolve on purpose
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
+      resolver._openRedirect(auth, provider, event);
+
+      // Wait a bit so the _openRedirect() call completes
+      await new Promise((resolve): void => {
+        setTimeout(resolve, 100);
+      });
+
+      const matches = newWindowLocation.match(/.*?#(.*)/);
+      expect(matches).not.to.be.null;
+      const fragment = matches![1];
+      expect(fragment).to.include('fac=fake-token');
+    });
+
+    it('does not add the App Check token in the url fragment if none returned', async () => {
+      sinon
+        .stub(FAKE_APP_CHECK_CONTROLLER, 'getToken')
+        .returns(Promise.resolve({ token: '' }));
+
+      // This promise will never resolve on purpose
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
+      resolver._openRedirect(auth, provider, event);
+
+      // Wait a bit so the _openRedirect() call completes
+      await new Promise((resolve): void => {
+        setTimeout(resolve, 100);
+      });
+
+      const matches = newWindowLocation.match(/.*?#(.*)/);
+      expect(matches).not.to.be.null;
+      const fragment = matches![1];
+      expect(fragment).not.to.include('fac');
+    });
+
+    it('does not add the App Check token in the url fragment if controller unavailable', async () => {
+      sinon
+        .stub(FAKE_APP_CHECK_CONTROLLER, 'getToken')
+        .returns(undefined as any);
+
+      // This promise will never resolve on purpose
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
+      resolver._openRedirect(auth, provider, event);
+
+      // Wait a bit so the _openRedirect() call completes
+      await new Promise((resolve): void => {
+        setTimeout(resolve, 100);
+      });
+
+      const matches = newWindowLocation.match(/.*?#(.*)/);
+      expect(matches).not.to.be.null;
+      const fragment = matches![1];
+      expect(fragment).not.to.include('fac');
     });
 
     it('throws an error if authDomain is unspecified', async () => {

--- a/packages/auth/src/platform_browser/popup_redirect.test.ts
+++ b/packages/auth/src/platform_browser/popup_redirect.test.ts
@@ -151,7 +151,7 @@ describe('platform_browser/popup_redirect', () => {
       const matches = (popupUrl as string).match(/.*?#(.*)/);
       expect(matches).not.to.be.null;
       const fragment = matches![1];
-      expect(fragment).not.to.include('fac');
+      expect(fragment).to.be.empty;
     });
 
     it('does not add the App Check token in the url fragment if controller unavailable', async () => {
@@ -165,7 +165,7 @@ describe('platform_browser/popup_redirect', () => {
       const matches = (popupUrl as string).match(/.*?#(.*)/);
       expect(matches).not.to.be.null;
       const fragment = matches![1];
-      expect(fragment).not.to.include('fac');
+      expect(fragment).to.be.empty;
     });
 
     it('throws an error if apiKey is unspecified', async () => {
@@ -259,7 +259,7 @@ describe('platform_browser/popup_redirect', () => {
       const matches = newWindowLocation.match(/.*?#(.*)/);
       expect(matches).not.to.be.null;
       const fragment = matches![1];
-      expect(fragment).not.to.include('fac');
+      expect(fragment).to.be.empty;
     });
 
     it('does not add the App Check token in the url fragment if controller unavailable', async () => {
@@ -279,7 +279,7 @@ describe('platform_browser/popup_redirect', () => {
       const matches = newWindowLocation.match(/.*?#(.*)/);
       expect(matches).not.to.be.null;
       const fragment = matches![1];
-      expect(fragment).not.to.include('fac');
+      expect(fragment).to.be.empty;
     });
 
     it('throws an error if authDomain is unspecified', async () => {

--- a/packages/auth/src/platform_browser/popup_redirect.test.ts
+++ b/packages/auth/src/platform_browser/popup_redirect.test.ts
@@ -150,9 +150,9 @@ describe('platform_browser/popup_redirect', () => {
       await resolver._openPopup(auth, provider, event);
 
       const matches = (popupUrl as string).match(/.*?#(.*)/);
-      expect(matches).not.to.be.null;
-      const fragment = matches![1];
-      expect(fragment).to.be.empty;
+      // The '#' character will not be included when the url fragment is not attached,
+      // so the url will not match the pattern
+      expect(matches).to.be.null;
     });
 
     it('does not add the App Check token in the url fragment if controller unavailable', async () => {
@@ -164,9 +164,9 @@ describe('platform_browser/popup_redirect', () => {
       await resolver._openPopup(auth, provider, event);
 
       const matches = (popupUrl as string).match(/.*?#(.*)/);
-      expect(matches).not.to.be.null;
-      const fragment = matches![1];
-      expect(fragment).to.be.empty;
+      // The '#' character will not be included when the url fragment is not attached,
+      // so the url will not match the pattern
+      expect(matches).to.be.null;
     });
 
     it('throws an error if apiKey is unspecified', async () => {
@@ -259,9 +259,9 @@ describe('platform_browser/popup_redirect', () => {
       });
 
       const matches = newWindowLocation.match(/.*?#(.*)/);
-      expect(matches).not.to.be.null;
-      const fragment = matches![1];
-      expect(fragment).to.be.empty;
+      // The '#' character will not be included when the url fragment is not attached,
+      // so the url will not match the pattern
+      expect(matches).to.be.null;
     });
 
     it('does not add the App Check token in the url fragment if controller unavailable', async () => {
@@ -279,9 +279,9 @@ describe('platform_browser/popup_redirect', () => {
       });
 
       const matches = newWindowLocation.match(/.*?#(.*)/);
-      expect(matches).not.to.be.null;
-      const fragment = matches![1];
-      expect(fragment).to.be.empty;
+      // The '#' character will not be included when the url fragment is not attached,
+      // so the url will not match the pattern
+      expect(matches).to.be.null;
     });
 
     it('throws an error if authDomain is unspecified', async () => {

--- a/packages/auth/src/platform_browser/popup_redirect.test.ts
+++ b/packages/auth/src/platform_browser/popup_redirect.test.ts
@@ -142,6 +142,7 @@ describe('platform_browser/popup_redirect', () => {
 
     it('does not add the App Check token in the url fragment if none returned', async () => {
       await resolver._initialize(auth);
+      // Redundant, already set in mock_auth.ts but adding here for clarity
       sinon
         .stub(FAKE_APP_CHECK_CONTROLLER, 'getToken')
         .returns(Promise.resolve({ token: '' }));
@@ -243,6 +244,7 @@ describe('platform_browser/popup_redirect', () => {
     });
 
     it('does not add the App Check token in the url fragment if none returned', async () => {
+      // Redundant, already set in mock_auth.ts but adding here for clarity
       sinon
         .stub(FAKE_APP_CHECK_CONTROLLER, 'getToken')
         .returns(Promise.resolve({ token: '' }));

--- a/packages/auth/src/platform_browser/popup_redirect.ts
+++ b/packages/auth/src/platform_browser/popup_redirect.ts
@@ -75,7 +75,7 @@ class BrowserPopupRedirectResolver implements PopupRedirectResolverInternal {
       '_initialize() not called before _openPopup()'
     );
 
-    const url = _getRedirectUrl(
+    const url = await _getRedirectUrl(
       auth,
       provider,
       authType,
@@ -92,9 +92,14 @@ class BrowserPopupRedirectResolver implements PopupRedirectResolverInternal {
     eventId?: string
   ): Promise<never> {
     await this._originValidation(auth);
-    _setWindowLocation(
-      _getRedirectUrl(auth, provider, authType, _getCurrentUrl(), eventId)
+    const url = await _getRedirectUrl(
+      auth,
+      provider,
+      authType,
+      _getCurrentUrl(),
+      eventId
     );
+    _setWindowLocation(url);
     return new Promise(() => {});
   }
 

--- a/packages/auth/test/helpers/mock_auth.ts
+++ b/packages/auth/test/helpers/mock_auth.ts
@@ -17,6 +17,7 @@
 
 import { FirebaseApp } from '@firebase/app';
 import { Provider } from '@firebase/component';
+import { AppCheckTokenResult } from '@firebase/app-check-interop-types';
 import { PopupRedirectResolver } from '../../src/model/public_types';
 import { debugErrorMap } from '../../src';
 
@@ -55,6 +56,19 @@ export const FAKE_HEARTBEAT_CONTROLLER_PROVIDER: Provider<'heartbeat'> = {
   }
 } as unknown as Provider<'heartbeat'>;
 
+export const FAKE_APP_CHECK_CONTROLLER = {
+  getToken: async () => {
+    return { token: '' } as AppCheckTokenResult;
+  }
+};
+
+export const FAKE_APP_CHECK_CONTROLLER_PROVIDER: Provider<'app-check-internal'> =
+  {
+    getImmediate(): typeof FAKE_APP_CHECK_CONTROLLER {
+      return FAKE_APP_CHECK_CONTROLLER;
+    }
+  } as unknown as Provider<'app-check-internal'>;
+
 export class MockPersistenceLayer extends InMemoryPersistence {
   lastObjectSet: PersistedBlob | null = null;
 
@@ -77,6 +91,7 @@ export async function testAuth(
   const auth: TestAuth = new AuthImpl(
     FAKE_APP,
     FAKE_HEARTBEAT_CONTROLLER_PROVIDER,
+    FAKE_APP_CHECK_CONTROLLER_PROVIDER,
     {
       apiKey: TEST_KEY,
       authDomain: TEST_AUTH_DOMAIN,


### PR DESCRIPTION
### Discussion

Includes App Check token in Auth header requests to backend, if present. Passes App Check token to widget via the URL fragment

As part of [go/auth-app-check-sdk](http://go/auth-app-check-sdk)
Internal bug link: [b/265453815](http://b/265453815)

### Testing

`yarn test` passes in `packages/auth` and `packages/auth-compat`

### API Changes

N/A
