### PR TITLE
docs: Fix 3 typos

### DIFF
--- a/docs-devsite/auth.googleauthprovider.md
+++ b/docs-devsite/auth.googleauthprovider.md
@@ -10,7 +10,7 @@ https://github.com/firebase/firebase-js-sdk
 {% endcomment %}
 
 # GoogleAuthProvider class
-Provider for generating an an [OAuthCredential](./auth.oauthcredential.md#oauthcredential_class) for [ProviderId](./auth.md#providerid)<!-- -->.GOOGLE.
+Provider for generating an [OAuthCredential](./auth.oauthcredential.md#oauthcredential_class) for [ProviderId](./auth.md#providerid)<!-- -->.GOOGLE.
 
 <b>Signature:</b>
 

--- a/docs-devsite/auth.md
+++ b/docs-devsite/auth.md
@@ -88,7 +88,7 @@ Firebase Authentication
 |  [EmailAuthProvider](./auth.emailauthprovider.md#emailauthprovider_class) | Provider for generating [EmailAuthCredential](./auth.emailauthcredential.md#emailauthcredential_class)<!-- -->. |
 |  [FacebookAuthProvider](./auth.facebookauthprovider.md#facebookauthprovider_class) | Provider for generating an [OAuthCredential](./auth.oauthcredential.md#oauthcredential_class) for [ProviderId](./auth.md#providerid)<!-- -->.FACEBOOK. |
 |  [GithubAuthProvider](./auth.githubauthprovider.md#githubauthprovider_class) | Provider for generating an [OAuthCredential](./auth.oauthcredential.md#oauthcredential_class) for [ProviderId](./auth.md#providerid)<!-- -->.GITHUB. |
-|  [GoogleAuthProvider](./auth.googleauthprovider.md#googleauthprovider_class) | Provider for generating an an [OAuthCredential](./auth.oauthcredential.md#oauthcredential_class) for [ProviderId](./auth.md#providerid)<!-- -->.GOOGLE. |
+|  [GoogleAuthProvider](./auth.googleauthprovider.md#googleauthprovider_class) | Provider for generating an [OAuthCredential](./auth.oauthcredential.md#oauthcredential_class) for [ProviderId](./auth.md#providerid)<!-- -->.GOOGLE. |
 |  [OAuthCredential](./auth.oauthcredential.md#oauthcredential_class) | Represents the OAuth credentials returned by an [OAuthProvider](./auth.oauthprovider.md#oauthprovider_class)<!-- -->. |
 |  [OAuthProvider](./auth.oauthprovider.md#oauthprovider_class) | Provider for generating generic [OAuthCredential](./auth.oauthcredential.md#oauthcredential_class)<!-- -->. |
 |  [PhoneAuthCredential](./auth.phoneauthcredential.md#phoneauthcredential_class) | Represents the credentials returned by [PhoneAuthProvider](./auth.phoneauthprovider.md#phoneauthprovider_class)<!-- -->. |

--- a/packages/auth/src/core/providers/google.ts
+++ b/packages/auth/src/core/providers/google.ts
@@ -26,7 +26,7 @@ import { BaseOAuthProvider } from './oauth';
 import { ProviderId, SignInMethod } from '../../model/enums';
 
 /**
- * Provider for generating an an {@link OAuthCredential} for {@link ProviderId}.GOOGLE.
+ * Provider for generating an {@link OAuthCredential} for {@link ProviderId}.GOOGLE.
  *
  * @example
  * ```javascript


### PR DESCRIPTION
Fixed a duplicate 'an' string in documentation for the `GoogleAuthProvider` class.