### PR TITLE
Cleanup TOTP code to include Firebase User reference in MultiFactorSession.

### DIFF
--- a/packages/auth/src/mfa/assertions/totp.test.ts
+++ b/packages/auth/src/mfa/assertions/totp.test.ts
@@ -12,18 +12,14 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License. 
+ * limitations under the License.
  */
 
 import { expect, use } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 
 import { mockEndpoint } from '../../../test/helpers/api/helper';
-import { 
-  testAuth, 
-  TestAuth, 
-  testUser 
-} from '../../../test/helpers/mock_auth';
+import { testAuth, TestAuth, testUser } from '../../../test/helpers/mock_auth';
 import * as mockFetch from '../../../test/helpers/mock_fetch';
 import { Endpoint } from '../../api';
 import { MultiFactorSessionImpl } from '../../mfa/mfa_session';

--- a/packages/auth/src/mfa/assertions/totp.test.ts
+++ b/packages/auth/src/mfa/assertions/totp.test.ts
@@ -85,7 +85,7 @@ describe('core/mfa/assertions/totp/TotpMultiFactorGenerator', () => {
     });
     afterEach(mockFetch.tearDown);
 
-    it('should throw error if auth instance is not found in mfaSession', async () => {
+    it('should throw error if user instance is not found in mfaSession', async () => {
       try {
         session = MultiFactorSessionImpl._fromIdtoken(
           'enrollment-id-token',
@@ -131,7 +131,6 @@ describe('core/mfa/assertions/totp/TotpMultiFactorGenerator', () => {
 
 describe('core/mfa/totp/assertions/TotpMultiFactorAssertionImpl', () => {
   let auth: TestAuth;
-  let user: UserInternal;
   let assertion: TotpMultiFactorAssertionImpl;
   let session: MultiFactorSessionImpl;
   let secret: TotpSecret;
@@ -164,6 +163,7 @@ describe('core/mfa/totp/assertions/TotpMultiFactorAssertionImpl', () => {
   afterEach(mockFetch.tearDown);
 
   describe('enroll', () => {
+    let user: UserInternal;
     beforeEach(() => {
       session = MultiFactorSessionImpl._fromIdtoken(
         'enrollment-id-token',
@@ -185,9 +185,8 @@ describe('core/mfa/totp/assertions/TotpMultiFactorAssertionImpl', () => {
           sessionInfo: 'verification-id'
         }
       });
-      if (session.user) {
-        expect(session.user.auth).to.eql(auth);
-      }
+      expect(session.user).to.not.eql(undefined);
+      expect(session.user).to.eql(user);
     });
 
     context('with display name', () => {
@@ -210,9 +209,8 @@ describe('core/mfa/totp/assertions/TotpMultiFactorAssertionImpl', () => {
             sessionInfo: 'verification-id'
           }
         });
-        if (session.user) {
-          expect(session.user.auth).to.eql(auth);
-        }
+        expect(session.user).to.not.eql(undefined);
+        expect(session.user).to.eql(user);
       });
     });
   });
@@ -291,7 +289,6 @@ describe('core/mfa/assertions/totp/TotpSecret', async () => {
   // this is the name used by the fake app in testAuth().
   const fakeAppName: AppName = 'test-app';
   const fakeEmail: string = 'user@email';
-  //const fakeUid has been declared as a global variable "uid"
   const auth = await testAuth();
   const secret = TotpSecret._fromStartTotpMfaEnrollmentResponse(
     serverResponse,

--- a/packages/auth/src/mfa/assertions/totp.test.ts
+++ b/packages/auth/src/mfa/assertions/totp.test.ts
@@ -185,7 +185,7 @@ describe('core/mfa/totp/assertions/TotpMultiFactorAssertionImpl', () => {
           sessionInfo: 'verification-id'
         }
       });
-      expect(session.user).to.not.eql(undefined);
+      expect(session.user).to.not.be.undefined;
       expect(session.user).to.eql(user);
     });
 
@@ -209,7 +209,7 @@ describe('core/mfa/totp/assertions/TotpMultiFactorAssertionImpl', () => {
             sessionInfo: 'verification-id'
           }
         });
-        expect(session.user).to.not.eql(undefined);
+        expect(session.user).to.not.be.undefined;
         expect(session.user).to.eql(user);
       });
     });

--- a/packages/auth/src/mfa/assertions/totp.test.ts
+++ b/packages/auth/src/mfa/assertions/totp.test.ts
@@ -41,6 +41,7 @@ use(chaiAsPromised);
 describe('core/mfa/assertions/totp/TotpMultiFactorGenerator', () => {
   let auth: TestAuth;
   let session: MultiFactorSessionImpl;
+  const fakeUid: string = 'uid';
   const startEnrollmentResponse: StartTotpMfaEnrollmentResponse = {
     totpSessionInfo: {
       sharedSecretKey: 'key123',

--- a/packages/auth/src/mfa/assertions/totp.test.ts
+++ b/packages/auth/src/mfa/assertions/totp.test.ts
@@ -12,7 +12,7 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
+ * limitations under the License. 
  */
 
 import { expect, use } from 'chai';

--- a/packages/auth/src/mfa/assertions/totp.test.ts
+++ b/packages/auth/src/mfa/assertions/totp.test.ts
@@ -19,7 +19,11 @@ import { expect, use } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 
 import { mockEndpoint } from '../../../test/helpers/api/helper';
-import { testAuth, TestAuth, testUser } from '../../../test/helpers/mock_auth';
+import { 
+  testAuth, 
+  TestAuth, 
+  testUser 
+} from '../../../test/helpers/mock_auth';
 import * as mockFetch from '../../../test/helpers/mock_fetch';
 import { Endpoint } from '../../api';
 import { MultiFactorSessionImpl } from '../../mfa/mfa_session';

--- a/packages/auth/src/mfa/assertions/totp.test.ts
+++ b/packages/auth/src/mfa/assertions/totp.test.ts
@@ -185,7 +185,9 @@ describe('core/mfa/totp/assertions/TotpMultiFactorAssertionImpl', () => {
           sessionInfo: 'verification-id'
         }
       });
-      expect(session.user?.auth).to.eql(auth);
+      if(session.user){
+        expect(session.user.auth).to.eql(auth);
+      }
     });
 
     context('with display name', () => {
@@ -208,7 +210,9 @@ describe('core/mfa/totp/assertions/TotpMultiFactorAssertionImpl', () => {
             sessionInfo: 'verification-id'
           }
         });
-        expect(session.user?.auth).to.eql(auth);
+        if(session.user){
+          expect(session.user.auth).to.eql(auth);
+        }
       });
     });
   });

--- a/packages/auth/src/mfa/assertions/totp.test.ts
+++ b/packages/auth/src/mfa/assertions/totp.test.ts
@@ -18,7 +18,6 @@
 import { expect, use } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 
-import { UserInternal } from '../../model/user';
 import { mockEndpoint } from '../../../test/helpers/api/helper';
 import { testAuth, TestAuth, testUser } from '../../../test/helpers/mock_auth';
 import * as mockFetch from '../../../test/helpers/mock_fetch';
@@ -36,7 +35,6 @@ import { AuthErrorCode } from '../../core/errors';
 import { AppName } from '../../model/auth';
 import { _castAuth } from '../../core/auth/auth_impl';
 import { MultiFactorAssertionImpl } from '../mfa_assertion';
-import { getModularInstance } from '@firebase/util';
 
 use(chaiAsPromised);
 

--- a/packages/auth/src/mfa/assertions/totp.test.ts
+++ b/packages/auth/src/mfa/assertions/totp.test.ts
@@ -103,7 +103,7 @@ describe('core/mfa/assertions/totp/TotpMultiFactorGenerator', () => {
       );
 
       auth = await testAuth();
-      let user = await testUser(auth, fakeUid);
+      const user = await testUser(auth, fakeUid);
       session = MultiFactorSessionImpl._fromIdtoken(
         'enrollment-id-token',
         user
@@ -185,7 +185,6 @@ describe('core/mfa/totp/assertions/TotpMultiFactorAssertionImpl', () => {
           sessionInfo: 'verification-id'
         }
       });
-      expect(session.user).to.eql(!undefined);
       expect(session.user?.auth).to.eql(auth);
     });
 
@@ -209,7 +208,6 @@ describe('core/mfa/totp/assertions/TotpMultiFactorAssertionImpl', () => {
             sessionInfo: 'verification-id'
           }
         });
-        expect(session.user).to.eq(!undefined);
         expect(session.user?.auth).to.eql(auth);
       });
     });

--- a/packages/auth/src/mfa/assertions/totp.test.ts
+++ b/packages/auth/src/mfa/assertions/totp.test.ts
@@ -185,7 +185,7 @@ describe('core/mfa/totp/assertions/TotpMultiFactorAssertionImpl', () => {
           sessionInfo: 'verification-id'
         }
       });
-      if(session.user){
+      if (session.user) {
         expect(session.user.auth).to.eql(auth);
       }
     });
@@ -210,7 +210,7 @@ describe('core/mfa/totp/assertions/TotpMultiFactorAssertionImpl', () => {
             sessionInfo: 'verification-id'
           }
         });
-        if(session.user){
+        if (session.user) {
           expect(session.user.auth).to.eql(auth);
         }
       });

--- a/packages/auth/src/mfa/assertions/totp.test.ts
+++ b/packages/auth/src/mfa/assertions/totp.test.ts
@@ -289,7 +289,7 @@ describe('core/mfa/assertions/totp/TotpSecret', async () => {
   // this is the name used by the fake app in testAuth().
   const fakeAppName: AppName = 'test-app';
   const fakeEmail: string = 'user@email';
-  //const fakeUid has been declared as a global variable.
+  //const fakeUid has been declared as a global variable "uid"
   const auth = await testAuth();
   const secret = TotpSecret._fromStartTotpMfaEnrollmentResponse(
     serverResponse,

--- a/packages/auth/src/mfa/assertions/totp.test.ts
+++ b/packages/auth/src/mfa/assertions/totp.test.ts
@@ -36,6 +36,7 @@ import { AuthErrorCode } from '../../core/errors';
 import { AppName } from '../../model/auth';
 import { _castAuth } from '../../core/auth/auth_impl';
 import { MultiFactorAssertionImpl } from '../mfa_assertion';
+import { getModularInstance } from '@firebase/util';
 
 use(chaiAsPromised);
 
@@ -163,7 +164,7 @@ describe('core/mfa/totp/assertions/TotpMultiFactorAssertionImpl', () => {
   afterEach(mockFetch.tearDown);
 
   describe('enroll', () => {
-    let user: UserInternal;
+    const user = testUser(auth, fakeUid);
     beforeEach(() => {
       session = MultiFactorSessionImpl._fromIdtoken(
         'enrollment-id-token',

--- a/packages/auth/src/mfa/assertions/totp.ts
+++ b/packages/auth/src/mfa/assertions/totp.ts
@@ -91,7 +91,8 @@ export class TotpMultiFactorGenerator {
   ): Promise<TotpSecret> {
     const mfaSession = session as MultiFactorSessionImpl;
     _assert(
-      typeof mfaSession.user !== 'undefined' && typeof mfaSession.user.auth !== 'undefined',
+      typeof mfaSession.user !== 'undefined' && 
+        typeof mfaSession.user.auth !== 'undefined',
       AuthErrorCode.INTERNAL_ERROR
     );
     const response = await startEnrollTotpMfa(mfaSession.user.auth, {

--- a/packages/auth/src/mfa/assertions/totp.ts
+++ b/packages/auth/src/mfa/assertions/totp.ts
@@ -91,8 +91,7 @@ export class TotpMultiFactorGenerator {
   ): Promise<TotpSecret> {
     const mfaSession = session as MultiFactorSessionImpl;
     _assert(
-      typeof mfaSession.user !== 'undefined' && 
-        typeof mfaSession.user.auth !== 'undefined',
+     typeof mfaSession.user?.auth !== 'undefined',
       AuthErrorCode.INTERNAL_ERROR
     );
     const response = await startEnrollTotpMfa(mfaSession.user.auth, {

--- a/packages/auth/src/mfa/assertions/totp.ts
+++ b/packages/auth/src/mfa/assertions/totp.ts
@@ -91,7 +91,6 @@ export class TotpMultiFactorGenerator {
   ): Promise<TotpSecret> {
     const mfaSession = session as MultiFactorSessionImpl;
     _assert(
-      //Angel change 3
       typeof mfaSession.user !== 'undefined' && typeof mfaSession.user.auth !== 'undefined',
       AuthErrorCode.INTERNAL_ERROR
     );

--- a/packages/auth/src/mfa/assertions/totp.ts
+++ b/packages/auth/src/mfa/assertions/totp.ts
@@ -91,7 +91,7 @@ export class TotpMultiFactorGenerator {
   ): Promise<TotpSecret> {
     const mfaSession = session as MultiFactorSessionImpl;
     _assert(
-     typeof mfaSession.user?.auth !== 'undefined',
+      typeof mfaSession.user?.auth !== 'undefined',
       AuthErrorCode.INTERNAL_ERROR
     );
     const response = await startEnrollTotpMfa(mfaSession.user.auth, {

--- a/packages/auth/src/mfa/assertions/totp.ts
+++ b/packages/auth/src/mfa/assertions/totp.ts
@@ -91,16 +91,17 @@ export class TotpMultiFactorGenerator {
   ): Promise<TotpSecret> {
     const mfaSession = session as MultiFactorSessionImpl;
     _assert(
-      typeof mfaSession.auth !== 'undefined',
+      //Angel change 3
+      typeof mfaSession.user !== 'undefined' && typeof mfaSession.user.auth !== 'undefined',
       AuthErrorCode.INTERNAL_ERROR
     );
-    const response = await startEnrollTotpMfa(mfaSession.auth, {
+    const response = await startEnrollTotpMfa(mfaSession.user.auth, {
       idToken: mfaSession.credential,
       totpEnrollmentInfo: {}
     });
     return TotpSecret._fromStartTotpMfaEnrollmentResponse(
       response,
-      mfaSession.auth
+      mfaSession.user.auth
     );
   }
 

--- a/packages/auth/src/mfa/mfa_session.ts
+++ b/packages/auth/src/mfa/mfa_session.ts
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 import { AuthInternal } from '../model/auth';
+import { UserInternal } from '../model/user';
 import { MultiFactorSession } from '../model/public_types';
 
 export const enum MultiFactorSessionType {
@@ -33,17 +34,19 @@ export class MultiFactorSessionImpl implements MultiFactorSession {
   private constructor(
     readonly type: MultiFactorSessionType,
     readonly credential: string,
-    readonly auth?: AuthInternal
+    //Angel change 1
+    readonly user?: UserInternal
   ) {}
 
   static _fromIdtoken(
     idToken: string,
-    auth?: AuthInternal
+    //Angel change 1
+    user?: UserInternal
   ): MultiFactorSessionImpl {
     return new MultiFactorSessionImpl(
       MultiFactorSessionType.ENROLL,
       idToken,
-      auth
+      user
     );
   }
 

--- a/packages/auth/src/mfa/mfa_session.ts
+++ b/packages/auth/src/mfa/mfa_session.ts
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { AuthInternal } from '../model/auth';
+
 import { UserInternal } from '../model/user';
 import { MultiFactorSession } from '../model/public_types';
 

--- a/packages/auth/src/mfa/mfa_session.ts
+++ b/packages/auth/src/mfa/mfa_session.ts
@@ -34,13 +34,11 @@ export class MultiFactorSessionImpl implements MultiFactorSession {
   private constructor(
     readonly type: MultiFactorSessionType,
     readonly credential: string,
-    //Angel change 1
     readonly user?: UserInternal
   ) {}
 
   static _fromIdtoken(
     idToken: string,
-    //Angel change 1
     user?: UserInternal
   ): MultiFactorSessionImpl {
     return new MultiFactorSessionImpl(

--- a/packages/auth/src/mfa/mfa_user.test.ts
+++ b/packages/auth/src/mfa/mfa_user.test.ts
@@ -88,7 +88,8 @@ describe('core/mfa/mfa_user/MultiFactorUser', () => {
       const mfaSession = (await mfaUser.getSession()) as MultiFactorSessionImpl;
       expect(mfaSession.type).to.eq(MultiFactorSessionType.ENROLL);
       expect(mfaSession.credential).to.eq('access-token');
-      expect(mfaSession.auth).to.eq(auth);
+      expect(mfaSession.user).to.eq(!undefined);
+      expect(mfaSession.user?.auth).to.eq(auth);
     });
   });
 

--- a/packages/auth/src/mfa/mfa_user.test.ts
+++ b/packages/auth/src/mfa/mfa_user.test.ts
@@ -88,7 +88,6 @@ describe('core/mfa/mfa_user/MultiFactorUser', () => {
       const mfaSession = (await mfaUser.getSession()) as MultiFactorSessionImpl;
       expect(mfaSession.type).to.eq(MultiFactorSessionType.ENROLL);
       expect(mfaSession.credential).to.eq('access-token');
-      expect(mfaSession.user).to.eq(!undefined);
       expect(mfaSession.user?.auth).to.eq(auth);
     });
   });

--- a/packages/auth/src/mfa/mfa_user.ts
+++ b/packages/auth/src/mfa/mfa_user.ts
@@ -50,7 +50,6 @@ export class MultiFactorUserImpl implements MultiFactorUser {
   async getSession(): Promise<MultiFactorSession> {
     return MultiFactorSessionImpl._fromIdtoken(
       await this.user.getIdToken(),
-      //Angel change 2
       this.user
     );
   }

--- a/packages/auth/src/mfa/mfa_user.ts
+++ b/packages/auth/src/mfa/mfa_user.ts
@@ -50,7 +50,8 @@ export class MultiFactorUserImpl implements MultiFactorUser {
   async getSession(): Promise<MultiFactorSession> {
     return MultiFactorSessionImpl._fromIdtoken(
       await this.user.getIdToken(),
-      this.user.auth
+      //Angel change 2
+      this.user
     );
   }
 

--- a/packages/auth/src/platform_browser/mfa/assertions/phone.test.ts
+++ b/packages/auth/src/platform_browser/mfa/assertions/phone.test.ts
@@ -80,7 +80,7 @@ describe('platform_browser/mfa/phone', () => {
           sessionInfo: 'verification-id'
         }
       });
-      expect(session.user).to.not.eql(undefined);
+      expect(session.user).to.not.be.undefined;
       expect(session.user).to.eql(user);
     });
 
@@ -104,7 +104,7 @@ describe('platform_browser/mfa/phone', () => {
             sessionInfo: 'verification-id'
           }
         });
-        expect(session.user).to.not.eql(undefined);
+        expect(session.user).to.not.be.undefined;
         expect(session.user).to.eql(user);
       });
     });
@@ -128,7 +128,7 @@ describe('platform_browser/mfa/phone', () => {
           sessionInfo: 'verification-id'
         }
       });
-      expect(session.user).to.eql(undefined);
+      expect(session.user).to.be.undefined;
     });
   });
 });

--- a/packages/auth/src/platform_browser/mfa/assertions/phone.test.ts
+++ b/packages/auth/src/platform_browser/mfa/assertions/phone.test.ts
@@ -20,7 +20,11 @@ import { expect, use } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 
 import { mockEndpoint } from '../../../../test/helpers/api/helper';
-import { testAuth, TestAuth, testUser } from '../../../../test/helpers/mock_auth';
+import { 
+  testAuth, 
+  TestAuth, 
+  testUser 
+} from '../../../../test/helpers/mock_auth';
 import * as mockFetch from '../../../../test/helpers/mock_fetch';
 import { Endpoint } from '../../../api';
 import { FinalizeMfaResponse } from '../../../api/authentication/mfa';

--- a/packages/auth/src/platform_browser/mfa/assertions/phone.test.ts
+++ b/packages/auth/src/platform_browser/mfa/assertions/phone.test.ts
@@ -82,7 +82,6 @@ describe('platform_browser/mfa/phone', () => {
       });
       expect(session.user).to.not.eql(undefined);
       expect(session.user).to.eql(user);
-      
     });
 
     context('with display name', () => {

--- a/packages/auth/src/platform_browser/mfa/assertions/phone.test.ts
+++ b/packages/auth/src/platform_browser/mfa/assertions/phone.test.ts
@@ -80,7 +80,9 @@ describe('platform_browser/mfa/phone', () => {
           sessionInfo: 'verification-id'
         }
       });
-      expect(session.user?.auth).to.eql(auth);
+      if(session.user){
+        expect(session.user.auth).to.eql(auth);
+      }
     });
 
     context('with display name', () => {
@@ -103,7 +105,9 @@ describe('platform_browser/mfa/phone', () => {
             sessionInfo: 'verification-id'
           }
         });
-        expect(session.user?.auth).to.eql(auth);
+        if(session.user){
+          expect(session.user.auth).to.eql(auth);
+        }
       });
     });
   });
@@ -126,7 +130,9 @@ describe('platform_browser/mfa/phone', () => {
           sessionInfo: 'verification-id'
         }
       });
-      expect(session.user?.auth).to.eql(undefined);
+      if(session.user){
+        expect(session.user.auth).to.eql(undefined);
+      }
     });
   });
 });

--- a/packages/auth/src/platform_browser/mfa/assertions/phone.test.ts
+++ b/packages/auth/src/platform_browser/mfa/assertions/phone.test.ts
@@ -20,10 +20,10 @@ import { expect, use } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 
 import { mockEndpoint } from '../../../../test/helpers/api/helper';
-import { 
-  testAuth, 
-  TestAuth, 
-  testUser 
+import {
+  testAuth,
+  TestAuth,
+  testUser
 } from '../../../../test/helpers/mock_auth';
 import * as mockFetch from '../../../../test/helpers/mock_fetch';
 import { Endpoint } from '../../../api';

--- a/packages/auth/src/platform_browser/mfa/assertions/phone.test.ts
+++ b/packages/auth/src/platform_browser/mfa/assertions/phone.test.ts
@@ -80,7 +80,6 @@ describe('platform_browser/mfa/phone', () => {
           sessionInfo: 'verification-id'
         }
       });
-      expect(session.user).to.eq(!undefined);
       expect(session.user?.auth).to.eql(auth);
     });
 
@@ -104,7 +103,6 @@ describe('platform_browser/mfa/phone', () => {
             sessionInfo: 'verification-id'
           }
         });
-        expect(session.user).to.eq(!undefined);
         expect(session.user?.auth).to.eql(auth);
       });
     });
@@ -128,7 +126,6 @@ describe('platform_browser/mfa/phone', () => {
           sessionInfo: 'verification-id'
         }
       });
-      expect(session.user).to.eq(undefined);
       expect(session.user?.auth).to.eql(undefined);
     });
   });

--- a/packages/auth/src/platform_browser/mfa/assertions/phone.test.ts
+++ b/packages/auth/src/platform_browser/mfa/assertions/phone.test.ts
@@ -21,6 +21,7 @@ import chaiAsPromised from 'chai-as-promised';
 
 import { mockEndpoint } from '../../../../test/helpers/api/helper';
 import { testAuth, TestAuth } from '../../../../test/helpers/mock_auth';
+import { UserInternal } from '../../../model/user';
 import * as mockFetch from '../../../../test/helpers/mock_fetch';
 import { Endpoint } from '../../../api';
 import { FinalizeMfaResponse } from '../../../api/authentication/mfa';
@@ -36,6 +37,7 @@ use(chaiAsPromised);
 
 describe('platform_browser/mfa/phone', () => {
   let auth: TestAuth;
+  let user: UserInternal;
   let credential: PhoneAuthCredential;
   let assertion: PhoneMultiFactorAssertionImpl;
   let session: MultiFactorSessionImpl;
@@ -60,7 +62,7 @@ describe('platform_browser/mfa/phone', () => {
     beforeEach(() => {
       session = MultiFactorSessionImpl._fromIdtoken(
         'enrollment-id-token',
-        auth
+        user
       );
     });
 
@@ -78,7 +80,8 @@ describe('platform_browser/mfa/phone', () => {
           sessionInfo: 'verification-id'
         }
       });
-      expect(session.auth).to.eql(auth);
+      expect(session.user).to.eq(!undefined);
+      expect(session.user?.auth).to.eql(auth);
     });
 
     context('with display name', () => {
@@ -101,7 +104,8 @@ describe('platform_browser/mfa/phone', () => {
             sessionInfo: 'verification-id'
           }
         });
-        expect(session.auth).to.eql(auth);
+        expect(session.user).to.eq(!undefined);
+        expect(session.user?.auth).to.eql(auth);
       });
     });
   });
@@ -124,7 +128,8 @@ describe('platform_browser/mfa/phone', () => {
           sessionInfo: 'verification-id'
         }
       });
-      expect(session.auth).to.eql(undefined);
+      expect(session.user).to.eq(undefined);
+      expect(session.user?.auth).to.eql(undefined);
     });
   });
 });

--- a/packages/auth/src/platform_browser/mfa/assertions/phone.test.ts
+++ b/packages/auth/src/platform_browser/mfa/assertions/phone.test.ts
@@ -20,8 +20,7 @@ import { expect, use } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 
 import { mockEndpoint } from '../../../../test/helpers/api/helper';
-import { testAuth, TestAuth } from '../../../../test/helpers/mock_auth';
-import { testUser } from '../../../../test/helpers/mock_auth';
+import { testAuth, TestAuth, testUser } from '../../../../test/helpers/mock_auth';
 import * as mockFetch from '../../../../test/helpers/mock_fetch';
 import { Endpoint } from '../../../api';
 import { FinalizeMfaResponse } from '../../../api/authentication/mfa';

--- a/packages/auth/src/platform_browser/mfa/assertions/phone.test.ts
+++ b/packages/auth/src/platform_browser/mfa/assertions/phone.test.ts
@@ -21,7 +21,7 @@ import chaiAsPromised from 'chai-as-promised';
 
 import { mockEndpoint } from '../../../../test/helpers/api/helper';
 import { testAuth, TestAuth } from '../../../../test/helpers/mock_auth';
-import { UserInternal } from '../../../model/user';
+import { testUser } from '../../../../test/helpers/mock_auth';
 import * as mockFetch from '../../../../test/helpers/mock_fetch';
 import { Endpoint } from '../../../api';
 import { FinalizeMfaResponse } from '../../../api/authentication/mfa';
@@ -58,7 +58,7 @@ describe('platform_browser/mfa/phone', () => {
   afterEach(mockFetch.tearDown);
 
   describe('enroll', () => {
-    let user: UserInternal;
+    const user = testUser(auth, 'uid');
     beforeEach(() => {
       session = MultiFactorSessionImpl._fromIdtoken(
         'enrollment-id-token',

--- a/packages/auth/src/platform_browser/mfa/assertions/phone.test.ts
+++ b/packages/auth/src/platform_browser/mfa/assertions/phone.test.ts
@@ -80,7 +80,7 @@ describe('platform_browser/mfa/phone', () => {
           sessionInfo: 'verification-id'
         }
       });
-      if(session.user){
+      if (session.user) {
         expect(session.user.auth).to.eql(auth);
       }
     });
@@ -105,7 +105,7 @@ describe('platform_browser/mfa/phone', () => {
             sessionInfo: 'verification-id'
           }
         });
-        if(session.user){
+        if (session.user) {
           expect(session.user.auth).to.eql(auth);
         }
       });
@@ -130,7 +130,7 @@ describe('platform_browser/mfa/phone', () => {
           sessionInfo: 'verification-id'
         }
       });
-      if(session.user){
+      if (session.user) {
         expect(session.user.auth).to.eql(undefined);
       }
     });

--- a/packages/auth/src/platform_browser/mfa/assertions/phone.test.ts
+++ b/packages/auth/src/platform_browser/mfa/assertions/phone.test.ts
@@ -37,7 +37,6 @@ use(chaiAsPromised);
 
 describe('platform_browser/mfa/phone', () => {
   let auth: TestAuth;
-  let user: UserInternal;
   let credential: PhoneAuthCredential;
   let assertion: PhoneMultiFactorAssertionImpl;
   let session: MultiFactorSessionImpl;
@@ -59,6 +58,7 @@ describe('platform_browser/mfa/phone', () => {
   afterEach(mockFetch.tearDown);
 
   describe('enroll', () => {
+    let user: UserInternal;
     beforeEach(() => {
       session = MultiFactorSessionImpl._fromIdtoken(
         'enrollment-id-token',
@@ -80,9 +80,9 @@ describe('platform_browser/mfa/phone', () => {
           sessionInfo: 'verification-id'
         }
       });
-      if (session.user) {
-        expect(session.user.auth).to.eql(auth);
-      }
+      expect(session.user).to.not.eql(undefined);
+      expect(session.user).to.eql(user);
+      
     });
 
     context('with display name', () => {
@@ -105,9 +105,8 @@ describe('platform_browser/mfa/phone', () => {
             sessionInfo: 'verification-id'
           }
         });
-        if (session.user) {
-          expect(session.user.auth).to.eql(auth);
-        }
+        expect(session.user).to.not.eql(undefined);
+        expect(session.user).to.eql(user);
       });
     });
   });
@@ -130,9 +129,7 @@ describe('platform_browser/mfa/phone', () => {
           sessionInfo: 'verification-id'
         }
       });
-      if (session.user) {
-        expect(session.user.auth).to.eql(undefined);
-      }
+      expect(session.user).to.eql(undefined);
     });
   });
 });


### PR DESCRIPTION
Cleanup TOTP code to include Firebase User reference in MultiFactorSession. 
- Changed a field in MultiFactorSession from AuthInternal to UserInternal
- fixed corresponding tests and functions to match the type change.

Ran the code in demo app and was able to complete TOTP enrollment. 
