### PR TITLE
[docs] Update service worker web notifications FcmOptions.link property description

### DIFF
--- a/docs-devsite/messaging_sw.fcmoptions.md
+++ b/docs-devsite/messaging_sw.fcmoptions.md
@@ -37,7 +37,7 @@ analyticsLabel?: string;
 
 ## FcmOptions.link
 
-The link to open when the user clicks on the notification.
+The link to open when the user clicks on the notification. For all URL values, HTTPS is required. It is required that the hostname of this property be the same as the hostname of the registered service worker handling the notification.
 
 <b>Signature:</b>
 


### PR DESCRIPTION
Documenting required conditions in the current [messaging service worker implementation](https://github.com/firebase/firebase-js-sdk/blob/37de4d015c9d0ed5341519533eb753b58ecbcff0/packages/messaging/src/listeners/sw-listeners.ts#L137) for the service worker to automatically handler click events on Web Notifications. 