### PR TITLE
Firestore: simple_db.ts: move getAndroidVersion() to a free function

### DIFF
--- a/.changeset/sharp-lizards-sit.md
+++ b/.changeset/sharp-lizards-sit.md
@@ -1,0 +1,6 @@
+---
+'@firebase/firestore': patch
+'firebase': patch
+---
+
+Reduce code size that accidentally regressed in 10.7.2 due to https://github.com/firebase/firebase-js-sdk/pull/7929 for application that did _not_ use IndexedDB persistence

--- a/.changeset/sharp-lizards-sit.md
+++ b/.changeset/sharp-lizards-sit.md
@@ -3,4 +3,4 @@
 'firebase': patch
 ---
 
-Reduce code size that accidentally regressed in 10.7.2 due to https://github.com/firebase/firebase-js-sdk/pull/7929 for application that did _not_ use IndexedDB persistence
+Reduce code bundle size by 6.5 kB in applications that only use memory persistence (the default persistence mode). This bundle size regression was accidentally introduced in v10.7.2.

--- a/packages/firestore/src/local/query_engine.ts
+++ b/packages/firestore/src/local/query_engine.ts
@@ -49,7 +49,7 @@ import { LocalDocumentsView } from './local_documents_view';
 import { PersistencePromise } from './persistence_promise';
 import { PersistenceTransaction } from './persistence_transaction';
 import { QueryContext } from './query_context';
-import { SimpleDb } from './simple_db';
+import { getAndroidVersion } from './simple_db';
 
 const DEFAULT_INDEX_AUTO_CREATION_MIN_COLLECTION_SIZE = 100;
 
@@ -65,7 +65,7 @@ function getDefaultRelativeIndexReadCostPerDocument(): number {
   // Googlers can see b/299284287 for details.
   if (isSafari()) {
     return 8;
-  } else if (SimpleDb.getAndroidVersion(getUA()) > 0) {
+  } else if (getAndroidVersion(getUA()) > 0) {
     return 6;
   } else {
     return 4;

--- a/packages/firestore/src/local/simple_db.ts
+++ b/packages/firestore/src/local/simple_db.ts
@@ -201,7 +201,7 @@ export class SimpleDb {
     const isUnsupportedIOS = 0 < iOSVersion && iOSVersion < 10;
 
     // Android browser: Disable for userse running version < 4.5.
-    const androidVersion = SimpleDb.getAndroidVersion(ua);
+    const androidVersion = getAndroidVersion(ua);
     const isUnsupportedAndroid = 0 < androidVersion && androidVersion < 4.5;
 
     if (
@@ -242,16 +242,6 @@ export class SimpleDb {
     const iOSVersionRegex = ua.match(/i(?:phone|pad|pod) os ([\d_]+)/i);
     const version = iOSVersionRegex
       ? iOSVersionRegex[1].split('_').slice(0, 2).join('.')
-      : '-1';
-    return Number(version);
-  }
-
-  // visible for testing
-  /** Parse User Agent to determine Android version. Returns -1 if not found. */
-  static getAndroidVersion(ua: string): number {
-    const androidVersionRegex = ua.match(/Android ([\d.]+)/i);
-    const version = androidVersionRegex
-      ? androidVersionRegex[1].split('.').slice(0, 2).join('.')
       : '-1';
     return Number(version);
   }
@@ -468,6 +458,15 @@ export class SimpleDb {
     }
     this.db = undefined;
   }
+}
+
+/** Parse User Agent to determine Android version. Returns -1 if not found. */
+export function getAndroidVersion(ua: string): number {
+  const androidVersionRegex = ua.match(/Android ([\d.]+)/i);
+  const version = androidVersionRegex
+    ? androidVersionRegex[1].split('.').slice(0, 2).join('.')
+    : '-1';
+  return Number(version);
 }
 
 /**

--- a/packages/firestore/test/unit/local/simple_db.test.ts
+++ b/packages/firestore/test/unit/local/simple_db.test.ts
@@ -22,6 +22,7 @@ import { Context } from 'mocha';
 import { dbKeyComparator } from '../../../src/local/indexeddb_remote_document_cache';
 import { PersistencePromise } from '../../../src/local/persistence_promise';
 import {
+  getAndroidVersion,
   SimpleDb,
   SimpleDbSchemaConverter,
   SimpleDbStore,
@@ -137,7 +138,7 @@ describe('SimpleDb', () => {
       ' AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1';
     expect(SimpleDb.getIOSVersion(iPhoneSafariAgent)).to.equal(10.14);
     expect(SimpleDb.getIOSVersion(iPadSafariAgent)).to.equal(9.0);
-    expect(SimpleDb.getAndroidVersion(androidAgent)).to.equal(2.2);
+    expect(getAndroidVersion(androidAgent)).to.equal(2.2);
   });
 
   it('can get', async () => {


### PR DESCRIPTION
https://github.com/firebase/firebase-js-sdk/pull/7929 accidentally pulled in the IndexedDB persistence code even in Firestore applications that did _not_ used IndexedDB, unnecessarily increasing the code size by 6.5 kB starting in v10.7.2. This PR fixes this code size increase by moving the `getAndroidVersion()` function from a static member of the `SimpleDB` class to a free function to avoid pulling in all of the IndexedDB code.