### PR TITLE
Explicitly set createdAt and lastLoginAt when cloning UserImpl

### DIFF
--- a/.changeset/fluffy-seas-behave.md
+++ b/.changeset/fluffy-seas-behave.md
@@ -1,0 +1,5 @@
+---
+"@firebase/auth": patch
+---
+
+Explicitly set createdAt and lastLoginAt when cloning UserImpl

--- a/packages/auth/src/core/user/user_impl.test.ts
+++ b/packages/auth/src/core/user/user_impl.test.ts
@@ -274,7 +274,9 @@ describe('core/user/user_impl', () => {
             uid: 'i-am-uid'
           }
         ],
-        tenantId: 'tenant-id'
+        tenantId: 'tenant-id',
+        createdAt: "2018-01-01 13:02:56.12345678",
+        lastLoginAt: "2018-01-05 13:02:56.12345678"
       });
 
       const newAuth = await testAuth();
@@ -294,6 +296,8 @@ describe('core/user/user_impl', () => {
           uid: 'i-am-uid'
         }
       ]);
+      expect(copy.metadata.creationTime).to.eq("2018-01-01 13:02:56.12345678");
+      expect(copy.metadata.lastSignInTime).to.eq("2018-01-05 13:02:56.12345678");
     });
   });
 });

--- a/packages/auth/src/core/user/user_impl.test.ts
+++ b/packages/auth/src/core/user/user_impl.test.ts
@@ -275,8 +275,8 @@ describe('core/user/user_impl', () => {
           }
         ],
         tenantId: 'tenant-id',
-        createdAt: "2018-01-01 13:02:56.12345678",
-        lastLoginAt: "2018-01-05 13:02:56.12345678"
+        createdAt: '2018-01-01 13:02:56.12345678',
+        lastLoginAt: '2018-01-05 13:02:56.12345678'
       });
 
       const newAuth = await testAuth();
@@ -296,8 +296,7 @@ describe('core/user/user_impl', () => {
           uid: 'i-am-uid'
         }
       ]);
-      expect(copy.metadata.creationTime).to.eq("2018-01-01 13:02:56.12345678");
-      expect(copy.metadata.lastSignInTime).to.eq("2018-01-05 13:02:56.12345678");
+      expect(copy.metadata.toJSON()).to.eql(user.metadata.toJSON());
     });
   });
 });

--- a/packages/auth/src/core/user/user_impl.ts
+++ b/packages/auth/src/core/user/user_impl.ts
@@ -140,13 +140,15 @@ export class UserImpl implements UserInternal {
   }
 
   _clone(auth: AuthInternal): UserInternal {
-    return new UserImpl({
+    const newUser = new UserImpl({
       ...this,
-      createdAt: this.metadata.creationTime,
-      lastLoginAt: this.metadata.lastSignInTime,
       auth,
       stsTokenManager: this.stsTokenManager._clone()
-    });
+    })
+
+    newUser.metadata._copy(this.metadata)
+
+    return newUser;
   }
 
   _onReload(callback: NextFn<APIUserInfo>): void {

--- a/packages/auth/src/core/user/user_impl.ts
+++ b/packages/auth/src/core/user/user_impl.ts
@@ -144,10 +144,8 @@ export class UserImpl implements UserInternal {
       ...this,
       auth,
       stsTokenManager: this.stsTokenManager._clone()
-    })
-
-    newUser.metadata._copy(this.metadata)
-
+    });
+    newUser.metadata._copy(this.metadata);
     return newUser;
   }
 

--- a/packages/auth/src/core/user/user_impl.ts
+++ b/packages/auth/src/core/user/user_impl.ts
@@ -142,6 +142,8 @@ export class UserImpl implements UserInternal {
   _clone(auth: AuthInternal): UserInternal {
     return new UserImpl({
       ...this,
+      createdAt: this.metadata.creationTime,
+      lastLoginAt: this.metadata.lastSignInTime,
       auth,
       stsTokenManager: this.stsTokenManager._clone()
     });


### PR DESCRIPTION
## Discussion

  * Issue being fixed by this PR: https://github.com/firebase/firebase-js-sdk/issues/7057
 
### Problem being addressed:

When calling `updateCurrentUser` the code clones the UserImpl class but incorrectly clones the UserMetadata resulting in `undefined` values. 

Line of code calling `_clone`: https://github.com/firebase/firebase-js-sdk/blob/bea604ea33c529e755cc3fcdc0a2ea75d04b9f19/packages/auth/src/core/auth/auth_impl.ts#L343

`_clone` function: https://github.com/firebase/firebase-js-sdk/blob/master/packages/auth/src/core/user/user_impl.ts#L142. 

The spread operator only passes keys on the UserImpl class and will not pass the Metadata properties belonging to `UserMetadata`.  This causes https://github.com/firebase/firebase-js-sdk/blob/master/packages/auth/src/core/user/user_impl.ts#L142 to fail.

This is missed in the test because the metadata properties are never set: https://github.com/firebase/firebase-js-sdk/blob/b6c231a282313aeda59c447c24f71fdad35240bc/packages/auth/src/core/user/user_impl.test.ts#L257


