### PR TITLE
Improved handling of reads after writes in transactions if the get is…

### DIFF
--- a/packages/firestore/src/core/transaction.ts
+++ b/packages/firestore/src/core/transaction.ts
@@ -48,7 +48,7 @@ export class Transaction {
    * A deferred usage error that occurred previously in this transaction that
    * will cause the transaction to fail once it actually commits.
    */
-  private lastWriteError: FirestoreError | null = null;
+  private lastTransactionError: FirestoreError | null = null;
 
   /**
    * Set of documents that have been written in the transaction.
@@ -64,10 +64,12 @@ export class Transaction {
     this.ensureCommitNotCalled();
 
     if (this.mutations.length > 0) {
+      this.lastTransactionError = null;
       throw new FirestoreError(
         Code.INVALID_ARGUMENT,
         'Firestore transactions require all reads to be executed before all writes.'
       );
+      throw this.lastTransactionError;
     }
     const docs = await invokeBatchGetDocumentsRpc(this.datastore, keys);
     docs.forEach(doc => this.recordVersion(doc));
@@ -83,7 +85,7 @@ export class Transaction {
     try {
       this.write(data.toMutation(key, this.preconditionForUpdate(key)));
     } catch (e) {
-      this.lastWriteError = e as FirestoreError | null;
+      this.lastTransactionError = e as FirestoreError | null;
     }
     this.writtenDocs.add(key.toString());
   }
@@ -96,8 +98,8 @@ export class Transaction {
   async commit(): Promise<void> {
     this.ensureCommitNotCalled();
 
-    if (this.lastWriteError) {
-      throw this.lastWriteError;
+    if (this.lastTransactionError) {
+      throw this.lastTransactionError;
     }
     const unwritten = this.readVersions;
     // For each mutation, note that the doc was written.

--- a/packages/firestore/src/core/transaction.ts
+++ b/packages/firestore/src/core/transaction.ts
@@ -64,8 +64,7 @@ export class Transaction {
     this.ensureCommitNotCalled();
 
     if (this.mutations.length > 0) {
-      this.lastTransactionError = null;
-      throw new FirestoreError(
+      this.lastTransactionError = new FirestoreError(
         Code.INVALID_ARGUMENT,
         'Firestore transactions require all reads to be executed before all writes.'
       );

--- a/packages/firestore/test/integration/api/transactions.test.ts
+++ b/packages/firestore/test/integration/api/transactions.test.ts
@@ -530,30 +530,6 @@ apiDescribe('Database transactions', persistence => {
     });
   });
 
-  it('cannot read after writing and does not commit - get is awaited', () => {
-    return withTestDb(persistence, async db => {
-      const docRef = doc(collection(db, '00000-anything'));
-      await setDoc(docRef, { foo: 'baz' });
-      await runTransaction(db, async transaction => {
-        transaction.set(docRef, { foo: 'bar' });
-        return transaction.get(docRef);
-      })
-        .then(() => {
-          expect.fail('transaction should fail');
-        })
-        .catch((err: FirestoreError) => {
-          expect(err).to.exist;
-          expect(err.code).to.equal('invalid-argument');
-          expect(err.message).to.contain(
-            'Firestore transactions require all reads to be executed'
-          );
-        });
-
-      const postSnap = await getDoc(docRef);
-      expect(postSnap.get('foo')).to.equal('baz');
-    });
-  });
-
   it('cannot read after writing and does not commit, even if the user transaction does not bubble up the error', () => {
     return withTestDb(persistence, async db => {
       const docRef = doc(collection(db, '00000-anything'));
@@ -561,11 +537,12 @@ apiDescribe('Database transactions', persistence => {
       await runTransaction(db, async transaction => {
         transaction.set(docRef, { foo: 'bar' });
 
-        // Is this valid, a `transaction.get(...)` without an await or return?
-        // `transaction.get(...)` returns a promise that must
-        // be awaited to get the result. If not awaited, then, you haven't done
-        // anything with the result of the get and the caller's code is invalid.
-        // If awaited, then the transaction will fail and not commit as expected.
+        // The following statement `transaction.get(...)` is problematic because
+        // it occurs after `transaction.set(...)`. In previous versions of the
+        // SDK this un-awaited `transaction.get(...)` failed but the transaction
+        // still committed successfully. This regression test ensures that the
+        // commit will fail even if the code does not await
+        // `transaction.get(...)`.
         // eslint-disable-next-line
         transaction.get(docRef);
       })


### PR DESCRIPTION
… not awaited or returned.

Handles the case of a read after write in a transaction where the `get(...)` is not awaited, such as in https://github.com/firebase/firebase-js-sdk/issues/7714.