### PR TITLE
fix(types): infer return type in `UploadTask.then`

### DIFF
--- a/packages/storage/src/public-types.ts
+++ b/packages/storage/src/public-types.ts
@@ -410,10 +410,10 @@ export interface UploadTask {
    * @param onFulfilled - The fulfillment callback. Promise chaining works as normal.
    * @param onRejected - The rejection callback.
    */
-  then(
-    onFulfilled?: ((snapshot: UploadTaskSnapshot) => unknown) | null,
+  then<T = unknown>(
+    onFulfilled?: ((snapshot: UploadTaskSnapshot) => T) | null,
     onRejected?: ((error: StorageError) => unknown) | null
-  ): Promise<unknown>;
+  ): Promise<Awaited<T>>;
 }
 
 /**


### PR DESCRIPTION
I noticed you couldn't chain a promise on an UploadTask:

```ts
uploadBytesResumable(storageSource, newData, newMetadata).then(() => {
  return refreshUrl() // returns Promise<string>
}) // returns Promise<unknown>
```