### PR TITLE
Add docgen all script and update documentation

### DIFF
--- a/.github/workflows/check-docs.yml
+++ b/.github/workflows/check-docs.yml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: Doc Change Check (Run "yarn docgen devsite" if this fails)
+name: Doc Change Check (Run "yarn docgen:all" if this fails)
 
 on: pull_request
 
@@ -33,10 +33,12 @@ jobs:
         node-version: 20.x
     - name: Yarn install
       run: yarn
-    - name: Run doc generation (devsite docs)
-      run: yarn docgen devsite
+    - name: Run doc generation
+      run: yarn docgen:all
     - name: Check for changes in docs-devsite dir (fail if so)
       run: git diff --exit-code docs-devsite
+    - name: Check for changes in toc dir (fail if so)
+      run: git diff --exit-code toc
     - name: Reference documentation needs to be updated. See message below.
       if: ${{ failure() }}
-      run: echo "Changes in this PR affect the reference docs. Run \`yarn docgen devsite\` locally to regenerate docs and add them to this PR."
+      run: echo "Changes in this PR affect the reference docs. Run \`yarn docgen:all\` locally to regenerate docs and add them to this PR."

--- a/.github/workflows/check-docs.yml
+++ b/.github/workflows/check-docs.yml
@@ -37,8 +37,6 @@ jobs:
       run: yarn docgen:all
     - name: Check for changes in docs-devsite dir (fail if so)
       run: git diff --exit-code docs-devsite
-    - name: Check for changes in toc dir (fail if so)
-      run: git diff --exit-code toc
     - name: Reference documentation needs to be updated. See message below.
       if: ${{ failure() }}
       run: echo "Changes in this PR affect the reference docs. Run \`yarn docgen:all\` locally to regenerate docs and add them to this PR."

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -228,10 +228,10 @@ root directory to generate the documentation locally:
 
 ```
 yarn
-yarn docgen devsite
+yarn docgen:all
 ```
 
-This will generate reference docs in `docs-devsite/`. Commit and push the generated
+This will generate reference docs in `docs-devsite/` and `/toc`. Commit and push the generated
 documentation changes to GitHub following the [PR submission guidelines](#submit). Your push
 to the remote repository should force any failing documentation checks to execute again.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -231,7 +231,7 @@ yarn
 yarn docgen:all
 ```
 
-This will generate reference docs in `docs-devsite/` and `/toc`. Commit and push the generated
+This will generate reference docs and the toc in `docs-devsite/`. Commit and push the generated
 documentation changes to GitHub following the [PR submission guidelines](#submit). Your push
 to the remote repository should force any failing documentation checks to execute again.
 

--- a/docs-devsite/_toc.yaml
+++ b/docs-devsite/_toc.yaml
@@ -472,6 +472,8 @@ toc:
         path: /docs/reference/js/vertexai-preview.date_2.md
       - title: EnhancedGenerateContentResponse
         path: /docs/reference/js/vertexai-preview.enhancedgeneratecontentresponse.md
+      - title: ErrorDetails
+        path: /docs/reference/js/vertexai-preview.errordetails.md
       - title: FileData
         path: /docs/reference/js/vertexai-preview.filedata.md
       - title: FileDataPart
@@ -515,6 +517,8 @@ toc:
         path: /docs/reference/js/vertexai-preview.groundingattribution.md
       - title: GroundingMetadata
         path: /docs/reference/js/vertexai-preview.groundingmetadata.md
+      - title: HTTPErrorDetails
+        path: /docs/reference/js/vertexai-preview.httperrordetails.md
       - title: InlineDataPart
         path: /docs/reference/js/vertexai-preview.inlinedatapart.md
       - title: ModelParams
@@ -541,6 +545,8 @@ toc:
         path: /docs/reference/js/vertexai-preview.usagemetadata.md
       - title: VertexAI
         path: /docs/reference/js/vertexai-preview.vertexai.md
+      - title: VertexAIError
+        path: /docs/reference/js/vertexai-preview.vertexaierror.md
       - title: VertexAIOptions
         path: /docs/reference/js/vertexai-preview.vertexaioptions.md
       - title: VideoMetadata

--- a/docs-devsite/_toc.yaml
+++ b/docs-devsite/_toc.yaml
@@ -472,8 +472,6 @@ toc:
         path: /docs/reference/js/vertexai-preview.date_2.md
       - title: EnhancedGenerateContentResponse
         path: /docs/reference/js/vertexai-preview.enhancedgeneratecontentresponse.md
-      - title: ErrorDetails
-        path: /docs/reference/js/vertexai-preview.errordetails.md
       - title: FileData
         path: /docs/reference/js/vertexai-preview.filedata.md
       - title: FileDataPart
@@ -517,8 +515,6 @@ toc:
         path: /docs/reference/js/vertexai-preview.groundingattribution.md
       - title: GroundingMetadata
         path: /docs/reference/js/vertexai-preview.groundingmetadata.md
-      - title: HTTPErrorDetails
-        path: /docs/reference/js/vertexai-preview.httperrordetails.md
       - title: InlineDataPart
         path: /docs/reference/js/vertexai-preview.inlinedatapart.md
       - title: ModelParams
@@ -545,8 +541,6 @@ toc:
         path: /docs/reference/js/vertexai-preview.usagemetadata.md
       - title: VertexAI
         path: /docs/reference/js/vertexai-preview.vertexai.md
-      - title: VertexAIError
-        path: /docs/reference/js/vertexai-preview.vertexaierror.md
       - title: VertexAIOptions
         path: /docs/reference/js/vertexai-preview.vertexaioptions.md
       - title: VideoMetadata

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "test:saucelabs": "node scripts/run_saucelabs.js",
     "docgen": "ts-node-script scripts/docgen/docgen.ts",
     "docgen:compat": "node scripts/docgen-compat/generate-docs.js --api js",
+    "docgen:all": "yarn docgen devsite && yarn docgen toc",
     "lint": "lerna run --scope @firebase/* lint",
     "lint:fix": "lerna run --scope @firebase/* lint:fix",
     "size-report": "ts-node-script scripts/size_report/report_binary_size.ts",

--- a/scripts/docgen/docgen.ts
+++ b/scripts/docgen/docgen.ts
@@ -152,9 +152,20 @@ async function generateToc() {
         'toc',
         '--input',
         'temp',
+        '--output',
+        'docs-devsite',
         '-p',
         '/docs/reference/js',
         '-j'
+      ],
+      { stdio: 'inherit' }
+    );
+    // The toc on the devsite must be named _toc.yaml
+    await spawn(
+      'mv',
+      [
+        'docs-devsite/toc.yaml',
+        'docs-devsite/_toc.yaml'
       ],
       { stdio: 'inherit' }
     );

--- a/scripts/docgen/docgen.ts
+++ b/scripts/docgen/docgen.ts
@@ -161,14 +161,9 @@ async function generateToc() {
       { stdio: 'inherit' }
     );
     // The toc on the devsite must be named _toc.yaml
-    await spawn(
-      'mv',
-      [
-        'docs-devsite/toc.yaml',
-        'docs-devsite/_toc.yaml'
-      ],
-      { stdio: 'inherit' }
-    );
+    await spawn('mv', ['docs-devsite/toc.yaml', 'docs-devsite/_toc.yaml'], {
+      stdio: 'inherit'
+    });
   } finally {
     cleanup();
   }


### PR DESCRIPTION
Since we are now checking in the `toc/toc.yaml` file, we should have a check to ensure this file was updated, just as we do for `docs-devsite`.