### PR TITLE
Bump all packages

### DIFF
--- a/.changeset/tiny-pots-sit.md
+++ b/.changeset/tiny-pots-sit.md
@@ -1,0 +1,52 @@
+---
+'@firebase/analytics': patch
+'@firebase/analytics-compat': patch
+'@firebase/analytics-interop-types': patch
+'@firebase/analytics-types': patch
+'@firebase/app': patch
+'@firebase/app-check': patch
+'@firebase/app-check-compat': patch
+'@firebase/app-check-interop-types': patch
+'@firebase/app-check-types': patch
+'@firebase/app-compat': patch
+'@firebase/app-types': patch
+'@firebase/auth': patch
+'@firebase/auth-compat': patch
+'@firebase/auth-interop-types': patch
+'@firebase/auth-types': patch
+'@firebase/component': patch
+'@firebase/database': patch
+'@firebase/database-compat': patch
+'@firebase/database-types': patch
+'firebase': patch
+'@firebase/firestore': patch
+'@firebase/firestore-compat': patch
+'@firebase/firestore-types': patch
+'@firebase/functions': patch
+'@firebase/functions-compat': patch
+'@firebase/functions-types': patch
+'@firebase/installations': patch
+'@firebase/installations-compat': patch
+'@firebase/installations-types': patch
+'@firebase/logger': patch
+'@firebase/messaging': patch
+'@firebase/messaging-compat': patch
+'@firebase/messaging-interop-types': patch
+'@firebase/performance': patch
+'@firebase/performance-compat': patch
+'@firebase/performance-types': patch
+'@firebase/remote-config': patch
+'@firebase/remote-config-compat': patch
+'@firebase/remote-config-types': patch
+'@firebase/rules-unit-testing': patch
+'@firebase/storage': patch
+'@firebase/storage-compat': patch
+'@firebase/storage-types': patch
+'@firebase/template': patch
+'@firebase/template-types': patch
+'@firebase/util': patch
+'@firebase/vertexai-preview': patch
+'@firebase/webchannel-wrapper': patch
+---
+
+Bump all packages so staging works.


### PR DESCRIPTION
Bump all packages by a patch.

Staging release selectively publishes only packages that had their versions bumped, and their direct dependencies (not transitive dependencies), which means on npm installs there are 2 versions of `@firebase/app` which causes component registration to be very buggy. This will roll into the existing "Version Packages" staging PR, so everything that's bumped minor there will stay minor, and any other package will be bumped by a patch from this changeset.

The long term solution is to fix the staging release check to publish all the packages that would need to be published, for this release, I just want to make sure we have a staging release to test with ASAP, and also be 100% sure we don't have a problem in prod.