### PR TITLE
Add `x-goog-request-params` to request header.

### DIFF
--- a/.changeset/eighty-roses-appear.md
+++ b/.changeset/eighty-roses-appear.md
@@ -2,4 +2,4 @@
 "@firebase/firestore": patch
 ---
 
-Add `x-goog-request-params` to REST request header.
+Fixed issue where count and lite API queries did not work with named databases.

--- a/.changeset/eighty-roses-appear.md
+++ b/.changeset/eighty-roses-appear.md
@@ -1,0 +1,5 @@
+---
+"@firebase/firestore": patch
+---
+
+Add `x-goog-request-params` to REST request header.

--- a/packages/firestore/src/remote/rest_connection.ts
+++ b/packages/firestore/src/remote/rest_connection.ts
@@ -73,9 +73,10 @@ export abstract class RestConnection implements Connection {
     const proto = databaseInfo.ssl ? 'https' : 'http';
     this.baseUrl = proto + '://' + databaseInfo.host;
     this.databasePath = `projects/${databaseInfo.databaseId.projectId}/databases/${databaseInfo.databaseId.database}`;
-    this.requestParams = this.databaseId.database === DEFAULT_DATABASE_NAME
-      ? `project_id=${this.databaseId.projectId}`
-      : `project_id=${this.databaseId.projectId}&database_id=${this.databaseId.database}`;
+    this.requestParams =
+      this.databaseId.database === DEFAULT_DATABASE_NAME
+        ? `project_id=${this.databaseId.projectId}`
+        : `project_id=${this.databaseId.projectId}&database_id=${this.databaseId.database}`;
   }
 
   invokeRPC<Req, Resp>(

--- a/packages/firestore/src/remote/rest_connection.ts
+++ b/packages/firestore/src/remote/rest_connection.ts
@@ -70,12 +70,14 @@ export abstract class RestConnection implements Connection {
   constructor(private readonly databaseInfo: DatabaseInfo) {
     this.databaseId = databaseInfo.databaseId;
     const proto = databaseInfo.ssl ? 'https' : 'http';
+    const projectId = encodeURIComponent(this.databaseId.projectId);
+    const databaseId = encodeURIComponent(this.databaseId.database);
     this.baseUrl = proto + '://' + databaseInfo.host;
-    this.databasePath = `projects/${databaseInfo.databaseId.projectId}/databases/${databaseInfo.databaseId.database}`;
+    this.databasePath = `projects/${projectId}/databases/${databaseId}`;
     this.requestParams =
       this.databaseId.database === DEFAULT_DATABASE_NAME
-        ? `project_id=${this.databaseId.projectId}`
-        : `project_id=${this.databaseId.projectId}&database_id=${this.databaseId.database}`;
+        ? `project_id=${projectId}`
+        : `project_id=${projectId}&database_id=${databaseId}`;
   }
 
   invokeRPC<Req, Resp>(

--- a/packages/firestore/src/remote/rest_connection.ts
+++ b/packages/firestore/src/remote/rest_connection.ts
@@ -61,7 +61,6 @@ export abstract class RestConnection implements Connection {
   private readonly databasePath: string;
   private readonly requestParams: string;
 
-
   get shouldResourcePathBeIncludedInRequest(): boolean {
     // Both `invokeRPC()` and `invokeStreamingRPC()` use their `path` arguments to determine
     // where to run the query, and expect the `request` to NOT specify the "path".

--- a/packages/firestore/src/remote/rest_connection.ts
+++ b/packages/firestore/src/remote/rest_connection.ts
@@ -17,7 +17,7 @@
 
 import { SDK_VERSION } from '../../src/core/version';
 import { Token } from '../api/credentials';
-import {DatabaseId, DatabaseInfo, DEFAULT_DATABASE_NAME} from '../core/database_info';
+import { DatabaseId, DatabaseInfo, DEFAULT_DATABASE_NAME } from '../core/database_info';
 import { debugAssert } from '../util/assert';
 import { generateUniqueDebugId } from '../util/debug_uid';
 import { FirestoreError } from '../util/error';

--- a/packages/firestore/src/remote/rest_connection.ts
+++ b/packages/firestore/src/remote/rest_connection.ts
@@ -90,10 +90,7 @@ export abstract class RestConnection implements Connection {
     logDebug(LOG_TAG, `Sending RPC '${rpcName}' ${streamId}:`, url, req);
 
     const headers: StringMap = {
-      'x-goog-request-params':
-        this.databaseId.database === DEFAULT_DATABASE_NAME
-          ? `project_id=${this.databaseId.projectId}`
-          : `project_id=${this.databaseId.projectId}&database_id=${this.databaseId.database}`
+      'x-goog-request-params': `project_id=${this.databaseId.projectId}&database_id=${this.databaseId.database}`
     };
     this.modifyHeadersForRequest(headers, authToken, appCheckToken);
 

--- a/packages/firestore/src/remote/rest_connection.ts
+++ b/packages/firestore/src/remote/rest_connection.ts
@@ -17,7 +17,11 @@
 
 import { SDK_VERSION } from '../../src/core/version';
 import { Token } from '../api/credentials';
-import { DatabaseId, DatabaseInfo } from '../core/database_info';
+import {
+  DatabaseId,
+  DatabaseInfo,
+  DEFAULT_DATABASE_NAME
+} from '../core/database_info';
 import { debugAssert } from '../util/assert';
 import { generateUniqueDebugId } from '../util/debug_uid';
 import { FirestoreError } from '../util/error';
@@ -86,7 +90,10 @@ export abstract class RestConnection implements Connection {
     logDebug(LOG_TAG, `Sending RPC '${rpcName}' ${streamId}:`, url, req);
 
     const headers: StringMap = {
-      'x-goog-request-params': `project_id=${this.databaseId.projectId}&database_id=${this.databaseId.database}`
+      'x-goog-request-params':
+        this.databaseId.database === DEFAULT_DATABASE_NAME
+          ? `project_id=${this.databaseId.projectId}`
+          : `project_id=${this.databaseId.projectId}&database_id=${this.databaseId.database}`
     };
     this.modifyHeadersForRequest(headers, authToken, appCheckToken);
 

--- a/packages/firestore/src/remote/rest_connection.ts
+++ b/packages/firestore/src/remote/rest_connection.ts
@@ -86,9 +86,10 @@ export abstract class RestConnection implements Connection {
     logDebug(LOG_TAG, `Sending RPC '${rpcName}' ${streamId}:`, url, req);
 
     const headers: StringMap = {
-      'x-goog-request-params':  this.databaseId.database === DEFAULT_DATABASE_NAME
-        ? `project_id=${this.databaseId.projectId}`
-        : `project_id=${this.databaseId.projectId}&database_id=${this.databaseId.database}`
+      'x-goog-request-params':
+        this.databaseId.database === DEFAULT_DATABASE_NAME
+          ? `project_id=${this.databaseId.projectId}`
+          : `project_id=${this.databaseId.projectId}&database_id=${this.databaseId.database}`
     };
     this.modifyHeadersForRequest(headers, authToken, appCheckToken);
 

--- a/packages/firestore/src/remote/rest_connection.ts
+++ b/packages/firestore/src/remote/rest_connection.ts
@@ -17,11 +17,7 @@
 
 import { SDK_VERSION } from '../../src/core/version';
 import { Token } from '../api/credentials';
-import {
-  DatabaseId,
-  DatabaseInfo,
-  DEFAULT_DATABASE_NAME
-} from '../core/database_info';
+import { DatabaseId, DatabaseInfo } from '../core/database_info';
 import { debugAssert } from '../util/assert';
 import { generateUniqueDebugId } from '../util/debug_uid';
 import { FirestoreError } from '../util/error';

--- a/packages/firestore/src/remote/rest_connection.ts
+++ b/packages/firestore/src/remote/rest_connection.ts
@@ -17,7 +17,11 @@
 
 import { SDK_VERSION } from '../../src/core/version';
 import { Token } from '../api/credentials';
-import { DatabaseId, DatabaseInfo, DEFAULT_DATABASE_NAME } from '../core/database_info';
+import {
+  DatabaseId,
+  DatabaseInfo,
+  DEFAULT_DATABASE_NAME
+} from '../core/database_info';
 import { debugAssert } from '../util/assert';
 import { generateUniqueDebugId } from '../util/debug_uid';
 import { FirestoreError } from '../util/error';

--- a/packages/firestore/src/remote/rest_connection.ts
+++ b/packages/firestore/src/remote/rest_connection.ts
@@ -85,7 +85,9 @@ export abstract class RestConnection implements Connection {
     const url = this.makeUrl(rpcName, path);
     logDebug(LOG_TAG, `Sending RPC '${rpcName}' ${streamId}:`, url, req);
 
-    const headers = {};
+    const headers = {
+      "x-goog-request-params": `project_id=${this.databaseId.projectId}&database_id=${this.databaseId.database}`
+    };
     this.modifyHeadersForRequest(headers, authToken, appCheckToken);
 
     return this.performRPCRequest<Req, Resp>(rpcName, url, headers, req).then(

--- a/packages/firestore/src/remote/rest_connection.ts
+++ b/packages/firestore/src/remote/rest_connection.ts
@@ -86,7 +86,7 @@ export abstract class RestConnection implements Connection {
     logDebug(LOG_TAG, `Sending RPC '${rpcName}' ${streamId}:`, url, req);
 
     const headers = {
-      "x-goog-request-params": `project_id=${this.databaseId.projectId}&database_id=${this.databaseId.database}`
+      'x-goog-request-params': `project_id=${this.databaseId.projectId}&database_id=${this.databaseId.database}`
     };
     this.modifyHeadersForRequest(headers, authToken, appCheckToken);
 

--- a/packages/firestore/src/remote/rest_connection.ts
+++ b/packages/firestore/src/remote/rest_connection.ts
@@ -17,7 +17,7 @@
 
 import { SDK_VERSION } from '../../src/core/version';
 import { Token } from '../api/credentials';
-import { DatabaseId, DatabaseInfo } from '../core/database_info';
+import {DatabaseId, DatabaseInfo, DEFAULT_DATABASE_NAME} from '../core/database_info';
 import { debugAssert } from '../util/assert';
 import { generateUniqueDebugId } from '../util/debug_uid';
 import { FirestoreError } from '../util/error';
@@ -85,8 +85,10 @@ export abstract class RestConnection implements Connection {
     const url = this.makeUrl(rpcName, path);
     logDebug(LOG_TAG, `Sending RPC '${rpcName}' ${streamId}:`, url, req);
 
-    const headers = {
-      'x-goog-request-params': `project_id=${this.databaseId.projectId}&database_id=${this.databaseId.database}`
+    const headers: StringMap = {
+      'x-goog-request-params':  this.databaseId.database === DEFAULT_DATABASE_NAME
+        ? `project_id=${this.databaseId.projectId}`
+        : `project_id=${this.databaseId.projectId}&database_id=${this.databaseId.database}`
     };
     this.modifyHeadersForRequest(headers, authToken, appCheckToken);
 

--- a/packages/firestore/test/unit/remote/rest_connection.test.ts
+++ b/packages/firestore/test/unit/remote/rest_connection.test.ts
@@ -96,7 +96,8 @@ describe('RestConnection', () => {
       'Content-Type': 'text/plain',
       'X-Firebase-GMPID': 'test-app-id',
       'X-Goog-Api-Client': `gl-js/ fire/${SDK_VERSION}`,
-      'x-firebase-appcheck': 'some-app-check-token'
+      'x-firebase-appcheck': 'some-app-check-token',
+      'x-goog-request-params': 'project_id=testproject&database_id=(default)'
     });
   });
 
@@ -111,7 +112,8 @@ describe('RestConnection', () => {
     expect(connection.lastHeaders).to.deep.equal({
       'Content-Type': 'text/plain',
       'X-Firebase-GMPID': 'test-app-id',
-      'X-Goog-Api-Client': `gl-js/ fire/${SDK_VERSION}`
+      'X-Goog-Api-Client': `gl-js/ fire/${SDK_VERSION}`,
+      'x-goog-request-params': 'project_id=testproject&database_id=(default)'
       // Note: AppCheck token should not exist here.
     });
   });

--- a/packages/firestore/test/unit/remote/rest_connection.test.ts
+++ b/packages/firestore/test/unit/remote/rest_connection.test.ts
@@ -97,7 +97,8 @@ describe('RestConnection', () => {
       'X-Firebase-GMPID': 'test-app-id',
       'X-Goog-Api-Client': `gl-js/ fire/${SDK_VERSION}`,
       'x-firebase-appcheck': 'some-app-check-token',
-      'x-goog-request-params': 'project_id=testproject'
+      'x-goog-request-params': 'project_id=testproject',
+      'google-cloud-resource-prefix': 'projects/testproject/databases/(default)'
     });
   });
 
@@ -113,7 +114,8 @@ describe('RestConnection', () => {
       'Content-Type': 'text/plain',
       'X-Firebase-GMPID': 'test-app-id',
       'X-Goog-Api-Client': `gl-js/ fire/${SDK_VERSION}`,
-      'x-goog-request-params': 'project_id=testproject'
+      'x-goog-request-params': 'project_id=testproject',
+      'google-cloud-resource-prefix': 'projects/testproject/databases/(default)'
       // Note: AppCheck token should not exist here.
     });
   });

--- a/packages/firestore/test/unit/remote/rest_connection.test.ts
+++ b/packages/firestore/test/unit/remote/rest_connection.test.ts
@@ -56,7 +56,7 @@ export class TestRestConnection extends RestConnection {
   }
 }
 
-describe.only('RestConnection', () => {
+describe('RestConnection', () => {
   const testDatabaseInfo = new DatabaseInfo(
     new DatabaseId('testproject'),
     'test-app-id',

--- a/packages/firestore/test/unit/remote/rest_connection.test.ts
+++ b/packages/firestore/test/unit/remote/rest_connection.test.ts
@@ -56,7 +56,7 @@ export class TestRestConnection extends RestConnection {
   }
 }
 
-describe('RestConnection', () => {
+describe.only('RestConnection', () => {
   const testDatabaseInfo = new DatabaseInfo(
     new DatabaseId('testproject'),
     'test-app-id',
@@ -97,7 +97,7 @@ describe('RestConnection', () => {
       'X-Firebase-GMPID': 'test-app-id',
       'X-Goog-Api-Client': `gl-js/ fire/${SDK_VERSION}`,
       'x-firebase-appcheck': 'some-app-check-token',
-      'x-goog-request-params': 'project_id=testproject&database_id=(default)'
+      'x-goog-request-params': 'project_id=testproject'
     });
   });
 
@@ -113,7 +113,7 @@ describe('RestConnection', () => {
       'Content-Type': 'text/plain',
       'X-Firebase-GMPID': 'test-app-id',
       'X-Goog-Api-Client': `gl-js/ fire/${SDK_VERSION}`,
-      'x-goog-request-params': 'project_id=testproject&database_id=(default)'
+      'x-goog-request-params': 'project_id=testproject'
       // Note: AppCheck token should not exist here.
     });
   });

--- a/scripts/emulator-testing/emulators/firestore-emulator.ts
+++ b/scripts/emulator-testing/emulators/firestore-emulator.ts
@@ -22,11 +22,11 @@ export class FirestoreEmulator extends Emulator {
 
   constructor(port: number, projectId = 'test-emulator') {
     super(
-      'cloud-firestore-emulator-v1.14.4.jar',
+      'cloud-firestore-emulator-v1.18.1.jar',
       // Use locked version of emulator for test to be deterministic.
       // The latest version can be found from firestore emulator doc:
       // https://firebase.google.com/docs/firestore/security/test-rules-emulator
-      'https://storage.googleapis.com/firebase-preview-drop/emulator/cloud-firestore-emulator-v1.14.4.jar',
+      'https://storage.googleapis.com/firebase-preview-drop/emulator/cloud-firestore-emulator-v1.18.1.jar',
       port
     );
     this.projectId = projectId;

--- a/scripts/emulator-testing/emulators/firestore-emulator.ts
+++ b/scripts/emulator-testing/emulators/firestore-emulator.ts
@@ -22,11 +22,11 @@ export class FirestoreEmulator extends Emulator {
 
   constructor(port: number, projectId = 'test-emulator') {
     super(
-      'cloud-firestore-emulator-v1.16.2.jar',
+      'cloud-firestore-emulator-v1.14.4.jar',
       // Use locked version of emulator for test to be deterministic.
       // The latest version can be found from firestore emulator doc:
       // https://firebase.google.com/docs/firestore/security/test-rules-emulator
-      'https://storage.googleapis.com/firebase-preview-drop/emulator/cloud-firestore-emulator-v1.16.2.jar',
+      'https://storage.googleapis.com/firebase-preview-drop/emulator/cloud-firestore-emulator-v1.14.4.jar',
       port
     );
     this.projectId = projectId;

--- a/scripts/emulator-testing/emulators/firestore-emulator.ts
+++ b/scripts/emulator-testing/emulators/firestore-emulator.ts
@@ -22,11 +22,11 @@ export class FirestoreEmulator extends Emulator {
 
   constructor(port: number, projectId = 'test-emulator') {
     super(
-      'cloud-firestore-emulator-v1.18.1.jar',
+      'cloud-firestore-emulator-v1.16.2.jar',
       // Use locked version of emulator for test to be deterministic.
       // The latest version can be found from firestore emulator doc:
       // https://firebase.google.com/docs/firestore/security/test-rules-emulator
-      'https://storage.googleapis.com/firebase-preview-drop/emulator/cloud-firestore-emulator-v1.18.1.jar',
+      'https://storage.googleapis.com/firebase-preview-drop/emulator/cloud-firestore-emulator-v1.16.2.jar',
       port
     );
     this.projectId = projectId;


### PR DESCRIPTION
Fix named databases calls to backend with REST connection that experience error:

> Missing routing header. Please fill in the request header with format x-goog-request-params:project_id=mrenshaw-multi-db&database_id=my-database