### PR TITLE
Update isEqual for arrayUnion, arrayRemove, and increment 

### DIFF
--- a/.changeset/yellow-houses-happen.md
+++ b/.changeset/yellow-houses-happen.md
@@ -1,0 +1,6 @@
+---
+'@firebase/firestore': patch
+'firebase': patch
+---
+
+Update the `isEqual` function for arrayUnion, arrayRemove and increment.

--- a/packages/firestore/src/lite-api/user_data_reader.ts
+++ b/packages/firestore/src/lite-api/user_data_reader.ts
@@ -20,7 +20,7 @@ import {
   FieldPath as PublicFieldPath,
   SetOptions
 } from '@firebase/firestore-types';
-import { Compat, getModularInstance } from '@firebase/util';
+import { Compat, deepEqual, getModularInstance } from '@firebase/util';
 
 import { ParseContext } from '../api/parse_context';
 import { DatabaseId } from '../core/database_info';
@@ -525,13 +525,15 @@ export class ArrayUnionFieldValueImpl extends FieldValue {
   }
 
   isEqual(other: FieldValue): boolean {
-    // TODO(mrschmidt): Implement isEquals
-    return this === other;
+    return (
+      other instanceof ArrayUnionFieldValueImpl &&
+      deepEqual(this._elements, other._elements)
+    );
   }
 }
 
 export class ArrayRemoveFieldValueImpl extends FieldValue {
-  constructor(methodName: string, readonly _elements: unknown[]) {
+  constructor(methodName: string, private readonly _elements: unknown[]) {
     super(methodName);
   }
 
@@ -549,8 +551,10 @@ export class ArrayRemoveFieldValueImpl extends FieldValue {
   }
 
   isEqual(other: FieldValue): boolean {
-    // TODO(mrschmidt): Implement isEquals
-    return this === other;
+    return (
+      other instanceof ArrayRemoveFieldValueImpl &&
+      deepEqual(this._elements, other._elements)
+    );
   }
 }
 
@@ -568,8 +572,10 @@ export class NumericIncrementFieldValueImpl extends FieldValue {
   }
 
   isEqual(other: FieldValue): boolean {
-    // TODO(mrschmidt): Implement isEquals
-    return this === other;
+    return (
+      other instanceof NumericIncrementFieldValueImpl &&
+      this._operand === other._operand
+    );
   }
 }
 

--- a/packages/firestore/test/lite/integration.test.ts
+++ b/packages/firestore/test/lite/integration.test.ts
@@ -883,6 +883,16 @@ describe('FieldValue', () => {
     expect(deleteField().isEqual(deleteField())).to.be.true;
     expect(serverTimestamp().isEqual(serverTimestamp())).to.be.true;
     expect(deleteField().isEqual(serverTimestamp())).to.be.false;
+    expect(arrayUnion().isEqual(arrayUnion())).to.be.true;
+    expect(arrayUnion('a').isEqual(arrayUnion('a'))).to.be.true;
+    expect(arrayUnion('a').isEqual(arrayUnion('b'))).to.be.false;
+    expect(arrayUnion('a', 'b').isEqual(arrayUnion('b', 'a'))).to.be.false;
+    expect(arrayRemove().isEqual(arrayRemove())).to.be.true;
+    expect(arrayRemove('a').isEqual(arrayRemove('a'))).to.be.true;
+    expect(arrayRemove('a').isEqual(arrayRemove('b'))).to.be.false;
+    expect(arrayRemove('a', 'b').isEqual(arrayRemove('b', 'a'))).to.be.false;
+    expect(increment(1).isEqual(increment(1))).to.be.true;
+    expect(increment(1).isEqual(increment(2))).to.be.false;
   });
 
   it('support instanceof checks', () => {


### PR DESCRIPTION
fix [7706](https://github.com/firebase/firebase-js-sdk/issues/7706)
Change the `isEqual` from identity equality check to comparing properties. 