### PR TITLE
Removes assertion that API key is nonempty.

### DIFF
--- a/packages/auth/src/core/auth/register.ts
+++ b/packages/auth/src/core/auth/register.ts
@@ -65,10 +65,10 @@ export function registerAuth(clientPlatform: ClientPlatform): void {
           container.getProvider<'heartbeat'>('heartbeat');
         const appCheckServiceProvider =
           container.getProvider<'app-check-internal'>('app-check-internal');
-        const { apiKey, authDomain } = app.options;
-
+        const { apiKey, authDomain, useEmulators } = app.options;
+        // Alternatively, we could just get rid of this assert
         _assert(
-          apiKey && !apiKey.includes(':'),
+          useEmulators || (apiKey && !apiKey.includes(':')),
           AuthErrorCode.INVALID_API_KEY,
           { appName: app.name }
         );

--- a/packages/auth/src/core/auth/register.ts
+++ b/packages/auth/src/core/auth/register.ts
@@ -65,10 +65,9 @@ export function registerAuth(clientPlatform: ClientPlatform): void {
           container.getProvider<'heartbeat'>('heartbeat');
         const appCheckServiceProvider =
           container.getProvider<'app-check-internal'>('app-check-internal');
-        const { apiKey, authDomain, useEmulators } = app.options;
-        // Alternatively, we could just get rid of this assert
+        const { apiKey, authDomain } = app.options;
         _assert(
-          useEmulators || (apiKey && !apiKey.includes(':')),
+          !apiKey.includes(':'),
           AuthErrorCode.INVALID_API_KEY,
           { appName: app.name }
         );


### PR DESCRIPTION
Removes assertion that API key is nonempty. This check is causing errors for emulator users who don't provide a fake API key (https://github.com/firebase/firebase-tools/issues/5218#issuecomment-1535494798).