### PR TITLE
Add browser iframe host to config

### DIFF
--- a/packages/auth/src/core/auth/auth_impl.test.ts
+++ b/packages/auth/src/core/auth/auth_impl.test.ts
@@ -76,6 +76,7 @@ describe('core/auth/auth_impl', () => {
         apiHost: DefaultConfig.API_HOST,
         apiScheme: DefaultConfig.API_SCHEME,
         tokenApiHost: DefaultConfig.TOKEN_API_HOST,
+        browserIframeHost: DefaultConfig.BROWSER_IFRAME_HOST,
         clientPlatform: ClientPlatform.BROWSER,
         sdkClientVersion: 'v'
       }
@@ -597,6 +598,7 @@ describe('core/auth/auth_impl', () => {
           apiHost: DefaultConfig.API_HOST,
           apiScheme: DefaultConfig.API_SCHEME,
           tokenApiHost: DefaultConfig.TOKEN_API_HOST,
+          browserIframeHost: DefaultConfig.BROWSER_IFRAME_HOST,
           clientPlatform: ClientPlatform.BROWSER,
           sdkClientVersion: 'v'
         }

--- a/packages/auth/src/core/auth/auth_impl.ts
+++ b/packages/auth/src/core/auth/auth_impl.ts
@@ -82,6 +82,7 @@ interface AsyncAction {
 export const enum DefaultConfig {
   TOKEN_API_HOST = 'securetoken.googleapis.com',
   API_HOST = 'identitytoolkit.googleapis.com',
+  BROWSER_IFRAME_HOST = 'apis.google.com',
   API_SCHEME = 'https'
 }
 

--- a/packages/auth/src/core/auth/register.ts
+++ b/packages/auth/src/core/auth/register.ts
@@ -79,6 +79,7 @@ export function registerAuth(clientPlatform: ClientPlatform): void {
           clientPlatform,
           apiHost: DefaultConfig.API_HOST,
           tokenApiHost: DefaultConfig.TOKEN_API_HOST,
+          browserIframeHost: DefaultConfig.BROWSER_IFRAME_HOST,
           apiScheme: DefaultConfig.API_SCHEME,
           sdkClientVersion: _getClientVersion(clientPlatform)
         };

--- a/packages/auth/src/model/public_types.ts
+++ b/packages/auth/src/model/public_types.ts
@@ -58,6 +58,10 @@ export interface Config {
    */
   tokenApiHost: string;
   /**
+   * The host at witch the browser iframe code is hosted.
+   */
+  browserIframeHost: string;
+  /**
    * The SDK Client Version.
    */
   sdkClientVersion: string;

--- a/packages/auth/src/platform_browser/auth.test.ts
+++ b/packages/auth/src/platform_browser/auth.test.ts
@@ -80,6 +80,7 @@ describe('core/auth/auth_impl', () => {
         apiHost: DefaultConfig.API_HOST,
         apiScheme: DefaultConfig.API_SCHEME,
         tokenApiHost: DefaultConfig.TOKEN_API_HOST,
+        browserIframeHost: DefaultConfig.BROWSER_IFRAME_HOST,
         clientPlatform: ClientPlatform.BROWSER,
         sdkClientVersion: 'v'
       }
@@ -152,6 +153,7 @@ describe('core/auth/initializeAuth', () => {
           apiHost: DefaultConfig.API_HOST,
           apiScheme: DefaultConfig.API_SCHEME,
           tokenApiHost: DefaultConfig.TOKEN_API_HOST,
+          browserIframeHost: DefaultConfig.BROWSER_IFRAME_HOST,
           authDomain,
           clientPlatform: ClientPlatform.BROWSER,
           sdkClientVersion: _getClientVersion(ClientPlatform.BROWSER)
@@ -391,6 +393,7 @@ describe('core/auth/initializeAuth', () => {
             apiHost: DefaultConfig.API_HOST,
             apiScheme: DefaultConfig.API_SCHEME,
             tokenApiHost: DefaultConfig.TOKEN_API_HOST,
+            browserIframeHost: DefaultConfig.BROWSER_IFRAME_HOST,
             authDomain: FAKE_APP.options.authDomain,
             clientPlatform: ClientPlatform.BROWSER,
             sdkClientVersion: _getClientVersion(ClientPlatform.BROWSER)

--- a/packages/auth/src/platform_browser/iframe/gapi.ts
+++ b/packages/auth/src/platform_browser/iframe/gapi.ts
@@ -104,7 +104,9 @@ function loadGapi(auth: AuthInternal): Promise<gapi.iframes.Context> {
       };
       // Load GApi loader.
       return js
-        ._loadJS(`https://apis.google.com/js/api.js?onload=${cbName}`)
+        ._loadJS(
+          `https://${auth.config.browserIframeHost}/js/api.js?onload=${cbName}`
+        )
         .catch(e => reject(e));
     }
   }).catch(error => {


### PR DESCRIPTION
This pull request reallocates the browser iframe host into the configuration. Currently, the host is hardcoded, making any attempt to modify the domain impossible. The necessity for such flexibility arises when, for instance, encountering firewall restrictions that impede the default domain.

By incorporating this domain into the configuration, developers gain the ability to customize it, facilitating scenarios where the default domain faces access challenges. This modification proves especially valuable when a custom domain is employed to act as a proxy, redirecting requests to apis.google.com. 