### PR TITLE
Enable previously failing `(Firestore) Node.js and Browser (Chrome) Tests`

### DIFF
--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -161,7 +161,7 @@ jobs:
     name: (Firestore) Node.js and Browser (Chrome) Tests
     needs: build
     runs-on: ubuntu-latest
-    if: false
+    # if: false
     # Disable test for now since it's failing 100% of the time since
     # https://github.com/firebase/firebase-js-sdk/pull/7453 and it needs to be investigated.
     steps:

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -161,9 +161,6 @@ jobs:
     name: (Firestore) Node.js and Browser (Chrome) Tests
     needs: build
     runs-on: ubuntu-latest
-    # if: false
-    # Disable test for now since it's failing 100% of the time since
-    # https://github.com/firebase/firebase-js-sdk/pull/7453 and it needs to be investigated.
     steps:
     # install Chrome so the correct version of webdriver can be installed by chromedriver when setting up the repo
     - name: install Chrome stable

--- a/scripts/ci/check_changeset.ts
+++ b/scripts/ci/check_changeset.ts
@@ -46,7 +46,7 @@ const bumpRank: Record<string, number> = {
 
 /**
  * Get highest bump that isn't the main firebase package, return
-// numerical rank, bump text, package name.
+ * numerical rank, bump text, package name.
  */
 function getHighestBump(changesetPackages: Record<string, string>) {
   const firebasePkgJson = require(resolve(


### PR DESCRIPTION
### Discussion

A Firestore CI test configuration was previously disabled in our GitHub action Workflows due to a 100% failure rate. While revisiting this issue months later, it seems that the test now passes. This might be related to our Node v20 CI upgrade.

As a bonus, fixed a comment typo in the check changeset script.

### Testing

CI

### API Changes

N/A