### PR TITLE
Tracking down TestAll Failures - Do not merge

### DIFF
--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -21,7 +21,7 @@ jobs:
       # The failure happens because https://chromedriver.chromium.org/downloads only goes up to version 114.
       # TODO(b/297380444) Update script to install the latest Chrome and ChromeDriver.
       run: |
-        sudo apt-get update
+        sudo apt-get update 
         sudo apt-get install wget
         sudo wget http://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_114.0.5735.90-1_amd64.deb
         sudo apt-get install -f ./google-chrome-stable_114.0.5735.90-1_amd64.deb --allow-downgrades


### PR DESCRIPTION
### Discussion

Try to go back to an older commit to see where the test-all ci started going awry. This is an explority change in GitHub so that we can track down the CI. Do not merge this PR.

### Testing

CI

### API Changes

N/A