### PR TITLE
Firestore: remove explicit type from `persistence` argument in integration tests

### DIFF
--- a/packages/firestore/test/integration/api/aggregation.test.ts
+++ b/packages/firestore/test/integration/api/aggregation.test.ts
@@ -42,7 +42,7 @@ import {
 } from '../util/helpers';
 import { USE_EMULATOR } from '../util/settings';
 
-apiDescribe('Count queries', (persistence: boolean) => {
+apiDescribe('Count queries', persistence => {
   it('can run count query getCountFromServer', () => {
     const testDocs = {
       a: { author: 'authorA', title: 'titleA' },
@@ -147,7 +147,7 @@ apiDescribe('Count queries', (persistence: boolean) => {
   );
 });
 
-apiDescribe('Aggregation queries', (persistence: boolean) => {
+apiDescribe('Aggregation queries', persistence => {
   it('can run count query getAggregationFromServer', () => {
     const testDocs = {
       a: { author: 'authorA', title: 'titleA' },
@@ -354,1201 +354,1193 @@ apiDescribe('Aggregation queries', (persistence: boolean) => {
 });
 
 // TODO (sum/avg) enable these tests when sum/avg is supported by the backend
-apiDescribe.skip(
-  'Aggregation queries - sum / average',
-  (persistence: boolean) => {
-    it('can run sum query getAggregationFromServer', () => {
-      const testDocs = {
-        a: { author: 'authorA', title: 'titleA', pages: 100 },
-        b: { author: 'authorB', title: 'titleB', pages: 50 }
-      };
-      return withTestCollection(persistence, testDocs, async coll => {
-        const snapshot = await getAggregateFromServer(coll, {
-          totalPages: sum('pages')
-        });
-        expect(snapshot.data().totalPages).to.equal(150);
+apiDescribe.skip('Aggregation queries - sum / average', persistence => {
+  it('can run sum query getAggregationFromServer', () => {
+    const testDocs = {
+      a: { author: 'authorA', title: 'titleA', pages: 100 },
+      b: { author: 'authorB', title: 'titleB', pages: 50 }
+    };
+    return withTestCollection(persistence, testDocs, async coll => {
+      const snapshot = await getAggregateFromServer(coll, {
+        totalPages: sum('pages')
       });
+      expect(snapshot.data().totalPages).to.equal(150);
     });
+  });
 
-    it('can run average query getAggregationFromServer', () => {
-      const testDocs = {
-        a: { author: 'authorA', title: 'titleA', pages: 100 },
-        b: { author: 'authorB', title: 'titleB', pages: 50 }
-      };
-      return withTestCollection(persistence, testDocs, async coll => {
-        const snapshot = await getAggregateFromServer(coll, {
-          averagePages: average('pages')
-        });
-        expect(snapshot.data().averagePages).to.equal(75);
+  it('can run average query getAggregationFromServer', () => {
+    const testDocs = {
+      a: { author: 'authorA', title: 'titleA', pages: 100 },
+      b: { author: 'authorB', title: 'titleB', pages: 50 }
+    };
+    return withTestCollection(persistence, testDocs, async coll => {
+      const snapshot = await getAggregateFromServer(coll, {
+        averagePages: average('pages')
       });
+      expect(snapshot.data().averagePages).to.equal(75);
     });
+  });
 
-    it('can get multiple aggregations using getAggregationFromServer', () => {
-      const testDocs = {
-        a: { author: 'authorA', title: 'titleA', pages: 100 },
-        b: { author: 'authorB', title: 'titleB', pages: 50 }
-      };
-      return withTestCollection(persistence, testDocs, async coll => {
-        const snapshot = await getAggregateFromServer(coll, {
-          totalPages: sum('pages'),
-          averagePages: average('pages'),
-          count: count()
-        });
-        expect(snapshot.data().totalPages).to.equal(150);
-        expect(snapshot.data().averagePages).to.equal(75);
-        expect(snapshot.data().count).to.equal(2);
+  it('can get multiple aggregations using getAggregationFromServer', () => {
+    const testDocs = {
+      a: { author: 'authorA', title: 'titleA', pages: 100 },
+      b: { author: 'authorB', title: 'titleB', pages: 50 }
+    };
+    return withTestCollection(persistence, testDocs, async coll => {
+      const snapshot = await getAggregateFromServer(coll, {
+        totalPages: sum('pages'),
+        averagePages: average('pages'),
+        count: count()
       });
+      expect(snapshot.data().totalPages).to.equal(150);
+      expect(snapshot.data().averagePages).to.equal(75);
+      expect(snapshot.data().count).to.equal(2);
     });
+  });
 
-    it('can get duplicate aggregations using getAggregationFromServer', () => {
-      const testDocs = {
-        a: { author: 'authorA', title: 'titleA', pages: 100 },
-        b: { author: 'authorB', title: 'titleB', pages: 50 }
-      };
-      return withTestCollection(persistence, testDocs, async coll => {
-        const snapshot = await getAggregateFromServer(coll, {
-          totalPages: sum('pages'),
-          averagePages: average('pages'),
-          totalPagesX: sum('pages'),
-          averagePagesY: average('pages')
-        });
-        expect(snapshot.data().totalPages).to.equal(150);
-        expect(snapshot.data().averagePages).to.equal(75);
-        expect(snapshot.data().totalPagesX).to.equal(150);
-        expect(snapshot.data().averagePagesY).to.equal(75);
+  it('can get duplicate aggregations using getAggregationFromServer', () => {
+    const testDocs = {
+      a: { author: 'authorA', title: 'titleA', pages: 100 },
+      b: { author: 'authorB', title: 'titleB', pages: 50 }
+    };
+    return withTestCollection(persistence, testDocs, async coll => {
+      const snapshot = await getAggregateFromServer(coll, {
+        totalPages: sum('pages'),
+        averagePages: average('pages'),
+        totalPagesX: sum('pages'),
+        averagePagesY: average('pages')
       });
+      expect(snapshot.data().totalPages).to.equal(150);
+      expect(snapshot.data().averagePages).to.equal(75);
+      expect(snapshot.data().totalPagesX).to.equal(150);
+      expect(snapshot.data().averagePagesY).to.equal(75);
     });
+  });
 
-    it('can perform max (5) aggregations using getAggregationFromServer', () => {
-      const testDocs = {
-        a: { author: 'authorA', title: 'titleA', pages: 100 },
-        b: { author: 'authorB', title: 'titleB', pages: 50 }
-      };
-      return withTestCollection(persistence, testDocs, async coll => {
-        const snapshot = await getAggregateFromServer(coll, {
-          totalPages: sum('pages'),
-          averagePages: average('pages'),
+  it('can perform max (5) aggregations using getAggregationFromServer', () => {
+    const testDocs = {
+      a: { author: 'authorA', title: 'titleA', pages: 100 },
+      b: { author: 'authorB', title: 'titleB', pages: 50 }
+    };
+    return withTestCollection(persistence, testDocs, async coll => {
+      const snapshot = await getAggregateFromServer(coll, {
+        totalPages: sum('pages'),
+        averagePages: average('pages'),
+        count: count(),
+        totalPagesX: sum('pages'),
+        averagePagesY: average('pages')
+      });
+      expect(snapshot.data().totalPages).to.equal(150);
+      expect(snapshot.data().averagePages).to.equal(75);
+      expect(snapshot.data().count).to.equal(2);
+      expect(snapshot.data().totalPagesX).to.equal(150);
+      expect(snapshot.data().averagePagesY).to.equal(75);
+    });
+  });
+
+  it('fails when exceeding the max (5) aggregations using getAggregationFromServer', () => {
+    const testDocs = {
+      a: { author: 'authorA', title: 'titleA', pages: 100 },
+      b: { author: 'authorB', title: 'titleB', pages: 50 }
+    };
+    return withTestCollection(persistence, testDocs, async coll => {
+      const promise = getAggregateFromServer(coll, {
+        totalPages: sum('pages'),
+        averagePages: average('pages'),
+        count: count(),
+        totalPagesX: sum('pages'),
+        averagePagesY: average('pages'),
+        countZ: count()
+      });
+
+      await expect(promise).to.eventually.be.rejectedWith(
+        /maximum number of aggregations/
+      );
+    });
+  });
+
+  it('aggregate query supports collection groups', () => {
+    return withTestDb(persistence, async db => {
+      const collectionGroupId = doc(collection(db, 'aggregateQueryTest')).id;
+      const docPaths = [
+        `${collectionGroupId}/cg-doc1`,
+        `abc/123/${collectionGroupId}/cg-doc2`,
+        `zzz${collectionGroupId}/cg-doc3`,
+        `abc/123/zzz${collectionGroupId}/cg-doc4`,
+        `abc/123/zzz/${collectionGroupId}`
+      ];
+      const batch = writeBatch(db);
+      for (const docPath of docPaths) {
+        batch.set(doc(db, docPath), { x: 2 });
+      }
+      await batch.commit();
+      const snapshot = await getAggregateFromServer(
+        collectionGroup(db, collectionGroupId),
+        {
           count: count(),
-          totalPagesX: sum('pages'),
-          averagePagesY: average('pages')
-        });
-        expect(snapshot.data().totalPages).to.equal(150);
-        expect(snapshot.data().averagePages).to.equal(75);
-        expect(snapshot.data().count).to.equal(2);
-        expect(snapshot.data().totalPagesX).to.equal(150);
-        expect(snapshot.data().averagePagesY).to.equal(75);
-      });
-    });
-
-    it('fails when exceeding the max (5) aggregations using getAggregationFromServer', () => {
-      const testDocs = {
-        a: { author: 'authorA', title: 'titleA', pages: 100 },
-        b: { author: 'authorB', title: 'titleB', pages: 50 }
-      };
-      return withTestCollection(persistence, testDocs, async coll => {
-        const promise = getAggregateFromServer(coll, {
-          totalPages: sum('pages'),
-          averagePages: average('pages'),
-          count: count(),
-          totalPagesX: sum('pages'),
-          averagePagesY: average('pages'),
-          countZ: count()
-        });
-
-        await expect(promise).to.eventually.be.rejectedWith(
-          /maximum number of aggregations/
-        );
-      });
-    });
-
-    it('aggregate query supports collection groups', () => {
-      return withTestDb(persistence, async db => {
-        const collectionGroupId = doc(collection(db, 'aggregateQueryTest')).id;
-        const docPaths = [
-          `${collectionGroupId}/cg-doc1`,
-          `abc/123/${collectionGroupId}/cg-doc2`,
-          `zzz${collectionGroupId}/cg-doc3`,
-          `abc/123/zzz${collectionGroupId}/cg-doc4`,
-          `abc/123/zzz/${collectionGroupId}`
-        ];
-        const batch = writeBatch(db);
-        for (const docPath of docPaths) {
-          batch.set(doc(db, docPath), { x: 2 });
+          sum: sum('x'),
+          avg: average('x')
         }
-        await batch.commit();
-        const snapshot = await getAggregateFromServer(
-          collectionGroup(db, collectionGroupId),
-          {
-            count: count(),
-            sum: sum('x'),
-            avg: average('x')
-          }
-        );
-        expect(snapshot.data().count).to.equal(2);
-        expect(snapshot.data().sum).to.equal(4);
-        expect(snapshot.data().avg).to.equal(2);
-      });
+      );
+      expect(snapshot.data().count).to.equal(2);
+      expect(snapshot.data().sum).to.equal(4);
+      expect(snapshot.data().avg).to.equal(2);
     });
+  });
 
-    it('performs aggregations on documents with all aggregated fields using getAggregationFromServer', () => {
-      const testDocs = {
-        a: { author: 'authorA', title: 'titleA', pages: 100, year: 1980 },
-        b: { author: 'authorB', title: 'titleB', pages: 50, year: 2020 },
-        c: { author: 'authorC', title: 'titleC', pages: 150, year: 2021 },
-        d: { author: 'authorD', title: 'titleD', pages: 50 }
-      };
-      return withTestCollection(persistence, testDocs, async coll => {
-        const snapshot = await getAggregateFromServer(coll, {
-          totalPages: sum('pages'),
-          averagePages: average('pages'),
-          averageYear: average('year'),
-          count: count()
-        });
-        expect(snapshot.data().totalPages).to.equal(300);
-        expect(snapshot.data().averagePages).to.equal(100);
-        expect(snapshot.data().averageYear).to.equal(2007);
-        expect(snapshot.data().count).to.equal(3);
+  it('performs aggregations on documents with all aggregated fields using getAggregationFromServer', () => {
+    const testDocs = {
+      a: { author: 'authorA', title: 'titleA', pages: 100, year: 1980 },
+      b: { author: 'authorB', title: 'titleB', pages: 50, year: 2020 },
+      c: { author: 'authorC', title: 'titleC', pages: 150, year: 2021 },
+      d: { author: 'authorD', title: 'titleD', pages: 50 }
+    };
+    return withTestCollection(persistence, testDocs, async coll => {
+      const snapshot = await getAggregateFromServer(coll, {
+        totalPages: sum('pages'),
+        averagePages: average('pages'),
+        averageYear: average('year'),
+        count: count()
       });
+      expect(snapshot.data().totalPages).to.equal(300);
+      expect(snapshot.data().averagePages).to.equal(100);
+      expect(snapshot.data().averageYear).to.equal(2007);
+      expect(snapshot.data().count).to.equal(3);
     });
+  });
 
-    it('performs aggregates on multiple fields where one aggregate could cause short-circuit due to NaN using getAggregationFromServer', () => {
-      const testDocs = {
-        a: {
-          author: 'authorA',
-          title: 'titleA',
-          pages: 100,
-          year: 1980,
-          rating: 5
-        },
-        b: {
-          author: 'authorB',
-          title: 'titleB',
-          pages: 50,
-          year: 2020,
-          rating: 4
-        },
-        c: {
-          author: 'authorC',
-          title: 'titleC',
-          pages: 100,
-          year: 1980,
-          rating: Number.NaN
-        },
-        d: {
-          author: 'authorD',
-          title: 'titleD',
-          pages: 50,
-          year: 2020,
-          rating: 0
-        }
-      };
-      return withTestCollection(persistence, testDocs, async coll => {
-        const snapshot = await getAggregateFromServer(coll, {
+  it('performs aggregates on multiple fields where one aggregate could cause short-circuit due to NaN using getAggregationFromServer', () => {
+    const testDocs = {
+      a: {
+        author: 'authorA',
+        title: 'titleA',
+        pages: 100,
+        year: 1980,
+        rating: 5
+      },
+      b: {
+        author: 'authorB',
+        title: 'titleB',
+        pages: 50,
+        year: 2020,
+        rating: 4
+      },
+      c: {
+        author: 'authorC',
+        title: 'titleC',
+        pages: 100,
+        year: 1980,
+        rating: Number.NaN
+      },
+      d: {
+        author: 'authorD',
+        title: 'titleD',
+        pages: 50,
+        year: 2020,
+        rating: 0
+      }
+    };
+    return withTestCollection(persistence, testDocs, async coll => {
+      const snapshot = await getAggregateFromServer(coll, {
+        totalRating: sum('rating'),
+        totalPages: sum('pages'),
+        averageYear: average('year')
+      });
+      expect(snapshot.data().totalRating).to.be.NaN;
+      expect(snapshot.data().totalPages).to.equal(300);
+      expect(snapshot.data().averageYear).to.equal(2000);
+    });
+  });
+
+  it('returns undefined when getting the result of an unrequested aggregation', () => {
+    const testDocs = {
+      a: {
+        author: 'authorA',
+        title: 'titleA',
+        pages: 100,
+        year: 1980,
+        rating: 5
+      },
+      b: {
+        author: 'authorB',
+        title: 'titleB',
+        pages: 50,
+        year: 2020,
+        rating: 4
+      },
+      c: {
+        author: 'authorC',
+        title: 'titleC',
+        pages: 100,
+        year: 1980,
+        rating: 3
+      },
+      d: {
+        author: 'authorD',
+        title: 'titleD',
+        pages: 50,
+        year: 2020,
+        rating: 0
+      }
+    };
+    return withTestCollection(persistence, testDocs, async coll => {
+      const snapshot = await getAggregateFromServer(
+        query(coll, where('pages', '>', 200)),
+        {
           totalRating: sum('rating'),
-          totalPages: sum('pages'),
-          averageYear: average('year')
-        });
-        expect(snapshot.data().totalRating).to.be.NaN;
-        expect(snapshot.data().totalPages).to.equal(300);
-        expect(snapshot.data().averageYear).to.equal(2000);
-      });
-    });
-
-    it('returns undefined when getting the result of an unrequested aggregation', () => {
-      const testDocs = {
-        a: {
-          author: 'authorA',
-          title: 'titleA',
-          pages: 100,
-          year: 1980,
-          rating: 5
-        },
-        b: {
-          author: 'authorB',
-          title: 'titleB',
-          pages: 50,
-          year: 2020,
-          rating: 4
-        },
-        c: {
-          author: 'authorC',
-          title: 'titleC',
-          pages: 100,
-          year: 1980,
-          rating: 3
-        },
-        d: {
-          author: 'authorD',
-          title: 'titleD',
-          pages: 50,
-          year: 2020,
-          rating: 0
+          averageRating: average('rating')
         }
-      };
-      return withTestCollection(persistence, testDocs, async coll => {
-        const snapshot = await getAggregateFromServer(
-          query(coll, where('pages', '>', 200)),
-          {
-            totalRating: sum('rating'),
-            averageRating: average('rating')
-          }
-        );
+      );
 
-        // @ts-expect-error
-        const totalPages = snapshot.data().totalPages;
-        expect(totalPages).to.equal(undefined);
-      });
+      // @ts-expect-error
+      const totalPages = snapshot.data().totalPages;
+      expect(totalPages).to.equal(undefined);
     });
+  });
 
-    it('performs aggregates when using `in` operator getAggregationFromServer', () => {
-      const testDocs = {
-        a: {
-          author: 'authorA',
-          title: 'titleA',
-          pages: 100,
-          year: 1980,
-          rating: 5
-        },
-        b: {
-          author: 'authorB',
-          title: 'titleB',
-          pages: 50,
-          year: 2020,
-          rating: 4
-        },
-        c: {
-          author: 'authorC',
-          title: 'titleC',
-          pages: 100,
-          year: 1980,
-          rating: 3
-        },
-        d: {
-          author: 'authorD',
-          title: 'titleD',
-          pages: 50,
-          year: 2020,
-          rating: 0
-        }
-      };
-      return withTestCollection(persistence, testDocs, async coll => {
-        const snapshot = await getAggregateFromServer(
-          query(coll, where('rating', 'in', [5, 3])),
-          {
-            totalRating: sum('rating'),
-            averageRating: average('rating'),
-            totalPages: sum('pages'),
-            averagePages: average('pages'),
-            countOfDocs: count()
-          }
-        );
-        expect(snapshot.data().totalRating).to.equal(8);
-        expect(snapshot.data().averageRating).to.equal(4);
-        expect(snapshot.data().totalPages).to.equal(200);
-        expect(snapshot.data().averagePages).to.equal(100);
-        expect(snapshot.data().countOfDocs).to.equal(2);
-      });
-    });
-
-    it('performs aggregates when using `array-contains-any` operator getAggregationFromServer', () => {
-      const testDocs = {
-        a: {
-          author: 'authorA',
-          title: 'titleA',
-          pages: 100,
-          year: 1980,
-          rating: [5, 1000]
-        },
-        b: {
-          author: 'authorB',
-          title: 'titleB',
-          pages: 50,
-          year: 2020,
-          rating: [4]
-        },
-        c: {
-          author: 'authorC',
-          title: 'titleC',
-          pages: 100,
-          year: 1980,
-          rating: [2222, 3]
-        },
-        d: {
-          author: 'authorD',
-          title: 'titleD',
-          pages: 50,
-          year: 2020,
-          rating: [0]
-        }
-      };
-      return withTestCollection(persistence, testDocs, async coll => {
-        const snapshot = await getAggregateFromServer(
-          query(coll, where('rating', 'array-contains-any', [5, 3])),
-          {
-            totalRating: sum('rating'),
-            averageRating: average('rating'),
-            totalPages: sum('pages'),
-            averagePages: average('pages'),
-            countOfDocs: count()
-          }
-        );
-        expect(snapshot.data().totalRating).to.equal(0);
-        expect(snapshot.data().averageRating).to.be.null;
-        expect(snapshot.data().totalPages).to.equal(200);
-        expect(snapshot.data().averagePages).to.equal(100);
-        expect(snapshot.data().countOfDocs).to.equal(2);
-      });
-    });
-
-    it('performs aggregations on nested map values using getAggregationFromServer', () => {
-      const testDocs = {
-        a: {
-          author: 'authorA',
-          title: 'titleA',
-          metadata: { pages: 100, rating: { critic: 2, user: 5 } }
-        },
-        b: {
-          author: 'authorB',
-          title: 'titleB',
-          metadata: { pages: 50, rating: { critic: 4, user: 4 } }
-        }
-      };
-      return withTestCollection(persistence, testDocs, async coll => {
-        const snapshot = await getAggregateFromServer(coll, {
-          totalPages: sum('metadata.pages'),
-          averagePages: average('metadata.pages'),
-          averageCriticRating: average('metadata.rating.critic'),
-          totalUserRating: sum('metadata.rating.user'),
-          count: count()
-        });
-        expect(snapshot.data().totalPages).to.equal(150);
-        expect(snapshot.data().averagePages).to.equal(75);
-        expect(snapshot.data().averageCriticRating).to.equal(3);
-        expect(snapshot.data().totalUserRating).to.equal(9);
-        expect(snapshot.data().count).to.equal(2);
-      });
-    });
-
-    it('performs sum that results in float using getAggregationFromServer', () => {
-      const testDocs = {
-        a: {
-          author: 'authorA',
-          title: 'titleA',
-          pages: 100,
-          year: 1980,
-          rating: 5
-        },
-        b: {
-          author: 'authorB',
-          title: 'titleB',
-          pages: 50,
-          year: 2020,
-          rating: 4.5
-        },
-        c: {
-          author: 'authorB',
-          title: 'titleB',
-          pages: 150,
-          year: 2021,
-          rating: 3
-        }
-      };
-      return withTestCollection(persistence, testDocs, async coll => {
-        const snapshot = await getAggregateFromServer(coll, {
-          totalRating: sum('rating')
-        });
-        expect(snapshot.data().totalRating).to.equal(12.5);
-      });
-    });
-
-    it('performs sum of ints and floats that results in an int using getAggregationFromServer', () => {
-      const testDocs = {
-        a: {
-          author: 'authorA',
-          title: 'titleA',
-          pages: 100,
-          year: 1980,
-          rating: 5
-        },
-        b: {
-          author: 'authorB',
-          title: 'titleB',
-          pages: 50,
-          year: 2020,
-          rating: 4.5
-        },
-        c: {
-          author: 'authorB',
-          title: 'titleB',
-          pages: 150,
-          year: 2021,
-          rating: 3.5
-        }
-      };
-      return withTestCollection(persistence, testDocs, async coll => {
-        const snapshot = await getAggregateFromServer(coll, {
-          totalRating: sum('rating')
-        });
-        expect(snapshot.data().totalRating).to.equal(13);
-      });
-    });
-
-    it('performs sum that overflows max int using getAggregationFromServer', () => {
-      // A large value that will be represented as a Long on the server, but
-      // doubling (2x) this value must overflow Long and force the result to be
-      // represented as a Double type on the server.
-      const maxLong = Math.pow(2, 63) - 1;
-
-      const testDocs = {
-        a: {
-          author: 'authorA',
-          title: 'titleA',
-          pages: 100,
-          year: 1980,
-          rating: maxLong
-        },
-        b: {
-          author: 'authorB',
-          title: 'titleB',
-          pages: 50,
-          year: 2020,
-          rating: maxLong
-        }
-      };
-      return withTestCollection(persistence, testDocs, async coll => {
-        const snapshot = await getAggregateFromServer(coll, {
-          totalRating: sum('rating')
-        });
-        expect(snapshot.data().totalRating).to.equal(maxLong + maxLong);
-      });
-    });
-
-    it('performs sum that can overflow integer values during accumulation using getAggregationFromServer', () => {
-      const testDocs = {
-        a: {
-          author: 'authorA',
-          title: 'titleA',
-          pages: 100,
-          year: 1980,
-          rating: Number.MAX_SAFE_INTEGER
-        },
-        b: {
-          author: 'authorB',
-          title: 'titleB',
-          pages: 50,
-          year: 2020,
-          rating: 1
-        },
-        c: {
-          author: 'authorC',
-          title: 'titleC',
-          pages: 50,
-          year: 2020,
-          rating: -101
-        }
-      };
-      return withTestCollection(persistence, testDocs, async coll => {
-        const snapshot = await getAggregateFromServer(coll, {
-          totalRating: sum('rating')
-        });
-        expect(snapshot.data().totalRating).to.equal(
-          Number.MAX_SAFE_INTEGER - 100
-        );
-      });
-    });
-
-    it('performs sum that is negative using getAggregationFromServer', () => {
-      const testDocs = {
-        a: {
-          author: 'authorA',
-          title: 'titleA',
-          pages: 100,
-          year: 1980,
-          rating: Number.MAX_SAFE_INTEGER
-        },
-        b: {
-          author: 'authorB',
-          title: 'titleB',
-          pages: 50,
-          year: 2020,
-          rating: Number.MIN_SAFE_INTEGER
-        },
-        c: {
-          author: 'authorC',
-          title: 'titleC',
-          pages: 50,
-          year: 2020,
-          rating: -101
-        },
-        d: {
-          author: 'authorD',
-          title: 'titleD',
-          pages: 50,
-          year: 2020,
-          rating: -10000
-        }
-      };
-      return withTestCollection(persistence, testDocs, async coll => {
-        const snapshot = await getAggregateFromServer(coll, {
-          totalRating: sum('rating')
-        });
-        expect(snapshot.data().totalRating).to.equal(-10101);
-      });
-    });
-
-    it('performs sum that is positive infinity using getAggregationFromServer', () => {
-      const testDocs = {
-        a: {
-          author: 'authorA',
-          title: 'titleA',
-          pages: 100,
-          year: 1980,
-          rating: Number.MAX_VALUE
-        },
-        b: {
-          author: 'authorB',
-          title: 'titleB',
-          pages: 50,
-          year: 2020,
-          rating: Number.MAX_VALUE
-        }
-      };
-      return withTestCollection(persistence, testDocs, async coll => {
-        const snapshot = await getAggregateFromServer(coll, {
-          totalRating: sum('rating')
-        });
-        expect(snapshot.data().totalRating).to.equal(Number.POSITIVE_INFINITY);
-      });
-    });
-
-    it('performs sum that is positive infinity using getAggregationFromServer v2', () => {
-      const testDocs = {
-        a: {
-          author: 'authorA',
-          title: 'titleA',
-          pages: 100,
-          year: 1980,
-          rating: Number.MAX_VALUE
-        },
-        b: {
-          author: 'authorB',
-          title: 'titleB',
-          pages: 50,
-          year: 2020,
-          rating: 1e293
-        }
-      };
-      return withTestCollection(persistence, testDocs, async coll => {
-        const snapshot = await getAggregateFromServer(coll, {
-          totalRating: sum('rating')
-        });
-        expect(snapshot.data().totalRating).to.equal(Number.POSITIVE_INFINITY);
-      });
-    });
-
-    it('performs sum that is negative infinity using getAggregationFromServer', () => {
-      const testDocs = {
-        a: {
-          author: 'authorA',
-          title: 'titleA',
-          pages: 100,
-          year: 1980,
-          rating: -Number.MAX_VALUE
-        },
-        b: {
-          author: 'authorB',
-          title: 'titleB',
-          pages: 50,
-          year: 2020,
-          rating: -Number.MAX_VALUE
-        }
-      };
-      return withTestCollection(persistence, testDocs, async coll => {
-        const snapshot = await getAggregateFromServer(coll, {
-          totalRating: sum('rating')
-        });
-        expect(snapshot.data().totalRating).to.equal(Number.NEGATIVE_INFINITY);
-      });
-    });
-
-    it('performs sum that is valid but could overflow during aggregation using getAggregationFromServer', () => {
-      const testDocs = {
-        a: {
-          author: 'authorA',
-          title: 'titleA',
-          pages: 100,
-          year: 1980,
-          rating: Number.MAX_VALUE
-        },
-        b: {
-          author: 'authorB',
-          title: 'titleB',
-          pages: 50,
-          year: 2020,
-          rating: Number.MAX_VALUE
-        },
-        c: {
-          author: 'authorC',
-          title: 'titleC',
-          pages: 100,
-          year: 1980,
-          rating: -Number.MAX_VALUE
-        },
-        d: {
-          author: 'authorD',
-          title: 'titleD',
-          pages: 50,
-          year: 2020,
-          rating: -Number.MAX_VALUE
-        },
-        e: {
-          author: 'authorE',
-          title: 'titleE',
-          pages: 100,
-          year: 1980,
-          rating: Number.MAX_VALUE
-        },
-        f: {
-          author: 'authorF',
-          title: 'titleF',
-          pages: 50,
-          year: 2020,
-          rating: -Number.MAX_VALUE
-        },
-        g: {
-          author: 'authorG',
-          title: 'titleG',
-          pages: 100,
-          year: 1980,
-          rating: -Number.MAX_VALUE
-        },
-        h: {
-          author: 'authorH',
-          title: 'titleDH',
-          pages: 50,
-          year: 2020,
-          rating: Number.MAX_VALUE
-        }
-      };
-      return withTestCollection(persistence, testDocs, async coll => {
-        const snapshot = await getAggregateFromServer(coll, {
-          totalRating: sum('rating')
-        });
-        expect(snapshot.data().totalRating).to.equal(0);
-      });
-    });
-
-    it('performs sum that includes NaN using getAggregationFromServer', () => {
-      const testDocs = {
-        a: {
-          author: 'authorA',
-          title: 'titleA',
-          pages: 100,
-          year: 1980,
-          rating: 5
-        },
-        b: {
-          author: 'authorB',
-          title: 'titleB',
-          pages: 50,
-          year: 2020,
-          rating: 4
-        },
-        c: {
-          author: 'authorC',
-          title: 'titleC',
-          pages: 100,
-          year: 1980,
-          rating: Number.NaN
-        },
-        d: {
-          author: 'authorD',
-          title: 'titleD',
-          pages: 50,
-          year: 2020,
-          rating: 0
-        }
-      };
-      return withTestCollection(persistence, testDocs, async coll => {
-        const snapshot = await getAggregateFromServer(coll, {
-          totalRating: sum('rating')
-        });
-        expect(snapshot.data().totalRating).to.be.NaN;
-      });
-    });
-
-    it('performs sum over a result set of zero documents using getAggregationFromServer', () => {
-      const testDocs = {
-        a: {
-          author: 'authorA',
-          title: 'titleA',
-          pages: 100,
-          year: 1980,
-          rating: 5
-        },
-        b: {
-          author: 'authorB',
-          title: 'titleB',
-          pages: 50,
-          year: 2020,
-          rating: 4
-        },
-        c: {
-          author: 'authorC',
-          title: 'titleC',
-          pages: 100,
-          year: 1980,
-          rating: 3
-        },
-        d: {
-          author: 'authorD',
-          title: 'titleD',
-          pages: 50,
-          year: 2020,
-          rating: 0
-        }
-      };
-      return withTestCollection(persistence, testDocs, async coll => {
-        const snapshot = await getAggregateFromServer(
-          query(coll, where('pages', '>', 200)),
-          {
-            totalRating: sum('rating')
-          }
-        );
-        expect(snapshot.data().totalRating).to.equal(0);
-      });
-    });
-
-    it('performs sum only on numeric fields using getAggregationFromServer', () => {
-      const testDocs = {
-        a: {
-          author: 'authorA',
-          title: 'titleA',
-          pages: 100,
-          year: 1980,
-          rating: 5
-        },
-        b: {
-          author: 'authorB',
-          title: 'titleB',
-          pages: 50,
-          year: 2020,
-          rating: 4
-        },
-        c: {
-          author: 'authorC',
-          title: 'titleC',
-          pages: 100,
-          year: 1980,
-          rating: '3'
-        },
-        d: {
-          author: 'authorD',
-          title: 'titleD',
-          pages: 50,
-          year: 2020,
-          rating: 1
-        }
-      };
-      return withTestCollection(persistence, testDocs, async coll => {
-        const snapshot = await getAggregateFromServer(coll, {
+  it('performs aggregates when using `in` operator getAggregationFromServer', () => {
+    const testDocs = {
+      a: {
+        author: 'authorA',
+        title: 'titleA',
+        pages: 100,
+        year: 1980,
+        rating: 5
+      },
+      b: {
+        author: 'authorB',
+        title: 'titleB',
+        pages: 50,
+        year: 2020,
+        rating: 4
+      },
+      c: {
+        author: 'authorC',
+        title: 'titleC',
+        pages: 100,
+        year: 1980,
+        rating: 3
+      },
+      d: {
+        author: 'authorD',
+        title: 'titleD',
+        pages: 50,
+        year: 2020,
+        rating: 0
+      }
+    };
+    return withTestCollection(persistence, testDocs, async coll => {
+      const snapshot = await getAggregateFromServer(
+        query(coll, where('rating', 'in', [5, 3])),
+        {
           totalRating: sum('rating'),
-          countOfDocs: count()
-        });
-        expect(snapshot.data().totalRating).to.equal(10);
-        expect(snapshot.data().countOfDocs).to.equal(4);
-      });
-    });
-
-    it('performs sum of min IEEE754 using getAggregationFromServer', () => {
-      const testDocs = {
-        a: {
-          author: 'authorA',
-          title: 'titleA',
-          pages: 100,
-          year: 1980,
-          rating: Number.MIN_VALUE
-        }
-      };
-      return withTestCollection(persistence, testDocs, async coll => {
-        const snapshot = await getAggregateFromServer(coll, {
-          totalRating: sum('rating')
-        });
-        expect(snapshot.data().totalRating).to.equal(Number.MIN_VALUE);
-      });
-    });
-
-    it('performs average of ints that results in an int using getAggregationFromServer', () => {
-      const testDocs = {
-        a: {
-          author: 'authorA',
-          title: 'titleA',
-          pages: 100,
-          year: 1980,
-          rating: 10
-        },
-        b: {
-          author: 'authorB',
-          title: 'titleB',
-          pages: 50,
-          year: 2020,
-          rating: 5
-        },
-        c: {
-          author: 'authorB',
-          title: 'titleB',
-          pages: 150,
-          year: 2021,
-          rating: 0
-        }
-      };
-      return withTestCollection(persistence, testDocs, async coll => {
-        const snapshot = await getAggregateFromServer(coll, {
-          averageRating: average('rating')
-        });
-        expect(snapshot.data().averageRating).to.equal(5);
-      });
-    });
-
-    it('performs average of floats that results in an int using getAggregationFromServer', () => {
-      const testDocs = {
-        a: {
-          author: 'authorA',
-          title: 'titleA',
-          pages: 100,
-          year: 1980,
-          rating: 10.5
-        },
-        b: {
-          author: 'authorB',
-          title: 'titleB',
-          pages: 50,
-          year: 2020,
-          rating: 9.5
-        }
-      };
-      return withTestCollection(persistence, testDocs, async coll => {
-        const snapshot = await getAggregateFromServer(coll, {
-          averageRating: average('rating')
-        });
-        expect(snapshot.data().averageRating).to.equal(10);
-      });
-    });
-
-    it('performs average of floats and ints that results in an int using getAggregationFromServer', () => {
-      const testDocs = {
-        a: {
-          author: 'authorA',
-          title: 'titleA',
-          pages: 100,
-          year: 1980,
-          rating: 10
-        },
-        b: {
-          author: 'authorB',
-          title: 'titleB',
-          pages: 50,
-          year: 2020,
-          rating: 9.5
-        },
-        c: {
-          author: 'authorC',
-          title: 'titleC',
-          pages: 150,
-          year: 2021,
-          rating: 10.5
-        }
-      };
-      return withTestCollection(persistence, testDocs, async coll => {
-        const snapshot = await getAggregateFromServer(coll, {
-          averageRating: average('rating')
-        });
-        expect(snapshot.data().averageRating).to.equal(10);
-      });
-    });
-
-    it('performs average of float that results in float using getAggregationFromServer', () => {
-      const testDocs = {
-        a: {
-          author: 'authorA',
-          title: 'titleA',
-          pages: 100,
-          year: 1980,
-          rating: 5.5
-        },
-        b: {
-          author: 'authorB',
-          title: 'titleB',
-          pages: 50,
-          year: 2020,
-          rating: 4.5
-        },
-        c: {
-          author: 'authorB',
-          title: 'titleB',
-          pages: 150,
-          year: 2021,
-          rating: 3.5
-        }
-      };
-      return withTestCollection(persistence, testDocs, async coll => {
-        const snapshot = await getAggregateFromServer(coll, {
-          averageRating: average('rating')
-        });
-        expect(snapshot.data().averageRating).to.equal(4.5);
-      });
-    });
-
-    it('performs average of floats and ints that results in a float using getAggregationFromServer', () => {
-      const testDocs = {
-        a: {
-          author: 'authorA',
-          title: 'titleA',
-          pages: 100,
-          year: 1980,
-          rating: 8.6
-        },
-        b: {
-          author: 'authorB',
-          title: 'titleB',
-          pages: 50,
-          year: 2020,
-          rating: 9
-        },
-        c: {
-          author: 'authorC',
-          title: 'titleC',
-          pages: 150,
-          year: 2021,
-          rating: 10
-        }
-      };
-      return withTestCollection(persistence, testDocs, async coll => {
-        const snapshot = await getAggregateFromServer(coll, {
-          averageRating: average('rating')
-        });
-        expect(snapshot.data().averageRating).to.be.approximately(
-          9.2,
-          0.0000001
-        );
-      });
-    });
-
-    it('performs average of ints that results in a float using getAggregationFromServer', () => {
-      const testDocs = {
-        a: {
-          author: 'authorA',
-          title: 'titleA',
-          pages: 100,
-          year: 1980,
-          rating: 10
-        },
-        b: {
-          author: 'authorB',
-          title: 'titleB',
-          pages: 50,
-          year: 2020,
-          rating: 9
-        }
-      };
-      return withTestCollection(persistence, testDocs, async coll => {
-        const snapshot = await getAggregateFromServer(coll, {
-          averageRating: average('rating')
-        });
-        expect(snapshot.data().averageRating).to.equal(9.5);
-      });
-    });
-
-    it('performs average causing underflow using getAggregationFromServer', () => {
-      const testDocs = {
-        a: {
-          author: 'authorA',
-          title: 'titleA',
-          pages: 100,
-          year: 1980,
-          rating: Number.MIN_VALUE
-        },
-        b: {
-          author: 'authorB',
-          title: 'titleB',
-          pages: 50,
-          year: 2020,
-          rating: 0
-        }
-      };
-      return withTestCollection(persistence, testDocs, async coll => {
-        const snapshot = await getAggregateFromServer(coll, {
-          averageRating: average('rating')
-        });
-        expect(snapshot.data().averageRating).to.equal(0);
-      });
-    });
-
-    it('performs average of min IEEE754 using getAggregationFromServer', () => {
-      const testDocs = {
-        a: {
-          author: 'authorA',
-          title: 'titleA',
-          pages: 100,
-          year: 1980,
-          rating: Number.MIN_VALUE
-        }
-      };
-      return withTestCollection(persistence, testDocs, async coll => {
-        const snapshot = await getAggregateFromServer(coll, {
-          averageRating: average('rating')
-        });
-        expect(snapshot.data().averageRating).to.equal(Number.MIN_VALUE);
-      });
-    });
-
-    it('performs average that overflows IEEE754 during accumulation using getAggregationFromServer', () => {
-      const testDocs = {
-        a: {
-          author: 'authorA',
-          title: 'titleA',
-          pages: 100,
-          year: 1980,
-          rating: Number.MAX_VALUE
-        },
-        b: {
-          author: 'authorB',
-          title: 'titleB',
-          pages: 50,
-          year: 2020,
-          rating: Number.MAX_VALUE
-        }
-      };
-      return withTestCollection(persistence, testDocs, async coll => {
-        const snapshot = await getAggregateFromServer(coll, {
-          averageRating: average('rating')
-        });
-        expect(snapshot.data().averageRating).to.equal(
-          Number.POSITIVE_INFINITY
-        );
-      });
-    });
-
-    it('performs average that includes NaN using getAggregationFromServer', () => {
-      const testDocs = {
-        a: {
-          author: 'authorA',
-          title: 'titleA',
-          pages: 100,
-          year: 1980,
-          rating: 5
-        },
-        b: {
-          author: 'authorB',
-          title: 'titleB',
-          pages: 50,
-          year: 2020,
-          rating: 4
-        },
-        c: {
-          author: 'authorC',
-          title: 'titleC',
-          pages: 100,
-          year: 1980,
-          rating: Number.NaN
-        },
-        d: {
-          author: 'authorD',
-          title: 'titleD',
-          pages: 50,
-          year: 2020,
-          rating: 0
-        }
-      };
-      return withTestCollection(persistence, testDocs, async coll => {
-        const snapshot = await getAggregateFromServer(coll, {
-          averageRating: average('rating')
-        });
-        expect(snapshot.data().averageRating).to.be.NaN;
-      });
-    });
-
-    it('performs average over a result set of zero documents using getAggregationFromServer', () => {
-      const testDocs = {
-        a: {
-          author: 'authorA',
-          title: 'titleA',
-          pages: 100,
-          year: 1980,
-          rating: 5
-        },
-        b: {
-          author: 'authorB',
-          title: 'titleB',
-          pages: 50,
-          year: 2020,
-          rating: 4
-        },
-        c: {
-          author: 'authorC',
-          title: 'titleC',
-          pages: 100,
-          year: 1980,
-          rating: 3
-        },
-        d: {
-          author: 'authorD',
-          title: 'titleD',
-          pages: 50,
-          year: 2020,
-          rating: 0
-        }
-      };
-      return withTestCollection(persistence, testDocs, async coll => {
-        const snapshot = await getAggregateFromServer(
-          query(coll, where('pages', '>', 200)),
-          {
-            averageRating: average('rating')
-          }
-        );
-        expect(snapshot.data().averageRating).to.be.null;
-      });
-    });
-
-    it('performs average only on numeric fields using getAggregationFromServer', () => {
-      const testDocs = {
-        a: {
-          author: 'authorA',
-          title: 'titleA',
-          pages: 100,
-          year: 1980,
-          rating: 5
-        },
-        b: {
-          author: 'authorB',
-          title: 'titleB',
-          pages: 50,
-          year: 2020,
-          rating: 4
-        },
-        c: {
-          author: 'authorC',
-          title: 'titleC',
-          pages: 100,
-          year: 1980,
-          rating: '3'
-        },
-        d: {
-          author: 'authorD',
-          title: 'titleD',
-          pages: 50,
-          year: 2020,
-          rating: 6
-        }
-      };
-      return withTestCollection(persistence, testDocs, async coll => {
-        const snapshot = await getAggregateFromServer(coll, {
           averageRating: average('rating'),
+          totalPages: sum('pages'),
+          averagePages: average('pages'),
           countOfDocs: count()
-        });
-        expect(snapshot.data().averageRating).to.equal(5);
-        expect(snapshot.data().countOfDocs).to.equal(4);
-      });
+        }
+      );
+      expect(snapshot.data().totalRating).to.equal(8);
+      expect(snapshot.data().averageRating).to.equal(4);
+      expect(snapshot.data().totalPages).to.equal(200);
+      expect(snapshot.data().averagePages).to.equal(100);
+      expect(snapshot.data().countOfDocs).to.equal(2);
     });
-  }
-);
+  });
+
+  it('performs aggregates when using `array-contains-any` operator getAggregationFromServer', () => {
+    const testDocs = {
+      a: {
+        author: 'authorA',
+        title: 'titleA',
+        pages: 100,
+        year: 1980,
+        rating: [5, 1000]
+      },
+      b: {
+        author: 'authorB',
+        title: 'titleB',
+        pages: 50,
+        year: 2020,
+        rating: [4]
+      },
+      c: {
+        author: 'authorC',
+        title: 'titleC',
+        pages: 100,
+        year: 1980,
+        rating: [2222, 3]
+      },
+      d: {
+        author: 'authorD',
+        title: 'titleD',
+        pages: 50,
+        year: 2020,
+        rating: [0]
+      }
+    };
+    return withTestCollection(persistence, testDocs, async coll => {
+      const snapshot = await getAggregateFromServer(
+        query(coll, where('rating', 'array-contains-any', [5, 3])),
+        {
+          totalRating: sum('rating'),
+          averageRating: average('rating'),
+          totalPages: sum('pages'),
+          averagePages: average('pages'),
+          countOfDocs: count()
+        }
+      );
+      expect(snapshot.data().totalRating).to.equal(0);
+      expect(snapshot.data().averageRating).to.be.null;
+      expect(snapshot.data().totalPages).to.equal(200);
+      expect(snapshot.data().averagePages).to.equal(100);
+      expect(snapshot.data().countOfDocs).to.equal(2);
+    });
+  });
+
+  it('performs aggregations on nested map values using getAggregationFromServer', () => {
+    const testDocs = {
+      a: {
+        author: 'authorA',
+        title: 'titleA',
+        metadata: { pages: 100, rating: { critic: 2, user: 5 } }
+      },
+      b: {
+        author: 'authorB',
+        title: 'titleB',
+        metadata: { pages: 50, rating: { critic: 4, user: 4 } }
+      }
+    };
+    return withTestCollection(persistence, testDocs, async coll => {
+      const snapshot = await getAggregateFromServer(coll, {
+        totalPages: sum('metadata.pages'),
+        averagePages: average('metadata.pages'),
+        averageCriticRating: average('metadata.rating.critic'),
+        totalUserRating: sum('metadata.rating.user'),
+        count: count()
+      });
+      expect(snapshot.data().totalPages).to.equal(150);
+      expect(snapshot.data().averagePages).to.equal(75);
+      expect(snapshot.data().averageCriticRating).to.equal(3);
+      expect(snapshot.data().totalUserRating).to.equal(9);
+      expect(snapshot.data().count).to.equal(2);
+    });
+  });
+
+  it('performs sum that results in float using getAggregationFromServer', () => {
+    const testDocs = {
+      a: {
+        author: 'authorA',
+        title: 'titleA',
+        pages: 100,
+        year: 1980,
+        rating: 5
+      },
+      b: {
+        author: 'authorB',
+        title: 'titleB',
+        pages: 50,
+        year: 2020,
+        rating: 4.5
+      },
+      c: {
+        author: 'authorB',
+        title: 'titleB',
+        pages: 150,
+        year: 2021,
+        rating: 3
+      }
+    };
+    return withTestCollection(persistence, testDocs, async coll => {
+      const snapshot = await getAggregateFromServer(coll, {
+        totalRating: sum('rating')
+      });
+      expect(snapshot.data().totalRating).to.equal(12.5);
+    });
+  });
+
+  it('performs sum of ints and floats that results in an int using getAggregationFromServer', () => {
+    const testDocs = {
+      a: {
+        author: 'authorA',
+        title: 'titleA',
+        pages: 100,
+        year: 1980,
+        rating: 5
+      },
+      b: {
+        author: 'authorB',
+        title: 'titleB',
+        pages: 50,
+        year: 2020,
+        rating: 4.5
+      },
+      c: {
+        author: 'authorB',
+        title: 'titleB',
+        pages: 150,
+        year: 2021,
+        rating: 3.5
+      }
+    };
+    return withTestCollection(persistence, testDocs, async coll => {
+      const snapshot = await getAggregateFromServer(coll, {
+        totalRating: sum('rating')
+      });
+      expect(snapshot.data().totalRating).to.equal(13);
+    });
+  });
+
+  it('performs sum that overflows max int using getAggregationFromServer', () => {
+    // A large value that will be represented as a Long on the server, but
+    // doubling (2x) this value must overflow Long and force the result to be
+    // represented as a Double type on the server.
+    const maxLong = Math.pow(2, 63) - 1;
+
+    const testDocs = {
+      a: {
+        author: 'authorA',
+        title: 'titleA',
+        pages: 100,
+        year: 1980,
+        rating: maxLong
+      },
+      b: {
+        author: 'authorB',
+        title: 'titleB',
+        pages: 50,
+        year: 2020,
+        rating: maxLong
+      }
+    };
+    return withTestCollection(persistence, testDocs, async coll => {
+      const snapshot = await getAggregateFromServer(coll, {
+        totalRating: sum('rating')
+      });
+      expect(snapshot.data().totalRating).to.equal(maxLong + maxLong);
+    });
+  });
+
+  it('performs sum that can overflow integer values during accumulation using getAggregationFromServer', () => {
+    const testDocs = {
+      a: {
+        author: 'authorA',
+        title: 'titleA',
+        pages: 100,
+        year: 1980,
+        rating: Number.MAX_SAFE_INTEGER
+      },
+      b: {
+        author: 'authorB',
+        title: 'titleB',
+        pages: 50,
+        year: 2020,
+        rating: 1
+      },
+      c: {
+        author: 'authorC',
+        title: 'titleC',
+        pages: 50,
+        year: 2020,
+        rating: -101
+      }
+    };
+    return withTestCollection(persistence, testDocs, async coll => {
+      const snapshot = await getAggregateFromServer(coll, {
+        totalRating: sum('rating')
+      });
+      expect(snapshot.data().totalRating).to.equal(
+        Number.MAX_SAFE_INTEGER - 100
+      );
+    });
+  });
+
+  it('performs sum that is negative using getAggregationFromServer', () => {
+    const testDocs = {
+      a: {
+        author: 'authorA',
+        title: 'titleA',
+        pages: 100,
+        year: 1980,
+        rating: Number.MAX_SAFE_INTEGER
+      },
+      b: {
+        author: 'authorB',
+        title: 'titleB',
+        pages: 50,
+        year: 2020,
+        rating: Number.MIN_SAFE_INTEGER
+      },
+      c: {
+        author: 'authorC',
+        title: 'titleC',
+        pages: 50,
+        year: 2020,
+        rating: -101
+      },
+      d: {
+        author: 'authorD',
+        title: 'titleD',
+        pages: 50,
+        year: 2020,
+        rating: -10000
+      }
+    };
+    return withTestCollection(persistence, testDocs, async coll => {
+      const snapshot = await getAggregateFromServer(coll, {
+        totalRating: sum('rating')
+      });
+      expect(snapshot.data().totalRating).to.equal(-10101);
+    });
+  });
+
+  it('performs sum that is positive infinity using getAggregationFromServer', () => {
+    const testDocs = {
+      a: {
+        author: 'authorA',
+        title: 'titleA',
+        pages: 100,
+        year: 1980,
+        rating: Number.MAX_VALUE
+      },
+      b: {
+        author: 'authorB',
+        title: 'titleB',
+        pages: 50,
+        year: 2020,
+        rating: Number.MAX_VALUE
+      }
+    };
+    return withTestCollection(persistence, testDocs, async coll => {
+      const snapshot = await getAggregateFromServer(coll, {
+        totalRating: sum('rating')
+      });
+      expect(snapshot.data().totalRating).to.equal(Number.POSITIVE_INFINITY);
+    });
+  });
+
+  it('performs sum that is positive infinity using getAggregationFromServer v2', () => {
+    const testDocs = {
+      a: {
+        author: 'authorA',
+        title: 'titleA',
+        pages: 100,
+        year: 1980,
+        rating: Number.MAX_VALUE
+      },
+      b: {
+        author: 'authorB',
+        title: 'titleB',
+        pages: 50,
+        year: 2020,
+        rating: 1e293
+      }
+    };
+    return withTestCollection(persistence, testDocs, async coll => {
+      const snapshot = await getAggregateFromServer(coll, {
+        totalRating: sum('rating')
+      });
+      expect(snapshot.data().totalRating).to.equal(Number.POSITIVE_INFINITY);
+    });
+  });
+
+  it('performs sum that is negative infinity using getAggregationFromServer', () => {
+    const testDocs = {
+      a: {
+        author: 'authorA',
+        title: 'titleA',
+        pages: 100,
+        year: 1980,
+        rating: -Number.MAX_VALUE
+      },
+      b: {
+        author: 'authorB',
+        title: 'titleB',
+        pages: 50,
+        year: 2020,
+        rating: -Number.MAX_VALUE
+      }
+    };
+    return withTestCollection(persistence, testDocs, async coll => {
+      const snapshot = await getAggregateFromServer(coll, {
+        totalRating: sum('rating')
+      });
+      expect(snapshot.data().totalRating).to.equal(Number.NEGATIVE_INFINITY);
+    });
+  });
+
+  it('performs sum that is valid but could overflow during aggregation using getAggregationFromServer', () => {
+    const testDocs = {
+      a: {
+        author: 'authorA',
+        title: 'titleA',
+        pages: 100,
+        year: 1980,
+        rating: Number.MAX_VALUE
+      },
+      b: {
+        author: 'authorB',
+        title: 'titleB',
+        pages: 50,
+        year: 2020,
+        rating: Number.MAX_VALUE
+      },
+      c: {
+        author: 'authorC',
+        title: 'titleC',
+        pages: 100,
+        year: 1980,
+        rating: -Number.MAX_VALUE
+      },
+      d: {
+        author: 'authorD',
+        title: 'titleD',
+        pages: 50,
+        year: 2020,
+        rating: -Number.MAX_VALUE
+      },
+      e: {
+        author: 'authorE',
+        title: 'titleE',
+        pages: 100,
+        year: 1980,
+        rating: Number.MAX_VALUE
+      },
+      f: {
+        author: 'authorF',
+        title: 'titleF',
+        pages: 50,
+        year: 2020,
+        rating: -Number.MAX_VALUE
+      },
+      g: {
+        author: 'authorG',
+        title: 'titleG',
+        pages: 100,
+        year: 1980,
+        rating: -Number.MAX_VALUE
+      },
+      h: {
+        author: 'authorH',
+        title: 'titleDH',
+        pages: 50,
+        year: 2020,
+        rating: Number.MAX_VALUE
+      }
+    };
+    return withTestCollection(persistence, testDocs, async coll => {
+      const snapshot = await getAggregateFromServer(coll, {
+        totalRating: sum('rating')
+      });
+      expect(snapshot.data().totalRating).to.equal(0);
+    });
+  });
+
+  it('performs sum that includes NaN using getAggregationFromServer', () => {
+    const testDocs = {
+      a: {
+        author: 'authorA',
+        title: 'titleA',
+        pages: 100,
+        year: 1980,
+        rating: 5
+      },
+      b: {
+        author: 'authorB',
+        title: 'titleB',
+        pages: 50,
+        year: 2020,
+        rating: 4
+      },
+      c: {
+        author: 'authorC',
+        title: 'titleC',
+        pages: 100,
+        year: 1980,
+        rating: Number.NaN
+      },
+      d: {
+        author: 'authorD',
+        title: 'titleD',
+        pages: 50,
+        year: 2020,
+        rating: 0
+      }
+    };
+    return withTestCollection(persistence, testDocs, async coll => {
+      const snapshot = await getAggregateFromServer(coll, {
+        totalRating: sum('rating')
+      });
+      expect(snapshot.data().totalRating).to.be.NaN;
+    });
+  });
+
+  it('performs sum over a result set of zero documents using getAggregationFromServer', () => {
+    const testDocs = {
+      a: {
+        author: 'authorA',
+        title: 'titleA',
+        pages: 100,
+        year: 1980,
+        rating: 5
+      },
+      b: {
+        author: 'authorB',
+        title: 'titleB',
+        pages: 50,
+        year: 2020,
+        rating: 4
+      },
+      c: {
+        author: 'authorC',
+        title: 'titleC',
+        pages: 100,
+        year: 1980,
+        rating: 3
+      },
+      d: {
+        author: 'authorD',
+        title: 'titleD',
+        pages: 50,
+        year: 2020,
+        rating: 0
+      }
+    };
+    return withTestCollection(persistence, testDocs, async coll => {
+      const snapshot = await getAggregateFromServer(
+        query(coll, where('pages', '>', 200)),
+        {
+          totalRating: sum('rating')
+        }
+      );
+      expect(snapshot.data().totalRating).to.equal(0);
+    });
+  });
+
+  it('performs sum only on numeric fields using getAggregationFromServer', () => {
+    const testDocs = {
+      a: {
+        author: 'authorA',
+        title: 'titleA',
+        pages: 100,
+        year: 1980,
+        rating: 5
+      },
+      b: {
+        author: 'authorB',
+        title: 'titleB',
+        pages: 50,
+        year: 2020,
+        rating: 4
+      },
+      c: {
+        author: 'authorC',
+        title: 'titleC',
+        pages: 100,
+        year: 1980,
+        rating: '3'
+      },
+      d: {
+        author: 'authorD',
+        title: 'titleD',
+        pages: 50,
+        year: 2020,
+        rating: 1
+      }
+    };
+    return withTestCollection(persistence, testDocs, async coll => {
+      const snapshot = await getAggregateFromServer(coll, {
+        totalRating: sum('rating'),
+        countOfDocs: count()
+      });
+      expect(snapshot.data().totalRating).to.equal(10);
+      expect(snapshot.data().countOfDocs).to.equal(4);
+    });
+  });
+
+  it('performs sum of min IEEE754 using getAggregationFromServer', () => {
+    const testDocs = {
+      a: {
+        author: 'authorA',
+        title: 'titleA',
+        pages: 100,
+        year: 1980,
+        rating: Number.MIN_VALUE
+      }
+    };
+    return withTestCollection(persistence, testDocs, async coll => {
+      const snapshot = await getAggregateFromServer(coll, {
+        totalRating: sum('rating')
+      });
+      expect(snapshot.data().totalRating).to.equal(Number.MIN_VALUE);
+    });
+  });
+
+  it('performs average of ints that results in an int using getAggregationFromServer', () => {
+    const testDocs = {
+      a: {
+        author: 'authorA',
+        title: 'titleA',
+        pages: 100,
+        year: 1980,
+        rating: 10
+      },
+      b: {
+        author: 'authorB',
+        title: 'titleB',
+        pages: 50,
+        year: 2020,
+        rating: 5
+      },
+      c: {
+        author: 'authorB',
+        title: 'titleB',
+        pages: 150,
+        year: 2021,
+        rating: 0
+      }
+    };
+    return withTestCollection(persistence, testDocs, async coll => {
+      const snapshot = await getAggregateFromServer(coll, {
+        averageRating: average('rating')
+      });
+      expect(snapshot.data().averageRating).to.equal(5);
+    });
+  });
+
+  it('performs average of floats that results in an int using getAggregationFromServer', () => {
+    const testDocs = {
+      a: {
+        author: 'authorA',
+        title: 'titleA',
+        pages: 100,
+        year: 1980,
+        rating: 10.5
+      },
+      b: {
+        author: 'authorB',
+        title: 'titleB',
+        pages: 50,
+        year: 2020,
+        rating: 9.5
+      }
+    };
+    return withTestCollection(persistence, testDocs, async coll => {
+      const snapshot = await getAggregateFromServer(coll, {
+        averageRating: average('rating')
+      });
+      expect(snapshot.data().averageRating).to.equal(10);
+    });
+  });
+
+  it('performs average of floats and ints that results in an int using getAggregationFromServer', () => {
+    const testDocs = {
+      a: {
+        author: 'authorA',
+        title: 'titleA',
+        pages: 100,
+        year: 1980,
+        rating: 10
+      },
+      b: {
+        author: 'authorB',
+        title: 'titleB',
+        pages: 50,
+        year: 2020,
+        rating: 9.5
+      },
+      c: {
+        author: 'authorC',
+        title: 'titleC',
+        pages: 150,
+        year: 2021,
+        rating: 10.5
+      }
+    };
+    return withTestCollection(persistence, testDocs, async coll => {
+      const snapshot = await getAggregateFromServer(coll, {
+        averageRating: average('rating')
+      });
+      expect(snapshot.data().averageRating).to.equal(10);
+    });
+  });
+
+  it('performs average of float that results in float using getAggregationFromServer', () => {
+    const testDocs = {
+      a: {
+        author: 'authorA',
+        title: 'titleA',
+        pages: 100,
+        year: 1980,
+        rating: 5.5
+      },
+      b: {
+        author: 'authorB',
+        title: 'titleB',
+        pages: 50,
+        year: 2020,
+        rating: 4.5
+      },
+      c: {
+        author: 'authorB',
+        title: 'titleB',
+        pages: 150,
+        year: 2021,
+        rating: 3.5
+      }
+    };
+    return withTestCollection(persistence, testDocs, async coll => {
+      const snapshot = await getAggregateFromServer(coll, {
+        averageRating: average('rating')
+      });
+      expect(snapshot.data().averageRating).to.equal(4.5);
+    });
+  });
+
+  it('performs average of floats and ints that results in a float using getAggregationFromServer', () => {
+    const testDocs = {
+      a: {
+        author: 'authorA',
+        title: 'titleA',
+        pages: 100,
+        year: 1980,
+        rating: 8.6
+      },
+      b: {
+        author: 'authorB',
+        title: 'titleB',
+        pages: 50,
+        year: 2020,
+        rating: 9
+      },
+      c: {
+        author: 'authorC',
+        title: 'titleC',
+        pages: 150,
+        year: 2021,
+        rating: 10
+      }
+    };
+    return withTestCollection(persistence, testDocs, async coll => {
+      const snapshot = await getAggregateFromServer(coll, {
+        averageRating: average('rating')
+      });
+      expect(snapshot.data().averageRating).to.be.approximately(9.2, 0.0000001);
+    });
+  });
+
+  it('performs average of ints that results in a float using getAggregationFromServer', () => {
+    const testDocs = {
+      a: {
+        author: 'authorA',
+        title: 'titleA',
+        pages: 100,
+        year: 1980,
+        rating: 10
+      },
+      b: {
+        author: 'authorB',
+        title: 'titleB',
+        pages: 50,
+        year: 2020,
+        rating: 9
+      }
+    };
+    return withTestCollection(persistence, testDocs, async coll => {
+      const snapshot = await getAggregateFromServer(coll, {
+        averageRating: average('rating')
+      });
+      expect(snapshot.data().averageRating).to.equal(9.5);
+    });
+  });
+
+  it('performs average causing underflow using getAggregationFromServer', () => {
+    const testDocs = {
+      a: {
+        author: 'authorA',
+        title: 'titleA',
+        pages: 100,
+        year: 1980,
+        rating: Number.MIN_VALUE
+      },
+      b: {
+        author: 'authorB',
+        title: 'titleB',
+        pages: 50,
+        year: 2020,
+        rating: 0
+      }
+    };
+    return withTestCollection(persistence, testDocs, async coll => {
+      const snapshot = await getAggregateFromServer(coll, {
+        averageRating: average('rating')
+      });
+      expect(snapshot.data().averageRating).to.equal(0);
+    });
+  });
+
+  it('performs average of min IEEE754 using getAggregationFromServer', () => {
+    const testDocs = {
+      a: {
+        author: 'authorA',
+        title: 'titleA',
+        pages: 100,
+        year: 1980,
+        rating: Number.MIN_VALUE
+      }
+    };
+    return withTestCollection(persistence, testDocs, async coll => {
+      const snapshot = await getAggregateFromServer(coll, {
+        averageRating: average('rating')
+      });
+      expect(snapshot.data().averageRating).to.equal(Number.MIN_VALUE);
+    });
+  });
+
+  it('performs average that overflows IEEE754 during accumulation using getAggregationFromServer', () => {
+    const testDocs = {
+      a: {
+        author: 'authorA',
+        title: 'titleA',
+        pages: 100,
+        year: 1980,
+        rating: Number.MAX_VALUE
+      },
+      b: {
+        author: 'authorB',
+        title: 'titleB',
+        pages: 50,
+        year: 2020,
+        rating: Number.MAX_VALUE
+      }
+    };
+    return withTestCollection(persistence, testDocs, async coll => {
+      const snapshot = await getAggregateFromServer(coll, {
+        averageRating: average('rating')
+      });
+      expect(snapshot.data().averageRating).to.equal(Number.POSITIVE_INFINITY);
+    });
+  });
+
+  it('performs average that includes NaN using getAggregationFromServer', () => {
+    const testDocs = {
+      a: {
+        author: 'authorA',
+        title: 'titleA',
+        pages: 100,
+        year: 1980,
+        rating: 5
+      },
+      b: {
+        author: 'authorB',
+        title: 'titleB',
+        pages: 50,
+        year: 2020,
+        rating: 4
+      },
+      c: {
+        author: 'authorC',
+        title: 'titleC',
+        pages: 100,
+        year: 1980,
+        rating: Number.NaN
+      },
+      d: {
+        author: 'authorD',
+        title: 'titleD',
+        pages: 50,
+        year: 2020,
+        rating: 0
+      }
+    };
+    return withTestCollection(persistence, testDocs, async coll => {
+      const snapshot = await getAggregateFromServer(coll, {
+        averageRating: average('rating')
+      });
+      expect(snapshot.data().averageRating).to.be.NaN;
+    });
+  });
+
+  it('performs average over a result set of zero documents using getAggregationFromServer', () => {
+    const testDocs = {
+      a: {
+        author: 'authorA',
+        title: 'titleA',
+        pages: 100,
+        year: 1980,
+        rating: 5
+      },
+      b: {
+        author: 'authorB',
+        title: 'titleB',
+        pages: 50,
+        year: 2020,
+        rating: 4
+      },
+      c: {
+        author: 'authorC',
+        title: 'titleC',
+        pages: 100,
+        year: 1980,
+        rating: 3
+      },
+      d: {
+        author: 'authorD',
+        title: 'titleD',
+        pages: 50,
+        year: 2020,
+        rating: 0
+      }
+    };
+    return withTestCollection(persistence, testDocs, async coll => {
+      const snapshot = await getAggregateFromServer(
+        query(coll, where('pages', '>', 200)),
+        {
+          averageRating: average('rating')
+        }
+      );
+      expect(snapshot.data().averageRating).to.be.null;
+    });
+  });
+
+  it('performs average only on numeric fields using getAggregationFromServer', () => {
+    const testDocs = {
+      a: {
+        author: 'authorA',
+        title: 'titleA',
+        pages: 100,
+        year: 1980,
+        rating: 5
+      },
+      b: {
+        author: 'authorB',
+        title: 'titleB',
+        pages: 50,
+        year: 2020,
+        rating: 4
+      },
+      c: {
+        author: 'authorC',
+        title: 'titleC',
+        pages: 100,
+        year: 1980,
+        rating: '3'
+      },
+      d: {
+        author: 'authorD',
+        title: 'titleD',
+        pages: 50,
+        year: 2020,
+        rating: 6
+      }
+    };
+    return withTestCollection(persistence, testDocs, async coll => {
+      const snapshot = await getAggregateFromServer(coll, {
+        averageRating: average('rating'),
+        countOfDocs: count()
+      });
+      expect(snapshot.data().averageRating).to.equal(5);
+      expect(snapshot.data().countOfDocs).to.equal(4);
+    });
+  });
+});

--- a/packages/firestore/test/integration/api/array_transforms.test.ts
+++ b/packages/firestore/test/integration/api/array_transforms.test.ts
@@ -42,7 +42,7 @@ addEqualityMatcher();
  * together, etc.) and so these tests mostly focus on the array transform
  * semantics.
  */
-apiDescribe('Array Transforms:', (persistence: boolean) => {
+apiDescribe('Array Transforms:', persistence => {
   // A document reference to read and write to.
   let docRef: DocumentReference;
 
@@ -164,76 +164,79 @@ apiDescribe('Array Transforms:', (persistence: boolean) => {
    * being enabled so documents remain in the cache after the write.
    */
   // eslint-disable-next-line no-restricted-properties
-  (persistence ? describe : describe.skip)('Server Application: ', () => {
-    it('set() with no cached base doc', async () => {
-      await withTestDoc(persistence, async docRef => {
-        await setDoc(docRef, { array: arrayUnion(1, 2) });
-        const snapshot = await getDocFromCache(docRef);
-        expect(snapshot.data()).to.deep.equal({ array: [1, 2] });
-      });
-    });
-
-    it('update() with no cached base doc', async () => {
-      let path: string | null = null;
-      // Write an initial document in an isolated Firestore instance so it's not
-      // stored in our cache
-      await withTestDoc(persistence, async docRef => {
-        path = docRef.path;
-        await setDoc(docRef, { array: [42] });
+  (persistence ? describe : describe.skip)(
+    'Server Application: ',
+    () => {
+      it('set() with no cached base doc', async () => {
+        await withTestDoc(persistence, async docRef => {
+          await setDoc(docRef, { array: arrayUnion(1, 2) });
+          const snapshot = await getDocFromCache(docRef);
+          expect(snapshot.data()).to.deep.equal({ array: [1, 2] });
+        });
       });
 
-      await withTestDb(persistence, async db => {
-        const docRef = doc(db, path!);
-        await updateDoc(docRef, { array: arrayUnion(1, 2) });
+      it('update() with no cached base doc', async () => {
+        let path: string | null = null;
+        // Write an initial document in an isolated Firestore instance so it's not
+        // stored in our cache
+        await withTestDoc(persistence, async docRef => {
+          path = docRef.path;
+          await setDoc(docRef, { array: [42] });
+        });
 
-        // Nothing should be cached since it was an update and we had no base
-        // doc.
-        let errCaught = false;
-        try {
-          await getDocFromCache(docRef);
-        } catch (err) {
-          expect((err as FirestoreError).code).to.equal('unavailable');
-          errCaught = true;
-        }
-        expect(errCaught).to.be.true;
+        await withTestDb(persistence, async db => {
+          const docRef = doc(db, path!);
+          await updateDoc(docRef, { array: arrayUnion(1, 2) });
+
+          // Nothing should be cached since it was an update and we had no base
+          // doc.
+          let errCaught = false;
+          try {
+            await getDocFromCache(docRef);
+          } catch (err) {
+            expect((err as FirestoreError).code).to.equal('unavailable');
+            errCaught = true;
+          }
+          expect(errCaught).to.be.true;
+        });
       });
-    });
 
-    it('set(..., {merge}) with no cached based doc', async () => {
-      let path: string | null = null;
-      // Write an initial document in an isolated Firestore instance so it's not
-      // stored in our cache
-      await withTestDoc(persistence, async docRef => {
-        path = docRef.path;
-        await setDoc(docRef, { array: [42] });
+      it('set(..., {merge}) with no cached based doc', async () => {
+        let path: string | null = null;
+        // Write an initial document in an isolated Firestore instance so it's not
+        // stored in our cache
+        await withTestDoc(persistence, async docRef => {
+          path = docRef.path;
+          await setDoc(docRef, { array: [42] });
+        });
+
+        await withTestDb(persistence, async db => {
+          const docRef = doc(db, path!);
+          await setDoc(docRef, { array: arrayUnion(1, 2) }, { merge: true });
+
+          // Document will be cached but we'll be missing 42.
+          const snapshot = await getDocFromCache(docRef);
+          expect(snapshot.data()).to.deep.equal({ array: [1, 2] });
+        });
       });
 
-      await withTestDb(persistence, async db => {
-        const docRef = doc(db, path!);
-        await setDoc(docRef, { array: arrayUnion(1, 2) }, { merge: true });
-
-        // Document will be cached but we'll be missing 42.
-        const snapshot = await getDocFromCache(docRef);
-        expect(snapshot.data()).to.deep.equal({ array: [1, 2] });
+      it('update() with cached base doc using arrayUnion()', async () => {
+        await withTestDoc(persistence, async docRef => {
+          await setDoc(docRef, { array: [42] });
+          await updateDoc(docRef, { array: arrayUnion(1, 2) });
+          const snapshot = await getDocFromCache(docRef);
+          expect(snapshot.data()).to.deep.equal({ array: [42, 1, 2] });
+        });
       });
-    });
 
-    it('update() with cached base doc using arrayUnion()', async () => {
-      await withTestDoc(persistence, async docRef => {
-        await setDoc(docRef, { array: [42] });
-        await updateDoc(docRef, { array: arrayUnion(1, 2) });
-        const snapshot = await getDocFromCache(docRef);
-        expect(snapshot.data()).to.deep.equal({ array: [42, 1, 2] });
+      it('update() with cached base doc using arrayRemove()', async () => {
+        await withTestDoc(persistence, async docRef => {
+          await setDoc(docRef, { array: [42, 1, 2] });
+          await updateDoc(docRef, { array: arrayRemove(1, 2) });
+          const snapshot = await getDocFromCache(docRef);
+          expect(snapshot.data()).to.deep.equal({ array: [42] });
+        });
       });
-    });
-
-    it('update() with cached base doc using arrayRemove()', async () => {
-      await withTestDoc(persistence, async docRef => {
-        await setDoc(docRef, { array: [42, 1, 2] });
-        await updateDoc(docRef, { array: arrayRemove(1, 2) });
-        const snapshot = await getDocFromCache(docRef);
-        expect(snapshot.data()).to.deep.equal({ array: [42] });
-      });
-    });
-  });
+    }
+  );
 });

--- a/packages/firestore/test/integration/api/array_transforms.test.ts
+++ b/packages/firestore/test/integration/api/array_transforms.test.ts
@@ -164,79 +164,76 @@ apiDescribe('Array Transforms:', persistence => {
    * being enabled so documents remain in the cache after the write.
    */
   // eslint-disable-next-line no-restricted-properties
-  (persistence ? describe : describe.skip)(
-    'Server Application: ',
-    () => {
-      it('set() with no cached base doc', async () => {
-        await withTestDoc(persistence, async docRef => {
-          await setDoc(docRef, { array: arrayUnion(1, 2) });
-          const snapshot = await getDocFromCache(docRef);
-          expect(snapshot.data()).to.deep.equal({ array: [1, 2] });
-        });
+  (persistence ? describe : describe.skip)('Server Application: ', () => {
+    it('set() with no cached base doc', async () => {
+      await withTestDoc(persistence, async docRef => {
+        await setDoc(docRef, { array: arrayUnion(1, 2) });
+        const snapshot = await getDocFromCache(docRef);
+        expect(snapshot.data()).to.deep.equal({ array: [1, 2] });
+      });
+    });
+
+    it('update() with no cached base doc', async () => {
+      let path: string | null = null;
+      // Write an initial document in an isolated Firestore instance so it's not
+      // stored in our cache
+      await withTestDoc(persistence, async docRef => {
+        path = docRef.path;
+        await setDoc(docRef, { array: [42] });
       });
 
-      it('update() with no cached base doc', async () => {
-        let path: string | null = null;
-        // Write an initial document in an isolated Firestore instance so it's not
-        // stored in our cache
-        await withTestDoc(persistence, async docRef => {
-          path = docRef.path;
-          await setDoc(docRef, { array: [42] });
-        });
+      await withTestDb(persistence, async db => {
+        const docRef = doc(db, path!);
+        await updateDoc(docRef, { array: arrayUnion(1, 2) });
 
-        await withTestDb(persistence, async db => {
-          const docRef = doc(db, path!);
-          await updateDoc(docRef, { array: arrayUnion(1, 2) });
+        // Nothing should be cached since it was an update and we had no base
+        // doc.
+        let errCaught = false;
+        try {
+          await getDocFromCache(docRef);
+        } catch (err) {
+          expect((err as FirestoreError).code).to.equal('unavailable');
+          errCaught = true;
+        }
+        expect(errCaught).to.be.true;
+      });
+    });
 
-          // Nothing should be cached since it was an update and we had no base
-          // doc.
-          let errCaught = false;
-          try {
-            await getDocFromCache(docRef);
-          } catch (err) {
-            expect((err as FirestoreError).code).to.equal('unavailable');
-            errCaught = true;
-          }
-          expect(errCaught).to.be.true;
-        });
+    it('set(..., {merge}) with no cached based doc', async () => {
+      let path: string | null = null;
+      // Write an initial document in an isolated Firestore instance so it's not
+      // stored in our cache
+      await withTestDoc(persistence, async docRef => {
+        path = docRef.path;
+        await setDoc(docRef, { array: [42] });
       });
 
-      it('set(..., {merge}) with no cached based doc', async () => {
-        let path: string | null = null;
-        // Write an initial document in an isolated Firestore instance so it's not
-        // stored in our cache
-        await withTestDoc(persistence, async docRef => {
-          path = docRef.path;
-          await setDoc(docRef, { array: [42] });
-        });
+      await withTestDb(persistence, async db => {
+        const docRef = doc(db, path!);
+        await setDoc(docRef, { array: arrayUnion(1, 2) }, { merge: true });
 
-        await withTestDb(persistence, async db => {
-          const docRef = doc(db, path!);
-          await setDoc(docRef, { array: arrayUnion(1, 2) }, { merge: true });
-
-          // Document will be cached but we'll be missing 42.
-          const snapshot = await getDocFromCache(docRef);
-          expect(snapshot.data()).to.deep.equal({ array: [1, 2] });
-        });
+        // Document will be cached but we'll be missing 42.
+        const snapshot = await getDocFromCache(docRef);
+        expect(snapshot.data()).to.deep.equal({ array: [1, 2] });
       });
+    });
 
-      it('update() with cached base doc using arrayUnion()', async () => {
-        await withTestDoc(persistence, async docRef => {
-          await setDoc(docRef, { array: [42] });
-          await updateDoc(docRef, { array: arrayUnion(1, 2) });
-          const snapshot = await getDocFromCache(docRef);
-          expect(snapshot.data()).to.deep.equal({ array: [42, 1, 2] });
-        });
+    it('update() with cached base doc using arrayUnion()', async () => {
+      await withTestDoc(persistence, async docRef => {
+        await setDoc(docRef, { array: [42] });
+        await updateDoc(docRef, { array: arrayUnion(1, 2) });
+        const snapshot = await getDocFromCache(docRef);
+        expect(snapshot.data()).to.deep.equal({ array: [42, 1, 2] });
       });
+    });
 
-      it('update() with cached base doc using arrayRemove()', async () => {
-        await withTestDoc(persistence, async docRef => {
-          await setDoc(docRef, { array: [42, 1, 2] });
-          await updateDoc(docRef, { array: arrayRemove(1, 2) });
-          const snapshot = await getDocFromCache(docRef);
-          expect(snapshot.data()).to.deep.equal({ array: [42] });
-        });
+    it('update() with cached base doc using arrayRemove()', async () => {
+      await withTestDoc(persistence, async docRef => {
+        await setDoc(docRef, { array: [42, 1, 2] });
+        await updateDoc(docRef, { array: arrayRemove(1, 2) });
+        const snapshot = await getDocFromCache(docRef);
+        expect(snapshot.data()).to.deep.equal({ array: [42] });
       });
-    }
-  );
+    });
+  });
 });

--- a/packages/firestore/test/integration/api/batch_writes.test.ts
+++ b/packages/firestore/test/integration/api/batch_writes.test.ts
@@ -41,7 +41,7 @@ import {
   withTestDoc
 } from '../util/helpers';
 
-apiDescribe('Database batch writes', (persistence: boolean) => {
+apiDescribe('Database batch writes', persistence => {
   it('supports empty batches', () => {
     return withTestDb(persistence, db => {
       return writeBatch(db).commit();
@@ -329,7 +329,7 @@ apiDescribe('Database batch writes', (persistence: boolean) => {
 
   // PORTING NOTE: These tests are for FirestoreDataConverter support and apply
   // only to web.
-  apiDescribe('withConverter() support', (persistence: boolean) => {
+  apiDescribe('withConverter() support', persistence => {
     class Post {
       constructor(readonly title: string, readonly author: string) {}
       byline(): string {

--- a/packages/firestore/test/integration/api/bundle.test.ts
+++ b/packages/firestore/test/integration/api/bundle.test.ts
@@ -69,7 +69,7 @@ const BUNDLE_TEMPLATE = [
   '{"document":{"name":"projects/{0}/databases/(default)/documents/coll-1/b","createTime":{"seconds":1,"nanos":9},"updateTime":{"seconds":1,"nanos":9},"fields":{"k":{"stringValue":"b"},"bar":{"integerValue":2}}}}'
 ];
 
-apiDescribe('Bundles', (persistence: boolean) => {
+apiDescribe('Bundles', persistence => {
   function verifySnapEqualsTestDocs(snap: QuerySnapshot): void {
     expect(toDataArray(snap)).to.deep.equal([
       { k: 'a', bar: 1 },

--- a/packages/firestore/test/integration/api/cursor.test.ts
+++ b/packages/firestore/test/integration/api/cursor.test.ts
@@ -44,7 +44,7 @@ import {
   withTestDbs
 } from '../util/helpers';
 
-apiDescribe('Cursors', (persistence: boolean) => {
+apiDescribe('Cursors', persistence => {
   it('can page through items', () => {
     const testDocs = {
       a: { v: 'a' },

--- a/packages/firestore/test/integration/api/database.test.ts
+++ b/packages/firestore/test/integration/api/database.test.ts
@@ -81,7 +81,7 @@ import { DEFAULT_SETTINGS, DEFAULT_PROJECT_ID } from '../util/settings';
 
 use(chaiAsPromised);
 
-apiDescribe('Database', (persistence: boolean) => {
+apiDescribe('Database', persistence => {
   it('can set a document', () => {
     return withTestDoc(persistence, docRef => {
       return setDoc(docRef, {
@@ -638,7 +638,7 @@ apiDescribe('Database', (persistence: boolean) => {
     });
   });
 
-  apiDescribe('Queries are validated client-side', (persistence: boolean) => {
+  apiDescribe('Queries are validated client-side', persistence => {
     // NOTE: Failure cases are validated in validation_test.ts
 
     it('same inequality fields works', () => {
@@ -1340,7 +1340,7 @@ apiDescribe('Database', (persistence: boolean) => {
 
   // PORTING NOTE: These tests are for FirestoreDataConverter support and apply
   // only to web.
-  apiDescribe('withConverter() support', (persistence: boolean) => {
+  apiDescribe('withConverter() support', persistence => {
     class Post {
       constructor(
         readonly title: string,

--- a/packages/firestore/test/integration/api/fields.test.ts
+++ b/packages/firestore/test/integration/api/fields.test.ts
@@ -43,7 +43,7 @@ import { DEFAULT_SETTINGS } from '../util/settings';
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type AnyTestData = any;
 
-apiDescribe('Nested Fields', (persistence: boolean) => {
+apiDescribe('Nested Fields', persistence => {
   const testData = (n?: number): AnyTestData => {
     n = n || 1;
     return {
@@ -240,7 +240,7 @@ apiDescribe('Nested Fields', (persistence: boolean) => {
 // NOTE(mikelehen): I originally combined these tests with the above ones, but
 // Datastore currently prohibits having nested fields and fields with dots in
 // the same entity, so I'm separating them.
-apiDescribe('Fields with special characters', (persistence: boolean) => {
+apiDescribe('Fields with special characters', persistence => {
   const testData = (n?: number): AnyTestData => {
     n = n || 1;
     return {
@@ -340,7 +340,7 @@ apiDescribe('Fields with special characters', (persistence: boolean) => {
   });
 });
 
-apiDescribe('Timestamp Fields in snapshots', (persistence: boolean) => {
+apiDescribe('Timestamp Fields in snapshots', persistence => {
   // Figure out how to pass in the Timestamp type
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const testDataWithTimestamps = (ts: any): AnyTestData => {
@@ -379,7 +379,7 @@ apiDescribe('Timestamp Fields in snapshots', (persistence: boolean) => {
   });
 });
 
-apiDescribe('`undefined` properties', (persistence: boolean) => {
+apiDescribe('`undefined` properties', persistence => {
   const settings = { ...DEFAULT_SETTINGS };
   settings.ignoreUndefinedProperties = true;
 

--- a/packages/firestore/test/integration/api/get_options.test.ts
+++ b/packages/firestore/test/integration/api/get_options.test.ts
@@ -39,7 +39,7 @@ import {
   withEnsuredLruGcTestDb
 } from '../util/helpers';
 
-apiDescribe('GetOptions', (persistence: boolean) => {
+apiDescribe('GetOptions', persistence => {
   it('get document while online with default get options', () => {
     const initialData = { key: 'value' };
     return withTestDocAndInitialData(persistence, initialData, docRef => {

--- a/packages/firestore/test/integration/api/index_configuration.test.ts
+++ b/packages/firestore/test/integration/api/index_configuration.test.ts
@@ -20,7 +20,7 @@ import { expect } from 'chai';
 import { setIndexConfiguration } from '../util/firebase_export';
 import { apiDescribe, withTestDb } from '../util/helpers';
 
-apiDescribe('Index Configuration:', (persistence: boolean) => {
+apiDescribe('Index Configuration:', persistence => {
   it('supports JSON', () => {
     return withTestDb(persistence, async db => {
       return setIndexConfiguration(

--- a/packages/firestore/test/integration/api/numeric_transforms.test.ts
+++ b/packages/firestore/test/integration/api/numeric_transforms.test.ts
@@ -37,7 +37,7 @@ import { apiDescribe, withTestDoc } from '../util/helpers';
 
 const DOUBLE_EPSILON = 0.000001;
 
-apiDescribe('Numeric Transforms:', (persistence: boolean) => {
+apiDescribe('Numeric Transforms:', persistence => {
   // A document reference to read and write to.
   let docRef: DocumentReference;
 

--- a/packages/firestore/test/integration/api/query.test.ts
+++ b/packages/firestore/test/integration/api/query.test.ts
@@ -70,7 +70,7 @@ import {
 import { USE_EMULATOR } from '../util/settings';
 import { captureExistenceFilterMismatches } from '../util/testing_hooks_util';
 
-apiDescribe('Queries', (persistence: boolean) => {
+apiDescribe('Queries', persistence => {
   addEqualityMatcher();
 
   it('can issue limit queries', () => {
@@ -2027,42 +2027,45 @@ apiDescribe('Queries', (persistence: boolean) => {
 
   // Reproduces https://github.com/firebase/firebase-js-sdk/issues/5873
   // eslint-disable-next-line no-restricted-properties
-  (persistence ? describe : describe.skip)('Caching empty results', () => {
-    it('can raise initial snapshot from cache, even if it is empty', () => {
-      return withTestCollection(persistence, {}, async coll => {
-        const snapshot1 = await getDocs(coll); // Populate the cache.
-        expect(snapshot1.metadata.fromCache).to.be.false;
-        expect(toDataArray(snapshot1)).to.deep.equal([]); // Precondition check.
+  (persistence ? describe : describe.skip)(
+    'Caching empty results',
+    () => {
+      it('can raise initial snapshot from cache, even if it is empty', () => {
+        return withTestCollection(persistence, {}, async coll => {
+          const snapshot1 = await getDocs(coll); // Populate the cache.
+          expect(snapshot1.metadata.fromCache).to.be.false;
+          expect(toDataArray(snapshot1)).to.deep.equal([]); // Precondition check.
 
-        // Add a snapshot listener whose first event should be raised from cache.
-        const storeEvent = new EventsAccumulator<QuerySnapshot>();
-        onSnapshot(coll, storeEvent.storeEvent);
-        const snapshot2 = await storeEvent.awaitEvent();
-        expect(snapshot2.metadata.fromCache).to.be.true;
-        expect(toDataArray(snapshot2)).to.deep.equal([]);
+          // Add a snapshot listener whose first event should be raised from cache.
+          const storeEvent = new EventsAccumulator<QuerySnapshot>();
+          onSnapshot(coll, storeEvent.storeEvent);
+          const snapshot2 = await storeEvent.awaitEvent();
+          expect(snapshot2.metadata.fromCache).to.be.true;
+          expect(toDataArray(snapshot2)).to.deep.equal([]);
+        });
       });
-    });
 
-    it('can raise initial snapshot from cache, even if it has become empty', () => {
-      const testDocs = {
-        a: { key: 'a' }
-      };
-      return withTestCollection(persistence, testDocs, async coll => {
-        // Populate the cache.
-        const snapshot1 = await getDocs(coll);
-        expect(snapshot1.metadata.fromCache).to.be.false;
-        expect(toDataArray(snapshot1)).to.deep.equal([{ key: 'a' }]);
-        // Empty the collection.
-        void deleteDoc(doc(coll, 'a'));
+      it('can raise initial snapshot from cache, even if it has become empty', () => {
+        const testDocs = {
+          a: { key: 'a' }
+        };
+        return withTestCollection(persistence, testDocs, async coll => {
+          // Populate the cache.
+          const snapshot1 = await getDocs(coll);
+          expect(snapshot1.metadata.fromCache).to.be.false;
+          expect(toDataArray(snapshot1)).to.deep.equal([{ key: 'a' }]);
+          // Empty the collection.
+          void deleteDoc(doc(coll, 'a'));
 
-        const storeEvent = new EventsAccumulator<QuerySnapshot>();
-        onSnapshot(coll, storeEvent.storeEvent);
-        const snapshot2 = await storeEvent.awaitEvent();
-        expect(snapshot2.metadata.fromCache).to.be.true;
-        expect(toDataArray(snapshot2)).to.deep.equal([]);
+          const storeEvent = new EventsAccumulator<QuerySnapshot>();
+          onSnapshot(coll, storeEvent.storeEvent);
+          const snapshot2 = await storeEvent.awaitEvent();
+          expect(snapshot2.metadata.fromCache).to.be.true;
+          expect(toDataArray(snapshot2)).to.deep.equal([]);
+        });
       });
-    });
-  });
+    }
+  );
 
   it('resuming a query should use bloom filter to avoid full requery', async () => {
     // Prepare the names and contents of the 100 documents to create.

--- a/packages/firestore/test/integration/api/query.test.ts
+++ b/packages/firestore/test/integration/api/query.test.ts
@@ -2027,45 +2027,42 @@ apiDescribe('Queries', persistence => {
 
   // Reproduces https://github.com/firebase/firebase-js-sdk/issues/5873
   // eslint-disable-next-line no-restricted-properties
-  (persistence ? describe : describe.skip)(
-    'Caching empty results',
-    () => {
-      it('can raise initial snapshot from cache, even if it is empty', () => {
-        return withTestCollection(persistence, {}, async coll => {
-          const snapshot1 = await getDocs(coll); // Populate the cache.
-          expect(snapshot1.metadata.fromCache).to.be.false;
-          expect(toDataArray(snapshot1)).to.deep.equal([]); // Precondition check.
+  (persistence ? describe : describe.skip)('Caching empty results', () => {
+    it('can raise initial snapshot from cache, even if it is empty', () => {
+      return withTestCollection(persistence, {}, async coll => {
+        const snapshot1 = await getDocs(coll); // Populate the cache.
+        expect(snapshot1.metadata.fromCache).to.be.false;
+        expect(toDataArray(snapshot1)).to.deep.equal([]); // Precondition check.
 
-          // Add a snapshot listener whose first event should be raised from cache.
-          const storeEvent = new EventsAccumulator<QuerySnapshot>();
-          onSnapshot(coll, storeEvent.storeEvent);
-          const snapshot2 = await storeEvent.awaitEvent();
-          expect(snapshot2.metadata.fromCache).to.be.true;
-          expect(toDataArray(snapshot2)).to.deep.equal([]);
-        });
+        // Add a snapshot listener whose first event should be raised from cache.
+        const storeEvent = new EventsAccumulator<QuerySnapshot>();
+        onSnapshot(coll, storeEvent.storeEvent);
+        const snapshot2 = await storeEvent.awaitEvent();
+        expect(snapshot2.metadata.fromCache).to.be.true;
+        expect(toDataArray(snapshot2)).to.deep.equal([]);
       });
+    });
 
-      it('can raise initial snapshot from cache, even if it has become empty', () => {
-        const testDocs = {
-          a: { key: 'a' }
-        };
-        return withTestCollection(persistence, testDocs, async coll => {
-          // Populate the cache.
-          const snapshot1 = await getDocs(coll);
-          expect(snapshot1.metadata.fromCache).to.be.false;
-          expect(toDataArray(snapshot1)).to.deep.equal([{ key: 'a' }]);
-          // Empty the collection.
-          void deleteDoc(doc(coll, 'a'));
+    it('can raise initial snapshot from cache, even if it has become empty', () => {
+      const testDocs = {
+        a: { key: 'a' }
+      };
+      return withTestCollection(persistence, testDocs, async coll => {
+        // Populate the cache.
+        const snapshot1 = await getDocs(coll);
+        expect(snapshot1.metadata.fromCache).to.be.false;
+        expect(toDataArray(snapshot1)).to.deep.equal([{ key: 'a' }]);
+        // Empty the collection.
+        void deleteDoc(doc(coll, 'a'));
 
-          const storeEvent = new EventsAccumulator<QuerySnapshot>();
-          onSnapshot(coll, storeEvent.storeEvent);
-          const snapshot2 = await storeEvent.awaitEvent();
-          expect(snapshot2.metadata.fromCache).to.be.true;
-          expect(toDataArray(snapshot2)).to.deep.equal([]);
-        });
+        const storeEvent = new EventsAccumulator<QuerySnapshot>();
+        onSnapshot(coll, storeEvent.storeEvent);
+        const snapshot2 = await storeEvent.awaitEvent();
+        expect(snapshot2.metadata.fromCache).to.be.true;
+        expect(toDataArray(snapshot2)).to.deep.equal([]);
       });
-    }
-  );
+    });
+  });
 
   it('resuming a query should use bloom filter to avoid full requery', async () => {
     // Prepare the names and contents of the 100 documents to create.

--- a/packages/firestore/test/integration/api/server_timestamp.test.ts
+++ b/packages/firestore/test/integration/api/server_timestamp.test.ts
@@ -38,7 +38,7 @@ import { apiDescribe, withTestDoc } from '../util/helpers';
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type AnyTestData = any;
 
-apiDescribe('Server Timestamps', (persistence: boolean) => {
+apiDescribe('Server Timestamps', persistence => {
   // Data written in tests via set().
   const setData = {
     a: 42,

--- a/packages/firestore/test/integration/api/smoke.test.ts
+++ b/packages/firestore/test/integration/api/smoke.test.ts
@@ -40,7 +40,7 @@ import {
   withTestDoc
 } from '../util/helpers';
 
-apiDescribe('Smoke Test', (persistence: boolean) => {
+apiDescribe('Smoke Test', persistence => {
   it('can write a single document', () => {
     return withTestDoc(persistence, ref => {
       return setDoc(ref, {

--- a/packages/firestore/test/integration/api/transactions.test.ts
+++ b/packages/firestore/test/integration/api/transactions.test.ts
@@ -35,7 +35,7 @@ import {
 } from '../util/firebase_export';
 import { apiDescribe, withTestDb } from '../util/helpers';
 
-apiDescribe('Database transactions', (persistence: boolean) => {
+apiDescribe('Database transactions', persistence => {
   type TransactionStage = (
     transaction: Transaction,
     docRef: DocumentReference
@@ -704,7 +704,7 @@ apiDescribe('Database transactions', (persistence: boolean) => {
 
   // PORTING NOTE: These tests are for FirestoreDataConverter support and apply
   // only to web.
-  apiDescribe('withConverter() support', (persistence: boolean) => {
+  apiDescribe('withConverter() support', persistence => {
     class Post {
       constructor(readonly title: string, readonly author: string) {}
       byline(): string {

--- a/packages/firestore/test/integration/api/type.test.ts
+++ b/packages/firestore/test/integration/api/type.test.ts
@@ -37,7 +37,7 @@ import {
 } from '../util/firebase_export';
 import { apiDescribe, withTestDb, withTestDoc } from '../util/helpers';
 
-apiDescribe('Firestore', (persistence: boolean) => {
+apiDescribe('Firestore', persistence => {
   addEqualityMatcher();
 
   async function expectRoundtrip(

--- a/packages/firestore/test/integration/api/validation.test.ts
+++ b/packages/firestore/test/integration/api/validation.test.ts
@@ -132,7 +132,7 @@ class TestClass {
   constructor(readonly property: string) {}
 }
 
-apiDescribe('Validation:', (persistence: boolean) => {
+apiDescribe('Validation:', persistence => {
   describe('FirestoreSettings', () => {
     // Enabling persistence counts as a use of the firestore instance, meaning
     // that it will be impossible to verify that a set of settings don't throw,

--- a/packages/firestore/test/integration/api_internal/database.test.ts
+++ b/packages/firestore/test/integration/api_internal/database.test.ts
@@ -33,7 +33,7 @@ import { withMockCredentialProviderTestDb } from '../util/internal_helpers';
 
 use(chaiAsPromised);
 
-apiDescribe('Database (with internal API)', (persistence: boolean) => {
+apiDescribe('Database (with internal API)', persistence => {
   // eslint-disable-next-line no-restricted-properties
   (persistence ? it : it.skip)(
     'will reject the promise if clear persistence fails',

--- a/packages/firestore/test/integration/api_internal/idle_timeout.test.ts
+++ b/packages/firestore/test/integration/api_internal/idle_timeout.test.ts
@@ -21,7 +21,7 @@ import { collection, doc, onSnapshot, setDoc } from '../util/firebase_export';
 import { apiDescribe, withTestDb } from '../util/helpers';
 import { asyncQueue } from '../util/internal_helpers';
 
-apiDescribe('Idle Timeout', (persistence: boolean) => {
+apiDescribe('Idle Timeout', persistence => {
   it('can write document after idle timeout', () => {
     return withTestDb(persistence, db => {
       const docRef = doc(collection(db, 'test-collection'));

--- a/packages/firestore/test/integration/api_internal/transaction.test.ts
+++ b/packages/firestore/test/integration/api_internal/transaction.test.ts
@@ -32,116 +32,152 @@ import {
 import { apiDescribe, withTestDb } from '../util/helpers';
 import { asyncQueue } from '../util/internal_helpers';
 
-apiDescribe(
-  'Database transactions (with internal API)',
-  (persistence: boolean) => {
-    it('should increment transactionally', async () => {
-      // A set of concurrent transactions.
-      const transactionPromises: Array<Promise<void>> = [];
-      const readPromises: Array<Promise<void>> = [];
-      // A barrier to make sure every transaction reaches the same spot.
-      const barrier = new Deferred<void>();
-      let started = 0;
+apiDescribe('Database transactions (with internal API)', persistence => {
+  it('should increment transactionally', async () => {
+    // A set of concurrent transactions.
+    const transactionPromises: Array<Promise<void>> = [];
+    const readPromises: Array<Promise<void>> = [];
+    // A barrier to make sure every transaction reaches the same spot.
+    const barrier = new Deferred<void>();
+    let started = 0;
 
-      await withTestDb(persistence, async db => {
-        asyncQueue(db).skipDelaysForTimerId(TimerId.TransactionRetry);
-        const docRef = doc(collection(db, 'counters'));
-        await setDoc(docRef, { count: 5 });
-        // Make 3 transactions that will all increment.
-        for (let i = 0; i < 3; i++) {
-          const resolveRead = new Deferred<void>();
-          readPromises.push(resolveRead.promise);
-          transactionPromises.push(
-            runTransaction(db, async transaction => {
-              const snapshot = await transaction.get(docRef);
-              expect(snapshot).to.exist;
-              started += 1;
-              resolveRead.resolve();
-              await barrier.promise;
-              transaction.set(docRef, {
-                count: snapshot.data()!['count'] + 1
-              });
-            })
-          );
-        }
+    await withTestDb(persistence, async db => {
+      asyncQueue(db).skipDelaysForTimerId(TimerId.TransactionRetry);
+      const docRef = doc(collection(db, 'counters'));
+      await setDoc(docRef, { count: 5 });
+      // Make 3 transactions that will all increment.
+      for (let i = 0; i < 3; i++) {
+        const resolveRead = new Deferred<void>();
+        readPromises.push(resolveRead.promise);
+        transactionPromises.push(
+          runTransaction(db, async transaction => {
+            const snapshot = await transaction.get(docRef);
+            expect(snapshot).to.exist;
+            started += 1;
+            resolveRead.resolve();
+            await barrier.promise;
+            transaction.set(docRef, {
+              count: snapshot.data()!['count'] + 1
+            });
+          })
+        );
+      }
 
-        // Let all of the transactions fetch the old value and stop once.
-        await Promise.all(readPromises);
+      // Let all of the transactions fetch the old value and stop once.
+      await Promise.all(readPromises);
 
-        // Let all of the transactions continue and wait for them to
-        // finish.
-        expect(started).to.equal(3);
-        barrier.resolve();
-        await Promise.all(transactionPromises);
+      // Let all of the transactions continue and wait for them to
+      // finish.
+      expect(started).to.equal(3);
+      barrier.resolve();
+      await Promise.all(transactionPromises);
 
-        // Now all transaction should be completed, so check the result.
-        const snapshot = await getDoc(docRef);
-        expect(snapshot).to.exist;
-        expect(snapshot.data()!['count']).to.equal(8);
-      });
+      // Now all transaction should be completed, so check the result.
+      const snapshot = await getDoc(docRef);
+      expect(snapshot).to.exist;
+      expect(snapshot.data()!['count']).to.equal(8);
     });
+  });
 
-    it('should update transactionally', async () => {
-      // A set of concurrent transactions.
-      const transactionPromises: Array<Promise<void>> = [];
-      const readPromises: Array<Promise<void>> = [];
-      // A barrier to make sure every transaction reaches the same spot.
-      const barrier = new Deferred<void>();
+  it('should update transactionally', async () => {
+    // A set of concurrent transactions.
+    const transactionPromises: Array<Promise<void>> = [];
+    const readPromises: Array<Promise<void>> = [];
+    // A barrier to make sure every transaction reaches the same spot.
+    const barrier = new Deferred<void>();
+    let counter = 0;
+
+    await withTestDb(persistence, async db => {
+      asyncQueue(db).skipDelaysForTimerId(TimerId.TransactionRetry);
+      const docRef = doc(collection(db, 'counters'));
+      await setDoc(docRef, {
+        count: 5,
+        other: 'yes'
+      });
+      // Make 3 transactions that will all increment.
+      for (let i = 0; i < 3; i++) {
+        const resolveRead = new Deferred<void>();
+        readPromises.push(resolveRead.promise);
+        transactionPromises.push(
+          runTransaction(db, async transaction => {
+            const snapshot = await transaction.get(docRef);
+            expect(snapshot).to.exist;
+            counter += 1;
+            resolveRead.resolve();
+            await barrier.promise;
+            await transaction.update(docRef, {
+              count: snapshot.data()!['count'] + 1
+            });
+          })
+        );
+      }
+
+      // Let all of the transactions fetch the old value and stop once.
+      await Promise.all(readPromises);
+
+      // Let all of the transactions continue and wait for them to
+      // finish. There should be 3 initial transaction runs.
+      expect(counter).to.equal(3);
+      barrier.resolve();
+      await Promise.all(transactionPromises);
+
+      // Now all transaction should be completed, so check the result.
+      // There should be a maximum of 3 retries: once for the 2nd update,
+      // and twice for the 3rd update.
+      expect(counter).to.be.lessThan(7);
+      const snapshot = await getDoc(docRef);
+      expect(snapshot).to.exist;
+      expect(snapshot.data()!['count']).to.equal(8);
+      expect(snapshot.data()!['other']).to.equal('yes');
+    });
+  });
+
+  it('should fail transaction (maxAttempts: default) when reading a doc twice with different versions', async () => {
+    await withTestDb(persistence, async db => {
+      asyncQueue(db).skipDelaysForTimerId(TimerId.TransactionRetry);
+      const docRef = doc(collection(db, 'counters'));
       let counter = 0;
-
-      await withTestDb(persistence, async db => {
-        asyncQueue(db).skipDelaysForTimerId(TimerId.TransactionRetry);
-        const docRef = doc(collection(db, 'counters'));
-        await setDoc(docRef, {
-          count: 5,
-          other: 'yes'
+      await setDoc(docRef, { count: 15 });
+      try {
+        await runTransaction(db, async transaction => {
+          counter++;
+          // Get the docRef once.
+          await transaction.get(docRef);
+          // Do a write outside of the transaction. Because the transaction
+          // will retry, set the document to a different value each time.
+          await setDoc(docRef, { count: 1234 + counter });
+          // Get the docRef again in the transaction with the new
+          // version.
+          await transaction.get(docRef);
+          // Now try to update the docRef from within the transaction.
+          // This should fail, because we read 15 earlier.
+          await transaction.set(docRef, { count: 16 });
         });
-        // Make 3 transactions that will all increment.
-        for (let i = 0; i < 3; i++) {
-          const resolveRead = new Deferred<void>();
-          readPromises.push(resolveRead.promise);
-          transactionPromises.push(
-            runTransaction(db, async transaction => {
-              const snapshot = await transaction.get(docRef);
-              expect(snapshot).to.exist;
-              counter += 1;
-              resolveRead.resolve();
-              await barrier.promise;
-              await transaction.update(docRef, {
-                count: snapshot.data()!['count'] + 1
-              });
-            })
-          );
-        }
-
-        // Let all of the transactions fetch the old value and stop once.
-        await Promise.all(readPromises);
-
-        // Let all of the transactions continue and wait for them to
-        // finish. There should be 3 initial transaction runs.
-        expect(counter).to.equal(3);
-        barrier.resolve();
-        await Promise.all(transactionPromises);
-
-        // Now all transaction should be completed, so check the result.
-        // There should be a maximum of 3 retries: once for the 2nd update,
-        // and twice for the 3rd update.
-        expect(counter).to.be.lessThan(7);
-        const snapshot = await getDoc(docRef);
-        expect(snapshot).to.exist;
-        expect(snapshot.data()!['count']).to.equal(8);
-        expect(snapshot.data()!['other']).to.equal('yes');
-      });
+        expect.fail('transaction should fail');
+      } catch (e) {
+        const err = e as FirestoreError;
+        expect(err).to.exist;
+        expect(err.code).to.equal('aborted');
+      }
+      const snapshot = await getDoc(docRef);
+      expect(snapshot.data()!['count']).to.equal(1234 + counter);
+      expect(counter).to.equal(DEFAULT_TRANSACTION_OPTIONS.maxAttempts);
     });
+  });
 
-    it('should fail transaction (maxAttempts: default) when reading a doc twice with different versions', async () => {
-      await withTestDb(persistence, async db => {
-        asyncQueue(db).skipDelaysForTimerId(TimerId.TransactionRetry);
-        const docRef = doc(collection(db, 'counters'));
-        let counter = 0;
-        await setDoc(docRef, { count: 15 });
-        try {
-          await runTransaction(db, async transaction => {
+  it('should fail transaction (maxAttempts: 1) when reading a doc twice with different versions', async () => {
+    await withTestDb(persistence, async db => {
+      asyncQueue(db).skipDelaysForTimerId(TimerId.TransactionRetry);
+      const docRef = doc(collection(db, 'counters'));
+      const options: TransactionOptions = {
+        maxAttempts: 1
+      };
+      let counter = 0;
+      await setDoc(docRef, { count: 15 });
+      try {
+        await runTransaction(
+          db,
+          async transaction => {
             counter++;
             // Get the docRef once.
             await transaction.get(docRef);
@@ -154,57 +190,18 @@ apiDescribe(
             // Now try to update the docRef from within the transaction.
             // This should fail, because we read 15 earlier.
             await transaction.set(docRef, { count: 16 });
-          });
-          expect.fail('transaction should fail');
-        } catch (e) {
-          const err = e as FirestoreError;
-          expect(err).to.exist;
-          expect(err.code).to.equal('aborted');
-        }
-        const snapshot = await getDoc(docRef);
-        expect(snapshot.data()!['count']).to.equal(1234 + counter);
-        expect(counter).to.equal(DEFAULT_TRANSACTION_OPTIONS.maxAttempts);
-      });
+          },
+          options
+        );
+        expect.fail('transaction should fail');
+      } catch (e) {
+        const err = e as FirestoreError;
+        expect(err).to.exist;
+        expect(err.code).to.equal('aborted');
+      }
+      const snapshot = await getDoc(docRef);
+      expect(snapshot.data()!['count']).to.equal(1234 + counter);
+      expect(counter).to.equal(options.maxAttempts);
     });
-
-    it('should fail transaction (maxAttempts: 1) when reading a doc twice with different versions', async () => {
-      await withTestDb(persistence, async db => {
-        asyncQueue(db).skipDelaysForTimerId(TimerId.TransactionRetry);
-        const docRef = doc(collection(db, 'counters'));
-        const options: TransactionOptions = {
-          maxAttempts: 1
-        };
-        let counter = 0;
-        await setDoc(docRef, { count: 15 });
-        try {
-          await runTransaction(
-            db,
-            async transaction => {
-              counter++;
-              // Get the docRef once.
-              await transaction.get(docRef);
-              // Do a write outside of the transaction. Because the transaction
-              // will retry, set the document to a different value each time.
-              await setDoc(docRef, { count: 1234 + counter });
-              // Get the docRef again in the transaction with the new
-              // version.
-              await transaction.get(docRef);
-              // Now try to update the docRef from within the transaction.
-              // This should fail, because we read 15 earlier.
-              await transaction.set(docRef, { count: 16 });
-            },
-            options
-          );
-          expect.fail('transaction should fail');
-        } catch (e) {
-          const err = e as FirestoreError;
-          expect(err).to.exist;
-          expect(err.code).to.equal('aborted');
-        }
-        const snapshot = await getDoc(docRef);
-        expect(snapshot.data()!['count']).to.equal(1234 + counter);
-        expect(counter).to.equal(options.maxAttempts);
-      });
-    });
-  }
-);
+  });
+});


### PR DESCRIPTION
The Firestore integration tests are parameterized by the persistence type being used. All of the tests accept a `persistence` argument of type `boolean`. The tests unnecessarily explicitly specify the type `boolean` for this argument; however, the type can be omitted and deduced by the TypeScript compiler, leading to less code.

The immediate motivation of this change is to prepare for changing the type from `boolean` to some new type. By removing the explicit specification of `boolean`, a future change, https://github.com/firebase/firebase-js-sdk/pull/7404, will be able to change the type without actually affecting most of the test code that accepts the `persistence` argument. This will lead to a more targeted diff for that PR.

Note to reviewers: This small change reduced some of the line lengths that caused massive indentation changes. Consider turning off whitespace in the diff while reviewing.