### PR TITLE
update page-view links in analytics docs

### DIFF
--- a/docs-devsite/analytics.gtagconfigparams.md
+++ b/docs-devsite/analytics.gtagconfigparams.md
@@ -29,9 +29,9 @@ export interface GtagConfigParams
 |  [cookie\_flags](./analytics.gtagconfigparams.md#gtagconfigparamscookie_flags) | string | Appends additional flags to the cookie when set. See [Cookies and user identification](https://developers.google.com/analytics/devguides/collection/ga4/cookies-user-id) |
 |  [cookie\_prefix](./analytics.gtagconfigparams.md#gtagconfigparamscookie_prefix) | string | Defaults to <code>_ga</code>. See [Cookies and user identification](https://developers.google.com/analytics/devguides/collection/ga4/cookies-user-id) |
 |  [cookie\_update](./analytics.gtagconfigparams.md#gtagconfigparamscookie_update) | boolean | If set to true, will update cookies on each page load. Defaults to true. See [Cookies and user identification](https://developers.google.com/analytics/devguides/collection/ga4/cookies-user-id) |
-|  [page\_location](./analytics.gtagconfigparams.md#gtagconfigparamspage_location) | string | The URL of the page. See [Page views](https://developers.google.com/analytics/devguides/collection/ga4/page-view) |
-|  [page\_title](./analytics.gtagconfigparams.md#gtagconfigparamspage_title) | string | The title of the page. See [Page views](https://developers.google.com/analytics/devguides/collection/ga4/page-view) |
-|  [send\_page\_view](./analytics.gtagconfigparams.md#gtagconfigparamssend_page_view) | boolean | Whether or not a page view should be sent. If set to true (default), a page view is automatically sent upon initialization of analytics. See [Page views](https://developers.google.com/analytics/devguides/collection/ga4/page-view) |
+|  [page\_location](./analytics.gtagconfigparams.md#gtagconfigparamspage_location) | string | The URL of the page. See [Page views](https://developers.google.com/analytics/devguides/collection/ga4/views) |
+|  [page\_title](./analytics.gtagconfigparams.md#gtagconfigparamspage_title) | string | The title of the page. See [Page views](https://developers.google.com/analytics/devguides/collection/ga4/views) |
+|  [send\_page\_view](./analytics.gtagconfigparams.md#gtagconfigparamssend_page_view) | boolean | Whether or not a page view should be sent. If set to true (default), a page view is automatically sent upon initialization of analytics. See [Page views](https://developers.google.com/analytics/devguides/collection/ga4/views) |
 
 ## GtagConfigParams.allow\_ad\_personalization\_signals
 
@@ -105,7 +105,7 @@ If set to true, will update cookies on each page load. Defaults to true. See [Co
 
 ## GtagConfigParams.page\_location
 
-The URL of the page. See [Page views](https://developers.google.com/analytics/devguides/collection/ga4/page-view)
+The URL of the page. See [Page views](https://developers.google.com/analytics/devguides/collection/ga4/views)
 
 <b>Signature:</b>
 
@@ -115,7 +115,7 @@ The URL of the page. See [Page views](https://developers.google.com/analytics/de
 
 ## GtagConfigParams.page\_title
 
-The title of the page. See [Page views](https://developers.google.com/analytics/devguides/collection/ga4/page-view)
+The title of the page. See [Page views](https://developers.google.com/analytics/devguides/collection/ga4/views)
 
 <b>Signature:</b>
 
@@ -125,7 +125,7 @@ The title of the page. See [Page views](https://developers.google.com/analytics/
 
 ## GtagConfigParams.send\_page\_view
 
-Whether or not a page view should be sent. If set to true (default), a page view is automatically sent upon initialization of analytics. See [Page views](https://developers.google.com/analytics/devguides/collection/ga4/page-view)
+Whether or not a page view should be sent. If set to true (default), a page view is automatically sent upon initialization of analytics. See [Page views](https://developers.google.com/analytics/devguides/collection/ga4/views)
 
 <b>Signature:</b>
 

--- a/docs-devsite/analytics.md
+++ b/docs-devsite/analytics.md
@@ -42,7 +42,7 @@ The Firebase Analytics Web SDK. This SDK does not work in a Node.js environment.
 |  [logEvent(analyticsInstance, eventName, eventParams, options)](./analytics.md#logevent_800159e) | Sends a Google Analytics event with given <code>eventParams</code>. This method automatically associates this logged event with this Firebase web app instance on this device.<!-- -->See [Measure exceptions](https://developers.google.com/analytics/devguides/collection/ga4/exceptions)<!-- -->. |
 |  [logEvent(analyticsInstance, eventName, eventParams, options)](./analytics.md#logevent_9c11aa9) | Sends a Google Analytics event with given <code>eventParams</code>. This method automatically associates this logged event with this Firebase web app instance on this device.<!-- -->List of recommended event parameters can be found in [the GA4 reference documentation](https://developers.google.com/gtagjs/reference/ga4-events)<!-- -->. |
 |  [logEvent(analyticsInstance, eventName, eventParams, options)](./analytics.md#logevent_1f3f282) | Sends a Google Analytics event with given <code>eventParams</code>. This method automatically associates this logged event with this Firebase web app instance on this device.<!-- -->List of recommended event parameters can be found in [the GA4 reference documentation](https://developers.google.com/gtagjs/reference/ga4-events)<!-- -->. |
-|  [logEvent(analyticsInstance, eventName, eventParams, options)](./analytics.md#logevent_0792e28) | Sends a Google Analytics event with given <code>eventParams</code>. This method automatically associates this logged event with this Firebase web app instance on this device.<!-- -->See [Page views](https://developers.google.com/analytics/devguides/collection/ga4/page-view)<!-- -->. |
+|  [logEvent(analyticsInstance, eventName, eventParams, options)](./analytics.md#logevent_0792e28) | Sends a Google Analytics event with given <code>eventParams</code>. This method automatically associates this logged event with this Firebase web app instance on this device.<!-- -->See [Page views](https://developers.google.com/analytics/devguides/collection/ga4/views)<!-- -->. |
 |  [setAnalyticsCollectionEnabled(analyticsInstance, enabled)](./analytics.md#setanalyticscollectionenabled_494179c) | Sets whether Google Analytics collection is enabled for this app on this device. Sets global <code>window['ga-disable-analyticsId'] = true;</code> |
 |  [setCurrentScreen(analyticsInstance, screenName, options)](./analytics.md#setcurrentscreen_a6168fa) | Use gtag <code>config</code> command to set <code>screen_name</code>. |
 |  [setUserId(analyticsInstance, id, options)](./analytics.md#setuserid_86d82f6) | Use gtag <code>config</code> command to set <code>user_id</code>. |
@@ -780,7 +780,7 @@ void
 
 Sends a Google Analytics event with given `eventParams`<!-- -->. This method automatically associates this logged event with this Firebase web app instance on this device.
 
-See [Page views](https://developers.google.com/analytics/devguides/collection/ga4/page-view)<!-- -->.
+See [Page views](https://developers.google.com/analytics/devguides/collection/ga4/views)<!-- -->.
 
 <b>Signature:</b>
 

--- a/packages/analytics-types/index.d.ts
+++ b/packages/analytics-types/index.d.ts
@@ -197,7 +197,7 @@ export interface FirebaseAnalytics {
    * automatically associates this logged event with this Firebase web
    * app instance on this device.
    * See
-   * {@link https://developers.google.com/analytics/devguides/collection/ga4/page-view
+   * {@link https://developers.google.com/analytics/devguides/collection/ga4/views
    * | Page views}.
    */
   logEvent(

--- a/packages/analytics/src/api.ts
+++ b/packages/analytics/src/api.ts
@@ -441,7 +441,7 @@ export function logEvent(
  * app instance on this device.
  * @public
  * See
- * {@link https://developers.google.com/analytics/devguides/collection/ga4/page-view
+ * {@link https://developers.google.com/analytics/devguides/collection/ga4/views
  * | Page views}.
  */
 export function logEvent(

--- a/packages/analytics/src/public-types.ts
+++ b/packages/analytics/src/public-types.ts
@@ -27,17 +27,17 @@ export interface GtagConfigParams {
    * Whether or not a page view should be sent.
    * If set to true (default), a page view is automatically sent upon initialization
    * of analytics.
-   * See {@link https://developers.google.com/analytics/devguides/collection/ga4/page-view | Page views }
+   * See {@link https://developers.google.com/analytics/devguides/collection/ga4/views | Page views }
    */
   'send_page_view'?: boolean;
   /**
    * The title of the page.
-   * See {@link https://developers.google.com/analytics/devguides/collection/ga4/page-view | Page views }
+   * See {@link https://developers.google.com/analytics/devguides/collection/ga4/views | Page views }
    */
   'page_title'?: string;
   /**
    * The URL of the page.
-   * See {@link https://developers.google.com/analytics/devguides/collection/ga4/page-view | Page views }
+   * See {@link https://developers.google.com/analytics/devguides/collection/ga4/views | Page views }
    */
   'page_location'?: string;
   /**

--- a/packages/firebase/compat/index.d.ts
+++ b/packages/firebase/compat/index.d.ts
@@ -4959,7 +4959,7 @@ declare namespace firebase.analytics {
      * automatically associates this logged event with this Firebase web
      * app instance on this device.
      * See
-     * {@link https://developers.google.com/analytics/devguides/collection/ga4/page-view
+     * {@link https://developers.google.com/analytics/devguides/collection/ga4/views
      * | Page views}.
      */
     logEvent(


### PR DESCRIPTION
Old page-view page is gone. New page is https://developers.google.com/analytics/devguides/collection/ga4/views