### PR TITLE
Implement revokeAccessToken public api

### DIFF
--- a/common/api-review/auth.api.md
+++ b/common/api-review/auth.api.md
@@ -725,6 +725,9 @@ export class RecaptchaVerifier implements ApplicationVerifierInternal {
 // @public
 export function reload(user: User): Promise<void>;
 
+// @public
+export function revokeAccessToken(auth: Auth, token: string): Promise<void>;
+
 // Warning: (ae-forgotten-export) The symbol "FederatedAuthProvider" needs to be exported by the entry point index.d.ts
 //
 // @public

--- a/docs-devsite/auth.md
+++ b/docs-devsite/auth.md
@@ -35,6 +35,7 @@ Firebase Authentication
 |  [isSignInWithEmailLink(auth, emailLink)](./auth.md#issigninwithemaillink) | Checks if an incoming link is a sign-in with email link suitable for [signInWithEmailLink()](./auth.md#signinwithemaillink)<!-- -->. |
 |  [onAuthStateChanged(auth, nextOrObserver, error, completed)](./auth.md#onauthstatechanged) | Adds an observer for changes to the user's sign-in state. |
 |  [onIdTokenChanged(auth, nextOrObserver, error, completed)](./auth.md#onidtokenchanged) | Adds an observer for changes to the signed-in user's ID token. |
+|  [revokeAccessToken(auth, token)](./auth.md#revokeaccesstoken) | Revokes the given access token. Currently only supports Apple OAuth Access token. |
 |  [sendPasswordResetEmail(auth, email, actionCodeSettings)](./auth.md#sendpasswordresetemail) | Sends a password reset email to the given email address. |
 |  [sendSignInLinkToEmail(auth, email, actionCodeSettings)](./auth.md#sendsigninlinktoemail) | Sends a sign-in email link to the user with the specified email. |
 |  [setPersistence(auth, persistence)](./auth.md#setpersistence) | Changes the type of persistence on the [Auth](./auth.auth.md#auth_interface) instance for the currently saved <code>Auth</code> session and applies this type of persistence for future sign-in requests, including sign-in with redirect requests. |
@@ -597,6 +598,27 @@ export declare function onIdTokenChanged(auth: Auth, nextOrObserver: NextOrObser
 <b>Returns:</b>
 
 [Unsubscribe](./util.md#unsubscribe)
+
+## revokeAccessToken()
+
+Revokes the given access token. Currently only supports Apple OAuth Access token.
+
+<b>Signature:</b>
+
+```typescript
+export declare function revokeAccessToken(auth: Auth, token: string): Promise<void>;
+```
+
+### Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  auth | [Auth](./auth.auth.md#auth_interface) |  |
+|  token | string |  |
+
+<b>Returns:</b>
+
+Promise&lt;void&gt;
 
 ## sendPasswordResetEmail()
 

--- a/packages/auth/demo/src/index.js
+++ b/packages/auth/demo/src/index.js
@@ -1734,7 +1734,6 @@ function onDelete() {
   var isAppleProviderLinked = false;
 
   for (const provider of activeUser().providerData) {
-    console.log('provider.providerId: ' + provider.providerId);
     if (provider.providerId == 'apple.com') {
       isAppleProviderLinked = true;
       break;
@@ -1761,7 +1760,6 @@ function revokeAppleTokenAndDeleteUser() {
   provider.addScope('name');
 
   const auth = getAuth();
-  // TODO: Make this pop up or redirect. Can't use signInWithPopupRedirect because we need `then`.
   signInWithPopup(auth, provider).then(result => {
     // The signed-in user info.
     const user = result.user;

--- a/packages/auth/demo/src/index.js
+++ b/packages/auth/demo/src/index.js
@@ -73,7 +73,8 @@ import {
   browserPopupRedirectResolver,
   connectAuthEmulator,
   initializeRecaptchaConfig,
-  validatePassword
+  validatePassword,
+  revokeAccessToken
 } from '@firebase/auth';
 
 import { config } from './config';
@@ -1730,13 +1731,60 @@ function logAdditionalUserInfo(response) {
  * Deletes the user account.
  */
 function onDelete() {
-  activeUser()
-    ['delete']()
-    .then(() => {
-      log('User successfully deleted.');
-      alertSuccess('User successfully deleted.');
-      refreshUserData();
-    }, onAuthError);
+  var isAppleProviderLinked = false;
+
+  for (const provider of activeUser().providerData) {
+    console.log('provider.providerId: ' + provider.providerId);
+    if (provider.providerId == 'apple.com') {
+      isAppleProviderLinked = true;
+      break;
+    }
+  }
+
+  if (isAppleProviderLinked) {
+    revokeAppleTokenAndDeleteUser();
+  } else {
+    activeUser()
+      ['delete']()
+      .then(() => {
+        log('User successfully deleted.');
+        alertSuccess('User successfully deleted.');
+        refreshUserData();
+      }, onAuthError);
+  }
+}
+
+function revokeAppleTokenAndDeleteUser() {
+  // Re-auth then revoke the token
+  const provider = new OAuthProvider('apple.com');
+  provider.addScope('email');
+  provider.addScope('name');
+
+  const auth = getAuth();
+  // TODO: Make this pop up or redirect. Can't use signInWithPopupRedirect because we need `then`.
+  signInWithPopup(auth, provider).then(result => {
+    // The signed-in user info.
+    const user = result.user;
+    const credential = OAuthProvider.credentialFromResult(result);
+    const accessToken = credential.accessToken;
+
+    revokeAccessToken(auth, accessToken)
+      .then(() => {
+        log('Token successfully revoked.');
+
+        // Usual user deletion
+        activeUser()
+          ['delete']()
+          .then(() => {
+            log('User successfully deleted.');
+            alertSuccess('User successfully deleted.');
+            refreshUserData();
+          }, onAuthError);
+      })
+      .catch(error => {
+        console.log(error.message);
+      });
+  });
 }
 
 /**

--- a/packages/auth/src/api/authentication/token.test.ts
+++ b/packages/auth/src/api/authentication/token.test.ts
@@ -147,7 +147,7 @@ describe('requestStsToken', () => {
 
 describe('api/authentication/revokeToken', () => {
   const request = {
-    provider_id: 'provider-id',
+    providerId: 'provider-id',
     tokenType: TokenType.ACCESS_TOKEN,
     token: 'token',
     idToken: 'id-token'

--- a/packages/auth/src/api/authentication/token.test.ts
+++ b/packages/auth/src/api/authentication/token.test.ts
@@ -21,11 +21,11 @@ import chaiAsPromised from 'chai-as-promised';
 
 import { FirebaseError, getUA, querystringDecode } from '@firebase/util';
 
-import { HttpHeader } from '../';
+import { Endpoint, HttpHeader } from '../';
 import { testAuth, TestAuth } from '../../../test/helpers/mock_auth';
 import * as fetch from '../../../test/helpers/mock_fetch';
 import { ServerError } from '../errors';
-import { Path, requestStsToken } from './token';
+import { requestStsToken } from './token';
 import { SDK_VERSION } from '@firebase/app';
 import { _getBrowserName } from '../../core/util/browser';
 
@@ -38,7 +38,7 @@ describe('requestStsToken', () => {
   beforeEach(async () => {
     auth = await testAuth();
     const { apiKey, tokenApiHost, apiScheme } = auth.config;
-    endpoint = `${apiScheme}://${tokenApiHost}${Path.TOKEN}?key=${apiKey}`;
+    endpoint = `${apiScheme}://${tokenApiHost}${Endpoint.TOKEN}?key=${apiKey}`;
     fetch.setUp();
   });
 

--- a/packages/auth/src/api/authentication/token.test.ts
+++ b/packages/auth/src/api/authentication/token.test.ts
@@ -25,7 +25,7 @@ import { HttpHeader } from '../';
 import { testAuth, TestAuth } from '../../../test/helpers/mock_auth';
 import * as fetch from '../../../test/helpers/mock_fetch';
 import { ServerError } from '../errors';
-import { Endpoint, requestStsToken } from './token';
+import { Path, requestStsToken } from './token';
 import { SDK_VERSION } from '@firebase/app';
 import { _getBrowserName } from '../../core/util/browser';
 
@@ -38,7 +38,7 @@ describe('requestStsToken', () => {
   beforeEach(async () => {
     auth = await testAuth();
     const { apiKey, tokenApiHost, apiScheme } = auth.config;
-    endpoint = `${apiScheme}://${tokenApiHost}${Endpoint.TOKEN}?key=${apiKey}`;
+    endpoint = `${apiScheme}://${tokenApiHost}${Path.TOKEN}?key=${apiKey}`;
     fetch.setUp();
   });
 

--- a/packages/auth/src/api/authentication/token.test.ts
+++ b/packages/auth/src/api/authentication/token.test.ts
@@ -22,10 +22,11 @@ import chaiAsPromised from 'chai-as-promised';
 import { FirebaseError, getUA, querystringDecode } from '@firebase/util';
 
 import { Endpoint, HttpHeader } from '../';
+import { mockEndpoint } from '../../../test/helpers/api/helper';
 import { testAuth, TestAuth } from '../../../test/helpers/mock_auth';
 import * as fetch from '../../../test/helpers/mock_fetch';
 import { ServerError } from '../errors';
-import { requestStsToken } from './token';
+import { TokenType, requestStsToken, revokeToken } from './token';
 import { SDK_VERSION } from '@firebase/app';
 import { _getBrowserName } from '../../core/util/browser';
 
@@ -141,5 +142,65 @@ describe('requestStsToken', () => {
       'grant_type': 'refresh_token',
       'refresh_token': 'old-token'
     });
+  });
+});
+
+describe('api/authentication/revokeToken', () => {
+  const request = {
+    provider_id: 'provider-id',
+    tokenType: TokenType.ACCESS_TOKEN,
+    token: 'token',
+    idToken: 'id-token'
+  };
+
+  let auth: TestAuth;
+
+  beforeEach(async () => {
+    auth = await testAuth();
+    fetch.setUp();
+  });
+
+  afterEach(() => {
+    fetch.tearDown();
+  });
+
+  it('should POST to the correct endpoint', async () => {
+    const mock = mockEndpoint(Endpoint.REVOKE_TOKEN, {});
+
+    auth.tenantId = 'tenant-id';
+    const response = await revokeToken(auth, request);
+    // Currently, backend returns an empty response.
+    expect(mock.calls[0].request).to.eql({ ...request, tenantId: 'tenant-id' });
+    expect(mock.calls[0].method).to.eq('POST');
+    expect(mock.calls[0].headers!.get(HttpHeader.CONTENT_TYPE)).to.eq(
+      'application/json'
+    );
+    expect(mock.calls[0].headers!.get(HttpHeader.X_CLIENT_VERSION)).to.eq(
+      'testSDK/0.0.0'
+    );
+  });
+
+  it('should handle errors', async () => {
+    const mock = mockEndpoint(
+      Endpoint.REVOKE_TOKEN,
+      {
+        error: {
+          code: 400,
+          message: ServerError.INVALID_IDP_RESPONSE,
+          errors: [
+            {
+              message: ServerError.INVALID_IDP_RESPONSE
+            }
+          ]
+        }
+      },
+      400
+    );
+
+    await expect(revokeToken(auth, request)).to.be.rejectedWith(
+      FirebaseError,
+      'Firebase: The supplied auth credential is malformed or has expired. (auth/invalid-credential).'
+    );
+    expect(mock.calls[0].request).to.eql(request);
   });
 });

--- a/packages/auth/src/api/authentication/token.test.ts
+++ b/packages/auth/src/api/authentication/token.test.ts
@@ -168,7 +168,7 @@ describe('api/authentication/revokeToken', () => {
     const mock = mockEndpoint(Endpoint.REVOKE_TOKEN, {});
 
     auth.tenantId = 'tenant-id';
-    const response = await revokeToken(auth, request);
+    await revokeToken(auth, request);
     // Currently, backend returns an empty response.
     expect(mock.calls[0].request).to.eql({ ...request, tenantId: 'tenant-id' });
     expect(mock.calls[0].method).to.eq('POST');

--- a/packages/auth/src/api/authentication/token.ts
+++ b/packages/auth/src/api/authentication/token.ts
@@ -32,10 +32,6 @@ import { FetchProvider } from '../../core/util/fetch_provider';
 import { Auth } from '../../model/public_types';
 import { AuthInternal } from '../../model/auth';
 
-export const enum Path {
-  TOKEN = '/v1/token'
-}
-
 export const enum TokenType {
   UNSPECIFIED = 'TOKEN_TYPE_UNSPECIFIED',
   REFRESH_TOKEN = 'REFRESH_TOKEN',
@@ -83,7 +79,7 @@ export async function requestStsToken(
         const url = _getFinalTarget(
           auth,
           tokenApiHost,
-          Path.TOKEN,
+          Endpoint.TOKEN,
           `key=${apiKey}`
         );
 

--- a/packages/auth/src/api/authentication/token.ts
+++ b/packages/auth/src/api/authentication/token.ts
@@ -33,7 +33,6 @@ import { Auth } from '../../model/public_types';
 import { AuthInternal } from '../../model/auth';
 
 export const enum TokenType {
-  UNSPECIFIED = 'TOKEN_TYPE_UNSPECIFIED',
   REFRESH_TOKEN = 'REFRESH_TOKEN',
   ACCESS_TOKEN = 'ACCESS_TOKEN'
 }

--- a/packages/auth/src/api/authentication/token.ts
+++ b/packages/auth/src/api/authentication/token.ts
@@ -52,12 +52,11 @@ export interface RequestStsTokenResponse {
 }
 
 export interface RevokeTokenRequest {
-  provider_id: string;
+  providerId: string;
   tokenType: TokenType;
   token: string;
   idToken: string;
   tenantId?: string;
-  redirectUri?: string;
 }
 
 export interface RevokeTokenResponse {}

--- a/packages/auth/src/api/index.ts
+++ b/packages/auth/src/api/index.ts
@@ -69,6 +69,7 @@ export const enum Endpoint {
   GET_PROJECT_CONFIG = '/v1/projects',
   GET_RECAPTCHA_CONFIG = '/v2/recaptchaConfig',
   GET_PASSWORD_POLICY = '/v2/passwordPolicy',
+  TOKEN = '/v1/token',
   REVOKE_TOKEN = '/v2/accounts:revokeToken'
 }
 

--- a/packages/auth/src/api/index.ts
+++ b/packages/auth/src/api/index.ts
@@ -68,7 +68,8 @@ export const enum Endpoint {
   WITHDRAW_MFA = '/v2/accounts/mfaEnrollment:withdraw',
   GET_PROJECT_CONFIG = '/v1/projects',
   GET_RECAPTCHA_CONFIG = '/v2/recaptchaConfig',
-  GET_PASSWORD_POLICY = '/v2/passwordPolicy'
+  GET_PASSWORD_POLICY = '/v2/passwordPolicy',
+  REVOKE_TOKEN = '/v2/accounts:revokeToken'
 }
 
 export const enum RecaptchaClientType {

--- a/packages/auth/src/core/auth/auth_impl.ts
+++ b/packages/auth/src/core/auth/auth_impl.ts
@@ -63,6 +63,7 @@ import { _getInstance } from '../util/instantiator';
 import { _getUserLanguage } from '../util/navigator';
 import { _getClientVersion } from '../util/version';
 import { HttpHeader } from '../../api';
+import { TokenType, revokeToken } from '../../api/authentication/token';
 import { AuthMiddlewareQueue } from './middleware';
 import { RecaptchaConfig } from '../../platform_browser/recaptcha/recaptcha';
 import { _logWarn } from '../util/log';
@@ -512,6 +513,22 @@ export class AuthImpl implements AuthInternal, _FirebaseService {
         }, reject);
       }
     });
+  }
+
+  /**
+   * Revokes the given access token. Currently only supports Apple OAuth Access token.
+   */
+  async revokeAccessToken(token: string): Promise<void> {
+    if (this.currentUser) {
+      const idToken = await this.currentUser.getIdToken();
+      // Generalize this to accept other providers once supported.
+      const response = await revokeToken(this, {
+        provider_id: 'apple.com',
+        tokenType: TokenType.ACCESS_TOKEN,
+        token: token,
+        idToken: idToken
+      });
+    }
   }
 
   toJSON(): object {

--- a/packages/auth/src/core/auth/auth_impl.ts
+++ b/packages/auth/src/core/auth/auth_impl.ts
@@ -63,7 +63,11 @@ import { _getInstance } from '../util/instantiator';
 import { _getUserLanguage } from '../util/navigator';
 import { _getClientVersion } from '../util/version';
 import { HttpHeader } from '../../api';
-import { TokenType, revokeToken } from '../../api/authentication/token';
+import {
+  RevokeTokenRequest,
+  TokenType,
+  revokeToken
+} from '../../api/authentication/token';
 import { AuthMiddlewareQueue } from './middleware';
 import { RecaptchaConfig } from '../../platform_browser/recaptcha/recaptcha';
 import { _logWarn } from '../util/log';
@@ -522,12 +526,16 @@ export class AuthImpl implements AuthInternal, _FirebaseService {
     if (this.currentUser) {
       const idToken = await this.currentUser.getIdToken();
       // Generalize this to accept other providers once supported.
-      const response = await revokeToken(this, {
-        provider_id: 'apple.com',
+      const request: RevokeTokenRequest = {
+        providerId: 'apple.com',
         tokenType: TokenType.ACCESS_TOKEN,
         token: token,
         idToken: idToken
-      });
+      };
+      if (this.tenantId != null) {
+        request.tenantId = this.tenantId;
+      }
+      await revokeToken(this, request);
     }
   }
 

--- a/packages/auth/src/core/auth/auth_impl.ts
+++ b/packages/auth/src/core/auth/auth_impl.ts
@@ -529,8 +529,8 @@ export class AuthImpl implements AuthInternal, _FirebaseService {
       const request: RevokeTokenRequest = {
         providerId: 'apple.com',
         tokenType: TokenType.ACCESS_TOKEN,
-        token: token,
-        idToken: idToken
+        token,
+        idToken
       };
       if (this.tenantId != null) {
         request.tenantId = this.tenantId;

--- a/packages/auth/src/core/index.ts
+++ b/packages/auth/src/core/index.ts
@@ -245,6 +245,14 @@ export function signOut(auth: Auth): Promise<void> {
   return getModularInstance(auth).signOut();
 }
 
+/**
+ * Revokes the given access token. Currently only supports Apple OAuth Access token.
+ */
+export function revokeAccessToken(auth: Auth, token: string): Promise<void> {
+  const authInternal = _castAuth(auth);
+  return authInternal.revokeAccessToken(token);
+}
+
 export { initializeAuth } from './auth/initialize';
 export { connectAuthEmulator } from './auth/emulator';
 

--- a/packages/auth/src/core/user/token_manager.test.ts
+++ b/packages/auth/src/core/user/token_manager.test.ts
@@ -23,7 +23,7 @@ import { FirebaseError } from '@firebase/util';
 
 import { testAuth, TestAuth } from '../../../test/helpers/mock_auth';
 import * as fetch from '../../../test/helpers/mock_fetch';
-import { Endpoint } from '../../api/authentication/token';
+import { Path } from '../../api/authentication/token';
 import { IdTokenResponse } from '../../model/id_token';
 import { StsTokenManager, Buffer } from './token_manager';
 import { FinalizeMfaResponse } from '../../api/authentication/mfa';
@@ -103,7 +103,7 @@ describe('core/user/token_manager', () => {
       let mock: fetch.Route;
       beforeEach(() => {
         const { apiKey, tokenApiHost, apiScheme } = auth.config;
-        const endpoint = `${apiScheme}://${tokenApiHost}${Endpoint.TOKEN}?key=${apiKey}`;
+        const endpoint = `${apiScheme}://${tokenApiHost}${Path.TOKEN}?key=${apiKey}`;
         mock = fetch.mock(endpoint, {
           'access_token': 'new-access-token',
           'refresh_token': 'new-refresh-token',

--- a/packages/auth/src/core/user/token_manager.test.ts
+++ b/packages/auth/src/core/user/token_manager.test.ts
@@ -23,11 +23,11 @@ import { FirebaseError } from '@firebase/util';
 
 import { testAuth, TestAuth } from '../../../test/helpers/mock_auth';
 import * as fetch from '../../../test/helpers/mock_fetch';
-import { Path } from '../../api/authentication/token';
 import { IdTokenResponse } from '../../model/id_token';
 import { StsTokenManager, Buffer } from './token_manager';
 import { FinalizeMfaResponse } from '../../api/authentication/mfa';
 import { makeJWT } from '../../../test/helpers/jwt';
+import { Endpoint } from '../../api';
 
 use(chaiAsPromised);
 
@@ -103,7 +103,7 @@ describe('core/user/token_manager', () => {
       let mock: fetch.Route;
       beforeEach(() => {
         const { apiKey, tokenApiHost, apiScheme } = auth.config;
-        const endpoint = `${apiScheme}://${tokenApiHost}${Path.TOKEN}?key=${apiKey}`;
+        const endpoint = `${apiScheme}://${tokenApiHost}${Endpoint.TOKEN}?key=${apiKey}`;
         mock = fetch.mock(endpoint, {
           'access_token': 'new-access-token',
           'refresh_token': 'new-refresh-token',

--- a/packages/auth/src/model/auth.ts
+++ b/packages/auth/src/model/auth.ts
@@ -105,4 +105,5 @@ export interface AuthInternal extends Auth {
   useDeviceLanguage(): void;
   signOut(): Promise<void>;
   validatePassword(password: string): Promise<PasswordValidationStatus>;
+  revokeAccessToken(token: string): Promise<void>;
 }


### PR DESCRIPTION
Implement revokeAccessToken public api. 

Note:
-Did not add tests to [auth_impl.test.ts](https://github.com/firebase/firebase-js-sdk/blob/master/packages/auth/src/core/auth/auth_impl.test.ts) because backend doesn’t return anything for revokeToken api and we cannot verify if apple oauth access token is revoked in auth_impl.test.ts. Please let me know if I’m wrong or there are ways to test `auth_impl#revokeAccessToken`.
-Tested with demo app and was able to revoke apple oauth access token. However, wasn't able to test in multi-tenancy environment because firebase test project doesn't support multi-tenancy and I don't have a personal project that has Apply sign in provider set up.

TODO: Write integration tests if we can retrieve the apple oauth access token in the testing environment.