### PR TITLE
Firestore: local_serializer.ts: change toDbIndexState() argument from user:User to uid:string

### DIFF
--- a/packages/firestore/src/local/indexeddb_index_manager.ts
+++ b/packages/firestore/src/local/indexeddb_index_manager.ts
@@ -120,7 +120,7 @@ export class IndexedDbIndexManager implements IndexManager {
    */
   private collectionParentsCache = new MemoryCollectionParentIndex();
 
-  private uid: string;
+  private readonly uid: string;
 
   /**
    * Maps from a target to its equivalent list of sub-targets. Each sub-target
@@ -131,7 +131,7 @@ export class IndexedDbIndexManager implements IndexManager {
     (l, r) => targetEquals(l, r)
   );
 
-  constructor(private user: User, private readonly databaseId: DatabaseId) {
+  constructor(user: User, private readonly databaseId: DatabaseId) {
     this.uid = user.uid || '';
   }
 
@@ -210,7 +210,7 @@ export class IndexedDbIndexManager implements IndexManager {
         states.put(
           toDbIndexState(
             indexId,
-            this.user,
+            this.uid,
             index.indexState.sequenceNumber,
             index.indexState.offset
           )
@@ -754,7 +754,7 @@ export class IndexedDbIndexManager implements IndexManager {
             states.put(
               toDbIndexState(
                 config.indexId!,
-                this.user,
+                this.uid,
                 nextSequenceNumber,
                 offset
               )

--- a/packages/firestore/src/local/local_serializer.ts
+++ b/packages/firestore/src/local/local_serializer.ts
@@ -476,13 +476,13 @@ export function fromDbIndexConfiguration(
 
 export function toDbIndexState(
   indexId: number,
-  user: User,
+  uid: string,
   sequenceNumber: number,
   offset: IndexOffset
 ): DbIndexState {
   return {
     indexId,
-    uid: user.uid || '',
+    uid,
     sequenceNumber,
     readTime: toDbTimestamp(offset.readTime),
     documentKey: encodeResourcePath(offset.documentKey.path),

--- a/packages/firestore/src/local/local_serializer.ts
+++ b/packages/firestore/src/local/local_serializer.ts
@@ -16,7 +16,6 @@
  */
 
 import { Timestamp } from '../api/timestamp';
-import { User } from '../auth/user';
 import { BundleMetadata, NamedQuery } from '../core/bundle';
 import { LimitType, Query, queryWithLimit } from '../core/query';
 import { SnapshotVersion } from '../core/snapshot_version';

--- a/packages/firestore/test/unit/local/local_serializer.test.ts
+++ b/packages/firestore/test/unit/local/local_serializer.test.ts
@@ -17,7 +17,6 @@
 
 import { expect } from 'chai';
 
-import { User } from '../../../src/auth/user';
 import { DatabaseId } from '../../../src/core/database_info';
 import { encodeResourcePath } from '../../../src/local/encoded_resource_path';
 import { DbMutationBatch } from '../../../src/local/indexeddb_schema';
@@ -258,7 +257,7 @@ describe('Local Serializer', () => {
 
     const dbIndexState = toDbIndexState(
       /* indexId= */ 1,
-      User.UNAUTHENTICATED,
+      /* uid= */ '',
       /* sequenceNumber= */ 2,
       expected
     );


### PR DESCRIPTION
This PR makes a tiny change to an internal function named `toDbIndexState()`. Formerly, this function had a `User` argument, of which only the `uid` property was used. If the given user was unauthenticated, then the empty string was used instead. This, however, is an implementation detail of the single call site which uses an empty string as the "uid" of an unauthenticated user.

To avoid this implementation detail bleeding into the `toDbIndexState()` function, this PR changes the argument from a `User` to simply a `string`, whose value is the "uid" to use. The caller, then is responsible for mapping the unauthenticated user to the correct string, keeping that implementation detail in one place.

This PR does not actually change any functionality, but merely cleans up the code a bit.