### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,7 +8,7 @@
 #######################################################################################################
 
 # These owners will be the default owners for everything in the repo.
-*       @dwyfrequency @hsubox76 @firebase/jssdk-global-approvers
+*       @firebase/jssdk-global-approvers
 
 # Database Code
 packages/database @maneesht @jsdt @jmwski @firebase/jssdk-global-approvers


### PR DESCRIPTION
Change default owners to the group, I don't think individual IDs are necessary?

I changed this in the github UI, I'm not sure what it's doing with the last line.