### PR TITLE
Change _fail to use NETWORK_REQUEST_FAILED

### DIFF
--- a/.changeset/sixty-buckets-repeat.md
+++ b/.changeset/sixty-buckets-repeat.md
@@ -1,0 +1,5 @@
+---
+'@firebase/auth': patch
+---
+
+Modify \_fail to use AuthErrorCode.NETWORK_REQUEST_FAILED

--- a/packages/auth/src/api/index.test.ts
+++ b/packages/auth/src/api/index.test.ts
@@ -358,10 +358,12 @@ describe('api/_performApiRequest', () => {
         Endpoint.SIGN_UP,
         request
       );
-      await expect(promise).to.be.rejectedWith(
-        FirebaseError,
-        'auth/network-request-failed'
-      );
+      await expect(promise)
+        .to.be.rejectedWith(FirebaseError, 'auth/network-request-failed')
+        .eventually.with.nested.property(
+          'customData.message',
+          'Error: network error'
+        );
     });
   });
 

--- a/packages/auth/src/api/index.test.ts
+++ b/packages/auth/src/api/index.test.ts
@@ -308,26 +308,6 @@ describe('api/_performApiRequest', () => {
     });
   });
 
-  context('with non-Firebase Errors', () => {
-    afterEach(mockFetch.tearDown);
-
-    it('should handle non-FirebaseErrors', async () => {
-      mockFetch.setUpWithOverride(() => {
-        return new Promise<never>((_, reject) => reject(new Error('error')));
-      });
-      const promise = _performApiRequest<typeof request, never>(
-        auth,
-        HttpMethod.POST,
-        Endpoint.SIGN_UP,
-        request
-      );
-      await expect(promise).to.be.rejectedWith(
-        FirebaseError,
-        'auth/internal-error'
-      );
-    });
-  });
-
   context('with network issues', () => {
     afterEach(mockFetch.tearDown);
 
@@ -364,6 +344,24 @@ describe('api/_performApiRequest', () => {
       await promise;
       expect(clock.clearTimeout).to.have.been.called;
       clock.restore();
+    });
+
+    it('should handle network failure', async () => {
+      mockFetch.setUpWithOverride(() => {
+        return new Promise<never>((_, reject) =>
+          reject(new Error('network error'))
+        );
+      });
+      const promise = _performApiRequest<typeof request, never>(
+        auth,
+        HttpMethod.POST,
+        Endpoint.SIGN_UP,
+        request
+      );
+      await expect(promise).to.be.rejectedWith(
+        FirebaseError,
+        'auth/network-request-failed'
+      );
     });
   });
 

--- a/packages/auth/src/api/index.ts
+++ b/packages/auth/src/api/index.ts
@@ -181,7 +181,10 @@ export async function _performFetchWithErrorHandling<V>(
     if (e instanceof FirebaseError) {
       throw e;
     }
-    _fail(auth, AuthErrorCode.INTERNAL_ERROR, { 'message': String(e) });
+    // Changing this to a different error code will log user out when there is a network error
+    // because we treat any error other than NETWORK_REQUEST_FAILED as token is invalid.
+    // https://github.com/firebase/firebase-js-sdk/blob/master/packages/auth/src/core/auth/auth_impl.ts#L309-L316
+    _fail(auth, AuthErrorCode.NETWORK_REQUEST_FAILED, { 'message': String(e) });
   }
 }
 

--- a/packages/auth/src/api/index.ts
+++ b/packages/auth/src/api/index.ts
@@ -183,7 +183,7 @@ export async function _performFetchWithErrorHandling<V>(
     }
     // Changing this to a different error code will log user out when there is a network error
     // because we treat any error other than NETWORK_REQUEST_FAILED as token is invalid.
-    // https://github.com/firebase/firebase-js-sdk/blob/master/packages/auth/src/core/auth/auth_impl.ts#L309-L316
+    // https://github.com/firebase/firebase-js-sdk/blob/4fbc73610d70be4e0852e7de63a39cb7897e8546/packages/auth/src/core/auth/auth_impl.ts#L309-L316
     _fail(auth, AuthErrorCode.NETWORK_REQUEST_FAILED, { 'message': String(e) });
   }
 }


### PR DESCRIPTION
Fix https://github.com/firebase/firebase-js-sdk/issues/7118. 
https://github.com/firebase/firebase-js-sdk/blob/master/packages/auth/src/api/index.ts#L184 throws INTERNAL_ERROR when there is a network error. However, https://github.com/firebase/firebase-js-sdk/blob/master/packages/auth/src/core/auth/auth_impl.ts#L309-L316 treats any error other than NETWORK_REQUEST_FAILED as token is invalid and signs user out which is not an expected behavior. Hence, we're changing it back to using NETWORK_REQUEST_FAILED.
