### PR TITLE
Ensure docgen script restores original files even if build fails

### DIFF
--- a/scripts/docgen/docgen.ts
+++ b/scripts/docgen/docgen.ts
@@ -145,44 +145,47 @@ async function generateDocs(
     `"mainEntryPointFilePath": "<projectFolder>/dist/esm5/index.d.ts"`,
     `"mainEntryPointFilePath": "<projectFolder>/dist/esm5/index.doc.d.ts"`
   );
-  fs.writeFileSync(
-    `${projectRoot}/packages/auth/api-extractor.json`,
-    authApiConfigModified
-  );
 
-  if (skipBuild) {
-    await spawn('yarn', ['api-report'], {
-      stdio: 'inherit'
-    });
-  } else {
-    // api-report is run as part of every build
-    await spawn(
-      'yarn',
-      [
-        'lerna',
-        'run',
-        '--scope',
-        '@firebase/*',
-        '--ignore',
-        '@firebase/*-compat',
-        'build'
-      ],
-      {
+  try {
+    fs.writeFileSync(
+      `${projectRoot}/packages/auth/api-extractor.json`,
+      authApiConfigModified
+    );
+
+    if (skipBuild) {
+      await spawn('yarn', ['api-report'], {
         stdio: 'inherit'
-      }
+      });
+    } else {
+      // api-report is run as part of every build
+      await spawn(
+        'yarn',
+        [
+          'lerna',
+          'run',
+          '--scope',
+          '@firebase/*',
+          '--ignore',
+          '@firebase/*-compat',
+          'build'
+        ],
+        {
+          stdio: 'inherit'
+        }
+      );
+    }
+  } finally {
+    // Restore original auth api-extractor.json contents.
+    fs.writeFileSync(
+      `${projectRoot}/packages/auth/api-extractor.json`,
+      authApiConfigOriginal
+    );
+    // Restore original auth.api.md
+    fs.writeFileSync(
+      `${projectRoot}/common/api-review/auth.api.md`,
+      authApiReportOriginal
     );
   }
-
-  // Restore original auth api-extractor.json contents.
-  fs.writeFileSync(
-    `${projectRoot}/packages/auth/api-extractor.json`,
-    authApiConfigOriginal
-  );
-  // Restore original auth.api.md
-  fs.writeFileSync(
-    `${projectRoot}/common/api-review/auth.api.md`,
-    authApiReportOriginal
-  );
 
   if (!fs.existsSync(tmpDir)) {
     fs.mkdirSync(tmpDir);

--- a/scripts/docgen/docgen.ts
+++ b/scripts/docgen/docgen.ts
@@ -99,26 +99,29 @@ async function generateToc() {
       );
     }
   }
-  await spawn(
-    'yarn',
-    [
-      'api-documenter-devsite',
-      'toc',
-      '--input',
-      'temp',
-      '-p',
-      '/docs/reference/js',
-      '-j'
-    ],
-    { stdio: 'inherit' }
-  );
-  console.log(`Restoring excluded packages' json files.`);
-  for (const excludedPackage of EXCLUDED_PACKAGES) {
-    if (fs.existsSync(`${projectRoot}/temp/${excludedPackage}.skip`)) {
-      fs.renameSync(
-        `${projectRoot}/temp/${excludedPackage}.skip`,
-        `${projectRoot}/temp/${excludedPackage}.api.json`
-      );
+  try {
+    await spawn(
+      'yarn',
+      [
+        'api-documenter-devsite',
+        'toc',
+        '--input',
+        'temp',
+        '-p',
+        '/docs/reference/js',
+        '-j'
+      ],
+      { stdio: 'inherit' }
+    );
+  } finally {
+    console.log(`Restoring excluded packages' json files.`);
+    for (const excludedPackage of EXCLUDED_PACKAGES) {
+      if (fs.existsSync(`${projectRoot}/temp/${excludedPackage}.skip`)) {
+        fs.renameSync(
+          `${projectRoot}/temp/${excludedPackage}.skip`,
+          `${projectRoot}/temp/${excludedPackage}.api.json`
+        );
+      }
     }
   }
 }
@@ -131,6 +134,7 @@ async function generateDocs(
   const outputFolder = forDevsite ? 'docs-devsite' : 'docs';
   const command = forDevsite ? 'api-documenter-devsite' : 'api-documenter';
 
+  console.log(`Temporarily modifying auth api-extractor.json for docgen.`);
   // Use a special d.ts file for auth for doc gen only.
   const authApiConfigOriginal = fs.readFileSync(
     `${projectRoot}/packages/auth/api-extractor.json`,
@@ -175,6 +179,7 @@ async function generateDocs(
       );
     }
   } finally {
+    console.log(`Restoring original auth api-extractor.json contents.`);
     // Restore original auth api-extractor.json contents.
     fs.writeFileSync(
       `${projectRoot}/packages/auth/api-extractor.json`,


### PR DESCRIPTION
Docgen modifies some files (usually packages/auth/api-extractor.json, but other files for TOC generation) before running `yarn build` and `yarn api-report` steps. If the process fails or is aborted during those steps, those files will remain modified, and any future runs will only restore them back to that modified state.

This PR uses a try/finally to make sure the files are always restored no matter what. Yes, you can have a try/finally without a catch: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/try...catch#description

Tested it in the cases of a `yarn api-report` failure and success and the files are restored properly in both cases.