### PR TITLE
Implementation draft of getClientId() for analytics

### DIFF
--- a/common/api-review/analytics.api.md
+++ b/common/api-review/analytics.api.md
@@ -134,6 +134,9 @@ export interface EventParams {
 export function getAnalytics(app?: FirebaseApp): Analytics;
 
 // @public
+export function getClientId(analyticsInstance: Analytics): Promise<string>;
+
+// @public
 export interface GtagConfigParams {
     // (undocumented)
     [key: string]: unknown;

--- a/packages/analytics/src/api.ts
+++ b/packages/analytics/src/api.ts
@@ -168,7 +168,7 @@ export function setCurrentScreen(
 }
 
 /**
- * Returns retrieves a unique identifier for the web client.
+ * Retrieves a unique identifier for the web client.
  *
  * @public
  *

--- a/packages/analytics/src/api.ts
+++ b/packages/analytics/src/api.ts
@@ -175,14 +175,26 @@ export function setCurrentScreen(
  * @param app - The {@link @firebase/app#FirebaseApp} to use.
  */
 export async function getClientId(
-  analyticsInstance: Analytics /** is there a way to get the measurementid from this else i'll need to check if  wrapped exists first + ask for targetId */,
-  targetId: string
+  analyticsInstance: Analytics
 ): Promise<string> {
-  const clientId: string = await new Promise(resolve => {
-    wrappedGtagFunction(GtagCommand.GET, targetId, 'client_id', fieldName => {
-      resolve(fieldName);
+  analyticsInstance = getModularInstance(analyticsInstance);
+  const measurementId = analyticsInstance.app.options.measurementId;
+  let clientId = '';
+  if (!measurementId) {
+    logger.error('The app has no recognizable measurement ID.');
+  } else {
+    clientId = await new Promise(resolve => {
+      wrappedGtagFunction(
+        GtagCommand.GET,
+        measurementId,
+        'client_id',
+        fieldName => {
+          resolve(fieldName);
+        }
+      );
     });
-  });
+  }
+
   return clientId;
 }
 

--- a/packages/analytics/src/api.ts
+++ b/packages/analytics/src/api.ts
@@ -168,6 +168,25 @@ export function setCurrentScreen(
 }
 
 /**
+ * Returns retrieves a unique identifier for the web client.
+ *
+ * @public
+ *
+ * @param app - The {@link @firebase/app#FirebaseApp} to use.
+ */
+export async function getClientId(
+  analyticsInstance: Analytics /** is there a way to get the measurementid from this else i'll need to check if  wrapped exists first + ask for targetId */,
+  targetId: string
+): Promise<string> {
+  const clientId: string = await new Promise(resolve => {
+    wrappedGtagFunction(GtagCommand.GET, targetId, 'client_id', fieldName => {
+      resolve(fieldName);
+    });
+  });
+  return clientId;
+}
+
+/**
  * Use gtag `config` command to set `user_id`.
  *
  * @public

--- a/packages/analytics/src/constants.ts
+++ b/packages/analytics/src/constants.ts
@@ -35,5 +35,6 @@ export const enum GtagCommand {
   EVENT = 'event',
   SET = 'set',
   CONFIG = 'config',
-  CONSENT = 'consent'
+  CONSENT = 'consent',
+  GET = 'get'
 }

--- a/packages/analytics/src/helpers.ts
+++ b/packages/analytics/src/helpers.ts
@@ -227,9 +227,10 @@ function wrapGtag(
    * @param gtagParams Params if event is EVENT/CONFIG.
    */
   async function gtagWrapper(
-    command: 'config' | 'set' | 'event' | 'consent',
+    command: 'config' | 'set' | 'event' | 'consent' | 'get',
     idOrNameOrParams: string | ControlParams,
-    gtagParams?: GtagConfigOrEventParams | ConsentSettings
+    gtagParams?: GtagConfigOrEventParams | ConsentSettings | string,
+    callback?: (s: string) => void
   ): Promise<void> {
     try {
       // If event, check that relevant initialization promises have completed.
@@ -255,6 +256,13 @@ function wrapGtag(
       } else if (command === GtagCommand.CONSENT) {
         // If CONFIG, second arg must be measurementId.
         gtagCore(GtagCommand.CONSENT, 'update', gtagParams as ConsentSettings);
+      } else if (command === GtagCommand.GET) {
+        gtagCore(
+          GtagCommand.GET,
+          idOrNameOrParams as string,
+          gtagParams as string,
+          callback as (fieldName: string) => void
+        );
       } else {
         // If SET, second arg must be params.
         gtagCore(GtagCommand.SET, idOrNameOrParams as CustomParams);

--- a/packages/analytics/src/types.ts
+++ b/packages/analytics/src/types.ts
@@ -73,6 +73,12 @@ export interface Gtag {
     subCommand: 'default' | 'update',
     consentSettings: ConsentSettings
   ): void;
+  (
+    command: 'get',
+    targetId: string,
+    fieldName: string,
+    callback: (s: string) => void
+  ): void;
 }
 
 export type DataLayer = IArguments[];


### PR DESCRIPTION
We were presented with use cases where users wanted to log `purchase` and other events from their backends using [Google Analytics 4 Measurement Protocol](https://developers.google.com/analytics/devguides/collection/protocol/ga4). In the [event sending documentation](https://developers.google.com/analytics/devguides/collection/protocol/ga4/sending-events?client_type=firebase#required_parameters), it dictates that `app_instance_id` is required for Firebase but we determined this was only focused on Firebase for mobile. Because the JS SDK analytics package is a wrapper around gtag, [we can use the `client_id` instead of `app_instance_id`](https://developers.google.com/analytics/devguides/collection/protocol/ga4/sending-events?client_type=gtag#required_parameters) for Measurement Protocol. To simplify the retrieval process from our analytics packages, we want to add a `getClientId()` method.