### PR TITLE
Add additional Vertex types

### DIFF
--- a/packages/vertexai/src/types/enums.ts
+++ b/packages/vertexai/src/types/enums.ts
@@ -57,6 +57,18 @@ export enum HarmBlockThreshold {
 }
 
 /**
+ * @public
+ */
+export enum HarmBlockMethod {
+  // The harm block method is unspecified.
+  HARM_BLOCK_METHOD_UNSPECIFIED = 'HARM_BLOCK_METHOD_UNSPECIFIED',
+  // The harm block method uses both probability and severity scores.
+  SEVERITY = 'SEVERITY',
+  // The harm block method uses the probability score.
+  PROBABILITY = 'PROBABILITY'
+}
+
+/**
  * Probability that a prompt or candidate matches a harm category.
  * @public
  */
@@ -71,6 +83,23 @@ export enum HarmProbability {
   MEDIUM = 'MEDIUM',
   // Content has a high chance of being unsafe.
   HIGH = 'HIGH'
+}
+
+/**
+ * Harm severity levels.
+ * @public
+ */
+export enum HarmSeverity {
+  // Harm severity unspecified.
+  HARM_SEVERITY_UNSPECIFIED = 'HARM_SEVERITY_UNSPECIFIED',
+  // Negligible level of harm severity.
+  HARM_SEVERITY_NEGLIGIBLE = 'HARM_SEVERITY_NEGLIGIBLE',
+  // Low level of harm severity.
+  HARM_SEVERITY_LOW = 'HARM_SEVERITY_LOW',
+  // Medium level of harm severity.
+  HARM_SEVERITY_MEDIUM = 'HARM_SEVERITY_MEDIUM',
+  // High level of harm severity.
+  HARM_SEVERITY_HIGH = 'HARM_SEVERITY_HIGH'
 }
 
 /**

--- a/packages/vertexai/src/types/requests.ts
+++ b/packages/vertexai/src/types/requests.ts
@@ -16,7 +16,7 @@
  */
 
 import { Content } from './content';
-import { HarmBlockThreshold, HarmCategory } from './enums';
+import { HarmBlockMethod, HarmBlockThreshold, HarmCategory } from './enums';
 
 /**
  * Base parameters for a number of methods.
@@ -52,6 +52,7 @@ export interface GenerateContentRequest extends BaseParams {
 export interface SafetySetting {
   category: HarmCategory;
   threshold: HarmBlockThreshold;
+  method: HarmBlockMethod;
 }
 
 /**
@@ -65,6 +66,8 @@ export interface GenerationConfig {
   temperature?: number;
   topP?: number;
   topK?: number;
+  presencePenalty?: number;
+  frequencyPenalty?: number;
 }
 
 /**

--- a/packages/vertexai/src/types/responses.ts
+++ b/packages/vertexai/src/types/responses.ts
@@ -20,7 +20,8 @@ import {
   BlockReason,
   FinishReason,
   HarmCategory,
-  HarmProbability
+  HarmProbability,
+  HarmSeverity
 } from './enums';
 
 /**
@@ -101,6 +102,7 @@ export interface GenerateContentCandidate {
   finishMessage?: string;
   safetyRatings?: SafetyRating[];
   citationMetadata?: CitationMetadata;
+  groundingMetadata?: GroundingMetadata;
 }
 
 /**
@@ -125,6 +127,51 @@ export interface Citation {
 }
 
 /**
+ * Metadata returned to client when grounding is enabled.
+ * @public
+ */
+export interface GroundingMetadata {
+  webSearchQueries?: string[];
+  retrievalQueries?: string[];
+  groundingAttributions: GroundingAttribution[];
+}
+
+/**
+ * @public
+ */
+export interface GroundingAttribution {
+  segment: Segment;
+  confidenceScore?: number;
+  web?: WebAttribution;
+  retrievedContext?: RetrievedContextAttribution;
+}
+
+/**
+ * @public
+ */
+export interface Segment {
+  partIndex: number;
+  startIndex: number;
+  endIndex: number;
+}
+
+/**
+ * @public
+ */
+export interface WebAttribution {
+  uri: string;
+  title: string;
+}
+
+/**
+ * @public
+ */
+export interface RetrievedContextAttribution {
+  uri: string;
+  title: string;
+}
+
+/**
  * Protobuf google.type.Date
  * @public
  */
@@ -141,6 +188,10 @@ export interface Date {
 export interface SafetyRating {
   category: HarmCategory;
   probability: HarmProbability;
+  severity: HarmSeverity;
+  probabilityScore: number;
+  severityScore: number;
+  blocked: boolean;
 }
 
 /**

--- a/packages/vertexai/src/types/responses.ts
+++ b/packages/vertexai/src/types/responses.ts
@@ -148,5 +148,13 @@ export interface SafetyRating {
  * @public
  */
 export interface CountTokensResponse {
+  /**
+   * The total number of tokens counted across all instances from the request.
+   */
   totalTokens: number;
+  /**
+   * The total number of billable characters counted across all instances
+   * from the request.
+   */
+  totalBillableCharacters?: number;
 }


### PR DESCRIPTION
After doing an audit, added a number of Vertex types that were missing in the JS SDK.

See https://docs.google.com/document/d/1E-Kw5NC5iwtAA4_D9O7eNM4DpT8OZjwY8YwKUrDSNSI/edit?resourcekey=0-agpRR_nc-s3n4cCy4tBkOQ&tab=t.0 (internal)