### PR TITLE
Support converter that returns undefined.

### DIFF
--- a/.changeset/strong-coins-repeat.md
+++ b/.changeset/strong-coins-repeat.md
@@ -1,0 +1,5 @@
+---
+'@firebase/firestore-compat': patch
+---
+
+Allow converter return value of undefined.

--- a/packages/firestore-compat/src/api/database.ts
+++ b/packages/firestore-compat/src/api/database.ts
@@ -972,11 +972,16 @@ export class QueryDocumentSnapshot<T = PublicDocumentData>
 {
   data(options?: PublicSnapshotOptions): T {
     const data = this._delegate.data(options);
-    _debugAssert(
-      data !== undefined,
-      'Document in a QueryDocumentSnapshot should exist'
-    );
-    return data;
+    if (this._delegate._converter) {
+      // Undefined is a possible valid value from converter.
+      return data as T;
+    } else {
+      _debugAssert(
+          data !== undefined,
+          'Document in a QueryDocumentSnapshot should exist'
+      );
+      return data;
+    }
   }
 }
 

--- a/packages/firestore-compat/src/api/database.ts
+++ b/packages/firestore-compat/src/api/database.ts
@@ -977,8 +977,8 @@ export class QueryDocumentSnapshot<T = PublicDocumentData>
       return data as T;
     } else {
       _debugAssert(
-          data !== undefined,
-          'Document in a QueryDocumentSnapshot should exist'
+        data !== undefined,
+        'Document in a QueryDocumentSnapshot should exist'
       );
       return data;
     }

--- a/packages/firestore-compat/test/database.test.ts
+++ b/packages/firestore-compat/test/database.test.ts
@@ -1647,6 +1647,30 @@ apiDescribe('Database', (persistence: boolean) => {
         expect(untypedDocRef.isEqual(ref)).to.be.true;
       });
     });
+
+    it('for DocumentReference.withConverter() that returns undefined', () => {
+      return withTestDb(persistence, async db => {
+        const docRef = db
+            .collection('posts')
+            .doc()
+            .withConverter({
+              toFirestore(post: Post): firestore.DocumentData {
+                return {title: post.title, author: post.author};
+              },
+              fromFirestore(
+                  snapshot: firestore.QueryDocumentSnapshot,
+                  options: firestore.SnapshotOptions
+              ): Post | undefined {
+                return undefined;
+              }
+            });
+
+        await docRef.set(new Post('post', 'author'));
+        const postData = await docRef.get();
+        const post = postData.data();
+        expect(post).to.equal(undefined);
+      });
+    });
   });
 
   // TODO(b/196858864): This test regularly times out on CI.

--- a/packages/firestore-compat/test/database.test.ts
+++ b/packages/firestore-compat/test/database.test.ts
@@ -1651,19 +1651,19 @@ apiDescribe('Database', (persistence: boolean) => {
     it('for DocumentReference.withConverter() that returns undefined', () => {
       return withTestDb(persistence, async db => {
         const docRef = db
-            .collection('posts')
-            .doc()
-            .withConverter({
-              toFirestore(post: Post): firestore.DocumentData {
-                return {title: post.title, author: post.author};
-              },
-              fromFirestore(
-                  snapshot: firestore.QueryDocumentSnapshot,
-                  options: firestore.SnapshotOptions
-              ): Post | undefined {
-                return undefined;
-              }
-            });
+          .collection('posts')
+          .doc()
+          .withConverter({
+            toFirestore(post: Post): firestore.DocumentData {
+              return { title: post.title, author: post.author };
+            },
+            fromFirestore(
+              snapshot: firestore.QueryDocumentSnapshot,
+              options: firestore.SnapshotOptions
+            ): Post | undefined {
+              return undefined;
+            }
+          });
 
         await docRef.set(new Post('post', 'author'));
         const postData = await docRef.get();


### PR DESCRIPTION
This is to resolve issue: https://github.com/firebase/firebase-js-sdk/issues/7719

A converter can return undefined, so we should not fail when data is undefined in compat library.