### PR TITLE
Export internal interface PrivateSettings for console

### DIFF
--- a/packages/firestore/src/api.ts
+++ b/packages/firestore/src/api.ts
@@ -82,7 +82,7 @@ export {
 } from './api/bundle';
 
 export { FirestoreSettings, PersistenceSettings } from './api/settings';
-export { PrivateSettings } from './lite-api/settings';
+export type { PrivateSettings } from './lite-api/settings';
 export { ExperimentalLongPollingOptions } from './api/long_polling_options';
 
 export {

--- a/packages/firestore/src/api.ts
+++ b/packages/firestore/src/api.ts
@@ -82,6 +82,7 @@ export {
 } from './api/bundle';
 
 export { FirestoreSettings, PersistenceSettings } from './api/settings';
+export { PrivateSettings } from './lite-api/settings';
 export { ExperimentalLongPollingOptions } from './api/long_polling_options';
 
 export {

--- a/packages/firestore/src/lite-api/settings.ts
+++ b/packages/firestore/src/lite-api/settings.ts
@@ -68,7 +68,10 @@ export interface FirestoreSettings {
   ignoreUndefinedProperties?: boolean;
 }
 
-/** Undocumented, private additional settings not exposed in our public API. */
+/** 
+ * @internal
+ * Undocumented, private additional settings not exposed in our public API.
+ */
 export interface PrivateSettings extends FirestoreSettings {
   // Can be a google-auth-library or gapi client.
   credentials?: CredentialsSettings;

--- a/packages/firestore/src/lite-api/settings.ts
+++ b/packages/firestore/src/lite-api/settings.ts
@@ -68,7 +68,7 @@ export interface FirestoreSettings {
   ignoreUndefinedProperties?: boolean;
 }
 
-/** 
+/**
  * @internal
  * Undocumented, private additional settings not exposed in our public API.
  */


### PR DESCRIPTION
Expose PrivateSettings interface as an internal type for the Firestore console. It was exported in the previous version of the non-modular firestore SDK we used in console.
