### PR TITLE
Add react-native field to auth internal package.json

### DIFF
--- a/packages/auth/internal/package.json
+++ b/packages/auth/internal/package.json
@@ -2,7 +2,7 @@
   "name": "@firebase/auth/internal",
   "description": "An internal version of the Auth SDK for use in the compatibility layer",
   "main": "../dist/node/internal.js",
-  "react-native": "../dist/rn/index.js",
+  "react-native": "../dist/rn/internal.js",
   "module": "../dist/esm2017/internal.js",
   "browser": "../dist/esm2017/internal.js",
   "esm5": "../dist/esm5/internal.js",

--- a/packages/auth/internal/package.json
+++ b/packages/auth/internal/package.json
@@ -2,6 +2,7 @@
   "name": "@firebase/auth/internal",
   "description": "An internal version of the Auth SDK for use in the compatibility layer",
   "main": "../dist/node/internal.js",
+  "react-native": "../dist/rn/index.js",
   "module": "../dist/esm2017/internal.js",
   "browser": "../dist/esm2017/internal.js",
   "esm5": "../dist/esm5/internal.js",


### PR DESCRIPTION
The @firebase/auth/internal package was missing its "react-native" field, causing the wrong code to be included in react-native bundles. This commit simply adds the field.