### PR TITLE
Add return type and return value to withSecurityRulesDisabled function

### DIFF
--- a/.changeset/nervous-berries-jump.md
+++ b/.changeset/nervous-berries-jump.md
@@ -1,0 +1,23 @@
+---
+'@firebase/rules-unit-testing': minor
+---
+
+Added a return type to the function `withSecurityRulesDisabled` that is the same as the return type of its callback.  
+It is more convenient for this function to return the return type of the callback, e.g. when context.firestore() is used to retrieve a document reference, this document reference can be returned directly, instead of using it in the callback, or assigning it to a variable, initialized outside of the callback function.
+
+### Current workflow
+```typescript
+let data
+await withSecurityRulesDisabled(async context => {
+  const fs = context.firestore()
+  data = await getDoc(fs.doc('firestore_path'))
+})
+```
+
+### Suggested workflow
+```typescript
+const data = await withSecurityRulesDisabled(async context => {
+  const fs = context.firestore()
+  return getDoc(fs.doc('firestore_path'))
+})
+```

--- a/packages/rules-unit-testing/src/impl/test_environment.ts
+++ b/packages/rules-unit-testing/src/impl/test_environment.ts
@@ -62,9 +62,9 @@ export class RulesTestEnvironmentImpl implements RulesTestEnvironment {
     return this.createContext(/* authToken = */ undefined);
   }
 
-  async withSecurityRulesDisabled(
-    callback: (context: RulesTestContext) => Promise<void>
-  ): Promise<void> {
+  async withSecurityRulesDisabled<T>(
+    callback: (context: RulesTestContext) => Promise<T>
+  ): Promise<T> {
     this.checkNotDestroyed();
     // The "owner" token is recognized by the emulators as a special value that bypasses Security
     // Rules. This should only ever be used in withSecurityRulesDisabled.
@@ -73,14 +73,16 @@ export class RulesTestEnvironmentImpl implements RulesTestEnvironment {
     // Admin SDKs to the emulators for integration testing via environment variables.
     // See: https://firebase.google.com/docs/emulator-suite/connect_firestore#admin_sdks
     const context = this.createContext('owner');
+    let data
     try {
-      await callback(context);
+      data = await callback(context);
     } finally {
       // We eagarly clean up this context to actively prevent misuse outside of the callback, e.g.
       // storing the context in a variable.
       context.cleanup();
       this.contexts.delete(context);
     }
+    return data
   }
 
   private createContext(


### PR DESCRIPTION
This PR suggests the `withSecurityRulesDisabled` function to return the return value of its callback. This would allow retrieved data to be assigned upon the instantiation of a variable, rather than instantiating a variable outside the callback function and assigning it a value inside of the callback.  
An example use case can be found in the changeset doc, attached to this PR.