### PR TITLE
spec_test_runner.ts: sort document changes before comparing for correctness

### DIFF
--- a/packages/firestore/test/unit/specs/spec_test_runner.ts
+++ b/packages/firestore/test/unit/specs/spec_test_runner.ts
@@ -1172,7 +1172,13 @@ abstract class TestRunner {
         });
       }
 
-      expect(actual.view!.docChanges).to.deep.equal(expectedChanges);
+      const actualChangesSorted = Array.from(actual.view!.docChanges).sort(
+        (a, b) => primitiveComparator(a.doc, b.doc)
+      );
+      const expectedChangesSorted = Array.from(expectedChanges).sort((a, b) =>
+        primitiveComparator(a.doc, b.doc)
+      );
+      expect(actualChangesSorted).to.deep.equal(expectedChangesSorted);
 
       expect(actual.view!.hasPendingWrites).to.equal(
         expected.hasPendingWrites,


### PR DESCRIPTION
When comparing document changes for correctness in spec tests, the lists of changes in the actual and expected results were assumed to be ordered the same; however, they are not necessarily ordered in the same manner. Since order doesn't actually matter, this PR fixes potential future problems with sort order mismatches by sorting both of them using the same comparator.

Credit for this PR goes to @milaGGL from https://github.com/firebase/firebase-js-sdk/pull/6897. I'm merely merging a small component of that PR into the master branch to reduce the diff when her PR ultimately gets merged.