### PR TITLE
More complex check for authTokenSyncUrl

### DIFF
--- a/.changeset/green-mugs-protect.md
+++ b/.changeset/green-mugs-protect.md
@@ -1,0 +1,5 @@
+---
+'@firebase/auth': patch
+---
+
+Additional protection against misuse of the authTokenSyncURL experiment

--- a/packages/auth/src/platform_browser/index.ts
+++ b/packages/auth/src/platform_browser/index.ts
@@ -91,7 +91,11 @@ export function getAuth(app: FirebaseApp = getApp()): Auth {
 
   const authTokenSyncPath = getExperimentalSetting('authTokenSyncURL');
   // Only do the Cookie exchange in a secure context
-  if (authTokenSyncPath && isSecureContext) {
+  if (
+    authTokenSyncPath &&
+    typeof isSecureContext === 'boolean' &&
+    isSecureContext
+  ) {
     // Don't allow urls (XSS possibility), only paths on the same domain
     const authTokenSyncUrl = new URL(authTokenSyncPath, location.origin);
     if (location.origin === authTokenSyncUrl.origin) {

--- a/packages/auth/src/platform_browser/index.ts
+++ b/packages/auth/src/platform_browser/index.ts
@@ -90,20 +90,14 @@ export function getAuth(app: FirebaseApp = getApp()): Auth {
   });
 
   const authTokenSyncPath = getExperimentalSetting('authTokenSyncURL');
-  if (authTokenSyncPath) {
-    // Reduce the chances of an XSS attack by only allowing secure contexts or the same origin.
-    const isLocalHost = ['localhost', '127.0.0.1', '0.0.0.0'].includes(
-      location.hostname
-    );
-    if (isSecureContext || isLocalHost) {
-      const authTokenSyncUrl = new URL(authTokenSyncPath, location.origin);
-      if (location.origin === authTokenSyncUrl.origin) {
-        const mintCookie = mintCookieFactory(authTokenSyncUrl.toString());
-        beforeAuthStateChanged(auth, mintCookie, () =>
-          mintCookie(auth.currentUser)
-        );
-        onIdTokenChanged(auth, user => mintCookie(user));
-      }
+  if (authTokenSyncPath && isSecureContext) {
+    const authTokenSyncUrl = new URL(authTokenSyncPath, location.origin);
+    if (location.origin === authTokenSyncUrl.origin) {
+      const mintCookie = mintCookieFactory(authTokenSyncUrl.toString());
+      beforeAuthStateChanged(auth, mintCookie, () =>
+        mintCookie(auth.currentUser)
+      );
+      onIdTokenChanged(auth, user => mintCookie(user));
     }
   }
 

--- a/packages/auth/src/platform_browser/index.ts
+++ b/packages/auth/src/platform_browser/index.ts
@@ -92,7 +92,9 @@ export function getAuth(app: FirebaseApp = getApp()): Auth {
   const authTokenSyncPath = getExperimentalSetting('authTokenSyncURL');
   if (authTokenSyncPath) {
     // Reduce the chances of an XSS attack by only allowing secure contexts or the same origin.
-    const isLocalHost = ['localhost', '127.0.0.1', '0.0.0.0'].includes(location.hostname);
+    const isLocalHost = ['localhost', '127.0.0.1', '0.0.0.0'].includes(
+      location.hostname
+    );
     if (isSecureContext || isLocalHost) {
       const authTokenSyncUrl = new URL(authTokenSyncPath, location.origin);
       if (location.origin === authTokenSyncUrl.origin) {

--- a/packages/auth/src/platform_browser/index.ts
+++ b/packages/auth/src/platform_browser/index.ts
@@ -90,7 +90,9 @@ export function getAuth(app: FirebaseApp = getApp()): Auth {
   });
 
   const authTokenSyncPath = getExperimentalSetting('authTokenSyncURL');
+  // Only do the Cookie exchange in a secure context
   if (authTokenSyncPath && isSecureContext) {
+    // Don't allow urls (XSS possibility), only paths on the same domain
     const authTokenSyncUrl = new URL(authTokenSyncPath, location.origin);
     if (location.origin === authTokenSyncUrl.origin) {
       const mintCookie = mintCookieFactory(authTokenSyncUrl.toString());


### PR DESCRIPTION
* Don't allow insecure context, unless localhost
* Protect against escaping hacks by instantiating a new URL instance

b/327386166

FYI @hsubox76

Q, should we guard against isSecureContext not being available? [Can I use isSecureContext?](https://caniuse.com/mdn-api_issecurecontext)