### PR TITLE
Fix eslint vscode settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,5 +10,6 @@
     "**/node_modules": true
   },
   "typescript.tsdk": "node_modules/typescript/lib",
-  "files.associations": { "*.json": "jsonc" }
+  "files.associations": { "*.json": "jsonc" },
+  "eslint.workingDirectories": [{ "mode": "auto" }]
 }


### PR DESCRIPTION
This should fix incorrect `import/no-extraneous-dependencies` eslint errors that only happen in the VSCode UI because it has trouble resolving dependencies in a monorepo.

More on the setting here: https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint#settings-options