### PR TITLE
Update Node version to 16 in workflows

### DIFF
--- a/.github/workflows/canary-deploy.yml
+++ b/.github/workflows/canary-deploy.yml
@@ -17,10 +17,10 @@ jobs:
       with:
         # Canary release script requires git history and tags.
         fetch-depth: 0
-    - name: Set up Node (14)
+    - name: Set up Node (16)
       uses: actions/setup-node@v3
       with:
-        node-version: 14.x
+        node-version: 16.x
     - name: Yarn install
       run: yarn
     - name: Deploy canary

--- a/.github/workflows/check-changeset.yml
+++ b/.github/workflows/check-changeset.yml
@@ -20,10 +20,10 @@ jobs:
       with:
         # This makes Actions fetch all Git history so check_changeset script can diff properly.
         fetch-depth: 0
-    - name: Set up Node (14)
+    - name: Set up Node (16)
       uses: actions/setup-node@v3
       with:
-        node-version: 14.x
+        node-version: 16.x
     - name: Yarn install
       run: yarn
     - name: Run changeset script

--- a/.github/workflows/check-docs.yml
+++ b/.github/workflows/check-docs.yml
@@ -13,10 +13,10 @@ jobs:
       with:
         # get all history for the diff
         fetch-depth: 0
-    - name: Set up Node (14)
+    - name: Set up Node (16)
       uses: actions/setup-node@v3
       with:
-        node-version: 14.x
+        node-version: 16.x
     - name: Yarn install
       run: yarn
     - name: Run doc generation (devsite docs)

--- a/.github/workflows/check-pkg-paths.yml
+++ b/.github/workflows/check-pkg-paths.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Node (16)
       uses: actions/setup-node@v3
       with:
-        node-version: 16.xx
+        node-version: 16.x
     - name: Yarn install
       run: yarn
     - name: Yarn build

--- a/.github/workflows/check-pkg-paths.yml
+++ b/.github/workflows/check-pkg-paths.yml
@@ -13,10 +13,10 @@ jobs:
       with:
         # This makes Actions fetch all Git history so run-changed script can diff properly.
         fetch-depth: 0
-    - name: Set up Node (14)
+    - name: Set up Node (16)
       uses: actions/setup-node@v3
       with:
-        node-version: 14.x
+        node-version: 16.xx
     - name: Yarn install
       run: yarn
     - name: Yarn build

--- a/.github/workflows/deploy-config.yml
+++ b/.github/workflows/deploy-config.yml
@@ -20,10 +20,10 @@ jobs:
       with:
         # This makes Actions fetch all Git history so run-changed script can diff properly.
         fetch-depth: 0
-    - name: Set up Node (14)
+    - name: Set up node (16)
       uses: actions/setup-node@v3
       with:
-        node-version: 14.x
+        node-version: 16.x
     - name: Yarn install
       run: yarn
     - name: Deploy project config if needed

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -17,10 +17,10 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@master
-      - name: Set up Node (14)
+      - name: Set up Node (16)
         uses: actions/setup-node@master
         with:
-          node-version: 14.x
+          node-version: 16.x
       - name: install Chrome stable
         run: |
           sudo apt-get update

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -17,10 +17,10 @@ jobs:
       with:
         # get all history for the diff
         fetch-depth: 0
-    - name: Set up Node (14)
+    - name: Set up node (16)
       uses: actions/setup-node@v3
       with:
-        node-version: 14.x
+        node-version: 16.x
     - name: Yarn install
       run: yarn
     - name: Run formatting script

--- a/.github/workflows/health-metrics-pull-request.yml
+++ b/.github/workflows/health-metrics-pull-request.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 14.x
+          node-version: 16.x
       - uses: 'google-github-actions/auth@v0'
         with:
           credentials_json: '${{ secrets.GCP_SA_KEY }}'
@@ -43,7 +43,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 14.x
+          node-version: 16.x
       - uses: 'google-github-actions/auth@v0'
         with:
           credentials_json: '${{ secrets.GCP_SA_KEY }}'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,10 +9,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Set up Node (14)
+    - name: Set up node (16)
       uses: actions/setup-node@v3
       with:
-        node-version: 14.x
+        node-version: 16.x
     - name: yarn install
       run: yarn
     - name: yarn lint

--- a/.github/workflows/prerelease-manual-deploy.yml
+++ b/.github/workflows/prerelease-manual-deploy.yml
@@ -20,10 +20,10 @@ jobs:
           with:
             # Canary release script requires git history and tags.
             fetch-depth: 0
-        - name: Set up Node (14)
+        - name: Set up node (16)
           uses: actions/setup-node@v3
           with:
-            node-version: 14.x
+            node-version: 16.x
         - name: Yarn install
           run: yarn
         - name: Deploy prerelease

--- a/.github/workflows/release-log.yml
+++ b/.github/workflows/release-log.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@master
 
-      - name: Setup Node.js 14.x
+      - name: Setup Node.js 16.x
         uses: actions/setup-node@master
         with:
           node-version: 16.x

--- a/.github/workflows/release-log.yml
+++ b/.github/workflows/release-log.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Node.js 14.x
         uses: actions/setup-node@master
         with:
-          node-version: 14.x
+          node-version: 16.x
 
       - name: Get PR number and send to tracker.
         run: node scripts/ci/log-changesets.js

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -18,7 +18,7 @@ jobs:
           # This makes Actions fetch all Git history so that Changesets can generate changelogs with the correct commits
           fetch-depth: 0
 
-      - name: Setup Node.js 14.x
+      - name: Setup Node.js 16.x
         uses: actions/setup-node@master
         with:
           node-version: 16.x

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Node.js 14.x
         uses: actions/setup-node@master
         with:
-          node-version: 14.x
+          node-version: 16.x
 
       - name: Install Dependencies
         run: yarn

--- a/.github/workflows/release-prod.yml
+++ b/.github/workflows/release-prod.yml
@@ -18,10 +18,10 @@ jobs:
       contents: write
 
     steps:
-    - name: Set up Node (14)
+    - name: Set up node (16)
       uses: actions/setup-node@v3
       with:
-        node-version: 14.x
+        node-version: 16.x
     - name: Checkout release branch (with history)
       uses: actions/checkout@master
       with:

--- a/.github/workflows/release-staging.yml
+++ b/.github/workflows/release-staging.yml
@@ -24,10 +24,10 @@ jobs:
     # Block this workflow if run on a non-release branch.
     if: github.event.inputs.release-branch == 'release' || endsWith(github.event.inputs.release-branch, '-releasebranch')
     steps:
-    - name: Set up Node (14)
+    - name: Set up node (16)
       uses: actions/setup-node@v3
       with:
-        node-version: 14.x
+        node-version: 16.x
     - name: Merge master into release
       uses: actions/github-script@v6
       with:

--- a/.github/workflows/release-tweet.yml
+++ b/.github/workflows/release-tweet.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Node.js 14.x
         uses: actions/setup-node@master
         with:
-          node-version: 14.x
+          node-version: 16.x
       - name: Poll release notes page on devsite
         run: node scripts/ci/poll_release_notes.js
         env:

--- a/.github/workflows/release-tweet.yml
+++ b/.github/workflows/release-tweet.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@master
-      - name: Setup Node.js 14.x
+      - name: Setup Node.js 16.x
         uses: actions/setup-node@master
         with:
           node-version: 16.x

--- a/.github/workflows/update-api-reports.yml
+++ b/.github/workflows/update-api-reports.yml
@@ -16,10 +16,10 @@ jobs:
         # checkout HEAD commit instead of merge commit
         ref: ${{ github.event.pull_request.head.ref }}
         token: ${{ github.token }}
-    - name: Set up Node (14)
+    - name: Set up node (16)
       uses: actions/setup-node@v3
       with:
-        node-version: 14.x
+        node-version: 16.x
     - name: Yarn install
       run: yarn
     - name: Update API reports


### PR DESCRIPTION
E2E tests are failing because they use `firebase-tools` which has been recently updated. The latest version requires Node 16.13.0 or greater. We should probably update it across all workflows. We should not update it to 18 because our unit tests do not work in Node 18 due to needing to upgrade webpack.