### PR TITLE
[Auth] Pin Chrome version 110.0.5481.177-1 for "Test Auth on Chrome and Node If Changed test"

### DIFF
--- a/.github/workflows/test-changed-auth.yml
+++ b/.github/workflows/test-changed-auth.yml
@@ -18,7 +18,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install wget
           sudo wget http://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_110.0.5481.177-1_amd64.deb
-          sudo apt-get install -f ./google-chrome-stable_110.0.5481.177-1_amd64.deb
+          sudo apt-get install -f ./google-chrome-stable_110.0.5481.177-1_amd64.deb --allow-downgrades
       - name: Checkout Repo
         uses: actions/checkout@master
         with:

--- a/.github/workflows/test-changed-auth.yml
+++ b/.github/workflows/test-changed-auth.yml
@@ -16,7 +16,9 @@ jobs:
       - name: install Chrome stable
         run: |
           sudo apt-get update
-          sudo apt-get install google-chrome-stable
+          apt-get install wget
+          wget http://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_110.0.5481.177-1_amd64.deb
+          apt-get install -f ./google-chrome-stable_110.0.5481.177-1_amd64.deb
       - name: Checkout Repo
         uses: actions/checkout@master
         with:

--- a/.github/workflows/test-changed-auth.yml
+++ b/.github/workflows/test-changed-auth.yml
@@ -18,7 +18,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install wget
           sudo wget http://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_110.0.5481.177-1_amd64.deb
-          apt-get install -f ./google-chrome-stable_110.0.5481.177-1_amd64.deb
+          sudo apt-get install -f ./google-chrome-stable_110.0.5481.177-1_amd64.deb
       - name: Checkout Repo
         uses: actions/checkout@master
         with:

--- a/.github/workflows/test-changed-auth.yml
+++ b/.github/workflows/test-changed-auth.yml
@@ -16,7 +16,7 @@ jobs:
       - name: install Chrome stable
         run: |
           sudo apt-get update
-          apt-get install wget
+          sudo apt-get install wget
           wget http://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_110.0.5481.177-1_amd64.deb
           apt-get install -f ./google-chrome-stable_110.0.5481.177-1_amd64.deb
       - name: Checkout Repo

--- a/.github/workflows/test-changed-auth.yml
+++ b/.github/workflows/test-changed-auth.yml
@@ -17,7 +17,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install wget
-          wget http://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_110.0.5481.177-1_amd64.deb
+          sudo wget http://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_110.0.5481.177-1_amd64.deb
           apt-get install -f ./google-chrome-stable_110.0.5481.177-1_amd64.deb
       - name: Checkout Repo
         uses: actions/checkout@master

--- a/.github/workflows/test-changed-auth.yml
+++ b/.github/workflows/test-changed-auth.yml
@@ -14,6 +14,8 @@ jobs:
     steps:
       # install Chrome first, so the correct version of webdriver can be installed by chromedriver when setting up the repo
       - name: install Chrome stable
+        # Install Chrome version 110.0.5481.177-1 as test starts to fail on version 111.0.5563.64-1.
+        # We will retry to use the latest, once Chrome releases stable version 112 (April 4 ETA).
         run: |
           sudo apt-get update
           sudo apt-get install wget

--- a/packages/auth/src/api/authentication/email_link.ts
+++ b/packages/auth/src/api/authentication/email_link.ts
@@ -30,6 +30,7 @@ export interface SignInWithEmailLinkRequest {
   tenantId?: string;
 }
 
+// add a comment to run packages/auth tests
 export interface SignInWithEmailLinkResponse extends IdTokenResponse {
   email: string;
   isNewUser: boolean;

--- a/packages/auth/src/api/authentication/email_link.ts
+++ b/packages/auth/src/api/authentication/email_link.ts
@@ -30,7 +30,6 @@ export interface SignInWithEmailLinkRequest {
   tenantId?: string;
 }
 
-// add a comment to run packages/auth tests
 export interface SignInWithEmailLinkResponse extends IdTokenResponse {
   email: string;
   isNewUser: boolean;


### PR DESCRIPTION
Auth CI tests are failing on all recent PRs due to new version of Chrome. 
Pinning Chrome version 110.0.5481.177-1 for "Test Auth on Chrome and Node If Changed test" where the tests passed previously to avoid this.

Tests pass locally on mac (in some setups) and fail different tests in linux + 111 chrome version. Sending this PR to unblock auth PRs for the upcoming release.

We will retry to use the latest, once Chrome releases stable version 112 (April 4 ETA).