### PR TITLE
Fix unimplemented error when loading bundles

### DIFF
--- a/.changeset/soft-nails-give.md
+++ b/.changeset/soft-nails-give.md
@@ -1,0 +1,5 @@
+---
+"@firebase/firestore": patch
+---
+
+Fix unimplemented error when loading bundles

--- a/packages/firestore/src/util/byte_stream.ts
+++ b/packages/firestore/src/util/byte_stream.ts
@@ -59,7 +59,7 @@ export function toByteStreamReaderHelper(
     },
     async cancel(): Promise<void> {},
     releaseLock() {},
-    closed: Promise.reject('unimplemented')
+    closed: Promise.resolve()
   };
   return reader;
 }


### PR DESCRIPTION
Fixes: https://github.com/firebase/firebase-js-sdk/issues/5838

Was introduced by: https://github.com/firebase/firebase-js-sdk/pull/4098