### PR TITLE
[Auth] Detect if IndexedDB returns an empty array in platform_browser/persistence.

### DIFF
--- a/packages/auth/src/platform_browser/persistence/indexed_db.ts
+++ b/packages/auth/src/platform_browser/persistence/indexed_db.ts
@@ -358,7 +358,7 @@ class IndexedDBLocalPersistence implements InternalPersistence {
       return new DBPromise<DBObject[] | null>(getAllRequest).toPromise();
     });
 
-    if (!result) {
+    if (!result || result.length === 0) {
       return [];
     }
 


### PR DESCRIPTION
### Discussion

Fix an assumption in Auth's usage of IndexedDB to check to see if the array returned from the IndexedDB is empty before enumerating its keys.

### Testing

CI.

### API Changes

N/A
