### PR TITLE
Analytics: Fix update consent method

### DIFF
--- a/.changeset/fluffy-cherries-fetch.md
+++ b/.changeset/fluffy-cherries-fetch.md
@@ -1,0 +1,5 @@
+---
+'@firebase/analytics': patch
+---
+
+Fix for update consents method. User consents were not being updated correctly.

--- a/packages/analytics/src/helpers.ts
+++ b/packages/analytics/src/helpers.ts
@@ -304,7 +304,6 @@ function wrapGtag(
           gtagParams as GtagConfigOrEventParams
         );
       } else if (command === GtagCommand.CONSENT) {
-        // If CONSENT, second arg must be 'default' or 'update'
         const [gtagMethod, gtagParams] = args;
         gtagCore(GtagCommand.CONSENT, 'update', gtagParams as ConsentSettings);
       } else if (command === GtagCommand.GET) {

--- a/packages/analytics/src/helpers.ts
+++ b/packages/analytics/src/helpers.ts
@@ -304,7 +304,8 @@ function wrapGtag(
           gtagParams as GtagConfigOrEventParams
         );
       } else if (command === GtagCommand.CONSENT) {
-        const [gtagParams] = args;
+        // If CONSENT, second arg must be 'default' or 'update'
+        const [gtagMethod, gtagParams] = args;
         gtagCore(GtagCommand.CONSENT, 'update', gtagParams as ConsentSettings);
       } else if (command === GtagCommand.GET) {
         const [measurementId, fieldName, callback] = args;


### PR DESCRIPTION
To send the user's consent status, second arg must be 'default' or 'update'

```javascript
gtag('consent', 'update', {
    'analytics_storage': 'granted',
    // ....
});
```

While destructing args in `gtagWrapper`, the first item is the string, and `ConsentSettings` is given as the second parameter.

```javascript
const [gtagParams] = args; // args is [ 'update', { 'analytics_storage': ... } ]
gtagCore(GtagCommand.CONSENT, 'update', gtagParams as ConsentSettings); // gtagParams is 'update' in this case
```