### PR TITLE
Update password validation in auth demo to be in each auth flow with a password

### DIFF
--- a/packages/auth/demo/public/index.html
+++ b/packages/auth/demo/public/index.html
@@ -252,8 +252,38 @@
               <form class="form form-bordered no-submit">
                 <input type="email" name="email" id="signup-email"
                        class="form-control" placeholder="Email" />
-                <input type="password" name="password" id="signup-password"
+                <div class="input-group">
+                  <input type="password" name="password" id="signup-password"
                        class="form-control" placeholder="Password" />
+                  <div class="input-group-btn">
+                    <button class="btn btn-default" type="button" id="signup-view-password" aria-label="View password">
+                      <span class="glyphicon glyphicon-eye-open" aria-hidden="true"></span>
+                    </button>
+                  </div>
+                </div>
+                <div class="list-group password-validation-requirements" id="signup-password-validation-requirements">
+                  <div class="list-group-item">
+                    <span class="glyphicon glyphicon-warning-sign" aria-hidden="true"></span> These requirements are not currently enforced by the backend. Basic requirements are still enforced
+                  </div>
+                  <div class="list-group-item" id="signup-password-validation-meets-min-password-length">
+                    Password must be at least <span id="signup-password-validation-min-length">6</span> characters.
+                  </div>
+                  <div class="list-group-item" id="signup-password-validation-meets-max-password-length">
+                    Password must be at most <span id="signup-password-validation-max-length">4096</span> characters.
+                  </div>
+                  <div class="list-group-item" id="signup-password-validation-contains-lowercase-letter">
+                    Password must contain a lowercase letter.
+                  </div>
+                  <div class="list-group-item" id="signup-password-validation-contains-uppercase-letter">
+                    Password must contain an uppercase letter.
+                  </div>
+                  <div class="list-group-item" id="signup-password-validation-contains-numeric-character">
+                    Password must contain a numeric character.
+                  </div>
+                  <div class="list-group-item password-validation-contains-non-alphanumeric-character" id="signup-password-validation-contains-non-alphanumeric-character">
+                    Password must contain a non-alphanumeric character. <span class="glyphicon glyphicon-info-sign" id="signup-password-validation-allowed-non-alphanumeric-characters" data-toggle="tooltip" data-placement="bottom" title="No allowed non-alphanumeric characters." aria-label="View non-alphanumeric characters"></span>
+                  </div>
+                </div>
                 <button class="btn btn-block btn-primary"
                         id="sign-up-with-email-and-password">Sign Up</button>
               </form>
@@ -264,8 +294,41 @@
               <form class="form form-bordered no-submit">
                 <input type="email" name="email" id="signin-email"
                        class="form-control" placeholder="Email" />
-                <input type="password" name="password" id="signin-password"
+                <div class="input-group">
+                  <input type="password" name="password" id="signin-password"
                        class="form-control" placeholder="Password" />
+                  <div class="input-group-btn">
+                    <button class="btn btn-default" type="button" id="signin-view-password" aria-label="View password">
+                      <span class="glyphicon glyphicon-eye-open" aria-hidden="true"></span>
+                    </button>
+                  </div>
+                </div>
+                <div class="list-group password-validation-requirements" id="signin-password-validation-requirements">
+                  <div class="list-group-item list-group-item-info" id="signin-password-validation-not-enforced">
+                    <span class="glyphicon glyphicon-warning-sign" aria-hidden="true"></span> These requirements are not currently enforced by the backend. Basic requirements are still enforced.
+                  </div>
+                  <div class="list-group-item list-group-item-warning" id="signin-password-validation-force-upgrade">
+                    <span class="glyphicon glyphicon-warning-sign" aria-hidden="true"></span> Existing password must meet these requirements.
+                  </div>
+                  <div class="list-group-item" id="signin-password-validation-meets-min-password-length">
+                    Password must be at least <span id="signin-password-validation-min-length">6</span> characters.
+                  </div>
+                  <div class="list-group-item" id="signin-password-validation-meets-max-password-length">
+                    Password must be at most <span id="signin-password-validation-max-length">4096</span> characters.
+                  </div>
+                  <div class="list-group-item" id="signin-password-validation-contains-lowercase-letter">
+                    Password must contain a lowercase letter.
+                  </div>
+                  <div class="list-group-item" id="signin-password-validation-contains-uppercase-letter">
+                    Password must contain an uppercase letter.
+                  </div>
+                  <div class="list-group-item" id="signin-password-validation-contains-numeric-character">
+                    Password must contain a numeric character.
+                  </div>
+                  <div class="list-group-item password-validation-contains-non-alphanumeric-character" id="signin-password-validation-contains-non-alphanumeric-character">
+                    Password must contain a non-alphanumeric character. <span class="glyphicon glyphicon-info-sign" id="signin-password-validation-allowed-non-alphanumeric-characters" data-toggle="tooltip" data-placement="bottom" title="No allowed non-alphanumeric characters." aria-label="View non-alphanumeric characters"></span>
+                  </div>
+                </div>
                 <button class="btn btn-block btn-primary"
                         id="sign-in-with-email-and-password">
                   Sign In with Email and Password
@@ -355,9 +418,39 @@
                 <input type="text" id="password-reset-code"
                        placeholder="Password Reset Code"
                        class="form-control" />
-                <input type="password" id="password-reset-password"
+                <div class="input-group">
+                  <input type="password" id="password-reset-password"
                        placeholder="New Password"
-                       class="form-control" />
+                       class="form-control input-group" />
+                  <div class="input-group-btn">
+                    <button class="btn btn-default" type="button" id="password-reset-view-password" aria-label="View password">
+                      <span class="glyphicon glyphicon-eye-open" aria-hidden="true"></span>
+                    </button>
+                  </div>
+                </div>
+                <div class="list-group password-validation-requirements" id="password-reset-password-validation-requirements">
+                  <div class="list-group-item list-group-item-info" id="password-reset-password-validation-not-enforced">
+                    <span class="glyphicon glyphicon-warning-sign" aria-hidden="true"></span> These requirements are not currently enforced by the backend. Basic requirements are still enforced.
+                  </div>
+                  <div class="list-group-item" id="password-reset-password-validation-meets-min-password-length">
+                    Password must be at least <span id="password-reset-password-validation-min-length">6</span> characters.
+                  </div>
+                  <div class="list-group-item" id="password-reset-password-validation-meets-max-password-length">
+                    Password must be at most <span id="password-reset-password-validation-max-length">4096</span> characters.
+                  </div>
+                  <div class="list-group-item" id="password-reset-password-validation-contains-lowercase-letter">
+                    Password must contain a lowercase letter.
+                  </div>
+                  <div class="list-group-item" id="password-reset-password-validation-contains-uppercase-letter">
+                    Password must contain an uppercase letter.
+                  </div>
+                  <div class="list-group-item" id="password-reset-password-validation-contains-numeric-character">
+                    Password must contain a numeric character.
+                  </div>
+                  <div class="list-group-item password-validation-contains-non-alphanumeric-character" id="password-reset-password-validation-contains-non-alphanumeric-character">
+                    Password must contain a non-alphanumeric character. <span class="glyphicon glyphicon-info-sign" id="password-reset-password-validation-allowed-non-alphanumeric-characters" data-toggle="tooltip" data-placement="bottom" title="No allowed non-alphanumeric characters." aria-label="View non-alphanumeric characters"></span>
+                  </div>
+                </div>
                 <button class="btn btn-block btn-default"
                         id="verify-password-reset-code">
                   Verify Password Reset Code
@@ -366,40 +459,6 @@
                         id="confirm-password-reset">
                   Confirm Password Change
                 </button>
-              </form>
-
-              <!-- Password Validation -->
-              <div class="group">Password Validation</div>
-              <form class="form form-bordered no-submit">
-                <div class="input-group">
-                  <input type="password" name="password" id="password-validation-password"
-                        class="form-control" placeholder="Password" />
-                  <div class="input-group-btn">
-                    <button class="btn btn-default" type="button" id="password-validation-view-password" aria-label="View password">
-                      <span class="glyphicon glyphicon-eye-open" aria-hidden="true"></span>
-                    </button>
-                  </div>
-                </div>
-                <ul class="list-group" id="password-validation-requirements">
-                  <li class="list-group-item" id="password-validation-meets-min-password-length">
-                    Password must be at least <span id="password-validation-min-length">6</span> characters.
-                  </li>
-                  <li class="list-group-item" id="password-validation-meets-max-password-length">
-                    Password must be at most <span id="password-validation-max-length">4096</span> characters.
-                  </li>
-                  <li class="list-group-item" id="password-validation-contains-lowercase-letter">
-                    Password must contain a lowercase letter.
-                  </li>
-                  <li class="list-group-item" id="password-validation-contains-uppercase-letter">
-                    Password must contain an uppercase letter.
-                  </li>
-                  <li class="list-group-item" id="password-validation-contains-numeric-character">
-                    Password must contain a numeric character.
-                  </li>
-                  <li class="list-group-item" id="password-validation-contains-non-alphanumeric-character">
-                    Password must contain a non-alphanumeric character. <span class="glyphicon glyphicon-info-sign" id="password-validation-allowed-non-alphanumeric-characters" data-toggle="tooltip" data-placement="bottom" title="No allowed non-alphanumeric characters." aria-label="View non-alphanumeric characters"></span>
-                  </li>
-                </ul>
               </form>
 
               <!-- Fetch Sign In Methods -->

--- a/packages/auth/demo/public/style.css
+++ b/packages/auth/demo/public/style.css
@@ -76,18 +76,16 @@ body.user-info-displayed {
   border: none;
 }
 
-#password-validation-requirements {
-  margin-top: 20px;
-  margin-bottom: 0;
+.password-validation-requirements {
+  margin: 5px 0;
   display: none;
 }
 
-#password-validation-requirements .list-group-item {
+.password-validation-requirements .list-group-item {
   display: none;
-  list-style-type: none;
 }
 
-#password-validation-contains-non-alphanumeric-character .tooltip {
+.password-validation-contains-non-alphanumeric-character .tooltip {
   font-family: 'Courier New', Courier;
   font-size: 1.1em;
   letter-spacing: 5px;
@@ -159,7 +157,11 @@ input + .form,
 
 .form + button,
 .form-control + .btn-block,
-.form-control + .form-control {
+.form-control + .form-control,
+.form-control + .input-group,
+.form-control + .list-group,
+.input-group + .btn-block,
+.list-group + .btn-block {
   margin-top: 5px;
 }
 

--- a/packages/auth/demo/src/index.js
+++ b/packages/auth/demo/src/index.js
@@ -496,8 +496,9 @@ function onInitializeRecaptchaConfig() {
 
 /**
  * Updates the displayed validation status for the inputted password.
+ * @param {string} sectionIdPrefix The ID prefix of the section to show the password requirements in.
  */
-function onValidatePassword() {
+function onValidatePassword(sectionIdPrefix) {
   /**
    * Updates the displayed status for a requirement.
    * @param {string} id The ID of the DOM element displaying the requirement status.
@@ -520,25 +521,47 @@ function onValidatePassword() {
     $(id).show();
   }
 
-  const password = $('#password-validation-password').val();
+  const idPrefix = sectionIdPrefix + 'password-validation-';
+  const requirementsId = idPrefix + 'requirements';
+  const passwordId = sectionIdPrefix + 'password';
+
+  const password = $(passwordId).val();
   validatePassword(auth, password).then(
     status => {
       const passwordPolicy = status.passwordPolicy;
       const customStrengthOptions = passwordPolicy.customStrengthOptions;
 
+      // Display a message if the password policy is not being enforced.
+      const notEnforcedId = idPrefix + 'not-enforced';
+      if (passwordPolicy.enforcementState === 'OFF') {
+        $(notEnforcedId).show();
+      } else {
+        $(notEnforcedId).hide();
+      }
+
       // Only show options required by the password policy.
+      $(requirementsId).children().hide();
+
+      // Do not show requirements on sign-in if the policy is not enforced for existing passwords.
+      if (
+        sectionIdPrefix === 'signin-' &&
+        !passwordPolicy.forceUpgradeOnSignin
+      ) {
+        return;
+      }
+
       if (customStrengthOptions.minPasswordLength) {
-        $('#password-validation-min-length').text(
+        $(idPrefix + 'min-length').text(
           customStrengthOptions.minPasswordLength
         );
       }
       if (customStrengthOptions.maxPasswordLength) {
-        $('#password-validation-max-length').text(
+        $(idPrefix + 'max-length').text(
           customStrengthOptions.maxPasswordLength
         );
       }
       if (customStrengthOptions.containsNonAlphanumericCharacter) {
-        $('#password-validation-allowed-non-alphanumeric-characters').attr(
+        $(idPrefix + 'allowed-non-alphanumeric-characters').attr(
           'data-original-title',
           passwordPolicy.allowedNonAlphanumericCharacters
         );
@@ -546,24 +569,49 @@ function onValidatePassword() {
       Object.keys(status).forEach(requirement => {
         if (requirement !== 'passwordPolicy') {
           // Get the requirement ID by converting to kebab case.
-          const requirementIdPrefix = '#password-validation-';
           const requirementId =
-            requirementIdPrefix +
+            idPrefix +
             requirement.replace(/[A-Z]/g, match => '-' + match.toLowerCase());
-
           setRequirementStatus(requirementId, status[requirement]);
         }
       });
 
-      $('#password-validation-password').prop('disabled', false);
-      $('#password-validation-requirements').show();
+      // Show a note that existing password must meet the policy if trying to sign-in.
+      if (sectionIdPrefix === '#signin-') {
+        const forceUpgradeId = idPrefix + 'force-upgrade';
+        if (passwordPolicy.forceUpgradeOnSignin) {
+          $(forceUpgradeId).show();
+        } else {
+          $(forceUpgradeId).hide();
+        }
+      }
+
+      $(passwordId).prop('disabled', false);
+      $(requirementsId).show();
+
+      // Fix the border radius, since hidden elements are still considered in styling.
+      const borderRadius = '5px';
+      const requirements = $(
+        idPrefix + 'requirements .list-group-item:visible'
+      );
+      requirements.each(function (index) {
+        if (index === 0) {
+          $(this).css('border-top-left-radius', borderRadius);
+          $(this).css('border-top-right-radius', borderRadius);
+        }
+        console.log(elem);
+        if (index === requirements.length - 1) {
+          $(this).css('border-bottom-left-radius', borderRadius);
+          $(this).css('border-bottom-right-radius', borderRadius);
+        }
+      });
     },
     error => {
       // Disable the password input and hide the requirements since validation cannot be performed.
       if (error.code === `auth/unsupported-password-policy-schema-version`) {
-        $('#password-validation-password').prop('disabled', true);
+        $(passwordId).prop('disabled', true);
       }
-      $('#password-validation-requirements').hide();
+      $(requirementsId).hide();
       onAuthError(error);
     }
   );
@@ -571,9 +619,10 @@ function onValidatePassword() {
 
 /**
  * Toggles text visibility for the password validation input field.
+ * @param {string} sectionIdPrefix The ID prefix of the section to show the password requirements in.
  */
-function onToggleViewPasswordForValidation() {
-  const id = '#password-validation-password';
+function onToggleViewPassword(sectionIdPrefix = '#') {
+  const id = sectionIdPrefix + '-password';
   if ($(id).prop('type') === 'password') {
     $(id).prop('type', 'text');
   } else {
@@ -2121,9 +2170,16 @@ function initApp() {
   $('#sign-in-anonymously').click(onSignInAnonymously);
   $('.set-tenant-id').click(onSetTenantID);
   $('#initialize-recaptcha-config').click(onInitializeRecaptchaConfig);
-  $('#password-validation-password').keyup(onValidatePassword);
-  $('#password-validation-view-password').click(
-    onToggleViewPasswordForValidation
+  $('#password-validation-password').keyup(() => onValidatePassword());
+  $('#signin-password').keyup(() => onValidatePassword('#signin-'));
+  $('#signup-password').keyup(() => onValidatePassword('#signup-'));
+  $('#password-reset-password').keyup(() =>
+    onValidatePassword('#password-reset-')
+  );
+  $('#signin-view-password').click(() => onToggleViewPassword('#signin-'));
+  $('#signup-view-password').click(() => onToggleViewPassword('#signup-'));
+  $('#password-reset-view-password').click(() =>
+    onToggleViewPassword('#password-reset-')
   );
   $('#sign-in-with-generic-idp-credential').click(
     onSignInWithGenericIdPCredential


### PR DESCRIPTION
Update the auth demo to move password validation under sign-in, sign up, and password reset sections. Also, include displaying enforcementState and forceUpgradeOnSignin properties to the user.