### PR TITLE
Ensure e2e tests fail on TS errors

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@master
       - name: Set up Node (14)
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@master
         with:
           node-version: 14.x
       - name: install Chrome stable

--- a/e2e/karma.conf.js
+++ b/e2e/karma.conf.js
@@ -83,7 +83,8 @@ module.exports = function (config) {
         'esModuleInterop': true,
         'sourceMap': true,
         'target': 'es5',
-        'importHelpers': true
+        'importHelpers': true,
+        'noEmitOnError': true,
       }
     },
     plugins: [

--- a/e2e/karma.conf.js
+++ b/e2e/karma.conf.js
@@ -84,7 +84,7 @@ module.exports = function (config) {
         'sourceMap': true,
         'target': 'es5',
         'importHelpers': true,
-        'noEmitOnError': true,
+        'noEmitOnError': true
       }
     },
     plugins: [


### PR DESCRIPTION
Use `noEmitOnError` TS config flag to ensure karma E2E tests fail if TS has a compile error.

Also getting a warning about actions/setup-node@v2 being deprecated - we should update this in all workflows.

Otherwise TS failures like the one in this E2E job are non-blocking and the workflow is considered passing https://github.com/firebase/firebase-js-sdk/actions/runs/4550223341