### PR TITLE
Firestore: Move local store index auto-creation unit tests into the proper file

### DIFF
--- a/packages/firestore/test/unit/local/local_store.test.ts
+++ b/packages/firestore/test/unit/local/local_store.test.ts
@@ -627,8 +627,7 @@ describe('LocalStore w/ IndexedDB Persistence', () => {
   }
 
   addEqualityMatcher();
-  describe('genericLocalStoreTests', () =>
-    genericLocalStoreTests(initialize, /* gcIsEager= */ false));
+  genericLocalStoreTests(initialize, /* gcIsEager= */ false);
 });
 
 function genericLocalStoreTests(

--- a/packages/firestore/test/unit/local/local_store.test.ts
+++ b/packages/firestore/test/unit/local/local_store.test.ts
@@ -2758,43 +2758,6 @@ function indexedDbLocalStoreTests(
   }
 
   // TODO(dconeybe) port this test next
-  it('index created by index auto creation exists after turn off auto creation', () => {
-    const query_ = query('coll', filter('value', 'not-in', [3]));
-    return (
-      expectLocalStore()
-        .afterAllocatingQuery(query_)
-        .toReturnTargetId(2)
-        .afterIndexAutoCreationConfigure({
-          isEnabled: true,
-          indexAutoCreationMinCollectionSize: 0,
-          relativeIndexReadCostPerDocument: 2
-        })
-        .afterRemoteEvents([
-          docAddedRemoteEvent(doc('coll/a', 10, { value: 5 }), [2], []),
-          docAddedRemoteEvent(doc('coll/b', 10, { value: 3 }), [2], []),
-          docAddedRemoteEvent(doc('coll/c', 10, { value: 3 }), [2], []),
-          docAddedRemoteEvent(doc('coll/d', 10, { value: 3 }), [2], []),
-          docAddedRemoteEvent(doc('coll/e', 10, { value: 2 }), [2], [])
-        ])
-        // First time query runs without indexes.
-        // Based on current heuristic, collection document counts (5) >
-        // 2 * resultSize (2).
-        // Full matched index should be created.
-        .afterExecutingQuery(query_)
-        .toHaveRead({ documentsByKey: 0, documentsByCollection: 2 })
-        .toReturnChanged('coll/a', 'coll/e')
-        .afterIndexAutoCreationConfigure({ isEnabled: false })
-        .afterBackfillIndexes()
-        .afterRemoteEvent(
-          docAddedRemoteEvent(doc('coll/f', 20, { value: 7 }), [2], [])
-        )
-        .afterExecutingQuery(query_)
-        .toHaveRead({ documentsByKey: 2, documentsByCollection: 1 })
-        .toReturnChanged('coll/a', 'coll/e', 'coll/f')
-        .finish()
-    );
-  });
-
   it('disable index auto creation works', () => {
     const query1 = query('coll', filter('value', 'in', [0, 1]));
     const query2 = query('foo', filter('value', '!=', Number.NaN));

--- a/packages/firestore/test/unit/local/local_store.test.ts
+++ b/packages/firestore/test/unit/local/local_store.test.ts
@@ -2758,52 +2758,6 @@ function indexedDbLocalStoreTests(
   }
 
   // TODO(dconeybe) port this test next
-  it('delete all indexes works with index auto creation', () => {
-    const query_ = query('coll', filter('value', '==', 'match'));
-    return (
-      expectLocalStore()
-        .afterAllocatingQuery(query_)
-        .toReturnTargetId(2)
-        .afterIndexAutoCreationConfigure({
-          isEnabled: true,
-          indexAutoCreationMinCollectionSize: 0,
-          relativeIndexReadCostPerDocument: 2
-        })
-        .afterRemoteEvents([
-          docAddedRemoteEvent(doc('coll/a', 10, { value: 'match' }), [2], []),
-          docAddedRemoteEvent(
-            doc('coll/b', 10, { value: Number.NaN }),
-            [2],
-            []
-          ),
-          docAddedRemoteEvent(doc('coll/c', 10, { value: null }), [2], []),
-          docAddedRemoteEvent(
-            doc('coll/d', 10, { value: 'mismatch' }),
-            [2],
-            []
-          ),
-          docAddedRemoteEvent(doc('coll/e', 10, { value: 'match' }), [2], [])
-        ])
-        // First time query is running without indexes.
-        // Based on current heuristic, collection document counts (5) >
-        // 2 * resultSize (2).
-        // Full matched index should be created.
-        .afterExecutingQuery(query_)
-        .toHaveRead({ documentsByKey: 0, documentsByCollection: 2 })
-        .toReturnChanged('coll/a', 'coll/e')
-        .afterIndexAutoCreationConfigure({ isEnabled: false })
-        .afterBackfillIndexes()
-        .afterExecutingQuery(query_)
-        .toHaveRead({ documentsByKey: 2, documentsByCollection: 0 })
-        .toReturnChanged('coll/a', 'coll/e')
-        .afterDeleteAllFieldIndexes()
-        .afterExecutingQuery(query_)
-        .toHaveRead({ documentsByKey: 0, documentsByCollection: 2 })
-        .toReturnChanged('coll/a', 'coll/e')
-        .finish()
-    );
-  });
-
   it('delete all indexes works with manual added indexes', () => {
     const query_ = query('coll', filter('matches', '==', true));
     return expectLocalStore()

--- a/packages/firestore/test/unit/local/local_store.test.ts
+++ b/packages/firestore/test/unit/local/local_store.test.ts
@@ -2758,55 +2758,6 @@ function indexedDbLocalStoreTests(
   }
 
   // TODO(dconeybe) port this test next
-  it('disable index auto creation works', () => {
-    const query1 = query('coll', filter('value', 'in', [0, 1]));
-    const query2 = query('foo', filter('value', '!=', Number.NaN));
-    return (
-      expectLocalStore()
-        .afterAllocatingQuery(query1)
-        .toReturnTargetId(2)
-        .afterIndexAutoCreationConfigure({
-          isEnabled: true,
-          indexAutoCreationMinCollectionSize: 0,
-          relativeIndexReadCostPerDocument: 2
-        })
-        .afterRemoteEvents([
-          docAddedRemoteEvent(doc('coll/a', 10, { value: 1 }), [2], []),
-          docAddedRemoteEvent(doc('coll/b', 10, { value: 8 }), [2], []),
-          docAddedRemoteEvent(doc('coll/c', 10, { value: 'string' }), [2], []),
-          docAddedRemoteEvent(doc('coll/d', 10, { value: false }), [2], []),
-          docAddedRemoteEvent(doc('coll/e', 10, { value: 0 }), [2], [])
-        ])
-        // First time query runs without indexes.
-        // Based on current heuristic, collection document counts (5) >
-        // 2 * resultSize (2).
-        // Full matched index should be created.
-        .afterExecutingQuery(query1)
-        .toHaveRead({ documentsByKey: 0, documentsByCollection: 2 })
-        .toReturnChanged('coll/a', 'coll/e')
-        .afterIndexAutoCreationConfigure({ isEnabled: false })
-        .afterBackfillIndexes()
-        .afterExecutingQuery(query1)
-        .toHaveRead({ documentsByKey: 2, documentsByCollection: 0 })
-        .toReturnChanged('coll/a', 'coll/e')
-        .afterAllocatingQuery(query2)
-        .toReturnTargetId(4)
-        .afterRemoteEvents([
-          docAddedRemoteEvent(doc('foo/a', 10, { value: 5 }), [2], []),
-          docAddedRemoteEvent(doc('foo/b', 10, { value: Number.NaN }), [2], []),
-          docAddedRemoteEvent(doc('foo/c', 10, { value: Number.NaN }), [2], []),
-          docAddedRemoteEvent(doc('foo/d', 10, { value: Number.NaN }), [2], []),
-          docAddedRemoteEvent(doc('foo/e', 10, { value: 'string' }), [2], [])
-        ])
-        .afterExecutingQuery(query2)
-        .toHaveRead({ documentsByKey: 0, documentsByCollection: 2 })
-        .afterBackfillIndexes()
-        .afterExecutingQuery(query2)
-        .toHaveRead({ documentsByKey: 0, documentsByCollection: 2 })
-        .finish()
-    );
-  });
-
   it('index auto creation works with mutation', () => {
     const query_ = query(
       'coll',

--- a/packages/firestore/test/unit/local/local_store.test.ts
+++ b/packages/firestore/test/unit/local/local_store.test.ts
@@ -2758,37 +2758,6 @@ function indexedDbLocalStoreTests(
   }
 
   // TODO(dconeybe) port this test next
-  it('does not auto-create indexes for small collections', () => {
-    const query_ = query('coll', filter('count', '>=', 3));
-    return (
-      expectLocalStore()
-        .afterAllocatingQuery(query_)
-        .toReturnTargetId(2)
-        .afterIndexAutoCreationConfigure({
-          isEnabled: true,
-          relativeIndexReadCostPerDocument: 2
-        })
-        .afterRemoteEvents([
-          docAddedRemoteEvent(doc('coll/a', 10, { count: 5 }), [2], []),
-          docAddedRemoteEvent(doc('coll/b', 10, { count: 1 }), [2], []),
-          docAddedRemoteEvent(doc('coll/c', 10, { count: 0 }), [2], []),
-          docAddedRemoteEvent(doc('coll/d', 10, { count: 1 }), [2], []),
-          docAddedRemoteEvent(doc('coll/e', 10, { count: 3 }), [2], [])
-        ])
-        // SDK will not create indexes since collection size is too small.
-        .afterExecutingQuery(query_)
-        .toHaveRead({ documentsByKey: 0, documentsByCollection: 2 })
-        .toReturnChanged('coll/a', 'coll/e')
-        .afterBackfillIndexes()
-        .afterRemoteEvent(
-          docAddedRemoteEvent(doc('coll/f', 20, { count: 4 }), [2], [])
-        )
-        .afterExecutingQuery(query_)
-        .toHaveRead({ documentsByKey: 0, documentsByCollection: 3 })
-        .toReturnChanged('coll/a', 'coll/e', 'coll/f')
-        .finish()
-    );
-  });
 
   it('does not auto create indexes when index lookup is expensive', () => {
     const query_ = query('coll', filter('array', 'array-contains-any', [0, 7]));

--- a/packages/firestore/test/unit/local/local_store.test.ts
+++ b/packages/firestore/test/unit/local/local_store.test.ts
@@ -2757,42 +2757,7 @@ function indexedDbLocalStoreTests(
     );
   }
 
-  it('can auto-create indexes', () => {
-    const query_ = query('coll', filter('matches', '==', true));
-    return (
-      expectLocalStore()
-        .afterAllocatingQuery(query_)
-        .toReturnTargetId(2)
-        .afterIndexAutoCreationConfigure({
-          isEnabled: true,
-          indexAutoCreationMinCollectionSize: 0,
-          relativeIndexReadCostPerDocument: 2
-        })
-        .afterRemoteEvents([
-          docAddedRemoteEvent(doc('coll/a', 10, { matches: true }), [2], []),
-          docAddedRemoteEvent(doc('coll/b', 10, { matches: false }), [2], []),
-          docAddedRemoteEvent(doc('coll/c', 10, { matches: false }), [2], []),
-          docAddedRemoteEvent(doc('coll/d', 10, { matches: false }), [2], []),
-          docAddedRemoteEvent(doc('coll/e', 10, { matches: true }), [2], [])
-        ])
-        // First time query runs without indexes.
-        // Based on current heuristic, collection document counts (5) >
-        // 2 * resultSize (2).
-        // Full matched index should be created.
-        .afterExecutingQuery(query_)
-        .toHaveRead({ documentsByKey: 0, documentsByCollection: 2 })
-        .toReturnChanged('coll/a', 'coll/e')
-        .afterBackfillIndexes()
-        .afterRemoteEvent(
-          docAddedRemoteEvent(doc('coll/f', 20, { matches: true }), [2], [])
-        )
-        .afterExecutingQuery(query_)
-        .toHaveRead({ documentsByKey: 2, documentsByCollection: 1 })
-        .toReturnChanged('coll/a', 'coll/e', 'coll/f')
-        .finish()
-    );
-  });
-
+  // TODO(dconeybe) port this test next
   it('does not auto-create indexes for small collections', () => {
     const query_ = query('coll', filter('count', '>=', 3));
     return (

--- a/packages/firestore/test/unit/local/local_store.test.ts
+++ b/packages/firestore/test/unit/local/local_store.test.ts
@@ -2758,42 +2758,6 @@ function indexedDbLocalStoreTests(
   }
 
   // TODO(dconeybe) port this test next
-  it('index auto creation works when backfiller runs halfway', () => {
-    const query_ = query('coll', filter('matches', '==', 'foo'));
-    return (
-      expectLocalStore()
-        .afterAllocatingQuery(query_)
-        .toReturnTargetId(2)
-        .afterIndexAutoCreationConfigure({
-          isEnabled: true,
-          indexAutoCreationMinCollectionSize: 0,
-          relativeIndexReadCostPerDocument: 2
-        })
-        .afterRemoteEvents([
-          docAddedRemoteEvent(doc('coll/a', 10, { matches: 'foo' }), [2], []),
-          docAddedRemoteEvent(doc('coll/b', 10, { matches: '' }), [2], []),
-          docAddedRemoteEvent(doc('coll/c', 10, { matches: 'bar' }), [2], []),
-          docAddedRemoteEvent(doc('coll/d', 10, { matches: 7 }), [2], []),
-          docAddedRemoteEvent(doc('coll/e', 10, { matches: 'foo' }), [2], [])
-        ])
-        // First time query runs without indexes.
-        // Based on current heuristic, collection document counts (5) >
-        // 2 * resultSize (2).
-        // Full matched index should be created.
-        .afterExecutingQuery(query_)
-        .toHaveRead({ documentsByKey: 0, documentsByCollection: 2 })
-        .toReturnChanged('coll/a', 'coll/e')
-        .afterBackfillIndexes({ maxDocumentsToProcess: 2 })
-        .afterRemoteEvent(
-          docAddedRemoteEvent(doc('coll/f', 20, { matches: 'foo' }), [2], [])
-        )
-        .afterExecutingQuery(query_)
-        .toHaveRead({ documentsByKey: 1, documentsByCollection: 2 })
-        .toReturnChanged('coll/a', 'coll/e', 'coll/f')
-        .finish()
-    );
-  });
-
   it('index created by index auto creation exists after turn off auto creation', () => {
     const query_ = query('coll', filter('value', 'not-in', [3]));
     return (

--- a/packages/firestore/test/unit/local/local_store.test.ts
+++ b/packages/firestore/test/unit/local/local_store.test.ts
@@ -2758,47 +2758,6 @@ function indexedDbLocalStoreTests(
   }
 
   // TODO(dconeybe) port this test next
-  it('index auto creation works with mutation', () => {
-    const query_ = query(
-      'coll',
-      filter('value', 'array-contains-any', [8, 1, 'string'])
-    );
-    return expectLocalStore()
-      .afterAllocatingQuery(query_)
-      .toReturnTargetId(2)
-      .afterIndexAutoCreationConfigure({
-        isEnabled: true,
-        indexAutoCreationMinCollectionSize: 0,
-        relativeIndexReadCostPerDocument: 2
-      })
-      .afterRemoteEvents([
-        docAddedRemoteEvent(
-          doc('coll/a', 10, { value: [8, 1, 'string'] }),
-          [2],
-          []
-        ),
-        docAddedRemoteEvent(doc('coll/b', 10, { value: [] }), [2], []),
-        docAddedRemoteEvent(doc('coll/c', 10, { value: [3] }), [2], []),
-        docAddedRemoteEvent(doc('coll/d', 10, { value: [0, 5] }), [2], []),
-        docAddedRemoteEvent(doc('coll/e', 10, { value: ['string'] }), [2], [])
-      ])
-      .afterExecutingQuery(query_)
-      .toHaveRead({ documentsByKey: 0, documentsByCollection: 2 })
-      .toReturnChanged('coll/a', 'coll/e')
-      .afterMutation(deleteMutation('coll/e'))
-      .afterBackfillIndexes()
-      .afterMutation(setMutation('coll/f', { value: [1] }))
-      .afterExecutingQuery(query_)
-      .toHaveRead({
-        documentsByKey: 1,
-        documentsByCollection: 0,
-        overlaysByKey: 1,
-        overlaysByCollection: 1
-      })
-      .toReturnChanged('coll/a', 'coll/f')
-      .finish();
-  });
-
   it('delete all indexes works with index auto creation', () => {
     const query_ = query('coll', filter('value', '==', 'match'));
     return (

--- a/packages/firestore/test/unit/local/local_store.test.ts
+++ b/packages/firestore/test/unit/local/local_store.test.ts
@@ -2758,44 +2758,6 @@ function indexedDbLocalStoreTests(
   }
 
   // TODO(dconeybe) port this test next
-
-  it('does not auto create indexes when index lookup is expensive', () => {
-    const query_ = query('coll', filter('array', 'array-contains-any', [0, 7]));
-    return (
-      expectLocalStore()
-        .afterAllocatingQuery(query_)
-        .toReturnTargetId(2)
-        .afterIndexAutoCreationConfigure({
-          isEnabled: true,
-          indexAutoCreationMinCollectionSize: 0,
-          relativeIndexReadCostPerDocument: 5
-        })
-        .afterRemoteEvents([
-          docAddedRemoteEvent(doc('coll/a', 10, { array: [2, 7] }), [2], []),
-          docAddedRemoteEvent(doc('coll/b', 10, { array: [] }), [2], []),
-          docAddedRemoteEvent(doc('coll/c', 10, { array: [3] }), [2], []),
-          docAddedRemoteEvent(
-            doc('coll/d', 10, { array: [2, 10, 20] }),
-            [2],
-            []
-          ),
-          docAddedRemoteEvent(doc('coll/e', 10, { array: [2, 0, 8] }), [2], [])
-        ])
-        // SDK will not create indexes since relative read cost is too large.
-        .afterExecutingQuery(query_)
-        .toHaveRead({ documentsByKey: 0, documentsByCollection: 2 })
-        .toReturnChanged('coll/a', 'coll/e')
-        .afterBackfillIndexes()
-        .afterRemoteEvent(
-          docAddedRemoteEvent(doc('coll/f', 20, { array: [0] }), [2], [])
-        )
-        .afterExecutingQuery(query_)
-        .toHaveRead({ documentsByKey: 0, documentsByCollection: 3 })
-        .toReturnChanged('coll/a', 'coll/e', 'coll/f')
-        .finish()
-    );
-  });
-
   it('index auto creation works when backfiller runs halfway', () => {
     const query_ = query('coll', filter('matches', '==', 'foo'));
     return (

--- a/packages/firestore/test/unit/local/local_store_indexeddb.test.ts
+++ b/packages/firestore/test/unit/local/local_store_indexeddb.test.ts
@@ -112,6 +112,12 @@ class AsyncLocalStoreTester {
     return this.lastTargetId;
   }
 
+  async applyRemoteEvents(...remoteEvents: RemoteEvent[]): Promise<void> {
+    for (const remoteEvent of remoteEvents) {
+      await this.applyRemoteEvent(remoteEvent);
+    }
+  }
+
   async applyRemoteEvent(remoteEvent: RemoteEvent): Promise<void> {
     this.prepareNextStep();
     this.lastChanges = await localStoreApplyRemoteEventToLocalCache(
@@ -499,21 +505,11 @@ describe('LocalStore w/ IndexedDB Persistence (Non generic)', () => {
       relativeIndexReadCostPerDocument: 2
     });
 
-    docAddedRemoteEvent(doc('coll/a', 10, { matches: true }), [targetId]);
-
-    await test.applyRemoteEvent(
-      docAddedRemoteEvent(doc('coll/a', 10, { matches: true }), [targetId])
-    );
-    await test.applyRemoteEvent(
-      docAddedRemoteEvent(doc('coll/b', 10, { matches: false }), [targetId])
-    );
-    await test.applyRemoteEvent(
-      docAddedRemoteEvent(doc('coll/c', 10, { matches: false }), [targetId])
-    );
-    await test.applyRemoteEvent(
-      docAddedRemoteEvent(doc('coll/d', 10, { matches: false }), [targetId])
-    );
-    await test.applyRemoteEvent(
+    await test.applyRemoteEvents(
+      docAddedRemoteEvent(doc('coll/a', 10, { matches: true }), [targetId]),
+      docAddedRemoteEvent(doc('coll/b', 10, { matches: false }), [targetId]),
+      docAddedRemoteEvent(doc('coll/c', 10, { matches: false }), [targetId]),
+      docAddedRemoteEvent(doc('coll/d', 10, { matches: false }), [targetId]),
       docAddedRemoteEvent(doc('coll/e', 10, { matches: true }), [targetId])
     );
 
@@ -544,19 +540,11 @@ describe('LocalStore w/ IndexedDB Persistence (Non generic)', () => {
       relativeIndexReadCostPerDocument: 2
     });
 
-    await test.applyRemoteEvent(
-      docAddedRemoteEvent(doc('coll/a', 10, { count: 5 }), [targetId])
-    );
-    await test.applyRemoteEvent(
-      docAddedRemoteEvent(doc('coll/b', 10, { count: 1 }), [targetId])
-    );
-    await test.applyRemoteEvent(
-      docAddedRemoteEvent(doc('coll/c', 10, { count: 0 }), [targetId])
-    );
-    await test.applyRemoteEvent(
-      docAddedRemoteEvent(doc('coll/d', 10, { count: 1 }), [targetId])
-    );
-    await test.applyRemoteEvent(
+    await test.applyRemoteEvents(
+      docAddedRemoteEvent(doc('coll/a', 10, { count: 5 }), [targetId]),
+      docAddedRemoteEvent(doc('coll/b', 10, { count: 1 }), [targetId]),
+      docAddedRemoteEvent(doc('coll/c', 10, { count: 0 }), [targetId]),
+      docAddedRemoteEvent(doc('coll/d', 10, { count: 1 }), [targetId]),
       docAddedRemoteEvent(doc('coll/e', 10, { count: 3 }), [targetId])
     );
 
@@ -585,19 +573,13 @@ describe('LocalStore w/ IndexedDB Persistence (Non generic)', () => {
       relativeIndexReadCostPerDocument: 5
     });
 
-    await test.applyRemoteEvent(
-      docAddedRemoteEvent(doc('coll/a', 10, { array: [2, 7] }), [targetId])
-    );
-    await test.applyRemoteEvent(
-      docAddedRemoteEvent(doc('coll/b', 10, { array: [] }), [targetId])
-    );
-    await test.applyRemoteEvent(
-      docAddedRemoteEvent(doc('coll/c', 10, { array: [3] }), [targetId])
-    );
-    await test.applyRemoteEvent(
-      docAddedRemoteEvent(doc('coll/d', 10, { array: [2, 10, 20] }), [targetId])
-    );
-    await test.applyRemoteEvent(
+    await test.applyRemoteEvents(
+      docAddedRemoteEvent(doc('coll/a', 10, { array: [2, 7] }), [targetId]),
+      docAddedRemoteEvent(doc('coll/b', 10, { array: [] }), [targetId]),
+      docAddedRemoteEvent(doc('coll/c', 10, { array: [3] }), [targetId]),
+      docAddedRemoteEvent(doc('coll/d', 10, { array: [2, 10, 20] }), [
+        targetId
+      ]),
       docAddedRemoteEvent(doc('coll/e', 10, { array: [2, 0, 8] }), [targetId])
     );
 
@@ -626,19 +608,11 @@ describe('LocalStore w/ IndexedDB Persistence (Non generic)', () => {
       relativeIndexReadCostPerDocument: 2
     });
 
-    await test.applyRemoteEvent(
-      docAddedRemoteEvent(doc('coll/a', 10, { matches: 'foo' }), [targetId])
-    );
-    await test.applyRemoteEvent(
-      docAddedRemoteEvent(doc('coll/b', 10, { matches: '' }), [targetId])
-    );
-    await test.applyRemoteEvent(
-      docAddedRemoteEvent(doc('coll/c', 10, { matches: 'bar' }), [targetId])
-    );
-    await test.applyRemoteEvent(
-      docAddedRemoteEvent(doc('coll/d', 10, { matches: 7 }), [targetId])
-    );
-    await test.applyRemoteEvent(
+    await test.applyRemoteEvents(
+      docAddedRemoteEvent(doc('coll/a', 10, { matches: 'foo' }), [targetId]),
+      docAddedRemoteEvent(doc('coll/b', 10, { matches: '' }), [targetId]),
+      docAddedRemoteEvent(doc('coll/c', 10, { matches: 'bar' }), [targetId]),
+      docAddedRemoteEvent(doc('coll/d', 10, { matches: 7 }), [targetId]),
       docAddedRemoteEvent(doc('coll/e', 10, { matches: 'foo' }), [targetId])
     );
 
@@ -670,19 +644,11 @@ describe('LocalStore w/ IndexedDB Persistence (Non generic)', () => {
       relativeIndexReadCostPerDocument: 2
     });
 
-    await test.applyRemoteEvent(
-      docAddedRemoteEvent(doc('coll/a', 10, { value: 5 }), [targetId])
-    );
-    await test.applyRemoteEvent(
-      docAddedRemoteEvent(doc('coll/b', 10, { value: 3 }), [targetId])
-    );
-    await test.applyRemoteEvent(
-      docAddedRemoteEvent(doc('coll/c', 10, { value: 3 }), [targetId])
-    );
-    await test.applyRemoteEvent(
-      docAddedRemoteEvent(doc('coll/d', 10, { value: 3 }), [targetId])
-    );
-    await test.applyRemoteEvent(
+    await test.applyRemoteEvents(
+      docAddedRemoteEvent(doc('coll/a', 10, { value: 5 }), [targetId]),
+      docAddedRemoteEvent(doc('coll/b', 10, { value: 3 }), [targetId]),
+      docAddedRemoteEvent(doc('coll/c', 10, { value: 3 }), [targetId]),
+      docAddedRemoteEvent(doc('coll/d', 10, { value: 3 }), [targetId]),
       docAddedRemoteEvent(doc('coll/e', 10, { value: 2 }), [targetId])
     );
 
@@ -717,19 +683,11 @@ describe('LocalStore w/ IndexedDB Persistence (Non generic)', () => {
       relativeIndexReadCostPerDocument: 2
     });
 
-    await test.applyRemoteEvent(
-      docAddedRemoteEvent(doc('coll/a', 10, { value: 1 }), [targetId1])
-    );
-    await test.applyRemoteEvent(
-      docAddedRemoteEvent(doc('coll/b', 10, { value: 8 }), [targetId1])
-    );
-    await test.applyRemoteEvent(
-      docAddedRemoteEvent(doc('coll/c', 10, { value: 'string' }), [targetId1])
-    );
-    await test.applyRemoteEvent(
-      docAddedRemoteEvent(doc('coll/d', 10, { value: false }), [targetId1])
-    );
-    await test.applyRemoteEvent(
+    await test.applyRemoteEvents(
+      docAddedRemoteEvent(doc('coll/a', 10, { value: 1 }), [targetId1]),
+      docAddedRemoteEvent(doc('coll/b', 10, { value: 8 }), [targetId1]),
+      docAddedRemoteEvent(doc('coll/c', 10, { value: 'string' }), [targetId1]),
+      docAddedRemoteEvent(doc('coll/d', 10, { value: false }), [targetId1]),
       docAddedRemoteEvent(doc('coll/e', 10, { value: 0 }), [targetId1])
     );
 
@@ -748,19 +706,11 @@ describe('LocalStore w/ IndexedDB Persistence (Non generic)', () => {
     test.assertQueryReturned('coll/a', 'coll/e');
 
     const targetId2 = await test.allocateQuery(query2);
-    await test.applyRemoteEvent(
-      docAddedRemoteEvent(doc('foo/a', 10, { value: 5 }), [targetId2])
-    );
-    await test.applyRemoteEvent(
-      docAddedRemoteEvent(doc('foo/b', 10, { value: Number.NaN }), [targetId2])
-    );
-    await test.applyRemoteEvent(
-      docAddedRemoteEvent(doc('foo/c', 10, { value: Number.NaN }), [targetId2])
-    );
-    await test.applyRemoteEvent(
-      docAddedRemoteEvent(doc('foo/d', 10, { value: Number.NaN }), [targetId2])
-    );
-    await test.applyRemoteEvent(
+    await test.applyRemoteEvents(
+      docAddedRemoteEvent(doc('foo/a', 10, { value: 5 }), [targetId2]),
+      docAddedRemoteEvent(doc('foo/b', 10, { value: Number.NaN }), [targetId2]),
+      docAddedRemoteEvent(doc('foo/c', 10, { value: Number.NaN }), [targetId2]),
+      docAddedRemoteEvent(doc('foo/d', 10, { value: Number.NaN }), [targetId2]),
       docAddedRemoteEvent(doc('foo/e', 10, { value: 'string' }), [targetId2])
     );
 
@@ -784,21 +734,13 @@ describe('LocalStore w/ IndexedDB Persistence (Non generic)', () => {
       relativeIndexReadCostPerDocument: 2
     });
 
-    await test.applyRemoteEvent(
+    await test.applyRemoteEvents(
       docAddedRemoteEvent(doc('coll/a', 10, { value: [8, 1, 'string'] }), [
         targetId
-      ])
-    );
-    await test.applyRemoteEvent(
-      docAddedRemoteEvent(doc('coll/b', 10, { value: [] }), [targetId])
-    );
-    await test.applyRemoteEvent(
-      docAddedRemoteEvent(doc('coll/c', 10, { value: [3] }), [targetId])
-    );
-    await test.applyRemoteEvent(
-      docAddedRemoteEvent(doc('coll/d', 10, { value: [0, 5] }), [targetId])
-    );
-    await test.applyRemoteEvent(
+      ]),
+      docAddedRemoteEvent(doc('coll/b', 10, { value: [] }), [targetId]),
+      docAddedRemoteEvent(doc('coll/c', 10, { value: [3] }), [targetId]),
+      docAddedRemoteEvent(doc('coll/d', 10, { value: [0, 5] }), [targetId]),
       docAddedRemoteEvent(doc('coll/e', 10, { value: ['string'] }), [targetId])
     );
 
@@ -826,19 +768,11 @@ describe('LocalStore w/ IndexedDB Persistence (Non generic)', () => {
       relativeIndexReadCostPerDocument: 2
     });
 
-    await test.applyRemoteEvent(
-      docAddedRemoteEvent(doc('coll/a', 10, { value: 'match' }), [targetId])
-    );
-    await test.applyRemoteEvent(
-      docAddedRemoteEvent(doc('coll/b', 10, { value: Number.NaN }), [targetId])
-    );
-    await test.applyRemoteEvent(
-      docAddedRemoteEvent(doc('coll/c', 10, { value: null }), [targetId])
-    );
-    await test.applyRemoteEvent(
-      docAddedRemoteEvent(doc('coll/d', 10, { value: 'mismatch' }), [targetId])
-    );
-    await test.applyRemoteEvent(
+    await test.applyRemoteEvents(
+      docAddedRemoteEvent(doc('coll/a', 10, { value: 'match' }), [targetId]),
+      docAddedRemoteEvent(doc('coll/b', 10, { value: Number.NaN }), [targetId]),
+      docAddedRemoteEvent(doc('coll/c', 10, { value: null }), [targetId]),
+      docAddedRemoteEvent(doc('coll/d', 10, { value: 'mismatch' }), [targetId]),
       docAddedRemoteEvent(doc('coll/e', 10, { value: 'match' }), [targetId])
     );
 

--- a/packages/firestore/test/unit/local/local_store_indexeddb.test.ts
+++ b/packages/firestore/test/unit/local/local_store_indexeddb.test.ts
@@ -137,10 +137,7 @@ class AsyncLocalStoreTester {
     this.prepareNextStep();
 
     if (config.isEnabled !== undefined) {
-      localStoreSetIndexAutoCreationEnabled(
-        this.localStore,
-        config.isEnabled
-      );
+      localStoreSetIndexAutoCreationEnabled(this.localStore, config.isEnabled);
     }
     LocalStoreTestingHooks.setIndexAutoCreationSettings(
       this.localStore,
@@ -149,7 +146,7 @@ class AsyncLocalStoreTester {
   }
 
   deleteAllFieldIndexes(): Promise<void> {
-    return localStoreDeleteAllFieldIndexes(this.localStore)
+    return localStoreDeleteAllFieldIndexes(this.localStore);
   }
 
   async configureAndAssertFieldsIndexes(
@@ -502,13 +499,23 @@ describe('LocalStore w/ IndexedDB Persistence (Non generic)', () => {
       relativeIndexReadCostPerDocument: 2
     });
 
-    docAddedRemoteEvent(doc('coll/a', 10, { matches: true }), [targetId])
+    docAddedRemoteEvent(doc('coll/a', 10, { matches: true }), [targetId]);
 
-    await test.applyRemoteEvent(docAddedRemoteEvent(doc('coll/a', 10, { matches: true }), [targetId]));
-    await test.applyRemoteEvent(docAddedRemoteEvent(doc('coll/b', 10, { matches: false }), [targetId]));
-    await test.applyRemoteEvent(docAddedRemoteEvent(doc('coll/c', 10, { matches: false }), [targetId]));
-    await test.applyRemoteEvent(docAddedRemoteEvent(doc('coll/d', 10, { matches: false }), [targetId]));
-    await test.applyRemoteEvent(docAddedRemoteEvent(doc('coll/e', 10, { matches: true }), [targetId]));
+    await test.applyRemoteEvent(
+      docAddedRemoteEvent(doc('coll/a', 10, { matches: true }), [targetId])
+    );
+    await test.applyRemoteEvent(
+      docAddedRemoteEvent(doc('coll/b', 10, { matches: false }), [targetId])
+    );
+    await test.applyRemoteEvent(
+      docAddedRemoteEvent(doc('coll/c', 10, { matches: false }), [targetId])
+    );
+    await test.applyRemoteEvent(
+      docAddedRemoteEvent(doc('coll/d', 10, { matches: false }), [targetId])
+    );
+    await test.applyRemoteEvent(
+      docAddedRemoteEvent(doc('coll/e', 10, { matches: true }), [targetId])
+    );
 
     // First time query runs without indexes.
     // Based on current heuristic, collection document counts (5) >
@@ -520,7 +527,9 @@ describe('LocalStore w/ IndexedDB Persistence (Non generic)', () => {
 
     await test.backfillIndexes();
 
-    await test.applyRemoteEvent(docAddedRemoteEvent(doc('coll/f', 20, { matches: true }), [targetId]));
+    await test.applyRemoteEvent(
+      docAddedRemoteEvent(doc('coll/f', 20, { matches: true }), [targetId])
+    );
 
     await test.executeQuery(query_);
     test.assertRemoteDocumentsRead(2, 1);
@@ -535,11 +544,21 @@ describe('LocalStore w/ IndexedDB Persistence (Non generic)', () => {
       relativeIndexReadCostPerDocument: 2
     });
 
-    await test.applyRemoteEvent(docAddedRemoteEvent(doc('coll/a', 10, { count: 5 }), [targetId]));
-    await test.applyRemoteEvent(docAddedRemoteEvent(doc('coll/b', 10, { count: 1 }), [targetId]));
-    await test.applyRemoteEvent(docAddedRemoteEvent(doc('coll/c', 10, { count: 0 }), [targetId]));
-    await test.applyRemoteEvent(docAddedRemoteEvent(doc('coll/d', 10, { count: 1 }), [targetId]));
-    await test.applyRemoteEvent(docAddedRemoteEvent(doc('coll/e', 10, { count: 3 }), [targetId]));
+    await test.applyRemoteEvent(
+      docAddedRemoteEvent(doc('coll/a', 10, { count: 5 }), [targetId])
+    );
+    await test.applyRemoteEvent(
+      docAddedRemoteEvent(doc('coll/b', 10, { count: 1 }), [targetId])
+    );
+    await test.applyRemoteEvent(
+      docAddedRemoteEvent(doc('coll/c', 10, { count: 0 }), [targetId])
+    );
+    await test.applyRemoteEvent(
+      docAddedRemoteEvent(doc('coll/d', 10, { count: 1 }), [targetId])
+    );
+    await test.applyRemoteEvent(
+      docAddedRemoteEvent(doc('coll/e', 10, { count: 3 }), [targetId])
+    );
 
     // SDK will not create indexes since collection size is too small.
     await test.executeQuery(query_);
@@ -548,7 +567,9 @@ describe('LocalStore w/ IndexedDB Persistence (Non generic)', () => {
 
     await test.backfillIndexes();
 
-    await test.applyRemoteEvent(docAddedRemoteEvent(doc('coll/f', 20, { count: 4 }), [targetId]));
+    await test.applyRemoteEvent(
+      docAddedRemoteEvent(doc('coll/f', 20, { count: 4 }), [targetId])
+    );
 
     await test.executeQuery(query_);
     test.assertRemoteDocumentsRead(0, 3);
@@ -564,11 +585,21 @@ describe('LocalStore w/ IndexedDB Persistence (Non generic)', () => {
       relativeIndexReadCostPerDocument: 5
     });
 
-    await test.applyRemoteEvent(docAddedRemoteEvent(doc('coll/a', 10, { array: [2, 7] }), [targetId]));
-    await test.applyRemoteEvent(docAddedRemoteEvent(doc('coll/b', 10, { array: [] }), [targetId]));
-    await test.applyRemoteEvent(docAddedRemoteEvent(doc('coll/c', 10, { array: [3] }), [targetId]));
-    await test.applyRemoteEvent(docAddedRemoteEvent(doc('coll/d', 10, { array: [2, 10, 20] }), [targetId]));
-    await test.applyRemoteEvent(docAddedRemoteEvent(doc('coll/e', 10, { array: [2, 0, 8] }), [targetId]));
+    await test.applyRemoteEvent(
+      docAddedRemoteEvent(doc('coll/a', 10, { array: [2, 7] }), [targetId])
+    );
+    await test.applyRemoteEvent(
+      docAddedRemoteEvent(doc('coll/b', 10, { array: [] }), [targetId])
+    );
+    await test.applyRemoteEvent(
+      docAddedRemoteEvent(doc('coll/c', 10, { array: [3] }), [targetId])
+    );
+    await test.applyRemoteEvent(
+      docAddedRemoteEvent(doc('coll/d', 10, { array: [2, 10, 20] }), [targetId])
+    );
+    await test.applyRemoteEvent(
+      docAddedRemoteEvent(doc('coll/e', 10, { array: [2, 0, 8] }), [targetId])
+    );
 
     // SDK will not create indexes since relative read cost is too large.
     await test.executeQuery(query_);
@@ -577,7 +608,9 @@ describe('LocalStore w/ IndexedDB Persistence (Non generic)', () => {
 
     await test.backfillIndexes();
 
-    await test.applyRemoteEvent(docAddedRemoteEvent(doc('coll/f', 20, { array: [0] }), [targetId]));
+    await test.applyRemoteEvent(
+      docAddedRemoteEvent(doc('coll/f', 20, { array: [0] }), [targetId])
+    );
 
     await test.executeQuery(query_);
     test.assertRemoteDocumentsRead(0, 3);
@@ -593,11 +626,21 @@ describe('LocalStore w/ IndexedDB Persistence (Non generic)', () => {
       relativeIndexReadCostPerDocument: 2
     });
 
-    await test.applyRemoteEvent(docAddedRemoteEvent(doc('coll/a', 10, { matches: 'foo' }), [targetId]));
-    await test.applyRemoteEvent(docAddedRemoteEvent(doc('coll/b', 10, { matches: '' }), [targetId]));
-    await test.applyRemoteEvent(docAddedRemoteEvent(doc('coll/c', 10, { matches: 'bar' }), [targetId]));
-    await test.applyRemoteEvent(docAddedRemoteEvent(doc('coll/d', 10, { matches: 7 }), [targetId]));
-    await test.applyRemoteEvent(docAddedRemoteEvent(doc('coll/e', 10, { matches: 'foo' }), [targetId]));
+    await test.applyRemoteEvent(
+      docAddedRemoteEvent(doc('coll/a', 10, { matches: 'foo' }), [targetId])
+    );
+    await test.applyRemoteEvent(
+      docAddedRemoteEvent(doc('coll/b', 10, { matches: '' }), [targetId])
+    );
+    await test.applyRemoteEvent(
+      docAddedRemoteEvent(doc('coll/c', 10, { matches: 'bar' }), [targetId])
+    );
+    await test.applyRemoteEvent(
+      docAddedRemoteEvent(doc('coll/d', 10, { matches: 7 }), [targetId])
+    );
+    await test.applyRemoteEvent(
+      docAddedRemoteEvent(doc('coll/e', 10, { matches: 'foo' }), [targetId])
+    );
 
     // First time query runs without indexes.
     // Based on current heuristic, collection document counts (5) >
@@ -609,7 +652,9 @@ describe('LocalStore w/ IndexedDB Persistence (Non generic)', () => {
 
     await test.backfillIndexes({ maxDocumentsToProcess: 2 });
 
-    await test.applyRemoteEvent(docAddedRemoteEvent(doc('coll/f', 20, { matches: 'foo' }), [targetId]));
+    await test.applyRemoteEvent(
+      docAddedRemoteEvent(doc('coll/f', 20, { matches: 'foo' }), [targetId])
+    );
 
     await test.executeQuery(query_);
     test.assertRemoteDocumentsRead(1, 2);
@@ -625,11 +670,21 @@ describe('LocalStore w/ IndexedDB Persistence (Non generic)', () => {
       relativeIndexReadCostPerDocument: 2
     });
 
-    await test.applyRemoteEvent(docAddedRemoteEvent(doc('coll/a', 10, { value: 5 }), [targetId]));
-    await test.applyRemoteEvent(docAddedRemoteEvent(doc('coll/b', 10, { value: 3 }), [targetId]));
-    await test.applyRemoteEvent(docAddedRemoteEvent(doc('coll/c', 10, { value: 3 }), [targetId]));
-    await test.applyRemoteEvent(docAddedRemoteEvent(doc('coll/d', 10, { value: 3 }), [targetId]));
-    await test.applyRemoteEvent(docAddedRemoteEvent(doc('coll/e', 10, { value: 2 }), [targetId]));
+    await test.applyRemoteEvent(
+      docAddedRemoteEvent(doc('coll/a', 10, { value: 5 }), [targetId])
+    );
+    await test.applyRemoteEvent(
+      docAddedRemoteEvent(doc('coll/b', 10, { value: 3 }), [targetId])
+    );
+    await test.applyRemoteEvent(
+      docAddedRemoteEvent(doc('coll/c', 10, { value: 3 }), [targetId])
+    );
+    await test.applyRemoteEvent(
+      docAddedRemoteEvent(doc('coll/d', 10, { value: 3 }), [targetId])
+    );
+    await test.applyRemoteEvent(
+      docAddedRemoteEvent(doc('coll/e', 10, { value: 2 }), [targetId])
+    );
 
     // First time query runs without indexes.
     // Based on current heuristic, collection document counts (5) >
@@ -639,10 +694,12 @@ describe('LocalStore w/ IndexedDB Persistence (Non generic)', () => {
     test.assertRemoteDocumentsRead(0, 2);
     test.assertQueryReturned('coll/a', 'coll/e');
 
-    test.configureIndexAutoCreation({isEnabled: false,});
+    test.configureIndexAutoCreation({ isEnabled: false });
     await test.backfillIndexes();
 
-    await test.applyRemoteEvent(docAddedRemoteEvent(doc('coll/f', 20, { value: 7 }), [targetId]));
+    await test.applyRemoteEvent(
+      docAddedRemoteEvent(doc('coll/f', 20, { value: 7 }), [targetId])
+    );
 
     await test.executeQuery(query_);
     test.assertRemoteDocumentsRead(2, 1);
@@ -660,11 +717,21 @@ describe('LocalStore w/ IndexedDB Persistence (Non generic)', () => {
       relativeIndexReadCostPerDocument: 2
     });
 
-    await test.applyRemoteEvent(docAddedRemoteEvent(doc('coll/a', 10, { value: 1 }), [targetId1]));
-    await test.applyRemoteEvent(docAddedRemoteEvent(doc('coll/b', 10, { value: 8 }), [targetId1]));
-    await test.applyRemoteEvent(docAddedRemoteEvent(doc('coll/c', 10, { value: 'string' }), [targetId1]));
-    await test.applyRemoteEvent(docAddedRemoteEvent(doc('coll/d', 10, { value: false }), [targetId1]));
-    await test.applyRemoteEvent(docAddedRemoteEvent(doc('coll/e', 10, { value: 0 }), [targetId1]));
+    await test.applyRemoteEvent(
+      docAddedRemoteEvent(doc('coll/a', 10, { value: 1 }), [targetId1])
+    );
+    await test.applyRemoteEvent(
+      docAddedRemoteEvent(doc('coll/b', 10, { value: 8 }), [targetId1])
+    );
+    await test.applyRemoteEvent(
+      docAddedRemoteEvent(doc('coll/c', 10, { value: 'string' }), [targetId1])
+    );
+    await test.applyRemoteEvent(
+      docAddedRemoteEvent(doc('coll/d', 10, { value: false }), [targetId1])
+    );
+    await test.applyRemoteEvent(
+      docAddedRemoteEvent(doc('coll/e', 10, { value: 0 }), [targetId1])
+    );
 
     // First time query runs without indexes.
     // Based on current heuristic, collection document counts (5) >
@@ -674,18 +741,28 @@ describe('LocalStore w/ IndexedDB Persistence (Non generic)', () => {
     test.assertRemoteDocumentsRead(0, 2);
     test.assertQueryReturned('coll/a', 'coll/e');
 
-    test.configureIndexAutoCreation({isEnabled: false,});
+    test.configureIndexAutoCreation({ isEnabled: false });
     await test.backfillIndexes();
     await test.executeQuery(query1);
     test.assertRemoteDocumentsRead(2, 0);
     test.assertQueryReturned('coll/a', 'coll/e');
 
     const targetId2 = await test.allocateQuery(query2);
-    await test.applyRemoteEvent(docAddedRemoteEvent(doc('foo/a', 10, { value: 5 }), [targetId2]));
-    await test.applyRemoteEvent(docAddedRemoteEvent(doc('foo/b', 10, { value: Number.NaN }), [targetId2]));
-    await test.applyRemoteEvent(docAddedRemoteEvent(doc('foo/c', 10, { value: Number.NaN }), [targetId2]));
-    await test.applyRemoteEvent(docAddedRemoteEvent(doc('foo/d', 10, { value: Number.NaN }), [targetId2]));
-    await test.applyRemoteEvent(docAddedRemoteEvent(doc('foo/e', 10, { value: 'string' }), [targetId2]));
+    await test.applyRemoteEvent(
+      docAddedRemoteEvent(doc('foo/a', 10, { value: 5 }), [targetId2])
+    );
+    await test.applyRemoteEvent(
+      docAddedRemoteEvent(doc('foo/b', 10, { value: Number.NaN }), [targetId2])
+    );
+    await test.applyRemoteEvent(
+      docAddedRemoteEvent(doc('foo/c', 10, { value: Number.NaN }), [targetId2])
+    );
+    await test.applyRemoteEvent(
+      docAddedRemoteEvent(doc('foo/d', 10, { value: Number.NaN }), [targetId2])
+    );
+    await test.applyRemoteEvent(
+      docAddedRemoteEvent(doc('foo/e', 10, { value: 'string' }), [targetId2])
+    );
 
     await test.executeQuery(query2);
     test.assertRemoteDocumentsRead(0, 2);
@@ -695,7 +772,10 @@ describe('LocalStore w/ IndexedDB Persistence (Non generic)', () => {
   });
 
   it('index auto creation works with mutation', async () => {
-    const query_ = query('coll', filter('value', 'array-contains-any', [8, 1, 'string']));
+    const query_ = query(
+      'coll',
+      filter('value', 'array-contains-any', [8, 1, 'string'])
+    );
 
     const targetId = await test.allocateQuery(query_);
     test.configureIndexAutoCreation({
@@ -704,11 +784,23 @@ describe('LocalStore w/ IndexedDB Persistence (Non generic)', () => {
       relativeIndexReadCostPerDocument: 2
     });
 
-    await test.applyRemoteEvent(docAddedRemoteEvent(doc('coll/a', 10, { value: [8, 1, 'string'] }), [targetId]));
-    await test.applyRemoteEvent(docAddedRemoteEvent(doc('coll/b', 10, { value: [] }), [targetId]));
-    await test.applyRemoteEvent(docAddedRemoteEvent(doc('coll/c', 10, { value: [3] }), [targetId]));
-    await test.applyRemoteEvent(docAddedRemoteEvent(doc('coll/d', 10, { value: [0, 5] }), [targetId]));
-    await test.applyRemoteEvent(docAddedRemoteEvent(doc('coll/e', 10, { value: ['string'] }), [targetId]));
+    await test.applyRemoteEvent(
+      docAddedRemoteEvent(doc('coll/a', 10, { value: [8, 1, 'string'] }), [
+        targetId
+      ])
+    );
+    await test.applyRemoteEvent(
+      docAddedRemoteEvent(doc('coll/b', 10, { value: [] }), [targetId])
+    );
+    await test.applyRemoteEvent(
+      docAddedRemoteEvent(doc('coll/c', 10, { value: [3] }), [targetId])
+    );
+    await test.applyRemoteEvent(
+      docAddedRemoteEvent(doc('coll/d', 10, { value: [0, 5] }), [targetId])
+    );
+    await test.applyRemoteEvent(
+      docAddedRemoteEvent(doc('coll/e', 10, { value: ['string'] }), [targetId])
+    );
 
     await test.executeQuery(query_);
     test.assertRemoteDocumentsRead(0, 2);
@@ -723,7 +815,7 @@ describe('LocalStore w/ IndexedDB Persistence (Non generic)', () => {
     test.assertOverlaysRead(1, 1);
     test.assertQueryReturned('coll/a', 'coll/f');
   });
-  
+
   it('delete all indexes works with index auto creation', async () => {
     const query_ = query('coll', filter('value', '==', 'match'));
 
@@ -734,11 +826,21 @@ describe('LocalStore w/ IndexedDB Persistence (Non generic)', () => {
       relativeIndexReadCostPerDocument: 2
     });
 
-    await test.applyRemoteEvent(docAddedRemoteEvent(doc('coll/a', 10, { value: 'match' }), [targetId]));
-    await test.applyRemoteEvent(docAddedRemoteEvent(doc('coll/b', 10, { value: Number.NaN }), [targetId]));
-    await test.applyRemoteEvent(docAddedRemoteEvent(doc('coll/c', 10, { value: null }), [targetId]));
-    await test.applyRemoteEvent(docAddedRemoteEvent(doc('coll/d', 10, { value: 'mismatch' }), [targetId]));
-    await test.applyRemoteEvent(docAddedRemoteEvent(doc('coll/e', 10, { value: 'match' }), [targetId]));
+    await test.applyRemoteEvent(
+      docAddedRemoteEvent(doc('coll/a', 10, { value: 'match' }), [targetId])
+    );
+    await test.applyRemoteEvent(
+      docAddedRemoteEvent(doc('coll/b', 10, { value: Number.NaN }), [targetId])
+    );
+    await test.applyRemoteEvent(
+      docAddedRemoteEvent(doc('coll/c', 10, { value: null }), [targetId])
+    );
+    await test.applyRemoteEvent(
+      docAddedRemoteEvent(doc('coll/d', 10, { value: 'mismatch' }), [targetId])
+    );
+    await test.applyRemoteEvent(
+      docAddedRemoteEvent(doc('coll/e', 10, { value: 'match' }), [targetId])
+    );
 
     // First time query is running without indexes.
     // Based on current heuristic, collection document counts (5) >
@@ -748,7 +850,7 @@ describe('LocalStore w/ IndexedDB Persistence (Non generic)', () => {
     test.assertRemoteDocumentsRead(0, 2);
     test.assertQueryReturned('coll/a', 'coll/e');
 
-    test.configureIndexAutoCreation({isEnabled: false})
+    test.configureIndexAutoCreation({ isEnabled: false });
     await test.backfillIndexes();
     await test.executeQuery(query_);
     test.assertRemoteDocumentsRead(2, 0);
@@ -759,16 +861,20 @@ describe('LocalStore w/ IndexedDB Persistence (Non generic)', () => {
     test.assertRemoteDocumentsRead(0, 2);
     test.assertQueryReturned('coll/a', 'coll/e');
   });
-  
+
   it('delete all indexes works with manual added indexes', async () => {
     const query_ = query('coll', filter('matches', '==', true));
-    
-    await test.configureFieldsIndexes(fieldIndex('coll', {
-      fields: [['matches', IndexKind.ASCENDING]]
-    }));
+
+    await test.configureFieldsIndexes(
+      fieldIndex('coll', {
+        fields: [['matches', IndexKind.ASCENDING]]
+      })
+    );
 
     const targetId = await test.allocateQuery(query_);
-    await test.applyRemoteEvent(docAddedRemoteEvent(doc('coll/a', 10, { matches: true }), [targetId]));
+    await test.applyRemoteEvent(
+      docAddedRemoteEvent(doc('coll/a', 10, { matches: true }), [targetId])
+    );
     await test.backfillIndexes();
 
     await test.executeQuery(query_);
@@ -781,5 +887,4 @@ describe('LocalStore w/ IndexedDB Persistence (Non generic)', () => {
     test.assertRemoteDocumentsRead(0, 1);
     test.assertQueryReturned('coll/a');
   });
-
 });

--- a/packages/firestore/test/unit/local/local_store_indexeddb.test.ts
+++ b/packages/firestore/test/unit/local/local_store_indexeddb.test.ts
@@ -214,7 +214,9 @@ class AsyncLocalStoreTester {
     }
   }
 
-  async backfillIndexes(config?: { maxDocumentsToProcess?: 2 }): Promise<void> {
+  async backfillIndexes(config?: {
+    maxDocumentsToProcess?: number;
+  }): Promise<void> {
     await this.indexBackfiller.backfill(config?.maxDocumentsToProcess);
   }
 }


### PR DESCRIPTION
In #7542 and #7587 I added local store unit tests for client-side index auto-creation logic into `local_store.test.ts`, which contains the generic unit tests that apply to both "memory" local store and "indexeddb" local store. But since client-side indexing is purely a feature of indexeddb local store, I should have put the tests into `local_store_indexeddb.test.ts`. This PR moves the tests into the correct file. This has the added benefit that uses a more modern and more readable "await" style testing rather than the promise chaining used in the generic tests.