### PR TITLE
Emit a module package file into esm2017 auth webextension bundle

### DIFF
--- a/.changeset/real-ravens-prove.md
+++ b/.changeset/real-ravens-prove.md
@@ -1,0 +1,5 @@
+---
+'@firebase/auth': patch
+---
+
+Emit a module package file with esm2017 auth browser extension builds

--- a/packages/auth/rollup.config.js
+++ b/packages/auth/rollup.config.js
@@ -125,7 +125,8 @@ const browserWebExtensionBuilds = [
     },
     plugins: [
       ...es2017BuildPlugins,
-      replace(generateBuildTargetReplaceConfig('esm', 2017))
+      replace(generateBuildTargetReplaceConfig('esm', 2017)),
+      emitModulePackageFile()
     ],
     external: id => deps.some(dep => id === dep || id.startsWith(`${dep}/`))
   },


### PR DESCRIPTION
The Firebase Auth webextension bundle was previously being shipped as a CommonJS package rather than a ES module, because it did not have a module package file indicating that it was an ES module.

Fixes #8115 

**Aside:** The web-extension entry point does not have a Node bundle, and browser bundles don't normally require a `package.json` file with `{ "type": "module" }`, but certain browser testing frameworks use Node, and need working ES module resolution.