### PR TITLE
Fix glob pattern to work with Node 20 and its NPM version

### DIFF
--- a/.changeset/selfish-donkeys-cheer.md
+++ b/.changeset/selfish-donkeys-cheer.md
@@ -1,0 +1,5 @@
+---
+'firebase': patch
+---
+
+Fix glob pattern to work with Node 20 and its NPM version.

--- a/packages/firebase/package.json
+++ b/packages/firebase/package.json
@@ -16,7 +16,7 @@
     "remote-config"
   ],
   "files": [
-    "**/dist/",
+    "**/dist/**/*",
     "**/package.json",
     "/firebase*.js",
     "/firebase*.map",


### PR DESCRIPTION
We are upgrading all our Github workflows from Node 16 and Node 20, and noticed this broke E2E tests that install from NPM.

It seems sometime between Node 16 and Node 18 there may have been a bump in NPM version, and this NPM change has a difference in the way it handles glob patterns in the `files` field `package.json`. Previously we used the pattern `"**/dist/"` and it included any file in any `dist` folder under `packages/firebase`, but after the bump to Node 20 (and consequent NPM version bump) it only included `package.json` files, no js or ts files, basically removing the entry points to all modular versions of products.

When changed to `"**/dist/**/*"`, it seems to work as it previously did.

If not fixed, this will break all releases.