### PR TITLE
Firestore: fix rollup config to keep intermediate bundles for source maps

### DIFF
--- a/packages/firestore/rollup.config.js
+++ b/packages/firestore/rollup.config.js
@@ -75,7 +75,7 @@ const allBuilds = [
   {
     input: './src/index.node.ts',
     output: {
-      file: "dist/index.node.intermediate.mjs",
+      file: 'dist/index.node.intermediate.mjs',
       format: 'es',
       sourcemap: true
     },
@@ -88,7 +88,7 @@ const allBuilds = [
   },
   // Node CJS build
   {
-    input: "dist/index.node.intermediate.mjs",
+    input: 'dist/index.node.intermediate.mjs',
     output: {
       file: pkg.main,
       format: 'cjs',
@@ -105,7 +105,7 @@ const allBuilds = [
   },
   // Node ESM build with build target reporting
   {
-    input: "dist/index.node.intermediate.mjs",
+    input: 'dist/index.node.intermediate.mjs',
     output: {
       file: pkg['main-esm'],
       format: 'es',
@@ -123,7 +123,7 @@ const allBuilds = [
   {
     input: './src/index.ts',
     output: {
-      file: "dist/index.esm2017.intermediate.js",
+      file: 'dist/index.esm2017.intermediate.js',
       format: 'es',
       sourcemap: true
     },
@@ -135,7 +135,7 @@ const allBuilds = [
   },
   // Convert es2017 build to ES5
   {
-    input: "dist/index.esm2017.intermediate.js",
+    input: 'dist/index.esm2017.intermediate.js',
     output: [
       {
         file: pkg['esm5'],
@@ -154,7 +154,7 @@ const allBuilds = [
   },
   // Convert es2017 build to cjs
   {
-    input: "dist/index.esm2017.intermediate.js",
+    input: 'dist/index.esm2017.intermediate.js',
     output: [
       {
         file: './dist/index.cjs.js',
@@ -170,7 +170,7 @@ const allBuilds = [
   },
   // es2017 build with build target reporting
   {
-    input: "dist/index.esm2017.intermediate.js",
+    input: 'dist/index.esm2017.intermediate.js',
     output: [
       {
         file: pkg['browser'],

--- a/packages/firestore/rollup.config.js
+++ b/packages/firestore/rollup.config.js
@@ -75,7 +75,7 @@ const allBuilds = [
   {
     input: './src/index.node.ts',
     output: {
-      file: pkg['main-esm'],
+      file: "dist/index.node.intermediate.mjs",
       format: 'es',
       sourcemap: true
     },
@@ -88,7 +88,7 @@ const allBuilds = [
   },
   // Node CJS build
   {
-    input: pkg['main-esm'],
+    input: "dist/index.node.intermediate.mjs",
     output: {
       file: pkg.main,
       format: 'cjs',
@@ -105,7 +105,7 @@ const allBuilds = [
   },
   // Node ESM build with build target reporting
   {
-    input: pkg['main-esm'],
+    input: "dist/index.node.intermediate.mjs",
     output: {
       file: pkg['main-esm'],
       format: 'es',
@@ -123,7 +123,7 @@ const allBuilds = [
   {
     input: './src/index.ts',
     output: {
-      file: pkg.browser,
+      file: "dist/index.esm2017.intermediate.js",
       format: 'es',
       sourcemap: true
     },
@@ -135,7 +135,7 @@ const allBuilds = [
   },
   // Convert es2017 build to ES5
   {
-    input: pkg['browser'],
+    input: "dist/index.esm2017.intermediate.js",
     output: [
       {
         file: pkg['esm5'],
@@ -154,7 +154,7 @@ const allBuilds = [
   },
   // Convert es2017 build to cjs
   {
-    input: pkg['browser'],
+    input: "dist/index.esm2017.intermediate.js",
     output: [
       {
         file: './dist/index.cjs.js',
@@ -170,7 +170,7 @@ const allBuilds = [
   },
   // es2017 build with build target reporting
   {
-    input: pkg['browser'],
+    input: "dist/index.esm2017.intermediate.js",
     output: [
       {
         file: pkg['browser'],


### PR DESCRIPTION
Firestore's rollup configuration produces some "intermediate" bundles, which are then further processed into the ultimate bundles. However, these "intermediate" bundles happen to have the same name as some of the "ultimate" bundles and get clobbered. As a result, the source maps refer to the bundled file rather than to the original sources, rendering the source maps useless.

Although I wasn't able to figure out how to get the source maps of the "ultimate" bundles to point to the original sources, I figured out how to at least save the "intermediate" bundles. This allows a 2-step process to look up the original source code by first looking up the map from the "ultimate" file to the "intermediate" file, then from the "intermediate" file to the original source code.