### PR TITLE
Add enforcementState and forceUpgradeOnSignin to PasswordPolicy type

### DIFF
--- a/common/api-review/auth.api.md
+++ b/common/api-review/auth.api.md
@@ -573,6 +573,8 @@ export interface PasswordPolicy {
         readonly containsNumericCharacter?: boolean;
         readonly containsNonAlphanumericCharacter?: boolean;
     };
+    readonly enforcementState: string;
+    readonly forceUpgradeOnSignin: boolean;
 }
 
 // @public

--- a/docs-devsite/auth.passwordpolicy.md
+++ b/docs-devsite/auth.passwordpolicy.md
@@ -24,6 +24,8 @@ export interface PasswordPolicy
 |  --- | --- | --- |
 |  [allowedNonAlphanumericCharacters](./auth.passwordpolicy.md#passwordpolicyallowednonalphanumericcharacters) | string | List of characters that are considered non-alphanumeric during validation. |
 |  [customStrengthOptions](./auth.passwordpolicy.md#passwordpolicycustomstrengthoptions) | { readonly minPasswordLength?: number; readonly maxPasswordLength?: number; readonly containsLowercaseLetter?: boolean; readonly containsUppercaseLetter?: boolean; readonly containsNumericCharacter?: boolean; readonly containsNonAlphanumericCharacter?: boolean; } | Requirements enforced by this password policy. |
+|  [enforcementState](./auth.passwordpolicy.md#passwordpolicyenforcementstate) | string | The enforcement state of the policy. Can be 'OFF' or 'ENFORCE'. |
+|  [forceUpgradeOnSignin](./auth.passwordpolicy.md#passwordpolicyforceupgradeonsignin) | boolean | Whether existing passwords must meet the policy. |
 
 ## PasswordPolicy.allowedNonAlphanumericCharacters
 
@@ -50,4 +52,24 @@ readonly customStrengthOptions: {
         readonly containsNumericCharacter?: boolean;
         readonly containsNonAlphanumericCharacter?: boolean;
     };
+```
+
+## PasswordPolicy.enforcementState
+
+The enforcement state of the policy. Can be 'OFF' or 'ENFORCE'.
+
+<b>Signature:</b>
+
+```typescript
+readonly enforcementState: string;
+```
+
+## PasswordPolicy.forceUpgradeOnSignin
+
+Whether existing passwords must meet the policy.
+
+<b>Signature:</b>
+
+```typescript
+readonly forceUpgradeOnSignin: boolean;
 ```

--- a/packages/auth/src/api/password_policy/get_password_policy.ts
+++ b/packages/auth/src/api/password_policy/get_password_policy.ts
@@ -43,6 +43,8 @@ export interface GetPasswordPolicyResponse {
     containsNonAlphanumericCharacter?: boolean;
   };
   allowedNonAlphanumericCharacters: string[];
+  enforcementState: string;
+  forceUpgradeOnSignin?: boolean;
   schemaVersion: number;
 }
 

--- a/packages/auth/src/core/auth/auth_impl.test.ts
+++ b/packages/auth/src/core/auth/auth_impl.test.ts
@@ -794,6 +794,8 @@ describe('core/auth/auth_impl', () => {
     const TEST_ALLOWED_NON_ALPHANUMERIC_STRING =
       TEST_ALLOWED_NON_ALPHANUMERIC_CHARS.join('');
     const TEST_MIN_PASSWORD_LENGTH = 6;
+    const TEST_ENFORCEMENT_STATE = 'ENFORCE';
+    const TEST_FORCE_UPGRADE_ON_SIGN_IN = false;
     const TEST_SCHEMA_VERSION = 1;
     const TEST_UNSUPPORTED_SCHEMA_VERSION = 0;
     const TEST_TENANT_ID = 'tenant-id';
@@ -805,6 +807,7 @@ describe('core/auth/auth_impl', () => {
         minPasswordLength: TEST_MIN_PASSWORD_LENGTH
       },
       allowedNonAlphanumericCharacters: TEST_ALLOWED_NON_ALPHANUMERIC_CHARS,
+      enforcementState: TEST_ENFORCEMENT_STATE,
       schemaVersion: TEST_SCHEMA_VERSION
     };
     const PASSWORD_POLICY_RESPONSE_REQUIRE_NUMERIC = {
@@ -813,6 +816,7 @@ describe('core/auth/auth_impl', () => {
         containsNumericCharacter: true
       },
       allowedNonAlphanumericCharacters: TEST_ALLOWED_NON_ALPHANUMERIC_CHARS,
+      enforcementState: TEST_ENFORCEMENT_STATE,
       schemaVersion: TEST_SCHEMA_VERSION
     };
     const PASSWORD_POLICY_RESPONSE_UNSUPPORTED_SCHEMA_VERSION = {
@@ -821,6 +825,8 @@ describe('core/auth/auth_impl', () => {
         unsupportedPasswordPolicyProperty: 10
       },
       allowedNonAlphanumericCharacters: TEST_ALLOWED_NON_ALPHANUMERIC_CHARS,
+      enforcementState: TEST_ENFORCEMENT_STATE,
+      forceUpgradeOnSignin: TEST_FORCE_UPGRADE_ON_SIGN_IN,
       schemaVersion: TEST_UNSUPPORTED_SCHEMA_VERSION
     };
     const CACHED_PASSWORD_POLICY = {
@@ -828,6 +834,8 @@ describe('core/auth/auth_impl', () => {
         minPasswordLength: TEST_MIN_PASSWORD_LENGTH
       },
       allowedNonAlphanumericCharacters: TEST_ALLOWED_NON_ALPHANUMERIC_STRING,
+      enforcementState: TEST_ENFORCEMENT_STATE,
+      forceUpgradeOnSignin: TEST_FORCE_UPGRADE_ON_SIGN_IN,
       schemaVersion: TEST_SCHEMA_VERSION
     };
     const CACHED_PASSWORD_POLICY_REQUIRE_NUMERIC = {
@@ -836,13 +844,17 @@ describe('core/auth/auth_impl', () => {
         containsNumericCharacter: true
       },
       allowedNonAlphanumericCharacters: TEST_ALLOWED_NON_ALPHANUMERIC_STRING,
+      enforcementState: TEST_ENFORCEMENT_STATE,
+      forceUpgradeOnSignin: TEST_FORCE_UPGRADE_ON_SIGN_IN,
       schemaVersion: TEST_SCHEMA_VERSION
     };
-    const PASSWORD_POLICY_UNSUPPORTED_SCHEMA_VERSION = {
+    const CACHED_PASSWORD_POLICY_UNSUPPORTED_SCHEMA_VERSION = {
       customStrengthOptions: {
         maxPasswordLength: TEST_MIN_PASSWORD_LENGTH
       },
       allowedNonAlphanumericCharacters: TEST_ALLOWED_NON_ALPHANUMERIC_STRING,
+      enforcementState: TEST_ENFORCEMENT_STATE,
+      forceUpgradeOnSignin: TEST_FORCE_UPGRADE_ON_SIGN_IN,
       schemaVersion: TEST_UNSUPPORTED_SCHEMA_VERSION
     };
 
@@ -915,7 +927,7 @@ describe('core/auth/auth_impl', () => {
       await expect(auth._updatePasswordPolicy()).to.be.fulfilled;
 
       expect(auth._getPasswordPolicyInternal()).to.eql(
-        PASSWORD_POLICY_UNSUPPORTED_SCHEMA_VERSION
+        CACHED_PASSWORD_POLICY_UNSUPPORTED_SCHEMA_VERSION
       );
     });
 

--- a/packages/auth/src/core/auth/auth_impl.test.ts
+++ b/packages/auth/src/core/auth/auth_impl.test.ts
@@ -794,7 +794,7 @@ describe('core/auth/auth_impl', () => {
     const TEST_ALLOWED_NON_ALPHANUMERIC_STRING =
       TEST_ALLOWED_NON_ALPHANUMERIC_CHARS.join('');
     const TEST_MIN_PASSWORD_LENGTH = 6;
-    const TEST_ENFORCEMENT_STATE = 'ENFORCE';
+    const TEST_ENFORCEMENT_STATE_ENFORCE = 'ENFORCE';
     const TEST_FORCE_UPGRADE_ON_SIGN_IN = false;
     const TEST_SCHEMA_VERSION = 1;
     const TEST_UNSUPPORTED_SCHEMA_VERSION = 0;
@@ -807,7 +807,7 @@ describe('core/auth/auth_impl', () => {
         minPasswordLength: TEST_MIN_PASSWORD_LENGTH
       },
       allowedNonAlphanumericCharacters: TEST_ALLOWED_NON_ALPHANUMERIC_CHARS,
-      enforcementState: TEST_ENFORCEMENT_STATE,
+      enforcementState: TEST_ENFORCEMENT_STATE_ENFORCE,
       schemaVersion: TEST_SCHEMA_VERSION
     };
     const PASSWORD_POLICY_RESPONSE_REQUIRE_NUMERIC = {
@@ -816,7 +816,7 @@ describe('core/auth/auth_impl', () => {
         containsNumericCharacter: true
       },
       allowedNonAlphanumericCharacters: TEST_ALLOWED_NON_ALPHANUMERIC_CHARS,
-      enforcementState: TEST_ENFORCEMENT_STATE,
+      enforcementState: TEST_ENFORCEMENT_STATE_ENFORCE,
       schemaVersion: TEST_SCHEMA_VERSION
     };
     const PASSWORD_POLICY_RESPONSE_UNSUPPORTED_SCHEMA_VERSION = {
@@ -825,7 +825,7 @@ describe('core/auth/auth_impl', () => {
         unsupportedPasswordPolicyProperty: 10
       },
       allowedNonAlphanumericCharacters: TEST_ALLOWED_NON_ALPHANUMERIC_CHARS,
-      enforcementState: TEST_ENFORCEMENT_STATE,
+      enforcementState: TEST_ENFORCEMENT_STATE_ENFORCE,
       forceUpgradeOnSignin: TEST_FORCE_UPGRADE_ON_SIGN_IN,
       schemaVersion: TEST_UNSUPPORTED_SCHEMA_VERSION
     };
@@ -834,7 +834,7 @@ describe('core/auth/auth_impl', () => {
         minPasswordLength: TEST_MIN_PASSWORD_LENGTH
       },
       allowedNonAlphanumericCharacters: TEST_ALLOWED_NON_ALPHANUMERIC_STRING,
-      enforcementState: TEST_ENFORCEMENT_STATE,
+      enforcementState: TEST_ENFORCEMENT_STATE_ENFORCE,
       forceUpgradeOnSignin: TEST_FORCE_UPGRADE_ON_SIGN_IN,
       schemaVersion: TEST_SCHEMA_VERSION
     };
@@ -844,7 +844,7 @@ describe('core/auth/auth_impl', () => {
         containsNumericCharacter: true
       },
       allowedNonAlphanumericCharacters: TEST_ALLOWED_NON_ALPHANUMERIC_STRING,
-      enforcementState: TEST_ENFORCEMENT_STATE,
+      enforcementState: TEST_ENFORCEMENT_STATE_ENFORCE,
       forceUpgradeOnSignin: TEST_FORCE_UPGRADE_ON_SIGN_IN,
       schemaVersion: TEST_SCHEMA_VERSION
     };
@@ -853,7 +853,7 @@ describe('core/auth/auth_impl', () => {
         maxPasswordLength: TEST_MIN_PASSWORD_LENGTH
       },
       allowedNonAlphanumericCharacters: TEST_ALLOWED_NON_ALPHANUMERIC_STRING,
-      enforcementState: TEST_ENFORCEMENT_STATE,
+      enforcementState: TEST_ENFORCEMENT_STATE_ENFORCE,
       forceUpgradeOnSignin: TEST_FORCE_UPGRADE_ON_SIGN_IN,
       schemaVersion: TEST_UNSUPPORTED_SCHEMA_VERSION
     };

--- a/packages/auth/src/core/auth/password_policy_impl.ts
+++ b/packages/auth/src/core/auth/password_policy_impl.ts
@@ -31,6 +31,8 @@ import { PasswordValidationStatus } from '../../model/public_types';
 export class PasswordPolicyImpl implements PasswordPolicyInternal {
   readonly customStrengthOptions: PasswordPolicyCustomStrengthOptions;
   readonly allowedNonAlphanumericCharacters: string;
+  readonly enforcementState: string;
+  readonly forceUpgradeOnSignin: boolean;
   readonly schemaVersion: number;
 
   constructor(response: GetPasswordPolicyResponse) {
@@ -62,8 +64,15 @@ export class PasswordPolicyImpl implements PasswordPolicyInternal {
         responseOptions.containsNonAlphanumericCharacter;
     }
 
+    const enforcementStateUnspecified =
+      response.enforcementState === 'ENFORCEMENT_STATE_UNSPECIFIED';
+    this.enforcementState = enforcementStateUnspecified
+      ? 'OFF'
+      : response.enforcementState;
+
     this.allowedNonAlphanumericCharacters =
       response.allowedNonAlphanumericCharacters.join('');
+    this.forceUpgradeOnSignin = response.forceUpgradeOnSignin ?? false;
     this.schemaVersion = response.schemaVersion;
   }
 

--- a/packages/auth/src/core/auth/password_policy_impl.ts
+++ b/packages/auth/src/core/auth/password_policy_impl.ts
@@ -64,11 +64,10 @@ export class PasswordPolicyImpl implements PasswordPolicyInternal {
         responseOptions.containsNonAlphanumericCharacter;
     }
 
-    const enforcementStateUnspecified =
-      response.enforcementState === 'ENFORCEMENT_STATE_UNSPECIFIED';
-    this.enforcementState = enforcementStateUnspecified
-      ? 'OFF'
-      : response.enforcementState;
+    this.enforcementState = response.enforcementState;
+    if (this.enforcementState === 'ENFORCEMENT_STATE_UNSPECIFIED') {
+      this.enforcementState = 'OFF';
+    }
 
     this.allowedNonAlphanumericCharacters =
       response.allowedNonAlphanumericCharacters.join('');

--- a/packages/auth/src/core/strategies/email_and_password.test.ts
+++ b/packages/auth/src/core/strategies/email_and_password.test.ts
@@ -802,6 +802,8 @@ describe('password policy cache is updated in auth flows upon error', () => {
   const TEST_ALLOWED_NON_ALPHANUMERIC_CHARS = ['!', '(', ')'];
   const TEST_ALLOWED_NON_ALPHANUMERIC_STRING =
     TEST_ALLOWED_NON_ALPHANUMERIC_CHARS.join('');
+  const TEST_ENFORCEMENT_STATE = 'ENFORCE';
+  const TEST_FORCE_UPGRADE_ON_SIGN_IN = false;
   const TEST_SCHEMA_VERSION = 1;
   const TEST_TENANT_ID = 'tenant-id';
   const TEST_TENANT_ID_REQUIRE_NUMERIC = 'other-tenant-id';
@@ -812,6 +814,7 @@ describe('password policy cache is updated in auth flows upon error', () => {
       minPasswordLength: TEST_MIN_PASSWORD_LENGTH
     },
     allowedNonAlphanumericCharacters: TEST_ALLOWED_NON_ALPHANUMERIC_CHARS,
+    enforcementState: TEST_ENFORCEMENT_STATE,
     schemaVersion: TEST_SCHEMA_VERSION
   };
   const PASSWORD_POLICY_RESPONSE_REQUIRE_NUMERIC = {
@@ -820,6 +823,7 @@ describe('password policy cache is updated in auth flows upon error', () => {
       containsNumericCharacter: true
     },
     allowedNonAlphanumericCharacters: TEST_ALLOWED_NON_ALPHANUMERIC_CHARS,
+    enforcementState: TEST_ENFORCEMENT_STATE,
     schemaVersion: TEST_SCHEMA_VERSION
   };
   const CACHED_PASSWORD_POLICY = {
@@ -827,6 +831,8 @@ describe('password policy cache is updated in auth flows upon error', () => {
       minPasswordLength: TEST_MIN_PASSWORD_LENGTH
     },
     allowedNonAlphanumericCharacters: TEST_ALLOWED_NON_ALPHANUMERIC_STRING,
+    enforcementState: TEST_ENFORCEMENT_STATE,
+    forceUpgradeOnSignin: TEST_FORCE_UPGRADE_ON_SIGN_IN,
     schemaVersion: TEST_SCHEMA_VERSION
   };
   const CACHED_PASSWORD_POLICY_REQUIRE_NUMERIC = {
@@ -835,6 +841,8 @@ describe('password policy cache is updated in auth flows upon error', () => {
       containsNumericCharacter: true
     },
     allowedNonAlphanumericCharacters: TEST_ALLOWED_NON_ALPHANUMERIC_STRING,
+    enforcementState: TEST_ENFORCEMENT_STATE,
+    forceUpgradeOnSignin: TEST_FORCE_UPGRADE_ON_SIGN_IN,
     schemaVersion: TEST_SCHEMA_VERSION
   };
   let policyEndpointMock: mockFetch.Route;

--- a/packages/auth/src/model/public_types.ts
+++ b/packages/auth/src/model/public_types.ts
@@ -1292,6 +1292,14 @@ export interface PasswordPolicy {
    * List of characters that are considered non-alphanumeric during validation.
    */
   readonly allowedNonAlphanumericCharacters: string;
+  /**
+   * The enforcement state of the policy. Can be 'OFF' or 'ENFORCE'.
+   */
+  readonly enforcementState: string;
+  /**
+   * Whether existing passwords must meet the policy.
+   */
+  readonly forceUpgradeOnSignin: boolean;
 }
 
 /**


### PR DESCRIPTION
Add the enforcementState and forceUpgradeOnSignin fields to the PasswordPolicy public type. These fields are not used internally for validation, but the developer can use them to determine if the password will be rejected during sign-in, sign up, or reset password flows.