### PR TITLE
Flag doc changes during staging release

### DIFF
--- a/.github/workflows/release-staging.yml
+++ b/.github/workflows/release-staging.yml
@@ -132,14 +132,25 @@ jobs:
         -H "Authorization:Bearer $OSS_BOT_GITHUB_TOKEN" \
         -d "{\"event_type\":\"staging-tests\", \"client_payload\":{\"versionOrTag\":\"$VERSION_OR_TAG\"}}" \
         https://api.github.com/repos/firebase/firebase-js-sdk/dispatches
+    - name: Check for changes requiring a reference doc publish
+      id: docs-check
+      run: git diff --exit-code docs-devsite
+    - name: No diff, docs not needed
+      if: ${{ success() }}
+      run: echo "DOCS_NEEDED=false" >> $GITHUB_STATE
+    - name: Diff returned something, docs are needed
+      if: ${{ failure() }}
+      run: echo "DOCS_NEEDED=true" >> $GITHUB_STATE
     - name: Log to release tracker
       # Sends release information to cloud functions endpoint of release tracker.
+      if: ${{ always() }}
       run: |
         DATE=$(date +'%m/%d/%Y')
         BASE_VERSION=${{ steps.get-version.outputs.BASE_VERSION }}
         STAGING_VERSION=${{ steps.get-version.outputs.STAGING_VERSION }}
         OPERATOR=${{ github.actor }}
         RELEASE_TRACKER_URL=${{ secrets.RELEASE_TRACKER_URL }}
+        DOCS_NEEDED=${{ steps.docs-check.outputs.DOCS_NEEDED }}
         curl -X POST -H "Content-Type:application/json" \
-        -d "{\"version\":\"$BASE_VERSION\",\"tag\":\"$STAGING_VERSION\",\"date\":\"$DATE\",\"operator\":\"$OPERATOR\"}" \
+        -d "{\"version\":\"$BASE_VERSION\",\"tag\":\"$STAGING_VERSION\",\"date\":\"$DATE\",\"operator\":\"$OPERATOR\",\"docs_needed\":\"$DOCS_NEEDED\"}" \
         $RELEASE_TRACKER_URL/logStaging

--- a/.github/workflows/release-staging.yml
+++ b/.github/workflows/release-staging.yml
@@ -134,7 +134,7 @@ jobs:
         https://api.github.com/repos/firebase/firebase-js-sdk/dispatches
     - name: Check for changes requiring a reference doc publish
       id: docs-check
-      run: git diff --exit-code docs-devsite
+      run: git diff --exit-code origin/master HEAD docs-devsite
     - name: No diff, docs not needed
       if: ${{ success() }}
       run: echo "DOCS_NEEDED=false" >> $GITHUB_STATE


### PR DESCRIPTION
Runs a diff against `origin/master` on the `docs-devsite` dir during the staging workflow. If a diff is found, it will send a `docs_needed=true` param to the release tracker. I'll make separate changes to the [release tracker](https://release-tracker.web.app/) to then put "docs needed" in the reference CL field and highlight it red.

Need to test this, so will wait until after this week's release is done, to not interfere with it.