### PR TITLE
Fix isSafari() throwing on React Native (fixes #7962)

### DIFF
--- a/.changeset/purple-cooks-explode.md
+++ b/.changeset/purple-cooks-explode.md
@@ -1,0 +1,5 @@
+---
+'@firebase/util': patch
+---
+
+Fix isSafari() throwing on React Native

--- a/packages/util/src/environment.ts
+++ b/packages/util/src/environment.ts
@@ -138,6 +138,7 @@ export function isNodeSdk(): boolean {
 export function isSafari(): boolean {
   return (
     !isNode() &&
+    navigator.userAgent !== undefined && // not react-native
     navigator.userAgent.includes('Safari') &&
     !navigator.userAgent.includes('Chrome')
   );

--- a/packages/util/src/environment.ts
+++ b/packages/util/src/environment.ts
@@ -138,7 +138,7 @@ export function isNodeSdk(): boolean {
 export function isSafari(): boolean {
   return (
     !isNode() &&
-    navigator.userAgent &&
+    !!navigator.userAgent &&
     navigator.userAgent.includes('Safari') &&
     !navigator.userAgent.includes('Chrome')
   );

--- a/packages/util/src/environment.ts
+++ b/packages/util/src/environment.ts
@@ -138,7 +138,7 @@ export function isNodeSdk(): boolean {
 export function isSafari(): boolean {
   return (
     !isNode() &&
-    navigator.userAgent !== undefined &&
+    navigator.userAgent &&
     navigator.userAgent.includes('Safari') &&
     !navigator.userAgent.includes('Chrome')
   );

--- a/packages/util/src/environment.ts
+++ b/packages/util/src/environment.ts
@@ -138,7 +138,7 @@ export function isNodeSdk(): boolean {
 export function isSafari(): boolean {
   return (
     !isNode() &&
-    navigator.userAgent !== undefined && // not react-native
+    navigator.userAgent !== undefined &&
     navigator.userAgent.includes('Safari') &&
     !navigator.userAgent.includes('Chrome')
   );


### PR DESCRIPTION
In https://github.com/firebase/firebase-js-sdk/pull/7929 some logic was added to Firestore to check for the browser being Safari. This new check for `isSafari()` unexpectedly threw an exception in React Native. This PR fixes the exception by explicitly checking for an object not being `undefined` before using it.

Fixes https://github.com/firebase/firebase-js-sdk/issues/7962
