### PR TITLE
Include the character option statuses even when an empty string is inputted to validatePassword

### DIFF
--- a/packages/auth/src/core/auth/password_policy_impl.test.ts
+++ b/packages/auth/src/core/auth/password_policy_impl.test.ts
@@ -60,6 +60,15 @@ describe('core/auth/password_policy_impl', () => {
     allowedNonAlphanumericCharacters: TEST_ALLOWED_NON_ALPHANUMERIC_CHARS,
     schemaVersion: TEST_SCHEMA_VERSION
   };
+  const PASSWORD_POLICY_RESPONSE_REQUIRE_NUMERIC: GetPasswordPolicyResponse = {
+    customStrengthOptions: {
+      minPasswordLength: TEST_MIN_PASSWORD_LENGTH,
+      maxPasswordLength: TEST_MAX_PASSWORD_LENGTH,
+      containsNumericCharacter: TEST_CONTAINS_NUMERIC
+    },
+    allowedNonAlphanumericCharacters: TEST_ALLOWED_NON_ALPHANUMERIC_CHARS,
+    schemaVersion: TEST_SCHEMA_VERSION
+  };
   const PASSWORD_POLICY_REQUIRE_ALL: PasswordPolicy = {
     customStrengthOptions: {
       minPasswordLength: TEST_MIN_PASSWORD_LENGTH,
@@ -78,6 +87,7 @@ describe('core/auth/password_policy_impl', () => {
     },
     allowedNonAlphanumericCharacters: TEST_ALLOWED_NON_ALPHANUMERIC_STRING
   };
+  const TEST_EMPTY_PASSWORD = '';
 
   context('#PasswordPolicyImpl', () => {
     it('can construct the password policy from the backend response', () => {
@@ -125,6 +135,9 @@ describe('core/auth/password_policy_impl', () => {
       );
       const PASSWORD_POLICY_IMPL_REQUIRE_LENGTH = new PasswordPolicyImpl(
         PASSWORD_POLICY_RESPONSE_REQUIRE_LENGTH
+      );
+      const PASSWORD_POLICY_IMPL_REQUIRE_NUMERIC = new PasswordPolicyImpl(
+        PASSWORD_POLICY_RESPONSE_REQUIRE_NUMERIC
       );
 
       it('password that is too short is considered invalid', async () => {
@@ -292,6 +305,38 @@ describe('core/auth/password_policy_impl', () => {
         expect(status.containsLowercaseLetter).to.be.undefined;
         expect(status.containsUppercaseLetter).to.be.undefined;
         expect(status.containsNumericCharacter).to.be.undefined;
+        expect(status.containsNonAlphanumericCharacter).to.be.undefined;
+      });
+
+      it('should include statuses for requirements included in the policy when the password is an empty string', async () => {
+        let policy = PASSWORD_POLICY_IMPL_REQUIRE_ALL;
+        let expectedValidationStatus: PasswordValidationStatus = {
+          isValid: false,
+          meetsMinPasswordLength: false,
+          meetsMaxPasswordLength: true,
+          containsLowercaseLetter: false,
+          containsUppercaseLetter: false,
+          containsNumericCharacter: false,
+          containsNonAlphanumericCharacter: false,
+          passwordPolicy: policy
+        };
+
+        let status = policy.validatePassword(TEST_EMPTY_PASSWORD);
+        expect(status).to.eql(expectedValidationStatus);
+
+        policy = PASSWORD_POLICY_IMPL_REQUIRE_NUMERIC;
+        expectedValidationStatus = {
+          isValid: false,
+          meetsMinPasswordLength: false,
+          meetsMaxPasswordLength: true,
+          containsNumericCharacter: false,
+          passwordPolicy: policy
+        };
+
+        status = policy.validatePassword(TEST_EMPTY_PASSWORD);
+        expect(status).to.eql(expectedValidationStatus);
+        expect(status.containsLowercaseLetter).to.be.undefined;
+        expect(status.containsUppercaseLetter).to.be.undefined;
         expect(status.containsNonAlphanumericCharacter).to.be.undefined;
       });
     });

--- a/packages/auth/src/core/auth/password_policy_impl.ts
+++ b/packages/auth/src/core/auth/password_policy_impl.ts
@@ -118,25 +118,63 @@ export class PasswordPolicyImpl implements PasswordPolicyInternal {
     password: string,
     status: PasswordValidationStatusInternal
   ): void {
+    // Assign statuses for requirements even if the password is an empty string.
+    this.updatePasswordCharacterOptionsStasuses(
+      status,
+      /* containsLowercaseCharacter= */ false,
+      /** containsUppercaseCharacter= */ false,
+      /** containsNumericCharacter= */ false,
+      /** containsNonAlphanumericCharacter= */ false
+    );
+
     let passwordChar;
     for (let i = 0; i < password.length; i++) {
       passwordChar = password.charAt(i);
-      if (this.customStrengthOptions.containsLowercaseLetter) {
-        status.containsLowercaseLetter ||=
-          passwordChar >= 'a' && passwordChar <= 'z';
-      }
-      if (this.customStrengthOptions.containsUppercaseLetter) {
-        status.containsUppercaseLetter ||=
-          passwordChar >= 'A' && passwordChar <= 'Z';
-      }
-      if (this.customStrengthOptions.containsNumericCharacter) {
-        status.containsNumericCharacter ||=
-          passwordChar >= '0' && passwordChar <= '9';
-      }
-      if (this.customStrengthOptions.containsNonAlphanumericCharacter) {
-        status.containsNonAlphanumericCharacter ||=
-          this.allowedNonAlphanumericCharacters.includes(passwordChar);
-      }
+      this.updatePasswordCharacterOptionsStasuses(
+        status,
+        /* containsLowercaseCharacter= */ passwordChar >= 'a' &&
+          passwordChar <= 'z',
+        /** containsUppercaseCharacter= */ passwordChar >= 'A' &&
+          passwordChar <= 'Z',
+        /** containsNumericCharacter= */ passwordChar >= '0' &&
+          passwordChar <= '9',
+        /** containsNonAlphanumericCharacter= */ this.allowedNonAlphanumericCharacters.includes(
+          passwordChar
+        )
+      );
+    }
+  }
+
+  /**
+   * Updates the running validation status with the statuses for the character options.
+   * Expected to be called each time a character is processed to update each option status
+   * based on the current character.
+   *
+   * @param status Validation status.
+   * @param containsLowercaseCharacter Whether the character is a lowercase letter.
+   * @param containsUppercaseCharacter Whether the character is an uppercase letter.
+   * @param containsNumericCharacter Whether the character is a numeric character.
+   * @param containsNonAlphanumericCharacter Whether the character is a non-alphanumeric character.
+   */
+  private updatePasswordCharacterOptionsStasuses(
+    status: PasswordValidationStatusInternal,
+    containsLowercaseCharacter: boolean,
+    containsUppercaseCharacter: boolean,
+    containsNumericCharacter: boolean,
+    containsNonAlphanumericCharacter: boolean
+  ): void {
+    if (this.customStrengthOptions.containsLowercaseLetter) {
+      status.containsLowercaseLetter ||= containsLowercaseCharacter;
+    }
+    if (this.customStrengthOptions.containsUppercaseLetter) {
+      status.containsUppercaseLetter ||= containsUppercaseCharacter;
+    }
+    if (this.customStrengthOptions.containsNumericCharacter) {
+      status.containsNumericCharacter ||= containsNumericCharacter;
+    }
+    if (this.customStrengthOptions.containsNonAlphanumericCharacter) {
+      status.containsNonAlphanumericCharacter ||=
+        containsNonAlphanumericCharacter;
     }
   }
 }

--- a/packages/auth/src/core/auth/password_policy_impl.ts
+++ b/packages/auth/src/core/auth/password_policy_impl.ts
@@ -122,9 +122,9 @@ export class PasswordPolicyImpl implements PasswordPolicyInternal {
     this.updatePasswordCharacterOptionsStasuses(
       status,
       /* containsLowercaseCharacter= */ false,
-      /** containsUppercaseCharacter= */ false,
-      /** containsNumericCharacter= */ false,
-      /** containsNonAlphanumericCharacter= */ false
+      /* containsUppercaseCharacter= */ false,
+      /* containsNumericCharacter= */ false,
+      /* containsNonAlphanumericCharacter= */ false
     );
 
     let passwordChar;
@@ -134,11 +134,11 @@ export class PasswordPolicyImpl implements PasswordPolicyInternal {
         status,
         /* containsLowercaseCharacter= */ passwordChar >= 'a' &&
           passwordChar <= 'z',
-        /** containsUppercaseCharacter= */ passwordChar >= 'A' &&
+        /* containsUppercaseCharacter= */ passwordChar >= 'A' &&
           passwordChar <= 'Z',
-        /** containsNumericCharacter= */ passwordChar >= '0' &&
+        /* containsNumericCharacter= */ passwordChar >= '0' &&
           passwordChar <= '9',
-        /** containsNonAlphanumericCharacter= */ this.allowedNonAlphanumericCharacters.includes(
+        /* containsNonAlphanumericCharacter= */ this.allowedNonAlphanumericCharacters.includes(
           passwordChar
         )
       );


### PR DESCRIPTION
Fix validatePasswordCharacterOptions to include the character options statuses even when an empty string is inputted.