### PR TITLE
Add app-check-interop-types dependency to database

### DIFF
--- a/.changeset/wet-moons-wave.md
+++ b/.changeset/wet-moons-wave.md
@@ -1,0 +1,5 @@
+---
+'@firebase/database': patch
+---
+
+Add `@firebase/app-check-interop-types` dependency to `database` package

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -52,6 +52,7 @@
     "@firebase/logger": "0.4.0",
     "@firebase/util": "1.9.3",
     "@firebase/component": "0.6.4",
+    "@firebase/app-check-interop-types": "0.3.0",
     "@firebase/auth-interop-types": "0.2.1",
     "faye-websocket": "0.11.4",
     "tslib": "^2.1.0"


### PR DESCRIPTION
An import of `@firebase/app-check-interop-types` was added to the standalone entry points (consumed by admin-node) in https://github.com/firebase/firebase-js-sdk/pull/7258

This dep wasn't getting installed when consumed by the admin-node package because admin-node only installs `@firebase/database-compat` and not the umbrella `firebase` package.

In this PR the dep is being added in `@firebase/database` but will be installed transitively as `database-compat` depends on `database`. This is already working for `auth-interop-types`. We just need to add `app-check-interop-types` in the same place.