### PR TITLE
query_engine.ts: move CSI code into its own class

### DIFF
--- a/packages/firestore/src/local/query_engine.ts
+++ b/packages/firestore/src/local/query_engine.ts
@@ -113,19 +113,38 @@ function getDefaultRelativeIndexReadCostPerDocument(): number {
 export class QueryEngine {
   private localDocumentsView!: LocalDocumentsView;
   private indexManager!: IndexManager;
+  private fieldIndexPlugin!: QueryEngineFieldIndexPlugin;
   private initialized = false;
 
-  indexAutoCreationEnabled = false;
+  // TODO(CsiTreeShake) Remove this property once `QueryEngineFieldIndexPlugin`
+  //  is installed separately from the initialize() method.
+  get indexAutoCreationEnabled(): boolean {
+    return this.fieldIndexPlugin.indexAutoCreationEnabled;
+  }
 
-  /**
-   * SDK only decides whether it should create index when collection size is
-   * larger than this.
-   */
-  indexAutoCreationMinCollectionSize =
-    DEFAULT_INDEX_AUTO_CREATION_MIN_COLLECTION_SIZE;
+  set indexAutoCreationEnabled(value: boolean) {
+    this.fieldIndexPlugin.indexAutoCreationEnabled = value;
+  }
 
-  relativeIndexReadCostPerDocument =
-    getDefaultRelativeIndexReadCostPerDocument();
+  // TODO(CsiTreeShake) Remove this property once `QueryEngineFieldIndexPlugin`
+  //  is installed separately from the initialize() method.
+  get indexAutoCreationMinCollectionSize(): number {
+    return this.fieldIndexPlugin.indexAutoCreationMinCollectionSize;
+  }
+
+  set indexAutoCreationMinCollectionSize(value: number) {
+    this.fieldIndexPlugin.indexAutoCreationMinCollectionSize = value;
+  }
+
+  // TODO(CsiTreeShake) Remove this property once `QueryEngineFieldIndexPlugin`
+  //  is installed separately from the initialize() method.
+  get relativeIndexReadCostPerDocument(): number {
+    return this.fieldIndexPlugin.relativeIndexReadCostPerDocument;
+  }
+
+  set relativeIndexReadCostPerDocument(value: number) {
+    this.fieldIndexPlugin.relativeIndexReadCostPerDocument = value;
+  }
 
   /** Sets the document view to query against. */
   initialize(
@@ -134,6 +153,12 @@ export class QueryEngine {
   ): void {
     this.localDocumentsView = localDocuments;
     this.indexManager = indexManager;
+    // TODO(CsiTreeShake) Provide a means for the `QueryEngineFieldIndexPlugin`
+    //  to be installed separately from this initialize() method.
+    this.fieldIndexPlugin = new QueryEngineFieldIndexPlugin(
+      indexManager,
+      localDocuments
+    );
     this.initialized = true;
   }
 
@@ -190,6 +215,215 @@ export class QueryEngine {
       .next(() => queryResult.result!);
   }
 
+  private createCacheIndexes(
+    transaction: PersistenceTransaction,
+    query: Query,
+    context: QueryContext,
+    resultSize: number
+  ): PersistencePromise<void> {
+    return this.fieldIndexPlugin.createCacheIndexes(
+      transaction,
+      query,
+      context,
+      resultSize
+    );
+  }
+
+  private performQueryUsingIndex(
+    transaction: PersistenceTransaction,
+    query: Query
+  ): PersistencePromise<DocumentMap | null> {
+    return this.fieldIndexPlugin?.performQueryUsingIndex(transaction, query);
+  }
+
+  /**
+   * Performs a query based on the target's persisted query mapping. Returns
+   * `null` if the mapping is not available or cannot be used.
+   */
+  private performQueryUsingRemoteKeys(
+    transaction: PersistenceTransaction,
+    query: Query,
+    remoteKeys: DocumentKeySet,
+    lastLimboFreeSnapshotVersion: SnapshotVersion
+  ): PersistencePromise<DocumentMap | null> {
+    if (queryMatchesAllDocuments(query)) {
+      // Queries that match all documents don't benefit from using
+      // key-based lookups. It is more efficient to scan all documents in a
+      // collection, rather than to perform individual lookups.
+      return PersistencePromise.resolve<DocumentMap | null>(null);
+    }
+
+    // Queries that have never seen a snapshot without limbo free documents
+    // should also be run as a full collection scan.
+    if (lastLimboFreeSnapshotVersion.isEqual(SnapshotVersion.min())) {
+      return PersistencePromise.resolve<DocumentMap | null>(null);
+    }
+
+    return this.localDocumentsView!.getDocuments(transaction, remoteKeys).next(
+      documents => {
+        const previousResults = applyQuery(query, documents);
+
+        if (
+          needsRefill(
+            query,
+            previousResults,
+            remoteKeys,
+            lastLimboFreeSnapshotVersion
+          )
+        ) {
+          return PersistencePromise.resolve<DocumentMap | null>(null);
+        }
+
+        if (getLogLevel() <= LogLevel.DEBUG) {
+          logDebug(
+            'QueryEngine',
+            'Re-using previous result from %s to execute query: %s',
+            lastLimboFreeSnapshotVersion.toString(),
+            stringifyQuery(query)
+          );
+        }
+
+        // Retrieve all results for documents that were updated since the last
+        // limbo-document free remote snapshot.
+        return appendRemainingResults(
+          transaction,
+          this.localDocumentsView,
+          previousResults,
+          query,
+          newIndexOffsetSuccessorFromReadTime(
+            lastLimboFreeSnapshotVersion,
+            INITIAL_LARGEST_BATCH_ID
+          )
+        ).next<DocumentMap | null>(results => results);
+      }
+    );
+  }
+
+  private executeFullCollectionScan(
+    transaction: PersistenceTransaction,
+    query: Query,
+    context: QueryContext
+  ): PersistencePromise<DocumentMap> {
+    if (getLogLevel() <= LogLevel.DEBUG) {
+      logDebug(
+        'QueryEngine',
+        'Using full collection scan to execute query:',
+        stringifyQuery(query)
+      );
+    }
+
+    return this.localDocumentsView!.getDocumentsMatchingQuery(
+      transaction,
+      query,
+      IndexOffset.min(),
+      context
+    );
+  }
+}
+
+export class QueryEngineFieldIndexPlugin {
+  indexAutoCreationEnabled = false;
+
+  /**
+   * SDK only decides whether it should create index when collection size is
+   * larger than this.
+   */
+  indexAutoCreationMinCollectionSize =
+    DEFAULT_INDEX_AUTO_CREATION_MIN_COLLECTION_SIZE;
+
+  relativeIndexReadCostPerDocument =
+    getDefaultRelativeIndexReadCostPerDocument();
+
+  constructor(
+    private readonly indexManager: IndexManager,
+    private readonly localDocumentsView: LocalDocumentsView
+  ) {}
+
+  /**
+   * Performs an indexed query that evaluates the query based on a collection's
+   * persisted index values. Returns `null` if an index is not available.
+   */
+  performQueryUsingIndex(
+    transaction: PersistenceTransaction,
+    query: Query
+  ): PersistencePromise<DocumentMap | null> {
+    if (queryMatchesAllDocuments(query)) {
+      // Queries that match all documents don't benefit from using
+      // key-based lookups. It is more efficient to scan all documents in a
+      // collection, rather than to perform individual lookups.
+      return PersistencePromise.resolve<DocumentMap | null>(null);
+    }
+
+    let target = queryToTarget(query);
+    return this.indexManager
+      .getIndexType(transaction, target)
+      .next(indexType => {
+        if (indexType === IndexType.NONE) {
+          // The target cannot be served from any index.
+          return null;
+        }
+
+        if (query.limit !== null && indexType === IndexType.PARTIAL) {
+          // We cannot apply a limit for targets that are served using a partial
+          // index. If a partial index will be used to serve the target, the
+          // query may return a superset of documents that match the target
+          // (e.g. if the index doesn't include all the target's filters), or
+          // may return the correct set of documents in the wrong order (e.g. if
+          // the index doesn't include a segment for one of the orderBys).
+          // Therefore, a limit should not be applied in such cases.
+          query = queryWithLimit(query, null, LimitType.First);
+          target = queryToTarget(query);
+        }
+
+        return this.indexManager
+          .getDocumentsMatchingTarget(transaction, target)
+          .next(keys => {
+            debugAssert(
+              !!keys,
+              'Index manager must return results for partial and full indexes.'
+            );
+            const sortedKeys = documentKeySet(...keys);
+            return this.localDocumentsView
+              .getDocuments(transaction, sortedKeys)
+              .next(indexedDocuments => {
+                return this.indexManager
+                  .getMinOffset(transaction, target)
+                  .next(offset => {
+                    const previousResults = applyQuery(query, indexedDocuments);
+
+                    if (
+                      needsRefill(
+                        query,
+                        previousResults,
+                        sortedKeys,
+                        offset.readTime
+                      )
+                    ) {
+                      // A limit query whose boundaries change due to local
+                      // edits can be re-run against the cache by excluding the
+                      // limit. This ensures that all documents that match the
+                      // query's filters are included in the result set. The SDK
+                      // can then apply the limit once all local edits are
+                      // incorporated.
+                      return this.performQueryUsingIndex(
+                        transaction,
+                        queryWithLimit(query, null, LimitType.First)
+                      );
+                    }
+
+                    return appendRemainingResults(
+                      transaction,
+                      this.localDocumentsView,
+                      previousResults,
+                      query,
+                      offset
+                    ) as PersistencePromise<DocumentMap | null>;
+                  });
+              });
+          });
+      });
+  }
+
   createCacheIndexes(
     transaction: PersistenceTransaction,
     query: Query,
@@ -244,263 +478,91 @@ export class QueryEngine {
 
     return PersistencePromise.resolve();
   }
+}
 
-  /**
-   * Performs an indexed query that evaluates the query based on a collection's
-   * persisted index values. Returns `null` if an index is not available.
-   */
-  private performQueryUsingIndex(
-    transaction: PersistenceTransaction,
-    query: Query
-  ): PersistencePromise<DocumentMap | null> {
-    if (queryMatchesAllDocuments(query)) {
-      // Queries that match all documents don't benefit from using
-      // key-based lookups. It is more efficient to scan all documents in a
-      // collection, rather than to perform individual lookups.
-      return PersistencePromise.resolve<DocumentMap | null>(null);
+/** Applies the query filter and sorting to the provided documents.  */
+function applyQuery(query: Query, documents: DocumentMap): SortedSet<Document> {
+  // Sort the documents and re-apply the query filter since previously
+  // matching documents do not necessarily still match the query.
+  let queryResults = new SortedSet<Document>(newQueryComparator(query));
+  documents.forEach((_, maybeDoc) => {
+    if (queryMatches(query, maybeDoc)) {
+      queryResults = queryResults.add(maybeDoc);
     }
+  });
+  return queryResults;
+}
 
-    let target = queryToTarget(query);
-    return this.indexManager
-      .getIndexType(transaction, target)
-      .next(indexType => {
-        if (indexType === IndexType.NONE) {
-          // The target cannot be served from any index.
-          return null;
-        }
+/**
+ * Determines if a limit query needs to be refilled from cache, making it
+ * ineligible for index-free execution.
+ *
+ * @param query - The query.
+ * @param sortedPreviousResults - The documents that matched the query when it
+ * was last synchronized, sorted by the query's comparator.
+ * @param remoteKeys - The document keys that matched the query at the last
+ * snapshot.
+ * @param limboFreeSnapshotVersion - The version of the snapshot when the
+ * query was last synchronized.
+ */
+function needsRefill(
+  query: Query,
+  sortedPreviousResults: SortedSet<Document>,
+  remoteKeys: DocumentKeySet,
+  limboFreeSnapshotVersion: SnapshotVersion
+): boolean {
+  if (query.limit === null) {
+    // Queries without limits do not need to be refilled.
+    return false;
+  }
 
-        if (query.limit !== null && indexType === IndexType.PARTIAL) {
-          // We cannot apply a limit for targets that are served using a partial
-          // index. If a partial index will be used to serve the target, the
-          // query may return a superset of documents that match the target
-          // (e.g. if the index doesn't include all the target's filters), or
-          // may return the correct set of documents in the wrong order (e.g. if
-          // the index doesn't include a segment for one of the orderBys).
-          // Therefore, a limit should not be applied in such cases.
-          query = queryWithLimit(query, null, LimitType.First);
-          target = queryToTarget(query);
-        }
+  if (remoteKeys.size !== sortedPreviousResults.size) {
+    // The query needs to be refilled if a previously matching document no
+    // longer matches.
+    return true;
+  }
 
-        return this.indexManager
-          .getDocumentsMatchingTarget(transaction, target)
-          .next(keys => {
-            debugAssert(
-              !!keys,
-              'Index manager must return results for partial and full indexes.'
-            );
-            const sortedKeys = documentKeySet(...keys);
-            return this.localDocumentsView
-              .getDocuments(transaction, sortedKeys)
-              .next(indexedDocuments => {
-                return this.indexManager
-                  .getMinOffset(transaction, target)
-                  .next(offset => {
-                    const previousResults = this.applyQuery(
-                      query,
-                      indexedDocuments
-                    );
+  // Limit queries are not eligible for index-free query execution if there is
+  // a potential that an older document from cache now sorts before a document
+  // that was previously part of the limit. This, however, can only happen if
+  // the document at the edge of the limit goes out of limit.
+  // If a document that is not the limit boundary sorts differently,
+  // the boundary of the limit itself did not change and documents from cache
+  // will continue to be "rejected" by this boundary. Therefore, we can ignore
+  // any modifications that don't affect the last document.
+  const docAtLimitEdge =
+    query.limitType === LimitType.First
+      ? sortedPreviousResults.last()
+      : sortedPreviousResults.first();
+  if (!docAtLimitEdge) {
+    // We don't need to refill the query if there were already no documents.
+    return false;
+  }
+  return (
+    docAtLimitEdge.hasPendingWrites ||
+    docAtLimitEdge.version.compareTo(limboFreeSnapshotVersion) > 0
+  );
+}
 
-                    if (
-                      this.needsRefill(
-                        query,
-                        previousResults,
-                        sortedKeys,
-                        offset.readTime
-                      )
-                    ) {
-                      // A limit query whose boundaries change due to local
-                      // edits can be re-run against the cache by excluding the
-                      // limit. This ensures that all documents that match the
-                      // query's filters are included in the result set. The SDK
-                      // can then apply the limit once all local edits are
-                      // incorporated.
-                      return this.performQueryUsingIndex(
-                        transaction,
-                        queryWithLimit(query, null, LimitType.First)
-                      );
-                    }
-
-                    return this.appendRemainingResults(
-                      transaction,
-                      previousResults,
-                      query,
-                      offset
-                    ) as PersistencePromise<DocumentMap | null>;
-                  });
-              });
-          });
+/**
+ * Combines the results from an indexed execution with the remaining documents
+ * that have not yet been indexed.
+ */
+function appendRemainingResults(
+  transaction: PersistenceTransaction,
+  localDocumentsView: LocalDocumentsView,
+  indexedResults: Iterable<Document>,
+  query: Query,
+  offset: IndexOffset
+): PersistencePromise<DocumentMap> {
+  // Retrieve all results for documents that were updated since the offset.
+  return localDocumentsView
+    .getDocumentsMatchingQuery(transaction, query, offset)
+    .next(remainingResults => {
+      // Merge with existing results
+      indexedResults.forEach(d => {
+        remainingResults = remainingResults.insert(d.key, d);
       });
-  }
-
-  /**
-   * Performs a query based on the target's persisted query mapping. Returns
-   * `null` if the mapping is not available or cannot be used.
-   */
-  private performQueryUsingRemoteKeys(
-    transaction: PersistenceTransaction,
-    query: Query,
-    remoteKeys: DocumentKeySet,
-    lastLimboFreeSnapshotVersion: SnapshotVersion
-  ): PersistencePromise<DocumentMap | null> {
-    if (queryMatchesAllDocuments(query)) {
-      // Queries that match all documents don't benefit from using
-      // key-based lookups. It is more efficient to scan all documents in a
-      // collection, rather than to perform individual lookups.
-      return PersistencePromise.resolve<DocumentMap | null>(null);
-    }
-
-    // Queries that have never seen a snapshot without limbo free documents
-    // should also be run as a full collection scan.
-    if (lastLimboFreeSnapshotVersion.isEqual(SnapshotVersion.min())) {
-      return PersistencePromise.resolve<DocumentMap | null>(null);
-    }
-
-    return this.localDocumentsView!.getDocuments(transaction, remoteKeys).next(
-      documents => {
-        const previousResults = this.applyQuery(query, documents);
-
-        if (
-          this.needsRefill(
-            query,
-            previousResults,
-            remoteKeys,
-            lastLimboFreeSnapshotVersion
-          )
-        ) {
-          return PersistencePromise.resolve<DocumentMap | null>(null);
-        }
-
-        if (getLogLevel() <= LogLevel.DEBUG) {
-          logDebug(
-            'QueryEngine',
-            'Re-using previous result from %s to execute query: %s',
-            lastLimboFreeSnapshotVersion.toString(),
-            stringifyQuery(query)
-          );
-        }
-
-        // Retrieve all results for documents that were updated since the last
-        // limbo-document free remote snapshot.
-        return this.appendRemainingResults(
-          transaction,
-          previousResults,
-          query,
-          newIndexOffsetSuccessorFromReadTime(
-            lastLimboFreeSnapshotVersion,
-            INITIAL_LARGEST_BATCH_ID
-          )
-        ).next<DocumentMap | null>(results => results);
-      }
-    );
-  }
-
-  /** Applies the query filter and sorting to the provided documents.  */
-  private applyQuery(
-    query: Query,
-    documents: DocumentMap
-  ): SortedSet<Document> {
-    // Sort the documents and re-apply the query filter since previously
-    // matching documents do not necessarily still match the query.
-    let queryResults = new SortedSet<Document>(newQueryComparator(query));
-    documents.forEach((_, maybeDoc) => {
-      if (queryMatches(query, maybeDoc)) {
-        queryResults = queryResults.add(maybeDoc);
-      }
+      return remainingResults;
     });
-    return queryResults;
-  }
-
-  /**
-   * Determines if a limit query needs to be refilled from cache, making it
-   * ineligible for index-free execution.
-   *
-   * @param query - The query.
-   * @param sortedPreviousResults - The documents that matched the query when it
-   * was last synchronized, sorted by the query's comparator.
-   * @param remoteKeys - The document keys that matched the query at the last
-   * snapshot.
-   * @param limboFreeSnapshotVersion - The version of the snapshot when the
-   * query was last synchronized.
-   */
-  private needsRefill(
-    query: Query,
-    sortedPreviousResults: SortedSet<Document>,
-    remoteKeys: DocumentKeySet,
-    limboFreeSnapshotVersion: SnapshotVersion
-  ): boolean {
-    if (query.limit === null) {
-      // Queries without limits do not need to be refilled.
-      return false;
-    }
-
-    if (remoteKeys.size !== sortedPreviousResults.size) {
-      // The query needs to be refilled if a previously matching document no
-      // longer matches.
-      return true;
-    }
-
-    // Limit queries are not eligible for index-free query execution if there is
-    // a potential that an older document from cache now sorts before a document
-    // that was previously part of the limit. This, however, can only happen if
-    // the document at the edge of the limit goes out of limit.
-    // If a document that is not the limit boundary sorts differently,
-    // the boundary of the limit itself did not change and documents from cache
-    // will continue to be "rejected" by this boundary. Therefore, we can ignore
-    // any modifications that don't affect the last document.
-    const docAtLimitEdge =
-      query.limitType === LimitType.First
-        ? sortedPreviousResults.last()
-        : sortedPreviousResults.first();
-    if (!docAtLimitEdge) {
-      // We don't need to refill the query if there were already no documents.
-      return false;
-    }
-    return (
-      docAtLimitEdge.hasPendingWrites ||
-      docAtLimitEdge.version.compareTo(limboFreeSnapshotVersion) > 0
-    );
-  }
-
-  private executeFullCollectionScan(
-    transaction: PersistenceTransaction,
-    query: Query,
-    context: QueryContext
-  ): PersistencePromise<DocumentMap> {
-    if (getLogLevel() <= LogLevel.DEBUG) {
-      logDebug(
-        'QueryEngine',
-        'Using full collection scan to execute query:',
-        stringifyQuery(query)
-      );
-    }
-
-    return this.localDocumentsView!.getDocumentsMatchingQuery(
-      transaction,
-      query,
-      IndexOffset.min(),
-      context
-    );
-  }
-
-  /**
-   * Combines the results from an indexed execution with the remaining documents
-   * that have not yet been indexed.
-   */
-  private appendRemainingResults(
-    transaction: PersistenceTransaction,
-    indexedResults: Iterable<Document>,
-    query: Query,
-    offset: IndexOffset
-  ): PersistencePromise<DocumentMap> {
-    // Retrieve all results for documents that were updated since the offset.
-    return this.localDocumentsView
-      .getDocumentsMatchingQuery(transaction, query, offset)
-      .next(remainingResults => {
-        // Merge with existing results
-        indexedResults.forEach(d => {
-          remainingResults = remainingResults.insert(d.key, d);
-        });
-        return remainingResults;
-      });
-  }
 }


### PR DESCRIPTION
Move the client-side indexing code in the `QueryEngine` class into its own, separate class. A later PR will further modify the `QueryEngine` class to allow that new class, named `QueryEngineFieldIndexPlugin`, to be "installed" independently into an instance of `QueryEngine` so that it can be tree-shaken away if not used.

The diff of this PR is more complicated than the changes really are. The main changes are:
1. Move the `performQueryUsingIndex()` and `createCacheIndexes()` method of the `QueryEngine` class into the new class `QueryEngineFieldIndexPlugin`.
2. Move some private methods of `QueryEngine` to top-level functions so that they can be shared by both `QueryEngine` and `QueryEngineFieldIndexPlugin`, namely `applyQuery()`, `needsRefill()`, and `appendRemainingResults()`.
3. Add a `QueryEngineFieldIndexPlugin` private property to `QueryEngine` and add/modify method to delegate to it.

This is the 1st PR in a series of PRs that refactor the client-side indexing code to be tree-shakeable. The next PR in this series is https://github.com/firebase/firebase-js-sdk/pull/7951.
