### PR TITLE
fix: 🐛 Align generics in collection() and doc()

### DIFF
--- a/packages/firestore/src/lite-api/reference.ts
+++ b/packages/firestore/src/lite-api/reference.ts
@@ -403,7 +403,7 @@ export function collection<AppModelType, DbModelType extends DocumentData>(
   reference: CollectionReference<AppModelType, DbModelType>,
   path: string,
   ...pathSegments: string[]
-): CollectionReference<DocumentData, DocumentData>;
+): CollectionReference<AppModelType, DbModelType>;
 /**
  * Gets a `CollectionReference` instance that refers to a subcollection of
  * `reference` at the the specified relative path.
@@ -420,7 +420,7 @@ export function collection<AppModelType, DbModelType extends DocumentData>(
   reference: DocumentReference<AppModelType, DbModelType>,
   path: string,
   ...pathSegments: string[]
-): CollectionReference<DocumentData, DocumentData>;
+): CollectionReference<AppModelType, DbModelType>;
 export function collection<AppModelType, DbModelType extends DocumentData>(
   parent:
     | Firestore
@@ -428,7 +428,7 @@ export function collection<AppModelType, DbModelType extends DocumentData>(
     | CollectionReference<AppModelType, DbModelType>,
   path: string,
   ...pathSegments: string[]
-): CollectionReference<DocumentData, DocumentData> {
+): CollectionReference<AppModelType, DbModelType> {
   parent = getModularInstance(parent);
 
   validateNonEmptyArgument('collection', 'path', path);
@@ -548,7 +548,7 @@ export function doc<AppModelType, DbModelType extends DocumentData>(
   reference: DocumentReference<AppModelType, DbModelType>,
   path: string,
   ...pathSegments: string[]
-): DocumentReference<DocumentData, DocumentData>;
+): DocumentReference<AppModelType, DbModelType>;
 export function doc<AppModelType, DbModelType extends DocumentData>(
   parent:
     | Firestore

--- a/repo-scripts/prune-dts/tests/firestore.output.d.ts
+++ b/repo-scripts/prune-dts/tests/firestore.output.d.ts
@@ -164,11 +164,11 @@ export declare function collection(
  * to a collection.
  * @returns The `CollectionReference` instance.
  */
-export declare function collection(
-  reference: CollectionReference<unknown>,
+export declare function collection<T>(
+  reference: CollectionReference<T>,
   path: string,
   ...pathSegments: string[]
-): CollectionReference<DocumentData>;
+): CollectionReference<T>;
 /**
  * Gets a `CollectionReference` instance that refers to a subcollection of
  * `reference` at the the specified relative path.
@@ -182,7 +182,7 @@ export declare function collection(
  * @returns The `CollectionReference` instance.
  */
 export declare function collection(
-  reference: DocumentReference,
+  reference: DocumentReference<unknown>,
   path: string,
   ...pathSegments: string[]
 ): CollectionReference<DocumentData>;


### PR DESCRIPTION
- Updated the `collection()` method to correctly handle generics.
- Adjusted the `doc()` method to align with the chagnes in `collection()`
	- Ensured that explicitly passed generic types are applied to `collection()` and `doc()` methods, instead of defaulting to `DocumentData` type.

Ref: #6961 
