### PR TITLE
Firestore: Set DEFAULT_RELATIVE_INDEX_READ_COST_PER_DOCUMENT to 8 in query_engine.ts

### DIFF
--- a/packages/firestore/src/local/query_engine.ts
+++ b/packages/firestore/src/local/query_engine.ts
@@ -55,9 +55,10 @@ const DEFAULT_INDEX_AUTO_CREATION_MIN_COLLECTION_SIZE = 100;
  * (([index, docKey] + [docKey, docContent]) per document in the result set)
  * / ([docKey, docContent] per documents in full collection scan) coming from
  * experiment [enter PR experiment URL here].
- * TODO: Enter PR experiment URL above.
+ * TODO(b/299284287) Choose a value appropriate for the browser/OS combination,
+ *  as determined by more data points from running the experiment.
  */
-const DEFAULT_RELATIVE_INDEX_READ_COST_PER_DOCUMENT = 2;
+const DEFAULT_RELATIVE_INDEX_READ_COST_PER_DOCUMENT = 8;
 
 /**
  * The Firestore query engine.


### PR DESCRIPTION
In `query_engine.ts` the `DEFAULT_RELATIVE_INDEX_READ_COST_PER_DOCUMENT` value was hardcoded as `2`, which was just copied from the Android SDK. Some experimentation has been done and we found that this value should not be hardcoded universally, but should be adjusted based on the browser/OS on which the code is running. More experiment data is needed, so changing the hardcoded value to `8` is the lowest-common-denominator of the experiment data captured so far. A later PR will refine this value.