### PR TITLE
Remove dependency on @react-native-async-storage/async-storage

### DIFF
--- a/.changeset/eleven-lamps-give.md
+++ b/.changeset/eleven-lamps-give.md
@@ -1,5 +1,6 @@
 ---
 '@firebase/auth': minor
+'firebase': minor
 ---
 
 Remove dependency on @react-native-async-storage/async-storage and add warnings to remind React Native users to manually import it.

--- a/.changeset/eleven-lamps-give.md
+++ b/.changeset/eleven-lamps-give.md
@@ -1,0 +1,5 @@
+---
+'@firebase/auth': minor
+---
+
+Remove dependency on @react-native-async-storage/async-storage and add warnings to remind React Native users to manually import it.

--- a/packages/auth/index.rn.ts
+++ b/packages/auth/index.rn.ts
@@ -71,11 +71,20 @@ export function getAuth(app: FirebaseApp = getApp()): Auth {
     return provider.getImmediate();
   }
 
+  // Only warn if getAuth() is called before initializeAuth()
   _logWarn(NO_PERSISTENCE_WARNING);
 
   return initializeAuthOriginal(app);
 }
 
+/**
+ * Wrapper around base `initializeAuth()` for RN users only, which
+ * shows the warning message if no persistence is provided.
+ * Double-checked potential collision with `export * from './index.shared'`
+ * as `./index.shared` also exports `initializeAuth()`, and the final
+ * bundle does correctly export only this `initializeAuth()` function
+ * and not the one from index.shared.
+ */
 export function initializeAuth(app: FirebaseApp, deps?: Dependencies): Auth {
   if (!deps?.persistence) {
     _logWarn(NO_PERSISTENCE_WARNING);

--- a/packages/auth/index.rn.ts
+++ b/packages/auth/index.rn.ts
@@ -28,7 +28,6 @@ import { Auth, Dependencies } from './src/model/public_types';
 import { initializeAuth as initializeAuthOriginal } from './src';
 import { registerAuth } from './src/core/auth/register';
 import { ClientPlatform } from './src/core/util/version';
-import { getReactNativePersistence } from './src/platform_react_native/persistence/react_native';
 import { _logWarn } from './src/core/util/log';
 
 // Core functionality shared by all clients
@@ -49,7 +48,7 @@ export {
 // MFA
 export { PhoneMultiFactorGenerator } from './src/platform_browser/mfa/assertions/phone';
 
-export { getReactNativePersistence };
+export { getReactNativePersistence } from './src/platform_react_native/persistence/react_native';
 
 const NO_PERSISTENCE_WARNING = `
 You are initializing Firebase Auth for React Native without providing

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -103,7 +103,13 @@
     "typings:public": "node ../../scripts/build/use_typings.js ./dist/auth-public.d.ts"
   },
   "peerDependencies": {
-    "@firebase/app": "0.x"
+    "@firebase/app": "0.x",
+    "@react-native-async-storage/async-storage": "^1.18.1"
+  },
+  "peerDependenciesMeta": {
+    "@react-native-async-storage/async-storage": {
+      "optional": true
+    }
   },
   "dependencies": {
     "@firebase/component": "0.6.4",

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -109,7 +109,6 @@
     "@firebase/component": "0.6.4",
     "@firebase/logger": "0.4.0",
     "@firebase/util": "1.9.3",
-    "@react-native-async-storage/async-storage": "^1.18.1",
     "node-fetch": "2.6.7",
     "tslib": "^2.1.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3263,13 +3263,6 @@
   resolved "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
   integrity sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA=
 
-"@react-native-async-storage/async-storage@^1.18.1":
-  version "1.19.0"
-  resolved "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-1.19.0.tgz#594aca9c20924b7955d62cf43797b4187e1e6cf8"
-  integrity sha512-xOFkz/FaQctD6yNJDur+WnHdSTigOs3pTz6HmfC8X8PYwcnnN3R9UxuWiwsfK8vvT2WioAxUkQt3lB7GySNA2w==
-  dependencies:
-    merge-options "^3.0.4"
-
 "@rollup/plugin-alias@3.1.9":
   version "3.1.9"
   resolved "https://registry.npmjs.org/@rollup/plugin-alias/-/plugin-alias-3.1.9.tgz#a5d267548fe48441f34be8323fb64d1d4a1b3fdf"
@@ -12289,13 +12282,6 @@ merge-descriptors@1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz#b00aaa556dd8b44568150ec9d1b953f3f90cbb61"
   integrity sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=
-
-merge-options@^3.0.4:
-  version "3.0.4"
-  resolved "https://registry.npmjs.org/merge-options/-/merge-options-3.0.4.tgz#84709c2aa2a4b24c1981f66c179fe5565cc6dbb7"
-  integrity sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ==
-  dependencies:
-    is-plain-obj "^2.1.0"
 
 merge-stream@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
See https://github.com/firebase/firebase-js-sdk/issues/7522

In 10.0.0 we added `@react-native-async-storage/async-storage` as a dependency to make things more convenient for React Native users, enabling us to automatically include it as a persistence method for auth. Unfortunately this causes a number of warnings and unexpected issues for non-React Native users. We cannot give the React Native bundle a separate set of dependencies without making a separate NPM package for it. The best compromise is to set the dependency list in a way that works for the majority of users, and document how React Native users can provide an AsyncStorage import to enable auth state persistence.

So this involves 2 steps:
1) Move the dependency to an optional `peerDependency`, using `peerDependenciesMeta` to flag it as optional. This will prevent warnings in the latest versions of all major package installers, including npm, yarn, and pnpm.
2) Added a warning that will display to RN users who call getAuth() or who call initializeAuth() without providing a `persistence` option. The warning will only appear to users of the RN bundle, and will go away if they provide a `persistence` option to `initializeAuth()`.

This will break RN users who have already converted to using `getAuth()` with version 10, but since that release was only a month ago, the sooner we get this out, the sooner we can catch any other users before they convert over. Also, the current `getAuth()` users should get the prominent warning.