### PR TITLE
Fix doc change detection logic

### DIFF
--- a/.github/workflows/release-staging.yml
+++ b/.github/workflows/release-staging.yml
@@ -134,7 +134,9 @@ jobs:
         https://api.github.com/repos/firebase/firebase-js-sdk/dispatches
     - name: Check for changes requiring a reference doc publish
       id: docs-check
-      run: git diff --exit-code origin/master HEAD docs-devsite
+      run: |
+        LAST_PUBLISHED_VERSION=$(npm info firebase version)
+        git diff --exit-code firebase@$LAST_PUBLISHED_VERSION HEAD docs-devsite
     - name: No diff, docs not needed
       if: ${{ success() }}
       run: echo "DOCS_NEEDED=false" >> $GITHUB_STATE


### PR DESCRIPTION
This should diff against the last published version, which we create a git tag for on every prod publish, in the format `firebase@[version number]`. We can use `npm info` to get the number and then git diff against that tag.