### PR TITLE
Update remaining test targets to use undici

### DIFF
--- a/integration/messaging/package.json
+++ b/integration/messaging/package.json
@@ -15,7 +15,7 @@
     "express": "4.18.2",
     "geckodriver": "2.0.4",
     "mocha": "9.2.2",
-    "node-fetch": "2.6.7", 
+    "undici": "5.26.5",
     "selenium-assistant": "6.1.1"
   }
 }

--- a/integration/messaging/test/utils/sendMessage.js
+++ b/integration/messaging/test/utils/sendMessage.js
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-const fetch = require('node-fetch');
+const undici = require('undici');
 const FCM_SEND_ENDPOINT = 'https://fcm.googleapis.com/fcm/send';
 // Rotatable fcm server key. It's generally a bad idea to expose server keys. The reason is to
 // simplify testing process (no need to implement server side decryption of git secret). The
@@ -28,7 +28,7 @@ module.exports = async payload => {
     'Requesting to send an FCM message with payload: ' + JSON.stringify(payload)
   );
 
-  const response = await fetch(FCM_SEND_ENDPOINT, {
+  const response = await undici.fetch(FCM_SEND_ENDPOINT, {
     method: 'POST',
     body: JSON.stringify(payload),
     headers: {

--- a/packages/rules-unit-testing/package.json
+++ b/packages/rules-unit-testing/package.json
@@ -54,6 +54,7 @@
     "url": "https://github.com/firebase/firebase-js-sdk/issues"
   },
   "dependencies": {
+    "undici": "5.26.5",
     "node-fetch": "2.6.7",
     "@types/node-fetch": "2.6.4"
   }

--- a/packages/rules-unit-testing/src/impl/rules.ts
+++ b/packages/rules-unit-testing/src/impl/rules.ts
@@ -17,7 +17,7 @@
 
 import { HostAndPort } from '../public_types';
 import { makeUrl } from './url';
-import fetch from 'node-fetch';
+import { fetch as undiciFetch } from 'undici';
 
 /**
  * @private
@@ -29,7 +29,7 @@ export async function loadDatabaseRules(
 ): Promise<void> {
   const url = makeUrl(hostAndPort, '/.settings/rules.json');
   url.searchParams.append('ns', databaseName);
-  const resp = await fetch(url, {
+  const resp = await undiciFetch(url, {
     method: 'PUT',
     headers: { Authorization: 'Bearer owner' },
     body: rules
@@ -48,7 +48,7 @@ export async function loadFirestoreRules(
   projectId: string,
   rules: string
 ): Promise<void> {
-  const resp = await fetch(
+  const resp = await undiciFetch(
     makeUrl(hostAndPort, `/emulator/v1/projects/${projectId}:securityRules`),
     {
       method: 'PUT',
@@ -72,7 +72,7 @@ export async function loadStorageRules(
   hostAndPort: HostAndPort,
   rules: string
 ): Promise<void> {
-  const resp = await fetch(makeUrl(hostAndPort, '/internal/setRules'), {
+  const resp = await undiciFetch(makeUrl(hostAndPort, '/internal/setRules'), {
     method: 'PUT',
     headers: {
       'Content-Type': 'application/json'

--- a/packages/rules-unit-testing/src/impl/test_environment.ts
+++ b/packages/rules-unit-testing/src/impl/test_environment.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import fetch from 'node-fetch';
+import { fetch as undiciFetch } from 'undici';
 import firebase from 'firebase/compat/app';
 import 'firebase/compat/firestore';
 import 'firebase/compat/database';
@@ -106,7 +106,7 @@ export class RulesTestEnvironmentImpl implements RulesTestEnvironment {
     this.checkNotDestroyed();
     assertEmulatorRunning(this.emulators, 'firestore');
 
-    const resp = await fetch(
+    const resp = await undiciFetch(
       makeUrl(
         this.emulators.firestore,
         `/emulator/v1/projects/${this.projectId}/databases/(default)/documents`

--- a/packages/rules-unit-testing/src/util.ts
+++ b/packages/rules-unit-testing/src/util.ts
@@ -21,7 +21,7 @@ import {
 } from './impl/discovery';
 import { fixHostname, makeUrl } from './impl/url';
 import { HostAndPort } from './public_types';
-import fetch from 'node-fetch';
+import { fetch as undiciFetch } from 'undici';
 
 /**
  * Run a setup function with background Cloud Functions triggers disabled. This can be used to
@@ -79,7 +79,7 @@ export async function withFunctionTriggersDisabled<TResult>(
   hub.host = fixHostname(hub.host);
   makeUrl(hub, '/functions/disableBackgroundTriggers');
   // Disable background triggers
-  const disableRes = await fetch(
+  const disableRes = await undiciFetch(
     makeUrl(hub, '/functions/disableBackgroundTriggers'),
     {
       method: 'PUT'
@@ -98,7 +98,7 @@ export async function withFunctionTriggersDisabled<TResult>(
     result = await maybeFn();
   } finally {
     // Re-enable background triggers
-    const enableRes = await fetch(
+    const enableRes = await undiciFetch(
       makeUrl(hub, '/functions/enableBackgroundTriggers'),
       {
         method: 'PUT'

--- a/packages/rules-unit-testing/src/util.ts
+++ b/packages/rules-unit-testing/src/util.ts
@@ -21,7 +21,6 @@ import {
 } from './impl/discovery';
 import { fixHostname, makeUrl } from './impl/url';
 import { HostAndPort } from './public_types';
-import fetch from 'node-fetch';
 import { fetch as undiciFetch } from 'undici';
 
 /**

--- a/packages/rules-unit-testing/src/util.ts
+++ b/packages/rules-unit-testing/src/util.ts
@@ -21,6 +21,7 @@ import {
 } from './impl/discovery';
 import { fixHostname, makeUrl } from './impl/url';
 import { HostAndPort } from './public_types';
+import fetch from 'node-fetch';
 import { fetch as undiciFetch } from 'undici';
 
 /**

--- a/packages/rules-unit-testing/test/util.test.ts
+++ b/packages/rules-unit-testing/test/util.test.ts
@@ -165,7 +165,7 @@ describe('assertFails()', () => {
 
 describe('withFunctionTriggersDisabled()', () => {
   it('disabling function triggers does not throw, returns value', async function () {
-    const fetchSpy = sinon.spy(require('node-fetch'), 'default');
+    const fetchSpy = sinon.spy(require('undici'), 'fetch');
 
     const res = await withFunctionTriggersDisabled(() => {
       return Promise.resolve(1234);
@@ -176,7 +176,7 @@ describe('withFunctionTriggersDisabled()', () => {
   });
 
   it('disabling function triggers always re-enables, event when the function throws', async function () {
-    const fetchSpy = sinon.spy(require('node-fetch'), 'default');
+    const fetchSpy = sinon.spy(require('undici'), 'fetch');
 
     const res = withFunctionTriggersDisabled(() => {
       throw new Error('I throw!');

--- a/packages/storage/src/implementation/type.ts
+++ b/packages/storage/src/implementation/type.ts
@@ -40,9 +40,7 @@ export function isNativeBlob(p: unknown): p is Blob {
 }
 
 export function isNativeBlobDefined(): boolean {
-  // Note: The `isNode()` check can be removed when `node-fetch` adds native Blob support
-  // PR: https://github.com/node-fetch/node-fetch/pull/1664
-  return typeof Blob !== 'undefined' && !isNode();
+  return typeof Blob !== 'undefined';
 }
 
 export function validateNumber(

--- a/packages/storage/src/implementation/type.ts
+++ b/packages/storage/src/implementation/type.ts
@@ -15,7 +15,6 @@
  * limitations under the License.
  */
 
-import { isNode } from '@firebase/util';
 import { invalidArgument } from './error';
 
 export function isJustDef<T>(p: T | null | undefined): p is T | null {

--- a/scripts/emulator-testing/emulators/emulator.ts
+++ b/scripts/emulator-testing/emulators/emulator.ts
@@ -21,7 +21,7 @@ import { ChildProcess } from 'child_process';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
-import { fetch as undiciFetch} from 'undici';
+import { fetch as undiciFetch } from 'undici';
 // @ts-ignore
 import * as tmp from 'tmp';
 
@@ -58,27 +58,26 @@ export abstract class Emulator {
 
         console.log(`Downloading emulator from [${this.binaryUrl}] ...`);
         undiciFetch(this.binaryUrl).then(resp => {
-          resp.body
-            .pipe(writeStream)
-            .on('finish', () => {
-              console.log(`Saved emulator binary file to [${filepath}].`);
-              // Change emulator binary file permission to 'rwxr-xr-x'.
-              // The execute permission is required for it to be able to start
-              // with 'java -jar'.
-              fs.chmod(filepath, 0o755, err => {
-                if (err) reject(err);
-                console.log(
-                  `Changed emulator file permissions to 'rwxr-xr-x'.`
-                );
-                this.binaryPath = filepath;
+          const body = resp.body();
+          writeStream.write(body);
+          writeStream.end();
 
-                if (this.copyToCache()) {
-                  console.log(`Cached emulator at ${this.cacheBinaryPath}`);
-                }
-                resolve();
-              });
-            })
-            .on('error', reject);
+          console.log(`Saved emulator binary file to [${filepath}].`);
+          // Change emulator binary file permission to 'rwxr-xr-x'.
+          // The execute permission is required for it to be able to start
+          // with 'java -jar'.
+          fs.chmod(filepath, 0o755, err => {
+            if (err) reject(err);
+            console.log(
+              `Changed emulator file permissions to 'rwxr-xr-x'.`
+            );
+            this.binaryPath = filepath;
+
+            if (this.copyToCache()) {
+              console.log(`Cached emulator at ${this.cacheBinaryPath}`);
+            }
+            resolve();
+          });
         });
       });
     });

--- a/scripts/emulator-testing/emulators/emulator.ts
+++ b/scripts/emulator-testing/emulators/emulator.ts
@@ -21,7 +21,7 @@ import { ChildProcess } from 'child_process';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
-import fetch from 'node-fetch';
+import { fetch as undiciFetch} from 'undici';
 // @ts-ignore
 import * as tmp from 'tmp';
 
@@ -57,7 +57,7 @@ export abstract class Emulator {
         const writeStream: fs.WriteStream = fs.createWriteStream(filepath);
 
         console.log(`Downloading emulator from [${this.binaryUrl}] ...`);
-        fetch(this.binaryUrl).then(resp => {
+        undiciFetch(this.binaryUrl).then(resp => {
           resp.body
             .pipe(writeStream)
             .on('finish', () => {
@@ -120,7 +120,7 @@ export abstract class Emulator {
           reject(`Emulator not ready after ${timeout}s. Exiting ...`);
         } else {
           console.log(`Ping emulator at [http://localhost:${this.port}] ...`);
-          fetch(`http://localhost:${this.port}`).then(
+          undiciFetch(`http://localhost:${this.port}`).then(
             () => {
               // Database and Firestore emulators will return 400 and 200 respectively.
               // As long as we get a response back, it means the emulator is ready.

--- a/scripts/emulator-testing/emulators/emulator.ts
+++ b/scripts/emulator-testing/emulators/emulator.ts
@@ -58,8 +58,7 @@ export abstract class Emulator {
 
         console.log(`Downloading emulator from [${this.binaryUrl}] ...`);
         undiciFetch(this.binaryUrl).then(resp => {
-          const body = resp.body();
-          writeStream.write(body);
+          writeStream.write(resp.body);
           writeStream.end();
 
           console.log(`Saved emulator binary file to [${filepath}].`);
@@ -68,9 +67,7 @@ export abstract class Emulator {
           // with 'java -jar'.
           fs.chmod(filepath, 0o755, err => {
             if (err) reject(err);
-            console.log(
-              `Changed emulator file permissions to 'rwxr-xr-x'.`
-            );
+            console.log(`Changed emulator file permissions to 'rwxr-xr-x'.`);
             this.binaryPath = filepath;
 
             if (this.copyToCache()) {

--- a/scripts/emulator-testing/emulators/emulator.ts
+++ b/scripts/emulator-testing/emulators/emulator.ts
@@ -21,7 +21,7 @@ import { ChildProcess } from 'child_process';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
-import { fetch as undiciFetch } from 'undici';
+import fetch from 'node-fetch';
 // @ts-ignore
 import * as tmp from 'tmp';
 
@@ -55,16 +55,11 @@ export abstract class Emulator {
         console.log(`Created temporary directory at [${dir}].`);
         const filepath: string = path.resolve(dir, this.binaryName);
         const writeStream: fs.WriteStream = fs.createWriteStream(filepath);
-        const writableStream = new WritableStream({
-          write(chunk) {
-            writeStream.write(chunk);
-          },
-        });
 
         console.log(`Downloading emulator from [${this.binaryUrl}] ...`);
-        undiciFetch(this.binaryUrl).then(resp => {
+        fetch(this.binaryUrl).then(resp => {
           resp.body
-            .pipeTo(writableStream)
+            .pipe(writeStream)
             .on('finish', () => {
               console.log(`Saved emulator binary file to [${filepath}].`);
               // Change emulator binary file permission to 'rwxr-xr-x'.
@@ -125,7 +120,7 @@ export abstract class Emulator {
           reject(`Emulator not ready after ${timeout}s. Exiting ...`);
         } else {
           console.log(`Ping emulator at [http://localhost:${this.port}] ...`);
-          undiciFetch(`http://localhost:${this.port}`).then(
+          fetch(`http://localhost:${this.port}`).then(
             () => {
               // Database and Firestore emulators will return 400 and 200 respectively.
               // As long as we get a response back, it means the emulator is ready.


### PR DESCRIPTION
### Discussion

Some of our build/test targets from ddb-upgrade-node-fetch still require a migration from node-fetch to undici. These remaining changes aren't straightforward so I'm creating a sub branch to iron out the required changes.

### Testing

Local / CI

### API Changes

N/A