### PR TITLE
fix: Fix a typo in the webchannel-wrapper's package.json.

### DIFF
--- a/.changeset/orange-rings-own.md
+++ b/.changeset/orange-rings-own.md
@@ -1,0 +1,5 @@
+---
+"@firebase/webchannel-wrapper": patch
+---
+
+fix: Fix a typo in the webchannel-wrapper's package.json that affected ems5 exports.

--- a/packages/webchannel-wrapper/package.json
+++ b/packages/webchannel-wrapper/package.json
@@ -14,7 +14,7 @@
     "./bloom-blob": {
       "types": "./dist/bloom-blob/bloom_blob_types.d.ts",
       "require": "./dist/bloom-blob/bloom_blob_es2018.js",
-      "es5": "./dist/bloom-blob/bloom_blob_es5.js",
+      "esm5": "./dist/bloom-blob/bloom_blob_es5.js",
       "default": "./dist/bloom-blob/esm/bloom_blob_es2018.js"
     },
     "./package.json": "./package.json"


### PR DESCRIPTION
Fixes a typo in the webchannel-wrapper's package.json that affected ems5 exports.