### PR TITLE
Run E2E tests on canary releases

### DIFF
--- a/.github/workflows/canary-deploy.yml
+++ b/.github/workflows/canary-deploy.yml
@@ -76,3 +76,15 @@ jobs:
         NPM_TOKEN_APP_CHECK_COMPAT: ${{ secrets.NPM_TOKEN_APP_CHECK_COMPAT }}
         NPM_TOKEN_API_DOCUMENTER: ${{ secrets.NPM_TOKEN_API_DOCUMENTER }}
         CI: true
+    - name: Launch E2E tests workflow
+      # Trigger e2e-test.yml
+      run: |
+        VERSION_SCRIPT="const pkg = require('./packages/firebase/package.json'); console.log(pkg.version);"
+        VERSION_OR_TAG=`node -e "${VERSION_SCRIPT}"`
+        OSS_BOT_GITHUB_TOKEN=${{ secrets.OSS_BOT_GITHUB_TOKEN }}
+        curl -X POST \
+        -H "Content-Type:application/json" \
+        -H "Accept:application/vnd.github.v3+json" \
+        -H "Authorization:Bearer $OSS_BOT_GITHUB_TOKEN" \
+        -d "{\"event_type\":\"canary-tests\", \"client_payload\":{\"versionOrTag\":\"$VERSION_OR_TAG\"}}" \
+        https://api.github.com/repos/firebase/firebase-js-sdk/dispatches

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -3,7 +3,7 @@ name: E2E Smoke Tests
 # Allows REST trigger. Currently triggered by release-cli script during a staging run.
 on:
   repository_dispatch:
-    types: [staging-tests]
+    types: [staging-tests,canary-tests]
 
 jobs:
   test:
@@ -62,6 +62,8 @@ jobs:
       - name: Tests succeeded
         if: success()
         run: node scripts/ci/notify-test-result.js success
+        # we don't want THIS step erroring to trigger the failure notification
+        continue-on-error: true
         env:
           WEBHOOK_URL: ${{ secrets.JSCORE_CHAT_WEBHOOK_URL }}
           RELEASE_TRACKER_URL: ${{ secrets.RELEASE_TRACKER_URL }}


### PR DESCRIPTION
E2E tests are running on staging release and have already caught some key bugs, but staging is pretty late in the process to fix bugs. Because E2E runs on published NPM versions to test that the NPM publish/install process works, it can't be run on CI checks on PRs. The next best thing is to run it on canary builds, which are published every time a PR is merged to master.

I added an additional event type ("canary-tests") accepted by the e2e workflow so that in the future it can maybe handle notifications differently depending on if it's the staging tests or canary tests, but that's a TODO. For now all the notifications go to the "Firebase JS Core SDK Team" chat, which pretty much only consists of automated notifications.