### PR TITLE
Firestore: Choose DEFAULT_RELATIVE_INDEX_READ_COST_PER_DOCUMENT value based on the browser, rather than hardcoding 8

### DIFF
--- a/.changeset/witty-comics-rule.md
+++ b/.changeset/witty-comics-rule.md
@@ -1,0 +1,6 @@
+---
+'firebase': patch
+'@firebase/firestore': patch
+---
+
+Tweak the automatic index creation parameters to use more optimal values for the platform/browser detected at runtime.

--- a/packages/firestore/src/local/query_engine.ts
+++ b/packages/firestore/src/local/query_engine.ts
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+import { getUA, isSafari } from '@firebase/util';
+
 import {
   LimitType,
   newQueryComparator,
@@ -47,6 +49,7 @@ import { LocalDocumentsView } from './local_documents_view';
 import { PersistencePromise } from './persistence_promise';
 import { PersistenceTransaction } from './persistence_transaction';
 import { QueryContext } from './query_context';
+import { SimpleDb } from './simple_db';
 
 const DEFAULT_INDEX_AUTO_CREATION_MIN_COLLECTION_SIZE = 100;
 
@@ -55,10 +58,19 @@ const DEFAULT_INDEX_AUTO_CREATION_MIN_COLLECTION_SIZE = 100;
  * (([index, docKey] + [docKey, docContent]) per document in the result set)
  * / ([docKey, docContent] per documents in full collection scan) coming from
  * experiment [enter PR experiment URL here].
- * TODO(b/299284287) Choose a value appropriate for the browser/OS combination,
- *  as determined by more data points from running the experiment.
  */
-const DEFAULT_RELATIVE_INDEX_READ_COST_PER_DOCUMENT = 8;
+function getDefaultRelativeIndexReadCostPerDocument(): number {
+  // These values were derived from an experiment where several members of the
+  // Firestore SDK team ran a performance test in various environments.
+  // Googlers can see b/299284287 for details.
+  if (isSafari()) {
+    return 8;
+  } else if (SimpleDb.getAndroidVersion(getUA()) > 0) {
+    return 6;
+  } else {
+    return 4;
+  }
+}
 
 /**
  * The Firestore query engine.
@@ -113,7 +125,7 @@ export class QueryEngine {
     DEFAULT_INDEX_AUTO_CREATION_MIN_COLLECTION_SIZE;
 
   relativeIndexReadCostPerDocument =
-    DEFAULT_RELATIVE_INDEX_READ_COST_PER_DOCUMENT;
+    getDefaultRelativeIndexReadCostPerDocument();
 
   /** Sets the document view to query against. */
   initialize(


### PR DESCRIPTION
A previous PR, https://github.com/firebase/firebase-js-sdk/pull/7608, hardcoded the value of `DEFAULT_RELATIVE_INDEX_READ_COST_PER_DOCUMENT` to 8. At the time, this was the "worst case" value, but penalized many platform/browser combinations that would experience performance benefits from a lower value.

Since then, an experiment was performed to calculate a more reasonable value. These optimal values were:
1. 8 for Safari
2. 6 for Android
3. 4 for everything else (e.g. desktop browsers)

This PR changes the hardcoded value of 8 to one of the values above, depending on the runtime environment.