### PR TITLE
Avoid changeset check on PRs to non-master branches

### DIFF
--- a/.github/workflows/check-changeset.yml
+++ b/.github/workflows/check-changeset.yml
@@ -2,8 +2,8 @@ name: Check Changeset
 
 on:
   pull_request:
-    branches-ignore:
-      - release
+    branches:
+      - master
 
 env:
   GITHUB_PULL_REQUEST_HEAD_SHA: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/check-docs.yml
+++ b/.github/workflows/check-docs.yml
@@ -1,6 +1,9 @@
 name: Doc Change Check (Run "yarn docgen devsite" if this fails)
 
-on: pull_request
+on:
+  pull_request:
+    branches:
+      - master
 
 jobs:
   doc-check:

--- a/.github/workflows/check-docs.yml
+++ b/.github/workflows/check-docs.yml
@@ -1,9 +1,6 @@
 name: Doc Change Check (Run "yarn docgen devsite" if this fails)
 
-on:
-  pull_request:
-    branches:
-      - master
+on: pull_request
 
 jobs:
   doc-check:


### PR DESCRIPTION
PRs to feature branches (and release branch) don't need changeset checker run. Should only run the changeset check on PRs targeting master.