### PR TITLE
Upgrade setup-gcloud to v2

### DIFF
--- a/.github/workflows/health-metrics-pull-request.yml
+++ b/.github/workflows/health-metrics-pull-request.yml
@@ -45,7 +45,7 @@ jobs:
       - uses: 'google-github-actions/auth@v0'
         with:
           credentials_json: '${{ secrets.GCP_SA_KEY }}'
-      - uses: google-github-actions/setup-gcloud@v0
+      - uses: google-github-actions/setup-gcloud@v2
       - run: yarn install
       - run: yarn build
       - name: Run health-metrics/binary-size test
@@ -62,7 +62,7 @@ jobs:
       - uses: 'google-github-actions/auth@v0'
         with:
           credentials_json: '${{ secrets.GCP_SA_KEY }}'
-      - uses: google-github-actions/setup-gcloud@v0
+      - uses: google-github-actions/setup-gcloud@v2
       - run: yarn install
       - run: yarn build
       - name: Run health-metrics/modular-exports-binary-size test

--- a/.github/workflows/health-metrics-release.yml
+++ b/.github/workflows/health-metrics-release.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: 'google-github-actions/auth@v0'
         with:
           credentials_json: '${{ secrets.GCP_SA_KEY }}'
-      - uses: google-github-actions/setup-gcloud@v0
+      - uses: google-github-actions/setup-gcloud@v2
       - uses: FirebaseExtended/github-actions/health-metrics/release-diffing@master
         with:
           repo: ${{ github.repository }}


### PR DESCRIPTION
https://github.com/google-github-actions/setup-gcloud v0 is no longer maintained.
```
Run google-github-actions/setup-gcloud@v0
Error: The v0 series of google-github-actions/setup-gcloud is no longer maintained. It will not receive updates, improvements, or security patches. Please upgrade to the latest supported versions: 
```