### PR TITLE
Firestore Modular V9 Changes for Console

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -50,6 +50,7 @@
     "rollup": "2.79.1",
     "rollup-plugin-replace": "2.2.0",
     "rollup-plugin-typescript2": "0.31.2",
+    "rollup-plugin-dts": "5.3.0",
     "typescript": "4.7.4"
   },
   "repository": {

--- a/packages/app/rollup.config.js
+++ b/packages/app/rollup.config.js
@@ -102,13 +102,13 @@ const cjsBuilds = [
     input: './dist/app/src/index.d.ts',
     output: {
       file: './dist/app/src/global_index.d.ts',
-      format: 'es',
+      format: 'es'
     },
     plugins: [
       dts({
-        respectExternal: true,
+        respectExternal: true
       })
-    ],
+    ]
   }
 ];
 

--- a/packages/app/rollup.config.js
+++ b/packages/app/rollup.config.js
@@ -19,6 +19,7 @@ import typescriptPlugin from 'rollup-plugin-typescript2';
 import replace from 'rollup-plugin-replace';
 import typescript from 'typescript';
 import json from '@rollup/plugin-json';
+import dts from 'rollup-plugin-dts';
 import { generateBuildTargetReplaceConfig } from '../../scripts/build/rollup_replace_build_target';
 import { emitModulePackageFile } from '../../scripts/build/rollup_emit_module_package_file';
 import pkg from './package.json';
@@ -96,6 +97,18 @@ const cjsBuilds = [
         '__RUNTIME_ENV__': 'node'
       })
     ]
+  },
+  {
+    input: './dist/app/src/index.d.ts',
+    output: {
+      file: './dist/app/src/global_index.d.ts',
+      format: 'es',
+    },
+    plugins: [
+      dts({
+        respectExternal: true,
+      })
+    ],
   }
 ];
 

--- a/packages/firebase/rollup.config.js
+++ b/packages/firebase/rollup.config.js
@@ -198,7 +198,12 @@ const cdnBuilds = [
               ...plugins,
               typescriptPluginCDN,
               terser({
-                format: { comments: false }
+                format: { comments: false },
+                keep_fnames: true,
+                keep_classnames: true,
+                mangle: {
+                  reserved: ['_getProvider', '__PRIVATE_lastReasonableEscapeIndex']
+                }
               })
             ],
             external: ['@firebase/app']

--- a/packages/firebase/rollup.config.js
+++ b/packages/firebase/rollup.config.js
@@ -170,7 +170,40 @@ const cdnBuilds = [
         ],
         external: ['@firebase/app']
       };
-    })
+    }),
+    {
+        input: 'app/index.cdn.ts',
+        output: {
+          file: 'firebase-app.cjs.js',
+          sourcemap: true,
+          format: 'cjs'
+        },
+        plugins: [...plugins, typescriptPluginCDN]
+      },
+      ...pkg.components
+        .filter(component => component !== 'app')
+        .map(component => {
+          // It is needed for handling sub modules, for example firestore/lite which should produce firebase-firestore-lite.js
+          // Otherwise, we will create a directory with '/' in the name.
+          const componentName = component.replace('/', '-');
+
+          return {
+            input: `${component}/index.ts`,
+            output: {
+              file: `firebase-${componentName}.cjs.js`,
+              sourcemap: true,
+              format: 'cjs'
+            },
+            plugins: [
+              ...plugins,
+              typescriptPluginCDN,
+              terser({
+                format: { comments: false }
+              })
+            ],
+            external: ['@firebase/app']
+          };
+        })
 ];
 
 export default [...appBuilds, ...componentBuilds, ...cdnBuilds];

--- a/packages/firebase/rollup.config.js
+++ b/packages/firebase/rollup.config.js
@@ -161,6 +161,9 @@ const cdnBuilds = [
           typescriptPluginCDN,
           terser({
             format: { comments: false }
+            keep_fnames: true,
+            keep_classnames: true,
+            keep_interfacenames: true,
           })
         ],
         external: ['@firebase/app']

--- a/packages/firebase/rollup.config.js
+++ b/packages/firebase/rollup.config.js
@@ -170,45 +170,7 @@ const cdnBuilds = [
         ],
         external: ['@firebase/app']
       };
-    }),
-    {
-        input: 'app/index.cdn.ts',
-        output: {
-          file: 'firebase-app.cjs.js',
-          sourcemap: true,
-          format: 'cjs'
-        },
-        plugins: [...plugins, typescriptPluginCDN]
-      },
-      ...pkg.components
-        .filter(component => component !== 'app')
-        .map(component => {
-          // It is needed for handling sub modules, for example firestore/lite which should produce firebase-firestore-lite.js
-          // Otherwise, we will create a directory with '/' in the name.
-          const componentName = component.replace('/', '-');
-
-          return {
-            input: `${component}/index.ts`,
-            output: {
-              file: `firebase-${componentName}.cjs.js`,
-              sourcemap: true,
-              format: 'cjs'
-            },
-            plugins: [
-              ...plugins,
-              typescriptPluginCDN,
-              terser({
-                format: { comments: false },
-                keep_fnames: true,
-                keep_classnames: true,
-                mangle: {
-                  reserved: ['_getProvider', '__PRIVATE_lastReasonableEscapeIndex']
-                }
-              })
-            ],
-            external: ['@firebase/app']
-          };
-        })
+    })
 ];
 
 export default [...appBuilds, ...componentBuilds, ...cdnBuilds];

--- a/packages/firebase/rollup.config.js
+++ b/packages/firebase/rollup.config.js
@@ -162,8 +162,8 @@ const cdnBuilds = [
           terser({
             format: { comments: false },
             keep_fnames: true,
-            keep_classnames: true,
-            keep_interfacenames: true
+            keep_classnames: true
+//             keep_interfacenames: true
           })
         ],
         external: ['@firebase/app']

--- a/packages/firebase/rollup.config.js
+++ b/packages/firebase/rollup.config.js
@@ -159,9 +159,9 @@ const cdnBuilds = [
         plugins: [
           ...plugins,
           typescriptPluginCDN,
-          terser({
-            format: { comments: false }
-          })
+//           terser({
+//             format: { comments: false }
+//           })
         ],
         external: ['@firebase/app']
       };

--- a/packages/firebase/rollup.config.js
+++ b/packages/firebase/rollup.config.js
@@ -160,10 +160,10 @@ const cdnBuilds = [
           ...plugins,
           typescriptPluginCDN,
           terser({
-            format: { comments: false }
+            format: { comments: false },
             keep_fnames: true,
             keep_classnames: true,
-            keep_interfacenames: true,
+            keep_interfacenames: true
           })
         ],
         external: ['@firebase/app']

--- a/packages/firebase/rollup.config.js
+++ b/packages/firebase/rollup.config.js
@@ -162,8 +162,10 @@ const cdnBuilds = [
           terser({
             format: { comments: false },
             keep_fnames: true,
-            keep_classnames: true
-//             keep_interfacenames: true
+            keep_classnames: true,
+            mangle: {
+              reserved: ['_getProvider', '__PRIVATE_lastReasonableEscapeIndex']
+            }
           })
         ],
         external: ['@firebase/app']

--- a/packages/firebase/rollup.config.js
+++ b/packages/firebase/rollup.config.js
@@ -159,9 +159,9 @@ const cdnBuilds = [
         plugins: [
           ...plugins,
           typescriptPluginCDN,
-//           terser({
-//             format: { comments: false }
-//           })
+          terser({
+            format: { comments: false }
+          })
         ],
         external: ['@firebase/app']
       };

--- a/packages/firestore/package.json
+++ b/packages/firestore/package.json
@@ -122,6 +122,7 @@
     "rollup-plugin-sourcemaps": "0.6.3",
     "rollup-plugin-terser": "7.0.2",
     "rollup-plugin-typescript2": "0.31.2",
+    "rollup-plugin-dts": "5.3.0",
     "ts-node": "10.9.1",
     "typescript": "4.7.4"
   },

--- a/packages/firestore/rollup.config.js
+++ b/packages/firestore/rollup.config.js
@@ -64,7 +64,7 @@ const browserPlugins = function () {
       transformers: [util.removeAssertAndPrefixInternalTransformer]
     }),
     json({ preferConst: true }),
-    terser(util.manglePrivatePropertiesOptions)
+//     terser(util.manglePrivatePropertiesOptions)
   ];
 };
 

--- a/packages/firestore/rollup.config.js
+++ b/packages/firestore/rollup.config.js
@@ -207,13 +207,13 @@ const allBuilds = [
     input: 'dist/firestore/src/index.d.ts',
     output: {
       file: 'dist/firestore/src/global_index.d.ts',
-      format: 'es',
+      format: 'es'
     },
     plugins: [
       dts({
-        respectExternal: true,
+        respectExternal: true
       })
-    ],
+    ]
   }
 ];
 

--- a/packages/firestore/rollup.config.js
+++ b/packages/firestore/rollup.config.js
@@ -64,7 +64,12 @@ const browserPlugins = function () {
       transformers: [util.removeAssertAndPrefixInternalTransformer]
     }),
     json({ preferConst: true }),
-//     terser(util.manglePrivatePropertiesOptions)
+    terser({
+      ...util.manglePrivatePropertiesOptions,
+      keep_fnames: true,
+      keep_classnames: true,
+      keep_interfacenames: true,
+    })
   ];
 };
 

--- a/packages/firestore/rollup.config.js
+++ b/packages/firestore/rollup.config.js
@@ -20,6 +20,7 @@ import alias from '@rollup/plugin-alias';
 import json from '@rollup/plugin-json';
 import replace from 'rollup-plugin-replace';
 import { terser } from 'rollup-plugin-terser';
+import dts from 'rollup-plugin-dts';
 import typescriptPlugin from 'rollup-plugin-typescript2';
 import tmp from 'tmp';
 import typescript from 'typescript';
@@ -201,6 +202,18 @@ const allBuilds = [
     treeshake: {
       moduleSideEffects: false
     }
+  },
+  {
+    input: 'dist/firestore/src/index.d.ts',
+    output: {
+      file: 'dist/firestore/src/global_index.d.ts',
+      format: 'es',
+    },
+    plugins: [
+      dts({
+        respectExternal: true,
+      })
+    ],
   }
 ];
 

--- a/packages/firestore/rollup.config.js
+++ b/packages/firestore/rollup.config.js
@@ -64,12 +64,7 @@ const browserPlugins = function () {
       transformers: [util.removeAssertAndPrefixInternalTransformer]
     }),
     json({ preferConst: true }),
-    terser({
-      ...util.manglePrivatePropertiesOptions,
-      keep_fnames: true,
-      keep_classnames: true,
-      keep_interfacenames: true,
-    })
+    terser(util.manglePrivatePropertiesOptions)
   ];
 };
 

--- a/packages/firestore/rollup.shared.js
+++ b/packages/firestore/rollup.shared.js
@@ -144,6 +144,9 @@ const manglePrivatePropertiesOptions = {
     comments: 'all',
     beautify: true
   },
+  keep_fnames: true,
+  keep_classnames: true,
+  keep_interfacenames: true,
   mangle: {
     // Temporary hack fix for an issue where mangled code causes some downstream
     // bundlers (Babel?) to confuse the same variable name in different scopes.

--- a/packages/firestore/rollup.shared.js
+++ b/packages/firestore/rollup.shared.js
@@ -146,7 +146,6 @@ const manglePrivatePropertiesOptions = {
   },
   keep_fnames: true,
   keep_classnames: true,
-  keep_interfacenames: true,
   mangle: {
     // Temporary hack fix for an issue where mangled code causes some downstream
     // bundlers (Babel?) to confuse the same variable name in different scopes.

--- a/yarn.lock
+++ b/yarn.lock
@@ -2019,6 +2019,11 @@
   resolved "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.11.tgz#771a1d8d744eeb71b6adb35808e1a6c7b9b8c8ec"
   integrity sha512-Fg32GrJo61m+VqYSdRSjRXMjQ06j8YIYfcTqndLYVAaHmroZHLJZCydsWBOTDqXS2v+mjxohBWEMfg97GXmYQg==
 
+"@jridgewell/sourcemap-codec@^1.4.13":
+  version "1.4.15"
+  resolved "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz#d7c6e6755c78567a951e04ab52ef0fd26de59f32"
+  integrity sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==
+
 "@jridgewell/trace-mapping@0.3.9":
   version "0.3.9"
   resolved "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz#6534fd5933a53ba7cbf3a17615e273a0d1273ff9"
@@ -11996,6 +12001,13 @@ magic-string@^0.25.2, magic-string@^0.25.7:
   dependencies:
     sourcemap-codec "^1.4.4"
 
+magic-string@^0.30.0:
+  version "0.30.0"
+  resolved "https://registry.npmjs.org/magic-string/-/magic-string-0.30.0.tgz#fd58a4748c5c4547338a424e90fa5dd17f4de529"
+  integrity sha512-LA+31JYDJLs82r2ScLrlz1GjSgu66ZV518eyWT+S8VhyQn/JL0u9MeBOvQMGYiPk1DBiSN9DDMOcXvigJZaViQ==
+  dependencies:
+    "@jridgewell/sourcemap-codec" "^1.4.13"
+
 magic-string@~0.26.2:
   version "0.26.7"
   resolved "https://registry.npmjs.org/magic-string/-/magic-string-0.26.7.tgz#caf7daf61b34e9982f8228c4527474dac8981d6f"
@@ -15155,6 +15167,15 @@ rollup-plugin-copy@3.4.0:
     fs-extra "^8.1.0"
     globby "10.0.1"
     is-plain-object "^3.0.0"
+
+rollup-plugin-dts@5.3.0:
+  version "5.3.0"
+  resolved "https://registry.npmjs.org/rollup-plugin-dts/-/rollup-plugin-dts-5.3.0.tgz#80a95988002f188e376f6db3b7e2f53679168957"
+  integrity sha512-8FXp0ZkyZj1iU5klkIJYLjIq/YZSwBoERu33QBDxm/1yw5UU4txrEtcmMkrq+ZiKu3Q4qvPCNqc3ovX6rjqzbQ==
+  dependencies:
+    magic-string "^0.30.0"
+  optionalDependencies:
+    "@babel/code-frame" "^7.18.6"
 
 rollup-plugin-license@3.0.1:
   version "3.0.1"


### PR DESCRIPTION
These changes include: 
- Exporting the firestore and app typescript typings in a consumable way in google3 (without imports)
- Keep the class and function names in the minified firestore file (at runtime, consuming the obfuscated names proves very challenging)