### PR TITLE
Fix GitHub Action Worfklow env configuration of node 'max_old_space_size'.

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -19,10 +19,15 @@ on:
   repository_dispatch:
     types: [staging-tests,canary-tests]
 
+env:
+  # Bump Node memory limit
+  NODE_OPTIONS: "--max_old_space_size=4096"
+
 jobs:
   test:
     name: Run E2E Smoke Tests
     runs-on: ubuntu-latest
+
     defaults:
       run:
         # Run any command steps in the /e2e subdir
@@ -39,8 +44,6 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install google-chrome-stable
-      - name: Bump Node memory limit
-        run: echo "NODE_OPTIONS=--max_old_space_size=4096" >> $GITHUB_ENV
       - name: Write project config
         env:
           PROJECT_CONFIG: ${{ secrets.TEST_PROJECT_CONFIG }}

--- a/.github/workflows/health-metrics-pull-request.yml
+++ b/.github/workflows/health-metrics-pull-request.yml
@@ -29,6 +29,7 @@ env:
   #     - https://github.com/actions/checkout/issues/27
   #     - https://github.com/actions/checkout/issues/237
   GITHUB_PULL_REQUEST_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+  # Bump Node memory limit
   NODE_OPTIONS: "--max-old-space-size=4096"
 
 jobs:

--- a/.github/workflows/release-staging.yml
+++ b/.github/workflows/release-staging.yml
@@ -35,6 +35,10 @@ on:
         type: boolean
         default: false
 
+env:
+  # Bump Node memory limit
+  NODE_OPTIONS: "--max_old_space_size=4096"
+
 jobs:
   deploy:
     name: Staging Release
@@ -46,8 +50,6 @@ jobs:
       uses: actions/setup-node@v3
       with:
         node-version: 16.x
-    - name: Bump Node memory limit
-      run: echo "NODE_OPTIONS=--max_old_space_size=4096" >> $GITHUB_ENV
     - name: Merge master into release
       uses: actions/github-script@v6
       with:

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -26,13 +26,13 @@ env:
   CHROMEDRIVER_CDNURL: https://googlechromelabs.github.io/
   CHROMEDRIVER_CDNBINARIESURL: https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/
   artifactRetentionDays: 14
+  # Bump Node memory limit
+  NODE_OPTIONS: "--max_old_space_size=4096"
 
 jobs:
   build:
     name: Build the SDK
     runs-on: ubuntu-latest
-    env:
-      NODE_OPTIONS: "--max_old_space_size=4096"
     steps:
     # Install Chrome so the correct version of webdriver can be installed by chromedriver when
     # setting up the repo. This must be done to build and execute Auth properly.
@@ -68,8 +68,6 @@ jobs:
     name: (bulk) Node.js and Browser (Chrome) Tests
     needs: build
     runs-on: ubuntu-latest
-    env:
-      NODE_OPTIONS: "--max_old_space_size=4096"
     steps:
     # install Chrome first, so the correct version of webdriver can be installed by chromedriver when setting up the repo
     - name: install Chrome stable
@@ -111,8 +109,6 @@ jobs:
     name: (Auth) Node.js and Browser (Chrome) Tests
     needs: build
     runs-on: ubuntu-latest
-    env:
-      NODE_OPTIONS: "--max_old_space_size=4096"
     steps:
       # install Chrome first, so the correct version of webdriver can be installed by chromedriver
       # when setting up the repo
@@ -157,8 +153,6 @@ jobs:
     if: false
     # Disable test for now since it's failing 100% of the time since
     # https://github.com/firebase/firebase-js-sdk/pull/7453 and it needs to be investigated.
-    env:
-      NODE_OPTIONS: "--max_old_space_size=4096"
     steps:
     # install Chrome so the correct version of webdriver can be installed by chromedriver when setting up the repo
     - name: install Chrome stable
@@ -203,8 +197,6 @@ jobs:
     name: Firestore Integration Tests (${{ matrix.persistence }})
     needs: build
     runs-on: ubuntu-latest
-    env:
-      NODE_OPTIONS: "--max_old_space_size=4096"
     steps:
     # install Chrome so the correct version of webdriver can be installed by chromedriver when setting up the repo
     - name: install Chrome stable

--- a/.github/workflows/test-changed-auth.yml
+++ b/.github/workflows/test-changed-auth.yml
@@ -23,6 +23,8 @@ env:
   # the beahvior to use the new URLs.
   CHROMEDRIVER_CDNURL: https://googlechromelabs.github.io/
   CHROMEDRIVER_CDNBINARIESURL: https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/
+  # Bump Node memory limit
+  NODE_OPTIONS: "--max_old_space_size=4096"
 
 jobs:
   test-chrome:
@@ -44,8 +46,6 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 16.x
-      - name: Bump Node memory limit
-        run: echo "NODE_OPTIONS=--max_old_space_size=4096" >> $GITHUB_ENV
       - name: Test setup and yarn install
         run: |
           cp config/ci.config.json config/project.json
@@ -78,8 +78,6 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 16.x
-      - name: Bump Node memory limit
-        run: echo "NODE_OPTIONS=--max_old_space_size=4096" >> $GITHUB_ENV
       - name: Test setup and yarn install
         run: |
           cp config/ci.config.json config/project.json

--- a/.github/workflows/test-changed-fcm-integration.yml
+++ b/.github/workflows/test-changed-fcm-integration.yml
@@ -19,6 +19,8 @@ on: pull_request
 env:
   # make chromedriver detect installed Chrome version and download the corresponding driver
   DETECT_CHROMEDRIVER_VERSION: true
+  # Bump Node memory limit
+  NODE_OPTIONS: "--max_old_space_size=4096"
 
 jobs:
   test:
@@ -40,8 +42,6 @@ jobs:
       uses: actions/setup-node@v3
       with:
         node-version: 16.x
-    - name: Bump Node memory limit
-      run: echo "NODE_OPTIONS=--max_old_space_size=4096" >> $GITHUB_ENV
     - name: Test setup and yarn install
       run: |
         cp config/ci.config.json config/project.json

--- a/.github/workflows/test-changed-firestore-integration.yml
+++ b/.github/workflows/test-changed-firestore-integration.yml
@@ -16,6 +16,10 @@ name: Test Firestore Integration
 
 on: pull_request
 
+env:
+  # Bump Node memory limit
+  NODE_OPTIONS: "--max_old_space_size=4096"
+
 jobs:
   test:
     name: Test Firestore Integration If Changed
@@ -67,8 +71,6 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install google-chrome-stable
-    - name: Bump Node memory limit
-      run: echo "NODE_OPTIONS=--max_old_space_size=4096" >> $GITHUB_ENV
     - name: Test setup and yarn install
       run: yarn
     - name: build

--- a/.github/workflows/test-changed-firestore.yml
+++ b/.github/workflows/test-changed-firestore.yml
@@ -18,6 +18,8 @@ on: pull_request
 
 env:
   artifactRetentionDays: 14
+  # Bump Node memory limit
+  NODE_OPTIONS: "--max_old_space_size=4096"
 
 jobs:
   build:
@@ -41,8 +43,6 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install google-chrome-stable
-      - name: Bump Node memory limit
-        run: echo "NODE_OPTIONS=--max_old_space_size=4096" >> $GITHUB_ENV
       - name: Test setup and yarn install
         run: |
           cp config/ci.config.json config/project.json
@@ -96,8 +96,6 @@ jobs:
           name: build.tar.gz
       - name: Unzip build artifact
         run: tar xf build.tar.gz
-      - name: Bump Node memory limit
-        run: echo "NODE_OPTIONS=--max_old_space_size=4096" >> $GITHUB_ENV
       - name: Test setup and yarn install
         run: cp config/ci.config.json config/project.json
       - name: Run compat tests
@@ -126,8 +124,6 @@ jobs:
           name: build.tar.gz
       - name: Unzip build artifact
         run: tar xf build.tar.gz
-      - name: Bump Node memory limit
-        run: echo "NODE_OPTIONS=--max_old_space_size=4096" >> $GITHUB_ENV
       - name: Test setup and yarn install
         run: cp config/ci.config.json config/project.json
       - name: Run tests
@@ -158,8 +154,6 @@ jobs:
           name: build.tar.gz
       - name: Unzip build artifact
         run: tar xf build.tar.gz
-      - name: Bump Node memory limit
-        run: echo "NODE_OPTIONS=--max_old_space_size=4096" >> $GITHUB_ENV
       - name: Test setup and yarn install
         run: cp config/ci.config.json config/project.json
       - name: Run compat tests
@@ -193,8 +187,6 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 16.x
-      - name: Bump Node memory limit
-        run: echo "NODE_OPTIONS=--max_old_space_size=4096" >> $GITHUB_ENV
       - name: Test setup and yarn install
         run: cp config/ci.config.json config/project.json
       - name: Run tests

--- a/.github/workflows/test-changed-misc.yml
+++ b/.github/workflows/test-changed-misc.yml
@@ -16,6 +16,10 @@ name: Test @firebase/rules-unit-testing
 
 on: pull_request
 
+env:
+  # Bump Node memory limit
+  NODE_OPTIONS: "--max_old_space_size=4096"
+
 jobs:
   test:
     name: Test Misc Packages If Changed
@@ -35,8 +39,6 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install google-chrome-stable
-    - name: Bump Node memory limit
-      run: echo "NODE_OPTIONS=--max_old_space_size=4096" >> $GITHUB_ENV
     - name: Test setup and yarn install
       run: |
         cp config/ci.config.json config/project.json

--- a/.github/workflows/test-changed.yml
+++ b/.github/workflows/test-changed.yml
@@ -16,6 +16,10 @@ name: Test Modified Packages
 
 on: pull_request
 
+env:
+  # Bump Node memory limit
+  NODE_OPTIONS: "--max_old_space_size=4096"
+
 jobs:
   test-chrome:
     name: Test Packages With Changed Files in Chrome and Node
@@ -35,8 +39,6 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install google-chrome-stable
-      - name: Bump Node memory limit
-        run: echo "NODE_OPTIONS=--max_old_space_size=4096" >> $GITHUB_ENV
       - name: Test setup and yarn install
         run: |
           cp config/ci.config.json config/project.json
@@ -66,8 +68,6 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install firefox
-      - name: Bump Node memory limit
-        run: echo "NODE_OPTIONS=--max_old_space_size=4096" >> $GITHUB_ENV
       - name: Test setup and yarn install
         run: |
           cp config/ci.config.json config/project.json

--- a/.github/workflows/test-firebase-integration.yml
+++ b/.github/workflows/test-firebase-integration.yml
@@ -16,6 +16,10 @@ name: Test Firebase Namespace
 
 on: pull_request
 
+env:
+  # Bump Node memory limit
+  NODE_OPTIONS: "--max_old_space_size=4096"
+
 jobs:
   test:
     name: Test Firebase Namespace
@@ -35,8 +39,6 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install google-chrome-stable
-    - name: Bump Node memory limit
-      run: echo "NODE_OPTIONS=--max_old_space_size=4096" >> $GITHUB_ENV
     - name: Test setup and yarn install
       run: |
         cp config/ci.config.json config/project.json


### PR DESCRIPTION
### Discussion

TLDR; This change migrates the configuration of NODE_OPTIONS from shell commands within individual jobs, to GitHub Workflow `env:` directives which apply to all jobs on the runner.

Our workflows attempted to configure the NODE_OPTIONS environment variable by executing the following shell command:

```
echo "NODE_OPTIONS=--max_old_space_size=4096" >> $GITHUB_ENV
```

This was once supported by GitHub Actions, but no more. Attempts at env config in this way produces [errors in our workflows](https://github.com/firebase/firebase-js-sdk/actions/runs/6869300208/job/18681776630#step:5:5) and the configuration fails to stick. In the worst case, this could be part of test flakiness, but at the least it's producing needless [error messages in the Annotation section our Workflow results](https://github.com/firebase/firebase-js-sdk/actions/runs/6869300208). To fix this, replace the errant shell-based env configuration with the [GitHub Workflow sanctioned method of setting environment variables](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#env).

### Testing

CI Run (below).

### API Changes

N/A.