### PR TITLE
Refactor stream

### DIFF
--- a/packages/firestore/src/remote/persistent_stream.ts
+++ b/packages/firestore/src/remote/persistent_stream.ts
@@ -535,7 +535,11 @@ export abstract class PersistentStream<
     });
     this.stream.onMessage((msg: ReceiveType) => {
       dispatchIfNotClosed(() => {
-        return ++this.responseCount === 1 ? this.onFirst(msg) : this.onNext(msg);
+        if (++this.responseCount === 1) {
+          return this.onFirst(msg);
+        } else {
+          return this.onNext(msg);
+        }
       });
     });
   }


### PR DESCRIPTION
This prepares for InitilaizeStream handshake by moving the logic to AbstractStream that distinguishes first response subsequent stream responses. The Listen stream will make use of this in future PRs.