### PR TITLE
Update health-metrics-pull-request to skip execution on Dependabot PRs

### DIFF
--- a/.github/workflows/health-metrics-pull-request.yml
+++ b/.github/workflows/health-metrics-pull-request.yml
@@ -35,7 +35,7 @@ env:
 jobs:
   binary-size:
     name: Binary Size
-    if: github.event_name == 'push' || !(github.event.pull_request.head.repo.fork)
+    if: github.event_name == 'push' || !(github.event.pull_request.head.repo.fork) && github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -52,7 +52,7 @@ jobs:
         run: yarn size-report
   modular-export-size:
     name: Binary Size For Modular Exports
-    if: github.event_name == 'push' || !(github.event.pull_request.head.repo.fork)
+    if: github.event_name == 'push' || !(github.event.pull_request.head.repo.fork) && github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
### Discussion

PRs created by Dependabot do not have privledges to run our non-critical Health Check CI workflows. Currently these workflows error-out on all Dependabot changes. It would be a better developer experience if these steps were simply skipped, so it doesn't look like we're merging a PR with errors.

### Testing

CI in the feature branch.
Also CI in a Dependabot branch.

### API Changes

N/A
