### PR TITLE
Fix ToTP typings issue

### DIFF
--- a/.changeset/soft-zoos-listen.md
+++ b/.changeset/soft-zoos-listen.md
@@ -1,0 +1,5 @@
+---
+'@firebase/auth': patch
+---
+
+Fix typings for `TotpMultiFactorGenerator`. This fixes a reversion in 9.19.0.

--- a/common/api-review/auth.api.md
+++ b/common/api-review/auth.api.md
@@ -754,8 +754,7 @@ export interface TotpMultiFactorAssertion extends MultiFactorAssertion {
 export class TotpMultiFactorGenerator {
     static assertionForEnrollment(secret: TotpSecret, oneTimePassword: string): TotpMultiFactorAssertion;
     static assertionForSignIn(enrollmentId: string, oneTimePassword: string): TotpMultiFactorAssertion;
-    // Warning: (ae-forgotten-export) The symbol "FactorId" needs to be exported by the entry point index.d.ts
-    static FACTOR_ID: FactorId_2;
+    static FACTOR_ID: "totp";
     static generateSecret(session: MultiFactorSession): Promise<TotpSecret>;
 }
 

--- a/docs-devsite/auth.totpmultifactorgenerator.md
+++ b/docs-devsite/auth.totpmultifactorgenerator.md
@@ -22,7 +22,7 @@ export declare class TotpMultiFactorGenerator
 
 |  Property | Modifiers | Type | Description |
 |  --- | --- | --- | --- |
-|  [FACTOR\_ID](./auth.totpmultifactorgenerator.md#totpmultifactorgeneratorfactor_id) | <code>static</code> | FactorId | The identifier of the TOTP second factor: <code>totp</code>. |
+|  [FACTOR\_ID](./auth.totpmultifactorgenerator.md#totpmultifactorgeneratorfactor_id) | <code>static</code> | "totp" | The identifier of the TOTP second factor: <code>totp</code>. |
 
 ## Methods
 
@@ -39,7 +39,7 @@ The identifier of the TOTP second factor: `totp`<!-- -->.
 <b>Signature:</b>
 
 ```typescript
-static FACTOR_ID: FactorId;
+static FACTOR_ID: "totp";
 ```
 
 ## TotpMultiFactorGenerator.assertionForEnrollment()

--- a/docs-devsite/auth.totpmultifactorgenerator.md
+++ b/docs-devsite/auth.totpmultifactorgenerator.md
@@ -22,7 +22,7 @@ export declare class TotpMultiFactorGenerator
 
 |  Property | Modifiers | Type | Description |
 |  --- | --- | --- | --- |
-|  [FACTOR\_ID](./auth.totpmultifactorgenerator.md#totpmultifactorgeneratorfactor_id) | <code>static</code> | "totp" | The identifier of the TOTP second factor: <code>totp</code>. |
+|  [FACTOR\_ID](./auth.totpmultifactorgenerator.md#totpmultifactorgeneratorfactor_id) | <code>static</code> | 'totp' | The identifier of the TOTP second factor: <code>totp</code>. |
 
 ## Methods
 
@@ -39,7 +39,7 @@ The identifier of the TOTP second factor: `totp`<!-- -->.
 <b>Signature:</b>
 
 ```typescript
-static FACTOR_ID: "totp";
+static FACTOR_ID: 'totp';
 ```
 
 ## TotpMultiFactorGenerator.assertionForEnrollment()

--- a/packages/auth/src/mfa/assertions/totp.ts
+++ b/packages/auth/src/mfa/assertions/totp.ts
@@ -107,7 +107,7 @@ export class TotpMultiFactorGenerator {
   /**
    * The identifier of the TOTP second factor: `totp`.
    */
-  static FACTOR_ID = FactorId.TOTP;
+  static FACTOR_ID: 'totp' = FactorId.TOTP;
 }
 
 export class TotpMultiFactorAssertionImpl


### PR DESCRIPTION
The const enum is internal and not exported with public types, causing an error since it's referenced.

I believe other publicly exported auth classes avoid this by following the pattern here: https://github.com/firebase/firebase-js-sdk/blob/1d5646ed68ccc59dde27983bfe2575db5ecb528d/packages/auth/src/platform_browser/providers/phone.ts#L55

So I've done the same for `TotpMultiFactorGenerator`.

Fixes https://github.com/firebase/firebase-js-sdk/issues/7174