### PR TITLE
remove gapi.auth fall back option for getAuthToken()

### DIFF
--- a/.changeset/plenty-radios-look.md
+++ b/.changeset/plenty-radios-look.md
@@ -1,0 +1,6 @@
+---
+'@firebase/firestore': patch
+'firebase': patch
+---
+
+Remove the deprecated gapi.auth from FirstPartyToken.

--- a/packages/firestore/src/api/credentials.ts
+++ b/packages/firestore/src/api/credentials.ts
@@ -407,9 +407,9 @@ export class FirstPartyToken implements Token {
     private readonly authTokenFactory: AuthTokenFactory | null
   ) {}
 
-  /** 
+  /**
    * Gets an authorization token, using a provided factory function, or return
-   * null. 
+   * null.
    */
   private getAuthToken(): string | null {
     if (this.authTokenFactory) {

--- a/packages/firestore/src/api/credentials.ts
+++ b/packages/firestore/src/api/credentials.ts
@@ -407,22 +407,15 @@ export class FirstPartyToken implements Token {
     private readonly authTokenFactory: AuthTokenFactory | null
   ) {}
 
-  /** Gets an authorization token, using a provided factory function, or falling back to First Party GAPI. */
+  /** 
+   * Gets an authorization token, using a provided factory function, or return
+   * null. 
+   */
   private getAuthToken(): string | null {
     if (this.authTokenFactory) {
       return this.authTokenFactory();
     } else {
-      // Make sure this really is a Gapi client.
-      hardAssert(
-        !!(
-          typeof this.gapi === 'object' &&
-          this.gapi !== null &&
-          this.gapi['auth'] &&
-          this.gapi['auth']['getAuthHeaderValueForFirstParty']
-        ),
-        'unexpected gapi interface'
-      );
-      return this.gapi!['auth']['getAuthHeaderValueForFirstParty']([]);
+      return null;
     }
   }
 


### PR DESCRIPTION
Gapi.auth is going to be deprecated on March 31, and it is used for first party authentication in firestore.
Issue: https://github.com/firebase/firebase-js-sdk/issues/7012
