### PR TITLE
indexeddb_index_manager.ts: move CSI code into its own class

### DIFF
--- a/packages/firestore/src/local/index_backfiller.ts
+++ b/packages/firestore/src/local/index_backfiller.ts
@@ -133,13 +133,19 @@ export class IndexBackfiller {
     transation: PersistenceTransaction,
     maxDocumentsToProcess: number
   ): PersistencePromise<number> {
+    const fieldIndexPlugin = this.localStore.indexManager.fieldIndexPlugin;
+    debugAssert(
+      !!fieldIndexPlugin,
+      'localStore.indexManager.fieldIndexPlugin must not be null'
+    );
+
     const processedCollectionGroups = new Set<string>();
     let documentsRemaining = maxDocumentsToProcess;
     let continueLoop = true;
     return PersistencePromise.doWhile(
       () => continueLoop === true && documentsRemaining > 0,
       () => {
-        return this.localStore.indexManager
+        return fieldIndexPlugin
           .getNextCollectionGroupToUpdate(transation)
           .next((collectionGroup: string | null) => {
             if (
@@ -171,8 +177,14 @@ export class IndexBackfiller {
     collectionGroup: string,
     documentsRemainingUnderCap: number
   ): PersistencePromise<number> {
+    const fieldIndexPlugin = this.localStore.indexManager.fieldIndexPlugin;
+    debugAssert(
+      !!fieldIndexPlugin,
+      'localStore.indexManager.fieldIndexPlugin must not be null'
+    );
+
     // Use the earliest offset of all field indexes to query the local cache.
-    return this.localStore.indexManager
+    return fieldIndexPlugin
       .getMinOffsetFromCollectionGroup(transaction, collectionGroup)
       .next(existingOffset =>
         this.localStore.localDocuments
@@ -184,12 +196,12 @@ export class IndexBackfiller {
           )
           .next(nextBatch => {
             const docs: DocumentMap = nextBatch.changes;
-            return this.localStore.indexManager
+            return fieldIndexPlugin
               .updateIndexEntries(transaction, docs)
               .next(() => this.getNewOffset(existingOffset, nextBatch))
               .next(newOffset => {
                 logDebug(LOG_TAG, `Updating offset: ${newOffset}`);
-                return this.localStore.indexManager.updateCollectionGroup(
+                return fieldIndexPlugin.updateCollectionGroup(
                   transaction,
                   collectionGroup,
                   newOffset

--- a/packages/firestore/src/local/index_manager.ts
+++ b/packages/firestore/src/local/index_manager.ts
@@ -86,6 +86,15 @@ export interface IndexManager {
   ): PersistencePromise<ResourcePath[]>;
 
   /**
+   * The plugin that implements the logic for field indexes; may be null if
+   * it has not been installed into this object, or if the implementation does
+   * not support the plugin.
+   */
+  readonly fieldIndexPlugin: IndexManagerFieldIndexPlugin | null;
+}
+
+export interface IndexManagerFieldIndexPlugin {
+  /**
    * Adds a field path index.
    *
    * Values for this index are persisted via the index backfill, which runs

--- a/packages/firestore/src/local/local_store_impl.ts
+++ b/packages/firestore/src/local/local_store_impl.ts
@@ -1498,13 +1498,15 @@ export async function localStoreConfigureFieldIndexes(
   newFieldIndexes: FieldIndex[]
 ): Promise<void> {
   const localStoreImpl = debugCast(localStore, LocalStoreImpl);
-  const indexManager = localStoreImpl.indexManager;
+  const fieldIndexPlugin = localStoreImpl.indexManager.fieldIndexPlugin;
+  hardAssert(!!fieldIndexPlugin);
+
   const promises: Array<PersistencePromise<void>> = [];
   return localStoreImpl.persistence.runTransaction(
     'Configure indexes',
     'readwrite',
     transaction =>
-      indexManager
+      fieldIndexPlugin
         .getFieldIndexes(transaction)
         .next(oldFieldIndexes =>
           diffArrays(
@@ -1513,12 +1515,12 @@ export async function localStoreConfigureFieldIndexes(
             fieldIndexSemanticComparator,
             fieldIndex => {
               promises.push(
-                indexManager.addFieldIndex(transaction, fieldIndex)
+                fieldIndexPlugin.addFieldIndex(transaction, fieldIndex)
               );
             },
             fieldIndex => {
               promises.push(
-                indexManager.deleteFieldIndex(transaction, fieldIndex)
+                fieldIndexPlugin.deleteFieldIndex(transaction, fieldIndex)
               );
             }
           )
@@ -1532,44 +1534,22 @@ export function localStoreSetIndexAutoCreationEnabled(
   isEnabled: boolean
 ): void {
   const localStoreImpl = debugCast(localStore, LocalStoreImpl);
-  localStoreImpl.queryEngine.indexAutoCreationEnabled = isEnabled;
+  const fieldIndexPlugin = localStoreImpl.queryEngine.fieldIndexPlugin;
+  if (isEnabled || fieldIndexPlugin) {
+    hardAssert(!!fieldIndexPlugin);
+    fieldIndexPlugin.indexAutoCreationEnabled = isEnabled;
+  }
 }
 
 export function localStoreDeleteAllFieldIndexes(
   localStore: LocalStore
 ): Promise<void> {
   const localStoreImpl = debugCast(localStore, LocalStoreImpl);
-  const indexManager = localStoreImpl.indexManager;
+  const fieldIndexPlugin = localStoreImpl.indexManager.fieldIndexPlugin;
+  hardAssert(!!fieldIndexPlugin);
   return localStoreImpl.persistence.runTransaction(
     'Delete All Indexes',
     'readwrite',
-    transaction => indexManager.deleteAllFieldIndexes(transaction)
+    transaction => fieldIndexPlugin.deleteAllFieldIndexes(transaction)
   );
-}
-
-/**
- * Test-only hooks into the SDK for use exclusively by tests.
- */
-export class TestingHooks {
-  private constructor() {
-    throw new Error('creating instances is not supported');
-  }
-
-  static setIndexAutoCreationSettings(
-    localStore: LocalStore,
-    settings: {
-      indexAutoCreationMinCollectionSize?: number;
-      relativeIndexReadCostPerDocument?: number;
-    }
-  ): void {
-    const localStoreImpl = debugCast(localStore, LocalStoreImpl);
-    if (settings.indexAutoCreationMinCollectionSize !== undefined) {
-      localStoreImpl.queryEngine.indexAutoCreationMinCollectionSize =
-        settings.indexAutoCreationMinCollectionSize;
-    }
-    if (settings.relativeIndexReadCostPerDocument !== undefined) {
-      localStoreImpl.queryEngine.relativeIndexReadCostPerDocument =
-        settings.relativeIndexReadCostPerDocument;
-    }
-  }
 }

--- a/packages/firestore/src/local/memory_index_manager.ts
+++ b/packages/firestore/src/local/memory_index_manager.ts
@@ -15,15 +15,11 @@
  * limitations under the License.
  */
 
-import { Target } from '../core/target';
-import { DocumentMap } from '../model/collections';
-import { DocumentKey } from '../model/document_key';
-import { FieldIndex, IndexOffset } from '../model/field_index';
 import { ResourcePath } from '../model/path';
 import { debugAssert } from '../util/assert';
 import { SortedSet } from '../util/sorted_set';
 
-import { IndexManager, IndexType } from './index_manager';
+import { IndexManager } from './index_manager';
 import { PersistencePromise } from './persistence_promise';
 import { PersistenceTransaction } from './persistence_transaction';
 
@@ -50,98 +46,7 @@ export class MemoryIndexManager implements IndexManager {
     );
   }
 
-  addFieldIndex(
-    transaction: PersistenceTransaction,
-    index: FieldIndex
-  ): PersistencePromise<void> {
-    // Field indices are not supported with memory persistence.
-    return PersistencePromise.resolve();
-  }
-
-  deleteFieldIndex(
-    transaction: PersistenceTransaction,
-    index: FieldIndex
-  ): PersistencePromise<void> {
-    // Field indices are not supported with memory persistence.
-    return PersistencePromise.resolve();
-  }
-
-  deleteAllFieldIndexes(
-    transaction: PersistenceTransaction
-  ): PersistencePromise<void> {
-    // Field indices are not supported with memory persistence.
-    return PersistencePromise.resolve();
-  }
-
-  createTargetIndexes(
-    transaction: PersistenceTransaction,
-    target: Target
-  ): PersistencePromise<void> {
-    // Field indices are not supported with memory persistence.
-    return PersistencePromise.resolve();
-  }
-
-  getDocumentsMatchingTarget(
-    transaction: PersistenceTransaction,
-    target: Target
-  ): PersistencePromise<DocumentKey[] | null> {
-    // Field indices are not supported with memory persistence.
-    return PersistencePromise.resolve<DocumentKey[] | null>(null);
-  }
-
-  getIndexType(
-    transaction: PersistenceTransaction,
-    target: Target
-  ): PersistencePromise<IndexType> {
-    // Field indices are not supported with memory persistence.
-    return PersistencePromise.resolve<IndexType>(IndexType.NONE);
-  }
-
-  getFieldIndexes(
-    transaction: PersistenceTransaction,
-    collectionGroup?: string
-  ): PersistencePromise<FieldIndex[]> {
-    // Field indices are not supported with memory persistence.
-    return PersistencePromise.resolve<FieldIndex[]>([]);
-  }
-
-  getNextCollectionGroupToUpdate(
-    transaction: PersistenceTransaction
-  ): PersistencePromise<string | null> {
-    // Field indices are not supported with memory persistence.
-    return PersistencePromise.resolve<string | null>(null);
-  }
-
-  getMinOffset(
-    transaction: PersistenceTransaction,
-    target: Target
-  ): PersistencePromise<IndexOffset> {
-    return PersistencePromise.resolve(IndexOffset.min());
-  }
-
-  getMinOffsetFromCollectionGroup(
-    transaction: PersistenceTransaction,
-    collectionGroup: string
-  ): PersistencePromise<IndexOffset> {
-    return PersistencePromise.resolve(IndexOffset.min());
-  }
-
-  updateCollectionGroup(
-    transaction: PersistenceTransaction,
-    collectionGroup: string,
-    offset: IndexOffset
-  ): PersistencePromise<void> {
-    // Field indices are not supported with memory persistence.
-    return PersistencePromise.resolve();
-  }
-
-  updateIndexEntries(
-    transaction: PersistenceTransaction,
-    documents: DocumentMap
-  ): PersistencePromise<void> {
-    // Field indices are not supported with memory persistence.
-    return PersistencePromise.resolve();
-  }
+  readonly fieldIndexPlugin = null;
 }
 
 /**

--- a/packages/firestore/test/unit/local/local_store.test.ts
+++ b/packages/firestore/test/unit/local/local_store.test.ts
@@ -661,13 +661,13 @@ function genericLocalStoreTests(
 
   it('localStoreSetIndexAutoCreationEnabled()', () => {
     localStoreSetIndexAutoCreationEnabled(localStore, true);
-    expect(queryEngine.indexAutoCreationEnabled).to.be.true;
+    expect(queryEngine.fieldIndexPlugin?.indexAutoCreationEnabled).to.be.true;
     localStoreSetIndexAutoCreationEnabled(localStore, false);
-    expect(queryEngine.indexAutoCreationEnabled).to.be.false;
+    expect(queryEngine.fieldIndexPlugin?.indexAutoCreationEnabled).to.be.false;
     localStoreSetIndexAutoCreationEnabled(localStore, true);
-    expect(queryEngine.indexAutoCreationEnabled).to.be.true;
+    expect(queryEngine.fieldIndexPlugin?.indexAutoCreationEnabled).to.be.true;
     localStoreSetIndexAutoCreationEnabled(localStore, false);
-    expect(queryEngine.indexAutoCreationEnabled).to.be.false;
+    expect(queryEngine.fieldIndexPlugin?.indexAutoCreationEnabled).to.be.false;
   });
 
   it('handles SetMutation', () => {

--- a/packages/firestore/test/unit/local/test_index_manager.ts
+++ b/packages/firestore/test/unit/local/test_index_manager.ts
@@ -51,7 +51,7 @@ export class TestIndexManager {
 
   addFieldIndex(index: FieldIndex): Promise<void> {
     return this.persistence.runTransaction('addFieldIndex', 'readwrite', txn =>
-      this.indexManager.addFieldIndex(txn, index)
+      this.indexManager.fieldIndexPlugin!.addFieldIndex(txn, index)
     );
   }
 
@@ -59,7 +59,7 @@ export class TestIndexManager {
     return this.persistence.runTransaction(
       'deleteFieldIndex',
       'readwrite',
-      txn => this.indexManager.deleteFieldIndex(txn, index)
+      txn => this.indexManager.fieldIndexPlugin!.deleteFieldIndex(txn, index)
     );
   }
 
@@ -67,7 +67,8 @@ export class TestIndexManager {
     return this.persistence.runTransaction(
       'createTargetIndexes',
       'readwrite',
-      txn => this.indexManager.createTargetIndexes(txn, target)
+      txn =>
+        this.indexManager.fieldIndexPlugin!.createTargetIndexes(txn, target)
     );
   }
 
@@ -75,21 +76,24 @@ export class TestIndexManager {
     return this.persistence.runTransaction(
       'deleteAllFieldIndexes',
       'readwrite',
-      txn => this.indexManager.deleteAllFieldIndexes(txn)
+      txn => this.indexManager.fieldIndexPlugin!.deleteAllFieldIndexes(txn)
     );
   }
 
   getFieldIndexes(collectionGroup?: string): Promise<FieldIndex[]> {
     return this.persistence.runTransaction('getFieldIndexes', 'readonly', txn =>
       collectionGroup
-        ? this.indexManager.getFieldIndexes(txn, collectionGroup)
-        : this.indexManager.getFieldIndexes(txn)
+        ? this.indexManager.fieldIndexPlugin!.getFieldIndexes(
+            txn,
+            collectionGroup
+          )
+        : this.indexManager.fieldIndexPlugin!.getFieldIndexes(txn)
     );
   }
 
   getIndexType(target: Target): Promise<IndexType> {
     return this.persistence.runTransaction('getIndexType', 'readonly', txn =>
-      this.indexManager.getIndexType(txn, target)
+      this.indexManager.fieldIndexPlugin!.getIndexType(txn, target)
     );
   }
 
@@ -97,7 +101,11 @@ export class TestIndexManager {
     return this.persistence.runTransaction(
       'getDocumentsMatchingTarget',
       'readonly',
-      txn => this.indexManager.getDocumentsMatchingTarget(txn, target)
+      txn =>
+        this.indexManager.fieldIndexPlugin!.getDocumentsMatchingTarget(
+          txn,
+          target
+        )
     );
   }
 
@@ -105,7 +113,8 @@ export class TestIndexManager {
     return this.persistence.runTransaction(
       'getNextCollectionGroupToUpdate',
       'readonly',
-      txn => this.indexManager.getNextCollectionGroupToUpdate(txn)
+      txn =>
+        this.indexManager.fieldIndexPlugin!.getNextCollectionGroupToUpdate(txn)
     );
   }
 
@@ -117,7 +126,11 @@ export class TestIndexManager {
       'updateCollectionGroup',
       'readwrite-primary',
       txn =>
-        this.indexManager.updateCollectionGroup(txn, collectionGroup, offset)
+        this.indexManager.fieldIndexPlugin!.updateCollectionGroup(
+          txn,
+          collectionGroup,
+          offset
+        )
     );
   }
 
@@ -125,7 +138,8 @@ export class TestIndexManager {
     return this.persistence.runTransaction(
       'updateIndexEntries',
       'readwrite-primary',
-      txn => this.indexManager.updateIndexEntries(txn, documents)
+      txn =>
+        this.indexManager.fieldIndexPlugin!.updateIndexEntries(txn, documents)
     );
   }
 }

--- a/packages/firestore/test/unit/specs/spec_test_runner.ts
+++ b/packages/firestore/test/unit/specs/spec_test_runner.ts
@@ -996,7 +996,9 @@ abstract class TestRunner {
             'getFieldIndexes ',
             'readonly',
             transaction =>
-              this.localStore.indexManager.getFieldIndexes(transaction)
+              this.localStore.indexManager.fieldIndexPlugin!.getFieldIndexes(
+                transaction
+              )
           );
 
         assert.deepEqualExcluding(


### PR DESCRIPTION
Move the client-side indexing API in the `IndexManager` interface into a separate "plugin" interface, and add a nullable property to `IndexManager` to store a reference to it. The `MemoryIndexManager` class easily implements this by setting the field to null. The `IndexedDbIndexManager`, however, is changed heavily to move all of the functions related to client-side indexing into a class implementing the new "plugin" interface. A later PR will further modify the `IndexedDbIndexManaber` class to allow that new class, named `IndexManaberFieldIndexPlugin`, to be "installed" independently into an instance of `IndexedDbIndexManaber` so that it can be tree-shaken away if not used.

This PR is preceded by https://github.com/firebase/firebase-js-sdk/pull/7950.