### PR TITLE
Allow port numbers in authdomain

### DIFF
--- a/.changeset/small-chairs-explain.md
+++ b/.changeset/small-chairs-explain.md
@@ -1,0 +1,5 @@
+---
+'@firebase/auth': patch
+---
+
+Allow port numbers in authDomain

--- a/packages/auth/src/core/auth/initialize.test.ts
+++ b/packages/auth/src/core/auth/initialize.test.ts
@@ -140,7 +140,7 @@ describe('core/auth/initialize', () => {
     fakeApp = initializeApp({
       apiKey: 'fake-key',
       appId: 'fake-app-id',
-      authDomain: 'fake-auth-domain'
+      authDomain: 'fake-auth-domain:9999'
     });
   });
 
@@ -165,7 +165,7 @@ describe('core/auth/initialize', () => {
         apiHost: 'identitytoolkit.googleapis.com',
         apiKey: 'fake-key',
         apiScheme: 'https',
-        authDomain: 'fake-auth-domain',
+        authDomain: 'fake-auth-domain:9999',
         clientPlatform: expectedClientPlatform,
         sdkClientVersion: expectedSdkClientVersion,
         tokenApiHost: 'securetoken.googleapis.com'

--- a/packages/auth/src/core/auth/register.ts
+++ b/packages/auth/src/core/auth/register.ts
@@ -72,10 +72,7 @@ export function registerAuth(clientPlatform: ClientPlatform): void {
           AuthErrorCode.INVALID_API_KEY,
           { appName: app.name }
         );
-        // Auth domain is optional if IdP sign in isn't being used
-        _assert(!authDomain?.includes(':'), AuthErrorCode.ARGUMENT_ERROR, {
-          appName: app.name
-        });
+
         const config: ConfigInternal = {
           apiKey,
           authDomain,


### PR DESCRIPTION
### Testing
Used demo app to test changes. The authdomain was set to localhost:8080 and I saw the redirect hitting URL 
https://localhost:8080/__/auth/handler?apiKey=<API_KEY>&appName=%5BDEFAULT%5D&authType=signInViaRedirect&redirectUrl=http%3A%2F%2Flocalhost%3A5000%2F&v=9.8.1&providerId=google.com&scopes=profile

Fixes: https://github.com/firebase/firebase-js-sdk/issues/7233