### PR TITLE
Firestore: stop the periodically-scheduled index backfill after Firestore is terminated

### DIFF
--- a/.changeset/odd-grapes-compete.md
+++ b/.changeset/odd-grapes-compete.md
@@ -1,0 +1,6 @@
+---
+'firebase': patch
+'@firebase/firestore': patch
+---
+
+Stop the periodic "index backfill" task from running after the Firestore instance is terminated

--- a/packages/firestore/src/core/component_provider.ts
+++ b/packages/firestore/src/core/component_provider.ts
@@ -167,6 +167,7 @@ export class MemoryOfflineComponentProvider
 
   async terminate(): Promise<void> {
     this.gcScheduler?.stop();
+    this.indexBackfillerScheduler?.stop();
     this.sharedClientState.shutdown();
     await this.persistence.shutdown();
   }


### PR DESCRIPTION
In `component_provider.ts` the `OfflineComponentProvider` defines a `terminate()` function that is supposed to shut down all of the components. This `terminate()` method correctly stops the "gcScheduler" but omits stopping "indexBackfillerScheduler". As a result of this apparent oversight, even after calling `terminate(db)` on a Firestore instance, the periodic index backfill continues to run every 60 seconds, forever. With the simple one-line fix in this PR, the periodically-scheduled index backfill task is stopped in `terminate()`, causing the backfiller to expectedly no longer run after the Firestore instance is terminated.