### PR TITLE
Prevent using authTokenSyncURL if the string begins with a double slash

### DIFF
--- a/.changeset/bright-avocados-attack.md
+++ b/.changeset/bright-avocados-attack.md
@@ -1,0 +1,5 @@
+---
+'@firebase/auth': patch
+---
+
+Do not allow double slash at beginning of authTokenSyncURL. (follow-up fix to https://github.com/firebase/firebase-js-sdk/pull/8056)

--- a/packages/auth/src/platform_browser/index.ts
+++ b/packages/auth/src/platform_browser/index.ts
@@ -91,8 +91,8 @@ export function getAuth(app: FirebaseApp = getApp()): Auth {
 
   const authTokenSyncPath = getExperimentalSetting('authTokenSyncURL');
   // Don't allow urls (XSS possibility), only paths on the same domain
-  // (starting with '/')
-  if (authTokenSyncPath && authTokenSyncPath.startsWith('/')) {
+  // (starting with a single '/')
+  if (authTokenSyncPath && authTokenSyncPath.match(/^\/[^\/].*/)) {
     const mintCookie = mintCookieFactory(authTokenSyncPath);
     beforeAuthStateChanged(auth, mintCookie, () =>
       mintCookie(auth.currentUser)


### PR DESCRIPTION
Additional fix to https://github.com/firebase/firebase-js-sdk/pull/8056 to prevent the string beginning with a double slash.