### PR TITLE
Surface the error for COUNT queries

### DIFF
--- a/packages/firestore-compat/src/index.console.ts
+++ b/packages/firestore-compat/src/index.console.ts
@@ -106,12 +106,12 @@ export class Firestore extends FirestoreCompat {
     delete: () => this.terminate(),
     count: (query: Compat<ExpQuery<unknown>>) => {
       return getCountFromServer(query._delegate)
-      .then(response => {
-        return response.data().count;
-      })
-      .catch(error => {
-        throw new FirestoreError(error.code, error.message);
-    });
+        .then(response => {
+          return response.data().count;
+        })
+        .catch(error => {
+          throw new FirestoreError(error.code, error.message);
+        });
     }
   };
 }

--- a/packages/firestore-compat/src/index.console.ts
+++ b/packages/firestore-compat/src/index.console.ts
@@ -105,13 +105,12 @@ export class Firestore extends FirestoreCompat {
   INTERNAL = {
     delete: () => this.terminate(),
     count: (query: Compat<ExpQuery<unknown>>) => {
-      return getCountFromServer(query._delegate).then(response => {
+      return getCountFromServer(query._delegate)
+      .then(response => {
         return response.data().count;
-      }).catch(error => {
-        throw new FirestoreError(
-        error.code,
-        error.message,
-      );
+      })
+      .catch(error => {
+        throw new FirestoreError(error.code, error.message);
     });
     }
   };

--- a/packages/firestore-compat/src/index.console.ts
+++ b/packages/firestore-compat/src/index.console.ts
@@ -107,7 +107,12 @@ export class Firestore extends FirestoreCompat {
     count: (query: Compat<ExpQuery<unknown>>) => {
       return getCountFromServer(query._delegate).then(response => {
         return response.data().count;
-      });
+      }).catch(error => {
+        throw new FirestoreError(
+        error.code,
+        error.message,
+      );
+    });
     }
   };
 }


### PR DESCRIPTION
This is necessary for errors where an index needs to be created and the user needs the creation link
