### PR TITLE
Fix changeset wording for `experimentalLongPollingOptions.timeoutSeconds`

### DIFF
--- a/.changeset/witty-wasps-play.md
+++ b/.changeset/witty-wasps-play.md
@@ -3,4 +3,4 @@
 'firebase': minor
 ---
 
-Added the ability to configure the long-polling hanging get request timeout using the new `idleHttpRequestTimeoutSeconds` setting
+Added the ability to configure the long-polling hanging get request timeout using the new `experimentalLongPollingOptions.timeoutSeconds` setting


### PR DESCRIPTION
This changeset was created by https://github.com/firebase/firebase-js-sdk/pull/7176, but its wording neglected to update `idleHttpRequestTimeoutSeconds` to `experimentalLongPollingOptions.timeoutSeconds`. This commit fixes the wording to specify the correct property.