### PR TITLE
[Heartbeat Service] Guard against empty heartbeat caches.

### DIFF
--- a/.changeset/chilly-emus-sit.md
+++ b/.changeset/chilly-emus-sit.md
@@ -2,4 +2,4 @@
 '@firebase/app': patch
 ---
 
-App - provide better checks for the existence of the internal heartbeat cache to help debug issues in Opera.
+App - provide a more robust check to cover more cases of empty heartbeat data.

--- a/.changeset/chilly-emus-sit.md
+++ b/.changeset/chilly-emus-sit.md
@@ -1,0 +1,5 @@
+---
+'@firebase/app': patch
+---
+
+App - provide better checks for the existence of the internal heartbeat cache to help debug issues in Opera.

--- a/packages/app/src/heartbeatService.ts
+++ b/packages/app/src/heartbeatService.ts
@@ -127,8 +127,10 @@ export class HeartbeatServiceImpl implements HeartbeatService {
       await this._heartbeatsCachePromise;
     }
     // If it's still null or the array is empty, there is no data to send.
-    if (this._heartbeatsCache?.heartbeats == null ||
-      this._heartbeatsCache.heartbeats.length === 0) {
+    if (
+      this._heartbeatsCache?.heartbeats == null ||
+      this._heartbeatsCache.heartbeats.length === 0
+    ) {
       return '';
     }
     const date = getUTCDateString();

--- a/packages/app/src/heartbeatService.ts
+++ b/packages/app/src/heartbeatService.ts
@@ -88,7 +88,7 @@ export class HeartbeatServiceImpl implements HeartbeatService {
     // service, not the browser user agent.
     const agent = platformLogger.getPlatformInfoString();
     const date = getUTCDateString();
-    if (this._heartbeatsCache === null) {
+    if (this._heartbeatsCache?.heartbeats == null) {
       this._heartbeatsCache = await this._heartbeatsCachePromise;
     }
     // Do not store a heartbeat if one is already stored for this day
@@ -127,10 +127,8 @@ export class HeartbeatServiceImpl implements HeartbeatService {
       await this._heartbeatsCachePromise;
     }
     // If it's still null or the array is empty, there is no data to send.
-    if (
-      this._heartbeatsCache === null ||
-      this._heartbeatsCache.heartbeats.length === 0
-    ) {
+    if (this._heartbeatsCache?.heartbeats == null ||
+      this._heartbeatsCache.heartbeats.length === 0) {
       return '';
     }
     const date = getUTCDateString();


### PR DESCRIPTION
### Discussion

There seems to be a potential scenario in the heartbeat service running in the Opera browser (#7736) that the heartbeatCache exists but it's an empty object. The code implementation encounters errors in these cases as it assumes the heartbeatCache has a heartbeats array. This change better detects these empty object cases and treats them in a similar way as if there's nothing in the heartbeatCache. 

### Testing

CI

### API Changes

None.