### PR TITLE
Catch more heartbeat read/write errors

### DIFF
--- a/.changeset/sixty-dolls-report.md
+++ b/.changeset/sixty-dolls-report.md
@@ -1,0 +1,5 @@
+---
+'@firebase/app': patch
+---
+
+Catch more heartbeat read/write errors.

--- a/packages/app/src/indexeddb.ts
+++ b/packages/app/src/indexeddb.ts
@@ -62,10 +62,11 @@ export async function readHeartbeatsFromIndexedDB(
 ): Promise<HeartbeatsInIndexedDB | undefined> {
   try {
     const db = await getDbPromise();
-    return db
+    const result = await db
       .transaction(STORE_NAME)
       .objectStore(STORE_NAME)
-      .get(computeKey(app)) as Promise<HeartbeatsInIndexedDB | undefined>;
+      .get(computeKey(app));
+    return result;
   } catch (e) {
     if (e instanceof FirebaseError) {
       logger.warn(e.message);
@@ -87,7 +88,7 @@ export async function writeHeartbeatsToIndexedDB(
     const tx = db.transaction(STORE_NAME, 'readwrite');
     const objectStore = tx.objectStore(STORE_NAME);
     await objectStore.put(heartbeatObject, computeKey(app));
-    return tx.done;
+    await tx.done;
   } catch (e) {
     if (e instanceof FirebaseError) {
       logger.warn(e.message);


### PR DESCRIPTION
These indexeddb read/write functions are supposed to never throw, as they are part of platform logging, which should never impact user functionality. There is a try/catch to prevent this, but unfortunately the last statement in each try block was returning a promise directly instead of using `await`, which prevents `try` from catching errors in that statement. Converted them to await statements. They should be properly caught by `try/catch` now.

Fixes https://github.com/firebase/firebase-js-sdk/issues/6871