### PR TITLE
Use the latest published version for auth sample app

### DIFF
--- a/packages/auth/demo/package.json
+++ b/packages/auth/demo/package.json
@@ -17,10 +17,10 @@
     "dev": "rollup -c -w"
   },
   "dependencies": {
-    "@firebase/app": "0.7.24",
+    "@firebase/app": "*",
     "@firebase/auth": "file:..",
-    "@firebase/logger": "0.3.2",
-    "@firebase/util": "1.6.0",
+    "@firebase/logger": "*",
+    "@firebase/util": "*",
     "tslib": "^2.1.0"
   },
   "license": "Apache-2.0",


### PR DESCRIPTION
Upgrade the sample app build file so that the latest published Firebase libs are for auth sample app.