### PR TITLE
Add initial implementation of getGoogleAnalyticsClientId

### DIFF
--- a/common/api-review/analytics.api.md
+++ b/common/api-review/analytics.api.md
@@ -134,6 +134,9 @@ export interface EventParams {
 export function getAnalytics(app?: FirebaseApp): Analytics;
 
 // @public
+export function getGoogleAnalyticsClientId(analyticsInstance: Analytics): Promise<string>;
+
+// @public
 export interface GtagConfigParams {
     // (undocumented)
     [key: string]: unknown;

--- a/packages/analytics/src/api.ts
+++ b/packages/analytics/src/api.ts
@@ -50,7 +50,8 @@ import {
   setUserProperties as internalSetUserProperties,
   setAnalyticsCollectionEnabled as internalSetAnalyticsCollectionEnabled,
   _setConsentDefaultForInit,
-  _setDefaultEventParametersForInit
+  _setDefaultEventParametersForInit,
+  internalGetGoogleAnalyticsClientId
 } from './functions';
 import { ERROR_FACTORY, AnalyticsError } from './errors';
 
@@ -165,6 +166,24 @@ export function setCurrentScreen(
     screenName,
     options
   ).catch(e => logger.error(e));
+}
+
+/**
+ * Retrieves a unique Google Analytics identifier for the web client.
+ * See {@link https://developers.google.com/analytics/devguides/collection/ga4/reference/config#client_id | client_id}.
+ *
+ * @public
+ *
+ * @param app - The {@link @firebase/app#FirebaseApp} to use.
+ */
+export async function getGoogleAnalyticsClientId(
+  analyticsInstance: Analytics
+): Promise<string> {
+  analyticsInstance = getModularInstance(analyticsInstance);
+  return internalGetGoogleAnalyticsClientId(
+    wrappedGtagFunction,
+    initializationPromisesMap[analyticsInstance.app.options.measurementId!]
+  );
 }
 
 /**

--- a/packages/analytics/src/constants.ts
+++ b/packages/analytics/src/constants.ts
@@ -35,5 +35,6 @@ export const enum GtagCommand {
   EVENT = 'event',
   SET = 'set',
   CONFIG = 'config',
-  CONSENT = 'consent'
+  CONSENT = 'consent',
+  GET = 'get'
 }

--- a/packages/analytics/src/errors.ts
+++ b/packages/analytics/src/errors.ts
@@ -28,6 +28,7 @@ export const enum AnalyticsError {
   CONFIG_FETCH_FAILED = 'config-fetch-failed',
   NO_API_KEY = 'no-api-key',
   NO_APP_ID = 'no-app-id',
+  NO_CLIENT_ID = 'no-client-id',
   INVALID_GTAG_RESOURCE = 'invalid-gtag-resource'
 }
 
@@ -66,6 +67,7 @@ const ERRORS: ErrorMap<AnalyticsError> = {
   [AnalyticsError.NO_APP_ID]:
     'The "appId" field is empty in the local Firebase config. Firebase Analytics requires this field to' +
     'contain a valid app ID.',
+  [AnalyticsError.NO_CLIENT_ID]: 'The "client_id" field is empty.',
   [AnalyticsError.INVALID_GTAG_RESOURCE]:
     'Trusted Types detected an invalid gtag resource: {$gtagURL}.'
 };

--- a/packages/analytics/src/functions.test.ts
+++ b/packages/analytics/src/functions.test.ts
@@ -27,10 +27,13 @@ import {
   defaultEventParametersForInit,
   _setDefaultEventParametersForInit,
   _setConsentDefaultForInit,
-  defaultConsentSettingsForInit
+  defaultConsentSettingsForInit,
+  internalGetGoogleAnalyticsClientId
 } from './functions';
 import { GtagCommand } from './constants';
 import { ConsentSettings } from './public-types';
+import { Gtag } from './types';
+import { AnalyticsError } from './errors';
 
 const fakeMeasurementId = 'abcd-efgh-ijkl';
 const fakeInitializationPromise = Promise.resolve(fakeMeasurementId);
@@ -237,5 +240,35 @@ describe('FirebaseAnalytics methods', () => {
     expect(defaultConsentSettingsForInit).to.deep.equal({
       ...additionalParams
     });
+  });
+  it('internalGetGoogleAnalyticsClientId() rejects when no client_id is available', async () => {
+    await expect(
+      internalGetGoogleAnalyticsClientId(
+        function fakeWrappedGtag(
+          unused1: unknown,
+          unused2: unknown,
+          unused3: unknown,
+          callBackStub: (clientId: string) => {}
+        ): void {
+          callBackStub('');
+        } as Gtag,
+        fakeInitializationPromise
+      )
+    ).to.be.rejectedWith(AnalyticsError.NO_CLIENT_ID);
+  });
+  it('internalGetGoogleAnalyticsClientId() returns client_id when available', async () => {
+    const CLIENT_ID = 'clientId1234';
+    const id = await internalGetGoogleAnalyticsClientId(
+      function fakeWrappedGtag(
+        unused1: unknown,
+        unused2: unknown,
+        unused3: unknown,
+        callBackStub: (clientId: string) => {}
+      ): void {
+        callBackStub(CLIENT_ID);
+      } as Gtag,
+      fakeInitializationPromise
+    );
+    expect(id).to.equal(CLIENT_ID);
   });
 });

--- a/packages/analytics/src/functions.ts
+++ b/packages/analytics/src/functions.ts
@@ -24,6 +24,7 @@ import {
 } from './public-types';
 import { Gtag } from './types';
 import { GtagCommand } from './constants';
+import { AnalyticsError, ERROR_FACTORY } from './errors';
 
 /**
  * Event parameters to set on 'gtag' during initialization.
@@ -135,6 +136,34 @@ export async function setUserProperties(
       'user_properties': properties
     });
   }
+}
+
+/**
+ * Retrieves a unique Google Analytics identifier for the web client.
+ * See {@link https://developers.google.com/analytics/devguides/collection/ga4/reference/config#client_id | client_id}.
+ *
+ * @public
+ *
+ * @param gtagFunction Wrapped gtag function that waits for fid to be set before sending an event
+ */
+export async function internalGetGoogleAnalyticsClientId(
+  gtagFunction: Gtag,
+  initializationPromise: Promise<string>
+): Promise<string> {
+  const measurementId = await initializationPromise;
+  return new Promise((resolve, reject) => {
+    gtagFunction(
+      GtagCommand.GET,
+      measurementId,
+      'client_id',
+      (clientId: string) => {
+        if (!clientId) {
+          reject(ERROR_FACTORY.create(AnalyticsError.NO_CLIENT_ID));
+        }
+        resolve(clientId);
+      }
+    );
+  });
 }
 
 /**

--- a/packages/analytics/src/helpers.test.ts
+++ b/packages/analytics/src/helpers.test.ts
@@ -24,12 +24,16 @@ import {
   insertScriptTag,
   wrapOrCreateGtag,
   findGtagScriptOnPage,
-  promiseAllSettled
+  promiseAllSettled,
+  createGtagTrustedTypesScriptURL,
+  createTrustedTypesPolicy
 } from './helpers';
-import { GtagCommand } from './constants';
+import { GtagCommand, GTAG_URL } from './constants';
 import { Deferred } from '@firebase/util';
 import { ConsentSettings } from './public-types';
 import { removeGtagScripts } from '../testing/gtag-script-util';
+import { logger } from './logger';
+import { AnalyticsError, ERROR_FACTORY } from './errors';
 
 const fakeMeasurementId = 'abcd-efgh-ijkl';
 const fakeAppId = 'my-test-app-1234';
@@ -45,6 +49,70 @@ const fakeDynamicConfig: DynamicConfig = {
   measurementId: fakeMeasurementId
 };
 const fakeDynamicConfigPromises = [Promise.resolve(fakeDynamicConfig)];
+
+describe('Trusted Types policies and functions', () => {
+  describe('Trusted types exists', () => {
+    let ttStub: SinonStub;
+
+    beforeEach(() => {
+      ttStub = stub(
+        window.trustedTypes as TrustedTypePolicyFactory,
+        'createPolicy'
+      ).returns({
+        createScriptURL: (s: string) => s
+      } as any);
+    });
+
+    afterEach(() => {
+      removeGtagScripts();
+      ttStub.restore();
+    });
+
+    it('Verify trustedTypes is called if the API is available', () => {
+      const trustedTypesPolicy = createTrustedTypesPolicy(
+        'firebase-js-sdk-policy',
+        {
+          createScriptURL: createGtagTrustedTypesScriptURL
+        }
+      );
+
+      expect(ttStub).to.be.called;
+      expect(trustedTypesPolicy).not.to.be.undefined;
+    });
+
+    it('createGtagTrustedTypesScriptURL verifies gtag URL base exists when a URL is provided', () => {
+      expect(createGtagTrustedTypesScriptURL(GTAG_URL)).to.equal(GTAG_URL);
+    });
+
+    it('createGtagTrustedTypesScriptURL rejects URLs with non-gtag base', () => {
+      const NON_GTAG_URL = 'http://iamnotgtag.com';
+      const loggerWarnStub = stub(logger, 'warn');
+      const errorMessage = ERROR_FACTORY.create(
+        AnalyticsError.INVALID_GTAG_RESOURCE,
+        {
+          gtagURL: NON_GTAG_URL
+        }
+      ).message;
+
+      expect(createGtagTrustedTypesScriptURL(NON_GTAG_URL)).to.equal('');
+      expect(loggerWarnStub).to.be.calledWith(errorMessage);
+    });
+  });
+
+  describe('Trusted types does not exist', () => {
+    it('Verify trustedTypes functions are not called if the API is not available', () => {
+      delete window.trustedTypes;
+      const trustedTypesPolicy = createTrustedTypesPolicy(
+        'firebase-js-sdk-policy',
+        {
+          createScriptURL: createGtagTrustedTypesScriptURL
+        }
+      );
+
+      expect(trustedTypesPolicy).to.be.undefined;
+    });
+  });
+});
 
 describe('Gtag wrapping functions', () => {
   afterEach(() => {

--- a/packages/analytics/src/helpers.test.ts
+++ b/packages/analytics/src/helpers.test.ts
@@ -24,16 +24,12 @@ import {
   insertScriptTag,
   wrapOrCreateGtag,
   findGtagScriptOnPage,
-  promiseAllSettled,
-  createGtagTrustedTypesScriptURL,
-  createTrustedTypesPolicy
+  promiseAllSettled
 } from './helpers';
-import { GtagCommand, GTAG_URL } from './constants';
+import { GtagCommand } from './constants';
 import { Deferred } from '@firebase/util';
 import { ConsentSettings } from './public-types';
 import { removeGtagScripts } from '../testing/gtag-script-util';
-import { logger } from './logger';
-import { AnalyticsError, ERROR_FACTORY } from './errors';
 
 const fakeMeasurementId = 'abcd-efgh-ijkl';
 const fakeAppId = 'my-test-app-1234';
@@ -49,70 +45,6 @@ const fakeDynamicConfig: DynamicConfig = {
   measurementId: fakeMeasurementId
 };
 const fakeDynamicConfigPromises = [Promise.resolve(fakeDynamicConfig)];
-
-describe('Trusted Types policies and functions', () => {
-  describe('Trusted types exists', () => {
-    let ttStub: SinonStub;
-
-    beforeEach(() => {
-      ttStub = stub(
-        window.trustedTypes as TrustedTypePolicyFactory,
-        'createPolicy'
-      ).returns({
-        createScriptURL: (s: string) => s
-      } as any);
-    });
-
-    afterEach(() => {
-      removeGtagScripts();
-      ttStub.restore();
-    });
-
-    it('Verify trustedTypes is called if the API is available', () => {
-      const trustedTypesPolicy = createTrustedTypesPolicy(
-        'firebase-js-sdk-policy',
-        {
-          createScriptURL: createGtagTrustedTypesScriptURL
-        }
-      );
-
-      expect(ttStub).to.be.called;
-      expect(trustedTypesPolicy).not.to.be.undefined;
-    });
-
-    it('createGtagTrustedTypesScriptURL verifies gtag URL base exists when a URL is provided', () => {
-      expect(createGtagTrustedTypesScriptURL(GTAG_URL)).to.equal(GTAG_URL);
-    });
-
-    it('createGtagTrustedTypesScriptURL rejects URLs with non-gtag base', () => {
-      const NON_GTAG_URL = 'http://iamnotgtag.com';
-      const loggerWarnStub = stub(logger, 'warn');
-      const errorMessage = ERROR_FACTORY.create(
-        AnalyticsError.INVALID_GTAG_RESOURCE,
-        {
-          gtagURL: NON_GTAG_URL
-        }
-      ).message;
-
-      expect(createGtagTrustedTypesScriptURL(NON_GTAG_URL)).to.equal('');
-      expect(loggerWarnStub).to.be.calledWith(errorMessage);
-    });
-  });
-
-  describe('Trusted types does not exist', () => {
-    it('Verify trustedTypes functions are not called if the API is not available', () => {
-      delete window.trustedTypes;
-      const trustedTypesPolicy = createTrustedTypesPolicy(
-        'firebase-js-sdk-policy',
-        {
-          createScriptURL: createGtagTrustedTypesScriptURL
-        }
-      );
-
-      expect(trustedTypesPolicy).to.be.undefined;
-    });
-  });
-});
 
 describe('Gtag wrapping functions', () => {
   afterEach(() => {
@@ -328,6 +260,37 @@ describe('Gtag wrapping functions', () => {
         'update',
         consentParameters
       );
+      expect((window['dataLayer'] as DataLayer).length).to.equal(1);
+    });
+
+    it('new window.gtag function does not wait when sending "get" calls', async () => {
+      wrapOrCreateGtag(
+        { [fakeAppId]: Promise.resolve(fakeMeasurementId) },
+        fakeDynamicConfigPromises,
+        {},
+        'dataLayer',
+        'gtag'
+      );
+      window['dataLayer'] = [];
+      (window['gtag'] as Gtag)(
+        GtagCommand.GET,
+        fakeMeasurementId,
+        'client_id',
+        clientId => console.log(clientId)
+      );
+      expect((window['dataLayer'] as DataLayer).length).to.equal(1);
+    });
+
+    it('new window.gtag function does not wait when sending an unknown command', async () => {
+      wrapOrCreateGtag(
+        { [fakeAppId]: Promise.resolve(fakeMeasurementId) },
+        fakeDynamicConfigPromises,
+        {},
+        'dataLayer',
+        'gtag'
+      );
+      window['dataLayer'] = [];
+      (window['gtag'] as Gtag)('new-command-from-gtag-team', fakeMeasurementId);
       expect((window['dataLayer'] as DataLayer).length).to.equal(1);
     });
 

--- a/packages/analytics/src/helpers.ts
+++ b/packages/analytics/src/helpers.ts
@@ -24,9 +24,24 @@ import {
 import { DynamicConfig, DataLayer, Gtag, MinimalDynamicConfig } from './types';
 import { GtagCommand, GTAG_URL } from './constants';
 import { logger } from './logger';
+import { AnalyticsError, ERROR_FACTORY } from './errors';
 
 // Possible parameter types for gtag 'event' and 'config' commands
 type GtagConfigOrEventParams = ControlParams & EventParams & CustomParams;
+
+/**
+ * Verifies and creates a TrustedScriptURL.
+ */
+export function createGtagTrustedTypesScriptURL(url: string): string {
+  if (!url.startsWith(GTAG_URL)) {
+    const err = ERROR_FACTORY.create(AnalyticsError.INVALID_GTAG_RESOURCE, {
+      gtagURL: url
+    });
+    logger.warn(err.message);
+    return '';
+  }
+  return url;
+}
 
 /**
  * Makeshift polyfill for Promise.allSettled(). Resolves when all promises
@@ -41,6 +56,29 @@ export function promiseAllSettled<T>(
 }
 
 /**
+ * Creates a TrustedTypePolicy object that implements the rules passed as policyOptions.
+ *
+ * @param policyName A string containing the name of the policy
+ * @param policyOptions Object containing implementations of instance methods for TrustedTypesPolicy, see {@link https://developer.mozilla.org/en-US/docs/Web/API/TrustedTypePolicy#instance_methods
+ * | the TrustedTypePolicy reference documentation}.
+ */
+export function createTrustedTypesPolicy(
+  policyName: string,
+  policyOptions: Partial<TrustedTypePolicyOptions>
+): Partial<TrustedTypePolicy> | undefined {
+  // Create a TrustedTypes policy that we can use for updating src
+  // properties
+  let trustedTypesPolicy: Partial<TrustedTypePolicy> | undefined;
+  if (window.trustedTypes) {
+    trustedTypesPolicy = window.trustedTypes.createPolicy(
+      policyName,
+      policyOptions
+    );
+  }
+  return trustedTypesPolicy;
+}
+
+/**
  * Inserts gtag script tag into the page to asynchronously download gtag.
  * @param dataLayerName Name of datalayer (most often the default, "_dataLayer").
  */
@@ -48,10 +86,22 @@ export function insertScriptTag(
   dataLayerName: string,
   measurementId: string
 ): void {
+  const trustedTypesPolicy = createTrustedTypesPolicy(
+    'firebase-js-sdk-policy',
+    {
+      createScriptURL: createGtagTrustedTypesScriptURL
+    }
+  );
+
   const script = document.createElement('script');
   // We are not providing an analyticsId in the URL because it would trigger a `page_view`
   // without fid. We will initialize ga-id using gtag (config) command together with fid.
-  script.src = `${GTAG_URL}?l=${dataLayerName}&id=${measurementId}`;
+
+  const gtagScriptURL = `${GTAG_URL}?l=${dataLayerName}&id=${measurementId}`;
+  (script.src as string | TrustedScriptURL) = trustedTypesPolicy
+    ? (trustedTypesPolicy as TrustedTypePolicy)?.createScriptURL(gtagScriptURL)
+    : gtagScriptURL;
+
   script.async = true;
   document.head.appendChild(script);
 }

--- a/packages/analytics/src/helpers.ts
+++ b/packages/analytics/src/helpers.ts
@@ -24,24 +24,9 @@ import {
 import { DynamicConfig, DataLayer, Gtag, MinimalDynamicConfig } from './types';
 import { GtagCommand, GTAG_URL } from './constants';
 import { logger } from './logger';
-import { AnalyticsError, ERROR_FACTORY } from './errors';
 
 // Possible parameter types for gtag 'event' and 'config' commands
 type GtagConfigOrEventParams = ControlParams & EventParams & CustomParams;
-
-/**
- * Verifies and creates a TrustedScriptURL.
- */
-export function createGtagTrustedTypesScriptURL(url: string): string {
-  if (!url.startsWith(GTAG_URL)) {
-    const err = ERROR_FACTORY.create(AnalyticsError.INVALID_GTAG_RESOURCE, {
-      gtagURL: url
-    });
-    logger.warn(err.message);
-    return '';
-  }
-  return url;
-}
 
 /**
  * Makeshift polyfill for Promise.allSettled(). Resolves when all promises
@@ -56,29 +41,6 @@ export function promiseAllSettled<T>(
 }
 
 /**
- * Creates a TrustedTypePolicy object that implements the rules passed as policyOptions.
- *
- * @param policyName A string containing the name of the policy
- * @param policyOptions Object containing implementations of instance methods for TrustedTypesPolicy, see {@link https://developer.mozilla.org/en-US/docs/Web/API/TrustedTypePolicy#instance_methods
- * | the TrustedTypePolicy reference documentation}.
- */
-export function createTrustedTypesPolicy(
-  policyName: string,
-  policyOptions: Partial<TrustedTypePolicyOptions>
-): Partial<TrustedTypePolicy> | undefined {
-  // Create a TrustedTypes policy that we can use for updating src
-  // properties
-  let trustedTypesPolicy: Partial<TrustedTypePolicy> | undefined;
-  if (window.trustedTypes) {
-    trustedTypesPolicy = window.trustedTypes.createPolicy(
-      policyName,
-      policyOptions
-    );
-  }
-  return trustedTypesPolicy;
-}
-
-/**
  * Inserts gtag script tag into the page to asynchronously download gtag.
  * @param dataLayerName Name of datalayer (most often the default, "_dataLayer").
  */
@@ -86,22 +48,10 @@ export function insertScriptTag(
   dataLayerName: string,
   measurementId: string
 ): void {
-  const trustedTypesPolicy = createTrustedTypesPolicy(
-    'firebase-js-sdk-policy',
-    {
-      createScriptURL: createGtagTrustedTypesScriptURL
-    }
-  );
-
   const script = document.createElement('script');
   // We are not providing an analyticsId in the URL because it would trigger a `page_view`
   // without fid. We will initialize ga-id using gtag (config) command together with fid.
-
-  const gtagScriptURL = `${GTAG_URL}?l=${dataLayerName}&id=${measurementId}`;
-  (script.src as string | TrustedScriptURL) = trustedTypesPolicy
-    ? (trustedTypesPolicy as TrustedTypePolicy)?.createScriptURL(gtagScriptURL)
-    : gtagScriptURL;
-
+  script.src = `${GTAG_URL}?l=${dataLayerName}&id=${measurementId}`;
   script.async = true;
   document.head.appendChild(script);
 }
@@ -277,37 +227,50 @@ function wrapGtag(
    * @param gtagParams Params if event is EVENT/CONFIG.
    */
   async function gtagWrapper(
-    command: 'config' | 'set' | 'event' | 'consent',
-    idOrNameOrParams: string | ControlParams,
-    gtagParams?: GtagConfigOrEventParams | ConsentSettings
+    command: 'config' | 'set' | 'event' | 'consent' | 'get' | string,
+    ...args: unknown[]
   ): Promise<void> {
     try {
       // If event, check that relevant initialization promises have completed.
       if (command === GtagCommand.EVENT) {
+        const [measurementId, gtagParams] = args;
         // If EVENT, second arg must be measurementId.
         await gtagOnEvent(
           gtagCore,
           initializationPromisesMap,
           dynamicConfigPromisesList,
-          idOrNameOrParams as string,
+          measurementId as string,
           gtagParams as GtagConfigOrEventParams
         );
       } else if (command === GtagCommand.CONFIG) {
+        const [measurementId, gtagParams] = args;
         // If CONFIG, second arg must be measurementId.
         await gtagOnConfig(
           gtagCore,
           initializationPromisesMap,
           dynamicConfigPromisesList,
           measurementIdToAppId,
-          idOrNameOrParams as string,
+          measurementId as string,
           gtagParams as GtagConfigOrEventParams
         );
       } else if (command === GtagCommand.CONSENT) {
+        const [gtagParams] = args;
         // If CONFIG, second arg must be measurementId.
         gtagCore(GtagCommand.CONSENT, 'update', gtagParams as ConsentSettings);
-      } else {
+      } else if (command === GtagCommand.GET) {
+        const [measurementId, fieldName, callback] = args;
+        gtagCore(
+          GtagCommand.GET,
+          measurementId as string,
+          fieldName as string,
+          callback as (...args: unknown[]) => void
+        );
+      } else if (command === GtagCommand.SET) {
+        const [customParams] = args;
         // If SET, second arg must be params.
-        gtagCore(GtagCommand.SET, idOrNameOrParams as CustomParams);
+        gtagCore(GtagCommand.SET, customParams as CustomParams);
+      } else {
+        gtagCore(command, ...args);
       }
     } catch (e) {
       logger.error(e);

--- a/packages/analytics/src/types.ts
+++ b/packages/analytics/src/types.ts
@@ -73,6 +73,13 @@ export interface Gtag {
     subCommand: 'default' | 'update',
     consentSettings: ConsentSettings
   ): void;
+  (
+    command: 'get',
+    measurementId: string,
+    fieldName: string,
+    callback: (...args: unknown[]) => void
+  ): void;
+  (command: string, ...args: unknown[]): void;
 }
 
 export type DataLayer = IArguments[];


### PR DESCRIPTION
Recently, we were presented with use cases where users wanted to log purchase and other events from their backends using [Google Analytics 4 Measurement Protocol](https://developers.google.com/analytics/devguides/collection/protocol/ga4) and to have those events be connected to actions taken on the client within their Firebase web app. In the [event sending documentation](https://developers.google.com/analytics/devguides/collection/protocol/ga4/sending-events?client_type=firebase#required_parameters), it dictates that app_instance_id is required for Firebase but this is only focused on Firebase for mobile. Because the JS SDK analytics package is a wrapper around gtag, [we must use gtag's client_id](https://developers.google.com/analytics/devguides/collection/protocol/ga4/sending-events?client_type=gtag#required_parameters) instead of app_instance_id for Measurement Protocol. To simplify the retrieval process from our analytics packages, we will add a getGoogleAnalyticsClientId() method. getGoogleAnalyticsClientId() will retrieve an unique identifier for a web client.