### PR TITLE
Firestore: use unique collection names in integration tests

### DIFF
--- a/packages/firestore/test/lite/integration.test.ts
+++ b/packages/firestore/test/lite/integration.test.ts
@@ -688,8 +688,7 @@ function genericMutationTests(
     });
 
     it('supports partials with merge', async () => {
-      return withTestDb(async db => {
-        const coll = collection(db, 'posts');
+      return withTestCollection(async coll => {
         const ref = doc(coll, 'post').withConverter(postConverterMerge);
         await setDoc(ref, new Post('walnut', 'author'));
         await setDoc(
@@ -704,8 +703,7 @@ function genericMutationTests(
     });
 
     it('supports partials with mergeFields', async () => {
-      return withTestDb(async db => {
-        const coll = collection(db, 'posts');
+      return withTestCollection(async coll => {
         const ref = doc(coll, 'post').withConverter(postConverterMerge);
         await setDoc(ref, new Post('walnut', 'author'));
         await setDoc(ref, { title: 'olive' }, { mergeFields: ['title'] });
@@ -1359,8 +1357,7 @@ describe('withConverter() support', () => {
       }
     };
 
-    return withTestDb(async db => {
-      const coll = collection(db, 'tests');
+    return withTestCollection(async coll => {
       const ref = doc(coll, 'number').withConverter(primitiveConverter);
       await setDoc(ref, 3);
       const result = await getDoc(ref);


### PR DESCRIPTION
Fix some Firestore integration tests to use uniquely-generated collection names rather than hardcoding the collection names. This ensures that concurrently-executing tests will not interfere with each other.

There have recently been a few flakes, such as in the `supports partials with merge` test that could be explained by concurrently-executing tests both manipulating the same collection. By uniquely generating the collection ID this possibility is eliminated.