### PR TITLE
Fix errors in reporting errors in the "Check changeset vs changed files" workflow

### DIFF
--- a/.github/workflows/check-changeset.yml
+++ b/.github/workflows/check-changeset.yml
@@ -47,7 +47,10 @@ jobs:
         yarn ts-node-script scripts/ci/check_changeset.ts
       id: check-changeset
     - name: Print changeset checker output
-      run: echo "${{steps.check-changeset.outputs.CHANGESET_ERROR_MESSAGE}}"
+      run: |
+        cat << 'eof_delimiter_that_will_never_occur_in_CHANGESET_ERROR_MESSAGE'
+        ${{steps.check-changeset.outputs.CHANGESET_ERROR_MESSAGE}}
+        eof_delimiter_that_will_never_occur_in_CHANGESET_ERROR_MESSAGE
     - name: Print blocking failure status
       run: echo "${{steps.check-changeset.outputs.BLOCKING_FAILURE}}"
     - name: Find Comment

--- a/scripts/ci/check_changeset.ts
+++ b/scripts/ci/check_changeset.ts
@@ -17,6 +17,7 @@
 
 import { resolve } from 'path';
 import { existsSync } from 'fs';
+import { writeFile } from 'fs/promises';
 import { exec } from 'child-process-promise';
 import chalk from 'chalk';
 import simpleGit from 'simple-git';
@@ -27,6 +28,14 @@ const git = simpleGit(root);
 
 const baseRef = process.env.GITHUB_PULL_REQUEST_BASE_SHA || 'master';
 const headRef = process.env.GITHUB_PULL_REQUEST_HEAD_SHA || 'HEAD';
+
+const githubOutputFile = (function (): string {
+  const value = process.env.GITHUB_OUTPUT;
+  if (!value) {
+    throw new Error('GITHUB_OUTPUT environment variable must be set');
+  }
+  return value;
+})();
 
 // Version bump text converted to rankable numbers.
 const bumpRank: Record<string, number> = {
@@ -205,10 +214,13 @@ async function main() {
    * step. See:
    * https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter
    */
-  if (errors.length > 0)
-    await exec(
-      `echo "CHANGESET_ERROR_MESSAGE=${errors.join('%0A')}" >> $GITHUB_OUTPUT`
+  if (errors.length > 0) {
+    await writeFile(
+      githubOutputFile,
+      `CHANGESET_ERROR_MESSAGE=${errors.join('%0A')}\n`,
+      { flag: 'a' }
     );
+  }
   process.exit();
 }
 


### PR DESCRIPTION
Here is an example of this change causing the workflow to correctly report the results:

##### Before

From https://github.com/firebase/firebase-js-sdk/actions/runs/7586489122/job/20664769245

![image](https://github.com/firebase/firebase-js-sdk/assets/61283819/4879ee1e-a388-48c5-8866-5c19e62091ea)

##### After

From https://github.com/firebase/firebase-js-sdk/actions/runs/7587195474/job/20666981441

![image](https://github.com/firebase/firebase-js-sdk/assets/61283819/8f884bd1-b6c9-4e1d-864e-b03510a64c87)
