### PR TITLE
Add job to create a GitHub release

### DIFF
--- a/.github/workflows/release-prod.yml
+++ b/.github/workflows/release-prod.yml
@@ -133,23 +133,26 @@ jobs:
 
         # Get the release notes from the description of the most recent merged PR into the "release" branch
         # See: https://github.com/firebase/firebase-js-sdk/pull/8236 for an example description
-        RELEASE_NOTES=$(gh pr list \
+        JSON_RELEASE_NOTES=$(gh pr list \
           --repo "$GITHUB_REPOSITORY" \
           --state "merged" \
           --base "release" \
           --limit 1 \
           --json "body" \
-          | jq '.[].body' \
-          | jq -r . \
-          | sed '1,/^# Releases/d' \
+          | jq '.[].body | split("\n# Releases\n")[-1]' # Remove the generated changesets header
         )
+         
+        # Prepend the new release header
+        # We have to be careful to insert the new release header after a " character, since we're
+        # modifying the JSON string
+        JSON_RELEASE_NOTES="\"For more detailed release notes, see [Firebase JavaScript SDK Release Notes](https://firebase.google.com/support/release-notes/js).\n\n# What's Changed\n\n${JSON_RELEASE_NOTES:1}"
 
-        # Prepend the Firebase release notes link and header
-        RELEASE_NOTES="For more detailed release notes, see [Firebase JavaScript SDK Release Notes](https://firebase.google.com/support/release-notes/js).\n\n# What's Changed\n\n${RELEASE_NOTES}"
+        # Format the JSON string into a readable markdown string
+        RELEASE_NOTES=$(echo -E $JSON_RELEASE_NOTES | jq -r .)
 
         # Create the GitHub release
         gh release create "$NEWEST_TAG" \
-          --repo="$GITHUB_REPOSITORY" \
-          --title="$NEWEST_TAG" \
+          --repo "$GITHUB_REPOSITORY" \
+          --title "$NEWEST_TAG" \
           --notes "$RELEASE_NOTES" \
           --verify-tag

--- a/.github/workflows/release-prod.yml
+++ b/.github/workflows/release-prod.yml
@@ -124,3 +124,28 @@ jobs:
         curl -X POST -H "Content-Type:application/json" \
         -d "{\"version\":\"$BASE_VERSION\",\"date\":\"$DATE\"}" \
         $RELEASE_TRACKER_URL/logProduction
+    - name: Create Github release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        # Get the newest release tag for the firebase package (e.g. firebase@10.12.0)
+        NEWEST_TAG=$(git describe --tags --match "firebase@[0-9]*.[0-9]*.[0-9]*" --abbrev=0)
+
+        # Get the release notes from the description of the most recent merged PR into the "release" branch
+        # See: https://github.com/firebase/firebase-js-sdk/pull/8236 for an example description
+        RELEASE_NOTES=$(gh pr list \
+          --repo "$GITHUB_REPOSITORY" \
+          --state "merged" \
+          --base "release" \
+          --limit 1 \
+          --json "body" \
+          | jq '.[].body'\
+          | jq -r . \
+          | sed '1,/^# Releases/d')
+
+        # Create the GitHub release
+        gh release create "$NEWEST_TAG" \
+          --repo="$GITHUB_REPOSITORY" \
+          --title="$NEWEST_TAG" \
+          --notes "$RELEASE_NOTES" \
+          --verify-tag

--- a/.github/workflows/release-prod.yml
+++ b/.github/workflows/release-prod.yml
@@ -139,9 +139,13 @@ jobs:
           --base "release" \
           --limit 1 \
           --json "body" \
-          | jq '.[].body'\
+          | jq '.[].body' \
           | jq -r . \
-          | sed '1,/^# Releases/d')
+          | sed '1,/^# Releases/d' \
+        )
+
+        # Prepend the Firebase release notes link and header
+        RELEASE_NOTES="For more detailed release notes, see [Firebase JavaScript SDK Release Notes](https://firebase.google.com/support/release-notes/js).\n\n# What's Changed\n\n${RELEASE_NOTES}"
 
         # Create the GitHub release
         gh release create "$NEWEST_TAG" \


### PR DESCRIPTION
Adds a job to the production release workflow to create a GitHub release.

I tested this on a minimal version (no build or npm publish) of the workflow on a fork. It adds and pushes tags the same way that the `scripts/release/release.ts` script does.
Test workflow: https://github.com/dlarocque/firebase-js-sdk/blob/master/.github/workflows/test-release.yml
Resulting release: https://github.com/dlarocque/firebase-js-sdk/releases/tag/firebase%405.5.5

This job assumes that the version packages PR was already merged.