### PR TITLE
Use ReactNativeAsyncStorage from community package.

### DIFF
--- a/.changeset/two-bags-jog.md
+++ b/.changeset/two-bags-jog.md
@@ -1,0 +1,6 @@
+---
+'@firebase/auth': major
+'firebase': major
+---
+
+Change `getAuth()` in the React Native bundle to default to importing `AsyncStorage` from `@react-native-async-storage/async-storage` instead of from the `react-native` core package (which has recently removed it).

--- a/docs-devsite/auth.md
+++ b/docs-devsite/auth.md
@@ -157,7 +157,6 @@ Firebase Authentication
 |  [OperationType](./auth.md#operationtype) | Enumeration of supported operation types. |
 |  [prodErrorMap](./auth.md#proderrormap) | A minimal error map with all verbose error messages stripped.<!-- -->See discussion at [AuthErrorMap](./auth.autherrormap.md#autherrormap_interface) |
 |  [ProviderId](./auth.md#providerid) | Enumeration of supported providers. |
-|  [reactNativeLocalPersistence](./auth.md#reactnativelocalpersistence) | An implementation of [Persistence](./auth.persistence.md#persistence_interface) of type 'LOCAL' for use in React Native environments. |
 |  [SignInMethod](./auth.md#signinmethod) | Enumeration of supported sign-in methods. |
 
 ## Type Aliases
@@ -1967,16 +1966,6 @@ ProviderId: {
     readonly PHONE: "phone";
     readonly TWITTER: "twitter.com";
 }
-```
-
-## reactNativeLocalPersistence
-
-An implementation of [Persistence](./auth.persistence.md#persistence_interface) of type 'LOCAL' for use in React Native environments.
-
-<b>Signature:</b>
-
-```typescript
-reactNativeLocalPersistence: Persistence
 ```
 
 ## SignInMethod

--- a/packages/auth/index.doc.ts
+++ b/packages/auth/index.doc.ts
@@ -28,7 +28,4 @@
 export * from './index';
 
 export { cordovaPopupRedirectResolver } from './index.cordova';
-export {
-  reactNativeLocalPersistence,
-  getReactNativePersistence
-} from './index.rn';
+export { getReactNativePersistence } from './index.rn';

--- a/packages/auth/index.rn.ts
+++ b/packages/auth/index.rn.ts
@@ -22,15 +22,14 @@
  * just use index.ts
  */
 
-import * as ReactNative from 'react-native';
-
 import { FirebaseApp, getApp, _getProvider } from '@firebase/app';
-import { Auth, Persistence } from './src/model/public_types';
+import { Auth } from './src/model/public_types';
 
 import { initializeAuth } from './src';
 import { registerAuth } from './src/core/auth/register';
 import { ClientPlatform } from './src/core/util/version';
 import { getReactNativePersistence } from './src/platform_react_native/persistence/react_native';
+import ReactNativeAsyncStorage from '@react-native-async-storage/async-storage';
 
 // Core functionality shared by all clients
 export * from './index.shared';
@@ -50,28 +49,6 @@ export {
 // MFA
 export { PhoneMultiFactorGenerator } from './src/platform_browser/mfa/assertions/phone';
 
-/**
- * An implementation of {@link Persistence} of type 'LOCAL' for use in React
- * Native environments.
- *
- * @public
- */
-export const reactNativeLocalPersistence: Persistence =
-  getReactNativePersistence({
-    getItem(...args) {
-      // Called inline to avoid deprecation warnings on startup.
-      return ReactNative.AsyncStorage.getItem(...args);
-    },
-    setItem(...args) {
-      // Called inline to avoid deprecation warnings on startup.
-      return ReactNative.AsyncStorage.setItem(...args);
-    },
-    removeItem(...args) {
-      // Called inline to avoid deprecation warnings on startup.
-      return ReactNative.AsyncStorage.removeItem(...args);
-    }
-  });
-
 export { getReactNativePersistence };
 
 export function getAuth(app: FirebaseApp = getApp()): Auth {
@@ -82,7 +59,7 @@ export function getAuth(app: FirebaseApp = getApp()): Auth {
   }
 
   return initializeAuth(app, {
-    persistence: reactNativeLocalPersistence
+    persistence: getReactNativePersistence(ReactNativeAsyncStorage)
   });
 }
 

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -114,6 +114,7 @@
     "@firebase/component": "0.6.4",
     "@firebase/logger": "0.4.0",
     "@firebase/util": "1.9.3",
+    "@react-native-async-storage/async-storage": "1.17.12",
     "node-fetch": "2.6.7",
     "tslib": "^2.1.0"
   },
@@ -122,6 +123,7 @@
     "@firebase/app": "0.9.10",
     "@rollup/plugin-json": "4.1.0",
     "@rollup/plugin-strip": "2.1.0",
+    "@types/express": "4.17.17",
     "chromedriver": "98.0.1",
     "rollup": "2.79.1",
     "rollup-plugin-sourcemaps": "0.6.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3050,6 +3050,13 @@
   resolved "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
   integrity sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA=
 
+"@react-native-async-storage/async-storage@1.17.12":
+  version "1.17.12"
+  resolved "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-1.17.12.tgz#a39e4df5b06795ce49b2ca5b7ca9b8faadf8e621"
+  integrity sha512-BXg4OxFdjPTRt+8MvN6jz4muq0/2zII3s7HeT/11e4Zeh3WCgk/BleLzUcDfVqF3OzFHUqEkSrb76d6Ndjd/Nw==
+  dependencies:
+    merge-options "^3.0.4"
+
 "@rollup/plugin-alias@3.1.9":
   version "3.1.9"
   resolved "https://registry.npmjs.org/@rollup/plugin-alias/-/plugin-alias-3.1.9.tgz#a5d267548fe48441f34be8323fb64d1d4a1b3fdf"
@@ -12250,6 +12257,13 @@ merge-descriptors@1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz#b00aaa556dd8b44568150ec9d1b953f3f90cbb61"
   integrity sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=
+
+merge-options@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.npmjs.org/merge-options/-/merge-options-3.0.4.tgz#84709c2aa2a4b24c1981f66c179fe5565cc6dbb7"
+  integrity sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ==
+  dependencies:
+    is-plain-obj "^2.1.0"
 
 merge-stream@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
DO NOT MERGE until 6/20. This is a breaking change and must be released with a major version. It is expected to release with the next major version of the SDK in June 2023.

See internal doc: https://docs.google.com/document/d/1ZA1u7gfyIZjNpFY_v8DVBpBvDZAbxASl826OvjiTLvg/edit?resourcekey=0-AfgkOJV0qHh5waZvdLxucg#heading=h.9g9y2z36z0g9

getAuth() has been using`AsyncStorage` from the React Native core package, which was deprecated for a while and has now been removed. Users are expected to get `AsyncStorage` from the community package (`@react-native-async-storage/async-storage`) now. We have tried to bridge the gap for a while by using the core AsyncStorage as the default and allowing users to import the community AsyncStorage using `initializeAuth()`, but the core AsyncStorage no longer exists so we can default to the community package with the next breaking change.

The community package has been added as a dependency to auth, which is an extraneous dependency for non-react-native users but it won't go into non-react-native bundles and the npm download size should be small. If the community package isn't installed, the React Native bundle will error on build, something we can't avoid as the Metro bundler doesn't allow runtime requires.

Fixes https://github.com/firebase/firebase-js-sdk/issues/6493
Fixes https://github.com/firebase/firebase-js-sdk/issues/6067

Tested this out in Expo and it's working.