### PR TITLE
FirebaseServerAppImpl: guard use of FinalizationRegistry based on its availability.

### DIFF
--- a/.changeset/clever-dryers-double.md
+++ b/.changeset/clever-dryers-double.md
@@ -1,0 +1,6 @@
+---
+'@firebase/app': patch
+'firebase': patch
+---
+
+Guard the use of `FinalizationRegistry` in `FirebaseServerApp` initialization based on the availability of `FinalizationRegistry` in the runtime.


### PR DESCRIPTION
### Discussion

The code had already guarded use of the `FinalizationRegstiry` during the initialization of `FirebaseServerApp` in `initializeServerApp` if the `releaseOnDeref` configuration parameter was defined. This gating was to provide functionality in older node versions.  However, there was other code that would errantly attempt to allocate a `FinalizationRegstiry` in `FirebaseServerAppImpl` regardless of the existence of `releaseOnDeref` field, and this caused issues in some edge environments.

This change fixes that issue.

### Testing

I had tested this previously using Node v14.14.0, which is the release version previous to the [reported addition](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/FinalizationRegistry#browser_compatibility) of the FinalizationRegistry, and our code had worked. However, it appears that 14.14.0 actually includes the FinalizationRegistry, so my tests completed successfully when they shouldn't have.

I was able to reproduce this problem in Node 14.0.0, and that's the version I used to test this fix.

### API Changes

N/A.