### PR TITLE
Firestore: Factor out logic that extracts paths from package.json in rollup scripts

### DIFF
--- a/packages/firestore/rollup.config.js
+++ b/packages/firestore/rollup.config.js
@@ -27,10 +27,10 @@ import typescript from 'typescript';
 
 import { generateBuildTargetReplaceConfig } from '../../scripts/build/rollup_replace_build_target';
 
-import pkg from './package.json';
-
 const sourcemaps = require('rollup-plugin-sourcemaps');
 const util = require('./rollup.shared');
+
+const outputFiles = util.getPackageJsonExportPaths();
 
 const nodePlugins = function () {
   return [
@@ -77,7 +77,7 @@ const allBuilds = [
   {
     input: './src/index.node.ts',
     output: {
-      file: pkg['main-esm'],
+      file: outputFiles.main.node.import,
       format: 'es',
       sourcemap: true
     },
@@ -90,9 +90,9 @@ const allBuilds = [
   },
   // Node CJS build
   {
-    input: pkg['main-esm'],
+    input: outputFiles.main.node.import,
     output: {
-      file: pkg.main,
+      file: outputFiles.main.node.require,
       format: 'cjs',
       sourcemap: true
     },
@@ -107,9 +107,9 @@ const allBuilds = [
   },
   // Node ESM build with build target reporting
   {
-    input: pkg['main-esm'],
+    input: outputFiles.main.node.import,
     output: {
-      file: pkg['main-esm'],
+      file: outputFiles.main.node.import,
       format: 'es',
       sourcemap: true
     },
@@ -128,7 +128,7 @@ const allBuilds = [
   {
     input: './src/index.ts',
     output: {
-      file: pkg.browser,
+      file: outputFiles.main.browser.import,
       format: 'es',
       sourcemap: true
     },
@@ -140,10 +140,10 @@ const allBuilds = [
   },
   // Convert es2017 build to ES5
   {
-    input: pkg['browser'],
+    input: outputFiles.main.browser.import,
     output: [
       {
-        file: pkg['esm5'],
+        file: outputFiles.main.esm5,
         format: 'es',
         sourcemap: true
       }
@@ -159,7 +159,7 @@ const allBuilds = [
   },
   // Convert es2017 build to cjs
   {
-    input: pkg['browser'],
+    input: outputFiles.main.browser.import,
     output: [
       {
         file: './dist/index.cjs.js',
@@ -178,10 +178,10 @@ const allBuilds = [
   },
   // es2017 build with build target reporting
   {
-    input: pkg['browser'],
+    input: outputFiles.main.browser.import,
     output: [
       {
-        file: pkg['browser'],
+        file: outputFiles.main.browser.import,
         format: 'es',
         sourcemap: true
       }
@@ -199,7 +199,7 @@ const allBuilds = [
   {
     input: './src/index.rn.ts',
     output: {
-      file: pkg['react-native'],
+      file: outputFiles.main.rn,
       format: 'es',
       sourcemap: true
     },

--- a/packages/firestore/rollup.config.lite.js
+++ b/packages/firestore/rollup.config.lite.js
@@ -16,7 +16,6 @@
  */
 
 import tmp from 'tmp';
-import path from 'path';
 import json from '@rollup/plugin-json';
 import alias from '@rollup/plugin-alias';
 import typescriptPlugin from 'rollup-plugin-typescript2';
@@ -25,10 +24,11 @@ import sourcemaps from 'rollup-plugin-sourcemaps';
 import replace from 'rollup-plugin-replace';
 import { terser } from 'rollup-plugin-terser';
 
-import pkg from './lite/package.json';
 import { generateBuildTargetReplaceConfig } from '../../scripts/build/rollup_replace_build_target';
 
 const util = require('./rollup.shared');
+
+const outputFiles = util.getPackageJsonExportPaths();
 
 const nodePlugins = function () {
   return [
@@ -72,7 +72,7 @@ const allBuilds = [
   {
     input: './lite/index.ts',
     output: {
-      file: path.resolve('./lite', pkg['main-esm']),
+      file: outputFiles.lite.node.import,
       format: 'es',
       sourcemap: true
     },
@@ -91,9 +91,9 @@ const allBuilds = [
   },
   // Node CJS build
   {
-    input: path.resolve('./lite', pkg['main-esm']),
+    input: outputFiles.lite.node.import,
     output: {
-      file: path.resolve('./lite', pkg.main),
+      file: outputFiles.lite.node.require,
       format: 'cjs',
       sourcemap: true
     },
@@ -117,9 +117,9 @@ const allBuilds = [
   },
   // Node ESM build
   {
-    input: path.resolve('./lite', pkg['main-esm']),
+    input: outputFiles.lite.node.import,
     output: {
-      file: path.resolve('./lite', pkg['main-esm']),
+      file: outputFiles.lite.node.import,
       format: 'es',
       sourcemap: true
     },
@@ -138,7 +138,7 @@ const allBuilds = [
   {
     input: './lite/index.ts',
     output: {
-      file: path.resolve('./lite', pkg.browser),
+      file: outputFiles.lite.browser.import,
       format: 'es',
       sourcemap: true
     },
@@ -157,10 +157,10 @@ const allBuilds = [
   },
   // Convert es2017 build to ES5
   {
-    input: path.resolve('./lite', pkg.browser),
+    input: outputFiles.lite.browser.import,
     output: [
       {
-        file: path.resolve('./lite', pkg.esm5),
+        file: outputFiles.lite.esm5,
         format: 'es',
         sourcemap: true
       }
@@ -176,7 +176,7 @@ const allBuilds = [
   },
   // Convert es2017 build to CJS
   {
-    input: path.resolve('./lite', pkg.browser),
+    input: outputFiles.lite.browser.import,
     output: [
       {
         file: './dist/lite/index.cjs.js',
@@ -195,10 +195,10 @@ const allBuilds = [
   },
   // Browser es2017 build
   {
-    input: path.resolve('./lite', pkg.browser),
+    input: outputFiles.lite.browser.import,
     output: [
       {
-        file: path.resolve('./lite', pkg.browser),
+        file: outputFiles.lite.browser.import,
         format: 'es',
         sourcemap: true
       }
@@ -216,7 +216,7 @@ const allBuilds = [
   {
     input: './lite/index.ts',
     output: {
-      file: path.resolve('./lite', pkg['react-native']),
+      file: outputFiles.lite.rn,
       format: 'es',
       sourcemap: true
     },

--- a/packages/firestore/rollup.shared.js
+++ b/packages/firestore/rollup.shared.js
@@ -364,3 +364,71 @@ exports.es2017PluginsCompat = function (
     ];
   }
 };
+
+function getPackageJsonExportPaths() {
+  const {
+    exports: {
+      '.': {
+        types: main_types,
+        browser: { require: main_browser_require, import: main_browser_import },
+        node: { require: main_node_require, import: main_node_import },
+        'react-native': main_react_native,
+        esm5: main_esm5
+      },
+      './lite': {
+        types: lite_types,
+        browser: { require: lite_browser_require, import: lite_browser_import },
+        node: { require: lite_node_require, import: lite_node_import },
+        'react-native': lite_react_native,
+        esm5: lite_esm5
+      }
+    }
+  } = pkg;
+
+  const map = new Map();
+  map.set('main_types', main_types);
+  map.set('main_browser_require', main_browser_require);
+  map.set('main_browser_import', main_browser_import);
+  map.set('main_node_require', main_node_require);
+  map.set('main_node_import', main_node_import);
+  map.set('main_react_native', main_react_native);
+  map.set('main_esm5', main_esm5);
+  map.set('lite_types', lite_types);
+  map.set('lite_browser_require', lite_browser_require);
+  map.set('lite_browser_import', lite_browser_import);
+  map.set('lite_node_require', lite_node_require);
+  map.set('lite_node_import', lite_node_import);
+  map.set('lite_react_native', lite_react_native);
+  map.set('lite_esm5', lite_esm5);
+
+  const missingKeys = [];
+  map.forEach((value, key) => {
+    if (!value) {
+      missingKeys.push(key);
+    }
+  });
+
+  if (missingKeys.length > 0) {
+    throw new Error(
+      'missing keys from package.json: ' + missingKeys.join(', ')
+    );
+  }
+
+  return {
+    main_types,
+    main_browser_require,
+    main_browser_import,
+    main_node_require,
+    main_node_import,
+    main_react_native,
+    main_esm5,
+    lite_types,
+    lite_browser_require,
+    lite_browser_import,
+    lite_node_require,
+    lite_node_import,
+    lite_react_native,
+    lite_esm5
+  };
+}
+exports.getPackageJsonExportPaths = getPackageJsonExportPaths;

--- a/packages/firestore/rollup.shared.js
+++ b/packages/firestore/rollup.shared.js
@@ -415,20 +415,32 @@ function getPackageJsonExportPaths() {
   }
 
   return {
-    main_types,
-    main_browser_require,
-    main_browser_import,
-    main_node_require,
-    main_node_import,
-    main_react_native,
-    main_esm5,
-    lite_types,
-    lite_browser_require,
-    lite_browser_import,
-    lite_node_require,
-    lite_node_import,
-    lite_react_native,
-    lite_esm5
+    main: {
+      types: main_types,
+      browser: {
+        require: main_browser_require,
+        import: main_browser_import
+      },
+      node: {
+        require: main_node_require,
+        import: main_node_import
+      },
+      rn: main_react_native,
+      esm5: main_esm5
+    },
+    lite: {
+      types: lite_types,
+      browser: {
+        require: lite_browser_require,
+        import: lite_browser_import
+      },
+      node: {
+        require: lite_node_require,
+        import: lite_node_import
+      },
+      rn: lite_react_native,
+      esm5: lite_esm5
+    }
   };
 }
 exports.getPackageJsonExportPaths = getPackageJsonExportPaths;


### PR DESCRIPTION
This PR adds the function `getPackageJsonExportPaths()` to `rollup.shared.js` so that the rollup scripts can access the "exports" paths from `package.json` in a consistent way, rather than the random bespoke ways. This should help to improve the readability of the rollup scripts.