### PR TITLE
Better JSON messages

### DIFF
--- a/packages/data-connect/CHANGELOG.md
+++ b/packages/data-connect/CHANGELOG.md
@@ -2,4 +2,4 @@
 ## UNRELEASED
 * Updated reporting to use @firebase/data-connect instead of @firebase/connect
 * Added functionality to retry queries and mutations if the server responds with UNAUTHENTICATED.
-
+* Updated errors to only show relevant details to the user.

--- a/packages/data-connect/src/network/fetch.ts
+++ b/packages/data-connect/src/network/fetch.ts
@@ -64,14 +64,15 @@ export function dcFetch<T, U>(
       } catch (e) {
         throw new DataConnectError(Code.OTHER, JSON.stringify(e));
       }
+      const message = getMessage(jsonResponse);
       if (response.status >= 400) {
         logError(
           'Error while performing request: ' + JSON.stringify(jsonResponse)
         );
         if(response.status === 401) {
-          throw new DataConnectError(Code.UNAUTHORIZED, JSON.stringify(jsonResponse));
+          throw new DataConnectError(Code.UNAUTHORIZED, message);
         }
-        throw new DataConnectError(Code.OTHER, JSON.stringify(jsonResponse));
+        throw new DataConnectError(Code.OTHER, message);
       }
       return jsonResponse;
     })
@@ -83,4 +84,14 @@ export function dcFetch<T, U>(
       }
       return res as { data: T; errors: Error[] };
     });
+}
+interface MessageObject {
+   message?: string;
+}
+function getMessage(obj: MessageObject) : string {
+  if ('message' in obj) {
+    console.log('message')
+    return obj.message;
+  }
+  return JSON.stringify(obj);
 }

--- a/packages/data-connect/src/network/fetch.ts
+++ b/packages/data-connect/src/network/fetch.ts
@@ -90,7 +90,6 @@ interface MessageObject {
 }
 function getMessage(obj: MessageObject) : string {
   if ('message' in obj) {
-    console.log('message')
     return obj.message;
   }
   return JSON.stringify(obj);

--- a/packages/data-connect/src/network/fetch.ts
+++ b/packages/data-connect/src/network/fetch.ts
@@ -69,7 +69,7 @@ export function dcFetch<T, U>(
         logError(
           'Error while performing request: ' + JSON.stringify(jsonResponse)
         );
-        if(response.status === 401) {
+        if (response.status === 401) {
           throw new DataConnectError(Code.UNAUTHORIZED, message);
         }
         throw new DataConnectError(Code.OTHER, message);
@@ -86,9 +86,9 @@ export function dcFetch<T, U>(
     });
 }
 interface MessageObject {
-   message?: string;
+  message?: string;
 }
-function getMessage(obj: MessageObject) : string {
+function getMessage(obj: MessageObject): string {
   if ('message' in obj) {
     return obj.message;
   }

--- a/packages/data-connect/test/emulatorSeeder.ts
+++ b/packages/data-connect/test/emulatorSeeder.ts
@@ -78,7 +78,7 @@ export async function setupQueries(
         })
       }
     },
-    // eslint-disable-line camelcase
+    // eslint-disable-next-line camelcase
     connection_string:
       'postgresql://postgres:secretpassword@localhost:5432/postgres?sslmode=disable'
   };

--- a/packages/data-connect/test/post.gql
+++ b/packages/data-connect/test/post.gql
@@ -9,4 +9,10 @@ query listPosts @auth(level: PUBLIC) {
     content
   }
 }
+query listPosts2  {
+  posts {
+    id,
+    content
+  }
+}
 

--- a/packages/data-connect/test/queries.test.ts
+++ b/packages/data-connect/test/queries.test.ts
@@ -59,7 +59,10 @@ const SEEDED_DATA = [
     content: 'task 2'
   }
 ];
-const REAL_DATA = SEEDED_DATA.map(obj => ({ ...obj, id: obj.id.replace(/-/g, '')}))
+const REAL_DATA = SEEDED_DATA.map(obj => ({
+  ...obj,
+  id: obj.id.replace(/-/g, '')
+}));
 function seedDatabase(instance: DataConnect): Promise<void> {
   // call mutation query that adds SEEDED_DATA to database
   return new Promise((resolve, reject) => {
@@ -170,9 +173,12 @@ describe('DataConnect Tests', async () => {
   });
   it('throws an error with just the message when the server responds with an error', async () => {
     const invalidTaskListQuery = queryRef<TaskListResponse>(dc, 'listPosts2');
-    const message = 'unauthorized: you are not authorized to perform this operation';
-    await expect(executeQuery(invalidTaskListQuery)).to.eventually.be.rejectedWith(message);
-  })
+    const message =
+      'unauthorized: you are not authorized to perform this operation';
+    await expect(
+      executeQuery(invalidTaskListQuery)
+    ).to.eventually.be.rejectedWith(message);
+  });
 });
 async function waitForFirstEvent<Data, Variables>(
   query: QueryRef<Data, Variables>

--- a/packages/data-connect/test/unit/dataconnect.test.ts
+++ b/packages/data-connect/test/unit/dataconnect.test.ts
@@ -21,14 +21,14 @@ import { expect } from 'chai';
 import { ConnectorConfig, getDataConnect } from '../../src';
 
 describe('Data Connect Test', () => {
-  it('should throw an error if `projectId` is not provided', () => {
+  it('should throw an error if `projectId` is not provided', async () => {
     const app = initializeApp({ projectId: undefined }, 'a');
     expect(() =>
       getDataConnect(app, { connector: 'c', location: 'l', service: 's' })
     ).to.throw(
       'Project ID must be provided. Did you pass in a proper projectId to initializeApp?'
     );
-    deleteApp(app);
+    await deleteApp(app);
   });
   it('should not throw an error if `projectId` is provided', () => {
     const projectId = 'p';

--- a/packages/data-connect/test/unit/dataconnect.test.ts
+++ b/packages/data-connect/test/unit/dataconnect.test.ts
@@ -4,8 +4,8 @@ import { expect } from "chai";
 
 describe('Data Connect Test', () => {
     it('should throw an error if `projectId` is not provided', () => {
-        const app = initializeApp({});
-        expect(() => getDataConnect({ connector: 'c', location: 'l', service: 's'})).to.throw('Project ID must be provided. Did you pass in a proper projectId to initializeApp?');
+        const app = initializeApp({projectId: undefined}, 'a');
+        expect(() => getDataConnect(app,{ connector: 'c', location: 'l', service: 's'})).to.throw('Project ID must be provided. Did you pass in a proper projectId to initializeApp?');
         deleteApp(app);
     });
     it('should not throw an error if `projectId` is provided', () => {

--- a/packages/data-connect/test/unit/dataconnect.test.ts
+++ b/packages/data-connect/test/unit/dataconnect.test.ts
@@ -21,23 +21,33 @@ import { expect } from 'chai';
 import { ConnectorConfig, getDataConnect } from '../../src';
 
 describe('Data Connect Test', () => {
-    it('should throw an error if `projectId` is not provided', () => {
-        const app = initializeApp({projectId: undefined}, 'a');
-        expect(() => getDataConnect(app,{ connector: 'c', location: 'l', service: 's'})).to.throw('Project ID must be provided. Did you pass in a proper projectId to initializeApp?');
-        deleteApp(app);
-    });
-    it('should not throw an error if `projectId` is provided', () => {
-        const projectId = 'p';
-        initializeApp({ projectId});
-        expect(() => getDataConnect({ connector: 'c', location: 'l', service: 's'})).to.not.throw('Project ID must be provided. Did you pass in a proper projectId to initializeApp?');
-        const dc = getDataConnect({ connector: 'c', location: 'l', service: 's'});
-        expect(dc.app.options.projectId).to.eq(projectId);
-    });
-    it('should throw an error if `connectorConfig` is not provided', () => {
-        const projectId = 'p';
-        initializeApp({ projectId});
-        expect(() => getDataConnect({ } as ConnectorConfig)).to.throw('DC Option Required');
-        const dc = getDataConnect({ connector: 'c', location: 'l', service: 's'});
-        expect(dc.app.options.projectId).to.eq(projectId);
-    });
+  it('should throw an error if `projectId` is not provided', () => {
+    const app = initializeApp({ projectId: undefined }, 'a');
+    expect(() =>
+      getDataConnect(app, { connector: 'c', location: 'l', service: 's' })
+    ).to.throw(
+      'Project ID must be provided. Did you pass in a proper projectId to initializeApp?'
+    );
+    deleteApp(app);
+  });
+  it('should not throw an error if `projectId` is provided', () => {
+    const projectId = 'p';
+    initializeApp({ projectId });
+    expect(() =>
+      getDataConnect({ connector: 'c', location: 'l', service: 's' })
+    ).to.not.throw(
+      'Project ID must be provided. Did you pass in a proper projectId to initializeApp?'
+    );
+    const dc = getDataConnect({ connector: 'c', location: 'l', service: 's' });
+    expect(dc.app.options.projectId).to.eq(projectId);
+  });
+  it('should throw an error if `connectorConfig` is not provided', () => {
+    const projectId = 'p';
+    initializeApp({ projectId });
+    expect(() => getDataConnect({} as ConnectorConfig)).to.throw(
+      'DC Option Required'
+    );
+    const dc = getDataConnect({ connector: 'c', location: 'l', service: 's' });
+    expect(dc.app.options.projectId).to.eq(projectId);
+  });
 });

--- a/packages/data-connect/test/unit/fetch.test.ts
+++ b/packages/data-connect/test/unit/fetch.test.ts
@@ -1,0 +1,39 @@
+import { expect, use } from 'chai';
+import { dcFetch, initializeFetch } from '../../src/network/fetch';
+import chaiAsPromised from 'chai-as-promised';
+import * as sinon from 'sinon';
+use(chaiAsPromised);
+function mockFetch(json: any) {
+  const fakeFetchImpl = sinon.stub().returns(
+    Promise.resolve({
+      json: () => {
+        return Promise.resolve(json);
+      },
+      status: 401
+    } as Response)
+  );
+  initializeFetch(fakeFetchImpl);
+}
+describe('fetch', () => {
+  it('should throw an error with just the message when the server responds with an error with a message property in the body', async () => {
+    const message = 'Failed to connect to Postgres instance';
+    mockFetch({
+      code: 401,
+      message
+    });
+    await expect(
+      dcFetch('http://localhost', {}, {} as AbortController, null)
+    ).to.eventually.be.rejectedWith(message);
+  });
+  it('should throw a stringified message when the server responds with an error without a message property in the body', async () => {
+    const message = 'Failed to connect to Postgres instance';
+    const json = {
+      code: 401,
+      message1: message
+    }
+    mockFetch(json);
+    await expect(
+      dcFetch('http://localhost', {}, {} as AbortController, null)
+    ).to.eventually.be.rejectedWith(JSON.stringify(json));
+  });
+});

--- a/packages/data-connect/test/unit/fetch.test.ts
+++ b/packages/data-connect/test/unit/fetch.test.ts
@@ -1,3 +1,20 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { expect, use } from 'chai';
 import { dcFetch, initializeFetch } from '../../src/network/fetch';
 import chaiAsPromised from 'chai-as-promised';
@@ -30,7 +47,7 @@ describe('fetch', () => {
     const json = {
       code: 401,
       message1: message
-    }
+    };
     mockFetch(json);
     await expect(
       dcFetch('http://localhost', {}, {} as AbortController, null)

--- a/packages/data-connect/test/unit/fetch.test.ts
+++ b/packages/data-connect/test/unit/fetch.test.ts
@@ -16,11 +16,12 @@
  */
 
 import { expect, use } from 'chai';
-import { dcFetch, initializeFetch } from '../../src/network/fetch';
 import chaiAsPromised from 'chai-as-promised';
 import * as sinon from 'sinon';
+
+import { dcFetch, initializeFetch } from '../../src/network/fetch';
 use(chaiAsPromised);
-function mockFetch(json: any) {
+function mockFetch(json: object): void {
   const fakeFetchImpl = sinon.stub().returns(
     Promise.resolve({
       json: () => {

--- a/packages/data-connect/test/unit/queries.test.ts
+++ b/packages/data-connect/test/unit/queries.test.ts
@@ -54,7 +54,7 @@ describe('Queries', () => {
     const rt = new RESTTransport(options, undefined, authProvider);
     await expect(
       rt.invokeQuery('test', null)
-    ).to.eventually.be.rejectedWith(JSON.stringify(json));
+    ).to.eventually.be.rejectedWith(json.message);
     expect(fakeFetchImpl.callCount).to.eq(2);
   });
   it('[MUTATION] should retry auth whenever the fetcher returns with unauthorized', async () => {
@@ -63,7 +63,7 @@ describe('Queries', () => {
     const rt = new RESTTransport(options, undefined, authProvider);
     await expect(
       rt.invokeMutation('test', null)
-    ).to.eventually.be.rejectedWith(JSON.stringify(json));
+    ).to.eventually.be.rejectedWith(json.message);
     expect(fakeFetchImpl.callCount).to.eq(2);
   });
   it("should not retry auth whenever the fetcher returns with unauthorized and the token doesn't change", async () => {
@@ -73,7 +73,7 @@ describe('Queries', () => {
     rt._setLastToken('initial token');
     await expect(
       rt.invokeQuery('test', null) as Promise<any>
-    ).to.eventually.be.rejectedWith(JSON.stringify(json));
+    ).to.eventually.be.rejectedWith(json.message);
     expect(fakeFetchImpl.callCount).to.eq(1);
   });
 });

--- a/packages/data-connect/test/unit/queries.test.ts
+++ b/packages/data-connect/test/unit/queries.test.ts
@@ -69,18 +69,18 @@ describe('Queries', () => {
     initializeFetch(fakeFetchImpl);
     const authProvider = new FakeAuthProvider();
     const rt = new RESTTransport(options, undefined, authProvider);
-    await expect(
-      rt.invokeQuery('test', null)
-    ).to.eventually.be.rejectedWith(json.message);
+    await expect(rt.invokeQuery('test', null)).to.eventually.be.rejectedWith(
+      json.message
+    );
     expect(fakeFetchImpl.callCount).to.eq(2);
   });
   it('[MUTATION] should retry auth whenever the fetcher returns with unauthorized', async () => {
     initializeFetch(fakeFetchImpl);
     const authProvider = new FakeAuthProvider();
     const rt = new RESTTransport(options, undefined, authProvider);
-    await expect(
-      rt.invokeMutation('test', null)
-    ).to.eventually.be.rejectedWith(json.message);
+    await expect(rt.invokeMutation('test', null)).to.eventually.be.rejectedWith(
+      json.message
+    );
     expect(fakeFetchImpl.callCount).to.eq(2);
   });
   it("should not retry auth whenever the fetcher returns with unauthorized and the token doesn't change", async () => {


### PR DESCRIPTION
When the server responds with an error, the response includes irrelevant information to the user in addition to the message itself. Instead of reporting this redundant information, we throw an error with just the nested message object.