### PR TITLE
Log publish details again

### DIFF
--- a/scripts/release/utils/publish.ts
+++ b/scripts/release/utils/publish.ts
@@ -135,7 +135,16 @@ async function publishPackageInCI(
       }" >> ~/.npmrc`
     );
 
-    return spawn('npm', args, { cwd: path });
+    const spawnPromise = spawn('npm', args, { cwd: path });
+    const childProcess = spawnPromise.childProcess;
+    childProcess.stdout?.on('data', function (data) {
+      console.log(`[publishing ${pkg}] stdout: `, data.toString());
+    });
+    childProcess.stderr?.on('data', function (data) {
+      console.log(`[publishing ${pkg}] stderr: `, data.toString());
+    });
+    await spawnPromise;
+    return spawnPromise;
   } catch (err) {
     throw err;
   }


### PR DESCRIPTION
Restore https://github.com/firebase/firebase-js-sdk/pull/7295

It leaves very long logs so we need to get rid of it later or add an option, but we need this to better debug what's going wrong with the NPM publish.