### PR TITLE
Firestore: component_provider.ts: cleanup terminate() functions

### DIFF
--- a/packages/firestore/src/core/component_provider.ts
+++ b/packages/firestore/src/core/component_provider.ts
@@ -167,6 +167,7 @@ export class MemoryOfflineComponentProvider
 
   async terminate(): Promise<void> {
     this.gcScheduler?.stop();
+    this.indexBackfillerScheduler?.stop();
     this.sharedClientState.shutdown();
     await this.persistence.shutdown();
   }

--- a/packages/firestore/src/core/component_provider.ts
+++ b/packages/firestore/src/core/component_provider.ts
@@ -166,10 +166,8 @@ export class MemoryOfflineComponentProvider
   }
 
   async terminate(): Promise<void> {
-    if (this.gcScheduler) {
-      this.gcScheduler.stop();
-    }
-    await this.sharedClientState.shutdown();
+    this.gcScheduler?.stop();
+    this.sharedClientState.shutdown();
     await this.persistence.shutdown();
   }
 }
@@ -485,9 +483,6 @@ export class OnlineComponentProvider {
 
   async terminate(): Promise<void> {
     await remoteStoreShutdown(this.remoteStore);
-
-    if (this.datastore) {
-      await this.datastore.terminate();
-    }
+    this.datastore?.terminate();
   }
 }


### PR DESCRIPTION
This PR makes a few tiny code improvements to the `terminate()` functions in `component_provider.ts`:

1. Simplify some `if` blocks checking for and object being null with more concise null chaining (i.e. the `?.` operator).
2. Remove `await` from function calls that simply return `void`, which make the `await` superfluous and potentially confusing.
3. Explicitly call `indexBackfillerScheduler?.stop()`, just like how `gcScheduler?.stop()` is called. This doesn't really affect anything because the scheduled job is cancelled by virtue of the AsyncQueue being shut down, but it's probably best not to rely on that implementation detail of the scheduler.