### PR TITLE
Firestore: local_store_indexeddb.test.ts: fix spurious errors on test cleanup

### DIFF
--- a/packages/firestore/test/unit/local/local_store_indexeddb.test.ts
+++ b/packages/firestore/test/unit/local/local_store_indexeddb.test.ts
@@ -248,7 +248,7 @@ describe('LocalStore w/ IndexedDB Persistence (Non generic)', () => {
   });
 
   afterEach(async () => {
-    await persistence.shutdown();
+    await persistence?.shutdown();
     await persistenceHelpers.clearTestPersistence();
   });
 


### PR DESCRIPTION
Fix some spurious test failures that get reported if some of the "before" actions of a test fail. Specifically, calling

```
persistence.shutdown()
```

would throw a

```
Uncaught TypeError: Cannot read properties of undefined
```

error if the "before" step that initialized the `persistence` variable failed before setting it.

Although this isn't a problem, it adds noise to a test failure that may already be difficult enough to debug.

The fix is simple: just _conditionally_ call the method only if the object is defined; that is, change it to

```
persistence?.shutdown()
```