### PR TITLE
fix: server app should initialize even if FinalizationRegistry is unsupported

### DIFF
--- a/.changeset/large-boats-admire.md
+++ b/.changeset/large-boats-admire.md
@@ -1,0 +1,5 @@
+---
+'@firebase/app': patch
+---
+
+FirebaseServerApp should initialize even if FinalizationRegistry is unsupported by runtime

--- a/packages/app/src/firebaseServerApp.ts
+++ b/packages/app/src/firebaseServerApp.ts
@@ -32,7 +32,7 @@ export class FirebaseServerAppImpl
   implements FirebaseServerApp
 {
   private readonly _serverConfig: FirebaseServerAppSettings;
-  private _finalizationRegistry: FinalizationRegistry<object>;
+  private _finalizationRegistry!: FinalizationRegistry<object>;
   private _refCount: number;
 
   constructor(
@@ -67,9 +67,11 @@ export class FirebaseServerAppImpl
       ...serverConfig
     };
 
-    this._finalizationRegistry = new FinalizationRegistry(() => {
-      this.automaticCleanup();
-    });
+    if (typeof FinalizationRegistry !== 'undefined') {
+      this._finalizationRegistry = new FinalizationRegistry(() => {
+        this.automaticCleanup();
+      });
+    }
 
     this._refCount = 0;
     this.incRefCount(this._serverConfig.releaseOnDeref);


### PR DESCRIPTION
FinalizationRegistry is required only if releaseOnDeref is provided in config; guard clause in initializeServerApp throws error if it's unsupported.

#8299