### PR TITLE
Disable nightly run with PR

### DIFF
--- a/.github/workflows/test-changed-firestore.yml
+++ b/.github/workflows/test-changed-firestore.yml
@@ -140,7 +140,7 @@ jobs:
         test-name: ["test:browser:nightly"]
     runs-on: ubuntu-latest
     needs: build
-    if: ${{ github.event.workflow_run.trigger_source != 'pull_request' }}
+    if: ${{ github.event_name != 'pull_request' }}
     steps:
       - name: Set up Node (16)
         uses: actions/setup-node@v3

--- a/.github/workflows/test-changed-firestore.yml
+++ b/.github/workflows/test-changed-firestore.yml
@@ -140,7 +140,7 @@ jobs:
         test-name: ["test:browser:nightly"]
     runs-on: ubuntu-latest
     needs: build
-    if: ${{ github.event.workflow_run.trigger_source == 'workflow_dispatch' }}
+    if: ${{ github.event.workflow_run.trigger_source != 'pull_request' }}
     steps:
       - name: Set up Node (16)
         uses: actions/setup-node@v3

--- a/.github/workflows/test-changed-firestore.yml
+++ b/.github/workflows/test-changed-firestore.yml
@@ -14,7 +14,9 @@
 
 name: Test Firestore
 
-on: pull_request
+on:
+  workflow_dispatch:
+  pull_request:
 
 env:
   artifactRetentionDays: 14
@@ -138,7 +140,7 @@ jobs:
         test-name: ["test:browser:nightly"]
     runs-on: ubuntu-latest
     needs: build
-    if: ${{ needs.build.outputs.changed == 'true'}}
+    if: ${{ github.event.workflow_run.trigger_source == 'workflow_dispatch' }}
     steps:
       - name: Set up Node (16)
         uses: actions/setup-node@v3

--- a/packages/firestore/test/integration/api/query.test.ts
+++ b/packages/firestore/test/integration/api/query.test.ts
@@ -411,7 +411,7 @@ apiDescribe('Queries', persistence => {
     });
   });
 
-  it('maintains correct DocumentChange indices', async () => {
+  it('maintains correct DocumentChange indexes', async () => {
     const testDocs = {
       'a': { order: 1 },
       'b': { order: 2 },


### PR DESCRIPTION
Skip the tests against Firestore nightly as a PR presubmit check, it is activated when the workflow is manually triggered still.