### PR TITLE
Firestore: Bump the version of webchannel-wrapper so that it gets released

### DIFF
--- a/.changeset/quiet-cycles-complain.md
+++ b/.changeset/quiet-cycles-complain.md
@@ -1,6 +1,4 @@
 ---
-'firebase': patch
-'@firebase/firestore': patch
 '@firebase/webchannel-wrapper': patch
 ---
 

--- a/.changeset/quiet-cycles-complain.md
+++ b/.changeset/quiet-cycles-complain.md
@@ -1,0 +1,7 @@
+---
+'firebase': patch
+'@firebase/firestore': patch
+'@firebase/webchannel-wrapper': patch
+---
+
+Fix the new `experimentalLongPollingOptions.timeoutSeconds` setting, which was released in v9.22.0 but didn't work.


### PR DESCRIPTION
In https://github.com/firebase/firebase-js-sdk/pull/7176 the new Firestore setting `experimentalLongPollingOptions.timeoutSeconds` was implemented; however, that PR forgot to mark `@firestore/webchannel-wrapper` as needing a new release and, therefore, the upgraded google-closure-library dependency was not picked up in the v9.22.0 release. As a result, setting `experimentalLongPollingOptions.timeoutSeconds` in that version has no effect. This PR bumps the version of webchannel-wrapper so it will get released with the upgraded google-closure-library dependency that implements the long polling timeout feature.

Fixes: #6987