### PR TITLE
Fix E2E runtime - pin Firebase Tools, node 18 runtime

### DIFF
--- a/.github/workflows/deploy-config.yml
+++ b/.github/workflows/deploy-config.yml
@@ -34,10 +34,10 @@ jobs:
       with:
         # This makes Actions fetch all Git history so run-changed script can diff properly.
         fetch-depth: 0
-    - name: Set up node (16)
+    - name: Set up node (18)
       uses: actions/setup-node@v3
       with:
-        node-version: 16.x
+        node-version: 18.x
     - name: Yarn install
       run: yarn
     - name: Deploy project config if needed

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -16,6 +16,7 @@ name: E2E Smoke Tests
 
 # Allows REST trigger. Currently triggered by release-cli script during a staging run.
 on:
+  push:
   repository_dispatch:
     types: [staging-tests,canary-tests]
 
@@ -36,10 +37,10 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@master
-      - name: Set up Node (16)
+      - name: Set up Node (18)
         uses: actions/setup-node@master
         with:
-          node-version: 16.x
+          node-version: 18.x
       - name: install Chrome stable
         run: |
           sudo apt-get update

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -61,7 +61,7 @@ jobs:
           pushd functions
           npm install
           popd
-          npx firebase-tools@12.9.1 deploy --only functions:callTest --project jscore-sandbox-141b5 --token $FIREBASE_CLI_TOKEN
+          npx firebase-tools@13.0.0 deploy --only functions:callTest --project jscore-sandbox-141b5 --token $FIREBASE_CLI_TOKEN
         working-directory: ./config
         env:
           FIREBASE_CLI_TOKEN: ${{ secrets.FIREBASE_CLI_TOKEN }}

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -61,7 +61,7 @@ jobs:
           pushd functions
           npm install
           popd
-          npx firebase-tools@13.0.0 deploy --only functions:callTest --project jscore-sandbox-141b5 --token $FIREBASE_CLI_TOKEN
+          npx firebase-tools@13.0.1 deploy --only functions:callTest --project jscore-sandbox-141b5 --token $FIREBASE_CLI_TOKEN
         working-directory: ./config
         env:
           FIREBASE_CLI_TOKEN: ${{ secrets.FIREBASE_CLI_TOKEN }}

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -61,7 +61,7 @@ jobs:
           pushd functions
           npm install
           popd
-          npx firebase-tools deploy --only functions:callTest --project jscore-sandbox-141b5 --token $FIREBASE_CLI_TOKEN
+          npx firebase-tools@12.9.1 deploy --only functions:callTest --project jscore-sandbox-141b5 --token $FIREBASE_CLI_TOKEN
         working-directory: ./config
         env:
           FIREBASE_CLI_TOKEN: ${{ secrets.FIREBASE_CLI_TOKEN }}

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -61,7 +61,7 @@ jobs:
           pushd functions
           npm install
           popd
-          npx firebase-tools@13.0.1 deploy --only functions:callTest --project jscore-sandbox-141b5 --token $FIREBASE_CLI_TOKEN
+          npx firebase-tools@12.9.1 deploy --only functions:callTest --project jscore-sandbox-141b5 --token $FIREBASE_CLI_TOKEN
         working-directory: ./config
         env:
           FIREBASE_CLI_TOKEN: ${{ secrets.FIREBASE_CLI_TOKEN }}

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -16,7 +16,6 @@ name: E2E Smoke Tests
 
 # Allows REST trigger. Currently triggered by release-cli script during a staging run.
 on:
-  push:
   repository_dispatch:
     types: [staging-tests,canary-tests]
 

--- a/config/functions/package.json
+++ b/config/functions/package.json
@@ -8,6 +8,6 @@
   },
   "private": true,
   "engines": {
-    "node": ">=16.0.0"
+    "node": "16"
   }
 }

--- a/config/functions/package.json
+++ b/config/functions/package.json
@@ -8,6 +8,6 @@
   },
   "private": true,
   "engines": {
-    "node": "16"
+    "node": ">=16.0.0"
   }
 }

--- a/config/functions/package.json
+++ b/config/functions/package.json
@@ -8,6 +8,6 @@
   },
   "private": true,
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=16.0.0"
   }
 }

--- a/config/functions/package.json
+++ b/config/functions/package.json
@@ -8,6 +8,6 @@
   },
   "private": true,
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   }
 }


### PR DESCRIPTION
### Discussion

Updates to our E2E tests in CI (`E2E Smoke Tests` and `Deploy Project Config`) to use Node v18. Additionally, pin the firebase-tools version to 12.9.1. While we plan to upgrade the firebase-tools version in the future, we're chosing to pin to a version for the long term to prevent suddent CI test failures.

### Testing

[Executed a E2E test in CI](https://github.com/firebase/firebase-js-sdk/actions/runs/7187075863).

### API Changes

N/A.