### PR TITLE
Firestore: Fix 'where indexeddb is not available' tests that were broken by persistence changes

### DIFF
--- a/packages/firestore/test/integration/browser/indexeddb.test.ts
+++ b/packages/firestore/test/integration/browser/indexeddb.test.ts
@@ -26,12 +26,12 @@ import {
 } from '../util/firebase_export';
 import {
   IndexedDbPersistenceMode,
-  MemoryEagerPersistenceMode,
   isPersistenceAvailable,
-  withTestDb
+  withTestDb,
+  PERSISTENCE_MODE_UNSPECIFIED
 } from '../util/helpers';
 
-describe('where indexeddb is not available: ', () => {
+describe.only('where indexeddb is not available: ', () => {
   // Only test on platforms where persistence is *not* available (e.g. Edge,
   // Node.JS).
   if (isPersistenceAvailable()) {
@@ -41,7 +41,7 @@ describe('where indexeddb is not available: ', () => {
   it('fails with code unimplemented', () => {
     // withTestDb will fail the test if persistence is requested but it fails
     // so we'll enable persistence here instead.
-    return withTestDb(new MemoryEagerPersistenceMode(), db => {
+    return withTestDb(PERSISTENCE_MODE_UNSPECIFIED, db => {
       return enableIndexedDbPersistence(db).then(
         () => expect.fail('enablePersistence should not have succeeded!'),
         (error: FirestoreError) => {
@@ -52,7 +52,7 @@ describe('where indexeddb is not available: ', () => {
   });
 
   it('falls back without requiring a wait for the promise', () => {
-    return withTestDb(new MemoryEagerPersistenceMode(), db => {
+    return withTestDb(PERSISTENCE_MODE_UNSPECIFIED, db => {
       const persistenceFailedPromise = enableIndexedDbPersistence(db).catch(
         (err: FirestoreError) => {
           expect(err.code).to.equal('unimplemented');
@@ -67,7 +67,7 @@ describe('where indexeddb is not available: ', () => {
     });
   });
 
-  it('fails back to memory cache with initializeFirestore too', () => {
+  it('falls back to memory cache with initializeFirestore too', () => {
     // withTestDb will fail the test if persistence is requested but it fails
     // so we'll enable persistence here instead.
     return withTestDb(new IndexedDbPersistenceMode(), db => {

--- a/packages/firestore/test/integration/browser/indexeddb.test.ts
+++ b/packages/firestore/test/integration/browser/indexeddb.test.ts
@@ -31,7 +31,7 @@ import {
   PERSISTENCE_MODE_UNSPECIFIED
 } from '../util/helpers';
 
-describe.only('where indexeddb is not available: ', () => {
+describe('where indexeddb is not available: ', () => {
   // Only test on platforms where persistence is *not* available (e.g. Edge,
   // Node.JS).
   if (isPersistenceAvailable()) {


### PR DESCRIPTION
The tests `'fails with code unimplemented'` and `'falls back without requiring a wait for the promise'` tests in `indexeddb.test.ts` were broken by https://github.com/firebase/firebase-js-sdk/pull/7404, which changed the way that "persistence" was tracked in the integration tests. These test failures were not noticed because they don't get executed by CI. This PR fixes the tests by providing a means to _not_ explicitly specify a `localCache` in `FirestoreSettings` and instead use the implicit default, which is required by these tests.