### PR TITLE
Mila/bloom filter add integration test

### DIFF
--- a/packages/firestore/test/integration/api/query.test.ts
+++ b/packages/firestore/test/integration/api/query.test.ts
@@ -1618,7 +1618,7 @@ apiDescribe('Queries', (persistence: boolean) => {
 
   // eslint-disable-next-line no-restricted-properties
   (persistence ? it.skip : it)(
-    'can raise expected snapshot when resume query after deleting docs',
+    'resuming a query should remove deleted documents indicated by existence filter',
     () => {
       const testDocs = {};
       for (let i = 1; i <= 100; i++) {
@@ -1633,11 +1633,9 @@ apiDescribe('Queries', (persistence: boolean) => {
             txn.delete(doc(coll, 'doc' + i));
           }
         });
-        // Wait 10 seconds, during which the watch will stop tracking the query
+        // Wait 10 seconds, during which Watch will stop tracking the query
         // and will send an existence filter rather than "delete" events.
-        await (function () {
-          return new Promise(resolve => setTimeout(resolve, 10000));
-        })();
+        await new Promise(resolve => setTimeout(resolve, 10000));
         const snapshot2 = await getDocs(coll);
         expect(snapshot2.size).to.equal(50);
       });

--- a/packages/firestore/test/integration/api/query.test.ts
+++ b/packages/firestore/test/integration/api/query.test.ts
@@ -1616,7 +1616,7 @@ apiDescribe('Queries', (persistence: boolean) => {
     });
   });
 
-  it('can handle existence filter', () => {
+  it('can raise expected snapshot when resume query after deleting docs', () => {
     const testDocs = {};
     for (let i = 1; i <= 100; i++) {
       Object.assign(testDocs, { ['doc' + i]: { key: i } });

--- a/packages/firestore/test/integration/api/query.test.ts
+++ b/packages/firestore/test/integration/api/query.test.ts
@@ -1615,9 +1615,9 @@ apiDescribe('Queries', (persistence: boolean) => {
       });
     });
   });
-  
+
   // eslint-disable-next-line no-restricted-properties
-  (persistence ?  it.skip: it)(
+  (persistence ? it.skip : it)(
     'can raise expected snapshot when resume query after deleting docs',
     () => {
       const testDocs = {};

--- a/packages/firestore/test/integration/api/query.test.ts
+++ b/packages/firestore/test/integration/api/query.test.ts
@@ -1620,9 +1620,9 @@ apiDescribe('Queries', (persistence: boolean) => {
   (persistence ? it.skip : it)(
     'resuming a query should remove deleted documents indicated by existence filter',
     () => {
-      const testDocs = {};
+      const testDocs: { [key: string]: object } = {};
       for (let i = 1; i <= 100; i++) {
-        Object.assign(testDocs, { ['doc' + i]: { key: i } });
+        testDocs['doc' + i] = { key: i };
       }
       return withTestCollection(persistence, testDocs, async (coll, db) => {
         const snapshot1 = await getDocs(coll);

--- a/packages/firestore/test/integration/api/query.test.ts
+++ b/packages/firestore/test/integration/api/query.test.ts
@@ -47,6 +47,7 @@ import {
   Query,
   query,
   QuerySnapshot,
+  runTransaction,
   setDoc,
   startAfter,
   startAt,
@@ -1614,6 +1615,30 @@ apiDescribe('Queries', (persistence: boolean) => {
       });
     });
   });
+
+  it('can handle existence filter', () => {
+    const testDocs = {};
+    for (let i = 1; i <= 100; i++) {
+      Object.assign(testDocs, { ['doc' + i]: { key: i } });
+    }
+    return withTestCollection(persistence, testDocs, async (coll, db) => {
+      const snapshot1 = await getDocs(coll);
+      expect(snapshot1.size).to.equal(100);
+      // Delete 50 docs in transaction so that it doesn't affect local cache.
+      await runTransaction(db, async txn => {
+        for (let i = 1; i <= 50; i++) {
+          txn.delete(doc(coll, 'doc' + i));
+        }
+      });
+      // Wait 10 seconds, during which the watch will stop tracking the query
+      // and will send an existence filter rather than "delete" events.
+      await (function () {
+        return new Promise(resolve => setTimeout(resolve, 10000));
+      })();
+      const snapshot2 = await getDocs(coll);
+      expect(snapshot2.size).to.equal(50);
+    });
+  }).timeout('15s');
 });
 
 function verifyDocumentChange<T>(


### PR DESCRIPTION
## Integration Test 1 - Typical Case

- Create 100 randomly-named documents.
- Run a query to sync these 100 documents locally with a resume token.
- Delete 50 of the documents using a transaction (so as not to affect the local cache).
- Wait 10 seconds, during which the CLC will stop tracking the query and will send an existence filter rather than "delete" events.
- Re-run the same query from step 2 (which will use the resume token).
- Verify that a snapshot eventually gets raised with the 50 documents that were not deleted.