### PR TITLE
Firestore: Remove the no-android tag from bloom filter spec tests

### DIFF
--- a/packages/firestore/test/unit/specs/existence_filter_spec.test.ts
+++ b/packages/firestore/test/unit/specs/existence_filter_spec.test.ts
@@ -277,9 +277,8 @@ describeSpec('Existence Filters:', [], () => {
    */
   specTest(
     'Full re-query is skipped when bloom filter can identify documents deleted',
-    // TODO(b/278759194) Remove 'no-android' once bloom filter is merged.
     // TODO(b/278759251) Remove 'no-ios' once bloom filter is merged.
-    ['no-ios', 'no-android'],
+    ['no-ios'],
     () => {
       const query1 = query('collection');
       const docA = doc('collection/a', 1000, { v: 1 });
@@ -311,9 +310,8 @@ describeSpec('Existence Filters:', [], () => {
 
   specTest(
     'Full re-query is triggered when bloom filter can not identify documents deleted',
-    // TODO(b/278759194) Remove 'no-android' once bloom filter is merged.
     // TODO(b/278759251) Remove 'no-ios' once bloom filter is merged.
-    ['no-ios', 'no-android'],
+    ['no-ios'],
     () => {
       const query1 = query('collection');
       const docA = doc('collection/a', 1000, { v: 1 });
@@ -345,9 +343,8 @@ describeSpec('Existence Filters:', [], () => {
 
   specTest(
     'Bloom filter can process special characters in document name',
-    // TODO(b/278759194) Remove 'no-android' once bloom filter is merged.
     // TODO(b/278759251) Remove 'no-ios' once bloom filter is merged.
-    ['no-ios', 'no-android'],
+    ['no-ios'],
     () => {
       const query1 = query('collection');
       const docA = doc('collection/ÀÒ∑', 1000, { v: 1 });
@@ -375,9 +372,8 @@ describeSpec('Existence Filters:', [], () => {
 
   specTest(
     'Bloom filter fills in default values for undefined padding and hashCount',
-    // TODO(b/278759194) Remove 'no-android' once bloom filter is merged.
     // TODO(b/278759251) Remove 'no-ios' once bloom filter is merged.
-    ['no-ios', 'no-android'],
+    ['no-ios'],
     () => {
       const query1 = query('collection');
       const docA = doc('collection/a', 1000, { v: 1 });
@@ -449,9 +445,8 @@ describeSpec('Existence Filters:', [], () => {
 
   specTest(
     'Full re-query is triggered when bloom filter hashCount is invalid',
-    // TODO(b/278759194) Remove 'no-android' once bloom filter is merged.
     // TODO(b/278759251) Remove 'no-ios' once bloom filter is merged.
-    ['no-ios', 'no-android'],
+    ['no-ios'],
     () => {
       const query1 = query('collection');
       const docA = doc('collection/a', 1000, { v: 1 });
@@ -485,9 +480,8 @@ describeSpec('Existence Filters:', [], () => {
 
   specTest(
     'Full re-query is triggered when bloom filter is empty',
-    // TODO(b/278759194) Remove 'no-android' once bloom filter is merged.
     // TODO(b/278759251) Remove 'no-ios' once bloom filter is merged.
-    ['no-ios', 'no-android'],
+    ['no-ios'],
     () => {
       const query1 = query('collection');
       const docA = doc('collection/a', 1000, { v: 1 });
@@ -522,9 +516,8 @@ describeSpec('Existence Filters:', [], () => {
 
   specTest(
     'Same documents can have different bloom filters',
-    // TODO(b/278759194) Remove 'no-android' once bloom filter is merged.
     // TODO(b/278759251) Remove 'no-ios' once bloom filter is merged.
-    ['no-ios', 'no-android'],
+    ['no-ios'],
     () => {
       const query1 = query('collection', filter('v', '<=', 2));
       const query2 = query('collection', filter('v', '>=', 2));
@@ -574,9 +567,8 @@ describeSpec('Existence Filters:', [], () => {
 
   specTest(
     'Bloom filter is handled at global snapshot',
-    // TODO(b/278759194) Remove 'no-android' once bloom filter is merged.
     // TODO(b/278759251) Remove 'no-ios' once bloom filter is merged.
-    ['no-ios', 'no-android'],
+    ['no-ios'],
     () => {
       const query1 = query('collection');
       const docA = doc('collection/a', 1000, { v: 1 });
@@ -608,9 +600,8 @@ describeSpec('Existence Filters:', [], () => {
 
   specTest(
     'Bloom filter limbo resolution is denied',
-    // TODO(b/278759194) Remove 'no-android' once bloom filter is merged.
     // TODO(b/278759251) Remove 'no-ios' once bloom filter is merged.
-    ['no-ios', 'no-android'],
+    ['no-ios'],
     () => {
       const query1 = query('collection');
       const docA = doc('collection/a', 1000, { v: 1 });
@@ -640,9 +631,8 @@ describeSpec('Existence Filters:', [], () => {
 
   specTest(
     'Bloom filter with large size works as expected',
-    // TODO(b/278759194) Remove 'no-android' once bloom filter is merged.
     // TODO(b/278759251) Remove 'no-ios' once bloom filter is merged.
-    ['no-ios', 'no-android'],
+    ['no-ios'],
     () => {
       const query1 = query('collection');
       const docs = [];

--- a/packages/firestore/test/unit/specs/limbo_spec.test.ts
+++ b/packages/firestore/test/unit/specs/limbo_spec.test.ts
@@ -929,9 +929,8 @@ describeSpec('Limbo Documents:', [], () => {
 
   specTest(
     'Limbo resolution throttling with bloom filter application',
-    // TODO(b/278759194) Remove 'no-android' once bloom filter is merged.
     // TODO(b/278759251) Remove 'no-ios' once bloom filter is merged.
-    ['no-ios', 'no-android'],
+    ['no-ios'],
     () => {
       const query1 = query('collection');
       const docA1 = doc('collection/a1', 1000, { key: 'a1' });

--- a/packages/firestore/test/unit/specs/listen_spec.test.ts
+++ b/packages/firestore/test/unit/specs/listen_spec.test.ts
@@ -1812,9 +1812,8 @@ describeSpec('Listens:', [], () => {
 
   specTest(
     'Resuming a query should specify expectedCount when adding the target',
-    // TODO(b/278759194) Remove 'no-android' once bloom filter is merged.
     // TODO(b/278759251) Remove 'no-ios' once bloom filter is merged.
-    ['no-ios', 'no-android'],
+    ['no-ios'],
     () => {
       const query1 = query('collection');
       const docA = doc('collection/a', 1000, { key: 'a' });
@@ -1848,9 +1847,8 @@ describeSpec('Listens:', [], () => {
 
   specTest(
     'Resuming a query should specify expectedCount that does not include pending mutations',
-    // TODO(b/278759194) Remove 'no-android' once bloom filter is merged.
     // TODO(b/278759251) Remove 'no-ios' once bloom filter is merged.
-    ['no-ios', 'no-android'],
+    ['no-ios'],
     () => {
       const query1 = query('collection');
       const docA = doc('collection/a', 1000, { key: 'a' });
@@ -1879,9 +1877,8 @@ describeSpec('Listens:', [], () => {
 
   specTest(
     'ExpectedCount in listen request should work after coming back online',
-    // TODO(b/278759194) Remove 'no-android' once bloom filter is merged.
     // TODO(b/278759251) Remove 'no-ios' once bloom filter is merged.
-    ['no-ios', 'no-android'],
+    ['no-ios'],
     () => {
       const query1 = query('collection');
       const docA = doc('collection/a', 1000, { key: 'a' });


### PR DESCRIPTION
Remove the no-android tag from bloom filter spec tests, now that the feature has been merged into the android sdk in https://github.com/firebase/firebase-android-sdk/pull/4982.

The spec test changes from this PR were ported to the iOS SDK in https://github.com/firebase/firebase-ios-sdk/pull/11245. Porting to the Android SDK is not needed since these changes were included in https://github.com/firebase/firebase-android-sdk/pull/4982.