### PR TITLE
Remove namespaced gapi; replace with interfaces

### DIFF
--- a/packages/auth/src/model/popup_redirect.ts
+++ b/packages/auth/src/model/popup_redirect.ts
@@ -27,6 +27,7 @@ import { FirebaseError } from '@firebase/util';
 import { AuthPopup } from '../platform_browser/util/popup';
 import { AuthInternal } from './auth';
 import { UserCredentialInternal } from './user';
+import { GapiMessage } from '../platform_browser/iframe/gapi.iframes';
 
 export const enum EventFilter {
   POPUP,
@@ -38,7 +39,7 @@ export const enum GapiOutcome {
   ERROR = 'ERROR'
 }
 
-export interface GapiAuthEvent extends gapi.iframes.Message {
+export interface GapiAuthEvent extends GapiMessage {
   authEvent: AuthEvent;
 }
 

--- a/packages/auth/src/platform_browser/auth_window.ts
+++ b/packages/auth/src/platform_browser/auth_window.ts
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+import { Gapi } from './iframe/gapi.iframes';
 import { Recaptcha } from './recaptcha/recaptcha';
 
 /**
@@ -30,7 +31,7 @@ export type AuthWindow = {
   grecaptcha?: Recaptcha;
   /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
   ___jsl?: Record<string, any>;
-  gapi?: typeof gapi;
+  gapi?: Gapi;
 } & {
   // A final catch-all for callbacks (which will have random names) that
   // we will stick on the window.

--- a/packages/auth/src/platform_browser/iframe/gapi.iframes.ts
+++ b/packages/auth/src/platform_browser/iframe/gapi.iframes.ts
@@ -15,63 +15,67 @@
  * limitations under the License.
  */
 
-// For some reason, the linter doesn't recognize that these are used elsewhere
-// in the SDK
-/* eslint-disable @typescript-eslint/no-unused-vars */
+interface LoadCallback {
+  (): void;
+}
+interface LoadOptions {
+  callback?: LoadCallback;
+  timeout?: number;
+  ontimeout?: LoadCallback;
+}
 
-declare namespace gapi {
-  type LoadCallback = () => void;
-  interface LoadConfig {}
-  interface LoadOptions {
-    callback?: LoadCallback;
-    timeout?: number;
-    ontimeout?: LoadCallback;
-  }
-  function load(
+export interface GapiMessage {
+  type: string;
+}
+
+interface IframesFilter {
+  (iframe: GapiIframe): boolean;
+}
+interface MessageHandler<T extends GapiMessage> {
+  (message: T): unknown | Promise<void>;
+}
+interface SendCallback {
+  (): void;
+}
+interface Callback {
+  (iframe: GapiIframe): void;
+}
+
+export interface GapiContext {
+  open(
+    options: Record<string, unknown>,
+    callback?: Callback
+  ): Promise<GapiIframe>;
+}
+
+export interface GapiIframe {
+  register<T extends GapiMessage>(
+    message: string,
+    handler: MessageHandler<T>,
+    filter?: IframesFilter
+  ): void;
+  send<T extends GapiMessage, U extends GapiMessage>(
+    type: string,
+    data: T,
+    callback?: MessageHandler<U>,
+    filter?: IframesFilter
+  ): void;
+  ping(callback: SendCallback, data?: unknown): Promise<unknown[]>;
+  restyle(
+    style: Record<string, string | boolean>,
+    callback?: SendCallback
+  ): Promise<unknown[]>;
+}
+
+export interface Gapi {
+  load(
     features: 'gapi.iframes',
     options?: LoadOptions | LoadCallback
   ): void;
-}
 
-declare namespace gapi.iframes {
-  interface Message {
-    type: string;
-  }
-
-  type IframesFilter = (iframe: Iframe) => boolean;
-  type MessageHandler<T extends Message> = (
-    message: T
-  ) => unknown | Promise<void>;
-  type SendCallback = () => void;
-  type Callback = (iframe: Iframe) => void;
-
-  class Context {
-    open(
-      options: Record<string, unknown>,
-      callback?: Callback
-    ): Promise<Iframe>;
-  }
-
-  class Iframe {
-    register<T extends Message>(
-      message: string,
-      handler: MessageHandler<T>,
-      filter?: IframesFilter
-    ): void;
-    send<T extends Message, U extends Message>(
-      type: string,
-      data: T,
-      callback?: MessageHandler<U>,
-      filter?: IframesFilter
-    ): void;
-    ping(callback: SendCallback, data?: unknown): Promise<unknown[]>;
-    restyle(
-      style: Record<string, string | boolean>,
-      callback?: SendCallback
-    ): Promise<unknown[]>;
-  }
-
-  const CROSS_ORIGIN_IFRAMES_FILTER: IframesFilter;
-
-  function getContext(): Context;
+  iframes?: {
+    CROSS_ORIGIN_IFRAMES_FILTER: IframesFilter;
+    getContext(): GapiContext;
+    Iframe?: GapiIframe;
+  };
 }

--- a/packages/auth/src/platform_browser/iframe/gapi.test.ts
+++ b/packages/auth/src/platform_browser/iframe/gapi.test.ts
@@ -26,16 +26,17 @@ import { testAuth, TestAuth } from '../../../test/helpers/mock_auth';
 import { _window } from '../auth_window';
 import * as js from '../load_js';
 import { _loadGapi, _resetLoader } from './gapi';
+import { Gapi, GapiContext } from './gapi.iframes';
 
 use(sinonChai);
 use(chaiAsPromised);
 
 describe('platform_browser/iframe/gapi', () => {
-  let library: typeof gapi;
+  let library: Gapi;
   let auth: TestAuth;
   let loadJsStub: sinon.SinonStub;
   function onJsLoad(globalLoadFnName: string): void {
-    _window().gapi = library as typeof gapi;
+    _window().gapi = library as Gapi;
     _window()[globalLoadFnName]();
   }
 
@@ -48,7 +49,7 @@ describe('platform_browser/iframe/gapi', () => {
     auth = await testAuth();
   });
 
-  function makeGapi(result: unknown, timesout = false): typeof gapi {
+  function makeGapi(result: unknown, timesout = false): Gapi {
     const callbackFn = timesout === false ? 'callback' : 'ontimeout';
     return {
       load: sinon
@@ -57,9 +58,9 @@ describe('platform_browser/iframe/gapi', () => {
           params[callbackFn]()
         ),
       iframes: {
-        getContext: () => result as gapi.iframes.Context
+        getContext: () => result as GapiContext,
       }
-    } as unknown as typeof gapi;
+    } as unknown as Gapi;
   }
 
   afterEach(() => {
@@ -111,7 +112,7 @@ describe('platform_browser/iframe/gapi', () => {
   });
 
   it('rejects with a network error if load fails', async () => {
-    library = {} as typeof gapi;
+    library = {} as Gapi;
     await expect(_loadGapi(auth)).to.be.rejectedWith(
       FirebaseError,
       'auth/network-request-failed'
@@ -127,7 +128,7 @@ describe('platform_browser/iframe/gapi', () => {
   });
 
   it('resets the load promise if the load errors', async () => {
-    library = {} as typeof gapi;
+    library = {} as Gapi;
     const firstAttempt = _loadGapi(auth);
     await expect(firstAttempt).to.be.rejectedWith(
       FirebaseError,

--- a/packages/auth/src/platform_browser/iframe/iframe.test.ts
+++ b/packages/auth/src/platform_browser/iframe/iframe.test.ts
@@ -33,6 +33,7 @@ import { stubSingleTimeout } from '../../../test/helpers/timeout_stub';
 import { _window } from '../auth_window';
 import * as gapiLoader from './gapi';
 import { _openIframe } from './iframe';
+import { Gapi, GapiContext, GapiIframe } from './gapi.iframes';
 
 use(sinonChai);
 use(chaiAsPromised);
@@ -49,7 +50,7 @@ describe('platform_browser/iframe/iframe', () => {
       iframes: {
         CROSS_ORIGIN_IFRAMES_FILTER: 'cross-origin-filter'
       }
-    } as unknown as typeof gapi;
+    } as unknown as Gapi;
     auth = await testAuth();
 
     sinon.stub(gapiLoader, '_loadGapi').returns(
@@ -62,7 +63,7 @@ describe('platform_browser/iframe/iframe', () => {
               libraryLoadedCallback = cb;
             }
           )
-      }) as unknown as Promise<gapi.iframes.Context>
+      }) as unknown as Promise<GapiContext>
     );
   });
 
@@ -111,14 +112,14 @@ describe('platform_browser/iframe/iframe', () => {
   });
 
   context('on load callback', () => {
-    let iframe: sinon.SinonStubbedInstance<gapi.iframes.Iframe>;
+    let iframe: sinon.SinonStubbedInstance<GapiIframe>;
     let clearTimeoutStub: sinon.SinonStub;
 
     beforeEach(() => {
       iframe = sinon.stub({
         restyle: () => {},
         ping: () => {}
-      } as unknown as gapi.iframes.Iframe);
+      } as unknown as GapiIframe);
       clearTimeoutStub = sinon.stub(_window(), 'clearTimeout');
     });
 

--- a/packages/auth/src/platform_browser/iframe/iframe.ts
+++ b/packages/auth/src/platform_browser/iframe/iframe.ts
@@ -26,6 +26,7 @@ import { _emulatorUrl } from '../../core/util/emulator';
 import { AuthInternal } from '../../model/auth';
 import { _window } from '../auth_window';
 import * as gapiLoader from './gapi';
+import { GapiIframe } from './gapi.iframes';
 
 const PING_TIMEOUT = new Delay(5000, 15000);
 const IFRAME_PATH = '__/auth/iframe';
@@ -75,10 +76,10 @@ function getIframeUrl(auth: AuthInternal): string {
 
 export async function _openIframe(
   auth: AuthInternal
-): Promise<gapi.iframes.Iframe> {
+): Promise<GapiIframe> {
   const context = await gapiLoader._loadGapi(auth);
   const gapi = _window().gapi;
-  _assert(gapi, auth, AuthErrorCode.INTERNAL_ERROR);
+  _assert(gapi?.iframes, auth, AuthErrorCode.INTERNAL_ERROR);
   return context.open(
     {
       where: document.body,
@@ -87,7 +88,7 @@ export async function _openIframe(
       attributes: IFRAME_ATTRIBUTES,
       dontclear: true
     },
-    (iframe: gapi.iframes.Iframe) =>
+    (iframe: GapiIframe) =>
       new Promise(async (resolve, reject) => {
         await iframe.restyle({
           // Prevent iframe from closing on mouse out.


### PR DESCRIPTION
Fixes https://github.com/firebase/firebase-js-sdk/issues/6960

This change totally removes the "namespace" definitions (which are so often messy in TS; we did this before we knew better). Instead gapi is now defined as a series of interfaces, with a method to pull it from the window object as a global variable.

This PR makes use of `!` assertions a lot. It's always safe when used because it's in contexts where gapi is definitely alredy loaded. In places where it's not obvious, I've left a comment.