### PR TITLE
Add support for GCS FileData in inference

### DIFF
--- a/packages/vertexai/src/requests/request-helpers.test.ts
+++ b/packages/vertexai/src/requests/request-helpers.test.ts
@@ -170,6 +170,33 @@ describe('request formatting methods', () => {
         ],
         systemInstruction: { role: 'system', parts: [{ text: 'be excited' }] }
       });
-    });
+    }),
+      it('formats fileData as part if provided as part', () => {
+        const result = formatGenerateContentInput([
+          'What is this?',
+          {
+            fileData: {
+              mimeType: 'image/jpeg',
+              fileUri: 'gs://sample.appspot.com/image.jpeg'
+            }
+          }
+        ]);
+        expect(result).to.be.deep.equal({
+          contents: [
+            {
+              role: 'user',
+              parts: [
+                {
+                  fileData: {
+                    mimeType: 'image/jpeg',
+                    fileUri: 'gs://sample.appspot.com/image.jpeg'
+                  }
+                },
+                { text: 'What is this?' }
+              ]
+            }
+          ]
+        });
+      });
   });
 });

--- a/packages/vertexai/src/types/content.ts
+++ b/packages/vertexai/src/types/content.ts
@@ -34,7 +34,8 @@ export type Part =
   | TextPart
   | InlineDataPart
   | FunctionCallPart
-  | FunctionResponsePart;
+  | FunctionResponsePart
+  | FileDataPart;
 
 /**
  * Content part interface if the part represents a text string.
@@ -102,6 +103,18 @@ export interface FunctionResponsePart {
 }
 
 /**
+ * Content part interface if the part represents {@link FileData}
+ * @public
+ */
+export interface FileDataPart {
+  text?: never;
+  inlineData?: never;
+  functionCall?: never;
+  functionResponse?: never;
+  fileData: FileData;
+}
+
+/**
  * A predicted [FunctionCall] returned from the model
  * that contains a string representing the [FunctionDeclaration.name]
  * and a structured JSON object containing the parameters and their values.
@@ -136,4 +149,13 @@ export interface GenerativeContentBlob {
    * Image as a base64 string.
    */
   data: string;
+}
+
+/**
+ * Data pointing to a file uploaded on Google Cloud Storage.
+ * @public
+ */
+export interface FileData {
+  mimeType: string;
+  fileUri: string;
 }


### PR DESCRIPTION
This chain of branches is getting a bit messy- I'm just putting this PR out so it can be reviewed :)

This PR follows #8216, and uses Firebase Authorization tokens to allow users to pass URLs in `generateContent` to GS resources that are secured by Firebase Security Rules.

This currently works against the production backend. I live tested in a React application configured with Firebase auth, storage, and vertexai.

Live tested using the following:
```javascript
const firebaseConfig = { /* OMITTED */ };
const app = initializeApp(firebaseConfig);
const auth = getAuth(app);
const vertex = getVertexAI(app);
const model = getGenerativeModel(vertex, { model: 'gemini-1.5-pro-preview-0409'});
const storage = getStorage(app)

async function run() {
  await signInWithEmailAndPassword(auth, "username@gmail.com", "password")
  const catRef = ref(storage, 'public/cat.jpeg')
  const googleStorageURL = catRef.toString();

  await model.generateContent({
    contents: [
        {
          role: "user",
          parts: [
            { text: "What is this?" },
            {
              fileData: {
                mimeType: 'image/jpeg', // Note: getMetadata(catRef) could be a convenient way to get the mimeType
                fileUri: googleStorageURL 
              }
            },
          ],
        },
    ],
  });
} 
```

Storage rules:
```
rules_version = '2';

service firebase.storage {
  match /b/{bucket}/o {
    match /public/{allPaths=**} {
      allow read: if true;
      allow write: if false;
    }
    match /images/{allPaths=**} {
      allow read: if request.auth != null;
      allow write: if false;
    }
    match /user/{userId}/{allPaths=**} {
      allow read: if request.auth != null && request.auth.uid == userId;
      allow write: if false;
    }
  }
}
```

Test cases:
1. A signed in client provides a GS URL they have permission to read: Success
2. A signed in client provides a GS URL they don't have permission to read: 403 Permission Denied
3. A client that is not signed in provides a GS URL they have permission to read: Success
4. A client that is not signed in provides a GS URL that they don't have permission to read: 403 Permission Denied

Sample request payload:
```JSON
{
  "generationConfig": {},
  "safetySettings": [],
  "contents": [
    {
      "role": "user",
      "parts": [
        {
          "text": "What is this?"
        },
        {
          "fileData": {
            "mimeType": "image/jpeg",
            "fileUri": "gs://<project>.appspot.com/public/cat.jpeg"
          }
        }
      ]
    }
  ]
}
```