### PR TITLE
Firestore: Add "development" export to package.json/rolllup that leaves in assertion messages and skips minification

### DIFF
--- a/.changeset/shiny-beans-teach.md
+++ b/.changeset/shiny-beans-teach.md
@@ -1,0 +1,6 @@
+---
+'@firebase/firestore': minor
+'firebase': minor
+---
+
+Add a "development" export that skips stripping assertion messages and skips minification

--- a/packages/firestore/package.json
+++ b/packages/firestore/package.json
@@ -57,14 +57,32 @@
     ".": {
       "types": "./dist/index.d.ts",
       "node": {
-        "require": "./dist/index.node.cjs.js",
-        "import": "./dist/index.node.mjs"
+        "require": {
+          "production": "./dist/index.node.cjs.js",
+          "development": "./dist/index.node.debug.cjs.js"
+        },
+        "import": {
+          "production": "./dist/index.node.mjs",
+          "development": "./dist/index.node.debug.mjs"
+        }
       },
-      "react-native": "./dist/index.rn.js",
-      "esm5": "./dist/index.esm5.js",
+      "react-native": {
+        "production": "./dist/index.rn.js",
+        "development": "./dist/index.rn.debug.js"
+      },
+      "esm5": {
+        "production": "./dist/index.esm5.js",
+        "development": "./dist/index.esm5.debug.js"
+      },
       "browser": {
-        "require": "./dist/index.cjs.js",
-        "import": "./dist/index.esm2017.js"
+        "require": {
+          "production": "./dist/index.cjs.js",
+          "development": "./dist/index.cjs.debug.js"
+        },
+        "import": {
+          "production": "./dist/index.esm2017.js",
+          "development": "./dist/index.esm2017.debug.js"
+        }
       },
       "default": "./dist/index.esm2017.js"
     },

--- a/packages/firestore/rollup.config.js
+++ b/packages/firestore/rollup.config.js
@@ -32,7 +32,7 @@ import pkg from './package.json';
 const sourcemaps = require('rollup-plugin-sourcemaps');
 const util = require('./rollup.shared');
 
-const nodePlugins = function* (mode) {
+function* nodePlugins(mode) {
   if (mode !== 'production' && mode !== 'development') {
     throw new Error(
       `invalid mode specified to browserPlugins(): '${mode}' ` +
@@ -61,9 +61,9 @@ const nodePlugins = function* (mode) {
   yield replace({
     '__GRPC_VERSION__': grpcVersion
   });
-};
+}
 
-const browserPlugins = function* (mode) {
+function* browserPlugins(mode) {
   if (mode !== 'production' && mode !== 'development') {
     throw new Error(
       `invalid mode specified to browserPlugins(): '${mode}' ` +
@@ -94,7 +94,7 @@ const browserPlugins = function* (mode) {
   if (mode === 'production') {
     yield terser(util.manglePrivatePropertiesOptions);
   }
-};
+}
 
 const allBuilds = [
   // Intermediate Node ESM build without build target reporting


### PR DESCRIPTION
Add a "development" conditional export for Firestore (https://nodejs.org/api/packages.html#conditional-exports).

This new "development" export is the same as the existing non-development (a.k.a. "production") export except that it is _not_ minified and  does _not_ strip out the assertion messages. The "development" export can be useful when customers run into the generic "INTERNAL ASSERTION FAILED: Unexpected state" error message (e.g. https://github.com/firebase/firebase-js-sdk/issues/4451). Such customers can make debugging easier, especially when reporting issues on GitHub, by switching to the "development" export to get the full error message (instead of "Unexpected state") and non-minified stack trace.

To use the "development" export in a node.js application, specify `-C development` to `node` on the command line. Bundlers such as rollup and webpack have their own bespoke mechanisms for selecting a non-default bundle. For example, a rollup script might do something like this to select the "development" export:

```ts
import resolve from '@rollup/plugin-node-resolve';
...
export default {
  ...
  plugins: [
    resolve({ browser: true, exportConditions: ['development'] }),
    ...
  ]
};
```

(see https://www.npmjs.com/package/@rollup/plugin-node-resolve#exportconditions for details).