### PR TITLE
Firestore: Add support for MOCK_PERSISTENCE_MEMORY_DB env var in tests

### DIFF
--- a/packages/firestore/test/unit/local/indexeddb_persistence.test.ts
+++ b/packages/firestore/test/unit/local/indexeddb_persistence.test.ts
@@ -264,6 +264,19 @@ describe('IndexedDbSchema: createOrUpgradeDb', () => {
     return;
   }
 
+  if (
+    typeof process !== 'undefined' &&
+    process.env.MOCK_PERSISTENCE_MEMORY_DB === 'YES'
+  ) {
+    console.warn(
+      'IndexedDB is configured to use an in-memory database. ' +
+        'Skipping createOrUpgradeDb() tests because they require the ability ' +
+        'to close and re-open a database, which an in-memory database does ' +
+        'not support (the re-opened database will be unexpectedly empty).'
+    );
+    return;
+  }
+
   beforeEach(() => SimpleDb.delete(INDEXEDDB_TEST_DATABASE_NAME));
 
   after(() => SimpleDb.delete(INDEXEDDB_TEST_DATABASE_NAME));

--- a/packages/firestore/test/util/node_persistence.ts
+++ b/packages/firestore/test/util/node_persistence.ts
@@ -37,11 +37,25 @@ const globalAny = global as any;
 const dbDir = fs.mkdtempSync(os.tmpdir() + '/firestore_tests');
 
 if (process.env.USE_MOCK_PERSISTENCE === 'YES') {
-  registerIndexedDBShim(null, {
-    checkOrigin: false,
-    databaseBasePath: dbDir,
-    deleteDatabaseFiles: true
-  });
+  const indexedDbShimOptions: Record<string, unknown> = {
+    checkOrigin: false
+  };
+
+  // Mocking persistence using an in-memory database, rather than the default
+  // on-disk database, can reduce test execution time by orders of magnitude;
+  // however, some tests have erratic behavior when using an in-memory database
+  // because they rely on the database persisting between opens (e.g. tests for
+  // upgrading the database schema). Therefore, setting the
+  // `MOCK_PERSISTENCE_MEMORY_DB` environment variable to `YES` is only
+  // recommended during local build/test development cycles.
+  if (process.env.MOCK_PERSISTENCE_MEMORY_DB === 'YES') {
+    indexedDbShimOptions.memoryDatabase = ':memory:';
+  } else {
+    indexedDbShimOptions.databaseBasePath = dbDir;
+    indexedDbShimOptions.deleteDatabaseFiles = true;
+  }
+
+  registerIndexedDBShim(null, indexedDbShimOptions);
 
   // 'indexeddbshim' installs IndexedDB onto `globalAny`, which means we don't
   // have to register it ourselves.


### PR DESCRIPTION
Firestore's unit and integration tests can mock IndexedDb when running in a node.js runtime (compared to running in the browser). This mocking is done using a sqlite database that is stored on disk, and deleted after each time. This PR adds the ability to, instead, use an _in-memory_ sqlite database for mocking IndexedDb, which can be significantly faster than the on-disk equivalent.

To use an in-memory database, set the `MOCK_PERSISTENCE_MEMORY_DB` environment variable to `YES`.

Note that some tests, such as those that close and re-open an indexeddb database to test for schema upgrades, will fail when using an in-memory database because the database's data is lost when the database is closed. As a result, these tests try to skip themselves if they detect an in-memory mock database being used. But since this isn't reliable, it is recommended only to set `MOCK_PERSISTENCE_MEMORY_DB=YES` for local development in the build/test cycle. Specifically, continuous integration should continue to use the on-disk mock database for maximal compatibility with indexeddb in the browser.