### PR TITLE
Pin Chrome version for test-all.yml

### DIFF
--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -17,7 +17,7 @@ jobs:
     # install Chrome first, so the correct version of webdriver can be installed by chromedriver when setting up the repo
     - name: install Chrome stable
       # Install Chrome version 110.0.5481.177-1 as some Auth tests start to fail on version 111.
-      # We will retry to use the latest, once version 112 becomes stable.
+      # Temporary: Auth team will explore what's going wrong with the auth tests.
       run: |
         sudo apt-get update
         sudo apt-get install wget

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -16,9 +16,13 @@ jobs:
     steps:
     # install Chrome first, so the correct version of webdriver can be installed by chromedriver when setting up the repo
     - name: install Chrome stable
+      # Install Chrome version 110.0.5481.177-1 as some Auth tests start to fail on version 111.
+      # We will retry to use the latest, once version 112 becomes stable.
       run: |
         sudo apt-get update
-        sudo apt-get install google-chrome-stable
+        sudo apt-get install wget
+        sudo wget http://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_110.0.5481.177-1_amd64.deb
+        sudo apt-get install -f ./google-chrome-stable_110.0.5481.177-1_amd64.deb --allow-downgrades
     - uses: actions/checkout@v3
     - name: Set up Node (16)
       uses: actions/setup-node@v3

--- a/.github/workflows/test-changed-auth.yml
+++ b/.github/workflows/test-changed-auth.yml
@@ -15,7 +15,7 @@ jobs:
       # install Chrome first, so the correct version of webdriver can be installed by chromedriver when setting up the repo
       - name: install Chrome stable
         # Install Chrome version 110.0.5481.177-1 as test starts to fail on version 111.
-        # We will retry to use the latest, once version 112 becomes stable.
+        # Temporary: Auth team will explore what's going wrong with the auth tests.
         run: |
           sudo apt-get update
           sudo apt-get install wget


### PR DESCRIPTION
Add Chrome pinning to `test-all.yml`, as was done for the auth-only tests in https://github.com/firebase/firebase-js-sdk/pull/7157. Although this is not a required check, it runs on all PRs and causes noise.

Auth team is working to determine the root cause and see if the tests can be fixed or skipped.