### PR TITLE
reorganized mfa totp integration tests

### DIFF
--- a/packages/auth/test/helpers/integration/helpers.ts
+++ b/packages/auth/test/helpers/integration/helpers.ts
@@ -113,5 +113,6 @@ export function getTotpCode(
   return token;
 }
 export const email = 'totpuser-donotdelete@test.com';
+export const fakePassword = 'password';
 //1000000 is always incorrect since it has 7 digits and we expect 6.
 export const incorrectTotpCode = '1000000';

--- a/packages/auth/test/integration/flows/totp.test.ts
+++ b/packages/auth/test/integration/flows/totp.test.ts
@@ -52,7 +52,6 @@ const fakePassword = 'password';
 let mfaUser: MultiFactorUser | null;
 
 describe(' Integration tests: Mfa enrollement using totp', () => {
-
   beforeEach(async () => {
     emulatorUrl = getEmulatorUrl();
     if (!emulatorUrl) {
@@ -64,8 +63,8 @@ describe(' Integration tests: Mfa enrollement using totp', () => {
 
   afterEach(async () => {
     if (!emulatorUrl) {
-      if(mfaUser && mfaUser.enrolledFactors.length>0){
-        for(let i = 0; i<mfaUser.enrolledFactors.length; i++){
+      if (mfaUser && mfaUser.enrolledFactors.length > 0) {
+        for (let i = 0; i < mfaUser.enrolledFactors.length; i++) {
           mfaUser.unenroll(mfaUser.enrolledFactors[i]);
         }
       }
@@ -122,8 +121,7 @@ describe(' Integration tests: Mfa enrollement using totp', () => {
   });
 });
 
-describe( 'Integration tests: sign-in for mfa-enrolled users', () => {
-  
+describe('Integration tests: sign-in for mfa-enrolled users', () => {
   beforeEach(async () => {
     emulatorUrl = getEmulatorUrl();
     mfaUser = null;
@@ -156,15 +154,15 @@ describe( 'Integration tests: sign-in for mfa-enrolled users', () => {
 
   afterEach(async () => {
     if (!emulatorUrl) {
-      if(mfaUser && mfaUser.enrolledFactors.length>0){
-        for(let i = 0; i<mfaUser.enrolledFactors.length; i++){
+      if (mfaUser && mfaUser.enrolledFactors.length > 0) {
+        for (let i = 0; i < mfaUser.enrolledFactors.length; i++) {
           mfaUser.unenroll(mfaUser.enrolledFactors[i]);
         }
       }
       await cleanUpTestInstance(auth);
     }
   });
-  
+
   it('should not allow sign-in with incorrect totp', async function () {
     let resolver: any;
     if (emulatorUrl) {

--- a/packages/auth/test/integration/flows/totp.test.ts
+++ b/packages/auth/test/integration/flows/totp.test.ts
@@ -31,6 +31,7 @@ import {
   getTestInstance,
   getTotpCode,
   email,
+  fakePassword,
   incorrectTotpCode
 } from '../../helpers/integration/helpers';
 
@@ -48,7 +49,6 @@ let totpSecret: TotpSecret;
 let displayName: string;
 let totpTimestamp: Date;
 let emulatorUrl: string | null;
-const fakePassword = 'password';
 let mfaUser: MultiFactorUser | null;
 
 describe(' Integration tests: Mfa enrollement using totp', () => {

--- a/packages/auth/test/integration/flows/totp.test.ts
+++ b/packages/auth/test/integration/flows/totp.test.ts
@@ -77,7 +77,7 @@ describe(' Integration tests: Mfa enrollement using totp', () => {
       this.skip();
     }
 
-    const cr = await signInWithEmailAndPassword(auth, email, 'password');
+    const cr = await signInWithEmailAndPassword(auth, email, fakePassword);
     mfaUser = multiFactor(cr.user);
     const session = await mfaUser.getSession();
     totpSecret = await TotpMultiFactorGenerator.generateSecret(session);
@@ -98,7 +98,7 @@ describe(' Integration tests: Mfa enrollement using totp', () => {
       this.skip();
     }
 
-    const cr = await signInWithEmailAndPassword(auth, email, 'password');
+    const cr = await signInWithEmailAndPassword(auth, email, fakePassword);
     mfaUser = multiFactor(cr.user);
     const session = await mfaUser.getSession();
     totpSecret = await TotpMultiFactorGenerator.generateSecret(session);
@@ -169,7 +169,7 @@ describe('Integration tests: sign-in for mfa-enrolled users', () => {
       this.skip();
     }
     try {
-      await signInWithEmailAndPassword(auth, email, 'password');
+      await signInWithEmailAndPassword(auth, email, fakePassword);
 
       throw new Error('Signin should not have been successful');
     } catch (error) {
@@ -196,7 +196,7 @@ describe('Integration tests: sign-in for mfa-enrolled users', () => {
       this.skip();
     }
     try {
-      await signInWithEmailAndPassword(auth, email, 'password');
+      await signInWithEmailAndPassword(auth, email, fakePassword);
 
       throw new Error('Signin should not have been successful');
     } catch (error) {
@@ -223,7 +223,7 @@ describe('Integration tests: sign-in for mfa-enrolled users', () => {
       const mfaUser = multiFactor(userCredential.user);
 
       await expect(mfaUser.unenroll(resolver.hints[0].uid)).to.be.fulfilled;
-      await expect(signInWithEmailAndPassword(auth, email, 'password')).to.be
+      await expect(signInWithEmailAndPassword(auth, email, fakePassword)).to.be
         .fulfilled;
     }
   });

--- a/packages/auth/test/integration/flows/totp.test.ts
+++ b/packages/auth/test/integration/flows/totp.test.ts
@@ -220,7 +220,7 @@ describe('Integration tests: sign-in for mfa-enrolled users', () => {
         totpVerificationCode
       );
       const userCredential = await resolver.resolveSignIn(assertion);
-      const mfaUser = multiFactor(userCredential.user);
+      mfaUser = multiFactor(userCredential.user);
 
       await expect(mfaUser.unenroll(resolver.hints[0].uid)).to.be.fulfilled;
       await expect(signInWithEmailAndPassword(auth, email, fakePassword)).to.be

--- a/packages/auth/test/integration/flows/totp.test.ts
+++ b/packages/auth/test/integration/flows/totp.test.ts
@@ -21,6 +21,7 @@ import sinonChai from 'sinon-chai';
 import {
   Auth,
   multiFactor,
+  MultiFactorUser,
   signInWithEmailAndPassword,
   getMultiFactorResolver
 } from '@firebase/auth';
@@ -38,7 +39,6 @@ import {
   TotpSecret
 } from '../../../src/mfa/assertions/totp';
 import { getEmulatorUrl } from '../../helpers/integration/settings';
-import { MultiFactorUser } from '@firebase/auth';
 
 use(chaiAsPromised);
 use(sinonChai);
@@ -65,7 +65,7 @@ describe(' Integration tests: Mfa enrollement using totp', () => {
     if (!emulatorUrl) {
       if (mfaUser && mfaUser.enrolledFactors.length > 0) {
         for (let i = 0; i < mfaUser.enrolledFactors.length; i++) {
-          mfaUser.unenroll(mfaUser.enrolledFactors[i]);
+          await mfaUser.unenroll(mfaUser.enrolledFactors[i]);
         }
       }
       await cleanUpTestInstance(auth);
@@ -148,7 +148,7 @@ describe('Integration tests: sign-in for mfa-enrolled users', () => {
           totpVerificationCode
         );
 
-      mfaUser.enroll(multiFactorAssertion, displayName);
+      await mfaUser.enroll(multiFactorAssertion, displayName);
     }
   });
 
@@ -156,7 +156,7 @@ describe('Integration tests: sign-in for mfa-enrolled users', () => {
     if (!emulatorUrl) {
       if (mfaUser && mfaUser.enrolledFactors.length > 0) {
         for (let i = 0; i < mfaUser.enrolledFactors.length; i++) {
-          mfaUser.unenroll(mfaUser.enrolledFactors[i]);
+          await mfaUser.unenroll(mfaUser.enrolledFactors[i]);
         }
       }
       await cleanUpTestInstance(auth);


### PR DESCRIPTION
Reorganized the mfa totp integration tests such that the user that is enrolled for mfa will always be unenrolled at the end of each test. 

Ran TOTP MFA integration tests against the backend locally. Intentionally added "expect(2).to.equal(200)" in each test. 
Also tried adding the false statement into the beforeEach block that enrolls users before the test. 

Used curl command to check the status of the user's MFA enrollment. 
Successfully verified that the user is unenrolled from MFA at the end despite different test failures. 