### PR TITLE
Add password policy endpoint in auth (#1)

### DIFF
--- a/packages/auth/src/api/index.ts
+++ b/packages/auth/src/api/index.ts
@@ -67,7 +67,8 @@ export const enum Endpoint {
   FINALIZE_MFA_SIGN_IN = '/v2/accounts/mfaSignIn:finalize',
   WITHDRAW_MFA = '/v2/accounts/mfaEnrollment:withdraw',
   GET_PROJECT_CONFIG = '/v1/projects',
-  GET_RECAPTCHA_CONFIG = '/v2/recaptchaConfig'
+  GET_RECAPTCHA_CONFIG = '/v2/recaptchaConfig',
+  GET_PASSWORD_POLICY = '/v2/passwordPolicy'
 }
 
 export const enum RecaptchaClientType {

--- a/packages/auth/src/api/password_policy/get_password_policy.test.ts
+++ b/packages/auth/src/api/password_policy/get_password_policy.test.ts
@@ -29,6 +29,10 @@ import { FirebaseError } from '@firebase/util';
 use(chaiAsPromised);
 
 describe('api/password_policy/getPasswordPolicy', () => {
+  const TEST_MIN_PASSWORD_LENGTH = 6;
+  const TEST_ALLOWED_NON_ALPHANUMERIC_CHARS = ['!'];
+  const TEST_SCHEMA_VERSION = 1;
+
   let auth: TestAuth;
 
   beforeEach(async () => {
@@ -41,16 +45,20 @@ describe('api/password_policy/getPasswordPolicy', () => {
   it('should GET to the correct endpoint', async () => {
     const mock = mockEndpoint(Endpoint.GET_PASSWORD_POLICY, {
       customStrengthOptions: {
-        minPasswordLength: 6
+        minPasswordLength: TEST_MIN_PASSWORD_LENGTH
       },
-      allowedNonAlphanumericCharacters: ['!'],
-      schemaVersion: 1
+      allowedNonAlphanumericCharacters: TEST_ALLOWED_NON_ALPHANUMERIC_CHARS,
+      schemaVersion: TEST_SCHEMA_VERSION
     });
 
     const response = await _getPasswordPolicy(auth);
-    expect(response.customStrengthOptions.minPasswordLength).to.eql(6);
-    expect(response.allowedNonAlphanumericCharacters).to.eql(['!']);
-    expect(response.schemaVersion).to.eql(1);
+    expect(response.customStrengthOptions.minPasswordLength).to.eql(
+      TEST_MIN_PASSWORD_LENGTH
+    );
+    expect(response.allowedNonAlphanumericCharacters).to.eql(
+      TEST_ALLOWED_NON_ALPHANUMERIC_CHARS
+    );
+    expect(response.schemaVersion).to.eql(TEST_SCHEMA_VERSION);
     expect(mock.calls[0].method).to.eq('GET');
     expect(mock.calls[0].headers!.get(HttpHeader.X_CLIENT_VERSION)).to.eq(
       'testSDK/0.0.0'

--- a/packages/auth/src/api/password_policy/get_password_policy.test.ts
+++ b/packages/auth/src/api/password_policy/get_password_policy.test.ts
@@ -1,0 +1,82 @@
+/**
+ * @license
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { expect, use } from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+
+import { Endpoint, HttpHeader } from '../';
+import { mockEndpoint } from '../../../test/helpers/api/helper';
+import { testAuth, TestAuth } from '../../../test/helpers/mock_auth';
+import * as mockFetch from '../../../test/helpers/mock_fetch';
+import { _getPasswordPolicy } from './get_password_policy';
+import { ServerError } from '../errors';
+import { FirebaseError } from '@firebase/util';
+
+use(chaiAsPromised);
+
+describe.only('api/password_policy/getPasswordPolicy', () => {
+  let auth: TestAuth;
+
+  beforeEach(async () => {
+    auth = await testAuth();
+    mockFetch.setUp();
+  });
+
+  afterEach(mockFetch.tearDown);
+
+  it('should GET to the correct endpoint', async () => {
+    const mock = mockEndpoint(Endpoint.GET_PASSWORD_POLICY, {
+      customStrengthOptions: {
+        minPasswordLength: 6
+      },
+      allowedNonAlphanumericCharacters: ["!"],
+      schemaVersion: 1
+    });
+
+    const response = await _getPasswordPolicy(auth);
+    expect(response.customStrengthOptions.minPasswordLength).to.eql(6);
+    expect(response.allowedNonAlphanumericCharacters).to.eql(["!"]);
+    expect(response.schemaVersion).to.eql(1);
+    expect(mock.calls[0].method).to.eq('GET');
+    expect(mock.calls[0].headers!.get(HttpHeader.X_CLIENT_VERSION)).to.eq(
+      'testSDK/0.0.0'
+    );
+  });
+
+  it('should handle errors', async () => {
+    mockEndpoint(
+      Endpoint.GET_PASSWORD_POLICY,
+      {
+        error: {
+          code: 400,
+          message: ServerError.INVALID_PROVIDER_ID,
+          errors: [
+            {
+              message: ServerError.INVALID_PROVIDER_ID
+            }
+          ]
+        }
+      },
+      400
+    );
+
+    await expect(_getPasswordPolicy(auth)).to.be.rejectedWith(
+      FirebaseError,
+      'Firebase: The specified provider ID is invalid. (auth/invalid-provider-id).'
+    );
+  });
+});

--- a/packages/auth/src/api/password_policy/get_password_policy.test.ts
+++ b/packages/auth/src/api/password_policy/get_password_policy.test.ts
@@ -28,7 +28,7 @@ import { FirebaseError } from '@firebase/util';
 
 use(chaiAsPromised);
 
-describe.only('api/password_policy/getPasswordPolicy', () => {
+describe('api/password_policy/getPasswordPolicy', () => {
   let auth: TestAuth;
 
   beforeEach(async () => {
@@ -43,13 +43,13 @@ describe.only('api/password_policy/getPasswordPolicy', () => {
       customStrengthOptions: {
         minPasswordLength: 6
       },
-      allowedNonAlphanumericCharacters: ["!"],
+      allowedNonAlphanumericCharacters: ['!'],
       schemaVersion: 1
     });
 
     const response = await _getPasswordPolicy(auth);
     expect(response.customStrengthOptions.minPasswordLength).to.eql(6);
-    expect(response.allowedNonAlphanumericCharacters).to.eql(["!"]);
+    expect(response.allowedNonAlphanumericCharacters).to.eql(['!']);
     expect(response.schemaVersion).to.eql(1);
     expect(mock.calls[0].method).to.eq('GET');
     expect(mock.calls[0].headers!.get(HttpHeader.X_CLIENT_VERSION)).to.eq(

--- a/packages/auth/src/api/password_policy/get_password_policy.ts
+++ b/packages/auth/src/api/password_policy/get_password_policy.ts
@@ -15,7 +15,12 @@
  * limitations under the License.
  */
 
-import { _performApiRequest, Endpoint, HttpMethod, _addTidIfNecessary } from '../index';
+import {
+  _performApiRequest,
+  Endpoint,
+  HttpMethod,
+  _addTidIfNecessary
+} from '../index';
 import { Auth } from '../../model/public_types';
 
 export interface GetPasswordPolicyRequest {
@@ -39,7 +44,10 @@ export async function _getPasswordPolicy(
   auth: Auth,
   request: GetPasswordPolicyRequest = {}
 ): Promise<GetPasswordPolicyResponse> {
-  return _performApiRequest<GetPasswordPolicyRequest, GetPasswordPolicyResponse>(
+  return _performApiRequest<
+    GetPasswordPolicyRequest,
+    GetPasswordPolicyResponse
+  >(
     auth,
     HttpMethod.GET,
     Endpoint.GET_PASSWORD_POLICY,

--- a/packages/auth/src/api/password_policy/get_password_policy.ts
+++ b/packages/auth/src/api/password_policy/get_password_policy.ts
@@ -1,0 +1,48 @@
+/**
+ * @license
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { _performApiRequest, Endpoint, HttpMethod, _addTidIfNecessary } from '../index';
+import { Auth } from '../../model/public_types';
+
+export interface GetPasswordPolicyRequest {
+  tenantId?: string;
+}
+
+export interface GetPasswordPolicyResponse {
+  customStrengthOptions: {
+    minPasswordLength?: number;
+    maxPasswordLength?: number;
+    containsLowercaseLetter?: boolean;
+    containsUppercaseLetter?: boolean;
+    containsNumericCharacter?: boolean;
+    containsNonAlphanumericCharacter?: boolean;
+  };
+  allowedNonAlphanumericCharacters: string[];
+  schemaVersion: number;
+}
+
+export async function _getPasswordPolicy(
+  auth: Auth,
+  request: GetPasswordPolicyRequest = {}
+): Promise<GetPasswordPolicyResponse> {
+  return _performApiRequest<GetPasswordPolicyRequest, GetPasswordPolicyResponse>(
+    auth,
+    HttpMethod.GET,
+    Endpoint.GET_PASSWORD_POLICY,
+    _addTidIfNecessary(auth, request)
+  );
+}

--- a/packages/auth/src/api/password_policy/get_password_policy.ts
+++ b/packages/auth/src/api/password_policy/get_password_policy.ts
@@ -23,10 +23,16 @@ import {
 } from '../index';
 import { Auth } from '../../model/public_types';
 
+/**
+ * Request object for fetching the password policy.
+ */
 export interface GetPasswordPolicyRequest {
   tenantId?: string;
 }
 
+/**
+ * Response object for fetching the password policy.
+ */
 export interface GetPasswordPolicyResponse {
   customStrengthOptions: {
     minPasswordLength?: number;
@@ -40,6 +46,13 @@ export interface GetPasswordPolicyResponse {
   schemaVersion: number;
 }
 
+/**
+ * Fetches the password policy for the currently set tenant or the project if no tenant is set.
+ *
+ * @param auth Auth object.
+ * @param request Password policy request.
+ * @returns Password policy response.
+ */
 export async function _getPasswordPolicy(
   auth: Auth,
   request: GetPasswordPolicyRequest = {}


### PR DESCRIPTION
Add an endpoint for fetching the password policy in auth, as this will be used to implement password validation against project/tenant policies.