### PR TITLE
Fix exports fields

### DIFF
--- a/.changeset/stupid-otters-speak.md
+++ b/.changeset/stupid-otters-speak.md
@@ -1,0 +1,17 @@
+---
+'@firebase/auth': patch
+'@firebase/auth-compat': patch
+'@firebase/database': patch
+'@firebase/database-compat': patch
+'firebase': patch
+'@firebase/firestore': patch
+'@firebase/firestore-compat': patch
+'@firebase/functions': patch
+'@firebase/functions-compat': patch
+'@firebase/rules-unit-testing': patch
+'@firebase/storage': patch
+'@firebase/template': patch
+'@firebase/util': patch
+---
+
+Move exports.default fields to always be the last field. This fixes a bug caused in 9.17.0 that prevented some bundlers and frameworks from building.

--- a/packages/auth-compat/package.json
+++ b/packages/auth-compat/package.json
@@ -16,11 +16,11 @@
         "require": "./dist/index.node.cjs.js"
       },
       "esm5": "./dist/index.esm.js",
-      "default": "./dist/index.esm2017.js",
       "browser": {
         "require": "./dist/index.cjs.js",
         "import": "./dist/index.esm2017.js"
-      }
+      },
+      "default": "./dist/index.esm2017.js"
     },
     "./package.json": "./package.json"
   },

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -31,11 +31,11 @@
         "default": "./dist/index.webworker.esm5.js"
       },
       "esm5": "./dist/esm5/index.js",
-      "default": "./dist/esm2017/index.js",
       "browser": {
         "require": "./dist/browser-cjs/index.js",
         "import": "./dist/esm2017/index.js"
-      }
+      },
+      "default": "./dist/esm2017/index.js"
     },
     "./cordova": {
       "types": "./dist/cordova/index.cordova.d.ts",
@@ -61,11 +61,11 @@
         "default": "./dist/cordova/internal.js"
       },
       "esm5": "./dist/esm5/internal.js",
-      "default": "./dist/esm2017/internal.js",
       "browser": {
         "require": "./dist/browser-cjs/internal.js",
         "import": "./dist/esm2017/internal.js"
-      }
+      },
+      "default": "./dist/esm2017/internal.js"
     },
     "./package.json": "./package.json"
   },

--- a/packages/database-compat/package.json
+++ b/packages/database-compat/package.json
@@ -22,11 +22,11 @@
         "require": "./dist/index.js"
       },
       "esm5": "./dist/index.esm5.js",
-      "default": "./dist/index.esm2017.js",
       "browser": {
         "require": "./dist/index.js",
         "import": "./dist/index.esm2017.js"
-      }
+      },
+      "default": "./dist/index.esm2017.js"
     },
     "./standalone": {
       "types": "./dist/database-compat/src/index.standalone.d.ts",

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -17,11 +17,11 @@
       },
       "esm5": "./dist/index.esm5.js",
       "standalone": "./dist/index.standalone.js",
-      "default": "./dist/index.esm2017.js",
       "browser": {
         "require": "./dist/index.cjs.js",
         "import": "./dist/index.esm2017.js"
-      }
+      },
+      "default": "./dist/index.esm2017.js"
     },
     "./package.json": "./package.json"
   },

--- a/packages/firebase/package.json
+++ b/packages/firebase/package.json
@@ -29,11 +29,11 @@
         "require": "./analytics/dist/index.cjs.js",
         "import": "./analytics/dist/index.mjs"
       },
-      "default": "./analytics/dist/esm/index.esm.js",
       "browser": {
         "require": "./analytics/dist/index.cjs.js",
         "import": "./analytics/dist/esm/index.esm.js"
-      }
+      },
+      "default": "./analytics/dist/esm/index.esm.js"
     },
     "./app": {
       "types": "./app/dist/app/index.d.ts",
@@ -41,11 +41,11 @@
         "require": "./app/dist/index.cjs.js",
         "import": "./app/dist/index.mjs"
       },
-      "default": "./app/dist/esm/index.esm.js",
       "browser": {
         "require": "./app/dist/index.cjs.js",
         "import": "./app/dist/esm/index.esm.js"
-      }
+      },
+      "default": "./app/dist/esm/index.esm.js"
     },
     "./app-check": {
       "types": "./app-check/dist/app-check/index.d.ts",
@@ -53,11 +53,11 @@
         "require": "./app-check/dist/index.cjs.js",
         "import": "./app-check/dist/index.mjs"
       },
-      "default": "./app-check/dist/esm/index.esm.js",
       "browser": {
         "require": "./app-check/dist/index.cjs.js",
         "import": "./app-check/dist/esm/index.esm.js"
-      }
+      },
+      "default": "./app-check/dist/esm/index.esm.js"
     },
     "./auth": {
       "types": "./auth/dist/auth/index.d.ts",
@@ -65,11 +65,11 @@
         "require": "./auth/dist/index.cjs.js",
         "import": "./auth/dist/index.mjs"
       },
-      "default": "./auth/dist/esm/index.esm.js",
       "browser": {
         "require": "./auth/dist/index.cjs.js",
         "import": "./auth/dist/esm/index.esm.js"
-      }
+      },
+      "default": "./auth/dist/esm/index.esm.js"
     },
     "./auth/cordova": {
       "types": "./auth/cordova/dist/auth/cordova/index.d.ts",
@@ -77,11 +77,11 @@
         "require": "./auth/cordova/dist/index.cjs.js",
         "import": "./auth/cordova/dist/index.mjs"
       },
-      "default": "./auth/cordova/dist/esm/index.esm.js",
       "browser": {
         "require": "./auth/cordova/dist/index.cjs.js",
         "import": "./auth/cordova/dist/esm/index.esm.js"
-      }
+      },
+      "default": "./auth/cordova/dist/esm/index.esm.js"
     },
     "./auth/react-native": {
       "types": "./auth/react-native/dist/auth/react-native/index.d.ts",
@@ -89,11 +89,11 @@
         "require": "./auth/react-native/dist/index.cjs.js",
         "import": "./auth/react-native/dist/index.mjs"
       },
-      "default": "./auth/react-native/dist/esm/index.esm.js",
       "browser": {
         "require": "./auth/react-native/dist/index.cjs.js",
         "import": "./auth/react-native/dist/esm/index.esm.js"
-      }
+      },
+      "default": "./auth/react-native/dist/esm/index.esm.js"
     },
     "./database": {
       "types": "./database/dist/database/index.d.ts",
@@ -101,11 +101,11 @@
         "require": "./database/dist/index.cjs.js",
         "import": "./database/dist/index.mjs"
       },
-      "default": "./database/dist/esm/index.esm.js",
       "browser": {
         "require": "./database/dist/index.cjs.js",
         "import": "./database/dist/esm/index.esm.js"
-      }
+      },
+      "default": "./database/dist/esm/index.esm.js"
     },
     "./firestore": {
       "types": "./firestore/dist/firestore/index.d.ts",
@@ -113,11 +113,11 @@
         "require": "./firestore/dist/index.cjs.js",
         "import": "./firestore/dist/index.mjs"
       },
-      "default": "./firestore/dist/esm/index.esm.js",
       "browser": {
         "require": "./firestore/dist/index.cjs.js",
         "import": "./firestore/dist/esm/index.esm.js"
-      }
+      },
+      "default": "./firestore/dist/esm/index.esm.js"
     },
     "./firestore/lite": {
       "types": "./firestore/lite/dist/firestore/lite/index.d.ts",
@@ -125,11 +125,11 @@
         "require": "./firestore/lite/dist/index.cjs.js",
         "import": "./firestore/lite/dist/index.mjs"
       },
-      "default": "./firestore/lite/dist/esm/index.esm.js",
       "browser": {
         "require": "./firestore/lite/dist/index.cjs.js",
         "import": "./firestore/lite/dist/esm/index.esm.js"
-      }
+      },
+      "default": "./firestore/lite/dist/esm/index.esm.js"
     },
     "./functions": {
       "types": "./functions/dist/functions/index.d.ts",
@@ -137,11 +137,11 @@
         "require": "./functions/dist/index.cjs.js",
         "import": "./functions/dist/index.mjs"
       },
-      "default": "./functions/dist/esm/index.esm.js",
       "browser": {
         "require": "./functions/dist/index.cjs.js",
         "import": "./functions/dist/esm/index.esm.js"
-      }
+      },
+      "default": "./functions/dist/esm/index.esm.js"
     },
     "./installations": {
       "types": "./installations/dist/installations/index.d.ts",
@@ -149,11 +149,11 @@
         "require": "./installations/dist/index.cjs.js",
         "import": "./installations/dist/index.mjs"
       },
-      "default": "./installations/dist/esm/index.esm.js",
       "browser": {
         "require": "./installations/dist/index.cjs.js",
         "import": "./installations/dist/esm/index.esm.js"
-      }
+      },
+      "default": "./installations/dist/esm/index.esm.js"
     },
     "./messaging": {
       "types": "./messaging/dist/messaging/index.d.ts",
@@ -161,11 +161,11 @@
         "require": "./messaging/dist/index.cjs.js",
         "import": "./messaging/dist/index.mjs"
       },
-      "default": "./messaging/dist/esm/index.esm.js",
       "browser": {
         "require": "./messaging/dist/index.cjs.js",
         "import": "./messaging/dist/esm/index.esm.js"
-      }
+      },
+      "default": "./messaging/dist/esm/index.esm.js"
     },
     "./messaging/sw": {
       "types": "./messaging/sw/dist/messaging/sw/index.d.ts",
@@ -173,11 +173,11 @@
         "require": "./messaging/sw/dist/index.cjs.js",
         "import": "./messaging/sw/dist/index.mjs"
       },
-      "default": "./messaging/sw/dist/esm/index.esm.js",
       "browser": {
         "require": "./messaging/sw/dist/index.cjs.js",
         "import": "./messaging/sw/dist/esm/index.esm.js"
-      }
+      },
+      "default": "./messaging/sw/dist/esm/index.esm.js"
     },
     "./performance": {
       "types": "./performance/dist/performance/index.d.ts",
@@ -185,11 +185,11 @@
         "require": "./performance/dist/index.cjs.js",
         "import": "./performance/dist/index.mjs"
       },
-      "default": "./performance/dist/esm/index.esm.js",
       "browser": {
         "require": "./performance/dist/index.cjs.js",
         "import": "./performance/dist/esm/index.esm.js"
-      }
+      },
+      "default": "./performance/dist/esm/index.esm.js"
     },
     "./remote-config": {
       "types": "./remote-config/dist/remote-config/index.d.ts",
@@ -197,11 +197,11 @@
         "require": "./remote-config/dist/index.cjs.js",
         "import": "./remote-config/dist/index.mjs"
       },
-      "default": "./remote-config/dist/esm/index.esm.js",
       "browser": {
         "require": "./remote-config/dist/index.cjs.js",
         "import": "./remote-config/dist/esm/index.esm.js"
-      }
+      },
+      "default": "./remote-config/dist/esm/index.esm.js"
     },
     "./storage": {
       "types": "./storage/dist/storage/index.d.ts",
@@ -209,11 +209,11 @@
         "require": "./storage/dist/index.cjs.js",
         "import": "./storage/dist/index.mjs"
       },
-      "default": "./storage/dist/esm/index.esm.js",
       "browser": {
         "require": "./storage/dist/index.cjs.js",
         "import": "./storage/dist/esm/index.esm.js"
-      }
+      },
+      "default": "./storage/dist/esm/index.esm.js"
     },
     "./compat/analytics": {
       "types": "./compat/analytics/dist/compat/analytics/index.d.ts",
@@ -221,11 +221,11 @@
         "require": "./compat/analytics/dist/index.cjs.js",
         "import": "./compat/analytics/dist/index.mjs"
       },
-      "default": "./compat/analytics/dist/esm/index.esm.js",
       "browser": {
         "require": "./compat/analytics/dist/index.cjs.js",
         "import": "./compat/analytics/dist/esm/index.esm.js"
-      }
+      },
+      "default": "./compat/analytics/dist/esm/index.esm.js"
     },
     "./compat/app": {
       "types": "./compat/app/dist/compat/app/index.d.ts",
@@ -233,11 +233,11 @@
         "require": "./compat/app/dist/index.cjs.js",
         "import": "./compat/app/dist/index.mjs"
       },
-      "default": "./compat/app/dist/esm/index.esm.js",
       "browser": {
         "require": "./compat/app/dist/index.cjs.js",
         "import": "./compat/app/dist/esm/index.esm.js"
-      }
+      },
+      "default": "./compat/app/dist/esm/index.esm.js"
     },
     "./compat/app-check": {
       "types": "./compat/app-check/dist/compat/app-check/index.d.ts",
@@ -245,11 +245,11 @@
         "require": "./compat/app-check/dist/index.cjs.js",
         "import": "./compat/app-check/dist/index.mjs"
       },
-      "default": "./compat/app-check/dist/esm/index.esm.js",
       "browser": {
         "require": "./compat/app-check/dist/index.cjs.js",
         "import": "./compat/app-check/dist/esm/index.esm.js"
-      }
+      },
+      "default": "./compat/app-check/dist/esm/index.esm.js"
     },
     "./compat/auth": {
       "types": "./compat/auth/dist/compat/auth/index.d.ts",
@@ -257,11 +257,11 @@
         "require": "./compat/auth/dist/index.cjs.js",
         "import": "./compat/auth/dist/index.mjs"
       },
-      "default": "./compat/auth/dist/esm/index.esm.js",
       "browser": {
         "require": "./compat/auth/dist/index.cjs.js",
         "import": "./compat/auth/dist/esm/index.esm.js"
-      }
+      },
+      "default": "./compat/auth/dist/esm/index.esm.js"
     },
     "./compat/database": {
       "types": "./compat/database/dist/compat/database/index.d.ts",
@@ -269,11 +269,11 @@
         "require": "./compat/database/dist/index.cjs.js",
         "import": "./compat/database/dist/index.mjs"
       },
-      "default": "./compat/database/dist/esm/index.esm.js",
       "browser": {
         "require": "./compat/database/dist/index.cjs.js",
         "import": "./compat/database/dist/esm/index.esm.js"
-      }
+      },
+      "default": "./compat/database/dist/esm/index.esm.js"
     },
     "./compat/firestore": {
       "types": "./compat/firestore/dist/compat/firestore/index.d.ts",
@@ -281,11 +281,11 @@
         "require": "./compat/firestore/dist/index.cjs.js",
         "import": "./compat/firestore/dist/index.mjs"
       },
-      "default": "./compat/firestore/dist/esm/index.esm.js",
       "browser": {
         "require": "./compat/firestore/dist/index.cjs.js",
         "import": "./compat/firestore/dist/esm/index.esm.js"
-      }
+      },
+      "default": "./compat/firestore/dist/esm/index.esm.js"
     },
     "./compat/functions": {
       "types": "./compat/functions/dist/compat/functions/index.d.ts",
@@ -293,11 +293,11 @@
         "require": "./compat/functions/dist/index.cjs.js",
         "import": "./compat/functions/dist/index.mjs"
       },
-      "default": "./compat/functions/dist/esm/index.esm.js",
       "browser": {
         "require": "./compat/functions/dist/index.cjs.js",
         "import": "./compat/functions/dist/esm/index.esm.js"
-      }
+      },
+      "default": "./compat/functions/dist/esm/index.esm.js"
     },
     "./compat/installations": {
       "types": "./compat/installations/dist/compat/installations/index.d.ts",
@@ -305,11 +305,11 @@
         "require": "./compat/installations/dist/index.cjs.js",
         "import": "./compat/installations/dist/index.mjs"
       },
-      "default": "./compat/installations/dist/esm/index.esm.js",
       "browser": {
         "require": "./compat/installations/dist/index.cjs.js",
         "import": "./compat/installations/dist/esm/index.esm.js"
-      }
+      },
+      "default": "./compat/installations/dist/esm/index.esm.js"
     },
     "./compat/messaging": {
       "types": "./compat/messaging/dist/compat/messaging/index.d.ts",
@@ -317,11 +317,11 @@
         "require": "./compat/messaging/dist/index.cjs.js",
         "import": "./compat/messaging/dist/index.mjs"
       },
-      "default": "./compat/messaging/dist/esm/index.esm.js",
       "browser": {
         "require": "./compat/messaging/dist/index.cjs.js",
         "import": "./compat/messaging/dist/esm/index.esm.js"
-      }
+      },
+      "default": "./compat/messaging/dist/esm/index.esm.js"
     },
     "./compat/performance": {
       "types": "./compat/performance/dist/compat/performance/index.d.ts",
@@ -329,11 +329,11 @@
         "require": "./compat/performance/dist/index.cjs.js",
         "import": "./compat/performance/dist/index.mjs"
       },
-      "default": "./compat/performance/dist/esm/index.esm.js",
       "browser": {
         "require": "./compat/performance/dist/index.cjs.js",
         "import": "./compat/performance/dist/esm/index.esm.js"
-      }
+      },
+      "default": "./compat/performance/dist/esm/index.esm.js"
     },
     "./compat/remote-config": {
       "types": "./compat/remote-config/dist/compat/remote-config/index.d.ts",
@@ -341,11 +341,11 @@
         "require": "./compat/remote-config/dist/index.cjs.js",
         "import": "./compat/remote-config/dist/index.mjs"
       },
-      "default": "./compat/remote-config/dist/esm/index.esm.js",
       "browser": {
         "require": "./compat/remote-config/dist/index.cjs.js",
         "import": "./compat/remote-config/dist/esm/index.esm.js"
-      }
+      },
+      "default": "./compat/remote-config/dist/esm/index.esm.js"
     },
     "./compat/storage": {
       "types": "./compat/storage/dist/compat/storage/index.d.ts",
@@ -353,11 +353,11 @@
         "require": "./compat/storage/dist/index.cjs.js",
         "import": "./compat/storage/dist/index.mjs"
       },
-      "default": "./compat/storage/dist/esm/index.esm.js",
       "browser": {
         "require": "./compat/storage/dist/index.cjs.js",
         "import": "./compat/storage/dist/esm/index.esm.js"
-      }
+      },
+      "default": "./compat/storage/dist/esm/index.esm.js"
     },
     "./package.json": "./package.json"
   },

--- a/packages/firestore-compat/package.json
+++ b/packages/firestore-compat/package.json
@@ -17,11 +17,11 @@
       },
       "react-native": "./dist/index.rn.js",
       "esm5": "./dist/index.esm5.js",
-      "default": "./dist/index.esm2017.js",
       "browser": {
         "require": "./dist/index.cjs.js",
         "import": "./dist/index.esm2017.js"
-      }
+      },
+      "default": "./dist/index.esm2017.js"
     },
     "./package.json": "./package.json"
   },

--- a/packages/firestore/package.json
+++ b/packages/firestore/package.json
@@ -56,11 +56,11 @@
       },
       "react-native": "./dist/index.rn.js",
       "esm5": "./dist/index.esm5.js",
-      "default": "./dist/index.esm2017.js",
       "browser": {
         "require": "./dist/index.cjs.js",
         "import": "./dist/index.esm2017.js"
-      }
+      },
+      "default": "./dist/index.esm2017.js"
     },
     "./lite": {
       "types": "./dist/lite/index.d.ts",
@@ -70,11 +70,11 @@
       },
       "react-native": "./dist/lite/index.rn.esm2017.js",
       "esm5": "./dist/lite/index.browser.esm5.js",
-      "default": "./dist/lite/index.browser.esm2017.js",
       "browser": {
         "require": "./dist/lite/index.cjs.js",
         "import": "./dist/lite/index.browser.esm2017.js"
-      }
+      },
+      "default": "./dist/lite/index.browser.esm2017.js"
     },
     "./package.json": "./package.json"
   },

--- a/packages/functions-compat/package.json
+++ b/packages/functions-compat/package.json
@@ -15,11 +15,11 @@
         "require": "./dist/index.node.cjs.js"
       },
       "esm5": "./dist/index.esm5.js",
-      "default": "./dist/index.esm2017.js",
       "browser": {
         "require": "./dist/index.cjs.js",
         "import": "./dist/index.esm2017.js"
-      }
+      },
+      "default": "./dist/index.esm2017.js"
     },
     "./package.json": "./package.json"
   },

--- a/packages/functions/package.json
+++ b/packages/functions/package.json
@@ -15,11 +15,11 @@
         "require": "./dist/index.node.cjs.js"
       },
       "esm5": "./dist/index.esm.js",
-      "default": "./dist/index.esm2017.js",
       "browser": {
         "require": "./dist/index.cjs.js",
         "import": "./dist/index.esm2017.js"
-      }
+      },
+      "default": "./dist/index.esm2017.js"
     },
     "./package.json": "./package.json"
   },

--- a/packages/rules-unit-testing/package.json
+++ b/packages/rules-unit-testing/package.json
@@ -11,11 +11,11 @@
         "import": "./dist/esm/index.esm.js",
         "require": "./dist/index.cjs.js"
       },
-      "default": "./dist/index.cjs.js",
       "browser": {
         "require": "./dist/index.cjs.js",
         "import": "./dist/esm/index.esm.js"
-      }
+      },
+      "default": "./dist/index.cjs.js"
     },
     "./package.json": "./package.json"
   },

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -15,11 +15,11 @@
         "default": "./dist/index.node.cjs.js"
       },
       "esm5": "./dist/index.esm5.js",
-      "default": "./dist/index.esm2017.js",
       "browser": {
         "require": "./dist/index.cjs.js",
         "import": "./dist/index.esm2017.js"
-      }
+      },
+      "default": "./dist/index.esm2017.js"
     },
     "./package.json": "./package.json"
   },

--- a/packages/template/package.json
+++ b/packages/template/package.json
@@ -16,11 +16,11 @@
         "require": "./dist/index.node.cjs.js"
       },
       "esm5": "./dist/index.esm5.js",
-      "default": "./dist/index.esm2017.js",
       "browser": {
         "require": "./dist/index.cjs.js",
         "import": "./dist/index.esm2017.js"
-      }
+      },
+      "default": "./dist/index.esm2017.js"
     },
     "./package.json": "./package.json"
   },

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -15,11 +15,11 @@
         "require": "./dist/index.node.cjs.js"
       },
       "esm5": "./dist/index.esm5.js",
-      "default": "./dist/index.esm2017.js",
       "browser": {
         "require": "./dist/index.cjs.js",
         "import": "./dist/index.esm2017.js"
-      }
+      },
+      "default": "./dist/index.esm2017.js"
     },
     "./package.json": "./package.json"
   },


### PR DESCRIPTION
Move `exports.defaults` field to the last field.
Fixes https://github.com/firebase/firebase-js-sdk/issues/7005.

This bug was introduced by https://github.com/firebase/firebase-js-sdk/pull/6981.

PR based on https://github.com/firebase/firebase-js-sdk/pull/7006

Edit: tested locally with a Next.js project