### PR TITLE
Firestore: update firestore-types with breaking API changes for FirestoreDataConverter

### DIFF
--- a/.changeset/empty-boats-dream.md
+++ b/.changeset/empty-boats-dream.md
@@ -1,0 +1,6 @@
+---
+'@firebase/firestore-types': major
+'firebase': major
+---
+
+Update to be consistent with the FirestoreDataConverter changes from #7310

--- a/packages/firestore-types/index.d.ts
+++ b/packages/firestore-types/index.d.ts
@@ -49,20 +49,11 @@ export type LogLevel =
 
 export function setLogLevel(logLevel: LogLevel): void;
 
-export interface FirestoreDataConverter<
-  AppModelType,
-  DbModelType extends DocumentData = DocumentData
-> {
-  toFirestore(modelObject: AppModelType): DbModelType;
-  toFirestore(
-    modelObject: Partial<AppModelType>,
-    options: SetOptions
-  ): Partial<DbModelType>;
+export interface FirestoreDataConverter<T> {
+  toFirestore(modelObject: T): DocumentData;
+  toFirestore(modelObject: Partial<T>, options: SetOptions): DocumentData;
 
-  fromFirestore(
-    snapshot: QueryDocumentSnapshot<DocumentData, DocumentData>,
-    options: SnapshotOptions
-  ): AppModelType;
+  fromFirestore(snapshot: QueryDocumentSnapshot, options: SnapshotOptions): T;
 }
 
 export class FirebaseFirestore {
@@ -80,13 +71,11 @@ export class FirebaseFirestore {
 
   enablePersistence(settings?: PersistenceSettings): Promise<void>;
 
-  collection(
-    collectionPath: string
-  ): CollectionReference<DocumentData, DocumentData>;
+  collection(collectionPath: string): CollectionReference<DocumentData>;
 
-  doc(documentPath: string): DocumentReference<DocumentData, DocumentData>;
+  doc(documentPath: string): DocumentReference<DocumentData>;
 
-  collectionGroup(collectionId: string): Query<DocumentData, DocumentData>;
+  collectionGroup(collectionId: string): Query<DocumentData>;
 
   runTransaction<T>(
     updateFunction: (transaction: Transaction) => Promise<T>
@@ -117,7 +106,7 @@ export class FirebaseFirestore {
     bundleData: ArrayBuffer | ReadableStream<Uint8Array> | string
   ): LoadBundleTask;
 
-  namedQuery(name: string): Promise<Query<DocumentData, DocumentData> | null>;
+  namedQuery(name: string): Promise<Query<DocumentData> | null>;
 
   INTERNAL: { delete: () => Promise<void> };
 }
@@ -196,63 +185,45 @@ export class Blob {
 export class Transaction {
   private constructor();
 
-  get<AppModelType, DbModelType extends DocumentData>(
-    documentRef: DocumentReference<AppModelType, DbModelType>
-  ): Promise<DocumentSnapshot<AppModelType, DbModelType>>;
+  get<T>(documentRef: DocumentReference<T>): Promise<DocumentSnapshot<T>>;
 
-  set<AppModelType, DbModelType extends DocumentData>(
-    documentRef: DocumentReference<AppModelType, DbModelType>,
-    data: Partial<AppModelType>,
+  set<T>(
+    documentRef: DocumentReference<T>,
+    data: Partial<T>,
     options: SetOptions
   ): Transaction;
-  set<AppModelType, DbModelType extends DocumentData>(
-    documentRef: DocumentReference<AppModelType, DbModelType>,
-    data: AppModelType
-  ): Transaction;
+  set<T>(documentRef: DocumentReference<T>, data: T): Transaction;
 
-  update<AppModelType, DbModelType extends DocumentData>(
-    documentRef: DocumentReference<AppModelType, DbModelType>,
-    data: DbModelType
-  ): Transaction;
-  update<AppModelType, DbModelType extends DocumentData>(
-    documentRef: DocumentReference<AppModelType, DbModelType>,
+  update(documentRef: DocumentReference<any>, data: UpdateData): Transaction;
+  update(
+    documentRef: DocumentReference<any>,
     field: string | FieldPath,
     value: any,
     ...moreFieldsAndValues: any[]
   ): Transaction;
 
-  delete<AppModelType, DbModelType extends DocumentData>(
-    documentRef: DocumentReference<AppModelType, DbModelType>
-  ): Transaction;
+  delete(documentRef: DocumentReference<any>): Transaction;
 }
 
 export class WriteBatch {
   private constructor();
 
-  set<AppModelType, DbModelType extends DocumentData>(
-    documentRef: DocumentReference<AppModelType, DbModelType>,
-    data: Partial<AppModelType>,
+  set<T>(
+    documentRef: DocumentReference<T>,
+    data: Partial<T>,
     options: SetOptions
   ): WriteBatch;
-  set<AppModelType, DbModelType extends DocumentData>(
-    documentRef: DocumentReference<AppModelType, DbModelType>,
-    data: AppModelType
-  ): WriteBatch;
+  set<T>(documentRef: DocumentReference<T>, data: T): WriteBatch;
 
-  update<AppModelType, DbModelType extends DocumentData>(
-    documentRef: DocumentReference<AppModelType, DbModelType>,
-    data: DbModelType
-  ): WriteBatch;
-  update<AppModelType, DbModelType extends DocumentData>(
-    documentRef: DocumentReference<AppModelType, DbModelType>,
+  update(documentRef: DocumentReference<any>, data: UpdateData): WriteBatch;
+  update(
+    documentRef: DocumentReference<any>,
     field: string | FieldPath,
     value: any,
     ...moreFieldsAndValues: any[]
   ): WriteBatch;
 
-  delete<AppModelType, DbModelType extends DocumentData>(
-    documentRef: DocumentReference<AppModelType, DbModelType>
-  ): WriteBatch;
+  delete(documentRef: DocumentReference<any>): WriteBatch;
 
   commit(): Promise<void>;
 }
@@ -271,26 +242,24 @@ export interface GetOptions {
 }
 
 export class DocumentReference<
-  AppModelType = DocumentData,
-  DbModelType extends DocumentData = DocumentData
+  T = DocumentData,
+  U extends DocumentData = DocumentData
 > {
   private constructor();
 
   readonly id: string;
   readonly firestore: FirebaseFirestore;
-  readonly parent: CollectionReference<AppModelType, DbModelType>;
+  readonly parent: CollectionReference<T>;
   readonly path: string;
 
-  collection(
-    collectionPath: string
-  ): CollectionReference<DocumentData, DocumentData>;
+  collection(collectionPath: string): CollectionReference<DocumentData>;
 
-  isEqual(other: DocumentReference<AppModelType, DbModelType>): boolean;
+  isEqual(other: DocumentReference<T>): boolean;
 
-  set(data: Partial<AppModelType>, options: SetOptions): Promise<void>;
-  set(data: AppModelType): Promise<void>;
+  set(data: Partial<T>, options: SetOptions): Promise<void>;
+  set(data: T): Promise<void>;
 
-  update(data: DbModelType): Promise<void>;
+  update(data: UpdateData): Promise<void>;
   update(
     field: string | FieldPath,
     value: any,
@@ -299,39 +268,35 @@ export class DocumentReference<
 
   delete(): Promise<void>;
 
-  get(
-    options?: GetOptions
-  ): Promise<DocumentSnapshot<AppModelType, DbModelType>>;
+  get(options?: GetOptions): Promise<DocumentSnapshot<T>>;
 
   onSnapshot(observer: {
-    next?: (snapshot: DocumentSnapshot<AppModelType, DbModelType>) => void;
+    next?: (snapshot: DocumentSnapshot<T>) => void;
     error?: (error: FirestoreError) => void;
     complete?: () => void;
   }): () => void;
   onSnapshot(
     options: SnapshotListenOptions,
     observer: {
-      next?: (snapshot: DocumentSnapshot<AppModelType, DbModelType>) => void;
+      next?: (snapshot: DocumentSnapshot<T>) => void;
       error?: (error: FirestoreError) => void;
       complete?: () => void;
     }
   ): () => void;
   onSnapshot(
-    onNext: (snapshot: DocumentSnapshot<AppModelType, DbModelType>) => void,
+    onNext: (snapshot: DocumentSnapshot<T>) => void,
     onError?: (error: FirestoreError) => void,
     onCompletion?: () => void
   ): () => void;
   onSnapshot(
     options: SnapshotListenOptions,
-    onNext: (snapshot: DocumentSnapshot<AppModelType, DbModelType>) => void,
+    onNext: (snapshot: DocumentSnapshot<T>) => void,
     onError?: (error: FirestoreError) => void,
     onCompletion?: () => void
   ): () => void;
 
-  withConverter(converter: null): DocumentReference<DocumentData, DocumentData>;
-  withConverter<NewAppModelType, NewDbModelType extends DocumentData>(
-    converter: FirestoreDataConverter<NewAppModelType, NewDbModelType>
-  ): DocumentReference<NewAppModelType, NewDbModelType>;
+  withConverter(converter: null): DocumentReference<DocumentData>;
+  withConverter<U>(converter: FirestoreDataConverter<U>): DocumentReference<U>;
 }
 
 export interface SnapshotOptions {
@@ -346,30 +311,30 @@ export interface SnapshotMetadata {
 }
 
 export class DocumentSnapshot<
-  AppModelType = DocumentData,
-  DbModelType extends DocumentData = DocumentData
+  T = DocumentData,
+  U extends DocumentData = DocumentData
 > {
   protected constructor();
 
   readonly exists: boolean;
-  readonly ref: DocumentReference<AppModelType, DbModelType>;
+  readonly ref: DocumentReference<T>;
   readonly id: string;
   readonly metadata: SnapshotMetadata;
 
-  data(options?: SnapshotOptions): AppModelType | undefined;
+  data(options?: SnapshotOptions): T | undefined;
 
   get(fieldPath: string | FieldPath, options?: SnapshotOptions): any;
 
-  isEqual(other: DocumentSnapshot<AppModelType, DbModelType>): boolean;
+  isEqual(other: DocumentSnapshot<T>): boolean;
 }
 
 export class QueryDocumentSnapshot<
-  AppModelType = DocumentData,
-  DbModelType extends DocumentData = DocumentData
-> extends DocumentSnapshot<AppModelType, DbModelType> {
+  T = DocumentData,
+  U extends DocumentData = DocumentData
+> extends DocumentSnapshot<T, U> {
   private constructor();
 
-  data(options?: SnapshotOptions): AppModelType;
+  data(options?: SnapshotOptions): T;
 }
 
 export type OrderByDirection = 'desc' | 'asc';
@@ -386,10 +351,7 @@ export type WhereFilterOp =
   | 'array-contains-any'
   | 'not-in';
 
-export class Query<
-  AppModelType = DocumentData,
-  DbModelType extends DocumentData = DocumentData
-> {
+export class Query<T = DocumentData, U extends DocumentData = DocumentData> {
   protected constructor();
 
   readonly firestore: FirebaseFirestore;
@@ -398,60 +360,54 @@ export class Query<
     fieldPath: string | FieldPath,
     opStr: WhereFilterOp,
     value: any
-  ): Query<AppModelType, DbModelType>;
+  ): Query<T>;
 
   orderBy(
     fieldPath: string | FieldPath,
     directionStr?: OrderByDirection
-  ): Query<AppModelType, DbModelType>;
+  ): Query<T>;
 
-  limit(limit: number): Query<AppModelType, DbModelType>;
+  limit(limit: number): Query<T>;
 
-  limitToLast(limit: number): Query<AppModelType, DbModelType>;
+  limitToLast(limit: number): Query<T>;
 
-  startAt(
-    snapshot: DocumentSnapshot<any, any>
-  ): Query<AppModelType, DbModelType>;
-  startAt(...fieldValues: any[]): Query<AppModelType, DbModelType>;
+  startAt(snapshot: DocumentSnapshot<any>): Query<T>;
+  startAt(...fieldValues: any[]): Query<T>;
 
-  startAfter(
-    snapshot: DocumentSnapshot<any, any>
-  ): Query<AppModelType, DbModelType>;
-  startAfter(...fieldValues: any[]): Query<AppModelType, DbModelType>;
+  startAfter(snapshot: DocumentSnapshot<any>): Query<T>;
+  startAfter(...fieldValues: any[]): Query<T>;
 
-  endBefore(
-    snapshot: DocumentSnapshot<any, any>
-  ): Query<AppModelType, DbModelType>;
-  endBefore(...fieldValues: any[]): Query<AppModelType, DbModelType>;
+  endBefore(snapshot: DocumentSnapshot<any>): Query<T>;
+  endBefore(...fieldValues: any[]): Query<T>;
 
-  endAt(snapshot: DocumentSnapshot<any, any>): Query<AppModelType, DbModelType>;
-  endAt(...fieldValues: any[]): Query<AppModelType, DbModelType>;
+  endAt(snapshot: DocumentSnapshot<any>): Query<T>;
+  endAt(...fieldValues: any[]): Query<T>;
 
-  isEqual(other: Query<AppModelType, DbModelType>): boolean;
+  isEqual(other: Query<T>): boolean;
 
-  get(options?: GetOptions): Promise<QuerySnapshot<AppModelType, DbModelType>>;
+  get(options?: GetOptions): Promise<QuerySnapshot<T>>;
 
   onSnapshot(observer: {
-    next?: (snapshot: QuerySnapshot<AppModelType, DbModelType>) => void;
+    next?: (snapshot: QuerySnapshot<T>) => void;
     error?: (error: FirestoreError) => void;
     complete?: () => void;
   }): () => void;
   onSnapshot(
     options: SnapshotListenOptions,
     observer: {
-      next?: (snapshot: QuerySnapshot<AppModelType, DbModelType>) => void;
+      next?: (snapshot: QuerySnapshot<T>) => void;
       error?: (error: FirestoreError) => void;
       complete?: () => void;
     }
   ): () => void;
   onSnapshot(
-    onNext: (snapshot: QuerySnapshot<AppModelType, DbModelType>) => void,
+    onNext: (snapshot: QuerySnapshot<T>) => void,
     onError?: (error: FirestoreError) => void,
     onCompletion?: () => void
   ): () => void;
   onSnapshot(
     options: SnapshotListenOptions,
-    onNext: (snapshot: QuerySnapshot<AppModelType, DbModelType>) => void,
+    onNext: (snapshot: QuerySnapshot<T>) => void,
     onError?: (error: FirestoreError) => void,
     onCompletion?: () => void
   ): () => void;
@@ -461,67 +417,59 @@ export class Query<
 }
 
 export class QuerySnapshot<
-  AppModelType = DocumentData,
-  DbModelType extends DocumentData = DocumentData
+  T = DocumentData,
+  U extends DocumentData = DocumentData
 > {
   private constructor();
 
-  readonly query: Query<AppModelType, DbModelType>;
+  readonly query: Query<T>;
   readonly metadata: SnapshotMetadata;
-  readonly docs: Array<QueryDocumentSnapshot<AppModelType, DbModelType>>;
+  readonly docs: Array<QueryDocumentSnapshot<T>>;
   readonly size: number;
   readonly empty: boolean;
 
-  docChanges(
-    options?: SnapshotListenOptions
-  ): Array<DocumentChange<AppModelType, DbModelType>>;
+  docChanges(options?: SnapshotListenOptions): Array<DocumentChange<T>>;
 
   forEach(
-    callback: (
-      result: QueryDocumentSnapshot<AppModelType, DbModelType>
-    ) => void,
+    callback: (result: QueryDocumentSnapshot<T>) => void,
     thisArg?: any
   ): void;
 
-  isEqual(other: QuerySnapshot<AppModelType, DbModelType>): boolean;
+  isEqual(other: QuerySnapshot<T>): boolean;
 }
 
 export type DocumentChangeType = 'added' | 'removed' | 'modified';
 
 export interface DocumentChange<
-  AppModelType = DocumentData,
-  DbModelType extends DocumentData = DocumentData
+  T = DocumentData,
+  U extends DocumentData = DocumentData
 > {
   readonly type: DocumentChangeType;
-  readonly doc: QueryDocumentSnapshot<AppModelType, DbModelType>;
+  readonly doc: QueryDocumentSnapshot<T>;
   readonly oldIndex: number;
   readonly newIndex: number;
 }
 
 export class CollectionReference<
-  AppModelType = DocumentData,
-  DbModelType extends DocumentData = DocumentData
-> extends Query<AppModelType, DbModelType> {
+  T = DocumentData,
+  U extends DocumentData = DocumentData
+> extends Query<T, U> {
   private constructor();
 
   readonly id: string;
-  readonly parent: DocumentReference<DocumentData, DocumentData> | null;
+  readonly parent: DocumentReference<DocumentData> | null;
   readonly path: string;
 
-  doc(documentPath?: string): DocumentReference<AppModelType, DbModelType>;
+  doc(documentPath?: string): DocumentReference<T>;
 
-  add(
-    data: AppModelType
-  ): Promise<DocumentReference<AppModelType, DbModelType>>;
+  add(data: T): Promise<DocumentReference<T>>;
 
-  isEqual(other: CollectionReference<AppModelType, DbModelType>): boolean;
+  isEqual(other: CollectionReference<T>): boolean;
 
-  withConverter(
-    converter: null
-  ): CollectionReference<DocumentData, DocumentData>;
-  withConverter<NewAppModelType, NewDbModelType extends DocumentData>(
-    converter: FirestoreDataConverter<NewDbModelType, NewDbModelType>
-  ): CollectionReference<NewAppModelType, NewDbModelType>;
+  withConverter(converter: null): CollectionReference<DocumentData>;
+  withConverter<U>(
+    converter: FirestoreDataConverter<U>
+  ): CollectionReference<U>;
 }
 
 export class FieldValue {

--- a/packages/firestore-types/index.d.ts
+++ b/packages/firestore-types/index.d.ts
@@ -243,7 +243,7 @@ export interface GetOptions {
 
 export class DocumentReference<
   T = DocumentData,
-  U extends DocumentData = DocumentData
+  T2 extends DocumentData = DocumentData
 > {
   private constructor();
 
@@ -312,7 +312,7 @@ export interface SnapshotMetadata {
 
 export class DocumentSnapshot<
   T = DocumentData,
-  U extends DocumentData = DocumentData
+  T2 extends DocumentData = DocumentData
 > {
   protected constructor();
 
@@ -330,8 +330,8 @@ export class DocumentSnapshot<
 
 export class QueryDocumentSnapshot<
   T = DocumentData,
-  U extends DocumentData = DocumentData
-> extends DocumentSnapshot<T, U> {
+  T2 extends DocumentData = DocumentData
+> extends DocumentSnapshot<T, T2> {
   private constructor();
 
   data(options?: SnapshotOptions): T;
@@ -351,7 +351,7 @@ export type WhereFilterOp =
   | 'array-contains-any'
   | 'not-in';
 
-export class Query<T = DocumentData, U extends DocumentData = DocumentData> {
+export class Query<T = DocumentData, T2 extends DocumentData = DocumentData> {
   protected constructor();
 
   readonly firestore: FirebaseFirestore;
@@ -418,7 +418,7 @@ export class Query<T = DocumentData, U extends DocumentData = DocumentData> {
 
 export class QuerySnapshot<
   T = DocumentData,
-  U extends DocumentData = DocumentData
+  T2 extends DocumentData = DocumentData
 > {
   private constructor();
 
@@ -442,7 +442,7 @@ export type DocumentChangeType = 'added' | 'removed' | 'modified';
 
 export interface DocumentChange<
   T = DocumentData,
-  U extends DocumentData = DocumentData
+  T2 extends DocumentData = DocumentData
 > {
   readonly type: DocumentChangeType;
   readonly doc: QueryDocumentSnapshot<T>;
@@ -452,8 +452,8 @@ export interface DocumentChange<
 
 export class CollectionReference<
   T = DocumentData,
-  U extends DocumentData = DocumentData
-> extends Query<T, U> {
+  T2 extends DocumentData = DocumentData
+> extends Query<T, T2> {
   private constructor();
 
   readonly id: string;


### PR DESCRIPTION
Update `index.d.ts` from the `firestore-types` package for the `FirestoreDataConverter` breaking API changes from https://github.com/firebase/firebase-js-sdk/pull/7310.

This fixes ~29 build errors that anyone using the `firestore-compat` library would get, that look like this:

```
node_modules/@firebase/firestore-compat/dist/src/index.d.ts:54:80 - error TS2707: Generic type 'CollectionReference<T>' requires between 0 and 1 type arguments.

54     function addDoc<AppModelType, DbModelType extends DocumentData>(reference: types.CollectionReference<AppModelType, DbModelType>, data: WithFieldValue<AppModelType>): Promise<DocumentReference<AppModelType, DbModelType>>;
                                                                                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

I tested this change by creating a new npm project and running `npm install firebase@next` and running this little test app: https://gist.github.com/dconeybe/cf113e198fe0e52283f0251fa0ff6899

Googlers see b/290216686 for details.