### PR TITLE
Add label for GitHub Issue hotlist mirroring

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report_v2.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report_v2.yaml
@@ -1,6 +1,7 @@
 name: 🐞 Bug Report V2
 description: File a bug report
 title: '[Bug]: '
+labels: 'new, type: question'
 body:
   - type: markdown
     id: before-you-start


### PR DESCRIPTION
We will use those labels to help configure which hotlist the GitHub Issue mirroring bot puts each issue.

Also used by other firebase teams https://github.com/search?q=org%3Afirebase%20%22new%2C%20type%3A%20question%22&type=code