### PR TITLE
Unpin version for React Native async storage dependency

### DIFF
--- a/.changeset/odd-bats-hug.md
+++ b/.changeset/odd-bats-hug.md
@@ -1,0 +1,5 @@
+---
+'@firebase/auth': patch
+---
+
+Unpin `@react-native-async-storage/async-storage` dependency to give users more control over the exact version.

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -109,7 +109,7 @@
     "@firebase/component": "0.6.4",
     "@firebase/logger": "0.4.0",
     "@firebase/util": "1.9.3",
-    "@react-native-async-storage/async-storage": "1.17.12",
+    "@react-native-async-storage/async-storage": "^1.18.1",
     "node-fetch": "2.6.7",
     "tslib": "^2.1.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3070,10 +3070,10 @@
   resolved "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
   integrity sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA=
 
-"@react-native-async-storage/async-storage@1.17.12":
-  version "1.17.12"
-  resolved "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-1.17.12.tgz#a39e4df5b06795ce49b2ca5b7ca9b8faadf8e621"
-  integrity sha512-BXg4OxFdjPTRt+8MvN6jz4muq0/2zII3s7HeT/11e4Zeh3WCgk/BleLzUcDfVqF3OzFHUqEkSrb76d6Ndjd/Nw==
+"@react-native-async-storage/async-storage@^1.18.1":
+  version "1.19.0"
+  resolved "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-1.19.0.tgz#594aca9c20924b7955d62cf43797b4187e1e6cf8"
+  integrity sha512-xOFkz/FaQctD6yNJDur+WnHdSTigOs3pTz6HmfC8X8PYwcnnN3R9UxuWiwsfK8vvT2WioAxUkQt3lB7GySNA2w==
   dependencies:
     merge-options "^3.0.4"
 


### PR DESCRIPTION
Fixes https://github.com/firebase/firebase-js-sdk/issues/7448

This gives React Native users more flexibility over the exact version of `@react-native-async-storage/async-storage` to be used in their project.