### PR TITLE
Disable extraneous import errors on violating lines in auth tests

### DIFF
--- a/packages/auth/test/helpers/integration/helpers.ts
+++ b/packages/auth/test/helpers/integration/helpers.ts
@@ -17,6 +17,7 @@
 
 import * as sinon from 'sinon';
 import { FirebaseServerApp, deleteApp, initializeApp } from '@firebase/app';
+// eslint-disable-next-line import/no-extraneous-dependencies
 import { Auth, User } from '@firebase/auth';
 
 import { getAuth, connectAuthEmulator } from '../../../'; // Use browser OR node dist entrypoint depending on test env.

--- a/packages/auth/test/integration/flows/totp.test.ts
+++ b/packages/auth/test/integration/flows/totp.test.ts
@@ -18,6 +18,7 @@
 import { expect, use } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import sinonChai from 'sinon-chai';
+// eslint-disable-next-line import/no-extraneous-dependencies
 import {
   Auth,
   multiFactor,


### PR DESCRIPTION
There are a couple lines that are violating an eslint rule. In other cases where this rule is violated, we add a similar exception.

This was causing `npm run lint` to fail in auth.