### PR TITLE
Prepare user for redirect with optional resolver

### DIFF
--- a/packages/auth/src/platform_browser/strategies/redirect.ts
+++ b/packages/auth/src/platform_browser/strategies/redirect.ts
@@ -169,7 +169,7 @@ export async function _reauthenticateWithRedirect(
   const resolverInternal = _withDefaultResolver(userInternal.auth, resolver);
   await _setPendingRedirectStatus(resolverInternal, userInternal.auth);
 
-  const eventId = await prepareUserForRedirect(userInternal);
+  const eventId = await prepareUserForRedirect(userInternal, resolver);
   return resolverInternal._openRedirect(
     userInternal.auth,
     provider,
@@ -231,7 +231,7 @@ export async function _linkWithRedirect(
   await _assertLinkedStatus(false, userInternal, provider.providerId);
   await _setPendingRedirectStatus(resolverInternal, userInternal.auth);
 
-  const eventId = await prepareUserForRedirect(userInternal);
+  const eventId = await prepareUserForRedirect(userInternal, resolver);
   return resolverInternal._openRedirect(
     userInternal.auth,
     provider,
@@ -307,10 +307,10 @@ export async function _getRedirectResult(
   return result;
 }
 
-async function prepareUserForRedirect(user: UserInternal): Promise<string> {
+async function prepareUserForRedirect(user: UserInternal, resolver?: PopupRedirectResolver): Promise<string> {
   const eventId = _generateEventId(`${user.uid}:::`);
   user._redirectEventId = eventId;
-  await user.auth._setRedirectUser(user);
+  await user.auth._setRedirectUser(user, resolver);
   await user.auth._persistUserIfCurrent(user);
   return eventId;
 }


### PR DESCRIPTION
### Discussion

linkWithRedirect does not work with auth emulator #4275

```
FirebaseError: Firebase: Error (auth/argument-error).
    at createErrorInternal (index-dd468b12.js:615:41)
    at _assert (index-dd468b12.js:621:15)
    at AuthImpl.getOrInitRedirectPersistenceManager (index-dd468b12.js:2970:13)
    at AuthImpl._setRedirectUser (index-dd468b12.js:2961:44)
    at prepareUserForRedirect (index-dd468b12.js:9486:21)
    at _linkWithRedirect (index-dd468b12.js:9424:27)
    at async linkWithApple (AppleLink.tsx:20:7)
```
