### PR TITLE
[CI] Reduce executions by removing `on: push` for two workflows

### DIFF
--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -14,9 +14,7 @@
 
 name: Test All Packages
 
-on:
-  push:
-    branches: ['**']
+on: pull_request
 
 env:
   # make chromedriver detect installed Chrome version and download the corresponding driver

--- a/.github/workflows/test-changed-auth.yml
+++ b/.github/workflows/test-changed-auth.yml
@@ -14,7 +14,7 @@
 
 name: Test Auth
 
-on: [push, pull_request]
+on: pull_request
 
 env:
   # make chromedriver detect installed Chrome version and download the corresponding driver


### PR DESCRIPTION
### Discussion

- Removes  `push` trigger for `test-changed-auth` which was added in error when debugging that workflow in #7872.
- Changes `test-all` worklfow to run only on pull requests. This workflow was previously triggered on branch pushes.

### Testing

CI execution.

### API Changes

None.