### PR TITLE
feat: add idb shortcuts

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -41,7 +41,7 @@
     "@firebase/util": "1.9.3",
     "@firebase/logger": "0.4.0",
     "@firebase/component": "0.6.4",
-    "idb": "7.1.1",
+    "idb": "8.0.0",
     "tslib": "^2.1.0"
   },
   "license": "Apache-2.0",

--- a/packages/app/src/indexeddb.ts
+++ b/packages/app/src/indexeddb.ts
@@ -69,10 +69,7 @@ export async function readHeartbeatsFromIndexedDB(
 ): Promise<HeartbeatsInIndexedDB | undefined> {
   try {
     const db = await getDbPromise();
-    const result = await db
-      .transaction(STORE_NAME)
-      .objectStore(STORE_NAME)
-      .get(computeKey(app));
+    const result = await db.get(STORE_NAME, computeKey(app));
     return result;
   } catch (e) {
     if (e instanceof FirebaseError) {
@@ -92,10 +89,7 @@ export async function writeHeartbeatsToIndexedDB(
 ): Promise<void> {
   try {
     const db = await getDbPromise();
-    const tx = db.transaction(STORE_NAME, 'readwrite');
-    const objectStore = tx.objectStore(STORE_NAME);
-    await objectStore.put(heartbeatObject, computeKey(app));
-    await tx.done;
+    await db.put(STORE_NAME, heartbeatObject, computeKey(app));
   } catch (e) {
     if (e instanceof FirebaseError) {
       logger.warn(e.message);

--- a/packages/installations/package.json
+++ b/packages/installations/package.json
@@ -65,7 +65,7 @@
   "dependencies": {
     "@firebase/util": "1.9.3",
     "@firebase/component": "0.6.4",
-    "idb": "7.1.1",
+    "idb": "8.0.0",
     "tslib": "^2.1.0"
   }
 }

--- a/packages/installations/src/helpers/idb-manager.ts
+++ b/packages/installations/src/helpers/idb-manager.ts
@@ -59,9 +59,7 @@ export async function get(
   const key = getKey(appConfig);
   const db = await getDbPromise();
   return db
-    .transaction(OBJECT_STORE_NAME)
-    .objectStore(OBJECT_STORE_NAME)
-    .get(key) as Promise<InstallationEntry>;
+    .get(OBJECT_STORE_NAME, key) as Promise<InstallationEntry>;
 }
 
 /** Assigns or overwrites the record for the given key with the given value. */
@@ -88,9 +86,7 @@ export async function set<ValueType extends InstallationEntry>(
 export async function remove(appConfig: AppConfig): Promise<void> {
   const key = getKey(appConfig);
   const db = await getDbPromise();
-  const tx = db.transaction(OBJECT_STORE_NAME, 'readwrite');
-  await tx.objectStore(OBJECT_STORE_NAME).delete(key);
-  await tx.done;
+  await db.delete(OBJECT_STORE_NAME, key);
 }
 
 /**
@@ -128,7 +124,5 @@ export async function update<ValueType extends InstallationEntry | undefined>(
 
 export async function clear(): Promise<void> {
   const db = await getDbPromise();
-  const tx = db.transaction(OBJECT_STORE_NAME, 'readwrite');
-  await tx.objectStore(OBJECT_STORE_NAME).clear();
-  await tx.done;
+  await db.clear(OBJECT_STORE_NAME);
 }

--- a/packages/messaging/package.json
+++ b/packages/messaging/package.json
@@ -57,7 +57,7 @@
     "@firebase/messaging-interop-types": "0.2.0",
     "@firebase/util": "1.9.3",
     "@firebase/component": "0.6.4",
-    "idb": "7.1.1",
+    "idb": "8.0.0",
     "tslib": "^2.1.0"
   },
   "devDependencies": {

--- a/packages/messaging/src/helpers/migrate-old-database.test.ts
+++ b/packages/messaging/src/helpers/migrate-old-database.test.ts
@@ -194,9 +194,7 @@ async function put(version: number, value: object): Promise<void> {
   });
 
   try {
-    const tx = db.transaction('fcm_token_object_Store', 'readwrite');
-    await tx.objectStore('fcm_token_object_Store').put(value);
-    await tx.done;
+    await db.put('fcm_token_object_Store', value);
   } finally {
     db.close();
   }

--- a/packages/messaging/src/internals/idb-manager.ts
+++ b/packages/messaging/src/internals/idb-manager.ts
@@ -59,9 +59,7 @@ export async function dbGet(
   const key = getKey(firebaseDependencies);
   const db = await getDbPromise();
   const tokenDetails = (await db
-    .transaction(OBJECT_STORE_NAME)
-    .objectStore(OBJECT_STORE_NAME)
-    .get(key)) as TokenDetails;
+    .get(OBJECT_STORE_NAME, key)) as TokenDetails;
 
   if (tokenDetails) {
     return tokenDetails;
@@ -84,9 +82,7 @@ export async function dbSet(
 ): Promise<TokenDetails> {
   const key = getKey(firebaseDependencies);
   const db = await getDbPromise();
-  const tx = db.transaction(OBJECT_STORE_NAME, 'readwrite');
-  await tx.objectStore(OBJECT_STORE_NAME).put(tokenDetails, key);
-  await tx.done;
+  await db.put(OBJECT_STORE_NAME, tokenDetails, key);
   return tokenDetails;
 }
 
@@ -96,9 +92,7 @@ export async function dbRemove(
 ): Promise<void> {
   const key = getKey(firebaseDependencies);
   const db = await getDbPromise();
-  const tx = db.transaction(OBJECT_STORE_NAME, 'readwrite');
-  await tx.objectStore(OBJECT_STORE_NAME).delete(key);
-  await tx.done;
+  await db.delete(OBJECT_STORE_NAME, key);
 }
 
 /** Deletes the DB. Useful for tests. */

--- a/yarn.lock
+++ b/yarn.lock
@@ -9450,10 +9450,10 @@ iconv-lite@0.6.3, iconv-lite@^0.6.2:
   dependencies:
     safer-buffer ">= 2.1.2 < 3.0.0"
 
-idb@7.1.1:
-  version "7.1.1"
-  resolved "https://registry.npmjs.org/idb/-/idb-7.1.1.tgz"
-  integrity sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ==
+idb@8.0.0:
+  version "8.0.0"
+  resolved "https://registry.npmjs.org/idb/-/idb-8.0.0.tgz#33d7ed894ed36e23bcb542fb701ad579bfaad41f"
+  integrity sha512-l//qvlAKGmQO31Qn7xdzagVPPaHTxXx199MhrAFuVBTPqydcPYBWjkrbv4Y0ktB+GmWOiwHl237UUOrLmQxLvw==
 
 ieee754@^1.1.13, ieee754@^1.2.1:
   version "1.2.1"


### PR DESCRIPTION
The primary change is an update to the **idb** package from version `7.1.1` to `8.0.0`.


We have refactored the storeObject transaction in code to simplify the process of getting/putting/setting/removing an object from the store. Previously, the code was written as follows:

```js
const db = await getDbPromise();
const result = await db
 .transaction(STORE_NAME)
 .objectStore(STORE_NAME)
 .get(computeKey(app));
```

We have updated this to a more streamlined approach:

```js
const db = await getDbPromise();
const result = await db.get(STORE_NAME, computeKey(app));
```

This change simplifies the code and makes it easier to read and maintain.

Please review these changes and let me know if you have any feedback or concerns.