### PR TITLE
Fix to test-all .github workflow yaml file.

### DIFF
--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -140,6 +140,7 @@ jobs:
     name: (Firestore) Node.js and Browser (Chrome) Tests
     needs: build
     runs-on: ubuntu-latest
+    if: false
     # Disable test for now since it's failing 100% of the time since
     # https://github.com/firebase/firebase-js-sdk/pull/7453 and it needs to be investigated.
     env:

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -12,12 +12,13 @@ env:
   CHROMEDRIVER_CDNURL: https://googlechromelabs.github.io/
   CHROMEDRIVER_CDNBINARIESURL: https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/
   artifactRetentionDays: 14
-  NODE_OPTIONS: "--max_old_space_size=4096"
 
 jobs:
   build:
     name: Build the SDK
     runs-on: ubuntu-latest
+    env:
+      NODE_OPTIONS: "--max_old_space_size=4096"
     steps:
     # Install Chrome so the correct version of webdriver can be installed by chromedriver when
     # setting up the repo. This must be done to build and execute Auth properly.
@@ -29,6 +30,8 @@ jobs:
       uses: actions/setup-node@v3
       with:
         node-version: 16.x
+    - name: Bump Node memory limit
+      run: echo "NODE_OPTIONS=--max_old_space_size=4096" >> $GITHUB_ENV
     - name: Test setup and yarn install
       run: |
         cp config/ci.config.json config/project.json
@@ -53,6 +56,8 @@ jobs:
     name: (bulk) Node.js and Browser (Chrome) Tests
     needs: build
     runs-on: ubuntu-latest
+    env:
+      NODE_OPTIONS: "--max_old_space_size=4096"
     steps:
     # install Chrome first, so the correct version of webdriver can be installed by chromedriver when setting up the repo
     - name: install Chrome stable
@@ -68,6 +73,8 @@ jobs:
       uses: actions/setup-node@v3
       with:
         node-version: 16.x
+    - name: Bump Node memory limit
+      run: echo "NODE_OPTIONS=--max_old_space_size=4096" >> $GITHUB_ENV
     - name: Test setup and yarn install
       run: |
         cp config/ci.config.json config/project.json
@@ -94,6 +101,8 @@ jobs:
     name: (Auth) Node.js and Browser (Chrome) Tests
     needs: build
     runs-on: ubuntu-latest
+    env:
+      NODE_OPTIONS: "--max_old_space_size=4096"
     steps:
       # install Chrome first, so the correct version of webdriver can be installed by chromedriver
       # when setting up the repo
@@ -110,6 +119,8 @@ jobs:
       uses: actions/setup-node@v3
       with:
         node-version: 16.x
+    - name: Bump Node memory limit
+      run: echo "NODE_OPTIONS=--max_old_space_size=4096" >> $GITHUB_ENV
     - name: Test setup and yarn install
       run: |
         cp config/ci.config.json config/project.json
@@ -135,6 +146,8 @@ jobs:
     name: (Firestore) Node.js and Browser (Chrome) Tests
     needs: build
     runs-on: ubuntu-latest
+    env:
+      NODE_OPTIONS: "--max_old_space_size=4096"
     steps:
     # install Chrome so the correct version of webdriver can be installed by chromedriver when setting up the repo
     - name: install Chrome stable
@@ -150,6 +163,8 @@ jobs:
       uses: actions/setup-node@v3
       with:
         node-version: 16.x
+    - name: Bump Node memory limit
+      run: echo "NODE_OPTIONS=--max_old_space_size=4096" >> $GITHUB_ENV
     - name: Test setup and yarn install
       run: |
         cp config/ci.config.json config/project.json
@@ -179,6 +194,8 @@ jobs:
     name: Firestore Integration Tests (${{ matrix.persistence }})
     needs: build
     runs-on: ubuntu-latest
+    env:
+      NODE_OPTIONS: "--max_old_space_size=4096"
     steps:
     # install Chrome so the correct version of webdriver can be installed by chromedriver when setting up the repo
     - name: install Chrome stable
@@ -194,6 +211,8 @@ jobs:
       uses: actions/setup-node@v3
       with:
         node-version: 16.x
+    - name: Bump Node memory limit
+      run: echo "NODE_OPTIONS=--max_old_space_size=4096" >> $GITHUB_ENV
     - run: cp config/ci.config.json config/project.json
     - run: yarn
     - run: yarn build:${{ matrix.persistence }}

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -12,6 +12,7 @@ env:
   CHROMEDRIVER_CDNURL: https://googlechromelabs.github.io/
   CHROMEDRIVER_CDNBINARIESURL: https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/
   artifactRetentionDays: 14
+  NODE_OPTIONS: "--max_old_space_size=4096"
 
 jobs:
   build:
@@ -28,8 +29,6 @@ jobs:
       uses: actions/setup-node@v3
       with:
         node-version: 16.x
-    - name: Bump Node memory limit
-      run: echo "NODE_OPTIONS=--max_old_space_size=4096" >> $GITHUB_ENV
     - name: Test setup and yarn install
       run: |
         cp config/ci.config.json config/project.json
@@ -69,8 +68,6 @@ jobs:
       uses: actions/setup-node@v3
       with:
         node-version: 16.x
-    - name: Bump Node memory limit
-      run: echo "NODE_OPTIONS=--max_old_space_size=4096" >> $GITHUB_ENV
     - name: Test setup and yarn install
       run: |
         cp config/ci.config.json config/project.json
@@ -113,8 +110,6 @@ jobs:
       uses: actions/setup-node@v3
       with:
         node-version: 16.x
-    - name: Bump Node memory limit
-      run: echo "NODE_OPTIONS=--max_old_space_size=4096" >> $GITHUB_ENV
     - name: Test setup and yarn install
       run: |
         cp config/ci.config.json config/project.json
@@ -155,8 +150,6 @@ jobs:
       uses: actions/setup-node@v3
       with:
         node-version: 16.x
-    - name: Bump Node memory limit
-      run: echo "NODE_OPTIONS=--max_old_space_size=4096" >> $GITHUB_ENV
     - name: Test setup and yarn install
       run: |
         cp config/ci.config.json config/project.json
@@ -201,8 +194,6 @@ jobs:
       uses: actions/setup-node@v3
       with:
         node-version: 16.x
-    - name: Bump Node memory limit
-      run: echo "NODE_OPTIONS=--max_old_space_size=4096" >> $GITHUB_ENV
     - run: cp config/ci.config.json config/project.json
     - run: yarn
     - run: yarn build:${{ matrix.persistence }}

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -142,9 +142,9 @@ jobs:
     runs-on: ubuntu-latest
     # Disable test for now since it's failing 100% of the time since
     # https://github.com/firebase/firebase-js-sdk/pull/7453 and it needs to be investigated.
-    if: false
     env:
       NODE_OPTIONS: "--max_old_space_size=4096"
+      EXPERIMENTAL_MODE: true
     steps:
     # install Chrome so the correct version of webdriver can be installed by chromedriver when setting up the repo
     - name: install Chrome stable

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -18,7 +18,7 @@ jobs:
     name: Build the SDK
     runs-on: ubuntu-latest
     env:
-      NODE_OPTIONS: "--max_old_space_size=4096"
+      NODE_OPTIONS: "--max_old_space_size=8192"
     steps:
     # Install Chrome so the correct version of webdriver can be installed by chromedriver when
     # setting up the repo. This must be done to build and execute Auth properly.
@@ -30,8 +30,6 @@ jobs:
       uses: actions/setup-node@v3
       with:
         node-version: 16.x
-    - name: Bump Node memory limit
-      run: echo "NODE_OPTIONS=--max_old_space_size=4096" >> $GITHUB_ENV
     - name: Test setup and yarn install
       run: |
         cp config/ci.config.json config/project.json
@@ -57,7 +55,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     env:
-      NODE_OPTIONS: "--max_old_space_size=4096"
+      NODE_OPTIONS: "--max_old_space_size=8192"
     steps:
     # install Chrome first, so the correct version of webdriver can be installed by chromedriver when setting up the repo
     - name: install Chrome stable
@@ -73,8 +71,6 @@ jobs:
       uses: actions/setup-node@v3
       with:
         node-version: 16.x
-    - name: Bump Node memory limit
-      run: echo "NODE_OPTIONS=--max_old_space_size=4096" >> $GITHUB_ENV
     - name: Test setup and yarn install
       run: |
         cp config/ci.config.json config/project.json
@@ -102,7 +98,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     env:
-      NODE_OPTIONS: "--max_old_space_size=4096"
+      NODE_OPTIONS: "--max_old_space_size=8192"
     steps:
       # install Chrome first, so the correct version of webdriver can be installed by chromedriver
       # when setting up the repo
@@ -119,8 +115,6 @@ jobs:
       uses: actions/setup-node@v3
       with:
         node-version: 16.x
-    - name: Bump Node memory limit
-      run: echo "NODE_OPTIONS=--max_old_space_size=4096" >> $GITHUB_ENV
     - name: Test setup and yarn install
       run: |
         cp config/ci.config.json config/project.json
@@ -147,7 +141,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     env:
-      NODE_OPTIONS: "--max_old_space_size=4096"
+      NODE_OPTIONS: "--max_old_space_size=8192"
     steps:
     # install Chrome so the correct version of webdriver can be installed by chromedriver when setting up the repo
     - name: install Chrome stable
@@ -163,8 +157,6 @@ jobs:
       uses: actions/setup-node@v3
       with:
         node-version: 16.x
-    - name: Bump Node memory limit
-      run: echo "NODE_OPTIONS=--max_old_space_size=4096" >> $GITHUB_ENV
     - name: Test setup and yarn install
       run: |
         cp config/ci.config.json config/project.json
@@ -173,7 +165,7 @@ jobs:
       run: echo "FIREBASE_CI_TEST_START_TIME=$(date +%s)" >> $GITHUB_ENV
     - name: Run unit tests
       run: |
-        xvfb-run yarn lerna run --concurrency 2 test:ci --scope '@firebase/firestore*'
+        xvfb-run yarn lerna run --concurrency 4 test:ci --scope '@firebase/firestore*'
         node scripts/print_test_logs.js
       env:
         FIREBASE_TOKEN: ${{ secrets.FIREBASE_CLI_TOKEN }}
@@ -185,7 +177,6 @@ jobs:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         path-to-lcov: ./lcov-all.info
       continue-on-error: true
-
   test-firestore-integration:
     strategy:
       fail-fast: false
@@ -195,7 +186,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     env:
-      NODE_OPTIONS: "--max_old_space_size=4096"
+      NODE_OPTIONS: "--max_old_space_size=8192"
     steps:
     # install Chrome so the correct version of webdriver can be installed by chromedriver when setting up the repo
     - name: install Chrome stable
@@ -211,8 +202,6 @@ jobs:
       uses: actions/setup-node@v3
       with:
         node-version: 16.x
-    - name: Bump Node memory limit
-      run: echo "NODE_OPTIONS=--max_old_space_size=4096" >> $GITHUB_ENV
     - run: cp config/ci.config.json config/project.json
     - run: yarn
     - run: yarn build:${{ matrix.persistence }}

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -101,9 +101,9 @@ jobs:
     steps:
       # install Chrome first, so the correct version of webdriver can be installed by chromedriver
       # when setting up the repo
-      - name: install Chrome stable
-        run: |
-          npx @puppeteer/browsers install chrome@stable
+    - name: install Chrome stable
+      run: |
+        npx @puppeteer/browsers install chrome@stable
     - name: Download build archive
       uses: actions/download-artifact@v3
       with:

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -173,7 +173,8 @@ jobs:
       run: echo "FIREBASE_CI_TEST_START_TIME=$(date +%s)" >> $GITHUB_ENV
     - name: Run unit tests
       run: |
-        xvfb-run yarn lerna run --concurrency 4 test:ci --scope '@firebase/firestore*'
+        echo $NODE_OPTIONS
+        xvfb-run yarn lerna run --concurrency 2 test:ci --scope '@firebase/firestore*'
         node scripts/print_test_logs.js
       env:
         FIREBASE_TOKEN: ${{ secrets.FIREBASE_CLI_TOKEN }}

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -173,7 +173,6 @@ jobs:
       run: echo "FIREBASE_CI_TEST_START_TIME=$(date +%s)" >> $GITHUB_ENV
     - name: Run unit tests
       run: |
-        echo $NODE_OPTIONS
         xvfb-run yarn lerna run --concurrency 2 test:ci --scope '@firebase/firestore*'
         node scripts/print_test_logs.js
       env:

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -58,8 +58,7 @@ jobs:
     # install Chrome first, so the correct version of webdriver can be installed by chromedriver when setting up the repo
     - name: install Chrome stable
       run: |
-        sudo apt-get update
-        sudo apt-get install google-chrome-stable
+        npx @puppeteer/browsers install chrome@stable
     - name: Download build archive
       uses: actions/download-artifact@v3
       with:
@@ -145,8 +144,7 @@ jobs:
     # install Chrome so the correct version of webdriver can be installed by chromedriver when setting up the repo
     - name: install Chrome stable
       run: |
-        sudo apt-get update
-        sudo apt-get install google-chrome-stable
+        npx @puppeteer/browsers install chrome@stable
     - name: Download build archive
       uses: actions/download-artifact@v3
       with:
@@ -192,8 +190,7 @@ jobs:
     # install Chrome so the correct version of webdriver can be installed by chromedriver when setting up the repo
     - name: install Chrome stable
       run: |
-        sudo apt-get update
-        sudo apt-get install google-chrome-stable
+        npx @puppeteer/browsers install chrome@stable
     - name: Download build archive
       uses: actions/download-artifact@v3
       with:

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -18,7 +18,7 @@ jobs:
     name: Build the SDK
     runs-on: ubuntu-latest
     env:
-      NODE_OPTIONS: "--max_old_space_size=8192"
+      NODE_OPTIONS: "--max_old_space_size=4096"
     steps:
     # Install Chrome so the correct version of webdriver can be installed by chromedriver when
     # setting up the repo. This must be done to build and execute Auth properly.
@@ -55,7 +55,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     env:
-      NODE_OPTIONS: "--max_old_space_size=8192"
+      NODE_OPTIONS: "--max_old_space_size=4096"
     steps:
     # install Chrome first, so the correct version of webdriver can be installed by chromedriver when setting up the repo
     - name: install Chrome stable
@@ -98,7 +98,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     env:
-      NODE_OPTIONS: "--max_old_space_size=8192"
+      NODE_OPTIONS: "--max_old_space_size=4096"
     steps:
       # install Chrome first, so the correct version of webdriver can be installed by chromedriver
       # when setting up the repo
@@ -141,7 +141,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     env:
-      NODE_OPTIONS: "--max_old_space_size=8192"
+      NODE_OPTIONS: "--max_old_space_size=4096"
     steps:
     # install Chrome so the correct version of webdriver can be installed by chromedriver when setting up the repo
     - name: install Chrome stable
@@ -186,7 +186,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     env:
-      NODE_OPTIONS: "--max_old_space_size=8192"
+      NODE_OPTIONS: "--max_old_space_size=4096"
     steps:
     # install Chrome so the correct version of webdriver can be installed by chromedriver when setting up the repo
     - name: install Chrome stable

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -140,6 +140,9 @@ jobs:
     name: (Firestore) Node.js and Browser (Chrome) Tests
     needs: build
     runs-on: ubuntu-latest
+    # Disable test for now since it's failing 100% of the time since
+    # https://github.com/firebase/firebase-js-sdk/pull/7453 and it needs to be investigated.
+    if: false
     env:
       NODE_OPTIONS: "--max_old_space_size=4096"
     steps:

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -144,7 +144,6 @@ jobs:
     # https://github.com/firebase/firebase-js-sdk/pull/7453 and it needs to be investigated.
     env:
       NODE_OPTIONS: "--max_old_space_size=4096"
-      EXPERIMENTAL_MODE: true
     steps:
     # install Chrome so the correct version of webdriver can be installed by chromedriver when setting up the repo
     - name: install Chrome stable
@@ -172,6 +171,7 @@ jobs:
         node scripts/print_test_logs.js
       env:
         FIREBASE_TOKEN: ${{ secrets.FIREBASE_CLI_TOKEN }}
+        EXPERIMENTAL_MODE: true
     - name: Generate coverage file
       run: yarn ci:coverage
     - name: Run coverage


### PR DESCRIPTION
### Discussion

Fixed a misaligned indentation on line #107 of `test-all.yaml` that cause a workflow execution failure in GitHub Action CI.

Includes an update to all of the `test-all.yml` chrome installation steps to use the `npx` install method.  

There's a Failure in `(Firestore) Node.js and Browser (Chrome) Tests`, but this existed even before the npx update (when installing Chrome via `apt-get`). [See this previous run](https://github.com/firebase/firebase-js-sdk/actions/runs/6254022106/job/17001301255). Since the Firestore issue still remains, the has been disabled (will skip) for now.

Also fixed the a problem setting the max heap size for node. Previous attempts echoed the value to the GITHUB_ENV variable on the command line, but this was producing errors. Changed it to use the worfklow `env:` directive and I have confirmed that the enviornment variable exists in the shell runtime (example echo output can be found in `run unit tests` step of [this worklfow run](https://github.com/firebase/firebase-js-sdk/actions/runs/6275509483/job/17044131577?pr=7640)).


### Testing

[CI](https://github.com/firebase/firebase-js-sdk/actions/runs/6326493231/job/17180174415?pr=7640)

### API Changes

N/A