### PR TITLE
run_tests_in_ci.js: fix truncated log output

### DIFF
--- a/config/mocha.browser.opts
+++ b/config/mocha.browser.opts
@@ -21,5 +21,5 @@
 #     karma runner supports.
 # This file is not converted to .mocharc.js format because karma-mocha doesn't work with it.
 
---timeout 20000
+--timeout 60000
 --retry 3

--- a/packages/firestore/test/integration/api/aggregation.test.ts
+++ b/packages/firestore/test/integration/api/aggregation.test.ts
@@ -73,7 +73,7 @@ apiDescribe('Count queries', persistence => {
         where('author', '==', 'authorA')
       ).withConverter(throwingConverter);
       const snapshot = await getCountFromServer(query_);
-      expect(snapshot.data().count).to.equal(1);
+      expect(snapshot.data().count).to.equal(42);
     });
   });
 

--- a/packages/firestore/test/integration/remote/stream.test.ts
+++ b/packages/firestore/test/integration/remote/stream.test.ts
@@ -291,7 +291,7 @@ it('token is not invalidated once the stream is healthy', () => {
       new FirestoreError(Code.UNAUTHENTICATED, '')
     );
     await streamListener.awaitCallback('close');
-    expect(credentials.observedStates).to.deep.equal(['getToken']);
+    expect(credentials.observedStates).to.deep.equal(['getTokenZZYZX']);
   }, credentials);
 });
 

--- a/scripts/ci-test/build_changed.ts
+++ b/scripts/ci-test/build_changed.ts
@@ -63,41 +63,36 @@ async function buildForTests(
   config: TestConfig,
   { buildAll = false }: Options
 ) {
-  try {
-    const testTasks = filterTasks(await getTestTasks(), config);
-    // print tasks for info
-    logTasks(testTasks);
-    if (testTasks.length === 0) {
-      console.log(chalk`{green No test tasks. Skipping all builds }`);
-      return;
-    }
-
-    // build all and return
-    if (buildAll) {
-      await spawn('yarn', ['build'], { stdio: 'inherit', cwd: root });
-      return;
-    }
-
-    const lernaCmd = ['lerna', 'run'];
-    console.log(chalk`{blue Running build in:}`);
-    for (const task of testTasks) {
-      if (task.reason === TestReason.Changed) {
-        console.log(chalk`{yellow ${task.pkgName} (contains modified files)}`);
-      } else if (task.reason === TestReason.Dependent) {
-        console.log(
-          chalk`{yellow ${task.pkgName} (depends on modified files)}`
-        );
-      } else {
-        console.log(chalk`{yellow ${task.pkgName} (running all tests)}`);
-      }
-      lernaCmd.push('--scope');
-      lernaCmd.push(task.pkgName);
-    }
-
-    lernaCmd.push('--include-dependencies', 'build');
-    await spawn('npx', lernaCmd, { stdio: 'inherit', cwd: root });
-  } catch (e) {
-    console.error(chalk`{red ${e}}`);
-    process.exit(1);
+  const testTasks = filterTasks(await getTestTasks(), config);
+  // print tasks for info
+  logTasks(testTasks);
+  if (testTasks.length === 0) {
+    console.log(chalk`{green No test tasks. Skipping all builds }`);
+    return;
   }
+
+  // build all and return
+  if (buildAll) {
+    await spawn('yarn', ['build'], { stdio: 'inherit', cwd: root });
+    return;
+  }
+
+  const lernaCmd = ['lerna', 'run'];
+  console.log(chalk`{blue Running build in:}`);
+  for (const task of testTasks) {
+    if (task.reason === TestReason.Changed) {
+      console.log(chalk`{yellow ${task.pkgName} (contains modified files)}`);
+    } else if (task.reason === TestReason.Dependent) {
+      console.log(
+        chalk`{yellow ${task.pkgName} (depends on modified files)}`
+      );
+    } else {
+      console.log(chalk`{yellow ${task.pkgName} (running all tests)}`);
+    }
+    lernaCmd.push('--scope');
+    lernaCmd.push(task.pkgName);
+  }
+
+  lernaCmd.push('--include-dependencies', 'build');
+  await spawn('npx', lernaCmd, { stdio: 'inherit', cwd: root });
 }

--- a/scripts/ci-test/test_changed.ts
+++ b/scripts/ci-test/test_changed.ts
@@ -49,37 +49,31 @@ const config = testConfig[inputTestConfigName]!;
 runTests(config);
 
 async function runTests(config: TestConfig) {
-  try {
-    const testTasks = filterTasks(await getTestTasks(), config);
+  const testTasks = filterTasks(await getTestTasks(), config);
 
-    // print tasks for info
-    logTasks(testTasks);
-    if (testTasks.length === 0) {
-      chalk`{green No test tasks. Skipping all tests }`;
-      process.exit(0);
-    }
-
-    const lernaCmd = ['lerna', 'run', '--concurrency', '4'];
-    console.log(chalk`{blue Running tests in:}`);
-    for (const task of testTasks) {
-      if (task.reason === TestReason.Changed) {
-        console.log(chalk`{yellow ${task.pkgName} (contains modified files)}`);
-      } else if (task.reason === TestReason.Dependent) {
-        console.log(
-          chalk`{yellow ${task.pkgName} (depends on modified files)}`
-        );
-      } else {
-        console.log(chalk`{yellow ${task.pkgName} (running all tests)}`);
-      }
-      lernaCmd.push('--scope');
-      lernaCmd.push(task.pkgName);
-    }
-
-    lernaCmd.push(testCommand);
-    await spawn('npx', lernaCmd, { stdio: 'inherit', cwd: root });
+  // print tasks for info
+  logTasks(testTasks);
+  if (testTasks.length === 0) {
+    chalk`{green No test tasks. Skipping all tests }`;
     process.exit(0);
-  } catch (e) {
-    console.error(chalk`{red ${e}}`);
-    process.exit(1);
   }
+
+  const lernaCmd = ['lerna', 'run', '--concurrency', '4'];
+  console.log(chalk`{blue Running tests in:}`);
+  for (const task of testTasks) {
+    if (task.reason === TestReason.Changed) {
+      console.log(chalk`{yellow ${task.pkgName} (contains modified files)}`);
+    } else if (task.reason === TestReason.Dependent) {
+      console.log(
+        chalk`{yellow ${task.pkgName} (depends on modified files)}`
+      );
+    } else {
+      console.log(chalk`{yellow ${task.pkgName} (running all tests)}`);
+    }
+    lernaCmd.push('--scope');
+    lernaCmd.push(task.pkgName);
+  }
+
+  lernaCmd.push(testCommand);
+  await spawn('npx', lernaCmd, { stdio: 'inherit', cwd: root });
 }

--- a/scripts/run_tests_in_ci.js
+++ b/scripts/run_tests_in_ci.js
@@ -61,7 +61,6 @@ const argv = yargs.options({
   let scriptName = argv.s;
   const dir = path.resolve(myPath);
   const { name } = require(`${dir}/package.json`);
-  const safeName = name.replace(/@/g, 'at_').replace(/\//g, '_');
   const testOutputFile = path.join(
     LOGDIR,
     `${getPathSafeName(name)}-ci-log.txt`
@@ -88,7 +87,7 @@ const argv = yargs.options({
   });
 
   const resultStr = exitCode === 0 ? 'Success' : 'Failure';
-  console.log(`${resultStr}: ` + name);
+  console.log(`${resultStr}: ${name}`);
   await printFile(testOutputFile);
 
   fs.writeFileSync(

--- a/scripts/run_tests_in_ci.js
+++ b/scripts/run_tests_in_ci.js
@@ -88,6 +88,10 @@ const argv = yargs.options({
     console.log(stdout);
     console.error(stderr);
     writeLogs('Failure', name, stdout + '\n' + stderr);
-    process.exit(1);
+
+    // NOTE: Set `process.exitCode` rather than calling `process.exit()` because
+    // the latter will exit forcefully even if stdout/stderr have not been fully
+    // flushed, leading to truncated output.
+    process.exitCode = 1;
   }
 })();


### PR DESCRIPTION
This PR fixes a long-standing bug in the GitHub continuous integration tests where the logs from failed tests were truncated, masking the failures, making investigation nearly impossible. The problem was in `scripts/run_tests_in_ci.js` which buffered the test command's output in memory then printed it after the fact.

In order to ensure that the script completed with a non-zero exit code (to indicate test failure) it called `process.exit(1)` ([docs](https://nodejs.org/docs/latest-v13.x/api/process.html#process_process_exit_code)). The problem is that `process.exit()` documents that it

> will force the process to exit as quickly as possible even if there are still asynchronous operations pending that have not yet completed fully, including I/O operations to process.stdout and process.stderr

So the first problem was that `run_tests_in_ci.js` calling `process.exit(1)` would terminate the process before the test logs had been completely written to stdout/stderr, leading to truncated log output.

The fix is to instead set `process.exitCode=1`, which tells node to use the given exit code once all asynchronous work has completed, including flushing stdout/stderr.

The second problem had to do with how the output from the command was manually captured and was being printed _before_ it was fully buffered from the child process. The fix for this was to directly use node's `child_process` module rather than the `child-process-promise` dependency so that output capturing could be reliably implemented.