### PR TITLE
Update password policy in sign-in flow

### DIFF
--- a/packages/auth/src/core/strategies/email_and_password.test.ts
+++ b/packages/auth/src/core/strategies/email_and_password.test.ts
@@ -841,6 +841,17 @@ describe('password policy cache is updated in auth flows upon error', () => {
   let policyEndpointMockWithTenant: mockFetch.Route;
   let policyEndpointMockWithOtherTenant: mockFetch.Route;
 
+  /**
+   * Wait for 50ms to allow the password policy to be fetched and recached.
+   */
+  async function waitForRecachePasswordPolicy(): Promise<void> {
+    await new Promise<void>(resolve => {
+      setTimeout(() => {
+        resolve();
+      }, 50);
+    });
+  }
+
   beforeEach(async () => {
     auth = await testAuth();
     mockFetch.setUp();
@@ -884,6 +895,9 @@ describe('password policy cache is updated in auth flows upon error', () => {
         createUserWithEmailAndPassword(auth, TEST_EMAIL, TEST_PASSWORD)
       ).to.be.fulfilled;
 
+      // Wait to ensure the password policy is not fetched and recached.
+      await waitForRecachePasswordPolicy();
+
       expect(policyEndpointMock.calls.length).to.eq(0);
       expect(auth._getPasswordPolicyInternal()).to.be.null;
     });
@@ -894,6 +908,9 @@ describe('password policy cache is updated in auth flows upon error', () => {
       await expect(
         createUserWithEmailAndPassword(auth, TEST_EMAIL, TEST_PASSWORD)
       ).to.be.fulfilled;
+
+      // Wait to ensure the password policy is not fetched and recached.
+      await waitForRecachePasswordPolicy();
 
       expect(policyEndpointMock.calls.length).to.eq(1);
       expect(auth._getPasswordPolicyInternal()).to.eql(CACHED_PASSWORD_POLICY);
@@ -926,6 +943,9 @@ describe('password policy cache is updated in auth flows upon error', () => {
           createUserWithEmailAndPassword(auth, TEST_EMAIL, TEST_PASSWORD)
         ).to.be.rejectedWith(FirebaseError, PASSWORD_ERROR_MSG);
 
+        // Wait for the password policy to be fetched and recached.
+        await waitForRecachePasswordPolicy();
+
         expect(policyEndpointMock.calls.length).to.eq(2);
         expect(auth._getPasswordPolicyInternal()).to.eql(
           CACHED_PASSWORD_POLICY_REQUIRE_NUMERIC
@@ -947,6 +967,9 @@ describe('password policy cache is updated in auth flows upon error', () => {
           createUserWithEmailAndPassword(auth, TEST_EMAIL, TEST_PASSWORD)
         ).to.be.rejectedWith(FirebaseError, PASSWORD_ERROR_MSG);
 
+        // Wait for the password policy to be fetched and recached.
+        await waitForRecachePasswordPolicy();
+
         expect(policyEndpointMockWithTenant.calls.length).to.eq(2);
         expect(auth._getPasswordPolicyInternal()).to.eql(
           CACHED_PASSWORD_POLICY_REQUIRE_NUMERIC
@@ -959,6 +982,9 @@ describe('password policy cache is updated in auth flows upon error', () => {
         await expect(
           createUserWithEmailAndPassword(auth, TEST_EMAIL, TEST_PASSWORD)
         ).to.be.rejectedWith(FirebaseError, PASSWORD_ERROR_MSG);
+
+        // Wait for the password policy to be fetched and recached.
+        await waitForRecachePasswordPolicy();
 
         expect(policyEndpointMock.calls.length).to.eq(0);
         expect(auth._getPasswordPolicyInternal()).to.be.null;
@@ -976,6 +1002,10 @@ describe('password policy cache is updated in auth flows upon error', () => {
         await expect(
           createUserWithEmailAndPassword(auth, TEST_EMAIL, TEST_PASSWORD)
         ).to.be.rejectedWith(FirebaseError, PASSWORD_ERROR_MSG);
+
+        // Wait to ensure the password policy is not fetched and recached.
+        await waitForRecachePasswordPolicy();
+
         expect(policyEndpointMockWithOtherTenant.calls.length).to.eq(0);
         expect(auth._getPasswordPolicyInternal()).to.be.undefined;
       });
@@ -995,6 +1025,9 @@ describe('password policy cache is updated in auth flows upon error', () => {
       await expect(confirmPasswordReset(auth, TEST_OOB_CODE, TEST_PASSWORD)).to
         .be.fulfilled;
 
+      // Wait to ensure the password policy is not fetched and recached.
+      await waitForRecachePasswordPolicy();
+
       expect(policyEndpointMock.calls.length).to.eq(0);
       expect(auth._getPasswordPolicyInternal()).to.be.null;
     });
@@ -1004,6 +1037,9 @@ describe('password policy cache is updated in auth flows upon error', () => {
 
       await expect(confirmPasswordReset(auth, TEST_OOB_CODE, TEST_PASSWORD)).to
         .be.fulfilled;
+
+      // Wait to ensure the password policy is not fetched and recached.
+      await waitForRecachePasswordPolicy();
 
       expect(policyEndpointMock.calls.length).to.eq(1);
       expect(auth._getPasswordPolicyInternal()).to.eql(CACHED_PASSWORD_POLICY);
@@ -1036,6 +1072,9 @@ describe('password policy cache is updated in auth flows upon error', () => {
           confirmPasswordReset(auth, TEST_OOB_CODE, TEST_PASSWORD)
         ).to.be.rejectedWith(FirebaseError, PASSWORD_ERROR_MSG);
 
+        // Wait for the password policy to be fetched and recached.
+        await waitForRecachePasswordPolicy();
+
         expect(policyEndpointMock.calls.length).to.eq(2);
         expect(auth._getPasswordPolicyInternal()).to.eql(
           CACHED_PASSWORD_POLICY_REQUIRE_NUMERIC
@@ -1057,6 +1096,9 @@ describe('password policy cache is updated in auth flows upon error', () => {
           confirmPasswordReset(auth, TEST_OOB_CODE, TEST_PASSWORD)
         ).to.be.rejectedWith(FirebaseError, PASSWORD_ERROR_MSG);
 
+        // Wait for the password policy to be fetched and recached.
+        await waitForRecachePasswordPolicy();
+
         expect(policyEndpointMockWithTenant.calls.length).to.eq(2);
         expect(auth._getPasswordPolicyInternal()).to.eql(
           CACHED_PASSWORD_POLICY_REQUIRE_NUMERIC
@@ -1069,6 +1111,9 @@ describe('password policy cache is updated in auth flows upon error', () => {
         await expect(
           confirmPasswordReset(auth, TEST_OOB_CODE, TEST_PASSWORD)
         ).to.be.rejectedWith(FirebaseError, PASSWORD_ERROR_MSG);
+
+        // Wait to ensure the password policy is not fetched and recached.
+        await waitForRecachePasswordPolicy();
 
         expect(policyEndpointMock.calls.length).to.eq(0);
         expect(auth._getPasswordPolicyInternal()).to.be.null;
@@ -1086,6 +1131,10 @@ describe('password policy cache is updated in auth flows upon error', () => {
         await expect(
           confirmPasswordReset(auth, TEST_OOB_CODE, TEST_PASSWORD)
         ).to.be.rejectedWith(FirebaseError, PASSWORD_ERROR_MSG);
+
+        // Wait to ensure the password policy is not fetched and recached.
+        await waitForRecachePasswordPolicy();
+
         expect(policyEndpointMockWithOtherTenant.calls.length).to.eq(0);
         expect(auth._getPasswordPolicyInternal()).to.be.undefined;
       });
@@ -1109,6 +1158,9 @@ describe('password policy cache is updated in auth flows upon error', () => {
       await expect(signInWithEmailAndPassword(auth, TEST_EMAIL, TEST_PASSWORD))
         .to.be.fulfilled;
 
+      // Wait to ensure the password policy is not fetched and recached.
+      await waitForRecachePasswordPolicy();
+
       expect(policyEndpointMock.calls.length).to.eq(0);
       expect(auth._getPasswordPolicyInternal()).to.be.null;
     });
@@ -1118,6 +1170,9 @@ describe('password policy cache is updated in auth flows upon error', () => {
 
       await expect(signInWithEmailAndPassword(auth, TEST_EMAIL, TEST_PASSWORD))
         .to.be.fulfilled;
+
+      // Wait to ensure the password policy is not fetched and recached.
+      await waitForRecachePasswordPolicy();
 
       expect(policyEndpointMock.calls.length).to.eq(1);
       expect(auth._getPasswordPolicyInternal()).to.eql(CACHED_PASSWORD_POLICY);
@@ -1150,6 +1205,9 @@ describe('password policy cache is updated in auth flows upon error', () => {
           signInWithEmailAndPassword(auth, TEST_EMAIL, TEST_PASSWORD)
         ).to.be.rejectedWith(FirebaseError, PASSWORD_ERROR_MSG);
 
+        // Wait for the password policy to be fetched and recached.
+        await waitForRecachePasswordPolicy();
+
         expect(policyEndpointMock.calls.length).to.eq(2);
         expect(auth._getPasswordPolicyInternal()).to.eql(
           CACHED_PASSWORD_POLICY_REQUIRE_NUMERIC
@@ -1171,6 +1229,9 @@ describe('password policy cache is updated in auth flows upon error', () => {
           signInWithEmailAndPassword(auth, TEST_EMAIL, TEST_PASSWORD)
         ).to.be.rejectedWith(FirebaseError, PASSWORD_ERROR_MSG);
 
+        // Wait for the password policy to be fetched and recached.
+        await waitForRecachePasswordPolicy();
+
         expect(policyEndpointMockWithTenant.calls.length).to.eq(2);
         expect(auth._getPasswordPolicyInternal()).to.eql(
           CACHED_PASSWORD_POLICY_REQUIRE_NUMERIC
@@ -1183,6 +1244,9 @@ describe('password policy cache is updated in auth flows upon error', () => {
         await expect(
           signInWithEmailAndPassword(auth, TEST_EMAIL, TEST_PASSWORD)
         ).to.be.rejectedWith(FirebaseError, PASSWORD_ERROR_MSG);
+
+        // Wait to ensure the password policy is not fetched and recached.
+        await waitForRecachePasswordPolicy();
 
         expect(policyEndpointMock.calls.length).to.eq(0);
         expect(auth._getPasswordPolicyInternal()).to.be.null;
@@ -1200,6 +1264,10 @@ describe('password policy cache is updated in auth flows upon error', () => {
         await expect(
           signInWithEmailAndPassword(auth, TEST_EMAIL, TEST_PASSWORD)
         ).to.be.rejectedWith(FirebaseError, PASSWORD_ERROR_MSG);
+
+        // Wait to ensure the password policy is not fetched and recached.
+        await waitForRecachePasswordPolicy();
+
         expect(policyEndpointMockWithOtherTenant.calls.length).to.eq(0);
         expect(auth._getPasswordPolicyInternal()).to.be.undefined;
       });

--- a/packages/auth/src/core/strategies/email_and_password.test.ts
+++ b/packages/auth/src/core/strategies/email_and_password.test.ts
@@ -745,149 +745,6 @@ describe('core/strategies/email_and_password/createUserWithEmailAndPassword', ()
       expect(user.isAnonymous).to.be.false;
     });
   });
-
-  context('#passwordPolicy', () => {
-    const TEST_MIN_PASSWORD_LENGTH = 6;
-    const TEST_ALLOWED_NON_ALPHANUMERIC_CHARS = ['!', '(', ')'];
-    const TEST_SCHEMA_VERSION = 1;
-
-    const TEST_TENANT_ID = 'tenant-id';
-    const TEST_REQUIRE_NUMERIC_TENANT_ID = 'other-tenant-id';
-
-    const PASSWORD_ERROR_MSG =
-      'Firebase: The password does not meet the requirements. (auth/password-does-not-meet-requirements).';
-
-    const passwordPolicyResponse = {
-      customStrengthOptions: {
-        minPasswordLength: TEST_MIN_PASSWORD_LENGTH
-      },
-      allowedNonAlphanumericCharacters: TEST_ALLOWED_NON_ALPHANUMERIC_CHARS,
-      schemaVersion: TEST_SCHEMA_VERSION
-    };
-    const passwordPolicyResponseRequireNumeric = {
-      customStrengthOptions: {
-        minPasswordLength: TEST_MIN_PASSWORD_LENGTH,
-        containsNumericCharacter: true
-      },
-      allowedNonAlphanumericCharacters: TEST_ALLOWED_NON_ALPHANUMERIC_CHARS,
-      schemaVersion: TEST_SCHEMA_VERSION
-    };
-    const cachedPasswordPolicy = {
-      customStrengthOptions: {
-        minPasswordLength: TEST_MIN_PASSWORD_LENGTH
-      },
-      allowedNonAlphanumericCharacters: TEST_ALLOWED_NON_ALPHANUMERIC_CHARS
-    };
-    const cachedPasswordPolicyRequireNumeric = {
-      customStrengthOptions: {
-        minPasswordLength: TEST_MIN_PASSWORD_LENGTH,
-        containsNumericCharacter: true
-      },
-      allowedNonAlphanumericCharacters: TEST_ALLOWED_NON_ALPHANUMERIC_CHARS
-    };
-    let policyEndpointMock: mockFetch.Route;
-    let policyEndpointMockWithTenant: mockFetch.Route;
-    let policyEndpointMockWithOtherTenant: mockFetch.Route;
-
-    beforeEach(() => {
-      policyEndpointMock = mockEndpointWithParams(
-        Endpoint.GET_PASSWORD_POLICY,
-        {},
-        passwordPolicyResponse
-      );
-      policyEndpointMockWithTenant = mockEndpointWithParams(
-        Endpoint.GET_PASSWORD_POLICY,
-        {
-          tenantId: TEST_TENANT_ID
-        },
-        passwordPolicyResponse
-      );
-      policyEndpointMockWithOtherTenant = mockEndpointWithParams(
-        Endpoint.GET_PASSWORD_POLICY,
-        {
-          tenantId: TEST_REQUIRE_NUMERIC_TENANT_ID
-        },
-        passwordPolicyResponseRequireNumeric
-      );
-    });
-
-    it('does not update the cached password policy upon successful sign up when there is no existing policy cache', async () => {
-      await expect(
-        createUserWithEmailAndPassword(auth, 'some-email', 'some-password')
-      ).to.be.fulfilled;
-
-      expect(policyEndpointMock.calls.length).to.eq(0);
-      expect(auth._getPasswordPolicy()).to.be.null;
-    });
-
-    it('does not update the cached password policy upon successful sign up when there is an existing policy cache', async () => {
-      await auth._updatePasswordPolicy();
-
-      await expect(
-        createUserWithEmailAndPassword(auth, 'some-email', 'some-password')
-      ).to.be.fulfilled;
-
-      expect(policyEndpointMock.calls.length).to.eq(1);
-      expect(auth._getPasswordPolicy()).to.eql(cachedPasswordPolicy);
-    });
-
-    context('handles password validation errors', () => {
-      beforeEach(() => {
-        mockEndpoint(
-          Endpoint.SIGN_UP,
-          {
-            error: {
-              code: 400,
-              message: ServerError.PASSWORD_DOES_NOT_MEET_REQUIREMENTS
-            }
-          },
-          400
-        );
-      });
-
-      it('updates the cached password policy when password does not meet backend requirements', async () => {
-        await auth._updatePasswordPolicy();
-        expect(policyEndpointMock.calls.length).to.eq(1);
-        expect(auth._getPasswordPolicy()).to.eql(cachedPasswordPolicy);
-
-        // Password policy changed after previous fetch.
-        policyEndpointMock.response = passwordPolicyResponseRequireNumeric;
-        await expect(
-          createUserWithEmailAndPassword(auth, 'some-email', 'some-password')
-        ).to.be.rejectedWith(FirebaseError, PASSWORD_ERROR_MSG);
-
-        expect(policyEndpointMock.calls.length).to.eq(2);
-        expect(auth._getPasswordPolicy()).to.eql(
-          cachedPasswordPolicyRequireNumeric
-        );
-      });
-
-      it('does not update the cached password policy upon error if policy has not previously been fetched', async () => {
-        expect(auth._getPasswordPolicy()).to.be.null;
-
-        await expect(
-          createUserWithEmailAndPassword(auth, 'some-email', 'some-password')
-        ).to.be.rejectedWith(FirebaseError, PASSWORD_ERROR_MSG);
-
-        expect(policyEndpointMock.calls.length).to.eq(0);
-        expect(auth._getPasswordPolicy()).to.be.null;
-      });
-
-      it('does not update the cached password policy upon error if tenant changes and policy has not previously been fetched', async () => {
-        auth.tenantId = TEST_TENANT_ID;
-        await auth._updatePasswordPolicy();
-        expect(policyEndpointMockWithTenant.calls.length).to.eq(1);
-        expect(auth._getPasswordPolicy()).to.eql(cachedPasswordPolicy);
-
-        auth.tenantId = TEST_REQUIRE_NUMERIC_TENANT_ID;
-        await expect(
-          createUserWithEmailAndPassword(auth, 'some-email', 'some-password')
-        ).to.be.rejectedWith(FirebaseError, PASSWORD_ERROR_MSG);
-        expect(policyEndpointMockWithOtherTenant.calls.length).to.eq(0);
-        expect(auth._getPasswordPolicy()).to.be.undefined;
-      });
-    });
-  });
 });
 
 describe('core/strategies/email_and_password/signInWithEmailAndPassword', () => {
@@ -927,5 +784,258 @@ describe('core/strategies/email_and_password/signInWithEmailAndPassword', () => 
     expect(operationType).to.eq(OperationType.SIGN_IN);
     expect(user.uid).to.eq(serverUser.localId);
     expect(user.isAnonymous).to.be.false;
+  });
+});
+
+describe('password policy cache is updated in auth flows upon error', () => {
+  let auth: TestAuth;
+
+  const TEST_MIN_PASSWORD_LENGTH = 6;
+  const TEST_ALLOWED_NON_ALPHANUMERIC_CHARS = ['!', '(', ')'];
+  const TEST_SCHEMA_VERSION = 1;
+
+  const TEST_TENANT_ID = 'tenant-id';
+  const TEST_REQUIRE_NUMERIC_TENANT_ID = 'other-tenant-id';
+
+  const PASSWORD_ERROR_MSG =
+    'Firebase: The password does not meet the requirements. (auth/password-does-not-meet-requirements).';
+
+  const passwordPolicyResponse = {
+    customStrengthOptions: {
+      minPasswordLength: TEST_MIN_PASSWORD_LENGTH
+    },
+    allowedNonAlphanumericCharacters: TEST_ALLOWED_NON_ALPHANUMERIC_CHARS,
+    schemaVersion: TEST_SCHEMA_VERSION
+  };
+  const passwordPolicyResponseRequireNumeric = {
+    customStrengthOptions: {
+      minPasswordLength: TEST_MIN_PASSWORD_LENGTH,
+      containsNumericCharacter: true
+    },
+    allowedNonAlphanumericCharacters: TEST_ALLOWED_NON_ALPHANUMERIC_CHARS,
+    schemaVersion: TEST_SCHEMA_VERSION
+  };
+  const cachedPasswordPolicy = {
+    customStrengthOptions: {
+      minPasswordLength: TEST_MIN_PASSWORD_LENGTH
+    },
+    allowedNonAlphanumericCharacters: TEST_ALLOWED_NON_ALPHANUMERIC_CHARS
+  };
+  const cachedPasswordPolicyRequireNumeric = {
+    customStrengthOptions: {
+      minPasswordLength: TEST_MIN_PASSWORD_LENGTH,
+      containsNumericCharacter: true
+    },
+    allowedNonAlphanumericCharacters: TEST_ALLOWED_NON_ALPHANUMERIC_CHARS
+  };
+  let policyEndpointMock: mockFetch.Route;
+  let policyEndpointMockWithTenant: mockFetch.Route;
+  let policyEndpointMockWithOtherTenant: mockFetch.Route;
+
+  beforeEach(async () => {
+    auth = await testAuth();
+    mockFetch.setUp();
+    policyEndpointMock = mockEndpointWithParams(
+      Endpoint.GET_PASSWORD_POLICY,
+      {},
+      passwordPolicyResponse
+    );
+    policyEndpointMockWithTenant = mockEndpointWithParams(
+      Endpoint.GET_PASSWORD_POLICY,
+      {
+        tenantId: TEST_TENANT_ID
+      },
+      passwordPolicyResponse
+    );
+    policyEndpointMockWithOtherTenant = mockEndpointWithParams(
+      Endpoint.GET_PASSWORD_POLICY,
+      {
+        tenantId: TEST_REQUIRE_NUMERIC_TENANT_ID
+      },
+      passwordPolicyResponseRequireNumeric
+    );
+  });
+  afterEach(mockFetch.tearDown);
+
+  context('#createUserWithEmailAndPassword', () => {
+    const serverUser: APIUserInfo = {
+      localId: 'local-id'
+    };
+
+    const email = 'some-email';
+    const password = 'some-password';
+
+    beforeEach(() => {
+      mockEndpoint(Endpoint.SIGN_UP, {
+        idToken: 'id-token',
+        refreshToken: 'refresh-token',
+        expiresIn: '1234',
+        localId: serverUser.localId!
+      });
+      mockEndpoint(Endpoint.GET_ACCOUNT_INFO, {
+        users: [serverUser]
+      });
+    });
+
+    it('does not update the cached password policy upon successful sign up when there is no existing policy cache', async () => {
+      await expect(createUserWithEmailAndPassword(auth, email, password)).to.be
+        .fulfilled;
+
+      expect(policyEndpointMock.calls.length).to.eq(0);
+      expect(auth._getPasswordPolicy()).to.be.null;
+    });
+
+    it('does not update the cached password policy upon successful sign up when there is an existing policy cache', async () => {
+      await auth._updatePasswordPolicy();
+
+      await expect(createUserWithEmailAndPassword(auth, email, password)).to.be
+        .fulfilled;
+
+      expect(policyEndpointMock.calls.length).to.eq(1);
+      expect(auth._getPasswordPolicy()).to.eql(cachedPasswordPolicy);
+    });
+
+    context('handles password validation errors', () => {
+      beforeEach(() => {
+        mockEndpoint(
+          Endpoint.SIGN_UP,
+          {
+            error: {
+              code: 400,
+              message: ServerError.PASSWORD_DOES_NOT_MEET_REQUIREMENTS
+            }
+          },
+          400
+        );
+      });
+
+      it('updates the cached password policy when password does not meet backend requirements', async () => {
+        await auth._updatePasswordPolicy();
+        expect(policyEndpointMock.calls.length).to.eq(1);
+        expect(auth._getPasswordPolicy()).to.eql(cachedPasswordPolicy);
+
+        // Password policy changed after previous fetch.
+        policyEndpointMock.response = passwordPolicyResponseRequireNumeric;
+        await expect(
+          createUserWithEmailAndPassword(auth, email, password)
+        ).to.be.rejectedWith(FirebaseError, PASSWORD_ERROR_MSG);
+
+        expect(policyEndpointMock.calls.length).to.eq(2);
+        expect(auth._getPasswordPolicy()).to.eql(
+          cachedPasswordPolicyRequireNumeric
+        );
+      });
+
+      it('does not update the cached password policy upon error if policy has not previously been fetched', async () => {
+        expect(auth._getPasswordPolicy()).to.be.null;
+
+        await expect(
+          createUserWithEmailAndPassword(auth, email, password)
+        ).to.be.rejectedWith(FirebaseError, PASSWORD_ERROR_MSG);
+
+        expect(policyEndpointMock.calls.length).to.eq(0);
+        expect(auth._getPasswordPolicy()).to.be.null;
+      });
+
+      it('does not update the cached password policy upon error if tenant changes and policy has not previously been fetched', async () => {
+        auth.tenantId = TEST_TENANT_ID;
+        await auth._updatePasswordPolicy();
+        expect(policyEndpointMockWithTenant.calls.length).to.eq(1);
+        expect(auth._getPasswordPolicy()).to.eql(cachedPasswordPolicy);
+
+        auth.tenantId = TEST_REQUIRE_NUMERIC_TENANT_ID;
+        await expect(
+          createUserWithEmailAndPassword(auth, email, password)
+        ).to.be.rejectedWith(FirebaseError, PASSWORD_ERROR_MSG);
+        expect(policyEndpointMockWithOtherTenant.calls.length).to.eq(0);
+        expect(auth._getPasswordPolicy()).to.be.undefined;
+      });
+    });
+  });
+
+  context('#confirmPasswordReset', () => {
+    const oobCode = 'oob-code';
+    const newPassword = 'new-password';
+
+    beforeEach(() => {
+      mockEndpoint(Endpoint.RESET_PASSWORD, {
+        email: 'foo@bar.com'
+      });
+    });
+
+    it('does not update the cached password policy upon successful password reset when there is no existing policy cache', async () => {
+      await expect(confirmPasswordReset(auth, oobCode, newPassword)).to.be
+        .fulfilled;
+
+      expect(policyEndpointMock.calls.length).to.eq(0);
+      expect(auth._getPasswordPolicy()).to.be.null;
+    });
+
+    it('does not update the cached password policy upon successful password reset when there is an existing policy cache', async () => {
+      await auth._updatePasswordPolicy();
+
+      await expect(confirmPasswordReset(auth, oobCode, newPassword)).to.be
+        .fulfilled;
+
+      expect(policyEndpointMock.calls.length).to.eq(1);
+      expect(auth._getPasswordPolicy()).to.eql(cachedPasswordPolicy);
+    });
+
+    context('handles password validation errors', () => {
+      beforeEach(() => {
+        mockEndpoint(
+          Endpoint.RESET_PASSWORD,
+          {
+            error: {
+              code: 400,
+              message: ServerError.PASSWORD_DOES_NOT_MEET_REQUIREMENTS
+            }
+          },
+          400
+        );
+      });
+
+      it('updates the cached password policy when password does not meet backend requirements', async () => {
+        await auth._updatePasswordPolicy();
+        expect(policyEndpointMock.calls.length).to.eq(1);
+        expect(auth._getPasswordPolicy()).to.eql(cachedPasswordPolicy);
+
+        // Password policy changed after previous fetch.
+        policyEndpointMock.response = passwordPolicyResponseRequireNumeric;
+        await expect(
+          confirmPasswordReset(auth, oobCode, newPassword)
+        ).to.be.rejectedWith(FirebaseError, PASSWORD_ERROR_MSG);
+
+        expect(policyEndpointMock.calls.length).to.eq(2);
+        expect(auth._getPasswordPolicy()).to.eql(
+          cachedPasswordPolicyRequireNumeric
+        );
+      });
+
+      it('does not update the cached password policy upon error if policy has not previously been fetched', async () => {
+        expect(auth._getPasswordPolicy()).to.be.null;
+
+        await expect(
+          confirmPasswordReset(auth, oobCode, newPassword)
+        ).to.be.rejectedWith(FirebaseError, PASSWORD_ERROR_MSG);
+
+        expect(policyEndpointMock.calls.length).to.eq(0);
+        expect(auth._getPasswordPolicy()).to.be.null;
+      });
+
+      it('does not update the cached password policy upon error if tenant changes and policy has not previously been fetched', async () => {
+        auth.tenantId = TEST_TENANT_ID;
+        await auth._updatePasswordPolicy();
+        expect(policyEndpointMockWithTenant.calls.length).to.eq(1);
+        expect(auth._getPasswordPolicy()).to.eql(cachedPasswordPolicy);
+
+        auth.tenantId = TEST_REQUIRE_NUMERIC_TENANT_ID;
+        await expect(
+          confirmPasswordReset(auth, oobCode, newPassword)
+        ).to.be.rejectedWith(FirebaseError, PASSWORD_ERROR_MSG);
+        expect(policyEndpointMockWithOtherTenant.calls.length).to.eq(0);
+        expect(auth._getPasswordPolicy()).to.be.undefined;
+      });
+    });
   });
 });

--- a/packages/auth/src/core/strategies/email_and_password.ts
+++ b/packages/auth/src/core/strategies/email_and_password.ts
@@ -391,8 +391,7 @@ export function signInWithEmailAndPassword(
     EmailAuthProvider.credential(email, password)
   ).catch(async error => {
     if (
-      error.code ===
-      `auth/${AuthErrorCode.PASSWORD_DOES_NOT_MEET_REQUIREMENTS}`
+      error.code === `auth/${AuthErrorCode.PASSWORD_DOES_NOT_MEET_REQUIREMENTS}`
     ) {
       await recachePasswordPolicy(auth);
     }

--- a/packages/auth/src/core/strategies/email_and_password.ts
+++ b/packages/auth/src/core/strategies/email_and_password.ts
@@ -389,5 +389,13 @@ export function signInWithEmailAndPassword(
   return signInWithCredential(
     getModularInstance(auth),
     EmailAuthProvider.credential(email, password)
-  );
+  ).catch(async error => {
+    if (
+      error.code === `auth/${AuthErrorCode.PASSWORD_DOES_NOT_MEET_REQUIREMENTS}`
+    ) {
+      await updatePasswordPolicyIfCached(auth);
+    }
+
+    return Promise.reject(error);
+  });
 }

--- a/packages/auth/src/core/strategies/email_and_password.ts
+++ b/packages/auth/src/core/strategies/email_and_password.ts
@@ -184,10 +184,10 @@ export async function confirmPasswordReset(
         error.code ===
         `auth/${AuthErrorCode.PASSWORD_DOES_NOT_MEET_REQUIREMENTS}`
       ) {
-        await recachePasswordPolicy(auth);
+        void recachePasswordPolicy(auth);
       }
 
-      return Promise.reject(error);
+      throw error;
     });
   // Do not return the email.
 }
@@ -343,10 +343,10 @@ export async function createUserWithEmailAndPassword(
           error.code ===
           `auth/${AuthErrorCode.PASSWORD_DOES_NOT_MEET_REQUIREMENTS}`
         ) {
-          await recachePasswordPolicy(auth);
+          void recachePasswordPolicy(auth);
         }
 
-        return Promise.reject(error);
+        throw error;
       }
     });
   }
@@ -393,9 +393,9 @@ export function signInWithEmailAndPassword(
     if (
       error.code === `auth/${AuthErrorCode.PASSWORD_DOES_NOT_MEET_REQUIREMENTS}`
     ) {
-      await recachePasswordPolicy(auth);
+      void recachePasswordPolicy(auth);
     }
 
-    return Promise.reject(error);
+    throw error;
   });
 }

--- a/packages/auth/src/core/strategies/email_and_password.ts
+++ b/packages/auth/src/core/strategies/email_and_password.ts
@@ -41,6 +41,26 @@ import { IdTokenResponse } from '../../model/id_token';
 import { RecaptchaActionName, RecaptchaClientType } from '../../api';
 
 /**
+ * Updates the password policy cached in the {@link Auth} instance if a policy is already
+ * cached for the project or tenant.
+ *
+ * @remarks
+ * We only fetch the password policy if the password did not meet policy requirements and
+ * there is an existing policy cached. A developer must call validatePassword at least
+ * once for the cache to be automatically updated.
+ *
+ * @param auth - The {@link Auth} instance.
+ *
+ * @private
+ */
+async function updatePasswordPolicyIfCached(auth: Auth): Promise<void> {
+  const authInternal = _castAuth(auth);
+  if (authInternal._getPasswordPolicy()) {
+    await authInternal._updatePasswordPolicy();
+  }
+}
+
+/**
  * Sends a password reset email to the given email address.
  *
  * @remarks
@@ -154,10 +174,21 @@ export async function confirmPasswordReset(
   oobCode: string,
   newPassword: string
 ): Promise<void> {
-  await account.resetPassword(getModularInstance(auth), {
-    oobCode,
-    newPassword
-  });
+  await account
+    .resetPassword(getModularInstance(auth), {
+      oobCode,
+      newPassword
+    })
+    .catch(async error => {
+      if (
+        error.code ===
+        `auth/${AuthErrorCode.PASSWORD_DOES_NOT_MEET_REQUIREMENTS}`
+      ) {
+        await updatePasswordPolicyIfCached(auth);
+      }
+
+      return Promise.reject(error);
+    });
   // Do not return the email.
 }
 
@@ -308,14 +339,11 @@ export async function createUserWithEmailAndPassword(
         );
         return signUp(authInternal, requestWithRecaptcha);
       } else {
-        // Only fetch the password policy if the password did not meet policy requirements and there is an existing policy cached.
-        // A developer must call validatePassword at least once for the cache to be automatically updated.
         if (
           error.code ===
-            `auth/${AuthErrorCode.PASSWORD_DOES_NOT_MEET_REQUIREMENTS}` &&
-          authInternal._getPasswordPolicy()
+          `auth/${AuthErrorCode.PASSWORD_DOES_NOT_MEET_REQUIREMENTS}`
         ) {
-          await authInternal._updatePasswordPolicy();
+          await updatePasswordPolicyIfCached(auth);
         }
 
         return Promise.reject(error);


### PR DESCRIPTION
Update the cached password policy when the sign-in flow (signInWithEmailAndPassword) receives a `PASSWORD_DOES_NOT_MEET_REQUIREMENTS` error.