### PR TITLE
Catch transaction.done errors

### DIFF
--- a/.changeset/few-drinks-kiss.md
+++ b/.changeset/few-drinks-kiss.md
@@ -1,0 +1,5 @@
+---
+'@firebase/app': patch
+---
+
+Catch `transaction.done` errors in `readHeartbeatsFromIndexedDB` and log them as a warning, because platform logging errors should never throw or block user app functionality.

--- a/packages/app/src/indexeddb.ts
+++ b/packages/app/src/indexeddb.ts
@@ -70,9 +70,7 @@ export async function readHeartbeatsFromIndexedDB(
   try {
     const db = await getDbPromise();
     const tx = db.transaction(STORE_NAME);
-    const result = await tx
-      .objectStore(STORE_NAME)
-      .get(computeKey(app));
+    const result = await tx.objectStore(STORE_NAME).get(computeKey(app));
     // We already have the value but tx.done can throw,
     // so we need to await it here to catch errors
     await tx.done;

--- a/packages/app/src/indexeddb.ts
+++ b/packages/app/src/indexeddb.ts
@@ -69,10 +69,13 @@ export async function readHeartbeatsFromIndexedDB(
 ): Promise<HeartbeatsInIndexedDB | undefined> {
   try {
     const db = await getDbPromise();
-    const result = await db
-      .transaction(STORE_NAME)
+    const tx = db.transaction(STORE_NAME);
+    const result = await tx
       .objectStore(STORE_NAME)
       .get(computeKey(app));
+    // We already have the value but tx.done can throw,
+    // so we need to await it here to catch errors
+    await tx.done;
     return result;
   } catch (e) {
     if (e instanceof FirebaseError) {


### PR DESCRIPTION
The `idb` library we use has a `done` promise on all transactions, which can throw unhandled rejections. It must be included in all try/catch blocks in order to avoid an unhandled rejection.

This is part of the platform logging functionality, which should never throw or block user app functionality. This change ensures it will be caught along with all other transaction errors and converted to a `console.warn`.