### PR TITLE
Extend timeout and add retries for CI tests that frequently time out

### DIFF
--- a/packages/firestore/test/unit/remote/bloom_filter.test.ts
+++ b/packages/firestore/test/unit/remote/bloom_filter.test.ts
@@ -211,7 +211,7 @@ describe('BloomFilter', () => {
       );
       //Extend default timeout(2000)
     })
-      .timeout(60_000)
+      .timeout(10_000)
       .retries(3);
     it('mightContain result for 50000 documents with 0.0001 false positive rate', () => {
       testBloomFilterAgainstExpectedResult(

--- a/packages/firestore/test/unit/remote/bloom_filter.test.ts
+++ b/packages/firestore/test/unit/remote/bloom_filter.test.ts
@@ -210,13 +210,17 @@ describe('BloomFilter', () => {
         TEST_DATA.count50000Rate01TestResult
       );
       //Extend default timeout(2000)
-    }).timeout(10_000);
+    })
+      .timeout(60_000)
+      .retries(3);
     it('mightContain result for 50000 documents with 0.0001 false positive rate', () => {
       testBloomFilterAgainstExpectedResult(
         TEST_DATA.count50000Rate0001TestData,
         TEST_DATA.count50000Rate0001TestResult
       );
       //Extend default timeout(2000)
-    }).timeout(10_000);
+    })
+      .timeout(60_000)
+      .retries(3);
   });
 });


### PR DESCRIPTION
Extending the timeout and adding retry for tests that have frequently timed out in CI, blocking PRs. The extended timeout and retry has likelihood to slow down testing overall, but it still beats the alternative of the timeout blocking the CI and causing the developer to re-run the entire check in attempt to get it to pass.