### PR TITLE
firestore-compat: fix typing error of 'settings' object in fields.test.ts

### DIFF
--- a/packages/firestore-compat/test/fields.test.ts
+++ b/packages/firestore-compat/test/fields.test.ts
@@ -387,8 +387,7 @@ apiDescribe('Timestamp Fields in snapshots', (persistence: boolean) => {
 });
 
 apiDescribe('`undefined` properties', (persistence: boolean) => {
-  const settings = { ...DEFAULT_SETTINGS };
-  settings.ignoreUndefinedProperties = true;
+  const settings = { ...DEFAULT_SETTINGS, ignoreUndefinedProperties: true };
 
   it('are ignored in set()', () => {
     return withTestDocAndSettings(persistence, settings, async doc => {


### PR DESCRIPTION
In some GitHub Actions, the `fields.test.ts` fails TypeScript compilation due to the following error:

```
TS2339: Property 'ignoreUndefinedProperties' does not exist on type '{ host: string; ssl: boolean; }'.
```
e.g. https://github.com/firebase/firebase-js-sdk/actions/runs/4367447223/jobs/7638769445 (full logs: https://gist.github.com/dconeybe/85ad1521dea7123530d1c28424098367).

This PR fixes the error by constructing the `settings` object in a single operation, rather than creating it with some default values, then adding a property to it.
