### PR TITLE
Handle app-compat environment check where self does not exist

### DIFF
--- a/.changeset/spicy-dragons-pay.md
+++ b/.changeset/spicy-dragons-pay.md
@@ -1,0 +1,5 @@
+---
+'@firebase/app-compat': patch
+---
+
+Handle JSDOM case in app-compat checks.

--- a/.changeset/spicy-dragons-pay.md
+++ b/.changeset/spicy-dragons-pay.md
@@ -2,4 +2,4 @@
 '@firebase/app-compat': patch
 ---
 
-Handle JSDOM case in app-compat checks.
+Properly handle the case in app-compat checks where `window` exists but `self` does not. (This occurs in Ionic Stencil's Jest preset.)

--- a/packages/app-compat/src/index.ts
+++ b/packages/app-compat/src/index.ts
@@ -16,22 +16,27 @@
  */
 
 import { FirebaseNamespace } from './public-types';
-import { isBrowser, getGlobal } from '@firebase/util';
+import { isBrowser } from '@firebase/util';
 import { firebase as firebaseNamespace } from './firebaseNamespace';
 import { logger } from './logger';
 import { registerCoreComponents } from './registerCoreComponents';
 
+declare global {
+  interface Window {
+    firebase: FirebaseNamespace;
+  }
+}
+
 // Firebase Lite detection
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-if (isBrowser() && (getGlobal() as any).firebase !== undefined) {
+if (isBrowser() && window.firebase !== undefined) {
   logger.warn(`
     Warning: Firebase is already defined in the global scope. Please make sure
     Firebase library is only loaded once.
   `);
 
   // eslint-disable-next-line
-  const sdkVersion = ((getGlobal() as any).firebase as FirebaseNamespace)
-    .SDK_VERSION;
+  const sdkVersion = (window.firebase as FirebaseNamespace).SDK_VERSION;
   if (sdkVersion && sdkVersion.indexOf('LITE') >= 0) {
     logger.warn(`
     Warning: You are trying to load Firebase while using Firebase Performance standalone script.

--- a/packages/app-compat/src/index.ts
+++ b/packages/app-compat/src/index.ts
@@ -16,21 +16,22 @@
  */
 
 import { FirebaseNamespace } from './public-types';
-import { isBrowser } from '@firebase/util';
+import { isBrowser, getGlobal } from '@firebase/util';
 import { firebase as firebaseNamespace } from './firebaseNamespace';
 import { logger } from './logger';
 import { registerCoreComponents } from './registerCoreComponents';
 
 // Firebase Lite detection
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-if (isBrowser() && (self as any).firebase !== undefined) {
+if (isBrowser() && (getGlobal() as any).firebase !== undefined) {
   logger.warn(`
     Warning: Firebase is already defined in the global scope. Please make sure
     Firebase library is only loaded once.
   `);
 
   // eslint-disable-next-line
-  const sdkVersion = ((self as any).firebase as FirebaseNamespace).SDK_VERSION;
+  const sdkVersion = ((getGlobal() as any).firebase as FirebaseNamespace)
+    .SDK_VERSION;
   if (sdkVersion && sdkVersion.indexOf('LITE') >= 0) {
     logger.warn(`
     Warning: You are trying to load Firebase while using Firebase Performance standalone script.

--- a/packages/util/src/environment.ts
+++ b/packages/util/src/environment.ts
@@ -80,8 +80,8 @@ export function isNode(): boolean {
 
 /**
  * Detect Browser Environment
- * Note: This will return true for JSDOM (e.g. Jest) as it is mimicking
- * a browser, and should not lead to assuming all browser APIs are
+ * Note: This will return true for certain test frameworks that are incompletely
+ * mimicking a browser, and should not lead to assuming all browser APIs are
  * available.
  */
 export function isBrowser(): boolean {

--- a/packages/util/src/environment.ts
+++ b/packages/util/src/environment.ts
@@ -80,6 +80,9 @@ export function isNode(): boolean {
 
 /**
  * Detect Browser Environment
+ * Note: This will return true for JSDOM (e.g. Jest) as it is mimicking
+ * a browser, and should not lead to assuming all browser APIs are
+ * available.
  */
 export function isBrowser(): boolean {
   return typeof window !== 'undefined' || isWebWorker();


### PR DESCRIPTION
Properly handle the case in app-compat checks where `window` exists but `self` does not. (This apparently occurs in Ionic Stencil's Jest preset.)

This is a safer check as `isBrowser()` now checks for the existence of `window`, so if it passes, the second condition shouldn't error.

Fixes https://github.com/firebase/firebase-js-sdk/issues/8365