### PR TITLE
Wait for upto 8s for IDP sign in to finish, after popup is closed.

### DIFF
--- a/.changeset/dry-cats-lick.md
+++ b/.changeset/dry-cats-lick.md
@@ -1,0 +1,5 @@
+---
+'@firebase/auth': patch
+---
+
+Increase the popup poller timeout to 8s to support blocking functions + Firefox

--- a/packages/auth/test/integration/webdriver/popup.test.ts
+++ b/packages/auth/test/integration/webdriver/popup.test.ts
@@ -192,7 +192,7 @@ browserDescribe('Popup IdP tests', driver => {
     await widget.fillEmail('bob@bob.test');
     await widget.clickSignIn();
 
-    // On redirect, check that the signed in user is different
+    // On return to main window, check that the signed in user is different
     await driver.selectMainWindow();
     const curUser = await driver.getUserSnapshot();
     expect(curUser.uid).not.to.eq(anonUser.uid);
@@ -210,7 +210,7 @@ browserDescribe('Popup IdP tests', driver => {
     await widget.fillEmail('bob@bob.test');
     await widget.clickSignIn();
 
-    // On redirect, check that the signed in user is upgraded
+    // On return to main window, check that the signed in user is upgraded
     await driver.selectMainWindow();
     const curUser = await driver.getUserSnapshot();
     expect(curUser.uid).to.eq(anonUser.uid);
@@ -396,6 +396,7 @@ browserDescribe('Popup IdP tests', driver => {
       user = await driver.getUserSnapshot();
       expect(user.uid).to.eq(user1.uid);
       expect(user.email).to.eq(user1.email);
-    }).timeout(12_000); // Test takes a while due to the closed-by-user errors
+    }).timeout(25_000); // Test takes a while due to the closed-by-user errors. Each closed-by-user
+    // takes 8s to timeout, and we have 2 instances.
   });
 });


### PR DESCRIPTION
In some cases (Fiefox or mobile or if opener is an iframe), the popup is closed by the oauth helper code right after sign in has completed at the IDP. The IDP response still needs to be processed by the SDK + signInWithIdp API call needs to be invoked. This can take upto 7s, if there is a blocking function configured. Increase the poller timeout to 8s, so it does not reject the sign in with popup-closed-by-user error.


Fixes - https://github.com/firebase/firebase-js-sdk/issues/7049, https://github.com/firebase/firebase-js-sdk/issues/7093
@sam-gc @renkelvin 