### PR TITLE
Updated Heartbeat Name for Data Connect

### DIFF
--- a/packages/app/src/constants.ts
+++ b/packages/app/src/constants.ts
@@ -60,7 +60,7 @@ export const PLATFORM_LOG_STRING = {
   [authName]: 'fire-auth',
   [authCompatName]: 'fire-auth-compat',
   [databaseName]: 'fire-rtdb',
-  [dataconnectName]: 'fire-connect',
+  [dataconnectName]: 'fire-data-connect',
   [databaseCompatName]: 'fire-rtdb-compat',
   [functionsName]: 'fire-fn',
   [functionsCompatName]: 'fire-fn-compat',


### PR DESCRIPTION
Replaced `fire-connect` with `fire-data-connect` to match other package names.