### PR TITLE
Tracking down TestAll Failures - Do not merge

### DIFF
--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -17,9 +17,6 @@ jobs:
     # Install Chrome so the correct version of webdriver can be installed by chromedriver when
     # setting up the repo. This must be done to build and execute Auth properly.
     - name: install Chrome stable
-      # Pin Chrome version 114.0.5735.90-1 to avoid install failures like "No such object: chromedriver/LATEST_RELEASE_115.0.5790".
-      # The failure happens because https://chromedriver.chromium.org/downloads only goes up to version 114.
-      # TODO(b/297380444) Update script to install the latest Chrome and ChromeDriver.
       run: |
         sudo apt-get update
         sudo apt-get install wget

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -7,28 +7,29 @@ on:
 env:
   # make chromedriver detect installed Chrome version and download the corresponding driver
   DETECT_CHROMEDRIVER_VERSION: true
+  # The default behavior of chromedriver uses the older Chrome download URLs. We need to override
+  # the beahvior to use the new URLs.
+  CHROMEDRIVER_CDNURL: https://googlechromelabs.github.io/
+  CHROMEDRIVER_CDNBINARIESURL: https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/
   artifactRetentionDays: 14
 
 jobs:
   build:
     name: Build the SDK
     runs-on: ubuntu-latest
+    env:
+      NODE_OPTIONS: "--max_old_space_size=4096"
     steps:
     # Install Chrome so the correct version of webdriver can be installed by chromedriver when
     # setting up the repo. This must be done to build and execute Auth properly.
     - name: install Chrome stable
       run: |
-        sudo apt-get update
-        sudo apt-get install wget
-        sudo wget http://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_114.0.5735.90-1_amd64.deb
-        sudo apt-get install -f ./google-chrome-stable_114.0.5735.90-1_amd64.deb --allow-downgrades
+        npx @puppeteer/browsers install chrome@stable
     - uses: actions/checkout@v3
     - name: Set up Node (16)
       uses: actions/setup-node@v3
       with:
         node-version: 16.x
-    - name: Bump Node memory limit
-      run: echo "NODE_OPTIONS=--max_old_space_size=4096" >> $GITHUB_ENV
     - name: Test setup and yarn install
       run: |
         cp config/ci.config.json config/project.json
@@ -53,12 +54,13 @@ jobs:
     name: (bulk) Node.js and Browser (Chrome) Tests
     needs: build
     runs-on: ubuntu-latest
+    env:
+      NODE_OPTIONS: "--max_old_space_size=4096"
     steps:
     # install Chrome first, so the correct version of webdriver can be installed by chromedriver when setting up the repo
     - name: install Chrome stable
       run: |
-        sudo apt-get update
-        sudo apt-get install google-chrome-stable
+        npx @puppeteer/browsers install chrome@stable
     - name: Download build archive
       uses: actions/download-artifact@v3
       with:
@@ -69,8 +71,6 @@ jobs:
       uses: actions/setup-node@v3
       with:
         node-version: 16.x
-    - name: Bump Node memory limit
-      run: echo "NODE_OPTIONS=--max_old_space_size=4096" >> $GITHUB_ENV
     - name: Test setup and yarn install
       run: |
         cp config/ci.config.json config/project.json
@@ -97,17 +97,14 @@ jobs:
     name: (Auth) Node.js and Browser (Chrome) Tests
     needs: build
     runs-on: ubuntu-latest
+    env:
+      NODE_OPTIONS: "--max_old_space_size=4096"
     steps:
-    # install Chrome so the correct version of webdriver can be installed by chromedriver when setting up the repo
+      # install Chrome first, so the correct version of webdriver can be installed by chromedriver
+      # when setting up the repo
     - name: install Chrome stable
-      # Pin Chrome version 114.0.5735.90-1 to avoid install failures like "No such object: chromedriver/LATEST_RELEASE_115.0.5790".
-      # The failure happens because https://chromedriver.chromium.org/downloads only goes up to version 114.
-      # TODO(b/297380444) Update script to install the latest Chrome and ChromeDriver.
       run: |
-        sudo apt-get update
-        sudo apt-get install wget
-        sudo wget http://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_114.0.5735.90-1_amd64.deb
-        sudo apt-get install -f ./google-chrome-stable_114.0.5735.90-1_amd64.deb --allow-downgrades
+        npx @puppeteer/browsers install chrome@stable
     - name: Download build archive
       uses: actions/download-artifact@v3
       with:
@@ -118,8 +115,6 @@ jobs:
       uses: actions/setup-node@v3
       with:
         node-version: 16.x
-    - name: Bump Node memory limit
-      run: echo "NODE_OPTIONS=--max_old_space_size=4096" >> $GITHUB_ENV
     - name: Test setup and yarn install
       run: |
         cp config/ci.config.json config/project.json
@@ -145,12 +140,13 @@ jobs:
     name: (Firestore) Node.js and Browser (Chrome) Tests
     needs: build
     runs-on: ubuntu-latest
+    env:
+      NODE_OPTIONS: "--max_old_space_size=4096"
     steps:
     # install Chrome so the correct version of webdriver can be installed by chromedriver when setting up the repo
     - name: install Chrome stable
       run: |
-        sudo apt-get update
-        sudo apt-get install google-chrome-stable
+        npx @puppeteer/browsers install chrome@stable
     - name: Download build archive
       uses: actions/download-artifact@v3
       with:
@@ -161,8 +157,6 @@ jobs:
       uses: actions/setup-node@v3
       with:
         node-version: 16.x
-    - name: Bump Node memory limit
-      run: echo "NODE_OPTIONS=--max_old_space_size=4096" >> $GITHUB_ENV
     - name: Test setup and yarn install
       run: |
         cp config/ci.config.json config/project.json
@@ -183,7 +177,6 @@ jobs:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         path-to-lcov: ./lcov-all.info
       continue-on-error: true
-
   test-firestore-integration:
     strategy:
       fail-fast: false
@@ -192,12 +185,13 @@ jobs:
     name: Firestore Integration Tests (${{ matrix.persistence }})
     needs: build
     runs-on: ubuntu-latest
+    env:
+      NODE_OPTIONS: "--max_old_space_size=4096"
     steps:
     # install Chrome so the correct version of webdriver can be installed by chromedriver when setting up the repo
     - name: install Chrome stable
       run: |
-        sudo apt-get update
-        sudo apt-get install google-chrome-stable
+        npx @puppeteer/browsers install chrome@stable
     - name: Download build archive
       uses: actions/download-artifact@v3
       with:
@@ -208,8 +202,6 @@ jobs:
       uses: actions/setup-node@v3
       with:
         node-version: 16.x
-    - name: Bump Node memory limit
-      run: echo "NODE_OPTIONS=--max_old_space_size=4096" >> $GITHUB_ENV
     - run: cp config/ci.config.json config/project.json
     - run: yarn
     - run: yarn build:${{ matrix.persistence }}


### PR DESCRIPTION
### Discussion

Try to go back to an older commit to see where the test-all ci started going awry. This is an explority change in GitHub so that we can track down the CI. Do not merge this PR.

### Testing

CI

### API Changes

N/A