### PR TITLE
Add trusted type check to lint workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -31,3 +31,5 @@ jobs:
       run: yarn
     - name: yarn lint
       run: yarn lint
+    - name: yarn trusted-type-check
+      run: yarn trusted-type-check


### PR DESCRIPTION
This adds a `tsec` check to the lint workflow.

The check currently fails, since there are unresolved errors with `tsec`. This PR should not be merged until the errors have been fixed, and CI is passing. Fixes are a WIP in #8301 