### PR TITLE
Firestore: database.test.ts: add tests for coercing long polling settings to boolean

### DIFF
--- a/packages/firestore/test/unit/api/database.test.ts
+++ b/packages/firestore/test/unit/api/database.test.ts
@@ -363,7 +363,7 @@ describe('Settings', () => {
     // Use a new instance of Firestore in order to configure settings.
     const db = newTestFirestore();
     db._setSettings({
-      experimentalAutoDetectLongPolling: 1 as any,
+      experimentalAutoDetectLongPolling: 1 as any
     });
     expect(db._getSettings().experimentalAutoDetectLongPolling).to.be.true;
   });
@@ -372,7 +372,7 @@ describe('Settings', () => {
     // Use a new instance of Firestore in order to configure settings.
     const db = newTestFirestore();
     db._setSettings({
-      experimentalAutoDetectLongPolling: 0 as any,
+      experimentalAutoDetectLongPolling: 0 as any
     });
     expect(db._getSettings().experimentalAutoDetectLongPolling).to.be.false;
   });
@@ -381,7 +381,7 @@ describe('Settings', () => {
     // Use a new instance of Firestore in order to configure settings.
     const db = newTestFirestore();
     db._setSettings({
-      experimentalForceLongPolling: "I am truthy" as any,
+      experimentalForceLongPolling: 'I am truthy' as any
     });
     expect(db._getSettings().experimentalForceLongPolling).to.be.true;
   });
@@ -390,7 +390,7 @@ describe('Settings', () => {
     // Use a new instance of Firestore in order to configure settings.
     const db = newTestFirestore();
     db._setSettings({
-      experimentalForceLongPolling: NaN as any,
+      experimentalForceLongPolling: NaN as any
     });
     expect(db._getSettings().experimentalForceLongPolling).to.be.false;
   });

--- a/packages/firestore/test/unit/api/database.test.ts
+++ b/packages/firestore/test/unit/api/database.test.ts
@@ -379,6 +379,16 @@ describe('Settings', () => {
     expect(db._getSettings().experimentalAutoDetectLongPolling).to.be.false;
   });
 
+  it('long polling autoDetect=null should be coerced to false', () => {
+    // Use a new instance of Firestore in order to configure settings.
+    const db = newTestFirestore();
+    db._setSettings({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      experimentalAutoDetectLongPolling: null as any
+    });
+    expect(db._getSettings().experimentalAutoDetectLongPolling).to.be.false;
+  });
+
   it('long polling force=[something truthy] should be coerced to true', () => {
     // Use a new instance of Firestore in order to configure settings.
     const db = newTestFirestore();
@@ -395,6 +405,16 @@ describe('Settings', () => {
     db._setSettings({
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       experimentalForceLongPolling: NaN as any
+    });
+    expect(db._getSettings().experimentalForceLongPolling).to.be.false;
+  });
+
+  it('long polling force=null should be coerced to false', () => {
+    // Use a new instance of Firestore in order to configure settings.
+    const db = newTestFirestore();
+    db._setSettings({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      experimentalForceLongPolling: null as any
     });
     expect(db._getSettings().experimentalForceLongPolling).to.be.false;
   });

--- a/packages/firestore/test/unit/api/database.test.ts
+++ b/packages/firestore/test/unit/api/database.test.ts
@@ -359,7 +359,7 @@ describe('Settings', () => {
     expect(db._getSettings().experimentalForceLongPolling).to.be.false;
   });
 
-  it('long polling autoDetect=[something truthy] is corced to true', () => {
+  it('long polling autoDetect=[something truthy] should be coerced to true', () => {
     // Use a new instance of Firestore in order to configure settings.
     const db = newTestFirestore();
     db._setSettings({
@@ -368,7 +368,7 @@ describe('Settings', () => {
     expect(db._getSettings().experimentalAutoDetectLongPolling).to.be.true;
   });
 
-  it('long polling autoDetect=[something falsy] is corced to false', () => {
+  it('long polling autoDetect=[something falsy] should be coerced to false', () => {
     // Use a new instance of Firestore in order to configure settings.
     const db = newTestFirestore();
     db._setSettings({
@@ -377,7 +377,7 @@ describe('Settings', () => {
     expect(db._getSettings().experimentalAutoDetectLongPolling).to.be.false;
   });
 
-  it('long polling force=[something truthy] is corced to true', () => {
+  it('long polling force=[something truthy] should be coerced to true', () => {
     // Use a new instance of Firestore in order to configure settings.
     const db = newTestFirestore();
     db._setSettings({
@@ -386,7 +386,7 @@ describe('Settings', () => {
     expect(db._getSettings().experimentalForceLongPolling).to.be.true;
   });
 
-  it('long polling force=[something falsy] is corced to false', () => {
+  it('long polling force=[something falsy] should be coerced to false', () => {
     // Use a new instance of Firestore in order to configure settings.
     const db = newTestFirestore();
     db._setSettings({

--- a/packages/firestore/test/unit/api/database.test.ts
+++ b/packages/firestore/test/unit/api/database.test.ts
@@ -359,6 +359,42 @@ describe('Settings', () => {
     expect(db._getSettings().experimentalForceLongPolling).to.be.false;
   });
 
+  it('long polling autoDetect=[something truthy] is corced to true', () => {
+    // Use a new instance of Firestore in order to configure settings.
+    const db = newTestFirestore();
+    db._setSettings({
+      experimentalAutoDetectLongPolling: 1 as any,
+    });
+    expect(db._getSettings().experimentalAutoDetectLongPolling).to.be.true;
+  });
+
+  it('long polling autoDetect=[something falsy] is corced to false', () => {
+    // Use a new instance of Firestore in order to configure settings.
+    const db = newTestFirestore();
+    db._setSettings({
+      experimentalAutoDetectLongPolling: 0 as any,
+    });
+    expect(db._getSettings().experimentalAutoDetectLongPolling).to.be.false;
+  });
+
+  it('long polling force=[something truthy] is corced to true', () => {
+    // Use a new instance of Firestore in order to configure settings.
+    const db = newTestFirestore();
+    db._setSettings({
+      experimentalForceLongPolling: "I am truthy" as any,
+    });
+    expect(db._getSettings().experimentalForceLongPolling).to.be.true;
+  });
+
+  it('long polling force=[something falsy] is corced to false', () => {
+    // Use a new instance of Firestore in order to configure settings.
+    const db = newTestFirestore();
+    db._setSettings({
+      experimentalForceLongPolling: NaN as any,
+    });
+    expect(db._getSettings().experimentalForceLongPolling).to.be.false;
+  });
+
   it('gets settings from useEmulator', () => {
     // Use a new instance of Firestore in order to configure settings.
     const db = newTestFirestore();

--- a/packages/firestore/test/unit/api/database.test.ts
+++ b/packages/firestore/test/unit/api/database.test.ts
@@ -363,6 +363,7 @@ describe('Settings', () => {
     // Use a new instance of Firestore in order to configure settings.
     const db = newTestFirestore();
     db._setSettings({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       experimentalAutoDetectLongPolling: 1 as any
     });
     expect(db._getSettings().experimentalAutoDetectLongPolling).to.be.true;
@@ -372,6 +373,7 @@ describe('Settings', () => {
     // Use a new instance of Firestore in order to configure settings.
     const db = newTestFirestore();
     db._setSettings({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       experimentalAutoDetectLongPolling: 0 as any
     });
     expect(db._getSettings().experimentalAutoDetectLongPolling).to.be.false;
@@ -381,6 +383,7 @@ describe('Settings', () => {
     // Use a new instance of Firestore in order to configure settings.
     const db = newTestFirestore();
     db._setSettings({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       experimentalForceLongPolling: 'I am truthy' as any
     });
     expect(db._getSettings().experimentalForceLongPolling).to.be.true;
@@ -390,6 +393,7 @@ describe('Settings', () => {
     // Use a new instance of Firestore in order to configure settings.
     const db = newTestFirestore();
     db._setSettings({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       experimentalForceLongPolling: NaN as any
     });
     expect(db._getSettings().experimentalForceLongPolling).to.be.false;


### PR DESCRIPTION
Add Firestore unit tests for coercing experimentalForceLongPolling and experimentalAutoDetectLongPolling to boolean