### PR TITLE
docs: Improve readability of headings for functions.

### DIFF
--- a/docs-devsite/analytics.md
+++ b/docs-devsite/analytics.md
@@ -16,10 +16,10 @@ The Firebase Analytics Web SDK. This SDK does not work in a Node.js environment.
 
 |  Function | Description |
 |  --- | --- |
-|  <b>function(app...)</b> |
+|  <b>function(app, ...)</b> |
 |  [getAnalytics(app)](./analytics.md#getanalytics_cf608e1) | Returns an [Analytics](./analytics.analytics.md#analytics_interface) instance for the given app. |
 |  [initializeAnalytics(app, options)](./analytics.md#initializeanalytics_a68c1d7) | Returns an [Analytics](./analytics.analytics.md#analytics_interface) instance for the given app. |
-|  <b>function(analyticsInstance...)</b> |
+|  <b>function(analyticsInstance, ...)</b> |
 |  [getGoogleAnalyticsClientId(analyticsInstance)](./analytics.md#getgoogleanalyticsclientid_b0a3b5a) | Retrieves a unique Google Analytics identifier for the web client. See [client\_id](https://developers.google.com/analytics/devguides/collection/ga4/reference/config#client_id)<!-- -->. |
 |  [logEvent(analyticsInstance, eventName, eventParams, options)](./analytics.md#logevent_d5f1743) | Sends a Google Analytics event with given <code>eventParams</code>. This method automatically associates this logged event with this Firebase web app instance on this device.<!-- -->List of recommended event parameters can be found in [the GA4 reference documentation](https://developers.google.com/gtagjs/reference/ga4-events)<!-- -->. |
 |  [logEvent(analyticsInstance, eventName, eventParams, options)](./analytics.md#logevent_507c89b) | Sends a Google Analytics event with given <code>eventParams</code>. This method automatically associates this logged event with this Firebase web app instance on this device.<!-- -->List of recommended event parameters can be found in [the GA4 reference documentation](https://developers.google.com/gtagjs/reference/ga4-events)<!-- -->. |
@@ -49,11 +49,11 @@ The Firebase Analytics Web SDK. This SDK does not work in a Node.js environment.
 |  [setUserProperties(analyticsInstance, properties, options)](./analytics.md#setuserproperties_877b6e8) | Use gtag <code>config</code> command to set all params specified. |
 |  <b>function()</b> |
 |  [isSupported()](./analytics.md#issupported) | This is a public static method provided to users that wraps four different checks:<!-- -->1. Check if it's not a browser extension environment. 2. Check if cookies are enabled in current browser. 3. Check if IndexedDB is supported by the browser environment. 4. Check if the current browser context is valid for using <code>IndexedDB.open()</code>. |
-|  <b>function(consentSettings...)</b> |
+|  <b>function(consentSettings, ...)</b> |
 |  [setConsent(consentSettings)](./analytics.md#setconsent_1697027) | Sets the applicable end user consent state for this web app across all gtag references once Firebase Analytics is initialized.<!-- -->Use the [ConsentSettings](./analytics.consentsettings.md#consentsettings_interface) to specify individual consent type values. By default consent types are set to "granted". |
-|  <b>function(customParams...)</b> |
+|  <b>function(customParams, ...)</b> |
 |  [setDefaultEventParameters(customParams)](./analytics.md#setdefaulteventparameters_0682bee) | Adds data that will be set on every event logged from the SDK, including automatic ones. With gtag's "set" command, the values passed persist on the current page and are passed with all subsequent events. |
-|  <b>function(options...)</b> |
+|  <b>function(options, ...)</b> |
 |  [settings(options)](./analytics.md#settings_eb37905) | Configures Firebase Analytics to use custom <code>gtag</code> or <code>dataLayer</code> names. Intended to be used if <code>gtag.js</code> script has been installed on this page independently of Firebase Analytics, and is using non-default names for either the <code>gtag</code> function or for <code>dataLayer</code>. Must be called before calling <code>getAnalytics()</code> or it won't have any effect. |
 
 ## Interfaces
@@ -81,7 +81,9 @@ The Firebase Analytics Web SDK. This SDK does not work in a Node.js environment.
 |  [CustomEventName](./analytics.md#customeventname) | Any custom event name string not in the standard list of recommended event names. |
 |  [EventNameString](./analytics.md#eventnamestring) | Type for standard Google Analytics event names. <code>logEvent</code> also accepts any custom string and interprets it as a custom event name. |
 
-## getAnalytics() {:#getanalytics_cf608e1}
+## function(app, ...)
+
+### getAnalytics(app) {:#getanalytics_cf608e1}
 
 Returns an [Analytics](./analytics.analytics.md#analytics_interface) instance for the given app.
 
@@ -91,7 +93,7 @@ Returns an [Analytics](./analytics.analytics.md#analytics_interface) instance fo
 export declare function getAnalytics(app?: FirebaseApp): Analytics;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -101,7 +103,7 @@ export declare function getAnalytics(app?: FirebaseApp): Analytics;
 
 [Analytics](./analytics.analytics.md#analytics_interface)
 
-## initializeAnalytics() {:#initializeanalytics_a68c1d7}
+### initializeAnalytics(app, options) {:#initializeanalytics_a68c1d7}
 
 Returns an [Analytics](./analytics.analytics.md#analytics_interface) instance for the given app.
 
@@ -111,7 +113,7 @@ Returns an [Analytics](./analytics.analytics.md#analytics_interface) instance fo
 export declare function initializeAnalytics(app: FirebaseApp, options?: AnalyticsSettings): Analytics;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -122,7 +124,9 @@ export declare function initializeAnalytics(app: FirebaseApp, options?: Analytic
 
 [Analytics](./analytics.analytics.md#analytics_interface)
 
-## getGoogleAnalyticsClientId() {:#getgoogleanalyticsclientid_b0a3b5a}
+## function(analyticsInstance, ...)
+
+### getGoogleAnalyticsClientId(analyticsInstance) {:#getgoogleanalyticsclientid_b0a3b5a}
 
 Retrieves a unique Google Analytics identifier for the web client. See [client\_id](https://developers.google.com/analytics/devguides/collection/ga4/reference/config#client_id)<!-- -->.
 
@@ -132,7 +136,7 @@ Retrieves a unique Google Analytics identifier for the web client. See [client\_
 export declare function getGoogleAnalyticsClientId(analyticsInstance: Analytics): Promise<string>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -142,7 +146,7 @@ export declare function getGoogleAnalyticsClientId(analyticsInstance: Analytics)
 
 Promise&lt;string&gt;
 
-## logEvent() {:#logevent_d5f1743}
+### logEvent(analyticsInstance, eventName, eventParams, options) {:#logevent_d5f1743}
 
 Sends a Google Analytics event with given `eventParams`<!-- -->. This method automatically associates this logged event with this Firebase web app instance on this device.
 
@@ -161,7 +165,7 @@ export declare function logEvent(analyticsInstance: Analytics, eventName: 'add_p
 }, options?: AnalyticsCallOptions): void;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -174,7 +178,7 @@ export declare function logEvent(analyticsInstance: Analytics, eventName: 'add_p
 
 void
 
-## logEvent() {:#logevent_507c89b}
+### logEvent(analyticsInstance, eventName, eventParams, options) {:#logevent_507c89b}
 
 Sends a Google Analytics event with given `eventParams`<!-- -->. This method automatically associates this logged event with this Firebase web app instance on this device.
 
@@ -196,7 +200,7 @@ export declare function logEvent(analyticsInstance: Analytics, eventName: 'purch
 }, options?: AnalyticsCallOptions): void;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -209,7 +213,7 @@ export declare function logEvent(analyticsInstance: Analytics, eventName: 'purch
 
 void
 
-## logEvent() {:#logevent_918c505}
+### logEvent(analyticsInstance, eventName, eventParams, options) {:#logevent_918c505}
 
 Sends a Google Analytics event with given `eventParams`<!-- -->. This method automatically associates this logged event with this Firebase web app instance on this device.
 
@@ -225,7 +229,7 @@ export declare function logEvent(analyticsInstance: Analytics, eventName: 'scree
 }, options?: AnalyticsCallOptions): void;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -238,7 +242,7 @@ export declare function logEvent(analyticsInstance: Analytics, eventName: 'scree
 
 void
 
-## logEvent() {:#logevent_97ff7c6}
+### logEvent(analyticsInstance, eventName, eventParams, options) {:#logevent_97ff7c6}
 
 Sends a Google Analytics event with given `eventParams`<!-- -->. This method automatically associates this logged event with this Firebase web app instance on this device.
 
@@ -253,7 +257,7 @@ export declare function logEvent(analyticsInstance: Analytics, eventName: 'searc
 }, options?: AnalyticsCallOptions): void;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -266,7 +270,7 @@ export declare function logEvent(analyticsInstance: Analytics, eventName: 'searc
 
 void
 
-## logEvent() {:#logevent_1f89527}
+### logEvent(analyticsInstance, eventName, eventParams, options) {:#logevent_1f89527}
 
 Sends a Google Analytics event with given `eventParams`<!-- -->. This method automatically associates this logged event with this Firebase web app instance on this device.
 
@@ -282,7 +286,7 @@ export declare function logEvent(analyticsInstance: Analytics, eventName: 'selec
 }, options?: AnalyticsCallOptions): void;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -295,7 +299,7 @@ export declare function logEvent(analyticsInstance: Analytics, eventName: 'selec
 
 void
 
-## logEvent() {:#logevent_5dd5dd2}
+### logEvent(analyticsInstance, eventName, eventParams, options) {:#logevent_5dd5dd2}
 
 Sends a Google Analytics event with given `eventParams`<!-- -->. This method automatically associates this logged event with this Firebase web app instance on this device.
 
@@ -312,7 +316,7 @@ export declare function logEvent(analyticsInstance: Analytics, eventName: 'selec
 }, options?: AnalyticsCallOptions): void;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -325,7 +329,7 @@ export declare function logEvent(analyticsInstance: Analytics, eventName: 'selec
 
 void
 
-## logEvent() {:#logevent_77bad34}
+### logEvent(analyticsInstance, eventName, eventParams, options) {:#logevent_77bad34}
 
 Sends a Google Analytics event with given `eventParams`<!-- -->. This method automatically associates this logged event with this Firebase web app instance on this device.
 
@@ -342,7 +346,7 @@ export declare function logEvent(analyticsInstance: Analytics, eventName: 'selec
 }, options?: AnalyticsCallOptions): void;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -355,7 +359,7 @@ export declare function logEvent(analyticsInstance: Analytics, eventName: 'selec
 
 void
 
-## logEvent() {:#logevent_560b592}
+### logEvent(analyticsInstance, eventName, eventParams, options) {:#logevent_560b592}
 
 Sends a Google Analytics event with given `eventParams`<!-- -->. This method automatically associates this logged event with this Firebase web app instance on this device.
 
@@ -371,7 +375,7 @@ export declare function logEvent(analyticsInstance: Analytics, eventName: 'set_c
 }, options?: AnalyticsCallOptions): void;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -384,7 +388,7 @@ export declare function logEvent(analyticsInstance: Analytics, eventName: 'set_c
 
 void
 
-## logEvent() {:#logevent_0f60635}
+### logEvent(analyticsInstance, eventName, eventParams, options) {:#logevent_0f60635}
 
 Sends a Google Analytics event with given `eventParams`<!-- -->. This method automatically associates this logged event with this Firebase web app instance on this device.
 
@@ -401,7 +405,7 @@ export declare function logEvent(analyticsInstance: Analytics, eventName: 'share
 }, options?: AnalyticsCallOptions): void;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -414,7 +418,7 @@ export declare function logEvent(analyticsInstance: Analytics, eventName: 'share
 
 void
 
-## logEvent() {:#logevent_bf98d4d}
+### logEvent(analyticsInstance, eventName, eventParams, options) {:#logevent_bf98d4d}
 
 Sends a Google Analytics event with given `eventParams`<!-- -->. This method automatically associates this logged event with this Firebase web app instance on this device.
 
@@ -429,7 +433,7 @@ export declare function logEvent(analyticsInstance: Analytics, eventName: 'sign_
 }, options?: AnalyticsCallOptions): void;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -442,7 +446,7 @@ export declare function logEvent(analyticsInstance: Analytics, eventName: 'sign_
 
 void
 
-## logEvent() {:#logevent_88130b6}
+### logEvent(analyticsInstance, eventName, eventParams, options) {:#logevent_88130b6}
 
 Sends a Google Analytics event with given `eventParams`<!-- -->. This method automatically associates this logged event with this Firebase web app instance on this device.
 
@@ -460,7 +464,7 @@ export declare function logEvent(analyticsInstance: Analytics, eventName: 'timin
 }, options?: AnalyticsCallOptions): void;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -473,7 +477,7 @@ export declare function logEvent(analyticsInstance: Analytics, eventName: 'timin
 
 void
 
-## logEvent() {:#logevent_feb40db}
+### logEvent(analyticsInstance, eventName, eventParams, options) {:#logevent_feb40db}
 
 Sends a Google Analytics event with given `eventParams`<!-- -->. This method automatically associates this logged event with this Firebase web app instance on this device.
 
@@ -492,7 +496,7 @@ export declare function logEvent(analyticsInstance: Analytics, eventName: 'add_s
 }, options?: AnalyticsCallOptions): void;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -505,7 +509,7 @@ export declare function logEvent(analyticsInstance: Analytics, eventName: 'add_s
 
 void
 
-## logEvent() {:#logevent_cfbc3bb}
+### logEvent(analyticsInstance, eventName, eventParams, options) {:#logevent_cfbc3bb}
 
 Sends a Google Analytics event with given `eventParams`<!-- -->. This method automatically associates this logged event with this Firebase web app instance on this device.
 
@@ -522,7 +526,7 @@ export declare function logEvent(analyticsInstance: Analytics, eventName: 'view_
 }, options?: AnalyticsCallOptions): void;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -535,7 +539,7 @@ export declare function logEvent(analyticsInstance: Analytics, eventName: 'view_
 
 void
 
-## logEvent() {:#logevent_f0c3c2c}
+### logEvent(analyticsInstance, eventName, eventParams, options) {:#logevent_f0c3c2c}
 
 Sends a Google Analytics event with given `eventParams`<!-- -->. This method automatically associates this logged event with this Firebase web app instance on this device.
 
@@ -552,7 +556,7 @@ export declare function logEvent(analyticsInstance: Analytics, eventName: 'view_
 }, options?: AnalyticsCallOptions): void;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -565,7 +569,7 @@ export declare function logEvent(analyticsInstance: Analytics, eventName: 'view_
 
 void
 
-## logEvent() {:#logevent_a155179}
+### logEvent(analyticsInstance, eventName, eventParams, options) {:#logevent_a155179}
 
 Sends a Google Analytics event with given `eventParams`<!-- -->. This method automatically associates this logged event with this Firebase web app instance on this device.
 
@@ -579,7 +583,7 @@ export declare function logEvent<T extends string>(analyticsInstance: Analytics,
 }, options?: AnalyticsCallOptions): void;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -592,7 +596,7 @@ export declare function logEvent<T extends string>(analyticsInstance: Analytics,
 
 void
 
-## logEvent() {:#logevent_c4de9a4}
+### logEvent(analyticsInstance, eventName, eventParams, options) {:#logevent_c4de9a4}
 
 Sends a Google Analytics event with given `eventParams`<!-- -->. This method automatically associates this logged event with this Firebase web app instance on this device.
 
@@ -609,7 +613,7 @@ export declare function logEvent(analyticsInstance: Analytics, eventName: 'add_t
 }, options?: AnalyticsCallOptions): void;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -622,7 +626,7 @@ export declare function logEvent(analyticsInstance: Analytics, eventName: 'add_t
 
 void
 
-## logEvent() {:#logevent_8260753}
+### logEvent(analyticsInstance, eventName, eventParams, options) {:#logevent_8260753}
 
 Sends a Google Analytics event with given `eventParams`<!-- -->. This method automatically associates this logged event with this Firebase web app instance on this device.
 
@@ -640,7 +644,7 @@ export declare function logEvent(analyticsInstance: Analytics, eventName: 'begin
 }, options?: AnalyticsCallOptions): void;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -653,7 +657,7 @@ export declare function logEvent(analyticsInstance: Analytics, eventName: 'begin
 
 void
 
-## logEvent() {:#logevent_162cb02}
+### logEvent(analyticsInstance, eventName, eventParams, options) {:#logevent_162cb02}
 
 Sends a Google Analytics event with given `eventParams`<!-- -->. This method automatically associates this logged event with this Firebase web app instance on this device.
 
@@ -673,7 +677,7 @@ export declare function logEvent(analyticsInstance: Analytics, eventName: 'check
 }, options?: AnalyticsCallOptions): void;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -686,7 +690,7 @@ export declare function logEvent(analyticsInstance: Analytics, eventName: 'check
 
 void
 
-## logEvent() {:#logevent_800159e}
+### logEvent(analyticsInstance, eventName, eventParams, options) {:#logevent_800159e}
 
 Sends a Google Analytics event with given `eventParams`<!-- -->. This method automatically associates this logged event with this Firebase web app instance on this device.
 
@@ -702,7 +706,7 @@ export declare function logEvent(analyticsInstance: Analytics, eventName: 'excep
 }, options?: AnalyticsCallOptions): void;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -715,7 +719,7 @@ export declare function logEvent(analyticsInstance: Analytics, eventName: 'excep
 
 void
 
-## logEvent() {:#logevent_9c11aa9}
+### logEvent(analyticsInstance, eventName, eventParams, options) {:#logevent_9c11aa9}
 
 Sends a Google Analytics event with given `eventParams`<!-- -->. This method automatically associates this logged event with this Firebase web app instance on this device.
 
@@ -731,7 +735,7 @@ export declare function logEvent(analyticsInstance: Analytics, eventName: 'gener
 }, options?: AnalyticsCallOptions): void;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -744,7 +748,7 @@ export declare function logEvent(analyticsInstance: Analytics, eventName: 'gener
 
 void
 
-## logEvent() {:#logevent_1f3f282}
+### logEvent(analyticsInstance, eventName, eventParams, options) {:#logevent_1f3f282}
 
 Sends a Google Analytics event with given `eventParams`<!-- -->. This method automatically associates this logged event with this Firebase web app instance on this device.
 
@@ -759,7 +763,7 @@ export declare function logEvent(analyticsInstance: Analytics, eventName: 'login
 }, options?: AnalyticsCallOptions): void;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -772,7 +776,7 @@ export declare function logEvent(analyticsInstance: Analytics, eventName: 'login
 
 void
 
-## logEvent() {:#logevent_0792e28}
+### logEvent(analyticsInstance, eventName, eventParams, options) {:#logevent_0792e28}
 
 Sends a Google Analytics event with given `eventParams`<!-- -->. This method automatically associates this logged event with this Firebase web app instance on this device.
 
@@ -789,7 +793,7 @@ export declare function logEvent(analyticsInstance: Analytics, eventName: 'page_
 }, options?: AnalyticsCallOptions): void;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -802,7 +806,7 @@ export declare function logEvent(analyticsInstance: Analytics, eventName: 'page_
 
 void
 
-## setAnalyticsCollectionEnabled() {:#setanalyticscollectionenabled_494179c}
+### setAnalyticsCollectionEnabled(analyticsInstance, enabled) {:#setanalyticscollectionenabled_494179c}
 
 Sets whether Google Analytics collection is enabled for this app on this device. Sets global `window['ga-disable-analyticsId'] = true;`
 
@@ -812,7 +816,7 @@ Sets whether Google Analytics collection is enabled for this app on this device.
 export declare function setAnalyticsCollectionEnabled(analyticsInstance: Analytics, enabled: boolean): void;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -823,7 +827,7 @@ export declare function setAnalyticsCollectionEnabled(analyticsInstance: Analyti
 
 void
 
-## setCurrentScreen() {:#setcurrentscreen_a6168fa}
+### setCurrentScreen(analyticsInstance, screenName, options) {:#setcurrentscreen_a6168fa}
 
 > Warning: This API is now obsolete.
 > 
@@ -838,7 +842,7 @@ Use gtag `config` command to set `screen_name`<!-- -->.
 export declare function setCurrentScreen(analyticsInstance: Analytics, screenName: string, options?: AnalyticsCallOptions): void;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -850,7 +854,7 @@ export declare function setCurrentScreen(analyticsInstance: Analytics, screenNam
 
 void
 
-## setUserId() {:#setuserid_86d82f6}
+### setUserId(analyticsInstance, id, options) {:#setuserid_86d82f6}
 
 Use gtag `config` command to set `user_id`<!-- -->.
 
@@ -860,7 +864,7 @@ Use gtag `config` command to set `user_id`<!-- -->.
 export declare function setUserId(analyticsInstance: Analytics, id: string | null, options?: AnalyticsCallOptions): void;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -872,7 +876,7 @@ export declare function setUserId(analyticsInstance: Analytics, id: string | nul
 
 void
 
-## setUserProperties() {:#setuserproperties_877b6e8}
+### setUserProperties(analyticsInstance, properties, options) {:#setuserproperties_877b6e8}
 
 Use gtag `config` command to set all params specified.
 
@@ -882,7 +886,7 @@ Use gtag `config` command to set all params specified.
 export declare function setUserProperties(analyticsInstance: Analytics, properties: CustomParams, options?: AnalyticsCallOptions): void;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -894,7 +898,9 @@ export declare function setUserProperties(analyticsInstance: Analytics, properti
 
 void
 
-## isSupported() {:#issupported}
+## function()
+
+### isSupported() {:#issupported}
 
 This is a public static method provided to users that wraps four different checks:
 
@@ -909,7 +915,9 @@ export declare function isSupported(): Promise<boolean>;
 
 Promise&lt;boolean&gt;
 
-## setConsent() {:#setconsent_1697027}
+## function(consentSettings, ...)
+
+### setConsent(consentSettings) {:#setconsent_1697027}
 
 Sets the applicable end user consent state for this web app across all gtag references once Firebase Analytics is initialized.
 
@@ -921,7 +929,7 @@ Use the [ConsentSettings](./analytics.consentsettings.md#consentsettings_interfa
 export declare function setConsent(consentSettings: ConsentSettings): void;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -931,7 +939,9 @@ export declare function setConsent(consentSettings: ConsentSettings): void;
 
 void
 
-## setDefaultEventParameters() {:#setdefaulteventparameters_0682bee}
+## function(customParams, ...)
+
+### setDefaultEventParameters(customParams) {:#setdefaulteventparameters_0682bee}
 
 Adds data that will be set on every event logged from the SDK, including automatic ones. With gtag's "set" command, the values passed persist on the current page and are passed with all subsequent events.
 
@@ -941,7 +951,7 @@ Adds data that will be set on every event logged from the SDK, including automat
 export declare function setDefaultEventParameters(customParams: CustomParams): void;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -951,7 +961,9 @@ export declare function setDefaultEventParameters(customParams: CustomParams): v
 
 void
 
-## settings() {:#settings_eb37905}
+## function(options, ...)
+
+### settings(options) {:#settings_eb37905}
 
 Configures Firebase Analytics to use custom `gtag` or `dataLayer` names. Intended to be used if `gtag.js` script has been installed on this page independently of Firebase Analytics, and is using non-default names for either the `gtag` function or for `dataLayer`<!-- -->. Must be called before calling `getAnalytics()` or it won't have any effect.
 
@@ -961,7 +973,7 @@ Configures Firebase Analytics to use custom `gtag` or `dataLayer` names. Intende
 export declare function settings(options: SettingsOptions): void;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |

--- a/docs-devsite/app-check.customprovider.md
+++ b/docs-devsite/app-check.customprovider.md
@@ -35,7 +35,7 @@ Constructs a new instance of the `CustomProvider` class
 constructor(_customProviderOptions: CustomProviderOptions);
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |

--- a/docs-devsite/app-check.md
+++ b/docs-devsite/app-check.md
@@ -18,9 +18,9 @@ Firebase App Check does not work in a Node.js environment using `ReCaptchaV3Prov
 
 |  Function | Description |
 |  --- | --- |
-|  <b>function(app...)</b> |
+|  <b>function(app, ...)</b> |
 |  [initializeAppCheck(app, options)](./app-check.md#initializeappcheck_5548dfc) | Activate App Check for the given app. Can be called only once per app. |
-|  <b>function(appCheckInstance...)</b> |
+|  <b>function(appCheckInstance, ...)</b> |
 |  [getLimitedUseToken(appCheckInstance)](./app-check.md#getlimitedusetoken_53ef5e3) | Requests a Firebase App Check token. This method should be used only if you need to authorize requests to a non-Firebase backend.<!-- -->Returns limited-use tokens that are intended for use with your non-Firebase backend endpoints that are protected with <a href="https://firebase.google.com/docs/app-check/custom-resource-backend#replay-protection"> Replay Protection</a>. This method does not affect the token generation behavior of the \#getAppCheckToken() method. |
 |  [getToken(appCheckInstance, forceRefresh)](./app-check.md#gettoken_39fc1b3) | Get the current App Check token. Attaches to the most recent in-flight request if one is present. Returns null if no token is present and no token requests are in-flight. |
 |  [onTokenChanged(appCheckInstance, observer)](./app-check.md#ontokenchanged_9761e16) | Registers a listener to changes in the token state. There can be more than one listener registered at the same time for one or more App Check instances. The listeners call back on the UI thread whenever the current token associated with this App Check instance changes. |
@@ -51,7 +51,9 @@ Firebase App Check does not work in a Node.js environment using `ReCaptchaV3Prov
 |  --- | --- |
 |  [AppCheckTokenListener](./app-check.md#appchecktokenlistener) | A listener that is called whenever the App Check token changes. |
 
-## initializeAppCheck() {:#initializeappcheck_5548dfc}
+## function(app, ...)
+
+### initializeAppCheck(app, options) {:#initializeappcheck_5548dfc}
 
 Activate App Check for the given app. Can be called only once per app.
 
@@ -61,7 +63,7 @@ Activate App Check for the given app. Can be called only once per app.
 export declare function initializeAppCheck(app: FirebaseApp | undefined, options: AppCheckOptions): AppCheck;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -72,7 +74,9 @@ export declare function initializeAppCheck(app: FirebaseApp | undefined, options
 
 [AppCheck](./app-check.appcheck.md#appcheck_interface)
 
-## getLimitedUseToken() {:#getlimitedusetoken_53ef5e3}
+## function(appCheckInstance, ...)
+
+### getLimitedUseToken(appCheckInstance) {:#getlimitedusetoken_53ef5e3}
 
 Requests a Firebase App Check token. This method should be used only if you need to authorize requests to a non-Firebase backend.
 
@@ -84,7 +88,7 @@ Returns limited-use tokens that are intended for use with your non-Firebase back
 export declare function getLimitedUseToken(appCheckInstance: AppCheck): Promise<AppCheckTokenResult>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -96,7 +100,7 @@ Promise&lt;[AppCheckTokenResult](./app-check.appchecktokenresult.md#appchecktoke
 
 The limited use token.
 
-## getToken() {:#gettoken_39fc1b3}
+### getToken(appCheckInstance, forceRefresh) {:#gettoken_39fc1b3}
 
 Get the current App Check token. Attaches to the most recent in-flight request if one is present. Returns null if no token is present and no token requests are in-flight.
 
@@ -106,7 +110,7 @@ Get the current App Check token. Attaches to the most recent in-flight request i
 export declare function getToken(appCheckInstance: AppCheck, forceRefresh?: boolean): Promise<AppCheckTokenResult>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -117,7 +121,7 @@ export declare function getToken(appCheckInstance: AppCheck, forceRefresh?: bool
 
 Promise&lt;[AppCheckTokenResult](./app-check.appchecktokenresult.md#appchecktokenresult_interface)<!-- -->&gt;
 
-## onTokenChanged() {:#ontokenchanged_9761e16}
+### onTokenChanged(appCheckInstance, observer) {:#ontokenchanged_9761e16}
 
 Registers a listener to changes in the token state. There can be more than one listener registered at the same time for one or more App Check instances. The listeners call back on the UI thread whenever the current token associated with this App Check instance changes.
 
@@ -127,7 +131,7 @@ Registers a listener to changes in the token state. There can be more than one l
 export declare function onTokenChanged(appCheckInstance: AppCheck, observer: PartialObserver<AppCheckTokenResult>): Unsubscribe;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -140,7 +144,7 @@ export declare function onTokenChanged(appCheckInstance: AppCheck, observer: Par
 
 A function that unsubscribes this listener.
 
-## onTokenChanged() {:#ontokenchanged_8ef80a7}
+### onTokenChanged(appCheckInstance, onNext, onError, onCompletion) {:#ontokenchanged_8ef80a7}
 
 Registers a listener to changes in the token state. There can be more than one listener registered at the same time for one or more App Check instances. The listeners call back on the UI thread whenever the current token associated with this App Check instance changes.
 
@@ -150,7 +154,7 @@ Registers a listener to changes in the token state. There can be more than one l
 export declare function onTokenChanged(appCheckInstance: AppCheck, onNext: (tokenResult: AppCheckTokenResult) => void, onError?: (error: Error) => void, onCompletion?: () => void): Unsubscribe;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -165,7 +169,7 @@ export declare function onTokenChanged(appCheckInstance: AppCheck, onNext: (toke
 
 A function that unsubscribes this listener.
 
-## setTokenAutoRefreshEnabled() {:#settokenautorefreshenabled_057a76c}
+### setTokenAutoRefreshEnabled(appCheckInstance, isTokenAutoRefreshEnabled) {:#settokenautorefreshenabled_057a76c}
 
 Set whether App Check will automatically refresh tokens as needed.
 
@@ -175,7 +179,7 @@ Set whether App Check will automatically refresh tokens as needed.
 export declare function setTokenAutoRefreshEnabled(appCheckInstance: AppCheck, isTokenAutoRefreshEnabled: boolean): void;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |

--- a/docs-devsite/app-check.recaptchaenterpriseprovider.md
+++ b/docs-devsite/app-check.recaptchaenterpriseprovider.md
@@ -35,7 +35,7 @@ Create a ReCaptchaEnterpriseProvider instance.
 constructor(_siteKey: string);
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |

--- a/docs-devsite/app-check.recaptchav3provider.md
+++ b/docs-devsite/app-check.recaptchav3provider.md
@@ -35,7 +35,7 @@ Create a ReCaptchaV3Provider instance.
 constructor(_siteKey: string);
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |

--- a/docs-devsite/app.md
+++ b/docs-devsite/app.md
@@ -18,20 +18,20 @@ This package coordinates the communication between the different Firebase compon
 
 |  Function | Description |
 |  --- | --- |
-|  <b>function(app...)</b> |
+|  <b>function(app, ...)</b> |
 |  [deleteApp(app)](./app.md#deleteapp_cf608e1) | Renders this app unusable and frees the resources of all associated services. |
 |  <b>function()</b> |
 |  [getApps()](./app.md#getapps) | A (read-only) array of all initialized apps. |
 |  [initializeApp()](./app.md#initializeapp) | Creates and initializes a FirebaseApp instance. |
-|  <b>function(libraryKeyOrName...)</b> |
+|  <b>function(libraryKeyOrName, ...)</b> |
 |  [registerVersion(libraryKeyOrName, version, variant)](./app.md#registerversion_f673248) | Registers a library's name and version for platform logging purposes. |
-|  <b>function(logCallback...)</b> |
+|  <b>function(logCallback, ...)</b> |
 |  [onLog(logCallback, options)](./app.md#onlog_fd46eae) | Sets log handler for all Firebase SDKs. |
-|  <b>function(logLevel...)</b> |
+|  <b>function(logLevel, ...)</b> |
 |  [setLogLevel(logLevel)](./app.md#setloglevel_697d53a) | Sets log level for all Firebase SDKs.<!-- -->All of the log types above the current log level are captured (i.e. if you set the log level to <code>info</code>, errors are logged, but <code>debug</code> and <code>verbose</code> logs are not). |
-|  <b>function(name...)</b> |
+|  <b>function(name, ...)</b> |
 |  [getApp(name)](./app.md#getapp_1eaaff4) | Retrieves a [FirebaseApp](./app.firebaseapp.md#firebaseapp_interface) instance.<!-- -->When called with no arguments, the default app is returned. When an app name is provided, the app corresponding to that name is returned.<!-- -->An exception is thrown if the app being retrieved has not yet been initialized. |
-|  <b>function(options...)</b> |
+|  <b>function(options, ...)</b> |
 |  [initializeApp(options, name)](./app.md#initializeapp_cb2f5e1) | Creates and initializes a [FirebaseApp](./app.firebaseapp.md#firebaseapp_interface) instance.<!-- -->See [Add Firebase to your app](https://firebase.google.com/docs/web/setup#add_firebase_to_your_app) and [Initialize multiple projects](https://firebase.google.com/docs/web/setup#multiple-projects) for detailed documentation. |
 |  [initializeApp(options, config)](./app.md#initializeapp_079e917) | Creates and initializes a FirebaseApp instance. |
 
@@ -49,7 +49,9 @@ This package coordinates the communication between the different Firebase compon
 |  --- | --- |
 |  [SDK\_VERSION](./app.md#sdk_version) | The current SDK version. |
 
-## deleteApp() {:#deleteapp_cf608e1}
+## function(app, ...)
+
+### deleteApp(app) {:#deleteapp_cf608e1}
 
 Renders this app unusable and frees the resources of all associated services.
 
@@ -59,7 +61,7 @@ Renders this app unusable and frees the resources of all associated services.
 export declare function deleteApp(app: FirebaseApp): Promise<void>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -83,7 +85,9 @@ deleteApp(app)
 
 ```
 
-## getApps() {:#getapps}
+## function()
+
+### getApps() {:#getapps}
 
 A (read-only) array of all initialized apps.
 
@@ -96,7 +100,7 @@ export declare function getApps(): FirebaseApp[];
 
 [FirebaseApp](./app.firebaseapp.md#firebaseapp_interface)<!-- -->\[\]
 
-## initializeApp() {:#initializeapp}
+### initializeApp() {:#initializeapp}
 
 Creates and initializes a FirebaseApp instance.
 
@@ -109,7 +113,9 @@ export declare function initializeApp(): FirebaseApp;
 
 [FirebaseApp](./app.firebaseapp.md#firebaseapp_interface)
 
-## registerVersion() {:#registerversion_f673248}
+## function(libraryKeyOrName, ...)
+
+### registerVersion(libraryKeyOrName, version, variant) {:#registerversion_f673248}
 
 Registers a library's name and version for platform logging purposes.
 
@@ -119,7 +125,7 @@ Registers a library's name and version for platform logging purposes.
 export declare function registerVersion(libraryKeyOrName: string, version: string, variant?: string): void;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -131,7 +137,9 @@ export declare function registerVersion(libraryKeyOrName: string, version: strin
 
 void
 
-## onLog() {:#onlog_fd46eae}
+## function(logCallback, ...)
+
+### onLog(logCallback, options) {:#onlog_fd46eae}
 
 Sets log handler for all Firebase SDKs.
 
@@ -141,7 +149,7 @@ Sets log handler for all Firebase SDKs.
 export declare function onLog(logCallback: LogCallback | null, options?: LogOptions): void;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -152,7 +160,9 @@ export declare function onLog(logCallback: LogCallback | null, options?: LogOpti
 
 void
 
-## setLogLevel() {:#setloglevel_697d53a}
+## function(logLevel, ...)
+
+### setLogLevel(logLevel) {:#setloglevel_697d53a}
 
 Sets log level for all Firebase SDKs.
 
@@ -164,7 +174,7 @@ All of the log types above the current log level are captured (i.e. if you set t
 export declare function setLogLevel(logLevel: LogLevelString): void;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -174,7 +184,9 @@ export declare function setLogLevel(logLevel: LogLevelString): void;
 
 void
 
-## getApp() {:#getapp_1eaaff4}
+## function(name, ...)
+
+### getApp(name) {:#getapp_1eaaff4}
 
 Retrieves a [FirebaseApp](./app.firebaseapp.md#firebaseapp_interface) instance.
 
@@ -188,7 +200,7 @@ An exception is thrown if the app being retrieved has not yet been initialized.
 export declare function getApp(name?: string): FirebaseApp;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -218,7 +230,9 @@ const otherApp = getApp("otherApp");
 
 ```
 
-## initializeApp() {:#initializeapp_cb2f5e1}
+## function(options, ...)
+
+### initializeApp(options, name) {:#initializeapp_cb2f5e1}
 
 Creates and initializes a [FirebaseApp](./app.firebaseapp.md#firebaseapp_interface) instance.
 
@@ -230,7 +244,7 @@ See [Add Firebase to your app](https://firebase.google.com/docs/web/setup#add_fi
 export declare function initializeApp(options: FirebaseOptions, name?: string): FirebaseApp;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -274,7 +288,7 @@ const otherApp = initializeApp({
 
 ```
 
-## initializeApp() {:#initializeapp_079e917}
+### initializeApp(options, config) {:#initializeapp_079e917}
 
 Creates and initializes a FirebaseApp instance.
 
@@ -284,7 +298,7 @@ Creates and initializes a FirebaseApp instance.
 export declare function initializeApp(options: FirebaseOptions, config?: FirebaseAppSettings): FirebaseApp;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |

--- a/docs-devsite/auth.actioncodeurl.md
+++ b/docs-devsite/auth.actioncodeurl.md
@@ -107,7 +107,7 @@ Parses the email action link string and returns an [ActionCodeURL](./auth.action
 static parseLink(link: string): ActionCodeURL | null;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |

--- a/docs-devsite/auth.auth.md
+++ b/docs-devsite/auth.auth.md
@@ -168,7 +168,7 @@ Adds a blocking callback that runs before an auth state change sets a new user.
 beforeAuthStateChanged(callback: (user: User | null) => void | Promise<void>, onAbort?: () => void): Unsubscribe;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -191,7 +191,7 @@ To keep the old behavior, see [Auth.onIdTokenChanged()](./auth.auth.md#authonidt
 onAuthStateChanged(nextOrObserver: NextOrObserver<User | null>, error?: ErrorFn, completed?: CompleteFn): Unsubscribe;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -215,7 +215,7 @@ This includes sign-in, sign-out, and token refresh events.
 onIdTokenChanged(nextOrObserver: NextOrObserver<User | null>, error?: ErrorFn, completed?: CompleteFn): Unsubscribe;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -243,7 +243,7 @@ This method does not work in a Node.js environment.
 setPersistence(persistence: Persistence): Promise<void>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -290,7 +290,7 @@ The operation fails with an error if the user to be updated belongs to a differe
 updateCurrentUser(user: User | null): Promise<void>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |

--- a/docs-devsite/auth.confirmationresult.md
+++ b/docs-devsite/auth.confirmationresult.md
@@ -52,7 +52,7 @@ Finishes a phone number sign-in, link, or reauthentication.
 confirm(verificationCode: string): Promise<UserCredential>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |

--- a/docs-devsite/auth.emailauthcredential.md
+++ b/docs-devsite/auth.emailauthcredential.md
@@ -40,7 +40,7 @@ Static method to deserialize a JSON representation of an object into an [AuthCre
 static fromJSON(json: object | string): EmailAuthCredential | null;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |

--- a/docs-devsite/auth.emailauthprovider.md
+++ b/docs-devsite/auth.emailauthprovider.md
@@ -85,7 +85,7 @@ Initialize an [AuthCredential](./auth.authcredential.md#authcredential_class) us
 static credential(email: string, password: string): EmailAuthCredential;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -125,7 +125,7 @@ Initialize an [AuthCredential](./auth.authcredential.md#authcredential_class) us
 static credentialWithLink(email: string, emailLink: string): EmailAuthCredential;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |

--- a/docs-devsite/auth.facebookauthprovider.md
+++ b/docs-devsite/auth.facebookauthprovider.md
@@ -80,7 +80,7 @@ Creates a credential for Facebook.
 static credential(accessToken: string): OAuthCredential;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -110,7 +110,7 @@ Used to extract the underlying [OAuthCredential](./auth.oauthcredential.md#oauth
 static credentialFromError(error: FirebaseError): OAuthCredential | null;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -130,7 +130,7 @@ Used to extract the underlying [OAuthCredential](./auth.oauthcredential.md#oauth
 static credentialFromResult(userCredential: UserCredential): OAuthCredential | null;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |

--- a/docs-devsite/auth.githubauthprovider.md
+++ b/docs-devsite/auth.githubauthprovider.md
@@ -82,7 +82,7 @@ Creates a credential for Github.
 static credential(accessToken: string): OAuthCredential;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -102,7 +102,7 @@ Used to extract the underlying [OAuthCredential](./auth.oauthcredential.md#oauth
 static credentialFromError(error: FirebaseError): OAuthCredential | null;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -122,7 +122,7 @@ Used to extract the underlying [OAuthCredential](./auth.oauthcredential.md#oauth
 static credentialFromResult(userCredential: UserCredential): OAuthCredential | null;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |

--- a/docs-devsite/auth.googleauthprovider.md
+++ b/docs-devsite/auth.googleauthprovider.md
@@ -80,7 +80,7 @@ Creates a credential for Google. At least one of ID token and access token is re
 static credential(idToken?: string | null, accessToken?: string | null): OAuthCredential;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -111,7 +111,7 @@ Used to extract the underlying [OAuthCredential](./auth.oauthcredential.md#oauth
 static credentialFromError(error: FirebaseError): OAuthCredential | null;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -131,7 +131,7 @@ Used to extract the underlying [OAuthCredential](./auth.oauthcredential.md#oauth
 static credentialFromResult(userCredential: UserCredential): OAuthCredential | null;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |

--- a/docs-devsite/auth.md
+++ b/docs-devsite/auth.md
@@ -16,12 +16,12 @@ Firebase Authentication
 
 |  Function | Description |
 |  --- | --- |
-|  <b>function(app...)</b> |
+|  <b>function(app, ...)</b> |
 |  [getAuth(app)](./auth.md#getauth_cf608e1) | Returns the Auth instance associated with the provided [FirebaseApp](./app.firebaseapp.md#firebaseapp_interface)<!-- -->. If no instance exists, initializes an Auth instance with platform-specific default dependencies. |
 |  [initializeAuth(app, deps)](./auth.md#initializeauth_ca77c9b) | Initializes an [Auth](./auth.auth.md#auth_interface) instance with fine-grained control over [Dependencies](./auth.dependencies.md#dependencies_interface)<!-- -->. |
-|  <b>function(storage...)</b> |
+|  <b>function(storage, ...)</b> |
 |  [getReactNativePersistence(storage)](./auth.md#getreactnativepersistence_bab4ada) | Returns a persistence object that wraps <code>AsyncStorage</code> imported from <code>react-native</code> or <code>@react-native-community/async-storage</code>, and can be used in the persistence dependency field in [initializeAuth()](./auth.md#initializeauth_ca77c9b)<!-- -->. |
-|  <b>function(auth...)</b> |
+|  <b>function(auth, ...)</b> |
 |  [applyActionCode(auth, oobCode)](./auth.md#applyactioncode_d2ae15a) | Applies a verification code sent to the user by email or other out-of-band mechanism. |
 |  [beforeAuthStateChanged(auth, callback, onAbort)](./auth.md#beforeauthstatechanged_22f2ab6) | Adds a blocking callback that runs before an auth state change sets a new user. |
 |  [checkActionCode(auth, oobCode)](./auth.md#checkactioncode_d2ae15a) | Checks a verification code sent to the user by email or other out-of-band mechanism. |
@@ -52,9 +52,9 @@ Firebase Authentication
 |  [useDeviceLanguage(auth)](./auth.md#usedevicelanguage_2a61ea7) | Sets the current language to the default device/browser preference. |
 |  [validatePassword(auth, password)](./auth.md#validatepassword_4dc4ad2) | Validates the password against the password policy configured for the project or tenant. |
 |  [verifyPasswordResetCode(auth, code)](./auth.md#verifypasswordresetcode_01e0a1a) | Checks a password reset code sent to the user by email or other out-of-band mechanism. |
-|  <b>function(link...)</b> |
+|  <b>function(link, ...)</b> |
 |  [parseActionCodeURL(link)](./auth.md#parseactioncodeurl_51293c3) | Parses the email action link string and returns an [ActionCodeURL](./auth.actioncodeurl.md#actioncodeurl_class) if the link is valid, otherwise returns null. |
-|  <b>function(user...)</b> |
+|  <b>function(user, ...)</b> |
 |  [deleteUser(user)](./auth.md#deleteuser_52b2e2e) | Deletes and signs out the user. |
 |  [getIdToken(user, forceRefresh)](./auth.md#getidtoken_ce7d429) | Returns a JSON Web Token (JWT) used to identify the user to a Firebase service. |
 |  [getIdTokenResult(user, forceRefresh)](./auth.md#getidtokenresult_ce7d429) | Returns a deserialized JSON Web Token (JWT) used to identify the user to a Firebase service. |
@@ -75,7 +75,7 @@ Firebase Authentication
 |  [updatePhoneNumber(user, credential)](./auth.md#updatephonenumber_0105c49) | Updates the user's phone number. |
 |  [updateProfile(user, { displayName, photoURL: photoUrl })](./auth.md#updateprofile_017e12d) | Updates a user's profile data. |
 |  [verifyBeforeUpdateEmail(user, newEmail, actionCodeSettings)](./auth.md#verifybeforeupdateemail_09d6f11) | Sends a verification email to a new email address. |
-|  <b>function(userCredential...)</b> |
+|  <b>function(userCredential, ...)</b> |
 |  [getAdditionalUserInfo(userCredential)](./auth.md#getadditionaluserinfo_838a6bd) | Extracts provider specific [AdditionalUserInfo](./auth.additionaluserinfo.md#additionaluserinfo_interface) for the given credential. |
 
 ## Classes
@@ -172,7 +172,9 @@ Firebase Authentication
 |  [PhoneInfoOptions](./auth.md#phoneinfooptions) | The information required to verify the ownership of a phone number. |
 |  [UserProfile](./auth.md#userprofile) | User profile used in [AdditionalUserInfo](./auth.additionaluserinfo.md#additionaluserinfo_interface)<!-- -->. |
 
-## getAuth() {:#getauth_cf608e1}
+## function(app, ...)
+
+### getAuth(app) {:#getauth_cf608e1}
 
 Returns the Auth instance associated with the provided [FirebaseApp](./app.firebaseapp.md#firebaseapp_interface)<!-- -->. If no instance exists, initializes an Auth instance with platform-specific default dependencies.
 
@@ -182,7 +184,7 @@ Returns the Auth instance associated with the provided [FirebaseApp](./app.fireb
 export declare function getAuth(app?: FirebaseApp): Auth;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -192,7 +194,7 @@ export declare function getAuth(app?: FirebaseApp): Auth;
 
 [Auth](./auth.auth.md#auth_interface)
 
-## initializeAuth() {:#initializeauth_ca77c9b}
+### initializeAuth(app, deps) {:#initializeauth_ca77c9b}
 
 Initializes an [Auth](./auth.auth.md#auth_interface) instance with fine-grained control over [Dependencies](./auth.dependencies.md#dependencies_interface)<!-- -->.
 
@@ -214,7 +216,7 @@ const auth = initializeAuth(app, {
 export declare function initializeAuth(app: FirebaseApp, deps?: Dependencies): Auth;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -225,7 +227,9 @@ export declare function initializeAuth(app: FirebaseApp, deps?: Dependencies): A
 
 [Auth](./auth.auth.md#auth_interface)
 
-## getReactNativePersistence() {:#getreactnativepersistence_bab4ada}
+## function(storage, ...)
+
+### getReactNativePersistence(storage) {:#getreactnativepersistence_bab4ada}
 
 Returns a persistence object that wraps `AsyncStorage` imported from `react-native` or `@react-native-community/async-storage`<!-- -->, and can be used in the persistence dependency field in [initializeAuth()](./auth.md#initializeauth_ca77c9b)<!-- -->.
 
@@ -235,7 +239,7 @@ Returns a persistence object that wraps `AsyncStorage` imported from `react-nati
 export declare function getReactNativePersistence(storage: ReactNativeAsyncStorage): Persistence;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -245,7 +249,9 @@ export declare function getReactNativePersistence(storage: ReactNativeAsyncStora
 
 [Persistence](./auth.persistence.md#persistence_interface)
 
-## applyActionCode() {:#applyactioncode_d2ae15a}
+## function(auth, ...)
+
+### applyActionCode(auth, oobCode) {:#applyactioncode_d2ae15a}
 
 Applies a verification code sent to the user by email or other out-of-band mechanism.
 
@@ -255,7 +261,7 @@ Applies a verification code sent to the user by email or other out-of-band mecha
 export declare function applyActionCode(auth: Auth, oobCode: string): Promise<void>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -266,7 +272,7 @@ export declare function applyActionCode(auth: Auth, oobCode: string): Promise<vo
 
 Promise&lt;void&gt;
 
-## beforeAuthStateChanged() {:#beforeauthstatechanged_22f2ab6}
+### beforeAuthStateChanged(auth, callback, onAbort) {:#beforeauthstatechanged_22f2ab6}
 
 Adds a blocking callback that runs before an auth state change sets a new user.
 
@@ -276,7 +282,7 @@ Adds a blocking callback that runs before an auth state change sets a new user.
 export declare function beforeAuthStateChanged(auth: Auth, callback: (user: User | null) => void | Promise<void>, onAbort?: () => void): Unsubscribe;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -288,7 +294,7 @@ export declare function beforeAuthStateChanged(auth: Auth, callback: (user: User
 
 [Unsubscribe](./util.md#unsubscribe)
 
-## checkActionCode() {:#checkactioncode_d2ae15a}
+### checkActionCode(auth, oobCode) {:#checkactioncode_d2ae15a}
 
 Checks a verification code sent to the user by email or other out-of-band mechanism.
 
@@ -298,7 +304,7 @@ Checks a verification code sent to the user by email or other out-of-band mechan
 export declare function checkActionCode(auth: Auth, oobCode: string): Promise<ActionCodeInfo>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -311,7 +317,7 @@ Promise&lt;[ActionCodeInfo](./auth.actioncodeinfo.md#actioncodeinfo_interface)<!
 
 metadata about the code.
 
-## confirmPasswordReset() {:#confirmpasswordreset_749dad8}
+### confirmPasswordReset(auth, oobCode, newPassword) {:#confirmpasswordreset_749dad8}
 
 Completes the password reset process, given a confirmation code and new password.
 
@@ -321,7 +327,7 @@ Completes the password reset process, given a confirmation code and new password
 export declare function confirmPasswordReset(auth: Auth, oobCode: string, newPassword: string): Promise<void>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -333,7 +339,7 @@ export declare function confirmPasswordReset(auth: Auth, oobCode: string, newPas
 
 Promise&lt;void&gt;
 
-## connectAuthEmulator() {:#connectauthemulator_657c7e5}
+### connectAuthEmulator(auth, url, options) {:#connectauthemulator_657c7e5}
 
 Changes the [Auth](./auth.auth.md#auth_interface) instance to communicate with the Firebase Auth Emulator, instead of production Firebase Auth services.
 
@@ -347,7 +353,7 @@ export declare function connectAuthEmulator(auth: Auth, url: string, options?: {
 }): void;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -367,7 +373,7 @@ connectAuthEmulator(auth, 'http://127.0.0.1:9099', { disableWarnings: true });
 
 ```
 
-## createUserWithEmailAndPassword() {:#createuserwithemailandpassword_21ad33b}
+### createUserWithEmailAndPassword(auth, email, password) {:#createuserwithemailandpassword_21ad33b}
 
 Creates a new user account associated with the specified email address and password.
 
@@ -383,7 +389,7 @@ Note: The email address acts as a unique identifier for the user and enables an 
 export declare function createUserWithEmailAndPassword(auth: Auth, email: string, password: string): Promise<UserCredential>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -395,7 +401,7 @@ export declare function createUserWithEmailAndPassword(auth: Auth, email: string
 
 Promise&lt;[UserCredential](./auth.usercredential.md#usercredential_interface)<!-- -->&gt;
 
-## fetchSignInMethodsForEmail() {:#fetchsigninmethodsforemail_efb3887}
+### fetchSignInMethodsForEmail(auth, email) {:#fetchsigninmethodsforemail_efb3887}
 
 Gets the list of possible sign in methods for the given email address. This method returns an empty list when \[Email Enumeration Protection\](https://cloud.google.com/identity-platform/docs/admin/email-enumeration-protection) is enabled, irrespective of the number of authentication methods available for the given email.
 
@@ -407,7 +413,7 @@ This is useful to differentiate methods of sign-in for the same provider, eg. [E
 export declare function fetchSignInMethodsForEmail(auth: Auth, email: string): Promise<string[]>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -418,7 +424,7 @@ export declare function fetchSignInMethodsForEmail(auth: Auth, email: string): P
 
 Promise&lt;string\[\]&gt;
 
-## getMultiFactorResolver() {:#getmultifactorresolver_201ba61}
+### getMultiFactorResolver(auth, error) {:#getmultifactorresolver_201ba61}
 
 Provides a [MultiFactorResolver](./auth.multifactorresolver.md#multifactorresolver_interface) suitable for completion of a multi-factor flow.
 
@@ -428,7 +434,7 @@ Provides a [MultiFactorResolver](./auth.multifactorresolver.md#multifactorresolv
 export declare function getMultiFactorResolver(auth: Auth, error: MultiFactorError): MultiFactorResolver;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -439,7 +445,7 @@ export declare function getMultiFactorResolver(auth: Auth, error: MultiFactorErr
 
 [MultiFactorResolver](./auth.multifactorresolver.md#multifactorresolver_interface)
 
-## getRedirectResult() {:#getredirectresult_c35dc1f}
+### getRedirectResult(auth, resolver) {:#getredirectresult_c35dc1f}
 
 Returns a [UserCredential](./auth.usercredential.md#usercredential_interface) from the redirect-based sign-in flow.
 
@@ -453,7 +459,7 @@ This method does not work in a Node.js environment.
 export declare function getRedirectResult(auth: Auth, resolver?: PopupRedirectResolver): Promise<UserCredential | null>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -492,7 +498,7 @@ const operationType = result.operationType;
 
 ```
 
-## initializeRecaptchaConfig() {:#initializerecaptchaconfig_2a61ea7}
+### initializeRecaptchaConfig(auth) {:#initializerecaptchaconfig_2a61ea7}
 
 Loads the reCAPTCHA configuration into the `Auth` instance.
 
@@ -510,7 +516,7 @@ This method does not work in a Node.js environment.
 export declare function initializeRecaptchaConfig(auth: Auth): Promise<void>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -528,7 +534,7 @@ initializeRecaptchaConfig(auth);
 
 ```
 
-## isSignInWithEmailLink() {:#issigninwithemaillink_db04f1d}
+### isSignInWithEmailLink(auth, emailLink) {:#issigninwithemaillink_db04f1d}
 
 Checks if an incoming link is a sign-in with email link suitable for [signInWithEmailLink()](./auth.md#signinwithemaillink_ed14c53)<!-- -->.
 
@@ -538,7 +544,7 @@ Checks if an incoming link is a sign-in with email link suitable for [signInWith
 export declare function isSignInWithEmailLink(auth: Auth, emailLink: string): boolean;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -549,7 +555,7 @@ export declare function isSignInWithEmailLink(auth: Auth, emailLink: string): bo
 
 boolean
 
-## onAuthStateChanged() {:#onauthstatechanged_b0d07ab}
+### onAuthStateChanged(auth, nextOrObserver, error, completed) {:#onauthstatechanged_b0d07ab}
 
 Adds an observer for changes to the user's sign-in state.
 
@@ -561,7 +567,7 @@ To keep the old behavior, see [onIdTokenChanged()](./auth.md#onidtokenchanged_b0
 export declare function onAuthStateChanged(auth: Auth, nextOrObserver: NextOrObserver<User>, error?: ErrorFn, completed?: CompleteFn): Unsubscribe;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -574,7 +580,7 @@ export declare function onAuthStateChanged(auth: Auth, nextOrObserver: NextOrObs
 
 [Unsubscribe](./util.md#unsubscribe)
 
-## onIdTokenChanged() {:#onidtokenchanged_b0d07ab}
+### onIdTokenChanged(auth, nextOrObserver, error, completed) {:#onidtokenchanged_b0d07ab}
 
 Adds an observer for changes to the signed-in user's ID token.
 
@@ -586,7 +592,7 @@ This includes sign-in, sign-out, and token refresh events. This will not be trig
 export declare function onIdTokenChanged(auth: Auth, nextOrObserver: NextOrObserver<User>, error?: ErrorFn, completed?: CompleteFn): Unsubscribe;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -599,7 +605,7 @@ export declare function onIdTokenChanged(auth: Auth, nextOrObserver: NextOrObser
 
 [Unsubscribe](./util.md#unsubscribe)
 
-## revokeAccessToken() {:#revokeaccesstoken_5556ad5}
+### revokeAccessToken(auth, token) {:#revokeaccesstoken_5556ad5}
 
 Revokes the given access token. Currently only supports Apple OAuth access tokens.
 
@@ -609,7 +615,7 @@ Revokes the given access token. Currently only supports Apple OAuth access token
 export declare function revokeAccessToken(auth: Auth, token: string): Promise<void>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -620,7 +626,7 @@ export declare function revokeAccessToken(auth: Auth, token: string): Promise<vo
 
 Promise&lt;void&gt;
 
-## sendPasswordResetEmail() {:#sendpasswordresetemail_95b079b}
+### sendPasswordResetEmail(auth, email, actionCodeSettings) {:#sendpasswordresetemail_95b079b}
 
 Sends a password reset email to the given email address. This method does not throw an error when there's no user account with the given email address and \[Email Enumeration Protection\](https://cloud.google.com/identity-platform/docs/admin/email-enumeration-protection) is enabled.
 
@@ -632,7 +638,7 @@ To complete the password reset, call [confirmPasswordReset()](./auth.md#confirmp
 export declare function sendPasswordResetEmail(auth: Auth, email: string, actionCodeSettings?: ActionCodeSettings): Promise<void>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -666,7 +672,7 @@ await confirmPasswordReset('user@example.com', code);
 
 ```
 
-## sendSignInLinkToEmail() {:#sendsigninlinktoemail_95b079b}
+### sendSignInLinkToEmail(auth, email, actionCodeSettings) {:#sendsigninlinktoemail_95b079b}
 
 Sends a sign-in email link to the user with the specified email.
 
@@ -680,7 +686,7 @@ To complete sign in with the email link, call [signInWithEmailLink()](./auth.md#
 export declare function sendSignInLinkToEmail(auth: Auth, email: string, actionCodeSettings: ActionCodeSettings): Promise<void>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -716,7 +722,7 @@ if(isSignInWithEmailLink(auth, emailLink)) {
 
 ```
 
-## setPersistence() {:#setpersistence_a3592ac}
+### setPersistence(auth, persistence) {:#setpersistence_a3592ac}
 
 Changes the type of persistence on the [Auth](./auth.auth.md#auth_interface) instance for the currently saved `Auth` session and applies this type of persistence for future sign-in requests, including sign-in with redirect requests.
 
@@ -730,7 +736,7 @@ This method does not work in a Node.js environment.
 export declare function setPersistence(auth: Auth, persistence: Persistence): Promise<void>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -751,7 +757,7 @@ setPersistence(auth, browserSessionPersistence);
 
 ```
 
-## signInAnonymously() {:#signinanonymously_2a61ea7}
+### signInAnonymously(auth) {:#signinanonymously_2a61ea7}
 
 Asynchronously signs in as an anonymous user.
 
@@ -763,7 +769,7 @@ If there is already an anonymous user signed in, that user will be returned; oth
 export declare function signInAnonymously(auth: Auth): Promise<UserCredential>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -773,7 +779,7 @@ export declare function signInAnonymously(auth: Auth): Promise<UserCredential>;
 
 Promise&lt;[UserCredential](./auth.usercredential.md#usercredential_interface)<!-- -->&gt;
 
-## signInWithCredential() {:#signinwithcredential_8074518}
+### signInWithCredential(auth, credential) {:#signinwithcredential_8074518}
 
 Asynchronously signs in with the given credentials.
 
@@ -785,7 +791,7 @@ An [AuthProvider](./auth.authprovider.md#authprovider_interface) can be used to 
 export declare function signInWithCredential(auth: Auth, credential: AuthCredential): Promise<UserCredential>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -796,7 +802,7 @@ export declare function signInWithCredential(auth: Auth, credential: AuthCredent
 
 Promise&lt;[UserCredential](./auth.usercredential.md#usercredential_interface)<!-- -->&gt;
 
-## signInWithCustomToken() {:#signinwithcustomtoken_32af683}
+### signInWithCustomToken(auth, customToken) {:#signinwithcustomtoken_32af683}
 
 Asynchronously signs in using a custom token.
 
@@ -810,7 +816,7 @@ Fails with an error if the token is invalid, expired, or not accepted by the Fir
 export declare function signInWithCustomToken(auth: Auth, customToken: string): Promise<UserCredential>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -821,7 +827,7 @@ export declare function signInWithCustomToken(auth: Auth, customToken: string): 
 
 Promise&lt;[UserCredential](./auth.usercredential.md#usercredential_interface)<!-- -->&gt;
 
-## signInWithEmailAndPassword() {:#signinwithemailandpassword_21ad33b}
+### signInWithEmailAndPassword(auth, email, password) {:#signinwithemailandpassword_21ad33b}
 
 Asynchronously signs in using an email and password.
 
@@ -835,7 +841,7 @@ Note: The user's password is NOT the password used to access the user's email ac
 export declare function signInWithEmailAndPassword(auth: Auth, email: string, password: string): Promise<UserCredential>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -847,7 +853,7 @@ export declare function signInWithEmailAndPassword(auth: Auth, email: string, pa
 
 Promise&lt;[UserCredential](./auth.usercredential.md#usercredential_interface)<!-- -->&gt;
 
-## signInWithEmailLink() {:#signinwithemaillink_ed14c53}
+### signInWithEmailLink(auth, email, emailLink) {:#signinwithemaillink_ed14c53}
 
 Asynchronously signs in using an email and sign-in email link.
 
@@ -863,7 +869,7 @@ Note: Confirm the link is a sign-in email link before calling this method fireba
 export declare function signInWithEmailLink(auth: Auth, email: string, emailLink?: string): Promise<UserCredential>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -899,7 +905,7 @@ if(isSignInWithEmailLink(auth, emailLink)) {
 
 ```
 
-## signInWithPhoneNumber() {:#signinwithphonenumber_75b2560}
+### signInWithPhoneNumber(auth, phoneNumber, appVerifier) {:#signinwithphonenumber_75b2560}
 
 Asynchronously signs in using a phone number.
 
@@ -915,7 +921,7 @@ This method does not work in a Node.js environment.
 export declare function signInWithPhoneNumber(auth: Auth, phoneNumber: string, appVerifier: ApplicationVerifier): Promise<ConfirmationResult>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -939,7 +945,7 @@ const credential = await confirmationResult.confirm(verificationCode);
 
 ```
 
-## signInWithPopup() {:#signinwithpopup_770f816}
+### signInWithPopup(auth, provider, resolver) {:#signinwithpopup_770f816}
 
 Authenticates a Firebase client using a popup-based OAuth authentication flow.
 
@@ -953,7 +959,7 @@ This method does not work in a Node.js environment.
 export declare function signInWithPopup(auth: Auth, provider: AuthProvider, resolver?: PopupRedirectResolver): Promise<UserCredential>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -981,7 +987,7 @@ const token = credential.accessToken;
 
 ```
 
-## signInWithRedirect() {:#signinwithredirect_770f816}
+### signInWithRedirect(auth, provider, resolver) {:#signinwithredirect_770f816}
 
 Authenticates a Firebase client using a full-page redirect flow.
 
@@ -995,7 +1001,7 @@ This method does not work in a Node.js environment.
 export declare function signInWithRedirect(auth: Auth, provider: AuthProvider, resolver?: PopupRedirectResolver): Promise<never>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -1035,7 +1041,7 @@ const operationType = result.operationType;
 
 ```
 
-## signOut() {:#signout_2a61ea7}
+### signOut(auth) {:#signout_2a61ea7}
 
 Signs out the current user.
 
@@ -1045,7 +1051,7 @@ Signs out the current user.
 export declare function signOut(auth: Auth): Promise<void>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -1055,7 +1061,7 @@ export declare function signOut(auth: Auth): Promise<void>;
 
 Promise&lt;void&gt;
 
-## updateCurrentUser() {:#updatecurrentuser_9d96fff}
+### updateCurrentUser(auth, user) {:#updatecurrentuser_9d96fff}
 
 Asynchronously sets the provided user as [Auth.currentUser](./auth.auth.md#authcurrentuser) on the [Auth](./auth.auth.md#auth_interface) instance.
 
@@ -1071,7 +1077,7 @@ The operation fails with an error if the user to be updated belongs to a differe
 export declare function updateCurrentUser(auth: Auth, user: User | null): Promise<void>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -1082,7 +1088,7 @@ export declare function updateCurrentUser(auth: Auth, user: User | null): Promis
 
 Promise&lt;void&gt;
 
-## useDeviceLanguage() {:#usedevicelanguage_2a61ea7}
+### useDeviceLanguage(auth) {:#usedevicelanguage_2a61ea7}
 
 Sets the current language to the default device/browser preference.
 
@@ -1092,7 +1098,7 @@ Sets the current language to the default device/browser preference.
 export declare function useDeviceLanguage(auth: Auth): void;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -1102,7 +1108,7 @@ export declare function useDeviceLanguage(auth: Auth): void;
 
 void
 
-## validatePassword() {:#validatepassword_4dc4ad2}
+### validatePassword(auth, password) {:#validatepassword_4dc4ad2}
 
 Validates the password against the password policy configured for the project or tenant.
 
@@ -1116,7 +1122,7 @@ If an auth flow fails because a submitted password does not meet the password po
 export declare function validatePassword(auth: Auth, password: string): Promise<PasswordValidationStatus>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -1135,7 +1141,7 @@ validatePassword(auth, 'some-password');
 
 ```
 
-## verifyPasswordResetCode() {:#verifypasswordresetcode_01e0a1a}
+### verifyPasswordResetCode(auth, code) {:#verifypasswordresetcode_01e0a1a}
 
 Checks a password reset code sent to the user by email or other out-of-band mechanism.
 
@@ -1145,7 +1151,7 @@ Checks a password reset code sent to the user by email or other out-of-band mech
 export declare function verifyPasswordResetCode(auth: Auth, code: string): Promise<string>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -1158,7 +1164,9 @@ Promise&lt;string&gt;
 
 the user's email address if valid.
 
-## parseActionCodeURL() {:#parseactioncodeurl_51293c3}
+## function(link, ...)
+
+### parseActionCodeURL(link) {:#parseactioncodeurl_51293c3}
 
 Parses the email action link string and returns an [ActionCodeURL](./auth.actioncodeurl.md#actioncodeurl_class) if the link is valid, otherwise returns null.
 
@@ -1168,7 +1176,7 @@ Parses the email action link string and returns an [ActionCodeURL](./auth.action
 export declare function parseActionCodeURL(link: string): ActionCodeURL | null;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -1178,7 +1186,9 @@ export declare function parseActionCodeURL(link: string): ActionCodeURL | null;
 
 [ActionCodeURL](./auth.actioncodeurl.md#actioncodeurl_class) \| null
 
-## deleteUser() {:#deleteuser_52b2e2e}
+## function(user, ...)
+
+### deleteUser(user) {:#deleteuser_52b2e2e}
 
 Deletes and signs out the user.
 
@@ -1190,7 +1200,7 @@ Important: this is a security-sensitive operation that requires the user to have
 export declare function deleteUser(user: User): Promise<void>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -1200,7 +1210,7 @@ export declare function deleteUser(user: User): Promise<void>;
 
 Promise&lt;void&gt;
 
-## getIdToken() {:#getidtoken_ce7d429}
+### getIdToken(user, forceRefresh) {:#getidtoken_ce7d429}
 
 Returns a JSON Web Token (JWT) used to identify the user to a Firebase service.
 
@@ -1212,7 +1222,7 @@ Returns the current token if it has not expired or if it will not expire in the 
 export declare function getIdToken(user: User, forceRefresh?: boolean): Promise<string>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -1223,7 +1233,7 @@ export declare function getIdToken(user: User, forceRefresh?: boolean): Promise<
 
 Promise&lt;string&gt;
 
-## getIdTokenResult() {:#getidtokenresult_ce7d429}
+### getIdTokenResult(user, forceRefresh) {:#getidtokenresult_ce7d429}
 
 Returns a deserialized JSON Web Token (JWT) used to identify the user to a Firebase service.
 
@@ -1235,7 +1245,7 @@ Returns the current token if it has not expired or if it will not expire in the 
 export declare function getIdTokenResult(user: User, forceRefresh?: boolean): Promise<IdTokenResult>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -1246,7 +1256,7 @@ export declare function getIdTokenResult(user: User, forceRefresh?: boolean): Pr
 
 Promise&lt;[IdTokenResult](./auth.idtokenresult.md#idtokenresult_interface)<!-- -->&gt;
 
-## linkWithCredential() {:#linkwithcredential_60f8043}
+### linkWithCredential(user, credential) {:#linkwithcredential_60f8043}
 
 Links the user account with the given credentials.
 
@@ -1258,7 +1268,7 @@ An [AuthProvider](./auth.authprovider.md#authprovider_interface) can be used to 
 export declare function linkWithCredential(user: User, credential: AuthCredential): Promise<UserCredential>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -1269,7 +1279,7 @@ export declare function linkWithCredential(user: User, credential: AuthCredentia
 
 Promise&lt;[UserCredential](./auth.usercredential.md#usercredential_interface)<!-- -->&gt;
 
-## linkWithPhoneNumber() {:#linkwithphonenumber_9ed75fe}
+### linkWithPhoneNumber(user, phoneNumber, appVerifier) {:#linkwithphonenumber_9ed75fe}
 
 Links the user account with the given phone number.
 
@@ -1281,7 +1291,7 @@ This method does not work in a Node.js environment.
 export declare function linkWithPhoneNumber(user: User, phoneNumber: string, appVerifier: ApplicationVerifier): Promise<ConfirmationResult>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -1293,7 +1303,7 @@ export declare function linkWithPhoneNumber(user: User, phoneNumber: string, app
 
 Promise&lt;[ConfirmationResult](./auth.confirmationresult.md#confirmationresult_interface)<!-- -->&gt;
 
-## linkWithPopup() {:#linkwithpopup_41c0b31}
+### linkWithPopup(user, provider, resolver) {:#linkwithpopup_41c0b31}
 
 Links the authenticated provider to the user account using a pop-up based OAuth flow.
 
@@ -1307,7 +1317,7 @@ This method does not work in a Node.js environment.
 export declare function linkWithPopup(user: User, provider: AuthProvider, resolver?: PopupRedirectResolver): Promise<UserCredential>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -1331,7 +1341,7 @@ await linkWithPopup(result.user, provider);
 
 ```
 
-## linkWithRedirect() {:#linkwithredirect_41c0b31}
+### linkWithRedirect(user, provider, resolver) {:#linkwithredirect_41c0b31}
 
 Links the [OAuthProvider](./auth.oauthprovider.md#oauthprovider_class) to the user account using a full-page redirect flow.
 
@@ -1345,7 +1355,7 @@ This method does not work in a Node.js environment.
 export declare function linkWithRedirect(user: User, provider: AuthProvider, resolver?: PopupRedirectResolver): Promise<never>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -1373,7 +1383,7 @@ const result = await getRedirectResult(auth);
 
 ```
 
-## multiFactor() {:#multifactor_52b2e2e}
+### multiFactor(user) {:#multifactor_52b2e2e}
 
 The [MultiFactorUser](./auth.multifactoruser.md#multifactoruser_interface) corresponding to the user.
 
@@ -1385,7 +1395,7 @@ This is used to access all multi-factor properties and operations related to the
 export declare function multiFactor(user: User): MultiFactorUser;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -1395,7 +1405,7 @@ export declare function multiFactor(user: User): MultiFactorUser;
 
 [MultiFactorUser](./auth.multifactoruser.md#multifactoruser_interface)
 
-## reauthenticateWithCredential() {:#reauthenticatewithcredential_60f8043}
+### reauthenticateWithCredential(user, credential) {:#reauthenticatewithcredential_60f8043}
 
 Re-authenticates a user using a fresh credential.
 
@@ -1407,7 +1417,7 @@ Use before operations such as [updatePassword()](./auth.md#updatepassword_6df673
 export declare function reauthenticateWithCredential(user: User, credential: AuthCredential): Promise<UserCredential>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -1418,7 +1428,7 @@ export declare function reauthenticateWithCredential(user: User, credential: Aut
 
 Promise&lt;[UserCredential](./auth.usercredential.md#usercredential_interface)<!-- -->&gt;
 
-## reauthenticateWithPhoneNumber() {:#reauthenticatewithphonenumber_9ed75fe}
+### reauthenticateWithPhoneNumber(user, phoneNumber, appVerifier) {:#reauthenticatewithphonenumber_9ed75fe}
 
 Re-authenticates a user using a fresh phone credential.
 
@@ -1432,7 +1442,7 @@ This method does not work in a Node.js environment.
 export declare function reauthenticateWithPhoneNumber(user: User, phoneNumber: string, appVerifier: ApplicationVerifier): Promise<ConfirmationResult>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -1444,7 +1454,7 @@ export declare function reauthenticateWithPhoneNumber(user: User, phoneNumber: s
 
 Promise&lt;[ConfirmationResult](./auth.confirmationresult.md#confirmationresult_interface)<!-- -->&gt;
 
-## reauthenticateWithPopup() {:#reauthenticatewithpopup_41c0b31}
+### reauthenticateWithPopup(user, provider, resolver) {:#reauthenticatewithpopup_41c0b31}
 
 Reauthenticates the current user with the specified [OAuthProvider](./auth.oauthprovider.md#oauthprovider_class) using a pop-up based OAuth flow.
 
@@ -1458,7 +1468,7 @@ This method does not work in a Node.js environment.
 export declare function reauthenticateWithPopup(user: User, provider: AuthProvider, resolver?: PopupRedirectResolver): Promise<UserCredential>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -1482,7 +1492,7 @@ await reauthenticateWithPopup(result.user, provider);
 
 ```
 
-## reauthenticateWithRedirect() {:#reauthenticatewithredirect_41c0b31}
+### reauthenticateWithRedirect(user, provider, resolver) {:#reauthenticatewithredirect_41c0b31}
 
 Reauthenticates the current user with the specified [OAuthProvider](./auth.oauthprovider.md#oauthprovider_class) using a full-page redirect flow.
 
@@ -1496,7 +1506,7 @@ This method does not work in a Node.js environment.
 export declare function reauthenticateWithRedirect(user: User, provider: AuthProvider, resolver?: PopupRedirectResolver): Promise<never>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -1528,7 +1538,7 @@ const result = await getRedirectResult(auth);
 
 ```
 
-## reload() {:#reload_52b2e2e}
+### reload(user) {:#reload_52b2e2e}
 
 Reloads user account data, if signed in.
 
@@ -1538,7 +1548,7 @@ Reloads user account data, if signed in.
 export declare function reload(user: User): Promise<void>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -1548,7 +1558,7 @@ export declare function reload(user: User): Promise<void>;
 
 Promise&lt;void&gt;
 
-## sendEmailVerification() {:#sendemailverification_6a885d6}
+### sendEmailVerification(user, actionCodeSettings) {:#sendemailverification_6a885d6}
 
 Sends a verification email to a user.
 
@@ -1560,7 +1570,7 @@ The verification process is completed by calling [applyActionCode()](./auth.md#a
 export declare function sendEmailVerification(user: User, actionCodeSettings?: ActionCodeSettings | null): Promise<void>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -1593,7 +1603,7 @@ await applyActionCode(auth, code);
 
 ```
 
-## unlink() {:#unlink_f289a14}
+### unlink(user, providerId) {:#unlink_f289a14}
 
 Unlinks a provider from a user account.
 
@@ -1603,7 +1613,7 @@ Unlinks a provider from a user account.
 export declare function unlink(user: User, providerId: string): Promise<User>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -1614,7 +1624,7 @@ export declare function unlink(user: User, providerId: string): Promise<User>;
 
 Promise&lt;[User](./auth.user.md#user_interface)<!-- -->&gt;
 
-## updateEmail() {:#updateemail_7737d57}
+### updateEmail(user, newEmail) {:#updateemail_7737d57}
 
 Updates the user's email address.
 
@@ -1628,7 +1638,7 @@ Important: this is a security sensitive operation that requires the user to have
 export declare function updateEmail(user: User, newEmail: string): Promise<void>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -1639,7 +1649,7 @@ export declare function updateEmail(user: User, newEmail: string): Promise<void>
 
 Promise&lt;void&gt;
 
-## updatePassword() {:#updatepassword_6df673e}
+### updatePassword(user, newPassword) {:#updatepassword_6df673e}
 
 Updates the user's password.
 
@@ -1651,7 +1661,7 @@ Important: this is a security sensitive operation that requires the user to have
 export declare function updatePassword(user: User, newPassword: string): Promise<void>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -1662,7 +1672,7 @@ export declare function updatePassword(user: User, newPassword: string): Promise
 
 Promise&lt;void&gt;
 
-## updatePhoneNumber() {:#updatephonenumber_0105c49}
+### updatePhoneNumber(user, credential) {:#updatephonenumber_0105c49}
 
 Updates the user's phone number.
 
@@ -1674,7 +1684,7 @@ This method does not work in a Node.js environment.
 export declare function updatePhoneNumber(user: User, credential: PhoneAuthCredential): Promise<void>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -1699,7 +1709,7 @@ await updatePhoneNumber(user, phoneCredential);
 
 ```
 
-## updateProfile() {:#updateprofile_017e12d}
+### updateProfile(user, { displayName, photoURL: photoUrl }) {:#updateprofile_017e12d}
 
 Updates a user's profile data.
 
@@ -1712,7 +1722,7 @@ export declare function updateProfile(user: User, { displayName, photoURL: photo
 }): Promise<void>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -1723,7 +1733,7 @@ export declare function updateProfile(user: User, { displayName, photoURL: photo
 
 Promise&lt;void&gt;
 
-## verifyBeforeUpdateEmail() {:#verifybeforeupdateemail_09d6f11}
+### verifyBeforeUpdateEmail(user, newEmail, actionCodeSettings) {:#verifybeforeupdateemail_09d6f11}
 
 Sends a verification email to a new email address.
 
@@ -1737,7 +1747,7 @@ If you have a custom email action handler, you can complete the verification pro
 export declare function verifyBeforeUpdateEmail(user: User, newEmail: string, actionCodeSettings?: ActionCodeSettings | null): Promise<void>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -1771,7 +1781,9 @@ await applyActionCode(auth, code);
 
 ```
 
-## getAdditionalUserInfo() {:#getadditionaluserinfo_838a6bd}
+## function(userCredential, ...)
+
+### getAdditionalUserInfo(userCredential) {:#getadditionaluserinfo_838a6bd}
 
 Extracts provider specific [AdditionalUserInfo](./auth.additionaluserinfo.md#additionaluserinfo_interface) for the given credential.
 
@@ -1781,7 +1793,7 @@ Extracts provider specific [AdditionalUserInfo](./auth.additionaluserinfo.md#add
 export declare function getAdditionalUserInfo(userCredential: UserCredential): AdditionalUserInfo | null;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |

--- a/docs-devsite/auth.multifactorresolver.md
+++ b/docs-devsite/auth.multifactorresolver.md
@@ -61,7 +61,7 @@ A helper function to help users complete sign in with a second factor using an [
 resolveSignIn(assertion: MultiFactorAssertion): Promise<UserCredential>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |

--- a/docs-devsite/auth.multifactoruser.md
+++ b/docs-devsite/auth.multifactoruser.md
@@ -54,7 +54,7 @@ On resolution, the user tokens are updated to reflect the change in the JWT payl
 enroll(assertion: MultiFactorAssertion, displayName?: string | null): Promise<void>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -137,7 +137,7 @@ To specify the factor to remove, pass a [MultiFactorInfo](./auth.multifactorinfo
 unenroll(option: MultiFactorInfo | string): Promise<void>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |

--- a/docs-devsite/auth.oauthcredential.md
+++ b/docs-devsite/auth.oauthcredential.md
@@ -76,7 +76,7 @@ Static method to deserialize a JSON representation of an object into an [AuthCre
 static fromJSON(json: string | object): OAuthCredential | null;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |

--- a/docs-devsite/auth.oauthprovider.md
+++ b/docs-devsite/auth.oauthprovider.md
@@ -40,7 +40,7 @@ The raw nonce is required when an ID token with a nonce field is provided. The S
 credential(params: OAuthCredentialOptions): OAuthCredential;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -74,7 +74,7 @@ Used to extract the underlying [OAuthCredential](./auth.oauthcredential.md#oauth
 static credentialFromError(error: FirebaseError): OAuthCredential | null;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -94,7 +94,7 @@ Creates an [OAuthCredential](./auth.oauthcredential.md#oauthcredential_class) fr
 static credentialFromJSON(json: object | string): OAuthCredential;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -114,7 +114,7 @@ Used to extract the underlying [OAuthCredential](./auth.oauthcredential.md#oauth
 static credentialFromResult(userCredential: UserCredential): OAuthCredential | null;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |

--- a/docs-devsite/auth.phoneauthcredential.md
+++ b/docs-devsite/auth.phoneauthcredential.md
@@ -36,7 +36,7 @@ Generates a phone credential based on a plain object or a JSON string.
 static fromJSON(json: object | string): PhoneAuthCredential | null;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |

--- a/docs-devsite/auth.phoneauthprovider.md
+++ b/docs-devsite/auth.phoneauthprovider.md
@@ -53,7 +53,7 @@ Constructs a new instance of the `PhoneAuthProvider` class
 constructor(auth: Auth);
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -99,7 +99,7 @@ Creates a phone auth credential, given the verification ID from [PhoneAuthProvid
 static credential(verificationId: string, verificationCode: string): PhoneAuthCredential;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -166,7 +166,7 @@ try {
 static credentialFromError(error: FirebaseError): AuthCredential | null;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -186,7 +186,7 @@ Generates an [AuthCredential](./auth.authcredential.md#authcredential_class) fro
 static credentialFromResult(userCredential: UserCredential): AuthCredential | null;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -206,7 +206,7 @@ Starts a phone number authentication flow by sending a verification code to the 
 verifyPhoneNumber(phoneOptions: PhoneInfoOptions | string, applicationVerifier: ApplicationVerifier): Promise<string>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |

--- a/docs-devsite/auth.phonemultifactorgenerator.md
+++ b/docs-devsite/auth.phonemultifactorgenerator.md
@@ -52,7 +52,7 @@ This method does not work in a Node.js environment.
 static assertion(credential: PhoneAuthCredential): PhoneMultiFactorAssertion;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |

--- a/docs-devsite/auth.reactnativeasyncstorage.md
+++ b/docs-devsite/auth.reactnativeasyncstorage.md
@@ -36,7 +36,7 @@ Retrieve an item from storage.
 getItem(key: string): Promise<string | null>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -56,7 +56,7 @@ Remove an item from storage.
 removeItem(key: string): Promise<void>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -76,7 +76,7 @@ Persist an item in storage.
 setItem(key: string, value: string): Promise<void>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |

--- a/docs-devsite/auth.recaptchaverifier.md
+++ b/docs-devsite/auth.recaptchaverifier.md
@@ -53,7 +53,7 @@ Check the reCAPTCHA docs for a comprehensive list. All parameters are accepted e
 constructor(authExtern: Auth, containerOrId: HTMLElement | string, parameters?: RecaptchaParameters);
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |

--- a/docs-devsite/auth.samlauthprovider.md
+++ b/docs-devsite/auth.samlauthprovider.md
@@ -43,7 +43,7 @@ Constructor. The providerId must start with "saml."
 constructor(providerId: string);
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -59,7 +59,7 @@ Used to extract the underlying [OAuthCredential](./auth.oauthcredential.md#oauth
 static credentialFromError(error: FirebaseError): AuthCredential | null;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -79,7 +79,7 @@ Creates an [AuthCredential](./auth.authcredential.md#authcredential_class) from 
 static credentialFromJSON(json: string | object): AuthCredential;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -107,7 +107,7 @@ const credential = SAMLAuthProvider.credentialFromResult(userCredential);
 static credentialFromResult(userCredential: UserCredential): AuthCredential | null;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |

--- a/docs-devsite/auth.totpmultifactorgenerator.md
+++ b/docs-devsite/auth.totpmultifactorgenerator.md
@@ -52,7 +52,7 @@ Provides a [TotpMultiFactorAssertion](./auth.totpmultifactorassertion.md#totpmul
 static assertionForEnrollment(secret: TotpSecret, oneTimePassword: string): TotpMultiFactorAssertion;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -75,7 +75,7 @@ Provides a [TotpMultiFactorAssertion](./auth.totpmultifactorassertion.md#totpmul
 static assertionForSignIn(enrollmentId: string, oneTimePassword: string): TotpMultiFactorAssertion;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -98,7 +98,7 @@ Returns a promise to [TotpSecret](./auth.totpsecret.md#totpsecret_class) which c
 static generateSecret(session: MultiFactorSession): Promise<TotpSecret>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |

--- a/docs-devsite/auth.totpsecret.md
+++ b/docs-devsite/auth.totpsecret.md
@@ -96,7 +96,7 @@ Returns a QR code URL as described in https://github.com/google/google-authentic
 generateQrCodeUrl(accountName?: string, issuer?: string): string;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |

--- a/docs-devsite/auth.twitterauthprovider.md
+++ b/docs-devsite/auth.twitterauthprovider.md
@@ -80,7 +80,7 @@ Creates a credential for Twitter.
 static credential(token: string, secret: string): OAuthCredential;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -101,7 +101,7 @@ Used to extract the underlying [OAuthCredential](./auth.oauthcredential.md#oauth
 static credentialFromError(error: FirebaseError): OAuthCredential | null;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -121,7 +121,7 @@ Used to extract the underlying [OAuthCredential](./auth.oauthcredential.md#oauth
 static credentialFromResult(userCredential: UserCredential): OAuthCredential | null;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |

--- a/docs-devsite/auth.user.md
+++ b/docs-devsite/auth.user.md
@@ -142,7 +142,7 @@ Returns the current token if it has not expired or if it will not expire in the 
 getIdToken(forceRefresh?: boolean): Promise<string>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -164,7 +164,7 @@ Returns the current token if it has not expired or if it will not expire in the 
 getIdTokenResult(forceRefresh?: boolean): Promise<IdTokenResult>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |

--- a/docs-devsite/database.datasnapshot.md
+++ b/docs-devsite/database.datasnapshot.md
@@ -100,7 +100,7 @@ Passing a relative path to the `child()` method of a DataSnapshot returns anothe
 child(path: string): DataSnapshot;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -154,7 +154,7 @@ If no explicit `orderBy*()` method is used, results are returned ordered by key 
 forEach(action: (child: IteratedDataSnapshot) => boolean | void): boolean;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -176,7 +176,7 @@ Returns true if the specified child path has (non-null) data.
 hasChild(path: string): boolean;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |

--- a/docs-devsite/database.md
+++ b/docs-devsite/database.md
@@ -16,9 +16,9 @@ Firebase Realtime Database
 
 |  Function | Description |
 |  --- | --- |
-|  <b>function(app...)</b> |
+|  <b>function(app, ...)</b> |
 |  [getDatabase(app, url)](./database.md#getdatabase_d9cea01) | Returns the instance of the Realtime Database SDK that is associated with the provided [FirebaseApp](./app.firebaseapp.md#firebaseapp_interface)<!-- -->. Initializes a new instance with with default settings if no instance exists or if the existing instance uses a custom database URL. |
-|  <b>function(db...)</b> |
+|  <b>function(db, ...)</b> |
 |  [connectDatabaseEmulator(db, host, port, options)](./database.md#connectdatabaseemulator_27b9e93) | Modify the provided instance to communicate with the Realtime Database emulator.<p>Note: This method must be called before performing any other operation. |
 |  [goOffline(db)](./database.md#gooffline_732b338) | Disconnects from the server (all Database operations will be completed offline).<!-- -->The client automatically maintains a persistent connection to the Database server, which will remain active indefinitely and reconnect when disconnected. However, the <code>goOffline()</code> and <code>goOnline()</code> methods may be used to control the client connection in cases where a persistent connection is undesirable.<!-- -->While offline, the client will no longer receive data updates from the Database. However, all Database operations performed locally will continue to immediately fire events, allowing your application to continue behaving normally. Additionally, each operation performed locally will automatically be queued and retried upon reconnection to the Database server.<!-- -->To reconnect to the Database and begin receiving remote events, see <code>goOnline()</code>. |
 |  [goOnline(db)](./database.md#goonline_732b338) | Reconnects to the server and synchronizes the offline Database state with the server state.<!-- -->This method should be used after disabling the active connection with <code>goOffline()</code>. Once reconnected, the client will transmit the proper data and fire the appropriate events so that your client "catches up" automatically. |
@@ -31,21 +31,21 @@ Firebase Realtime Database
 |  [orderByPriority()](./database.md#orderbypriority) | Creates a new <code>QueryConstraint</code> that orders by priority.<!-- -->Applications need not use priority but can order collections by ordinary properties (see [Sort data](https://firebase.google.com/docs/database/web/lists-of-data#sort_data) for alternatives to priority. |
 |  [orderByValue()](./database.md#orderbyvalue) | Creates a new <code>QueryConstraint</code> that orders by value.<!-- -->If the children of a query are all scalar values (string, number, or boolean), you can order the results by their (ascending) values.<!-- -->You can read more about <code>orderByValue()</code> in [Sort data](https://firebase.google.com/docs/database/web/lists-of-data#sort_data)<!-- -->. |
 |  [serverTimestamp()](./database.md#servertimestamp) | Returns a placeholder value for auto-populating the current timestamp (time since the Unix epoch, in milliseconds) as determined by the Firebase servers. |
-|  <b>function(delta...)</b> |
+|  <b>function(delta, ...)</b> |
 |  [increment(delta)](./database.md#increment_1a4266e) | Returns a placeholder value that can be used to atomically increment the current database value by the provided delta. |
-|  <b>function(enabled...)</b> |
+|  <b>function(enabled, ...)</b> |
 |  [enableLogging(enabled, persistent)](./database.md#enablelogging_cd4f840) | Logs debugging information to the console. |
-|  <b>function(limit...)</b> |
+|  <b>function(limit, ...)</b> |
 |  [limitToFirst(limit)](./database.md#limittofirst_ec46c78) | Creates a new <code>QueryConstraint</code> that if limited to the first specific number of children.<!-- -->The <code>limitToFirst()</code> method is used to set a maximum number of children to be synced for a given callback. If we set a limit of 100, we will initially only receive up to 100 <code>child_added</code> events. If we have fewer than 100 messages stored in our Database, a <code>child_added</code> event will fire for each message. However, if we have over 100 messages, we will only receive a <code>child_added</code> event for the first 100 ordered messages. As items change, we will receive <code>child_removed</code> events for each item that drops out of the active list so that the total number stays at 100.<!-- -->You can read more about <code>limitToFirst()</code> in [Filtering data](https://firebase.google.com/docs/database/web/lists-of-data#filtering_data)<!-- -->. |
 |  [limitToLast(limit)](./database.md#limittolast_ec46c78) | Creates a new <code>QueryConstraint</code> that is limited to return only the last specified number of children.<!-- -->The <code>limitToLast()</code> method is used to set a maximum number of children to be synced for a given callback. If we set a limit of 100, we will initially only receive up to 100 <code>child_added</code> events. If we have fewer than 100 messages stored in our Database, a <code>child_added</code> event will fire for each message. However, if we have over 100 messages, we will only receive a <code>child_added</code> event for the last 100 ordered messages. As items change, we will receive <code>child_removed</code> events for each item that drops out of the active list so that the total number stays at 100.<!-- -->You can read more about <code>limitToLast()</code> in [Filtering data](https://firebase.google.com/docs/database/web/lists-of-data#filtering_data)<!-- -->. |
-|  <b>function(logger...)</b> |
+|  <b>function(logger, ...)</b> |
 |  [enableLogging(logger)](./database.md#enablelogging_3886555) | Logs debugging information to the console. |
-|  <b>function(parent...)</b> |
+|  <b>function(parent, ...)</b> |
 |  [child(parent, path)](./database.md#child_28a1a9f) | Gets a <code>Reference</code> for the location at the specified relative path.<!-- -->The relative path can either be a simple child name (for example, "ada") or a deeper slash-separated path (for example, "ada/name/first"). |
 |  [push(parent, value)](./database.md#push_c74661c) | Generates a new child location using a unique key and returns its <code>Reference</code>.<!-- -->This is the most common pattern for adding data to a collection of items.<!-- -->If you provide a value to <code>push()</code>, the value is written to the generated location. If you don't pass a value, nothing is written to the database and the child remains empty (but you can use the <code>Reference</code> elsewhere).<!-- -->The unique keys generated by <code>push()</code> are ordered by the current time, so the resulting list of items is chronologically sorted. The keys are also designed to be unguessable (they contain 72 random bits of entropy).<!-- -->See [Append to a list of data](https://firebase.google.com/docs/database/web/lists-of-data#append_to_a_list_of_data)<!-- -->. See [The 2^120 Ways to Ensure Unique Identifiers](https://firebase.googleblog.com/2015/02/the-2120-ways-to-ensure-unique_68.html)<!-- -->. |
-|  <b>function(path...)</b> |
+|  <b>function(path, ...)</b> |
 |  [orderByChild(path)](./database.md#orderbychild_fe1f8e4) | Creates a new <code>QueryConstraint</code> that orders by the specified child key.<!-- -->Queries can only order by one key at a time. Calling <code>orderByChild()</code> multiple times on the same query is an error.<!-- -->Firebase queries allow you to order your data by any child key on the fly. However, if you know in advance what your indexes will be, you can define them via the .indexOn rule in your Security Rules for better performance. See the[https://firebase.google.com/docs/database/security/indexing-data](https://firebase.google.com/docs/database/security/indexing-data) rule for more information.<!-- -->You can read more about <code>orderByChild()</code> in [Sort data](https://firebase.google.com/docs/database/web/lists-of-data#sort_data)<!-- -->. |
-|  <b>function(query...)</b> |
+|  <b>function(query, ...)</b> |
 |  [get(query)](./database.md#get_20b2416) | Gets the most up-to-date result for this query. |
 |  [off(query, eventType, callback)](./database.md#off_17bb961) | Detaches a callback previously attached with the corresponding <code>on*()</code> (<code>onValue</code>, <code>onChildAdded</code>) listener. Note: This is not the recommended way to remove a listener. Instead, please use the returned callback function from the respective <code>on*</code> callbacks.<!-- -->Detach a callback previously attached with <code>on*()</code>. Calling <code>off()</code> on a parent listener will not automatically remove listeners registered on child nodes, <code>off()</code> must also be called on any child listeners to remove the callback.<!-- -->If a callback is not specified, all callbacks for the specified eventType will be removed. Similarly, if no eventType is specified, all callbacks for the <code>Reference</code> will be removed.<!-- -->Individual listeners can also be removed by invoking their unsubscribe callbacks. |
 |  [onChildAdded(query, callback, cancelCallback)](./database.md#onchildadded_139c747) | Listens for data changes at a particular location.<!-- -->This is the primary way to read data from a Database. Your callback will be triggered for the initial data and again whenever the data changes. Invoke the returned unsubscribe callback to stop receiving updates. See [Retrieve Data on the Web](https://firebase.google.com/docs/database/web/retrieve-data) for more details.<!-- -->An <code>onChildAdded</code> event will be triggered once for each initial child at this location, and it will be triggered again every time a new child is added. The <code>DataSnapshot</code> passed into the callback will reflect the data for the relevant child. For ordering purposes, it is passed a second argument which is a string containing the key of the previous sibling child by sort order, or <code>null</code> if it is the first child. |
@@ -64,7 +64,7 @@ Firebase Realtime Database
 |  [onValue(query, callback, options)](./database.md#onvalue_7357cb6) | Listens for data changes at a particular location.<!-- -->This is the primary way to read data from a Database. Your callback will be triggered for the initial data and again whenever the data changes. Invoke the returned unsubscribe callback to stop receiving updates. See [Retrieve Data on the Web](https://firebase.google.com/docs/database/web/retrieve-data) for more details.<!-- -->An <code>onValue</code> event will trigger once with the initial data stored at this location, and then trigger again each time the data changes. The <code>DataSnapshot</code> passed to the callback will be for the location at which <code>on()</code> was called. It won't trigger until the entire contents has been synchronized. If the location has no data, it will be triggered with an empty <code>DataSnapshot</code> (<code>val()</code> will return <code>null</code>). |
 |  [onValue(query, callback, cancelCallback, options)](./database.md#onvalue_e66d5b6) | Listens for data changes at a particular location.<!-- -->This is the primary way to read data from a Database. Your callback will be triggered for the initial data and again whenever the data changes. Invoke the returned unsubscribe callback to stop receiving updates. See [Retrieve Data on the Web](https://firebase.google.com/docs/database/web/retrieve-data) for more details.<!-- -->An <code>onValue</code> event will trigger once with the initial data stored at this location, and then trigger again each time the data changes. The <code>DataSnapshot</code> passed to the callback will be for the location at which <code>on()</code> was called. It won't trigger until the entire contents has been synchronized. If the location has no data, it will be triggered with an empty <code>DataSnapshot</code> (<code>val()</code> will return <code>null</code>). |
 |  [query(query, queryConstraints)](./database.md#query_870e07a) | Creates a new immutable instance of <code>Query</code> that is extended to also include additional query constraints. |
-|  <b>function(ref...)</b> |
+|  <b>function(ref, ...)</b> |
 |  [onDisconnect(ref)](./database.md#ondisconnect_8616c19) | Returns an <code>OnDisconnect</code> object - see [Enabling Offline Capabilities in JavaScript](https://firebase.google.com/docs/database/web/offline-capabilities) for more information on how to use it. |
 |  [remove(ref)](./database.md#remove_8616c19) | Removes the data at this Database location.<!-- -->Any data at child locations will also be deleted.<!-- -->The effect of the remove will be visible immediately and the corresponding event 'value' will be triggered. Synchronization of the remove to the Firebase servers will also be started, and the returned Promise will resolve when complete. If provided, the onComplete callback will be called asynchronously after synchronization has finished. |
 |  [runTransaction(ref, transactionUpdate, options)](./database.md#runtransaction_a3641e5) | Atomically modifies the data at this location.<!-- -->Atomically modify the data at this location. Unlike a normal <code>set()</code>, which just overwrites the data regardless of its previous value, <code>runTransaction()</code> is used to modify the existing value to a new value, ensuring there are no conflicts with other clients writing to the same location at the same time.<!-- -->To accomplish this, you pass <code>runTransaction()</code> an update function which is used to transform the current value into a new value. If another client writes to the location before your new value is successfully written, your update function will be called again with the new current value, and the write will be retried. This will happen repeatedly until your write succeeds without conflict or you abort the transaction by not returning a value from your update function.<!-- -->Note: Modifying data with <code>set()</code> will cancel any pending transactions at that location, so extreme care should be taken if mixing <code>set()</code> and <code>runTransaction()</code> to update the same data.<!-- -->Note: When using transactions with Security and Firebase Rules in place, be aware that a client needs <code>.read</code> access in addition to <code>.write</code> access in order to perform a transaction. This is because the client-side nature of transactions requires the client to read the data in order to transactionally update it. |
@@ -72,7 +72,7 @@ Firebase Realtime Database
 |  [setPriority(ref, priority)](./database.md#setpriority_f979832) | Sets a priority for the data at this Database location.<!-- -->Applications need not use priority but can order collections by ordinary properties (see [Sorting and filtering data](https://firebase.google.com/docs/database/web/lists-of-data#sorting_and_filtering_data) ). |
 |  [setWithPriority(ref, value, priority)](./database.md#setwithpriority_dc560e7) | Writes data the Database location. Like <code>set()</code> but also specifies the priority for that data.<!-- -->Applications need not use priority but can order collections by ordinary properties (see [Sorting and filtering data](https://firebase.google.com/docs/database/web/lists-of-data#sorting_and_filtering_data) ). |
 |  [update(ref, values)](./database.md#update_06756b7) | Writes multiple values to the Database at once.<!-- -->The <code>values</code> argument contains multiple property-value pairs that will be written to the Database together. Each child property can either be a simple property (for example, "name") or a relative path (for example, "name/first") from the current location to the data to update.<!-- -->As opposed to the <code>set()</code> method, <code>update()</code> can be use to selectively update only the referenced properties at the current location (instead of replacing all the child properties at the current location).<!-- -->The effect of the write will be visible immediately, and the corresponding events ('value', 'child\_added', etc.) will be triggered. Synchronization of the data to the Firebase servers will also be started, and the returned Promise will resolve when complete. If provided, the <code>onComplete</code> callback will be called asynchronously after synchronization has finished.<!-- -->A single <code>update()</code> will generate a single "value" event at the location where the <code>update()</code> was performed, regardless of how many children were modified.<!-- -->Note that modifying data with <code>update()</code> will cancel any pending transactions at that location, so extreme care should be taken if mixing <code>update()</code> and <code>transaction()</code> to modify the same data.<!-- -->Passing <code>null</code> to <code>update()</code> will remove the data at this location.<!-- -->See [Introducing multi-location updates and more](https://firebase.googleblog.com/2015/09/introducing-multi-location-updates-and_86.html)<!-- -->. |
-|  <b>function(value...)</b> |
+|  <b>function(value, ...)</b> |
 |  [endAt(value, key)](./database.md#endat_51c2c8b) | Creates a <code>QueryConstraint</code> with the specified ending point.<!-- -->Using <code>startAt()</code>, <code>startAfter()</code>, <code>endBefore()</code>, <code>endAt()</code> and <code>equalTo()</code> allows you to choose arbitrary starting and ending points for your queries.<!-- -->The ending point is inclusive, so children with exactly the specified value will be included in the query. The optional key argument can be used to further limit the range of the query. If it is specified, then children that have exactly the specified value must also have a key name less than or equal to the specified key.<!-- -->You can read more about <code>endAt()</code> in [Filtering data](https://firebase.google.com/docs/database/web/lists-of-data#filtering_data)<!-- -->. |
 |  [endBefore(value, key)](./database.md#endbefore_51c2c8b) | Creates a <code>QueryConstraint</code> with the specified ending point (exclusive).<!-- -->Using <code>startAt()</code>, <code>startAfter()</code>, <code>endBefore()</code>, <code>endAt()</code> and <code>equalTo()</code> allows you to choose arbitrary starting and ending points for your queries.<!-- -->The ending point is exclusive. If only a value is provided, children with a value less than the specified value will be included in the query. If a key is specified, then children must have a value less than or equal to the specified value and a key name less than the specified key. |
 |  [equalTo(value, key)](./database.md#equalto_51c2c8b) | Creates a <code>QueryConstraint</code> that includes children that match the specified value.<!-- -->Using <code>startAt()</code>, <code>startAfter()</code>, <code>endBefore()</code>, <code>endAt()</code> and <code>equalTo()</code> allows you to choose arbitrary starting and ending points for your queries.<!-- -->The optional key argument can be used to further limit the range of the query. If it is specified, then children that have exactly the specified value must also have exactly the specified key as their key name. This can be used to filter result sets with many matches for the same value.<!-- -->You can read more about <code>equalTo()</code> in [Filtering data](https://firebase.google.com/docs/database/web/lists-of-data#filtering_data)<!-- -->. |
@@ -108,7 +108,9 @@ Firebase Realtime Database
 |  [QueryConstraintType](./database.md#queryconstrainttype) | Describes the different query constraints available in this SDK. |
 |  [Unsubscribe](./database.md#unsubscribe) | A callback that can invoked to remove a listener. |
 
-## getDatabase() {:#getdatabase_d9cea01}
+## function(app, ...)
+
+### getDatabase(app, url) {:#getdatabase_d9cea01}
 
 Returns the instance of the Realtime Database SDK that is associated with the provided [FirebaseApp](./app.firebaseapp.md#firebaseapp_interface)<!-- -->. Initializes a new instance with with default settings if no instance exists or if the existing instance uses a custom database URL.
 
@@ -118,7 +120,7 @@ Returns the instance of the Realtime Database SDK that is associated with the pr
 export declare function getDatabase(app?: FirebaseApp, url?: string): Database;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -131,7 +133,9 @@ export declare function getDatabase(app?: FirebaseApp, url?: string): Database;
 
 The `Database` instance of the provided app.
 
-## connectDatabaseEmulator() {:#connectdatabaseemulator_27b9e93}
+## function(db, ...)
+
+### connectDatabaseEmulator(db, host, port, options) {:#connectdatabaseemulator_27b9e93}
 
 Modify the provided instance to communicate with the Realtime Database emulator.
 
@@ -145,7 +149,7 @@ export declare function connectDatabaseEmulator(db: Database, host: string, port
 }): void;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -158,7 +162,7 @@ export declare function connectDatabaseEmulator(db: Database, host: string, port
 
 void
 
-## goOffline() {:#gooffline_732b338}
+### goOffline(db) {:#gooffline_732b338}
 
 Disconnects from the server (all Database operations will be completed offline).
 
@@ -174,7 +178,7 @@ To reconnect to the Database and begin receiving remote events, see `goOnline()`
 export declare function goOffline(db: Database): void;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -184,7 +188,7 @@ export declare function goOffline(db: Database): void;
 
 void
 
-## goOnline() {:#goonline_732b338}
+### goOnline(db) {:#goonline_732b338}
 
 Reconnects to the server and synchronizes the offline Database state with the server state.
 
@@ -196,7 +200,7 @@ This method should be used after disabling the active connection with `goOffline
 export declare function goOnline(db: Database): void;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -206,7 +210,7 @@ export declare function goOnline(db: Database): void;
 
 void
 
-## ref() {:#ref_5f88fa2}
+### ref(db, path) {:#ref_5f88fa2}
 
 Returns a `Reference` representing the location in the Database corresponding to the provided path. If no path is provided, the `Reference` will point to the root of the Database.
 
@@ -216,7 +220,7 @@ Returns a `Reference` representing the location in the Database corresponding to
 export declare function ref(db: Database, path?: string): DatabaseReference;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -229,7 +233,7 @@ export declare function ref(db: Database, path?: string): DatabaseReference;
 
 If a path is provided, a `Reference` pointing to the provided path. Otherwise, a `Reference` pointing to the root of the Database.
 
-## refFromURL() {:#reffromurl_98d95ad}
+### refFromURL(db, url) {:#reffromurl_98d95ad}
 
 Returns a `Reference` representing the location in the Database corresponding to the provided Firebase URL.
 
@@ -243,7 +247,7 @@ Note that all query parameters (`orderBy`<!-- -->, `limitToLast`<!-- -->, etc.) 
 export declare function refFromURL(db: Database, url: string): DatabaseReference;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -256,7 +260,9 @@ export declare function refFromURL(db: Database, url: string): DatabaseReference
 
 A `Reference` pointing to the provided Firebase URL.
 
-## forceLongPolling() {:#forcelongpolling}
+## function()
+
+### forceLongPolling() {:#forcelongpolling}
 
 Force the use of longPolling instead of websockets. This will be ignored if websocket protocol is used in databaseURL.
 
@@ -269,7 +275,7 @@ export declare function forceLongPolling(): void;
 
 void
 
-## forceWebSockets() {:#forcewebsockets}
+### forceWebSockets() {:#forcewebsockets}
 
 Force the use of websockets instead of longPolling.
 
@@ -282,7 +288,7 @@ export declare function forceWebSockets(): void;
 
 void
 
-## orderByKey() {:#orderbykey}
+### orderByKey() {:#orderbykey}
 
 Creates a new `QueryConstraint` that orders by the key.
 
@@ -299,7 +305,7 @@ export declare function orderByKey(): QueryConstraint;
 
 [QueryConstraint](./database.queryconstraint.md#queryconstraint_class)
 
-## orderByPriority() {:#orderbypriority}
+### orderByPriority() {:#orderbypriority}
 
 Creates a new `QueryConstraint` that orders by priority.
 
@@ -314,7 +320,7 @@ export declare function orderByPriority(): QueryConstraint;
 
 [QueryConstraint](./database.queryconstraint.md#queryconstraint_class)
 
-## orderByValue() {:#orderbyvalue}
+### orderByValue() {:#orderbyvalue}
 
 Creates a new `QueryConstraint` that orders by value.
 
@@ -331,7 +337,7 @@ export declare function orderByValue(): QueryConstraint;
 
 [QueryConstraint](./database.queryconstraint.md#queryconstraint_class)
 
-## serverTimestamp() {:#servertimestamp}
+### serverTimestamp() {:#servertimestamp}
 
 Returns a placeholder value for auto-populating the current timestamp (time since the Unix epoch, in milliseconds) as determined by the Firebase servers.
 
@@ -344,7 +350,9 @@ export declare function serverTimestamp(): object;
 
 object
 
-## increment() {:#increment_1a4266e}
+## function(delta, ...)
+
+### increment(delta) {:#increment_1a4266e}
 
 Returns a placeholder value that can be used to atomically increment the current database value by the provided delta.
 
@@ -354,7 +362,7 @@ Returns a placeholder value that can be used to atomically increment the current
 export declare function increment(delta: number): object;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -366,7 +374,9 @@ object
 
 A placeholder value for modifying data atomically server-side.
 
-## enableLogging() {:#enablelogging_cd4f840}
+## function(enabled, ...)
+
+### enableLogging(enabled, persistent) {:#enablelogging_cd4f840}
 
 Logs debugging information to the console.
 
@@ -376,7 +386,7 @@ Logs debugging information to the console.
 export declare function enableLogging(enabled: boolean, persistent?: boolean): any;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -387,7 +397,9 @@ export declare function enableLogging(enabled: boolean, persistent?: boolean): a
 
 any
 
-## limitToFirst() {:#limittofirst_ec46c78}
+## function(limit, ...)
+
+### limitToFirst(limit) {:#limittofirst_ec46c78}
 
 Creates a new `QueryConstraint` that if limited to the first specific number of children.
 
@@ -401,7 +413,7 @@ You can read more about `limitToFirst()` in [Filtering data](https://firebase.go
 export declare function limitToFirst(limit: number): QueryConstraint;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -411,7 +423,7 @@ export declare function limitToFirst(limit: number): QueryConstraint;
 
 [QueryConstraint](./database.queryconstraint.md#queryconstraint_class)
 
-## limitToLast() {:#limittolast_ec46c78}
+### limitToLast(limit) {:#limittolast_ec46c78}
 
 Creates a new `QueryConstraint` that is limited to return only the last specified number of children.
 
@@ -425,7 +437,7 @@ You can read more about `limitToLast()` in [Filtering data](https://firebase.goo
 export declare function limitToLast(limit: number): QueryConstraint;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -435,7 +447,9 @@ export declare function limitToLast(limit: number): QueryConstraint;
 
 [QueryConstraint](./database.queryconstraint.md#queryconstraint_class)
 
-## enableLogging() {:#enablelogging_3886555}
+## function(logger, ...)
+
+### enableLogging(logger) {:#enablelogging_3886555}
 
 Logs debugging information to the console.
 
@@ -445,7 +459,7 @@ Logs debugging information to the console.
 export declare function enableLogging(logger: (message: string) => unknown): any;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -455,7 +469,9 @@ export declare function enableLogging(logger: (message: string) => unknown): any
 
 any
 
-## child() {:#child_28a1a9f}
+## function(parent, ...)
+
+### child(parent, path) {:#child_28a1a9f}
 
 Gets a `Reference` for the location at the specified relative path.
 
@@ -467,7 +483,7 @@ The relative path can either be a simple child name (for example, "ada") or a de
 export declare function child(parent: DatabaseReference, path: string): DatabaseReference;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -480,7 +496,7 @@ export declare function child(parent: DatabaseReference, path: string): Database
 
 The specified child location.
 
-## push() {:#push_c74661c}
+### push(parent, value) {:#push_c74661c}
 
 Generates a new child location using a unique key and returns its `Reference`<!-- -->.
 
@@ -498,7 +514,7 @@ See [Append to a list of data](https://firebase.google.com/docs/database/web/lis
 export declare function push(parent: DatabaseReference, value?: unknown): ThenableReference;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -511,7 +527,9 @@ export declare function push(parent: DatabaseReference, value?: unknown): Thenab
 
 Combined `Promise` and `Reference`<!-- -->; resolves when write is complete, but can be used immediately as the `Reference` to the child location.
 
-## orderByChild() {:#orderbychild_fe1f8e4}
+## function(path, ...)
+
+### orderByChild(path) {:#orderbychild_fe1f8e4}
 
 Creates a new `QueryConstraint` that orders by the specified child key.
 
@@ -527,7 +545,7 @@ You can read more about `orderByChild()` in [Sort data](https://firebase.google.
 export declare function orderByChild(path: string): QueryConstraint;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -537,7 +555,9 @@ export declare function orderByChild(path: string): QueryConstraint;
 
 [QueryConstraint](./database.queryconstraint.md#queryconstraint_class)
 
-## get() {:#get_20b2416}
+## function(query, ...)
+
+### get(query) {:#get_20b2416}
 
 Gets the most up-to-date result for this query.
 
@@ -547,7 +567,7 @@ Gets the most up-to-date result for this query.
 export declare function get(query: Query): Promise<DataSnapshot>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -559,7 +579,7 @@ Promise&lt;[DataSnapshot](./database.datasnapshot.md#datasnapshot_class)<!-- -->
 
 A `Promise` which resolves to the resulting DataSnapshot if a value is available, or rejects if the client is unable to return a value (e.g., if the server is unreachable and there is nothing cached).
 
-## off() {:#off_17bb961}
+### off(query, eventType, callback) {:#off_17bb961}
 
 Detaches a callback previously attached with the corresponding `on*()` (`onValue`<!-- -->, `onChildAdded`<!-- -->) listener. Note: This is not the recommended way to remove a listener. Instead, please use the returned callback function from the respective `on*` callbacks.
 
@@ -575,7 +595,7 @@ Individual listeners can also be removed by invoking their unsubscribe callbacks
 export declare function off(query: Query, eventType?: EventType, callback?: (snapshot: DataSnapshot, previousChildName?: string | null) => unknown): void;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -587,7 +607,7 @@ export declare function off(query: Query, eventType?: EventType, callback?: (sna
 
 void
 
-## onChildAdded() {:#onchildadded_139c747}
+### onChildAdded(query, callback, cancelCallback) {:#onchildadded_139c747}
 
 Listens for data changes at a particular location.
 
@@ -601,7 +621,7 @@ An `onChildAdded` event will be triggered once for each initial child at this lo
 export declare function onChildAdded(query: Query, callback: (snapshot: DataSnapshot, previousChildName?: string | null) => unknown, cancelCallback?: (error: Error) => unknown): Unsubscribe;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -615,7 +635,7 @@ export declare function onChildAdded(query: Query, callback: (snapshot: DataSnap
 
 A function that can be invoked to remove the listener.
 
-## onChildAdded() {:#onchildadded_cf4f177}
+### onChildAdded(query, callback, options) {:#onchildadded_cf4f177}
 
 Listens for data changes at a particular location.
 
@@ -629,7 +649,7 @@ An `onChildAdded` event will be triggered once for each initial child at this lo
 export declare function onChildAdded(query: Query, callback: (snapshot: DataSnapshot, previousChildName: string | null) => unknown, options: ListenOptions): Unsubscribe;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -643,7 +663,7 @@ export declare function onChildAdded(query: Query, callback: (snapshot: DataSnap
 
 A function that can be invoked to remove the listener.
 
-## onChildAdded() {:#onchildadded_456d092}
+### onChildAdded(query, callback, cancelCallback, options) {:#onchildadded_456d092}
 
 Listens for data changes at a particular location.
 
@@ -657,7 +677,7 @@ An `onChildAdded` event will be triggered once for each initial child at this lo
 export declare function onChildAdded(query: Query, callback: (snapshot: DataSnapshot, previousChildName: string | null) => unknown, cancelCallback: (error: Error) => unknown, options: ListenOptions): Unsubscribe;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -672,7 +692,7 @@ export declare function onChildAdded(query: Query, callback: (snapshot: DataSnap
 
 A function that can be invoked to remove the listener.
 
-## onChildChanged() {:#onchildchanged_c1edf58}
+### onChildChanged(query, callback, cancelCallback) {:#onchildchanged_c1edf58}
 
 Listens for data changes at a particular location.
 
@@ -686,7 +706,7 @@ An `onChildChanged` event will be triggered when the data stored in a child (or 
 export declare function onChildChanged(query: Query, callback: (snapshot: DataSnapshot, previousChildName: string | null) => unknown, cancelCallback?: (error: Error) => unknown): Unsubscribe;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -700,7 +720,7 @@ export declare function onChildChanged(query: Query, callback: (snapshot: DataSn
 
 A function that can be invoked to remove the listener.
 
-## onChildChanged() {:#onchildchanged_cf4f177}
+### onChildChanged(query, callback, options) {:#onchildchanged_cf4f177}
 
 Listens for data changes at a particular location.
 
@@ -714,7 +734,7 @@ An `onChildChanged` event will be triggered when the data stored in a child (or 
 export declare function onChildChanged(query: Query, callback: (snapshot: DataSnapshot, previousChildName: string | null) => unknown, options: ListenOptions): Unsubscribe;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -728,7 +748,7 @@ export declare function onChildChanged(query: Query, callback: (snapshot: DataSn
 
 A function that can be invoked to remove the listener.
 
-## onChildChanged() {:#onchildchanged_456d092}
+### onChildChanged(query, callback, cancelCallback, options) {:#onchildchanged_456d092}
 
 Listens for data changes at a particular location.
 
@@ -742,7 +762,7 @@ An `onChildChanged` event will be triggered when the data stored in a child (or 
 export declare function onChildChanged(query: Query, callback: (snapshot: DataSnapshot, previousChildName: string | null) => unknown, cancelCallback: (error: Error) => unknown, options: ListenOptions): Unsubscribe;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -757,7 +777,7 @@ export declare function onChildChanged(query: Query, callback: (snapshot: DataSn
 
 A function that can be invoked to remove the listener.
 
-## onChildMoved() {:#onchildmoved_c1edf58}
+### onChildMoved(query, callback, cancelCallback) {:#onchildmoved_c1edf58}
 
 Listens for data changes at a particular location.
 
@@ -771,7 +791,7 @@ An `onChildMoved` event will be triggered when a child's sort order changes such
 export declare function onChildMoved(query: Query, callback: (snapshot: DataSnapshot, previousChildName: string | null) => unknown, cancelCallback?: (error: Error) => unknown): Unsubscribe;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -785,7 +805,7 @@ export declare function onChildMoved(query: Query, callback: (snapshot: DataSnap
 
 A function that can be invoked to remove the listener.
 
-## onChildMoved() {:#onchildmoved_cf4f177}
+### onChildMoved(query, callback, options) {:#onchildmoved_cf4f177}
 
 Listens for data changes at a particular location.
 
@@ -799,7 +819,7 @@ An `onChildMoved` event will be triggered when a child's sort order changes such
 export declare function onChildMoved(query: Query, callback: (snapshot: DataSnapshot, previousChildName: string | null) => unknown, options: ListenOptions): Unsubscribe;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -813,7 +833,7 @@ export declare function onChildMoved(query: Query, callback: (snapshot: DataSnap
 
 A function that can be invoked to remove the listener.
 
-## onChildMoved() {:#onchildmoved_456d092}
+### onChildMoved(query, callback, cancelCallback, options) {:#onchildmoved_456d092}
 
 Listens for data changes at a particular location.
 
@@ -827,7 +847,7 @@ An `onChildMoved` event will be triggered when a child's sort order changes such
 export declare function onChildMoved(query: Query, callback: (snapshot: DataSnapshot, previousChildName: string | null) => unknown, cancelCallback: (error: Error) => unknown, options: ListenOptions): Unsubscribe;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -842,7 +862,7 @@ export declare function onChildMoved(query: Query, callback: (snapshot: DataSnap
 
 A function that can be invoked to remove the listener.
 
-## onChildRemoved() {:#onchildremoved_47c1ae9}
+### onChildRemoved(query, callback, cancelCallback) {:#onchildremoved_47c1ae9}
 
 Listens for data changes at a particular location.
 
@@ -858,7 +878,7 @@ An `onChildRemoved` event will be triggered once every time a child is removed. 
 export declare function onChildRemoved(query: Query, callback: (snapshot: DataSnapshot) => unknown, cancelCallback?: (error: Error) => unknown): Unsubscribe;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -872,7 +892,7 @@ export declare function onChildRemoved(query: Query, callback: (snapshot: DataSn
 
 A function that can be invoked to remove the listener.
 
-## onChildRemoved() {:#onchildremoved_7357cb6}
+### onChildRemoved(query, callback, options) {:#onchildremoved_7357cb6}
 
 Listens for data changes at a particular location.
 
@@ -888,7 +908,7 @@ An `onChildRemoved` event will be triggered once every time a child is removed. 
 export declare function onChildRemoved(query: Query, callback: (snapshot: DataSnapshot) => unknown, options: ListenOptions): Unsubscribe;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -902,7 +922,7 @@ export declare function onChildRemoved(query: Query, callback: (snapshot: DataSn
 
 A function that can be invoked to remove the listener.
 
-## onChildRemoved() {:#onchildremoved_e66d5b6}
+### onChildRemoved(query, callback, cancelCallback, options) {:#onchildremoved_e66d5b6}
 
 Listens for data changes at a particular location.
 
@@ -918,7 +938,7 @@ An `onChildRemoved` event will be triggered once every time a child is removed. 
 export declare function onChildRemoved(query: Query, callback: (snapshot: DataSnapshot) => unknown, cancelCallback: (error: Error) => unknown, options: ListenOptions): Unsubscribe;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -933,7 +953,7 @@ export declare function onChildRemoved(query: Query, callback: (snapshot: DataSn
 
 A function that can be invoked to remove the listener.
 
-## onValue() {:#onvalue_47c1ae9}
+### onValue(query, callback, cancelCallback) {:#onvalue_47c1ae9}
 
 Listens for data changes at a particular location.
 
@@ -947,7 +967,7 @@ An `onValue` event will trigger once with the initial data stored at this locati
 export declare function onValue(query: Query, callback: (snapshot: DataSnapshot) => unknown, cancelCallback?: (error: Error) => unknown): Unsubscribe;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -961,7 +981,7 @@ export declare function onValue(query: Query, callback: (snapshot: DataSnapshot)
 
 A function that can be invoked to remove the listener.
 
-## onValue() {:#onvalue_7357cb6}
+### onValue(query, callback, options) {:#onvalue_7357cb6}
 
 Listens for data changes at a particular location.
 
@@ -975,7 +995,7 @@ An `onValue` event will trigger once with the initial data stored at this locati
 export declare function onValue(query: Query, callback: (snapshot: DataSnapshot) => unknown, options: ListenOptions): Unsubscribe;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -989,7 +1009,7 @@ export declare function onValue(query: Query, callback: (snapshot: DataSnapshot)
 
 A function that can be invoked to remove the listener.
 
-## onValue() {:#onvalue_e66d5b6}
+### onValue(query, callback, cancelCallback, options) {:#onvalue_e66d5b6}
 
 Listens for data changes at a particular location.
 
@@ -1003,7 +1023,7 @@ An `onValue` event will trigger once with the initial data stored at this locati
 export declare function onValue(query: Query, callback: (snapshot: DataSnapshot) => unknown, cancelCallback: (error: Error) => unknown, options: ListenOptions): Unsubscribe;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -1018,7 +1038,7 @@ export declare function onValue(query: Query, callback: (snapshot: DataSnapshot)
 
 A function that can be invoked to remove the listener.
 
-## query() {:#query_870e07a}
+### query(query, queryConstraints) {:#query_870e07a}
 
 Creates a new immutable instance of `Query` that is extended to also include additional query constraints.
 
@@ -1028,7 +1048,7 @@ Creates a new immutable instance of `Query` that is extended to also include add
 export declare function query(query: Query, ...queryConstraints: QueryConstraint[]): Query;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -1039,11 +1059,13 @@ export declare function query(query: Query, ...queryConstraints: QueryConstraint
 
 [Query](./database.query.md#query_interface)
 
-## Exceptions
+#### Exceptions
 
 if any of the provided query constraints cannot be combined with the existing or new constraints.
 
-## onDisconnect() {:#ondisconnect_8616c19}
+## function(ref, ...)
+
+### onDisconnect(ref) {:#ondisconnect_8616c19}
 
 Returns an `OnDisconnect` object - see [Enabling Offline Capabilities in JavaScript](https://firebase.google.com/docs/database/web/offline-capabilities) for more information on how to use it.
 
@@ -1053,7 +1075,7 @@ Returns an `OnDisconnect` object - see [Enabling Offline Capabilities in JavaScr
 export declare function onDisconnect(ref: DatabaseReference): OnDisconnect;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -1063,7 +1085,7 @@ export declare function onDisconnect(ref: DatabaseReference): OnDisconnect;
 
 [OnDisconnect](./database.ondisconnect.md#ondisconnect_class)
 
-## remove() {:#remove_8616c19}
+### remove(ref) {:#remove_8616c19}
 
 Removes the data at this Database location.
 
@@ -1077,7 +1099,7 @@ The effect of the remove will be visible immediately and the corresponding event
 export declare function remove(ref: DatabaseReference): Promise<void>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -1089,7 +1111,7 @@ Promise&lt;void&gt;
 
 Resolves when remove on server is complete.
 
-## runTransaction() {:#runtransaction_a3641e5}
+### runTransaction(ref, transactionUpdate, options) {:#runtransaction_a3641e5}
 
 Atomically modifies the data at this location.
 
@@ -1107,7 +1129,7 @@ Note: When using transactions with Security and Firebase Rules in place, be awar
 export declare function runTransaction(ref: DatabaseReference, transactionUpdate: (currentData: any) => unknown, options?: TransactionOptions): Promise<TransactionResult>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -1121,7 +1143,7 @@ Promise&lt;[TransactionResult](./database.transactionresult.md#transactionresult
 
 A `Promise` that can optionally be used instead of the `onComplete` callback to handle success and failure.
 
-## set() {:#set_c9eacde}
+### set(ref, value) {:#set_c9eacde}
 
 Writes data to this Database location.
 
@@ -1143,7 +1165,7 @@ A single `set()` will generate a single "value" event at the location where the 
 export declare function set(ref: DatabaseReference, value: unknown): Promise<void>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -1156,7 +1178,7 @@ Promise&lt;void&gt;
 
 Resolves when write to server is complete.
 
-## setPriority() {:#setpriority_f979832}
+### setPriority(ref, priority) {:#setpriority_f979832}
 
 Sets a priority for the data at this Database location.
 
@@ -1168,7 +1190,7 @@ Applications need not use priority but can order collections by ordinary propert
 export declare function setPriority(ref: DatabaseReference, priority: string | number | null): Promise<void>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -1181,7 +1203,7 @@ Promise&lt;void&gt;
 
 Resolves when write to server is complete.
 
-## setWithPriority() {:#setwithpriority_dc560e7}
+### setWithPriority(ref, value, priority) {:#setwithpriority_dc560e7}
 
 Writes data the Database location. Like `set()` but also specifies the priority for that data.
 
@@ -1193,7 +1215,7 @@ Applications need not use priority but can order collections by ordinary propert
 export declare function setWithPriority(ref: DatabaseReference, value: unknown, priority: string | number | null): Promise<void>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -1207,7 +1229,7 @@ Promise&lt;void&gt;
 
 Resolves when write to server is complete.
 
-## update() {:#update_06756b7}
+### update(ref, values) {:#update_06756b7}
 
 Writes multiple values to the Database at once.
 
@@ -1231,7 +1253,7 @@ See [Introducing multi-location updates and more](https://firebase.googleblog.co
 export declare function update(ref: DatabaseReference, values: object): Promise<void>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -1244,7 +1266,9 @@ Promise&lt;void&gt;
 
 Resolves when update on server is complete.
 
-## endAt() {:#endat_51c2c8b}
+## function(value, ...)
+
+### endAt(value, key) {:#endat_51c2c8b}
 
 Creates a `QueryConstraint` with the specified ending point.
 
@@ -1260,7 +1284,7 @@ You can read more about `endAt()` in [Filtering data](https://firebase.google.co
 export declare function endAt(value: number | string | boolean | null, key?: string): QueryConstraint;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -1271,7 +1295,7 @@ export declare function endAt(value: number | string | boolean | null, key?: str
 
 [QueryConstraint](./database.queryconstraint.md#queryconstraint_class)
 
-## endBefore() {:#endbefore_51c2c8b}
+### endBefore(value, key) {:#endbefore_51c2c8b}
 
 Creates a `QueryConstraint` with the specified ending point (exclusive).
 
@@ -1285,7 +1309,7 @@ The ending point is exclusive. If only a value is provided, children with a valu
 export declare function endBefore(value: number | string | boolean | null, key?: string): QueryConstraint;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -1296,7 +1320,7 @@ export declare function endBefore(value: number | string | boolean | null, key?:
 
 [QueryConstraint](./database.queryconstraint.md#queryconstraint_class)
 
-## equalTo() {:#equalto_51c2c8b}
+### equalTo(value, key) {:#equalto_51c2c8b}
 
 Creates a `QueryConstraint` that includes children that match the specified value.
 
@@ -1312,7 +1336,7 @@ You can read more about `equalTo()` in [Filtering data](https://firebase.google.
 export declare function equalTo(value: number | string | boolean | null, key?: string): QueryConstraint;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -1323,7 +1347,7 @@ export declare function equalTo(value: number | string | boolean | null, key?: s
 
 [QueryConstraint](./database.queryconstraint.md#queryconstraint_class)
 
-## startAfter() {:#startafter_51c2c8b}
+### startAfter(value, key) {:#startafter_51c2c8b}
 
 Creates a `QueryConstraint` with the specified starting point (exclusive).
 
@@ -1337,7 +1361,7 @@ The starting point is exclusive. If only a value is provided, children with a va
 export declare function startAfter(value: number | string | boolean | null, key?: string): QueryConstraint;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -1348,7 +1372,7 @@ export declare function startAfter(value: number | string | boolean | null, key?
 
 [QueryConstraint](./database.queryconstraint.md#queryconstraint_class)
 
-## startAt() {:#startat_51c2c8b}
+### startAt(value, key) {:#startat_51c2c8b}
 
 Creates a `QueryConstraint` with the specified starting point.
 
@@ -1364,7 +1388,7 @@ You can read more about `startAt()` in [Filtering data](https://firebase.google.
 export declare function startAt(value?: number | string | boolean | null, key?: string): QueryConstraint;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |

--- a/docs-devsite/database.ondisconnect.md
+++ b/docs-devsite/database.ondisconnect.md
@@ -80,7 +80,7 @@ Note that `onDisconnect` operations are only triggered once. If you want an oper
 set(value: unknown): Promise<void>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -102,7 +102,7 @@ Ensures the data at this location is set to the specified value and priority whe
 setWithPriority(value: unknown, priority: number | string | null): Promise<void>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -129,7 +129,7 @@ As opposed to the `set()` method, `update()` can be use to selectively update on
 update(values: object): Promise<void>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |

--- a/docs-devsite/database.query.md
+++ b/docs-devsite/database.query.md
@@ -60,7 +60,7 @@ Two `Query` objects are equivalent if they represent the same location, have the
 isEqual(other: Query | null): boolean;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |

--- a/docs-devsite/firestore_.bytes.md
+++ b/docs-devsite/firestore_.bytes.md
@@ -39,7 +39,7 @@ Creates a new `Bytes` object from the given Base64 string, converting it to byte
 static fromBase64String(base64: string): Bytes;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -59,7 +59,7 @@ Creates a new `Bytes` object from the given Uint8Array.
 static fromUint8Array(array: Uint8Array): Bytes;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -79,7 +79,7 @@ Returns true if this `Bytes` object is equal to the provided one.
 isEqual(other: Bytes): boolean;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |

--- a/docs-devsite/firestore_.collectionreference.md
+++ b/docs-devsite/firestore_.collectionreference.md
@@ -85,7 +85,7 @@ Applies a custom data converter to this `CollectionReference`<!-- -->, allowing 
 withConverter<NewAppModelType, NewDbModelType extends DocumentData = DocumentData>(converter: FirestoreDataConverter<NewAppModelType, NewDbModelType>): CollectionReference<NewAppModelType, NewDbModelType>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -107,7 +107,7 @@ Removes the current converter.
 withConverter(converter: null): CollectionReference<DocumentData, DocumentData>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |

--- a/docs-devsite/firestore_.documentreference.md
+++ b/docs-devsite/firestore_.documentreference.md
@@ -106,7 +106,7 @@ Applies a custom data converter to this `DocumentReference`<!-- -->, allowing yo
 withConverter<NewAppModelType, NewDbModelType extends DocumentData = DocumentData>(converter: FirestoreDataConverter<NewAppModelType, NewDbModelType>): DocumentReference<NewAppModelType, NewDbModelType>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -128,7 +128,7 @@ Removes the current converter.
 withConverter(converter: null): DocumentReference<DocumentData, DocumentData>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |

--- a/docs-devsite/firestore_.documentsnapshot.md
+++ b/docs-devsite/firestore_.documentsnapshot.md
@@ -94,7 +94,7 @@ By default, `serverTimestamp()` values that have not yet been set to their final
 data(options?: SnapshotOptions): AppModelType | undefined;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -131,7 +131,7 @@ By default, a `serverTimestamp()` that has not yet been set to its final value w
 get(fieldPath: string | FieldPath, options?: SnapshotOptions): any;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |

--- a/docs-devsite/firestore_.fieldpath.md
+++ b/docs-devsite/firestore_.fieldpath.md
@@ -42,7 +42,7 @@ Creates a `FieldPath` from the provided field names. If more than one field name
 constructor(...fieldNames: string[]);
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -58,7 +58,7 @@ Returns true if this `FieldPath` is equal to the provided one.
 isEqual(other: FieldPath): boolean;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |

--- a/docs-devsite/firestore_.fieldvalue.md
+++ b/docs-devsite/firestore_.fieldvalue.md
@@ -34,7 +34,7 @@ Compares `FieldValue`<!-- -->s for equality.
 abstract isEqual(other: FieldValue): boolean;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |

--- a/docs-devsite/firestore_.firestoredataconverter.md
+++ b/docs-devsite/firestore_.firestoredataconverter.md
@@ -40,7 +40,7 @@ Generally, the data returned from `snapshot.data()` can be cast to `DbModelType`
 fromFirestore(snapshot: QueryDocumentSnapshot<DocumentData, DocumentData>, options?: SnapshotOptions): AppModelType;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -63,7 +63,7 @@ The `WithFieldValue<T>` type extends `T` to also allow FieldValues such as [dele
 toFirestore(modelObject: WithFieldValue<AppModelType>): WithFieldValue<DbModelType>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -85,7 +85,7 @@ The `PartialWithFieldValue<T>` type extends `Partial<T>` to allow FieldValues su
 toFirestore(modelObject: PartialWithFieldValue<AppModelType>, options: SetOptions): PartialWithFieldValue<DbModelType>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |

--- a/docs-devsite/firestore_.geopoint.md
+++ b/docs-devsite/firestore_.geopoint.md
@@ -50,7 +50,7 @@ Creates a new immutable `GeoPoint` object with the provided latitude and longitu
 constructor(latitude: number, longitude: number);
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -87,7 +87,7 @@ Returns true if this `GeoPoint` is equal to the provided one.
 isEqual(other: GeoPoint): boolean;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |

--- a/docs-devsite/firestore_.loadbundletask.md
+++ b/docs-devsite/firestore_.loadbundletask.md
@@ -39,7 +39,7 @@ Implements the `Promise<LoadBundleTaskProgress>.catch` interface.
 catch<R>(onRejected: (a: Error) => R | PromiseLike<R>): Promise<R | LoadBundleTaskProgress>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -59,7 +59,7 @@ Registers functions to listen to bundle loading progress events.
 onProgress(next?: (progress: LoadBundleTaskProgress) => unknown, error?: (err: Error) => unknown, complete?: () => void): void;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -81,7 +81,7 @@ Implements the `Promise<LoadBundleTaskProgress>.then` interface.
 then<T, R>(onFulfilled?: (a: LoadBundleTaskProgress) => T | PromiseLike<T>, onRejected?: (a: Error) => R | PromiseLike<R>): Promise<T | R>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |

--- a/docs-devsite/firestore_.md
+++ b/docs-devsite/firestore_.md
@@ -15,11 +15,11 @@ https://github.com/firebase/firebase-js-sdk
 
 |  Function | Description |
 |  --- | --- |
-|  <b>function(app...)</b> |
+|  <b>function(app, ...)</b> |
 |  [getFirestore(app)](./firestore_.md#getfirestore_cf608e1) | Returns the existing default [Firestore](./firestore_.firestore.md#firestore_class) instance that is associated with the provided [FirebaseApp](./app.firebaseapp.md#firebaseapp_interface)<!-- -->. If no instance exists, initializes a new instance with default settings. |
 |  [getFirestore(app, databaseId)](./firestore_.md#getfirestore_48de6cb) | <b><i>(BETA)</i></b> Returns the existing named [Firestore](./firestore_.firestore.md#firestore_class) instance that is associated with the provided [FirebaseApp](./app.firebaseapp.md#firebaseapp_interface)<!-- -->. If no instance exists, initializes a new instance with default settings. |
 |  [initializeFirestore(app, settings, databaseId)](./firestore_.md#initializefirestore_fc7d200) | Initializes a new instance of [Firestore](./firestore_.firestore.md#firestore_class) with the provided settings. Can only be called before any other function, including [getFirestore()](./firestore_.md#getfirestore)<!-- -->. If the custom settings are empty, this function is equivalent to calling [getFirestore()](./firestore_.md#getfirestore)<!-- -->. |
-|  <b>function(firestore...)</b> |
+|  <b>function(firestore, ...)</b> |
 |  [clearIndexedDbPersistence(firestore)](./firestore_.md#clearindexeddbpersistence_231a8e0) | Clears the persistent storage. This includes pending writes and cached documents.<!-- -->Must be called while the [Firestore](./firestore_.firestore.md#firestore_class) instance is not started (after the app is terminated or when the app is first initialized). On startup, this function must be called before other functions (other than [initializeFirestore()](./firestore_.md#initializefirestore_fc7d200) or [getFirestore()](./firestore_.md#getfirestore)<!-- -->)). If the [Firestore](./firestore_.firestore.md#firestore_class) instance is still running, the promise will be rejected with the error code of <code>failed-precondition</code>.<!-- -->Note: <code>clearIndexedDbPersistence()</code> is primarily intended to help write reliable tests that use Cloud Firestore. It uses an efficient mechanism for dropping existing data but does not attempt to securely overwrite or otherwise make cached data unrecoverable. For applications that are sensitive to the disclosure of cached data in between user sessions, we strongly recommend not enabling persistence at all. |
 |  [collection(firestore, path, pathSegments)](./firestore_.md#collection_1eb4c23) | Gets a <code>CollectionReference</code> instance that refers to the collection at the specified absolute path. |
 |  [collectionGroup(firestore, collectionId)](./firestore_.md#collectiongroup_1838fc3) | Creates and returns a new <code>Query</code> instance that includes all documents in the database that are contained in a collection or subcollection with the given <code>collectionId</code>. |
@@ -48,40 +48,40 @@ https://github.com/firebase/firebase-js-sdk
 |  [memoryEagerGarbageCollector()](./firestore_.md#memoryeagergarbagecollector) | Creates an instance of <code>MemoryEagerGarbageCollector</code>. This is also the default garbage collector unless it is explicitly specified otherwise. |
 |  [persistentMultipleTabManager()](./firestore_.md#persistentmultipletabmanager) | Creates an instance of <code>PersistentMultipleTabManager</code>. |
 |  [serverTimestamp()](./firestore_.md#servertimestamp) | Returns a sentinel used with [setDoc()](./firestore_lite.md#setdoc_ee215ad) or [updateDoc()](./firestore_lite.md#updatedoc_51a65e3) to include a server-generated timestamp in the written data. |
-|  <b>function(databaseId...)</b> |
+|  <b>function(databaseId, ...)</b> |
 |  [getFirestore(databaseId)](./firestore_.md#getfirestore_53dc891) | <b><i>(BETA)</i></b> Returns the existing named [Firestore](./firestore_.firestore.md#firestore_class) instance that is associated with the default [FirebaseApp](./app.firebaseapp.md#firebaseapp_interface)<!-- -->. If no instance exists, initializes a new instance with default settings. |
-|  <b>function(elements...)</b> |
+|  <b>function(elements, ...)</b> |
 |  [arrayRemove(elements)](./firestore_.md#arrayremove_7d853aa) | Returns a special value that can be used with [setDoc()](./firestore_.md#setdoc_ee215ad) or  that tells the server to remove the given elements from any array value that already exists on the server. All instances of each element specified will be removed from the array. If the field being modified is not already an array it will be overwritten with an empty array. |
 |  [arrayUnion(elements)](./firestore_.md#arrayunion_7d853aa) | Returns a special value that can be used with [setDoc()](./firestore_lite.md#setdoc_ee215ad) or [updateDoc()](./firestore_lite.md#updatedoc_51a65e3) that tells the server to union the given elements with any array value that already exists on the server. Each specified element that doesn't already exist in the array will be added to the end. If the field being modified is not already an array it will be overwritten with an array containing exactly the specified elements. |
-|  <b>function(field...)</b> |
+|  <b>function(field, ...)</b> |
 |  [average(field)](./firestore_.md#average_aacc3a9) | Create an AggregateField object that can be used to compute the average of a specified field over a range of documents in the result set of a query. |
 |  [sum(field)](./firestore_.md#sum_aacc3a9) | Create an AggregateField object that can be used to compute the sum of a specified field over a range of documents in the result set of a query. |
-|  <b>function(fieldPath...)</b> |
+|  <b>function(fieldPath, ...)</b> |
 |  [orderBy(fieldPath, directionStr)](./firestore_.md#orderby_006d61f) | Creates a [QueryOrderByConstraint](./firestore_.queryorderbyconstraint.md#queryorderbyconstraint_class) that sorts the query result by the specified field, optionally in descending order instead of ascending.<!-- -->Note: Documents that do not contain the specified field will not be present in the query result. |
 |  [where(fieldPath, opStr, value)](./firestore_.md#where_0fae4bf) | Creates a [QueryFieldFilterConstraint](./firestore_.queryfieldfilterconstraint.md#queryfieldfilterconstraint_class) that enforces that documents must contain the specified field and that the value should satisfy the relation constraint provided. |
-|  <b>function(fieldValues...)</b> |
+|  <b>function(fieldValues, ...)</b> |
 |  [endAt(fieldValues)](./firestore_.md#endat_8b2f2c8) | Creates a [QueryEndAtConstraint](./firestore_.queryendatconstraint.md#queryendatconstraint_class) that modifies the result set to end at the provided fields relative to the order of the query. The order of the field values must match the order of the order by clauses of the query. |
 |  [endBefore(fieldValues)](./firestore_.md#endbefore_8b2f2c8) | Creates a [QueryEndAtConstraint](./firestore_.queryendatconstraint.md#queryendatconstraint_class) that modifies the result set to end before the provided fields relative to the order of the query. The order of the field values must match the order of the order by clauses of the query. |
 |  [startAfter(fieldValues)](./firestore_.md#startafter_8b2f2c8) | Creates a [QueryStartAtConstraint](./firestore_.querystartatconstraint.md#querystartatconstraint_class) that modifies the result set to start after the provided fields relative to the order of the query. The order of the field values must match the order of the order by clauses of the query. |
 |  [startAt(fieldValues)](./firestore_.md#startat_8b2f2c8) | Creates a [QueryStartAtConstraint](./firestore_.querystartatconstraint.md#querystartatconstraint_class) that modifies the result set to start at the provided fields relative to the order of the query. The order of the field values must match the order of the order by clauses of the query. |
-|  <b>function(indexManager...)</b> |
+|  <b>function(indexManager, ...)</b> |
 |  [deleteAllPersistentCacheIndexes(indexManager)](./firestore_.md#deleteallpersistentcacheindexes_98b2645) | Removes all persistent cache indexes.<!-- -->Please note this function will also deletes indexes generated by <code>setIndexConfiguration()</code>, which is deprecated. |
 |  [disablePersistentCacheIndexAutoCreation(indexManager)](./firestore_.md#disablepersistentcacheindexautocreation_98b2645) | Stops creating persistent cache indexes automatically for local query execution. The indexes which have been created by calling <code>enablePersistentCacheIndexAutoCreation()</code> still take effect. |
 |  [enablePersistentCacheIndexAutoCreation(indexManager)](./firestore_.md#enablepersistentcacheindexautocreation_98b2645) | Enables the SDK to create persistent cache indexes automatically for local query execution when the SDK believes cache indexes can help improve performance.<!-- -->This feature is disabled by default. |
-|  <b>function(left...)</b> |
+|  <b>function(left, ...)</b> |
 |  [aggregateFieldEqual(left, right)](./firestore_.md#aggregatefieldequal_e80a2b2) | Compares two 'AggregateField<!-- -->\` instances for equality. |
 |  [aggregateQuerySnapshotEqual(left, right)](./firestore_.md#aggregatequerysnapshotequal_1529a20) | Compares two <code>AggregateQuerySnapshot</code> instances for equality.<!-- -->Two <code>AggregateQuerySnapshot</code> instances are considered "equal" if they have underlying queries that compare equal, and the same data. |
 |  [queryEqual(left, right)](./firestore_.md#queryequal_7a1f045) | Returns true if the provided queries point to the same collection and apply the same constraints. |
 |  [refEqual(left, right)](./firestore_.md#refequal_598b780) | Returns true if the provided references are equal. |
 |  [snapshotEqual(left, right)](./firestore_.md#snapshotequal_5109204) | Returns true if the provided snapshots are equal. |
-|  <b>function(limit...)</b> |
+|  <b>function(limit, ...)</b> |
 |  [limit(limit)](./firestore_.md#limit_ec46c78) | Creates a [QueryLimitConstraint](./firestore_.querylimitconstraint.md#querylimitconstraint_class) that only returns the first matching documents. |
 |  [limitToLast(limit)](./firestore_.md#limittolast_ec46c78) | Creates a [QueryLimitConstraint](./firestore_.querylimitconstraint.md#querylimitconstraint_class) that only returns the last matching documents.<!-- -->You must specify at least one <code>orderBy</code> clause for <code>limitToLast</code> queries, otherwise an exception will be thrown during execution. |
-|  <b>function(logLevel...)</b> |
+|  <b>function(logLevel, ...)</b> |
 |  [setLogLevel(logLevel)](./firestore_.md#setloglevel_d02fda2) | Sets the verbosity of Cloud Firestore logs (debug, error, or silent). |
-|  <b>function(n...)</b> |
+|  <b>function(n, ...)</b> |
 |  [increment(n)](./firestore_.md#increment_5685735) | Returns a special value that can be used with [setDoc()](./firestore_lite.md#setdoc_ee215ad) or [updateDoc()](./firestore_lite.md#updatedoc_51a65e3) that tells the server to increment the field's current value by the given value.<!-- -->If either the operand or the current field value uses floating point precision, all arithmetic follows IEEE 754 semantics. If both values are integers, values outside of JavaScript's safe number range (<code>Number.MIN_SAFE_INTEGER</code> to <code>Number.MAX_SAFE_INTEGER</code>) are also subject to precision loss. Furthermore, once processed by the Firestore backend, all integer operations are capped between -2^63 and 2^63-1.<!-- -->If the current field value is not of type <code>number</code>, or if the field does not yet exist, the transformation sets the field to the given value. |
-|  <b>function(query...)</b> |
+|  <b>function(query, ...)</b> |
 |  [getAggregateFromServer(query, aggregateSpec)](./firestore_.md#getaggregatefromserver_2073a74) | Calculates the specified aggregations over the documents in the result set of the given query, without actually downloading the documents.<!-- -->Using this function to perform aggregations is efficient because only the final aggregation values, not the documents' data, are downloaded. This function can even perform aggregations of the documents if the result set would be prohibitively large to download entirely (e.g. thousands of documents).<!-- -->The result received from the server is presented, unaltered, without considering any local state. That is, documents in the local cache are not taken into consideration, neither are local modifications not yet synchronized with the server. Previously-downloaded results, if any, are not used: every request using this source necessarily involves a round trip to the server. |
 |  [getCountFromServer(query)](./firestore_.md#getcountfromserver_4e56953) | Calculates the number of documents in the result set of the given query, without actually downloading the documents.<!-- -->Using this function to count the documents is efficient because only the final count, not the documents' data, is downloaded. This function can even count the documents if the result set would be prohibitively large to download entirely (e.g. thousands of documents).<!-- -->The result received from the server is presented, unaltered, without considering any local state. That is, documents in the local cache are not taken into consideration, neither are local modifications not yet synchronized with the server. Previously-downloaded results, if any, are not used: every request using this source necessarily involves a round trip to the server. |
 |  [getDocs(query)](./firestore_.md#getdocs_4e56953) | Executes the query and returns the results as a <code>QuerySnapshot</code>.<!-- -->Note: <code>getDocs()</code> attempts to provide up-to-date data when possible by waiting for data from the server, but it may return cached data or fail if you are offline and the server cannot be reached. To specify this behavior, invoke [getDocsFromCache()](./firestore_.md#getdocsfromcache_4e56953) or [getDocsFromServer()](./firestore_.md#getdocsfromserver_4e56953)<!-- -->. |
@@ -93,10 +93,10 @@ https://github.com/firebase/firebase-js-sdk
 |  [onSnapshot(query, options, onNext, onError, onCompletion)](./firestore_.md#onsnapshot_b8f9c47) | Attaches a listener for <code>QuerySnapshot</code> events. You may either pass individual <code>onNext</code> and <code>onError</code> callbacks or pass a single observer object with <code>next</code> and <code>error</code> callbacks. The listener can be cancelled by calling the function that is returned when <code>onSnapshot</code> is called.<!-- -->NOTE: Although an <code>onCompletion</code> callback can be provided, it will never be called because the snapshot stream is never-ending. |
 |  [query(query, compositeFilter, queryConstraints)](./firestore_.md#query_9f7b0f4) | Creates a new immutable instance of [Query](./firestore_.query.md#query_class) that is extended to also include additional query constraints. |
 |  [query(query, queryConstraints)](./firestore_.md#query_0f46da1) | Creates a new immutable instance of [Query](./firestore_.query.md#query_class) that is extended to also include additional query constraints. |
-|  <b>function(queryConstraints...)</b> |
+|  <b>function(queryConstraints, ...)</b> |
 |  [and(queryConstraints)](./firestore_.md#and_e72c712) | Creates a new [QueryCompositeFilterConstraint](./firestore_.querycompositefilterconstraint.md#querycompositefilterconstraint_class) that is a conjunction of the given filter constraints. A conjunction filter includes a document if it satisfies all of the given filters. |
 |  [or(queryConstraints)](./firestore_.md#or_e72c712) | Creates a new [QueryCompositeFilterConstraint](./firestore_.querycompositefilterconstraint.md#querycompositefilterconstraint_class) that is a disjunction of the given filter constraints. A disjunction filter includes a document if it satisfies any of the given filters. |
-|  <b>function(reference...)</b> |
+|  <b>function(reference, ...)</b> |
 |  [addDoc(reference, data)](./firestore_.md#adddoc_6e783ff) | Add a new document to specified <code>CollectionReference</code> with the given data, assigning it a document ID automatically. |
 |  [collection(reference, path, pathSegments)](./firestore_.md#collection_568f98d) | Gets a <code>CollectionReference</code> instance that refers to a subcollection of <code>reference</code> at the the specified relative path. |
 |  [collection(reference, path, pathSegments)](./firestore_.md#collection_70b4396) | Gets a <code>CollectionReference</code> instance that refers to a subcollection of <code>reference</code> at the the specified relative path. |
@@ -114,12 +114,12 @@ https://github.com/firebase/firebase-js-sdk
 |  [setDoc(reference, data, options)](./firestore_.md#setdoc_ff80739) | Writes to the document referred to by the specified <code>DocumentReference</code>. If the document does not yet exist, it will be created. If you provide <code>merge</code> or <code>mergeFields</code>, the provided data can be merged into an existing document. |
 |  [updateDoc(reference, data)](./firestore_.md#updatedoc_51a65e3) | Updates fields in the document referred to by the specified <code>DocumentReference</code>. The update will fail if applied to a document that does not exist. |
 |  [updateDoc(reference, field, value, moreFieldsAndValues)](./firestore_.md#updatedoc_7c28659) | Updates fields in the document referred to by the specified <code>DocumentReference</code> The update will fail if applied to a document that does not exist.<!-- -->Nested fields can be updated by providing dot-separated field path strings or by providing <code>FieldPath</code> objects. |
-|  <b>function(settings...)</b> |
+|  <b>function(settings, ...)</b> |
 |  [memoryLocalCache(settings)](./firestore_.md#memorylocalcache_05f4bf2) | Creates an instance of <code>MemoryLocalCache</code>. The instance can be set to <code>FirestoreSettings.cache</code> to tell the SDK which cache layer to use. |
 |  [memoryLruGarbageCollector(settings)](./firestore_.md#memorylrugarbagecollector_5ee014c) | Creates an instance of <code>MemoryLruGarbageCollector</code>.<!-- -->A target size can be specified as part of the setting parameter. The collector will start deleting documents once the cache size exceeds the given size. The default cache size is 40MB (40 \* 1024 \* 1024 bytes). |
 |  [persistentLocalCache(settings)](./firestore_.md#persistentlocalcache_d312f71) | Creates an instance of <code>PersistentLocalCache</code>. The instance can be set to <code>FirestoreSettings.cache</code> to tell the SDK which cache layer to use.<!-- -->Persistent cache cannot be used in a Node.js environment. |
 |  [persistentSingleTabManager(settings)](./firestore_.md#persistentsingletabmanager_c99c68d) | Creates an instance of <code>PersistentSingleTabManager</code>. |
-|  <b>function(snapshot...)</b> |
+|  <b>function(snapshot, ...)</b> |
 |  [endAt(snapshot)](./firestore_.md#endat_9a4477f) | Creates a [QueryEndAtConstraint](./firestore_.queryendatconstraint.md#queryendatconstraint_class) that modifies the result set to end at the provided document (inclusive). The end position is relative to the order of the query. The document must contain all of the fields provided in the orderBy of the query. |
 |  [endBefore(snapshot)](./firestore_.md#endbefore_9a4477f) | Creates a [QueryEndAtConstraint](./firestore_.queryendatconstraint.md#queryendatconstraint_class) that modifies the result set to end before the provided document (exclusive). The end position is relative to the order of the query. The document must contain all of the fields provided in the orderBy of the query. |
 |  [startAfter(snapshot)](./firestore_.md#startafter_9a4477f) | Creates a [QueryStartAtConstraint](./firestore_.querystartatconstraint.md#querystartatconstraint_class) that modifies the result set to start after the provided document (exclusive). The starting position is relative to the order of the query. The document must contain all of the fields provided in the orderBy of the query. |
@@ -220,7 +220,9 @@ https://github.com/firebase/firebase-js-sdk
 |  [WhereFilterOp](./firestore_.md#wherefilterop) | Filter conditions in a [where()](./firestore_.md#where_0fae4bf) clause are specified using the strings '&amp;lt;', '&amp;lt;=', '==', '!=', '&amp;gt;=', '&amp;gt;', 'array-contains', 'in', 'array-contains-any', and 'not-in'. |
 |  [WithFieldValue](./firestore_.md#withfieldvalue) | Allows FieldValues to be passed in as a property value while maintaining type safety. |
 
-## getFirestore() {:#getfirestore_cf608e1}
+## function(app, ...)
+
+### getFirestore(app) {:#getfirestore_cf608e1}
 
 Returns the existing default [Firestore](./firestore_.firestore.md#firestore_class) instance that is associated with the provided [FirebaseApp](./app.firebaseapp.md#firebaseapp_interface)<!-- -->. If no instance exists, initializes a new instance with default settings.
 
@@ -230,7 +232,7 @@ Returns the existing default [Firestore](./firestore_.firestore.md#firestore_cla
 export declare function getFirestore(app: FirebaseApp): Firestore;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -242,7 +244,7 @@ export declare function getFirestore(app: FirebaseApp): Firestore;
 
 The default [Firestore](./firestore_.firestore.md#firestore_class) instance of the provided app.
 
-## getFirestore() {:#getfirestore_48de6cb}
+### getFirestore(app, databaseId) {:#getfirestore_48de6cb}
 
 > This API is provided as a preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
 > 
@@ -255,7 +257,7 @@ Returns the existing named [Firestore](./firestore_.firestore.md#firestore_class
 export declare function getFirestore(app: FirebaseApp, databaseId: string): Firestore;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -268,7 +270,7 @@ export declare function getFirestore(app: FirebaseApp, databaseId: string): Fire
 
 The named [Firestore](./firestore_.firestore.md#firestore_class) instance of the provided app.
 
-## initializeFirestore() {:#initializefirestore_fc7d200}
+### initializeFirestore(app, settings, databaseId) {:#initializefirestore_fc7d200}
 
 Initializes a new instance of [Firestore](./firestore_.firestore.md#firestore_class) with the provided settings. Can only be called before any other function, including [getFirestore()](./firestore_.md#getfirestore)<!-- -->. If the custom settings are empty, this function is equivalent to calling [getFirestore()](./firestore_.md#getfirestore)<!-- -->.
 
@@ -278,7 +280,7 @@ Initializes a new instance of [Firestore](./firestore_.firestore.md#firestore_cl
 export declare function initializeFirestore(app: FirebaseApp, settings: FirestoreSettings, databaseId?: string): Firestore;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -292,7 +294,9 @@ export declare function initializeFirestore(app: FirebaseApp, settings: Firestor
 
 A newly initialized [Firestore](./firestore_.firestore.md#firestore_class) instance.
 
-## clearIndexedDbPersistence() {:#clearindexeddbpersistence_231a8e0}
+## function(firestore, ...)
+
+### clearIndexedDbPersistence(firestore) {:#clearindexeddbpersistence_231a8e0}
 
 Clears the persistent storage. This includes pending writes and cached documents.
 
@@ -306,7 +310,7 @@ Note: `clearIndexedDbPersistence()` is primarily intended to help write reliable
 export declare function clearIndexedDbPersistence(firestore: Firestore): Promise<void>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -318,7 +322,7 @@ Promise&lt;void&gt;
 
 A `Promise` that is resolved when the persistent storage is cleared. Otherwise, the promise is rejected with an error.
 
-## collection() {:#collection_1eb4c23}
+### collection(firestore, path, pathSegments) {:#collection_1eb4c23}
 
 Gets a `CollectionReference` instance that refers to the collection at the specified absolute path.
 
@@ -328,7 +332,7 @@ Gets a `CollectionReference` instance that refers to the collection at the speci
 export declare function collection(firestore: Firestore, path: string, ...pathSegments: string[]): CollectionReference<DocumentData, DocumentData>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -342,11 +346,11 @@ export declare function collection(firestore: Firestore, path: string, ...pathSe
 
 The `CollectionReference` instance.
 
-## Exceptions
+#### Exceptions
 
 If the final path has an even number of segments and does not point to a collection.
 
-## collectionGroup() {:#collectiongroup_1838fc3}
+### collectionGroup(firestore, collectionId) {:#collectiongroup_1838fc3}
 
 Creates and returns a new `Query` instance that includes all documents in the database that are contained in a collection or subcollection with the given `collectionId`<!-- -->.
 
@@ -356,7 +360,7 @@ Creates and returns a new `Query` instance that includes all documents in the da
 export declare function collectionGroup(firestore: Firestore, collectionId: string): Query<DocumentData, DocumentData>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -369,7 +373,7 @@ export declare function collectionGroup(firestore: Firestore, collectionId: stri
 
 The created `Query`<!-- -->.
 
-## connectFirestoreEmulator() {:#connectfirestoreemulator_7c247cd}
+### connectFirestoreEmulator(firestore, host, port, options) {:#connectfirestoreemulator_7c247cd}
 
 Modify this instance to communicate with the Cloud Firestore emulator.
 
@@ -383,7 +387,7 @@ export declare function connectFirestoreEmulator(firestore: Firestore, host: str
 }): void;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -396,7 +400,7 @@ export declare function connectFirestoreEmulator(firestore: Firestore, host: str
 
 void
 
-## disableNetwork() {:#disablenetwork_231a8e0}
+### disableNetwork(firestore) {:#disablenetwork_231a8e0}
 
 Disables network usage for this instance. It can be re-enabled via [enableNetwork()](./firestore_.md#enablenetwork_231a8e0)<!-- -->. While the network is disabled, any snapshot listeners, `getDoc()` or `getDocs()` calls will return results from cache, and any write operations will be queued until the network is restored.
 
@@ -406,7 +410,7 @@ Disables network usage for this instance. It can be re-enabled via [enableNetwor
 export declare function disableNetwork(firestore: Firestore): Promise<void>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -418,7 +422,7 @@ Promise&lt;void&gt;
 
 A `Promise` that is resolved once the network has been disabled.
 
-## doc() {:#doc_1eb4c23}
+### doc(firestore, path, pathSegments) {:#doc_1eb4c23}
 
 Gets a `DocumentReference` instance that refers to the document at the specified absolute path.
 
@@ -428,7 +432,7 @@ Gets a `DocumentReference` instance that refers to the document at the specified
 export declare function doc(firestore: Firestore, path: string, ...pathSegments: string[]): DocumentReference<DocumentData, DocumentData>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -442,11 +446,11 @@ export declare function doc(firestore: Firestore, path: string, ...pathSegments:
 
 The `DocumentReference` instance.
 
-## Exceptions
+#### Exceptions
 
 If the final path has an odd number of segments and does not point to a document.
 
-## enableIndexedDbPersistence() {:#enableindexeddbpersistence_224174f}
+### enableIndexedDbPersistence(firestore, persistenceSettings) {:#enableindexeddbpersistence_224174f}
 
 > Warning: This API is now obsolete.
 > 
@@ -471,7 +475,7 @@ Persistence cannot be used in a Node.js environment.
 export declare function enableIndexedDbPersistence(firestore: Firestore, persistenceSettings?: PersistenceSettings): Promise<void>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -484,7 +488,7 @@ Promise&lt;void&gt;
 
 A `Promise` that represents successfully enabling persistent storage.
 
-## enableMultiTabIndexedDbPersistence() {:#enablemultitabindexeddbpersistence_231a8e0}
+### enableMultiTabIndexedDbPersistence(firestore) {:#enablemultitabindexeddbpersistence_231a8e0}
 
 > Warning: This API is now obsolete.
 > 
@@ -505,7 +509,7 @@ There are several reasons why this can fail, which can be identified by the `cod
 export declare function enableMultiTabIndexedDbPersistence(firestore: Firestore): Promise<void>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -517,7 +521,7 @@ Promise&lt;void&gt;
 
 A `Promise` that represents successfully enabling persistent storage.
 
-## enableNetwork() {:#enablenetwork_231a8e0}
+### enableNetwork(firestore) {:#enablenetwork_231a8e0}
 
 Re-enables use of the network for this [Firestore](./firestore_.firestore.md#firestore_class) instance after a prior call to [disableNetwork()](./firestore_.md#disablenetwork_231a8e0)<!-- -->.
 
@@ -527,7 +531,7 @@ Re-enables use of the network for this [Firestore](./firestore_.firestore.md#fir
 export declare function enableNetwork(firestore: Firestore): Promise<void>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -539,7 +543,7 @@ Promise&lt;void&gt;
 
 A `Promise` that is resolved once the network has been enabled.
 
-## getPersistentCacheIndexManager() {:#getpersistentcacheindexmanager_231a8e0}
+### getPersistentCacheIndexManager(firestore) {:#getpersistentcacheindexmanager_231a8e0}
 
 Returns the PersistentCache Index Manager used by the given `Firestore` object.
 
@@ -551,7 +555,7 @@ Returns the PersistentCache Index Manager used by the given `Firestore` object.
 export declare function getPersistentCacheIndexManager(firestore: Firestore): PersistentCacheIndexManager | null;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -561,7 +565,7 @@ export declare function getPersistentCacheIndexManager(firestore: Firestore): Pe
 
 [PersistentCacheIndexManager](./firestore_.persistentcacheindexmanager.md#persistentcacheindexmanager_class) \| null
 
-## loadBundle() {:#loadbundle_bec5b75}
+### loadBundle(firestore, bundleData) {:#loadbundle_bec5b75}
 
 Loads a Firestore bundle into the local cache.
 
@@ -571,7 +575,7 @@ Loads a Firestore bundle into the local cache.
 export declare function loadBundle(firestore: Firestore, bundleData: ReadableStream<Uint8Array> | ArrayBuffer | string): LoadBundleTask;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -584,7 +588,7 @@ export declare function loadBundle(firestore: Firestore, bundleData: ReadableStr
 
 A `LoadBundleTask` object, which notifies callers with progress updates, and completion or error events. It can be used as a `Promise<LoadBundleTaskProgress>`<!-- -->.
 
-## namedQuery() {:#namedquery_6438876}
+### namedQuery(firestore, name) {:#namedquery_6438876}
 
 Reads a Firestore [Query](./firestore_.query.md#query_class) from local cache, identified by the given name.
 
@@ -596,7 +600,7 @@ The named queries are packaged into bundles on the server side (along with resul
 export declare function namedQuery(firestore: Firestore, name: string): Promise<Query | null>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -609,7 +613,7 @@ Promise&lt;[Query](./firestore_.query.md#query_class) \| null&gt;
 
 A `Promise` that is resolved with the Query or `null`<!-- -->.
 
-## onSnapshotsInSync() {:#onsnapshotsinsync_2f0dfa4}
+### onSnapshotsInSync(firestore, observer) {:#onsnapshotsinsync_2f0dfa4}
 
 Attaches a listener for a snapshots-in-sync event. The snapshots-in-sync event indicates that all listeners affected by a given change have fired, even if a single server-generated change affects multiple listeners.
 
@@ -625,7 +629,7 @@ export declare function onSnapshotsInSync(firestore: Firestore, observer: {
 }): Unsubscribe;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -638,7 +642,7 @@ export declare function onSnapshotsInSync(firestore: Firestore, observer: {
 
 An unsubscribe function that can be called to cancel the snapshot listener.
 
-## onSnapshotsInSync() {:#onsnapshotsinsync_1901c06}
+### onSnapshotsInSync(firestore, onSync) {:#onsnapshotsinsync_1901c06}
 
 Attaches a listener for a snapshots-in-sync event. The snapshots-in-sync event indicates that all listeners affected by a given change have fired, even if a single server-generated change affects multiple listeners.
 
@@ -650,7 +654,7 @@ NOTE: The snapshots-in-sync event only indicates that listeners are in sync with
 export declare function onSnapshotsInSync(firestore: Firestore, onSync: () => void): Unsubscribe;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -663,7 +667,7 @@ export declare function onSnapshotsInSync(firestore: Firestore, onSync: () => vo
 
 An unsubscribe function that can be called to cancel the snapshot listener.
 
-## runTransaction() {:#runtransaction_6f03ec4}
+### runTransaction(firestore, updateFunction, options) {:#runtransaction_6f03ec4}
 
 Executes the given `updateFunction` and then attempts to commit the changes applied within the transaction. If any document read within the transaction has changed, Cloud Firestore retries the `updateFunction`<!-- -->. If it fails to commit after 5 attempts, the transaction fails.
 
@@ -675,7 +679,7 @@ The maximum number of writes allowed in a single transaction is 500.
 export declare function runTransaction<T>(firestore: Firestore, updateFunction: (transaction: Transaction) => Promise<T>, options?: TransactionOptions): Promise<T>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -689,7 +693,7 @@ Promise&lt;T&gt;
 
 If the transaction completed successfully or was explicitly aborted (the `updateFunction` returned a failed promise), the promise returned by the `updateFunction `<!-- -->is returned here. Otherwise, if the transaction failed, a rejected promise with the corresponding failure error is returned.
 
-## setIndexConfiguration() {:#setindexconfiguration_c362f04}
+### setIndexConfiguration(firestore, configuration) {:#setindexconfiguration_c362f04}
 
 > This API is provided as a preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
 > 
@@ -711,7 +715,7 @@ Indexes are only supported with IndexedDb persistence. If IndexedDb is not enabl
 export declare function setIndexConfiguration(firestore: Firestore, configuration: IndexConfiguration): Promise<void>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -724,11 +728,11 @@ Promise&lt;void&gt;
 
 A `Promise` that resolves once all indices are successfully configured.
 
-## Exceptions
+#### Exceptions
 
 FirestoreError if the JSON format is invalid.
 
-## setIndexConfiguration() {:#setindexconfiguration_90d0285}
+### setIndexConfiguration(firestore, json) {:#setindexconfiguration_90d0285}
 
 > This API is provided as a preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
 > 
@@ -752,7 +756,7 @@ The method accepts the JSON format exported by the Firebase CLI (`firebase fires
 export declare function setIndexConfiguration(firestore: Firestore, json: string): Promise<void>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -765,11 +769,11 @@ Promise&lt;void&gt;
 
 A `Promise` that resolves once all indices are successfully configured.
 
-## Exceptions
+#### Exceptions
 
 FirestoreError if the JSON format is invalid.
 
-## terminate() {:#terminate_231a8e0}
+### terminate(firestore) {:#terminate_231a8e0}
 
 Terminates the provided [Firestore](./firestore_.firestore.md#firestore_class) instance.
 
@@ -787,7 +791,7 @@ Note: Under normal circumstances, calling `terminate()` is not required. This fu
 export declare function terminate(firestore: Firestore): Promise<void>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -799,7 +803,7 @@ Promise&lt;void&gt;
 
 A `Promise` that is resolved when the instance has been successfully terminated.
 
-## waitForPendingWrites() {:#waitforpendingwrites_231a8e0}
+### waitForPendingWrites(firestore) {:#waitforpendingwrites_231a8e0}
 
 Waits until all currently pending writes for the active user have been acknowledged by the backend.
 
@@ -813,7 +817,7 @@ Any outstanding `waitForPendingWrites()` promises are rejected during user chang
 export declare function waitForPendingWrites(firestore: Firestore): Promise<void>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -825,7 +829,7 @@ Promise&lt;void&gt;
 
 A `Promise` which resolves when all currently pending writes have been acknowledged by the backend.
 
-## writeBatch() {:#writebatch_231a8e0}
+### writeBatch(firestore) {:#writebatch_231a8e0}
 
 Creates a write batch, used for performing multiple writes as a single atomic operation. The maximum number of writes allowed in a single [WriteBatch](./firestore_.writebatch.md#writebatch_class) is 500.
 
@@ -837,7 +841,7 @@ Unlike transactions, write batches are persisted offline and therefore are prefe
 export declare function writeBatch(firestore: Firestore): WriteBatch;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -849,7 +853,9 @@ export declare function writeBatch(firestore: Firestore): WriteBatch;
 
 A [WriteBatch](./firestore_.writebatch.md#writebatch_class) that can be used to atomically execute multiple writes.
 
-## count() {:#count}
+## function()
+
+### count() {:#count}
 
 Create an AggregateField object that can be used to compute the count of documents in the result set of a query.
 
@@ -862,7 +868,7 @@ export declare function count(): AggregateField<number>;
 
 [AggregateField](./firestore_.aggregatefield.md#aggregatefield_class)<!-- -->&lt;number&gt;
 
-## deleteField() {:#deletefield}
+### deleteField() {:#deletefield}
 
 Returns a sentinel for use with [updateDoc()](./firestore_lite.md#updatedoc_51a65e3) or [setDoc()](./firestore_lite.md#setdoc_ee215ad) with `{merge: true}` to mark a field for deletion.
 
@@ -875,7 +881,7 @@ export declare function deleteField(): FieldValue;
 
 [FieldValue](./firestore_.fieldvalue.md#fieldvalue_class)
 
-## documentId() {:#documentid}
+### documentId() {:#documentid}
 
 Returns a special sentinel `FieldPath` to refer to the ID of a document. It can be used in queries to sort or filter by the document ID.
 
@@ -888,7 +894,7 @@ export declare function documentId(): FieldPath;
 
 [FieldPath](./firestore_.fieldpath.md#fieldpath_class)
 
-## getFirestore() {:#getfirestore}
+### getFirestore() {:#getfirestore}
 
 Returns the existing default [Firestore](./firestore_.firestore.md#firestore_class) instance that is associated with the default [FirebaseApp](./app.firebaseapp.md#firebaseapp_interface)<!-- -->. If no instance exists, initializes a new instance with default settings.
 
@@ -903,7 +909,7 @@ export declare function getFirestore(): Firestore;
 
 The default [Firestore](./firestore_.firestore.md#firestore_class) instance of the default app.
 
-## memoryEagerGarbageCollector() {:#memoryeagergarbagecollector}
+### memoryEagerGarbageCollector() {:#memoryeagergarbagecollector}
 
 Creates an instance of `MemoryEagerGarbageCollector`<!-- -->. This is also the default garbage collector unless it is explicitly specified otherwise.
 
@@ -916,7 +922,7 @@ export declare function memoryEagerGarbageCollector(): MemoryEagerGarbageCollect
 
 [MemoryEagerGarbageCollector](./firestore_.memoryeagergarbagecollector.md#memoryeagergarbagecollector_interface)
 
-## persistentMultipleTabManager() {:#persistentmultipletabmanager}
+### persistentMultipleTabManager() {:#persistentmultipletabmanager}
 
 Creates an instance of `PersistentMultipleTabManager`<!-- -->.
 
@@ -929,7 +935,7 @@ export declare function persistentMultipleTabManager(): PersistentMultipleTabMan
 
 [PersistentMultipleTabManager](./firestore_.persistentmultipletabmanager.md#persistentmultipletabmanager_interface)
 
-## serverTimestamp() {:#servertimestamp}
+### serverTimestamp() {:#servertimestamp}
 
 Returns a sentinel used with [setDoc()](./firestore_lite.md#setdoc_ee215ad) or [updateDoc()](./firestore_lite.md#updatedoc_51a65e3) to include a server-generated timestamp in the written data.
 
@@ -942,7 +948,9 @@ export declare function serverTimestamp(): FieldValue;
 
 [FieldValue](./firestore_.fieldvalue.md#fieldvalue_class)
 
-## getFirestore() {:#getfirestore_53dc891}
+## function(databaseId, ...)
+
+### getFirestore(databaseId) {:#getfirestore_53dc891}
 
 > This API is provided as a preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
 > 
@@ -955,7 +963,7 @@ Returns the existing named [Firestore](./firestore_.firestore.md#firestore_class
 export declare function getFirestore(databaseId: string): Firestore;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -967,7 +975,9 @@ export declare function getFirestore(databaseId: string): Firestore;
 
 The named [Firestore](./firestore_.firestore.md#firestore_class) instance of the default app.
 
-## arrayRemove() {:#arrayremove_7d853aa}
+## function(elements, ...)
+
+### arrayRemove(elements) {:#arrayremove_7d853aa}
 
 Returns a special value that can be used with [setDoc()](./firestore_.md#setdoc_ee215ad) or  that tells the server to remove the given elements from any array value that already exists on the server. All instances of each element specified will be removed from the array. If the field being modified is not already an array it will be overwritten with an empty array.
 
@@ -977,7 +987,7 @@ Returns a special value that can be used with [setDoc()](./firestore_.md#setdoc_
 export declare function arrayRemove(...elements: unknown[]): FieldValue;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -989,7 +999,7 @@ export declare function arrayRemove(...elements: unknown[]): FieldValue;
 
 The `FieldValue` sentinel for use in a call to `setDoc()` or `updateDoc()`
 
-## arrayUnion() {:#arrayunion_7d853aa}
+### arrayUnion(elements) {:#arrayunion_7d853aa}
 
 Returns a special value that can be used with [setDoc()](./firestore_lite.md#setdoc_ee215ad) or [updateDoc()](./firestore_lite.md#updatedoc_51a65e3) that tells the server to union the given elements with any array value that already exists on the server. Each specified element that doesn't already exist in the array will be added to the end. If the field being modified is not already an array it will be overwritten with an array containing exactly the specified elements.
 
@@ -999,7 +1009,7 @@ Returns a special value that can be used with [setDoc()](./firestore_lite.md#set
 export declare function arrayUnion(...elements: unknown[]): FieldValue;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -1011,7 +1021,9 @@ export declare function arrayUnion(...elements: unknown[]): FieldValue;
 
 The `FieldValue` sentinel for use in a call to `setDoc()` or `updateDoc()`<!-- -->.
 
-## average() {:#average_aacc3a9}
+## function(field, ...)
+
+### average(field) {:#average_aacc3a9}
 
 Create an AggregateField object that can be used to compute the average of a specified field over a range of documents in the result set of a query.
 
@@ -1021,7 +1033,7 @@ Create an AggregateField object that can be used to compute the average of a spe
 export declare function average(field: string | FieldPath): AggregateField<number | null>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -1031,7 +1043,7 @@ export declare function average(field: string | FieldPath): AggregateField<numbe
 
 [AggregateField](./firestore_.aggregatefield.md#aggregatefield_class)<!-- -->&lt;number \| null&gt;
 
-## sum() {:#sum_aacc3a9}
+### sum(field) {:#sum_aacc3a9}
 
 Create an AggregateField object that can be used to compute the sum of a specified field over a range of documents in the result set of a query.
 
@@ -1041,7 +1053,7 @@ Create an AggregateField object that can be used to compute the sum of a specifi
 export declare function sum(field: string | FieldPath): AggregateField<number>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -1051,7 +1063,9 @@ export declare function sum(field: string | FieldPath): AggregateField<number>;
 
 [AggregateField](./firestore_.aggregatefield.md#aggregatefield_class)<!-- -->&lt;number&gt;
 
-## orderBy() {:#orderby_006d61f}
+## function(fieldPath, ...)
+
+### orderBy(fieldPath, directionStr) {:#orderby_006d61f}
 
 Creates a [QueryOrderByConstraint](./firestore_.queryorderbyconstraint.md#queryorderbyconstraint_class) that sorts the query result by the specified field, optionally in descending order instead of ascending.
 
@@ -1063,7 +1077,7 @@ Note: Documents that do not contain the specified field will not be present in t
 export declare function orderBy(fieldPath: string | FieldPath, directionStr?: OrderByDirection): QueryOrderByConstraint;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -1076,7 +1090,7 @@ export declare function orderBy(fieldPath: string | FieldPath, directionStr?: Or
 
 The created [QueryOrderByConstraint](./firestore_.queryorderbyconstraint.md#queryorderbyconstraint_class)<!-- -->.
 
-## where() {:#where_0fae4bf}
+### where(fieldPath, opStr, value) {:#where_0fae4bf}
 
 Creates a [QueryFieldFilterConstraint](./firestore_.queryfieldfilterconstraint.md#queryfieldfilterconstraint_class) that enforces that documents must contain the specified field and that the value should satisfy the relation constraint provided.
 
@@ -1086,7 +1100,7 @@ Creates a [QueryFieldFilterConstraint](./firestore_.queryfieldfilterconstraint.m
 export declare function where(fieldPath: string | FieldPath, opStr: WhereFilterOp, value: unknown): QueryFieldFilterConstraint;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -1100,7 +1114,9 @@ export declare function where(fieldPath: string | FieldPath, opStr: WhereFilterO
 
 The created [QueryFieldFilterConstraint](./firestore_.queryfieldfilterconstraint.md#queryfieldfilterconstraint_class)<!-- -->.
 
-## endAt() {:#endat_8b2f2c8}
+## function(fieldValues, ...)
+
+### endAt(fieldValues) {:#endat_8b2f2c8}
 
 Creates a [QueryEndAtConstraint](./firestore_.queryendatconstraint.md#queryendatconstraint_class) that modifies the result set to end at the provided fields relative to the order of the query. The order of the field values must match the order of the order by clauses of the query.
 
@@ -1110,7 +1126,7 @@ Creates a [QueryEndAtConstraint](./firestore_.queryendatconstraint.md#queryendat
 export declare function endAt(...fieldValues: unknown[]): QueryEndAtConstraint;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -1122,7 +1138,7 @@ export declare function endAt(...fieldValues: unknown[]): QueryEndAtConstraint;
 
 A [QueryEndAtConstraint](./firestore_.queryendatconstraint.md#queryendatconstraint_class) to pass to `query()`
 
-## endBefore() {:#endbefore_8b2f2c8}
+### endBefore(fieldValues) {:#endbefore_8b2f2c8}
 
 Creates a [QueryEndAtConstraint](./firestore_.queryendatconstraint.md#queryendatconstraint_class) that modifies the result set to end before the provided fields relative to the order of the query. The order of the field values must match the order of the order by clauses of the query.
 
@@ -1132,7 +1148,7 @@ Creates a [QueryEndAtConstraint](./firestore_.queryendatconstraint.md#queryendat
 export declare function endBefore(...fieldValues: unknown[]): QueryEndAtConstraint;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -1144,7 +1160,7 @@ export declare function endBefore(...fieldValues: unknown[]): QueryEndAtConstrai
 
 A [QueryEndAtConstraint](./firestore_.queryendatconstraint.md#queryendatconstraint_class) to pass to `query()`
 
-## startAfter() {:#startafter_8b2f2c8}
+### startAfter(fieldValues) {:#startafter_8b2f2c8}
 
 Creates a [QueryStartAtConstraint](./firestore_.querystartatconstraint.md#querystartatconstraint_class) that modifies the result set to start after the provided fields relative to the order of the query. The order of the field values must match the order of the order by clauses of the query.
 
@@ -1154,7 +1170,7 @@ Creates a [QueryStartAtConstraint](./firestore_.querystartatconstraint.md#querys
 export declare function startAfter(...fieldValues: unknown[]): QueryStartAtConstraint;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -1166,7 +1182,7 @@ export declare function startAfter(...fieldValues: unknown[]): QueryStartAtConst
 
 A [QueryStartAtConstraint](./firestore_.querystartatconstraint.md#querystartatconstraint_class) to pass to `query()`
 
-## startAt() {:#startat_8b2f2c8}
+### startAt(fieldValues) {:#startat_8b2f2c8}
 
 Creates a [QueryStartAtConstraint](./firestore_.querystartatconstraint.md#querystartatconstraint_class) that modifies the result set to start at the provided fields relative to the order of the query. The order of the field values must match the order of the order by clauses of the query.
 
@@ -1176,7 +1192,7 @@ Creates a [QueryStartAtConstraint](./firestore_.querystartatconstraint.md#querys
 export declare function startAt(...fieldValues: unknown[]): QueryStartAtConstraint;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -1188,7 +1204,9 @@ export declare function startAt(...fieldValues: unknown[]): QueryStartAtConstrai
 
 A [QueryStartAtConstraint](./firestore_.querystartatconstraint.md#querystartatconstraint_class) to pass to `query()`<!-- -->.
 
-## deleteAllPersistentCacheIndexes() {:#deleteallpersistentcacheindexes_98b2645}
+## function(indexManager, ...)
+
+### deleteAllPersistentCacheIndexes(indexManager) {:#deleteallpersistentcacheindexes_98b2645}
 
 Removes all persistent cache indexes.
 
@@ -1200,7 +1218,7 @@ Please note this function will also deletes indexes generated by `setIndexConfig
 export declare function deleteAllPersistentCacheIndexes(indexManager: PersistentCacheIndexManager): void;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -1210,7 +1228,7 @@ export declare function deleteAllPersistentCacheIndexes(indexManager: Persistent
 
 void
 
-## disablePersistentCacheIndexAutoCreation() {:#disablepersistentcacheindexautocreation_98b2645}
+### disablePersistentCacheIndexAutoCreation(indexManager) {:#disablepersistentcacheindexautocreation_98b2645}
 
 Stops creating persistent cache indexes automatically for local query execution. The indexes which have been created by calling `enablePersistentCacheIndexAutoCreation()` still take effect.
 
@@ -1220,7 +1238,7 @@ Stops creating persistent cache indexes automatically for local query execution.
 export declare function disablePersistentCacheIndexAutoCreation(indexManager: PersistentCacheIndexManager): void;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -1230,7 +1248,7 @@ export declare function disablePersistentCacheIndexAutoCreation(indexManager: Pe
 
 void
 
-## enablePersistentCacheIndexAutoCreation() {:#enablepersistentcacheindexautocreation_98b2645}
+### enablePersistentCacheIndexAutoCreation(indexManager) {:#enablepersistentcacheindexautocreation_98b2645}
 
 Enables the SDK to create persistent cache indexes automatically for local query execution when the SDK believes cache indexes can help improve performance.
 
@@ -1242,7 +1260,7 @@ This feature is disabled by default.
 export declare function enablePersistentCacheIndexAutoCreation(indexManager: PersistentCacheIndexManager): void;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -1252,7 +1270,9 @@ export declare function enablePersistentCacheIndexAutoCreation(indexManager: Per
 
 void
 
-## aggregateFieldEqual() {:#aggregatefieldequal_e80a2b2}
+## function(left, ...)
+
+### aggregateFieldEqual(left, right) {:#aggregatefieldequal_e80a2b2}
 
 Compares two 'AggregateField<!-- -->\` instances for equality.
 
@@ -1262,7 +1282,7 @@ Compares two 'AggregateField<!-- -->\` instances for equality.
 export declare function aggregateFieldEqual(left: AggregateField<unknown>, right: AggregateField<unknown>): boolean;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -1273,7 +1293,7 @@ export declare function aggregateFieldEqual(left: AggregateField<unknown>, right
 
 boolean
 
-## aggregateQuerySnapshotEqual() {:#aggregatequerysnapshotequal_1529a20}
+### aggregateQuerySnapshotEqual(left, right) {:#aggregatequerysnapshotequal_1529a20}
 
 Compares two `AggregateQuerySnapshot` instances for equality.
 
@@ -1285,7 +1305,7 @@ Two `AggregateQuerySnapshot` instances are considered "equal" if they have under
 export declare function aggregateQuerySnapshotEqual<AggregateSpecType extends AggregateSpec, AppModelType, DbModelType extends DocumentData>(left: AggregateQuerySnapshot<AggregateSpecType, AppModelType, DbModelType>, right: AggregateQuerySnapshot<AggregateSpecType, AppModelType, DbModelType>): boolean;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -1298,7 +1318,7 @@ boolean
 
 `true` if the objects are "equal", as defined above, or `false` otherwise.
 
-## queryEqual() {:#queryequal_7a1f045}
+### queryEqual(left, right) {:#queryequal_7a1f045}
 
 Returns true if the provided queries point to the same collection and apply the same constraints.
 
@@ -1308,7 +1328,7 @@ Returns true if the provided queries point to the same collection and apply the 
 export declare function queryEqual<AppModelType, DbModelType extends DocumentData>(left: Query<AppModelType, DbModelType>, right: Query<AppModelType, DbModelType>): boolean;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -1321,7 +1341,7 @@ boolean
 
 true if the references point to the same location in the same Firestore database.
 
-## refEqual() {:#refequal_598b780}
+### refEqual(left, right) {:#refequal_598b780}
 
 Returns true if the provided references are equal.
 
@@ -1331,7 +1351,7 @@ Returns true if the provided references are equal.
 export declare function refEqual<AppModelType, DbModelType extends DocumentData>(left: DocumentReference<AppModelType, DbModelType> | CollectionReference<AppModelType, DbModelType>, right: DocumentReference<AppModelType, DbModelType> | CollectionReference<AppModelType, DbModelType>): boolean;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -1344,7 +1364,7 @@ boolean
 
 true if the references point to the same location in the same Firestore database.
 
-## snapshotEqual() {:#snapshotequal_5109204}
+### snapshotEqual(left, right) {:#snapshotequal_5109204}
 
 Returns true if the provided snapshots are equal.
 
@@ -1354,7 +1374,7 @@ Returns true if the provided snapshots are equal.
 export declare function snapshotEqual<AppModelType, DbModelType extends DocumentData>(left: DocumentSnapshot<AppModelType, DbModelType> | QuerySnapshot<AppModelType, DbModelType>, right: DocumentSnapshot<AppModelType, DbModelType> | QuerySnapshot<AppModelType, DbModelType>): boolean;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -1367,7 +1387,9 @@ boolean
 
 true if the snapshots are equal.
 
-## limit() {:#limit_ec46c78}
+## function(limit, ...)
+
+### limit(limit) {:#limit_ec46c78}
 
 Creates a [QueryLimitConstraint](./firestore_.querylimitconstraint.md#querylimitconstraint_class) that only returns the first matching documents.
 
@@ -1377,7 +1399,7 @@ Creates a [QueryLimitConstraint](./firestore_.querylimitconstraint.md#querylimit
 export declare function limit(limit: number): QueryLimitConstraint;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -1389,7 +1411,7 @@ export declare function limit(limit: number): QueryLimitConstraint;
 
 The created [QueryLimitConstraint](./firestore_.querylimitconstraint.md#querylimitconstraint_class)<!-- -->.
 
-## limitToLast() {:#limittolast_ec46c78}
+### limitToLast(limit) {:#limittolast_ec46c78}
 
 Creates a [QueryLimitConstraint](./firestore_.querylimitconstraint.md#querylimitconstraint_class) that only returns the last matching documents.
 
@@ -1401,7 +1423,7 @@ You must specify at least one `orderBy` clause for `limitToLast` queries, otherw
 export declare function limitToLast(limit: number): QueryLimitConstraint;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -1413,7 +1435,9 @@ export declare function limitToLast(limit: number): QueryLimitConstraint;
 
 The created [QueryLimitConstraint](./firestore_.querylimitconstraint.md#querylimitconstraint_class)<!-- -->.
 
-## setLogLevel() {:#setloglevel_d02fda2}
+## function(logLevel, ...)
+
+### setLogLevel(logLevel) {:#setloglevel_d02fda2}
 
 Sets the verbosity of Cloud Firestore logs (debug, error, or silent).
 
@@ -1423,7 +1447,7 @@ Sets the verbosity of Cloud Firestore logs (debug, error, or silent).
 export declare function setLogLevel(logLevel: LogLevel): void;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -1433,7 +1457,9 @@ export declare function setLogLevel(logLevel: LogLevel): void;
 
 void
 
-## increment() {:#increment_5685735}
+## function(n, ...)
+
+### increment(n) {:#increment_5685735}
 
 Returns a special value that can be used with [setDoc()](./firestore_lite.md#setdoc_ee215ad) or [updateDoc()](./firestore_lite.md#updatedoc_51a65e3) that tells the server to increment the field's current value by the given value.
 
@@ -1447,7 +1473,7 @@ If the current field value is not of type `number`<!-- -->, or if the field does
 export declare function increment(n: number): FieldValue;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -1459,7 +1485,9 @@ export declare function increment(n: number): FieldValue;
 
 The `FieldValue` sentinel for use in a call to `setDoc()` or `updateDoc()`
 
-## getAggregateFromServer() {:#getaggregatefromserver_2073a74}
+## function(query, ...)
+
+### getAggregateFromServer(query, aggregateSpec) {:#getaggregatefromserver_2073a74}
 
 Calculates the specified aggregations over the documents in the result set of the given query, without actually downloading the documents.
 
@@ -1473,7 +1501,7 @@ The result received from the server is presented, unaltered, without considering
 export declare function getAggregateFromServer<AggregateSpecType extends AggregateSpec, AppModelType, DbModelType extends DocumentData>(query: Query<AppModelType, DbModelType>, aggregateSpec: AggregateSpecType): Promise<AggregateQuerySnapshot<AggregateSpecType, AppModelType, DbModelType>>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -1500,7 +1528,7 @@ const averageScore: number | null = aggregateSnapshot.data().averageScore;
 
 ```
 
-## getCountFromServer() {:#getcountfromserver_4e56953}
+### getCountFromServer(query) {:#getcountfromserver_4e56953}
 
 Calculates the number of documents in the result set of the given query, without actually downloading the documents.
 
@@ -1516,7 +1544,7 @@ export declare function getCountFromServer<AppModelType, DbModelType extends Doc
 }, AppModelType, DbModelType>>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -1528,7 +1556,7 @@ Promise&lt;[AggregateQuerySnapshot](./firestore_.aggregatequerysnapshot.md#aggre
 
 A Promise that will be resolved with the count; the count can be retrieved from `snapshot.data().count`<!-- -->, where `snapshot` is the `AggregateQuerySnapshot` to which the returned Promise resolves.
 
-## getDocs() {:#getdocs_4e56953}
+### getDocs(query) {:#getdocs_4e56953}
 
 Executes the query and returns the results as a `QuerySnapshot`<!-- -->.
 
@@ -1540,7 +1568,7 @@ Note: `getDocs()` attempts to provide up-to-date data when possible by waiting f
 export declare function getDocs<AppModelType, DbModelType extends DocumentData>(query: Query<AppModelType, DbModelType>): Promise<QuerySnapshot<AppModelType, DbModelType>>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -1552,7 +1580,7 @@ Promise&lt;[QuerySnapshot](./firestore_.querysnapshot.md#querysnapshot_class)<!-
 
 A `Promise` that will be resolved with the results of the query.
 
-## getDocsFromCache() {:#getdocsfromcache_4e56953}
+### getDocsFromCache(query) {:#getdocsfromcache_4e56953}
 
 Executes the query and returns the results as a `QuerySnapshot` from cache. Returns an empty result set if no documents matching the query are currently cached.
 
@@ -1562,7 +1590,7 @@ Executes the query and returns the results as a `QuerySnapshot` from cache. Retu
 export declare function getDocsFromCache<AppModelType, DbModelType extends DocumentData>(query: Query<AppModelType, DbModelType>): Promise<QuerySnapshot<AppModelType, DbModelType>>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -1574,7 +1602,7 @@ Promise&lt;[QuerySnapshot](./firestore_.querysnapshot.md#querysnapshot_class)<!-
 
 A `Promise` that will be resolved with the results of the query.
 
-## getDocsFromServer() {:#getdocsfromserver_4e56953}
+### getDocsFromServer(query) {:#getdocsfromserver_4e56953}
 
 Executes the query and returns the results as a `QuerySnapshot` from the server. Returns an error if the network is not available.
 
@@ -1584,7 +1612,7 @@ Executes the query and returns the results as a `QuerySnapshot` from the server.
 export declare function getDocsFromServer<AppModelType, DbModelType extends DocumentData>(query: Query<AppModelType, DbModelType>): Promise<QuerySnapshot<AppModelType, DbModelType>>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -1596,7 +1624,7 @@ Promise&lt;[QuerySnapshot](./firestore_.querysnapshot.md#querysnapshot_class)<!-
 
 A `Promise` that will be resolved with the results of the query.
 
-## onSnapshot() {:#onsnapshot_8d14049}
+### onSnapshot(query, observer) {:#onsnapshot_8d14049}
 
 Attaches a listener for `QuerySnapshot` events. You may either pass individual `onNext` and `onError` callbacks or pass a single observer object with `next` and `error` callbacks. The listener can be cancelled by calling the function that is returned when `onSnapshot` is called.
 
@@ -1612,7 +1640,7 @@ export declare function onSnapshot<AppModelType, DbModelType extends DocumentDat
 }): Unsubscribe;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -1625,7 +1653,7 @@ export declare function onSnapshot<AppModelType, DbModelType extends DocumentDat
 
 An unsubscribe function that can be called to cancel the snapshot listener.
 
-## onSnapshot() {:#onsnapshot_03dfff5}
+### onSnapshot(query, options, observer) {:#onsnapshot_03dfff5}
 
 Attaches a listener for `QuerySnapshot` events. You may either pass individual `onNext` and `onError` callbacks or pass a single observer object with `next` and `error` callbacks. The listener can be cancelled by calling the function that is returned when `onSnapshot` is called.
 
@@ -1641,7 +1669,7 @@ export declare function onSnapshot<AppModelType, DbModelType extends DocumentDat
 }): Unsubscribe;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -1655,7 +1683,7 @@ export declare function onSnapshot<AppModelType, DbModelType extends DocumentDat
 
 An unsubscribe function that can be called to cancel the snapshot listener.
 
-## onSnapshot() {:#onsnapshot_3ebfbe2}
+### onSnapshot(query, onNext, onError, onCompletion) {:#onsnapshot_3ebfbe2}
 
 Attaches a listener for `QuerySnapshot` events. You may either pass individual `onNext` and `onError` callbacks or pass a single observer object with `next` and `error` callbacks. The listener can be cancelled by calling the function that is returned when `onSnapshot` is called.
 
@@ -1667,7 +1695,7 @@ NOTE: Although an `onCompletion` callback can be provided, it will never be call
 export declare function onSnapshot<AppModelType, DbModelType extends DocumentData>(query: Query<AppModelType, DbModelType>, onNext: (snapshot: QuerySnapshot<AppModelType, DbModelType>) => void, onError?: (error: FirestoreError) => void, onCompletion?: () => void): Unsubscribe;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -1682,7 +1710,7 @@ export declare function onSnapshot<AppModelType, DbModelType extends DocumentDat
 
 An unsubscribe function that can be called to cancel the snapshot listener.
 
-## onSnapshot() {:#onsnapshot_b8f9c47}
+### onSnapshot(query, options, onNext, onError, onCompletion) {:#onsnapshot_b8f9c47}
 
 Attaches a listener for `QuerySnapshot` events. You may either pass individual `onNext` and `onError` callbacks or pass a single observer object with `next` and `error` callbacks. The listener can be cancelled by calling the function that is returned when `onSnapshot` is called.
 
@@ -1694,7 +1722,7 @@ NOTE: Although an `onCompletion` callback can be provided, it will never be call
 export declare function onSnapshot<AppModelType, DbModelType extends DocumentData>(query: Query<AppModelType, DbModelType>, options: SnapshotListenOptions, onNext: (snapshot: QuerySnapshot<AppModelType, DbModelType>) => void, onError?: (error: FirestoreError) => void, onCompletion?: () => void): Unsubscribe;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -1710,7 +1738,7 @@ export declare function onSnapshot<AppModelType, DbModelType extends DocumentDat
 
 An unsubscribe function that can be called to cancel the snapshot listener.
 
-## query() {:#query_9f7b0f4}
+### query(query, compositeFilter, queryConstraints) {:#query_9f7b0f4}
 
 Creates a new immutable instance of [Query](./firestore_.query.md#query_class) that is extended to also include additional query constraints.
 
@@ -1720,7 +1748,7 @@ Creates a new immutable instance of [Query](./firestore_.query.md#query_class) t
 export declare function query<AppModelType, DbModelType extends DocumentData>(query: Query<AppModelType, DbModelType>, compositeFilter: QueryCompositeFilterConstraint, ...queryConstraints: QueryNonFilterConstraint[]): Query<AppModelType, DbModelType>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -1732,11 +1760,11 @@ export declare function query<AppModelType, DbModelType extends DocumentData>(qu
 
 [Query](./firestore_.query.md#query_class)<!-- -->&lt;AppModelType, DbModelType&gt;
 
-## Exceptions
+#### Exceptions
 
 if any of the provided query constraints cannot be combined with the existing or new constraints.
 
-## query() {:#query_0f46da1}
+### query(query, queryConstraints) {:#query_0f46da1}
 
 Creates a new immutable instance of [Query](./firestore_.query.md#query_class) that is extended to also include additional query constraints.
 
@@ -1746,7 +1774,7 @@ Creates a new immutable instance of [Query](./firestore_.query.md#query_class) t
 export declare function query<AppModelType, DbModelType extends DocumentData>(query: Query<AppModelType, DbModelType>, ...queryConstraints: QueryConstraint[]): Query<AppModelType, DbModelType>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -1757,11 +1785,13 @@ export declare function query<AppModelType, DbModelType extends DocumentData>(qu
 
 [Query](./firestore_.query.md#query_class)<!-- -->&lt;AppModelType, DbModelType&gt;
 
-## Exceptions
+#### Exceptions
 
 if any of the provided query constraints cannot be combined with the existing or new constraints.
 
-## and() {:#and_e72c712}
+## function(queryConstraints, ...)
+
+### and(queryConstraints) {:#and_e72c712}
 
 Creates a new [QueryCompositeFilterConstraint](./firestore_.querycompositefilterconstraint.md#querycompositefilterconstraint_class) that is a conjunction of the given filter constraints. A conjunction filter includes a document if it satisfies all of the given filters.
 
@@ -1771,7 +1801,7 @@ Creates a new [QueryCompositeFilterConstraint](./firestore_.querycompositefilter
 export declare function and(...queryConstraints: QueryFilterConstraint[]): QueryCompositeFilterConstraint;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -1783,7 +1813,7 @@ export declare function and(...queryConstraints: QueryFilterConstraint[]): Query
 
 The newly created [QueryCompositeFilterConstraint](./firestore_.querycompositefilterconstraint.md#querycompositefilterconstraint_class)<!-- -->.
 
-## or() {:#or_e72c712}
+### or(queryConstraints) {:#or_e72c712}
 
 Creates a new [QueryCompositeFilterConstraint](./firestore_.querycompositefilterconstraint.md#querycompositefilterconstraint_class) that is a disjunction of the given filter constraints. A disjunction filter includes a document if it satisfies any of the given filters.
 
@@ -1793,7 +1823,7 @@ Creates a new [QueryCompositeFilterConstraint](./firestore_.querycompositefilter
 export declare function or(...queryConstraints: QueryFilterConstraint[]): QueryCompositeFilterConstraint;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -1805,7 +1835,9 @@ export declare function or(...queryConstraints: QueryFilterConstraint[]): QueryC
 
 The newly created [QueryCompositeFilterConstraint](./firestore_.querycompositefilterconstraint.md#querycompositefilterconstraint_class)<!-- -->.
 
-## addDoc() {:#adddoc_6e783ff}
+## function(reference, ...)
+
+### addDoc(reference, data) {:#adddoc_6e783ff}
 
 Add a new document to specified `CollectionReference` with the given data, assigning it a document ID automatically.
 
@@ -1815,7 +1847,7 @@ Add a new document to specified `CollectionReference` with the given data, assig
 export declare function addDoc<AppModelType, DbModelType extends DocumentData>(reference: CollectionReference<AppModelType, DbModelType>, data: WithFieldValue<AppModelType>): Promise<DocumentReference<AppModelType, DbModelType>>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -1828,7 +1860,7 @@ Promise&lt;[DocumentReference](./firestore_.documentreference.md#documentreferen
 
 A `Promise` resolved with a `DocumentReference` pointing to the newly created document after it has been written to the backend (Note that it won't resolve while you're offline).
 
-## collection() {:#collection_568f98d}
+### collection(reference, path, pathSegments) {:#collection_568f98d}
 
 Gets a `CollectionReference` instance that refers to a subcollection of `reference` at the the specified relative path.
 
@@ -1838,7 +1870,7 @@ Gets a `CollectionReference` instance that refers to a subcollection of `referen
 export declare function collection<AppModelType, DbModelType extends DocumentData>(reference: CollectionReference<AppModelType, DbModelType>, path: string, ...pathSegments: string[]): CollectionReference<DocumentData, DocumentData>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -1852,11 +1884,11 @@ export declare function collection<AppModelType, DbModelType extends DocumentDat
 
 The `CollectionReference` instance.
 
-## Exceptions
+#### Exceptions
 
 If the final path has an even number of segments and does not point to a collection.
 
-## collection() {:#collection_70b4396}
+### collection(reference, path, pathSegments) {:#collection_70b4396}
 
 Gets a `CollectionReference` instance that refers to a subcollection of `reference` at the the specified relative path.
 
@@ -1866,7 +1898,7 @@ Gets a `CollectionReference` instance that refers to a subcollection of `referen
 export declare function collection<AppModelType, DbModelType extends DocumentData>(reference: DocumentReference<AppModelType, DbModelType>, path: string, ...pathSegments: string[]): CollectionReference<DocumentData, DocumentData>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -1880,11 +1912,11 @@ export declare function collection<AppModelType, DbModelType extends DocumentDat
 
 The `CollectionReference` instance.
 
-## Exceptions
+#### Exceptions
 
 If the final path has an even number of segments and does not point to a collection.
 
-## deleteDoc() {:#deletedoc_4569087}
+### deleteDoc(reference) {:#deletedoc_4569087}
 
 Deletes the document referred to by the specified `DocumentReference`<!-- -->.
 
@@ -1894,7 +1926,7 @@ Deletes the document referred to by the specified `DocumentReference`<!-- -->.
 export declare function deleteDoc<AppModelType, DbModelType extends DocumentData>(reference: DocumentReference<AppModelType, DbModelType>): Promise<void>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -1906,7 +1938,7 @@ Promise&lt;void&gt;
 
 A Promise resolved once the document has been successfully deleted from the backend (note that it won't resolve while you're offline).
 
-## doc() {:#doc_568f98d}
+### doc(reference, path, pathSegments) {:#doc_568f98d}
 
 Gets a `DocumentReference` instance that refers to a document within `reference` at the specified relative path. If no path is specified, an automatically-generated unique ID will be used for the returned `DocumentReference`<!-- -->.
 
@@ -1916,7 +1948,7 @@ Gets a `DocumentReference` instance that refers to a document within `reference`
 export declare function doc<AppModelType, DbModelType extends DocumentData>(reference: CollectionReference<AppModelType, DbModelType>, path?: string, ...pathSegments: string[]): DocumentReference<AppModelType, DbModelType>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -1930,11 +1962,11 @@ export declare function doc<AppModelType, DbModelType extends DocumentData>(refe
 
 The `DocumentReference` instance.
 
-## Exceptions
+#### Exceptions
 
 If the final path has an odd number of segments and does not point to a document.
 
-## doc() {:#doc_70b4396}
+### doc(reference, path, pathSegments) {:#doc_70b4396}
 
 Gets a `DocumentReference` instance that refers to a document within `reference` at the specified relative path.
 
@@ -1944,7 +1976,7 @@ Gets a `DocumentReference` instance that refers to a document within `reference`
 export declare function doc<AppModelType, DbModelType extends DocumentData>(reference: DocumentReference<AppModelType, DbModelType>, path: string, ...pathSegments: string[]): DocumentReference<DocumentData, DocumentData>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -1958,11 +1990,11 @@ export declare function doc<AppModelType, DbModelType extends DocumentData>(refe
 
 The `DocumentReference` instance.
 
-## Exceptions
+#### Exceptions
 
 If the final path has an odd number of segments and does not point to a document.
 
-## getDoc() {:#getdoc_4569087}
+### getDoc(reference) {:#getdoc_4569087}
 
 Reads the document referred to by this `DocumentReference`<!-- -->.
 
@@ -1974,7 +2006,7 @@ Note: `getDoc()` attempts to provide up-to-date data when possible by waiting fo
 export declare function getDoc<AppModelType, DbModelType extends DocumentData>(reference: DocumentReference<AppModelType, DbModelType>): Promise<DocumentSnapshot<AppModelType, DbModelType>>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -1986,7 +2018,7 @@ Promise&lt;[DocumentSnapshot](./firestore_.documentsnapshot.md#documentsnapshot_
 
 A Promise resolved with a `DocumentSnapshot` containing the current document contents.
 
-## getDocFromCache() {:#getdocfromcache_4569087}
+### getDocFromCache(reference) {:#getdocfromcache_4569087}
 
 Reads the document referred to by this `DocumentReference` from cache. Returns an error if the document is not currently cached.
 
@@ -1996,7 +2028,7 @@ Reads the document referred to by this `DocumentReference` from cache. Returns a
 export declare function getDocFromCache<AppModelType, DbModelType extends DocumentData>(reference: DocumentReference<AppModelType, DbModelType>): Promise<DocumentSnapshot<AppModelType, DbModelType>>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -2008,7 +2040,7 @@ Promise&lt;[DocumentSnapshot](./firestore_.documentsnapshot.md#documentsnapshot_
 
 A `Promise` resolved with a `DocumentSnapshot` containing the current document contents.
 
-## getDocFromServer() {:#getdocfromserver_4569087}
+### getDocFromServer(reference) {:#getdocfromserver_4569087}
 
 Reads the document referred to by this `DocumentReference` from the server. Returns an error if the network is not available.
 
@@ -2018,7 +2050,7 @@ Reads the document referred to by this `DocumentReference` from the server. Retu
 export declare function getDocFromServer<AppModelType, DbModelType extends DocumentData>(reference: DocumentReference<AppModelType, DbModelType>): Promise<DocumentSnapshot<AppModelType, DbModelType>>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -2030,7 +2062,7 @@ Promise&lt;[DocumentSnapshot](./firestore_.documentsnapshot.md#documentsnapshot_
 
 A `Promise` resolved with a `DocumentSnapshot` containing the current document contents.
 
-## onSnapshot() {:#onsnapshot_0312fd7}
+### onSnapshot(reference, observer) {:#onsnapshot_0312fd7}
 
 Attaches a listener for `DocumentSnapshot` events. You may either pass individual `onNext` and `onError` callbacks or pass a single observer object with `next` and `error` callbacks.
 
@@ -2046,7 +2078,7 @@ export declare function onSnapshot<AppModelType, DbModelType extends DocumentDat
 }): Unsubscribe;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -2059,7 +2091,7 @@ export declare function onSnapshot<AppModelType, DbModelType extends DocumentDat
 
 An unsubscribe function that can be called to cancel the snapshot listener.
 
-## onSnapshot() {:#onsnapshot_86b6b9e}
+### onSnapshot(reference, options, observer) {:#onsnapshot_86b6b9e}
 
 Attaches a listener for `DocumentSnapshot` events. You may either pass individual `onNext` and `onError` callbacks or pass a single observer object with `next` and `error` callbacks.
 
@@ -2075,7 +2107,7 @@ export declare function onSnapshot<AppModelType, DbModelType extends DocumentDat
 }): Unsubscribe;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -2089,7 +2121,7 @@ export declare function onSnapshot<AppModelType, DbModelType extends DocumentDat
 
 An unsubscribe function that can be called to cancel the snapshot listener.
 
-## onSnapshot() {:#onsnapshot_905f42c}
+### onSnapshot(reference, onNext, onError, onCompletion) {:#onsnapshot_905f42c}
 
 Attaches a listener for `DocumentSnapshot` events. You may either pass individual `onNext` and `onError` callbacks or pass a single observer object with `next` and `error` callbacks.
 
@@ -2101,7 +2133,7 @@ NOTE: Although an `onCompletion` callback can be provided, it will never be call
 export declare function onSnapshot<AppModelType, DbModelType extends DocumentData>(reference: DocumentReference<AppModelType, DbModelType>, onNext: (snapshot: DocumentSnapshot<AppModelType, DbModelType>) => void, onError?: (error: FirestoreError) => void, onCompletion?: () => void): Unsubscribe;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -2116,7 +2148,7 @@ export declare function onSnapshot<AppModelType, DbModelType extends DocumentDat
 
 An unsubscribe function that can be called to cancel the snapshot listener.
 
-## onSnapshot() {:#onsnapshot_0c39991}
+### onSnapshot(reference, options, onNext, onError, onCompletion) {:#onsnapshot_0c39991}
 
 Attaches a listener for `DocumentSnapshot` events. You may either pass individual `onNext` and `onError` callbacks or pass a single observer object with `next` and `error` callbacks.
 
@@ -2128,7 +2160,7 @@ NOTE: Although an `onCompletion` callback can be provided, it will never be call
 export declare function onSnapshot<AppModelType, DbModelType extends DocumentData>(reference: DocumentReference<AppModelType, DbModelType>, options: SnapshotListenOptions, onNext: (snapshot: DocumentSnapshot<AppModelType, DbModelType>) => void, onError?: (error: FirestoreError) => void, onCompletion?: () => void): Unsubscribe;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -2144,7 +2176,7 @@ export declare function onSnapshot<AppModelType, DbModelType extends DocumentDat
 
 An unsubscribe function that can be called to cancel the snapshot listener.
 
-## setDoc() {:#setdoc_ee215ad}
+### setDoc(reference, data) {:#setdoc_ee215ad}
 
 Writes to the document referred to by this `DocumentReference`<!-- -->. If the document does not yet exist, it will be created.
 
@@ -2154,7 +2186,7 @@ Writes to the document referred to by this `DocumentReference`<!-- -->. If the d
 export declare function setDoc<AppModelType, DbModelType extends DocumentData>(reference: DocumentReference<AppModelType, DbModelType>, data: WithFieldValue<AppModelType>): Promise<void>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -2167,7 +2199,7 @@ Promise&lt;void&gt;
 
 A `Promise` resolved once the data has been successfully written to the backend (note that it won't resolve while you're offline).
 
-## setDoc() {:#setdoc_ff80739}
+### setDoc(reference, data, options) {:#setdoc_ff80739}
 
 Writes to the document referred to by the specified `DocumentReference`<!-- -->. If the document does not yet exist, it will be created. If you provide `merge` or `mergeFields`<!-- -->, the provided data can be merged into an existing document.
 
@@ -2177,7 +2209,7 @@ Writes to the document referred to by the specified `DocumentReference`<!-- -->.
 export declare function setDoc<AppModelType, DbModelType extends DocumentData>(reference: DocumentReference<AppModelType, DbModelType>, data: PartialWithFieldValue<AppModelType>, options: SetOptions): Promise<void>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -2191,7 +2223,7 @@ Promise&lt;void&gt;
 
 A Promise resolved once the data has been successfully written to the backend (note that it won't resolve while you're offline).
 
-## updateDoc() {:#updatedoc_51a65e3}
+### updateDoc(reference, data) {:#updatedoc_51a65e3}
 
 Updates fields in the document referred to by the specified `DocumentReference`<!-- -->. The update will fail if applied to a document that does not exist.
 
@@ -2201,7 +2233,7 @@ Updates fields in the document referred to by the specified `DocumentReference`<
 export declare function updateDoc<AppModelType, DbModelType extends DocumentData>(reference: DocumentReference<AppModelType, DbModelType>, data: UpdateData<DbModelType>): Promise<void>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -2214,7 +2246,7 @@ Promise&lt;void&gt;
 
 A `Promise` resolved once the data has been successfully written to the backend (note that it won't resolve while you're offline).
 
-## updateDoc() {:#updatedoc_7c28659}
+### updateDoc(reference, field, value, moreFieldsAndValues) {:#updatedoc_7c28659}
 
 Updates fields in the document referred to by the specified `DocumentReference` The update will fail if applied to a document that does not exist.
 
@@ -2226,7 +2258,7 @@ Nested fields can be updated by providing dot-separated field path strings or by
 export declare function updateDoc<AppModelType, DbModelType extends DocumentData>(reference: DocumentReference<AppModelType, DbModelType>, field: string | FieldPath, value: unknown, ...moreFieldsAndValues: unknown[]): Promise<void>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -2241,7 +2273,9 @@ Promise&lt;void&gt;
 
 A `Promise` resolved once the data has been successfully written to the backend (note that it won't resolve while you're offline).
 
-## memoryLocalCache() {:#memorylocalcache_05f4bf2}
+## function(settings, ...)
+
+### memoryLocalCache(settings) {:#memorylocalcache_05f4bf2}
 
 Creates an instance of `MemoryLocalCache`<!-- -->. The instance can be set to `FirestoreSettings.cache` to tell the SDK which cache layer to use.
 
@@ -2251,7 +2285,7 @@ Creates an instance of `MemoryLocalCache`<!-- -->. The instance can be set to `F
 export declare function memoryLocalCache(settings?: MemoryCacheSettings): MemoryLocalCache;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -2261,7 +2295,7 @@ export declare function memoryLocalCache(settings?: MemoryCacheSettings): Memory
 
 [MemoryLocalCache](./firestore_.memorylocalcache.md#memorylocalcache_interface)
 
-## memoryLruGarbageCollector() {:#memorylrugarbagecollector_5ee014c}
+### memoryLruGarbageCollector(settings) {:#memorylrugarbagecollector_5ee014c}
 
 Creates an instance of `MemoryLruGarbageCollector`<!-- -->.
 
@@ -2275,7 +2309,7 @@ export declare function memoryLruGarbageCollector(settings?: {
 }): MemoryLruGarbageCollector;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -2285,7 +2319,7 @@ export declare function memoryLruGarbageCollector(settings?: {
 
 [MemoryLruGarbageCollector](./firestore_.memorylrugarbagecollector.md#memorylrugarbagecollector_interface)
 
-## persistentLocalCache() {:#persistentlocalcache_d312f71}
+### persistentLocalCache(settings) {:#persistentlocalcache_d312f71}
 
 Creates an instance of `PersistentLocalCache`<!-- -->. The instance can be set to `FirestoreSettings.cache` to tell the SDK which cache layer to use.
 
@@ -2297,7 +2331,7 @@ Persistent cache cannot be used in a Node.js environment.
 export declare function persistentLocalCache(settings?: PersistentCacheSettings): PersistentLocalCache;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -2307,7 +2341,7 @@ export declare function persistentLocalCache(settings?: PersistentCacheSettings)
 
 [PersistentLocalCache](./firestore_.persistentlocalcache.md#persistentlocalcache_interface)
 
-## persistentSingleTabManager() {:#persistentsingletabmanager_c99c68d}
+### persistentSingleTabManager(settings) {:#persistentsingletabmanager_c99c68d}
 
 Creates an instance of `PersistentSingleTabManager`<!-- -->.
 
@@ -2317,7 +2351,7 @@ Creates an instance of `PersistentSingleTabManager`<!-- -->.
 export declare function persistentSingleTabManager(settings: PersistentSingleTabManagerSettings | undefined): PersistentSingleTabManager;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -2327,7 +2361,9 @@ export declare function persistentSingleTabManager(settings: PersistentSingleTab
 
 [PersistentSingleTabManager](./firestore_.persistentsingletabmanager.md#persistentsingletabmanager_interface)
 
-## endAt() {:#endat_9a4477f}
+## function(snapshot, ...)
+
+### endAt(snapshot) {:#endat_9a4477f}
 
 Creates a [QueryEndAtConstraint](./firestore_.queryendatconstraint.md#queryendatconstraint_class) that modifies the result set to end at the provided document (inclusive). The end position is relative to the order of the query. The document must contain all of the fields provided in the orderBy of the query.
 
@@ -2337,7 +2373,7 @@ Creates a [QueryEndAtConstraint](./firestore_.queryendatconstraint.md#queryendat
 export declare function endAt<AppModelType, DbModelType extends DocumentData>(snapshot: DocumentSnapshot<AppModelType, DbModelType>): QueryEndAtConstraint;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -2349,7 +2385,7 @@ export declare function endAt<AppModelType, DbModelType extends DocumentData>(sn
 
 A [QueryEndAtConstraint](./firestore_.queryendatconstraint.md#queryendatconstraint_class) to pass to `query()`
 
-## endBefore() {:#endbefore_9a4477f}
+### endBefore(snapshot) {:#endbefore_9a4477f}
 
 Creates a [QueryEndAtConstraint](./firestore_.queryendatconstraint.md#queryendatconstraint_class) that modifies the result set to end before the provided document (exclusive). The end position is relative to the order of the query. The document must contain all of the fields provided in the orderBy of the query.
 
@@ -2359,7 +2395,7 @@ Creates a [QueryEndAtConstraint](./firestore_.queryendatconstraint.md#queryendat
 export declare function endBefore<AppModelType, DbModelType extends DocumentData>(snapshot: DocumentSnapshot<AppModelType, DbModelType>): QueryEndAtConstraint;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -2371,7 +2407,7 @@ export declare function endBefore<AppModelType, DbModelType extends DocumentData
 
 A [QueryEndAtConstraint](./firestore_.queryendatconstraint.md#queryendatconstraint_class) to pass to `query()`
 
-## startAfter() {:#startafter_9a4477f}
+### startAfter(snapshot) {:#startafter_9a4477f}
 
 Creates a [QueryStartAtConstraint](./firestore_.querystartatconstraint.md#querystartatconstraint_class) that modifies the result set to start after the provided document (exclusive). The starting position is relative to the order of the query. The document must contain all of the fields provided in the orderBy of the query.
 
@@ -2381,7 +2417,7 @@ Creates a [QueryStartAtConstraint](./firestore_.querystartatconstraint.md#querys
 export declare function startAfter<AppModelType, DbModelType extends DocumentData>(snapshot: DocumentSnapshot<AppModelType, DbModelType>): QueryStartAtConstraint;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -2393,7 +2429,7 @@ export declare function startAfter<AppModelType, DbModelType extends DocumentDat
 
 A [QueryStartAtConstraint](./firestore_.querystartatconstraint.md#querystartatconstraint_class) to pass to `query()`
 
-## startAt() {:#startat_9a4477f}
+### startAt(snapshot) {:#startat_9a4477f}
 
 Creates a [QueryStartAtConstraint](./firestore_.querystartatconstraint.md#querystartatconstraint_class) that modifies the result set to start at the provided document (inclusive). The starting position is relative to the order of the query. The document must contain all of the fields provided in the `orderBy` of this query.
 
@@ -2403,7 +2439,7 @@ Creates a [QueryStartAtConstraint](./firestore_.querystartatconstraint.md#querys
 export declare function startAt<AppModelType, DbModelType extends DocumentData>(snapshot: DocumentSnapshot<AppModelType, DbModelType>): QueryStartAtConstraint;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |

--- a/docs-devsite/firestore_.query.md
+++ b/docs-devsite/firestore_.query.md
@@ -89,7 +89,7 @@ Removes the current converter.
 withConverter(converter: null): Query<DocumentData, DocumentData>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -111,7 +111,7 @@ Applies a custom data converter to this query, allowing you to use your own cust
 withConverter<NewAppModelType, NewDbModelType extends DocumentData = DocumentData>(converter: FirestoreDataConverter<NewAppModelType, NewDbModelType>): Query<NewAppModelType, NewDbModelType>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |

--- a/docs-devsite/firestore_.querydocumentsnapshot.md
+++ b/docs-devsite/firestore_.querydocumentsnapshot.md
@@ -40,7 +40,7 @@ By default, `serverTimestamp()` values that have not yet been set to their final
 data(options?: SnapshotOptions): AppModelType;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |

--- a/docs-devsite/firestore_.querysnapshot.md
+++ b/docs-devsite/firestore_.querysnapshot.md
@@ -95,7 +95,7 @@ Returns an array of the documents changes since the last snapshot. If this is th
 docChanges(options?: SnapshotListenOptions): Array<DocumentChange<AppModelType, DbModelType>>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -115,7 +115,7 @@ Enumerates all of the documents in the `QuerySnapshot`<!-- -->.
 forEach(callback: (result: QueryDocumentSnapshot<AppModelType, DbModelType>) => void, thisArg?: unknown): void;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |

--- a/docs-devsite/firestore_.snapshotmetadata.md
+++ b/docs-devsite/firestore_.snapshotmetadata.md
@@ -61,7 +61,7 @@ Returns true if this `SnapshotMetadata` is equal to the provided one.
 isEqual(other: SnapshotMetadata): boolean;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |

--- a/docs-devsite/firestore_.timestamp.md
+++ b/docs-devsite/firestore_.timestamp.md
@@ -61,7 +61,7 @@ constructor(
     nanoseconds: number);
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -98,7 +98,7 @@ Creates a new timestamp from the given date.
 static fromDate(date: Date): Timestamp;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -120,7 +120,7 @@ Creates a new timestamp from the given number of milliseconds.
 static fromMillis(milliseconds: number): Timestamp;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -142,7 +142,7 @@ Returns true if this `Timestamp` is equal to the provided one.
 isEqual(other: Timestamp): boolean;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |

--- a/docs-devsite/firestore_.transaction.md
+++ b/docs-devsite/firestore_.transaction.md
@@ -41,7 +41,7 @@ Deletes the document referred to by the provided [DocumentReference](./firestore
 delete<AppModelType, DbModelType extends DocumentData>(documentRef: DocumentReference<AppModelType, DbModelType>): this;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -63,7 +63,7 @@ Reads the document referenced by the provided [DocumentReference](./firestore_.d
 get<AppModelType, DbModelType extends DocumentData>(documentRef: DocumentReference<AppModelType, DbModelType>): Promise<DocumentSnapshot<AppModelType, DbModelType>>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -85,7 +85,7 @@ Writes to the document referred to by the provided [DocumentReference](./firesto
 set<AppModelType, DbModelType extends DocumentData>(documentRef: DocumentReference<AppModelType, DbModelType>, data: WithFieldValue<AppModelType>): this;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -98,7 +98,7 @@ this
 
 This `Transaction` instance. Used for chaining method calls.
 
-## Exceptions
+#### Exceptions
 
 Error - If the provided input is not a valid Firestore document.
 
@@ -112,7 +112,7 @@ Writes to the document referred to by the provided [DocumentReference](./firesto
 set<AppModelType, DbModelType extends DocumentData>(documentRef: DocumentReference<AppModelType, DbModelType>, data: PartialWithFieldValue<AppModelType>, options: SetOptions): this;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -126,7 +126,7 @@ this
 
 This `Transaction` instance. Used for chaining method calls.
 
-## Exceptions
+#### Exceptions
 
 Error - If the provided input is not a valid Firestore document.
 
@@ -140,7 +140,7 @@ Updates fields in the document referred to by the provided [DocumentReference](.
 update<AppModelType, DbModelType extends DocumentData>(documentRef: DocumentReference<AppModelType, DbModelType>, data: UpdateData<DbModelType>): this;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -153,7 +153,7 @@ this
 
 This `Transaction` instance. Used for chaining method calls.
 
-## Exceptions
+#### Exceptions
 
 Error - If the provided input is not valid Firestore data.
 
@@ -169,7 +169,7 @@ Nested fields can be updated by providing dot-separated field path strings or by
 update<AppModelType, DbModelType extends DocumentData>(documentRef: DocumentReference<AppModelType, DbModelType>, field: string | FieldPath, value: unknown, ...moreFieldsAndValues: unknown[]): this;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -184,7 +184,7 @@ this
 
 This `Transaction` instance. Used for chaining method calls.
 
-## Exceptions
+#### Exceptions
 
 Error - If the provided input is not valid Firestore data.
 

--- a/docs-devsite/firestore_.writebatch.md
+++ b/docs-devsite/firestore_.writebatch.md
@@ -58,7 +58,7 @@ Deletes the document referred to by the provided [DocumentReference](./firestore
 delete<AppModelType, DbModelType extends DocumentData>(documentRef: DocumentReference<AppModelType, DbModelType>): WriteBatch;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -80,7 +80,7 @@ Writes to the document referred to by the provided [DocumentReference](./firesto
 set<AppModelType, DbModelType extends DocumentData>(documentRef: DocumentReference<AppModelType, DbModelType>, data: WithFieldValue<AppModelType>): WriteBatch;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -103,7 +103,7 @@ Writes to the document referred to by the provided [DocumentReference](./firesto
 set<AppModelType, DbModelType extends DocumentData>(documentRef: DocumentReference<AppModelType, DbModelType>, data: PartialWithFieldValue<AppModelType>, options: SetOptions): WriteBatch;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -117,7 +117,7 @@ set<AppModelType, DbModelType extends DocumentData>(documentRef: DocumentReferen
 
 This `WriteBatch` instance. Used for chaining method calls.
 
-## Exceptions
+#### Exceptions
 
 Error - If the provided input is not a valid Firestore document.
 
@@ -131,7 +131,7 @@ Updates fields in the document referred to by the provided [DocumentReference](.
 update<AppModelType, DbModelType extends DocumentData>(documentRef: DocumentReference<AppModelType, DbModelType>, data: UpdateData<DbModelType>): WriteBatch;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -144,7 +144,7 @@ update<AppModelType, DbModelType extends DocumentData>(documentRef: DocumentRefe
 
 This `WriteBatch` instance. Used for chaining method calls.
 
-## Exceptions
+#### Exceptions
 
 Error - If the provided input is not valid Firestore data.
 
@@ -160,7 +160,7 @@ Nested fields can be update by providing dot-separated field path strings or by 
 update<AppModelType, DbModelType extends DocumentData>(documentRef: DocumentReference<AppModelType, DbModelType>, field: string | FieldPath, value: unknown, ...moreFieldsAndValues: unknown[]): WriteBatch;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -175,7 +175,7 @@ update<AppModelType, DbModelType extends DocumentData>(documentRef: DocumentRefe
 
 This `WriteBatch` instance. Used for chaining method calls.
 
-## Exceptions
+#### Exceptions
 
 Error - If the provided input is not valid Firestore data.
 

--- a/docs-devsite/firestore_lite.bytes.md
+++ b/docs-devsite/firestore_lite.bytes.md
@@ -39,7 +39,7 @@ Creates a new `Bytes` object from the given Base64 string, converting it to byte
 static fromBase64String(base64: string): Bytes;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -59,7 +59,7 @@ Creates a new `Bytes` object from the given Uint8Array.
 static fromUint8Array(array: Uint8Array): Bytes;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -79,7 +79,7 @@ Returns true if this `Bytes` object is equal to the provided one.
 isEqual(other: Bytes): boolean;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |

--- a/docs-devsite/firestore_lite.collectionreference.md
+++ b/docs-devsite/firestore_lite.collectionreference.md
@@ -85,7 +85,7 @@ Applies a custom data converter to this `CollectionReference`<!-- -->, allowing 
 withConverter<NewAppModelType, NewDbModelType extends DocumentData = DocumentData>(converter: FirestoreDataConverter<NewAppModelType, NewDbModelType>): CollectionReference<NewAppModelType, NewDbModelType>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -107,7 +107,7 @@ Removes the current converter.
 withConverter(converter: null): CollectionReference<DocumentData, DocumentData>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |

--- a/docs-devsite/firestore_lite.documentreference.md
+++ b/docs-devsite/firestore_lite.documentreference.md
@@ -106,7 +106,7 @@ Applies a custom data converter to this `DocumentReference`<!-- -->, allowing yo
 withConverter<NewAppModelType, NewDbModelType extends DocumentData = DocumentData>(converter: FirestoreDataConverter<NewAppModelType, NewDbModelType>): DocumentReference<NewAppModelType, NewDbModelType>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -128,7 +128,7 @@ Removes the current converter.
 withConverter(converter: null): DocumentReference<DocumentData, DocumentData>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |

--- a/docs-devsite/firestore_lite.documentsnapshot.md
+++ b/docs-devsite/firestore_lite.documentsnapshot.md
@@ -111,7 +111,7 @@ Retrieves the field specified by `fieldPath`<!-- -->. Returns `undefined` if the
 get(fieldPath: string | FieldPath): any;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |

--- a/docs-devsite/firestore_lite.fieldpath.md
+++ b/docs-devsite/firestore_lite.fieldpath.md
@@ -42,7 +42,7 @@ Creates a `FieldPath` from the provided field names. If more than one field name
 constructor(...fieldNames: string[]);
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -58,7 +58,7 @@ Returns true if this `FieldPath` is equal to the provided one.
 isEqual(other: FieldPath): boolean;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |

--- a/docs-devsite/firestore_lite.fieldvalue.md
+++ b/docs-devsite/firestore_lite.fieldvalue.md
@@ -34,7 +34,7 @@ Compares `FieldValue`<!-- -->s for equality.
 abstract isEqual(other: FieldValue): boolean;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |

--- a/docs-devsite/firestore_lite.firestoredataconverter.md
+++ b/docs-devsite/firestore_lite.firestoredataconverter.md
@@ -40,7 +40,7 @@ Generally, the data returned from `snapshot.data()` can be cast to `DbModelType`
 fromFirestore(snapshot: QueryDocumentSnapshot<DocumentData, DocumentData>): AppModelType;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -62,7 +62,7 @@ The `WithFieldValue<T>` type extends `T` to also allow FieldValues such as [dele
 toFirestore(modelObject: WithFieldValue<AppModelType>): WithFieldValue<DbModelType>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -84,7 +84,7 @@ The `PartialWithFieldValue<T>` type extends `Partial<T>` to allow FieldValues su
 toFirestore(modelObject: PartialWithFieldValue<AppModelType>, options: SetOptions): PartialWithFieldValue<DbModelType>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |

--- a/docs-devsite/firestore_lite.geopoint.md
+++ b/docs-devsite/firestore_lite.geopoint.md
@@ -50,7 +50,7 @@ Creates a new immutable `GeoPoint` object with the provided latitude and longitu
 constructor(latitude: number, longitude: number);
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -87,7 +87,7 @@ Returns true if this `GeoPoint` is equal to the provided one.
 isEqual(other: GeoPoint): boolean;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |

--- a/docs-devsite/firestore_lite.md
+++ b/docs-devsite/firestore_lite.md
@@ -15,12 +15,12 @@ https://github.com/firebase/firebase-js-sdk
 
 |  Function | Description |
 |  --- | --- |
-|  <b>function(app...)</b> |
+|  <b>function(app, ...)</b> |
 |  [getFirestore(app)](./firestore_lite.md#getfirestore_cf608e1) | Returns the existing default [Firestore](./firestore_.firestore.md#firestore_class) instance that is associated with the provided [FirebaseApp](./app.firebaseapp.md#firebaseapp_interface)<!-- -->. If no instance exists, initializes a new instance with default settings. |
 |  [getFirestore(app, databaseId)](./firestore_lite.md#getfirestore_48de6cb) | <b><i>(BETA)</i></b> Returns the existing [Firestore](./firestore_.firestore.md#firestore_class) instance that is associated with the provided [FirebaseApp](./app.firebaseapp.md#firebaseapp_interface)<!-- -->. If no instance exists, initializes a new instance with default settings. |
 |  [initializeFirestore(app, settings)](./firestore_lite.md#initializefirestore_87c6318) | Initializes a new instance of Cloud Firestore with the provided settings. Can only be called before any other functions, including [getFirestore()](./firestore_.md#getfirestore)<!-- -->. If the custom settings are empty, this function is equivalent to calling [getFirestore()](./firestore_.md#getfirestore)<!-- -->. |
 |  [initializeFirestore(app, settings, databaseId)](./firestore_lite.md#initializefirestore_37baaaf) | <b><i>(BETA)</i></b> Initializes a new instance of Cloud Firestore with the provided settings. Can only be called before any other functions, including [getFirestore()](./firestore_.md#getfirestore)<!-- -->. If the custom settings are empty, this function is equivalent to calling [getFirestore()](./firestore_.md#getfirestore)<!-- -->. |
-|  <b>function(firestore...)</b> |
+|  <b>function(firestore, ...)</b> |
 |  [collection(firestore, path, pathSegments)](./firestore_lite.md#collection_1eb4c23) | Gets a <code>CollectionReference</code> instance that refers to the collection at the specified absolute path. |
 |  [collectionGroup(firestore, collectionId)](./firestore_lite.md#collectiongroup_1838fc3) | Creates and returns a new <code>Query</code> instance that includes all documents in the database that are contained in a collection or subcollection with the given <code>collectionId</code>. |
 |  [connectFirestoreEmulator(firestore, host, port, options)](./firestore_lite.md#connectfirestoreemulator_7c247cd) | Modify this instance to communicate with the Cloud Firestore emulator.<!-- -->Note: This must be called before this instance has been used to do any operations. |
@@ -34,45 +34,45 @@ https://github.com/firebase/firebase-js-sdk
 |  [documentId()](./firestore_lite.md#documentid) | Returns a special sentinel <code>FieldPath</code> to refer to the ID of a document. It can be used in queries to sort or filter by the document ID. |
 |  [getFirestore()](./firestore_lite.md#getfirestore) | Returns the existing default [Firestore](./firestore_.firestore.md#firestore_class) instance that is associated with the default [FirebaseApp](./app.firebaseapp.md#firebaseapp_interface)<!-- -->. If no instance exists, initializes a new instance with default settings. |
 |  [serverTimestamp()](./firestore_lite.md#servertimestamp) | Returns a sentinel used with [setDoc()](./firestore_lite.md#setdoc_ee215ad) or [updateDoc()](./firestore_lite.md#updatedoc_51a65e3) to include a server-generated timestamp in the written data. |
-|  <b>function(databaseId...)</b> |
+|  <b>function(databaseId, ...)</b> |
 |  [getFirestore(databaseId)](./firestore_lite.md#getfirestore_53dc891) | <b><i>(BETA)</i></b> Returns the existing [Firestore](./firestore_.firestore.md#firestore_class) instance that is associated with the default [FirebaseApp](./app.firebaseapp.md#firebaseapp_interface)<!-- -->. If no instance exists, initializes a new instance with default settings. |
-|  <b>function(elements...)</b> |
+|  <b>function(elements, ...)</b> |
 |  [arrayRemove(elements)](./firestore_lite.md#arrayremove_7d853aa) | Returns a special value that can be used with [setDoc()](./firestore_.md#setdoc_ee215ad) or  that tells the server to remove the given elements from any array value that already exists on the server. All instances of each element specified will be removed from the array. If the field being modified is not already an array it will be overwritten with an empty array. |
 |  [arrayUnion(elements)](./firestore_lite.md#arrayunion_7d853aa) | Returns a special value that can be used with [setDoc()](./firestore_lite.md#setdoc_ee215ad) or [updateDoc()](./firestore_lite.md#updatedoc_51a65e3) that tells the server to union the given elements with any array value that already exists on the server. Each specified element that doesn't already exist in the array will be added to the end. If the field being modified is not already an array it will be overwritten with an array containing exactly the specified elements. |
-|  <b>function(field...)</b> |
+|  <b>function(field, ...)</b> |
 |  [average(field)](./firestore_lite.md#average_aacc3a9) | Create an AggregateField object that can be used to compute the average of a specified field over a range of documents in the result set of a query. |
 |  [sum(field)](./firestore_lite.md#sum_aacc3a9) | Create an AggregateField object that can be used to compute the sum of a specified field over a range of documents in the result set of a query. |
-|  <b>function(fieldPath...)</b> |
+|  <b>function(fieldPath, ...)</b> |
 |  [orderBy(fieldPath, directionStr)](./firestore_lite.md#orderby_006d61f) | Creates a [QueryOrderByConstraint](./firestore_.queryorderbyconstraint.md#queryorderbyconstraint_class) that sorts the query result by the specified field, optionally in descending order instead of ascending.<!-- -->Note: Documents that do not contain the specified field will not be present in the query result. |
 |  [where(fieldPath, opStr, value)](./firestore_lite.md#where_0fae4bf) | Creates a [QueryFieldFilterConstraint](./firestore_.queryfieldfilterconstraint.md#queryfieldfilterconstraint_class) that enforces that documents must contain the specified field and that the value should satisfy the relation constraint provided. |
-|  <b>function(fieldValues...)</b> |
+|  <b>function(fieldValues, ...)</b> |
 |  [endAt(fieldValues)](./firestore_lite.md#endat_8b2f2c8) | Creates a [QueryEndAtConstraint](./firestore_.queryendatconstraint.md#queryendatconstraint_class) that modifies the result set to end at the provided fields relative to the order of the query. The order of the field values must match the order of the order by clauses of the query. |
 |  [endBefore(fieldValues)](./firestore_lite.md#endbefore_8b2f2c8) | Creates a [QueryEndAtConstraint](./firestore_.queryendatconstraint.md#queryendatconstraint_class) that modifies the result set to end before the provided fields relative to the order of the query. The order of the field values must match the order of the order by clauses of the query. |
 |  [startAfter(fieldValues)](./firestore_lite.md#startafter_8b2f2c8) | Creates a [QueryStartAtConstraint](./firestore_.querystartatconstraint.md#querystartatconstraint_class) that modifies the result set to start after the provided fields relative to the order of the query. The order of the field values must match the order of the order by clauses of the query. |
 |  [startAt(fieldValues)](./firestore_lite.md#startat_8b2f2c8) | Creates a [QueryStartAtConstraint](./firestore_.querystartatconstraint.md#querystartatconstraint_class) that modifies the result set to start at the provided fields relative to the order of the query. The order of the field values must match the order of the order by clauses of the query. |
-|  <b>function(left...)</b> |
+|  <b>function(left, ...)</b> |
 |  [aggregateFieldEqual(left, right)](./firestore_lite.md#aggregatefieldequal_e80a2b2) | Compares two 'AggregateField<!-- -->\` instances for equality. |
 |  [aggregateQuerySnapshotEqual(left, right)](./firestore_lite.md#aggregatequerysnapshotequal_1529a20) | Compares two <code>AggregateQuerySnapshot</code> instances for equality.<!-- -->Two <code>AggregateQuerySnapshot</code> instances are considered "equal" if they have underlying queries that compare equal, and the same data. |
 |  [queryEqual(left, right)](./firestore_lite.md#queryequal_7a1f045) | Returns true if the provided queries point to the same collection and apply the same constraints. |
 |  [refEqual(left, right)](./firestore_lite.md#refequal_598b780) | Returns true if the provided references are equal. |
 |  [snapshotEqual(left, right)](./firestore_lite.md#snapshotequal_5109204) | Returns true if the provided snapshots are equal. |
-|  <b>function(limit...)</b> |
+|  <b>function(limit, ...)</b> |
 |  [limit(limit)](./firestore_lite.md#limit_ec46c78) | Creates a [QueryLimitConstraint](./firestore_.querylimitconstraint.md#querylimitconstraint_class) that only returns the first matching documents. |
 |  [limitToLast(limit)](./firestore_lite.md#limittolast_ec46c78) | Creates a [QueryLimitConstraint](./firestore_.querylimitconstraint.md#querylimitconstraint_class) that only returns the last matching documents.<!-- -->You must specify at least one <code>orderBy</code> clause for <code>limitToLast</code> queries, otherwise an exception will be thrown during execution. |
-|  <b>function(logLevel...)</b> |
+|  <b>function(logLevel, ...)</b> |
 |  [setLogLevel(logLevel)](./firestore_lite.md#setloglevel_d02fda2) | Sets the verbosity of Cloud Firestore logs (debug, error, or silent). |
-|  <b>function(n...)</b> |
+|  <b>function(n, ...)</b> |
 |  [increment(n)](./firestore_lite.md#increment_5685735) | Returns a special value that can be used with [setDoc()](./firestore_lite.md#setdoc_ee215ad) or [updateDoc()](./firestore_lite.md#updatedoc_51a65e3) that tells the server to increment the field's current value by the given value.<!-- -->If either the operand or the current field value uses floating point precision, all arithmetic follows IEEE 754 semantics. If both values are integers, values outside of JavaScript's safe number range (<code>Number.MIN_SAFE_INTEGER</code> to <code>Number.MAX_SAFE_INTEGER</code>) are also subject to precision loss. Furthermore, once processed by the Firestore backend, all integer operations are capped between -2^63 and 2^63-1.<!-- -->If the current field value is not of type <code>number</code>, or if the field does not yet exist, the transformation sets the field to the given value. |
-|  <b>function(query...)</b> |
+|  <b>function(query, ...)</b> |
 |  [getAggregate(query, aggregateSpec)](./firestore_lite.md#getaggregate_2073a74) | Calculates the specified aggregations over the documents in the result set of the given query, without actually downloading the documents.<!-- -->Using this function to perform aggregations is efficient because only the final aggregation values, not the documents' data, are downloaded. This function can even perform aggregations of the documents if the result set would be prohibitively large to download entirely (e.g. thousands of documents). |
 |  [getCount(query)](./firestore_lite.md#getcount_4e56953) | Calculates the number of documents in the result set of the given query, without actually downloading the documents.<!-- -->Using this function to count the documents is efficient because only the final count, not the documents' data, is downloaded. This function can even count the documents if the result set would be prohibitively large to download entirely (e.g. thousands of documents). |
 |  [getDocs(query)](./firestore_lite.md#getdocs_4e56953) | Executes the query and returns the results as a [QuerySnapshot](./firestore_.querysnapshot.md#querysnapshot_class)<!-- -->.<!-- -->All queries are executed directly by the server, even if the the query was previously executed. Recent modifications are only reflected in the retrieved results if they have already been applied by the backend. If the client is offline, the operation fails. To see previously cached result and local modifications, use the full Firestore SDK. |
 |  [query(query, compositeFilter, queryConstraints)](./firestore_lite.md#query_9f7b0f4) | Creates a new immutable instance of [Query](./firestore_.query.md#query_class) that is extended to also include additional query constraints. |
 |  [query(query, queryConstraints)](./firestore_lite.md#query_0f46da1) | Creates a new immutable instance of [Query](./firestore_.query.md#query_class) that is extended to also include additional query constraints. |
-|  <b>function(queryConstraints...)</b> |
+|  <b>function(queryConstraints, ...)</b> |
 |  [and(queryConstraints)](./firestore_lite.md#and_e72c712) | Creates a new [QueryCompositeFilterConstraint](./firestore_.querycompositefilterconstraint.md#querycompositefilterconstraint_class) that is a conjunction of the given filter constraints. A conjunction filter includes a document if it satisfies all of the given filters. |
 |  [or(queryConstraints)](./firestore_lite.md#or_e72c712) | Creates a new [QueryCompositeFilterConstraint](./firestore_.querycompositefilterconstraint.md#querycompositefilterconstraint_class) that is a disjunction of the given filter constraints. A disjunction filter includes a document if it satisfies any of the given filters. |
-|  <b>function(reference...)</b> |
+|  <b>function(reference, ...)</b> |
 |  [addDoc(reference, data)](./firestore_lite.md#adddoc_6e783ff) | Add a new document to specified <code>CollectionReference</code> with the given data, assigning it a document ID automatically.<!-- -->The result of this write will only be reflected in document reads that occur after the returned promise resolves. If the client is offline, the write fails. If you would like to see local modifications or buffer writes until the client is online, use the full Firestore SDK. |
 |  [collection(reference, path, pathSegments)](./firestore_lite.md#collection_568f98d) | Gets a <code>CollectionReference</code> instance that refers to a subcollection of <code>reference</code> at the the specified relative path. |
 |  [collection(reference, path, pathSegments)](./firestore_lite.md#collection_70b4396) | Gets a <code>CollectionReference</code> instance that refers to a subcollection of <code>reference</code> at the the specified relative path. |
@@ -84,7 +84,7 @@ https://github.com/firebase/firebase-js-sdk
 |  [setDoc(reference, data, options)](./firestore_lite.md#setdoc_ff80739) | Writes to the document referred to by the specified <code>DocumentReference</code>. If the document does not yet exist, it will be created. If you provide <code>merge</code> or <code>mergeFields</code>, the provided data can be merged into an existing document.<!-- -->The result of this write will only be reflected in document reads that occur after the returned promise resolves. If the client is offline, the write fails. If you would like to see local modifications or buffer writes until the client is online, use the full Firestore SDK. |
 |  [updateDoc(reference, data)](./firestore_lite.md#updatedoc_51a65e3) | Updates fields in the document referred to by the specified <code>DocumentReference</code>. The update will fail if applied to a document that does not exist.<!-- -->The result of this update will only be reflected in document reads that occur after the returned promise resolves. If the client is offline, the update fails. If you would like to see local modifications or buffer writes until the client is online, use the full Firestore SDK. |
 |  [updateDoc(reference, field, value, moreFieldsAndValues)](./firestore_lite.md#updatedoc_7c28659) | Updates fields in the document referred to by the specified <code>DocumentReference</code> The update will fail if applied to a document that does not exist.<!-- -->Nested fields can be updated by providing dot-separated field path strings or by providing <code>FieldPath</code> objects.<!-- -->The result of this update will only be reflected in document reads that occur after the returned promise resolves. If the client is offline, the update fails. If you would like to see local modifications or buffer writes until the client is online, use the full Firestore SDK. |
-|  <b>function(snapshot...)</b> |
+|  <b>function(snapshot, ...)</b> |
 |  [endAt(snapshot)](./firestore_lite.md#endat_9a4477f) | Creates a [QueryEndAtConstraint](./firestore_.queryendatconstraint.md#queryendatconstraint_class) that modifies the result set to end at the provided document (inclusive). The end position is relative to the order of the query. The document must contain all of the fields provided in the orderBy of the query. |
 |  [endBefore(snapshot)](./firestore_lite.md#endbefore_9a4477f) | Creates a [QueryEndAtConstraint](./firestore_.queryendatconstraint.md#queryendatconstraint_class) that modifies the result set to end before the provided document (exclusive). The end position is relative to the order of the query. The document must contain all of the fields provided in the orderBy of the query. |
 |  [startAfter(snapshot)](./firestore_lite.md#startafter_9a4477f) | Creates a [QueryStartAtConstraint](./firestore_.querystartatconstraint.md#querystartatconstraint_class) that modifies the result set to start after the provided document (exclusive). The starting position is relative to the order of the query. The document must contain all of the fields provided in the orderBy of the query. |
@@ -152,7 +152,9 @@ https://github.com/firebase/firebase-js-sdk
 |  [WhereFilterOp](./firestore_lite.md#wherefilterop) | Filter conditions in a [where()](./firestore_.md#where_0fae4bf) clause are specified using the strings '&amp;lt;', '&amp;lt;=', '==', '!=', '&amp;gt;=', '&amp;gt;', 'array-contains', 'in', 'array-contains-any', and 'not-in'. |
 |  [WithFieldValue](./firestore_lite.md#withfieldvalue) | Allows FieldValues to be passed in as a property value while maintaining type safety. |
 
-## getFirestore() {:#getfirestore_cf608e1}
+## function(app, ...)
+
+### getFirestore(app) {:#getfirestore_cf608e1}
 
 Returns the existing default [Firestore](./firestore_.firestore.md#firestore_class) instance that is associated with the provided [FirebaseApp](./app.firebaseapp.md#firebaseapp_interface)<!-- -->. If no instance exists, initializes a new instance with default settings.
 
@@ -162,7 +164,7 @@ Returns the existing default [Firestore](./firestore_.firestore.md#firestore_cla
 export declare function getFirestore(app: FirebaseApp): Firestore;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -174,7 +176,7 @@ export declare function getFirestore(app: FirebaseApp): Firestore;
 
 The [Firestore](./firestore_.firestore.md#firestore_class) instance of the provided app.
 
-## getFirestore() {:#getfirestore_48de6cb}
+### getFirestore(app, databaseId) {:#getfirestore_48de6cb}
 
 > This API is provided as a preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
 > 
@@ -187,7 +189,7 @@ Returns the existing [Firestore](./firestore_.firestore.md#firestore_class) inst
 export declare function getFirestore(app: FirebaseApp, databaseId: string): Firestore;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -200,7 +202,7 @@ export declare function getFirestore(app: FirebaseApp, databaseId: string): Fire
 
 The [Firestore](./firestore_.firestore.md#firestore_class) instance of the provided app.
 
-## initializeFirestore() {:#initializefirestore_87c6318}
+### initializeFirestore(app, settings) {:#initializefirestore_87c6318}
 
 Initializes a new instance of Cloud Firestore with the provided settings. Can only be called before any other functions, including [getFirestore()](./firestore_.md#getfirestore)<!-- -->. If the custom settings are empty, this function is equivalent to calling [getFirestore()](./firestore_.md#getfirestore)<!-- -->.
 
@@ -210,7 +212,7 @@ Initializes a new instance of Cloud Firestore with the provided settings. Can on
 export declare function initializeFirestore(app: FirebaseApp, settings: Settings): Firestore;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -223,7 +225,7 @@ export declare function initializeFirestore(app: FirebaseApp, settings: Settings
 
 A newly initialized `Firestore` instance.
 
-## initializeFirestore() {:#initializefirestore_37baaaf}
+### initializeFirestore(app, settings, databaseId) {:#initializefirestore_37baaaf}
 
 > This API is provided as a preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
 > 
@@ -236,7 +238,7 @@ Initializes a new instance of Cloud Firestore with the provided settings. Can on
 export declare function initializeFirestore(app: FirebaseApp, settings: Settings, databaseId?: string): Firestore;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -250,7 +252,9 @@ export declare function initializeFirestore(app: FirebaseApp, settings: Settings
 
 A newly initialized `Firestore` instance.
 
-## collection() {:#collection_1eb4c23}
+## function(firestore, ...)
+
+### collection(firestore, path, pathSegments) {:#collection_1eb4c23}
 
 Gets a `CollectionReference` instance that refers to the collection at the specified absolute path.
 
@@ -260,7 +264,7 @@ Gets a `CollectionReference` instance that refers to the collection at the speci
 export declare function collection(firestore: Firestore, path: string, ...pathSegments: string[]): CollectionReference<DocumentData, DocumentData>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -274,11 +278,11 @@ export declare function collection(firestore: Firestore, path: string, ...pathSe
 
 The `CollectionReference` instance.
 
-## Exceptions
+#### Exceptions
 
 If the final path has an even number of segments and does not point to a collection.
 
-## collectionGroup() {:#collectiongroup_1838fc3}
+### collectionGroup(firestore, collectionId) {:#collectiongroup_1838fc3}
 
 Creates and returns a new `Query` instance that includes all documents in the database that are contained in a collection or subcollection with the given `collectionId`<!-- -->.
 
@@ -288,7 +292,7 @@ Creates and returns a new `Query` instance that includes all documents in the da
 export declare function collectionGroup(firestore: Firestore, collectionId: string): Query<DocumentData, DocumentData>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -301,7 +305,7 @@ export declare function collectionGroup(firestore: Firestore, collectionId: stri
 
 The created `Query`<!-- -->.
 
-## connectFirestoreEmulator() {:#connectfirestoreemulator_7c247cd}
+### connectFirestoreEmulator(firestore, host, port, options) {:#connectfirestoreemulator_7c247cd}
 
 Modify this instance to communicate with the Cloud Firestore emulator.
 
@@ -315,7 +319,7 @@ export declare function connectFirestoreEmulator(firestore: Firestore, host: str
 }): void;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -328,7 +332,7 @@ export declare function connectFirestoreEmulator(firestore: Firestore, host: str
 
 void
 
-## doc() {:#doc_1eb4c23}
+### doc(firestore, path, pathSegments) {:#doc_1eb4c23}
 
 Gets a `DocumentReference` instance that refers to the document at the specified absolute path.
 
@@ -338,7 +342,7 @@ Gets a `DocumentReference` instance that refers to the document at the specified
 export declare function doc(firestore: Firestore, path: string, ...pathSegments: string[]): DocumentReference<DocumentData, DocumentData>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -352,11 +356,11 @@ export declare function doc(firestore: Firestore, path: string, ...pathSegments:
 
 The `DocumentReference` instance.
 
-## Exceptions
+#### Exceptions
 
 If the final path has an odd number of segments and does not point to a document.
 
-## runTransaction() {:#runtransaction_6f03ec4}
+### runTransaction(firestore, updateFunction, options) {:#runtransaction_6f03ec4}
 
 Executes the given `updateFunction` and then attempts to commit the changes applied within the transaction. If any document read within the transaction has changed, Cloud Firestore retries the `updateFunction`<!-- -->. If it fails to commit after 5 attempts, the transaction fails.
 
@@ -368,7 +372,7 @@ The maximum number of writes allowed in a single transaction is 500.
 export declare function runTransaction<T>(firestore: Firestore, updateFunction: (transaction: Transaction) => Promise<T>, options?: TransactionOptions): Promise<T>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -382,7 +386,7 @@ Promise&lt;T&gt;
 
 If the transaction completed successfully or was explicitly aborted (the `updateFunction` returned a failed promise), the promise returned by the `updateFunction `<!-- -->is returned here. Otherwise, if the transaction failed, a rejected promise with the corresponding failure error is returned.
 
-## terminate() {:#terminate_231a8e0}
+### terminate(firestore) {:#terminate_231a8e0}
 
 Terminates the provided `Firestore` instance.
 
@@ -398,7 +402,7 @@ Note: Under normal circumstances, calling `terminate()` is not required. This fu
 export declare function terminate(firestore: Firestore): Promise<void>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -410,7 +414,7 @@ Promise&lt;void&gt;
 
 A `Promise` that is resolved when the instance has been successfully terminated.
 
-## writeBatch() {:#writebatch_231a8e0}
+### writeBatch(firestore) {:#writebatch_231a8e0}
 
 Creates a write batch, used for performing multiple writes as a single atomic operation. The maximum number of writes allowed in a single WriteBatch is 500.
 
@@ -422,7 +426,7 @@ The result of these writes will only be reflected in document reads that occur a
 export declare function writeBatch(firestore: Firestore): WriteBatch;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -434,7 +438,9 @@ export declare function writeBatch(firestore: Firestore): WriteBatch;
 
 A `WriteBatch` that can be used to atomically execute multiple writes.
 
-## count() {:#count}
+## function()
+
+### count() {:#count}
 
 Create an AggregateField object that can be used to compute the count of documents in the result set of a query.
 
@@ -447,7 +453,7 @@ export declare function count(): AggregateField<number>;
 
 [AggregateField](./firestore_lite.aggregatefield.md#aggregatefield_class)<!-- -->&lt;number&gt;
 
-## deleteField() {:#deletefield}
+### deleteField() {:#deletefield}
 
 Returns a sentinel for use with [updateDoc()](./firestore_lite.md#updatedoc_51a65e3) or [setDoc()](./firestore_lite.md#setdoc_ee215ad) with `{merge: true}` to mark a field for deletion.
 
@@ -460,7 +466,7 @@ export declare function deleteField(): FieldValue;
 
 [FieldValue](./firestore_lite.fieldvalue.md#fieldvalue_class)
 
-## documentId() {:#documentid}
+### documentId() {:#documentid}
 
 Returns a special sentinel `FieldPath` to refer to the ID of a document. It can be used in queries to sort or filter by the document ID.
 
@@ -473,7 +479,7 @@ export declare function documentId(): FieldPath;
 
 [FieldPath](./firestore_lite.fieldpath.md#fieldpath_class)
 
-## getFirestore() {:#getfirestore}
+### getFirestore() {:#getfirestore}
 
 Returns the existing default [Firestore](./firestore_.firestore.md#firestore_class) instance that is associated with the default [FirebaseApp](./app.firebaseapp.md#firebaseapp_interface)<!-- -->. If no instance exists, initializes a new instance with default settings.
 
@@ -488,7 +494,7 @@ export declare function getFirestore(): Firestore;
 
 The [Firestore](./firestore_.firestore.md#firestore_class) instance of the provided app.
 
-## serverTimestamp() {:#servertimestamp}
+### serverTimestamp() {:#servertimestamp}
 
 Returns a sentinel used with [setDoc()](./firestore_lite.md#setdoc_ee215ad) or [updateDoc()](./firestore_lite.md#updatedoc_51a65e3) to include a server-generated timestamp in the written data.
 
@@ -501,7 +507,9 @@ export declare function serverTimestamp(): FieldValue;
 
 [FieldValue](./firestore_lite.fieldvalue.md#fieldvalue_class)
 
-## getFirestore() {:#getfirestore_53dc891}
+## function(databaseId, ...)
+
+### getFirestore(databaseId) {:#getfirestore_53dc891}
 
 > This API is provided as a preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
 > 
@@ -514,7 +522,7 @@ Returns the existing [Firestore](./firestore_.firestore.md#firestore_class) inst
 export declare function getFirestore(databaseId: string): Firestore;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -526,7 +534,9 @@ export declare function getFirestore(databaseId: string): Firestore;
 
 The [Firestore](./firestore_.firestore.md#firestore_class) instance of the provided app.
 
-## arrayRemove() {:#arrayremove_7d853aa}
+## function(elements, ...)
+
+### arrayRemove(elements) {:#arrayremove_7d853aa}
 
 Returns a special value that can be used with [setDoc()](./firestore_.md#setdoc_ee215ad) or  that tells the server to remove the given elements from any array value that already exists on the server. All instances of each element specified will be removed from the array. If the field being modified is not already an array it will be overwritten with an empty array.
 
@@ -536,7 +546,7 @@ Returns a special value that can be used with [setDoc()](./firestore_.md#setdoc_
 export declare function arrayRemove(...elements: unknown[]): FieldValue;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -548,7 +558,7 @@ export declare function arrayRemove(...elements: unknown[]): FieldValue;
 
 The `FieldValue` sentinel for use in a call to `setDoc()` or `updateDoc()`
 
-## arrayUnion() {:#arrayunion_7d853aa}
+### arrayUnion(elements) {:#arrayunion_7d853aa}
 
 Returns a special value that can be used with [setDoc()](./firestore_lite.md#setdoc_ee215ad) or [updateDoc()](./firestore_lite.md#updatedoc_51a65e3) that tells the server to union the given elements with any array value that already exists on the server. Each specified element that doesn't already exist in the array will be added to the end. If the field being modified is not already an array it will be overwritten with an array containing exactly the specified elements.
 
@@ -558,7 +568,7 @@ Returns a special value that can be used with [setDoc()](./firestore_lite.md#set
 export declare function arrayUnion(...elements: unknown[]): FieldValue;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -570,7 +580,9 @@ export declare function arrayUnion(...elements: unknown[]): FieldValue;
 
 The `FieldValue` sentinel for use in a call to `setDoc()` or `updateDoc()`<!-- -->.
 
-## average() {:#average_aacc3a9}
+## function(field, ...)
+
+### average(field) {:#average_aacc3a9}
 
 Create an AggregateField object that can be used to compute the average of a specified field over a range of documents in the result set of a query.
 
@@ -580,7 +592,7 @@ Create an AggregateField object that can be used to compute the average of a spe
 export declare function average(field: string | FieldPath): AggregateField<number | null>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -590,7 +602,7 @@ export declare function average(field: string | FieldPath): AggregateField<numbe
 
 [AggregateField](./firestore_lite.aggregatefield.md#aggregatefield_class)<!-- -->&lt;number \| null&gt;
 
-## sum() {:#sum_aacc3a9}
+### sum(field) {:#sum_aacc3a9}
 
 Create an AggregateField object that can be used to compute the sum of a specified field over a range of documents in the result set of a query.
 
@@ -600,7 +612,7 @@ Create an AggregateField object that can be used to compute the sum of a specifi
 export declare function sum(field: string | FieldPath): AggregateField<number>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -610,7 +622,9 @@ export declare function sum(field: string | FieldPath): AggregateField<number>;
 
 [AggregateField](./firestore_lite.aggregatefield.md#aggregatefield_class)<!-- -->&lt;number&gt;
 
-## orderBy() {:#orderby_006d61f}
+## function(fieldPath, ...)
+
+### orderBy(fieldPath, directionStr) {:#orderby_006d61f}
 
 Creates a [QueryOrderByConstraint](./firestore_.queryorderbyconstraint.md#queryorderbyconstraint_class) that sorts the query result by the specified field, optionally in descending order instead of ascending.
 
@@ -622,7 +636,7 @@ Note: Documents that do not contain the specified field will not be present in t
 export declare function orderBy(fieldPath: string | FieldPath, directionStr?: OrderByDirection): QueryOrderByConstraint;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -635,7 +649,7 @@ export declare function orderBy(fieldPath: string | FieldPath, directionStr?: Or
 
 The created [QueryOrderByConstraint](./firestore_.queryorderbyconstraint.md#queryorderbyconstraint_class)<!-- -->.
 
-## where() {:#where_0fae4bf}
+### where(fieldPath, opStr, value) {:#where_0fae4bf}
 
 Creates a [QueryFieldFilterConstraint](./firestore_.queryfieldfilterconstraint.md#queryfieldfilterconstraint_class) that enforces that documents must contain the specified field and that the value should satisfy the relation constraint provided.
 
@@ -645,7 +659,7 @@ Creates a [QueryFieldFilterConstraint](./firestore_.queryfieldfilterconstraint.m
 export declare function where(fieldPath: string | FieldPath, opStr: WhereFilterOp, value: unknown): QueryFieldFilterConstraint;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -659,7 +673,9 @@ export declare function where(fieldPath: string | FieldPath, opStr: WhereFilterO
 
 The created [QueryFieldFilterConstraint](./firestore_.queryfieldfilterconstraint.md#queryfieldfilterconstraint_class)<!-- -->.
 
-## endAt() {:#endat_8b2f2c8}
+## function(fieldValues, ...)
+
+### endAt(fieldValues) {:#endat_8b2f2c8}
 
 Creates a [QueryEndAtConstraint](./firestore_.queryendatconstraint.md#queryendatconstraint_class) that modifies the result set to end at the provided fields relative to the order of the query. The order of the field values must match the order of the order by clauses of the query.
 
@@ -669,7 +685,7 @@ Creates a [QueryEndAtConstraint](./firestore_.queryendatconstraint.md#queryendat
 export declare function endAt(...fieldValues: unknown[]): QueryEndAtConstraint;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -681,7 +697,7 @@ export declare function endAt(...fieldValues: unknown[]): QueryEndAtConstraint;
 
 A [QueryEndAtConstraint](./firestore_.queryendatconstraint.md#queryendatconstraint_class) to pass to `query()`
 
-## endBefore() {:#endbefore_8b2f2c8}
+### endBefore(fieldValues) {:#endbefore_8b2f2c8}
 
 Creates a [QueryEndAtConstraint](./firestore_.queryendatconstraint.md#queryendatconstraint_class) that modifies the result set to end before the provided fields relative to the order of the query. The order of the field values must match the order of the order by clauses of the query.
 
@@ -691,7 +707,7 @@ Creates a [QueryEndAtConstraint](./firestore_.queryendatconstraint.md#queryendat
 export declare function endBefore(...fieldValues: unknown[]): QueryEndAtConstraint;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -703,7 +719,7 @@ export declare function endBefore(...fieldValues: unknown[]): QueryEndAtConstrai
 
 A [QueryEndAtConstraint](./firestore_.queryendatconstraint.md#queryendatconstraint_class) to pass to `query()`
 
-## startAfter() {:#startafter_8b2f2c8}
+### startAfter(fieldValues) {:#startafter_8b2f2c8}
 
 Creates a [QueryStartAtConstraint](./firestore_.querystartatconstraint.md#querystartatconstraint_class) that modifies the result set to start after the provided fields relative to the order of the query. The order of the field values must match the order of the order by clauses of the query.
 
@@ -713,7 +729,7 @@ Creates a [QueryStartAtConstraint](./firestore_.querystartatconstraint.md#querys
 export declare function startAfter(...fieldValues: unknown[]): QueryStartAtConstraint;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -725,7 +741,7 @@ export declare function startAfter(...fieldValues: unknown[]): QueryStartAtConst
 
 A [QueryStartAtConstraint](./firestore_.querystartatconstraint.md#querystartatconstraint_class) to pass to `query()`
 
-## startAt() {:#startat_8b2f2c8}
+### startAt(fieldValues) {:#startat_8b2f2c8}
 
 Creates a [QueryStartAtConstraint](./firestore_.querystartatconstraint.md#querystartatconstraint_class) that modifies the result set to start at the provided fields relative to the order of the query. The order of the field values must match the order of the order by clauses of the query.
 
@@ -735,7 +751,7 @@ Creates a [QueryStartAtConstraint](./firestore_.querystartatconstraint.md#querys
 export declare function startAt(...fieldValues: unknown[]): QueryStartAtConstraint;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -747,7 +763,9 @@ export declare function startAt(...fieldValues: unknown[]): QueryStartAtConstrai
 
 A [QueryStartAtConstraint](./firestore_.querystartatconstraint.md#querystartatconstraint_class) to pass to `query()`<!-- -->.
 
-## aggregateFieldEqual() {:#aggregatefieldequal_e80a2b2}
+## function(left, ...)
+
+### aggregateFieldEqual(left, right) {:#aggregatefieldequal_e80a2b2}
 
 Compares two 'AggregateField<!-- -->\` instances for equality.
 
@@ -757,7 +775,7 @@ Compares two 'AggregateField<!-- -->\` instances for equality.
 export declare function aggregateFieldEqual(left: AggregateField<unknown>, right: AggregateField<unknown>): boolean;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -768,7 +786,7 @@ export declare function aggregateFieldEqual(left: AggregateField<unknown>, right
 
 boolean
 
-## aggregateQuerySnapshotEqual() {:#aggregatequerysnapshotequal_1529a20}
+### aggregateQuerySnapshotEqual(left, right) {:#aggregatequerysnapshotequal_1529a20}
 
 Compares two `AggregateQuerySnapshot` instances for equality.
 
@@ -780,7 +798,7 @@ Two `AggregateQuerySnapshot` instances are considered "equal" if they have under
 export declare function aggregateQuerySnapshotEqual<AggregateSpecType extends AggregateSpec, AppModelType, DbModelType extends DocumentData>(left: AggregateQuerySnapshot<AggregateSpecType, AppModelType, DbModelType>, right: AggregateQuerySnapshot<AggregateSpecType, AppModelType, DbModelType>): boolean;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -793,7 +811,7 @@ boolean
 
 `true` if the objects are "equal", as defined above, or `false` otherwise.
 
-## queryEqual() {:#queryequal_7a1f045}
+### queryEqual(left, right) {:#queryequal_7a1f045}
 
 Returns true if the provided queries point to the same collection and apply the same constraints.
 
@@ -803,7 +821,7 @@ Returns true if the provided queries point to the same collection and apply the 
 export declare function queryEqual<AppModelType, DbModelType extends DocumentData>(left: Query<AppModelType, DbModelType>, right: Query<AppModelType, DbModelType>): boolean;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -816,7 +834,7 @@ boolean
 
 true if the references point to the same location in the same Firestore database.
 
-## refEqual() {:#refequal_598b780}
+### refEqual(left, right) {:#refequal_598b780}
 
 Returns true if the provided references are equal.
 
@@ -826,7 +844,7 @@ Returns true if the provided references are equal.
 export declare function refEqual<AppModelType, DbModelType extends DocumentData>(left: DocumentReference<AppModelType, DbModelType> | CollectionReference<AppModelType, DbModelType>, right: DocumentReference<AppModelType, DbModelType> | CollectionReference<AppModelType, DbModelType>): boolean;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -839,7 +857,7 @@ boolean
 
 true if the references point to the same location in the same Firestore database.
 
-## snapshotEqual() {:#snapshotequal_5109204}
+### snapshotEqual(left, right) {:#snapshotequal_5109204}
 
 Returns true if the provided snapshots are equal.
 
@@ -849,7 +867,7 @@ Returns true if the provided snapshots are equal.
 export declare function snapshotEqual<AppModelType, DbModelType extends DocumentData>(left: DocumentSnapshot<AppModelType, DbModelType> | QuerySnapshot<AppModelType, DbModelType>, right: DocumentSnapshot<AppModelType, DbModelType> | QuerySnapshot<AppModelType, DbModelType>): boolean;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -862,7 +880,9 @@ boolean
 
 true if the snapshots are equal.
 
-## limit() {:#limit_ec46c78}
+## function(limit, ...)
+
+### limit(limit) {:#limit_ec46c78}
 
 Creates a [QueryLimitConstraint](./firestore_.querylimitconstraint.md#querylimitconstraint_class) that only returns the first matching documents.
 
@@ -872,7 +892,7 @@ Creates a [QueryLimitConstraint](./firestore_.querylimitconstraint.md#querylimit
 export declare function limit(limit: number): QueryLimitConstraint;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -884,7 +904,7 @@ export declare function limit(limit: number): QueryLimitConstraint;
 
 The created [QueryLimitConstraint](./firestore_.querylimitconstraint.md#querylimitconstraint_class)<!-- -->.
 
-## limitToLast() {:#limittolast_ec46c78}
+### limitToLast(limit) {:#limittolast_ec46c78}
 
 Creates a [QueryLimitConstraint](./firestore_.querylimitconstraint.md#querylimitconstraint_class) that only returns the last matching documents.
 
@@ -896,7 +916,7 @@ You must specify at least one `orderBy` clause for `limitToLast` queries, otherw
 export declare function limitToLast(limit: number): QueryLimitConstraint;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -908,7 +928,9 @@ export declare function limitToLast(limit: number): QueryLimitConstraint;
 
 The created [QueryLimitConstraint](./firestore_.querylimitconstraint.md#querylimitconstraint_class)<!-- -->.
 
-## setLogLevel() {:#setloglevel_d02fda2}
+## function(logLevel, ...)
+
+### setLogLevel(logLevel) {:#setloglevel_d02fda2}
 
 Sets the verbosity of Cloud Firestore logs (debug, error, or silent).
 
@@ -918,7 +940,7 @@ Sets the verbosity of Cloud Firestore logs (debug, error, or silent).
 export declare function setLogLevel(logLevel: LogLevel): void;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -928,7 +950,9 @@ export declare function setLogLevel(logLevel: LogLevel): void;
 
 void
 
-## increment() {:#increment_5685735}
+## function(n, ...)
+
+### increment(n) {:#increment_5685735}
 
 Returns a special value that can be used with [setDoc()](./firestore_lite.md#setdoc_ee215ad) or [updateDoc()](./firestore_lite.md#updatedoc_51a65e3) that tells the server to increment the field's current value by the given value.
 
@@ -942,7 +966,7 @@ If the current field value is not of type `number`<!-- -->, or if the field does
 export declare function increment(n: number): FieldValue;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -954,7 +978,9 @@ export declare function increment(n: number): FieldValue;
 
 The `FieldValue` sentinel for use in a call to `setDoc()` or `updateDoc()`
 
-## getAggregate() {:#getaggregate_2073a74}
+## function(query, ...)
+
+### getAggregate(query, aggregateSpec) {:#getaggregate_2073a74}
 
 Calculates the specified aggregations over the documents in the result set of the given query, without actually downloading the documents.
 
@@ -966,7 +992,7 @@ Using this function to perform aggregations is efficient because only the final 
 export declare function getAggregate<AggregateSpecType extends AggregateSpec, AppModelType, DbModelType extends DocumentData>(query: Query<AppModelType, DbModelType>, aggregateSpec: AggregateSpecType): Promise<AggregateQuerySnapshot<AggregateSpecType, AppModelType, DbModelType>>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -993,7 +1019,7 @@ const averageScore: number | null = aggregateSnapshot.data().averageScore;
 
 ```
 
-## getCount() {:#getcount_4e56953}
+### getCount(query) {:#getcount_4e56953}
 
 Calculates the number of documents in the result set of the given query, without actually downloading the documents.
 
@@ -1007,7 +1033,7 @@ export declare function getCount<AppModelType, DbModelType extends DocumentData>
 }, AppModelType, DbModelType>>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -1019,7 +1045,7 @@ Promise&lt;[AggregateQuerySnapshot](./firestore_lite.aggregatequerysnapshot.md#a
 
 A Promise that will be resolved with the count; the count can be retrieved from `snapshot.data().count`<!-- -->, where `snapshot` is the `AggregateQuerySnapshot` to which the returned Promise resolves.
 
-## getDocs() {:#getdocs_4e56953}
+### getDocs(query) {:#getdocs_4e56953}
 
 Executes the query and returns the results as a [QuerySnapshot](./firestore_.querysnapshot.md#querysnapshot_class)<!-- -->.
 
@@ -1031,7 +1057,7 @@ All queries are executed directly by the server, even if the the query was previ
 export declare function getDocs<AppModelType, DbModelType extends DocumentData>(query: Query<AppModelType, DbModelType>): Promise<QuerySnapshot<AppModelType, DbModelType>>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -1043,7 +1069,7 @@ Promise&lt;[QuerySnapshot](./firestore_lite.querysnapshot.md#querysnapshot_class
 
 A Promise that will be resolved with the results of the query.
 
-## query() {:#query_9f7b0f4}
+### query(query, compositeFilter, queryConstraints) {:#query_9f7b0f4}
 
 Creates a new immutable instance of [Query](./firestore_.query.md#query_class) that is extended to also include additional query constraints.
 
@@ -1053,7 +1079,7 @@ Creates a new immutable instance of [Query](./firestore_.query.md#query_class) t
 export declare function query<AppModelType, DbModelType extends DocumentData>(query: Query<AppModelType, DbModelType>, compositeFilter: QueryCompositeFilterConstraint, ...queryConstraints: QueryNonFilterConstraint[]): Query<AppModelType, DbModelType>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -1065,11 +1091,11 @@ export declare function query<AppModelType, DbModelType extends DocumentData>(qu
 
 [Query](./firestore_lite.query.md#query_class)<!-- -->&lt;AppModelType, DbModelType&gt;
 
-## Exceptions
+#### Exceptions
 
 if any of the provided query constraints cannot be combined with the existing or new constraints.
 
-## query() {:#query_0f46da1}
+### query(query, queryConstraints) {:#query_0f46da1}
 
 Creates a new immutable instance of [Query](./firestore_.query.md#query_class) that is extended to also include additional query constraints.
 
@@ -1079,7 +1105,7 @@ Creates a new immutable instance of [Query](./firestore_.query.md#query_class) t
 export declare function query<AppModelType, DbModelType extends DocumentData>(query: Query<AppModelType, DbModelType>, ...queryConstraints: QueryConstraint[]): Query<AppModelType, DbModelType>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -1090,11 +1116,13 @@ export declare function query<AppModelType, DbModelType extends DocumentData>(qu
 
 [Query](./firestore_lite.query.md#query_class)<!-- -->&lt;AppModelType, DbModelType&gt;
 
-## Exceptions
+#### Exceptions
 
 if any of the provided query constraints cannot be combined with the existing or new constraints.
 
-## and() {:#and_e72c712}
+## function(queryConstraints, ...)
+
+### and(queryConstraints) {:#and_e72c712}
 
 Creates a new [QueryCompositeFilterConstraint](./firestore_.querycompositefilterconstraint.md#querycompositefilterconstraint_class) that is a conjunction of the given filter constraints. A conjunction filter includes a document if it satisfies all of the given filters.
 
@@ -1104,7 +1132,7 @@ Creates a new [QueryCompositeFilterConstraint](./firestore_.querycompositefilter
 export declare function and(...queryConstraints: QueryFilterConstraint[]): QueryCompositeFilterConstraint;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -1116,7 +1144,7 @@ export declare function and(...queryConstraints: QueryFilterConstraint[]): Query
 
 The newly created [QueryCompositeFilterConstraint](./firestore_.querycompositefilterconstraint.md#querycompositefilterconstraint_class)<!-- -->.
 
-## or() {:#or_e72c712}
+### or(queryConstraints) {:#or_e72c712}
 
 Creates a new [QueryCompositeFilterConstraint](./firestore_.querycompositefilterconstraint.md#querycompositefilterconstraint_class) that is a disjunction of the given filter constraints. A disjunction filter includes a document if it satisfies any of the given filters.
 
@@ -1126,7 +1154,7 @@ Creates a new [QueryCompositeFilterConstraint](./firestore_.querycompositefilter
 export declare function or(...queryConstraints: QueryFilterConstraint[]): QueryCompositeFilterConstraint;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -1138,7 +1166,9 @@ export declare function or(...queryConstraints: QueryFilterConstraint[]): QueryC
 
 The newly created [QueryCompositeFilterConstraint](./firestore_.querycompositefilterconstraint.md#querycompositefilterconstraint_class)<!-- -->.
 
-## addDoc() {:#adddoc_6e783ff}
+## function(reference, ...)
+
+### addDoc(reference, data) {:#adddoc_6e783ff}
 
 Add a new document to specified `CollectionReference` with the given data, assigning it a document ID automatically.
 
@@ -1150,7 +1180,7 @@ The result of this write will only be reflected in document reads that occur aft
 export declare function addDoc<AppModelType, DbModelType extends DocumentData>(reference: CollectionReference<AppModelType, DbModelType>, data: WithFieldValue<AppModelType>): Promise<DocumentReference<AppModelType, DbModelType>>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -1163,11 +1193,11 @@ Promise&lt;[DocumentReference](./firestore_lite.documentreference.md#documentref
 
 A `Promise` resolved with a `DocumentReference` pointing to the newly created document after it has been written to the backend.
 
-## Exceptions
+#### Exceptions
 
 Error - If the provided input is not a valid Firestore document.
 
-## collection() {:#collection_568f98d}
+### collection(reference, path, pathSegments) {:#collection_568f98d}
 
 Gets a `CollectionReference` instance that refers to a subcollection of `reference` at the the specified relative path.
 
@@ -1177,7 +1207,7 @@ Gets a `CollectionReference` instance that refers to a subcollection of `referen
 export declare function collection<AppModelType, DbModelType extends DocumentData>(reference: CollectionReference<AppModelType, DbModelType>, path: string, ...pathSegments: string[]): CollectionReference<DocumentData, DocumentData>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -1191,11 +1221,11 @@ export declare function collection<AppModelType, DbModelType extends DocumentDat
 
 The `CollectionReference` instance.
 
-## Exceptions
+#### Exceptions
 
 If the final path has an even number of segments and does not point to a collection.
 
-## collection() {:#collection_70b4396}
+### collection(reference, path, pathSegments) {:#collection_70b4396}
 
 Gets a `CollectionReference` instance that refers to a subcollection of `reference` at the the specified relative path.
 
@@ -1205,7 +1235,7 @@ Gets a `CollectionReference` instance that refers to a subcollection of `referen
 export declare function collection<AppModelType, DbModelType extends DocumentData>(reference: DocumentReference<AppModelType, DbModelType>, path: string, ...pathSegments: string[]): CollectionReference<DocumentData, DocumentData>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -1219,11 +1249,11 @@ export declare function collection<AppModelType, DbModelType extends DocumentDat
 
 The `CollectionReference` instance.
 
-## Exceptions
+#### Exceptions
 
 If the final path has an even number of segments and does not point to a collection.
 
-## deleteDoc() {:#deletedoc_4569087}
+### deleteDoc(reference) {:#deletedoc_4569087}
 
 Deletes the document referred to by the specified `DocumentReference`<!-- -->.
 
@@ -1235,7 +1265,7 @@ The deletion will only be reflected in document reads that occur after the retur
 export declare function deleteDoc<AppModelType, DbModelType extends DocumentData>(reference: DocumentReference<AppModelType, DbModelType>): Promise<void>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -1247,7 +1277,7 @@ Promise&lt;void&gt;
 
 A `Promise` resolved once the document has been successfully deleted from the backend.
 
-## doc() {:#doc_568f98d}
+### doc(reference, path, pathSegments) {:#doc_568f98d}
 
 Gets a `DocumentReference` instance that refers to a document within `reference` at the specified relative path. If no path is specified, an automatically-generated unique ID will be used for the returned `DocumentReference`<!-- -->.
 
@@ -1257,7 +1287,7 @@ Gets a `DocumentReference` instance that refers to a document within `reference`
 export declare function doc<AppModelType, DbModelType extends DocumentData>(reference: CollectionReference<AppModelType, DbModelType>, path?: string, ...pathSegments: string[]): DocumentReference<AppModelType, DbModelType>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -1271,11 +1301,11 @@ export declare function doc<AppModelType, DbModelType extends DocumentData>(refe
 
 The `DocumentReference` instance.
 
-## Exceptions
+#### Exceptions
 
 If the final path has an odd number of segments and does not point to a document.
 
-## doc() {:#doc_70b4396}
+### doc(reference, path, pathSegments) {:#doc_70b4396}
 
 Gets a `DocumentReference` instance that refers to a document within `reference` at the specified relative path.
 
@@ -1285,7 +1315,7 @@ Gets a `DocumentReference` instance that refers to a document within `reference`
 export declare function doc<AppModelType, DbModelType extends DocumentData>(reference: DocumentReference<AppModelType, DbModelType>, path: string, ...pathSegments: string[]): DocumentReference<DocumentData, DocumentData>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -1299,11 +1329,11 @@ export declare function doc<AppModelType, DbModelType extends DocumentData>(refe
 
 The `DocumentReference` instance.
 
-## Exceptions
+#### Exceptions
 
 If the final path has an odd number of segments and does not point to a document.
 
-## getDoc() {:#getdoc_4569087}
+### getDoc(reference) {:#getdoc_4569087}
 
 Reads the document referred to by the specified document reference.
 
@@ -1315,7 +1345,7 @@ All documents are directly fetched from the server, even if the document was pre
 export declare function getDoc<AppModelType, DbModelType extends DocumentData>(reference: DocumentReference<AppModelType, DbModelType>): Promise<DocumentSnapshot<AppModelType, DbModelType>>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -1327,7 +1357,7 @@ Promise&lt;[DocumentSnapshot](./firestore_lite.documentsnapshot.md#documentsnaps
 
 A Promise resolved with a `DocumentSnapshot` containing the current document contents.
 
-## setDoc() {:#setdoc_ee215ad}
+### setDoc(reference, data) {:#setdoc_ee215ad}
 
 Writes to the document referred to by the specified `DocumentReference`<!-- -->. If the document does not yet exist, it will be created.
 
@@ -1339,7 +1369,7 @@ The result of this write will only be reflected in document reads that occur aft
 export declare function setDoc<AppModelType, DbModelType extends DocumentData>(reference: DocumentReference<AppModelType, DbModelType>, data: WithFieldValue<AppModelType>): Promise<void>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -1352,11 +1382,11 @@ Promise&lt;void&gt;
 
 A `Promise` resolved once the data has been successfully written to the backend.
 
-## Exceptions
+#### Exceptions
 
 Error - If the provided input is not a valid Firestore document.
 
-## setDoc() {:#setdoc_ff80739}
+### setDoc(reference, data, options) {:#setdoc_ff80739}
 
 Writes to the document referred to by the specified `DocumentReference`<!-- -->. If the document does not yet exist, it will be created. If you provide `merge` or `mergeFields`<!-- -->, the provided data can be merged into an existing document.
 
@@ -1368,7 +1398,7 @@ The result of this write will only be reflected in document reads that occur aft
 export declare function setDoc<AppModelType, DbModelType extends DocumentData>(reference: DocumentReference<AppModelType, DbModelType>, data: PartialWithFieldValue<AppModelType>, options: SetOptions): Promise<void>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -1382,11 +1412,11 @@ Promise&lt;void&gt;
 
 A `Promise` resolved once the data has been successfully written to the backend.
 
-## Exceptions
+#### Exceptions
 
 Error - If the provided input is not a valid Firestore document.
 
-## updateDoc() {:#updatedoc_51a65e3}
+### updateDoc(reference, data) {:#updatedoc_51a65e3}
 
 Updates fields in the document referred to by the specified `DocumentReference`<!-- -->. The update will fail if applied to a document that does not exist.
 
@@ -1398,7 +1428,7 @@ The result of this update will only be reflected in document reads that occur af
 export declare function updateDoc<AppModelType, DbModelType extends DocumentData>(reference: DocumentReference<AppModelType, DbModelType>, data: UpdateData<DbModelType>): Promise<void>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -1411,11 +1441,11 @@ Promise&lt;void&gt;
 
 A `Promise` resolved once the data has been successfully written to the backend.
 
-## Exceptions
+#### Exceptions
 
 Error - If the provided input is not valid Firestore data.
 
-## updateDoc() {:#updatedoc_7c28659}
+### updateDoc(reference, field, value, moreFieldsAndValues) {:#updatedoc_7c28659}
 
 Updates fields in the document referred to by the specified `DocumentReference` The update will fail if applied to a document that does not exist.
 
@@ -1429,7 +1459,7 @@ The result of this update will only be reflected in document reads that occur af
 export declare function updateDoc<AppModelType, DbModelType extends DocumentData>(reference: DocumentReference<AppModelType, DbModelType>, field: string | FieldPath, value: unknown, ...moreFieldsAndValues: unknown[]): Promise<void>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -1444,11 +1474,13 @@ Promise&lt;void&gt;
 
 A `Promise` resolved once the data has been successfully written to the backend.
 
-## Exceptions
+#### Exceptions
 
 Error - If the provided input is not valid Firestore data.
 
-## endAt() {:#endat_9a4477f}
+## function(snapshot, ...)
+
+### endAt(snapshot) {:#endat_9a4477f}
 
 Creates a [QueryEndAtConstraint](./firestore_.queryendatconstraint.md#queryendatconstraint_class) that modifies the result set to end at the provided document (inclusive). The end position is relative to the order of the query. The document must contain all of the fields provided in the orderBy of the query.
 
@@ -1458,7 +1490,7 @@ Creates a [QueryEndAtConstraint](./firestore_.queryendatconstraint.md#queryendat
 export declare function endAt<AppModelType, DbModelType extends DocumentData>(snapshot: DocumentSnapshot<AppModelType, DbModelType>): QueryEndAtConstraint;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -1470,7 +1502,7 @@ export declare function endAt<AppModelType, DbModelType extends DocumentData>(sn
 
 A [QueryEndAtConstraint](./firestore_.queryendatconstraint.md#queryendatconstraint_class) to pass to `query()`
 
-## endBefore() {:#endbefore_9a4477f}
+### endBefore(snapshot) {:#endbefore_9a4477f}
 
 Creates a [QueryEndAtConstraint](./firestore_.queryendatconstraint.md#queryendatconstraint_class) that modifies the result set to end before the provided document (exclusive). The end position is relative to the order of the query. The document must contain all of the fields provided in the orderBy of the query.
 
@@ -1480,7 +1512,7 @@ Creates a [QueryEndAtConstraint](./firestore_.queryendatconstraint.md#queryendat
 export declare function endBefore<AppModelType, DbModelType extends DocumentData>(snapshot: DocumentSnapshot<AppModelType, DbModelType>): QueryEndAtConstraint;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -1492,7 +1524,7 @@ export declare function endBefore<AppModelType, DbModelType extends DocumentData
 
 A [QueryEndAtConstraint](./firestore_.queryendatconstraint.md#queryendatconstraint_class) to pass to `query()`
 
-## startAfter() {:#startafter_9a4477f}
+### startAfter(snapshot) {:#startafter_9a4477f}
 
 Creates a [QueryStartAtConstraint](./firestore_.querystartatconstraint.md#querystartatconstraint_class) that modifies the result set to start after the provided document (exclusive). The starting position is relative to the order of the query. The document must contain all of the fields provided in the orderBy of the query.
 
@@ -1502,7 +1534,7 @@ Creates a [QueryStartAtConstraint](./firestore_.querystartatconstraint.md#querys
 export declare function startAfter<AppModelType, DbModelType extends DocumentData>(snapshot: DocumentSnapshot<AppModelType, DbModelType>): QueryStartAtConstraint;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -1514,7 +1546,7 @@ export declare function startAfter<AppModelType, DbModelType extends DocumentDat
 
 A [QueryStartAtConstraint](./firestore_.querystartatconstraint.md#querystartatconstraint_class) to pass to `query()`
 
-## startAt() {:#startat_9a4477f}
+### startAt(snapshot) {:#startat_9a4477f}
 
 Creates a [QueryStartAtConstraint](./firestore_.querystartatconstraint.md#querystartatconstraint_class) that modifies the result set to start at the provided document (inclusive). The starting position is relative to the order of the query. The document must contain all of the fields provided in the `orderBy` of this query.
 
@@ -1524,7 +1556,7 @@ Creates a [QueryStartAtConstraint](./firestore_.querystartatconstraint.md#querys
 export declare function startAt<AppModelType, DbModelType extends DocumentData>(snapshot: DocumentSnapshot<AppModelType, DbModelType>): QueryStartAtConstraint;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |

--- a/docs-devsite/firestore_lite.query.md
+++ b/docs-devsite/firestore_lite.query.md
@@ -89,7 +89,7 @@ Removes the current converter.
 withConverter(converter: null): Query<DocumentData, DocumentData>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -111,7 +111,7 @@ Applies a custom data converter to this query, allowing you to use your own cust
 withConverter<NewAppModelType, NewDbModelType extends DocumentData = DocumentData>(converter: FirestoreDataConverter<NewAppModelType, NewDbModelType>): Query<NewAppModelType, NewDbModelType>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |

--- a/docs-devsite/firestore_lite.querysnapshot.md
+++ b/docs-devsite/firestore_lite.querysnapshot.md
@@ -83,7 +83,7 @@ Enumerates all of the documents in the `QuerySnapshot`<!-- -->.
 forEach(callback: (result: QueryDocumentSnapshot<AppModelType, DbModelType>) => void, thisArg?: unknown): void;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |

--- a/docs-devsite/firestore_lite.timestamp.md
+++ b/docs-devsite/firestore_lite.timestamp.md
@@ -61,7 +61,7 @@ constructor(
     nanoseconds: number);
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -98,7 +98,7 @@ Creates a new timestamp from the given date.
 static fromDate(date: Date): Timestamp;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -120,7 +120,7 @@ Creates a new timestamp from the given number of milliseconds.
 static fromMillis(milliseconds: number): Timestamp;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -142,7 +142,7 @@ Returns true if this `Timestamp` is equal to the provided one.
 isEqual(other: Timestamp): boolean;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |

--- a/docs-devsite/firestore_lite.transaction.md
+++ b/docs-devsite/firestore_lite.transaction.md
@@ -41,7 +41,7 @@ Deletes the document referred to by the provided [DocumentReference](./firestore
 delete<AppModelType, DbModelType extends DocumentData>(documentRef: DocumentReference<AppModelType, DbModelType>): this;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -63,7 +63,7 @@ Reads the document referenced by the provided [DocumentReference](./firestore_.d
 get<AppModelType, DbModelType extends DocumentData>(documentRef: DocumentReference<AppModelType, DbModelType>): Promise<DocumentSnapshot<AppModelType, DbModelType>>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -85,7 +85,7 @@ Writes to the document referred to by the provided [DocumentReference](./firesto
 set<AppModelType, DbModelType extends DocumentData>(documentRef: DocumentReference<AppModelType, DbModelType>, data: WithFieldValue<AppModelType>): this;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -98,7 +98,7 @@ this
 
 This `Transaction` instance. Used for chaining method calls.
 
-## Exceptions
+#### Exceptions
 
 Error - If the provided input is not a valid Firestore document.
 
@@ -112,7 +112,7 @@ Writes to the document referred to by the provided [DocumentReference](./firesto
 set<AppModelType, DbModelType extends DocumentData>(documentRef: DocumentReference<AppModelType, DbModelType>, data: PartialWithFieldValue<AppModelType>, options: SetOptions): this;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -126,7 +126,7 @@ this
 
 This `Transaction` instance. Used for chaining method calls.
 
-## Exceptions
+#### Exceptions
 
 Error - If the provided input is not a valid Firestore document.
 
@@ -140,7 +140,7 @@ Updates fields in the document referred to by the provided [DocumentReference](.
 update<AppModelType, DbModelType extends DocumentData>(documentRef: DocumentReference<AppModelType, DbModelType>, data: UpdateData<DbModelType>): this;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -153,7 +153,7 @@ this
 
 This `Transaction` instance. Used for chaining method calls.
 
-## Exceptions
+#### Exceptions
 
 Error - If the provided input is not valid Firestore data.
 
@@ -169,7 +169,7 @@ Nested fields can be updated by providing dot-separated field path strings or by
 update<AppModelType, DbModelType extends DocumentData>(documentRef: DocumentReference<AppModelType, DbModelType>, field: string | FieldPath, value: unknown, ...moreFieldsAndValues: unknown[]): this;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -184,7 +184,7 @@ this
 
 This `Transaction` instance. Used for chaining method calls.
 
-## Exceptions
+#### Exceptions
 
 Error - If the provided input is not valid Firestore data.
 

--- a/docs-devsite/firestore_lite.writebatch.md
+++ b/docs-devsite/firestore_lite.writebatch.md
@@ -58,7 +58,7 @@ Deletes the document referred to by the provided [DocumentReference](./firestore
 delete<AppModelType, DbModelType extends DocumentData>(documentRef: DocumentReference<AppModelType, DbModelType>): WriteBatch;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -80,7 +80,7 @@ Writes to the document referred to by the provided [DocumentReference](./firesto
 set<AppModelType, DbModelType extends DocumentData>(documentRef: DocumentReference<AppModelType, DbModelType>, data: WithFieldValue<AppModelType>): WriteBatch;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -103,7 +103,7 @@ Writes to the document referred to by the provided [DocumentReference](./firesto
 set<AppModelType, DbModelType extends DocumentData>(documentRef: DocumentReference<AppModelType, DbModelType>, data: PartialWithFieldValue<AppModelType>, options: SetOptions): WriteBatch;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -117,7 +117,7 @@ set<AppModelType, DbModelType extends DocumentData>(documentRef: DocumentReferen
 
 This `WriteBatch` instance. Used for chaining method calls.
 
-## Exceptions
+#### Exceptions
 
 Error - If the provided input is not a valid Firestore document.
 
@@ -131,7 +131,7 @@ Updates fields in the document referred to by the provided [DocumentReference](.
 update<AppModelType, DbModelType extends DocumentData>(documentRef: DocumentReference<AppModelType, DbModelType>, data: UpdateData<DbModelType>): WriteBatch;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -144,7 +144,7 @@ update<AppModelType, DbModelType extends DocumentData>(documentRef: DocumentRefe
 
 This `WriteBatch` instance. Used for chaining method calls.
 
-## Exceptions
+#### Exceptions
 
 Error - If the provided input is not valid Firestore data.
 
@@ -160,7 +160,7 @@ Nested fields can be update by providing dot-separated field path strings or by 
 update<AppModelType, DbModelType extends DocumentData>(documentRef: DocumentReference<AppModelType, DbModelType>, field: string | FieldPath, value: unknown, ...moreFieldsAndValues: unknown[]): WriteBatch;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -175,7 +175,7 @@ update<AppModelType, DbModelType extends DocumentData>(documentRef: DocumentRefe
 
 This `WriteBatch` instance. Used for chaining method calls.
 
-## Exceptions
+#### Exceptions
 
 Error - If the provided input is not valid Firestore data.
 

--- a/docs-devsite/functions.md
+++ b/docs-devsite/functions.md
@@ -16,9 +16,9 @@ Cloud Functions for Firebase
 
 |  Function | Description |
 |  --- | --- |
-|  <b>function(app...)</b> |
+|  <b>function(app, ...)</b> |
 |  [getFunctions(app, regionOrCustomDomain)](./functions.md#getfunctions_60f2095) | Returns a [Functions](./functions.functions.md#functions_interface) instance for the given app. |
-|  <b>function(functionsInstance...)</b> |
+|  <b>function(functionsInstance, ...)</b> |
 |  [connectFunctionsEmulator(functionsInstance, host, port)](./functions.md#connectfunctionsemulator_505c08d) | Modify this instance to communicate with the Cloud Functions emulator.<!-- -->Note: this must be called before this instance has been used to do any operations. |
 |  [httpsCallable(functionsInstance, name, options)](./functions.md#httpscallable_1dd297c) | Returns a reference to the callable HTTPS trigger with the given name. |
 |  [httpsCallableFromURL(functionsInstance, url, options)](./functions.md#httpscallablefromurl_7af6987) | Returns a reference to the callable HTTPS trigger with the specified url. |
@@ -40,7 +40,9 @@ Cloud Functions for Firebase
 |  [FunctionsErrorCodeCore](./functions.md#functionserrorcodecore) | Functions error code string appended after "functions/" product prefix. See [FunctionsErrorCode](./functions.md#functionserrorcode) for full documentation of codes. |
 |  [HttpsCallable](./functions.md#httpscallable) | A reference to a "callable" HTTP trigger in Google Cloud Functions. |
 
-## getFunctions() {:#getfunctions_60f2095}
+## function(app, ...)
+
+### getFunctions(app, regionOrCustomDomain) {:#getfunctions_60f2095}
 
 Returns a [Functions](./functions.functions.md#functions_interface) instance for the given app.
 
@@ -50,7 +52,7 @@ Returns a [Functions](./functions.functions.md#functions_interface) instance for
 export declare function getFunctions(app?: FirebaseApp, regionOrCustomDomain?: string): Functions;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -61,7 +63,9 @@ export declare function getFunctions(app?: FirebaseApp, regionOrCustomDomain?: s
 
 [Functions](./functions.functions.md#functions_interface)
 
-## connectFunctionsEmulator() {:#connectfunctionsemulator_505c08d}
+## function(functionsInstance, ...)
+
+### connectFunctionsEmulator(functionsInstance, host, port) {:#connectfunctionsemulator_505c08d}
 
 Modify this instance to communicate with the Cloud Functions emulator.
 
@@ -73,7 +77,7 @@ Note: this must be called before this instance has been used to do any operation
 export declare function connectFunctionsEmulator(functionsInstance: Functions, host: string, port: number): void;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -85,7 +89,7 @@ export declare function connectFunctionsEmulator(functionsInstance: Functions, h
 
 void
 
-## httpsCallable() {:#httpscallable_1dd297c}
+### httpsCallable(functionsInstance, name, options) {:#httpscallable_1dd297c}
 
 Returns a reference to the callable HTTPS trigger with the given name.
 
@@ -95,7 +99,7 @@ Returns a reference to the callable HTTPS trigger with the given name.
 export declare function httpsCallable<RequestData = unknown, ResponseData = unknown>(functionsInstance: Functions, name: string, options?: HttpsCallableOptions): HttpsCallable<RequestData, ResponseData>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -107,7 +111,7 @@ export declare function httpsCallable<RequestData = unknown, ResponseData = unkn
 
 [HttpsCallable](./functions.md#httpscallable)<!-- -->&lt;RequestData, ResponseData&gt;
 
-## httpsCallableFromURL() {:#httpscallablefromurl_7af6987}
+### httpsCallableFromURL(functionsInstance, url, options) {:#httpscallablefromurl_7af6987}
 
 Returns a reference to the callable HTTPS trigger with the specified url.
 
@@ -117,7 +121,7 @@ Returns a reference to the callable HTTPS trigger with the specified url.
 export declare function httpsCallableFromURL<RequestData = unknown, ResponseData = unknown>(functionsInstance: Functions, url: string, options?: HttpsCallableOptions): HttpsCallable<RequestData, ResponseData>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |

--- a/docs-devsite/installations.md
+++ b/docs-devsite/installations.md
@@ -16,9 +16,9 @@ The Firebase Installations Web SDK. This SDK does not work in a Node.js environm
 
 |  Function | Description |
 |  --- | --- |
-|  <b>function(app...)</b> |
+|  <b>function(app, ...)</b> |
 |  [getInstallations(app)](./installations.md#getinstallations_cf608e1) | Returns an instance of [Installations](./installations.installations.md#installations_interface) associated with the given [FirebaseApp](./app.firebaseapp.md#firebaseapp_interface) instance. |
-|  <b>function(installations...)</b> |
+|  <b>function(installations, ...)</b> |
 |  [deleteInstallations(installations)](./installations.md#deleteinstallations_606c567) | Deletes the Firebase Installation and all associated data. |
 |  [getId(installations)](./installations.md#getid_606c567) | Creates a Firebase Installation if there isn't one for the app and returns the Installation ID. |
 |  [getToken(installations, forceRefresh)](./installations.md#gettoken_cf009a7) | Returns a Firebase Installations auth token, identifying the current Firebase Installation. |
@@ -37,7 +37,9 @@ The Firebase Installations Web SDK. This SDK does not work in a Node.js environm
 |  [IdChangeCallbackFn](./installations.md#idchangecallbackfn) | An user defined callback function that gets called when Installations ID changes. |
 |  [IdChangeUnsubscribeFn](./installations.md#idchangeunsubscribefn) | Unsubscribe a callback function previously added via [IdChangeCallbackFn](./installations.md#idchangecallbackfn)<!-- -->. |
 
-## getInstallations() {:#getinstallations_cf608e1}
+## function(app, ...)
+
+### getInstallations(app) {:#getinstallations_cf608e1}
 
 Returns an instance of [Installations](./installations.installations.md#installations_interface) associated with the given [FirebaseApp](./app.firebaseapp.md#firebaseapp_interface) instance.
 
@@ -47,7 +49,7 @@ Returns an instance of [Installations](./installations.installations.md#installa
 export declare function getInstallations(app?: FirebaseApp): Installations;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -57,7 +59,9 @@ export declare function getInstallations(app?: FirebaseApp): Installations;
 
 [Installations](./installations.installations.md#installations_interface)
 
-## deleteInstallations() {:#deleteinstallations_606c567}
+## function(installations, ...)
+
+### deleteInstallations(installations) {:#deleteinstallations_606c567}
 
 Deletes the Firebase Installation and all associated data.
 
@@ -67,7 +71,7 @@ Deletes the Firebase Installation and all associated data.
 export declare function deleteInstallations(installations: Installations): Promise<void>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -77,7 +81,7 @@ export declare function deleteInstallations(installations: Installations): Promi
 
 Promise&lt;void&gt;
 
-## getId() {:#getid_606c567}
+### getId(installations) {:#getid_606c567}
 
 Creates a Firebase Installation if there isn't one for the app and returns the Installation ID.
 
@@ -87,7 +91,7 @@ Creates a Firebase Installation if there isn't one for the app and returns the I
 export declare function getId(installations: Installations): Promise<string>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -97,7 +101,7 @@ export declare function getId(installations: Installations): Promise<string>;
 
 Promise&lt;string&gt;
 
-## getToken() {:#gettoken_cf009a7}
+### getToken(installations, forceRefresh) {:#gettoken_cf009a7}
 
 Returns a Firebase Installations auth token, identifying the current Firebase Installation.
 
@@ -107,7 +111,7 @@ Returns a Firebase Installations auth token, identifying the current Firebase In
 export declare function getToken(installations: Installations, forceRefresh?: boolean): Promise<string>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -118,7 +122,7 @@ export declare function getToken(installations: Installations, forceRefresh?: bo
 
 Promise&lt;string&gt;
 
-## onIdChange() {:#onidchange_b579e0e}
+### onIdChange(installations, callback) {:#onidchange_b579e0e}
 
 Sets a new callback that will get called when Installation ID changes. Returns an unsubscribe function that will remove the callback when called.
 
@@ -128,7 +132,7 @@ Sets a new callback that will get called when Installation ID changes. Returns a
 export declare function onIdChange(installations: Installations, callback: IdChangeCallbackFn): IdChangeUnsubscribeFn;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |

--- a/docs-devsite/messaging_.md
+++ b/docs-devsite/messaging_.md
@@ -15,9 +15,9 @@ https://github.com/firebase/firebase-js-sdk
 
 |  Function | Description |
 |  --- | --- |
-|  <b>function(app...)</b> |
+|  <b>function(app, ...)</b> |
 |  [getMessaging(app)](./messaging_.md#getmessaging_cf608e1) | Retrieves a Firebase Cloud Messaging instance. |
-|  <b>function(messaging...)</b> |
+|  <b>function(messaging, ...)</b> |
 |  [deleteToken(messaging)](./messaging_.md#deletetoken_3fae4b1) | Deletes the registration token associated with this [Messaging](./messaging_.messaging.md#messaging_interface) instance and unsubscribes the [Messaging](./messaging_.messaging.md#messaging_interface) instance from the push subscription. |
 |  [getToken(messaging, options)](./messaging_.md#gettoken_b538f38) | Subscribes the [Messaging](./messaging_.messaging.md#messaging_interface) instance to push notifications. Returns a Firebase Cloud Messaging registration token that can be used to send push messages to that [Messaging](./messaging_.messaging.md#messaging_interface) instance.<!-- -->If notification permission isn't already granted, this method asks the user for permission. The returned promise rejects if the user does not allow the app to show notifications. |
 |  [onMessage(messaging, nextOrObserver)](./messaging_.md#onmessage_b9887da) | When a push message is received and the user is currently on a page for your origin, the message is passed to the page and an <code>onMessage()</code> event is dispatched with the payload of the push message. |
@@ -34,7 +34,9 @@ https://github.com/firebase/firebase-js-sdk
 |  [Messaging](./messaging_.messaging.md#messaging_interface) | Public interface of the Firebase Cloud Messaging SDK. |
 |  [NotificationPayload](./messaging_.notificationpayload.md#notificationpayload_interface) | Display notification details. Details are sent through the [Send API](https://firebase.google.com/docs/reference/fcm/rest/v1/projects.messages#notification)<!-- -->. |
 
-## getMessaging() {:#getmessaging_cf608e1}
+## function(app, ...)
+
+### getMessaging(app) {:#getmessaging_cf608e1}
 
 Retrieves a Firebase Cloud Messaging instance.
 
@@ -44,7 +46,7 @@ Retrieves a Firebase Cloud Messaging instance.
 export declare function getMessagingInWindow(app?: FirebaseApp): Messaging;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -56,7 +58,9 @@ export declare function getMessagingInWindow(app?: FirebaseApp): Messaging;
 
 The Firebase Cloud Messaging instance associated with the provided firebase app.
 
-## deleteToken() {:#deletetoken_3fae4b1}
+## function(messaging, ...)
+
+### deleteToken(messaging) {:#deletetoken_3fae4b1}
 
 Deletes the registration token associated with this [Messaging](./messaging_.messaging.md#messaging_interface) instance and unsubscribes the [Messaging](./messaging_.messaging.md#messaging_interface) instance from the push subscription.
 
@@ -66,7 +70,7 @@ Deletes the registration token associated with this [Messaging](./messaging_.mes
 export declare function deleteToken(messaging: Messaging): Promise<boolean>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -78,7 +82,7 @@ Promise&lt;boolean&gt;
 
 The promise resolves when the token has been successfully deleted.
 
-## getToken() {:#gettoken_b538f38}
+### getToken(messaging, options) {:#gettoken_b538f38}
 
 Subscribes the [Messaging](./messaging_.messaging.md#messaging_interface) instance to push notifications. Returns a Firebase Cloud Messaging registration token that can be used to send push messages to that [Messaging](./messaging_.messaging.md#messaging_interface) instance.
 
@@ -90,7 +94,7 @@ If notification permission isn't already granted, this method asks the user for 
 export declare function getToken(messaging: Messaging, options?: GetTokenOptions): Promise<string>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -103,7 +107,7 @@ Promise&lt;string&gt;
 
 The promise resolves with an FCM registration token.
 
-## onMessage() {:#onmessage_b9887da}
+### onMessage(messaging, nextOrObserver) {:#onmessage_b9887da}
 
 When a push message is received and the user is currently on a page for your origin, the message is passed to the page and an `onMessage()` event is dispatched with the payload of the push message.
 
@@ -113,7 +117,7 @@ When a push message is received and the user is currently on a page for your ori
 export declare function onMessage(messaging: Messaging, nextOrObserver: NextFn<MessagePayload> | Observer<MessagePayload>): Unsubscribe;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -126,7 +130,9 @@ export declare function onMessage(messaging: Messaging, nextOrObserver: NextFn<M
 
 To stop listening for messages execute this returned function.
 
-## isSupported() {:#issupported}
+## function()
+
+### isSupported() {:#issupported}
 
 Checks if all required APIs exist in the browser.
 

--- a/docs-devsite/messaging_sw.md
+++ b/docs-devsite/messaging_sw.md
@@ -15,9 +15,9 @@ https://github.com/firebase/firebase-js-sdk
 
 |  Function | Description |
 |  --- | --- |
-|  <b>function(app...)</b> |
+|  <b>function(app, ...)</b> |
 |  [getMessaging(app)](./messaging_sw.md#getmessaging_cf608e1) | Retrieves a Firebase Cloud Messaging instance. |
-|  <b>function(messaging...)</b> |
+|  <b>function(messaging, ...)</b> |
 |  [experimentalSetDeliveryMetricsExportedToBigQueryEnabled(messaging, enable)](./messaging_sw.md#experimentalsetdeliverymetricsexportedtobigqueryenabled_f3e53bd) | Enables or disables Firebase Cloud Messaging message delivery metrics export to BigQuery. By default, message delivery metrics are not exported to BigQuery. Use this method to enable or disable the export at runtime. |
 |  [onBackgroundMessage(messaging, nextOrObserver)](./messaging_sw.md#onbackgroundmessage_b9887da) | Called when a message is received while the app is in the background. An app is considered to be in the background if no active window is displayed. |
 |  <b>function()</b> |
@@ -33,7 +33,9 @@ https://github.com/firebase/firebase-js-sdk
 |  [Messaging](./messaging_sw.messaging.md#messaging_interface) | Public interface of the Firebase Cloud Messaging SDK. |
 |  [NotificationPayload](./messaging_sw.notificationpayload.md#notificationpayload_interface) | Display notification details. Details are sent through the [Send API](https://firebase.google.com/docs/reference/fcm/rest/v1/projects.messages#notification)<!-- -->. |
 
-## getMessaging() {:#getmessaging_cf608e1}
+## function(app, ...)
+
+### getMessaging(app) {:#getmessaging_cf608e1}
 
 Retrieves a Firebase Cloud Messaging instance.
 
@@ -43,7 +45,7 @@ Retrieves a Firebase Cloud Messaging instance.
 export declare function getMessagingInSw(app?: FirebaseApp): Messaging;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -55,7 +57,9 @@ export declare function getMessagingInSw(app?: FirebaseApp): Messaging;
 
 The Firebase Cloud Messaging instance associated with the provided firebase app.
 
-## experimentalSetDeliveryMetricsExportedToBigQueryEnabled() {:#experimentalsetdeliverymetricsexportedtobigqueryenabled_f3e53bd}
+## function(messaging, ...)
+
+### experimentalSetDeliveryMetricsExportedToBigQueryEnabled(messaging, enable) {:#experimentalsetdeliverymetricsexportedtobigqueryenabled_f3e53bd}
 
 Enables or disables Firebase Cloud Messaging message delivery metrics export to BigQuery. By default, message delivery metrics are not exported to BigQuery. Use this method to enable or disable the export at runtime.
 
@@ -65,7 +69,7 @@ Enables or disables Firebase Cloud Messaging message delivery metrics export to 
 export declare function experimentalSetDeliveryMetricsExportedToBigQueryEnabled(messaging: Messaging, enable: boolean): void;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -76,7 +80,7 @@ export declare function experimentalSetDeliveryMetricsExportedToBigQueryEnabled(
 
 void
 
-## onBackgroundMessage() {:#onbackgroundmessage_b9887da}
+### onBackgroundMessage(messaging, nextOrObserver) {:#onbackgroundmessage_b9887da}
 
 Called when a message is received while the app is in the background. An app is considered to be in the background if no active window is displayed.
 
@@ -86,7 +90,7 @@ Called when a message is received while the app is in the background. An app is 
 export declare function onBackgroundMessage(messaging: Messaging, nextOrObserver: NextFn<MessagePayload> | Observer<MessagePayload>): Unsubscribe;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -99,7 +103,9 @@ export declare function onBackgroundMessage(messaging: Messaging, nextOrObserver
 
 To stop listening for messages execute this returned function
 
-## isSupported() {:#issupported}
+## function()
+
+### isSupported() {:#issupported}
 
 Checks whether all required APIs exist within SW Context
 

--- a/docs-devsite/performance.md
+++ b/docs-devsite/performance.md
@@ -16,10 +16,10 @@ The Firebase Performance Monitoring Web SDK. This SDK does not work in a Node.js
 
 |  Function | Description |
 |  --- | --- |
-|  <b>function(app...)</b> |
+|  <b>function(app, ...)</b> |
 |  [getPerformance(app)](./performance.md#getperformance_cf608e1) | Returns a [FirebasePerformance](./performance.firebaseperformance.md#firebaseperformance_interface) instance for the given app. |
 |  [initializePerformance(app, settings)](./performance.md#initializeperformance_980350e) | Returns a [FirebasePerformance](./performance.firebaseperformance.md#firebaseperformance_interface) instance for the given app. Can only be called once. |
-|  <b>function(performance...)</b> |
+|  <b>function(performance, ...)</b> |
 |  [trace(performance, name)](./performance.md#trace_62e4b7e) | Returns a new <code>PerformanceTrace</code> instance. |
 
 ## Interfaces
@@ -30,7 +30,9 @@ The Firebase Performance Monitoring Web SDK. This SDK does not work in a Node.js
 |  [PerformanceSettings](./performance.performancesettings.md#performancesettings_interface) | Defines configuration options for the Performance Monitoring SDK. |
 |  [PerformanceTrace](./performance.performancetrace.md#performancetrace_interface) | The interface representing a <code>Trace</code>. |
 
-## getPerformance() {:#getperformance_cf608e1}
+## function(app, ...)
+
+### getPerformance(app) {:#getperformance_cf608e1}
 
 Returns a [FirebasePerformance](./performance.firebaseperformance.md#firebaseperformance_interface) instance for the given app.
 
@@ -40,7 +42,7 @@ Returns a [FirebasePerformance](./performance.firebaseperformance.md#firebaseper
 export declare function getPerformance(app?: FirebaseApp): FirebasePerformance;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -50,7 +52,7 @@ export declare function getPerformance(app?: FirebaseApp): FirebasePerformance;
 
 [FirebasePerformance](./performance.firebaseperformance.md#firebaseperformance_interface)
 
-## initializePerformance() {:#initializeperformance_980350e}
+### initializePerformance(app, settings) {:#initializeperformance_980350e}
 
 Returns a [FirebasePerformance](./performance.firebaseperformance.md#firebaseperformance_interface) instance for the given app. Can only be called once.
 
@@ -60,7 +62,7 @@ Returns a [FirebasePerformance](./performance.firebaseperformance.md#firebaseper
 export declare function initializePerformance(app: FirebaseApp, settings?: PerformanceSettings): FirebasePerformance;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -71,7 +73,9 @@ export declare function initializePerformance(app: FirebaseApp, settings?: Perfo
 
 [FirebasePerformance](./performance.firebaseperformance.md#firebaseperformance_interface)
 
-## trace() {:#trace_62e4b7e}
+## function(performance, ...)
+
+### trace(performance, name) {:#trace_62e4b7e}
 
 Returns a new `PerformanceTrace` instance.
 
@@ -81,7 +85,7 @@ Returns a new `PerformanceTrace` instance.
 export declare function trace(performance: FirebasePerformance, name: string): PerformanceTrace;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |

--- a/docs-devsite/performance.performancetrace.md
+++ b/docs-devsite/performance.performancetrace.md
@@ -43,7 +43,7 @@ Retrieves the value which a custom attribute is set to.
 getAttribute(attr: string): string | undefined;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -78,7 +78,7 @@ Returns the value of the custom metric by that name. If a custom metric with tha
 getMetric(metricName: string): number;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -98,7 +98,7 @@ Adds to the value of a custom metric. If a custom metric with the provided name 
 incrementMetric(metricName: string, num?: number): void;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -119,7 +119,7 @@ Set a custom attribute of a trace to a certain value.
 putAttribute(attr: string, value: string): void;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -140,7 +140,7 @@ Sets the value of the specified custom metric to the given number regardless of 
 putMetric(metricName: string, num: number): void;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -168,7 +168,7 @@ record(startTime: number, duration: number, options?: {
     }): void;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -190,7 +190,7 @@ Removes the specified custom attribute from a trace instance.
 removeAttribute(attr: string): void;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |

--- a/docs-devsite/remote-config.md
+++ b/docs-devsite/remote-config.md
@@ -16,9 +16,9 @@ The Firebase Remote Config Web SDK. This SDK does not work in a Node.js environm
 
 |  Function | Description |
 |  --- | --- |
-|  <b>function(app...)</b> |
+|  <b>function(app, ...)</b> |
 |  [getRemoteConfig(app)](./remote-config.md#getremoteconfig_cf608e1) |  |
-|  <b>function(remoteConfig...)</b> |
+|  <b>function(remoteConfig, ...)</b> |
 |  [activate(remoteConfig)](./remote-config.md#activate_722a192) | Makes the last fetched config available to the getters. |
 |  [ensureInitialized(remoteConfig)](./remote-config.md#ensureinitialized_722a192) | Ensures the last activated config are available to the getters. |
 |  [fetchAndActivate(remoteConfig)](./remote-config.md#fetchandactivate_722a192) | Performs fetch and activate operations, as a convenience. |
@@ -48,7 +48,9 @@ The Firebase Remote Config Web SDK. This SDK does not work in a Node.js environm
 |  [LogLevel](./remote-config.md#loglevel) | Defines levels of Remote Config logging. |
 |  [ValueSource](./remote-config.md#valuesource) | Indicates the source of a value.<ul> <li>"static" indicates the value was defined by a static constant.</li> <li>"default" indicates the value was defined by default config.</li> <li>"remote" indicates the value was defined by fetched config.</li> </ul> |
 
-## getRemoteConfig() {:#getremoteconfig_cf608e1}
+## function(app, ...)
+
+### getRemoteConfig(app) {:#getremoteconfig_cf608e1}
 
 <b>Signature:</b>
 
@@ -56,7 +58,7 @@ The Firebase Remote Config Web SDK. This SDK does not work in a Node.js environm
 export declare function getRemoteConfig(app?: FirebaseApp): RemoteConfig;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -68,7 +70,9 @@ export declare function getRemoteConfig(app?: FirebaseApp): RemoteConfig;
 
 A [RemoteConfig](./remote-config.remoteconfig.md#remoteconfig_interface) instance.
 
-## activate() {:#activate_722a192}
+## function(remoteConfig, ...)
+
+### activate(remoteConfig) {:#activate_722a192}
 
 Makes the last fetched config available to the getters.
 
@@ -78,7 +82,7 @@ Makes the last fetched config available to the getters.
 export declare function activate(remoteConfig: RemoteConfig): Promise<boolean>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -90,7 +94,7 @@ Promise&lt;boolean&gt;
 
 A `Promise` which resolves to true if the current call activated the fetched configs. If the fetched configs were already activated, the `Promise` will resolve to false.
 
-## ensureInitialized() {:#ensureinitialized_722a192}
+### ensureInitialized(remoteConfig) {:#ensureinitialized_722a192}
 
 Ensures the last activated config are available to the getters.
 
@@ -100,7 +104,7 @@ Ensures the last activated config are available to the getters.
 export declare function ensureInitialized(remoteConfig: RemoteConfig): Promise<void>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -112,7 +116,7 @@ Promise&lt;void&gt;
 
 A `Promise` that resolves when the last activated config is available to the getters.
 
-## fetchAndActivate() {:#fetchandactivate_722a192}
+### fetchAndActivate(remoteConfig) {:#fetchandactivate_722a192}
 
 Performs fetch and activate operations, as a convenience.
 
@@ -122,7 +126,7 @@ Performs fetch and activate operations, as a convenience.
 export declare function fetchAndActivate(remoteConfig: RemoteConfig): Promise<boolean>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -134,7 +138,7 @@ Promise&lt;boolean&gt;
 
 A `Promise` which resolves to true if the current call activated the fetched configs. If the fetched configs were already activated, the `Promise` will resolve to false.
 
-## fetchConfig() {:#fetchconfig_722a192}
+### fetchConfig(remoteConfig) {:#fetchconfig_722a192}
 
 Fetches and caches configuration from the Remote Config service.
 
@@ -144,7 +148,7 @@ Fetches and caches configuration from the Remote Config service.
 export declare function fetchConfig(remoteConfig: RemoteConfig): Promise<void>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -154,7 +158,7 @@ export declare function fetchConfig(remoteConfig: RemoteConfig): Promise<void>;
 
 Promise&lt;void&gt;
 
-## getAll() {:#getall_722a192}
+### getAll(remoteConfig) {:#getall_722a192}
 
 Gets all config.
 
@@ -164,7 +168,7 @@ Gets all config.
 export declare function getAll(remoteConfig: RemoteConfig): Record<string, Value>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -176,7 +180,7 @@ Record&lt;string, [Value](./remote-config.value.md#value_interface)<!-- -->&gt;
 
 All config.
 
-## getBoolean() {:#getboolean_476c09f}
+### getBoolean(remoteConfig, key) {:#getboolean_476c09f}
 
 Gets the value for the given key as a boolean.
 
@@ -188,7 +192,7 @@ Convenience method for calling <code>remoteConfig.getValue(key).asBoolean()</cod
 export declare function getBoolean(remoteConfig: RemoteConfig, key: string): boolean;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -201,7 +205,7 @@ boolean
 
 The value for the given key as a boolean.
 
-## getNumber() {:#getnumber_476c09f}
+### getNumber(remoteConfig, key) {:#getnumber_476c09f}
 
 Gets the value for the given key as a number.
 
@@ -213,7 +217,7 @@ Convenience method for calling <code>remoteConfig.getValue(key).asNumber()</code
 export declare function getNumber(remoteConfig: RemoteConfig, key: string): number;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -226,7 +230,7 @@ number
 
 The value for the given key as a number.
 
-## getString() {:#getstring_476c09f}
+### getString(remoteConfig, key) {:#getstring_476c09f}
 
 Gets the value for the given key as a string. Convenience method for calling <code>remoteConfig.getValue(key).asString()</code>.
 
@@ -236,7 +240,7 @@ Gets the value for the given key as a string. Convenience method for calling <co
 export declare function getString(remoteConfig: RemoteConfig, key: string): string;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -249,7 +253,7 @@ string
 
 The value for the given key as a string.
 
-## getValue() {:#getvalue_476c09f}
+### getValue(remoteConfig, key) {:#getvalue_476c09f}
 
 Gets the [Value](./remote-config.value.md#value_interface) for the given key.
 
@@ -259,7 +263,7 @@ Gets the [Value](./remote-config.value.md#value_interface) for the given key.
 export declare function getValue(remoteConfig: RemoteConfig, key: string): Value;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -272,7 +276,7 @@ export declare function getValue(remoteConfig: RemoteConfig, key: string): Value
 
 The value for the given key.
 
-## setLogLevel() {:#setloglevel_039a45b}
+### setLogLevel(remoteConfig, logLevel) {:#setloglevel_039a45b}
 
 Defines the log level to use.
 
@@ -282,7 +286,7 @@ Defines the log level to use.
 export declare function setLogLevel(remoteConfig: RemoteConfig, logLevel: RemoteConfigLogLevel): void;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -293,7 +297,9 @@ export declare function setLogLevel(remoteConfig: RemoteConfig, logLevel: Remote
 
 void
 
-## isSupported() {:#issupported}
+## function()
+
+### isSupported() {:#issupported}
 
 This method provides two different checks:
 

--- a/docs-devsite/storage.md
+++ b/docs-devsite/storage.md
@@ -16,12 +16,12 @@ Cloud Storage for Firebase
 
 |  Function | Description |
 |  --- | --- |
-|  <b>function(app...)</b> |
+|  <b>function(app, ...)</b> |
 |  [getStorage(app, bucketUrl)](./storage.md#getstorage_25f3a57) | Gets a [FirebaseStorage](./storage.firebasestorage.md#firebasestorage_interface) instance for the given Firebase app. |
-|  <b>function(storage...)</b> |
+|  <b>function(storage, ...)</b> |
 |  [connectStorageEmulator(storage, host, port, options)](./storage.md#connectstorageemulator_e9039de) | Modify this [FirebaseStorage](./storage.firebasestorage.md#firebasestorage_interface) instance to communicate with the Cloud Storage emulator. |
 |  [ref(storage, url)](./storage.md#ref_5672fc1) | Returns a [StorageReference](./storage.storagereference.md#storagereference_interface) for the given url. |
-|  <b>function(ref...)</b> |
+|  <b>function(ref, ...)</b> |
 |  [deleteObject(ref)](./storage.md#deleteobject_30df0b2) | Deletes the object at this location. |
 |  [getBlob(ref, maxDownloadSizeBytes)](./storage.md#getblob_1c7a935) | Downloads the data at the object's location. Returns an error if the object is not found.<!-- -->To use this functionality, you have to whitelist your app's origin in your Cloud Storage bucket. See also https://cloud.google.com/storage/docs/configuring-cors<!-- -->This API is not available in Node. |
 |  [getBytes(ref, maxDownloadSizeBytes)](./storage.md#getbytes_1c7a935) | Downloads the data at the object's location. Returns an error if the object is not found.<!-- -->To use this functionality, you have to whitelist your app's origin in your Cloud Storage bucket. See also https://cloud.google.com/storage/docs/configuring-cors |
@@ -34,7 +34,7 @@ Cloud Storage for Firebase
 |  [uploadBytes(ref, data, metadata)](./storage.md#uploadbytes_02686b1) | Uploads data to this object's location. The upload is not resumable. |
 |  [uploadBytesResumable(ref, data, metadata)](./storage.md#uploadbytesresumable_02686b1) | Uploads data to this object's location. The upload can be paused and resumed, and exposes progress updates. |
 |  [uploadString(ref, value, format, metadata)](./storage.md#uploadstring_277829d) | Uploads a string to this object's location. The upload is not resumable. |
-|  <b>function(storageOrRef...)</b> |
+|  <b>function(storageOrRef, ...)</b> |
 |  [ref(storageOrRef, path)](./storage.md#ref_41be95d) | Returns a [StorageReference](./storage.storagereference.md#storagereference_interface) for the given path in the default bucket. |
 
 ## Classes
@@ -79,7 +79,9 @@ Cloud Storage for Firebase
 |  [TaskEvent](./storage.md#taskevent) | An event that is triggered on a task. |
 |  [TaskState](./storage.md#taskstate) | Represents the current state of a running upload. |
 
-## getStorage() {:#getstorage_25f3a57}
+## function(app, ...)
+
+### getStorage(app, bucketUrl) {:#getstorage_25f3a57}
 
 Gets a [FirebaseStorage](./storage.firebasestorage.md#firebasestorage_interface) instance for the given Firebase app.
 
@@ -89,7 +91,7 @@ Gets a [FirebaseStorage](./storage.firebasestorage.md#firebasestorage_interface)
 export declare function getStorage(app?: FirebaseApp, bucketUrl?: string): FirebaseStorage;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -102,7 +104,9 @@ export declare function getStorage(app?: FirebaseApp, bucketUrl?: string): Fireb
 
 A [FirebaseStorage](./storage.firebasestorage.md#firebasestorage_interface) instance.
 
-## connectStorageEmulator() {:#connectstorageemulator_e9039de}
+## function(storage, ...)
+
+### connectStorageEmulator(storage, host, port, options) {:#connectstorageemulator_e9039de}
 
 Modify this [FirebaseStorage](./storage.firebasestorage.md#firebasestorage_interface) instance to communicate with the Cloud Storage emulator.
 
@@ -114,7 +118,7 @@ export declare function connectStorageEmulator(storage: FirebaseStorage, host: s
 }): void;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -127,7 +131,7 @@ export declare function connectStorageEmulator(storage: FirebaseStorage, host: s
 
 void
 
-## ref() {:#ref_5672fc1}
+### ref(storage, url) {:#ref_5672fc1}
 
 Returns a [StorageReference](./storage.storagereference.md#storagereference_interface) for the given url.
 
@@ -137,7 +141,7 @@ Returns a [StorageReference](./storage.storagereference.md#storagereference_inte
 export declare function ref(storage: FirebaseStorage, url?: string): StorageReference;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -148,7 +152,9 @@ export declare function ref(storage: FirebaseStorage, url?: string): StorageRefe
 
 [StorageReference](./storage.storagereference.md#storagereference_interface)
 
-## deleteObject() {:#deleteobject_30df0b2}
+## function(ref, ...)
+
+### deleteObject(ref) {:#deleteobject_30df0b2}
 
 Deletes the object at this location.
 
@@ -158,7 +164,7 @@ Deletes the object at this location.
 export declare function deleteObject(ref: StorageReference): Promise<void>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -170,7 +176,7 @@ Promise&lt;void&gt;
 
 A `Promise` that resolves if the deletion succeeds.
 
-## getBlob() {:#getblob_1c7a935}
+### getBlob(ref, maxDownloadSizeBytes) {:#getblob_1c7a935}
 
 Downloads the data at the object's location. Returns an error if the object is not found.
 
@@ -184,7 +190,7 @@ This API is not available in Node.
 export declare function getBlob(ref: StorageReference, maxDownloadSizeBytes?: number): Promise<Blob>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -197,7 +203,7 @@ Promise&lt;Blob&gt;
 
 A Promise that resolves with a Blob containing the object's bytes
 
-## getBytes() {:#getbytes_1c7a935}
+### getBytes(ref, maxDownloadSizeBytes) {:#getbytes_1c7a935}
 
 Downloads the data at the object's location. Returns an error if the object is not found.
 
@@ -209,7 +215,7 @@ To use this functionality, you have to whitelist your app's origin in your Cloud
 export declare function getBytes(ref: StorageReference, maxDownloadSizeBytes?: number): Promise<ArrayBuffer>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -222,7 +228,7 @@ Promise&lt;ArrayBuffer&gt;
 
 A Promise containing the object's bytes
 
-## getDownloadURL() {:#getdownloadurl_30df0b2}
+### getDownloadURL(ref) {:#getdownloadurl_30df0b2}
 
 Returns the download URL for the given [StorageReference](./storage.storagereference.md#storagereference_interface)<!-- -->.
 
@@ -232,7 +238,7 @@ Returns the download URL for the given [StorageReference](./storage.storagerefer
 export declare function getDownloadURL(ref: StorageReference): Promise<string>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -244,7 +250,7 @@ Promise&lt;string&gt;
 
 A `Promise` that resolves with the download URL for this object.
 
-## getMetadata() {:#getmetadata_30df0b2}
+### getMetadata(ref) {:#getmetadata_30df0b2}
 
 A `Promise` that resolves with the metadata for this object. If this object doesn't exist or metadata cannot be retreived, the promise is rejected.
 
@@ -254,7 +260,7 @@ A `Promise` that resolves with the metadata for this object. If this object does
 export declare function getMetadata(ref: StorageReference): Promise<FullMetadata>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -264,7 +270,7 @@ export declare function getMetadata(ref: StorageReference): Promise<FullMetadata
 
 Promise&lt;[FullMetadata](./storage.fullmetadata.md#fullmetadata_interface)<!-- -->&gt;
 
-## getStream() {:#getstream_1c7a935}
+### getStream(ref, maxDownloadSizeBytes) {:#getstream_1c7a935}
 
 Downloads the data at the object's location. Raises an error event if the object is not found.
 
@@ -276,7 +282,7 @@ This API is only available in Node.
 export declare function getStream(ref: StorageReference, maxDownloadSizeBytes?: number): NodeJS.ReadableStream;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -289,7 +295,7 @@ NodeJS.ReadableStream
 
 A stream with the object's data as bytes
 
-## list() {:#list_36af757}
+### list(ref, options) {:#list_36af757}
 
 List items (files) and prefixes (folders) under this storage reference.
 
@@ -305,7 +311,7 @@ To adhere to Firebase Rules's Semantics, Firebase Storage does not support objec
 export declare function list(ref: StorageReference, options?: ListOptions): Promise<ListResult>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -318,7 +324,7 @@ Promise&lt;[ListResult](./storage.listresult.md#listresult_interface)<!-- -->&gt
 
 A `Promise` that resolves with the items and prefixes. `prefixes` contains references to sub-folders and `items` contains references to objects in this folder. `nextPageToken` can be used to get the rest of the results.
 
-## listAll() {:#listall_30df0b2}
+### listAll(ref) {:#listall_30df0b2}
 
 List all items (files) and prefixes (folders) under this storage reference.
 
@@ -334,7 +340,7 @@ Warning: `listAll` may potentially consume too many resources if there are too m
 export declare function listAll(ref: StorageReference): Promise<ListResult>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -346,7 +352,7 @@ Promise&lt;[ListResult](./storage.listresult.md#listresult_interface)<!-- -->&gt
 
 A `Promise` that resolves with all the items and prefixes under the current storage reference. `prefixes` contains references to sub-directories and `items` contains references to objects in this folder. `nextPageToken` is never returned.
 
-## updateMetadata() {:#updatemetadata_a634608}
+### updateMetadata(ref, metadata) {:#updatemetadata_a634608}
 
 Updates the metadata for this object.
 
@@ -356,7 +362,7 @@ Updates the metadata for this object.
 export declare function updateMetadata(ref: StorageReference, metadata: SettableMetadata): Promise<FullMetadata>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -369,7 +375,7 @@ Promise&lt;[FullMetadata](./storage.fullmetadata.md#fullmetadata_interface)<!-- 
 
 A `Promise` that resolves with the new metadata for this object.
 
-## uploadBytes() {:#uploadbytes_02686b1}
+### uploadBytes(ref, data, metadata) {:#uploadbytes_02686b1}
 
 Uploads data to this object's location. The upload is not resumable.
 
@@ -379,7 +385,7 @@ Uploads data to this object's location. The upload is not resumable.
 export declare function uploadBytes(ref: StorageReference, data: Blob | Uint8Array | ArrayBuffer, metadata?: UploadMetadata): Promise<UploadResult>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -393,7 +399,7 @@ Promise&lt;[UploadResult](./storage.uploadresult.md#uploadresult_interface)<!-- 
 
 A Promise containing an UploadResult
 
-## uploadBytesResumable() {:#uploadbytesresumable_02686b1}
+### uploadBytesResumable(ref, data, metadata) {:#uploadbytesresumable_02686b1}
 
 Uploads data to this object's location. The upload can be paused and resumed, and exposes progress updates.
 
@@ -403,7 +409,7 @@ Uploads data to this object's location. The upload can be paused and resumed, an
 export declare function uploadBytesResumable(ref: StorageReference, data: Blob | Uint8Array | ArrayBuffer, metadata?: UploadMetadata): UploadTask;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -417,7 +423,7 @@ export declare function uploadBytesResumable(ref: StorageReference, data: Blob |
 
 An UploadTask
 
-## uploadString() {:#uploadstring_277829d}
+### uploadString(ref, value, format, metadata) {:#uploadstring_277829d}
 
 Uploads a string to this object's location. The upload is not resumable.
 
@@ -427,7 +433,7 @@ Uploads a string to this object's location. The upload is not resumable.
 export declare function uploadString(ref: StorageReference, value: string, format?: StringFormat, metadata?: UploadMetadata): Promise<UploadResult>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -442,7 +448,9 @@ Promise&lt;[UploadResult](./storage.uploadresult.md#uploadresult_interface)<!-- 
 
 A Promise containing an UploadResult
 
-## ref() {:#ref_41be95d}
+## function(storageOrRef, ...)
+
+### ref(storageOrRef, path) {:#ref_41be95d}
 
 Returns a [StorageReference](./storage.storagereference.md#storagereference_interface) for the given path in the default bucket.
 
@@ -452,7 +460,7 @@ Returns a [StorageReference](./storage.storagereference.md#storagereference_inte
 export declare function ref(storageOrRef: FirebaseStorage | StorageReference, path?: string): StorageReference;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |

--- a/docs-devsite/storage.storageerror.md
+++ b/docs-devsite/storage.storageerror.md
@@ -49,7 +49,7 @@ Constructs a new instance of the `StorageError` class
 constructor(code: StorageErrorCode, message: string, status_?: number);
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -101,7 +101,7 @@ Compares a `StorageErrorCode` against this error's code, filtering out the prefi
 _codeEquals(code: StorageErrorCode): boolean;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |

--- a/docs-devsite/storage.uploadtask.md
+++ b/docs-devsite/storage.uploadtask.md
@@ -70,7 +70,7 @@ Equivalent to calling `then(null, onRejected)`<!-- -->.
 catch(onRejected: (error: StorageError) => unknown): Promise<unknown>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -96,7 +96,7 @@ Callbacks can be passed either as three separate arguments <em>or</em> as the `n
 on(event: TaskEvent, nextOrObserver?: StorageObserver<UploadTaskSnapshot> | null | ((snapshot: UploadTaskSnapshot) => unknown), error?: ((a: StorageError) => unknown) | null, complete?: Unsubscribe | null): Unsubscribe | Subscribe<UploadTaskSnapshot>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
@@ -242,7 +242,7 @@ This object behaves like a Promise, and resolves with its snapshot data when the
 then(onFulfilled?: ((snapshot: UploadTaskSnapshot) => unknown) | null, onRejected?: ((error: StorageError) => unknown) | null): Promise<unknown>;
 ```
 
-### Parameters
+#### Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |

--- a/repo-scripts/api-documenter/src/documenters/MarkdownDocumenterHelpers.ts
+++ b/repo-scripts/api-documenter/src/documenters/MarkdownDocumenterHelpers.ts
@@ -347,7 +347,8 @@ function appendAndMergeSection(
 
 export function createThrowsSection(
   apiItem: ApiItem,
-  configuration: TSDocConfiguration
+  configuration: TSDocConfiguration,
+  parentHeadingLevel: number
 ): DocNode[] {
   const output: DocNode[] = [];
   if (apiItem instanceof ApiDocumentedItem) {
@@ -363,7 +364,13 @@ export function createThrowsSection(
 
       if (throwsBlocks.length > 0) {
         const heading: string = 'Exceptions';
-        output.push(new DocHeading({ configuration, title: heading }));
+        output.push(
+          new DocHeading({
+            configuration,
+            title: heading,
+            level: parentHeadingLevel + 1
+          })
+        );
 
         for (const throwsBlock of throwsBlocks) {
           output.push(...throwsBlock.content.nodes);

--- a/repo-scripts/api-documenter/src/markdown/CustomMarkdownEmitter.ts
+++ b/repo-scripts/api-documenter/src/markdown/CustomMarkdownEmitter.ts
@@ -85,7 +85,7 @@ export class CustomMarkdownEmitter extends MarkdownEmitter {
             prefix = '###';
             break;
           case 3:
-            prefix = '###';
+            prefix = '####';
             break;
           default:
             prefix = '####';


### PR DESCRIPTION
Fixes b/316190402

One change to the Functions table at the top of the page:

1. In function table, change `function(param...)` to `function(param, ...)`


Three changes to the function definitions at the bottom of the page:

1. When function definitions are sorted by first param, add section headers within function definitions to show the logical groupings of functions.
2. Add params to the function definition title, so readers can differentiate two adjacent headers
3. Fix the heading level of the Exception node.

Function definitions was:
```
## foo()
### params: app, Field
## Exception If something something

## foo()
### params: app, string
## Exception If something something

## bar()
### params: app, ...

## baz()
### params: app

## foo()
### params: firestore, ...
```

Function definitions is now:
```
## function(app, ...)

### foo(app, Field)
#### params: app, Field
#### Exception If something something

### foo(app, string)
#### params: app, string
#### Exception If something something

### bar(app, ...)
#### params: app, ...

### baz(app)
#### params: app

## function(firestore, ...)

### foo(firestore)
#### params: firestore, ...
```

