### PR TITLE
Fix "Update API reports" workflow

### DIFF
--- a/.github/workflows/update-api-reports.yml
+++ b/.github/workflows/update-api-reports.yml
@@ -14,7 +14,7 @@ jobs:
       uses: actions/checkout@master
       with:
         # checkout HEAD commit instead of merge commit
-        ref: ${{ github.event.pull_request.head.sha }}
+        ref: ${{ github.event.pull_request.head.ref }}
         token: ${{ github.token }}
     - name: Set up Node (14)
       uses: actions/setup-node@v2

--- a/common/api-review/auth.api.md
+++ b/common/api-review/auth.api.md
@@ -754,7 +754,7 @@ export interface TotpMultiFactorAssertion extends MultiFactorAssertion {
 export class TotpMultiFactorGenerator {
     static assertionForEnrollment(secret: TotpSecret, oneTimePassword: string): TotpMultiFactorAssertion;
     static assertionForSignIn(enrollmentId: string, oneTimePassword: string): TotpMultiFactorAssertion;
-    static FACTOR_ID: "totp";
+    static FACTOR_ID: 'totp';
     static generateSecret(session: MultiFactorSession): Promise<TotpSecret>;
 }
 


### PR DESCRIPTION
Fix a bug in the "Update API reports" workflow as seen in runs like https://github.com/firebase/firebase-js-sdk/pull/7205#issue-1657951238 as a result of upgrading EndBug/add-and-commit to v9.