### PR TITLE
[SeverApp] Restrict certain auth operations

### DIFF
--- a/docs-devsite/auth.auth.md
+++ b/docs-devsite/auth.auth.md
@@ -42,7 +42,7 @@ export interface Auth
 |  [onAuthStateChanged(nextOrObserver, error, completed)](./auth.auth.md#authonauthstatechanged) | Adds an observer for changes to the user's sign-in state. |
 |  [onIdTokenChanged(nextOrObserver, error, completed)](./auth.auth.md#authonidtokenchanged) | Adds an observer for changes to the signed-in user's ID token. |
 |  [setPersistence(persistence)](./auth.auth.md#authsetpersistence) | Changes the type of persistence on the <code>Auth</code> instance. |
-|  [signOut()](./auth.auth.md#authsignout) | Signs out the current user. This does not automatically revoke the user's ID token. |
+|  [signOut()](./auth.auth.md#authsignout) | Signs out the current user. This does not automatically revoke the user's ID token.<!-- -->Note: This method is not supported by [Auth](./auth.auth.md#auth_interface) instances created with a . |
 |  [updateCurrentUser(user)](./auth.auth.md#authupdatecurrentuser) | Asynchronously sets the provided user as [Auth.currentUser](./auth.auth.md#authcurrentuser) on the [Auth](./auth.auth.md#auth_interface) instance. |
 |  [useDeviceLanguage()](./auth.auth.md#authusedevicelanguage) | Sets the current language to the default device/browser preference. |
 
@@ -264,6 +264,8 @@ auth.setPersistence(browserSessionPersistence);
 ## Auth.signOut()
 
 Signs out the current user. This does not automatically revoke the user's ID token.
+
+Note: This method is not supported by [Auth](./auth.auth.md#auth_interface) instances created with a .
 
 <b>Signature:</b>
 

--- a/docs-devsite/auth.auth.md
+++ b/docs-devsite/auth.auth.md
@@ -42,7 +42,7 @@ export interface Auth
 |  [onAuthStateChanged(nextOrObserver, error, completed)](./auth.auth.md#authonauthstatechanged) | Adds an observer for changes to the user's sign-in state. |
 |  [onIdTokenChanged(nextOrObserver, error, completed)](./auth.auth.md#authonidtokenchanged) | Adds an observer for changes to the signed-in user's ID token. |
 |  [setPersistence(persistence)](./auth.auth.md#authsetpersistence) | Changes the type of persistence on the <code>Auth</code> instance. |
-|  [signOut()](./auth.auth.md#authsignout) | Signs out the current user. This does not automatically revoke the user's ID token.<!-- -->Note: This method is not supported by [Auth](./auth.auth.md#auth_interface) instances created with a . |
+|  [signOut()](./auth.auth.md#authsignout) | Signs out the current user. This does not automatically revoke the user's ID token.<!-- -->Note: This method is not supported by [Auth](./auth.auth.md#auth_interface) instances created with a [FirebaseServerApp](./app.firebaseserverapp.md#firebaseserverapp_interface)<!-- -->. |
 |  [updateCurrentUser(user)](./auth.auth.md#authupdatecurrentuser) | Asynchronously sets the provided user as [Auth.currentUser](./auth.auth.md#authcurrentuser) on the [Auth](./auth.auth.md#auth_interface) instance. |
 |  [useDeviceLanguage()](./auth.auth.md#authusedevicelanguage) | Sets the current language to the default device/browser preference. |
 
@@ -265,7 +265,7 @@ auth.setPersistence(browserSessionPersistence);
 
 Signs out the current user. This does not automatically revoke the user's ID token.
 
-Note: This method is not supported by [Auth](./auth.auth.md#auth_interface) instances created with a .
+Note: This method is not supported by [Auth](./auth.auth.md#auth_interface) instances created with a [FirebaseServerApp](./app.firebaseserverapp.md#firebaseserverapp_interface)<!-- -->.
 
 <b>Signature:</b>
 

--- a/docs-devsite/auth.auth.md
+++ b/docs-devsite/auth.auth.md
@@ -42,7 +42,7 @@ export interface Auth
 |  [onAuthStateChanged(nextOrObserver, error, completed)](./auth.auth.md#authonauthstatechanged) | Adds an observer for changes to the user's sign-in state. |
 |  [onIdTokenChanged(nextOrObserver, error, completed)](./auth.auth.md#authonidtokenchanged) | Adds an observer for changes to the signed-in user's ID token. |
 |  [setPersistence(persistence)](./auth.auth.md#authsetpersistence) | Changes the type of persistence on the <code>Auth</code> instance. |
-|  [signOut()](./auth.auth.md#authsignout) | Signs out the current user. This does not automatically revoke the user's ID token.<!-- -->Note: This method is not supported by [Auth](./auth.auth.md#auth_interface) instances created with a [FirebaseServerApp](./app.firebaseserverapp.md#firebaseserverapp_interface)<!-- -->. |
+|  [signOut()](./auth.auth.md#authsignout) | Signs out the current user. This does not automatically revoke the user's ID token. |
 |  [updateCurrentUser(user)](./auth.auth.md#authupdatecurrentuser) | Asynchronously sets the provided user as [Auth.currentUser](./auth.auth.md#authcurrentuser) on the [Auth](./auth.auth.md#auth_interface) instance. |
 |  [useDeviceLanguage()](./auth.auth.md#authusedevicelanguage) | Sets the current language to the default device/browser preference. |
 
@@ -265,7 +265,7 @@ auth.setPersistence(browserSessionPersistence);
 
 Signs out the current user. This does not automatically revoke the user's ID token.
 
-Note: This method is not supported by [Auth](./auth.auth.md#auth_interface) instances created with a [FirebaseServerApp](./app.firebaseserverapp.md#firebaseserverapp_interface)<!-- -->.
+This method is not supported by [Auth](./auth.auth.md#auth_interface) instances created with a [FirebaseServerApp](./app.firebaseserverapp.md#firebaseserverapp_interface)<!-- -->.
 
 <b>Signature:</b>
 

--- a/docs-devsite/auth.md
+++ b/docs-devsite/auth.md
@@ -1648,6 +1648,8 @@ Updates the user's email address.
 
 An email will be sent to the original email address (if it was set) that allows to revoke the email address change, in order to protect them from account hijacking.
 
+This method is not supported on any [User](./auth.user.md#user_interface) signed in by [Auth](./auth.auth.md#auth_interface) instances created with a [FirebaseServerApp](./app.firebaseserverapp.md#firebaseserverapp_interface)<!-- -->.
+
 Important: this is a security sensitive operation that requires the user to have recently signed in. If this requirement isn't met, ask the user to authenticate again and then call [reauthenticateWithCredential()](./auth.md#reauthenticatewithcredential_60f8043)<!-- -->.
 
 <b>Signature:</b>

--- a/docs-devsite/auth.md
+++ b/docs-devsite/auth.md
@@ -1427,7 +1427,7 @@ Re-authenticates a user using a fresh credential.
 
 Use before operations such as [updatePassword()](./auth.md#updatepassword_6df673e) that require tokens from recent sign-in attempts. This method can be used to recover from a `CREDENTIAL_TOO_OLD_LOGIN_AGAIN` error or a `TOKEN_EXPIRED` error.
 
-This method is not supported by [Auth](./auth.auth.md#auth_interface) instances created with a [FirebaseServerApp](./app.firebaseserverapp.md#firebaseserverapp_interface)<!-- -->.
+This method is not supported on any [User](./auth.user.md#user_interface) signed in by [Auth](./auth.auth.md#auth_interface) instances created with a [FirebaseServerApp](./app.firebaseserverapp.md#firebaseserverapp_interface)<!-- -->.
 
 <b>Signature:</b>
 
@@ -1452,7 +1452,7 @@ Re-authenticates a user using a fresh phone credential.
 
 Use before operations such as [updatePassword()](./auth.md#updatepassword_6df673e) that require tokens from recent sign-in attempts.
 
-This method does not work in a Node.js environment or with [Auth](./auth.auth.md#auth_interface) instances created with a [FirebaseServerApp](./app.firebaseserverapp.md#firebaseserverapp_interface)<!-- -->.
+This method does not work in a Node.js environment or on any [User](./auth.user.md#user_interface) signed in by [Auth](./auth.auth.md#auth_interface) instances created with a [FirebaseServerApp](./app.firebaseserverapp.md#firebaseserverapp_interface)<!-- -->.
 
 <b>Signature:</b>
 
@@ -1478,7 +1478,7 @@ Reauthenticates the current user with the specified [OAuthProvider](./auth.oauth
 
 If the reauthentication is successful, the returned result will contain the user and the provider's credential.
 
-This method does not work in a Node.js environment or with [Auth](./auth.auth.md#auth_interface) instances created with a [FirebaseServerApp](./app.firebaseserverapp.md#firebaseserverapp_interface)<!-- -->.
+This method does not work in a Node.js environment or on any [User](./auth.user.md#user_interface) signed in by [Auth](./auth.auth.md#auth_interface) instances created with a [FirebaseServerApp](./app.firebaseserverapp.md#firebaseserverapp_interface)<!-- -->.
 
 <b>Signature:</b>
 
@@ -1694,7 +1694,7 @@ Promise&lt;void&gt;
 
 Updates the user's phone number.
 
-This method does not work in a Node.js environment or with [Auth](./auth.auth.md#auth_interface) instances created with a [FirebaseServerApp](./app.firebaseserverapp.md#firebaseserverapp_interface)<!-- -->.
+This method does not work in a Node.js environment or on any [User](./auth.user.md#user_interface) signed in by [Auth](./auth.auth.md#auth_interface) instances created with a [FirebaseServerApp](./app.firebaseserverapp.md#firebaseserverapp_interface)<!-- -->.
 
 <b>Signature:</b>
 

--- a/docs-devsite/auth.md
+++ b/docs-devsite/auth.md
@@ -47,7 +47,7 @@ Firebase Authentication
 |  [signInWithPhoneNumber(auth, phoneNumber, appVerifier)](./auth.md#signinwithphonenumber_75b2560) | Asynchronously signs in using a phone number. |
 |  [signInWithPopup(auth, provider, resolver)](./auth.md#signinwithpopup_770f816) | Authenticates a Firebase client using a popup-based OAuth authentication flow. |
 |  [signInWithRedirect(auth, provider, resolver)](./auth.md#signinwithredirect_770f816) | Authenticates a Firebase client using a full-page redirect flow. |
-|  [signOut(auth)](./auth.md#signout_2a61ea7) | Signs out the current user.<!-- -->Note: This method is not supported by [Auth](./auth.auth.md#auth_interface) instances created with a . |
+|  [signOut(auth)](./auth.md#signout_2a61ea7) | Signs out the current user.<!-- -->Note: This method is not supported by [Auth](./auth.auth.md#auth_interface) instances created with a [FirebaseServerApp](./app.firebaseserverapp.md#firebaseserverapp_interface)<!-- -->. |
 |  [updateCurrentUser(auth, user)](./auth.md#updatecurrentuser_9d96fff) | Asynchronously sets the provided user as [Auth.currentUser](./auth.auth.md#authcurrentuser) on the [Auth](./auth.auth.md#auth_interface) instance. |
 |  [useDeviceLanguage(auth)](./auth.md#usedevicelanguage_2a61ea7) | Sets the current language to the default device/browser preference. |
 |  [validatePassword(auth, password)](./auth.md#validatepassword_4dc4ad2) | Validates the password against the password policy configured for the project or tenant. |
@@ -383,7 +383,7 @@ User account creation can fail if the account already exists or the password is 
 
 Note: The email address acts as a unique identifier for the user and enables an email-based password reset. This function will create a new user account and set the initial user password.
 
-Note: This method is not supported on [Auth](./auth.auth.md#auth_interface) instances created with a .
+Note: This method is not supported on [Auth](./auth.auth.md#auth_interface) instances created with a [FirebaseServerApp](./app.firebaseserverapp.md#firebaseserverapp_interface)<!-- -->.
 
 <b>Signature:</b>
 
@@ -453,7 +453,7 @@ Returns a [UserCredential](./auth.usercredential.md#usercredential_interface) fr
 
 If sign-in succeeded, returns the signed in user. If sign-in was unsuccessful, fails with an error. If no redirect operation was called, returns `null`<!-- -->.
 
-This method does not work in a Node.js environment or with [Auth](./auth.auth.md#auth_interface) instances created with a .
+This method does not work in a Node.js environment or with [Auth](./auth.auth.md#auth_interface) instances created with a [FirebaseServerApp](./app.firebaseserverapp.md#firebaseserverapp_interface)<!-- -->.
 
 <b>Signature:</b>
 
@@ -730,7 +730,7 @@ Changes the type of persistence on the [Auth](./auth.auth.md#auth_interface) ins
 
 This makes it easy for a user signing in to specify whether their session should be remembered or not. It also makes it easier to never persist the `Auth` state for applications that are shared by other users or have sensitive data.
 
-This method does not work in a Node.js environment or with [Auth](./auth.auth.md#auth_interface) instances created with a .
+This method does not work in a Node.js environment or with [Auth](./auth.auth.md#auth_interface) instances created with a [FirebaseServerApp](./app.firebaseserverapp.md#firebaseserverapp_interface)<!-- -->.
 
 <b>Signature:</b>
 
@@ -765,7 +765,7 @@ Asynchronously signs in as an anonymous user.
 
 If there is already an anonymous user signed in, that user will be returned; otherwise, a new anonymous user identity will be created and returned.
 
-Note: This method is not supported by [Auth](./auth.auth.md#auth_interface) instances created with a .
+Note: This method is not supported by [Auth](./auth.auth.md#auth_interface) instances created with a [FirebaseServerApp](./app.firebaseserverapp.md#firebaseserverapp_interface)<!-- -->.
 
 <b>Signature:</b>
 
@@ -789,7 +789,7 @@ Asynchronously signs in with the given credentials.
 
 An [AuthProvider](./auth.authprovider.md#authprovider_interface) can be used to generate the credential.
 
-Note: This method is not supported by [Auth](./auth.auth.md#auth_interface) instances created with a .
+Note: This method is not supported by [Auth](./auth.auth.md#auth_interface) instances created with a [FirebaseServerApp](./app.firebaseserverapp.md#firebaseserverapp_interface)<!-- -->.
 
 <b>Signature:</b>
 
@@ -816,7 +816,7 @@ Custom tokens are used to integrate Firebase Auth with existing auth systems, an
 
 Fails with an error if the token is invalid, expired, or not accepted by the Firebase Auth service.
 
-Note: This method is not supported by [Auth](./auth.auth.md#auth_interface) instances created with a .
+Note: This method is not supported by [Auth](./auth.auth.md#auth_interface) instances created with a [FirebaseServerApp](./app.firebaseserverapp.md#firebaseserverapp_interface)<!-- -->.
 
 <b>Signature:</b>
 
@@ -843,7 +843,7 @@ Fails with an error if the email address and password do not match. When \[Email
 
 Note: The user's password is NOT the password used to access the user's email account. The email address serves as a unique identifier for the user, and the password is used to access the user's account in your Firebase project. See also: [createUserWithEmailAndPassword()](./auth.md#createuserwithemailandpassword_21ad33b)<!-- -->.
 
-Note: This method is not supported on [Auth](./auth.auth.md#auth_interface) instances created with a .
+Note: This method is not supported on [Auth](./auth.auth.md#auth_interface) instances created with a [FirebaseServerApp](./app.firebaseserverapp.md#firebaseserverapp_interface)<!-- -->.
 
 <b>Signature:</b>
 
@@ -873,7 +873,7 @@ Fails with an error if the email address is invalid or OTP in email link expires
 
 Note: Confirm the link is a sign-in email link before calling this method firebase.auth.Auth.isSignInWithEmailLink.
 
-Note: This method is not supported by [Auth](./auth.auth.md#auth_interface) instances created with a .
+Note: This method is not supported by [Auth](./auth.auth.md#auth_interface) instances created with a [FirebaseServerApp](./app.firebaseserverapp.md#firebaseserverapp_interface)<!-- -->.
 
 <b>Signature:</b>
 
@@ -925,7 +925,7 @@ This method sends a code via SMS to the given phone number, and returns a [Confi
 
 For abuse prevention, this method also requires a [ApplicationVerifier](./auth.applicationverifier.md#applicationverifier_interface)<!-- -->. This SDK includes a reCAPTCHA-based implementation, [RecaptchaVerifier](./auth.recaptchaverifier.md#recaptchaverifier_class)<!-- -->. This function can work on other platforms that do not support the [RecaptchaVerifier](./auth.recaptchaverifier.md#recaptchaverifier_class) (like React Native), but you need to use a third-party [ApplicationVerifier](./auth.applicationverifier.md#applicationverifier_interface) implementation.
 
-This method does not work in a Node.js environment or with [Auth](./auth.auth.md#auth_interface) instances created with a .
+This method does not work in a Node.js environment or with [Auth](./auth.auth.md#auth_interface) instances created with a [FirebaseServerApp](./app.firebaseserverapp.md#firebaseserverapp_interface)<!-- -->.
 
 <b>Signature:</b>
 
@@ -963,7 +963,7 @@ Authenticates a Firebase client using a popup-based OAuth authentication flow.
 
 If succeeds, returns the signed in user along with the provider's credential. If sign in was unsuccessful, returns an error object containing additional information about the error.
 
-This method does not work in a Node.js environment or with [Auth](./auth.auth.md#auth_interface) instances created with a .
+This method does not work in a Node.js environment or with [Auth](./auth.auth.md#auth_interface) instances created with a [FirebaseServerApp](./app.firebaseserverapp.md#firebaseserverapp_interface)<!-- -->.
 
 <b>Signature:</b>
 
@@ -1005,7 +1005,7 @@ Authenticates a Firebase client using a full-page redirect flow.
 
 To handle the results and errors for this operation, refer to [getRedirectResult()](./auth.md#getredirectresult_c35dc1f)<!-- -->. Follow the [best practices](https://firebase.google.com/docs/auth/web/redirect-best-practices) when using [signInWithRedirect()](./auth.md#signinwithredirect_770f816)<!-- -->.
 
-This method does not work in a Node.js environment or with [Auth](./auth.auth.md#auth_interface) instances created with a .
+This method does not work in a Node.js environment or with [Auth](./auth.auth.md#auth_interface) instances created with a [FirebaseServerApp](./app.firebaseserverapp.md#firebaseserverapp_interface)<!-- -->.
 
 <b>Signature:</b>
 
@@ -1057,7 +1057,7 @@ const operationType = result.operationType;
 
 Signs out the current user.
 
-Note: This method is not supported by [Auth](./auth.auth.md#auth_interface) instances created with a .
+Note: This method is not supported by [Auth](./auth.auth.md#auth_interface) instances created with a [FirebaseServerApp](./app.firebaseserverapp.md#firebaseserverapp_interface)<!-- -->.
 
 <b>Signature:</b>
 
@@ -1085,7 +1085,7 @@ This will trigger [onAuthStateChanged()](./auth.md#onauthstatechanged_b0d07ab) a
 
 The operation fails with an error if the user to be updated belongs to a different Firebase project.
 
-Note: This method is not supported by [Auth](./auth.auth.md#auth_interface) instances created with a .
+Note: This method is not supported by [Auth](./auth.auth.md#auth_interface) instances created with a [FirebaseServerApp](./app.firebaseserverapp.md#firebaseserverapp_interface)<!-- -->.
 
 <b>Signature:</b>
 
@@ -1363,7 +1363,7 @@ Links the [OAuthProvider](./auth.oauthprovider.md#oauthprovider_class) to the us
 
 To handle the results and errors for this operation, refer to [getRedirectResult()](./auth.md#getredirectresult_c35dc1f)<!-- -->. Follow the [best practices](https://firebase.google.com/docs/auth/web/redirect-best-practices) when using [linkWithRedirect()](./auth.md#linkwithredirect_41c0b31)<!-- -->.
 
-This method does not work in a Node.js environment or with [Auth](./auth.auth.md#auth_interface) instances created with a .
+This method does not work in a Node.js environment or with [Auth](./auth.auth.md#auth_interface) instances created with a [FirebaseServerApp](./app.firebaseserverapp.md#firebaseserverapp_interface)<!-- -->.
 
 <b>Signature:</b>
 
@@ -1427,7 +1427,7 @@ Re-authenticates a user using a fresh credential.
 
 Use before operations such as [updatePassword()](./auth.md#updatepassword_6df673e) that require tokens from recent sign-in attempts. This method can be used to recover from a `CREDENTIAL_TOO_OLD_LOGIN_AGAIN` error or a `TOKEN_EXPIRED` error.
 
-Note: This method is not supported by [Auth](./auth.auth.md#auth_interface) instances created with a .
+Note: This method is not supported by [Auth](./auth.auth.md#auth_interface) instances created with a [FirebaseServerApp](./app.firebaseserverapp.md#firebaseserverapp_interface)<!-- -->.
 
 <b>Signature:</b>
 
@@ -1452,7 +1452,7 @@ Re-authenticates a user using a fresh phone credential.
 
 Use before operations such as [updatePassword()](./auth.md#updatepassword_6df673e) that require tokens from recent sign-in attempts.
 
-This method does not work in a Node.js environment or with [Auth](./auth.auth.md#auth_interface) instances created with a .
+This method does not work in a Node.js environment or with [Auth](./auth.auth.md#auth_interface) instances created with a [FirebaseServerApp](./app.firebaseserverapp.md#firebaseserverapp_interface)<!-- -->.
 
 <b>Signature:</b>
 
@@ -1478,7 +1478,7 @@ Reauthenticates the current user with the specified [OAuthProvider](./auth.oauth
 
 If the reauthentication is successful, the returned result will contain the user and the provider's credential.
 
-This method does not work in a Node.js environment or with [Auth](./auth.auth.md#auth_interface) instances created with a .
+This method does not work in a Node.js environment or with [Auth](./auth.auth.md#auth_interface) instances created with a [FirebaseServerApp](./app.firebaseserverapp.md#firebaseserverapp_interface)<!-- -->.
 
 <b>Signature:</b>
 
@@ -1516,7 +1516,7 @@ Reauthenticates the current user with the specified [OAuthProvider](./auth.oauth
 
 To handle the results and errors for this operation, refer to [getRedirectResult()](./auth.md#getredirectresult_c35dc1f)<!-- -->. Follow the [best practices](https://firebase.google.com/docs/auth/web/redirect-best-practices) when using [reauthenticateWithRedirect()](./auth.md#reauthenticatewithredirect_41c0b31)<!-- -->.
 
-This method does not work in a Node.js environment or with [Auth](./auth.auth.md#auth_interface) instances created with a .
+This method does not work in a Node.js environment or with [Auth](./auth.auth.md#auth_interface) instances created with a [FirebaseServerApp](./app.firebaseserverapp.md#firebaseserverapp_interface)<!-- -->.
 
 <b>Signature:</b>
 
@@ -1694,7 +1694,7 @@ Promise&lt;void&gt;
 
 Updates the user's phone number.
 
-This method does not work in a Node.js environment or with [Auth](./auth.auth.md#auth_interface) instances created with a .
+This method does not work in a Node.js environment or with [Auth](./auth.auth.md#auth_interface) instances created with a [FirebaseServerApp](./app.firebaseserverapp.md#firebaseserverapp_interface)<!-- -->.
 
 <b>Signature:</b>
 

--- a/docs-devsite/auth.md
+++ b/docs-devsite/auth.md
@@ -47,7 +47,7 @@ Firebase Authentication
 |  [signInWithPhoneNumber(auth, phoneNumber, appVerifier)](./auth.md#signinwithphonenumber_75b2560) | Asynchronously signs in using a phone number. |
 |  [signInWithPopup(auth, provider, resolver)](./auth.md#signinwithpopup_770f816) | Authenticates a Firebase client using a popup-based OAuth authentication flow. |
 |  [signInWithRedirect(auth, provider, resolver)](./auth.md#signinwithredirect_770f816) | Authenticates a Firebase client using a full-page redirect flow. |
-|  [signOut(auth)](./auth.md#signout_2a61ea7) | Signs out the current user. |
+|  [signOut(auth)](./auth.md#signout_2a61ea7) | Signs out the current user.<!-- -->Note: This method is not supported by [Auth](./auth.auth.md#auth_interface) instances created with a . |
 |  [updateCurrentUser(auth, user)](./auth.md#updatecurrentuser_9d96fff) | Asynchronously sets the provided user as [Auth.currentUser](./auth.auth.md#authcurrentuser) on the [Auth](./auth.auth.md#auth_interface) instance. |
 |  [useDeviceLanguage(auth)](./auth.md#usedevicelanguage_2a61ea7) | Sets the current language to the default device/browser preference. |
 |  [validatePassword(auth, password)](./auth.md#validatepassword_4dc4ad2) | Validates the password against the password policy configured for the project or tenant. |
@@ -383,6 +383,8 @@ User account creation can fail if the account already exists or the password is 
 
 Note: The email address acts as a unique identifier for the user and enables an email-based password reset. This function will create a new user account and set the initial user password.
 
+Note: This method is not supported on [Auth](./auth.auth.md#auth_interface) instances created with a .
+
 <b>Signature:</b>
 
 ```typescript
@@ -451,7 +453,7 @@ Returns a [UserCredential](./auth.usercredential.md#usercredential_interface) fr
 
 If sign-in succeeded, returns the signed in user. If sign-in was unsuccessful, fails with an error. If no redirect operation was called, returns `null`<!-- -->.
 
-This method does not work in a Node.js environment.
+This method does not work in a Node.js environment or with [Auth](./auth.auth.md#auth_interface) instances created with a .
 
 <b>Signature:</b>
 
@@ -728,7 +730,7 @@ Changes the type of persistence on the [Auth](./auth.auth.md#auth_interface) ins
 
 This makes it easy for a user signing in to specify whether their session should be remembered or not. It also makes it easier to never persist the `Auth` state for applications that are shared by other users or have sensitive data.
 
-This method does not work in a Node.js environment.
+This method does not work in a Node.js environment or with [Auth](./auth.auth.md#auth_interface) instances created with a .
 
 <b>Signature:</b>
 
@@ -763,6 +765,8 @@ Asynchronously signs in as an anonymous user.
 
 If there is already an anonymous user signed in, that user will be returned; otherwise, a new anonymous user identity will be created and returned.
 
+Note: This method is not supported by [Auth](./auth.auth.md#auth_interface) instances created with a .
+
 <b>Signature:</b>
 
 ```typescript
@@ -784,6 +788,8 @@ Promise&lt;[UserCredential](./auth.usercredential.md#usercredential_interface)<!
 Asynchronously signs in with the given credentials.
 
 An [AuthProvider](./auth.authprovider.md#authprovider_interface) can be used to generate the credential.
+
+Note: This method is not supported by [Auth](./auth.auth.md#auth_interface) instances created with a .
 
 <b>Signature:</b>
 
@@ -810,6 +816,8 @@ Custom tokens are used to integrate Firebase Auth with existing auth systems, an
 
 Fails with an error if the token is invalid, expired, or not accepted by the Firebase Auth service.
 
+Note: This method is not supported by [Auth](./auth.auth.md#auth_interface) instances created with a .
+
 <b>Signature:</b>
 
 ```typescript
@@ -834,6 +842,8 @@ Asynchronously signs in using an email and password.
 Fails with an error if the email address and password do not match. When \[Email Enumeration Protection\](https://cloud.google.com/identity-platform/docs/admin/email-enumeration-protection) is enabled, this method fails with "auth/invalid-credential" in case of an invalid email/password.
 
 Note: The user's password is NOT the password used to access the user's email account. The email address serves as a unique identifier for the user, and the password is used to access the user's account in your Firebase project. See also: [createUserWithEmailAndPassword()](./auth.md#createuserwithemailandpassword_21ad33b)<!-- -->.
+
+Note: This method is not supported on [Auth](./auth.auth.md#auth_interface) instances created with a .
 
 <b>Signature:</b>
 
@@ -862,6 +872,8 @@ If no link is passed, the link is inferred from the current URL.
 Fails with an error if the email address is invalid or OTP in email link expires.
 
 Note: Confirm the link is a sign-in email link before calling this method firebase.auth.Auth.isSignInWithEmailLink.
+
+Note: This method is not supported by [Auth](./auth.auth.md#auth_interface) instances created with a .
 
 <b>Signature:</b>
 
@@ -913,7 +925,7 @@ This method sends a code via SMS to the given phone number, and returns a [Confi
 
 For abuse prevention, this method also requires a [ApplicationVerifier](./auth.applicationverifier.md#applicationverifier_interface)<!-- -->. This SDK includes a reCAPTCHA-based implementation, [RecaptchaVerifier](./auth.recaptchaverifier.md#recaptchaverifier_class)<!-- -->. This function can work on other platforms that do not support the [RecaptchaVerifier](./auth.recaptchaverifier.md#recaptchaverifier_class) (like React Native), but you need to use a third-party [ApplicationVerifier](./auth.applicationverifier.md#applicationverifier_interface) implementation.
 
-This method does not work in a Node.js environment.
+This method does not work in a Node.js environment or with [Auth](./auth.auth.md#auth_interface) instances created with a .
 
 <b>Signature:</b>
 
@@ -951,7 +963,7 @@ Authenticates a Firebase client using a popup-based OAuth authentication flow.
 
 If succeeds, returns the signed in user along with the provider's credential. If sign in was unsuccessful, returns an error object containing additional information about the error.
 
-This method does not work in a Node.js environment.
+This method does not work in a Node.js environment or with [Auth](./auth.auth.md#auth_interface) instances created with a .
 
 <b>Signature:</b>
 
@@ -993,7 +1005,7 @@ Authenticates a Firebase client using a full-page redirect flow.
 
 To handle the results and errors for this operation, refer to [getRedirectResult()](./auth.md#getredirectresult_c35dc1f)<!-- -->. Follow the [best practices](https://firebase.google.com/docs/auth/web/redirect-best-practices) when using [signInWithRedirect()](./auth.md#signinwithredirect_770f816)<!-- -->.
 
-This method does not work in a Node.js environment.
+This method does not work in a Node.js environment or with [Auth](./auth.auth.md#auth_interface) instances created with a .
 
 <b>Signature:</b>
 
@@ -1045,6 +1057,8 @@ const operationType = result.operationType;
 
 Signs out the current user.
 
+Note: This method is not supported by [Auth](./auth.auth.md#auth_interface) instances created with a .
+
 <b>Signature:</b>
 
 ```typescript
@@ -1070,6 +1084,8 @@ A new instance copy of the user provided will be made and set as currentUser.
 This will trigger [onAuthStateChanged()](./auth.md#onauthstatechanged_b0d07ab) and [onIdTokenChanged()](./auth.md#onidtokenchanged_b0d07ab) listeners like other sign in methods.
 
 The operation fails with an error if the user to be updated belongs to a different Firebase project.
+
+Note: This method is not supported by [Auth](./auth.auth.md#auth_interface) instances created with a .
 
 <b>Signature:</b>
 
@@ -1347,7 +1363,7 @@ Links the [OAuthProvider](./auth.oauthprovider.md#oauthprovider_class) to the us
 
 To handle the results and errors for this operation, refer to [getRedirectResult()](./auth.md#getredirectresult_c35dc1f)<!-- -->. Follow the [best practices](https://firebase.google.com/docs/auth/web/redirect-best-practices) when using [linkWithRedirect()](./auth.md#linkwithredirect_41c0b31)<!-- -->.
 
-This method does not work in a Node.js environment.
+This method does not work in a Node.js environment or with [Auth](./auth.auth.md#auth_interface) instances created with a .
 
 <b>Signature:</b>
 
@@ -1411,6 +1427,8 @@ Re-authenticates a user using a fresh credential.
 
 Use before operations such as [updatePassword()](./auth.md#updatepassword_6df673e) that require tokens from recent sign-in attempts. This method can be used to recover from a `CREDENTIAL_TOO_OLD_LOGIN_AGAIN` error or a `TOKEN_EXPIRED` error.
 
+Note: This method is not supported by [Auth](./auth.auth.md#auth_interface) instances created with a .
+
 <b>Signature:</b>
 
 ```typescript
@@ -1434,7 +1452,7 @@ Re-authenticates a user using a fresh phone credential.
 
 Use before operations such as [updatePassword()](./auth.md#updatepassword_6df673e) that require tokens from recent sign-in attempts.
 
-This method does not work in a Node.js environment.
+This method does not work in a Node.js environment or with [Auth](./auth.auth.md#auth_interface) instances created with a .
 
 <b>Signature:</b>
 
@@ -1460,7 +1478,7 @@ Reauthenticates the current user with the specified [OAuthProvider](./auth.oauth
 
 If the reauthentication is successful, the returned result will contain the user and the provider's credential.
 
-This method does not work in a Node.js environment.
+This method does not work in a Node.js environment or with [Auth](./auth.auth.md#auth_interface) instances created with a .
 
 <b>Signature:</b>
 
@@ -1498,7 +1516,7 @@ Reauthenticates the current user with the specified [OAuthProvider](./auth.oauth
 
 To handle the results and errors for this operation, refer to [getRedirectResult()](./auth.md#getredirectresult_c35dc1f)<!-- -->. Follow the [best practices](https://firebase.google.com/docs/auth/web/redirect-best-practices) when using [reauthenticateWithRedirect()](./auth.md#reauthenticatewithredirect_41c0b31)<!-- -->.
 
-This method does not work in a Node.js environment.
+This method does not work in a Node.js environment or with [Auth](./auth.auth.md#auth_interface) instances created with a .
 
 <b>Signature:</b>
 
@@ -1676,7 +1694,7 @@ Promise&lt;void&gt;
 
 Updates the user's phone number.
 
-This method does not work in a Node.js environment.
+This method does not work in a Node.js environment or with [Auth](./auth.auth.md#auth_interface) instances created with a .
 
 <b>Signature:</b>
 

--- a/docs-devsite/auth.md
+++ b/docs-devsite/auth.md
@@ -47,7 +47,7 @@ Firebase Authentication
 |  [signInWithPhoneNumber(auth, phoneNumber, appVerifier)](./auth.md#signinwithphonenumber_75b2560) | Asynchronously signs in using a phone number. |
 |  [signInWithPopup(auth, provider, resolver)](./auth.md#signinwithpopup_770f816) | Authenticates a Firebase client using a popup-based OAuth authentication flow. |
 |  [signInWithRedirect(auth, provider, resolver)](./auth.md#signinwithredirect_770f816) | Authenticates a Firebase client using a full-page redirect flow. |
-|  [signOut(auth)](./auth.md#signout_2a61ea7) | Signs out the current user.<!-- -->Note: This method is not supported by [Auth](./auth.auth.md#auth_interface) instances created with a [FirebaseServerApp](./app.firebaseserverapp.md#firebaseserverapp_interface)<!-- -->. |
+|  [signOut(auth)](./auth.md#signout_2a61ea7) | Signs out the current user. |
 |  [updateCurrentUser(auth, user)](./auth.md#updatecurrentuser_9d96fff) | Asynchronously sets the provided user as [Auth.currentUser](./auth.auth.md#authcurrentuser) on the [Auth](./auth.auth.md#auth_interface) instance. |
 |  [useDeviceLanguage(auth)](./auth.md#usedevicelanguage_2a61ea7) | Sets the current language to the default device/browser preference. |
 |  [validatePassword(auth, password)](./auth.md#validatepassword_4dc4ad2) | Validates the password against the password policy configured for the project or tenant. |
@@ -381,9 +381,9 @@ On successful creation of the user account, this user will also be signed in to 
 
 User account creation can fail if the account already exists or the password is invalid.
 
-Note: The email address acts as a unique identifier for the user and enables an email-based password reset. This function will create a new user account and set the initial user password.
+This method is not supported on [Auth](./auth.auth.md#auth_interface) instances created with a [FirebaseServerApp](./app.firebaseserverapp.md#firebaseserverapp_interface)<!-- -->.
 
-Note: This method is not supported on [Auth](./auth.auth.md#auth_interface) instances created with a [FirebaseServerApp](./app.firebaseserverapp.md#firebaseserverapp_interface)<!-- -->.
+Note: The email address acts as a unique identifier for the user and enables an email-based password reset. This function will create a new user account and set the initial user password.
 
 <b>Signature:</b>
 
@@ -765,7 +765,7 @@ Asynchronously signs in as an anonymous user.
 
 If there is already an anonymous user signed in, that user will be returned; otherwise, a new anonymous user identity will be created and returned.
 
-Note: This method is not supported by [Auth](./auth.auth.md#auth_interface) instances created with a [FirebaseServerApp](./app.firebaseserverapp.md#firebaseserverapp_interface)<!-- -->.
+This method is not supported by [Auth](./auth.auth.md#auth_interface) instances created with a [FirebaseServerApp](./app.firebaseserverapp.md#firebaseserverapp_interface)<!-- -->.
 
 <b>Signature:</b>
 
@@ -789,7 +789,7 @@ Asynchronously signs in with the given credentials.
 
 An [AuthProvider](./auth.authprovider.md#authprovider_interface) can be used to generate the credential.
 
-Note: This method is not supported by [Auth](./auth.auth.md#auth_interface) instances created with a [FirebaseServerApp](./app.firebaseserverapp.md#firebaseserverapp_interface)<!-- -->.
+This method is not supported by [Auth](./auth.auth.md#auth_interface) instances created with a [FirebaseServerApp](./app.firebaseserverapp.md#firebaseserverapp_interface)<!-- -->.
 
 <b>Signature:</b>
 
@@ -816,7 +816,7 @@ Custom tokens are used to integrate Firebase Auth with existing auth systems, an
 
 Fails with an error if the token is invalid, expired, or not accepted by the Firebase Auth service.
 
-Note: This method is not supported by [Auth](./auth.auth.md#auth_interface) instances created with a [FirebaseServerApp](./app.firebaseserverapp.md#firebaseserverapp_interface)<!-- -->.
+This method is not supported by [Auth](./auth.auth.md#auth_interface) instances created with a [FirebaseServerApp](./app.firebaseserverapp.md#firebaseserverapp_interface)<!-- -->.
 
 <b>Signature:</b>
 
@@ -841,9 +841,9 @@ Asynchronously signs in using an email and password.
 
 Fails with an error if the email address and password do not match. When \[Email Enumeration Protection\](https://cloud.google.com/identity-platform/docs/admin/email-enumeration-protection) is enabled, this method fails with "auth/invalid-credential" in case of an invalid email/password.
 
-Note: The user's password is NOT the password used to access the user's email account. The email address serves as a unique identifier for the user, and the password is used to access the user's account in your Firebase project. See also: [createUserWithEmailAndPassword()](./auth.md#createuserwithemailandpassword_21ad33b)<!-- -->.
+This method is not supported on [Auth](./auth.auth.md#auth_interface) instances created with a [FirebaseServerApp](./app.firebaseserverapp.md#firebaseserverapp_interface)<!-- -->.
 
-Note: This method is not supported on [Auth](./auth.auth.md#auth_interface) instances created with a [FirebaseServerApp](./app.firebaseserverapp.md#firebaseserverapp_interface)<!-- -->.
+Note: The user's password is NOT the password used to access the user's email account. The email address serves as a unique identifier for the user, and the password is used to access the user's account in your Firebase project. See also: [createUserWithEmailAndPassword()](./auth.md#createuserwithemailandpassword_21ad33b)<!-- -->.
 
 <b>Signature:</b>
 
@@ -871,9 +871,9 @@ If no link is passed, the link is inferred from the current URL.
 
 Fails with an error if the email address is invalid or OTP in email link expires.
 
-Note: Confirm the link is a sign-in email link before calling this method firebase.auth.Auth.isSignInWithEmailLink.
+This method is not supported by [Auth](./auth.auth.md#auth_interface) instances created with a [FirebaseServerApp](./app.firebaseserverapp.md#firebaseserverapp_interface)<!-- -->.
 
-Note: This method is not supported by [Auth](./auth.auth.md#auth_interface) instances created with a [FirebaseServerApp](./app.firebaseserverapp.md#firebaseserverapp_interface)<!-- -->.
+Note: Confirm the link is a sign-in email link before calling this method firebase.auth.Auth.isSignInWithEmailLink.
 
 <b>Signature:</b>
 
@@ -1057,7 +1057,7 @@ const operationType = result.operationType;
 
 Signs out the current user.
 
-Note: This method is not supported by [Auth](./auth.auth.md#auth_interface) instances created with a [FirebaseServerApp](./app.firebaseserverapp.md#firebaseserverapp_interface)<!-- -->.
+This method is not supported by [Auth](./auth.auth.md#auth_interface) instances created with a [FirebaseServerApp](./app.firebaseserverapp.md#firebaseserverapp_interface)<!-- -->.
 
 <b>Signature:</b>
 
@@ -1085,7 +1085,7 @@ This will trigger [onAuthStateChanged()](./auth.md#onauthstatechanged_b0d07ab) a
 
 The operation fails with an error if the user to be updated belongs to a different Firebase project.
 
-Note: This method is not supported by [Auth](./auth.auth.md#auth_interface) instances created with a [FirebaseServerApp](./app.firebaseserverapp.md#firebaseserverapp_interface)<!-- -->.
+This method is not supported by [Auth](./auth.auth.md#auth_interface) instances created with a [FirebaseServerApp](./app.firebaseserverapp.md#firebaseserverapp_interface)<!-- -->.
 
 <b>Signature:</b>
 
@@ -1427,7 +1427,7 @@ Re-authenticates a user using a fresh credential.
 
 Use before operations such as [updatePassword()](./auth.md#updatepassword_6df673e) that require tokens from recent sign-in attempts. This method can be used to recover from a `CREDENTIAL_TOO_OLD_LOGIN_AGAIN` error or a `TOKEN_EXPIRED` error.
 
-Note: This method is not supported by [Auth](./auth.auth.md#auth_interface) instances created with a [FirebaseServerApp](./app.firebaseserverapp.md#firebaseserverapp_interface)<!-- -->.
+This method is not supported by [Auth](./auth.auth.md#auth_interface) instances created with a [FirebaseServerApp](./app.firebaseserverapp.md#firebaseserverapp_interface)<!-- -->.
 
 <b>Signature:</b>
 

--- a/docs-devsite/auth.user.md
+++ b/docs-devsite/auth.user.md
@@ -121,7 +121,7 @@ Deletes and signs out the user.
 
 Important: this is a security-sensitive operation that requires the user to have recently signed in. If this requirement isn't met, ask the user to authenticate again and then call one of the reauthentication methods like [reauthenticateWithCredential()](./auth.md#reauthenticatewithcredential_60f8043)<!-- -->.
 
-Note: this method is not supported for any [User](./auth.user.md#user_interface) signed in by [Auth](./auth.auth.md#auth_interface) instances created with a [FirebaseServerApp](./app.firebaseserverapp.md#firebaseserverapp_interface)<!-- -->.
+This method is not supported for any [User](./auth.user.md#user_interface) signed in by [Auth](./auth.auth.md#auth_interface) instances created with a [FirebaseServerApp](./app.firebaseserverapp.md#firebaseserverapp_interface)<!-- -->.
 
 <b>Signature:</b>
 

--- a/docs-devsite/auth.user.md
+++ b/docs-devsite/auth.user.md
@@ -121,7 +121,7 @@ Deletes and signs out the user.
 
 Important: this is a security-sensitive operation that requires the user to have recently signed in. If this requirement isn't met, ask the user to authenticate again and then call one of the reauthentication methods like [reauthenticateWithCredential()](./auth.md#reauthenticatewithcredential_60f8043)<!-- -->.
 
-This method is not supported for any [User](./auth.user.md#user_interface) signed in by [Auth](./auth.auth.md#auth_interface) instances created with a [FirebaseServerApp](./app.firebaseserverapp.md#firebaseserverapp_interface)<!-- -->.
+This method is not supported on any [User](./auth.user.md#user_interface) signed in by [Auth](./auth.auth.md#auth_interface) instances created with a [FirebaseServerApp](./app.firebaseserverapp.md#firebaseserverapp_interface)<!-- -->.
 
 <b>Signature:</b>
 

--- a/docs-devsite/auth.user.md
+++ b/docs-devsite/auth.user.md
@@ -121,7 +121,7 @@ Deletes and signs out the user.
 
 Important: this is a security-sensitive operation that requires the user to have recently signed in. If this requirement isn't met, ask the user to authenticate again and then call one of the reauthentication methods like [reauthenticateWithCredential()](./auth.md#reauthenticatewithcredential_60f8043)<!-- -->.
 
-Note: this method is not supported for any [User](./auth.user.md#user_interface) signed in by [Auth](./auth.auth.md#auth_interface) instances created with a .
+Note: this method is not supported for any [User](./auth.user.md#user_interface) signed in by [Auth](./auth.auth.md#auth_interface) instances created with a [FirebaseServerApp](./app.firebaseserverapp.md#firebaseserverapp_interface)<!-- -->.
 
 <b>Signature:</b>
 

--- a/docs-devsite/auth.user.md
+++ b/docs-devsite/auth.user.md
@@ -121,6 +121,8 @@ Deletes and signs out the user.
 
 Important: this is a security-sensitive operation that requires the user to have recently signed in. If this requirement isn't met, ask the user to authenticate again and then call one of the reauthentication methods like [reauthenticateWithCredential()](./auth.md#reauthenticatewithcredential_60f8043)<!-- -->.
 
+Note: this method is not supported for any [User](./auth.user.md#user_interface) signed in by [Auth](./auth.auth.md#auth_interface) instances created with a .
+
 <b>Signature:</b>
 
 ```typescript

--- a/packages/auth/src/core/auth/auth_impl.ts
+++ b/packages/auth/src/core/auth/auth_impl.ts
@@ -62,7 +62,7 @@ import {
   PersistenceUserManager
 } from '../persistence/persistence_user_manager';
 import { _reloadWithoutSaving } from '../user/reload';
-import { _assert } from '../util/assert';
+import { _assert, _createError } from '../util/assert';
 import { _getInstance } from '../util/instantiator';
 import { _getUserLanguage } from '../util/navigator';
 import { _getClientVersion } from '../util/version';
@@ -354,6 +354,11 @@ export class AuthImpl implements AuthInternal, _FirebaseService {
   }
 
   async updateCurrentUser(userExtern: User | null): Promise<void> {
+    if (_isFirebaseServerApp(this.app)) {
+      return Promise.reject(
+        _createError(this, AuthErrorCode.OPERATION_NOT_SUPPORTED)
+      );
+    }
     // The public updateCurrentUser method needs to make a copy of the user,
     // and also check that the project matches
     const user = userExtern
@@ -395,6 +400,11 @@ export class AuthImpl implements AuthInternal, _FirebaseService {
   }
 
   async signOut(): Promise<void> {
+    if (_isFirebaseServerApp(this.app)) {
+      return Promise.reject(
+        _createError(this, AuthErrorCode.OPERATION_NOT_SUPPORTED)
+      );
+    }
     // Run first, to block _setRedirectUser() if any callbacks fail.
     await this.beforeStateQueue.runMiddleware(null);
     // Clear the redirect user when signOut is called
@@ -408,6 +418,11 @@ export class AuthImpl implements AuthInternal, _FirebaseService {
   }
 
   setPersistence(persistence: Persistence): Promise<void> {
+    if (_isFirebaseServerApp(this.app)) {
+      return Promise.reject(
+        _createError(this, AuthErrorCode.OPERATION_NOT_SUPPORTED)
+      );
+    }
     return this.queue(async () => {
       await this.assertedPersistence.setPersistence(_getInstance(persistence));
     });

--- a/packages/auth/src/core/index.ts
+++ b/packages/auth/src/core/index.ts
@@ -47,7 +47,7 @@ export {
  * that are shared by other users or have sensitive data.
  *
  * This method does not work in a Node.js environment or with {@link Auth} instances created with a
- * {@link FirebaseServerApp}.
+ * {@link @firebase/app#FirebaseServerApp}.
  *
  * @example
  * ```javascript
@@ -225,7 +225,7 @@ export function useDeviceLanguage(auth: Auth): void {
  * project.
  *
  * Note: This method is not supported by {@link Auth} instances created with a
- * {@link FirebaseServerApp}.
+ * {@link @firebase/app#FirebaseServerApp}.
  *
  * @param auth - The {@link Auth} instance.
  * @param user - The new {@link User}.
@@ -242,7 +242,7 @@ export function updateCurrentUser(
  * Signs out the current user.
  *
  * Note: This method is not supported by {@link Auth} instances created with a
- * {@link FirebaseServerApp}.
+ * {@link @firebase/app#FirebaseServerApp}.
  *
  * @param auth - The {@link Auth} instance.
  *

--- a/packages/auth/src/core/index.ts
+++ b/packages/auth/src/core/index.ts
@@ -224,7 +224,7 @@ export function useDeviceLanguage(auth: Auth): void {
  * The operation fails with an error if the user to be updated belongs to a different Firebase
  * project.
  *
- * Note: This method is not supported by {@link Auth} instances created with a
+ * This method is not supported by {@link Auth} instances created with a
  * {@link @firebase/app#FirebaseServerApp}.
  *
  * @param auth - The {@link Auth} instance.
@@ -241,7 +241,8 @@ export function updateCurrentUser(
 /**
  * Signs out the current user.
  *
- * Note: This method is not supported by {@link Auth} instances created with a
+ * @remarks
+ * This method is not supported by {@link Auth} instances created with a
  * {@link @firebase/app#FirebaseServerApp}.
  *
  * @param auth - The {@link Auth} instance.

--- a/packages/auth/src/core/index.ts
+++ b/packages/auth/src/core/index.ts
@@ -46,7 +46,8 @@ export {
  * remembered or not. It also makes it easier to never persist the `Auth` state for applications
  * that are shared by other users or have sensitive data.
  *
- * This method does not work in a Node.js environment.
+ * This method does not work in a Node.js environment or with {@link Auth} instances created with a
+ * {@link FirebaseServerApp}.
  *
  * @example
  * ```javascript
@@ -223,6 +224,9 @@ export function useDeviceLanguage(auth: Auth): void {
  * The operation fails with an error if the user to be updated belongs to a different Firebase
  * project.
  *
+ * Note: This method is not supported by {@link Auth} instances created with a
+ * {@link FirebaseServerApp}.
+ *
  * @param auth - The {@link Auth} instance.
  * @param user - The new {@link User}.
  *
@@ -236,6 +240,9 @@ export function updateCurrentUser(
 }
 /**
  * Signs out the current user.
+ *
+ * Note: This method is not supported by {@link Auth} instances created with a
+ * {@link FirebaseServerApp}.
  *
  * @param auth - The {@link Auth} instance.
  *

--- a/packages/auth/src/core/strategies/anonymous.ts
+++ b/packages/auth/src/core/strategies/anonymous.ts
@@ -32,7 +32,7 @@ import { AuthErrorCode } from '../../core/errors';
  * If there is already an anonymous user signed in, that user will be returned; otherwise, a
  * new anonymous user identity will be created and returned.
  *
- * Note: This method is not supported by {@link Auth} instances created with a
+ * This method is not supported by {@link Auth} instances created with a
  * {@link @firebase/app#FirebaseServerApp}.
  *
  * @param auth - The {@link Auth} instance.

--- a/packages/auth/src/core/strategies/anonymous.ts
+++ b/packages/auth/src/core/strategies/anonymous.ts
@@ -33,7 +33,7 @@ import { AuthErrorCode } from '../../core/errors';
  * new anonymous user identity will be created and returned.
  *
  * Note: This method is not supported by {@link Auth} instances created with a
- * {@link FirebaseServerApp}.
+ * {@link @firebase/app#FirebaseServerApp}.
  *
  * @param auth - The {@link Auth} instance.
  *

--- a/packages/auth/src/core/strategies/anonymous.ts
+++ b/packages/auth/src/core/strategies/anonymous.ts
@@ -21,6 +21,9 @@ import { UserInternal } from '../../model/user';
 import { UserCredentialImpl } from '../user/user_credential_impl';
 import { _castAuth } from '../auth/auth_impl';
 import { OperationType } from '../../model/enums';
+import { _isFirebaseServerApp } from '@firebase/app';
+import { _createError } from '../../core/util/assert';
+import { AuthErrorCode } from '../../core/errors';
 
 /**
  * Asynchronously signs in as an anonymous user.
@@ -29,11 +32,19 @@ import { OperationType } from '../../model/enums';
  * If there is already an anonymous user signed in, that user will be returned; otherwise, a
  * new anonymous user identity will be created and returned.
  *
+ * Note: This method is not supported by {@link Auth} instances created with a
+ * {@link FirebaseServerApp}.
+ *
  * @param auth - The {@link Auth} instance.
  *
  * @public
  */
 export async function signInAnonymously(auth: Auth): Promise<UserCredential> {
+  if (_isFirebaseServerApp(auth.app)) {
+    return Promise.reject(
+      _createError(auth, AuthErrorCode.OPERATION_NOT_SUPPORTED)
+    );
+  }
   const authInternal = _castAuth(auth);
   await authInternal._initializationPromise;
   if (authInternal.currentUser?.isAnonymous) {

--- a/packages/auth/src/core/strategies/credential.ts
+++ b/packages/auth/src/core/strategies/credential.ts
@@ -110,8 +110,8 @@ export async function linkWithCredential(
  * attempts. This method can be used to recover from a `CREDENTIAL_TOO_OLD_LOGIN_AGAIN` error
  * or a `TOKEN_EXPIRED` error.
  *
- * This method is not supported by {@link Auth} instances created with a
- * {@link @firebase/app#FirebaseServerApp}.
+ * This method is not supported on any {@link User} signed in by {@link Auth} instances
+ * created with a {@link @firebase/app#FirebaseServerApp}.
  *
  * @param user - The user.
  * @param credential - The auth credential.

--- a/packages/auth/src/core/strategies/credential.ts
+++ b/packages/auth/src/core/strategies/credential.ts
@@ -65,7 +65,7 @@ export async function _signInWithCredential(
  * @remarks
  * An {@link AuthProvider} can be used to generate the credential.
  *
- * Note: This method is not supported by {@link Auth} instances created with a
+ * This method is not supported by {@link Auth} instances created with a
  * {@link @firebase/app#FirebaseServerApp}.
  *
  * @param auth - The {@link Auth} instance.
@@ -110,7 +110,7 @@ export async function linkWithCredential(
  * attempts. This method can be used to recover from a `CREDENTIAL_TOO_OLD_LOGIN_AGAIN` error
  * or a `TOKEN_EXPIRED` error.
  *
- * Note: This method is not supported by {@link Auth} instances created with a
+ * This method is not supported by {@link Auth} instances created with a
  * {@link @firebase/app#FirebaseServerApp}.
  *
  * @param user - The user.

--- a/packages/auth/src/core/strategies/credential.ts
+++ b/packages/auth/src/core/strategies/credential.ts
@@ -66,7 +66,7 @@ export async function _signInWithCredential(
  * An {@link AuthProvider} can be used to generate the credential.
  *
  * Note: This method is not supported by {@link Auth} instances created with a
- * {@link FirebaseServerApp}.
+ * {@link @firebase/app#FirebaseServerApp}.
  *
  * @param auth - The {@link Auth} instance.
  * @param credential - The auth credential.
@@ -111,7 +111,7 @@ export async function linkWithCredential(
  * or a `TOKEN_EXPIRED` error.
  *
  * Note: This method is not supported by {@link Auth} instances created with a
- * {@link FirebaseServerApp}.
+ * {@link @firebase/app#FirebaseServerApp}.
  *
  * @param user - The user.
  * @param credential - The auth credential.

--- a/packages/auth/src/core/strategies/credential.ts
+++ b/packages/auth/src/core/strategies/credential.ts
@@ -27,12 +27,20 @@ import { UserCredentialImpl } from '../user/user_credential_impl';
 import { _castAuth } from '../auth/auth_impl';
 import { getModularInstance } from '@firebase/util';
 import { OperationType } from '../../model/enums';
+import { _isFirebaseServerApp } from '@firebase/app';
+import { _createError } from '../../core/util/assert';
+import { AuthErrorCode } from '../../core/errors';
 
 export async function _signInWithCredential(
   auth: AuthInternal,
   credential: AuthCredential,
   bypassAuthState = false
 ): Promise<UserCredential> {
+  if (_isFirebaseServerApp(auth.app)) {
+    return Promise.reject(
+      _createError(auth, AuthErrorCode.OPERATION_NOT_SUPPORTED)
+    );
+  }
   const operationType = OperationType.SIGN_IN;
   const response = await _processCredentialSavingMfaContextIfNecessary(
     auth,
@@ -56,6 +64,9 @@ export async function _signInWithCredential(
  *
  * @remarks
  * An {@link AuthProvider} can be used to generate the credential.
+ *
+ * Note: This method is not supported by {@link Auth} instances created with a
+ * {@link FirebaseServerApp}.
  *
  * @param auth - The {@link Auth} instance.
  * @param credential - The auth credential.
@@ -98,6 +109,9 @@ export async function linkWithCredential(
  * Use before operations such as {@link updatePassword} that require tokens from recent sign-in
  * attempts. This method can be used to recover from a `CREDENTIAL_TOO_OLD_LOGIN_AGAIN` error
  * or a `TOKEN_EXPIRED` error.
+ *
+ * Note: This method is not supported by {@link Auth} instances created with a
+ * {@link FirebaseServerApp}.
  *
  * @param user - The user.
  * @param credential - The auth credential.

--- a/packages/auth/src/core/strategies/custom_token.ts
+++ b/packages/auth/src/core/strategies/custom_token.ts
@@ -37,7 +37,7 @@ import { AuthErrorCode } from '../../core/errors';
  * Fails with an error if the token is invalid, expired, or not accepted by the Firebase Auth service.
  *
  * Note: This method is not supported by {@link Auth} instances created with a
- * {@link FirebaseServerApp}.
+ * {@link @firebase/app#FirebaseServerApp}.
  *
  * @param auth - The {@link Auth} instance.
  * @param customToken - The custom token to sign in with.

--- a/packages/auth/src/core/strategies/custom_token.ts
+++ b/packages/auth/src/core/strategies/custom_token.ts
@@ -36,7 +36,7 @@ import { AuthErrorCode } from '../../core/errors';
  *
  * Fails with an error if the token is invalid, expired, or not accepted by the Firebase Auth service.
  *
- * Note: This method is not supported by {@link Auth} instances created with a
+ * This method is not supported by {@link Auth} instances created with a
  * {@link @firebase/app#FirebaseServerApp}.
  *
  * @param auth - The {@link Auth} instance.

--- a/packages/auth/src/core/strategies/custom_token.ts
+++ b/packages/auth/src/core/strategies/custom_token.ts
@@ -22,7 +22,9 @@ import { IdTokenResponse } from '../../model/id_token';
 import { UserCredentialImpl } from '../user/user_credential_impl';
 import { _castAuth } from '../auth/auth_impl';
 import { OperationType } from '../../model/enums';
-
+import { _isFirebaseServerApp } from '@firebase/app';
+import { _createError } from '../../core/util/assert';
+import { AuthErrorCode } from '../../core/errors';
 /**
  * Asynchronously signs in using a custom token.
  *
@@ -34,6 +36,9 @@ import { OperationType } from '../../model/enums';
  *
  * Fails with an error if the token is invalid, expired, or not accepted by the Firebase Auth service.
  *
+ * Note: This method is not supported by {@link Auth} instances created with a
+ * {@link FirebaseServerApp}.
+ *
  * @param auth - The {@link Auth} instance.
  * @param customToken - The custom token to sign in with.
  *
@@ -43,6 +48,11 @@ export async function signInWithCustomToken(
   auth: Auth,
   customToken: string
 ): Promise<UserCredential> {
+  if (_isFirebaseServerApp(auth.app)) {
+    return Promise.reject(
+      _createError(auth, AuthErrorCode.OPERATION_NOT_SUPPORTED)
+    );
+  }
   const authInternal = _castAuth(auth);
   const response: IdTokenResponse = await getIdTokenResponse(authInternal, {
     token: customToken,

--- a/packages/auth/src/core/strategies/email_and_password.ts
+++ b/packages/auth/src/core/strategies/email_and_password.ts
@@ -254,11 +254,11 @@ export async function verifyPasswordResetCode(
  *
  * User account creation can fail if the account already exists or the password is invalid.
  *
+ * This method is not supported on {@link Auth} instances created with a
+ * {@link @firebase/app#FirebaseServerApp}.
+ *
  * Note: The email address acts as a unique identifier for the user and enables an email-based
  * password reset. This function will create a new user account and set the initial user password.
- *
- * Note: This method is not supported on {@link Auth} instances created with a
- * {@link @firebase/app#FirebaseServerApp}.
  *
  * @param auth - The {@link Auth} instance.
  * @param email - The user's email address.
@@ -317,12 +317,13 @@ export async function createUserWithEmailAndPassword(
  * When [Email Enumeration Protection](https://cloud.google.com/identity-platform/docs/admin/email-enumeration-protection) is enabled,
  * this method fails with "auth/invalid-credential" in case of an invalid email/password.
  *
+ * This method is not supported on {@link Auth} instances created with a
+ * {@link @firebase/app#FirebaseServerApp}.
+ *
  * Note: The user's password is NOT the password used to access the user's email account. The
  * email address serves as a unique identifier for the user, and the password is used to access
  * the user's account in your Firebase project. See also: {@link createUserWithEmailAndPassword}.
  *
- * Note: This method is not supported on {@link Auth} instances created with a
- * {@link @firebase/app#FirebaseServerApp}.
  *
  * @param auth - The {@link Auth} instance.
  * @param email - The users email address.

--- a/packages/auth/src/core/strategies/email_and_password.ts
+++ b/packages/auth/src/core/strategies/email_and_password.ts
@@ -29,7 +29,7 @@ import { signUp, SignUpRequest } from '../../api/authentication/sign_up';
 import { MultiFactorInfoImpl } from '../../mfa/mfa_info';
 import { EmailAuthProvider } from '../providers/email';
 import { UserCredentialImpl } from '../user/user_credential_impl';
-import { _assert } from '../util/assert';
+import { _assert, _createError } from '../util/assert';
 import { _setActionCodeSettingsOnRequest } from './action_code_settings';
 import { signInWithCredential } from './credential';
 import { _castAuth } from '../auth/auth_impl';
@@ -39,6 +39,7 @@ import { OperationType } from '../../model/enums';
 import { handleRecaptchaFlow } from '../../platform_browser/recaptcha/recaptcha_enterprise_verifier';
 import { IdTokenResponse } from '../../model/id_token';
 import { RecaptchaActionName, RecaptchaClientType } from '../../api';
+import { _isFirebaseServerApp } from '@firebase/app';
 
 /**
  * Updates the password policy cached in the {@link Auth} instance if a policy is already
@@ -256,6 +257,9 @@ export async function verifyPasswordResetCode(
  * Note: The email address acts as a unique identifier for the user and enables an email-based
  * password reset. This function will create a new user account and set the initial user password.
  *
+ * Note: This method is not supported on {@link Auth} instances created with a
+ * {@link FirebaseServerApp}.
+ *
  * @param auth - The {@link Auth} instance.
  * @param email - The user's email address.
  * @param password - The user's chosen password.
@@ -267,6 +271,11 @@ export async function createUserWithEmailAndPassword(
   email: string,
   password: string
 ): Promise<UserCredential> {
+  if (_isFirebaseServerApp(auth.app)) {
+    return Promise.reject(
+      _createError(auth, AuthErrorCode.OPERATION_NOT_SUPPORTED)
+    );
+  }
   const authInternal = _castAuth(auth);
   const request: SignUpRequest = {
     returnSecureToken: true,
@@ -312,6 +321,9 @@ export async function createUserWithEmailAndPassword(
  * email address serves as a unique identifier for the user, and the password is used to access
  * the user's account in your Firebase project. See also: {@link createUserWithEmailAndPassword}.
  *
+ * Note: This method is not supported on {@link Auth} instances created with a
+ * {@link FirebaseServerApp}.
+ *
  * @param auth - The {@link Auth} instance.
  * @param email - The users email address.
  * @param password - The users password.
@@ -323,6 +335,11 @@ export function signInWithEmailAndPassword(
   email: string,
   password: string
 ): Promise<UserCredential> {
+  if (_isFirebaseServerApp(auth.app)) {
+    return Promise.reject(
+      _createError(auth, AuthErrorCode.OPERATION_NOT_SUPPORTED)
+    );
+  }
   return signInWithCredential(
     getModularInstance(auth),
     EmailAuthProvider.credential(email, password)

--- a/packages/auth/src/core/strategies/email_and_password.ts
+++ b/packages/auth/src/core/strategies/email_and_password.ts
@@ -258,7 +258,7 @@ export async function verifyPasswordResetCode(
  * password reset. This function will create a new user account and set the initial user password.
  *
  * Note: This method is not supported on {@link Auth} instances created with a
- * {@link FirebaseServerApp}.
+ * {@link @firebase/app#FirebaseServerApp}.
  *
  * @param auth - The {@link Auth} instance.
  * @param email - The user's email address.
@@ -322,7 +322,7 @@ export async function createUserWithEmailAndPassword(
  * the user's account in your Firebase project. See also: {@link createUserWithEmailAndPassword}.
  *
  * Note: This method is not supported on {@link Auth} instances created with a
- * {@link FirebaseServerApp}.
+ * {@link @firebase/app#FirebaseServerApp}.
  *
  * @param auth - The {@link Auth} instance.
  * @param email - The users email address.

--- a/packages/auth/src/core/strategies/email_link.ts
+++ b/packages/auth/src/core/strategies/email_link.ts
@@ -133,10 +133,10 @@ export function isSignInWithEmailLink(auth: Auth, emailLink: string): boolean {
  *
  * Fails with an error if the email address is invalid or OTP in email link expires.
  *
- * Note: Confirm the link is a sign-in email link before calling this method firebase.auth.Auth.isSignInWithEmailLink.
- *
- * Note: This method is not supported by {@link Auth} instances created with a
+ * This method is not supported by {@link Auth} instances created with a
  * {@link @firebase/app#FirebaseServerApp}.
+ *
+ * Note: Confirm the link is a sign-in email link before calling this method firebase.auth.Auth.isSignInWithEmailLink.
  *
  * @example
  * ```javascript

--- a/packages/auth/src/core/strategies/email_link.ts
+++ b/packages/auth/src/core/strategies/email_link.ts
@@ -34,6 +34,8 @@ import { getModularInstance } from '@firebase/util';
 import { _castAuth } from '../auth/auth_impl';
 import { handleRecaptchaFlow } from '../../platform_browser/recaptcha/recaptcha_enterprise_verifier';
 import { RecaptchaActionName, RecaptchaClientType } from '../../api';
+import { _isFirebaseServerApp } from '@firebase/app';
+import { _createError } from '../../core/util/assert';
 
 /**
  * Sends a sign-in email link to the user with the specified email.
@@ -133,6 +135,9 @@ export function isSignInWithEmailLink(auth: Auth, emailLink: string): boolean {
  *
  * Note: Confirm the link is a sign-in email link before calling this method firebase.auth.Auth.isSignInWithEmailLink.
  *
+ * Note: This method is not supported by {@link Auth} instances created with a
+ * {@link FirebaseServerApp}.
+ *
  * @example
  * ```javascript
  * const actionCodeSettings = {
@@ -154,6 +159,7 @@ export function isSignInWithEmailLink(auth: Auth, emailLink: string): boolean {
  * }
  * ```
  *
+ *
  * @param auth - The {@link Auth} instance.
  * @param email - The user's email address.
  * @param emailLink - The link sent to the user's email address.
@@ -165,6 +171,11 @@ export async function signInWithEmailLink(
   email: string,
   emailLink?: string
 ): Promise<UserCredential> {
+  if (_isFirebaseServerApp(auth.app)) {
+    return Promise.reject(
+      _createError(auth, AuthErrorCode.OPERATION_NOT_SUPPORTED)
+    );
+  }
   const authModular = getModularInstance(auth);
   const credential = EmailAuthProvider.credentialWithLink(
     email,

--- a/packages/auth/src/core/strategies/email_link.ts
+++ b/packages/auth/src/core/strategies/email_link.ts
@@ -136,7 +136,7 @@ export function isSignInWithEmailLink(auth: Auth, emailLink: string): boolean {
  * Note: Confirm the link is a sign-in email link before calling this method firebase.auth.Auth.isSignInWithEmailLink.
  *
  * Note: This method is not supported by {@link Auth} instances created with a
- * {@link FirebaseServerApp}.
+ * {@link @firebase/app#FirebaseServerApp}.
  *
  * @example
  * ```javascript

--- a/packages/auth/src/core/user/reauthenticate.ts
+++ b/packages/auth/src/core/user/reauthenticate.ts
@@ -25,6 +25,8 @@ import { _assert, _fail } from '../util/assert';
 import { _parseToken } from './id_token_result';
 import { _logoutIfInvalidated } from './invalidation';
 import { UserCredentialImpl } from './user_credential_impl';
+import { _isFirebaseServerApp } from '@firebase/app';
+import { _createError } from '../../core/util/assert';
 
 export async function _reauthenticate(
   user: UserInternal,
@@ -32,6 +34,11 @@ export async function _reauthenticate(
   bypassAuthState = false
 ): Promise<UserCredentialImpl> {
   const { auth } = user;
+  if (_isFirebaseServerApp(auth.app)) {
+    return Promise.reject(
+      _createError(auth, AuthErrorCode.OPERATION_NOT_SUPPORTED)
+    );
+  }
   const operationType = OperationType.REAUTHENTICATE;
 
   try {

--- a/packages/auth/src/model/public_types.ts
+++ b/packages/auth/src/model/public_types.ts
@@ -322,6 +322,9 @@ export interface Auth {
   useDeviceLanguage(): void;
   /**
    * Signs out the current user. This does not automatically revoke the user's ID token.
+   *
+   * Note: This method is not supported by {@link Auth} instances created with a
+   * {@link FirebaseServerApp}.
    */
   signOut(): Promise<void>;
 }
@@ -1004,6 +1007,9 @@ export interface User extends UserInfo {
    * Important: this is a security-sensitive operation that requires the user to have recently
    * signed in. If this requirement isn't met, ask the user to authenticate again and then call
    * one of the reauthentication methods like {@link reauthenticateWithCredential}.
+   *
+   * Note: this method is not supported for any {@link User} signed in by {@link Auth} instances
+   * created with a {@link FirebaseServerApp}.
    */
   delete(): Promise<void>;
   /**

--- a/packages/auth/src/model/public_types.ts
+++ b/packages/auth/src/model/public_types.ts
@@ -324,7 +324,7 @@ export interface Auth {
    * Signs out the current user. This does not automatically revoke the user's ID token.
    *
    * Note: This method is not supported by {@link Auth} instances created with a
-   * {@link FirebaseServerApp}.
+   * {@link @firebase/app#FirebaseServerApp}.
    */
   signOut(): Promise<void>;
 }
@@ -1009,7 +1009,7 @@ export interface User extends UserInfo {
    * one of the reauthentication methods like {@link reauthenticateWithCredential}.
    *
    * Note: this method is not supported for any {@link User} signed in by {@link Auth} instances
-   * created with a {@link FirebaseServerApp}.
+   * created with a {@link @firebase/app#FirebaseServerApp}.
    */
   delete(): Promise<void>;
   /**

--- a/packages/auth/src/model/public_types.ts
+++ b/packages/auth/src/model/public_types.ts
@@ -323,7 +323,8 @@ export interface Auth {
   /**
    * Signs out the current user. This does not automatically revoke the user's ID token.
    *
-   * Note: This method is not supported by {@link Auth} instances created with a
+   * @remarks
+   * This method is not supported by {@link Auth} instances created with a
    * {@link @firebase/app#FirebaseServerApp}.
    */
   signOut(): Promise<void>;
@@ -1008,7 +1009,7 @@ export interface User extends UserInfo {
    * signed in. If this requirement isn't met, ask the user to authenticate again and then call
    * one of the reauthentication methods like {@link reauthenticateWithCredential}.
    *
-   * Note: this method is not supported for any {@link User} signed in by {@link Auth} instances
+   * This method is not supported for any {@link User} signed in by {@link Auth} instances
    * created with a {@link @firebase/app#FirebaseServerApp}.
    */
   delete(): Promise<void>;

--- a/packages/auth/src/model/public_types.ts
+++ b/packages/auth/src/model/public_types.ts
@@ -1009,7 +1009,7 @@ export interface User extends UserInfo {
    * signed in. If this requirement isn't met, ask the user to authenticate again and then call
    * one of the reauthentication methods like {@link reauthenticateWithCredential}.
    *
-   * This method is not supported for any {@link User} signed in by {@link Auth} instances
+   * This method is not supported on any {@link User} signed in by {@link Auth} instances
    * created with a {@link @firebase/app#FirebaseServerApp}.
    */
   delete(): Promise<void>;

--- a/packages/auth/src/platform_browser/strategies/phone.ts
+++ b/packages/auth/src/platform_browser/strategies/phone.ts
@@ -84,7 +84,7 @@ class ConfirmationResultImpl implements ConfirmationResult {
  * third-party {@link ApplicationVerifier} implementation.
  *
  * This method does not work in a Node.js environment or with {@link Auth} instances created with a
- * {@link FirebaseServerApp}.
+ * {@link @firebase/app#FirebaseServerApp}.
  *
  * @example
  * ```javascript
@@ -158,7 +158,7 @@ export async function linkWithPhoneNumber(
  * Use before operations such as {@link updatePassword} that require tokens from recent sign-in attempts.
  *
  * This method does not work in a Node.js environment or with {@link Auth} instances created with a
- * {@link FirebaseServerApp}.
+ * {@link @firebase/app#FirebaseServerApp}.
  *
  * @param user - The user.
  * @param phoneNumber - The user's phone number in E.164 format (e.g. +16505550101).
@@ -273,7 +273,7 @@ export async function _verifyPhoneNumber(
  *
  * @remarks
  * This method does not work in a Node.js environment or with {@link Auth} instances created with a
- * {@link FirebaseServerApp}.
+ * {@link @firebase/app#FirebaseServerApp}.
  *
  * @example
  * ```

--- a/packages/auth/src/platform_browser/strategies/phone.ts
+++ b/packages/auth/src/platform_browser/strategies/phone.ts
@@ -157,8 +157,8 @@ export async function linkWithPhoneNumber(
  * @remarks
  * Use before operations such as {@link updatePassword} that require tokens from recent sign-in attempts.
  *
- * This method does not work in a Node.js environment or with {@link Auth} instances created with a
- * {@link @firebase/app#FirebaseServerApp}.
+ * This method does not work in a Node.js environment or on any {@link User} signed in by
+ * {@link Auth} instances created with a {@link @firebase/app#FirebaseServerApp}.
  *
  * @param user - The user.
  * @param phoneNumber - The user's phone number in E.164 format (e.g. +16505550101).
@@ -272,8 +272,8 @@ export async function _verifyPhoneNumber(
  * Updates the user's phone number.
  *
  * @remarks
- * This method does not work in a Node.js environment or with {@link Auth} instances created with a
- * {@link @firebase/app#FirebaseServerApp}.
+ * This method does not work in a Node.js environment or on any {@link User} signed in by
+ * {@link Auth} instances created with a {@link @firebase/app#FirebaseServerApp}.
  *
  * @example
  * ```

--- a/packages/auth/src/platform_browser/strategies/phone.ts
+++ b/packages/auth/src/platform_browser/strategies/phone.ts
@@ -31,7 +31,7 @@ import { ApplicationVerifierInternal } from '../../model/application_verifier';
 import { PhoneAuthCredential } from '../../core/credentials/phone';
 import { AuthErrorCode } from '../../core/errors';
 import { _assertLinkedStatus, _link } from '../../core/user/link_unlink';
-import { _assert } from '../../core/util/assert';
+import { _assert, _createError } from '../../core/util/assert';
 import { AuthInternal } from '../../model/auth';
 import {
   linkWithCredential,
@@ -47,6 +47,7 @@ import { RECAPTCHA_VERIFIER_TYPE } from '../recaptcha/recaptcha_verifier';
 import { _castAuth } from '../../core/auth/auth_impl';
 import { getModularInstance } from '@firebase/util';
 import { ProviderId } from '../../model/enums';
+import { _isFirebaseServerApp } from '@firebase/app';
 
 interface OnConfirmationCallback {
   (credential: PhoneAuthCredential): Promise<UserCredential>;
@@ -82,7 +83,8 @@ class ConfirmationResultImpl implements ConfirmationResult {
  * {@link RecaptchaVerifier} (like React Native), but you need to use a
  * third-party {@link ApplicationVerifier} implementation.
  *
- * This method does not work in a Node.js environment.
+ * This method does not work in a Node.js environment or with {@link Auth} instances created with a
+ * {@link FirebaseServerApp}.
  *
  * @example
  * ```javascript
@@ -104,6 +106,11 @@ export async function signInWithPhoneNumber(
   phoneNumber: string,
   appVerifier: ApplicationVerifier
 ): Promise<ConfirmationResult> {
+  if (_isFirebaseServerApp(auth.app)) {
+    return Promise.reject(
+      _createError(auth, AuthErrorCode.OPERATION_NOT_SUPPORTED)
+    );
+  }
   const authInternal = _castAuth(auth);
   const verificationId = await _verifyPhoneNumber(
     authInternal,
@@ -150,7 +157,8 @@ export async function linkWithPhoneNumber(
  * @remarks
  * Use before operations such as {@link updatePassword} that require tokens from recent sign-in attempts.
  *
- * This method does not work in a Node.js environment.
+ * This method does not work in a Node.js environment or with {@link Auth} instances created with a
+ * {@link FirebaseServerApp}.
  *
  * @param user - The user.
  * @param phoneNumber - The user's phone number in E.164 format (e.g. +16505550101).
@@ -164,6 +172,11 @@ export async function reauthenticateWithPhoneNumber(
   appVerifier: ApplicationVerifier
 ): Promise<ConfirmationResult> {
   const userInternal = getModularInstance(user) as UserInternal;
+  if (_isFirebaseServerApp(userInternal.auth.app)) {
+    return Promise.reject(
+      _createError(userInternal.auth, AuthErrorCode.OPERATION_NOT_SUPPORTED)
+    );
+  }
   const verificationId = await _verifyPhoneNumber(
     userInternal.auth,
     phoneNumber,
@@ -259,7 +272,8 @@ export async function _verifyPhoneNumber(
  * Updates the user's phone number.
  *
  * @remarks
- * This method does not work in a Node.js environment.
+ * This method does not work in a Node.js environment or with {@link Auth} instances created with a
+ * {@link FirebaseServerApp}.
  *
  * @example
  * ```
@@ -281,5 +295,11 @@ export async function updatePhoneNumber(
   user: User,
   credential: PhoneAuthCredential
 ): Promise<void> {
-  await _link(getModularInstance(user) as UserInternal, credential);
+  const userInternal = getModularInstance(user) as UserInternal;
+  if (_isFirebaseServerApp(userInternal.auth.app)) {
+    return Promise.reject(
+      _createError(userInternal.auth, AuthErrorCode.OPERATION_NOT_SUPPORTED)
+    );
+  }
+  await _link(userInternal, credential);
 }

--- a/packages/auth/src/platform_browser/strategies/popup.ts
+++ b/packages/auth/src/platform_browser/strategies/popup.ts
@@ -65,7 +65,7 @@ export const _POLL_WINDOW_CLOSE_TIMEOUT = new Delay(2000, 10000);
  * unsuccessful, returns an error object containing additional information about the error.
  *
  * This method does not work in a Node.js environment or with {@link Auth} instances created with a
- * {@link FirebaseServerApp}.
+ * {@link @firebase/app#FirebaseServerApp}.
  *
  * @example
  * ```javascript
@@ -119,7 +119,7 @@ export async function signInWithPopup(
  * provider's credential.
  *
  * This method does not work in a Node.js environment or with {@link Auth} instances created with a
- * {@link FirebaseServerApp}.
+ * {@link @firebase/app#FirebaseServerApp}.
  *
  * @example
  * ```javascript

--- a/packages/auth/src/platform_browser/strategies/popup.ts
+++ b/packages/auth/src/platform_browser/strategies/popup.ts
@@ -44,6 +44,7 @@ import { AuthPopup } from '../util/popup';
 import { AbstractPopupRedirectOperation } from '../../core/strategies/abstract_popup_redirect_operation';
 import { FederatedAuthProvider } from '../../core/providers/federated';
 import { getModularInstance } from '@firebase/util';
+import { _isFirebaseServerApp } from '@firebase/app';
 
 /*
  * The event timeout is the same on mobile and desktop, no need for Delay. Set this to 8s since
@@ -63,7 +64,8 @@ export const _POLL_WINDOW_CLOSE_TIMEOUT = new Delay(2000, 10000);
  * If succeeds, returns the signed in user along with the provider's credential. If sign in was
  * unsuccessful, returns an error object containing additional information about the error.
  *
- * This method does not work in a Node.js environment.
+ * This method does not work in a Node.js environment or with {@link Auth} instances created with a
+ * {@link FirebaseServerApp}.
  *
  * @example
  * ```javascript
@@ -91,6 +93,11 @@ export async function signInWithPopup(
   provider: AuthProvider,
   resolver?: PopupRedirectResolver
 ): Promise<UserCredential> {
+  if (_isFirebaseServerApp(auth.app)) {
+    return Promise.reject(
+      _createError(auth, AuthErrorCode.OPERATION_NOT_SUPPORTED)
+    );
+  }
   const authInternal = _castAuth(auth);
   _assertInstanceOf(auth, provider, FederatedAuthProvider);
   const resolverInternal = _withDefaultResolver(authInternal, resolver);
@@ -111,7 +118,8 @@ export async function signInWithPopup(
  * If the reauthentication is successful, the returned result will contain the user and the
  * provider's credential.
  *
- * This method does not work in a Node.js environment.
+ * This method does not work in a Node.js environment or with {@link Auth} instances created with a
+ * {@link FirebaseServerApp}.
  *
  * @example
  * ```javascript
@@ -136,6 +144,11 @@ export async function reauthenticateWithPopup(
   resolver?: PopupRedirectResolver
 ): Promise<UserCredential> {
   const userInternal = getModularInstance(user) as UserInternal;
+  if (_isFirebaseServerApp(userInternal.auth.app)) {
+    return Promise.reject(
+      _createError(userInternal.auth, AuthErrorCode.OPERATION_NOT_SUPPORTED)
+    );
+  }
   _assertInstanceOf(userInternal.auth, provider, FederatedAuthProvider);
   const resolverInternal = _withDefaultResolver(userInternal.auth, resolver);
   const action = new PopupOperation(

--- a/packages/auth/src/platform_browser/strategies/popup.ts
+++ b/packages/auth/src/platform_browser/strategies/popup.ts
@@ -118,8 +118,8 @@ export async function signInWithPopup(
  * If the reauthentication is successful, the returned result will contain the user and the
  * provider's credential.
  *
- * This method does not work in a Node.js environment or with {@link Auth} instances created with a
- * {@link @firebase/app#FirebaseServerApp}.
+ * This method does not work in a Node.js environment or on any {@link User} signed in by
+ * {@link Auth} instances created with a {@link @firebase/app#FirebaseServerApp}.
  *
  * @example
  * ```javascript

--- a/packages/auth/src/platform_browser/strategies/redirect.ts
+++ b/packages/auth/src/platform_browser/strategies/redirect.ts
@@ -48,7 +48,7 @@ import { AuthErrorCode } from '../../core/errors';
  * | best practices} when using {@link signInWithRedirect}.
  *
  * This method does not work in a Node.js environment or with {@link Auth} instances created with a
- * {@link FirebaseServerApp}.
+ * {@link @firebase/app#FirebaseServerApp}.
  *
  * @example
  * ```javascript
@@ -125,7 +125,7 @@ export async function _signInWithRedirect(
  * | best practices} when using {@link reauthenticateWithRedirect}.
  *
  * This method does not work in a Node.js environment or with {@link Auth} instances created with a
- * {@link FirebaseServerApp}.
+ * {@link @firebase/app#FirebaseServerApp}.
  *
  * @example
  * ```javascript
@@ -200,7 +200,7 @@ export async function _reauthenticateWithRedirect(
  * | best practices} when using {@link linkWithRedirect}.
  *
  * This method does not work in a Node.js environment or with {@link Auth} instances created with a
- * {@link FirebaseServerApp}.
+ * {@link @firebase/app#FirebaseServerApp}.
  *
  * @example
  * ```javascript
@@ -263,7 +263,7 @@ export async function _linkWithRedirect(
  * error. If no redirect operation was called, returns `null`.
  *
  * This method does not work in a Node.js environment or with {@link Auth} instances created with a
- * {@link FirebaseServerApp}.
+ * {@link @firebase/app#FirebaseServerApp}.
  *
  * @example
  * ```javascript

--- a/packages/auth/src/platform_browser/strategies/redirect.ts
+++ b/packages/auth/src/platform_browser/strategies/redirect.ts
@@ -124,8 +124,8 @@ export async function _signInWithRedirect(
  * Follow the {@link https://firebase.google.com/docs/auth/web/redirect-best-practices
  * | best practices} when using {@link reauthenticateWithRedirect}.
  *
- * This method does not work in a Node.js environment or with {@link Auth} instances created with a
- * {@link @firebase/app#FirebaseServerApp}.
+ * This method does not work in a Node.js environment or with {@link Auth} instances
+ * created with a {@link @firebase/app#FirebaseServerApp}.
  *
  * @example
  * ```javascript
@@ -199,8 +199,8 @@ export async function _reauthenticateWithRedirect(
  * Follow the {@link https://firebase.google.com/docs/auth/web/redirect-best-practices
  * | best practices} when using {@link linkWithRedirect}.
  *
- * This method does not work in a Node.js environment or with {@link Auth} instances created with a
- * {@link @firebase/app#FirebaseServerApp}.
+ * This method does not work in a Node.js environment or with {@link Auth} instances
+ * created with a {@link @firebase/app#FirebaseServerApp}.
  *
  * @example
  * ```javascript

--- a/packages/auth/src/platform_browser/strategies/redirect.ts
+++ b/packages/auth/src/platform_browser/strategies/redirect.ts
@@ -25,7 +25,7 @@ import {
 
 import { _castAuth } from '../../core/auth/auth_impl';
 import { _assertLinkedStatus } from '../../core/user/link_unlink';
-import { _assertInstanceOf } from '../../core/util/assert';
+import { _assertInstanceOf, _createError } from '../../core/util/assert';
 import { _generateEventId } from '../../core/util/event_id';
 import { AuthEventType } from '../../model/popup_redirect';
 import { UserInternal } from '../../model/user';
@@ -36,6 +36,8 @@ import {
 } from '../../core/strategies/redirect';
 import { FederatedAuthProvider } from '../../core/providers/federated';
 import { getModularInstance } from '@firebase/util';
+import { _isFirebaseServerApp } from '@firebase/app';
+import { AuthErrorCode } from '../../core/errors';
 
 /**
  * Authenticates a Firebase client using a full-page redirect flow.
@@ -45,7 +47,8 @@ import { getModularInstance } from '@firebase/util';
  * Follow the {@link https://firebase.google.com/docs/auth/web/redirect-best-practices
  * | best practices} when using {@link signInWithRedirect}.
  *
- * This method does not work in a Node.js environment.
+ * This method does not work in a Node.js environment or with {@link Auth} instances created with a
+ * {@link FirebaseServerApp}.
  *
  * @example
  * ```javascript
@@ -93,6 +96,11 @@ export async function _signInWithRedirect(
   provider: AuthProvider,
   resolver?: PopupRedirectResolver
 ): Promise<void | never> {
+  if (_isFirebaseServerApp(auth.app)) {
+    return Promise.reject(
+      _createError(auth, AuthErrorCode.OPERATION_NOT_SUPPORTED)
+    );
+  }
   const authInternal = _castAuth(auth);
   _assertInstanceOf(auth, provider, FederatedAuthProvider);
   // Wait for auth initialization to complete, this will process pending redirects and clear the
@@ -116,7 +124,8 @@ export async function _signInWithRedirect(
  * Follow the {@link https://firebase.google.com/docs/auth/web/redirect-best-practices
  * | best practices} when using {@link reauthenticateWithRedirect}.
  *
- * This method does not work in a Node.js environment.
+ * This method does not work in a Node.js environment or with {@link Auth} instances created with a
+ * {@link FirebaseServerApp}.
  *
  * @example
  * ```javascript
@@ -161,6 +170,11 @@ export async function _reauthenticateWithRedirect(
 ): Promise<void | never> {
   const userInternal = getModularInstance(user) as UserInternal;
   _assertInstanceOf(userInternal.auth, provider, FederatedAuthProvider);
+  if (_isFirebaseServerApp(userInternal.auth.app)) {
+    return Promise.reject(
+      _createError(userInternal.auth, AuthErrorCode.OPERATION_NOT_SUPPORTED)
+    );
+  }
   // Wait for auth initialization to complete, this will process pending redirects and clear the
   // PENDING_REDIRECT_KEY in persistence. This should be completed before starting a new
   // redirect and creating a PENDING_REDIRECT_KEY entry.
@@ -185,7 +199,8 @@ export async function _reauthenticateWithRedirect(
  * Follow the {@link https://firebase.google.com/docs/auth/web/redirect-best-practices
  * | best practices} when using {@link linkWithRedirect}.
  *
- * This method does not work in a Node.js environment.
+ * This method does not work in a Node.js environment or with {@link Auth} instances created with a
+ * {@link FirebaseServerApp}.
  *
  * @example
  * ```javascript
@@ -247,7 +262,8 @@ export async function _linkWithRedirect(
  * If sign-in succeeded, returns the signed in user. If sign-in was unsuccessful, fails with an
  * error. If no redirect operation was called, returns `null`.
  *
- * This method does not work in a Node.js environment.
+ * This method does not work in a Node.js environment or with {@link Auth} instances created with a
+ * {@link FirebaseServerApp}.
  *
  * @example
  * ```javascript
@@ -293,6 +309,11 @@ export async function _getRedirectResult(
   resolverExtern?: PopupRedirectResolver,
   bypassAuthState = false
 ): Promise<UserCredential | null> {
+  if (_isFirebaseServerApp(auth.app)) {
+    return Promise.reject(
+      _createError(auth, AuthErrorCode.OPERATION_NOT_SUPPORTED)
+    );
+  }
   const authInternal = _castAuth(auth);
   const resolver = _withDefaultResolver(authInternal, resolverExtern);
   const action = new RedirectAction(authInternal, resolver, bypassAuthState);

--- a/packages/auth/test/integration/flows/firebaseserverapp.test.ts
+++ b/packages/auth/test/integration/flows/firebaseserverapp.test.ts
@@ -21,16 +21,26 @@ import chaiAsPromised from 'chai-as-promised';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import {
   Auth,
-  OperationType,
   createUserWithEmailAndPassword,
+  EmailAuthProvider,
   getAdditionalUserInfo,
+  getRedirectResult,
+  GoogleAuthProvider,
   onAuthStateChanged,
+  OperationType,
+  reauthenticateWithCredential,
   signInAnonymously,
+  signInWithCredential,
+  signInWithCustomToken,
+  signInWithEmailAndPassword,
+  signInWithEmailLink,
+  signInWithRedirect,
   signOut,
+  updateCurrentUser,
   updateProfile
 } from '@firebase/auth';
-import { isBrowser } from '@firebase/util';
-import { initializeServerApp } from '@firebase/app';
+import { isBrowser, FirebaseError } from '@firebase/util';
+import { initializeServerApp, deleteApp } from '@firebase/app';
 
 import {
   cleanUpTestInstance,
@@ -47,17 +57,12 @@ const signInWaitDuration = 200;
 
 describe('Integration test: Auth FirebaseServerApp tests', () => {
   let auth: Auth;
-  let serverAppAuth: Auth | null;
 
   beforeEach(() => {
     auth = getTestInstance();
   });
 
   afterEach(async () => {
-    if (serverAppAuth) {
-      await signOut(serverAppAuth);
-      serverAppAuth = null;
-    }
     await cleanUpTestInstance(auth);
   });
 
@@ -79,7 +84,7 @@ describe('Integration test: Auth FirebaseServerApp tests', () => {
     const firebaseServerAppSettings = { authIdToken };
 
     const serverApp = initializeServerApp(auth.app, firebaseServerAppSettings);
-    serverAppAuth = getTestInstanceForServerApp(serverApp);
+    const serverAppAuth = getTestInstanceForServerApp(serverApp);
 
     console.log('auth.emulatorConfig ', auth.emulatorConfig);
     console.log('serverAuth.emulatorConfig ', serverAppAuth.emulatorConfig);
@@ -105,6 +110,8 @@ describe('Integration test: Auth FirebaseServerApp tests', () => {
     });
 
     expect(numberServerLogins).to.equal(1);
+
+    await deleteApp(serverApp);
   });
 
   it('getToken operations fullfilled or rejected', async () => {
@@ -126,7 +133,7 @@ describe('Integration test: Auth FirebaseServerApp tests', () => {
       getAppConfig(),
       firebaseServerAppSettings
     );
-    serverAppAuth = getTestInstanceForServerApp(serverApp);
+    const serverAppAuth = getTestInstanceForServerApp(serverApp);
     let numberServerLogins = 0;
     onAuthStateChanged(serverAppAuth, serverAuthUser => {
       if (serverAuthUser) {
@@ -154,6 +161,8 @@ describe('Integration test: Auth FirebaseServerApp tests', () => {
       await expect(serverAppAuth.currentUser.getIdToken(/*forceRefresh=*/ true))
         .to.be.rejected;
     }
+
+    await deleteApp(serverApp);
   });
 
   it('invalid token does not sign in user', async () => {
@@ -167,7 +176,7 @@ describe('Integration test: Auth FirebaseServerApp tests', () => {
       getAppConfig(),
       firebaseServerAppSettings
     );
-    serverAppAuth = getTestInstanceForServerApp(serverApp);
+    const serverAppAuth = getTestInstanceForServerApp(serverApp);
     expect(serverAppAuth.currentUser).to.be.null;
 
     let numberServerLogins = 0;
@@ -183,6 +192,8 @@ describe('Integration test: Auth FirebaseServerApp tests', () => {
 
     expect(numberServerLogins).to.equal(0);
     expect(serverAppAuth.currentUser).to.be.null;
+
+    await deleteApp(serverApp);
   });
 
   it('signs in with email crednetial user', async () => {
@@ -213,7 +224,7 @@ describe('Integration test: Auth FirebaseServerApp tests', () => {
       getAppConfig(),
       firebaseServerAppSettings
     );
-    serverAppAuth = getTestInstanceForServerApp(serverApp);
+    const serverAppAuth = getTestInstanceForServerApp(serverApp);
     let numberServerLogins = 0;
     onAuthStateChanged(serverAppAuth, serverAuthUser => {
       if (serverAuthUser) {
@@ -238,6 +249,8 @@ describe('Integration test: Auth FirebaseServerApp tests', () => {
     });
 
     expect(numberServerLogins).to.equal(1);
+
+    await deleteApp(serverApp);
   });
 
   it('can reload user', async () => {
@@ -258,7 +271,7 @@ describe('Integration test: Auth FirebaseServerApp tests', () => {
       getAppConfig(),
       firebaseServerAppSettings
     );
-    serverAppAuth = getTestInstanceForServerApp(serverApp);
+    const serverAppAuth = getTestInstanceForServerApp(serverApp);
     let numberServerLogins = 0;
     onAuthStateChanged(serverAppAuth, serverAuthUser => {
       if (serverAuthUser) {
@@ -280,6 +293,8 @@ describe('Integration test: Auth FirebaseServerApp tests', () => {
       await serverAppAuth.currentUser.reload();
     }
     expect(numberServerLogins).to.equal(1);
+
+    await deleteApp(serverApp);
   });
 
   it('can update server based user profile', async () => {
@@ -301,7 +316,7 @@ describe('Integration test: Auth FirebaseServerApp tests', () => {
       getAppConfig(),
       firebaseServerAppSettings
     );
-    serverAppAuth = getTestInstanceForServerApp(serverApp);
+    const serverAppAuth = getTestInstanceForServerApp(serverApp);
     let numberServerLogins = 0;
     const newDisplayName = 'newName';
     onAuthStateChanged(serverAppAuth, serverAuthUser => {
@@ -336,6 +351,8 @@ describe('Integration test: Auth FirebaseServerApp tests', () => {
       expect(serverAppAuth.currentUser?.displayName).to.not.be.null;
       expect(serverAppAuth.currentUser?.displayName).to.equal(newDisplayName);
     }
+
+    await deleteApp(serverApp);
   });
 
   it('can sign out of main auth and still use server auth', async () => {
@@ -357,7 +374,7 @@ describe('Integration test: Auth FirebaseServerApp tests', () => {
       getAppConfig(),
       firebaseServerAppSettings
     );
-    serverAppAuth = getTestInstanceForServerApp(serverApp);
+    const serverAppAuth = getTestInstanceForServerApp(serverApp);
     let numberServerLogins = 0;
     onAuthStateChanged(serverAppAuth, serverAuthUser => {
       if (serverAuthUser) {
@@ -387,5 +404,130 @@ describe('Integration test: Auth FirebaseServerApp tests', () => {
     if (serverAppAuth) {
       expect(serverAppAuth.currentUser).to.not.be.null;
     }
+
+    await deleteApp(serverApp);
+  });
+
+  it('auth operations fail correctly on FirebaseServerApp instances', async () => {
+    if (isBrowser()) {
+      return;
+    }
+    const userCred = await signInAnonymously(auth);
+    expect(auth.currentUser).to.eq(userCred.user);
+
+    const user = userCred.user;
+    expect(user).to.equal(auth.currentUser);
+    expect(user.uid).to.be.a('string');
+
+    const authIdToken = await user.getIdToken();
+    const firebaseServerAppSettings = { authIdToken };
+
+    const serverApp = initializeServerApp(
+      getAppConfig(),
+      firebaseServerAppSettings
+    );
+
+    const serverAppAuth = getTestInstanceForServerApp(serverApp);
+    await new Promise(resolve => {
+      setTimeout(resolve, signInWaitDuration);
+    });
+
+    expect(serverAppAuth.currentUser).to.not.be.null;
+    const email = randomEmail();
+    const password = 'password';
+
+    // Auth tests:
+    await expect(
+      createUserWithEmailAndPassword(serverAppAuth, email, password)
+    ).to.be.rejectedWith(
+      FirebaseError,
+      'operation-not-supported-in-this-environment'
+    );
+    await expect(
+      signInWithRedirect(serverAppAuth, new GoogleAuthProvider())
+    ).to.be.rejectedWith(
+      FirebaseError,
+      'operation-not-supported-in-this-environment'
+    );
+    await expect(getRedirectResult(serverAppAuth)).to.be.rejectedWith(
+      FirebaseError,
+      'operation-not-supported-in-this-environment'
+    );
+    await expect(signInAnonymously(serverAppAuth)).to.be.rejectedWith(
+      FirebaseError,
+      'operation-not-supported-in-this-environment'
+    );
+
+    const credential = EmailAuthProvider.credential(email, password);
+    await expect(
+      signInWithCredential(serverAppAuth, credential)
+    ).to.be.rejectedWith(
+      FirebaseError,
+      'operation-not-supported-in-this-environment'
+    );
+
+    await expect(
+      signInWithCustomToken(serverAppAuth, 'custom token')
+    ).to.be.rejectedWith(
+      FirebaseError,
+      'operation-not-supported-in-this-environment'
+    );
+    await expect(
+      signInWithEmailAndPassword(serverAppAuth, email, password)
+    ).to.be.rejectedWith(
+      FirebaseError,
+      'operation-not-supported-in-this-environment'
+    );
+    await expect(
+      signInWithEmailLink(serverAppAuth, email, 'email link')
+    ).to.be.rejectedWith(
+      FirebaseError,
+      'operation-not-supported-in-this-environment'
+    );
+    await expect(
+      updateCurrentUser(serverAppAuth, serverAppAuth.currentUser)
+    ).to.be.rejectedWith(
+      FirebaseError,
+      'operation-not-supported-in-this-environment'
+    );
+    await expect(
+      updateCurrentUser(serverAppAuth, serverAppAuth.currentUser)
+    ).to.be.rejectedWith(
+      FirebaseError,
+      'operation-not-supported-in-this-environment'
+    );
+    await expect(signOut(serverAppAuth)).to.be.rejectedWith(
+      FirebaseError,
+      'operation-not-supported-in-this-environment'
+    );
+
+    if (serverAppAuth.currentUser !== null) {
+      await expect(
+        reauthenticateWithCredential(serverAppAuth.currentUser, credential)
+      ).to.be.rejectedWith(
+        FirebaseError,
+        'operation-not-supported-in-this-environment'
+      );
+
+      console.log('DEDB deleting user');
+      await expect(serverAppAuth.currentUser.delete()).to.be.rejectedWith(
+        FirebaseError,
+        'operation-not-supported-in-this-environment'
+      );
+    }
+
+    // Note: the following methods aren't defined in this environment:
+    // Auth:
+    //  - setPersistence
+    //  - signInWithPhoneNumber
+    //  - signInWithPopup
+    //
+    // User:
+    //  - reauthenticateWithRedirect
+    //  - reauthenticateWithPhoneNumber
+    //  - reauthenticateWithPopup
+    //  - updatePhoneNumber
+
+    await deleteApp(serverApp);
   });
 });

--- a/packages/auth/test/integration/flows/firebaseserverapp.test.ts
+++ b/packages/auth/test/integration/flows/firebaseserverapp.test.ts
@@ -37,6 +37,7 @@ import {
   signInWithRedirect,
   signOut,
   updateCurrentUser,
+  updateEmail,
   updateProfile
 } from '@firebase/auth';
 import { isBrowser, FirebaseError } from '@firebase/util';
@@ -510,6 +511,13 @@ describe('Integration test: Auth FirebaseServerApp tests', () => {
       );
 
       await expect(serverAppAuth.currentUser.delete()).to.be.rejectedWith(
+        FirebaseError,
+        'operation-not-supported-in-this-environment'
+      );
+
+      await expect(
+        updateEmail(serverAppAuth.currentUser, email)
+      ).to.be.rejectedWith(
         FirebaseError,
         'operation-not-supported-in-this-environment'
       );

--- a/packages/auth/test/integration/flows/firebaseserverapp.test.ts
+++ b/packages/auth/test/integration/flows/firebaseserverapp.test.ts
@@ -509,24 +509,11 @@ describe('Integration test: Auth FirebaseServerApp tests', () => {
         'operation-not-supported-in-this-environment'
       );
 
-      console.log('DEDB deleting user');
       await expect(serverAppAuth.currentUser.delete()).to.be.rejectedWith(
         FirebaseError,
         'operation-not-supported-in-this-environment'
       );
     }
-
-    // Note: the following methods aren't defined in this environment:
-    // Auth:
-    //  - setPersistence
-    //  - signInWithPhoneNumber
-    //  - signInWithPopup
-    //
-    // User:
-    //  - reauthenticateWithRedirect
-    //  - reauthenticateWithPhoneNumber
-    //  - reauthenticateWithPopup
-    //  - updatePhoneNumber
 
     await deleteApp(serverApp);
   });


### PR DESCRIPTION
### Discussion

Updates FirebaseServerApp implementation in Auth to prevent operations that would change the currently logged in user. The user should be that of the authIdToken provided to FirebaseServerApp only.

Note: some of the method implementations currently reside in browser-only files. I added safe guards to these methods even though FirebaseServerApp is not supported in browser enviornments.  These guards protect us in case the methods are later adapted to other environments and/or migrated to other files that are not browser-only. The changes to the browser implementations produce little overhead, so I thought that safety first was the correct call here.

### Testing

New tests added.

### API Changes

N/A