### PR TITLE
Fix chromedriver issue 2

### DIFF
--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -24,7 +24,7 @@ env:
   # The default behavior of chromedriver uses the older Chrome download URLs. We need to override
   # the beahvior to use the new URLs.
   CHROMEDRIVER_CDNURL: https://googlechromelabs.github.io/
-  CHROMEDRIVER_CDNBINARIESURL: https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/
+  CHROMEDRIVER_CDNBINARIESURL: https://storage.googleapis.com/chrome-for-testing-public
   CHROME_VALIDATED_VERSION: linux-120.0.6099.71
   CHROME_VERSION_MISMATCH_MESSAGE: "The Chrome version doesn't match the previously validated version. Consider updating CHROME_VALIDATED_VERSION in the GitHub workflow if tests pass."
   artifactRetentionDays: 14

--- a/.github/workflows/test-changed-auth.yml
+++ b/.github/workflows/test-changed-auth.yml
@@ -22,7 +22,7 @@ env:
   # The default behavior of chromedriver uses the older Chrome download URLs. We need to override
   # the beahvior to use the new URLs.
   CHROMEDRIVER_CDNURL: https://googlechromelabs.github.io/
-  CHROMEDRIVER_CDNBINARIESURL: https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/
+  CHROMEDRIVER_CDNBINARIESURL: https://storage.googleapis.com/chrome-for-testing-public
   CHROME_VALIDATED_VERSION: linux-120.0.6099.71
   # Bump Node memory limit
   NODE_OPTIONS: "--max_old_space_size=4096"

--- a/integration/messaging/package.json
+++ b/integration/messaging/package.json
@@ -11,7 +11,7 @@
   "devDependencies": {
     "firebase": "10.8.0",
     "chai": "4.3.7",
-    "chromedriver": "114.0.2",
+    "chromedriver": "116.0.0",
     "express": "4.18.2",
     "geckodriver": "2.0.4",
     "mocha": "9.2.2",

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -138,7 +138,7 @@
     "@rollup/plugin-json": "4.1.0",
     "@rollup/plugin-strip": "2.1.0",
     "@types/express": "4.17.17",
-    "chromedriver": "114.0.2",
+    "chromedriver": "116.0.0",
     "rollup": "2.79.1",
     "rollup-plugin-sourcemaps": "0.6.3",
     "rollup-plugin-typescript2": "0.31.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5583,14 +5583,14 @@ chrome-trace-event@^1.0.2:
   resolved "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.3.tgz"
   integrity sha512-p3KULyQg4S7NIHixdwbGX+nFHkoBiA4YQmyWtjb8XngSKV124nJmRysgAeujbUVb15vh+RvFUfCPqU7rXk+hZg==
 
-chromedriver@114.0.2:
-  version "114.0.2"
-  resolved "https://registry.npmjs.org/chromedriver/-/chromedriver-114.0.2.tgz"
-  integrity sha512-v0qrXRBknbxqmtklG7RWOe3TJ/dLaHhtB0jVxE7BAdYERxUjEaNRyqBwoGgVfQDibHCB0swzvzsj158nnfPgZw==
+chromedriver@116.0.0:
+  version "116.0.0"
+  resolved "https://registry.npmjs.org/chromedriver/-/chromedriver-116.0.0.tgz#3f5d07b5427953270461791651d7b68cb6afe9fe"
+  integrity sha512-/TQaRn+RUAYnVqy5Vx8VtU8DvtWosU8QLM2u7BoNM5h55PRQPXF/onHAehEi8Sj/CehdKqH50NFdiumQAUr0DQ==
   dependencies:
     "@testim/chrome-version" "^1.1.3"
     axios "^1.4.0"
-    compare-versions "^5.0.3"
+    compare-versions "^6.0.0"
     extract-zip "^2.0.1"
     https-proxy-agent "^5.0.1"
     proxy-from-env "^1.1.0"
@@ -5955,10 +5955,10 @@ compare-func@^2.0.0:
     array-ify "^1.0.0"
     dot-prop "^5.1.0"
 
-compare-versions@^5.0.3:
-  version "5.0.3"
-  resolved "https://registry.npmjs.org/compare-versions/-/compare-versions-5.0.3.tgz"
-  integrity sha512-4UZlZP8Z99MGEY+Ovg/uJxJuvoXuN4M6B3hKaiackiHrgzQFEe3diJi1mf1PNHbFujM7FvLrK2bpgIaImbtZ1A==
+compare-versions@^6.0.0:
+  version "6.1.0"
+  resolved "https://registry.npmjs.org/compare-versions/-/compare-versions-6.1.0.tgz#3f2131e3ae93577df111dba133e6db876ffe127a"
+  integrity sha512-LNZQXhqUvqUTotpZ00qLSaify3b4VFD588aRr8MKFw4CMUr98ytzCW5wDH5qx/DEY5kCDXcbcRuCqL0szEf2tg==
 
 component-emitter@^1.2.1, component-emitter@~1.3.0:
   version "1.3.0"


### PR DESCRIPTION
We're having some CI issues on npm install for auth tests. Seems to be related to a new url for downloading chrome.

https://github.com/puppeteer/puppeteer/pull/11923

I bumped the `chromedriver` NPM package to version 116.0.0 because I think it needs to be above 115 in order to use this env variable (see https://github.com/giggio/node-chromedriver?tab=readme-ov-file#for-versions--115) but starting with 117.0.0 it requires Node 18+ which we're not ready to convert our workflows to.