### PR TITLE
Remove VertexAIError related entries from TOC

### DIFF
--- a/docs-devsite/_toc.yaml
+++ b/docs-devsite/_toc.yaml
@@ -472,8 +472,6 @@ toc:
         path: /docs/reference/js/vertexai-preview.date_2.md
       - title: EnhancedGenerateContentResponse
         path: /docs/reference/js/vertexai-preview.enhancedgeneratecontentresponse.md
-      - title: ErrorDetails
-        path: /docs/reference/js/vertexai-preview.errordetails.md
       - title: FileData
         path: /docs/reference/js/vertexai-preview.filedata.md
       - title: FileDataPart
@@ -517,8 +515,6 @@ toc:
         path: /docs/reference/js/vertexai-preview.groundingattribution.md
       - title: GroundingMetadata
         path: /docs/reference/js/vertexai-preview.groundingmetadata.md
-      - title: HTTPErrorDetails
-        path: /docs/reference/js/vertexai-preview.httperrordetails.md
       - title: InlineDataPart
         path: /docs/reference/js/vertexai-preview.inlinedatapart.md
       - title: ModelParams
@@ -545,8 +541,6 @@ toc:
         path: /docs/reference/js/vertexai-preview.usagemetadata.md
       - title: VertexAI
         path: /docs/reference/js/vertexai-preview.vertexai.md
-      - title: VertexAIError
-        path: /docs/reference/js/vertexai-preview.vertexaierror.md
       - title: VertexAIOptions
         path: /docs/reference/js/vertexai-preview.vertexaioptions.md
       - title: VideoMetadata


### PR DESCRIPTION
These entries were introduced when the `toc.yaml` was first added to the repository here: https://github.com/firebase/firebase-js-sdk/pull/8257

The uploaded file was generated in the [vertexaierror branch](https://github.com/firebase/firebase-js-sdk/tree/dlarocque/vertexaierror) (not merged). Since it wasn't tracked by Git, we weren't able to notice that there were new entries. This shouldn't happen again now that we have the checks in place.

**Note**: The changes being removed here haven't been uploaded to devsite, so the change is only on GitHub
