### PR TITLE
[E2E CI] Update firebase-tools to v13.0.2

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -60,7 +60,7 @@ jobs:
           pushd functions
           npm install
           popd
-          npx firebase-tools@12.9.1 deploy --only functions:callTest --project jscore-sandbox-141b5 --token $FIREBASE_CLI_TOKEN
+          npx firebase-tools deploy --only functions:callTest --project jscore-sandbox-141b5 --token $FIREBASE_CLI_TOKEN
         working-directory: ./config
         env:
           FIREBASE_CLI_TOKEN: ${{ secrets.FIREBASE_CLI_TOKEN }}

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -16,7 +16,7 @@ name: E2E Smoke Tests
 
 # Allows REST trigger. Currently triggered by release-cli script during a staging run.
 on:
-  push:
+  push:   
   repository_dispatch:
     types: [staging-tests,canary-tests]
 
@@ -61,7 +61,7 @@ jobs:
           pushd functions
           npm install
           popd
-          npx firebase-tools deploy --only functions:callTest --project jscore-sandbox-141b5 --token $FIREBASE_CLI_TOKEN
+          npx firebase-tools@13.0.2 deploy --only functions:callTest --project jscore-sandbox-141b5 --token $FIREBASE_CLI_TOKEN
         working-directory: ./config
         env:
           FIREBASE_CLI_TOKEN: ${{ secrets.FIREBASE_CLI_TOKEN }}

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -16,6 +16,7 @@ name: E2E Smoke Tests
 
 # Allows REST trigger. Currently triggered by release-cli script during a staging run.
 on:
+  push:
   repository_dispatch:
     types: [staging-tests,canary-tests]
 

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -16,7 +16,6 @@ name: E2E Smoke Tests
 
 # Allows REST trigger. Currently triggered by release-cli script during a staging run.
 on:
-  push:   
   repository_dispatch:
     types: [staging-tests,canary-tests]
 

--- a/config/firebase.json
+++ b/config/firebase.json
@@ -5,5 +5,8 @@
   "firestore": {
     "rules": "firestore.rules",
     "indexes": "firestore.indexes.json"
+  },
+  "functions": {
+    "runtime": "nodejs18"
   }
 }


### PR DESCRIPTION
### Discussion

Previously we ran into an issue where we couldn't use the latest firebase-tools CLI version (v13+) due to an error attempting to deploy the E2E cloud function.

The error was due to a new requirement of the CLI that `firebase.json` requires a `functions` configuration. This change adds that configuration and pins the firebase CLI version to 13.

### Testing

Forced [a CI execution](https://github.com/firebase/firebase-js-sdk/actions/runs/7241120102) on push.

### API Changes

N/A