### PR TITLE
increase GHA artifact retention from 2 to 14 days

### DIFF
--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -7,7 +7,7 @@ on:
 env:
   # make chromedriver detect installed Chrome version and download the corresponding driver
   DETECT_CHROMEDRIVER_VERSION: true
-  artifactRetentionDays: 2
+  artifactRetentionDays: 14
 
 jobs:
   build:


### PR DESCRIPTION
### Discussion

The test-all workflow builds in one job and runs tests in subsequent jobs, and it uses the upload-artifact and download-artifact GitHub Actions to deliver the build results between the build and test jobs.

The retention period for storing these artifacts was configured for 2 days. Unfortunately this made it difficult to debug failures or re-run flaky tests that failed over the weekend.

This change updates the retention to two weeks, which should be more than enough time.

Note that artifacts might not actually last two weeks. If we exceed our storage limits then the older artifacts will be automatically deleted to create more space for the newer workflow runs.

### Testing

CI tests only, as this change affects only a single CI Workflow.
[CI Execution](https://github.com/firebase/firebase-js-sdk/actions/runs/5657456990). Also re-executed the Firestore test to ensure the build artifact still exists.

### API Changes

None.