### PR TITLE
Point the demo app to use local auth SDK changes by default.

### DIFF
--- a/packages/auth/demo/README.md
+++ b/packages/auth/demo/README.md
@@ -90,14 +90,22 @@ The demo page by default runs against the actual Auth Backend. To run against th
 yarn run demo:emulator
 ```
 
+## Running against Auth Staging endpoint
+
+Modify the configured endpoint to staging by following the changes in this branch:
+
+https://github.com/firebase/firebase-js-sdk/compare/use-staging
+
 ## Running against local changes to auth package
 
-By default, the demo runs against the latest release of firebase-auth sdk. This can be modified by:
+
+By default, the demo runs against the local firebase-auth implementation in packages/auth/src.
+This can be modified to point to a released version using:
 
 ```
 // packages/auth/demo/package.json
-+  "@firebase/auth": "file:..",
--  "@firebase/auth": "0.18.0",
+-  "@firebase/auth": "file:..",
++  "@firebase/auth": "0.18.0",
 ```
 
 ## Troubleshooting

--- a/packages/auth/demo/package.json
+++ b/packages/auth/demo/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "@firebase/app": "0.7.24",
-    "@firebase/auth": "0.20.1",
+    "@firebase/auth": "file:..",
     "@firebase/logger": "0.3.2",
     "@firebase/util": "1.6.0",
     "tslib": "^2.1.0"


### PR DESCRIPTION
Update the README with steps to use the staging endpoint.




