### PR TITLE
Revert "Install latest chrome version for "Test Auth on Chrome and Node If Changed" test"

### DIFF
--- a/.github/workflows/test-changed-auth.yml
+++ b/.github/workflows/test-changed-auth.yml
@@ -14,13 +14,13 @@ jobs:
     steps:
       # install Chrome first, so the correct version of webdriver can be installed by chromedriver when setting up the repo
       - name: install Chrome stable
-        # Install Chrome unstable version 112.0.5615.49 as test starts to fail on version 111.
-        # We will unpin, once version 112 becomes stable.
+        # Install Chrome version 110.0.5481.177-1 as test starts to fail on version 111.
+        # We will retry to use the latest, once version 112 becomes stable.
         run: |
           sudo apt-get update
           sudo apt-get install wget
-          sudo wget http://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-unstable_112.0.5615.49_amd64.deb
-          sudo apt-get install -f ./google-chrome-unstable_112.0.5615.49_amd64.deb --allow-downgrades
+          sudo wget http://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_110.0.5481.177-1_amd64.deb
+          sudo apt-get install -f ./google-chrome-stable_110.0.5481.177-1_amd64.deb --allow-downgrades
       - name: Checkout Repo
         uses: actions/checkout@master
         with:

--- a/.github/workflows/test-changed-auth.yml
+++ b/.github/workflows/test-changed-auth.yml
@@ -14,13 +14,13 @@ jobs:
     steps:
       # install Chrome first, so the correct version of webdriver can be installed by chromedriver when setting up the repo
       - name: install Chrome stable
-        # Install Chrome version 112.0.5615.49 as test starts to fail on version 111.
+        # Install Chrome unstable version 112.0.5615.49 as test starts to fail on version 111.
         # We will unpin, once version 112 becomes stable.
         run: |
           sudo apt-get update
           sudo apt-get install wget
-          sudo wget http://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_112.0.5615.49_amd64.deb
-          sudo apt-get install -f ./google-chrome-stable_112.0.5615.49_amd64.deb --allow-downgrades
+          sudo wget http://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-unstable_112.0.5615.49_amd64.deb
+          sudo apt-get install -f ./google-chrome-unstable_112.0.5615.49_amd64.deb --allow-downgrades
       - name: Checkout Repo
         uses: actions/checkout@master
         with:

--- a/.github/workflows/test-changed-auth.yml
+++ b/.github/workflows/test-changed-auth.yml
@@ -14,9 +14,13 @@ jobs:
     steps:
       # install Chrome first, so the correct version of webdriver can be installed by chromedriver when setting up the repo
       - name: install Chrome stable
+        # Install Chrome version 112.0.5615.49 as test starts to fail on version 111.
+        # We will unpin, once version 112 becomes stable.
         run: |
           sudo apt-get update
-          sudo apt-get install google-chrome-stable
+          sudo apt-get install wget
+          sudo wget http://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_112.0.5615.49_amd64.deb
+          sudo apt-get install -f ./google-chrome-stable_112.0.5615.49_amd64.deb --allow-downgrades
       - name: Checkout Repo
         uses: actions/checkout@master
         with:

--- a/packages/auth/src/api/authentication/email_link.ts
+++ b/packages/auth/src/api/authentication/email_link.ts
@@ -30,6 +30,7 @@ export interface SignInWithEmailLinkRequest {
   tenantId?: string;
 }
 
+// add a comment to trigger packages/auth CI tests
 export interface SignInWithEmailLinkResponse extends IdTokenResponse {
   email: string;
   isNewUser: boolean;

--- a/packages/auth/src/api/authentication/email_link.ts
+++ b/packages/auth/src/api/authentication/email_link.ts
@@ -30,7 +30,6 @@ export interface SignInWithEmailLinkRequest {
   tenantId?: string;
 }
 
-// add a comment to trigger packages/auth CI tests
 export interface SignInWithEmailLinkResponse extends IdTokenResponse {
   email: string;
   isNewUser: boolean;


### PR DESCRIPTION
This reverts https://github.com/firebase/firebase-js-sdk/pull/7197 which unpinned the chrome version in "Test Auth on Chrome and Node If Changed".

The test still fails on version 111. Tests passed in the above PR because there were no code changes to auth.

Chrome version 112 has not become stable yet, so `sudo apt-get install google-chrome-stable` still installs version 111.

