### PR TITLE
Fixed issue where queryConstraint.type was undefined

### DIFF
--- a/.changeset/cyan-apes-listen.md
+++ b/.changeset/cyan-apes-listen.md
@@ -1,0 +1,5 @@
+---
+"@firebase/database": patch
+---
+
+Fixed issue where queryConstraint.type was undefined

--- a/packages/database/src/api/Reference_impl.ts
+++ b/packages/database/src/api/Reference_impl.ts
@@ -1683,7 +1683,7 @@ export abstract class QueryConstraint {
 }
 
 class QueryEndAtConstraint extends QueryConstraint {
-  readonly type: 'endAt';
+  readonly type = 'endAt';
 
   constructor(
     private readonly _value: number | string | boolean | null,
@@ -1748,7 +1748,7 @@ export function endAt(
 }
 
 class QueryEndBeforeConstraint extends QueryConstraint {
-  readonly type: 'endBefore';
+  readonly type = 'endBefore';
 
   constructor(
     private readonly _value: number | string | boolean | null,
@@ -1809,7 +1809,7 @@ export function endBefore(
 }
 
 class QueryStartAtConstraint extends QueryConstraint {
-  readonly type: 'startAt';
+  readonly type = 'startAt';
 
   constructor(
     private readonly _value: number | string | boolean | null,
@@ -1873,7 +1873,7 @@ export function startAt(
 }
 
 class QueryStartAfterConstraint extends QueryConstraint {
-  readonly type: 'startAfter';
+  readonly type = 'startAfter';
 
   constructor(
     private readonly _value: number | string | boolean | null,
@@ -1933,7 +1933,7 @@ export function startAfter(
 }
 
 class QueryLimitToFirstConstraint extends QueryConstraint {
-  readonly type: 'limitToFirst';
+  readonly type = 'limitToFirst';
 
   constructor(private readonly _limit: number) {
     super();
@@ -1981,7 +1981,7 @@ export function limitToFirst(limit: number): QueryConstraint {
 }
 
 class QueryLimitToLastConstraint extends QueryConstraint {
-  readonly type: 'limitToLast';
+  readonly type = 'limitToLast';
 
   constructor(private readonly _limit: number) {
     super();
@@ -2030,7 +2030,7 @@ export function limitToLast(limit: number): QueryConstraint {
 }
 
 class QueryOrderByChildConstraint extends QueryConstraint {
-  readonly type: 'orderByChild';
+  readonly type = 'orderByChild';
 
   constructor(private readonly _path: string) {
     super();
@@ -2093,7 +2093,7 @@ export function orderByChild(path: string): QueryConstraint {
 }
 
 class QueryOrderByKeyConstraint extends QueryConstraint {
-  readonly type: 'orderByKey';
+  readonly type = 'orderByKey';
 
   _apply<T>(query: QueryImpl): QueryImpl {
     validateNoPreviousOrderByCall(query, 'orderByKey');
@@ -2121,7 +2121,7 @@ export function orderByKey(): QueryConstraint {
 }
 
 class QueryOrderByPriorityConstraint extends QueryConstraint {
-  readonly type: 'orderByPriority';
+  readonly type = 'orderByPriority';
 
   _apply<T>(query: QueryImpl): QueryImpl {
     validateNoPreviousOrderByCall(query, 'orderByPriority');
@@ -2149,7 +2149,7 @@ export function orderByPriority(): QueryConstraint {
 }
 
 class QueryOrderByValueConstraint extends QueryConstraint {
-  readonly type: 'orderByValue';
+  readonly type = 'orderByValue';
 
   _apply<T>(query: QueryImpl): QueryImpl {
     validateNoPreviousOrderByCall(query, 'orderByValue');
@@ -2178,7 +2178,7 @@ export function orderByValue(): QueryConstraint {
 }
 
 class QueryEqualToValueConstraint extends QueryConstraint {
-  readonly type: 'equalTo';
+  readonly type = 'equalTo';
 
   constructor(
     private readonly _value: number | string | boolean | null,

--- a/packages/database/test/queryconstraint.test.ts
+++ b/packages/database/test/queryconstraint.test.ts
@@ -54,7 +54,7 @@ describe('Query Constraints', () => {
       { qc: equalTo(''), name: 'equalTo' }
     ];
     queryConstraintTypes.forEach(({ qc, name }) => {
-        expect(qc.type).to.equal(name);
+      expect(qc.type).to.equal(name);
     });
   });
 });

--- a/packages/database/test/queryconstraint.test.ts
+++ b/packages/database/test/queryconstraint.test.ts
@@ -1,0 +1,60 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { expect } from 'chai';
+
+import {
+  endAt,
+  endBefore,
+  equalTo,
+  limitToFirst,
+  limitToLast,
+  orderByChild,
+  orderByKey,
+  orderByPriority,
+  orderByValue,
+  startAfter,
+  startAt
+} from '../src';
+
+import { createTestApp } from './exp/integration.test';
+
+describe('Query Constraints', () => {
+  let defaultApp;
+
+  beforeEach(() => {
+    defaultApp = createTestApp();
+  });
+  it('query constraint types are exposed', () => {
+    const queryConstraintTypes = [
+      { qc: endAt(0), name: 'endAt' },
+      { qc: endBefore(0), name: 'endBefore' },
+      { qc: startAt(0), name: 'startAt' },
+      { qc: startAfter(0), name: 'startAfter' },
+      { qc: limitToFirst(1), name: 'limitToFirst' },
+      { qc: limitToLast(1), name: 'limitToLast' },
+      { qc: orderByChild('a'), name: 'orderByChild' },
+      { qc: orderByKey(), name: 'orderByKey' },
+      { qc: orderByPriority(), name: 'orderByPriority' },
+      { qc: orderByValue(), name: 'orderByValue' },
+      { qc: equalTo(''), name: 'equalTo' }
+    ];
+    queryConstraintTypes.forEach(({ qc, name }) => {
+        expect(qc.type).to.equal(name);
+    });
+  });
+});


### PR DESCRIPTION
Fixes #7835. Originally, we set the type of `type` to be a string, but that didn't actually set the value of the property (`s/:/=`)