### PR TITLE
Fix docs unnecessarily undergo limbo resolution while resuming query bug

### DIFF
--- a/.changeset/olive-dogs-play.md
+++ b/.changeset/olive-dogs-play.md
@@ -1,0 +1,7 @@
+---
+'@firebase/firestore': patch
+'firebase': patch
+---
+
+Fixed an issue in the local cache synchronization logic where all locally-cached documents that matched a resumed query would be unnecessarily re-downloaded; with the fix it now only downloads the documents that are known to be out-of-sync.
+

--- a/packages/firestore/src/core/firestore_client.ts
+++ b/packages/firestore/src/core/firestore_client.ts
@@ -729,7 +729,7 @@ async function executeQueryFromCache(
     const viewDocChanges = view.computeDocChanges(queryResult.documents);
     const viewChange = view.applyChanges(
       viewDocChanges,
-      /* updateLimboDocuments= */ false
+      /* limboResolutionEnabled= */ false
     );
     result.resolve(viewChange.snapshot!);
   } catch (e) {

--- a/packages/firestore/src/core/sync_engine_impl.ts
+++ b/packages/firestore/src/core/sync_engine_impl.ts
@@ -1081,10 +1081,13 @@ async function applyDocChanges(
 
   const targetChange =
     remoteEvent && remoteEvent.targetChanges.get(queryView.targetId);
+  const isPendingForRequeryResult =
+    remoteEvent && remoteEvent.targetMismatches.get(queryView.targetId) != null;
   const viewChange = queryView.view.applyChanges(
     viewDocChanges,
     /* updateLimboDocuments= */ syncEngineImpl.isPrimaryClient,
-    targetChange
+    targetChange,
+    isPendingForRequeryResult
   );
   updateTrackedLimbos(
     syncEngineImpl,

--- a/packages/firestore/src/core/sync_engine_impl.ts
+++ b/packages/firestore/src/core/sync_engine_impl.ts
@@ -1081,13 +1081,13 @@ async function applyDocChanges(
 
   const targetChange =
     remoteEvent && remoteEvent.targetChanges.get(queryView.targetId);
-  const isPendingForRequeryResult =
+  const waitForRequeryResult =
     remoteEvent && remoteEvent.targetMismatches.get(queryView.targetId) != null;
   const viewChange = queryView.view.applyChanges(
     viewDocChanges,
     /* updateLimboDocuments= */ syncEngineImpl.isPrimaryClient,
     targetChange,
-    isPendingForRequeryResult
+    waitForRequeryResult
   );
   updateTrackedLimbos(
     syncEngineImpl,

--- a/packages/firestore/src/core/sync_engine_impl.ts
+++ b/packages/firestore/src/core/sync_engine_impl.ts
@@ -368,7 +368,7 @@ async function initializeViewAndComputeSnapshot(
     );
   const viewChange = view.applyChanges(
     viewDocChanges,
-    /* updateLimboDocuments= */ syncEngineImpl.isPrimaryClient,
+    /* limboResolutionEnabled= */ syncEngineImpl.isPrimaryClient,
     synthesizedTargetChange
   );
   updateTrackedLimbos(syncEngineImpl, targetId, viewChange.limboChanges);
@@ -1081,13 +1081,13 @@ async function applyDocChanges(
 
   const targetChange =
     remoteEvent && remoteEvent.targetChanges.get(queryView.targetId);
-  const waitForRequeryResult =
+  const targetIsPendingReset =
     remoteEvent && remoteEvent.targetMismatches.get(queryView.targetId) != null;
   const viewChange = queryView.view.applyChanges(
     viewDocChanges,
-    /* updateLimboDocuments= */ syncEngineImpl.isPrimaryClient,
+    /* limboResolutionEnabled= */ syncEngineImpl.isPrimaryClient,
     targetChange,
-    waitForRequeryResult
+    targetIsPendingReset
   );
   updateTrackedLimbos(
     syncEngineImpl,

--- a/packages/firestore/src/core/view.ts
+++ b/packages/firestore/src/core/view.ts
@@ -284,7 +284,7 @@ export class View {
     docChanges: ViewDocumentChanges,
     updateLimboDocuments: boolean,
     targetChange?: TargetChange,
-    isPendingForRequeryResult: boolean = false,
+    isPendingForRequeryResult?: boolean
   ): ViewChange {
     debugAssert(
       !docChanges.needsRefill,
@@ -303,15 +303,18 @@ export class View {
     });
 
     this.applyTargetChange(targetChange);
-    const limboChanges = !isPendingForRequeryResult && updateLimboDocuments
-      ? this.updateLimboDocuments()
-      : [];
+    const limboChanges =
+      !isPendingForRequeryResult && updateLimboDocuments
+        ? this.updateLimboDocuments()
+        : [];
 
     // We are at synced state if there is no limbo docs are waiting to be resolved, view is current
     // with the backend, and the query is not pending for full re-query result due to existence
     // filter mismatch.
-      const synced =
-        this.limboDocuments.size === 0 && this.current && !isPendingForRequeryResult;
+    const synced =
+      this.limboDocuments.size === 0 &&
+      this.current &&
+      !isPendingForRequeryResult;
 
     const newSyncState = synced ? SyncState.Synced : SyncState.Local;
     const syncStateChanged = newSyncState !== this.syncState;

--- a/packages/firestore/src/core/view.ts
+++ b/packages/firestore/src/core/view.ts
@@ -273,7 +273,7 @@ export class View {
    * @param docChanges - The set of changes to make to the view's docs.
    * @param updateLimboDocuments - Whether to update limbo documents based on
    *        this change.
-   * @param isPendingForRequeryResult - Whether the target is pending to run a full
+   * @param waitForRequeryResult - Whether the target is pending to run a full
    *        re-query due to existence filter mismatch.
    * @param targetChange - A target change to apply for computing limbo docs and
    *        sync state.
@@ -284,7 +284,7 @@ export class View {
     docChanges: ViewDocumentChanges,
     updateLimboDocuments: boolean,
     targetChange?: TargetChange,
-    isPendingForRequeryResult?: boolean
+    waitForRequeryResult?: boolean
   ): ViewChange {
     debugAssert(
       !docChanges.needsRefill,
@@ -304,7 +304,7 @@ export class View {
 
     this.applyTargetChange(targetChange);
     const limboChanges =
-      !isPendingForRequeryResult && updateLimboDocuments
+      !waitForRequeryResult && updateLimboDocuments
         ? this.updateLimboDocuments()
         : [];
 
@@ -312,9 +312,7 @@ export class View {
     // with the backend, and the query is not pending for full re-query result due to existence
     // filter mismatch.
     const synced =
-      this.limboDocuments.size === 0 &&
-      this.current &&
-      !isPendingForRequeryResult;
+      this.limboDocuments.size === 0 && this.current && !waitForRequeryResult;
 
     const newSyncState = synced ? SyncState.Synced : SyncState.Local;
     const syncStateChanged = newSyncState !== this.syncState;

--- a/packages/firestore/src/core/view.ts
+++ b/packages/firestore/src/core/view.ts
@@ -273,10 +273,10 @@ export class View {
    * @param docChanges - The set of changes to make to the view's docs.
    * @param updateLimboDocuments - Whether to update limbo documents based on
    *        this change.
-   * @param waitForRequeryResult - Whether the target is pending to run a full
-   *        re-query due to existence filter mismatch.
    * @param targetChange - A target change to apply for computing limbo docs and
    *        sync state.
+   * @param waitForRequeryResult - Whether the target is pending to run a full
+   *        re-query due to existence filter mismatch.
    * @returns A new ViewChange with the given docs, changes, and sync state.
    */
   // PORTING NOTE: The iOS/Android clients always compute limbo document changes.
@@ -303,10 +303,9 @@ export class View {
     });
 
     this.applyTargetChange(targetChange);
-    const limboChanges =
-      !waitForRequeryResult && updateLimboDocuments
-        ? this.updateLimboDocuments()
-        : [];
+    const limboChanges = updateLimboDocuments
+      ? this.updateLimboDocuments(waitForRequeryResult ?? false)
+      : [];
 
     // We are at synced state if there is no limbo docs are waiting to be resolved, view is current
     // with the backend, and the query is not pending for full re-query result due to existence
@@ -413,9 +412,11 @@ export class View {
     }
   }
 
-  private updateLimboDocuments(): LimboDocumentChange[] {
+  private updateLimboDocuments(
+    waitForRequeryResult: boolean
+  ): LimboDocumentChange[] {
     // We can only determine limbo documents when we're in-sync with the server.
-    if (!this.current) {
+    if (waitForRequeryResult || !this.current) {
       return [];
     }
 

--- a/packages/firestore/src/core/view.ts
+++ b/packages/firestore/src/core/view.ts
@@ -277,7 +277,7 @@ export class View {
    *        sync state.
    * @param targetIsPendingReset - Whether the target is pending to reset due to
    *        existence filter mismatch. If not explicitly specified, it is treated
-   *        equivalently to false.
+   *        equivalently to `false`.
    * @returns A new ViewChange with the given docs, changes, and sync state.
    */
   // PORTING NOTE: The iOS/Android clients always compute limbo document changes.

--- a/packages/firestore/test/unit/core/view.test.ts
+++ b/packages/firestore/test/unit/core/view.test.ts
@@ -304,19 +304,19 @@ describe('View', () => {
     let changes = view.computeDocChanges(documentUpdates(doc1));
     let viewChange = view.applyChanges(
       changes,
-      /* updateLimboDocuments= */ true
+      /* limboResolutionEnabled= */ true
     );
     expect(viewChange.snapshot!.fromCache).to.be.true;
 
     // Add doc2 to generate a snapshot. Doc1 is still missing.
     changes = view.computeDocChanges(documentUpdates(doc2));
-    viewChange = view.applyChanges(changes, /* updateLimboDocuments= */ true);
+    viewChange = view.applyChanges(changes, /* limboResolutionEnabled= */ true);
     expect(viewChange.snapshot!.fromCache).to.be.true;
 
     // Add doc2 to the backend's result set.
     viewChange = view.applyChanges(
       changes,
-      /* updateLimboDocuments= */ true,
+      /* limboResolutionEnabled= */ true,
       updateMapping(version(0), [doc2], [], [], /* current= */ true)
     );
     // We are CURRENT but doc1 is in limbo.
@@ -325,7 +325,7 @@ describe('View', () => {
     // Add doc1 to the backend's result set.
     viewChange = view.applyChanges(
       changes,
-      /* updateLimboDocuments= */ true,
+      /* limboResolutionEnabled= */ true,
       updateMapping(version(0), [doc1], [], [], /* current= */ true)
     );
     expect(viewChange.snapshot!.fromCache).to.be.false;

--- a/packages/firestore/test/unit/local/query_engine.test.ts
+++ b/packages/firestore/test/unit/local/query_engine.test.ts
@@ -253,7 +253,7 @@ function genericQueryEngineTest(
               const viewDocChanges = view.computeDocChanges(docs);
               return view.applyChanges(
                 viewDocChanges,
-                /*updateLimboDocuments=*/ true
+                /* limboResolutionEnabled= */ true
               ).snapshot!.docs;
             });
         });

--- a/packages/firestore/test/unit/specs/limbo_spec.test.ts
+++ b/packages/firestore/test/unit/specs/limbo_spec.test.ts
@@ -889,6 +889,7 @@ describeSpec('Limbo Documents:', [], () => {
           // to just send the docBs with an existence filter with a count of 3.
           .watchSends({ affects: [query1] }, docB1, docB2, docB3)
           .watchFilters([query1], [docB1.key, docB2.key, docB3.key])
+          .watchCurrents(query1, 'resume-token-1001')
           .watchSnapshots(1001)
           .expectEvents(query1, {
             added: [docB1, docB2, docB3],
@@ -968,6 +969,7 @@ describeSpec('Limbo Documents:', [], () => {
             [docB1.key, docB2.key, docB3.key],
             bloomFilterProto
           )
+          .watchCurrents(query1, 'resume-token-1001')
           .watchSnapshots(1001)
           .expectEvents(query1, {
             added: [docB1, docB2, docB3],
@@ -978,8 +980,6 @@ describeSpec('Limbo Documents:', [], () => {
           // existence filter mismatch. Bloom filter checks membership of the
           // docs, and filters out docAs, while docBs returns true. Number of
           // existing docs matches the expected count, so skip the re-query.
-          .watchCurrents(query1, 'resume-token-1002')
-          .watchSnapshots(1002)
           // The docAs are now in limbo; the client begins limbo resolution.
           .expectLimboDocs(docA1.key, docA2.key)
           .expectEnqueuedLimboDocs(docA3.key)

--- a/packages/firestore/test/unit/specs/limbo_spec.test.ts
+++ b/packages/firestore/test/unit/specs/limbo_spec.test.ts
@@ -928,7 +928,7 @@ describeSpec('Limbo Documents:', [], () => {
     }
   );
 
-  // Reproduce the bug in b/238823695
+  // Regression test for the bug in https://github.com/firebase/firebase-android-sdk/issues/5357
   specTest(
     'Limbo resolution should wait for full re-query result if there is an existence filter mismatch ',
     [],
@@ -949,8 +949,6 @@ describeSpec('Limbo Documents:', [], () => {
           .watchAcks(query1)
           // DocB is deleted in the next sync.
           .watchFilters([query1], [docA.key])
-          // Bugged behavior: Missing watchCurrent here will move
-          // all the docs to limbo unnecessarily.
           .watchCurrents(query1, 'resume-token-2000')
           .watchSnapshots(2000)
           .expectActiveTargets({
@@ -962,7 +960,7 @@ describeSpec('Limbo Documents:', [], () => {
           .watchAcksFull(query1, 3000, docA)
           // Only the deleted doc is moved to limbo after re-query result.
           .expectLimboDocs(docB.key)
-          .ackLimbo(3000, deletedDoc('collection/b', 3000))
+          .ackLimbo(3000, deletedDoc(docB.key.toString(), 3000))
           .expectLimboDocs()
           .expectEvents(query1, {
             removed: [docB]

--- a/packages/firestore/test/unit/specs/limit_spec.test.ts
+++ b/packages/firestore/test/unit/specs/limit_spec.test.ts
@@ -343,6 +343,7 @@ describeSpec('Limits:', [], () => {
           // out of sync.
           .watchSends({ affects: [limitQuery] }, secondDocument)
           .watchFilters([limitQuery], [secondDocument.key])
+          .watchCurrents(limitQuery, 'resume-token-1004')
           .watchSnapshots(1004)
           .expectActiveTargets({
             query: limitQuery,


### PR DESCRIPTION
While resuming a query and there is an existence filter mismatch detected, SDK updated the limbo docs without waiting for a full re-query result. 

- [ ] Add a new flag to check if we should send docs to limbo
- [ ] Add missing .watchCurrent for some spec tests
- [ ] add a new spec test dedicated for this bug 
- [ ] renamed `updateLimboDocuments` in applyChanges to `limboResolutionEnabled` for better semantic meaning

Ported to android in https://github.com/firebase/firebase-android-sdk/pull/5506 and ios in https://github.com/firebase/firebase-ios-sdk/pull/12044.
