### PR TITLE
One neat trick to fix slow builds

### DIFF
--- a/packages/firebase/tsconfig.json
+++ b/packages/firebase/tsconfig.json
@@ -4,6 +4,6 @@
     "outDir": "dist"
   },
   "exclude": [
-    "dist/**/*"
+    "**/dist/**/*"
   ]
 }


### PR DESCRIPTION
Ensure `firebase` main package builds ignore all dist files even in subdirectories. This was causing very slow builds in `rollup-plugin-typescript2` (30-50s per small index file). This didn't seem to be a problem in the past (perhaps a change to rpt2 or typescript introduced this), and it's not a problem for `@rollup/plugin-typescript` which doesn't even seem to need the `exclude` to know to ignore `dist/` files.

This reduces build times per file from roughly 30s to about 3s.