### PR TITLE
Firestore: Hardcode path names in rollup scripts

### DIFF
--- a/packages/firestore/rollup.config.debug.js
+++ b/packages/firestore/rollup.config.debug.js
@@ -62,9 +62,9 @@ const browserDeps = [
 
 export default [
   {
-    input: './src/index.ts',
+    input: 'src/index.ts',
     output: {
-      file: pkg.browser,
+      file: 'dist/index.esm2017.js',
       format: 'es',
       sourcemap: true
     },

--- a/packages/firestore/rollup.config.js
+++ b/packages/firestore/rollup.config.js
@@ -27,8 +27,6 @@ import typescript from 'typescript';
 
 import { generateBuildTargetReplaceConfig } from '../../scripts/build/rollup_replace_build_target';
 
-import pkg from './package.json';
-
 const sourcemaps = require('rollup-plugin-sourcemaps');
 const util = require('./rollup.shared');
 
@@ -75,9 +73,9 @@ const allBuilds = [
   // this is an intermediate build used to generate the actual esm and cjs builds
   // which add build target reporting
   {
-    input: './src/index.node.ts',
+    input: 'src/index.node.ts',
     output: {
-      file: pkg['main-esm'],
+      file: 'dist/index.node.mjs',
       format: 'es',
       sourcemap: true
     },
@@ -90,9 +88,9 @@ const allBuilds = [
   },
   // Node CJS build
   {
-    input: pkg['main-esm'],
+    input: 'dist/index.node.mjs',
     output: {
-      file: pkg.main,
+      file: 'dist/index.node.cjs.js',
       format: 'cjs',
       sourcemap: true
     },
@@ -107,9 +105,9 @@ const allBuilds = [
   },
   // Node ESM build with build target reporting
   {
-    input: pkg['main-esm'],
+    input: 'dist/index.node.mjs',
     output: {
-      file: pkg['main-esm'],
+      file: 'dist/index.node.mjs',
       format: 'es',
       sourcemap: true
     },
@@ -126,9 +124,9 @@ const allBuilds = [
   // this is an intermediate build used to generate the actual esm and cjs builds
   // which add build target reporting
   {
-    input: './src/index.ts',
+    input: 'src/index.ts',
     output: {
-      file: pkg.browser,
+      file: 'dist/index.esm2017.js',
       format: 'es',
       sourcemap: true
     },
@@ -140,10 +138,10 @@ const allBuilds = [
   },
   // Convert es2017 build to ES5
   {
-    input: pkg['browser'],
+    input: 'dist/index.esm2017.js',
     output: [
       {
-        file: pkg['esm5'],
+        file: 'dist/index.esm5.js',
         format: 'es',
         sourcemap: true
       }
@@ -159,7 +157,7 @@ const allBuilds = [
   },
   // Convert es2017 build to cjs
   {
-    input: pkg['browser'],
+    input: 'dist/index.esm2017.js',
     output: [
       {
         file: './dist/index.cjs.js',
@@ -178,10 +176,10 @@ const allBuilds = [
   },
   // es2017 build with build target reporting
   {
-    input: pkg['browser'],
+    input: 'dist/index.esm2017.js',
     output: [
       {
-        file: pkg['browser'],
+        file: 'dist/index.esm2017.js',
         format: 'es',
         sourcemap: true
       }
@@ -197,9 +195,9 @@ const allBuilds = [
   },
   // RN build
   {
-    input: './src/index.rn.ts',
+    input: 'src/index.rn.ts',
     output: {
-      file: pkg['react-native'],
+      file: 'dist/index.rn.js',
       format: 'es',
       sourcemap: true
     },

--- a/packages/firestore/rollup.config.js
+++ b/packages/firestore/rollup.config.js
@@ -160,7 +160,7 @@ const allBuilds = [
     input: 'dist/index.esm2017.js',
     output: [
       {
-        file: './dist/index.cjs.js',
+        file: 'dist/index.cjs.js',
         format: 'cjs',
         sourcemap: true
       }

--- a/packages/firestore/rollup.config.lite.js
+++ b/packages/firestore/rollup.config.lite.js
@@ -16,7 +16,6 @@
  */
 
 import tmp from 'tmp';
-import path from 'path';
 import json from '@rollup/plugin-json';
 import alias from '@rollup/plugin-alias';
 import typescriptPlugin from 'rollup-plugin-typescript2';
@@ -25,7 +24,6 @@ import sourcemaps from 'rollup-plugin-sourcemaps';
 import replace from 'rollup-plugin-replace';
 import { terser } from 'rollup-plugin-terser';
 
-import pkg from './lite/package.json';
 import { generateBuildTargetReplaceConfig } from '../../scripts/build/rollup_replace_build_target';
 
 const util = require('./rollup.shared');
@@ -70,9 +68,9 @@ const allBuilds = [
   // this is an intermidiate build used to generate the actual esm and cjs builds
   // which add build target reporting
   {
-    input: './lite/index.ts',
+    input: 'lite/index.ts',
     output: {
-      file: path.resolve('./lite', pkg['main-esm']),
+      file: 'dist/lite/index.node.mjs',
       format: 'es',
       sourcemap: true
     },
@@ -91,9 +89,9 @@ const allBuilds = [
   },
   // Node CJS build
   {
-    input: path.resolve('./lite', pkg['main-esm']),
+    input: 'dist/lite/index.node.mjs',
     output: {
-      file: path.resolve('./lite', pkg.main),
+      file: 'dist/lite/index.node.cjs.js',
       format: 'cjs',
       sourcemap: true
     },
@@ -117,9 +115,9 @@ const allBuilds = [
   },
   // Node ESM build
   {
-    input: path.resolve('./lite', pkg['main-esm']),
+    input: 'dist/lite/index.node.mjs',
     output: {
-      file: path.resolve('./lite', pkg['main-esm']),
+      file: 'dist/lite/index.node.mjs',
       format: 'es',
       sourcemap: true
     },
@@ -136,9 +134,9 @@ const allBuilds = [
   // this is an intermidiate build used to generate the actual esm and cjs builds
   // which add build target reporting
   {
-    input: './lite/index.ts',
+    input: 'lite/index.ts',
     output: {
-      file: path.resolve('./lite', pkg.browser),
+      file: 'dist/lite/index.esm2017.js',
       format: 'es',
       sourcemap: true
     },
@@ -157,10 +155,10 @@ const allBuilds = [
   },
   // Convert es2017 build to ES5
   {
-    input: path.resolve('./lite', pkg.browser),
+    input: 'dist/lite/index.esm2017.js',
     output: [
       {
-        file: path.resolve('./lite', pkg.esm5),
+        file: 'dist/lite/index.esm5.js',
         format: 'es',
         sourcemap: true
       }
@@ -176,10 +174,10 @@ const allBuilds = [
   },
   // Convert es2017 build to CJS
   {
-    input: path.resolve('./lite', pkg.browser),
+    input: 'dist/lite/index.esm2017.js',
     output: [
       {
-        file: './dist/lite/index.cjs.js',
+        file: 'dist/lite/index.cjs.js',
         format: 'es',
         sourcemap: true
       }
@@ -195,10 +193,10 @@ const allBuilds = [
   },
   // Browser es2017 build
   {
-    input: path.resolve('./lite', pkg.browser),
+    input: 'dist/lite/index.esm2017.js',
     output: [
       {
-        file: path.resolve('./lite', pkg.browser),
+        file: 'dist/lite/index.esm2017.js',
         format: 'es',
         sourcemap: true
       }
@@ -214,9 +212,9 @@ const allBuilds = [
   },
   // RN build
   {
-    input: './lite/index.ts',
+    input: 'lite/index.ts',
     output: {
-      file: path.resolve('./lite', pkg['react-native']),
+      file: 'dist/lite/index.rn.js',
       format: 'es',
       sourcemap: true
     },

--- a/packages/firestore/rollup.config.lite.js
+++ b/packages/firestore/rollup.config.lite.js
@@ -136,7 +136,7 @@ const allBuilds = [
   {
     input: 'lite/index.ts',
     output: {
-      file: 'dist/lite/index.esm2017.js',
+      file: 'dist/lite/index.browser.esm2017.js',
       format: 'es',
       sourcemap: true
     },
@@ -155,10 +155,10 @@ const allBuilds = [
   },
   // Convert es2017 build to ES5
   {
-    input: 'dist/lite/index.esm2017.js',
+    input: 'dist/lite/index.browser.esm2017.js',
     output: [
       {
-        file: 'dist/lite/index.esm5.js',
+        file: 'dist/lite/index.browser.esm5.js',
         format: 'es',
         sourcemap: true
       }
@@ -174,7 +174,7 @@ const allBuilds = [
   },
   // Convert es2017 build to CJS
   {
-    input: 'dist/lite/index.esm2017.js',
+    input: 'dist/lite/index.browser.esm2017.js',
     output: [
       {
         file: 'dist/lite/index.cjs.js',
@@ -193,10 +193,10 @@ const allBuilds = [
   },
   // Browser es2017 build
   {
-    input: 'dist/lite/index.esm2017.js',
+    input: 'dist/lite/index.browser.esm2017.js',
     output: [
       {
-        file: 'dist/lite/index.esm2017.js',
+        file: 'dist/lite/index.browser.esm2017.js',
         format: 'es',
         sourcemap: true
       }
@@ -214,7 +214,7 @@ const allBuilds = [
   {
     input: 'lite/index.ts',
     output: {
-      file: 'dist/lite/index.rn.js',
+      file: 'dist/lite/index.rn.esm2017.js',
       format: 'es',
       sourcemap: true
     },


### PR DESCRIPTION
This PR modifies Firestore's rollup scripts to hardcode the paths of the input and output files, rather than loading them from `package.json`. No functionality whatsoever was changed. The motivation for this change was to improve readability of the rollup scripts: with the paths hardcoded it is much easier to understand from reading the scripts which files are getting consumed and which are getting created.