### PR TITLE
Prevent Trusted Types tests to run when the API does not exist

### DIFF
--- a/packages/analytics/src/helpers.test.ts
+++ b/packages/analytics/src/helpers.test.ts
@@ -51,54 +51,55 @@ const fakeDynamicConfig: DynamicConfig = {
 const fakeDynamicConfigPromises = [Promise.resolve(fakeDynamicConfig)];
 
 describe('Trusted Types policies and functions', () => {
-  describe('Trusted types exists', () => {
-    let ttStub: SinonStub;
+  if (window.trustedTypes) {
+    describe('Trusted types exists', () => {
+      let ttStub: SinonStub;
 
-    beforeEach(() => {
-      ttStub = stub(
-        window.trustedTypes as TrustedTypePolicyFactory,
-        'createPolicy'
-      ).returns({
-        createScriptURL: (s: string) => s
-      } as any);
+      beforeEach(() => {
+        ttStub = stub(
+          window.trustedTypes as TrustedTypePolicyFactory,
+          'createPolicy'
+        ).returns({
+          createScriptURL: (s: string) => s
+        } as any);
+      });
+
+      afterEach(() => {
+        removeGtagScripts();
+        ttStub.restore();
+      });
+
+      it('Verify trustedTypes is called if the API is available', () => {
+        const trustedTypesPolicy = createTrustedTypesPolicy(
+          'firebase-js-sdk-policy',
+          {
+            createScriptURL: createGtagTrustedTypesScriptURL
+          }
+        );
+
+        expect(ttStub).to.be.called;
+        expect(trustedTypesPolicy).not.to.be.undefined;
+      });
+
+      it('createGtagTrustedTypesScriptURL verifies gtag URL base exists when a URL is provided', () => {
+        expect(createGtagTrustedTypesScriptURL(GTAG_URL)).to.equal(GTAG_URL);
+      });
+
+      it('createGtagTrustedTypesScriptURL rejects URLs with non-gtag base', () => {
+        const NON_GTAG_URL = 'http://iamnotgtag.com';
+        const loggerWarnStub = stub(logger, 'warn');
+        const errorMessage = ERROR_FACTORY.create(
+          AnalyticsError.INVALID_GTAG_RESOURCE,
+          {
+            gtagURL: NON_GTAG_URL
+          }
+        ).message;
+
+        expect(createGtagTrustedTypesScriptURL(NON_GTAG_URL)).to.equal('');
+        expect(loggerWarnStub).to.be.calledWith(errorMessage);
+      });
     });
-
-    afterEach(() => {
-      removeGtagScripts();
-      ttStub.restore();
-    });
-
-    it('Verify trustedTypes is called if the API is available', () => {
-      const trustedTypesPolicy = createTrustedTypesPolicy(
-        'firebase-js-sdk-policy',
-        {
-          createScriptURL: createGtagTrustedTypesScriptURL
-        }
-      );
-
-      expect(ttStub).to.be.called;
-      expect(trustedTypesPolicy).not.to.be.undefined;
-    });
-
-    it('createGtagTrustedTypesScriptURL verifies gtag URL base exists when a URL is provided', () => {
-      expect(createGtagTrustedTypesScriptURL(GTAG_URL)).to.equal(GTAG_URL);
-    });
-
-    it('createGtagTrustedTypesScriptURL rejects URLs with non-gtag base', () => {
-      const NON_GTAG_URL = 'http://iamnotgtag.com';
-      const loggerWarnStub = stub(logger, 'warn');
-      const errorMessage = ERROR_FACTORY.create(
-        AnalyticsError.INVALID_GTAG_RESOURCE,
-        {
-          gtagURL: NON_GTAG_URL
-        }
-      ).message;
-
-      expect(createGtagTrustedTypesScriptURL(NON_GTAG_URL)).to.equal('');
-      expect(loggerWarnStub).to.be.calledWith(errorMessage);
-    });
-  });
-
+  }
   describe('Trusted types does not exist', () => {
     it('Verify trustedTypes functions are not called if the API is not available', () => {
       delete window.trustedTypes;


### PR DESCRIPTION
Check if trusted types exists in the browser before running tests that stub the API stubbing

For example, Firefox still has not implemented the API, see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/trusted-types#browser_compatibility