### PR TITLE
Update to the labels applied to new issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report_v2.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report_v2.yaml
@@ -1,7 +1,7 @@
 name: 🐞 Bug Report
 description: File a bug report
 title: 'Title for the bug'
-labels: 'new, type: question'
+labels: 'question, new'
 body:
   - type: markdown
     id: before-you-start


### PR DESCRIPTION

### Discussion

An upate to transition the `type: question` label to simply `question`. This saves space on the Issue list page where many labels might be applied a single issue.

Pushed the `new` label to be second so that it sticks out more.

### Testing

N/A

### API Changes

N/A
