### PR TITLE
[App Check] Install catch handler for promise in Deferred.

### DIFF
--- a/.changeset/shiny-houses-stare.md
+++ b/.changeset/shiny-houses-stare.md
@@ -1,0 +1,5 @@
+---
+'@firebase/app-check': patch
+---
+
+Prevent App Check from logging "uncaught" cancelled promises. The cancelled promises are part of App Check's expected behavior, and their cancellation wasn't intended to produce errors or warnings. See issue #7805.

--- a/packages/app-check/src/proactive-refresh.ts
+++ b/packages/app-check/src/proactive-refresh.ts
@@ -64,6 +64,9 @@ export class Refresher {
     this.stop();
     try {
       this.pending = new Deferred();
+      this.pending.promise.catch(_e => {
+        /* ignore */
+      });
       await sleep(this.getNextRun(hasSucceeded));
 
       // Why do we resolve a promise, then immediate wait for it?
@@ -74,6 +77,9 @@ export class Refresher {
       this.pending.resolve();
       await this.pending.promise;
       this.pending = new Deferred();
+      this.pending.promise.catch(_e => {
+        /* ignore */
+      });
       await this.operation();
 
       this.pending.resolve();


### PR DESCRIPTION
### Discussion

Install catch handlers for promises in the Derferred object used by in AppCheck. There were some cases where the promise was cancelled and this bubbled up error messages to our clients' applications despite this being expected behavior.

This change is to alleviate the logging reported in issue #7805.

### Testing

CI.

### API Changes

N/A
