### PR TITLE
Fix client headers

### DIFF
--- a/packages/vertexai/src/requests/request.test.ts
+++ b/packages/vertexai/src/requests/request.test.ts
@@ -112,7 +112,9 @@ describe('request methods', () => {
     );
     it('adds client headers', async () => {
       const headers = await getHeaders(fakeUrl);
-      expect(headers.get('x-goog-api-client')).to.include('gl-js/ fire/');
+      expect(headers.get('x-goog-api-client')).to.match(
+        /gl-js\/[0-9\.]+ fire\/[0-9\.]+/
+      );
     });
     it('adds api key', async () => {
       const headers = await getHeaders(fakeUrl);

--- a/packages/vertexai/src/requests/request.ts
+++ b/packages/vertexai/src/requests/request.ts
@@ -71,7 +71,7 @@ export class RequestUrl {
  */
 function getClientHeaders(): string {
   const loggingTags = [];
-  loggingTags.push(`${LANGUAGE_TAG}/`);
+  loggingTags.push(`${LANGUAGE_TAG}/${PACKAGE_VERSION}`);
   loggingTags.push(`fire/${PACKAGE_VERSION}`);
   return loggingTags.join(' ');
 }


### PR DESCRIPTION
All headers need a version number or they won't show up. Adding a version to the `gl-js/` client header.