### PR TITLE
Enforce authTokenSyncURL being a path and not a url.

### DIFF
--- a/.changeset/thirty-otters-hug.md
+++ b/.changeset/thirty-otters-hug.md
@@ -1,0 +1,5 @@
+---
+'@firebase/auth': patch
+---
+
+Fix possible XSS vulnerability through **FIREBASE_DEFAULTS** settings.

--- a/packages/auth/src/platform_browser/index.ts
+++ b/packages/auth/src/platform_browser/index.ts
@@ -89,9 +89,11 @@ export function getAuth(app: FirebaseApp = getApp()): Auth {
     ]
   });
 
-  const authTokenSyncUrl = getExperimentalSetting('authTokenSyncURL');
-  if (authTokenSyncUrl) {
-    const mintCookie = mintCookieFactory(authTokenSyncUrl);
+  const authTokenSyncPath = getExperimentalSetting('authTokenSyncURL');
+  // Don't allow urls (XSS possibility), only paths on the same domain
+  // (starting with '/')
+  if (authTokenSyncPath && authTokenSyncPath.startsWith('/')) {
+    const mintCookie = mintCookieFactory(authTokenSyncPath);
     beforeAuthStateChanged(auth, mintCookie, () =>
       mintCookie(auth.currentUser)
     );


### PR DESCRIPTION
The `_authTokenSyncURL` property coming from the __FIREBASE_DEFAULTS__ autoinit (for frameworks tooling) should only point to the same domain and be a relative path. Do not set the cookie if this is not a relative path (such as if it is a full url), as this could be a possible vulnerability.

See b/327386166