### PR TITLE
Fix composite index testing build bug

### DIFF
--- a/.github/workflows/test-changed-firestore-integration.yml
+++ b/.github/workflows/test-changed-firestore-integration.yml
@@ -29,7 +29,7 @@ jobs:
       if: github.event_name == 'pull_request'
       run: |
         cd packages/firestore
-        terraform apply -var-file=../../config/project.json -auto-approve
+        terraform apply -var-file=../../config/project.json -auto-approve &> /dev/null
       continue-on-error: true
     - name: Set up Node (16)
       uses: actions/setup-node@v3

--- a/.gitignore
+++ b/.gitignore
@@ -98,4 +98,3 @@ toc/
 .terraform.lock.hcl
 *.tfstate
 *.tfstate.*
-*/project.json

--- a/.gitignore
+++ b/.gitignore
@@ -98,3 +98,4 @@ toc/
 .terraform.lock.hcl
 *.tfstate
 *.tfstate.*
+*/project.json

--- a/common/api-review/firestore.api.md
+++ b/common/api-review/firestore.api.md
@@ -55,12 +55,6 @@ export function arrayRemove(...elements: unknown[]): FieldValue;
 // @public
 export function arrayUnion(...elements: unknown[]): FieldValue;
 
-// @public (undocumented)
-export class _AutoId {
-    // (undocumented)
-    static newId(): string;
-}
-
 // @public
 export class Bytes {
     static fromBase64String(base64: string): Bytes;

--- a/common/api-review/firestore.api.md
+++ b/common/api-review/firestore.api.md
@@ -55,6 +55,12 @@ export function arrayRemove(...elements: unknown[]): FieldValue;
 // @public
 export function arrayUnion(...elements: unknown[]): FieldValue;
 
+// @public (undocumented)
+export class _AutoId {
+    // (undocumented)
+    static newId(): string;
+}
+
 // @public
 export class Bytes {
     static fromBase64String(base64: string): Bytes;

--- a/integration/firestore/gulpfile.js
+++ b/integration/firestore/gulpfile.js
@@ -42,6 +42,7 @@ function copyTests() {
     .src(
       [
         testBase + '/integration/api/*.ts',
+        testBase + '/integration/util/composite_index_test_helper.ts',
         testBase + '/integration/util/events_accumulator.ts',
         testBase + '/integration/util/helpers.ts',
         testBase + '/integration/util/settings.ts',

--- a/integration/firestore/gulpfile.js
+++ b/integration/firestore/gulpfile.js
@@ -48,6 +48,7 @@ function copyTests() {
         testBase + '/integration/util/settings.ts',
         testBase + '/integration/util/testing_hooks_util.ts',
         testBase + '/util/equality_matcher.ts',
+        testBase + '/util/helpers.ts',
         testBase + '/util/promise.ts'
       ],
       { base: '../../packages/firestore' }

--- a/integration/firestore/gulpfile.js
+++ b/integration/firestore/gulpfile.js
@@ -48,7 +48,6 @@ function copyTests() {
         testBase + '/integration/util/settings.ts',
         testBase + '/integration/util/testing_hooks_util.ts',
         testBase + '/util/equality_matcher.ts',
-        testBase + '/util/helpers.ts',
         testBase + '/util/promise.ts'
       ],
       { base: '../../packages/firestore' }

--- a/packages/firestore/src/api.ts
+++ b/packages/firestore/src/api.ts
@@ -225,6 +225,7 @@ export { FieldPath as _FieldPath } from './model/path';
 export type { ResourcePath as _ResourcePath } from './model/path';
 export { ByteString as _ByteString } from './util/byte_string';
 export { logWarn as _logWarn } from './util/log';
+export { AutoId as _AutoId } from './util/misc';
 export type {
   AuthTokenFactory,
   FirstPartyCredentialsSettings

--- a/packages/firestore/src/util/misc.ts
+++ b/packages/firestore/src/util/misc.ts
@@ -24,6 +24,12 @@ export interface Indexable {
   [k: string]: unknown;
 }
 
+/**
+ * A utility class for generating unique alphanumeric IDs of a specified length.
+ *
+ * @internal
+ * Exported internally for testing purposes.
+ */
 export class AutoId {
   static newId(): string {
     // Alphanumeric characters

--- a/packages/firestore/test/integration/api/README.md
+++ b/packages/firestore/test/integration/api/README.md
@@ -11,17 +11,19 @@ replaced via the gulpfile in 'integration/firestore' and should not be
 modified.
 
 
-### Testing composite index query against production
+## Testing composite index query against production
+
+### Setting Up the Environment:
 1. Create a `project.json` file in the `firebase-js-sdk/packages/firestore` directory. This file should contain your target Firebase project's configuration.
-2. If not already done, log in to your Google Cloud Platform (GCP) account using `gcloud auth application-default login`. You can check your logged-in accounts with `gcloud auth list`.
-3. In the `firebase-js-sdk/packages/firestore`, run:
+2. If not already logged in, authenticate with your Google Cloud Platform (GCP) account using `gcloud auth application-default login`. You can check your logged-in accounts by running `gcloud auth list`.
+3. Navigate to the `firebase-js-sdk/packages/firestore` directory, run:
 ```
 terraform init
 terraform apply -var-file=project.json -auto-approve
 ```
-Note: Index creation may occasionally encounter issues. If it fails due to concurrent operations, consider running the index creation process a second time. You can safely disregard error messages indicating that indexes have already been created.
+Note: If the index creation encounters issues, such as concurrent operations, consider running the index creation process again. Error messages indicating that indexes have already been created can be safely disregarded.
 
 
 ### Adding new composite index query tests
-1. create the new composite index by clicking on the link to firebase console in the error message.
-2. Add the new composite index to the `firestore_index_config.tf` file. The "__name__" field is not required to be explicitly added to the file as the index creation will auto complete it on behalf.
+1. To create a new composite index for local development, click on the provided link in the test error message, which will direct you to the Firebase Console.
+2. Add the newly created composite index to the `firestore_index_config.tf` file. The "__name__" field is not required to be explicitly added to the file, as the index creation will auto complete it on behalf.

--- a/packages/firestore/test/integration/api/README.md
+++ b/packages/firestore/test/integration/api/README.md
@@ -14,12 +14,12 @@ modified.
 ## Testing composite index query against production
 
 ### Setting Up the Environment:
-1. Create a `project.json` file in the `firebase-js-sdk/packages/firestore` directory. This file should contain your target Firebase project's configuration.
+1. Create a `project.json` file in the `firebase-js-sdk/config` directory. This file should contain your target Firebase project's configuration.
 2. If not already logged in, authenticate with your Google Cloud Platform (GCP) account using `gcloud auth application-default login`. You can check your logged-in accounts by running `gcloud auth list`.
 3. Navigate to the `firebase-js-sdk/packages/firestore` directory, run:
 ```
 terraform init
-terraform apply -var-file=project.json -auto-approve
+terraform apply -var-file=../../config/project.json -auto-approve
 ```
 Note: If the index creation encounters issues, such as concurrent operations, consider running the index creation process again. Error messages indicating that indexes have already been created can be safely disregarded.
 

--- a/packages/firestore/test/integration/api/README.md
+++ b/packages/firestore/test/integration/api/README.md
@@ -9,3 +9,19 @@ put in test/integration/api_internal instead.
 The line "import * as firebaseExport from '../util/firebase_export';" is
 replaced via the gulpfile in 'integration/firestore' and should not be
 modified.
+
+
+### Testing composite index query against production
+1. Create a `project.json` file in the `firebase-js-sdk/packages/firestore` directory. This file should contain your target Firebase project's configuration.
+2. If not already done, log in to your Google Cloud Platform (GCP) account using `gcloud auth application-default login`. You can check your logged-in accounts with `gcloud auth list`.
+3. In the `firebase-js-sdk/packages/firestore`, run:
+```
+terraform init
+terraform apply -var-file=project.json -auto-approve
+```
+Note: Index creation may occasionally encounter issues. If it fails due to concurrent operations, consider running the index creation process a second time. You can safely disregard error messages indicating that indexes have already been created.
+
+
+### Adding new composite index query tests
+1. create the new composite index by clicking on the link to firebase console in the error message.
+2. Add the new composite index to the `firestore_index_config.tf` file. The "__name__" field is not required to be explicitly added to the file as the index creation will auto complete it on behalf.

--- a/packages/firestore/test/integration/api/composite_index_query.test.ts
+++ b/packages/firestore/test/integration/api/composite_index_query.test.ts
@@ -32,7 +32,7 @@ import { apiDescribe } from '../util/helpers';
  * "CompositeIndexTestHelper" class. This utility class provides methods for creating
  * and setting test documents and running queries with ease, ensuring proper data
  * isolation and query construction.
- * 
+ *
  * To get started, please refer to the instructions provided in the README file. This will guide you
  * through setting up your local testing environment and updating the Terraform configuration with
  * any new composite indexes required for your testing scenarios.

--- a/packages/firestore/test/integration/api/composite_index_query.test.ts
+++ b/packages/firestore/test/integration/api/composite_index_query.test.ts
@@ -32,13 +32,11 @@ import { apiDescribe } from '../util/helpers';
  * "CompositeIndexTestHelper" class. This utility class provides methods for creating
  * and setting test documents and running queries with ease, ensuring proper data
  * isolation and query construction.
- *
- * Please remember to update the main index configuration file (firestore_index_config.tf)
- * with any new composite indexes needed for the tests. This ensures synchronization with
- * other testing environments, including CI. You can generate the required index link by
- * clicking on the Firebase console link in the error message while running tests locally.
+ * 
+ * To get started, please refer to the instructions provided in the README file. This will guide you
+ * through setting up your local testing environment and updating the Terraform configuration with
+ * any new composite indexes required for your testing scenarios.
  */
-
 apiDescribe('Composite Index Queries', persistence => {
   // OR Query tests only run when the SDK's local cache is configured to use
   // LRU garbage collection (rather than eager garbage collection) because

--- a/packages/firestore/test/integration/util/composite_index_test_helper.ts
+++ b/packages/firestore/test/integration/util/composite_index_test_helper.ts
@@ -15,8 +15,6 @@
  * limitations under the License.
  */
 
-import { and } from '../../../src/lite-api/query';
-import { AutoId } from '../../../src/util/misc';
 import { field } from '../../util/helpers';
 
 import {
@@ -41,7 +39,9 @@ import {
   getDocs as getDocuments,
   QuerySnapshot,
   deleteDoc as deleteDocument,
-  doc
+  doc,
+  and,
+  _AutoId
 } from './firebase_export';
 import {
   batchCommitDocsToCollection,
@@ -72,7 +72,7 @@ export class CompositeIndexTestHelper {
   // Creates a new instance of the CompositeIndexTestHelper class, with a unique test
   // identifier for data isolation.
   constructor() {
-    this.testId = 'test-id-' + AutoId.newId();
+    this.testId = 'test-id-' + _AutoId.newId();
   }
 
   // Runs a test with specified documents in the COMPOSITE_INDEX_TEST_COLLECTION.

--- a/packages/firestore/test/integration/util/composite_index_test_helper.ts
+++ b/packages/firestore/test/integration/util/composite_index_test_helper.ts
@@ -15,7 +15,6 @@
  * limitations under the License.
  */
 
-
 import {
   query as internalQuery,
   CollectionReference,

--- a/packages/firestore/test/integration/util/composite_index_test_helper.ts
+++ b/packages/firestore/test/integration/util/composite_index_test_helper.ts
@@ -15,7 +15,6 @@
  * limitations under the License.
  */
 
-import { field } from '../../util/helpers';
 
 import {
   query as internalQuery,
@@ -41,7 +40,8 @@ import {
   deleteDoc as deleteDocument,
   doc,
   and,
-  _AutoId
+  _AutoId,
+  _FieldPath
 } from './firebase_export';
 import {
   batchCommitDocsToCollection,
@@ -113,8 +113,8 @@ export class CompositeIndexTestHelper {
 
   // Remove test-specific fields from a document, including the testId and expiration date.
   private removeTestSpecificFieldsFromDoc(doc: DocumentData): void {
-    doc._document?.data?.delete(field(this.TTL_FIELD));
-    doc._document?.data?.delete(field(this.TEST_ID_FIELD));
+    doc._document?.data?.delete(new _FieldPath([this.TEST_ID_FIELD]));
+    doc._document?.data?.delete(new _FieldPath([this.TEST_ID_FIELD]));
   }
 
   // Helper method to hash document keys and add test-specific fields for the provided documents.

--- a/packages/firestore/test/integration/util/helpers.ts
+++ b/packages/firestore/test/integration/util/helpers.ts
@@ -18,8 +18,6 @@
 import { isIndexedDBAvailable } from '@firebase/util';
 import { expect } from 'chai';
 
-import { AutoId } from '../../../src/util/misc';
-
 import {
   clearIndexedDbPersistence,
   collection,
@@ -45,7 +43,8 @@ import {
   writeBatch,
   Query,
   getDocsFromServer,
-  getDocsFromCache
+  getDocsFromCache,
+  _AutoId
 } from './firebase_export';
 import {
   ALT_PROJECT_ID,
@@ -448,7 +447,7 @@ export function withTestCollectionSettings<T>(
   docs: { [key: string]: DocumentData },
   fn: (collection: CollectionReference, db: Firestore) => Promise<T>
 ): Promise<T> {
-  const collectionId = AutoId.newId();
+  const collectionId = _AutoId.newId();
   return batchCommitDocsToCollection(
     persistence,
     settings,


### PR DESCRIPTION
- [x] Fix the build reference problem caused by not including `/integration/util/composite_index_test_helper.ts` in `gulpfile.js`.
- [x] Internally export AutoId for integration testing, and remove the `src` folder dependency in `composite_index_test_helper.ts` file.
- [x] Add a detailed composite index testing development instruction in the `ReadMe` file.

