### PR TITLE
Update the URL for the Metric Service

### DIFF
--- a/scripts/size_report/size_report_helper.ts
+++ b/scripts/size_report/size_report_helper.ts
@@ -27,7 +27,7 @@ export enum RequestEndpoint {
 }
 export const runId = process.env.GITHUB_RUN_ID || 'local-run-id';
 
-const METRICS_SERVICE_URL = 'https://api.firebase-sdk-health-metrics.com';
+const METRICS_SERVICE_URL = 'https://metric-service-tv5rmd4a6q-uc.a.run.app';
 
 function constructRequestPath(requestEndpoint: string): string {
   const repo = process.env.GITHUB_REPOSITORY;


### PR DESCRIPTION
The custom domain "firebase-sdk-health-metrics.com" currently associated with the Metric Service will be deprecated eventually, due to the acquisition of Google Domains by Squarespace.

Switching to the original URL created by Google Cloud Run (which hosts the Metric Service) to avoid service disruption.

See b/303931111 for more details.