### PR TITLE
Make text() accessor handle mixed-parts responses

### DIFF
--- a/packages/vertexai/src/requests/response-helpers.ts
+++ b/packages/vertexai/src/requests/response-helpers.ts
@@ -85,13 +85,19 @@ export function addHelpers(
 }
 
 /**
- * Returns text of first candidate.
+ * Returns all text found in all parts of first candidate.
  */
 export function getText(response: GenerateContentResponse): string {
-  if (response.candidates?.[0].content?.parts?.[0]?.text) {
-    return response.candidates[0].content.parts
-      .map(({ text }) => text)
-      .join('');
+  const textStrings = [];
+  if (response.candidates?.[0].content?.parts) {
+    for (const part of response.candidates?.[0].content?.parts) {
+      if (part.text) {
+        textStrings.push(part.text);
+      }
+    }
+  }
+  if (textStrings.length > 0) {
+    return textStrings.join('');
   } else {
     return '';
   }


### PR DESCRIPTION
`response.text()` only works when the first `Part` in the candidate has text, and fails if it's mixed in with `FunctionCallPart`s. Modified to look for text on any `Part` and added some tests.

We also need to port this fix to GoogleAI.

Internal reference: b/338296397