### PR TITLE
Fix typo in index.ts

### DIFF
--- a/packages/rules-unit-testing/src/public_types/index.ts
+++ b/packages/rules-unit-testing/src/public_types/index.ts
@@ -180,7 +180,7 @@ export interface RulesTestEnvironment {
    * @example
    * ```javascript
    * const alice = testEnv.authenticatedContext('alice');
-   * await assertSucceeds(get(doc(alice.firestore(), '/doc/readable/by/alice'), { ... });
+   * await assertSucceeds(getDoc(doc(alice.firestore(), '/doc/readable/by/alice'), { ... });
    * ```
    */
   authenticatedContext(
@@ -197,7 +197,7 @@ export interface RulesTestEnvironment {
    * @example
    * ```javascript
    * const unauthed = testEnv.unauthenticatedContext();
-   * await assertFails(get(doc(unauthed.firestore(), '/private/doc'), { ... });
+   * await assertFails(getDoc(doc(unauthed.firestore(), '/private/doc'), { ... });
    * ```
    */
   unauthenticatedContext(): RulesTestContext;


### PR DESCRIPTION
This pull request fixes two typos in the documentation of the functions `RulesTestEnvironment.authenticatedContext` and `RulesTestEnvironment.unauthenticatedContext` of the `@firebase/rules-unit-testing` package.