### PR TITLE
Run npm pkg fix on all packages

### DIFF
--- a/.changeset/thick-eagles-collect.md
+++ b/.changeset/thick-eagles-collect.md
@@ -1,0 +1,51 @@
+---
+'@firebase/analytics-interop-types': patch
+'@firebase/app-check-interop-types': patch
+'@firebase/messaging-interop-types': patch
+'@firebase/installations-compat': patch
+'@firebase/remote-config-compat': patch
+'@firebase/installations-types': patch
+'@firebase/remote-config-types': patch
+'@firebase/auth-interop-types': patch
+'@firebase/performance-compat': patch
+'@firebase/rules-unit-testing': patch
+'@firebase/webchannel-wrapper': patch
+'@firebase/performance-types': patch
+'@firebase/analytics-compat': patch
+'@firebase/app-check-compat': patch
+'@firebase/firestore-compat': patch
+'@firebase/functions-compat': patch
+'@firebase/messaging-compat': patch
+'@firebase/analytics-types': patch
+'@firebase/app-check-types': patch
+'@firebase/database-compat': patch
+'@firebase/firestore-types': patch
+'@firebase/functions-types': patch
+'@firebase/database-types': patch
+'@firebase/storage-compat': patch
+'@firebase/template-types': patch
+'@firebase/installations': patch
+'@firebase/remote-config': patch
+'@firebase/storage-types': patch
+'@firebase/auth-compat': patch
+'@firebase/performance': patch
+'@firebase/app-compat': patch
+'@firebase/auth-types': patch
+'@firebase/analytics': patch
+'@firebase/app-check': patch
+'@firebase/app-types': patch
+'@firebase/component': patch
+'@firebase/firestore': patch
+'@firebase/functions': patch
+'@firebase/messaging': patch
+'@firebase/database': patch
+'firebase': patch
+'@firebase/template': patch
+'@firebase/storage': patch
+'@firebase/logger': patch
+'@firebase/auth': patch
+'@firebase/util': patch
+'@firebase/app': patch
+---
+
+Update `repository.url` field in all `package.json` files to NPM's preferred format.

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/firebase/firebase-js-sdk.git"
+    "url": "git+https://github.com/firebase/firebase-js-sdk.git"
   },
   "workspaces": [
     "packages/*",

--- a/packages/analytics-compat/package.json
+++ b/packages/analytics-compat/package.json
@@ -33,7 +33,7 @@
   "repository": {
     "directory": "packages/analytics-compat",
     "type": "git",
-    "url": "https://github.com/firebase/firebase-js-sdk.git"
+    "url": "git+https://github.com/firebase/firebase-js-sdk.git"
   },
   "bugs": {
     "url": "https://github.com/firebase/firebase-js-sdk/issues"

--- a/packages/analytics-interop-types/package.json
+++ b/packages/analytics-interop-types/package.json
@@ -14,7 +14,7 @@
   "repository": {
     "directory": "packages/analytics-interop-types",
     "type": "git",
-    "url": "https://github.com/firebase/firebase-js-sdk.git"
+    "url": "git+https://github.com/firebase/firebase-js-sdk.git"
   },
   "bugs": {
     "url": "https://github.com/firebase/firebase-js-sdk/issues"

--- a/packages/analytics-types/package.json
+++ b/packages/analytics-types/package.json
@@ -14,7 +14,7 @@
   "repository": {
     "directory": "packages/analytics-types",
     "type": "git",
-    "url": "https://github.com/firebase/firebase-js-sdk.git"
+    "url": "git+https://github.com/firebase/firebase-js-sdk.git"
   },
   "bugs": {
     "url": "https://github.com/firebase/firebase-js-sdk/issues"

--- a/packages/analytics/package.json
+++ b/packages/analytics/package.json
@@ -59,7 +59,7 @@
   "repository": {
     "directory": "packages/analytics",
     "type": "git",
-    "url": "https://github.com/firebase/firebase-js-sdk.git"
+    "url": "git+https://github.com/firebase/firebase-js-sdk.git"
   },
   "bugs": {
     "url": "https://github.com/firebase/firebase-js-sdk/issues"

--- a/packages/app-check-compat/package.json
+++ b/packages/app-check-compat/package.json
@@ -55,7 +55,7 @@
   "repository": {
     "directory": "packages/app-check",
     "type": "git",
-    "url": "https://github.com/firebase/firebase-js-sdk.git"
+    "url": "git+https://github.com/firebase/firebase-js-sdk.git"
   },
   "bugs": {
     "url": "https://github.com/firebase/firebase-js-sdk/issues"

--- a/packages/app-check-interop-types/package.json
+++ b/packages/app-check-interop-types/package.json
@@ -14,7 +14,7 @@
   "repository": {
     "directory": "packages/app-check-interop-types",
     "type": "git",
-    "url": "https://github.com/firebase/firebase-js-sdk.git"
+    "url": "git+https://github.com/firebase/firebase-js-sdk.git"
   },
   "bugs": {
     "url": "https://github.com/firebase/firebase-js-sdk/issues"

--- a/packages/app-check-types/package.json
+++ b/packages/app-check-types/package.json
@@ -14,7 +14,7 @@
   "repository": {
     "directory": "packages/app-check-types",
     "type": "git",
-    "url": "https://github.com/firebase/firebase-js-sdk.git"
+    "url": "git+https://github.com/firebase/firebase-js-sdk.git"
   },
   "bugs": {
     "url": "https://github.com/firebase/firebase-js-sdk/issues"

--- a/packages/app-check/package.json
+++ b/packages/app-check/package.json
@@ -56,7 +56,7 @@
   "repository": {
     "directory": "packages/app-check",
     "type": "git",
-    "url": "https://github.com/firebase/firebase-js-sdk.git"
+    "url": "git+https://github.com/firebase/firebase-js-sdk.git"
   },
   "bugs": {
     "url": "https://github.com/firebase/firebase-js-sdk/issues"

--- a/packages/app-compat/package.json
+++ b/packages/app-compat/package.json
@@ -56,7 +56,7 @@
   "repository": {
     "directory": "packages/app-compat",
     "type": "git",
-    "url": "https://github.com/firebase/firebase-js-sdk.git"
+    "url": "git+https://github.com/firebase/firebase-js-sdk.git"
   },
   "bugs": {
     "url": "https://github.com/firebase/firebase-js-sdk/issues"

--- a/packages/app-types/package.json
+++ b/packages/app-types/package.json
@@ -15,7 +15,7 @@
   "repository": {
     "directory": "packages/app-types",
     "type": "git",
-    "url": "https://github.com/firebase/firebase-js-sdk.git"
+    "url": "git+https://github.com/firebase/firebase-js-sdk.git"
   },
   "bugs": {
     "url": "https://github.com/firebase/firebase-js-sdk/issues"

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -56,7 +56,7 @@
   "repository": {
     "directory": "packages/app",
     "type": "git",
-    "url": "https://github.com/firebase/firebase-js-sdk.git"
+    "url": "git+https://github.com/firebase/firebase-js-sdk.git"
   },
   "bugs": {
     "url": "https://github.com/firebase/firebase-js-sdk/issues"

--- a/packages/auth-compat/demo/package.json
+++ b/packages/auth-compat/demo/package.json
@@ -39,7 +39,7 @@
   "repository": {
     "directory": "packages/auth-compat/demo",
     "type": "git",
-    "url": "https://github.com/firebase/firebase-js-sdk.git"
+    "url": "git+https://github.com/firebase/firebase-js-sdk.git"
   },
   "bugs": {
     "url": "https://github.com/firebase/firebase-js-sdk/issues"

--- a/packages/auth-compat/package.json
+++ b/packages/auth-compat/package.json
@@ -70,7 +70,7 @@
   "repository": {
     "directory": "packages/auth-compat",
     "type": "git",
-    "url": "https://github.com/firebase/firebase-js-sdk.git"
+    "url": "git+https://github.com/firebase/firebase-js-sdk.git"
   },
   "bugs": {
     "url": "https://github.com/firebase/firebase-js-sdk/issues"

--- a/packages/auth-interop-types/package.json
+++ b/packages/auth-interop-types/package.json
@@ -14,7 +14,7 @@
   "repository": {
     "directory": "packages/auth-types",
     "type": "git",
-    "url": "https://github.com/firebase/firebase-js-sdk.git"
+    "url": "git+https://github.com/firebase/firebase-js-sdk.git"
   },
   "bugs": {
     "url": "https://github.com/firebase/firebase-js-sdk/issues"

--- a/packages/auth-types/package.json
+++ b/packages/auth-types/package.json
@@ -18,7 +18,7 @@
   "repository": {
     "directory": "packages/auth-types",
     "type": "git",
-    "url": "https://github.com/firebase/firebase-js-sdk.git"
+    "url": "git+https://github.com/firebase/firebase-js-sdk.git"
   },
   "bugs": {
     "url": "https://github.com/firebase/firebase-js-sdk/issues"

--- a/packages/auth/demo/package.json
+++ b/packages/auth/demo/package.json
@@ -38,7 +38,7 @@
   "repository": {
     "directory": "packages/auth/demo",
     "type": "git",
-    "url": "https://github.com/firebase/firebase-js-sdk.git"
+    "url": "git+https://github.com/firebase/firebase-js-sdk.git"
   },
   "bugs": {
     "url": "https://github.com/firebase/firebase-js-sdk/issues"

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -149,7 +149,7 @@
   "repository": {
     "directory": "packages/auth",
     "type": "git",
-    "url": "https://github.com/firebase/firebase-js-sdk.git"
+    "url": "git+https://github.com/firebase/firebase-js-sdk.git"
   },
   "bugs": {
     "url": "https://github.com/firebase/firebase-js-sdk/issues"

--- a/packages/component/package.json
+++ b/packages/component/package.json
@@ -44,7 +44,7 @@
   "repository": {
     "directory": "packages/component",
     "type": "git",
-    "url": "https://github.com/firebase/firebase-js-sdk.git"
+    "url": "git+https://github.com/firebase/firebase-js-sdk.git"
   },
   "bugs": {
     "url": "https://github.com/firebase/firebase-js-sdk/issues"

--- a/packages/database-compat/package.json
+++ b/packages/database-compat/package.json
@@ -64,7 +64,7 @@
   "repository": {
     "directory": "packages/database-compat",
     "type": "git",
-    "url": "https://github.com/firebase/firebase-js-sdk.git"
+    "url": "git+https://github.com/firebase/firebase-js-sdk.git"
   },
   "bugs": {
     "url": "https://github.com/firebase/firebase-js-sdk/issues"

--- a/packages/database-types/package.json
+++ b/packages/database-types/package.json
@@ -18,7 +18,7 @@
   "repository": {
     "directory": "packages/database-types",
     "type": "git",
-    "url": "https://github.com/firebase/firebase-js-sdk.git"
+    "url": "git+https://github.com/firebase/firebase-js-sdk.git"
   },
   "bugs": {
     "url": "https://github.com/firebase/firebase-js-sdk/issues"

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -66,7 +66,7 @@
   "repository": {
     "directory": "packages/database",
     "type": "git",
-    "url": "https://github.com/firebase/firebase-js-sdk.git"
+    "url": "git+https://github.com/firebase/firebase-js-sdk.git"
   },
   "bugs": {
     "url": "https://github.com/firebase/firebase-js-sdk/issues"

--- a/packages/firebase/package.json
+++ b/packages/firebase/package.json
@@ -363,7 +363,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/firebase/firebase-js-sdk.git"
+    "url": "git+https://github.com/firebase/firebase-js-sdk.git"
   },
   "scripts": {
     "build": "rollup -c && gulp cdn-type-module-path && yarn build:compat",

--- a/packages/firestore-compat/package.json
+++ b/packages/firestore-compat/package.json
@@ -69,7 +69,7 @@
   "repository": {
     "directory": "packages/firestore-compat",
     "type": "git",
-    "url": "https://github.com/firebase/firebase-js-sdk.git"
+    "url": "git+https://github.com/firebase/firebase-js-sdk.git"
   },
   "bugs": {
     "url": "https://github.com/firebase/firebase-js-sdk/issues"

--- a/packages/firestore-types/package.json
+++ b/packages/firestore-types/package.json
@@ -18,7 +18,7 @@
   "repository": {
     "directory": "packages/firestore-types",
     "type": "git",
-    "url": "https://github.com/firebase/firebase-js-sdk.git"
+    "url": "git+https://github.com/firebase/firebase-js-sdk.git"
   },
   "bugs": {
     "url": "https://github.com/firebase/firebase-js-sdk/issues"

--- a/packages/firestore/package.json
+++ b/packages/firestore/package.json
@@ -133,7 +133,7 @@
   "repository": {
     "directory": "packages/firestore",
     "type": "git",
-    "url": "https://github.com/firebase/firebase-js-sdk.git"
+    "url": "git+https://github.com/firebase/firebase-js-sdk.git"
   },
   "bugs": {
     "url": "https://github.com/firebase/firebase-js-sdk/issues"

--- a/packages/functions-compat/package.json
+++ b/packages/functions-compat/package.json
@@ -40,7 +40,7 @@
   "repository": {
     "directory": "packages/functions-compat",
     "type": "git",
-    "url": "https://github.com/firebase/firebase-js-sdk.git"
+    "url": "git+https://github.com/firebase/firebase-js-sdk.git"
   },
   "bugs": {
     "url": "https://github.com/firebase/firebase-js-sdk/issues"

--- a/packages/functions-types/package.json
+++ b/packages/functions-types/package.json
@@ -14,7 +14,7 @@
   "repository": {
     "directory": "packages/functions-types",
     "type": "git",
-    "url": "https://github.com/firebase/firebase-js-sdk.git"
+    "url": "git+https://github.com/firebase/firebase-js-sdk.git"
   },
   "bugs": {
     "url": "https://github.com/firebase/firebase-js-sdk/issues"

--- a/packages/functions/package.json
+++ b/packages/functions/package.json
@@ -59,7 +59,7 @@
   "repository": {
     "directory": "packages/functions",
     "type": "git",
-    "url": "https://github.com/firebase/firebase-js-sdk.git"
+    "url": "git+https://github.com/firebase/firebase-js-sdk.git"
   },
   "bugs": {
     "url": "https://github.com/firebase/firebase-js-sdk/issues"

--- a/packages/installations-compat/package.json
+++ b/packages/installations-compat/package.json
@@ -39,7 +39,7 @@
   "repository": {
     "directory": "packages/installations-compat",
     "type": "git",
-    "url": "https://github.com/firebase/firebase-js-sdk.git"
+    "url": "git+https://github.com/firebase/firebase-js-sdk.git"
   },
   "bugs": {
     "url": "https://github.com/firebase/firebase-js-sdk/issues"

--- a/packages/installations-types/package.json
+++ b/packages/installations-types/package.json
@@ -17,7 +17,7 @@
   "repository": {
     "directory": "packages/installations-types",
     "type": "git",
-    "url": "https://github.com/firebase/firebase-js-sdk.git"
+    "url": "git+https://github.com/firebase/firebase-js-sdk.git"
   },
   "bugs": {
     "url": "https://github.com/firebase/firebase-js-sdk/issues"

--- a/packages/installations/package.json
+++ b/packages/installations/package.json
@@ -44,7 +44,7 @@
   "repository": {
     "directory": "packages/installations",
     "type": "git",
-    "url": "https://github.com/firebase/firebase-js-sdk.git"
+    "url": "git+https://github.com/firebase/firebase-js-sdk.git"
   },
   "bugs": {
     "url": "https://github.com/firebase/firebase-js-sdk/issues"

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -43,7 +43,7 @@
   "repository": {
     "directory": "packages/logger",
     "type": "git",
-    "url": "https://github.com/firebase/firebase-js-sdk.git"
+    "url": "git+https://github.com/firebase/firebase-js-sdk.git"
   },
   "bugs": {
     "url": "https://github.com/firebase/firebase-js-sdk/issues"

--- a/packages/messaging-compat/package.json
+++ b/packages/messaging-compat/package.json
@@ -54,7 +54,7 @@
   "repository": {
     "directory": "packages/messaging",
     "type": "git",
-    "url": "https://github.com/firebase/firebase-js-sdk.git"
+    "url": "git+https://github.com/firebase/firebase-js-sdk.git"
   },
   "bugs": {
     "url": "https://github.com/firebase/firebase-js-sdk/issues"

--- a/packages/messaging-interop-types/package.json
+++ b/packages/messaging-interop-types/package.json
@@ -14,7 +14,7 @@
   "repository": {
     "directory": "packages/messaging-interop-types",
     "type": "git",
-    "url": "https://github.com/firebase/firebase-js-sdk.git"
+    "url": "git+https://github.com/firebase/firebase-js-sdk.git"
   },
   "bugs": {
     "url": "https://github.com/firebase/firebase-js-sdk/issues"

--- a/packages/messaging/package.json
+++ b/packages/messaging/package.json
@@ -71,7 +71,7 @@
   "repository": {
     "directory": "packages/messaging",
     "type": "git",
-    "url": "https://github.com/firebase/firebase-js-sdk.git"
+    "url": "git+https://github.com/firebase/firebase-js-sdk.git"
   },
   "bugs": {
     "url": "https://github.com/firebase/firebase-js-sdk/issues"

--- a/packages/performance-compat/package.json
+++ b/packages/performance-compat/package.json
@@ -57,7 +57,7 @@
   "repository": {
     "directory": "packages/performance-compat",
     "type": "git",
-    "url": "https://github.com/firebase/firebase-js-sdk.git"
+    "url": "git+https://github.com/firebase/firebase-js-sdk.git"
   },
   "bugs": {
     "url": "https://github.com/firebase/firebase-js-sdk/issues"

--- a/packages/performance-types/package.json
+++ b/packages/performance-types/package.json
@@ -17,7 +17,7 @@
   "repository": {
     "directory": "packages/performance-types",
     "type": "git",
-    "url": "https://github.com/firebase/firebase-js-sdk.git"
+    "url": "git+https://github.com/firebase/firebase-js-sdk.git"
   },
   "bugs": {
     "url": "https://github.com/firebase/firebase-js-sdk/issues"

--- a/packages/performance/package.json
+++ b/packages/performance/package.json
@@ -56,7 +56,7 @@
   "repository": {
     "directory": "packages/performance",
     "type": "git",
-    "url": "https://github.com/firebase/firebase-js-sdk.git"
+    "url": "git+https://github.com/firebase/firebase-js-sdk.git"
   },
   "bugs": {
     "url": "https://github.com/firebase/firebase-js-sdk/issues"

--- a/packages/remote-config-compat/package.json
+++ b/packages/remote-config-compat/package.json
@@ -56,7 +56,7 @@
   "repository": {
     "directory": "packages/remote-config-compat",
     "type": "git",
-    "url": "https://github.com/firebase/firebase-js-sdk.git"
+    "url": "git+https://github.com/firebase/firebase-js-sdk.git"
   },
   "bugs": {
     "url": "https://github.com/firebase/firebase-js-sdk/issues"

--- a/packages/remote-config-types/package.json
+++ b/packages/remote-config-types/package.json
@@ -14,7 +14,7 @@
   "repository": {
     "directory": "packages/remote-config-types",
     "type": "git",
-    "url": "https://github.com/firebase/firebase-js-sdk.git"
+    "url": "git+https://github.com/firebase/firebase-js-sdk.git"
   },
   "bugs": {
     "url": "https://github.com/firebase/firebase-js-sdk/issues"

--- a/packages/remote-config/package.json
+++ b/packages/remote-config/package.json
@@ -57,7 +57,7 @@
   "repository": {
     "directory": "packages/remote-config",
     "type": "git",
-    "url": "https://github.com/firebase/firebase-js-sdk.git"
+    "url": "git+https://github.com/firebase/firebase-js-sdk.git"
   },
   "bugs": {
     "url": "https://github.com/firebase/firebase-js-sdk/issues"

--- a/packages/rules-unit-testing/package.json
+++ b/packages/rules-unit-testing/package.json
@@ -47,7 +47,7 @@
   "repository": {
     "directory": "packages/rules-unit-testing",
     "type": "git",
-    "url": "https://github.com/firebase/firebase-js-sdk.git"
+    "url": "git+https://github.com/firebase/firebase-js-sdk.git"
   },
   "typings": "dist/index.d.ts",
   "bugs": {

--- a/packages/storage-compat/package.json
+++ b/packages/storage-compat/package.json
@@ -58,7 +58,7 @@
   "repository": {
     "directory": "packages/storage-compat",
     "type": "git",
-    "url": "https://github.com/firebase/firebase-js-sdk.git"
+    "url": "git+https://github.com/firebase/firebase-js-sdk.git"
   },
   "bugs": {
     "url": "https://github.com/firebase/firebase-js-sdk/issues"

--- a/packages/storage-types/package.json
+++ b/packages/storage-types/package.json
@@ -18,7 +18,7 @@
   "repository": {
     "directory": "packages/storage-types",
     "type": "git",
-    "url": "https://github.com/firebase/firebase-js-sdk.git"
+    "url": "git+https://github.com/firebase/firebase-js-sdk.git"
   },
   "bugs": {
     "url": "https://github.com/firebase/firebase-js-sdk/issues"

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -66,7 +66,7 @@
   "repository": {
     "directory": "packages/storage",
     "type": "git",
-    "url": "https://github.com/firebase/firebase-js-sdk.git"
+    "url": "git+https://github.com/firebase/firebase-js-sdk.git"
   },
   "bugs": {
     "url": "https://github.com/firebase/firebase-js-sdk/issues"

--- a/packages/template-types/package.json
+++ b/packages/template-types/package.json
@@ -15,7 +15,7 @@
   "repository": {
     "directory": "packages/template-types",
     "type": "git",
-    "url": "https://github.com/firebase/firebase-js-sdk.git"
+    "url": "git+https://github.com/firebase/firebase-js-sdk.git"
   },
   "bugs": {
     "url": "https://github.com/firebase/firebase-js-sdk/issues"

--- a/packages/template/package.json
+++ b/packages/template/package.json
@@ -57,7 +57,7 @@
   "repository": {
     "directory": "packages/template",
     "type": "git",
-    "url": "https://github.com/firebase/firebase-js-sdk.git"
+    "url": "git+https://github.com/firebase/firebase-js-sdk.git"
   },
   "bugs": {
     "url": "https://github.com/firebase/firebase-js-sdk/issues"

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -53,7 +53,7 @@
   "repository": {
     "directory": "packages/util",
     "type": "git",
-    "url": "https://github.com/firebase/firebase-js-sdk.git"
+    "url": "git+https://github.com/firebase/firebase-js-sdk.git"
   },
   "bugs": {
     "url": "https://github.com/firebase/firebase-js-sdk/issues"

--- a/packages/webchannel-wrapper/package.json
+++ b/packages/webchannel-wrapper/package.json
@@ -39,7 +39,7 @@
   "repository": {
     "directory": "packages/webchannel-wrapper",
     "type": "git",
-    "url": "https://github.com/firebase/firebase-js-sdk.git"
+    "url": "git+https://github.com/firebase/firebase-js-sdk.git"
   },
   "typings": "src/index.d.ts",
   "bugs": {

--- a/repo-scripts/api-documenter/package.json
+++ b/repo-scripts/api-documenter/package.json
@@ -5,7 +5,7 @@
   "repository": {
     "directory": "repo-scripts/documenter",
     "type": "git",
-    "url": "https://github.com/firebase/firebase-js-sdk.git"
+    "url": "git+https://github.com/firebase/firebase-js-sdk.git"
   },
   "license": "Apache-2.0",
   "scripts": {
@@ -13,7 +13,7 @@
     "test": "TS_NODE_COMPILER_OPTIONS='{\"module\":\"commonjs\"}' nyc --reporter lcovonly -- mocha src/**/*.test.ts --config ../../config/mocharc.node.js"
   },
   "bin": {
-    "api-documenter-fire": "./dist/start.js"
+    "api-documenter-fire": "dist/start.js"
   },
   "files": [
     "dist"

--- a/repo-scripts/changelog-generator/package.json
+++ b/repo-scripts/changelog-generator/package.json
@@ -29,7 +29,7 @@
   "repository": {
     "directory": "repo-scripts/changelog-generator",
     "type": "git",
-    "url": "https://github.com/firebase/firebase-js-sdk.git"
+    "url": "git+https://github.com/firebase/firebase-js-sdk.git"
   },
   "bugs": {
     "url": "https://github.com/firebase/firebase-js-sdk/issues"

--- a/repo-scripts/prune-dts/package.json
+++ b/repo-scripts/prune-dts/package.json
@@ -20,7 +20,7 @@
   "repository": {
     "directory": "repo-scripts/prune-dts",
     "type": "git",
-    "url": "https://github.com/firebase/firebase-js-sdk.git"
+    "url": "git+https://github.com/firebase/firebase-js-sdk.git"
   },
   "bugs": {
     "url": "https://github.com/firebase/firebase-js-sdk/issues"

--- a/repo-scripts/size-analysis/package.json
+++ b/repo-scripts/size-analysis/package.json
@@ -47,7 +47,7 @@
   "repository": {
     "directory": "repo-scripts/size-analysis",
     "type": "git",
-    "url": "https://github.com/firebase/firebase-js-sdk.git"
+    "url": "git+https://github.com/firebase/firebase-js-sdk.git"
   },
   "bugs": {
     "url": "https://github.com/firebase/firebase-js-sdk/issues"


### PR DESCRIPTION
We got what looks like a flaky error on publish due to NPM attempting to autocorrect a repository url. In order to be safe, running `npm pkg fix` on all packages. NPM seems to prefer a `git+` prefix before all `repository.url` fields pointing to Github. It does not need this on the `bugs.url` field, I assume since it's pointing to a website meant to be viewed in browser, and not a repo.