### PR TITLE
firestore: verify DOMException exists before using it in when base64 decoding

### DIFF
--- a/.changeset/friendly-ads-yell.md
+++ b/.changeset/friendly-ads-yell.md
@@ -1,0 +1,6 @@
+---
+'@firebase/firestore': patch
+'firebase': patch
+---
+
+Check that DOMException exists before referencing it, to fix react-native, which was broken by https://github.com/firebase/firebase-js-sdk/pull/7019 in v9.17.2.

--- a/packages/firestore/src/platform/browser/base64.ts
+++ b/packages/firestore/src/platform/browser/base64.ts
@@ -22,7 +22,10 @@ export function decodeBase64(encoded: string): string {
   try {
     return atob(encoded);
   } catch (e) {
-    if (e instanceof DOMException) {
+    // Check that `DOMException` is defined before using it to avoid
+    // "ReferenceError: Property 'DOMException' doesn't exist" in react-native.
+    // (https://github.com/firebase/firebase-js-sdk/issues/7115)
+    if (typeof DOMException !== 'undefined' && e instanceof DOMException) {
       throw new Base64DecodeError('Invalid base64 string: ' + e);
     } else {
       throw e;


### PR DESCRIPTION
In https://github.com/firebase/firebase-js-sdk/issues/7115 the customer shows that the "browser" logic for decoding a base64 string was being invoked from a react-native app. In react-native, the `DOMException` class does not exist, which results in the following error:

```
ReferenceError: Property 'DOMException' doesn't exist
```

This usage of `DOMException` was added by https://github.com/firebase/firebase-js-sdk/pull/7019.

Although a react-native app _should_ be using a different implementation of base64 decoding, we may as well be safe here so that the error message produced from a react-native app is more meaningful, something like `Uncaught ReferenceError: atob() is not defined`.