### PR TITLE
Use a default minimum password length of 6

### DIFF
--- a/packages/auth/src/core/auth/auth_impl.test.ts
+++ b/packages/auth/src/core/auth/auth_impl.test.ts
@@ -821,7 +821,7 @@ describe('core/auth/auth_impl', () => {
     };
     const PASSWORD_POLICY_RESPONSE_UNSUPPORTED_SCHEMA_VERSION = {
       customStrengthOptions: {
-        maxPasswordLength: TEST_MIN_PASSWORD_LENGTH,
+        minPasswordLength: TEST_MIN_PASSWORD_LENGTH,
         unsupportedPasswordPolicyProperty: 10
       },
       allowedNonAlphanumericCharacters: TEST_ALLOWED_NON_ALPHANUMERIC_CHARS,
@@ -850,7 +850,7 @@ describe('core/auth/auth_impl', () => {
     };
     const CACHED_PASSWORD_POLICY_UNSUPPORTED_SCHEMA_VERSION = {
       customStrengthOptions: {
-        maxPasswordLength: TEST_MIN_PASSWORD_LENGTH
+        minPasswordLength: TEST_MIN_PASSWORD_LENGTH
       },
       allowedNonAlphanumericCharacters: TEST_ALLOWED_NON_ALPHANUMERIC_STRING,
       enforcementState: TEST_ENFORCEMENT_STATE_ENFORCE,

--- a/packages/auth/src/core/auth/password_policy_impl.test.ts
+++ b/packages/auth/src/core/auth/password_policy_impl.test.ts
@@ -97,6 +97,11 @@ describe('core/auth/password_policy_impl', () => {
       enforcementState: TEST_ENFORCEMENT_STATE_ENFORCE,
       schemaVersion: TEST_SCHEMA_VERSION
     };
+  const PASSWORD_POLICY_RESPONSE_NO_MIN_LENGTH: GetPasswordPolicyResponse = {
+    customStrengthOptions: {},
+    enforcementState: TEST_ENFORCEMENT_STATE_ENFORCE,
+    schemaVersion: TEST_SCHEMA_VERSION
+  };
   const PASSWORD_POLICY_REQUIRE_ALL: PasswordPolicy = {
     customStrengthOptions: {
       minPasswordLength: TEST_MIN_PASSWORD_LENGTH,
@@ -186,6 +191,13 @@ describe('core/auth/password_policy_impl', () => {
         PASSWORD_POLICY_RESPONSE_NO_NON_ALPHANUMERIC_CHARS
       );
       expect(policy.allowedNonAlphanumericCharacters).to.eql('');
+    });
+
+    it('assigns a default minimum length if it is undefined in the response', () => {
+      const policy: PasswordPolicyInternal = new PasswordPolicyImpl(
+        PASSWORD_POLICY_RESPONSE_NO_MIN_LENGTH
+      );
+      expect(policy.customStrengthOptions.minPasswordLength).to.eql(6);
     });
 
     context('#validatePassword', () => {

--- a/packages/auth/src/core/auth/password_policy_impl.ts
+++ b/packages/auth/src/core/auth/password_policy_impl.ts
@@ -23,7 +23,7 @@ import {
 } from '../../model/password_policy';
 import { PasswordValidationStatus } from '../../model/public_types';
 
-// Minimum password length enforced by the backend, even if no minimum length is set.
+// Minimum min password length enforced by the backend, even if no minimum length is set.
 const MINIMUM_MIN_PASSWORD_LENGTH = 6;
 
 /**

--- a/packages/auth/src/core/auth/password_policy_impl.ts
+++ b/packages/auth/src/core/auth/password_policy_impl.ts
@@ -23,6 +23,9 @@ import {
 } from '../../model/password_policy';
 import { PasswordValidationStatus } from '../../model/public_types';
 
+// Minimum password length enforced by the backend, even if no minimum length is set.
+const MINIMUM_MIN_PASSWORD_LENGTH = 6;
+
 /**
  * Stores password policy requirements and provides password validation against the policy.
  *
@@ -39,9 +42,9 @@ export class PasswordPolicyImpl implements PasswordPolicyInternal {
     // Only include custom strength options defined in the response.
     const responseOptions = response.customStrengthOptions;
     this.customStrengthOptions = {};
-    // A minimum length of 6 will be enforced by the backend if no minimum length is set.
+    // TODO: Remove once the backend is updated to include the minimum min password length instead of undefined when there is no minimum length set.
     this.customStrengthOptions.minPasswordLength =
-      responseOptions.minPasswordLength ?? 6;
+      responseOptions.minPasswordLength ?? MINIMUM_MIN_PASSWORD_LENGTH;
     if (responseOptions.maxPasswordLength) {
       this.customStrengthOptions.maxPasswordLength =
         responseOptions.maxPasswordLength;

--- a/packages/auth/src/core/auth/password_policy_impl.ts
+++ b/packages/auth/src/core/auth/password_policy_impl.ts
@@ -39,10 +39,9 @@ export class PasswordPolicyImpl implements PasswordPolicyInternal {
     // Only include custom strength options defined in the response.
     const responseOptions = response.customStrengthOptions;
     this.customStrengthOptions = {};
-    if (responseOptions.minPasswordLength) {
-      this.customStrengthOptions.minPasswordLength =
-        responseOptions.minPasswordLength;
-    }
+    // A minimum length of 6 will be enforced by the backend if no minimum length is set.
+    this.customStrengthOptions.minPasswordLength =
+      responseOptions.minPasswordLength ?? 6;
     if (responseOptions.maxPasswordLength) {
       this.customStrengthOptions.maxPasswordLength =
         responseOptions.maxPasswordLength;


### PR DESCRIPTION
The backend will enforce a minimum password length of 6 even if no minimum password length is configured. I created a backend bug for this, but we will also default to using this value in the SDK if no minimum length is set.