### PR TITLE
Rerun prettier/docs after prettier dependency update

### DIFF
--- a/common/api-review/auth.api.md
+++ b/common/api-review/auth.api.md
@@ -20,7 +20,7 @@ export interface ActionCodeInfo {
         multiFactorInfo?: MultiFactorInfo | null;
         previousEmail?: string | null;
     };
-    operation: typeof ActionCodeOperation[keyof typeof ActionCodeOperation];
+    operation: (typeof ActionCodeOperation)[keyof typeof ActionCodeOperation];
 }
 
 // @public
@@ -456,13 +456,13 @@ export function multiFactor(user: User): MultiFactorUser;
 
 // @public
 export interface MultiFactorAssertion {
-    readonly factorId: typeof FactorId[keyof typeof FactorId];
+    readonly factorId: (typeof FactorId)[keyof typeof FactorId];
 }
 
 // @public
 export interface MultiFactorError extends AuthError {
     readonly customData: AuthError['customData'] & {
-        readonly operationType: typeof OperationType[keyof typeof OperationType];
+        readonly operationType: (typeof OperationType)[keyof typeof OperationType];
     };
 }
 
@@ -470,7 +470,7 @@ export interface MultiFactorError extends AuthError {
 export interface MultiFactorInfo {
     readonly displayName?: string | null;
     readonly enrollmentTime: string;
-    readonly factorId: typeof FactorId[keyof typeof FactorId];
+    readonly factorId: (typeof FactorId)[keyof typeof FactorId];
     readonly uid: string;
 }
 
@@ -844,7 +844,7 @@ export interface User extends UserInfo {
 
 // @public
 export interface UserCredential {
-    operationType: typeof OperationType[keyof typeof OperationType];
+    operationType: (typeof OperationType)[keyof typeof OperationType];
     providerId: string | null;
     user: User;
 }

--- a/common/api-review/storage.api.md
+++ b/common/api-review/storage.api.md
@@ -304,7 +304,7 @@ export interface StorageReference {
 }
 
 // @public
-export type StringFormat = typeof StringFormat[keyof typeof StringFormat];
+export type StringFormat = (typeof StringFormat)[keyof typeof StringFormat];
 
 // @public
 export const StringFormat: {
@@ -329,7 +329,7 @@ export const _TaskEvent: {
 export type TaskState = 'running' | 'paused' | 'success' | 'canceled' | 'error';
 
 // @internal
-export type _TaskState = typeof _TaskState[keyof typeof _TaskState];
+export type _TaskState = (typeof _TaskState)[keyof typeof _TaskState];
 
 // @internal
 export const _TaskState: {

--- a/docs-devsite/auth.actioncodeinfo.md
+++ b/docs-devsite/auth.actioncodeinfo.md
@@ -23,7 +23,7 @@ export interface ActionCodeInfo
 |  Property | Type | Description |
 |  --- | --- | --- |
 |  [data](./auth.actioncodeinfo.md#actioncodeinfodata) | { email?: string \| null; multiFactorInfo?: [MultiFactorInfo](./auth.multifactorinfo.md#multifactorinfo_interface) \| null; previousEmail?: string \| null; } | The data associated with the action code. |
-|  [operation](./auth.actioncodeinfo.md#actioncodeinfooperation) | typeof [ActionCodeOperationMap](./auth.md#actioncodeoperation)<!-- -->\[keyof typeof [ActionCodeOperationMap](./auth.md#actioncodeoperation)<!-- -->\] | The type of operation that generated the action code. |
+|  [operation](./auth.actioncodeinfo.md#actioncodeinfooperation) | (typeof [ActionCodeOperationMap](./auth.md#actioncodeoperation)<!-- -->)\[keyof typeof [ActionCodeOperationMap](./auth.md#actioncodeoperation)<!-- -->\] | The type of operation that generated the action code. |
 
 ## ActionCodeInfo.data
 
@@ -54,5 +54,5 @@ The type of operation that generated the action code.
 <b>Signature:</b>
 
 ```typescript
-operation: typeof ActionCodeOperationMap[keyof typeof ActionCodeOperationMap];
+operation: (typeof ActionCodeOperationMap)[keyof typeof ActionCodeOperationMap];
 ```

--- a/docs-devsite/auth.multifactorassertion.md
+++ b/docs-devsite/auth.multifactorassertion.md
@@ -24,7 +24,7 @@ export interface MultiFactorAssertion
 
 |  Property | Type | Description |
 |  --- | --- | --- |
-|  [factorId](./auth.multifactorassertion.md#multifactorassertionfactorid) | typeof [FactorIdMap](./auth.md#factorid)<!-- -->\[keyof typeof [FactorIdMap](./auth.md#factorid)<!-- -->\] | The identifier of the second factor. |
+|  [factorId](./auth.multifactorassertion.md#multifactorassertionfactorid) | (typeof [FactorIdMap](./auth.md#factorid)<!-- -->)\[keyof typeof [FactorIdMap](./auth.md#factorid)<!-- -->\] | The identifier of the second factor. |
 
 ## MultiFactorAssertion.factorId
 
@@ -33,5 +33,5 @@ The identifier of the second factor.
 <b>Signature:</b>
 
 ```typescript
-readonly factorId: typeof FactorIdMap[keyof typeof FactorIdMap];
+readonly factorId: (typeof FactorIdMap)[keyof typeof FactorIdMap];
 ```

--- a/docs-devsite/auth.multifactorerror.md
+++ b/docs-devsite/auth.multifactorerror.md
@@ -25,7 +25,7 @@ export interface MultiFactorError extends AuthError
 
 |  Property | Type | Description |
 |  --- | --- | --- |
-|  [customData](./auth.multifactorerror.md#multifactorerrorcustomdata) | [AuthError](./auth.autherror.md#autherror_interface)<!-- -->\['customData'\] &amp; { readonly operationType: typeof [OperationTypeMap](./auth.md#operationtype)<!-- -->\[keyof typeof [OperationTypeMap](./auth.md#operationtype)<!-- -->\]; } | Details about the MultiFactorError. |
+|  [customData](./auth.multifactorerror.md#multifactorerrorcustomdata) | [AuthError](./auth.autherror.md#autherror_interface)<!-- -->\['customData'\] &amp; { readonly operationType: (typeof [OperationTypeMap](./auth.md#operationtype)<!-- -->)\[keyof typeof [OperationTypeMap](./auth.md#operationtype)<!-- -->\]; } | Details about the MultiFactorError. |
 
 ## MultiFactorError.customData
 
@@ -35,7 +35,7 @@ Details about the MultiFactorError.
 
 ```typescript
 readonly customData: AuthError['customData'] & {
-        readonly operationType: typeof OperationTypeMap[keyof typeof OperationTypeMap];
+        readonly operationType: (typeof OperationTypeMap)[keyof typeof OperationTypeMap];
     };
 ```
 

--- a/docs-devsite/auth.multifactorinfo.md
+++ b/docs-devsite/auth.multifactorinfo.md
@@ -24,7 +24,7 @@ export interface MultiFactorInfo
 |  --- | --- | --- |
 |  [displayName](./auth.multifactorinfo.md#multifactorinfodisplayname) | string \| null | The user friendly name of the current second factor. |
 |  [enrollmentTime](./auth.multifactorinfo.md#multifactorinfoenrollmenttime) | string | The enrollment date of the second factor formatted as a UTC string. |
-|  [factorId](./auth.multifactorinfo.md#multifactorinfofactorid) | typeof [FactorIdMap](./auth.md#factorid)<!-- -->\[keyof typeof [FactorIdMap](./auth.md#factorid)<!-- -->\] | The identifier of the second factor. |
+|  [factorId](./auth.multifactorinfo.md#multifactorinfofactorid) | (typeof [FactorIdMap](./auth.md#factorid)<!-- -->)\[keyof typeof [FactorIdMap](./auth.md#factorid)<!-- -->\] | The identifier of the second factor. |
 |  [uid](./auth.multifactorinfo.md#multifactorinfouid) | string | The multi-factor enrollment ID. |
 
 ## MultiFactorInfo.displayName
@@ -54,7 +54,7 @@ The identifier of the second factor.
 <b>Signature:</b>
 
 ```typescript
-readonly factorId: typeof FactorIdMap[keyof typeof FactorIdMap];
+readonly factorId: (typeof FactorIdMap)[keyof typeof FactorIdMap];
 ```
 
 ## MultiFactorInfo.uid

--- a/docs-devsite/auth.usercredential.md
+++ b/docs-devsite/auth.usercredential.md
@@ -24,7 +24,7 @@ export interface UserCredential
 
 |  Property | Type | Description |
 |  --- | --- | --- |
-|  [operationType](./auth.usercredential.md#usercredentialoperationtype) | typeof [OperationTypeMap](./auth.md#operationtype)<!-- -->\[keyof typeof [OperationTypeMap](./auth.md#operationtype)<!-- -->\] | The type of operation which was used to authenticate the user (such as sign-in or link). |
+|  [operationType](./auth.usercredential.md#usercredentialoperationtype) | (typeof [OperationTypeMap](./auth.md#operationtype)<!-- -->)\[keyof typeof [OperationTypeMap](./auth.md#operationtype)<!-- -->\] | The type of operation which was used to authenticate the user (such as sign-in or link). |
 |  [providerId](./auth.usercredential.md#usercredentialproviderid) | string \| null | The provider which was used to authenticate the user. |
 |  [user](./auth.usercredential.md#usercredentialuser) | [User](./auth.user.md#user_interface) | The user authenticated by this credential. |
 
@@ -35,7 +35,7 @@ The type of operation which was used to authenticate the user (such as sign-in o
 <b>Signature:</b>
 
 ```typescript
-operationType: typeof OperationTypeMap[keyof typeof OperationTypeMap];
+operationType: (typeof OperationTypeMap)[keyof typeof OperationTypeMap];
 ```
 
 ## UserCredential.providerId

--- a/docs-devsite/storage.md
+++ b/docs-devsite/storage.md
@@ -485,7 +485,7 @@ An enumeration of the possible string formats for upload.
 <b>Signature:</b>
 
 ```typescript
-export declare type StringFormat = typeof StringFormat[keyof typeof StringFormat];
+export declare type StringFormat = (typeof StringFormat)[keyof typeof StringFormat];
 ```
 
 ## TaskEvent

--- a/packages/auth/src/core/strategies/redirect.test.ts
+++ b/packages/auth/src/core/strategies/redirect.test.ts
@@ -238,7 +238,8 @@ describe('core/strategies/redirect', () => {
     it('returns false if sessionStorage is permission denied', async () => {
       _getInstance<PopupRedirectResolverInternal>(
         resolver
-      )._redirectPersistence = ErroringUnavailablePersistence as unknown as Persistence;
+      )._redirectPersistence =
+        ErroringUnavailablePersistence as unknown as Persistence;
       expect(
         await _getAndClearPendingRedirectStatus(_getInstance(resolver), auth)
       ).to.be.false;

--- a/packages/auth/src/model/public_types.ts
+++ b/packages/auth/src/model/public_types.ts
@@ -416,7 +416,7 @@ export interface ActionCodeInfo {
   /**
    * The type of operation that generated the action code.
    */
-  operation: typeof ActionCodeOperationMap[keyof typeof ActionCodeOperationMap];
+  operation: (typeof ActionCodeOperationMap)[keyof typeof ActionCodeOperationMap];
 }
 
 /**
@@ -589,7 +589,7 @@ export interface ConfirmationResult {
  */
 export interface MultiFactorAssertion {
   /** The identifier of the second factor. */
-  readonly factorId: typeof FactorIdMap[keyof typeof FactorIdMap];
+  readonly factorId: (typeof FactorIdMap)[keyof typeof FactorIdMap];
 }
 
 /**
@@ -629,7 +629,7 @@ export interface MultiFactorError extends AuthError {
     /**
      * The type of operation (sign-in, linking, or re-authentication) that raised the error.
      */
-    readonly operationType: typeof OperationTypeMap[keyof typeof OperationTypeMap];
+    readonly operationType: (typeof OperationTypeMap)[keyof typeof OperationTypeMap];
   };
 }
 
@@ -646,7 +646,7 @@ export interface MultiFactorInfo {
   /** The enrollment date of the second factor formatted as a UTC string. */
   readonly enrollmentTime: string;
   /** The identifier of the second factor. */
-  readonly factorId: typeof FactorIdMap[keyof typeof FactorIdMap];
+  readonly factorId: (typeof FactorIdMap)[keyof typeof FactorIdMap];
 }
 
 /**
@@ -1049,7 +1049,7 @@ export interface UserCredential {
   /**
    * The type of operation which was used to authenticate the user (such as sign-in or link).
    */
-  operationType: typeof OperationTypeMap[keyof typeof OperationTypeMap];
+  operationType: (typeof OperationTypeMap)[keyof typeof OperationTypeMap];
 }
 
 /**

--- a/packages/messaging/src/internals/idb-manager.test.ts
+++ b/packages/messaging/src/internals/idb-manager.test.ts
@@ -72,7 +72,7 @@ describe('idb manager', () => {
 
     describe('old DB migration', () => {
       let migrateOldDatabaseStub: Stub<
-        typeof migrateOldDatabaseModule['migrateOldDatabase']
+        (typeof migrateOldDatabaseModule)['migrateOldDatabase']
       >;
 
       beforeEach(() => {

--- a/packages/messaging/src/internals/token-manager.test.ts
+++ b/packages/messaging/src/internals/token-manager.test.ts
@@ -39,9 +39,9 @@ import { getFakeTokenDetails } from '../testing/fakes/token-details';
 describe('Token Manager', () => {
   let tokenDetails: TokenDetails;
   let messaging: MessagingService;
-  let requestGetTokenStub: Stub<typeof apiModule['requestGetToken']>;
-  let requestUpdateTokenStub: Stub<typeof apiModule['requestUpdateToken']>;
-  let requestDeleteTokenStub: Stub<typeof apiModule['requestDeleteToken']>;
+  let requestGetTokenStub: Stub<(typeof apiModule)['requestGetToken']>;
+  let requestUpdateTokenStub: Stub<(typeof apiModule)['requestUpdateToken']>;
+  let requestDeleteTokenStub: Stub<(typeof apiModule)['requestDeleteToken']>;
 
   beforeEach(() => {
     tokenDetails = getFakeTokenDetails();

--- a/packages/messaging/src/listeners/sw-listeners.test.ts
+++ b/packages/messaging/src/listeners/sw-listeners.test.ts
@@ -92,9 +92,9 @@ describe('SwController', () => {
   // eslint-disable-next-line @typescript-eslint/ban-types
   let eventListenerMap: Map<string, Function>;
   let messaging: MessagingService;
-  let getTokenStub: Stub<typeof tokenManagementModule['getTokenInternal']>;
+  let getTokenStub: Stub<(typeof tokenManagementModule)['getTokenInternal']>;
   let deleteTokenStub: Stub<
-    typeof tokenManagementModule['deleteTokenInternal']
+    (typeof tokenManagementModule)['deleteTokenInternal']
   >;
 
   beforeEach(() => {

--- a/packages/storage/src/implementation/string.ts
+++ b/packages/storage/src/implementation/string.ts
@@ -22,7 +22,7 @@ import { decodeBase64 } from '../platform/base64';
  * An enumeration of the possible string formats for upload.
  * @public
  */
-export type StringFormat = typeof StringFormat[keyof typeof StringFormat];
+export type StringFormat = (typeof StringFormat)[keyof typeof StringFormat];
 /**
  * An enumeration of the possible string formats for upload.
  * @public

--- a/packages/storage/src/implementation/taskenums.ts
+++ b/packages/storage/src/implementation/taskenums.ts
@@ -62,7 +62,7 @@ export const enum InternalTaskState {
  * Represents the current state of a running upload.
  * @internal
  */
-export type TaskState = typeof TaskState[keyof typeof TaskState];
+export type TaskState = (typeof TaskState)[keyof typeof TaskState];
 
 // type keys = keyof TaskState
 /**

--- a/scripts/format/prettier.ts
+++ b/scripts/format/prettier.ts
@@ -73,7 +73,7 @@ export async function doPrettier(changedFiles?: string[]) {
       chalk`{green Validating ${changedFiles.length} files with Prettier}`
     );
   } else {
-    prettierArgs.push('{,!(node_modules)/}**/*.{js,ts}');
+    prettierArgs.push('{,!(node_modules)}/**/*.{js,ts}');
     console.log(chalk`{green Validating all .js and .ts files with Prettier}`);
   }
 


### PR DESCRIPTION
We recently bumped the `prettier` dependency (https://github.com/firebase/firebase-js-sdk/pull/7232) which included a change to `typeof` expressions (puts parens around them): https://github.com/prettier/prettier/blob/main/CHANGELOG.md#add-parentheses-for-tstypequery-to-improve-readability-14042-by-onishi-kohei

Running it on the whole repo and also running docgen on the newly changed files so that these changes don't just pop up randomly in everyone's PRs going forward.