### PR TITLE
Include full output from mocha/karma in CI

### DIFF
--- a/config/karma.base.js
+++ b/config/karma.base.js
@@ -87,11 +87,5 @@ const config = {
 config.mochaReporter = {
   showDiff: true
 };
-// Make it easy to spot failed tests in CI
-if (process.env.CI) {
-  config.mochaReporter = {
-    output: 'minimal'
-  };
-}
 
 module.exports = config;

--- a/config/mocharc.node.js
+++ b/config/mocharc.node.js
@@ -29,11 +29,6 @@ const config = {
   exit: true
 };
 
-// use min reporter in CI to make it easy to spot failed tests
-if (process.env.CI) {
-  config.reporter = 'min';
-}
-
 // Firestore uses babel to compile tests in Nodejs
 if (process.env.NO_TS_NODE) {
   delete config.require;


### PR DESCRIPTION
This effectively reverts https://github.com/firebase/firebase-js-sdk/pull/2980 but the reduced output in CI is too terse to diagnose some Firestore CI issues. And I don't think that having more output is a bad thing, even when there _are_ failures.