### PR TITLE
Use GitHub ref to get PR head

### DIFF
--- a/.github/workflows/update-api-reports.yml
+++ b/.github/workflows/update-api-reports.yml
@@ -28,7 +28,7 @@ jobs:
       uses: actions/checkout@master
       with:
         # checkout HEAD commit instead of merge commit
-        ref: ${{ github.event.pull_request.head.ref }}
+        ref: refs/pull/${{ github.event.pull_request.number }}/head
         token: ${{ github.token }}
     - name: Set up node (20)
       uses: actions/setup-node@v3


### PR DESCRIPTION
The pull request head ref name is local to its originating repository. For pull requests from forks, that ref is unlikely to exist.

GitHub has special magic refs (refs/pull/<number>/<head|merge>) that can be used to reference the pull request from the destination repository's perspective.

Note that the merge magic ref is not instance and is slightly quirky. Here, we're using the head ref which is less quirky.

### Discussion

#8274
https://github.com/firebase/firebase-js-sdk/pull/8275#issuecomment-2142798301

### Testing

Requires a second copy linked copy of a repository.

### API Changes

