### PR TITLE
Firestore: firestore_client.ts: async getConfiguration() -> get configuration()

### DIFF
--- a/packages/firestore/src/core/firestore_client.ts
+++ b/packages/firestore/src/core/firestore_client.ts
@@ -254,10 +254,9 @@ export async function setOnlineComponentProvider(
   const offlineComponentProvider = await ensureOfflineComponents(client);
 
   logDebug(LOG_TAG, 'Initializing OnlineComponentProvider');
-  const configuration = await client.configuration;
   await onlineComponentProvider.initialize(
     offlineComponentProvider,
-    configuration
+    client.configuration
   );
   // The CredentialChangeListener of the online component provider takes
   // precedence over the offline component provider.

--- a/packages/firestore/src/core/firestore_client.ts
+++ b/packages/firestore/src/core/firestore_client.ts
@@ -150,7 +150,7 @@ export class FirestoreClient {
     });
   }
 
-  async getConfiguration(): Promise<ComponentConfiguration> {
+  get configuration(): ComponentConfiguration {
     return {
       asyncQueue: this.asyncQueue,
       databaseInfo: this.databaseInfo,
@@ -222,7 +222,7 @@ export async function setOfflineComponentProvider(
   client.asyncQueue.verifyOperationInProgress();
 
   logDebug(LOG_TAG, 'Initializing OfflineComponentProvider');
-  const configuration = await client.getConfiguration();
+  const configuration = client.configuration;
   await offlineComponentProvider.initialize(configuration);
 
   let currentUser = configuration.initialUser;
@@ -254,7 +254,7 @@ export async function setOnlineComponentProvider(
   const offlineComponentProvider = await ensureOfflineComponents(client);
 
   logDebug(LOG_TAG, 'Initializing OnlineComponentProvider');
-  const configuration = await client.getConfiguration();
+  const configuration = await client.configuration;
   await onlineComponentProvider.initialize(
     offlineComponentProvider,
     configuration


### PR DESCRIPTION
This is a minor implementation detail change in Firestore where a method was unnecessarily declared as `async` and was change to a simple property access. This has little (if any) performance improvement but makes the code a bit clearer for future readers. No functionality was changed.