### PR TITLE
Rolling back the use of useFetchStreams, which has lead to hanging queries.

### DIFF
--- a/.changeset/real-ants-notice.md
+++ b/.changeset/real-ants-notice.md
@@ -1,0 +1,5 @@
+---
+"@firebase/firestore": patch
+---
+
+Rolling back the use of useFetchStreams, which has lead to hanging and incomplete queries.

--- a/packages/firestore/src/platform/browser/webchannel_connection.ts
+++ b/packages/firestore/src/platform/browser/webchannel_connection.ts
@@ -27,7 +27,8 @@ import {
   EventTarget,
   StatEvent,
   Event,
-  Stat
+  Stat,
+  FetchXmlHttpFactory
 } from '@firebase/webchannel-wrapper';
 
 import { Token } from '../../api/credentials';
@@ -208,7 +209,9 @@ export class WebChannelConnection extends RestConnection {
     }
 
     if (this.useFetchStreams) {
-      request.useFetchStreams = true;
+      // When b/307942499 is fixed, revert to the following line:
+      // request.useFetchStreams = true;
+      request.xmlHttpFactory = new FetchXmlHttpFactory({});
     }
 
     this.modifyHeadersForRequest(

--- a/packages/firestore/src/platform/browser/webchannel_connection.ts
+++ b/packages/firestore/src/platform/browser/webchannel_connection.ts
@@ -209,8 +209,7 @@ export class WebChannelConnection extends RestConnection {
     }
 
     if (this.useFetchStreams) {
-      // When b/307942499 is fixed, revert to the following line:
-      // request.useFetchStreams = true;
+      // TODO(b/307942499): switch to `useFetchStreams` once WebChannel is fixed.
       request.xmlHttpFactory = new FetchXmlHttpFactory({});
     }
 


### PR DESCRIPTION
Rolling back the use of useFetchStreams, which has lead to hanging queries.

Writing additional automated tests for this is non-trivial. This change has been tested locally using `yarn link` against a reproduction project. This change can be pushed alone, or it can wait for automated tests to be written.

This is the original change we're rolling back: https://github.com/firebase/firebase-js-sdk/pull/7569/files#diff-a0dc4840c5dc14c6bd4f1a172930675ddde606430fbc23bc613aca0cbd6d031d