### PR TITLE
Fix bug when non-alphanumeric characters is undefined

### DIFF
--- a/packages/auth/src/api/password_policy/get_password_policy.ts
+++ b/packages/auth/src/api/password_policy/get_password_policy.ts
@@ -42,7 +42,7 @@ export interface GetPasswordPolicyResponse {
     containsNumericCharacter?: boolean;
     containsNonAlphanumericCharacter?: boolean;
   };
-  allowedNonAlphanumericCharacters: string[];
+  allowedNonAlphanumericCharacters?: string[];
   enforcementState: string;
   forceUpgradeOnSignin?: boolean;
   schemaVersion: number;

--- a/packages/auth/src/core/auth/password_policy_impl.test.ts
+++ b/packages/auth/src/core/auth/password_policy_impl.test.ts
@@ -88,6 +88,15 @@ describe('core/auth/password_policy_impl', () => {
       enforcementState: 'ENFORCEMENT_STATE_UNSPECIFIED',
       schemaVersion: TEST_SCHEMA_VERSION
     };
+  const PASSWORD_POLICY_RESPONSE_NO_NON_ALPHANUMERIC_CHARS: GetPasswordPolicyResponse =
+    {
+      customStrengthOptions: {
+        minPasswordLength: TEST_MIN_PASSWORD_LENGTH,
+        maxPasswordLength: TEST_MAX_PASSWORD_LENGTH
+      },
+      enforcementState: TEST_ENFORCEMENT_STATE_ENFORCE,
+      schemaVersion: TEST_SCHEMA_VERSION
+    };
   const PASSWORD_POLICY_REQUIRE_ALL: PasswordPolicy = {
     customStrengthOptions: {
       minPasswordLength: TEST_MIN_PASSWORD_LENGTH,
@@ -170,6 +179,13 @@ describe('core/auth/password_policy_impl', () => {
         PASSWORD_POLICY_RESPONSE_REQUIRE_NUMERIC
       );
       expect(policy.forceUpgradeOnSignin).to.be.false;
+    });
+
+    it('assigns an empty string as the allowed non-alphanumeric characters when they are undefined in the response', () => {
+      const policy: PasswordPolicyInternal = new PasswordPolicyImpl(
+        PASSWORD_POLICY_RESPONSE_NO_NON_ALPHANUMERIC_CHARS
+      );
+      expect(policy.allowedNonAlphanumericCharacters).to.eql('');
     });
 
     context('#validatePassword', () => {

--- a/packages/auth/src/core/auth/password_policy_impl.ts
+++ b/packages/auth/src/core/auth/password_policy_impl.ts
@@ -69,8 +69,10 @@ export class PasswordPolicyImpl implements PasswordPolicyInternal {
       this.enforcementState = 'OFF';
     }
 
+    // Use an empty string if no non-alphanumeric characters are specified in the response.
     this.allowedNonAlphanumericCharacters =
-      response.allowedNonAlphanumericCharacters.join('');
+      response.allowedNonAlphanumericCharacters?.join('') ?? '';
+
     this.forceUpgradeOnSignin = response.forceUpgradeOnSignin ?? false;
     this.schemaVersion = response.schemaVersion;
   }


### PR DESCRIPTION
The non-alphanumeric characters could be undefined when returned from the backend, even though they are not marked as optional. In this case, the SDK will store and return an empty string as part of the policy.