### PR TITLE
Disable Deploy Config workflow on dependabot PRs.

### DIFF
--- a/.github/workflows/deploy-config.yml
+++ b/.github/workflows/deploy-config.yml
@@ -27,6 +27,7 @@ jobs:
   test:
     name: Deploy Firebase Project Rules and Functions
     runs-on: ubuntu-latest
+    if: (github.actor != 'dependabot[bot]')
 
     steps:
     - name: Checkout Repo


### PR DESCRIPTION
### Discussion

One more Workflow to skip when dependabot makes a PR: the deploy config workflow. This workflow will still work if we push code to the branch ourselves. 

### Testing

CI.

### API Changes

N/A.
