### PR TITLE
Add builds to E2E workflow

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -47,6 +47,10 @@ jobs:
         working-directory: ./config
         env:
           FIREBASE_CLI_TOKEN: ${{ secrets.FIREBASE_CLI_TOKEN }}
+      - name: Do modular build
+        run: yarn build:modular
+      - name: Do compat build
+        run: yarn build:compat
       - name: Run modular tests
         env:
           APP_CHECK_DEBUG_TOKEN: ${{ secrets.APP_CHECK_DEBUG_TOKEN }}

--- a/e2e/.gitignore
+++ b/e2e/.gitignore
@@ -1,3 +1,4 @@
 build/*.js
+build/*.map
 firebase-config.js
 context.html

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -11,7 +11,9 @@
     "watch": "webpack --watch",
     "build": "webpack",
     "start:modular": "webpack serve --config-name modular",
-    "start:compat": "webpack serve --config-name compat"
+    "start:compat": "webpack serve --config-name compat",
+    "build:modular": "webpack --config-name modular",
+    "build:compat": "webpack --config-name compat"
   },
   "author": "",
   "license": "ISC",

--- a/e2e/webpack.config.js
+++ b/e2e/webpack.config.js
@@ -49,9 +49,6 @@ module.exports = [
         }
       ]
     },
-    resolve: {
-      mainFields: ['browser', 'module', 'main']
-    },
     stats: {
       colors: true
     },
@@ -87,9 +84,6 @@ module.exports = [
           }
         }
       ]
-    },
-    resolve: {
-      mainFields: ['browser', 'module', 'main']
     },
     stats: {
       colors: true


### PR DESCRIPTION
Add steps in E2E smoke test just to see if the app will build with a pretty standard webpack config. This would have caught https://github.com/firebase/firebase-js-sdk/issues/7005 . The E2E unit tests are run with karma-typescript and don't use webpack at all so they didn't catch this.