### PR TITLE
Firestore: Increase test coverage for persistent cache indexing

### DIFF
--- a/packages/firestore/test/integration/api/persistent_cache_index_manager.test.ts
+++ b/packages/firestore/test/integration/api/persistent_cache_index_manager.test.ts
@@ -72,6 +72,19 @@ apiDescribe('PersistentCacheIndexManager', persistence => {
     return;
   }
 
+  it(
+    'getPersistentCacheIndexManager() should return distinct instances ' +
+      'for distinct Firestore objects',
+    () =>
+      withTestDb(persistence, db1 =>
+        withTestDb(persistence, async db2 => {
+          const indexManager1 = getPersistentCacheIndexManager(db1);
+          const indexManager2 = getPersistentCacheIndexManager(db2);
+          expect(indexManager1).to.not.equal(indexManager2);
+        })
+      )
+  );
+
   describe('enable/disable persistent index auto creation', () => {
     it('enable on new instance should succeed', () =>
       withTestDb(persistence, async db => {

--- a/packages/firestore/test/unit/model/target_index_matcher.test.ts
+++ b/packages/firestore/test/unit/model/target_index_matcher.test.ts
@@ -747,7 +747,7 @@ describe('Target Bounds', () => {
         validateBuildTargetIndexCreateFullMatchIndex
       ));
 
-    it('queries with order by', () =>
+    it('queries with order bys', () =>
       queriesWithOrderBy.forEach(validateBuildTargetIndexCreateFullMatchIndex));
 
     it('queries with inequalities uses single field index', () =>


### PR DESCRIPTION
Port testing improvements for persistent cache auto indexing from the Android SDK: https://github.com/firebase/firebase-android-sdk/pull/5213