### PR TITLE
VertexAI: add support for mock responses versioning system

### DIFF
--- a/.github/workflows/check-vertexai-responses.yml
+++ b/.github/workflows/check-vertexai-responses.yml
@@ -1,0 +1,55 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Check Vertex AI Mock Responses Version
+
+on: pull_request
+
+jobs:
+  check-responses-version:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Clone mock responses
+      run: scripts/update_vertexai_responses.sh
+    - name: Find cloned and latest versions
+      run: |
+        echo "current_tag=$(git describe --tags)" >> $GITHUB_ENV
+        # Fetch the latest tag matching the major version from the golden files repository
+        echo "latest_tag=$(git -c 'versionsort.suffix=-' ls-remote --tags --sort='v:refname' \
+          https://github.com/FirebaseExtended/vertexai-sdk-test-data.git | tail -n1 \
+          | awk -F'/' '{print $NF}')" >> $GITHUB_ENV
+      working-directory: packages/vertexai/test-utils/vertexai-sdk-test-data
+    - name: Find comment from previous run if exists
+      uses: peter-evans/find-comment@3eae4d37986fb5a8592848f6a574fdf654e61f9e
+      id: fc
+      with:
+        issue-number: ${{github.event.number}}
+        body-includes: Vertex AI Mock Responses Check
+    - name: Comment on PR if newer version is available
+      if: ${{env.current_tag != env.latest_tag && !steps.fc.outputs.comment-id}}
+      uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043
+      with:
+        issue-number: ${{github.event.number}}
+        body: >
+          ### Vertex AI Mock Responses Check :warning:
+          
+          A newer major version of the mock responses for Vertex AI unit tests is available.
+          [update_vertexai_responses.sh](https://github.com/firebase/firebase-js-sdk/blob/main/scripts/update_vertexai_responses.sh)
+          should be updated to clone the latest version of the responses.
+    - name: Delete comment when version gets updated
+      if: ${{env.current_tag == env.latest_tag && steps.fc.outputs.comment-id}}
+      uses: detomarco/delete-comment@850734dd44d8b15fef55b45252613b903ceb06f0
+      with:
+        comment-id: ${{ steps.fc.outputs.comment-id }}

--- a/packages/vertexai/package.json
+++ b/packages/vertexai/package.json
@@ -33,7 +33,7 @@
     "build": "rollup -c && yarn api-report",
     "build:deps": "lerna run --scope @firebase/vertexai --include-dependencies build",
     "dev": "rollup -c -w",
-    "update-responses": "cd test-utils && rm -rf vertexai-sdk-test-data && git clone --depth 1 https://github.com/FirebaseExtended/vertexai-sdk-test-data.git",
+    "update-responses": "../../scripts/update_vertexai_responses.sh",
     "testsetup": "yarn update-responses && yarn ts-node ./test-utils/convert-mocks.ts",
     "test": "run-p --npm-path npm lint test:browser",
     "test:ci": "yarn testsetup && node ../../scripts/run_tests_in_ci.js -s test",

--- a/scripts/update_vertexai_responses.sh
+++ b/scripts/update_vertexai_responses.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script replaces mock response files for Vertex AI unit tests with a fresh
+# clone of the shared repository of Vertex AI test data.
+
+RESPONSES_VERSION='v1.*' # The major version of mock responses to use
+REPO="https://github.com/FirebaseExtended/vertexai-sdk-test-data.git"
+# Fetch the latest tag matching the major version from the golden files repository
+TAG=$(git -c 'versionsort.suffix=-' ls-remote --tags --sort='v:refname' "$REPO" \
+  | grep "$RESPONSES_VERSION" \
+  | tail -n1 \
+  | awk -F'/' '{print $NF}')
+
+cd "$(dirname "$0")/../packages/vertexai/test-utils" || exit
+rm -rf vertexai-sdk-test-data
+git clone --quiet --config advice.detachedHead=false --depth 1 --branch "$TAG" "$REPO"


### PR DESCRIPTION
This adds a new script that clones the latest minor version within a hard-coded major version of the mock responses.

It also adds a CI job that leaves a comment on the PR if the script is cloning an outdated major version.