### PR TITLE
Firestore: fix source maps that incorrectly referenced back into the bundle itself

### DIFF
--- a/.changeset/sour-glasses-count.md
+++ b/.changeset/sour-glasses-count.md
@@ -1,0 +1,6 @@
+---
+'@firebase/firestore': patch
+'firebase': patch
+---
+
+Fix source maps that incorrectly referenced yet another minified and mangled bundle, rendering them useless. The fixed bundles' source maps are: index.esm2017.js, index.cjs.js, index.node.mjs, and index.browser.esm2017.js (lite sdk only).

--- a/packages/firestore/rollup.config.js
+++ b/packages/firestore/rollup.config.js
@@ -28,6 +28,7 @@ import { generateBuildTargetReplaceConfig } from '../../scripts/build/rollup_rep
 
 import pkg from './package.json';
 
+const sourcemaps = require('rollup-plugin-sourcemaps');
 const util = require('./rollup.shared');
 
 const nodePlugins = function () {
@@ -111,7 +112,10 @@ const allBuilds = [
       format: 'es',
       sourcemap: true
     },
-    plugins: [replace(generateBuildTargetReplaceConfig('esm', 2017))],
+    plugins: [
+      sourcemaps(),
+      replace(generateBuildTargetReplaceConfig('esm', 2017))
+    ],
     external: util.resolveNodeExterns,
     treeshake: {
       moduleSideEffects: false
@@ -162,7 +166,10 @@ const allBuilds = [
         sourcemap: true
       }
     ],
-    plugins: [replace(generateBuildTargetReplaceConfig('cjs', 2017))],
+    plugins: [
+      sourcemaps(),
+      replace(generateBuildTargetReplaceConfig('cjs', 2017))
+    ],
     external: util.resolveBrowserExterns,
     treeshake: {
       moduleSideEffects: false
@@ -178,7 +185,10 @@ const allBuilds = [
         sourcemap: true
       }
     ],
-    plugins: [replace(generateBuildTargetReplaceConfig('esm', 2017))],
+    plugins: [
+      sourcemaps(),
+      replace(generateBuildTargetReplaceConfig('esm', 2017))
+    ],
     external: util.resolveBrowserExterns,
     treeshake: {
       moduleSideEffects: false

--- a/packages/firestore/rollup.config.lite.js
+++ b/packages/firestore/rollup.config.lite.js
@@ -106,8 +106,8 @@ const allBuilds = [
         },
         include: ['dist/lite/*.js']
       }),
-      sourcemaps(),
       json(),
+      sourcemaps(),
       replace(generateBuildTargetReplaceConfig('cjs', 5))
     ],
     external: util.resolveNodeExterns,

--- a/packages/firestore/rollup.config.lite.js
+++ b/packages/firestore/rollup.config.lite.js
@@ -106,8 +106,8 @@ const allBuilds = [
         },
         include: ['dist/lite/*.js']
       }),
-      json(),
       sourcemaps(),
+      json(),
       replace(generateBuildTargetReplaceConfig('cjs', 5))
     ],
     external: util.resolveNodeExterns,
@@ -123,7 +123,10 @@ const allBuilds = [
       format: 'es',
       sourcemap: true
     },
-    plugins: [replace(generateBuildTargetReplaceConfig('esm', 2017))],
+    plugins: [
+      sourcemaps(),
+      replace(generateBuildTargetReplaceConfig('esm', 2017))
+    ],
     external: util.resolveNodeExterns,
     treeshake: {
       moduleSideEffects: false
@@ -181,7 +184,10 @@ const allBuilds = [
         sourcemap: true
       }
     ],
-    plugins: [replace(generateBuildTargetReplaceConfig('cjs', 2017))],
+    plugins: [
+      sourcemaps(),
+      replace(generateBuildTargetReplaceConfig('cjs', 2017))
+    ],
     external: util.resolveBrowserExterns,
     treeshake: {
       moduleSideEffects: false
@@ -197,7 +203,10 @@ const allBuilds = [
         sourcemap: true
       }
     ],
-    plugins: [replace(generateBuildTargetReplaceConfig('esm', 2017))],
+    plugins: [
+      sourcemaps(),
+      replace(generateBuildTargetReplaceConfig('esm', 2017))
+    ],
     external: util.resolveBrowserExterns,
     treeshake: {
       moduleSideEffects: false


### PR DESCRIPTION
Some of the bundles produced by Firestore's rollup pipeline generated source maps that incorrectly linked into yet another minified, mangled JavaScript file, instead of back into the original source code. This rendered the source maps useless because there was no way to get back to the original source code.

The root problem was that the rollup pipeline is done in a two step process. Step 1 produces a minified, mangled bundle and step 2 takes that minified, mangled bundle and produces other minified, mangled bundles. Surprisingly, _some_ of the source maps did indeed map back to the original source code (i.e. `index.esm5.js.map` and `index.node.cjs.js`) but others referenced the intermediate minified, mangled bundle (i.e. `index.esm2017.js`, `index.cjs.js`, `index.node.mjs`, and `index.browser.esm2017.js`).

The "good" source maps, it was discovered, worked correctly by using the [rollup-plugin-sourcemaps](https://www.npmjs.com/package/rollup-plugin-sourcemaps) plugin, which "passes through" the source maps of intermediate files. So the fix was easy: just use the rollup-plugin-sourcemaps plugin in the other bundles as well. Sure enough, that is the fix in this PR and the source maps are good again.