### PR TITLE
Expose INVALID_LOGIN_CREDENTIALS as auth/invalid-credential error.

### DIFF
--- a/common/api-review/auth.api.md
+++ b/common/api-review/auth.api.md
@@ -165,6 +165,7 @@ export const AuthErrorCodes: {
     readonly INVALID_EMAIL: "auth/invalid-email";
     readonly INVALID_EMULATOR_SCHEME: "auth/invalid-emulator-scheme";
     readonly INVALID_IDP_RESPONSE: "auth/invalid-credential";
+    readonly INVALID_LOGIN_CREDENTIALS: "auth/invalid-credential";
     readonly INVALID_MESSAGE_PAYLOAD: "auth/invalid-message-payload";
     readonly INVALID_MFA_SESSION: "auth/invalid-multi-factor-session";
     readonly INVALID_OAUTH_CLIENT_ID: "auth/invalid-oauth-client-id";

--- a/packages/auth/src/api/errors.ts
+++ b/packages/auth/src/api/errors.ts
@@ -44,6 +44,7 @@ export const enum ServerError {
   INVALID_ID_TOKEN = 'INVALID_ID_TOKEN',
   INVALID_IDP_RESPONSE = 'INVALID_IDP_RESPONSE',
   INVALID_IDENTIFIER = 'INVALID_IDENTIFIER',
+  INVALID_LOGIN_CREDENTIALS = 'INVALID_LOGIN_CREDENTIALS',
   INVALID_MESSAGE_PAYLOAD = 'INVALID_MESSAGE_PAYLOAD',
   INVALID_MFA_PENDING_CREDENTIAL = 'INVALID_MFA_PENDING_CREDENTIAL',
   INVALID_OAUTH_CLIENT_ID = 'INVALID_OAUTH_CLIENT_ID',
@@ -144,6 +145,10 @@ export const SERVER_ERROR_MAP: Partial<ServerErrorMap<ServerError>> = {
   [ServerError.INVALID_PASSWORD]: AuthErrorCode.INVALID_PASSWORD,
   // This can only happen if the SDK sends a bad request.
   [ServerError.MISSING_PASSWORD]: AuthErrorCode.MISSING_PASSWORD,
+  // Thrown if Email Enumeration Protection is enabled in the project and the email or password is
+  // invalid.
+  [ServerError.INVALID_LOGIN_CREDENTIALS]:
+    AuthErrorCode.INVALID_LOGIN_CREDENTIALS,
 
   // Sign up with email and password errors.
   [ServerError.EMAIL_EXISTS]: AuthErrorCode.EMAIL_EXISTS,

--- a/packages/auth/src/core/errors.ts
+++ b/packages/auth/src/core/errors.ts
@@ -61,6 +61,7 @@ export const enum AuthErrorCode {
   INVALID_EMAIL = 'invalid-email',
   INVALID_EMULATOR_SCHEME = 'invalid-emulator-scheme',
   INVALID_IDP_RESPONSE = 'invalid-credential',
+  INVALID_LOGIN_CREDENTIALS = 'invalid-credential',
   INVALID_MESSAGE_PAYLOAD = 'invalid-message-payload',
   INVALID_MFA_SESSION = 'invalid-multi-factor-session',
   INVALID_OAUTH_CLIENT_ID = 'invalid-oauth-client-id',
@@ -219,6 +220,8 @@ function _debugErrorMap(): ErrorMap<AuthErrorCode> {
       'The SHA-1 certificate hash provided is invalid.',
     [AuthErrorCode.INVALID_IDP_RESPONSE]:
       'The supplied auth credential is malformed or has expired.',
+    [AuthErrorCode.INVALID_LOGIN_CREDENTIALS]:
+      'The supplied login credentials are invalid.',
     [AuthErrorCode.INVALID_MESSAGE_PAYLOAD]:
       'The email template corresponding to this action contains invalid characters in its message. ' +
       'Please fix by going to the Auth email templates section in the Firebase Console.',
@@ -528,6 +531,7 @@ export const AUTH_ERROR_CODES_MAP_DO_NOT_USE_INTERNALLY = {
   INVALID_EMAIL: 'auth/invalid-email',
   INVALID_EMULATOR_SCHEME: 'auth/invalid-emulator-scheme',
   INVALID_IDP_RESPONSE: 'auth/invalid-credential',
+  INVALID_LOGIN_CREDENTIALS: 'auth/invalid-credential',
   INVALID_MESSAGE_PAYLOAD: 'auth/invalid-message-payload',
   INVALID_MFA_SESSION: 'auth/invalid-multi-factor-session',
   INVALID_OAUTH_CLIENT_ID: 'auth/invalid-oauth-client-id',

--- a/packages/auth/src/core/strategies/email.ts
+++ b/packages/auth/src/core/strategies/email.ts
@@ -33,7 +33,9 @@ import { _setActionCodeSettingsOnRequest } from './action_code_settings';
 import { getModularInstance } from '@firebase/util';
 
 /**
- * Gets the list of possible sign in methods for the given email address.
+ * Gets the list of possible sign in methods for the given email address. This method returns an
+ * empty list when [Email Enumeration Protection](https://cloud.google.com/identity-platform/docs/admin/email-enumeration-protection) is enabled, irrespective of the number of
+ * authentication methods available for the given email.
  *
  * @remarks
  * This is useful to differentiate methods of sign-in for the same provider, eg.

--- a/packages/auth/src/core/strategies/email_and_password.ts
+++ b/packages/auth/src/core/strategies/email_and_password.ts
@@ -61,7 +61,8 @@ async function recachePasswordPolicy(auth: Auth): Promise<void> {
 }
 
 /**
- * Sends a password reset email to the given email address.
+ * Sends a password reset email to the given email address. This method does not throw an error when
+ * [Email Enumeration Protection](https://cloud.google.com/identity-platform/docs/admin/email-enumeration-protection) is enabled.
  *
  * @remarks
  * To complete the password reset, call {@link confirmPasswordReset} with the code supplied in
@@ -303,6 +304,7 @@ export async function createUserWithEmailAndPassword(
  *
  * @remarks
  * Fails with an error if the email address and password do not match.
+ * When [Email Enumeration Protection](https://cloud.google.com/identity-platform/docs/admin/email-enumeration-protection) is enabled, this method fails with "auth/invalid-credential" in case of an invalid email/password.
  *
  * Note: The user's password is NOT the password used to access the user's email account. The
  * email address serves as a unique identifier for the user, and the password is used to access

--- a/packages/auth/src/core/user/account_info.ts
+++ b/packages/auth/src/core/user/account_info.ts
@@ -88,6 +88,9 @@ export async function updateProfile(
  * @param user - The user.
  * @param newEmail - The new email address.
  *
+ * Throws "auth/operation-not-allowed" error when [Email Enumeration Protection](https://cloud.google.com/identity-platform/docs/admin/email-enumeration-protection) is enabled.
+ * Deprecated - Use {@link verifyBeforeUpdateEmail} instead.
+ *
  * @public
  */
 export function updateEmail(user: User, newEmail: string): Promise<void> {


### PR DESCRIPTION
This PR has the following changes:

* Expose INVALID_LOGIN_CREDENTIALS as auth/invalid-credential error.
* Update the doc snippets for various SDK methods to explain the behavior when Email Enumeration Protection is enabled.
*  Mark fetchSignInMethodsForEmail and updateEmail as deprecated.


