### PR TITLE
Catch possible Safari error

### DIFF
--- a/.changeset/good-seals-promise.md
+++ b/.changeset/good-seals-promise.md
@@ -1,0 +1,5 @@
+---
+'@firebase/app': patch
+---
+
+Catch possible error in Safari browsers.

--- a/packages/app/src/indexeddb.ts
+++ b/packages/app/src/indexeddb.ts
@@ -45,7 +45,14 @@ function getDbPromise(): Promise<IDBPDatabase<AppDB>> {
         // eslint-disable-next-line default-case
         switch (oldVersion) {
           case 0:
-            db.createObjectStore(STORE_NAME);
+            try {
+              db.createObjectStore(STORE_NAME);
+            } catch(e) {
+              // Safari/iOS browsers throw occasional exceptions on
+              // db.createObjectStore() that may be a bug. Avoid blocking
+              // the rest of the app functionality.
+              console.warn(e);
+            }
         }
       }
     }).catch(e => {

--- a/packages/app/src/indexeddb.ts
+++ b/packages/app/src/indexeddb.ts
@@ -47,7 +47,7 @@ function getDbPromise(): Promise<IDBPDatabase<AppDB>> {
           case 0:
             try {
               db.createObjectStore(STORE_NAME);
-            } catch(e) {
+            } catch (e) {
               // Safari/iOS browsers throw occasional exceptions on
               // db.createObjectStore() that may be a bug. Avoid blocking
               // the rest of the app functionality.


### PR DESCRIPTION
This is part of the platform logging code and errors should not block any Firebase functionality.

Sometimes in Safari (and other Safari-based browsers), db.createObjectStore() triggers a "the database is not running a version change transaction" error which is not supposed to happen inside the onupgradeneeded event handler (abstracted to `upgrade` in the `idb` wrapper). Would guess this is an error in Safari or `idb`. We will just catch and warn for now to avoid spamming monitoring logs or crashing the app.

Fixes https://github.com/firebase/firebase-js-sdk/issues/7829