### PR TITLE
Unmangle a switch variable for Closure

### DIFF
--- a/packages/firebase/compat/rollup.config.js
+++ b/packages/firebase/compat/rollup.config.js
@@ -31,7 +31,10 @@ import { emitModulePackageFile } from '../../../scripts/build/rollup_emit_module
 
 const external = Object.keys(pkg.dependencies || {});
 const uglifyOptions = {
-  mangle: true,
+  mangle: {
+    // Hack for a bug in Closure regarding switch block scope
+    reserved: ['__PRIVATE_lastReasonableEscapeIndex']
+  },
   webkit: true // Necessary to avoid https://bugs.webkit.org/show_bug.cgi?id=223533
 };
 

--- a/packages/firestore/rollup.shared.js
+++ b/packages/firestore/rollup.shared.js
@@ -150,8 +150,10 @@ const manglePrivatePropertiesOptions = {
     // This can be removed if the problem in the downstream library is fixed
     // or if terser's mangler provides an option to avoid mangling everything
     // that isn't a property.
+    // `lastReasonableEscapeIndex` was causing problems in a switch statement
+    // due to a Closure bug.
     // See issue: https://github.com/firebase/firebase-js-sdk/issues/5384
-    reserved: ['_getProvider'],
+    reserved: ['_getProvider', '__PRIVATE_lastReasonableEscapeIndex'],
     properties: {
       regex: /^__PRIVATE_/,
       // All JS Keywords are reserved. Although this should be taken cared of by


### PR DESCRIPTION
There is a bug where Closure has trouble handling scope in a switch statement. The mangler reuses a name in the switch statement body that was previously declared outside the switch scope and used inside the switch condition. If we don't mangle the outer variable, there can't be a name collision.