### PR TITLE
Keep the context on cancel callback handler.

### DIFF
--- a/packages/database/src/core/view/EventRegistration.ts
+++ b/packages/database/src/core/view/EventRegistration.ts
@@ -63,7 +63,7 @@ export class CallbackContext {
       this.hasCancelCallback,
       'Raising a cancel event on a listener with no cancel callback'
     );
-    return this.cancelCallback.call(null, error);
+    return this.cancelCallback.call(error);
   }
 
   get hasCancelCallback(): boolean {

--- a/packages/database/src/core/view/EventRegistration.ts
+++ b/packages/database/src/core/view/EventRegistration.ts
@@ -63,7 +63,7 @@ export class CallbackContext {
       this.hasCancelCallback,
       'Raising a cancel event on a listener with no cancel callback'
     );
-    return this.cancelCallback.call(error);
+    this.cancelCallback(error);
   }
 
   get hasCancelCallback(): boolean {


### PR DESCRIPTION
# Overview
I have an issue where there is an unhandled promise rejection throwing, but I have an error handler on this scenario, it looks something like this

```js
const Display = function(deviceId){
  Component.call(this)
  this.bindedOnUnhandledRejection_ = this.onUnhandledRejection_.bind(this)
}

Display.prototype.addEventListeners = function(){
  window.addEventListener("unhandledrejection", this.bindedOnUnhandledRejection_)
}

Display.prototype.onUnhandledRejection_ = function(event){
  this.logger_.log({
    message: event.reason instanceof Error ? 
      event.reason.message :
      String(event.reason), 
    type: 'ERROR',
  }, {
    'reason': maybeConvertErrorToSerializableObject(event.reason),
  })
  this.paintErrors_()
}
```

My issue is that onUnhandledRejection_ is getting called from Firebase, and Firebase is removing the context from my function. So the error comes in and `this.logger_` is undefined. I'm proposing that Firebase should not be messing with my function context.



