### PR TITLE
Update injectRecaptchaFields to inject recaptcha enterprise fields into phone API requests

### DIFF
--- a/packages/auth/src/api/account_management/mfa.test.ts
+++ b/packages/auth/src/api/account_management/mfa.test.ts
@@ -20,7 +20,12 @@ import chaiAsPromised from 'chai-as-promised';
 
 import { FirebaseError } from '@firebase/util';
 
-import { Endpoint, HttpHeader } from '../';
+import {
+  Endpoint,
+  HttpHeader,
+  RecaptchaClientType,
+  RecaptchaVersion
+} from '../';
 import { mockEndpoint } from '../../../test/helpers/api/helper';
 import { testAuth, TestAuth } from '../../../test/helpers/mock_auth';
 import * as mockFetch from '../../../test/helpers/mock_fetch';
@@ -40,7 +45,10 @@ describe('api/account_management/startEnrollPhoneMfa', () => {
     idToken: 'id-token',
     phoneEnrollmentInfo: {
       phoneNumber: 'phone-number',
-      recaptchaToken: 'captcha-token'
+      recaptchaToken: 'captcha-token',
+      captchaResponse: 'captcha-response',
+      clientType: RecaptchaClientType.WEB,
+      recaptchaVersion: RecaptchaVersion.ENTERPRISE
     }
   };
 

--- a/packages/auth/src/api/account_management/mfa.ts
+++ b/packages/auth/src/api/account_management/mfa.ts
@@ -18,6 +18,8 @@
 import {
   Endpoint,
   HttpMethod,
+  RecaptchaClientType,
+  RecaptchaVersion,
   _addTidIfNecessary,
   _performApiRequest
 } from '../index';
@@ -55,7 +57,10 @@ export interface StartPhoneMfaEnrollmentRequest {
   idToken: string;
   phoneEnrollmentInfo: {
     phoneNumber: string;
-    recaptchaToken: string;
+    recaptchaToken?: string;
+    captchaResponse?: string;
+    clientType?: RecaptchaClientType;
+    recaptchaVersion?: RecaptchaVersion;
   };
   tenantId?: string;
 }

--- a/packages/auth/src/api/account_management/mfa.ts
+++ b/packages/auth/src/api/account_management/mfa.ts
@@ -57,7 +57,9 @@ export interface StartPhoneMfaEnrollmentRequest {
   idToken: string;
   phoneEnrollmentInfo: {
     phoneNumber: string;
+    // reCAPTCHA v2 token
     recaptchaToken?: string;
+    // reCAPTCHA Enterprise token
     captchaResponse?: string;
     clientType?: RecaptchaClientType;
     recaptchaVersion?: RecaptchaVersion;

--- a/packages/auth/src/api/authentication/mfa.test.ts
+++ b/packages/auth/src/api/authentication/mfa.test.ts
@@ -20,7 +20,12 @@ import chaiAsPromised from 'chai-as-promised';
 
 import { FirebaseError } from '@firebase/util';
 
-import { Endpoint, HttpHeader } from '../';
+import {
+  Endpoint,
+  HttpHeader,
+  RecaptchaClientType,
+  RecaptchaVersion
+} from '../';
 import { mockEndpoint } from '../../../test/helpers/api/helper';
 import { testAuth, TestAuth } from '../../../test/helpers/mock_auth';
 import * as mockFetch from '../../../test/helpers/mock_fetch';
@@ -34,7 +39,10 @@ describe('api/authentication/startSignInPhoneMfa', () => {
     mfaPendingCredential: 'my-creds',
     mfaEnrollmentId: 'my-enrollment-id',
     phoneSignInInfo: {
-      recaptchaToken: 'catpcha-token'
+      recaptchaToken: 'catpcha-token',
+      captchaResponse: 'captcha-response',
+      clientType: RecaptchaClientType.WEB,
+      recaptchaVersion: RecaptchaVersion.ENTERPRISE
     }
   };
 

--- a/packages/auth/src/api/authentication/mfa.ts
+++ b/packages/auth/src/api/authentication/mfa.ts
@@ -19,6 +19,8 @@ import {
   _performApiRequest,
   Endpoint,
   HttpMethod,
+  RecaptchaClientType,
+  RecaptchaVersion,
   _addTidIfNecessary
 } from '../index';
 import { Auth } from '../../model/public_types';
@@ -47,7 +49,10 @@ export interface StartPhoneMfaSignInRequest {
   mfaPendingCredential: string;
   mfaEnrollmentId: string;
   phoneSignInInfo: {
-    recaptchaToken: string;
+    recaptchaToken?: string;
+    captchaResponse?: string;
+    clientType?: RecaptchaClientType;
+    recaptchaVersion?: RecaptchaVersion;
   };
   tenantId?: string;
 }

--- a/packages/auth/src/api/authentication/mfa.ts
+++ b/packages/auth/src/api/authentication/mfa.ts
@@ -49,7 +49,9 @@ export interface StartPhoneMfaSignInRequest {
   mfaPendingCredential: string;
   mfaEnrollmentId: string;
   phoneSignInInfo: {
+    // reCAPTCHA v2 token
     recaptchaToken?: string;
+    // reCAPTCHA Enterprise token
     captchaResponse?: string;
     clientType?: RecaptchaClientType;
     recaptchaVersion?: RecaptchaVersion;

--- a/packages/auth/src/api/authentication/sms.test.ts
+++ b/packages/auth/src/api/authentication/sms.test.ts
@@ -21,7 +21,12 @@ import chaiAsPromised from 'chai-as-promised';
 import { ProviderId } from '../../model/enums';
 import { FirebaseError } from '@firebase/util';
 
-import { Endpoint, HttpHeader } from '../';
+import {
+  Endpoint,
+  HttpHeader,
+  RecaptchaClientType,
+  RecaptchaVersion
+} from '../';
 import { mockEndpoint } from '../../../test/helpers/api/helper';
 import { testAuth, TestAuth } from '../../../test/helpers/mock_auth';
 import * as mockFetch from '../../../test/helpers/mock_fetch';
@@ -38,7 +43,10 @@ use(chaiAsPromised);
 describe('api/authentication/sendPhoneVerificationCode', () => {
   const request = {
     phoneNumber: '123456789',
-    recaptchaToken: 'captchad'
+    recaptchaToken: 'captchad',
+    captchaResponse: 'captcha-response',
+    clientType: RecaptchaClientType.WEB,
+    recaptchaVersion: RecaptchaVersion.ENTERPRISE
   };
 
   let auth: TestAuth;

--- a/packages/auth/src/api/authentication/sms.ts
+++ b/packages/auth/src/api/authentication/sms.ts
@@ -18,6 +18,8 @@
 import {
   Endpoint,
   HttpMethod,
+  RecaptchaClientType,
+  RecaptchaVersion,
   _addTidIfNecessary,
   _makeTaggedError,
   _performApiRequest,
@@ -30,8 +32,11 @@ import { Auth } from '../../model/public_types';
 
 export interface SendPhoneVerificationCodeRequest {
   phoneNumber: string;
-  recaptchaToken: string;
+  recaptchaToken?: string;
   tenantId?: string;
+  captchaResponse?: string;
+  clientType?: RecaptchaClientType;
+  recaptchaVersion?: RecaptchaVersion;
 }
 
 export interface SendPhoneVerificationCodeResponse {

--- a/packages/auth/src/api/authentication/sms.ts
+++ b/packages/auth/src/api/authentication/sms.ts
@@ -32,8 +32,10 @@ import { Auth } from '../../model/public_types';
 
 export interface SendPhoneVerificationCodeRequest {
   phoneNumber: string;
+  // reCAPTCHA v2 token
   recaptchaToken?: string;
   tenantId?: string;
+  // reCAPTCHA Enterprise token
   captchaResponse?: string;
   clientType?: RecaptchaClientType;
   recaptchaVersion?: RecaptchaVersion;

--- a/packages/auth/src/api/index.ts
+++ b/packages/auth/src/api/index.ts
@@ -86,7 +86,10 @@ export const enum RecaptchaVersion {
 export const enum RecaptchaActionName {
   SIGN_IN_WITH_PASSWORD = 'signInWithPassword',
   GET_OOB_CODE = 'getOobCode',
-  SIGN_UP_PASSWORD = 'signUpPassword'
+  SIGN_UP_PASSWORD = 'signUpPassword',
+  SEND_VERIFICATION_CODE = 'sendVerificationCode',
+  MFA_SMS_ENROLLMENT = 'mfaSmsEnrollment',
+  MFA_SMS_SIGNIN = 'mfaSmsSignin'
 }
 
 export const enum EnforcementState {
@@ -98,7 +101,8 @@ export const enum EnforcementState {
 
 // Providers that have reCAPTCHA Enterprise support.
 export const enum RecaptchaProvider {
-  EMAIL_PASSWORD_PROVIDER = 'EMAIL_PASSWORD_PROVIDER'
+  EMAIL_PASSWORD_PROVIDER = 'EMAIL_PASSWORD_PROVIDER',
+  PHONE_PROVIDER = 'PHONE_PROVIDER'
 }
 
 export const DEFAULT_API_TIMEOUT_MS = new Delay(30_000, 60_000);

--- a/packages/auth/src/platform_browser/recaptcha/recaptcha.test.ts
+++ b/packages/auth/src/platform_browser/recaptcha/recaptcha.test.ts
@@ -86,7 +86,9 @@ describe('platform_browser/recaptcha/recaptcha', () => {
     };
 
   const recaptchaConfig = new RecaptchaConfig(GET_RECAPTCHA_CONFIG_RESPONSE);
-  const recaptchaConfigOff = new RecaptchaConfig(GET_RECAPTCHA_CONFIG_RESPONSE_OFF);
+  const recaptchaConfigOff = new RecaptchaConfig(
+    GET_RECAPTCHA_CONFIG_RESPONSE_OFF
+  );
   const recaptchaConfigEnforceAndOff = new RecaptchaConfig(
     GET_RECAPTCHA_CONFIG_RESPONSE_ENFORCE_AND_OFF
   );

--- a/packages/auth/src/platform_browser/recaptcha/recaptcha.test.ts
+++ b/packages/auth/src/platform_browser/recaptcha/recaptcha.test.ts
@@ -39,7 +39,6 @@ describe('platform_browser/recaptcha/recaptcha', () => {
   let recaptchaV2: MockReCaptcha;
   let recaptchaV3: MockGreCAPTCHA;
   let recaptchaEnterprise: MockGreCAPTCHATopLevel;
-  let recaptchaConfig: RecaptchaConfig;
 
   const TEST_SITE_KEY = 'test-site-key';
 
@@ -56,6 +55,41 @@ describe('platform_browser/recaptcha/recaptcha', () => {
       }
     ]
   };
+
+  const GET_RECAPTCHA_CONFIG_RESPONSE_OFF: GetRecaptchaConfigResponse = {
+    recaptchaKey: 'projects/testproj/keys/' + TEST_SITE_KEY,
+    recaptchaEnforcementState: [
+      {
+        provider: RecaptchaProvider.EMAIL_PASSWORD_PROVIDER,
+        enforcementState: EnforcementState.OFF
+      },
+      {
+        provider: RecaptchaProvider.PHONE_PROVIDER,
+        enforcementState: EnforcementState.OFF
+      }
+    ]
+  };
+
+  const GET_RECAPTCHA_CONFIG_RESPONSE_ENFORCE_AND_OFF: GetRecaptchaConfigResponse =
+    {
+      recaptchaKey: 'projects/testproj/keys/' + TEST_SITE_KEY,
+      recaptchaEnforcementState: [
+        {
+          provider: RecaptchaProvider.EMAIL_PASSWORD_PROVIDER,
+          enforcementState: EnforcementState.ENFORCE
+        },
+        {
+          provider: RecaptchaProvider.PHONE_PROVIDER,
+          enforcementState: EnforcementState.OFF
+        }
+      ]
+    };
+
+  const recaptchaConfig = new RecaptchaConfig(GET_RECAPTCHA_CONFIG_RESPONSE);
+  const recaptchaConfigOff = new RecaptchaConfig(GET_RECAPTCHA_CONFIG_RESPONSE_OFF);
+  const recaptchaConfigEnforceAndOff = new RecaptchaConfig(
+    GET_RECAPTCHA_CONFIG_RESPONSE_ENFORCE_AND_OFF
+  );
 
   context('#verify', () => {
     beforeEach(async () => {
@@ -81,10 +115,6 @@ describe('platform_browser/recaptcha/recaptcha', () => {
   });
 
   context('#RecaptchaConfig', () => {
-    beforeEach(async () => {
-      recaptchaConfig = new RecaptchaConfig(GET_RECAPTCHA_CONFIG_RESPONSE);
-    });
-
     it('should construct the recaptcha config from the backend response', () => {
       expect(recaptchaConfig.siteKey).to.eq(TEST_SITE_KEY);
       expect(recaptchaConfig.recaptchaEnforcementState[0]).to.eql({
@@ -94,6 +124,10 @@ describe('platform_browser/recaptcha/recaptcha', () => {
       expect(recaptchaConfig.recaptchaEnforcementState[1]).to.eql({
         provider: RecaptchaProvider.PHONE_PROVIDER,
         enforcementState: EnforcementState.AUDIT
+      });
+      expect(recaptchaConfigEnforceAndOff.recaptchaEnforcementState[1]).to.eql({
+        provider: RecaptchaProvider.PHONE_PROVIDER,
+        enforcementState: EnforcementState.OFF
       });
     });
 
@@ -108,6 +142,11 @@ describe('platform_browser/recaptcha/recaptcha', () => {
           RecaptchaProvider.PHONE_PROVIDER
         )
       ).to.eq(EnforcementState.AUDIT);
+      expect(
+        recaptchaConfigEnforceAndOff.getProviderEnforcementState(
+          RecaptchaProvider.PHONE_PROVIDER
+        )
+      ).to.eq(EnforcementState.OFF);
       expect(recaptchaConfig.getProviderEnforcementState('invalid-provider')).to
         .be.null;
     });
@@ -121,29 +160,18 @@ describe('platform_browser/recaptcha/recaptcha', () => {
       expect(
         recaptchaConfig.isProviderEnabled(RecaptchaProvider.PHONE_PROVIDER)
       ).to.be.true;
+      expect(
+        recaptchaConfigEnforceAndOff.isProviderEnabled(
+          RecaptchaProvider.PHONE_PROVIDER
+        )
+      ).to.be.false;
       expect(recaptchaConfig.isProviderEnabled('invalid-provider')).to.be.false;
     });
 
     it('#isAnyProviderEnabled should return true if at least one provider is enabled', () => {
       expect(recaptchaConfig.isAnyProviderEnabled()).to.be.true;
-
-      const getRecaptchaConfigResponse: GetRecaptchaConfigResponse = {
-        recaptchaKey: 'projects/testproj/keys/' + TEST_SITE_KEY,
-        recaptchaEnforcementState: [
-          {
-            provider: RecaptchaProvider.EMAIL_PASSWORD_PROVIDER,
-            enforcementState: EnforcementState.OFF
-          },
-          {
-            provider: RecaptchaProvider.PHONE_PROVIDER,
-            enforcementState: EnforcementState.OFF
-          }
-        ]
-      };
-      const configNoProviderEnabled = new RecaptchaConfig(
-        getRecaptchaConfigResponse
-      );
-      expect(configNoProviderEnabled.isAnyProviderEnabled()).to.be.false;
+      expect(recaptchaConfigEnforceAndOff.isAnyProviderEnabled()).to.be.true;
+      expect(recaptchaConfigOff.isAnyProviderEnabled()).to.be.false;
     });
   });
 });

--- a/packages/auth/src/platform_browser/recaptcha/recaptcha.ts
+++ b/packages/auth/src/platform_browser/recaptcha/recaptcha.ts
@@ -20,7 +20,11 @@ import {
   GetRecaptchaConfigResponse,
   RecaptchaEnforcementProviderState
 } from '../../api/authentication/recaptcha';
-import { EnforcementState, _parseEnforcementState } from '../../api/index';
+import {
+  EnforcementState,
+  RecaptchaProvider,
+  _parseEnforcementState
+} from '../../api/index';
 
 // reCAPTCHA v2 interface
 export interface Recaptcha {
@@ -133,6 +137,19 @@ export class RecaptchaConfig {
       this.getProviderEnforcementState(providerStr) ===
         EnforcementState.ENFORCE ||
       this.getProviderEnforcementState(providerStr) === EnforcementState.AUDIT
+    );
+  }
+
+  /**
+   * Returns true if reCAPTCHA Enterprise protection is enabled in at least one provider, otherwise
+   * returns false.
+   *
+   * @returns Whether or not reCAPTCHA Enterprise protection is enabled for at least one provider.
+   */
+  isAnyProviderEnabled(): boolean {
+    return (
+      this.isProviderEnabled(RecaptchaProvider.EMAIL_PASSWORD_PROVIDER) ||
+      this.isProviderEnabled(RecaptchaProvider.PHONE_PROVIDER)
     );
   }
 }

--- a/packages/auth/src/platform_browser/recaptcha/recaptcha_enterprise_verifier.ts
+++ b/packages/auth/src/platform_browser/recaptcha/recaptcha_enterprise_verifier.ts
@@ -32,7 +32,6 @@ import * as jsHelpers from '../load_js';
 import { AuthErrorCode } from '../../core/errors';
 import { StartPhoneMfaEnrollmentRequest } from '../../api/account_management/mfa';
 import { StartPhoneMfaSignInRequest } from '../../api/authentication/mfa';
-import { _assert } from '../../core/util/assert';
 
 const RECAPTCHA_ENTERPRISE_URL =
   'https://www.google.com/recaptcha/enterprise.js?render=';

--- a/packages/auth/src/platform_browser/recaptcha/recaptcha_enterprise_verifier.ts
+++ b/packages/auth/src/platform_browser/recaptcha/recaptcha_enterprise_verifier.ts
@@ -30,6 +30,9 @@ import { AuthInternal } from '../../model/auth';
 import { _castAuth } from '../../core/auth/auth_impl';
 import * as jsHelpers from '../load_js';
 import { AuthErrorCode } from '../../core/errors';
+import { StartPhoneMfaEnrollmentRequest } from '../../api/account_management/mfa';
+import { StartPhoneMfaSignInRequest } from '../../api/authentication/mfa';
+import { _assert } from '../../core/util/assert';
 
 const RECAPTCHA_ENTERPRISE_URL =
   'https://www.google.com/recaptcha/enterprise.js?render=';
@@ -155,16 +158,61 @@ export async function injectRecaptchaFields<T>(
   auth: AuthInternal,
   request: T,
   action: RecaptchaActionName,
-  captchaResp = false
+  captchaResp = false,
+  fakeToken = false
 ): Promise<T> {
   const verifier = new RecaptchaEnterpriseVerifier(auth);
   let captchaResponse;
-  try {
-    captchaResponse = await verifier.verify(action);
-  } catch (error) {
-    captchaResponse = await verifier.verify(action, true);
+
+  if (fakeToken) {
+    captchaResponse = FAKE_TOKEN;
+  } else {
+    try {
+      captchaResponse = await verifier.verify(action);
+    } catch (error) {
+      captchaResponse = await verifier.verify(action, true);
+    }
   }
+
   const newRequest = { ...request };
+  if (
+    action === RecaptchaActionName.MFA_SMS_ENROLLMENT ||
+    action === RecaptchaActionName.MFA_SMS_SIGNIN
+  ) {
+    if ('phoneEnrollmentInfo' in newRequest) {
+      const phoneNumber = (
+        newRequest as unknown as StartPhoneMfaEnrollmentRequest
+      ).phoneEnrollmentInfo.phoneNumber;
+      const recaptchaToken = (
+        newRequest as unknown as StartPhoneMfaEnrollmentRequest
+      ).phoneEnrollmentInfo.recaptchaToken;
+
+      Object.assign(newRequest, {
+        'phoneEnrollmentInfo': {
+          phoneNumber,
+          recaptchaToken,
+          captchaResponse,
+          'clientType': RecaptchaClientType.WEB,
+          'recaptchaVersion': RecaptchaVersion.ENTERPRISE
+        }
+      });
+    } else if ('phoneSignInInfo' in newRequest) {
+      const recaptchaToken = (
+        newRequest as unknown as StartPhoneMfaSignInRequest
+      ).phoneSignInInfo.recaptchaToken;
+
+      Object.assign(newRequest, {
+        'phoneSignInInfo': {
+          recaptchaToken,
+          captchaResponse,
+          'clientType': RecaptchaClientType.WEB,
+          'recaptchaVersion': RecaptchaVersion.ENTERPRISE
+        }
+      });
+    }
+    return newRequest;
+  }
+
   if (!captchaResp) {
     Object.assign(newRequest, { captchaResponse });
   } else {
@@ -235,7 +283,7 @@ export async function _initializeRecaptchaConfig(auth: Auth): Promise<void> {
     authInternal._tenantRecaptchaConfigs[authInternal.tenantId] = config;
   }
 
-  if (config.isProviderEnabled(RecaptchaProvider.EMAIL_PASSWORD_PROVIDER)) {
+  if (config.isAnyProviderEnabled()) {
     const verifier = new RecaptchaEnterpriseVerifier(authInternal);
     void verifier.verify();
   }

--- a/packages/auth/src/platform_browser/recaptcha/recaptcha_enterprise_verifier.ts
+++ b/packages/auth/src/platform_browser/recaptcha/recaptcha_enterprise_verifier.ts
@@ -157,13 +157,13 @@ export async function injectRecaptchaFields<T>(
   auth: AuthInternal,
   request: T,
   action: RecaptchaActionName,
-  captchaResp = false,
-  fakeToken = false
+  isCaptchaResp = false,
+  isFakeToken = false
 ): Promise<T> {
   const verifier = new RecaptchaEnterpriseVerifier(auth);
   let captchaResponse;
 
-  if (fakeToken) {
+  if (isFakeToken) {
     captchaResponse = FAKE_TOKEN;
   } else {
     try {
@@ -212,7 +212,7 @@ export async function injectRecaptchaFields<T>(
     return newRequest;
   }
 
-  if (!captchaResp) {
+  if (!isCaptchaResp) {
     Object.assign(newRequest, { captchaResponse });
   } else {
     Object.assign(newRequest, { 'captchaResp': captchaResponse });


### PR DESCRIPTION
### Discussion
This is the pre-req for reCAPTCHA Enterprise and phone auth integration support.

- Add Phone provider and action names
- Add reCAPTCHA Enterprise fields to phone API requests
- Update injectRecaptchaFields to inject recaptcha enterprise fields into phone API requests

### Testing
Tested the following flows with the demo app:
- Phone Auth
- SMS MFA
- Email auth with reCAPTCHA Enterprise