### PR TITLE
Encode timestamp fraction according to the Proto3 JSON Specification.

### DIFF
--- a/.changeset/beige-worms-sleep.md
+++ b/.changeset/beige-worms-sleep.md
@@ -1,0 +1,5 @@
+---
+"@firebase/firestore": patch
+---
+
+Encode Timestamp fraction according to the Proto3 JSON Specification.

--- a/packages/firestore/src/remote/serializer.ts
+++ b/packages/firestore/src/remote/serializer.ts
@@ -213,10 +213,18 @@ export function toTimestamp(
     const jsDateStr = new Date(timestamp.seconds * 1000).toISOString();
     // Remove .xxx frac part and Z in the end.
     const strUntilSeconds = jsDateStr.replace(/\.\d*/, '').replace('Z', '');
-    // Pad the fraction out to 9 digits (nanos).
-    const nanoStr = ('000000000' + timestamp.nanoseconds).slice(-9);
 
-    return `${strUntilSeconds}.${nanoStr}Z`;
+    // If nanoseconds is 0, omit the decimal
+    if (timestamp.nanoseconds === 0) {
+      return `${strUntilSeconds}Z`;
+    }
+
+    // Pad the fraction out to 3, 6, or 9 digits
+    let microStr = ('000000000' + timestamp.nanoseconds).slice(-9);
+    while (microStr.endsWith('000')) {
+      microStr = microStr.slice(0, microStr.length - 3);
+    }
+    return `${strUntilSeconds}.${microStr}Z`;
   } else {
     return {
       seconds: '' + timestamp.seconds,

--- a/packages/firestore/test/unit/remote/serializer.helper.ts
+++ b/packages/firestore/test/unit/remote/serializer.helper.ts
@@ -323,16 +323,19 @@ export function serializerTest(
       it('converts TimestampValue from proto', () => {
         const examples = [
           new Timestamp(1451730050, 850000000),
+          new Timestamp(1451730050, 850100000),
           new Timestamp(1466160615, 0)
         ];
 
         const expectedJson = [
-          '2016-01-02T10:20:50.850000000Z',
-          '2016-06-17T10:50:15.000000000Z'
+          '2016-01-02T10:20:50.850Z',
+          '2016-01-02T10:20:50.850100Z',
+          '2016-06-17T10:50:15Z'
         ];
 
         const expectedProtoJs = [
           { seconds: '1451730050', nanos: 850000000 },
+          { seconds: '1451730050', nanos: 850100000 },
           { seconds: '1466160615', nanos: 0 }
         ];
 
@@ -379,7 +382,7 @@ export function serializerTest(
             'timestampConversion',
             new Timestamp(1488872578, 916123000)
           )
-        ).to.deep.equal({ timestampValue: '2017-03-07T07:42:58.916123000Z' });
+        ).to.deep.equal({ timestampValue: '2017-03-07T07:42:58.916123Z' });
 
         expect(
           parseQueryValue(
@@ -387,7 +390,7 @@ export function serializerTest(
             'timestampConversion',
             new Timestamp(1488872578, 916000000)
           )
-        ).to.deep.equal({ timestampValue: '2017-03-07T07:42:58.916000000Z' });
+        ).to.deep.equal({ timestampValue: '2017-03-07T07:42:58.916Z' });
 
         expect(
           parseQueryValue(
@@ -395,7 +398,15 @@ export function serializerTest(
             'timestampConversion',
             new Timestamp(1488872578, 916000)
           )
-        ).to.deep.equal({ timestampValue: '2017-03-07T07:42:58.000916000Z' });
+        ).to.deep.equal({ timestampValue: '2017-03-07T07:42:58.000916Z' });
+
+        expect(
+          parseQueryValue(
+            protobufJsonReader,
+            'timestampConversion',
+            new Timestamp(1488872578, 916999)
+          )
+        ).to.deep.equal({ timestampValue: '2017-03-07T07:42:58.000916Z' });
 
         expect(
           parseQueryValue(
@@ -403,7 +414,7 @@ export function serializerTest(
             'timestampConversion',
             new Timestamp(1488872578, 0)
           )
-        ).to.deep.equal({ timestampValue: '2017-03-07T07:42:58.000000000Z' });
+        ).to.deep.equal({ timestampValue: '2017-03-07T07:42:58Z' });
       });
 
       it('converts GeoPointValue', () => {


### PR DESCRIPTION
The SDK encodes a string representation of a timestamp for use as the key value in client side indexes. For this, and other reason, the SDK and Firestore backend must stringify timestamps identically.

Fixes: #8031 