### PR TITLE
Fix `Named export 'Integer' not found` error in es module node project

### DIFF
--- a/packages/webchannel-wrapper/gulpfile.js
+++ b/packages/webchannel-wrapper/gulpfile.js
@@ -120,7 +120,7 @@ function createRollupTask({
     };
 
     const outputOptions = {
-      file: `dist/index${outputExtension ? '.' : ''}${outputExtension}.js`,
+      file: `dist/index${outputExtension ? '.' : ''}${outputExtension}.mjs`,
       format,
       sourcemap: true,
       // Prevents warning when compiling CJS that there are named and default exports together.

--- a/packages/webchannel-wrapper/package.json
+++ b/packages/webchannel-wrapper/package.json
@@ -10,8 +10,8 @@
     ".": {
       "types": "./src/index.d.ts",
       "require": "./dist/index.js",
-      "esm5": "./dist/index.esm.js",
-      "default": "./dist/index.esm2017.js"
+      "esm5": "./dist/index.esm.mjs",
+      "default": "./dist/index.esm2017.mjs"
     },
     "./package.json": "./package.json"
   },


### PR DESCRIPTION
The Firestore Node bundles now all have a dependency on `@firebase/webchannel-wrapper` (previously, only the "browser" bundles had this dependency). If a project consuming the Firebase SDK does not define `"type": "module"` in its `package.json`, or defines `"type": "commonjs"` then the Firestore bundle `index.node.cjs.js` is used. This bundle has the line

```ts
var webchannelWrapper = require('@firebase/webchannel-wrapper');
```

which works.

However, if a project consuming the Firebase SDK does defines "type": "module" then the Firestore bundle `index.node.mjs` is used. This bundle has the line

```
import { Integer, Md5 } from '@firebase/webchannel-wrapper';
```

which fails at runtime with this error:

```
file:///home/dconeybe/tmp/bftest/mjs/node_modules/@firebase/firestore/dist/index.node.mjs:7
import { Integer, Md5 } from '@firebase/webchannel-wrapper';
         ^^^^^^^
SyntaxError: Named export 'Integer' not found. The requested module '@firebase/webchannel-wrapper' is a CommonJS module, which may not support all module.exports as named exports.
CommonJS modules can always be imported via the default export, for example using:

import pkg from '@firebase/webchannel-wrapper';
const { Integer, Md5 } = pkg;

    at ModuleJob._instantiate (node:internal/modules/esm/module_job:124:21)
    at async ModuleJob.run (node:internal/modules/esm/module_job:190:5)

Node.js v18.14.2

Process finished with exit code 1
```

This seems to be because the `@webchannel-wrapper` bundle `index.esm2017.js` is being incorrectly loaded as a commonjs module, when, in fact, it is an es module.

This PR fixes the problem by simply changing the `.js` extension to `.mjs` to indicate that it is an es module and not a commonjs module.