### PR TITLE
Fix multi-tab snapshot listener metadata sync issue

### DIFF
--- a/.changeset/flat-scissors-suffer.md
+++ b/.changeset/flat-scissors-suffer.md
@@ -1,0 +1,6 @@
+---
+'@firebase/firestore': patch
+'firebase': patch
+---
+
+Fix persistence multi-tab snapshot listener metadata sync issue.

--- a/packages/firestore/src/core/sync_engine_impl.ts
+++ b/packages/firestore/src/core/sync_engine_impl.ts
@@ -1095,7 +1095,13 @@ export async function syncEngineEmitNewSnapsAndNotifyLocalStore(
           // secondary clients to update query state.
           if (viewSnapshot || remoteEvent) {
             if (syncEngineImpl.isPrimaryClient) {
-              const isCurrent = viewSnapshot && !viewSnapshot.fromCache;
+              // Query state is set to `current` if:
+              // - The is a view change and it is up-to-date, or,
+              // - There are no changes and the Target is current
+              const isCurrent = viewSnapshot
+                ? !viewSnapshot.fromCache
+                : remoteEvent?.targetChanges.get(queryView.targetId)?.current;
+
               syncEngineImpl.sharedClientState.updateQueryState(
                 queryView.targetId,
                 isCurrent ? 'current' : 'not-current'

--- a/packages/firestore/src/core/sync_engine_impl.ts
+++ b/packages/firestore/src/core/sync_engine_impl.ts
@@ -1097,7 +1097,7 @@ export async function syncEngineEmitNewSnapsAndNotifyLocalStore(
             if (syncEngineImpl.isPrimaryClient) {
               // Query state is set to `current` if:
               // - The is a view change and it is up-to-date, or,
-              // - There are no changes and the Target is current
+              // - We received a global snapshot and the Target is current
               const isCurrent = viewSnapshot
                 ? !viewSnapshot.fromCache
                 : remoteEvent?.targetChanges.get(queryView.targetId)?.current;

--- a/packages/firestore/src/core/sync_engine_impl.ts
+++ b/packages/firestore/src/core/sync_engine_impl.ts
@@ -1096,8 +1096,8 @@ export async function syncEngineEmitNewSnapsAndNotifyLocalStore(
           if (viewSnapshot || remoteEvent) {
             if (syncEngineImpl.isPrimaryClient) {
               // Query state is set to `current` if:
-              // - The is a view change and it is up-to-date, or,
-              // - We received a global snapshot and the Target is current
+              // - There is a view change and it is up-to-date, or,
+              // - There is a global snapshot, the Target is current, and no changes to be resolved
               const isCurrent = viewSnapshot
                 ? !viewSnapshot.fromCache
                 : remoteEvent?.targetChanges.get(queryView.targetId)?.current;

--- a/packages/firestore/test/unit/specs/listen_spec.test.ts
+++ b/packages/firestore/test/unit/specs/listen_spec.test.ts
@@ -1916,7 +1916,7 @@ describeSpec('Listens:', [], () => {
           // marked as "not-current" as the Target is up to date.
           .watchFilters([query1], [docA.key])
           .watchSnapshots(2000, [], 'resume-token-2000')
-          // Listening to the query in the secondary tab. The snapshot is up to date.
+          // Listen to the query in the secondary tab. The snapshot is up to date.
           .client(1)
           .userListens(query1)
           .expectEvents(query1, { added: [docA] })


### PR DESCRIPTION
Fix https://github.com/firebase/firebase-js-sdk/issues/8314.

The previous fix  https://github.com/firebase/firebase-js-sdk/pull/8247 introduced out-of-sync metadata issue for multi-tab users.  When viewSnapshot is not defined, that means there is no change, so it should not be seen as "not-current".