### PR TITLE
Firestore: equality_matcher.ts: fix missing custom assertion failure message in deep equals

### DIFF
--- a/packages/firestore/test/util/equality_matcher.ts
+++ b/packages/firestore/test/util/equality_matcher.ts
@@ -138,13 +138,8 @@ export function addEqualityMatcher(
       // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
       const assertEql = (_super: (r: unknown, l: unknown) => boolean) => {
         originalFunction = originalFunction || _super;
-        return function (
-          this: Chai.Assertion,
-          expected?: unknown,
-          msg?: unknown
-        ): void {
+        return function (this: Chai.Assertion, expected?: unknown): void {
           if (isActive) {
-            utils.flag(this, 'message', msg);
             const actual = utils.flag(this, 'object');
 
             // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/firestore/test/util/equality_matcher.ts
+++ b/packages/firestore/test/util/equality_matcher.ts
@@ -156,7 +156,7 @@ export function addEqualityMatcher(
               /*showDiff=*/ true
             );
           } else if (originalFunction) {
-            originalFunction.call(this, expected, msg);
+            originalFunction.call(this, expected);
           }
         };
       };

--- a/packages/firestore/test/util/equality_matcher.ts
+++ b/packages/firestore/test/util/equality_matcher.ts
@@ -123,7 +123,7 @@ function customDeepEqual(
 }
 
 /** The original equality function passed in by chai(). */
-let originalFunction: ((r: unknown, l: unknown) => boolean) | null = null;
+let originalFunction: ((expected: unknown) => void) | null = null;
 
 export function addEqualityMatcher(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -136,7 +136,7 @@ export function addEqualityMatcher(
       const Assertion = chai.Assertion;
 
       // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-      const assertEql = (_super: (r: unknown, l: unknown) => boolean) => {
+      const assertEql = (_super: (expected: unknown) => void) => {
         originalFunction = originalFunction || _super;
         return function (this: Chai.Assertion, expected?: unknown): void {
           if (isActive) {


### PR DESCRIPTION
This PR fixes a bug in Firestore's unit/integration testing framework where a "deep equals" assertion check would _omit_ the custom failure message, when it should have _included_ the custom failure message.

For example, consider the following "expect" checks:
```ts
expect({foo: 42}, 'custom message').to.deep.equal({bar: 42});
expect({foo: 42}).to.deep.equal({bar: 42}, 'custom message');
```

Both of these checks will unconditionally fail because `{foo: 42}` does not "deep equal" `{bar: 42}`. Also, both the checks specify a custom failure message to be incorporated into the failure message, albeit in different ways.

The problem is that the custom message is _not_ included in the ultimate failure message:

```
AssertionError: expected { foo: 42 } to roughly deeply equal { bar: 42 }
```

With the fix in this PR, the custom message _is_ included in the failure message:

```
AssertionError: custom message: expected { foo: 42 } to roughly deeply equal { bar: 42 }
```

The root cause of the bug was the misconception that custom message would be specified as an argument to the function. The function signature was actually incorrectly typed as `(r: unknown, l: unknown) => boolean`, suggesting that it was supposed to compare `r` and `l` for equality. This coincidentally just happened to work because `r` was treated as the "expected" and the `l` argument was simply ignored, which worked because it was always undefined anyways. The type was fixed to `(expected: unknown) => void`.

The custom function also did not need to call `utils.flag(this, 'message', msg)` because the chai testing framework _already_ makes this call, and when the custom function made the call it just clobbered the previously-set custom message with `undefined`.