### PR TITLE
Add size report for Firestore read & write w/ persistence

### DIFF
--- a/repo-scripts/size-analysis/bundle-definitions/firestore.json
+++ b/repo-scripts/size-analysis/bundle-definitions/firestore.json
@@ -195,6 +195,40 @@
     ]
   },
   {
+    "name": "Read Write w Persistence",
+    "dependencies": [
+      {
+        "packageName": "firebase",
+        "versionOrTag": "latest",
+        "imports": [
+          {
+            "path": "app",
+            "imports": [
+              "initializeApp"
+            ]
+          }
+        ]
+      },
+      {
+        "packageName": "firebase",
+        "versionOrTag": "latest",
+        "imports": [
+          {
+            "path": "firestore",
+            "imports": [
+              "collection",
+              "doc",
+              "enableMultiTabIndexedDbPersistence",
+              "getDoc",
+              "getFirestore",
+              "setDoc"
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
     "name": "Transaction",
     "dependencies": [
       {


### PR DESCRIPTION
Add a new size report for Firestore: "Read Write w Persistence". This is a bundle size for an app that calls getDoc, setDoc, and enables IndexedDb persistence.

![image](https://github.com/firebase/firebase-js-sdk/assets/61283819/2803fd26-ebdc-4ba6-999d-40f764c3cac4)
