### PR TITLE
Change Vertex typings path to point to rolled up d.ts file

### DIFF
--- a/.changeset/empty-windows-push.md
+++ b/.changeset/empty-windows-push.md
@@ -1,0 +1,5 @@
+---
+'@firebase/vertexai-preview': patch
+---
+
+Change `types` paths to point to rolled-up public `d.ts` files. This fixes some TypeScript compiler errors users are seeing.

--- a/packages/vertexai/package.json
+++ b/packages/vertexai/package.json
@@ -11,7 +11,7 @@
   "module": "dist/esm/index.esm2017.js",
   "exports": {
     ".": {
-      "types": "./dist/src/index.d.ts",
+      "types": "./dist/vertexai-preview-public.d.ts",
       "node": {
         "require": "./dist/index.cjs.js",
         "import": "./dist/esm/index.esm2017.js"
@@ -37,7 +37,8 @@
     "test": "run-p --npm-path npm lint test:browser",
     "test:ci": "yarn testsetup && node ../../scripts/run_tests_in_ci.js -s test",
     "test:browser": "yarn testsetup && karma start --single-run",
-    "api-report": "api-extractor run --local --verbose"
+    "api-report": "api-extractor run --local --verbose",
+    "typings:public": "node ../../scripts/build/use_typings.js ./dist/vertexai-preview-public.d.ts"
   },
   "peerDependencies": {
     "@firebase/app": "0.x",


### PR DESCRIPTION
Vertex typings point to the entry point index.d.ts instead of the rolled-up typings file created by api-extractor. This causes errors in some build tools.

May be the cause of: https://github.com/angular/angularfire/issues/3532

Similar fix as https://github.com/firebase/firebase-js-sdk/pull/8251 (those are for auth/web-extension and auth/cordova)

Was able to repro in a TS project and this change fixed it.