### PR TITLE
Catch all recaptcha errors

### DIFF
--- a/.changeset/shaggy-zebras-leave.md
+++ b/.changeset/shaggy-zebras-leave.md
@@ -1,0 +1,5 @@
+---
+'@firebase/app-check': patch
+---
+
+Catch all ReCAPTCHA errors and, if caught, prevent App Check from making a request to the exchange endpoint.

--- a/packages/app-check/src/api.test.ts
+++ b/packages/app-check/src/api.test.ts
@@ -60,6 +60,10 @@ describe('api', () => {
   let storageReadStub: SinonStub;
   let storageWriteStub: SinonStub;
 
+  function setRecaptchaSuccess(isSuccess: boolean = true): void {
+    getStateReference(app).reCAPTCHAState!.succeeded = isSuccess;
+  }
+
   beforeEach(() => {
     app = getFullApp();
     storageReadStub = stub(storage, 'readTokenFromStorage').resolves(undefined);
@@ -291,6 +295,8 @@ describe('api', () => {
         isTokenAutoRefreshEnabled: true
       });
 
+      setRecaptchaSuccess(true);
+
       expect(getStateReference(app).tokenObservers.length).to.equal(1);
 
       const fakeRecaptchaToken = 'fake-recaptcha-token';
@@ -334,6 +340,8 @@ describe('api', () => {
         provider: new ReCaptchaV3Provider(FAKE_SITE_KEY),
         isTokenAutoRefreshEnabled: true
       });
+
+      setRecaptchaSuccess(true);
 
       expect(getStateReference(app).tokenObservers.length).to.equal(1);
 
@@ -390,6 +398,8 @@ describe('api', () => {
         provider: new ReCaptchaV3Provider(FAKE_SITE_KEY),
         isTokenAutoRefreshEnabled: false
       });
+
+      setRecaptchaSuccess(true);
 
       expect(getStateReference(app).tokenObservers.length).to.equal(0);
 

--- a/packages/app-check/src/internal-api.test.ts
+++ b/packages/app-check/src/internal-api.test.ts
@@ -70,6 +70,15 @@ describe('internal api', () => {
   let storageReadStub: SinonStub;
   let storageWriteStub: SinonStub;
 
+  function stubGetRecaptchaToken(
+    token: string = fakeRecaptchaToken,
+    isSuccess: boolean = true
+  ): SinonStub {
+    getStateReference(app).reCAPTCHAState!.succeeded = isSuccess;
+
+    return stub(reCAPTCHA, 'getToken').returns(Promise.resolve(token));
+  }
+
   beforeEach(() => {
     app = getFullApp();
     storageReadStub = stub(storage, 'readTokenFromStorage').resolves(undefined);
@@ -104,9 +113,7 @@ describe('internal api', () => {
         provider: new ReCaptchaV3Provider(FAKE_SITE_KEY)
       });
 
-      const reCAPTCHASpy = stub(reCAPTCHA, 'getToken').returns(
-        Promise.resolve(fakeRecaptchaToken)
-      );
+      const reCAPTCHASpy = stubGetRecaptchaToken();
       const exchangeTokenStub: SinonStub = stub(
         client,
         'exchangeToken'
@@ -127,9 +134,8 @@ describe('internal api', () => {
         provider: new ReCaptchaEnterpriseProvider(FAKE_SITE_KEY)
       });
 
-      const reCAPTCHASpy = stub(reCAPTCHA, 'getToken').returns(
-        Promise.resolve(fakeRecaptchaToken)
-      );
+      const reCAPTCHASpy = stubGetRecaptchaToken();
+
       const exchangeTokenStub: SinonStub = stub(
         client,
         'exchangeToken'
@@ -151,9 +157,7 @@ describe('internal api', () => {
         provider: new ReCaptchaV3Provider(FAKE_SITE_KEY)
       });
 
-      const reCAPTCHASpy = stub(reCAPTCHA, 'getToken').returns(
-        Promise.resolve(fakeRecaptchaToken)
-      );
+      const reCAPTCHASpy = stubGetRecaptchaToken();
 
       const error = new Error('oops, something went wrong');
       stub(client, 'exchangeToken').returns(Promise.reject(error));
@@ -167,6 +171,26 @@ describe('internal api', () => {
       });
       expect(errorStub.args[0][1].message).to.include(
         'oops, something went wrong'
+      );
+      errorStub.restore();
+    });
+
+    it('resolves with a dummy token and an error if recaptcha failed', async () => {
+      const errorStub = stub(console, 'error');
+      const appCheck = initializeAppCheck(app, {
+        provider: new ReCaptchaV3Provider(FAKE_SITE_KEY)
+      });
+
+      const reCAPTCHASpy = stubGetRecaptchaToken('', false);
+      const exchangeTokenStub = stub(client, 'exchangeToken');
+
+      const token = await getToken(appCheck as AppCheckService);
+
+      expect(reCAPTCHASpy).to.be.called;
+      expect(exchangeTokenStub).to.not.be.called;
+      expect(token.token).to.equal(formatDummyToken(defaultTokenErrorData));
+      expect(errorStub.args[0][1].message).to.include(
+        AppCheckError.RECAPTCHA_ERROR
       );
       errorStub.restore();
     });
@@ -213,7 +237,7 @@ describe('internal api', () => {
         isTokenAutoRefreshEnabled: true
       });
 
-      stub(reCAPTCHA, 'getToken').returns(Promise.resolve(fakeRecaptchaToken));
+      stubGetRecaptchaToken();
       stub(client, 'exchangeToken').returns(
         Promise.resolve(fakeRecaptchaAppCheckToken)
       );
@@ -247,7 +271,7 @@ describe('internal api', () => {
         provider: new ReCaptchaV3Provider(FAKE_SITE_KEY),
         isTokenAutoRefreshEnabled: true
       });
-      stub(reCAPTCHA, 'getToken').returns(Promise.resolve(fakeRecaptchaToken));
+      stubGetRecaptchaToken();
       stub(client, 'exchangeToken').rejects('exchange error');
       const listener1 = spy();
       const errorFn1 = spy();
@@ -271,7 +295,7 @@ describe('internal api', () => {
         provider: new ReCaptchaV3Provider(FAKE_SITE_KEY),
         isTokenAutoRefreshEnabled: true
       });
-      stub(reCAPTCHA, 'getToken').returns(Promise.resolve(fakeRecaptchaToken));
+      stubGetRecaptchaToken();
       stub(client, 'exchangeToken').returns(
         Promise.resolve(fakeRecaptchaAppCheckToken)
       );
@@ -324,7 +348,7 @@ describe('internal api', () => {
         provider: new ReCaptchaV3Provider(FAKE_SITE_KEY)
       });
 
-      stub(reCAPTCHA, 'getToken').returns(Promise.resolve(fakeRecaptchaToken));
+      stubGetRecaptchaToken();
       stub(client, 'exchangeToken').returns(
         Promise.resolve(fakeRecaptchaAppCheckToken)
       );
@@ -365,7 +389,7 @@ describe('internal api', () => {
         token: fakeRecaptchaAppCheckToken
       });
 
-      stub(reCAPTCHA, 'getToken').returns(Promise.resolve(fakeRecaptchaToken));
+      stubGetRecaptchaToken();
       stub(client, 'exchangeToken').returns(
         Promise.resolve({
           token: 'new-recaptcha-app-check-token',
@@ -390,7 +414,7 @@ describe('internal api', () => {
         cachedTokenPromise: undefined
       });
 
-      stub(reCAPTCHA, 'getToken').returns(Promise.resolve(fakeRecaptchaToken));
+      stubGetRecaptchaToken();
       stub(client, 'exchangeToken').returns(
         Promise.resolve({
           token: 'new-recaptcha-app-check-token',
@@ -431,7 +455,7 @@ describe('internal api', () => {
         cachedTokenPromise: undefined
       });
 
-      stub(reCAPTCHA, 'getToken').returns(Promise.resolve(fakeRecaptchaToken));
+      stubGetRecaptchaToken();
       let count = 0;
       stub(client, 'exchangeToken').callsFake(
         () =>
@@ -485,7 +509,7 @@ describe('internal api', () => {
         }
       });
 
-      stub(reCAPTCHA, 'getToken').returns(Promise.resolve(fakeRecaptchaToken));
+      stubGetRecaptchaToken();
       stub(client, 'exchangeToken').returns(
         Promise.resolve({
           token: 'new-recaptcha-app-check-token',
@@ -532,7 +556,7 @@ describe('internal api', () => {
         issuedAtTimeMillis: 0
       };
 
-      stub(reCAPTCHA, 'getToken').returns(Promise.resolve(fakeRecaptchaToken));
+      stubGetRecaptchaToken();
       stub(client, 'exchangeToken').returns(Promise.resolve(freshToken));
 
       expect(await getToken(appCheck as AppCheckService)).to.deep.equal({
@@ -556,7 +580,7 @@ describe('internal api', () => {
         token: fakeRecaptchaAppCheckToken
       });
 
-      stub(reCAPTCHA, 'getToken').returns(Promise.resolve(fakeRecaptchaToken));
+      stubGetRecaptchaToken();
       stub(client, 'exchangeToken').returns(Promise.reject(new Error('blah')));
 
       const tokenResult = await getToken(appCheck as AppCheckService, true);
@@ -589,6 +613,7 @@ describe('internal api', () => {
       const appCheck = initializeAppCheck(app, {
         provider: new ReCaptchaV3Provider(FAKE_SITE_KEY)
       });
+      stubGetRecaptchaToken();
       const warnStub = stub(logger, 'warn');
       stub(client, 'exchangeToken').returns(
         Promise.reject(
@@ -615,6 +640,7 @@ describe('internal api', () => {
       const appCheck = initializeAppCheck(app, {
         provider: new ReCaptchaV3Provider(FAKE_SITE_KEY)
       });
+      stubGetRecaptchaToken();
       const warnStub = stub(logger, 'warn');
       stub(client, 'exchangeToken').returns(
         Promise.reject(
@@ -765,6 +791,8 @@ describe('internal api', () => {
         })
       );
 
+      stubGetRecaptchaToken();
+
       addTokenListener(
         appCheck as AppCheckService,
         ListenerType.INTERNAL,
@@ -798,6 +826,8 @@ describe('internal api', () => {
           issuedAtTimeMillis: 0
         }
       });
+
+      stubGetRecaptchaToken();
 
       const fakeListener: AppCheckTokenListener = stub();
 
@@ -838,6 +868,8 @@ describe('internal api', () => {
         }
       });
 
+      stubGetRecaptchaToken();
+
       const fakeListener: AppCheckTokenListener = stub();
 
       const fakeExchange = stub(client, 'exchangeToken').returns(
@@ -865,6 +897,8 @@ describe('internal api', () => {
         provider: new ReCaptchaV3Provider(FAKE_SITE_KEY),
         isTokenAutoRefreshEnabled: true
       });
+
+      stubGetRecaptchaToken();
       setInitialState(app, {
         ...getStateReference(app),
         token: {
@@ -905,6 +939,8 @@ describe('internal api', () => {
         provider: new ReCaptchaV3Provider(FAKE_SITE_KEY),
         isTokenAutoRefreshEnabled: true
       });
+
+      stubGetRecaptchaToken();
       setInitialState(app, {
         ...getStateReference(app),
         token: {

--- a/packages/app-check/src/providers.ts
+++ b/packages/app-check/src/providers.ts
@@ -35,6 +35,7 @@ import {
   initializeV3 as initializeRecaptchaV3,
   initializeEnterprise as initializeRecaptchaEnterprise
 } from './recaptcha';
+import { getStateReference } from './state';
 import { AppCheckProvider, AppCheckTokenInternal, ThrottleData } from './types';
 import { getDurationString } from './util';
 
@@ -73,6 +74,10 @@ export class ReCaptchaV3Provider implements AppCheckProvider {
         throw ERROR_FACTORY.create(AppCheckError.RECAPTCHA_ERROR);
       }
     );
+    // Check if a failure state was set by the recaptcha "error-callback".
+    if (!getStateReference(this._app!).reCAPTCHAState?.succeeded) {
+      throw ERROR_FACTORY.create(AppCheckError.RECAPTCHA_ERROR);
+    }
     let result;
     try {
       result = await exchangeToken(

--- a/packages/app-check/src/providers.ts
+++ b/packages/app-check/src/providers.ts
@@ -164,6 +164,10 @@ export class ReCaptchaEnterpriseProvider implements AppCheckProvider {
         throw ERROR_FACTORY.create(AppCheckError.RECAPTCHA_ERROR);
       }
     );
+    // Check if a failure state was set by the recaptcha "error-callback".
+    if (!getStateReference(this._app!).reCAPTCHAState?.succeeded) {
+      throw ERROR_FACTORY.create(AppCheckError.RECAPTCHA_ERROR);
+    }
     let result;
     try {
       result = await exchangeToken(

--- a/packages/app-check/src/recaptcha.test.ts
+++ b/packages/app-check/src/recaptcha.test.ts
@@ -17,7 +17,7 @@
 
 import '../test/setup';
 import { expect } from 'chai';
-import { stub } from 'sinon';
+import { stub, match } from 'sinon';
 import { deleteApp, FirebaseApp } from '@firebase/app';
 import {
   getFullApp,
@@ -93,7 +93,9 @@ describe('recaptcha', () => {
 
       expect(renderStub).to.be.calledWith(`fire_app_check_${app.name}`, {
         sitekey: FAKE_SITE_KEY,
-        size: 'invisible'
+        size: 'invisible',
+        callback: match.any,
+        'error-callback': match.any
       });
 
       expect(getStateReference(app).reCAPTCHAState?.widgetId).to.equal(
@@ -141,7 +143,9 @@ describe('recaptcha', () => {
 
       expect(renderStub).to.be.calledWith(`fire_app_check_${app.name}`, {
         sitekey: FAKE_SITE_KEY,
-        size: 'invisible'
+        size: 'invisible',
+        callback: match.any,
+        'error-callback': match.any
       });
 
       expect(getStateReference(app).reCAPTCHAState?.widgetId).to.equal(

--- a/packages/app-check/src/recaptcha.ts
+++ b/packages/app-check/src/recaptcha.ts
@@ -143,11 +143,19 @@ function renderInvisibleWidget(
   grecaptcha: GreCAPTCHA,
   container: string
 ): void {
+  const state = getStateReference(app);
   const widgetId = grecaptcha.render(container, {
     sitekey: siteKey,
-    size: 'invisible'
+    size: 'invisible',
+    // Success callback - set state
+    callback: () => {
+      getStateReference(app).reCAPTCHAState!.succeeded = true;
+    },
+    // Failure callback - set state
+    'error-callback': () => {
+      getStateReference(app).reCAPTCHAState!.succeeded = false;
+    }
   });
-  const state = getStateReference(app);
 
   state.reCAPTCHAState = {
     ...state.reCAPTCHAState!, // state.reCAPTCHAState is set in the initialize()
@@ -191,4 +199,6 @@ export interface GreCAPTCHA {
 export interface GreCAPTCHARenderOption {
   sitekey: string;
   size: 'invisible';
+  callback: () => void;
+  'error-callback': () => void;
 }

--- a/packages/app-check/src/recaptcha.ts
+++ b/packages/app-check/src/recaptcha.ts
@@ -143,7 +143,6 @@ function renderInvisibleWidget(
   grecaptcha: GreCAPTCHA,
   container: string
 ): void {
-  const state = getStateReference(app);
   const widgetId = grecaptcha.render(container, {
     sitekey: siteKey,
     size: 'invisible',
@@ -156,6 +155,8 @@ function renderInvisibleWidget(
       getStateReference(app).reCAPTCHAState!.succeeded = false;
     }
   });
+  
+  const state = getStateReference(app);
 
   state.reCAPTCHAState = {
     ...state.reCAPTCHAState!, // state.reCAPTCHAState is set in the initialize()

--- a/packages/app-check/src/recaptcha.ts
+++ b/packages/app-check/src/recaptcha.ts
@@ -155,7 +155,7 @@ function renderInvisibleWidget(
       getStateReference(app).reCAPTCHAState!.succeeded = false;
     }
   });
-  
+
   const state = getStateReference(app);
 
   state.reCAPTCHAState = {

--- a/packages/app-check/src/state.ts
+++ b/packages/app-check/src/state.ts
@@ -39,6 +39,8 @@ export interface AppCheckState {
 export interface ReCAPTCHAState {
   initialized: Deferred<GreCAPTCHA>;
   widgetId?: string;
+  // True if the most recent recaptcha check succeeded.
+  succeeded?: boolean;
 }
 
 export interface DebugState {

--- a/packages/app-check/test/util.ts
+++ b/packages/app-check/test/util.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { FirebaseApp, initializeApp, _registerComponent } from '@firebase/app';
+import { FirebaseApp, initializeApp, _addOrOverwriteComponent, _registerComponent } from '@firebase/app';
 import {
   GreCAPTCHA,
   GreCAPTCHATopLevel,
@@ -62,11 +62,14 @@ export function getFakeAppCheck(app: FirebaseApp): AppCheck {
 
 export function getFullApp(): FirebaseApp {
   const app = initializeApp(fakeConfig);
-  _registerComponent(
+  _addOrOverwriteComponent(app,
+    //@ts-ignore
     new Component(
       'heartbeat',
       () => {
-        return {} as any;
+        return {
+          triggerHeartbeat: () => {}
+        } as any;
       },
       ComponentType.PUBLIC
     )

--- a/packages/app-check/test/util.ts
+++ b/packages/app-check/test/util.ts
@@ -15,7 +15,12 @@
  * limitations under the License.
  */
 
-import { FirebaseApp, initializeApp, _addOrOverwriteComponent, _registerComponent } from '@firebase/app';
+import {
+  FirebaseApp,
+  initializeApp,
+  _addOrOverwriteComponent,
+  _registerComponent
+} from '@firebase/app';
 import {
   GreCAPTCHA,
   GreCAPTCHATopLevel,
@@ -62,7 +67,8 @@ export function getFakeAppCheck(app: FirebaseApp): AppCheck {
 
 export function getFullApp(): FirebaseApp {
   const app = initializeApp(fakeConfig);
-  _addOrOverwriteComponent(app,
+  _addOrOverwriteComponent(
+    app,
     //@ts-ignore
     new Component(
       'heartbeat',


### PR DESCRIPTION
We were catching local errors in recaptcha by `catch`ing the result of `grecaptcha.execute`. It turns out that not all recaptcha errors result in `recaptcha.execute` throwing. Errors can also be caught in `error-callback` params passed to `grecaptcha.render`. See https://developers.google.com/recaptcha/docs/invisible for parameters accepted by `grecaptcha.render`.

These callbacks will set a boolean variable in our AppCheck state object, which will be checked in provider.getToken() methods for the two reCAPTCHA providers, and provider.getToken() will throw with a RECAPTCHA_ERROR if false. This will prevent the main `getToken()` in internal-api.ts from going on to call the exchange endpoint, since we already know we don't have a usable reCAPTCHA token to send. This will then prevent a 503 error caused by sending a bad token, which will prevent a 1 day backoff being imposed.

This means that a device that ran into a reCAPTCHA error while asleep, or in a background tab, or some other temporary reason, won't be locked off from retrying on the next request.

This may help with errors such as:
https://github.com/firebase/firebase-js-sdk/issues/7116
and
https://github.com/firebase/firebase-js-sdk/issues/6708