### PR TITLE
More logging for npm publish

### DIFF
--- a/.github/workflows/release-staging.yml
+++ b/.github/workflows/release-staging.yml
@@ -16,6 +16,10 @@ on:
         options:
         - master
         - v8
+      verbose:
+        description: 'Enable verbose logging'
+        type: boolean
+        default: false
 
 jobs:
   deploy:
@@ -107,6 +111,7 @@ jobs:
         NPM_TOKEN_APP_CHECK_COMPAT: ${{ secrets.NPM_TOKEN_APP_CHECK_COMPAT }}
         NPM_TOKEN_API_DOCUMENTER: ${{ secrets.NPM_TOKEN_API_DOCUMENTER }}
         CI: true
+        VERBOSE_NPM_LOGGING: ${{github.event.inputs.verbose}}
     - name: Get release version
       id: get-version
       # STAGING_VERSION = version with staging hash, e.g. 1.2.3-20430523

--- a/scripts/release/utils/publish.ts
+++ b/scripts/release/utils/publish.ts
@@ -131,7 +131,7 @@ async function publishPackageInCI(
     }
 
     if (process.env.VERBOSE_NPM_LOGGING === 'true') {
-      args.push('--verbose')
+      args.push('--verbose');
     }
 
     // Write proxy registry token for this package to .npmrc.

--- a/scripts/release/utils/publish.ts
+++ b/scripts/release/utils/publish.ts
@@ -108,6 +108,8 @@ async function publishPackageInCI(
   npmTag: string,
   dryRun: boolean
 ) {
+  let stdoutText = '';
+  let stderrText = '';
   try {
     const path = await mapPkgNameToPkgPath(pkg);
 
@@ -128,24 +130,34 @@ async function publishPackageInCI(
       args.push('--dry-run');
     }
 
+    if (process.env.VERBOSE_NPM_LOGGING === 'true') {
+      args.push('--verbose')
+    }
+
     // Write proxy registry token for this package to .npmrc.
     await exec(
       `echo "//wombat-dressing-room.appspot.com/:_authToken=${
         process.env[getEnvTokenKey(pkg)]
       }" >> ~/.npmrc`
     );
-
     const spawnPromise = spawn('npm', args, { cwd: path });
     const childProcess = spawnPromise.childProcess;
+    // These logs can be very verbose. Only print them if there's
+    // an error.
     childProcess.stdout?.on('data', function (data) {
-      console.log(`[publishing ${pkg}] stdout: `, data.toString());
+      stdoutText += data.toString();
     });
     childProcess.stderr?.on('data', function (data) {
-      console.log(`[publishing ${pkg}] stderr: `, data.toString());
+      stderrText += data.toString();
     });
     await spawnPromise;
     return spawnPromise;
   } catch (err) {
+    console.log(`Error publishing ${pkg}`);
+    console.log(`stdout for ${pkg} publish:`);
+    console.log(stdoutText);
+    console.log(`stderr for ${pkg} publish:`);
+    console.error(stderrText);
     throw err;
   }
 }


### PR DESCRIPTION
- Add a workflow option to set NPM publish `--verbose` option.
- Only print publish logs if a publish task failed