### PR TITLE
Firestore: Remove obsolete special case from tests when verifying "missing index" error message in non-default DB

### DIFF
--- a/packages/firestore/test/integration/api/aggregation.test.ts
+++ b/packages/firestore/test/integration/api/aggregation.test.ts
@@ -159,17 +159,9 @@ apiDescribe('Count queries', persistence => {
           where('key1', '==', 42),
           where('key2', '<', 42)
         );
-        // TODO(b/316359394) Remove the special logic for non-default databases
-        // once cl/582465034 is rolled out to production.
-        if (coll.firestore._databaseId.isDefaultDatabase) {
-          await expect(
-            getCountFromServer(query_)
-          ).to.be.eventually.rejectedWith(
-            /index.*https:\/\/console\.firebase\.google\.com/
-          );
-        } else {
-          await expect(getCountFromServer(query_)).to.be.eventually.rejected;
-        }
+        await expect(getCountFromServer(query_)).to.be.eventually.rejectedWith(
+          /index.*https:\/\/console\.firebase\.google\.com/
+        );
       });
     }
   );
@@ -371,23 +363,13 @@ apiDescribe('Aggregation queries', persistence => {
           where('key1', '==', 42),
           where('key2', '<', 42)
         );
-        // TODO(b/316359394) Remove the special logic for non-default databases
-        // once cl/582465034 is rolled out to production.
-        if (coll.firestore._databaseId.isDefaultDatabase) {
-          await expect(
-            getAggregateFromServer(query_, {
-              count: count()
-            })
-          ).to.be.eventually.rejectedWith(
-            /index.*https:\/\/console\.firebase\.google\.com/
-          );
-        } else {
-          await expect(
-            getAggregateFromServer(query_, {
-              count: count()
-            })
-          ).to.be.eventually.rejected;
-        }
+        await expect(
+          getAggregateFromServer(query_, {
+            count: count()
+          })
+        ).to.be.eventually.rejectedWith(
+          /index.*https:\/\/console\.firebase\.google\.com/
+        );
       });
     }
   );

--- a/packages/firestore/test/lite/integration.test.ts
+++ b/packages/firestore/test/lite/integration.test.ts
@@ -2451,15 +2451,9 @@ describe('Count queries', () => {
           where('key1', '==', 42),
           where('key2', '<', 42)
         );
-        // TODO(b/316359394) Remove the special logic for non-default databases
-        // once cl/582465034 is rolled out to production.
-        if (coll.firestore._databaseId.isDefaultDatabase) {
-          await expect(getCount(query_)).to.be.eventually.rejectedWith(
-            /index.*https:\/\/console\.firebase\.google\.com/
-          );
-        } else {
-          await expect(getCount(query_)).to.be.eventually.rejected;
-        }
+        await expect(getCount(query_)).to.be.eventually.rejectedWith(
+          /index.*https:\/\/console\.firebase\.google\.com/
+        );
       });
     }
   );
@@ -2760,23 +2754,13 @@ describe('Aggregate queries', () => {
           where('key1', '==', 42),
           where('key2', '<', 42)
         );
-        // TODO(b/316359394) Remove the special logic for non-default databases
-        // once cl/582465034 is rolled out to production.
-        if (coll.firestore._databaseId.isDefaultDatabase) {
-          await expect(
-            getAggregate(query_, {
-              myCount: count()
-            })
-          ).to.be.eventually.rejectedWith(
-            /index.*https:\/\/console\.firebase\.google\.com/
-          );
-        } else {
-          await expect(
-            getAggregate(query_, {
-              myCount: count()
-            })
-          ).to.be.eventually.rejected;
-        }
+        await expect(
+          getAggregate(query_, {
+            myCount: count()
+          })
+        ).to.be.eventually.rejectedWith(
+          /index.*https:\/\/console\.firebase\.google\.com/
+        );
       });
     }
   );


### PR DESCRIPTION
This PR removes a special case from the integration tests (#7874) that verifies the "missing index" error message returned from the server. Previously, a non-default database would result in a different, less descriptive error message; however, the backend was updated to use the same, descriptive error message for both default and non-default databases. The tests, therefore, should have to the special case removed to increase the coverage of the tests.

Googlers see b/316359394 for more information.