### PR TITLE
Update test 'bloom filter should correctly encode special unicode characters' in query.test.ts

### DIFF
--- a/packages/firestore/src/remote/watch_change.ts
+++ b/packages/firestore/src/remote/watch_change.ts
@@ -514,10 +514,11 @@ export class WatchChangeAggregator {
       return { status: BloomFilterApplicationStatus.Skipped };
     }
 
-    const bloomFilterMightContain = (documentPath: string) => {
+    const bloomFilterMightContain = (documentPath: string): boolean => {
       const databaseId = this.metadataProvider.getDatabaseId();
       return bloomFilter.mightContain(
-        `projects/${databaseId.projectId}/databases/${databaseId.database}/documents/${documentPath}`
+        `projects/${databaseId.projectId}/databases/${databaseId.database}` +
+          `/documents/${documentPath}`
       );
     };
 

--- a/packages/firestore/src/remote/watch_change.ts
+++ b/packages/firestore/src/remote/watch_change.ts
@@ -433,15 +433,15 @@ export class WatchChangeAggregator {
         // raise a snapshot with `isFromCache:true`.
         if (currentSize !== expectedCount) {
           // Apply bloom filter to identify and mark removed documents.
-          const status = this.applyBloomFilter(watchChange, currentSize);
+          const applyResult = this.applyBloomFilter(watchChange, currentSize);
 
-          if (status !== BloomFilterApplicationStatus.Success) {
+          if (applyResult.status !== BloomFilterApplicationStatus.Success) {
             // If bloom filter application fails, we reset the mapping and
             // trigger re-run of the query.
             this.resetTarget(targetId);
 
             const purpose: TargetPurpose =
-              status === BloomFilterApplicationStatus.FalsePositive
+              applyResult.status === BloomFilterApplicationStatus.FalsePositive
                 ? TargetPurpose.ExistenceFilterMismatchBloom
                 : TargetPurpose.ExistenceFilterMismatch;
             this.pendingTargetResets = this.pendingTargetResets.insert(
@@ -451,7 +451,8 @@ export class WatchChangeAggregator {
           }
           TestingHooks.instance?.notifyOnExistenceFilterMismatch(
             createExistenceFilterMismatchInfoForTestingHooks(
-              status,
+              applyResult.status,
+              applyResult.bloomFilterMightContain ?? null,
               currentSize,
               watchChange.existenceFilter
             )
@@ -468,12 +469,15 @@ export class WatchChangeAggregator {
   private applyBloomFilter(
     watchChange: ExistenceFilterChange,
     currentCount: number
-  ): BloomFilterApplicationStatus {
+  ): {
+    status: BloomFilterApplicationStatus;
+    bloomFilterMightContain?: (documentPath: string) => boolean;
+  } {
     const { unchangedNames, count: expectedCount } =
       watchChange.existenceFilter;
 
     if (!unchangedNames || !unchangedNames.bits) {
-      return BloomFilterApplicationStatus.Skipped;
+      return { status: BloomFilterApplicationStatus.Skipped };
     }
 
     const {
@@ -491,7 +495,7 @@ export class WatchChangeAggregator {
             err.message +
             '); ignoring the bloom filter and falling back to full re-query.'
         );
-        return BloomFilterApplicationStatus.Skipped;
+        return { status: BloomFilterApplicationStatus.Skipped };
       } else {
         throw err;
       }
@@ -507,23 +511,39 @@ export class WatchChangeAggregator {
       } else {
         logWarn('Applying bloom filter failed: ', err);
       }
-      return BloomFilterApplicationStatus.Skipped;
+      return { status: BloomFilterApplicationStatus.Skipped };
     }
 
+    const bloomFilterMightContain = (documentPath: string) => {
+      const databaseId = this.metadataProvider.getDatabaseId();
+      return bloomFilter.mightContain(
+        `projects/${databaseId.projectId}/databases/${databaseId.database}/documents/${documentPath}`
+      );
+    };
+
     if (bloomFilter.bitCount === 0) {
-      return BloomFilterApplicationStatus.Skipped;
+      return {
+        status: BloomFilterApplicationStatus.Skipped,
+        bloomFilterMightContain
+      };
     }
 
     const removedDocumentCount = this.filterRemovedDocuments(
       watchChange.targetId,
-      bloomFilter
+      bloomFilterMightContain
     );
 
     if (expectedCount !== currentCount - removedDocumentCount) {
-      return BloomFilterApplicationStatus.FalsePositive;
+      return {
+        status: BloomFilterApplicationStatus.FalsePositive,
+        bloomFilterMightContain
+      };
     }
 
-    return BloomFilterApplicationStatus.Success;
+    return {
+      status: BloomFilterApplicationStatus.Success,
+      bloomFilterMightContain
+    };
   }
 
   /**
@@ -532,18 +552,13 @@ export class WatchChangeAggregator {
    */
   private filterRemovedDocuments(
     targetId: number,
-    bloomFilter: BloomFilter
+    bloomFilterMightContain: (documentPath: string) => boolean
   ): number {
     const existingKeys = this.metadataProvider.getRemoteKeysForTarget(targetId);
     let removalCount = 0;
 
     existingKeys.forEach(key => {
-      const databaseId = this.metadataProvider.getDatabaseId();
-      const documentPath = `projects/${databaseId.projectId}/databases/${
-        databaseId.database
-      }/documents/${key.path.canonicalString()}`;
-
-      if (!bloomFilter.mightContain(documentPath)) {
+      if (!bloomFilterMightContain(key.path.canonicalString())) {
         this.removeDocumentFromTarget(targetId, key, /*updatedDocument=*/ null);
         removalCount++;
       }
@@ -829,6 +844,7 @@ function snapshotChangesMap(): SortedMap<DocumentKey, ChangeType> {
 
 function createExistenceFilterMismatchInfoForTestingHooks(
   status: BloomFilterApplicationStatus,
+  bloomFilterMightContain: null | ((documentPath: string) => boolean),
   localCacheCount: number,
   existenceFilter: ExistenceFilter
 ): TestingHooksExistenceFilterMismatchInfo {
@@ -845,6 +861,9 @@ function createExistenceFilterMismatchInfoForTestingHooks(
       bitmapLength: unchangedNames?.bits?.bitmap?.length ?? 0,
       padding: unchangedNames?.bits?.padding ?? 0
     };
+    if (bloomFilterMightContain) {
+      result.bloomFilter.mightContain = bloomFilterMightContain;
+    }
   }
 
   return result;

--- a/packages/firestore/src/remote/watch_change.ts
+++ b/packages/firestore/src/remote/watch_change.ts
@@ -523,10 +523,7 @@ export class WatchChangeAggregator {
     };
 
     if (bloomFilter.bitCount === 0) {
-      return {
-        status: BloomFilterApplicationStatus.Skipped,
-        bloomFilterMightContain
-      };
+      return { status: BloomFilterApplicationStatus.Skipped };
     }
 
     const removedDocumentCount = this.filterRemovedDocuments(
@@ -534,17 +531,11 @@ export class WatchChangeAggregator {
       bloomFilterMightContain
     );
 
-    if (expectedCount !== currentCount - removedDocumentCount) {
-      return {
-        status: BloomFilterApplicationStatus.FalsePositive,
-        bloomFilterMightContain
-      };
-    }
-
-    return {
-      status: BloomFilterApplicationStatus.Success,
-      bloomFilterMightContain
-    };
+    const status =
+      expectedCount === currentCount - removedDocumentCount
+        ? BloomFilterApplicationStatus.Success
+        : BloomFilterApplicationStatus.FalsePositive;
+    return { status, bloomFilterMightContain };
   }
 
   /**

--- a/packages/firestore/src/util/testing_hooks.ts
+++ b/packages/firestore/src/util/testing_hooks.ts
@@ -124,6 +124,21 @@ export interface ExistenceFilterMismatchInfo {
 
     /** The number of bits of padding in the last byte of the bloom filter. */
     padding: number;
+
+    /**
+     * Check if the given document path is contained in the bloom filter.
+     *
+     * The "path" of a document can be retrieved from the
+     * `DocumentReference.path` property.
+     *
+     * Note that due to the probabilistic nature of a bloom filter, it is
+     * possible that false positives may occur; that is, this function may
+     * return `true` even though the given string is not in the bloom filter.
+     *
+     * This property is "optional"; if it is undefined then parsing the bloom
+     * filter failed.
+     */
+    mightContain?(documentPath: string): boolean;
   };
 }
 

--- a/packages/firestore/test/integration/util/testing_hooks_util.ts
+++ b/packages/firestore/test/integration/util/testing_hooks_util.ts
@@ -69,5 +69,6 @@ export interface ExistenceFilterMismatchInfo {
     hashCount: number;
     bitmapLength: number;
     padding: number;
+    mightContain?(documentPath: string): boolean;
   };
 }


### PR DESCRIPTION
Modify the test `'bloom filter should correctly encode special unicode characters'` in `query.test.ts`, that was added by the recent PR https://github.com/firebase/firebase-js-sdk/pull/7412, to directly check the bloom filter for containing the document paths with complex Unicode characters. Previously, it was indirectly checking this via the other properties of the existence filter. As a result, the "retry" logic was removed, since it doesn't matter if there is a false positive.

To add the ability to directly interrogate the bloom filter, the testing hooks needed to be augments to expose the "mightContain" method of `BloomFilter`.