### PR TITLE
Update the linkWithCredential API to call the signUp endpoint

### DIFF
--- a/.changeset/tiny-items-grin.md
+++ b/.changeset/tiny-items-grin.md
@@ -1,0 +1,5 @@
+---
+'@firebase/auth': patch
+---
+
+Fixes https://github.com/firebase/firebase-js-sdk/issues/7675

--- a/packages/auth/src/api/account_management/email_and_password.ts
+++ b/packages/auth/src/api/account_management/email_and_password.ts
@@ -69,6 +69,18 @@ export async function updateEmailPassword(
   >(auth, HttpMethod.POST, Endpoint.SET_ACCOUNT_INFO, request);
 }
 
+// Used for linking an email/password account to an existing idToken. Uses the same request/response
+// format as updateEmailPassword.
+export async function linkEmailPassword(
+  auth: Auth,
+  request: UpdateEmailPasswordRequest
+): Promise<UpdateEmailPasswordResponse> {
+  return _performApiRequest<
+    UpdateEmailPasswordRequest,
+    UpdateEmailPasswordResponse
+  >(auth, HttpMethod.POST, Endpoint.SIGN_UP, request);
+}
+
 export interface ApplyActionCodeRequest {
   oobCode: string;
   tenantId?: string;

--- a/packages/auth/src/api/account_management/email_and_password.ts
+++ b/packages/auth/src/api/account_management/email_and_password.ts
@@ -25,6 +25,7 @@ import {
 } from '../index';
 import { IdTokenResponse } from '../../model/id_token';
 import { MfaEnrollment } from './mfa';
+import { SignUpRequest, SignUpResponse } from '../authentication/sign_up';
 
 export interface ResetPasswordRequest {
   oobCode: string;
@@ -73,12 +74,14 @@ export async function updateEmailPassword(
 // format as updateEmailPassword.
 export async function linkEmailPassword(
   auth: Auth,
-  request: UpdateEmailPasswordRequest
-): Promise<UpdateEmailPasswordResponse> {
-  return _performApiRequest<
-    UpdateEmailPasswordRequest,
-    UpdateEmailPasswordResponse
-  >(auth, HttpMethod.POST, Endpoint.SIGN_UP, request);
+  request: SignUpRequest
+): Promise<SignUpResponse> {
+  return _performApiRequest<SignUpRequest, SignUpResponse>(
+    auth,
+    HttpMethod.POST,
+    Endpoint.SIGN_UP,
+    request
+  );
 }
 
 export interface ApplyActionCodeRequest {

--- a/packages/auth/src/api/authentication/sign_up.ts
+++ b/packages/auth/src/api/authentication/sign_up.ts
@@ -27,6 +27,7 @@ import { IdTokenResponse } from '../../model/id_token';
 import { Auth } from '../../model/public_types';
 
 export interface SignUpRequest {
+  idToken?: string;
   returnSecureToken?: boolean;
   email?: string;
   password?: string;

--- a/packages/auth/src/core/credentials/email.test.ts
+++ b/packages/auth/src/core/credentials/email.test.ts
@@ -288,8 +288,8 @@ describe('core/credentials/email', () => {
     });
 
     describe('#_linkToIdToken', () => {
-      it('calls update email password', async () => {
-        apiMock = mockEndpoint(Endpoint.SET_ACCOUNT_INFO, {
+      it('calls sign up with email password', async () => {
+        apiMock = mockEndpoint(Endpoint.SIGN_UP, {
           idToken: 'id-token',
           refreshToken: 'refresh-token',
           expiresIn: '1234',

--- a/packages/auth/src/core/credentials/email.test.ts
+++ b/packages/auth/src/core/credentials/email.test.ts
@@ -39,8 +39,94 @@ import { MockGreCAPTCHATopLevel } from '../../platform_browser/recaptcha/recaptc
 import * as jsHelpers from '../../platform_browser/load_js';
 import { ServerError } from '../../api/errors';
 import { _initializeRecaptchaConfig } from '../../platform_browser/recaptcha/recaptcha_enterprise_verifier';
+import assert from 'assert';
 
 use(chaiAsPromised);
+
+const recaptchaConfigResponseEnforce = {
+  recaptchaKey: 'foo/bar/to/site-key',
+  recaptchaEnforcementState: [
+    { provider: 'EMAIL_PASSWORD_PROVIDER', enforcementState: 'ENFORCE' }
+  ]
+};
+const recaptchaConfigResponseOff = {
+  recaptchaKey: 'foo/bar/to/site-key',
+  recaptchaEnforcementState: [
+    { provider: 'EMAIL_PASSWORD_PROVIDER', enforcementState: 'OFF' }
+  ]
+};
+
+const RECAPTCHA_MODE_ENFORCE = 'enforce';
+const RECAPTCHA_MODE_OFF = 'off';
+const FAKE_RECAPTCHA_TOKEN = 'recaptcha-response';
+
+function mockRecaptchaEnterpriseEnablement(
+  enablementState: string
+): mockFetch.Route | undefined {
+  let recaptchaConfigResponse = {};
+  if (enablementState === RECAPTCHA_MODE_ENFORCE) {
+    recaptchaConfigResponse = recaptchaConfigResponseEnforce;
+  } else {
+    // assumes OFF for now.
+    recaptchaConfigResponse = recaptchaConfigResponseOff;
+  }
+  const recaptcha = new MockGreCAPTCHATopLevel();
+  if (typeof window === 'undefined') {
+    return;
+  }
+  window.grecaptcha = recaptcha;
+  sinon
+    .stub(recaptcha.enterprise, 'execute')
+    .returns(Promise.resolve(FAKE_RECAPTCHA_TOKEN));
+  return mockEndpointWithParams(
+    Endpoint.GET_RECAPTCHA_CONFIG,
+    {
+      clientType: RecaptchaClientType.WEB,
+      version: RecaptchaVersion.ENTERPRISE
+    },
+    recaptchaConfigResponse
+  );
+}
+
+function mockRecaptchaEnterpriseTokenFailure(): mockFetch.Route | undefined {
+  if (typeof window === 'undefined') {
+    return;
+  }
+  // Mock recaptcha js loading method but not set window.recaptcha to simulate recaptcha token retrieval failure
+  sinon.stub(jsHelpers, '_loadJS').returns(Promise.resolve(new Event('')));
+  window.grecaptcha = undefined;
+
+  return mockEndpointWithParams(
+    Endpoint.GET_RECAPTCHA_CONFIG,
+    {
+      clientType: RecaptchaClientType.WEB,
+      version: RecaptchaVersion.ENTERPRISE
+    },
+    recaptchaConfigResponseEnforce
+  );
+}
+
+function mockRecaptchaEnterpriseTokenSuccess(action: string): void {
+  // Mock recaptcha js loading method and manually set window.recaptcha
+  sinon.stub(jsHelpers, '_loadJS').returns(Promise.resolve(new Event('')));
+  const recaptcha = new MockGreCAPTCHATopLevel();
+  window.grecaptcha = recaptcha;
+  const stub = sinon.stub(recaptcha.enterprise, 'execute');
+  stub
+    .withArgs('site-key', {
+      action
+    })
+    .returns(Promise.resolve(FAKE_RECAPTCHA_TOKEN));
+
+  mockEndpointWithParams(
+    Endpoint.GET_RECAPTCHA_CONFIG,
+    {
+      clientType: RecaptchaClientType.WEB,
+      version: RecaptchaVersion.ENTERPRISE
+    },
+    recaptchaConfigResponseEnforce
+  );
+}
 
 describe('core/credentials/email', () => {
   let auth: TestAuth;
@@ -95,7 +181,7 @@ describe('core/credentials/email', () => {
           returnSecureToken: true,
           email: 'some-email',
           password: 'some-password',
-          clientType: 'CLIENT_TYPE_WEB'
+          clientType: RecaptchaClientType.WEB
         });
       });
 
@@ -106,45 +192,24 @@ describe('core/credentials/email', () => {
           sinon.restore();
         });
 
-        const recaptchaConfigResponseEnforce = {
-          recaptchaKey: 'foo/bar/to/site-key',
-          recaptchaEnforcementState: [
-            { provider: 'EMAIL_PASSWORD_PROVIDER', enforcementState: 'ENFORCE' }
-          ]
-        };
-        const recaptchaConfigResponseOff = {
-          recaptchaKey: 'foo/bar/to/site-key',
-          recaptchaEnforcementState: [
-            { provider: 'EMAIL_PASSWORD_PROVIDER', enforcementState: 'OFF' }
-          ]
-        };
-
         it('calls sign in with password with recaptcha enabled', async () => {
-          const recaptcha = new MockGreCAPTCHATopLevel();
+          // TODO(renkelvin) - refactor these tests to be in the same describe block, so we can use
+          // describe.skip in one place.
           if (typeof window === 'undefined') {
+            // Skip in non-browser environment.
             return;
           }
-          window.grecaptcha = recaptcha;
-          sinon
-            .stub(recaptcha.enterprise, 'execute')
-            .returns(Promise.resolve('recaptcha-response'));
-          mockEndpointWithParams(
-            Endpoint.GET_RECAPTCHA_CONFIG,
-            {
-              clientType: RecaptchaClientType.WEB,
-              version: RecaptchaVersion.ENTERPRISE
-            },
-            recaptchaConfigResponseEnforce
-          );
-          await _initializeRecaptchaConfig(auth);
+          mockRecaptchaEnterpriseEnablement(RECAPTCHA_MODE_ENFORCE);
 
+          await _initializeRecaptchaConfig(auth);
           const idTokenResponse = await credential._getIdTokenResponse(auth);
+
           expect(idTokenResponse.idToken).to.eq('id-token');
           expect(idTokenResponse.refreshToken).to.eq('refresh-token');
           expect(idTokenResponse.expiresIn).to.eq('1234');
           expect(idTokenResponse.localId).to.eq(serverUser.localId);
           expect(apiMock.calls[0].request).to.eql({
-            captchaResponse: 'recaptcha-response',
+            captchaResponse: FAKE_RECAPTCHA_TOKEN,
             clientType: RecaptchaClientType.WEB,
             email: 'some-email',
             password: 'some-password',
@@ -154,25 +219,15 @@ describe('core/credentials/email', () => {
         });
 
         it('calls sign in with password with recaptcha disabled', async () => {
-          const recaptcha = new MockGreCAPTCHATopLevel();
           if (typeof window === 'undefined') {
+            // Skip in non-browser environment.
             return;
           }
-          window.grecaptcha = recaptcha;
-          sinon
-            .stub(recaptcha.enterprise, 'execute')
-            .returns(Promise.resolve('recaptcha-response'));
-          mockEndpointWithParams(
-            Endpoint.GET_RECAPTCHA_CONFIG,
-            {
-              clientType: RecaptchaClientType.WEB,
-              version: RecaptchaVersion.ENTERPRISE
-            },
-            recaptchaConfigResponseOff
-          );
-          await _initializeRecaptchaConfig(auth);
+          mockRecaptchaEnterpriseEnablement(RECAPTCHA_MODE_OFF);
 
+          await _initializeRecaptchaConfig(auth);
           const idTokenResponse = await credential._getIdTokenResponse(auth);
+
           expect(idTokenResponse.idToken).to.eq('id-token');
           expect(idTokenResponse.refreshToken).to.eq('refresh-token');
           expect(idTokenResponse.expiresIn).to.eq('1234');
@@ -181,28 +236,19 @@ describe('core/credentials/email', () => {
             email: 'some-email',
             password: 'some-password',
             returnSecureToken: true,
-            clientType: 'CLIENT_TYPE_WEB'
+            clientType: RecaptchaClientType.WEB
           });
         });
 
         it('calls sign in with password with recaptcha forced refresh', async () => {
           if (typeof window === 'undefined') {
+            // Skip in non-browser environment.
             return;
           }
-          // Mock recaptcha js loading method but not set window.recaptcha to simulate recaptcha token retrieval failure
-          sinon
-            .stub(jsHelpers, '_loadJS')
-            .returns(Promise.resolve(new Event('')));
-          window.grecaptcha = undefined;
+          mockRecaptchaEnterpriseEnablement(RECAPTCHA_MODE_ENFORCE);
+          const getRecaptchaConfigMock = mockRecaptchaEnterpriseTokenFailure();
+          assert(getRecaptchaConfigMock !== undefined);
 
-          const getRecaptchaConfigMock = mockEndpointWithParams(
-            Endpoint.GET_RECAPTCHA_CONFIG,
-            {
-              clientType: RecaptchaClientType.WEB,
-              version: RecaptchaVersion.ENTERPRISE
-            },
-            recaptchaConfigResponseEnforce
-          );
           await _initializeRecaptchaConfig(auth);
           auth._agentRecaptchaConfig!.siteKey = 'cached-site-key';
 
@@ -216,18 +262,14 @@ describe('core/credentials/email', () => {
 
         it('calls fallback to recaptcha flow when receiving MISSING_RECAPTCHA_TOKEN error', async () => {
           if (typeof window === 'undefined') {
+            // Skip in non-browser environment.
             return;
           }
-
-          // First call without recaptcha token should fail with MISSING_RECAPTCHA_TOKEN error
-          mockEndpointWithParams(
+          mockRecaptchaEnterpriseTokenSuccess(
+            RecaptchaActionName.SIGN_IN_WITH_PASSWORD
+          );
+          const failureMock = mockEndpoint(
             Endpoint.SIGN_IN_WITH_PASSWORD,
-            {
-              email: 'second-email',
-              password: 'some-password',
-              returnSecureToken: true,
-              clientType: RecaptchaClientType.WEB
-            },
             {
               error: {
                 code: 400,
@@ -237,52 +279,32 @@ describe('core/credentials/email', () => {
             400
           );
 
-          // Second call with a valid recaptcha token (captchaResp) should succeed
-          mockEndpointWithParams(
-            Endpoint.SIGN_IN_WITH_PASSWORD,
-            {
-              captchaResponse: 'recaptcha-response',
-              clientType: RecaptchaClientType.WEB,
-              email: 'some-email',
-              password: 'some-password',
-              recaptchaVersion: RecaptchaVersion.ENTERPRISE,
-              returnSecureToken: true
-            },
-            {
-              idToken: 'id-token',
-              refreshToken: 'refresh-token',
-              expiresIn: '1234',
-              localId: serverUser.localId!
-            }
+          // First call without recaptcha token should fail with MISSING_RECAPTCHA_TOKEN error
+          // Though the internal implementation retries with a reCAPTCHA Enterprise token, the second call will fail in this test.
+          // This is because our endpoint mock does not support returning different responses based on different request body params.
+          // TODO(renkelvin) - refactor this once we expose a mockEndpointWithBodyParams or similar method.
+          await expect(credential._getIdTokenResponse(auth)).to.be.rejectedWith(
+            'Firebase: The reCAPTCHA token is missing when sending request to the backend. (auth/missing-recaptcha-token).'
           );
 
-          // Mock recaptcha js loading method and manually set window.recaptcha
-          sinon
-            .stub(jsHelpers, '_loadJS')
-            .returns(Promise.resolve(new Event('')));
-          const recaptcha = new MockGreCAPTCHATopLevel();
-          window.grecaptcha = recaptcha;
-          const stub = sinon.stub(recaptcha.enterprise, 'execute');
-          stub
-            .withArgs('site-key', {
-              action: RecaptchaActionName.SIGN_IN_WITH_PASSWORD
-            })
-            .returns(Promise.resolve('recaptcha-response'));
-
-          mockEndpointWithParams(
-            Endpoint.GET_RECAPTCHA_CONFIG,
-            {
-              clientType: RecaptchaClientType.WEB,
-              version: RecaptchaVersion.ENTERPRISE
-            },
-            recaptchaConfigResponseEnforce
+          assert(
+            failureMock.calls.length === 2,
+            'Expected 2 calls to the backend API'
           );
-
-          const idTokenResponse = await credential._getIdTokenResponse(auth);
-          expect(idTokenResponse.idToken).to.eq('id-token');
-          expect(idTokenResponse.refreshToken).to.eq('refresh-token');
-          expect(idTokenResponse.expiresIn).to.eq('1234');
-          expect(idTokenResponse.localId).to.eq(serverUser.localId);
+          expect(failureMock.calls[0].request).to.eql({
+            returnSecureToken: true,
+            email: 'some-email',
+            password: 'some-password',
+            clientType: RecaptchaClientType.WEB
+          });
+          expect(failureMock.calls[1].request).to.eql({
+            returnSecureToken: true,
+            email: 'some-email',
+            password: 'some-password',
+            clientType: RecaptchaClientType.WEB,
+            recaptchaVersion: 'RECAPTCHA_ENTERPRISE',
+            captchaResponse: FAKE_RECAPTCHA_TOKEN
+          });
         });
       });
     });
@@ -314,129 +336,89 @@ describe('core/credentials/email', () => {
       });
       context('#recaptcha', () => {
         beforeEach(async () => {
-      apiMock = mockEndpoint(Endpoint.SIGN_UP, {
-        idToken: 'id-token',
-        refreshToken: 'refresh-token',
-        expiresIn: '1234',
-        localId: serverUser.localId!
-      });
-
+          apiMock = mockEndpoint(Endpoint.SIGN_UP, {
+            idToken: 'id-token',
+            refreshToken: 'refresh-token',
+            expiresIn: '1234',
+            localId: serverUser.localId!
+          });
         });
 
         afterEach(() => {
           sinon.restore();
         });
 
-        const recaptchaConfigResponseEnforce = {
-          recaptchaKey: 'foo/bar/to/site-key',
-          recaptchaEnforcementState: [
-            { provider: 'EMAIL_PASSWORD_PROVIDER', enforcementState: 'ENFORCE' }
-          ]
-        };
-        const recaptchaConfigResponseOff = {
-          recaptchaKey: 'foo/bar/to/site-key',
-          recaptchaEnforcementState: [
-            { provider: 'EMAIL_PASSWORD_PROVIDER', enforcementState: 'OFF' }
-          ]
-        };
-
         it('calls sign up with password with recaptcha enabled', async () => {
-          const recaptcha = new MockGreCAPTCHATopLevel();
           if (typeof window === 'undefined') {
+            // Skip in non-browser environment.
             return;
           }
-          window.grecaptcha = recaptcha;
-          sinon
-            .stub(recaptcha.enterprise, 'execute')
-            .returns(Promise.resolve('recaptcha-response'));
-          mockEndpointWithParams(
-            Endpoint.GET_RECAPTCHA_CONFIG,
-            {
-              clientType: RecaptchaClientType.WEB,
-              version: RecaptchaVersion.ENTERPRISE
-            },
-            recaptchaConfigResponseEnforce
-          );
+          mockRecaptchaEnterpriseEnablement(RECAPTCHA_MODE_ENFORCE);
+
+          // proactively initialize config so that token fetch is attempted with the first request.
           await _initializeRecaptchaConfig(auth);
 
           const idTokenResponse = await credential._linkToIdToken(
-          auth,
-          'id-token-2'
-        );
-        expect(idTokenResponse.idToken).to.eq('id-token');
-        expect(idTokenResponse.refreshToken).to.eq('refresh-token');
-        expect(idTokenResponse.expiresIn).to.eq('1234');
-        expect(idTokenResponse.localId).to.eq(serverUser.localId);
-        expect(apiMock.calls[0].request).to.eql({
-          captchaResponse: 'recaptcha-response',
-          recaptchaVersion: RecaptchaVersion.ENTERPRISE,
-          idToken: 'id-token-2',
-          returnSecureToken: true,
-          email: 'some-email',
-          password: 'some-password',
-          clientType: 'CLIENT_TYPE_WEB'
-        });
+            auth,
+            'id-token-2'
+          );
+          expect(idTokenResponse.idToken).to.eq('id-token');
+          expect(idTokenResponse.refreshToken).to.eq('refresh-token');
+          expect(idTokenResponse.expiresIn).to.eq('1234');
+          expect(idTokenResponse.localId).to.eq(serverUser.localId);
+          expect(apiMock.calls[0].request).to.eql({
+            captchaResponse: FAKE_RECAPTCHA_TOKEN,
+            recaptchaVersion: RecaptchaVersion.ENTERPRISE,
+            idToken: 'id-token-2',
+            returnSecureToken: true,
+            email: 'some-email',
+            password: 'some-password',
+            clientType: 'CLIENT_TYPE_WEB'
+          });
         });
 
         it('calls sign up with password with recaptcha disabled', async () => {
-          const recaptcha = new MockGreCAPTCHATopLevel();
           if (typeof window === 'undefined') {
+            // Skip in non-browser environment.
             return;
           }
-          window.grecaptcha = recaptcha;
-          sinon
-            .stub(recaptcha.enterprise, 'execute')
-            .returns(Promise.resolve('recaptcha-response'));
-          mockEndpointWithParams(
-            Endpoint.GET_RECAPTCHA_CONFIG,
-            {
-              clientType: RecaptchaClientType.WEB,
-              version: RecaptchaVersion.ENTERPRISE
-            },
-            recaptchaConfigResponseOff
-          );
+          mockRecaptchaEnterpriseEnablement(RECAPTCHA_MODE_OFF);
+
+          // proactively initialize config so that token fetch is attempted with the first request.
           await _initializeRecaptchaConfig(auth);
-        const idTokenResponse = await credential._linkToIdToken(
-          auth,
-          'id-token-2'
-        );
-        expect(idTokenResponse.idToken).to.eq('id-token');
-        expect(idTokenResponse.refreshToken).to.eq('refresh-token');
-        expect(idTokenResponse.expiresIn).to.eq('1234');
-        expect(idTokenResponse.localId).to.eq(serverUser.localId);
-        expect(apiMock.calls[0].request).to.eql({
-          idToken: 'id-token-2',
-          returnSecureToken: true,
-          email: 'some-email',
-          password: 'some-password',
-          clientType: 'CLIENT_TYPE_WEB'
-        });
+          const idTokenResponse = await credential._linkToIdToken(
+            auth,
+            'id-token-2'
+          );
+
+          expect(idTokenResponse.idToken).to.eq('id-token');
+          expect(idTokenResponse.refreshToken).to.eq('refresh-token');
+          expect(idTokenResponse.expiresIn).to.eq('1234');
+          expect(idTokenResponse.localId).to.eq(serverUser.localId);
+          expect(apiMock.calls[0].request).to.eql({
+            idToken: 'id-token-2',
+            returnSecureToken: true,
+            email: 'some-email',
+            password: 'some-password',
+            clientType: 'CLIENT_TYPE_WEB'
+          });
         });
 
         it('calls sign up with password with recaptcha forced refresh', async () => {
           if (typeof window === 'undefined') {
+            // Skip in non-browser environment.
             return;
           }
-          // Mock recaptcha js loading method but not set window.recaptcha to simulate recaptcha token retrieval failure
-          sinon
-            .stub(jsHelpers, '_loadJS')
-            .returns(Promise.resolve(new Event('')));
-          window.grecaptcha = undefined;
+          const getRecaptchaConfigMock = mockRecaptchaEnterpriseTokenFailure();
+          assert(getRecaptchaConfigMock !== undefined);
 
-          const getRecaptchaConfigMock = mockEndpointWithParams(
-            Endpoint.GET_RECAPTCHA_CONFIG,
-            {
-              clientType: RecaptchaClientType.WEB,
-              version: RecaptchaVersion.ENTERPRISE
-            },
-            recaptchaConfigResponseEnforce
-          );
+          // proactively initialize config so that token fetch is attempted with the first request.
           await _initializeRecaptchaConfig(auth);
           auth._agentRecaptchaConfig!.siteKey = 'cached-site-key';
 
-          await expect(credential._linkToIdToken(auth, 'id-token-2')).to.be.rejectedWith(
-            'No reCAPTCHA enterprise script loaded.'
-          );
+          await expect(
+            credential._linkToIdToken(auth, 'id-token-2')
+          ).to.be.rejectedWith('No reCAPTCHA enterprise script loaded.');
           // Should call getRecaptchaConfig once to refresh the cached recaptcha config
           expect(getRecaptchaConfigMock.calls.length).to.eq(2);
           expect(auth._agentRecaptchaConfig?.siteKey).to.eq('site-key');
@@ -444,19 +426,14 @@ describe('core/credentials/email', () => {
 
         it('calls fallback to recaptcha flow when receiving MISSING_RECAPTCHA_TOKEN error', async () => {
           if (typeof window === 'undefined') {
+            // Skip in non-browser environment.
             return;
           }
-
-          // First call without recaptcha token should fail with MISSING_RECAPTCHA_TOKEN error
-          mockEndpointWithParams(
+          mockRecaptchaEnterpriseTokenSuccess(
+            RecaptchaActionName.SIGN_UP_PASSWORD
+          );
+          const failureMock = mockEndpoint(
             Endpoint.SIGN_UP,
-            {
-              idToken: 'id-token-2',
-              email: 'some-email',
-              password: 'some-password',
-              returnSecureToken: true,
-              clientType: RecaptchaClientType.WEB
-            },
             {
               error: {
                 code: 400,
@@ -466,52 +443,36 @@ describe('core/credentials/email', () => {
             400
           );
 
-          // Second call with a valid recaptcha token (captchaResp) should succeed
-          mockEndpointWithParams(
-            Endpoint.SIGN_UP,
-            {
-              captchaResponse: 'recaptcha-response',
-              clientType: RecaptchaClientType.WEB,
-              email: 'some-email',
-              password: 'some-password',
-              recaptchaVersion: RecaptchaVersion.ENTERPRISE,
-              returnSecureToken: true
-            },
-            {
-              idToken: 'id-token',
-              refreshToken: 'refresh-token',
-              expiresIn: '1234',
-              localId: serverUser.localId!
-            }
+          // First call without recaptcha token should fail with MISSING_RECAPTCHA_TOKEN error
+          // Though the internal implementation retries with a reCAPTCHA Enterprise token, the second call will fail in this test.
+          // This is because our endpoint mock does not support returning different responses based on different request body params.
+          // TODO(renkelvin) - refactor this once we expose a mockEndpointWithBodyParams or similar method.
+          await expect(
+            credential._linkToIdToken(auth, 'id-token-2')
+          ).to.be.rejectedWith(
+            'Firebase: The reCAPTCHA token is missing when sending request to the backend. (auth/missing-recaptcha-token).'
           );
 
-          // Mock recaptcha js loading method and manually set window.recaptcha
-          sinon
-            .stub(jsHelpers, '_loadJS')
-            .returns(Promise.resolve(new Event('')));
-          const recaptcha = new MockGreCAPTCHATopLevel();
-          window.grecaptcha = recaptcha;
-          const stub = sinon.stub(recaptcha.enterprise, 'execute');
-          stub
-            .withArgs('site-key', {
-              action: RecaptchaActionName.SIGN_IN_WITH_PASSWORD
-            })
-            .returns(Promise.resolve('recaptcha-response'));
-
-          mockEndpointWithParams(
-            Endpoint.GET_RECAPTCHA_CONFIG,
-            {
-              clientType: RecaptchaClientType.WEB,
-              version: RecaptchaVersion.ENTERPRISE
-            },
-            recaptchaConfigResponseEnforce
+          assert(
+            failureMock.calls.length === 2,
+            'Expected 2 calls to the backend API'
           );
-
-          const idTokenResponse = await credential._linkToIdToken(auth, "id-token-2");
-          expect(idTokenResponse.idToken).to.eq('id-token');
-          expect(idTokenResponse.refreshToken).to.eq('refresh-token');
-          expect(idTokenResponse.expiresIn).to.eq('1234');
-          expect(idTokenResponse.localId).to.eq(serverUser.localId);
+          expect(failureMock.calls[0].request).to.eql({
+            idToken: 'id-token-2',
+            returnSecureToken: true,
+            email: 'some-email',
+            password: 'some-password',
+            clientType: RecaptchaClientType.WEB
+          });
+          expect(failureMock.calls[1].request).to.eql({
+            idToken: 'id-token-2',
+            returnSecureToken: true,
+            email: 'some-email',
+            password: 'some-password',
+            clientType: RecaptchaClientType.WEB,
+            recaptchaVersion: 'RECAPTCHA_ENTERPRISE',
+            captchaResponse: FAKE_RECAPTCHA_TOKEN
+          });
         });
       });
     });

--- a/packages/auth/src/core/credentials/email.test.ts
+++ b/packages/auth/src/core/credentials/email.test.ts
@@ -308,7 +308,210 @@ describe('core/credentials/email', () => {
           idToken: 'id-token-2',
           returnSecureToken: true,
           email: 'some-email',
-          password: 'some-password'
+          password: 'some-password',
+          clientType: RecaptchaClientType.WEB
+        });
+      });
+      context('#recaptcha', () => {
+        beforeEach(async () => {
+      apiMock = mockEndpoint(Endpoint.SIGN_UP, {
+        idToken: 'id-token',
+        refreshToken: 'refresh-token',
+        expiresIn: '1234',
+        localId: serverUser.localId!
+      });
+
+        });
+
+        afterEach(() => {
+          sinon.restore();
+        });
+
+        const recaptchaConfigResponseEnforce = {
+          recaptchaKey: 'foo/bar/to/site-key',
+          recaptchaEnforcementState: [
+            { provider: 'EMAIL_PASSWORD_PROVIDER', enforcementState: 'ENFORCE' }
+          ]
+        };
+        const recaptchaConfigResponseOff = {
+          recaptchaKey: 'foo/bar/to/site-key',
+          recaptchaEnforcementState: [
+            { provider: 'EMAIL_PASSWORD_PROVIDER', enforcementState: 'OFF' }
+          ]
+        };
+
+        it('calls sign up with password with recaptcha enabled', async () => {
+          const recaptcha = new MockGreCAPTCHATopLevel();
+          if (typeof window === 'undefined') {
+            return;
+          }
+          window.grecaptcha = recaptcha;
+          sinon
+            .stub(recaptcha.enterprise, 'execute')
+            .returns(Promise.resolve('recaptcha-response'));
+          mockEndpointWithParams(
+            Endpoint.GET_RECAPTCHA_CONFIG,
+            {
+              clientType: RecaptchaClientType.WEB,
+              version: RecaptchaVersion.ENTERPRISE
+            },
+            recaptchaConfigResponseEnforce
+          );
+          await _initializeRecaptchaConfig(auth);
+
+          const idTokenResponse = await credential._linkToIdToken(
+          auth,
+          'id-token-2'
+        );
+        expect(idTokenResponse.idToken).to.eq('id-token');
+        expect(idTokenResponse.refreshToken).to.eq('refresh-token');
+        expect(idTokenResponse.expiresIn).to.eq('1234');
+        expect(idTokenResponse.localId).to.eq(serverUser.localId);
+        expect(apiMock.calls[0].request).to.eql({
+          captchaResponse: 'recaptcha-response',
+          recaptchaVersion: RecaptchaVersion.ENTERPRISE,
+          idToken: 'id-token-2',
+          returnSecureToken: true,
+          email: 'some-email',
+          password: 'some-password',
+          clientType: 'CLIENT_TYPE_WEB'
+        });
+        });
+
+        it('calls sign up with password with recaptcha disabled', async () => {
+          const recaptcha = new MockGreCAPTCHATopLevel();
+          if (typeof window === 'undefined') {
+            return;
+          }
+          window.grecaptcha = recaptcha;
+          sinon
+            .stub(recaptcha.enterprise, 'execute')
+            .returns(Promise.resolve('recaptcha-response'));
+          mockEndpointWithParams(
+            Endpoint.GET_RECAPTCHA_CONFIG,
+            {
+              clientType: RecaptchaClientType.WEB,
+              version: RecaptchaVersion.ENTERPRISE
+            },
+            recaptchaConfigResponseOff
+          );
+          await _initializeRecaptchaConfig(auth);
+        const idTokenResponse = await credential._linkToIdToken(
+          auth,
+          'id-token-2'
+        );
+        expect(idTokenResponse.idToken).to.eq('id-token');
+        expect(idTokenResponse.refreshToken).to.eq('refresh-token');
+        expect(idTokenResponse.expiresIn).to.eq('1234');
+        expect(idTokenResponse.localId).to.eq(serverUser.localId);
+        expect(apiMock.calls[0].request).to.eql({
+          idToken: 'id-token-2',
+          returnSecureToken: true,
+          email: 'some-email',
+          password: 'some-password',
+          clientType: 'CLIENT_TYPE_WEB'
+        });
+        });
+
+        it('calls sign up with password with recaptcha forced refresh', async () => {
+          if (typeof window === 'undefined') {
+            return;
+          }
+          // Mock recaptcha js loading method but not set window.recaptcha to simulate recaptcha token retrieval failure
+          sinon
+            .stub(jsHelpers, '_loadJS')
+            .returns(Promise.resolve(new Event('')));
+          window.grecaptcha = undefined;
+
+          const getRecaptchaConfigMock = mockEndpointWithParams(
+            Endpoint.GET_RECAPTCHA_CONFIG,
+            {
+              clientType: RecaptchaClientType.WEB,
+              version: RecaptchaVersion.ENTERPRISE
+            },
+            recaptchaConfigResponseEnforce
+          );
+          await _initializeRecaptchaConfig(auth);
+          auth._agentRecaptchaConfig!.siteKey = 'cached-site-key';
+
+          await expect(credential._linkToIdToken(auth, 'id-token-2')).to.be.rejectedWith(
+            'No reCAPTCHA enterprise script loaded.'
+          );
+          // Should call getRecaptchaConfig once to refresh the cached recaptcha config
+          expect(getRecaptchaConfigMock.calls.length).to.eq(2);
+          expect(auth._agentRecaptchaConfig?.siteKey).to.eq('site-key');
+        });
+
+        it('calls fallback to recaptcha flow when receiving MISSING_RECAPTCHA_TOKEN error', async () => {
+          if (typeof window === 'undefined') {
+            return;
+          }
+
+          // First call without recaptcha token should fail with MISSING_RECAPTCHA_TOKEN error
+          mockEndpointWithParams(
+            Endpoint.SIGN_UP,
+            {
+              idToken: 'id-token-2',
+              email: 'some-email',
+              password: 'some-password',
+              returnSecureToken: true,
+              clientType: RecaptchaClientType.WEB
+            },
+            {
+              error: {
+                code: 400,
+                message: ServerError.MISSING_RECAPTCHA_TOKEN
+              }
+            },
+            400
+          );
+
+          // Second call with a valid recaptcha token (captchaResp) should succeed
+          mockEndpointWithParams(
+            Endpoint.SIGN_UP,
+            {
+              captchaResponse: 'recaptcha-response',
+              clientType: RecaptchaClientType.WEB,
+              email: 'some-email',
+              password: 'some-password',
+              recaptchaVersion: RecaptchaVersion.ENTERPRISE,
+              returnSecureToken: true
+            },
+            {
+              idToken: 'id-token',
+              refreshToken: 'refresh-token',
+              expiresIn: '1234',
+              localId: serverUser.localId!
+            }
+          );
+
+          // Mock recaptcha js loading method and manually set window.recaptcha
+          sinon
+            .stub(jsHelpers, '_loadJS')
+            .returns(Promise.resolve(new Event('')));
+          const recaptcha = new MockGreCAPTCHATopLevel();
+          window.grecaptcha = recaptcha;
+          const stub = sinon.stub(recaptcha.enterprise, 'execute');
+          stub
+            .withArgs('site-key', {
+              action: RecaptchaActionName.SIGN_IN_WITH_PASSWORD
+            })
+            .returns(Promise.resolve('recaptcha-response'));
+
+          mockEndpointWithParams(
+            Endpoint.GET_RECAPTCHA_CONFIG,
+            {
+              clientType: RecaptchaClientType.WEB,
+              version: RecaptchaVersion.ENTERPRISE
+            },
+            recaptchaConfigResponseEnforce
+          );
+
+          const idTokenResponse = await credential._linkToIdToken(auth, "id-token-2");
+          expect(idTokenResponse.idToken).to.eq('id-token');
+          expect(idTokenResponse.refreshToken).to.eq('refresh-token');
+          expect(idTokenResponse.expiresIn).to.eq('1234');
+          expect(idTokenResponse.localId).to.eq(serverUser.localId);
         });
       });
     });

--- a/packages/auth/src/core/credentials/email.ts
+++ b/packages/auth/src/core/credentials/email.ts
@@ -153,7 +153,7 @@ export class EmailAuthCredential extends AuthCredential {
           email: this._email,
           password: this._password,
           clientType: RecaptchaClientType.WEB
-        }
+        };
         return handleRecaptchaFlow(
           auth,
           request,

--- a/packages/auth/src/core/credentials/email.ts
+++ b/packages/auth/src/core/credentials/email.ts
@@ -17,9 +17,7 @@
 
 import { ProviderId, SignInMethod } from '../../model/enums';
 
-import {
-  linkEmailPassword,
-} from '../../api/account_management/email_and_password';
+import { linkEmailPassword } from '../../api/account_management/email_and_password';
 import {
   signInWithPassword,
   SignInWithPasswordRequest

--- a/packages/auth/src/core/credentials/email.ts
+++ b/packages/auth/src/core/credentials/email.ts
@@ -17,7 +17,9 @@
 
 import { ProviderId, SignInMethod } from '../../model/enums';
 
-import { updateEmailPassword } from '../../api/account_management/email_and_password';
+import {
+  linkEmailPassword,
+} from '../../api/account_management/email_and_password';
 import {
   signInWithPassword,
   SignInWithPasswordRequest
@@ -146,7 +148,7 @@ export class EmailAuthCredential extends AuthCredential {
   ): Promise<IdTokenResponse> {
     switch (this.signInMethod) {
       case SignInMethod.EMAIL_PASSWORD:
-        return updateEmailPassword(auth, {
+        return linkEmailPassword(auth, {
           idToken,
           returnSecureToken: true,
           email: this._email,

--- a/packages/auth/src/core/credentials/email.ts
+++ b/packages/auth/src/core/credentials/email.ts
@@ -33,6 +33,7 @@ import { _fail } from '../util/assert';
 import { AuthCredential } from './auth_credential';
 import { handleRecaptchaFlow } from '../../platform_browser/recaptcha/recaptcha_enterprise_verifier';
 import { RecaptchaActionName, RecaptchaClientType } from '../../api';
+import { SignUpRequest } from '../../api/authentication/sign_up';
 /**
  * Interface that represents the credentials returned by {@link EmailAuthProvider} for
  * {@link ProviderId}.PASSWORD
@@ -146,12 +147,19 @@ export class EmailAuthCredential extends AuthCredential {
   ): Promise<IdTokenResponse> {
     switch (this.signInMethod) {
       case SignInMethod.EMAIL_PASSWORD:
-        return linkEmailPassword(auth, {
+        const request: SignUpRequest = {
           idToken,
           returnSecureToken: true,
           email: this._email,
-          password: this._password
-        });
+          password: this._password,
+          clientType: RecaptchaClientType.WEB
+        }
+        return handleRecaptchaFlow(
+          auth,
+          request,
+          RecaptchaActionName.SIGN_UP_PASSWORD,
+          linkEmailPassword
+        );
       case SignInMethod.EMAIL_LINK:
         return signInWithEmailLinkForLinking(auth, {
           idToken,


### PR DESCRIPTION
The /signUp API supports linking when Email Enumeration Protection is enabled as well as disabled. /setAccountInfo does not work when Email Enumeration Protection is enabled.


Verified with the test app that anonymous user upgrade works.
