### PR TITLE
More logging and increase memory limit

### DIFF
--- a/.changeset/quiet-drinks-cross.md
+++ b/.changeset/quiet-drinks-cross.md
@@ -1,6 +1,0 @@
----
-'@firebase/auth': patch
-'@firebase/firestore': patch
----
-
-Test

--- a/.changeset/quiet-drinks-cross.md
+++ b/.changeset/quiet-drinks-cross.md
@@ -1,0 +1,6 @@
+---
+'@firebase/auth': patch
+'@firebase/firestore': patch
+---
+
+Test

--- a/.github/workflows/release-staging.yml
+++ b/.github/workflows/release-staging.yml
@@ -33,6 +33,8 @@ jobs:
       uses: actions/setup-node@v3
       with:
         node-version: 16.x
+    - name: Bump Node memory limit
+      run: echo "NODE_OPTIONS=--max_old_space_size=4096" >> $GITHUB_ENV
     - name: Merge master into release
       uses: actions/github-script@v6
       with:

--- a/.github/workflows/release-staging.yml
+++ b/.github/workflows/release-staging.yml
@@ -16,6 +16,7 @@ on:
         options:
         - master
         - v8
+        - ch-debug-staging
       verbose:
         description: 'Enable verbose logging'
         type: boolean

--- a/.github/workflows/release-staging.yml
+++ b/.github/workflows/release-staging.yml
@@ -16,7 +16,6 @@ on:
         options:
         - master
         - v8
-        - ch-debug-staging
       verbose:
         description: 'Enable verbose logging'
         type: boolean

--- a/scripts/release/utils/publish.ts
+++ b/scripts/release/utils/publish.ts
@@ -151,6 +151,12 @@ async function publishPackageInCI(
       stderrText += data.toString();
     });
     await spawnPromise;
+    if (process.env.VERBOSE_NPM_LOGGING === 'true') {
+      console.log(`stdout for ${pkg} publish:`);
+      console.log(stdoutText);
+      console.log(`stderr for ${pkg} publish:`);
+      console.error(stderrText);
+    }
     return spawnPromise;
   } catch (err) {
     console.log(`Error publishing ${pkg}`);


### PR DESCRIPTION
Trying a few more things to fix or diagnose staging problems.

- bump memory limit in case memory is the issue (we do this on builds)
- ensure it always spits out all logs if the "verbose" option is enabled 