### PR TITLE
Add tslib bsd-0 license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -203,6 +203,23 @@ which is licensed under BSD-3-Clause, both licenses given below.
    See the License for the specific language governing permissions and
    limitations under the License.
 
+-------------------------------------------------------------------------------
+
+For tslib.
+
+file: [source code root]/packages/auth
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+PERFORMANCE OF THIS SOFTWARE.
+
 ------------------------------------------------------------------------------
 
 For Google protobuf source.

--- a/LICENSE
+++ b/LICENSE
@@ -207,7 +207,7 @@ which is licensed under BSD-3-Clause, both licenses given below.
 
 For tslib.
 
-file: [source code root]/packages/auth
+file: [source code root]/packages/firebase
 
 Permission to use, copy, modify, and/or distribute this software for any
 purpose with or without fee is hereby granted.


### PR DESCRIPTION
Tslib is bundled into our code in some of the CDN packages and it has a BSD-0-Clause license. Import into google3 requires this license be reflected in the top-level LICENSE file.