### PR TITLE
Add size report for Firestore client-side indexing

### DIFF
--- a/repo-scripts/size-analysis/bundle-definitions/firestore.json
+++ b/repo-scripts/size-analysis/bundle-definitions/firestore.json
@@ -258,5 +258,71 @@
         ]
       }
     ]
+  },
+  {
+    "name": "CSI Auto Indexing Enable",
+    "dependencies": [
+      {
+        "packageName": "firebase",
+        "versionOrTag": "latest",
+        "imports": [
+          {
+            "path": "app",
+            "imports": [
+              "initializeApp"
+            ]
+          }
+        ]
+      },
+      {
+        "packageName": "firebase",
+        "versionOrTag": "latest",
+        "imports": [
+          {
+            "path": "firestore",
+            "imports": [
+              "deleteAllPersistentCacheIndexes",
+              "enableIndexedDbPersistence",
+              "enablePersistentCacheIndexAutoCreation",
+              "getFirestore",
+              "getPersistentCacheIndexManager"
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "name": "CSI Auto Indexing Disable and Delete",
+    "dependencies": [
+      {
+        "packageName": "firebase",
+        "versionOrTag": "latest",
+        "imports": [
+          {
+            "path": "app",
+            "imports": [
+              "initializeApp"
+            ]
+          }
+        ]
+      },
+      {
+        "packageName": "firebase",
+        "versionOrTag": "latest",
+        "imports": [
+          {
+            "path": "firestore",
+            "imports": [
+              "deleteAllPersistentCacheIndexes",
+              "disablePersistentCacheIndexAutoCreation",
+              "enableIndexedDbPersistence",
+              "getFirestore",
+              "getPersistentCacheIndexManager"
+            ]
+          }
+        ]
+      }
+    ]
   }
 ]


### PR DESCRIPTION
Add two new size reports for Firestore: "CSI Auto Indexing Enable" and "CSI Auto Indexing Disable and Delete". These calculate how much client-side indexing contributes to the bundle size. These numbers will help prioritize the work to make the client-side indexing code tree-shakeable (https://github.com/firebase/firebase-js-sdk/pull/7902).

![image](https://github.com/firebase/firebase-js-sdk/assets/61283819/a17cea91-b287-485d-a2b5-f2dc0e16b328)
