### PR TITLE
Fix lerna commands in test-all.yml

### DIFF
--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -82,7 +82,7 @@ jobs:
     - name: Run unit tests
       # Ignore auth and firestore since they're handled in their own separate jobs.
       run: |
-        xvfb-run lerna run --ignore '{firebase-messaging-integration-test,@firebase/auth*,@firebase/firestore*,firebase-firestore-integration-test}' --concurrency 4 test:ci
+        xvfb-run yarn lerna run --ignore '{firebase-messaging-integration-test,@firebase/auth*,@firebase/firestore*,firebase-firestore-integration-test}' --concurrency 4 test:ci
         node scripts/print_test_logs.js
       env:
         FIREBASE_TOKEN: ${{ secrets.FIREBASE_CLI_TOKEN }}
@@ -129,7 +129,7 @@ jobs:
       run: echo "FIREBASE_CI_TEST_START_TIME=$(date +%s)" >> $GITHUB_ENV
     - name: Run unit tests
       run: |
-        xvfb-run lerna run --concurrency 4 test:ci --scope '@firebase/auth*'
+        xvfb-run yarn lerna run --concurrency 4 test:ci --scope '@firebase/auth*'
         node scripts/print_test_logs.js
       env:
         FIREBASE_TOKEN: ${{ secrets.FIREBASE_CLI_TOKEN }}
@@ -172,7 +172,7 @@ jobs:
       run: echo "FIREBASE_CI_TEST_START_TIME=$(date +%s)" >> $GITHUB_ENV
     - name: Run unit tests
       run: |
-        xvfb-run lerna run --concurrency 4 test:ci --scope '{@firebase/firestore*,firebase-firestore-integration-test}'
+        xvfb-run yarn lerna run --concurrency 4 test:ci --scope '{@firebase/firestore*,firebase-firestore-integration-test}'
         node scripts/print_test_logs.js
       env:
         FIREBASE_TOKEN: ${{ secrets.FIREBASE_CLI_TOKEN }}


### PR DESCRIPTION
Lerna commands need to be run with yarn to use the locally installed version instead of the globally installed version on the Github VM (a much higher version).