### PR TITLE
Fix setConsent to properly use the `update` gtag command

### DIFF
--- a/packages/analytics/src/helpers.ts
+++ b/packages/analytics/src/helpers.ts
@@ -304,8 +304,8 @@ function wrapGtag(
           gtagParams as GtagConfigOrEventParams
         );
       } else if (command === GtagCommand.CONSENT) {
-        const [gtagParams] = args;
-        gtagCore(GtagCommand.CONSENT, 'update', gtagParams as ConsentSettings);
+        const [consentString, gtagParams] = args;
+        gtagCore(GtagCommand.CONSENT, consentString, gtagParams as ConsentSettings);
       } else if (command === GtagCommand.GET) {
         const [measurementId, fieldName, callback] = args;
         gtagCore(


### PR DESCRIPTION
### Discussion

We wrap the gtag function internally and plumb calls through the wrapper function. While we invoke it with the identical gtag parameters, we were dropping the `update` string on the floor. Additionally, we were feeding the `consentSettings` as the `update` string parameter.

This change fixes our wrappedGtag function implementation to properly parse `update` from the provided arguments, and pass it on to the actual gtag method.

Closes #8210

### Testing

  * Make sure all existing tests in the repository pass after your change.
  * If you fixed a bug or added a feature, add a new test to cover your code.

### API Changes

N/A