### PR TITLE
Update social media platforms

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ As contributors and maintainers of the Firebase JS SDK project, we pledge to res
 contributes by posting issues, updating documentation, submitting pull requests, providing feedback
 in comments, and any other activities.
 
-Communication through any of Firebase's channels (GitHub, StackOverflow, Google+, Twitter, etc.)
+Communication through any of Firebase's channels (GitHub, StackOverflow, X, etc.)
 must be constructive and never resort to personal attacks, trolling, public or private harassment,
 insults, or other unprofessional conduct.
 


### PR DESCRIPTION
### Discussion

#8276 

### Testing

I verified that Google+ is gone: https://plus.google.com redirects to https://workspaceupdates.googleblog.com/2023/04/new-community-features-for-google-chat-and-an-update-currents%20.html

I verified that Twitter is gone: https://twitter.com redirects to https://x.com

