### PR TITLE
Firestore: transactions.test.ts: increase the timeout of some tests to reduce flakiness

### DIFF
--- a/packages/firestore/test/integration/api/transactions.test.ts
+++ b/packages/firestore/test/integration/api/transactions.test.ts
@@ -314,7 +314,7 @@ apiDescribe('Database transactions', (persistence: boolean) => {
         .run(get, set1, set2)
         .expectDoc({ foo: 'bar2' });
     });
-  });
+  }).timeout(10000);
 
   // This test is identical to the test above, except that withNonexistentDoc()
   // is replaced by withDeletedDoc(), to guard against regression of
@@ -355,7 +355,7 @@ apiDescribe('Database transactions', (persistence: boolean) => {
         .expectDoc({ foo: 'bar2' });
       await tt.withDeletedDoc().run(get, set1, set2).expectDoc({ foo: 'bar2' });
     });
-  });
+  }).timeout(10000);
 
   it('runs transactions on existing document', async () => {
     return withTestDb(persistence, async db => {


### PR DESCRIPTION
These tests were flirting with the 5-second timeout, and sometimes timed out when run locally. This PR increases the timeout to 10 seconds to reduce the flakiness.