### PR TITLE
Update Auth to use PasswordPolicyImpl for validation

### DIFF
--- a/common/api-review/auth.api.md
+++ b/common/api-review/auth.api.md
@@ -564,7 +564,7 @@ export interface ParsedToken {
 
 // @public
 export interface PasswordPolicy {
-    readonly allowedNonAlphanumericCharacters?: string[];
+    readonly allowedNonAlphanumericCharacters: string[];
     readonly customStrengthOptions: {
         readonly minPasswordLength?: number;
         readonly maxPasswordLength?: number;

--- a/packages/auth/src/core/auth/auth_impl.test.ts
+++ b/packages/auth/src/core/auth/auth_impl.test.ts
@@ -854,7 +854,7 @@ describe('core/auth/auth_impl', () => {
       auth.tenantId = null;
       await auth._updatePasswordPolicy();
 
-      expect(auth._getPasswordPolicy()).to.eql(CACHED_PASSWORD_POLICY);
+      expect(auth._getPasswordPolicyInternal()).to.eql(CACHED_PASSWORD_POLICY);
     });
 
     it('password policy should be set for tenant if tenant ID is not null', async () => {
@@ -862,7 +862,7 @@ describe('core/auth/auth_impl', () => {
       auth.tenantId = TEST_TENANT_ID;
       await auth._updatePasswordPolicy();
 
-      expect(auth._getPasswordPolicy()).to.eql(
+      expect(auth._getPasswordPolicyInternal()).to.eql(
         CACHED_PASSWORD_POLICY_REQUIRE_NUMERIC
       );
     });
@@ -876,13 +876,13 @@ describe('core/auth/auth_impl', () => {
       await auth._updatePasswordPolicy();
 
       auth.tenantId = null;
-      expect(auth._getPasswordPolicy()).to.eql(CACHED_PASSWORD_POLICY);
+      expect(auth._getPasswordPolicyInternal()).to.eql(CACHED_PASSWORD_POLICY);
       auth.tenantId = TEST_TENANT_ID;
-      expect(auth._getPasswordPolicy()).to.eql(
+      expect(auth._getPasswordPolicyInternal()).to.eql(
         CACHED_PASSWORD_POLICY_REQUIRE_NUMERIC
       );
       auth.tenantId = 'other-tenant-id';
-      expect(auth._getPasswordPolicy()).to.be.undefined;
+      expect(auth._getPasswordPolicyInternal()).to.be.undefined;
     });
 
     it('password policy should not be set when the schema version is not supported', async () => {
@@ -892,7 +892,7 @@ describe('core/auth/auth_impl', () => {
         AuthErrorCode.UNSUPPORTED_PASSWORD_POLICY_SCHEMA_VERSION
       );
 
-      expect(auth._getPasswordPolicy()).to.be.undefined;
+      expect(auth._getPasswordPolicyInternal()).to.be.undefined;
     });
   });
 });

--- a/packages/auth/src/core/auth/auth_impl.test.ts
+++ b/packages/auth/src/core/auth/auth_impl.test.ts
@@ -790,23 +790,27 @@ describe('core/auth/auth_impl', () => {
   context('passwordPolicy', () => {
     const TEST_ALLOWED_NON_ALPHANUMERIC_CHARS = ['!', '(', ')'];
     const TEST_MIN_PASSWORD_LENGTH = 6;
+    const TEST_SCHEMA_VERSION = 1;
+    const TEST_TENANT_ID = 'tenant-id';
+    const TEST_TENANT_ID_UNSUPPORTED_POLICY_VERSION =
+      'tenant-id-unsupported-policy-version';
 
-    const passwordPolicyResponse = {
+    const PASSWORD_POLICY_RESPONSE = {
       customStrengthOptions: {
         minPasswordLength: TEST_MIN_PASSWORD_LENGTH
       },
       allowedNonAlphanumericCharacters: TEST_ALLOWED_NON_ALPHANUMERIC_CHARS,
-      schemaVersion: 1
+      schemaVersion: TEST_SCHEMA_VERSION
     };
-    const passwordPolicyResponseRequireNumeric = {
+    const PASSWORD_POLICY_RESPONSE_REQUIRE_NUMERIC = {
       customStrengthOptions: {
         minPasswordLength: TEST_MIN_PASSWORD_LENGTH,
         containsNumericCharacter: true
       },
       allowedNonAlphanumericCharacters: TEST_ALLOWED_NON_ALPHANUMERIC_CHARS,
-      schemaVersion: 1
+      schemaVersion: TEST_SCHEMA_VERSION
     };
-    const passwordPolicyResponseUnsupportedVersion = {
+    const PASSWORD_POLICY_RESPONSE_UNSUPPORTED_VERSION = {
       customStrengthOptions: {
         maxPasswordLength: TEST_MIN_PASSWORD_LENGTH,
         unsupportedPasswordPolicyProperty: 10
@@ -814,40 +818,30 @@ describe('core/auth/auth_impl', () => {
       allowedNonAlphanumericCharacters: TEST_ALLOWED_NON_ALPHANUMERIC_CHARS,
       schemaVersion: 0
     };
-    const cachedPasswordPolicy = {
-      customStrengthOptions: {
-        minPasswordLength: TEST_MIN_PASSWORD_LENGTH
-      },
-      allowedNonAlphanumericCharacters: TEST_ALLOWED_NON_ALPHANUMERIC_CHARS
-    };
-    const cachedPasswordPolicyRequireNumeric = {
-      customStrengthOptions: {
-        minPasswordLength: TEST_MIN_PASSWORD_LENGTH,
-        containsNumericCharacter: true
-      },
-      allowedNonAlphanumericCharacters: TEST_ALLOWED_NON_ALPHANUMERIC_CHARS
-    };
+    const CACHED_PASSWORD_POLICY = PASSWORD_POLICY_RESPONSE;
+    const CACHED_PASSWORD_POLICY_REQUIRE_NUMERIC =
+      PASSWORD_POLICY_RESPONSE_REQUIRE_NUMERIC;
 
     beforeEach(async () => {
       mockFetch.setUp();
       mockEndpointWithParams(
         Endpoint.GET_PASSWORD_POLICY,
         {},
-        passwordPolicyResponse
+        PASSWORD_POLICY_RESPONSE
       );
       mockEndpointWithParams(
         Endpoint.GET_PASSWORD_POLICY,
         {
-          tenantId: 'tenant-id'
+          tenantId: TEST_TENANT_ID
         },
-        passwordPolicyResponseRequireNumeric
+        PASSWORD_POLICY_RESPONSE_REQUIRE_NUMERIC
       );
       mockEndpointWithParams(
         Endpoint.GET_PASSWORD_POLICY,
         {
-          tenantId: 'tenant-id-with-unsupported-policy-version'
+          tenantId: TEST_TENANT_ID_UNSUPPORTED_POLICY_VERSION
         },
-        passwordPolicyResponseUnsupportedVersion
+        PASSWORD_POLICY_RESPONSE_UNSUPPORTED_VERSION
       );
     });
 
@@ -860,16 +854,16 @@ describe('core/auth/auth_impl', () => {
       auth.tenantId = null;
       await auth._updatePasswordPolicy();
 
-      expect(auth._getPasswordPolicy()).to.eql(cachedPasswordPolicy);
+      expect(auth._getPasswordPolicy()).to.eql(CACHED_PASSWORD_POLICY);
     });
 
     it('password policy should be set for tenant if tenant ID is not null', async () => {
       auth = await testAuth();
-      auth.tenantId = 'tenant-id';
+      auth.tenantId = TEST_TENANT_ID;
       await auth._updatePasswordPolicy();
 
       expect(auth._getPasswordPolicy()).to.eql(
-        cachedPasswordPolicyRequireNumeric
+        CACHED_PASSWORD_POLICY_REQUIRE_NUMERIC
       );
     });
 
@@ -878,14 +872,14 @@ describe('core/auth/auth_impl', () => {
       auth.tenantId = null;
       await auth._updatePasswordPolicy();
 
-      auth.tenantId = 'tenant-id';
+      auth.tenantId = TEST_TENANT_ID;
       await auth._updatePasswordPolicy();
 
       auth.tenantId = null;
-      expect(auth._getPasswordPolicy()).to.eql(cachedPasswordPolicy);
-      auth.tenantId = 'tenant-id';
+      expect(auth._getPasswordPolicy()).to.eql(CACHED_PASSWORD_POLICY);
+      auth.tenantId = TEST_TENANT_ID;
       expect(auth._getPasswordPolicy()).to.eql(
-        cachedPasswordPolicyRequireNumeric
+        CACHED_PASSWORD_POLICY_REQUIRE_NUMERIC
       );
       auth.tenantId = 'other-tenant-id';
       expect(auth._getPasswordPolicy()).to.be.undefined;
@@ -893,7 +887,7 @@ describe('core/auth/auth_impl', () => {
 
     it('password policy should not be set when the schema version is not supported', async () => {
       auth = await testAuth();
-      auth.tenantId = 'tenant-id-with-unsupported-policy-version';
+      auth.tenantId = TEST_TENANT_ID_UNSUPPORTED_POLICY_VERSION;
       await expect(auth._updatePasswordPolicy()).to.be.rejectedWith(
         AuthErrorCode.UNSUPPORTED_PASSWORD_POLICY_SCHEMA_VERSION
       );

--- a/packages/auth/src/core/auth/auth_impl.ts
+++ b/packages/auth/src/core/auth/auth_impl.ts
@@ -430,14 +430,14 @@ export class AuthImpl implements AuthInternal, _FirebaseService {
   }
 
   async validatePassword(password: string): Promise<PasswordValidationStatus> {
-    if (!this._getPasswordPolicy()) {
+    if (!this._getPasswordPolicyInternal()) {
       await this._updatePasswordPolicy();
     }
 
-    return this._getPasswordPolicy()!.validatePassword(password);
+    return this._getPasswordPolicyInternal()!.validatePassword(password);
   }
 
-  _getPasswordPolicy(): PasswordPolicyInternal | null {
+  _getPasswordPolicyInternal(): PasswordPolicyInternal | null {
     if (this.tenantId === null) {
       return this._projectPasswordPolicy;
     } else {

--- a/packages/auth/src/core/auth/auth_impl.ts
+++ b/packages/auth/src/core/auth/auth_impl.ts
@@ -32,7 +32,6 @@ import {
   ErrorFn,
   NextFn,
   Unsubscribe,
-  PasswordPolicy,
   PasswordValidationStatus
 } from '../../model/public_types';
 import {
@@ -70,6 +69,8 @@ import { AuthMiddlewareQueue } from './middleware';
 import { RecaptchaConfig } from '../../platform_browser/recaptcha/recaptcha';
 import { _logWarn } from '../util/log';
 import { _getPasswordPolicy } from '../../api/password_policy/get_password_policy';
+import { PasswordPolicyInternal } from '../../model/password_policy';
+import { PasswordPolicyImpl } from './password_policy_impl';
 
 interface AsyncAction {
   (): Promise<void>;
@@ -105,8 +106,8 @@ export class AuthImpl implements AuthInternal, _FirebaseService {
     _DEFAULT_AUTH_ERROR_FACTORY;
   _agentRecaptchaConfig: RecaptchaConfig | null = null;
   _tenantRecaptchaConfigs: Record<string, RecaptchaConfig> = {};
-  _projectPasswordPolicy: PasswordPolicy | null = null;
-  _tenantPasswordPolicies: Record<string, PasswordPolicy> = {};
+  _projectPasswordPolicy: PasswordPolicyInternal | null = null;
+  _tenantPasswordPolicies: Record<string, PasswordPolicyInternal> = {};
   readonly name: string;
 
   // Tracks the last notified UID for state change listeners to prevent
@@ -429,11 +430,14 @@ export class AuthImpl implements AuthInternal, _FirebaseService {
   }
 
   async validatePassword(password: string): Promise<PasswordValidationStatus> {
-    // TODO(chazzy): Implement.
-    return Promise.reject(password);
+    if (!this._getPasswordPolicy()) {
+      await this._updatePasswordPolicy();
+    }
+
+    return this._getPasswordPolicy()!.validatePassword(password);
   }
 
-  _getPasswordPolicy(): PasswordPolicy | null {
+  _getPasswordPolicy(): PasswordPolicyInternal | null {
     if (this.tenantId === null) {
       return this._projectPasswordPolicy;
     } else {
@@ -457,11 +461,9 @@ export class AuthImpl implements AuthInternal, _FirebaseService {
       );
     }
 
-    const passwordPolicy: PasswordPolicy = {
-      customStrengthOptions: response.customStrengthOptions,
-      allowedNonAlphanumericCharacters:
-        response.allowedNonAlphanumericCharacters
-    };
+    const passwordPolicy: PasswordPolicyInternal = new PasswordPolicyImpl(
+      response
+    );
 
     if (this.tenantId === null) {
       this._projectPasswordPolicy = passwordPolicy;

--- a/packages/auth/src/core/strategies/email_and_password.test.ts
+++ b/packages/auth/src/core/strategies/email_and_password.test.ts
@@ -757,14 +757,14 @@ describe('core/strategies/email_and_password/createUserWithEmailAndPassword', ()
     const PASSWORD_ERROR_MSG =
       'Firebase: The password does not meet the requirements. (auth/password-does-not-meet-requirements).';
 
-    const passwordPolicyResponse = {
+    const PASSWORD_POLICY_RESPONSE = {
       customStrengthOptions: {
         minPasswordLength: TEST_MIN_PASSWORD_LENGTH
       },
       allowedNonAlphanumericCharacters: TEST_ALLOWED_NON_ALPHANUMERIC_CHARS,
       schemaVersion: TEST_SCHEMA_VERSION
     };
-    const passwordPolicyResponseRequireNumeric = {
+    const PASSWORD_POLICY_RESPONSE_REQUIRE_NUMERIC = {
       customStrengthOptions: {
         minPasswordLength: TEST_MIN_PASSWORD_LENGTH,
         containsNumericCharacter: true
@@ -772,19 +772,9 @@ describe('core/strategies/email_and_password/createUserWithEmailAndPassword', ()
       allowedNonAlphanumericCharacters: TEST_ALLOWED_NON_ALPHANUMERIC_CHARS,
       schemaVersion: TEST_SCHEMA_VERSION
     };
-    const cachedPasswordPolicy = {
-      customStrengthOptions: {
-        minPasswordLength: TEST_MIN_PASSWORD_LENGTH
-      },
-      allowedNonAlphanumericCharacters: TEST_ALLOWED_NON_ALPHANUMERIC_CHARS
-    };
-    const cachedPasswordPolicyRequireNumeric = {
-      customStrengthOptions: {
-        minPasswordLength: TEST_MIN_PASSWORD_LENGTH,
-        containsNumericCharacter: true
-      },
-      allowedNonAlphanumericCharacters: TEST_ALLOWED_NON_ALPHANUMERIC_CHARS
-    };
+    const CACHED_PASSWORD_POLICY = PASSWORD_POLICY_RESPONSE;
+    const CACHED_PASSWORD_POLICY_REQUIRE_NUMERIC =
+      PASSWORD_POLICY_RESPONSE_REQUIRE_NUMERIC;
     let policyEndpointMock: mockFetch.Route;
     let policyEndpointMockWithTenant: mockFetch.Route;
     let policyEndpointMockWithOtherTenant: mockFetch.Route;
@@ -793,21 +783,21 @@ describe('core/strategies/email_and_password/createUserWithEmailAndPassword', ()
       policyEndpointMock = mockEndpointWithParams(
         Endpoint.GET_PASSWORD_POLICY,
         {},
-        passwordPolicyResponse
+        PASSWORD_POLICY_RESPONSE
       );
       policyEndpointMockWithTenant = mockEndpointWithParams(
         Endpoint.GET_PASSWORD_POLICY,
         {
           tenantId: TEST_TENANT_ID
         },
-        passwordPolicyResponse
+        PASSWORD_POLICY_RESPONSE
       );
       policyEndpointMockWithOtherTenant = mockEndpointWithParams(
         Endpoint.GET_PASSWORD_POLICY,
         {
           tenantId: TEST_REQUIRE_NUMERIC_TENANT_ID
         },
-        passwordPolicyResponseRequireNumeric
+        PASSWORD_POLICY_RESPONSE_REQUIRE_NUMERIC
       );
     });
 
@@ -828,7 +818,7 @@ describe('core/strategies/email_and_password/createUserWithEmailAndPassword', ()
       ).to.be.fulfilled;
 
       expect(policyEndpointMock.calls.length).to.eq(1);
-      expect(auth._getPasswordPolicy()).to.eql(cachedPasswordPolicy);
+      expect(auth._getPasswordPolicy()).to.eql(CACHED_PASSWORD_POLICY);
     });
 
     context('handles password validation errors', () => {
@@ -848,17 +838,17 @@ describe('core/strategies/email_and_password/createUserWithEmailAndPassword', ()
       it('updates the cached password policy when password does not meet backend requirements', async () => {
         await auth._updatePasswordPolicy();
         expect(policyEndpointMock.calls.length).to.eq(1);
-        expect(auth._getPasswordPolicy()).to.eql(cachedPasswordPolicy);
+        expect(auth._getPasswordPolicy()).to.eql(CACHED_PASSWORD_POLICY);
 
         // Password policy changed after previous fetch.
-        policyEndpointMock.response = passwordPolicyResponseRequireNumeric;
+        policyEndpointMock.response = PASSWORD_POLICY_RESPONSE_REQUIRE_NUMERIC;
         await expect(
           createUserWithEmailAndPassword(auth, 'some-email', 'some-password')
         ).to.be.rejectedWith(FirebaseError, PASSWORD_ERROR_MSG);
 
         expect(policyEndpointMock.calls.length).to.eq(2);
         expect(auth._getPasswordPolicy()).to.eql(
-          cachedPasswordPolicyRequireNumeric
+          CACHED_PASSWORD_POLICY_REQUIRE_NUMERIC
         );
       });
 
@@ -877,7 +867,7 @@ describe('core/strategies/email_and_password/createUserWithEmailAndPassword', ()
         auth.tenantId = TEST_TENANT_ID;
         await auth._updatePasswordPolicy();
         expect(policyEndpointMockWithTenant.calls.length).to.eq(1);
-        expect(auth._getPasswordPolicy()).to.eql(cachedPasswordPolicy);
+        expect(auth._getPasswordPolicy()).to.eql(CACHED_PASSWORD_POLICY);
 
         auth.tenantId = TEST_REQUIRE_NUMERIC_TENANT_ID;
         await expect(

--- a/packages/auth/src/core/strategies/email_and_password.ts
+++ b/packages/auth/src/core/strategies/email_and_password.ts
@@ -313,7 +313,7 @@ export async function createUserWithEmailAndPassword(
         if (
           error.code ===
             `auth/${AuthErrorCode.PASSWORD_DOES_NOT_MEET_REQUIREMENTS}` &&
-          authInternal._getPasswordPolicy()
+          authInternal._getPasswordPolicyInternal()
         ) {
           await authInternal._updatePasswordPolicy();
         }

--- a/packages/auth/src/model/auth.ts
+++ b/packages/auth/src/model/auth.ts
@@ -88,7 +88,7 @@ export interface AuthInternal extends Auth {
   _stopProactiveRefresh(): void;
   _getPersistence(): string;
   _getRecaptchaConfig(): RecaptchaConfig | null;
-  _getPasswordPolicy(): PasswordPolicyInternal | null;
+  _getPasswordPolicyInternal(): PasswordPolicyInternal | null;
   _updatePasswordPolicy(): Promise<void>;
   _logFramework(framework: string): void;
   _getFrameworks(): readonly string[];

--- a/packages/auth/src/model/auth.ts
+++ b/packages/auth/src/model/auth.ts
@@ -32,6 +32,7 @@ import { PopupRedirectResolverInternal } from './popup_redirect';
 import { UserInternal } from './user';
 import { ClientPlatform } from '../core/util/version';
 import { RecaptchaConfig } from '../platform_browser/recaptcha/recaptcha';
+import { PasswordPolicyInternal } from './password_policy';
 
 export type AppName = string;
 export type ApiKey = string;
@@ -87,7 +88,7 @@ export interface AuthInternal extends Auth {
   _stopProactiveRefresh(): void;
   _getPersistence(): string;
   _getRecaptchaConfig(): RecaptchaConfig | null;
-  _getPasswordPolicy(): PasswordPolicy | null;
+  _getPasswordPolicy(): PasswordPolicyInternal | null;
   _updatePasswordPolicy(): Promise<void>;
   _logFramework(framework: string): void;
   _getFrameworks(): readonly string[];


### PR DESCRIPTION
Update AuthImpl to use the internal `PasswordPolicyImpl` for performing password validation. Also, update test cases to include fields used in the policy internally.