### PR TITLE
Bump undici due to security issue

### DIFF
--- a/integration/messaging/package.json
+++ b/integration/messaging/package.json
@@ -15,7 +15,7 @@
     "express": "4.18.2",
     "geckodriver": "2.0.4",
     "mocha": "9.2.2",
-    "undici": "5.26.5",
+    "undici": "5.28.3",
     "selenium-assistant": "6.1.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -153,7 +153,7 @@
     "tslint": "6.1.3",
     "typedoc": "0.16.11",
     "typescript": "4.7.4",
-    "undici": "5.26.5",
+    "undici": "5.28.3",
     "watch": "1.0.2",
     "webpack": "5.76.0",
     "yargs": "17.7.2"

--- a/packages/auth-compat/package.json
+++ b/packages/auth-compat/package.json
@@ -54,7 +54,7 @@
     "@firebase/auth-types": "0.12.0",
     "@firebase/component": "0.6.5",
     "@firebase/util": "1.9.4",
-    "undici": "5.26.5",
+    "undici": "5.28.3",
     "tslib": "^2.1.0"
   },
   "license": "Apache-2.0",

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -129,7 +129,7 @@
     "@firebase/component": "0.6.5",
     "@firebase/logger": "0.4.0",
     "@firebase/util": "1.9.4",
-    "undici": "5.26.5",
+    "undici": "5.28.3",
     "tslib": "^2.1.0"
   },
   "license": "Apache-2.0",

--- a/packages/firestore/package.json
+++ b/packages/firestore/package.json
@@ -102,7 +102,7 @@
     "@firebase/webchannel-wrapper": "0.10.5",
     "@grpc/grpc-js": "~1.9.0",
     "@grpc/proto-loader": "^0.7.8",
-    "undici": "5.26.5",
+    "undici": "5.28.3",
     "tslib": "^2.1.0"
   },
   "peerDependencies": {

--- a/packages/functions/package.json
+++ b/packages/functions/package.json
@@ -71,7 +71,7 @@
     "@firebase/auth-interop-types": "0.2.1",
     "@firebase/app-check-interop-types": "0.3.0",
     "@firebase/util": "1.9.4",
-    "undici": "5.26.5",
+    "undici": "5.28.3",
     "tslib": "^2.1.0"
   },
   "nyc": {

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -48,7 +48,7 @@
   "dependencies": {
     "@firebase/util": "1.9.4",
     "@firebase/component": "0.6.5",
-    "undici": "5.26.5",
+    "undici": "5.28.3",
     "tslib": "^2.1.0"
   },
   "peerDependencies": {

--- a/repo-scripts/changelog-generator/package.json
+++ b/repo-scripts/changelog-generator/package.json
@@ -20,7 +20,7 @@
     "@changesets/types": "3.3.0",
     "@changesets/get-github-info": "0.5.2",
     "@types/node": "20.8.10",
-    "undici": "5.26.5"
+    "undici": "5.28.3"
   },
   "license": "Apache-2.0",
   "devDependencies": {


### PR DESCRIPTION
See https://github.com/advisories/GHSA-3787-6prv-h9w3

For reference, `undici` is used to polyfill `fetch` in our Node bundles, as we are not restricting Node support to 18+ yet.

Fixes https://github.com/firebase/firebase-js-sdk/issues/8038