### PR TITLE
Fix `getApp()` error message for non-autoinit situations

### DIFF
--- a/.changeset/funny-ways-carry.md
+++ b/.changeset/funny-ways-carry.md
@@ -1,0 +1,5 @@
+---
+'@firebase/app': patch
+---
+
+Make the error more helpful when `getApp()` is called before `initializeApp()`.

--- a/packages/app/src/api.test.ts
+++ b/packages/app/src/api.test.ts
@@ -206,6 +206,13 @@ describe('API tests', () => {
     it('throws retrieving a non existing App (default name)', () => {
       expect(() => getApp()).throws(/No Firebase App/);
     });
+
+    it('does not throw on a non existing App (default name) if a defaults object exists', () => {
+      global.__FIREBASE_DEFAULTS__ = { config: { apiKey: 'abcd' } };
+      const app = getApp();
+      expect(app.options.apiKey).to.equal('abcd');
+      global.__FIREBASE_DEFAULTS__ = undefined;
+    });
   });
 
   describe('getApps', () => {

--- a/packages/app/src/api.test.ts
+++ b/packages/app/src/api.test.ts
@@ -199,8 +199,12 @@ describe('API tests', () => {
       expect(getApp(appName)).to.equal(app);
     });
 
-    it('throws retrieving a non existing App', () => {
+    it('throws retrieving a non existing App (custom name)', () => {
       expect(() => getApp('RandomName')).throws(/No Firebase App 'RandomName'/);
+    });
+
+    it('throws retrieving a non existing App (default name)', () => {
+      expect(() => getApp()).throws(/No Firebase App/);
     });
   });
 

--- a/packages/app/src/api.ts
+++ b/packages/app/src/api.ts
@@ -202,7 +202,7 @@ export function initializeApp(
  */
 export function getApp(name: string = DEFAULT_ENTRY_NAME): FirebaseApp {
   const app = _apps.get(name);
-  if (!app && name === DEFAULT_ENTRY_NAME) {
+  if (!app && name === DEFAULT_ENTRY_NAME && getDefaultAppConfig()) {
     return initializeApp();
   }
   if (!app) {

--- a/packages/app/src/errors.ts
+++ b/packages/app/src/errors.ts
@@ -34,7 +34,7 @@ export const enum AppError {
 const ERRORS: ErrorMap<AppError> = {
   [AppError.NO_APP]:
     "No Firebase App '{$appName}' has been created - " +
-    'call Firebase App.initializeApp()',
+    'call initializeApp()',
   [AppError.BAD_APP_NAME]: "Illegal App name: '{$appName}",
   [AppError.DUPLICATE_APP]:
     "Firebase App named '{$appName}' already exists with different options or config",

--- a/packages/app/src/errors.ts
+++ b/packages/app/src/errors.ts
@@ -34,7 +34,7 @@ export const enum AppError {
 const ERRORS: ErrorMap<AppError> = {
   [AppError.NO_APP]:
     "No Firebase App '{$appName}' has been created - " +
-    'call initializeApp()',
+    'call initializeApp() first',
   [AppError.BAD_APP_NAME]: "Illegal App name: '{$appName}",
   [AppError.DUPLICATE_APP]:
     "Firebase App named '{$appName}' already exists with different options or config",

--- a/packages/app/src/internal.test.ts
+++ b/packages/app/src/internal.test.ts
@@ -30,6 +30,7 @@ import {
   _getProvider,
   _removeServiceInstance
 } from './internal';
+import { logger } from './logger';
 
 declare module '@firebase/component' {
   interface NameServiceMapping {
@@ -60,10 +61,12 @@ describe('Internal API tests', () => {
     it('does NOT throw registering duplicate components', () => {
       const app = initializeApp({}) as FirebaseAppImpl;
       const testComp = createTestComponent('test');
+      const debugStub = stub(logger, 'debug');
 
       _addComponent(app, testComp);
 
       expect(() => _addComponent(app, testComp)).to.not.throw();
+      expect(debugStub).to.be.called;
       expect(app.container.getProvider('test').getComponent()).to.equal(
         testComp
       );


### PR DESCRIPTION
See https://github.com/firebase/firebase-js-sdk/issues/7262

The `if` block added for modular autoinit is intercepting errors that users should be getting for calling `getApp()` before `initializeApp()`.  This change uses `getDefaultAppConfig()` as an additional condition. If it returns undefined, this isn't a modular autoinit situation and the user will get the correct `NO_APP` error.

Also updated the error message with the correct modular name for `initializeApp()`.

Also stubbed `logger.debug` on a test that had a verbose debug log that was cluttering test output.