### PR TITLE
Change _fail to use AuthErrorCode.INTERNAL_ERROR and pass in error me…

### DIFF
--- a/.changeset/tough-taxis-travel.md
+++ b/.changeset/tough-taxis-travel.md
@@ -1,0 +1,5 @@
+---
+'@firebase/auth': patch
+---
+
+Modify \_fail to use AuthErrorCode.INTERNAL_ERROR and pass in error message.

--- a/packages/auth/src/api/index.test.ts
+++ b/packages/auth/src/api/index.test.ts
@@ -308,6 +308,26 @@ describe('api/_performApiRequest', () => {
     });
   });
 
+  context('with non-Firebase Errors', () => {
+    afterEach(mockFetch.tearDown);
+
+    it('should handle non-FirebaseErrors', async () => {
+      mockFetch.setUpWithOverride(() => {
+        return new Promise<never>((_, reject) => reject(new Error('error')));
+      });
+      const promise = _performApiRequest<typeof request, never>(
+        auth,
+        HttpMethod.POST,
+        Endpoint.SIGN_UP,
+        request
+      );
+      await expect(promise).to.be.rejectedWith(
+        FirebaseError,
+        'auth/internal-error'
+      );
+    });
+  });
+
   context('with network issues', () => {
     afterEach(mockFetch.tearDown);
 
@@ -344,24 +364,6 @@ describe('api/_performApiRequest', () => {
       await promise;
       expect(clock.clearTimeout).to.have.been.called;
       clock.restore();
-    });
-
-    it('should handle network failure', async () => {
-      mockFetch.setUpWithOverride(() => {
-        return new Promise<never>((_, reject) =>
-          reject(new Error('network error'))
-        );
-      });
-      const promise = _performApiRequest<typeof request, never>(
-        auth,
-        HttpMethod.POST,
-        Endpoint.SIGN_UP,
-        request
-      );
-      await expect(promise).to.be.rejectedWith(
-        FirebaseError,
-        'auth/network-request-failed'
-      );
     });
   });
 

--- a/packages/auth/src/api/index.ts
+++ b/packages/auth/src/api/index.ts
@@ -181,7 +181,7 @@ export async function _performFetchWithErrorHandling<V>(
     if (e instanceof FirebaseError) {
       throw e;
     }
-    _fail(auth, AuthErrorCode.NETWORK_REQUEST_FAILED);
+    _fail(auth, AuthErrorCode.INTERNAL_ERROR, { 'message': String(e) });
   }
 }
 


### PR DESCRIPTION
Currently, `auth/network-request-failed` is caused by many different issues. After this change, if someone sees a `auth/network-request-failed` error, then it means the API call timed out (https://github.com/firebase/firebase-js-sdk/blob/04dcdbb0f5b19e51082a846463d84aadb77e98d4/packages/auth/src/api/index.ts#L141 and https://github.com/firebase/firebase-js-sdk/blob/04dcdbb0f5b19e51082a846463d84aadb77e98d4/packages/auth/src/api/index.ts#L234). 

Other failures will be thrown with AuthErrorCode.INTERNAL_ERROR and an error message.